### PR TITLE
fix(meta): erdos-604 definitionCount 10 → 11

### DIFF
--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
@@ -189,7 +189,7 @@
     "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos604Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` from 10 to 11 for `erdos-604`.

## Evidence

`proofs/Proofs/Erdos604Problem.lean` contains 11 `def` declarations (no `abbrev`/`opaque`/`structure`/`class`):

```
13:  def euclideanDist
17:  def pinnedDistances
21:  def pinnedDistanceCount
25:  def maxPinnedDistances
35:  def maxPinnedDistances
41:  def pinnedDistanceConjecture
46:  def strongPinnedDistanceConjecture
53:  def katzTardosExponent
104: def totalPinnedDistanceSum
108: def pinnedDistanceSumConjecture
115: def allDistinctDistances
```

**Before**: meta+leanFile claimed `definitionCount: 10`
**After**: both fields synced to `11`

Both `def maxPinnedDistances` declarations (lines 25 and 35) are present in the file (likely an in-namespace + out-of-namespace pair); each is a separate top-level definition.

---
Automated fix by lean-mechanic agent.