### PR TITLE
Enrich Binary GCD O(log²n) bit complexity: add 2 cross-references

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -123,6 +123,16 @@
       "targetId": "bezout-identity",
       "relationship": "ancestor",
       "description": "Root of the Bézout identity hub. Bézout's identity $\\gcd(a,b) = sa + tb$ underlies the practical role of GCD algorithms — once the gcd is computed, the coefficients $s, t$ can be extracted from the same recursion. Stein's algorithm computes the gcd; an extended-Bézout variant tracks $s, t$ at the cost of constant-factor overhead per step (the $O(\\log^2 n)$ bound here applies equally)."
+    },
+    {
+      "targetId": "binary-gcd-oq-02-oq-01",
+      "relationship": "supports",
+      "description": "**Direct relevance to this entry's openQuestion #1**: that question asks whether `stepBitOps_le` can be eliminated by defining a more explicit bit-level computation model. `binary-gcd-oq-02-oq-01` does exactly that: it expresses Stein's algorithm using hardware-level bit operations (`Nat.testBit 0` for parity, `Nat.shiftRight 1` for halving) and proves equivalence with `Nat.gcd`. A future enrichment of the present entry could replace the `stepBitOps`/`stepBitOps_le` axioms with a step-cost lemma stated in terms of those bit-level primitives, eliminating one of the two remaining axioms (modulo a still-needed model of comparison cost on `testBit` representations)."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "shares-technique",
+      "description": "Sibling formulation of Stein's algorithm in the gallery's separate `binary-gcd` hub. The two hubs (`bezout-identity-*` and `binary-gcd-*`) approach the same algorithm from complementary angles — the bezout-identity branch focuses on correctness and complexity for the specific Bézout-extension use case (computing $s, t$ as well as gcd); the binary-gcd branch focuses on bit-level operational equivalences with hardware primitives. The complexity bound proved here transfers to the binary-gcd branch verbatim, since the step count is a property of the abstract control flow, not the bit-level encoding."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass for `bezout-identity-oq-01-oq-01-oq-01`

This entry formalizes the $O(\log^2(\max(a,b)))$ bit-operation complexity bound for Stein's binary GCD. Quality 98, 7 deep annotations, very dense coverage. The `crossReferences` list had 3 entries (parent, HGCD sibling, Bézout-identity ancestor). This pass adds 2 high-value cross-references.

### Changes

**`crossReferences[binary-gcd-oq-02-oq-01]`** (relationship: `supports`)

The entry's `conclusion.openQuestions[0]` asks:

> Can `stepBitOps_le` be eliminated by defining a more explicit bit-level computation model in Lean 4? One path: implement `binaryGcd` as an operation on `Bool` lists (binary representations) and count bit-level steps directly.

`binary-gcd-oq-02-oq-01` does exactly this — it expresses Stein's algorithm using hardware bit primitives (`Nat.testBit 0` for parity, `Nat.shiftRight 1` for halving) and proves equivalence with `Nat.gcd`. The new cross-ref makes the open-question / in-progress-answer connection explicit and points the reader to the entry that would let `stepBitOps`/`stepBitOps_le` be replaced by step-cost lemmas stated in terms of those primitives.

**`crossReferences[binary-gcd]`** (relationship: `shares-technique`)

Documents that the gallery has two parallel hubs for Stein's algorithm (`bezout-identity-*` for correctness + complexity in the Bézout-extension use case; `binary-gcd-*` for bit-level operational equivalences) and that the complexity bound proved here transfers to the `binary-gcd` hub verbatim — the step count is a property of abstract control flow, not bit encoding.

### Status & axiom integrity

`status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` — unchanged. The two axioms (`stepBitOps`, `stepBitOps_le`) are intentional documented placeholders for the bit-RAM cost model. This PR is metadata-only.

### Build note

`pnpm build` currently fails on `tsc -b` due to a **pre-existing** TypeScript schema drift in `src/data/proofs/hilbert-10-oq-01-oq-02/index.ts`. The enrichment-build scripts run cleanly across the full gallery. This PR does not touch that file.