### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S11 — symmetric (1,2) shape, axiom-free (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -614,6 +614,160 @@ theorem burnside_p_squared_q_twelve
     haveI hP_normal : (P : Subgroup G).Normal := Sylow.normal_of_subsingleton P
     exact burnside_pq_with_normal_pSylow (a := 2) (b := 1) hcard' (P : Subgroup G) hP_card
 
+/-! Iteration 11 (S11) — symmetric `(a, b) = (1, 2)` shape, axiom-free.
+
+    The S7/S7.5/S9 trio fully discharges `(a, b) = (2, 1)` (with the S10
+    sorry). This iteration mirrors it for `(a, b) = (1, 2)`: `|G| = p · q²`.
+
+    The two non-exceptional cases follow by direct mirroring:
+      * **`p < q` (mirror of S7)**: `n_q ∣ p` and `n_q ≡ 1 [MOD q]` with
+        `p < q` forces `n_q = 1` (helper `sylow_count_eq_one_of_lt_prime`,
+        applied with `(p, q)` swapped).
+      * **`q < p`, `(p, q) ≠ (3, 2)` (mirror of S7.5)**: `n_p ∣ q²` and
+        `n_p ≡ 1 [MOD p]` with `q < p` and `(q, p) ≠ (2, 3)` forces
+        `n_p = 1` (helper `sylow_count_eq_one_of_lt_prime_pow_two`,
+        applied with `(p, q)` swapped).
+
+    The exceptional case `(p, q) = (3, 2)` gives `|G| = 3 · 4 = 12`, which
+    coincides with the `|G| = 12 = 2² · 3` group order from S9. Reuses
+    `burnside_p_squared_q_twelve` directly via a thin wrapper.
+
+    After S11, `burnside_pq_nontrivial` will be axiom-only for shapes with
+    `2 ≤ a ∧ 2 ≤ b` (modulo the S10 sorry); S12 updates the dispatch. -/
+
+/-- **Burnside `|G| = p · q²`, case `p < q`** (axiom-free).
+
+    Mirror of `burnside_p_squared_q_p_gt_q`. Sylow's third theorem
+    (`card_sylow_modEq_one`) gives `n_q ≡ 1 [MOD q]`, and
+    `Sylow.card_dvd_index` gives `n_q ∣ p` (the index of a Sylow
+    `q`-subgroup is `p`, since `|Q| = q²` and `|G| = p · q²`). The helper
+    `sylow_count_eq_one_of_lt_prime`, with primes swapped to `(q, p)`,
+    forces `n_q = 1`: `p ≡ 1 [MOD q]` with `p < q` is impossible.
+
+    With `n_q = 1`, the unique Sylow `q`-subgroup `Q` is normal
+    (`Sylow.normal_of_subsingleton`). Then `burnside_pq_with_normal_qSylow`
+    discharges, treating `|G| = p¹ · q²`.
+
+    This eliminates the `(a, b) = (1, 2)` shape from the
+    `burnside_pq_nontrivial` axiom whenever `p < q`. -/
+theorem burnside_p_q_squared_p_lt_q
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p < q) (hcard : Nat.card G = p * q ^ 2) :
+    IsSolvable G := by
+  -- Step 1: pick a Sylow q-subgroup; |Q| = q² by `Sylow.card_eq_multiplicity`.
+  obtain ⟨Q⟩ : Nonempty (Sylow q G) := inferInstance
+  have hp_ne_q : p ≠ q := by omega
+  have hq_ne_p : q ≠ p := fun h => hp_ne_q h.symm
+  have hq_not_dvd_p : ¬ q ∣ p :=
+    mt (Nat.prime_dvd_prime_iff_eq hq.out hp.out).mp hq_ne_p
+  have hcop : Nat.Coprime p (q ^ 2) :=
+    (((Nat.coprime_primes hp.out hq.out).mpr hp_ne_q)).pow_right 2
+  have hQ_card : Nat.card (Q : Subgroup G) = q ^ 2 := by
+    have hmult := Sylow.card_eq_multiplicity Q
+    have hfact : Nat.factorization (Nat.card G) q = 2 := by
+      rw [hcard, Nat.factorization_mul_apply_of_coprime hcop,
+          Nat.factorization_eq_zero_of_not_dvd hq_not_dvd_p,
+          Nat.Prime.factorization_pow hq.out]
+      simp
+    rw [hfact] at hmult
+    exact hmult
+  -- Step 2: index of Q is p (Lagrange + cancellation).
+  have hq2_pos : 0 < q ^ 2 := pow_pos hq.out.pos 2
+  have hQ_index : (Q : Subgroup G).index = p := by
+    have h := Subgroup.card_mul_index (Q : Subgroup G)
+    rw [hQ_card, hcard, mul_comm p (q ^ 2)] at h
+    exact Nat.eq_of_mul_eq_mul_left hq2_pos h
+  -- Step 3: n_q ≡ 1 [MOD q] and n_q ∣ p; helper (with primes swapped) forces n_q = 1.
+  have hnq_mod : Nat.card (Sylow q G) ≡ 1 [MOD q] := card_sylow_modEq_one q G
+  have hnq_dvd : Nat.card (Sylow q G) ∣ p := hQ_index ▸ Sylow.card_dvd_index Q
+  have hnq_eq_one : Nat.card (Sylow q G) = 1 :=
+    sylow_count_eq_one_of_lt_prime hq.out hp.out hpq hnq_mod hnq_dvd
+  -- Step 4: n_q = 1 ⇒ Subsingleton (Sylow q G) ⇒ Q.Normal.
+  haveI hSub : Subsingleton (Sylow q G) :=
+    (Nat.card_eq_one_iff_unique.mp hnq_eq_one).1
+  haveI hQ_normal : (Q : Subgroup G).Normal := Sylow.normal_of_subsingleton Q
+  -- Step 5: discharge via burnside_pq_with_normal_qSylow with a = 1, b = 2.
+  have hcard' : Nat.card G = p ^ 1 * q ^ 2 := by rw [pow_one]; exact hcard
+  exact burnside_pq_with_normal_qSylow (a := 1) (b := 2) hcard' (Q : Subgroup G) hQ_card
+
+/-- **Burnside `|G| = p · q²`, case `q < p`, non-exceptional** (axiom-free).
+
+    Mirror of `burnside_p_squared_q_p_lt_q`. Sylow's third theorem
+    gives `n_p ≡ 1 [MOD p]`, and `Sylow.card_dvd_index` gives
+    `n_p ∣ q²` (the index of a Sylow `p`-subgroup is `q²`, since
+    `|P| = p` and `|G| = p · q²`). The helper
+    `sylow_count_eq_one_of_lt_prime_pow_two`, with primes swapped to
+    `(q, p)`, then forces `n_p = 1`, using `(q, p) ≠ (2, 3)` (i.e.,
+    `(p, q) ≠ (3, 2)`) to rule out the `n_p = q²` case.
+
+    With `n_p = 1`, the unique Sylow `p`-subgroup `P` is normal
+    (`Sylow.normal_of_subsingleton`). Then `burnside_pq_with_normal_pSylow`
+    discharges, treating `|G| = p¹ · q²`.
+
+    Together with `burnside_p_q_squared_p_lt_q` and the exceptional case
+    `(p, q) = (3, 2)` handled via `burnside_p_q_squared_twelve_mirror`,
+    this completes the `(a, b) = (1, 2)` shape elimination. -/
+theorem burnside_p_q_squared_q_lt_p
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : q < p) (hexc : ¬ (p = 3 ∧ q = 2))
+    (hcard : Nat.card G = p * q ^ 2) :
+    IsSolvable G := by
+  -- Step 1: pick a Sylow p-subgroup; |P| = p^1 = p by `Sylow.card_eq_multiplicity`.
+  obtain ⟨P⟩ : Nonempty (Sylow p G) := inferInstance
+  have hp_ne_q : p ≠ q := by omega
+  have hp_not_dvd_q2 : ¬ p ∣ q ^ 2 := by
+    intro hdvd
+    have : p ∣ q := hp.out.dvd_of_dvd_pow hdvd
+    exact hp_ne_q ((Nat.prime_dvd_prime_iff_eq hp.out hq.out).mp this)
+  have hcop : Nat.Coprime p (q ^ 2) :=
+    (((Nat.coprime_primes hp.out hq.out).mpr hp_ne_q)).pow_right 2
+  have hP_card : Nat.card (P : Subgroup G) = p := by
+    have hmult := Sylow.card_eq_multiplicity P
+    have hfact : Nat.factorization (Nat.card G) p = 1 := by
+      rw [hcard, Nat.factorization_mul_apply_of_coprime hcop,
+          Nat.Prime.factorization_self hp.out,
+          Nat.factorization_eq_zero_of_not_dvd hp_not_dvd_q2]
+      simp
+    rw [hfact, pow_one] at hmult
+    exact hmult
+  -- Step 2: index of P is q² (Lagrange + cancellation).
+  have hp_pos : 0 < p := hp.out.pos
+  have hP_index : (P : Subgroup G).index = q ^ 2 := by
+    have h := Subgroup.card_mul_index (P : Subgroup G)
+    rw [hP_card, hcard] at h
+    exact Nat.eq_of_mul_eq_mul_left hp_pos h
+  -- Step 3: n_p ≡ 1 [MOD p] and n_p ∣ q²; helper (primes swapped) forces n_p = 1.
+  have hnp_mod : Nat.card (Sylow p G) ≡ 1 [MOD p] := card_sylow_modEq_one p G
+  have hnp_dvd : Nat.card (Sylow p G) ∣ q ^ 2 := hP_index ▸ Sylow.card_dvd_index P
+  -- Translate `hexc : ¬ (p = 3 ∧ q = 2)` to the helper's swapped frame.
+  have hexc' : ¬ (q = 2 ∧ p = 3) := fun ⟨hq2, hp3⟩ => hexc ⟨hp3, hq2⟩
+  have hnp_eq_one : Nat.card (Sylow p G) = 1 :=
+    sylow_count_eq_one_of_lt_prime_pow_two hq.out hp.out hpq hexc' hnp_mod hnp_dvd
+  -- Step 4: n_p = 1 ⇒ Subsingleton (Sylow p G) ⇒ P.Normal.
+  haveI hSub : Subsingleton (Sylow p G) :=
+    (Nat.card_eq_one_iff_unique.mp hnp_eq_one).1
+  haveI hP_normal : (P : Subgroup G).Normal := Sylow.normal_of_subsingleton P
+  -- Step 5: discharge via burnside_pq_with_normal_pSylow with a = 1, b = 2.
+  have hcard' : Nat.card G = p ^ 1 * q ^ 2 := by rw [pow_one]; exact hcard
+  exact burnside_pq_with_normal_pSylow (a := 1) (b := 2) hcard' (P : Subgroup G) hP_card
+
+/-- **Burnside `|G| = 12 = 3 · 2²`, mirror of S9** (axiom-free, modulo
+    the same isolated S10 sorry as `burnside_p_squared_q_twelve`).
+
+    The exceptional case `(p, q) = (3, 2)` of the `(a, b) = (1, 2)`
+    shape: `|G| = p · q² = 3 · 4 = 12`. This is the same group order as
+    the S9 case `|G| = 12 = 2² · 3`, just viewed under the mirror
+    factorisation. The proof is a thin wrapper around
+    `burnside_p_squared_q_twelve`. -/
+theorem burnside_p_q_squared_twelve_mirror
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 2)] [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12) :
+    IsSolvable G :=
+  burnside_p_squared_q_twelve hcard
+
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART IV: Main theorem
 -- ═══════════════════════════════════════════════════════════════════════

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,77 +1,92 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T18:30:00Z
-**Iteration**: 9 (partial Lean implementation)
+**Since**: 2026-05-08T19:45:00Z
+**Iteration**: 11 (symmetric (1,2) shape, axiom-free, 3 new theorems)
 
-## S9 (this session, researcher-10, partial implementation)
+## S11 (this session, researcher-11, full implementation)
 
-S7 (PR #17114), S7.5 (PR #17155), and S8 spec (PR #17180) are merged.
-S8 produced a detailed spec for the exceptional `(p, q) = (2, 3),
-|G| = 12` case (`session-8-twelve-spec.md`); S9 implements the bulk
-of that spec axiom-free, with a single isolated `sorry` deferred to
-S10 for the element-counting cardinality lemma.
+S7 (PR #17114), S7.5 (PR #17155), S8 spec (PR #17180), and S9 (PR #17270)
+are merged. S9 implemented the bulk of the `(a, b) = (2, 1)` shape modulo
+a single isolated `sorry` deferred to S10.
 
-**This session's contribution** (~140 added lines in
+S11 (this session) mirrors the S7/S7.5/S9 trio for the symmetric
+`(a, b) = (1, 2)` shape `|G| = p · q²`.
+
+**This session's contribution** (~154 added lines in
 `AbelRuffiniGaloisExtensionsOQ07.lean`):
 
-* `sylow_count_dvd_four_modEq_one_three` (private helper, axiom-free):
-  if `n ≥ 1`, `n ∣ 4`, `n ≡ 1 [MOD 3]`, then `n ∈ {1, 4}`. Decidable
-  on Nat via `interval_cases` (2 ≢ 1 [MOD 3]; 3 ∤ 4).
-* `sylow_two_unique_when_n3_four` (private, sorry'd for S10): when
-  `|G| = 12` and `n_3 = 4`, the Sylow 2-subgroup is unique. Proof
-  outline carried in the docstring; implementation requires
-  Set/Finset cardinality machinery.
-* `burnside_p_squared_q_twelve` (axiom-free modulo the above sorry):
-  case-splits on `n_3 ∈ {1, 4}`. The `n_3 = 1` branch is fully
-  discharged (Sylow 3-subgroup normal; `burnside_pq_with_normal_qSylow`
-  with `(a, b) = (2, 1)`). The `n_3 = 4` branch reduces to
-  `Subsingleton (Sylow 2 G)` via the S10 lemma, yielding a normal
-  Sylow 2-subgroup; `burnside_pq_with_normal_pSylow` with
-  `(a, b) = (2, 1)` discharges.
+* `burnside_p_q_squared_p_lt_q` (axiom-free): mirror of S7. For
+  `|G| = p · q²` with `p < q`, Sylow's third theorem and
+  `Sylow.card_dvd_index` force `n_q ∣ p` and `n_q ≡ 1 [MOD q]`. The
+  EXISTING helper `sylow_count_eq_one_of_lt_prime` (S7) is applied with
+  primes swapped to `(q, p)`, forcing `n_q = 1`; the unique Sylow
+  q-subgroup is normal; `burnside_pq_with_normal_qSylow` discharges with
+  `(a, b) = (1, 2)`. ~50 lines.
+* `burnside_p_q_squared_q_lt_p` (axiom-free, modulo `(p, q) ≠ (3, 2)`):
+  mirror of S7.5. For `|G| = p · q²` with `q < p` and `(p, q) ≠ (3, 2)`,
+  the EXISTING helper `sylow_count_eq_one_of_lt_prime_pow_two` (S7.5) is
+  applied with primes swapped to `(q, p)` — its exclusion `¬ (p = 2 ∧ q = 3)`
+  in the swapped frame is exactly our `¬ (q = 2 ∧ p = 3)`, equivalent to
+  our `¬ (p = 3 ∧ q = 2)`. Forces `n_p = 1`; unique Sylow p-subgroup is
+  normal; `burnside_pq_with_normal_pSylow` discharges. ~55 lines.
+* `burnside_p_q_squared_twelve_mirror` (axiom-free, modulo S10 sorry):
+  thin wrapper around S9's `burnside_p_squared_q_twelve` for the
+  exceptional `(p, q) = (3, 2)` case, where `|G| = 3 · 2² = 12` is the
+  same group order as S9's `|G| = 2² · 3 = 12`. ~5 lines.
+
+**No new helpers**: S11 reuses both Sylow-count helpers from S7/S7.5
+verbatim (with primes swapped at the call site). Zero risk of helper
+incompatibility — the swap is purely cosmetic.
 
 **Build status**: not verified locally (`proofs/.lake` recursive
-self-symlink; ≥45-min cold-cache builds). Code follows the S7.5 idioms
+self-symlink; ≥45-min cold-cache builds). Code follows S7/S7.5 idioms
 verbatim (factorization-of-cardinality computation,
 `Sylow.card_eq_multiplicity` + `Subgroup.card_mul_index` chain) so the
-risk profile is identical to the merged-but-build-pending S7.5.
+risk profile is identical to the merged-but-build-pending S7/S7.5/S9.
 
-**Counts**: `lineCount 738 → 876` (+138, including ~35 lines of
-docstrings). `theoremCount 17 → 20` (+1 main theorem, +2 private
-lemmas). `axiomCount 1` unchanged. `sorries 0 → 1` (the isolated S10
+**Counts**: `lineCount 876 → 1030` (+154, including ~30 lines of
+docstrings and ~25 lines of iteration narrative). `theoremCount 20 → 23`
+(+3 main theorems). `substantiveTheoremCount 16 → 18` (+2; the trivial
+S9 wrapper not counted as substantive). `axiomCount 1` unchanged.
+`sorries 1` unchanged (no new sorries; S10 sorry remains the only
 deferred lemma).
 
 ## Current Focus
 
-`(a, b) = (2, 1)` shape of `burnside_pq_nontrivial` is **near-fully
-discharged** axiom-free:
+After S11 the `(a, b) = (1, 2)` shape is fully covered (modulo S10):
+
+* `q > p` (S11.1, this PR): axiom-free.
+* `p > q ≠ q + 1` (S11.2, this PR): axiom-free.
+* `(p, q) = (3, 2), |G| = 12` (S11.3, this PR): axiom-free modulo
+  the S10 sorry (via wrapper around S9).
+
+Symmetrically, the `(a, b) = (2, 1)` shape is fully covered (modulo S10):
 
 * `q < p` (S7, PR #17114): axiom-free.
 * `p < q ≠ p + 1` (S7.5, PR #17155): axiom-free.
-* `(p, q) = (2, 3), |G| = 12` (S9, this PR): axiom-free modulo a
-  single sorry in `sylow_two_unique_when_n3_four`.
+* `(p, q) = (2, 3), |G| = 12` (S9, PR #17270): axiom-free modulo
+  the S10 sorry.
 
-After S10 closes the sorry, `burnside_pq` can peel off `(a, b) = (2, 1)`
-axiom-free for **all** `(p, q)`. With the symmetric `(1, 2)` shape (S11),
-`burnside_pq_nontrivial` narrows to require `2 ≤ a ∧ 2 ≤ b`.
+After S10 closes the sorry, both shapes are fully axiom-free; S12
+updates the `burnside_pq` dispatch to peel them off; what remains
+in `burnside_pq_nontrivial` requires `2 ≤ a ∧ 2 ≤ b` (genuinely
+both ≥ 2).
 
-## Active Approach (S10)
+## Active Approach (S10, unchanged)
 
-Close `sylow_two_unique_when_n3_four`. The element-counting argument:
+Close `sylow_two_unique_when_n3_four` via element counting:
 
 1. Each pair of distinct Sylow 3-subgroups intersects trivially
    (cardinality of `Q ⊓ Q'` divides `|Q| = 3` and is < `|Q|`, so = 1).
-   Use `Subgroup.card_inf_le_card` or direct Lagrange.
-2. Show `{g : G | g^3 = 1} = ⋃ᵢ (Q_i : Set G)` as sets, then partition
-   as `{e} ⊔ ⊔ᵢ (Q_i \ {e})` with the `Q_i \ {e}` pairwise disjoint
-   (Finset.disjoint via subgroup intersection).
+2. `{g : G | g^3 = 1} = ⋃ᵢ (Q_i : Set G)`; partition as
+   `{e} ⊔ ⊔ᵢ (Q_i \ {e})`.
 3. Cardinality sum: `1 + 4·2 = 9`.
-4. For any Sylow 2-subgroup `P`: `P \ {e} ⊆ G \ {g | g^3 = 1}` (orders
-   2, 4 don't satisfy `g^3 = 1` unless `g = 1`); cardinalities match
-   (`|P| - 1 = 3 = |G \ ...|`); so `P = {e} ∪ (G \ ...)` set-theoretically.
+4. For any Sylow 2-subgroup `P`: `P \ {e} ⊆ G \ {g | g^3 = 1}`;
+   cardinalities match (`|P| - 1 = 3 = |G \ ...|`); so
+   `P = {e} ∪ (G \ ...)` set-theoretically.
 5. RHS depends only on `G`, not on choice of `P`; hence
-   `Subsingleton (Sylow 2 G)` (two Sylow 2's would have the same
-   underlying set, hence equal as subgroups, hence equal as Sylow's).
+   `Subsingleton (Sylow 2 G)`.
 
 Mathlib API likely needed:
 * `Subgroup.disjoint_iff_inf_eq_bot` or `Subgroup.eq_bot_of_card_le_one`
@@ -83,10 +98,9 @@ Estimated ~80-120 lines.
 
 ## Blockers
 
-Same as S8: build verification deferred (`.lake` symlink; ~45 min
-cold-cache). S9 code shipped "build pending" with high confidence
-based on S7.5-pattern adherence. S10 element-counting will need
-careful handling of `Set.ncard` vs `Finset.card` choice.
+Same as S7/S7.5/S9: build verification deferred (`.lake` symlink;
+~45 min cold-cache). S11 code shipped "build pending" with high
+confidence based on S7/S7.5-pattern adherence.
 
 The residual axiom (orders divisible by `p²` AND `q²` for distinct
 primes, once both shapes peeled) requires character theory or
@@ -98,42 +112,42 @@ focal-subgroup machinery. Estimated 400-800 lines on top of
 1. **(S10)** Close `sylow_two_unique_when_n3_four`'s sorry via
    element-counting (~80-120 lines). Mathlib API verification
    required for `Set.ncard_biUnion`-style lemmas.
-2. **(post-S10)** Update `burnside_pq` dispatch to peel off
-   `(a, b) = (2, 1)`: combine S7 (`q < p`), S7.5 (`p < q ≠ p+1`),
-   and `burnside_p_squared_q_twelve` (`(p, q) = (2, 3)`).
-3. **(S11)** Symmetric `(1, 2)` shape: prove
-   `burnside_p_q_squared_p_gt_q`, `burnside_p_q_squared_p_lt_q`,
-   `burnside_p_q_squared_eighteen` (mirror of S7/S7.5/S9).
-4. **(S12)** Update `burnside_pq` dispatch to peel off `(1, 2)` too.
-   Narrow `burnside_pq_nontrivial` axiom hypothesis to
-   `2 ≤ a ∧ 2 ≤ b`.
-5. **(S13+)** `|G| = p² · q²` Sylow analysis (~150 lines).
-6. **(S14+)** Goldschmidt-Matsuyama on `Mathlib.GroupTheory.Focal` for
+2. **(S12)** Update `burnside_pq` dispatch to peel off both
+   `(a, b) = (2, 1)` AND `(a, b) = (1, 2)`: combine S7/S7.5/S9 for
+   `(2, 1)` and S11.1/S11.2/S11.3 for `(1, 2)`. Narrow
+   `burnside_pq_nontrivial` axiom hypothesis to `2 ≤ a ∧ 2 ≤ b`.
+3. **(S13+)** `|G| = p² · q²` Sylow analysis (~150 lines).
+4. **(S14+)** Goldschmidt-Matsuyama on `Mathlib.GroupTheory.Focal` for
    `(a, b) ≥ (2, 2)`.
 
-## Iteration 9 Builds (researcher-10, 2026-05-08)
+## Iteration 11 Builds (researcher-11, 2026-05-08)
 
-- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`: 738→876 lines.
-- New private helper `sylow_count_dvd_four_modEq_one_three` (~12 lines).
-- New private placeholder `sylow_two_unique_when_n3_four` (~7 lines, sorry).
-- New theorem `burnside_p_squared_q_twelve` (~55 lines including docstring).
-- Section header + iteration narrative comment block (~35 lines).
-- meta.json: lineCount 738→876, theoremCount 17→20,
-  substantiveTheoremCount 15→16, sorries 0→1, axiomCount 1 unchanged.
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`: 876→1030 lines.
+- New theorem `burnside_p_q_squared_p_lt_q` (~50 lines including docstring).
+- New theorem `burnside_p_q_squared_q_lt_p` (~55 lines including docstring).
+- New theorem `burnside_p_q_squared_twelve_mirror` (~13 lines including docstring).
+- New iteration narrative comment block (~22 lines).
+- New helper code: NONE (reuses S7/S7.5 helpers verbatim with primes
+  swapped at call sites).
+- meta.json: lineCount 876→1030, theoremCount 20→23,
+  substantiveTheoremCount 16→18, sorries 1 unchanged, axiomCount 1
+  unchanged. Updated `originalContributions`, `mainTheorems`, and
+  `assumptions` text to reflect S9 + S11.
 
 ## Why Build-Pending Is Acceptable Here
 
-S9's three new declarations follow the established S7/S7.5 pattern
+S11's three new declarations follow the established S7/S7.5 pattern
 verbatim:
 
-* `sylow_count_dvd_four_modEq_one_three` is a 12-line `interval_cases`
-  proof on Nat — verifiable by hand.
-* `burnside_p_squared_q_twelve` reuses the exact factorization +
-  Sylow-cardinality + index-cancellation chain that S7.5 already
-  proved (also build-pending) for the symmetric case. The only novel
-  Mathlib calls are the same ones S7.5 uses.
-* `sylow_two_unique_when_n3_four` is `sorry`'d — no build risk.
+* `burnside_p_q_squared_p_lt_q` is a near-line-for-line mirror of
+  `burnside_p_squared_q_p_gt_q` (S7) with `(p, q)` roles swapped at
+  the helper call. The only Mathlib calls are the same ones S7 uses.
+* `burnside_p_q_squared_q_lt_p` mirrors `burnside_p_squared_q_p_lt_q`
+  (S7.5) similarly. The `hexc` translation
+  `¬ (p = 3 ∧ q = 2) ↔ ¬ (q = 2 ∧ p = 3)` is a one-line `fun ⟨…⟩ ⟨…⟩` swap.
+* `burnside_p_q_squared_twelve_mirror` is a 1-line wrapper invocation —
+  no proof content.
 
-The risk profile is identical to S7.5's. If S7.5 builds, S9 builds.
-If S7.5 needs fixing, S9 needs the same fix. Coupling them in a
-single fix-up cycle (when `.lake` is repaired) is efficient.
+The risk profile is identical to S7/S7.5/S9's. If those build, S11
+builds. If they need fixing, S11 needs the same fix. Coupling them
+in a single fix-up cycle (when `.lake` is repaired) is efficient.

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 876,
+    "lineCount": 1030,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -126,10 +126,13 @@
       "Six sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime), |G| = 12 with normal Sylow-2 (A₄-style), and |G| = 75 = 5²·3 (Iteration 7, axiom-free via burnside_p_squared_q_p_gt_q) — all axiom-free.",
       "alternatingGroupFin5_card: axiom-free proof that |A₅| = 2²·3·5, exhibiting the three distinct prime factors that make A₅ a sharpness witness.",
       "alternatingGroupFin5_not_solvable: axiom-free proof that A₅ is not solvable, via reduction to Equiv.Perm.not_solvable (Fin 5) through the short exact sequence A₅ → S₅ → ℤ/2.",
-      "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses; A₅ also defeats the squarefree route since 60 has 2²)."
+      "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses; A₅ also defeats the squarefree route since 60 has 2²).",
+      "burnside_p_q_squared_p_lt_q (Iteration 11): axiom-free Burnside for `|G| = p · q²` in the case `p < q`. Mirror of S7 for the `(a, b) = (1, 2)` shape: Sylow's third theorem + `Sylow.card_dvd_index` force n_q ∣ p and n_q ≡ 1 [MOD q]; the existing helper `sylow_count_eq_one_of_lt_prime` (with primes swapped to `(q, p)`) forces n_q = 1; the unique Sylow q-subgroup is normal, and `burnside_pq_with_normal_qSylow` discharges with (a, b) = (1, 2). FIRST sub-case of the (1, 2) shape elimination.",
+      "burnside_p_q_squared_q_lt_p (Iteration 11): axiom-free Burnside for `|G| = p · q²` in the case `q < p`, excluding the exceptional `(p, q) = (3, 2)`. Mirror of S7.5: helper `sylow_count_eq_one_of_lt_prime_pow_two` (with primes swapped) forces n_p = 1; the unique Sylow p-subgroup is normal; `burnside_pq_with_normal_pSylow` discharges with (a, b) = (1, 2). SECOND sub-case of the (1, 2) shape elimination.",
+      "burnside_p_q_squared_twelve_mirror (Iteration 11): axiom-free Burnside for the exceptional `|G| = 12 = 3 · 2²` case of the (1, 2) shape (modulo the same isolated S10 sorry as S9's `burnside_p_squared_q_twelve`). Thin wrapper around `burnside_p_squared_q_twelve` — the (1, 2) and (2, 1) views of |G| = 12 share group-theoretic content, so the same Sylow analysis applies. THIRD sub-case completing the (1, 2) shape coverage."
     ],
-    "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited; this is a strict shortcut for any future case-by-case Sylow-counting analysis (`|G| = p² · q`, `|G| = p · q²`, …). Iteration 7 adds the FIRST sub-case discharge of the `(a, b) = (2, 1)` shape: `burnside_p_squared_q_p_gt_q` proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`, by combining Sylow's third theorem (`card_sylow_modEq_one`) with `Sylow.card_dvd_index` to force `n_p = 1`, then plugging into `burnside_pq_with_normal_pSylow`. The symmetric `p < q ≠ 3` case (S7.5) and the exceptional `(p, q) = (2, 3), |G| = 12` case (S8) are the remaining S-iterations needed to remove `(a, b) = (2, 1)` from the axiom hypothesis entirely. The axiom statement itself is unchanged: it still isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
-    "theoremCount": 20,
+    "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7/9/11): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited. Iteration 7 (S7), 7.5, and 9 progressively cover the three sub-cases of the `(a, b) = (2, 1)` shape: S7 proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`; S7.5 covers `p < q` with `(p, q) ≠ (2, 3)`; S9 covers the exceptional `(p, q) = (2, 3), |G| = 12` (modulo a single isolated sorry deferred to S10 — the `sylow_two_unique_when_n3_four` element-counting lemma). Iteration 11 (S11) mirrors this trio for the symmetric `(a, b) = (1, 2)` shape: `burnside_p_q_squared_p_lt_q` (mirror of S7), `burnside_p_q_squared_q_lt_p` excluding `(p, q) = (3, 2)` (mirror of S7.5), and `burnside_p_q_squared_twelve_mirror` reusing S9 for `|G| = 12 = 3 · 2²`. After S10 closes the deferred sorry and S12 updates the `burnside_pq` dispatch, `burnside_pq_nontrivial` will be required only for shapes with `2 ≤ a ∧ 2 ≤ b` (orders divisible by `p²` AND `q²` for distinct primes); a full proof of that residual axiom would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route — character theory + algebraic integers à la Burnside 1904, or transfer + focal subgroup à la Goldschmidt-Matsuyama 1970s).",
+    "theoremCount": 23,
     "definitionCount": 0
   },
   "overview": {
@@ -267,10 +270,10 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 876,
+    "lineCount": 1030,
     "axiomCount": 1,
-    "theoremCount": 20,
-    "substantiveTheoremCount": 16,
+    "theoremCount": 23,
+    "substantiveTheoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
     "sorries": 1
@@ -316,6 +319,21 @@
       "name": "burnside_pq_sharp",
       "statement": "Nat.card (alternatingGroup (Fin 5)) = 2^2 · 3 · 5 ∧ ¬ IsSolvable (alternatingGroup (Fin 5))",
       "description": "Sharpness witness: A₅ has order 60 = 2²·3·5 (three distinct primes) and is non-solvable. Demonstrates that `burnside_pq` cannot be extended to three distinct primes. Axiom-free."
+    },
+    {
+      "name": "burnside_p_q_squared_p_lt_q",
+      "statement": "∀ {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact p.Prime] [Fact q.Prime], p < q → Nat.card G = p · q^2 → IsSolvable G",
+      "description": "Iteration 11 axiom-free discharge: Burnside for `|G| = p · q²` with `p < q`. Mirror of `burnside_p_squared_q_p_gt_q`. Sylow's third theorem forces n_q = 1; the unique Sylow q-subgroup is normal; `burnside_pq_with_normal_qSylow` discharges with (a, b) = (1, 2). First of three sub-cases needed to remove `(a, b) = (1, 2)` from the `burnside_pq_nontrivial` hypothesis."
+    },
+    {
+      "name": "burnside_p_q_squared_q_lt_p",
+      "statement": "∀ {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact p.Prime] [Fact q.Prime], q < p → ¬ (p = 3 ∧ q = 2) → Nat.card G = p · q^2 → IsSolvable G",
+      "description": "Iteration 11 axiom-free discharge: Burnside for `|G| = p · q²` with `q < p`, excluding the exceptional `(p, q) = (3, 2)`. Mirror of `burnside_p_squared_q_p_lt_q`. Sylow's third theorem + the existing `sylow_count_eq_one_of_lt_prime_pow_two` helper (with primes swapped) force n_p = 1; the unique Sylow p-subgroup is normal; `burnside_pq_with_normal_pSylow` discharges. Second of three sub-cases of the `(a, b) = (1, 2)` shape elimination."
+    },
+    {
+      "name": "burnside_p_q_squared_twelve_mirror",
+      "statement": "∀ {G : Type*} [Group G] [Finite G] [Fact (Nat.Prime 2)] [Fact (Nat.Prime 3)], Nat.card G = 12 → IsSolvable G",
+      "description": "Iteration 11 axiom-free discharge (modulo the same isolated S10 sorry as `burnside_p_squared_q_twelve`): the exceptional `(p, q) = (3, 2), |G| = 12 = 3 · 2²` case of the `(a, b) = (1, 2)` shape. Reuses S9's `burnside_p_squared_q_twelve` directly via a thin wrapper — the (1, 2) and (2, 1) views of |G| = 12 share the same Sylow analysis. Third and final sub-case of the `(a, b) = (1, 2)` shape coverage."
     }
   ],
   "sorries": 1


### PR DESCRIPTION
## Summary

Mirror of S7/S7.5/S9 for the symmetric `(a, b) = (1, 2)` shape `|G| = p · q²`. Three new theorems, **zero new helpers** — reuses S7/S7.5's Sylow-count helpers verbatim with primes swapped at call sites.

## What changed

`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (+154 lines):

- **`burnside_p_q_squared_p_lt_q`** (axiom-free): mirror of S7. For `|G| = p · q²` with `p < q`, Sylow's third theorem + `Sylow.card_dvd_index` force `n_q ∣ p` and `n_q ≡ 1 [MOD q]`; the existing helper `sylow_count_eq_one_of_lt_prime` (S7) is applied with primes swapped to `(q, p)`, forcing `n_q = 1`; the unique Sylow q-subgroup is normal; `burnside_pq_with_normal_qSylow` discharges with `(a, b) = (1, 2)`.

- **`burnside_p_q_squared_q_lt_p`** (axiom-free, modulo `(p, q) ≠ (3, 2)`): mirror of S7.5. The existing helper `sylow_count_eq_one_of_lt_prime_pow_two` (S7.5) is applied with primes swapped — its exclusion `¬ (p = 2 ∧ q = 3)` in the swapped frame is exactly our `¬ (q = 2 ∧ p = 3)`, equivalent to our `¬ (p = 3 ∧ q = 2)`. Forces `n_p = 1`; unique Sylow p-subgroup is normal; `burnside_pq_with_normal_pSylow` discharges.

- **`burnside_p_q_squared_twelve_mirror`** (axiom-free, modulo S10 sorry): thin wrapper around S9's `burnside_p_squared_q_twelve` — the (1, 2) and (2, 1) views of `|G| = 12` share the same Sylow analysis.

## Coverage status

After S11, both `(a, b)` shapes covered modulo the single S10 sorry:

| Shape | `q < p` | `p < q` (non-exc) | `(p,q)` exc, `\|G\| = 12` |
|-------|---------|-------------------|---------------------------|
| `(2, 1)` | S7 (PR #17114) | S7.5 (PR #17155) | S9 (PR #17270) |
| `(1, 2)` | **S11.2 (this PR)** | **S11.1 (this PR)** | **S11.3 (this PR)** |

Once S10 closes `sylow_two_unique_when_n3_four`, S12 can update the `burnside_pq` dispatch to peel both shapes off, leaving `burnside_pq_nontrivial` required only for `2 ≤ a ∧ 2 ≤ b`.

## Counts

- `lineCount`: 876 → 1030 (+154)
- `theoremCount`: 20 → 23 (+3)
- `substantiveTheoremCount`: 16 → 18 (+2; thin wrapper not substantive)
- `axiomCount`: 1 (unchanged)
- `sorries`: 1 (unchanged — no new sorries; S10 sorry unaffected)

`meta.json` `originalContributions`, `mainTheorems`, and `assumptions` text all updated to reflect S9 + S11.

## Build status

Not verified locally — `proofs/.lake` recursive self-symlink + ≥45 min cold-cache builds make local Docker verification impractical this session.

**Risk profile identical to S7/S7.5/S9** (merged build-pending): same Mathlib calls (`Sylow.card_eq_multiplicity`, `Subgroup.card_mul_index`, `Nat.factorization_mul_apply_of_coprime`, `Nat.Coprime.pow_right`, `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Nat.card_eq_one_iff_unique`, `Sylow.normal_of_subsingleton`, `burnside_pq_with_normal_{p,q}Sylow`); helpers reused verbatim. If S7/S7.5 build, S11 builds. CI is the authoritative verifier.

## Test plan

- [ ] CI builds `Proofs.AbelRuffiniGaloisExtensionsOQ07` cleanly
- [ ] No new sorries introduced (`sorries: 1` consistent across `meta`, `leanFile`, top-level)
- [ ] Mirror reuse pattern: helpers `sylow_count_eq_one_of_lt_prime` and `sylow_count_eq_one_of_lt_prime_pow_two` correctly invoked with `(p, q)` arguments swapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)