### PR TITLE
Enrich ballot-problem-oq-02-oq-02: fix crossRefs schema + add 2 cross-refs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -84,9 +84,19 @@
   },
   "crossReferences": [
     {
-      "id": "ballot-problem-oq-02",
-      "title": "Ballot Problem OQ-02",
-      "relationship": "The parent file that this proof eliminates an axiom from, providing the csInf-based characterization."
+      "proofId": "ballot-problem-oq-02",
+      "relationship": "parent",
+      "description": "Parent file (Continuous-Time Ballot Problem via Brownian Motion) that originally axiomatized the set equality {ω | τ(ω) ≤ T} = maxEvent. This entry eliminates that axiom by deriving the conditional biconditional fpt_le_iff_maxEvent under the natural nonemptiness hypothesis, exposing why the unconditional set equality is in fact false in Lean's setting (sInf ∅ = 0 makes paths that never hit level a vacuously satisfy τ ≤ T). The csInf-based proof here is the Mathlib-ready replacement."
+    },
+    {
+      "proofId": "intermediate-value-theorem",
+      "relationship": "uses-shared-tool",
+      "description": "The IVT section (lines 137–185) invokes the Intermediate Value Theorem to provide the nonemptiness witness for crossing paths (B(0,ω) < a ≤ B(T,ω) ⇒ ∃s ∈ (0,T], B(s,ω) ≥ a). Without IVT-derived nonemptiness, the csInf characterization would not apply to typical Brownian paths. This is the same IVT used in classical proofs of the reflection principle and the strong Markov property setup."
+    },
+    {
+      "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling open-question line in the ballot-problem family. Both entries instantiate the broader research program of eliminating axioms in continuous-time ballot/Brownian formalizations by extracting the precise topological hypotheses (closed hitting set, nonemptiness) needed for csInf and order-theoretic arguments to discharge the original assumptions."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

The single existing cross-reference used the wrong field names: `id` and `title` instead of `proofId` and `description` (per the `CrossReference` type in `src/types/proof.ts`). The renderer silently drops unknown fields, so the parent link to `ballot-problem-oq-02` wasn't rendering on the live site.

## Changes

- **Schema fix**: `id` → `proofId`; descriptive text moved from `relationship` into `description`; `relationship` set to short label `"parent"` matching gallery convention.
- **Added `intermediate-value-theorem` (uses-shared-tool)**: the IVT section (lines 137–185) invokes Mathlib's IVT to provide nonemptiness for crossing paths — same tool used in classical reflection-principle proofs.
- **Added `ballot-problem-oq-01-oq-02-oq-01-oq-02` (sibling)**: both entries instantiate the broader research program of eliminating axioms from continuous-time ballot/Brownian formalizations by extracting the topological hypotheses needed for csInf and order-theoretic arguments.

## Test plan

- [x] All three target directories exist
- [x] All three crossRefs have `proofId` (not legacy `id`)
- [x] JSON syntax valid (`json.load` round-trip)
- [x] Single-file diff (13 insertions, 3 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)