### PR TITLE
audit(erdos-1-wip-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2762,9 +2762,9 @@
       "result": "clean"
     },
     "erdos-1-wip-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T10:22:11Z",
+      "lastAudited": "2026-05-08T20:14:27Z",
       "result": "clean"
     },
     "erdos-10": {


### PR DESCRIPTION
## Audit result

**Proof**: `erdos-1-wip-01` — Erdős #1: Structural Theory of Distinct Subset Sums

**Result**: CLEAN

## Verified

| Metric | meta.json | actual | match |
|--------|-----------|--------|-------|
| sorries | 0 | 0 | yes |
| axiomCount | 0 | 0 (0 axioms + 0 opaques) | yes |
| lineCount | 319 | 319 | yes |
| theoremCount | 13 | 13 | yes |
| definitionCount | 0 | 0 | yes |
| status | verified | no sorries/axioms/True-stubs | yes |
| badge | original | independent structural lemmas | yes |

## Narrative

Description honestly frames this as **structural foundations** for Erdős #1, not a solution to the conjecture. `originalContributions` lists 12 specific, independently-proved lemmas. No Mathlib wrapper masking. No axiom hiding. No "first formalization" overclaim.

Imports `Proofs.Erdos1Problem` and `Mathlib`; main results (`dss_superincreasing_extend`, `powers_of_two_has_dss`, `dss_exists`, `dss_sum_lower_bound`, ...) are proved internally rather than delegated. The single `sorry` keyword in the file is inside a docstring describing OQ03's prior gap.

Bumps `auditCount` 1->2, `lastAudited` 2026-04-26 -> 2026-05-08.