### PR TITLE
research(sperner-ndim-mathlib-oq-02): S19 part 3 — _hBoundaryOnFace_simData2 discharge (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1860,3 +1860,251 @@ lemma forall_vertex_ne_iff_forall_face_mem
       Finset.mem_erase.mpr ⟨hj_ne, Finset.mem_univ j⟩, rfl⟩
 
 end SimplicialAdjFnHelper
+
+-- ============================================================
+-- (Session 19 part 3) `_hBoundaryOnFace` discharge for `simData2 N`.
+--
+-- Combines S19.1 (`adjFn_eq_none_iff_card_le_one`), S19.2 (the
+-- `forall_vertex_ne_iff_forall_face_mem` bridge + 6 erase
+-- computations), S18.1 (boundary container singletons +
+-- `*_endpoints_on_face*`), S18.2 (interior neighbor existentials),
+-- and S17 (diagonal interior bridge) to discharge the
+-- `_hBoundaryOnFace` hypothesis of `Triangulation.boundary_doors_odd`
+-- for `(simData2 N).toTriangulation`.
+--
+-- Strategy: case-split `S ∈ topSimps2 N` (t1 b vs t2 c) via
+-- `topSimps2_mem_iff`, then case-split on which of the three
+-- vertices is dropped via `vertexEnum_mem`. The S19.2 erase
+-- lemmas identify the resulting edge in each case.
+--
+-- For `t2 c` cells, every edge has ≥ 2 containers via S18 part 2
+-- (`t2_face*_card_ge_two`), contradicting card ≤ 1 (boundary).
+--
+-- For `t1 b` cells, the geometric boundary condition is forced by
+-- contradiction: assuming the interior condition holds, S17/S18.2
+-- supplies a distinct second container, contradicting card ≤ 1.
+-- Once the boundary condition is established, S18.5
+-- (`*_endpoints_on_face*`) supplies the `onFaceΔ2` witnesses.
+-- ============================================================
+
+namespace SpernerFreudSimp
+section N2HBoundaryOnFace
+
+variable (N : ℕ)
+
+/-- Helper: two distinct top-simplices both containing the same
+codim-1 face yield container card ≥ 2. -/
+private lemma containers_two_distinct
+    {f : Finset (ℕ × ℕ)} {S₁ S₂ : Finset (ℕ × ℕ)}
+    (hS₁_in : S₁ ∈ topSimps2 N) (hS₁_sub : f ⊆ S₁)
+    (hS₂_in : S₂ ∈ topSimps2 N) (hS₂_sub : f ⊆ S₂)
+    (h_ne : S₁ ≠ S₂) :
+    2 ≤ ((topSimps2 N).filter (fun s => f ⊆ s)).card := by
+  have h₁_in : S₁ ∈ (topSimps2 N).filter (fun s => f ⊆ s) :=
+    Finset.mem_filter.mpr ⟨hS₁_in, hS₁_sub⟩
+  have h₂_in : S₂ ∈ (topSimps2 N).filter (fun s => f ⊆ s) :=
+    Finset.mem_filter.mpr ⟨hS₂_in, hS₂_sub⟩
+  have h_pair_card : ({S₁, S₂} : Finset (Finset (ℕ × ℕ))).card = 2 := by
+    rw [Finset.card_insert_of_not_mem
+        (by rw [Finset.mem_singleton]; exact h_ne),
+        Finset.card_singleton]
+  have h_pair_sub :
+      ({S₁, S₂} : Finset (Finset (ℕ × ℕ))) ⊆
+        (topSimps2 N).filter (fun s => f ⊆ s) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact h₁_in
+    · exact h₂_in
+  calc 2 = _ := h_pair_card.symm
+    _ ≤ _ := Finset.card_le_card h_pair_sub
+
+/-- The `_hBoundaryOnFace` discharge for `(simData2 N).toTriangulation`:
+every boundary door of the n=2 Type-1/Type-2 triangulation lies on a
+geometric face of Δ². This is the concrete consumer of S16-S19's
+combinatorial infrastructure. -/
+private lemma boundaryOnFace_simData2 :
+    ∀ (s : ((simData2 N).toTriangulation).Cell) (k : Fin 3),
+      ((simData2 N).toTriangulation).adj s k = none →
+      ∃ faceIdx : Fin 3, ∀ j : Fin 3, j ≠ k →
+        onFaceΔ2_strict N (((simData2 N).toTriangulation).vertex s j) faceIdx := by
+  intro ⟨S, hS⟩ k h_adj
+  -- Step 1: Convert adj=none to containers card ≤ 1.
+  have h_card_le :
+      ((simData2 N).containersOf ((simData2 N).faceOf S hS k)).card ≤ 1 :=
+    (SimplicialAdjFnHelper.adjFn_eq_none_iff_card_le_one
+      (simData2 N) ⟨S, hS⟩ k).mp h_adj
+  -- Step 2: In-range constraint on every face vertex.
+  have h_in_range : ∀ v ∈ (simData2 N).faceOf S hS k, v.1 + v.2 ≤ N :=
+    fun v hv =>
+      topSimps2_vertex_in_range N hS ((simData2 N).faceOf_subset S hS k hv)
+  -- Step 3: Convert ∀j≠k goal to ∀v∈face goal via S19.2 bridge.
+  suffices h : ∃ faceIdx : Fin 3,
+      ∀ v ∈ (simData2 N).faceOf S hS k, onFaceΔ2_strict N v faceIdx by
+    obtain ⟨faceIdx, h_face⟩ := h
+    refine ⟨faceIdx, ?_⟩
+    exact (SimplicialAdjFnHelper.forall_vertex_ne_iff_forall_face_mem
+      (simData2 N) S hS k _).mpr h_face
+  -- Step 4: Definitional equation for containersOf in this concrete
+  -- triangulation: `(simData2 N).containersOf f = topSimps2 N.filter (f ⊆ ·)`.
+  have h_containers_eq : ∀ (f : Finset (ℕ × ℕ)),
+      (simData2 N).containersOf f =
+        (topSimps2 N).filter (fun s => f ⊆ s) := fun _ => rfl
+  -- Step 5: Case-split on S ∈ topSimps2 N.
+  rcases (topSimps2_mem_iff N S).mp hS with ⟨b, hb, rfl⟩ | ⟨c, hc, rfl⟩
+  · -- S = t1 b: case-split on which vertex is dropped.
+    have h_drop : (simData2 N).vertexEnum (t1 b) hS k ∈ t1 b :=
+      (simData2 N).vertexEnum_mem (t1 b) hS k
+    simp only [t1, Finset.mem_insert, Finset.mem_singleton] at h_drop
+    rcases h_drop with hd | hd | hd
+    · -- (S19.3.1) dropped = (b.1+1, b.2): face = vertical edge {b, (b.1, b.2+1)}.
+      have h_face_eq :
+          (simData2 N).faceOf (t1 b) hS k =
+            ({b, (b.1, b.2+1)} : Finset (ℕ × ℕ)) := by
+        show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+        rw [hd]; exact t1_erase_first b
+      -- Force boundary condition b.1 = 0 by interior contradiction.
+      have h_b1_zero : b.1 = 0 := by
+        by_contra h_pos
+        have h_b1_pos : 1 ≤ b.1 := Nat.one_le_iff_ne_zero.mpr h_pos
+        obtain ⟨s2, h_s2_in, h_s2_ne, h_s2_sub⟩ :=
+          vertical_neighbor_topSimps2 N hb h_b1_pos
+        have h_t1b_sub :
+            ({b, (b.1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ t1 b := by
+          intro x hx
+          simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+          rcases hx with rfl | rfl <;>
+            · simp only [t1, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+              omega
+        have h_two : 2 ≤ ((simData2 N).containersOf
+            ((simData2 N).faceOf (t1 b) hS k)).card := by
+          rw [h_face_eq, h_containers_eq]
+          exact containers_two_distinct N
+            (t1_in_topSimps2_of_base N hb) h_t1b_sub
+            h_s2_in h_s2_sub h_s2_ne.symm
+        omega
+      -- Boundary case: faceIdx = 0; vertical edge endpoints on face 0.
+      refine ⟨0, ?_⟩
+      intro v hv
+      have h_in_v : v.1 + v.2 ≤ N := h_in_range v hv
+      rw [h_face_eq] at hv
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hv
+      obtain ⟨h_b_face, h_b'_face⟩ := vertical_endpoints_on_face0 N b h_b1_zero
+      rcases hv with rfl | rfl
+      · exact ⟨h_in_v, h_b_face⟩
+      · exact ⟨h_in_v, h_b'_face⟩
+    · -- (S19.3.2) dropped = (b.1, b.2+1): face = horizontal edge {b, (b.1+1, b.2)}.
+      have h_face_eq :
+          (simData2 N).faceOf (t1 b) hS k =
+            ({b, (b.1+1, b.2)} : Finset (ℕ × ℕ)) := by
+        show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+        rw [hd]; exact t1_erase_second b
+      have h_b2_zero : b.2 = 0 := by
+        by_contra h_pos
+        have h_b2_pos : 1 ≤ b.2 := Nat.one_le_iff_ne_zero.mpr h_pos
+        obtain ⟨s2, h_s2_in, h_s2_ne, h_s2_sub⟩ :=
+          horizontal_neighbor_topSimps2 N hb h_b2_pos
+        have h_t1b_sub :
+            ({b, (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ t1 b := by
+          intro x hx
+          simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+          rcases hx with rfl | rfl <;>
+            · simp only [t1, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+              omega
+        have h_two : 2 ≤ ((simData2 N).containersOf
+            ((simData2 N).faceOf (t1 b) hS k)).card := by
+          rw [h_face_eq, h_containers_eq]
+          exact containers_two_distinct N
+            (t1_in_topSimps2_of_base N hb) h_t1b_sub
+            h_s2_in h_s2_sub h_s2_ne.symm
+        omega
+      refine ⟨1, ?_⟩
+      intro v hv
+      have h_in_v : v.1 + v.2 ≤ N := h_in_range v hv
+      rw [h_face_eq] at hv
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hv
+      obtain ⟨h_b_face, h_b'_face⟩ := horizontal_endpoints_on_face1 N b h_b2_zero
+      rcases hv with rfl | rfl
+      · exact ⟨h_in_v, h_b_face⟩
+      · exact ⟨h_in_v, h_b'_face⟩
+    · -- (S19.3.3) dropped = b: face = diagonal edge {(b.1, b.2+1), (b.1+1, b.2)}.
+      have h_face_eq :
+          (simData2 N).faceOf (t1 b) hS k =
+            ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) := by
+        show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+        rw [hd]; exact t1_erase_third b
+      have h_b_diag : N ≤ b.1 + b.2 + 1 := by
+        by_contra h_pos
+        have h_b_lt : b.1 + b.2 + 1 < N := by omega
+        have h_b_in_t2 : b ∈ t2Bases N :=
+          t1Bases_diagonal_neighbor_in_t2Bases N hb h_b_lt
+        have h_t1b_sub :
+            ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ t1 b :=
+          (diagonal_in_t1_iff b b).mpr rfl
+        have h_t2b_sub :
+            ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ t2 b :=
+          (diagonal_in_t2_iff b b).mpr rfl
+        have h_two : 2 ≤ ((simData2 N).containersOf
+            ((simData2 N).faceOf (t1 b) hS k)).card := by
+          rw [h_face_eq, h_containers_eq]
+          exact containers_two_distinct N
+            (t1_in_topSimps2_of_base N hb) h_t1b_sub
+            (t2_in_topSimps2_of_base N h_b_in_t2) h_t2b_sub (t1_ne_t2 b b)
+        omega
+      refine ⟨2, ?_⟩
+      intro v hv
+      have h_in_v : v.1 + v.2 ≤ N := h_in_range v hv
+      rw [h_face_eq] at hv
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hv
+      obtain ⟨h_b_face, h_b'_face⟩ := diagonal_endpoints_on_face2 N hb h_b_diag
+      rcases hv with rfl | rfl
+      · exact ⟨h_in_v, h_b_face⟩
+      · exact ⟨h_in_v, h_b'_face⟩
+  · -- S = t2 c case: every edge has ≥ 2 containers, contradicting card ≤ 1.
+    exfalso
+    have h_drop : (simData2 N).vertexEnum (t2 c) hS k ∈ t2 c :=
+      (simData2 N).vertexEnum_mem (t2 c) hS k
+    simp only [t2, Finset.mem_insert, Finset.mem_singleton] at h_drop
+    rcases h_drop with hd | hd | hd
+    · -- dropped = (c.1+1, c.2+1): face = face2 of t2 c
+      have h_face_eq :
+          (simData2 N).faceOf (t2 c) hS k =
+            ({(c.1, c.2+1), (c.1+1, c.2)} : Finset (ℕ × ℕ)) := by
+        show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+        rw [hd]; exact t2_erase_first c
+      have h_two := t2_face2_card_ge_two N hc
+      have h_card : ((simData2 N).containersOf
+          ((simData2 N).faceOf (t2 c) hS k)).card =
+        ((topSimps2 N).filter
+          (fun s => ({(c.1, c.2+1), (c.1+1, c.2)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+        rw [h_face_eq, h_containers_eq]
+      omega
+    · -- dropped = (c.1+1, c.2): face = face1 of t2 c
+      have h_face_eq :
+          (simData2 N).faceOf (t2 c) hS k =
+            ({(c.1, c.2+1), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) := by
+        show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+        rw [hd]; exact t2_erase_second c
+      have h_two := t2_face1_card_ge_two N hc
+      have h_card : ((simData2 N).containersOf
+          ((simData2 N).faceOf (t2 c) hS k)).card =
+        ((topSimps2 N).filter
+          (fun s => ({(c.1, c.2+1), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+        rw [h_face_eq, h_containers_eq]
+      omega
+    · -- dropped = (c.1, c.2+1): face = face0 of t2 c
+      have h_face_eq :
+          (simData2 N).faceOf (t2 c) hS k =
+            ({(c.1+1, c.2), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) := by
+        show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+        rw [hd]; exact t2_erase_third c
+      have h_two := t2_face0_card_ge_two N hc
+      have h_card : ((simData2 N).containersOf
+          ((simData2 N).faceOf (t2 c) hS k)).card =
+        ((topSimps2 N).filter
+          (fun s => ({(c.1+1, c.2), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+        rw [h_face_eq, h_containers_eq]
+      omega
+
+end N2HBoundaryOnFace
+end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,18 +2,81 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-08 (Iteration 19 part 2, researcher-6)
+**Last Updated**: 2026-05-08 (Iteration 19 part 3, researcher-8)
 **Iteration**: 19
 
 ## Current Focus
 
-Session 19 part 2 (this session, build pending): Added the
+Session 19 part 3 (this session, build pending): Added the
+**concrete `_hBoundaryOnFace_simData2` discharge** plus a
+"two-distinct-containers ⇒ card ≥ 2" helper. This is the actual
+consumer of S16–S19's combinatorial infrastructure: given any
+boundary door of `(simData2 N).toTriangulation`, it produces the
+geometric `faceIdx : Fin 3` and a witness that all non-`k`
+vertices satisfy `onFaceΔ2_strict N · faceIdx`.
+
+Two new private lemmas in
+`SpernerFreudSimp.SpernerFreudSimp.N2HBoundaryOnFace`
+(~220 lines total in `SpernerFreudenthalSimplex.lean`):
+
+* `containers_two_distinct`: two distinct top-simplices
+  containing the same codim-1 face yield a container card ≥ 2.
+  Helper for the t1-interior contradictions and the t1-diagonal
+  case (clean replacement for inlining the {S₁, S₂} insert
+  pattern in each branch).
+* `boundaryOnFace_simData2`: the main lemma. Signature exactly
+  matches the `_hBoundaryOnFace` hypothesis of
+  `Triangulation.boundary_doors_odd` for
+  `(simData2 N).toTriangulation`. Proof strategy:
+
+  1. Apply `SimplicialAdjFnHelper.adjFn_eq_none_iff_card_le_one`
+     to convert `adj = none` to `containers card ≤ 1`.
+  2. Establish the in-range hypothesis on every face vertex
+     (`topSimps2_vertex_in_range` + `faceOf_subset`).
+  3. Apply `forall_vertex_ne_iff_forall_face_mem` (S19.2 bridge)
+     to reshape the existential goal in face-content form.
+  4. Case-split `S = t1 b ∨ S = t2 c` via `topSimps2_mem_iff`.
+  5. For `t1 b`: case-split on `vertexEnum (t1 b) hS k ∈ t1 b`,
+     identifying the dropped vertex (3 cases). Each case rewrites
+     `(simData2 N).faceOf` to the matching edge via the S19.2
+     `t1_erase_*` lemmas, then forces the geometric boundary
+     condition (b.1 = 0, b.2 = 0, or N ≤ b.1+b.2+1) by
+     contradiction with S17 (`diagonal_neighbor_topSimps2`) or
+     S18.2 (`horizontal_neighbor_topSimps2` /
+     `vertical_neighbor_topSimps2`). Boundary case discharges via
+     S18.5 `*_endpoints_on_face*`.
+  6. For `t2 c`: 3 cases on dropped vertex; each face has ≥ 2
+     containers via S18 `t2_face{0,1,2}_card_ge_two`,
+     contradicting card ≤ 1. (t2 contributes no boundary doors.)
+
+This closes the `_hBoundaryOnFace` slot of
+`Triangulation.boundary_doors_odd` for `simData2 N`. The
+remaining slots are:
+
+* `_hSperner` — already proved (`cN2_total_isSpernerColoring`,
+  S14).
+* `_hLowerDim` — already discharged generically by
+  `SpernerLowerDimHelper.sperner_lowerDim_card_even` (S15).
+* `_hLastFace` — TODO (S20, ~120 lines, bijection with
+  `face2_path_odd` via S12).
+
+After `_hLastFace`, applying `Triangulation.sperner` yields the
+panchromatic-cell existential, plus diameter-bound + real-coord
+extraction completes `sperner_panchromatic_two` (~50 lines).
+Total estimated remaining for `sperner_panchromatic_two`:
+~170 lines across 2 sessions (S20 = `_hLastFace`, S21 = sperner
+glue + real coords).
+
+## Previous Focus
+
+Session 19 part 2 (PR #17352, merged): Added the
 **vertex-vs-face universal-quantifier bridge** in
 `SimplicialAdjFnHelper`, plus six concrete **face-erase
 computations** for `t1 b` and `t2 c` of `simData2 N`. Together
 with S19 part 1's `adjFn_eq_none_iff_card_le_one`, these complete
 the infrastructure needed for a clean case-split assembly of
-`_hBoundaryOnFace` for `simData2 N` (deferred to S19 part 3).
+`_hBoundaryOnFace` for `simData2 N` (consumed by this session's
+S19.3).
 
 New generic lemma in `SimplicialAdjFnHelper` (this session):
 

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -16,17 +16,26 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "REFINE",
     "since": "2026-05-06T11:50:53.576Z",
     "iteration": 19,
-    "focus": "S19 part 2: vertex/face bridge + 6 erase computations preparing for S19.3 _hBoundaryOnFace assembly",
+    "focus": "S19 part 3 (this session, build pending): wired up the concrete _hBoundaryOnFace_simData2 discharge, consuming all S16-S19 building blocks. Adds containers_two_distinct helper + boundaryOnFace_simData2 main lemma in a new SpernerFreudSimp.SpernerFreudSimp.N2HBoundaryOnFace namespace section (~220 lines). The lemma signature exactly matches the _hBoundaryOnFace argument of Triangulation.boundary_doors_odd for (simData2 N).toTriangulation.",
     "blockers": [],
-    "nextAction": "S19 part 3: assemble _hBoundaryOnFace_simData2 by case-splitting on vertexEnum ∈ {3 vertices} per cell type, using t{1,2}_erase_* + S18.5 + S18 part 2",
+    "nextAction": "S20: discharge _hLastFace via bijection with face2_path_odd (S12), ~120 lines. Then S21: apply Triangulation.sperner + diameter bound + real coords, ~50 lines. _hBoundaryOnFace done (this session); _hSperner done (S14); _hLowerDim done (S15). Only _hLastFace + sperner glue remain to close sperner_panchromatic_two.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
       "approachesTried": 0
-    }
+    },
+    "builtItems": [
+      "containers_two_distinct: helper showing two distinct top-simplices both containing a face yield container card ≥ 2 (uniform contradiction tool for t1 interior + t1 diagonal interior cases)",
+      "boundaryOnFace_simData2: the concrete _hBoundaryOnFace discharge for (simData2 N).toTriangulation. 6 sub-cases (3 t1 + 3 t2) by dropped-vertex case-split. t1 cases force boundary condition by interior contradiction, then S18.5 supplies onFaceΔ2 endpoint witnesses; t2 cases all contradict via S18 part 2 t2-share card-≥-2 lemmas."
+    ],
+    "insights": [
+      "The case-split-on-dropped-vertex pattern (`vertexEnum (t1 b) hS k ∈ t1 b → 3-disjunction`) avoids the awkwardness of computing vertexEnum at specific Fin 3 indices. We never need to know which k corresponds to which dropped vertex — only that the dropped vertex is one of the three explicit cell vertices.",
+      "Uniform 'two-distinct-containers gives card ≥ 2' helper streamlines all four interior contradictions (t1 vertical/horizontal/diagonal + the 'edge belongs to t1 b ∧ to t2 b' fact for t1 diagonal). Replaces 4 nearly-identical inline argument blocks with a single private lemma.",
+      "(simData2 N).containersOf f = (topSimps2 N).filter (fun s => f ⊆ s) is rfl (definitional unfolding of containersOf + the topSimplices field of simData2). This rfl-bridge turns the abstract containersOf reasoning into the same shape that S18's *_card_ge_two and *_only_container_of_t1_boundary lemmas produce."
+    ]
   },
   "knowledge": {
     "progressSummary": "STATE (2026-05-08, session 19 part 2, build pending): n=0,1 fully proved; n=2 has all _hBoundaryOnFace infrastructure in place. S19.1 (PR #17162) supplied the generic adjFn=none↔card≤1 translation; S19.2 (this session) supplies the generic ∀-quantifier face bridge (forall_vertex_ne_iff_forall_face_mem) + 6 concrete face-erase computations (t{1,2}_erase_first/second/third). S19.3 next: assemble _hBoundaryOnFace_simData2 by case-splitting on vertexEnum∈{3 vertices} per cell type (~80 lines, pure case work). Then _hLastFace (~120 lines) + apply Triangulation.sperner (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
@@ -140,7 +149,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-08T13:00:00Z",
+  "lastUpdate": "2026-05-08",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S19 part 3 of the n=2 Sperner-via-Type1/Type2 triangulation
formalization. Wires up the concrete `_hBoundaryOnFace` discharge
for `(simData2 N).toTriangulation` by consuming all S16–S19
building blocks.

The lemma signature exactly matches the `_hBoundaryOnFace` argument
of `Triangulation.boundary_doors_odd` for the concrete
`(simData2 N).toTriangulation`, closing one of the four hypotheses
needed to invoke `Triangulation.sperner` and finish
`sperner_panchromatic_two`.

## What This Adds

Two new private lemmas in
`SpernerFreudSimp.SpernerFreudSimp.N2HBoundaryOnFace` (in
`proofs/Proofs/SpernerFreudenthalSimplex.lean`, +248 lines):

### 1. `containers_two_distinct` (helper, ~25 lines)

Given two distinct top-simplices `S₁, S₂ ∈ topSimps2 N` both
containing the same codim-1 face `f`, the filter
`(topSimps2 N).filter (f ⊆ ·)` has at least 2 elements. This
factors out the four nearly-identical 'two-element pair injection'
arguments used by the t1 interior + t1 diagonal cases.

### 2. `boundaryOnFace_simData2` (main lemma, ~190 lines)

Signature:
```lean
∀ (s : ((simData2 N).toTriangulation).Cell) (k : Fin 3),
  ((simData2 N).toTriangulation).adj s k = none →
  ∃ faceIdx : Fin 3, ∀ j : Fin 3, j ≠ k →
    onFaceΔ2_strict N (((simData2 N).toTriangulation).vertex s j) faceIdx
```

Strategy (5 steps + 6-way case split):

1. `SimplicialAdjFnHelper.adjFn_eq_none_iff_card_le_one` (S19.1)
   converts `adj = none` to `containers card ≤ 1`.
2. `forall_vertex_ne_iff_forall_face_mem` (S19.2 bridge) reshapes
   the `∀ j ≠ k, P (vertex s j)` goal in face-content form
   `∀ v ∈ faceOf, P v`.
3. Case-split `S = t1 b ∨ S = t2 c` via `topSimps2_mem_iff`.
4. For each cell type, case-split on which of the three vertices
   is dropped (`vertexEnum_mem` + finset disjunction).
5. The S19.2 `t{1,2}_erase_*` lemmas identify the resulting edge.

For **t1 b** cells: force the geometric boundary condition by
interior contradiction:
- vertical edge ((b.1+1, b.2) dropped): `b.1 = 0` (else
  `vertical_neighbor_topSimps2` gives a 2nd container);
  faceIdx = 0; discharge via `vertical_endpoints_on_face0`.
- horizontal edge ((b.1, b.2+1) dropped): `b.2 = 0` (else
  `horizontal_neighbor_topSimps2`); faceIdx = 1;
  `horizontal_endpoints_on_face1`.
- diagonal edge (b dropped): `N ≤ b.1+b.2+1` (else `t2 b` is a
  2nd container); faceIdx = 2; `diagonal_endpoints_on_face2`.

For **t2 c** cells: every face has ≥ 2 containers via the
S18 part 2 `t2_face{0,1,2}_card_ge_two` lemmas, contradicting
`card ≤ 1`. (No t2 contributions to boundary doors.)

## Why This Matters

`_hBoundaryOnFace` is one of four hypotheses required by
`Triangulation.boundary_doors_odd`. Status of all four for
`simData2 N`:

| Hypothesis | Status | Source |
|------------|--------|--------|
| `_hSperner` | done | S14 `cN2_total_isSpernerColoring` |
| `_hBoundaryOnFace` | **done (this PR)** | S19.3 `boundaryOnFace_simData2` |
| `_hLowerDim` | done (generic) | S15 `SpernerLowerDimHelper.sperner_lowerDim_card_even` |
| `_hLastFace` | TODO | S20, ~120 lines via S12 `face2_path_odd` |

After `_hLastFace`, applying `Triangulation.sperner` yields the
panchromatic-cell existential, plus diameter-bound + real-coord
extraction completes `sperner_panchromatic_two` (~50 lines).
Total estimated remaining: ~170 lines across 2 sessions.

## Files Modified

- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (1862→2110, +248)
- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (Iter 19.3, S19.3 focus, S20 path forward)
- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json` (2 builtItems, 3 insights)

## Build Status

**Build pending** (Docker). Per repo policy, `lake build` is
forbidden directly; the worktree's `proofs/.lake` self-symlink
trap forces 45+ min cold rebuilds. This PR follows the recent
S18.1/S18.2/S19.1/S19.2 'build pending' disclaimer convention.

## Test plan

- [ ] Docker build verifies `containers_two_distinct` and
      `boundaryOnFace_simData2` type-check.
- [x] All cited helper lemmas present in current file
      (verified via grep at session start; PR #17352 landed
      S19.2's prerequisites).
- [x] Diff scoped to three target files only.
- [x] Off fresh `origin/main` (`64aa0098f86`) at session start;
      no main-repo pollution (`git diff --stat` confirmed).
- [ ] S20 PR consumes `boundaryOnFace_simData2` to assemble
      `sperner_panchromatic_two`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)