### PR TITLE
Enrich schauder-fixed-point-oq-03: fix index.ts source-empty bug

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03/index.ts
+++ b/src/data/proofs/schauder-fixed-point-oq-03/index.ts
@@ -1,10 +1,28 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
-const leanSource = () => import('../../../../proofs/Proofs/SchauderFixedPointOQ03.lean?raw')
-export const proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: '', overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const proofData: ProofData = { proof, annotations }
-export async function getProofSource(): Promise<string> { const module = await leanSource(); return module.default }
-export default proofData
+import sourceRaw from '../../../../proofs/Proofs/SchauderFixedPointOQ03.lean?raw'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schauderFixedPointOq03Proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections ?? [], source: sourceRaw,
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schauderFixedPointOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schauderFixedPointOq03Data: ProofData = {
+  proof: schauderFixedPointOq03Proof,
+  annotations: schauderFixedPointOq03Annotations,
+}
+
+export default schauderFixedPointOq03Data


### PR DESCRIPTION
## Summary

Page renderer reads `proof.source` synchronously but this entry shipped `source: ''` plus a lazy `getProofSource()` async loader, so the Lean source for the Kakutani-fixed-point proof never reached the live site.

## Changes

- Replaced `source: ''` + lazy `getProofSource()` with `import sourceRaw from '...?raw'` (standard gallery pattern).
- Renamed exports to slug-camelCased forms (`schauderFixedPointOq03Data`) matching the aggregator's `slugToExportName`.

## No content changes

Underlying meta.json already well-structured: 7 sections with line ranges, 6 annotations, 5 keyInsights, 3 openQuestions, 3 cross-refs (`targetId` legacy alias is valid). Pure UI plumbing fix.

## Test plan

- [x] `source` populates synchronously via `?raw`
- [x] Single-file diff
- [x] Default export = ProofData

🤖 Generated with [Claude Code](https://claude.com/claude-code)