### PR TITLE
fix(meta): batch sync sorries to total chain count (54 entries)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 5,
     "axiomCount": 0,
     "theoremCount": 16,
     "lineCount": 265,
@@ -133,5 +133,5 @@
       "Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 5
 }

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
       "dependent-variables"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
     "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) \u2014 the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 3 sorries: (1) nested ciSup of zeros = 0 for independent sequences, (2) i.i.d. Lindeberg condition via dominated convergence for truncated moments, (3) i.i.d. Lyapunov condition via rpow moment decay.",
@@ -169,5 +169,5 @@
       "mathContext": "$(X_1+\\cdots+X_n)/\\sqrt{n} \\xrightarrow{d} N(0,\\sigma^2)$; sorry: $\\mathbb{E}[X^2 \\cdot \\mathbf{1}_{|X|>\\varepsilon\\sqrt{n}}] \\xrightarrow{\\text{DCT}} 0$; $\\Lambda_n(\\delta) = \\mathbb{E}[|X|^{2+\\delta}]/n^{\\delta/2} \\to 0$"
     }
   ],
-  "sorries": 3
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 8,
     "axiomCount": 4,
     "assumptions": "4 axioms: totient_sum_mertens_error (elementary Mertens O(N log N) error), totient_sum_walfisz_error (Walfisz 1963 O(N(logN)^(2/3)(loglogN)^(4/3))), rangeTotientSum_walfisz_error (Abel summation from Walfisz to range sum), convergence_rate_sharp (EST reduction to range sum with Walfisz bound). 4 sorries: walfisz_rate_isLittleO_mertens_rate, walfisz_full_rate_isLittleO_mertens_rate, sharp_rate_isLittleO_oq02_rate, improvement_factor_tends_to_zero — all real-analysis rpow comparisons, Aristotle candidates.",
     "erdosNumber": 1001,
@@ -164,5 +164,5 @@
       "mathContext": "The main theorem combines: (1) the sharp rate axiom $|S-f| = O(A(\\log N)^{2/3}(\\log\\log N)^{4/3}/N)$, and (2) the comparison $(\\log N)^{2/3}(\\log\\log N)^{4/3}/N = o(\\log N/N)$, via $\\texttt{IsBigO.trans\\_isLittleO}$. This yields $|S-f| = o(A \\log N/N)$ — strictly better convergence than OQ-02's O bound."
     }
   ],
-  "sorries": 4
+  "sorries": 8
 }

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 8,
     "axiomCount": 1,
     "theoremCount": 11,
     "lineCount": 737,
@@ -144,5 +144,5 @@
       "Proofs/Erdos1018OQ04Incomplete01Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 8
 }

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 22,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
@@ -248,5 +248,5 @@
       "Proofs/Erdos1018Aristotle.lean"
     ]
   },
-  "sorries": 7
+  "sorries": 22
 }

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -17,7 +17,7 @@
       "turan-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 6,
     "erdosNumber": 1019,
     "erdosUrl": "https://erdosproblems.com/1019",
     "erdosProblemStatus": "solved",
@@ -308,5 +308,5 @@
     "Proof of the 1-edge threshold gap via `omega`",
     "Definition of `completeBipartite` on `Fin m ⊕ Fin n` with adjacency between parts"
   ],
-  "sorries": 1
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -17,7 +17,7 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 17,
     "axiomCount": 2,
     "lineCount": 191,
     "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries in dependency chain: 4 in this file + 2 in parent Erdos1021Problem.lean (k3_case_solved, trivial_bound).",
@@ -140,5 +140,5 @@
       "Proofs/Erdos1021OQ01Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 17
 }

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
@@ -247,5 +247,5 @@
       "Proofs/Erdos1040Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 14,
     "erdosNumber": 1048,
     "erdosUrl": "https://erdosproblems.com/1048",
     "erdosProblemStatus": "disproved",
@@ -303,5 +303,5 @@
       "type": "book"
     }
   ],
-  "sorries": 10
+  "sorries": 14
 }

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 14,
     "erdosNumber": 1049,
     "erdosUrl": "https://erdosproblems.com/1049",
     "erdosProblemStatus": "open",
@@ -293,5 +293,5 @@
       "Proofs/Erdos1049ProblemAristotle.lean"
     ]
   },
-  "sorries": 9
+  "sorries": 14
 }

--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1132,
     "erdosUrl": "https://erdosproblems.com/1132",
     "erdosProblemStatus": "open",
@@ -254,5 +254,5 @@
       "Proofs/Erdos1132Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 14,
     "axiomCount": 3,
     "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 1 sorry: base_implies_behavior (limit → exponential behavior, requires Tendsto with nhds ε-balls). limInf_ge_log_c1 now fully proved.",
     "erdosNumber": 117,
@@ -149,5 +149,5 @@
       "Proofs/Erdos117OQ01Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 14
 }

--- a/src/data/proofs/erdos-1196/meta.json
+++ b/src/data/proofs/erdos-1196/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 1196,
     "erdosUrl": "https://erdosproblems.com/1196",
     "erdosProblemStatus": "proved",
@@ -216,5 +216,5 @@
       "Proofs/Erdos1196Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -19,7 +19,7 @@
       "extremal-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
@@ -224,5 +224,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     }
   ],
-  "sorries": 3
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -12,7 +12,7 @@
     "erdosUrl": "https://erdosproblems.com/160",
     "erdosProblemStatus": "open",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -181,5 +181,5 @@
       "note": "Survey of rainbow-free colorings and anti-Ramsey problems in arithmetic settings"
     }
   ],
-  "sorries": 2
+  "sorries": 4
 }

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 214,
     "erdosUrl": "https://erdosproblems.com/214",
     "erdosProblemStatus": "solved",
@@ -253,5 +253,5 @@
       "note": "Best known O(n^{4/3}) bound for unit distances"
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 225,
     "erdosUrl": "https://erdosproblems.com/225",
     "erdosProblemStatus": "solved",
@@ -162,5 +162,5 @@
       "description": "Related Erdős problem sharing themes: analysis, solved"
     }
   ],
-  "sorries": 3
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 240,
     "erdosUrl": "https://erdosproblems.com/240",
     "erdosProblemStatus": "solved",
@@ -270,5 +270,5 @@
       "Proofs/Erdos240ProblemAristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 381,
     "erdosUrl": "https://erdosproblems.com/381",
     "erdosProblemStatus": "disproved",
@@ -202,5 +202,5 @@
       "description": "Related Erdős problem sharing themes: divisor-functions, number-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-415/meta.json
+++ b/src/data/proofs/erdos-415/meta.json
@@ -20,7 +20,7 @@
       "arithmetic-functions"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 16,
     "erdosNumber": 415,
     "erdosUrl": "https://erdosproblems.com/415",
     "erdosProblemStatus": "open",
@@ -284,5 +284,5 @@
       "description": "Related Erdős problem sharing themes: arithmetic-functions, number-theory, totient-function"
     }
   ],
-  "sorries": 14
+  "sorries": 16
 }

--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 454,
     "erdosUrl": "https://erdosproblems.com/454",
     "erdosProblemStatus": "open",
@@ -300,5 +300,5 @@
       "description": "Both concern the fine distribution of primes beyond PNT: bounded prime gaps (Maynard-Tao) shows primes cluster more than average, while #454 studies how prime sums deviate from their expected values — complementary perspectives on prime irregularity"
     }
   ],
-  "sorries": 3
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 9,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",
@@ -183,5 +183,5 @@
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory"
     }
   ],
-  "sorries": 6
+  "sorries": 9
 }

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -18,7 +18,7 @@
       "flag-algebras"
     ],
     "badge": "wip",
-    "sorries": 14,
+    "sorries": 15,
     "erdosNumber": 549,
     "erdosUrl": "https://erdosproblems.com/549",
     "erdosProblemStatus": "solved",
@@ -243,5 +243,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory, trees"
     }
   ],
-  "sorries": 14
+  "sorries": 15
 }

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -16,7 +16,7 @@
       "cycles"
     ],
     "badge": "wip",
-    "sorries": 22,
+    "sorries": 25,
     "erdosNumber": 551,
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
@@ -225,5 +225,5 @@
     "Erdős, P.; Faudree, R.J.; Rousseau, C.C.; Schelp, R.H. (1978): The Ramsey number for the pair complete graph-cycle",
     "https://erdosproblems.com/551"
   ],
-  "sorries": 22
+  "sorries": 25
 }

--- a/src/data/proofs/erdos-553/meta.json
+++ b/src/data/proofs/erdos-553/meta.json
@@ -17,7 +17,7 @@
       "off-diagonal"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 17,
     "erdosNumber": 553,
     "erdosUrl": "https://erdosproblems.com/553",
     "erdosProblemStatus": "solved",
@@ -186,5 +186,5 @@
       "description": "Related Erdős problem sharing themes: graph-coloring, ramsey-theory"
     }
   ],
-  "sorries": 15
+  "sorries": 17
 }

--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",
     "erdosProblemStatus": "solved",
@@ -202,5 +202,5 @@
       "note": "High-girth constructions showing χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — demonstrating the reciprocal sum divergence in Problem #57 is precisely calibrated"
     }
   ],
-  "sorries": 2
+  "sorries": 4
 }

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 17,
+    "sorries": 20,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",
@@ -255,5 +255,5 @@
       "description": "Foundational Ramsey theory (2-complete sets): the Ramsey-theoretic framework underpinning Kim's theorem R(3,k) = Θ(k²/log k)"
     }
   ],
-  "sorries": 17
+  "sorries": 20
 }

--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 13,
+    "sorries": 16,
     "erdosNumber": 611,
     "erdosUrl": "https://erdosproblems.com/611",
     "erdosProblemStatus": "open",
@@ -275,5 +275,5 @@
       "note": "Uses probabilistic techniques for graph structure under clique constraints; the Bollobás-Erdős threshold result in #611 employs similar random graph methodology."
     }
   ],
-  "sorries": 13
+  "sorries": 16
 }

--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -18,7 +18,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 5,
+    "sorries": 8,
     "erdosNumber": 623,
     "erdosUrl": "https://erdosproblems.com/623",
     "erdosProblemStatus": "open",
@@ -226,5 +226,5 @@
       "description": "Related Erdős problem sharing themes: cardinals, independence, set-theory"
     }
   ],
-  "sorries": 5
+  "sorries": 8
 }

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 10,
     "erdosNumber": 632,
     "erdosUrl": "https://erdosproblems.com/632",
     "erdosProblemStatus": "solved",
@@ -231,5 +231,5 @@
       "description": "Related Erdős problem sharing themes: counterexample, disproved, graph-theory"
     }
   ],
-  "sorries": 5
+  "sorries": 10
 }

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -17,7 +17,7 @@
       "counting"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 7,
     "erdosNumber": 636,
     "erdosUrl": "https://erdosproblems.com/636",
     "erdosProblemStatus": "solved",
@@ -267,5 +267,5 @@
       "type": "paper"
     }
   ],
-  "sorries": 4
+  "sorries": 7
 }

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -16,7 +16,7 @@
       "degrees"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 13,
     "erdosNumber": 637,
     "erdosUrl": "https://erdosproblems.com/637",
     "erdosProblemStatus": "solved",
@@ -214,5 +214,5 @@
       "Proofs/Erdos637ProblemAristotle.lean"
     ]
   },
-  "sorries": 10
+  "sorries": 13
 }

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -19,7 +19,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 19,
     "erdosNumber": 644,
     "erdosUrl": "https://erdosproblems.com/644",
     "erdosProblemStatus": "open",
@@ -200,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, open"
     }
   ],
-  "sorries": 16
+  "sorries": 19
 }

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -19,7 +19,7 @@
       "3D-geometry"
     ],
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 13,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
     "erdosProblemStatus": "open",
@@ -168,5 +168,5 @@
       "description": "Related Erdős problem sharing themes: combinatorial-geometry, distinct-distances"
     }
   ],
-  "sorries": 10
+  "sorries": 13
 }

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 12,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -181,5 +181,5 @@
       "description": "Related Erdős problem sharing themes: approximation-theory, interpolation, open"
     }
   ],
-  "sorries": 7
+  "sorries": 12
 }

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -18,7 +18,7 @@
       "distribution"
     ],
     "badge": "wip",
-    "sorries": 20,
+    "sorries": 30,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",
@@ -253,5 +253,5 @@
       "description": "Related Erdős problem sharing themes: analytic-number-theory, arithmetic-functions, number-theory"
     }
   ],
-  "sorries": 20
+  "sorries": 30
 }

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 11,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",
     "erdosProblemStatus": "open",
@@ -293,5 +293,5 @@
       "Proofs/Erdos679ProblemAristotle.lean"
     ]
   },
-  "sorries": 10
+  "sorries": 11
 }

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 18,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",
@@ -238,5 +238,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, subgraphs"
     }
   ],
-  "sorries": 15
+  "sorries": 18
 }

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 9,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -239,5 +239,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 7
+  "sorries": 9
 }

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -17,7 +17,7 @@
       "distinct-products"
     ],
     "badge": "wip",
-    "sorries": 14,
+    "sorries": 24,
     "erdosNumber": 795,
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
@@ -199,5 +199,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
   ],
-  "sorries": 14
+  "sorries": 24
 }

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 9,
     "erdosNumber": 798,
     "erdosUrl": "https://erdosproblems.com/798",
     "erdosProblemStatus": "solved",
@@ -204,5 +204,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, geometry, solved"
     }
   ],
-  "sorries": 7
+  "sorries": 9
 }

--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 7,
     "erdosNumber": 859,
     "erdosUrl": "https://erdosproblems.com/859",
     "erdosProblemStatus": "open",
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: density, divisors, number-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 7
 }

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -20,7 +20,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 860,
     "erdosUrl": "https://erdosproblems.com/860",
     "erdosProblemStatus": "open",
@@ -196,5 +196,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, open, prime-numbers"
     }
   ],
-  "sorries": 3
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -17,7 +17,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 7,
     "erdosNumber": 876,
     "erdosUrl": "https://erdosproblems.com/876",
     "erdosProblemStatus": "open",
@@ -189,5 +189,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, partially-solved"
     }
   ],
-  "sorries": 2
+  "sorries": 7
 }

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 877,
     "erdosUrl": "https://erdosproblems.com/877",
     "erdosProblemStatus": "solved",
@@ -194,5 +194,5 @@
       "Proofs/Erdos877ProblemAristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -42,7 +42,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 19,
+    "sorries": 22,
     "erdosNumber": 901,
     "erdosUrl": "https://erdosproblems.com/901",
     "erdosProblemStatus": "open",
@@ -220,5 +220,5 @@
       "What is the relationship between $m(n)$ and the cover number $\\tau(n)$ (minimum vertices to hit all edges)?"
     ]
   },
-  "sorries": 19
+  "sorries": 22
 }

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -16,7 +16,7 @@
       "mersenne"
     ],
     "badge": "wip",
-    "sorries": 23,
+    "sorries": 26,
     "erdosNumber": 977,
     "erdosUrl": "https://erdosproblems.com/977",
     "erdosProblemStatus": "solved",
@@ -133,5 +133,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, prime-factors"
     }
   ],
-  "sorries": 23
+  "sorries": 26
 }

--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
       "sharp-constants"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 8,
     "axiomCount": 3,
     "theoremCount": 11,
     "lineCount": 427,
@@ -239,5 +239,5 @@
       "description": "Exponential Fourier decay for strip-analytic periodic functions"
     }
   ],
-  "sorries": 2
+  "sorries": 8
 }

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 16,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
@@ -150,7 +150,7 @@
       "description": "Sister entry proving the solvability divide (S_n solvable iff n ≤ 4) and A₅ analysis"
     }
   ],
-  "sorries": 6,
+  "sorries": 16,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ02.lean",
     "lineCount": 388,

--- a/src/data/proofs/leibniz-pi-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/LeibnizPiOQ02.lean",
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 14,
     "mathlibDependencies": [
       {
         "theorem": "Real.tendsto_sum_pi_div_four",
@@ -209,5 +209,5 @@
       "leanType": "(s : ℝ) → s > 1 → tsum η = (1-2^{1-s}) * tsum ζ"
     }
   ],
-  "sorries": 9
+  "sorries": 14
 }

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -17,7 +17,7 @@
       "polynomial-inequalities"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 9,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
     "assumptions": "1 sorry remains: lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization (all terms equal iff x = 1/(d+1)). Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
@@ -202,5 +202,5 @@
       "leanType": "(d : ℕ) → 0 < d → (p : ℚ) → 0 ≤ p → (∃ x : ℚ, 0 ≤ x ∧ x ≤ 1 ∧ p ≤ x * (1-x)^d) ↔ p ≤ lllThreshold d"
     }
   ],
-  "sorries": 1
+  "sorries": 9
 }

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -192,5 +192,5 @@
       "Proofs/NewtonInductiveStepOQ01Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 2
 }

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 5,
     "axiomCount": 0,
     "lineCount": 257,
     "mathlibDependencies": [
@@ -180,7 +180,7 @@
       "note": "Chapter 3 — modern treatment"
     }
   ],
-  "sorries": 4,
+  "sorries": 5,
   "parentId": "schroeder-bernstein",
   "openQuestionId": "oq-03",
   "theorems": [

--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ03.lean",
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 6,
     "axiomCount": 0,
     "assumptions": "0 axioms. 3 sorries: alternating tail bound, alternating remainder for sin, alternating remainder for cos. Partial sum bounds fully proved by induction on paired terms.",
     "originalContributions": [
@@ -127,5 +127,5 @@
       "Quantitative sharpness: at x = 1, the alternating bound for n = 5 is 1/5040 \u2248 0.0002, while the actual error is much smaller. Is the alternating bound itself tight, or can it be further improved for specific values of x?"
     ]
   },
-  "sorries": 3
+  "sorries": 6
 }


### PR DESCRIPTION
## Fix

Cleared 54 of the 73 \`sorry mismatch\` find-targets findings.

The auditor (\`scripts/auditor/find-targets.ts\`) aggregates sorry counts across the full file chain (\`meta.proofRepoPath\` + every entry of \`meta.additionalFiles\` + auto-followed \`*Aristotle\` sibling imports) and compares to \`meta.meta.sorries\`. By convention (cf. PR #16418):

- \`meta.sorries\` and top-level \`sorries\` → **total** chain count
- \`leanFile.sorries\` → **main file only**

These 54 entries had drifted because the meta-block sorries field still reflected only the main file's sorry count, ignoring the companion's open Aristotle targets.

## Pattern

Each diff is two single-digit replacements:

\`\`\`diff
   "meta": {
-    "sorries": 4,
+    "sorries": 5,
   },
   ...
-  "sorries": 4
+  "sorries": 5
\`\`\`

\`leanFile.sorries\` is preserved (it intentionally counts only the main file).

## Counts

| Slug | Before | After | Δ |
|---|---|---|---|
| erdos-877 | 4 | 5 | +1 |
| erdos-859 | 3 | 7 | +4 |
| erdos-771 | 7 | 9 | +2 |
| erdos-636 | 4 | 7 | +3 |
| erdos-381 | 3 | 6 | +3 |
| erdos-225 | 3 | 5 | +2 |
| erdos-1132 | 0 | 1 | +1 |
| taylor-sincos-convergence-oq-03 | 3 | 6 | +3 |
| erdos-1018-oq-04-incomplete-01 | 1 | 8 | +7 |
| erdos-1001-oq-02-oq-01 | 4 | 8 | +4 |
| erdos-679 | 10 | 11 | +1 |
| erdos-240 | 2 | 3 | +1 |
| erdos-214 | 1 | 3 | +2 |
| angle-trisection-oq-02-oq-01-oq-02 | 2 | 5 | +3 |
| erdos-160 | 2 | 4 | +2 |
| erdos-156 | 3 | 6 | +3 |
| erdos-901 | 19 | 22 | +3 |
| erdos-876 | 2 | 7 | +5 |
| erdos-860 | 3 | 5 | +2 |
| erdos-671 | 7 | 12 | +5 |
| erdos-798 | 7 | 9 | +2 |
| erdos-795 | 14 | 24 | +10 |
| erdos-715 | 15 | 18 | +3 |
| erdos-660 | 10 | 13 | +3 |
| erdos-644 | 16 | 19 | +3 |
| erdos-637 | 10 | 13 | +3 |
| erdos-632 | 5 | 10 | +5 |
| erdos-623 | 5 | 8 | +3 |
| erdos-611 | 13 | 16 | +3 |
| erdos-610 | 17 | 20 | +3 |
| erdos-57 | 2 | 4 | +2 |
| erdos-553 | 15 | 17 | +2 |
| erdos-551 | 22 | 25 | +3 |
| erdos-548 | 6 | 9 | +3 |
| erdos-549 | 14 | 15 | +1 |
| erdos-454 | 3 | 5 | +2 |
| erdos-415 | 14 | 16 | +2 |
| fourier-series-oq-02-oq-03-oq-02 | 2 | 8 | +6 |
| central-limit-theorem-oq-02 | 3 | 6 | +3 |
| erdos-673 | 20 | 30 | +10 |
| erdos-117-oq-01 | 1 | 14 | +13 |
| erdos-1018 | 7 | 22 | +15 |
| erdos-1019 | 1 | 6 | +5 |
| erdos-1040 | 0 | 1 | +1 |
| erdos-1049 | 9 | 14 | +5 |
| erdos-1048 | 10 | 14 | +4 |
| inverse-galois-oq-02 | 6 | 16 | +10 |
| erdos-1021-oq-01 | 4 | 17 | +13 |
| newton-inductive-step-oq-01 | 1 | 2 | +1 |
| erdos-977 | 23 | 26 | +3 |
| erdos-1196 | 1 | 3 | +2 |
| lovasz-local-lemma-oq-02 | 1 | 9 | +8 |
| leibniz-pi-oq-02 | 9 | 14 | +5 |
| schroeder-bernstein-oq-03 | 4 | 5 | +1 |

## Out of scope

- **18 status-verified violations** (e.g. \`shannon-entropy-oq-03\`, \`fourier-series-oq-02-incomplete-01\`): companion has sorries but \`status="verified"\`. Updating sorries would not clear the \`status "verified" but has N sorries\` finding alone — these need a semantic decision (status demote vs. \`additionalFiles\` removal). Deferred.
- **\`binomial-theorem-oq-02-oq-01-oq-01\`**: in-flight research PR #17233 is editing the relevant Lean files; skipped to avoid a merge race.

## Validation

After this PR, \`npx tsx scripts/auditor/find-targets.ts --all --json\` should drop from 73 → 19 entries with detected issues (the remaining 19 listed above).

Counts in this PR were computed against \`origin/main\` blob content using the same comment-stripping convention as the auditor.

---
Automated fix by lean-mechanic agent.