### PR TITLE
audit: aggregate companion-file sorries (erdos-628, binomial-theorem, ballot-problem)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,10 +23,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 open sorry: gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners). Axiom-free; all axiom declarations are 0.",
+    "assumptions": "3 open sorries (aggregate across additionalFiles): gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners) + 2 in BallotProblemOQ03OQ01OQ02Aristotle.lean. Axiom-free; all axiom declarations are 0.",
     "lineCount": 398,
     "theoremCount": 16,
     "definitionCount": 1,
@@ -220,5 +220,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,11 +16,11 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 6,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 264,
-    "assumptions": "No axioms. 5 sorries for: ENNReal normalization, support characterization, marginal distributions, mean, and covariance. The Fintype instance and concrete dice example are fully proved.",
+    "assumptions": "No axioms. 6 sorries (aggregate): 5 in main file (ENNReal normalization, support characterization, marginal distributions, mean, covariance) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. The Fintype instance and concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
       "PMF construction via multinomialPMFVal in ENNReal",
@@ -196,5 +196,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 5
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -22,7 +22,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 14,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 246,
-    "assumptions": "4 axioms and 12 sorries (2 sorry-typed parameters on line 209, 10 theorem/proof sorries). The 2 type-annotation sorries on line 209 (hC₁_cycle : sorry) (hC₂_cycle : sorry) were previously miscounted as 1.",
+    "assumptions": "4 axioms and 14 sorries (aggregate): 12 in main file (2 sorry-typed parameters on line 209, 10 theorem/proof sorries) + 2 in Erdos628ProblemAristotle.lean. The 2 type-annotation sorries on line 209 (hC₁_cycle : sorry) (hC₂_cycle : sorry) were previously miscounted as 1.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 12
@@ -229,5 +229,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 12
+  "sorries": 14
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #17287. Three more entries had `meta.sorries` stuck at the main-file count, ignoring sorries in companion files (`*Aristotle.lean`, `*Helpers.lean`) declared in `additionalFiles`. `scripts/auditor/find-targets.ts` aggregates sorry counts across `additionalFiles`, so each was flagged with a `sorry mismatch` on every audit cycle.

| slug                                  | before | after | breakdown                        |
|---------------------------------------|--------|-------|----------------------------------|
| erdos-628                             | 12     | 14    | 12 main + 2 Aristotle            |
| binomial-theorem-oq-02-oq-01-oq-01    | 5      | 6     | 5 main + 1 Aristotle             |
| ballot-problem-oq-03-oq-01-oq-02      | 1      | 3     | 0 main + 1 Helpers + 2 Aristotle |

Status unchanged for all three — erdos-628 stays `axiomatized`, the other two stay `formalized/wip`. `leanFile.sorries` remains the main-file count (12/5/0) per the convention. `meta.assumptions` text updated to describe the aggregate count and its breakdown.

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos628Problem.lean | strip-comments | grep -c '\bsorry\b' → 12
$ git show origin/main:proofs/Proofs/Erdos628ProblemAristotle.lean | strip-comments | grep -c '\bsorry\b' → 2
```

Same methodology applied to all three entries.

After this PR, `find-targets --issues` drops to the verified+Aristotle subset documented in #17291.

## Test plan

- [x] JSON validity verified for all 3 files
- [x] `find-targets --issues` no longer reports any of the 3
- [x] Cross-checked counts against `git show origin/main:` (no working-tree pollution)
- [x] No conflicting open PRs/issues for these slugs

---
Discovered during gallery integrity audit (loom:auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)