### PR TITLE
research(hilbert-10-oq-01-oq-02): S9 — Σ₁ closed under binary union, Π₁ under binary intersection (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -65,6 +65,10 @@ import Proofs.Hilbert10OQ01
 -- This is the first Mathlib import in this file; iterations 1–7 were
 -- entirely zero-Mathlib (Path A discipline). See state.md for context.
 import Mathlib.Algebra.Group.Basic
+-- S9 (iter 9, Path B): `mul_eq_zero` (and `zero_mul` / `mul_zero`) on ℚ
+-- for closure of Σ₁ under binary union and Π₁ under binary intersection.
+-- ℚ is a field, hence `NoZeroDivisors`, so `mul_eq_zero` applies.
+import Mathlib.Algebra.GroupWithZero.Basic
 
 namespace Hilbert10Rationals
 
@@ -845,6 +849,142 @@ theorem singletonOf_zero_isDiophantineDefinition :
   singletonOf_isDiophantineDefinition 0
 
 -- ============================================================
+-- Part VIII.10 (iter 9, Path B): Σ₁ closed under binary union;
+--                                Π₁ closed under binary intersection
+-- ============================================================
+
+/-- Iter 9, Path B: **the Σ₁ class is closed under binary union**.
+
+    If `S₁` and `S₂` are both Σ₁-definable over ℚ, then so is the
+    pointwise disjunction `fun q => S₁ q ∨ S₂ q`.
+
+    Witness: the product polynomial `P(q, x) = P₁(q, x) · P₂(q, x)`,
+    where `P₁` and `P₂` are the witnesses for `S₁` and `S₂` respectively
+    (both witnesses share the same infinite variable assignment block,
+    which is fine for union — the existential quantifier is OR-ed across
+    which factor vanishes).
+
+    The Σ₁ side uses the fact that a single `x` makes the product zero
+    iff it makes one of the factors zero (`mul_eq_zero` over ℚ;
+    `NoZeroDivisors` from ℚ being a field). Specifically:
+
+    * Forward (`S₁ q ∨ S₂ q → ∃ x, P₁(q,x)·P₂(q,x) = 0`): pick the
+      witness `x` for whichever side holds and use `zero_mul` /
+      `mul_zero` to conclude the product vanishes.
+    * Reverse (`∃ x, P₁(q,x)·P₂(q,x) = 0 → S₁ q ∨ S₂ q`): apply
+      `mul_eq_zero` at the witness to split into `P₁(q,x) = 0` or
+      `P₂(q,x) = 0`, and feed back through `(hP_i q).mpr`.
+
+    Path B (Mathlib): adds `Mathlib.Algebra.GroupWithZero.Basic` for
+    `mul_eq_zero` (no other API surfaces). No new axioms.
+
+    By iterating over a finite list, this lifts to closure under any
+    *finite* union. The OPEN Σ₁ question for ℤ ⊂ ℚ is precisely the
+    question of whether finite-union closure extends to *countable*
+    union along the family of singletons `{n} : n : ℤ` (each of which
+    is Σ₁ by `singletonOf_isDiophantineDefinition` from S8). -/
+theorem union_isDiophantineDefinition
+    {S₁ S₂ : RatSubset}
+    (h₁ : IsDiophantineDefinition S₁) (h₂ : IsDiophantineDefinition S₂) :
+    IsDiophantineDefinition (fun q => S₁ q ∨ S₂ q) := by
+  obtain ⟨P₁, hP₁⟩ := h₁
+  obtain ⟨P₂, hP₂⟩ := h₂
+  refine ⟨fun q x => (P₁ q x) * (P₂ q x), fun q => ?_⟩
+  constructor
+  · rintro (hS₁ | hS₂)
+    · obtain ⟨x, hx⟩ := (hP₁ q).mp hS₁
+      exact ⟨x, by rw [hx, zero_mul]⟩
+    · obtain ⟨x, hx⟩ := (hP₂ q).mp hS₂
+      exact ⟨x, by rw [hx, mul_zero]⟩
+  · rintro ⟨x, hx⟩
+    rcases mul_eq_zero.mp hx with hzero | hzero
+    · exact Or.inl ((hP₁ q).mpr ⟨x, hzero⟩)
+    · exact Or.inr ((hP₂ q).mpr ⟨x, hzero⟩)
+
+/-- Iter 9, Path B: **the Π₁ class is closed under binary intersection**.
+
+    If `S₁` and `S₂` are both Π₁-definable over ℚ, then so is the
+    pointwise conjunction `fun q => S₁ q ∧ S₂ q`.
+
+    Direct dual of `union_isDiophantineDefinition`: the same product
+    polynomial `P(q, x) = P₁(q, x) · P₂(q, x)` works as the Π₁ witness,
+    via `mul_eq_zero` (in its contrapositive form: a product is nonzero
+    iff each factor is nonzero, applied at every `x`).
+
+    Concretely:
+
+    * Forward (`S₁ q ∧ S₂ q → ∀ x, P₁(q,x)·P₂(q,x) ≠ 0`): if both `S_i q`
+      hold, then by `(hP_i q).mp`, neither `P_i q` admits a rational
+      solution; for any `x`, if `P₁(q,x)·P₂(q,x) = 0` then by
+      `mul_eq_zero` one factor is zero, contradicting one of the `(hP_i q).mp` hypotheses.
+    * Reverse (`(∀ x, P₁(q,x)·P₂(q,x) ≠ 0) → S₁ q ∧ S₂ q`): if any single
+      factor `P_i q x = 0`, multiplying by zero on the other side gives
+      the product zero, contradicting the universal nonvanishing.
+
+    Path B (Mathlib): same import as union closure. No new axioms.
+
+    By iterating over a finite list, this lifts to closure of Π₁ under
+    any *finite* intersection — the dual statement to finite-union
+    closure of Σ₁. -/
+theorem intersection_isCoDiophantineDefinition
+    {S₁ S₂ : RatSubset}
+    (h₁ : IsCoDiophantineDefinition S₁) (h₂ : IsCoDiophantineDefinition S₂) :
+    IsCoDiophantineDefinition (fun q => S₁ q ∧ S₂ q) := by
+  obtain ⟨P₁, hP₁⟩ := h₁
+  obtain ⟨P₂, hP₂⟩ := h₂
+  refine ⟨fun q x => (P₁ q x) * (P₂ q x), fun q => ?_⟩
+  constructor
+  · rintro ⟨hS₁, hS₂⟩ ⟨x, hx⟩
+    rcases mul_eq_zero.mp hx with hzero | hzero
+    · exact ((hP₁ q).mp hS₁) ⟨x, hzero⟩
+    · exact ((hP₂ q).mp hS₂) ⟨x, hzero⟩
+  · intro hnsol
+    refine ⟨?_, ?_⟩
+    · apply (hP₁ q).mpr
+      rintro ⟨x, hx⟩
+      exact hnsol ⟨x, by rw [hx, zero_mul]⟩
+    · apply (hP₂ q).mpr
+      rintro ⟨x, hx⟩
+      exact hnsol ⟨x, by rw [hx, mul_zero]⟩
+
+/-- Iter 9 corollary, Path B: **every pair `{a, b} ⊂ ℚ` is Σ₁-definable**
+    for any `a, b : ℚ`.
+
+    Direct application of `union_isDiophantineDefinition` to the two S8
+    singleton witnesses `singletonOf_isDiophantineDefinition a` and
+    `singletonOf_isDiophantineDefinition b`. -/
+theorem singletonPair_isDiophantineDefinition (a b : Rat) :
+    IsDiophantineDefinition (fun q : Rat => q = a ∨ q = b) :=
+  union_isDiophantineDefinition (singletonOf_isDiophantineDefinition a)
+    (singletonOf_isDiophantineDefinition b)
+
+/-- Iter 9 corollary, Path B: **every "complement-of-a-pair"
+    `ℚ \ {a, b}` is Π₁-definable** for any `a, b : ℚ`.
+
+    Direct application of `intersection_isCoDiophantineDefinition` to
+    the two S8 co-singleton witnesses
+    `notSingletonOf_isCoDiophantineDefinition a` and `... b`. -/
+theorem notSingletonPair_isCoDiophantineDefinition (a b : Rat) :
+    IsCoDiophantineDefinition (fun q : Rat => q ≠ a ∧ q ≠ b) :=
+  intersection_isCoDiophantineDefinition
+    (notSingletonOf_isCoDiophantineDefinition a)
+    (notSingletonOf_isCoDiophantineDefinition b)
+
+/-- Iter 9 corollary, Path B: **every pair `{a, b}` is Π₂-definable**
+    via the trivial inclusion `Σ₁ ⊆ Π₂`. -/
+theorem singletonPair_isUniversalExistentialDefinition (a b : Rat) :
+    IsUniversalExistentialDefinition (fun q : Rat => q = a ∨ q = b) :=
+  diophantine_implies_universal_existential _
+    (singletonPair_isDiophantineDefinition a b)
+
+/-- Iter 9 corollary, Path B: **every complement-of-a-pair `ℚ \ {a, b}`
+    is Σ₂-definable** via the trivial inclusion `Π₁ ⊆ Σ₂`. -/
+theorem notSingletonPair_isExistentialUniversalDefinition (a b : Rat) :
+    IsExistentialUniversalDefinition (fun q : Rat => q ≠ a ∧ q ≠ b) :=
+  codiophantine_implies_existentialUniversal _
+    (notSingletonPair_isCoDiophantineDefinition a b)
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -901,6 +1041,18 @@ open gap is Σ₁ vs Π₂ (equivalently, Π₁(complement) vs Σ₂(complement)
   (and finite intersection) but NOT known to be closed under countable
   union (the OPEN Σ₁ question for ℤ is precisely the question of whether
   this particular countable union admits a uniform Σ₁ witness).
+- **Σ₁ is closed under binary union; Π₁ is closed under binary intersection**
+  (iter 9): the same product polynomial witness `P(q, x) = P₁(q, x)·P₂(q, x)`
+  serves both — `mul_eq_zero` over ℚ provides the bridge in both
+  directions. Two concrete corollaries: every PAIR `{a, b} ⊂ ℚ` is
+  Σ₁-definable, every "complement-of-a-pair" `ℚ \ {a, b}` is
+  Π₁-definable, for any `a, b : ℚ`. By an obvious induction on a finite
+  list, finite *unions* of singletons (i.e., any FINITE subset of ℚ) are
+  Σ₁-definable. The OPEN Σ₁ question for ℤ ⊂ ℚ thus reduces precisely
+  to whether the countable union `⋃_{n : ℤ} {n}` admits a *uniform*
+  polynomial witness — finite truncations `⋃_{n : ℤ ∩ [-N, N]} {n}` are
+  Σ₁-definable for every finite `N`, but the limit `N → ∞` requires a
+  single polynomial whose existence is the OPEN content.
 
 ## Axioms in THIS file (1 net new)
 
@@ -912,7 +1064,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (40)
+## Theorems in THIS file (46)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -954,6 +1106,12 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `singletonOf_isUniversalExistentialDefinition a` ({a} is Π₂ for any a : ℚ, iter 8 Path B)
   - `notSingletonOf_isExistentialUniversalDefinition a` (ℚ\{a} is Σ₂ for any a : ℚ, iter 8 Path B)
   - `singletonOf_zero_isDiophantineDefinition` (S6 recovered as a = 0 instance, iter 8)
+  - `union_isDiophantineDefinition` (Σ₁ closed under binary union, iter 9 Path B)
+  - `intersection_isCoDiophantineDefinition` (Π₁ closed under binary intersection, iter 9 Path B)
+  - `singletonPair_isDiophantineDefinition a b` ({a, b} ⊂ ℚ is Σ₁ for any a, b : ℚ, iter 9)
+  - `notSingletonPair_isCoDiophantineDefinition a b` (ℚ\{a, b} is Π₁ for any a, b : ℚ, iter 9)
+  - `singletonPair_isUniversalExistentialDefinition a b` ({a, b} is Π₂, iter 9)
+  - `notSingletonPair_isExistentialUniversalDefinition a b` (ℚ\{a, b} is Σ₂, iter 9)
 -/
 
 #check @IsDiophantineDefinition
@@ -995,5 +1153,11 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @singletonOf_isUniversalExistentialDefinition
 #check @notSingletonOf_isExistentialUniversalDefinition
 #check @singletonOf_zero_isDiophantineDefinition
+#check @union_isDiophantineDefinition
+#check @intersection_isCoDiophantineDefinition
+#check @singletonPair_isDiophantineDefinition
+#check @notSingletonPair_isCoDiophantineDefinition
+#check @singletonPair_isUniversalExistentialDefinition
+#check @notSingletonPair_isExistentialUniversalDefinition
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -2,109 +2,105 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T18:30:00Z
-**Iteration**: 8
-**Last Updated**: 2026-05-08 (researcher-5)
+**Iteration**: 9
+**Last Updated**: 2026-05-08 (researcher-9)
 
 ## Current Focus
 
-Iteration 8 (2026-05-08, researcher-5, this PR): **arbitrary singletons
-`{a} ⊂ ℚ` for `a : ℚ`** — the proper generalization of S6's
-`singletonZero_isDiophantineDefinition`. The witness is the **shift
-polynomial** `P(q, x) = q - a` (constant in the variable `x`); its zero
-set in `q` is exactly `{a}`. From this base case the four-class
-placement of `{a}` (resp. `ℚ \ {a}`) into Σ₁/Π₁/Π₂/Σ₂ falls out via
-the trivial inclusions established in earlier iterations:
+Iteration 9 (2026-05-08, researcher-9, this PR): **closure of Σ₁ under
+binary union and Π₁ under binary intersection** via the **product
+polynomial witness**
 
-    {a} : Σ₁ (this PR), and hence Π₂ via Σ₁ ⊆ Π₂ (iter 4)
-    ℚ\{a} : Π₁ (this PR), and hence Σ₂ via Π₁ ⊆ Σ₂ (iter 4)
+    P(q, x) = P₁(q, x) · P₂(q, x)
 
-Net new content: 1 definition (`shiftPoly`, private), 5 theorems,
-0 axioms.
-Updated to total: 12 definitions (incl. 4 private), 44 theorems (incl.
-4 private), 1 axiom, 0 sorries, 999 lines (was 885).
+where `P₁` and `P₂` are the witnesses for `S₁` and `S₂` respectively
+(both polynomials share the same infinite variable assignment block).
 
-S6 (`singletonZero_isDiophantineDefinition`) is recovered as the special
-case `a = 0` of the new family, documented as the corollary
-`singletonOf_zero_isDiophantineDefinition`. S6 is NOT replaced: the S6
-witness `parameterPoly = fun _ => q` is leaner than the S8 witness
-`shiftPoly 0 = fun _ => q - 0` (S6 avoids subtraction entirely), so
-S6 remains the preferred Path A witness for the special case `{0}`.
+The same product polynomial serves both directions:
 
-## Architectural Note (Path A → Path B)
+* **Union (Σ₁)**: `∃ x, P₁(q,x)·P₂(q,x) = 0  ⟺  (∃ x, P₁(q,x) = 0) ∨
+  (∃ x, P₂(q,x) = 0)`. Both directions trivial — for the forward (∨ →
+  ∃), pick the existential witness for whichever side holds and use
+  `zero_mul` / `mul_zero`; for the reverse (∃ → ∨), apply `mul_eq_zero`
+  at the witness.
+* **Intersection (Π₁)**: `(∀ x, P₁(q,x)·P₂(q,x) ≠ 0)  ⟺  (∀ x, P₁(q,x) ≠ 0)
+  ∧ (∀ x, P₂(q,x) ≠ 0)`. The universal "splits" across the conjunction
+  — same `mul_eq_zero` (in its contrapositive form) does the work.
 
-Iterations 1–7 maintained a **zero-Mathlib (Path A)** discipline,
-relying only on Lean core for arithmetic and on classical excluded
-middle for the duality theorems. Iteration 8 introduces the **first
-Mathlib import** in this file: `Mathlib.Algebra.Group.Basic` for the
-single lemma `sub_eq_zero : a - b = 0 ↔ a = b`. This is the minimal
-import needed to prove that `q - a = 0 ↔ q = a` over `ℚ`.
+The Mathlib API surface is one new lemma — `mul_eq_zero` over ℚ — and
+the elementary `zero_mul` / `mul_zero`. ℚ is a field, hence
+`NoZeroDivisors`, so `mul_eq_zero` applies. Adds the import
+`Mathlib.Algebra.GroupWithZero.Basic` (the **second** Mathlib import
+in this file, after S8's `Mathlib.Algebra.Group.Basic`).
 
-This is the deliberate Path B transition flagged at the end of S7's
-state.md: "The Path A axiom-free corner of the file is now substantially
-saturated; further single-PR progress without Mathlib is incrementally
-smaller." The Mathlib import unlocks the genuine generalization to
-arbitrary `a : ℚ` (S8) and the closure properties (union, intersection,
-Π₁ ⊆ Π₂ via polynomial inversion) targeted for S9+.
+Two main theorems plus four concrete corollaries:
 
-## Active Approach
+  1. `union_isDiophantineDefinition` — Σ₁ is closed under binary union.
+  2. `intersection_isCoDiophantineDefinition` — Π₁ is closed under
+     binary intersection.
+  3. `singletonPair_isDiophantineDefinition a b` — every PAIR
+     `{a, b} ⊂ ℚ` is Σ₁-definable (corollary of #1 applied to two S8
+     `singletonOf` witnesses).
+  4. `notSingletonPair_isCoDiophantineDefinition a b` — every
+     complement-of-pair `ℚ \ {a, b}` is Π₁-definable (corollary of #2).
+  5. `singletonPair_isUniversalExistentialDefinition a b` — every PAIR
+     `{a, b}` is Π₂-definable (corollary via Σ₁ ⊆ Π₂).
+  6. `notSingletonPair_isExistentialUniversalDefinition a b` — every
+     complement-of-pair is Σ₂-definable (corollary via Π₁ ⊆ Σ₂).
 
-S8 — arbitrary singletons (this iteration):
+Net new content: 0 definitions, 6 theorems, 0 axioms.
+Updated total: 12 definitions (incl. 4 private), 50 theorems (incl.
+4 private), 1 axiom, 0 sorries, 1163 lines (was 999).
 
-1. `shiftPoly a` (private def) — the shift polynomial `fun q _ => q - a`
-   for `a : ℚ`, generalizing S6's `parameterPoly = fun q _ => q`.
-2. `singletonOf_isDiophantineDefinition (a : Rat)` —
-   `IsDiophantineDefinition (fun q => q = a)`. Proof: `refine ⟨shiftPoly a, fun q => ?_⟩` then a 2-line term using `sub_eq_zero.mpr`/`.mp` to convert between `q - a = 0` and `q = a`.
-3. `notSingletonOf_isCoDiophantineDefinition (a : Rat)` —
-   `IsCoDiophantineDefinition (fun q => q ≠ a)`. Direct dual via the
-   same polynomial witness; same `sub_eq_zero` bridge.
-4. `singletonOf_isUniversalExistentialDefinition (a : Rat)` —
-   `IsUniversalExistentialDefinition (fun q => q = a)`. One-line
-   corollary via `diophantine_implies_universal_existential` (iter 1).
-5. `notSingletonOf_isExistentialUniversalDefinition (a : Rat)` —
-   `IsExistentialUniversalDefinition (fun q => q ≠ a)`. One-line
-   corollary via `codiophantine_implies_existentialUniversal` (iter 4).
-6. `singletonOf_zero_isDiophantineDefinition` — the special case `a = 0`
-   of #2, recovering S6's predicate; documents the S6 → S8
-   generalization without claiming S8 is leaner for the `a = 0` case.
+## Sharpening of the OPEN Σ₁ Question
 
-The two `theorem`s with `by`-tactic proofs (#2, #3) each consist of one
-`refine ⟨shiftPoly a, fun q => ?_⟩` step followed by a 2-line term
-combining the existential witness `fun _ => 0` with `sub_eq_zero`. The
-three corollaries (#4, #5, #6) are pure term-mode one-liners.
+The S9 closure theorems make precise the boundary of what S8 + S9
+reach. Combining them with finite induction:
 
-## Why this matters
+    every FINITE subset {a₀, a₁, …, a_k} ⊂ ℚ is Σ₁-definable
 
-The four singleton-of-`a` theorems make precise that **Σ₁-definability
-is closed under "rational shifts of a fixed Σ₁ subset"** at the level of
-the polynomial witness. In the family `{a} : a : ℚ`, every individual
-member is Σ₁-definable, but the OPEN Σ₁ question for ℤ ⊂ ℚ is NOT
-immediately settled by viewing ℤ as a *family* of singletons `{n}` for
-`n : ℤ`. The reason: Σ₁-definability is closed under finite union (and
-finite intersection) — see closure properties to be added in S9+ — but
-NOT known to be closed under countable union. The OPEN Σ₁ question is
-precisely the question of whether the countable union `⋃_{n : ℤ} {n}`
-admits a single uniform polynomial witness `P(t, x₁, …, x_k)` whose
-rational-solution slices recover `t ∈ ℤ`.
+(Sketch: by induction on `k`, using S8 `singletonOf_isDiophantineDefinition`
+for the base and S9 `union_isDiophantineDefinition` for the step.
+This is straightforward but not formalized in this PR — left as S10.3.)
 
-So this iteration sharpens the OPEN-question landscape by exhibiting
-the smallest piece of the answer that *can* be assembled — every
-individual `{n}` for `n : ℤ` is Σ₁-definable as a member of the
-parametric family `singletonOf_isDiophantineDefinition`. The
-non-uniform "case-by-case" Σ₁-definability of each integer is settled;
-the OPEN content is the existence of a *uniform* polynomial witness.
+The OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to the question:
+
+    is the COUNTABLE union ⋃_{n : ℤ} {n} Σ₁-definable in ℚ?
+
+i.e., does there exist a SINGLE polynomial `P(t, x₁, …, x_k) ∈ ℚ[t,x]`
+whose rational-solution slices simultaneously witness `t = n` for every
+`n : ℤ`. **Finite truncations** `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` are Σ₁-definable
+for every finite `N` (corollary of S8 + S9), so the OPEN content is
+*precisely the limit `N → ∞`*: a uniform polynomial witness whose
+existence is the question.
+
+This is the cleanest restatement of the OPEN Σ₁ question yet:
+
+* The non-uniform "case-by-case" Σ₁-definability of each integer is
+  settled (S8): `{n}` is Σ₁ for every `n : ℤ ⊂ ℚ`.
+* The non-uniform "any finite collection" Σ₁-definability is settled
+  (S9 + induction): `{n₀, n₁, …, n_k}` is Σ₁ for every finite list
+  `n₀, n₁, …, n_k : ℤ`.
+* The **uniform** Σ₁-definability of all of ℤ is the OPEN question:
+  no single polynomial is known to witness `t ∈ ℤ` for all `t : ℚ`.
 
 ## Build Status
 
-Iteration 8 build: PENDING. Worktree's `proofs/.lake` is a recursive
+Iteration 9 build: PENDING. Worktree's `proofs/.lake` is a recursive
 self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so a
-local Docker build would re-fresh-clone Mathlib (~25-45 min) and the
-new `Mathlib.Algebra.Group.Basic` import adds modest extra compilation.
-The two `by`-tactic proofs use only `refine`, `exact`, an existential
-witness `fun _ => 0`, and the Mathlib lemma `sub_eq_zero` (`.mp` and
-`.mpr` directions). The three corollaries are pure term mode. No new
-imports beyond `Mathlib.Algebra.Group.Basic`. Confidence high; CI is
-the ground truth.
+local Docker build would re-fresh-clone Mathlib (~25-45 min). The new
+import `Mathlib.Algebra.GroupWithZero.Basic` is small (it sits below
+`Mathlib.Algebra.Field.Basic` in the import graph, modest extra
+compilation). The two `by`-tactic proofs use only `refine`, `obtain`,
+`rcases`, `rintro`, `exact`, `rw`, and the Mathlib lemmas
+`mul_eq_zero` (.mp), `zero_mul`, `mul_zero`. The four corollaries are
+pure term mode (one `union_isDiophantineDefinition` /
+`intersection_isCoDiophantineDefinition` application + one
+`diophantine_implies_universal_existential` /
+`codiophantine_implies_existentialUniversal` lift). No new axioms.
+Confidence high; CI is the ground truth.
 
+Iteration 8 build: PASSED ✅ (per #17219 CI).
 Iteration 7 build: PASSED ✅ (per #17125 CI).
 Iteration 6 build: PASSED ✅ (per #17083 CI).
 Iteration 5 build: PASSED ✅ (per #17065 CI).
@@ -113,44 +109,41 @@ Iteration 3 build: PASSED ✅ (3 jobs, exit code 0).
 
 ## Blockers
 
-None for the singleton-of-`a` story. S9+ extensions:
-- Closure under union: needs `mul_eq_zero` (Mathlib —
-  `Mathlib.Algebra.GroupWithZero.Basic` or similar) for the witness
-  `P(q, x, y) = P₁(q, x) · P₂(q, y)`.
-- Closure under intersection: needs sum-of-squares positivity over `ℚ`
-  for the witness `P(q, x, y) = P₁(q, x)² + P₂(q, y)²`. Mathlib has
-  `add_pow_le_pow_mul_pow_of_sq` and friends but the elementary
-  `a² + b² = 0 ↔ a = 0 ∧ b = 0` over an ordered field is the cleaner
-  primitive.
-- Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a · z = 1`
-  — needs `Rat` field arithmetic.
+None for the binary-union / binary-intersection story. S10+ extensions:
+
+- **S10.1**: Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a·z = 1`
+  — needs `Rat` field arithmetic (`mul_inv`, `mul_inv_cancel` from
+  Mathlib's field library).
+- **S10.2**: Σ₁ closure under binary INTERSECTION via sum-of-squares
+  witness `P(q, x, y) = P₁(q, x)² + P₂(q, y)²`. Requires:
+  (a) `a² + b² = 0 ↔ a = 0 ∧ b = 0` over an ordered field (Mathlib has
+  this via `add_sq_eq_zero_iff_of_nonneg` and friends);
+  (b) a packing-trick to use disjoint variable indices for `x` and `y`,
+  since the SAME variable assignment block won't work for intersection
+  (where we need both factors to vanish at the SAME polynomial value).
+- **S10.3**: `finUnion_singletons_isDiophantineDefinition` — by induction
+  on a finite list of rationals (extending S9's binary pair to `k`-tuple),
+  every FINITE subset of ℚ is Σ₁-definable. Makes precise the
+  uniform/non-uniform boundary discussed above.
 
 ## Next Action
 
-Commit, push, create PR for iteration 8 (this).
+Commit, push, create PR for iteration 9 (this).
 
-If S8 lands cleanly, S9+ candidates:
-- **S9 (Path B continuation)**: closure of Σ₁ under finite union via
-  the product-of-polynomials witness. Single new lemma; uses
-  `mul_eq_zero` (one more Mathlib import).
-- **S9 (Path B continuation)**: closure of Σ₁ under finite intersection
-  via the sum-of-squares witness. Needs `a² + b² = 0 ↔ a = 0 ∧ b = 0`
-  over an ordered field.
-- **S10**: Π₁ ⊆ Π₂ via polynomial inversion (`a ≠ 0 ⟺ ∃ z, a·z = 1`)
-  — completes the four-corner inclusion picture (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂,
-  Σ₁ ⊆ Π₂ via inversion, Π₁ ⊆ Π₂ via inversion).
-- **S10+**: `IntSubset` exhibited as a *finite-union limit* of
-  `singletonOf` along `Int.cast : Int → Rat` — the explicit union
-  `⋃_{n : ℤ ∩ [-N, N]} {n}` is Σ₁-definable for each finite `N` (a
-  corollary of S9 union closure). The OPEN content is the limit
-  `N → ∞` (uniform vs. non-uniform witness).
-- **S11+**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
+If S9 lands cleanly, S10+ candidates (in priority order):
+
+- **S10.1**: Π₁ ⊆ Π₂ via polynomial inversion (`a ≠ 0 ⟺ ∃ z, a·z = 1`).
+- **S10.2**: Σ₁ closure under finite INTERSECTION via sum-of-squares.
+- **S10.3**: `finUnion_singletons_isDiophantineDefinition` — every
+  finite subset of ℚ is Σ₁-definable (corollary of S8 + S9 by induction).
+- **S10.4**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
   separate axiomatized witness — adds 1 axiom, documentary value only.
 
 ## Attempt Counts
 
-- Total attempts: 8
-- Current approach attempts: 1 (S8 — arbitrary singletons, this iteration)
-- Approaches tried: 7 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+- Total attempts: 9
+- Current approach attempts: 1 (S9 — binary union/intersection closure)
+- Approaches tried: 8 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
   congruence, S5 symmetric duality + trivial sets, S6 smallest
-  non-trivial subset, S7 ¬¬-shadow, S8 arbitrary singletons)
+  non-trivial subset, S7 ¬¬-shadow, S8 arbitrary singletons, S9 binary
+  union/intersection closure)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -24,8 +24,23 @@
     "mathlibDependencies": [
       {
         "theorem": "sub_eq_zero",
-        "description": "x - y = 0 ↔ x = y; used in singleton {a} ⊂ ℚ Σ₁-definability via shift polynomial P(q,x) = q - a",
+        "description": "x - y = 0 ↔ x = y; used in singleton {a} ⊂ ℚ Σ₁-definability via shift polynomial P(q,x) = q - a (S8)",
         "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "mul_eq_zero",
+        "description": "a * b = 0 ↔ a = 0 ∨ b = 0 (NoZeroDivisors); ℚ is a field. Used in S9 binary union closure of Σ₁ and binary intersection closure of Π₁ via the product polynomial witness P(q,x) = P₁(q,x)·P₂(q,x).",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "zero_mul",
+        "description": "0 * a = 0 over MulZeroClass; used in the forward direction of S9 union closure (when P₁(q,x) = 0, the product P₁·P₂ vanishes at the same x).",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "mul_zero",
+        "description": "a * 0 = 0 over MulZeroClass; symmetric counterpart of zero_mul, used analogously in S9 union closure when P₂(q,x) = 0.",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
       }
     ],
     "originalContributions": [
@@ -60,11 +75,17 @@
       "notSingletonOf_isCoDiophantineDefinition: every complement ℚ \\ {a} is Π₁-definable for arbitrary a : ℚ via the same shift polynomial (iter 8 Path B, dual of singletonOf)",
       "singletonOf_isUniversalExistentialDefinition: every {a} ⊂ ℚ is Π₂-definable, corollary of Σ₁ membership via Σ₁ ⊆ Π₂ (iter 8 Path B)",
       "notSingletonOf_isExistentialUniversalDefinition: every ℚ \\ {a} is Σ₂-definable, corollary of Π₁ membership via Π₁ ⊆ Σ₂ (iter 8 Path B)",
-      "singletonOf_zero_isDiophantineDefinition: documents that S6's singletonZero is recovered as the a = 0 instance of S8's parametric singletonOf family (iter 8)"
+      "singletonOf_zero_isDiophantineDefinition: documents that S6's singletonZero is recovered as the a = 0 instance of S8's parametric singletonOf family (iter 8)",
+      "union_isDiophantineDefinition: Σ₁ class is closed under binary union — for any two Σ₁-definable subsets S₁, S₂ ⊂ ℚ, the disjunction `fun q => S₁ q ∨ S₂ q` is Σ₁-definable, witnessed by the product polynomial P(q,x) = P₁(q,x)·P₂(q,x) (iter 9 Path B; uses mul_eq_zero from Mathlib.Algebra.GroupWithZero.Basic; no new axioms)",
+      "intersection_isCoDiophantineDefinition: Π₁ class is closed under binary intersection — for any two Π₁-definable subsets S₁, S₂ ⊂ ℚ, the conjunction `fun q => S₁ q ∧ S₂ q` is Π₁-definable, witnessed by the same product polynomial (iter 9 Path B, dual of union closure)",
+      "singletonPair_isDiophantineDefinition: every PAIR {a, b} ⊂ ℚ is Σ₁-definable for arbitrary a, b : ℚ (iter 9 Path B; corollary of union closure applied to two S8 singleton witnesses)",
+      "notSingletonPair_isCoDiophantineDefinition: every complement-of-pair ℚ \\ {a, b} is Π₁-definable for arbitrary a, b : ℚ (iter 9 Path B; corollary of intersection closure)",
+      "singletonPair_isUniversalExistentialDefinition: every PAIR {a, b} ⊂ ℚ is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (iter 9)",
+      "notSingletonPair_isExistentialUniversalDefinition: every complement-of-pair ℚ \\ {a, b} is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (iter 9)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 999,
+    "lineCount": 1163,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -72,7 +93,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 44,
+    "theoremCount": 50,
     "definitionCount": 12
   },
   "overview": {
@@ -197,13 +218,14 @@
   "leanFile": {
     "imports": [
       "Proofs.Hilbert10OQ01",
-      "Mathlib.Algebra.Group.Basic"
+      "Mathlib.Algebra.Group.Basic",
+      "Mathlib.Algebra.GroupWithZero.Basic"
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 999,
+    "lineCount": 1163,
     "axiomCount": 1,
-    "theoremCount": 44,
+    "theoremCount": 50,
     "definitionCount": 12,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
@@ -305,6 +327,16 @@
       "name": "koenigsmann_implies_complement_existentialUniversal",
       "type": "theorem",
       "description": "Corollary of Koenigsmann via Σ₂/Π₂ duality: ℚ \\ ℤ is Σ₂-definable in ℚ (no new axiom)"
+    },
+    {
+      "name": "union_isDiophantineDefinition",
+      "type": "theorem",
+      "description": "Σ₁ closed under binary union: if S₁, S₂ are Σ₁-definable, so is `fun q => S₁ q ∨ S₂ q`. Witness: product polynomial P₁(q,x)·P₂(q,x); uses mul_eq_zero (iter 9 Path B)"
+    },
+    {
+      "name": "intersection_isCoDiophantineDefinition",
+      "type": "theorem",
+      "description": "Π₁ closed under binary intersection: if S₁, S₂ are Π₁-definable, so is `fun q => S₁ q ∧ S₂ q`. Same product polynomial witness, dual of union closure (iter 9 Path B)"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -38,18 +38,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T06:00:00.000Z",
-    "iteration": 4,
-    "focus": "Phase-2 ACT iteration 4 (this PR, researcher-1): completes the propositional-equivalence congruence story for all four definability classes. Adds three theorems analogous to iteration 3's `universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence): `diophantineDefinition_iff_of_pred_iff` (Σ₁), `coDiophantineDefinition_iff_of_pred_iff` (Π₁), and `existentialUniversalDefinition_iff_of_pred_iff` (Σ₂). All three follow the same `(h q).symm.trans (hP q)` two-line template; mechanical but completes the four-class symmetry. Net: +3 theorems, 0 defs, 0 axioms. Total 526 lines (was 462), 16 theorems (was 13), 8 defs, 1 axiom, 0 sorries. Build pending (CI). Iteration 3 (researcher-9 session 2, 2026-05-08, PR #16885 merged): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary.",
+    "iteration": 9,
+    "focus": "Phase-2 ACT iteration 9 (this PR, researcher-9): **closure of Σ₁ under binary union and Π₁ under binary intersection** via the product polynomial witness P(q,x) = P₁(q,x)·P₂(q,x). One new Mathlib import (Mathlib.Algebra.GroupWithZero.Basic for `mul_eq_zero` over ℚ; ℚ is a field, hence NoZeroDivisors). The same product polynomial serves both directions: for union, ∃x, P₁·P₂=0 ⟺ (∃x, P₁=0) ∨ (∃x, P₂=0); for intersection, ∀x, P₁·P₂≠0 ⟺ (∀x, P₁≠0) ∧ (∀x, P₂≠0). Adds 6 theorems (2 closure + 4 concrete corollaries for pairs {a, b} and complements ℚ\\{a, b} across Σ₁/Π₁/Π₂/Σ₂); 0 new defs, 0 new axioms. Total: 1163 lines (was 999), 50 theorems (was 44), 12 defs, 1 axiom, 0 sorries. Build pending (CI). Sharpens the OPEN-question landscape: every FINITE subset of ℚ is Σ₁-definable; the OPEN Σ₁ question for ℤ ⊂ ℚ reduces to whether *countable* union closure holds (uniform polynomial witness for the family {n} : n : ℤ).",
     "blockers": [],
-    "nextAction": "S5+ candidates (after this PR lands): (a) Σ₂ ⊆ Π₂'s ¬¬-shadow technical clarification — would tighten the predicate-equivalence bridge into a stronger congruence lemma; (b) Σ₁ × Π₁ closure properties (∪/∩) — needs Rat.mul_eq_zero / sum-of-squares, currently no Mathlib import; (c) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker; (d) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (e) Eisenträger-Park 2018 universal-existential characterization for global fields.",
+    "nextAction": "S10+ candidates (after this PR lands): (a) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — needs Rat field arithmetic (further Mathlib import); (b) closure of Σ₁ under binary INTERSECTION via sum-of-squares witness P(q, x, y) = P₁(q,x)² + P₂(q,y)² (needs `a²+b²=0 ↔ a=0 ∧ b=0` over an ordered field, plus a packing-trick to use disjoint variable indices for x and y); (c) finUnion_singletons_isDiophantineDefinition: induction on a finite list of rationals — every finite subset of ℚ is Σ₁-definable (extension of S9's pair to arbitrary k-tuple); (d) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (e) Eisenträger-Park 2018 universal-existential characterization for global fields.",
     "attemptCounts": {
-      "total": 4,
+      "total": 9,
       "currentApproach": 1,
-      "approachesTried": 3
+      "approachesTried": 8
     }
   },
   "knowledge": {
-    "progressSummary": "PHASE-2 ACT iterations 1-8 complete. Iter 1 (researcher-6): scaffold (5 thm). Iter 2 (researcher-9): Σ₁/Π₁ duality (+4 thm). Iter 3 (researcher-9): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (+4 thm). Iter 4 (researcher-1): three remaining class congruence helpers (+3 thm, axiom-free). Iter 5 (PR #17065): symmetric duality + ∅/ℚ trivial-set library across all four classes. Iter 6 (PR #17083): smallest non-trivial parameter-dependent witness {0}/ℚ\\{0} via projection polynomial P(q,x)=q. Iter 7 (PR #17125): four ¬¬-shadows (Σ₁/Π₁/Σ₂/Π₂ stable under classical double negation) + concrete OPEN-question shadow IntegersAreDiophantineOverQ ⟺ Σ₁(¬¬ IntSubset). Iter 8 (researcher-5, this PR): **Path B transition** — first Mathlib import (Mathlib.Algebra.Group.Basic for sub_eq_zero) enables the proper generalization of S6 singletonZero to **arbitrary singletons {a} ⊂ ℚ for any a : ℚ** via the shift polynomial P(q,x) = q - a. Adds 5 theorems (4 parametric + 1 a=0 recovery instance) + 1 private def (shiftPoly). Total: 999 lines, 44 theorems, 12 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries. The Σ₁ question itself remains OPEN (intentionally). Iter 8 build pending; iter 7 build passed.",
+    "progressSummary": "PHASE-2 ACT iterations 1-9 complete. Iter 1 (researcher-6): scaffold (5 thm). Iter 2 (researcher-9): Σ₁/Π₁ duality (+4 thm). Iter 3 (researcher-9): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (+4 thm). Iter 4 (researcher-1): three remaining class congruence helpers (+3 thm, axiom-free). Iter 5 (PR #17065): symmetric duality + ∅/ℚ trivial-set library across all four classes. Iter 6 (PR #17083): smallest non-trivial parameter-dependent witness {0}/ℚ\\{0} via projection polynomial P(q,x)=q. Iter 7 (PR #17125): four ¬¬-shadows (Σ₁/Π₁/Σ₂/Π₂ stable under classical double negation) + concrete OPEN-question shadow IntegersAreDiophantineOverQ ⟺ Σ₁(¬¬ IntSubset). Iter 8 (researcher-5, PR #17219 merged): **Path B transition** — first Mathlib import (Mathlib.Algebra.Group.Basic for sub_eq_zero) enables the proper generalization of S6 singletonZero to **arbitrary singletons {a} ⊂ ℚ for any a : ℚ** via the shift polynomial P(q,x) = q - a. Adds 5 theorems + 1 private def. Iter 9 (researcher-9, this PR): **closure of Σ₁ under binary union and Π₁ under binary intersection** via the product polynomial witness P(q,x) = P₁(q,x)·P₂(q,x). Second Mathlib import (Mathlib.Algebra.GroupWithZero.Basic for `mul_eq_zero` on ℚ). Adds 6 theorems (2 closure + 4 concrete pair corollaries). Total: 1163 lines, 50 theorems, 12 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries. The Σ₁ question itself remains OPEN (intentionally) — but every FINITE subset of ℚ is now Σ₁-definable; the OPEN content is precisely the COUNTABLE union of singletons {n} : n : ℤ.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
       "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
@@ -85,7 +85,15 @@
       "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonOf_isUniversalExistentialDefinition (a : Rat) — every {a} ⊂ ℚ is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (S8)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonOf_isExistentialUniversalDefinition (a : Rat) — every ℚ \\ {a} is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (S8)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonOf_zero_isDiophantineDefinition — documents S6 = a=0 instance of S8 family (S8)",
-      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 885→999, theoremCount 39→44, definitionCount 11→12; mathlibDependencies = [Mathlib.Algebra.Group.Basic]; leanFile.imports gained Mathlib.Algebra.Group.Basic"
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 885→999, theoremCount 39→44, definitionCount 11→12; mathlibDependencies = [Mathlib.Algebra.Group.Basic]; leanFile.imports gained Mathlib.Algebra.Group.Basic",
+      "Proofs/Hilbert10OQ01OQ02.lean: import Mathlib.Algebra.GroupWithZero.Basic added (S9 iter 9, second Mathlib import — `mul_eq_zero` on ℚ for binary union/intersection closure)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem union_isDiophantineDefinition — Σ₁ closed under binary union via product polynomial witness P(q,x)=P₁(q,x)·P₂(q,x) (S9 Path B; uses mul_eq_zero, zero_mul, mul_zero)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem intersection_isCoDiophantineDefinition — Π₁ closed under binary intersection via the SAME product polynomial witness (S9 Path B, dual of union)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonPair_isDiophantineDefinition (a b : Rat) — every PAIR {a, b} ⊂ ℚ is Σ₁-definable (S9 corollary of union closure applied to two S8 singletonOf witnesses)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonPair_isCoDiophantineDefinition (a b : Rat) — every complement-of-pair ℚ \\ {a, b} is Π₁-definable (S9 corollary)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonPair_isUniversalExistentialDefinition (a b : Rat) — every PAIR {a, b} is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (S9)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonPair_isExistentialUniversalDefinition (a b : Rat) — every complement-of-pair is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (S9)",
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 999→1163, theoremCount 44→50, definitionCount unchanged at 12; mathlibDependencies adds Mathlib.Algebra.GroupWithZero.Basic; leanFile.imports gained Mathlib.Algebra.GroupWithZero.Basic"
     ],
     "insights": [
       "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",
@@ -106,7 +114,9 @@
       "Pattern for axiom-free duality proofs in Lean core: `apply Classical.byContradiction; intro hn; have : ... := ...` — this idiom carries the file with no Mathlib import.",
       "S6 → S8 generalization (singletonZero → singletonOf): the projection polynomial P(q,x) = q recovers as the special case a = 0 of the shift polynomial P(q,x) = q - a; the shift family adds nothing new for a = 0 but parameterizes the entire family of singletons by a single witness",
       "Σ₁-definability is closed under FINITE union (and intersection) but the OPEN ℤ ⊂ ℚ Σ₁ question is precisely the question of closure under COUNTABLE union along Int.cast — the family of singletons {n} for n : ℤ is uniformly Σ₁-definable per-element (via singletonOf at a = n) but not known to admit a single uniform polynomial witness for the union",
-      "Path A → Path B transition: the file architecture changes at iter 8 to allow Mathlib imports. The minimal cost (one import: Mathlib.Algebra.Group.Basic for sub_eq_zero) unlocks the singleton-of-a generalization, the closure properties (S9+: needs mul_eq_zero), and Π₁ ⊆ Π₂ via inversion (S10+: needs Rat field arithmetic)"
+      "Path A → Path B transition: the file architecture changes at iter 8 to allow Mathlib imports. The minimal cost (one import: Mathlib.Algebra.Group.Basic for sub_eq_zero) unlocks the singleton-of-a generalization, the closure properties (S9+: needs mul_eq_zero), and Π₁ ⊆ Π₂ via inversion (S10+: needs Rat field arithmetic)",
+      "S9 design choice — same product polynomial for both union and intersection: the witness P(q, x) = P₁(q, x)·P₂(q, x) reuses the SAME variable assignment block for both factors. For union (Σ₁), this is fine: ∃x, P₁·P₂=0 ⟺ (∃x, P₁=0) ∨ (∃x, P₂=0) — both directions hold trivially because we don't need the same x to vanish in both factors. For intersection (Π₁), the dual statement holds: ∀x, P₁·P₂≠0 ⟺ (∀x, P₁≠0) ∧ (∀x, P₂≠0) — the universal quantifier 'splits' across the conjunction. Sum-of-squares would be needed for Σ₁ INTERSECTION (where we need the same x to make both factors zero), not for Σ₁ union or Π₁ intersection.",
+      "S9 sharpens the OPEN landscape: every FINITE subset of ℚ is Σ₁-definable (by induction over a finite list, using S8 singletons + S9 binary union). The OPEN Σ₁ question for ℤ ⊂ ℚ thus reduces precisely to: does the COUNTABLE union ⋃_{n : ℤ} {n} admit a UNIFORM polynomial witness? Finite truncations ⋃_{n ∈ [-N, N]} {n} are Σ₁-definable for every N (corollary of S8 + S9), but the limit N → ∞ requires a single polynomial whose existence is precisely the open content of the question."
     ],
     "mathlibGaps": [
       "No formal definition of 'Diophantine subset of a ring' in Mathlib — `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat → Rat) → Rat`",
@@ -116,15 +126,12 @@
       "Mathlib has sub_eq_zero, mul_eq_zero, and Rat field arithmetic — so Path B for arbitrary singletons + finite-union closure is fully buildable. The OPEN content is the COUNTABLE union (uniform vs non-uniform witness for ℤ ⊂ ℚ Σ₁-definability), which is precisely the open Σ₁ question and not a Mathlib gap"
     ],
     "nextSteps": [
-      "S4: Σ₁ × Π₁ closure properties (under finite union/intersection) — requires either Mathlib import for Rat.mul_eq_zero / sum-of-squares-zero or hand-rolled proofs from Lean core. Significant infrastructure work.",
-      "S5: Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker as S4.",
-      "S6: Daans 2021 (10-quantifier reduction) as a separate axiom refining koenigsmann_2016_universal — would add 1 new axiom but improve quantitative content.",
-      "S7: Eisenträger-Park 2018 universal-existential characterization for global fields — sibling-of-sibling formalization track.",
-      "Eventually: formalize the explicit Koenigsmann polynomial in Lean to discharge `koenigsmann_2016_universal` — requires Hilbert-symbol/quaternion infrastructure (partial in Hilbert11_QuadraticForms.lean).",
-      "S9 (Path B): closure of Σ₁ under finite union via P(q,x,y) = P_1(q,x) · P_2(q,y); needs mul_eq_zero (one more Mathlib import). Apply to deduce the explicit finite union {n : -N ≤ n ≤ N} ⊂ ℚ is Σ₁-definable for each finite N",
-      "S9 (Path B): closure of Σ₁ under finite intersection via P(q,x,y) = P_1(q,x)^2 + P_2(q,y)^2; needs (a^2 + b^2 = 0 ↔ a = 0 ∧ b = 0) over an ordered field",
-      "S10 (Path B): Π₁ ⊆ Π₂ via the polynomial-inversion trick a ≠ 0 ⟺ ∃ z, a · z = 1 — completes the four-corner inclusion picture",
-      "S10+ (Path B): IntSubset exhibited as a finite-union limit of singletonOf along Int.cast — explicit ⋃_{n ∈ [-N, N]} {n} Σ₁-definable for each finite N (corollary of S9). The OPEN content is the limit N → ∞ (uniform witness)"
+      "S10.1 (Path B): Π₁ ⊆ Π₂ via the polynomial-inversion trick a ≠ 0 ⟺ ∃ z, a·z = 1 — completes the four-corner inclusion picture (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂, Π₁ ⊆ Π₂). Needs Rat field arithmetic (mul_inv, mul_inv_cancel from Mathlib).",
+      "S10.2 (Path B): Σ₁ closure under finite INTERSECTION via sum-of-squares witness P(q, x, y) = P₁(q, x)² + P₂(q, y)². Needs (a² + b² = 0 ↔ a = 0 ∧ b = 0) over an ordered field, plus a packing-trick to use disjoint variable indices for x and y (since the SAME variable assignment block won't work for intersection).",
+      "S10.3 (Path B): finUnion_singletons_isDiophantineDefinition — by induction on a finite list of rationals (extending S9's binary pair), every FINITE subset of ℚ is Σ₁-definable. Makes precise the boundary of what S8+S9 reach: every finite subset is Σ₁; the OPEN Σ₁ question for ℤ ⊂ ℚ is whether COUNTABLE union extends.",
+      "S10.4: Daans 2021 (10-quantifier reduction) as a separate axiom refining koenigsmann_2016_universal — would add 1 new axiom but improve quantitative content.",
+      "S10.5: Eisenträger-Park 2018 universal-existential characterization for global fields — sibling-of-sibling formalization track.",
+      "Eventually: formalize the explicit Koenigsmann polynomial in Lean to discharge `koenigsmann_2016_universal` — requires Hilbert-symbol/quaternion infrastructure (partial in Hilbert11_QuadraticForms.lean)."
     ]
   },
   "tags": [
@@ -169,7 +176,7 @@
     ]
   },
   "started": "2026-05-05T02:57:43.927Z",
-  "lastUpdate": "2026-05-08T06:00:00.000Z",
+  "lastUpdate": "2026-05-08T18:30:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -209,10 +216,10 @@
     {
       "path": "Proofs/Hilbert10OQ01OQ02.lean",
       "filename": "Hilbert10OQ01OQ02.lean",
-      "lineCount": 709,
-      "theoremCount": 29,
+      "lineCount": 1163,
+      "theoremCount": 50,
       "axiomCount": 1,
-      "defCount": 10,
+      "defCount": 12,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert10OQ01OQ02.lean"


### PR DESCRIPTION
## Summary

Iteration 9 (Path B) of `hilbert-10-oq-01-oq-02` (*Is ℤ purely Diophantine over ℚ?*).
Adds **closure of Σ₁ under binary union** and **closure of Π₁ under binary intersection**, via a single product polynomial witness:

  P(q, x) = P₁(q, x) · P₂(q, x).

The same polynomial witness serves both directions:

* **Union (Σ₁)**: `∃x, P₁(q,x)·P₂(q,x) = 0  ⟺  (∃x, P₁(q,x) = 0) ∨ (∃x, P₂(q,x) = 0)`.
* **Intersection (Π₁)**: `(∀x, P₁·P₂ ≠ 0)  ⟺  (∀x, P₁ ≠ 0) ∧ (∀x, P₂ ≠ 0)`.

Both directions use `mul_eq_zero` over ℚ (`NoZeroDivisors` via the `Field` instance). Adds the second Mathlib import in this file: `Mathlib.Algebra.GroupWithZero.Basic` (after S8's `Mathlib.Algebra.Group.Basic`).

## New declarations (6 theorems, 0 defs, 0 axioms)

| Decl | Kind | Statement |
|------|------|-----------|
| `union_isDiophantineDefinition` | theorem | Σ₁ closed under binary union. |
| `intersection_isCoDiophantineDefinition` | theorem | Π₁ closed under binary intersection. |
| `singletonPair_isDiophantineDefinition a b` | theorem | every pair `{a, b} ⊂ ℚ` is Σ₁. |
| `notSingletonPair_isCoDiophantineDefinition a b` | theorem | every `ℚ \ {a, b}` is Π₁. |
| `singletonPair_isUniversalExistentialDefinition a b` | theorem | corollary `{a, b}` is Π₂. |
| `notSingletonPair_isExistentialUniversalDefinition a b` | theorem | corollary `ℚ \ {a, b}` is Σ₂. |

## Counts

|        | Before | After | Δ |
|--------|-------:|------:|--:|
| `theoremCount` | 44 | 50 | +6 |
| `defCount`     | 12 | 12 |  0 |
| `axiomCount`   |  1 |  1 |  0 |
| `sorries`      |  0 |  0 |  0 |
| `lineCount`    | 999 | 1163 | +164 |

## Why this matters — sharpening the OPEN Σ₁ question

S8 + S9 together imply that **every FINITE subset of ℚ is Σ₁-definable** (by induction over a finite list — straightforward but left as S10.3 in this PR's `nextSteps`). So the OPEN Σ₁ question for ℤ ⊂ ℚ reduces precisely to whether **countable** union closure holds:

* Every finite truncation `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` is Σ₁-definable.
* The OPEN content is the limit `N → ∞` — a *uniform* polynomial witness whose existence is the question.

This is the cleanest restatement of the OPEN Σ₁ question yet in this file.

## Mathlib API surface used

* `mul_eq_zero` (`a * b = 0 ↔ a = 0 ∨ b = 0` for `NoZeroDivisors`)
* `zero_mul`, `mul_zero` (basic `MulZeroClass` lemmas)

All from `Mathlib.Algebra.GroupWithZero.Basic`. ℚ is a field, hence `NoZeroDivisors`.

## Build status

NOT attempted in this worktree — `proofs/.lake` is the known recursive self-symlink (per memory note `feedback_researcher_lake_symlink_broken.md`), forcing a ~45-min cold-cache Docker build. Tactics restricted to `refine`/`obtain`/`rcases`/`rintro`/`exact`/`rw` plus the three Mathlib lemmas listed above. No new axioms. **CI is the ground truth.**

Iteration 8 build: PASSED ✅ (per #17219 CI).

## Test plan

- [ ] CI: build `Proofs.Hilbert10OQ01OQ02` succeeds.
- [ ] `axiomCount` remains 1; `sorries` remains 0.
- [ ] `mathlibDependencies` validates against the new object-schema (`{theorem, description, module}[]`) introduced in #17277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)