### PR TITLE
fix(meta): batch sync count drift (4 entries)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
     "lineCount": 1555,
-    "theoremCount": 48,
+    "theoremCount": 47,
     "definitionCount": 8,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,12 +142,12 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 1295,
+    "lineCount": 1555,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 41,
-    "definitionCount": 6
+    "theoremCount": 47,
+    "definitionCount": 8
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 11
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
@@ -189,7 +189,7 @@
     "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos604Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1213,
-    "theoremCount": 92,
+    "lineCount": 1279,
+    "theoremCount": 93,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 481,
+    "lineCount": 482,
     "theoremCount": 7,
     "definitionCount": 0,
     "assumptions": "One axiom remains (down from four). Three former measure-theory axioms are now proved or unused: `blichfeldt_proj_measurable` and `blichfeldt_disj_bound` were promoted to proved theorems in earlier sessions; `blichfeldt_volume_partition` was eliminated by replacing the manual partition-pigeonhole proof of `blichfeldt_basic` with a direct application of `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain). The single remaining axiom is `blichfeldt_general` \u2014 the general k\u22651 case via averaging the covering count function c(z) = #{v | z+v \u2208 S}; the k=1 case is fully proved without it. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`. S9 (researcher-3, 2026-05-08) added the analytic core of the covering-count argument as a new fully-proved theorem `volume_eq_setLIntegral_indicator_tsum`: \u222b\u207b x in F, (\u03a3' g, 1_s((g : \u211d\u207f) + x)) dx = vol(s), proved from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli (`lintegral_tsum`); this reduces the remaining work for `blichfeldt_general` to a self-contained combinatorial extraction step.",
@@ -168,7 +168,7 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 1,
     "sorries": 0,
-    "lineCount": 481,
+    "lineCount": 482,
     "theoremCount": 7,
     "definitionCount": 0,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

Surgical sync of stale `lineCount` / `theoremCount` / `definitionCount` fields after recent research/audit PRs. All values verified by manual newline-count + comment-stripped declaration-head regex matching `scripts/auditor/find-targets.ts` conventions.

## Entries

| Slug | Field | Before | After |
|------|-------|--------|-------|
| `erdos-604` | meta.definitionCount | 11 | 10 |
| `erdos-604` | leanFile.definitionCount | 11 | 10 |
| `minkowski-theorem-oq-04` | meta.lineCount | 481 | 482 |
| `minkowski-theorem-oq-04` | leanFile.lineCount | 481 | 482 |
| `birthday-problem-oq-03-oq-01-oq-02` | meta.theoremCount | 48 | 47 |
| `birthday-problem-oq-03-oq-01-oq-02` | leanFile.lineCount | 1295 | 1555 |
| `birthday-problem-oq-03-oq-01-oq-02` | leanFile.theoremCount | 41 | 47 |
| `birthday-problem-oq-03-oq-01-oq-02` | leanFile.definitionCount | 6 | 8 |
| `four-square-distribution-oq-01` | meta.lineCount | 1213 | 1279 |
| `four-square-distribution-oq-01` | meta.theoremCount | 92 | 93 |

## Notes

- `erdos-604` has a commented-out duplicate `noncomputable def maxPinnedDistances` inside a `/- ... -/` block (lines 102–113). meta was counting both copies; only one is live code.
- `birthday-problem-oq-03-oq-01-oq-02` had a meta-block update at some point but the `leanFile` sub-object was not synced (classic two-block drift).
- `four-square-distribution-oq-01` lacks a `leanFile` sub-object; only meta-block fields needed update. Drift came from S9 PR #17347 adding ~66 lines.
- `minkowski-theorem-oq-04` was off by 1 line (recent S9 edit).

## Validation

Post-fix: manual drift scanner reports **0 mismatches** across all 2401 gallery entries. \`find-targets.ts\` also reports \`0\` issues.

Diff is 10 +/- 10, format-preserving (\`Edit\` tool surgical replace).

---
🤖 Automated fix by lean-mechanic agent.