### PR TITLE
Enrich bounded-prime-gaps-oq-01-oq-03: add OQ-03 dependency + OQ-04 related cross-refs

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -124,6 +124,16 @@
       "id": "bounded-prime-gaps-oq-01-oq-02",
       "relationship": "sibling",
       "description": "EH-conditional H ≤ 12 using the admissible 5-tuple {0,2,6,8,12}"
+    },
+    {
+      "id": "bounded-prime-gaps-oq-03",
+      "relationship": "dependency",
+      "description": "Provides the public engelsma50Tuple definition, its admissibility/cardinality/diameter lemmas, and the engelsma_lower_bound axiom — the entire mathematical content this file assembles into the OQ-01 framework"
+    },
+    {
+      "id": "bounded-prime-gaps-oq-04",
+      "relationship": "related",
+      "description": "Bombieri–Vinogradov formalizability assessment: the missing analytic input that bounds the unconditional Maynard–Tao approach to H ≤ 246, motivating why the 246 ceiling here is a methodological (not quantitative) limit"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for `bounded-prime-gaps-oq-01-oq-03`

This file (Engelsma 50-tuple, exact diameter 246) imports `Proofs.BoundedPrimeGapsOQ03` directly — the source of the `engelsma50Tuple` definition and the `engelsma_lower_bound` axiom this file's main results depend on — but the gallery `crossReferences` list omitted OQ-03.

### Changes

`src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json`:

- Added `bounded-prime-gaps-oq-03` as `dependency`: surfaces the direct upstream that provides the engelsma50Tuple and the lower-bound axiom.
- Added `bounded-prime-gaps-oq-04` (Bombieri–Vinogradov formalizability) as `related`: the analytic-input gap referenced (but not linked) in the existing `conclusion.implications` and `openQuestions`.

### What was preserved

No removals. `historicalContext`, `keyInsights` (5), `conclusion.openQuestions` (4), `sections` (4), and all 5 annotations are unchanged. Counts, badge, axiomCount unchanged (entry remains `axiomatized` with 1 axiom = `engelsma_lower_bound`).

### Why this is high impact

The reader landing on this entry now has a one-click path to (a) the Lean file that *defines* the tuple and proves its admissibility/diameter, and (b) the analytic conjecture (Bombieri–Vinogradov) whose absence ceilings the 50-tuple sieve at H ≤ 246 — both of which the prose already discusses but the gallery wasn't surfacing as navigable links.