### PR TITLE
fix(meta): sync ehrhart-cube-proven-oq-02 counts (lineCount 423→539, theoremCount 16→19)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -6,8 +6,8 @@
   "leanFile": {
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
-    "lineCount": 423,
-    "theoremCount": 16,
+    "lineCount": 539,
+    "theoremCount": 19,
     "definitionCount": 2,
     "sorries": 1,
     "axiomCount": 0
@@ -31,7 +31,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 423,
+    "lineCount": 539,
     "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. Foundation helpers cweight_le_iff and cweight_translate added (Session 3) for the eventual fiber bijection. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
@@ -47,7 +47,7 @@
       "cweight_translate: bridge identity equating the centered weight at center n with the centered weight at center M (after translation), enabling the bijection between truncated lattice fibers and crossBall d M",
       "Concrete verifications: d=1 (2n+1), d=2 (2n\u00b2+2n+1), d=3 spot checks via native_decide"
     ],
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Fix

`src/data/proofs/ehrhart-cube-proven-oq-02/meta.json` is stale across two dimensions after research PRs (#16842, #17008, #17031, #17086, others) extended `proofs/Proofs/EhrhartCrossPolytope.lean`.

## Evidence

On origin/main (HEAD `4faa847dc17`):

| Field | Claimed | Actual | Δ |
|-------|---------|--------|---|
| `lineCount` | 423 | 539 | +116 |
| `theoremCount` | 16 | 19 | +3 |
| `definitionCount` | 2 | 2 | – |
| `axiomCount` | 0 | 0 | – |
| `sorries` | 1 | 1 | – |

`wc -l proofs/Proofs/EhrhartCrossPolytope.lean` → 539. The 3 extra lemmas (`cweight_translate`, `cweight_sum_individual`, `cweight_sum_range` plus other Session-4/5 additions) landed after the previous count-sync (PR #16865, which fixed 14→16 theorems).

Updates both blocks consistently:
- `leanFile.lineCount/theoremCount`
- `meta.lineCount/theoremCount`

## Scope

Surgical 4-line diff. No other entries touched. Section line ranges are not part of this fix.

This is the natural recurrence of drift after another 3 research sessions; previous count-sync was PR #16865 (merged 2026-05-08).

---
Automated fix by lean-mechanic agent.