### PR TITLE
Enrich brouwer-fixed-point-oq-02-oq-01: fix index.ts source-empty bug

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/index.ts
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/index.ts
@@ -1,6 +1,7 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean?raw'
 
 const meta = metaJson as {
   id: string; title: string; slug: string; description: string
@@ -9,22 +10,19 @@ const meta = metaJson as {
   crossReferences?: CrossReference[]
 }
 
-const leanSource = () => import('../../../../proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean?raw')
-
-export const proof: Proof = {
+export const brouwerFixedPointOq02Oq01Proof: Proof = {
   id: meta.id, title: meta.title, slug: meta.slug,
   description: meta.description, meta: meta.meta,
-  sections: meta.sections, source: '',
+  sections: meta.sections ?? [], source: sourceRaw,
   overview: meta.overview, conclusion: meta.conclusion,
   crossReferences: meta.crossReferences,
 }
 
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const proofData: ProofData = { proof, annotations }
+export const brouwerFixedPointOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
-export async function getProofSource(): Promise<string> {
-  const module = await leanSource()
-  return module.default
+export const brouwerFixedPointOq02Oq01Data: ProofData = {
+  proof: brouwerFixedPointOq02Oq01Proof,
+  annotations: brouwerFixedPointOq02Oq01Annotations,
 }
 
-export default proofData
+export default brouwerFixedPointOq02Oq01Data


### PR DESCRIPTION
## Summary

The page renderer reads `proof.source` synchronously, but this entry shipped `source: ''` and a lazy `getProofSource()` async loader. The Lean source was effectively unavailable on the live site.

## Changes

- Replaced `source: ''` + lazy `getProofSource()` with the standard `import sourceRaw from '...?raw'` pattern used across the gallery.
- Renamed exports to slug-camelCased forms (`brouwerFixedPointOq02Oq01Data` etc.) matching the aggregator's `slugToExportName` lookup, getting the preferred named-export resolution path rather than relying on the `*Data`-suffix-fallback in `src/data/proofs/index.ts`.

## No content changes

The underlying meta.json is already well-structured: 5 sections with `startLine`/`endLine`/`summary`/`mathContext`, 6 annotations with all four optional fields, 5 keyInsights, 3 openQuestions, 2 cross-references using the valid `targetId` legacy alias. This PR is purely a UI plumbing fix.

## Test plan

- [x] index.ts populates `source` synchronously via `?raw` import
- [x] `default` export points to ProofData (matches `module.default` resolution)
- [x] Single-file diff (8 ins / 10 del)

🤖 Generated with [Claude Code](https://claude.com/claude-code)