### PR TITLE
fix(meta): mirror lf.additionalFiles into meta block (13 entries)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "additionalFiles": [
+      "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     ],
     "tags": [

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos626Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos626ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos627Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos627ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos628Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos628ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos630Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos630ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos631Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos631ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -11,6 +11,7 @@
     "badge": "original",
     "proofRepoPath": "Proofs/SzemerediCoreOQ01.lean",
     "additionalFiles": [
+      "Proofs/SzemerediCoreOQ01Aristotle.lean",
       "Proofs/SzemerediCore.lean"
     ],
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Follow-up to #17266 (136 entries). PR #17266 mirrored `lf.additionalFiles` into `meta.additionalFiles` for entries where the meta block had no `additionalFiles` field at all.

This batch covers 13 entries that already had a **partial** `meta.additionalFiles` (typically just the Helpers/Core file) but were silently missing the `*Aristotle.lean` companion.

## Why this matters

The auditor's `find-targets.ts` reads `meta.meta.additionalFiles` (not `lf.additionalFiles`) to follow imports across companion files. When meta is missing the Aristotle companion:
- find-targets sibling-follow misses the companion
- sorry/axiom totals can silently exclude companion content
- See feedback memory: *Aristotle companion missing from additionalFiles* (PR #16518) and *additionalFiles schema split — meta.meta vs meta.leanFile*

## Evidence

Each diff is a single insertion of one filename into `meta.additionalFiles`:

| Slug | meta before | meta after |
|------|-------------|-----------|
| ballot-problem-oq-03-oq-01-oq-02 | [Helpers] | [Aristotle, Helpers] |
| binomial-theorem-oq-02-oq-01-oq-01 | (missing) | [Aristotle] |
| chebyshev-bounds-oq-04 | (missing) | [Aristotle] |
| erdos-1018 | (missing) | [Aristotle] |
| erdos-1056 | (missing) | [Aristotle] |
| erdos-626/627/628/630/631 | [GraphCore] | [Aristotle, GraphCore] |
| feuerbachs-theorem-oq-02 | (missing) | [Aristotle] |
| laws-of-large-numbers-oq-01 | (missing) | [Aristotle] |
| szemeredi-core-oq-01 | [SzemerediCore] | [Aristotle, SzemerediCore] |

Surgical edits: 13 files changed, 30 insertions(+), 5 deletions(-). All target files verified to exist on disk.

---
Automated fix by lean-mechanic agent.