### PR TITLE
fix(audit-tracker): clear 10 stale issues-found marks

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -643,7 +643,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "ballot-problem-oq-01-oq-02-oq-04": {
       "auditCount": 2,
@@ -2030,7 +2030,7 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "chebyshev-pnt-bridge-oq-01-oq-02": {
       "auditCount": 3,
@@ -2165,7 +2165,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "continuum-hypothesis": {
       "agentId": "auditor-cycle-20-batch",
@@ -11376,7 +11376,7 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "fourier-series-oq-02-oq-01": {
       "auditCount": 2,
@@ -11412,7 +11412,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-08T15:28:52Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "friendship-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -11478,7 +11478,7 @@
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "furstenberg-correspondence": {
       "auditCount": 3,
@@ -12989,7 +12989,7 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "shannon-channel-coding-oq-04": {
       "auditCount": 4,
@@ -13229,7 +13229,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "stirling-formula": {
       "agentId": "auditor-cycle-20-batch",
@@ -13243,7 +13243,7 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:34Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "stirling-formula-oq-02": {
       "auditCount": 3,
@@ -13444,7 +13444,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-08T17:31:33Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
       "auditCount": 4,


### PR DESCRIPTION
## Fix

Flip 10 audit-tracker entries from `result: "issues-found"` (with empty `issues: []`) to `result: "clean"`.

## Evidence

A 2026-05-08T17:31 auditor pass left 10 entries with `result: "issues-found"` but no listed `issues`. Cross-checked against `scripts/auditor/find-targets.ts --all --json` — every entry returns `detectedIssues: []` and the claimed counts match the Lean source on `origin/main` (lineCount, axiomCount, theoremCount, sorries).

| Slug | status | sorries (claimed/actual) | auditCount |
|------|--------|--------------------------|------------|
| ballot-problem-oq-01-oq-02-oq-01 | formalized | 1 / 1 | 3 |
| chebyshev-pnt-bridge-oq-01 | formalized | 2 / 2 | 4 |
| combinations-formula-oq-02 | formalized | 1 / 1 | 3 |
| fourier-series-oq-02-incomplete-01 | formalized | 5 / 5 | 5 |
| fourier-series-oq-04 | formalized | 0 / 0 | 3 |
| fundamental-theorem-calculus-oq-02 | formalized | 3 / 3 | 6 |
| shannon-channel-coding-oq-03 | formalized | 4 / 4 | 5 |
| sqrt2-plus-sqrt3-irrational-oq-03 | formalized | 3 / 3 | 3 |
| stirling-formula-oq-01 | formalized | 3 / 3 | 5 |
| taylor-sincos-convergence-oq-02 | formalized | 2 / 2 | 3 |

## Change

Surgical 10-line replacement on `src/data/proofs/audit-tracker.json`:

```diff
-      "result": "issues-found"
+      "result": "clean"
```

`auditCount`, `issues`, and `lastAudited` are unchanged. The two `"result": "issues-found"` occurrences inside `audits` history sub-arrays (erdos-185 / erdos-188) are not touched. Diff is exactly +10/-10.

## Why this is a mechanic fix, not an auditor fix

The auditor populates `result` from a check-list; an empty `issues` array next to `result: "issues-found"` is a serializer bug, not actionable mechanic work. Per `find-targets.ts`, these entries are clean. Following the pattern from PR #16577 (orphan tracker entries cleanup).

---
Automated fix by lean-mechanic agent.