### PR TITLE
Enrich SNF over PIDs (bezout-identity-oq-04-oq-01-oq-01): fix 2 schema bugs blocking site display

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/index.ts
@@ -1,4 +1,38 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ04OQ01OQ01.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bezoutIdentityOQ04OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOQ04OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOQ04OQ01OQ01Data: ProofData = {
+  proof: bezoutIdentityOQ04OQ01OQ01Proof,
+  annotations: bezoutIdentityOQ04OQ01OQ01Annotations,
+}
+
+export default bezoutIdentityOQ04OQ01OQ01Data

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -121,12 +121,19 @@
   },
   "crossReferences": [
     {
-      "id": "bezout-identity-oq-04-oq-01",
-      "relationship": "parent: Smith Normal Form theory over ℤ — this entry lifts to arbitrary PIDs"
+      "proofId": "bezout-identity-oq-04-oq-01",
+      "relationship": "parent",
+      "description": "Smith Normal Form theory over ℤ — this entry lifts to arbitrary PIDs by replacing the IsUnimodular (det = ±1) and Int.gcd primitives with IsUnimodularPID (IsUnit det) and GCDMonoid.gcd. The 1×2 invariant-factor argument is the same up to the case-split-vs-unit-cancellation switch (`unit.inv_val`)."
     },
     {
-      "id": "bezout-identity",
-      "relationship": "root: Bezout's identity — the foundational result formalized in the main entry"
+      "proofId": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "Root of the Bézout identity hub. The forward direction `ax + by = c → gcd(a,b) | c` proved here in `bezout_pid_forward` is the GCDMonoid generalization of the classical Bézout identity over ℤ; the backward direction (existence of $s, t$ with $sa + tb = \\gcd(a,b)$) follows over any PID from the principal-ideal property and is shown over ℤ here via Int.gcdA / Int.gcdB."
+    },
+    {
+      "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+      "relationship": "shares-technique",
+      "description": "Both entries demonstrate the same *abstract-vs-concrete* refactoring template under the bezout-identity hub. *This entry*: replace ±1 case split → `unit.inv_val` cancellation in any GCDMonoid, lifting Smith Normal Form from ℤ to arbitrary PIDs. *That entry* (Binary GCD O(log²n)): replace ad-hoc bit tracking → abstract Lyapunov measure $M(a,b) = \\log_2 a + \\log_2 b$, lifting the complexity argument from ℤ-specific bit manipulation to a strong-induction-on-measure framework. In each case the abstraction yields a strict generalization without enlarging the proof — a recurring pattern in the bezout-identity-oq-* tree."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass for `bezout-identity-oq-04-oq-01-oq-01`

This entry generalizes Smith Normal Form theory from ℤ to arbitrary PIDs. Quality 98 according to the tracker, but **two real schema bugs** were hiding most of the content on the live site. This PR fixes both.

### Bug 1 — Broken `index.ts`

The previous file was 4 lines:
```ts
import meta from "./meta.json";
import annotations from "./annotations.json";
export { meta, annotations };
```

This is not the gallery's standard template. It does not import the `?raw` Lean source, does not type-cast the JSON to the `Proof` / `Annotation` / `ProofData` types, and does not provide the slug-keyed structured exports (e.g., `bezoutIdentityOQ04OQ01OQ01Proof`) that Vite's `import.meta.glob` discovers. Without the standard template, the proof page shows "proof not found" / source code unavailable on the live site — an instance of the documented enricher trap [from MEMORY: "missing index.ts" schema bug].

**Fix**: rewrote `index.ts` to the standard template, importing `Proofs/BezoutIdentityOQ04OQ01OQ01.lean?raw` for the Lean source and exporting `bezoutIdentityOQ04OQ01OQ01Proof`, `bezoutIdentityOQ04OQ01OQ01Annotations`, `bezoutIdentityOQ04OQ01OQ01Data` (default).

### Bug 2 — Malformed `crossReferences`

The previous schema:
```json
{ "id": "bezout-identity-oq-04-oq-01",
  "relationship": "parent: Smith Normal Form theory over ℤ — this entry lifts to arbitrary PIDs" }
```

Two issues:
- **Wrong field name**: `id` is not a `CrossReference` field. The schema accepts `proofId` (preferred) or `targetId` (legacy alias).
- **Description stuffed into relationship**: `relationship` is meant to be a short tag (e.g., "parent", "sibling", "shares-technique"). The 70-character explanation was crammed into it instead of the optional `description` field.

Result: on the live site, the cross-reference would not resolve to the linked proof, and the rendered relationship label would be 70 characters of mixed metadata.

**Fix**: rewrote both crossRefs with proper `proofId` + `relationship` + `description` triplets, and added a third cross-reference to `bezout-identity-oq-01-oq-01-oq-01` documenting the recurring abstract-vs-concrete refactoring pattern across the bezout-identity-oq-* tree.

### Status & axiom integrity

`status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` — unchanged. The two axioms (`snf_pid_exists`, `snf_pid_solvability`) are intentional placeholders for the bridge to Mathlib's `Submodule.smithNormalForm`. This PR is metadata-only; the Lean file is not modified.

### Build note

`pnpm build` currently fails on `tsc -b` due to a **pre-existing** TypeScript schema drift in `src/data/proofs/hilbert-10-oq-01-oq-02/index.ts` (mathlibDependencies field). The enrichment-build scripts run cleanly across the full gallery, and JSON for this entry validates. This PR does not touch that file — but it *does* fix this entry's own broken `index.ts`, which previously would also have surfaced as a different `tsc` error if examined.