### PR TITLE
Enrich Inseparable Galois Counterexample: fix stale line ranges + add 2 annotations

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -24,9 +24,33 @@
     "prerequisites": ["characteristic p fields", "Artin-Schreier theory", "inseparability (derivative = 0)", "fraction rings"]
   },
   {
+    "id": "ann-g-factor-scaffolding",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 132 },
+    "type": "technique",
+    "title": "g_factor Structural Scaffolding (Capelli-Style Inputs)",
+    "content": "Four short lemmas mirroring the f_target scaffolding, but for the Artin-Schreier inner factor g_factor = X² + X + aGen: g_factor_natDegree (=2 via compute_degree!), g_factor_degree (=2 in WithBot ℕ), g_factor_ne_zero (corollary of natDegree=2), and g_factor_monic (leading coefficient = 1). These structural facts about g are the standard inputs to a **Capelli-style irreducibility argument** for the composition f_target = g_factor.comp(X^2): one shows (i) g_factor is irreducible over F₂(a) via Artin-Schreier (a is not of the form t² + t), and (ii) the inner polynomial X² is 'totally inseparable' over F (specifically, a generator of g_factor.SplittingField is not a square in that field). Step (i) consumes g_factor_monic + g_factor_degree + an Artin-Schreier irreducibility lemma; step (ii) is what `counterexample_gal_card` currently axiomatizes. Discharging these structural prerequisites up front turns the file's single remaining axiom into a clean, single-statement assumption rather than a stack of unstated structural facts.",
+    "mathContext": "**Capelli's theorem** (the standard tool for irreducibility of composition $g(X^n)$): if $g \\in F[X]$ is irreducible with root $\\alpha$ in some extension, then $g(X^n) \\in F[X]$ is irreducible iff $X^n - \\alpha$ is irreducible over $F(\\alpha)$. Specialized to $n = 2$ over a characteristic-$\\ne 2$ field: $g(X^2)$ is irreducible iff $\\alpha$ is not a square in $F(\\alpha)$. In characteristic 2 the situation is more delicate (Frobenius takes squares to squares), but the same template applies: one needs $\\alpha \\notin F(\\alpha)^2$ in the appropriate sense. The g_factor structural lemmas are the prerequisite vocabulary that any future formalization of this argument must speak — `compute_degree!` discharges them in two tactic invocations, but Mathlib's irreducibility / SplittingField APIs require them as explicit hypotheses, not as derivable side facts.",
+    "significance": "supporting",
+    "relatedConcepts": ["Capelli's theorem", "irreducibility of composition", "Artin-Schreier polynomials", "compute_degree tactic", "Polynomial.Monic"],
+    "prerequisites": ["polynomial degree", "Polynomial.coeff", "compute_degree! tactic", "irreducibility of polynomial compositions"]
+  },
+  {
+    "id": "ann-coefficient-lemmas",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 157 },
+    "type": "technique",
+    "title": "f_target Coefficient Lemmas — Quadratic Factorisation Inputs",
+    "content": "Five short coefficient lemmas pinning down every nonzero entry of f_target = X⁴ + X² + aGen: coeff 0 = aGen, coeff 1 = 0, coeff 2 = 1, coeff 3 = 0, coeff 4 = 1. They look trivial — each is a one-line `simp` over the polynomial-coefficient API — but they are the *exact* inputs to a Mathlib-style quadratic-factorisation argument that would discharge `counterexample_gal_card`. The argument in the header docstring runs as follows: assume f_target = (X² + b₁X + c₁)(X² + b₂X + c₂); expanding and comparing coefficients gives a system in (b₁, b₂, c₁, c₂); the X³ coefficient = 0 yields b₁ + b₂ = 0 (in char 2: b₁ = b₂); the X¹ coefficient = 0 then yields b₁(c₂ + c₁) = 0; the X² coefficient = 1 and X⁰ coefficient = aGen close out the system, ultimately forcing c₁, c₂ to be roots of X² + X + aGen — which is irreducible over F₂(a) by Artin-Schreier. So the coefficient lemmas don't *prove* irreducibility, but they are the *only* hooks any irreducibility tactic can latch onto when confronted with f_target stated symbolically.",
+    "mathContext": "Coefficient comparison for $(X^2 + b_1 X + c_1)(X^2 + b_2 X + c_2) = X^4 + (b_1 + b_2)X^3 + (c_1 + c_2 + b_1 b_2) X^2 + (b_1 c_2 + b_2 c_1) X + c_1 c_2$.\n\nMatching against $f_{\\text{target}} = X^4 + 0 \\cdot X^3 + 1 \\cdot X^2 + 0 \\cdot X + a$:\n\n1. $b_1 + b_2 = 0 \\Rightarrow b_2 = -b_1 = b_1$ (char 2).\n2. $b_1 c_2 + b_2 c_1 = b_1(c_1 + c_2) = 0$ (using $b_1 = b_2$).\n3. **Case $b_1 = 0$**: $c_1 + c_2 = 1$ and $c_1 c_2 = a$, so $c_1, c_2$ are roots of $T^2 + T + a$ — irreducible over $\\mathbb{F}_2(a)$ (Artin-Schreier: $a$ is not of the form $t^2 + t$ for any $t \\in \\mathbb{F}_2(a)$, since $\\mathbb{F}_2(a)/\\mathbb{F}_2(a^2 + a) = \\mathbb{F}_2(a)$ has no Artin-Schreier solutions to $T^2 + T = a$ inside itself).\n4. **Case $b_1 \\ne 0$**: $c_1 + c_2 = 0$ from step 2, so $c_2 = c_1$; then $c_1 + c_2 + b_1 b_2 = 0 + b_1^2 = 1$, giving $b_1^2 = 1$ so $b_1 = 1$; and $c_1 c_2 = c_1^2 = a$, but $a$ is not a square in $\\mathbb{F}_2(a)$, contradiction.\n\nBoth cases fail, so f_target is irreducible.",
+    "significance": "supporting",
+    "relatedConcepts": ["coefficient comparison", "polynomial irreducibility over function fields", "Artin-Schreier theory", "quadratic factorisation in char 2", "Polynomial.coeff"],
+    "prerequisites": ["polynomial coefficient API", "Polynomial.coeff_add", "Polynomial.coeff_X_pow", "Polynomial.coeff_C", "Artin-Schreier irreducibility"]
+  },
+  {
     "id": "ann-frobenius-key-lemma",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 117, "endLine": 124 },
+    "range": { "startLine": 163, "endLine": 170 },
     "type": "technique",
     "title": "Char-p Frobenius: (σ(x)−x)^(p^n) = 0",
     "content": "The key technical lemma sub_pow_char_pow_eq: in a characteristic-p ring, (a − b)^(p^n) = a^(p^n) − b^(p^n). This is the additive Frobenius endomorphism: the map x ↦ x^p is a ring homomorphism in char p. The proof uses CharP.add_pow_char_pow repeatedly. This lemma is the algebraic engine of the purely-inseparable Galois triviality proof.",
@@ -38,7 +62,7 @@
   {
     "id": "ann-main-theorem",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 126, "endLine": 157 },
+    "range": { "startLine": 172, "endLine": 203 },
     "type": "technique",
     "title": "Purely Inseparable Extension → Trivial Galois Group",
     "content": "algEquiv_eq_refl_of_isPurelyInseparable: every F-algebra automorphism of a purely inseparable extension K/F is the identity. Proof: for any σ : K ≃ₐ[F] K and x ∈ K, get n with x^(p^n) ∈ F (IsPurelyInseparable.pow_mem). Then σ(x)^(p^n) = x^(p^n) (σ fixes F), so (σ(x)−x)^(p^n) = 0 (Frobenius lemma). Fields have no nonzero nilpotents, so σ(x) = x. Since x is arbitrary, σ = id.",
@@ -50,7 +74,7 @@
   {
     "id": "ann-gal-card-corollary",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 159, "endLine": 169 },
+    "range": { "startLine": 205, "endLine": 215 },
     "type": "insight",
     "title": "Corollary: |Gal(f)| = 1 for Purely Inseparable Splitting Field",
     "content": "gal_card_one_of_purelyInseparable_splitting: if f.SplittingField is a purely inseparable extension of F, then Nat.card f.Gal = 1. Follows from algEquiv_eq_refl_of_isPurelyInseparable: every element of Gal(f) is the identity, so |Gal(f)| = 1. The counterexample_gal_card axiom provides the concrete Gal cardinality for the char-2 counterexample (|Gal(f_target)| = 2), which is used to formally refute the original insep_gal_trivial claim.",
@@ -74,7 +98,7 @@
   {
     "id": "ann-formal-refutation",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 175, "endLine": 196 },
+    "range": { "startLine": 221, "endLine": 242 },
     "type": "insight",
     "title": "Formal Refutation: ∃ f, ¬Separable ∧ |Gal| ≠ 1",
     "content": "The block opens with the documented `counterexample_gal_card` axiom (|Gal(f_target)| = 2 — the only axiom in the file, intentional pending Artin-Schreier formalization). `insep_gal_trivial_refuted` then packages the entire counterexample chain into a single existential statement. The witness is f_target. The first conjunct (¬f_target.Separable) is discharged from f_derivative_zero (separable polynomials have nonzero derivative). The second conjunct (Nat.card f_target.Gal ≠ 1) is discharged from the counterexample_gal_card axiom. The Lean theorem is exactly the negation of the false axiom in the parent file, making the refutation machine-checkable.",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -94,25 +94,25 @@
       "id": "setup",
       "title": "Counterexample Framework",
       "startLine": 1,
-      "endLine": 167,
+      "endLine": 158,
       "summary": "Introduces the base field F₂(a) = FractionRing(F₂[X]). Defines f_target = X⁴+X²+a and g_factor = X²+X+a. Proves f = g ∘ (X²) structurally, f' = 0 in char 2 (inseparability), structural identities for both f_target and g_factor (natDegree, degree, ne_zero, Monic), and the five non-trivial coefficient values of f_target (coeffs 0, 1, 2, 3, 4) needed for downstream irreducibility / Galois-group arguments.",
       "mathContext": "F = F₂(a) = Frac(F₂[X]), g(X) = X²+X+a (Artin-Schreier: irred since a ≠ t²+t for t ∈ F₂(a)), f(X) = g(X²) = X⁴+X²+a. In char 2: f'(X) = 4X³+2X = 0. natDegree(f) = 4, leading coefficient = 1; coefficients of f at X^0, X^2, X^4 are aGen, 1, 1 (all others zero). natDegree(g) = 2, leading coefficient = 1."
     },
     {
       "id": "correct-theorem",
       "title": "The Correct Theorem: Purely Inseparable → Trivial Gal",
-      "startLine": 168,
-      "endLine": 252,
-      "summary": "Proves the correct replacement for insep_gal_trivial: algEquiv_eq_refl_of_isPurelyInseparable shows every automorphism of a purely inseparable extension is the identity. Derives gal_card_one_of_purelyInseparable_splitting as a corollary.",
+      "startLine": 159,
+      "endLine": 215,
+      "summary": "Proves the correct replacement for insep_gal_trivial: sub_pow_char_pow_eq supplies the char-p Frobenius identity (a-b)^(p^n) = a^(p^n) - b^(p^n) via the iterated-Frobenius ring hom; algEquiv_eq_refl_of_isPurelyInseparable shows every F-automorphism of a purely inseparable extension is the identity; gal_card_one_of_purelyInseparable_splitting is the headline corollary.",
       "mathContext": "Key: (σ(x)-x)^(p^n) = σ(x)^(p^n) - x^(p^n) = 0 by char-p Frobenius. Then σ(x) = x since field has no nilpotents."
     },
     {
-      "id": "when-purely-insep",
-      "title": "When Is the Splitting Field Purely Inseparable?",
-      "startLine": 253,
+      "id": "counterexample-and-refutation",
+      "title": "Counterexample, Axiom, and Formal Refutation",
+      "startLine": 217,
       "endLine": 285,
-      "summary": "States and axiomatizes that f_target has |Gal| = 2 (counterexample_gal_card, pending Artin-Schreier). Uses this to formally refute insep_gal_trivial in the parent.",
-      "mathContext": "X^p - a: splitting field = F(a^(1/p)), purely inseparable since (a^(1/p))^p = a ∈ F. But X⁴+X²+a: splitting field = F₂(a)(α^(1/2)), NOT purely inseparable — has nontrivial automorphism."
+      "summary": "Part III axiomatizes |Gal(f_target)| = 2 (counterexample_gal_card, the file's only axiom — pending an Artin-Schreier formalization over F₂(a)) and uses it to prove insep_gal_trivial_refuted: ∃ f, ¬f.Separable ∧ Nat.card f.Gal ≠ 1, which is precisely the negation of the parent file's false axiom. Part IV is a docstring summary table of every theorem and its status.",
+      "mathContext": "X^p - a: splitting field = F(a^(1/p)), purely inseparable since (a^(1/p))^p = a ∈ F. But X⁴+X²+a: splitting field = F₂(a)(α^(1/2)), NOT purely inseparable — has nontrivial automorphism σ : α^(1/2) ↦ α^(1/2) + 1 of order 2, witnessed by (α^(1/2)+1)² = α^(1/2)² + 1² = α + 1 = β (the second Artin-Schreier root) in characteristic 2."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01`

This is the entry that refutes the parent file's false `insep_gal_trivial` axiom and proves the correct purely-inseparable-splitting-field theorem. Quality 96, passes 0; this pass fixes a real **schema bug** (stale annotation line ranges) and adds two annotations covering recent Session-4 additions.

### The bug

Session 4 (per `originalContributions[6]`) added 9 new lemmas to the Lean file: 4 `g_factor_*` structural lemmas (lines 113-132) and 5 `f_target_coeff_*` coefficient lemmas (lines 134-157). All annotations whose ranges were below line 113 drifted by ~46 lines but were not updated. As a result, on the live site the wrong code is highlighted when a user clicks on these annotations:

| Annotation | Stale range | Actual subject | Fixed range |
|---|---|---|---|
| `ann-frobenius-key-lemma` | 117-124 | `sub_pow_char_pow_eq` | **163-170** |
| `ann-main-theorem` | 126-157 | `algEquiv_eq_refl_of_isPurelyInseparable` | **172-203** |
| `ann-gal-card-corollary` | 159-169 | `gal_card_one_of_purelyInseparable_splitting` | **205-215** |
| `ann-formal-refutation` | 175-196 | `counterexample_gal_card` axiom + `insep_gal_trivial_refuted` | **221-242** |

Three section ranges were similarly stale. Renamed `when-purely-insep` to `counterexample-and-refutation` since the section actually spans Parts III (counterexample axiom + refutation theorem) and IV (summary table), not just Part III. New section ranges: setup 1-158, correct-theorem 159-215, counterexample-and-refutation 217-285.

### New annotations

- **`ann-g-factor-scaffolding`** (lines 113-132). Documents the 4 g_factor structural lemmas (`natDegree`, `degree`, `ne_zero`, `Monic`) as Capelli-style irreducibility prerequisites. The annotation explains *why* these one-line tactic proofs matter: any future formalization of `f_target` irreducibility (which would discharge the file's only axiom `counterexample_gal_card`) consumes monic + degree-2 + nonzero on g_factor as inputs to a Capelli argument that splits into "α not a square in $F(\alpha)$" sub-cases.

- **`ann-coefficient-lemmas`** (lines 134-157). Documents the 5 f_target coefficient lemmas as the inputs to the quadratic-factorisation argument sketched in the header docstring. Spells out both factorisation cases:
  - $b_1 = 0$: forces $c_1, c_2$ to be roots of $T^2 + T + a$ — irreducible by Artin-Schreier;
  - $b_1 \ne 0$: forces $b_1 = 1$ and $c_1^2 = a$ — but $a$ is not a square in $\mathbb{F}_2(a)$.
  
  Both cases contradict, proving f_target is irreducible.

### Status & axiom integrity

- `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1` — unchanged. The entry's single axiom `counterexample_gal_card` (|Gal(f_target)| = 2 pending an Artin-Schreier formalization) is documented as intentional and the new `ann-coefficient-lemmas` annotation explains exactly which formalization step would discharge it.
- 0 sorries, 19 theorems, 4 definitions — unchanged.
- This PR is metadata-only; the Lean file is not modified.

### Build note

`pnpm build` currently fails on `tsc -b` due to a **pre-existing** TypeScript schema drift in `src/data/proofs/hilbert-10-oq-01-oq-02/index.ts` (the `mathlibDependencies` field type mismatch introduced by recent research PRs #17125 and #17219). The enrichment-build scripts run cleanly across the full gallery, and JSON for this entry validates. This PR does not touch that file.