### PR TITLE
Enrich ballot-problem-oq-02-oq-02: cover biconditional/set-eq theorems, add openQuestions

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/annotations.json
@@ -108,6 +108,29 @@
     ]
   },
   {
+    "id": "ann-ballot-biconditional-set-eq",
+    "proofId": "ballot-problem-oq-02-oq-02",
+    "range": { "startLine": 123, "endLine": 135 },
+    "type": "concept",
+    "title": "Assembling the Biconditional and Set-Extensional Form",
+    "content": "These two theorems package the easy and hard directions into the headline statements:\n\n**fpt_le_iff_maxEvent** (lines 123-127): Under hitting-set nonemptiness, $\\tau(\\omega) \\leq T \\iff \\omega \\in \\mathrm{maxEvent}$. The proof is just an `⟨_, _⟩` anonymous constructor pairing `fpt_le_implies_maxEvent` (forward) and `maxEvent_implies_fpt_le` (backward) — a one-liner now that both halves are individually proved. This is *the correct conditional version* of the parent file's broken axiom.\n\n**fpt_le_set_eq_maxEvent** (lines 131-135): When nonemptiness holds for *every* ω, the underlying sets are equal: $\\{\\omega : \\tau(\\omega) \\leq T\\} = \\mathrm{maxEvent}$. The proof is `ext ω; exact fpt_le_iff_maxEvent ...` — set extensionality plus the pointwise iff. This is the literal form the parent's `firstPassageTime_eq_maxEvent` axiom *attempted* to assert.\n\nThe two-step packaging (pointwise iff → setwise equality via `Set.ext`) is a reusable Lean idiom: prove the pointwise version with all hypotheses local to ω, then derive the global set equality by quantifying the side condition. This decoupling is what makes the conditional correctness statement (`fpt_le_iff_maxEvent`) usable in contexts where some paths fail nonemptiness.",
+    "mathContext": "Two layers: (1) **pointwise biconditional** `fpt_le_iff_maxEvent : H_a(ω).Nonempty → (τ(ω) ≤ T ↔ ω ∈ maxEvent)`, and (2) **setwise equality** `fpt_le_set_eq_maxEvent : (∀ ω, H_a(ω).Nonempty) → {ω | τ(ω) ≤ T} = maxEvent`. The setwise form is what classical probability uses for measure-theoretic equalities $\\Pr[\\tau \\leq T] = \\Pr[M_T \\geq a]$, but the pointwise form is what's actually true under realistic hypotheses (some paths might never hit level $a$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.ext (Mathlib)",
+      "anonymous constructor for And/Iff",
+      "pointwise vs setwise equality",
+      "conditional theorem statements",
+      "parent axiom firstPassageTime_eq_maxEvent"
+    ],
+    "prerequisites": [
+      "fpt_le_implies_maxEvent",
+      "maxEvent_implies_fpt_le",
+      "Set.ext for extensional set equality",
+      "Iff anonymous constructor ⟨_, _⟩"
+    ]
+  },
+  {
     "id": "ann-ballot-ivt",
     "proofId": "ballot-problem-oq-02-oq-02",
     "range": { "startLine": 142, "endLine": 185 },

--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -93,7 +93,9 @@
     "openQuestions": [
       "Can the strong Markov property (the distribution of B(\u03c4+\u00b7) given \u03c4 equals the distribution of B given B(0)=a) be formalized in Lean using Mathlib's probability spaces?",
       "Does L\u00e9vy's reflection principle (conditional on \u03c4_a \u2264 T, the path B reflected at \u03c4_a is again Brownian) follow from this characterization and symmetry?",
-      "Can Doob's optional stopping theorem for martingales be formalized in Lean, using this first passage time characterization to verify the stopping time measurability hypothesis?"
+      "Can Doob's optional stopping theorem for martingales be formalized in Lean, using this first passage time characterization to verify the stopping time measurability hypothesis?",
+      "Generalize the csInf + IsClosed.csInf_mem pattern to a Mathlib lemma `IsClosed.firstHittingTime_mem`: for any continuous process $X : \\mathbb{R}_{\\ge 0} \\times \\Omega \\to E$ and any closed target set $F \\subseteq E$, the first hitting time $\\tau_F(\\omega) = \\inf\\{t \\ge 0 : X(t,\\omega) \\in F\\}$ belongs to the hitting set whenever the latter is nonempty.",
+      "Prove the measurability of `firstPassageTime` as a function $\\Omega \\to \\mathbb{R}$: under standard adapted-filtration hypotheses, $\\tau$ is a stopping time. The pointwise characterization `fpt_le_iff_maxEvent` reduces this to measurability of `maxEvent`, which is the pre-image of $[a,\\infty)$ under the running maximum process."
     ]
   },
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass for ballot-problem-oq-02-oq-02 (First Passage Time via csInf Theory)

### Coverage gap closed
Annotation coverage previously had a gap between **line 121** (end of `ann-ballot-hard-direction`) and **line 142** (start of `ann-ballot-ivt`), missing the *headline* biconditional theorems `fpt_le_iff_maxEvent` (lines 123-127) and `fpt_le_set_eq_maxEvent` (lines 131-135). These are the assembled forms that prove the parent file's broken axiom under its (missing) nonemptiness hypothesis — they deserved their own annotation.

### Changes
**annotations.json**
- New annotation `ann-ballot-biconditional-set-eq` (123-135), `key` significance, `concept` type:
  - Walks through both theorems, the anonymous-constructor + `Set.ext` packaging idiom, and contrasts pointwise iff vs setwise equality.
  - Highlights why the conditional pointwise form is what's *actually true* under realistic Brownian-path hypotheses, while the setwise form requires the strong (often-failing) universal nonemptiness condition.

**meta.json**
- Two new `openQuestions`:
  1. Generalize the `csInf` + `IsClosed.csInf_mem` pattern to a reusable Mathlib lemma `IsClosed.firstHittingTime_mem` for arbitrary continuous processes and closed target sets.
  2. Prove measurability of `firstPassageTime`, which would make $\\tau$ a genuine stopping time. The pointwise iff reduces this to `maxEvent` measurability (running-max preimage).

### Coverage after
Annotations now cover lines 44-185 contiguously (modulo small gaps for section headers). 7 annotations all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. 5 keyInsights, 5 openQuestions, 8 prerequisites, 7 references.

### Axiom integrity
`status: "verified"`, `badge: "original"`, `axiomCount: 0` — accurate. The file proves 11 theorems with 0 sorries and 0 axioms; this entry's value is precisely that it eliminates an axiom from the parent `ballot-problem-oq-02`. No structure-encoded assumptions: `BrownianMotion` carries `path_continuous` as a *hypothesis to be discharged* by callers, not as an unproved axiom of this proof.