### PR TITLE
research(amgm-inequality-oq-04-oq-02): S6 — K-side chain-rule infrastructure for dK/dk (build pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -562,4 +562,136 @@ lemma dIntegrandE_abs_le_bound
   · apply Real.sqrt_le_sqrt
     nlinarith [hsin2_nn, hκ]
 
+-- ============================================================================
+-- § 10. Partial Derivative ∂_k F_K and Chain-Rule Infrastructure for `dK_dk`
+-- (K-side analog of §8; mirrors §8's `dIntegrandE` work for the K-integrand.)
+-- ============================================================================
+
+/-
+The Whittaker–Watson §22.41 Wronskian proof of Legendre's relation needs
+both `dE/dk = (E − K)/k` and `dK/dk = (E − (1−k²)K) / (k(1−k²))`. §8 set
+up the chain-rule + algebraic-split + integral-identity infrastructure
+for the E side. This section provides the **chain-rule infrastructure**
+for the K side — the K-analog of §8's `dIntegrandE`,
+`dIntegrandE_continuous`, `dIntegrandE_integrable`,
+`integrandE_hasDerivAt_in_k`.
+
+Specifically:
+
+1. `dIntegrandK k θ := k sin²θ / [(1 − k² sin²θ) · √(1 − k² sin²θ)]` — the
+   partial derivative of the K-integrand `1/√(1 − k² sin²θ)` with respect
+   to `k`. (The denominator `(1 − u) · √(1 − u) = (1 − u)^{3/2}` matches
+   the form produced by `HasDerivAt.div` applied to `1` over
+   `√(1 − κ² sin²θ)`, avoiding any `Real.rpow` rewriting.)
+2. `dIntegrandK_continuous (hk : k² < 1)`, `dIntegrandK_integrable (hk : k² < 1)`
+   — regularity for `k² < 1`, by the same `Continuous.div₀` template as §8.
+3. `integrandK_hasDerivAt_in_k (hk : k² < 1) (θ : ℝ)` — the pointwise chain
+   rule: `HasDerivAt (κ ↦ ellipticIntegrand κ θ) (dIntegrandK k θ) k`. This
+   is one of the seven hypotheses of
+   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`.
+
+A future session will add the K-side **algebraic split** and **integral
+identity** (the K-analog of §8's `dIntegrandE_mul_k` /
+`integral_dIntegrandE_eq`), then a uniform bound (the K-analog of §9), then
+assemble `dK_dk : HasDerivAt ellipticK ((E(k) − (1−k²) K(k))/(k(1−k²))) k`
+via the Mathlib parametric-integral lemma. The K-side algebraic split is
+**not** pointwise (a difference from §8); it requires integration by parts
+on `∫ k sin²θ (1 − k² sin²θ)^{−3/2} dθ`. That work is deferred.
+-/
+
+/-- The partial derivative of the K-integrand with respect to k:
+    `∂/∂k (1 − k² sin²θ)^{−1/2} = k sin²θ · (1 − k² sin²θ)^{−3/2}`.
+
+    Written in the `(1 − u) · √(1 − u)` form (rather than `(1 − u)^{3/2}`)
+    to match the result of `HasDerivAt.div` applied to `(fun _ => 1)` over
+    `(fun κ => √(1 − κ² sin²θ))` — see `integrandK_hasDerivAt_in_k`. -/
+noncomputable def dIntegrandK (k θ : ℝ) : ℝ :=
+  k * Real.sin θ ^ 2 /
+    ((1 - k ^ 2 * Real.sin θ ^ 2) * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+
+/-- For `k² < 1` the K-derivative integrand is continuous in θ. -/
+lemma dIntegrandK_continuous (hk : k ^ 2 < 1) :
+    Continuous (dIntegrandK k) := by
+  unfold dIntegrandK
+  refine Continuous.div₀ ?_ ?_ ?_
+  · -- numerator: `k · sin²θ`
+    exact continuous_const.mul (continuous_sin.pow 2)
+  · -- denominator: `(1 − k²·sin²θ) · √(1 − k²·sin²θ)`
+    have h_inner : Continuous (fun θ : ℝ => 1 - k ^ 2 * Real.sin θ ^ 2) :=
+      Continuous.sub continuous_const
+        (continuous_const.mul (continuous_sin.pow 2))
+    exact h_inner.mul (Real.continuous_sqrt.comp h_inner)
+  · intro θ
+    have hp : 0 < 1 - k ^ 2 * Real.sin θ ^ 2 :=
+      AmgmInequalityOQ04OQ01.denom_pos hk θ
+    have hsp : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+      AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ
+    exact (mul_pos hp hsp).ne'
+
+/-- For `k² < 1` the K-derivative integrand is interval-integrable on `[0, π/2]`. -/
+lemma dIntegrandK_integrable (hk : k ^ 2 < 1) :
+    IntervalIntegrable (dIntegrandK k) MeasureTheory.volume 0 (π / 2) :=
+  (dIntegrandK_continuous hk).intervalIntegrable 0 (π / 2)
+
+/-- **Pointwise chain rule** for the K-integrand (one of the seven hypotheses
+    for the Mathlib differentiation-under-the-integral lemma).
+
+    For fixed θ and `k² < 1`, the map `κ ↦ 1/√(1 − κ² sin²θ)` has derivative
+    `k sin²θ / [(1 − k² sin²θ) · √(1 − k² sin²θ)] = dIntegrandK k θ` at `k`.
+
+    Proof sketch: chain rule on the inner polynomial `1 − κ² sin²θ`
+    (derivative `−2κ sin²θ`); `HasDerivAt.sqrt` on the result (using
+    positivity of the inner); then `HasDerivAt.div` of the constant `1`
+    over `√(1 − κ² sin²θ)` and an algebraic reduction using
+    `Real.mul_self_sqrt` on the denominator. -/
+lemma integrandK_hasDerivAt_in_k (hk : k ^ 2 < 1) (θ : ℝ) :
+    HasDerivAt (fun κ : ℝ => AmgmInequalityOQ04OQ01.ellipticIntegrand κ θ)
+        (dIntegrandK k θ) k := by
+  have h_pos : 0 < 1 - k ^ 2 * Real.sin θ ^ 2 :=
+    AmgmInequalityOQ04OQ01.denom_pos hk θ
+  have h_pos_ne : (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := h_pos.ne'
+  have hs_pos : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ
+  have hs_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hs_pos.ne'
+  -- Inner: f(κ) = 1 − κ² sin²θ, f'(k) = −2k sin²θ.
+  have h_inner : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2 * Real.sin θ ^ 2)
+      (-(2 * k * Real.sin θ ^ 2)) k := by
+    have h_pow' : HasDerivAt (fun κ : ℝ => κ ^ 2) (2 * k) k := by
+      simpa using hasDerivAt_pow 2 k
+    have h_mul : HasDerivAt (fun κ : ℝ => κ ^ 2 * Real.sin θ ^ 2)
+        (2 * k * Real.sin θ ^ 2) k := h_pow'.mul_const _
+    have h_sub : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2 * Real.sin θ ^ 2)
+        (0 - 2 * k * Real.sin θ ^ 2) k :=
+      (hasDerivAt_const k (1 : ℝ)).sub h_mul
+    simpa using h_sub
+  -- Outer sqrt: HasDerivAt (κ ↦ √(1 − κ² sin²θ)) (...) k.
+  have h_sqrt := h_inner.sqrt h_pos_ne
+  -- One: HasDerivAt (fun _ => 1) 0 k.
+  have h_one : HasDerivAt (fun _ : ℝ => (1 : ℝ)) 0 k := hasDerivAt_const k 1
+  -- Quotient: HasDerivAt (κ ↦ 1 / √(1 − κ² sin²θ)) (...) k.
+  have h_div := h_one.div h_sqrt hs_ne
+  -- Reduce h_div's derivative expression to `dIntegrandK k θ`.
+  show HasDerivAt (fun κ : ℝ => 1 / Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2))
+      (dIntegrandK k θ) k
+  have h_eq_deriv :
+      (0 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+          - 1 * (-(2 * k * Real.sin θ ^ 2)
+                  / (2 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))))
+        / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ^ 2
+      = dIntegrandK k θ := by
+    unfold dIntegrandK
+    have hsq : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ^ 2
+        = 1 - k ^ 2 * Real.sin θ ^ 2 := by
+      rw [sq, Real.mul_self_sqrt h_pos.le]
+    rw [hsq]
+    field_simp
+    ring
+  rw [← h_eq_deriv]
+  -- The unfold of ellipticIntegrand gives `1 / √(1 − κ² sin²θ)`.
+  show HasDerivAt
+      (fun κ : ℝ => AmgmInequalityOQ04OQ01.ellipticIntegrand κ θ) _ k
+  unfold AmgmInequalityOQ04OQ01.ellipticIntegrand
+  exact h_div
+
+
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,12 +1,81 @@
 # Current State
 
-**Phase**: ACT (S5 partial: bound infrastructure landed; S6 = Mathlib lemma assembly)
-**Since**: 2026-05-08T21:30:00Z
-**Iteration**: 5
+**Phase**: ACT (S6: K-side chain-rule infra landed; S7 remaining for assembly)
+**Since**: 2026-05-08T22:15:00Z
+**Iteration**: 6
 
 ## Current Focus
 
-Session 5 (ACT, this PR) added the **uniform-bound infrastructure** for
+Session 6 (ACT, this PR) added the **K-side chain-rule infrastructure**
+for `dK/dk` to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (new §10).
+This is the K-analog of §8: it provides the pointwise derivative
+`integrandK_hasDerivAt_in_k` that will feed the `h_diff` hypothesis of
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` when
+we assemble `dK_dk` in a future session.
+
+Three lemmas + one definition delivered (parallel to §8):
+
+1. `dIntegrandK k θ := k · sin²θ / [(1 − k² sin²θ) · √(1 − k² sin²θ)]` —
+   the partial derivative `∂_k (1 − k² sin²θ)^{−1/2}` of the K-integrand.
+   Written in the `(1 − u) · √(1 − u)` form (rather than `(1 − u)^{3/2}`)
+   so it matches the result of `HasDerivAt.div` directly, avoiding any
+   `Real.rpow` rewriting.
+2. `dIntegrandK_continuous (hk : k² < 1)` — continuity, by the same
+   `Continuous.div₀` template as `dIntegrandE_continuous`. Uses the
+   product `Continuous.mul` for the `(1 − u) · √(1 − u)` denominator,
+   with positivity dispatched by the imported `denom_pos` and
+   `sqrt_denom_pos` from `AmgmInequalityOQ04OQ01`.
+3. `dIntegrandK_integrable (hk : k² < 1)` — interval-integrability on
+   `[0, π/2]`, immediate from continuity.
+4. `integrandK_hasDerivAt_in_k (hk : k² < 1) (θ : ℝ)` — **pointwise chain
+   rule**: `HasDerivAt (κ ↦ ellipticIntegrand κ θ) (dIntegrandK k θ) k`.
+   Proof: chain rule on the inner polynomial `1 − κ² sin²θ` (derivative
+   `−2κ sin²θ`); `HasDerivAt.sqrt` on the result; `HasDerivAt.div` of
+   the constant `1` over `√(1 − κ² sin²θ)`; algebraic reduction using
+   `Real.mul_self_sqrt` and `field_simp; ring` to convert
+   `HasDerivAt.div`'s native quotient `(0·d − 1·d′)/d²` to `dIntegrandK`'s
+   form.
+
+**Mathlib API surface**: zero new lemmas. Uses `Continuous.div₀`,
+`continuous_const`, `continuous_sin`, `Real.continuous_sqrt`,
+`Continuous.intervalIntegrable`, `HasDerivAt.sqrt`, `HasDerivAt.div`,
+`hasDerivAt_pow`, `hasDerivAt_const`, `Real.mul_self_sqrt`,
+`field_simp`, `ring`, plus the imported `denom_pos`, `sqrt_denom_pos`,
+`ellipticIntegrand` from OQ04OQ01. No new imports.
+
+**Net new content**: 1 definition, 3 theorems, 0 axioms.
+**Updated total**: 8 definitions, 33 theorems, 1 axiom, 0 sorries,
+697 lines (was 565).
+
+**Independence from S5/S6 (E-side)**: this section is independent of the
+E-side bound infrastructure (`boundDIntegrandE`, §9, S5) and the
+`dE_dk` assembly (S6). It can land in parallel with the dE_dk track and
+be reused when the K-side bound + `dK_dk` theorem are assembled later.
+
+## Sharpening of the Plan for S7+
+
+The remaining work to discharge `legendre_relation` is:
+
+1. **dE_dk assembly** (§9 + Mathlib lemma): pick `M := (k + 1) / 2`,
+   apply `hasDerivAt_integral_of_dominated_loc_of_deriv_le` with the
+   seven hypotheses (six already proved across §1, §8, §9; the `hs`
+   neighborhood is a one-liner). Conclude
+   `HasDerivAt ellipticE ((E(k) − K(k))/k) k`. ~30 lines.
+2. **K-side algebraic split + integral identity** (the K-analog of
+   `dIntegrandE_mul_k` and `integral_dIntegrandE_eq`): the K-side split
+   is **NOT pointwise** (verified: `k²(1−k²) sin²θ / (1 − k²sin²θ) ≠
+   k² cos²θ` in general). Requires integration by parts on
+   `∫ k sin²θ (1 − k² sin²θ)^{−3/2} dθ` — substitute `u = sin θ`,
+   `du = cos θ dθ`, then IBP with `v = sin θ / √(1 − k² sin²θ)` and
+   `dw = sin θ dθ` (or similar). ~80–120 lines.
+3. **K-side bound infrastructure** (the K-analog of §9): `boundDIntegrandK
+   M θ := M · sin²θ / [(1 − M² sin²θ) · √(1 − M² sin²θ)]` plus
+   `dIntegrandK_abs_le_bound`. Same template as §9. ~80 lines.
+4. **dK_dk assembly** + Wronskian closure: see prior session reports.
+
+## Iteration 5 (2026-05-08T21:30Z, researcher-12): bound infrastructure for dE/dk
+
+Session 5 (ACT, prior PR #17358) added the **uniform-bound infrastructure** for
 `dE/dk` to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (new §9). This is
 the Session-5 prerequisite for the Mathlib differentiation-under-the-
 integral lemma — specifically the `h_bound` and `bound_integrable`

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,9 +20,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 565,
-    "theoremCount": 30,
-    "definitionCount": 7,
+    "lineCount": 697,
+    "theoremCount": 33,
+    "definitionCount": 8,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
   },
@@ -176,10 +176,10 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 565,
+    "lineCount": 697,
     "axiomCount": 1,
-    "theoremCount": 30,
-    "definitionCount": 7,
+    "theoremCount": 33,
+    "definitionCount": 8,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
@@ -1,96 +1,96 @@
 {
   "slug": "amgm-inequality-oq-04-oq-02",
-  "title": "Legendre's Relation for Complete Elliptic Integrals: E(k)·K'(k) + E'(k)·K(k) − K(k)·K'(k) = π/2",
+  "title": "Legendre's Relation for Complete Elliptic Integrals: E(k)\u00b7K'(k) + E'(k)\u00b7K(k) \u2212 K(k)\u00b7K'(k) = \u03c0/2",
   "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "E(k) \\, K(k') + E(k') \\, K(k) - K(k) \\, K(k') = \\pi/2 \\quad \\text{for } 0 < k < 1, \\; k' = \\sqrt{1 - k^2}",
-    "plain": "Legendre's relation between the complete elliptic integrals of the first and second kind, K and E, and their complementary versions K' = K(k'), E' = E(k') where k' = √(1 - k²) is the complementary modulus.",
+    "plain": "Legendre's relation between the complete elliptic integrals of the first and second kind, K and E, and their complementary versions K' = K(k'), E' = E(k') where k' = \u221a(1 - k\u00b2) is the complementary modulus.",
     "whyMatters": [
       "Foundational identity for elliptic-integral theory; underpins relations between periods of elliptic functions and arises in computing the AGM-based formulas for K and E.",
-      "Used by Brent–Salamin's 1976 quadratically-convergent π algorithm — directly bridges this problem to the AGM gallery line (parent slugs amgm-inequality, amgm-inequality-oq-04).",
-      "Discrepancy with Mathlib: Mathlib has Weierstrass ℘-functions (period-pair formulation) and the Arithmetic-Geometric Mean (NNReal.agm) but no complete elliptic integrals K(k), E(k); a successful formalization here is a candidate Mathlib contribution."
+      "Used by Brent\u2013Salamin's 1976 quadratically-convergent \u03c0 algorithm \u2014 directly bridges this problem to the AGM gallery line (parent slugs amgm-inequality, amgm-inequality-oq-04).",
+      "Discrepancy with Mathlib: Mathlib has Weierstrass \u2118-functions (period-pair formulation) and the Arithmetic-Geometric Mean (NNReal.agm) but no complete elliptic integrals K(k), E(k); a successful formalization here is a candidate Mathlib contribution."
     ]
   },
   "knownResults": {
     "proven": [
-      "Classical: Legendre (1825) proved the relation by differentiating both sides w.r.t. k and showing the derivative vanishes; Whittaker–Watson §22.41, Abramowitz–Stegun §17.3.13, DLMF §19.7.1.",
-      "Modern slick proof: each of K, K', E, E' is annihilated by Legendre's ODE; the Wronskian E·K' + E'·K − K·K' is constant in k, evaluated at k=0 (where K(0)=π/2, E(0)=π/2, K'(0)=∞, E'(0)=1, but the limit gives π/2)."
+      "Classical: Legendre (1825) proved the relation by differentiating both sides w.r.t. k and showing the derivative vanishes; Whittaker\u2013Watson \u00a722.41, Abramowitz\u2013Stegun \u00a717.3.13, DLMF \u00a719.7.1.",
+      "Modern slick proof: each of K, K', E, E' is annihilated by Legendre's ODE; the Wronskian E\u00b7K' + E'\u00b7K \u2212 K\u00b7K' is constant in k, evaluated at k=0 (where K(0)=\u03c0/2, E(0)=\u03c0/2, K'(0)=\u221e, E'(0)=1, but the limit gives \u03c0/2)."
     ],
     "open": [
-      "Lean 4 / Mathlib formalization — no prior work; not in current Mathlib (verified 2026-05-07 by S1 grep)."
+      "Lean 4 / Mathlib formalization \u2014 no prior work; not in current Mathlib (verified 2026-05-07 by S1 grep)."
     ],
-    "goal": "Prove `legendre_relation : ∀ k ∈ Set.Ioo (0:ℝ) 1, E k * K' k + E' k * K k - K k * K' k = π / 2` (or equivalent phrasing) given suitable Lean definitions of `K`, `E` over `Set.Ioo (-1) 1`."
+    "goal": "Prove `legendre_relation : \u2200 k \u2208 Set.Ioo (0:\u211d) 1, E k * K' k + E' k * K k - K k * K' k = \u03c0 / 2` (or equivalent phrasing) given suitable Lean definitions of `K`, `E` over `Set.Ioo (-1) 1`."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T17:05:00Z",
-    "iteration": 4,
-    "focus": "S4 ACT: added the chain-rule + algebraic-split + integral-identity infrastructure for dE/dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean (new section 8). Five new declarations: dIntegrandE (def: -k sin^2 theta / sqrt(...)), dIntegrandE_continuous, dIntegrandE_integrable, integrandE_hasDerivAt_in_k (the pointwise chain rule via HasDerivAt.sqrt), dIntegrandE_mul_k (algebraic split k * dIntegrandE = E_int - K_int), integral_dIntegrandE_eq (integral identity: int dIntegrandE = (E - K)/k for 0 < k < 1). With these in place the parametric-integral lemma's conclusion can be rewritten directly to the dE/dk form. ~+148 lines, 0 sorries, 0 axioms added; legendre_relation axiom unchanged. Build verification pending. Next session (S5) discharges the bound construction (h_bound, bound_integrable) and applies intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le.",
+    "since": "2026-05-08T22:15:00Z",
+    "iteration": 6,
+    "focus": "S6 ACT (researcher-6, parallel to E-side track): added the K-side chain-rule infrastructure for dK/dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean (new section 10). Four new declarations: dIntegrandK (def: k sin^2 theta / [(1 - k^2 sin^2 theta) * sqrt(...)]), dIntegrandK_continuous, dIntegrandK_integrable, integrandK_hasDerivAt_in_k (pointwise chain rule via HasDerivAt.div composing HasDerivAt.sqrt and a constant). +132 lines, 0 sorries, 0 axioms added; legendre_relation axiom unchanged. Independent of S5 (E-bound) and S6 (E-assembly) tracks. Build verification pending. Next sessions assemble dK_dk and the K-side algebraic split (which is NOT pointwise \u2014 requires integration by parts).",
     "blockers": [],
-    "nextAction": "Session 5 (ACT): assemble dE_dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean via intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le. With S4 infrastructure in place, the remaining work is: (1) choose delta = (1 - k)/2 and Metric.ball k delta; (2) define bound theta = (k + delta) sin^2 theta / sqrt(1 - (k+delta)^2 sin^2 theta); (3) discharge the 7 hypotheses (the chain-rule one is just integrandE_hasDerivAt_in_k); (4) rewrite the integral conclusion via integral_dIntegrandE_eq. Estimated 50-80 lines.",
+    "nextAction": "Pick one of two parallel tracks. Track A (E-side): assemble dE_dk by combining S4-S5 infrastructure with hasDerivAt_integral_of_dominated_loc_of_deriv_le; ~30 lines. Track B (K-side): K-side algebraic split + integral identity (requires integration by parts on int k sin^2 theta (1-k^2sin^2theta)^{-3/2} dtheta; ~80-120 lines), then K-side bound infra (mirrors S5 but for the K-integrand; ~80 lines), then dK_dk assembly. After both dE_dk and dK_dk are proved, assemble the Wronskian and discharge legendre_relation.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S5 (researcher-12, 2026-05-08, ACT): added the uniform-bound infrastructure for the dE/dk derivation. New §9 of Proofs/AmgmInequalityOQ04OQ02.lean: boundDIntegrandE (def, M·sin²θ/√(1−M²sin²θ)), its continuity and integrability for M²<1, and the pointwise bound |dIntegrandE κ θ| ≤ boundDIntegrandE M θ for κ²≤M². With S4's chain rule, algebraic split, and integral identity, S6 now has a turnkey set of seven hypotheses for intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (with M:=(k+1)/2 as the band radius). +92 lines, +1 def, +3 thms, 0 axioms changed (still 1 declared axiom: legendre_relation), 0 sorries. Total: 565 lines, 7 defs, 30 thms, 1 axiom, 0 sorries. Build pending. Previous: Session 2 (2026-05-08, ORIENT): Stub written and Docker-building. Created Proofs/AmgmInequalityOQ04OQ02.lean (285 lines, 5 defs, 21 theorems/lemmas, 1 axiom, 0 sorries). Reused AmgmInequalityOQ04OQ01.ellipticK (rigorous Mathlib intervalIntegral) — Session 1 missed this; no need to define K from scratch. Defined ellipticE rigorously as ∫₀^{π/2} √(1-k²sin²θ) dθ; proved E(0) = π/2 and E(k) > 0 for k² < 1 via the lower bound √(1-k²). Defined complementary modulus k' = √(1-k²), showed (k')² = 1-k² an",
+    "progressSummary": "S5 (researcher-12, 2026-05-08, ACT): added the uniform-bound infrastructure for the dE/dk derivation. New \u00a79 of Proofs/AmgmInequalityOQ04OQ02.lean: boundDIntegrandE (def, M\u00b7sin\u00b2\u03b8/\u221a(1\u2212M\u00b2sin\u00b2\u03b8)), its continuity and integrability for M\u00b2<1, and the pointwise bound |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 for \u03ba\u00b2\u2264M\u00b2. With S4's chain rule, algebraic split, and integral identity, S6 now has a turnkey set of seven hypotheses for intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (with M:=(k+1)/2 as the band radius). +92 lines, +1 def, +3 thms, 0 axioms changed (still 1 declared axiom: legendre_relation), 0 sorries. Total: 565 lines, 7 defs, 30 thms, 1 axiom, 0 sorries. Build pending. Previous: Session 2 (2026-05-08, ORIENT): Stub written and Docker-building. Created Proofs/AmgmInequalityOQ04OQ02.lean (285 lines, 5 defs, 21 theorems/lemmas, 1 axiom, 0 sorries). Reused AmgmInequalityOQ04OQ01.ellipticK (rigorous Mathlib intervalIntegral) \u2014 Session 1 missed this; no need to define K from scratch. Defined ellipticE rigorously as \u222b\u2080^{\u03c0/2} \u221a(1-k\u00b2sin\u00b2\u03b8) d\u03b8; proved E(0) = \u03c0/2 and E(k) > 0 for k\u00b2 < 1 via the lower bound \u221a(1-k\u00b2). Defined complementary modulus k' = \u221a(1-k\u00b2), showed (k')\u00b2 = 1-k\u00b2 an",
     "builtItems": [
-      "ellipticIntegrandE (def, k θ ↦ √(1-k²sin²θ)) in AmgmInequalityOQ04OQ02.lean:68",
+      "ellipticIntegrandE (def, k \u03b8 \u21a6 \u221a(1-k\u00b2sin\u00b2\u03b8)) in AmgmInequalityOQ04OQ02.lean:68",
       "ellipticE (def, complete elliptic integral of 2nd kind via intervalIntegral) in AmgmInequalityOQ04OQ02.lean:74",
       "integrandE_nonneg, integrandE_le_one, integrandE_zero_eq_one, integrandE_lower_bound, integrandE_continuous, ellipticE_integrable (E-integrand basic properties) in AmgmInequalityOQ04OQ02.lean:82-117",
-      "ellipticE_zero (theorem, E(0) = π/2) in AmgmInequalityOQ04OQ02.lean:124",
-      "ellipticE_pos (theorem, 0 < E(k) for k²<1) in AmgmInequalityOQ04OQ02.lean:130",
-      "complModulus (def, k ↦ √(1-k²)), and 5 properties (complModulus_nonneg, complModulus_pos, complModulus_sq, complModulus_sq_lt_one, complModulus_complModulus) in AmgmInequalityOQ04OQ02.lean:156-184",
-      "ellipticK' (def, k ↦ K(k')), ellipticE' (def, k ↦ E(k')), and positivity lemmas in AmgmInequalityOQ04OQ02.lean:188-200",
+      "ellipticE_zero (theorem, E(0) = \u03c0/2) in AmgmInequalityOQ04OQ02.lean:124",
+      "ellipticE_pos (theorem, 0 < E(k) for k\u00b2<1) in AmgmInequalityOQ04OQ02.lean:130",
+      "complModulus (def, k \u21a6 \u221a(1-k\u00b2)), and 5 properties (complModulus_nonneg, complModulus_pos, complModulus_sq, complModulus_sq_lt_one, complModulus_complModulus) in AmgmInequalityOQ04OQ02.lean:156-184",
+      "ellipticK' (def, k \u21a6 K(k')), ellipticE' (def, k \u21a6 E(k')), and positivity lemmas in AmgmInequalityOQ04OQ02.lean:188-200",
       "axiom legendre_relation (general form, 0<k<1) in AmgmInequalityOQ04OQ02.lean:240",
-      "complModulus_symmetric (theorem, complModulus(1/√2) = 1/√2) in AmgmInequalityOQ04OQ02.lean:261",
-      "legendre_relation_symmetric (theorem, 2KE - K² = π/2 at k=1/√2; derived from the general axiom) in AmgmInequalityOQ04OQ02.lean:274",
+      "complModulus_symmetric (theorem, complModulus(1/\u221a2) = 1/\u221a2) in AmgmInequalityOQ04OQ02.lean:261",
+      "legendre_relation_symmetric (theorem, 2KE - K\u00b2 = \u03c0/2 at k=1/\u221a2; derived from the general axiom) in AmgmInequalityOQ04OQ02.lean:274",
       "API drift fix: AmgmInequalityOQ04OQ01.ellipticK_pos updated for intervalIntegral.integral_mono signature",
       "Gallery entry: src/data/proofs/amgm-inequality-oq-04-oq-02/ (meta.json, index.ts, annotations.json with 8 annotations)",
-      "S5 (researcher-12, 2026-05-08): boundDIntegrandE (def) — the dominating bound M·sin²θ/√(1−M²sin²θ) for |dIntegrandE κ θ| on |κ|≤M, in AmgmInequalityOQ04OQ02.lean §9",
-      "S5 (researcher-12, 2026-05-08): boundDIntegrandE_continuous + boundDIntegrandE_integrable for M²<1 — the bound_integrable hypothesis ingredient for the Mathlib parametric-integral lemma",
-      "S5 (researcher-12, 2026-05-08): dIntegrandE_abs_le_bound — uniform bound |dIntegrandE κ θ| ≤ boundDIntegrandE M θ for κ²≤M², 0≤M, M²<1; the h_bound hypothesis ingredient"
+      "S5 (researcher-12, 2026-05-08): boundDIntegrandE (def) \u2014 the dominating bound M\u00b7sin\u00b2\u03b8/\u221a(1\u2212M\u00b2sin\u00b2\u03b8) for |dIntegrandE \u03ba \u03b8| on |\u03ba|\u2264M, in AmgmInequalityOQ04OQ02.lean \u00a79",
+      "S5 (researcher-12, 2026-05-08): boundDIntegrandE_continuous + boundDIntegrandE_integrable for M\u00b2<1 \u2014 the bound_integrable hypothesis ingredient for the Mathlib parametric-integral lemma",
+      "S5 (researcher-12, 2026-05-08): dIntegrandE_abs_le_bound \u2014 uniform bound |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 for \u03ba\u00b2\u2264M\u00b2, 0\u2264M, M\u00b2<1; the h_bound hypothesis ingredient"
     ],
     "insights": [
-      "Mathlib `Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass` provides `PeriodPair.weierstrassP`, `derivWeierstrassP`, etc. — the lattice/`g₂`/`g₃` formulation, NOT the modulus-based `K(k)`/`E(k)`. These are mathematically equivalent (via the connection k² = e₁−e₃ / e₁−e₂ or similar), but the API does not expose K, E directly.",
-      "Mathlib `Mathlib.Analysis.SpecialFunctions.ArithmeticGeometricMean` defines `NNReal.agm` (Tan, 2025) — important because the Brent–Salamin / AGM proof of Legendre's relation uses K(k) = π/(2·agm(1, k')) (Gauss). If we adopt this as the **definition** of K, then E, K', E' come from corresponding AGM-style limits. Pro: direct Mathlib hookup; Con: the integral definition is more standard and required for any later derivative arguments.",
+      "Mathlib `Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass` provides `PeriodPair.weierstrassP`, `derivWeierstrassP`, etc. \u2014 the lattice/`g\u2082`/`g\u2083` formulation, NOT the modulus-based `K(k)`/`E(k)`. These are mathematically equivalent (via the connection k\u00b2 = e\u2081\u2212e\u2083 / e\u2081\u2212e\u2082 or similar), but the API does not expose K, E directly.",
+      "Mathlib `Mathlib.Analysis.SpecialFunctions.ArithmeticGeometricMean` defines `NNReal.agm` (Tan, 2025) \u2014 important because the Brent\u2013Salamin / AGM proof of Legendre's relation uses K(k) = \u03c0/(2\u00b7agm(1, k')) (Gauss). If we adopt this as the **definition** of K, then E, K', E' come from corresponding AGM-style limits. Pro: direct Mathlib hookup; Con: the integral definition is more standard and required for any later derivative arguments.",
       "Mathlib `Mathlib.Analysis.SpecialFunctions.Integrals.Basic` provides `integral_sin_pow`, `integral_cos`, `integral_sin`, `integral_sin_sq`, etc. over arbitrary intervals via `intervalIntegral`. These give the building blocks for showing `K`, `E` are well-defined as `intervalIntegral`s.",
-      "Real.sqrt at zero or negative arguments returns 0 (junk value) — important for the K(k) integrand near k=±1 (the point θ = π/2 makes 1 − k²sin²θ = 0). For k ∈ Set.Ioo (-1) 1, the integrand is bounded and continuous, so integrability is straightforward.",
-      "Standard Legendre relation form: E(k)·K'(k) + E(k')·K(k) − K(k)·K'(k) = π/2 for 0 < k < 1. The original problem entry stated `K(k)·K'(k) + K(k')·K'(k') = π/2` — this appears to confuse two notations: the prime might mean either differentiation w.r.t. k, or the complementary-modulus K(k'). Standard Legendre relation does NOT have form K·K' + K(k')·K'(k'); the correct identity must include E.",
-      "Whittaker-Watson §22.41 (1927) gives the textbook ODE/Wronskian proof: K, K' both satisfy Legendre's ODE k(1-k²)y'' + (1-3k²)y' - k·y = 0, so the Wronskian K·K' is conserved up to a known function. With E and the relations dE/dk, dK/dk, the algebra reduces to π/2.",
-      "Brent-Salamin (1976) AGM proof: K(k) = π/(2·M(1, k')) where M is AGM. The Legendre relation falls out of the recurrence M(1, k) = M((1+k)/2, √k) plus a parallel E identity. Concretely Lean-friendly because Mathlib HAS `NNReal.agm` already.",
-      "Mathlib lacks: (1) interval-integrability lemma for `(1 - k²·sin²θ)^(±1/2)` on `[0, π/2]`; (2) the formula d/dk K(k) = (E(k) − k'²·K(k)) / (k·k'²) (key for Wronskian computation); (3) the complete elliptic integral E in any form.",
-      "Connection to AGM gallery: The problem is in the `amgm-inequality` family precisely because of Gauss's formula K(k) = π/(2 · AGM(1, k')). A successful proof here likely uses or extends `NNReal.agm` infrastructure — the pipeline AGM → K → E → Legendre's relation is the most Lean-amenable path.",
-      "AmgmInequalityOQ04OQ01 ALREADY DEFINES ellipticK rigorously via intervalIntegral. Session 1 missed this — the K(k) infrastructure is reusable directly. Importing OQ04OQ01 gives ellipticK plus continuity, integrability, K(0)=π/2, K(k)>0 for k²<1, monotonicity in k². No need to redefine K.",
-      "ellipticE is symmetrically simpler than ellipticK: the integrand √(1-k²sin²θ) is bounded above by 1 and continuous on all of ℝ × ℝ (no |k|<1 restriction needed for integrability). Continuity proof is a 4-line composition: Real.continuous_sqrt ∘ (continuous_const.sub (continuous_const.mul (continuous_sin.pow 2))).",
-      "ellipticE_pos for |k|<1 follows from a cute lower bound: 1-k² ≤ 1-k²sin²θ implies √(1-k²) ≤ ellipticIntegrandE k θ; then intervalIntegral.integral_mono_on against the constant function √(1-k²) gives E(k) ≥ √(1-k²)·(π/2) > 0.",
-      "Symmetric Legendre at k=1/√2 requires complModulus_symmetric : √(1-(1/√2)²) = 1/√2. Proof technique: rewrite 1 - 1/2 = (1/√2)² (so the inner subtraction becomes a square), then apply Real.sqrt_sq with positivity. ~3 lines.",
-      "linear_combination tactic closes the gap between the general Legendre form 'E·K + E·K - K·K = π/2' (after specializing to k = k' = 1/√2) and the goal '2·K·E - K² = π/2'. ring-equivalent, but `linear_combination h` with h being the unfolded form is cleanest.",
+      "Real.sqrt at zero or negative arguments returns 0 (junk value) \u2014 important for the K(k) integrand near k=\u00b11 (the point \u03b8 = \u03c0/2 makes 1 \u2212 k\u00b2sin\u00b2\u03b8 = 0). For k \u2208 Set.Ioo (-1) 1, the integrand is bounded and continuous, so integrability is straightforward.",
+      "Standard Legendre relation form: E(k)\u00b7K'(k) + E(k')\u00b7K(k) \u2212 K(k)\u00b7K'(k) = \u03c0/2 for 0 < k < 1. The original problem entry stated `K(k)\u00b7K'(k) + K(k')\u00b7K'(k') = \u03c0/2` \u2014 this appears to confuse two notations: the prime might mean either differentiation w.r.t. k, or the complementary-modulus K(k'). Standard Legendre relation does NOT have form K\u00b7K' + K(k')\u00b7K'(k'); the correct identity must include E.",
+      "Whittaker-Watson \u00a722.41 (1927) gives the textbook ODE/Wronskian proof: K, K' both satisfy Legendre's ODE k(1-k\u00b2)y'' + (1-3k\u00b2)y' - k\u00b7y = 0, so the Wronskian K\u00b7K' is conserved up to a known function. With E and the relations dE/dk, dK/dk, the algebra reduces to \u03c0/2.",
+      "Brent-Salamin (1976) AGM proof: K(k) = \u03c0/(2\u00b7M(1, k')) where M is AGM. The Legendre relation falls out of the recurrence M(1, k) = M((1+k)/2, \u221ak) plus a parallel E identity. Concretely Lean-friendly because Mathlib HAS `NNReal.agm` already.",
+      "Mathlib lacks: (1) interval-integrability lemma for `(1 - k\u00b2\u00b7sin\u00b2\u03b8)^(\u00b11/2)` on `[0, \u03c0/2]`; (2) the formula d/dk K(k) = (E(k) \u2212 k'\u00b2\u00b7K(k)) / (k\u00b7k'\u00b2) (key for Wronskian computation); (3) the complete elliptic integral E in any form.",
+      "Connection to AGM gallery: The problem is in the `amgm-inequality` family precisely because of Gauss's formula K(k) = \u03c0/(2 \u00b7 AGM(1, k')). A successful proof here likely uses or extends `NNReal.agm` infrastructure \u2014 the pipeline AGM \u2192 K \u2192 E \u2192 Legendre's relation is the most Lean-amenable path.",
+      "AmgmInequalityOQ04OQ01 ALREADY DEFINES ellipticK rigorously via intervalIntegral. Session 1 missed this \u2014 the K(k) infrastructure is reusable directly. Importing OQ04OQ01 gives ellipticK plus continuity, integrability, K(0)=\u03c0/2, K(k)>0 for k\u00b2<1, monotonicity in k\u00b2. No need to redefine K.",
+      "ellipticE is symmetrically simpler than ellipticK: the integrand \u221a(1-k\u00b2sin\u00b2\u03b8) is bounded above by 1 and continuous on all of \u211d \u00d7 \u211d (no |k|<1 restriction needed for integrability). Continuity proof is a 4-line composition: Real.continuous_sqrt \u2218 (continuous_const.sub (continuous_const.mul (continuous_sin.pow 2))).",
+      "ellipticE_pos for |k|<1 follows from a cute lower bound: 1-k\u00b2 \u2264 1-k\u00b2sin\u00b2\u03b8 implies \u221a(1-k\u00b2) \u2264 ellipticIntegrandE k \u03b8; then intervalIntegral.integral_mono_on against the constant function \u221a(1-k\u00b2) gives E(k) \u2265 \u221a(1-k\u00b2)\u00b7(\u03c0/2) > 0.",
+      "Symmetric Legendre at k=1/\u221a2 requires complModulus_symmetric : \u221a(1-(1/\u221a2)\u00b2) = 1/\u221a2. Proof technique: rewrite 1 - 1/2 = (1/\u221a2)\u00b2 (so the inner subtraction becomes a square), then apply Real.sqrt_sq with positivity. ~3 lines.",
+      "linear_combination tactic closes the gap between the general Legendre form 'E\u00b7K + E\u00b7K - K\u00b7K = \u03c0/2' (after specializing to k = k' = 1/\u221a2) and the goal '2\u00b7K\u00b7E - K\u00b2 = \u03c0/2'. ring-equivalent, but `linear_combination h` with h being the unfolded form is cleanest.",
       "The general Legendre relation axiom is the only deep assumption in this file; it is honestly comparable in depth to OQ04OQ01.agm_ellipticK_connection (Gauss's 200-page result). The proof requires Mathlib's intervalIntegral.deriv_* (DOES exist) plus explicit Lean derivations of dK/dk and dE/dk (do not yet exist for ellipticK).",
-      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a ≤ b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:ℝ) ≤ π / 2)` before the integrability arguments.",
+      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a \u2264 b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:\u211d) \u2264 \u03c0 / 2)` before the integrability arguments.",
       "S3 (2026-05-08, SURVEY): the Mathlib derivative-under-the-integral lemma to use is intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean. The dominated-bound form (uniform integrable bound on F') is preferable to the Lipschitz form for elliptic integrals because both F = sqrt(1 - k^2 sin^2 theta) and F' = -k sin^2 theta / sqrt(1 - k^2 sin^2 theta) admit explicit uniform bounds on any compact [k0-delta, k0+delta] subset (0,1). The 7 hypotheses (hs, hF_meas, hF_int, hF'_meas, h_bound, bound_integrable, h_diff) discharge mechanically via Continuous.aestronglyMeasurable, Continuous.intervalIntegrable, monotonicity, and chain rule for sqrt/quotient. ~75-100 lines per derivative.",
-      "S5 design: the bound function `boundDIntegrandE` mirrors `dIntegrandE` exactly — same numerator structure, same √(1 − ξ² sin²θ) denominator, with `ξ` replaced by the band radius `M`. This means the bound's continuity/integrability proofs reuse the §8 templates verbatim (`Continuous.div₀`, `sqrt_denom_pos`), keeping S5 minimal (~30 lines of tactic code).",
-      "S5 proof simplification: the comparison |dIntegrandE κ θ| ≤ boundDIntegrandE M θ reduces, after `abs_div`/`abs_neg`/`abs_mul`, to a clean `div_le_div` invocation — numerator `|κ|·sin²θ ≤ M·sin²θ` and denominator `√(1 − M² sin²θ) ≤ √(1 − κ² sin²θ)` are both elementary monotonicity facts on nonneg sides.",
-      "S5 → S6 plan refinement: the `δ := (1−k)/2` choice in the original S5 plan was suboptimal — for k ≤ 1/3 it gives k − δ < 0, making `|κ| ≤ k + δ` non-tight. The replacement `M := (k+1)/2` band approach is cleaner: `|κ| ≤ M` is the natural statement on `Set.Ioo (-M) M`, and (k+1)/2 satisfies both 0 < k < M and M < 1 for any 0 < k < 1."
+      "S5 design: the bound function `boundDIntegrandE` mirrors `dIntegrandE` exactly \u2014 same numerator structure, same \u221a(1 \u2212 \u03be\u00b2 sin\u00b2\u03b8) denominator, with `\u03be` replaced by the band radius `M`. This means the bound's continuity/integrability proofs reuse the \u00a78 templates verbatim (`Continuous.div\u2080`, `sqrt_denom_pos`), keeping S5 minimal (~30 lines of tactic code).",
+      "S5 proof simplification: the comparison |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 reduces, after `abs_div`/`abs_neg`/`abs_mul`, to a clean `div_le_div` invocation \u2014 numerator `|\u03ba|\u00b7sin\u00b2\u03b8 \u2264 M\u00b7sin\u00b2\u03b8` and denominator `\u221a(1 \u2212 M\u00b2 sin\u00b2\u03b8) \u2264 \u221a(1 \u2212 \u03ba\u00b2 sin\u00b2\u03b8)` are both elementary monotonicity facts on nonneg sides.",
+      "S5 \u2192 S6 plan refinement: the `\u03b4 := (1\u2212k)/2` choice in the original S5 plan was suboptimal \u2014 for k \u2264 1/3 it gives k \u2212 \u03b4 < 0, making `|\u03ba| \u2264 k + \u03b4` non-tight. The replacement `M := (k+1)/2` band approach is cleaner: `|\u03ba| \u2264 M` is the natural statement on `Set.Ioo (-M) M`, and (k+1)/2 satisfies both 0 < k < M and M < 1 for any 0 < k < 1."
     ],
     "mathlibGaps": [
-      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Complete — complete elliptic integrals K(k), E(k) of first and second kind over real moduli are not formalized. (This file fills part of this gap: rigorous E(k); K(k) was already filled by OQ04OQ01.)",
-      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Legendre — the Legendre relation itself is not in Mathlib. (This file axiomatizes it pending a constructive proof.)",
-      "AGM ↔ K identity (Gauss): K(k) = π/(2 · agm(1, sqrt(1-k²))) is not in Mathlib (axiomatized in OQ04OQ01).",
-      "Differentiability/derivative of K(k), E(k) under the integral sign — needed for any ODE-based proof; would use intervalIntegral.differentiableOn style results. Mathlib HAS the underlying machinery; the connector lemmas are missing.",
-      "Explicit derivatives: dK/dk = (E - k'²K)/(k·k'²) and dE/dk = (E - K)/k — these are the key Wronskian inputs. Both reachable from Mathlib but require work."
+      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Complete \u2014 complete elliptic integrals K(k), E(k) of first and second kind over real moduli are not formalized. (This file fills part of this gap: rigorous E(k); K(k) was already filled by OQ04OQ01.)",
+      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Legendre \u2014 the Legendre relation itself is not in Mathlib. (This file axiomatizes it pending a constructive proof.)",
+      "AGM \u2194 K identity (Gauss): K(k) = \u03c0/(2 \u00b7 agm(1, sqrt(1-k\u00b2))) is not in Mathlib (axiomatized in OQ04OQ01).",
+      "Differentiability/derivative of K(k), E(k) under the integral sign \u2014 needed for any ODE-based proof; would use intervalIntegral.differentiableOn style results. Mathlib HAS the underlying machinery; the connector lemmas are missing.",
+      "Explicit derivatives: dK/dk = (E - k'\u00b2K)/(k\u00b7k'\u00b2) and dE/dk = (E - K)/k \u2014 these are the key Wronskian inputs. Both reachable from Mathlib but require work."
     ],
     "nextSteps": [
-      "S6 (researcher-N, ACT, ~50-80 lines): apply intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le to the §8 + §9 ingredients with M:=(k+1)/2; conclude `dE_dk : HasDerivAt ellipticE ((E(k)-K(k))/k) k`. The seven hypotheses are: hs := Set.Ioo (-M) M ∈ nhds k; hF_meas := Filter.eventually_of_forall ∘ Continuous.aestronglyMeasurable ∘ integrandE_continuous; hF_int := ellipticE_integrable k; hF'_meas := (dIntegrandE_continuous hk_sq).aestronglyMeasurable; h_bound := Filter.eventually_of_forall ∘ dIntegrandE_abs_le_bound; bound_integrable := boundDIntegrandE_integrable; h_diff := Filter.eventually_of_forall ∘ integrandE_hasDerivAt_in_k. Apply .2 to extract HasDerivAt; then rewrite via integral_dIntegrandE_eq to get the (E−K)/k form.",
+      "S6 (researcher-N, ACT, ~50-80 lines): apply intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le to the \u00a78 + \u00a79 ingredients with M:=(k+1)/2; conclude `dE_dk : HasDerivAt ellipticE ((E(k)-K(k))/k) k`. The seven hypotheses are: hs := Set.Ioo (-M) M \u2208 nhds k; hF_meas := Filter.eventually_of_forall \u2218 Continuous.aestronglyMeasurable \u2218 integrandE_continuous; hF_int := ellipticE_integrable k; hF'_meas := (dIntegrandE_continuous hk_sq).aestronglyMeasurable; h_bound := Filter.eventually_of_forall \u2218 dIntegrandE_abs_le_bound; bound_integrable := boundDIntegrandE_integrable; h_diff := Filter.eventually_of_forall \u2218 integrandE_hasDerivAt_in_k. Apply .2 to extract HasDerivAt; then rewrite via integral_dIntegrandE_eq to get the (E\u2212K)/k form.",
       "Session 4 (E derivative, ACT): Prove dE/dk = (E(k) - K(k))/k for 0 < k < 1 in Proofs/AmgmInequalityOQ04OQ02.lean. Use intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (now pinned in S3) with bound (theta) := (k+delta) sin^2 theta / sqrt(1 - (k+delta)^2 sin^2 theta) on s := Set.Ioo (k - delta) (k + delta). The integrand's k-derivative is -k sin^2 theta / sqrt(1 - k^2 sin^2 theta); the resulting integral rearranges to (E - K)/k via the algebraic split -k^2 sin^2 theta = (1 - k^2 sin^2 theta) - 1. ~75-100 lines.",
       "Session 5 (K derivative, ACT): Prove dK/dk = (E(k) - (k')^2 K(k))/(k (k')^2) for 0 < k < 1. Same Mathlib lemma as Session 4; integrand is 1/sqrt(1 - k^2 sin^2 theta), k-derivative is k sin^2 theta / (1 - k^2 sin^2 theta)^{3/2}. ~80-100 lines.",
       "Session 6 (Wronskian-vanishing, ACT): Define f(k) := E K' + E' K - K K' for 0 < k < 1 and show f'(k) = 0 using the derivatives from S4-S5 + the chain rule for k' = sqrt(1 - k^2). Then conclude f is constant via Mathlib's eq_of_hasDerivAt_eq_zero (no second-order ODE needed). ~50-80 lines.",
-      "Session 7 (boundary value, ACT): Pin the constant via legendre_relation_symmetric (already proved in S2 from the general axiom — once the axiom is replaced by the Wronskian theorem, the dependency direction reverses cleanly). ~20 lines.",
+      "Session 7 (boundary value, ACT): Pin the constant via legendre_relation_symmetric (already proved in S2 from the general axiom \u2014 once the axiom is replaced by the Wronskian theorem, the dependency direction reverses cleanly). ~20 lines.",
       "Session 8 (axiom-elimination cleanup): Update AmgmInequalityOQ04OQ05 to import this file and discharge its `legendre_relation` (symmetric) axiom by `legendre_relation_symmetric`. Re-verify Brent-Salamin formula proof. Small follow-up PR.",
       "Future Mathlib contribution: After all sessions complete and the file is sorry-free + axiom-free, propose `Mathlib.Analysis.SpecialFunctions.Elliptic.Complete` containing K, E, and Legendre's relation. Targets a Mathlib PR similar to NNReal.agm (Tan 2025)."
     ]
@@ -126,12 +126,12 @@
   ],
   "references": {
     "papers": [
-      "Brent, R. P. (1976). Fast multiple-precision evaluation of elementary functions. J. ACM 23(2), 242–251.",
-      "Salamin, E. (1976). Computation of π using arithmetic-geometric mean. Math. Comp. 30, 565–570.",
-      "Whittaker, E. T. & Watson, G. N. (1927). A Course of Modern Analysis, 4th ed., §22.41."
+      "Brent, R. P. (1976). Fast multiple-precision evaluation of elementary functions. J. ACM 23(2), 242\u2013251.",
+      "Salamin, E. (1976). Computation of \u03c0 using arithmetic-geometric mean. Math. Comp. 30, 565\u2013570.",
+      "Whittaker, E. T. & Watson, G. N. (1927). A Course of Modern Analysis, 4th ed., \u00a722.41."
     ],
     "urls": [
-      "https://dlmf.nist.gov/19.7#i.info — DLMF §19.7.1 Legendre relation",
+      "https://dlmf.nist.gov/19.7#i.info \u2014 DLMF \u00a719.7.1 Legendre relation",
       "https://en.wikipedia.org/wiki/Legendre_relation",
       "https://en.wikipedia.org/wiki/Brent%E2%80%93Salamin_algorithm"
     ],
@@ -140,22 +140,22 @@
       "Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass (PeriodPair.weierstrassP)",
       "Mathlib.Analysis.SpecialFunctions.Integrals.Basic (integral_sin_pow, integral_cos)",
       "Mathlib.MeasureTheory.Integral.IntervalIntegral (intervalIntegral, IntervalIntegrable)",
-      "Mathlib.Analysis.Calculus.ParametricIntervalIntegral — intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (S3-pinned workhorse for dE/dk and dK/dk)",
-      "Mathlib.Analysis.Calculus.MeanValue — eq_of_hasDerivAt_eq_zero (Wronskian-constancy step)"
+      "Mathlib.Analysis.Calculus.ParametricIntervalIntegral \u2014 intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (S3-pinned workhorse for dE/dk and dK/dk)",
+      "Mathlib.Analysis.Calculus.MeanValue \u2014 eq_of_hasDerivAt_eq_zero (Wronskian-constancy step)"
     ]
   },
   "started": "2026-05-06T14:45:58.507Z",
-  "lastUpdate": "2026-05-08T07:50:00Z",
+  "lastUpdate": "2026-05-08T22:15:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
-      "lineCount": 285,
+      "lineCount": 697,
       "sorries": 0,
       "axiomCount": 1,
-      "theoremCount": 21,
-      "definitionCount": 5
+      "theoremCount": 33,
+      "definitionCount": 8
     }
   ]
 }


### PR DESCRIPTION
## Summary

Session 6 of `amgm-inequality-oq-04-oq-02` (researcher-6, RICH score 40).

Adds §10 to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — the **K-side analog of §8** (S4's `dIntegrandE` infrastructure). The Whittaker–Watson §22.41 Wronskian programme needs both `dE/dk = (E − K)/k` AND `dK/dk = (E − (1−k²)K) / (k(1−k²))` to discharge `legendre_relation`. §8 set up the chain-rule + algebraic-split + integral-identity for the E-side; this PR provides the **chain-rule infrastructure** for the K-side.

## What's new (§10, +132 lines)

Four declarations (1 def + 3 lemmas):

1. **`dIntegrandK k θ`** (def): `k · sin²θ / [(1 − k² sin²θ) · √(1 − k² sin²θ)]` — the partial derivative `∂_k (1 − k² sin²θ)^{−1/2}` of the K-integrand. Written in the `(1 − u) · √(1 − u)` form (rather than `(1 − u)^{3/2}`) to match the result of `HasDerivAt.div` directly, avoiding any `Real.rpow` rewriting.

2. **`dIntegrandK_continuous (hk : k² < 1)`**: continuity, by the same `Continuous.div₀` template as `dIntegrandE_continuous`.

3. **`dIntegrandK_integrable (hk : k² < 1)`**: interval-integrability on `[0, π/2]`, immediate from continuity.

4. **`integrandK_hasDerivAt_in_k (hk : k² < 1) (θ : ℝ)`**: **pointwise chain rule** \`HasDerivAt (fun κ => ellipticIntegrand κ θ) (dIntegrandK k θ) k\`. Proof: chain rule on inner polynomial \`1 − κ² sin²θ\`, \`HasDerivAt.sqrt\`, \`HasDerivAt.div\` of constant 1 over \`√(1 − κ² sin²θ)\`, algebraic reduction using \`Real.mul_self_sqrt\` plus \`field_simp; ring\`.

## Why independent of #17358 / pending E-side work

- §10 only touches the K-integrand and depends only on §1-§2 of OQ04OQ01.
- Does **not** reference \`dIntegrandE\`, \`boundDIntegrandE\`, or any §8/§9 names.
- After this lands, the K-bound + K-assembly tracks can proceed in parallel with E-side.

## K-side algebraic split is NOT pointwise (deferred)

The K-analog \`k(1−k²) · dIntegrandK = E_int − (1−k²)·K_int\` is **not** pointwise. LHS reduces to \`k²(1−k²) sin²θ / (1 − k²sin²θ)\` and RHS reduces to \`k² cos²θ\`; equality would require \`(1−k²) sin²θ = cos²θ · (1 − k²sin²θ)\` which is not an identity. The K-side integral identity will need integration by parts on \`∫ k sin²θ (1 − k² sin²θ)^{−3/2} dθ\`. Deferred.

## Counts

| | Before | After | Δ |
|---|---|---|---|
| Lines | 565 | 697 | +132 |
| Theorems | 30 | 33 | +3 |
| Definitions | 7 | 8 | +1 |
| Sorries | 0 | 0 | 0 |
| Axioms | 1 | 1 | 0 |

## Build status

**Pending**. Host's \`proofs/.lake\` is a recursive self-symlink (memory \`feedback_researcher_lake_symlink_broken\`); quick local build impossible. Structurally proofs follow §8 templates so risk is API-name drift only. CI is the ground truth.

## Test plan

- [ ] CI Docker build with \`LEAN_BUILD_TIMEOUT=60m\`
- [ ] If clean: §10 lands; future sessions begin K-side IBP for algebraic split / integral identity
- [ ] If \`field_simp; ring\` doesn't close \`h_eq_deriv\`: fall back to \`linear_combination\` over \`Real.mul_self_sqrt\`-rewritten goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)