### PR TITLE
research(schauder-oq03-oq01-incomplete-01): S6 — approx_selection_exists is FALSE as stated; counterexample + salvage outline

### DIFF
--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s6-axiom-counterexample.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s6-axiom-counterexample.md
@@ -1,0 +1,199 @@
+# S6 Analysis — `approx_selection_exists` is false as stated
+
+**Researcher**: researcher-6
+**Date**: 2026-05-08
+**Status**: Mathematical finding, no Lean changes (axiom remains pending revision)
+
+## Summary
+
+The S4-verified file `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` posits two axioms:
+1. `brouwer_fpt` — Brouwer's FPT for compact convex `S ⊆ EuclideanSpace ℝ (Fin n)`.
+2. `approx_selection_exists` — for an upper-hemicontinuous (UHC) `F : ↥S → 2^↥S` with
+   nonempty convex values and any `ε > 0`, there exists a continuous
+   `f : ↥S → ↥S` such that `IsApproxSelection F f ε` holds **pointwise**.
+
+The S4 next-action proposed proving axiom 2 from `Mathlib.Topology.PartitionOfUnity`
+("Cellina-style partition-of-unity averaging"). **This S6 analysis shows that
+the pointwise statement is FALSE under the listed hypotheses, so the proposed
+PartitionOfUnity proof cannot succeed.** The salvage path — weaken the axiom
+to its provable graph-form variant and re-thread `kakutani_from_brouwer`
+through that variant — is concrete but requires a non-trivial rewrite of the
+main reduction.
+
+This finding does not invalidate Kakutani's theorem (well-known) nor the
+S3+S4 work on `approx_fixedpoint_implies_fixedpoint` and the limit argument
+(which are independent of the axiom's exact form). It does invalidate the
+**proof strategy** chosen for `kakutani_from_brouwer` as currently stated.
+
+## The relevant definitions, verbatim from the file
+
+```lean
+def IsUpperHemicontinuous {X Y : Type*} [TopologicalSpace X]
+    [TopologicalSpace Y] (F : SetValuedMap X Y) : Prop :=
+  ∀ V : Set Y, IsOpen V → IsOpen {x | F x ⊆ V}
+
+def IsApproxSelection {X : Type*} [PseudoMetricSpace X]
+    (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
+  ∀ x, ∃ y ∈ F x, dist (f x) y < ε
+```
+
+`IsApproxSelection F f ε` requires that **at every point `x`**, the value
+`f(x)` is within `ε` of `F(x)`. This is the pointwise form, strictly stronger
+than the graph form `∀ x, ∃ x', dist(x, x') < ε ∧ ∃ y ∈ F(x'), dist(f(x), y) < ε`.
+
+## A counterexample in dimension 1
+
+Take `n = 1`, identifying `EuclideanSpace ℝ (Fin 1) ≅ ℝ` (isometric, the
+proof transfers verbatim through the homeomorphism).
+
+Set `S := [-1, 1] ⊆ ℝ` (compact convex, nonempty). Define `F : ↥S → 2^↥S` by
+
+| `t`            | `F(t)`     |
+| -------------- | ---------- |
+| `t = 0`        | `[0, 1]`   |
+| `t ∈ (0, 1]`   | `{0}`      |
+| `t ∈ [-1, 0)`  | `{1}`      |
+
+### `F` satisfies every hypothesis of `approx_selection_exists`
+
+1. **Nonempty values** (`hF_ne`): `[0,1]`, `{0}`, `{1}` are all nonempty. ✓
+2. **Convex values** (`hF_convex`, after `Subtype.val`-lift): each value is a
+   sub-interval of `[-1, 1] ⊆ ℝ` and intervals are convex. ✓
+3. **UHC** (`hF_uhc`): we check `∀ V open, {t : F(t) ⊆ V}` is open.
+   - If `V ⊇ [0, 1]`, then `F(0) = [0,1] ⊆ V`, `F(t>0) = {0} ⊆ [0,1] ⊆ V`,
+     `F(t<0) = {1} ⊆ [0,1] ⊆ V`. So `{t : F(t) ⊆ V} = [-1, 1]`, open.
+   - If `V ⊇ {0}` but `V ⊉ [0,1]` (so `V` misses some point of `(0,1]`),
+     then `F(0) ⊄ V`. `F(t>0) = {0} ⊆ V` ✓; `F(t<0) = {1} ⊆ V` iff `1 ∈ V`.
+     So `{t : F(t) ⊆ V}` is either `(0,1]` (if `1 ∉ V`) or `[-1,0) ∪ (0,1]`
+     (if `1 ∈ V`). Both are open in `[-1, 1]` (subspace topology — `(0,1]`
+     is `(0, 2) ∩ [-1, 1]`, `[-1, 0)` is `(-2, 0) ∩ [-1, 1]`).
+   - The remaining cases are symmetric or trivial (`V` misses `0`, etc.).
+   ✓ UHC holds.
+
+(The graph of `F` is also closed, so the counterexample also rules out the
+"closed graph + USC" strengthening.)
+
+### No continuous `f : ↥S → ↥S` is a pointwise `(1/3)`-approximate selection
+
+Suppose for contradiction such `f` exists with `ε = 1/3`.
+
+- At any `t ∈ (0, 1]`: `IsApproxSelection` requires `∃ y ∈ {0}, dist(f(t), y) < 1/3`,
+  i.e. `|f(t)| < 1/3`. So `f(t) ∈ (-1/3, 1/3)`.
+- At any `t ∈ [-1, 0)`: similarly `|f(t) - 1| < 1/3`, so `f(t) ∈ (2/3, 4/3) ∩ S = (2/3, 1]`.
+- At `t = 0`: `f(0)` within `1/3` of some point of `[0, 1]`, so `f(0) ∈ [-1/3, 4/3] ∩ S = [-1/3, 1]`.
+
+Continuity at `0`:
+- Right limit: `lim_{t→0⁺} f(t) = f(0)` and `f(t) ∈ (-1/3, 1/3)` for `t > 0`,
+  so `f(0) ∈ [-1/3, 1/3]`.
+- Left limit:  `lim_{t→0⁻} f(t) = f(0)` and `f(t) ∈ (2/3, 1]` for `t < 0`,
+  so `f(0) ∈ [2/3, 1]`.
+
+These two intervals are disjoint (`[-1/3, 1/3] ∩ [2/3, 1] = ∅`), so no such
+`f(0)` exists. ∎
+
+The same argument rules out any continuous pointwise `ε`-approximate selection
+for every `ε < 1/2`. So the existential in `approx_selection_exists` fails for
+this `F` at every sufficiently small `ε`.
+
+## Why the proposed PartitionOfUnity proof cannot work
+
+The S4-suggested proof outline (in the axiom's docstring) says:
+> 1. For each `x`, pick `y_x ∈ F(x)` and use UHC to get a neighborhood `U_x`
+>    where `F(U_x) ⊆ B(F(x), ε)` ...
+> 4. Define `f(x) = Σ φ_i(x) · y_{x_i}` ...
+> 6. By construction, `f(x)` is within `ε` of `F(x)`.
+
+Step 6 is the gap. UHC at `xᵢ` gives `F(U_i) ⊆ ε`-thickening of `F(xᵢ)`, i.e.
+`∀ x' ∈ U_i, ∀ z ∈ F(x'), dist(z, F(xᵢ)) < ε`. Reading the **other**
+direction — that `y_{x_i} ∈ F(x_i)` is close to some point of `F(x')` — is
+exactly *lower hemicontinuity*, not UHC. Without LHC, the chosen `y_{x_i}`
+need not be near `F(x')`, and the convex combination `f(x') = Σ φ_i(x') · y_{x_i}`
+need not be either. The counterexample makes this concrete: at `t = 0` and
+`F(0) = [0,1]`, the natural choice `y_0 ∈ [0,1]` is "fine" only at `t = 0`
+itself; the moment we step to `t > 0` the only point of `F(t) = {0}` is `0`,
+and any positive `y_0` becomes "far".
+
+This matches the literature: under USC + convex values one obtains only a
+**graph approximate selection** (Cellina–Browder), not a pointwise one.
+
+## What is actually provable, and how to repair `kakutani_from_brouwer`
+
+### The provable graph-form selection
+
+```lean
+def IsGraphApproxSelection {X : Type*} [PseudoMetricSpace X]
+    (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
+  ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
+```
+
+The Cellina–Browder theorem (Cellina 1969, Browder 1968; modern reference:
+Aubin–Frankowska *Set-Valued Analysis* §9.2) gives:
+
+> Let `X` be a paracompact metric space, `Y` a Banach space, `F : X → 2^Y`
+> USC with nonempty convex values. Then for every `ε > 0` there is a
+> continuous `f : X → Y` whose graph is in the `ε`-neighborhood of
+> `graph(F)`.
+
+A constructive PoU proof of this *does* go through (steps 1–5 above are
+correct; step 6 changes from "pointwise" to "graph", and the convex
+combination conclusion follows by averaging into the `ε`-fattened graph).
+
+### Re-threading `kakutani_from_brouwer`
+
+The current proof uses the pointwise form **at exactly one point**: the
+Brouwer fixed point `x₀ = f_ε(x₀)`, deduces `dist(x₀, F(x₀)) < ε`, and
+hands `(x₀, y, hy_dist)` triples to `approx_fixedpoint_implies_fixedpoint`.
+
+With a graph approximate selection, the analogous step gives:
+`x' ∈ S, y ∈ F(x')` with `dist(x₀, x') < ε` and `dist(f_ε(x₀), y) < ε`,
+hence `dist(x', y) < dist(x', x₀) + dist(x₀, f_ε(x₀)) + dist(f_ε(x₀), y) < 2ε`
+(using `f_ε(x₀) = x₀`). So the diagonal property
+`∀ ε > 0, ∃ x ∈ S, ∃ y ∈ F x, dist x y < ε` is recovered with `ε ↦ 2ε`,
+a harmless change. **The helper `approx_fixedpoint_implies_fixedpoint`
+itself is unaffected.**
+
+In short: the `kakutani_from_brouwer` reduction is rescuable with a roughly
+ten-line edit — replace the use of pointwise `IsApproxSelection` with the
+graph form, and supply one triangle-inequality step.
+
+## Recommended next steps (S7+)
+
+1. **Replace** `IsApproxSelection` with `IsGraphApproxSelection` in the file
+   (or keep both, marking the pointwise one explicitly as
+   "stronger than is provable from USC alone").
+2. **Restate** the axiom to assert the graph form. Update its docstring to
+   cite Cellina–Browder rather than the (incorrect) pointwise sketch.
+3. **Patch** `kakutani_from_brouwer` to chain `dist(x₀, x') + dist(x₀, y)`
+   into the diagonal-distance hypothesis fed to
+   `approx_fixedpoint_implies_fixedpoint` (with `2ε` substitution).
+4. **Then** attempt the PartitionOfUnity proof of the *graph* form, which
+   is the standard textbook proof and matches what Mathlib's PoU
+   infrastructure actually supports.
+5. (Optional, much later) — If a strengthened pointwise approximate
+   selection is desired, it requires LHC of `F`, which is a non-trivial
+   additional hypothesis. For Kakutani as used in game theory, the graph
+   form is what's available and what's needed.
+
+## Independent finding: Brouwer-FPT axiom is also stronger than Mathlib
+
+Mathlib proves Brouwer's FPT only for the closed unit ball
+(`Mathlib.Topology.MetricSpace.Brouwer`); the axiom `brouwer_fpt` extends
+this to arbitrary nonempty compact convex sets via a homeomorphism /
+retraction argument. That extension is folklore-level and provable in
+Mathlib (the standard trick: any compact convex set in `ℝⁿ` is a retract
+of a closed ball, and a retract of a fixed-point space has the FPP).
+This is not a counterexample, just a note that *both* axioms are pending
+formalization, and the Brouwer extension is the easier of the two.
+
+## Confidence
+
+- The counterexample is checked by hand twice; the disjoint-interval
+  conclusion is elementary.
+- The literature alignment (Cellina–Browder gives only the graph form
+  under USC) is consistent with Aubin–Cellina, Aubin–Frankowska, and
+  Repovš–Semenov.
+- The `kakutani_from_brouwer` salvage uses only triangle inequality
+  and is not subtle.
+
+No Lean build was attempted in this iteration; finding is purely
+mathematical and does not depend on Mathlib's current state.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,34 +1,57 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ACT (verified)
+**Phase**: ORIENT (axiom revision needed)
 **Path**: full
-**Since**: 2026-05-08T03:00:00Z
-**Iteration**: 4
+**Since**: 2026-05-08T15:30:00Z
+**Iteration**: 5
 
 ## Current Focus
-S3 build VERIFIED via Docker (S4, 2026-05-08). All 4 declarations type-check.
-0 sorries, 2 axioms (brouwer_fpt, approx_selection_exists), 349 lines.
-meta.json now sync'd: leanFile.imports list 5→7 (HausdorffDistance, Sequences).
+S6 (researcher-6, 2026-05-08): Mathematical analysis surfaces a critical
+issue with the chosen proof strategy. The axiom `approx_selection_exists`
+is **false as stated** under USC + convex values alone. A 1-D counterexample
+shows no continuous pointwise `(1/3)`-approximate selection exists for
+`F : [-1,1] → 2^[-1,1]` with `F(0)=[0,1]`, `F(t>0)={0}`, `F(t<0)={1}`.
+See `s6-axiom-counterexample.md` for the full analysis (verbatim
+definitions, USC verification, no-`f` proof via continuity-at-zero IVT,
+and the Cellina–Browder graph-form salvage).
 
 ## Active Approach
-Direct proof, now build-verified:
-- `seq_compact_of_compact` from `IsCompact.isSeqCompact` (axiom 3 → theorem)
-- `approx_fixedpoint_implies_fixedpoint` via choose + seq compact + squeeze +
-  by_contra + case split + union-of-balls UHC + triangle inequality
-- `kakutani_from_brouwer` via subtype-univ trick wired through helper
+Revise the axiom to the provable graph form (Cellina–Browder) and rethread
+`kakutani_from_brouwer` through it (≈10-line edit using triangle
+inequality, with the helper `approx_fixedpoint_implies_fixedpoint`
+unchanged). Only after that is the PartitionOfUnity proof of the
+*graph form* tractable.
 
 ## Attempt Count
 - Total attempts: 2
-- Approaches tried: S2 documentation; S3 full proof submission;
-  S4 build verification + meta sync; S5 PR flush off fresh main
+- Approaches tried:
+  - S2 documentation (researcher-3, #16731);
+  - S3 full proof submission (researcher-11, #16784);
+  - S4 build verification + meta sync (researcher-10);
+  - S5 PR flush off fresh main (researcher-?, content already on main);
+  - S6 axiom-strength counterexample analysis (researcher-6, this PR).
 
 ## Blockers
-None. Build verified offline; the only remaining axioms are mathematically
-intentional (Brouwer FPT for arbitrary compact convex S; approx_selection_exists
-for USC convex-valued maps).
+None at the math level — the path forward (graph-form axiom + 10-line
+`kakutani_from_brouwer` patch) is concrete. The PartitionOfUnity proof
+itself remains a separate, larger Mathlib-API task.
 
 ## Next Action
-Optional follow-up: prove `approx_selection_exists` from
-`Mathlib.Topology.PartitionOfUnity` — would leave only `brouwer_fpt` as an
-axiom (the canonical Mathlib gap for Brouwer on general compact convex S).
+S7: edit `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`:
+
+1. Add `IsGraphApproxSelection` definition (graph form, see analysis doc).
+2. Restate `approx_selection_exists` to use the graph form. Update
+   docstring to cite Cellina–Browder and remove the (incorrect) pointwise
+   step-6 sketch.
+3. Patch `kakutani_from_brouwer` to chain
+   `dist(x', y) ≤ dist(x', x₀) + dist(x₀, f_ε(x₀)) + dist(f_ε(x₀), y) < 2ε`
+   when feeding `approx_fixedpoint_implies_fixedpoint` (substitute ε ↦ 2ε
+   in the outer existential — harmless).
+4. Verify build via Docker (`./proofs/scripts/docker-build.sh
+   Proofs.SchauderFixedPointOQ03OQ01`).
+5. (Optional, S8+) Attempt the PartitionOfUnity proof of the graph form.
+
+A separate follow-up should also note that `brouwer_fpt`'s extension from
+Mathlib's unit-ball Brouwer to general compact convex `S` is provable
+via a retraction argument and is the easier of the two axioms.

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -28,20 +28,20 @@
     "goal": "Fill 2 sorries using Mathlib's partition of unity machinery"
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-08T03:00:00Z",
-    "iteration": 4,
-    "focus": "S3 build verified offline (S4). All 4 declarations type-check. 0 sorries, 2 axioms remain. Next reduction: prove approx_selection_exists via partition of unity.",
+    "phase": "ORIENT",
+    "since": "2026-05-08T15:30:00Z",
+    "iteration": 5,
+    "focus": "S6 (researcher-6): mathematical analysis surfaces that approx_selection_exists is FALSE as stated under USC + nonempty convex values. 1-D counterexample with F(0)=[0,1], F(t>0)={0}, F(t<0)={1} satisfies all hypotheses but admits no continuous pointwise (1/3)-approximate selection (continuity-at-zero forces f(0) into two disjoint intervals). The proposed PartitionOfUnity proof cannot succeed for the pointwise form; only the graph form (Cellina–Browder, Aubin–Frankowska §9.2) is provable from USC + convex values. Salvage: weaken the axiom to graph form and add a triangle-inequality step (≈10 lines) to kakutani_from_brouwer.",
     "blockers": [],
-    "nextAction": "Optional follow-up: prove approx_selection_exists axiom from Mathlib.Topology.PartitionOfUnity (would leave only brouwer_fpt as an axiom — a Mathlib gap for general compact convex S).",
+    "nextAction": "S7: edit the Lean file to (1) define IsGraphApproxSelection, (2) restate approx_selection_exists in graph form (cite Cellina–Browder), (3) patch kakutani_from_brouwer with triangle-inequality chain (ε ↦ 2ε in outer existential, helper unchanged), (4) Docker-verify build. Then S8+: attempt the PartitionOfUnity proof of the graph form.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "S4 (researcher-10, 2026-05-08): Build VERIFIED. Ran `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` (6GB cap, 38s lake build after Mathlib cache restore). All 4 declarations elaborated cleanly: brouwer_fpt, approx_selection_exists, approx_fixedpoint_implies_fixedpoint, kakutani_from_brouwer. No errors, no warnings. Confirms S3's restructuring is mathematically and syntactically sound: helper + main theorem proofs hold, Convex ℝ (Subtype.val '' F x) type fix is correct, seq_compact_of_compact theorem reduces to IsCompact.isSeqCompact. File counts confirmed: 0 sorries, 2 axioms (brouwer_fpt, approx_selection_exists), 349 lines, 3 theorems, 4 definitions. Also synced meta.json leanFile.imports list (5→7) to include S3-added Mathlib.Topology.MetricSpace.HausdorffDistance and Mathlib.Topology.Sequences.\n\nS3 (researcher-11, 2026-05-08): Major restructuring submitted, build verification pending. Changes: (1) Eliminated seq_compact_of_compact axiom — replaced with theorem proved from IsCompact.isSeqCompact (3 axioms → 2). (2) Wrote full proof of approx_fixedpoint_implies_fixedpoint using union-of-balls open neighborhood + UHC + sequential compactness. (3) Filled kakutani_from_brouwer body with the previously-commented skeleton. (4) FIXED a pre-existing compilation error: Convex ℝ (F x) was malformed because Set ↥S has no AddCommMonoid; rewrote as Convex ℝ (Subtype.val '' F x) (lifted to ambient EuclideanSpace). The merged S2 commit (#16731) was docstring-only and never actually compiled. (5) Build attempt OOM'd during Mathlib clone+build under heavy multi-agent contention (8+ concurrent docker builds). File counts: 0 sorries, 2 axioms, 349 lines, 3 theorems, 4 definitions.",
+    "progressSummary": "S6 (researcher-6, 2026-05-08): KEY FINDING — the axiom approx_selection_exists is false as stated under USC + nonempty convex values. Counterexample (n=1): S = [-1, 1], F(0) = [0, 1], F(t) = {0} for t in (0, 1], F(t) = {1} for t in [-1, 0). Verified that F satisfies all four axiom hypotheses (nonempty, convex values via Subtype.val image, UHC by case-checking on V open). Verified that no continuous f : S → S can be a pointwise (1/3)-approximate selection: at t > 0 forces f(t) in (-1/3, 1/3); at t < 0 forces f(t) in (2/3, 1]; continuity at 0 forces f(0) into both [-1/3, 1/3] and [2/3, 1], which are disjoint. Same argument works for any ε < 1/2. Implication: the proposed S5/S4 next-step (prove approx_selection_exists via Mathlib.Topology.PartitionOfUnity) cannot succeed — under USC + convex values one obtains only a GRAPH approximate selection (Cellina–Browder, Aubin–Frankowska §9.2; Repovš–Semenov), not a pointwise one. The pointwise form requires lower hemicontinuity (LHC), which is a strictly stronger hypothesis. Salvage: replace IsApproxSelection with IsGraphApproxSelection in the axiom and chain a triangle-inequality step (~10 lines) into kakutani_from_brouwer (the helper approx_fixedpoint_implies_fixedpoint is unaffected). Full analysis with verbatim definitions, USC-verification by case split on V, no-f proof, and salvage outline written to research/problems/.../s6-axiom-counterexample.md (no Lean changes — axiom remains until S7 redefines it). Independent observation: brouwer_fpt's extension from Mathlib's unit-ball Brouwer to general compact convex S is provable via a retraction argument (every compact convex set in R^n is a retract of a closed ball; retracts inherit FPP) — easier of the two axioms.\n\nS4 (researcher-10, 2026-05-08): Build VERIFIED. Ran `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` (6GB cap, 38s lake build after Mathlib cache restore). All 4 declarations elaborated cleanly: brouwer_fpt, approx_selection_exists, approx_fixedpoint_implies_fixedpoint, kakutani_from_brouwer. No errors, no warnings. Confirms S3's restructuring is mathematically and syntactically sound: helper + main theorem proofs hold, Convex ℝ (Subtype.val '' F x) type fix is correct, seq_compact_of_compact theorem reduces to IsCompact.isSeqCompact. File counts confirmed: 0 sorries, 2 axioms (brouwer_fpt, approx_selection_exists), 349 lines, 3 theorems, 4 definitions. Also synced meta.json leanFile.imports list (5→7) to include S3-added Mathlib.Topology.MetricSpace.HausdorffDistance and Mathlib.Topology.Sequences.\n\nS3 (researcher-11, 2026-05-08): Major restructuring submitted, build verification pending. Changes: (1) Eliminated seq_compact_of_compact axiom — replaced with theorem proved from IsCompact.isSeqCompact (3 axioms → 2). (2) Wrote full proof of approx_fixedpoint_implies_fixedpoint using union-of-balls open neighborhood + UHC + sequential compactness. (3) Filled kakutani_from_brouwer body with the previously-commented skeleton. (4) FIXED a pre-existing compilation error: Convex ℝ (F x) was malformed because Set ↥S has no AddCommMonoid; rewrote as Convex ℝ (Subtype.val '' F x) (lifted to ambient EuclideanSpace). The merged S2 commit (#16731) was docstring-only and never actually compiled. (5) Build attempt OOM'd during Mathlib clone+build under heavy multi-agent contention (8+ concurrent docker builds). File counts: 0 sorries, 2 axioms, 349 lines, 3 theorems, 4 definitions.",
     "builtItems": [
       "Detailed 4-step proof outline for approx_fixedpoint_implies_fixedpoint (committed as docstring) — covers sequence construction, subsequence extraction, limit transfer, and UHC-contradiction with empty/nonempty case split.",
       "Commented-out reduction skeleton for kakutani_from_brouwer (committed in tactic block) — exact 10-line proof body once the helper is moved up.",
@@ -53,6 +53,10 @@
       "Added imports: Mathlib.Topology.MetricSpace.HausdorffDistance (for Metric.infDist family), Mathlib.Topology.Sequences (for IsCompact.isSeqCompact)."
     ],
     "insights": [
+      "S6 KEY FINDING: approx_selection_exists is FALSE as stated under USC + nonempty convex values. Counterexample (n=1): F : [-1,1] → 2^[-1,1] with F(0)=[0,1], F(t>0)={0}, F(t<0)={1} satisfies every axiom hypothesis but admits no continuous pointwise ε-approximate selection for ε < 1/2 (continuity at 0 forces disjoint intervals).",
+      "S6 SALVAGE: replace IsApproxSelection with the GRAPH form (Cellina–Browder); patch kakutani_from_brouwer with triangle-inequality chain dist(x', y) ≤ dist(x', x₀) + dist(x₀, f(x₀)) + dist(f(x₀), y) < 2ε (substitute ε ↦ 2ε in outer existential). Helper approx_fixedpoint_implies_fixedpoint is unaffected. ≈10-line edit.",
+      "S6 LITERATURE: under USC + convex values one gets only GRAPH approximate selection (Cellina 1969, Browder 1968; Aubin–Frankowska Set-Valued Analysis §9.2; Repovš–Semenov). Pointwise approximate selection requires LHC, which is strictly stronger. The S4-suggested PartitionOfUnity proof step '6. By construction, f(x) is within ε of F(x)' is exactly where USC fails — UHC gives F(U) ⊆ ε-fattening of F(x), which is the WRONG direction for the chosen y_x to be near F(x').",
+      "S6 OBSERVATION: brouwer_fpt's extension from Mathlib's unit-ball Brouwer to general compact convex S in R^n is folklore-provable via a retraction argument (compact convex set in R^n is a retract of a closed ball; retracts inherit fixed-point property). Easier of the two axioms once S7+ lands the graph form.",
       "approx_selection_exists is an AXIOM, not a sorry — the file's 2 sorries are kakutani_from_brouwer and approx_fixedpoint_implies_fixedpoint. The original problemStatement framing is misleading.",
       "kakutani_from_brouwer reduces in ~10 lines to approx_fixedpoint_implies_fixedpoint after pulling the helper above the main theorem (Lean 4 disallows forward references). Closing the helper closes BOTH sorries.",
       "The reduction in kakutani_from_brouwer: for each ε, get continuous f_ε via approx_selection_exists, get fixed point x_0 = f_ε(x_0) via brouwer_fpt, extract y ∈ F(x_0) with dist(f_ε(x_0), y) < ε, conclude dist(x_0, y) < ε. Hand the family of ε-witnesses to the helper.",
@@ -72,10 +76,12 @@
       "Mathlib.Topology.PartitionOfUnity has partition of unity constructions (only relevant if proving approx_selection_exists; not needed for the two current sorries)"
     ],
     "nextSteps": [
-      "(1) Re-run Docker build when memory contention is lower (current: 8+ concurrent builds OOM'd at 510s). Verify all proofs compile.",
-      "(2) If proof bugs surface, fix and resubmit. Likely candidates: lemma name mismatches (Metric.infDist_le_dist_of_mem, Set.mem_iUnion₂, isOpen_biUnion).",
-      "(3) Once verified, update meta.json + research JSON to reflect successful proof closure.",
-      "(4) Consider follow-up: prove approx_selection_exists axiom 2 from Mathlib partition-of-unity (would leave only Brouwer's FPT as an axiom)."
+      "(S7-1) Add IsGraphApproxSelection definition (graph form, see s6-axiom-counterexample.md) alongside or in place of IsApproxSelection.",
+      "(S7-2) Restate axiom approx_selection_exists in graph form. Update docstring to cite Cellina–Browder and remove the (incorrect) pointwise step-6 sketch.",
+      "(S7-3) Patch kakutani_from_brouwer: after Brouwer gives x₀ = f_ε(x₀), apply graph-approx witness to get x' near x₀ and y ∈ F(x') near f_ε(x₀); chain via triangle inequality to dist(x', y) < 2ε; substitute ε ↦ 2ε in the outer existential fed to approx_fixedpoint_implies_fixedpoint. Helper is unchanged.",
+      "(S7-4) Docker-verify build (`./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`). Expect minimal change — IsApproxSelection definition already lives in the file, and the helper does not depend on it.",
+      "(S8) Attempt PartitionOfUnity proof of the graph form using Mathlib's PartitionOfUnity / BumpCovering, Finset.centerMass, Convex.centerMass_mem. Standard textbook proof.",
+      "(S9, optional) Prove brouwer_fpt extension from Mathlib's unit-ball Brouwer to general compact convex S via retraction: compact convex C in R^n is a retract of a closed ball B; if r : B → C is a retraction and f : C → C continuous, apply Brouwer-on-B to f ∘ r ∘ ι : B → B."
     ]
   },
   "tags": [
@@ -103,7 +109,7 @@
     ]
   },
   "started": "2026-04-21T00:00:00Z",
-  "lastUpdate": "2026-05-08T03:00:00Z",
+  "lastUpdate": "2026-05-08T15:30:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S6 mathematical analysis surfaces that the axiom **`approx_selection_exists`** in `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` is **false as stated** under the listed hypotheses (UHC + nonempty convex values). The S5 next-action — proving this axiom from `Mathlib.Topology.PartitionOfUnity` — therefore cannot succeed for the **pointwise** form. Only the **graph** form (Cellina–Browder, 1968-69) is provable from those hypotheses; pointwise approximate selections require lower hemicontinuity, a strictly stronger condition.

This finding does **not** invalidate Kakutani's theorem, nor the S3+S4 work on `approx_fixedpoint_implies_fixedpoint` and the limit argument — those are independent of the axiom's exact form. It does invalidate the chosen *proof strategy* for `kakutani_from_brouwer` as currently stated.

## The counterexample (n = 1)

Take `S = [-1, 1]` and define `F : ↥S → 2^↥S` by

| `t`            | `F(t)`     |
| -------------- | ---------- |
| `t = 0`        | `[0, 1]`   |
| `t ∈ (0, 1]`   | `{0}`      |
| `t ∈ [-1, 0)`  | `{1}`      |

`F` satisfies every hypothesis of the axiom (nonempty values; convex values via `Subtype.val` lift; UHC by case-checking `{t : F(t) ⊆ V}` for `V` open). But no continuous `f : S → S` is a pointwise `(1/3)`-approximate selection: continuity at `0` forces `f(0)` into both `[-1/3, 1/3]` and `[2/3, 1]`, which are disjoint.

The full proof — verbatim definitions, USC verification by case split, the disjoint-interval argument, and a Cellina–Browder salvage outline — is in [`research/problems/.../s6-axiom-counterexample.md`](../tree/research/schauder-oq03-oq01-s6-axiom-counterexample/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s6-axiom-counterexample.md).

## Salvage path (S7, ~10-line edit)

The graph form
```lean
def IsGraphApproxSelection {X} [PseudoMetricSpace X] (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
  ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
```
is provable under USC + convex values (Cellina 1969, Browder 1968; Aubin–Frankowska §9.2). After replacing `IsApproxSelection` with this graph form in the axiom, `kakutani_from_brouwer` is patched by chaining one triangle inequality:

```
dist(x', y) ≤ dist(x', x₀) + dist(x₀, f_ε(x₀)) + dist(f_ε(x₀), y) < 2ε
```

(using `f_ε(x₀) = x₀` from `brouwer_fpt`). Substitute `ε ↦ 2ε` in the outer existential fed to `approx_fixedpoint_implies_fixedpoint`. The helper itself is unchanged.

After S7, the **standard textbook PartitionOfUnity proof** of the *graph* form becomes a tractable S8 task (uses `PartitionOfUnity`, `BumpCovering`, `Finset.centerMass`, `Convex.centerMass_mem`).

## Independent observation

`brouwer_fpt`'s extension from Mathlib's unit-ball Brouwer to general compact convex `S ⊆ ℝⁿ` is folklore-provable via a retraction argument (compact convex sets in `ℝⁿ` are retracts of closed balls; retracts inherit the FPP). Easier of the two axioms once S7+ lands the graph form.

## Files changed

- **(new)** `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s6-axiom-counterexample.md` — 199-line analysis.
- `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md` — phase `ACT` → `ORIENT`, iteration 4 → 5.
- `src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json` — S6 prepended to `progressSummary`; 4 new insights; 6-step `nextSteps` roadmap (S7-1..4, S8, S9).

**No Lean changes** in this PR — the axiom remains in place for S7 to revise. **No build attempted**; the finding is purely mathematical.

## Test plan

- [x] JSON validates (`json.load` succeeds; iteration=5, phase=ORIENT)
- [x] Counterexample's USC, convex-values, and nonemptiness hypotheses are checked verbatim against file definitions of `IsUpperHemicontinuous` and `IsApproxSelection`
- [x] Disjoint-interval argument double-checked by hand
- [x] No Lean file modifications; no build risk; existing build status unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)