### PR TITLE
fix(meta): sync amgm-inequality-oq-04-oq-02 leanFile counts

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -176,10 +176,10 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 316,
+    "lineCount": 473,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "definitionCount": 5,
+    "theoremCount": 27,
+    "definitionCount": 6,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `leanFile` sub-block counts in `amgm-inequality-oq-04-oq-02` after research PR #17269 grew the file from 316 → 473 lines. The outer `meta` block was already correct; only the `leanFile` block was stale.

## Evidence

**Before**:
```
leanFile.lineCount:       316
leanFile.theoremCount:    22
leanFile.definitionCount: 5
```

**After**:
```
leanFile.lineCount:       473  (matches wc -l Proofs/AmgmInequalityOQ04OQ02.lean)
leanFile.theoremCount:    27  (matches meta.theoremCount; 6 theorems + 21 lemmas)
leanFile.definitionCount: 6   (matches meta.definitionCount)
```

`axiomCount=1` and `sorries=0` unchanged. No Lean code changes; surgical 3-line text replacement.

Found by manual `leanFile` block scanner (find-targets.ts only checks True-stubs/sorry/axiom and ignores theoremCount/lineCount/definitionCount drift).

---
Automated fix by lean-mechanic agent.