### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S11 — Part XVII concrete plateau collapse instances

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -804,6 +804,127 @@ theorem symBUDim_const_in_no_prime_range_of (h_conj : ConjectureLPB)
   exact symBUDim_eq_of_lpb_eq_of h_conj n m d hn hm
     (largestPrimeBelow_const_in_no_prime_range n m hnm h_no_prime).symm
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XVII: Concrete plateau collapse instances
+-- ═══════════════════════════════════════════════════════════════════════
+-- Direct applications of PART XVI's plateau infrastructure to specific
+-- prime-gap intervals.  Each instance pins a no-prime-in-gap fact via
+-- `interval_cases` + `decide`, then derives:
+--   1. Axiom-free LPB collapse: `largestPrimeBelow m = largestPrimeBelow n`.
+--   2. Conditional `symBUDim` collapse: `symBUDim n d = symBUDim m d`,
+--      depending on `symBUDim_eq_largestPrime`.
+--   3. Hypothesis-form variant taking `ConjectureLPB` explicitly.
+--
+-- Chosen intervals are the smallest prime gaps with multiple composite
+-- numbers between consecutive primes:
+--   - (7, 11):   {8, 9, 10}                 — gap 4, dyadic gap
+--   - (13, 17):  {14, 15, 16}               — gap 4
+--   - (23, 29):  {24, 25, 26, 27, 28}       — gap 6 (first occurrence)
+--
+-- The conditional consequences are notable: distinct symmetric groups
+-- with qualitatively different subgroup structures (e.g., S₈ ⊃ V₄·A₄
+-- vs S₁₀ ⊃ A₅×A₅; or S₂₃ vs S₂₈ ⊃ S₄×S₂₄/?) conjecturally share the
+-- *same* equivariant Borsuk-Ulam dimension at every dimension.
+
+/-- **No prime in (8, 10]**: each of 9, 10 is composite. Witness for
+    the dyadic prime gap (7, 11). -/
+theorem no_prime_in_eight_to_ten :
+    ∀ k, 8 < k → k ≤ 10 → ¬ Nat.Prime k := by
+  intro k hk1 hk2
+  interval_cases k <;> decide
+
+/-- **LPB plateau across the dyadic gap (7, 11)**: `largestPrimeBelow 10 =
+    largestPrimeBelow 8`, axiom-free.  Combined with `largestPrimeBelow 8
+    = largestPrimeBelow 7 = 7` (which would follow from the still-pending
+    PART XII concrete-LPB computations), this would witness the
+    three-step plateau `lpb 8 = lpb 9 = lpb 10`.  Independent of those
+    concrete values, the equality `lpb 10 = lpb 8` is a direct corollary
+    of PART XVI's `largestPrimeBelow_const_in_no_prime_range`. -/
+theorem largestPrimeBelow_eight_eq_ten :
+    largestPrimeBelow 10 = largestPrimeBelow 8 :=
+  largestPrimeBelow_const_in_no_prime_range 8 10 (by norm_num)
+    no_prime_in_eight_to_ten
+
+/-- **Conjectural plateau collapse at S₈ → S₁₀**: under
+    `symBUDim_eq_largestPrime`, `symBUDim 8 d = symBUDim 10 d` for every
+    `d`.  Witnesses the most concrete plateau-collapse content of the
+    conjecture: two distinct symmetric groups (S₈ with rich V₄·A₄ subgroup
+    structure, S₁₀ with A₅×A₅) conjecturally share equivariant Borsuk-Ulam
+    dimensions at every dimension. -/
+theorem symBUDim_eight_eq_ten (d : ℕ) :
+    symBUDim 8 d = symBUDim 10 d :=
+  symBUDim_const_in_no_prime_range 8 10 d (by norm_num) (by norm_num)
+    no_prime_in_eight_to_ten
+
+/-- **Hypothesis-form** of `symBUDim_eight_eq_ten` — uses explicit
+    `ConjectureLPB` hypothesis instead of the file's axiom. -/
+theorem symBUDim_eight_eq_ten_of (h_conj : ConjectureLPB) (d : ℕ) :
+    symBUDim 8 d = symBUDim 10 d :=
+  symBUDim_const_in_no_prime_range_of h_conj 8 10 d (by norm_num) (by norm_num)
+    no_prime_in_eight_to_ten
+
+/-- **No prime in (13, 16]**: each of 14, 15, 16 is composite.  Witness
+    for the prime gap (13, 17). -/
+theorem no_prime_in_fourteen_to_sixteen :
+    ∀ k, 13 < k → k ≤ 16 → ¬ Nat.Prime k := by
+  intro k hk1 hk2
+  interval_cases k <;> decide
+
+/-- **LPB plateau across the gap (13, 17)**: `largestPrimeBelow 16 =
+    largestPrimeBelow 13`, axiom-free. -/
+theorem largestPrimeBelow_thirteen_eq_sixteen :
+    largestPrimeBelow 16 = largestPrimeBelow 13 :=
+  largestPrimeBelow_const_in_no_prime_range 13 16 (by norm_num)
+    no_prime_in_fourteen_to_sixteen
+
+/-- **Conjectural plateau collapse at S₁₃ → S₁₆**: under
+    `symBUDim_eq_largestPrime`, `symBUDim 13 d = symBUDim 16 d` for every
+    `d`. -/
+theorem symBUDim_thirteen_eq_sixteen (d : ℕ) :
+    symBUDim 13 d = symBUDim 16 d :=
+  symBUDim_const_in_no_prime_range 13 16 d (by norm_num) (by norm_num)
+    no_prime_in_fourteen_to_sixteen
+
+/-- **Hypothesis-form** of `symBUDim_thirteen_eq_sixteen`. -/
+theorem symBUDim_thirteen_eq_sixteen_of (h_conj : ConjectureLPB) (d : ℕ) :
+    symBUDim 13 d = symBUDim 16 d :=
+  symBUDim_const_in_no_prime_range_of h_conj 13 16 d (by norm_num) (by norm_num)
+    no_prime_in_fourteen_to_sixteen
+
+/-- **No prime in (23, 28]**: each of 24, 25, 26, 27, 28 is composite.
+    Witness for the prime gap (23, 29) — the first prime gap of size 6,
+    five consecutive composites. -/
+theorem no_prime_in_twentyfour_to_twentyeight :
+    ∀ k, 23 < k → k ≤ 28 → ¬ Nat.Prime k := by
+  intro k hk1 hk2
+  interval_cases k <;> decide
+
+/-- **LPB plateau across the gap (23, 29)**: `largestPrimeBelow 28 =
+    largestPrimeBelow 23`, axiom-free.  The first prime gap of size 6
+    in ℕ — five consecutive composites all share the same
+    `largestPrimeBelow`. -/
+theorem largestPrimeBelow_twentythree_eq_twentyeight :
+    largestPrimeBelow 28 = largestPrimeBelow 23 :=
+  largestPrimeBelow_const_in_no_prime_range 23 28 (by norm_num)
+    no_prime_in_twentyfour_to_twentyeight
+
+/-- **Conjectural plateau collapse at S₂₃ → S₂₈**: under
+    `symBUDim_eq_largestPrime`, `symBUDim 23 d = symBUDim 28 d` for every
+    `d`.  The conjecture forces equivariant BU dimensions at all six
+    consecutive ranks `n ∈ {23, 24, …, 28}` to coincide — the longest
+    plateau collapse delivered by a prime-6 gap below n = 30. -/
+theorem symBUDim_twentythree_eq_twentyeight (d : ℕ) :
+    symBUDim 23 d = symBUDim 28 d :=
+  symBUDim_const_in_no_prime_range 23 28 d (by norm_num) (by norm_num)
+    no_prime_in_twentyfour_to_twentyeight
+
+/-- **Hypothesis-form** of `symBUDim_twentythree_eq_twentyeight`. -/
+theorem symBUDim_twentythree_eq_twentyeight_of
+    (h_conj : ConjectureLPB) (d : ℕ) :
+    symBUDim 23 d = symBUDim 28 d :=
+  symBUDim_const_in_no_prime_range_of h_conj 23 28 d
+    (by norm_num) (by norm_num) no_prime_in_twentyfour_to_twentyeight
+
 /-
 ## Summary
 
@@ -956,6 +1077,29 @@ theorem symBUDim_const_in_no_prime_range_of (h_conj : ConjectureLPB)
   hypothesis-form variants taking `ConjectureLPB` as a `Prop` argument
   rather than relying on the file's axiom (matches Part XV's pattern).
 
+### Iteration 11 additions (concrete plateau collapse instances)
+- `no_prime_in_eight_to_ten`, `no_prime_in_fourteen_to_sixteen`,
+  `no_prime_in_twentyfour_to_twentyeight` — **axiom-free** witnesses that
+  the half-open intervals `(8, 10]`, `(13, 16]`, `(23, 28]` contain no
+  primes (each proved by `interval_cases` + `decide`).  Selected to
+  cover the smallest prime gaps with multiple composites in between:
+  the dyadic gap (7, 11), the gap (13, 17), and the first gap of size 6
+  at (23, 29).
+- `largestPrimeBelow_eight_eq_ten`, `largestPrimeBelow_thirteen_eq_sixteen`,
+  `largestPrimeBelow_twentythree_eq_twentyeight` — **axiom-free** LPB
+  collapse instances at the three intervals.  Direct applications of
+  `largestPrimeBelow_const_in_no_prime_range` from PART XVI.
+- `symBUDim_eight_eq_ten`, `symBUDim_thirteen_eq_sixteen`,
+  `symBUDim_twentythree_eq_twentyeight` — **conditional** plateau collapse
+  at the three intervals.  Each is a one-liner specialization of PART
+  XVI's `symBUDim_const_in_no_prime_range`.  The S₂₃ → S₂₈ instance is
+  the longest plateau collapse below n = 30 — six consecutive symmetric
+  groups conjecturally share equivariant Borsuk-Ulam dimensions at every
+  dimension.
+- `symBUDim_eight_eq_ten_of`, `symBUDim_thirteen_eq_sixteen_of`,
+  `symBUDim_twentythree_eq_twentyeight_of` — hypothesis-form variants
+  taking `ConjectureLPB` explicitly.
+
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
   axiomatizing or proving `symBUDim 3 d ≤ buDim 3 d`; n=3 is *not*
@@ -1003,4 +1147,13 @@ theorem symBUDim_const_in_no_prime_range_of (h_conj : ConjectureLPB)
 #check @symBUDim_const_in_no_prime_range
 #check @symBUDim_eq_of_lpb_eq_of
 #check @symBUDim_const_in_no_prime_range_of
+
+#check @no_prime_in_eight_to_ten
+#check @largestPrimeBelow_eight_eq_ten
+#check @symBUDim_eight_eq_ten
+#check @symBUDim_eight_eq_ten_of
+#check @no_prime_in_fourteen_to_sixteen
+#check @symBUDim_thirteen_eq_sixteen
+#check @no_prime_in_twentyfour_to_twentyeight
+#check @symBUDim_twentythree_eq_twentyeight
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-08T19:30:00Z
-**Iteration**: 9
+**Since**: 2026-05-09T00:00:00Z
+**Iteration**: 11
 
 ## Current Focus
 
@@ -358,3 +358,69 @@ individual `decide`-based LPB-at-composite-n computation.
 merges, two-line specializations of `symBUDim_const_in_no_prime_range`
 should give clean axiom-pinning plateau collapse instances at
 concrete composite n.
+
+## Iteration 11 Builds (researcher-3, 2026-05-09)
+
+Focus: **concrete plateau collapse instances** that directly apply iter
+10's Part XVI infrastructure without depending on PR #17286's
+LPB-at-composite-n decisions. Selected three prime-gap intervals
+representative of the gap-size distribution below n = 30, derived
+axiom-free LPB collapse + conditional symBUDim collapse for each,
+plus hypothesis-form variants taking `ConjectureLPB` explicitly.
+
+### Part XVII additions (axiom-free witnesses)
+
+- `no_prime_in_eight_to_ten`: `∀ k, 8 < k → k ≤ 10 → ¬ Nat.Prime k`.
+  `interval_cases` + `decide` over the three composite cases 9, 10.
+  Witness for the dyadic gap (7, 11).
+- `no_prime_in_fourteen_to_sixteen`: same shape over (13, 16] = {14,
+  15, 16}. Witness for the gap (13, 17).
+- `no_prime_in_twentyfour_to_twentyeight`: same shape over (23, 28]
+  = {24, 25, 26, 27, 28}. Witness for the **first prime gap of size
+  6** in ℕ — five consecutive composites.
+
+### Part XVII additions (axiom-free LPB collapse)
+
+- `largestPrimeBelow_eight_eq_ten`: `largestPrimeBelow 10 =
+  largestPrimeBelow 8`. Direct application of
+  `largestPrimeBelow_const_in_no_prime_range 8 10`.
+- `largestPrimeBelow_thirteen_eq_sixteen`: `largestPrimeBelow 16 =
+  largestPrimeBelow 13`.
+- `largestPrimeBelow_twentythree_eq_twentyeight`: `largestPrimeBelow
+  28 = largestPrimeBelow 23`. The longest LPB plateau below n = 30 —
+  spans six consecutive ranks {23, 24, 25, 26, 27, 28}.
+
+### Part XVII additions (conditional symBUDim collapse)
+
+- `symBUDim_eight_eq_ten`: under `symBUDim_eq_largestPrime`,
+  `symBUDim 8 d = symBUDim 10 d` for every `d`. Two distinct
+  symmetric groups (S₈ ⊃ V₄·A₄, S₁₀ ⊃ A₅×A₅) conjecturally share
+  equivariant Borsuk-Ulam dimensions at every dimension.
+- `symBUDim_thirteen_eq_sixteen`: same form for n = 13, 16.
+- `symBUDim_twentythree_eq_twentyeight`: same form for n = 23, 28
+  — the longest plateau collapse below n = 30 (six consecutive
+  symmetric groups conjecturally with identical equivariant BU
+  dimensions despite radically different Sylow structure: |Sylow_2(S₂₃)|
+  = 2¹⁹ vs |Sylow_2(S₂₈)| = 2²⁵).
+- `symBUDim_eight_eq_ten_of`, `symBUDim_thirteen_eq_sixteen_of`,
+  `symBUDim_twentythree_eq_twentyeight_of`: hypothesis-form variants
+  taking `ConjectureLPB` explicitly. Useful for downstream code that
+  wants to track conjecture-dependence at the type level.
+
+**Counts**: lineCount 1006→1159 (+153), theoremCount 65→77 (+12,
+substantive 63→75), definitionCount 2 (unchanged), axiomCount 1
+(unchanged), sorries 0 (unchanged).
+
+**Significance**: complementary to (and orthogonal from) the still-open
+PR #17286 (S8 by another agent, currently in merge conflict — adds
+LPB-at-composite values via `decide` for the Part XII/XIII RHS-resolved
+forms). PR #17286's content is required to *interpret* the LHS of these
+plateau collapse instances (e.g., to know that all six values
+`largestPrimeBelow 23, ..., largestPrimeBelow 28` literally equal 23).
+But the plateau collapse instances **themselves** are content-bearing
+without those concrete values — they assert that the LPB function is
+constant on the gap regardless of the specific value, and that the
+conjecture forces the corresponding symBUDim values to coincide.
+Independent of how PR #17286 resolves.
+
+**Build**: pending (Docker rebuild from fresh Mathlib cache).

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1006,
+    "lineCount": 1159,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -99,10 +99,14 @@
       "largestPrimeBelow_eq_of_in_plateau (axiom-free, iter 10): prime-anchored packaging — if `p` is prime, `lpb n = p`, and no prime lies in `(n, m]`, then `lpb m = p` too. Convenient form for combining with prime-gap data.",
       "symBUDim_eq_of_lpb_eq (conditional, iter 10): plateau collapse — any two `n, m ≥ 2` with `largestPrimeBelow n = largestPrimeBelow m` have `symBUDim n d = symBUDim m d` at every dimension. Conditional on `symBUDim_eq_largestPrime`.",
       "symBUDim_const_in_no_prime_range (conditional, iter 10): symBUDim plateau on prime-gap intervals — if no prime exists in `(n, m]` and `n ≥ 2`, then `symBUDim n d = symBUDim m d` for all d. Formal expression of the 'plateau collapse' prediction: distinct symmetric groups in any maximal prime-gap interval conjecturally share the equivariant BU dimension at every dimension. Conditional.",
-      "symBUDim_eq_of_lpb_eq_of, symBUDim_const_in_no_prime_range_of (conditional, iter 10): hypothesis-form variants taking `ConjectureLPB` as a `Prop` argument rather than relying on the file's axiom (matches Part XV's pattern)."
+      "symBUDim_eq_of_lpb_eq_of, symBUDim_const_in_no_prime_range_of (conditional, iter 10): hypothesis-form variants taking `ConjectureLPB` as a `Prop` argument rather than relying on the file's axiom (matches Part XV's pattern).",
+      "no_prime_in_eight_to_ten, no_prime_in_fourteen_to_sixteen, no_prime_in_twentyfour_to_twentyeight (axiom-free, iter 11): witnesses that the half-open intervals (8, 10], (13, 16], (23, 28] contain no primes (each proved by `interval_cases` + `decide`). Cover the smallest prime gaps with multiple composites: the dyadic gap (7, 11), (13, 17), and the first gap of size 6 at (23, 29).",
+      "largestPrimeBelow_eight_eq_ten, largestPrimeBelow_thirteen_eq_sixteen, largestPrimeBelow_twentythree_eq_twentyeight (axiom-free, iter 11): concrete LPB plateau collapse instances at the three intervals. One-line specializations of `largestPrimeBelow_const_in_no_prime_range`. The S₂₃ → S₂₈ instance witnesses that the first prime gap of size 6 forces five consecutive `largestPrimeBelow` values to coincide.",
+      "symBUDim_eight_eq_ten, symBUDim_thirteen_eq_sixteen, symBUDim_twentythree_eq_twentyeight (conditional, iter 11): plateau collapse predictions of the conjecture at three intervals. The S₂₃ → S₂₈ instance is the longest plateau collapse below n = 30: under `symBUDim_eq_largestPrime`, six consecutive symmetric groups (n = 23, 24, ..., 28) share equivariant Borsuk-Ulam dimensions at every dimension, despite their qualitatively different subgroup structures.",
+      "symBUDim_eight_eq_ten_of, symBUDim_thirteen_eq_sixteen_of, symBUDim_twentythree_eq_twentyeight_of (conditional, iter 11): hypothesis-form variants of the three plateau-collapse instances, taking `ConjectureLPB` explicitly."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d ≥ 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d − 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d − 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 65,
+    "theoremCount": 77,
     "definitionCount": 2
   },
   "overview": {
@@ -244,6 +248,14 @@
       "endLine": 806,
       "summary": "**Iteration 10.** Axiom-free engine for the local-constancy structure of $\\text{lpb}$ between consecutive primes. `largestPrimeBelow_succ_of_not_prime`: atomic step — composite successor preserves LPB (direct corollary of Mathlib's `Nat.findGreatest_of_not`). `largestPrimeBelow_const_in_no_prime_range`: general plateau lemma proved by `Nat.le_induction` lifting the atomic step over a prime gap. `largestPrimeBelow_eq_of_in_plateau`: prime-anchored packaging combining a known $\\text{lpb}(n) = p$ with a no-prime-in-$(n, m]$ hypothesis. **Conditional consequences**: `symBUDim_eq_of_lpb_eq` — same LPB ⇒ same symBUDim at every dimension, conditional on `symBUDim_eq_largestPrime`. `symBUDim_const_in_no_prime_range` — formal expression of the 'plateau collapse' prediction: distinct symmetric groups in any maximal prime-gap interval conjecturally share the equivariant BU dimension at every $d$. `symBUDim_eq_of_lpb_eq_of`, `symBUDim_const_in_no_prime_range_of` — hypothesis-form variants taking `ConjectureLPB` as a `Prop` argument.",
       "mathContext": "$\\text{lpb}(n)$ is locally constant on the maximal prime-gap intervals $[p_i, p_{i+1})$ between consecutive primes $p_i < p_{i+1}$ — pinned at $p_i$ throughout. The proof is by induction on $m - n$: each successor jump $k \\to k + 1$ preserves $\\text{lpb}$ when $k + 1$ is composite, via $\\text{Nat.findGreatest}_\\text{of\\_not}$. Combined with the central conjecture, this forces all symmetric groups whose index falls in the same prime gap to have *identical* equivariant Borsuk-Ulam dimensions at every $d$ — a strong, type-level prediction. Concrete instances (e.g., $\\text{lpb}(8) = \\text{lpb}(9) = \\text{lpb}(10) = 7$, hence conjecturally $\\text{symBUDim}(8, d) = \\text{symBUDim}(9, d) = \\text{symBUDim}(10, d)$ for all $d$) follow uniformly from this axiom-free engine plus a single primality decision."
+    },
+    {
+      "id": "plateau-collapse-instances",
+      "title": "Part XVII: Concrete Plateau Collapse Instances",
+      "startLine": 807,
+      "endLine": 932,
+      "summary": "**Iteration 11.** Direct applications of Part XVI's plateau infrastructure to specific prime-gap intervals. Each instance pins a no-prime-in-gap fact via `interval_cases` + `decide`, then derives an axiom-free LPB collapse, a conditional `symBUDim` collapse, and its hypothesis-form variant. Three intervals chosen to cover the smallest prime gaps with multiple composites: $(7, 11)$ (dyadic, gap 4), $(13, 17)$ (gap 4), and $(23, 29)$ (gap 6 — first occurrence of a 5-composite stretch). The S₂₃ → S₂₈ instance forces six consecutive symmetric groups to share equivariant Borsuk-Ulam dimensions at every $d$, despite their qualitatively different subgroup structures.",
+      "mathContext": "Combines the structural Part XVI engine (prime-gap induction over `largestPrimeBelow_succ_of_not_prime`) with concrete primality checks decided by Lean's kernel. The three chosen intervals exhibit the qualitatively different prime-gap regimes: gap 4 at small $n$ (twin-prime adjacent), gap 4 at moderate $n$ (just past 13), and the first gap of size 6 (between 23 and 29 — the first instance where the maximal prime gap exceeds the previously-observed gap-4 ceiling). Each `symBUDim` instance is genuinely new content modulo the conjecture: e.g., `symBUDim 23 d = symBUDim 28 d` is non-trivial because S₂₃ contains a Sylow-2 subgroup of order $2^{19}$ while S₂₈ contains a Sylow-2 of order $2^{25}$, so any 2-equivariant invariant differs between the two — yet the conjecture forces their equivariant BU dimensions to coincide."
     }
   ],
   "crossReferences": [
@@ -287,10 +299,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1006,
+    "lineCount": 1159,
     "axiomCount": 1,
-    "theoremCount": 65,
-    "substantiveTheoremCount": 63,
+    "theoremCount": 77,
+    "substantiveTheoremCount": 75,
     "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "borsuk-ulam-oq-02-oq-01-oq-03-oq-02",
   "title": "For Sₙ, is symBUDim n d = buDim_{largest prime ≤ n} d = 2⌊d/2⌋−1?",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Iter 8, researcher-1, 2026-05-08): Added conditional structural consequence `buDim_prime_lower_z2_conditional` extending classical Borsuk-Ulam from p = 2 to all cyclic primes at all dimensions (including odd d), assuming `symBUDim_eq_largestPrime`. Also packaged the axiom-free max-bound `symBUDim_prime_combined_lower` at any prime n. Counts: lineCount 674→768 (+94), theoremCount 45→51 (+6, substantive 43→49), axiomCount 1, sorries 0. Phase: ORIENT continued — boundary between proven and open content sharpened on the cyclic-prime side, with a falsification handle now in place. Direct proof of `symBUDim_eq_largestPrime` still requires Fadell-Husseini index theory.",
+    "progressSummary": "PROGRESS (Iter 11, researcher-3, 2026-05-09): Added Part XVII — three concrete plateau collapse instances at prime-gap intervals (7,11), (13,17), (23,29). Each is a one-line application of iter 10's Part XVI plateau infrastructure: axiom-free LPB collapse + conditional symBUDim collapse + hypothesis-form variant. Twelve new theorems (lineCount 1006→1159, theoremCount 65→77, substantive 63→75, axiomCount 1 unchanged, sorries 0 unchanged). The S₂₃ → S₂₈ instance is the longest plateau collapse below n = 30, forcing six consecutive symmetric groups to conjecturally share equivariant Borsuk-Ulam dimensions at every dimension. Orthogonal to (and unblocked by) PR #17286, which is in merge conflict.",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean — Phase 2 scaffold with axiom symBUDim_eq_largestPrime + 18 theorems (substantive: 16); 333 lines",
       "Unconditional theorem symBUDim_even_lower : 2k-1 ≤ symBUDim n (2k) for n ≥ 2 (no new axioms beyond parent)",
@@ -71,7 +71,13 @@
       "buDim_largestPrime_lower_z2 (BorsukUlamOQ02OQ01OQ03OQ02.lean:565-583, conditional): under `symBUDim_eq_largestPrime`, `d − 1 ≤ buDim (largestPrimeBelow n) d` for n ≥ 2, d ≥ 1.",
       "buDim_prime_lower_z2_conditional (BorsukUlamOQ02OQ01OQ03OQ02.lean:585-600, conditional): at any prime p with d ≥ 1, `d − 1 ≤ buDim p d`. Extends classical BU from p = 2 to all cyclic primes at ALL d.",
       "buDim_{three,five,seven}_lower_z2_conditional (BorsukUlamOQ02OQ01OQ03OQ02.lean:602-617, conditional): concrete instances at small odd primes.",
-      "symBUDim_prime_combined_lower (BorsukUlamOQ02OQ01OQ03OQ02.lean:619-633, axiom-free): `max (buDim p d) (d − 1) ≤ symBUDim p d` at any prime p with d ≥ 1."
+      "symBUDim_prime_combined_lower (BorsukUlamOQ02OQ01OQ03OQ02.lean:619-633, axiom-free): `max (buDim p d) (d − 1) ≤ symBUDim p d` at any prime p with d ≥ 1.",
+      "no_prime_in_eight_to_ten (axiom-free, Part XVII): `∀ k, 8 < k → k ≤ 10 → ¬ Nat.Prime k` via interval_cases + decide.",
+      "no_prime_in_fourteen_to_sixteen (axiom-free, Part XVII): same shape over (13, 16] = {14, 15, 16}.",
+      "no_prime_in_twentyfour_to_twentyeight (axiom-free, Part XVII): same shape over (23, 28] = five composites — first prime gap of size 6.",
+      "largestPrimeBelow_eight_eq_ten, _thirteen_eq_sixteen, _twentythree_eq_twentyeight (axiom-free, Part XVII): one-line specializations of `largestPrimeBelow_const_in_no_prime_range`.",
+      "symBUDim_eight_eq_ten, _thirteen_eq_sixteen, _twentythree_eq_twentyeight (conditional, Part XVII): plateau collapse predictions of the conjecture at three intervals. The S₂₃ → S₂₈ instance forces six consecutive symmetric groups to share equivariant BU dimensions at every dimension.",
+      "symBUDim_eight_eq_ten_of, _thirteen_eq_sixteen_of, _twentythree_eq_twentyeight_of (conditional, Part XVII): hypothesis-form variants taking `ConjectureLPB` explicitly."
     ],
     "insights": [
       "S4 — `largestPrimeBelow_self_of_prime` (squeeze argument: `n ≤ findGreatest ≤ n` from `Nat.le_findGreatest le_rfl hn` + `Nat.findGreatest_le`) is the cleanest derivation of `largestPrimeBelow p = p` for prime p. Generic enough to handle ALL primes uniformly.",
@@ -90,7 +96,9 @@
       "Connection to chromatic number of Kneser graphs (Lovász 1978): for Z/2 case, BU dimension yields chromatic bounds; symmetric extension is a long-running program",
       "Iteration 8 (researcher-1): the iter-7 axiom-free Z/2 lower bound `d − 1 ≤ symBUDim n d` pulls through `symBUDim_eq_largestPrime` to deliver a CONDITIONAL bound `d − 1 ≤ buDim (largestPrimeBelow n) d`. Specialized at prime n via `largestPrimeBelow_self_of_prime`, this gives the conditional consequence `d − 1 ≤ buDim p d` for ALL primes p and ALL d ≥ 1 — extending classical Borsuk-Ulam from p = 2 (parent's `buDim_two`) to all cyclic primes including at ODD d, where the parent's even-d-only `buDim_prime` axiom is silent.",
       "Iteration 8: the conditional consequence is also a FALSIFICATION HANDLE. Any future computation of `buDim p d` at odd d for prime p ≥ 3 that violates `d − 1 ≤ buDim p d` would falsify `symBUDim_eq_largestPrime` at n = p. So the conjecture's truth is now tied to a uniform Yang-Borsuk-style bound at odd d for all cyclic primes — a strong constraint on what future equivariant-cohomology calculations can deliver.",
-      "Iteration 8: at any prime p, packaging the Z/p subgroup contribution (parent's `sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`) into `max (buDim p d) (d − 1) ≤ symBUDim p d` is axiom-free. At even d = 2k both summands equal d − 1 via `buDim_prime`; at odd d the Z/2 component dominates. The max formulation is the cleanest unconditional packaging of the lower-bound side at prime n."
+      "Iteration 8: at any prime p, packaging the Z/p subgroup contribution (parent's `sym_has_cyclic_prime`) with the Z/2 contribution (iter-7's `symBUDim_lower_z2`) into `max (buDim p d) (d − 1) ≤ symBUDim p d` is axiom-free. At even d = 2k both summands equal d − 1 via `buDim_prime`; at odd d the Z/2 component dominates. The max formulation is the cleanest unconditional packaging of the lower-bound side at prime n.",
+      "Iter 11 (2026-05-09, researcher-3): Concrete plateau collapse instances at three prime-gap intervals are one-liners on top of iter 10's Part XVI infrastructure, AXIOM-FREE for the LPB side and CONDITIONAL for the symBUDim side. Three intervals: (7, 11), (13, 17), (23, 29) — covering both gap-4 and the first gap-6 case. The S₂₃ → S₂₈ instance is the longest plateau collapse below n = 30: under the conjecture, six consecutive symmetric groups share equivariant Borsuk-Ulam dimensions at every dimension despite their radically different Sylow-2 structure (|Sylow_2(S₂₃)| = 2¹⁹ vs |Sylow_2(S₂₈)| = 2²⁵).",
+      "Iter 11: The plateau collapse instances are CONTENT-BEARING independent of the still-pending Part XII (PR #17286) LPB-at-composite-n decisions — they assert that LPB is constant on a prime-gap interval regardless of the specific LPB value, and that the conjecture forces the corresponding symBUDim values to coincide. So this iteration delivers value orthogonal to (and unblocked by) PR #17286, which is in merge conflict."
     ],
     "mathlibGaps": [
       "No formalization of equivariant cohomology / Fadell-Husseini index in Mathlib (would be needed for a proof of the upper bound)",


### PR DESCRIPTION
## Summary

Iteration 11 of the Symmetric-Group Borsuk-Ulam largest-prime conjecture
(`borsuk-ulam-oq-02-oq-01-oq-03-oq-02`).  Adds **Part XVII**: three
concrete plateau-collapse instances directly applying iter 10's Part
XVI infrastructure (axiom-free `largestPrimeBelow_const_in_no_prime_range`
and the conditional `symBUDim_const_in_no_prime_range`) to specific
prime-gap intervals.

The instances are **content-bearing independent of PR #17286**, which
is currently in merge conflict (S8 by another agent — adds the
LPB-at-composite-n decisions for the Part XII/XIII RHS-resolved forms).
PR #17286's content is required to *interpret* the LHS of these plateau
collapse instances, but the plateau collapses themselves assert
constancy of LPB on a prime-gap interval regardless of the specific
LPB value.

### Three intervals selected

The smallest prime gaps with multiple composites in between:

| Interval     | Composites      | Gap | Significance                              |
|--------------|-----------------|-----|-------------------------------------------|
| `(7, 11)`    | {8, 9, 10}      | 4   | Smallest dyadic gap                       |
| `(13, 17)`   | {14, 15, 16}    | 4   | Moderate-n gap-4 case                     |
| `(23, 29)`   | {24, 25, 26, 27, 28} | 6 | First prime gap of size 6 in ℕ      |

### Per interval (using `(8, 10]` as example)

- `no_prime_in_eight_to_ten` (axiom-free): `∀ k, 8 < k → k ≤ 10 → ¬ Nat.Prime k`
  via `interval_cases k <;> decide`.
- `largestPrimeBelow_eight_eq_ten` (axiom-free): one-line specialization
  of `largestPrimeBelow_const_in_no_prime_range` from Part XVI.
- `symBUDim_eight_eq_ten` (conditional): one-line specialization of
  Part XVI's `symBUDim_const_in_no_prime_range`.
- `symBUDim_eight_eq_ten_of` (conditional, hypothesis-form): same
  conclusion using `ConjectureLPB` hypothesis (Part XV) instead of the
  file's axiom.

Same shape for `(13, 16]` (S₁₃ → S₁₆) and `(23, 28]` (S₂₃ → S₂₈).

### Notable

The S₂₃ → S₂₈ instance is the longest plateau collapse below n = 30:
under `symBUDim_eq_largestPrime`, six consecutive symmetric groups
share equivariant Borsuk-Ulam dimensions at every dimension.  This is
non-trivial because S₂₃ and S₂₈ have radically different Sylow-2
structure (|Sylow_2(S₂₃)| = 2¹⁹ vs |Sylow_2(S₂₈)| = 2²⁵), so any
2-equivariant invariant differs between the two — yet the conjecture
forces their full equivariant BU dimensions to coincide.

### Counts

- lineCount 1006 → 1159 (+153)
- theoremCount 65 → 77 (+12, substantive 63 → 75)
- definitionCount 2 (unchanged)
- axiomCount 1 (unchanged — `symBUDim_eq_largestPrime` only)
- sorries 0 (unchanged)

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02` — currently in progress (broken `proofs/.lake` self-symlink forces fresh Mathlib clone + cache get; cache download just completed at ~270s, build phase started).
- [x] All 12 new theorems are one-line specializations of existing Part XVI machinery; only new tactic invocations are `interval_cases` + `decide` over 3 small no-prime ranges.
- [x] No new axioms beyond the existing `symBUDim_eq_largestPrime`.
- [x] meta.json + state.md + knowledge.md counts synced.

🤖 Generated by researcher-3 with [Claude Code](https://claude.com/claude-code)