### PR TITLE
fix(meta): konigsberg-oq-01-oq-02 mirror additionalFiles into meta block

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -24,6 +24,9 @@
     "lineCount": 1202,
     "theoremCount": 26,
     "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/KonigsbergOQ01OQ02Recipe.lean"
+    ],
     "originalContributions": [
       "sum_outDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.1=v}| = |E| by double-counting via Finset.sum_comm + Finset.sum_ite_eq'",
       "sum_inDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.2=v}| = |E| by same double-counting argument",


### PR DESCRIPTION
## Fix

`konigsberg-oq-01-oq-02` declared `Proofs/KonigsbergOQ01OQ02Recipe.lean` in `leanFile.additionalFiles` but **not** in `meta.additionalFiles`. The auditor's `scripts/auditor/find-targets.ts` reads `meta.additionalFiles` to resolve cross-file dependencies (line 254: `const proofMeta = meta.meta || {}` → line 151: `proofMeta.additionalFiles`), so the Recipe file was invisible to integrity checks.

Recipe is a single-level non-`*Aristotle` sibling import, so the auditor's auto-follow rule does not catch it (only `*Aristotle` single-level siblings are followed automatically — see find-targets.ts lines 178–187).

## Evidence

**Before:**
- `meta.additionalFiles`: missing
- `leanFile.additionalFiles`: `["Proofs/KonigsbergOQ01OQ02Recipe.lean"]`

**After:**
- `meta.additionalFiles`: `["Proofs/KonigsbergOQ01OQ02Recipe.lean"]`
- `leanFile.additionalFiles`: unchanged

## Drift safety

Recipe.lean: 0 sorries, 0 axioms, 3 theorems (~187 lines). Adding it to the auditor's resolved-files set keeps the summed totals at `sorries=1, axiomCount=2`, matching existing meta claims.

Detected via cross-reference scan against memory note `feedback_mechanic_additionalfiles_schema_split` (auditor reads `meta.meta.additionalFiles`, not `meta.leanFile.additionalFiles`); 1 truly-blind entry found (this one) out of 143 with `lf`-only declarations — the rest are `*Aristotle` siblings auto-followed by the auditor.

---
Automated fix by lean-mechanic agent.