### PR TITLE
fix(meta): convert string mathlibDependencies to MathlibDependency objects (4 entries)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -35,7 +35,11 @@
       "Concrete verification examples via native_decide"
     ],
     "mathlibDependencies": [
-      "Archive.Wiedijk100Theorems.BallotProblem (Ballot.ballot_problem)"
+      {
+        "theorem": "Ballot.ballot_problem",
+        "description": "Wiedijk #100 ballot problem formalization",
+        "module": "Archive.Wiedijk100Theorems.BallotProblem"
+      }
     ]
   },
   "overview": {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -21,11 +21,26 @@
     "theoremCount": 9,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
-      "Polynomial.IsAlgClosed.degree_eq_card_roots",
-      "Polynomial.aeval_conj",
-      "Complex.conj_ofReal",
-      "Polynomial.eval_map",
-      "Complex.normSq_apply"
+      {
+        "theorem": "Polynomial.IsAlgClosed.degree_eq_card_roots",
+        "description": "Over an algebraically closed field, degree equals the cardinality of the multiset of roots"
+      },
+      {
+        "theorem": "Polynomial.aeval_conj",
+        "description": "Compatibility of algebra evaluation with complex conjugation"
+      },
+      {
+        "theorem": "Complex.conj_ofReal",
+        "description": "Conjugation fixes real numbers embedded in ℂ"
+      },
+      {
+        "theorem": "Polynomial.eval_map",
+        "description": "Evaluation of a polynomial mapped through a ring hom"
+      },
+      {
+        "theorem": "Complex.normSq_apply",
+        "description": "Squared norm formula for ℂ"
+      }
     ],
     "definitionCount": 0
   },

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -22,7 +22,11 @@
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
-      "Mathlib.Algebra.Group.Basic"
+      {
+        "theorem": "sub_eq_zero",
+        "description": "x - y = 0 ↔ x = y; used in singleton {a} ⊂ ℚ Σ₁-definability via shift polynomial P(q,x) = q - a",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
     ],
     "originalContributions": [
       "IsDiophantineDefinition: Σ₁ (purely existential) definability of subsets of ℚ",

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -24,7 +24,23 @@
     "lineCount": 249,
     "theoremCount": 8,
     "definitionCount": 3,
-    "mathlibDependencies": ["Mathlib.Tactic", "Mathlib.Data.Finset.Basic", "Mathlib.Data.Fin.Basic"],
+    "mathlibDependencies": [
+      {
+        "theorem": "(general tactics)",
+        "description": "Standard tactic library",
+        "module": "Mathlib.Tactic"
+      },
+      {
+        "theorem": "Finset.basic",
+        "description": "Finite sets API",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Fin.basic",
+        "description": "Finite types Fin n API",
+        "module": "Mathlib.Data.Fin.Basic"
+      }
+    ],
     "originalContributions": [
       "Formal definition of n-part partitions as sorted Fin n → ℕ functions",
       "IndexTriple structure encoding r-element subset triples (I, J, K)",


### PR DESCRIPTION
## Summary

Site build was failing with TS2352 on `hilbert-10-oq-01-oq-02/index.ts`:

```
The types of 'meta.mathlibDependencies' are incompatible
Type 'string[]' is not comparable to type 'MathlibDependency[]'.
```

Four meta.json entries had `mathlibDependencies` authored as `string[]`, but the schema in `src/types/proof.ts` expects `MathlibDependency[]` (`{theorem, description, module?}`).

## Fixes

- `hilbert-10-oq-01-oq-02` — `["Mathlib.Algebra.Group.Basic"]` → 1 obj (`sub_eq_zero`)
- `hilbert-15-oq-02-oq-03` — 3 module strings → 3 objs (Tactic/Finset/Fin)
- `descartes-rule-of-signs-oq-01-oq-01` — 5 theorem-name strings → 5 objs (Polynomial/Complex)
- `ballot-problem-oq-01-oq-02` — 1 string → 1 obj (`Ballot.ballot_problem`)

## Test plan

- [x] `tsc -p . --noEmit` passes locally
- [x] Site build (deployer pipeline) — to be verified after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)