### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S9 — conjecture-as-Prop and falsification handles

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -630,6 +630,82 @@ theorem symBUDim_prime_combined_lower (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d
   · exact sym_has_cyclic_prime p d p hp le_rfl
   · exact symBUDim_lower_z2 p d hp.two_le hd
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XV: Conjecture-as-Prop and explicit falsification handles
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- The Largest-Prime-Below conjecture, stated as a `Prop` rather than an
+    axiom. Downstream developments that wish to track conjecture-dependence
+    explicitly can take this as a hypothesis instead of using the file's
+    `symBUDim_eq_largestPrime` axiom. -/
+def ConjectureLPB : Prop :=
+  ∀ n d : ℕ, 2 ≤ n → symBUDim n d = buDim (largestPrimeBelow n) d
+
+/-- Hypothesis-form variant of `buDim_largestPrime_lower_z2`: the conjecture
+    (as a `Prop` hypothesis) implies the Z/2 lower bound on the cyclic
+    Yang-Borsuk dimension at the largest prime ≤ n. Same statement as the
+    axiom-using version, but the conjecture-dependence is explicit. -/
+theorem buDim_largestPrime_lower_z2_of (h : ConjectureLPB) (n d : ℕ)
+    (hn : 2 ≤ n) (hd : 0 < d) :
+    d - 1 ≤ buDim (largestPrimeBelow n) d := by
+  rw [← h n d hn]
+  exact symBUDim_lower_z2 n d hn hd
+
+/-- Hypothesis-form variant of `buDim_prime_lower_z2_conditional`. -/
+theorem buDim_prime_lower_z2_of (h : ConjectureLPB) (p d : ℕ)
+    (hp : Nat.Prime p) (hd : 0 < d) :
+    d - 1 ≤ buDim p d := by
+  have hL := buDim_largestPrime_lower_z2_of h p d hp.two_le hd
+  rwa [largestPrimeBelow_self_of_prime p hp] at hL
+
+/-- Hypothesis-form variant of `symBUDim_eq_buDim_at_prime`: at any prime p,
+    the conjecture pins `symBUDim p d = buDim p d` for all d. -/
+theorem symBUDim_eq_buDim_at_prime_of (h : ConjectureLPB) (p d : ℕ)
+    (hp : Nat.Prime p) :
+    symBUDim p d = buDim p d := by
+  have hL := h p d hp.two_le
+  rwa [largestPrimeBelow_self_of_prime p hp] at hL
+
+/-- **Falsification handle (general)**: if for some prime p and some d ≥ 1
+    we ever prove the strict bound `buDim p d < d - 1`, then `ConjectureLPB`
+    is false.
+
+    This is the contrapositive of `buDim_prime_lower_z2_of`. It is the
+    formal restatement of iter-8's remark "any future computation of
+    `buDim p d` at odd d that violates `d − 1 ≤ buDim p d` would FALSIFY
+    `symBUDim_eq_largestPrime` at n = p". -/
+theorem not_conjectureLPB_of_buDim_lt {p d : ℕ} (hp : Nat.Prime p)
+    (hd : 0 < d) (hlt : buDim p d < d - 1) :
+    ¬ ConjectureLPB := by
+  intro h
+  have := buDim_prime_lower_z2_of h p d hp hd
+  omega
+
+/-- **Falsification handle at p = 3, d = 3**: a proof of `buDim 3 3 < 2`
+    would refute the conjecture. Concrete instance most likely amenable
+    to direct equivariant-cohomology computation, since the Yang-Borsuk
+    dimension at p = 3 in odd dimension d = 3 is exactly the simplest
+    case beyond the parent file's even-d axiomatization. -/
+theorem not_conjectureLPB_of_buDim_three_three_lt_two
+    (h : buDim 3 3 < 2) : ¬ ConjectureLPB :=
+  not_conjectureLPB_of_buDim_lt (p := 3) (d := 3) (by decide) (by norm_num)
+    (by simpa using h)
+
+/-- **Falsification handle at p = 5, d = 3**: a proof of `buDim 5 3 < 2`
+    would refute the conjecture. The conjecture's claim here is strictly
+    beyond Yang-Borsuk's even-d axiomatization. -/
+theorem not_conjectureLPB_of_buDim_five_three_lt_two
+    (h : buDim 5 3 < 2) : ¬ ConjectureLPB :=
+  not_conjectureLPB_of_buDim_lt (p := 5) (d := 3) (by decide) (by norm_num)
+    (by simpa using h)
+
+/-- **Falsification handle at p = 3, d = 5**: a proof of `buDim 3 5 < 4`
+    would refute the conjecture. -/
+theorem not_conjectureLPB_of_buDim_three_five_lt_four
+    (h : buDim 3 5 < 4) : ¬ ConjectureLPB :=
+  not_conjectureLPB_of_buDim_lt (p := 3) (d := 5) (by decide) (by norm_num)
+    (by simpa using h)
+
 /-
 ## Summary
 
@@ -735,6 +811,30 @@ theorem symBUDim_prime_combined_lower (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d
   both coincide (`buDim p (2k) = 2k − 1 = d − 1`); at odd d the Z/2
   component dominates.
 
+### Iteration 9 additions (conjecture-as-Prop and falsification handles)
+- `ConjectureLPB : Prop` — the equality conjecture stated as an explicit
+  hypothesis (not an axiom). Lets downstream developments take the
+  conjecture as a hypothesis instead of using `symBUDim_eq_largestPrime`,
+  making conjecture-dependence explicit at the type level.
+- `buDim_largestPrime_lower_z2_of`, `buDim_prime_lower_z2_of`,
+  `symBUDim_eq_buDim_at_prime_of` — hypothesis-form variants of the
+  iter-8 conditional theorems (and `symBUDim_eq_buDim_at_prime` from
+  iter 5). Same statements, but the dependence on the conjecture is
+  encoded via a `ConjectureLPB` hypothesis rather than via the file's
+  axiom.
+- `not_conjectureLPB_of_buDim_lt` — **falsification theorem**: a future
+  proof of `buDim p d < d − 1` at any prime p and any d ≥ 1 refutes
+  `ConjectureLPB`. Formal contrapositive of `buDim_prime_lower_z2_of`.
+  Crystallizes iter-8's "falsification handle" remark as a concrete
+  theorem at the type level.
+- Concrete falsification handles at small (p, d):
+  `not_conjectureLPB_of_buDim_three_three_lt_two`,
+  `not_conjectureLPB_of_buDim_five_three_lt_two`,
+  `not_conjectureLPB_of_buDim_three_five_lt_four` — explicit instances
+  at the simplest odd-d cases beyond the parent's `buDim_prime` axiom
+  (which only fires on even d). These pinpoint exactly where future
+  Yang-Borsuk research could refute the conjecture.
+
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
   axiomatizing or proving `symBUDim 3 d ≤ buDim 3 d`; n=3 is *not*
@@ -746,6 +846,10 @@ theorem symBUDim_prime_combined_lower (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d
 - The Bertrand bound shows the cyclic lower bound is within factor 2 of
   optimal; tightening past this would require S_n-specific structure
   (representation-theoretic obstructions, V₄-style non-cyclic factors).
+- Concrete falsification target: compute or bound `buDim 3 3` directly
+  via equivariant cohomology of Z/3 on simple S^2-actions. A proof of
+  `buDim 3 3 < 2` would refute `ConjectureLPB`; a proof of `buDim 3 3 = 2`
+  would tighten its content at the simplest odd-d case.
 -/
 
 #check @symBUDim_eq_largestPrime
@@ -765,5 +869,10 @@ theorem symBUDim_prime_combined_lower (p d : ℕ) (hp : Nat.Prime p) (hd : 0 < d
 #check @buDim_largestPrime_lower_z2
 #check @buDim_prime_lower_z2_conditional
 #check @symBUDim_prime_combined_lower
+#check @ConjectureLPB
+#check @buDim_largestPrime_lower_z2_of
+#check @buDim_prime_lower_z2_of
+#check @symBUDim_eq_buDim_at_prime_of
+#check @not_conjectureLPB_of_buDim_lt
 
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-08T18:30:00Z
-**Iteration**: 8
+**Since**: 2026-05-08T19:30:00Z
+**Iteration**: 9
 
 ## Current Focus
 
@@ -231,3 +231,56 @@ Mathlib. Stretch goals at small n: prove the n=3 case (next-easiest after
 n=2; would need a `symBUDim_three` base axiom that the parent doesn't
 yet have), prove the n=4 case via V₄ ≤ S₄ structure, or coordinate with
 sister-question OQ-02-OQ-01-OQ-03-OQ-01 (dihedral D_n analog).
+
+## Iteration 9 Builds (researcher-5, 2026-05-08)
+
+Focus: **conjecture-as-Prop reformulation + explicit falsification handles**.
+Crystallizes iter 8's "falsification handle" remark as concrete, well-typed
+theorems and provides a hypothesis-form alternative to the file's axiom.
+
+- `ConjectureLPB : Prop` (axiom-free definition): the equality conjecture
+  stated as a `Prop` rather than via the file's `axiom`. Lets downstream
+  developments take the conjecture as an explicit hypothesis instead of
+  relying on the file's axiom — making conjecture-dependence visible at
+  the type level.
+- `buDim_largestPrime_lower_z2_of`, `buDim_prime_lower_z2_of`,
+  `symBUDim_eq_buDim_at_prime_of` (axiom-free, hypothesis-form):
+  hypothesis-form variants of iter-5/iter-8 conditional theorems
+  (`symBUDim_eq_buDim_at_prime`, `buDim_largestPrime_lower_z2`,
+  `buDim_prime_lower_z2_conditional`). Same statements, but the
+  dependence on the conjecture is encoded via a `ConjectureLPB`
+  hypothesis rather than via the file's axiom. Useful when downstream
+  code wants to track conjecture-dependence in the type signature.
+- `not_conjectureLPB_of_buDim_lt` (axiom-free): the **falsification
+  theorem**. At any prime p with d ≥ 1, a future proof of
+  `buDim p d < d − 1` refutes `ConjectureLPB`. Formal contrapositive
+  of `buDim_prime_lower_z2_of` — turns iter 8's "falsification handle"
+  remark into a concrete theorem.
+- Concrete falsification handles at small (p, d):
+  - `not_conjectureLPB_of_buDim_three_three_lt_two`
+  - `not_conjectureLPB_of_buDim_five_three_lt_two`
+  - `not_conjectureLPB_of_buDim_three_five_lt_four`
+  Each pinpoints the simplest odd-d case at a small prime where the
+  parent's `buDim_prime` axiom is silent (it fires only on even d).
+  These mark exactly where future Yang-Borsuk research could refute
+  the conjecture.
+
+**Counts**: lineCount 769→878 (+109), theoremCount 51→58 (+7,
+substantive 49→56), definitionCount 1→2 (+1 for `ConjectureLPB`),
+axiomCount 1 (unchanged), sorries 0 (unchanged).
+
+**Significance**: the conjecture is now expressible at two levels in
+the file — as the `axiom symBUDim_eq_largestPrime` (used for direct
+derivations of conditional consequences) and as `ConjectureLPB : Prop`
+(used by hypothesis-form variants for explicit dependency tracking).
+The `_of` lemmas mirror their axiom-using counterparts on a one-to-one
+basis, and the falsification theorem is type-level explicit.
+
+**Path forward** (unchanged from iter 8): direct proof of the
+conjecture requires Fadell-Husseini index theory not in Mathlib.
+Concrete next-target: compute or bound `buDim 3 3` directly via
+equivariant cohomology of Z/3 on small spheres. A proof of
+`buDim 3 3 < 2` would refute `ConjectureLPB` via
+`not_conjectureLPB_of_buDim_three_three_lt_two`; a proof of
+`buDim 3 3 = 2` would tighten the conjecture's content at the
+simplest odd-d case beyond Yang-Borsuk.

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 769,
+    "lineCount": 878,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -89,11 +89,15 @@
       "buDim_largestPrime_lower_z2 (conditional, iter 8): the axiom-free Z/2 lower bound `symBUDim_lower_z2` pulls through `symBUDim_eq_largestPrime` to deliver `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1. Genuinely new content beyond the parent's axiomatization: at odd d the parent's `buDim_prime` axiom (which only fires on even d) leaves `buDim p d` unconstrained for primes p ≥ 3; the symmetric-group conjecture would PIN a NEW lower bound `d − 1` valid at odd d.",
       "buDim_prime_lower_z2_conditional (conditional, iter 8): at any prime p and d ≥ 1, conditionally `d − 1 ≤ buDim p d`. Specializes `buDim_largestPrime_lower_z2` via `largestPrimeBelow_self_of_prime`. **Significance**: classical Yang-Borsuk only handles even d at primes ≥ 3; this conditional bound transfers the Z/2 Borsuk-Ulam dimension to ALL cyclic-prime Yang-Borsuk dimensions at ALL d.",
       "buDim_{three,five,seven}_lower_z2_conditional (conditional, iter 8): concrete instances of the conditional bound at small odd primes (e.g., conditionally `buDim 3 3 ≥ 2`).",
-      "symBUDim_prime_combined_lower (axiom-free, iter 8): packaged max-bound at any prime p with d ≥ 1: `max (buDim p d) (d − 1) ≤ symBUDim p d`. Combines the Z/p subgroup contribution (`sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`). At even d = 2k both coincide via `buDim_prime`; at odd d the Z/2 component dominates."
+      "symBUDim_prime_combined_lower (axiom-free, iter 8): packaged max-bound at any prime p with d ≥ 1: `max (buDim p d) (d − 1) ≤ symBUDim p d`. Combines the Z/p subgroup contribution (`sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`). At even d = 2k both coincide via `buDim_prime`; at odd d the Z/2 component dominates.",
+      "ConjectureLPB (iter 9): the equality conjecture stated as a `Prop` rather than an axiom. Lets downstream developments take the conjecture as a hypothesis instead of using `symBUDim_eq_largestPrime`, making conjecture-dependence explicit at the type level.",
+      "buDim_largestPrime_lower_z2_of, buDim_prime_lower_z2_of, symBUDim_eq_buDim_at_prime_of (iter 9): hypothesis-form variants of iter-8's conditional theorems and iter-5's symBUDim_eq_buDim_at_prime. Same statements, but the dependence on the conjecture is encoded via a `ConjectureLPB` hypothesis rather than via the file's axiom.",
+      "not_conjectureLPB_of_buDim_lt (iter 9): formal **falsification theorem** — at any prime p with d ≥ 1, a future proof of `buDim p d < d − 1` refutes `ConjectureLPB`. Crystallizes iter-8's remark \"any computation of buDim p d at odd d violating d − 1 ≤ buDim p d would falsify symBUDim_eq_largestPrime at n = p\" as a concrete theorem at the type level.",
+      "not_conjectureLPB_of_buDim_{three_three_lt_two, five_three_lt_two, three_five_lt_four} (iter 9): explicit falsification handles at small (p, d) with odd d — the simplest cases beyond the parent's `buDim_prime` axiom (which fires only on even d). These pinpoint exactly where future Yang-Borsuk research could refute the conjecture."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d ≥ 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d − 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d − 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 51,
-    "definitionCount": 1
+    "theoremCount": 58,
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "The classical Borsuk-Ulam theorem (Borsuk 1933) says any continuous odd map $S^n \\to \\mathbb{R}^n$ has a zero. For a finite group $G$ acting linearly on a real representation, the equivariant analog asks: what is the largest sphere dimension on which every $G$-equivariant map to a $d$-dimensional representation must vanish? Yang (1954) and Borsuk (1933) settled the case $G = \\mathbb{Z}/p$ for prime $p$, giving the celebrated formula $\\text{buDim}(\\mathbb{Z}/p, 2k) = 2k - 1$ — the 'tight prime bound'. For non-cyclic groups the answer requires cohomological index theory (Fadell-Husseini 1988).\n\nFor the symmetric group $S_n$, every prime $p \\leq n$ embeds as a cyclic subgroup via $p$-cycles, so subgroup monotonicity gives $\\text{symBUDim}(n, d) \\geq \\text{buDim}(p, d)$. The strongest bound comes from $p = p^*$, the **largest prime $\\leq n$**. Bertrand's postulate (Chebyshev 1850, Erdős 1932) guarantees $p^* > n/2$, so $\\text{symBUDim}(n, 2k) \\geq 2k - 1$ unconditionally — within factor 2 of the trivial upper bound $d - 1$.\n\nThe open question studied here is whether $\\text{symBUDim}(n, d)$ EQUALS $\\text{buDim}(p^*, d)$ — i.e. whether the $S_n$-equivariant structure adds nothing beyond the largest cyclic subgroup of prime order. A positive answer would yield the closed form $\\text{symBUDim}(n, 2k) = 2k - 1$. A negative answer would have to come from $S_n$-specific structure (Klein-4 subgroup $V_4 \\leq S_4$, representation-theoretic obstructions, ...).",
@@ -214,9 +218,17 @@
       "id": "z2-transfer-to-cyclic-primes",
       "title": "Part XIV: Conditional Z/2 Transfer to Cyclic Primes",
       "startLine": 565,
-      "endLine": 638,
+      "endLine": 631,
       "summary": "**Iteration 8.** `buDim_largestPrime_lower_z2`: conditional on `symBUDim_eq_largestPrime`, `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1. `buDim_prime_lower_z2_conditional`: at any prime p with d ≥ 1, conditionally `d − 1 ≤ buDim p d` — extends Yang-Borsuk's lower bound from p = 2 (parent's `buDim_two`) to all primes and all dimensions including odd d. Concrete instances `buDim_{three,five,seven}_lower_z2_conditional`. `symBUDim_prime_combined_lower`: axiom-free packaged max-bound `max (buDim p d) (d − 1) ≤ symBUDim p d` at prime p — combines the Z/p and Z/2 subgroup contributions.",
       "mathContext": "The parent's `buDim_prime` axiom only fires on EVEN d ($\\text{buDim}(p, 2k) = 2k - 1$ for prime $p$, $k \\geq 1$); at odd $d$, $\\text{buDim}(p, d)$ for primes $p \\geq 3$ is unconstrained by the existing axiomatization. The new axiom $\\text{symBUDim}_n d = \\text{buDim}(p^*, d)$ combined with the axiom-free Z/2 lower bound $d - 1 \\leq \\text{symBUDim}(n, d)$ (iter 7) WOULD pin a NEW lower bound $d - 1 \\leq \\text{buDim}(p, d)$ valid at ALL d for ALL primes p. This is genuinely new content: a structural consequence of the symmetric-group conjecture for cyclic-prime Yang-Borsuk dimensions. **Falsification corollary**: any future computation of $\\text{buDim}(p, d)$ at odd $d$ violating $d - 1 \\leq \\text{buDim}(p, d)$ would falsify the symmetric-group conjecture at $n = p$."
+    },
+    {
+      "id": "conjecture-as-prop-and-falsification",
+      "title": "Part XV: Conjecture-as-Prop and Falsification Handles",
+      "startLine": 633,
+      "endLine": 720,
+      "summary": "**Iteration 9.** `ConjectureLPB : Prop` — the equality conjecture stated as an explicit hypothesis (not an axiom). `buDim_largestPrime_lower_z2_of`, `buDim_prime_lower_z2_of`, `symBUDim_eq_buDim_at_prime_of`: hypothesis-form variants of iter-5/iter-8 conditional theorems with `ConjectureLPB` as an explicit hypothesis instead of using the file's axiom. `not_conjectureLPB_of_buDim_lt`: formal falsification theorem — a proof of `buDim p d < d − 1` at any prime p, d ≥ 1 refutes `ConjectureLPB`. Concrete falsification handles `not_conjectureLPB_of_buDim_three_three_lt_two`, `_five_three_lt_two`, `_three_five_lt_four` pinpoint the simplest odd-d cases beyond the parent's even-d Yang-Borsuk axiomatization where future research could refute the conjecture.",
+      "mathContext": "Reformulates iter-8's structural consequence as a Prop-level hypothesis so downstream developments can track conjecture-dependence explicitly. The falsification theorem is the formal contrapositive of `buDim_prime_lower_z2_of`: assuming `ConjectureLPB`, the Z/2 lower bound $d - 1 \\leq \\text{symBUDim}(n, d)$ (axiom-free, iter 7) transfers via the conjecture to $d - 1 \\leq \\text{buDim}(p, d)$ at any prime $p$ — content beyond the parent's `buDim_prime` axiom at odd $d$. So a proof of $\\text{buDim}(p, d) < d - 1$ at odd $d$ for any prime $p \\geq 3$ would refute the conjecture. The concrete instances at $(p, d) = (3, 3), (5, 3), (3, 5)$ are the simplest cases where the conjecture's content is genuinely beyond the parent's even-d axiomatization."
     }
   ],
   "crossReferences": [
@@ -260,11 +272,11 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 769,
+    "lineCount": 878,
     "axiomCount": 1,
-    "theoremCount": 51,
-    "substantiveTheoremCount": 49,
-    "definitionCount": 1,
+    "theoremCount": 58,
+    "substantiveTheoremCount": 56,
+    "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Iteration 9 of the Symmetric Group Borsuk-Ulam: Largest-Prime-Below conjecture (`borsuk-ulam-oq-02-oq-01-oq-03-oq-02`). Crystallizes iter 8's "falsification handle" remark as concrete theorems and provides a hypothesis-form alternative to the file's `symBUDim_eq_largestPrime` axiom.

## What's New (PART XV — axiom-free)

- **`ConjectureLPB : Prop`**: the equality conjecture stated as a `Prop`. Downstream developments can take this as an explicit hypothesis instead of relying on the file's axiom — conjecture-dependence becomes visible at the type level.
- **Hypothesis-form variants** of iter-5/iter-8 conditional theorems:
  - `buDim_largestPrime_lower_z2_of`
  - `buDim_prime_lower_z2_of`
  - `symBUDim_eq_buDim_at_prime_of`
- **`not_conjectureLPB_of_buDim_lt`** — formal **falsification theorem**: at any prime $p$ with $d \geq 1$, a future proof of $\text{buDim}(p, d) < d - 1$ refutes `ConjectureLPB`. Formal contrapositive of `buDim_prime_lower_z2_of`.
- **Concrete falsification handles** at small (p, d):
  - `not_conjectureLPB_of_buDim_three_three_lt_two`
  - `not_conjectureLPB_of_buDim_five_three_lt_two`
  - `not_conjectureLPB_of_buDim_three_five_lt_four`

  These pinpoint the simplest odd-d cases at small primes — exactly where the parent's `buDim_prime` axiom is silent (it fires only on even d) and where future Yang-Borsuk research could refute the conjecture.

## Counts

- `lineCount`: 769 → 878 (+109)
- `theoremCount`: 51 → 58 (+7); substantive: 49 → 56 (+7)
- `definitionCount`: 1 → 2 (+1 for `ConjectureLPB`)
- `axiomCount`: 1 (unchanged)
- `sorries`: 0 (unchanged)

## Significance

The conjecture is now expressible at two levels in the file:

1. As `axiom symBUDim_eq_largestPrime` (used for direct derivations of conditional consequences in iter 8 / Part XIV).
2. As `ConjectureLPB : Prop` (used by hypothesis-form variants for explicit dependency tracking — Part XV).

The `_of` lemmas mirror their axiom-using counterparts on a one-to-one basis, and the falsification theorem is type-level explicit. A concrete falsification target — e.g., compute or bound `buDim 3 3` directly via equivariant cohomology of $\mathbb{Z}/3$ on small spheres — would slot directly into `not_conjectureLPB_of_buDim_three_three_lt_two` if the bound is `< 2`.

## Build

```
$ ./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02
...
Build completed successfully (3068 jobs).
```

(Pre-existing `unused variable hq` warning in parent `BorsukUlamOQ02OQ01.lean:111` is unrelated to S9 changes.)

## Test plan

- [x] All seven new theorems and one new definition type-check
- [x] No new sorries, no new axioms
- [x] meta.json/state.md updated to reflect iter 9 contributions
- [x] Branch off fresh `origin/main`; no conflicts with concurrent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)