### PR TITLE
audit(tracker): descartes-rule-of-signs-oq-03 — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2453,9 +2453,9 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T18:49:46Z",
+      "lastAudited": "2026-05-08T16:11:38Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-04": {


### PR DESCRIPTION
## Audit result: CLEAN (3rd audit)

**Slug**: `descartes-rule-of-signs-oq-03`
**Status**: verified | **Badge**: mathlib

### Verified counts (against origin/main)
- `lineCount` 440 ✓
- `sorries` 0 ✓
- `axiomCount` 0 ✓
- `theoremCount` 29 ✓
- `definitionCount` 3 ✓
- No `True`-stub theorems
- No phantom axiom narrative

### Tier classification
Tier B (formalized using Mathlib theorem). Badge `mathlib` correctly attributes the heavy lifting to Mathlib's `signVariations` and `cauchyBound`. Description and originalContributions correctly scope the bridge work and cross-reference the Mathlib dependencies, so no delegation opacity.

### Diff
Two-line tracker bump for `descartes-rule-of-signs-oq-03` (auditCount 2→3, lastAudited 2026-04-24 → 2026-05-08). Built with plumbing on top of `origin/main` to avoid pulling in concurrent agent state.