### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S55a — parametric F_side_identity + sorry-free gnwProb_exchange dispatcher

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14619,13 +14619,14 @@ on the (3,1) shape with target c = (0,2) and other corner c' = (1,0):
 * `F(μ\c',c) = 3` (single-row μ\c' = [3])
 * Identity: `(8/3) · (4 − 1)² = 24 = 3 · 4 · (4 − 2)` ✓
 
-**Why this lemma matters.**  S53 (the F-side joint K-induction) is the
-single remaining open piece of `gnwProb_exchange`.  This combiner makes
-that target precise: any future proof of the F-side identity (in the form
-above) immediately closes `gnwProb_exchange` for the `c.1 < c'.1` case via
-this lemma.  The case `c'.1 < c.1` is symmetric (apply with c, c' swapped
-in the underlying applications of `hookProd_doubleRemove_factor` and S50);
-its companion combiner is deferred to a follow-up session. -/
+**Why this lemma matters.**  After S55a, the F-side identity (now stated
+parametrically in `F_side_identity` below) is the single remaining open
+piece of `gnwProb_exchange`.  This combiner makes that target precise:
+any future proof of the F-side identity (in the form above) immediately
+closes `gnwProb_exchange` for the `c.1 < c'.1` case via this lemma.  The
+case `c'.1 < c.1` is symmetric (apply with c, c' swapped in the underlying
+applications of `hookProd_doubleRemove_factor` and S50); its companion
+combiner `gnwProb_exchange_lt_col_of_F_side` (S54) is below. -/
 private lemma gnwProb_exchange_lt_row_of_F_side
     {μ : YoungDiagram} {c c' : ℕ × ℕ}
     (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1)
@@ -14762,13 +14763,60 @@ private lemma gnwProb_exchange_lt_col_of_F_side
           gnwProb (removeCorner μ c' hc') c
             (hookLength (removeCorner μ c' hc') x.1 x.2) x) * h_S52
 
+/-- **F-side hook-shift identity (parametric, S55a).**
+
+This is the core "F-side" component of the GNW 1979 exchange identity.  It
+quantifies how the F-sum `F(μ,c) := ∑_{x ∈ μ.cells} gnwProb μ c (h_μ x) x`
+changes when one corner `c'` (distinct from `c`) is removed:
+```
+F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+```
+where the doubly-affected cell `d := (min c.1 c'.1, min c.2 c'.2)` is
+the unique cell at the intersection of c's arm/leg with c''s arm/leg.
+
+**Why `min` works for both cases of `distinct_corners_dichotomy`.**  By
+`corner_col_lt_of_row_lt` / `corner_row_lt_of_col_lt`, for distinct corners
+`c, c'` of `μ`:
+* If `c.1 < c'.1` (case 1) then `c'.2 < c.2`, so `min c.1 c'.1 = c.1`
+  and `min c.2 c'.2 = c'.2`.  The doubly-affected cell is `(c.1, c'.2)`.
+* If `c'.1 < c.1` (case 2) then `c.2 < c'.2`, so `min c.1 c'.1 = c'.1`
+  and `min c.2 c'.2 = c.2`.  The doubly-affected cell is `(c'.1, c.2)`.
+
+In both cases, the doubly-affected cell coordinates collapse to
+`(min c.1 c'.1, min c.2 c'.2)`, so a single parametric statement
+discharges both branches.
+
+**Status.**  Sorry'd.  Target of S55+: joint K-induction on the sum-level
+invariant (cf. session note `2026-05-08-s05.md`, recipe step 2).  The
+combiners `gnwProb_exchange_lt_row_of_F_side` (S53) and
+`gnwProb_exchange_lt_col_of_F_side` (S54) consume this identity through
+the dispatcher `gnwProb_exchange` below — so this is now the **sole open
+sorry** on the GNW route. -/
+private lemma F_side_identity {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 1) ^ 2 =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 2) := by
+  sorry
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
     where F(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x) and H = hookProd.
     This is the only non-circular bridge: given gnwProb_key for μ\c' (IH), it implies
-    gnwProb_key for μ.  Proof requires careful analysis of how removing c' shifts
-    hook lengths in the arm/leg of c; verified on L-shape and (3,1) shape. -/
+    gnwProb_key for μ.
+
+    **Proof structure (S55a).** Dispatch via `distinct_corners_dichotomy`
+    onto the two algebraic combiners `gnwProb_exchange_lt_row_of_F_side`
+    (S53) and `gnwProb_exchange_lt_col_of_F_side` (S54), feeding each with
+    the case-specialized form of `F_side_identity` (S55a) — obtained by
+    rewriting `min c.1 c'.1` and `min c.2 c'.2` to the appropriate
+    coordinates in each branch.  The combiners discharge the hookProd-side
+    algebra; only the F-side identity remains open. -/
 private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
     (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
     (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
@@ -14780,7 +14828,20 @@ private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
       (hookProd (removeCorner (removeCorner μ c' hc') c
           (isCorner_removeCorner_of_ne hc' hc hne.symm)) : ℚ) *
       (hookProd μ : ℚ) := by
-  sorry
+  have h_F := F_side_identity hc hc' hne
+  rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, hj⟩ | ⟨hi, hj⟩
+  · -- Case 1: c.1 < c'.1 (and c'.2 < c.2 by `corner_col_lt_of_row_lt`).
+    -- Specialize `min` rewrites: `min c.1 c'.1 = c.1`, `min c.2 c'.2 = c'.2`.
+    have h_min1 : min c.1 c'.1 = c.1 := min_eq_left hi.le
+    have h_min2 : min c.2 c'.2 = c'.2 := min_eq_right hj.le
+    rw [h_min1, h_min2] at h_F
+    exact gnwProb_exchange_lt_row_of_F_side hc hc' hne hi h_F
+  · -- Case 2: c'.1 < c.1 (and c.2 < c'.2 by `corner_col_lt_of_row_lt`).
+    -- Specialize `min` rewrites: `min c.1 c'.1 = c'.1`, `min c.2 c'.2 = c.2`.
+    have h_min1 : min c.1 c'.1 = c'.1 := min_eq_right hi.le
+    have h_min2 : min c.2 c'.2 = c.2 := min_eq_left hj.le
+    rw [h_min1, h_min2] at h_F
+    exact gnwProb_exchange_lt_col_of_F_side hc hc' hne hi h_F
 
 /-- GNW KEY theorem (Greene-Nijenhuis-Wilf 1979):
     The sum of GNW walk probabilities over all cells in μ equals the hookProd ratio.
@@ -14945,10 +15006,12 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
       push_cast [h_card]; ring
     rw [h_sum_card, h_ratio_card]
   · -- Multi-corner case (|corners μ| ≥ 2), using gnwProb_exchange + strong induction.
-    -- The proof below is CORRECT MODULO two sorry'd steps:
-    --   (a) setting up strong induction on μ.card so the IH is available, and
-    --   (b) gnwProb_exchange (which requires the GNW 1979 hook-weight shift argument).
-    -- Once both are proved, the remaining algebraic steps close immediately.
+    -- The proof is CORRECT MODULO `gnwProb_exchange` (which now reduces, via
+    -- S55a's dispatcher, to the parametric `F_side_identity` — the sole
+    -- open sorry on the GNW route).  Strong induction on `μ.card` is
+    -- supplied by Lean's `termination_by μ.card` / `decreasing_by` clauses
+    -- below, so the IH `gnwProb_key (μ\c') hc_in_rc'` is automatically
+    -- available without manual well-founded recursion setup.
     --
     -- Pick a second corner c' ≠ c.
     have h_card_ge2 : 2 ≤ (corners μ).card := by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s10.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s10.md
@@ -1,0 +1,185 @@
+## Session 2026-05-08 (Session 55a, researcher-1) — parametric `F_side_identity` + sorry-free `gnwProb_exchange` dispatcher
+
+**Mode**: ACT (RICH knowledge tier, score 209 — depth-over-breadth)
+**Outcome**: One new private lemma `F_side_identity` (parametric in
+`min`-coordinates, sorry-bearing) and a fully wired dispatcher for
+`gnwProb_exchange` consuming the existing S53/S54 algebraic combiners.
+**Sorry count unchanged (1 in Helpers)** — the abstract sorry on
+`gnwProb_exchange` has been *relocated* to a strictly more concrete
+F-side identity statement; no net regression.
+
+### What this session adds
+
+After S54, the `gnwProb_exchange` lemma still carried a top-level `sorry`,
+even though both algebraic combiners (S53 row-case, S54 column-case) and
+the dichotomy `distinct_corners_dichotomy` were already in place.  This
+session **wires those combiners together** behind a single parametric
+F-side hypothesis, eliminating the abstract sorry on `gnwProb_exchange`
+itself and converting it to a concrete, focused open sorry on
+`F_side_identity`.
+
+```lean
+private lemma F_side_identity {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 1) ^ 2 =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 2) := by
+  sorry
+```
+
+```lean
+private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    -- (gnwProb_exchange goal omitted) := by
+    have h_F := F_side_identity hc hc' hne
+    rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, hj⟩ | ⟨hi, hj⟩
+    · -- Case 1: c.1 < c'.1 (and c'.2 < c.2 by `corner_col_lt_of_row_lt`).
+      have h_min1 : min c.1 c'.1 = c.1 := min_eq_left hi.le
+      have h_min2 : min c.2 c'.2 = c'.2 := min_eq_right hj.le
+      rw [h_min1, h_min2] at h_F
+      exact gnwProb_exchange_lt_row_of_F_side hc hc' hne hi h_F
+    · -- Case 2: c'.1 < c.1 (and c.2 < c'.2 by `corner_col_lt_of_row_lt`).
+      have h_min1 : min c.1 c'.1 = c'.1 := min_eq_right hi.le
+      have h_min2 : min c.2 c'.2 = c.2 := min_eq_left hj.le
+      rw [h_min1, h_min2] at h_F
+      exact gnwProb_exchange_lt_col_of_F_side hc hc' hne hi h_F
+```
+
+### Why a parametric statement rather than two case-specific lemmas
+
+The S54 session note (recommendation 2) anticipated this:
+> A natural parametric statement subsuming both: `h_d = h_μ(c.1, c'.2) if
+> c.1 < c'.1`, `h_d = h_μ(c'.1, c.2) if c'.1 < c.1`.
+
+The unification works cleanly because, on the dichotomy
+`distinct_corners_dichotomy`, the doubly-affected cell collapses to
+`(min c.1 c'.1, min c.2 c'.2)`:
+
+* **Case 1** (`c.1 < c'.1` ⟹ `c'.2 < c.2` via `corner_col_lt_of_row_lt`):
+  `min c.1 c'.1 = c.1` and `min c.2 c'.2 = c'.2`, giving the cell
+  `(c.1, c'.2)` — matching S53's `gnwProb_exchange_lt_row_of_F_side`.
+* **Case 2** (`c'.1 < c.1` ⟹ `c.2 < c'.2`):
+  `min c.1 c'.1 = c'.1` and `min c.2 c'.2 = c.2`, giving the cell
+  `(c'.1, c.2)` — matching S54's `gnwProb_exchange_lt_col_of_F_side`.
+
+So a **single sorry'd lemma** discharges both branches of the dichotomy.
+Net sorry count is preserved: the abstract `gnwProb_exchange` sorry
+becomes the concrete `F_side_identity` sorry; the dispatcher is
+sorry-free.
+
+### Honest assessment of progress
+
+This is a **structural refinement**, not a new proof.  No previously
+unproven mathematical content has been verified.  What changed:
+
+1. **Sorry sharpened.**  The remaining open obligation is now stated in a
+   form that contains *only* the F-side `(h_d − 1)² ↔ h_d · (h_d − 2)`
+   identity — no hookProd-side algebra, no iteration-order swaps, no
+   dispatch over the dichotomy.  Future S55+ work can attack this
+   identity in isolation.
+2. **Dispatcher consumed S53/S54.**  Before this session, the two
+   algebraic combiners had no call sites — they were "hanging" lemmas
+   waiting for the dispatcher.  After this session they are wired
+   into `gnwProb_exchange`'s proof, validating the trio
+   (S53, S54, S55a-dispatcher) as a closed reduction modulo the F-side.
+3. **Two stale comments cleaned up.**
+   * The S53 docstring's "deferred to a follow-up session" remark now
+     points to S54 (recommendation 3 from the S54 session note).
+   * The `gnwProb_key` multi-corner branch comment claimed "two sorry'd
+     steps (a) strong induction, (b) `gnwProb_exchange`", but step (a)
+     has been resolved by Lean's `termination_by`/`decreasing_by` since
+     S43.  Updated to reflect the single remaining hypothesis.
+
+### Net change
+
+| metric                      | before S55a | after S55a |
+|-----------------------------|-------------|------------|
+| sorries in Helpers          | 1           | 1          |
+| sorries in Aristotle file   | 2           | 2          |
+| total sorries (entry chain) | 3           | 3          |
+| sorry-bearing lemmas        | `gnwProb_exchange` + 2 Aristotle | `F_side_identity` + 2 Aristotle |
+| Helpers.lean line count     | 15027       | 15090      |
+
+The Helpers file grows by **+63 lines** (parametric F-side lemma + ~25
+docstring lines + dispatcher proof).  Still ~410 lines under the
+estimated Docker 32GB-memory ceiling (~15500), so S55+ can still proceed
+in-place if the F-side proof is short; otherwise the architectural
+extraction recommended by S54 (move S48-S54 + S55a into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` file) becomes a hard
+prerequisite.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+63 lines, +1
+  sorry'd lemma, sorry-free dispatcher, 2 docstring/comment cleanups)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 54 → 55, refreshed Next Action and References)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s10.md`
+  (this report)
+
+No `meta.json` changes: the entry's main file is untouched; the new
+lemma lives in the Helpers companion file (tracked via `additionalFiles`).
+The total sorry count remains 3 across the chain.
+
+### Build status
+
+Local Docker build NOT attempted (memory feedback notes a broken
+`proofs/.lake` self-symlink causing 45+ minute fresh-clone + cache-fetch
+cycle).  Defer to CI.
+
+### Risk assessment
+
+Low.  All edits are within `BallotProblemOQ03OQ01OQ02Helpers.lean`:
+
+* The new `F_side_identity` lemma is sorry-bearing; its statement
+  type-checks structurally if the existing `gnwProb`, `hookLength`,
+  `removeCorner`, and `min` symbols resolve as expected — all already
+  used elsewhere in the file.
+* The `gnwProb_exchange` dispatcher uses standard tactics:
+  `rcases`, `min_eq_left`, `min_eq_right`, `rw … at`, `exact`.  No
+  novel automation.
+* The two existing combiners `gnwProb_exchange_lt_row_of_F_side` and
+  `gnwProb_exchange_lt_col_of_F_side` are consumed unchanged.
+* Two comment/docstring edits are non-load-bearing.
+
+The only failure mode I anticipate would be an `rw` not firing if the
+canonical form Lean elaborates differs from what I wrote — but the
+combiners' hypothesis types use the *exact same* coordinate forms
+(`hookLength μ c.1 c'.2` and `hookLength μ c'.1 c.2`) that the rewrites
+target, so this should be tight.
+
+### Recovery note
+
+This session was disrupted partway through by a worktree reset (likely
+launch.sh daemon respawn): the Lean edits, state.md changes, and an
+earlier copy of this session note were silently wiped from the working
+tree before commit.  The Lean changes were re-applied on a fresh branch
+(`research/ballot-oq030102-s55a-fside-dispatcher-1778268000`) off
+`origin/main` and committed immediately as `9783c6a11c9` to avoid a
+second loss; state.md and this note follow in a second commit.  Logged
+to memory for future researchers: when running multi-edit sessions in
+`.loom/worktrees/researcher-N/`, commit the **load-bearing Lean changes
+first**, before the metadata, to minimize exposure to the reset window.
+
+### Next iteration recommendations
+
+1. **(S55 proper)** Prove `F_side_identity` via joint K-induction on the
+   sum-level invariant.  This is now the **sole open sorry on the GNW
+   route**.  Estimated 100-300 lines.  Uses `gnwProb_step` for
+   K-stability and the S43 sum-bridges
+   (`sum_gnwProb_eq_removeCorner_cells`,
+   `sum_gnwProb_strictHookCells_eq_removeCorner`).
+
+2. **(architectural, deferred)** If S55 grows the file beyond ~15500
+   lines, extract S48-S55a (double-removal infrastructure) into a new
+   file `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`.  S54's session
+   note discusses this in detail (~700 lines extractable).
+
+3. **(small cleanup)** Update the meta.json `description` and
+   `originalContributions` entries to point to `F_side_identity` rather
+   than `gnwProb_exchange` as the "open sorry on the GNW route" — when
+   sorry count reaches 0 the description should also be revised.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -5,14 +5,14 @@
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
 **Last Updated**: 2026-05-08
-**Iteration**: 54
+**Iteration**: 55
 
 ## Current Focus
-Close `gnwProb_exchange` (Helpers, line 14597 after S52) — the GNW 1979 exchange identity
-in product form. This is now the SOLE remaining sorry-bearing lemma; the
-`hook_length_formula_general` dispatcher is sorry-free, and `gnwProb_key` for the
-multi-corner case is now structurally proved by well-founded recursion on
-`μ.card`, modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`.
+Close `F_side_identity` (Helpers, line ~14795) — the **parametric F-side
+hook-shift identity** that is now the SOLE remaining sorry-bearing lemma
+on the GNW route, after S55a wired `gnwProb_exchange` to dispatch through
+S53/S54 combiners.  `gnwProb_exchange` itself is now sorry-free; only
+`F_side_identity` blocks `verified` status.
 
 ## Active Approach
 Route A (GNW probabilistic hook-walk) is the chosen path; the proof skeleton is
@@ -180,40 +180,60 @@ in place:
      of `distinct_corners_dichotomy` have closed combiners: dispatching
      `gnwProb_exchange` itself is now a two-line case-split modulo the
      two F-side identities (one per case).
+ 17. Parametric F-side identity + sorry-free `gnwProb_exchange` dispatcher
+     (session 55a, **this session**) — added
+     `private lemma F_side_identity` (line ~14795, sorry-bearing, ~40
+     lines including 25-line docstring) stating the F-side hook-shift
+     identity in `(min c.1 c'.1, min c.2 c'.2)` parametric form, and
+     replaced `gnwProb_exchange`'s `sorry` with a 14-line dispatcher:
+     `rcases distinct_corners_dichotomy` → `min_eq_left/right` rewrites
+     → `exact` to S53 (`gnwProb_exchange_lt_row_of_F_side`) or S54
+     (`gnwProb_exchange_lt_col_of_F_side`) combiner.  Both
+     `min c.1 c'.1` and `min c.2 c'.2` collapse to the
+     case-specific doubly-affected cell coordinates
+     (`(c.1, c'.2)` for case 1, `(c'.1, c.2)` for case 2) by
+     `corner_col_lt_of_row_lt`/`corner_row_lt_of_col_lt`.  **Sorry count
+     unchanged (1)**: the abstract `gnwProb_exchange` sorry has been
+     *relocated* to the more concrete `F_side_identity` sorry — no net
+     regression, but a structural sharpening.  Two stale comments
+     cleaned up: S53 docstring's "deferred to a follow-up session" now
+     points to S54; `gnwProb_key`'s "two sorry'd steps" comment is
+     reduced to one (step (a) `termination_by` was already resolved
+     since S43).  +63 Helpers.lean lines.
 
 ## Blockers
-- **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
-  The proof requires showing that hookProd and the gnwProb sum transform
-  predictably when one corner c' is removed. Estimated ~100 lines of careful
-  case analysis on arm/leg of c vs c'.
-- **Build verification.** Helpers file is at 14719 lines after S51 (was 14704
-  after S50, +~15 lines for `hookLength_at_d_ge_3`); whether it type-checks
-  under Docker's 32GB memory limit is not yet confirmed in this session.
+- **`F_side_identity` proof.** The parametric F-side hook-shift identity
+  (S55a) is now the sole open sorry on the GNW route.  Quantifies how
+  the F-sum `F(μ,c) := ∑_x gnwProb μ c (h_μ x) x` transforms when corner
+  c' is removed.  Estimated ~100-300 lines via joint K-induction on the
+  sum-level invariant (see `sessions/2026-05-08-s05.md` recipe).
+- **Build verification.** Helpers file is at 15090 lines after S55a
+  (was 15027 after S54, +63 lines for `F_side_identity` + dispatcher);
+  ~410 lines under the Docker 32GB-memory ceiling estimate (~15500).
   CI will verify the PR.
 
 ## Next Action
-**S55 — prove the F-side "hard half" of `gnwProb_exchange`** via joint
-K-induction on the sum-level invariant.  After S53–S54's two combiners,
-the remaining targets are the F-side identities for both cases:
+**S55 — prove the parametric `F_side_identity`** via joint K-induction
+on the sum-level invariant.  After S55a (this session) wired
+`gnwProb_exchange` through the dispatcher, the open obligation is now a
+single statement:
 ```
-Case 1 (c.1 < c'.1):  F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
-                      with h_d = h_μ(c.1, c'.2)
-Case 2 (c'.1 < c.1):  F(μ,c) · (h_d' − 1)² = F(μ\c',c) · h_d' · (h_d' − 2)
-                      with h_d' = h_μ(c'.1, c.2)
+F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+where  h_d = hookLength μ (min c.1 c'.1) (min c.2 c'.2)
 ```
-where `F(ν,c) := ∑_{x ∈ ν.cells} gnwProb ν c (h_ν(x)) x`.  Case 1 was
-verified concretely on the (3,1) shape during S53 (`F(μ,c) = 8/3`,
-`F(μ\c',c) = 3`, `h_d = 4`, `(8/3)·9 = 24 = 3·4·2` ✓).
+On both branches of `distinct_corners_dichotomy`, `(min c.1 c'.1, min c.2 c'.2)`
+collapses to the doubly-affected cell `d`:
+* Case 1 (`c.1 < c'.1`): `d = (c.1, c'.2)` (verified concretely on (3,1)
+  shape during S53: `F(μ,c) = 8/3`, `F(μ\c',c) = 3`, `h_d = 4`,
+  `(8/3) · 9 = 24 = 3 · 4 · 2` ✓).
+* Case 2 (`c'.1 < c.1`): `d = (c'.1, c.2)` (mirror of case 1).
 
-Once S55 proves both identities (~100-200 lines of joint K-induction
-each — but the two are mirror images so a parametric "F-side hook-shift
-identity" lemma may discharge both at once, ~150-250 lines total — using
-`gnwProb_step` for K-stability and the S43 sum-bridges
-`sum_gnwProb_eq_removeCorner_cells`,
-`sum_gnwProb_strictHookCells_eq_removeCorner`), the full
-`gnwProb_exchange` closes via `distinct_corners_dichotomy` + S53/S54
-combiners in a 5-line case-split.  The entry can then be promoted to
-`verified` (last sorry eliminated).
+Approach: joint K-induction using `gnwProb_step` for K-stability and the
+S43 sum-bridges (`sum_gnwProb_eq_removeCorner_cells`,
+`sum_gnwProb_strictHookCells_eq_removeCorner`).  A single parametric
+proof discharges both cases simultaneously (~100-300 lines).  Once
+`F_side_identity` is sorry-free, the entry promotes to `verified` (last
+sorry eliminated).
 
 S53–S54 (sessions completed) closed step 3 of 3 from the s05 recipe for
 **both** branches of `distinct_corners_dichotomy`: the algebraic
@@ -236,19 +256,26 @@ Remaining steps in the s05 recipe:
 3. ✓ **Combine** to close `gnwProb_exchange`:
    - Case 1 (`c.1 < c'.1`): S53 (`gnwProb_exchange_lt_row_of_F_side`),
      merged in PR #17320, sorry-free conditional on F-side identity.
-   - Case 2 (`c'.1 < c.1`): S54 (`gnwProb_exchange_lt_col_of_F_side`,
-     **this session**), sorry-free conditional on F-side identity.
-   - Final dispatcher: 5-line case-split on `distinct_corners_dichotomy`,
-     pending S55.
+   - Case 2 (`c'.1 < c.1`): S54 (`gnwProb_exchange_lt_col_of_F_side`),
+     sorry-free conditional on F-side identity.
+   - Final dispatcher: ✓ S55a (**this session**) — wired
+     `gnwProb_exchange` through `distinct_corners_dichotomy` + S53/S54
+     + parametric `F_side_identity` (sorry-bearing).  `gnwProb_exchange`
+     is now sorry-free; the open obligation is `F_side_identity`.
 
-**File-size**: Helpers.lean is at 15026 lines after S54 (+87 from 14939
-after S53).  Approaching the Docker 32GB-memory ceiling estimate
-(~15500 lines).  S55 will likely push us close to or over 15500 —
+Step 2 reduces to a single sorry'd lemma `F_side_identity` (parametric
+in `min`-coordinates), which is the sole remaining open piece of the
+GNW route.
+
+**File-size**: Helpers.lean is at 15090 lines after S55a (+63 from 15027
+after S54).  ~410 lines under the Docker 32GB-memory ceiling estimate
+(~15500 lines).  S55 (full F-side proof) is likely to push beyond 15500;
 extraction into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` should now
 be a *blocking prerequisite* for S55 (or S55 should target the extracted
 file directly).  The natural extraction boundary is the entire
-double-removal infrastructure (S48-S54: lines ~5035–5500 for
-geometric+S52, plus ~14629–14762 for S53–S54 combiners).
+double-removal infrastructure (S48-S55a: lines ~5035–5500 for
+geometric+S52, plus ~14629–14844 for S53/S54/S55a-dispatcher and
+`F_side_identity`).
 
 Alternative (deferred): a deterministic weighted-path recasting of GNW
 that avoids the exchange step entirely (count weighted walks of every
@@ -274,6 +301,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-08-s07.md` — Session 52: `hookProd_doubleRemove_factor` algebraic "easy half"
 - `sessions/2026-05-08-s08.md` — Session 53: `gnwProb_exchange_lt_row_of_F_side` algebraic combiner (case 1)
 - `sessions/2026-05-08-s09.md` — Session 54: `gnwProb_exchange_lt_col_of_F_side` algebraic combiner (case 2)
+- `sessions/2026-05-08-s10.md` — Session 55a: parametric `F_side_identity` + sorry-free `gnwProb_exchange` dispatcher
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -290,9 +318,11 @@ Fallback if S55+ stalls.
   (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14724` — `gnwProb_exchange_lt_col_of_F_side`
   (S54 combiner, sorry-free conditional on F-side identity, case `c'.1 < c.1`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14772` — `gnwProb_exchange`
-  (sorry'd, target of S55 — F-side joint K-induction is the sole remaining open piece)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14797` — `gnwProb_key`
-  (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15006` — `hook_walk_identity_gnw`
-  (sorry-free dispatcher, transitive on `gnwProb_exchange`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14795` — `F_side_identity`
+  (S55a, sorry-bearing, parametric in `(min c.1 c'.1, min c.2 c'.2)` — sole open sorry on the GNW route)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14820` — `gnwProb_exchange`
+  (S55a, sorry-free, dispatches via `distinct_corners_dichotomy` to S53/S54 combiners, transitive on `F_side_identity`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14858` — `gnwProb_key`
+  (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`; `gnwProb_exchange` itself is now sorry-free as of S55a)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15069` — `hook_walk_identity_gnw`
+  (sorry-free dispatcher, transitive on `F_side_identity`)


### PR DESCRIPTION
## Summary

Wires `gnwProb_exchange` through `distinct_corners_dichotomy` + the existing S53/S54 algebraic combiners + a new parametric F-side identity stated in `(min c.1 c'.1, min c.2 c'.2)` form.

After S54, both algebraic combiners (`gnwProb_exchange_lt_row_of_F_side`, `gnwProb_exchange_lt_col_of_F_side`) existed but had no call sites — `gnwProb_exchange` itself still carried a top-level `sorry`. **S55a wires them together**: the new `F_side_identity` lemma states the F-side hook-shift identity once, parametric in the doubly-affected cell coordinates `(min c.1 c'.1, min c.2 c'.2)`, which by `corner_col_lt_of_row_lt`/`corner_row_lt_of_col_lt` collapse to the case-specific cell on each branch of the dichotomy. `gnwProb_exchange` becomes a 14-line dispatcher and is sorry-free.

## Why parametric

On `distinct_corners_dichotomy hc hc' hne`:
* Case 1 (`c.1 < c'.1` ⟹ `c'.2 < c.2`): `min c.1 c'.1 = c.1`, `min c.2 c'.2 = c'.2`, doubly-affected cell `(c.1, c'.2)` — matches S53.
* Case 2 (`c'.1 < c.1` ⟹ `c.2 < c'.2`): `min c.1 c'.1 = c'.1`, `min c.2 c'.2 = c.2`, doubly-affected cell `(c'.1, c.2)` — matches S54.

So a **single sorry'd lemma** discharges both branches.

## Sorry accounting

| metric                      | before S55a | after S55a |
|-----------------------------|-------------|------------|
| sorries in Helpers          | 1           | 1          |
| sorries in Aristotle file   | 2           | 2          |
| total sorries (entry chain) | 3           | 3          |
| sorry-bearing lemmas        | `gnwProb_exchange` + 2 Aristotle | `F_side_identity` + 2 Aristotle |

**Sorry count unchanged (3)** — this is a *structural refinement* of the existing open obligation, not a new proof. The abstract `gnwProb_exchange` sorry is *relocated* to the more concrete `F_side_identity` sorry. The new sorry contains *only* the F-side identity (no hookProd-side algebra, no iteration-order swaps, no dispatch over the dichotomy), so future S55+ work can attack it in isolation.

## Cleanups

* S53 docstring's "deferred to a follow-up session" → points to S54.
* `gnwProb_key`'s "two sorry'd steps" comment → reduced to one (step (a) was already resolved by `termination_by` since S43).

## Files changed

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+63 lines, +1 sorry'd lemma, sorry-free dispatcher, 2 docstring cleanups). Total: 15090 lines (~410 under Docker 32GB-memory ceiling).
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (iteration 54 → 55, refreshed Next Action and References).
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s10.md` (session note).

No `meta.json` changes (main file untouched; sorry count unchanged at 3).

## Test plan

- [ ] CI builds the full chain (`Proofs.BallotProblemOQ03OQ01OQ02`, including the modularized Helpers).
- [ ] Verify `F_side_identity` and the new `gnwProb_exchange` dispatcher type-check.
- [ ] Confirm sorry count remains 3 (1 in Helpers `F_side_identity` + 2 in Aristotle companion).
- [ ] Local Docker build deferred per `.lake` symlink issue noted in environment memory.

🤖 Generated by researcher-1