### PR TITLE
research(erdos-1151-oq-04): S23 — m-choice + hm_le + hcap_max packager (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -1652,6 +1652,119 @@ private lemma chebyshev_h_interior_of_close_and_max_index_cap
         _ = (m : ℝ) * Real.pi / n := by ring
     linarith
 
+/-- **Step 7a (m-choice + `hm_le` + `hcap_max` packager).**
+
+    For `θ ∈ (0, π/2]`, `n ≥ 4`, the standard nearest-node closeness
+    `|θ - φ_{k₀}| ≤ π/(2n)`, and any `m : ℕ` with `(m : ℝ) ≤ n·θ/(4π)`,
+    both arithmetic preconditions of the trig sub-sum chain hold:
+
+      • `hm_le`: `k₀.val + m + 1 ≤ n` (input to `trig_sum_subsum_log_lb`),
+      • `hcap_max`: `φ_{k₀+m} ≤ π - θ/2` (input to
+        `chebyshev_h_interior_of_close_and_max_index_cap`).
+
+    The standard Step 7a caller-side choice `m := ⌊n·θ/(4π)⌋` satisfies the
+    `(m : ℝ) ≤ n·θ/(4π)` hypothesis via `Nat.floor_le`. Combined with
+    `chebyshev_h_interior_of_close_and_max_index_cap`, this closes every
+    arithmetic precondition of `trig_sum_subsum_log_lb` for the asymptotic
+    branch of `trig_sum_harmonic_lb`.
+
+    **Key arithmetic** (with `θ ≤ π/2` and `n ≥ 4`):
+
+      • From closeness: `(2k₀+1)·π/(2n) ≤ θ + π/(2n)`, hence
+        `2 k₀ · π ≤ 2 n θ ≤ n π`, giving `2 k₀ ≤ n` (in ℕ).
+      • From `(m : ℝ) ≤ n·θ/(4π) ≤ n/8`: `8 m ≤ n` (in ℕ).
+      • Then `omega` closes `k₀.val + m + 1 ≤ n` from `2 k₀ ≤ n`,
+        `8 m ≤ n`, `n ≥ 4` (since `8(k₀ + m + 1) ≤ 4n + n + 8 ≤ 8n`).
+      • For the cap: `φ_{k₀+m} = φ_{k₀} + m·π/n ≤ (θ + π/(2n)) + θ/4`.
+        With `θ ≤ π/2` and `n ≥ 4`: `≤ π/2 + π/8 + π/8 = 3π/4`, and
+        `π - θ/2 ≥ π - π/4 = 3π/4`. -/
+private lemma chebyshev_quarter_floor_hm_le_and_cap_max
+    (n : ℕ) (hn : 4 ≤ n) (θ : ℝ) (hθ_pos : 0 < θ) (hθ_le : θ ≤ Real.pi / 2)
+    (k₀ : Fin n)
+    (hk₀_close : |θ - (2 * (k₀.val : ℝ) + 1) * Real.pi / (2 * n)| ≤ Real.pi / (2 * n))
+    (m : ℕ) (hm_real_le : (m : ℝ) ≤ (n : ℝ) * θ / (4 * Real.pi)) :
+    k₀.val + m + 1 ≤ n ∧
+    (2 * ((k₀.val + m : ℕ) : ℝ) + 1) * Real.pi / (2 * n) ≤ Real.pi - θ / 2 := by
+  have hpi_pos := Real.pi_pos
+  have hπ_ne : Real.pi ≠ 0 := hpi_pos.ne'
+  have hn_pos_nat : 0 < n := by omega
+  have hn_pos : (0 : ℝ) < (n : ℝ) := Nat.cast_pos.mpr hn_pos_nat
+  have hn_ne : (n : ℝ) ≠ 0 := hn_pos.ne'
+  have h2n_pos : (0 : ℝ) < 2 * (n : ℝ) := by linarith
+  have h2n_ne : 2 * (n : ℝ) ≠ 0 := h2n_pos.ne'
+  have h4_le_n : (4 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  -- Step 1: m·π/n ≤ θ/4 (multiply hm_real_le by π/n > 0 and simplify)
+  have hm_pi_n_le_θ4 : (m : ℝ) * Real.pi / n ≤ θ / 4 := by
+    have hπn_nn : (0 : ℝ) ≤ Real.pi / n := (div_pos hpi_pos hn_pos).le
+    have step :
+        (m : ℝ) * (Real.pi / n) ≤ ((n : ℝ) * θ / (4 * Real.pi)) * (Real.pi / n) :=
+      mul_le_mul_of_nonneg_right hm_real_le hπn_nn
+    have hLHS : (m : ℝ) * (Real.pi / n) = (m : ℝ) * Real.pi / n := by ring
+    have hRHS : ((n : ℝ) * θ / (4 * Real.pi)) * (Real.pi / n) = θ / 4 := by
+      field_simp
+      ring
+    linarith
+  have hθ4_le_π8 : θ / 4 ≤ Real.pi / 8 := by linarith
+  have hm_pi_n_le_π8 : (m : ℝ) * Real.pi / n ≤ Real.pi / 8 :=
+    le_trans hm_pi_n_le_θ4 hθ4_le_π8
+  -- Step 2: φ_{k₀} ≤ θ + π/(2n) (from |θ - φ_{k₀}| ≤ π/(2n) via abs_le)
+  have hφk₀_le : (2 * (k₀.val : ℝ) + 1) * Real.pi / (2 * n) ≤ θ + Real.pi / (2 * n) := by
+    have := (abs_le.mp hk₀_close).1
+    linarith
+  -- Step 3: φ_{k₀+m} = φ_{k₀} + m·π/n (Nat-cast bridge + algebra)
+  have hφ_k0m_decomp :
+      (2 * ((k₀.val + m : ℕ) : ℝ) + 1) * Real.pi / (2 * n) =
+        (2 * (k₀.val : ℝ) + 1) * Real.pi / (2 * n) + (m : ℝ) * Real.pi / n := by
+    have hcast : ((k₀.val + m : ℕ) : ℝ) = (k₀.val : ℝ) + (m : ℝ) := by push_cast; ring
+    rw [hcast]; field_simp; ring
+  -- Step 4: π/(2n) ≤ π/8 (since n ≥ 4 ⟹ 2n ≥ 8)
+  have hπ_2n_le_π_8 : Real.pi / (2 * n) ≤ Real.pi / 8 := by
+    rw [div_le_div_iff₀ h2n_pos (by norm_num : (0 : ℝ) < 8)]
+    have h_8_le_2n : (8 : ℝ) ≤ 2 * (n : ℝ) := by linarith
+    nlinarith [hpi_pos]
+  -- Step 5: hcap_max — assemble the cap bound.
+  -- φ_{k₀+m} ≤ (θ + π/(2n)) + m·π/n ≤ (θ + π/8) + π/8 ≤ (π/2 + π/8) + π/8 = 3π/4 ≤ π - θ/2.
+  have hcap_max :
+      (2 * ((k₀.val + m : ℕ) : ℝ) + 1) * Real.pi / (2 * n) ≤ Real.pi - θ / 2 := by
+    rw [hφ_k0m_decomp]
+    have h_3π4_eq : Real.pi / 2 + Real.pi / 8 + Real.pi / 8 = 3 * Real.pi / 4 := by ring
+    have h_target_ge_3π4 : 3 * Real.pi / 4 ≤ Real.pi - θ / 2 := by linarith
+    linarith [hφk₀_le, hπ_2n_le_π_8, hθ_le, hm_pi_n_le_π8, h_3π4_eq, h_target_ge_3π4]
+  refine ⟨?_, hcap_max⟩
+  -- Step 6: hm_le — derive 2*k₀ ≤ n and 8*m ≤ n in ℕ, then `omega`.
+  -- 2*k₀ ≤ n: clear (2n) from hφk₀_le, then bound by 2nθ ≤ nπ via θ ≤ π/2.
+  have h2k0_real_le : 2 * (k₀.val : ℝ) ≤ (n : ℝ) := by
+    have hφk₀_clear :
+        (2 * (k₀.val : ℝ) + 1) * Real.pi ≤ 2 * (n : ℝ) * θ + Real.pi := by
+      have step := mul_le_mul_of_nonneg_right hφk₀_le h2n_pos.le
+      have hLHS :
+          (2 * (k₀.val : ℝ) + 1) * Real.pi / (2 * n) * (2 * n) =
+            (2 * (k₀.val : ℝ) + 1) * Real.pi := by
+        field_simp
+      have hRHS :
+          (θ + Real.pi / (2 * n)) * (2 * n) = 2 * (n : ℝ) * θ + Real.pi := by
+        field_simp; ring
+      linarith
+    have h_2nθ_le_nπ : 2 * (n : ℝ) * θ ≤ (n : ℝ) * Real.pi := by
+      nlinarith [hθ_le, hn_pos.le]
+    have h_2k0π_le_nπ : 2 * (k₀.val : ℝ) * Real.pi ≤ (n : ℝ) * Real.pi := by linarith
+    nlinarith [h_2k0π_le_nπ, hpi_pos]
+  have h2k0_nat_le : 2 * k₀.val ≤ n := by exact_mod_cast h2k0_real_le
+  -- 8*m ≤ n: from m·π/n ≤ π/8, clear denominators via 8n > 0.
+  have h8m_real_le : 8 * (m : ℝ) ≤ (n : ℝ) := by
+    have h8n_pos : (0 : ℝ) < 8 * (n : ℝ) := by linarith
+    have step := mul_le_mul_of_nonneg_right hm_pi_n_le_π8 h8n_pos.le
+    have hLHS :
+        (m : ℝ) * Real.pi / n * (8 * (n : ℝ)) = 8 * (m : ℝ) * Real.pi := by
+      field_simp; ring
+    have hRHS : Real.pi / 8 * (8 * (n : ℝ)) = (n : ℝ) * Real.pi := by
+      field_simp; ring
+    have h_8mπ_le_nπ : 8 * (m : ℝ) * Real.pi ≤ (n : ℝ) * Real.pi := by linarith
+    nlinarith [h_8mπ_le_nπ, hpi_pos]
+  have h8m_nat_le : 8 * m ≤ n := by exact_mod_cast h8m_real_le
+  -- Conclude k₀.val + m + 1 ≤ n: 8(k₀ + m + 1) ≤ 4n + n + 8 ≤ 8n iff n ≥ 8/3.
+  omega
+
 /-- **Reindex symmetry of the Chebyshev-Lebesgue trig sum: θ ↔ π - θ.**
 
     Under the involution `σ : Fin n ≃ Fin n`, `k ↦ n - 1 - k`:

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,10 +4,62 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 22
+**Iteration**: 23
 **Last Updated**: 2026-05-08
 
-## Session 22 (researcher-11, this session, build pending)
+## Session 23 (researcher-3, this session, build pending)
+
+Added the **Step 7a m-choice + arithmetic packager** as a new private helper
+`chebyshev_quarter_floor_hm_le_and_cap_max` (~110 lines). Given:
+
+  • `θ ∈ (0, π/2]`, `n ≥ 4`,
+  • the standard nearest-node closeness `|θ - φ_{k₀}| ≤ π/(2n)`, and
+  • any `m : ℕ` with `(m : ℝ) ≤ n·θ/(4π)` (e.g. `m := ⌊n·θ/(4π)⌋` via
+    `Nat.floor_le`),
+
+the lemma simultaneously discharges both arithmetic preconditions of the
+trig sub-sum chain:
+
+  • `hm_le`: `k₀.val + m + 1 ≤ n` (input to `trig_sum_subsum_log_lb`),
+  • `hcap_max`: `(2(k₀+m)+1)·π/(2n) ≤ π - θ/2` (input to S22's
+    `chebyshev_h_interior_of_close_and_max_index_cap`).
+
+**Proof skeleton** (with `θ ≤ π/2` and `n ≥ 4`):
+
+  1. `m·π/n ≤ θ/4 ≤ π/8`: multiply `(m : ℝ) ≤ n·θ/(4π)` by `π/n > 0`.
+  2. `φ_{k₀} ≤ θ + π/(2n)` from `abs_le.mp hk₀_close`.
+  3. `φ_{k₀+m} = φ_{k₀} + m·π/n ≤ π/2 + π/8 + π/8 = 3π/4 ≤ π - θ/2`.
+  4. `2 k₀ ≤ n` (ℕ) from `(2k₀+1)π ≤ 2nθ + π ≤ nπ + π`; divide by π via
+     `nlinarith`, cast.
+  5. `8 m ≤ n` (ℕ) from `m·π/n ≤ π/8`, multiply by `8n`; cast.
+  6. `omega` closes `k₀.val + m + 1 ≤ n` from `2 k₀ ≤ n`, `8 m ≤ n`,
+     `n ≥ 4` (since `8(k₀+m+1) ≤ 5n + 8 ≤ 8n` for `n ≥ 3`).
+
+**Why packaged this way**: the next session (Step 7a glue) will pick the
+concrete `m := ⌊n·θ/(4π)⌋` and need both `hm_le` and `hcap_max` in the
+*same* shape consumed by S22's `chebyshev_h_interior_of_close_and_max_index_cap`
+verifier. Bundling both into one lemma keeps the asymptotic-branch caller
+free of arithmetic boilerplate. The generality `(m : ℝ) ≤ n·θ/(4π)`
+(rather than fixing `m := Nat.floor …`) leaves room for a tighter choice
+if a future variant prefers `m := ⌊n·θ/(4π)⌋ - 1` for cleaner log estimates.
+
+## Session 22 (researcher-3, h_interior verifier, merged via #17324)
+
+Earlier in S22, researcher-3 added `chebyshev_h_interior_of_close_and_max_index_cap`
+(~75 lines) — the **abstract h_interior verifier** that bridges:
+
+  • `hk₀_close : |θ - φ_{k₀}| ≤ π/(2n)` and
+  • `hcap_max : φ_{k₀+m} ≤ π - θ/2`
+
+into the full `h_interior` of `trig_sum_subsum_lb` / `trig_sum_subsum_log_lb`
+(setting `d = θ`). For each `j : Fin m`, both `θ/2 ≤ φ_{k₀+j+1}` (from
+the closeness lower bound + section-spacing `(j+1)·π/n ≥ π/n = 2·(π/(2n))`)
+and `φ_{k₀+j+1} ≤ π - θ/2` (monotone in the index, capped at `m`). All
+arithmetic via `linarith` + `field_simp`. The S23 helper
+`chebyshev_quarter_floor_hm_le_and_cap_max` (this session) is the natural
+feeder for this lemma's `hcap_max` input when `m := ⌊n·θ/(4π)⌋`.
+
+## Session 22 (researcher-11, trig_sum_small_n_const, merged via #17330)
 
 Added one Step 7 helper: `trig_sum_small_n_const` (~80 lines) — closed the
 **finite-set side** of `trig_sum_harmonic_lb`'s Step 7. For any cutoff
@@ -111,19 +163,23 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
 
 ## Next Steps
 
-1. Prove `trig_sum_harmonic_lb` using the existing scaffolding (~50–80 lines remaining):
-   - **Step 7a (asymptotic, large `n`)**: WLOG θ ∈ (0, π/2] via
-     `trig_sum_reindex_symmetry`; pick `m := ⌊n·d/(4π)⌋` and verify
-     `hm_le` / `h_interior` for `trig_sum_subsum_log_lb`; this yields
-     `sin(d/2) · (2n/π) · ((1/2) · log(m+2) − 1) ≤ S(θ, n)` for `n ≥ N₀(d)`,
-     which dominates `C₁ · n · log(n+1)` asymptotically with
-     `C₁ ≈ sin(d/2)/π`.
+1. Prove `trig_sum_harmonic_lb` using the existing scaffolding (~30–60 lines remaining):
+   - **Step 7a (asymptotic, large `n`)**: WLOG `θ ∈ (0, π/2]` via
+     `trig_sum_reindex_symmetry`; pick `m := ⌊n·θ/(4π)⌋` (with `Nat.floor_le`
+     supplying the `(m : ℝ) ≤ n·θ/(4π)` hypothesis), then chain
+     `chebyshev_quarter_floor_hm_le_and_cap_max` (S23) →
+     `chebyshev_h_interior_of_close_and_max_index_cap` (S22) →
+     `trig_sum_subsum_log_lb` to obtain
+     `sin(θ/2) · (2n/π) · ((1/2) · log(m+2) − 1) ≤ S(θ, n)` for `n ≥ N₀(θ)`.
+     Asymptotically dominates `C₁ · n · log(n+1)` with `C₁ ≈ sin(θ/2)/π`,
+     once `log(m+2) ≥ (1/2)·log(n+1)` is established (use
+     `Nat.lt_floor_add_one` + log-monotonicity).
    - **Step 7b (small `n`, finite-set min')**: ✅ **closed in S22** by
      `trig_sum_small_n_const`. Returns `C₂ > 0` with
-     `C₂ · n · log(n+1) ≤ S(θ, n)` for `1 ≤ n ≤ N₀(d) − 1`.
+     `C₂ · n · log(n+1) ≤ S(θ, n)` for `1 ≤ n ≤ N₀(θ) − 1`.
    - **Step 7c (combine)**: `C := min C₁ C₂`. Both halves use the
      same `n · log(n+1)` shape, so the unified bound follows by case
-     split on `n < N₀(d)` vs `n ≥ N₀(d)`.
+     split on `n < N₀(θ)` vs `n ≥ N₀(θ)`.
 
 2. For Sorry 2 (`divergence_from_lebesgue_growth`):
    - **Option A (recommended)**: weaken statement to `Filter.Tendsto … atTop`
@@ -160,17 +216,24 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
   `S(θ, n)` for any `θ` whose cosine avoids all `n` Chebyshev nodes.
 - 2026-05-08: Session 21 (doctor): `trig_sum_subsum_log_lb` — combined log
   lower bound (Step 6a + 6b). Recovered from PR #17046 orphan branch.
-- 2026-05-08: Session 22 (researcher-11, this session): `trig_sum_small_n_const`
-  — finite-set min' lower bound for the small-`n` side of Step 7. Composes
+- 2026-05-08: Session 22 (researcher-11): `trig_sum_small_n_const` — finite-set
+  min' lower bound for the small-`n` side of Step 7. Composes
   `chebyshev_trig_sum_pos` (S20) with `Finset.min'` over
-  `(Finset.Icc 1 N).image (n ↦ S(θ, n) / (n · log(n+1)))`.
+  `(Finset.Icc 1 N).image (n ↦ S(θ, n) / (n · log(n+1)))`. Merged via #17330.
+- 2026-05-08: Session 22 (researcher-3): `chebyshev_h_interior_of_close_and_max_index_cap`
+  — abstract h_interior verifier from `hk₀_close` + `hcap_max`. Merged via #17324.
+- 2026-05-08: Session 23 (researcher-3, this session): `chebyshev_quarter_floor_hm_le_and_cap_max`
+  — m-choice + arithmetic packager that, for `θ ∈ (0, π/2]`, `n ≥ 4`, and any
+  `m : ℕ` with `(m : ℝ) ≤ n·θ/(4π)`, produces both `hm_le` and `hcap_max`
+  inputs simultaneously. Closes the arithmetic boilerplate for the
+  asymptotic-branch caller of `trig_sum_subsum_log_lb`.
 
 ## Open PRs
 
-- (this session) PR pending — `trig_sum_small_n_const` (~80 lines, build TBD)
+- (this session) PR pending — `chebyshev_quarter_floor_hm_le_and_cap_max` (~110 lines, build TBD)
 
-## File Stats (after Session 22 added trig_sum_small_n_const)
+## File Stats (after Session 23 added chebyshev_quarter_floor_hm_le_and_cap_max)
 
-- `proofs/Proofs/Erdos1151OQ04.lean`: 1969 lines, 2 sorries (was 1872 lines)
+- `proofs/Proofs/Erdos1151OQ04.lean`: 2178 lines, 2 sorries (was 2067 lines)
 - `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: companion file (0 sorries)
 - `proofs/Proofs/Erdos1151Problem.lean`: parent problem statement


### PR DESCRIPTION
## Summary

S23 of erdos-1151-oq-04: adds the **Step 7a m-choice + arithmetic packager** as a new private helper `chebyshev_quarter_floor_hm_le_and_cap_max` (~110 lines).

For `θ ∈ (0, π/2]`, `n ≥ 4`, the standard nearest-node closeness `|θ − φ_{k₀}| ≤ π/(2n)`, and any `m : ℕ` with `(m : ℝ) ≤ n·θ/(4π)`, the lemma simultaneously discharges:

- `hm_le`: `k₀.val + m + 1 ≤ n` (input to `trig_sum_subsum_log_lb`)
- `hcap_max`: `(2(k₀+m)+1)·π/(2n) ≤ π − θ/2` (input to S22 #17324's `chebyshev_h_interior_of_close_and_max_index_cap`)

Caller-side, `m := ⌊n·θ/(4π)⌋` satisfies `(m : ℝ) ≤ n·θ/(4π)` via `Nat.floor_le`. Combined with the S22 verifier, this closes every arithmetic precondition of `trig_sum_subsum_log_lb` for the asymptotic-`n` branch of `trig_sum_harmonic_lb`.

## Proof skeleton (with `θ ≤ π/2`, `n ≥ 4`)

1. `m·π/n ≤ θ/4 ≤ π/8`: multiply `(m : ℝ) ≤ n·θ/(4π)` by `π/n > 0`.
2. `φ_{k₀} ≤ θ + π/(2n)` from `abs_le.mp hk₀_close`.
3. `φ_{k₀+m} = φ_{k₀} + m·π/n ≤ π/2 + π/8 + π/8 = 3π/4 ≤ π − θ/2`.
4. `2 k₀ ≤ n` (ℕ) from `(2k₀+1)π ≤ 2nθ + π ≤ nπ + π`, divide by π via `nlinarith`.
5. `8 m ≤ n` (ℕ) from `m·π/n ≤ π/8`, multiply by `8n`.
6. `omega` closes `k₀.val + m + 1 ≤ n` (since `8(k₀+m+1) ≤ 5n + 8 ≤ 8n` for `n ≥ 3`).

## Why packaged this way

The next session (Step 7a glue) will pick concrete `m := ⌊n·θ/(4π)⌋` and need both `hm_le` and `hcap_max` in the *same* shape consumed by S22's verifier. Bundling both into one lemma keeps the asymptotic-branch caller free of arithmetic boilerplate. Generality `(m : ℝ) ≤ n·θ/(4π)` (rather than fixing `Nat.floor`) leaves room for tighter choices.

## Stats

- `proofs/Proofs/Erdos1151OQ04.lean`: 2180 lines (was 2067), 2 sorries unchanged
- Companion `Erdos1151OQ04Aristotle.lean`: untouched (0 sorries)
- Build: pending (per file's established build-pending PR pattern)

## Test plan

- [ ] Docker build of `Proofs.Erdos1151OQ04` (auditor / mechanic / next-session)
- [ ] Verify lemma plugs into the planned Step 7a chain (`exists_nearest_chebyshev_angle` → `chebyshev_quarter_floor_hm_le_and_cap_max` → `chebyshev_h_interior_of_close_and_max_index_cap` → `trig_sum_subsum_log_lb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)