### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): S8 — binomialCDF tail-limit lemmas (complement to PR #17233)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -242,6 +242,38 @@ theorem standardNormalCDF_continuous : Continuous standardNormalCDF := by
   exact continuous_const.add
     ((ProbabilityTheory.integrable_gaussianPDFReal 0 1).continuous_primitive 0)
 
+/-- **Right-tail saturation of Φ.** As `x → +∞`, the standard normal CDF
+    tends to `1`.
+
+    Proof: the family `(Set.Iic x)_{x : ℝ}` is an `AECover` for `volume`
+    along `Filter.atTop` (`MeasureTheory.aecover_Iic Filter.tendsto_id`);
+    applying `MeasureTheory.AECover.integral_tendsto_of_countably_generated`
+    to the integrable density `ProbabilityTheory.gaussianPDFReal 0 1`
+    gives convergence of `∫ t in Iic x, gaussianPDFReal 0 1 t` to the total
+    integral, which equals `1` by
+    `ProbabilityTheory.integral_gaussianPDFReal_eq_one`.
+
+    On the **Phase-4 Portmanteau-bridge critical path**: paired with the
+    binomialCDF right-tail saturation `binomialCDF_tendsto_one_atTop`,
+    this is one of the two asymptotic identities the Portmanteau direction
+    at `+∞` consumes (and ditto at `-∞`, via the matching `_atBot` lemmas
+    once added). With Φ's continuity (`standardNormalCDF_continuous`)
+    and these tail saturations together, the Portmanteau bridge applies
+    universally to discharge `binomial_clt_pointwise`. -/
+theorem standardNormalCDF_tendsto_one_atTop :
+    Filter.Tendsto standardNormalCDF Filter.atTop (nhds 1) := by
+  unfold standardNormalCDF
+  have hcov : MeasureTheory.AECover (MeasureTheory.volume : MeasureTheory.Measure ℝ)
+      Filter.atTop (fun x : ℝ => Set.Iic x) :=
+    MeasureTheory.aecover_Iic Filter.tendsto_id
+  have hint : MeasureTheory.Integrable (ProbabilityTheory.gaussianPDFReal 0 1) :=
+    ProbabilityTheory.integrable_gaussianPDFReal 0 1
+  have h := hcov.integral_tendsto_of_countably_generated hint
+  have htotal : ∫ t, ProbabilityTheory.gaussianPDFReal 0 1 t = 1 :=
+    ProbabilityTheory.integral_gaussianPDFReal_eq_one 0 one_ne_zero
+  rw [htotal] at h
+  exact h
+
 /-! ## Axiom: classical de Moivre–Laplace (binomial CLT) -/
 
 /-- **AXIOM** (de Moivre–Laplace, 1733/1812): the standardized binomial CDF
@@ -481,6 +513,44 @@ theorem binomialCDF_eq_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
   rw [← hadd]
   refine Finset.sum_congr rfl (fun j _ => ?_)
   ring
+
+/-- **Right-tail asymptote of `binomialCDF`.** As `x → +∞`, the binomial
+    CDF tends to `1` (under `0 ≤ p ≤ 1`).
+
+    Proof: by `binomialCDF_eq_one`, `binomialCDF n p x = 1` for every
+    `x` with `(n : ℝ) ≤ x`; the predicate `(n : ℝ) ≤ x` holds eventually
+    along `Filter.atTop` (`Filter.eventually_ge_atTop`), so the function
+    is *eventually constant equal to `1`* and the limit is `1`.
+
+    Companion to `standardNormalCDF_tendsto_one_atTop`: paired right-tail
+    saturation feeding the Phase-4 Portmanteau bridge. -/
+theorem binomialCDF_tendsto_one_atTop (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) := by
+  have h : Filter.Tendsto (fun _ : ℝ => (1 : ℝ)) Filter.atTop (nhds 1) :=
+    tendsto_const_nhds
+  refine h.congr' ?_
+  filter_upwards [Filter.eventually_ge_atTop (n : ℝ)] with x hx
+  exact (binomialCDF_eq_one n hp0 hp1 hx).symm
+
+/-- **Left-tail asymptote of `binomialCDF`.** As `x → -∞`, the binomial
+    CDF tends to `0`.
+
+    Proof: by `binomialCDF_neg`, `binomialCDF n p x = 0` for every `x < 0`;
+    the predicate `x < 0` holds eventually along `Filter.atBot`
+    (`Filter.eventually_lt_atBot`), so the function is *eventually constant
+    equal to `0`* and the limit is `0`. No constraints on `p` are needed:
+    `binomialCDF_neg` already holds for arbitrary `p`.
+
+    The matching `standardNormalCDF_tendsto_zero_atBot` (Φ's left-tail
+    saturation) is the next structural-CDF prerequisite for the
+    Phase-4 Portmanteau bridge. -/
+theorem binomialCDF_tendsto_zero_atBot (n : ℕ) (p : ℝ) :
+    Filter.Tendsto (binomialCDF n p) Filter.atBot (nhds 0) := by
+  have h : Filter.Tendsto (fun _ : ℝ => (0 : ℝ)) Filter.atBot (nhds 0) :=
+    tendsto_const_nhds
+  refine h.congr' ?_
+  filter_upwards [Filter.eventually_lt_atBot (0 : ℝ)] with x hx
+  exact (binomialCDF_neg n p hx).symm
 
 /-! ## Main theorem: multinomial marginal CLT (derived) -/
 

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -242,38 +242,6 @@ theorem standardNormalCDF_continuous : Continuous standardNormalCDF := by
   exact continuous_const.add
     ((ProbabilityTheory.integrable_gaussianPDFReal 0 1).continuous_primitive 0)
 
-/-- **Right-tail saturation of Φ.** As `x → +∞`, the standard normal CDF
-    tends to `1`.
-
-    Proof: the family `(Set.Iic x)_{x : ℝ}` is an `AECover` for `volume`
-    along `Filter.atTop` (`MeasureTheory.aecover_Iic Filter.tendsto_id`);
-    applying `MeasureTheory.AECover.integral_tendsto_of_countably_generated`
-    to the integrable density `ProbabilityTheory.gaussianPDFReal 0 1`
-    gives convergence of `∫ t in Iic x, gaussianPDFReal 0 1 t` to the total
-    integral, which equals `1` by
-    `ProbabilityTheory.integral_gaussianPDFReal_eq_one`.
-
-    On the **Phase-4 Portmanteau-bridge critical path**: paired with the
-    binomialCDF right-tail saturation `binomialCDF_tendsto_one_atTop`,
-    this is one of the two asymptotic identities the Portmanteau direction
-    at `+∞` consumes (and ditto at `-∞`, via the matching `_atBot` lemmas
-    once added). With Φ's continuity (`standardNormalCDF_continuous`)
-    and these tail saturations together, the Portmanteau bridge applies
-    universally to discharge `binomial_clt_pointwise`. -/
-theorem standardNormalCDF_tendsto_one_atTop :
-    Filter.Tendsto standardNormalCDF Filter.atTop (nhds 1) := by
-  unfold standardNormalCDF
-  have hcov : MeasureTheory.AECover (MeasureTheory.volume : MeasureTheory.Measure ℝ)
-      Filter.atTop (fun x : ℝ => Set.Iic x) :=
-    MeasureTheory.aecover_Iic Filter.tendsto_id
-  have hint : MeasureTheory.Integrable (ProbabilityTheory.gaussianPDFReal 0 1) :=
-    ProbabilityTheory.integrable_gaussianPDFReal 0 1
-  have h := hcov.integral_tendsto_of_countably_generated hint
-  have htotal : ∫ t, ProbabilityTheory.gaussianPDFReal 0 1 t = 1 :=
-    ProbabilityTheory.integral_gaussianPDFReal_eq_one 0 one_ne_zero
-  rw [htotal] at h
-  exact h
-
 /-! ## Axiom: classical de Moivre–Laplace (binomial CLT) -/
 
 /-- **AXIOM** (de Moivre–Laplace, 1733/1812): the standardized binomial CDF

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,32 +1,52 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT (Phase-4 prep — completed CDF-structure library for Φ)
+**Phase**: ACT (Phase-4 prep — tendsto-saturation lemmas added on right tail)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Session 7, researcher-11)
-**Iteration**: 7
+**Last Updated**: 2026-05-08 (Session 8, researcher-6)
+**Iteration**: 8
 
 ## Current Focus
-Phase-4 prep continued — Session 7 completed the standard-normal CDF
-structural library by adding `standardNormalCDF_continuous`. Together
-with the three lemmas Session 6 added (`_nonneg`, `_le_one`, `_mono`)
-and the four `binomialCDF_*` lemmas (Sessions 4–5), the file now has
-machine-verified evidence on both sides of the Portmanteau convergence
-that Φ and the standardized binomial CDFs are *bona fide* CDFs in the
-Mathlib sense — non-negative, monotone, bounded above by 1, and (for
-the limit Φ) continuous everywhere. The continuity proof reduces
-`standardNormalCDF` to `standardNormalCDF 0 + intervalIntegral 0..x`
-via `MeasureTheory.intervalIntegral_tendsto_integral_Iic` and the
-adjacent-intervals identity, then applies
-`MeasureTheory.Integrable.continuous_primitive` (which uses `NoAtoms`
-on `volume`). New imports: `Mathlib.MeasureTheory.Integral.IntegralEqImproper`,
-`Mathlib.MeasureTheory.Integral.DominatedConvergence`.
+Phase-4 prep continued — Session 8 adds three asymptotic-saturation
+(`Filter.Tendsto`-form) lemmas covering the right-tail of both Φ and the
+binomial CDF, plus the left-tail of the binomial CDF:
+
+- `standardNormalCDF_tendsto_one_atTop`: `Tendsto Φ atTop (𝓝 1)`. Proof
+  uses `MeasureTheory.aecover_Iic Filter.tendsto_id` to get the AECover
+  for `volume` along `atTop`, then
+  `AECover.integral_tendsto_of_countably_generated` on the integrable
+  `gaussianPDFReal 0 1`, with the total integral identified as 1 by
+  `ProbabilityTheory.integral_gaussianPDFReal_eq_one 0 one_ne_zero`.
+- `binomialCDF_tendsto_one_atTop` (under `0 ≤ p ≤ 1`): eventually
+  constant via `binomialCDF_eq_one`, packaged with `Tendsto.congr'` and
+  `Filter.eventually_ge_atTop (n : ℝ)`.
+- `binomialCDF_tendsto_zero_atBot`: eventually constant via
+  `binomialCDF_neg`, packaged with `Tendsto.congr'` and
+  `Filter.eventually_lt_atBot (0 : ℝ)`. No `p` constraint required.
+
+These three lemmas convert the boundary-value information from
+Sessions 4–7 into the `Filter.Tendsto` form Mathlib's Portmanteau
+direction at `±∞` consumes. Together with `standardNormalCDF_continuous`
+(Session 7) and the four-corner `binomialCDF_*` lemmas (Sessions 4–7),
+all the right-tail prerequisites are in place. The matching
+`standardNormalCDF_tendsto_zero_atBot` (Φ left tail) is the remaining
+structural-CDF prerequisite: the proof needs the `Antitone` direction
+(`Antitone.tendsto_setIntegral` on `(fun y => Iic (-y))` composed with
+`Filter.tendsto_neg_atBot_atTop`) since `aecover_Iic` only cares about
+covers expanding to the whole space, not contracting to `∅`.
 
 **Axiom count: 1 (unchanged).** The file is now 0 sorries / 1 axiom
-(`binomial_clt_pointwise` only). With the CDF-structure library now
-complete on both sides of the convergence, Session 8 should be able to
-attempt the Portmanteau-bridge axiom discharge.
+(`binomial_clt_pointwise` only), 17 theorems (substantive count: 13),
+582 lines.
+
+**Build verification.** Session 8 was conducted under the broken
+`/Users/rwalters/GitHub/lean-genius/proofs/.lake` self-symlink trap
+(see memory feedback `feedback_researcher_lake_symlink_broken.md`),
+so a Docker build was not run. Each lemma uses well-tested Mathlib
+idioms (`AECover` API, `Filter.Tendsto.congr'`, `filter_upwards` over
+`eventually_ge_atTop` / `eventually_lt_atBot`), so confidence is high
+but not verified locally. CI is the ground truth for this PR.
 
 ## Active Approach
 **CDF-based** rather than the measure-theoretic Bernoulli-sum approach

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -8,16 +8,9 @@
 **Iteration**: 8
 
 ## Current Focus
-Phase-4 prep continued — Session 8 adds three asymptotic-saturation
-(`Filter.Tendsto`-form) lemmas covering the right-tail of both Φ and the
-binomial CDF, plus the left-tail of the binomial CDF:
+Phase-4 prep continued — Session 8 (this PR, complementary track) adds
+two binomialCDF-side asymptotic-saturation (`Filter.Tendsto`-form) lemmas:
 
-- `standardNormalCDF_tendsto_one_atTop`: `Tendsto Φ atTop (𝓝 1)`. Proof
-  uses `MeasureTheory.aecover_Iic Filter.tendsto_id` to get the AECover
-  for `volume` along `atTop`, then
-  `AECover.integral_tendsto_of_countably_generated` on the integrable
-  `gaussianPDFReal 0 1`, with the total integral identified as 1 by
-  `ProbabilityTheory.integral_gaussianPDFReal_eq_one 0 one_ne_zero`.
 - `binomialCDF_tendsto_one_atTop` (under `0 ≤ p ≤ 1`): eventually
   constant via `binomialCDF_eq_one`, packaged with `Tendsto.congr'` and
   `Filter.eventually_ge_atTop (n : ℝ)`.
@@ -25,20 +18,25 @@ binomial CDF, plus the left-tail of the binomial CDF:
   `binomialCDF_neg`, packaged with `Tendsto.congr'` and
   `Filter.eventually_lt_atBot (0 : ℝ)`. No `p` constraint required.
 
-These three lemmas convert the boundary-value information from
-Sessions 4–7 into the `Filter.Tendsto` form Mathlib's Portmanteau
-direction at `±∞` consumes. Together with `standardNormalCDF_continuous`
-(Session 7) and the four-corner `binomialCDF_*` lemmas (Sessions 4–7),
-all the right-tail prerequisites are in place. The matching
-`standardNormalCDF_tendsto_zero_atBot` (Φ left tail) is the remaining
-structural-CDF prerequisite: the proof needs the `Antitone` direction
-(`Antitone.tendsto_setIntegral` on `(fun y => Iic (-y))` composed with
-`Filter.tendsto_neg_atBot_atTop`) since `aecover_Iic` only cares about
-covers expanding to the whole space, not contracting to `∅`.
+The matching standardNormalCDF tail-limit lemmas (Φ → 1 at +∞ and
+Φ → 0 at -∞) are added in the parallel S8 PR #17233 (researcher-1, opened
+3 minutes earlier). To avoid lemma-statement collisions on a hot file,
+this PR was narrowed to the binomialCDF side only — the original draft
+also included `standardNormalCDF_tendsto_one_atTop` but that lemma is
+already in #17233 under name `standardNormalCDF_tendsto_atTop` with the
+same proof technique (AECover + integral_gaussianPDFReal_eq_one), so
+keeping it here would have produced a merge conflict.
 
-**Axiom count: 1 (unchanged).** The file is now 0 sorries / 1 axiom
-(`binomial_clt_pointwise` only), 17 theorems (substantive count: 13),
-582 lines.
+Together, the two PRs convert the boundary-value information from
+Sessions 4–7 into the `Filter.Tendsto` form Mathlib's Portmanteau
+direction at `±∞` consumes. With `standardNormalCDF_continuous`
+(Session 7) and the four-corner `binomialCDF_*` lemmas (Sessions 4–7),
+all the structural-CDF prerequisites for the Portmanteau bridge are
+now in place after both S8 PRs land.
+
+**Axiom count: 1 (unchanged).** After this PR alone: 0 sorries / 1 axiom
+(`binomial_clt_pointwise` only), 16 theorems (substantive count: 12),
+550 lines.
 
 **Build verification.** Session 8 was conducted under the broken
 `/Users/rwalters/GitHub/lean-genius/proofs/.lake` self-symlink trap

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -20,8 +20,8 @@
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 512,
-    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The Session-2 `standardNormalCDF` opaque marker has been replaced (Session 6) by a concrete `noncomputable def` integrating Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`; this removes that declaration from the assumption count and adds four elementary structural lemmas (`standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono`, `standardNormalCDF_continuous` [Session 7]) that together establish Φ is a *bona fide* continuous CDF on ℝ — every point is a continuity point, so the Portmanteau bridge that next session will build to discharge the axiom applies universally. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` was proved in Phase-3: it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
+    "lineCount": 582,
+    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The Session-2 `standardNormalCDF` opaque marker has been replaced (Session 6) by a concrete `noncomputable def` integrating Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`; this removes that declaration from the assumption count and adds four elementary structural lemmas (`standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono`, `standardNormalCDF_continuous` [Session 7]) that together establish Φ is a *bona fide* continuous CDF on ℝ — every point is a continuity point, so the Portmanteau bridge that next session will build to discharge the axiom applies universally. Session 8 (this session) adds three asymptotic-saturation lemmas — `standardNormalCDF_tendsto_one_atTop` (Φ(x) → 1 as x → +∞ via `MeasureTheory.aecover_Iic` + `AECover.integral_tendsto_of_countably_generated` + `integral_gaussianPDFReal_eq_one`), `binomialCDF_tendsto_one_atTop` (binomialCDF n p x → 1 as x → +∞, eventually-constant via `binomialCDF_eq_one`), and `binomialCDF_tendsto_zero_atBot` (binomialCDF n p x → 0 as x → -∞, eventually-constant via `binomialCDF_neg`). Together with the Session-7 boundary lemmas, these complete the right-tail tendsto saturation on both sides of the Portmanteau convergence; the matching `standardNormalCDF_tendsto_zero_atBot` (left tail of Φ via `Antitone.tendsto_setIntegral`) is the next prerequisite. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` was proved in Phase-3: it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
       "multinomialMarginalCDF: marginal CDF of coordinate i₀ of Multinomial(n,p), defined directly from multinomialProb",
@@ -38,10 +38,13 @@
       "standardNormalCDF_le_one: standardNormalCDF x ≤ 1 — bounded above by the total integral, which equals 1 by integral_gaussianPDFReal_eq_one (Session 6)",
       "standardNormalCDF_mono: Monotone standardNormalCDF — Iic monotonicity + nonneg integrand via setIntegral_mono_set (Session 6)",
       "standardNormalCDF_eq_zero_plus_intervalIntegral (private, Session 7): bridge lemma — standardNormalCDF x = standardNormalCDF 0 + ∫ t in (0:ℝ)..x, gaussianPDFReal 0 1 t. Both ∫ Iic x and ∫ Iic 0 are limits of ∫ a..x and ∫ a..0 as a → atBot via MeasureTheory.intervalIntegral_tendsto_integral_Iic; for each a, ∫ a..x = ∫ a..0 + ∫ 0..x by intervalIntegral.integral_add_adjacent_intervals; uniqueness of limits (tendsto_nhds_unique) closes the equation",
-      "standardNormalCDF_continuous (Session 7): Continuous standardNormalCDF — rewrite as standardNormalCDF 0 + intervalIntegral 0..x then apply MeasureTheory.Integrable.continuous_primitive (NoAtoms volume on ℝ). Final input to the Phase-4 Portmanteau bridge: every x ∈ ℝ is a continuity point of Φ, so weak convergence implies pointwise CDF convergence universally"
+      "standardNormalCDF_continuous (Session 7): Continuous standardNormalCDF — rewrite as standardNormalCDF 0 + intervalIntegral 0..x then apply MeasureTheory.Integrable.continuous_primitive (NoAtoms volume on ℝ). Final input to the Phase-4 Portmanteau bridge: every x ∈ ℝ is a continuity point of Φ, so weak convergence implies pointwise CDF convergence universally",
+      "standardNormalCDF_tendsto_one_atTop (Session 8): Filter.Tendsto standardNormalCDF Filter.atTop (nhds 1) — `Iic` is an AECover for `volume` along `atTop` (`MeasureTheory.aecover_Iic Filter.tendsto_id`), so `AECover.integral_tendsto_of_countably_generated` gives ∫ Iic x, gauss → ∫ ℝ, gauss = 1 via `ProbabilityTheory.integral_gaussianPDFReal_eq_one`. Right-tail saturation prerequisite for Phase-4 Portmanteau bridge",
+      "binomialCDF_tendsto_one_atTop (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) under 0 ≤ p ≤ 1 — eventually-constant wrapper around `binomialCDF_eq_one` via `Filter.eventually_ge_atTop (n : ℝ)` and `Tendsto.congr'`. Companion to standardNormalCDF_tendsto_one_atTop on the binomial side",
+      "binomialCDF_tendsto_zero_atBot (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atBot (nhds 0) — eventually-constant wrapper around `binomialCDF_neg` via `Filter.eventually_lt_atBot (0 : ℝ)`. Left-tail saturation; no constraint on p needed since `binomialCDF_neg` holds for arbitrary p"
     ],
-    "theoremCount": 14,
-    "substantiveTheoremCount": 10,
+    "theoremCount": 17,
+    "substantiveTheoremCount": 13,
     "definitionCount": 3
   },
   "leanFile": {
@@ -62,10 +65,10 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 512,
+    "lineCount": 582,
     "axiomCount": 1,
-    "theoremCount": 14,
-    "substantiveTheoremCount": 10,
+    "theoremCount": 17,
+    "substantiveTheoremCount": 13,
     "duplicateTheorems": 0,
     "definitionCount": 3,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -20,8 +20,8 @@
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 582,
-    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The Session-2 `standardNormalCDF` opaque marker has been replaced (Session 6) by a concrete `noncomputable def` integrating Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`; this removes that declaration from the assumption count and adds four elementary structural lemmas (`standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono`, `standardNormalCDF_continuous` [Session 7]) that together establish Φ is a *bona fide* continuous CDF on ℝ — every point is a continuity point, so the Portmanteau bridge that next session will build to discharge the axiom applies universally. Session 8 (this session) adds three asymptotic-saturation lemmas — `standardNormalCDF_tendsto_one_atTop` (Φ(x) → 1 as x → +∞ via `MeasureTheory.aecover_Iic` + `AECover.integral_tendsto_of_countably_generated` + `integral_gaussianPDFReal_eq_one`), `binomialCDF_tendsto_one_atTop` (binomialCDF n p x → 1 as x → +∞, eventually-constant via `binomialCDF_eq_one`), and `binomialCDF_tendsto_zero_atBot` (binomialCDF n p x → 0 as x → -∞, eventually-constant via `binomialCDF_neg`). Together with the Session-7 boundary lemmas, these complete the right-tail tendsto saturation on both sides of the Portmanteau convergence; the matching `standardNormalCDF_tendsto_zero_atBot` (left tail of Φ via `Antitone.tendsto_setIntegral`) is the next prerequisite. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` was proved in Phase-3: it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
+    "lineCount": 550,
+    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The Session-2 `standardNormalCDF` opaque marker has been replaced (Session 6) by a concrete `noncomputable def` integrating Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`; this removes that declaration from the assumption count and adds four elementary structural lemmas (`standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono`, `standardNormalCDF_continuous` [Session 7]) that together establish Φ is a *bona fide* continuous CDF on ℝ — every point is a continuity point, so the Portmanteau bridge that next session will build to discharge the axiom applies universally. Session 8 (this session, complementary track) adds two asymptotic-saturation lemmas on the binomialCDF side — `binomialCDF_tendsto_one_atTop` (binomialCDF n p x → 1 as x → +∞, eventually-constant via `binomialCDF_eq_one`) and `binomialCDF_tendsto_zero_atBot` (binomialCDF n p x → 0 as x → -∞, eventually-constant via `binomialCDF_neg`). The matching standardNormalCDF tail-limit lemmas (Φ → 1 at +∞ and Φ → 0 at -∞) are added in the parallel S8 PR #17233; together the two PRs complete the right-tail tendsto saturation on both sides of the Portmanteau convergence. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` was proved in Phase-3: it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
       "multinomialMarginalCDF: marginal CDF of coordinate i₀ of Multinomial(n,p), defined directly from multinomialProb",
@@ -39,12 +39,11 @@
       "standardNormalCDF_mono: Monotone standardNormalCDF — Iic monotonicity + nonneg integrand via setIntegral_mono_set (Session 6)",
       "standardNormalCDF_eq_zero_plus_intervalIntegral (private, Session 7): bridge lemma — standardNormalCDF x = standardNormalCDF 0 + ∫ t in (0:ℝ)..x, gaussianPDFReal 0 1 t. Both ∫ Iic x and ∫ Iic 0 are limits of ∫ a..x and ∫ a..0 as a → atBot via MeasureTheory.intervalIntegral_tendsto_integral_Iic; for each a, ∫ a..x = ∫ a..0 + ∫ 0..x by intervalIntegral.integral_add_adjacent_intervals; uniqueness of limits (tendsto_nhds_unique) closes the equation",
       "standardNormalCDF_continuous (Session 7): Continuous standardNormalCDF — rewrite as standardNormalCDF 0 + intervalIntegral 0..x then apply MeasureTheory.Integrable.continuous_primitive (NoAtoms volume on ℝ). Final input to the Phase-4 Portmanteau bridge: every x ∈ ℝ is a continuity point of Φ, so weak convergence implies pointwise CDF convergence universally",
-      "standardNormalCDF_tendsto_one_atTop (Session 8): Filter.Tendsto standardNormalCDF Filter.atTop (nhds 1) — `Iic` is an AECover for `volume` along `atTop` (`MeasureTheory.aecover_Iic Filter.tendsto_id`), so `AECover.integral_tendsto_of_countably_generated` gives ∫ Iic x, gauss → ∫ ℝ, gauss = 1 via `ProbabilityTheory.integral_gaussianPDFReal_eq_one`. Right-tail saturation prerequisite for Phase-4 Portmanteau bridge",
-      "binomialCDF_tendsto_one_atTop (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) under 0 ≤ p ≤ 1 — eventually-constant wrapper around `binomialCDF_eq_one` via `Filter.eventually_ge_atTop (n : ℝ)` and `Tendsto.congr'`. Companion to standardNormalCDF_tendsto_one_atTop on the binomial side",
+      "binomialCDF_tendsto_one_atTop (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) under 0 ≤ p ≤ 1 — eventually-constant wrapper around `binomialCDF_eq_one` via `Filter.eventually_ge_atTop (n : ℝ)` and `Tendsto.congr'`. Binomial-side companion to the Φ tail-limit lemmas added in parallel S8 PR #17233",
       "binomialCDF_tendsto_zero_atBot (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atBot (nhds 0) — eventually-constant wrapper around `binomialCDF_neg` via `Filter.eventually_lt_atBot (0 : ℝ)`. Left-tail saturation; no constraint on p needed since `binomialCDF_neg` holds for arbitrary p"
     ],
-    "theoremCount": 17,
-    "substantiveTheoremCount": 13,
+    "theoremCount": 16,
+    "substantiveTheoremCount": 12,
     "definitionCount": 3
   },
   "leanFile": {
@@ -65,10 +64,10 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 582,
+    "lineCount": 550,
     "axiomCount": 1,
-    "theoremCount": 17,
-    "substantiveTheoremCount": 13,
+    "theoremCount": 16,
+    "substantiveTheoremCount": 12,
     "duplicateTheorems": 0,
     "definitionCount": 3,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",


### PR DESCRIPTION
## Summary

Session 8 of the binomial CLT (de Moivre–Laplace) formalization — **binomialCDF-side complement** to parallel PR #17233 by researcher-1 (which covers the Φ side). Together the two PRs complete the four-corner `Filter.Tendsto`-form CDF saturation needed by the Phase-4 Portmanteau bridge.

### Lemmas added (this PR)

| # | Name | Statement | Proof technique |
|---|------|-----------|-----------------|
| 1 | `binomialCDF_tendsto_one_atTop` (under `0 ≤ p ≤ 1`) | `Tendsto (binomialCDF n p) atTop (𝓝 1)` | Eventually-constant via `binomialCDF_eq_one` + `Tendsto.congr'` + `Filter.eventually_ge_atTop (n : ℝ)` |
| 2 | `binomialCDF_tendsto_zero_atBot` (no `p` constraint) | `Tendsto (binomialCDF n p) atBot (𝓝 0)` | Eventually-constant via `binomialCDF_neg` + `Tendsto.congr'` + `Filter.eventually_lt_atBot (0 : ℝ)` |

### Scope narrowing (rationale)

This PR's first commit also included `standardNormalCDF_tendsto_one_atTop` (Φ → 1 at +∞ via the same `MeasureTheory.aecover_Iic` + `AECover.integral_tendsto_of_countably_generated` + `integral_gaussianPDFReal_eq_one` pipeline). PR #17233 was opened 3 minutes earlier (15:42:29Z vs 15:45:23Z) with the same lemma under a slightly different name (`standardNormalCDF_tendsto_atTop`). To avoid a hot-file merge conflict, that lemma was dropped here in commit `35d60f2afb8`. PR #17233 is the canonical home for the Φ-side tail limits.

### Phase-4 critical-path status (combined view)

After both S8 PRs land:
- **Φ side** (#17233): `_tendsto_atBot` (→0) + `_tendsto_atTop` (→1) ✓
- **binomialCDF side** (this PR): `_tendsto_zero_atBot` + `_tendsto_one_atTop` ✓
- **Φ continuity** (S7, merged): `standardNormalCDF_continuous` ✓
- **binomial-side boundary-value lemmas** (S4–S7, merged): `binomialCDF_neg`, `_mono`, `_zero_le`, `_le_one`, `_zero`, `_eq_one` ✓

This is the complete structural-CDF prerequisite set for the Portmanteau bridge (S9–S10 next).

### Counts (this PR alone)

- `theoremCount`: 14 → **16**
- `substantiveTheoremCount`: 10 → **12**
- `lineCount`: 512 → **550**
- `axiomCount`: 1 (unchanged — `binomial_clt_pointwise` only)
- `sorries`: 0 (unchanged)

## Build verification

⚠️ **Docker build NOT run locally** — Session 8 conducted under the broken `proofs/.lake` self-symlink trap (forces fresh-clone Mathlib ≈30–45 min on every build attempt).

Both lemmas are 4-line eventually-constant wrappers over already-merged `binomialCDF_eq_one` (S5, #16992) and `binomialCDF_neg` (S4, #16951), using only `Tendsto.congr'`, `tendsto_const_nhds`, `Filter.eventually_ge_atTop`, and `Filter.eventually_lt_atBot` — all standard Mathlib idioms with no new imports. **CI is the ground truth for this PR.**

## Test plan

- [ ] CI green on `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
- [ ] No conflict with PR #17233 after rebase order
- [ ] `lineCount`, `theoremCount`, `substantiveTheoremCount` match new file
- [ ] `axiomCount` remains 1 (only `binomial_clt_pointwise`)
- [ ] No new sorries (still 0)

## Next sessions (after both S8 PRs merge)

- **S9 — Portmanteau bridge**: prove the abstract bridge "convergence in distribution + continuous limit CDF ⟹ pointwise CDF convergence" using Mathlib's portmanteau lemmas + `standardNormalCDF_continuous` + the new four-corner saturation set.
- **S10 — Bernoulli→Binomial measure bridge + axiom discharge**: pushforward of n i.i.d. Bernoulli(p) under sum equals `PMF.binomial(n,p)`; then assemble bridge + Mathlib `tendstoInDistribution_inv_sqrt_mul_sum` → discharge `binomial_clt_pointwise`. Promotes status `axiomatized` → `verified` (axiomCount 1 → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)