### PR TITLE
fix(meta): batch sync sorries to chain count (6 entries)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 open sorry: gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners). Axiom-free; all axiom declarations are 0.",
@@ -220,5 +220,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 6,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 264,
@@ -196,5 +196,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 5
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -24,7 +24,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 15,
+    "sorries": 19,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",
@@ -226,5 +226,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 15
+  "sorries": 19
 }

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -23,7 +23,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 18,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -223,5 +223,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 16
+  "sorries": 18
 }

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -22,7 +22,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 14,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -229,5 +229,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 12
+  "sorries": 14
 }

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -23,7 +23,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 20,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",
@@ -221,5 +221,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 15
+  "sorries": 20
 }


### PR DESCRIPTION
## Fix

Sync top-level and `meta.sorries` to the actual chain count (main file + Aristotle/Helpers companions) reported by `scripts/auditor/find-targets.ts`. No source code changes.

## Evidence

| slug | claimed | actual chain |
|------|---------|--------------|
| erdos-626 | 15 | 19 (15 main + 4 Aristotle) |
| erdos-627 | 16 | 18 (16 main + 2 Aristotle) |
| erdos-628 | 12 | 14 (12 main + 2 Aristotle) |
| erdos-630 | 15 | 20 (15 main + 5 Aristotle) |
| ballot-problem-oq-03-oq-01-oq-02 | 1 | 3 (0 main + 2 Aristotle + 1 Helpers) |
| binomial-theorem-oq-02-oq-01-oq-01 | 5 | 6 (5 main + 1 Aristotle) |

Counts verified against `git show origin/main:` for each file with comment-stripped `\bsorry\b` regex.

Each meta.json receives a 2-line diff (`meta.sorries` + top-level `sorries`).

---
Automated fix by lean-mechanic agent.