### PR TITLE
Enrich ballot-problem-oq-02-oq-02: add originalContributions

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -29,6 +29,14 @@
       "Mathlib.Topology.Order.IntermediateValue",
       "Mathlib.Order.ConditionallyCompleteLattice.Basic",
       "Mathlib.Tactic"
+    ],
+    "originalContributions": [
+      "Eliminates the parent file's `firstPassageTime_eq_maxEvent` axiom by deriving the conditional biconditional `fpt_le_iff_maxEvent` (under hitting-set nonemptiness) from `path_continuous` alone — no axioms in this file or its imports beyond Mathlib's standard foundations.",
+      "Surfaces the `Real.sInf_empty = 0` (rather than $+\\infty$) convention as a one-line lemma `csInf_empty_eq_zero`, making the parent axiom's hidden nonemptiness hypothesis impossible to overlook. The constant path $B \\equiv 0$ with $a = 1$, $T = 1$ is an explicit counter-witness to the parent's unconditional set equality.",
+      "Provides a reusable Lean template for first-hitting-time arguments in stochastic analysis: (i) `hittingSet_isClosed` via continuity + `isClosed_Ici.preimage`; (ii) `hittingSet_bddBelow` via the $0 \\le t$ conjunct; (iii) `hittingSet_csInf_mem` via Mathlib's `IsClosed.csInf_mem`; (iv) IVT-based nonemptiness witness via `isPreconnected_Icc.intermediate_value₂`. The four-step recipe applies verbatim to any continuous process and any closed threshold set.",
+      "Bundles `path_continuous : ∀ ω, Continuous (fun t => W t ω)` as a *structure field* of `BrownianMotion` (rather than a free `variable` or a `[Fact ...]` instance), so every theorem signature receives the continuity hypothesis automatically via `bm.path_continuous` — closer to the mathematician's notion of 'a Brownian motion is a value-with-property'.",
+      "Capstone corollary `fpt_le_T_of_crossing` discharges the nonemptiness side condition automatically for the most natural Brownian use case (paths satisfying $B(0,\\omega) < a \\le B(T,\\omega)$), so end users of the level-crossing identity do not have to manually verify nonemptiness in practice.",
+      "Methodological pattern of *axiom elimination by hypothesis surfacing*: rather than proving a parent axiom verbatim, identify the implicit hypothesis the axiom was assuming, prove the conditional theorem, and supply a natural side condition that discharges the hypothesis. Applies broadly to other axiomatized convenience identities in measure theory and stochastic analysis."
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

Enrichment pass for `ballot-problem-oq-02-oq-02` (First Passage Time Characterization via csInf Theory). Pre-pass quality 98/100; sections were already well-handled by #17348 (overlap fix + mathContext), and the `keyInsights`/`mainTheorems`/`prerequisites` arrays are dense. The remaining structural gap was the missing **`originalContributions`** array in the `meta` block — most enriched entries have this populated, and it feeds the gallery's 'What's novel here?' surface.

## What changes

Added 6 bullets to `meta.originalContributions` articulating the entry's distinctive claims:

1. **Axiom elimination from `path_continuous` alone** — the parent file's `firstPassageTime_eq_maxEvent` axiom is replaced by the conditional biconditional `fpt_le_iff_maxEvent` under hitting-set nonemptiness.
2. **`Real.sInf_empty = 0` surfaced as a one-line lemma** with the constant path $B \\equiv 0, a = 1, T = 1$ as an explicit counter-witness to the parent's unconditional set equality.
3. **Reusable four-step Lean template** for first-hitting-time arguments: closure of hitting set → bddBelow → `IsClosed.csInf_mem` → IVT-based nonemptiness.
4. **Bundling `path_continuous` as a structure field** of `BrownianMotion` (vs free variable or `[Fact ...]` instance), so theorems receive the continuity hypothesis automatically via `bm.path_continuous`.
5. **Capstone corollary `fpt_le_T_of_crossing`** discharges the nonemptiness side condition automatically for crossing paths ($B(0,\\omega) < a \\le B(T,\\omega)$).
6. **Methodological pattern**: 'axiom elimination by hypothesis surfacing' as a recipe applicable beyond this file (any axiomatized convenience identity in measure theory / stochastic analysis).

Each bullet is grounded in the existing `keyInsights` / `mainTheorems` content but reframed as a contribution claim suitable for the originalContributions surface.

## What does NOT change

- `status` (`verified`), `badge` (`original`), `axiomCount` (0), `sorries` (0), `theoremCount` (11), `definitionCount` (2), `lineCount` (185)
- `sections` array (already correct after #17348)
- `annotations.json` — untouched
- `overview` (historicalContext, problemStatement, proofStrategy, keyInsights, prerequisites)
- `mainTheorems` (9 entries), `references` (7), `crossReferences` (3), `conclusion`

## Test plan

- [x] JSON round-trip via `python3 json.load` passes
- [x] `tsx scripts/annotations/build.ts` reports no errors for `ballot-problem-oq-02-oq-02`
- [x] All 6 originalContributions are non-empty strings
- [x] Branch is unique (`enrich/ballot-problem-oq-02-oq-02-1778273242`) and rebased on fresh `origin/main`
- [x] Diff is exactly 1 file, +8 / 0, scoped to `src/data/proofs/ballot-problem-oq-02-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)