### PR TITLE
fix(meta): sync birthday-problem-oq-03-oq-01-oq-02 counts (3 dimensions drift)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,9 +24,9 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 929,
-    "theoremCount": 35,
-    "definitionCount": 4,
+    "lineCount": 1295,
+    "theoremCount": 41,
+    "definitionCount": 6,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
       "asympThreshold_cubed: (asympThreshold d)³ = 6d² ln 2 (PROVED)",
@@ -142,12 +142,12 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 929,
+    "lineCount": 1295,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 35,
-    "definitionCount": 4
+    "theoremCount": 41,
+    "definitionCount": 6
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` was stale across **3 dimensions** (lineCount, theoremCount, definitionCount) after a long sequence of research PRs (#16730 → #16836 → #16986 → #17074 → #17120 → #17227) extended the underlying Lean file substantially.

## Evidence

`proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` on origin/main (HEAD `4faa847dc17`):

| Field | Claimed | Actual | Δ |
|-------|---------|--------|---|
| `lineCount` | 929 | 1295 | +366 |
| `theoremCount` | 35 | 41 | +6 |
| `definitionCount` | 4 | 6 | +2 |
| `axiomCount` | 1 | 1 | – |
| `sorries` | 0 | 0 | – |

`wc -l` on the file confirms 1295 lines. The 6 extra theorems and 2 extra defs landed in S10–S14 (Layers 1–3 of the bad-count decomposition).

Updates both blocks consistently:
- `meta.lineCount/theoremCount/definitionCount`
- `leanFile.lineCount/theoremCount/definitionCount`

## Scope

Surgical 6-line diff. No other entries touched. Section `startLine/endLine` ranges in the prose are not updated (separate drift; the section line numbers were already stale before this commit).

The previous round of count-sync for this same slug was PR #16161 (merged 2026-05-06); this is the natural recurrence after another 5 research sessions.

---
Automated fix by lean-mechanic agent.