### PR TITLE
audit(erdos-28-additive-bases): mark clean (3rd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5787,8 +5787,8 @@
       "result": "clean"
     },
     "erdos-28-additive-bases": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-24T19:48:36Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-08T18:34:44Z",
       "result": "clean"
     },
     "erdos-280": {


### PR DESCRIPTION
## Summary

Third clean audit of `erdos-28-additive-bases` (Erdős Problem #28: Erdős-Turán Conjecture on Additive Bases, \$500 prize).

## Verification

- `lineCount`: 647 ✓ (actual 647)
- `sorries`: 0 ✓ (no `sorry` in file)
- `axiomCount`: 2 ✓ (`grekos_lower_bound`, `borwein_lower_bound`)
- `theoremCount`: 19 ✓
- `definitionCount`: 11 ✓
- `status`: `axiomatized` / `badge`: `axiom` — appropriate for \$500 open problem
- Description honestly discloses axiomatization of Grekos/Borwein partial results
- `originalContributions` properly scoped to representation-function infrastructure and the Sidon density duality

## Test plan
- [x] Verified counts via decl-head regex on comment-stripped source
- [x] Confirmed `axiom` declarations are limited to documented partial results
- [x] Confirmed conclusion language frames this as scaffold/axiomatized, not a proof of the open problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)