### PR TITLE
research(e-transcendental-oq-02): S13 — discharge normal_imp_irrational axiom

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -587,18 +587,94 @@ private theorem rational_has_missing_ktuple (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
   obtain ⟨s, hs⟩ := periodic_has_missing_ktuple b T T hb hT_pos hT_lt f N₀ hper_fin
   exact ⟨T, N₀, s, hT_pos, hs⟩
 
-/-- Normal numbers must be irrational.
-    Proof: if x = p/q is rational, its expansion has period T ≤ q (by rational_digits_eventually_periodic).
-    Choose k with bᵏ > T (exists since b ≥ 2). By periodic_has_missing_ktuple, some k-string s₀
-    never appears in the expansion after position N₀, so its count is bounded by N₀.
-    Hence count(s₀, N)/N → 0 as N → ∞. But normality requires count(s₀, N)/N → 1/bᵏ > 0.
-    Contradiction (the Tendsto codings need cast between Fin b and ℤ-valued nthDigit).
+/-- **Layer 4b bridge (Session 13)**: rational missing-tuple lifted to the
+    ℤ-valued `nthDigit` form that appears literally inside `IsNormalInBase`. -/
+private theorem rational_has_missing_ktuple_intCast (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
+    ∃ (k N₀ : ℕ) (s : Fin k → Fin b),
+      0 < k ∧
+      ∀ n ≥ N₀, ∃ i : Fin k,
+        nthDigit b (n + i.val) (q : ℝ) ≠ (s i : ℤ) := by
+  obtain ⟨k, N₀, s, hk_pos, hs⟩ := rational_has_missing_ktuple b hb q
+  refine ⟨k, N₀, s, hk_pos, ?_⟩
+  intro n hn
+  obtain ⟨i, hi⟩ := hs n hn
+  refine ⟨i, ?_⟩
+  intro hcontra
+  apply hi
+  apply Fin.ext
+  have hbpos : 0 < b := by omega
+  have hcast := nthDigitFin_intCast b hbpos (n + i.val) (q : ℝ)
+  have : ((nthDigitFin b hbpos (n + i.val) (q : ℝ) : ℕ) : ℤ) = (s i : ℤ) := by
+    rw [hcast]; exact hcontra
+  exact_mod_cast this
 
-    **Layer 4a (Session 12)** built the cast bridge and the missing-tuple
-    composite (`rational_has_missing_ktuple`). The remaining work for Session 13
-    is the count/Tendsto step. -/
-axiom normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
-    (hn : IsNormalInBase b x) : Irrational x
+/-- **Count bound (Session 13)**: positions where the digit-tuple matches `s`
+    all lie below `N₀`, so the count over any `Finset.range N` is at most `N₀`. -/
+private lemma rational_match_count_le (b : ℕ) (q : ℚ) (k N₀ : ℕ) (s : Fin k → Fin b)
+    (h : ∀ n ≥ N₀, ∃ i : Fin k,
+        nthDigit b (n + i.val) (q : ℝ) ≠ (s i : ℤ))
+    (N : ℕ) :
+    ((Finset.range N).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) (q : ℝ) = (s i : ℤ))).card
+      ≤ N₀ := by
+  refine (Finset.card_le_card (s := _) (t := Finset.range N₀) ?_).trans
+    (Finset.card_range N₀).le
+  intro n hn
+  rw [Finset.mem_filter, Finset.mem_range] at hn
+  obtain ⟨_, hmatch⟩ := hn
+  rw [Finset.mem_range]
+  by_contra hN
+  push_neg at hN
+  obtain ⟨i, hi⟩ := h n hN
+  exact hi (hmatch i)
+
+/-- **Tendsto squeeze (Session 13)**: a sequence bounded above by `N₀` (in `ℕ`)
+    has frequency `count_N / N → 0` as `N → ∞`. -/
+private lemma tendsto_bounded_count_div_atTop_zero (N₀ : ℕ) (c : ℕ → ℕ)
+    (hc : ∀ N, c N ≤ N₀) :
+    Tendsto (fun N : ℕ => (c N : ℝ) / (N : ℝ)) atTop (nhds 0) := by
+  have h_inv : Tendsto (fun N : ℕ => (N : ℝ)⁻¹) atTop (nhds 0) :=
+    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+  have h_const_div : Tendsto (fun N : ℕ => (N₀ : ℝ) / (N : ℝ)) atTop (nhds 0) := by
+    have : Tendsto (fun N : ℕ => (N₀ : ℝ) * (N : ℝ)⁻¹) atTop (nhds ((N₀ : ℝ) * 0)) :=
+      h_inv.const_mul _
+    simpa [div_eq_mul_inv] using this
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h_const_div
+    (Filter.Eventually.of_forall fun N => ?_)
+    (Filter.Eventually.of_forall fun N => ?_)
+  · positivity
+  · rcases Nat.eq_zero_or_pos N with hN | hN
+    · simp [hN]
+    · have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+      have h_le : (c N : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast hc N
+      gcongr
+
+/-- **Normal numbers are irrational (Session 13).**
+    Proof: if `x = q : ℚ` is rational, the base-`b` expansion has a missing
+    `k`-tuple `s` after some `N₀` (`rational_has_missing_ktuple_intCast`). The
+    matching-position count is then bounded by `N₀`, so its frequency tends to
+    `0`. Normality forces the same frequency to tend to `b^(-k) > 0`, and the
+    uniqueness of limits derives `b^(-k) = 0`, the desired contradiction. -/
+theorem normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) : Irrational x := by
+  rintro ⟨q, hq⟩
+  subst hq
+  obtain ⟨k, N₀, s, hk_pos, hmiss⟩ := rational_has_missing_ktuple_intCast b hb q
+  have h_normal := hn k s
+  have h_count_le := rational_match_count_le b q k N₀ s hmiss
+  have h_zero :
+      Tendsto
+        (fun N : ℕ =>
+          (((Finset.range N).filter
+            (fun n => ∀ i : Fin k, nthDigit b (n + i.val) (q : ℝ) = (s i : ℤ))).card : ℝ)
+            / (N : ℝ))
+        atTop (nhds 0) :=
+    tendsto_bounded_count_div_atTop_zero N₀ _ h_count_le
+  have heq : (0 : ℝ) = (b : ℝ) ^ (-(k : ℤ)) :=
+    tendsto_nhds_unique h_zero h_normal
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hpos : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  linarith
 
 -- ============================================================
 -- PART V: OPEN QUESTION

--- a/research/problems/e-transcendental-oq-02/state.md
+++ b/research/problems/e-transcendental-oq-02/state.md
@@ -1,17 +1,31 @@
 # Current State
 
-**Phase**: ACT — Layer 4a (Fin b cast bridge) and `rational_has_missing_ktuple` complete
+**Phase**: ACT — `normal_imp_irrational` discharged (axiomCount 2 → 1)
 **Since**: 2026-05-04T16:38:18.044Z
-**Last Updated**: 2026-05-08 (Session 12, researcher-10)
-**Iteration**: 12
+**Last Updated**: 2026-05-08 (Session 13, researcher-11)
+**Iteration**: 13
 
 ## Current Focus
 
-Session 12 added **Layer 4a** — the `Fin b` cast bridge between the
-ℤ-valued `nthDigit` and `Fin b`-valued sequences accepted by
-`periodic_has_missing_ktuple` — and used it to prove a new private
-theorem `rational_has_missing_ktuple`. This is the structural input
-required by the count/Tendsto contradiction in `normal_imp_irrational`.
+**Session 13** discharged the `normal_imp_irrational` axiom by composing
+S12's `rational_has_missing_ktuple` with three new private lemmas:
+
+1. `rational_has_missing_ktuple_intCast` — bridges S12's `Fin b` form to
+   the ℤ-valued `nthDigit` form that appears literally inside `IsNormalInBase`.
+2. `rational_match_count_le` — for the missing-tuple data, the count of
+   matching positions in `Finset.range N` is at most `N₀` (positions `≥ N₀`
+   are excluded by the missing-tuple property; `Finset.card_le_card` ▷
+   `Finset.range N₀`).
+3. `tendsto_bounded_count_div_atTop_zero` — squeeze theorem: a non-negative
+   ℕ-sequence bounded above by `N₀` has `c_N / N → 0` (`N₀ / N = N₀ · N⁻¹
+   → N₀ · 0 = 0`; `tendsto_inv_atTop_zero` ∘ `tendsto_natCast_atTop_atTop`).
+
+Composing: the matching-position frequency tends to `0`, but `IsNormalInBase`
+forces it to tend to `b^(-k) > 0`. `tendsto_nhds_unique` gives `0 = b^(-k)`,
+which contradicts `zpow_pos`. Hence rational `x` cannot be normal.
+
+`normal_imp_irrational` is now a `theorem` rather than `axiom`. Only one axiom
+remains: **`e_absolutely_normal`** — the genuinely-open conjecture.
 
 ### New code (4 lemmas + 1 def + 1 theorem; ~95 lines)
 
@@ -88,60 +102,68 @@ The Lean entry now establishes:
   - L4a (S12): `nthDigit_nonneg`, `nthDigit_lt_base`, `nthDigitFin_intCast`,
     `nthDigitFin_eq_iff`, `rational_has_missing_ktuple`.
 
-**Two remaining axioms**:
-- `normal_imp_irrational` — Layer 4a built the missing-tuple structural input.
-  S13's task: count/Tendsto step. Recipe:
-  1. From `rational_has_missing_ktuple` extract k, N₀, s (data only depends on q).
-  2. Show `count(N) := |{n < N : ∀ i, nthDigit b (n+i) q = (s i : ℤ)}| ≤ max N₀ 0`
-     via `nthDigitFin_eq_iff` and the missing-tuple property.
-  3. Bound `(count(N) : ℝ) / N ≤ N₀ / N → 0`.
-  4. By normality, `count(N) / N → b^(-k) > 0` (since `b ≥ 2`).
-  5. Contradiction.
+**One remaining axiom**:
 - `e_absolutely_normal` — the **main open conjecture**. Genuinely open
   as of 2026; will remain axiomatized.
 
+S13 closed `normal_imp_irrational` per the recipe sketched in S12:
+  1. ✅ Extract k, N₀, s from `rational_has_missing_ktuple` and lift to ℤ-valued
+     form via `nthDigitFin_intCast` (`rational_has_missing_ktuple_intCast`).
+  2. ✅ `Finset.card_le_card` ▷ `Finset.range N₀` proves
+     `count(N) ≤ N₀` (`rational_match_count_le`).
+  3. ✅ Squeeze `0 ≤ count(N)/N ≤ N₀/N` with `N₀/N → 0`
+     (`tendsto_bounded_count_div_atTop_zero`).
+  4. ✅ By normality, `count(N)/N → b^(-k)`; uniqueness of limits gives
+     `0 = b^(-k)`, but `zpow_pos` says `b^(-k) > 0`. Contradiction.
+
 ## Blockers
 
-- **Local Lean build unreliable**: Worktree's `proofs/.lake` is a
-  self-cycle symlink — Docker build cold-clones Mathlib (~45 min).
-  Following S8/S9/S10/S11 convention, build verification is deferred to CI.
-  All Mathlib lemmas used are well-established and stable in v4.26.0.
+- **Build region wider drift**: `Proofs/eTranscendental.lean` (the importing
+  parent of this entry, used for `e_irrational`/`e_transcendental`) currently
+  fails to build at v4.26.0 because `IsFractionRing.isAlgebraic_iff` was
+  removed/renamed in mathlib upstream (9 call sites). This is a pre-existing
+  drift unrelated to S13 — fixing it is out of scope here. Local build
+  verification deferred per S8/S9/S10/S11/S12 convention. The S13 logic
+  itself uses only `tendsto_inv_atTop_zero`, `tendsto_natCast_atTop_atTop`,
+  `Tendsto.const_mul`, `Tendsto.comp`, `tendsto_of_tendsto_of_tendsto_of_le_of_le'`,
+  `tendsto_const_nhds`, `tendsto_nhds_unique`, `Filter.Eventually.of_forall`,
+  `Finset.card_le_card`, `Finset.card_range`, `Finset.mem_filter`,
+  `Finset.mem_range`, `Fin.ext`, `Nat.eq_zero_or_pos`, `zpow_pos`, and `gcongr`
+  — all well-established and verified present in mathlib v4.26.0.
 
 ## Next Action
 
-**ACT (Session 13)** — discharge `normal_imp_irrational` using the count/Tendsto
-recipe (steps 4–5 above). The structural input (missing k-tuple) is now
-provided by Layer 4a's `rational_has_missing_ktuple`.
+**ORIENT (Session 14)** — only the open conjecture `e_absolutely_normal`
+remains. No further axiom-discharge work is meaningful (this is the
+genuinely-open mathematical question, 2026). Future sessions could:
+- Add convergence-rate annotations to the existing digit theorems (e.g.
+  Bailey–Borwein–Plouffe-style bounds);
+- Hook up Borel's theorem (almost-all-normal) as a Lebesgue-density result;
+- Cross-reference irrationality measure (e-transcendental-oq-03).
 
-Sketch: for the rational case, define
-```lean
-let A : Finset ℕ := (Finset.range N).filter
-  (fun n => ∀ i : Fin k, nthDigit b (n + i.val) (q : ℝ) = (s i : ℤ))
-```
-and show `A ⊆ Finset.range N₀` via the missing-tuple guarantee for `n ≥ N₀`.
-Then `(A.card : ℝ) / N ≤ N₀ / N → 0`, but normality demands the limit is
-`b^(-k) > 0`. Contradiction; hence `x` is not rational.
-
-After Session 13, only `e_absolutely_normal` remains axiomatized — and
-that is the genuinely-open conjecture.
+Or simply mark the entry **"axiomatized — final"** and move on.
 
 ## Attempt Counts
 
-- Total attempts: 7 (Session 1 = entry built 2026-05-04; Session 2 =
+- Total attempts: 8 (Session 1 = entry built 2026-05-04; Session 2 =
   metadata reconciliation 2026-05-07; Session 3 = recipe (2026-05-08);
   Session 8 = Layer 1 (#16993, 2026-05-08); Session 9 = Layer 2
   (#17016, 2026-05-08); Session 10 = Layer 3a (#17037, 2026-05-08);
   Session 11 = Layer 3b + axiom discharge (#17084, 2026-05-08);
   Session 12 = Layer 4a Fin b cast bridge + rational_has_missing_ktuple
-  (this PR, 2026-05-08)).
-- Current approach attempts: 5 (Layers 1, 2, 3a, 3b, 4a all closed).
+  (#17126, 2026-05-08); Session 13 = Layer 4b normal_imp_irrational
+  discharge — 3 helper lemmas + theorem replacement (this PR, 2026-05-08)).
+- Current approach attempts: 6 (Layers 1, 2, 3a, 3b, 4a, 4b all closed).
 
 ## References
 
+- `proofs/Proofs/ETranscendentalOQ02.lean:590+` — `rational_has_missing_ktuple_intCast`,
+  `rational_match_count_le`, `tendsto_bounded_count_div_atTop_zero`,
+  `normal_imp_irrational` (Layer 4b, S13)
 - `proofs/Proofs/ETranscendentalOQ02.lean:495+` — `nthDigit_nonneg`,
   `nthDigit_lt_base`, `nthDigitFin`, `nthDigitFin_intCast`,
   `nthDigitFin_eq_iff` (Layer 4a, S12)
-- `proofs/Proofs/ETranscendentalOQ02.lean:573+` — `rational_has_missing_ktuple`
+- `proofs/Proofs/ETranscendentalOQ02.lean:568+` — `rational_has_missing_ktuple`
   (Layer 4a headline, S12)
 - `proofs/Proofs/ETranscendentalOQ02.lean:424` — `rational_digits_eventually_periodic`
   (theorem, S11)

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 44,
+    "theoremCount": 48,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -62,13 +62,16 @@
       "Theorem periodic_has_missing_ktuple: proved — T-periodic Fin-b sequences have missing k-tuples when bᵏ > T (orbit cardinality: image of range T has card ≤ T < bᵏ = |univ|; periodicity maps any n ≥ N₀ to orbit entry)",
       "Layer 4a (S12, private): nthDigitFin packages the [0, b) bound on nthDigit into Fin b, with cast lemma nthDigitFin_intCast bridging back to ℤ-valued nthDigit",
       "Theorem rational_has_missing_ktuple (S12, private): for any rational q : ℚ and base b ≥ 2, there exist k > 0 and N₀ and s : Fin k → Fin b such that no n ≥ N₀ produces tuple s in (q : ℝ)'s base-b expansion (composes Layer 3 with periodic_has_missing_ktuple via Layer 4a; uses k = T and Nat.lt_two_pow_self ≤ Nat.pow_le_pow_left for T < bᵏ)",
-      "Axiom normal_imp_irrational: normality in any base implies irrationality (count/Tendsto step pending — Layer 4a built the missing-tuple input in S12)",
-      "Axiom e_absolutely_normal: e is absolutely normal — the main open conjecture (2026)"
+      "Theorem rational_has_missing_ktuple_intCast (S13, private): the ℤ-valued lift of Layer 4a — the missing-tuple statement in the form that appears literally inside IsNormalInBase, via the nthDigitFin_intCast bridge",
+      "Lemma rational_match_count_le (S13, private): for the missing-tuple data, the count of n ∈ Finset.range N where the digit-tuple matches s is at most N₀ (positions ≥ N₀ are excluded by the missing-tuple property; Finset.card_le_card with Finset.range N₀)",
+      "Lemma tendsto_bounded_count_div_atTop_zero (S13, private): a non-negative ℕ-valued sequence bounded above by N₀ has c_N / N → 0 as N → ∞ (squeeze theorem with N₀/N = N₀ · N⁻¹ → N₀ · 0 = 0)",
+      "Theorem normal_imp_irrational (S13, was axiom): normality in any base b ≥ 2 implies irrationality — discharged by composing the three Layer-4b lemmas: missing-tuple ⇒ bounded count ⇒ frequency → 0 contradicts normality's frequency → b^(-k) > 0 (tendsto_nhds_unique + zpow_pos)",
+      "Axiom e_absolutely_normal: e is absolutely normal — the main open conjecture (2026, the only remaining axiom)"
     ],
     "dateAdded": "2026-05-04",
-    "axiomCount": 2,
-    "lineCount": 639,
-    "assumptions": "2 axioms (Sessions 11–12 made structural progress on normal_imp_irrational): (1) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (the count/Tendsto step remains, but the missing-tuple input has been built); (2) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). The rational-digits-periodic axiom was discharged in Session 11 via the 3-layer recipe: Layer 1 (eventually_periodic_iterate, S8, orbit pigeonhole), Layer 2 (ratResidue_eventually_periodic, S9, residue sequence in ZMod q.den), Layer 3a (floor_pow_mul_div, S10, ℝ→ℤ cast bridge), Layer 3b (nthDigit_succ_via_residue, S11, integer-arithmetic residue-to-digit bridge). Session 12 added Layer 4a (the Fin b cast bridge): nthDigitFin packages nthDigit's [0, b) bound into Fin b, and rational_has_missing_ktuple composes Layers 1–3 with periodic_has_missing_ktuple to assert that for any rational q some k-tuple never appears in (q : ℝ)'s base-b expansion past a finite cutoff. 29 public theorems including first 9 decimal digits of e proved from exp_one bounds.",
+    "axiomCount": 1,
+    "lineCount": 717,
+    "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 5
   },
@@ -171,9 +174,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 639,
-    "axiomCount": 2,
-    "theoremCount": 44,
+    "lineCount": 717,
+    "axiomCount": 1,
+    "theoremCount": 48,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Closes the **`normal_imp_irrational`** axiom in `e-transcendental-oq-02` by composing S12's `rational_has_missing_ktuple` (the Layer 4a missing-tuple structural input) with three new private lemmas that complete the count/Tendsto contradiction recipe.

After this PR, the entry has **1 axiom** (axiomCount 2→1) — only `e_absolutely_normal` remains, which is the genuinely-open conjecture (2026).

## What's new

| New lemma | Role |
|-----------|------|
| `rational_has_missing_ktuple_intCast` | Bridges S12's `Fin b` form to the ℤ-valued `nthDigit` form that appears literally inside `IsNormalInBase` (via existing `nthDigitFin_intCast`) |
| `rational_match_count_le` | For the missing-tuple data, the count of matching positions in `Finset.range N` is ≤ `N₀` (positions ≥ `N₀` are excluded; `Finset.card_le_card` ▷ `Finset.range N₀`) |
| `tendsto_bounded_count_div_atTop_zero` | Squeeze: a non-negative ℕ-sequence bounded above by `N₀` has `c_N / N → 0` (`N₀/N = N₀ · N⁻¹ → N₀ · 0 = 0`) |

The replaced theorem `normal_imp_irrational` (was `axiom`):

```lean
theorem normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
    (hn : IsNormalInBase b x) : Irrational x := by
  rintro ⟨q, hq⟩
  subst hq
  obtain ⟨k, N₀, s, hk_pos, hmiss⟩ := rational_has_missing_ktuple_intCast b hb q
  have h_normal := hn k s
  have h_count_le := rational_match_count_le b q k N₀ s hmiss
  have h_zero := tendsto_bounded_count_div_atTop_zero N₀ _ h_count_le
  have heq : (0 : ℝ) = (b : ℝ) ^ (-(k : ℤ)) :=
    tendsto_nhds_unique h_zero h_normal
  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
  have hpos : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
  linarith
```

Mathematical structure: matching-position frequency tends to `0` (squeeze) but normality forces it to tend to `b^(-k)`; `tendsto_nhds_unique` gives `0 = b^(-k)`, contradicting `zpow_pos`.

## Counts

- `axiomCount`: 2 → 1
- `theoremCount`: 44 → 48
- `lineCount`: 639 → 717
- `definitionCount`: 5 (unchanged)
- `sorries`: 0 (unchanged)

## Build status

**Not Docker-verified locally.** `Proofs/eTranscendental.lean` (the parent file imported for `e_irrational`/`e_transcendental`) fails to build at `mathlib v4.26.0` because `IsFractionRing.isAlgebraic_iff` was removed/renamed upstream (9 call sites in eTranscendental.lean). This is a **pre-existing drift unrelated to S13** — fixing it is out of scope here.

The S13 logic itself uses only well-established Mathlib lemmas verified present in `v4.26.0` via the declaration-data index:
`tendsto_inv_atTop_zero`, `tendsto_natCast_atTop_atTop`, `Tendsto.const_mul`, `Tendsto.comp`, `tendsto_of_tendsto_of_tendsto_of_le_of_le'`, `tendsto_const_nhds`, `tendsto_nhds_unique`, `Filter.Eventually.of_forall`, `Finset.card_le_card`, `Finset.card_range`, `Finset.mem_filter`, `Finset.mem_range`, `Fin.ext`, `Nat.eq_zero_or_pos`, `zpow_pos`, `gcongr`.

Local build verification deferred per S8/S9/S10/S11/S12 convention.

## Test plan

- [x] meta.json valid JSON
- [x] all new lemma names verified present in mathlib v4.26.0 declaration index
- [ ] Docker build — blocked by pre-existing eTranscendental drift (out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)