### PR TITLE
fix(meta): batch sync definitionCount drift (26 entries, batch m-p)

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 686,
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "originalContributions": [
       "Custom Lattice structure with basis matrix and invertibility condition",
       "CentrallySymmetric and ConvexBody types with origin membership theorem",
@@ -138,7 +138,7 @@
     "path": "Proofs/MinkowskiFundamentalTheorem.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "theoremCount": 19
   },
   "sorries": 0

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -76,7 +76,7 @@
       "Linear algebra: inner product spaces, basis, linear independence"
     ],
     "theoremCount": 19,
-    "definitionCount": 14
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "Hermann Minkowski (1864--1909), a Lithuanian-German mathematician and one of Einstein's teachers at ETH Zurich, presented his convex body theorem in 'Geometrie der Zahlen' (1896), founding the field now called the geometry of numbers. The central idea was revolutionary: purely geometric reasoning about volumes and convex sets could yield arithmetic conclusions about the existence of integer points. Minkowski had first announced the result in 1889 and developed it over several years.\n\nThe theorem emerged from Minkowski's study of quadratic forms and their arithmetic properties. He realized that asking whether a quadratic form represents small values is equivalent to asking whether a certain ellipsoid contains lattice points -- transforming an algebraic question into a geometric one. This insight connected two previously separate mathematical traditions: the algebraic theory of quadratic forms (Gauss, Hermite) and the geometry of convex bodies.\n\nMinkowski's theorem was immediately recognized as fundamental. Hilbert used Minkowski's bound to prove the finiteness of the ideal class group of algebraic number fields, one of the cornerstones of algebraic number theory. The classical proof via the pigeonhole principle applied to lattice translates of the scaled set $S/2$ is a model of mathematical elegance: a deep arithmetic conclusion follows from a simple volume comparison.\n\nBlichfeldt (1914) refined the result into a counting generalization. Siegel later extended the geometry of numbers to adelic settings, connecting it to the theory of automorphic forms. Today the theorem underpins lattice-based cryptography (LWE, NTRU, FHE), where the guaranteed existence of short lattice vectors is central to both security proofs and cryptanalytic attacks. The shortest vector problem (SVP) and closest vector problem (CVP), both related to Minkowski's bounds, are believed to be hard even for quantum computers, making lattice cryptography a leading candidate for post-quantum security.",
@@ -274,7 +274,7 @@
     "lineCount": 686,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "mainTheorems": [
       {
         "name": "minkowski_fundamental",

--- a/src/data/proofs/morleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01/meta.json
@@ -43,7 +43,7 @@
       "Product-to-sum trig identities for the verification"
     ],
     "theoremCount": 15,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Morley's theorem — that the intersections of adjacent trisectors of any triangle form an equilateral triangle — was discovered by Frank Morley around 1899 but not published until 1929. Despite its elementary statement, it resisted conventional proof for decades; Morley himself described it as a theorem that 'cannot be proved by elementary methods'. The first published proofs (by Naraniengar in 1909 and Taylor-Marr in 1914) were trigonometric and non-trivial. John Conway's 'backward construction' proof (c. 1995) is celebrated for its conceptual elegance: by reversing the question — starting from the equilateral Morley triangle and constructing the original — he reduced the hard direction to a verification. The construction attaches three isoceles 'ear' triangles to the equilateral core, and the fundamental identity α/3 + β/3 + γ/3 = π/3 (for any triangle) provides the exact apex angles needed to make it work. This file formalizes Conway's approach in Lean 4, proving all the supporting lemmas (0 axioms, 0 sorries). The remaining step — the coordinate computation verifying the side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) — is finite and mechanical but substantial.",
@@ -147,7 +147,7 @@
     "lineCount": 292,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/MorleysTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -57,7 +57,7 @@
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Frank Morley (1860-1937), an English-American mathematician and professor at Johns Hopkins University, discovered this theorem in 1899. Despite centuries of intensive study of triangle geometry by mathematicians from Euclid to Euler, this beautiful property remained hidden until the dawn of the 20th century. It has been called 'the most remarkable theorem in elementary geometry discovered in the 20th century.'\n\nThe theorem wasn't discovered earlier because angle trisection is impossible with compass and straightedge alone — a fact proved by Pierre Wantzel in 1837 using Galois theory. The ancient Greeks, who could not construct the trisector configuration, never encountered the Morley triangle. The algebraic reason is that trisecting angle $\\theta$ requires solving the irreducible cubic $4\\cos^3\\phi - 3\\cos\\phi = \\cos\\theta$.\n\nMorley first communicated the result around 1899, but it was not published until 1929. Multiple elegant proofs have been found: trigonometric (direct computation), complex number coordinates, and John Conway's celebrated 'backward proof' which starts with the equilateral triangle and reconstructs the original. The formalization here follows Conway's approach using complex coordinates.\n\nMorley's theorem appears as #84 in Freek Wiedijk's list of 100 greatest theorems. It connects to angle trisection impossibility (#8 on the same list) through the triple angle formula $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$.",
@@ -249,7 +249,7 @@
     "lineCount": 532,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "sorries": 0,
     "path": "Proofs/MorleysTheorem.lean"
   }

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "2 axiom(s): motivicClassPartialFlagMaps (motivic class of maps to partial flags), partial_flag_extension (conjectured extension to parabolic subgroups). 0 sorries — all algebraic identities (duality, lines, Gaussian binomial) are proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 38,
-    "definitionCount": 16
+    "definitionCount": 18
   },
   "sections": [
     {
@@ -138,7 +138,7 @@
     "lineCount": 635,
     "path": "Proofs/MotivicFlagMapsPartialFlags.lean",
     "sorries": 0,
-    "definitionCount": 16,
+    "definitionCount": 18,
     "theoremCount": 38
   },
   "sorries": 0

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -72,7 +72,7 @@
     "assumptions": "2 axiom(s): motivicClassBasedMaps, motivic_class_flag_maps. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 26,
-    "definitionCount": 17
+    "definitionCount": 21
   },
   "overview": {
     "historicalContext": "This result was announced in January 2025 by Jim Bryan, Balázs Elek, Freddie Manners, George Salafatinos, and Ravi Vakil. It represents a significant advance in understanding the motivic structure of moduli spaces of maps.\n\n**Notably, the authors explicitly credit AI assistance**: \"The proof of this result was obtained in conjunction with Google Gemini and related tools.\" This makes it one of the first major mathematical results to credit AI collaboration in the research process.\n\nThe result connects several deep areas of mathematics: algebraic geometry (flag varieties), K-theory (Grothendieck rings), and moduli theory (spaces of rational curves).",
@@ -184,7 +184,7 @@
     "lineCount": 438,
     "axiomCount": 2,
     "theoremCount": 26,
-    "definitionCount": 17,
+    "definitionCount": 21,
     "path": "Proofs/MotivicFlagMaps.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -45,7 +45,7 @@
     "lineCount": 6370,
     "mathlib_version": "4.26.0",
     "theoremCount": 302,
-    "definitionCount": 150
+    "definitionCount": 154
   },
   "leanFile": {
     "path": "Proofs/PNPBarriersUnified.lean",
@@ -132,7 +132,7 @@
     ],
     "axiomCount": 211,
     "sorries": 0,
-    "definitionCount": 150,
+    "definitionCount": 154,
     "theoremCount": 302,
     "additionalFiles": [
       "Proofs/ComplexityCore.lean"

--- a/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "1 axiom: two_points_determine_chord. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 17
+    "definitionCount": 21
   },
   "sections": [
     {
@@ -159,7 +159,7 @@
     "lineCount": 453,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 17,
+    "definitionCount": 21,
     "path": "Proofs/ParallelPostulateIndependenceOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/parallel-postulate-independence/meta.json
+++ b/src/data/proofs/parallel-postulate-independence/meta.json
@@ -38,7 +38,7 @@
     "assumptions": "5 axioms: euclidean_incidence_geometry, euclidean_satisfies_parallel_postulate, poincare_incidence_geometry, poincare_satisfies_hyperbolic_parallel, poincare_nontrivial. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 3
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "For over 2000 years — from Euclid (~300 BCE) through Ptolemy, Proclus, al-Haytham, Khayyam, Saccheri, Lambert, and Legendre — mathematicians tried to prove the Fifth Postulate from the other axioms. Bolyai and Lobachevsky independently developed hyperbolic geometry (1829-1832), and Beltrami (1868) proved its consistency by constructing models within Euclidean geometry. The independence follows by the soundness theorem: a model satisfying all axioms except the parallel postulate certifies it cannot be proved from the others. Klein (1871) and Poincaré (1882) gave further elegant models, and Hilbert (1899) provided the rigorous axiomatic framework. The discovery of non-Euclidean geometry was one of the most consequential events in the history of mathematics, reshaping the philosophy of mathematical truth and paving the way for Riemannian geometry and general relativity.",
@@ -177,7 +177,7 @@
     "lineCount": 312,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 3,
+    "definitionCount": 7,
     "path": "Proofs/ParallelPostulateIndependence.lean",
     "sorries": 0
   },

--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -28,7 +28,7 @@
     "assumptions": "1 axiom: numOverpartitions. 0 sorries.",
     "lineCount": 62,
     "theoremCount": 2,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Euler (1748) proved his famous partition identity in Introductio in Analysin Infinitorum: the number of partitions of n into odd parts equals the number of partitions of n into distinct parts. This was proved by the bijection between the two sets, or algebraically via generating functions: ∏(1+x^k) = ∏ 1/(1-x^(2k-1)). Overpartitions were formally introduced by Corteel and Lovejoy in 2004 as a natural generalization: an overpartition of n allows the first occurrence of each part size to be optionally 'overlined' (marked). The overlined parts are exactly the distinct parts that can be treated as a separate population. Corteel-Lovejoy proved that the number of overpartitions of n equals 2^ω(n) times the number of ordinary partitions (where ω(n) depends on the partition type), and established many Euler-like identities for overpartitions. The key combinatorial fact: for a partition with d distinct part sizes, there are 2^d overpartition choices (each distinct part size can independently be overlined or not). This connects directly to the generating function (1+q^k)/(1-q^k) = (1+q^k) × 1/(1-q^k) for each part size k.",
@@ -130,7 +130,7 @@
     "lineCount": 62,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/PartitionTheoremOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -50,7 +50,7 @@
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",
     "mathlib_version": "4.26.0",
     "theoremCount": 46,
-    "definitionCount": 27
+    "definitionCount": 28
   },
   "overview": {
     "historicalContext": "Blaise Pascal discovered this theorem in 1639, at age 16, calling it the *Hexagrammum Mysticum* (Mystic Hexagram). His original proof, presented to the Académie Parisienne, was lost, but its statement was recorded by Leibniz, who found it among Pascal's papers. Pascal claimed to derive over 400 corollaries from this single result.\n\nThe theorem became a cornerstone of projective geometry, which was systematically developed by Jean-Victor Poncelet in his 1822 *Traité des propriétés projectives des figures*. Charles-Julien Brianchon discovered the dual theorem in 1806 as a student at the École Polytechnique: if a hexagon is circumscribed about a conic, the three main diagonals are concurrent.\n\nThe configuration of 60 Pascal lines arising from permutations of six points on a conic — the *Hexagrammum Mysticum* configuration — attracted major attention from Jakob Steiner (1828), Thomas Kirkman (1849), Arthur Cayley (1849), and George Salmon (1852), who discovered its remarkable incidence properties: 20 Steiner points, 60 Kirkman points, and 15 Plücker lines.\n\nPascal's theorem appears as #28 in Freek Wiedijk's list of 100 greatest theorems. The formalization here uses projective coordinates in $\\mathbb{R}^3$ with the cross product serving double duty for line-through and line-intersection, and the key algebraic identity axiomatized via the Cayley-Bacharach / Bézout argument.",
@@ -214,7 +214,7 @@
     "axiomCount": 1,
     "sorries": 1,
     "theoremCount": 46,
-    "definitionCount": 27,
+    "definitionCount": 28,
     "imports": [
       "import Mathlib.Data.Real.Basic",
       "import Mathlib.LinearAlgebra.Matrix.Determinant.Basic",

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -13,7 +13,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 11,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "lineCount": 215,
     "tags": [
       "number-theory",
@@ -109,7 +109,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 11,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "imports": [
       "import Mathlib.Data.Int.GCD",
       "import Mathlib.Data.List.Basic",

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "4 assumptions: 3 axioms (picks_theorem — Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean; scaled_area — Area(tP)=t²A; scaled_boundary — |∂(tP)|=t·B for t≥1) plus 1 opaque constant (scaledPolygon — the integer dilation tP, opaque since its concrete construction is not needed for the theorem). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "originalContributions": [
       "rectangle_ehrhart: L(R_{a,b},t) = (ta+1)(tb+1) via Finset.card_product (0 axioms)",
       "triangle_ehrhart_double: 2·L(Δ_n,t) = (tn+1)(tn+2) via Nat.antidiagonal biUnion + Gauss sum (0 axioms)",
@@ -112,7 +112,7 @@
     "path": "Proofs/PicksTheoremOQ01OQ02.lean",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "axiomCount": 4,
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03-product/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-product/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Ehrhart theory studies lattice point counting in polytopes. The Ehrhart polynomial L(P, n) = |nP ∩ ℤ^d| was introduced by Eugène Ehrhart in the 1960s; for an integer polytope P of dimension d, L(P, n) is a polynomial in n of degree d with leading coefficient vol(P). The product formula L(P×Q, n) = L(P,n)·L(Q,n) follows from the fact that integer points in a product polytope are products of integer points. Quasipolynomials arise when polytopes have rational (non-integer) vertices: L(P, t) is a quasipolynomial with period equal to the LCM of denominators. Zonotopes (Minkowski sums of line segments) were studied by Zaslavsky and others; their Ehrhart theory is captured by the theory of mixed volumes. The valuation property connects Ehrhart theory to the broader theory of lattice polytope valuations studied by McMullen (1978).",
@@ -105,7 +105,7 @@
     "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/PicksTheoremOQ03Product.lean",
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -79,7 +79,7 @@
     "assumptions": "2 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change).",
     "mathlib_version": "4.26.0",
     "theoremCount": 45,
-    "definitionCount": 21
+    "definitionCount": 23
   },
   "overview": {
     "historicalContext": "Eugène Ehrhart (1906-2000) was a French mathematician who published his landmark theorem in 1962, showing that for any d-dimensional lattice polytope P and positive integer n, the number of lattice points in the dilated polytope nP is a polynomial of degree d in n. This polynomial, now called the Ehrhart polynomial, encodes deep geometric and combinatorial information about the polytope.\n\nEhrhart's theorem provides the correct higher-dimensional generalization of Pick's theorem (1899). While Pick's formula A = i + b/2 - 1 works beautifully in 2D, the Reeve tetrahedra show it cannot extend to 3D. Ehrhart theory explains why: in 2D the polynomial has 3 coefficients determined by 2 independent counts (i and b), but in 3D the polynomial has 4 coefficients while i and b provide only 2 equations.\n\nThe theory was further enriched by Macdonald's reciprocity theorem (1971), connecting interior and boundary counts through sign changes in the polynomial, and Stanley's nonnegativity theorem (1980) for h*-vectors.",
@@ -237,7 +237,7 @@
     "lineCount": 710,
     "sorries": 0,
     "path": "Proofs/EhrhartPolynomialOQ03.lean",
-    "definitionCount": 21,
+    "definitionCount": 23,
     "theoremCount": 45
   }
 }

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -46,7 +46,7 @@
     "assumptions": "1 axiom: picks_theorem (the main theorem statement). Removed inconsistent area_bounded_by_box_axiom (claimed A(P) ≤ w_x*w_y for all w_x,w_y without containment hypothesis).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "Georg Alexander Pick (1859-1942) was an Austrian mathematician who studied under Leo Konigsberger and Felix Klein. He published this theorem in 1899 in the journal *Sitzungsberichte der kaiserlichen Akademie der Wissenschaften*. The result remained obscure for over 60 years until Hugo Steinhaus popularized it in his 1960 book *Mathematical Snapshots*. Pick was murdered in the Theresienstadt concentration camp in 1942.\n\nThe theorem connects two seemingly different mathematical worlds: discrete counting (lattice points) and continuous measurement (area). This connection foreshadowed the development of Ehrhart theory (1962), which generalizes Pick's formula to higher-dimensional lattice polytopes using Ehrhart polynomials.\n\nPick's theorem has a natural proof via triangulation and additivity: verify for the unit right triangle ($i=0, b=3, A=1/2$), then show the formula is preserved when combining polygons along shared edges. An alternative proof uses Euler's formula $V - E + F = 2$ for planar graphs, counting how vertices and edges contribute to interior, boundary, and face counts.\n\nPick's theorem appears as #92 in Freek Wiedijk's list of 100 greatest theorems. It is one of the most accessible results on the list, requiring only basic arithmetic, yet it reveals deep structure connecting discrete and continuous mathematics.",
@@ -226,7 +226,7 @@
     "lineCount": 484,
     "sorries": 0,
     "path": "Proofs/PicksTheorem.lean",
-    "definitionCount": 15,
+    "definitionCount": 16,
     "theoremCount": 12
   }
 }

--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Coxeter-Schlaefli determinant and Gram matrices"
     ],
     "mathlib_version": "4.26.0",
-    "definitionCount": 28
+    "definitionCount": 31
   },
   "overview": {
     "historicalContext": "Ludwig Schlaefli (1852) classified regular polytopes in all dimensions, extending Euclid's classification of the 5 Platonic solids. He discovered that dimension 4 is exceptional: it admits 6 regular polytopes, including the remarkable 24-cell which has no analog in any other dimension. For dimensions 5 and above, only three families survive: the simplex, hypercube, and cross-polytope. H.S.M. Coxeter later systematized this theory using reflection groups and Gram matrices, providing the algebraic framework used in this formalization.",
@@ -169,7 +169,7 @@
     "lineCount": 628,
     "axiomCount": 0,
     "theoremCount": 53,
-    "definitionCount": 28,
+    "definitionCount": 31,
     "mainTheorems": [
       {
         "name": "regular_4polytope_classification",

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -48,7 +48,7 @@
       "Platonic solids classification (parent proof)"
     ],
     "mathlib_version": "4.26.0",
-    "definitionCount": 31
+    "definitionCount": 32
   },
   "overview": {
     "historicalContext": "The Archimedean solids generalize the Platonic solids by relaxing the requirement that all faces be congruent. Instead, all faces must be regular polygons, and the same cyclic arrangement of faces must meet at every vertex. Archimedes reportedly studied these solids, though his original work is lost. Johannes Kepler gave the first systematic enumeration in *Harmonices Mundi* (1619), finding 13 types. The modern rigorous proof follows Grünbaum's *Convex Polytopes* (1967) and Cromwell's *Polyhedra* (1997).\n\nThe classification has two parts: (1) the angle defect constraint narrows the field to finitely many candidate vertex types, and (2) geometric analysis determines which candidates actually close up into convex polyhedra. This formalization handles part (1) computationally and axiomatizes part (2).",
@@ -129,7 +129,7 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 31,
+    "definitionCount": 32,
     "path": "Proofs/PlatonicSolidsOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -44,7 +44,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The Platonic solids were known to the ancient Greeks and studied extensively by Plato (hence the name). Euclid proved in Elements Book XIII that these are the only five regular convex polyhedra. The classification relies on Euler's polyhedral formula V - E + F = 2 combined with regularity constraints: all faces are congruent regular p-gons and q faces meet at each vertex. The five solids correspond to the finite subgroups of SO(3) acting on the sphere, a connection fully developed by Klein (1884). Schläfli (1852) classified regular polytopes in higher dimensions, finding six in dimension 4 and only three (the simplex, hypercube, and cross-polytope) in each dimension 5 and above.",
@@ -141,7 +141,7 @@
     "lineCount": 419,
     "axiomCount": 0,
     "theoremCount": 24,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "mainTheorems": [
       {
         "name": "platonic_classification",

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -54,7 +54,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Lovasz Local Lemma (LLL), proved by Paul Erdos and Laszlo Lovasz in 1975, is widely regarded as the crown jewel of the probabilistic method. It addresses a fundamental limitation of the basic probabilistic method: when bad events are not independent, the naive union bound can be far too pessimistic.\n\nThe LLL shows that if each bad event has small probability and is independent of most other bad events, then with positive probability none of the bad events occur. The precise condition involves a dependency graph: each event must be independent of all events not in its neighborhood, and the probabilities must satisfy a system of inequalities involving the graph structure.\n\nThe symmetric form of the LLL is especially elegant: if each event has probability at most p and depends on at most d other events, and if ep(d+1) <= 1 (where e is Euler's number), then all bad events can be simultaneously avoided. This clean criterion is remarkably powerful.\n\nIn 2010, Moser and Tardos gave a constructive proof of the LLL via a resampling algorithm, resolving a long-standing question about whether the non-constructive existence proof could be made algorithmic. Their proof showed that repeated resampling of violated constraints converges rapidly.",
@@ -207,7 +207,7 @@
     "lineCount": 364,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/LovaszLocalLemma.lean",
     "sorries": 0
   },

--- a/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "lineCount": 228,
     "theoremCount": 6,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "assumptions": "None.",
     "originalContributions": [
       "Dimension-independent proof of the chord quadratic equation in any real inner product space",
@@ -113,7 +113,7 @@
     "lineCount": 228,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/ProductOfSegmentsOfChordsOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -48,7 +48,7 @@
     "assumptions": "1 axiom: converse_product_implies_concyclic_axiom. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The Product of Segments of Chords theorem appears as Proposition 35 in Book III of Euclid's *Elements* (c. 300 BCE), where Euclid proves it using similar triangles: triangles PAC and PDB are similar (by the inscribed angle theorem), giving PA/PD = PC/PB, hence PA·PB = PC·PD. This makes it one of the oldest formally stated results in circle geometry.\n\nThe deeper unifying concept — the *power of a point* — was introduced by Jakob Steiner in his 1826 work *Einige geometrische Betrachtungen*. Steiner recognized that the quantity $d^2 - r^2$ (where $d$ is the distance from the point to the center) is invariant for all lines through the point, unifying four classical theorems: intersecting chords (interior), two secants (exterior), secant-tangent, and two tangents. The radical axis of two circles (locus where powers are equal) became a fundamental tool in projective and inversive geometry.\n\nThis formalization takes the algebraic approach via Vieta's formulas rather than Euclid's synthetic proof, parametrizing chord-circle intersections as roots of a quadratic equation whose constant term equals the power.",
@@ -212,7 +212,7 @@
     "lineCount": 541,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/ProductOfSegmentsOfChords.lean",
     "sorries": 0
   },

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "lineCount": 288,
     "theoremCount": 8,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Ptolemy's theorem (c. 150 AD) states that for a cyclic quadrilateral ABCD in convex position, AC·BD = AB·CD + BC·DA. The question of whether equality alone characterizes concyclic order — the *converse* — was implicit in Ptolemy's work but requires careful proof. In modern terms, it follows from the cross-ratio characterization: for four points on a circle, the cross-ratio R = (z₂-z₃)(z₁-z₄)/((z₁-z₂)(z₃-z₄)) is always real, and R > 0 precisely when the points are in CCW or CW order. This file provides the Lean 4 formalization of the converse direction, completing the full biconditional characterization.",
@@ -151,7 +151,7 @@
     "lineCount": 288,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/PtolemysTheoremOQ01OQ01.lean"
   }

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -67,7 +67,7 @@
     "assumptions": "0 axioms. Structure fields (HyperbolicRightTriangle.law, SphericalRightTriangle.law, SphericalRightTriangleR.law) define the mathematical objects — users must provide proof to construct instances. All 50+ consequence theorems are fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 105,
-    "definitionCount": 18
+    "definitionCount": 21
   },
   "overview": {
     "historicalContext": "The Pythagorean theorem $a^2 + b^2 = c^2$ is arguably the most fundamental metric relation in all of mathematics. Its generalization to non-Euclidean geometries reveals deep connections between algebra, analysis, and geometry.\n\nSpherical trigonometry has ancient roots: the Islamic mathematician al-Battani (c. 858–929 CE) used the spherical law of cosines for astronomical calculations, and Regiomontanus (1436–1476) systematized spherical trigonometry in *De Triangulis Omnimodis* (1464). The spherical Pythagorean theorem $\\cos(c/R) = \\cos(a/R) \\cdot \\cos(b/R)$ was known implicitly through this tradition.\n\nHyperbolic geometry emerged much later. Nikolai Lobachevsky (1829) and János Bolyai (1832) independently discovered that Euclid's parallel postulate could be negated consistently, producing a geometry where the angle sum of triangles is less than $\\pi$. The hyperbolic Pythagorean theorem $\\cosh c = \\cosh a \\cdot \\cosh b$ follows from the hyperbolic metric. Carl Friedrich Gauss had privately anticipated these results but never published them.\n\nThe unification came through Bernhard Riemann's 1854 *Habilitationsschrift*, where he introduced the concept of curvature $\\kappa$ parameterizing a family of geometries. The generalized cosine function $C_\\kappa(x)$ packages all three cases: $\\cos(\\sqrt{\\kappa} \\cdot x)$ for $\\kappa > 0$, $\\cosh(\\sqrt{|\\kappa|} \\cdot x)$ for $\\kappa < 0$, and the flat limit $\\kappa \\to 0$ recovering $a^2 + b^2 = c^2$ via Taylor expansion.\n\nThis formalization answers the open question from our Pythagorean theorem proof: 'What is the analog of the Pythagorean theorem in hyperbolic and spherical geometry?' The 65+ fully proved theorems (zero sorries, zero axioms) cover the complete picture: structures, identities, area-defect formulas, laws of cosines, monotonicity, and quantitative approximation.",
@@ -276,7 +276,7 @@
     "lineCount": 1431,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 18,
+    "definitionCount": 21,
     "theoremCount": 105
   },
   "sorries": 0

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The core theorem is an original construction (badge: original) using Mathlib's `InnerProductSpace` infrastructure — the proof expands $\\langle v+w, v+w \\rangle$ via `inner_add_left`/`inner_add_right` and applies the orthogonality hypothesis to zero the cross terms. The converse direction uses the same bilinearity expansion in reverse.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Pythagorean theorem is arguably the most recognized result in all of mathematics. While named after the Greek mathematician Pythagoras (c. 570-495 BCE), evidence suggests the theorem was known independently in at least three ancient civilizations over 1000 years earlier.\n\nThe Babylonian clay tablet Plimpton 322 (c. 1800 BCE) lists 15 rows of Pythagorean triples in a systematic table, demonstrating that Mesopotamian scribes understood the relationship between the sides of right triangles. The Indian Sulba Sutras (Baudhayana's version c. 800 BCE) state the theorem explicitly — \"the diagonal of a rectangle produces by itself both the areas which the two sides of the rectangle produce separately\" — in the context of Vedic altar construction. Chinese mathematicians recorded the theorem in the Zhou Bi Suan Jing (The Mathematical Classic of the Zhou Gnomon, c. 1000 BCE), where it is known as the Gōu-Gǔ theorem (勾股定理) and attributed to the Duke of Zhou.\n\nPythagoras, or more likely his school, is credited with providing the first general deductive proof in the Greek tradition. The theorem appears as Proposition 47 in Book I of Euclid's Elements (c. 300 BCE), where it's proved via shearing areas of squares constructed on the triangle's sides — a landmark of axiomatic geometry. The converse appears as Proposition I.48.\n\nBy 1940, mathematician Elisha Loomis had catalogued 367 distinct proofs, and new proofs continue to be discovered. James Garfield, before becoming the 20th US President, published an elegant trapezoid-area proof in 1876. In 2023, high school students Ne'Kiya Jackson and Calcea Johnson presented a trigonometric proof avoiding circular reasoning, historically thought impossible.",
@@ -281,7 +281,7 @@
     "lineCount": 214,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "substantiveTheoremCount": 3,
     "trivialSpecializations": 3,
     "mainTheorems": [

--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -89,7 +89,7 @@
     "lineCount": 2485,
     "mathlib_version": "4.26.0",
     "theoremCount": 117,
-    "definitionCount": 39,
+    "definitionCount": 40,
     "additionalFiles": [
       "Proofs/PythagoreanTriplesOQ01Aristotle.lean"
     ]
@@ -240,7 +240,7 @@
     "lineCount": 2485,
     "axiomCount": 7,
     "theoremCount": 117,
-    "definitionCount": 39,
+    "definitionCount": 40,
     "path": "Proofs/PythagoreanTriplesOQ01.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Batch-synchronize `meta.definitionCount` and `leanFile.definitionCount`
for 26 gallery entries in the `m-` / `p-` slug range where the recorded
count diverged from the actual declarations in the primary Lean file.

Counting convention (per memory note `feedback_mechanic_def_counting`):
`def + abbrev + opaque + structure + inductive + class`, including
modifiers (`noncomputable`, `private`, `partial`, `protected`,
`scoped`, `unsafe`); `instance` excluded.

Complements the in-flight a-c batches in #17407 / #17422 / #17409 and
the merged d-e batch (#17429) and f-l batch (#17430). No alphabetic
overlap.

## Evidence

Drift detected via stripped-comments regex scan over the file
referenced by `leanFile.path` (relative to `proofs/`):
- block + line comments stripped (nested `/-` … `-/` honored)
- decl-head regex: `^\s*(?:(?:private|protected|noncomputable|partial|unsafe|scoped)\s+)*(?:def|abbrev|opaque|structure|inductive|class)\s+`
- `instance` excluded by construction

Each entry's pair (`meta.definitionCount`, `leanFile.definitionCount`)
was already equal; both updated to the actual count via a single
`str.replace("\"definitionCount\": <old>", "\"definitionCount\": <new>")`
that captured both occurrences atomically. JSON parse-validated
post-edit.

## Per-entry deltas (claimed → actual)

| slug | old | new |
|---|---|---|
| minkowski-fundamental-theorem | 14 | 17 |
| minkowski-theorem | 14 | 17 |
| morleys-theorem | 12 | 13 |
| morleys-theorem-oq-01 | 8 | 9 |
| motivic-flag-maps | 17 | 21 |
| motivic-flag-maps-oq-02 | 16 | 18 |
| p-vs-np | 150 | 154 |
| parallel-postulate-independence | 3 | 7 |
| parallel-postulate-independence-oq-02 | 17 | 21 |
| partition-theorem-oq-03 | 1 | 2 |
| pascals-hexagon | 27 | 28 |
| picks-theorem | 15 | 16 |
| picks-theorem-oq-01-oq-01 | 5 | 6 |
| picks-theorem-oq-01-oq-02 | 6 | 7 |
| picks-theorem-oq-03 | 21 | 23 |
| picks-theorem-oq-03-product | 12 | 13 |
| platonic-solids | 10 | 11 |
| platonic-solids-oq-01 | 28 | 31 |
| platonic-solids-oq-02 | 31 | 32 |
| prob-method-lovasz-local | 2 | 3 |
| product-of-segments-of-chords | 3 | 4 |
| product-of-segments-of-chords-oq-01 | 1 | 2 |
| ptolemys-theorem-oq-01-oq-01 | 1 | 2 |
| pythagorean-theorem | 2 | 3 |
| pythagorean-theorem-oq-03 | 18 | 21 |
| pythagorean-triples-oq-01 | 39 | 40 |

Surgical 2-line `.replace()` per file; no other formatting changed.
No Lean source changes.

---
Automated fix by lean-mechanic agent.