### PR TITLE
audit: mark wilsons-theorem-oq-02 clean (counts verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13618,8 +13618,8 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-24T18:53:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-08T16:29:52Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-03": {


### PR DESCRIPTION
## Audit Summary

**Slug**: `wilsons-theorem-oq-02` (Gauss-Wilson Theorem)
**Result**: CLEAN — counts and claims match Lean source

### Verified counts (main file)
- `proofs/Proofs/WilsonsTheoremOQ02.lean`: 426 lines, 21 theorems, 8 defs, **0 sorries**, **0 axioms**

Matches meta.json exactly: `lineCount=426`, `theoremCount=21`, `definitionCount=8`, `sorries=0`, `axiomCount=0`.

### Companion files (also clean)
- `proofs/Proofs/WilsonsTheoremOQ02Ext.lean`: 539 lines, 22 theorems, 1 def, **0 sorries**, **0 axioms**
- `proofs/Proofs/GaussWilsonNonCyclic.lean`: 323 lines, **0 sorries**, **0 axioms**

Status `verified` / badge `original` is consistent with the full dependency chain (no axioms, no sorries anywhere reachable from this proof).

### Note (non-blocking)
The companion files (`WilsonsTheoremOQ02Ext`, `GaussWilsonNonCyclic`) are not declared in `meta.additionalFiles` / `leanFile.additionalFiles`. `find-targets` won't audit them automatically, so future drift in the companions could go unnoticed. Pattern is well-known and tracked by mechanic-batch PRs (#16518, #16669) — leaving as-is here.

### Tracker bump
- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-24 → 2026-05-08
- `result`: `clean`