### PR TITLE
fix(meta): batch sync definitionCount drift (4 entries, batch 2)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -69,7 +69,7 @@
       "Risch algorithm basics",
       "Lean 4 and Mathlib"
     ],
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "crossReferences": [
     {
@@ -203,7 +203,7 @@
     "lineCount": 540,
     "axiomCount": 5,
     "theoremCount": 24,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/AbelRuffiniOQ09.lean",
     "sorries": 0
   },

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "lineCount": 206,
     "theoremCount": 6,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "assumptions": "Two axioms: snf_pid_exists (every matrix over a PID has a Smith Normal Form) and snf_pid_solvability (solvability criterion via invariant factors). These generalize the same axioms from BezoutIdentityOQ04OQ01 to arbitrary PIDs.",
     "mathlibDependencies": [
       {
@@ -165,7 +165,7 @@
     "lineCount": 206,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "sorries": 0
   }
 }

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "2 axiom: smooth3D_buffon_eq (the expected crossing count formula for smooth 3D curves). No sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Buffon's 1777 needle problem and Barbier's 1860 noodle extension show that the expected crossing count depends only on arc length, not shape. The 3D version replaces parallel lines with parallel planes. BuffonsNeedleOQ02.lean proved the 3D formula E = L/(2d) for polygonal paths using the sphere average E_{S²}[|cos φ|] = 1/2. This file extends the result to smooth C¹ curves via the approximation argument: inscribed polygonal paths converge in arc length, so expected crossings converge by continuity.",
@@ -232,7 +232,7 @@
     "lineCount": 376,
     "axiomCount": 2,
     "theoremCount": 15,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axiom declarations and 0 sorries, but 3 of 9 theorems (easton_consistency, easton_full_characterization, easton_iff_characterization) prove the trivial conclusion `True` instead of their intended forcing-direction content. These True-stubs are semantically equivalent to assumed axioms: the existence of an Easton-realizing forcing extension is asserted at the meta level but not formalized, since class forcing is not available in Mathlib. The 6 fully proved theorems (E1–E3 necessary conditions, the SatisfiesEastonConditions certificate, and the cofinality exclusion 2^{ℵ_α} ≠ ℵ_{α+ω}) are machine-checked.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Easton's theorem (1970) is one of the deepest results in set-theoretic cardinal arithmetic. It completely characterizes which functions F : Reg → Card can be the continuum function κ ↦ 2^κ restricted to regular cardinals. The necessary conditions (E1)–(E3) were known before Easton; the revolutionary content is the consistency of ANY function satisfying them, proved via class product forcing (Easton forcing). The problem generalizes König's theorem (1905) and Cantor's theorem to give the first complete picture of the continuum function's behavior.",
@@ -104,7 +104,7 @@
     "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Batch-synchronize `meta.definitionCount` and `leanFile.definitionCount`
for 4 gallery entries where the recorded count diverged from the actual
declarations in the Lean source file.

Counting convention applied (per memory note `feedback_mechanic_def_counting`):
`def + abbrev + opaque + structure + inductive + class`, including
modifiers (`noncomputable`, `private`, `partial`, `protected`,
`scoped`, `unsafe`); `instance` excluded.

## Evidence

| slug | claimed | actual | Lean file |
| --- | --- | --- | --- |
| `abel-ruffini-oq-09` | 5 | 6 | `AbelRuffiniOQ09.lean` (1 class + 1 def + 3 opaque + 1 private def) |
| `bezout-identity-oq-04-oq-01-oq-01` | 3 | 4 | `BezoutIdentityOQ04OQ01OQ01.lean` (2 def + 1 structure + 1 def) |
| `buffons-needle-oq-02-oq-02` | 3 | 4 | `BuffonsNeedleOQ02OQ02.lean` (2 def + 1 structure + 1 def) |
| `cantor-diagonalization-oq-01-oq-01-oq-02-oq-03` | 0 | 1 | `CantorDiagonalizationOQ01OQ01OQ02OQ03.lean` (1 structure) |

Both `meta.definitionCount` and `leanFile.definitionCount` are updated in
each entry; no status/badge change is needed (all 4 remain
`axiomatized/axiom` and the Lean source is untouched).

Complements the in-flight a/b/c-batch in #17407.

---
Automated fix by lean-mechanic agent.