### PR TITLE
Enrich Burnside's Lemma & Necklace Counting: mainTheorems + references

### DIFF
--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -74,6 +74,122 @@
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "burnside_lemma",
+      "type": "core",
+      "statement": "$\\sum_{g \\in G} |\\mathrm{Fix}(g)| = |X/G| \\cdot |G|$",
+      "significance": "**The headline theorem.** The Cauchy-Frobenius / Burnside / orbit-counting identity in its multiplicative (division-free) form. States that summing the fixed-point cardinalities over all group elements equals the number of orbits times the group size. The Lean proof is a one-line wrapper around Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` — all content comes from Mathlib's group-action library.",
+      "description": "Lean signature: `theorem burnside_lemma {G X} [Group G] [MulAction G X] [Fintype G] [(g : G) → Fintype (fixedBy X g)] [Fintype (orbitRel.Quotient G X)] : ∑ g : G, Fintype.card (fixedBy X g) = Fintype.card (orbitRel.Quotient G X) * Fintype.card G`. The four `Fintype` instance arguments make the statement run on any concrete finite group action."
+    },
+    {
+      "name": "cyclicAddActionOnColorings",
+      "type": "definition",
+      "statement": "`instance : AddAction (ZMod n) (Coloring n k)`",
+      "significance": "**The example action.** Defines $\\mathbb{Z}/n\\mathbb{Z}$ acting by cyclic rotation on functions `Fin n → Fin k`. The action sends a rotation $r$ and a coloring $c$ to the coloring $i \\mapsto c((i + n - r) \\bmod n)$, computed in `ℕ` to avoid `ZMod` underflow. The `zero_vadd` and `add_vadd` AddAction axioms are discharged using `rotatedIndex_zero` (verified) and `rotatedIndex_add` (axiom).",
+      "description": "Built from the helper `rotateColoring` and `rotatedIndex` definitions. Uses `[NeZero n]` to guarantee the modulus is positive. Note that `burnside_lemma` consumes `MulAction`, not `AddAction`; bridging this gap requires the `coloringSetoid` axiom which postulates the orbit equivalence relation directly."
+    },
+    {
+      "name": "binary_4_colorings_count",
+      "type": "supporting",
+      "statement": "$|\\{c : \\mathrm{Fin}\\ 4 \\to \\mathrm{Fin}\\ 2\\}| = 16$",
+      "significance": "**The total domain count.** Establishes $|X| = 2^4 = 16$ binary colorings of length 4 — equivalently, $|\\mathrm{Fix}(\\mathrm{id})|$, the largest fixed-point set in the Burnside sum. Fully verified via `Fintype.card_fun` plus `norm_num`.",
+      "description": "Proof: `simp only [Fintype.card_fun, Fintype.card_fin]; norm_num`. Uses `Fintype.card_fun : |A → B| = |B|^|A|` and `Fintype.card_fin : |Fin n| = n`."
+    },
+    {
+      "name": "constant_coloring_count",
+      "type": "core",
+      "statement": "$\\forall n \\geq 1\\ \\forall k,\\ |\\{c : \\mathrm{Coloring}\\ n\\ k\\ //\\ \\mathrm{IsConstant}\\ c\\}| = k$",
+      "significance": "**Fixed points of odd rotations.** A constant coloring is determined by a single color choice, giving exactly $k$ such colorings. For binary 4-necklaces, this proves $|\\mathrm{Fix}(r)| = 2$ for $r \\in \\{1, 3\\}$ (the rotations of order 4 acting freely on the non-constant orbits). Fully verified — no axioms.",
+      "description": "Proof constructs an explicit bijection with `Fin k` via `Equiv.ofBijective`: $c \\mapsto c(0)$ (forward) and $v \\mapsto (\\lambda \\_, v)$ (backward). Both `LeftInverse` and `RightInverse` are discharged by `funext` + the constancy hypothesis."
+    },
+    {
+      "name": "period2_count",
+      "type": "supporting",
+      "statement": "$|\\{c : \\mathrm{Coloring}\\ 4\\ 2\\ //\\ \\mathrm{HasPeriod2}\\ c\\}| = 4$",
+      "significance": "**Fixed points of the half-turn.** Counts binary 4-colorings invariant under rotation by 2 (i.e., $c(0) = c(2)$ and $c(1) = c(3)$). These are determined by the first two values, giving $|\\mathrm{Fin}\\ 2 \\times \\mathrm{Fin}\\ 2| = 4$. Fully verified.",
+      "description": "Proof uses `Equiv.ofBijective` between the period-2 subtype and `Fin 2 × Fin 2`, with the inverse map sending $(a, b)$ to the vector literal `![a, b, a, b]`. The `LeftInverse` step uses `fin_cases i` to handle each of the four positions."
+    },
+    {
+      "name": "rotatedIndex_add",
+      "type": "axiom",
+      "statement": "$\\mathrm{rotatedIndex}\\ n\\ s\\ (\\mathrm{rotatedIndex}\\ n\\ r\\ i) = \\mathrm{rotatedIndex}\\ n\\ (r + s)\\ i$",
+      "significance": "**The composition axiom.** States that successive rotations compose additively in `ZMod n`. This is the key modular-arithmetic identity needed for `add_vadd` in `cyclicAddActionOnColorings`. The mathematical content is elementary — $((i + n - r) \\bmod n + n - s) \\bmod n = (i + n - (r + s)) \\bmod n$ — but cleanly proving it in Lean requires careful `Nat.sub` / `Nat.mod` case analysis, hence the axiomatic stance.",
+      "description": "Stated as `axiom rotatedIndex_add (n : ℕ) [NeZero n] (r s : ZMod n) (i : Fin n) : rotatedIndex n s (rotatedIndex n r i) = rotatedIndex n (r + s) i`. Discharging it would convert this from `axiomatized` to `verified` for the rotation infrastructure (but four other axioms would remain)."
+    },
+    {
+      "name": "fixed_point_sum_binary_4",
+      "type": "axiom",
+      "statement": "$|\\mathrm{Fix}(0)| + |\\mathrm{Fix}(1)| + |\\mathrm{Fix}(2)| + |\\mathrm{Fix}(3)| = 24$",
+      "significance": "**The Burnside numerator.** Records the explicit fixed-point counts for the four elements of $\\mathbb{Z}/4\\mathbb{Z}$ acting on binary 4-colorings: $16 + 2 + 4 + 2 = 24$. Could be discharged by `native_decide` once `IsFixedByRotation` is wired into a fully-decidable framework, but the axiom currently sidesteps the `AddAction` / `MulAction` API mismatch.",
+      "description": "Stated as a sum of `Fintype.card { c : Coloring 4 2 // IsFixedByRotation r c }` for $r = 0, 1, 2, 3$. The arithmetic $16 + 2 + 4 + 2 = 24$ is decidable; the wrapping `Fintype.card` is decidable provided `IsFixedByRotation` is. The 24 directly produces the necklace count $24/4 = 6$ via Burnside."
+    },
+    {
+      "name": "binary_necklaces_4",
+      "type": "axiom",
+      "statement": "$|(\\mathrm{Coloring}\\ 4\\ 2)/\\sim| = 6$",
+      "significance": "**The headline application.** The number of distinct binary necklaces of length 4 is exactly 6: $\\{0000\\}, \\{1111\\}, \\{0001, 0010, 0100, 1000\\}, \\{0011, 0110, 1100, 1001\\}, \\{0101, 1010\\}, \\{0111, 1011, 1101, 1110\\}$. Matches OEIS A000029 (necklaces under rotation) at $n=4$.",
+      "description": "Stated against the axiomatized `coloringSetoid` and `coloringQuotientFintype` instance. Once `MulAction.orbitRel` is bridged to the `AddAction` of `ZMod 4`, `binary_necklaces_4` follows from `burnside_lemma` applied to `fixed_point_sum_binary_4` divided by $|\\mathbb{Z}/4\\mathbb{Z}| = 4$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cauchy, A.-L.",
+      "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+      "year": "1845",
+      "venue": "Exercices d'analyse et de physique mathématique 3, Paris (Bachelier)",
+      "note": "Original statement of the orbit-counting identity in the language of permutation arrangements; predates Burnside's textbook by 52 years."
+    },
+    {
+      "authors": "Frobenius, F. G.",
+      "title": "Über die Congruenz nach einem aus zwei endlichen Gruppen gebildeten Doppelmodul",
+      "year": "1887",
+      "venue": "Journal für die reine und angewandte Mathematik 101, 273-299",
+      "note": "Re-proves and generalizes Cauchy's counting identity using character theory. Modern usage 'Cauchy-Frobenius lemma' acknowledges this priority."
+    },
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "venue": "Cambridge University Press (1st ed., 2nd ed. 1911)",
+      "note": "The canonical textbook reference. Burnside himself acknowledges Frobenius's priority; the misattribution 'Burnside's lemma' is a 20th-century standardization (sometimes called the 'lemma that is not Burnside's')."
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "venue": "Acta Mathematica 68, 145-254",
+      "note": "Generalizes Burnside's lemma to weighted counting via the cycle index $Z(G) = \\frac{1}{|G|}\\sum_g p_1^{c_1(g)}\\cdots$. For $\\mathbb{Z}/4\\mathbb{Z}$: $Z = (p_1^4 + p_2^2 + 2p_4)/4$, which produces $b^4 + b^3w + 2b^2w^2 + bw^3 + w^4$ on substitution — the six 4-necklaces."
+    },
+    {
+      "authors": "de Bruijn, N. G.",
+      "title": "Pólya's Theory of Counting",
+      "year": "1964",
+      "venue": "In E. F. Beckenbach (ed.), *Applied Combinatorial Mathematics*, Wiley, 144-184",
+      "note": "Standard modern exposition of the Burnside-Pólya counting framework. Includes the cycle index machinery and worked examples for chemical isomers, graphs, and necklaces."
+    },
+    {
+      "authors": "Sloane, N. J. A. (OEIS Foundation)",
+      "title": "Sequence A000029 (Number of binary necklaces with n beads)",
+      "year": "accessed 2026",
+      "venue": "Online Encyclopedia of Integer Sequences, https://oeis.org/A000029",
+      "note": "Lists the binary-necklace counts: 1, 2, 3, 4, 6, 8, 13, 18, 30, ... for $n = 0, 1, 2, 3, 4, 5, 6, ...$ The value 6 at $n=4$ is exactly `binary_necklaces_4` here. Companion sequence A000031 counts under rotation only (no flips)."
+    },
+    {
+      "authors": "Neumann, P. M.",
+      "title": "A lemma that is not Burnside's",
+      "year": "1979",
+      "venue": "Mathematical Scientist 4, 133-141",
+      "note": "Tracks the attribution history and explicitly identifies Cauchy (1845) as the original source. Standard reference for the historical correction."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: GroupTheory.GroupAction.Quotient",
+      "year": "2024",
+      "venue": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/GroupAction/Quotient.html",
+      "note": "Source of `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`, the Mathlib statement of Burnside's lemma. The Lean proof here is a one-line wrapper. The `MulAction` API is complementary to (and not yet fully bridged with) the `AddAction` API used here for $\\mathbb{Z}/n\\mathbb{Z}$."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "ramseys-theorem",


### PR DESCRIPTION
## Summary

Fills the **structural-schema-gap pattern** for `burnside-counting` (Burnside's Lemma and Binary 4-Necklaces): the meta.json had both top-level `mainTheorems` and `references` arrays empty.

This is a docstring-only enrichment; the Lean proof, axiom count (5), and all existing rich arrays (overview with 4 inline prerequisites, sections, conclusion, crossReferences) are untouched.

## What's added

- **`mainTheorems` (8 items)** — `burnside_lemma` (Mathlib wrapper), `cyclicAddActionOnColorings` (the example action), `binary_4_colorings_count` (= 16), `constant_coloring_count` (verified bijection with `Fin k`), `period2_count` (= 4 via `Fin 2 × Fin 2` literal), and the three remaining axioms `rotatedIndex_add`, `fixed_point_sum_binary_4`, `binary_necklaces_4`. Type tags (`core`/`axiom`/`supporting`/`definition`) match the actual Lean declarations.
- **`references` (8 items)** — Cauchy (1845, original) → Frobenius (1887, character-theoretic generalization) → Burnside (1897, textbook attribution) → Pólya (1937, cycle index) → de Bruijn (1964, modern exposition) → OEIS A000029 → Neumann (1979, *A lemma that is not Burnside's*) → Mathlib `GroupAction.Quotient`.

## Why no top-level prerequisites?

`overview.prerequisites` already contains 4 entries (group actions, finite-group theory, modular arithmetic, Pólya enumeration). Adding a parallel top-level array would duplicate. Left as-is.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` validates meta.json
- [x] `git diff --stat origin/main` is exactly the one file (+116 lines)
- [x] All 8 `mainTheorems[].name` entries match `proofs/Proofs/BurnsideCounting.lean` symbols verbatim
- [x] Axioms (`rotatedIndex_add`, `fixed_point_sum_binary_4`, `binary_necklaces_4`) tagged `type: axiom` — consistent with `meta.axiomCount: 5` (the remaining two, `coloringSetoid` and `coloringQuotientFintype`, are infrastructure axioms not surfaced here)
- [x] Cauchy 1845 / Frobenius 1887 / Burnside 1897 priority ordering matches Neumann's 1979 attribution paper
- [x] `binary_necklaces_4 = 6` checked against OEIS A000029 at $n=4$