### PR TITLE
audit: mark erdos-877 clean (counts verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10263,9 +10263,9 @@
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T13:36:35Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T16:46:43Z",
+      "result": "clean"
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Verified Erdos877Problem.lean against meta.json — all counts and narrative are accurate.

## Checks

- sorries: 4 ✓ (matches lf.sorries and meta.sorries)
- axiomCount: 2 ✓ (`cameron_erdos_lower_bound`, `luczak_schoen_theorem`)
- theoremCount: 9 ✓
- definitionCount: 6 ✓
- lineCount: 291 ✓
- status `axiomatized` + badge `axiom` — consistent with 2 axioms + 4 sorries

Companion file `Erdos877ProblemAristotle.lean`: 1 sorry, 0 True stubs.
Narrative (overview, conclusion, originalContributions) correctly attributes
the axiomatized portions to Cameron-Erdős and Łuczak-Schoen. No overclaiming.

Tracker entry updated 2026-04-28 issues-fixed → 2026-05-08 clean.