### PR TITLE
fix(meta): batch sync stale leanFile counts (3 entries)

### DIFF
--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -147,9 +147,9 @@
       "Finset"
     ],
     "namespace": "Erdos190",
-    "lineCount": 348,
+    "lineCount": 399,
     "axiomCount": 3,
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 10,
     "path": "Proofs/Erdos190Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -176,9 +176,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 187,
+    "lineCount": 229,
     "axiomCount": 3,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 3,
     "path": "Proofs/Erdos200Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -24,7 +24,7 @@
     "lineCount": 208,
     "assumptions": "3 axioms inherited from Erdos25LogDensity.lean: naturalDensity_implies_logDensity (natural density implies logarithmic density), exists_logDensity_no_naturalDensity (existence of sets with log density but no natural density), davenport_erdos (Davenport-Erdős theorem on log density). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 6
   },
   "overview": {
@@ -151,9 +151,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 166,
+    "lineCount": 208,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 11,
     "definitionCount": 6,
     "path": "Proofs/Erdos25Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `leanFile` block counts after research-PR iterations updated the Lean files and the `meta` sub-object but forgot the `leanFile` block.

## Evidence

Verified against actual Lean files at origin/main HEAD using the visible-lines convention (matches PR #17208) and the standard theorem/lemma regex with `@[…]` / `private|protected|noncomputable` modifiers (matches PR #17194).

| slug | field | before | after |
|------|-------|--------|-------|
| erdos-190 | lf.lineCount | 348 | 399 |
| erdos-190 | lf.theoremCount | 6 | 9 |
| erdos-200 | lf.lineCount | 187 | 229 |
| erdos-200 | lf.theoremCount | 8 | 11 |
| erdos-25 | lf.lineCount | 166 | 208 |
| erdos-25 | lf.theoremCount | 7 | 11 |
| erdos-25 | meta.theoremCount | 10 | 11 |

For erdos-190 and erdos-200, the `meta` sub-object was already correct (399 / 229; 9 / 11). For erdos-25, both `lf` and `meta` were stale on `theoremCount`.

axiomCount untouched: erdos-25 has `meta.axiomCount=3` vs file-only=0 (the 3 axioms are inherited from `Erdos25LogDensity.lean`). Per Axiom Integrity Policy, this divergence is by design (meta tracks import chain).

## Source attribution

These three entries had recent research-PR merges that updated the file and the `meta` sub-object but left `leanFile` stale:
- erdos-190 → #17207 (Iter 2)
- erdos-200 → #17195 (Iter 8)
- erdos-25 → #17201 (Iter 2)

---
Automated fix by lean-mechanic agent.