### PR TITLE
research(amgm-inequality-oq-04-oq-02): S7 — K-side uniform bound for dIntegrandK (build pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -693,5 +693,137 @@ lemma integrandK_hasDerivAt_in_k (hk : k ^ 2 < 1) (θ : ℝ) :
   unfold AmgmInequalityOQ04OQ01.ellipticIntegrand
   exact h_div
 
+-- ============================================================================
+-- § 11. Uniform Bound for `dIntegrandK` (K-side analog of §9)
+-- ============================================================================
+
+/-
+The K-side counterpart of §9. To apply
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` for
+`ellipticK` we need an integrable function `boundDIntegrandK M θ` that
+majorizes `|dIntegrandK κ θ|` uniformly for `|κ| ≤ M`. This section
+provides exactly that infrastructure, mirroring §9 line for line.
+
+The bound is
+
+    boundDIntegrandK M θ
+      :=  M · sin²θ / [(1 − M² sin²θ) · √(1 − M² sin²θ)],
+
+obtained from `dIntegrandK κ θ = κ sin²θ / [(1 − κ²sin²θ) √(1 − κ²sin²θ)]`
+by replacing every `κ` with `M`. For `|κ| ≤ M < 1`:
+
+* numerator  `|κ| · sin²θ ≤ M · sin²θ`  (since `|κ| ≤ M`, `sin²θ ≥ 0`);
+* denominator factor `(1 − M² sin²θ) ≤ (1 − κ² sin²θ)` (from `κ² ≤ M²`);
+* so `√(1 − M² sin²θ) ≤ √(1 − κ² sin²θ)`, and hence the product
+  `(1 − M² sin²θ) · √(1 − M² sin²θ) ≤ (1 − κ² sin²θ) · √(1 − κ² sin²θ)`.
+
+The two displayed inequalities feed `div_le_div`. The denominator on the
+M-side is positive (we only use the bound for `M² < 1`), so the quotient
+inequality is well-formed.
+
+This section is the K-side precondition for the future `dK_dk` assembly,
+which will follow the same template as the (still-open) `dE_dk` work in
+§10/PR #17371. Once the K-side algebraic split + integral identity (the
+non-pointwise IBP step) is also in place, `dK_dk` can be assembled in a
+parallel session.
+-/
+
+/-- Dominating bound for `|dIntegrandK κ θ|` on the band `|κ| ≤ M`:
+    `M · sin²θ / [(1 − M² sin²θ) · √(1 − M² sin²θ)]`.
+
+    Mirrors `dIntegrandK` with `κ` replaced by `M` everywhere — designed
+    to give a uniform integrable upper bound on `|dIntegrandK κ θ|` for
+    `κ` in a closed band. The denominator is the same `(1 − u) · √(1 − u)`
+    form as `dIntegrandK` itself (§10), so the two pieces compose
+    naturally in `dIntegrandK_abs_le_bound`. -/
+noncomputable def boundDIntegrandK (M θ : ℝ) : ℝ :=
+  M * Real.sin θ ^ 2 /
+    ((1 - M ^ 2 * Real.sin θ ^ 2) * Real.sqrt (1 - M ^ 2 * Real.sin θ ^ 2))
+
+/-- For `M² < 1` the K-side bound function is continuous in `θ`. -/
+lemma boundDIntegrandK_continuous (hM : M ^ 2 < 1) :
+    Continuous (boundDIntegrandK M) := by
+  unfold boundDIntegrandK
+  refine Continuous.div₀ ?_ ?_ ?_
+  · -- numerator: `M · sin²θ`
+    exact continuous_const.mul (continuous_sin.pow 2)
+  · -- denominator: `(1 − M² sin²θ) · √(1 − M² sin²θ)`
+    have h_inner : Continuous (fun θ : ℝ => 1 - M ^ 2 * Real.sin θ ^ 2) :=
+      Continuous.sub continuous_const
+        (continuous_const.mul (continuous_sin.pow 2))
+    exact h_inner.mul (Real.continuous_sqrt.comp h_inner)
+  · intro θ
+    have hp : 0 < 1 - M ^ 2 * Real.sin θ ^ 2 :=
+      AmgmInequalityOQ04OQ01.denom_pos hM θ
+    have hsp : 0 < Real.sqrt (1 - M ^ 2 * Real.sin θ ^ 2) :=
+      AmgmInequalityOQ04OQ01.sqrt_denom_pos hM θ
+    exact (mul_pos hp hsp).ne'
+
+/-- For `M² < 1` the K-side bound is interval-integrable on `[0, π/2]`. -/
+lemma boundDIntegrandK_integrable (hM : M ^ 2 < 1) :
+    IntervalIntegrable (boundDIntegrandK M) MeasureTheory.volume 0 (π / 2) :=
+  (boundDIntegrandK_continuous hM).intervalIntegrable 0 (π / 2)
+
+/-- **Uniform bound** on `|dIntegrandK|` over the band `|κ| ≤ M`.
+
+    For `0 ≤ M` with `M² < 1` and any `κ` with `κ² ≤ M²`,
+    `|dIntegrandK κ θ| ≤ boundDIntegrandK M θ` for every `θ`.
+
+    This is the pointwise content of the `h_bound` hypothesis of
+    `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+    on the K-side, the analog of `dIntegrandE_abs_le_bound` (§9). -/
+lemma dIntegrandK_abs_le_bound
+    (hM : M ^ 2 < 1) (hM_nn : 0 ≤ M) (κ θ : ℝ) (hκ : κ ^ 2 ≤ M ^ 2) :
+    |dIntegrandK κ θ| ≤ boundDIntegrandK M θ := by
+  unfold dIntegrandK boundDIntegrandK
+  have hsin2_nn : 0 ≤ Real.sin θ ^ 2 := sq_nonneg _
+  have hκ_sq_lt : κ ^ 2 < 1 := lt_of_le_of_lt hκ hM
+  have hM_pos : 0 < 1 - M ^ 2 * Real.sin θ ^ 2 :=
+    AmgmInequalityOQ04OQ01.denom_pos hM θ
+  have hM_sqrt_pos : 0 < Real.sqrt (1 - M ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hM θ
+  have hκ_pos : 0 < 1 - κ ^ 2 * Real.sin θ ^ 2 :=
+    AmgmInequalityOQ04OQ01.denom_pos hκ_sq_lt θ
+  have hκ_sqrt_pos : 0 < Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hκ_sq_lt θ
+  -- |κ| ≤ M from κ² ≤ M² and 0 ≤ M (via `Real.sqrt`).
+  have habs_κ : |κ| ≤ M := by
+    have h1 : Real.sqrt (κ ^ 2) ≤ Real.sqrt (M ^ 2) := Real.sqrt_le_sqrt hκ
+    rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq hM_nn] at h1
+  -- Compute |·| on the LHS. Numerator = κ · sin²θ (no sign here, unlike §9).
+  have h_num : |κ * Real.sin θ ^ 2| = |κ| * Real.sin θ ^ 2 := by
+    rw [abs_mul, abs_of_nonneg hsin2_nn]
+  have h_denom_pos :
+      0 < (1 - κ ^ 2 * Real.sin θ ^ 2)
+        * Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2) :=
+    mul_pos hκ_pos hκ_sqrt_pos
+  have h_denom :
+      |(1 - κ ^ 2 * Real.sin θ ^ 2)
+            * Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2)|
+          = (1 - κ ^ 2 * Real.sin θ ^ 2)
+              * Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2) :=
+    abs_of_pos h_denom_pos
+  rw [abs_div, h_num, h_denom]
+  -- Goal:
+  --   |κ| · sin²θ / [(1 − κ²sin²θ)·√(1 − κ²sin²θ)]
+  --     ≤ M · sin²θ / [(1 − M²sin²θ)·√(1 − M²sin²θ)].
+  apply div_le_div
+  · -- 0 ≤ numerator on RHS
+    exact mul_nonneg hM_nn hsin2_nn
+  · -- numerator inequality: |κ|·sin²θ ≤ M·sin²θ
+    exact mul_le_mul_of_nonneg_right habs_κ hsin2_nn
+  · -- 0 < denominator on RHS
+    exact mul_pos hM_pos hM_sqrt_pos
+  · -- denominator inequality:
+    -- (1 − M²sin²θ) · √(1 − M²sin²θ) ≤ (1 − κ²sin²θ) · √(1 − κ²sin²θ).
+    have h_inner_le : 1 - M ^ 2 * Real.sin θ ^ 2 ≤ 1 - κ ^ 2 * Real.sin θ ^ 2 := by
+      have hmono : κ ^ 2 * Real.sin θ ^ 2 ≤ M ^ 2 * Real.sin θ ^ 2 :=
+        mul_le_mul_of_nonneg_right hκ hsin2_nn
+      linarith
+    have h_sqrt_le :
+        Real.sqrt (1 - M ^ 2 * Real.sin θ ^ 2)
+          ≤ Real.sqrt (1 - κ ^ 2 * Real.sin θ ^ 2) :=
+      Real.sqrt_le_sqrt h_inner_le
+    exact mul_le_mul h_inner_le h_sqrt_le hM_sqrt_pos.le hκ_pos.le
 
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s07-k-side-bound.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s07-k-side-bound.md
@@ -1,0 +1,117 @@
+# Session 7 — K-side uniform bound (`boundDIntegrandK`) infrastructure
+
+**Date**: 2026-05-08
+**Researcher**: researcher-9
+**Phase**: ACT
+**Outcome**: New §11 added; +1 def, +3 lemmas, +0 axioms, +0 sorries; ~132 lines.
+
+## Goal
+
+Provide the K-side analog of §9 (E-side uniform bound) so that the
+seven-hypothesis discharge of
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+for `ellipticK` has its `h_bound` and `bound_integrable` ingredients
+ready when the (still-pending) K-side algebraic split + integral
+identity is in place. This is one of the four remaining items called out
+in the post-S6 sharpening of the plan ("K-side bound infrastructure
+… ~80 lines").
+
+## Mathematical content
+
+For `0 ≤ M` with `M² < 1` and any `κ` with `κ² ≤ M²`, every `θ ∈ ℝ`:
+
+  |dIntegrandK κ θ|  ≤  M · sin²θ / [(1 − M² sin²θ) · √(1 − M² sin²θ)]
+                    =:  boundDIntegrandK M θ.
+
+The denominator on the M-side is positive (we only use this for
+`M² < 1`), and `boundDIntegrandK M` is continuous in `θ`, hence
+interval-integrable on `[0, π/2]`.
+
+The proof has the same shape as `dIntegrandE_abs_le_bound` (§9):
+
+* numerator monotonicity:  `|κ| · sin²θ ≤ M · sin²θ`  (uses `|κ| ≤ M`,
+  `sin²θ ≥ 0`);
+* denominator antitonicity:  `(1 − M² sin²θ) ≤ (1 − κ² sin²θ)`  (from
+  `κ² ≤ M²`), hence
+  `√(1 − M² sin²θ) ≤ √(1 − κ² sin²θ)`, hence the **product**
+  `(1 − M²sin²θ) · √(1 − M²sin²θ) ≤ (1 − κ²sin²θ) · √(1 − κ²sin²θ)` by
+  `mul_le_mul` (both sides nonneg/positive).
+
+These two inequalities discharge `div_le_div`. The numerator on the
+LHS is `|κ · sin²θ| = |κ| · sin²θ` (one fewer `abs_neg` than §9, since
+`dIntegrandK` has no leading minus sign). The denominator under the `|·|`
+is positive, so `abs_div` followed by `abs_of_pos` removes the absolute
+values.
+
+## Mathlib API surface
+
+Zero new lemmas. Reuses:
+
+* `Continuous.div₀`, `continuous_const`, `continuous_sin`,
+  `Real.continuous_sqrt`, `Continuous.intervalIntegrable`
+  (continuity / integrability of `boundDIntegrandK`);
+* `AmgmInequalityOQ04OQ01.denom_pos`, `AmgmInequalityOQ04OQ01.sqrt_denom_pos`
+  (imported, identical to §9's usage);
+* `Real.sqrt_le_sqrt`, `Real.sqrt_sq_eq_abs`, `Real.sqrt_sq`
+  (the `|κ| ≤ M` reduction from `κ² ≤ M²`);
+* `abs_div`, `abs_mul`, `abs_of_nonneg`, `abs_of_pos`
+  (absolute-value rewrites);
+* `div_le_div`, `mul_le_mul`, `mul_le_mul_of_nonneg_right`,
+  `mul_pos`, `mul_nonneg` (the divisor / divided inequality plumbing).
+
+No new imports.
+
+## File-level deltas
+
+* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`: 697 → 829 lines (+132).
+* `src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json`:
+  `lineCount` 697 → 829; `theoremCount` 33 → 36; `definitionCount` 8 → 9.
+* New definition: `boundDIntegrandK`.
+* New lemmas: `boundDIntegrandK_continuous`, `boundDIntegrandK_integrable`,
+  `dIntegrandK_abs_le_bound`.
+* `legendre_relation` axiom unchanged (1 axiom, 0 sorries).
+
+## Independence from other in-flight S-PRs
+
+This section uses only §10 (K-side chain rule, merged in PR #17373) and
+the imported `denom_pos` / `sqrt_denom_pos` from `AmgmInequalityOQ04OQ01`.
+It is independent of the still-open PR #17371 (`dE_dk` E-side
+assembly) — that PR touches §1/§8/§9 only and adds a new §10 on the
+E-side that is already locally renamed. No conflict.
+
+## Next action (S8)
+
+Of the four remaining items in the post-S6 plan, two are now done
+(S6 K-side chain rule = §10; S7 K-side bound = §11). Open work:
+
+1. **K-side algebraic split + integral identity** (~80–120 lines).
+   This is the *non-pointwise* IBP step on
+   `∫ k sin²θ (1 − k²sin²θ)^{−3/2} dθ`. State:
+
+       ∫₀^{π/2} dIntegrandK k θ dθ
+         = (E(k) − (1 − k²) K(k)) / (k (1 − k²)).
+
+   Substitute `u = sin θ`, `du = cos θ dθ`; IBP with
+   `v = sin θ / √(1 − k² sin²θ)` and `dw = sin θ dθ`. Key Mathlib
+   lemmas: `intervalIntegral.integral_mul_deriv_eq_deriv_mul`
+   (integration by parts), `MeasureTheory.integral_image_eq_integral_abs_deriv_smul`
+   (substitution).
+
+2. **`dE_dk` assembly** (PR #17371; ~30 lines). When that lands,
+   `dK_dk` follows the same template using §10 (chain rule), §11 (this
+   PR, the K-side bound), and the K-side integral identity from item 1.
+
+3. **Wronskian closure** (~50 lines): once both `dE_dk` and `dK_dk`
+   are theorems, `Mathlib.Analysis.Calculus.eq_of_hasDerivAt_eq_zero`
+   shows that `f(k) = E·K' + E'·K − K·K'` is constant on `(0, 1)`;
+   evaluating at `k = 1/√2` (where `f = 2KE − K²`) and using
+   `legendre_relation_symmetric` (§7) pins the constant to `π/2`,
+   discharging the `legendre_relation` axiom.
+
+## Build status
+
+Build pending. The §11 lemmas mirror §9's pattern essentially line for
+line, and §9 was build-verified in PR #17358 (S5). The only new
+denominator structure (`(1 − u) · √(1 − u)` instead of `√(1 − u)`) was
+already introduced in §10 and build-verified in PR #17373 (S6). No new
+imports, no new Mathlib API.

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,10 +1,82 @@
 # Current State
 
-**Phase**: ACT (S6: K-side chain-rule infra landed; S7 remaining for assembly)
-**Since**: 2026-05-08T22:15:00Z
-**Iteration**: 6
+**Phase**: ACT (S7: K-side bound infra landed; S8 = K-side IBP integral identity)
+**Since**: 2026-05-08T23:30:00Z
+**Iteration**: 7
 
-## Current Focus
+## Iteration 7 (2026-05-08T23:30Z, researcher-9): K-side uniform bound
+
+Session 7 (ACT, this PR) added the **K-side uniform bound** infrastructure
+to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (new §11). This is the
+K-analog of §9 (the E-side `boundDIntegrandE` bound, S5/PR #17358) and
+provides the `h_bound` and `bound_integrable` ingredients of
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` for
+the K-side `dK_dk` assembly that follows §10's K-side chain rule
+(S6/PR #17373).
+
+Three lemmas + one definition delivered (parallel to §9):
+
+1. `boundDIntegrandK M θ := M · sin²θ / [(1 − M² sin²θ) · √(1 − M² sin²θ)]`
+   — the dominating bound on `|dIntegrandK κ θ|` over `|κ| ≤ M`.
+   Same `(1 − u) · √(1 − u)` form as `dIntegrandK` (§10).
+2. `boundDIntegrandK_continuous (hM : M² < 1)` — continuity, by the same
+   `Continuous.div₀` template as §9 (with the §10-style product
+   denominator).
+3. `boundDIntegrandK_integrable (hM : M² < 1)` — interval-integrability
+   on `[0, π/2]`, immediate from continuity.
+4. `dIntegrandK_abs_le_bound (hM : M² < 1) (hM_nn : 0 ≤ M) (κ θ : ℝ)`
+   `(hκ : κ² ≤ M²) : |dIntegrandK κ θ| ≤ boundDIntegrandK M θ` — the
+   **uniform bound** itself. Proof: `|κ| ≤ M` from `κ² ≤ M²` via
+   `Real.sqrt`; numerator monotonicity `|κ|·sin²θ ≤ M·sin²θ`;
+   denominator antitonicity packaged as `(1 − M²sin²θ) · √(1 − M²sin²θ)
+   ≤ (1 − κ²sin²θ) · √(1 − κ²sin²θ)` via `mul_le_mul`; conclude with
+   `div_le_div`.
+
+**Mathlib API surface**: zero new lemmas. Reuses `Continuous.div₀`,
+`Real.sqrt_le_sqrt`, `Real.sqrt_sq_eq_abs`, `Real.sqrt_sq`, `abs_div`,
+`abs_mul`, `abs_of_nonneg`, `abs_of_pos`, `div_le_div`, `mul_le_mul`,
+`mul_le_mul_of_nonneg_right`, `mul_pos`, plus the imported `denom_pos`
+and `sqrt_denom_pos` from `AmgmInequalityOQ04OQ01`. No new imports.
+
+**Net new content**: 1 definition, 3 theorems, 0 axioms.
+**Updated total**: 9 definitions, 36 theorems, 1 axiom, 0 sorries,
+829 lines (was 697).
+
+**Independence from open PR #17371 (E-side `dE_dk`)**: §11 uses §10
+(K-side chain rule, merged) and the imported `denom_pos` /
+`sqrt_denom_pos` from OQ04OQ01. It does not touch §1/§8/§9 (the
+E-side machinery PR #17371 modifies). No conflict.
+
+## Sharpening of the Plan for S8+
+
+With §10 (K-side chain rule) and §11 (this PR, K-side bound) in place,
+the remaining work to discharge `legendre_relation` is:
+
+1. **K-side algebraic split + integral identity** (~80–120 lines, S8).
+   *Non-pointwise* — requires integration by parts on
+   `∫ k sin²θ (1 − k²sin²θ)^{−3/2} dθ`. Substitute `u = sin θ`,
+   `du = cos θ dθ`, then IBP with `v = sin θ / √(1 − k² sin²θ)` and
+   `dw = sin θ dθ`. Goal:
+   `∫₀^{π/2} dIntegrandK k θ dθ = (E(k) − (1−k²) K(k)) / (k (1−k²))`.
+   Mathlib API:
+   `intervalIntegral.integral_mul_deriv_eq_deriv_mul` (IBP),
+   `MeasureTheory.integral_image_eq_integral_abs_deriv_smul`
+   (substitution).
+2. **`dE_dk` assembly** — covered by open PR #17371.
+3. **`dK_dk` assembly** (~30 lines, S9). Same template as PR #17371
+   on the K-side: pick `M := (k+1)/2`, discharge the seven hypotheses
+   of `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+   using §10 (chain rule), §11 (this PR, bound), and item 1 (integral
+   identity). Conclude
+   `HasDerivAt ellipticK ((E(k) − (1 − k²) K(k)) / (k (1 − k²))) k`.
+4. **Wronskian closure** (~50 lines, S10). Use
+   `eq_of_hasDerivAt_eq_zero` on `f(k) = E·K' + E'·K − K·K'`, with
+   `dE_dk` (PR #17371), `dK_dk` (S9), and the chain rule for the
+   complementary modulus. Pin the constant at `k = 1/√2` via
+   `legendre_relation_symmetric` (§7) to discharge the
+   `legendre_relation` axiom.
+
+## Current Focus (was S6 — superseded)
 
 Session 6 (ACT, this PR) added the **K-side chain-rule infrastructure**
 for `dK/dk` to `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (new §10).

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,9 +20,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 697,
-    "theoremCount": 33,
-    "definitionCount": 8,
+    "lineCount": 829,
+    "theoremCount": 36,
+    "definitionCount": 9,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
   },
@@ -176,10 +176,10 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 697,
+    "lineCount": 829,
     "axiomCount": 1,
-    "theoremCount": 33,
-    "definitionCount": 8,
+    "theoremCount": 36,
+    "definitionCount": 9,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

S7 (ACT) for `amgm-inequality-oq-04-oq-02` Legendre's relation: adds the
**K-side uniform bound** (§11), the K-analog of §9's `boundDIntegrandE`.
This provides the `h_bound`/`bound_integrable` ingredients of
`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` for
the (future) `dK_dk` assembly.

**Net new content**: 1 def, 3 lemmas, 0 axioms, 0 sorries.

- `boundDIntegrandK M θ := M · sin²θ / [(1 − M²sin²θ) · √(1 − M²sin²θ)]`
- `boundDIntegrandK_continuous (hM : M² < 1)`
- `boundDIntegrandK_integrable (hM : M² < 1)`
- `dIntegrandK_abs_le_bound (hM : M² < 1) (hM_nn : 0 ≤ M) (κ θ : ℝ)
   (hκ : κ² ≤ M²) : |dIntegrandK κ θ| ≤ boundDIntegrandK M θ`

**Proof template** mirrors `dIntegrandE_abs_le_bound` (§9). Numerator
monotonicity `|κ|·sin²θ ≤ M·sin²θ` from `|κ| ≤ M` via `Real.sqrt`;
denominator antitonicity packaged as
`(1 − M²sin²θ) · √(1 − M²sin²θ) ≤ (1 − κ²sin²θ) · √(1 − κ²sin²θ)`
via `mul_le_mul` (both factors monotone, both sides positive);
`div_le_div` discharges the quotient comparison.

**Mathlib API surface**: zero new lemmas. Reuses `Continuous.div₀`,
`Real.sqrt_le_sqrt`, `Real.sqrt_sq_eq_abs`, `Real.sqrt_sq`,
`abs_div`, `abs_mul`, `abs_of_pos`, `div_le_div`, `mul_le_mul`,
`mul_pos`, plus the imported `denom_pos`/`sqrt_denom_pos` from
`AmgmInequalityOQ04OQ01`. No new imports.

## Independence from open PR #17371 (E-side dE_dk assembly)

§11 uses §10 (K-side chain rule, merged in #17373) and the
OQ04OQ01 imports only — no overlap with §1/§8/§9 (the E-side
machinery PR #17371 modifies). Both can land independently.

## File deltas

- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`: 697 → 829 lines (+132).
- `meta.json` (both blocks): lineCount 697 → 829, theoremCount 33 → 36,
  definitionCount 8 → 9. `axiomCount` unchanged at 1
  (`legendre_relation`).

## Build status

**Build pending.** §11 mirrors §9's `Continuous.div₀` and `div_le_div`
template line-for-line (build-verified in PR #17358) with §10's
`(1 − u) · √(1 − u)` denominator structure (build-verified in
PR #17373). Zero new Mathlib API.

## Next action (S8)

K-side algebraic split + integral identity (~80–120 lines) — the
non-pointwise IBP on
`∫ k sin²θ (1 − k²sin²θ)^{−3/2} dθ`. Substitute `u = sin θ`,
`du = cos θ dθ`; IBP with `v = sin θ / √(1 − k²sin²θ)`,
`dw = sin θ dθ`. With S8 + S7 (this PR) + §10 (chain rule, merged)
in place, `dK_dk` follows the same template as the open
`dE_dk` PR #17371.

## Test plan

- [ ] Lean build passes (Docker wrapper)
- [ ] `legendre_relation` axiom unchanged (1 axiom, 0 sorries)
- [ ] Section ordering preserved (§11 follows §10)
- [ ] No new imports

🤖 Researcher-9 session