### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 8 — lcmRange_dvd_prod_prime_powers (reverse Chebyshev, build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Data.Nat.Log
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Tactic
 
 /-
@@ -216,6 +217,69 @@ theorem prod_prime_powers_dvd_lcmRange (n : ℕ) :
   · intro p hp q hq hpq
     exact coprime_prime_pow_pow_of_ne (Finset.mem_filter.mp hp).2
       (Finset.mem_filter.mp hq).2 hpq _ _
+
+/-- **Reverse direction of Chebyshev's decomposition**: `lcmRange n` divides
+    the product of maximal prime powers `p ^ ⌊log_p n⌋` over primes `p ≤ n`.
+
+    Combined with `prod_prime_powers_dvd_lcmRange` (the forward direction),
+    this gives Chebyshev's full prime-power formula
+    `lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ ⌊log_p n⌋`
+    via `Nat.dvd_antisymm` (next iteration).
+
+    Strategy: it suffices to show every `m ∈ {1,…,n}` divides the product.
+    For each such `m`, write `m = ∏_{p ∈ m.primeFactors} p ^ m.factorization p`
+    via `Nat.factorization_prod_pow_eq_self`, extend the index set to all of
+    `(Finset.range (n+1)).filter Nat.Prime` (the extra factors are 1 since
+    `m.factorization p = 0` outside `m.primeFactors`), and bound each
+    exponent by `Nat.log p n` using `Nat.le_log_of_pow_le`. -/
+theorem lcmRange_dvd_prod_prime_powers (n : ℕ) :
+    lcmRange n ∣ ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, p ^ Nat.log p n := by
+  unfold lcmRange
+  rw [Finset.lcm_dvd_iff]
+  intro k hk
+  rw [Finset.mem_range] at hk
+  set m := k + 1 with hm_def
+  have hm_pos : 0 < m := Nat.succ_pos _
+  have hm_ne : m ≠ 0 := hm_pos.ne'
+  have hm_le : m ≤ n := by omega
+  set P : Finset ℕ := (Finset.range (n + 1)).filter Nat.Prime with hP_def
+  -- Subset relation: every prime factor of `m` is ≤ `m ≤ n`, so it lies in `P`.
+  have hsupp_sub : m.primeFactors ⊆ P := by
+    intro p hp
+    rw [Nat.mem_primeFactors] at hp
+    rw [hP_def, Finset.mem_filter, Finset.mem_range]
+    refine ⟨?_, hp.1⟩
+    have hp_le : p ≤ m := Nat.le_of_dvd hm_pos hp.2.1
+    omega
+  -- Reformulate `m` as a product over `P` (extending by 1's outside `m.primeFactors`).
+  have hm_eq : m = ∏ p ∈ P, p ^ m.factorization p := by
+    have h1 : m = ∏ p ∈ m.primeFactors, p ^ m.factorization p := by
+      have hself := Nat.factorization_prod_pow_eq_self hm_ne
+      rw [Finsupp.prod, Nat.support_factorization] at hself
+      exact hself.symm
+    rw [h1]
+    apply Finset.prod_subset hsupp_sub
+    intro p _ hp_not
+    have h_zero : m.factorization p = 0 := by
+      rw [← Nat.support_factorization] at hp_not
+      exact Finsupp.not_mem_support_iff.mp hp_not
+    rw [h_zero, pow_zero]
+  rw [hm_eq]
+  -- Pointwise divisibility of factors over `P`.
+  apply Finset.prod_dvd_prod_of_dvd
+  intro p hp
+  rw [hP_def, Finset.mem_filter, Finset.mem_range] at hp
+  obtain ⟨hp_lt, hp_prime⟩ := hp
+  apply pow_dvd_pow
+  -- `m.factorization p ≤ Nat.log p n`: trivial when factorization is 0,
+  -- and otherwise `p ^ (m.factorization p) ∣ m ≤ n` ⇒ `… ≤ Nat.log p n`.
+  by_cases hf : m.factorization p = 0
+  · rw [hf]; exact Nat.zero_le _
+  · have hpow_dvd : p ^ m.factorization p ∣ m :=
+      (Nat.Prime.pow_dvd_iff_le_factorization hp_prime hm_ne).mpr le_rfl
+    have hpow_le_n : p ^ m.factorization p ≤ n :=
+      le_trans (Nat.le_of_dvd hm_pos hpow_dvd) hm_le
+    exact Nat.le_log_of_pow_le hp_prime.one_lt hpow_le_n
 
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,11 +4,35 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Iteration 7, researcher-11)
-**Iteration**: 7
+**Last Updated**: 2026-05-08 (Iteration 8, researcher-9)
+**Iteration**: 8
 
 ## Current Focus
-Iteration 7 (2026-05-08, this PR): closes the **easy direction of
+Iteration 8 (2026-05-08, this PR): closes the **reverse direction of
+Chebyshev's decomposition**, complementing Iter 7's forward direction:
+
+- `lcmRange_dvd_prod_prime_powers (n : ℕ) :
+   lcmRange n ∣ ∏ p ∈ (Finset.range (n+1)).filter Nat.Prime, p ^ Nat.log p n`
+
+The proof routes through `Nat.factorization`:
+
+1. By `Finset.lcm_dvd_iff` it suffices to show every `m ∈ {1,…,n}`
+   divides the product `N`.
+2. Rewrite `m = ∏_{p ∈ m.primeFactors} p^(m.factorization p)` via
+   `Nat.factorization_prod_pow_eq_self`.
+3. Extend the index set from `m.primeFactors` to
+   `(Finset.range (n+1)).filter Nat.Prime` via `Finset.prod_subset`
+   (the extra factors contribute `p^0 = 1`).
+4. Pointwise divisibility on the resulting two products: each
+   `m.factorization p ≤ Nat.log p n` since
+   `p^(m.factorization p) ∣ m ≤ n` and `Nat.le_log_of_pow_le` lifts
+   the `p^k ≤ n` inequality into the exponent bound (using
+   `hp_prime.one_lt`).
+
+Combining Iter 7 and Iter 8 via `Nat.dvd_antisymm` gives the exact
+Chebyshev identity (Iter 9 candidate).
+
+Iteration 7 (#17166 merged): closes the **easy direction of
 Chebyshev's decomposition**, the major structural milestone of the
 last six iterations:
 
@@ -75,7 +99,7 @@ Currently blocked on:
   `4^n` intermediate.
 
 ## Attempt Count
-- Total attempts: 7.
+- Total attempts: 8.
 - Current approach attempts: 0 (Approach 1 not started; awaits Mathlib).
 - Approaches tried: bootstrap with elementary bounds + axiom (iter 1);
   structural-lemma layer for inductive proofs (iter 2); generic
@@ -84,7 +108,9 @@ Currently blocked on:
   prime-power specialization `prime_pow_dvd_lcmRange` (iter 5, #17021);
   coprime distinct prime powers `coprime_prime_pow_pow_of_ne` (iter 6,
   #17128); easy direction of Chebyshev's decomposition
-  `prod_prime_powers_dvd_lcmRange` (iter 7, this PR).
+  `prod_prime_powers_dvd_lcmRange` (iter 7, #17166); reverse
+  direction `lcmRange_dvd_prod_prime_powers` via `Nat.factorization`
+  (iter 8, this PR).
 
 ## Blockers
 - **Mathlib Beta-integral over ℚ**: not in usable form.
@@ -93,30 +119,15 @@ Currently blocked on:
 
 ## Next Action
 
-**Iteration 8 candidate**: the **reverse direction** of Chebyshev's
-decomposition,
-
-  `lcmRange n ∣ ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`.
-
-Strategy: route through Mathlib's `Nat.factorization` framework. For
-each `k ∈ {1,...,n}`:
-1. Write `k = ∏_p p^(k.factorization p)` via
-   `Nat.factorization_prod_pow_factorization` (or
-   `Nat.eq_prod_pow_factorization`).
-2. Bound each exponent: `k.factorization p ≤ Nat.log p n` since
-   `p^(k.factorization p) ∣ k ≤ n` and `Nat.log` is the maximal exponent
-   such that `p^a ≤ n`. The Mathlib API for this is
-   `Nat.factorization_le_log_of_dvd` (if it exists) or hand-derived
-   via `Nat.pow_le_iff_le_log` + `Nat.dvd_iff_le_pow_factorization`.
-3. Therefore `k ∣ ∏ p ∈ filter Prime (range (n+1)), p^(Nat.log p n)`.
-4. By `Finset.lcm_dvd`, `lcmRange n ∣ that product`.
-
-Once Iter 8 lands, **Iteration 9** is the antisymmetric closure:
+**Iteration 9 candidate**: the **antisymmetric closure** —
+combining Iter 7 and Iter 8 to produce the exact Chebyshev identity:
 
   `lcmRange_eq_prod_prime_powers : lcmRange n =
      ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`
 
-via `Nat.dvd_antisymm` from Iter 7 + Iter 8.
+This is a one-line `Nat.dvd_antisymm` proof from
+`prod_prime_powers_dvd_lcmRange` (Iter 7) and
+`lcmRange_dvd_prod_prime_powers` (Iter 8).
 
 After this, the Chebyshev product gives an explicit prime-power
 form for `lcmRange n`, and the bound

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 341,
-    "theoremCount": 33,
+    "lineCount": 405,
+    "theoremCount": 34,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [
@@ -62,39 +62,39 @@
       "**Chebyshev-function reformulation**: Hanson's bound is equivalent to ψ(n) ≤ n · ln 3 for ψ(n) = log lcm(1,...,n). The PNT gives ψ(n)/n → 1 < ln 3, so Hanson is consistent with PNT — but Hanson's non-asymptotic constant is what's needed for explicit applications like Apéry.",
       "**Numerical evidence**: For n = 20, lcm(1,...,20) = 232,792,560 vs 3^20 = 3,486,784,401, a margin of 15×. For n = 50, the ratio grows. This consistent margin gives strong empirical confidence in Hanson's bound.",
       "**Mathlib infrastructure status**: `Mathlib.NumberTheory.Primorial` has `primorial_le_4_pow`. `Mathlib.NumberTheory.Bertrand` has the Bertrand postulate. `Mathlib.Data.Nat.Lcm` has lcm definitions. None give an `lcm(1..n) ≤ X^n` bound directly. The bridge from primorial to lcm is the missing combinatorial step.",
-      "**Chebyshev's decomposition — easy direction proved (Iter 5–7)**: This file now proves `(∏_{p ≤ n, p prime} p^⌊log_p n⌋) ∣ lcmRange n`, the *forward* half of Chebyshev's identity `lcm(1,...,n) = ∏_{p ≤ n} p^⌊log_p n⌋`. Built incrementally: `pow_dvd_lcmRange` (generic), `prime_pow_dvd_lcmRange` (each prime-power factor), `coprime_prime_pow_pow_of_ne` (pairwise coprimality), `prod_dvd_of_pairwise_coprime` (Finset induction packaging), then `prod_prime_powers_dvd_lcmRange` assembles them. The reverse direction `lcmRange n ∣ ∏ p^⌊log_p n⌋` (the *hard half*) routes through `Nat.factorization` extracting the maximal exponent per prime — the next structural milestone before applying Beta-integral / primorial-bound estimates to upper-bound the product by `3^n` and discharge `hanson_bound`."
+      "**Chebyshev's decomposition — both directions proved (Iter 5–8)**: This file now proves both inclusions of Chebyshev's identity `lcm(1,...,n) = ∏_{p ≤ n, p prime} p^⌊log_p n⌋`. The *forward* half `(∏ p, p^⌊log_p n⌋) ∣ lcmRange n` (`prod_prime_powers_dvd_lcmRange`, Iter 7) was assembled from `pow_dvd_lcmRange` (generic), `prime_pow_dvd_lcmRange` (each factor), `coprime_prime_pow_pow_of_ne` (pairwise coprime), `prod_dvd_of_pairwise_coprime` (Finset induction). The *reverse* half `lcmRange n ∣ ∏ p, p^⌊log_p n⌋` (`lcmRange_dvd_prod_prime_powers`, Iter 8) routes through `Nat.factorization`: write `m = ∏_{p ∈ m.primeFactors} p^(m.factorization p)` via `Nat.factorization_prod_pow_eq_self`, extend the index set to `(range (n+1)).filter Prime` (extra factors are 1), and bound each exponent by `Nat.log p n` using `Nat.le_log_of_pow_le`. Iter 9 will close the antisymmetric identity `lcmRange n = ∏_{p ≤ n} p^⌊log_p n⌋` via `Nat.dvd_antisymm`. After that, applying Beta-integral / primorial-bound estimates to upper-bound the product by `3^n` is the path to discharge `hanson_bound`."
     ]
   },
   "sections": [
     {
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
-      "startLine": 65,
-      "endLine": 264,
-      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), prime_pow_dvd_lcmRange (specialization to the maximal prime-power p^⌊log_p n⌋ — the prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^⌊log_p n⌋), coprime_prime_pow_pow_of_ne (distinct prime powers are coprime), the helper prod_dvd_of_pairwise_coprime (Finset induction packaging), prod_prime_powers_dvd_lcmRange (easy direction of Chebyshev's decomposition: ∏_p p^⌊log_p n⌋ ∣ lcmRange n), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
+      "startLine": 67,
+      "endLine": 328,
+      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), prime_pow_dvd_lcmRange (specialization to the maximal prime-power p^⌊log_p n⌋ — the prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^⌊log_p n⌋), coprime_prime_pow_pow_of_ne (distinct prime powers are coprime), the helper prod_dvd_of_pairwise_coprime (Finset induction packaging), prod_prime_powers_dvd_lcmRange (forward direction of Chebyshev's decomposition: ∏_p p^⌊log_p n⌋ ∣ lcmRange n), lcmRange_dvd_prod_prime_powers (reverse direction: lcmRange n ∣ ∏_p p^⌊log_p n⌋, via Nat.factorization), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 266,
-      "endLine": 285,
+      "startLine": 330,
+      "endLine": 349,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 287,
-      "endLine": 309,
+      "startLine": 351,
+      "endLine": 373,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 311,
-      "endLine": 339,
+      "startLine": 375,
+      "endLine": 403,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }
@@ -106,7 +106,7 @@
       "Replace `axiom hanson_bound` with a Lean theorem using the Beta-integral approach.",
       "Prove the intermediate bound lcm(1,...,n) ≤ 4^n via a primorial bridge — easier than Hanson's 3^n but still nontrivial.",
       "Strengthen to non-asymptotic forms of the prime number theorem: ψ(n)/n approaches 1 from below.",
-      "Close the *reverse direction* of Chebyshev's decomposition: prove `lcmRange n ∣ ∏_{p ≤ n} p^⌊log_p n⌋` via `Nat.factorization` to upgrade the forward divisibility (`prod_prime_powers_dvd_lcmRange`) into the exact identity `lcmRange n = ∏_{p ≤ n} p^⌊log_p n⌋`."
+      "Combine the forward (`prod_prime_powers_dvd_lcmRange`, Iter 7) and reverse (`lcmRange_dvd_prod_prime_powers`, Iter 8) inclusions via `Nat.dvd_antisymm` to obtain the exact Chebyshev identity `lcmRange n = ∏_{p ≤ n} p^⌊log_p n⌋`. From there, the next layer is to bound the product by `3^n` (Hanson) or `4^n` (primorial-bridge) — both are substantial Mathlib-API tasks."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Iteration 8 closes the **reverse direction** of Chebyshev's decomposition `lcm(1,…,n) = ∏_{p ≤ n, prime} p^⌊log_p n⌋`, complementing Iter 7's forward direction (#17166):

```lean
theorem lcmRange_dvd_prod_prime_powers (n : ℕ) :
    lcmRange n ∣ ∏ p ∈ (Finset.range (n+1)).filter Nat.Prime, p ^ Nat.log p n
```

After this, **Iter 9** is a one-line `Nat.dvd_antisymm` from Iter 7 + Iter 8 to obtain the exact Chebyshev identity `lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`.

## Proof sketch

`Finset.lcm_dvd_iff` reduces to: every `m ∈ {1,…,n}` divides the product `N`. For each such `m`:

1. Rewrite `m = ∏_{p ∈ m.primeFactors} p^(m.factorization p)` via `Nat.factorization_prod_pow_eq_self` + `Finsupp.prod` + `Nat.support_factorization`.
2. Extend the index set from `m.primeFactors` to `(Finset.range (n+1)).filter Nat.Prime` via `Finset.prod_subset` (extra factors contribute `p^0 = 1`).
3. Pointwise divisibility: each `m.factorization p ≤ Nat.log p n` because `p^(m.factorization p) ∣ m ≤ n` and `Nat.le_log_of_pow_le hp_prime.one_lt` lifts the inequality into the exponent bound.
4. `Finset.prod_dvd_prod_of_dvd` packages the pointwise step.

## Mathlib lemmas used (all v4.26.0)

| Lemma | Module | Role |
|-------|--------|------|
| `Nat.factorization_prod_pow_eq_self` | `Nat.Factorization.Basic` | `n ≠ 0 → n.factorization.prod (· ^ ·) = n` |
| `Nat.support_factorization` | `Nat.Factorization.Basic` | `n.factorization.support = n.primeFactors` |
| `Nat.mem_primeFactors` | `Nat.Factorization.Basic` | membership iff `prime ∧ dvd ∧ ne_zero` |
| `Nat.Prime.pow_dvd_iff_le_factorization` | `Nat.Factorization.Basic` | `p^k ∣ n ↔ k ≤ n.factorization p` |
| `Nat.le_log_of_pow_le` | `Nat.Log` | `1 < b → b^k ≤ n → k ≤ Nat.log b n` |
| `Finsupp.not_mem_support_iff` | core | `p ∉ f.support ↔ f p = 0` |
| `Finset.prod_subset` | core | extends a product over a subset by factor-1 outside |
| `Finset.prod_dvd_prod_of_dvd` | core | pointwise divisibility lifts to products |
| `Finset.lcm_dvd_iff` | `Algebra.GCDMonoid.Finset` | lcm divisibility iff every element divides target |

All names grep-verified against existing usages in `Erdos1052Problem.lean`, `Erdos684Problem.lean`, `PrimeReciprocalDivergenceOQ03.lean`, `FundamentalArithmeticOQ01OQ01.lean`, etc.

## Counts

| field | before | after |
|-------|--------|-------|
| `lineCount` | 341 | 405 |
| `theoremCount` | 33 | 34 |
| `axiomCount` | 1 | 1 |
| `definitionCount` | 1 | 1 |
| `sorries` | 0 | 0 |

New import: `Mathlib.Data.Nat.Factorization.Basic`.

`meta.json` updates: `lineCount` 341→405, `theoremCount` 33→34, section `startLine`/`endLine` resynced. `keyInsights` and `openQuestions` updated to reflect both directions of Chebyshev's decomposition now being in place.

`state.md` updates: bumped iteration 7→8, added the new theorem to the focus, and rewrote the Next Action to point at Iter 9 (`Nat.dvd_antisymm`).

## Build verification

⚠️ **Docker build NOT run locally** — `proofs/.lake` self-cycle symlink trap forces fresh-clone Mathlib (~30–45 min) on every attempt. All Mathlib lemma names grep-verified. **CI is the ground truth.**

## Test plan

- [ ] CI green on `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`
- [ ] `theoremCount` is 34 (33 + new `lcmRange_dvd_prod_prime_powers`)
- [ ] `lineCount` is 405 (341 + 64 — new theorem ~60 lines + 1 import + minor whitespace)
- [ ] `axiomCount` unchanged at 1
- [ ] `sorries` unchanged at 0

## Sessions arc

| Iter | Outcome |
|------|---------|
| 1 | Bootstrap: elementary bounds + Hanson axiom |
| 2 | Structural lemmas (lcmRange_succ, monotonicity) (#16704) |
| 3 | `pow_dvd_lcmRange` generic power-divisibility (#16772) |
| 4 | Hanson empirical extension n ∈ {25, 30, 50} (#16880) |
| 5 | `prime_pow_dvd_lcmRange` (#17021) |
| 6 | `coprime_prime_pow_pow_of_ne` (#17128) |
| 7 | `prod_prime_powers_dvd_lcmRange` (forward Chebyshev) (#17166) |
| **8** | **`lcmRange_dvd_prod_prime_powers` (reverse Chebyshev)** ⟵ this PR |
| 9 (next) | `lcmRange_eq_prod_prime_powers` via `Nat.dvd_antisymm` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)