### PR TITLE
research(schauder-oq03-oq01-incomplete-01): S7 — graph-form axiom + 10-line kakutani patch (build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -12,16 +12,23 @@ Brouwer's fixed point theorem using approximate continuous selections.
 
 **Status**: AXIOMATIZED (2 axioms)
 - Axiom 1: Brouwer's FPT in Euclidean space
-- Axiom 2: Approximate selections exist for UHC maps with convex values
+- Axiom 2: Cellina–Browder graph-approximate selections exist for UHC
+  maps with convex values
 - Proved: Sequential compactness (from Mathlib's IsCompact.isSeqCompact)
 - Proved: The combination argument (Kakutani from the two axioms via the helper)
 - Proved: The limit-argument helper (approx_fixedpoint_implies_fixedpoint)
 
-**Why approximate selections instead of simplicial approximation?**
-Both approaches work, but approximate selections avoid the need for
-triangulation infrastructure (which is not in Mathlib). The key lemma
-(existence of continuous ε-approximate selections for UHC maps with
-nonempty convex values) can be proved using partitions of unity.
+**Why graph-approximate selections (vs pointwise / simplicial approximation)?**
+The simplicial approach avoids approximate selections altogether but
+requires triangulation infrastructure not currently in Mathlib. The
+selection approach requires only `Mathlib.Topology.PartitionOfUnity`,
+but a subtle point (made precise in S6) is that under USC + convex
+values one obtains only the *graph* approximate selection (Cellina 1969,
+Browder 1968), NOT the pointwise selection: the strictly stronger
+pointwise form is mathematically false in general. This file therefore
+states the axiom in graph form and threads a triangle-inequality step
+through `kakutani_from_brouwer` to recover the diagonal-distance
+witness expected by `approx_fixedpoint_implies_fixedpoint`.
 
 **References**:
 - Kakutani, S. (1941). A generalization of Brouwer's fixed point theorem.
@@ -79,26 +86,51 @@ axiom brouwer_fpt {n : ℕ}
     (f : ↥S → ↥S) (hf : Continuous f) :
     ∃ x : ↥S, f x = x
 
-/-- A continuous function f : S → S is an ε-approximate selection of F
-    if d(f(x), F(x)) < ε for all x ∈ S. -/
-def IsApproxSelection {X : Type*} [PseudoMetricSpace X]
+/-- A continuous `f : S → S` is an ε-graph-approximate selection of `F`
+    if for every `x` there is a nearby point `x'` (within `ε`) and a point
+    `y ∈ F(x')` with `dist (f x) y < ε` — i.e. the graph of `f` lies inside
+    the `ε`-fattening of the graph of `F`.
+
+    This is the Cellina–Browder form of approximate selection: it is the
+    strongest form provable for upper-hemicontinuous maps with nonempty
+    convex values (S6 analysis: the strictly stronger pointwise form
+    `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values
+    alone — a 1-D counterexample with `F(0) = [0,1]`, `F(t>0) = {0}`,
+    `F(t<0) = {1}` admits no continuous pointwise (1/3)-selection by
+    continuity at `0`). -/
+def IsGraphApproxSelection {X : Type*} [PseudoMetricSpace X]
     (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
-  ∀ x, ∃ y ∈ F x, dist (f x) y < ε
+  ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
 
-/-- **Axiom 2: Approximate Continuous Selections**
+/-- **Axiom 2: Cellina–Browder Graph-Approximate Continuous Selections**
 
-    For a compact convex S, an UHC map F : S → 2^S with nonempty convex
-    values, and any ε > 0, there exists a continuous ε-approximate
-    selection f : S → S.
+    For a compact convex `S`, an UHC map `F : S → 2^S` with nonempty
+    convex values, and any `ε > 0`, there exists a continuous
+    `f : S → S` whose graph lies in the `ε`-fattening of `graph(F)`.
 
-    The proof uses:
-    1. For each x, pick y_x ∈ F(x) and use UHC to get a neighborhood U_x
-       where F(U_x) ⊆ B(F(x), ε)
-    2. By compactness, extract a finite subcover U_{x_1}, ..., U_{x_k}
-    3. Take a subordinate partition of unity {φ_i}
-    4. Define f(x) = Σ φ_i(x) · y_{x_i}
-    5. By convexity of S, f maps into S
-    6. By construction, f(x) is within ε of F(x) -/
+    **Why the graph form (not the pointwise form):** S6 mathematical
+    analysis (`s6-axiom-counterexample.md`) shows the pointwise form
+    `IsApproxSelection F f ε` is FALSE under USC + convex values alone.
+    The graph form is the standard Cellina–Browder selection theorem
+    (Cellina 1969; Browder 1968; Aubin–Frankowska, *Set-Valued Analysis*
+    §9.2) and suffices to derive Kakutani's theorem (see
+    `kakutani_from_brouwer` below; the helper passes a `2ε`-bound
+    through `approx_fixedpoint_implies_fixedpoint`).
+
+    **Proof sketch (PartitionOfUnity construction):**
+    1. For each `x ∈ S`, pick `y_x ∈ F(x)` and use UHC to choose an open
+       `U_x ∋ x` with `F(U_x) ⊆ ε`-thickening of `F(x)`.
+    2. Compactness extracts a finite subcover `U_{x_1}, …, U_{x_k}`.
+    3. Subordinate partition of unity `{φ_i}` with `supp φ_i ⊆ U_{x_i}`.
+    4. Define `f(x) := Σ φ_i(x) · y_{x_i}`. Convexity of `S` gives `f x ∈ S`.
+    5. Graph bound: at any `x`, pick `i` with `φ_i(x) > 0`; then
+       `x ∈ U_{x_i}` and `(x_i, y_{x_i})` lies in the graph of `F`,
+       certifying graph-distance `< ε`. (The pointwise form would require
+       step 5 to bound `dist(f(x), F(x))` directly, which fails — see S6.)
+
+    Formalizing this in Lean requires `Mathlib.Topology.PartitionOfUnity`
+    plus the Cellina averaging argument; it is a standard but non-trivial
+    Mathlib-level task and is not yet in scope here. -/
 axiom approx_selection_exists {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
@@ -107,7 +139,7 @@ axiom approx_selection_exists {n : ℕ}
     (hF_convex : ∀ x, Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n))))
     (hF_uhc : IsUpperHemicontinuous F)
     (ε : ℝ) (hε : 0 < ε) :
-    ∃ f : ↥S → ↥S, Continuous f ∧ IsApproxSelection F (fun x => (f x : ↥S)) ε
+    ∃ f : ↥S → ↥S, Continuous f ∧ IsGraphApproxSelection F (fun x => (f x : ↥S)) ε
 
 /-- **Sequential Compactness in Metric Spaces**
 
@@ -259,17 +291,22 @@ theorem approx_fixedpoint_implies_fixedpoint
 -- Part IV: The Proof of Kakutani from Brouwer
 -- ============================================================
 
-/-- **Kakutani's FPT from Brouwer + Approximate Selections**
+/-- **Kakutani's FPT from Brouwer + Cellina–Browder Graph Selections**
 
     Proof sketch (filled body below):
-    1. For each ε > 0, get a continuous ε-approximate selection f_ε of F
-       via `approx_selection_exists`.
-    2. Apply `brouwer_fpt` to f_ε on S to get x₀ with f_ε(x₀) = x₀.
-    3. The approximate-selection property at x₀ gives y ∈ F(x₀) with
-       `dist(f_ε(x₀), y) < ε`. Since f_ε(x₀) = x₀, `dist(x₀, y) < ε`.
-    4. Hand the family of ε-witnesses to `approx_fixedpoint_implies_fixedpoint`,
-       which uses sequential compactness + closedness + UHC of F to extract
-       a genuine fixed point. -/
+    1. For each `ε > 0`, call `approx_selection_exists` with `ε/2` to get
+       a continuous `(ε/2)`-graph-approximate selection `f` of `F`.
+    2. Apply `brouwer_fpt` to `f` on `S` to get `x₀` with `f(x₀) = x₀`.
+    3. The graph-form property at `x₀` gives `(x', y)` with
+       `dist(x₀, x') < ε/2`, `y ∈ F(x')`, `dist(f(x₀), y) < ε/2`.
+       Since `f(x₀) = x₀`, the triangle inequality
+       `dist(x', y) ≤ dist(x', x₀) + dist(x₀, f x₀) + dist(f x₀, y)
+                    < ε/2 + 0 + ε/2 = ε`
+       provides the diagonal-distance witness.
+    4. Hand the family of `ε`-witnesses to
+       `approx_fixedpoint_implies_fixedpoint`, which uses sequential
+       compactness + closedness + UHC of `F` to extract a genuine fixed
+       point. -/
 theorem kakutani_from_brouwer {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
@@ -288,15 +325,27 @@ theorem kakutani_from_brouwer {n : ℕ}
   have happrox_total :
       ∀ ε > 0, ∃ x ∈ (Set.univ : Set ↥S), ∃ y ∈ F x, dist x y < ε := by
     intro ε hε
+    -- Call the graph-selection axiom with ε/2; the triangle-inequality step
+    -- below converts the (ε/2, ε/2) graph witness into an ε-diagonal witness.
+    have hε_half : 0 < ε / 2 := by linarith
     obtain ⟨f, hf_cont, hf_approx⟩ :=
       approx_selection_exists S hS_ne hS_compact hS_convex F
-        hF_ne hF_convex hF_uhc ε hε
+        hF_ne hF_convex hF_uhc (ε / 2) hε_half
     obtain ⟨x0, hx0⟩ := brouwer_fpt S hS_ne hS_compact hS_convex f hf_cont
-    obtain ⟨y, hy_F, hy_dist⟩ := hf_approx x0
-    refine ⟨x0, Set.mem_univ _, y, hy_F, ?_⟩
-    -- dist (f x0) y < ε with f x0 = x0 ⇒ dist x0 y < ε
-    rw [← hx0]
-    exact hy_dist
+    -- Graph-form witness at `x = x0`:
+    --   dist x0 x' < ε/2,  y ∈ F x',  dist (f x0) y < ε/2.
+    obtain ⟨x', y, hxx', hy_F, hy_dist⟩ := hf_approx x0
+    -- Beta-reduce the `(fun x => (f x : ↥S)) x0` form sitting inside `hy_dist`.
+    have hy_dist' : dist (f x0) y < ε / 2 := hy_dist
+    refine ⟨x', Set.mem_univ _, y, hy_F, ?_⟩
+    -- Triangle: dist x' y ≤ dist x' x0 + dist x0 (f x0) + dist (f x0) y.
+    -- f x0 = x0 forces dist x0 (f x0) = 0, so the bound is < ε/2 + ε/2 = ε.
+    have hxx0 : dist x' x0 < ε / 2 := by
+      rw [dist_comm]; exact hxx'
+    have h_tri1 : dist x' y ≤ dist x' x0 + dist x0 y := dist_triangle _ _ _
+    have h_tri2 : dist x0 y ≤ dist x0 (f x0) + dist (f x0) y := dist_triangle _ _ _
+    have h_zero : dist x0 (f x0) = 0 := by rw [hx0]; exact dist_self _
+    linarith
   obtain ⟨x_star, _, hfp⟩ :=
     approx_fixedpoint_implies_fixedpoint (Set.univ : Set ↥S) hUniv F
       hF_closed' hF_uhc happrox_total
@@ -305,10 +354,12 @@ theorem kakutani_from_brouwer {n : ℕ}
 /-
 ## Part V: Why This Matters
 
-The proof of Kakutani from Brouwer via approximate selections demonstrates
-the power of three fundamental principles:
+The proof of Kakutani from Brouwer via graph-approximate selections
+demonstrates the power of three fundamental principles:
 1. **Brouwer's FPT** (topological): continuous self-maps of compact convex sets have fixed points
-2. **Approximate selections** (geometric): UHC maps with convex values can be approximated
+2. **Cellina–Browder graph selections** (geometric): UHC maps with convex
+   values admit continuous functions whose graph lies in any prescribed
+   neighborhood of the graph of `F`
 3. **Compactness** (analytical): bounded sequences have convergent subsequences
 
 The combination yields fixed points for set-valued maps — the cornerstone
@@ -317,6 +368,7 @@ of Nash equilibrium existence in game theory.
 ### Infrastructure Needed in Mathlib
 - Brouwer's FPT for general compact convex sets (currently only for closed balls)
 - Partition of unity construction for finite open covers in Euclidean space
+  (powering the Cellina–Browder construction)
 
 ### Alternative Proof Paths
 1. **Simplicial approximation**: Triangulate S, define PL approximations. Avoids
@@ -324,21 +376,34 @@ of Nash equilibrium existence in game theory.
 2. **Michael's selection theorem**: Stronger than needed here (gives exact continuous
    selections for lower hemicontinuous maps with convex values).
 
+### Why not a pointwise approximate selection?
+Under USC + convex values, the pointwise form
+`∀ x, ∃ y ∈ F x, dist (f x) y < ε` is provably false in general (S6
+analysis: 1-D counterexample with `F(0) = [0,1]`, `F(t > 0) = {0}`,
+`F(t < 0) = {1}` admits no continuous pointwise (1/3)-selection by an
+IVT argument at `0`). The graph form is the strongest selection
+provable from USC alone, and is what Mathlib's `PartitionOfUnity`
+infrastructure can produce via the Cellina averaging argument.
+
 ## Summary
 
 ### Axioms (2)
 1. `brouwer_fpt` - Brouwer's FPT for compact convex subsets of ℝⁿ
-2. `approx_selection_exists` - UHC + convex values → continuous ε-selections exist
+2. `approx_selection_exists` - UHC + convex values → continuous
+   `ε`-graph-approximate selections (Cellina–Browder form)
 
 ### Theorems (proved)
 - `seq_compact_of_compact` - Sequential compactness in compact metric spaces
   (was an axiom; now derived from Mathlib)
 - `approx_fixedpoint_implies_fixedpoint` - Limit argument for approximate fixed points
 - `kakutani_from_brouwer` - The main reduction: Kakutani from the two axioms
+  (uses the graph form via a triangle-inequality `ε ↦ 2·(ε/2) = ε` step)
 
 ### Path to Full Verification
-1. Prove `approx_selection_exists` using partition of unity (main infrastructure gap)
+1. Prove `approx_selection_exists` (graph form) using `PartitionOfUnity`
+   plus the Cellina averaging argument
 2. Verify `brouwer_fpt` against Mathlib's existing Brouwer formalization
+   for the unit ball, extended to compact convex sets via a retraction
 -/
 
 #check @brouwer_fpt

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,56 +1,60 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ORIENT (axiom revision needed)
+**Phase**: ACT (graph-form axiom in place; build pending)
 **Path**: full
-**Since**: 2026-05-08T15:30:00Z
-**Iteration**: 5
+**Since**: 2026-05-08T16:55:00Z
+**Iteration**: 7
 
 ## Current Focus
-S6 (researcher-6, 2026-05-08): Mathematical analysis surfaces a critical
-issue with the chosen proof strategy. The axiom `approx_selection_exists`
-is **false as stated** under USC + convex values alone. A 1-D counterexample
-shows no continuous pointwise `(1/3)`-approximate selection exists for
-`F : [-1,1] → 2^[-1,1]` with `F(0)=[0,1]`, `F(t>0)={0}`, `F(t<0)={1}`.
-See `s6-axiom-counterexample.md` for the full analysis (verbatim
-definitions, USC verification, no-`f` proof via continuity-at-zero IVT,
-and the Cellina–Browder graph-form salvage).
+S7 (researcher-9, 2026-05-08): Implements the salvage path identified by
+S6 — replace the (provably-false) pointwise `IsApproxSelection` with the
+Cellina–Browder graph form `IsGraphApproxSelection`, restate Axiom 2 in
+graph form (Cellina 1969, Browder 1968), and patch `kakutani_from_brouwer`
+with a triangle-inequality `ε ↦ 2·(ε/2) = ε` step so the helper
+`approx_fixedpoint_implies_fixedpoint` is unchanged.
 
 ## Active Approach
-Revise the axiom to the provable graph form (Cellina–Browder) and rethread
-`kakutani_from_brouwer` through it (≈10-line edit using triangle
-inequality, with the helper `approx_fixedpoint_implies_fixedpoint`
-unchanged). Only after that is the PartitionOfUnity proof of the
-*graph form* tractable.
+With the axiom now stated in the form actually provable from USC + convex
+values (the Cellina–Browder graph selection), the next layer of work is
+the PartitionOfUnity proof of the graph-form axiom itself, which uses
+`Mathlib.Topology.PartitionOfUnity` plus the standard Cellina averaging
+argument. That proof is a separate, larger Mathlib-API task; this S7
+pass changes only the axiom statement and the reduction.
 
 ## Attempt Count
-- Total attempts: 2
+- Total attempts: 7
 - Approaches tried:
   - S2 documentation (researcher-3, #16731);
   - S3 full proof submission (researcher-11, #16784);
   - S4 build verification + meta sync (researcher-10);
-  - S5 PR flush off fresh main (researcher-?, content already on main);
-  - S6 axiom-strength counterexample analysis (researcher-6, this PR).
+  - S5 PR flush off fresh main (#16883);
+  - S6 axiom-strength counterexample analysis (researcher-6, #17265);
+  - S7 graph-form axiom + 10-line kakutani_from_brouwer patch (this PR).
 
 ## Blockers
-None at the math level — the path forward (graph-form axiom + 10-line
-`kakutani_from_brouwer` patch) is concrete. The PartitionOfUnity proof
-itself remains a separate, larger Mathlib-API task.
+- **Build verification deferred**: Docker build not run locally
+  (`proofs/.lake` self-cycle symlink trap, see researcher-9 memory note —
+  `feedback_researcher_lake_symlink_broken.md`). All Mathlib lemma names
+  used in the patch are well-established (`dist_triangle`, `dist_comm`,
+  `dist_self`, `linarith`, `Set.mem_univ`); CI is the ground truth.
 
 ## Next Action
-S7: edit `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`:
+**S8 (PartitionOfUnity proof of `approx_selection_exists` graph form)**:
 
-1. Add `IsGraphApproxSelection` definition (graph form, see analysis doc).
-2. Restate `approx_selection_exists` to use the graph form. Update
-   docstring to cite Cellina–Browder and remove the (incorrect) pointwise
-   step-6 sketch.
-3. Patch `kakutani_from_brouwer` to chain
-   `dist(x', y) ≤ dist(x', x₀) + dist(x₀, f_ε(x₀)) + dist(f_ε(x₀), y) < 2ε`
-   when feeding `approx_fixedpoint_implies_fixedpoint` (substitute ε ↦ 2ε
-   in the outer existential — harmless).
-4. Verify build via Docker (`./proofs/scripts/docker-build.sh
-   Proofs.SchauderFixedPointOQ03OQ01`).
-5. (Optional, S8+) Attempt the PartitionOfUnity proof of the graph form.
+1. Set up the Cellina averaging construction:
+   - For `x ∈ S`, pick `y_x ∈ F x` and a neighborhood `U_x` with
+     `F U_x ⊆ ε`-thickening of `F x` (UHC).
+   - Compactness extracts a finite subcover `U_{x_1}, …, U_{x_k}`.
+   - Build a subordinate partition of unity `{φ_i}` via
+     `Mathlib.Topology.PartitionOfUnity`.
+   - Define `f x := Σ φ_i(x) · y_{x_i}` (convex combination, lands in `S`).
+2. Verify the graph bound: at any `x`, pick `i` with `φ_i x > 0`; then
+   `x ∈ U_{x_i}` and `(x_i, y_{x_i})` is a graph point of `F` within `ε`
+   of `(x, f x)`.
+3. Discharge the axiom in Lean.
+
+This is a sizable Mathlib-API task and is best treated as its own session.
 
 A separate follow-up should also note that `brouwer_fpt`'s extension from
 Mathlib's unit-ball Brouwer to general compact convex `S` is provable

--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -36,23 +36,23 @@
       }
     ],
     "originalContributions": [
-      "IsApproxSelection: Definition of ε-approximate continuous selections",
+      "IsGraphApproxSelection: Definition of ε-graph-approximate continuous selections (Cellina–Browder form)",
       "brouwer_fpt: Brouwer's FPT for compact convex sets (AXIOMATIZED)",
-      "approx_selection_exists: UHC + convex → ε-selections exist (AXIOMATIZED)",
+      "approx_selection_exists: UHC + convex → continuous ε-graph-approximate selections (AXIOMATIZED, Cellina–Browder form; pointwise form is provably false under USC alone — see S6 analysis)",
       "seq_compact_of_compact: Sequential compactness derived from Mathlib's IsCompact.isSeqCompact",
       "approx_fixedpoint_implies_fixedpoint: Limit argument for approximate fixed points (proved)",
       "kakutani_from_brouwer: Combines Brouwer + approximate selections to prove Kakutani (proved)"
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 349,
+    "lineCount": 414,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
       "Convex sets in Euclidean space",
       "Upper hemicontinuity"
     ],
-    "assumptions": "Two axioms: (1) Brouwer's FPT for compact convex sets, (2) existence of approximate continuous selections for UHC maps with convex values. Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved.",
+    "assumptions": "Two axioms: (1) Brouwer's FPT for compact convex sets, (2) existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
     "definitionCount": 4
@@ -81,63 +81,63 @@
       "id": "header",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Module docstring explaining the proof strategy, status, references, and Lean imports (Mathlib topology, convexity, Euclidean space)."
+      "endLine": 50,
+      "summary": "Module docstring explaining the proof strategy, status (2 axioms), the choice of graph-approximate selections (over the strictly stronger pointwise form, which is provably false under USC alone), references, and Lean imports."
     },
     {
       "id": "definitions",
       "title": "Set-Valued Map Definitions",
-      "startLine": 46,
-      "endLine": 61,
+      "startLine": 56,
+      "endLine": 70,
       "summary": "Defines SetValuedMap (correspondence), IsFixedPoint ($x \\in F(x)$), and IsUpperHemicontinuous (preimages of open sets are open)."
     },
     {
       "id": "brouwer-axiom",
       "title": "Axiom 1: Brouwer's FPT",
-      "startLine": 63,
-      "endLine": 77,
+      "startLine": 72,
+      "endLine": 87,
       "summary": "Axiomatizes Brouwer's fixed point theorem for compact convex subsets of $\\mathbb{R}^n$ — the topological engine of the proof."
     },
     {
       "id": "approx-selection",
-      "title": "Approximate Selections and Axiom 2",
-      "startLine": 79,
-      "endLine": 106,
-      "summary": "Defines IsApproxSelection and axiomatizes the existence of continuous $\\varepsilon$-approximate selections for UHC maps with convex values."
+      "title": "Graph-Approximate Selections and Axiom 2",
+      "startLine": 89,
+      "endLine": 142,
+      "summary": "Defines IsGraphApproxSelection (Cellina–Browder form) and axiomatizes the existence of continuous $\\varepsilon$-graph-approximate selections for UHC maps with convex values. Docstring explains why the pointwise form is unprovable under USC + convex values alone (S6 counterexample) and outlines the PartitionOfUnity construction for the graph form."
     },
     {
       "id": "seq-compact-theorem",
       "title": "Sequential Compactness (derived from Mathlib)",
-      "startLine": 112,
-      "endLine": 122,
+      "startLine": 144,
+      "endLine": 154,
       "summary": "Sequential compactness in pseudo-metric spaces, derived in one line from Mathlib's `IsCompact.isSeqCompact`. Previously stated as Axiom 3."
     },
     {
       "id": "kakutani-proof",
       "title": "Kakutani's FPT from Brouwer",
-      "startLine": 258,
-      "endLine": 304,
-      "summary": "The main theorem combining the two axioms: approximate selections → Brouwer fixed points → hand off to the limit lemma. Fully proved."
+      "startLine": 290,
+      "endLine": 352,
+      "summary": "The main theorem combining the two axioms: call the graph-selection axiom with $\\varepsilon/2$, get a Brouwer fixed point, apply the triangle inequality to convert the $(\\varepsilon/2, \\varepsilon/2)$ graph witness into an $\\varepsilon$-diagonal witness, hand off to the limit lemma. Fully proved."
     },
     {
       "id": "commentary",
       "title": "Mathematical Commentary",
-      "startLine": 305,
-      "endLine": 343,
-      "summary": "Discussion of why the proof matters, Mathlib infrastructure gaps (partition of unity, general Brouwer), and alternative proof paths (simplicial approximation, Michael selection)."
+      "startLine": 354,
+      "endLine": 407,
+      "summary": "Discussion of why the proof matters, Mathlib infrastructure gaps (partition of unity, general Brouwer), why the pointwise selection is unprovable, and alternative proof paths (simplicial approximation, Michael selection)."
     },
     {
       "id": "structural-lemma",
       "title": "Approximate FPs Imply True FPs",
-      "startLine": 124,
-      "endLine": 256,
+      "startLine": 156,
+      "endLine": 288,
       "summary": "Structural lemma abstracting the limit argument: if approximate fixed points exist for all $\\varepsilon > 0$, compactness and closedness yield a true fixed point. Fully proved using sequential compactness, the squeeze theorem, and a UHC closed-graph case split."
     },
     {
       "id": "summary-checks",
       "title": "Summary and Type Checks",
-      "startLine": 344,
-      "endLine": 349,
+      "startLine": 409,
+      "endLine": 414,
       "summary": "#check commands verifying the types of the four main declarations."
     }
   ],
@@ -200,7 +200,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 349,
+    "lineCount": 414,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Session 7 of `schauder-fixed-point-oq-03-oq-01-incomplete-01`. Implements the S6-identified salvage path: the previous Axiom 2 (`approx_selection_exists`, pointwise form) was **mathematically false as stated** — S6 produced a 1-D counterexample on `F(0)=[0,1]`, `F(t>0)={0}`, `F(t<0)={1}` showing no continuous pointwise (1/3)-selection exists by an IVT-at-0 argument. This PR restates the axiom in the standard Cellina–Browder graph form and re-threads the main reduction.

## Changes

### Lean (`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`)

- **Replace** `def IsApproxSelection` with `def IsGraphApproxSelection` (Cellina 1969, Browder 1968):
  ```lean
  def IsGraphApproxSelection (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
    ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
  ```
  i.e. the graph of `f` lies in the `ε`-fattening of `graph(F)`.

- **Restate `approx_selection_exists`** to assert the graph form. Updated docstring cites Cellina–Browder and Aubin–Frankowska §9.2, and replaces the (incorrect) pointwise PoU sketch with the correct graph-form sketch.

- **Patch `kakutani_from_brouwer`**: call the axiom with `ε/2`; the graph-form witness `(x', y)` plus `f x₀ = x₀` from Brouwer give:
  ```
  dist(x', y) ≤ dist(x', x₀) + dist(x₀, f x₀) + dist(f x₀, y)
              < ε/2 + 0 + ε/2 = ε
  ```
  recovering the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint` (which is itself unchanged).

- Update top-of-file `**Status**` and Part V `## Why This Matters` commentary to explain the choice of graph form.

### Metadata (`src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json`)

| field | before | after |
|-------|--------|-------|
| `meta.lineCount` / `leanFile.lineCount` | 349 | 414 |
| `meta.axiomCount` / `leanFile.axiomCount` | 2 | 2 |
| `meta.theoremCount` / `leanFile.theoremCount` | 3 | 3 |
| `meta.definitionCount` / `leanFile.definitionCount` | 4 | 4 |
| `meta.sorries` / `leanFile.sorries` | 0 | 0 |

`originalContributions[0]` renamed to `IsGraphApproxSelection`; `assumptions` text updated to describe the graph form and why the pointwise form was rejected. Section `startLine`/`endLine` values resynced.

### State (`research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md`)

Bumped to iteration 7. Phase: **ACT (graph-form axiom in place; build pending)**. Next action: **S8 — PartitionOfUnity proof of `approx_selection_exists` (graph form)** using `Mathlib.Topology.PartitionOfUnity` + Cellina averaging.

## Build verification

⚠️ **Docker build NOT run locally** — `proofs/.lake` self-cycle symlink trap forces a fresh-clone Mathlib (~30–45 min) on every attempt; the researcher-9 environment hits this trap. All Mathlib lemmas used in the new proof body (`dist_triangle`, `dist_comm`, `dist_self`, `Set.mem_univ`, `linarith`) are well-established and present at v4.26.0. **CI is the ground truth.**

## Test plan

- [ ] CI green on `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`
- [ ] `axiomCount` is 2 (`brouwer_fpt`, `approx_selection_exists`)
- [ ] `definitionCount` is 4 (`SetValuedMap`, `IsFixedPoint`, `IsUpperHemicontinuous`, `IsGraphApproxSelection`)
- [ ] `theoremCount` is 3 (`seq_compact_of_compact`, `approx_fixedpoint_implies_fixedpoint`, `kakutani_from_brouwer`)
- [ ] `sorries` is 0
- [ ] `kakutani_from_brouwer` typechecks — beta-reduction of the `(fun x => (f x : ↥S)) x0` form inside `hy_dist` is handled by the explicit `have hy_dist' : dist (f x0) y < ε / 2 := hy_dist` step

## Sessions arc

| Session | Outcome |
|---------|---------|
| S2 | Documentation skeleton (#16731) |
| S3 | Full proof submission (#16784) |
| S4 | Build verification + meta sync |
| S5 | PR flush off fresh main (#16883) |
| S6 | Axiom-strength counterexample analysis (#17265) |
| **S7** | **Graph-form axiom + kakutani triangle-inequality patch** ⟵ this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)