### PR TITLE
research(e-transcendental-oq-02): S13 — discharge `normal_imp_irrational` axiom (count/Tendsto, build pending)

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -587,18 +587,100 @@ private theorem rational_has_missing_ktuple (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
   obtain ⟨s, hs⟩ := periodic_has_missing_ktuple b T T hb hT_pos hT_lt f N₀ hper_fin
   exact ⟨T, N₀, s, hT_pos, hs⟩
 
-/-- Normal numbers must be irrational.
-    Proof: if x = p/q is rational, its expansion has period T ≤ q (by rational_digits_eventually_periodic).
-    Choose k with bᵏ > T (exists since b ≥ 2). By periodic_has_missing_ktuple, some k-string s₀
-    never appears in the expansion after position N₀, so its count is bounded by N₀.
-    Hence count(s₀, N)/N → 0 as N → ∞. But normality requires count(s₀, N)/N → 1/bᵏ > 0.
-    Contradiction (the Tendsto codings need cast between Fin b and ℤ-valued nthDigit).
+/-- **Bridge (S13 prep)**: matching the missing-tuple bound to the
+    `IsNormalInBase` predicate. The ℤ-valued `nthDigit` and the
+    `Fin b`-valued `nthDigitFin` agree on equality with a constant `d : Fin b`. -/
+private lemma nthDigit_eq_iff_nthDigitFin (b : ℕ) (hb : 0 < b) (n : ℕ) (x : ℝ)
+    (d : Fin b) :
+    nthDigit b n x = (d : ℤ) ↔ nthDigitFin b hb n x = d := by
+  have h1 : ((nthDigitFin b hb n x : ℕ) : ℤ) = nthDigit b n x :=
+    nthDigitFin_intCast b hb n x
+  have hd : (d : ℤ) = ((d : ℕ) : ℤ) := by norm_cast
+  rw [hd]
+  constructor
+  · intro heq
+    apply Fin.ext
+    have hint : ((nthDigitFin b hb n x : ℕ) : ℤ) = ((d : ℕ) : ℤ) := h1.trans heq
+    exact_mod_cast hint
+  · intro heq
+    rw [← h1]
+    exact_mod_cast congrArg Fin.val heq
 
-    **Layer 4a (Session 12)** built the cast bridge and the missing-tuple
-    composite (`rational_has_missing_ktuple`). The remaining work for Session 13
-    is the count/Tendsto step. -/
-axiom normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
-    (hn : IsNormalInBase b x) : Irrational x
+/-- **Theorem (Session 13)**: Normal numbers must be irrational.
+
+    Proof outline (recipe owner: state.md S12):
+    1. Assume `x = (q : ℝ)` for some rational `q`.
+    2. Apply `rational_has_missing_ktuple` to get `(k, N₀, s)` such that
+       for `n ≥ N₀`, ∃ i, `nthDigitFin b _ (n+i) (q : ℝ) ≠ s i`.
+    3. Apply `IsNormalInBase` at this `(k, s)` to get
+       `count(N) / N → b^(-k)` where `count(N)` is the cardinality of
+       starting positions `n < N` with all `k` digits at offsets `0..k-1`
+       matching `s`.
+    4. By the missing-tuple property + `nthDigit_eq_iff_nthDigitFin`, every
+       matching position satisfies `n < N₀`, so `count(N) ≤ N₀`.
+    5. Hence `count(N)/N ≤ N₀/N → 0` (squeeze theorem).
+    6. By `tendsto_nhds_unique`, `b^(-k) = 0`. But `b ≥ 2` makes
+       `b^(-k) > 0` (`zpow_pos`). Contradiction. -/
+theorem normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) : Irrational x := by
+  intro hRat
+  obtain ⟨q, hq⟩ := hRat
+  -- hq : (q : ℝ) = x
+  have hbpos : 0 < b := by omega
+  -- Get the missing k-tuple data from Layer 4a
+  obtain ⟨k, N₀, s, _hk_pos, hmiss⟩ := rational_has_missing_ktuple b hb q
+  -- Apply `IsNormalInBase` at this `(k, s)`
+  have hcount : Tendsto
+      (fun N : ℕ =>
+        (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) /
+        (N : ℝ))
+      atTop (nhds ((b : ℝ) ^ (-(k : ℤ)))) := hn k s
+  -- Bound: count ≤ N₀ for every N
+  have hbound : ∀ N : ℕ, ((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card ≤ N₀ := by
+    intro N
+    have hsubset : (Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)) ⊆
+        Finset.range N₀ := by
+      intro n hn_mem
+      rw [Finset.mem_filter, Finset.mem_range] at hn_mem
+      rw [Finset.mem_range]
+      by_contra h_not_lt
+      push_neg at h_not_lt
+      obtain ⟨i, hi_neq⟩ := hmiss n h_not_lt
+      apply hi_neq
+      have h_nthDigit_eq : nthDigit b (n + i.val) (q : ℝ) = (s i : ℤ) := by
+        rw [← hq]; exact hn_mem.2 i
+      exact (nthDigit_eq_iff_nthDigitFin b hbpos (n + i.val) (q : ℝ) (s i)).mp
+        h_nthDigit_eq
+    calc ((Finset.range N).filter _).card
+        ≤ (Finset.range N₀).card := Finset.card_le_card hsubset
+      _ = N₀ := Finset.card_range N₀
+  -- count/N → 0 by squeeze (count/N ∈ [0, N₀/N], both bounds → 0)
+  have htozero : Tendsto
+      (fun N : ℕ =>
+        (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) /
+        (N : ℝ))
+      atTop (nhds 0) := by
+    have hzero : Tendsto (fun _ : ℕ => (0 : ℝ)) atTop (nhds 0) := tendsto_const_nhds
+    apply tendsto_of_tendsto_of_tendsto_of_le_of_le hzero
+      (tendsto_const_div_atTop_nhds_zero_nat (N₀ : ℝ))
+    · intro N
+      positivity
+    · intro N
+      rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+      · simp [hN0]
+      · have hNR : (0 : ℝ) < N := by exact_mod_cast hNpos
+        gcongr
+        exact_mod_cast hbound N
+  -- Contradiction: b^(-k) → 0 forces b^(-k) = 0, but b^(-k) > 0
+  have h_eq : ((b : ℝ) ^ (-(k : ℤ))) = 0 := tendsto_nhds_unique hcount htozero
+  have h_pos : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := by
+    apply zpow_pos
+    exact_mod_cast hbpos
+  linarith
 
 -- ============================================================
 -- PART V: OPEN QUESTION

--- a/research/problems/e-transcendental-oq-02/state.md
+++ b/research/problems/e-transcendental-oq-02/state.md
@@ -1,17 +1,48 @@
 # Current State
 
-**Phase**: ACT — Layer 4a (Fin b cast bridge) and `rational_has_missing_ktuple` complete
+**Phase**: ACT — `normal_imp_irrational` axiom DISCHARGED (Session 13)
 **Since**: 2026-05-04T16:38:18.044Z
-**Last Updated**: 2026-05-08 (Session 12, researcher-10)
-**Iteration**: 12
+**Last Updated**: 2026-05-08 (Session 13, researcher-6)
+**Iteration**: 13
 
 ## Current Focus
 
-Session 12 added **Layer 4a** — the `Fin b` cast bridge between the
-ℤ-valued `nthDigit` and `Fin b`-valued sequences accepted by
-`periodic_has_missing_ktuple` — and used it to prove a new private
-theorem `rational_has_missing_ktuple`. This is the structural input
-required by the count/Tendsto contradiction in `normal_imp_irrational`.
+**Session 13 (this session) discharges the `normal_imp_irrational` axiom.**
+Builds on Session 12's `rational_has_missing_ktuple` (Layer 4a) using
+the count/Tendsto recipe sketched in S12.
+
+Two new declarations (~90 lines):
+
+- `nthDigit_eq_iff_nthDigitFin` (private bridge lemma): connects the
+  ℤ-valued digit equality `nthDigit b n x = (d : ℤ)` (used in
+  `IsNormalInBase`) to the `Fin b`-valued equality `nthDigitFin b hb n x = d`
+  (used by `rational_has_missing_ktuple`). Both directions via
+  `nthDigitFin_intCast` + `Fin.ext`.
+
+- `normal_imp_irrational` (theorem, was axiom): assume `x = (q : ℝ)`
+  rational. Get `(k, N₀, s)` from `rational_has_missing_ktuple`. Apply
+  `IsNormalInBase` at `(k, s)` to get `count(N)/N → b^(-k)`. Bound
+  `count(N) ≤ N₀` by showing every match satisfies `n < N₀` (using the
+  bridge lemma to connect the predicate forms). Squeeze gives
+  `count(N)/N → 0` via `tendsto_const_div_atTop_nhds_zero_nat` and
+  `tendsto_of_tendsto_of_tendsto_of_le_of_le`. Then `tendsto_nhds_unique`
+  forces `b^(-k) = 0`, contradicting `zpow_pos` at `b ≥ 2`.
+
+After this PR, only **`e_absolutely_normal`** remains axiomatized — the
+genuinely-open conjecture (status: 2026 unknown).
+
+**Counts after S13**: lineCount 639 → 721, theoremCount 44 → 46
+(+1 private bridge, +1 main theorem), axiomCount 2 → 1, sorries 0
+(unchanged).
+
+**Build verification**: Docker build NOT run locally (`proofs/.lake`
+self-cycle symlink trap forces fresh Mathlib clone, ~30–45 min). All
+Mathlib lemma names verified against the existing codebase
+(`tendsto_of_tendsto_of_tendsto_of_le_of_le` in
+CentralLimitTheoremOQ02:218, `tendsto_const_div_atTop_nhds_zero_nat` in
+BinomialTheoremOQ03:367, `tendsto_nhds_unique` in
+LawsOfLargeNumbersOQ03Aristotle:59, `zpow_pos` in NavierStokes:6176).
+CI is the ground truth.
 
 ### New code (4 lemmas + 1 def + 1 theorem; ~95 lines)
 

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 44,
+    "theoremCount": 46,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -62,13 +62,14 @@
       "Theorem periodic_has_missing_ktuple: proved — T-periodic Fin-b sequences have missing k-tuples when bᵏ > T (orbit cardinality: image of range T has card ≤ T < bᵏ = |univ|; periodicity maps any n ≥ N₀ to orbit entry)",
       "Layer 4a (S12, private): nthDigitFin packages the [0, b) bound on nthDigit into Fin b, with cast lemma nthDigitFin_intCast bridging back to ℤ-valued nthDigit",
       "Theorem rational_has_missing_ktuple (S12, private): for any rational q : ℚ and base b ≥ 2, there exist k > 0 and N₀ and s : Fin k → Fin b such that no n ≥ N₀ produces tuple s in (q : ℝ)'s base-b expansion (composes Layer 3 with periodic_has_missing_ktuple via Layer 4a; uses k = T and Nat.lt_two_pow_self ≤ Nat.pow_le_pow_left for T < bᵏ)",
-      "Axiom normal_imp_irrational: normality in any base implies irrationality (count/Tendsto step pending — Layer 4a built the missing-tuple input in S12)",
+      "Lemma nthDigit_eq_iff_nthDigitFin (S13, private): bridges the ℤ-valued and Fin b-valued forms of digit equality; the IsNormalInBase predicate uses (s i : ℤ) while rational_has_missing_ktuple gives Fin b inequality",
+      "Theorem normal_imp_irrational (S13, was axiom): normality in any base implies irrationality — count/Tendsto contradiction. Given x = (q : ℝ) rational, get the missing k-tuple s from rational_has_missing_ktuple. The IsNormalInBase predicate at (k, s) gives count(N)/N → b^(-k). The missing-tuple property bounds count(N) ≤ N₀, so by squeeze count(N)/N → 0. Then tendsto_nhds_unique gives b^(-k) = 0, contradicting zpow_pos at b ≥ 2",
       "Axiom e_absolutely_normal: e is absolutely normal — the main open conjecture (2026)"
     ],
     "dateAdded": "2026-05-04",
-    "axiomCount": 2,
-    "lineCount": 639,
-    "assumptions": "2 axioms (Sessions 11–12 made structural progress on normal_imp_irrational): (1) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (the count/Tendsto step remains, but the missing-tuple input has been built); (2) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). The rational-digits-periodic axiom was discharged in Session 11 via the 3-layer recipe: Layer 1 (eventually_periodic_iterate, S8, orbit pigeonhole), Layer 2 (ratResidue_eventually_periodic, S9, residue sequence in ZMod q.den), Layer 3a (floor_pow_mul_div, S10, ℝ→ℤ cast bridge), Layer 3b (nthDigit_succ_via_residue, S11, integer-arithmetic residue-to-digit bridge). Session 12 added Layer 4a (the Fin b cast bridge): nthDigitFin packages nthDigit's [0, b) bound into Fin b, and rational_has_missing_ktuple composes Layers 1–3 with periodic_has_missing_ktuple to assert that for any rational q some k-tuple never appears in (q : ℝ)'s base-b expansion past a finite cutoff. 29 public theorems including first 9 decimal digits of e proved from exp_one bounds.",
+    "axiomCount": 1,
+    "lineCount": 721,
+    "assumptions": "1 axiom remaining (Session 13 discharged normal_imp_irrational): e_absolutely_normal — e is absolutely normal in every base b ≥ 2 (the main open conjecture, 2026). Sessions 8–13 progressively eliminated the structural axioms: rational-digits-periodic (S11) via the 3-layer recipe — Layer 1 (eventually_periodic_iterate, S8, orbit pigeonhole), Layer 2 (ratResidue_eventually_periodic, S9, residue sequence in ZMod q.den), Layer 3a (floor_pow_mul_div, S10, ℝ→ℤ cast bridge), Layer 3b (nthDigit_succ_via_residue, S11, integer-arithmetic residue-to-digit bridge); Layer 4a (S12) — nthDigitFin packages nthDigit's [0, b) bound into Fin b, and rational_has_missing_ktuple composes Layers 1–3 with periodic_has_missing_ktuple to assert that for any rational q some k-tuple never appears in (q : ℝ)'s base-b expansion past a finite cutoff; finally normal_imp_irrational (S13) via the count/Tendsto recipe — given the missing k-tuple s for x = (q : ℝ), the count of starting positions n < N with all k digits at offsets 0..k-1 matching s is bounded by N₀ (every match satisfies n < N₀ by the missing-tuple property), so count(N)/N → 0 by squeeze (count/N ∈ [0, N₀/N], both bounds → 0); but normality forces count(N)/N → b^(-k) > 0; tendsto_nhds_unique then gives 0 = b^(-k), contradicting zpow_pos. 29 public theorems including first 9 decimal digits of e proved from exp_one bounds.",
     "mathlib_version": "4.26.0",
     "definitionCount": 5
   },
@@ -171,9 +172,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 639,
-    "axiomCount": 2,
-    "theoremCount": 44,
+    "lineCount": 721,
+    "axiomCount": 1,
+    "theoremCount": 46,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Session 13 of the e-normal-number formalization. **Discharges the `normal_imp_irrational` axiom** — the second of two structural axioms that Sessions 8–12 progressively addressed.

After this PR, only `e_absolutely_normal` (the genuinely-open conjecture, 2026 unknown) remains axiomatized.

### Proof structure

Two new declarations (~90 lines):

#### `nthDigit_eq_iff_nthDigitFin` (private bridge lemma)

The `IsNormalInBase` predicate uses `nthDigit b n x = (s i : ℤ)` (ℤ-valued) while `rational_has_missing_ktuple` (S12) uses `nthDigitFin b _ n x = s i` (`Fin b`-valued). The bridge shows these are equivalent, via `nthDigitFin_intCast` chained with `Fin.ext` and `norm_cast` / `exact_mod_cast`.

#### `normal_imp_irrational` (theorem, was axiom)

The count/Tendsto contradiction recipe sketched in state.md S12:

| Step | Lemma | Output |
|------|-------|--------|
| 1 | (assume) | `x = (q : ℝ)` for some `q : ℚ` |
| 2 | `rational_has_missing_ktuple` (S12) | `(k, N₀, s)` with `∀ n ≥ N₀, ∃ i, nthDigitFin b _ (n+i) (q : ℝ) ≠ s i` |
| 3 | `hn k s` (`IsNormalInBase`) | `count(N)/N → b^(-k)` along `atTop` |
| 4 | bridge + missing-tuple | `count(N) ≤ N₀` (every match has `n < N₀`) |
| 5 | `tendsto_of_tendsto_of_tendsto_of_le_of_le` | `count(N)/N → 0` (squeeze: `0 ≤ count/N ≤ N₀/N`, both tend to 0) |
| 6 | `tendsto_nhds_unique` | `b^(-k) = 0`, contradicts `zpow_pos` at `b ≥ 2` |

Mathlib idioms used (all verified to exist in this codebase via grep):
- `tendsto_of_tendsto_of_tendsto_of_le_of_le` (CentralLimitTheoremOQ02.lean:218)
- `tendsto_const_div_atTop_nhds_zero_nat` (BinomialTheoremOQ03.lean:367)
- `tendsto_nhds_unique` (LawsOfLargeNumbersOQ03Aristotle.lean:59)
- `zpow_pos` (NavierStokes.lean:6176)
- Standard: `tendsto_const_nhds`, `Finset.card_le_card`, `Finset.card_range`, `gcongr`, `positivity`

### Sessions 8–13 progress arc

| Session | Layer | Outcome |
|---------|-------|---------|
| S3 | Recipe | 3-layer recipe drafted (#16976) |
| S8 | Layer 1 | `eventually_periodic_iterate` (orbit pigeonhole) (#16993) |
| S9 | Layer 2 | `ratResidue_eventually_periodic` (ZMod bridge) (#17016) |
| S10 | Layer 3a | `floor_pow_rat_eq_ediv` (ℝ→ℤ cast) (#17037) |
| S11 | Layer 3b | `rational_digits_eventually_periodic` (axiom → theorem) (#17084) |
| S12 | Layer 4a | `rational_has_missing_ktuple` (Fin b cast bridge) (#17126) |
| **S13** | **Discharge** | **`normal_imp_irrational` (axiom → theorem)** ⟵ this PR |

### Counts

- `lineCount`: 639 → **721**
- `theoremCount`: 44 → **46** (private bridge + main theorem)
- `axiomCount`: 2 → **1** (only `e_absolutely_normal` remains)
- `sorries`: 0 (unchanged)

## Build verification

⚠️ **Docker build NOT run locally** — `proofs/.lake` self-cycle symlink trap forces fresh-clone Mathlib (~30–45 min on every build attempt). All Mathlib lemma names verified via grep against the existing codebase. **CI is the ground truth.**

## Test plan

- [ ] CI green on `proofs/Proofs/ETranscendentalOQ02.lean`
- [ ] meta.json `lineCount`, `theoremCount` match new file
- [ ] `axiomCount` is 1 (only `e_absolutely_normal`)
- [ ] No new sorries (still 0)
- [ ] `e_irrational_necessary_for_normality` (downstream consumer) still compiles

## Next sessions

Only the open question remains — `e_absolutely_normal`. No structural work pending; the entry status remains `axiomatized` because the open conjecture (is e absolutely normal?) is genuinely open as of 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)