### PR TITLE
fix(meta): batch sync count drift (3 entries)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 1555,
-    "theoremCount": 47,
+    "lineCount": 1795,
+    "theoremCount": 49,
     "definitionCount": 8,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,11 +142,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 1555,
+    "lineCount": 1795,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 47,
+    "theoremCount": 49,
     "definitionCount": 8
   },
   "sorries": 0

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "theoremCount": 39,
-    "definitionCount": 20
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
@@ -191,7 +191,7 @@
     "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 39,
-    "definitionCount": 20,
+    "definitionCount": 16,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 1299,
+    "lineCount": 1301,
     "theoremCount": 59,
     "definitionCount": 8,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
@@ -249,7 +249,7 @@
       "Polynomial"
     ],
     "namespace": "Hilbert11OQ02",
-    "lineCount": 1299,
+    "lineCount": 1301,
     "axiomCount": 2,
     "theoremCount": 59,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync stale count fields in three `meta.json` entries against current `origin/main` Lean source files.

### erdos-643: `definitionCount` 20 → 16 (lf and meta sub-blocks)

`proofs/Proofs/Erdos643Problem.lean` contains 16 `def`/`abbrev`/`opaque` declarations after stripping comments. The previous count of 20 was likely a naive grep over the raw file (which counts decls inside block comments) or stale from before a refactor that consolidated some definitions.

```
$ # comment-stripped declaration count
16 def/abbrev/opaque (verified via TS scanner)
```

### birthday-problem-oq-03-oq-01-oq-02: `lineCount` 1555 → 1795, `theoremCount` 47 → 49

The Lean file has grown again since #17382 landed. `wc -l` returns 1795 lines and the comment-stripped theorem/lemma count is 49. The `leanFile` and `meta` sub-blocks are kept in sync (no submodule imports or `additionalFiles`, so chain count = file count).

```
$ wc -l proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
1795
```

### hilbert-11-oq-02: `lineCount` 1299 → 1301 (lf and meta)

Off-by-two in both `leanFile.lineCount` and `meta.lineCount`.

```
$ wc -l proofs/Proofs/Hilbert11OQ02.lean
1301
```

## Notes

- `find-targets.ts` only checks sorry/axiom/True-stub drift, not `theoremCount`/`lineCount`/`definitionCount` — so these slip past automated detection.
- All values verified against the current `origin/main` snapshots via newline-count and comment-stripped declaration scanning.
- Surgical 8-line diff (no JSON re-formatting).

---
Automated fix by lean-mechanic agent.