### PR TITLE
Fix: binomial-theorem-oq-02-oq-01-oq-01-oq-01 definitionCount 1→2

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -32,7 +32,7 @@
       "sum_composition_eq_piAntidiag_sum: sum transfer via the equivalence"
     ],
     "theoremCount": 5,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "The study of compositions — ways of writing a positive integer $n$ as an ordered sum of positive integers — dates to the early history of combinatorics. Euler and later Cayley noted that the number of compositions of $n$ into $k$ positive parts equals $\\binom{n-1}{k-1}$ (the 'stars and bars' or 'ballot' formula), and the total number of compositions is $2^{n-1}$ (each of the $n-1$ gaps between stars can hold a bar or not). This contrasts with the number of unordered integer partitions of $n$, which has no clean closed form (Hardy-Ramanujan asymptotic $\\sim \\frac{1}{4n\\sqrt{3}} e^{\\pi\\sqrt{2n/3}}$).\n\nThe multinomial distribution, introduced by the Bernoullis in the early 18th century and formalized by Laplace, generalizes the binomial: when a die with $k$ faces is rolled $n$ times, the probability that face $i$ appears $c_i$ times (with $\\sum c_i = n$) is $\\binom{n}{c_1, c_2, \\ldots, c_k} \\prod_i p_i^{c_i}$. The support of this distribution is precisely the set of compositions of $n$ into $k$ non-negative parts — the 'weak compositions' counted by $\\binom{n+k-1}{k-1}$.\n\nIn formal mathematics libraries, establishing that a probability mass function (PMF) is well-defined requires enumerating its support — which requires a `Fintype` instance for the support type. Mathlib's `PMF` type requires a computable enumeration of all outcome types to compute the normalization sum $\\sum_{x} P(x) = 1$. The `piAntidiag` construction (`Finset.piAntidiag`) was introduced precisely for this purpose: it provides the standard Lean 4 encoding of weak compositions as a computable finset, enabling the multinomial PMF to be constructed without ad-hoc inductive constructions.\n\nThe challenge of Fintype instances for dependent product types (like Composition) is a common source of sorry-gaps in Lean 4 formalization. The general pattern — bijection with an already-Fintype type, then `Fintype.ofEquiv` — appears throughout Mathlib for enumerating combinatorial objects (partitions, tableaux, matchings). This entry demonstrates the pattern at its simplest: the bijection proof is 10 lines, the Fintype instance 2 lines, and the extensionality lemma 5 lines.",
@@ -153,7 +153,7 @@
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean",
     "lineCount": 185,
     "theoremCount": 5,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "axiomCount": 0,
     "sorries": 0
   }


### PR DESCRIPTION
## Fix

Update `meta.definitionCount` and `leanFile.definitionCount` from 1 to 2 in `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json`.

## Evidence

**Before**: Both `meta.definitionCount` and `leanFile.definitionCount` claimed 1.

**After**: Both correctly report 2.

`proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean` contains 2 definitions per the canonical convention (`def+abbrev+opaque+structure+inductive+class`, excluding `instance`):

- Line 41: `structure Composition (α : Type*) [DecidableEq α] (s : Finset α) (n : ℕ) where`
- Line 68: `def compositionEquiv (α : Type*) [DecidableEq α] (s : Finset α) (n : ℕ) :`

No status/badge change needed (status `verified`, sorries=0, axioms=0, all other counts match).

Closes #17404

---
Automated fix by lean-mechanic agent.