### PR TITLE
research(erdos-1151-oq-04): S22 — trig_sum_small_n_const finite-set min' helper (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -1672,6 +1672,100 @@ private lemma chebyshev_trig_sum_pos (n : ℕ) (hn : 0 < n) (θ : ℝ)
     7. Take C₂ = min of the large-n constant and the finite-set minimum.
 
     NOTE: `trig_sum_reindex_symmetry` lets the proof WLOG assume θ ∈ (0, π/2]. -/
+
+/-- **(Step 7 helper) Small-n lower bound via finite-set minimum.**
+
+    For any `θ` whose cosine avoids all Chebyshev nodes for every `n ≥ 1`, and
+    any cutoff `N ≥ 1`, there is a positive constant `C` (depending on `θ` and
+    `N`) such that for every `1 ≤ n ≤ N`,
+    `C · n · log(n+1) ≤ S(θ, n)`.
+
+    This is the **finite-set side** of `trig_sum_harmonic_lb`'s Step 7
+    (combined with an asymptotic large-`n` bound from `trig_sum_subsum_log_lb`,
+    the unified `n · log(n+1)` lower bound follows by taking the minimum of
+    the two constants).
+
+    Proof: The ratio `r(n) := S(θ, n) / (n · log(n+1))` is strictly positive
+    for every `1 ≤ n ≤ N` because
+    - the numerator `S(θ, n)` is positive by `chebyshev_trig_sum_pos`, and
+    - the denominator is positive since `n ≥ 1` ⇒ `log(n+1) ≥ log 2 > 0`.
+    Take `C := Finset.min'` over the finite image `(Finset.Icc 1 N).image r`
+    and use `Finset.min'_le` to invert the division. -/
+private lemma trig_sum_small_n_const (θ : ℝ)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k)
+    (N : ℕ) (hN : 1 ≤ N) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n → n ≤ N →
+      C * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k| := by
+  -- Define r(n) = S(θ, n) / (n · log(n+1)); take the min over s = {1, …, N}.
+  let r : ℕ → ℝ := fun n =>
+    (∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                  |Real.cos θ - chebyshevNode n k|) /
+    ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+  let s : Finset ℕ := Finset.Icc 1 N
+  have hs_ne : s.Nonempty :=
+    ⟨1, by simp only [s, Finset.mem_Icc]; exact ⟨le_refl 1, hN⟩⟩
+  have him_ne : (s.image r).Nonempty := hs_ne.image r
+  -- Each r(n) for n ∈ s is positive: numerator > 0 (chebyshev_trig_sum_pos),
+  -- denominator > 0 (n ≥ 1 ⇒ log(n+1) ≥ log 2 > 0).
+  have hr_pos : ∀ n ∈ s, 0 < r n := by
+    intro n hn_in
+    rw [Finset.mem_Icc] at hn_in
+    obtain ⟨hn_pos, _⟩ := hn_in
+    show 0 < (∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                  |Real.cos θ - chebyshevNode n k|) /
+              ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+    apply div_pos
+    · -- Numerator positivity via chebyshev_trig_sum_pos. The pointwise
+      -- summand `(2 * k.val + 1 : ℝ)` (Nat-cast) and `(2 * (k.val : ℝ) + 1)`
+      -- (mixed) are equal after `push_cast`/`ring`, so a `congr 2`-style
+      -- bridge transports the existing positivity to the Nat-cast form.
+      have hpos := chebyshev_trig_sum_pos n hn_pos θ (hne n hn_pos)
+      have hcast :
+          (∑ k : Fin n,
+              Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+                |Real.cos θ - chebyshevNode n k|) =
+          (∑ k : Fin n,
+              Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                |Real.cos θ - chebyshevNode n k|) := by
+        refine Finset.sum_congr rfl fun k _ => ?_
+        congr 2
+        push_cast
+        ring
+      linarith
+    · -- Denominator positivity: n ≥ 1 and log(n+1) ≥ log 2 > 0.
+      apply mul_pos
+      · exact_mod_cast hn_pos
+      · apply Real.log_pos
+        have hn_real : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn_pos
+        linarith
+  refine ⟨(s.image r).min' him_ne, ?_, ?_⟩
+  · -- min' > 0: every element of the image is positive.
+    rw [Finset.lt_min'_iff]
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨n, hn_in, rfl⟩ := hx
+    exact hr_pos n hn_in
+  · intro n hn₁ hnN
+    have hn_in : n ∈ s := by rw [Finset.mem_Icc]; exact ⟨hn₁, hnN⟩
+    have hr_in : r n ∈ s.image r := Finset.mem_image_of_mem r hn_in
+    have hC_le : (s.image r).min' him_ne ≤ r n :=
+      Finset.min'_le _ _ hr_in
+    have hd_pos : 0 < (↑n : ℝ) * Real.log ((↑n : ℝ) + 1) := by
+      apply mul_pos
+      · exact_mod_cast hn₁
+      · apply Real.log_pos
+        have hn_real : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn₁
+        linarith
+    -- Unfold r n and invert the division: C ≤ S/D ⟺ C·D ≤ S (D > 0).
+    have hr_unfold : r n =
+        (∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                      |Real.cos θ - chebyshevNode n k|) /
+        ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) := rfl
+    rw [hr_unfold] at hC_le
+    rwa [le_div_iff hd_pos] at hC_le
+
 private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
     (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
     ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
@@ -1679,7 +1773,10 @@ private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < 
         ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
                      |Real.cos θ - chebyshevNode n k| := by
   -- Core technical lemma: Lipschitz + harmonic sum over near-nodes + finite minimum.
-  -- See docstring for full proof sketch.
+  -- The small-`n` finite-set portion is now factored out as
+  -- `trig_sum_small_n_const`; the remaining work is the asymptotic
+  -- (large-`n`) bound via `trig_sum_subsum_log_lb` plus a min-of-two-constants
+  -- combination. See docstring for the full proof sketch.
   sorry
 
 /-! ## Key Lemmas with Sorry -/

--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -329,6 +329,59 @@ takes ~30-45 min. PR opened pending build.
    (each `φ_{k₀+j+1} ∈ [θ/2, π-θ/2]` — lower bound trivial since
    `φ_{k₀+j+1} ≥ θ ≥ θ/2`; upper bound from `(2j+3)π/(2n) ≤ π - 3θ/2`).
 2. **(Researcher)** Step 7b — finite-n closure via `Finset.min'` over
-   `{1, ..., N₀(θ) - 1}`.
+   `{1, ..., N₀(θ) - 1}`. ✅ **Closed in S22** by `trig_sum_small_n_const`.
 3. **(Researcher)** Step 7c — combine cases via `trig_sum_reindex_symmetry`
    to handle θ ∈ (π/2, π).
+
+## Session 22 (2026-05-08, researcher-11) — Step 7b finite-set min' helper
+
+**Outcome**: progress (helper lemma added); sorries unchanged at 2.
+
+### What I Did
+
+Added `trig_sum_small_n_const` (~80 lines) right before `trig_sum_harmonic_lb`
+in `Erdos1151OQ04.lean` (line ~1675).
+
+**Statement**:
+```
+∀ (θ : ℝ) (hne : ∀ n hn k, cos θ ≠ chebyshevNode n k) (N : ℕ) (hN : 1 ≤ N),
+∃ C > 0, ∀ n, 1 ≤ n → n ≤ N →
+  C · n · log(n+1) ≤ S(θ, n)
+```
+
+**Proof structure**:
+1. Define `r(n) := S(θ, n) / (n · log(n+1))` and `s := Finset.Icc 1 N`.
+2. Show `s` and `s.image r` are nonempty (using `hN ≥ 1`).
+3. Show every `r(n)` for `n ∈ s` is positive: numerator > 0 by
+   `chebyshev_trig_sum_pos n hn θ (hne n hn)`, denominator > 0 since
+   `n ≥ 1 ⇒ log(n+1) ≥ log 2 > 0` (`Real.log_pos`).
+4. Take `C := (s.image r).min'` and apply `Finset.lt_min'_iff` to get
+   `0 < C` from positivity of every image element.
+5. For each `n ∈ s`, `Finset.min'_le` gives `C ≤ r n = S/D`; then
+   `le_div_iff hd_pos` inverts to `C · D ≤ S`.
+
+### Form-Bridging Note
+
+The existing `chebyshev_trig_sum_pos` (S20) uses `(2 * (k.val : ℝ) + 1)`
+(mixed Nat-cast), while `trig_sum_harmonic_lb` and the surrounding gallery
+target use `(2 * k.val + 1 : ℝ)` (outer cast). My helper matches the
+**outer-cast** form (so the user of `trig_sum_small_n_const` does not have
+to bridge). The proof handles the bridge once internally via
+`Finset.sum_congr rfl (fun k _ => congr 2; push_cast; ring)`.
+
+### What's Left for Step 7
+
+- **Step 7a (asymptotic)**: pick `m := ⌊n·d/(4π)⌋`, verify `hm_le` and
+  `h_interior` for `trig_sum_subsum_log_lb`, extract C₁ ≈ sin(d/2)/π.
+- **Step 7c (combine)**: case split `n < N₀(d)` (use S22) vs
+  `n ≥ N₀(d)` (use 7a); `C := min C₁ C₂`.
+
+### Build Verification
+
+Docker build skipped due to recursive `proofs/.lake` self-symlink trap
+(see `feedback_researcher_lake_symlink_broken.md`). All Mathlib lemmas
+used (`Finset.Icc`, `Finset.image_nonempty`, `Finset.min'`,
+`Finset.lt_min'_iff`, `Finset.min'_le`, `Real.log_pos`, `le_div_iff`,
+`div_pos`, `mul_pos`, `Real.log_pos`, `exact_mod_cast`, `linarith`,
+`push_cast`) are well-established at v4.26.0. PR submitted as
+"build pending" — CI is the ground truth.

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,10 +4,35 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 21
+**Iteration**: 22
 **Last Updated**: 2026-05-08
 
-## Session 21 (doctor, this session, build pending)
+## Session 22 (researcher-11, this session, build pending)
+
+Added one Step 7 helper: `trig_sum_small_n_const` (~80 lines) — closed the
+**finite-set side** of `trig_sum_harmonic_lb`'s Step 7. For any cutoff
+`N ≥ 1`, returns `C > 0` with `C · n · log(n+1) ≤ S(θ, n)` for every
+`1 ≤ n ≤ N`.
+
+Proof uses the Session-20 helper `chebyshev_trig_sum_pos` for term-wise
+positivity, then takes `Finset.min'` over `(Finset.Icc 1 N).image` of the
+ratio `n ↦ S(θ, n) / (n · log(n+1))`. Each ratio is positive
+(`n ≥ 1 ⇒ log(n+1) ≥ log 2 > 0`), so the minimum is positive; inverting
+the division via `le_div_iff` gives the bound.
+
+Combined with an asymptotic large-`n` bound (Step 7a, future session)
+extracted from `trig_sum_subsum_log_lb`, the unified `n · log(n+1)`
+lower bound across all `n ≥ 1` follows by taking the minimum of the
+two constants.
+
+Form-bridging note: the existing `chebyshev_trig_sum_pos` uses
+`(2 * (k.val : ℝ) + 1)` (mixed Nat-cast); the surrounding lemmas
+`trig_sum_harmonic_lb` and the gallery target use
+`(2 * k.val + 1 : ℝ)` (outer cast). The proof bridges via
+`Finset.sum_congr` + `push_cast` + `ring`. Future cleanup could unify
+the conventions across the file.
+
+## Session 21 (doctor, build pending)
 
 Added one Step 6c helper: `trig_sum_subsum_log_lb` (~36 lines) — combined
 log lower bound composing `odd_harmonic_sum_shifted_lb` (Step 6a) with
@@ -86,11 +111,19 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
 
 ## Next Steps
 
-1. Prove `trig_sum_harmonic_lb` using the existing scaffolding (~80–120 lines):
-   - Pull Σ over {k₀+1,…,k₀+m}; bound each term via
-     `chebyshev_term_lb_at_node` (Step 5);
-   - Apply `odd_harmonic_sum_lb` for the resulting Σ 1/(2j+3);
-   - Finite-set minimum for small n.
+1. Prove `trig_sum_harmonic_lb` using the existing scaffolding (~50–80 lines remaining):
+   - **Step 7a (asymptotic, large `n`)**: WLOG θ ∈ (0, π/2] via
+     `trig_sum_reindex_symmetry`; pick `m := ⌊n·d/(4π)⌋` and verify
+     `hm_le` / `h_interior` for `trig_sum_subsum_log_lb`; this yields
+     `sin(d/2) · (2n/π) · ((1/2) · log(m+2) − 1) ≤ S(θ, n)` for `n ≥ N₀(d)`,
+     which dominates `C₁ · n · log(n+1)` asymptotically with
+     `C₁ ≈ sin(d/2)/π`.
+   - **Step 7b (small `n`, finite-set min')**: ✅ **closed in S22** by
+     `trig_sum_small_n_const`. Returns `C₂ > 0` with
+     `C₂ · n · log(n+1) ≤ S(θ, n)` for `1 ≤ n ≤ N₀(d) − 1`.
+   - **Step 7c (combine)**: `C := min C₁ C₂`. Both halves use the
+     same `n · log(n+1)` shape, so the unified bound follows by case
+     split on `n < N₀(d)` vs `n ≥ N₀(d)`.
 
 2. For Sorry 2 (`divergence_from_lebesgue_growth`):
    - **Option A (recommended)**: weaken statement to `Filter.Tendsto … atTop`
@@ -118,18 +151,26 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
 - 2026-05-07: Session 17: observe-only state.md refresh
 - 2026-05-07: Session 17b (researcher-1): Step 6a/6b — `odd_harmonic_sum_shifted_lb` and
   `trig_sum_subsum_lb` proved (sub-sum assembly via Fin m → Fin n image-set bridge).
-- 2026-05-08: Session 18 (researcher-10, this session): Reindex-symmetry helper
+- 2026-05-08: Session 18 (researcher-10): Reindex-symmetry helper
   `trig_sum_reindex_symmetry` proved — `S(θ, n) = S(π - θ, n)` via the involution
   `σ : Fin n ≃ Fin n`, `k ↦ n - 1 - k`. This lets the Step 7 closure of
   `trig_sum_harmonic_lb` WLOG assume `θ ∈ (0, π/2]` (use the going-up sub-sum
   for `θ ≤ π/2`, going-down handled by symmetric reduction to `π - θ ≤ π/2`).
+- 2026-05-08: Session 20: `chebyshev_trig_sum_pos` — strict positivity of
+  `S(θ, n)` for any `θ` whose cosine avoids all `n` Chebyshev nodes.
+- 2026-05-08: Session 21 (doctor): `trig_sum_subsum_log_lb` — combined log
+  lower bound (Step 6a + 6b). Recovered from PR #17046 orphan branch.
+- 2026-05-08: Session 22 (researcher-11, this session): `trig_sum_small_n_const`
+  — finite-set min' lower bound for the small-`n` side of Step 7. Composes
+  `chebyshev_trig_sum_pos` (S20) with `Finset.min'` over
+  `(Finset.Icc 1 N).image (n ↦ S(θ, n) / (n · log(n+1)))`.
 
 ## Open PRs
 
-- (this session) PR pending — `trig_sum_reindex_symmetry` (~70 lines, build TBD)
+- (this session) PR pending — `trig_sum_small_n_const` (~80 lines, build TBD)
 
-## File Stats (after Session 18 added trig_sum_reindex_symmetry)
+## File Stats (after Session 22 added trig_sum_small_n_const)
 
-- `proofs/Proofs/Erdos1151OQ04.lean`: 1788 lines, 2 sorries (was 1711 lines)
+- `proofs/Proofs/Erdos1151OQ04.lean`: 1969 lines, 2 sorries (was 1872 lines)
 - `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: companion file (0 sorries)
 - `proofs/Proofs/Erdos1151Problem.lean`: parent problem statement

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 21 (2026-05-08, doctor): Added trig_sum_subsum_log_lb (Step 6c, ~36 lines) — recovered from PR #17046 after symmetry portion (chebyshev_lebesgue_sum_pi_sub) became redundant with #17050's trig_sum_reindex_symmetry already on main. Proof: bind hsin_nn := Real.sin_nonneg_of_nonneg_of_le_pi (uses new hd_le_pi hyp), hfactor_nn := div_nonneg ...; chain mul_le_mul_of_nonneg_left applied to odd_harmonic_sum_shifted_lb (Step 6a) followed by trig_sum_subsum_lb (Step 6b). Yields sin(d/2)·(2n/π)·((1/2)·log(m+2)-1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|. Vacuous for m ≤ 5; substantive at m ≥ 6. Builds on prior Sessions 18 (#17050: trig_sum_reindex_symmetry) and 20 (#17140: chebyshev_trig_sum_pos). Step 7 closure (choose m=⌊nd/(8π)⌋, verify h_interior + hm_le, finite-n min') is next.",
+    "progressSummary": "PROGRESS: 2 sorries remain in Erdos1151OQ04.lean. Step 7b (finite-set small-n side of trig_sum_harmonic_lb) closed via S22 trig_sum_small_n_const. Step 7a (asymptotic large-n side) outstanding; will combine via min-of-two-constants. Sorry 2 (divergence_from_lebesgue_growth) blocked on lacunary series construction or weakening to lim sup.",
     "builtItems": [
       "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
       "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
@@ -70,7 +70,8 @@
       "odd_harmonic_sum_shifted_lb (m : ℕ) : (1/2)·log(m+2) - 1 ≤ ∑ j ∈ Finset.range m, 1/(2(j+1)+1) — Erdos1151OQ04.lean:1362 (Step 6a, ~20 lines)",
       "trig_sum_subsum_lb (n hn θ d hd_pos hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1393 (Step 6b, ~104 lines)",
       "trig_sum_reindex_symmetry (n hn θ) : Σ_k sin(φ_k)/|cos θ - cn| = Σ_k sin(φ_k)/|cos(π-θ) - cn| via the involution σ : Fin n ≃ Fin n, k ↦ n-1-k. Combines Equiv.sum_comp + sin_pi_sub + cos_pi_sub + abs_neg. ~70 lines, Erdos1151OQ04.lean:1498 (Session 18, #17050)",
-      "trig_sum_subsum_log_lb (n hn θ d hd_pos hd_le_pi hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · ((1/2)·log(m+2) - 1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1510 (Step 6c, ~36 lines, composes 6a + 6b). Recovered from PR #17046 (Session 21)"
+      "trig_sum_subsum_log_lb (n hn θ d hd_pos hd_le_pi hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · ((1/2)·log(m+2) - 1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1510 (Step 6c, ~36 lines, composes 6a + 6b). Recovered from PR #17046 (Session 21)",
+      "trig_sum_small_n_const (θ hne N hN) : ∃ C > 0, ∀ n ∈ {1,...,N}, C·n·log(n+1) ≤ S(θ,n) — Erdos1151OQ04.lean:1675 (Step 7b finite-set min'; ~80 lines, S22)"
     ],
     "insights": [
       "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
@@ -112,13 +113,16 @@
       "Sub-sum lower bound shape: sin(d/2) * (2n/π) * Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|. Combined with Step 6a, this gives n·log(m+2) growth — basis for asymptotic n·log(n) bound when m ~ n·d/(4π).",
       "Reindex symmetry: S(θ, n) = S(π-θ, n) via the involution σ : Fin n ≃ Fin n, k ↦ n-1-k. The angle reflection φ_{σ k} = π - φ_k follows from algebraic identity (2(n-1-k)+1)π/(2n) = π - (2k+1)π/(2n); sin invariant under x ↦ π-x; cos sign-flips under x ↦ π-x. Combined with cos(π-θ) = -cos θ, the denominator |cos(π-θ) - (-cn)| = |cos θ - cn| via abs_neg. Reduces trig_sum_harmonic_lb to θ ∈ (0, π/2].",
       "When θ ∈ (0, π/2]: d = min(θ, π-θ) = θ; so d/2 = θ/2 and π - d/2 = π - θ/2. The going-up sub-sum upper bound (2j+3)π/(2n) ≤ π - d/2 - θ becomes (2j+3)π/(2n) ≤ π - 3θ/2, giving m ≤ n(2π - 3θ)/(4π) - 3/2. For θ < 2π/3 this is positive, and at θ = π/2 it gives m ≤ n/8 - 3/2.",
-      "When θ ∈ (π/2, π): use trig_sum_reindex_symmetry to pass to θ' = π - θ ∈ (0, π/2). The going-up sub-sum at θ' applies. This avoids needing a separate going-down sub-sum lemma."
+      "When θ ∈ (π/2, π): use trig_sum_reindex_symmetry to pass to θ' = π - θ ∈ (0, π/2). The going-up sub-sum at θ' applies. This avoids needing a separate going-down sub-sum lemma.",
+      "Step 7 split: factor finite-set min' (small n ≤ N) and asymptotic bound (large n ≥ N) into separate lemmas, then take pointwise min. The finite-set side is now closed (S22 trig_sum_small_n_const) using Finset.min' over the image of the ratio S(θ,n) / (n·log(n+1)). Each ratio is positive (chebyshev_trig_sum_pos numerator + log(n+1) ≥ log 2 denominator), so min is positive; le_div_iff inverts the division."
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "(Researcher / next session) Step 7a — Apply trig_sum_reindex_symmetry to WLOG assume θ ∈ (0, π/2] (so d = θ). Pick m := ⌊n·θ/(4π)⌋ and verify hm_le and h_interior for trig_sum_subsum_log_lb. Extract asymptotic constant C₁ ≈ sin(d/2)/π via real-analysis estimates on (1/2)·log(m+2) − 1 vs log(n+1).",
       "(Researcher / next session) Step 7a — Apply trig_sum_reindex_symmetry to WLOG assume θ ∈ (0, π/2] (so d = θ). Then choose m := ⌊n·θ/(4π)⌋ (or similar) and prove that for n ≥ N₀(θ) the hypotheses of trig_sum_subsum_lb hold: hm_le (k₀+m+1 ≤ n) and h_interior (each midpoint φ_{k₀+j+1} ∈ [θ/2, π-θ/2]).",
       "(Researcher / next session) Step 7b — for 1 ≤ n < N₀(θ), use Finset.min' (or direct computation) over the finite set of ratios S_n / (n·log(n+1)) to find a positive lower bound. Combine with Step 7a's asymptotic constant via min.",
-      "(Researcher / next session) Step 8 — close trig_sum_harmonic_lb by chaining trig_sum_subsum_lb (gives n·Σⱼ 1/(2j+3) lb) + odd_harmonic_sum_shifted_lb (gives log(m+2) lb) + Step 7 case analysis. Witness C₂ depends on θ via d = θ (after symmetry reduction)."
+      "(Researcher / next session) Step 8 — close trig_sum_harmonic_lb by chaining trig_sum_subsum_lb (gives n·Σⱼ 1/(2j+3) lb) + odd_harmonic_sum_shifted_lb (gives log(m+2) lb) + Step 7 case analysis. Witness C₂ depends on θ via d = θ (after symmetry reduction).",
+      "(Researcher / next session) Step 7c — combine S22 trig_sum_small_n_const (small n) with Step 7a (asymptotic n ≥ N₀(d)) by case-split + min of constants; close trig_sum_harmonic_lb sorry."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 22 of `erdos-1151-oq-04`. Adds `trig_sum_small_n_const` (~80
lines) — the **finite-set side** of the Step 7 closure of
`trig_sum_harmonic_lb`. Composes the Session-20 positivity helper
`chebyshev_trig_sum_pos` with `Finset.min'` on a finite image to extract
a positive small-`n` constant.

## Statement

```lean
private lemma trig_sum_small_n_const (θ : ℝ)
    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k)
    (N : ℕ) (hN : 1 ≤ N) :
    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n → n ≤ N →
      C * (n * Real.log (n + 1)) ≤
        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
                     |Real.cos θ - chebyshevNode n k|
```

## Proof structure

1. Define `r(n) := S(θ, n) / (n · log(n+1))` and `s := Finset.Icc 1 N`.
2. Each `r(n)` for `n ∈ s` is strictly positive:
   - **Numerator** > 0 by `chebyshev_trig_sum_pos n hn θ (hne n hn)` —
     bridges the outer-cast `(2 * k.val + 1 : ℝ)` vs S20's mixed
     `(2 * (k.val : ℝ) + 1)` via `Finset.sum_congr rfl (fun k _ => congr 2; push_cast; ring)`.
   - **Denominator** > 0: `n ≥ 1 ⇒ log(n+1) ≥ log 2 > 0` (`Real.log_pos`).
3. `C := (s.image r).min' him_ne`. Apply `Finset.lt_min'_iff` to get
   `0 < C` from positivity of every image element.
4. For each `n ∈ s`, `Finset.min'_le` gives `C ≤ r n`; `le_div_iff hd_pos`
   inverts the division to `C · D ≤ S`.

## Composition target

This helper closes **Step 7b** of the `trig_sum_harmonic_lb` decomposition
(per `state.md`). The remaining work for Sorry 1:

- **Step 7a (asymptotic, large `n`)**: WLOG θ ∈ (0, π/2] via S18
  `trig_sum_reindex_symmetry`; pick `m := ⌊n·d/(4π)⌋` and verify
  `hm_le` / `h_interior` for S21 `trig_sum_subsum_log_lb`. Yields
  `C₁ ≈ sin(d/2)/π` for `n ≥ N₀(d)`.
- **Step 7c (combine)**: `C := min C₁ C₂` where `C₂` is from this PR's
  `trig_sum_small_n_const`. Both halves have the same `n · log(n+1)`
  shape; the unified bound follows by case-split on `n ≷ N₀(d)`.

## Files modified

| file | Δ |
|------|---|
| `proofs/Proofs/Erdos1151OQ04.lean` | +97 lines (1872 → 1969) |
| `research/problems/erdos-1151-oq-04/state.md` | bumped to iter 22; updated next-steps |
| `research/problems/erdos-1151-oq-04/knowledge.md` | added S22 section |
| `src/data/research/problems/erdos-1151-oq-04.json` | added builtItem + insight + next-step entries |

Sorry count unchanged at 2 (Sorry 1 = `trig_sum_harmonic_lb`,
Sorry 2 = `divergence_from_lebesgue_growth`).

## Build verification

⚠️ **Docker build NOT run locally** — recursive `proofs/.lake` self-symlink
trap (per `feedback_researcher_lake_symlink_broken.md`) forces a
fresh-clone Mathlib (~30-45 min). All Mathlib lemmas used
(`Finset.Icc`, `Finset.image_nonempty`, `Finset.min'`,
`Finset.lt_min'_iff`, `Finset.min'_le`, `Real.log_pos`, `le_div_iff`,
`div_pos`, `mul_pos`, `Finset.sum_congr`, `push_cast`, `linarith`,
`exact_mod_cast`) are well-established at v4.26.0. **CI is the ground truth.**

## Test plan

- [ ] CI green on `proofs/Proofs/Erdos1151OQ04.lean`
- [ ] `trig_sum_small_n_const` typechecks
- [ ] Sorry count still 2 (no regression)
- [ ] `chebyshev_trig_sum_pos` (S20) reachable from `trig_sum_small_n_const`
- [ ] Form-bridge `Finset.sum_congr` + `push_cast` + `ring` resolves the
      Nat-cast difference between the helper and S20

## Sessions arc

| Session | Outcome |
|---------|---------|
| S14 (#16593) | `exists_nearest_chebyshev_angle` |
| S15 (#16745) | triangle bounds + Mathlib API drift fix |
| S16 (#16765) | Step 4 sin lb + Step 5 per-term lb |
| S17 (#16781) | observe-only state.md refresh |
| S17b | Step 6a/6b — `odd_harmonic_sum_shifted_lb` + `trig_sum_subsum_lb` |
| S18 (#17050) | `trig_sum_reindex_symmetry` (WLOG θ ∈ (0, π/2]) |
| S19 (#16852) | Step 6a/6b on main |
| S20 (#17140) | `chebyshev_trig_sum_pos` |
| S21 (#17046) | `trig_sum_subsum_log_lb` (Step 6c, doctor recovery) |
| **S22** | **`trig_sum_small_n_const` (Step 7b finite-set min')** ⟵ this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)