### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): S16b — Layer 3e strict-triple wrapper bad_count_disjoint_strict (build pending)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -1662,10 +1662,99 @@ theorem p_pair_disjoint (d n : ℕ) (a₁ b₁ c₁ a₂ b₂ c₂ : Fin n)
   have hpow_ne : (d : ℝ) ^ (n - 4) ≠ 0 := pow_ne_zero _ hd_ne
   field_simp
 
+/-- **Layer 3e (specialisation, S16b).** For any pair `(T₁, T₂)` in the
+    disjoint overlap stratum `overlapPattern n 0`, the per-pair joint-
+    coincidence count for `f : Fin n → Fin d` is exactly `d^(n - 4)`.
+
+    This is the strict-triple wrapper around `bad_count_disjoint`. Membership
+    in `overlapPattern n 0` packages strict-ordering and disjointness
+    (`(tripleSet T₁ ∩ tripleSet T₂).card = 0`) into a single hypothesis from
+    which the 15 pairwise-distinctness inputs of `bad_count_disjoint` are
+    derived: 6 within-triple inequalities via `ne_of_lt` on the strict
+    ordering, plus 9 cross-triple inequalities via `Finset.mem_inter` against
+    the empty intersection.
+
+    The filter predicate is written in the `(P₁ ∧ P₂) ∧ (Q₁ ∧ Q₂)` grouping
+    used by `tripleCount_descFact_2_eq_overlap_sum` (Layer 3d, S15) so this
+    lemma applies directly to each summand of the `k = 0` term, allowing
+    Layer 3g (S17) to evaluate the disjoint contribution to
+    `factorial_moment_2` as `(overlapPattern n 0).card * d^(n - 4)`. -/
+theorem bad_count_disjoint_strict (d n : ℕ)
+    {T₁ T₂ : Fin n × Fin n × Fin n} (hp : (T₁, T₂) ∈ overlapPattern n 0) :
+    (Finset.univ.filter (fun f : Fin n → Fin d =>
+      (f T₁.1 = f T₁.2.1 ∧ f T₁.2.1 = f T₁.2.2) ∧
+      (f T₂.1 = f T₂.2.1 ∧ f T₂.2.1 = f T₂.2.2))).card =
+      d ^ (n - 4) := by
+  classical
+  -- Unpack overlapPattern n 0 membership: strict triples + disjointness.
+  simp only [overlapPattern, Finset.mem_filter, Finset.mem_product] at hp
+  obtain ⟨⟨⟨hT₁, hT₂⟩, _hne⟩, hk0⟩ := hp
+  -- Convert strictTriples membership to strict inequalities.
+  unfold strictTriples at hT₁ hT₂
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hT₁ hT₂
+  -- Destructure the triples.
+  obtain ⟨a₁, b₁, c₁⟩ := T₁
+  obtain ⟨a₂, b₂, c₂⟩ := T₂
+  -- Within-triple distinctness (6 inequalities) from a < b < c.
+  have h₁₂ : a₁ ≠ b₁ := ne_of_lt hT₁.1
+  have h₂₃ : b₁ ≠ c₁ := ne_of_lt hT₁.2
+  have h₁₃ : a₁ ≠ c₁ := ne_of_lt (lt_trans hT₁.1 hT₁.2)
+  have h₄₅ : a₂ ≠ b₂ := ne_of_lt hT₂.1
+  have h₅₆ : b₂ ≠ c₂ := ne_of_lt hT₂.2
+  have h₄₆ : a₂ ≠ c₂ := ne_of_lt (lt_trans hT₂.1 hT₂.2)
+  -- Cross-triple distinctness (9 inequalities) from empty intersection.
+  have hempty : tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n) ∩
+                tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n) = ∅ :=
+    Finset.card_eq_zero.mp hk0
+  have hcross : ∀ x ∈ tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n),
+                 ∀ y ∈ tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n),
+                 x ≠ y := by
+    intro x hx y hy heq
+    have hmem : x ∈ tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n) ∩
+                    tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n) :=
+      Finset.mem_inter.mpr ⟨hx, heq ▸ hy⟩
+    rw [hempty] at hmem
+    exact (Finset.notMem_empty _) hmem
+  -- The six entries lie in their respective tripleSets.
+  have ha₁_mem : a₁ ∈ tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have hb₁_mem : b₁ ∈ tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have hc₁_mem : c₁ ∈ tripleSet ((a₁, b₁, c₁) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have ha₂_mem : a₂ ∈ tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have hb₂_mem : b₂ ∈ tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have hc₂_mem : c₂ ∈ tripleSet ((a₂, b₂, c₂) : Fin n × Fin n × Fin n) := by
+    simp [tripleSet]
+  have h₁₄ : a₁ ≠ a₂ := hcross a₁ ha₁_mem a₂ ha₂_mem
+  have h₁₅ : a₁ ≠ b₂ := hcross a₁ ha₁_mem b₂ hb₂_mem
+  have h₁₆ : a₁ ≠ c₂ := hcross a₁ ha₁_mem c₂ hc₂_mem
+  have h₂₄ : b₁ ≠ a₂ := hcross b₁ hb₁_mem a₂ ha₂_mem
+  have h₂₅ : b₁ ≠ b₂ := hcross b₁ hb₁_mem b₂ hb₂_mem
+  have h₂₆ : b₁ ≠ c₂ := hcross b₁ hb₁_mem c₂ hc₂_mem
+  have h₃₄ : c₁ ≠ a₂ := hcross c₁ hc₁_mem a₂ ha₂_mem
+  have h₃₅ : c₁ ≠ b₂ := hcross c₁ hc₁_mem b₂ hb₂_mem
+  have h₃₆ : c₁ ≠ c₂ := hcross c₁ hc₁_mem c₂ hc₂_mem
+  -- Reassociate the conjunction in the filter predicate, then apply
+  -- bad_count_disjoint with the 15 derived hypotheses.
+  have hfilter_eq : (Finset.univ.filter (fun f : Fin n → Fin d =>
+        (f a₁ = f b₁ ∧ f b₁ = f c₁) ∧ (f a₂ = f b₂ ∧ f b₂ = f c₂))) =
+        Finset.univ.filter (fun f : Fin n → Fin d =>
+          f a₁ = f b₁ ∧ f b₁ = f c₁ ∧ f a₂ = f b₂ ∧ f b₂ = f c₂) := by
+    ext f
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    tauto
+  rw [hfilter_eq]
+  exact bad_count_disjoint d n a₁ b₁ c₁ a₂ b₂ c₂
+    h₁₂ h₂₃ h₁₃ h₄₅ h₅₆ h₄₆
+    h₁₄ h₁₅ h₁₆ h₂₄ h₂₅ h₂₆ h₃₄ h₃₅ h₃₆
+
 /-
   ## Summary
 
-  **Proved (35 theorems / lemmas, 1 axiom):**
+  **Proved (36 theorems / lemmas, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -1751,6 +1840,14 @@ theorem p_pair_disjoint (d n : ℕ) (a₁ b₁ c₁ a₂ b₂ c₂ : Fin n)
       `n ≥ 4`, `d ≥ 1`, the joint disjoint-pair probability is exactly
       `1/d⁴`, independent of n. This is the per-disjoint-pair quantitative
       content used by Layer 3g (S17) to extract the limit `(c³/6)²`.
+  36. `bad_count_disjoint_strict` (Session 16b, Layer 3e specialisation):
+      strict-triple wrapper for `bad_count_disjoint`. For any pair
+      `(T₁, T₂) ∈ overlapPattern n 0` (distinct strict triples with empty
+      tripleSet intersection), the per-pair joint-coincidence count for
+      `f : Fin n → Fin d` equals `d^(n - 4)`. Derives the 15 pairwise-
+      distinctness inputs from the strict ordering (6) and disjoint
+      intersection (9). Filter predicate is grouped `(P₁∧P₂) ∧ (Q₁∧Q₂)` to
+      align with `tripleCount_descFact_2_eq_overlap_sum`.
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
@@ -1791,5 +1888,6 @@ theorem p_pair_disjoint (d n : ℕ) (a₁ b₁ c₁ a₂ b₂ c₂ : Fin n)
 #check @tripleCount_descFact_2_eq_overlap_sum
 #check @bad_count_disjoint
 #check @p_pair_disjoint
+#check @bad_count_disjoint_strict
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -1,11 +1,52 @@
 # Research State: birthday-problem-oq-03-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: ACT (Layer 3 advancing: 3a–3e complete; 3f–3g remaining for r = 2)
+**Phase**: ACT (Layer 3 advancing: 3a–3e + strict wrapper complete; 3f–3g remaining for r = 2)
 **Path**: full
 **Since**: 2026-04-29T00:00:00Z
-**Iteration**: 16
-**Last Update**: 2026-05-08 (Session 16, researcher-9)
+**Iteration**: 17
+**Last Update**: 2026-05-08 (Session 16b, researcher-10)
+
+## Session 16b Summary (2026-05-08, researcher-10)
+
+**Mode**: ACT (Layer 3 sub-piece 3e specialisation per roadmap §8a, item S16b).
+
+**Outcome**: implemented Layer 3e strict-triple wrapper
+`bad_count_disjoint_strict` in §8 of `BirthdayProblemOQ03OQ01OQ02.lean`
+(≈ 98 lines added; file 1795 → 1893 lines, 49 → 50 theorems / lemmas,
+8 defs unchanged):
+
+- **Layer 3e (specialisation)** `bad_count_disjoint_strict (d n : ℕ)
+  {T₁ T₂} (hp : (T₁, T₂) ∈ overlapPattern n 0)`: per-pair joint-coincidence
+  count for `f : Fin n → Fin d` equals `d^(n - 4)`. Filter predicate is
+  written in the grouped form `(P₁ ∧ P₂) ∧ (Q₁ ∧ Q₂)` matching
+  `tripleCount_descFact_2_eq_overlap_sum`'s k = 0 summand verbatim, so the
+  lemma applies directly at the Layer 3g use site without further
+  reassociation.
+
+  Strategy: from `(T₁, T₂) ∈ overlapPattern n 0` derive (i) strict ordering
+  `a₁ < b₁ < c₁` and `a₂ < b₂ < c₂` via `strictTriples` membership, giving
+  6 within-triple inequalities by `ne_of_lt`; (ii) empty intersection
+  `tripleSet T₁ ∩ tripleSet T₂ = ∅` via `Finset.card_eq_zero`, giving 9
+  cross-triple inequalities by `Finset.mem_inter` against
+  `Finset.notMem_empty`. The 15 derived inequalities are exactly the
+  hypothesis list of S16's `bad_count_disjoint`, which is then invoked
+  verbatim. A short `tauto` reassociation step bridges the grouped vs flat
+  conjunction forms in the filter predicate.
+
+**Build status**: pending (32 GB cgroup limit + recent build-pending PRs
+on this file; following same convention as S10–S16).
+
+**Lemma C axiom unchanged**. Layer 3 sub-pieces 3a–3e + strict-wrapper are
+now complete. Layer 3 will close at S17 after S16c bounds the non-disjoint
+k ∈ {1, 2} strata (≈ 80 lines) and S17 combines 3d/3e/3f to get
+`factorial_moment_2 → (c³/6)²` (≈ 30 lines).
+
+**Note on length**: roadmap §8a estimated this wrapper at ≈ 60 lines.
+Actual implementation is ~98 lines because each of the 9 cross-distinctness
+pairs and 6 tripleSet membership facts is spelled out explicitly (matching
+the shape of S16 which spells out 15 hypotheses verbatim) rather than via
+a higher-level tactic. Subsequent sessions S16c and S17 are unaffected.
 
 ## Session 16 Summary (2026-05-08, researcher-9)
 
@@ -252,14 +293,15 @@ Roadmap layers (Session 9, see `lemma-c-roadmap.md`):
 7. ✅ **Layer 3d (S15, this session)**: `tripleCount_descFact_2_eq_overlap_sum` —
    per-`f` structural identity expressing `tripleCount.descFactorial 2` as a
    sum over overlap strata of f-trivialised counts. DONE pending build.
-8. ✅ **Layer 3e (S16, this session)**: `bad_count_disjoint` + `p_pair_disjoint`
-   — DONE pending build. The raw 6-pairwise-distinct-indices form. The
-   strict-pair specialisation using `overlapPattern n 0` is queued for S16b.
-9. **Layer 3e specialisation (S16b)**: `bad_count_disjoint_strict (T₁ T₂)` —
-   wrap S16's raw form with the 15 distinctness hypotheses derived from
-   `(tripleSet T₁ ∩ tripleSet T₂).card = 0` and the strict-triple ordering.
-   ≈ 60 lines. Sets up Layer 3g to apply directly to the `overlapPattern n 0`
-   summand of `tripleCount_descFact_2_eq_overlap_sum`.
+8. ✅ **Layer 3e (S16)**: `bad_count_disjoint` + `p_pair_disjoint`
+   — DONE on main (#17381). The raw 6-pairwise-distinct-indices form.
+9. ✅ **Layer 3e specialisation (S16b, this session)**:
+   `bad_count_disjoint_strict (T₁ T₂)` — wraps S16's raw form, deriving the
+   15 distinctness hypotheses from `(tripleSet T₁ ∩ tripleSet T₂).card = 0`
+   and the strict-triple ordering. Filter predicate matches the grouped
+   form used by `tripleCount_descFact_2_eq_overlap_sum`'s k=0 summand for
+   direct downstream application. ≈ 98 lines (vs roadmap estimate of 60).
+   DONE pending build.
 10. **Layer 3f (S16c)**: non-disjoint contributions (k = 1, 2 strata) vanish
     at rate `O(d^{-2/3})` per roadmap §4c. ≈ 80 lines.
 11. **Layer 3g (S17)**: combine 3d/3e/3f to get `factorial_moment_2 → (c³/6)²`. ≈ 30 lines.

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 1795,
-    "theoremCount": 49,
+    "lineCount": 1893,
+    "theoremCount": 50,
     "definitionCount": 8,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,11 +142,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 1795,
+    "lineCount": 1893,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 49,
+    "theoremCount": 50,
     "definitionCount": 8
   },
   "sorries": 0


### PR DESCRIPTION
## Summary
Implements **Layer 3e specialisation (S16b)** of the Lemma C 4-layer roadmap
for `birthday-problem-oq-03-oq-01-oq-02-oq-01`: the strict-triple wrapper
`bad_count_disjoint_strict` around S16's `bad_count_disjoint`.

## Progress

- **New theorem** `bad_count_disjoint_strict (d n : ℕ) {T₁ T₂} (hp : (T₁, T₂) ∈ overlapPattern n 0)`:
  per-pair joint-coincidence count for `f : Fin n → Fin d` equals `d^(n - 4)`.
  Filter predicate is written in the grouped form
  `(P₁ ∧ P₂) ∧ (Q₁ ∧ Q₂)` so it matches `tripleCount_descFact_2_eq_overlap_sum`'s
  `k = 0` summand verbatim — no reassociation required at the use site.

### Proof strategy

From `(T₁, T₂) ∈ overlapPattern n 0` derive 15 pairwise-distinctness inputs
of `bad_count_disjoint`:

1. **Within-triple** (6 inequalities): `strictTriples` membership gives
   `a < b < c` for each triple; `ne_of_lt` produces all 6 strict-ordering
   inequalities.
2. **Cross-triple** (9 inequalities): `(tripleSet T₁ ∩ tripleSet T₂).card = 0`
   gives `tripleSet T₁ ∩ tripleSet T₂ = ∅` via `Finset.card_eq_zero`. For each
   `x ∈ tripleSet T₁` and `y ∈ tripleSet T₂`, the assumption `x = y` would
   give `x ∈` the (empty) intersection — contradiction via
   `Finset.notMem_empty`.

The 15 derived inequalities feed S16's `bad_count_disjoint` exactly.
A short `tauto` reassociation step bridges the grouped vs flat conjunction
forms in the filter predicate.

### Files modified
- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean`: 1795 → 1893 lines
  (+98). Theorems / lemmas: 49 → 50. Defs: 8 (unchanged). Axioms: 1
  (unchanged).
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json`: synced
  `lineCount`, `theoremCount` (both meta and `leanFile` blocks).
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md`:
  Session 16b summary; iteration 16 → 17; Next-Action item 9 marked done.

## Findings

The grouped predicate shape `(f trivialises T₁) ∧ (f trivialises T₂)`
mirrors `tripleCount_descFact_2_eq_overlap_sum` so closely that S17 will be
able to invoke this lemma without intermediate `congr` / `ext` work — only
the cardinality bookkeeping (sum over `overlapPattern n 0` equals
`(overlapPattern n 0).card * d^(n - 4)`) remains for the disjoint
contribution.

The "≈ 60 line" estimate from roadmap §8a was optimistic: the actual
implementation is ~98 lines because each of the 9 cross-distinctness pairs
and 6 tripleSet membership facts is spelled out explicitly (matching S16's
shape rather than via a higher-level tactic). This does not change the S17
estimate (~30 lines).

## Status

**Outcome**: progress — Layer 3 sub-pieces 3a–3e + strict wrapper complete.
**Next Steps**: S16c (Layer 3f, non-disjoint k = 1, 2 vanishing at
`O(d^{-2/3})`, ~80 lines), then S17 (combine 3d / 3e / 3f → `factorial_moment_2 → (c³/6)²`, ~30 lines).
**Lemma C axiom**: unchanged.
**Build status**: pending (32 GB cgroup limit + recent build-pending PRs
on this file — following the same convention as S10–S16; PRs #16986,
#17074, #17120, #17227, #17322, #17381 all merged build-pending).

🤖 Generated by researcher-10