### PR TITLE
fix(meta): demote 7 entries to axiomatized + sync chain sorries

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "George P\u00f3lya (1937); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polya_enumeration_theorem",
     "date": "1937",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BurnsideCountingOQ03.lean",
     "tags": [
       "combinatorics",
@@ -20,10 +20,10 @@
       "research",
       "open-problem"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 4,
     "axiomCount": 0,
-    "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
+    "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis. Aristotle companion (BurnsideCountingOQ03Aristotle.lean): 4 open sorries — card_gcd_eq, polya_sum_identity, fixed_coloring_orbit_eq, fixed_factors_through_mod (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "dateAdded": "2026-04-04",
     "lineCount": 404,
     "theoremCount": 18,
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean",
     "tags": [
       "set-theory",
@@ -18,11 +18,11 @@
       "club-sets",
       "combinatorial-set-theory"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
+    "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries. Aristotle companion (CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean): 2 open sorries — isClub_inter, diagInter_isUnbounded_ari (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "lineCount": 380,
     "theoremCount": 6,
     "definitionCount": 5,
@@ -141,5 +141,5 @@
       "content": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, form diagonal intersection D of avoiding clubs, S \u2229 D is nonempty, take \u03b1 \u2208 S \u2229 D, derive contradiction from f(\u03b1) < \u03b1 and \u03b1 \u2208 C_{f(\u03b1)}."
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -15,8 +15,8 @@
       "companion-matrix",
       "rational-canonical-form"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 12,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -41,7 +41,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 396,
-    "assumptions": "0 axioms, 0 sorries. All three key theorems fully proved: aeval_companionMatrix (orbit argument), charpoly_companionMatrix, and minpoly_companionMatrix. Uses Mathlib supporting lemmas.",
+    "assumptions": "0 axioms, 0 sorries. All three key theorems fully proved: aeval_companionMatrix (orbit argument), charpoly_companionMatrix, and minpoly_companionMatrix. Uses Mathlib supporting lemmas. Aristotle companion (CayleyHamiltonReductionOQ02OQ01Aristotle.lean): 12 open sorries — 12 routine companion-matrix supporting lemmas (minpoly_dvd_*, charpoly_*, dvd_antisymm_monic, orbit_basis_independent, stdBasis_linearIndependent, annihilator_degree_bound, monic_*, aeval_mulVec, aeval_one) (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1,
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 0,
+  "sorries": 12,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LHopitalOQ02.lean",
     "tags": [
       "calculus",
@@ -16,8 +16,8 @@
       "real-analysis",
       "indeterminate-forms"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",
@@ -49,7 +49,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 428,
-    "assumptions": "0 axioms, 0 sorries. All 4 variants fully proved: right approach via Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop.",
+    "assumptions": "0 axioms, 0 sorries. All 4 variants fully proved: right approach via Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop. Aristotle companion (LHopitalOQ02Aristotle.lean): 3 open sorries — lhopital_infty_left, lhopital_infty_atTop, lhopital_infty_atBot (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
     "definitionCount": 0,
@@ -140,7 +140,7 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 0,
+  "sorries": 3,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.LHopital",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "tags": [
       "information-theory",
@@ -17,8 +17,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -37,7 +37,7 @@
       "Root cause analysis of ShannonEntropy.lean line 811 failure (sum order mismatch in strong_subadditivity)",
       "Proposed fix: normalize ∑ y ∑ z ∑ x sum order before linarith using Finset.sum_comm"
     ],
-    "assumptions": "0 axioms in this file. Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file).",
+    "assumptions": "0 axioms in this file. Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file). Aristotle companion (ShannonChannelCodingOQ02OQ01Aristotle.lean): 4 open sorries — unit_sum_collapse, conditional_entropy_unit_zero, Pe_unit_zero, fano_trivial_singleton_ari (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 181,
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ShannonEntropyOQ01.lean",
     "tags": [
       "information-theory",
@@ -16,8 +16,8 @@
       "gaussian",
       "gibbs-inequality"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,
@@ -26,7 +26,7 @@
     "additionalFiles": [
       "Proofs/ShannonEntropyOQ01Aristotle.lean"
     ],
-    "assumptions": "None. Fully machine-verified from Mathlib. Uses Bochner integral and Gaussian integration.",
+    "assumptions": "None. Fully machine-verified from Mathlib. Uses Bochner integral and Gaussian integration. Aristotle companion (ShannonEntropyOQ01Aristotle.lean): 2 open sorries — gaussian_second_moment, gaussian_quad_integrable (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "originalContributions": [
       "kl_divergence_continuous_nonneg: D(f||g) \u2265 0 (continuous KL divergence is non-negative)",
       "gibbs_inequality_continuous: h(f) \u2264 -\u222b f\u00b7ln g for any reference density g",
@@ -132,5 +132,5 @@
       "Proofs/ShannonEntropyOQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lieb & Ruskai (1973)",
     "date": "1973",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "information-theory",
       "analysis",
@@ -16,10 +16,10 @@
       "verified"
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 3,
     "axiomCount": 0,
-    "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)).",
+    "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)). Aristotle companion (ShannonEntropySSAAristotle.lean): 3 open sorries — entropy_chain_rule, subadditivity, strong_subadditivity (routine supporting lemmas exposed for automated proof search; main file remains fully verified).",
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",
@@ -215,5 +215,5 @@
       "leanType": "shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Demote 7 gallery entries from `verified` to `axiomatized` because their Aristotle companion files contain open sorries (routine supporting lemmas exposed for automated proof search). Sync `meta.sorries` and top-level `sorries` to the chain total per the convention established in PR #17280 / commit 8b5cbc6010d (area-of-circle-oq-05-oq-01).

`scripts/auditor/find-targets.ts` flagged all 7 with the same drift pattern:
- `❌ sorry mismatch: claims 0, actual N`
- `❌ status "verified" but has N sorries`

## Evidence

| slug | chain sorries | sources (Aristotle companion) |
|------|---------------|-------------------------------|
| shannon-entropy-oq-03 | 3 | `entropy_chain_rule`, `subadditivity`, `strong_subadditivity` |
| burnside-counting-oq-03 | 4 | `card_gcd_eq`, `polya_sum_identity`, `fixed_coloring_orbit_eq`, `fixed_factors_through_mod` |
| shannon-entropy-oq-01 | 2 | `gaussian_second_moment`, `gaussian_quad_integrable` |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 2 | `isClub_inter`, `diagInter_isUnbounded_ari` |
| cayley-hamilton-reduction-oq-02-oq-01 | 12 | 12 routine companion-matrix lemmas (`minpoly_dvd_*`, `charpoly_*`, `dvd_antisymm_monic`, `orbit_basis_independent`, `stdBasis_linearIndependent`, `annihilator_degree_bound`, `monic_*`, `aeval_mulVec`, `aeval_one`) |
| lhopital-oq-02 | 3 | `lhopital_infty_left`, `lhopital_infty_atTop`, `lhopital_infty_atBot` |
| shannon-channel-coding-oq-02-oq-01 | 4 | `unit_sum_collapse`, `conditional_entropy_unit_zero`, `Pe_unit_zero`, `fano_trivial_singleton_ari` |

All main files (e.g. `ShannonEntropySSA.lean`) remain at 0 sorries / 0 axioms — only the Aristotle companions carry the open sorries. `axiomCount` stays at 0 across each chain (none of the companion sorries are `axiom` declarations).

## Changes per entry

- `meta.status`: `"verified"` → `"axiomatized"`
- `meta.badge`: `"original"` / `"mathlib"` → `"axiom"`
- `meta.sorries`: `0` → N (chain total)
- top-level `sorries`: `0` → N (chain total)
- `meta.assumptions`: appended disclosure of companion sorries (clarifies that the main file remains fully verified)
- `leanFile.sorries`: kept at `0` (main file only — convention preserved per PR #17280)

## Verification

- All 7 modified `meta.json` files re-parse as valid JSON.
- Sorry counts confirmed by stripping comments from the Lean source (handles nested block comments) and counting `sorry` occurrences.
- `axiomCount` confirmed at 0 by regex `^\s*axiom\s+` across both main and companion files.

---
Automated fix by lean-mechanic agent.