### PR TITLE
fix(meta): batch sync lineCount drift (2 entries)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1213,
+    "lineCount": 1279,
     "theoremCount": 92,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 481,
+    "lineCount": 482,
     "theoremCount": 7,
     "definitionCount": 0,
     "assumptions": "One axiom remains (down from four). Three former measure-theory axioms are now proved or unused: `blichfeldt_proj_measurable` and `blichfeldt_disj_bound` were promoted to proved theorems in earlier sessions; `blichfeldt_volume_partition` was eliminated by replacing the manual partition-pigeonhole proof of `blichfeldt_basic` with a direct application of `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain). The single remaining axiom is `blichfeldt_general` \u2014 the general k\u22651 case via averaging the covering count function c(z) = #{v | z+v \u2208 S}; the k=1 case is fully proved without it. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`. S9 (researcher-3, 2026-05-08) added the analytic core of the covering-count argument as a new fully-proved theorem `volume_eq_setLIntegral_indicator_tsum`: \u222b\u207b x in F, (\u03a3' g, 1_s((g : \u211d\u207f) + x)) dx = vol(s), proved from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli (`lintegral_tsum`); this reduces the remaining work for `blichfeldt_general` to a self-contained combinatorial extraction step.",
@@ -168,7 +168,7 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 1,
     "sorries": 0,
-    "lineCount": 481,
+    "lineCount": 482,
     "theoremCount": 7,
     "definitionCount": 0,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields after recent research merges.

| Slug | Field | Claimed | Actual | Cause |
|---|---|---|---|---|
| `four-square-distribution-oq-01` | `meta.lineCount` | 1213 | 1279 | PR #17347 S9 (Eisenstein-coefficient work, +66) |
| `minkowski-theorem-oq-04` | `meta.lineCount` + `leanFile.lineCount` | 481 | 482 | PR #17329 S14 (ENNReal scope fix, +1) |

## Method

Surgical text-replace on `"lineCount": <claimed>,` — preserves whitespace and field ordering. JSON parses cleanly post-fix.

## Evidence

Manual drift scanner found 3 lineCount drifts gallery-wide; the third (`birthday-problem-oq-03-oq-01-oq-02`) was skipped because 3 open research PRs (#16777/#16837/#16873) are still touching its Lean file. find-targets.ts only checks True-stubs/sorry/axiom and misses lineCount drift.

Verified neither target slug has open PRs touching its Lean file.

---
Automated fix by lean-mechanic agent.