### PR TITLE
research(binary-gcd-oq-03-oq-02): S24 — survey-range tabulation framework for outer-guard density (build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -890,6 +890,65 @@ example : schonhageOuterGuardFires 63 1 = false := by native_decide
 
 example : schonhageOuterGuardFires 63 63 = false := by native_decide
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART XV: SURVEY-RANGE TABULATION FRAMEWORK (Session 24)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Outer-guard density framework on the S17 counterexample range
+
+    The S17 PART XIV counterexample family `(130, 89)` (BinaryGcd
+    OQ03OQ02 PART XIV) sits inside a survey range
+      `S = {(a, b) : 64 ≤ b ≤ a < 130}`.
+    On `S` the row-vector invariant fails on a positive-density
+    subset (PART XIV); the S23 outer guard `schonhageOuterGuardFires`
+    catches every such pair and dispatches to `Nat.gcd`.
+
+    This section provides the QUANTITATIVE infrastructure to measure
+    outer-guard firing density on `S`:
+
+      * `surveyRange`: the explicit list of all 2211 pairs
+        (lower-triangular `[64, 130) × [64, 130)`).
+      * `outerGuardFiresInSurveyRange`: count of pairs where the
+        outer guard fires (`schonhageGcd` recurses on a strictly
+        smaller pair).
+      * `outerGuardAbortsInSurveyRange`: count of pairs where the
+        outer guard aborts (`schonhageGcd` falls back to `Nat.gcd`).
+
+    The exact numerical density is left as a future `native_decide`
+    evaluation (each of the 2211 calls runs a full safe-HGCD
+    recursion). This session establishes the data structure and
+    the enumeration size; downstream callers can plug specific
+    `native_decide` checks against the count definitions. -/
+
+/-- Explicit enumeration of pairs `(a, b)` with `64 ≤ b ≤ a < 130`,
+    constructed via nested `foldr` (no `bind` / `flatMap`
+    dependency). The result is the lower-triangular set on
+    `[64, 130) × [64, 130)`. -/
+def surveyRange : List (ℕ × ℕ) :=
+  (List.range 66).foldr
+    (fun i acc =>
+      (List.range (i + 1)).foldr
+        (fun j acc' => (64 + i, 64 + j) :: acc') acc)
+    []
+
+/-- The survey range has exactly `2211 = 66 · 67 / 2` pairs.
+    Verified by `native_decide` on a structural fold over `List.range`,
+    independent of any `hgcdSafeApply` recursion. -/
+theorem surveyRange_length : surveyRange.length = 2211 := by native_decide
+
+/-- Count of pairs `(a, b)` in `surveyRange` for which the outer
+    guard fires — equivalently, on which `schonhageGcd` recurses
+    rather than falling back to `Nat.gcd`. -/
+def outerGuardFiresInSurveyRange : ℕ :=
+  (surveyRange.filter (fun p => schonhageOuterGuardFires p.1 p.2)).length
+
+/-- Count of pairs `(a, b)` in `surveyRange` for which the outer
+    guard aborts — equivalently, on which `schonhageGcd` falls back
+    to `Nat.gcd` (whether because of below-threshold dispatch or
+    because `hgcdSafeApply` did not strictly reduce `max a b`). -/
+def outerGuardAbortsInSurveyRange : ℕ :=
+  (surveyRange.filter (fun p => !schonhageOuterGuardFires p.1 p.2)).length
+
 end HGcdSafe
 
 /-! ## Summary

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -1,21 +1,50 @@
 # Current State
 
 **Phase**: ACT — Path A's algorithmic story (S18–S20), primary
-API (S21–S22), and now the outer-guard branching characterisation
-(S23) are closed. S23 introduces a Boolean predicate
-`schonhageOuterGuardFires : ℕ → ℕ → Bool` capturing the OUTER
-size-reduction guard from `schonhageGcd`'s recursive case, plus
-five structural lemmas that reduce every reasoning step about the
-recursion to a Boolean case-split on the predicate. This is the
-qualitative foundation for the deferred quantitative speedup
-story (S24+).
+API (S21–S22), the outer-guard branching characterisation (S23),
+and now the survey-range tabulation framework for outer-guard
+density (S24) are in place. S24 (this session) adds
+`surveyRange : List (ℕ × ℕ)` (the explicit 2211-pair lower
+triangle on `[64, 130) × [64, 130)`), proves
+`surveyRange.length = 2211` via `native_decide`, and defines
+`outerGuardFiresInSurveyRange` / `outerGuardAbortsInSurveyRange`
+counting functions. The exact density magnitude is left for
+future `native_decide` evaluation; this session establishes the
+framework and confirms enumeration size.
 
 **Since**: 2026-05-01
-**Iteration**: 23
+**Iteration**: 24
 
 ## Current Focus
 
-Session 23 (this PR) introduces an outer-guard predicate
+Session 24 (this PR, researcher-6) adds the **survey-range
+tabulation framework** (Path A PART XV) for measuring outer-guard
+density on the S17 PART XIV counterexample family. Three
+contributions:
+
+  - `surveyRange : List (ℕ × ℕ)` — explicit lower-triangular
+    enumeration of `{(a, b) : 64 ≤ b ≤ a < 130}`, built via
+    nested `foldr` / `::` (no `bind`/`flatMap` dependency).
+  - `surveyRange_length : surveyRange.length = 2211` — confirms
+    the enumeration covers `66 · 67 / 2` pairs. By
+    `native_decide` on a structural fold over `List.range`,
+    independent of any HGCD recursion (fast).
+  - `outerGuardFiresInSurveyRange` and
+    `outerGuardAbortsInSurveyRange` — `ℕ`-valued count
+    definitions partitioning the survey range by
+    `schonhageOuterGuardFires`. Future sessions can plug
+    `native_decide` evaluations on these counts to obtain the
+    exact density magnitude.
+
+Net: +59 lines (1 theorem + 3 defs), 0 new axioms, 0 new sorries.
+Together with S23's headline theorem
+`schonhageGcd_succ_via_outerGuard`, the outer-guard story is now
+both qualitatively (S23) and structurally (S24) anchored: the
+QUALITATIVE branching is fully described by a Boolean predicate
+and the QUANTITATIVE density framework is in place to support
+future `native_decide` magnitude measurements.
+
+Session 23 introduced an outer-guard predicate
 characterisation of `schonhageGcd`'s recursive case. The predicate
 `schonhageOuterGuardFires : ℕ → ℕ → Bool` returns `true` iff
 applying `hgcdSafeApply a b` strictly reduces `max a b` (and the
@@ -232,25 +261,31 @@ speedup, bit-complexity bound).
 
 ## Next Action
 
-1. **Session 24 — outer-guard density theorem**: with the S23
-   branching equation in hand, prove a *density* statement for
-   `schonhageOuterGuardFires`. Concrete sub-targets:
-   - Coprime pairs above threshold with matching bit-length:
-     does the outer guard provably fire? Inspecting `hgcdSafeApply`
-     on such inputs would yield a *deterministic* speedup bound on
-     this regime (one full HGCD step per call, rather than the
-     worst-case fallback to `Nat.gcd`).
-   - Survey-range characterisation: for the S17 PART XIV
-     counterexample family `{(a, b) : 64 ≤ b ≤ a < 130}`, what
-     fraction of inputs trigger the outer guard? Can be measured
-     by `native_decide` on a Boolean tabulation function and
-     would calibrate the qualitative-vs-quantitative gap.
-2. **Session 25+ — inner-reduction characterisation**: refine the
+1. **Session 25 — outer-guard density magnitude**: with the S24
+   tabulation framework in place, run `native_decide` on
+   `outerGuardFiresInSurveyRange` and
+   `outerGuardAbortsInSurveyRange` to obtain the exact density
+   numbers. Likely 60–120 seconds of native_decide compute time
+   per count (2211 calls × ~ ms-scale `hgcdSafeApply` evaluation).
+   Once magnitudes are known, package them as named constants
+   (`schonhageOuterGuard_fires_count`,
+   `schonhageOuterGuard_aborts_count`) and add a `decide`-checked
+   sum-equals-2211 partition theorem. The relative magnitude
+   answers the qualitative-vs-quantitative gap left by S17 PART
+   XIV: if firing density is high (e.g. > 80%), Schönhage gives a
+   measurable speedup on this regime; if low, fallback dominates.
+2. **Session 26+ — inner-reduction characterisation**: refine the
    *inner* runtime guard analysis for `hgcdMatrixSafe` itself,
    complementing the S23 outer-guard predicate. This is the
    second-level question the S17 PART XIV counterexample raised.
-3. **Bit-complexity bound**: still blocked on Mathlib; defer.
-4. **Mathlib upstream**: the current `schonhageGcdOf` API surface
+3. **Coprime-bit-length theorem**: with the S24 framework, the
+   stronger sub-target — "every coprime pair above threshold with
+   matching bit-length triggers the outer guard" — becomes a
+   *theorem candidate* whose statement is now well-typed in the
+   PathA file. Proving it requires structural analysis of
+   `hgcdSafeApply`, deferred.
+4. **Bit-complexity bound**: still blocked on Mathlib; defer.
+5. **Mathlib upstream**: the current `schonhageGcdOf` API surface
    (S21+S22) is now sufficient that, contingent on a working
    Docker build, candidate Mathlib upstream PRs could be drafted
    for one or two of the routine wrapper lemmas. Survey what


### PR DESCRIPTION
## Summary
S24 adds **Path A PART XV** to `proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean`: framework for measuring outer-guard firing density on the S17 PART XIV counterexample family `{(a, b) : 64 ≤ b ≤ a < 130}`.

Three contributions:

| Item | Type | Purpose |
|------|------|---------|
| `surveyRange : List (ℕ × ℕ)` | def | Explicit lower-triangular enumeration of the 2211-pair survey range |
| `surveyRange_length` | theorem | `surveyRange.length = 2211 = 66 · 67 / 2`, by `native_decide` (structural fold, no HGCD recursion) |
| `outerGuardFiresInSurveyRange` / `outerGuardAbortsInSurveyRange` | defs | `ℕ`-valued count definitions partitioning the survey range by `schonhageOuterGuardFires` (S23) |

**Net change**: +59 lines, 0 new axioms, 0 new sorries.

## Why this matters
S23 left the QUALITATIVE outer-guard branching fully characterised (`schonhageGcd_succ_via_outerGuard`), but the QUANTITATIVE density question on the S17 counterexample range was open. S24 supplies the data-structural infrastructure — the explicit enumeration plus count definitions — that future sessions can plug `native_decide` into to obtain exact firing density magnitudes.

The S25 next action is now well-defined: run `native_decide` on `outerGuardFiresInSurveyRange = ?` to extract the exact count, then derive the partition theorem `outerGuardFiresInSurveyRange + outerGuardAbortsInSurveyRange = 2211`. Density magnitude answers the qualitative-vs-quantitative gap left by S17 PART XIV: high firing density implies a measurable Schönhage speedup on this regime; low density means fallback dominates.

## Implementation notes
- `surveyRange` is built via nested `foldr` / `::` rather than `List.bind` / `List.flatMap`, avoiding any recent name-churn in those combinators.
- `surveyRange_length` is checked by `native_decide` on a *structural* fold (no HGCD recursion involved), so the proof is fast.
- The count definitions deliberately do not commit to specific magnitudes — those are the S25 next-action's deliverable.
- File is `additionalFiles` of the gallery entry; main-file `meta.json` counts (`lineCount`/`theoremCount` for `BinaryGcdOQ03OQ02.lean`) are unchanged.

## Continuity
Builds on:
- S23 (#17305, merged 17:37Z 2026-05-08): Path A PART XIII — `schonhageOuterGuardFires` predicate + branching characterisation.
- S22 (#15091): Path A PART XI/XII — extended algebraic identities + empirical witnesses.
- S21 (#17104): Path A PART X — primary API surface for `schonhageGcdOf`.
- S20 (#17087): Path A PART VIII — recursive Schönhage GCD `schonhageGcd` + correctness.

## Build status
**Build pending** — `proofs/.lake` self-referential symlink forces fresh Mathlib clone per Docker build (~45 min cold). Path A pattern: every Sxx since S18 has been "build pending" with auditor pipeline carrying the build outcome.

## Test plan
- [ ] Lean build verifies via auditor pipeline (Docker)
- [x] No new axioms (axiomCount unchanged at 0)
- [x] No new sorries (sorries unchanged at 1, the `hgcdMatrix_row_output_le` line 1078 of main file)
- [x] No `bind`/`flatMap` dependency (uses `foldr` / `::` only)
- [x] `surveyRange_length` `native_decide` is on a structural fold (no HGCD recursion), so verification is fast
- [x] `surveyRange` size is `66 · 67 / 2 = 2211` (matches state.md and S17 PART XIV envelope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)