### PR TITLE
fix(meta): erdos-859 sorries 3 → 7 (companion file added 4)

### DIFF
--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 7,
     "erdosNumber": 859,
     "erdosUrl": "https://erdosproblems.com/859",
     "erdosProblemStatus": "open",
@@ -50,7 +50,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 348,
-    "assumptions": "3 axioms: erdos_density_exists, erdos_density_positive, erdos_bounds. 3 sorries.",
+    "assumptions": "3 axioms: erdos_density_exists, erdos_density_positive, erdos_bounds. 7 sorries (3 in main file, 4 in Aristotle companion).",
     "theoremCount": 13,
     "definitionCount": 9,
     "additionalFiles": [
@@ -208,7 +208,7 @@
     "theoremCount": 13,
     "definitionCount": 9,
     "path": "Proofs/Erdos859Problem.lean",
-    "sorries": 3,
+    "sorries": 7,
     "additionalFiles": [
       "Proofs/Erdos859ProblemAristotle.lean"
     ]
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: density, divisors, number-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Sync `meta.sorries` to reflect total sorries across main file (3) and Aristotle companion (4).

## Evidence

\`find-targets.ts\` reports:
\`\`\`
erdos-859 ❌ sorry mismatch: claims 3, actual 7
\`\`\`

- \`Erdos859Problem.lean\`: 3 sorries
- \`Erdos859ProblemAristotle.lean\`: 4 sorries
- Total: 7

## Changes

- \`meta.sorries\`: 3 → 7
- \`leanFile.sorries\`: 3 → 7
- top-level \`sorries\`: 3 → 7
- \`meta.assumptions\`: clarified "7 sorries (3 in main file, 4 in Aristotle companion)"

After fix, find-targets clean for this slug.

---
Automated fix by lean-mechanic agent.