### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01-oq-03 — lineCount 550→604, theoremCount 16→18

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 550,
+    "lineCount": 604,
     "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The Session-2 `standardNormalCDF` opaque marker has been replaced (Session 6) by a concrete `noncomputable def` integrating Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`; this removes that declaration from the assumption count and adds four elementary structural lemmas (`standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono`, `standardNormalCDF_continuous` [Session 7]) that together establish Φ is a *bona fide* continuous CDF on ℝ — every point is a continuity point, so the Portmanteau bridge that next session will build to discharge the axiom applies universally. Session 8 (this session, complementary track) adds two asymptotic-saturation lemmas on the binomialCDF side — `binomialCDF_tendsto_one_atTop` (binomialCDF n p x → 1 as x → +∞, eventually-constant via `binomialCDF_eq_one`) and `binomialCDF_tendsto_zero_atBot` (binomialCDF n p x → 0 as x → -∞, eventually-constant via `binomialCDF_neg`). The matching standardNormalCDF tail-limit lemmas (Φ → 1 at +∞ and Φ → 0 at -∞) are added in the parallel S8 PR #17233; together the two PRs complete the right-tail tendsto saturation on both sides of the Portmanteau convergence. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` was proved in Phase-3: it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
@@ -42,7 +42,7 @@
       "binomialCDF_tendsto_one_atTop (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) under 0 ≤ p ≤ 1 — eventually-constant wrapper around `binomialCDF_eq_one` via `Filter.eventually_ge_atTop (n : ℝ)` and `Tendsto.congr'`. Binomial-side companion to the Φ tail-limit lemmas added in parallel S8 PR #17233",
       "binomialCDF_tendsto_zero_atBot (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atBot (nhds 0) — eventually-constant wrapper around `binomialCDF_neg` via `Filter.eventually_lt_atBot (0 : ℝ)`. Left-tail saturation; no constraint on p needed since `binomialCDF_neg` holds for arbitrary p"
     ],
-    "theoremCount": 16,
+    "theoremCount": 18,
     "substantiveTheoremCount": 12,
     "definitionCount": 3
   },
@@ -64,9 +64,9 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 550,
+    "lineCount": 604,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "substantiveTheoremCount": 12,
     "duplicateTheorems": 0,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` (550→604) and `theoremCount` (16→18) on `binomial-theorem-oq-02-oq-01-oq-01-oq-03` after the S8 research merge in PR #17233 (Φ tail-limit lemmas) added `binomialCDF_tendsto_one_atTop` and `binomialCDF_tendsto_zero_atBot`.

Both the `meta.*` and `leanFile.*` blocks were stale.

## Evidence

**Before**: `lineCount: 550`, `theoremCount: 16`
**After**: `lineCount: 604`, `theoremCount: 18`

Verified counts on `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`:
- `wc -l` → 604
- 18 theorem/lemma declarations after stripping comments (was 16; +2 from S8 PR #17233)
- definitionCount unchanged (3)
- axiomCount unchanged (1)
- sorries unchanged (0)

`substantiveTheoremCount` left at 12 (curatorial value, not auto-synced).

## Background

find-targets.ts checks structural dimensions only via the `lf` block; the upstream find-targets misses `lineCount`/`theoremCount` drift. This is a manual scan-detected sync after a research merge.

---
Automated fix by lean-mechanic agent.