### PR TITLE
research(erdos-1151-oq-04): S25 — Step 7c combine helper (replay of stale PR #17386, build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -2085,6 +2085,67 @@ private lemma chebyshev_quarter_floor_log_asymp_lb
   push_cast at h_log_ineq
   linarith
 
+/-- **(Step 7c combine helper) Min-of-two-constants closure.**
+
+    Given an asymptotic `C₁ · n · log(n+1) ≤ S(θ, n)` for all `n ≥ N₀`
+    (the user's responsibility — typically built from `trig_sum_subsum_log_lb`
+    with `m := ⌊nd/(4π)⌋` plus arithmetic comparing `log(m+2)` to `log(n+1)`)
+    and the finite-set min' lower bound from `trig_sum_small_n_const`, the
+    unified `C · n · log(n+1) ≤ S(θ, n)` for all `n ≥ 1` follows by case split
+    with `C := min C₁ C₂`.
+
+    This is the **case-split closure** of Step 7 in the proof of
+    `trig_sum_harmonic_lb`: it factors the unified-constant arithmetic out of
+    the main proof so that the only remaining work in `trig_sum_harmonic_lb`
+    is producing the asymptotic side `hlarge`. With S24's
+    `chebyshev_quarter_floor_log_asymp_lb` (Step 7a) plus
+    `trig_sum_subsum_log_lb` (Step 6c, S21), the asymptotic
+    `(sin(θ/2) / (2π)) · (1/4) · n · log(n+1)` lower bound is at hand.
+
+    Note: `N₀` is unconstrained — the helper handles `N₀ = 0` (trivial — `hlarge`
+    already covers all `n ≥ 1`, the small-n branch is still applied so the
+    final `C` accounts for both bounds), `N₀ = 1` (`hsmall` covers only `n = 1`,
+    `hlarge` covers `n ≥ 1`), and `N₀ ≥ 2` (the standard split). -/
+private lemma trig_sum_combine_small_large_const
+    (θ : ℝ)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k)
+    (N₀ : ℕ)
+    {C₁ : ℝ} (hC₁_pos : 0 < C₁)
+    (hlarge : ∀ n : ℕ, N₀ ≤ n →
+      C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k|) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      C * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k| := by
+  -- Cutoff `N := max N₀ 1` is always ≥ 1, so `trig_sum_small_n_const` applies.
+  set N : ℕ := max N₀ 1 with hN_def
+  have hN_ge : 1 ≤ N := le_max_right N₀ 1
+  obtain ⟨C₂, hC₂_pos, hsmall⟩ := trig_sum_small_n_const θ hne N hN_ge
+  refine ⟨min C₁ C₂, lt_min hC₁_pos hC₂_pos, fun n hn₁ => ?_⟩
+  -- Denominator nonneg: n ≥ 1 ⇒ n·log(n+1) ≥ 0 (in fact > 0, but ≥ 0 suffices).
+  have hg_nn : 0 ≤ (↑n : ℝ) * Real.log ((↑n : ℝ) + 1) := by
+    apply mul_nonneg (by exact_mod_cast Nat.zero_le n)
+    apply Real.log_nonneg
+    have hn_ge : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn₁
+    linarith
+  by_cases hcase : n ≤ N
+  · -- Small-n branch: 1 ≤ n ≤ N ⇒ apply `hsmall`; min ≤ C₂ by `min_le_right`.
+    calc min C₁ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+        ≤ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) :=
+          mul_le_mul_of_nonneg_right (min_le_right _ _) hg_nn
+      _ ≤ _ := hsmall n hn₁ hcase
+  · -- Large-n branch: n > N ≥ N₀ ⇒ apply `hlarge`; min ≤ C₁ by `min_le_left`.
+    push_neg at hcase
+    have hN₀_le_n : N₀ ≤ n := by
+      have hN₀_le_N : N₀ ≤ N := le_max_left N₀ 1
+      omega
+    calc min C₁ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+        ≤ C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) :=
+          mul_le_mul_of_nonneg_right (min_le_left _ _) hg_nn
+      _ ≤ _ := hlarge n hN₀_le_n
+
 private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
     (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
     ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →

--- a/research/problems/erdos-1151-oq-04/session-25-combine-replay.md
+++ b/research/problems/erdos-1151-oq-04/session-25-combine-replay.md
@@ -1,0 +1,124 @@
+# Session 25 (2026-05-08, researcher-1): Step 7c combine helper replay
+
+**Phase**: ACT
+**Outcome**: trig_sum_combine_small_large_const helper added (replay of stale PR #17386). Step 7 helpers fully populated.
+
+## Problem context
+
+PR #17386 (S23, researcher-N, 2026-05-08T19:37Z) added a `trig_sum_combine_small_large_const`
+helper — the min-of-two-constants closure for the Step 7 unified-constant arithmetic in
+`trig_sum_harmonic_lb`. The PR was technically sound but went CONFLICTING after several
+subsequent merges:
+
+- **S22 PR #17324** (h_interior verifier, merged ~19:10Z)
+- **S22 PR #17330** (trig_sum_small_n_const, merged ~18:43Z — actually before #17386)
+- **S24 PR #17438** (chebyshev_quarter_floor_log_asymp_lb, merged 21:14Z)
+
+#17386 was never rebased — sat stale for ~3 hours, blocking the Step 7 closure path.
+
+## Resolution: PR-rebase-via-new-branch
+
+Per memory pattern `feedback_researcher_pr_rebase_strategy.md`, this session opens a fresh
+branch off current `origin/main` and inserts the helper at the now-correct position
+(between S24's `chebyshev_quarter_floor_log_asymp_lb` and `trig_sum_harmonic_lb`).
+
+The helper proof body transfers verbatim; only the docstring is augmented to mention
+S24's now-available companion. The original PR insertion point (after `trig_sum_small_n_const`,
+before `trig_sum_harmonic_lb`) has been displaced by S24's helper, so the new insertion
+is one section later.
+
+## Helper added
+
+**Location**: §X of `proofs/Proofs/Erdos1151OQ04.lean`, lines 2087–2147 (after S24's
+helper which spans 2009–2086, before `trig_sum_harmonic_lb` at line 2149).
+
+**Signature**:
+
+```lean
+private lemma trig_sum_combine_small_large_const
+    (θ : ℝ)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k)
+    (N₀ : ℕ)
+    {C₁ : ℝ} (hC₁_pos : 0 < C₁)
+    (hlarge : ∀ n : ℕ, N₀ ≤ n →
+      C₁ * ((n : ℝ) * log ((n : ℝ) + 1)) ≤ S(θ, n)) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      C * ((n : ℝ) * log ((n : ℝ) + 1)) ≤ S(θ, n)
+```
+
+**Proof structure**:
+
+1. Set `N := max N₀ 1`. Apply `trig_sum_small_n_const θ hne N (by le_max_right)` to get C₂.
+2. Set `C := min C₁ C₂`. The witness is `⟨C, lt_min hC₁_pos hC₂_pos, ...⟩`.
+3. Case-split on `n ≤ N`:
+   - **Small-n branch** (n ≤ N): apply `hsmall n hn₁ hcase`. Use `min_le_right` to drop `C` to `C₂`.
+   - **Large-n branch** (n > N ≥ N₀): apply user's `hlarge n (by omega)`. Use `min_le_left` to drop `C` to `C₁`.
+4. Both branches use `mul_le_mul_of_nonneg_right` with `0 ≤ n·log(n+1)` (proved via
+   `Real.log_nonneg` + `mul_nonneg`).
+
+## Step 7 closure picture (after this PR)
+
+| Step | Helper | Status |
+|------|--------|--------|
+| 6c   | `trig_sum_subsum_log_lb`         | merged (S21, PR #17046) |
+| 7a   | `chebyshev_quarter_floor_log_asymp_lb` | merged (S24, PR #17438) |
+| 7b   | `trig_sum_small_n_const`         | merged (S22, PR #17330) |
+| 7b   | `chebyshev_h_interior_of_close_and_max_index_cap` | merged (S22, PR #17324) |
+| 7c   | `trig_sum_combine_small_large_const` | **this PR** (S25 replay) |
+
+## What's left for trig_sum_harmonic_lb
+
+**Caller-side glue** (S26+):
+
+1. WLOG `θ ∈ (0, π/2]` via `trig_sum_reindex_symmetry` (S18, merged).
+2. Pick `m := ⌊n·θ/(4π)⌋ : ℕ` — satisfies `(m : ℝ) ≥ n·θ/(4π) − 1` via `Nat.lt_floor_add_one`.
+3. Apply S22 `h_interior` verifier + S21 `trig_sum_subsum_log_lb` to get
+   `(sin(θ/2)/(2π)) · ((1/2)·log(m+2) − 1) ≤ S(θ, n)`.
+4. Apply S24 `chebyshev_quarter_floor_log_asymp_lb` to convert
+   `(1/2)·log(m+2) − 1 ≥ (1/4)·log(n+1)` for `n ≥ N₀(θ)`.
+5. Combine into `hlarge : ∀ n ≥ N₀, (sin(θ/2)/(2π)) · (1/4) · n · log(n+1) ≤ S(θ, n)`.
+6. Pass C₁ := sin(θ/2)/(8π), N₀, hlarge to `trig_sum_combine_small_large_const`.
+
+This caller-glue is itself ~50–80 lines. Estimated S26 size.
+
+## Counts delta
+
+|              | Before (S24)     | After (S25)       | Δ    |
+|--------------|-----------------:|------------------:|-----:|
+| Lines        | 2288             | 2349              | +61  |
+| Theorems     | 59               | 60                | +1   |
+| Axioms       | 1                | 1                 | 0    |
+| Sorries      | 2                | 2                 | 0    |
+
+The +61 vs PR #17386's +58 reflects 3 additional docstring lines added to mention
+S24's `chebyshev_quarter_floor_log_asymp_lb` (which didn't exist when #17386 was authored).
+
+## Mathlib API surface
+
+Zero new lemmas. Composes from existing helpers:
+- `trig_sum_small_n_const` (file-local, S22)
+- `lt_min`, `min_le_left`, `min_le_right`, `mul_le_mul_of_nonneg_right`,
+  `mul_nonneg`, `Real.log_nonneg`, `le_max_right`, `le_max_left`,
+  `omega`, `linarith`, `by_cases`, `push_neg`, `exact_mod_cast`.
+
+No new imports.
+
+## Build status
+
+**[BUILD UNVERIFIED]** — Docker build queued. Proof body is verbatim from
+PR #17386's working theorem (which was build-pending in #17386 too;
+neither has Docker-verified). Per memory `feedback_researcher_lake_symlink_broken.md`,
+local builds re-clone Mathlib (~30–45 min); risk profile is identical to other
+build-pending Step 7 PRs.
+
+## Stale PR #17386
+
+Should be closed (the helper has been rebased here).
+
+## References
+
+- Stale PR #17386 (origin/research/...-s23-step-7c-combine, researcher-N)
+- Memory: `feedback_researcher_pr_rebase_strategy.md`
+- `proofs/Proofs/Erdos1151OQ04.lean` lines 2087–2147 (this PR)
+- S24 PR #17438 (asymptotic log lb), S22 PRs #17324/#17330 (h_interior, small-n const),
+  S21 PR #17046 (subsum log lb), S18 PR #17050 (reindex symmetry).

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,8 +4,71 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 24
+**Iteration**: 25 (S25 — combine helper, replay of stale PR #17386)
 **Last Updated**: 2026-05-08
+
+## Session 25 (researcher-1, 2026-05-08, replay of stale PR #17386)
+
+S23 (PR #17386) added `trig_sum_combine_small_large_const` (~58 lines) at
+2026-05-08T19:37Z, but went CONFLICTING after S22 (#17324, #17330) and S24
+(#17438) merged on top of its base. It was never rebased — sat stale for
+~3 hours.
+
+Per memory pattern `feedback_researcher_pr_rebase_strategy.md`, this PR
+opens a fresh branch off current `origin/main` and inserts the S23 helper
+between the now-merged S24 helper (`chebyshev_quarter_floor_log_asymp_lb`)
+and `trig_sum_harmonic_lb`. The proof body transfers verbatim; only the
+docstring is augmented to reference S24's now-available companion.
+
+The helper signature:
+
+```lean
+private lemma trig_sum_combine_small_large_const
+    (θ : ℝ) (hne : ∀ n > 0, ∀ k : Fin n, cos θ ≠ chebyshevNode n k)
+    (N₀ : ℕ) {C₁ : ℝ} (hC₁_pos : 0 < C₁)
+    (hlarge : ∀ n ≥ N₀, C₁ · n · log(n+1) ≤ S(θ, n)) :
+    ∃ C, 0 < C ∧ ∀ n ≥ 1, C · n · log(n+1) ≤ S(θ, n)
+```
+
+**Proof**: case-split on `n ≤ max N₀ 1`. Small-n branch uses
+`trig_sum_small_n_const θ hne (max N₀ 1) (by omega)` to get C₂; then
+`min C₁ C₂ ≤ C₂` plus `n·log(n+1) ≥ 0` gives the bound. Large-n branch
+uses user's `hlarge` directly with `min C₁ C₂ ≤ C₁`.
+
+### Step 7 closure picture (after S25)
+
+| Step | Helper | Status |
+|------|--------|--------|
+| 6c   | `trig_sum_subsum_log_lb`         | merged (S21, PR #17046) |
+| 7a   | `chebyshev_quarter_floor_log_asymp_lb` | merged (S24, PR #17438) |
+| 7b   | `trig_sum_small_n_const`         | merged (S22, PR #17330) |
+| 7b   | `chebyshev_h_interior_of_close_and_max_index_cap` | merged (S22, PR #17324) |
+| 7c   | `trig_sum_combine_small_large_const` | **this PR** (S25 replay) |
+
+With all five helpers in place, the only remaining work in
+`trig_sum_harmonic_lb` is **caller-side glue** that:
+
+1. WLOG `θ ∈ (0, π/2]` via `trig_sum_reindex_symmetry` (S18, merged).
+2. Picks `m := ⌊n·θ/(4π)⌋ : ℕ` — satisfies `(m : ℝ) ≥ n·θ/(4π) − 1` via `Nat.lt_floor_add_one`.
+3. Applies S22's `h_interior` verifier + S21's `trig_sum_subsum_log_lb` to get
+   `(sin(θ/2)/(2π)) · ((1/2)·log(m+2) − 1) ≤ S(θ, n)`.
+4. Applies S24's `chebyshev_quarter_floor_log_asymp_lb` to convert the
+   `(1/2)·log(m+2) − 1` factor to `(1/4)·log(n+1)` for `n ≥ N₀(θ)`.
+5. Hands `C₁ := sin(θ/2)/(2π) · 1/4` and the resulting `hlarge` to S25's
+   `trig_sum_combine_small_large_const` to produce the unified `C·n·log(n+1)`.
+
+### Counts
+
+- `lineCount`: 2288 → 2349 (+61, includes augmented docstring referencing S24)
+- `theoremCount`: 59 → 60 (+1: trig_sum_combine_small_large_const)
+- `axiomCount`: 1 (unchanged: `erdos_1151` — open conjecture)
+- `sorries`: 2 (unchanged: `trig_sum_harmonic_lb` and `divergence_from_lebesgue_growth`)
+
+### Build status
+
+**[BUILD UNVERIFIED]** — Docker build queued. Proof body is verbatim from
+PR #17386's working theorem; only the docstring was augmented to mention
+S24's `chebyshev_quarter_floor_log_asymp_lb`.
 
 ## Session 24 (researcher-4, this session, build pending)
 

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 2 sorries remain in Erdos1151OQ04.lean. Step 7b (finite-set small-n side of trig_sum_harmonic_lb) closed via S22 trig_sum_small_n_const. Step 7a (asymptotic large-n side) outstanding; will combine via min-of-two-constants. Sorry 2 (divergence_from_lebesgue_growth) blocked on lacunary series construction or weakening to lim sup.",
+    "progressSummary": "S25 (researcher-1, 2026-05-08, ACT, replay): adds trig_sum_combine_small_large_const (~58 lines) — the **min-of-two-constants closure** of Step 7. Replays stale PR #17386 (researcher-N, S23, CONFLICTING ~3 hours after S22+S24 merged on top of its base) onto fresh origin/main. Per memory pattern feedback_researcher_pr_rebase_strategy.md. Helper signature: given C₁·n·log(n+1) ≤ S(θ,n) for n≥N₀ (user's hlarge), composes with trig_sum_small_n_const (S22) to give a unified C·n·log(n+1) bound for all n≥1 with C := min C₁ C₂ via case-split on n ≤ max N₀ 1. Inserted between chebyshev_quarter_floor_log_asymp_lb (S24, just merged) and trig_sum_harmonic_lb. With S25 (combine), S24 (Step 7a asymp lb), S22 (small-n const), S22 (h_interior), and S21 (Step 6c log lb), the only remaining work in trig_sum_harmonic_lb is the asymptotic-side caller-glue: WLOG θ ∈ (0,π/2] via S18, pick m := ⌊nθ/(4π)⌋, apply S22 h_interior + S21 to get the asymptotic side, hand off to S25. +61 lines, +1 thm (combine helper), 0 axioms changed (still 1: erdos_1151), 1 sorry unchanged (trig_sum_harmonic_lb itself). Total: 2349 lines, 60 thms in this file. Build pending. Previous: PROGRESS: 2 sorries remain in Erdos1151OQ04.lean. Step 7b (finite-set small-n side of trig_sum_harmonic_lb) closed via S22 trig_sum_small_n_const. Step 7a (asymptotic large-n side) outstanding; will combine via min-of-two-constants. Sorry 2 (divergence_from_lebesgue_growth) blocked on lacunary series construction or weakening to lim sup.",
     "builtItems": [
       "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
       "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
@@ -71,7 +71,8 @@
       "trig_sum_subsum_lb (n hn θ d hd_pos hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1393 (Step 6b, ~104 lines)",
       "trig_sum_reindex_symmetry (n hn θ) : Σ_k sin(φ_k)/|cos θ - cn| = Σ_k sin(φ_k)/|cos(π-θ) - cn| via the involution σ : Fin n ≃ Fin n, k ↦ n-1-k. Combines Equiv.sum_comp + sin_pi_sub + cos_pi_sub + abs_neg. ~70 lines, Erdos1151OQ04.lean:1498 (Session 18, #17050)",
       "trig_sum_subsum_log_lb (n hn θ d hd_pos hd_le_pi hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · ((1/2)·log(m+2) - 1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1510 (Step 6c, ~36 lines, composes 6a + 6b). Recovered from PR #17046 (Session 21)",
-      "trig_sum_small_n_const (θ hne N hN) : ∃ C > 0, ∀ n ∈ {1,...,N}, C·n·log(n+1) ≤ S(θ,n) — Erdos1151OQ04.lean:1675 (Step 7b finite-set min'; ~80 lines, S22)"
+      "trig_sum_small_n_const (θ hne N hN) : ∃ C > 0, ∀ n ∈ {1,...,N}, C·n·log(n+1) ≤ S(θ,n) — Erdos1151OQ04.lean:1675 (Step 7b finite-set min'; ~80 lines, S22)",
+      "S25 (researcher-1, 2026-05-08, replay of stale PR #17386): trig_sum_combine_small_large_const (private lemma, ~58 lines) in Erdos1151OQ04.lean §X (lines 2109-2147). Min-of-two-constants closure of Step 7."
     ],
     "insights": [
       "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
@@ -114,7 +115,8 @@
       "Reindex symmetry: S(θ, n) = S(π-θ, n) via the involution σ : Fin n ≃ Fin n, k ↦ n-1-k. The angle reflection φ_{σ k} = π - φ_k follows from algebraic identity (2(n-1-k)+1)π/(2n) = π - (2k+1)π/(2n); sin invariant under x ↦ π-x; cos sign-flips under x ↦ π-x. Combined with cos(π-θ) = -cos θ, the denominator |cos(π-θ) - (-cn)| = |cos θ - cn| via abs_neg. Reduces trig_sum_harmonic_lb to θ ∈ (0, π/2].",
       "When θ ∈ (0, π/2]: d = min(θ, π-θ) = θ; so d/2 = θ/2 and π - d/2 = π - θ/2. The going-up sub-sum upper bound (2j+3)π/(2n) ≤ π - d/2 - θ becomes (2j+3)π/(2n) ≤ π - 3θ/2, giving m ≤ n(2π - 3θ)/(4π) - 3/2. For θ < 2π/3 this is positive, and at θ = π/2 it gives m ≤ n/8 - 3/2.",
       "When θ ∈ (π/2, π): use trig_sum_reindex_symmetry to pass to θ' = π - θ ∈ (0, π/2). The going-up sub-sum at θ' applies. This avoids needing a separate going-down sub-sum lemma.",
-      "Step 7 split: factor finite-set min' (small n ≤ N) and asymptotic bound (large n ≥ N) into separate lemmas, then take pointwise min. The finite-set side is now closed (S22 trig_sum_small_n_const) using Finset.min' over the image of the ratio S(θ,n) / (n·log(n+1)). Each ratio is positive (chebyshev_trig_sum_pos numerator + log(n+1) ≥ log 2 denominator), so min is positive; le_div_iff inverts the division."
+      "Step 7 split: factor finite-set min' (small n ≤ N) and asymptotic bound (large n ≥ N) into separate lemmas, then take pointwise min. The finite-set side is now closed (S22 trig_sum_small_n_const) using Finset.min' over the image of the ratio S(θ,n) / (n·log(n+1)). Each ratio is positive (chebyshev_trig_sum_pos numerator + log(n+1) ≥ log 2 denominator), so min is positive; le_div_iff inverts the division.",
+      "S25 (2026-05-08): the unified-constant arithmetic of Step 7 factors cleanly into trig_sum_combine_small_large_const, which is independent of θ ∈ (0,π/2) reduction and the Lipschitz/min'-bound machinery. The helper takes the asymptotic side as a user-supplied hypothesis (`hlarge`), so the caller can choose any N₀ and any C₁ — the helper handles the case split with N := max N₀ 1, ensuring small-n is always covered by trig_sum_small_n_const. The min-of-two-constants idiom (case-split + monotonicity) is a recurring pattern; this is the third use in this file (after S20 chebyshev_trig_sum_pos and S22 trig_sum_small_n_const). Worth promoting to a higher-level utility once Step 7 closes."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -146,15 +148,15 @@
     "mathlib": []
   },
   "started": "2026-04-21T19:30:00.000Z",
-  "lastUpdate": "2026-05-08T11:00:00Z",
+  "lastUpdate": "2026-05-08T21:48:03Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2288,
-      "theoremCount": 59,
+      "lineCount": 2349,
+      "theoremCount": 60,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary

Replays PR #17386's `trig_sum_combine_small_large_const` helper onto fresh
`origin/main`. PR #17386 (S23, 2026-05-08T19:37Z) went CONFLICTING after S22
(#17324, #17330) and S24 (#17438) merged on top of its base, and was never
rebased.

Per memory pattern `feedback_researcher_pr_rebase_strategy.md`, this PR
opens a fresh branch and inserts the helper at the correct new location:
between S24's `chebyshev_quarter_floor_log_asymp_lb` (lines 2009-2086) and
`trig_sum_harmonic_lb` (line 2149).

## Helper added

```lean
private lemma trig_sum_combine_small_large_const
    (θ : ℝ) (hne : ∀ n > 0, ∀ k : Fin n, cos θ ≠ chebyshevNode n k)
    (N₀ : ℕ) {C₁ : ℝ} (hC₁_pos : 0 < C₁)
    (hlarge : ∀ n ≥ N₀, C₁ · n · log(n+1) ≤ S(θ, n)) :
    ∃ C, 0 < C ∧ ∀ n ≥ 1, C · n · log(n+1) ≤ S(θ, n)
```

**Proof**: case-split on `n ≤ max N₀ 1`. Small-n branch uses
`trig_sum_small_n_const` (S22) for C₂; `min C₁ C₂ ≤ C₂` + `n·log(n+1) ≥ 0`
gives the bound. Large-n branch uses user's `hlarge` with `min C₁ C₂ ≤ C₁`.
Zero new imports.

The proof body transfers verbatim from PR #17386; only the docstring is
augmented to mention S24's now-available companion
`chebyshev_quarter_floor_log_asymp_lb`.

## Step 7 closure picture (after this PR)

| Step | Helper | Status |
|------|--------|--------|
| 6c   | `trig_sum_subsum_log_lb`         | merged (S21, PR #17046) |
| 7a   | `chebyshev_quarter_floor_log_asymp_lb` | merged (S24, PR #17438) |
| 7b   | `trig_sum_small_n_const`         | merged (S22, PR #17330) |
| 7b   | `chebyshev_h_interior_of_close_and_max_index_cap` | merged (S22, PR #17324) |
| 7c   | `trig_sum_combine_small_large_const` | **this PR** (S25 replay) |

## What's left for trig_sum_harmonic_lb

**Caller-side glue** (S26+):

1. WLOG `θ ∈ (0, π/2]` via `trig_sum_reindex_symmetry` (S18, merged).
2. Pick `m := ⌊n·θ/(4π)⌋`, apply S22+S21 → asymptotic side.
3. Apply S24 to convert `(1/2)·log(m+2) − 1 ≥ (1/4)·log(n+1)` for `n ≥ N₀(θ)`.
4. Hand `C₁ := sin(θ/2)/(8π)`, `N₀`, `hlarge` to `trig_sum_combine_small_large_const`.

~50-80 lines for caller-glue, then `trig_sum_harmonic_lb`'s sorry closes.

## Counts

|              | Before (S24)     | After (S25)       | Δ    |
|--------------|-----------------:|------------------:|-----:|
| Lines        | 2288             | 2349              | +61  |
| Theorems     | 59               | 60                | +1   |
| Axioms       | 1                | 1                 | 0    |
| Sorries      | 2                | 2                 | 0    |

The +61 vs PR #17386's +58 reflects 3 additional docstring lines mentioning
S24 (which didn't exist when #17386 was authored).

## Build status

**[BUILD UNVERIFIED]** — Docker build queued. Proof body verbatim from PR #17386's working theorem. Risk-equivalent to other build-pending Step 7 PRs.

## Files modified

- `proofs/Proofs/Erdos1151OQ04.lean` — new helper at §X (lines 2087-2147)
- `src/data/research/problems/erdos-1151-oq-04.json` — leanFile.lineCount 2288→2349, theoremCount 59→60; +1 insight, +1 builtItem
- `research/problems/erdos-1151-oq-04/state.md` — Iteration 25 section
- `research/problems/erdos-1151-oq-04/session-25-combine-replay.md` — session note (NEW)

## Stale PR #17386

Should be closed (the helper has been rebased here).

## Outcome

**Progress** (Step 7 helpers fully populated; 1 helper added, no sorry delta).

🤖 Generated by researcher-1