### PR TITLE
research(ehrhart-cube-proven-oq-02): S6 — Mathlib API drift fix (build restored)

### DIFF
--- a/proofs/Proofs/EhrhartCrossPolytope.lean
+++ b/proofs/Proofs/EhrhartCrossPolytope.lean
@@ -242,11 +242,11 @@ example : crossEhrhart 3 4 = 129 := by native_decide
 
 -- Helper: natDegree of `descPochhammer ℚ k` is at most `k`.
 private lemma natDegree_descPochhammer_le (k : ℕ) :
-    (Polynomial.descPochhammer ℚ k).natDegree ≤ k := by
+    (descPochhammer ℚ k).natDegree ≤ k := by
   induction k with
   | zero => simp
   | succ k ih =>
-    rw [Polynomial.descPochhammer_succ_right]
+    rw [descPochhammer_succ_right]
     refine le_trans Polynomial.natDegree_mul_le ?_
     have h1 : (Polynomial.X - ((k : ℕ) : Polynomial ℚ)).natDegree ≤ 1 := by
       refine le_trans (Polynomial.natDegree_sub_le _ _) ?_
@@ -255,12 +255,12 @@ private lemma natDegree_descPochhammer_le (k : ℕ) :
 
 -- Helper: `(descPochhammer ℚ k).eval (n : ℚ) = ↑(n.descFactorial k)`.
 private lemma eval_descPochhammer_natCast (k n : ℕ) :
-    (Polynomial.descPochhammer ℚ k).eval ((n : ℕ) : ℚ) =
+    (descPochhammer ℚ k).eval ((n : ℕ) : ℚ) =
       ((n.descFactorial k : ℕ) : ℚ) := by
   induction k with
   | zero => simp
   | succ k ih =>
-    rw [Polynomial.descPochhammer_succ_right]
+    rw [descPochhammer_succ_right]
     simp only [Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_X,
                Polynomial.eval_natCast, ih]
     rcases le_or_lt k n with hkn | hkn
@@ -301,7 +301,7 @@ theorem crossEhrhart_is_poly (d : ℕ) :
     ∀ n : ℕ, P.eval (n : ℚ) = (crossEhrhart d n : ℚ) := by
   refine ⟨∑ k ∈ range (d + 1),
     Polynomial.C ((2 ^ k : ℚ) * (Nat.choose d k : ℚ) / (k.factorial : ℚ)) *
-      Polynomial.descPochhammer ℚ k, ?_, ?_⟩
+      descPochhammer ℚ k, ?_, ?_⟩
   · -- natDegree ≤ d
     refine le_trans (Polynomial.natDegree_sum_le _ _) ?_
     apply Finset.sup_le
@@ -321,7 +321,6 @@ theorem crossEhrhart_is_poly (d : ℕ) :
       exact_mod_cast Nat.factorial_ne_zero k
     push_cast
     field_simp [hk_ne]
-    ring
 
 -- ============================================================
 -- PART VIII: Connection to Lattice Points
@@ -388,18 +387,18 @@ private lemma fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n) :
   apply Finset.card_bij'
     -- Forward: y ↦ z where z idx := (y idx).val - (n - M).
     (fun y hy idx =>
-      ⟨(y idx).val - (n - M), by
+      (⟨(y idx).val - (n - M), by
         have hsum :
             ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
           simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
           exact hy
         obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum idx
-        omega⟩)
+        omega⟩ : Fin (2 * M + 1)))
     -- Backward: z ↦ y' where y' idx := (z idx).val + (n - M).
     (fun z _ idx =>
-      ⟨(z idx).val + (n - M), by
-        have hcoord : (z idx).val < 2 * M + 1 := (z idx).is_lt
-        omega⟩)
+      (⟨(z idx).val + (n - M), by
+        have hcoord : (z idx).val < 2 * M + 1 := (z idx).isLt
+        omega⟩ : Fin (2 * n + 1)))
     -- (1) Forward image lies in `crossBall d M`.
     (by
       intro y hy

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ehrhart-cube-proven-oq-02
 
 ## Current State
-**Phase**: ACT — fiber bijection helper added; 1 sorry remains
+**Phase**: ACT — Mathlib API drift fix (S6); 1 sorry remains
 **Path**: incremental sorry closure
 **Since**: 2026-05-07
 **Last Updated**: 2026-05-08
-**Iteration**: 4
+**Iteration**: 6
 
 ## Current Focus
 One sorry remains in `proofs/Proofs/EhrhartCrossPolytope.lean`:
@@ -58,7 +58,7 @@ foundation lemmas are now in place:
    `crossEhrhart_succ_d` closes the proof.
 
 ## Attempt Count
-- Total attempts: 4
+- Total attempts: 6
 - Approaches tried:
   - Session 1 (researcher-8, OBSERVE): mapped Mathlib tools for
     `crossEhrhart_is_poly` (descPochhammer-based)
@@ -68,17 +68,52 @@ foundation lemmas are now in place:
   - Session 4 (researcher-9, ACT): added `cweight_sum_individual`,
     `cweight_sum_range`, and `fiber_card_eq_crossBall_card` (via
     `Finset.card_bij'`)
+  - Session 5 (researcher-12, ORIENT): wrote slicing decomposition spec
+    (`session-5-slicing-spec.md`); deferred Lean prototype
+  - Session 6 (researcher-1, ACT): **Mathlib API drift fix**. After
+    deleting the broken `proofs/.lake` self-symlink and running the
+    Docker build, found that origin/main no longer compiles due to
+    Mathlib API drift since PR #16734 / #17008 merged unverified.
+    Three fixes restored buildability:
+    (a) `Polynomial.descPochhammer` → `descPochhammer` (5 refs);
+        `Polynomial.descPochhammer_succ_right` → `descPochhammer_succ_right` (2 refs).
+        `descPochhammer` lives at the root namespace (after `open Polynomial`),
+        not inside `namespace Polynomial`.
+    (b) Removed redundant `ring` after `field_simp [hk_ne]` in
+        `crossEhrhart_is_poly` (field_simp now closes the goal directly).
+    (c) Added explicit `Fin (2 * M + 1)` and `Fin (2 * n + 1)` type
+        annotations to the Forward/Backward bijection lambdas inside
+        `Finset.card_bij'` for `fiber_card_eq_crossBall_card`. Without
+        the annotations, Lean's elaborator failed to fix the lambda's
+        codomain, leaving the Fin-bound proof obligation unmaterialized
+        ("No goals to be solved" at the inner `by` block) and leaving
+        a stray metavariable inside the post-`simp only [crossBall, ...]`
+        sum body ("show tactic failed: pattern not definitionally equal"
+        with `↑?m.56` on the target side).
+    Also bumped `is_lt` → `isLt` (cosmetic; both work).
+    Build verified: `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope`
+    in worktree `researcher-1`, exit 0, 1 sorry / 0 axioms / 538 lines.
 
 ## Blockers
-- **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle
-  (broken). Docker build is the only verifier; iteration cost is high.
-  PR-driven CI is the ground truth.
+- **Local Lean build**: The recursive self-symlink at
+  `/Users/rwalters/GitHub/lean-genius/proofs/.lake` (and the inherited
+  symlink in fresh worktrees) blocks Docker builds. Workaround:
+  `rm proofs/.lake` in the worktree and let the container clone Mathlib
+  fresh — adds ~10 min for clone + ~5 min for cache get on first use,
+  then incremental builds are ~2 min.
 
 ## Next Action
-**For Session 5**: Use `fiber_card_eq_crossBall_card` to express
-`(crossBall (d+1) n).card = ∑ j ∈ range (2n+1), (crossBall d M_j).card`
-where `M_j = if j ≤ n then j else 2n - j`. The fiber-to-filter
-bijection over `Fin.snoc` is the next chunk; estimate ~80–120 lines.
+**For Session 7**: Resume the slicing decomposition prototype from
+`session-5-slicing-spec.md` §4-6 on top of the now-buildable
+origin/main. The S6 prototype committed to local branch
+`research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307`
+(`4e9853d0510`) adds `crossBall_succ_d_fiber_card` (~80 lines),
+`crossBall_succ_d_slice` (~10 lines), `sum_crossBall_pair` (~55 lines)
+and the `crossBall_card` wire-in (~6 lines). When pulled into a fresh
+build it will surface its own Mathlib-drift issues
+(`Finset.card_eq_sum_card_fiberwise` MapsTo vs `∀ x ∈ s, f x ∈ t`,
+`Fin.snoc_last` arg order, possible `change`/`omega` interactions on
+opaque sums) which will likely need fixes similar to Session 6.
 
 ## References
 - `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight bridge

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -6,7 +6,7 @@
   "leanFile": {
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
-    "lineCount": 539,
+    "lineCount": 538,
     "theoremCount": 19,
     "definitionCount": 2,
     "sorries": 1,
@@ -31,7 +31,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 539,
+    "lineCount": 538,
     "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. Foundation helpers cweight_le_iff and cweight_translate added (Session 3) for the eventual fiber bijection. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",

--- a/src/data/research/problems/ehrhart-cube-proven-oq-02.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-02.json
@@ -18,54 +18,56 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:49:03.933Z",
-    "iteration": 5,
-    "focus": "S5 (researcher-12, 2026-05-08): Slicing decomposition specification (research/problems/ehrhart-cube-proven-oq-02/session-5-slicing-spec.md). Three-piece factoring (crossBall_succ_d_slice, sum_crossBall_pair, main wire-in) with verified Mathlib API (Finset.card_eq_sum_card_fiberwise, Fin.snoc / Fin.init / Fin.snoc_init_self / Fin.init_snoc / Fin.snoc_castSucc, Fin.sum_univ_castSucc, Fin.sum_univ_eq_sum_range, Finset.sum_nbij'). Build-ready Lean 4 skeleton with 2 mechanical `sorry`s (each ≤10 lines: cweight + Σ split via Fin.sum_univ_castSucc, both directions). Estimated total new code: ~90 lines. Lean prototype deferred until proofs/.lake symlink repaired. Still 1 sorry / 0 axioms / 539 lines on origin/main.",
+    "iteration": 6,
+    "focus": "S6 (researcher-1, 2026-05-08): Mathlib API drift fix. origin/main no longer compiled after PR #16734 / #17008 because (a) Mathlib's `descPochhammer` is at the root namespace (after `open Polynomial`) — `Polynomial.descPochhammer` and `Polynomial.descPochhammer_succ_right` are unknown; (b) `field_simp [hk_ne]` now closes the goal so the trailing `ring` is redundant; (c) the bijection lambdas inside `Finset.card_bij'` for `fiber_card_eq_crossBall_card` need explicit `Fin (2 * M + 1)` / `Fin (2 * n + 1)` annotations or Lean's elaborator leaves the Fin-bound proof obligation unmaterialized and a metavariable in the simp-unfolded goal body. Three-line, three-call fix verified by Docker build. Still 1 sorry / 0 axioms / 538 lines on the fix branch.",
     "blockers": [
-      "proofs/.lake recursive self-symlink: every Docker build = ~30-45 min Mathlib clone + ~10 min cache fetch. Blocks S6 prototype build verification."
+      "Slicing decomposition prototype (S5 spec → S7 implementation) still TODO. The local commit 4e9853d0510 on branch `research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307` adds ~195 lines but is build-pending and will need its own Mathlib-drift fixes when verified."
     ],
-    "nextAction": "S6: prototype Steps A+B+C per session-5-slicing-spec.md §4-6 once `.lake` symlink is repaired. Two mechanical `sorry`s to discharge (cweight + Σ split via Fin.sum_univ_castSucc, both directions; each ≤10 lines). Then Docker build with `LEAN_BUILD_TIMEOUT=60m`.",
+    "nextAction": "S7: Resume the slicing decomposition prototype on top of the now-buildable origin/main. Pull commit `4e9853d0510` into a fresh worktree, run Docker build, fix surfaced Mathlib-drift issues (likely `Finset.card_eq_sum_card_fiberwise` MapsTo coercion, `Fin.snoc_last` arg order, and `change`/`omega` interactions on opaque sums).",
     "attemptCounts": {
-      "total": 5,
+      "total": 6,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S5 (2026-05-08, researcher-12): Slicing decomposition specification (`session-5-slicing-spec.md`) factoring the remaining `crossBall_card` succ-d `sorry` into three pieces: (A) `crossBall_succ_d_slice` slicing identity via `Finset.card_eq_sum_card_fiberwise` + `Fin.init`/`Fin.snoc`; (B) `sum_crossBall_pair` j↔2n-j reorganization via `Finset.sum_nbij'`; (C) wire into induction via `crossEhrhart_succ_d`. All Mathlib lemmas verified against `mathlib4` master (file paths + line numbers in spec §3). Build-ready Lean skeleton with 2 mechanical `sorry`s (each ≤10 lines, `omega`-discharable). Estimated ~90 new lines. Lean prototype deferred to S6 pending `.lake` symlink repair. S0 PR #16339 framework + S2 PR #16734 crossEhrhart_is_poly + S3 PR #16842 cweight foundation helpers + S4 PR #17008 fiber_card_eq_crossBall_card all merged. EhrhartCrossPolytope.lean on origin/main: 14 theorems / 1 sorry / 0 axioms / 539 lines (post-PR #17008).",
+    "progressSummary": "S6 (2026-05-08, researcher-1): Mathlib API drift fix restoring origin/main buildability. Three-bug bundle: (1) `Polynomial.descPochhammer` → `descPochhammer` (5 refs) + `Polynomial.descPochhammer_succ_right` → `descPochhammer_succ_right` (2 refs) — Mathlib's `descPochhammer` lives at root namespace after `open Polynomial`, NOT inside `namespace Polynomial`; (2) drop redundant `ring` after `field_simp [hk_ne]` in `crossEhrhart_is_poly` (field_simp now closes); (3) explicit `Fin (2 * M + 1)` / `Fin (2 * n + 1)` annotations on bijection lambdas in `Finset.card_bij'` for `fiber_card_eq_crossBall_card` — without them the elaborator leaves the Fin-bound proof obligation unmaterialized (\"No goals to be solved\" at inner `by`) and a metavariable inside post-`simp only [crossBall, ...]` sum bodies (\"show tactic failed: pattern not definitionally equal\" with `↑?m.56` on target). Build verified via `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope` after `rm proofs/.lake` (broken self-symlink). Still 1 sorry (`crossBall_card` succ-d) / 0 axioms / 538 lines. S5 slicing spec (`session-5-slicing-spec.md`) and the local-only S6 prototype branch (`4e9853d0510`, ~195 lines) remain valid but deferred — they'll need their own Mathlib-drift fixes when implemented.",
     "builtItems": [
-      "sum_choose_range: hockey-stick \u03a3 C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:118",
+      "sum_choose_range: hockey-stick Σ C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:118",
       "sum_shift_hockey: sum interchange at EhrhartCrossPolytope.lean:130",
       "crossEhrhart_expand: Pascal split at EhrhartCrossPolytope.lean:152",
       "crossEhrhart_succ_d: geometric recursion at EhrhartCrossPolytope.lean:205",
       "crossEhrhart_d0/d1/n0: base cases at EhrhartCrossPolytope.lean:63-83",
       "crossEhrhart_pos/mono: structural properties at EhrhartCrossPolytope.lean:95-108",
       "crossEhrhart_d2: proved via induction using recursion (after succ_d) at EhrhartCrossPolytope.lean:223",
-      "crossEhrhart_is_poly: descPochhammer-based polynomial of degree \u2264 d (PR #16734 Session 2) at EhrhartCrossPolytope.lean:299",
+      "crossEhrhart_is_poly: descPochhammer-based polynomial of degree ≤ d (PR #16734 Session 2) at EhrhartCrossPolytope.lean:299",
       "crossBall: Finset model of cross-polytope at EhrhartCrossPolytope.lean:332",
       "cweight_le_iff (Session 3): centered-weight bound characterization at EhrhartCrossPolytope.lean:338",
       "cweight_translate (Session 3): translation bridge for fiber bijection at EhrhartCrossPolytope.lean:346"
     ],
     "insights": [
-      "S5 (researcher-12, 2026-05-08): The slicing identity `(crossBall (d+1) n).card = \u2211 j : Fin (2n+1), (crossBall d M_j).card` factors through `Finset.card_eq_sum_card_fiberwise` (project via `fun y => y (Fin.last d)`) + per-fiber bijection `Fin.init`/`Fin.snoc`. M_j := if j.val \u2264 n then j.val else 2n - j.val (= n - cweight(j, n)). \u03a3 over Fin (d+1) splits via `Fin.sum_univ_castSucc`; the last summand is exactly cweight(j, n) since `y (last d) = j` is fixed inside the fiber.",
-      "S5 (researcher-12, 2026-05-08): The j\u21942n-j pairing collapses cleanly: split `range (2n+1) = range n \u222a {n} \u222a Ico (n+1) (2n+1)`; the high half reverses via `Finset.sum_nbij'` with `m \u21a6 2n - m`. This produces `(crossBall d n).card + 2 \u00b7 \u2211 m \u2208 range n, (crossBall d m).card`, matching `crossEhrhart_succ_d` exactly under the IH. All three pieces total ~90 lines.",
-      "S5 (researcher-12, 2026-05-08): `Finset.card_eq_sum_card_fiberwise` (verified at `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean:979`) needs `(s : Set \u03b9).MapsTo f t`; for the slicing application `s := crossBall (d+1) n`, `f := fun y => y (Fin.last d)`, `t := Finset.univ`, the MapsTo is trivially `Finset.mem_univ _`.",
-      "crossEhrhart_expand proved: L(B_{d+1},n) = L(B_d,n) + 2*\u03a3_k 2^k C(d,k) C(n,k+1) via Pascal split of C(d+1,k+1) and key identity 1+2*\u03a3 C(d,k+1)C(n,k+1) = \u03a3 C(d,k)C(n,k)",
-      "sum_choose_range (hockey-stick): \u03a3_{m<n} C(m,k) = C(n,k+1) proved by induction with Pascal step",
-      "sum_shift_hockey: \u03a3_k f(k)*C(n,k+1) = \u03a3_{m<n} \u03a3_k f(k)*C(m,k) via \u2190 sum_choose_range + Finset.sum_comm",
+      "S5 (researcher-12, 2026-05-08): The slicing identity `(crossBall (d+1) n).card = ∑ j : Fin (2n+1), (crossBall d M_j).card` factors through `Finset.card_eq_sum_card_fiberwise` (project via `fun y => y (Fin.last d)`) + per-fiber bijection `Fin.init`/`Fin.snoc`. M_j := if j.val ≤ n then j.val else 2n - j.val (= n - cweight(j, n)). Σ over Fin (d+1) splits via `Fin.sum_univ_castSucc`; the last summand is exactly cweight(j, n) since `y (last d) = j` is fixed inside the fiber.",
+      "S5 (researcher-12, 2026-05-08): The j↔2n-j pairing collapses cleanly: split `range (2n+1) = range n ∪ {n} ∪ Ico (n+1) (2n+1)`; the high half reverses via `Finset.sum_nbij'` with `m ↦ 2n - m`. This produces `(crossBall d n).card + 2 · ∑ m ∈ range n, (crossBall d m).card`, matching `crossEhrhart_succ_d` exactly under the IH. All three pieces total ~90 lines.",
+      "S5 (researcher-12, 2026-05-08): `Finset.card_eq_sum_card_fiberwise` (verified at `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean:979`) needs `(s : Set ι).MapsTo f t`; for the slicing application `s := crossBall (d+1) n`, `f := fun y => y (Fin.last d)`, `t := Finset.univ`, the MapsTo is trivially `Finset.mem_univ _`.",
+      "crossEhrhart_expand proved: L(B_{d+1},n) = L(B_d,n) + 2*Σ_k 2^k C(d,k) C(n,k+1) via Pascal split of C(d+1,k+1) and key identity 1+2*Σ C(d,k+1)C(n,k+1) = Σ C(d,k)C(n,k)",
+      "sum_choose_range (hockey-stick): Σ_{m<n} C(m,k) = C(n,k+1) proved by induction with Pascal step",
+      "sum_shift_hockey: Σ_k f(k)*C(n,k+1) = Σ_{m<n} Σ_k f(k)*C(m,k) via ← sum_choose_range + Finset.sum_comm",
       "crossEhrhart_succ_d: one-step from expand + hshift; proved via linarith after sum_shift_hockey",
-      "Key identity in proof: \u03a3 2^k C(d,k) C(n,k) = 1 + 2*\u03a3 2^k C(d,k+1) C(n,k+1) \u2014 proved by extracting k=0 via sum_range_succ then dropping d+1 term (C(d,d+1)=0)",
-      "Lean 4.26 notation: \u2211 x \u2208 range n not \u2211 x in range n in theorem signatures",
-      "Lean Pascal direction: rw [Nat.choose_succ_succ] not \u2190 to go C(d+1,k+1) \u2192 C(d,k)+C(d,k+1)",
-      "Lean mul_sum direction: rw [Finset.mul_sum] (forward) to expand 2*\u03a3 \u2192 \u03a3(2*...)"
+      "Key identity in proof: Σ 2^k C(d,k) C(n,k) = 1 + 2*Σ 2^k C(d,k+1) C(n,k+1) — proved by extracting k=0 via sum_range_succ then dropping d+1 term (C(d,d+1)=0)",
+      "Lean 4.26 notation: ∑ x ∈ range n not ∑ x in range n in theorem signatures",
+      "Lean Pascal direction: rw [Nat.choose_succ_succ] not ← to go C(d+1,k+1) → C(d,k)+C(d,k+1)",
+      "Lean mul_sum direction: rw [Finset.mul_sum] (forward) to expand 2*Σ → Σ(2*...)",
+      "S6 (researcher-1, 2026-05-08): Mathlib API drift since PR #16734/#17008 — origin/main no longer builds. descPochhammer is at root namespace (after `open Polynomial` in Mathlib/RingTheory/Polynomial/Pochhammer.lean), NOT inside `namespace Polynomial`. Pattern to flag in code review: any `Polynomial.descPochhammer*` reference is wrong; should be just `descPochhammer*`.",
+      "S6 (researcher-1, 2026-05-08): When using `Finset.card_bij'` with anonymous-constructor bijection lambdas like `fun y _ idx => ⟨..., by ...⟩`, give the lambda return type explicit annotation. Without it, Lean infers the lambda codomain weakly; the inner `by` block runs with no Fin-bound goal (\"No goals to be solved\" at the `have` line), and downstream `simp only [crossBall, ...]` leaves stray metavariables in the sum body (target `(∑ x, if ↑?m.56 ≤ M ...) ≤ M` with metavar shared across all three arms).",
+      "S6 (researcher-1, 2026-05-08): The proofs/.lake self-symlink trap is reproducible across worktrees: `.lake -> /Users/rwalters/GitHub/lean-genius/proofs/.lake`. `rm proofs/.lake` in the worktree before building lets Docker create a fresh `.lake` (mathlib clone ~10 min, cache get ~5 min, EhrhartCrossPolytope compile ~16s after that)."
     ],
     "mathlibGaps": [
       "(Session 2 resolved: descPochhammer + descPochhammer_eval_eq_descFactorial + Nat.descFactorial_eq_factorial_mul_choose suffice for the polynomial identification.)"
     ],
     "nextSteps": [
-      "S6 (recommended): prototype Steps A+B+C per `session-5-slicing-spec.md` \u00a74-6. Discharge the 2 mechanical `sorry`s (each \u226410 lines: cweight + \u03a3 split via `Fin.sum_univ_castSucc`, both directions). Then Docker build with `LEAN_BUILD_TIMEOUT=60m`. Estimated ~90 new lines. Requires healthy `proofs/.lake`.",
-      "S7 (post-build): once `crossBall_card` sorry eliminated, set `sorryCount: 0`, `status: verified`, `badge: original`. Update `meta.json`, `index.ts`, gallery annotations.",
-      "S8 (optional, advanced): connect `crossEhrhart d n` to the central Delannoy numbers `D(d, n) := \u2211 2^k C(d,k) C(n,k)`. Mathlib has no `Delannoy` namespace yet; could be a Mathlib upstream contribution.",
-      "(S0-S4 nextSteps complete; see git log for PRs #16339, #16734, #16842, #17008.)"
+      "S7 (recommended): Resume the slicing decomposition prototype on top of the now-buildable origin/main. Pull commit `4e9853d0510` from local branch `research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307` into a fresh worktree, run Docker build, fix surfaced Mathlib-drift issues (likely `Finset.card_eq_sum_card_fiberwise` MapsTo coercion, `Fin.snoc_last` arg order, `change`/`omega` interactions on opaque sums).",
+      "S8 (post-build): once `crossBall_card` sorry eliminated, set `sorryCount: 0`, `status: verified`, `badge: original`. Update `meta.json`, `index.ts`, gallery annotations.",
+      "S9 (optional, advanced): connect `crossEhrhart d n` to the central Delannoy numbers `D(d, n) := ∑ 2^k C(d,k) C(n,k)`. Mathlib has no `Delannoy` namespace yet; could be a Mathlib upstream contribution."
     ]
   },
   "tags": [
@@ -83,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T13:49:03.933Z",
-  "lastUpdate": "2026-05-08T09:50:00.000Z",
+  "lastUpdate": "2026-05-08T21:50:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

`Proofs.EhrhartCrossPolytope` no longer compiled on `origin/main` due to Mathlib API drift since PRs #16734 / #17008 merged unverified.  This PR restores buildability with three small, independent fixes; the `crossBall_card` succ-d sorry is unchanged.

**Build verified:** `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope` (exit 0, 1 sorry / 0 axioms / 538 lines).

## What broke

Running the Docker build on `origin/main` surfaces:

```
error: Unknown constant `Polynomial.descPochhammer`
error: Unknown constant `Polynomial.descPochhammer_succ_right`
error: ...:324:4: No goals to be solved
error: ...:392:8: No goals to be solved
error: ...:401:8: No goals to be solved
error: ...:420:6: 'show' tactic failed, pattern (∑ i, if ↑(y i) - (n - M) ≤ M then ...)
       is not definitionally equal to target (∑ x, if ↑?m.56 ≤ M then ...)
error: ...:446:6: 'show' tactic failed, pattern (∑ i, if ↑(z i) + (n - M) ≤ n then ...)
       is not definitionally equal to target (∑ x, if ↑?m.66 ≤ n then ...)
error: build failed
```

## What this PR does

Three independent fixes in `proofs/Proofs/EhrhartCrossPolytope.lean`:

1. **`descPochhammer` namespace.**  Mathlib defines `descPochhammer : ℕ → R[X]` at the root namespace (after `open Polynomial` in `Mathlib/RingTheory/Polynomial/Pochhammer.lean`), NOT inside `namespace Polynomial`.  All `Polynomial.descPochhammer` and `Polynomial.descPochhammer_succ_right` references replaced with `descPochhammer` and `descPochhammer_succ_right` (5 + 2 sites in `natDegree_descPochhammer_le`, `eval_descPochhammer_natCast`, and `crossEhrhart_is_poly`).

2. **`field_simp` already closes.**  In `crossEhrhart_is_poly`, the trailing `ring` after `field_simp [hk_ne]` is now redundant.  Removed.

3. **Explicit Fin-codomain annotations.**  In `fiber_card_eq_crossBall_card`, the Forward and Backward bijection lambdas inside `Finset.card_bij'` now carry `: Fin (2 * M + 1)` and `: Fin (2 * n + 1)` annotations.  Without them, Lean's elaborator left the Fin-bound proof obligation unmaterialized at the inner `by` block (\"No goals to be solved\" at the `have hsum` / `have hcoord` lines) and stranded a metavariable `?m.56` shared across all three arms of the post-`simp only [crossBall]` sum body, breaking the subsequent `show` tactic.

Cosmetic: `(z idx).is_lt` → `(z idx).isLt` (both still valid; new name is preferred).

## Status

**Outcome**: progress (origin/main build restored; sorry count unchanged at 1)

**Files modified**:
- `proofs/Proofs/EhrhartCrossPolytope.lean` (-21/+21 lines, net −1 from `ring` removal)
- `src/data/proofs/ehrhart-cube-proven-oq-02/meta.json` (lineCount 539 → 538)
- `src/data/research/problems/ehrhart-cube-proven-oq-02.json` (S6 progress entry)
- `research/problems/ehrhart-cube-proven-oq-02/state.md` (S6 session log)

**Sorry / axiom delta**: 0 (still 1 sorry / 0 axioms; the remaining sorry is `crossBall_card` succ-d).

**Next**: S7 should resume the slicing decomposition prototype (`session-5-slicing-spec.md`).  The local-only branch `research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307` (commit `4e9853d0510`, ~195 lines) is build-pending and will likely surface its own Mathlib-drift issues — those should be fixed in S7's PR.

🤖 Generated by researcher-1