### PR TITLE
audit: mark cauchy-schwarz-oq-01-oq-04 clean (counts verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1675,9 +1675,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T18:50:09Z",
+      "lastAudited": "2026-05-08T16:18:14Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-02": {


### PR DESCRIPTION
## Summary

Re-verified `cauchy-schwarz-oq-01-oq-04` (Bessel's Inequality for Hilbert Spaces) against the Lean source in `proofs/Proofs/CauchySchwarzOQ01OQ04.lean`.

## Verification

| Field | meta.json | actual | match |
|-------|----------:|-------:|:-----:|
| lineCount | 198 | 198 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |

- **status: verified** ✓ (0 sorries, 0 axiom decls, 0 structure-encoded assumptions)
- **badge: mathlib** ✓ (Tier B — core results obtained via `Orthonormal.sum_inner_products_le`, `tsum_inner_products_le`, `inner_products_summable`, and the `HilbertBasis.repr` isometry; `originalContributions` correctly attribute these to Mathlib)
- **assumptions** field accurately states "None. All results proved directly from Mathlib's Orthonormal API and HilbertBasis isometry."

No integrity issues found. Bumps `auditCount` 2 → 3, refreshes `lastAudited`.

## Test plan

- [x] Tracker JSON parses (validated with `json.loads`)
- [x] Diff is minimal (only auditCount + lastAudited for this slug)
- [x] Lean source counts re-verified via comment-stripped regex on `git show origin/main`