### PR TITLE
research(law-of-cosines-oq-01-oq-01-oq-03): S5 — clean-hypothesis dual law corollary (build pending)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -513,4 +513,34 @@ theorem dual_spherical_law_of_cosines (A B C : Fin 3 → ℝ)
   -- γ' = dihedralAngle(C', A', B') = π - arcLen A B
   · exact polar_angle_eq A B C hA hB hC hBC hCA hAB hpBC hpCA hBC_p hCA_p
 
+/-- **Dual Spherical Law of Cosines (reduced hypotheses)**.
+
+    Corollary of `dual_spherical_law_of_cosines` that drops four redundant
+    `projPerp` non-degeneracy hypotheses. Each `normSq (projPerp · ·) ≠ 0`
+    condition follows from a cross-product non-degeneracy via
+    `normSq_cross_eq_projperp` / `normSq_cross_CA`. The two polar-triangle
+    non-degeneracies (`hBC_p`, `hCA_p`) remain genuinely independent — they
+    encode that `tripleProduct A B C ≠ 0`, which is not implied by pairwise
+    cross-product non-degeneracy alone (consider three coplanar but pairwise
+    non-parallel unit vectors). -/
+theorem dual_spherical_law_of_cosines' (A B C : Fin 3 → ℝ)
+    (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
+    (hBC : 0 < normSq (B ×₃ C)) (hCA : 0 < normSq (C ×₃ A)) (hAB : 0 < normSq (A ×₃ B))
+    (hBC_p : normSq (projPerp (normalize3 (B ×₃ C)) (normalize3 (A ×₃ B))) ≠ 0)
+    (hCA_p : normSq (projPerp (normalize3 (C ×₃ A)) (normalize3 (A ×₃ B))) ≠ 0) :
+    Real.cos (dihedralAngle C A B) =
+      -Real.cos (dihedralAngle A B C) * Real.cos (dihedralAngle B A C) +
+        Real.sin (dihedralAngle A B C) * Real.sin (dihedralAngle B A C) *
+          Real.cos (arcLen A B) := by
+  have hpBC : normSq (projPerp B C) ≠ 0 := by
+    rw [← normSq_cross_eq_projperp B C hB hC]; exact hBC.ne'
+  have hpAC : normSq (projPerp A C) ≠ 0 := by
+    rw [← normSq_cross_CA A C hA hC]; exact hCA.ne'
+  have hpCA : normSq (projPerp C A) ≠ 0 := by
+    rw [← normSq_cross_eq_projperp C A hC hA]; exact hCA.ne'
+  have hpBA : normSq (projPerp B A) ≠ 0 := by
+    rw [← normSq_cross_CA B A hB hA]; exact hAB.ne'
+  exact dual_spherical_law_of_cosines A B C hA hB hC hBC hCA hAB
+    hpBC hpAC hpCA hpBA hBC_p hCA_p
+
 end PolarSphericalLaw

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -39,19 +39,20 @@
       "Proves projperp_dot_sinsincos: dot(projPerp A C, projPerp B C) = sin(arcLen A C)·sin(arcLen B C)·cos(dihedralAngle C A B), via Cauchy-Schwarz (Lagrange identity) and Real.cos_arccos",
       "Derives the dual spherical law of cosines via polar triangle substitution",
       "Proves the cross-of-crosses BAC-CAB identities (C×A)×(A×B) = tripleProduct(A,B,C)·A and (A×B)×(B×C) = tripleProduct(A,B,C)·B (Session 4) — the BAC-CAB rule specialized to cyclic cross products on the polar triangle",
-      "Proves the polar dihedral-angle formula (Session 4): dihedralAngle(C',A',B') = π − arcLen(A,B), eliminating the final axiom of the entry. The proof reduces to polar_side_eq_pi_minus_angle applied to (A',B',C') after showing dot(normalize(B'×C'), normalize(C'×A')) = dot(A,B), via the cross-cross identities and a sign analysis using tripleProduct ≠ 0 (which is forced by the non-degeneracy hypothesis)"
+      "Proves the polar dihedral-angle formula (Session 4): dihedralAngle(C',A',B') = π − arcLen(A,B), eliminating the final axiom of the entry. The proof reduces to polar_side_eq_pi_minus_angle applied to (A',B',C') after showing dot(normalize(B'×C'), normalize(C'×A')) = dot(A,B), via the cross-cross identities and a sign analysis using tripleProduct ≠ 0 (which is forced by the non-degeneracy hypothesis)",
+      "Provides a clean corollary `dual_spherical_law_of_cosines'` (Session 5) with reduced hypotheses: drops four redundant projPerp non-degeneracies that follow from the cross-product non-degeneracies via normSq_cross_eq_projperp / normSq_cross_CA. Hypothesis count drops 12 → 8, with the two polar-triangle non-degeneracies retained as genuinely independent"
     ],
     "axiomCount": 0,
     "assumptions": "No axioms remain. Sessions 3 and 4 eliminated both original axioms (projperp_dot_sinsincos via Lagrange/Cauchy-Schwarz, polar_angle_eq via the polar-of-polar reduction).",
-    "lineCount": 516,
-    "theoremCount": 16,
+    "lineCount": 546,
+    "theoremCount": 17,
     "definitionCount": 1
   },
   "leanFile": {
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 1,
-    "lineCount": 516,
+    "lineCount": 546,
     "sorries": 0,
     "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
   },
@@ -113,9 +114,9 @@
       "id": "dual-law",
       "title": "Dual Law via Polar Substitution",
       "startLine": 441,
-      "endLine": 516,
-      "summary": "Applies the standard spherical law to the polar triangle. After substituting the supplementary side/angle relationships (c' = π-γ, a' = π-α, b' = π-β, γ' = π-c), the dual law follows by pure trigonometric algebra via dual_trig_identity using cos(π-x) = -cos(x) and sin(π-x) = sin(x).",
-      "mathContext": "The standard law cos(c') = cos(a')cos(b') + sin(a')sin(b')cos(γ') becomes -cos(γ) = cos(α)cos(β) - sin(α)sin(β)cos(c) after substitution, giving cos(γ) = -cos(α)cos(β) + sin(α)sin(β)cos(c)."
+      "endLine": 546,
+      "summary": "Applies the standard spherical law to the polar triangle. After substituting the supplementary side/angle relationships (c' = π-γ, a' = π-α, b' = π-β, γ' = π-c), the dual law follows by pure trigonometric algebra via dual_trig_identity using cos(π-x) = -cos(x) and sin(π-x) = sin(x). Closes with `dual_spherical_law_of_cosines'`, a clean-hypothesis corollary that drops four redundant projPerp non-degeneracies derivable from the cross-product non-degeneracies.",
+      "mathContext": "The standard law cos(c') = cos(a')cos(b') + sin(a')sin(b')cos(γ') becomes -cos(γ) = cos(α)cos(β) - sin(α)sin(β)cos(c) after substitution, giving cos(γ) = -cos(α)cos(β) + sin(α)sin(β)cos(c). The clean-hypothesis form retains only 8 hypotheses (3 unit + 3 cross non-deg + 2 polar non-deg) versus 12 in the original — the two polar non-degeneracies remain because tripleProduct ≠ 0 is not implied by pairwise cross non-deg alone."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- Adds `dual_spherical_law_of_cosines'`, a corollary of the main `dual_spherical_law_of_cosines` with **4 fewer hypotheses** (12 → 8).
- The four `normSq (projPerp · ·) ≠ 0` hypotheses are derivable from the cross-product non-degeneracies via existing lemmas `normSq_cross_eq_projperp` / `normSq_cross_CA`. The corollary discharges them internally.
- The two polar-triangle non-degeneracies (`hBC_p`, `hCA_p`) are **retained** because they encode `tripleProduct A B C ≠ 0` — three coplanar but pairwise non-parallel unit vectors witness that this is independent of the pairwise cross non-degeneracies.
- Status remains `verified`, 0 axioms, 0 sorries.

## File changes

- `proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean`: +30 lines (516 → 546), +1 theorem (16 → 17)
- `src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json`: bump `lineCount`, `theoremCount`, extend `originalContributions`, update dual-law section endLine and summary

## Hypothesis reduction

```
Original (12):  hA hB hC hBC hCA hAB hpBC hpAC hpCA hpBA hBC_p hCA_p
Clean    (8):   hA hB hC hBC hCA hAB                       hBC_p hCA_p
                                ^^^ 4 projPerp hypotheses derived internally
```

The clean form is closer to a textbook statement of the dual law on a non-degenerate spherical triangle.

## Test plan

- [ ] \`./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ01OQ01OQ03\` builds clean (build pending — Docker wrapper not run in this worktree; PR #17158 also marked build pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)