### PR TITLE
audit(erdos-1018-oq-04): fix stale 'isEmbeddable has sorry' narrative

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04.lean
+++ b/proofs/Proofs/Erdos1018OQ04.lean
@@ -312,7 +312,7 @@ axiom density_exceeds_turan (t r : ℕ) (hr : r ≥ 2) (ht : t > r) :
 
   Axiom count: 4 (vanKampen_Flores, triangle_planar, K4_planar,
   density_exceeds_turan).
-  Sorry count: 2 (isEmbeddable def, turanNumber def).
+  Sorry count: 1 (turanNumber def; isEmbeddable now concretely defined via convex-hull intersection).
 -/
 
 end Erdos1018OQ04

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -50,7 +50,7 @@
       "The critical dimension 2(r-1) is determined by general position: a generic (r-1)-simplex lives in R^{r-1}, and a generic (r-1)-dimensional simplicial complex embeds in R^{2(r-1)+1} but can obstruct embedding in R^{2(r-1)}",
       "The density threshold n^{r-1+ε} is the super-Turán regime: Turán numbers for r-uniform complete subhypergraphs are polynomially smaller than n^{r-1+ε} for large n, so dense hypergraphs force complete sub-hypergraphs as candidates for non-embeddable pieces",
       "The Hypergraph structure uses a Finset-of-Finsets model with a proof-valued uniformity field, allowing the uniformity constraint to be inherited automatically by sub-hypergraphs via the induced definition",
-      "The isEmbeddable definition has a sorry: formalizing it requires geometric realization of simplicial complexes in R^d as a topological space — infrastructure not yet in Mathlib, making the isNonEmbeddable and vanKampen_Flores axiom necessary",
+      "The isEmbeddable definition is concretely formalized via injective vertex maps with the convex-hull intersection condition, so non-embeddability is a concrete (not axiomatic) statement; the vanKampen_Flores axiom is needed because formalizing the deleted-product / Borsuk-Ulam proof is out of scope",
       "K₇^{(3)} has C(7,3) = 35 edges — proved by decide. The analogous K₅ has C(5,2) = 10 edges. The ratio 35/10 shows how much richer 3-uniform hypergraph theory is compared to graphs"
     ],
     "prerequisites": [


### PR DESCRIPTION
## Summary
Audit of erdos-1018-oq-04 found all integrity counts match (4 axioms, 1 sorry, 318 lines, 11 theorems, 11 defs, 0 True stubs; status `axiomatized`/`axiom` correct). Two LOW-severity stale narrative artifacts:

1. `proofs/Proofs/Erdos1018OQ04.lean` line 315 trailing comment said `Sorry count: 2 (isEmbeddable def, turanNumber def)` — but isEmbeddable was later concretely defined; only turanNumber remains a sorry.
2. `src/data/proofs/erdos-1018-oq-04/meta.json` `overview.keyInsights[4]` claimed "The isEmbeddable definition has a sorry: ..." — same stale narrative.

The `assumptions` field already correctly states `1 sorry: turanNumber definition (was 2: isEmbeddable now concretely defined via vertex-map + convex-hull intersection)`. This PR aligns the Lean source comment and the keyInsights bullet with that.

## Verification
- Lean line count unchanged (318 lines, only in-comment text edited).
- meta.json validates as JSON; only the one keyInsights string changed.
- All numeric/structural fields untouched.

## Test plan
- [x] Counts re-verified against `git show origin/main:` source.
- [x] JSON validity asserted.
- [x] Line count preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)