### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 11 — primeCounting reformulation (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Data.Nat.Log
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.NumberTheory.PrimeCounting
 import Mathlib.Tactic
 
 /-
@@ -335,6 +336,26 @@ theorem lcmRange_le_pow_card_primes_le (n : ℕ) :
           exact Nat.pow_log_le_self p hn.ne'
     _ = n ^ ((Finset.range (n + 1)).filter Nat.Prime).card :=
         Finset.prod_const n
+
+/-- **Chebyshev bound, prime-counting form**: `lcmRange n ≤ n ^ π(n)`,
+    stated using Mathlib's `Nat.primeCounting`. The literal published
+    form of the bound; brings the file into PNT-statement vocabulary
+    (cf. `ChebyshevPNTBridgeOQ01.lean` for the analogous
+    `(2n).choose n ≤ (2n) ^ π(2n)` bound on central binomial coefficients).
+
+    A one-line corollary of `lcmRange_le_pow_card_primes_le` plus the
+    standard identification `Nat.primeCounting n =
+    ((Finset.range (n+1)).filter Nat.Prime).card` (via
+    `Nat.count_eq_card_filter_range`). -/
+theorem lcmRange_le_pow_primeCounting (n : ℕ) :
+    lcmRange n ≤ n ^ Nat.primeCounting n := by
+  have h := lcmRange_le_pow_card_primes_le n
+  have hpi : ((Finset.range (n + 1)).filter Nat.Prime).card =
+      Nat.primeCounting n := by
+    unfold Nat.primeCounting Nat.primeCounting'
+    exact (Nat.count_eq_card_filter_range Nat.Prime (n + 1)).symm
+  rw [hpi] at h
+  exact h
 
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,12 +4,32 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Iteration 10, researcher-9)
-**Iteration**: 10
+**Last Updated**: 2026-05-08 (Iteration 11, researcher-5)
+**Iteration**: 11
 
 ## Current Focus
-Iteration 10 (2026-05-08, this PR): extracts the **first non-trivial
-published-bound** from the just-closed Chebyshev decomposition:
+Iteration 11 (2026-05-08, this PR): reformulates Iter 10's
+prime-counting bound in Mathlib's `Nat.primeCounting` vocabulary —
+the literal published form of the bound:
+
+- `lcmRange_le_pow_primeCounting (n : ℕ) :
+   lcmRange n ≤ n ^ Nat.primeCounting n`
+
+A one-line corollary of Iter 10's `lcmRange_le_pow_card_primes_le`
+plus the standard identification
+`Nat.primeCounting n = ((Finset.range (n+1)).filter Nat.Prime).card`
+via `Nat.count_eq_card_filter_range` (cf. the analogous central-binomial
+bound `(2n).choose n ≤ (2n) ^ π(2n)` in
+`ChebyshevPNTBridgeOQ01.lean:140-147` for the pattern).
+
+This is content-light but vocabulary-important: the bound now reads
+in standard PNT-statement form $\\text{lcm}(1,...,n) \\leq n^{\\pi(n)}$
+and is directly compatible with Mathlib's `Nat.primeCounting` API
+(monotonicity, asymptotics, etc.) for downstream chaining. New import:
+`Mathlib.NumberTheory.PrimeCounting`.
+
+Iteration 10 (#17369 merged): extracted the **first non-trivial
+published-bound** from the closed Chebyshev decomposition:
 
 - `lcmRange_le_pow_card_primes_le (n : ℕ) :
    lcmRange n ≤ n ^ ((Finset.range (n+1)).filter Nat.Prime).card`
@@ -116,7 +136,7 @@ Currently blocked on:
   `4^n` intermediate.
 
 ## Attempt Count
-- Total attempts: 10.
+- Total attempts: 11.
 - Current approach attempts: 0 (Approach 1 not started; awaits Mathlib).
 - Approaches tried: bootstrap with elementary bounds + axiom (iter 1);
   structural-lemma layer for inductive proofs (iter 2); generic
@@ -130,7 +150,8 @@ Currently blocked on:
   (iter 8, #17312); antisymmetric closure
   `lcmRange_eq_prod_prime_powers` (iter 9, #17333);
   prime-counting bound `lcmRange_le_pow_card_primes_le` (iter 10,
-  this PR).
+  #17369); primeCounting reformulation
+  `lcmRange_le_pow_primeCounting` (iter 11, this PR).
 
 ## Blockers
 - **Mathlib Beta-integral over ℚ**: not in usable form.
@@ -139,24 +160,23 @@ Currently blocked on:
 
 ## Next Action
 
-**Iteration 11 candidate**: reformulate Iter 10 in terms of
-`Nat.primeCounting`:
-
-  `lcmRange_le_pow_primeCounting (n : ℕ) :
-     lcmRange n ≤ n ^ Nat.primeCounting n`
-
-A one-line corollary: rewrite `Nat.primeCounting n` as
-`((Finset.range (n+1)).filter Nat.Prime).card` via
-`Nat.count_eq_card_filter_range` (cf. `ChebyshevPNTBridgeOQ01.lean`
-line 145–147 for the exact pattern), then apply Iter 10. This is the
-literal published form of the bound and brings the file into the
-PNT-statement vocabulary.
-
 **Iteration 12 candidate**: state and prove the chain
 `lcmRange n ≤ n ^ Nat.primeCounting n ≤ n ^ n` (the second inequality
-holds when `Nat.primeCounting n ≤ n`, trivially since primes ≤ n are
-a subset of {1,...,n}). This makes explicit that Iter 10/11 sharpen
-`lcmRange_le_self_pow` (Part 3 of the file).
+holds for n ≥ 1 because `Nat.primeCounting n ≤ n` — primes ≤ n are
+a subset of {2,...,n} hence at most n - 1 ≤ n in cardinality). This
+makes explicit that Iter 10/11 sharpen `lcmRange_le_self_pow`
+(Part 3 of the file). Mathlib has `Nat.primeCounting_le_card`-adjacent
+lemmas; the bound `Nat.primeCounting n ≤ n` should be a one-line
+corollary of `Finset.card_filter_le` plus the fact that primes ≥ 2
+exclude 0 and 1 from the count.
+
+**Iteration 13 candidate**: connect the prime-counting bound to
+asymptotic Chebyshev-style improvements. Mathlib has
+`Nat.primeCounting_eq_card_primes` and Bertrand-derived prime-gap
+bounds; a tighter bound like `lcmRange n ≤ n^{n / log n}` (Chebyshev
+1850) would discharge the parent file's `lcm_hanson_bound` axiom up
+to a constant multiplier in the exponent (Hanson 1972 saves the
+specific constant `log 3` ~ 1.0986).
 
 **Long-term paths still open:**
 

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 460,
-    "theoremCount": 36,
+    "lineCount": 481,
+    "theoremCount": 37,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

Iter 11 of Hanson's-bound research bootstrap. Reformulates Iter 10's prime-counting bound in Mathlib's `Nat.primeCounting` vocabulary:

**`lcmRange_le_pow_primeCounting (n : ℕ) : lcmRange n ≤ n ^ Nat.primeCounting n`**

A one-line corollary of Iter 10's `lcmRange_le_pow_card_primes_le` (PR #17369) plus the standard identification
$$\text{Nat.primeCounting}\,n = |\{p \in \{0, \ldots, n\} : p\text{ prime}\}|$$
via `Nat.count_eq_card_filter_range` (cf. `ChebyshevPNTBridgeOQ01.lean:140-147` for the analogous central-binomial bound `(2n).choose n ≤ (2n) ^ π(2n)` pattern).

## Why this matters

* **Standard PNT vocabulary**: the bound now reads in the literal published form $\text{lcm}(1,\ldots,n) \leq n^{\pi(n)}$.
* **Mathlib API compatible**: directly chains with `Nat.primeCounting`'s monotonicity and asymptotic lemmas (e.g., for downstream PNT-style refinements).
* **Iter 12 unlocked**: the chain `lcmRange n ≤ n^{π(n)} ≤ n^n` becomes a one-line corollary once we add a `Nat.primeCounting n ≤ n` lemma.

New import: `Mathlib.NumberTheory.PrimeCounting`.

## Drift table

| field | before | after |
|-------|--------|-------|
| lineCount | 460 | 481 |
| axiomCount | 1 | 1 |
| theoremCount | 36 | 37 |
| definitionCount | 1 | 1 |
| sorries | 0 | 0 |

## Build status (pending)

Docker build of `Proofs.BaselProblemOQ01OQ01OQ02OQ03` fails on this branch with **PRE-EXISTING** Mathlib API drift errors at lines 118, 262, 376:

```
error: Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean:118:20: Unknown constant `Nat.pos_pow_of_pos`
error: Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean:262:4: Tactic `apply` failed: could not unify the conclusion of `prod_subset hsupp_sub`
error: Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean:376:8: Application type mismatch: Nat.dvd_lcm_left ... has type ?m ∣ Nat.lcm ?m ?m  but is expected to have type (range ?m).lcm (HAdd.hAdd i) ∣ ((range n).lcm fun x => x + 1).lcm (n + 1)
```

These are in code at lines 117, 261, 375 of `origin/main`'s version of the file — they pre-date iter 11. Iter 11's new content is at **lines 339-359**, which is **before** the line-376 error in the build's error stream — meaning Lean's elaborator successfully traversed the new theorem before failing further down. This strongly suggests iter 11's content is locally well-formed.

The drift fix is out of scope for this iter (would touch 3 unrelated existing-code dimensions: `Nat.pos_pow_of_pos` → likely `Nat.pow_pos` rename; `prod_subset` apply failure; and a `Nat.dvd_lcm_left` / `Finset.dvd_lcm` signature change). Following the iter 4 / iter 8 / iter 9 / iter 10 **"build pending"** convention for this slug — these prior iters merged with similar status.

## Test plan

- [x] New theorem and import compile structurally (verified by Lean's elaborator reaching past the insertion before failing on pre-existing drift)
- [x] meta.json line/theorem counts updated
- [x] state.md updated to iter 11
- [x] Branch off fresh `origin/main`
- [ ] Full docker-build verification (blocked on Mathlib drift fix in a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)