### PR TITLE
fix(meta): downgrade verified→formalized for 16 entries with companion sorries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "probability",
       "combinatorics",
@@ -14,8 +14,8 @@
       "measure-theory"
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
@@ -174,5 +174,5 @@
       "description": "Uniform fibers preserve uniformOn probability (0 sorries, complete proof)"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "George P\u00f3lya (1937); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polya_enumeration_theorem",
     "date": "1937",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BurnsideCountingOQ03.lean",
     "tags": [
       "combinatorics",
@@ -20,8 +20,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 4,
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean",
     "tags": [
       "set-theory",
@@ -18,8 +18,8 @@
       "club-sets",
       "combinatorial-set-theory"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
@@ -141,5 +141,5 @@
       "content": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, form diagonal intersection D of avoiding clubs, S \u2229 D is nonempty, take \u03b1 \u2208 S \u2229 D, derive contradiction from f(\u03b1) < \u03b1 and \u03b1 \u2208 C_{f(\u03b1)}."
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -15,8 +15,8 @@
       "companion-matrix",
       "rational-canonical-form"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 12,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 0,
+  "sorries": 12,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "chebyshev-pnt-bridge-oq-01",
   "description": "Proves the prime power factorization bound for central binomial coefficients: p^{v_p(C(2n,n))} ≤ 2n. Key ingredient in Chebyshev's proof of Bertrand's postulate. Uses the carry-counting interpretation of Kummer's theorem.",
   "meta": {
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01.lean",
     "tags": [
       "number-theory",
@@ -13,8 +13,8 @@
       "Chebyshev",
       "research"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 210,
     "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",
@@ -170,5 +170,5 @@
       "Proofs/ChebyshevPNTBridgeOQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -15,8 +15,8 @@
       "binomial-coefficients",
       "central-binomial"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -37,7 +37,7 @@
   "meta": {
     "author": "Classical (Bernstein, Zygmund, Sobolev)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Rate_of_convergence",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourierSeriesOQ02Incomplete01.lean",
     "tags": [
       "analysis",
@@ -47,8 +47,8 @@
       "coefficient-decay",
       "infrastructure"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 5,
     "dateAdded": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -179,5 +179,5 @@
       "url": "https://en.wikipedia.org/wiki/Harmonic_analysis"
     }
   ],
-  "sorries": 0
+  "sorries": 5
 }

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stokes (1854), Cartan (1945)",
     "date": "1854",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "calculus",
@@ -16,8 +16,8 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries in main file. d^2=0 in 2D (Clairaut's theorem) now proved via ContDiff.contDiffAt.isSymmSndFDerivAt; Green's theorem in Stokes form proved via GreensTheoremOQ01.greens_theorem_concrete.",
     "mathlibDependencies": [
@@ -254,5 +254,5 @@
       "leanType": "Continuous f -> exists F, extDeriv1D F = f"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LHopitalOQ02.lean",
     "tags": [
       "calculus",
@@ -16,8 +16,8 @@
       "real-analysis",
       "indeterminate-forms"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",
@@ -140,7 +140,7 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 0,
+  "sorries": 3,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.LHopital",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "tags": [
       "information-theory",
@@ -17,8 +17,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ03.lean",
     "tags": [
       "information-theory",
@@ -17,8 +17,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",
@@ -225,5 +225,5 @@
       "note": "Chapter 7: Fano's inequality and its application to channel coding converse"
     }
   ],
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonEntropyOQ01.lean",
     "tags": [
       "information-theory",
@@ -16,8 +16,8 @@
       "gaussian",
       "gibbs-inequality"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,
@@ -132,5 +132,5 @@
       "Proofs/ShannonEntropyOQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lieb & Ruskai (1973)",
     "date": "1973",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "information-theory",
       "analysis",
@@ -16,8 +16,8 @@
       "verified"
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)).",
     "mathlibDependencies": [
@@ -215,5 +215,5 @@
       "leanType": "shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-22",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean",
     "tags": [
       "minimal-polynomial",
@@ -15,8 +15,8 @@
       "irreducibility",
       "square-roots"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "None. Fully proved: 0 sorries, 0 axioms. Irreducibility is proved over \u2124[X] via case analysis, then transferred to \u211a[X] via Gauss's lemma (Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
@@ -129,5 +129,5 @@
       "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [\u211a(\u221a2+\u221a3):\u211a]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: fully proved by direct algebra \u2014 if \u221a2+\u221a3=q then (q\u00b2-5)/2=\u221a6, contradicting irrationality of \u221a6."
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Stirling (1730), de Moivre (1733)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stirling%27s_approximation#Speed_of_convergence_and_error_estimates",
     "date": "1730",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/StirlingExpansion.lean",
     "tags": [
       "analysis",
@@ -16,8 +16,8 @@
       "factorials",
       "bernoulli-numbers"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. The full chain {log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_formula, stirling_step_upper, stirling_step_lower, telescoping helpers (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope), partial-sum bounds (log_stirlingSeq_partial_upper/lower), stirling_first_correction, stirling_two_term_expansion, error_bound_from_correction} is fully proved. The final upper-half exp-Taylor bound is discharged via Real.exp_bound at degree n=2 (|L|≤1 → |exp L − (1+L)| ≤ 3·L²/4), combined with L² ≤ 1/n² (from 0 ≤ L ≤ 1/n) and the algebraic identity L − 1/(12n) ≤ 1/(2n²) (from L ≤ 1/(12(n−1)) + 1/(12(n−1)²)).",
     "dateAdded": "2026-03-29",
@@ -154,5 +154,5 @@
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_formula",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "complex-analysis",
@@ -17,8 +17,8 @@
       "euler-formula"
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ02.lean",
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries via Mathlib bridge. The core step uses Mathlib's NormedSpace.expSeries_div_hasSum_exp for the exp series; all 16 theorems including the bonus bridge lemmas are proved with 0 sorries.",
     "originalContributions": [
@@ -148,5 +148,5 @@
       "Generalize: can this approach prove the power series identity for cosh/sinh (replacing ix with x), giving cosh x = \u2211 x^{2k}/(2k)! and sinh x = \u2211 x^{2k+1}/(2k+1)!?"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

The auditor (`scripts/auditor/find-targets.ts`) flagged 16 gallery entries with the conjoined drift:

- `sorry mismatch: claims 0, actual N`
- `status "verified" but has N sorries`

Each main file is genuinely sorry-free, but the auto-followed `*Aristotle.lean` companion holds unsolved supporting lemmas. Per the chain-total convention (#17280) the auditor counts the full chain, and per `CLAUDE.md` status definitions `verified` requires **0 chain sorries**.

This PR applies the same minimal structural fix as the merged single-entry precedent PR #17284 (sum-of-kth-powers-oq-04: verified→formalized) and PR #17281 (area-of-circle-oq-05-oq-01) across the remaining 16 entries.

## Pattern

Each `meta.json` receives a 4-line surgical diff:

```diff
   "meta": {
-    "status": "verified",
+    "status": "formalized",
   ...
-    "badge": "original",   (or "mathlib")
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": <N>,
   ...
   ],
-  "sorries": 0
+  "sorries": <N>
 }
```

`leanFile.sorries` is preserved at `0` (main-file count, per the per-file convention from #17280).

## Counts

| slug | sorries 0→ | badge before |
|------|--------|--------------|
| ballot-problem-oq-01-oq-02-oq-01 | 1 | original |
| burnside-counting-oq-03 | 4 | mathlib |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 2 | original |
| cayley-hamilton-reduction-oq-02-oq-01 | 12 | original |
| chebyshev-pnt-bridge-oq-01 | 2 | mathlib |
| combinations-formula-oq-02 | 1 | original |
| fourier-series-oq-02-incomplete-01 | 5 | original |
| fundamental-theorem-calculus-oq-02 | 3 | original |
| lhopital-oq-02 | 3 | original |
| shannon-channel-coding-oq-02-oq-01 | 4 | mathlib |
| shannon-channel-coding-oq-03 | 4 | original |
| shannon-entropy-oq-01 | 2 | original |
| shannon-entropy-oq-03 | 3 | original |
| sqrt2-plus-sqrt3-irrational-oq-03 | 3 | mathlib |
| stirling-formula-oq-01 | 3 | original |
| taylor-sincos-convergence-oq-02 | 2 | mathlib |

All chain-sorry counts verified against the current Lean source files using the same comment-stripping `\bsorry\b` regex as `find-targets.ts`.

## Validation

After this PR, `npx tsx scripts/auditor/find-targets.ts --all` reports **6 remaining issues**, all of which are the sorry-mismatch entries already covered by open PR #17285. The 16 status-`verified`-with-sorries violations are fully resolved.

## Out of scope (deferred)

Some entries' `assumptions` / `description` / `conclusion.summary` prose still says "0 sorries" or "fully verified" — that's narrative drift the auditor doesn't catch. A follow-up enricher / mechanic pass can sweep that.

---
Automated fix by lean-mechanic agent.