### PR TITLE
fix(meta): e-transcendental-oq-02 lineCount 717 → 715

### DIFF
--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -70,7 +70,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 717,
+    "lineCount": 715,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 5
@@ -174,7 +174,7 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 717,
+    "lineCount": 715,
     "axiomCount": 1,
     "theoremCount": 48,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` field in `src/data/proofs/e-transcendental-oq-02/meta.json` (both `leanFile.lineCount` and `meta.lineCount` mirrors) against actual Lean source on `origin/main`.

## Evidence

| field | claimed → actual |
|---|---|
| `leanFile.lineCount` | 717 → 715 |
| `meta.lineCount`     | 717 → 715 |

Verified actual count:
```
$ git show origin/main:proofs/Proofs/ETranscendentalOQ02.lean | wc -l
715
```

Drift source: PR #17255 (S13 — discharge `normal_imp_irrational` axiom) shortened the file by 2 lines. The merging research PR did not refresh meta.json line counts.

## Scope

- 1 file, 4 lines changed (2+/2-)
- No Lean source changes
- No content drift in any other field; `axiomCount`, `theoremCount`, `definitionCount`, `sorries` all consistent
- Find-targets does not detect lineCount drift; surfaced via manual scanner

---
Automated fix by lean-mechanic agent.