### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S25 — Sub-lemma 1 split_count_eq_powersetCard_card (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -767,6 +767,55 @@ private lemma weight_eq_totalSym' {n a b : ℕ} (hb : 1 ≤ b)
     ((totalSym' hb P' Q').1.map (X : Fin n → MvPolynomial (Fin n) R)).prod := by
   rw [totalSym'_val]; exact weight_eq_total_multiset P' Q'
 
+/-- **Sub-lemma 1 of `ballot_counting_identity`** (S25, see
+    `sessions/2026-05-08-s24.md` §"Recommended strategy"): the count of
+    ordered `Sym`-splits `(P, Q) : Sym (Fin n) p × Sym (Fin n) q` with
+    `P.1 + Q.1 = M` (as multisets) equals the count of submultisets of `M`
+    of size `p`. The forward bijection `(P, Q) ↦ P.1` lands in
+    `M.powersetCard p`; the inverse sends `P' ∈ M.powersetCard p` to
+    `(⟨P', _⟩, ⟨M − P', _⟩)`. The hypothesis `hM : M.card = p + q` ensures
+    the codomain `Q` size is well-defined.
+
+    Used by `ballot_counting_identity` (S26+) with two instantiations:
+    `(p, q) := (a, b)` for the LHS filter (after stripping `¬ColStrictSym`)
+    and `(p, q) := (a + 1, b - 1)` for the RHS, reducing the cardinality
+    identity to a difference identity over `M.powersetCard a` strata. -/
+private lemma split_count_eq_powersetCard_card {n p q : ℕ}
+    (M : Multiset (Fin n)) (hM : M.card = p + q) :
+    ((Finset.univ : Finset (Sym (Fin n) p × Sym (Fin n) q)).filter
+      (fun PQ => PQ.1.1 + PQ.2.1 = M)).card =
+    (M.powersetCard p).card := by
+  classical
+  apply Finset.card_bij (fun (PQ : Sym (Fin n) p × Sym (Fin n) q) _ => PQ.1.1)
+  · -- Map lands in M.powersetCard p
+    intro PQ hPQ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hPQ
+    rw [Multiset.mem_powersetCard]
+    refine ⟨?_, PQ.1.2⟩
+    calc PQ.1.1 ≤ PQ.1.1 + PQ.2.1 := le_self_add
+      _ = M := hPQ
+  · -- Injective: PQ₁.1.1 = PQ₂.1.1 implies PQ₁ = PQ₂
+    intro PQ₁ hPQ₁ PQ₂ hPQ₂ heq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hPQ₁ hPQ₂
+    have hP : PQ₁.1 = PQ₂.1 := Subtype.ext heq
+    have hQval : PQ₁.2.1 = PQ₂.2.1 := by
+      have hadd : PQ₁.1.1 + PQ₁.2.1 = PQ₁.1.1 + PQ₂.2.1 := by
+        rw [hPQ₁, ← hPQ₂, heq]
+      exact add_left_cancel hadd
+    have hQ : PQ₁.2 = PQ₂.2 := Subtype.ext hQval
+    exact Prod.ext hP hQ
+  · -- Surjective
+    intro P' hP'
+    rw [Multiset.mem_powersetCard] at hP'
+    obtain ⟨hP'_le, hP'_card⟩ := hP'
+    have hQcard : (M - P').card = q := by
+      rw [Multiset.card_sub hP'_le, hM, hP'_card, Nat.add_sub_cancel_left]
+    refine ⟨(⟨P', hP'_card⟩, ⟨M - P', hQcard⟩), ?_, rfl⟩
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    -- Need: P' + (M - P') = M; via tsub: (M - P') + P' = M, then add_comm.
+    rw [add_comm]
+    exact tsub_add_cancel_of_le hP'_le
+
 /-- **Ballot counting identity (per total multiset).**
 
     For `b ≥ 2` and any total multiset `M : Sym (Fin n) (a + b)`, the number

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,58 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-08 (S24 — researcher-5)
-**Iteration**: 24
+**Last Updated**: 2026-05-08 (S25 — researcher-10)
+**Iteration**: 25
+
+## S25 Summary (2026-05-08, researcher-10)
+
+**Mode**: ACT (Sub-lemma 1 implementation per S24's strategy decomposition).
+
+**Outcome**: implemented Sub-lemma 1 of `ballot_counting_identity` —
+`split_count_eq_powersetCard_card` — in `BallotProblemOQ03OQ01OQ01OQ01.lean`
+between `weight_eq_totalSym'` and `ballot_counting_identity` (lines 770–818;
+file 1266 → 1315 lines, +1 lemma, 8 defs unchanged, 0 axioms unchanged,
+2 sorries unchanged — the Sub-lemma 1 proof is real Lean code, no sorry
+added).
+
+**Lemma signature** (generic in `(p, q)`):
+
+```lean
+private lemma split_count_eq_powersetCard_card {n p q : ℕ}
+    (M : Multiset (Fin n)) (hM : M.card = p + q) :
+    ((Finset.univ : Finset (Sym (Fin n) p × Sym (Fin n) q)).filter
+      (fun PQ => PQ.1.1 + PQ.2.1 = M)).card =
+    (M.powersetCard p).card
+```
+
+**Proof**: `Finset.card_bij` with forward map `(P, Q) ↦ P.1` and inverse
+`P' ↦ (⟨P', _⟩, ⟨M − P', _⟩)`. Three obligations:
+
+1. **Maps to codomain**: `(P, Q) ↦ P.1 ∈ M.powersetCard p` follows from
+   `P.1 ≤ P.1 + Q.1 = M` (via `le_self_add`) and `P.1.card = p` (by `P.2`).
+2. **Injective**: `PQ₁.1.1 = PQ₂.1.1` forces `PQ₁.1 = PQ₂.1` (`Subtype.ext`);
+   then `PQ₁.2.1 = PQ₂.2.1` by `add_left_cancel` on
+   `PQ₁.1.1 + PQ₁.2.1 = PQ₁.1.1 + PQ₂.2.1`; then `Prod.ext`.
+3. **Surjective**: given `P' ∈ M.powersetCard p`, set `Q' := M - P'`; check
+   `Q'.card = q` via `Multiset.card_sub` + `hM` + `Nat.add_sub_cancel_left`;
+   check `P' + (M - P') = M` via `add_comm` + `tsub_add_cancel_of_le`.
+
+**Why generic in `(p, q)`**: the same lemma instantiates for both sides of
+`ballot_counting_identity`. With `(p, q) := (a, b)` and `hM := M.2`, it
+converts the LHS to `(M.1.powersetCard a).card`. With `(p, q) := (a+1, b-1)`
+(under `b ≥ 1`), it converts the RHS to `(M.1.powersetCard (a+1)).card`.
+S26 will use both instantiations to convert `ballot_counting_identity` into
+the difference identity `#{ColStrict_b on M.1.powersetCard a}
+ = #(M.1.powersetCard a) - #(M.1.powersetCard (a+1))` — the new
+Sub-lemma 2 (deep cycle/reflection argument deferred to S27+).
+
+**Build status**: pending (32 GB cgroup convention; following S10–S24).
+
+**Sorry count unchanged** (still 2: `ballot_counting_identity` and
+`jacobi_trudi_ssyt_eq` k ≥ 3); this is the intended outcome of S25 per the
+S24 plan. The sorry in `ballot_counting_identity` will shift to a new
+Sub-lemma 2 sorry only when S26 wires this PR's lemma into the difference
+identity.
 
 ## Current Focus
 
@@ -126,7 +176,7 @@ Completed:
 
 ## Attempt Count
 
-- Total iterations: 24 (sessions 1-24).
+- Total iterations: 25 (sessions 1-25).
 - Approaches tried:
   1. SSYT infrastructure (sessions 1-14).
   2. Decompose `jdt_weight_sum` (S15).
@@ -141,7 +191,10 @@ Completed:
  10. Identify missing `b ≤ a` hypothesis on `ballot_counting_identity` +
      correct signature + propagate at call site (S21) ✓.
  11. Decompose `ballot_counting_identity` proof into three named
-     sub-lemmas via difference-identity route (S24, this session) ✓.
+     sub-lemmas via difference-identity route (S24) ✓.
+ 12. Implement Sub-lemma 1 `split_count_eq_powersetCard_card` —
+     `Finset.card_bij` between multiset-split pairs and submultisets
+     (S25, this session) ✓.
 
 ## Blockers
 
@@ -151,15 +204,27 @@ None for current approach. The ballot bijection inside
 
 ## Next Action
 
-1. **S25**: Prove **Sub-lemma 1** (`submultiset_count_via_powersetCard`)
-   — mechanical Mathlib `Finset.card_bij` argument, ~20 lines. Real code
-   contribution; sorry count unchanged. See `sessions/2026-05-08-s24.md`
-   for the precise signature.
+1. ✅ **S25 (this session)**: Sub-lemma 1 implemented as
+   `split_count_eq_powersetCard_card` — generic in `(p, q)` so it serves
+   both LHS (`p = a, q = b`) and RHS (`p = a + 1, q = b - 1`) of
+   `ballot_counting_identity`. ~49 lines including docstring.
 
-2. **S26+**: State **Sub-lemma 2** (`colStrict_count_eq_card_diff`) with
-   `sorry`. Replace `ballot_counting_identity` body with a one-liner
-   combining Sub-lemmas 1 and 2. Net sorry count: unchanged (one
-   `sorry` replaces another, with cleaner provenance).
+2. **S26**: State **Sub-lemma 2** (`colStrict_count_eq_card_diff`) with
+   `sorry`. The signature is the difference identity:
+
+   ```lean
+   private lemma colStrict_count_eq_card_diff {n a b : ℕ}
+       (hb : 2 ≤ b) (hba : b ≤ a) (M : Sym (Fin n) (a + b)) :
+       ((M.1.powersetCard a).filter
+         (fun P => /- ColStrict_b on (P.toSym, (M.1 - P).toSym) -/)).card =
+       (M.1.powersetCard a).card - (M.1.powersetCard (a + 1)).card
+   ```
+
+   Then replace the body of `ballot_counting_identity` with a one-liner
+   combining Sub-lemma 1 (twice — for `p = a, b` and `p = a + 1, b - 1`)
+   with Sub-lemma 2 to convert both sides to `M.powersetCard`-cardinality
+   arithmetic. Net sorry count: unchanged (one `sorry` replaces another,
+   with cleaner provenance).
 
 3. **S27+**: Attack **Sub-lemma 2** proof via the Cycle Lemma route.
    ~80–100 lines; the dominant cost. Requires either a small Mathlib
@@ -171,9 +236,10 @@ None for current approach. The ballot bijection inside
 
 ## File Status
 
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1266 lines (unchanged
-  this session — research-only iteration).
-- Sorry count: 2 (`ballot_counting_identity`, `jacobi_trudi_ssyt_eq` k≥3).
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1266 → 1315 lines
+  (+49 this session: Sub-lemma 1 + docstring).
+- Sorry count: 2 (`ballot_counting_identity`, `jacobi_trudi_ssyt_eq` k≥3,
+  both unchanged).
 - 0 axioms.
-- Theorems: 31 (unchanged).
+- Theorems / lemmas: +1 (`split_count_eq_powersetCard_card`).
 - Definitions: 8 (unchanged).

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) ballot_counting_identity (~150 lines) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1266,
-    "theoremCount": 31,
+    "lineCount": 1315,
+    "theoremCount": 32,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
@@ -86,9 +86,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1266,
+    "lineCount": 1315,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 32,
     "definitionCount": 8,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Summary

Session 25 of `ballot-problem-oq-03-oq-01-oq-01-oq-01` (researcher-10). Implements **Sub-lemma 1** of `ballot_counting_identity` per S24's strategy decomposition (PR #17310, see `sessions/2026-05-08-s24.md` §"Recommended strategy").

The lemma is real Lean code; sorry count is **unchanged at 2**. The sorry in `ballot_counting_identity` will shift to a new Sub-lemma 2 sorry only when S26 wires this PR's lemma into the difference identity.

## Progress

New `private lemma split_count_eq_powersetCard_card` in `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (between `weight_eq_totalSym'` and `ballot_counting_identity`, lines 770–818; file 1266 → 1315 lines, +1 lemma).

**Signature** (generic in `(p, q)`):

```lean
private lemma split_count_eq_powersetCard_card {n p q : ℕ}
    (M : Multiset (Fin n)) (hM : M.card = p + q) :
    ((Finset.univ : Finset (Sym (Fin n) p × Sym (Fin n) q)).filter
      (fun PQ => PQ.1.1 + PQ.2.1 = M)).card =
    (M.powersetCard p).card
```

**Proof** — `Finset.card_bij` with forward map `(P, Q) ↦ P.1` and inverse `P' ↦ (⟨P', _⟩, ⟨M - P', _⟩)`:

1. **Maps to codomain**: `P.1 ∈ M.powersetCard p` follows from `P.1 ≤ P.1 + Q.1 = M` (via `le_self_add`) and `P.1.card = p` (via `P.2`).
2. **Injective**: `PQ₁.1.1 = PQ₂.1.1` forces `PQ₁.1 = PQ₂.1` (`Subtype.ext`); then `PQ₁.2.1 = PQ₂.2.1` by `add_left_cancel` on `PQ₁.1.1 + PQ₁.2.1 = PQ₁.1.1 + PQ₂.2.1`; then `Prod.ext`.
3. **Surjective**: given `P' ∈ M.powersetCard p`, set `Q' := M - P'`; `Q'.card = q` via `Multiset.card_sub` + `hM` + `Nat.add_sub_cancel_left`; `P' + (M - P') = M` via `add_comm` + `tsub_add_cancel_of_le`.

## Why generic in `(p, q)`

The same lemma instantiates for both sides of `ballot_counting_identity`:
- `(p, q) := (a, b)` and `hM := M.2 : M.1.card = a + b` ⟹ LHS becomes `(M.1.powersetCard a).card`.
- `(p, q) := (a + 1, b - 1)` (with `b ≥ 1`, satisfied since `hb : 2 ≤ b`) ⟹ RHS becomes `(M.1.powersetCard (a + 1)).card`.

S26 will use both instantiations to convert `ballot_counting_identity` into the difference identity:

`#{ColStrict_b on M.1.powersetCard a} = #(M.1.powersetCard a) - #(M.1.powersetCard (a + 1))`

— the new Sub-lemma 2 (deep cycle/reflection argument deferred to S27+).

## Strategy decomposition (S24, PR #17310)

| Sub-piece | Lines (est) | Session | Status |
|-----------|------------:|---------|--------|
| Sub-lemma 1 `split_count_eq_powersetCard_card` | 20–30 | **S25** | done this PR (49 lines incl. docstring) |
| Sub-lemma 2 `colStrict_count_eq_card_diff` | 80–100 | S26+ | sorry; deep |
| Sub-lemma 3 `symPair_list_iso` | 30–40 | optional | technical glue if needed |
| `ballot_counting_identity` itself | 5–10 (one-liner) | S26 | depends on Sub-lemmas 1+2 |

## Findings

- The forward map `(P, Q) ↦ P.1` is the natural choice (it discards Q, since Q is recoverable as `M - P`). Injectivity then reduces to additive cancellation on multisets — `add_left_cancel` suffices, no need for nontrivial `Multiset` manipulation.
- The hypothesis `hM : M.card = p + q` is required for the inverse: without it, `(M - P').card` could fail to match `q`, and the codomain `Sym (Fin n) q` would be the wrong type. Stating Sub-lemma 1 with this explicit hypothesis (rather than wrapping `M` in `Sym (Fin n) (a + b)`) makes the `(a + 1, b - 1)` instantiation in S26 mechanical: just supply `hM` from `(a + 1) + (b - 1) = a + b` (which holds when `b ≥ 1`) plus `M.2`.

## Status

**Outcome**: progress (Sub-lemma 1 implemented; sorry count unchanged at 2)
**Build**: pending (32 GB cgroup convention; following S10–S24)
**Next Steps**: S26 — state Sub-lemma 2 with `sorry`, replace `ballot_counting_identity` body with one-liner combining Sub-lemmas 1 and 2.

🤖 Generated by researcher-10