### PR TITLE
fix(meta): minkowski-theorem-oq-04 axiomCount 1 → 0

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -21,7 +21,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 482,
     "theoremCount": 7,
     "definitionCount": 0,
@@ -166,7 +166,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "BlichfeldtTheorem",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "lineCount": 482,
     "theoremCount": 7,


### PR DESCRIPTION
## Fix

Sync `meta.axiomCount` and `leanFile.axiomCount` from `1 → 0` for `minkowski-theorem-oq-04`.

After PR #17329 (S14 ENNReal-scope fix, 2026-05-08), `blichfeldt_general` was promoted from an `axiom` declaration to a fully-proved `theorem` in `proofs/Proofs/MinkowskiTheoremOQ04.lean`. The file now contains 0 `axiom` declarations and 0 `opaque` declarations.

## Evidence

```bash
$ grep -cE '^(noncomputable\s+|private\s+|protected\s+)?axiom\s+' proofs/Proofs/MinkowskiTheoremOQ04.lean
0
$ grep -cE '^(noncomputable\s+|private\s+|protected\s+)?opaque\s+' proofs/Proofs/MinkowskiTheoremOQ04.lean
0
$ grep -n '^theorem blichfeldt_general' proofs/Proofs/MinkowskiTheoremOQ04.lean
245:theorem blichfeldt_general {n : ℕ} [NeZero n]
```

The imported `Proofs.MinkowskiFundamentalTheorem` chain contains 2 structures (`Lattice`, `ConvexBody`) but their fields are data-shape constraints (e.g. `basis_invertible : basis.det ≠ 0`, `convex : Convex ℝ carrier`) rather than mathematical-assumption packs.

## Diff

| Field | Before | After |
|---|---|---|
| `meta.axiomCount` | 1 | 0 |
| `leanFile.axiomCount` | 1 | 0 |

## Out of scope

The `meta.assumptions` narrative still asserts "single remaining axiom is `blichfeldt_general`" — this prose drift requires a separate fix (precedent: PR #16401 for erdos-183). Kept out of this PR for scope discipline.

`status: axiomatized` / `badge: axiom` preserved per the policy that an entry's open-conjecture status overrides automatic count-driven promotion.

---
🤖 Automated fix by lean-mechanic agent.