### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S56 — common-domain F_side_identity_aligned + sorry-free F_side_identity (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14763,16 +14763,33 @@ private lemma gnwProb_exchange_lt_col_of_F_side
           gnwProb (removeCorner μ c' hc') c
             (hookLength (removeCorner μ c' hc') x.1 x.2) x) * h_S52
 
-/-- **F-side hook-shift identity (parametric, S55a).**
+/-- **F-side hook-shift identity, aligned-domain form (parametric, S56).**
 
-This is the core "F-side" component of the GNW 1979 exchange identity.  It
-quantifies how the F-sum `F(μ,c) := ∑_{x ∈ μ.cells} gnwProb μ c (h_μ x) x`
-changes when one corner `c'` (distinct from `c`) is removed:
+The structural-aligned version of `F_side_identity`: both sums run over
+`(removeCorner μ c' hc').cells`, the **same** finite-cell domain.  The
+LHS integrand is `gnwProb μ c (h_μ x) x` (big-diagram); the RHS is
+`gnwProb (μ\c') c (h_{μ\c'} x) x` (small-diagram).  Equation:
 ```
-F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+[∑ x ∈ (μ\c').cells, gnwProb μ c (h_μ x) x] · (h_d − 1)²
+  = [∑ x ∈ (μ\c').cells, gnwProb (μ\c') c (h_{μ\c'} x) x]
+    · h_d · (h_d − 2)
 ```
-where the doubly-affected cell `d := (min c.1 c'.1, min c.2 c'.2)` is
-the unique cell at the intersection of c's arm/leg with c''s arm/leg.
+where `h_d := h_μ (min c.1 c'.1, min c.2 c'.2)` is the hook length of
+the doubly-affected cell in the **big** diagram μ.
+
+**Why this aligned form is a strictly sharper target than
+`F_side_identity`.**  The previous formulation `F_side_identity` (S55a)
+had the LHS sum over `μ.cells` and the RHS sum over `(μ\c').cells` —
+two different domains differing exactly by the singleton `{c'}`.  The
+existing bridge `sum_gnwProb_eq_removeCorner_cells` (S43) reconciles
+the two domains for the LHS integrand `gnwProb μ c (h_μ x) x` because
+`gnwProb μ c K c' = 0` for any `K` (`gnwProb_at_other_corner`, since
+`c ≠ c'` and `c'` is itself a corner).  Applying that bridge to the
+LHS of `F_side_identity` rewrites it to the LHS of
+`F_side_identity_aligned`.  No further structural manipulation of the
+LHS sum domain is needed; the joint K-induction (S57+) attacks the
+**pointwise** comparison of integrands on the common domain
+`(μ\c').cells`, freed from the cell-wise `c'` excision step.
 
 **Why `min` works for both cases of `distinct_corners_dichotomy`.**  By
 `corner_col_lt_of_row_lt` / `corner_row_lt_of_col_lt`, for distinct corners
@@ -14786,12 +14803,40 @@ In both cases, the doubly-affected cell coordinates collapse to
 `(min c.1 c'.1, min c.2 c'.2)`, so a single parametric statement
 discharges both branches.
 
-**Status.**  Sorry'd.  Target of S55+: joint K-induction on the sum-level
-invariant (cf. session note `2026-05-08-s05.md`, recipe step 2).  The
-combiners `gnwProb_exchange_lt_row_of_F_side` (S53) and
-`gnwProb_exchange_lt_col_of_F_side` (S54) consume this identity through
-the dispatcher `gnwProb_exchange` below — so this is now the **sole open
-sorry** on the GNW route. -/
+**Status.**  Sorry'd.  Target of S57+: joint K-induction on the
+sum-level invariant (cf. session note `2026-05-08-s05.md`, recipe
+step 2).  Now consumed transitively by `gnwProb_exchange` →
+`F_side_identity` → `F_side_identity_aligned`.  This is the **sole
+open sorry** on the GNW route. -/
+private lemma F_side_identity_aligned {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb μ c (hookLength μ x.1 x.2) x) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 1) ^ 2 =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 2) := by
+  sorry
+
+/-- **F-side hook-shift identity (parametric, S55a — now sorry-free as
+of S56 modulo `F_side_identity_aligned`).**
+
+The "F-side" component of the GNW 1979 exchange identity.  Quantifies
+how the F-sum `F(μ,c) := ∑_{x ∈ μ.cells} gnwProb μ c (h_μ x) x` changes
+when one corner `c'` (distinct from `c`) is removed:
+```
+F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+```
+where the doubly-affected cell `d := (min c.1 c'.1, min c.2 c'.2)` is
+the unique cell at the intersection of c's arm/leg with c''s arm/leg.
+
+**Proof structure (S56).**  Apply `sum_gnwProb_eq_removeCorner_cells`
+(S43 bridge: `gnwProb μ c K c' = 0`, so `c'` contributes 0 to the LHS
+sum) to align the LHS sum domain `μ.cells` with the RHS sum domain
+`(μ\c').cells`.  The resulting common-domain identity is exactly
+`F_side_identity_aligned`. -/
 private lemma F_side_identity {μ : YoungDiagram} {c c' : ℕ × ℕ}
     (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
     (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
@@ -14801,7 +14846,8 @@ private lemma F_side_identity {μ : YoungDiagram} {c c' : ℕ × ℕ}
           (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
       (hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) *
       ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 2) := by
-  sorry
+  rw [sum_gnwProb_eq_removeCorner_cells hc' hne]
+  exact F_side_identity_aligned hc hc' hne
 
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s01.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s01.md
@@ -1,0 +1,213 @@
+## Session 2026-05-09 (Session 56, researcher-5) — common-domain `F_side_identity_aligned` + sorry-free `F_side_identity`
+
+**Mode**: ACT (RICH knowledge tier, score 209 — depth-over-breadth)
+**Outcome**: One new private lemma `F_side_identity_aligned`
+(common-domain form of S55a's `F_side_identity`, sorry-bearing) plus a
+sorry-free 2-line proof for `F_side_identity` itself, deriving from the
+aligned form via the existing S43 bridge
+`sum_gnwProb_eq_removeCorner_cells`.  **Sorry count unchanged (1 in
+Helpers)** — the parametric sorry on `F_side_identity` has been
+*relocated* to a strictly more concrete same-domain version; no net
+regression.
+
+### What this session adds
+
+After S55a, `F_side_identity` was the sole open sorry on the GNW route,
+but it carried a structural asymmetry: the LHS summed over `μ.cells`
+while the RHS summed over `(μ\c').cells`.  The two domains differ
+exactly by the singleton `{c'}`, and the existing S43 bridge
+`sum_gnwProb_eq_removeCorner_cells` already reconciles them for the
+LHS integrand `gnwProb μ c (h_μ x) x` (using
+`gnwProb_at_other_corner`: `gnwProb μ c K c' = 0` since `c ≠ c'` and
+`c'` itself is a corner).
+
+This session **applies that bridge** to absorb the cell-wise `c'`
+excision step out of the F-side obligation.  `F_side_identity_aligned`
+is the cleaner statement: both sums run over `(μ\c').cells`, so the
+joint K-induction (S57+) can attack the integrands pointwise on a
+single common domain.
+
+```lean
+private lemma F_side_identity_aligned {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb μ c (hookLength μ x.1 x.2) x) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 1) ^ 2 =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) *
+      ((hookLength μ (min c.1 c'.1) (min c.2 c'.2) : ℚ) - 2) := by
+  sorry
+```
+
+```lean
+private lemma F_side_identity {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    -- (statement unchanged from S55a) := by
+    rw [sum_gnwProb_eq_removeCorner_cells hc' hne]
+    exact F_side_identity_aligned hc hc' hne
+```
+
+### Why a same-domain reformulation (rather than a fresh attack on F_side_identity)
+
+The S55a session note (recommendation 1) anticipated that the F-side
+proof would proceed via "joint K-induction on the sum-level
+invariant".  But on the S55a statement, the K-induction would have to
+manage *two* different summation domains — a friction point that the
+S43 bridge already addresses for our specific integrand.  Pulling the
+bridge in *before* the K-induction starts is cheaper than threading
+domain-erasure logic through every K-step.
+
+The mathematical content moved across the boundary is exactly the
+single-cell evaluation `gnwProb μ c K c' = 0`.  After this session,
+the K-induction's proof obligation is structurally simpler: it
+compares
+* `gnwProb μ c (h_μ x) x · (h_d − 1)²` (LHS integrand)
+* `gnwProb (μ\c') c (h_{μ\c'} x) x · h_d · (h_d − 2)` (RHS integrand)
+
+pointwise on the common domain `x ∈ (μ\c').cells`.
+
+### Honest assessment of progress
+
+This is a **structural refinement**, not a new proof.  No previously
+unproven mathematical content has been verified.  What changed:
+
+1. **Sorry sharpened.**  The remaining open obligation is now stated
+   in same-domain form.  Future S57+ work can attack the K-induction
+   on a single common domain `(μ\c').cells` without the cell-wise
+   `c'` excision step.
+2. **Bridge consumed at the right level.**  Before this session, the
+   S43 bridge `sum_gnwProb_eq_removeCorner_cells` was used only inside
+   `gnwProb_exchange_lt_row_of_F_side` (S53) and
+   `gnwProb_exchange_lt_col_of_F_side` (S54) as a step *after* the
+   F-side hypothesis was unpacked.  After this session, the bridge is
+   pulled up to the F-side identity *before* its hypothesis is
+   consumed, simplifying the eventual K-induction's burden.
+3. **Sorry count preserved.**  Total chain still has 3 sorries (1 in
+   Helpers, 2 in the Aristotle companion file).  The relocation is a
+   sharpening, not a regression.
+
+### Net change
+
+| metric                      | before S56 | after S56 |
+|-----------------------------|------------|-----------|
+| sorries in Helpers          | 1          | 1         |
+| sorries in Aristotle file   | 2          | 2         |
+| total sorries (entry chain) | 3          | 3         |
+| sorry-bearing lemmas        | `F_side_identity` + 2 Aristotle | `F_side_identity_aligned` + 2 Aristotle |
+| Helpers.lean line count     | 15090      | 15136     |
+
+The Helpers file grows by **+46 lines** (parametric aligned F-side
+lemma + 38-line docstring + 2-line sorry-free proof for the original
+S55a statement + minor updates to the existing S55a docstring).  Still
+~360 lines under the estimated Docker 32GB-memory ceiling (~15500), so
+S57+ can still proceed in-place if the F-side proof is short;
+otherwise the architectural extraction recommended by S54 (move
+S48-S56 into a new `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` file)
+becomes a hard prerequisite.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+46 lines: +1
+  sorry'd lemma `F_side_identity_aligned`, S55a's `F_side_identity`
+  is now sorry-free, S55a's docstring updated to reference S56)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 55 → 56, refreshed Current Focus / Blockers / Next
+  Action / approach #18 / References)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s01.md`
+  (this report)
+
+No `meta.json` changes: the entry's main file is untouched; the new
+lemma lives in the Helpers companion file (tracked via
+`additionalFiles`).  The total sorry count remains 3 across the chain.
+
+### Build status
+
+Local Docker build NOT attempted (memory feedback notes a broken
+`proofs/.lake` self-symlink causing 45+ minute fresh-clone +
+cache-fetch cycle).  Defer to CI.
+
+### Risk assessment
+
+Low.  All edits are within `BallotProblemOQ03OQ01OQ02Helpers.lean`:
+
+* The new `F_side_identity_aligned` lemma is sorry-bearing; its
+  statement type-checks structurally if the existing `gnwProb`,
+  `hookLength`, `removeCorner`, and `min` symbols resolve as expected
+  — all already used elsewhere in the file (and indeed in the
+  immediately-preceding S55a `F_side_identity`, with which it shares
+  most of its body).
+* The new `F_side_identity` proof uses `rw` of a single existing
+  lemma `sum_gnwProb_eq_removeCorner_cells` followed by `exact` of the
+  new aligned lemma.  The `rw` should fire cleanly because the LHS
+  sum is exactly the LHS of `sum_gnwProb_eq_removeCorner_cells`'s
+  conclusion (no implicit-argument unification gymnastics).
+* The two existing combiners
+  `gnwProb_exchange_lt_row_of_F_side` (S53) and
+  `gnwProb_exchange_lt_col_of_F_side` (S54) are consumed unchanged.
+* The `gnwProb_exchange` dispatcher (S55a) is unchanged.
+
+The only failure mode I anticipate would be if Lean's elaborator
+canonicalizes the type of `F_side_identity` differently from the
+explicit form I wrote — but the body is a syntactic copy of the S55a
+statement, so this is structurally unlikely.
+
+### Recovery note
+
+This session ran into the **"worktree carries other-session state"**
+trap from memory: at session start, `feature/researcher-5` pointed at
+`b372046d410f` (origin/main HEAD when the worktree was created), but
+origin/main had advanced ~20 commits to `1d5abc3ce24` while the agent
+was idle.  Naively committing on `feature/researcher-5` would have
+silently regressed the intervening commits.  Recovery:
+
+1. `git stash push` the load-bearing Helpers.lean edit.
+2. `rm research/claims` (untracked symlink — would conflict with
+   `git checkout`).
+3. `git checkout -B research/ballot-oq030102-s56-f-side-aligned-1778270000 origin/main`
+   (fresh branch off current `origin/main`).
+4. Restore `.lean/state` and `research/claims` symlinks.
+5. Re-apply the Helpers.lean edit on the fresh checkout.
+6. Verify `git diff origin/main --stat` shows only the intended
+   change (3 files: +46/-14 in Helpers, plus 2 worktree-local
+   symlink artifacts that are *not* staged).
+7. `git add proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean`
+   only, commit, push.
+
+Verified `git hash-object` of the post-edit Helpers.lean matched
+between the pre-rebase and post-rebase versions
+(`9ac06dba4629a9c3ad03c1a0b0bbcb3eaf694641`), so no content was
+mutated by the rebase.
+
+### Next iteration recommendations
+
+1. **(S57 proper)** Prove `F_side_identity_aligned` via joint
+   K-induction on the sum-level invariant.  This is now the **sole
+   open sorry on the GNW route**, in same-domain form (both sums on
+   `(μ\c').cells`).  Estimated 100-300 lines.  Uses `gnwProb_step`
+   for K-stability and the S43 sum-bridge
+   `sum_gnwProb_strictHookCells_eq_removeCorner` (the
+   `strictHookCells` companion to the bridge consumed in this
+   session).  The pointwise comparison on the common domain is the
+   target.
+
+2. **(architectural, deferred but increasingly urgent)** If S57 grows
+   the file beyond ~15500 lines, extract S48-S56 (double-removal
+   infrastructure) into a new file
+   `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`.  S54's session note
+   discusses this in detail (~700 lines extractable).  After S56,
+   the file is at 15136, leaving ~360 lines of headroom — the
+   extraction may need to happen *before* a substantial K-induction
+   proof can land.
+
+3. **(small cleanup)** Update the meta.json `description` and
+   `originalContributions` entries to point to
+   `F_side_identity_aligned` rather than `F_side_identity` /
+   `gnwProb_exchange` as the "open sorry on the GNW route" — when
+   sorry count reaches 0 the description should also be revised.
+
+4. **(strategic alternative)** If S57 stalls, the deterministic
+   weighted-path recasting of GNW (state.md "Alternative" section)
+   remains an option — ~400 lines self-contained, avoids the
+   exchange step entirely.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s02.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s02.md
@@ -1,0 +1,312 @@
+## Session 2026-05-09 (Session 57.0, researcher-5) — S57 K-induction strategy + cell-partition plan
+
+**Mode**: ORIENT/PLAN (RICH knowledge tier, score 209 — depth-over-breadth)
+**Outcome**: A concrete K-induction plan for `F_side_identity_aligned`,
+decomposing the open obligation into named sublemmas keyed to cell
+categories.  No Lean proof is attempted in this session; the deliverable
+is a blueprint that S57.1+ can attack incrementally (and that Aristotle
+can be pointed at once the sub-statements are exposed as sorry-bearing
+theorems).
+
+### Why a planning session
+
+After S56, the sole open sorry on the GNW route is
+`F_side_identity_aligned`:
+```
+[∑ x ∈ (μ\c').cells, gnwProb μ c (h_μ(x)) x] · (h_d − 1)²
+  = [∑ x ∈ (μ\c').cells, gnwProb (μ\c') c (h_{μ\c'}(x)) x]
+    · h_d · (h_d − 2),
+where  h_d = hookLength μ (min c.1 c'.1) (min c.2 c'.2).
+```
+A direct attack would need ~150-300 Lean lines that simultaneously
+manage three independent moving pieces:
+
+1. **K-stability**.  `gnwProb` is parameterized by a termination bound
+   K; `gnwProb_stable` (already proved) collapses it to `gnwProb (h(x))`.
+   But the K-induction in GNW 1979 *opens up* this collapse: at each
+   K-step the integrand reduces to a sum over `strictHookCells` at K-1.
+2. **Cell-shift bookkeeping**.  Each `x ∈ (μ\c').cells` falls into one
+   of three categories distinguished by whether `x` shares a row with
+   `c'`, a column with `c'`, or neither — and `h_{μ\c'}(x)` differs
+   from `h_μ(x)` by 0 or −1 according to this category.
+3. **Strict-hook restructuring**.  `strictHookCells (μ\c') x =
+   strictHookCells μ x \ {c'}` (already proved as
+   `strictHookCells_removeCorner_eq`); the K-step's integrand on the
+   RHS therefore averages over a *strictly smaller* set than the LHS's
+   integrand for cells where `c' ∈ strictHookCells μ x`.
+
+S55a's note already anticipated joint K-induction.  This session
+sharpens "joint K-induction" into an explicit decomposition that
+delineates which steps are recyclable from existing infrastructure
+(S48-S52) and which are genuinely new mathematical content.
+
+### Statement-level anatomy
+
+Define the per-cell **integrand contributions**:
+```
+L(x) := gnwProb μ c (h_μ(x)) x          -- LHS integrand at x
+R(x) := gnwProb (μ\c') c (h_{μ\c'}(x)) x  -- RHS integrand at x
+```
+and let `α := h_d`.  The target identity is
+```
+(∑_{x∈(μ\c').cells} L(x)) · (α − 1)² = (∑_{x∈(μ\c').cells} R(x)) · α · (α − 2).
+```
+By `hookLength_at_d_ge_3` (S51), `α ≥ 3`, so `α − 1 ≥ 2 > 0` and
+`α · (α − 2) ≥ 3` strictly positive — no degenerate zero-product case.
+
+### Cell partition
+
+Partition `(μ\c').cells` into four pairwise-disjoint subsets:
+
+| Tag | Definition (within `(μ\c').cells`) | Hook shift `h_{μ\c'}(x)` vs `h_μ(x)` | `c ∈ strictHookCells μ x`? |
+|-----|-----|-----|-----|
+| **A** (off-spine, off-arm-of-c) | `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2 ∧ c ∉ strictHookCells μ x` | unchanged | no |
+| **B** (off-spine, on-arm/leg-of-c) | `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2 ∧ c ∈ strictHookCells μ x` | unchanged | yes |
+| **C** (arm-of-c') | `x.1 = c'.1 ∧ x.2 < c'.2` | decreases by 1 | depends |
+| **D** (leg-of-c') | `x.2 = c'.2 ∧ x.1 < c'.1` | decreases by 1 | depends |
+
+Note that the doubly-affected cell `d = (min c.1 c'.1, min c.2 c'.2)`
+sits in **category C** (case 1, `c.1 < c'.1`) or **category D**
+(case 2, `c'.1 < c.1`); never in A or B.
+
+#### Strict-hook category mapping
+For each x, define `H*(x) := strictHookCells μ x.1 x.2` and `H'*(x) :=
+strictHookCells (μ\c') x.1 x.2`.  By S43's
+`strictHookCells_removeCorner_eq`:
+```
+H'*(x) = H*(x) \ {c'}
+```
+so the categories above correspond exactly to:
+* A, B: `c' ∉ H*(x)` ⟹ `H'*(x) = H*(x)` (same averaging set on the K-step).
+* C, D: `c' ∈ H*(x)` ⟹ `H'*(x) = H*(x) \ {c'}` (averaging set shrinks by 1).
+
+### K-induction lemma family (proposed)
+
+Replace the monolithic `F_side_identity_aligned` proof with a family of
+named sublemmas, each tracking a single piece of the pointwise
+integrand-difference budget.  The natural decomposition:
+
+#### (S1) `gnwProb_invariant_off_strictHook_of_c'` — **category A**
+```lean
+private lemma gnwProb_invariant_off_strictHook_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    (x : ℕ × ℕ) (hx : x ∈ removeCorner μ c' hc')
+    (hx_off : x.1 ≠ c'.1 ∧ x.2 ≠ c'.2)
+    (hc_off : c ∉ strictHookCells μ x.1 x.2) :
+    gnwProb (removeCorner μ c' hc') c
+        (hookLength (removeCorner μ c' hc') x.1 x.2) x =
+    gnwProb μ c (hookLength μ x.1 x.2) x := by
+  sorry
+```
+**Mathematical content**: when `x` is off `c'`'s spine and `c` is not
+in its strict hook, both `h(x)` and `H*(x)` are invariant under
+`μ ↦ μ\c'`, AND `c` does not occur in any descendant K-step (since
+walks from `x` that avoid `c` produce `gnwProb _ c _ y = 0` everywhere).
+**Confidence**: high.  Likely <40 lines.  Reuses
+`strictHookCells_removeCorner_eq_of_not_mem` (S43-companion).
+
+#### (S2) `gnwProb_aligned_on_arm_of_c'` — **category C reduction**
+```lean
+private lemma gnwProb_aligned_on_arm_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc : isCorner μ c)
+    (hc' : isCorner μ c') (hne : c ≠ c')
+    (x : ℕ × ℕ) (hx_arm : x.1 = c'.1 ∧ x.2 < c'.2)
+    (hx_mem : x ∈ removeCorner μ c' hc') :
+    gnwProb (removeCorner μ c' hc') c
+        (hookLength (removeCorner μ c' hc') x.1 x.2) x · α^2 =
+    (gnwProb μ c (hookLength μ x.1 x.2) x) · ((α − 1)^2 + δ_arm(x))
+  where δ_arm(x) is a *named correction term* representing the
+  pointwise contribution of the c'-removal on this cell.
+```
+*(The exact form of δ_arm is part of S57.1's design space — it should
+absorb the `(α − 1)² ↦ α(α − 2) = (α − 1)² − 1` algebraic identity at
+the level of a single cell on c''s arm.)*
+**Confidence**: medium.  Likely 80-150 lines.  This is the "hard"
+algebraic-combinatorial step.
+
+#### (S3) `gnwProb_aligned_on_leg_of_c'` — **category D reduction**
+Mirror of (S2), case `x.2 = c'.2 ∧ x.1 < c'.1`.  Should be derivable
+from (S2) via the transpose-duality machinery already in PART XXIV
+(`cells_transpose_eq_image_swap`, `isCorner_transpose_iff`,
+`hookProd_removeCorner_transpose`).  **Confidence**: high once (S2)
+lands.  Likely 30-60 lines.
+
+#### (S4) `F_side_aligned_arm_summand` — **arm cell-summed form**
+```lean
+private lemma F_side_aligned_arm_summand ... :
+    (∑ x ∈ arm_of_c'(μ \ c'), L(x)) · (α − 1)² −
+    (∑ x ∈ arm_of_c'(μ \ c'), R(x)) · α · (α − 2) = 0
+```
+A direct corollary of (S2) summed over the arm.  Uses
+`Finset.sum_congr` + algebraic manipulation.  **Confidence**: high
+once (S2) lands.  Likely 30-50 lines.
+
+#### (S5) `F_side_aligned_leg_summand` — **leg cell-summed form**
+Mirror of (S4) via (S3).  **Confidence**: high.  ~30-50 lines.
+
+#### (S6) `F_side_aligned_off_spine_summand` — **off-spine cell-summed form**
+```lean
+private lemma F_side_aligned_off_spine_summand ... :
+    (∑ x ∈ off_spine(μ \ c'), L(x)) · (α − 1)² =
+    (∑ x ∈ off_spine(μ \ c'), R(x)) · (α − 1)²  -- L(x) = R(x) pointwise
+    -- multiplied through by (α-1)²/α(α-2) requires α ≥ 3 (S51)
+```
+Uses (S1) per-cell + summation.  **Confidence**: high.  ~40-80 lines.
+The α-factor reconciliation is mechanical (multiply both sides by
+`α(α−2)/(α−1)²` is wrong in ring; instead, show the off-spine
+contribution is **proportional with the correct factor already
+absorbed** because `c ∉ H*(x)` means `gnwProb · c = 0` at all stages —
+or, more carefully: the off-spine contribution to L equals the
+off-spine contribution to R, and the side identity reduces to the
+arm+leg+d-cell summands.)
+
+(*This is one of the two trickiest design points: confirming on a
+small example that off-spine cells indeed contribute zero to **both**
+sides modulo their identical hook-walk structures.*)
+
+#### (S7) `F_side_identity_aligned` — **assembly**
+```lean
+private lemma F_side_identity_aligned ... := by
+  rw [← decompose_sum_by_arm_leg_off]   -- partition both sums
+  ring_nf
+  exact F_side_aligned_arm_summand .. ▸
+        F_side_aligned_leg_summand .. ▸
+        F_side_aligned_off_spine_summand ..
+```
+**Confidence**: high once (S4)–(S6) land.  ~40-80 lines (mostly
+algebraic tidying).
+
+### Estimated total
+
+| Sublemma | Lines (low) | Lines (high) | Confidence |
+|----------|-------------|--------------|------------|
+| (S1) off-spine pointwise | 30 | 50 | high |
+| (S2) arm pointwise | 80 | 150 | medium |
+| (S3) leg pointwise (transpose) | 30 | 60 | high |
+| (S4) arm summand | 30 | 50 | high |
+| (S5) leg summand | 30 | 50 | high |
+| (S6) off-spine summand | 40 | 80 | high |
+| (S7) assembly | 40 | 80 | high |
+| **Total** | **280** | **520** | — |
+
+This is wide enough that it **cannot fit in the current Helpers.lean
+file** (estimated 15500-line ceiling, currently at 15136 — see S56's
+file-size note).  The architectural extraction recommended by S54 is
+now a hard prerequisite for S57.1+.
+
+### Extraction layout (S57.0a — prerequisite)
+
+Move the following lemmas into a new file
+`proofs/Proofs/BallotProblemOQ03OQ01OQ02DoubleRemove.lean`:
+
+| Region | Lines (current Helpers.lean) | Description |
+|--------|------------------------------|-------------|
+| S48 (5035-5230) | `hookLength_doubleRemove_*` family (6 lemmas) | hookLength-shift identities for `removeCorner (removeCorner μ c) c'` |
+| S50 (5232-5290) | `hookLength_removeCornerC'_*` (3 lemmas) | single-removal bridges |
+| S51 (5288-5295) | `hookLength_at_d_ge_3` | geometric prerequisite for ℚ-cast safety |
+| S52 (5297-?)   | `hookProd_doubleRemove_factor` | algebraic "easy half" |
+| S53 (14629-14721) | `gnwProb_exchange_lt_row_of_F_side` | case 1 algebraic combiner |
+| S54 (14724-14808) | `gnwProb_exchange_lt_col_of_F_side` | case 2 algebraic combiner |
+| S55a (14811-?) | `F_side_identity_aligned` (sorry'd) | TARGET of S57+ |
+| S55a (14823-14864) | `F_side_identity` (sorry-free as of S56) | derives from S56 + S43 bridge |
+| S55a (14866-14902) | `gnwProb_exchange` (sorry-free) | dispatcher |
+
+**Net move**: ~700 lines.  Helpers.lean drops to ~14400 lines.  The
+new `DoubleRemove.lean` lands at ~700 lines + headers + imports.
+
+#### Import structure (proposed)
+```
+DoubleRemove.lean
+  imports Helpers        -- needs gnwProb, isCorner, hookLength, etc.
+  exports F_side_identity_aligned, F_side_identity, gnwProb_exchange
+```
+But Helpers.lean is currently used by the main entry file
+`BallotProblemOQ03OQ01OQ02.lean`, which consumes
+`gnwProb_exchange` and `gnwProb_key`.  Two options:
+
+* **Option E1**: `gnwProb_key` stays in Helpers; it consumes
+  `gnwProb_exchange` from DoubleRemove → cyclic.  ✗ rejected.
+* **Option E2**: `gnwProb_key` *also* moves to DoubleRemove.  Then
+  Helpers.lean has all foundational machinery (gnwProb,
+  strictHookCells, *etc.*), DoubleRemove has the K-induction
+  apparatus, and the main entry imports both.  ✓ preferred.
+* **Option E3**: a fresh file `BallotProblemOQ03OQ01OQ02FsideKind.lean`
+  holds *only* the F-side proof (S57.1-S57.7 = ~280-520 lines), while
+  S48-S55a stay in Helpers.  This delays the "split point" until
+  S57.7's assembly lands, minimizing the diff and keeping the prior
+  file structure intact.  ✓ alternative — more conservative.
+
+**Recommendation**: **Option E3**, proceed without splitting until
+S57.1's first sublemma is complete; then split iff the file actually
+exceeds 15500 lines.  This defers the architectural change until it's
+empirically forced.
+
+### S57.1 first attack (proposed)
+
+Begin with **(S1)** — the off-spine invariance lemma.  Reasoning:
+1. Highest confidence of completing in one session.
+2. Smallest line count.
+3. Independent of (S2)/(S3) — can land standalone.
+4. The infrastructure (`strictHookCells_removeCorner_eq_of_not_mem`,
+   `gnwProb_step`) is all already proved and unit-tested via existing
+   call sites.
+
+If (S1) lands, S57.2 attacks (S2) — the harder algebraic core.
+
+### Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| File-size ceiling hit during S57.1+ | Defer extraction until empirically forced; use Option E3 layout when needed |
+| `δ_arm`/`δ_leg` correction term ill-defined | (S2) design must validate on the (3,1) test case from S53 (`F=8/3`, `F\c'=3`, `α=4`) before generalizing |
+| Off-spine sum identity (S6) circular | Validate by hand on a small example (e.g. (3,2) shape, c=(0,2), c'=(1,1)) before formalizing |
+| Aristotle attempts on sorry'd sublemmas waste capacity | Don't expose sublemmas to Aristotle until their statement has been hand-validated on a test case |
+| PR #17443 (S56) auto-merges before S57 work pushes | Rebase any new commits onto fresh `origin/main` before push |
+
+### What this session does NOT do
+
+* **No Lean changes**.  The extraction (E3) and sublemma stubs can be
+  written in S57.1 once a researcher has full focus.
+* **No meta.json updates**.  The `description` field referencing
+  `gnwProb_key` as the open sorry is now stale (S55a/S56 moved the
+  sorry to `F_side_identity_aligned`); a recommended one-line
+  description update is left to a separate small PR (mechanic-style)
+  to keep this session scope-narrow.
+* **No additional formalization**.  This is a planning artifact only.
+
+### Files Modified
+
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 56 → 57; Next Action refined with (S1)–(S7) decomposition)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s02.md`
+  (this report)
+
+### Build status
+
+No Lean changes; no build attempted.
+
+### Recovery / trap-checks performed
+
+1. `gh pr list --search ballot-problem-oq-03-oq-01-oq-02 --state open`
+   confirms PR #17443 (S56, this researcher's prior session) is the
+   only open PR for the slug.  No competing in-flight S57 work.
+2. `git fetch origin main && git log origin/main --oneline -25 | grep ballot`
+   shows two recent ballot merges (oq-02-oq-02 enrichment, oq-03-oq-01-oq-01-oq-01 S27/S28),
+   both for *different* slugs — no risk of conflict on this entry.
+3. `claim-random` selected `ballot-problem-oq-03-oq-01-oq-02` again
+   via knowledge prioritization (RICH score 209, 9 in MODERATE+ tier).
+4. `git status` shows only worktree-symlink artifacts (claims dir),
+   not staged.
+
+### Next iteration recommendations
+
+1. **(S57.1)** Implement sublemma (S1) `gnwProb_invariant_off_strictHook_of_c'`.
+   ~30-50 lines, high confidence.  This is the smallest-risk first
+   attack on the K-induction.
+2. **(S57.2)** Implement sublemma (S2) `gnwProb_aligned_on_arm_of_c'`.
+   The hardest piece.  Validate `δ_arm` design on the (3,1) test case
+   first (concrete numbers from S53 confirm `F=8/3`, `F\c'=3`, `α=4`,
+   so `(8/3)·9 = 24` and `3·4·2 = 24` ✓).
+3. **(S57.3-S57.7)** Implement (S3)–(S7) in order.
+4. **(S57.0a, deferred)** Architectural extraction per Option E3 *iff*
+   Helpers.lean exceeds 15500 lines during S57.1+ work.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT
+**Phase**: ORIENT (S57 plan: K-induction decomposition into (S1)-(S7) sublemmas)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
 **Last Updated**: 2026-05-09
-**Iteration**: 56
+**Iteration**: 57
 
 ## Current Focus
 Close `F_side_identity_aligned` (Helpers, line ~14811) — the
@@ -238,10 +238,40 @@ in place:
   memory ceiling estimate (~15500).  CI will verify the PR.
 
 ## Next Action
-**S57 — prove the common-domain `F_side_identity_aligned`** via joint
-K-induction on the sum-level invariant.  After S56 (this session)
-sharpened the obligation to a same-domain comparison, the open
-statement is:
+**S57.1 — implement sublemma (S1) `gnwProb_invariant_off_strictHook_of_c'`**
+as the smallest-risk first attack on the K-induction
+decomposition planned in S57.0 (session note `2026-05-09-s02.md`).
+The plan partitions the open lemma `F_side_identity_aligned` into
+seven sublemmas (S1)–(S7), keyed to the four cell categories A/B/C/D
+of `(μ\c').cells` (off-spine, off-arm-of-c, arm-of-c', leg-of-c').
+
+S57.0's blueprint (sublemma family — see `2026-05-09-s02.md` for full
+discussion):
+* (S1) `gnwProb_invariant_off_strictHook_of_c'` — pointwise off-spine
+  invariance.  ~30-50 lines, **high** confidence.  ← **S57.1 target**.
+* (S2) `gnwProb_aligned_on_arm_of_c'` — arm-cell pointwise reduction
+  with `δ_arm` correction term.  ~80-150 lines, medium confidence.
+  Hardest piece.  ← S57.2.
+* (S3) `gnwProb_aligned_on_leg_of_c'` — leg-cell mirror via PART XXIV
+  transpose duality.  ~30-60 lines, high.  ← S57.3.
+* (S4)/(S5) arm/leg summands.  ~30-50 each.  ← S57.4/S57.5.
+* (S6) off-spine summand.  ~40-80 lines.  ← S57.6.
+* (S7) assembly.  ~40-80 lines.  ← S57.7.
+
+**Total estimated**: 280-520 lines.  This *will* exceed the 15500-line
+Helpers.lean ceiling, so an extraction is forced before assembly
+lands; S57.0's plan recommends **Option E3** (defer the split until
+empirically needed; only move the F-side proof apparatus into a fresh
+`BallotProblemOQ03OQ01OQ02FsideKind.lean` if the S57.1+ commits push
+past the ceiling).
+
+**Open statement** (target of S57.1+):
+```
+[∑ x ∈ (μ\c').cells, gnwProb μ c (h_μ x) x] · (h_d − 1)²
+  = [∑ x ∈ (μ\c').cells, gnwProb (μ\c') c (h_{μ\c'} x) x]
+    · h_d · (h_d − 2)
+where  h_d = hookLength μ (min c.1 c'.1) (min c.2 c'.2)
+```
 ```
 [∑ x ∈ (μ\c').cells, gnwProb μ c (h_μ x) x] · (h_d − 1)²
   = [∑ x ∈ (μ\c').cells, gnwProb (μ\c') c (h_{μ\c'} x) x]
@@ -340,6 +370,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-08-s09.md` — Session 54: `gnwProb_exchange_lt_col_of_F_side` algebraic combiner (case 2)
 - `sessions/2026-05-08-s10.md` — Session 55a: parametric `F_side_identity` + sorry-free `gnwProb_exchange` dispatcher
 - `sessions/2026-05-09-s01.md` — Session 56: common-domain `F_side_identity_aligned` + sorry-free `F_side_identity`
+- `sessions/2026-05-09-s02.md` — Session 57.0: K-induction strategy + cell-partition + (S1)-(S7) sublemma plan
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -4,15 +4,19 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
-**Last Updated**: 2026-05-08
-**Iteration**: 55
+**Last Updated**: 2026-05-09
+**Iteration**: 56
 
 ## Current Focus
-Close `F_side_identity` (Helpers, line ~14795) — the **parametric F-side
-hook-shift identity** that is now the SOLE remaining sorry-bearing lemma
-on the GNW route, after S55a wired `gnwProb_exchange` to dispatch through
-S53/S54 combiners.  `gnwProb_exchange` itself is now sorry-free; only
-`F_side_identity` blocks `verified` status.
+Close `F_side_identity_aligned` (Helpers, line ~14811) — the
+**common-domain parametric F-side hook-shift identity** that is now the
+sole remaining sorry-bearing lemma on the GNW route, after S56 (this
+session) sharpened the open obligation by aligning both summation
+domains to `(μ\c').cells`.  `F_side_identity` (S55a) is now sorry-free,
+deriving from `F_side_identity_aligned` via the existing S43 bridge
+`sum_gnwProb_eq_removeCorner_cells`.  `gnwProb_exchange` (S55a)
+remains sorry-free; only `F_side_identity_aligned` blocks `verified`
+status.
 
 ## Active Approach
 Route A (GNW probabilistic hook-walk) is the chosen path; the proof skeleton is
@@ -200,25 +204,48 @@ in place:
      points to S54; `gnwProb_key`'s "two sorry'd steps" comment is
      reduced to one (step (a) `termination_by` was already resolved
      since S43).  +63 Helpers.lean lines.
+ 18. Common-domain sharpening of `F_side_identity` (session 56,
+     **this session**) — added `private lemma F_side_identity_aligned`
+     (line ~14811, sorry-bearing, +46 lines including 38-line
+     docstring) running both sums over `(removeCorner μ c' hc').cells`
+     (the same finite-cell domain).  Replaced `F_side_identity`'s
+     `sorry` with a 2-line proof:
+     `rw [sum_gnwProb_eq_removeCorner_cells hc' hne]`
+     `exact F_side_identity_aligned hc hc' hne`,
+     deriving the original `μ.cells`-domain statement from the aligned
+     form via the existing S43 bridge (which uses
+     `gnwProb_at_other_corner` to deduce `gnwProb μ c K c' = 0`, so the
+     `c'` term vanishes when erasing the LHS sum domain).
+     **Sorry count unchanged (1)**: the abstract `F_side_identity`
+     sorry has been *relocated* to the more concrete same-domain
+     `F_side_identity_aligned` sorry — no net regression, but a
+     structural sharpening that removes the cell-wise `c'` excision
+     step from the K-induction's burden (S57+ now compares integrands
+     pointwise on a single common domain).
 
 ## Blockers
-- **`F_side_identity` proof.** The parametric F-side hook-shift identity
-  (S55a) is now the sole open sorry on the GNW route.  Quantifies how
-  the F-sum `F(μ,c) := ∑_x gnwProb μ c (h_μ x) x` transforms when corner
-  c' is removed.  Estimated ~100-300 lines via joint K-induction on the
-  sum-level invariant (see `sessions/2026-05-08-s05.md` recipe).
-- **Build verification.** Helpers file is at 15090 lines after S55a
-  (was 15027 after S54, +63 lines for `F_side_identity` + dispatcher);
-  ~410 lines under the Docker 32GB-memory ceiling estimate (~15500).
-  CI will verify the PR.
+- **`F_side_identity_aligned` proof.** The common-domain parametric
+  F-side hook-shift identity (S56) is now the sole open sorry on the
+  GNW route.  Both summation domains run over `(μ\c').cells`; the
+  remaining obligation compares **integrands pointwise**:
+  `gnwProb μ c (h_μ x) x` (LHS) versus
+  `gnwProb (μ\c') c (h_{μ\c'} x) x` (RHS).  Estimated ~100-300 lines
+  via joint K-induction on the sum-level invariant (see
+  `sessions/2026-05-08-s05.md` recipe).
+- **Build verification.** Helpers file is at 15136 lines after S56
+  (was 15090 after S55a, +46 lines for `F_side_identity_aligned`
+  + sorry-free `F_side_identity`); ~360 lines under the Docker 32GB-
+  memory ceiling estimate (~15500).  CI will verify the PR.
 
 ## Next Action
-**S55 — prove the parametric `F_side_identity`** via joint K-induction
-on the sum-level invariant.  After S55a (this session) wired
-`gnwProb_exchange` through the dispatcher, the open obligation is now a
-single statement:
+**S57 — prove the common-domain `F_side_identity_aligned`** via joint
+K-induction on the sum-level invariant.  After S56 (this session)
+sharpened the obligation to a same-domain comparison, the open
+statement is:
 ```
-F(μ,c) · (h_d − 1)² = F(μ\c',c) · h_d · (h_d − 2)
+[∑ x ∈ (μ\c').cells, gnwProb μ c (h_μ x) x] · (h_d − 1)²
+  = [∑ x ∈ (μ\c').cells, gnwProb (μ\c') c (h_{μ\c'} x) x]
+    · h_d · (h_d − 2)
 where  h_d = hookLength μ (min c.1 c'.1) (min c.2 c'.2)
 ```
 On both branches of `distinct_corners_dichotomy`, `(min c.1 c'.1, min c.2 c'.2)`
@@ -230,10 +257,14 @@ collapses to the doubly-affected cell `d`:
 
 Approach: joint K-induction using `gnwProb_step` for K-stability and the
 S43 sum-bridges (`sum_gnwProb_eq_removeCorner_cells`,
-`sum_gnwProb_strictHookCells_eq_removeCorner`).  A single parametric
-proof discharges both cases simultaneously (~100-300 lines).  Once
-`F_side_identity` is sorry-free, the entry promotes to `verified` (last
-sorry eliminated).
+`sum_gnwProb_strictHookCells_eq_removeCorner`).  Crucially, both sums
+in `F_side_identity_aligned` are now over the **same** finite-cell
+domain `(μ\c').cells`, so the K-induction can attack the integrands
+pointwise; the cell-wise `c'` excision step (LHS sum split) is no
+longer needed, having been absorbed by the bridge in `F_side_identity`.
+A single parametric proof discharges both cases simultaneously
+(~100-300 lines).  Once `F_side_identity_aligned` is sorry-free, the
+entry promotes to `verified` (last sorry eliminated).
 
 S53–S54 (sessions completed) closed step 3 of 3 from the s05 recipe for
 **both** branches of `distinct_corners_dichotomy`: the algebraic
@@ -249,33 +280,39 @@ Remaining steps in the s05 recipe:
 
 2. **F-side "hard half"** (~150-250 lines if proved parametrically for
    both cases, or ~100-200 each).  Joint K-induction on the sum-level
-   invariant.  Confidence: medium.  May require S55.5 to extract the
-   K=0 base case as a separate lemma if the induction step is too large
-   for one PR.
+   invariant.  Confidence: medium.  S56 (this session) sharpened the
+   obligation to a common-domain form `F_side_identity_aligned`; the
+   K-induction now compares integrands pointwise on `(μ\c').cells`.
+   May still require S57.5 to extract the K=0 base case as a separate
+   lemma if the induction step is too large for one PR.
 
 3. ✓ **Combine** to close `gnwProb_exchange`:
    - Case 1 (`c.1 < c'.1`): S53 (`gnwProb_exchange_lt_row_of_F_side`),
      merged in PR #17320, sorry-free conditional on F-side identity.
    - Case 2 (`c'.1 < c.1`): S54 (`gnwProb_exchange_lt_col_of_F_side`),
      sorry-free conditional on F-side identity.
-   - Final dispatcher: ✓ S55a (**this session**) — wired
-     `gnwProb_exchange` through `distinct_corners_dichotomy` + S53/S54
-     + parametric `F_side_identity` (sorry-bearing).  `gnwProb_exchange`
-     is now sorry-free; the open obligation is `F_side_identity`.
+   - Final dispatcher: ✓ S55a — wired `gnwProb_exchange` through
+     `distinct_corners_dichotomy` + S53/S54 + parametric
+     `F_side_identity` (sorry-bearing).  `gnwProb_exchange` is now
+     sorry-free.
+   - Common-domain sharpening: ✓ S56 (**this session**) — added
+     `F_side_identity_aligned` (sorry-bearing, both sums over
+     `(μ\c').cells`); `F_side_identity` is now sorry-free, deriving
+     from `F_side_identity_aligned` via the S43 bridge.
 
-Step 2 reduces to a single sorry'd lemma `F_side_identity` (parametric
-in `min`-coordinates), which is the sole remaining open piece of the
-GNW route.
+Step 2 reduces to a single sorry'd lemma `F_side_identity_aligned`
+(parametric in `min`-coordinates, both sums on `(μ\c').cells`), which
+is the sole remaining open piece of the GNW route.
 
-**File-size**: Helpers.lean is at 15090 lines after S55a (+63 from 15027
-after S54).  ~410 lines under the Docker 32GB-memory ceiling estimate
-(~15500 lines).  S55 (full F-side proof) is likely to push beyond 15500;
-extraction into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` should now
-be a *blocking prerequisite* for S55 (or S55 should target the extracted
-file directly).  The natural extraction boundary is the entire
-double-removal infrastructure (S48-S55a: lines ~5035–5500 for
-geometric+S52, plus ~14629–14844 for S53/S54/S55a-dispatcher and
-`F_side_identity`).
+**File-size**: Helpers.lean is at 15136 lines after S56 (+46 from 15090
+after S55a).  ~360 lines under the Docker 32GB-memory ceiling estimate
+(~15500 lines).  S57 (full F-side proof) is likely to push beyond
+15500; extraction into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`
+should now be a *blocking prerequisite* for S57 (or S57 should target
+the extracted file directly).  The natural extraction boundary is the
+entire double-removal infrastructure (S48-S56: lines ~5035–5500 for
+geometric+S52, plus ~14629–14850 for S53/S54/S55a-dispatcher and the
+S55a/S56 F-side block).
 
 Alternative (deferred): a deterministic weighted-path recasting of GNW
 that avoids the exchange step entirely (count weighted walks of every
@@ -302,6 +339,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-08-s08.md` — Session 53: `gnwProb_exchange_lt_row_of_F_side` algebraic combiner (case 1)
 - `sessions/2026-05-08-s09.md` — Session 54: `gnwProb_exchange_lt_col_of_F_side` algebraic combiner (case 2)
 - `sessions/2026-05-08-s10.md` — Session 55a: parametric `F_side_identity` + sorry-free `gnwProb_exchange` dispatcher
+- `sessions/2026-05-09-s01.md` — Session 56: common-domain `F_side_identity_aligned` + sorry-free `F_side_identity`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -318,11 +356,13 @@ Fallback if S55+ stalls.
   (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14724` — `gnwProb_exchange_lt_col_of_F_side`
   (S54 combiner, sorry-free conditional on F-side identity, case `c'.1 < c.1`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14795` — `F_side_identity`
-  (S55a, sorry-bearing, parametric in `(min c.1 c'.1, min c.2 c'.2)` — sole open sorry on the GNW route)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14820` — `gnwProb_exchange`
-  (S55a, sorry-free, dispatches via `distinct_corners_dichotomy` to S53/S54 combiners, transitive on `F_side_identity`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14858` — `gnwProb_key`
-  (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`; `gnwProb_exchange` itself is now sorry-free as of S55a)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15069` — `hook_walk_identity_gnw`
-  (sorry-free dispatcher, transitive on `F_side_identity`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14811` — `F_side_identity_aligned`
+  (S56, sorry-bearing, both sums on `(μ\c').cells` — sole open sorry on the GNW route)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14840` — `F_side_identity`
+  (S55a; sorry-free as of S56, derives from `F_side_identity_aligned` via `sum_gnwProb_eq_removeCorner_cells`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14866` — `gnwProb_exchange`
+  (S55a, sorry-free, dispatches via `distinct_corners_dichotomy` to S53/S54 combiners, transitive on `F_side_identity_aligned`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14904` — `gnwProb_key`
+  (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`; `gnwProb_exchange` itself is sorry-free as of S55a)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15115` — `hook_walk_identity_gnw`
+  (sorry-free dispatcher, transitive on `F_side_identity_aligned`)


### PR DESCRIPTION
## Summary

S56 — structural sharpening of the sole open sorry on the GNW route (`F_side_identity`, S55a) by aligning both summation domains to `(μ\c').cells`.

- **Adds** `private lemma F_side_identity_aligned` (sorry-bearing): same parametric F-side hook-shift identity as S55a's `F_side_identity`, but with both sums over the **same** finite-cell domain `(removeCorner μ c' hc').cells` (LHS integrand uses big-diagram `gnwProb μ c (h_μ x) x`; RHS uses small-diagram `gnwProb (μ\c') c (h_{μ\c'} x) x`).
- **Replaces** `F_side_identity`'s `sorry` with a 2-line proof (`rw [sum_gnwProb_eq_removeCorner_cells hc' hne]; exact F_side_identity_aligned hc hc' hne`), deriving the original `μ.cells`-domain statement from the aligned form via the existing S43 bridge (which uses `gnwProb_at_other_corner` to deduce `gnwProb μ c K c' = 0`, so the `c'` term vanishes when erasing the LHS sum domain).
- **Sorry count unchanged** (1 in Helpers, 2 in Aristotle, total chain = 3): the abstract `F_side_identity` sorry is *relocated* to the more concrete same-domain `F_side_identity_aligned` sorry — no net regression, but a structural sharpening that removes the cell-wise `c'` excision step from the K-induction's burden (S57+ now compares integrands pointwise on a single common domain).

## Why a same-domain reformulation

The S55a session note flagged the F-side proof as proceeding via "joint K-induction on the sum-level invariant".  But on S55a's statement, the K-induction would have to manage *two* different summation domains.  Pulling the S43 bridge in *before* the K-induction starts is cheaper than threading domain-erasure logic through every K-step.  The mathematical content moved across is exactly the single-cell evaluation `gnwProb μ c K c' = 0`.

## Net change

| metric                      | before S56 | after S56 |
|-----------------------------|------------|-----------|
| sorries in Helpers          | 1          | 1         |
| sorries in Aristotle file   | 2          | 2         |
| total sorries (entry chain) | 3          | 3         |
| sorry-bearing lemmas        | F_side_identity + 2 Aristotle | F_side_identity_aligned + 2 Aristotle |
| Helpers.lean line count     | 15090      | 15136     |

## Test plan
- [ ] CI builds `Proofs.BallotProblemOQ03OQ01OQ02Helpers` cleanly (local Docker build deferred — broken `proofs/.lake` symlink causes 45+ minute fresh-clone cycle).
- [ ] CI confirms sorry count chain unchanged at 3 (verified locally via Python comment-stripper).
- [ ] CI verifies `F_side_identity` discharges via the rewrite-then-exact tactic (the pure refactoring half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)