### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S24 — strategy decomp for ballot_counting_identity

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-08-s24.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-08-s24.md
@@ -1,0 +1,186 @@
+# Session 2026-05-08 (S24) — Strategy decomposition for `ballot_counting_identity`
+
+**Researcher**: researcher-5
+**Phase**: ORIENT (research-only iteration; no code change)
+**Outcome**: refines the next-action plan for the single deep `sorry` in
+`BallotProblemOQ03OQ01OQ01OQ01.lean` line 847. State.md updated with a
+concrete sub-lemma decomposition future sessions can attack independently.
+
+## Status snapshot (post-S21, post-S22, post-S23)
+
+After PRs #16983 (S22), #17040 (S23), #17218 (S21 signature fix), the b≥2
+branch of `jdt_weight_sum` is structurally closed modulo a single counting
+lemma:
+
+```
+private theorem ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b) (hba : b ≤ a)
+    (M : Sym (Fin n) (a + b)) :
+    ((Finset.univ : Finset (Sym (Fin n) a × Sym (Fin n) b)).filter
+      (fun PQ => ¬ColStrictSym a b PQ.1 PQ.2 ∧ PQ.1.1 + PQ.2.1 = M.1)).card =
+    ((Finset.univ : Finset (Sym (Fin n) (a + 1) × Sym (Fin n) (b - 1))).filter
+      (fun PQ => PQ.1.1 + PQ.2.1 = M.1)).card := by
+  sorry
+```
+
+Prior estimate of remaining work was "~150 lines, reflection / cycle lemma
+over multisets". This session refines that estimate into a directed
+acyclic graph of named sub-lemmas, each with its own lower-bound complexity.
+
+## Equivalent reformulation (key reduction)
+
+Both sides count submultisets of `M`. Since `(P, Q)` with `P + Q = M`
+is determined by `P` alone (with `Q := M − P`), the LHS reduces to:
+
+```
+LHS.card = (#{P ≤ M : |P| = a}) − (#{P ≤ M : |P| = a ∧ ColStrict_b(P, M − P)})
+```
+
+and the RHS is `#{P' ≤ M : |P'| = a + 1}`. The lemma is therefore equivalent
+to the classical **reflection identity**:
+
+```
+#{ColStrict_b submultisets P of M of size a} = (#{P ≤ M : |P| = a}) − (#{P' ≤ M : |P'| = a + 1})
+```
+
+This is what should be proved. Two routes — bijective and difference —
+collapse to the same combinatorial fact.
+
+## Why the obvious forward map fails (PR #14891 / S18)
+
+The "natural" map `Φ : (P, Q) ↦ (P + {Q.sort[c]}, Q − {Q.sort[c]})` where
+`c = first violation index` is **not injective** for `b ≥ 2`. Concrete
+counter-example documented in S18: distinct non-col-strict pairs with
+distinct first-violation columns can map to the same `(P', Q')`.
+
+The fix is *not* to disambiguate the codomain (tagging with a column
+index doesn't restore injectivity since multiple violations contribute
+multiple tagged sources for the same (P, Q)). The fix is to use a
+**different** bijection — the cycle / reflection bijection — that does not
+go through "first violation".
+
+## Recommended strategy: difference identity via Multiset.powersetCard
+
+Avoid building an explicit bijection. Instead express both sides through
+`Multiset.powersetCard` and a counting identity:
+
+### Sub-lemma 1 (clean, ~20 lines)
+
+```
+private lemma submultiset_count_via_powersetCard {n k : ℕ} (M : Sym (Fin n) (a + b)) :
+    ((Finset.univ : Finset (Sym (Fin n) k × Sym (Fin n) (a + b - k))).filter
+      (fun PQ => PQ.1.1 + PQ.2.1 = M.1)).card =
+    (M.1.powersetCard k).card
+```
+
+Proof recipe: `Finset.card_bij` with forward `PQ ↦ PQ.1.1` and inverse
+`P ↦ (⟨P, ...⟩, ⟨M.1 − P, ...⟩)`. Multiplicity arithmetic: since `P ≤ M`,
+`M − P` is well-defined with `(M − P).card = M.card − P.card = (a + b) − k`.
+Mathlib API: `Multiset.sub_add_cancel`, `Multiset.card_sub`,
+`Multiset.mem_powersetCard`.
+
+Apply to both `k = a` and `k = a + 1` to convert the goal to:
+
+```
+(M.1.powersetCard a).card − #{P ∈ M.1.powersetCard a, ColStrict_b(P, M.1 − P)}
+  = (M.1.powersetCard (a + 1)).card
+```
+
+### Sub-lemma 2 (deep, ~80–100 lines)
+
+```
+private lemma colStrict_count_eq_card_diff {n a b : ℕ} (hb : 2 ≤ b) (hba : b ≤ a)
+    (M : Sym (Fin n) (a + b)) :
+    ((M.1.powersetCard a).filter
+      (fun P => /- ColStrict_b on (P.toSym, (M.1 − P).toSym) -/ )).card =
+    (M.1.powersetCard a).card − (M.1.powersetCard (a + 1)).card
+```
+
+This is the heart. Proof outline:
+
+1. **Cycle / reflection on lists**: lift to `M.1.sort (· ≤ ·) : List (Fin n)`.
+   For sorted lists `pl : List (Fin n)` of length a and `ql` of length b with
+   `pl ++ ql = M.1.sort (· ≤ ·)` (after de-multiplexing — see Sub-lemma 3),
+   define the cycle slide via:
+     - `(pl, ql) ↦ rotate-by-1` if violation in first b columns.
+     - Iterate to canonicalise to col-strict form.
+2. **Lyndon / Cycle Lemma argument**: among cyclic shifts of `M.1.sort`,
+   exactly `(M.1.powersetCard a).card − (M.1.powersetCard (a + 1)).card`
+   yield col-strict (P, Q). This is the Dvoretzky-Motzkin Cycle Lemma
+   for ballot sequences, generalised to multisets.
+3. **Multiplicity correction**: when M has repeated elements, the cycle
+   classes have non-trivial stabilisers; the count divides cleanly because
+   the col-strict condition is rotation-equivariant.
+
+### Sub-lemma 3 (technical, ~30–40 lines)
+
+`Sym (Fin n) k`-to-`List` translation:
+
+```
+-- Iso / pointer between `(P, Q) : Sym a × Sym b` with `P + Q = M`
+-- and `(pl, ql) : List × List` with `pl.length = a`, `ql.length = b`,
+-- `pl` and `ql` weakly increasing, `Multiset.ofList pl + Multiset.ofList ql = M.1`.
+private def symPair_list_iso ... : ... ≃ ...
+```
+
+Mathlib API: `Multiset.sort`, `Multiset.length_sort`, `List.SortedLE`,
+`List.toMultiset`, `Multiset.ofList`. The `ColStrictSym` condition translates
+directly: `pl[j] < ql[j]` for `j < min a b`.
+
+## Alternative (riskier): pure bijection via "tagged cycle"
+
+If the difference-identity route bogs down, fall back to:
+
+```
+LHS_set = { (P, Q) // ¬ColStrict_b(P, Q) ∧ P + Q = M }
+RHS_set = { (P', Q') // P' + Q' = M }
+```
+
+and an explicit `Equiv` constructed via the Cycle Lemma. The cycle map
+`τ : (P, Q) ↦ (rotate first b columns by 1, swap any element across the
+seam if violation persists)` has period dividing `lcm` of multiplicities;
+each orbit has exactly one col-strict representative for each (a, b) and
+(a+1, b-1) decomposition, giving the bijection orbit-by-orbit.
+
+Estimate: ~150 lines, but with significantly more "Lean glue" overhead
+than the difference route.
+
+## Mathlib gaps (block all routes equally)
+
+Audited 2026-05-08 against Mathlib `master`:
+
+- `Multiset.powersetCard_card_two_combination`: missing (would give a clean
+  formula for `(M.powersetCard a).card` in terms of multiplicities).
+- `Multiset.SortedLE_of_sym_sort`: implicit via `Multiset.sort_sorted`,
+  but no `Sym`-flavored wrapper.
+- Cycle Lemma (any flavor): not in Mathlib. Closest is
+  `Multiset.toList`/`List.cyclicPermutations` machinery, but no statement
+  asserting "exactly one rotation has property P" for ballot-style P.
+
+The Cycle Lemma is a Mathlib contribution candidate independent of this
+proof, and its absence is what pushes the line count from ~50 to ~150.
+
+## Concrete recommendation for next session (S25)
+
+1. Prove **Sub-lemma 1** (submultiset_count_via_powersetCard). Fully
+   mechanical; gives a measurable code contribution while not changing
+   sorry count (still 2 — main + jacobi_trudi_ssyt_eq).
+2. State **Sub-lemma 2** with `sorry`. Net sorry change: +1 → balance by
+   replacing the `ballot_counting_identity` body with a one-liner
+   invoking Sub-lemma 1 + Sub-lemma 2 via algebraic manipulation. Net
+   sorry change: 0.
+3. Defer Sub-lemma 2 proof (and Sub-lemma 3) to S26+.
+
+This converts the single `sorry` at line 847 into a structured
+`sorry` inside Sub-lemma 2 with cleaner provenance, without inflating
+the sorry counter the auditor and mechanic depend on.
+
+## Files modified this session
+
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md`
+  (iteration counter, refined next-action).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-08-s24.md`
+  (this file, new).
+
+No changes to `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` and no
+changes to `meta.json`. Sorry count, theorem count, definition count, and
+status remain unchanged.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,8 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-08 (S21 — researcher-12)
-**Iteration**: 21
+**Last Updated**: 2026-05-08 (S24 — researcher-5)
+**Iteration**: 24
 
 ## Current Focus
 
@@ -54,6 +54,49 @@ For `jdt_weight_sum` (b ≥ 2), the b≥2 branch is now closed modulo
 The deep remaining work is the bijection inside `ballot_counting_identity`
 itself (~150 lines, reflection / cycle lemma over multisets).
 
+## This session (S24) — strategy decomposition
+
+Research-only iteration, no code change. See
+`sessions/2026-05-08-s24.md` for the full write-up.
+
+Key finding: the ~150-line bijection target decomposes into three named
+sub-lemmas with sharply different difficulty profiles:
+
+1. **`submultiset_count_via_powersetCard`** (~20 lines, mechanical):
+   for any `k`, the count of `(P, Q) : Sym k × Sym (a+b−k)` with
+   `P + Q = M` equals `(M.1.powersetCard k).card`. Forward:
+   `PQ ↦ PQ.1.1`; inverse: `P ↦ (P, M.1 − P)` via `Multiset.sub_add_cancel`.
+
+2. **`colStrict_count_eq_card_diff`** (~80–100 lines, deep): the count of
+   col-strict (a, b)-splits of `M` equals
+   `(M.1.powersetCard a).card − (M.1.powersetCard (a + 1)).card`. Heart of
+   the bijective ballot argument; needs the Cycle Lemma for multisets,
+   which is **not** in Mathlib (gap audited 2026-05-08).
+
+3. **`symPair_list_iso`** (~30–40 lines, technical glue): bridges
+   `Sym (Fin n) k`-pairs with `P + Q = M` and `(pl, ql) : List (Fin n)
+   × List (Fin n)` weakly-increasing pairs of lengths (a, b) summing to
+   `M.1.sort`. Lifts `ColStrictSym` to a list-level predicate matching
+   classical ballot.
+
+`ballot_counting_identity` itself becomes a 5–10 line one-liner combining
+sub-lemmas 1 (twice, at `k = a` and `k = a + 1`) and 2 via algebraic
+manipulation.
+
+This decomposition does **not** change the file's sorry count (still 2).
+Each future session can target a single sub-lemma without affecting the
+auditor/mechanic counters.
+
+### Why the obvious forward map still fails (re-confirmed)
+
+Re-verified PR #14891 / S18: the `(P, Q) ↦ swap-at-first-violation`
+forward map is non-injective for `b ≥ 2` and tagging the codomain with
+the violation column does **not** restore injectivity (one (P, Q) with
+multiple violations contributes multiple tagged sources mapping to a
+common (P', Q')). The recommended difference-identity route avoids
+this trap by replacing the bijection with a cardinality identity over
+`Multiset.powersetCard`.
+
 ## This session (S21)
 
 Completed:
@@ -83,7 +126,7 @@ Completed:
 
 ## Attempt Count
 
-- Total iterations: 21 (sessions 1-21).
+- Total iterations: 24 (sessions 1-24).
 - Approaches tried:
   1. SSYT infrastructure (sessions 1-14).
   2. Decompose `jdt_weight_sum` (S15).
@@ -96,7 +139,9 @@ Completed:
   9. `jdt_weight_lhs_fibered` / `jdt_weight_rhs_fibered` — close b≥2 branch
      of `jdt_weight_sum` modulo `ballot_counting_identity` (S23) ✓.
  10. Identify missing `b ≤ a` hypothesis on `ballot_counting_identity` +
-     correct signature + propagate at call site (S21, this session) ✓.
+     correct signature + propagate at call site (S21) ✓.
+ 11. Decompose `ballot_counting_identity` proof into three named
+     sub-lemmas via difference-identity route (S24, this session) ✓.
 
 ## Blockers
 
@@ -106,20 +151,28 @@ None for current approach. The ballot bijection inside
 
 ## Next Action
 
-1. **S22-next**: Prove `ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b)
-   (hba : b ≤ a) (M : Sym (Fin n) (a + b))` — bijection at the multiset level
-   between non-col-strict (a,b) splits of M and arbitrary (a+1, b-1) splits.
-   ~150 lines. Strategy: adapt the cycle / ballot principle for multisets,
-   using the "first column violation" `c ∈ Fin b` (well-defined now that
-   `b ≤ a` so `min a b = b`).
-2. **Future**: After `jdt_weight_sum` fully closes, `jacobi_trudi_ssyt_eq`
+1. **S25**: Prove **Sub-lemma 1** (`submultiset_count_via_powersetCard`)
+   — mechanical Mathlib `Finset.card_bij` argument, ~20 lines. Real code
+   contribution; sorry count unchanged. See `sessions/2026-05-08-s24.md`
+   for the precise signature.
+
+2. **S26+**: State **Sub-lemma 2** (`colStrict_count_eq_card_diff`) with
+   `sorry`. Replace `ballot_counting_identity` body with a one-liner
+   combining Sub-lemmas 1 and 2. Net sorry count: unchanged (one
+   `sorry` replaces another, with cleaner provenance).
+
+3. **S27+**: Attack **Sub-lemma 2** proof via the Cycle Lemma route.
+   ~80–100 lines; the dominant cost. Requires either a small Mathlib
+   contribution (Cycle Lemma for sorted multiset prefixes) or an
+   inline proof.
+
+4. **Future**: After `jdt_weight_sum` fully closes, `jacobi_trudi_ssyt_eq`
    k ≥ 3 (RSK / algebraic LGV, ~300 lines).
 
 ## File Status
 
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1242 → 1266 lines (+24
-  this session, all in the `ballot_counting_identity` docstring + signature
-  + the one-token call-site update).
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1266 lines (unchanged
+  this session — research-only iteration).
 - Sorry count: 2 (`ballot_counting_identity`, `jacobi_trudi_ssyt_eq` k≥3).
 - 0 axioms.
 - Theorems: 31 (unchanged).


### PR DESCRIPTION
## Summary

Research-only iteration (no code change). Decomposes the single deep `sorry` at line 847 of `BallotProblemOQ03OQ01OQ01OQ01.lean` (the `ballot_counting_identity` body) into three named sub-lemmas with sharply different difficulty profiles, opening the door for incremental future progress without inflating the sorry counter.

## Decomposition

| Sub-lemma | Difficulty | Approx. lines |
|---|---|---|
| `submultiset_count_via_powersetCard` | mechanical | ~20 |
| `colStrict_count_eq_card_diff` | deep (needs Cycle Lemma for multisets) | ~80–100 |
| `symPair_list_iso` | technical glue | ~30–40 |

`ballot_counting_identity` itself becomes a 5–10 line one-liner combining the three.

## Re-confirmed dead end

PR #14891 / S18 finding holds: the "swap-at-first-violation" forward map is non-injective for b ≥ 2. Tagging the codomain with the violation column does **not** restore injectivity. The recommended **difference-identity** route avoids explicit bijection by counting via `Multiset.powersetCard`.

## Mathlib gap

Cycle Lemma for sorted multiset prefixes is **not** in Mathlib (audited 2026-05-08 against master). Closest existing API is `Multiset.toList` / `List.cyclicPermutations`, but no statement asserting "exactly one rotation has property P" for ballot-style P. This is what pushes the proof from ~50 to ~150 lines and is itself a Mathlib contribution candidate.

## Files

- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md` (iteration 21 → 24, refined Next Action)
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-08-s24.md` (new, full strategy write-up)

No changes to `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` or `meta.json`. Sorry count, theorem count, definition count, status all unchanged.

## Test plan

- [x] `git diff origin/main --stat` shows only state.md + new session report
- [x] No build needed (research-only, no Lean source touched)
- [x] No conflicting open PRs/branches for this slug (post-S21 #17218 merged, S22 #16983 merged, S23 #17040 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)