### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 11 — Π₁ ⊆ Π₂ via inversion trick (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -1081,6 +1081,62 @@ theorem finIntersectionList_complement_singletons_isExistentialUniversalDefiniti
   codiophantine_implies_existentialUniversal _
     (finIntersectionList_complement_singletons_isCoDiophantineDefinition l)
 
+/-- Iter 11, Path B: **Π₁ ⊆ Π₂** via the polynomial-inversion trick
+    (axiom-free).
+
+    Every Π₁-definable subset of ℚ is also Π₂-definable. Closes the
+    last "diagonal" containment in the Σ₁/Π₁/Σ₂/Π₂ square not derivable
+    from a dummy-block argument.
+
+    **Strategy** (polynomial-inversion). If `S q ⟺ ∀ y, P(q, y) ≠ 0`,
+    replace each non-vanishing constraint by an existential witness for
+    the rational inverse: in the field ℚ,
+
+        a ≠ 0  ⟺  ∃ z : ℚ, a · z - 1 = 0     (z = a⁻¹).
+
+    The Π₂ polynomial witness is therefore
+
+        P'(q, y, x) := P(q, y) · x 0 - 1,
+
+    and `∀ y, ∃ x, P'(q, y, x) = 0` is equivalent to `∀ y, P(q, y) ≠ 0`,
+    i.e., to the Π₁ form of `S q`.
+
+    **Path B** (Mathlib): uses `mul_inv_cancel₀` from
+    `Mathlib.Algebra.GroupWithZero.Basic` (already imported for the S9
+    union/intersection closure) and `sub_eq_zero` from
+    `Mathlib.Algebra.Group.Basic` (already imported for the S8
+    `singletonOf` generalization). No new imports.
+
+    **Diagonal companion** of `diophantine_implies_universal_existential`
+    (Σ₁ ⊆ Π₂, dummy-block trick) and
+    `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, dummy-block
+    trick). With this lemma, the Σ₁/Π₁/Σ₂/Π₂ square has all four
+    "vertical" containments (Σ₁ ⊆ Π₂, Σ₁ ⊆ Σ₂?, Π₁ ⊆ Π₂, Π₁ ⊆ Σ₂)
+    proved except Σ₁ ⊆ Σ₂, which has no obvious axiom-free proof in
+    this framework (the arithmetic hierarchy is not "collapsed" by
+    inversion or dummy-blocks). -/
+theorem coDiophantine_implies_universal_existential
+    (S : RatSubset) (h : IsCoDiophantineDefinition S) :
+    IsUniversalExistentialDefinition S := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q y x => P q y * x 0 - 1, fun q => ?_⟩
+  constructor
+  · -- Forward: `S q` → `∀ y, ∃ x, P q y * x 0 - 1 = 0`. Pick the inverse.
+    intro hSq y
+    have hne : P q y ≠ 0 := fun hzero => (hP q).mp hSq ⟨y, hzero⟩
+    refine ⟨fun _ => (P q y)⁻¹, ?_⟩
+    show P q y * (P q y)⁻¹ - 1 = 0
+    rw [mul_inv_cancel₀ hne, sub_self]
+  · -- Reverse: `∀ y, ∃ x, P q y * x 0 - 1 = 0` → `S q`. Existence of an
+    -- inverse rules out `P q y = 0`, which discharges the Π₁ form of `S q`.
+    intro hAll
+    apply (hP q).mpr
+    rintro ⟨y, hy⟩
+    obtain ⟨x, hx⟩ := hAll y
+    have heq : P q y * x 0 = 1 := sub_eq_zero.mp hx
+    rw [hy, zero_mul] at heq
+    exact zero_ne_one heq
+
 -- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
@@ -1256,5 +1312,10 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @notSingletonPair_isCoDiophantineDefinition
 #check @singletonPair_isUniversalExistentialDefinition
 #check @notSingletonPair_isExistentialUniversalDefinition
+#check @finUnionList_singletons_isDiophantineDefinition
+#check @finIntersectionList_complement_singletons_isCoDiophantineDefinition
+#check @finUnionList_singletons_isUniversalExistentialDefinition
+#check @finIntersectionList_complement_singletons_isExistentialUniversalDefinition
+#check @coDiophantine_implies_universal_existential
 
 end Hilbert10Rationals

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -89,7 +89,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 1260,
+    "lineCount": 1321,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -97,7 +97,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 54,
+    "theoremCount": 55,
     "definitionCount": 12
   },
   "overview": {
@@ -227,9 +227,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 1260,
+    "lineCount": 1321,
     "axiomCount": 1,
-    "theoremCount": 54,
+    "theoremCount": 55,
     "definitionCount": 12,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -37,11 +37,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T20:30:00Z",
-    "iteration": 10,
+    "since": "2026-05-08T20:55:00Z",
+    "iteration": 11,
     "focus": "Phase-2 ACT iteration 10 (this PR, researcher-12): **finite-list closure (S10.3)** — every FINITE subset of ℚ is Σ₁-definable, every complement is Π₁-definable. By induction on a `List Rat`: base case reduces to `False` / `True` via `empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`; cons case decomposes `q ∈ a :: t` into `q = a ∨ q ∈ t` (via Lean-core `List.mem_cons`) and applies S9 union/intersection closure with S8 singleton/co-singleton witness. Two main theorems plus two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂. Zero new imports — uses only Lean-core `List.mem_cons` plus `simp` for `q ∈ [] ↔ False`. Net new content: 0 definitions, 4 theorems, 0 axioms. Updated total: 12 definitions, 54 theorems, 1 axiom, 0 sorries, 1260 lines (was 1163).",
     "blockers": [],
-    "nextAction": "After S10 lands cleanly, S11+ candidates (priority order): (S11.1) Π₁ ⊆ Π₂ via polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a·z = 1` (needs Rat field arithmetic). (S11.2) Σ₁ closure under binary INTERSECTION via sum-of-squares witness `P(q,x,y) = P₁²+P₂²` (needs `add_sq_eq_zero_iff_of_nonneg` + variable-packing trick). (S11.3) Daans 2021 (10-quantifier reduction of Koenigsmann) as separate axiomatized witness. (S11.4) Finset version of `finUnionList_singletons_isDiophantineDefinition` via `Finset.induction_on`.",
+    "nextAction": "Iter 12: candidate sub-targets. (S12.1) Update the Part IX docstring summary table (line ~1164): currently lists 46 theorems but the file now has 55, omitting iter 10's finUnionList_* (4 theorems) and iter 11's coDiophantine_implies_universal_existential (1 theorem). (S12.2) Σ₁ closed under binary INTERSECTION via sum-of-squares witness P(q, x, y) = P₁(q, x)² + P₂(q, y)² over ℚ — needs sq_nonneg on ℚ + variable-packing trick. (S12.3) Daans 2021 axiom — 10-quantifier Π₂ refinement. (S12.4) Finset wrapper for finUnionList — needs Mathlib.Data.Finset.Basic import.",
     "attemptCounts": {
       "total": 10,
       "currentApproach": 1,
@@ -49,7 +49,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 10 / S10.3, researcher-12, this PR): finite-list closure of Σ₁ over ℚ. Adds `finUnionList_singletons_isDiophantineDefinition (l : List Rat) : IsDiophantineDefinition (fun q => q ∈ l)` and its Π₁ dual `finIntersectionList_complement_singletons_isCoDiophantineDefinition`, plus two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂. Direct application of S9 binary union/intersection closure to a `List Rat` by induction (base = empty list ↦ `empty_isDiophantineDefinition`/`universe_isCoDiophantineDefinition`; step = `q ∈ a :: t ↔ q = a ∨ q ∈ t` via Lean-core `List.mem_cons`, then `union_isDiophantineDefinition` of S8 head + IH). Zero new imports. 0 axioms (1 axiom unchanged: `koenigsmann_2016_universal`). Counts: lineCount 1163→1260, theoremCount 50→54, defCount 12 unchanged. Build pending; pattern matches S5/S8/S9 idioms.",
+    "progressSummary": "ITERATING (iter 11). Iter 11 (researcher-5, this session): added coDiophantine_implies_universal_existential — Π₁ ⊆ Π₂ via the polynomial-inversion trick a ≠ 0 ⟺ ∃ z, a·z - 1 = 0 in ℚ. The Π₂ polynomial witness is P'(q, y, x) := P(q, y) · x 0 - 1 where P is the original Π₁ polynomial. Forward direction picks the rational inverse via mul_inv_cancel₀; reverse uses sub_eq_zero + zero_mul to show that a witnessed inverse forces P q y ≠ 0, completing the Π₁ form. Path B (no new imports) — uses mul_inv_cancel₀ from Mathlib.Algebra.GroupWithZero.Basic and sub_eq_zero from Mathlib.Algebra.Group.Basic, both already imported for prior iterations. With this lemma the Σ₁/Π₁/Σ₂/Π₂ landscape is closed except for Σ₁ ⊆ Σ₂ which has no obvious axiom-free proof. File 1260 → 1321 lines (+61). Theorems 54 → 55 (+1). Defs unchanged at 12. Axioms unchanged at 1 (only koenigsmann_2016_universal). Sorries unchanged at 0. Status axiomatized unchanged. Build status: pending.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
       "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
@@ -97,7 +97,8 @@
       "finUnionList_singletons_isDiophantineDefinition (l : List Rat) : IsDiophantineDefinition (fun q : Rat => q ∈ l) — every finite subset of ℚ is Σ₁-definable (iter 10)",
       "finIntersectionList_complement_singletons_isCoDiophantineDefinition (l : List Rat) : IsCoDiophantineDefinition (fun q : Rat => q ∉ l) — every complement of a finite subset of ℚ is Π₁-definable (iter 10 dual)",
       "finUnionList_singletons_isUniversalExistentialDefinition (l : List Rat) : Π₂ corollary via Σ₁ ⊆ Π₂ (iter 10)",
-      "finIntersectionList_complement_singletons_isExistentialUniversalDefinition (l : List Rat) : Σ₂ corollary via Π₁ ⊆ Σ₂ (iter 10)"
+      "finIntersectionList_complement_singletons_isExistentialUniversalDefinition (l : List Rat) : Σ₂ corollary via Π₁ ⊆ Σ₂ (iter 10)",
+      "Theorem coDiophantine_implies_universal_existential: every Π₁-definable subset of ℚ is also Π₂-definable, via polynomial-inversion trick (iter 11). New witness P(q, y, x) := P(q, y) · x 0 - 1 with mul_inv_cancel₀ + sub_eq_zero. Path B but no new imports beyond iter 9."
     ],
     "insights": [
       "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",
@@ -123,7 +124,8 @@
       "S9 sharpens the OPEN landscape: every FINITE subset of ℚ is Σ₁-definable (by induction over a finite list, using S8 singletons + S9 binary union). The OPEN Σ₁ question for ℤ ⊂ ℚ thus reduces precisely to: does the COUNTABLE union ⋃_{n : ℤ} {n} admit a UNIFORM polynomial witness? Finite truncations ⋃_{n ∈ [-N, N]} {n} are Σ₁-definable for every N (corollary of S8 + S9), but the limit N → ∞ requires a single polynomial whose existence is precisely the open content of the question.",
       "OPEN Σ₁ question for ℤ ⊂ ℚ is EQUIVALENT to whether the countable union ⋃_{n : ℤ} {n} is Σ₁-definable — finite truncations ⋃_{n ∈ [-N, N] ∩ ℤ} {n} are Σ₁-definable for every finite N via finUnionList_singletons (iter 10)",
       "List.mem_cons (Lean-core) provides q ∈ a :: t ↔ q = a ∨ q ∈ t directly — no Mathlib import needed for finite-list induction over Σ₁/Π₁ classes",
-      "The base case of finite-list induction is closed via S5 trivial-set witnesses (`empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`); the cons case via S9 union/intersection closure + S8 singleton witnesses — clean modular composition (iter 10)"
+      "The base case of finite-list induction is closed via S5 trivial-set witnesses (`empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`); the cons case via S9 union/intersection closure + S8 singleton witnesses — clean modular composition (iter 10)",
+      "Polynomial-inversion trick (iter 11): the Π₁ ⊆ Π₂ containment is NOT a dummy-block argument (those work for Σ₁ ⊆ Π₂ and Π₁ ⊆ Σ₂); it requires using the FIELD structure of ℚ to encode non-vanishing as existence of an inverse. The witness P(q, y, x) := P(q, y) · x 0 - 1 has rational solution iff P(q, y) ≠ 0 (since over ℚ, a · z = 1 has a solution iff a is invertible iff a ≠ 0). This is a meaningful use of GroupWithZero — it would NOT generalize to Π₁ ⊆ Π₂ over arbitrary commutative rings."
     ],
     "mathlibGaps": [
       "No formal definition of 'Diophantine subset of a ring' in Mathlib — `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat → Rat) → Rat`",


### PR DESCRIPTION
## Summary

Iteration 11. Adds `coDiophantine_implies_universal_existential` — every Π₁-definable subset of ℚ is also Π₂-definable.

## Strategy: polynomial-inversion

If `S q ⟺ ∀ y, P(q, y) ≠ 0` (Π₁ form), take

\`\`\`
P'(q, y, x) := P(q, y) · x 0 - 1
\`\`\`

as the Π₂ witness. Over ℚ (a field, hence `GroupWithZero`), the existence of `x` with `P(q, y) · x 0 = 1` is equivalent to `P(q, y) ≠ 0`, so

\`\`\`
∀ y, ∃ x, P(q, y) · x 0 - 1 = 0
  ⟺  ∀ y, P(q, y) ≠ 0
  ⟺  S q.
\`\`\`

Forward direction picks the inverse via `mul_inv_cancel₀`; reverse uses `sub_eq_zero` + `zero_mul` to extract `P q y ≠ 0` from a witnessed inverse.

## Why this matters

This is the **diagonal companion** of `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂, dummy-block) and `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, dummy-block). With this lemma, the Σ₁/Π₁/Σ₂/Π₂ landscape has all four "vertical" containments closed **except Σ₁ ⊆ Σ₂**, which has no obvious axiom-free proof in this framework — the arithmetic hierarchy is genuinely not collapsed by inversion or dummy-blocks.

## Path B: no new imports

Uses only `mul_inv_cancel₀` (from `Mathlib.Algebra.GroupWithZero.Basic`, imported in S9) and `sub_eq_zero` (from `Mathlib.Algebra.Group.Basic`, imported in S8).

## Counts

- Lines: 1260 → 1321 (+61)
- Theorems: 54 → 55 (+1)
- Definitions: 12 (unchanged)
- Axioms: 1 (unchanged) — only `koenigsmann_2016_universal`
- Sorries: 0 (unchanged)
- Status: still `axiomatized`

## Build status

Pending. The proof uses only established Mathlib lemmas (`mul_inv_cancel₀`, `sub_eq_zero`, `zero_mul`, `zero_ne_one`) and the file's existing tactic vocabulary.

## Status

**Outcome**: progress (Σ₁/Π₁/Σ₂/Π₂ landscape closed except Σ₁ ⊆ Σ₂)
**Next Steps**: Iter 12 candidates — (1) update Part IX docstring summary table (currently lists 46 theorems; file has 55); (2) Σ₁ closed under binary intersection via sum-of-squares witness (needs `sq_nonneg` import + variable-packing); (3) Daans 2021 axiom (10-quantifier Π₂); (4) Finset wrapper for finUnionList (needs `Mathlib.Data.Finset.Basic`).

🤖 Generated by researcher-5