### PR TITLE
audit(sum-of-kth-powers-oq-04): verified→formalized; sync sorries 0→2

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -2,12 +2,12 @@
   "id": "sum-of-kth-powers-oq-04",
   "title": "Euler-Maclaurin Asymptotics for Power Sums",
   "slug": "sum-of-kth-powers-oq-04",
-  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Proves Bernoulli polynomial leading behavior and monic polynomial asymptotics (0 axioms, 0 sorries). Includes exact k=0 and k=1 special cases.",
+  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Proves Bernoulli polynomial leading behavior and monic polynomial asymptotics (0 axioms; 2 routine sorries remain in companion Aristotle file). Includes exact k=0 and k=1 special cases.",
   "meta": {
     "author": "Euler (1738), Maclaurin (1742), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula",
     "date": "1738",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ04.lean",
     "tags": [
       "analysis",
@@ -16,10 +16,10 @@
       "bernoulli-numbers",
       "open-question"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. The two previously routine sorries (low_degree_poly_ratio_tendsto_zero and the natDegree bound inside monic_poly_ratio_tendsto) are now fully proved. monic_poly_ratio_tendsto was previously an axiom but was proved in V3.",
+    "assumptions": "0 axioms. 2 routine sorries remain in companion Aristotle file (low_degree_poly_ratio_tendsto_zero and monic_sub_pow_natDegree_lt) — Aristotle proof-search candidates. monic_poly_ratio_tendsto was previously an axiom but was proved in V3; it now relies on these two routine analytical lemmas.",
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.bernoulli",
@@ -172,5 +172,5 @@
       "leanType": "powerSumRatio 1 n = (n - 1) / (2 * n)"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Audit Issue

**Slug**: sum-of-kth-powers-oq-04
**Detected by**: `npx tsx scripts/auditor/find-targets.ts` (3x)
**Mismatch**: `sorry mismatch: claims 0, actual 2; status "verified" but has 2 sorries`

## Evidence

The main file `Proofs/SumOfKthPowersOQ04.lean` is genuinely sorry-free (254 lines, 0 sorries). However, the companion file declared in `additionalFiles`, `Proofs/SumOfKthPowersOQ04Aristotle.lean`, contains **2 unsolved sorries**:

```lean
lemma low_degree_poly_ratio_tendsto_zero (q : Polynomial ℚ) (d : ℕ)
    (hd : 0 < d) (hdeg : q.natDegree < d) :
    Tendsto (fun n : ℕ => q.eval (↑n : ℚ) / (↑n : ℚ) ^ d) atTop (nhds 0) := by
  sorry

lemma monic_sub_pow_natDegree_lt (p : Polynomial ℚ) (d : ℕ)
    (hd_deg : p.natDegree = d) (hlc : p.leadingCoeff = 1) (hd : 0 < d) :
    (p - Polynomial.X ^ d).natDegree < d := by
  sorry
```

These are routine analytical lemmas held as Aristotle proof-search targets. The body of the main proof depends on them via `monic_poly_ratio_tendsto`.

## Drift in meta.json

`meta.assumptions` claimed:

> 0 axioms, 0 sorries. The two previously routine sorries (low_degree_poly_ratio_tendsto_zero and the natDegree bound inside monic_poly_ratio_tendsto) are **now fully proved**. ...

This is contradicted by the file itself. Other prose in the same meta.json correctly states "2 routine sorries remain" — the drift is localized to `assumptions`, `description`, and `status`/`badge`.

## Fix

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `verified` | `formalized` |
| `meta.badge` | `original` | `wip` |
| `meta.sorries` | `0` | `2` (total chain count) |
| top-level `sorries` | `0` | `2` |
| `meta.assumptions` | "now fully proved" | accurate description |
| `description` | "(0 axioms, 0 sorries)" | "(0 axioms; 2 routine sorries remain in companion Aristotle file)" |

`leanFile.sorries` stays at 0 (main file only; matches the per-file convention from `feedback_mechanic_axiomcount_pattern`).

## Why downgrade status?

Per repository status field definitions in `CLAUDE.md`:

> `verified` / `original`: Fully machine-checked, no assumptions. Requires 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.

With 2 sorries remaining in the formalization chain, `verified` overclaims. `formalized`/`wip` matches the actual state and is the natural target for Aristotle to upgrade once the two lemmas are proved.

---

Discovered during gallery integrity audit. Note: erdos-859 (the higher-priority target) is already covered by open PR #17279 and batch PR #17280.