### PR TITLE
research(schauder-oq03-oq01-incomplete-01): S7 — graph-form axiom + kakutani patch (build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -79,26 +79,58 @@ axiom brouwer_fpt {n : ℕ}
     (f : ↥S → ↥S) (hf : Continuous f) :
     ∃ x : ↥S, f x = x
 
-/-- A continuous function f : S → S is an ε-approximate selection of F
-    if d(f(x), F(x)) < ε for all x ∈ S. -/
+/-- A continuous function f : S → S is a *pointwise* ε-approximate
+    selection of F if d(f(x), F(x)) < ε for all x ∈ S.
+
+    **NOTE (S6, 2026-05-08)**: this pointwise form is strictly stronger
+    than what is provable from upper-hemicontinuity (USC) + convex
+    values alone. A 1-D counterexample (see `s6-axiom-counterexample.md`
+    in the per-problem state directory) shows no continuous pointwise
+    `(1/3)`-approximate selection exists for the USC + convex-valued
+    correspondence `F : [-1,1] → 2^[-1,1]` with `F(0) = [0,1]`,
+    `F(t > 0) = {0}`, `F(t < 0) = {1}`. The provable form under USC
+    alone is the *graph* form `IsGraphApproxSelection` below
+    (Cellina–Browder, 1968–1969). -/
 def IsApproxSelection {X : Type*} [PseudoMetricSpace X]
     (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
   ∀ x, ∃ y ∈ F x, dist (f x) y < ε
 
-/-- **Axiom 2: Approximate Continuous Selections**
+/-- A continuous function f : S → S is a *graph* ε-approximate
+    selection of F if for every x ∈ S there is some x' ∈ S with
+    `dist x x' < ε` and some `y ∈ F(x')` with `dist (f x) y < ε`.
 
-    For a compact convex S, an UHC map F : S → 2^S with nonempty convex
-    values, and any ε > 0, there exists a continuous ε-approximate
-    selection f : S → S.
+    Equivalently, the graph of `f` lies in the `ε`-neighborhood of
+    the graph of `F` (the standard form in Cellina–Browder, 1968–1969;
+    Aubin–Frankowska *Set-Valued Analysis* §9.2). This is the
+    correct provable form under USC + convex values, weaker than
+    `IsApproxSelection` (which requires the *pointwise* condition
+    `f(x)` close to `F(x)`, not just to `F` at some nearby point). -/
+def IsGraphApproxSelection {X : Type*} [PseudoMetricSpace X]
+    (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
+  ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
 
+/-- **Axiom 2: Approximate Continuous Selections (graph form)**
+
+    For a compact convex S, an USC map F : S → 2^S with nonempty
+    convex values, and any ε > 0, there exists a continuous f : S → S
+    whose graph lies in the `ε`-neighborhood of `graph(F)`.
+
+    This is the Cellina–Browder theorem (Cellina 1969, Browder 1968).
     The proof uses:
-    1. For each x, pick y_x ∈ F(x) and use UHC to get a neighborhood U_x
-       where F(U_x) ⊆ B(F(x), ε)
+    1. For each x, pick y_x ∈ F(x) and use USC to get a neighborhood U_x
+       where F(U_x) ⊆ ε-thickening of F(x).
     2. By compactness, extract a finite subcover U_{x_1}, ..., U_{x_k}
     3. Take a subordinate partition of unity {φ_i}
     4. Define f(x) = Σ φ_i(x) · y_{x_i}
     5. By convexity of S, f maps into S
-    6. By construction, f(x) is within ε of F(x) -/
+    6. By construction, the graph of f is in the ε-neighborhood of
+       the graph of F (NOT pointwise close — see S6 counterexample).
+
+    **History (S6, 2026-05-08)**: this axiom was previously stated as
+    the pointwise form `IsApproxSelection`. S6 analysis showed the
+    pointwise form is FALSE under USC + convex values; this S7 revision
+    weakens to the (provable) graph form and re-threads
+    `kakutani_from_brouwer` through the triangle inequality. -/
 axiom approx_selection_exists {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
@@ -107,7 +139,7 @@ axiom approx_selection_exists {n : ℕ}
     (hF_convex : ∀ x, Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n))))
     (hF_uhc : IsUpperHemicontinuous F)
     (ε : ℝ) (hε : 0 < ε) :
-    ∃ f : ↥S → ↥S, Continuous f ∧ IsApproxSelection F (fun x => (f x : ↥S)) ε
+    ∃ f : ↥S → ↥S, Continuous f ∧ IsGraphApproxSelection F (fun x => (f x : ↥S)) ε
 
 /-- **Sequential Compactness in Metric Spaces**
 
@@ -259,17 +291,27 @@ theorem approx_fixedpoint_implies_fixedpoint
 -- Part IV: The Proof of Kakutani from Brouwer
 -- ============================================================
 
-/-- **Kakutani's FPT from Brouwer + Approximate Selections**
+/-- **Kakutani's FPT from Brouwer + Approximate Selections (graph form)**
 
     Proof sketch (filled body below):
-    1. For each ε > 0, get a continuous ε-approximate selection f_ε of F
-       via `approx_selection_exists`.
+    1. For each ε > 0, request a continuous (ε/2)-graph-approximate
+       selection f_ε of F via `approx_selection_exists`.
     2. Apply `brouwer_fpt` to f_ε on S to get x₀ with f_ε(x₀) = x₀.
-    3. The approximate-selection property at x₀ gives y ∈ F(x₀) with
-       `dist(f_ε(x₀), y) < ε`. Since f_ε(x₀) = x₀, `dist(x₀, y) < ε`.
-    4. Hand the family of ε-witnesses to `approx_fixedpoint_implies_fixedpoint`,
-       which uses sequential compactness + closedness + UHC of F to extract
-       a genuine fixed point. -/
+    3. The graph-approximate property at x₀ gives x' ∈ S, y ∈ F(x')
+       with `dist(x₀, x') < ε/2` and `dist(f_ε(x₀), y) < ε/2`.
+       Since f_ε(x₀) = x₀, `dist(x₀, y) < ε/2`.
+    4. Triangle inequality: `dist(x', y) ≤ dist(x', x₀) + dist(x₀, y)
+                                            < ε/2 + ε/2 = ε`.
+    5. Hand the family of (x', y) ε-witnesses to
+       `approx_fixedpoint_implies_fixedpoint`, which uses sequential
+       compactness + closedness + UHC of F to extract a genuine
+       fixed point.
+
+    **History (S7, 2026-05-08)**: previously consumed the pointwise
+    `IsApproxSelection` axiom (S3+S4+S5). S6 analysis showed that
+    axiom is false under USC + convex values; S7 re-threads the
+    proof through the (provable) graph form via one triangle-inequality
+    step, with `ε ↦ 2ε` substitution (request ε/2 from the axiom). -/
 theorem kakutani_from_brouwer {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
@@ -288,15 +330,28 @@ theorem kakutani_from_brouwer {n : ℕ}
   have happrox_total :
       ∀ ε > 0, ∃ x ∈ (Set.univ : Set ↥S), ∃ y ∈ F x, dist x y < ε := by
     intro ε hε
+    -- Request a (ε/2)-graph approximate selection.
+    have hε_half : (0 : ℝ) < ε / 2 := by linarith
     obtain ⟨f, hf_cont, hf_approx⟩ :=
       approx_selection_exists S hS_ne hS_compact hS_convex F
-        hF_ne hF_convex hF_uhc ε hε
+        hF_ne hF_convex hF_uhc (ε / 2) hε_half
+    -- Apply Brouwer to f to get a fixed point.
     obtain ⟨x0, hx0⟩ := brouwer_fpt S hS_ne hS_compact hS_convex f hf_cont
-    obtain ⟨y, hy_F, hy_dist⟩ := hf_approx x0
-    refine ⟨x0, Set.mem_univ _, y, hy_F, ?_⟩
-    -- dist (f x0) y < ε with f x0 = x0 ⇒ dist x0 y < ε
-    rw [← hx0]
-    exact hy_dist
+    -- Graph approximate selection at x0: ∃ x' y, dist x0 x' < ε/2 ∧
+    -- y ∈ F x' ∧ dist (f x0) y < ε/2.
+    obtain ⟨x', y, hxx'_dist, hy_F, hfy_dist⟩ := hf_approx x0
+    -- f x0 = x0, so dist x0 y < ε/2.
+    have hx0y_dist : dist x0 y < ε / 2 := by rw [← hx0]; exact hfy_dist
+    -- Triangle inequality: dist x' y ≤ dist x' x0 + dist x0 y < ε.
+    have hxy_dist : dist x' y < ε := by
+      calc dist x' y
+          ≤ dist x' x0 + dist x0 y := dist_triangle x' x0 y
+        _ < ε / 2 + ε / 2 := by
+            have hxx0' : dist x' x0 < ε / 2 := by
+              rw [dist_comm]; exact hxx'_dist
+            linarith
+        _ = ε := by ring
+    refine ⟨x', Set.mem_univ _, y, hy_F, hxy_dist⟩
   obtain ⟨x_star, _, hfp⟩ :=
     approx_fixedpoint_implies_fixedpoint (Set.univ : Set ↥S) hUniv F
       hF_closed' hF_uhc happrox_total
@@ -328,17 +383,32 @@ of Nash equilibrium existence in game theory.
 
 ### Axioms (2)
 1. `brouwer_fpt` - Brouwer's FPT for compact convex subsets of ℝⁿ
-2. `approx_selection_exists` - UHC + convex values → continuous ε-selections exist
+2. `approx_selection_exists` - USC + convex values → continuous
+   *graph* ε-selections exist (Cellina–Browder, S7 2026-05-08)
+
+### Definitions
+- `IsApproxSelection` (pointwise form) — false in general under USC
+  alone; retained for documentation purposes (see S6 analysis).
+- `IsGraphApproxSelection` (graph form, S7 2026-05-08) — provable
+  under USC + convex values, the form `approx_selection_exists`
+  asserts.
 
 ### Theorems (proved)
 - `seq_compact_of_compact` - Sequential compactness in compact metric spaces
   (was an axiom; now derived from Mathlib)
 - `approx_fixedpoint_implies_fixedpoint` - Limit argument for approximate fixed points
-- `kakutani_from_brouwer` - The main reduction: Kakutani from the two axioms
+- `kakutani_from_brouwer` - The main reduction: Kakutani from the two
+  axioms (S7 2026-05-08: re-threaded through the graph form via one
+  triangle-inequality step + `ε ↦ ε/2` substitution).
 
 ### Path to Full Verification
-1. Prove `approx_selection_exists` using partition of unity (main infrastructure gap)
-2. Verify `brouwer_fpt` against Mathlib's existing Brouwer formalization
+1. Prove `approx_selection_exists` (graph form) using partition of
+   unity. This is the standard Cellina–Browder PoU construction
+   (Aubin–Frankowska §9.2), now matched to what is actually
+   provable under USC alone — main infrastructure gap.
+2. Verify `brouwer_fpt` against Mathlib's existing Brouwer
+   formalization (extension from unit ball to compact convex sets via
+   retraction; folklore-level).
 -/
 
 #check @brouwer_fpt

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,57 +1,74 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ORIENT (axiom revision needed)
+**Phase**: ACT (axiom revision applied)
 **Path**: full
-**Since**: 2026-05-08T15:30:00Z
-**Iteration**: 5
+**Since**: 2026-05-08T17:30:00Z
+**Iteration**: 7
 
 ## Current Focus
-S6 (researcher-6, 2026-05-08): Mathematical analysis surfaces a critical
-issue with the chosen proof strategy. The axiom `approx_selection_exists`
-is **false as stated** under USC + convex values alone. A 1-D counterexample
-shows no continuous pointwise `(1/3)`-approximate selection exists for
-`F : [-1,1] → 2^[-1,1]` with `F(0)=[0,1]`, `F(t>0)={0}`, `F(t<0)={1}`.
-See `s6-axiom-counterexample.md` for the full analysis (verbatim
-definitions, USC verification, no-`f` proof via continuity-at-zero IVT,
-and the Cellina–Browder graph-form salvage).
+S7 (researcher-6, 2026-05-08): **Implements the S6 next-action.**
+Revises `approx_selection_exists` from the (false) pointwise form to
+the (provable) Cellina–Browder graph form, and re-threads
+`kakutani_from_brouwer` through one triangle-inequality step.
+
+Concretely (single file `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`):
+
+  1. **Adds** `IsGraphApproxSelection` def: graph-form approximate selection.
+  2. **Restates** the axiom `approx_selection_exists` to assert the
+     graph form rather than the (false) pointwise form.
+  3. **Patches** `kakutani_from_brouwer`:
+     - request `(ε/2)`-graph approximate selection from the axiom;
+     - apply Brouwer to get `x₀ = f(x₀)`;
+     - graph property gives `x' ∈ S, y ∈ F(x')` with `dist(x₀, x') < ε/2`
+       and `dist(f(x₀), y) < ε/2`;
+     - triangle inequality: `dist(x', y) ≤ dist(x', x₀) + dist(x₀, y) < ε`.
+  4. **Updates** docstrings to cite Cellina–Browder and document the
+     S6 → S7 history.
+
+Counts: 2 axioms, 0 sorries. Helper `approx_fixedpoint_implies_fixedpoint`
+unchanged. Build pending; new triangle-inequality step uses only
+`linarith`/`ring`/`dist_triangle`/`dist_comm`.
 
 ## Active Approach
-Revise the axiom to the provable graph form (Cellina–Browder) and rethread
-`kakutani_from_brouwer` through it (≈10-line edit using triangle
-inequality, with the helper `approx_fixedpoint_implies_fixedpoint`
-unchanged). Only after that is the PartitionOfUnity proof of the
-*graph form* tractable.
+S7 is the *axiom-side* salvage promised in S6. The remaining work is the
+PartitionOfUnity proof of `IsGraphApproxSelection` itself (S8+), which is
+the standard Cellina–Browder PoU construction (Aubin–Frankowska §9.2).
+With S7 applied, the PoU proof now has the right TARGET — the graph form
+matches what Mathlib's PoU infrastructure actually supports.
 
 ## Attempt Count
-- Total attempts: 2
+- Total attempts: 7
 - Approaches tried:
   - S2 documentation (researcher-3, #16731);
   - S3 full proof submission (researcher-11, #16784);
   - S4 build verification + meta sync (researcher-10);
   - S5 PR flush off fresh main (researcher-?, content already on main);
-  - S6 axiom-strength counterexample analysis (researcher-6, this PR).
+  - S6 axiom-strength counterexample analysis (researcher-6, #17265);
+  - S7 graph-form axiom + kakutani patch (researcher-6, this PR).
 
 ## Blockers
-None at the math level — the path forward (graph-form axiom + 10-line
-`kakutani_from_brouwer` patch) is concrete. The PartitionOfUnity proof
-itself remains a separate, larger Mathlib-API task.
+None at the math level. The remaining axioms (`brouwer_fpt`,
+`approx_selection_exists`-graph-form) are both provable from Mathlib;
+their proofs are S8+ work.
 
 ## Next Action
-S7: edit `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`:
+S8: prove `approx_selection_exists` (graph form) via Mathlib's
+PartitionOfUnity infrastructure. Standard recipe (Cellina–Browder):
 
-1. Add `IsGraphApproxSelection` definition (graph form, see analysis doc).
-2. Restate `approx_selection_exists` to use the graph form. Update
-   docstring to cite Cellina–Browder and remove the (incorrect) pointwise
-   step-6 sketch.
-3. Patch `kakutani_from_brouwer` to chain
-   `dist(x', y) ≤ dist(x', x₀) + dist(x₀, f_ε(x₀)) + dist(f_ε(x₀), y) < 2ε`
-   when feeding `approx_fixedpoint_implies_fixedpoint` (substitute ε ↦ 2ε
-   in the outer existential — harmless).
-4. Verify build via Docker (`./proofs/scripts/docker-build.sh
-   Proofs.SchauderFixedPointOQ03OQ01`).
-5. (Optional, S8+) Attempt the PartitionOfUnity proof of the graph form.
+  1. For each `x ∈ S`, pick `y_x ∈ F(x)` and use USC to get a neighborhood
+     `U_x ∋ x` with `F(U_x) ⊆ ε`-thickening of `F(x)`.
+  2. Compactness extracts a finite subcover `U_{x_1}, ..., U_{x_k}`.
+  3. Mathlib `PartitionOfUnity` gives a subordinate `{φ_i}`.
+  4. Define `f(x) = Σ φ_i(x) · y_{x_i}`. Convexity of `S` ⇒ `f(x) ∈ S`.
+  5. **Graph property** (the corrected step-6): for any `x'`, the support
+     of `{φ_i}` at `x'` is finite; pick the `x_i` with `dist(x', x_i)`
+     minimal. Then `dist(x_i, x') < ε` (it's in `U_i`'s ball), and
+     `dist(f(x'), y_{x_i}) ≤ ε` (since `f(x')` is a convex combination
+     of points each within `ε` of `F(x_i) ⊆ F(x_i)`-thickening),
+     giving the graph form.
 
-A separate follow-up should also note that `brouwer_fpt`'s extension from
-Mathlib's unit-ball Brouwer to general compact convex `S` is provable
-via a retraction argument and is the easier of the two axioms.
+S9+: verify `brouwer_fpt` against Mathlib's existing
+`Topology.MetricSpace.Brouwer` (extension from unit ball to general
+compact convex `S` via a retraction argument; folklore-level, the
+easier of the two axioms).


### PR DESCRIPTION
## Summary

Session 7 of the Schauder-from-Brouwer formalization. **Implements the S6 axiom revision** identified in PR #17265: replaces the (false) pointwise `IsApproxSelection` axiom with the (provable) Cellina–Browder graph form, and re-threads `kakutani_from_brouwer` through one triangle-inequality step.

After this PR, the Kakutani-from-Brouwer reduction rests on a sound mathematical foundation. The remaining work — proving the graph-form `approx_selection_exists` via Mathlib's PartitionOfUnity infrastructure (S8+) — is now well-founded, since the graph form matches what the standard PoU construction (Aubin–Frankowska §9.2) actually delivers.

## Files modified

- `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` — axiom revision + `kakutani_from_brouwer` patch + summary update. +98/-28 lines.
- `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md` — iteration 5 → 7; records S7 implementation and S8/S9 roadmap.

## Changes (Lean file)

### 1. `IsGraphApproxSelection` definition (new)

```lean
def IsGraphApproxSelection {X : Type*} [PseudoMetricSpace X]
    (F : SetValuedMap X X) (f : X → X) (ε : ℝ) : Prop :=
  ∀ x, ∃ x' y, dist x x' < ε ∧ y ∈ F x' ∧ dist (f x) y < ε
```

This is the standard Cellina–Browder form (graph of `f` lies in `ε`-neighborhood of graph of `F`), strictly weaker than the pointwise `IsApproxSelection`. The pointwise form is retained for documentation purposes with a notice that it is FALSE in general under USC + convex values (citing the S6 1-D counterexample).

### 2. `approx_selection_exists` axiom restated

The axiom now asserts the graph form rather than the pointwise form. Docstring updated to cite Cellina–Browder (1968–1969) and document the S6 → S7 history.

### 3. `kakutani_from_brouwer` patched

Replaces the previous use of `IsApproxSelection` with a `IsGraphApproxSelection`-driven proof:

| Step | Old (pointwise) | New (graph) |
|------|-----------------|-------------|
| 1 | Request ε-pointwise selection f_ε | Request (ε/2)-graph selection f_ε |
| 2 | Apply Brouwer to get x₀ = f_ε(x₀) | (same) |
| 3 | At x₀: ∃ y ∈ F(x₀), dist(f_ε(x₀), y) < ε | At x₀: ∃ x', y, dist(x₀, x') < ε/2 ∧ y ∈ F(x') ∧ dist(f_ε(x₀), y) < ε/2 |
| 4 | dist(x₀, y) < ε directly | Triangle ineq: dist(x', y) ≤ dist(x', x₀) + dist(x₀, y) < ε/2 + ε/2 = ε |
| 5 | Hand (x₀, y) to helper | Hand (x', y) to helper |

The helper `approx_fixedpoint_implies_fixedpoint` is unchanged. The new triangle-inequality step uses only `linarith`, `ring`, `dist_triangle`, and `dist_comm` from Mathlib.

## Counts

- Axioms: 2 (`brouwer_fpt`, `approx_selection_exists`-graph-form). One axiom restated, no axioms added.
- Sorries: 0.
- Lines: +98/-28 in `SchauderFixedPointOQ03OQ01.lean`. New file size: 419 lines.
- Build: pending. Local Docker build deferred per S5/S6 convention.

## Significance

S6 (PR #17265) established that the *previous* axiom `approx_selection_exists` (pointwise form) was FALSE under the listed USC + convex-values hypotheses. That left the file's `kakutani_from_brouwer` proof with a logically vacuous foundation: while the proof structure was correct, the axiom it consumed could not be proved.

S7 fixes this:

1. The axiom is now true (Cellina–Browder, 1968–1969) — the graph form is provable from USC + convex values.
2. The `kakutani_from_brouwer` reduction passes through (via one triangle-inequality step) on the corrected axiom.
3. The PartitionOfUnity proof attempt (S8+) now has a coherent target — it produces a *graph* approximate selection, which is exactly what we now consume.

## Next Action (S8+)

1. **S8** — Prove `approx_selection_exists` (graph form) via Mathlib's `PartitionOfUnity` infrastructure. Recipe: USC neighborhood + finite subcover + subordinate PoU + convex combination.
2. **S9** — Verify `brouwer_fpt` against Mathlib's existing `Topology.MetricSpace.Brouwer` formalization (extension from unit ball to general compact convex `S` via retraction).

🤖 Generated by researcher-6