### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-07 line/theorem count drift

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1030,
+    "lineCount": 1077,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -132,7 +132,7 @@
       "burnside_p_q_squared_twelve_mirror (Iteration 11): axiom-free Burnside for the exceptional `|G| = 12 = 3 · 2²` case of the (1, 2) shape (modulo the same isolated S10 sorry as S9's `burnside_p_squared_q_twelve`). Thin wrapper around `burnside_p_squared_q_twelve` — the (1, 2) and (2, 1) views of |G| = 12 share group-theoretic content, so the same Sylow analysis applies. THIRD sub-case completing the (1, 2) shape coverage."
     ],
     "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7/9/11): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited. Iteration 7 (S7), 7.5, and 9 progressively cover the three sub-cases of the `(a, b) = (2, 1)` shape: S7 proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`; S7.5 covers `p < q` with `(p, q) ≠ (2, 3)`; S9 covers the exceptional `(p, q) = (2, 3), |G| = 12` (modulo a single isolated sorry deferred to S10 — the `sylow_two_unique_when_n3_four` element-counting lemma). Iteration 11 (S11) mirrors this trio for the symmetric `(a, b) = (1, 2)` shape: `burnside_p_q_squared_p_lt_q` (mirror of S7), `burnside_p_q_squared_q_lt_p` excluding `(p, q) = (3, 2)` (mirror of S7.5), and `burnside_p_q_squared_twelve_mirror` reusing S9 for `|G| = 12 = 3 · 2²`. After S10 closes the deferred sorry and S12 updates the `burnside_pq` dispatch, `burnside_pq_nontrivial` will be required only for shapes with `2 ≤ a ∧ 2 ≤ b` (orders divisible by `p²` AND `q²` for distinct primes); a full proof of that residual axiom would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route — character theory + algebraic integers à la Burnside 1904, or transfer + focal subgroup à la Goldschmidt-Matsuyama 1970s).",
-    "theoremCount": 23,
+    "theoremCount": 24,
     "definitionCount": 0
   },
   "overview": {
@@ -270,9 +270,9 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1030,
+    "lineCount": 1077,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 24,
     "substantiveTheoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",


### PR DESCRIPTION
## Fix

Sync `lineCount` and `theoremCount` for `abel-ruffini-galois-extensions-oq-07` after research PRs #17313 (S11) and #17405 (S11.5) extended the Lean source.

## Evidence

`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`:
- File line count: **1077** (was claimed: 1030)
- Stripped-comment theorem/lemma count: **24** (was claimed: 23)

Both `meta.lineCount`/`meta.theoremCount` and the corresponding `leanFile.lineCount`/`leanFile.theoremCount` were stale; this PR brings all four into agreement with the source. `definitionCount` (0), `axiomCount` (1), and `sorries` (1) are unchanged and verified to still match.

**Before**:
```
lineCount: 1030
theoremCount: 23
```

**After**:
```
lineCount: 1077
theoremCount: 24
```

---
Automated fix by lean-mechanic agent.