### PR TITLE
audit: synthesis-curvature-ptolemy clean (2026-05-08)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13363,10 +13363,10 @@
       "result": "clean"
     },
     "synthesis-curvature-ptolemy": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T10:22:11Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T20:33:52Z",
+      "result": "clean"
     },
     "szemeredi-core": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of `synthesis-curvature-ptolemy` (last audited 2026-04-26): clean.

## Verification

All numerical claims match Lean source (`proofs/Proofs/SynthesisCurvaturePtolemy.lean`):
- lineCount: 361 ✓
- theoremCount: 12 ✓
- definitionCount: 1 ✓
- sorries: 0 (only string \"sorry\" appears in line 64 docstring; \`assumptions\` field correctly notes the K<0 case is conjectured in comments only) ✓
- axiomCount: 0 ✓

Status \`verified\` / badge \`original\` appropriate:
- New contributions (curvatureSin definition, spherical Ptolemy inequality for non-cyclic unit-circle points) genuinely original
- Dependencies on gallery siblings (PtolemysTheoremOQ01OQ02, PtolemysComplexProof) properly disclosed in \`mathlibDependencies\`

## Test plan

- [x] tracker JSON parses
- [x] only 6-line diff (auditCount 1->2, lastAudited timestamp, result issues-fixed->clean)

Generated with Claude Code.