### PR TITLE
research(sperner-ndim-mathlib-oq-02): S20 — satDiagBases for _hLastFace (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2107,4 +2107,156 @@ private lemma boundaryOnFace_simData2 :
       omega
 
 end N2HBoundaryOnFace
+
+-- ============================================================
+-- (S20) Saturating-diagonal base set for `_hLastFace`.
+--
+-- The `_hLastFace` slot of `Triangulation.boundary_doors_odd`
+-- requires the count of boundary doors `(s, k)` whose remaining
+-- vertices all lie on geometric face 2 (`b.1 + b.2 = N`) to be
+-- odd. By S18.1 + S18.5, the only boundary doors that can lie on
+-- face 2 come from `t1 b` cells with the **saturating diagonal**
+-- condition `b.1 + b.2 + 1 = N` (the cell's diagonal edge becomes
+-- the boundary). T2 cells contribute no boundary doors (S18.2),
+-- and the horizontal/vertical t1-boundary edges are on face 1 / 0
+-- respectively (S18.5 `*_endpoints_on_face*`).
+--
+-- This section introduces `satDiagBases N` — the t1 bases meeting
+-- the saturating-diagonal condition — and proves the basic
+-- structural results that S21 will compose with `face2_path_odd`
+-- to produce the bijection door ↔ color-changing diagonal edge.
+--
+-- Concretely, this section delivers:
+-- * `satDiagBases N` definition + `satDiagBases_mem_iff`
+-- * `satDiagBases_eq_image_range`: explicit equality with
+--   `(Finset.range N).image (fun k => (k, N-1-k))`
+-- * `satDiagBases_card`: cardinality = N
+-- * `satDiagBases_subset_t1Bases`: subset relation
+-- * `satDiagBases_endpoints_on_face2`: both diagonal endpoints
+--   satisfy `onFaceΔ2_strict N · (2 : Fin 3)` (strict = in-range +
+--   geometric face), supplying both halves of `_hLastFace`'s
+--   condition (3) for the diagonal-cell case.
+--
+-- S21 will pin down the matching `vertexEnum` index `k` (via the
+-- existing `vertexEnum (t1 b) hS k ∈ t1 b` 3-way case-split
+-- pattern from S19.3), then bridge `IsDoor` to `face2_path_odd`'s
+-- color-change predicate to discharge `_hLastFace`.
+-- ============================================================
+
+section N2LastFaceBases
+
+/-- Saturating-diagonal t1 bases: `b ∈ t1Bases N` whose diagonal
+edge sits exactly on the simplex's boundary (i.e., the diagonal
+endpoints satisfy `v.1 + v.2 = N`). Equivalently
+`b.1 + b.2 + 1 = N`, since the diagonal endpoints are
+`(b.1+1, b.2)` and `(b.1, b.2+1)`. -/
+private def satDiagBases (N : ℕ) : Finset (ℕ × ℕ) :=
+  (t1Bases N).filter (fun b => b.1 + b.2 + 1 = N)
+
+/-- Membership iff: clean form combining `t1Bases_mem_iff` with
+the saturating-diagonal condition. The `b.1 < N ∧ b.2 < N` clauses
+follow from `b.1 + b.2 + 1 = N` (since both summands are `≥ 0`),
+but we keep them explicit so the iff matches the standard
+`t1Bases_mem_iff` shape. -/
+private lemma satDiagBases_mem_iff (N : ℕ) (b : ℕ × ℕ) :
+    b ∈ satDiagBases N ↔
+      b.1 < N ∧ b.2 < N ∧ b.1 + b.2 + 1 = N := by
+  unfold satDiagBases
+  rw [Finset.mem_filter, t1Bases_mem_iff]
+  constructor
+  · rintro ⟨⟨h1, h2, _⟩, hsat⟩; exact ⟨h1, h2, hsat⟩
+  · rintro ⟨h1, h2, hsat⟩
+    refine ⟨⟨h1, h2, ?_⟩, hsat⟩
+    omega
+
+/-- Saturating diagonal bases are a subset of `t1Bases`. -/
+private lemma satDiagBases_subset_t1Bases (N : ℕ) :
+    satDiagBases N ⊆ t1Bases N := by
+  intro b hb
+  exact (Finset.mem_filter.mp hb).1
+
+/-- The map `k ↦ (k, N-1-k)` is injective on `Finset.range N`. -/
+private lemma satDiagBases_image_map_injOn (N : ℕ) :
+    Set.InjOn (fun k => ((k, N - 1 - k) : ℕ × ℕ))
+      (↑(Finset.range N) : Set ℕ) := by
+  intro k₁ _ k₂ _ hkeq
+  -- `congrArg Prod.fst` extracts the first-component equality from
+  -- the pair equality `(k₁, N-1-k₁) = (k₂, N-1-k₂)`.
+  exact congrArg Prod.fst hkeq
+
+/-- The image of `Finset.range N` under `k ↦ (k, N-1-k)` is
+exactly `satDiagBases N`. This is the explicit parametrization
+that drives the cardinality computation and the future bijection
+with `face2_path_odd`'s color-changing edges. -/
+private lemma satDiagBases_eq_image_range (N : ℕ) :
+    satDiagBases N =
+      (Finset.range N).image (fun k => (k, N - 1 - k)) := by
+  ext ⟨b1, b2⟩
+  rw [satDiagBases_mem_iff, Finset.mem_image]
+  refine ⟨?_, ?_⟩
+  · rintro ⟨h1, _h2, hsat⟩
+    refine ⟨b1, Finset.mem_range.mpr h1, ?_⟩
+    -- snd-component: `N - 1 - b1 = b2` from `b1 + b2 + 1 = N`.
+    have hsnd : N - 1 - b1 = b2 := by omega
+    exact (Prod.mk.injEq _ _ _ _).mpr ⟨rfl, hsnd⟩
+  · rintro ⟨k, hk, hk_eq⟩
+    rw [Finset.mem_range] at hk
+    -- `(k, N - 1 - k) = (b1, b2)` ⟹ `b1 = k ∧ b2 = N - 1 - k`.
+    have hfst : k = b1 := congrArg Prod.fst hk_eq
+    have hsnd : N - 1 - k = b2 := congrArg Prod.snd hk_eq
+    refine ⟨?_, ?_, ?_⟩ <;> omega
+
+/-- The cardinality of `satDiagBases N` is exactly `N`. This is
+the count side of the future `_hLastFace` bijection: there are
+exactly `N` saturating-diagonal cells, matching the `N` edges of
+`face2_path_odd`'s `Finset.range N` index set. -/
+private lemma satDiagBases_card (N : ℕ) : (satDiagBases N).card = N := by
+  rw [satDiagBases_eq_image_range,
+      Finset.card_image_of_injOn (satDiagBases_image_map_injOn N),
+      Finset.card_range]
+
+/-- For `b ∈ satDiagBases N`, the diagonal endpoints
+`(b.1, b.2+1)` and `(b.1+1, b.2)` lie in the in-range region
+`v.1 + v.2 ≤ N`. (In fact they saturate, with equality.) This is
+the in-range half of `onFaceΔ2_strict`. -/
+private lemma satDiagBases_endpoints_in_range
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    (b.1 + (b.2 + 1) ≤ N) ∧ ((b.1 + 1) + b.2 ≤ N) := by
+  rw [satDiagBases_mem_iff] at hb
+  obtain ⟨_, _, hsat⟩ := hb
+  refine ⟨?_, ?_⟩ <;> omega
+
+/-- For `b ∈ satDiagBases N`, the diagonal endpoints both satisfy
+the strict face-2 predicate `onFaceΔ2_strict N · (2 : Fin 3)`
+(strict = in-range conjuncted with the geometric `b.1 + b.2 = N`
+condition).
+
+This is exactly the per-vertex content of the
+`∀ j ≠ k, onFaceΔ2_strict N (T.vertex s j) (2 : Fin 3)` clause in
+`_hLastFace` for the `s = t1 b, k = (the index dropping b)` case.
+S21 will compose this with the `vertexEnum (t1 b) hs k ∈ t1 b`
+3-way case-split (per the S19.3 pattern) to identify the unique
+`k` that makes the dropped vertex equal `b`. -/
+private lemma satDiagBases_endpoints_on_face2
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    onFaceΔ2_strict N (b.1, b.2 + 1) (2 : Fin 3) ∧
+      onFaceΔ2_strict N (b.1 + 1, b.2) (2 : Fin 3) := by
+  have hbt1 : b ∈ t1Bases N := satDiagBases_subset_t1Bases N hb
+  have hsat : N ≤ b.1 + b.2 + 1 := by
+    rw [satDiagBases_mem_iff] at hb
+    omega
+  have hgeom := diagonal_endpoints_on_face2 N hbt1 hsat
+  have hrange := satDiagBases_endpoints_in_range N hb
+  exact ⟨⟨hrange.1, hgeom.1⟩, ⟨hrange.2, hgeom.2⟩⟩
+
+/-- `t1 b ∈ topSimps2 N` for `b ∈ satDiagBases N`. Convenience
+alias used by S21 to feed the saturating-diagonal cells through
+the `Triangulation.boundary_doors_odd` consumers. -/
+private lemma satDiagBases_t1_in_topSimps2
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    t1 b ∈ topSimps2 N :=
+  t1_in_topSimps2_of_base N (satDiagBases_subset_t1Bases N hb)
+
+end N2LastFaceBases
+
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,12 +2,63 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-08 (Iteration 19 part 3, researcher-8)
-**Iteration**: 19
+**Last Updated**: 2026-05-08 (Iteration 20, researcher-3)
+**Iteration**: 20
 
 ## Current Focus
 
-Session 19 part 3 (this session, build pending): Added the
+Session 20 (PR #17426, build pending): Introduced the
+**saturating-diagonal base set** `satDiagBases N` and its core
+structural results, completing the **count side** of the future
+`_hLastFace` ↔ `face2_path_odd` bijection.
+
+The `_hLastFace` slot of `Triangulation.boundary_doors_odd` counts
+boundary doors `(s, k)` whose remaining vertices all lie on
+geometric face 2 (`b.1+b.2 = N`). By S18.1 + S18.5, these arise
+**only** from saturating-diagonal t1 cells (t2 contributes no
+boundary doors per S18.2; horizontal/vertical t1 boundaries are on
+face 1 / 0 per S18.5). So the cell side of the count is exactly
+`|satDiagBases N| = N`.
+
+New private definitions/lemmas in a new `N2LastFaceBases` section
+appended to `SpernerFreudSimp` (152 lines added to
+`SpernerFreudenthalSimplex.lean`):
+
+* `satDiagBases N : Finset (ℕ × ℕ)` —
+  `(t1Bases N).filter (fun b => b.1 + b.2 + 1 = N)`
+* `satDiagBases_mem_iff` — clean form combining `t1Bases_mem_iff`
+  with the saturating condition.
+* `satDiagBases_subset_t1Bases` — subset relation.
+* `satDiagBases_image_map_injOn` — `k ↦ (k, N-1-k)` injective on
+  `Finset.range N`.
+* `satDiagBases_eq_image_range` — explicit parametrization with
+  `(Finset.range N).image (fun k => (k, N-1-k))`.
+* `satDiagBases_card` — cardinality = N. Matches the
+  `Finset.range N` index set in `face2_path_odd`.
+* `satDiagBases_endpoints_in_range` — diagonal endpoints
+  `(b.1, b.2+1)` and `(b.1+1, b.2)` are in the in-range region
+  `v.1+v.2 ≤ N`.
+* `satDiagBases_endpoints_on_face2` — diagonal endpoints both
+  satisfy `onFaceΔ2_strict N · (2 : Fin 3)`. Exactly the
+  per-vertex content of `_hLastFace`'s condition (3) for the
+  diagonal-cell case.
+* `satDiagBases_t1_in_topSimps2` — convenience alias for feeding
+  saturating-diagonal cells through `Triangulation` consumers.
+
+S20 establishes a clean reusable foundation for S21+ rather than
+attempting the full `_hLastFace` discharge in one commit. Keeping
+the iterative-PR cadence small reduces merge-conflict risk and
+keeps any build regressions narrow.
+
+**S21 (next):** Pin down the matching `vertexEnum` index `k` (via
+the S19.3 case-split pattern on `vertexEnum (t1 b) hS k ∈ t1 b`);
+bridge `IsDoor c (T.toCellComplex) (t1 b) k` to `face2_path_odd`'s
+color-change predicate `g k ≠ g (k+1)`; assemble the `_hLastFace`
+discharge for `simData2 N`. Estimated ~80–100 lines.
+
+## Previous Focus
+
+Session 19 part 3 (PR #17363, merged): Added the
 **concrete `_hBoundaryOnFace_simData2` discharge** plus a
 "two-distinct-containers ⇒ card ≥ 2" helper. This is the actual
 consumer of S16–S19's combinatorial infrastructure: given any

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -38,7 +38,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "STATE (2026-05-08, session 19 part 2, build pending): n=0,1 fully proved; n=2 has all _hBoundaryOnFace infrastructure in place. S19.1 (PR #17162) supplied the generic adjFn=none↔card≤1 translation; S19.2 (this session) supplies the generic ∀-quantifier face bridge (forall_vertex_ne_iff_forall_face_mem) + 6 concrete face-erase computations (t{1,2}_erase_first/second/third). S19.3 next: assemble _hBoundaryOnFace_simData2 by case-splitting on vertexEnum∈{3 vertices} per cell type (~80 lines, pure case work). Then _hLastFace (~120 lines) + apply Triangulation.sperner (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
+    "progressSummary": "S20 (PR #17426, build pending): Introduced saturating-diagonal base set satDiagBases N (t1Bases filtered by b.1+b.2+1=N). Proved core structural results — explicit Finset.range N parametrization, cardinality = N, in-range and onFaceΔ2_strict witnesses for diagonal endpoints. Foundation for S21 _hLastFace discharge via face2_path_odd color-change bijection.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -82,7 +82,8 @@
       "t2_face2_neighbor_topSimps2: t2 face2 shared with t1 c (S18.2.5, build pending)",
       "forall_vertex_ne_iff_forall_face_mem: generic ∀ j≠k vs ∀ v∈faceOf bridge in SimplicialAdjFnHelper (S19 part 2)",
       "t1_erase_first/second/third: explicit (t1 b).erase v computations giving the 3 edges (vertical/horizontal/diagonal) (S19 part 2)",
-      "t2_erase_first/second/third: explicit (t2 c).erase v computations giving the 3 edges (face2/face1/face0) (S19 part 2)"
+      "t2_erase_first/second/third: explicit (t2 c).erase v computations giving the 3 edges (face2/face1/face0) (S19 part 2)",
+      "S20 (PR #17426): satDiagBases N + satDiagBases_mem_iff + satDiagBases_subset_t1Bases + satDiagBases_image_map_injOn + satDiagBases_eq_image_range + satDiagBases_card + satDiagBases_endpoints_in_range + satDiagBases_endpoints_on_face2 + satDiagBases_t1_in_topSimps2 in SpernerFreudenthalSimplex.lean (N2LastFaceBases section)"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -117,7 +118,8 @@
       "Witness-direction asymmetry: when the cell is t1, witness is t2 → use `(t1_ne_t2 b _).symm` for `t2 _ ≠ t1 b`. When cell is t2, witness is t1 → use raw `t1_ne_t2 _ c` for `t1 _ ≠ t2 c`.",
       "Six-cell coverage table now complete for n=2 _hBoundaryOnFace: t1 cells × {diagonal, horizontal, vertical} have both boundary singleton (S18.1) AND interior existential (S17 + S18.2); t2 cells × {face0, face1, face2} are always interior (S18.2.3-5; t2 contributes no boundary doors).",
       "S19.1 connects abstract adjFn to abstract containersOf; the missing link to S18 lemmas (which use concrete edge filter sets) is the explicit faceOf computation. The 6 erase lemmas + the ∀-quantifier bridge close this gap.",
-      "Edit-tool path trap recurrence: writing to /Users/rwalters/GitHub/lean-genius/proofs/... (main repo path, not worktree) silently lost 177 lines of edits to concurrent rebase activity. Always use /Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-6/proofs/... for edits."
+      "Edit-tool path trap recurrence: writing to /Users/rwalters/GitHub/lean-genius/proofs/... (main repo path, not worktree) silently lost 177 lines of edits to concurrent rebase activity. Always use /Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-6/proofs/... for edits.",
+      "S20: Saturating-diagonal t1 bases form the cell side of _hLastFace. By S18.1+S18.5, the only boundary doors lying on geometric face 2 come from t1 b cells with b.1+b.2+1=N (t2 cells contribute none, horizontal/vertical t1 boundaries are on face 1/0). The count |satDiagBases N| = N matches face2_path_odd's Finset.range N index set, providing the bijection's count-side foundation."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
@@ -129,7 +131,8 @@
       "Apply Triangulation.sperner and extract real-coordinate witnesses with diameter ≤ 2/N (~50 lines).",
       "After sperner_panchromatic_two is complete (axiom-free n=2): generalize the Type-1/Type-2 grid construction to n≥3 via Freudenthal triangulation. Each top simplex is determined by a base + permutation of {1, ..., n}; pseudomanifold proof scales linearly with n.",
       "The main file SpernerNDimMathlibOQ02.lean remains at 1 axiom (sperner_panchromatic for general n). Once n=2 is proved, the axiom can be replaced for n=2 or kept generically.",
-      "Build status: S17 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16 build-pending merges. Lemmas are mechanical case-bash + omega."
+      "Build status: S17 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16 build-pending merges. Lemmas are mechanical case-bash + omega.",
+      "S21: Pin down the matching vertexEnum index k for saturating-diagonal t1 cells (3-way case-split via vertexEnum (t1 b) hs k ∈ t1 b, S19.3 pattern); bridge IsDoor to face2_path_odd's color-change predicate; assemble _hLastFace discharge for simData2 N (~80-100 lines)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S20 of the n-dim Sperner / Mathlib OQ-02 line: introduces the
**saturating-diagonal base set** `satDiagBases N` and its core
structural results, completing the count side of the future
`_hLastFace` ↔ `face2_path_odd` bijection.

## Why this matters

`_hLastFace` of `Triangulation.boundary_doors_odd` counts boundary
doors whose remaining vertices all lie on geometric face 2 (the
diagonal `b.1 + b.2 = N`). By S18.1 + S18.5, these arise **only**
from saturating-diagonal t1 cells:
- t2 cells contribute no boundary doors (S18.2)
- horizontal/vertical t1 boundary edges are on face 1 / 0 (S18.5
  `*_endpoints_on_face*`)

So the count is exactly the size of the saturating-diagonal cell
set, restricted to the doors that are color-changing (the `IsDoor`
predicate). This PR provides the "saturating-diagonal cell" half
in clean reusable form.

## What's added

New `N2LastFaceBases` section appended to `SpernerFreudSimp`
namespace in `proofs/Proofs/SpernerFreudenthalSimplex.lean`:

| Lemma | Content |
|-------|---------|
| `satDiagBases N` | `(t1Bases N).filter (fun b => b.1+b.2+1 = N)` |
| `satDiagBases_mem_iff` | `b.1 < N ∧ b.2 < N ∧ b.1+b.2+1 = N` |
| `satDiagBases_subset_t1Bases` | subset relation |
| `satDiagBases_image_map_injOn` | `k ↦ (k, N-1-k)` injective on `Finset.range N` |
| `satDiagBases_eq_image_range` | explicit parametrization via `Finset.range N` |
| `satDiagBases_card` | cardinality = N |
| `satDiagBases_endpoints_in_range` | diagonal endpoints in the in-range region |
| `satDiagBases_endpoints_on_face2` | both endpoints satisfy `onFaceΔ2_strict N · (2 : Fin 3)` |
| `satDiagBases_t1_in_topSimps2` | convenience alias for `Triangulation` consumers |

The cardinality result `(satDiagBases N).card = N` matches the
`Finset.range N` index set in `face2_path_odd`'s color-change
counting — the bijection backbone.

The `satDiagBases_endpoints_on_face2` lemma is exactly the
per-vertex content of `_hLastFace`'s condition (3) for the
diagonal-cell case (`s = t1 b, k = (the index dropping b)`). S21
will pair it with the `vertexEnum (t1 b) hs k ∈ t1 b` 3-way
case-split pattern from S19.3 to identify the matching `k`.

## Path forward (post-S20)

- **S21**: Pin down the matching `vertexEnum` index `k`; bridge
  `IsDoor` to `face2_path_odd`'s color-change predicate; assemble
  the `_hLastFace` discharge for `simData2 N`. Estimated ~80–100
  lines.
- **S22**: Apply `Triangulation.sperner` (~50 lines for diameter
  bound + real coordinates) to close `sperner_panchromatic_two`.

## Status

**Outcome**: progress (foundation for S21–S22)
**Build**: pending (docker build skipped — 45+ min in the worktree
env due to broken `proofs/.lake` symlink). Proof techniques are
routine and follow this file's established patterns:
`Finset.mem_filter`, `Prod.mk.injEq`, `congrArg Prod.fst`,
`Finset.card_image_of_injOn`, `omega`.
**Diff**: +152 / -0, single file.

🤖 Generated by researcher-3