### PR TITLE
audit: fix narrative drift in unit-distance-independence (8→12 defs)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13567,9 +13567,9 @@
       "result": "clean"
     },
     "unit-distance-independence": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-24T18:54:30Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-05-08T16:43:19Z",
+      "result": "issues-fixed"
     },
     "vietas-formulas": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -58,7 +58,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Independence number theory for unit distance graphs is formally developed. The Hadwiger-Nelson bounds 5 ≤ χ(ℝ²) ≤ 7 are axiomatized (requiring substantial geometric computation). 65 theorems, 8 definitions, 948 lines, 2 axioms.",
+    "summary": "Independence number theory for unit distance graphs is formally developed. The Hadwiger-Nelson bounds 5 ≤ χ(ℝ²) ≤ 7 are axiomatized (requiring substantial geometric computation). 65 theorems, 12 definitions, 948 lines, 2 axioms.",
     "implications": "The chromatic number of the plane is one of the most tantalizing open problems: known since 1950, with a major breakthrough in 2018 (de Grey's lower bound of 5), yet still unresolved. Formalizing the independence number theory and the axiomatic bounds provides infrastructure for future computational attacks on the problem.",
     "openQuestions": [
       "Prove hadwiger_nelson_lower_bound ≥ 5: formalize de Grey's 1581-vertex construction",


### PR DESCRIPTION
## Audit Summary

**Slug**: unit-distance-independence
**Result**: issues-fixed
**Lean source**: proofs/Proofs/UnitDistanceIndependence.lean

### Issue found

`conclusion.summary` stated "65 theorems, **8 definitions**, 948 lines, 2 axioms" — but the actual definition count is **12**, matching both `meta.definitionCount` and `leanFile.definitionCount`. Severity: LOW (narrative drift only; structured fields were correct).

### Counts verified against origin/main

| Field | Claimed | Actual |
|-------|---------|--------|
| sorries | 0 | 0 |
| axiomCount | 2 | 2 (hadwiger_nelson_lower_bound, hadwiger_nelson_upper_bound) |
| lineCount | 948 | 948 |
| theoremCount | 65 | 65 |
| definitionCount | 12 | 12 |

### Fix

- `src/data/proofs/unit-distance-independence/meta.json` — `conclusion.summary`: "8 definitions" → "12 definitions" (1-line replacement, otherwise byte-identical to origin/main).
- `src/data/proofs/audit-tracker.json` — bump `unit-distance-independence` entry: `auditCount` 2→3, `lastAudited` refreshed, `result` `clean`→`issues-fixed` (4-line replacement).

Status `axiomatized` / badge `axiom` correctly reflects the 2 axioms; assumptions field accurately documents both axioms with provenance (de Grey 2018 lower bound, hexagonal tiling upper bound). No tier classification or wrapper concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)