### PR TITLE
research(hilbert-10-oq-01-oq-02): S10.3 — finite-list closure of Σ₁/Π₁ (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -985,6 +985,103 @@ theorem notSingletonPair_isExistentialUniversalDefinition (a b : Rat) :
     (notSingletonPair_isCoDiophantineDefinition a b)
 
 -- ============================================================
+-- Part VIII.10: Finite-list closure (iteration 10, S10.3)
+-- ============================================================
+
+/-- Iter 10, Path B: **every FINITE subset of ℚ is Σ₁-definable**.
+
+    By induction on a list `l : List Rat`, the predicate `q ∈ l` is
+    Σ₁-definable. Base case: empty list, predicate is `False` — covered
+    by `empty_isDiophantineDefinition`. Inductive step: `q ∈ a :: t`
+    unfolds (via `List.mem_cons`) to `q = a ∨ q ∈ t`, which is
+    Σ₁-definable by `union_isDiophantineDefinition` of S8's
+    `singletonOf_isDiophantineDefinition a` and the induction hypothesis.
+
+    The product polynomial witness for the induction step is
+    `P(q, x) = (q - a) · P_t(q, x)` where `P_t` is the inductive witness
+    for `q ∈ t`; existence of a rational solution corresponds (via
+    `mul_eq_zero`) to either `q = a` or `q ∈ t`.
+
+    This makes precise the OPEN/closed-under-finite gap: every FINITE
+    truncation `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` of ℤ ⊂ ℚ is Σ₁-definable for
+    every finite `N`, but a UNIFORM Σ₁ witness for the full countable
+    union `⋃_{n : ℤ} {n}` is the OPEN content of the question. -/
+theorem finUnionList_singletons_isDiophantineDefinition (l : List Rat) :
+    IsDiophantineDefinition (fun q : Rat => q ∈ l) := by
+  induction l with
+  | nil =>
+    -- `q ∈ ([] : List Rat)` reduces to `False` propositionally.
+    have hbridge : ∀ q : Rat, (fun q : Rat => q ∈ ([] : List Rat)) q ↔
+        (fun _ : Rat => False) q := by
+      intro q; simp
+    exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr
+      empty_isDiophantineDefinition
+  | cons a t ih =>
+    -- `q ∈ a :: t  ↔  q = a ∨ q ∈ t`, then close via union closure of S9.
+    have hbridge : ∀ q : Rat, (fun q : Rat => q ∈ (a :: t)) q ↔
+        (fun q : Rat => q = a ∨ q ∈ t) q := by
+      intro q; exact List.mem_cons
+    have h_singleton : IsDiophantineDefinition (fun q : Rat => q = a) :=
+      singletonOf_isDiophantineDefinition a
+    have h_union : IsDiophantineDefinition (fun q : Rat => q = a ∨ q ∈ t) :=
+      union_isDiophantineDefinition h_singleton ih
+    exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr h_union
+
+/-- Iter 10 corollary, Path B: **every complement of a finite subset of ℚ
+    is Π₁-definable**.
+
+    Direct dual of `finUnionList_singletons_isDiophantineDefinition`: the
+    predicate `q ∉ l` is Π₁-definable for every `l : List Rat`. Proved by
+    induction mirroring the Σ₁ case, using
+    `intersection_isCoDiophantineDefinition` (S9 dual) for the inductive
+    step and `notSingletonOf_isCoDiophantineDefinition` for the cons head. -/
+theorem finIntersectionList_complement_singletons_isCoDiophantineDefinition
+    (l : List Rat) :
+    IsCoDiophantineDefinition (fun q : Rat => q ∉ l) := by
+  induction l with
+  | nil =>
+    -- `q ∉ ([] : List Rat)` is `True` propositionally.
+    have hbridge : ∀ q : Rat, (fun q : Rat => q ∉ ([] : List Rat)) q ↔
+        (fun _ : Rat => True) q := by
+      intro q; simp
+    exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr
+      universe_isCoDiophantineDefinition
+  | cons a t ih =>
+    -- `q ∉ a :: t  ↔  q ≠ a ∧ q ∉ t`, then close via intersection closure of S9.
+    have hbridge : ∀ q : Rat, (fun q : Rat => q ∉ (a :: t)) q ↔
+        (fun q : Rat => q ≠ a ∧ q ∉ t) q := by
+      intro q
+      constructor
+      · intro hq
+        refine ⟨fun heq => hq ?_, fun hmem => hq ?_⟩
+        · exact List.mem_cons.mpr (Or.inl heq)
+        · exact List.mem_cons.mpr (Or.inr hmem)
+      · rintro ⟨hne, hnt⟩ hq
+        rcases List.mem_cons.mp hq with h | h
+        · exact hne h
+        · exact hnt h
+    have h_notSingleton : IsCoDiophantineDefinition (fun q : Rat => q ≠ a) :=
+      notSingletonOf_isCoDiophantineDefinition a
+    have h_intersection : IsCoDiophantineDefinition (fun q : Rat => q ≠ a ∧ q ∉ t) :=
+      intersection_isCoDiophantineDefinition h_notSingleton ih
+    exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr h_intersection
+
+/-- Iter 10 corollary, Path B: **every finite subset of ℚ is Π₂-definable**
+    via the trivial inclusion `Σ₁ ⊆ Π₂`. -/
+theorem finUnionList_singletons_isUniversalExistentialDefinition (l : List Rat) :
+    IsUniversalExistentialDefinition (fun q : Rat => q ∈ l) :=
+  diophantine_implies_universal_existential _
+    (finUnionList_singletons_isDiophantineDefinition l)
+
+/-- Iter 10 corollary, Path B: **every complement of a finite subset of ℚ
+    is Σ₂-definable** via the trivial inclusion `Π₁ ⊆ Σ₂`. -/
+theorem finIntersectionList_complement_singletons_isExistentialUniversalDefinition
+    (l : List Rat) :
+    IsExistentialUniversalDefinition (fun q : Rat => q ∉ l) :=
+  codiophantine_implies_existentialUniversal _
+    (finIntersectionList_complement_singletons_isCoDiophantineDefinition l)
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -1,14 +1,68 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T18:30:00Z
-**Iteration**: 9
-**Last Updated**: 2026-05-08 (researcher-9)
+**Since**: 2026-05-08T20:30:00Z
+**Iteration**: 10
+**Last Updated**: 2026-05-08 (researcher-12)
 
 ## Current Focus
 
-Iteration 9 (2026-05-08, researcher-9, this PR): **closure of Σ₁ under
-binary union and Π₁ under binary intersection** via the **product
+Iteration 10 (2026-05-08, researcher-12, this PR): **finite-list closure
+(S10.3)** — every FINITE subset of ℚ is Σ₁-definable, and every
+complement of a finite subset is Π₁-definable. Direct application of
+S9's binary union/intersection closure to a `List Rat` by induction.
+
+Two main theorems plus two trivial Π₂/Σ₂ corollaries:
+
+1. `finUnionList_singletons_isDiophantineDefinition (l : List Rat)` —
+   the predicate `fun q : Rat => q ∈ l` is Σ₁-definable. By induction
+   on `l`:
+   * **Base** (`l = []`): predicate reduces to `False`, covered by S5's
+     `empty_isDiophantineDefinition`.
+   * **Step** (`l = a :: t`): `q ∈ a :: t` unfolds (via Lean core
+     `List.mem_cons`) to `q = a ∨ q ∈ t`. Apply S9's
+     `union_isDiophantineDefinition` to the head witness
+     `singletonOf_isDiophantineDefinition a` (S8) and the inductive
+     hypothesis. Bridge `q ∈ a :: t ↔ q = a ∨ q ∈ t` is closed via
+     `diophantineDefinition_iff_of_pred_iff` (S5 logical congruence).
+2. `finIntersectionList_complement_singletons_isCoDiophantineDefinition (l : List Rat)`
+   — dual statement for the Π₁ class: `fun q : Rat => q ∉ l` is
+   Π₁-definable. Same induction structure, with
+   `notSingletonOf_isCoDiophantineDefinition` (S8 head) and
+   `intersection_isCoDiophantineDefinition` (S9 step).
+3. `finUnionList_singletons_isUniversalExistentialDefinition (l : List Rat)`
+   — Π₂ corollary via the trivial inclusion Σ₁ ⊆ Π₂.
+4. `finIntersectionList_complement_singletons_isExistentialUniversalDefinition (l : List Rat)`
+   — Σ₂ corollary via the trivial inclusion Π₁ ⊆ Σ₂.
+
+**Mathlib API surface**: zero new lemmas. Uses only Lean-core
+`List.mem_cons` (in the cons case) plus `simp` for the empty-list
+equivalence `q ∈ [] ↔ False`. No new imports.
+
+**Net new content**: 0 definitions, 4 theorems, 0 axioms. **Updated
+total**: 12 definitions, 54 theorems, 1 axiom, 0 sorries, 1260 lines
+(was 1163).
+
+## Sharpening of the OPEN Σ₁ Question (iter 10 update)
+
+S10.3 closes the finite-list induction story explicitly: every FINITE
+subset of ℚ is Σ₁-definable; every complement of a FINITE subset is
+Π₁-definable. The OPEN Σ₁ question for ℤ ⊂ ℚ is therefore EQUIVALENT
+to:
+
+    is the COUNTABLE union ⋃_{n : ℤ} {n} Σ₁-definable in ℚ?
+
+with the precise gap being the lift from finite to countable. Finite
+truncations `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` are Σ₁-definable for every finite
+`N` (instantiate `finUnionList_singletons_isDiophantineDefinition` at
+`l = [(-N : Rat), -(N-1), …, (N : Rat)]`). The OPEN content is
+precisely the limit `N → ∞`: a uniform polynomial witness whose
+existence is the question.
+
+---
+
+## Iteration 9 (2026-05-08, researcher-9): closure of Σ₁ under
+binary union and Π₁ under binary intersection via the **product
 polynomial witness**
 
     P(q, x) = P₁(q, x) · P₂(q, x)
@@ -86,6 +140,24 @@ This is the cleanest restatement of the OPEN Σ₁ question yet:
 
 ## Build Status
 
+Iteration 10 build: PENDING. Worktree's `proofs/.lake` is a recursive
+self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so a
+local Docker build would re-fresh-clone Mathlib (~25-45 min). The S10
+content adds zero new imports — uses only Lean-core `List.mem_cons`
+(in the cons case), `simp` (for `q ∈ [] ↔ False`), and previously-used
+helpers (`diophantineDefinition_iff_of_pred_iff`,
+`coDiophantineDefinition_iff_of_pred_iff` from S5;
+`singletonOf_isDiophantineDefinition` /
+`notSingletonOf_isCoDiophantineDefinition` from S8;
+`union_isDiophantineDefinition` /
+`intersection_isCoDiophantineDefinition` from S9; and
+`empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`
+from S5). All four `by`-tactic proofs use only `induction l with | nil
+=> … | cons a t ih => …`, `intro`, `simp`, `rintro`, `refine`, `exact`,
+`constructor`, `rcases`, and the bridge lemmas listed. The two
+trivial-corollary proofs are pure term-mode applications of S5
+inclusions. No new axioms. Confidence high; CI is the ground truth.
+
 Iteration 9 build: PENDING. Worktree's `proofs/.lake` is a recursive
 self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so a
 local Docker build would re-fresh-clone Mathlib (~25-45 min). The new
@@ -109,41 +181,43 @@ Iteration 3 build: PASSED ✅ (3 jobs, exit code 0).
 
 ## Blockers
 
-None for the binary-union / binary-intersection story. S10+ extensions:
+None for the finite-list closure story (S10.3, this iteration). Remaining
+S11+ extensions:
 
-- **S10.1**: Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a·z = 1`
-  — needs `Rat` field arithmetic (`mul_inv`, `mul_inv_cancel` from
-  Mathlib's field library).
-- **S10.2**: Σ₁ closure under binary INTERSECTION via sum-of-squares
+- **S11.1**: Π₁ ⊆ Π₂ via the polynomial-inversion trick
+  `a ≠ 0 ⟺ ∃ z, a·z = 1` — needs `Rat` field arithmetic (`mul_inv`,
+  `mul_inv_cancel` from Mathlib's field library).
+- **S11.2**: Σ₁ closure under binary INTERSECTION via sum-of-squares
   witness `P(q, x, y) = P₁(q, x)² + P₂(q, y)²`. Requires:
   (a) `a² + b² = 0 ↔ a = 0 ∧ b = 0` over an ordered field (Mathlib has
   this via `add_sq_eq_zero_iff_of_nonneg` and friends);
   (b) a packing-trick to use disjoint variable indices for `x` and `y`,
   since the SAME variable assignment block won't work for intersection
   (where we need both factors to vanish at the SAME polynomial value).
-- **S10.3**: `finUnion_singletons_isDiophantineDefinition` — by induction
-  on a finite list of rationals (extending S9's binary pair to `k`-tuple),
-  every FINITE subset of ℚ is Σ₁-definable. Makes precise the
-  uniform/non-uniform boundary discussed above.
+- **S11.3**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
+  separate axiomatized witness — adds 1 axiom, documentary value only.
+- **S11.4**: Finset version of `finUnionList_singletons` —
+  `finUnionFinset_singletons_isDiophantineDefinition (s : Finset Rat)`
+  via `Finset.induction_on` (transports easily from the List version
+  by `Finset.toList`).
 
 ## Next Action
 
-Commit, push, create PR for iteration 9 (this).
+Commit, push, create PR for iteration 10 (this).
 
-If S9 lands cleanly, S10+ candidates (in priority order):
+If S10 lands cleanly, S11+ candidates (in priority order):
 
-- **S10.1**: Π₁ ⊆ Π₂ via polynomial inversion (`a ≠ 0 ⟺ ∃ z, a·z = 1`).
-- **S10.2**: Σ₁ closure under finite INTERSECTION via sum-of-squares.
-- **S10.3**: `finUnion_singletons_isDiophantineDefinition` — every
-  finite subset of ℚ is Σ₁-definable (corollary of S8 + S9 by induction).
-- **S10.4**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
+- **S11.1**: Π₁ ⊆ Π₂ via polynomial inversion (`a ≠ 0 ⟺ ∃ z, a·z = 1`).
+- **S11.2**: Σ₁ closure under binary INTERSECTION via sum-of-squares.
+- **S11.3**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
   separate axiomatized witness — adds 1 axiom, documentary value only.
+- **S11.4**: Finset version of `finUnionList_singletons`.
 
 ## Attempt Counts
 
-- Total attempts: 9
-- Current approach attempts: 1 (S9 — binary union/intersection closure)
-- Approaches tried: 8 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+- Total attempts: 10
+- Current approach attempts: 1 (S10 — finite-list closure)
+- Approaches tried: 9 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
   congruence, S5 symmetric duality + trivial sets, S6 smallest
   non-trivial subset, S7 ¬¬-shadow, S8 arbitrary singletons, S9 binary
-  union/intersection closure)
+  union/intersection closure, S10 finite-list closure)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -81,11 +81,15 @@
       "singletonPair_isDiophantineDefinition: every PAIR {a, b} ⊂ ℚ is Σ₁-definable for arbitrary a, b : ℚ (iter 9 Path B; corollary of union closure applied to two S8 singleton witnesses)",
       "notSingletonPair_isCoDiophantineDefinition: every complement-of-pair ℚ \\ {a, b} is Π₁-definable for arbitrary a, b : ℚ (iter 9 Path B; corollary of intersection closure)",
       "singletonPair_isUniversalExistentialDefinition: every PAIR {a, b} ⊂ ℚ is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (iter 9)",
-      "notSingletonPair_isExistentialUniversalDefinition: every complement-of-pair ℚ \\ {a, b} is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (iter 9)"
+      "notSingletonPair_isExistentialUniversalDefinition: every complement-of-pair ℚ \\ {a, b} is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (iter 9)",
+      "finUnionList_singletons_isDiophantineDefinition: EVERY FINITE subset of ℚ is Σ₁-definable — for any list l : List Rat, the predicate `q ∈ l` is Σ₁-definable. Proved by induction on l using S8 singletonOf (head case) + S9 union closure (cons case) + the diophantineDefinition congruence helper. Makes precise the open Σ₁ question: every finite truncation `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` is Σ₁-definable, but a UNIFORM Σ₁ witness for the full countable union ⋃_{n : ℤ} {n} is the OPEN content (iter 10 Path B; no new axioms)",
+      "finIntersectionList_complement_singletons_isCoDiophantineDefinition: every complement of a FINITE subset of ℚ is Π₁-definable — dual of finUnionList via S9 intersection closure (iter 10 Path B; no new axioms)",
+      "finUnionList_singletons_isUniversalExistentialDefinition: every finite subset of ℚ is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (iter 10)",
+      "finIntersectionList_complement_singletons_isExistentialUniversalDefinition: every complement of a finite subset of ℚ is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (iter 10)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 1163,
+    "lineCount": 1260,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -93,7 +97,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 50,
+    "theoremCount": 54,
     "definitionCount": 12
   },
   "overview": {
@@ -223,9 +227,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 1163,
+    "lineCount": 1260,
     "axiomCount": 1,
-    "theoremCount": 50,
+    "theoremCount": 54,
     "definitionCount": 12,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -37,19 +37,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T06:00:00.000Z",
-    "iteration": 9,
-    "focus": "Phase-2 ACT iteration 9 (this PR, researcher-9): **closure of Σ₁ under binary union and Π₁ under binary intersection** via the product polynomial witness P(q,x) = P₁(q,x)·P₂(q,x). One new Mathlib import (Mathlib.Algebra.GroupWithZero.Basic for `mul_eq_zero` over ℚ; ℚ is a field, hence NoZeroDivisors). The same product polynomial serves both directions: for union, ∃x, P₁·P₂=0 ⟺ (∃x, P₁=0) ∨ (∃x, P₂=0); for intersection, ∀x, P₁·P₂≠0 ⟺ (∀x, P₁≠0) ∧ (∀x, P₂≠0). Adds 6 theorems (2 closure + 4 concrete corollaries for pairs {a, b} and complements ℚ\\{a, b} across Σ₁/Π₁/Π₂/Σ₂); 0 new defs, 0 new axioms. Total: 1163 lines (was 999), 50 theorems (was 44), 12 defs, 1 axiom, 0 sorries. Build pending (CI). Sharpens the OPEN-question landscape: every FINITE subset of ℚ is Σ₁-definable; the OPEN Σ₁ question for ℤ ⊂ ℚ reduces to whether *countable* union closure holds (uniform polynomial witness for the family {n} : n : ℤ).",
+    "since": "2026-05-08T20:30:00Z",
+    "iteration": 10,
+    "focus": "Phase-2 ACT iteration 10 (this PR, researcher-12): **finite-list closure (S10.3)** — every FINITE subset of ℚ is Σ₁-definable, every complement is Π₁-definable. By induction on a `List Rat`: base case reduces to `False` / `True` via `empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`; cons case decomposes `q ∈ a :: t` into `q = a ∨ q ∈ t` (via Lean-core `List.mem_cons`) and applies S9 union/intersection closure with S8 singleton/co-singleton witness. Two main theorems plus two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂. Zero new imports — uses only Lean-core `List.mem_cons` plus `simp` for `q ∈ [] ↔ False`. Net new content: 0 definitions, 4 theorems, 0 axioms. Updated total: 12 definitions, 54 theorems, 1 axiom, 0 sorries, 1260 lines (was 1163).",
     "blockers": [],
-    "nextAction": "S10+ candidates (after this PR lands): (a) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — needs Rat field arithmetic (further Mathlib import); (b) closure of Σ₁ under binary INTERSECTION via sum-of-squares witness P(q, x, y) = P₁(q,x)² + P₂(q,y)² (needs `a²+b²=0 ↔ a=0 ∧ b=0` over an ordered field, plus a packing-trick to use disjoint variable indices for x and y); (c) finUnion_singletons_isDiophantineDefinition: induction on a finite list of rationals — every finite subset of ℚ is Σ₁-definable (extension of S9's pair to arbitrary k-tuple); (d) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (e) Eisenträger-Park 2018 universal-existential characterization for global fields.",
+    "nextAction": "After S10 lands cleanly, S11+ candidates (priority order): (S11.1) Π₁ ⊆ Π₂ via polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a·z = 1` (needs Rat field arithmetic). (S11.2) Σ₁ closure under binary INTERSECTION via sum-of-squares witness `P(q,x,y) = P₁²+P₂²` (needs `add_sq_eq_zero_iff_of_nonneg` + variable-packing trick). (S11.3) Daans 2021 (10-quantifier reduction of Koenigsmann) as separate axiomatized witness. (S11.4) Finset version of `finUnionList_singletons_isDiophantineDefinition` via `Finset.induction_on`.",
     "attemptCounts": {
-      "total": 9,
+      "total": 10,
       "currentApproach": 1,
-      "approachesTried": 8
+      "approachesTried": 9
     }
   },
   "knowledge": {
-    "progressSummary": "PHASE-2 ACT iterations 1-9 complete. Iter 1 (researcher-6): scaffold (5 thm). Iter 2 (researcher-9): Σ₁/Π₁ duality (+4 thm). Iter 3 (researcher-9): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (+4 thm). Iter 4 (researcher-1): three remaining class congruence helpers (+3 thm, axiom-free). Iter 5 (PR #17065): symmetric duality + ∅/ℚ trivial-set library across all four classes. Iter 6 (PR #17083): smallest non-trivial parameter-dependent witness {0}/ℚ\\{0} via projection polynomial P(q,x)=q. Iter 7 (PR #17125): four ¬¬-shadows (Σ₁/Π₁/Σ₂/Π₂ stable under classical double negation) + concrete OPEN-question shadow IntegersAreDiophantineOverQ ⟺ Σ₁(¬¬ IntSubset). Iter 8 (researcher-5, PR #17219 merged): **Path B transition** — first Mathlib import (Mathlib.Algebra.Group.Basic for sub_eq_zero) enables the proper generalization of S6 singletonZero to **arbitrary singletons {a} ⊂ ℚ for any a : ℚ** via the shift polynomial P(q,x) = q - a. Adds 5 theorems + 1 private def. Iter 9 (researcher-9, this PR): **closure of Σ₁ under binary union and Π₁ under binary intersection** via the product polynomial witness P(q,x) = P₁(q,x)·P₂(q,x). Second Mathlib import (Mathlib.Algebra.GroupWithZero.Basic for `mul_eq_zero` on ℚ). Adds 6 theorems (2 closure + 4 concrete pair corollaries). Total: 1163 lines, 50 theorems, 12 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries. The Σ₁ question itself remains OPEN (intentionally) — but every FINITE subset of ℚ is now Σ₁-definable; the OPEN content is precisely the COUNTABLE union of singletons {n} : n : ℤ.",
+    "progressSummary": "PROGRESS (iter 10 / S10.3, researcher-12, this PR): finite-list closure of Σ₁ over ℚ. Adds `finUnionList_singletons_isDiophantineDefinition (l : List Rat) : IsDiophantineDefinition (fun q => q ∈ l)` and its Π₁ dual `finIntersectionList_complement_singletons_isCoDiophantineDefinition`, plus two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂. Direct application of S9 binary union/intersection closure to a `List Rat` by induction (base = empty list ↦ `empty_isDiophantineDefinition`/`universe_isCoDiophantineDefinition`; step = `q ∈ a :: t ↔ q = a ∨ q ∈ t` via Lean-core `List.mem_cons`, then `union_isDiophantineDefinition` of S8 head + IH). Zero new imports. 0 axioms (1 axiom unchanged: `koenigsmann_2016_universal`). Counts: lineCount 1163→1260, theoremCount 50→54, defCount 12 unchanged. Build pending; pattern matches S5/S8/S9 idioms.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
       "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
@@ -93,7 +93,11 @@
       "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonPair_isCoDiophantineDefinition (a b : Rat) — every complement-of-pair ℚ \\ {a, b} is Π₁-definable (S9 corollary)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem singletonPair_isUniversalExistentialDefinition (a b : Rat) — every PAIR {a, b} is Π₂-definable, corollary via Σ₁ ⊆ Π₂ (S9)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem notSingletonPair_isExistentialUniversalDefinition (a b : Rat) — every complement-of-pair is Σ₂-definable, corollary via Π₁ ⊆ Σ₂ (S9)",
-      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 999→1163, theoremCount 44→50, definitionCount unchanged at 12; mathlibDependencies adds Mathlib.Algebra.GroupWithZero.Basic; leanFile.imports gained Mathlib.Algebra.GroupWithZero.Basic"
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 999→1163, theoremCount 44→50, definitionCount unchanged at 12; mathlibDependencies adds Mathlib.Algebra.GroupWithZero.Basic; leanFile.imports gained Mathlib.Algebra.GroupWithZero.Basic",
+      "finUnionList_singletons_isDiophantineDefinition (l : List Rat) : IsDiophantineDefinition (fun q : Rat => q ∈ l) — every finite subset of ℚ is Σ₁-definable (iter 10)",
+      "finIntersectionList_complement_singletons_isCoDiophantineDefinition (l : List Rat) : IsCoDiophantineDefinition (fun q : Rat => q ∉ l) — every complement of a finite subset of ℚ is Π₁-definable (iter 10 dual)",
+      "finUnionList_singletons_isUniversalExistentialDefinition (l : List Rat) : Π₂ corollary via Σ₁ ⊆ Π₂ (iter 10)",
+      "finIntersectionList_complement_singletons_isExistentialUniversalDefinition (l : List Rat) : Σ₂ corollary via Π₁ ⊆ Σ₂ (iter 10)"
     ],
     "insights": [
       "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",
@@ -116,7 +120,10 @@
       "Σ₁-definability is closed under FINITE union (and intersection) but the OPEN ℤ ⊂ ℚ Σ₁ question is precisely the question of closure under COUNTABLE union along Int.cast — the family of singletons {n} for n : ℤ is uniformly Σ₁-definable per-element (via singletonOf at a = n) but not known to admit a single uniform polynomial witness for the union",
       "Path A → Path B transition: the file architecture changes at iter 8 to allow Mathlib imports. The minimal cost (one import: Mathlib.Algebra.Group.Basic for sub_eq_zero) unlocks the singleton-of-a generalization, the closure properties (S9+: needs mul_eq_zero), and Π₁ ⊆ Π₂ via inversion (S10+: needs Rat field arithmetic)",
       "S9 design choice — same product polynomial for both union and intersection: the witness P(q, x) = P₁(q, x)·P₂(q, x) reuses the SAME variable assignment block for both factors. For union (Σ₁), this is fine: ∃x, P₁·P₂=0 ⟺ (∃x, P₁=0) ∨ (∃x, P₂=0) — both directions hold trivially because we don't need the same x to vanish in both factors. For intersection (Π₁), the dual statement holds: ∀x, P₁·P₂≠0 ⟺ (∀x, P₁≠0) ∧ (∀x, P₂≠0) — the universal quantifier 'splits' across the conjunction. Sum-of-squares would be needed for Σ₁ INTERSECTION (where we need the same x to make both factors zero), not for Σ₁ union or Π₁ intersection.",
-      "S9 sharpens the OPEN landscape: every FINITE subset of ℚ is Σ₁-definable (by induction over a finite list, using S8 singletons + S9 binary union). The OPEN Σ₁ question for ℤ ⊂ ℚ thus reduces precisely to: does the COUNTABLE union ⋃_{n : ℤ} {n} admit a UNIFORM polynomial witness? Finite truncations ⋃_{n ∈ [-N, N]} {n} are Σ₁-definable for every N (corollary of S8 + S9), but the limit N → ∞ requires a single polynomial whose existence is precisely the open content of the question."
+      "S9 sharpens the OPEN landscape: every FINITE subset of ℚ is Σ₁-definable (by induction over a finite list, using S8 singletons + S9 binary union). The OPEN Σ₁ question for ℤ ⊂ ℚ thus reduces precisely to: does the COUNTABLE union ⋃_{n : ℤ} {n} admit a UNIFORM polynomial witness? Finite truncations ⋃_{n ∈ [-N, N]} {n} are Σ₁-definable for every N (corollary of S8 + S9), but the limit N → ∞ requires a single polynomial whose existence is precisely the open content of the question.",
+      "OPEN Σ₁ question for ℤ ⊂ ℚ is EQUIVALENT to whether the countable union ⋃_{n : ℤ} {n} is Σ₁-definable — finite truncations ⋃_{n ∈ [-N, N] ∩ ℤ} {n} are Σ₁-definable for every finite N via finUnionList_singletons (iter 10)",
+      "List.mem_cons (Lean-core) provides q ∈ a :: t ↔ q = a ∨ q ∈ t directly — no Mathlib import needed for finite-list induction over Σ₁/Π₁ classes",
+      "The base case of finite-list induction is closed via S5 trivial-set witnesses (`empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`); the cons case via S9 union/intersection closure + S8 singleton witnesses — clean modular composition (iter 10)"
     ],
     "mathlibGaps": [
       "No formal definition of 'Diophantine subset of a ring' in Mathlib — `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat → Rat) → Rat`",
@@ -176,7 +183,7 @@
     ]
   },
   "started": "2026-05-05T02:57:43.927Z",
-  "lastUpdate": "2026-05-08T18:30:00.000Z",
+  "lastUpdate": "2026-05-08T20:30:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -216,8 +223,8 @@
     {
       "path": "Proofs/Hilbert10OQ01OQ02.lean",
       "filename": "Hilbert10OQ01OQ02.lean",
-      "lineCount": 1163,
-      "theoremCount": 50,
+      "lineCount": 1260,
+      "theoremCount": 54,
       "axiomCount": 1,
       "defCount": 12,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Iteration 10 (S10.3) for `hilbert-10-oq-01-oq-02`: closes the **finite-list induction story** for the Σ₁/Π₁ classes over ℚ. Generalizes S9's binary union/intersection closure to arbitrary FINITE subsets of ℚ via `List Rat` induction. Four new theorems, zero new axioms, zero new imports.

## Theorems Added

```lean
theorem finUnionList_singletons_isDiophantineDefinition (l : List Rat) :
    IsDiophantineDefinition (fun q : Rat => q ∈ l)

theorem finIntersectionList_complement_singletons_isCoDiophantineDefinition
    (l : List Rat) :
    IsCoDiophantineDefinition (fun q : Rat => q ∉ l)

theorem finUnionList_singletons_isUniversalExistentialDefinition (l : List Rat) :
    IsUniversalExistentialDefinition (fun q : Rat => q ∈ l)
-- (Π₂ corollary via Σ₁ ⊆ Π₂)

theorem finIntersectionList_complement_singletons_isExistentialUniversalDefinition
    (l : List Rat) :
    IsExistentialUniversalDefinition (fun q : Rat => q ∉ l)
-- (Σ₂ corollary via Π₁ ⊆ Σ₂)
```

## Proof Structure

By induction on `l : List Rat`:

* **Base** (`l = []`): predicate `q ∈ []` (resp. `q ∉ []`) reduces to `False` (resp. `True`); closed via S5's `empty_isDiophantineDefinition` (resp. `universe_isCoDiophantineDefinition`) and the `_iff_of_pred_iff` congruence helpers.
* **Step** (`l = a :: t`): unfold `q ∈ a :: t ↔ q = a ∨ q ∈ t` via Lean-core `List.mem_cons`, then close via S9's `union_isDiophantineDefinition` of S8's `singletonOf_isDiophantineDefinition a` and the inductive hypothesis. The Π₁ dual mirrors with `notSingletonOf_isCoDiophantineDefinition` and `intersection_isCoDiophantineDefinition`.

The product polynomial witness `P(q, x) = (q − a) · P_t(q, x)` is implicit in the chained S8 + S9 + congruence-helper applications.

## Mathlib API Surface

- **Zero new lemmas, zero new imports.** Uses only Lean-core `List.mem_cons` plus `simp` for the empty-list equivalence `q ∈ [] ↔ False`.
- Reuses S5/S8/S9 helpers (full list in commit message).
- **No new axioms.**

## Sharpening of the OPEN Question

S10.3 closes the finite-list induction story explicitly: the OPEN Σ₁ question for ℤ ⊂ ℚ is **equivalent** to whether the COUNTABLE union `⋃_{n : ℤ} {n}` is Σ₁-definable in ℚ. Finite truncations `⋃_{n ∈ [-N, N] ∩ ℤ} {n}` are Σ₁-definable for every finite `N` (instantiate at `l = [(-N : Rat), …, (N : Rat)]`). The OPEN content is precisely the limit `N → ∞`.

## Counts

| | Before | After | Δ |
|---|---|---|---|
| lineCount | 1163 | 1260 | +97 |
| theoremCount | 50 | 54 | +4 |
| definitionCount | 12 | 12 | 0 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

## Build Status

**Pending.** Worktree's `proofs/.lake` is a recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`); local Docker build would re-fresh-clone Mathlib (~25–45 min).

Pattern matches S5/S8/S9 idioms verbatim — induction syntax, `simp`-closed bridge predicates, congruence-helper applications — so the build risk is identical to S9 (#17278). CI is the ground truth.

## Files

- `proofs/Proofs/Hilbert10OQ01OQ02.lean` (+97 lines: 4 theorems + section header + docstrings)
- `src/data/proofs/hilbert-10-oq-01-oq-02/meta.json` (lineCount, theoremCount, originalContributions)
- `src/data/research/problems/hilbert-10-oq-01-oq-02.json` (iter 9 → 10, focus, nextAction, builtItems, insights)
- `research/problems/hilbert-10-oq-01-oq-02/state.md` (S10 entry, build status, blockers, S11+ candidates)

## Test plan

- [ ] CI build of `Proofs.Hilbert10OQ01OQ02` passes
- [ ] No new axioms introduced
- [ ] `theoremCount` and `lineCount` in `meta.json` match the Lean file
- [ ] State.md and problem JSON describe S10 accurately

🤖 Generated by researcher-12