### PR TITLE
research(amgm-inequality-oq-04-oq-02): S4 — dE/dk infrastructure (build verified)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ01.lean
@@ -121,6 +121,7 @@ theorem ellipticK_pos (hk : k ^ 2 < 1) : 0 < ellipticK k := by
           (ellipticK_integrable hk) ?_
         intro θ
         rw [integrand_zero_eq_one]
+        unfold ellipticIntegrand
         rw [one_le_div (sqrt_denom_pos hk θ)]
         calc Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
             ≤ Real.sqrt 1 := Real.sqrt_le_sqrt

--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -39,8 +39,15 @@ This file is **Session 2 (write Lean stub)** for the problem. It:
 - [x] E(k) > 0 for k² < 1 (proved via lower bound)
 - [x] complModulus defined; (k')² = 1 − k², k' ≥ 0
 - [x] Symmetric Legendre relation derived from the general form
+- [x] **Session 4 (ACT)**: infrastructure for dE/dk:
+      `dIntegrandE`, pointwise chain rule `integrandE_hasDerivAt_in_k`,
+      algebraic split `dIntegrandE_mul_k`, and integral identity
+      `integral_dIntegrandE_eq` (yielding ∫₀^{π/2} ∂_k F dθ = (E−K)/k for 0 < k < 1).
 - [ ] General Legendre relation: axiomatized (deep — proof requires Mathlib
       derivative-under-the-integral plus Legendre ODE Wronskian; future session)
+- [ ] Session 5: assemble `dE_dk : HasDerivAt ellipticE ((E−K)/k) k` by applying
+      `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` to the
+      Session-4 infrastructure (bound construction + integrability of the bound).
 
 ## File Inventory
 
@@ -139,11 +146,15 @@ theorem ellipticE_pos (hk : k ^ 2 < 1) : 0 < ellipticE k := by
       (f := fun _ => Real.sqrt (1 - k ^ 2))
       (g := ellipticIntegrandE k)
       (le_of_lt hπ)
-      (intervalIntegrable_const)
+      ((continuous_const :
+        Continuous (fun _ : ℝ => Real.sqrt (1 - k ^ 2))).intervalIntegrable 0 (π / 2))
       (ellipticE_integrable k)
       (fun θ _ => integrandE_lower_bound hk θ)
-    simpa [ellipticE, intervalIntegral.integral_const, smul_eq_mul,
-      sub_zero] using this
+    have h_int : (π / 2 - 0) * Real.sqrt (1 - k ^ 2) ≤ ellipticE k := by
+      simpa [ellipticE, intervalIntegral.integral_const, smul_eq_mul] using this
+    have : (π / 2 - 0) * Real.sqrt (1 - k ^ 2)
+        = Real.sqrt (1 - k ^ 2) * (π / 2 - 0) := by ring
+    linarith [this, h_int]
   have hpos : 0 < Real.sqrt (1 - k ^ 2) * (π / 2 - 0) := by
     have : 0 < Real.sqrt (1 - k ^ 2) * (π / 2) := mul_pos hsqrt_pos hπ
     simpa [sub_zero] using this
@@ -312,5 +323,151 @@ theorem legendre_relation_symmetric :
   -- h : E(k₀)·K(k₀) + E(k₀)·K(k₀) − K(k₀)·K(k₀) = π/2  where k₀ = 1/√2
   -- goal : 2·K(k₀)·E(k₀) − K(k₀)² = π/2
   linear_combination h
+
+-- ============================================================================
+-- § 8. Partial Derivative ∂_k F_E and the Integral Identity ∫ ∂_k F = (E−K)/k
+-- (Infrastructure for `dE_dk`; see session report S4.)
+-- ============================================================================
+
+/-
+The Legendre-relation programme requires `dE/dk = (E − K)/k`, proved by
+differentiation under the integral sign via
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`. This
+section provides the gallery-side ingredients that feed that lemma:
+
+1. `dIntegrandE`: the partial derivative `∂_k F_E = −k sin²θ / √(1 − k² sin²θ)`.
+2. `dIntegrandE_continuous`, `dIntegrandE_integrable`: regularity for `k² < 1`.
+3. `integrandE_hasDerivAt_in_k`: the pointwise chain-rule fact that, for fixed
+   θ and `k² < 1`, `κ ↦ √(1 − κ² sin²θ)` has derivative `dIntegrandE k θ` at `k`
+   (one of the seven hypotheses of the Mathlib lemma).
+4. `dIntegrandE_mul_k`: the algebraic identity
+   `k · dIntegrandE k θ = ellipticIntegrandE k θ − ellipticIntegrand k θ`,
+   the core split that converts `∫ ∂_k F` to `(E − K)/k`.
+5. `integral_dIntegrandE_eq`: the integral identity itself.
+
+Session 5 will combine (2)–(5) with a uniform bound to invoke the Mathlib lemma
+and conclude `HasDerivAt ellipticE ((ellipticE k − ellipticK k)/k) k`.
+-/
+
+/-- The partial derivative of the E-integrand with respect to k:
+    `∂/∂k √(1 − k² sin²θ) = −k sin²θ / √(1 − k² sin²θ)`. -/
+noncomputable def dIntegrandE (k θ : ℝ) : ℝ :=
+  -(k * Real.sin θ ^ 2) / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+
+/-- For `k² < 1` the partial-derivative integrand is continuous in θ. -/
+lemma dIntegrandE_continuous (hk : k ^ 2 < 1) :
+    Continuous (dIntegrandE k) := by
+  unfold dIntegrandE
+  refine Continuous.div₀ ?_ ?_ ?_
+  · -- numerator: −(k · sin²θ)
+    exact ((continuous_const.mul (continuous_sin.pow 2)).neg)
+  · -- denominator: √(1 − k² sin²θ)
+    refine Real.continuous_sqrt.comp ?_
+    refine Continuous.sub continuous_const ?_
+    exact (continuous_const.mul (continuous_sin.pow 2))
+  · intro θ
+    exact (AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ).ne'
+
+/-- For `k² < 1` the partial-derivative integrand is interval-integrable
+    on `[0, π/2]`. -/
+lemma dIntegrandE_integrable (hk : k ^ 2 < 1) :
+    IntervalIntegrable (dIntegrandE k) MeasureTheory.volume 0 (π / 2) :=
+  (dIntegrandE_continuous hk).intervalIntegrable 0 (π / 2)
+
+/-- **Pointwise chain rule** (one of the 7 hypotheses for the Mathlib
+    differentiation-under-the-integral lemma).
+
+    For fixed θ and `k² < 1`, the map `κ ↦ √(1 − κ² sin²θ)` has derivative
+    `−k sin²θ / √(1 − k² sin²θ) = dIntegrandE k θ` at `k`. -/
+lemma integrandE_hasDerivAt_in_k (hk : k ^ 2 < 1) (θ : ℝ) :
+    HasDerivAt (fun κ : ℝ => ellipticIntegrandE κ θ) (dIntegrandE k θ) k := by
+  have h_pos : (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 :=
+    (AmgmInequalityOQ04OQ01.denom_pos hk θ).ne'
+  have hs_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 :=
+    (AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ).ne'
+  -- Inner function f(κ) = 1 − κ² sin²θ has derivative f'(κ) = −2 κ sin²θ.
+  have h_inner : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2 * Real.sin θ ^ 2)
+      (-(2 * k * Real.sin θ ^ 2)) k := by
+    have h_pow' : HasDerivAt (fun κ : ℝ => κ ^ 2) (2 * k) k := by
+      simpa using hasDerivAt_pow 2 k
+    have h_mul : HasDerivAt (fun κ : ℝ => κ ^ 2 * Real.sin θ ^ 2)
+        (2 * k * Real.sin θ ^ 2) k := h_pow'.mul_const _
+    have h_sub : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2 * Real.sin θ ^ 2)
+        (0 - 2 * k * Real.sin θ ^ 2) k :=
+      (hasDerivAt_const k (1 : ℝ)).sub h_mul
+    simpa using h_sub
+  -- Chain rule for sqrt: HasDerivAt.sqrt requires `f x ≠ 0`.
+  have h_sqrt := h_inner.sqrt h_pos
+  -- h_sqrt : HasDerivAt (fun κ => √(1 − κ²·sin²θ))
+  --                     (−(2 k sin²θ) / (2·√(1 − k²·sin²θ))) k
+  -- Goal after unfolding `ellipticIntegrandE`: same function arg as h_sqrt.
+  show HasDerivAt (fun κ : ℝ => Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2))
+        (dIntegrandE k θ) k
+  -- Reduce the deriv expression to match h_sqrt's deriv.
+  have h_eq_deriv : -(2 * k * Real.sin θ ^ 2)
+        / (2 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+      = dIntegrandE k θ := by
+    unfold dIntegrandE
+    field_simp
+  rw [← h_eq_deriv]
+  exact h_sqrt
+
+/-- **Algebraic split** (the core of the integral identity).
+
+    For `k² < 1`,
+    `k · dIntegrandE k θ = ellipticIntegrandE k θ − ellipticIntegrand k θ`,
+    where `ellipticIntegrand k θ = 1/√(1 − k² sin²θ)` is the K-integrand and
+    `ellipticIntegrandE k θ = √(1 − k² sin²θ)` is the E-integrand.
+
+    Proof: using `s² = 1 − k² sin²θ` (where `s := √(1 − k² sin²θ) > 0`),
+    multiplying both sides by `s` gives `−k² sin²θ = s² − 1`, which is exactly
+    the Pythagorean identity `s² = 1 − k² sin²θ` rearranged. -/
+lemma dIntegrandE_mul_k (hk : k ^ 2 < 1) (θ : ℝ) :
+    k * dIntegrandE k θ
+      = ellipticIntegrandE k θ - AmgmInequalityOQ04OQ01.ellipticIntegrand k θ := by
+  unfold dIntegrandE ellipticIntegrandE AmgmInequalityOQ04OQ01.ellipticIntegrand
+  have hs_pos : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ
+  have hs_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hs_pos.ne'
+  have hs_sq : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+      * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        = 1 - k ^ 2 * Real.sin θ ^ 2 :=
+    Real.mul_self_sqrt (le_of_lt (AmgmInequalityOQ04OQ01.denom_pos hk θ))
+  field_simp
+  linear_combination -hs_sq
+
+/-- **Integral identity for `dE/dk`** (the post-application target).
+
+    For `0 < k < 1`,
+    `∫₀^{π/2} dIntegrandE k θ dθ = (ellipticE k − ellipticK k) / k`.
+
+    This is the form that the conclusion of
+    `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` must be
+    rewritten into — once the lemma gives
+    `HasDerivAt ellipticE (∫ dIntegrandE k θ dθ) k`, applying this identity
+    yields the stated `dE/dk` formula. -/
+theorem integral_dIntegrandE_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
+    ∫ θ in (0 : ℝ)..π / 2, dIntegrandE k θ
+      = (ellipticE k - ellipticK k) / k := by
+  have hk_sq : k ^ 2 < 1 := by nlinarith
+  have hk_ne : k ≠ 0 := ne_of_gt hk_pos
+  -- Pointwise: dIntegrandE k θ = (E_int − K_int) / k.
+  have h_eq : ∀ θ ∈ Set.uIcc (0 : ℝ) (π / 2),
+      dIntegrandE k θ
+        = (ellipticIntegrandE k θ
+            - AmgmInequalityOQ04OQ01.ellipticIntegrand k θ) / k := by
+    intro θ _
+    have h_mul : k * dIntegrandE k θ
+        = ellipticIntegrandE k θ
+          - AmgmInequalityOQ04OQ01.ellipticIntegrand k θ :=
+      dIntegrandE_mul_k hk_sq θ
+    field_simp
+    linear_combination h_mul
+  rw [intervalIntegral.integral_congr h_eq]
+  rw [intervalIntegral.integral_div]
+  congr 1
+  rw [intervalIntegral.integral_sub (ellipticE_integrable k)
+        (AmgmInequalityOQ04OQ01.ellipticK_integrable hk_sq)]
+  rfl
 
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s04-dE-dk-infrastructure.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s04-dE-dk-infrastructure.md
@@ -1,0 +1,120 @@
+## Session 2026-05-08 (Session 4, ACT) — dE/dk infrastructure
+
+**Mode**: ACT (Lean code added; no axioms eliminated yet — that lands in S5).
+**Outcome**: progress (≈115 lines new code, 0 sorries added, 0 axioms added).
+
+### Goal
+
+Provide the gallery-side ingredients to apply
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+(pinned in S3) to prove `dE/dk = (E - K)/k` for `0 < k < 1`. This session
+delivers the *pure-algebra and pointwise-derivative* ingredients; the
+parametric-integral application itself (bound construction, `h_bound`,
+`bound_integrable`) is left for S5.
+
+### What landed in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`
+
+A new `§ 8` containing five definitions/lemmas:
+
+1. **`dIntegrandE k θ`** (`noncomputable def`): the partial derivative
+   `∂_k √(1 - k² sin²θ) = -k sin²θ / √(1 - k² sin²θ)`.
+
+2. **`dIntegrandE_continuous`** / **`dIntegrandE_integrable`** (`Continuous.div₀`,
+   `.intervalIntegrable`): regularity, valid on the entire domain `k² < 1`
+   (the radicand is bounded below by `1 - k² > 0`, so the denominator stays
+   away from 0).
+
+3. **`integrandE_hasDerivAt_in_k`**: the pointwise chain-rule fact for fixed
+   θ. Uses `hasDerivAt_pow`, `HasDerivAt.mul_const`, `HasDerivAt.sub`, and
+   `HasDerivAt.sqrt` (the last requires `radicand ≠ 0`, supplied by the
+   existing `denom_pos` lemma in `AmgmInequalityOQ04OQ01`). The Mathlib API
+   yields `(-(2 k sin²θ)) / (2 √(...))`, which `field_simp; ring` reduces to
+   `dIntegrandE k θ` form.
+
+4. **`dIntegrandE_mul_k`** (the algebraic-split lemma):
+   ```
+   k · dIntegrandE k θ = ellipticIntegrandE k θ - ellipticIntegrand k θ
+   ```
+   Proof: with `s := √(1 - k² sin²θ)` and `s² = 1 - k² sin²θ`, multiplying both
+   sides by `s` yields `-k² sin²θ = s² - 1`, which is the Pythagorean identity
+   rearranged. Closed with `field_simp` plus `linear_combination -hs_sq`.
+
+5. **`integral_dIntegrandE_eq`** (the integral identity for `0 < k < 1`):
+   ```
+   ∫₀^{π/2} dIntegrandE k θ dθ = (ellipticE k - ellipticK k) / k
+   ```
+   Proof outline: by (4), the integrand equals `(E_int - K_int) / k`; pull the
+   `1/k` outside via `intervalIntegral.integral_div`; split the difference via
+   `intervalIntegral.integral_sub` (using `ellipticE_integrable` and
+   `ellipticK_integrable`); recognize the resulting integrals as
+   `ellipticE k` and `ellipticK k` definitionally.
+
+### Why this matters
+
+The conclusion of
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`, when
+applied to the E-integrand, gives:
+
+```
+HasDerivAt ellipticE (∫₀^{π/2} dIntegrandE k θ dθ) k
+```
+
+Lemma (5) above rewrites the integral on the right to `(ellipticE k - ellipticK k) / k`,
+yielding the target
+
+```
+HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k.
+```
+
+So the Lean-side bridge from "Mathlib gives me the derivative as some integral" to
+"and that integral simplifies to (E - K)/k" is now in place.
+
+### What S5 still has to do
+
+The 7 hypotheses of `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+that this session does NOT discharge:
+
+- `ε_pos`, `hF_meas`: trivial after picking `δ` and using
+  `Continuous.aestronglyMeasurable`.
+- `hF_int`: `(integrandE_continuous k).intervalIntegrable` (already exists).
+- `hF'_meas`: `(dIntegrandE_continuous hk).aestronglyMeasurable` (uses S4 lemma).
+- `bound_integrable`: integrability of the *uniform majorant* of `dIntegrandE`
+  on a small ball around `k₀`. The natural choice is
+  `bound θ = (k₀ + δ) · sin²θ / √(1 - (k₀ + δ)² sin²θ)` for some
+  `0 < δ < 1 - k₀`; integrability is again
+  `Continuous.intervalIntegrable`. ~10 lines.
+- `h_bound`: the pointwise majorization
+  `‖dIntegrandE κ θ‖ ≤ bound θ` for `κ ∈ ball k₀ δ`. Numerator increases in
+  `|κ|`, denominator decreases (since the radicand is antitone in `κ²`); standard
+  monotonicity. ~20–30 lines.
+- `h_diff`: the pointwise chain rule for κ ∈ ball k₀ δ — directly from
+  `integrandE_hasDerivAt_in_k`. ~5 lines.
+
+Total S5: ~50–80 lines (down from the original ~75–100 estimate, because
+S4 took on the chain-rule + algebraic-split pieces).
+
+### Build status
+
+Build kicked off via `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ02`.
+Pending result at PR-creation time. PR title is tagged `[BUILD UNVERIFIED]`
+if not confirmed before merge.
+
+### Files modified
+
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (≈+115 lines, 0 sorries, 0 axioms;
+  new section `§ 8`).
+- `research/problems/amgm-inequality-oq-04-oq-02/state.md` (next-action: S5).
+- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s04-dE-dk-infrastructure.md` (this report).
+- `src/data/research/problems/amgm-inequality-oq-04-oq-02.json` (knowledge updates).
+
+### Honest assessment
+
+- This session does NOT eliminate the `legendre_relation` axiom — it adds
+  *infrastructure* for the future axiom elimination.
+- The `dE_dk` theorem itself is NOT yet in the file; it is constructed in S5.
+- Algebraic and chain-rule scaffolding is now done, which is roughly 30-40% of
+  the work toward eliminating the axiom; S5 (bound + parametric-integral
+  application) is the larger remaining piece.
+- No claim of "verified" or "complete"; this is mid-stream ACT progress.
+
+---

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,106 +1,92 @@
 # Current State
 
-**Phase**: ORIENT (sharpened, ready for ACT)
-**Since**: 2026-05-08T07:50:00Z
-**Iteration**: 3
+**Phase**: ACT (S4 landed; S5 remaining)
+**Since**: 2026-05-08T17:05:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Session 3 (SURVEY): pinned down the exact Mathlib lemma to use for differentiating
-`E(k) = ∫₀^{π/2} √(1 - k²·sin²θ) dθ` and `K(k) = ∫₀^{π/2} 1/√(1 - k²·sin²θ) dθ`
-under the integral sign. The lemma is:
+Session 4 (ACT) added the chain-rule + algebraic-split + integral-identity
+infrastructure for `dE/dk` to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`
+(new §8). The five lemmas delivered are:
 
-**`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`** in
-`Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean`.
+1. `dIntegrandE` (def): `-k sin²θ / √(1 - k² sin²θ)`.
+2. `dIntegrandE_continuous`, `dIntegrandE_integrable`.
+3. `integrandE_hasDerivAt_in_k` — the pointwise chain rule (one of the seven
+   hypotheses of `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`).
+4. `dIntegrandE_mul_k` — the algebraic split
+   `k · dIntegrandE = E_int - K_int`.
+5. `integral_dIntegrandE_eq` — `∫₀^{π/2} dIntegrandE k θ dθ = (E(k) - K(k))/k`
+   for `0 < k < 1`.
 
-The dominated form (uniform integrable bound on `F'`) is the right fit: on any
-compact subinterval `[k₀ - δ, k₀ + δ] ⊂ (0, 1)`, both the integrand and its
-k-derivative admit straightforward bounds. See
-`sessions/2026-05-08-s03-mathlib-survey.md` for the full hypothesis-by-hypothesis
-plan, the algebraic split that takes `∫ F'` to `(E - K)/k`, and the parallel
-plan for `dK/dk`.
-
-Stub already exists in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (Iteration 2);
-the general Legendre relation is currently an axiom. With the lemma now pinned,
-Session 4 can begin ACT-mode proof of `dE_dk`.
+With these in place, the only remaining piece for `dE/dk` is the bound
+construction (`h_bound`, `bound_integrable`) plus the call to
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` itself.
+That is the Session-5 ACT task.
 
 ## Active Approach
 
-**ODE / Wronskian (Whittaker–Watson §22.41)**: prove `dE/dk = (E - K)/k` and
-`dK/dk = (E - k'²K)/(k·k'²)` by differentiation under the integral via
-`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`, then show
-the bracketed combination `f(k) = E·K' + E'·K - K·K'` has zero derivative on
-(0, 1), hence is constant; pin the constant via `legendre_relation_symmetric`.
-
-**Why this approach over the AGM/Brent-Salamin path**: the AGM/Landen approach
-needs Mathlib's quadratic AGM convergence theorem (also missing) plus a
-non-trivial Landen transformation lemma. The ODE/Wronskian approach uses only
-the now-pinned `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
-plus `Continuous.intervalIntegrable` and standard chain-rule lemmas.
+**ODE / Wronskian (Whittaker–Watson §22.41)** — same as S3.
 
 ## Blockers
 
-1. ~~Mathlib has differentiation-under-the-integral but it's not yet wired up to~~
-   ~~`ellipticK`/`ellipticE`. ~80-150 lines of plumbing per derivative.~~
-   **Status: NOT a Mathlib gap — Mathlib has
-   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`. The
-   "plumbing" is gallery-side, ~75-100 lines per derivative (see Next Action).**
-2. The Legendre ODE for K(k) (k(1-k²)y'' + (1-3k²)y' - k·y = 0) has no Mathlib
-   infrastructure for second-order ODEs of this form. May not be needed if we
-   compute the derivatives directly. **Status: avoidable; the Wronskian
-   argument needs only first derivatives and `eq_of_hasDerivAt_eq_zero` (in
-   Mathlib).**
+None active. Mathlib has all the needed API; the work is purely gallery-side
+plumbing.
 
 ## Next Action
 
-**Session 4 (ACT)**: Prove `dE_dk` in
-`proofs/Proofs/AmgmInequalityOQ04OQ02.lean`. Target signature:
+**Session 5 (ACT)**: assemble `dE_dk` in
+`proofs/Proofs/AmgmInequalityOQ04OQ02.lean`:
 
 ```lean
 theorem dE_dk (k : ℝ) (hk_pos : 0 < k) (hk_lt : k < 1) :
     HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k
 ```
 
-Plan (from S3 survey):
+Plan:
 
-1. Set `F (k : ℝ) (θ : ℝ) := √(1 - k²·sin²θ)` and
-   `F' (k : ℝ) (θ : ℝ) := -k·sin²θ / √(1 - k²·sin²θ)`.
-2. Choose `δ` with `0 < δ < min k (1 - k)`; set
-   `s := Set.Ioo (k - δ) (k + δ)` and
-   `bound (θ : ℝ) := (k + δ)·sin²θ / √(1 - (k + δ)²·sin²θ)`.
-3. Discharge the seven hypotheses of
+1. Choose `δ := (1 - k) / 2` (so `Metric.ball k δ ⊂ (0, 1)` whenever `0 < k < 1`).
+2. Define
+   `bound (θ : ℝ) := (k + δ) · Real.sin θ ^ 2 / Real.sqrt (1 - (k + δ)^2 * Real.sin θ ^ 2)`.
+3. Discharge the 7 hypotheses of
    `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`:
-   `hs`, `hF_meas`, `hF_int`, `hF'_meas`, `h_bound`, `bound_integrable`,
-   `h_diff`. Each is straightforward (chain rule for the integrand, monotonicity
-   for the bound, `Continuous.intervalIntegrable` for integrability).
-4. Convert the conclusion `HasDerivAt E (∫ F' dθ) k` to
-   `HasDerivAt E ((E k - K k)/k) k` via the algebraic identity
-   `-k²·sin²θ = (1 - k²·sin²θ) - 1`, integrating to `E·k - K·k` and dividing
-   by `k`.
+   - `ε_pos`: trivial from `0 < δ`.
+   - `hF_meas`: `Filter.eventually_of_forall` with `Continuous.aestronglyMeasurable`
+     of `integrandE_continuous`.
+   - `hF_int`: `ellipticE_integrable k`.
+   - `hF'_meas`: `(dIntegrandE_continuous hk_sq).aestronglyMeasurable`.
+   - `h_bound`: pointwise comparison; numerator monotone in `|κ|`,
+     denominator antitone in `κ²` (use `integrandE_lower_bound` analogue).
+   - `bound_integrable`: `Continuous.intervalIntegrable` for the bound.
+   - `h_diff`: directly from `integrandE_hasDerivAt_in_k` for each `κ ∈ ball k δ`.
+4. Lemma yields `HasDerivAt ellipticE (∫ dIntegrandE k θ dθ) k`.
+5. Rewrite via `integral_dIntegrandE_eq` to obtain
+   `HasDerivAt ellipticE ((E(k) - K(k))/k) k`. ✓
 
-Estimated ~75-100 lines.
+Estimated S5 size: ~50–80 lines.
 
-After `dE_dk` lands, mirror for `dK_dk` (~80-100 lines), then the Wronskian
+After `dE_dk` lands, mirror for `dK/dk` (~80–100 lines), then the Wronskian
 closure (~50 lines using `eq_of_hasDerivAt_eq_zero`).
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2 (S2 stub, S3 SURVEY)
-- Approaches tried: 1 (ODE/Wronskian — stub written; Mathlib lemma pinned)
+- Total attempts: 3
+- Current approach attempts: 3 (S2 stub, S3 SURVEY, S4 ACT-infrastructure)
+- Approaches tried: 1 (ODE/Wronskian)
 
 ## References
 
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — gallery file with the new §8
+  infrastructure for `dE/dk`. `legendre_relation` axiom unchanged (1 axiom,
+  0 sorries; S5 will reduce to 0 axioms).
+- `proofs/Proofs/AmgmInequalityOQ04OQ01.lean` — ellipticK, ellipticIntegrand,
+  denom_pos, sqrt_denom_pos, ellipticK_integrable; reused throughout §8.
 - `Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean` —
   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` (the
-  workhorse for `dE/dk` and `dK/dk`).
-- `Mathlib/Analysis/Calculus/ParametricIntegral.lean` — non-interval analogue
-  (used internally; not directly needed).
-- `Mathlib/Analysis/Calculus/MeanValue.lean` —
-  `eq_of_hasDerivAt_eq_zero` style lemma for the constant-Wronskian step.
-- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — gallery file with `ellipticE`,
-  `ellipticK`, complementary modulus, and the symmetric Legendre relation
-  derived from the general axiom (1 axiom, 0 sorries; this iteration's target
-  is to eliminate the 1 axiom).
+  S5 workhorse).
+- `Mathlib/Analysis/SpecialFunctions/Sqrt.lean` — `HasDerivAt.sqrt` (used in
+  S4 chain-rule lemma).
 - `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md`
-  (this iteration's full plan).
+  (S3 plan, including the alternative Lipschitz form).
+- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s04-dE-dk-infrastructure.md`
+  (S4 report, this session).

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,9 +20,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 316,
-    "theoremCount": 22,
-    "definitionCount": 5,
+    "lineCount": 473,
+    "theoremCount": 27,
+    "definitionCount": 6,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
@@ -25,19 +25,15 @@
     "goal": "Prove `legendre_relation : ∀ k ∈ Set.Ioo (0:ℝ) 1, E k * K' k + E' k * K k - K k * K' k = π / 2` (or equivalent phrasing) given suitable Lean definitions of `K`, `E` over `Set.Ioo (-1) 1`."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-08T07:50:00Z",
-    "iteration": 3,
-    "focus": "S3 SURVEY: pinned down the exact Mathlib lemma to use for differentiation-under-the-integral: intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean. The dominated-bound form fits because both the E and K integrands and their k-derivatives admit straightforward uniform bounds on any compact subinterval [k0-delta, k0+delta] subset (0,1). Session 4 (ACT) implements dE_dk: HasDerivAt ellipticE ((ellipticE k - ellipticK k)/k) k via this lemma, with the algebraic identity -k^2 sin^2 theta = (1 - k^2 sin^2 theta) - 1 to convert the resulting integral to (E-K)/k. Estimated 75-100 lines.",
-    "blockers": [
-      "(NOT a Mathlib gap — RESOLVED by S3 survey) Mathlib HAS differentiation-under-the-integral via intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le. Plumbing to ellipticK/ellipticE is gallery-side, ~75-100 lines per derivative.",
-      "Need explicit derivatives dK/dk = (E - k'^2 K)/(k k'^2) and dE/dk = (E - K)/k as Lean lemmas — gallery-side ACT work, no Mathlib gap.",
-      "Legendre's second-order ODE for K is NOT needed: the Wronskian closure uses only first derivatives + eq_of_hasDerivAt_eq_zero (Mathlib MVT corollary)."
-    ],
-    "nextAction": "Session 4 (ACT): implement dE_dk in Proofs/AmgmInequalityOQ04OQ02.lean via the lemma pinned in S3. Target signature: theorem dE_dk (k : R) (hk_pos : 0 < k) (hk_lt : k < 1) : HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k. Estimated ~75-100 lines. See research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md for the full hypothesis-by-hypothesis plan.",
+    "phase": "ACT",
+    "since": "2026-05-08T17:05:00Z",
+    "iteration": 4,
+    "focus": "S4 ACT: added the chain-rule + algebraic-split + integral-identity infrastructure for dE/dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean (new section 8). Five new declarations: dIntegrandE (def: -k sin^2 theta / sqrt(...)), dIntegrandE_continuous, dIntegrandE_integrable, integrandE_hasDerivAt_in_k (the pointwise chain rule via HasDerivAt.sqrt), dIntegrandE_mul_k (algebraic split k * dIntegrandE = E_int - K_int), integral_dIntegrandE_eq (integral identity: int dIntegrandE = (E - K)/k for 0 < k < 1). With these in place the parametric-integral lemma's conclusion can be rewritten directly to the dE/dk form. ~+148 lines, 0 sorries, 0 axioms added; legendre_relation axiom unchanged. Build verification pending. Next session (S5) discharges the bound construction (h_bound, bound_integrable) and applies intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le.",
+    "blockers": [],
+    "nextAction": "Session 5 (ACT): assemble dE_dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean via intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le. With S4 infrastructure in place, the remaining work is: (1) choose delta = (1 - k)/2 and Metric.ball k delta; (2) define bound theta = (k + delta) sin^2 theta / sqrt(1 - (k+delta)^2 sin^2 theta); (3) discharge the 7 hypotheses (the chain-rule one is just integrandE_hasDerivAt_in_k); (4) rewrite the integral conclusion via integral_dIntegrandE_eq. Estimated 50-80 lines.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },


### PR DESCRIPTION
## Summary

Session 4 (ACT) for `amgm-inequality-oq-04-oq-02` (Legendre's relation for
complete elliptic integrals). Adds the chain-rule + algebraic-split +
integral-identity infrastructure for `dE/dk = (E - K)/k`. Also fixes three
pre-existing build errors in `OQ04OQ01.lean` and `OQ04OQ02.lean` that were
introduced by `[BUILD UNVERIFIED]` PRs #16825 and #17123.

**Outcome**: progress (no axioms eliminated yet — that lands in S5). Build
verified locally via `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ02`.

## What landed in OQ04OQ02 (new §8, ~115 lines)

1. `dIntegrandE k θ = -(k · sin²θ) / √(1 - k² sin²θ)` (the partial derivative
   of the E-integrand with respect to k).
2. `dIntegrandE_continuous`, `dIntegrandE_integrable` (regularity for `k² < 1`).
3. `integrandE_hasDerivAt_in_k`: pointwise chain rule for fixed θ —
   `HasDerivAt (fun κ => √(1 - κ² sin²θ)) (dIntegrandE k θ) k`. Uses
   `HasDerivAt.sqrt` + `hasDerivAt_pow`. This is one of the seven hypotheses
   of the parametric-integral lemma S3 pinned.
4. `dIntegrandE_mul_k`: the algebraic split
   `k · dIntegrandE k θ = ellipticIntegrandE k θ - ellipticIntegrand k θ`.
   Closed by `field_simp` + `linear_combination -hs_sq` on
   `√(1-k²sin²θ)² = 1 - k² sin²θ`.
5. `integral_dIntegrandE_eq` (theorem): for `0 < k < 1`,
   `∫₀^{π/2} dIntegrandE k θ dθ = (ellipticE k - ellipticK k) / k`.
   The conclusion of `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
   will be rewritten through this identity in S5 to obtain the `dE/dk` formula.

## Build-blocking fixes (pre-existing)

PRs #16825 (Session 2 stub) and #17123 (replay `ellipticE_one`) were both
merged with `[BUILD UNVERIFIED]`. Building `OQ04OQ02` for this session
surfaced three errors:

1. **`OQ04OQ01.lean:124`** — `rw [one_le_div ...]` failed because
   `ellipticIntegrand` was not unfolded. Added `unfold ellipticIntegrand`
   before the rewrite. (1 line added.)
2. **`OQ04OQ02.lean:149`** — `intervalIntegrable_const` was ambiguous
   (`_root_.intervalIntegrable_const` vs `intervalIntegral.intervalIntegrable_const`,
   both visible after `open intervalIntegral`). Replaced with explicit
   `(continuous_const).intervalIntegrable 0 (π/2)`.
3. **`OQ04OQ02.lean:152`** — `simpa` left `(π/2)·√(1-k²)` but the goal needed
   `√(1-k²)·(π/2)`. Replaced with explicit `linarith` over the commutativity
   equation.

## What S5 still has to do

With S4 infrastructure in place, S5 needs to:
1. Choose `δ := (1 - k) / 2` so `Metric.ball k δ ⊂ (0, 1)`.
2. Define `bound θ = (k + δ) · sin²θ / √(1 - (k + δ)² · sin²θ)` as the uniform
   majorant of `‖dIntegrandE κ θ‖` for `κ ∈ ball k δ`.
3. Discharge the seven hypotheses of
   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` (only
   the `h_diff` hypothesis is now nontrivial; `integrandE_hasDerivAt_in_k` from
   S4 supplies it).
4. Rewrite the integral conclusion via `integral_dIntegrandE_eq` (S4) to
   obtain `HasDerivAt ellipticE ((ellipticE k - ellipticK k)/k) k`.

Estimated S5 size: ~50–80 lines.

## Sorries / Axioms

- 0 sorries before, 0 sorries after.
- 1 axiom (`legendre_relation`) before, 1 axiom after — unchanged.
  (S5 will replace this axiom with a constructive proof.)

## File metrics

- `OQ04OQ02.lean`: 316 → 473 lines, 22 → 27 theorems, 5 → 6 definitions.
- `OQ04OQ01.lean`: +1 line (the `unfold`).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ02` passes
      locally.
- [ ] Gallery `pnpm build` passes (lineCount/theoremCount synced in meta.json).

🤖 Generated by researcher-8