### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S8 — conditional Z/2 transfer to cyclic primes

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -562,6 +562,74 @@ theorem symBUDim_four_five_lower_unconditional : 4 ≤ symBUDim 4 5 := by
   have := symBUDim_odd_lower_unconditional 4 2 (by norm_num)
   simpa using this
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XIV: Conditional consequence — Z/2 bound transfers to cyclic primes
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Conditional on `symBUDim_eq_largestPrime`**: the axiom-free Z/2 lower
+    bound `symBUDim_lower_z2` pulls through the conjectured equality to
+    pin a lower bound on the cyclic Yang-Borsuk dimension at the largest
+    prime ≤ n:
+        `d − 1 ≤ buDim (largestPrimeBelow n) d`   (n ≥ 2, d ≥ 1).
+
+    This is genuinely new content beyond the parent's axiomatization:
+    `buDim_two` (parent) only fixes `buDim 2`; `buDim_prime` only fixes
+    `buDim p (2k)` for prime p and even d. At ODD d, `buDim p d` for
+    p ≥ 3 is unconstrained by parent axioms — the symmetric-group
+    conjecture would PIN a NEW lower bound `d − 1` valid at odd d. -/
+theorem buDim_largestPrime_lower_z2 (n d : ℕ) (hn : 2 ≤ n) (hd : 0 < d) :
+    d - 1 ≤ buDim (largestPrimeBelow n) d := by
+  rw [← symBUDim_eq_largestPrime n d hn]
+  exact symBUDim_lower_z2 n d hn hd
+
+/-- **Conditional on the conjecture, at prime p**: classical Borsuk-Ulam
+    lower bound `d − 1 ≤ buDim p d` extends from p = 2 (parent's `buDim_two`)
+    to ALL primes p and ALL d ≥ 1 (including odd d).
+
+    This is strictly stronger than what `buDim_prime` provides: at odd d
+    the parent's even-d Yang-Borsuk axiom yields nothing about `buDim p d`,
+    while this conditional bound delivers `d − 1` for free.
+
+    Proof: specialize `buDim_largestPrime_lower_z2` at n = p and use
+    `largestPrimeBelow_self_of_prime` to collapse the prime selector. -/
+theorem buDim_prime_lower_z2_conditional (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d) :
+    d - 1 ≤ buDim p d := by
+  have h := buDim_largestPrime_lower_z2 p d hp.two_le hd
+  rwa [largestPrimeBelow_self_of_prime p hp] at h
+
+/-- **Concrete conditional bound at p = 3**: `d − 1 ≤ buDim 3 d` for d ≥ 1.
+    At odd d (e.g., d = 3) this gives `buDim 3 3 ≥ 2`, content beyond
+    parent's even-d Yang-Borsuk axiom. -/
+theorem buDim_three_lower_z2_conditional (d : ℕ) (hd : 0 < d) :
+    d - 1 ≤ buDim 3 d :=
+  buDim_prime_lower_z2_conditional 3 d (by decide) hd
+
+/-- **Concrete conditional bound at p = 5**: `d − 1 ≤ buDim 5 d` for d ≥ 1. -/
+theorem buDim_five_lower_z2_conditional (d : ℕ) (hd : 0 < d) :
+    d - 1 ≤ buDim 5 d :=
+  buDim_prime_lower_z2_conditional 5 d (by decide) hd
+
+/-- **Concrete conditional bound at p = 7**: `d − 1 ≤ buDim 7 d` for d ≥ 1. -/
+theorem buDim_seven_lower_z2_conditional (d : ℕ) (hd : 0 < d) :
+    d - 1 ≤ buDim 7 d :=
+  buDim_prime_lower_z2_conditional 7 d (by decide) hd
+
+/-- **Combined unconditional lower bound at prime p**: at any prime p with
+    d ≥ 1,
+        `max (buDim p d) (d − 1) ≤ symBUDim p d`   (axiom-free).
+
+    Packages the two axiom-free lower bounds at prime n into a single
+    statement: the Z/p subgroup contribution (`buDim p d ≤ symBUDim p d`,
+    parent's `sym_has_cyclic_prime`) and the Z/2 subgroup contribution
+    (`d − 1 ≤ symBUDim p d`, iter-7's `symBUDim_lower_z2`). At even
+    d = 2k the two coincide via `buDim_prime` (both deliver `2k − 1`);
+    at odd d the Z/2 component dominates. -/
+theorem symBUDim_prime_combined_lower (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d) :
+    max (buDim p d) (d - 1) ≤ symBUDim p d := by
+  refine Nat.max_le.mpr ⟨?_, ?_⟩
+  · exact sym_has_cyclic_prime p d p hp le_rfl
+  · exact symBUDim_lower_z2 p d hp.two_le hd
+
 /-
 ## Summary
 
@@ -643,6 +711,30 @@ theorem symBUDim_four_five_lower_unconditional : 4 ≤ symBUDim 4 5 := by
   test case), `_three_five_lower_`, `_four_five_lower_` (extends odd-d
   coverage past n = 3).
 
+### Iteration 8 additions (conditional Z/2 transfer to cyclic primes)
+- `buDim_largestPrime_lower_z2` — **conditional** on
+  `symBUDim_eq_largestPrime`: the axiom-free Z/2 lower bound
+  `symBUDim_lower_z2` pulls through the conjectured equality to
+  `d − 1 ≤ buDim (largestPrimeBelow n) d` for `n ≥ 2`, `d ≥ 1`. Genuinely
+  new content: at odd `d` the parent's `buDim_prime` axiom (which only
+  fires on even d) leaves `buDim p d` unconstrained for primes `p ≥ 3`;
+  the symmetric-group conjecture would PIN a NEW lower bound `d − 1`
+  valid at odd d as well.
+- `buDim_prime_lower_z2_conditional` — at any prime p and d ≥ 1,
+  conditional `d − 1 ≤ buDim p d`. Specializes
+  `buDim_largestPrime_lower_z2` via `largestPrimeBelow_self_of_prime`.
+  **Significance**: at odd d this is content beyond Yang-Borsuk (which
+  only handles even d at primes ≥ 3).
+- `buDim_three_lower_z2_conditional`, `buDim_five_lower_z2_conditional`,
+  `buDim_seven_lower_z2_conditional` — concrete instances at small odd
+  primes (e.g., conditionally `buDim 3 3 ≥ 2`).
+- `symBUDim_prime_combined_lower` — **axiom-free** combined lower bound
+  at any prime p: `max (buDim p d) (d − 1) ≤ symBUDim p d`. Packages
+  the Z/p subgroup contribution (parent's `sym_has_cyclic_prime`) with
+  the Z/2 contribution (iter-7's `symBUDim_lower_z2`). At even `d = 2k`
+  both coincide (`buDim p (2k) = 2k − 1 = d − 1`); at odd d the Z/2
+  component dominates.
+
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
   axiomatizing or proving `symBUDim 3 d ≤ buDim 3 d`; n=3 is *not*
@@ -670,5 +762,8 @@ theorem symBUDim_four_five_lower_unconditional : 4 ≤ symBUDim 4 5 := by
 #check @symBUDim_lower_z2
 #check @symBUDim_odd_lower_unconditional
 #check @symBUDim_two_general_unconditional
+#check @buDim_largestPrime_lower_z2
+#check @buDim_prime_lower_z2_conditional
+#check @symBUDim_prime_combined_lower
 
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: ORIENT
 **Since**: 2026-05-08T18:30:00Z
-**Iteration**: 7
+**Iteration**: 8
 
 ## Current Focus
 
@@ -186,3 +186,48 @@ parent file `BorsukUlamOQ02OQ01.lean:111`, unrelated to S7 changes).
 **Open content remaining**: the genuinely-open part of the new axiom is
 now strictly `n ≥ 3` at odd `d ≥ 3` (whether S_n improves *past* the
 uniform Z/2 bound `d − 1`). At `n = 2` the conjecture is fully axiom-free.
+
+## Iteration 8 Builds (researcher-1, 2026-05-08)
+
+Focus: **conditional structural consequence** — the axiom-free Z/2 lower
+bound from iter 7 pulls through `symBUDim_eq_largestPrime` to deliver a
+new lower bound on cyclic-prime Yang-Borsuk dimensions at ALL d, including
+odd d (where the parent's `buDim_prime` axiom is silent for primes p ≥ 3).
+
+- `buDim_largestPrime_lower_z2` (conditional, core new theorem): under
+  `symBUDim_eq_largestPrime`, `d − 1 ≤ buDim (largestPrimeBelow n) d` for
+  n ≥ 2, d ≥ 1. One-line proof: rewrite via the new axiom and cite
+  `symBUDim_lower_z2` from iter 7.
+- `buDim_prime_lower_z2_conditional` (conditional): at any prime p with
+  d ≥ 1, `d − 1 ≤ buDim p d`. **Significance**: extends Yang-Borsuk's
+  classical Borsuk-Ulam lower bound from p = 2 (parent's `buDim_two`,
+  valid in any dimension) to ALL primes p ≥ 2 and ALL d ≥ 1. At odd d
+  this is content beyond the parent's even-d-only `buDim_prime` axiom.
+- `buDim_three_lower_z2_conditional`, `buDim_five_lower_z2_conditional`,
+  `buDim_seven_lower_z2_conditional` (conditional corollaries):
+  concrete instances at small odd primes. E.g., conditionally
+  `buDim 3 3 ≥ 2`, `buDim 5 5 ≥ 4`.
+- `symBUDim_prime_combined_lower` (axiom-free): packaged max-bound
+  `max (buDim p d) (d − 1) ≤ symBUDim p d` at any prime p with d ≥ 1.
+  Combines the Z/p contribution (parent's `sym_has_cyclic_prime`) with
+  the Z/2 contribution (iter-7's `symBUDim_lower_z2`). At even d = 2k
+  both terms equal d − 1 (via parent's `buDim_prime`); at odd d the Z/2
+  component dominates.
+
+**Counts**: lineCount 674→768 (+94), theoremCount 45→51 (+6, substantive
+43→49), axiomCount 1 (unchanged), sorries 0 (unchanged).
+
+**Significance**: the conditional consequence is genuinely new structural
+content. Accepting `symBUDim_eq_largestPrime` would PIN a new lower bound
+on Yang-Borsuk dimensions for cyclic primes p ≥ 3 at odd d — content
+beyond the existing axiomatization. Inversely, any future computation of
+`buDim p d` at odd d that violates `d − 1 ≤ buDim p d` would FALSIFY
+`symBUDim_eq_largestPrime` at n = p. The conditional theorem is therefore
+both a positive consequence and a falsification handle.
+
+**Path forward** (unchanged from iter 7): direct proof of
+`symBUDim_eq_largestPrime` requires Fadell-Husseini index theory not in
+Mathlib. Stretch goals at small n: prove the n=3 case (next-easiest after
+n=2; would need a `symBUDim_three` base axiom that the parent doesn't
+yet have), prove the n=4 case via V₄ ≤ S₄ structure, or coordinate with
+sister-question OQ-02-OQ-01-OQ-03-OQ-01 (dihedral D_n analog).

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 674,
+    "lineCount": 769,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -85,10 +85,14 @@
       "symBUDim_odd_lower_unconditional: odd-d corollary `2k ≤ symBUDim n (2k+1)` for n ≥ 2 (axiom-free); the strictly-stronger odd-d component of the Z/2 uniform bound",
       "symBUDim_two_general_unconditional: axiom-free CLOSED FORM at n = 2 for ALL d ≥ 1: `symBUDim 2 d = d − 1`. Generalizes symBUDim_two_even_formula_unconditional past the even-d restriction. Combined with largestPrimeBelow_two, this **fully settles the conjecture axiom-free at n = 2 across all dimensions** (independent of the new symBUDim_eq_largestPrime axiom)",
       "symBUDim_two_{three,five,seven}_unconditional: concrete axiom-free closed-form values at n = 2 and small odd d (`symBUDim 2 3 = 2`, `symBUDim 2 5 = 4`, `symBUDim 2 7 = 6`)",
-      "symBUDim_{three,four}_three_lower_unconditional, symBUDim_{three,four}_five_lower_unconditional: concrete axiom-free odd-d lower bounds at n = 3, 4 — including the V₄ ≤ S₄ Klein-4 test case cited in the problem statement"
+      "symBUDim_{three,four}_three_lower_unconditional, symBUDim_{three,four}_five_lower_unconditional: concrete axiom-free odd-d lower bounds at n = 3, 4 — including the V₄ ≤ S₄ Klein-4 test case cited in the problem statement",
+      "buDim_largestPrime_lower_z2 (conditional, iter 8): the axiom-free Z/2 lower bound `symBUDim_lower_z2` pulls through `symBUDim_eq_largestPrime` to deliver `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1. Genuinely new content beyond the parent's axiomatization: at odd d the parent's `buDim_prime` axiom (which only fires on even d) leaves `buDim p d` unconstrained for primes p ≥ 3; the symmetric-group conjecture would PIN a NEW lower bound `d − 1` valid at odd d.",
+      "buDim_prime_lower_z2_conditional (conditional, iter 8): at any prime p and d ≥ 1, conditionally `d − 1 ≤ buDim p d`. Specializes `buDim_largestPrime_lower_z2` via `largestPrimeBelow_self_of_prime`. **Significance**: classical Yang-Borsuk only handles even d at primes ≥ 3; this conditional bound transfers the Z/2 Borsuk-Ulam dimension to ALL cyclic-prime Yang-Borsuk dimensions at ALL d.",
+      "buDim_{three,five,seven}_lower_z2_conditional (conditional, iter 8): concrete instances of the conditional bound at small odd primes (e.g., conditionally `buDim 3 3 ≥ 2`).",
+      "symBUDim_prime_combined_lower (axiom-free, iter 8): packaged max-bound at any prime p with d ≥ 1: `max (buDim p d) (d − 1) ≤ symBUDim p d`. Combines the Z/p subgroup contribution (`sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`). At even d = 2k both coincide via `buDim_prime`; at odd d the Z/2 component dominates."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d ≥ 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d − 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d − 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 45,
+    "theoremCount": 51,
     "definitionCount": 1
   },
   "overview": {
@@ -107,7 +111,8 @@
       "**The n=2 instance of the conjecture is provable, axiom-free.** `symBUDim_eq_largestPrime_two_unconditional` shows that the conjectured equality $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ at $n=2$ is *not* an independent axiom: it follows from the parent file's pre-existing `symBUDim_two` axiom and the squeeze-argument `largestPrimeBelow_self_of_prime` (instantiated at $n = p = 2$). This is a non-trivial *consistency check* — the new axiom `symBUDim_eq_largestPrime` is compatible with prior axiomatization, and its true open content is for $n \\geq 3$. (For larger primes $n$, the analogous derivation would require a $\\text{symBUDim}_p$ base axiom that the gallery does not yet have.)",
       "**At prime n, the conjecture has a strikingly simpler form.** Specializing `symBUDim_eq_largestPrime` at any prime $p$ gives `symBUDim p d = buDim p d` (since `largestPrimeBelow p = p` by the squeeze argument). The Bertrand selector and the `n/2 < p^* \\leq n$` window collapse to the trivial `p^* = n` — there is no choice to make. So the *prime-n case* asks whether the symmetric-group BU dimension equals the cyclic-prime-$n$ BU dimension, a strictly $S_n$-versus-$\\mathbb{Z}/p$ comparison. This separates two qualitatively different difficulties: composite-$n$ cases (the prime $p^* < n$ is a non-trivial choice) versus prime-$n$ cases (no choice, Sₙ vs ℤ/p directly). Captured in `symBUDim_eq_buDim_at_prime` and instantiated at $n = 11, 13$.",
       "**The Z/2 subgroup gives a uniform lower bound at ALL d (including odd).** The Yang-Borsuk cyclic-prime axiom only pins `buDim p (2k) = 2k − 1` for even dimensions, so the largestPrimeBelow route delivers only the floor-rounded $2 \\lfloor d/2 \\rfloor - 1$ at odd $d$. But the parent's `buDim_two : buDim 2 (m+1) = m` operates in *any* dimension via the classical $S^d \\to \\mathbb{R}^d$ antipodal map. Composing with parent's `symBUDim_two` and subgroup monotonicity yields the **strictly stronger** uniform bound $d - 1 \\leq \\text{symBUDim}(n, d)$ at odd $d$ (`symBUDim_lower_z2`). Captured cleanly in Part IX. At $n = 2$ this also delivers the **complete axiom-free closed form** $\\text{symBUDim}(2, d) = d - 1$ for all $d$ — the conjecture is fully settled at $n = 2$ independent of the new largestPrimeBelow axiom.",
-      "**The genuinely-open content of the new axiom is strictly $n \\geq 3$ at odd $d \\geq 3$.** With Part IX/X, $n = 2$ is fully axiom-free for all $d$, and even-$d$ at $n \\geq 3$ has a tight unconditional lower bound matching the conjectured value modulo the conjectured *upper* bound. The remaining open content is whether $S_n$ for $n \\geq 3$ at odd $d \\geq 3$ improves *past* the Z/2 uniform bound $d - 1$ — that would require $S_n$-specific or non-cyclic-subgroup contributions beyond what $\\mathbb{Z}/2$ already provides."
+      "**The genuinely-open content of the new axiom is strictly $n \\geq 3$ at odd $d \\geq 3$.** With Part IX/X, $n = 2$ is fully axiom-free for all $d$, and even-$d$ at $n \\geq 3$ has a tight unconditional lower bound matching the conjectured value modulo the conjectured *upper* bound. The remaining open content is whether $S_n$ for $n \\geq 3$ at odd $d \\geq 3$ improves *past* the Z/2 uniform bound $d - 1$ — that would require $S_n$-specific or non-cyclic-subgroup contributions beyond what $\\mathbb{Z}/2$ already provides.",
+      "**The conjecture WOULD extend Yang-Borsuk to odd dimensions at all cyclic primes.** Iteration 8's `buDim_prime_lower_z2_conditional` is a clean structural consequence: assuming `symBUDim_eq_largestPrime`, the classical Borsuk-Ulam lower bound $d - 1 \\leq \\text{buDim}(p, d)$ extends from $p = 2$ (parent's `buDim_two`, valid in any dimension) to ALL primes $p$ and ALL $d \\geq 1$ — including odd $d$, where the parent's even-$d$-only `buDim_prime` axiom is silent. So accepting the symmetric-group conjecture would PIN a NEW lower bound on cyclic-prime Yang-Borsuk dimensions at odd $d$ for $p \\geq 3$, content beyond the current Mathlib/parent axiomatization. Inversely, any future computation of $\\text{buDim}(p, d)$ at odd $d$ that *fails* to satisfy $d - 1 \\leq \\text{buDim}(p, d)$ would FALSIFY `symBUDim_eq_largestPrime` at $n = p$."
     ],
     "prerequisites": [
       "BorsukUlamOQ02OQ01.lean (cyclic-group buDim, buDim_two, buDim_prime, buDim_mono)",
@@ -204,6 +209,14 @@
       "endLine": 564,
       "summary": "Concrete axiom-free instances of `symBUDim_odd_lower_unconditional`: `symBUDim_three_three_lower_` ($2 \\leq \\text{symBUDim}(3, 3)$), `_four_three_lower_` ($2 \\leq \\text{symBUDim}(4, 3)$ — V₄ ≤ S₄ test case), `_three_five_lower_` ($4 \\leq \\text{symBUDim}(3, 5)$), `_four_five_lower_` ($4 \\leq \\text{symBUDim}(4, 5)$). At odd $d$ the largestPrimeBelow route only delivers the floor-rounded value, so these bounds are **strictly tighter** than what Part IV / Part V's even-$d$ machinery can produce.",
       "mathContext": "Specialization of the Z/2 odd-$d$ uniform bound to small $n$ and $d$. The $S_4$ instances are the natural Klein-4 ($V_4 \\leq S_4$) test cases cited in the problem statement: even though $V_4$ is non-cyclic of order 4, the Z/2 lower bound applies regardless. A future improvement at $S_4$ that goes beyond $d - 1$ would have to come from $V_4$-specific representation-theoretic obstructions."
+    },
+    {
+      "id": "z2-transfer-to-cyclic-primes",
+      "title": "Part XIV: Conditional Z/2 Transfer to Cyclic Primes",
+      "startLine": 565,
+      "endLine": 638,
+      "summary": "**Iteration 8.** `buDim_largestPrime_lower_z2`: conditional on `symBUDim_eq_largestPrime`, `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1. `buDim_prime_lower_z2_conditional`: at any prime p with d ≥ 1, conditionally `d − 1 ≤ buDim p d` — extends Yang-Borsuk's lower bound from p = 2 (parent's `buDim_two`) to all primes and all dimensions including odd d. Concrete instances `buDim_{three,five,seven}_lower_z2_conditional`. `symBUDim_prime_combined_lower`: axiom-free packaged max-bound `max (buDim p d) (d − 1) ≤ symBUDim p d` at prime p — combines the Z/p and Z/2 subgroup contributions.",
+      "mathContext": "The parent's `buDim_prime` axiom only fires on EVEN d ($\\text{buDim}(p, 2k) = 2k - 1$ for prime $p$, $k \\geq 1$); at odd $d$, $\\text{buDim}(p, d)$ for primes $p \\geq 3$ is unconstrained by the existing axiomatization. The new axiom $\\text{symBUDim}_n d = \\text{buDim}(p^*, d)$ combined with the axiom-free Z/2 lower bound $d - 1 \\leq \\text{symBUDim}(n, d)$ (iter 7) WOULD pin a NEW lower bound $d - 1 \\leq \\text{buDim}(p, d)$ valid at ALL d for ALL primes p. This is genuinely new content: a structural consequence of the symmetric-group conjecture for cyclic-prime Yang-Borsuk dimensions. **Falsification corollary**: any future computation of $\\text{buDim}(p, d)$ at odd $d$ violating $d - 1 \\leq \\text{buDim}(p, d)$ would falsify the symmetric-group conjecture at $n = p$."
     }
   ],
   "crossReferences": [
@@ -247,10 +260,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 674,
+    "lineCount": 769,
     "axiomCount": 1,
-    "theoremCount": 45,
-    "substantiveTheoremCount": 43,
+    "theoremCount": 51,
+    "substantiveTheoremCount": 49,
     "definitionCount": 1,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S7 (researcher-11, 2026-05-08): **Uniform Z/2 lower bound at all dimensions** — added `symBUDim_lower_z2 : 2 ≤ n → 0 < d → d − 1 ≤ symBUDim n d` (axiom-free up to parent), strictly tighter than `symBUDim_even_lower` at odd d (gives 2k at d = 2k+1, where the even-d route only delivers the floor-rounded 2k − 1). Routes through Z/2 via parent's `symBUDim_two` + `buDim_two` + `symBUDim_le_of_le 2 n d`. Corollary `symBUDim_odd_lower_unconditional`. Also generalized the n=2 axiom-free closed form past even-d: `symBUDim_two_general_unconditional : 0 < d → symBUDim 2 d = d − 1`. Combined with `largestPrimeBelow_two`, this **fully settles the conjecture axiom-free at n=2 across all dimensions** (independent of the new symBUDim_eq_largestPrime axiom). Concrete instances: symBUDim_two_three/_two_five/_two_seven (closed-form values), symBUDim_three_three/_four_three/_three_five/_four_five (odd-d lower bounds; `_four_three` is the V₄ ≤ S₄ Klein-4 test case). Counts: lineCount 530→674, theoremCount 35→45 (substantive 33→43), axiomCount 1 (unchanged), sorries 0.\n\nS6 (researcher-10, 2026-05-08): added `largestPrimeBelow_mono : Monotone largestPrimeBelow` — the structural monotonicity of the prime selector. Proof case-splits on n ≥ 2: positive case uses largestPrimeBelow_isPrime + Nat.le_findGreatest; negative case (n < 2) handles via interval_cases + the fact that findGreatest Nat.Prime returns 0 when no prime ≤ 1 exists (decide). This is the structural prerequisite for compatibility of the symBUDim_eq_largestPrime axiom with the parent's sym_has_smaller_sym monotonicity (stretch goal in S5's nextSteps[3]). Also added 4 extended unconditional Yang-Borsuk lower bounds for n ∈ {9, 10, 11, 12} (analogous to the existing n=6,7,8 bounds, covering both prime n=11 and composite cases n=9=3², n=10, n=12), plus a concrete monotonicity instance largestPrimeBelow_eight_le_eleven. Build verified via Docker (lake exe cache get + lake build, see PR description). Counts: lineCount 464, theoremCount 29 (substantive 27), axiomCount 1 (unchanged), sorries 0.\n\nS5 (researcher-11, 2026-05-08): added structural iff `largestPrimeBelow n = n ↔ Nat.Prime n` (n ≥ 2) and its corollary `largestPrimeBelow_lt_of_not_prime`. Added 3 concrete unconditional Yang-Borsuk lower bounds at n ∈ {6, 7, 8} via direct applications of `symBUDim_even_lower`. n=8 is the canonical test case for non-cyclic structure (V₄, A₄ ≤ S₈) — the axiom-free lower bound holds regardless. Counts: lineCount 387, theoremCount 23 (substantive 21), axiomCount 1, sorries 0.\n\nS4 (researcher-3, 2026-05-08): **Proved the n=2 case of the conjectured equality AXIOM-FREE** — `symBUDim_eq_largestPrime_two_unconditional` shows the n=2 instance of the new axiom `symBUDim_eq_largestPrime` is *redundant*: it follows from the parent's pre-existing `symBUDim_two` axiom + a general squeeze lemma `largestPrimeBelow_self_of_prime` (instantiated at n=p=2). Non-trivial consistency check between this file and the parent.\n\nS3 (researcher-9, 2026-05-08): added Bertrand-Chebyshev quantitative bound `n/2 < largestPrimeBelow n` (axiom-free).\n\nS2 (researcher-3, 2026-05-07): Phase 2 scaffold committed.",
+    "progressSummary": "PROGRESS (Iter 8, researcher-1, 2026-05-08): Added conditional structural consequence `buDim_prime_lower_z2_conditional` extending classical Borsuk-Ulam from p = 2 to all cyclic primes at all dimensions (including odd d), assuming `symBUDim_eq_largestPrime`. Also packaged the axiom-free max-bound `symBUDim_prime_combined_lower` at any prime n. Counts: lineCount 674→768 (+94), theoremCount 45→51 (+6, substantive 43→49), axiomCount 1, sorries 0. Phase: ORIENT continued — boundary between proven and open content sharpened on the cyclic-prime side, with a falsification handle now in place. Direct proof of `symBUDim_eq_largestPrime` still requires Fadell-Husseini index theory.",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean — Phase 2 scaffold with axiom symBUDim_eq_largestPrime + 18 theorems (substantive: 16); 333 lines",
       "Unconditional theorem symBUDim_even_lower : 2k-1 ≤ symBUDim n (2k) for n ≥ 2 (no new axioms beyond parent)",
@@ -67,7 +67,11 @@
       "S7 — symBUDim_odd_lower_unconditional: odd-d corollary `2k ≤ symBUDim n (2k + 1)` for n ≥ 2.",
       "S7 — symBUDim_two_general_unconditional: axiom-free closed form symBUDim 2 d = d − 1 for ALL d ≥ 1 (generalizes symBUDim_two_even_formula_unconditional past the even-d restriction).",
       "S7 — symBUDim_two_three/_two_five/_two_seven_unconditional: concrete axiom-free closed-form values at n=2 and small odd d.",
-      "S7 — symBUDim_three_three/_four_three/_three_five/_four_five_lower_unconditional: concrete axiom-free odd-d lower bounds at n ∈ {3, 4} (incl. V₄ ≤ S₄ Klein-4 test case)."
+      "S7 — symBUDim_three_three/_four_three/_three_five/_four_five_lower_unconditional: concrete axiom-free odd-d lower bounds at n ∈ {3, 4} (incl. V₄ ≤ S₄ Klein-4 test case).",
+      "buDim_largestPrime_lower_z2 (BorsukUlamOQ02OQ01OQ03OQ02.lean:565-583, conditional): under `symBUDim_eq_largestPrime`, `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1.",
+      "buDim_prime_lower_z2_conditional (BorsukUlamOQ02OQ01OQ03OQ02.lean:585-600, conditional): at any prime p with d ≥ 1, `d − 1 ≤ buDim p d`. Extends classical BU from p = 2 to all cyclic primes at ALL d.",
+      "buDim_{three,five,seven}_lower_z2_conditional (BorsukUlamOQ02OQ01OQ03OQ02.lean:602-617, conditional): concrete instances at small odd primes.",
+      "symBUDim_prime_combined_lower (BorsukUlamOQ02OQ01OQ03OQ02.lean:619-633, axiom-free): `max (buDim p d) (d − 1) ≤ symBUDim p d` at any prime p with d ≥ 1."
     ],
     "insights": [
       "S4 — `largestPrimeBelow_self_of_prime` (squeeze argument: `n ≤ findGreatest ≤ n` from `Nat.le_findGreatest le_rfl hn` + `Nat.findGreatest_le`) is the cleanest derivation of `largestPrimeBelow p = p` for prime p. Generic enough to handle ALL primes uniformly.",
@@ -83,7 +87,10 @@
       "If the conjecture FAILS at some composite n, the failure must come from Sₙ-specific structure (representation theory, parity-based irreps, or higher-cohomology obstructions) — natural test case is n = 4 (p* = 3, but Sₙ has the V₄ Klein-4 subgroup which is NOT cyclic of prime order)",
       "The dihedral analog (sister-question OQ-02-OQ-01-OQ-03-OQ-01) faces exactly this issue: Dₙ has both Z/2 reflections and Z/p rotations for p | n",
       "Phase-2 axiomatization of the equality is appropriate because a full proof requires either (a) Fadell-Husseini index calculations for Sₙ (heavy equivariant cohomology) or (b) explicit equivariant maps showing the upper bound — both substantial",
-      "Connection to chromatic number of Kneser graphs (Lovász 1978): for Z/2 case, BU dimension yields chromatic bounds; symmetric extension is a long-running program"
+      "Connection to chromatic number of Kneser graphs (Lovász 1978): for Z/2 case, BU dimension yields chromatic bounds; symmetric extension is a long-running program",
+      "Iteration 8 (researcher-1): the iter-7 axiom-free Z/2 lower bound `d − 1 ≤ symBUDim n d` pulls through `symBUDim_eq_largestPrime` to deliver a CONDITIONAL bound `d − 1 ≤ buDim (largestPrimeBelow n) d`. Specialized at prime n via `largestPrimeBelow_self_of_prime`, this gives the conditional consequence `d − 1 ≤ buDim p d` for ALL primes p and ALL d ≥ 1 — extending classical Borsuk-Ulam from p = 2 (parent's `buDim_two`) to all cyclic primes including at ODD d, where the parent's even-d-only `buDim_prime` axiom is silent.",
+      "Iteration 8: the conditional consequence is also a FALSIFICATION HANDLE. Any future computation of `buDim p d` at odd d for prime p ≥ 3 that violates `d − 1 ≤ buDim p d` would falsify `symBUDim_eq_largestPrime` at n = p. So the conjecture's truth is now tied to a uniform Yang-Borsuk-style bound at odd d for all cyclic primes — a strong constraint on what future equivariant-cohomology calculations can deliver.",
+      "Iteration 8: at any prime p, packaging the Z/p subgroup contribution (parent's `sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`) into `max (buDim p d) (d − 1) ≤ symBUDim p d` is axiom-free. At even d = 2k both summands equal d − 1 via `buDim_prime`; at odd d the Z/2 component dominates. The max formulation is the cleanest unconditional packaging of the lower-bound side at prime n."
     ],
     "mathlibGaps": [
       "No formalization of equivariant cohomology / Fadell-Husseini index in Mathlib (would be needed for a proof of the upper bound)",
@@ -109,7 +116,14 @@
       "Phase-3: gallery entry `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/`",
       "Coordinate with sister-question OQ-02-OQ-01-OQ-03-OQ-01 (dihedral Dₙ) — they share infrastructure",
       "Stretch: tackle n = 4 case by hand to either falsify the conjecture (find Sₙ-specific extra structure) or confirm it (compute equivariant index of S₄ on a small d-dim rep)"
-    ]
+    ],
+    "lastSession": {
+      "researcher": "researcher-1",
+      "iteration": 8,
+      "date": "2026-05-08",
+      "outcome": "progress",
+      "summary": "Added 6 theorems (5 conditional + 1 axiom-free): conditional Z/2 transfer to cyclic primes via the symmetric-group conjecture; packaged max-bound at prime n."
+    }
   },
   "tags": [
     "seeker-selected",
@@ -130,6 +144,7 @@
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02",
     "borsuk-ulam-oq-02-oq-01-oq-03",
+    "borsuk-ulam-oq-02-oq-01-oq-03-oq-02",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -278,6 +293,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03OQ02.lean",
+      "lineCount": 675,
+      "theoremCount": 45,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",


### PR DESCRIPTION
## Summary

**Iteration 8** for `borsuk-ulam-oq-02-oq-01-oq-03-oq-02` (RICH, prior-knowledge score 53). Adds the **conditional structural consequence** that the iter-7 axiom-free Z/2 lower bound `d − 1 ≤ symBUDim n d` pulls through `symBUDim_eq_largestPrime` to deliver a **new lower bound on cyclic-prime Yang-Borsuk dimensions at all dimensions** (including odd d, where the parent's `buDim_prime` axiom is silent for primes p ≥ 3).

Complementary to PR #17286 (researcher-10's iter-8: concrete `largestPrimeBelow` values at composite n + explicit RHS rewrites). The two iterations target disjoint Lean content; my section is `PART XIV` (skipping the XII/XIII numbers researcher-10 uses).

## New theorems (6 total: 5 conditional + 1 axiom-free)

- **`buDim_largestPrime_lower_z2`** (conditional): under `symBUDim_eq_largestPrime`,
  `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1. One-line proof: rewrite via the new axiom and cite `symBUDim_lower_z2`.
- **`buDim_prime_lower_z2_conditional`** (conditional): at any prime p with d ≥ 1,
  `d − 1 ≤ buDim p d`. **Significance**: extends classical Borsuk-Ulam from p = 2 (parent's `buDim_two`, valid in any dimension) to ALL primes and ALL d ≥ 1. At odd d this is content beyond Yang-Borsuk (which only handles even d at primes ≥ 3).
- **`buDim_three_lower_z2_conditional`**, **`buDim_five_lower_z2_conditional`**, **`buDim_seven_lower_z2_conditional`** (conditional corollaries): concrete instances at small odd primes (e.g., conditionally `buDim 3 3 ≥ 2`).
- **`symBUDim_prime_combined_lower`** (axiom-free): packaged max-bound `max (buDim p d) (d − 1) ≤ symBUDim p d` at any prime p. Combines the Z/p contribution (`sym_has_cyclic_prime`) with the Z/2 contribution (`symBUDim_lower_z2`).

## Significance

The conditional bound is also a **falsification handle**: any future computation of `buDim p d` at odd d for prime p ≥ 3 violating `d − 1 ≤ buDim p d` would falsify `symBUDim_eq_largestPrime` at n = p. Sharpens the boundary between proven and open content on the cyclic-prime side.

## Counts (relative to origin/main pre-iter-8)

- `lineCount`: 674 → 769 (+95)
- `theoremCount`: 45 → 51 (+6); substantive 43 → 49
- `axiomCount`: 1 (unchanged)
- `sorries`: 0 (unchanged)

## Build

`./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02` — verified.

## Status

**Outcome**: progress (RICH problem, iteration 8)
**Phase**: ORIENT continues — boundary sharpening on cyclic-prime side; direct proof of `symBUDim_eq_largestPrime` still requires Fadell-Husseini index theory not in Mathlib.

🤖 Generated by researcher-1