### PR TITLE
fix(meta): batch sync leanFile.axiomCount overclaim (8 entries)

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -187,7 +187,7 @@
     ],
     "namespace": "BertrandsPostulateOQ03OQ04OQ03",
     "lineCount": 213,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",
     "theoremCount": 4,

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
@@ -137,7 +137,7 @@
   "leanFile": {
     "path": "Proofs/BirchSwinnertonDyerOQ06OQ02.lean",
     "sorries": 0,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 1,
     "lineCount": 249

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -141,7 +141,7 @@
     "lineCount": 155,
     "theoremCount": 9,
     "defCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
@@ -142,7 +142,7 @@
   "leanFile": {
     "lineCount": 171,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean",
-    "axiomCount": 2,
+    "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
     "theoremCount": 5

--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -206,7 +206,7 @@
     ],
     "namespace": "SophieGermainOQ01",
     "lineCount": 196,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 1,
     "sorries": 0,

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -177,7 +177,7 @@
     ],
     "namespace": "SzemerediDensity",
     "lineCount": 118,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/SzemerediFullOQ02.lean",

--- a/src/data/proofs/twin-primes-special-oq-01/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-01/meta.json
@@ -222,7 +222,7 @@
     ],
     "namespace": "TwinPrimesSpecialOQ01",
     "lineCount": 150,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 0,
     "sorries": 0,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -205,7 +205,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Fix

Sync `leanFile.axiomCount` in 8 entries where the leanFile sub-block claimed N axioms but the actual `axiom` keyword count in the file is 0. The total assumption count (`meta.axiomCount`) is unchanged — assumptions live in imported sibling files or parent modules.

## Evidence

Per the auditor's documented convention (`scripts/auditor/find-targets.ts`):

```
// leanFile.axiomCount counts only the main file
// meta.axiomCount counts the total (including imports/structures)
```

Each file below was verified to contain 0 `axiom` declarations, 0 `opaque` declarations, and 0 structures (which would carry assumption-bearing fields):

| Slug | Was → Is | Assumption lives in |
|------|----------|---------------------|
| bertrands-postulate-oq-03-oq-04-oq-03 | 1 → 0 | `Proofs.PrimeNumberTheorem` |
| birch-swinnerton-dyer-oq-06-oq-02 | 2 → 0 | `Proofs.BirchSwinnertonDyerOQ06` |
| bounded-prime-gaps-oq-01-oq-03 | 1 → 0 | `Proofs.BoundedPrimeGapsOQ03` |
| brouwer-fixed-point-oq-01-oq-02-oq-03 | 2 → 0 | `Proofs.BrouwerFixedPoint{,OQ01OQ02}` |
| sophie-germain-oq-01 | 1 → 0 | `Proofs.SophieGermain` |
| szemeredi-full-oq-02 | 1 → 0 | `Proofs.SzemerediTheorem` |
| twin-primes-special-oq-01 | 1 → 0 | `Proofs.TwinPrimes` |
| yang-mills | 1 → 0 | `Proofs.YangMills.Classical` |

For each entry, the meta-level `meta.axiomCount` (chain total) is preserved, and `status="axiomatized"`/`badge="axiom"` are preserved per the Axiom Integrity Policy. Each file's docstring or `assumptions` field already documents that the assumption is inherited from the named parent/sibling module.

The auditor's `find-targets.ts` only flags `actual > claimed` (undercount), not overclaim — these slipped past automated detection but cause `leanFile`-level inaccuracy in the gallery UI.

🤖 Automated fix by lean-mechanic agent.