### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 9 — Chebyshev decomposition equality (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -281,6 +281,22 @@ theorem lcmRange_dvd_prod_prime_powers (n : ℕ) :
       le_trans (Nat.le_of_dvd hm_pos hpow_dvd) hm_le
     exact Nat.le_log_of_pow_le hp_prime.one_lt hpow_le_n
 
+/-- **Chebyshev's prime-power decomposition** (full equality):
+    `lcm(1,...,n) = ∏_{p prime ≤ n} p^⌊log_p n⌋`.
+
+    Antisymmetric combination of the two divisibility theorems:
+    - `prod_prime_powers_dvd_lcmRange` (forward direction; Iter 7),
+    - `lcmRange_dvd_prod_prime_powers` (reverse direction; Iter 8).
+
+    With this equality in hand, bounding `lcmRange n` reduces to bounding
+    each maximal prime power `p ^ ⌊log_p n⌋` and summing logarithmically:
+    Hanson's bound `lcmRange n ≤ 3 ^ n` becomes the Chebyshev-type
+    prime-counting inequality `∑_{p ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3`. -/
+theorem lcmRange_eq_prod_prime_powers (n : ℕ) :
+    lcmRange n = ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, p ^ Nat.log p n :=
+  Nat.dvd_antisymm (lcmRange_dvd_prod_prime_powers n)
+    (prod_prime_powers_dvd_lcmRange n)
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 405,
-    "theoremCount": 34,
+    "lineCount": 421,
+    "theoremCount": 35,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -30,14 +30,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08",
-    "iteration": 7,
+    "since": "2026-05-08T20:50:00Z",
+    "iteration": 9,
     "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n. Iteration 5 (#17021 merged) specialized to the prime case: prime_pow_dvd_lcmRange. Iteration 6 (#17128 merged) added pairwise-coprimality of distinct prime-power factors: coprime_prime_pow_pow_of_ne. Iteration 7 (this PR) closes the **easy direction of Chebyshev's decomposition**: prod_prime_powers_dvd_lcmRange : (∏ p ∈ filter Prime (range (n+1)), p^⌊log_p n⌋) ∣ lcmRange n. Adds the helper prod_dvd_of_pairwise_coprime (Finset induction packaging) which combines Nat.Coprime.prod_right and Nat.Coprime.mul_dvd_of_dvd_of_dvd. The reverse direction (lcmRange ∣ prod) — needing Nat.factorization — is the next structural target.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
       "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Iteration 8 should prove the **reverse direction**: `lcmRange n ∣ ∏ p ∈ filter Prime (range (n+1)), p^Nat.log p n`. This requires Mathlib's `Nat.factorization` framework: for each k ∈ {1,...,n}, write k = ∏_p p^(k.factorization p) (Nat.factorization_prod_pow_factorization), then bound each exponent by Nat.log p n via `Nat.factorization_lt_log_self_of_lt` (or equivalent). The two key Mathlib facts needed: (1) Nat.factorization_le_factorization_of_dvd OR direct `p^(k.factorization p) ∣ p^(Nat.log p n)` for k ≤ n; (2) the squarefree-style bound that combines factorizations across k. Once Iter 8 lands, Iteration 9 derives `lcmRange_eq_prod_prime_powers` via Nat.dvd_antisymm of Iter 7 + Iter 8. Then `lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` follows immediately as a non-trivial published bound.",
+    "nextAction": "Iter 10: leverage the new equality to reduce hanson_bound to a Chebyshev-type prime-counting inequality. Two natural sub-targets: (a) prove ∑_{p prime ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3 using primorial_le_4_pow + Bertrand-style bounds (Mathlib has Nat.primorial_le_4_pow but the conversion to log-summed inequality requires real analysis); (b) the cleaner combinatorial route via Erdős/Nair: lcm(1,...,n) ∣ n · binomial(2n, n) (Erdős 1932), then 4^n bound via central-binomial (Nat.centralBinom_lt_pow_of_le_pow_of_pos in Mathlib v4.26).",
     "attemptCounts": {
       "total": 6,
       "currentApproach": 2,
@@ -45,7 +45,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Iteration 7. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (341 lines, 33 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange. Iteration 5 (#17021 merged) added prime_pow_dvd_lcmRange. Iteration 6 (#17128 merged) added coprime_prime_pow_pow_of_ne. Iteration 7 (this PR) closes the **easy direction of Chebyshev's decomposition**: `prod_prime_powers_dvd_lcmRange (n : ℕ) : (∏ p ∈ (Finset.range (n+1)).filter Nat.Prime, p^Nat.log p n) ∣ lcmRange n`. Adds the helper `prod_dvd_of_pairwise_coprime` (Finset.induction; private, parallels Erdos1057Problem.prod_primes_dvd_of_each_dvd). The proof combines prime_pow_dvd_lcmRange (each factor divides) with coprime_prime_pow_pow_of_ne lifted via Nat.Coprime.prod_right to coprime-with-product, then Nat.Coprime.mul_dvd_of_dvd_of_dvd. The n=0 boundary case is handled by noting (Finset.range 1).filter Nat.Prime = ∅ via Nat.not_prime_zero.",
+    "progressSummary": "ITERATING (iter 9). Iter 9 (researcher-5, this session): added lcmRange_eq_prod_prime_powers — Chebyshev's prime-power decomposition equality (lcmRange n = ∏ p prime ≤ n, p^(Nat.log p n)) as the antisymmetric combination of Iter 7's prod_prime_powers_dvd_lcmRange (forward) and Iter 8's lcmRange_dvd_prod_prime_powers (reverse). Two-line proof via Nat.dvd_antisymm. With this equality, Hanson's bound lcmRange n ≤ 3^n reduces to a Chebyshev-type prime-counting inequality on ∑_{p ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3. File 405 → 421 lines (+16). Theorems 34 → 35 (+1). Defs 1 unchanged. Axioms 1 unchanged (only hanson_bound). Sorries 0 unchanged. Status axiomatized unchanged. Build status: pending.",
     "builtItems": [
       "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:80",
       "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:87-98",
@@ -64,7 +64,8 @@
       "hanson_n1 .. hanson_n20: numerical verification for 13 values of n",
       "lcmRange_5/10/15/20_eq: concrete OEIS values 60, 2520, 360360, 232792560",
       "hanson_bound (axiom): the open target ∀ n, lcmRange n ≤ 3^n",
-      "hanson_strictly_stronger_than_factorial: 3^n < n^n for n ≥ 4"
+      "hanson_strictly_stronger_than_factorial: 3^n < n^n for n ≥ 4",
+      "Theorem lcmRange_eq_prod_prime_powers: lcm(1,...,n) = ∏ p prime ≤ n, p^Nat.log p n in BaselProblemOQ01OQ01OQ02OQ03.lean (iter 9). Two-line proof: Nat.dvd_antisymm of lcmRange_dvd_prod_prime_powers and prod_prime_powers_dvd_lcmRange. Closes Chebyshev decomposition started in iters 7-8."
     ],
     "insights": [
       "Apéry's proof of ζ(3) irrationality requires the exact constant 3 (threshold c ≈ 3.245); the easier 4^n is insufficient.",
@@ -76,7 +77,8 @@
       "**pow_dvd_lcmRange** is the structural-lemma counterpart of `dvd_lcmRange` for prime-power arguments: applied with `b = p` prime and `k = Nat.log p n`, with `Nat.pow_log_le_self p hn` it gives the maximal-prime-power divisibility `p^(⌊log_p n⌋) ∣ lcmRange n` in a single line — the easy direction of the Chebyshev decomposition.",
       "**prime_pow_dvd_lcmRange** (Iteration 5) makes the corollary explicit. The proof is literally `pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))` — three Mathlib calls glued together. This is the canonical entry point for any prime-power Chebyshev-style argument on `lcmRange`.",
       "**coprime_prime_pow_pow_of_ne** (Iteration 6) — the second half of the easy direction's machinery. The proof routes through `Nat.dvd_prime` rather than `Nat.prime_dvd_prime_iff_eq` to avoid an API drift risk: `(Nat.dvd_prime hq).mp` produces `p = 1 ∨ p = q`, both alternatives directly contradicting hypotheses (`hp.one_lt.ne'` and `hpq` respectively). The pow-lifting `((..).pow_left a).pow_right b` is the same idiom used in Erdos828Problem.lean:53 and Erdos1136Problem.lean:60 (cross-referenced for stability).",
-      "**prod_prime_powers_dvd_lcmRange** (Iteration 7) — the easy direction of Chebyshev's decomposition closes in 8 lines on top of the helper. The Finset.induction packaging (prod_dvd_of_pairwise_coprime) is abstracted over the divisor function f : ℕ → ℕ so it can be reused for any pairwise-coprime divisor product (e.g., squarefree × squarefree, prime × prime^k). Direct parallel of Erdos1057Problem.prod_primes_dvd_of_each_dvd at lines 84-105, but generalized from primes to prime powers; the n=0 base case dispatches via Nat.not_prime_zero (range 1 = {0}, 0 ∉ Prime). Three Mathlib calls glued: Nat.Coprime.prod_right, Nat.Coprime.mul_dvd_of_dvd_of_dvd, and the existing prime_pow_dvd_lcmRange/coprime_prime_pow_pow_of_ne from previous iterations."
+      "**prod_prime_powers_dvd_lcmRange** (Iteration 7) — the easy direction of Chebyshev's decomposition closes in 8 lines on top of the helper. The Finset.induction packaging (prod_dvd_of_pairwise_coprime) is abstracted over the divisor function f : ℕ → ℕ so it can be reused for any pairwise-coprime divisor product (e.g., squarefree × squarefree, prime × prime^k). Direct parallel of Erdos1057Problem.prod_primes_dvd_of_each_dvd at lines 84-105, but generalized from primes to prime powers; the n=0 base case dispatches via Nat.not_prime_zero (range 1 = {0}, 0 ∉ Prime). Three Mathlib calls glued: Nat.Coprime.prod_right, Nat.Coprime.mul_dvd_of_dvd_of_dvd, and the existing prime_pow_dvd_lcmRange/coprime_prime_pow_pow_of_ne from previous iterations.",
+      "Closing the Chebyshev decomposition (iter 9): once both directions of divisibility are established, antisymmetry is mechanical via Nat.dvd_antisymm. The decomposition reduces hanson_bound (lcmRange n ≤ 3^n) from an opaque LCM-bound to a transparent prime-counting inequality ∑_{p prime ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3, exposing the Chebyshev-style content of Hanson 1972."
     ],
     "mathlibGaps": [
       "No `lcm(1,...,n) ≤ X^n`-style bound exists in Mathlib for any X.",


### PR DESCRIPTION
## Summary

Iteration 9. Adds the antisymmetric equality

\`\`\`
lcmRange n = ∏ p prime ≤ n, p ^ Nat.log p n
\`\`\`

as a two-line consequence (`Nat.dvd_antisymm`) of the two divisibility theorems established in iters 7–8:

- `prod_prime_powers_dvd_lcmRange` (Iter 7 — forward direction)
- `lcmRange_dvd_prod_prime_powers` (Iter 8 — reverse direction)

## Why this matters

This is the structural bridge for the `hanson_bound` axiom-elimination roadmap. Once `lcmRange n` is expressed as a product of maximal prime powers, the bound `lcmRange n ≤ 3 ^ n` reduces (taking log) to the Chebyshev-type prime-counting inequality

\`\`\`
∑_{p prime ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3
\`\`\`

which is the analytic content of Hanson 1972.

## Counts

- Lines: 405 → 421 (+16)
- Theorems: 34 → 35 (+1)
- Definitions: 1 (unchanged)
- Axioms: 1 (unchanged) — only `hanson_bound`
- Sorries: 0 (unchanged)
- Status: still `axiomatized`

## Build status

Pending. The proof is a one-line `Nat.dvd_antisymm` of two existing in-tree theorems, so build risk is essentially nil.

## Status

**Outcome**: progress (Chebyshev decomposition closed — both directions plus equality)
**Next Steps**: Iter 10 — leverage the equality to begin the prime-counting inequality. Two natural routes: (a) Mathlib's `Nat.primorial_le_4_pow` + Bertrand-style bounds; (b) Erdős/Nair's `lcm(1,...,n) ∣ n · binomial(2n, n)` followed by central-binomial bounds.

🤖 Generated by researcher-5