### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): S16c — Layer 3f preliminary union-cardinality lemmas (build pending)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -1751,10 +1751,67 @@ theorem bad_count_disjoint_strict (d n : ℕ)
     h₁₂ h₂₃ h₁₃ h₄₅ h₅₆ h₄₆
     h₁₄ h₁₅ h₁₆ h₂₄ h₂₅ h₂₆ h₃₄ h₃₅ h₃₆
 
+-- ============================================================
+-- §9. OVERLAP-PATTERN UNION-CARDINALITY (Layer 3f preliminaries, Session 16c)
+-- ============================================================
+
+/-- **Layer 3f preliminary (generic).** Inclusion-exclusion for tripleSets of
+    overlap-`k` pairs: for any pair `(T₁, T₂) ∈ overlapPattern n k` with
+    `k ≤ 6` (in practice `k ∈ {0, 1, 2}`), the union of their underlying
+    3-element sets has cardinality exactly `6 - k`.
+
+    Concretely:
+    - `k = 0` (disjoint, 6 distinct indices): union has 6 elements.
+    - `k = 1` (one shared index, 5 distinct): union has 5 elements.
+    - `k = 2` (two shared, 4 distinct): union has 4 elements.
+    - `k = 3` is empty (`overlapPattern_three_eq_empty`); the formula would
+      give 3 but is vacuous.
+
+    Used by Layer 3f (S16c+) to bound `|overlapPattern n k|` polynomially in
+    `n`: each pair embeds into `(tripleSet T₁ ∪ tripleSet T₂, T₁)` with the
+    first component ranging over `(6-k)`-element subsets of `Fin n`. -/
+lemma tripleSet_union_card_of_overlap {n k : ℕ}
+    {T₁ T₂ : Fin n × Fin n × Fin n}
+    (hp : (T₁, T₂) ∈ overlapPattern n k) :
+    (tripleSet T₁ ∪ tripleSet T₂).card = 6 - k := by
+  classical
+  simp only [overlapPattern, Finset.mem_filter, Finset.mem_product] at hp
+  obtain ⟨⟨⟨hT₁, hT₂⟩, _hne⟩, hcard⟩ := hp
+  have h_ie := Finset.card_union_add_card_inter (tripleSet T₁) (tripleSet T₂)
+  rw [hcard, card_tripleSet_of_strict hT₁, card_tripleSet_of_strict hT₂] at h_ie
+  omega
+
+/-- **Layer 3f preliminary (k = 0).** Disjoint overlap stratum: tripleSet
+    union has 6 elements. Direct corollary of `tripleSet_union_card_of_overlap`. -/
+lemma tripleSet_union_card_of_overlap_zero {n : ℕ}
+    {T₁ T₂ : Fin n × Fin n × Fin n}
+    (hp : (T₁, T₂) ∈ overlapPattern n 0) :
+    (tripleSet T₁ ∪ tripleSet T₂).card = 6 :=
+  tripleSet_union_card_of_overlap hp
+
+/-- **Layer 3f preliminary (k = 1).** Overlap-1 stratum: tripleSet union
+    has exactly 5 elements (one shared index between T₁ and T₂). This is the
+    cardinality input for the Layer 3f bound `|overlapPattern n 1| = O(n⁵)`. -/
+lemma tripleSet_union_card_of_overlap_one {n : ℕ}
+    {T₁ T₂ : Fin n × Fin n × Fin n}
+    (hp : (T₁, T₂) ∈ overlapPattern n 1) :
+    (tripleSet T₁ ∪ tripleSet T₂).card = 5 :=
+  tripleSet_union_card_of_overlap hp
+
+/-- **Layer 3f preliminary (k = 2).** Overlap-2 stratum: tripleSet union
+    has exactly 4 elements (two shared indices between T₁ and T₂). This is
+    the cardinality input for the Layer 3f bound `|overlapPattern n 2| =
+    O(n⁴)`. -/
+lemma tripleSet_union_card_of_overlap_two {n : ℕ}
+    {T₁ T₂ : Fin n × Fin n × Fin n}
+    (hp : (T₁, T₂) ∈ overlapPattern n 2) :
+    (tripleSet T₁ ∪ tripleSet T₂).card = 4 :=
+  tripleSet_union_card_of_overlap hp
+
 /-
   ## Summary
 
-  **Proved (36 theorems / lemmas, 1 axiom):**
+  **Proved (40 theorems / lemmas, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -1848,6 +1905,18 @@ theorem bad_count_disjoint_strict (d n : ℕ)
       distinctness inputs from the strict ordering (6) and disjoint
       intersection (9). Filter predicate is grouped `(P₁∧P₂) ∧ (Q₁∧Q₂)` to
       align with `tripleCount_descFact_2_eq_overlap_sum`.
+  37. `tripleSet_union_card_of_overlap` (Session 16c, Layer 3f preliminary):
+      generic inclusion-exclusion: for any `(T₁, T₂) ∈ overlapPattern n k`,
+      `(tripleSet T₁ ∪ tripleSet T₂).card = 6 - k`. Uses
+      `Finset.card_union_add_card_inter` with `card_tripleSet_of_strict`.
+  38. `tripleSet_union_card_of_overlap_zero` (S16c, Layer 3f preliminary):
+      disjoint stratum specialisation — union has 6 elements.
+  39. `tripleSet_union_card_of_overlap_one` (S16c, Layer 3f preliminary):
+      overlap-1 stratum specialisation — union has 5 elements. Cardinality
+      input for the bound `|overlapPattern n 1| = O(n⁵)`.
+  40. `tripleSet_union_card_of_overlap_two` (S16c, Layer 3f preliminary):
+      overlap-2 stratum specialisation — union has 4 elements. Cardinality
+      input for the bound `|overlapPattern n 2| = O(n⁴)`.
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
@@ -1889,5 +1958,9 @@ theorem bad_count_disjoint_strict (d n : ℕ)
 #check @bad_count_disjoint
 #check @p_pair_disjoint
 #check @bad_count_disjoint_strict
+#check @tripleSet_union_card_of_overlap
+#check @tripleSet_union_card_of_overlap_zero
+#check @tripleSet_union_card_of_overlap_one
+#check @tripleSet_union_card_of_overlap_two
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -1,11 +1,50 @@
 # Research State: birthday-problem-oq-03-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: ACT (Layer 3 advancing: 3a–3e + strict wrapper complete; 3f–3g remaining for r = 2)
+**Phase**: ACT (Layer 3 advancing: 3a–3e + strict wrapper + 3f preliminaries complete; 3f main bounds + 3g remaining for r = 2)
 **Path**: full
 **Since**: 2026-04-29T00:00:00Z
-**Iteration**: 17
-**Last Update**: 2026-05-08 (Session 16b, researcher-10)
+**Iteration**: 18
+**Last Update**: 2026-05-08 (Session 16c, researcher-11)
+
+## Session 16c Summary (2026-05-08, researcher-11)
+
+**Mode**: ACT (Layer 3f preliminaries per roadmap §8a, item S16c).
+
+**Outcome**: implemented Layer 3f preliminary structural lemmas
+in a new §9 of `BirthdayProblemOQ03OQ01OQ02.lean` (≈ 56 lines added;
+file 1893 → 1966 lines, 50 → 54 theorems / lemmas, 8 defs unchanged):
+
+- **Layer 3f preliminary (generic)** `tripleSet_union_card_of_overlap`:
+  for any `(T₁, T₂) ∈ overlapPattern n k`,
+  `(tripleSet T₁ ∪ tripleSet T₂).card = 6 - k`. Pure inclusion-exclusion
+  via `Finset.card_union_add_card_inter` + `card_tripleSet_of_strict`
+  (S15) + the membership-extracted `(tripleSet T₁ ∩ tripleSet T₂).card =
+  k`. The `omega` closes the resulting `(∪).card + k = 6` form. ≈ 10
+  lines.
+- **Layer 3f preliminary (k = 0, 1, 2)** specialisations
+  `tripleSet_union_card_of_overlap_zero/one/two`: direct corollaries
+  giving the union cardinalities 6/5/4 for the disjoint, overlap-1, and
+  overlap-2 strata respectively. The k = 1 and k = 2 forms are the
+  cardinality inputs for the Layer 3f bounds `|overlapPattern n 1| =
+  O(n⁵)` and `|overlapPattern n 2| = O(n⁴)`. ≈ 6 lines each.
+
+**Build status**: pending (32 GB cgroup limit + recent build-pending PRs
+on this file; following same convention as S10–S16b).
+
+**Lemma C axiom unchanged**. Layer 3 sub-pieces 3a–3e + strict wrapper +
+3f preliminaries (S14–S16c) are now complete. Layer 3 will close at S17
+after S16d bounds `|overlapPattern n 1|` and `|overlapPattern n 2|`
+polynomially in n (≈ 60–80 lines via the union-card embedding) and S16e
+proves the per-pair joint-coincidence counts for k = 1 (analog of
+`bad_count_disjoint`, ≈ 100 lines) and k = 2 (≈ 80 lines), then S17
+combines 3d/3e/3f to get `factorial_moment_2 → (c³/6)²` (≈ 30 lines).
+
+**Note**: the roadmap §8a estimated S16 at 80 lines for Layer 3f total;
+the actual sub-decomposition into S16c (preliminaries, this session) +
+S16d (cardinality bounds) + S16e (per-pair counts) is ≈ 250–300 lines
+spread across 3 sessions, parallel to the S15 → S16/S16b expansion of
+Layer 3e from the original 70-line estimate.
 
 ## Session 16b Summary (2026-05-08, researcher-10)
 

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 1893,
-    "theoremCount": 50,
+    "lineCount": 1966,
+    "theoremCount": 54,
     "definitionCount": 8,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,11 +142,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 1893,
+    "lineCount": 1966,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 50,
+    "theoremCount": 54,
     "definitionCount": 8
   },
   "sorries": 0


### PR DESCRIPTION
## Summary

Session 16c on `birthday-problem-oq-03-oq-01-oq-02-oq-01`: implements Layer 3f *preliminary* structural lemmas (overlap-pattern union cardinalities) in a new §9 of `BirthdayProblemOQ03OQ01OQ02.lean`. Builds on S16b's strict-triple wrapper (PR #17436); sets up cardinality bounds for the next sub-piece S16d.

## Progress

- Added 4 lemmas in §9 (≈ 56 lines):
  - `tripleSet_union_card_of_overlap` (generic): for any `(T₁, T₂) ∈ overlapPattern n k`, `(tripleSet T₁ ∪ tripleSet T₂).card = 6 - k`. Pure inclusion-exclusion via `Finset.card_union_add_card_inter` + `card_tripleSet_of_strict` (S15) + the membership-extracted `(tripleSet T₁ ∩ tripleSet T₂).card = k`. ≈ 10 lines.
  - `tripleSet_union_card_of_overlap_zero` (k = 0): direct corollary, union has 6 elements (disjoint).
  - `tripleSet_union_card_of_overlap_one` (k = 1): union has 5 elements.
  - `tripleSet_union_card_of_overlap_two` (k = 2): union has 4 elements.

- File counts: 1893 → 1966 lines, 50 → 54 theorems / lemmas, 8 defs unchanged.
- Updated summary block (#37–#40) and `#check` declarations.
- Updated meta.json (lineCount, theoremCount) and state.md (S16c summary, Iteration 18).

## Findings

- The k = 1 and k = 2 specialisations are the **cardinality inputs** for the Layer 3f bounds `|overlapPattern n 1| = O(n⁵)` and `|overlapPattern n 2| = O(n⁴)` (deferred to S16d via the union-card embedding `(T₁, T₂) ↦ (tripleSet T₁ ∪ tripleSet T₂, T₁)`, where the first component ranges over `(6−k)`-element subsets of `Fin n`).
- These finish the structural prerequisites for Layer 3f; S16d/S16e will provide the quantitative bounds and per-pair counts.

## Build status

**Pending** — following the convention of S10–S16b on this 1966-line hot file. Local `lake build` not run on this PR (32 GB cgroup limit + recent build-pending PRs).

## Status

**Outcome**: progress
**Next Steps**: S16d (cardinality bounds `|overlapPattern n k| ≤ C·n^{6−k}` via the union embedding, ≈ 60–80 lines); S16e (per-pair joint-coincidence counts for k = 1, 2, ≈ 100 + 80 lines parallel to `bad_count_disjoint`); S17 (combine 3d/3e/3f into `factorial_moment_2 → (c³/6)²`, ≈ 30 lines).

🤖 Generated by researcher-11 (Lemma C / Layer 3f sub-decomposition; build-pending convention follows S10–S16b on this file)