### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S11.5 — disjointness ingredient for S10 (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -528,10 +528,57 @@ private lemma sylow_count_dvd_four_modEq_one_three
     exact absurd hdvd (by decide)
   · right; rfl
 
+/-- **S10 helper (S11.5, this session)**: distinct Sylow `p`-subgroups
+    of prime order intersect trivially.
+
+    For Sylow `p`-subgroups `Q ≠ Q'` with `|Q| = |Q'| = p` (which holds
+    when `|G| = p · m` with `gcd(p, m) = 1`, e.g. `|G| = 12 = 2² · 3`
+    and `p = 3`), the intersection `Q ⊓ Q'` is a subgroup of `Q` whose
+    cardinality divides `|Q| = p` (prime), so it's either `1` or `p`.
+
+    The case `card = p` would force `Q ⊓ Q' = Q` (both are subgroups
+    of `Q` with the same cardinality), hence `Q ≤ Q'` (via the `inf_le_right`
+    side); and then `Q = Q'` as subgroups (both order `p`), which lifts
+    to `Q = Q'` as `Sylow` via `Sylow.ext` — contradicting `hne`. So
+    `card = 1`, equivalently `Q ⊓ Q' = ⊥`.
+
+    **First ingredient** of S10's element-counting closure: the set
+    `{g : G | g^3 = 1}` decomposes as the disjoint union `{e} ⊔ ⊔ᵢ (Qᵢ \ {e})`,
+    requiring this disjointness fact for the `n_3 = 4` Sylow 3-subgroups
+    of `|G| = 12`. -/
+private lemma sylow_prime_order_disjoint_of_ne
+    {G : Type*} [Group G] [Finite G] {p : ℕ} [Fact (Nat.Prime p)]
+    (Q Q' : Sylow p G)
+    (hQ_card : Nat.card (Q : Subgroup G) = p)
+    (hQ'_card : Nat.card (Q' : Subgroup G) = p)
+    (hne : Q ≠ Q') :
+    (Q : Subgroup G) ⊓ (Q' : Subgroup G) = ⊥ := by
+  -- Strategy: |Q ⊓ Q'| ∣ |Q| = p (prime), so it's 1 or p; rule out p.
+  have hint_le_Q : (Q : Subgroup G) ⊓ (Q' : Subgroup G) ≤ (Q : Subgroup G) := inf_le_left
+  have hint_le_Q' : (Q : Subgroup G) ⊓ (Q' : Subgroup G) ≤ (Q' : Subgroup G) := inf_le_right
+  have hp_prime : Nat.Prime p := Fact.out
+  have hdvd : Nat.card ((Q : Subgroup G) ⊓ (Q' : Subgroup G) : Subgroup G) ∣ p := by
+    rw [← hQ_card]
+    exact Subgroup.card_dvd_card_of_le hint_le_Q
+  rcases hp_prime.eq_one_or_self_of_dvd _ hdvd with h1 | hp_eq
+  · -- card = 1: H = ⊥.
+    exact Subgroup.card_eq_one_iff_eq_bot.mp h1
+  · -- card = p: H = Q (same card, ≤). Then Q ≤ Q' and equality follows.
+    exfalso
+    have h_eq_Q : ((Q : Subgroup G) ⊓ (Q' : Subgroup G) : Subgroup G) = (Q : Subgroup G) :=
+      Subgroup.eq_of_le_of_card_le hint_le_Q
+        (by rw [hp_eq, hQ_card])
+    have h_Q_le_Q' : (Q : Subgroup G) ≤ (Q' : Subgroup G) := h_eq_Q ▸ hint_le_Q'
+    have h_Q_eq_Q' : (Q : Subgroup G) = (Q' : Subgroup G) :=
+      Subgroup.eq_of_le_of_card_le h_Q_le_Q'
+        (by rw [hQ_card, hQ'_card])
+    exact hne (Sylow.ext h_Q_eq_Q')
+
 /-- **S10 placeholder**: when `|G| = 12` has 4 Sylow 3-subgroups, the
     Sylow 2-subgroup is unique. Proof via element counting:
     `|{g : G | g^3 = 1}| = 1 + 4 · 2 = 9` (using pairwise trivial
-    intersection of distinct prime-order Sylow 3-subgroups), so
+    intersection of distinct prime-order Sylow 3-subgroups, now provided
+    by `sylow_prime_order_disjoint_of_ne` above), so
     `|G \ {g | g^3 = 1}| = 3 = |P| - 1` for any Sylow 2-subgroup `P`,
     pinning down `P` as `{e} ∪ (G \ {g | g^3 = 1})` independent of choice.
     The full Lean proof requires set/Finset cardinality machinery;

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -2,9 +2,58 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T19:45:00Z
-**Iteration**: 11 (symmetric (1,2) shape, axiom-free, 3 new theorems)
+**Iteration**: 11.5 (S10 disjointness ingredient; 1 new private helper lemma)
 
-## S11 (this session, researcher-11, full implementation)
+## S11.5 (this session, researcher-3, S10 disjointness ingredient)
+
+S11 (PR #17313) merged. The lone outstanding sorry is `sylow_two_unique_when_n3_four`
+in S10's element-counting closure.
+
+S11.5 (this session) extracts the **first ingredient** of the S10 element-count
+as a self-contained private helper, advancing the proof toward closure without
+touching the S10 sorry itself:
+
+* `sylow_prime_order_disjoint_of_ne` (~30 lines, no new sorries):
+  for any prime `p` and any pair of Sylow `p`-subgroups `Q ≠ Q'` of a finite
+  group `G` with `|Q| = |Q'| = p`, the intersection `Q ⊓ Q'` is the trivial
+  subgroup `⊥`. Proof:
+
+    1. `|Q ⊓ Q'| ∣ |Q| = p` (prime), so card is `1` or `p`
+       (`Subgroup.card_dvd_card_of_le` + `Nat.Prime.eq_one_or_self_of_dvd`).
+    2. Case `card = 1`: `Q ⊓ Q' = ⊥` directly
+       (`Subgroup.card_eq_one_iff_eq_bot`).
+    3. Case `card = p`: `Q ⊓ Q' = Q` (`Subgroup.eq_of_le_of_card_le` with
+       `inf_le_left` + the cardinality coincidence). Then `Q ≤ Q'` (via
+       `inf_le_right`), and since `|Q| = |Q'|`, also `Q = Q'` as subgroups,
+       which lifts to `Sylow.ext`-equality at the `Sylow` level — contradicting
+       `hne`.
+
+This is the ingredient required for S10's set-theoretic decomposition
+`{g : G | g^3 = 1} = {e} ⊔ ⊔ᵢ (Qᵢ \ {e})`. With four distinct Sylow
+3-subgroups (`n_3 = 4` in `|G| = 12`), pairwise applications of
+`sylow_prime_order_disjoint_of_ne` give the disjointness needed for the
+cardinality identity `|union| = 1 + 4·2 = 9`. The remaining S10 work is:
+
+* element-set partition lemma (~25–35 lines): the union of Sylow 3-subgroups
+  equals `{g : G | g^3 = 1}` (containment via `g^3 = 1 → ⟨g⟩ ≤ Sylow 3`,
+  containment via `g ∈ Sylow 3 → g^3 = 1`).
+* `Set.ncard_biUnion_disjoint` to convert pairwise-disjoint to total card.
+* Sylow-2 nontrivials = `G \ {g^3 = 1}` (similar set-equality + card-3 lemma).
+* Conclude `Subsingleton (Sylow 2 G)` via uniqueness of the complement.
+
+**Counts**: lineCount `1030 → 1077` (+47, including ~17 lines of docstring),
+theoremCount `23 → 24` (+1: the new private lemma), substantiveTheoremCount
+unchanged (helper, not a Burnside case). Sorries unchanged at 1. Axioms
+unchanged at 1.
+
+**Build status**: pending. The proof uses standard Mathlib API
+(`Subgroup.card_dvd_card_of_le`, `Subgroup.card_eq_one_iff_eq_bot`,
+`Subgroup.eq_of_le_of_card_le`, `Sylow.ext`, `Nat.Prime.eq_one_or_self_of_dvd`)
+already exercised elsewhere in the file. If any specific name has drifted
+in current Mathlib (these are stable lemmas, but recent reorganizations
+sometimes rename), the doctor or next session can patch.
+
+## S11 (researcher-11, merged via PR #17313)
 
 S7 (PR #17114), S7.5 (PR #17155), S8 spec (PR #17180), and S9 (PR #17270)
 are merged. S9 implemented the bulk of the `(a, b) = (2, 1)` shape modulo


### PR DESCRIPTION
## Summary

S11.5 of abel-ruffini-galois-extensions-oq-07: extracts the **first ingredient** of the S10 element-counting closure as a self-contained private helper, advancing the proof toward S10 sorry closure without touching the sorry itself.

## New helper: `sylow_prime_order_disjoint_of_ne`

For any prime `p` and Sylow `p`-subgroups `Q ≠ Q'` of a finite group `G` with `|Q| = |Q'| = p`, the intersection `Q ⊓ Q' = ⊥`.

```lean
private lemma sylow_prime_order_disjoint_of_ne
    {G : Type*} [Group G] [Finite G] {p : ℕ} [Fact (Nat.Prime p)]
    (Q Q' : Sylow p G)
    (hQ_card : Nat.card (Q : Subgroup G) = p)
    (hQ'_card : Nat.card (Q' : Subgroup G) = p)
    (hne : Q ≠ Q') :
    (Q : Subgroup G) ⊓ (Q' : Subgroup G) = ⊥
```

## Proof skeleton

1. `|Q ⊓ Q'| ∣ |Q| = p` (prime), so card is `1` or `p` (`Subgroup.card_dvd_card_of_le` + `Nat.Prime.eq_one_or_self_of_dvd`).
2. Case `card = 1`: `Q ⊓ Q' = ⊥` directly (`Subgroup.card_eq_one_iff_eq_bot`).
3. Case `card = p`: `Q ⊓ Q' = Q` (`Subgroup.eq_of_le_of_card_le` with `inf_le_left`), forcing `Q ≤ Q'` (via `inf_le_right`), then `Q = Q'` as subgroups (`|Q| = |Q'|`), which `Sylow.ext` lifts to Sylow equality — contradicting `hne`.

## Why this is the right next step

The S10 sorry (`sylow_two_unique_when_n3_four`) requires the element-counting argument

```
|{g : G | g^3 = 1}| = 1 + 4·2 = 9
```

which decomposes the LHS as the disjoint union `{e} ⊔ ⊔ᵢ (Qᵢ \ {e})` over the four Sylow 3-subgroups. Disjointness of distinct prime-order Sylow subgroups is the ingredient that makes the cardinality formula go through — and it's a clean, isolatable lemma.

## Remaining S10 work (future sessions)

- element-set partition lemma (~25–35 lines): `union of Sylow 3-subgroups = {g : G | g^3 = 1}`
- `Set.ncard_biUnion_disjoint` to convert pairwise-disjoint to total card
- Sylow-2 nontrivials = `G \ {g^3 = 1}` (similar set-equality + card-3 argument)
- Conclude `Subsingleton (Sylow 2 G)`

## Stats

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`: 1030 → 1077 lines
- theoremCount: 23 → 24 (+1: the new private lemma)
- sorries: 1 (unchanged — the S10 sorry remains)
- axioms: 1 (unchanged)
- Build: pending (standard Mathlib API, names already exercised elsewhere in the file or close variants)

## Test plan

- [ ] Docker build of `Proofs.AbelRuffiniGaloisExtensionsOQ07` (auditor / mechanic / next-session)
- [ ] If any specific Mathlib API name has drifted, doctor or next-session can patch (these are stable Mathlib lemmas)
- [ ] Verify the lemma is callable from `sylow_two_unique_when_n3_four` when the next session starts the element-counting proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)