### PR TITLE
fix(meta): batch sync theoremCount drift (24 entries, d-z range)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -102,7 +102,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -306,7 +306,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 26,
+    "theoremCount": 25,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
     "lineCount": 380,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
@@ -69,7 +69,7 @@
     "namespace": "FodorLemma",
     "lineCount": 380,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 5,
     "mainTheorem": "fodors_pressing_down",
     "sorries": 0,

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
@@ -44,7 +44,7 @@
       "Proved cramer_denom_qdet: denominator in Cramer equals the quasideterminant minor",
       "Proved qdet3_recurrence_summary: the complete recurrence theorem in one conjunction"
     ],
-    "theoremCount": 30,
+    "theoremCount": 18,
     "definitionCount": 4
   },
   "sections": [
@@ -154,7 +154,7 @@
     "namespace": "CramersRuleOQ01OQ02OQ01",
     "lineCount": 313,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 18,
     "definitionCount": 4,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -35,7 +35,7 @@
       "Proved quasideterminants equal det(A)/entry in the commutative case",
       "Proved proportionality: qdet00 * a11 = a00 * qdet11 over commutative fields"
     ],
-    "theoremCount": 32,
+    "theoremCount": 26,
     "definitionCount": 6
   },
   "sections": [
@@ -157,7 +157,7 @@
     "namespace": "CramersRuleOQ01OQ02",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 26,
     "definitionCount": 6,
     "path": "Proofs/CramersRuleOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 600,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 10
   },
   "overview": {
@@ -196,7 +196,7 @@
     "namespace": "SternBrocot",
     "lineCount": 600,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 10,
     "path": "Proofs/DenumerabilityRationalsOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -34,7 +34,7 @@
         "relationship": "OQ-02-OQ-01 proves Budan's building blocks; Sturm's exact count goes further, using GCD-based sequences instead of derivative towers."
       }
     ],
-    "theoremCount": 28,
+    "theoremCount": 26,
     "definitionCount": 6
   },
   "overview": {
@@ -53,7 +53,7 @@
     "namespace": "SturmTheorem",
     "lineCount": 458,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 26,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -30,7 +30,7 @@
         "relationship": "Proves the budan_upper_bound_axiom from OQ-02"
       }
     ],
-    "theoremCount": 9,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "overview": {
@@ -49,7 +49,7 @@
     "namespace": "BudanUpperBound",
     "lineCount": 239,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 6,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -68,7 +68,7 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
     "lineCount": 698,
-    "theoremCount": 43,
+    "theoremCount": 41,
     "defCount": 8,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
@@ -246,7 +246,7 @@
     "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
     "sorries": 0,
     "definitionCount": 8,
-    "theoremCount": 43
+    "theoremCount": 41
   },
   "sorries": 0
 }

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -48,7 +48,7 @@
     "dateAdded": "2026-04-03",
     "axiomCount": 1,
     "lineCount": 328,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 5
   },
   "overview": {
@@ -145,7 +145,7 @@
     "namespace": "DissectionOfCubesOQ01OQ01",
     "lineCount": 328,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -43,7 +43,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Note: `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` (line 55-56) is a stub placeholder definition — not an axiom declaration or structure-encoded assumption. Dehn’s theorem is taken as an explicit hypothesis in `hilbert_third_problem`, not as an axiom declaration. The core number-theoretic result (arccos(1/3)/π is irrational via Chebyshev recurrence) is fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 18,
     "definitionCount": 7
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "DissectionOfCubesOQ02",
     "lineCount": 379,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 18,
     "definitionCount": 7,
     "opens": [
       "Real"

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of \u211d over \u2124) is proved in DissectionOfCubesOQ02OQ02.lean via Mathlib Module.Flat \u2124 \u211d (B\u00e9zout + NoZeroSMulDivisors) and lTensor_preserves_injective_linearMap. icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 irrational) is proved here via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations and 0 sorries; OQ02OQ02 import chain is also axiom-free.",
     "lineCount": 561,
-    "theoremCount": 25,
+    "theoremCount": 21,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/DissectionOfCubesOQ04Aristotle.lean"
@@ -189,7 +189,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 561,
-    "theoremCount": 25,
+    "theoremCount": 21,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,
-    "theoremCount": 21,
+    "theoremCount": 20,
     "definitionCount": 1,
     "assumptions": [],
     "dateAdded": "2026-04-12",
@@ -177,7 +177,7 @@
     "namespace": "DigitalRootBase",
     "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 20,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/DivisibilityBy3OQ03OQ02.lean"

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-04-05",
     "lineCount": 202,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/DivisibilityByThreeOQ01OQ02Aristotle.lean"
@@ -87,7 +87,7 @@
     "namespace": "DivisibilityByThreeOQ01OQ02",
     "lineCount": 202,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/DivisibilityByThreeOQ01OQ02.lean",
     "sorries": 0,

--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -54,7 +54,7 @@
       "Extremal combinatorics",
       "Lean 4 and Mathlib"
     ],
-    "theoremCount": 18,
+    "theoremCount": 12,
     "definitionCount": 9
   },
   "crossReferences": [
@@ -159,7 +159,7 @@
     "lineCount": 320,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 18,
+    "theoremCount": 12,
     "definitionCount": 9
   },
   "sorries": 0

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 2,
     "lineCount": 239,
     "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C²-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs.",
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 14
   },
   "overview": {
@@ -236,7 +236,7 @@
     "namespace": null,
     "lineCount": 239,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 14,
     "path": "Proofs/Erdos1009Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 792,
     "assumptions": "No axioms. 4 sorry(s) remain (all deep — require non-Mathlib mathematics): folklore_irrationality (Mahler-type criterion), kovac_tao_not_irrationality (Egyptian fraction construction), positive_condition_irrationality (liminf analysis), truncation_insufficient (requires known irrationality sequence witness). Proved (no sorry): doubleExp_strictly_increasing, doubleExp_square_growth, doubleExp_not_folklore_growth, doubleExp_convergent, doubleExp_superexponential, doubleExp_not_kovac_tao, characterization_gap, factorial_no_folklore_growth, factorial_has_kovac_tao_condition, connection_262_proved, doubleExp_term_eq, doubleExp_sum_summable, doubleExp_fin_mul_nat, doubleExp_tail_pos, doubleExp_tail_bound, tsum_split_at, doubleExp_sum_irrational (integer-gap argument, session 9).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 19,
     "additionalFiles": [
       "Proofs/Erdos263Aristotle.lean"
@@ -166,7 +166,7 @@
     "namespace": "Erdos263",
     "lineCount": 792,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 19,
     "path": "Proofs/Erdos263Problem.lean",
     "sorries": 4,

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -23,7 +23,7 @@
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 375,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "definitionCount": 12
   },
   "sections": [
@@ -155,7 +155,7 @@
     "lineCount": 375,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "lemmaCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -87,7 +87,7 @@
       "euler-identity-oq-01-oq-01",
       "demoivre"
     ],
-    "theoremCount": 16,
+    "theoremCount": 13,
     "definitionCount": 2
   },
   "overview": {
@@ -216,7 +216,7 @@
     "path": "Proofs/EulerIdentityOQ01OQ01OQ01.lean",
     "filename": "EulerIdentityOQ01OQ01OQ01.lean",
     "lineCount": 241,
-    "theoremCount": 16,
+    "theoremCount": 13,
     "definitionCount": 2,
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 9,
     "assumptions": "hurwitz_euclidean: For any Hurwitz quaternions a and nonzero b, there exist q, r ∈ H with a = b·q + r and N(r) < N(b). This Euclidean property requires the covering radius argument from algebraic topology to prove fully.",
     "originalContributions": [
@@ -31,7 +31,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 9
   },
   "overview": {

--- a/src/data/proofs/kummer-theorem-oq-02/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02/meta.json
@@ -54,7 +54,7 @@
     ],
     "assumptions": "0 axioms, 0 sorries. All q-analog definitions built from scratch. Cyclotomic factorization of q-numbers from Mathlib; all else original.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 16,
     "definitionCount": 4
   },
   "overview": {
@@ -183,7 +183,7 @@
     "namespace": "KummerTheoremOQ02",
     "lineCount": 412,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 16,
     "definitionCount": 4,
     "path": "Proofs/KummerTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -31,7 +31,7 @@
       "Recovery theorems: K=1 gives spherical law, K=-1 gives hyperbolic law",
       "Algebraic equivalences: unified formula ↔ scaled spherical/hyperbolic laws for all K≠0"
     ],
-    "theoremCount": 28,
+    "theoremCount": 22,
     "definitionCount": 2
   },
   "overview": {
@@ -195,7 +195,7 @@
     "namespace": "UnifiedLawOfCosines",
     "lineCount": 693,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 22,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ05.lean",
     "sorries": 0

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 52,
+    "theoremCount": 40,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/LebesgueMeasureOQ06Aristotle.lean"
@@ -220,7 +220,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 52,
+    "theoremCount": 40,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,

--- a/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 453,
     "assumptions": "1 axiom: two_points_determine_chord. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 17
   },
   "sections": [
@@ -158,7 +158,7 @@
     "namespace": "BeltramiKlein",
     "lineCount": 453,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 17,
     "path": "Proofs/ParallelPostulateIndependenceOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/shannon-channel-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04/meta.json
@@ -58,7 +58,7 @@
       "Basic real analysis inequalities"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 10,
     "definitionCount": 2
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "InformationTheory.BinaryEntropy",
     "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 10,
     "definitionCount": 2,
     "path": "Proofs/ShannonChannelCodingOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Continuation of #17408 (which covered a-c range). Re-syncs stale `theoremCount` values for 24 additional gallery entries where the main Lean file's theorem/lemma count has drifted. Each entry had matching `meta.theoremCount` (sub-object) and `leanFile.theoremCount`; both updated to actual.

## Evidence

Counts verified via the same convention as #17408: comment-stripped source + `^(?:(private|protected|noncomputable)\s+)*(theorem|lemma)\b` regex.

| Slug | Before | After |
|---|---|---|
| amgm-inequality-oq-02 | 26 | 25 |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 6 | 5 |
| cramers-rule-oq-01-oq-02 | 32 | 26 |
| cramers-rule-oq-01-oq-02-oq-01 | 30 | 18 |
| denumerability-rationals-oq-03 | 31 | 30 |
| descartes-rule-of-signs-oq-02 | 43 | 41 |
| descartes-rule-of-signs-oq-02-oq-01 | 9 | 6 |
| descartes-rule-of-signs-oq-02-oq-01-oq-02 | 28 | 26 |
| dissection-of-cubes-oq-01-oq-01 | 29 | 26 |
| dissection-of-cubes-oq-02 | 20 | 18 |
| dissection-of-cubes-oq-04 | 25 | 21 |
| divisibility-by-3-oq-03-oq-02 | 21 | 20 |
| divisibility-by-three-oq-01-oq-02 | 14 | 13 |
| erdos-1009 | 7 | 5 |
| erdos-1009-oq-02 | 18 | 12 |
| erdos-263 | 31 | 30 |
| erdos-662 | 21 | 19 |
| euler-identity-oq-01-oq-01-oq-01 | 16 | 13 |
| fermat-two-squares-oq-01-oq-03 | 18 | 15 |
| kummer-theorem-oq-02 | 21 | 16 |
| law-of-cosines-oq-01-oq-05 | 28 | 22 |
| lebesgue-measure-oq-06 | 52 | 40 |
| parallel-postulate-independence-oq-02 | 19 | 17 |
| shannon-channel-coding-oq-04 | 12 | 10 |

Surgical 2-line replacement per file (48 line changes total) — no JSON reformatting. No Lean source changes. `abel-ruffini-galois-extensions-oq-07` and `ballot-problem-oq-03-oq-01-oq-01-oq-01` and `four-square-distribution-oq-01` were excluded due to in-flight PRs touching those slugs.

---
Automated fix by lean-mechanic agent.