### PR TITLE
fix(meta): erdos-859 leanFile.sorries 7 → 3 (main file only)

### DIFF
--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -208,7 +208,7 @@
     "theoremCount": 13,
     "definitionCount": 9,
     "path": "Proofs/Erdos859Problem.lean",
-    "sorries": 7,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos859ProblemAristotle.lean"
     ]


### PR DESCRIPTION
## Fix

Restore the **established convention** from PR #17287 for sorry counts:

- \`leanFile.sorries\` = main file only
- \`meta.sorries\` = aggregate chain count (main + additionalFiles)
- top-level \`sorries\` = aggregate chain count

## Evidence

| field | before | after |
|---|---|---|
| \`leanFile.sorries\` | 7 | **3** |
| \`meta.sorries\` | 7 | 7 (unchanged) |
| top-level \`sorries\` | 7 | 7 (unchanged) |

Sorry counts (verified with comment-stripped \`\\bsorry\\b\` regex):

| file | sorries |
|---|---|
| \`Proofs/Erdos859Problem.lean\` (main) | 3 |
| \`Proofs/Erdos859ProblemAristotle.lean\` (companion) | 4 |
| **chain total** | 7 |

## Why

PR #17279 bumped \`leanFile.sorries\` to the chain total when the
companion file gained 4 sorries. The follow-up batch PR #17280 (54
entries) kept \`leanFile.sorries\` at the main-file count for the same
pattern. PR #17287 (erdos-626/627/630) made the convention explicit:

> \`leanFile.sorries\` remains the main-file count … per the established
> convention (lf.* = main file only, meta.* = aggregate).

erdos-859 was a stale outlier.

## Validation

- meta.json parses (\`json.loads\`)
- Diff is 1 line (\`7\` → \`3\`)
- \`scripts/auditor/find-targets.ts\` compares only \`meta.sorries\`
  vs chain total, so the audit pipeline remains green
- No Lean source changes

## Scope

- 1 file, 1 line changed
- Surgical text replacement preserves all surrounding formatting
- No other fields touched

---
Automated fix by lean-mechanic agent.