### PR TITLE
research(lagrange-four-squares-oq-01-oq-02): S10aux — reverse 4-scaling lemma (build pending)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -254,6 +254,54 @@ lemma four_mul_sum_three_sq {n : ℕ} (h : ∃ a b c : ℤ, a^2 + b^2 + c^2 = n)
   rw [this, hab]
   simp
 
+/-- **Reverse 4-scaling**: if `4n` is a sum of three integer squares, so is `n`.
+
+Given `4n = a² + b² + c²`, divisibility by 4 forces each of `a, b, c` to be even
+(by `four_dvd_sum_three_sq_implies_even`). Writing `a = 2a'`, `b = 2b'`, `c = 2c'`
+yields `4(a'² + b'² + c'²) = 4n`, hence `n = a'² + b'² + c'²`.
+
+Companion to `four_mul_sum_three_sq`: together they give `sum_three_sq_iff_four_mul`,
+the iff-form. This is the descent direction used implicitly in the necessity proof
+(`excluded_form_not_sum_three_sq`) at the integer level; this lemma exposes it as
+a stand-alone reduction usable by the sufficiency proof. -/
+lemma sum_three_sq_of_four_mul {n : ℕ}
+    (h : ∃ a b c : ℤ, a^2 + b^2 + c^2 = (4 * n : ℕ)) :
+    ∃ a b c : ℤ, a^2 + b^2 + c^2 = n := by
+  obtain ⟨a, b, c, hab⟩ := h
+  -- 4 ∣ a² + b² + c²
+  have hdvd : (4 : ℤ) ∣ a^2 + b^2 + c^2 := by
+    rw [hab]; exact ⟨n, by push_cast; ring⟩
+  obtain ⟨ha, hb, hc⟩ := four_dvd_sum_three_sq_implies_even a b c hdvd
+  obtain ⟨a', ha_eq⟩ := ha
+  obtain ⟨b', hb_eq⟩ := hb
+  obtain ⟨c', hc_eq⟩ := hc
+  refine ⟨a', b', c', ?_⟩
+  -- Substitute a = 2a', b = 2b', c = 2c' in hab
+  rw [ha_eq, hb_eq, hc_eq] at hab
+  -- Cast (4 * n : ℕ) → (4 * (n : ℤ))
+  have hcast : ((4 * n : ℕ) : ℤ) = 4 * (n : ℤ) := by push_cast; ring
+  rw [hcast] at hab
+  -- LHS = 4 · (a'² + b'² + c'²)
+  have hlhs : (2 * a')^2 + (2 * b')^2 + (2 * c')^2 = 4 * (a'^2 + b'^2 + c'^2) := by ring
+  rw [hlhs] at hab
+  -- 4 · X = 4 · n in ℤ ⟹ X = n
+  have h4 : (4 : ℤ) ≠ 0 := by norm_num
+  have h_eq : a'^2 + b'^2 + c'^2 = (n : ℤ) := mul_left_cancel₀ h4 hab
+  exact_mod_cast h_eq
+
+/-- **Iff form**: `n` is a sum of three integer squares iff `4n` is.
+
+Combines `four_mul_sum_three_sq` (forward) with `sum_three_sq_of_four_mul` (reverse).
+Lets the sufficiency proof normalise `n` modulo the action of `4` — combined with
+`Nat.exists_eq_two_pow_mul_odd` and the descent in the necessity direction, the
+case analysis for `not_excluded_form_is_sum_three_sq` can assume `n` is not divisible
+by `4`, leaving residue classes `n % 8 ∈ {1, 2, 3, 5, 6}` (the cases targeted by
+`dirichlet_key_lemma` for `d ∈ {1, 2}`). -/
+lemma sum_three_sq_iff_four_mul {n : ℕ} :
+    (∃ a b c : ℤ, a^2 + b^2 + c^2 = n) ↔
+    (∃ a b c : ℤ, a^2 + b^2 + c^2 = (4 * n : ℕ)) :=
+  ⟨four_mul_sum_three_sq, sum_three_sq_of_four_mul⟩
+
 /-- **Square scaling**: If m is a sum of 3 squares, so is k²m.
 This is the "easy direction" of the square-free reduction.
 Combined with the reverse (which requires more work), this allows reducing


### PR DESCRIPTION
## Summary

**S10aux**: Add the converse of `four_mul_sum_three_sq` (line 247) to
`ThreeSquares.lean` — if `4n` is a sum of three integer squares, so is `n`.

This is the descent direction already used internally inside
`excluded_form_not_sum_three_sq` (necessity proof, lines 196–240), exposed
here as a stand-alone *forward-direction* lemma usable by the sufficiency
proof.

## Mathematical content

```lean
lemma sum_three_sq_of_four_mul {n : ℕ}
    (h : ∃ a b c : ℤ, a^2 + b^2 + c^2 = (4 * n : ℕ)) :
    ∃ a b c : ℤ, a^2 + b^2 + c^2 = n

lemma sum_three_sq_iff_four_mul {n : ℕ} :
    (∃ a b c : ℤ, a^2 + b^2 + c^2 = n) ↔
    (∃ a b c : ℤ, a^2 + b^2 + c^2 = (4 * n : ℕ))
```

**Proof sketch** (~25 tactic lines for the main lemma, iff is one-liner):

1. From `4n = a²+b²+c²`, extract `(4 : ℤ) ∣ a²+b²+c²` via the explicit
   witness `n`.
2. Apply `four_dvd_sum_three_sq_implies_even` (line 155) to get `2 ∣ a`,
   `2 ∣ b`, `2 ∣ c`.
3. Destructure to `a = 2a'`, `b = 2b'`, `c = 2c'`.
4. Substitute, push the `(4 * n : ℕ) → 4 * (n : ℤ)` cast, and `ring`-rewrite
   the LHS to `4 · (a'² + b'² + c'²)`.
5. Cancel the `4` factor via `mul_left_cancel₀` over ℤ (a
   `CancelCommMonoidWithZero`).

## Why this granularity

- **Self-contained**: only `four_dvd_sum_three_sq_implies_even` (already in
  the file) plus standard `mul_left_cancel₀` from Mathlib's
  `CancelMonoidWithZero` API. No measure theory, no lattice machinery,
  immune to the latent S5-region build issues and `MeasureTheory.*` API
  drift.
- **Edit-zone non-conflict**: the new lemmas are inserted at the line-255
  area (immediately after `four_mul_sum_three_sq`), far from PR #17374
  (S10C)'s edit zone (`mem_dirichletSublattice`/axiom boundary, ~line 1387).
  This PR composes freely with PR #17374.
- **Useful for the recipe**: enables the case analysis at the
  `not_excluded_form_is_sum_three_sq` axiom (line 1400 docstring step 4)
  to reduce to `n` not divisible by `4` — combined with
  `Nat.exists_eq_two_pow_mul_odd` and the descent in the necessity direction,
  the case work for the sufficiency proof can assume `n % 8 ∈ {1, 2, 3, 5, 6}`,
  exactly the residue classes for which `dirichlet_key_lemma` is
  parametrised at `d ∈ {1, 2}`.

## Counts (delta)

|        | Before | After  | Δ                       |
|--------|--------|--------|-------------------------|
| Lines  | 1690   | 1738   | +48                     |
| Theorems | —    | —      | +2 (1 main + 1 iff)     |
| Defs   | —      | —      | 0                       |
| Axioms | 2      | 2      | 0                       |
| Sorries| 0      | 0      | 0                       |

(File `proofs/Proofs/ThreeSquares.lean` is auxiliary — no gallery entry has
it as primary `leanFile.path`. No `meta.json` updates required.)

## Axiom delta

Unchanged at 2 (`dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`).
S10aux is *infrastructure* — supplies a reduction primitive whose absence
forces every downstream sufficiency-direction argument to inline the
divisibility-by-4 descent.

## Build status

**Pending** — recursive `proofs/.lake` self-symlink prevents local Docker
verification (memory: `feedback_researcher_lake_symlink_broken.md`).
The new tactic uses (`obtain` with `ha_eq` form, `push_cast`, `ring`,
`mul_left_cancel₀`, `exact_mod_cast`) compile against Mathlib 4.26 — patterns
mirror the line-200–240 necessity proof line-for-line. CI / Auditor will catch
any issues.

## Test plan

- [ ] CI builds `Proofs.ThreeSquares` cleanly.
- [ ] No new axioms or sorries introduced.
- [ ] No conflict with PR #17374 (S10C real-side basis) merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>