### PR TITLE
Enrich bezout-identity-oq-04-oq-01-oq-01: axioms section, line ranges, deeper openQuestions

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/annotations.json
@@ -24,7 +24,7 @@
   {
     "id": "ann-unimodular",
     "proofId": "bezout-identity-oq-04-oq-01-oq-01",
-    "range": { "startLine": 36, "endLine": 58 },
+    "range": { "startLine": 39, "endLine": 58 },
     "type": "concept",
     "title": "IsUnimodularPID: From det = ±1 to IsUnit det",
     "content": "Three theorems for IsUnimodularPID:\n\n1. **isUnimodularPID_one**: The identity matrix is unimodular — its determinant is 1, which is always a unit. Proof: `simp [IsUnimodularPID, det_one]`.\n\n2. **IsUnimodularPID.mul**: Product of unimodular matrices is unimodular — det(MN) = det(M)·det(N) is a product of units. Proof: `simp [IsUnimodularPID, det_mul]; exact hM.mul hN`. The `IsUnit.mul` combines two IsUnit hypotheses.\n\n3. **isUnimodularPID_int_iff**: Over ℤ, IsUnit↔{±1} via `Int.isUnit_iff`. This is the 'specialization' theorem — the abstract notion restricts to the concrete one.\n\nThe `GL_n(R) = {M | IsUnit det(M)}` connection: by Cramer's rule, M is invertible over R iff det(M) is a unit. So IsUnimodularPID is exactly the condition for M to have a two-sided inverse in the matrix ring — i.e., M ∈ GL_n(R).\n\nOver a field, every nonzero matrix is in GL_n (field units are all nonzero elements). Over ℤ, only ±1. Over k[X], units are scalar multiples.",
@@ -46,7 +46,7 @@
   {
     "id": "ann-snf-structure",
     "proofId": "bezout-identity-oq-04-oq-01-oq-01",
-    "range": { "startLine": 59, "endLine": 82 },
+    "range": { "startLine": 60, "endLine": 80 },
     "type": "technique",
     "title": "SmithNormalFormPID: Parameterizing the Decomposition over R",
     "content": "The `SmithNormalFormPID R m n` structure bundles all the data of the Smith Normal Form:\n- `U : Matrix (Fin m) (Fin m) R` — left unimodular factor\n- `D : Matrix (Fin m) (Fin n) R` — diagonal with invariant factors\n- `V : Matrix (Fin n) (Fin n) R` — right unimodular factor\n- `hU`, `hV` — IsUnimodularPID proofs\n- `hD_diag` — off-diagonal entries are 0\n- `hD_div` — divisibility chain d₁|d₂|...|dₖ\n\nTwo derived definitions:\n- `isDecompOf snf A` asserts `A = U * D * V`\n- `invariantFactor snf k` extracts D[k,k] (the k-th diagonal entry), returning 0 for out-of-range k\n\nThe structure is identical to BezoutIdentityOQ04OQ01 except: parameterized by `R` (not just `ℤ`), and `IsUnimodularPID` replaces the concrete det ∈ {±1} condition.\n\nThe divisibility chain in `hD_div` uses a careful Lean encoding: it quantifies over `k : ℕ` with bounds `k + 1 < min m n` and provides the Fin bounds as explicit parameters `hm, hn, hm', hn'`.",
@@ -69,7 +69,7 @@
   {
     "id": "ann-gcd-forward",
     "proofId": "bezout-identity-oq-04-oq-01-oq-01",
-    "range": { "startLine": 83, "endLine": 120 },
+    "range": { "startLine": 87, "endLine": 120 },
     "type": "technique",
     "title": "Main Theorem Setup: Extracting Entry Equations from A = U·D·V",
     "content": "The theorem `snf_1x2_invariant_factor_pid` is the mathematical core. The first half of the proof extracts the entry-level equations from the matrix equation `A = U·D·V`.\n\n**Setup**: Set `u = U[0,0]`, `d = D[0,0]`, `v00 = V[0,0]`, `v01 = V[0,1]`, `v10 = V[1,0]`, `v11 = V[1,1]`. The `set` tactic introduces local names for these values.\n\n**Claim: a = u·d·v00** (from [A = U·D·V][0,0]):\n- Expand the matrix product: (U·D·V)[0,0] = Σ_i Σ_j U[0,i]·D[i,j]·V[j,0]\n- For 1×2 case: U is 1×1, D is 1×2. The only term surviving is U[0,0]·D[0,0]·V[0,0] (since D[0,1] = 0 by hD_diag)\n- The `simp` with `Fin.sum_univ_one/two`, `Matrix.cons_val`, `Matrix.mul_apply` reduces to this.\n- `linear_combination h` closes the goal.\n\n**Claim: b = u·d·v01** (from [A = U·D·V][0,1]): analogously.\n\n**Part 1 (d | gcd)**: From `a = u·d·v00` and `b = u·d·v01`, we get d | a and d | b with witnesses u·v00 and u·v01. Then `dvd_gcd` gives d | gcd(a,b).",
@@ -91,7 +91,7 @@
   {
     "id": "ann-unit-cancellation",
     "proofId": "bezout-identity-oq-04-oq-01-oq-01",
-    "range": { "startLine": 121, "endLine": 148 },
+    "range": { "startLine": 121, "endLine": 154 },
     "type": "insight",
     "title": "The Key Innovation: unit.inv_val Replaces the ±1 Case Split",
     "content": "The backward direction (gcd | d) is where this proof differs fundamentally from the ℤ case. The innovation:\n\n**Key identity**: `a*v11 - b*v10 = u*d*(v00*v11 - v01*v10)` — proved by substituting `a = u*d*v00` and `b = u*d*v01` and using `ring`.\n\n**gcd divides LHS**: Since gcd|a and gcd|b, we get gcd | (a*v11 - b*v10) by `dvd_sub`.\n\n**u*(v00*v11 - v01*v10) is a unit**: `u = U[0,0]` is a unit (from IsUnimodularPID of U), and `v00*v11 - v01*v10 = det(V)` is a unit (from IsUnimodularPID of V). Their product is a unit by `hU_unit.mul hV_unit`.\n\n**The inv_val trick**: Get the Units representative `uval : Rˣ` with `↑uval = u*(v00*v11 - v01*v10)`. Then `uval.inv_val : uval.inv * ↑uval = 1`.\n\n**Cancellation**: From `↑uval * d = gcd * w` (via the divisibility chain), compute:\n```\nd = uval.inv * (↑uval * d)\n  = uval.inv * (gcd * w)\n  = gcd * (uval.inv * w)\n```\nThe first equality uses inv_val to get `uval.inv * ↑uval = 1`, then `1 * d = d`. This single abstract argument replaces the 4 concrete cases (u = ±1, det(V) = ±1) from the ℤ proof.",
@@ -112,9 +112,32 @@
     ]
   },
   {
+    "id": "ann-axioms",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-01",
+    "range": { "startLine": 156, "endLine": 171 },
+    "type": "context",
+    "title": "Why Two Axioms Remain: The Mathlib Module ↔ Matrix Bridge",
+    "content": "The two `axiom` declarations are the only remaining gaps. Both are theorems Mathlib already has machinery for, but in a different form:\n\n**snf_pid_exists**: For any PID $R$, every $A \\in M_{m \\times n}(R)$ has an SNF decomposition $A = U \\cdot D \\cdot V$. Mathlib has `Submodule.smithNormalForm` (in `Mathlib.LinearAlgebra.FreeModule.PID`) which gives a basis of $R^m$ in which the image $A(R^n)$ has SNF basis. Bridging requires translating between matrices (concrete entries) and submodules (abstract subspaces).\n\n**snf_pid_solvability**: $Ax = b$ is solvable iff for each row $i$, either $\\mathrm{invariantFactor}_i \\neq 0$ and divides $(Ub)_i$, or $\\mathrm{invariantFactor}_i = 0$ and $(Ub)_i = 0$. The intuition: SNF reduces $Ax = b$ to $Dy = Ub$ (with $y = Vx$), and a diagonal system $d_i y_i = c_i$ is solvable iff $d_i | c_i$ (or both sides are 0).\n\nThe axioms are stated with full PID hypotheses (`[CommRing R] [IsDomain R] [IsPrincipalIdealRing R]`) so they apply to ℤ, k[X], ℤ[i], etc. simultaneously. Once the bridge to `Submodule.smithNormalForm` is built, both axioms become theorems and this entry transitions from `axiomatized` to `verified`.\n\nThe authors chose to state these as axioms (rather than `sorry`) because: (1) they are *actually true* mathematical statements (not conjectures), (2) Aristotle proof search skips axioms entirely, signaling that human translation work is needed, and (3) the entire downstream theory is unblocked while the bridge is built.",
+    "mathContext": "The Mathlib bridge: given $A : R^n \\to R^m$, restrict to $A : R^n \\to A(R^n)$ surjectively, then `Submodule.smithNormalForm` gives bases $\\{e_i\\}$ of $R^m$ and $\\{f_j\\}$ of $A(R^n)$ with $f_j = d_j e_j$ and $d_1 | \\cdots | d_r$. Translating to matrix form: $U$ is the change of basis from standard $R^m$ to $\\{e_i\\}$, $V$ from $\\{a_j := A^{-1}(f_j)\\}$ to standard $R^n$, $D = \\mathrm{diag}(d_1, \\ldots, d_r, 0, \\ldots)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Submodule.smithNormalForm (Mathlib.LinearAlgebra.FreeModule.PID)",
+      "axiom vs sorry vs theorem (proof search semantics)",
+      "module ↔ matrix correspondence",
+      "diagonal system solvability via divisibility",
+      "axiomatized status vs verified status (gallery badge)"
+    ],
+    "prerequisites": [
+      "Mathlib finitely generated free modules over PIDs",
+      "Smith Normal Form for submodules",
+      "change-of-basis matrices and their unimodularity",
+      "Aristotle proof search skipping rules"
+    ]
+  },
+  {
     "id": "ann-bezout-pid",
     "proofId": "bezout-identity-oq-04-oq-01-oq-01",
-    "range": { "startLine": 149, "endLine": 165 },
+    "range": { "startLine": 172, "endLine": 191 },
     "type": "concept",
     "title": "Bezout in GCDMonoid and k[X] as PID",
     "content": "The final section provides the two directions of Bezout's identity and the canonical PID instance.\n\n**bezout_pid_forward** (any GCDMonoid): If ax+by=c, then gcd(a,b)|c. The proof is pure divisibility algebra:\n- gcd|a → gcd|ax (dvd_mul_of_dvd_left)\n- gcd|b → gcd|by (dvd_mul_of_dvd_left)\n- gcd|(ax+by) = c (dvd_add)\n\nThis holds in any GCDMonoid (no PID needed) — a GCDMonoid provides gcd_dvd_left and gcd_dvd_right, which suffice.\n\n**bezout_int_backward** (ℤ only): Uses `Int.gcdA` and `Int.gcdB` (the Bezout coefficients over ℤ satisfying `a * gcdA a b + b * gcdB a b = Int.gcd a b`). The proof multiplies through by k (the quotient c = k*gcd) and reassociates.\n\n**k[X] is a PID**: `instance {k : Type*} [Field k] : IsPrincipalIdealRing (Polynomial k) := inferInstance`. This instance is in Mathlib (Euclidean domains are PIDs, and k[X] is Euclidean via polynomial division). The single line makes the entire SNF theory available for polynomial rings over fields.\n\nThis means rational canonical form and Frobenius normal form — classical results of linear algebra — follow from the PID SNF theory instantiated at R = k[X].",

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -96,18 +96,26 @@
     {
       "id": "gcd-char",
       "title": "GCD Characterization: 1×2 Case",
-      "startLine": 83,
-      "endLine": 140,
+      "startLine": 82,
+      "endLine": 154,
       "summary": "Main theorem: the 1×2 invariant factor is associated to gcd(a,b) in any GCDMonoid. New vs. parent: uses unit.inv_val cancellation instead of ±1 case split.",
       "mathContext": "For [a, b] = U·D·V with U 1×1 unimodular and V 2×2 unimodular, extracting entries gives a = u·d·v₀₀ and b = u·d·v₀₁ where u = U[0,0] is a unit. Then d|a and d|b so d|gcd. For the reverse: a·v₁₁ - b·v₁₀ = u·d·det(V), and u·det(V) is a unit, so cancellation gives gcd|d."
     },
     {
+      "id": "axioms",
+      "title": "Existence and Solvability Axioms",
+      "startLine": 156,
+      "endLine": 171,
+      "summary": "Two axioms encode the genuine ring-theoretic↔matrix-theoretic gap in current Mathlib: snf_pid_exists (every matrix over a PID has an SNF) and snf_pid_solvability (Ax = b is solvable iff invariant factors satisfy a divisibility/zero-row criterion).",
+      "mathContext": "Mathlib has `Submodule.smithNormalForm` (LinearAlgebra.FreeModule.PID) for finitely generated submodules of free modules over PIDs, but bridging it to the matrix-theoretic `SmithNormalFormPID` structure requires picking bases and translating between $A : R^n \\to R^m$ and the image submodule $A(R^n) \\subseteq R^m$. The two axioms here are exactly the assumptions needed to use SNF as a black box, deferring this bridge as future work."
+    },
+    {
       "id": "bezout",
-      "title": "Bezout in GCDMonoid",
-      "startLine": 148,
-      "endLine": 165,
-      "summary": "Forward direction ax+by=c → gcd|c in any GCDMonoid. Backward direction for ℤ via Bezout coefficients.",
-      "mathContext": "The forward direction is purely algebraic and holds in any GCDMonoid. The backward direction requires Bezout coefficients (the existence of which is equivalent to the Bezout domain property, holding in any PID). Over ℤ, Int.gcdA and Int.gcdB provide these coefficients explicitly."
+      "title": "Bezout in GCDMonoid and the k[X] Instance",
+      "startLine": 172,
+      "endLine": 191,
+      "summary": "Forward direction ax+by=c → gcd|c in any GCDMonoid. Backward direction for ℤ via Bezout coefficients. Single-line k[X] is a PID instance via Mathlib inference.",
+      "mathContext": "The forward direction is purely algebraic and holds in any GCDMonoid. The backward direction requires Bezout coefficients (the existence of which is equivalent to the Bezout domain property, holding in any PID). Over ℤ, Int.gcdA and Int.gcdB provide these coefficients explicitly. The k[X] PID instance unlocks the entire SNF apparatus for polynomial matrices — the algebraic backbone of rational canonical form."
     }
   ],
   "conclusion": {
@@ -116,7 +124,9 @@
     "openQuestions": [
       "Prove snf_pid_exists by bridging Mathlib's Submodule.smithNormalForm (module-theoretic, in LinearAlgebra.FreeModule.PID) to the matrix-theoretic SmithNormalFormPID structure here",
       "Derive the structure theorem for finitely generated R-modules from snf_pid_exists + snf_pid_solvability: M ≅ R/d₁ ⊕ ... ⊕ R/dₖ ⊕ Rˡ with d₁|d₂|...|dₖ",
-      "Formalize rational canonical form for k[X]: the SNF of the matrix (tI - A) ∈ M_n(k[X]) gives the rational canonical form of the linear map A : k^n → k^n"
+      "Formalize rational canonical form for k[X]: the SNF of the matrix (tI - A) ∈ M_n(k[X]) gives the rational canonical form of the linear map A : k^n → k^n",
+      "Generalize snf_1x2_invariant_factor_pid to the m × 2 (and ultimately m × n) case: the first invariant factor d₁ should equal gcd of all entries; the k-th invariant factor d_k equals gcd of all k × k minors divided by gcd of (k-1) × (k-1) minors (Smith's classical formula)",
+      "Extend the unit.inv_val cancellation pattern to a reusable Mathlib lemma: in any commutative monoid, divisibility c ∣ u·d with u a unit collapses to c ∣ d — this is currently re-derived ad hoc in many places"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass for bezout-identity-oq-04-oq-01-oq-01 (Smith Normal Form over PIDs)

### Coverage gaps closed
- The Lean file's *Existence and Solvability Axioms* block (lines 156-171, where the two `axiom` declarations live) had **zero annotation/section coverage** in the gallery; now has its own section and a key-significance annotation.
- Section ranges previously stopped at line 165, leaving the `k[X] is a PID` Mathlib instance (line 191) and the closing summary outside any section. Sections now run through 191.

### Changes
**meta.json**
- New section `axioms` (156-171) with mathContext explaining the Mathlib `Submodule.smithNormalForm` ↔ `SmithNormalFormPID` bridge.
- Section `gcd-char` range corrected from 83-140 → 82-154 (covers the actual proof body including the unit.inv_val `calc` block).
- Section `bezout` range corrected from 148-165 → 172-191; title and summary expanded to mention the k[X] PID instance.
- Two new `openQuestions`: (1) generalize `snf_1x2_invariant_factor_pid` to m×n via Smith's classical minor formula; (2) extract the unit.inv_val cancellation as a reusable Mathlib lemma.

**annotations.json**
- New annotation `ann-axioms` (lines 156-171), `key` significance, explaining why the two axioms remain and how the Mathlib module-theoretic SNF translates to the matrix-theoretic structure.
- Annotation `ann-unit-cancellation` range extended 121-148 → 121-154 to include the full `calc` cancellation block.
- Annotation `ann-bezout-pid` range corrected 149-165 → 172-191 (now includes the k[X] PID instance).
- Pre-existing validator warnings (`No Lean construct found at line 36/59/83`) fixed by moving annotation startLines to land on actual Lean constructs (39 / 60 / 87).

### Coverage after
Sections cover lines 36-191 (entire active Lean source; 1-35 is the file header, 193-204 is the in-source summary docstring). 7 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

### Axiom integrity
`status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` — accurate and unchanged. The two axioms (`snf_pid_exists`, `snf_pid_solvability`) are now explicitly documented in their own section/annotation, including the path to making them theorems.