### PR TITLE
fix(meta): batch sync definitionCount drift (9 entries, batch d-e)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -62,7 +62,7 @@
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 31,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "The Stern-Brocot tree was independently discovered by Moritz Abraham Stern in 1858 and Achille Brocot in 1861. Stern was a German mathematician studying number-theoretic functions; Brocot was a French clockmaker seeking optimal gear ratios for mechanical clocks. Both arrived at the same elegant structure: a binary tree containing every positive rational number exactly once, already in lowest terms.\n\nThe tree is built using the mediant operation: given fractions a/b and c/d, their mediant is (a+c)/(b+d). Starting with the 'sentinels' 0/1 and 1/0, the root is their mediant 1/1. Each node's left child is the mediant of the node with its left ancestor, and likewise for the right.\n\nThe Stern-Brocot tree has deep connections to continued fractions (the path to any rational encodes its continued fraction expansion), the Euclidean algorithm (the search path mimics gcd computation), Farey sequences (each level of the tree corresponds to a Farey-like refinement), and the Calkin-Wilf tree (a closely related structure with the same enumeration but different tree shape).\n\nGraham, Knuth, and Patashnik's 'Concrete Mathematics' (1994) popularized the tree in computer science, using it to derive properties of continued fractions and to prove the density of rationals in the reals constructively.",
@@ -197,7 +197,7 @@
     "lineCount": 600,
     "axiomCount": 0,
     "theoremCount": 31,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/DenumerabilityRationalsOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/desargues-theorem-oq-02/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-02/meta.json
@@ -44,7 +44,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 37,
-    "definitionCount": 22
+    "definitionCount": 23
   },
   "overview": {
     "historicalContext": "Girard Desargues stated his theorem around 1639 in the context of perspective drawing and projective geometry. The theorem — that two triangles in perspective from a point are also in perspective from a line — holds in every projective plane coordinatizable by a division ring, a result formalized in OQ-01 using cross-product algebra. Forest Ray Moulton (1902) constructed the first concrete counterexample: an affine plane with the same point set as $\\mathbb{R}^2$ but modified lines, where negative slopes double upon crossing the $y$-axis. This showed that Desargues's theorem is not a consequence of the incidence axioms alone — it depends on the algebraic structure of the coordinate system. The Hessenberg-Artin theorem (Karl Hessenberg 1905, Emil Artin 1957) later proved the converse: a projective plane is Desarguesian if and only if it is coordinatizable by a division ring. The Moulton plane thus occupies a central place in the classification of projective planes and serves as the canonical example in most modern textbooks on incidence geometry (e.g., Hartshorne's *Foundations of Projective Geometry*).",
@@ -150,7 +150,7 @@
     "lineCount": 332,
     "axiomCount": 0,
     "theoremCount": 37,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "path": "Proofs/DesarguesTheoremOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/desargues-theorem-oq-04/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-04/meta.json
@@ -67,7 +67,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "sections": [
     {
@@ -209,7 +209,7 @@
     "lineCount": 415,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/DesarguesTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -72,7 +72,7 @@
     "defCount": 8,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "François Budan de Boislaurent, a physician and amateur mathematician, published *Nouvelle méthode pour la résolution des équations numériques* in 1807. His theorem generalized Descartes' Rule of Signs (1637) from counting positive roots to counting roots in any interval $(a, b]$ by evaluating the polynomial and all its derivatives at the endpoints and comparing sign changes. Budan's original motivation was practical numerical root-finding for engineering applications.\n\nJoseph Fourier independently discovered the same result around 1820, based on lecture notes from the École Polytechnique. Fourier's treatment was more analytical, connecting the sign variation count to the behavior of the Taylor expansion at each endpoint. His work was published posthumously in 1831 (*Analyse des équations déterminées*), leading to the dual name 'Budan-Fourier theorem.' The priority dispute between Budan and Fourier was noted by Sturm himself.\n\nCharles Sturm's 1829 theorem superseded Budan-Fourier for exact root counting by replacing the derivative sequence with a pseudo-remainder sequence (Sturm chain), eliminating the parity gap entirely. However, Budan's theorem remained computationally important because derivative sequences require only $O(n^2)$ arithmetic operations versus $O(n^2 \\log n)$ for Sturm chains (with fast polynomial arithmetic).\n\nThe modern revival of Budan-Fourier came through its role in root isolation algorithms. Alexandre-Joseph-Hidulphe Vincent (1834) proved that continued fraction expansion of a polynomial eventually isolates all positive real roots, with Budan's theorem providing the termination certificates. The VAS algorithm (Vincent-Akritas-Strzeboński, 2005–2008) formalized this into a practical root isolator used in computer algebra systems including Mathematica, Maple, and SageMath. Recent work by Sagraloff and Mehlhorn (2016) achieved near-optimal bit complexity bounds for Budan-based root isolation.",
@@ -245,7 +245,7 @@
     "axiomCount": 3,
     "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
     "sorries": 0,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "theoremCount": 43
   },
   "sorries": 0

--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 440,
     "theoremCount": 29,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "originalContributions": [
       "root_in_cauchy_interval: all real roots lie in (-cauchyBound p, cauchyBound p)",
       "no_pos_roots_of_zero_variations: if signVariations(p.coeffList) = 0, no positive roots",
@@ -66,7 +66,7 @@
     "lineCount": 440,
     "axiomCount": 0,
     "theoremCount": 29,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -52,7 +52,7 @@
     "axiomCount": 0,
     "lineCount": 256,
     "theoremCount": 14,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Wiedijk #82 — 'A cube cannot be cut into a finite number of distinct smaller cubes' — appears on the canonical 'Formalizing 100 Theorems' list of mathematical landmarks. The 3D non-dissection result is the cube-analogue of the squared-square problem: while Duijvestijn's 1978 'simple perfect squared square of order 21' shows the 2D case admits such tilings, the 3D analogue is impossible. Littlewood's *A Mathematician's Miscellany* (1953) records the infinite-descent argument that bridges from any candidate dissection to a strictly smaller one, leading to contradiction. The base Wiedijk #82 formalization in this gallery records the structural skeleton (cubes contained in $[0,1]^3$ with disjoint interiors) but uses `covers_unit_cube : True` as a placeholder — it doesn't enforce that the cubes actually fill the unit cube. OQ-01 proved every nonempty such dissection has a collision pair (same-size distinct cubes); OQ-01-OQ-03 takes the next step by adding the necessary volumetric condition $\\sum c.\\text{side}^3 = 1$ to the structure, narrowing the gap between the formalized object and a genuine geometric tiling.",
@@ -131,7 +131,7 @@
     "lineCount": 256,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/DissectionOfCubesOQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom, all_different_implies_long_chains_axiom. 2 sorries for geometric confinement lemmas (smallest_above_is_smaller, global_min_not_reaching_top).",
     "lineCount": 599,
     "theoremCount": 17,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "originalContributions": [
       "CubePacking: structure for disjoint contained cubes (relaxation of dissection)",
       "IsReciprocalPacking: packing with all distinct reciprocal-of-integer side lengths",
@@ -167,7 +167,7 @@
     "lineCount": 599,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "path": "Proofs/DissectionOfCubesOQ03.lean",
     "sorries": 2,
     "imports": [

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -62,7 +62,7 @@
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The question of whether a cube can be dissected into smaller cubes of all different sizes emerged from the broader study of geometric dissection problems. Max Dehn's 1903 paper 'Über die Zerlegung von Rechtecken in Rechtecke' initiated the systematic study of rectangle and square dissections. The analogous 2D question — can a square be dissected into squares of all different sizes? — was posed as a puzzle by Zbigniew Moron in 1925 and became known as 'squaring the square.'\n\nThe 2D problem was solved affirmatively in a remarkable 1940 paper by four Cambridge undergraduates: R.L. Brooks, C.A.B. Smith, A.H. Stone, and W.T. Tutte. They discovered an extraordinary connection between squared rectangles and electrical networks: interpreting horizontal cuts as nodes and vertical square boundaries as resistors, they showed that every squared rectangle corresponds to a planar resistor network (the 'Smith diagram'). Using Kirchhoff's laws to analyze these networks, they found perfect squared rectangles and eventually squared squares. Tutte later recalled that the problem arose from a puzzle in H.E. Dudeney's 'Canterbury Puzzles' (1907).\n\nThe first perfect squared squares found were compound (containing smaller squared sub-rectangles). The simplest 'simple perfect squared square' — one with no squared sub-rectangle — was found by A.J.W. Duijvestijn in 1978, after an exhaustive computer search: it has 21 squares with side lengths from 2 to 50, arranged in a 112×112 frame.\n\nThe 3D impossibility was proved by J.E. Littlewood and included in his delightful book 'A Mathematician's Miscellany' (1953). The proof is a model of mathematical elegance — it requires no computation, no algebra, just geometric visualization and the method of infinite descent. The key geometric insight: in a 3D cube dissection with all different sizes, the smallest cube resting on any horizontal face is completely surrounded by taller cubes on all four vertical sides (since all sizes are different). This forces the top face of the smallest cube to be a new interior 'floor,' entirely contained within the original cube, covered by cubes that must be even smaller. Repeating this argument yields an infinite strictly decreasing sequence of cube sizes — contradicting the assumption that only finitely many cubes were used.\n\nThe contrast between 2D and 3D is striking: in 2D, a small square on the bottom edge can extend to the side wall of the enclosing square, escaping the 'surrounding' argument. In 3D, no cube on the bottom face can reach all four side walls simultaneously (since it would then be a full layer, not a smaller cube). The impossibility extends to all dimensions $n \\geq 3$ and to dissections of rectangular boxes into cubes of all different sizes.",
@@ -159,7 +159,7 @@
     "lineCount": 366,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "path": "Proofs/DissectionOfCubes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "defCount": 6,
     "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. All 27 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card and quarticChar_kernel_card (|ker χ| = (p-1)/3 and (p-1)/4 via IsCyclic.card_pow_eq_one_le), cubicEuler_hard and quarticEuler_hard (both Euler criterion hard directions via discrete log).",
     "mathlib_version": "4.26.0",
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Cubic reciprocity was discovered by Gauss and proved by Eisenstein in 1844 using the Eisenstein integers ℤ[ω] where ω = e^{2πi/3}. The law states that for primary Eisenstein primes π and ρ, the cubic residue symbol (ρ/π)₃ equals (π/ρ)₃. This extends the Zolotarev character uniqueness argument: for primes p ≡ 1 (mod 3), the group (ZMod p)ˣ is cyclic of order p-1 divisible by 3, giving exactly two non-trivial cubic characters (plus the trivial one). The cubic Euler criterion — a is a cube mod p iff a^((p-1)/3) = 1 — is the natural generalization of Euler's quadratic criterion. Ireland and Rosen's book (Ch. 9) gives the definitive modern treatment via Jacobi sums.",
@@ -170,7 +170,7 @@
     "lineCount": 562,
     "axiomCount": 2,
     "theoremCount": 27,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Batch-synchronize `meta.definitionCount` and `leanFile.definitionCount`
for 9 gallery entries in the `d-` / `e-` slug range where the recorded
count diverged from the actual declarations in the primary Lean file.

Counting convention (per memory note `feedback_mechanic_def_counting`):
`def + abbrev + opaque + structure + inductive + class`, including
modifiers (`noncomputable`, `private`, `partial`, `protected`,
`scoped`, `unsafe`); `instance` excluded.

Complements the in-flight a-c batches in #17407 and #17422 (and the
single-slug fix in #17409). No alphabetic overlap.

## Evidence

| Slug | Before | After | Decl types added |
|---|---|---|---|
| denumerability-rationals-oq-03 | 10 | 12 | +1 inductive, +1 abbrev |
| desargues-theorem-oq-02 | 22 | 23 | +1 inductive |
| desargues-theorem-oq-04 | 9 | 10 | +1 structure |
| descartes-rule-of-signs-oq-02 | 8 | 9 | +1 structure |
| descartes-rule-of-signs-oq-03 | 3 | 4 | +1 structure |
| dissection-of-cubes | 8 | 10 | +2 structure |
| dissection-of-cubes-oq-01-oq-03 | 1 | 2 | +1 structure |
| dissection-of-cubes-oq-03 | 11 | 13 | +2 structure |
| elementary-quadratic-reciprocity-oq-01-oq-02 | 6 | 7 | +1 structure |

Both `meta.definitionCount` (in the `meta` sub-object) and
`leanFile.definitionCount` were stale by the same amount in every entry;
both fields updated together.

Verification: comment-stripped Lean source matched against the canonical
def-counting regex (excludes `instance`, includes modifier prefixes).

Surgical 2-line replacement per file (18 line changes total), no JSON
reformatting. JSON parse-validated post-edit. No Lean source changes.

---
Automated fix by lean-mechanic agent. No `loom:review-requested` label
(deployer auto-merges math-agent meta fixes).