### PR TITLE
fix(area-of-circle-oq-05-oq-01): demote verified → axiomatized + sync chain sorries 0→2

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral#Polar_coordinates",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "analysis",
       "integration",
@@ -17,10 +17,10 @@
       "measure-theory"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ01.lean",
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 2,
     "axiomCount": 0,
-    "assumptions": "None. All 10 theorems fully verified with 0 sorries and 0 axioms. The polar_integral_factorization sorry was resolved via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst.",
+    "assumptions": "Main file (AreaOfCircleOQ05OQ01.lean): 0 sorries, 0 axioms — all 10 theorems including polar_integral_factorization fully proved via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst. Aristotle companion (AreaOfCircleOQ05OQ01Aristotle.lean): 2 open sorries — gaussian_product_integrable and radial_product_integrable (both routine product-measure integrability lemmas, proved inline in the main file but exposed as separate Aristotle targets).",
     "originalContributions": [
       "Named theorem for each step of the polar-coordinate proof: Fubini, change of variables, separation, radial, angular",
       "polar_sum_sq lemma: (r\u00b7cos \u03b8)\u00b2 + (r\u00b7sin \u03b8)\u00b2 = r\u00b2 (compiled, 0 sorry)",
@@ -153,5 +153,5 @@
       "Connect to a formal statement that \u03c0 = area of unit disk via this polar decomposition"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

The main proof file is verified, but the Aristotle companion has 2 open sorries that the chain-total counters were ignoring.

`scripts/auditor/find-targets.ts` flagged:
- sorry mismatch: claims 0, actual 2
- status \"verified\" but has 2 sorries

## Evidence

| File | sorries | axioms |
|---|---|---|
| `AreaOfCircleOQ05OQ01.lean` (main) | 0 | 0 |
| `AreaOfCircleOQ05OQ01Aristotle.lean` (companion) | 2 | 0 |
| **chain total** | **2** | **0** |

The 2 companion sorries (`gaussian_product_integrable`, `radial_product_integrable`) are routine product-measure integrability lemmas — they're already proved inline in the main file but exposed as separate Aristotle targets in the companion.

## Changes

| field | before | after |
|---|---|---|
| `meta.status` | `verified` | `axiomatized` |
| `meta.badge` | `mathlib` | `axiom` |
| `meta.sorries` | `0` | `2` |
| top-level `sorries` | `0` | `2` |
| `meta.assumptions` | "None. All 10 theorems fully verified..." | rewritten to credit the main file's verification while disclosing the 2 companion sorries |
| `leanFile.sorries` | `0` (preserved — main file only, per #17280 convention) | `0` |

Per the chain-total convention established in #17280, `meta.sorries` and top-level `sorries` count the full file chain (main + `additionalFiles`), while `leanFile.sorries` is kept at the main-file count.

---
Automated fix by lean-mechanic agent.