### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S54 — algebraic combiner for gnwProb_exchange (case c'.1 < c.1)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14674,6 +14674,94 @@ private lemma gnwProb_exchange_lt_row_of_F_side
           gnwProb (removeCorner μ c' hc') c
             (hookLength (removeCorner μ c' hc') x.1 x.2) x) * h_S52
 
+/-- **Algebraic combiner for `gnwProb_exchange` (case `c'.1 < c.1`, S54).**
+
+The symmetric companion to `gnwProb_exchange_lt_row_of_F_side` (S53), for
+the other branch of `distinct_corners_dichotomy`.  Given the F-side
+identity `h_F` (with the doubly-affected cell now at `(c'.1, c.2)` instead
+of `(c.1, c'.2)`), the GNW exchange identity in product form follows
+immediately from S52 — _without the iteration-order swap step_ that S53
+needed.
+
+**Why no swap is needed.**  When `c'.1 < c.1`, applying S52
+(`hookProd_doubleRemove_factor`) to the pair `(c', c)` (with
+`hi : c'.1 < c.1`) yields `H((μ\c')\c)` directly, which is precisely the
+iteration order on the RHS of `gnwProb_exchange`.  S53 had to invoke
+`hookProd_removeCorner_swap` because S52 with arguments
+`(c, c', hi : c.1 < c'.1)` produces `H((μ\c)\c')` instead.
+
+**F-side identity (Case 2).**  With `h_d' = h_μ(c'.1, c.2)` — the cell at
+the intersection of c''s row and c's column, mirror of the Case-1
+doubly-affected cell `(c.1, c'.2)`:
+`F(μ,c) · (h_d' − 1)² = F(μ\c',c) · h_d' · (h_d' − 2)`.
+
+The factor `(h_d' − 1)²` is non-zero in ℚ since `h_d' ≥ 3` by
+`hookLength_at_d_ge_3 hc' hc hi`.
+
+**Linear-combination coefficients.**  Identical to S53's combiner:
+`α · h_F + β · h_S52` with `α = H(μ\c) · H(μ\c')` and `β = −F(μ\c',c)`.
+The symbolic structure of the two cases is the same; only the geometric
+witness (the doubly-affected cell coordinates) shifts from `(c.1, c'.2)`
+to `(c'.1, c.2)`.
+
+**Polynomial identity check.**  Define `α = H(μ\c) · H(μ\c')` and
+`β = −F(μ\c',c)`.  Then over ℚ:
+```
+α · (F(μ,c) · (h_d' − 1)² − F(μ\c',c) · h_d' · (h_d' − 2))             [α · h_F]
+  + β · (H(μ) · H((μ\c')\c) · (h_d' − 1)² − H(μ\c') · H(μ\c) · h_d' · (h_d' − 2))
+                                                                       [β · h_S52]
+  = F(μ,c) · H(μ\c) · H(μ\c') · (h_d' − 1)²
+    − F(μ\c',c) · H((μ\c')\c) · H(μ) · (h_d' − 1)²,
+```
+which is exactly the goal multiplied through by `(h_d' − 1)²` (after the
+two `F(μ\c',c) · h_d' · (h_d' − 2)` cross-terms cancel).  The cancellation
+of `(h_d' − 1)²` is then justified by `mul_right_cancel₀`.
+
+**Status.**  Sorry-free conditional on `h_F`.  Together with S53, the two
+combiners reduce `gnwProb_exchange` to a two-line case-split via
+`distinct_corners_dichotomy` — modulo the still-open F-side identity for
+each case (the joint K-induction of S55+). -/
+private lemma gnwProb_exchange_lt_col_of_F_side
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c'.1 < c.1)
+    (h_F :
+      (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+        ((hookLength μ c'.1 c.2 : ℚ) - 1) ^ 2 =
+      (∑ x ∈ (removeCorner μ c' hc').cells,
+          gnwProb (removeCorner μ c' hc') c
+            (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+        (hookLength μ c'.1 c.2 : ℚ) *
+        ((hookLength μ c'.1 c.2 : ℚ) - 2)) :
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      (hookProd (removeCorner μ c hc) : ℚ) *
+      (hookProd (removeCorner μ c' hc') : ℚ) =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookProd (removeCorner (removeCorner μ c' hc') c
+          (isCorner_removeCorner_of_ne hc' hc hne.symm)) : ℚ) *
+      (hookProd μ : ℚ) := by
+  -- Geometric prerequisite (S51 with c, c' swapped): h_d' ≥ 3, hence
+  -- (h_d' − 1)² ≠ 0 in ℚ.
+  have hd_ge_3 : 3 ≤ hookLength μ c'.1 c.2 := hookLength_at_d_ge_3 hc' hc hi
+  have hd_ge_3_Q : (3 : ℚ) ≤ (hookLength μ c'.1 c.2 : ℚ) := by exact_mod_cast hd_ge_3
+  have hd_sub1_ne : (hookLength μ c'.1 c.2 : ℚ) - 1 ≠ 0 := by linarith
+  have hd_sub1_sq_ne : ((hookLength μ c'.1 c.2 : ℚ) - 1) ^ 2 ≠ 0 :=
+    pow_ne_zero 2 hd_sub1_ne
+  -- S52 (algebraic easy half) applied with c, c' swapped — iteration order
+  -- already matches the gnwProb_exchange goal RHS H((μ\c')\c), so no swap
+  -- step is needed (unlike S53).
+  have h_S52 := hookProd_doubleRemove_factor hc' hc hne.symm hi
+  -- Multiply both sides of the goal by (h_d' − 1)², then close over ℚ
+  -- with linear_combination of h_F (scaled by H(μ\c) · H(μ\c')) and h_S52
+  -- (scaled by −F_ν).
+  apply mul_right_cancel₀ hd_sub1_sq_ne
+  linear_combination
+    (hookProd (removeCorner μ c hc) : ℚ) * (hookProd (removeCorner μ c' hc') : ℚ) * h_F
+      - (∑ x ∈ (removeCorner μ c' hc').cells,
+          gnwProb (removeCorner μ c' hc') c
+            (hookLength (removeCorner μ c' hc') x.1 x.2) x) * h_S52
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s09.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s09.md
@@ -1,0 +1,206 @@
+## Session 2026-05-08 (Session 54, researcher-4) — S54 algebraic combiner for `gnwProb_exchange` (case `c'.1 < c.1`)
+
+**Mode**: ACT (RICH knowledge tier, score 209 — depth-over-breadth)
+**Outcome**: One new private lemma `gnwProb_exchange_lt_col_of_F_side` in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` between
+`gnwProb_exchange_lt_row_of_F_side` (S53, line 14629) and `gnwProb_exchange`
+(line 14772 after S54 insertion).  +88 lines (~46 docstring, ~42 proof +
+statement).  **Sorry count unchanged (1)** — sorry-free conditional
+combiner; the F-side identity for case 2 is introduced as a hypothesis,
+not a new sorry.  Build verification deferred to CI for the PR.
+
+### What this session adds
+
+The **case-2 companion** to S53's algebraic combiner: a sorry-free lemma
+that takes the symmetric F-side identity as a hypothesis and closes
+`gnwProb_exchange` (case 2: `c'.1 < c.1`).
+
+```lean
+private lemma gnwProb_exchange_lt_col_of_F_side
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c'.1 < c.1)
+    (h_F :
+      (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+        ((hookLength μ c'.1 c.2 : ℚ) - 1) ^ 2 =
+      (∑ x ∈ (removeCorner μ c' hc').cells,
+          gnwProb (removeCorner μ c' hc') c
+            (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+        (hookLength μ c'.1 c.2 : ℚ) *
+        ((hookLength μ c'.1 c.2 : ℚ) - 2)) :
+    -- gnwProb_exchange's goal (identical for both cases)
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      (hookProd (removeCorner μ c hc) : ℚ) *
+      (hookProd (removeCorner μ c' hc') : ℚ) =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookProd (removeCorner (removeCorner μ c' hc') c
+          (isCorner_removeCorner_of_ne hc' hc hne.symm)) : ℚ) *
+      (hookProd μ : ℚ)
+```
+
+### Proof structure (parallels S53, simpler)
+
+The Case-2 combiner mirrors S53's proof but **drops the iteration-order
+swap step**:
+
+1. **Geometric prerequisite (S51-swapped).**  `hookLength_at_d_ge_3 hc' hc hi`
+   gives `3 ≤ hookLength μ c'.1 c.2 = h_d'`.  Hence `(h_d' − 1)² ≠ 0` in ℚ
+   via `linarith` + `pow_ne_zero`.
+
+2. **S52 applied with c, c' swapped.**
+   `have h_S52 := hookProd_doubleRemove_factor hc' hc hne.symm hi` yields
+   ```
+   H(μ) · H((μ\c')\c) · (h_d' − 1)² = H(μ\c') · H(μ\c) · h_d' · (h_d' − 2)
+   ```
+   The iteration order `H((μ\c')\c)` here **already matches** the
+   `gnwProb_exchange` goal RHS — no `hookProd_removeCorner_swap` rewrite
+   is needed (unlike S53, where S52 with `(c, c', hi : c.1 < c'.1)` gave
+   `H((μ\c)\c')` and required a swap to align with the goal).
+
+3. **`mul_right_cancel₀` and `linear_combination`.**  After multiplying
+   the goal by `(h_d' − 1)²` via `mul_right_cancel₀ hd_sub1_sq_ne`, the
+   resulting polynomial identity over ℚ closes by `linear_combination`
+   with **the same coefficients as S53**:
+   `α · h_F + β · h_S52` with `α = H(μ\c) · H(μ\c')` and `β = −F(μ\c',c)`.
+
+### Polynomial identity check (algebraic walkthrough)
+
+Let `A = F(μ,c)`, `B = F(μ\c',c)`, `H = H(μ)`, `Hc = H(μ\c)`,
+`Hc' = H(μ\c')`, `Hc'c = H((μ\c')\c)`, `d = h_d' = hookLength μ c'.1 c.2`.
+
+Goal (post-mul_right_cancel): `A · Hc · Hc' · (d−1)² = B · Hc'c · H · (d−1)²`.
+
+`α · h_F = Hc · Hc' · (A · (d−1)² − B · d · (d−2))`
+`β · h_S52 = −B · (H · Hc'c · (d−1)² − Hc' · Hc · d · (d−2))`
+
+Sum: `Hc · Hc' · A · (d−1)² − B · H · Hc'c · (d−1)²` — exactly `goal_lhs − goal_rhs` ✓
+(The two `B · Hc · Hc' · d · (d−2)` cross-terms cancel.)
+
+### Geometry — the doubly-affected cell
+
+In Case 1 (`c.1 < c'.1`, ⟹ `c'.2 < c.2` by `corner_col_lt_of_row_lt`):
+- Doubly-affected cell `d = (c.1, c'.2)`.
+- Row of c, column of c'.
+
+In Case 2 (`c'.1 < c.1`, ⟹ `c.2 < c'.2`): the geometry mirrors via the
+c↔c' swap:
+- Doubly-affected cell `d = (c'.1, c.2)`.
+- Row of c', column of c.
+
+Both cells satisfy `≥ 3` hook length (`hookLength_at_d_ge_3` is
+symmetric in its first two arguments via the `hi : first.1 < second.1`
+parameter), so the same ℚ-cast safety condition holds in both cases.
+
+### Why the swap-free path works
+
+The lemma `hookProd_doubleRemove_factor` produces a doubly-removed
+hookProd in iteration order `(removeCorner μ <first> ...) <second> ...`,
+i.e. first remove `<first>`, then `<second>`.  In `gnwProb_exchange`'s
+goal, the RHS uses `removeCorner (removeCorner μ c' hc') c ...`, i.e.
+remove c' first, then c.
+
+For S53 to apply S52, the S52 call was `hookProd_doubleRemove_factor hc hc' hne hi`
+where the "first" corner is c.  This produces `(μ\c)\c'`, opposite to the
+goal's `(μ\c')\c` — hence S53 needs `hookProd_removeCorner_swap` to align.
+
+For S54's call `hookProd_doubleRemove_factor hc' hc hne.symm hi`, the
+"first" corner is c'.  This produces `(μ\c')\c` directly — already
+matching the goal RHS.  No swap needed.
+
+### Remaining work
+
+After S54, **both** branches of `distinct_corners_dichotomy` have closed
+combiners.  Dispatching `gnwProb_exchange` itself is now a ~5-line
+case-split:
+
+```lean
+private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    <gnwProb_exchange goal> := by
+  rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, _⟩ | ⟨hi, _⟩
+  · exact gnwProb_exchange_lt_row_of_F_side hc hc' hne hi (?_ : F_side_case1)
+  · exact gnwProb_exchange_lt_col_of_F_side hc hc' hne hi (?_ : F_side_case2)
+```
+
+The two `?_` placeholders are the open F-side identities — one per case.
+**S55** is to prove these via joint K-induction.
+
+A natural parametric statement subsuming both:
+```
+F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+where  h_d = h_μ(c.1, c'.2)  if c.1 < c'.1
+       h_d = h_μ(c'.1, c.2)  if c'.1 < c.1
+```
+i.e. `h_d` is the hook length at the unique cell at row `min(c.1, c'.1)`
+and column `min(c.2, c'.2)`.  A single proof handling both cases would
+likely be ~150-250 lines, vs ~100-200 lines per case for separate proofs.
+
+### File-size update
+
+Helpers.lean: 14939 → 15026 (+87, S54 contribution).  ~474 lines under
+the Docker 32GB-memory ceiling estimate (~15500).  S55 will likely push
+us close to or over 15500.  Modularization into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` should be a blocking
+prerequisite for S55.
+
+The natural extraction boundary is the entire double-removal
+infrastructure:
+- S48 lemmas (`hookLength_doubleRemove_*`): ~lines 5035-5200
+- S50 single-removal bridges (`hookLength_removeCornerC'_*`): ~5200-5290
+- S51 (`hookLength_at_d_ge_3`): ~5288-5295
+- S52 (`hookProd_doubleRemove_factor`): ~5297-5500 (incl. proof body)
+- S53 (`gnwProb_exchange_lt_row_of_F_side`): ~14629-14675
+- S54 (`gnwProb_exchange_lt_col_of_F_side`, **this session**): ~14724-14762
+
+Total ~700 lines extractable.  After extraction Helpers.lean would be
+~14300 lines and the new file ~700 lines — both well within the build
+ceiling.  The S43 sum-bridges (`sum_gnwProb_*`) and `gnwProb_step` would
+need to remain in Helpers.lean (they have many other dependents).
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+88 lines, +1 lemma)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 53 → 54, added entry 16, refreshed Next Action and References)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s09.md`
+  (this report)
+
+No `meta.json` changes: the entry's main file (`BallotProblemOQ03OQ01OQ02.lean`,
+398 lines, 16 theorems) is untouched; the new lemma lives in the Helpers
+companion file, which is tracked via `additionalFiles`.  Sorry count
+remains 3 (1 in Helpers + 2 in Aristotle companion).
+
+### Build status
+
+Local Docker build NOT attempted (memory feedback:
+`proofs/.lake` is broken self-symlink causing 45+ minute fresh-clone
++ cache-fetch cycle).  Defer to CI.
+
+### Honest assessment
+
+S54 is a **clean follow-up** to S53, mechanical in nature: the c↔c' role
+swap in S52 produces the iteration order needed for the goal directly,
+making the Case 2 combiner strictly simpler than S53's.  The new lemma
+is sorry-free, conditional on the same kind of F-side identity that S53
+introduced as a hypothesis (now mirrored to the doubly-affected cell of
+Case 2 geometry).
+
+This does NOT close the open `gnwProb_exchange` sorry — the F-side joint
+K-induction is still required.  What S54 does is **clear the algebraic
+scaffolding for both cases**, so that S55 can focus exclusively on the
+joint K-induction without algebra still pending.
+
+### Next iteration recommendations
+
+1. **(architectural)** Modularize: extract S48-S54 into
+   `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` (~700 lines).  Blocking
+   prerequisite for S55 to avoid Docker memory ceiling.
+
+2. **(parametric F-side)** Frame S55 as a single lemma whose statement
+   uses `min(c.1, c'.1)` and `min(c.2, c'.2)` for the doubly-affected
+   cell coordinates.  Discharges both cases at once.
+
+3. **(small cleanup)** S53's docstring claims case 2 needs "an analogous
+   combiner (deferred to a follow-up session — symmetric proof
+   structure)".  Update this comment to point to S54.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -5,7 +5,7 @@
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
 **Last Updated**: 2026-05-08
-**Iteration**: 53
+**Iteration**: 54
 
 ## Current Focus
 Close `gnwProb_exchange` (Helpers, line 14597 after S52) — the GNW 1979 exchange identity
@@ -160,6 +160,26 @@ in place:
      instantiate `gnwProb_exchange_lt_row_of_F_side` to close case 1.
      Case 2 (`c'.1 < c.1`) needs an analogous combiner (deferred to a
      follow-up session — symmetric proof structure).
+ 16. Algebraic combiner (case 2) for `gnwProb_exchange` (session 54,
+     **this session**) — proved
+     `private lemma gnwProb_exchange_lt_col_of_F_side` (line ~14723,
+     +88 lines including ~46-line docstring).  Symmetric companion to
+     S53's `gnwProb_exchange_lt_row_of_F_side`, completing Case 2 of the
+     `distinct_corners_dichotomy` branch (`c'.1 < c.1`).  Conditional on
+     the symmetric F-side identity
+     `F(μ,c) · (h_d' − 1)² = F(μ\c',c) · h_d' · (h_d' − 2)` with
+     `h_d' = h_μ(c'.1, c.2)`.  Proof structure identical to S53 but
+     **without** the iteration-order swap step:
+     `hookProd_doubleRemove_factor hc' hc hne.symm hi` produces
+     `H((μ\c')\c)` directly — already matching the gnwProb_exchange RHS
+     iteration order — so no `hookProd_removeCorner_swap` invocation is
+     needed.  `linear_combination` coefficients identical to S53's
+     `(α=H(μ\c)·H(μ\c'), β=−F(μ\c',c))`; only the doubly-affected cell
+     coordinates `(c.1, c'.2) → (c'.1, c.2)` differ.  **Sorry count
+     unchanged (1)**: combiner is sorry-free.  After S54, both branches
+     of `distinct_corners_dichotomy` have closed combiners: dispatching
+     `gnwProb_exchange` itself is now a two-line case-split modulo the
+     two F-side identities (one per case).
 
 ## Blockers
 - **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
@@ -172,34 +192,34 @@ in place:
   CI will verify the PR.
 
 ## Next Action
-**S54 — prove the F-side "hard half" of `gnwProb_exchange`** via joint
-K-induction on the sum-level invariant.  After S53's combiner, the
-remaining target is the **corrected** F-side identity (case `c.1 < c'.1`):
+**S55 — prove the F-side "hard half" of `gnwProb_exchange`** via joint
+K-induction on the sum-level invariant.  After S53–S54's two combiners,
+the remaining targets are the F-side identities for both cases:
 ```
-F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+Case 1 (c.1 < c'.1):  F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+                      with h_d = h_μ(c.1, c'.2)
+Case 2 (c'.1 < c.1):  F(μ,c) · (h_d' − 1)² = F(μ\c',c) · h_d' · (h_d' − 2)
+                      with h_d' = h_μ(c'.1, c.2)
 ```
-where `F(ν,c) := ∑_{x ∈ ν.cells} gnwProb ν c (h_ν(x)) x` and
-`h_d = h_μ(c.1, c'.2)`.  **Note**: the direction here is the reverse of
-what was recorded in state.md before S53 — verified concretely on the
-(3,1) shape (`F(μ,c) = 8/3`, `F(μ\c',c) = 3`, `h_d = 4`,
-`(8/3)·9 = 24 = 3·4·2` ✓).
+where `F(ν,c) := ∑_{x ∈ ν.cells} gnwProb ν c (h_ν(x)) x`.  Case 1 was
+verified concretely on the (3,1) shape during S53 (`F(μ,c) = 8/3`,
+`F(μ\c',c) = 3`, `h_d = 4`, `(8/3)·9 = 24 = 3·4·2` ✓).
 
-Once S54 proves this identity (~100-200 lines of joint K-induction using
+Once S55 proves both identities (~100-200 lines of joint K-induction
+each — but the two are mirror images so a parametric "F-side hook-shift
+identity" lemma may discharge both at once, ~150-250 lines total — using
 `gnwProb_step` for K-stability and the S43 sum-bridges
 `sum_gnwProb_eq_removeCorner_cells`,
-`sum_gnwProb_strictHookCells_eq_removeCorner`), case 1 of
-`gnwProb_exchange` closes via S53's
-`gnwProb_exchange_lt_row_of_F_side`.  Case 2 (`c'.1 < c.1`) requires a
-symmetric companion combiner + a symmetric F-side identity.  After both
-cases, `gnwProb_exchange` itself is closed via
-`distinct_corners_dichotomy`, and the entry can be promoted to
+`sum_gnwProb_strictHookCells_eq_removeCorner`), the full
+`gnwProb_exchange` closes via `distinct_corners_dichotomy` + S53/S54
+combiners in a 5-line case-split.  The entry can then be promoted to
 `verified` (last sorry eliminated).
 
-S53 (this session) closed step 3 of 3 from the s05 recipe: the
-**algebraic combiner** that takes the F-side identity as a hypothesis
-and closes `gnwProb_exchange` (case `c.1 < c'.1`) by combining with S52
-and `hookProd_removeCorner_swap`.  The combiner is sorry-free.  S52 had
-already closed step 1.  Step 2 (F-side joint K-induction) is now the
+S53–S54 (sessions completed) closed step 3 of 3 from the s05 recipe for
+**both** branches of `distinct_corners_dichotomy`: the algebraic
+combiners that take the F-side identity as a hypothesis and close
+`gnwProb_exchange` for each case.  Both combiners are sorry-free.  S52
+had already closed step 1.  Step 2 (F-side joint K-induction) is now the
 sole remaining open piece of `gnwProb_exchange`.
 
 Remaining steps in the s05 recipe:
@@ -207,24 +227,33 @@ Remaining steps in the s05 recipe:
 1. ✓ **Algebraic "easy half" — `hookProd_doubleRemove_factor`** (S52,
    sorry-free, merged in PR #17173).
 
-2. **F-side "hard half"** (~100-200 lines, S54 next action — corrected
-   direction).  Joint K-induction on the sum-level invariant.
-   Confidence: medium.  May require S54.5 to extract the K=0 base case
-   as a separate lemma if the induction step is too large for one PR.
+2. **F-side "hard half"** (~150-250 lines if proved parametrically for
+   both cases, or ~100-200 each).  Joint K-induction on the sum-level
+   invariant.  Confidence: medium.  May require S55.5 to extract the
+   K=0 base case as a separate lemma if the induction step is too large
+   for one PR.
 
-3. ✓ **Combine** to close `gnwProb_exchange` case 1 (S53, this session,
-   sorry-free conditional on F-side identity).  Case 2 combiner deferred.
+3. ✓ **Combine** to close `gnwProb_exchange`:
+   - Case 1 (`c.1 < c'.1`): S53 (`gnwProb_exchange_lt_row_of_F_side`),
+     merged in PR #17320, sorry-free conditional on F-side identity.
+   - Case 2 (`c'.1 < c.1`): S54 (`gnwProb_exchange_lt_col_of_F_side`,
+     **this session**), sorry-free conditional on F-side identity.
+   - Final dispatcher: 5-line case-split on `distinct_corners_dichotomy`,
+     pending S55.
 
-**File-size**: Helpers.lean is at 14939 lines after S53 (+87 from 14852
-after S52).  Approaching the Docker 32GB-memory ceiling estimate (~15500
-lines).  S54 will likely push us close to or over 15000 — extraction into
-`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` should now be a *blocking
-prerequisite* for S54 (or S54 should target the extracted file directly).
+**File-size**: Helpers.lean is at 15026 lines after S54 (+87 from 14939
+after S53).  Approaching the Docker 32GB-memory ceiling estimate
+(~15500 lines).  S55 will likely push us close to or over 15500 —
+extraction into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` should now
+be a *blocking prerequisite* for S55 (or S55 should target the extracted
+file directly).  The natural extraction boundary is the entire
+double-removal infrastructure (S48-S54: lines ~5035–5500 for
+geometric+S52, plus ~14629–14762 for S53–S54 combiners).
 
 Alternative (deferred): a deterministic weighted-path recasting of GNW
 that avoids the exchange step entirely (count weighted walks of every
 length, divide by `μ.card · ∏ |strict hook|`); ~400 lines self-contained.
-Fallback if S53-S54 stall.
+Fallback if S55+ stalls.
 
 ## References
 
@@ -243,6 +272,8 @@ Fallback if S53-S54 stall.
 - `sessions/2026-05-08-s05.md` — Session 50: single-removal bridges + S51 Lean recipe
 - `sessions/2026-05-08-s06.md` — Session 51: `hookLength_at_d_ge_3` geometric prerequisite for ℚ-cast safety
 - `sessions/2026-05-08-s07.md` — Session 52: `hookProd_doubleRemove_factor` algebraic "easy half"
+- `sessions/2026-05-08-s08.md` — Session 53: `gnwProb_exchange_lt_row_of_F_side` algebraic combiner (case 1)
+- `sessions/2026-05-08-s09.md` — Session 54: `gnwProb_exchange_lt_col_of_F_side` algebraic combiner (case 2)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -255,13 +286,13 @@ Fallback if S53-S54 stall.
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5258` — `hookLength_removeCornerC'_leg_of_c` (S50)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5288` — `hookLength_at_d_ge_3` (S51)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5297` — `hookProd_doubleRemove_factor` (S52)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14597` — `gnwProb_exchange`
-  (sorry'd, target of S53-S54 — line shifted by +133 from S52 additions)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14622` — `gnwProb_key`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14629` — `gnwProb_exchange_lt_row_of_F_side`
+  (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14724` — `gnwProb_exchange_lt_col_of_F_side`
+  (S54 combiner, sorry-free conditional on F-side identity, case `c'.1 < c.1`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14772` — `gnwProb_exchange`
+  (sorry'd, target of S55 — F-side joint K-induction is the sole remaining open piece)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14797` — `gnwProb_key`
   (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14831` — `hook_walk_identity_gnw`
-  (sorry-free dispatcher, transitive on `gnwProb_exchange`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14489` — `gnwProb_key`
-  (proved modulo `gnwProb_exchange`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14698` — `hook_walk_identity_gnw`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15006` — `hook_walk_identity_gnw`
   (sorry-free dispatcher, transitive on `gnwProb_exchange`)


### PR DESCRIPTION
## Summary

S54 follow-up to S53 (PR #17320) — proves the **case-2 algebraic combiner** for `gnwProb_exchange`, the symmetric companion to S53's case-1 combiner.

After this PR, both branches of `distinct_corners_dichotomy` have sorry-free conditional combiners; dispatching `gnwProb_exchange` itself reduces to a 5-line case-split modulo the two F-side identities (S55+ target).

## What this adds

`proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (14939 → 15026, +87 lines):

- **`private lemma gnwProb_exchange_lt_col_of_F_side`** (~46-line docstring + ~42-line proof).
- Case `c'.1 < c.1`: takes the symmetric F-side identity (with doubly-affected cell at `(c'.1, c.2)` mirroring the Case-1 cell `(c.1, c'.2)`) as a hypothesis and discharges `gnwProb_exchange` algebraically.

```lean
private lemma gnwProb_exchange_lt_col_of_F_side
    {μ : YoungDiagram} {c c' : ℕ × ℕ}
    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c'.1 < c.1)
    (h_F :
      (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
        ((hookLength μ c'.1 c.2 : ℚ) - 1) ^ 2 =
      (∑ x ∈ (removeCorner μ c' hc').cells,
          gnwProb (removeCorner μ c' hc') c
            (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
        (hookLength μ c'.1 c.2 : ℚ) *
        ((hookLength μ c'.1 c.2 : ℚ) - 2)) :
    -- gnwProb_exchange goal (identical for both cases)
    ...
```

## Why S54 is simpler than S53

When S52 (`hookProd_doubleRemove_factor`) is applied with `c, c'` swapped — `hookProd_doubleRemove_factor hc' hc hne.symm hi` — the resulting iteration order `H((μ\c')\c)` **already matches** the gnwProb_exchange goal RHS.  No `hookProd_removeCorner_swap` invocation is needed (unlike S53, where the unswapped S52 produced `H((μ\c)\c')` and required a swap).

`linear_combination` coefficients are **identical** to S53's:
`α = H(μ\c) · H(μ\c')`, `β = −F(μ\c',c)`. Only the doubly-affected cell coordinates differ: `(c.1, c'.2) → (c'.1, c.2)`.

## Polynomial identity verification

Let `A = F(μ,c)`, `B = F(μ\c',c)`, `H = H(μ)`, `Hc = H(μ\c)`, `Hc' = H(μ\c')`, `Hc'c = H((μ\c')\c)`, `d = h_d' = hookLength μ c'.1 c.2`.

Goal (post-mul_right_cancel by `(d−1)²`): `A · Hc · Hc' · (d−1)² = B · Hc'c · H · (d−1)²`.

```
α · h_F  = Hc · Hc' · (A · (d−1)² − B · d · (d−2))
β · h_S52 = −B · (H · Hc'c · (d−1)² − Hc' · Hc · d · (d−2))
```

Sum: `Hc · Hc' · A · (d−1)² − B · H · Hc'c · (d−1)²` — exactly `goal_lhs − goal_rhs` ✓
(The two `B · Hc · Hc' · d · (d−2)` cross-terms cancel.)

## Architectural impact

After this PR, the case-split for `gnwProb_exchange` is mechanical:

```lean
private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
    <gnwProb_exchange goal> := by
  rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, _⟩ | ⟨hi, _⟩
  · exact gnwProb_exchange_lt_row_of_F_side hc hc' hne hi (?_ : F_side_case1)
  · exact gnwProb_exchange_lt_col_of_F_side hc hc' hne hi (?_ : F_side_case2)
```

The two `?_` placeholders are the open F-side identities (one per case).  **S55** is to prove these via joint K-induction, ~150-250 lines if proved parametrically over both cases.

## File-size posture

- Helpers.lean: 14939 → 15026 (+87 lines)
- ~474 lines under the Docker 32GB-memory ceiling estimate (~15500).
- S55 will likely push close to or over 15500.  **Modularization** (extracting S48-S54 double-removal infrastructure into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`, ~700 lines) should now be a blocking prerequisite for S55.

## What this is NOT

- **Not** closing the open `gnwProb_exchange` sorry — the F-side joint K-induction is still required.
- **Not** changing the chain sorry count (still 3: `gnwProb_exchange` + 2 in Aristotle companion).

What this **does** is clear the algebraic scaffolding for case 2, mirroring S53.  S55 can now focus exclusively on the F-side identity without algebra still pending.

## Test plan

- [ ] CI Docker build of Proofs.BallotProblemOQ03OQ01OQ02Helpers compiles successfully.
- [ ] No new sorries introduced (chain count remains 3).
- [ ] `linear_combination` discharges the polynomial identity (the same coefficients as S53 work for case 2).

Local Docker build NOT attempted: `proofs/.lake` is the broken self-symlink (memory: `feedback_researcher_lake_symlink_broken`); fresh-clone + cache-fetch would take 45+ minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)