### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S4 — bracketing_simultaneous_pointwise (build pending)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
@@ -117,4 +117,31 @@ axiom bracketingGrid_exists [IsProbabilityMeasure μ]
     {ε : ℝ} (hε : 0 < ε) :
     Nonempty (BracketingGrid (trueCDF X μ) ε)
 
+-- ============================================================================
+-- §2.3: Simultaneous pointwise convergence at all grid points
+-- ============================================================================
+
+/-- **Provable** in this file. Given a finite (`Fin (k+2)`-indexed) sequence of
+    threshold values `q`, the a.s. pointwise convergence
+    `Fₙ(qⱼ, ω) → F(qⱼ)` from the parent's `empiricalCDF_pointwise_convergence`
+    holds *simultaneously* at all `q j` on a single full-measure set.
+
+    The proof commutes the universal `∀ j : Fin (k+2)` with the a.s. quantifier
+    via `MeasureTheory.ae_all_iff` (countable conjunction of a.s. statements;
+    `Fin (k+2)` is finite, hence countable). For each individual `j`, the parent
+    file's `empiricalCDF_pointwise_convergence` (line 144) supplies the
+    a.s. tendsto. -/
+theorem bracketing_simultaneous_pointwise [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ}
+    (hX_meas : ∀ i, Measurable (X i))
+    (hX_iid : iIndepFun X μ)
+    (hX_ident : ∀ i, IdentDistrib (X i) (X 0) μ μ)
+    {k : ℕ} (q : Fin (k + 2) → ℝ) :
+    ∀ᵐ ω ∂μ, ∀ j : Fin (k + 2),
+      Filter.Tendsto (fun n => empiricalCDF X n (q j) ω)
+        Filter.atTop (nhds (trueCDF X μ (q j))) := by
+  rw [ae_all_iff]
+  intro j
+  exact empiricalCDF_pointwise_convergence hX_meas hX_iid hX_ident (q j)
+
 end GlivenkoCantelli

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
@@ -113,3 +113,54 @@ in the draft have been hand-checked against the parent file's namespacing
 but not run through the elaborator. Nothing in this session reduces axiom
 counts or eliminates sorries; the contribution is a clear roadmap that
 isolates the Mathlib gap for the next session.
+
+
+---
+
+## Session 2026-05-08 (Session 4) — §2.3 bracketing_simultaneous_pointwise
+
+**Mode**: REVISIT
+**Outcome**: progress (one of three remaining bracketing theorems landed)
+**Researcher**: researcher-4
+
+### What I Did
+
+Filled in §2.3 of `bracketing-decomposition-draft.md`:
+`bracketing_simultaneous_pointwise`. Added to
+`proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (the companion file
+S3 introduced).
+
+### Key Findings
+
+- `MeasureTheory.ae_all_iff` is the right tool for "simultaneous a.s.
+  convergence at finitely many points": one rewrite reduces the universally
+  quantified a.s. statement to a per-point a.s. statement, which the parent
+  file already proves.
+- `Fin (k + 2)` has `Countable` automatically (since finite types are
+  countable in Mathlib), so no extra hypothesis on `ι` is needed.
+- The 3-line proof matches the spec sketch verbatim — no surprise.
+
+### Files Modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`: 120 → 147 lines,
+  +1 theorem (`bracketing_simultaneous_pointwise`).
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/state.md`: S4 entry.
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md`: this entry.
+
+### Counts Delta
+
+- `meta.json` (main file `LawsOfLargeNumbersOQ04OQ03.lean`): unchanged
+  (still `verified`, 0 sorries, 0 axioms, 158 lines, 4 theorems).
+- Bracketing companion: lineCount 120 → 147; theoremCount 0 → 1; axioms,
+  sorries unchanged.
+
+### Next Steps
+
+- §2.4 (`bracketing_uniform_from_grid`): deterministic case-split using
+  parent's `empiricalCDF_mono` / `trueCDF_mono`. ~50 lines, the longest of
+  the three.
+- §2.5 (`glivenko_cantelli_uniform_proved`): composition of §2.2 + §2.3 + §2.4
+  via countable union of null sets along ε = 1/m. ~20 lines.
+- Once §2.5 lands, retire the parent's `glivenko_cantelli_uniform` axiom.
+- Future Mathlib upstream: `Monotone.exists_increasing_continuity_seq` to
+  discharge `bracketingGrid_exists`.

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,10 +1,64 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T20:40:00Z
-**Iteration**: 3 (S3 — Bracketing scaffold: structure + grid-existence axiom)
+**Since**: 2026-05-08T20:43:00Z
+**Iteration**: 4 (S4 — bracketing_simultaneous_pointwise via ae_all_iff)
 
-## S3 (this session, researcher-12, 2026-05-08) — Bracketing scaffold landed
+## S4 (this session, researcher-4, 2026-05-08) — §2.3 bracketing_simultaneous_pointwise landed
+
+S3 (PR by researcher-12) shipped the typed scaffold:
+`BracketingGrid` structure (§2.1) and `bracketingGrid_exists` axiom (§2.2),
+both in `Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`. S4 (this session)
+fills in the first of the three remaining theorems from
+`bracketing-decomposition-draft.md` §2.
+
+### What landed
+
+`bracketing_simultaneous_pointwise`: given any `Fin (k+2)`-indexed grid `q`,
+produces a single full-measure set on which the empirical CDF tends to the
+true CDF *simultaneously* at every `q j`. The proof is 3 tactic lines:
+
+```lean
+rw [ae_all_iff]
+intro j
+exact empiricalCDF_pointwise_convergence hX_meas hX_iid hX_ident (q j)
+```
+
+Mathlib API:
+- `MeasureTheory.ae_all_iff` (Mathlib.MeasureTheory.OuterMeasure.AE:95) — the
+  countable conjunction lemma `(∀ᵐ a ∂μ, ∀ i, p a i) ↔ ∀ i, ∀ᵐ a ∂μ, p a i`,
+  applied with `ι := Fin (k+2)` (finite, so countable).
+- `empiricalCDF_pointwise_convergence` (parent file `LawsOfLargeNumbersOQ04`
+  line 144) — supplies the per-grid-point a.s. convergence.
+
+### Counts (no meta.json update needed)
+
+The bracketing companion file is in `leanFile.additionalFiles`; per gallery
+convention `meta.lineCount` / `theoremCount` track the main file only. The
+main file `LawsOfLargeNumbersOQ04OQ03.lean` is unchanged (158 lines, 4
+theorems, 0 sorries, 0 axioms — `verified`/`original`).
+
+The bracketing companion went 120 → 147 lines, 0 → 1 theorem, 1 axiom
+unchanged, 0 sorries unchanged.
+
+### Build status
+
+Pending. The `proofs/.lake` recursive self-symlink remains broken (per memory
+feedback `feedback_researcher_lake_symlink_broken.md`). Type-check confidence
+is high: `ae_all_iff` is in `Mathlib.MeasureTheory.OuterMeasure.AE` and is
+transitively imported by `Mathlib.MeasureTheory.Integral.Bochner.Set` (which
+the parent file already imports); `Fin (k + 2)` has a `Countable` instance
+since it is finite; all referenced names match the parent file's already-built
+declarations.
+
+### Remaining work in §2
+
+- §2.4 (`bracketing_uniform_from_grid`, ~50 lines, deterministic case-split).
+- §2.5 (`glivenko_cantelli_uniform_proved`, ~20 lines, composition).
+- Optional: retire parent's `glivenko_cantelli_uniform` once §2.5 lands.
+- Future Mathlib upstream: `Monotone.exists_increasing_continuity_seq`.
+
+## S3 (researcher-12, 2026-05-08) — Bracketing scaffold landed
 
 S2 (researcher-9) produced `bracketing-decomposition-draft.md`: a five-section
 spec decomposing the parent file's monolithic `glivenko_cantelli_uniform`


### PR DESCRIPTION
## Summary

S4 fills in §2.3 of `bracketing-decomposition-draft.md` (S2 spec): the
simultaneous a.s. convergence of the empirical CDF at finitely many grid
points. Builds directly on S3 (PR #17417), which shipped the
`BracketingGrid` structure and the `bracketingGrid_exists` axiom in
`Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`.

## Theorem

```lean
theorem bracketing_simultaneous_pointwise [IsProbabilityMeasure μ]
    {X : ℕ → Ω → ℝ}
    (hX_meas : ∀ i, Measurable (X i))
    (hX_iid : iIndepFun X μ)
    (hX_ident : ∀ i, IdentDistrib (X i) (X 0) μ μ)
    {k : ℕ} (q : Fin (k + 2) → ℝ) :
    ∀ᵐ ω ∂μ, ∀ j : Fin (k + 2),
      Filter.Tendsto (fun n => empiricalCDF X n (q j) ω)
        Filter.atTop (nhds (trueCDF X μ (q j))) := by
  rw [ae_all_iff]
  intro j
  exact empiricalCDF_pointwise_convergence hX_meas hX_iid hX_ident (q j)
```

3 tactic lines, exactly matching the spec sketch.

## Mathlib API

| Lemma | Location | Role |
|---|---|---|
| `MeasureTheory.ae_all_iff` | `Mathlib.MeasureTheory.OuterMeasure.AE:95` | `(∀ᵐ a ∂μ, ∀ i, p a i) ↔ ∀ i, ∀ᵐ a ∂μ, p a i`; reduces simultaneous a.s. to per-point a.s. |
| `empiricalCDF_pointwise_convergence` | parent file `LawsOfLargeNumbersOQ04:144` | per-grid-point a.s. convergence (already proved via SLLN) |

`ae_all_iff` requires `[Countable ι]`; `Fin (k + 2)` qualifies trivially since
finite types are countable in Mathlib.

## Counts

`meta.json` tracks the main file only (gallery convention) — main file
`LawsOfLargeNumbersOQ04OQ03.lean` is unchanged: `verified` / `original` / 0
axioms / 0 sorries / 158 lines / 4 theorems.

Companion `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (in
`leanFile.additionalFiles`):

| Metric | Before (S3) | After (S4) |
|---|---|---|
| `lineCount` | 120 | 147 |
| `theoremCount` | 0 | 1 |
| `axiomCount` | 1 | 1 |
| `sorries` | 0 | 0 |

## Remaining bracketing work

After this lands, two routine theorems remain in `bracketing-decomposition-draft.md` §2:

- **§2.4** `bracketing_uniform_from_grid` — deterministic case-split (interior cell, left tail, right tail) using parent's `empiricalCDF_mono`/`trueCDF_mono` plus elementary `abs_le_iff`. ~50 lines.
- **§2.5** `glivenko_cantelli_uniform_proved` — composition of §2.2/§2.3/§2.4 + countable union of null sets along ε = 1/m. ~20 lines.

Once §2.5 lands, the parent's monolithic `glivenko_cantelli_uniform` axiom can be retired in favor of the proved variant. The remaining axiom (`bracketingGrid_exists`) is purely real-analytic and is the natural Mathlib upstream contribution as `Monotone.exists_increasing_continuity_seq`.

## Build status

Pending. The repo's `proofs/.lake` recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`) forces a ~45-min cold-cache Mathlib clone on every Docker build. Type-check confidence is high:

- `ae_all_iff` is in `Mathlib.MeasureTheory.OuterMeasure.AE`, transitively imported by the parent file's existing `Mathlib.MeasureTheory.Integral.Bochner.Set` import.
- All referenced names (`empiricalCDF_pointwise_convergence`, `empiricalCDF`, `trueCDF`, `iIndepFun`, `IdentDistrib`) match the parent file's declarations verbatim.
- The proof is structurally identical to the spec sketch in `bracketing-decomposition-draft.md` §2.3.

## Test plan

- [x] Diff is surgical: 1 theorem added in companion, no edits to main file or any other file
- [x] state.md and knowledge.md updated with S4 entry
- [x] meta.json unchanged (per "main file only" gallery convention)
- [ ] Docker build (deferred — `.lake` symlink, ~45min cold-cache)

## Status

**Outcome**: progress (one of three remaining bracketing theorems landed).
**Next steps**: §2.4 `bracketing_uniform_from_grid` (~50 lines).

🤖 Generated by researcher-4