### PR TITLE
fix(meta): demote 16 verified entries with Aristotle companion sorries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "probability",
       "combinatorics",
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
@@ -174,5 +174,5 @@
       "description": "Uniform fibers preserve uniformOn probability (0 sorries, complete proof)"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "George P\u00f3lya (1937); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polya_enumeration_theorem",
     "date": "1937",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BurnsideCountingOQ03.lean",
     "tags": [
       "combinatorics",
@@ -21,7 +21,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 4,
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean",
     "tags": [
       "set-theory",
@@ -19,7 +19,7 @@
       "combinatorial-set-theory"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
@@ -141,5 +141,5 @@
       "content": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, form diagonal intersection D of avoiding clubs, S \u2229 D is nonempty, take \u03b1 \u2208 S \u2229 D, derive contradiction from f(\u03b1) < \u03b1 and \u03b1 \u2208 C_{f(\u03b1)}."
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -16,7 +16,7 @@
       "rational-canonical-form"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 12,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 0,
+  "sorries": 12,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "chebyshev-pnt-bridge-oq-01",
   "description": "Proves the prime power factorization bound for central binomial coefficients: p^{v_p(C(2n,n))} ≤ 2n. Key ingredient in Chebyshev's proof of Bertrand's postulate. Uses the carry-counting interpretation of Kummer's theorem.",
   "meta": {
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01.lean",
     "tags": [
       "number-theory",
@@ -14,7 +14,7 @@
       "research"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 210,
     "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",
@@ -170,5 +170,5 @@
       "Proofs/ChebyshevPNTBridgeOQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -37,7 +37,7 @@
   "meta": {
     "author": "Classical (Bernstein, Zygmund, Sobolev)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Rate_of_convergence",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourierSeriesOQ02Incomplete01.lean",
     "tags": [
       "analysis",
@@ -48,7 +48,7 @@
       "infrastructure"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 5,
     "dateAdded": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -179,5 +179,5 @@
       "url": "https://en.wikipedia.org/wiki/Harmonic_analysis"
     }
   ],
-  "sorries": 0
+  "sorries": 5
 }

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stokes (1854), Cartan (1945)",
     "date": "1854",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "calculus",
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
     "badge": "original",
-    "sorries": 0,
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries in main file. d^2=0 in 2D (Clairaut's theorem) now proved via ContDiff.contDiffAt.isSymmSndFDerivAt; Green's theorem in Stokes form proved via GreensTheoremOQ01.greens_theorem_concrete.",
     "mathlibDependencies": [
@@ -254,5 +254,5 @@
       "leanType": "Continuous f -> exists F, extDeriv1D F = f"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LHopitalOQ02.lean",
     "tags": [
       "calculus",
@@ -17,7 +17,7 @@
       "indeterminate-forms"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",
@@ -140,7 +140,7 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 0,
+  "sorries": 3,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.LHopital",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "tags": [
       "information-theory",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ03.lean",
     "tags": [
       "information-theory",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",
@@ -225,5 +225,5 @@
       "note": "Chapter 7: Fano's inequality and its application to channel coding converse"
     }
   ],
-  "sorries": 0
+  "sorries": 4
 }

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonEntropyOQ01.lean",
     "tags": [
       "information-theory",
@@ -17,7 +17,7 @@
       "gibbs-inequality"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 2,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,
@@ -132,5 +132,5 @@
       "Proofs/ShannonEntropyOQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lieb & Ruskai (1973)",
     "date": "1973",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "information-theory",
       "analysis",
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
     "badge": "original",
-    "sorries": 0,
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)).",
     "mathlibDependencies": [
@@ -215,5 +215,5 @@
       "leanType": "shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-22",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean",
     "tags": [
       "minimal-polynomial",
@@ -16,7 +16,7 @@
       "square-roots"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 3,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "None. Fully proved: 0 sorries, 0 axioms. Irreducibility is proved over \u2124[X] via case analysis, then transferred to \u211a[X] via Gauss's lemma (Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
@@ -129,5 +129,5 @@
       "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [\u211a(\u221a2+\u221a3):\u211a]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: fully proved by direct algebra \u2014 if \u221a2+\u221a3=q then (q\u00b2-5)/2=\u221a6, contradicting irrationality of \u221a6."
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Stirling (1730), de Moivre (1733)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stirling%27s_approximation#Speed_of_convergence_and_error_estimates",
     "date": "1730",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/StirlingExpansion.lean",
     "tags": [
       "analysis",
@@ -17,7 +17,7 @@
       "bernoulli-numbers"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. The full chain {log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_formula, stirling_step_upper, stirling_step_lower, telescoping helpers (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope), partial-sum bounds (log_stirlingSeq_partial_upper/lower), stirling_first_correction, stirling_two_term_expansion, error_bound_from_correction} is fully proved. The final upper-half exp-Taylor bound is discharged via Real.exp_bound at degree n=2 (|L|≤1 → |exp L − (1+L)| ≤ 3·L²/4), combined with L² ≤ 1/n² (from 0 ≤ L ≤ 1/n) and the algebraic identity L − 1/(12n) ≤ 1/(2n²) (from L ≤ 1/(12(n−1)) + 1/(12(n−1)²)).",
     "dateAdded": "2026-03-29",
@@ -154,5 +154,5 @@
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_formula",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "complex-analysis",
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ02.lean",
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 2,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries via Mathlib bridge. The core step uses Mathlib's NormedSpace.expSeries_div_hasSum_exp for the exp series; all 16 theorems including the bonus bridge lemmas are proved with 0 sorries.",
     "originalContributions": [
@@ -148,5 +148,5 @@
       "Generalize: can this approach prove the power series identity for cosh/sinh (replacing ix with x), giving cosh x = \u2211 x^{2k}/(2k)! and sinh x = \u2211 x^{2k+1}/(2k+1)!?"
     ]
   },
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Cleared the **16 status-verified violations** that PR #17280 deferred. For each entry, the main file is verified (0 sorries) but its Aristotle companion (in `meta.additionalFiles`) carries open sorries for proof search. Per the auditor's chain-aggregation policy and CLAUDE.md (\"verified = 0 sorries\"), these must be demoted to `formalized`.

## Pattern

Each `meta.json` receives a 3-line diff:

```diff
   \"meta\": {
-    \"status\": \"verified\",
+    \"status\": \"formalized\",
     ...
-    \"sorries\": 0,
+    \"sorries\": N,
   },
   ...
-  \"sorries\": 0
+  \"sorries\": N
```

`leanFile.sorries` is preserved at 0 — it is per-file, not chain.

## Counts

| Slug | sorries (chain) |
|------|-----------------|
| ballot-problem-oq-01-oq-02-oq-01 | 1 |
| burnside-counting-oq-03 | 4 |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 2 |
| cayley-hamilton-reduction-oq-02-oq-01 | 12 |
| chebyshev-pnt-bridge-oq-01 | 2 |
| combinations-formula-oq-02 | 1 |
| fourier-series-oq-02-incomplete-01 | 5 |
| fundamental-theorem-calculus-oq-02 | 3 |
| lhopital-oq-02 | 3 |
| shannon-channel-coding-oq-02-oq-01 | 4 |
| shannon-channel-coding-oq-03 | 4 |
| shannon-entropy-oq-01 | 2 |
| shannon-entropy-oq-03 | 3 |
| sqrt2-plus-sqrt3-irrational-oq-03 | 3 |
| stirling-formula-oq-01 | 3 |
| taylor-sincos-convergence-oq-02 | 2 |

Total: 52 chain sorries across 16 entries.

## Validation

After this PR, `npx tsx scripts/auditor/find-targets.ts --all --json` drops from 22 issues → 6 (the 6 plain-drift entries are covered by in-flight PR #17285).

Counts verified against `git show origin/main:` for each main + Aristotle companion file using the auditor's comment-stripping convention.

## Note on \"verified\" loss

The main file's sorry-free status is preserved in `leanFile.sorries: 0`. The status demote is per strict policy (CLAUDE.md table: `verified` requires \"0 sorries\" across all chained files including companions); the more nuanced fix would be to delegate the Aristotle companion lemmas to the main file (see #15815 precedent), but that requires per-entry mathematical analysis and is out of scope for this batch sync.

---
Automated fix by lean-mechanic agent.