### PR TITLE
Enrich Hanson lcm bound: add chebyshev-bounds-oq-04 cross-reference

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -134,6 +134,11 @@
       "targetId": "erdos-1057",
       "relationship": "shares-technique",
       "description": "Erdős Problem #1057 (Carmichael number counting) uses an analogous Finset-induction packaging: `Erdos1057Problem.prod_primes_dvd_of_each_dvd` shows that pairwise-coprime prime divisors of `N` have their product dividing `N`. The helper here (`prod_dvd_of_pairwise_coprime`) generalizes that pattern over an arbitrary `f : ℕ → ℕ` so it can handle prime-power factors `p ↦ p^⌊log_p n⌋` rather than just `p ↦ p` — a small but essential abstraction step toward Chebyshev's exact decomposition."
+    },
+    {
+      "targetId": "chebyshev-bounds-oq-04",
+      "relationship": "supports",
+      "description": "Direct logarithmic reformulation: Hanson's bound `lcmRange n ≤ 3^n` (this entry's `axiom hanson_bound`) is equivalent to $\\psi(n) \\le n \\log 3$, where $\\psi(n) = \\log\\operatorname{lcm}(1, \\ldots, n)$ is Chebyshev's second function (the subject of `chebyshev-bounds-oq-04`). The two entries hold the same content in different units: Hanson's bound is the *exponential* form, $\\psi$-bounds are the *logarithmic* form. A future Mathlib refactoring would establish `lcmRange n = Nat.exp (psi n)` (where `psi` is the Lean version of $\\psi$), making each bound mechanically derivable from the other. Until then, the two entries develop the same machinery (prime-power decomposition, primorial-to-lcm bridge) along parallel tracks."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass for `basel-problem-oq-01-oq-01-oq-02-oq-03`

This entry bootstraps Hanson's 1972 bound `lcm(1,...,n) ≤ 3^n` as a Lean 4 research target. Quality 98, 12 deep annotations, very dense coverage. This pass is a single targeted addition — a missing cross-reference.

### The gap

The entry's `keyInsights` already notes:

> **Chebyshev-function reformulation**: Hanson's bound is equivalent to ψ(n) ≤ n · ln 3 for ψ(n) = log lcm(1,...,n).

But the `crossReferences` list does not point to `chebyshev-bounds-oq-04` — the canonical gallery home for Chebyshev's second function ψ(n) bounds. A reader looking for the logarithmic-form companion would not find the link.

### Change

Add a 6th `crossReference`:

- **`targetId: chebyshev-bounds-oq-04`**, `relationship: supports`.
- Describes the entries as the **exponential vs logarithmic forms of the same content**: Hanson's bound (this entry) is `lcmRange n ≤ 3^n`; ψ-bounds (chebyshev-bounds-oq-04) are `ψ(n) ≤ n · log 3`. They develop parallel machinery (prime-power decomposition, primorial-to-lcm bridge) along the two tracks.
- Notes the future Mathlib refactoring direction: an `lcmRange n = exp(psi n)` lemma would let each entry mechanically derive its bound from the other.

### Status & axiom integrity

`status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1` — unchanged. The single axiom `hanson_bound` (pending Beta-integral / Chebyshev infrastructure in Mathlib) is documented elsewhere in the entry. This PR is metadata-only.

### Build note

`pnpm build` currently fails on `tsc -b` due to a **pre-existing** TypeScript schema drift in `src/data/proofs/hilbert-10-oq-01-oq-02/index.ts`. The enrichment-build scripts run cleanly across the full gallery. This PR does not touch that file.