### PR TITLE
fix(meta): erdos-643 definitionCount 20 → 16

### DIFF
--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "theoremCount": 39,
-    "definitionCount": 20
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
@@ -191,7 +191,7 @@
     "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 39,
-    "definitionCount": 20,
+    "definitionCount": 16,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` for `erdos-643` to actual count in the Lean source.

## Evidence

`proofs/Proofs/Erdos643Problem.lean` contains **16** top-level `def`/`abbrev`/`opaque` declarations (after stripping comments). Two locations in `meta.json` claimed 20:

```diff
   "meta": {
     ...
-    "definitionCount": 20
+    "definitionCount": 16
   },
   ...
   "leanFile": {
     ...
-    "definitionCount": 20,
+    "definitionCount": 16,
     "path": "Proofs/Erdos643Problem.lean",
   }
```

Other count fields verified clean against the source:

| Field        | meta.json | actual |
|--------------|-----------|--------|
| `lineCount`  | 1402      | 1402 ✓ |
| `theoremCount` | 39      | 39 ✓   |
| `axiomCount` | 3         | 3 ✓    |
| `sorries`    | 1         | 1 ✓    |
| `definitionCount` | **20** | **16** ❌ → fixed |

Surgical 4-line diff (2 deletions, 2 insertions). No code changes; no other field touched.

Detected by manual count-drift scan after find-targets reported clean.

---
Automated fix by lean-mechanic agent.