### PR TITLE
Enrich hilbert-22-oq-01: fix index.ts source-empty bug

### DIFF
--- a/src/data/proofs/hilbert-22-oq-01/index.ts
+++ b/src/data/proofs/hilbert-22-oq-01/index.ts
@@ -1,10 +1,28 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
-const leanSource = () => import('../../../../proofs/Proofs/Hilbert22OQ01.lean?raw')
-export const proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: '', overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const proofData: ProofData = { proof, annotations }
-export async function getProofSource(): Promise<string> { const module = await leanSource(); return module.default }
-export default proofData
+import sourceRaw from '../../../../proofs/Proofs/Hilbert22OQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert22Oq01Proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections ?? [], source: sourceRaw,
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert22Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert22Oq01Data: ProofData = {
+  proof: hilbert22Oq01Proof,
+  annotations: hilbert22Oq01Annotations,
+}
+
+export default hilbert22Oq01Data


### PR DESCRIPTION
## Summary

Page renderer reads `proof.source` synchronously, but this entry shipped `source: ''` and a lazy `getProofSource()` async loader. The Lean source for Hilbert's 22nd problem (Higher-Dimensional Uniformization) never reached the live site.

## Changes

- Switched to the standard `import sourceRaw from '...?raw'` pattern.
- Renamed exports to slug-camelCased forms (`hilbert22Oq01Data`).

Pure UI plumbing fix; no content changes.

## Test plan

- [x] `source` populates synchronously
- [x] Single-file diff
- [x] Default export = ProofData

🤖 Generated with [Claude Code](https://claude.com/claude-code)