### PR TITLE
research(hilbert-10-oq-01-oq-02): S8 Path B — arbitrary singletons {a} ⊂ ℚ (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -60,6 +60,11 @@ expose the equivalent statement `IsDiophantineDefinition (Set.range Int)`.
 -/
 
 import Proofs.Hilbert10OQ01
+-- S8 (iter 8, Path B): one Mathlib import for `sub_eq_zero` on ℚ, used to
+-- generalize `singletonZero` (S6) to arbitrary singletons `{a}` for `a : ℚ`.
+-- This is the first Mathlib import in this file; iterations 1–7 were
+-- entirely zero-Mathlib (Path A discipline). See state.md for context.
+import Mathlib.Algebra.Group.Basic
 
 namespace Hilbert10Rationals
 
@@ -751,6 +756,95 @@ theorem integers_diophantine_iff_doubleNeg :
   (diophantineDefinition_doubleNeg_iff IntSubset).symm
 
 -- ============================================================
+-- Part VIII.9 (iter 8, Path B): Arbitrary singletons {a} for a : ℚ
+-- ============================================================
+
+/-- "Shift" parametric polynomial witness: for each `a : ℚ`, the polynomial
+    that ignores its variable assignment and returns `q - a`. This generalizes
+    iteration 6's `parameterPoly` (the constant-zero shift) to an arbitrary
+    rational shift `a`.
+
+    Concretely, `shiftPoly a = fun q _ => q - a`. The polynomial is constant
+    in the variable assignment; its zero set in `q` is exactly `{a}`. Used
+    to place every singleton `{a} ⊂ ℚ` (and its complement `ℚ \ {a}`) into
+    the Σ₁ class (resp. Π₁ class).
+
+    Path B (Mathlib): the proofs use `sub_eq_zero` from `Mathlib.Algebra.Group.Basic`
+    to bridge `q - a = 0 ↔ q = a`. -/
+private def shiftPoly (a : Rat) : Rat → RatDiophantinePoly := fun q _ => q - a
+
+/-- Iter 8, Path B: **the singleton `{a} ⊂ ℚ` is Σ₁-definable** for every
+    `a : ℚ`.
+
+    Witness: `shiftPoly a`, i.e., `P(q, x) = q - a`. Then
+    `hasRationalSolution (P q) ⟺ ∃ x, q - a = 0 ⟺ q - a = 0 ⟺ q = a`.
+    The first iff is trivial (the polynomial does not depend on `x`); the
+    second is `sub_eq_zero` from Mathlib's additive-group library.
+
+    This is the proper generalization of S6's `singletonZero_isDiophantineDefinition`
+    (the special case `a = 0`, modulo `sub_zero`) to arbitrary `a : ℚ`. The
+    OPEN Σ₁ question for ℤ ⊂ ℚ is genuinely harder: ℤ is the union of the
+    family of singletons `{n}` for `n : ℤ ⊂ ℚ`, but Σ₁-definability is NOT
+    known to be closed under countable union (unlike finite union — see
+    closure properties to be added in S9+).
+
+    Path B (Mathlib import): adds `Mathlib.Algebra.Group.Basic`. No new
+    axioms. -/
+theorem singletonOf_isDiophantineDefinition (a : Rat) :
+    IsDiophantineDefinition (fun q : Rat => q = a) := by
+  refine ⟨shiftPoly a, fun q => ?_⟩
+  exact ⟨fun hq => ⟨fun _ => 0, sub_eq_zero.mpr hq⟩,
+          fun ⟨_, hP⟩ => sub_eq_zero.mp hP⟩
+
+/-- Iter 8, Path B: **the complement `ℚ \ {a}` is Π₁-definable** for every
+    `a : ℚ`.
+
+    Witness: the same `shiftPoly a`, i.e., `P(q, x) = q - a`. Then
+    `¬ hasRationalSolution (P q) ⟺ ¬ ∃ x, q - a = 0 ⟺ q - a ≠ 0 ⟺ q ≠ a`.
+
+    Direct dual of `singletonOf_isDiophantineDefinition`, generalizing S6's
+    `notZero_isCoDiophantineDefinition` (the special case `a = 0`) to
+    arbitrary `a : ℚ`. -/
+theorem notSingletonOf_isCoDiophantineDefinition (a : Rat) :
+    IsCoDiophantineDefinition (fun q : Rat => q ≠ a) := by
+  refine ⟨shiftPoly a, fun q => ?_⟩
+  exact ⟨fun hq ⟨_, hP⟩ => hq (sub_eq_zero.mp hP),
+          fun hnsol hq => hnsol ⟨fun _ => 0, sub_eq_zero.mpr hq⟩⟩
+
+/-- Iter 8, Path B: **the singleton `{a}` is Π₂-definable** for every
+    `a : ℚ`.
+
+    Corollary of `singletonOf_isDiophantineDefinition` via the trivial
+    inclusion `Σ₁ ⊆ Π₂` (`diophantine_implies_universal_existential`).
+    Generalizes S6's `singletonZero_isUniversalExistentialDefinition`. -/
+theorem singletonOf_isUniversalExistentialDefinition (a : Rat) :
+    IsUniversalExistentialDefinition (fun q : Rat => q = a) :=
+  diophantine_implies_universal_existential _ (singletonOf_isDiophantineDefinition a)
+
+/-- Iter 8, Path B: **the complement `ℚ \ {a}` is Σ₂-definable** for every
+    `a : ℚ`.
+
+    Corollary of `notSingletonOf_isCoDiophantineDefinition` via the trivial
+    inclusion `Π₁ ⊆ Σ₂` (`codiophantine_implies_existentialUniversal`).
+    Generalizes S6's `notZero_isExistentialUniversalDefinition`. -/
+theorem notSingletonOf_isExistentialUniversalDefinition (a : Rat) :
+    IsExistentialUniversalDefinition (fun q : Rat => q ≠ a) :=
+  codiophantine_implies_existentialUniversal _ (notSingletonOf_isCoDiophantineDefinition a)
+
+/-- Iter 8, Path B: **S6 recovered as the special case `a = 0`** of S8.
+
+    The S8 family `singletonOf_isDiophantineDefinition` evaluated at `a = 0`
+    yields a Σ₁-definability proof of `{q | q = 0}`, the same predicate as
+    S6's `singletonZero_isDiophantineDefinition`. This concrete instance
+    documents that S8 properly generalizes S6 (NOT replaces it: the S6
+    polynomial witness `parameterPoly = fun _ => q` is leaner than the S8
+    witness `shiftPoly 0 = fun _ => q - 0`, so S6 remains the preferred
+    Path A witness for `{0}` specifically). -/
+theorem singletonOf_zero_isDiophantineDefinition :
+    IsDiophantineDefinition (fun q : Rat => q = 0) :=
+  singletonOf_isDiophantineDefinition 0
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -797,6 +891,16 @@ open gap is Σ₁ vs Π₂ (equivalently, Π₁(complement) vs Σ₂(complement)
   ¬¬-shadow `Σ₁(¬¬ IntSubset)`, which is occasionally a more tractable
   reformulation when a refutation argument naturally produces a `¬¬`
   layer (e.g., a classical decomposition of a Π₁ counter-witness).
+- **Every singleton `{a} ⊂ ℚ` is Σ₁-definable** for `a : ℚ` (iter 8): the
+  shift polynomial `P(q, x) = q - a` places `{a}` (resp. `ℚ \ {a}`) into
+  Σ₁ (resp. Π₁), and hence into Π₂ (resp. Σ₂) via the trivial inclusions.
+  This properly generalizes S6's special case `a = 0` to arbitrary
+  `a : ℚ`, recovering S6 as `singletonOf_zero_isDiophantineDefinition`.
+  ℤ as a *family* of singletons `{n} : n : ℤ` does NOT immediately yield
+  Σ₁-definability of ℤ ⊂ ℚ: Σ₁-definability is closed under finite union
+  (and finite intersection) but NOT known to be closed under countable
+  union (the OPEN Σ₁ question for ℤ is precisely the question of whether
+  this particular countable union admits a uniform Σ₁ witness).
 
 ## Axioms in THIS file (1 net new)
 
@@ -808,7 +912,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (35)
+## Theorems in THIS file (40)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -845,6 +949,11 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `universalExistentialDefinition_doubleNeg_iff` (Π₂ ¬¬-shadow, iter 7)
   - `existentialUniversalDefinition_doubleNeg_iff` (Σ₂ ¬¬-shadow, iter 7)
   - `integers_diophantine_iff_doubleNeg` (OPEN Σ₁ question ⟺ its ¬¬-shadow, iter 7)
+  - `singletonOf_isDiophantineDefinition a` ({a} ⊂ ℚ is Σ₁ for any a : ℚ, iter 8 Path B)
+  - `notSingletonOf_isCoDiophantineDefinition a` (ℚ\{a} is Π₁ for any a : ℚ, iter 8 Path B)
+  - `singletonOf_isUniversalExistentialDefinition a` ({a} is Π₂ for any a : ℚ, iter 8 Path B)
+  - `notSingletonOf_isExistentialUniversalDefinition a` (ℚ\{a} is Σ₂ for any a : ℚ, iter 8 Path B)
+  - `singletonOf_zero_isDiophantineDefinition` (S6 recovered as a = 0 instance, iter 8)
 -/
 
 #check @IsDiophantineDefinition
@@ -881,5 +990,10 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @universalExistentialDefinition_doubleNeg_iff
 #check @existentialUniversalDefinition_doubleNeg_iff
 #check @integers_diophantine_iff_doubleNeg
+#check @singletonOf_isDiophantineDefinition
+#check @notSingletonOf_isCoDiophantineDefinition
+#check @singletonOf_isUniversalExistentialDefinition
+#check @notSingletonOf_isExistentialUniversalDefinition
+#check @singletonOf_zero_isDiophantineDefinition
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -1,78 +1,111 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T13:00:00Z
-**Iteration**: 7
-**Last Updated**: 2026-05-08 (researcher-8)
+**Since**: 2026-05-08T18:30:00Z
+**Iteration**: 8
+**Last Updated**: 2026-05-08 (researcher-5)
 
 ## Current Focus
 
-Iteration 7 (2026-05-08, researcher-8, this PR): completing the
-**¬¬-shadow / double-negation invariance** story for all four
-definability classes. Each of Σ₁, Π₁, Σ₂, Π₂ is proved stable under
-classical double-negation of the predicate:
+Iteration 8 (2026-05-08, researcher-5, this PR): **arbitrary singletons
+`{a} ⊂ ℚ` for `a : ℚ`** — the proper generalization of S6's
+`singletonZero_isDiophantineDefinition`. The witness is the **shift
+polynomial** `P(q, x) = q - a` (constant in the variable `x`); its zero
+set in `q` is exactly `{a}`. From this base case the four-class
+placement of `{a}` (resp. `ℚ \ {a}`) into Σ₁/Π₁/Π₂/Σ₂ falls out via
+the trivial inclusions established in earlier iterations:
 
-    Class(¬¬ S)  ⟺  Class(S),  for Class ∈ {Σ₁, Π₁, Σ₂, Π₂}.
+    {a} : Σ₁ (this PR), and hence Π₂ via Σ₁ ⊆ Π₂ (iter 4)
+    ℚ\{a} : Π₁ (this PR), and hence Σ₂ via Π₁ ⊆ Σ₂ (iter 4)
 
-All four are one-line corollaries of the iteration-3/4 `_iff_of_pred_iff`
-class-congruence helpers, applied to the classical bridge
-`S q ↔ ¬¬ S q` (factored out as a private named lemma
-`doubleNeg_pred_iff`). One concrete corollary specializes the Σ₁
-shadow to the open question for ℤ ⊂ ℚ:
+Net new content: 1 definition (`shiftPoly`, private), 5 theorems,
+0 axioms.
+Updated to total: 12 definitions (incl. 4 private), 44 theorems (incl.
+4 private), 1 axiom, 0 sorries, 999 lines (was 885).
 
-    IntegersAreDiophantineOverQ  ⟺  Σ₁(fun q => ¬¬ IntSubset q).
+S6 (`singletonZero_isDiophantineDefinition`) is recovered as the special
+case `a = 0` of the new family, documented as the corollary
+`singletonOf_zero_isDiophantineDefinition`. S6 is NOT replaced: the S6
+witness `parameterPoly = fun _ => q` is leaner than the S8 witness
+`shiftPoly 0 = fun _ => q - 0` (S6 avoids subtraction entirely), so
+S6 remains the preferred Path A witness for the special case `{0}`.
 
-Net new content: 0 definitions, 6 theorems (5 public + 1 private
-bridge), 0 axioms.
-Updated to total: 11 definitions (incl. 3 private), 39 theorems (incl.
-4 private), 1 axiom, 0 sorries, 885 lines (was 787).
+## Architectural Note (Path A → Path B)
 
-Iterations 1–6 established Σ₁ (open), Π₂ (Koenigsmann), the Σ₁/Π₁
-duality (with symmetric form), the Σ₂/Π₂ duality (with symmetric form),
-all four class-congruence helpers, the unconditional Σ₂(ℚ\ℤ) corollary
-of Koenigsmann, the ∅ and ℚ trivial-set library across all four classes,
-and the smallest non-trivial parameter-dependent witness {0}/ℚ\{0}
-across all four classes via the projection polynomial `P(q,x) = q`.
+Iterations 1–7 maintained a **zero-Mathlib (Path A)** discipline,
+relying only on Lean core for arithmetic and on classical excluded
+middle for the duality theorems. Iteration 8 introduces the **first
+Mathlib import** in this file: `Mathlib.Algebra.Group.Basic` for the
+single lemma `sub_eq_zero : a - b = 0 ↔ a = b`. This is the minimal
+import needed to prove that `q - a = 0 ↔ q = a` over `ℚ`.
+
+This is the deliberate Path B transition flagged at the end of S7's
+state.md: "The Path A axiom-free corner of the file is now substantially
+saturated; further single-PR progress without Mathlib is incrementally
+smaller." The Mathlib import unlocks the genuine generalization to
+arbitrary `a : ℚ` (S8) and the closure properties (union, intersection,
+Π₁ ⊆ Π₂ via polynomial inversion) targeted for S9+.
 
 ## Active Approach
 
-S7 — ¬¬-shadow / double-negation invariance (this iteration):
+S8 — arbitrary singletons (this iteration):
 
-1. `doubleNeg_pred_iff S` (private bridge) — `∀ q, S q ↔ ¬¬ S q`,
-   classical (one `Classical.byContradiction`).
-2. `diophantineDefinition_doubleNeg_iff S` — Σ₁(¬¬ S) ⟺ Σ₁(S).
-3. `coDiophantineDefinition_doubleNeg_iff S` — Π₁(¬¬ S) ⟺ Π₁(S).
-4. `universalExistentialDefinition_doubleNeg_iff S` — Π₂(¬¬ S) ⟺ Π₂(S).
-5. `existentialUniversalDefinition_doubleNeg_iff S` — Σ₂(¬¬ S) ⟺ Σ₂(S).
-6. `integers_diophantine_iff_doubleNeg` — concrete shadow specialization
-   for the OPEN Σ₁ question on ℤ ⊂ ℚ.
+1. `shiftPoly a` (private def) — the shift polynomial `fun q _ => q - a`
+   for `a : ℚ`, generalizing S6's `parameterPoly = fun q _ => q`.
+2. `singletonOf_isDiophantineDefinition (a : Rat)` —
+   `IsDiophantineDefinition (fun q => q = a)`. Proof: `refine ⟨shiftPoly a, fun q => ?_⟩` then a 2-line term using `sub_eq_zero.mpr`/`.mp` to convert between `q - a = 0` and `q = a`.
+3. `notSingletonOf_isCoDiophantineDefinition (a : Rat)` —
+   `IsCoDiophantineDefinition (fun q => q ≠ a)`. Direct dual via the
+   same polynomial witness; same `sub_eq_zero` bridge.
+4. `singletonOf_isUniversalExistentialDefinition (a : Rat)` —
+   `IsUniversalExistentialDefinition (fun q => q = a)`. One-line
+   corollary via `diophantine_implies_universal_existential` (iter 1).
+5. `notSingletonOf_isExistentialUniversalDefinition (a : Rat)` —
+   `IsExistentialUniversalDefinition (fun q => q ≠ a)`. One-line
+   corollary via `codiophantine_implies_existentialUniversal` (iter 4).
+6. `singletonOf_zero_isDiophantineDefinition` — the special case `a = 0`
+   of #2, recovering S6's predicate; documents the S6 → S8
+   generalization without claiming S8 is leaner for the `a = 0` case.
 
-Each of #2–#5 is a single `(_iff_of_pred_iff (doubleNeg_pred_iff S)).symm`
-term; #6 is `(diophantineDefinition_doubleNeg_iff IntSubset).symm`. No
-new imports; no field arithmetic; no Mathlib dependencies. Same Path A
-(zero-Mathlib, classical-only) discipline as iterations 5/6.
+The two `theorem`s with `by`-tactic proofs (#2, #3) each consist of one
+`refine ⟨shiftPoly a, fun q => ?_⟩` step followed by a 2-line term
+combining the existential witness `fun _ => 0` with `sub_eq_zero`. The
+three corollaries (#4, #5, #6) are pure term-mode one-liners.
 
 ## Why this matters
 
-The four ¬¬-shadow theorems make explicit a property that was used
-implicitly in iteration 5's symmetric Σ₂/Π₂ duality: the Π₂ class is
-invariant under `¬¬`-rewriting. Promoting that to a named theorem at
-each level gives a uniform tool for refutation arguments that produce
-classical double-negation layers (e.g., a Π₁ counter-witness obtained
-by `Classical.byContradiction` before being repackaged as a Σ₁
-predicate). The concrete `integers_diophantine_iff_doubleNeg` corollary
-is the bridge a refutation argument would actually use on the OPEN
-question for ℤ ⊂ ℚ.
+The four singleton-of-`a` theorems make precise that **Σ₁-definability
+is closed under "rational shifts of a fixed Σ₁ subset"** at the level of
+the polynomial witness. In the family `{a} : a : ℚ`, every individual
+member is Σ₁-definable, but the OPEN Σ₁ question for ℤ ⊂ ℚ is NOT
+immediately settled by viewing ℤ as a *family* of singletons `{n}` for
+`n : ℤ`. The reason: Σ₁-definability is closed under finite union (and
+finite intersection) — see closure properties to be added in S9+ — but
+NOT known to be closed under countable union. The OPEN Σ₁ question is
+precisely the question of whether the countable union `⋃_{n : ℤ} {n}`
+admits a single uniform polynomial witness `P(t, x₁, …, x_k)` whose
+rational-solution slices recover `t ∈ ℤ`.
+
+So this iteration sharpens the OPEN-question landscape by exhibiting
+the smallest piece of the answer that *can* be assembled — every
+individual `{n}` for `n : ℤ` is Σ₁-definable as a member of the
+parametric family `singletonOf_isDiophantineDefinition`. The
+non-uniform "case-by-case" Σ₁-definability of each integer is settled;
+the OPEN content is the existence of a *uniform* polynomial witness.
 
 ## Build Status
 
-Iteration 7 build: PENDING. Worktree's `proofs/.lake` is a recursive
-self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so
-Docker build would re-fresh-clone Mathlib (~25-45 min). The six new
-theorems use ONLY one-line term-mode proofs that compose existing
-iteration-3/4 lemmas by `.symm`; no tactic blocks, no new imports, no
-new defs. Confidence high; CI is the ground truth.
+Iteration 8 build: PENDING. Worktree's `proofs/.lake` is a recursive
+self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so a
+local Docker build would re-fresh-clone Mathlib (~25-45 min) and the
+new `Mathlib.Algebra.Group.Basic` import adds modest extra compilation.
+The two `by`-tactic proofs use only `refine`, `exact`, an existential
+witness `fun _ => 0`, and the Mathlib lemma `sub_eq_zero` (`.mp` and
+`.mpr` directions). The three corollaries are pure term mode. No new
+imports beyond `Mathlib.Algebra.Group.Basic`. Confidence high; CI is
+the ground truth.
 
+Iteration 7 build: PASSED ✅ (per #17125 CI).
 Iteration 6 build: PASSED ✅ (per #17083 CI).
 Iteration 5 build: PASSED ✅ (per #17065 CI).
 Iteration 4 build: PASSED ✅ (per #17026 CI).
@@ -80,39 +113,44 @@ Iteration 3 build: PASSED ✅ (3 jobs, exit code 0).
 
 ## Blockers
 
-None for axiom-free Path A pure-logic iterations. Field-arithmetic
-extensions (closure under union/intersection, Π₁ ⊆ Π₂ via
-polynomial-inversion, arbitrary singletons {a} for a ≠ 0) all require
-Mathlib for `Rat.sub_eq_zero_iff`, `Rat.mul_eq_zero`, etc.
+None for the singleton-of-`a` story. S9+ extensions:
+- Closure under union: needs `mul_eq_zero` (Mathlib —
+  `Mathlib.Algebra.GroupWithZero.Basic` or similar) for the witness
+  `P(q, x, y) = P₁(q, x) · P₂(q, y)`.
+- Closure under intersection: needs sum-of-squares positivity over `ℚ`
+  for the witness `P(q, x, y) = P₁(q, x)² + P₂(q, y)²`. Mathlib has
+  `add_pow_le_pow_mul_pow_of_sq` and friends but the elementary
+  `a² + b² = 0 ↔ a = 0 ∧ b = 0` over an ordered field is the cleaner
+  primitive.
+- Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a · z = 1`
+  — needs `Rat` field arithmetic.
 
 ## Next Action
 
-Commit, push, create PR for iteration 7 (this).
+Commit, push, create PR for iteration 8 (this).
 
-If S7 lands cleanly, S8+ candidates:
-- **S8 (Path A, axiom-free)**: extend the smallest-non-trivial-witness
-  story to other constant-polynomial subsets — e.g., `{q : ℚ | q = 0 ∨
-  q = 0}` (degenerate), or chained singletons via predicate equivalence
-  (`{0} ∪ {0} = {0}` via `_iff_of_pred_iff`).
-- **S8 (Path B, Mathlib import)**: arbitrary singletons {a} for a : ℚ
-  via `P(q, x) = q - a` and `Rat.sub_eq_zero_iff` (the genuine
-  generalization of S6's `singletonZero`).
-- **S8 (Path C, axiomatized)**: Daans 2021 (10-quantifier reduction of
-  Koenigsmann) as a separate axiomatized witness — adds 1 axiom,
-  documentary value only.
-- **S9+**: closure properties (union/intersection) — needs
-  `Rat.mul_eq_zero` (Mathlib).
-- **S9+**: Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z,
-  a·z = 1` — needs `Rat` field arithmetic.
-
-The Path A axiom-free corner of the file is now substantially
-saturated; further single-PR progress without Mathlib is
-incrementally smaller.
+If S8 lands cleanly, S9+ candidates:
+- **S9 (Path B continuation)**: closure of Σ₁ under finite union via
+  the product-of-polynomials witness. Single new lemma; uses
+  `mul_eq_zero` (one more Mathlib import).
+- **S9 (Path B continuation)**: closure of Σ₁ under finite intersection
+  via the sum-of-squares witness. Needs `a² + b² = 0 ↔ a = 0 ∧ b = 0`
+  over an ordered field.
+- **S10**: Π₁ ⊆ Π₂ via polynomial inversion (`a ≠ 0 ⟺ ∃ z, a·z = 1`)
+  — completes the four-corner inclusion picture (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂,
+  Σ₁ ⊆ Π₂ via inversion, Π₁ ⊆ Π₂ via inversion).
+- **S10+**: `IntSubset` exhibited as a *finite-union limit* of
+  `singletonOf` along `Int.cast : Int → Rat` — the explicit union
+  `⋃_{n : ℤ ∩ [-N, N]} {n}` is Σ₁-definable for each finite `N` (a
+  corollary of S9 union closure). The OPEN content is the limit
+  `N → ∞` (uniform vs. non-uniform witness).
+- **S11+**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
+  separate axiomatized witness — adds 1 axiom, documentary value only.
 
 ## Attempt Counts
 
-- Total attempts: 7
-- Current approach attempts: 1 (S7 — ¬¬-shadow, this iteration)
-- Approaches tried: 6 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+- Total attempts: 8
+- Current approach attempts: 1 (S8 — arbitrary singletons, this iteration)
+- Approaches tried: 7 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
   congruence, S5 symmetric duality + trivial sets, S6 smallest
-  non-trivial subset, S7 ¬¬-shadow)
+  non-trivial subset, S7 ¬¬-shadow, S8 arbitrary singletons)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -21,7 +21,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "mathlibDependencies": [],
+    "mathlibDependencies": [
+      "Mathlib.Algebra.Group.Basic"
+    ],
     "originalContributions": [
       "IsDiophantineDefinition: Σ₁ (purely existential) definability of subsets of ℚ",
       "IsUniversalExistentialDefinition: Π₂ (∀∃, universal-existential) definability of subsets of ℚ",
@@ -49,11 +51,16 @@
       "coDiophantineDefinition_doubleNeg_iff: Π₁ class is invariant under classical double-negation — Π₁(¬¬ S) ⟺ Π₁(S) (iter 7, axiom-free)",
       "universalExistentialDefinition_doubleNeg_iff: Π₂ class is invariant under classical double-negation — Π₂(¬¬ S) ⟺ Π₂(S) (iter 7, axiom-free)",
       "existentialUniversalDefinition_doubleNeg_iff: Σ₂ class is invariant under classical double-negation — Σ₂(¬¬ S) ⟺ Σ₂(S) (iter 7, axiom-free; completes the four-class ¬¬-shadow story)",
-      "integers_diophantine_iff_doubleNeg: the OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to its ¬¬-shadow — IntegersAreDiophantineOverQ ⟺ Σ₁(fun q => ¬¬ IntSubset q) (iter 7, axiom-free, refutation-ergonomic reformulation)"
+      "integers_diophantine_iff_doubleNeg: the OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to its ¬¬-shadow — IntegersAreDiophantineOverQ ⟺ Σ₁(fun q => ¬¬ IntSubset q) (iter 7, axiom-free, refutation-ergonomic reformulation)",
+      "singletonOf_isDiophantineDefinition: every singleton {a} ⊂ ℚ is Σ₁-definable for arbitrary a : ℚ via the shift polynomial P(q,x) = q - a (iter 8 Path B, generalizes S6's a = 0 instance; first Mathlib import — uses sub_eq_zero from Mathlib.Algebra.Group.Basic; no new axioms)",
+      "notSingletonOf_isCoDiophantineDefinition: every complement ℚ \\ {a} is Π₁-definable for arbitrary a : ℚ via the same shift polynomial (iter 8 Path B, dual of singletonOf)",
+      "singletonOf_isUniversalExistentialDefinition: every {a} ⊂ ℚ is Π₂-definable, corollary of Σ₁ membership via Σ₁ ⊆ Π₂ (iter 8 Path B)",
+      "notSingletonOf_isExistentialUniversalDefinition: every ℚ \\ {a} is Σ₂-definable, corollary of Π₁ membership via Π₁ ⊆ Σ₂ (iter 8 Path B)",
+      "singletonOf_zero_isDiophantineDefinition: documents that S6's singletonZero is recovered as the a = 0 instance of S8's parametric singletonOf family (iter 8)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 885,
+    "lineCount": 999,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -61,8 +68,8 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 39,
-    "definitionCount": 11
+    "theoremCount": 44,
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -185,14 +192,15 @@
   },
   "leanFile": {
     "imports": [
-      "Proofs.Hilbert10OQ01"
+      "Proofs.Hilbert10OQ01",
+      "Mathlib.Algebra.Group.Basic"
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 885,
+    "lineCount": 999,
     "axiomCount": 1,
-    "theoremCount": 39,
-    "definitionCount": 11,
+    "theoremCount": 44,
+    "definitionCount": 12,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -49,7 +49,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PHASE-2 ACT iterations 1-4 complete. Iteration 1 (researcher-6, 2026-05-08): scaffolded the file with Σ₁/Π₂ skeleton (5 theorems, 5 defs, 1 axiom). Iteration 2 (researcher-9 session 1, 2026-05-08): added Σ₁/Π₁ duality (4 new theorems, 2 new defs, 0 new axioms; PR #16839 merged). Iteration 3 (researcher-9 session 2, 2026-05-08): added Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (4 new theorems, 1 new def, 0 new axioms; PR #16885 merged). Iteration 4 (researcher-1, 2026-05-08, this PR): completes the propositional-equivalence congruence story by adding the three remaining class congruence helpers — diophantineDefinition_iff_of_pred_iff (Σ₁), coDiophantineDefinition_iff_of_pred_iff (Π₁), existentialUniversalDefinition_iff_of_pred_iff (Σ₂) — all axiom-free, mechanically templated on the existing Π₂ congruence. The file is now 526 lines with 16 theorems, 8 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries; the Σ₁ question itself remains OPEN (intentionally). All four corners of the Σ₁/Π₁/Σ₂/Π₂ square — two trivial containments (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂), two dualities (Σ₁/Π₁, Σ₂/Π₂), and now four propositional-equivalence congruences — are formalized. Iteration 4 build pending; iteration 3 build passed.",
+    "progressSummary": "PHASE-2 ACT iterations 1-8 complete. Iter 1 (researcher-6): scaffold (5 thm). Iter 2 (researcher-9): Σ₁/Π₁ duality (+4 thm). Iter 3 (researcher-9): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (+4 thm). Iter 4 (researcher-1): three remaining class congruence helpers (+3 thm, axiom-free). Iter 5 (PR #17065): symmetric duality + ∅/ℚ trivial-set library across all four classes. Iter 6 (PR #17083): smallest non-trivial parameter-dependent witness {0}/ℚ\\{0} via projection polynomial P(q,x)=q. Iter 7 (PR #17125): four ¬¬-shadows (Σ₁/Π₁/Σ₂/Π₂ stable under classical double negation) + concrete OPEN-question shadow IntegersAreDiophantineOverQ ⟺ Σ₁(¬¬ IntSubset). Iter 8 (researcher-5, this PR): **Path B transition** — first Mathlib import (Mathlib.Algebra.Group.Basic for sub_eq_zero) enables the proper generalization of S6 singletonZero to **arbitrary singletons {a} ⊂ ℚ for any a : ℚ** via the shift polynomial P(q,x) = q - a. Adds 5 theorems (4 parametric + 1 a=0 recovery instance) + 1 private def (shiftPoly). Total: 999 lines, 44 theorems, 12 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries. The Σ₁ question itself remains OPEN (intentionally). Iter 8 build pending; iter 7 build passed.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
       "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
@@ -77,7 +77,15 @@
       "Proofs/Hilbert10OQ01OQ02.lean: theorem diophantineDefinition_iff_of_pred_iff (Σ₁ class congruence under propositional equivalence; pure logic, no axioms) (lines 367-385, iteration 4)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem coDiophantineDefinition_iff_of_pred_iff (Π₁ class congruence under propositional equivalence; pure logic, no axioms) (lines 387-403, iteration 4)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem existentialUniversalDefinition_iff_of_pred_iff (Σ₂ class congruence under propositional equivalence; pure logic, no axioms) (lines 405-422, iteration 4)",
-      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 462→526, theoremCount 13→16 (axiomCount/definitionCount unchanged)"
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 462→526, theoremCount 13→16 (axiomCount/definitionCount unchanged)",
+      "Proofs/Hilbert10OQ01OQ02.lean: import Mathlib.Algebra.Group.Basic added (S8 iter 8, first Mathlib import in this file — Path B transition for sub_eq_zero on ℚ)",
+      "Proofs/Hilbert10OQ01OQ02.lean: private def shiftPoly (a : Rat) : Rat → RatDiophantinePoly := fun q _ => q - a (S8, generalizes S6 parameterPoly to arbitrary rational shift)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonOf_isDiophantineDefinition (a : Rat) — every {a} ⊂ ℚ is Σ₁-definable for any a : ℚ (S8 Path B; uses sub_eq_zero from Mathlib)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonOf_isCoDiophantineDefinition (a : Rat) — every ℚ \\ {a} is Π₁-definable for any a : ℚ (S8 dual)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonOf_isUniversalExistentialDefinition (a : Rat) — every {a} ⊂ ℚ is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (S8)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonOf_isExistentialUniversalDefinition (a : Rat) — every ℚ \\ {a} is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (S8)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonOf_zero_isDiophantineDefinition — documents S6 = a=0 instance of S8 family (S8)",
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 885→999, theoremCount 39→44, definitionCount 11→12; mathlibDependencies = [Mathlib.Algebra.Group.Basic]; leanFile.imports gained Mathlib.Algebra.Group.Basic"
     ],
     "insights": [
       "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",
@@ -95,20 +103,28 @@
       "Π₁ ⊆ Σ₂ is the precise dual of Σ₁ ⊆ Π₂: a Π₁ formula ∀ x, P(q,x) ≠ 0 is automatically a Σ₂ formula ∃ y, ∀ x, P(q,x) ≠ 0 with a dummy existential block (witnessed by `fun _ => 0`). 6-line proof.",
       "The Σ₂(ℚ\\ℤ) corollary of Koenigsmann is non-trivial structural content: it places ℚ\\ℤ on the second level of the arithmetic hierarchy unconditionally, with no new axiom beyond Koenigsmann.",
       "Bridging across negation requires a predicate-equivalence helper: Π₂ class is invariant under propositional equivalence (universalExistentialDefinition_iff_of_pred_iff). The bridge IntSubset q ↔ ¬ NotIntSubset q uses standard double-negation introduction + Classical.byContradiction.",
-      "Pattern for axiom-free duality proofs in Lean core: `apply Classical.byContradiction; intro hn; have : ... := ...` — this idiom carries the file with no Mathlib import."
+      "Pattern for axiom-free duality proofs in Lean core: `apply Classical.byContradiction; intro hn; have : ... := ...` — this idiom carries the file with no Mathlib import.",
+      "S6 → S8 generalization (singletonZero → singletonOf): the projection polynomial P(q,x) = q recovers as the special case a = 0 of the shift polynomial P(q,x) = q - a; the shift family adds nothing new for a = 0 but parameterizes the entire family of singletons by a single witness",
+      "Σ₁-definability is closed under FINITE union (and intersection) but the OPEN ℤ ⊂ ℚ Σ₁ question is precisely the question of closure under COUNTABLE union along Int.cast — the family of singletons {n} for n : ℤ is uniformly Σ₁-definable per-element (via singletonOf at a = n) but not known to admit a single uniform polynomial witness for the union",
+      "Path A → Path B transition: the file architecture changes at iter 8 to allow Mathlib imports. The minimal cost (one import: Mathlib.Algebra.Group.Basic for sub_eq_zero) unlocks the singleton-of-a generalization, the closure properties (S9+: needs mul_eq_zero), and Π₁ ⊆ Π₂ via inversion (S10+: needs Rat field arithmetic)"
     ],
     "mathlibGaps": [
       "No formal definition of 'Diophantine subset of a ring' in Mathlib — `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat → Rat) → Rat`",
       "No formalization of Matiyasevich's DPRM theorem (would be needed to prove the reduction `IntegersDiophantineOverQ → ¬H10_Rational_Decidable` rather than axiomatizing it)",
       "No formalization of Koenigsmann's universal definition of ℤ in ℚ (the 2016 Annals paper has explicit polynomials)",
-      "No general first-order logic / Σ_n / Π_n hierarchy in Mathlib for this kind of definability question"
+      "No general first-order logic / Σ_n / Π_n hierarchy in Mathlib for this kind of definability question",
+      "Mathlib has sub_eq_zero, mul_eq_zero, and Rat field arithmetic — so Path B for arbitrary singletons + finite-union closure is fully buildable. The OPEN content is the COUNTABLE union (uniform vs non-uniform witness for ℤ ⊂ ℚ Σ₁-definability), which is precisely the open Σ₁ question and not a Mathlib gap"
     ],
     "nextSteps": [
       "S4: Σ₁ × Π₁ closure properties (under finite union/intersection) — requires either Mathlib import for Rat.mul_eq_zero / sum-of-squares-zero or hand-rolled proofs from Lean core. Significant infrastructure work.",
       "S5: Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker as S4.",
       "S6: Daans 2021 (10-quantifier reduction) as a separate axiom refining koenigsmann_2016_universal — would add 1 new axiom but improve quantitative content.",
       "S7: Eisenträger-Park 2018 universal-existential characterization for global fields — sibling-of-sibling formalization track.",
-      "Eventually: formalize the explicit Koenigsmann polynomial in Lean to discharge `koenigsmann_2016_universal` — requires Hilbert-symbol/quaternion infrastructure (partial in Hilbert11_QuadraticForms.lean)."
+      "Eventually: formalize the explicit Koenigsmann polynomial in Lean to discharge `koenigsmann_2016_universal` — requires Hilbert-symbol/quaternion infrastructure (partial in Hilbert11_QuadraticForms.lean).",
+      "S9 (Path B): closure of Σ₁ under finite union via P(q,x,y) = P_1(q,x) · P_2(q,y); needs mul_eq_zero (one more Mathlib import). Apply to deduce the explicit finite union {n : -N ≤ n ≤ N} ⊂ ℚ is Σ₁-definable for each finite N",
+      "S9 (Path B): closure of Σ₁ under finite intersection via P(q,x,y) = P_1(q,x)^2 + P_2(q,y)^2; needs (a^2 + b^2 = 0 ↔ a = 0 ∧ b = 0) over an ordered field",
+      "S10 (Path B): Π₁ ⊆ Π₂ via the polynomial-inversion trick a ≠ 0 ⟺ ∃ z, a · z = 1 — completes the four-corner inclusion picture",
+      "S10+ (Path B): IntSubset exhibited as a finite-union limit of singletonOf along Int.cast — explicit ⋃_{n ∈ [-N, N]} {n} Σ₁-definable for each finite N (corollary of S9). The OPEN content is the limit N → ∞ (uniform witness)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Iteration 8 of the Hilbert 10 OQ-01-OQ-02 (Σ₁ vs Π₂ definability of ℤ in ℚ) line of work.

**S8 Path B:** generalize S6's `singletonZero_isDiophantineDefinition` to arbitrary singletons `{a} ⊂ ℚ` for any `a : ℚ`, via the **shift polynomial** `P(q, x) = q - a`.

This is the deliberate **Path A → Path B transition** flagged at the end of S7's state.md ("the Path A axiom-free corner of the file is now substantially saturated"). Iter 8 introduces the **first Mathlib import** in this file: `Mathlib.Algebra.Group.Basic`, used solely for `sub_eq_zero` to bridge `q - a = 0 ↔ q = a` over `ℚ`.

## What's new

5 theorems, 1 private definition, 0 axioms.

| Theorem | Statement |
|---|---|
| `singletonOf_isDiophantineDefinition a` | `{a} ⊂ ℚ` is Σ₁-definable |
| `notSingletonOf_isCoDiophantineDefinition a` | `ℚ\{a}` is Π₁-definable |
| `singletonOf_isUniversalExistentialDefinition a` | `{a}` is Π₂-definable (via Σ₁ ⊆ Π₂) |
| `notSingletonOf_isExistentialUniversalDefinition a` | `ℚ\{a}` is Σ₂-definable (via Π₁ ⊆ Σ₂) |
| `singletonOf_zero_isDiophantineDefinition` | recovers S6 as the `a = 0` instance |

S6 is **not replaced**: the S6 witness `parameterPoly = fun _ => q` is leaner than the S8 witness `shiftPoly 0 = fun _ => q - 0` (S6 avoids subtraction entirely), so S6 remains the preferred Path A witness for the special case `{0}`.

## Why this matters

Every individual `{n}` for `n : ℤ` is now Σ₁-definable as a member of the parametric family `singletonOf_isDiophantineDefinition`. But the **OPEN** ℤ ⊂ ℚ Σ₁ question is NOT immediately settled by viewing ℤ as the family of singletons `{n} : n : ℤ` — Σ₁-definability is closed under finite union (and intersection) but **NOT known to be closed under countable union**. The OPEN content is precisely the existence of a single uniform polynomial witness for `⋃_{n : ℤ} {n}`.

S8 sharpens the OPEN-question landscape by exhibiting the smallest piece of the answer that *can* be assembled — non-uniform "case-by-case" Σ₁-definability of each integer is settled; the OPEN content is the existence of a *uniform* polynomial witness.

## Counts

| Metric | Before (S7) | After (S8) | Δ |
|---|---|---|---|
| Lines | 885 | 999 | +114 |
| Theorems | 39 | 44 | +5 |
| Definitions | 11 | 12 | +1 (private `shiftPoly`) |
| Axioms | 1 | 1 | 0 |
| Sorries | 0 | 0 | 0 |
| Mathlib deps | 0 | 1 | +1 (`Mathlib.Algebra.Group.Basic`) |

## Files changed

- `proofs/Proofs/Hilbert10OQ01OQ02.lean` — `import Mathlib.Algebra.Group.Basic`; new `Part VIII.9` section (1 def + 5 theorems, ~115 lines); narrative bullet in `Part IX`; theorem-list entries; #check entries
- `research/problems/hilbert-10-oq-01-oq-02/state.md` — S7 → S8 (next-actions, build status, attempt counts)
- `src/data/proofs/hilbert-10-oq-01-oq-02/meta.json` — counts 885→999 / 39→44 / 11→12; `mathlibDependencies` + `leanFile.imports` add `Mathlib.Algebra.Group.Basic`; +5 `originalContributions`
- `src/data/research/problems/hilbert-10-oq-01-oq-02.json` — +8 `builtItems`, +3 `insights`, +1 `mathlibGap`, +4 `nextSteps`; updated `progressSummary`

## Build status

**PENDING.** Local Docker build is impractical: this worktree's `proofs/.lake` is a recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), forcing a fresh Mathlib clone (~25-45 min). The new `Mathlib.Algebra.Group.Basic` import adds modest extra compilation.

The two `by`-tactic proofs (`singletonOf_isDiophantineDefinition` and `notSingletonOf_isCoDiophantineDefinition`) are 2-line `refine ⟨shiftPoly a, fun q => ?_⟩` + `exact` term combos using `sub_eq_zero` (`.mp`/`.mpr`). The three corollaries are pure term-mode one-liners. **Confidence high; CI is the ground truth.** Iterations 3–7 all PASSED CI.

## Test plan

- [ ] CI builds `Proofs.Hilbert10OQ01OQ02` cleanly with the new Mathlib import
- [ ] Auditor confirms no count drift (lineCount=999, theoremCount=44, definitionCount=12, axiomCount=1, sorries=0)
- [ ] Gallery renders without schema errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)