### PR TITLE
fix(meta): batch sync definitionCount/theoremCount drift (25 entries, batch m-r)

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 686,
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "originalContributions": [
       "Custom Lattice structure with basis matrix and invertibility condition",
       "CentrallySymmetric and ConvexBody types with origin membership theorem",
@@ -138,7 +138,7 @@
     "path": "Proofs/MinkowskiFundamentalTheorem.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "theoremCount": 19
   },
   "sorries": 0

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -76,7 +76,7 @@
       "Linear algebra: inner product spaces, basis, linear independence"
     ],
     "theoremCount": 19,
-    "definitionCount": 14
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "Hermann Minkowski (1864--1909), a Lithuanian-German mathematician and one of Einstein's teachers at ETH Zurich, presented his convex body theorem in 'Geometrie der Zahlen' (1896), founding the field now called the geometry of numbers. The central idea was revolutionary: purely geometric reasoning about volumes and convex sets could yield arithmetic conclusions about the existence of integer points. Minkowski had first announced the result in 1889 and developed it over several years.\n\nThe theorem emerged from Minkowski's study of quadratic forms and their arithmetic properties. He realized that asking whether a quadratic form represents small values is equivalent to asking whether a certain ellipsoid contains lattice points -- transforming an algebraic question into a geometric one. This insight connected two previously separate mathematical traditions: the algebraic theory of quadratic forms (Gauss, Hermite) and the geometry of convex bodies.\n\nMinkowski's theorem was immediately recognized as fundamental. Hilbert used Minkowski's bound to prove the finiteness of the ideal class group of algebraic number fields, one of the cornerstones of algebraic number theory. The classical proof via the pigeonhole principle applied to lattice translates of the scaled set $S/2$ is a model of mathematical elegance: a deep arithmetic conclusion follows from a simple volume comparison.\n\nBlichfeldt (1914) refined the result into a counting generalization. Siegel later extended the geometry of numbers to adelic settings, connecting it to the theory of automorphic forms. Today the theorem underpins lattice-based cryptography (LWE, NTRU, FHE), where the guaranteed existence of short lattice vectors is central to both security proofs and cryptanalytic attacks. The shortest vector problem (SVP) and closest vector problem (CVP), both related to Minkowski's bounds, are believed to be hard even for quantum computers, making lattice cryptography a leading candidate for post-quantum security.",
@@ -274,7 +274,7 @@
     "lineCount": 686,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "mainTheorems": [
       {
         "name": "minkowski_fundamental",

--- a/src/data/proofs/morleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01/meta.json
@@ -43,7 +43,7 @@
       "Product-to-sum trig identities for the verification"
     ],
     "theoremCount": 15,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Morley's theorem — that the intersections of adjacent trisectors of any triangle form an equilateral triangle — was discovered by Frank Morley around 1899 but not published until 1929. Despite its elementary statement, it resisted conventional proof for decades; Morley himself described it as a theorem that 'cannot be proved by elementary methods'. The first published proofs (by Naraniengar in 1909 and Taylor-Marr in 1914) were trigonometric and non-trivial. John Conway's 'backward construction' proof (c. 1995) is celebrated for its conceptual elegance: by reversing the question — starting from the equilateral Morley triangle and constructing the original — he reduced the hard direction to a verification. The construction attaches three isoceles 'ear' triangles to the equilateral core, and the fundamental identity α/3 + β/3 + γ/3 = π/3 (for any triangle) provides the exact apex angles needed to make it work. This file formalizes Conway's approach in Lean 4, proving all the supporting lemmas (0 axioms, 0 sorries). The remaining step — the coordinate computation verifying the side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) — is finite and mechanical but substantial.",
@@ -147,7 +147,7 @@
     "lineCount": 292,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/MorleysTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -57,7 +57,7 @@
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Frank Morley (1860-1937), an English-American mathematician and professor at Johns Hopkins University, discovered this theorem in 1899. Despite centuries of intensive study of triangle geometry by mathematicians from Euclid to Euler, this beautiful property remained hidden until the dawn of the 20th century. It has been called 'the most remarkable theorem in elementary geometry discovered in the 20th century.'\n\nThe theorem wasn't discovered earlier because angle trisection is impossible with compass and straightedge alone — a fact proved by Pierre Wantzel in 1837 using Galois theory. The ancient Greeks, who could not construct the trisector configuration, never encountered the Morley triangle. The algebraic reason is that trisecting angle $\\theta$ requires solving the irreducible cubic $4\\cos^3\\phi - 3\\cos\\phi = \\cos\\theta$.\n\nMorley first communicated the result around 1899, but it was not published until 1929. Multiple elegant proofs have been found: trigonometric (direct computation), complex number coordinates, and John Conway's celebrated 'backward proof' which starts with the equilateral triangle and reconstructs the original. The formalization here follows Conway's approach using complex coordinates.\n\nMorley's theorem appears as #84 in Freek Wiedijk's list of 100 greatest theorems. It connects to angle trisection impossibility (#8 on the same list) through the triple angle formula $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$.",
@@ -249,7 +249,7 @@
     "lineCount": 532,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "sorries": 0,
     "path": "Proofs/MorleysTheorem.lean"
   }

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "2 axiom(s): motivicClassPartialFlagMaps (motivic class of maps to partial flags), partial_flag_extension (conjectured extension to parabolic subgroups). 0 sorries — all algebraic identities (duality, lines, Gaussian binomial) are proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 38,
-    "definitionCount": 16
+    "definitionCount": 18
   },
   "sections": [
     {
@@ -138,7 +138,7 @@
     "lineCount": 635,
     "path": "Proofs/MotivicFlagMapsPartialFlags.lean",
     "sorries": 0,
-    "definitionCount": 16,
+    "definitionCount": 18,
     "theoremCount": 38
   },
   "sorries": 0

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Binomial coefficients and absorption identities",
       "Real arithmetic and polynomial inequalities"
     ],
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 2,
     "additionalFiles": [
       "Proofs/NewtonInductiveStepOQ01Aristotle.lean"

--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -28,7 +28,7 @@
     "assumptions": "1 axiom: numOverpartitions. 0 sorries.",
     "lineCount": 62,
     "theoremCount": 2,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Euler (1748) proved his famous partition identity in Introductio in Analysin Infinitorum: the number of partitions of n into odd parts equals the number of partitions of n into distinct parts. This was proved by the bijection between the two sets, or algebraically via generating functions: ∏(1+x^k) = ∏ 1/(1-x^(2k-1)). Overpartitions were formally introduced by Corteel and Lovejoy in 2004 as a natural generalization: an overpartition of n allows the first occurrence of each part size to be optionally 'overlined' (marked). The overlined parts are exactly the distinct parts that can be treated as a separate population. Corteel-Lovejoy proved that the number of overpartitions of n equals 2^ω(n) times the number of ordinary partitions (where ω(n) depends on the partition type), and established many Euler-like identities for overpartitions. The key combinatorial fact: for a partition with d distinct part sizes, there are 2^d overpartition choices (each distinct part size can independently be overlined or not). This connects directly to the generating function (1+q^k)/(1-q^k) = (1+q^k) × 1/(1-q^k) for each part size k.",
@@ -130,7 +130,7 @@
     "lineCount": 62,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/PartitionTheoremOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -50,7 +50,7 @@
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",
     "mathlib_version": "4.26.0",
     "theoremCount": 46,
-    "definitionCount": 27
+    "definitionCount": 28
   },
   "overview": {
     "historicalContext": "Blaise Pascal discovered this theorem in 1639, at age 16, calling it the *Hexagrammum Mysticum* (Mystic Hexagram). His original proof, presented to the Académie Parisienne, was lost, but its statement was recorded by Leibniz, who found it among Pascal's papers. Pascal claimed to derive over 400 corollaries from this single result.\n\nThe theorem became a cornerstone of projective geometry, which was systematically developed by Jean-Victor Poncelet in his 1822 *Traité des propriétés projectives des figures*. Charles-Julien Brianchon discovered the dual theorem in 1806 as a student at the École Polytechnique: if a hexagon is circumscribed about a conic, the three main diagonals are concurrent.\n\nThe configuration of 60 Pascal lines arising from permutations of six points on a conic — the *Hexagrammum Mysticum* configuration — attracted major attention from Jakob Steiner (1828), Thomas Kirkman (1849), Arthur Cayley (1849), and George Salmon (1852), who discovered its remarkable incidence properties: 20 Steiner points, 60 Kirkman points, and 15 Plücker lines.\n\nPascal's theorem appears as #28 in Freek Wiedijk's list of 100 greatest theorems. The formalization here uses projective coordinates in $\\mathbb{R}^3$ with the cross product serving double duty for line-through and line-intersection, and the key algebraic identity axiomatized via the Cayley-Bacharach / Bézout argument.",
@@ -214,7 +214,7 @@
     "axiomCount": 1,
     "sorries": 1,
     "theoremCount": 46,
-    "definitionCount": 27,
+    "definitionCount": 28,
     "imports": [
       "import Mathlib.Data.Real.Basic",
       "import Mathlib.LinearAlgebra.Matrix.Determinant.Basic",

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -13,7 +13,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 11,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "lineCount": 215,
     "tags": [
       "number-theory",
@@ -109,7 +109,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 11,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "imports": [
       "import Mathlib.Data.Int.GCD",
       "import Mathlib.Data.List.Basic",

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "4 assumptions: 3 axioms (picks_theorem — Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean; scaled_area — Area(tP)=t²A; scaled_boundary — |∂(tP)|=t·B for t≥1) plus 1 opaque constant (scaledPolygon — the integer dilation tP, opaque since its concrete construction is not needed for the theorem). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "originalContributions": [
       "rectangle_ehrhart: L(R_{a,b},t) = (ta+1)(tb+1) via Finset.card_product (0 axioms)",
       "triangle_ehrhart_double: 2·L(Δ_n,t) = (tn+1)(tn+2) via Nat.antidiagonal biUnion + Gauss sum (0 axioms)",
@@ -112,7 +112,7 @@
     "path": "Proofs/PicksTheoremOQ01OQ02.lean",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "axiomCount": 4,
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03-product/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-product/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Ehrhart theory studies lattice point counting in polytopes. The Ehrhart polynomial L(P, n) = |nP ∩ ℤ^d| was introduced by Eugène Ehrhart in the 1960s; for an integer polytope P of dimension d, L(P, n) is a polynomial in n of degree d with leading coefficient vol(P). The product formula L(P×Q, n) = L(P,n)·L(Q,n) follows from the fact that integer points in a product polytope are products of integer points. Quasipolynomials arise when polytopes have rational (non-integer) vertices: L(P, t) is a quasipolynomial with period equal to the LCM of denominators. Zonotopes (Minkowski sums of line segments) were studied by Zaslavsky and others; their Ehrhart theory is captured by the theory of mixed volumes. The valuation property connects Ehrhart theory to the broader theory of lattice polytope valuations studied by McMullen (1978).",
@@ -105,7 +105,7 @@
     "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/PicksTheoremOQ03Product.lean",
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -79,7 +79,7 @@
     "assumptions": "2 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change).",
     "mathlib_version": "4.26.0",
     "theoremCount": 45,
-    "definitionCount": 21
+    "definitionCount": 23
   },
   "overview": {
     "historicalContext": "Eugène Ehrhart (1906-2000) was a French mathematician who published his landmark theorem in 1962, showing that for any d-dimensional lattice polytope P and positive integer n, the number of lattice points in the dilated polytope nP is a polynomial of degree d in n. This polynomial, now called the Ehrhart polynomial, encodes deep geometric and combinatorial information about the polytope.\n\nEhrhart's theorem provides the correct higher-dimensional generalization of Pick's theorem (1899). While Pick's formula A = i + b/2 - 1 works beautifully in 2D, the Reeve tetrahedra show it cannot extend to 3D. Ehrhart theory explains why: in 2D the polynomial has 3 coefficients determined by 2 independent counts (i and b), but in 3D the polynomial has 4 coefficients while i and b provide only 2 equations.\n\nThe theory was further enriched by Macdonald's reciprocity theorem (1971), connecting interior and boundary counts through sign changes in the polynomial, and Stanley's nonnegativity theorem (1980) for h*-vectors.",
@@ -237,7 +237,7 @@
     "lineCount": 710,
     "sorries": 0,
     "path": "Proofs/EhrhartPolynomialOQ03.lean",
-    "definitionCount": 21,
+    "definitionCount": 23,
     "theoremCount": 45
   }
 }

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -46,7 +46,7 @@
     "assumptions": "1 axiom: picks_theorem (the main theorem statement). Removed inconsistent area_bounded_by_box_axiom (claimed A(P) ≤ w_x*w_y for all w_x,w_y without containment hypothesis).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "Georg Alexander Pick (1859-1942) was an Austrian mathematician who studied under Leo Konigsberger and Felix Klein. He published this theorem in 1899 in the journal *Sitzungsberichte der kaiserlichen Akademie der Wissenschaften*. The result remained obscure for over 60 years until Hugo Steinhaus popularized it in his 1960 book *Mathematical Snapshots*. Pick was murdered in the Theresienstadt concentration camp in 1942.\n\nThe theorem connects two seemingly different mathematical worlds: discrete counting (lattice points) and continuous measurement (area). This connection foreshadowed the development of Ehrhart theory (1962), which generalizes Pick's formula to higher-dimensional lattice polytopes using Ehrhart polynomials.\n\nPick's theorem has a natural proof via triangulation and additivity: verify for the unit right triangle ($i=0, b=3, A=1/2$), then show the formula is preserved when combining polygons along shared edges. An alternative proof uses Euler's formula $V - E + F = 2$ for planar graphs, counting how vertices and edges contribute to interior, boundary, and face counts.\n\nPick's theorem appears as #92 in Freek Wiedijk's list of 100 greatest theorems. It is one of the most accessible results on the list, requiring only basic arithmetic, yet it reveals deep structure connecting discrete and continuous mathematics.",
@@ -226,7 +226,7 @@
     "lineCount": 484,
     "sorries": 0,
     "path": "Proofs/PicksTheorem.lean",
-    "definitionCount": 15,
+    "definitionCount": 16,
     "theoremCount": 12
   }
 }

--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Coxeter-Schlaefli determinant and Gram matrices"
     ],
     "mathlib_version": "4.26.0",
-    "definitionCount": 28
+    "definitionCount": 31
   },
   "overview": {
     "historicalContext": "Ludwig Schlaefli (1852) classified regular polytopes in all dimensions, extending Euclid's classification of the 5 Platonic solids. He discovered that dimension 4 is exceptional: it admits 6 regular polytopes, including the remarkable 24-cell which has no analog in any other dimension. For dimensions 5 and above, only three families survive: the simplex, hypercube, and cross-polytope. H.S.M. Coxeter later systematized this theory using reflection groups and Gram matrices, providing the algebraic framework used in this formalization.",
@@ -169,7 +169,7 @@
     "lineCount": 628,
     "axiomCount": 0,
     "theoremCount": 53,
-    "definitionCount": 28,
+    "definitionCount": 31,
     "mainTheorems": [
       {
         "name": "regular_4polytope_classification",

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -48,7 +48,7 @@
       "Platonic solids classification (parent proof)"
     ],
     "mathlib_version": "4.26.0",
-    "definitionCount": 31
+    "definitionCount": 32
   },
   "overview": {
     "historicalContext": "The Archimedean solids generalize the Platonic solids by relaxing the requirement that all faces be congruent. Instead, all faces must be regular polygons, and the same cyclic arrangement of faces must meet at every vertex. Archimedes reportedly studied these solids, though his original work is lost. Johannes Kepler gave the first systematic enumeration in *Harmonices Mundi* (1619), finding 13 types. The modern rigorous proof follows Grünbaum's *Convex Polytopes* (1967) and Cromwell's *Polyhedra* (1997).\n\nThe classification has two parts: (1) the angle defect constraint narrows the field to finitely many candidate vertex types, and (2) geometric analysis determines which candidates actually close up into convex polyhedra. This formalization handles part (1) computationally and axiomatizes part (2).",
@@ -129,7 +129,7 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 31,
+    "definitionCount": 32,
     "path": "Proofs/PlatonicSolidsOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -44,7 +44,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The Platonic solids were known to the ancient Greeks and studied extensively by Plato (hence the name). Euclid proved in Elements Book XIII that these are the only five regular convex polyhedra. The classification relies on Euler's polyhedral formula V - E + F = 2 combined with regularity constraints: all faces are congruent regular p-gons and q faces meet at each vertex. The five solids correspond to the finite subgroups of SO(3) acting on the sphere, a connection fully developed by Klein (1884). Schläfli (1852) classified regular polytopes in higher dimensions, finding six in dimension 4 and only three (the simplex, hypercube, and cross-polytope) in each dimension 5 and above.",
@@ -141,7 +141,7 @@
     "lineCount": 419,
     "axiomCount": 0,
     "theoremCount": 24,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "mainTheorems": [
       {
         "name": "platonic_classification",

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -54,7 +54,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Lovasz Local Lemma (LLL), proved by Paul Erdos and Laszlo Lovasz in 1975, is widely regarded as the crown jewel of the probabilistic method. It addresses a fundamental limitation of the basic probabilistic method: when bad events are not independent, the naive union bound can be far too pessimistic.\n\nThe LLL shows that if each bad event has small probability and is independent of most other bad events, then with positive probability none of the bad events occur. The precise condition involves a dependency graph: each event must be independent of all events not in its neighborhood, and the probabilities must satisfy a system of inequalities involving the graph structure.\n\nThe symmetric form of the LLL is especially elegant: if each event has probability at most p and depends on at most d other events, and if ep(d+1) <= 1 (where e is Euler's number), then all bad events can be simultaneously avoided. This clean criterion is remarkably powerful.\n\nIn 2010, Moser and Tardos gave a constructive proof of the LLL via a resampling algorithm, resolving a long-standing question about whether the non-constructive existence proof could be made algorithmic. Their proof showed that repeated resampling of violated constraints converges rapidly.",
@@ -207,7 +207,7 @@
     "lineCount": 364,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/LovaszLocalLemma.lean",
     "sorries": 0
   },

--- a/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "lineCount": 228,
     "theoremCount": 6,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "assumptions": "None.",
     "originalContributions": [
       "Dimension-independent proof of the chord quadratic equation in any real inner product space",
@@ -113,7 +113,7 @@
     "lineCount": 228,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/ProductOfSegmentsOfChordsOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -48,7 +48,7 @@
     "assumptions": "1 axiom: converse_product_implies_concyclic_axiom. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The Product of Segments of Chords theorem appears as Proposition 35 in Book III of Euclid's *Elements* (c. 300 BCE), where Euclid proves it using similar triangles: triangles PAC and PDB are similar (by the inscribed angle theorem), giving PA/PD = PC/PB, hence PA·PB = PC·PD. This makes it one of the oldest formally stated results in circle geometry.\n\nThe deeper unifying concept — the *power of a point* — was introduced by Jakob Steiner in his 1826 work *Einige geometrische Betrachtungen*. Steiner recognized that the quantity $d^2 - r^2$ (where $d$ is the distance from the point to the center) is invariant for all lines through the point, unifying four classical theorems: intersecting chords (interior), two secants (exterior), secant-tangent, and two tangents. The radical axis of two circles (locus where powers are equal) became a fundamental tool in projective and inversive geometry.\n\nThis formalization takes the algebraic approach via Vieta's formulas rather than Euclid's synthetic proof, parametrizing chord-circle intersections as roots of a quadratic equation whose constant term equals the power.",
@@ -212,7 +212,7 @@
     "lineCount": 541,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/ProductOfSegmentsOfChords.lean",
     "sorries": 0
   },

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "lineCount": 288,
     "theoremCount": 8,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Ptolemy's theorem (c. 150 AD) states that for a cyclic quadrilateral ABCD in convex position, AC·BD = AB·CD + BC·DA. The question of whether equality alone characterizes concyclic order — the *converse* — was implicit in Ptolemy's work but requires careful proof. In modern terms, it follows from the cross-ratio characterization: for four points on a circle, the cross-ratio R = (z₂-z₃)(z₁-z₄)/((z₁-z₂)(z₃-z₄)) is always real, and R > 0 precisely when the points are in CCW or CW order. This file provides the Lean 4 formalization of the converse direction, completing the full biconditional characterization.",
@@ -151,7 +151,7 @@
     "lineCount": 288,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/PtolemysTheoremOQ01OQ01.lean"
   }

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -67,7 +67,7 @@
     "assumptions": "0 axioms. Structure fields (HyperbolicRightTriangle.law, SphericalRightTriangle.law, SphericalRightTriangleR.law) define the mathematical objects — users must provide proof to construct instances. All 50+ consequence theorems are fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 105,
-    "definitionCount": 18
+    "definitionCount": 21
   },
   "overview": {
     "historicalContext": "The Pythagorean theorem $a^2 + b^2 = c^2$ is arguably the most fundamental metric relation in all of mathematics. Its generalization to non-Euclidean geometries reveals deep connections between algebra, analysis, and geometry.\n\nSpherical trigonometry has ancient roots: the Islamic mathematician al-Battani (c. 858–929 CE) used the spherical law of cosines for astronomical calculations, and Regiomontanus (1436–1476) systematized spherical trigonometry in *De Triangulis Omnimodis* (1464). The spherical Pythagorean theorem $\\cos(c/R) = \\cos(a/R) \\cdot \\cos(b/R)$ was known implicitly through this tradition.\n\nHyperbolic geometry emerged much later. Nikolai Lobachevsky (1829) and János Bolyai (1832) independently discovered that Euclid's parallel postulate could be negated consistently, producing a geometry where the angle sum of triangles is less than $\\pi$. The hyperbolic Pythagorean theorem $\\cosh c = \\cosh a \\cdot \\cosh b$ follows from the hyperbolic metric. Carl Friedrich Gauss had privately anticipated these results but never published them.\n\nThe unification came through Bernhard Riemann's 1854 *Habilitationsschrift*, where he introduced the concept of curvature $\\kappa$ parameterizing a family of geometries. The generalized cosine function $C_\\kappa(x)$ packages all three cases: $\\cos(\\sqrt{\\kappa} \\cdot x)$ for $\\kappa > 0$, $\\cosh(\\sqrt{|\\kappa|} \\cdot x)$ for $\\kappa < 0$, and the flat limit $\\kappa \\to 0$ recovering $a^2 + b^2 = c^2$ via Taylor expansion.\n\nThis formalization answers the open question from our Pythagorean theorem proof: 'What is the analog of the Pythagorean theorem in hyperbolic and spherical geometry?' The 65+ fully proved theorems (zero sorries, zero axioms) cover the complete picture: structures, identities, area-defect formulas, laws of cosines, monotonicity, and quantitative approximation.",
@@ -276,7 +276,7 @@
     "lineCount": 1431,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 18,
+    "definitionCount": 21,
     "theoremCount": 105
   },
   "sorries": 0

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The core theorem is an original construction (badge: original) using Mathlib's `InnerProductSpace` infrastructure — the proof expands $\\langle v+w, v+w \\rangle$ via `inner_add_left`/`inner_add_right` and applies the orthogonality hypothesis to zero the cross terms. The converse direction uses the same bilinearity expansion in reverse.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Pythagorean theorem is arguably the most recognized result in all of mathematics. While named after the Greek mathematician Pythagoras (c. 570-495 BCE), evidence suggests the theorem was known independently in at least three ancient civilizations over 1000 years earlier.\n\nThe Babylonian clay tablet Plimpton 322 (c. 1800 BCE) lists 15 rows of Pythagorean triples in a systematic table, demonstrating that Mesopotamian scribes understood the relationship between the sides of right triangles. The Indian Sulba Sutras (Baudhayana's version c. 800 BCE) state the theorem explicitly — \"the diagonal of a rectangle produces by itself both the areas which the two sides of the rectangle produce separately\" — in the context of Vedic altar construction. Chinese mathematicians recorded the theorem in the Zhou Bi Suan Jing (The Mathematical Classic of the Zhou Gnomon, c. 1000 BCE), where it is known as the Gōu-Gǔ theorem (勾股定理) and attributed to the Duke of Zhou.\n\nPythagoras, or more likely his school, is credited with providing the first general deductive proof in the Greek tradition. The theorem appears as Proposition 47 in Book I of Euclid's Elements (c. 300 BCE), where it's proved via shearing areas of squares constructed on the triangle's sides — a landmark of axiomatic geometry. The converse appears as Proposition I.48.\n\nBy 1940, mathematician Elisha Loomis had catalogued 367 distinct proofs, and new proofs continue to be discovered. James Garfield, before becoming the 20th US President, published an elegant trapezoid-area proof in 1876. In 2023, high school students Ne'Kiya Jackson and Calcea Johnson presented a trigonometric proof avoiding circular reasoning, historically thought impossible.",
@@ -281,7 +281,7 @@
     "lineCount": 214,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "substantiveTheoremCount": 3,
     "trivialSpecializations": 3,
     "mainTheorems": [

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "1 axiom: multicolor_ramsey_exists. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Ramsey's theorem was proved by Frank Plumpton Ramsey in 1930, just before his untimely death at age 26. The theorem appeared in his paper 'On a Problem of Formal Logic' where he was investigating decision procedures for first-order logic.\n\nThe result spawned an entire branch of combinatorics now called Ramsey theory, which studies the emergence of order in sufficiently large structures. The guiding principle is that complete disorder is impossible—given enough elements, some regular pattern must appear.\n\nThe most famous special case is the 'party problem': at any party of 6 people, either 3 mutually know each other or 3 are mutual strangers. This corresponds to R(3,3) = 6.",
@@ -216,7 +216,7 @@
     "lineCount": 627,
     "axiomCount": 1,
     "theoremCount": 24,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/RamseysTheorem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/randomized-maxcut-oq-01/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-01/meta.json
@@ -73,7 +73,7 @@
     "lineCount": 403,
     "assumptions": "8 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "theoremCount": 34,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "The Goemans-Williamson algorithm (1995) was a landmark result in combinatorial optimization, achieving a 0.878-approximation ratio for the Maximum Cut problem using semidefinite programming (SDP). This substantially improved the simple randomized 1/2-approximation.\n\nThe key insight is to relax the integer programming formulation of MaxCut to a semidefinite program, where each vertex is assigned a unit vector on a high-dimensional sphere instead of a binary ±1 value. The SDP can be solved in polynomial time, and a random hyperplane is used to round the continuous solution back to a discrete cut.\n\nRemarkably, under the Unique Games Conjecture (Khot et al. 2007), α_GW ≈ 0.878 is the best possible approximation ratio achievable in polynomial time, making this algorithm conditionally optimal.",
@@ -220,7 +220,7 @@
     "lineCount": 403,
     "axiomCount": 8,
     "theoremCount": 34,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/GoemansWilliamsonMaxCut.lean",
     "sorries": 0
   },

--- a/src/data/proofs/randomized-maxcut/meta.json
+++ b/src/data/proofs/randomized-maxcut/meta.json
@@ -64,7 +64,7 @@
     "lineCount": 324,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The Maximum Cut problem asks: given a graph, partition its vertices into two sets to maximize the number of edges crossing between them. This problem is NP-Complete, meaning no polynomial-time algorithm is known (and likely none exists).\n\nIn the 1970s, researchers began studying approximation algorithms—algorithms that don't find the optimal solution but guarantee a solution within some factor of optimal. The randomized algorithm presented here, which simply flips a fair coin for each vertex, was one of the earliest and simplest approximation algorithms discovered.\n\nRemarkably, this trivial algorithm achieves a 1/2-approximation: the expected cut size is at least half of the maximum possible. The proof uses linearity of expectation, a fundamental technique in probabilistic analysis that remains central to algorithm design today.\n\nIn 1994, Goemans and Williamson achieved a breakthrough with a 0.878-approximation using semidefinite programming. However, the simple randomized algorithm remains important for its elegance, efficiency, and as a teaching tool for probabilistic analysis.",
@@ -211,7 +211,7 @@
     "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/RandomizedMaxCut.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` and `theoremCount` in 25 meta.json files (alphabet range m-r) where the cached counts lagged the referenced Lean source. Surgical text-only edits preserve formatting and field ordering; both `meta.*` and `leanFile.*` mirrors are updated where both exist.

## Evidence

24 entries: `definitionCount` drift (claimed N, actual N+δ where δ ∈ {1, 2, 3}).
1 entry (`newton-inductive-step-oq-01`): `theoremCount` drift (21→22).

Each fix verified by recounting `def/abbrev/opaque/structure/inductive/class` (and `theorem/lemma` for the newton entry) in the main Lean file plus declared `additionalFiles`, with comments stripped and the standard modifier set (`private/protected/noncomputable/unsafe/partial/scoped`) ignored. Counting convention matches existing mechanic batches (#17407, #17429, #17430, #17441).

| slug | field | claimed → actual |
| --- | --- | --- |
| minkowski-fundamental-theorem | definitionCount | 14 → 17 |
| minkowski-theorem | definitionCount | 14 → 17 |
| morleys-theorem | definitionCount | 12 → 13 |
| morleys-theorem-oq-01 | definitionCount | 8 → 9 |
| motivic-flag-maps-oq-02 | definitionCount | 16 → 18 |
| newton-inductive-step-oq-01 | theoremCount | 21 → 22 |
| partition-theorem-oq-03 | definitionCount | 1 → 2 |
| pascals-hexagon | definitionCount | 27 → 28 |
| picks-theorem | definitionCount | 15 → 16 |
| picks-theorem-oq-01-oq-01 | definitionCount | 5 → 6 |
| picks-theorem-oq-01-oq-02 | definitionCount | 6 → 7 |
| picks-theorem-oq-03 | definitionCount | 21 → 23 |
| picks-theorem-oq-03-product | definitionCount | 12 → 13 |
| platonic-solids | definitionCount | 10 → 11 |
| platonic-solids-oq-01 | definitionCount | 28 → 31 |
| platonic-solids-oq-02 | definitionCount | 31 → 32 |
| prob-method-lovasz-local | definitionCount | 2 → 3 |
| product-of-segments-of-chords | definitionCount | 3 → 4 |
| product-of-segments-of-chords-oq-01 | definitionCount | 1 → 2 |
| ptolemys-theorem-oq-01-oq-01 | definitionCount | 1 → 2 |
| pythagorean-theorem | definitionCount | 2 → 3 |
| pythagorean-theorem-oq-03 | definitionCount | 18 → 21 |
| ramseys-theorem | definitionCount | 13 → 14 |
| randomized-maxcut | definitionCount | 6 → 7 |
| randomized-maxcut-oq-01 | definitionCount | 7 → 8 |

## Test plan

- [x] All 25 meta.json files parse as valid JSON post-edit
- [x] Recount script confirms each entry now matches actual Lean source

---
Automated fix by lean-mechanic agent.