### PR TITLE
fix(meta): mirror lf.additionalFiles into meta block (residual 6 entries)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -29,7 +29,10 @@
       "Feasibility analysis for Mathlib contribution (~200-300 lines)"
     ],
     "theoremCount": 8,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The multinomial distribution was introduced by Jakob Bernoulli in his posthumous Ars Conjectandi (1713) as a natural generalization of the binomial to multiple outcomes. Pierre-Simon Laplace further developed its theory in Théorie analytique des probabilités (1812), deriving the multinomial theorem and using it to analyze games of chance with more than two outcomes. In the 20th century, the multinomial became central to categorical data analysis, information theory (Shannon entropy for discrete distributions), and maximum likelihood estimation for categorical models. The multinomial theorem — the key algebraic identity $(p_1+\\cdots+p_k)^n = \\sum \\binom{n}{k_1,\\ldots,k_r} \\prod p_i^{k_i}$ — simultaneously serves as both the probability normalization proof and a combinatorial identity, making it the elegant bridge between combinatorics and probability theory in this formalization.",

--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -34,7 +34,10 @@
             "Proof of chebyshevPsi_doubling_le: chains psi_doubling_le_log_centralBinom with log C(2n,n) ≤ 2n·log 2 via Nat.centralBinom_le_four_pow + Real.log_pow",
             "Proof of psi_odd_le_log_choose: ψ(2m+1)−ψ(m+1) ≤ log C(2m+1,m) via Hermite floor inequality — for d ∈ (m+1,2m+1], ⌊(2m+1)/d⌋=1 and ⌊m/d⌋=⌊(m+1)/d⌋=0",
             "Proof of chebyshevPsi_upper_bound: strong induction with even case via chebyshevPsi_doubling_le and odd case via Nat.choose_middle_le_pow (C(2m+1,m) ≤ 4^m) — axiomCount 3→2"
-        ]
+        ],
+      "additionalFiles": [
+        "Proofs/ChebyshevBoundsOQ04Aristotle.lean"
+      ]
     },
     "overview": {
         "historicalContext": "The second Chebyshev function ψ(x) = Σ_{p^k ≤ x} log p was introduced by Chebyshev alongside θ(x) = Σ_{p ≤ x} log p. While θ counts primes with logarithmic weight, ψ also counts prime powers, making it analytic ally more tractable: ψ(x) = Σ_p ⌊log_p(x)⌋ · log p, which connects to the logarithmic derivative of the Riemann zeta function via ψ(x) = -Σ_ρ x^ρ/ρ + x - log(2π) - ½log(1 - x^{-2}) (Riemann's explicit formula). The Prime Number Theorem — proved independently by Hadamard and de la Vallée Poussin in 1896 — is equivalent to ψ(x) ~ x.",

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -30,7 +30,10 @@
     "assumptions": "7 axioms: K5_nonplanar (K₅ is non-planar), K33_nonplanar (K₃,₃ is non-planar), kuratowski_theorem (non-planar iff contains K₅ or K₃,₃ subdivision), kostochka_pyber (ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices, 1988), constant_grows (C(ε) → ∞ as ε → 0), planar_linear_bound (planar graphs have ≤ 3n−6 edges), kostochka_pyber_explicit (polynomial bound in 1/ε). 7 sorries (incomplete topological and density definitions).",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "additionalFiles": [
+      "Proofs/Erdos1018Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Planarity, Density, and Topological Obstructions**\n\nThe study of planar graphs has deep roots: Euler's formula (1752) implies that planar graphs on $n \\ge 3$ vertices have at most $3n - 6$ edges—a linear bound. Kuratowski (1930) characterized non-planarity: a graph is non-planar if and only if it contains a subdivision of $K_5$ or $K_{3,3}$. Wagner (1937) proved the equivalent minor characterization.\n\nErdős asked a quantitative refinement: if a graph has $n^{1+\\varepsilon}$ edges (super-linear density), must non-planarity be concentrated in a *small* subgraph? Specifically, does there exist a constant $C_\\varepsilon$, depending only on $\\varepsilon$ and not on $n$, such that every such graph contains a non-planar subgraph on at most $C_\\varepsilon$ vertices?\n\n**Kostochka and Pyber (1988)** resolved this affirmatively, proving that graphs with $n^{1+\\varepsilon}$ edges contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Their proof uses the probabilistic method combined with extremal graph theory. Mader (1967) had earlier shown that the Turán number for $K_t$ subdivisions is $O(t\\sqrt{\\log t} \\cdot n)$, establishing a linear threshold for topological containment. The Kostochka-Pyber result goes further by bounding the *size* of the subdivision found.\n\nErdős also observed that $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$: as the density approaches linear, non-planarity becomes more diffuse and cannot be localized to a small subgraph. This tradeoff between density and obstruction size is a recurring theme in extremal graph theory.",

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -30,7 +30,10 @@
     "assumptions": "1 axiom: erdos_1056_conjecture (main conjecture — for every k ≥ 2 there exists a solution). k=2 (p=11) and k=3 (p=17) cases fully proved by native_decide. Wilson constraint proved via Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "additionalFiles": [
+      "Proofs/Erdos1056Aristotle.lean"
+    ]
   },
   "sections": [
     {

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -40,7 +40,10 @@
       "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T₀)"
     ],
     "theoremCount": 17,
-    "definitionCount": 48
+    "definitionCount": 48,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Feuerbach's theorem (1822) that the nine-point circle is tangent to the incircle and all three excircles is considered one of the most beautiful results in classical triangle geometry. The natural question of its 3D analogue was studied by Court (1934) and Murakami (1952): for orthocentric tetrahedra, a sphere related to the circumcenter and Monge point should play the role of the nine-point circle. This formalization began with the candidate `(N₂₄, R/3)`-sphere (center = midpoint of circumcenter and Monge point, radius R/3 vs R/2 for the nine-point circle). Numerical experiments (sessions 1–2, April 2026) flagged the candidate as suspect; on 2026-05-02 a closed-form symbolic computation at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) refuted the candidate outright, and the previously sorry-stated tangency theorems were removed. Identifying and formalizing the correct 3D Feuerbach sphere — Murakami's construction uses face circumcircles — remains open.",

--- a/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
@@ -62,7 +62,10 @@
     "assumptions": "1 axiom: slln_necessity. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Law of Large Numbers has two classical forms: the Weak LLN (sample mean converges in probability) and the Strong LLN (sample mean converges almost surely). The earliest proofs used Chebyshev's inequality, requiring finite variance E[X²] < ∞. This created a misconception: that infinite variance implies LLN failure.\n\nIn 1930, Kolmogorov proved the definitive characterization: for i.i.d. random variables, the SLLN holds if and only if E[|X|] < ∞. This is Kolmogorov's classical theorem, now formalized in Mathlib as `ProbabilityTheory.strong_law_ae`.\n\nThe 'open question' is pedagogically important: many textbooks teach Chebyshev's WLLN as THE law of large numbers, leaving students to believe heavy-tailed distributions (where Chebyshev fails) violate the LLN. This formalization corrects that misconception rigorously.",


### PR DESCRIPTION
## Fix

Follow-up to #17266 (which batched 136 entries). These 6 entries were missed by that scan and still have `leanFile.additionalFiles` set without a corresponding mirror in `meta.additionalFiles`.

## Why this matters

The auditor's `find-targets` reads `meta.meta.additionalFiles`, while the gallery convention populates `meta.leanFile.additionalFiles`. When only the `leanFile` copy is set, `find-targets` silently skips the companion file, masking sorry/axiom drift in `*Aristotle.lean`.

Reference: memory `additionalFiles schema split — meta.meta vs meta.leanFile`.

## Evidence

**Before**: `meta.additionalFiles` is null/missing
**After**: `meta.additionalFiles` mirrors `leanFile.additionalFiles`

Entries fixed:
| Slug | Companion file |
|------|----------------|
| binomial-theorem-oq-02-oq-01-oq-01 | Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean |
| chebyshev-bounds-oq-04 | Proofs/ChebyshevBoundsOQ04Aristotle.lean |
| erdos-1018 | Proofs/Erdos1018Aristotle.lean |
| erdos-1056 | Proofs/Erdos1056Aristotle.lean |
| feuerbachs-theorem-oq-02 | Proofs/FeuerbachsTheoremOQ02Aristotle.lean |
| laws-of-large-numbers-oq-01 | Proofs/LawsOfLargeNumbersOQ01Aristotle.lean |

## Validation

- All 6 meta.json files parse as valid JSON
- All 6 referenced companion files exist on disk in `proofs/Proofs/`
- No overlap with open PRs touching these specific meta.json files

---
Automated fix by lean-mechanic agent.