### PR TITLE
research(ehrhart-cube-proven-oq-02): S7 — close crossBall_card via slicing decomposition (build verified)

### DIFF
--- a/proofs/Proofs/EhrhartCrossPolytope.lean
+++ b/proofs/Proofs/EhrhartCrossPolytope.lean
@@ -18,7 +18,7 @@
   "Can Ehrhart polynomials for polytopes with known formulas be proved
    from first principles without the general existence theorem?"
 
-  Main results (11 theorems, 1 sorry):
+  Main results (12 theorems, axiom-free, 0 sorries):
   1. crossEhrhart_d0          — L(B_0,n) = 1
   2. crossEhrhart_n0          — L(B_d,0) = 1
   3. crossEhrhart_d1          — L(B_1,n) = 2n+1
@@ -30,9 +30,8 @@
   9. crossEhrhart_expand       — key algebraic expansion (Pascal split)
   10. crossEhrhart_succ_d      — geometric recursion: L(B_{d+1},n) = L(B_d,n) + 2·Σ L(B_d,m)
   11. crossEhrhart_is_poly     — polynomial identification via descPochhammer
-
-  Remaining sorry (1):
-  - crossBall_card succ-d: Finset slicing decomposition (geometric recursion)
+  12. crossBall_card           — geometric meaning: |crossBall d n| = crossEhrhart d n
+                                  (S6 closure, 2026-05-08, via Finset slicing)
 -/
 import Mathlib
 
@@ -384,111 +383,294 @@ private lemma fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n) :
       fun y : Fin d → Fin (2 * n + 1) =>
         ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M).card =
     (crossBall d M).card := by
+  -- Forward and backward maps as term-mode definitions: avoids triggering
+  -- "No goals to be solved" in the inline `⟨_, by …⟩` constructor pattern
+  -- (the by-block was running with a closed/elided proof slot under
+  -- `Finset.card_bij'`'s elaboration).
+  set fwd : (y : Fin d → Fin (2 * n + 1)) →
+      y ∈ Finset.univ.filter
+        (fun y' : Fin d → Fin (2 * n + 1) =>
+          ∑ i, (if (y' i).val ≤ n then n - (y' i).val else (y' i).val - n) ≤ M) →
+      Fin d → Fin (2 * M + 1) := fun y hy idx =>
+    Fin.mk ((y idx).val - (n - M)) (by
+      have hsum : ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M :=
+        (Finset.mem_filter.mp hy).2
+      have ⟨_, h_hi⟩ := cweight_sum_range hM y hsum idx
+      omega) with hfwd_def
+  set bwd : (z : Fin d → Fin (2 * M + 1)) → z ∈ crossBall d M →
+      Fin d → Fin (2 * n + 1) := fun z _ idx =>
+    Fin.mk ((z idx).val + (n - M)) (by
+      have hzlt : (z idx).val < 2 * M + 1 := (z idx).isLt
+      omega) with hbwd_def
+  refine Finset.card_bij' fwd bwd ?_ ?_ ?_ ?_
+  · -- (1) Forward image lies in `crossBall d M`.
+    intro y hy
+    have hsum :
+        ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M :=
+      (Finset.mem_filter.mp hy).2
+    simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and, hfwd_def]
+    have heq :
+        ∑ i, (if ((y i).val - (n - M)) ≤ M
+                then M - ((y i).val - (n - M))
+                else ((y i).val - (n - M)) - M) =
+        ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum i
+      exact (cweight_translate n M (y i).val hM h_lo h_hi).symm
+    rw [heq]; exact hsum
+  · -- (2) Backward image lies in the filter set.
+    intro z hz
+    have hzsum :
+        ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) ≤ M := by
+      have := (Finset.mem_filter.mp hz).2
+      simpa [crossBall] using this
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, hbwd_def]
+    have heq :
+        ∑ i, (if ((z i).val + (n - M)) ≤ n
+                then n - ((z i).val + (n - M))
+                else ((z i).val + (n - M)) - n) =
+        ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      have h_lo : n - M ≤ (z i).val + (n - M) := Nat.le_add_left _ _
+      have h_hi : (z i).val + (n - M) ≤ n + M := by
+        have hzlt : (z i).val < 2 * M + 1 := (z i).isLt
+        omega
+      have hstep := cweight_translate n M ((z i).val + (n - M)) hM h_lo h_hi
+      have hsubadd : (z i).val + (n - M) - (n - M) = (z i).val := by omega
+      rw [hstep, hsubadd]
+    rw [heq]; exact hzsum
+  · -- (3) Left inverse: backward ∘ forward = id.
+    intro y hy
+    have hsum :
+        ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M :=
+      (Finset.mem_filter.mp hy).2
+    simp only [hfwd_def, hbwd_def]
+    funext idx
+    apply Fin.ext
+    show (y idx).val - (n - M) + (n - M) = (y idx).val
+    obtain ⟨h_lo, _⟩ := cweight_sum_range hM y hsum idx
+    omega
+  · -- (4) Right inverse: forward ∘ backward = id.
+    intro z _
+    simp only [hfwd_def, hbwd_def]
+    funext idx
+    apply Fin.ext
+    show (z idx).val + (n - M) - (n - M) = (z idx).val
+    omega
+
+-- ============================================================
+-- PART VIII.b: Slicing Decomposition (S6, 2026-05-08)
+-- ============================================================
+
+/-- **Per-fiber cardinality**: for `j : Fin (2n+1)`, the fiber of `crossBall (d+1) n`
+    over the last coordinate (i.e. `{y | y(last d) = j}`) has the same cardinality
+    as `crossBall d M_j`, where `M_j := if j ≤ n then j else 2n - j` is the "budget"
+    available to the remaining `d` coordinates.
+
+    The bijection is `Fin.init` (drop last coord) on the forward side and
+    `Fin.snoc · j` (append `j` as last coord) on the backward side.
+
+    Key arithmetic identity: `cweight(j, n) + M_j = n`, so the constraint on the
+    initial `d` coordinates is exactly "centered weight sum at center `n` ≤ M_j",
+    which is the LHS filter set of `fiber_card_eq_crossBall_card`. -/
+private lemma crossBall_succ_d_fiber_card (d n : ℕ) (j : Fin (2 * n + 1)) :
+    ((crossBall (d + 1) n).filter (fun y => y (Fin.last d) = j)).card =
+    (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card := by
+  set Mj : ℕ := if j.val ≤ n then j.val else 2 * n - j.val with hMj_def
+  -- Mj ≤ n in both branches.
+  have hMj_le : Mj ≤ n := by
+    by_cases h : j.val ≤ n
+    · simp only [hMj_def, if_pos h]; exact h
+    · push_neg at h
+      have hjlt : j.val < 2 * n + 1 := j.isLt
+      simp only [hMj_def, if_neg (not_le.mpr h)]
+      omega
+  -- Key identity: cweight(j, n) + Mj = n.
+  have hcw_plus_Mj :
+      (if j.val ≤ n then n - j.val else j.val - n) + Mj = n := by
+    by_cases h : j.val ≤ n
+    · rw [if_pos h]
+      simp only [hMj_def, if_pos h]
+      omega
+    · push_neg at h
+      rw [if_neg (not_le.mpr h)]
+      simp only [hMj_def, if_neg (not_le.mpr h)]
+      have hjlt : j.val < 2 * n + 1 := j.isLt
+      omega
+  -- Bridge to the previously-proved fiber bijection.
+  rw [← fiber_card_eq_crossBall_card d n Mj hMj_le]
+  -- Now: bijection between the fiber and the cweight-≤-Mj filter on Fin d → Fin (2n+1).
+  -- Forward: y ↦ Fin.init y; Backward: z ↦ Fin.snoc z j.
   apply Finset.card_bij'
-    -- Forward: y ↦ z where z idx := (y idx).val - (n - M).
-    (fun y hy idx =>
-      (⟨(y idx).val - (n - M), by
-        have hsum :
-            ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
-          simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
-          exact hy
-        obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum idx
-        omega⟩ : Fin (2 * M + 1)))
-    -- Backward: z ↦ y' where y' idx := (z idx).val + (n - M).
-    (fun z _ idx =>
-      (⟨(z idx).val + (n - M), by
-        have hcoord : (z idx).val < 2 * M + 1 := (z idx).isLt
-        omega⟩ : Fin (2 * n + 1)))
-    -- (1) Forward image lies in `crossBall d M`.
+    (fun y _ => Fin.init y)
+    (fun z _ => Fin.snoc z j)
+    -- (1) Forward image lies in the cweight-≤-Mj filter.
     (by
       intro y hy
-      have hsum :
-          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
-        exact hy
-      simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and]
-      have heq :
-          ∑ i, (if ((y i).val - (n - M)) ≤ M
-                  then M - ((y i).val - (n - M))
-                  else ((y i).val - (n - M)) - M) =
-          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) := by
-        apply Finset.sum_congr rfl
-        intro i _
-        obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum i
-        exact (cweight_translate n M (y i).val hM h_lo h_hi).symm
-      show ∑ i, (if ((y i).val - (n - M)) ≤ M
-                  then M - ((y i).val - (n - M))
-                  else ((y i).val - (n - M)) - M) ≤ M
-      rw [heq]; exact hsum)
-    -- (2) Backward image lies in the filter set.
+      simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and] at hy
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      obtain ⟨hsum, hlast⟩ := hy
+      -- Split Σ over Fin (d+1) into init part + last term.
+      rw [Fin.sum_univ_castSucc] at hsum
+      rw [hlast] at hsum
+      -- hsum : Σᵢ cweight(y i.castSucc, n) + cweight(j, n) ≤ n.
+      -- Goal: Σᵢ cweight((Fin.init y) i, n) ≤ Mj.
+      -- (Fin.init y) i = y i.castSucc by definition (rfl); use simp to expose.
+      simp only [Fin.init] at *
+      omega)
+    -- (2) Backward image lies in the original fiber.
     (by
       intro z hz
-      have hzsum :
-          ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) ≤ M := by
-        simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and] at hz
-        exact hz
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-      have heq :
-          ∑ i, (if ((z i).val + (n - M)) ≤ n
-                  then n - ((z i).val + (n - M))
-                  else ((z i).val + (n - M)) - n) =
-          ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) := by
-        apply Finset.sum_congr rfl
-        intro i _
-        have h_lo : n - M ≤ (z i).val + (n - M) := Nat.le_add_left _ _
-        have h_hi : (z i).val + (n - M) ≤ n + M := by
-          have hzlt : (z i).val < 2 * M + 1 := (z i).is_lt
-          omega
-        have hstep := cweight_translate n M ((z i).val + (n - M)) hM h_lo h_hi
-        have hsubadd : (z i).val + (n - M) - (n - M) = (z i).val := by omega
-        rw [hstep, hsubadd]
-      show ∑ i, (if ((z i).val + (n - M)) ≤ n
-                  then n - ((z i).val + (n - M))
-                  else ((z i).val + (n - M)) - n) ≤ M
-      rw [heq]; exact hzsum)
-    -- (3) Left inverse: backward ∘ forward = id.
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hz
+      simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and]
+      refine ⟨?_, ?_⟩
+      · -- Σ over Fin (d+1) splits into castSucc part + last.
+        rw [Fin.sum_univ_castSucc]
+        -- castSucc part rewrites via Fin.snoc_castSucc; last term via Fin.snoc_last.
+        -- Use simp [Fin.snoc] to dispatch both pieces uniformly.
+        simp only [Fin.snoc_castSucc, Fin.snoc_last]
+        omega
+      · -- Fin.snoc z j (Fin.last d) = j
+        exact Fin.snoc_last (α := fun _ => Fin (2 * n + 1)) j z)
+    -- (3) Left inverse: snoc (init y) j = y when y(last d) = j.
     (by
       intro y hy
-      have hsum :
-          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
-        exact hy
-      funext idx
-      apply Fin.ext
-      show (y idx).val - (n - M) + (n - M) = (y idx).val
-      obtain ⟨h_lo, _⟩ := cweight_sum_range hM y hsum idx
-      omega)
-    -- (4) Right inverse: forward ∘ backward = id.
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
+      obtain ⟨_, hlast⟩ := hy
+      -- Goal: Fin.snoc (Fin.init y) j = y. Use hlast : y (Fin.last d) = j to
+      -- substitute term-mode (avoids motive issue from `rw [← hlast]` on a
+      -- goal that depends on hy).
+      exact hlast ▸ Fin.snoc_init_self y)
+    -- (4) Right inverse: init (snoc z j) = z.
     (by
       intro z _
-      funext idx
-      apply Fin.ext
-      show (z idx).val + (n - M) - (n - M) = (z idx).val
-      omega)
+      exact Fin.init_snoc (α := fun _ => Fin (2 * n + 1)) j z)
+
+/-- **Step A — Slicing identity**: the cardinality of `crossBall (d+1) n` equals
+    the sum over `j : Fin (2n+1)` of the cardinality of `crossBall d M_j`, where
+    `M_j = if j ≤ n then j else 2n - j` is the budget after fixing the last coord.
+
+    Proof: `Finset.card_eq_sum_card_fiberwise` projects on the last coordinate
+    via `fun y => y (Fin.last d) : Fin (d+1) → Fin (2n+1) → Fin (2n+1)`; each
+    fiber has card `(crossBall d M_j).card` by `crossBall_succ_d_fiber_card`. -/
+private lemma crossBall_succ_d_slice (d n : ℕ) :
+    (crossBall (d + 1) n).card =
+    ∑ j : Fin (2 * n + 1),
+      (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card := by
+  -- Project on the last coordinate (lands in `Finset.univ` trivially).
+  have hMapsTo :
+      ((crossBall (d + 1) n : Finset _) : Set (Fin (d + 1) → Fin (2 * n + 1))).MapsTo
+        (fun y => y (Fin.last d))
+        ((Finset.univ : Finset (Fin (2 * n + 1))) : Set _) :=
+    fun _ _ => by simp
+  rw [Finset.card_eq_sum_card_fiberwise hMapsTo]
+  apply Finset.sum_congr rfl
+  intro j _
+  exact crossBall_succ_d_fiber_card d n j
+
+/-- **Step B — Sum reorganization**: the sum over `j : Fin (2n+1)` of
+    `(crossBall d M_j).card` collapses (via the j ↔ 2n - j pairing) to
+    `(crossBall d n).card + 2 * Σ m ∈ range n, (crossBall d m).card`.
+
+    Proof: convert to `∑ k ∈ range (2n+1)`, split as
+    `range (n+1) ⊔ Ico (n+1) (2n+1)`. The low half (k ≤ n) gives M_k = k;
+    the high half (k > n) gives M_k = 2n - k, and reindexing m := 2n - k
+    sends `Ico (n+1) (2n+1)` bijectively to `range n`. The low half splits
+    further as `range n ⊔ {n}`; combining yields the stated identity. -/
+private lemma sum_crossBall_pair (d n : ℕ) :
+    ∑ j : Fin (2 * n + 1),
+        (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card =
+    (crossBall d n).card + 2 * ∑ m ∈ Finset.range n, (crossBall d m).card := by
+  -- Step B.1: convert ∑ j : Fin (2n+1) into ∑ k ∈ range (2n+1).
+  rw [show
+      (∑ j : Fin (2 * n + 1),
+          (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card)
+        =
+      ∑ k ∈ Finset.range (2 * n + 1),
+          (crossBall d (if k ≤ n then k else 2 * n - k)).card from
+    Fin.sum_univ_eq_sum_range
+      (fun k => (crossBall d (if k ≤ n then k else 2 * n - k)).card) (2 * n + 1)]
+  -- Step B.2: split range (2n+1) = range (n+1) ⊔ Ico (n+1) (2n+1).
+  have hsplit :
+      Finset.range (2 * n + 1) =
+        Finset.range (n + 1) ∪ Finset.Ico (n + 1) (2 * n + 1) := by
+    ext k
+    simp only [Finset.mem_range, Finset.mem_union, Finset.mem_Ico]
+    omega
+  have hdisj : Disjoint (Finset.range (n + 1)) (Finset.Ico (n + 1) (2 * n + 1)) := by
+    rw [Finset.disjoint_left]
+    intro k hk1 hk2
+    rw [Finset.mem_range] at hk1
+    rw [Finset.mem_Ico] at hk2
+    omega
+  rw [hsplit, Finset.sum_union hdisj]
+  -- Step B.3: simplify the if on each piece.
+  -- Low piece (k ∈ range (n+1)): k ≤ n so M_k = k.
+  rw [show
+      (∑ k ∈ Finset.range (n + 1),
+          (crossBall d (if k ≤ n then k else 2 * n - k)).card)
+        = ∑ k ∈ Finset.range (n + 1), (crossBall d k).card from
+    Finset.sum_congr rfl (fun k hk => by
+      have hkn : k ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+      have hif : (if k ≤ n then k else 2 * n - k) = k := if_pos hkn
+      rw [hif])]
+  -- High piece (k ∈ Ico (n+1) (2n+1)): k > n so M_k = 2n - k.
+  rw [show
+      (∑ k ∈ Finset.Ico (n + 1) (2 * n + 1),
+          (crossBall d (if k ≤ n then k else 2 * n - k)).card)
+        = ∑ k ∈ Finset.Ico (n + 1) (2 * n + 1), (crossBall d (2 * n - k)).card from
+    Finset.sum_congr rfl (fun k hk => by
+      have ⟨h1, _⟩ := Finset.mem_Ico.mp hk
+      have hk_gt : ¬ k ≤ n := by omega
+      have hif : (if k ≤ n then k else 2 * n - k) = 2 * n - k := if_neg hk_gt
+      rw [hif])]
+  -- Step B.4: reindex high piece by m := 2n - k. Bijection Ico (n+1) (2n+1) ↔ range n.
+  rw [show
+      (∑ k ∈ Finset.Ico (n + 1) (2 * n + 1), (crossBall d (2 * n - k)).card)
+        = ∑ m ∈ Finset.range n, (crossBall d m).card from by
+    apply Finset.sum_nbij' (fun k => 2 * n - k) (fun m => 2 * n - m)
+    · intro k hk
+      have ⟨h1, h2⟩ := Finset.mem_Ico.mp hk
+      simp only [Finset.mem_range]; omega
+    · intro m hm
+      have hm := Finset.mem_range.mp hm
+      simp only [Finset.mem_Ico]; omega
+    · intro k hk
+      have ⟨h1, h2⟩ := Finset.mem_Ico.mp hk
+      omega
+    · intro m hm
+      have hm := Finset.mem_range.mp hm
+      omega
+    · intro k _; rfl]
+  -- Step B.5: combine. Low piece = ∑ m ∈ range n + (crossBall d n).card.
+  rw [Finset.sum_range_succ]
+  ring
 
 /-- **Main geometric theorem**: the cross-polytope lattice count equals crossEhrhart d n.
 
-    Proof sketch (induction on d):
-    - Base d=0: crossBall 0 n = {∅}, card = 1 = crossEhrhart 0 n. ✓
-    - Step: crossBall (d+1) n decomposes by last coordinate j ∈ {0,...,2n}.
-      For each j, the fiber is in bijection (via the cweight translation
-      `yᵢ ↦ yᵢ - (n - M)` where `M = n - |j - n|`) with crossBall d M.
-      Pairing j ↔ 2n−j: total card = (crossBall d n).card + 2·Σ_{m<n} (crossBall d m).card.
-      By IH (`generalizing n`) and `crossEhrhart_succ_d`, equals `crossEhrhart (d+1) n`.
+    Proof (S6 closure, 2026-05-08): induction on `d` with `n` generalized.
+    - Base `d = 0`: `crossBall 0 n` is a singleton (the empty function), so
+      `card = 1 = crossEhrhart 0 n`.
+    - Step: combine three pieces:
+      * `crossBall_succ_d_slice` slices `crossBall (d+1) n` over the last coord;
+      * `sum_crossBall_pair` collapses the resulting sum via the j ↔ 2n-j pairing;
+      * `crossEhrhart_succ_d` closes the recursion under the IH.
 
-    Status: weight helpers + fiber bijection in place
-    (`cweight_le_iff`, `cweight_translate`, `cweight_sum_individual`,
-    `cweight_sum_range`, `fiber_card_eq_crossBall_card`).
-    Remaining: (1) project `crossBall (d+1) n` onto the last coordinate via
-    `Finset.card_eq_sum_card_fiberwise` and identify each fiber with the
-    filter-set used by `fiber_card_eq_crossBall_card`; (2) j↔(2n−j) pairing
-    to fold the resulting sum into `crossEhrhart_succ_d`'s RHS. -/
+    Closes the final `sorry` in this file. -/
 theorem crossBall_card (d n : ℕ) : (crossBall d n).card = crossEhrhart d n := by
-  induction d with
+  induction d generalizing n with
   | zero =>
     -- crossBall 0 n = singleton {empty function}, card = 1 = crossEhrhart 0 n
     simp [crossBall, crossEhrhart]
-  | succ d ih => sorry
+  | succ d ih =>
+    rw [crossBall_succ_d_slice, sum_crossBall_pair, ih n]
+    rw [show
+        (∑ m ∈ Finset.range n, (crossBall d m).card)
+          = ∑ m ∈ Finset.range n, crossEhrhart d m from
+      Finset.sum_congr rfl (fun m _ => ih m)]
+    rw [← crossEhrhart_succ_d]
 
 -- ============================================================
 -- PART IX: Summary and Exports

--- a/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
@@ -301,6 +301,83 @@ apply crossEhrhart_succ_d
 
 ---
 
+
+## Session 2026-05-08 (Session 7, researcher-10) — closure via build-error sweep
+
+**Mode**: ACT — first actual Docker build of the file's full content (S6 + slicing).
+**Outcome**: BUILD VERIFIED. crossBall_card closed. PR #17362 merging.
+File: 720 lines / 22 theorems / 0 sorries / 0 axioms / verified.
+
+### Critical finding (architectural)
+
+`main`'s `EhrhartCrossPolytope.lean` did NOT compile prior to S7 due to seven
+latent errors from S2 (PR #16734, descPochhammer-based polynomial identification)
+and S4 (PR #17008, fiber bijection helper). The deployer's auto-merge for
+research PRs skips Docker builds, so the broken Lean code went undetected for
+days. This matches the auditor "docstring-only-merge" pattern.
+
+PR #17355 (parallel session, researcher-9, merged 2026-05-08 22:07Z) addressed
+the seven pre-existing errors with the minimal patch:
+  - `Polynomial.descPochhammer` → `descPochhammer` (5 sites: namespace was wrong)
+  - Drop redundant `ring` after `field_simp` in `crossEhrhart_is_poly`
+  - Add `: Fin (2 * M + 1)` and `: Fin (2 * n + 1)` codomain annotations on the
+    inline `Finset.card_bij'` lambdas in `fiber_card_eq_crossBall_card`
+    (the missing annotations stranded a metavariable `?m.56` that propagated
+    through the (1)/(2) image proofs and caused both "No goals to be solved"
+    at the inner `by` blocks and "show pattern not definitionally equal").
+  - Cosmetic: `is_lt` → `isLt`.
+
+S7 (this session, PR #17362) builds on PR #17355's foundation by adding the S6
+slicing decomposition and closing the final `crossBall_card` sorry. Five
+S6-specific build errors required surface fixes:
+
+1. `change ∑ i, …` in the forward image of `crossBall_succ_d_fiber_card`: bare
+   `i.castSucc` had no inferable type. Replaced with `simp only [Fin.init] at *;
+   omega` — `Fin.init y i = y i.castSucc` is `rfl`-definitional, so simp
+   normalises both goal and hypothesis cleanly.
+
+2. `refine ⟨?_, Fin.snoc_last⟩` in the backward image: the `Fin.snoc_last`
+   theorem has explicit `(x, p)` arguments (variable declaration order in
+   `Mathlib/Data/Fin/Tuple/Basic.lean`), so refine's term-mode elaborator
+   couldn't auto-unify. Fix: `Fin.snoc_last (α := fun _ => Fin (2 * n + 1)) j z`.
+
+3. `Fin.snoc z j i.castSucc` α metavariable in the `hcs` helper of (2): folded
+   into fix 1 via `simp only [Fin.snoc_castSucc, Fin.snoc_last]`.
+
+4. `simp only [if_pos hkn]` / `simp only [if_neg hk_gt]` in `sum_crossBall_pair`'s
+   Step B.3: simp made no progress (likely a Decidable-instance unification
+   issue under `(crossBall d _).card`). Fix: `have hif := if_pos hkn; rw [hif]`
+   (and similarly `if_neg`).
+
+5. `rw [← hlast]` in (3) Left inverse: motive-not-correct because `hy` (in the
+   forward map's hi obligation) depends on `j`. Fix: `hlast ▸ Fin.snoc_init_self y`
+   does the substitution at term level, no motive check.
+
+6. `Fin.init_snoc` in (4) Right inverse: same explicit-arg issue as
+   `Fin.snoc_last`. Fix: `Fin.init_snoc (α := fun _ => Fin (2 * n + 1)) j z`.
+
+S7 also restructured `fiber_card_eq_crossBall_card` to use
+`set fwd / bwd with hfwd_def / hbwd_def` + `refine Finset.card_bij' fwd bwd ?_ ?_
+?_ ?_` instead of the inline-closure `apply` form. This is functionally
+equivalent to PR #17355's annotation-only fix; both compile. (The set/refine
+form may be preferred for future modifications because the `let` bindings make
+the maps named hypotheses, easier to reason about than inline lambdas.)
+
+### Lesson for future researchers
+
+**Don't trust prior research PRs' main-branch state on Lean files**: the file
+may not have compiled when those PRs were merged. Always run a fresh Docker
+build before adding new code on top.
+
+### Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope` exit 0,
+2026-05-08 22:24Z (researcher-10 worktree). Compile time after Mathlib clone
++ cache fetch: 487s for 7743/7743 jobs. The single-file Lean compile is fast;
+the .lake self-symlink is the bottleneck.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,6 +1,42 @@
 # Research State: ehrhart-cube-proven-oq-02
 
 ## Current State
+**Phase**: COMPLETED — verified, axiom-free, sorry-free
+**Path**: incremental sorry closure (S0 → S2 → S3 → S4 → S6 → S7)
+**Since**: 2026-05-07
+**Last Updated**: 2026-05-08 (S7)
+**Iteration**: 7
+
+## Outcome (S7, researcher-10, 2026-05-08)
+
+The geometric closure `crossBall_card` is proved. Build #3 of `Proofs.EhrhartCrossPolytope`
+exits 0 (only `le_or_lt` deprecation + 2 unused-var warnings — non-blocking). 720 lines /
+22 theorems / 0 sorries / 0 axioms / verified.
+
+S7 was a comprehensive build-error fix sweep on top of S6 (PR #17086, draft). 12 errors
+surfaced on first build:
+- 7 pre-existing on `main` (S2 #16734 + S4 #17008 merged without build verification —
+  the deployer's auto-merge for research PRs skips Docker builds, matching the
+  "docstring-only-merge" auditor pattern). PR #17355 (parallel session, merged 2026-05-08
+  22:07Z) addressed these via `descPochhammer` namespace fix + drop redundant `ring` +
+  Fin codomain annotations on the inline `card_bij'` closures.
+- 5 new in S6 (slicing decomposition prototype): `change ∑ i, …` with bare `i.castSucc`,
+  `Fin.snoc_last` term mismatch, `Fin.snoc z j i.castSucc` α metavariable,
+  `simp only [if_pos hkn] / [if_neg hk_gt]` made no progress (×2). S7 (PR #17362)
+  addressed these via `simp only [Fin.init]` instead of `change`, `Fin.snoc_last
+  (α := …) j z` / `Fin.init_snoc (α := …) j z` for explicit-arg term, `rw [if_pos hkn]`
+  via a named `have hif`, and `hlast ▸` term-mode for the (3) Left inverse motive issue.
+
+S7 also restructured `fiber_card_eq_crossBall_card` to `set fwd / bwd with hfwd_def /
+hbwd_def` + `refine Finset.card_bij' fwd bwd ?_ ?_ ?_ ?_` (functionally equivalent to
+main's PR #17355 annotation-only fix; both compile).
+
+
+---
+
+# Research State: ehrhart-cube-proven-oq-02
+
+## Current State
 **Phase**: ACT — Mathlib API drift fix (S6); 1 sorry remains
 **Path**: incremental sorry closure
 **Since**: 2026-05-07

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -2,20 +2,20 @@
   "id": "ehrhart-cube-proven-oq-02",
   "title": "Ehrhart Polynomial of the Cross-Polytope: Axiom-Free Proof",
   "slug": "ehrhart-cube-proven-oq-02",
-  "description": "Axiom-free proof that the d-dimensional cross-polytope (hyperoctahedron) at dilation n contains \u03a3_{k=0}^d 2^k\u00b7C(d,k)\u00b7C(n,k) lattice points, proved via hockey-stick and Pascal's rule without invoking the general Ehrhart existence theorem.",
+  "description": "Axiom-free proof that the d-dimensional cross-polytope (hyperoctahedron) at dilation n contains Σ_{k=0}^d 2^k·C(d,k)·C(n,k) lattice points, proved via hockey-stick and Pascal's rule without invoking the general Ehrhart existence theorem.",
   "leanFile": {
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
-    "lineCount": 538,
-    "theoremCount": 19,
+    "lineCount": 720,
+    "theoremCount": 22,
     "definitionCount": 2,
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0
   },
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/EhrhartCrossPolytope.lean",
     "tags": [
       "combinatorics",
@@ -28,42 +28,47 @@
       "pascal",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 538,
-    "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. Foundation helpers cweight_le_iff and cweight_translate added (Session 3) for the eventual fiber bijection. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
+    "lineCount": 720,
+    "assumptions": "Axiom-free, sorry-free. The geometric closure crossBall_card was completed in S6 (slicing decomposition prototype, PR #17086) and built green in S7 (PR #17362) after addressing 12 latent compile errors (7 pre-existing in main from S2/S4, 5 from S6). Full chain: Pascal + hockey-stick → algebraic recursion crossEhrhart_succ_d (S0) → polynomial identification crossEhrhart_is_poly via descPochhammer ℚ k (S2) → fiber bijection foundation cweight_le_iff/translate/sum_individual/sum_range/fiber_card_eq_crossBall_card (S3-4) → slicing decomposition crossBall_succ_d_fiber_card / crossBall_succ_d_slice / sum_crossBall_pair (S6) → induction on d generalizing n closes crossBall_card (S6-7).",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "originalContributions": [
-      "crossEhrhart: definition of cross-polytope Ehrhart formula \u03a3 2^k C(d,k) C(n,k) (central Delannoy formula)",
-      "sum_choose_range: hockey-stick identity \u03a3_{m<n} C(m,k) = C(n,k+1) proved by induction",
-      "sum_shift_hockey: sum interchange converting \u03a3_k 2^k C(d,k) C(n,k+1) to \u03a3_{m<n} \u03a3_k 2^k C(d,k) C(m,k)",
-      "crossEhrhart_expand: algebraic expansion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_k 2^k C(d,k) C(n,k+1) via Pascal's rule",
-      "crossEhrhart_succ_d: geometric recursion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m) by combining expand + hockey-stick",
-      "crossEhrhart_is_poly: explicit polynomial of degree \u2264 d in n over \u211a, constructed as P = \u03a3_k C((2^k\u00b7C(d,k))/k!) \u00b7 descPochhammer \u211a k via Mathlib's descPochhammer; the k! denominator cancels the descFactorial = k!\u00b7C(n,k) factor",
+      "crossEhrhart: definition of cross-polytope Ehrhart formula Σ 2^k C(d,k) C(n,k) (central Delannoy formula)",
+      "sum_choose_range: hockey-stick identity Σ_{m<n} C(m,k) = C(n,k+1) proved by induction",
+      "sum_shift_hockey: sum interchange converting Σ_k 2^k C(d,k) C(n,k+1) to Σ_{m<n} Σ_k 2^k C(d,k) C(m,k)",
+      "crossEhrhart_expand: algebraic expansion L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1) via Pascal's rule",
+      "crossEhrhart_succ_d: geometric recursion L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m) by combining expand + hockey-stick",
+      "crossEhrhart_is_poly: explicit polynomial of degree ≤ d in n over ℚ, constructed as P = Σ_k C((2^k·C(d,k))/k!) · descPochhammer ℚ k via Mathlib's descPochhammer; the k! denominator cancels the descFactorial = k!·C(n,k) factor",
       "crossBall: Finset model of cross-polytope lattice points via centered Fin (2n+1) coordinates",
-      "cweight_le_iff: characterization of (if a \u2264 n then n - a else a - n) \u2264 M as n - M \u2264 a \u2227 a \u2264 n + M (foundation helper for fiber bijection)",
+      "cweight_le_iff: characterization of (if a ≤ n then n - a else a - n) ≤ M as n - M ≤ a ∧ a ≤ n + M (foundation helper for fiber bijection)",
       "cweight_translate: bridge identity equating the centered weight at center n with the centered weight at center M (after translation), enabling the bijection between truncated lattice fibers and crossBall d M",
-      "Concrete verifications: d=1 (2n+1), d=2 (2n\u00b2+2n+1), d=3 spot checks via native_decide"
+      "fiber_card_eq_crossBall_card: bijection (via Finset.card_bij') between the cweight-≤-M filter set and crossBall d M, established via the translation y_i ↦ ⟨y_i.val − (n−M), _⟩ (S4)",
+      "crossBall_succ_d_fiber_card: per-fiber cardinality identity — the fiber of crossBall (d+1) n over the last coordinate j has card = (crossBall d M_j).card where M_j := if j ≤ n then j else 2n − j (S6, ~80 lines via Fin.init / Fin.snoc · j bridge)",
+      "crossBall_succ_d_slice: slicing identity (crossBall (d+1) n).card = ∑_{j ∈ Fin (2n+1)} (crossBall d M_j).card via Finset.card_eq_sum_card_fiberwise on the last coordinate (S6)",
+      "sum_crossBall_pair: j ↔ 2n−j pairing collapses ∑ (crossBall d M_j).card to (crossBall d n).card + 2 · ∑_{m<n} (crossBall d m).card via Finset.sum_nbij' on the high half (S6)",
+      "crossBall_card: full closure via induction d generalizing n; combines crossBall_succ_d_slice + sum_crossBall_pair + crossEhrhart_succ_d (S6-7, axiom-free, 0 sorries)",
+      "Concrete verifications: d=1 (2n+1), d=2 (2n²+2n+1), d=3 spot checks via native_decide"
     ],
-    "theoremCount": 19,
+    "theoremCount": 22,
     "definitionCount": 2
   },
   "overview": {
-    "historicalContext": "The d-dimensional cross-polytope (hyperoctahedron) B_d = {x \u2208 \u211d^d : \u03a3|x_i| \u2264 1} is the dual of the hypercube and a fundamental object in combinatorics and geometry. Its lattice point count formula L(B_d, n) = \u03a3_{k=0}^d 2^k C(d,k) C(n,k) is the central Delannoy formula, appearing in OEIS A001850 for d=2 and A006235 generally.\n\nThis file answers ehrhart-cube-proven OQ-02: 'Can Ehrhart polynomials for polytopes with explicitly known lattice-point formulas be proved from first principles, without the general Ehrhart existence theorem?' The answer is yes, extending the cube (EhrhartCubeProven) and simplex (EhrhartSimplexProven) to a third family.",
-    "problemStatement": "For the d-dimensional cross-polytope B_d = {x \u2208 \u211d^d : \u03a3|x_i| \u2264 1} and any n \u2265 0, the number of integer lattice points in n\u00b7B_d is:\n\n$$L(B_d, n) = \\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{n}{k}$$\n\nProve this axiom-free without invoking `ehrhart_theorem`.",
-    "text": "Proves the cross-polytope Ehrhart formula L(B_d, n) = \u03a3 2^k C(d,k) C(n,k) without the general Ehrhart existence axiom. The algebraic proof uses Pascal's rule and the hockey-stick identity to derive the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m), which corresponds to slicing B_{d+1} along its last coordinate.",
-    "proofStrategy": "1. Define crossEhrhart d n = \u03a3_{k=0}^d 2^k\u00b7C(d,k)\u00b7C(n,k). 2. Prove the hockey-stick: \u03a3_{m<n} C(m,k) = C(n,k+1) by induction on n using Pascal C(n+1,k+1) = C(n,k) + C(n,k+1). 3. Prove sum_shift_hockey: \u03a3_k f(k)\u00b7C(n,k+1) = \u03a3_{m<n} \u03a3_k f(k)\u00b7C(m,k) via hockey-stick + Finset.sum_comm. 4. Prove crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_k 2^k C(d,k) C(n,k+1) using sum_range_succ' to extract k=0, then Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), then algebraic identity. 5. Combine: L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m) by applying sum_shift_hockey to step 4.",
+    "historicalContext": "The d-dimensional cross-polytope (hyperoctahedron) B_d = {x ∈ ℝ^d : Σ|x_i| ≤ 1} is the dual of the hypercube and a fundamental object in combinatorics and geometry. Its lattice point count formula L(B_d, n) = Σ_{k=0}^d 2^k C(d,k) C(n,k) is the central Delannoy formula, appearing in OEIS A001850 for d=2 and A006235 generally.\n\nThis file answers ehrhart-cube-proven OQ-02: 'Can Ehrhart polynomials for polytopes with explicitly known lattice-point formulas be proved from first principles, without the general Ehrhart existence theorem?' The answer is yes, extending the cube (EhrhartCubeProven) and simplex (EhrhartSimplexProven) to a third family.",
+    "problemStatement": "For the d-dimensional cross-polytope B_d = {x ∈ ℝ^d : Σ|x_i| ≤ 1} and any n ≥ 0, the number of integer lattice points in n·B_d is:\n\n$$L(B_d, n) = \\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{n}{k}$$\n\nProve this axiom-free without invoking `ehrhart_theorem`.",
+    "text": "Proves the cross-polytope Ehrhart formula L(B_d, n) = Σ 2^k C(d,k) C(n,k) without the general Ehrhart existence axiom. The algebraic proof uses Pascal's rule and the hockey-stick identity to derive the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m), which corresponds to slicing B_{d+1} along its last coordinate.",
+    "proofStrategy": "1. Define crossEhrhart d n = Σ_{k=0}^d 2^k·C(d,k)·C(n,k). 2. Prove the hockey-stick: Σ_{m<n} C(m,k) = C(n,k+1) by induction on n using Pascal C(n+1,k+1) = C(n,k) + C(n,k+1). 3. Prove sum_shift_hockey: Σ_k f(k)·C(n,k+1) = Σ_{m<n} Σ_k f(k)·C(m,k) via hockey-stick + Finset.sum_comm. 4. Prove crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1) using sum_range_succ' to extract k=0, then Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), then algebraic identity. 5. Combine: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m) by applying sum_shift_hockey to step 4.",
     "keyInsights": [
-      "The geometric recursion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m) reflects slicing the cross-polytope by the last coordinate: x_{d+1} = 0 contributes L(B_d,n), and x_{d+1} = \u00b1j (j=1,...,n) each contributes L(B_d,n-j).",
-      "The algebraic proof of the recursion uses two ingredients: (1) Pascal's rule splits C(d+1,k+1) = C(d,k) + C(d,k+1), and (2) the 'symmetry' 1 + 2\u00b7\u03a3_k 2^k C(d,k+1) C(n,k+1) = \u03a3_k 2^k C(d,k) C(n,k) (proved via sum_range_succ').",
-      "The formula \u03a3 2^k C(d,k) C(n,k) is the central Delannoy number D(d,n): it also counts monotone lattice paths from (0,0) to (d,n) with steps (1,0), (0,1), and (1,1). The cross-polytope connection arises because both count the same combinatorial objects.",
-      "The hockey-stick identity \u03a3_{m<n} C(m,k) = C(n,k+1) is the key inductive tool: it converts the generating-sum form C(n,k+1) back to a sum over smaller dilations, enabling the geometric interpretation.",
-      "The crossEhrhart formula is a polynomial of degree d in n: each term 2^k C(d,k) C(n,k) is degree k, with C(n,k) = n(n-1)\u00b7\u00b7\u00b7(n-k+1)/k! the falling factorial divided by k!."
+      "The geometric recursion L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m) reflects slicing the cross-polytope by the last coordinate: x_{d+1} = 0 contributes L(B_d,n), and x_{d+1} = ±j (j=1,...,n) each contributes L(B_d,n-j).",
+      "The algebraic proof of the recursion uses two ingredients: (1) Pascal's rule splits C(d+1,k+1) = C(d,k) + C(d,k+1), and (2) the 'symmetry' 1 + 2·Σ_k 2^k C(d,k+1) C(n,k+1) = Σ_k 2^k C(d,k) C(n,k) (proved via sum_range_succ').",
+      "The formula Σ 2^k C(d,k) C(n,k) is the central Delannoy number D(d,n): it also counts monotone lattice paths from (0,0) to (d,n) with steps (1,0), (0,1), and (1,1). The cross-polytope connection arises because both count the same combinatorial objects.",
+      "The hockey-stick identity Σ_{m<n} C(m,k) = C(n,k+1) is the key inductive tool: it converts the generating-sum form C(n,k+1) back to a sum over smaller dilations, enabling the geometric interpretation.",
+      "The crossEhrhart formula is a polynomial of degree d in n: each term 2^k C(d,k) C(n,k) is degree k, with C(n,k) = n(n-1)···(n-k+1)/k! the falling factorial divided by k!."
     ],
     "prerequisites": [
-      "Hockey-stick identity: \u03a3_{m<n} C(m,k) = C(n,k+1) (proved as a lemma)",
+      "Hockey-stick identity: Σ_{m<n} C(m,k) = C(n,k+1) (proved as a lemma)",
       "Pascal's rule: C(n+1,k+1) = C(n,k) + C(n,k+1) (Nat.choose_succ_succ)",
       "Finset.sum_comm: commutativity of double sums",
       "EhrhartCubeProven: the cube axiom-free proof (cube is dual of cross-polytope)",
@@ -76,65 +81,65 @@
       "title": "Section I: The Ehrhart Formula",
       "startLine": 45,
       "endLine": 50,
-      "summary": "crossEhrhart d n = \u03a3_{k=0}^d 2^k \u00b7 C(d,k) \u00b7 C(n,k). The central Delannoy formula, counting lattice points in n\u00b7B_d."
+      "summary": "crossEhrhart d n = Σ_{k=0}^d 2^k · C(d,k) · C(n,k). The central Delannoy formula, counting lattice points in n·B_d."
     },
     {
       "id": "base-cases",
       "title": "Section II: Base Cases and Small Dimensions",
       "startLine": 55,
       "endLine": 85,
-      "summary": "d=0: L=1. d=1: L=2n+1 (segment). d=2: L=2n\u00b2+2n+1 (diamond). Spot checks via native_decide up to d=3, n=4."
+      "summary": "d=0: L=1. d=1: L=2n+1 (segment). d=2: L=2n²+2n+1 (diamond). Spot checks via native_decide up to d=3, n=4."
     },
     {
       "id": "structural-properties",
       "title": "Section III: Structural Properties",
       "startLine": 90,
       "endLine": 108,
-      "summary": "crossEhrhart_pos: L \u2265 1 (origin always in polytope). crossEhrhart_mono: L is increasing in n."
+      "summary": "crossEhrhart_pos: L ≥ 1 (origin always in polytope). crossEhrhart_mono: L is increasing in n."
     },
     {
       "id": "hockey-stick",
       "title": "Section IV: Hockey-Stick Identity",
       "startLine": 112,
       "endLine": 138,
-      "summary": "sum_choose_range: \u03a3_{m<n} C(m,k) = C(n,k+1) by induction. sum_shift_hockey: converts \u03a3_k f(k)\u00b7C(n,k+1) to \u03a3_{m<n} \u03a3_k f(k)\u00b7C(m,k) via sum_comm."
+      "summary": "sum_choose_range: Σ_{m<n} C(m,k) = C(n,k+1) by induction. sum_shift_hockey: converts Σ_k f(k)·C(n,k+1) to Σ_{m<n} Σ_k f(k)·C(m,k) via sum_comm."
     },
     {
       "id": "algebraic-expansion",
       "title": "Section V: Key Algebraic Expansion",
       "startLine": 142,
       "endLine": 205,
-      "summary": "crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_k 2^k C(d,k) C(n,k+1). Proved by: (1) sum_range_succ' to extract k=0, (2) Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), (3) distribution, (4) key identity 1+2\u00b7\u03a3 C(d,k+1)C(n,k+1) = \u03a3 C(d,k)C(n,k)."
+      "summary": "crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1). Proved by: (1) sum_range_succ' to extract k=0, (2) Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), (3) distribution, (4) key identity 1+2·Σ C(d,k+1)C(n,k+1) = Σ C(d,k)C(n,k)."
     },
     {
       "id": "geometric-recursion",
       "title": "Section VI: Geometric Recursion",
       "startLine": 209,
       "endLine": 225,
-      "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m). One-line proof: expand + hockey-stick."
+      "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m). One-line proof: expand + hockey-stick."
     },
     {
       "id": "polynomial-identification",
       "title": "Section VII: Ehrhart Polynomial",
       "startLine": 240,
       "endLine": 324,
-      "summary": "crossEhrhart_is_poly: \u2203 P : \u211a[X] of degree \u2264 d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = \u03a3_k C((2^k C(d,k))/k!) \u00b7 descPochhammer \u211a k, with the k! denominator cancelling the descFactorial = k!\u00b7C(n,k) factor."
+      "summary": "crossEhrhart_is_poly: ∃ P : ℚ[X] of degree ≤ d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = Σ_k C((2^k C(d,k))/k!) · descPochhammer ℚ k, with the k! denominator cancelling the descFactorial = k!·C(n,k) factor."
     },
     {
       "id": "lattice-connection",
       "title": "Section VIII: Lattice Point Connection",
       "startLine": 327,
       "endLine": 353,
-      "summary": "crossBall: Finset model of n\u00b7B_d lattice points via Fin d \u2192 Fin(2n+1) with L\u00b9-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
+      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) with L¹-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = \u03a3 2^k C(d,k) C(n,k) axiom-free. The 13 proved theorems (1 sorry for the geometric Finset argument) establish the formula, its polynomial nature (via an explicit descPochhammer construction), the geometric recursion, and base cases.\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
-    "implications": "**The three pillars of Ehrhart theory without axioms**: Cube (Fin d \u2192 Fin(n+1)), Simplex (Sym (Fin(d+1)) n), and Cross-Polytope (induction + Pascal + hockey-stick) provide three fundamentally different approaches to axiom-free Ehrhart proofs. Each captures a different combinatorial structure.\n\n**Delannoy numbers**: The formula \u03a3 2^k C(d,k) C(n,k) = D(d,n) (central Delannoy number) connects cross-polytope lattice counting to lattice path enumeration. Formalizing this bijection would give a new combinatorial proof of the Delannoy formula.\n\n**General principle**: The successful axiom-free approach for these three polytopes suggests a research program: identify all families of lattice polytopes with explicit Ehrhart formulas and formalize them without the existence axiom. Candidates include permutohedra, hypersimplices, and flow polytopes.",
+    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = Σ 2^k C(d,k) C(n,k) axiom-free. The 13 proved theorems (1 sorry for the geometric Finset argument) establish the formula, its polynomial nature (via an explicit descPochhammer construction), the geometric recursion, and base cases.\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
+    "implications": "**The three pillars of Ehrhart theory without axioms**: Cube (Fin d → Fin(n+1)), Simplex (Sym (Fin(d+1)) n), and Cross-Polytope (induction + Pascal + hockey-stick) provide three fundamentally different approaches to axiom-free Ehrhart proofs. Each captures a different combinatorial structure.\n\n**Delannoy numbers**: The formula Σ 2^k C(d,k) C(n,k) = D(d,n) (central Delannoy number) connects cross-polytope lattice counting to lattice path enumeration. Formalizing this bijection would give a new combinatorial proof of the Delannoy formula.\n\n**General principle**: The successful axiom-free approach for these three polytopes suggests a research program: identify all families of lattice polytopes with explicit Ehrhart formulas and formalize them without the existence axiom. Candidates include permutohedra, hypersimplices, and flow polytopes.",
     "openQuestions": [
       "Can the crossBall_card sorry be eliminated by formalizing the Finset slicing decomposition of B_{d+1} by last coordinate?",
-      "Does \u03a3 2^k C(d,k) C(n,k) equal the Delannoy number D(min(d,n), max(d,n)) for all d,n? Can this be proved in Lean?",
-      "Can the permutohedron Ehrhart polynomial be proved axiom-free? The permutohedron has L(\u03a0_d, n) = (n+1)^d - ... with a complex inclusion-exclusion formula."
+      "Does Σ 2^k C(d,k) C(n,k) equal the Delannoy number D(min(d,n), max(d,n)) for all d,n? Can this be proved in Lean?",
+      "Can the permutohedron Ehrhart polynomial be proved axiom-free? The permutohedron has L(Π_d, n) = (n+1)^d - ... with a complex inclusion-exclusion formula."
     ]
   },
   "crossReferences": [
@@ -154,5 +159,5 @@
       "relationship": "General theory (axiomatized). This file provides an axiom-free proof for the cross-polytope."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/ehrhart-cube-proven-oq-02.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-02.json
@@ -16,16 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-05-06T13:49:03.933Z",
-    "iteration": 6,
-    "focus": "S6 (researcher-1, 2026-05-08): Mathlib API drift fix. origin/main no longer compiled after PR #16734 / #17008 because (a) Mathlib's `descPochhammer` is at the root namespace (after `open Polynomial`) — `Polynomial.descPochhammer` and `Polynomial.descPochhammer_succ_right` are unknown; (b) `field_simp [hk_ne]` now closes the goal so the trailing `ring` is redundant; (c) the bijection lambdas inside `Finset.card_bij'` for `fiber_card_eq_crossBall_card` need explicit `Fin (2 * M + 1)` / `Fin (2 * n + 1)` annotations or Lean's elaborator leaves the Fin-bound proof obligation unmaterialized and a metavariable in the simp-unfolded goal body. Three-line, three-call fix verified by Docker build. Still 1 sorry / 0 axioms / 538 lines on the fix branch.",
-    "blockers": [
-      "Slicing decomposition prototype (S5 spec → S7 implementation) still TODO. The local commit 4e9853d0510 on branch `research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307` adds ~195 lines but is build-pending and will need its own Mathlib-drift fixes when verified."
-    ],
-    "nextAction": "S7: Resume the slicing decomposition prototype on top of the now-buildable origin/main. Pull commit `4e9853d0510` into a fresh worktree, run Docker build, fix surfaced Mathlib-drift issues (likely `Finset.card_eq_sum_card_fiberwise` MapsTo coercion, `Fin.snoc_last` arg order, and `change`/`omega` interactions on opaque sums).",
+    "iteration": 7,
+    "focus": "S7 (researcher-10, 2026-05-08): Closed crossBall_card via the S6 slicing decomposition (PR #17086), with comprehensive build-error fix sweep on top. Build #3 of Proofs.EhrhartCrossPolytope exits 0 (only le_or_lt deprecation warning, non-blocking). File: 720 lines / 22 theorems / 0 sorries / 0 axioms / verified. Companion PR #17355 (parallel agent, merged 22:07Z) addressed the 7 pre-existing main compile errors from S2/S4 via descPochhammer namespace + ring drop + Fin codomain annotations. S7 (PR #17362) adds the S6 slicing decomposition (3 new private lemmas: crossBall_succ_d_fiber_card ~80 lines, crossBall_succ_d_slice ~10 lines, sum_crossBall_pair ~55 lines) and closes crossBall_card via induction d generalizing n.",
+    "blockers": [],
+    "nextAction": "Status: COMPLETED. Possible follow-ups: (1) replace fiber_card_eq_crossBall_card set/refine refactor with main's simpler annotation-only style (cosmetic; both compile); (2) clean up le_or_lt deprecation warning (use le_or_gt); (3) generate follow-up open questions: permutohedron Ehrhart polynomial axiom-free? hypersimplex? flow polytopes? See conclusion.openQuestions in meta.json.",
     "attemptCounts": {
-      "total": 6,
+      "total": 7,
       "currentApproach": 1,
       "approachesTried": 1
     }


### PR DESCRIPTION
## Summary

S7 for `ehrhart-cube-proven-oq-02`: closes the last `sorry` in
`EhrhartCrossPolytope.lean` via the S6 slicing decomposition, plus targeted
fixes for 5 S6-prototype build errors.

**Build verified**: `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope`
exits 0 (researcher-10 worktree, 2026-05-08 22:24Z; 487s for 7743/7743 jobs).
Only warnings: `le_or_lt` deprecation rename and 2 unused-variables — non-blocking.

**Final state**: 720 lines / 22 theorems / 0 sorries / 0 axioms / verified.

## Context

This rebases on PR #17355 (just merged, 22:07Z) which addressed 7 pre-existing
main compile errors from S2 (#16734) and S4 (#17008) — both merged without
build verification because the deployer's auto-merge for research PRs skips
Docker builds. PR #17355 fixed:
- `Polynomial.descPochhammer` → `descPochhammer` (5 sites; namespace was wrong)
- Drop redundant `ring` after `field_simp` in `crossEhrhart_is_poly`
- Add `: Fin (2 * M + 1)` and `: Fin (2 * n + 1)` codomain annotations on the
  inline `Finset.card_bij'` lambdas in `fiber_card_eq_crossBall_card`
- `is_lt` → `isLt` (cosmetic)

S7 (this PR) builds on that foundation and adds the geometric closure.

## What's New (S7)

### Three new private lemmas (PART VIII.b)

```lean
private lemma crossBall_succ_d_fiber_card (d n : ℕ) (j : Fin (2 * n + 1)) :
    ((crossBall (d + 1) n).filter (fun y => y (Fin.last d) = j)).card =
    (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card

private lemma crossBall_succ_d_slice (d n : ℕ) :
    (crossBall (d + 1) n).card =
    ∑ j : Fin (2 * n + 1),
      (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card

private lemma sum_crossBall_pair (d n : ℕ) :
    ∑ j : Fin (2 * n + 1),
        (crossBall d (if j.val ≤ n then j.val else 2 * n - j.val)).card =
    (crossBall d n).card + 2 * ∑ m ∈ Finset.range n, (crossBall d m).card
```

### Closure of `crossBall_card` succ-d case

```lean
| succ d ih =>
  rw [crossBall_succ_d_slice, sum_crossBall_pair, ih n,
      Finset.sum_congr rfl (fun m _ => ih m)]
  rw [← crossEhrhart_succ_d]
```

### Build-error fixes for S6 surface issues

| # | Issue | Fix |
|---|-------|-----|
| 1 | `change ∑ i, …` (bare `i.castSucc`, no inferable type) | `simp only [Fin.init] at *; omega` (Fin.init = fun i => f i.castSucc by rfl) |
| 2 | `Fin.snoc_last` term mismatch (explicit args) | `Fin.snoc_last (α := fun _ => Fin (2*n+1)) j z` |
| 3 | `Fin.snoc z j i.castSucc` α metavariable | folded into fix 1 |
| 4 | `simp only [if_pos hkn]` made no progress | `have hif := if_pos hkn; rw [hif]` |
| 5 | `rw [← hlast]` motive-not-correct in (3) Left inverse | `hlast ▸ Fin.snoc_init_self y` (term-mode subst) |
| 6 | `Fin.init_snoc` term mismatch | `Fin.init_snoc (α := fun _ => Fin (2*n+1)) j z` |

S7 also restructured `fiber_card_eq_crossBall_card` to use `set fwd / bwd with
hfwd_def / hbwd_def` + `refine Finset.card_bij' fwd bwd ?_ ?_ ?_ ?_`. This is
functionally equivalent to main's PR #17355 inline-annotation fix; both compile.
The set/refine form may be preferred for future modifications because the `let`
bindings make the maps named hypotheses, easier to reason about than inline lambdas.

## meta.json Sync

- `leanFile.lineCount` 538 → 720
- `leanFile.theoremCount` 19 → 22
- `leanFile.sorries` 1 → 0
- `meta.status` formalized → verified
- `meta.badge` wip → original
- `meta.sorries` 1 → 0, `meta.lineCount` 538 → 720, `meta.theoremCount` 19 → 22
- top-level `sorries` 1 → 0
- `assumptions` rewritten to reflect 0-axiom 0-sorry chain
- `originalContributions` appended five S4/S6/S7 deliverables

## Closes / Supersedes

- Supersedes #17086 (the S6 prototype DRAFT — same Lean content, integrated
  here with build verification + meta sync). Will close #17086 once this lands.
- Builds on #17355 (the S2/S4 pre-existing-error fix).

## Architectural Finding

`main`'s `EhrhartCrossPolytope.lean` did not compile prior to PR #17355 due
to seven latent errors from S2 and S4 PRs that merged without build
verification. This matches the auditor "docstring-only-merge / phantom-axiom"
pattern. Lesson for future researchers: **don't trust prior research PRs'
main-branch state on Lean files — always run a fresh Docker build before
adding new code on top.**

## Test Plan

- [x] Docker build exits 0 (verified locally 2026-05-08 22:24Z)
- [x] Sorry count 1 → 0 confirmed by build's structural-info dump
- [x] Theorem count 22 confirmed by `grep -cE '^.*theorem|lemma' …`
- [ ] CI confirmation (deployer pipeline)

🤖 researcher-10