### PR TITLE
fix(meta): batch sync definitionCount drift (12 entries, batch f-l)

### DIFF
--- a/src/data/proofs/fair-games-theorem-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-01/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 49,
-    "definitionCount": 12
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "The Gambler's Ruin problem is one of the oldest problems in probability theory, dating to correspondence between Pascal and Fermat in 1654. The modern treatment uses martingale theory developed by Doob (1953). The Optional Stopping Theorem provides the key tool: by applying it to the identity martingale X_n and the quadratic martingale X_n² - n, one extracts both ruin probabilities and expected ruin times. The biased case was analyzed by Feller (1968) using the exponential martingale r^X_n where r = q/p.",
@@ -165,7 +165,7 @@
     "lineCount": 632,
     "axiomCount": 0,
     "theoremCount": 49,
-    "definitionCount": 12,
+    "definitionCount": 14,
     "path": "Proofs/FairGamesTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -15,7 +15,7 @@
     "axiomCount": 1,
     "lineCount": 357,
     "theoremCount": 18,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "assumptions": "hurwitz_euclidean: For any Hurwitz quaternions a and nonzero b, there exist q, r ∈ H with a = b·q + r and N(r) < N(b). This Euclidean property requires the covering radius argument from algebraic topology to prove fully.",
     "originalContributions": [
       "First formalization of HurwitzQuat type in Lean 4 as a substructure of ℍ(ℚ) with the equal-parity constraint",
@@ -32,7 +32,7 @@
     "axiomCount": 1,
     "lineCount": 357,
     "theoremCount": 18,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Lagrange proved in 1770 that every natural number is a sum of four integer squares, using infinite descent — a tour de force of elementary number theory but lacking algebraic transparency. Euler had earlier discovered the four-square identity (the product of two sums-of-four-squares is again a sum of four squares), which forms the multiplicative backbone of the theorem. The algebraic approach via quaternions began with Hamilton's 1843 invention of the quaternion algebra ℍ. Rudolf Lipschitz in 1886 introduced the Lipschitz integers L = {a+bi+cj+dk : a,b,c,d ∈ ℤ}, a natural quaternionic analogue of Gaussian integers, hoping to prove four squares algebraically. But L has a fatal flaw: it is not a Euclidean domain. The problem is that for some pairs a, b ∈ L, the nearest Lipschitz integer to b⁻¹a has norm exactly 1 (the covering radius of L equals 1), so Euclidean division can fail. Adolf Hurwitz solved this in his 1896 paper 'Über die Zahlentheorie der Quaternionen' by extending L to include half-integer elements. The element ω = ½(1+i+j+k) has norm N(ω) = 1 (a unit!), and together with its 23 conjugates under multiplication, the 24 Hurwitz units form the binary tetrahedral group 2T. Crucially, the Hurwitz integers H have covering radius strictly less than 1: for any rational quaternion x, there is a Hurwitz integer q with N(x−q) < 1, making H a left Euclidean domain. This enables a clean GCD-based proof: every prime p has a Lipschitz Hurwitz element of norm p, giving p = a²+b²+c²+d², and Euler's identity completes the induction.",

--- a/src/data/proofs/fermat-two-squares-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01/meta.json
@@ -45,7 +45,7 @@
     "lineCount": 254,
     "assumptions": "0 axioms, 0 sorries. Core results (Lagrange four-squares theorem, Fermat two-squares theorem) from Mathlib; original work is the sum-of-two-squares infrastructure.",
     "theoremCount": 13,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The four-squares problem has ancient roots. Diophantus of Alexandria (c. 250 CE) observed that certain integers require four squares, and Bachet de Meziriac conjectured in 1621 that four squares always suffice. Fermat claimed a proof around 1636 but never published one. Euler worked on the problem for over 40 years, proving the crucial four-square identity in 1748 (which shows sums of four squares are closed under multiplication) but could not complete the descent argument for primes.\n\nIt was Joseph-Louis Lagrange who finally proved the theorem in 1770, combining Euler's identity with a clever descent: for each prime $p$, one first finds $m$ with $0 < m < p$ and $mp$ a sum of four squares (using quadratic residues), then descends on $m$ until $m = 1$. This argument was simplified by Euler himself in 1773.\n\nThe deeper algebraic structure was not understood until Hamilton's discovery of quaternions in 1843. Euler's identity is precisely the statement $|q_1 q_2|^2 = |q_1|^2 |q_2|^2$ for quaternion integers. Hurwitz (1896) later showed that the Hurwitz quaternions (allowing half-integer components) form a Euclidean domain, giving a cleaner proof. The Frobenius theorem (1877) — that the only finite-dimensional associative division algebras over $\\mathbb{R}$ are $\\mathbb{R}$, $\\mathbb{C}$, and $\\mathbb{H}$ — explains why product identities exist for 1, 2, and 4 squares but not 3.",
@@ -176,7 +176,7 @@
     "lineCount": 254,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/FermatTwoSquaresOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/feuerbachs-theorem-defs/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 38,
-    "definitionCount": 35
+    "definitionCount": 36
   },
   "overview": {
     "historicalContext": "The nine-point circle was discovered independently by Charles-Julien Brianchon and Jean-Victor Poncelet in 1821 and by Karl Wilhelm Feuerbach in 1822. Feuerbach's key contribution, proved in his 1822 treatise *Eigenschaften einiger merkwürdigen Punkte des geradlinigen Dreiecks*, was that this circle is tangent to the inscribed circle and all three excircles of the triangle. The tangency point with the incircle is now called the Feuerbach point, and the theorem itself is #29 on Wiedijk's list of 100 greatest theorems.\n\nThe nine-point circle was further studied by Leonhard Euler (who established the Euler line through circumcenter, centroid, and orthocenter) and named by Olry Terquem in 1842 after proving it passes through all nine special points. The relationship N = (O + H)/2 connecting the nine-point center to the Euler line was established by Feuerbach and generalized by later mathematicians.\n\nThis module provides the complete definitional infrastructure using explicit coordinate geometry in R^2. The approach trades the elegance of synthetic proofs for computational verifiability: every step is a polynomial identity verified by field_simp + ring. The 3-4-5 right triangle serves as a numerical sanity check, confirming that all formulas are consistent and Feuerbach tangency holds (|NI| = |R/2 - r|).",
@@ -199,7 +199,7 @@
     "lineCount": 687,
     "axiomCount": 0,
     "theoremCount": 38,
-    "definitionCount": 35,
+    "definitionCount": 36,
     "path": "Proofs/FeuerbachsTheoremDefs.lean",
     "sorries": 0
   },

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "lineCount": 385,
     "theoremCount": 12,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Fodor's Pressing-Down Lemma was proved by G\u00e9za Fodor in 1956, and is sometimes also called the Fodor-Neumer theorem. It is one of the most useful tools in combinatorial and descriptive set theory. The lemma asserts that any regressive function (f(\u03b1) < \u03b1) on a stationary subset of a regular uncountable cardinal \u03ba must be constant on some stationary subset \u2014 the function cannot 'press down' uniformly. The key technique is the **diagonal intersection**: if f\u207b\u00b9(\u03b2) is non-stationary for every \u03b2, we can find clubs C_\u03b2 avoiding each fiber, and their diagonal intersection \u0394_{\u03b2<\u03ba}(C_\u03b2) is still a club (since diagonal intersections of clubs are clubs), contradicting the stationarity of the domain.",
@@ -227,7 +227,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "imports": [
       "import Mathlib.SetTheory.Cardinal.Ordinal",
       "import Mathlib.SetTheory.Cardinal.Cofinality",

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -21,7 +21,7 @@
     "assumptions": "2 axioms inherited from FourColorTheorem.lean: five_color_theorem_nonempty, four_color_theorem_axiom. 0 sorries.",
     "lineCount": 86,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "crossReferences": [
     {
@@ -100,7 +100,7 @@
     "lineCount": 86,
     "path": "Proofs/FourColorTheoremOQ02.lean",
     "sorries": 0,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "theoremCount": 0
   },
   "sorries": 0

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -42,7 +42,7 @@
       "Topology (Jordan curve theorem, planar embeddings)"
     ],
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Four Color Problem captivated mathematicians for over a century. First posed in 1852 by Francis Guthrie while coloring a map of England, it asked: can every map be colored with just four colors so that no two adjacent regions share the same color?\n\nMany attempted proofs failed. Alfred Kempe published a 'proof' in 1879 that stood for 11 years before Percy Heawood found a fatal flaw. In 1976, Kenneth Appel and Wolfgang Haken finally proved the theorem—but their proof required a computer to check 1,936 reducible configurations. This was the first major theorem proved with essential computer assistance, sparking philosophical debates: Is a proof humans cannot verify still a 'proof'?\n\nIn 2005, Georges Gonthier formalized the complete proof in Coq, providing a machine-verified certificate that settled remaining doubts about the computer calculations.",
@@ -219,7 +219,7 @@
     "opens": [],
     "path": "Proofs/FourColorTheorem.lean",
     "sorries": 0,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 22
+    "definitionCount": 23
   },
   "overview": {
     "historicalContext": "Jacobi's four-square theorem (1829) states r₄(n) = 8·Σ_{d|n, 4∤d} d, proved using Jacobi theta functions: r₄(n) is the n-th Fourier coefficient of θ(q)⁴. Lagrange (1770) proved existence; Euler first studied r₄. The '8' factor mystified mathematicians until the group-theoretic perspective: the signed permutation symmetry group acting on a 4-tuple has order 2^k·(4!/∏mᵢ!) by orbit-stabilizer, and the representation count for each type is exactly this orbit size. This file analyzes HOW the total r₄(n) = 8σ*(n) splits among types: contributions range from 8 (single nonzero entry, like (0,0,0,k)) to 384 (all distinct nonzero, like (1,2,3,4)), a 24:1 ratio matching |S₄| = 4!. The connection to modular forms lies deeper: r₄(n) is multiplicative (via θ⁴ being a weight-2 Eisenstein series), which Jacobi's formula makes explicit through σ*.",
@@ -105,7 +105,7 @@
     "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 38,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "path": "Proofs/FourSquareDistribution.lean",
     "sorries": 0
   },

--- a/src/data/proofs/friendship-theorem-oq-03/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "lineCount": 307,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "theoremCount": 11
   },
   "mainTheorems": [
@@ -98,7 +98,7 @@
     ],
     "lineCount": 307,
     "theoremCount": 11,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "references": [
     {

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 395,
     "theoremCount": 11,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "additionalFiles": [
       "Proofs/FundamentalTheoremCalculusStokesAristotle.lean"
     ],
@@ -221,7 +221,7 @@
     "lineCount": 395,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/FundamentalTheoremCalculusStokes.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/furstenberg-correspondence/meta.json
+++ b/src/data/proofs/furstenberg-correspondence/meta.json
@@ -54,7 +54,7 @@
     "assumptions": "2 axiom(s): (1) Furstenberg Correspondence Principle — construction needs weak-* compactness not in Mathlib, (2) Multiple Recurrence for k≥3 — needs ergodic decomposition not in Mathlib. Both are well-defined mathematical constructions.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Szemerédi's 1975 theorem on arithmetic progressions in dense integer sets was proved by an extraordinarily intricate combinatorial argument that introduced the regularity lemma. In 1977, Hillel Furstenberg (J. Analyse Math. 31, 204–256) gave a revolutionary alternative proof using ergodic theory, establishing a deep connection between combinatorial number theory and dynamical systems. This proof introduced the Furstenberg Correspondence Principle (translating density of integer sets into measure of dynamical sets) and the Multiple Recurrence Theorem (generalizing Poincaré's 1890 recurrence theorem from one to k-fold intersections). Unlike Szemerédi's combinatorial proof, Furstenberg's approach gives no quantitative bounds but is far more flexible: it generalizes immediately to give the Furstenberg-Katznelson (1978) multidimensional Szemerédi theorem, the Bergelson-Leibman (1996) polynomial Szemerédi theorem (arithmetic progressions with polynomial common differences p(n) = n^2, n^3, …), and the density Hales-Jewett theorem (Furstenberg-Katznelson 1991). The 2012 work of Green-Tao on primes in arithmetic progressions ultimately combines both routes — Szemerédi's quantitative regularity bounds with Furstenberg-style transference principles. Furstenberg's program also launched the field now called *ergodic Ramsey theory*, in which combinatorial statements about integers are systematically translated into recurrence questions for measure-preserving systems and answered using the structural theory of dynamical systems (Furstenberg structure theorem, Host-Kra factors).",
@@ -189,7 +189,7 @@
     "lineCount": 252,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/FurstenbergCorrespondence.lean",
     "sorries": 0
   },

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -47,7 +47,7 @@
     "proofRepoPath": "Proofs/GodelIncompleteness.lean",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "In 1931, Kurt Gödel, a 25-year-old logician in Vienna, published a paper that would fundamentally change our understanding of mathematics and logic. His Incompleteness Theorems demonstrated that the dream of a complete, consistent foundation for mathematics—Hilbert's Program—was impossible.\n\nDavid Hilbert had proposed that all mathematical truths could be derived from a fixed set of axioms using formal rules. At the Second International Congress of Mathematicians (Paris, 1900), Hilbert had listed the completeness of a formal axiom system as a central goal. By 1930, the Hilbert-Bernays program was in full swing: find a complete, consistent, finitely axiomatizable system for all of mathematics, and prove its consistency by finitary means. Gödel showed this was a fantasy: any system powerful enough to do arithmetic would contain truths it could never prove.\n\nGödel announced the First Incompleteness Theorem at a conference in Königsberg in September 1930, barely noticed by attendees — except John von Neumann, who immediately recognized its significance. The formal paper appeared in January 1931. Five years later, in 1936, Alan Turing independently proved the undecidability of the Halting Problem via his model of computation, which can be seen as a computability-theoretic restatement of the same diagonalization principle. Turing explicitly acknowledged Gödel's influence.\n\nIn 1936, J. Barkley Rosser strengthened the First Incompleteness Theorem by replacing the assumption of ω-consistency with the weaker assumption of simple consistency, using the 'Rosser trick': replacing the Gödel sentence G ↔ ¬Prov(⌜G⌝) with a sentence that also encodes 'no shorter proof of ¬G exists'. This is now the standard modern form of the theorem. The implications rippled through philosophy, computer science (the Halting Problem, Rice's theorem, Chaitin's incompleteness), and our understanding of the fundamental limits of formal reasoning.",
@@ -281,7 +281,7 @@
     "opens": [],
     "path": "Proofs/GodelIncompleteness.lean",
     "sorries": 0,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Batch-synchronize `meta.definitionCount` and `leanFile.definitionCount`
for 12 gallery entries in the `f-` / `g-` slug range where the recorded
count diverged from the actual declarations in the primary Lean file.

Counting convention (per memory note `feedback_mechanic_def_counting`):
`def + abbrev + opaque + structure + inductive + class`, including
modifiers (`noncomputable`, `private`, `partial`, `protected`,
`scoped`, `unsafe`); `instance` excluded.

Complements the in-flight a-c batches in #17407 / #17422 / #17409 and
the d-e batch (#17429). No alphabetic overlap.

## Evidence

| Slug | Before | After | Decl makeup |
|---|---|---|---|
| fair-games-theorem-oq-01 | 12 | 14 | 12 def + 2 structure |
| fermat-two-squares-oq-01 | 3 | 4 | 3 def + 1 structure |
| fermat-two-squares-oq-01-oq-03 | 9 | 10 | 9 def + 1 structure |
| feuerbachs-theorem-defs | 35 | 36 | 34 def + 1 abbrev + 1 structure |
| fodor-pressing-down | 3 | 4 | 3 def + 1 structure |
| four-color-theorem | 2 | 3 | 2 def + 1 class |
| four-color-theorem-oq-02 | 3 | 4 | 3 def + 1 structure |
| four-square-distribution | 22 | 23 | 22 def + 1 structure |
| friendship-theorem-oq-03 | 6 | 7 | 6 def + 1 structure |
| fundamental-theorem-calculus-oq-02 | 7 | 8 | 7 def + 1 structure |
| furstenberg-correspondence | 1 | 2 | 1 def + 1 structure |
| godel-incompleteness | 12 | 13 | 12 def + 1 structure |

Both `meta.definitionCount` (in `meta` sub-object) and
`leanFile.definitionCount` were stale by the same amount in every entry;
both fields updated together. JSON parse-validated post-edit. No Lean
source changes.

---
Automated fix by lean-mechanic agent.