### PR TITLE
Enrich bezout-identity-oq-01-oq-01-oq-01: assumptions accuracy + section gap + mathContext

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -26,7 +26,7 @@
     "lineCount": 242,
     "theoremCount": 7,
     "definitionCount": 2,
-    "assumptions": "stepBitOps_le: each recursive step uses at most 3·(log₂(max a b)+1) bit operations (one comparison, one subtraction or shift, one parity test). This models the idealized bit-RAM cost; it is independent of Lean's actual computation.",
+    "assumptions": "Two axioms model the bit-RAM cost: (1) `stepBitOps : ℕ → ℕ → ℕ` — abstract per-call bit-operation cost (intentionally noncomputable, since Lean's `Nat` is not bit-level); (2) `stepBitOps_le : stepBitOps a b ≤ 3·(log₂(max a b)+1)` — bounds each recursive step (one comparison, one subtraction or shift, one parity test) at $O(\\log)$ bits. Both axioms are independent of Lean's actual computation; the step-count theorem `binaryGcdSteps_le_log` is fully proved without them.",
     "originalContributions": [
       "binaryGcdSteps: counts recursive calls, mirrors binaryGcd branching exactly, terminates by well-founded recursion on a+b",
       "binaryGcdSteps_le_log: step count ≤ 2·(log₂ a + log₂ b) + 2 — proved by strong induction, each branch peels one bit from log₂ a or log₂ b via log_div_two and log_odd_sub_half",
@@ -69,32 +69,44 @@
   },
   "sections": [
     {
+      "id": "header-and-imports",
+      "title": "File Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring summarizing the two-stage complexity argument (step count × per-step bit cost = $O(\\log^2)$), the imports (`Nat.GCD.Basic`, `Nat.Log`, `Mathlib.Tactic`, plus the parent `BezoutIdentityOQ01OQ01` for the algorithm itself), and the namespace `BezoutIdentityOQ01OQ01OQ01` housing the complexity analysis. The parent file's `binaryGcd` definition is re-used unchanged.",
+      "mathContext": "The two-file split — algorithm in `BezoutIdentityOQ01OQ01`, complexity analysis here — is intentional: it lets the step-count theorem be proved against the *exact* algorithm definition that the correctness proof in the parent file uses, with no risk of complexity drift if the algorithm is refactored. The `Nat.Log` import provides `Nat.log 2 n = ⌊\\log_2 n\\rfloor`, the natural-number-truncated base-2 logarithm used as the bit-measure throughout."
+    },
+    {
       "id": "step-counter",
       "title": "Step Counter Definition",
       "startLine": 44,
       "endLine": 66,
-      "summary": "Defines binaryGcdSteps : ℕ → ℕ → ℕ mirroring all seven branches of binaryGcd exactly. Terminates by well-founded recursion on a+b via the same argument as the algorithm itself."
+      "summary": "Defines binaryGcdSteps : ℕ → ℕ → ℕ mirroring all seven branches of binaryGcd exactly. Terminates by well-founded recursion on a+b via the same argument as the algorithm itself.",
+      "mathContext": "$\\mathrm{steps}(a,b) := \\#\\{\\text{recursive calls of binaryGcd starting from } (a,b)\\}$. The seven branches partition $(a,b) \\in \\mathbb{N}^2 \\setminus \\{(0,\\cdot), (\\cdot, 0)\\}$ on the joint parity of $(a, b)$ and the comparison $a \\lessgtr b$. Termination is on $a+b$: each branch strictly decreases this sum (halving is replaced by subtraction in the both-odd case, but the resulting argument is at least $1$). Lean's `decreasing_by` tactic discharges this via `omega` once the algorithm's branch decreasings are made explicit."
     },
     {
       "id": "log-helpers",
       "title": "Logarithm Helper Lemmas",
       "startLine": 67,
       "endLine": 103,
-      "summary": "Four private lemmas: log_div_two (log₂(n/2) = log₂ n − 1 for n ≥ 2), log_mono (log monotone), log_odd_sub_half ((b−a)/2 drops log₂ b by 1 when b is odd and a < b), log_odd_sub_half_left (symmetric case)."
+      "summary": "Four private lemmas: log_div_two (log₂(n/2) = log₂ n − 1 for n ≥ 2), log_mono (log monotone), log_odd_sub_half ((b−a)/2 drops log₂ b by 1 when b is odd and a < b), log_odd_sub_half_left (symmetric case).",
+      "mathContext": "These four lemmas are the bit-counting arithmetic that powers each branch of the step-count proof. **log_div_two** is the standard halving identity $\\log_2(n/2) = \\log_2 n - 1$ for $n \\ge 2$ — used in the both-even and even-odd branches. **log_odd_sub_half** is the most delicate: for $b$ odd and $a < b$, the difference $b - a$ is even (parity arithmetic) and $b - a < 2 \\cdot (b - a) / 2 + 1 \\le b$, so $(b-a)/2 \\le (b-1)/2 < b/2$, giving $\\log_2((b-a)/2) \\le \\log_2 b - 1$. The strict inequality is what the both-odd branch needs to advance the bit-measure by 1."
     },
     {
       "id": "step-bound",
       "title": "Step Count Bound",
       "startLine": 105,
       "endLine": 188,
-      "summary": "binaryGcdSteps_le_log: binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2. Proved by strong induction on a+b with case analysis over the seven algorithm branches, each peeling one bit from the logarithm measure."
+      "summary": "binaryGcdSteps_le_log: binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2. Proved by strong induction on a+b with case analysis over the seven algorithm branches, each peeling one bit from the logarithm measure.",
+      "mathContext": "**Lyapunov-style argument**: define $\\Phi(a,b) := \\log_2 a + \\log_2 b$ for $a,b \\ge 1$. Each recursive call decreases $\\Phi$ by at least $1$: in `both-even`, both arguments halve so $\\Phi$ drops by exactly $2$; in `even-odd` (or symmetric), only the even argument halves so $\\Phi$ drops by $1$; in `both-odd` with $a < b$, the new pair is $(a, (b-a)/2)$ with $\\log_2((b-a)/2) \\le \\log_2 b - 1$ by `log_odd_sub_half`, so $\\Phi$ drops by at least $1$. After at most $2(\\log_2 a + \\log_2 b)$ calls $\\Phi$ has been driven to $0$ (one of the arguments is $1$); two more calls finish the base case."
     },
     {
       "id": "bit-complexity",
       "title": "Bit Complexity Model and O(log² n) Bound",
       "startLine": 190,
       "endLine": 242,
-      "summary": "Axiomatizes the per-step bit cost (stepBitOps, stepBitOps_le). Defines totalBitOps and proves binaryGcd_log_sq_complexity (explicit bound) and binaryGcd_log_sq_bound (O(log²) corollary: ≤ 6·(log₂(max a b)+1)²)."
+      "summary": "Axiomatizes the per-step bit cost (stepBitOps, stepBitOps_le). Defines totalBitOps and proves binaryGcd_log_sq_complexity (explicit bound) and binaryGcd_log_sq_bound (O(log²) corollary: ≤ 6·(log₂(max a b)+1)²).",
+      "mathContext": "Two-stage cost decomposition: $\\mathrm{totalBitOps}(a,b) = \\mathrm{steps}(a,b) \\cdot \\mathrm{stepBitOps}(a,b)$. By `binaryGcdSteps_le_log`: $\\mathrm{steps}(a,b) \\le 2(\\log_2 a + \\log_2 b) + 2$. By the axiom: $\\mathrm{stepBitOps}(a,b) \\le 3(\\log_2(\\max a b) + 1)$. Multiplying and using $\\log_2 a + \\log_2 b \\le 2 \\log_2(\\max a b)$ yields $\\mathrm{totalBitOps}(a,b) \\le 6(\\log_2(\\max a b) + 1)^2$, the headline $O(\\log^2)$ bound. The constant 6 is the product of the two stage constants ($2 \\cdot 3$) and reflects the worst-case input where each stage saturates simultaneously."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass for `bezout-identity-oq-01-oq-01-oq-01` (Binary GCD $O(\log^2 n)$ Bit Complexity). Pre-pass quality 98/100; this pass corrects an axiom-prose mismatch and adds substantive depth to sections.

## Changes
- **Fixed `assumptions` accuracy** (axiom integrity): the prose mentioned only `stepBitOps_le` but the file declares 2 axioms — `stepBitOps : ℕ → ℕ → ℕ` (intentionally noncomputable abstract cost) and `stepBitOps_le` (the $O(\log)$ bound). Both axioms are now enumerated, with an explanation of why `stepBitOps` is necessarily noncomputable (Lean's `Nat` is not bit-level). `axiomCount = 2` in `meta.json` is correct.
- **Added section for file header** (lines 1-43): previously sections started at line 44 (the `binaryGcdSteps` definition), leaving the docstring / imports / namespace uncovered. The new `header-and-imports` section explains the two-file algorithm/complexity split.
- **Added `mathContext` to all 5 sections** (previously 0/4): each section now surfaces the mathematical content of its Lean code:
  - `step-counter`: termination on $a+b$, branch partition by parity
  - `log-helpers`: detail on $\log_2((b-a)/2) \le \log_2 b - 1$ for odd $b$
  - `step-bound`: Lyapunov-style $\Phi(a,b) := \log_2 a + \log_2 b$ argument with explicit per-branch decrease
  - `bit-complexity`: two-stage cost decomposition $\mathrm{steps} \cdot \mathrm{stepBitOps}$ and the constant-6 saturation analysis

## Axiom Integrity
- `axiomCount = 2`, `status = axiomatized`, `badge = axiom`, `sorries = 0`.
- The `stepBitOps_le` axiom is *not* the same as `stepBitOps` — they are two distinct declarations (line 190 and line 191 of the Lean file).

## Validation
- `tsx scripts/annotations/build.ts` — exit 0.
- JSON well-formed; section line ranges (1-43, 44-66, 67-103, 105-188, 190-242) cover the Lean file's content with only the natural gaps at lines 104 and 189 (blank-line section dividers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)