### PR TITLE
audit: aggregate Aristotle companion sorries (erdos-626/627/630)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8487,15 +8487,15 @@
     },
     "erdos-626": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T17:19:42Z",
+      "result": "issues-fixed"
     },
     "erdos-627": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T17:19:42Z",
+      "result": "issues-fixed"
     },
     "erdos-628": {
       "auditCount": 5,
@@ -8519,9 +8519,9 @@
     },
     "erdos-630": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:34Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T17:19:37Z",
+      "result": "issues-fixed"
     },
     "erdos-631": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -24,7 +24,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 15,
+    "sorries": 19,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",
@@ -226,5 +226,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 15
+  "sorries": 19
 }

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -23,7 +23,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 18,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 236,
-    "assumptions": "8 axiom(s) and 16 sorries.",
+    "assumptions": "8 axiom(s) and 18 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
     "definitionCount": 10
@@ -223,5 +223,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 16
+  "sorries": 18
 }

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -23,7 +23,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 20,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 246,
-    "assumptions": "11 axiom(s) and 15 sorries(s).",
+    "assumptions": "11 axiom(s) and 20 sorries(s).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8
@@ -221,5 +221,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 15
+  "sorries": 20
 }


### PR DESCRIPTION
## Summary

Three gallery entries had `meta.sorries` stuck at the main-file count, ignoring sorries in the `*Aristotle.lean` companion declared in `additionalFiles`. `scripts/auditor/find-targets.ts` aggregates sorry counts across `additionalFiles`, so the auditor flagged a `sorry mismatch` on every cycle (3 audits each, all marked `clean` despite the persisting issue).

| slug      | before | after | aristotle file               | adds |
|-----------|--------|-------|------------------------------|------|
| erdos-626 | 15     | 19    | Erdos626ProblemAristotle.lean | 4    |
| erdos-627 | 16     | 18    | Erdos627ProblemAristotle.lean | 2    |
| erdos-630 | 15     | 20    | Erdos630ProblemAristotle.lean | 5    |

`leanFile.sorries` remains the main-file count (15/16/15) per the convention (`lf.*` = main file only, `meta.*` = aggregate across `additionalFiles`). Status stays `axiomatized` (badge `axiom`) — the additional sorries are open Aristotle targets, not new mathematical claims.

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos630Problem.lean | strip-comments | grep -c '\bsorry\b' → 15
$ git show origin/main:proofs/Proofs/Erdos630ProblemAristotle.lean | strip-comments | grep -c '\bsorry\b' → 5
$ git show origin/main:proofs/Proofs/GraphCore.lean | strip-comments | grep -c '\bsorry\b' → 0
```

Same count methodology applied to erdos-626 (15+4+0=19) and erdos-627 (16+2+0=18).

After this PR, `npx tsx scripts/auditor/find-targets.ts --issues` drops from 22 → 19.

## Test plan

- [x] JSON validity verified for all 3 files
- [x] `find-targets.ts` no longer reports erdos-626/627/630 mismatches
- [x] Cross-checked counts against `git show origin/main:` (no working-tree pollution)
- [x] No open PRs/issues conflict with these slugs

---
Discovered during gallery integrity audit (loom:auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)