### PR TITLE
fix(meta): batch sync definitionCount/theoremCount drift (25 entries, batch a-b)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -161,7 +161,7 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -126,7 +126,7 @@
     "lineCount": 265,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "sorries": 2,
     "additionalFiles": [

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 1
   },
   "overview": {
@@ -104,7 +104,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 10
+    "theoremCount": 13
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -55,7 +55,7 @@
     "assumptions": "Five axioms: (1) fourier_decomp_exists (Fourier decomposition for periodic C¹ functions), (2) exists_nice_reparam (arc-length reparametrization with zero mean), (3) wirtinger_sum_bound (Wirtinger applied to coordinate functions), (4) area_cauchy_schwarz_bound (Green’s theorem + Cauchy–Schwarz), (5) integral_cauchy_schwarz_sq (L² Cauchy–Schwarz). Of these, #1 and #3 are proved in AreaOfCircleOQ01OQ03.lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The isoperimetric inequality C² ≥ 4πA states that among all simple closed curves of given circumference, the circle encloses the maximum area. Known since antiquity (Zenodorus, ~200 BC), the first rigorous proof was given by Weierstrass (1870s) using the calculus of variations. Hurwitz (1901) gave a substantially simpler proof using Fourier analysis: the key insight is that Wirtinger’s inequality (itself a consequence of Parseval’s identity + integration by parts) provides the analytical bound that, combined with Cauchy-Schwarz, yields the geometric inequality. Wirtinger’s inequality — $\\int f^2 \\leq \\int (f’)^2$ for mean-zero periodic functions — was first proved in this context, though Wilhelm Wirtinger published it independently in 1904. The isoperimetric inequality has deep connections to Sobolev inequalities in PDE theory and to the Cheeger constant in Riemannian geometry.",
@@ -192,7 +192,7 @@
     "lineCount": 419,
     "axiomCount": 5,
     "theoremCount": 11,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -23,7 +23,7 @@
     "lineCount": 213,
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Roger Apéry's 1978 proof that $\\zeta(3)$ is irrational stunned the mathematical world. At age 61, Apéry presented at the Journées Arithmétiques conference a sequence of identities that produced integer sequences $(a_n, b_n)$ satisfying $b_n \\zeta(3) - a_n \\to 0$ geometrically — fast enough to prove irrationality by a simple denominators argument. Henri Cohen reconstructed the proof on the spot; several attendees left in disbelief. The method rests on a 3-term recurrence $(n+1)^3 u_{n+1} = (2n+1)(17n^2+17n+5)u_n - n^3 u_{n-1}$ with remarkable integrality properties. Despite decades of computer searches, no analogous recurrence is known for $\\zeta(5)$. Zudilin (2001) showed at least one of $\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)$ is irrational via a different method, but cannot identify which one.",
@@ -110,7 +110,7 @@
     "lineCount": 213,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 5,
+    "definitionCount": 8,
     "path": "Proofs/BaselProblemOQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "assumptions": ""
     },
@@ -106,7 +106,7 @@
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "sorries": 0
     },

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Logarithmic functions on naturals",
       "Well-founded recursion and termination proofs"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2
   },
   "overview": {
@@ -177,7 +177,7 @@
     "namespace": "BinaryGcdOQ01",
     "lineCount": 215,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -67,7 +67,7 @@
       "Mathlib's Int.gcd defined via natAbs",
       "Basic absolute-value identities on ℤ"
     ],
-    "theoremCount": 8,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "sections": [
@@ -204,7 +204,7 @@
     "namespace": "BinaryGcdOQ02",
     "lineCount": 134,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 14,
     "definitionCount": 1,
     "path": "Proofs/BinaryGcdOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/binary-gcd-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03/meta.json
@@ -29,7 +29,7 @@
     "lineCount": 488,
     "assumptions": "",
     "theoremCount": 15,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Derrick Henry Lehmer proposed his GCD acceleration in 1938, motivated by the observation that the leading digits of two numbers determine the first several quotients in the Euclidean algorithm. Instead of performing expensive full-precision divisions, Lehmer's method extracts the top w bits of a and b, runs the cheap single-precision Euclidean algorithm on these approximations, and records the sequence of quotients as a 2×2 integer cofactor matrix M = [[α,β],[γ,δ]]. One matrix-vector multiply (a',b') = M·(a,b) then performs all those quotient steps at once on the full-precision numbers. Arnold Schönhage (1971) took this further: by recursively applying Lehmer's idea (computing HGCD on the top half of the bits, applying, then recursing), one achieves O(M(n) log n) bit complexity using fast multiplication M(n). The GMP library's mpn_gcd uses this Lehmer-Schönhage hybrid, switching between plain Euclidean (≤64 bits), Lehmer's method (64–few thousand bits), and recursive HGCD (very large inputs). The key mathematical invariant is that unimodular matrices (det = ±1) preserve GCD — a direct consequence of Cramer's rule showing the inverse exists over ℤ.",
@@ -161,7 +161,7 @@
     "lineCount": 488,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/BinaryGcdOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -169,7 +169,7 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "sorries": 5,
     "additionalFiles": [

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "lineCount": 224,
     "assumptions": "None. All theorems are fully proved including the q-Vandermonde identity.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 1
   },
   "overview": {
@@ -154,7 +154,7 @@
     "namespace": "BinomialTheoremOQ04OQ02OQ01",
     "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "privateCount": 2,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "3 axiom declarations: (1) BSD_rank2_Lderiv2: rank-2 BSD formula (L''(E,1)/2 = BSDConstant), encoding the strong BSD conjecture for rank-2 curves; (2) curve389a_second_L_derivative: the second L-derivative of 389a at s=1, whose existence is established by the Buhler-Gross-Zagier computation; (3) curve389a_BGZ_computation: bounds 0.7557 < L''(389a,1)/2 < 0.7558, from the numerical verification of Buhler-Gross-Zagier (1985). The main BSD axioms (analyticRank, L-function, regulator positivity) are inherited from the parent BirchSwinnertonDyer.lean.",
     "lineCount": 273,
     "theoremCount": 27,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Curve 389a1 (Cremona label) — the elliptic curve y² + y = x³ + x² - 2x — holds the distinction of being the smallest-conductor elliptic curve with algebraic rank 2 (conductor N = 389, a prime). Established by Cremona's systematic enumeration of elliptic curves by conductor. The Birch and Swinnerton-Dyer conjecture predicts a deep relationship between the arithmetic structure of the curve (Mordell-Weil group, regulator, Shafarevich-Tate group) and the analytic behavior of its L-function L(E, s) at s = 1. For a rank-2 curve, L(E, 1) = L'(E, 1) = 0, and BSD predicts: L''(E, 1)/2 = Ω · R · |Ш| · ∏cₚ / |tors|². Buhler, Gross, and Zagier (Math. Comp. 44, 1985) computed L''(389a, 1) to high precision and confirmed that L''(389a, 1)/2 ≈ 0.7558 matches the predicted value 4.959 × 0.1524 × 1 × 1 / 1 ≈ 0.7558, providing the first explicit numerical verification of BSD for a rank-2 curve.",
@@ -62,7 +62,7 @@
     "lineCount": 273,
     "path": "Proofs/BirchSwinnertonDyerOQ06.lean",
     "sorries": 0,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "sections": [
     {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -36,7 +36,7 @@
       "threshold_d10: exact k=3 birthday threshold for d=10 days is n=12 (verified by native_decide)"
     ],
     "lineCount": 317,
-    "theoremCount": 41,
+    "theoremCount": 43,
     "defCount": 2,
     "definitionCount": 2
   },
@@ -135,7 +135,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 41
+    "theoremCount": 43
   },
   "sorries": 0
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "4 axioms inherited from BorsukUlamOQ02OQ01.lean: buDim (Borsuk-Ulam dimension function), buDim_two (dimension 2 case), buDim_prime (prime dimension case), buDim_mono (monotonicity of buDim). 0 own axioms. 0 sorries.",
     "lineCount": 251,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The **Fadell-Husseini index** (1988) is an ideal-valued cohomological invariant that assigns to each G-space X a homogeneous ideal $\\text{Index}_G(X) \\subseteq H^*(BG; k)$. Unlike numerical indices (which lose information), the ideal-valued index captures the full algebraic structure of the equivariant obstruction.\n\nFor cyclic groups $G = \\mathbb{Z}/p$, the cohomology ring $H^*(B\\mathbb{Z}/p; \\mathbb{F}_p)$ is a polynomial ring, and the FH index is always a principal ideal $(u^m)$. The key computation: for the standard free $\\mathbb{Z}/p$ action on $S^{2n-1}$ (rotation in $\\mathbb{C}^n$), $\\text{Index}_{\\mathbb{Z}/p}(S^{2n-1}) = (u^n)$. This immediately gives the Yang-Borsuk theorem: $\\text{buDim}(p, 2n) = 2n-1$.\n\nFor composite groups $G = \\mathbb{Z}/n$, the FH index provides finer information than simple monotonicity. Restriction maps $\\text{res}_p : H^*(B\\mathbb{Z}/n) \\to H^*(B\\mathbb{Z}/p)$ for each prime $p | n$ give independent constraints on the index ideal.",
@@ -166,7 +166,7 @@
     "lineCount": 251,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
     "sorries": 0,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "theoremCount": 8
   },
   "sorries": 0

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 3
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Tucker's lemma (1946) is the discrete combinatorial analogue of the Borsuk-Ulam theorem, one of the fundamental results of algebraic topology. Albert Tucker, a Princeton mathematician best known for the Karush-Kuhn-Tucker conditions in optimization, proved that any antipodal labeling of a triangulated sphere must contain a complementary edge — two adjacent vertices whose labels sum to zero. The graph-theoretic path-following proof, popularized by Matousek's influential textbook 'Using the Borsuk-Ulam Theorem' (2003), reveals the constructive content of Tucker's lemma: one can actually follow a path through the triangulation to find the complementary edge algorithmically. This constructive approach connects Tucker's lemma to the broader family of path-following algorithms in combinatorial topology, including Sperner's lemma (for fixed-point theorems) and the Lemke-Howson algorithm (for Nash equilibria). The equivalence between Tucker's lemma and Borsuk-Ulam was established by several authors, making the combinatorial version a powerful tool for proving topological results without homotopy theory.",
@@ -171,7 +171,7 @@
     "lineCount": 434,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 3,
+    "definitionCount": 7,
     "path": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 2633,
     "assumptions": "1 axiom: tucker_2d_grid. See Lean source for the complete statement.",
     "theoremCount": 123,
-    "definitionCount": 32
+    "definitionCount": 36
   },
   "overview": {
     "historicalContext": "Tucker's lemma (1946) is the combinatorial analog of the Borsuk-Ulam theorem. While BU states that every continuous map from S^n to R^n has an antipodal pair, Tucker's lemma states that every antipodally-labeled triangulation of the disk has a complementary edge. The connection: discretize a continuous map via Tucker labeling, apply Tucker's lemma to find complementary edges, take limits to get exact antipodal pairs. This provides a constructive/combinatorial proof of BU, avoiding algebraic topology (degree theory, homology).",
@@ -202,7 +202,7 @@
     "lineCount": 2633,
     "axiomCount": 1,
     "theoremCount": 123,
-    "definitionCount": 32,
+    "definitionCount": 36,
     "path": "Proofs/BorsukUlamOQ03OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -71,8 +71,8 @@
     "mathlib_version": "4.26.0",
     "axioms": 4,
     "lineCount": 5139,
-    "theoremCount": 217,
-    "definitionCount": 35
+    "theoremCount": 220,
+    "definitionCount": 46
   },
   "overview": {
     "historicalContext": "**Constructive Borsuk-Ulam**\n\nThe Borsuk-Ulam theorem states that every continuous map f: S^n -> R^n has an antipodal pair: a point x with f(x) = f(-x). The classical proof for n >= 2 uses algebraic topology (Brouwer degree or homology), which is inherently non-constructive.\n\nFor n = 1, however, the theorem reduces to the Intermediate Value Theorem: define g(x) = f(x) - f(-x), observe g is antisymmetric (g(-a) = -g(a)), and apply IVT to find a zero. This argument is constructive in the sense that it produces a witness via IVT.\n\n**Tucker's Lemma**\n\nThe combinatorial analog: any signed labeling of a subdivided interval with opposite signs at the endpoints must have a sign-change edge. This is the discrete foundation for constructive Borsuk-Ulam proofs.",
@@ -203,8 +203,8 @@
     "namespace": "BorsukUlamOQ03",
     "lineCount": 5139,
     "axiomCount": 1,
-    "theoremCount": 217,
-    "definitionCount": 35,
+    "theoremCount": 220,
+    "definitionCount": 46,
     "path": "Proofs/BorsukUlamOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "1 axiom inherited from BorsukUlam.lean: no_continuous_odd_nonzero_on_sphere (no continuous odd function from sphere is everywhere nonzero — the Borsuk-Ulam theorem). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
-    "definitionCount": 11
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "The Borsuk-Ulam theorem (1933) asserts that every continuous map $S^n \\to \\mathbb{R}^n$ identifies a pair of antipodal points. Karol Borsuk posed the conjecture in 1933 and Stanisław Ulam is credited with the original formulation. The covering space proof, developed in the 1950s-60s through the work of algebraic topologists including Eilenberg and Steenrod, reduces the problem to showing no continuous odd map $S^n \\to S^{n-1}$ exists. The key idea is descent: an odd map $g$ induces $\\bar{g}: \\mathbb{R}P^n \\to \\mathbb{R}P^{n-1}$, and the induced homomorphism $\\pi_1(\\mathbb{R}P^n) \\to \\pi_1(\\mathbb{R}P^{n-1})$, i.e., $\\mathbb{Z}/2\\mathbb{Z} \\to \\mathbb{Z}/2\\mathbb{Z}$, must be both surjective (by the lifting property) and trivial (by geometric constraints) — contradiction. The higher categorical perspective emerged from Grothendieck's Pursuing Stacks (1983) and was systematized by Lurie in Higher Topos Theory (2009): classical covering spaces are functors $\\Pi_1(X) \\to \\mathbf{Set}$, while $\\infty$-coverings are local systems $\\Pi_\\infty(X) \\to \\mathbf{Space}$, capturing all homotopical information. Whether these higher-categorical tools yield genuinely stronger Borsuk-Ulam-type results remains an active research question, connecting to equivariant stable homotopy theory and the Hill-Hopkins-Ravenel solution of the Kervaire invariant problem (2016).",
@@ -142,7 +142,7 @@
     "lineCount": 448,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 11,
+    "definitionCount": 16,
     "path": "Proofs/BorsukUlamOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -64,7 +64,7 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The Borsuk-Ulam theorem was conjectured by Stanisław Ulam and proved by Karol Borsuk in 1933, published in *Fundamenta Mathematicae* — the journal founded in 1920 by the Lwów-Warsaw school of mathematicians (Kuratowski, Sierpiński, Mazurkiewicz) that became the world center of point-set and algebraic topology. The theorem has a beautifully intuitive interpretation: at any given moment, there exist two antipodal points on Earth that have exactly the same temperature AND atmospheric pressure.\n\nBorsuk's original proof used the degree theory of continuous maps: an antipodal-preserving map $S^n \\to S^n$ has odd degree, and the nonexistence of an odd map $S^n \\to S^{n-1}$ follows from comparing cohomology rings. Modern proofs use three main approaches: (1) covering spaces via the double cover $S^n \\to \\mathbb{RP}^n$ and $\\pi_1(\\mathbb{RP}^n) \\cong \\mathbb{Z}/2\\mathbb{Z}$; (2) $\\mathbb{Z}/2$-homology and the transfer; (3) the Tucker lemma (a combinatorial analog, proved by Ky Fan 1952).\n\nWhat makes Borsuk-Ulam remarkable is its extraordinary range of applications. In 1978, László Lovász used it to prove Kneser's conjecture — that the chromatic number of the Kneser graph $KG(n,k)$ is $n - 2k + 2$ — launching the field of **topological combinatorics**. It implies the ham sandwich theorem (any $n$ measurable sets in $\\mathbb{R}^n$ can be simultaneously bisected by a hyperplane) and has applications to fair division (envy-free cake cutting), discrete geometry, and even economics (equilibrium existence). Jiří Matoušek's *Using the Borsuk-Ulam Theorem* (2003) surveys dozens of applications across mathematics.",
@@ -274,7 +274,7 @@
     "lineCount": 267,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/BorsukUlam.lean",
     "sorries": 0
   },

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -33,7 +33,7 @@
     "assumptions": "2 axioms: minAdmissibleDiameter_50 (minimum diameter of admissible 50-tuple), diameter_upper_bound_exists (existence of diameter upper bound). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The bounded gaps between primes saga is one of the great stories of 21st-century mathematics. In May 2013, Yitang Zhang stunned the mathematical world by proving that there are infinitely many pairs of primes differing by at most 70 million — the first finite bound ever established. Within months, James Maynard (then a postdoc at Montreal) and, independently, Terence Tao developed a radically simpler sieve-theoretic approach based on multidimensional Selberg sieve weights, reducing the bound below 600. The Polymath 8b collaborative project, coordinated online, then optimized every parameter: sieve weights, level of distribution, and crucially the admissible k-tuple used. Thomas Engelsma's exhaustive 2013 computation showed that the narrowest admissible 50-tuple has diameter exactly 246, and the Polymath team proved this suffices — yielding the current record of 246 for consecutive prime gaps. This file formalizes why 246 is a hard barrier for these methods.",
@@ -146,7 +146,7 @@
     "lineCount": 389,
     "axiomCount": 2,
     "theoremCount": 23,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/BoundedPrimeGapsOQ03OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -39,7 +39,7 @@
       "MinimalAddition inductive type with estimatedLines, tractability, prPriority",
       "gaussSumUnlocks, largeSieveUnlocks, vaughanIdentityUnlocks: impact lists"
     ],
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "The Bombieri-Vinogradov theorem (1965, independently proved by E. Bombieri and A. I. Vinogradov) is the central quantitative result on primes in arithmetic progressions. It states that primes are well-distributed in APs for almost all moduli q ≤ √x: the total error in ψ(x;q,a) summed over q ≤ √x is O(x/(log x)^A) for any fixed A. This is essentially as strong as the Generalized Riemann Hypothesis for many applications, and it is the key ingredient in the Maynard-Tao bounded prime gaps proof.\n\nAs of Mathlib v4.26.0, the infrastructure for Dirichlet characters, L-functions, and the von Mangoldt function exists, but none of the deep analytic tools (Gauss sum bounds, sieve inequalities, zero-density estimates) are formalized. This file answers the question: what is the minimal set of additions needed?",
@@ -146,7 +146,7 @@
     "lineCount": 599,
     "axiomCount": 6,
     "theoremCount": 10,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/BoundedPrimeGapsOQ04OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -59,7 +59,7 @@
     "erdosUrl": null,
     "dateAdded": "2026-03-27",
     "theoremCount": 12,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The Bombieri-Vinogradov theorem (1965) is one of the deepest results in analytic number theory. It shows that primes are equidistributed in arithmetic progressions 'on average' over moduli q up to √x, giving results of 'Riemann Hypothesis quality' without assuming RH. It was independently proved by Enrico Bombieri and Askold Ivanovich Vinogradov.\n\nIn 2013, Yitang Zhang used a variant of BV (with 'smooth moduli') as the key analytic input to prove bounded prime gaps. The Maynard-Tao improvement (2014) and Polymath 8b optimization used the full BV theorem to achieve the current record gap bound of 246.",
@@ -195,7 +195,7 @@
     "lineCount": 366,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/BoundedPrimeGapsOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 233,
     "assumptions": "1 axiom: singular_homology_retraction_split — encoding H_{n-1}(S^{n-1}) ≅ ℤ, H_{n-1}(B^n) = 0, functoriality r ∘ i = id → r* ∘ i* = id*. no_retraction_axiom appears only in a block-comment example (showing the parent file's approach), not as an actual axiom in this file. The algebraic argument (Part II) is fully proved with 0 axioms.",
     "theoremCount": 10,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The **No-Retraction Theorem** was proved by Karol Borsuk in 1931, predating Brouwer's 1912 fixed-point theorem (which came first chronologically, with various proofs following). The two results are equivalent: a retraction $r: B^n \\to S^{n-1}$ would yield a continuous map $f = i \\circ r: B^n \\to B^n$ with no fixed point (since $f(x) \\in S^{n-1}$ but $f(x) \\neq x$ for interior points), contradicting Brouwer.\n\nThe **singular homology proof** was developed in the 1920s-1940s following the emergence of algebraic topology. The key steps were laid out by Lefschetz (1930) and formalized in Eilenberg-Steenrod axioms (1945). The crucial computations are: $H_{n-1}(S^{n-1}) \\cong \\mathbb{Z}$ (proved via Mayer-Vietoris by covering $S^{n-1}$ with two hemispheres) and $H_{n-1}(B^n) = 0$ (since $B^n$ is contractible and contractible spaces have trivial reduced homology).\n\nThis file implements the **refined axiomatization** of the homological proof, cleanly separating the algebraic component (provable with 0 axioms) from the analytic component (1 axiom encoding Mathlib gaps). The algebraic fact — that $\\mathrm{id}: \\mathbb{Z} \\to \\mathbb{Z}$ cannot factor through the trivial group — is the categorical heart of the entire argument.",
@@ -146,7 +146,7 @@
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "axiomCount": 1,
     "sorries": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "theoremCount": 10
   },
   "sorries": 0

--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -51,8 +51,8 @@
     "lineCount": 391,
     "assumptions": "0 axioms, 0 sorries. 1D fixed point existence uses Mathlib's exists_mem_Icc_isFixedPt_of_mapsTo (Brouwer FPT).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
-    "definitionCount": 4
+    "theoremCount": 13,
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The computational complexity of finding fixed points interweaves topology, analysis, and computational complexity theory across a century of development. L.E.J. Brouwer (1911) proved existence non-constructively using degree theory, sparking foundational debates about constructive mathematics — Brouwer himself later rejected his own proof's methods. Stefan Banach (1922) provided the first constructive algorithm: iterate a contraction and converge geometrically, yielding explicit error bounds. Emanuel Sperner (1928) supplied the combinatorial foundation with his simplex labeling lemma, which Knaster, Kuratowski, and Mazurkiewicz used to give an independent proof of Brouwer's theorem. The complexity-theoretic revolution came with Christos Papadimitriou's introduction of PPAD (1994), identifying a class of total search problems whose totality follows from the 'parity argument on directed graphs.' Xi Chen and Xiaotie Deng (2009) proved that computing approximate Brouwer fixed points is PPAD-complete in dimensions $\\geq 2$, resolving a major open question. In 1D, however, the bisection method achieves optimal $O(\\log(1/\\varepsilon))$ query complexity — a dramatic complexity gap between one and higher dimensions. John Nash's proof (1950) that every finite game has an equilibrium relies on Brouwer's theorem, and the PPAD-completeness of Nash equilibrium computation (Daskalakis-Goldberg-Papadimitriou 2009) is a direct descendant of this line of work.",
@@ -221,8 +221,8 @@
     "namespace": "BrouwerOQ02",
     "lineCount": 391,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 4,
+    "theoremCount": 13,
+    "definitionCount": 5,
     "path": "Proofs/BrouwerFixedPointOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -79,7 +79,7 @@
       }
     ],
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Luitzen Egbertus Jan Brouwer proved this theorem in 1911 in *Mathematische Annalen*. Earlier special cases were known: Poincaré proved a version for smooth maps in 1886, and Hadamard proved the 2D case in 1910 using degree theory. Brouwer's contribution was the full generalization to continuous maps in arbitrary dimension.\n\nThe result is beautifully intuitive: no matter how you continuously 'stir' a disk, some point must end up exactly where it started. Multiple proofs exist: Brouwer's original via degree theory, Sperner's 1928 combinatorial proof via his lemma on triangulations, Milnor's 1965 differential topology proof via Sard's theorem, and modern proofs via singular homology.\n\nThe theorem's applications are vast. John Nash used it in 1950 to prove equilibrium existence in non-cooperative games (Nobel Prize 1994). It guarantees solutions to differential equations via Schauder's extension to Banach spaces. In computational complexity, finding Brouwer fixed points is PPAD-complete (Papadimitriou 1994), explaining why Nash equilibrium computation is hard.\n\nIronically, Brouwer later founded **intuitionism** (1920s), rejecting the law of excluded middle and the non-constructive proof-by-contradiction his own theorem relies upon. He came to view the theorem as an example of mathematics that proves existence without construction — precisely what intuitionists object to.",
@@ -313,7 +313,7 @@
     "lineCount": 249,
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPoint.lean",
-    "definitionCount": 5,
+    "definitionCount": 7,
     "theoremCount": 5
   }
 }


### PR DESCRIPTION
## Fix

Sync stale `definitionCount` / `theoremCount` values in 25 gallery `meta.json` files to match the actual declaration count in the referenced Lean source.

## Evidence

For each entry, both the `meta.*` and `leanFile.*` mirrors of the count were updated where both exist. Surgical text-only diffs preserve JSON formatting and field ordering; total diff is 52 insertions / 52 deletions across 25 files.

Counting convention: `def + abbrev + opaque + structure + inductive + class` (NOT `instance`) with `partial / private / protected / noncomputable / unsafe / scoped` modifiers; `theorem + lemma` with the same modifier set. Comments stripped before counting (line, block, and doc comments) per Lean 4 nesting rules.

Slugs covered (alphabet range a-b):
- amgm-inequality-oq-02-oq-02 (theorem 17→18)
- angle-trisection-oq-02-oq-01-oq-02 (def 3→4, lf-only)
- angle-trisection-oq-03-oq-02 (theorem 10→13)
- area-of-circle-oq-01-oq-02-oq-02-oq-01 (def 4→6)
- basel-problem-oq-01-oq-03 (def 5→8)
- bezout-identity-oq-03-oq-03 (theorem 7→8)
- binary-gcd-oq-01 (theorem 3→4)
- binary-gcd-oq-02 (theorem 8→14)
- binary-gcd-oq-03 (def 13→14)
- binomial-theorem-oq-02-oq-01-oq-01 (def 2→3, lf-only)
- binomial-theorem-oq-04-oq-02-oq-01 (theorem 8→10)
- birch-swinnerton-dyer-oq-06 (def 1→2)
- birthday-problem-oq-03-oq-01-oq-01 (theorem 41→43)
- borsuk-ulam (def 5→6)
- borsuk-ulam-oq-02-oq-01-oq-04 (def 4→7)
- borsuk-ulam-oq-03 (def 35→46, theorem 217→220)
- borsuk-ulam-oq-03-oq-01-oq-01 (def 3→7)
- borsuk-ulam-oq-03-oq-03 (def 32→36)
- borsuk-ulam-oq-04 (def 11→16)
- bounded-prime-gaps-oq-03-oq-01 (def 5→6)
- bounded-prime-gaps-oq-04 (def 10→11)
- bounded-prime-gaps-oq-04-oq-02 (def 8→9)
- brouwer-fixed-point (def 5→7)
- brouwer-fixed-point-oq-01-oq-02 (def 2→3)
- brouwer-fixed-point-oq-02 (def 4→5, theorem 12→13)

---
Automated fix by lean-mechanic agent.