### PR TITLE
fix(meta): cayley-hamilton + lhopital — sorries 0→{12,3}, status verified→formalized

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -15,8 +15,8 @@
       "companion-matrix",
       "rational-canonical-form"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 12,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 0,
+  "sorries": 12,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LHopitalOQ02.lean",
     "tags": [
       "calculus",
@@ -16,8 +16,8 @@
       "real-analysis",
       "indeterminate-forms"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",
@@ -140,7 +140,7 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 0,
+  "sorries": 3,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.LHopital",


### PR DESCRIPTION
## Fix

Two `verified/original` gallery entries whose `*Aristotle.lean` companions
(declared in `meta.additionalFiles` by PR #17266) contain unproven sorries.
The auditor's `find-targets` aggregates sorries across the chain, so
`meta.sorries` should reflect the total — and a chain with sorries cannot
truthfully claim `verified/original`.

## Evidence

Counts verified against `git show origin/main:` with nested-block-comment-stripped `\bsorry\b` regex:

| slug | sorries (was → now) | status | badge |
|------|---------------------|--------|-------|
| cayley-hamilton-reduction-oq-02-oq-01 | 0 → 12 (0 main + 12 Aristotle) | verified → formalized | original → wip |
| lhopital-oq-02 | 0 → 3 (0 main + 3 Aristotle) | verified → formalized | original → wip |

Each meta.json receives a 4-line diff (`meta.status`, `meta.badge`, `meta.sorries`, top-level `sorries`). `leanFile.sorries` stays at 0 (per gallery convention: lf reflects main file only).

## Why this matters

`scripts/auditor/find-targets.ts` flagged both entries as:
- `sorry mismatch: claims 0, actual {12,3}; status "verified" but has {12,3} sorries`

This brings them in line with the convention used by sister mechanic PRs
(e.g. #17285 for axiomatized erdos-{626,627,630} sorry-count syncs, and
parallel verified→formalized batches).

## Scope

Two entries the auditor surfaced that were **not covered** by other
in-flight PRs (verified against `gh pr list --search` and concurrent
mechanic worktree diffs).

---
Automated fix by lean-mechanic agent.