### PR TITLE
fix(meta): correct additionalFiles drift (cayley-hamilton-cyclic + erdos-2-oq-01)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
@@ -9,7 +9,7 @@
     "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
     "additionalFiles": [
-      "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
     ],
     "tags": [
       "linear-algebra",

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -18,7 +18,7 @@
       "extension"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 2,
     "erdosUrl": "https://erdosproblems.com/2",
     "erdosProblemStatus": "open-question",
@@ -39,7 +39,8 @@
     ],
     "mathlib_version": "4.29.0",
     "additionalFiles": [
-      "Proofs/Erdos2Problem.lean"
+      "Proofs/Erdos2Problem.lean",
+      "Proofs/Erdos2OQ01Aristotle.lean"
     ],
     "originalContributions": [
       "Formal definition of IsExactMaxMinModulus with equivalent characterizations",
@@ -147,5 +148,5 @@
       "Proofs/Erdos2OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Two `meta.additionalFiles` drift cases where the meta sub-block referenced wrong/incomplete sibling files, hiding chain content from auditor scans.

## Evidence

### cayley-hamilton-cyclic-vector-all-fields-oq-01

**Before**: `meta.additionalFiles = ["Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"]` -- an unrelated WIP file from a different proof's exploration.

**After**: `meta.additionalFiles = ["Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"]` -- the actual Aristotle sibling, matching `lf.additionalFiles`.

Counts unchanged: both files have 0 sorries / 0 axioms, so `verified/original` and `sorries: 0 / axiomCount: 0` claims remain correct.

### erdos-2-oq-01

**Before**: `meta.additionalFiles = ["Proofs/Erdos2Problem.lean"]` (the imported parent sibling), omitting `Erdos2OQ01Aristotle.lean` which carries 1 sorry. Top-level `sorries: 0` was effectively false because the Aristotle file was invisible to find-targets.

**After**: `meta.additionalFiles = ["Proofs/Erdos2Problem.lean", "Proofs/Erdos2OQ01Aristotle.lean"]`. Top-level + meta.sub `sorries: 0 -> 1` to reflect the now-visible chain count.

Status remains `axiomatized/axiom`. Axiom counts unchanged (Aristotle file has 0 axioms).

---
Automated fix by lean-mechanic agent.