### PR TITLE
fix(meta): binomial-theorem CLT status axiomatized→formalized (#17317)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-08",
-    "status": "axiomatized",
+    "status": "formalized",
     "tags": [
       "probability",
       "central-limit-theorem",
@@ -16,7 +16,7 @@
       "convergence-in-distribution"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,


### PR DESCRIPTION
## Fix

Demote `status` and `badge` for `binomial-theorem-oq-02-oq-01-oq-01-oq-03` to reflect that the underlying Lean file does not build.

## Evidence

`#17317` reports 5 elaboration failures in `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` under Mathlib v4.26.0:

| Line | Error |
|------|-------|
| 271 | Unknown identifier `MeasureTheory.tendsto_integral_Iic_zero` |
| 381 | `omega could not prove c ≥ 0` |
| 409 | Application type mismatch |
| 519 | `rewrite` failed: pattern not found |
| 585 | `rewrite` failed: pattern not found |

Per Lean's kernel-level `sorry`-substitution semantics, declarations that fail to elaborate behave as `sorry` in dependent modules. The pre-fix meta.json claimed `status: "axiomatized"` / `badge: "axiom"` / `sorries: 0`, which structurally overstates the proof's verification state.

## Change

Surgical 2-line diff to `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json`:

```diff
-    "status": "axiomatized",
+    "status": "formalized",
...
-    "badge": "axiom",
+    "badge": "wip",
```

Other fields (`sorries: 0`, `axiomCount: 1`, `theoremCount: 18`, etc.) are kept unchanged — they reflect the static `find-targets` regex view of the file. The 5 code repairs themselves remain open in #17317; they require Docker builds out of scope for a 30-minute mechanic cycle.

References #17317 (does not close — code repairs still pending).

---
Automated fix by lean-mechanic agent.