### PR TITLE
fix(meta): erdos-643 definitionCount 16 → 20 (revert under-count from #17335)

### DIFF
--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "theoremCount": 39,
-    "definitionCount": 16
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
@@ -191,7 +191,7 @@
     "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 39,
-    "definitionCount": 16,
+    "definitionCount": 20,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Restores `erdos-643` `definitionCount` to **20** after PR #17335 under-counted by missing `partial def` declarations.

The previous mechanic's regex required `def`/`noncomputable def`/`opaque def` at line start, but did NOT include `partial` as an allowed modifier prefix. This caused 4 `partial def` declarations (Mathlib `generalizeProofs` elaboration helpers at lines 112, 186, 208, 270) to be silently dropped.

## Evidence

`proofs/Proofs/Erdos643Problem.lean` contains **20** top-level `def`-like declarations after stripping line and block comments:

| Kind | Count | Lines |
|------|-------|-------|
| plain `def` | 13 | 100, 316, 334, 341, 351, 536, 579, 832, 841, 844, 847, 1291, 1306 |
| `partial def` | 4 | 112, 186, 208, 270 |
| `noncomputable def` | 2 | 320, 359 |
| `abbrev` | 1 | 313 |
| **Total** | **20** | |

None lie inside block comments (verified by depth-tracking single-pass scanner that handles nested `/-` `-/` and `--` line comments correctly).

PR #17335 set this to 16, exactly equal to 20 − 4 (the missed `partial def` count). This is the canonical undercount-by-modifier-prefix anti-pattern noted in `feedback_mechanic_def_counting.md` and `feedback_auditor_simp_attribute_theorems.md`.

## Diff

```diff
-    "definitionCount": 16
+    "definitionCount": 20
   },                          # meta sub-object
...
-    "definitionCount": 16,
+    "definitionCount": 20,    # leanFile sub-object
```

Surgical 4-line diff (2 deletions, 2 insertions). Format-preserving. JSON parses cleanly.

## Other count fields verified

| Field         | Claimed | Actual | Status |
|---------------|---------|--------|--------|
| `lineCount`   | 1402    | 1402   | ✓      |
| `theoremCount`| 39      | 39     | ✓      |
| `axiomCount`  | 3       | 3      | ✓      |
| `sorries`     | 1       | 1      | ✓      |
| `definitionCount` | **16** → **20** | 20 | ❌ → fixed |

---
Automated fix by lean-mechanic agent.