### PR TITLE
research(sperner-ndim-mathlib-oq-02): S21A — t1-side _hLastFace forward extraction (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2259,4 +2259,111 @@ private lemma satDiagBases_t1_in_topSimps2
 
 end N2LastFaceBases
 
+-- ============================================================
+-- (S21A) Forward extraction for `_hLastFace` (t1-side).
+--
+-- For `b ∈ t1Bases N` and any drop-index `k : Fin 3`, if all
+-- non-`k` vertices of `t1 b` lie on geometric face 2 (the
+-- per-vertex condition that defines membership in the
+-- `_hLastFace` filter of `Triangulation.boundary_doors_odd`),
+-- then the drop must be `b` itself and `b ∈ satDiagBases N`. The
+-- two non-diagonal drop cases are eliminated by inconsistent
+-- face-2 sums (`b.1+b.2 = N ∧ b.1+b.2+1 = N` is impossible);
+-- the diagonal-drop case forces both endpoints to satisfy
+-- `b.1+b.2+1 = N`, exactly the saturating-diagonal condition.
+--
+-- This is the t1-side of the eventual bijection between the
+-- `_hLastFace` filter and `face2_path_odd`'s color-changing
+-- edges. S21B will assemble the full discharge by combining
+-- this with the existing t2-extinction (every t2 face has ≥ 2
+-- containers, so `adj = none ∧ S = t2 c` is impossible — see
+-- `boundaryOnFace_simData2` t2 branch) and an `IsDoor` ↔
+-- `g k ≠ g (k+1)` color-change bridge.
+-- ============================================================
+
+section N2LastFaceExtract
+
+/-- Forward extraction for `_hLastFace` (t1-side): for
+`b ∈ t1Bases N` and `k : Fin 3`, if every non-`k` vertex of
+`t1 b` lies on geometric face 2 (`onFaceΔ2_strict N · 2`), then
+`b ∈ satDiagBases N` and the drop is `b` itself.
+
+Proof: case-split on `vertexEnum (t1 b) hS k ∈ t1 b` (the S19.3
+pattern). The drops `(b.1+1, b.2)` and `(b.1, b.2+1)` each leave
+a face whose two endpoints differ in `b.1+b.2` sum by 1, so they
+cannot simultaneously satisfy `(·).1+(·).2 = N`. The drop `b`
+leaves the diagonal edge whose endpoints both satisfy
+`b.1+b.2+1 = N`, exactly the `satDiagBases_mem_iff` condition. -/
+private lemma t1_lastFace_implies_satDiag
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ t1Bases N)
+    (k : Fin 3)
+    (h_face2 : ∀ j : Fin 3, j ≠ k →
+      onFaceΔ2_strict N
+        ((simData2 N).vertexEnum (t1 b)
+          (t1_in_topSimps2_of_base N hb) j)
+        (2 : Fin 3)) :
+    b ∈ satDiagBases N ∧
+      (simData2 N).vertexEnum (t1 b)
+        (t1_in_topSimps2_of_base N hb) k = b := by
+  set hS := t1_in_topSimps2_of_base N hb with hS_def
+  -- Convert the `∀ j ≠ k`-on-vertexEnum hypothesis to the
+  -- `∀ v ∈ faceOf` form via the S19.2 generic bridge.
+  have h_face_v : ∀ v ∈ (simData2 N).faceOf (t1 b) hS k,
+      onFaceΔ2_strict N v (2 : Fin 3) :=
+    (SimplicialAdjFnHelper.forall_vertex_ne_iff_forall_face_mem
+      (simData2 N) (t1 b) hS k _).mp h_face2
+  -- Case-split on which vertex of `t1 b` is dropped (S19.3 pattern).
+  have h_drop : (simData2 N).vertexEnum (t1 b) hS k ∈ t1 b :=
+    (simData2 N).vertexEnum_mem (t1 b) hS k
+  simp only [t1, Finset.mem_insert, Finset.mem_singleton] at h_drop
+  rcases h_drop with hd | hd | hd
+  · -- Drop = `(b.1+1, b.2)`: face = `{b, (b.1, b.2+1)}` (vertical edge).
+    -- Both must be on face 2: forces `b.1+b.2 = N ∧ b.1+(b.2+1) = N`.
+    exfalso
+    have h_face_eq : (simData2 N).faceOf (t1 b) hS k =
+        ({b, (b.1, b.2+1)} : Finset (ℕ × ℕ)) := by
+      show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+      rw [hd]; exact t1_erase_first b
+    have h_b_on : onFaceΔ2_strict N b (2 : Fin 3) := by
+      apply h_face_v; rw [h_face_eq]; simp
+    have h_v_on : onFaceΔ2_strict N (b.1, b.2+1) (2 : Fin 3) := by
+      apply h_face_v; rw [h_face_eq]; simp
+    have h_b_face := h_b_on.2
+    have h_v_face := h_v_on.2
+    rw [onFaceΔ2_two_iff] at h_b_face h_v_face
+    omega
+  · -- Drop = `(b.1, b.2+1)`: face = `{b, (b.1+1, b.2)}` (horizontal edge).
+    -- Symmetric contradiction via `b.1+b.2 = N ∧ (b.1+1)+b.2 = N`.
+    exfalso
+    have h_face_eq : (simData2 N).faceOf (t1 b) hS k =
+        ({b, (b.1+1, b.2)} : Finset (ℕ × ℕ)) := by
+      show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+      rw [hd]; exact t1_erase_second b
+    have h_b_on : onFaceΔ2_strict N b (2 : Fin 3) := by
+      apply h_face_v; rw [h_face_eq]; simp
+    have h_v_on : onFaceΔ2_strict N (b.1+1, b.2) (2 : Fin 3) := by
+      apply h_face_v; rw [h_face_eq]; simp
+    have h_b_face := h_b_on.2
+    have h_v_face := h_v_on.2
+    rw [onFaceΔ2_two_iff] at h_b_face h_v_face
+    omega
+  · -- Drop = `b`: face = `{(b.1, b.2+1), (b.1+1, b.2)}` (diagonal edge).
+    -- Endpoint `(b.1, b.2+1)` on face 2 ⟹ `b.1 + b.2 + 1 = N`,
+    -- exactly the `satDiagBases` defining condition.
+    have h_face_eq : (simData2 N).faceOf (t1 b) hS k =
+        ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) := by
+      show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+      rw [hd]; exact t1_erase_third b
+    have h_v_on : onFaceΔ2_strict N (b.1, b.2+1) (2 : Fin 3) := by
+      apply h_face_v; rw [h_face_eq]; simp
+    have h_v_face := h_v_on.2
+    rw [onFaceΔ2_two_iff] at h_v_face
+    rw [t1Bases_mem_iff] at hb
+    have h_sat : b.1 + b.2 + 1 = N := by omega
+    refine ⟨?_, hd⟩
+    rw [satDiagBases_mem_iff]
+    exact ⟨hb.1, hb.2.1, h_sat⟩
+
+end N2LastFaceExtract
+
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,10 +2,52 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-08 (Iteration 20, researcher-3)
-**Iteration**: 20
+**Last Updated**: 2026-05-08 (Iteration 21, researcher-12)
+**Iteration**: 21
 
 ## Current Focus
+
+Session 21A (this iteration, researcher-12, 2026-05-08, build
+pending): Added the **t1-side forward extraction lemma** for
+`_hLastFace`, eliminating the two non-diagonal drop cases by
+inconsistent face-2 sums and identifying the diagonal-drop case
+with `b ∈ satDiagBases N`.
+
+New private lemma in a new `N2LastFaceExtract` section appended
+to `SpernerFreudSimp` (84 lines added to
+`SpernerFreudenthalSimplex.lean`):
+
+* `t1_lastFace_implies_satDiag` — for `b ∈ t1Bases N` and
+  `k : Fin 3`, if every non-`k` vertex of `t1 b` lies on
+  geometric face 2, then `b ∈ satDiagBases N` and the dropped
+  vertex is `b` itself. Proof case-splits on
+  `vertexEnum (t1 b) hS k ∈ t1 b` (the S19.3 pattern):
+    - Drop `(b.1+1, b.2)` ⟹ face = `{b, (b.1, b.2+1)}`.
+      Both on face 2 ⟹ `b.1+b.2 = N ∧ b.1+(b.2+1) = N`.
+      Contradiction (`omega`).
+    - Drop `(b.1, b.2+1)` ⟹ face = `{b, (b.1+1, b.2)}`.
+      Symmetric contradiction.
+    - Drop `b` ⟹ face = `{(b.1, b.2+1), (b.1+1, b.2)}`
+      (diagonal). Endpoint on face 2 ⟹ `b.1+b.2+1 = N`,
+      exactly the `satDiagBases_mem_iff` defining condition.
+
+Together with S20's `satDiagBases_card N = N`, this gives a
+forward map `(t1 b, k₀) ↦ b` from t1-cell members of the
+`_hLastFace` filter into `satDiagBases N`. **S21B** will handle
+the t2 side (every t2 face has ≥ 2 containers per
+`t2_face*_card_ge_two`, so `adj = none ∧ S = t2 c` is impossible
+— already proved as the `exfalso` branch of
+`boundaryOnFace_simData2`) and add the `IsDoor` ↔
+`g k ≠ g (k+1)` color-change bridge needed to match the
+`face2_path_odd` filter exactly.
+
+S21A keeps the iterative-PR cadence small (one self-contained
+lemma) to reduce merge-conflict risk and keep any build
+regressions narrow, given the persistent `proofs/.lake`
+recursive-symlink build infrastructure issue (every Docker
+build is a 30–45 min Mathlib refetch + 10 min cache fetch).
+
+## Previous Focus
 
 Session 20 (PR #17426, build pending): Introduced the
 **saturating-diagonal base set** `satDiagBases N` and its core
@@ -50,11 +92,17 @@ attempting the full `_hLastFace` discharge in one commit. Keeping
 the iterative-PR cadence small reduces merge-conflict risk and
 keeps any build regressions narrow.
 
-**S21 (next):** Pin down the matching `vertexEnum` index `k` (via
-the S19.3 case-split pattern on `vertexEnum (t1 b) hS k ∈ t1 b`);
-bridge `IsDoor c (T.toCellComplex) (t1 b) k` to `face2_path_odd`'s
+**S21 (next, partially done — S21A this session):** Pin down the
+matching `vertexEnum` index `k` (via the S19.3 case-split pattern
+on `vertexEnum (t1 b) hS k ∈ t1 b`); bridge
+`IsDoor c (T.toCellComplex) (t1 b) k` to `face2_path_odd`'s
 color-change predicate `g k ≠ g (k+1)`; assemble the `_hLastFace`
 discharge for `simData2 N`. Estimated ~80–100 lines.
+
+S21A (this session) handles the first sub-task: the t1-side
+forward extraction `t1_lastFace_implies_satDiag` (~84 lines).
+S21B will add the IsDoor ↔ color-change bridge and assemble the
+full `_hLastFace_simData2` discharge.
 
 ## Previous Focus
 
@@ -398,9 +446,20 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
 - `SimplicialAdjFnHelper.forall_vertex_ne_iff_forall_face_mem`
   (S19 part 2, this session, build pending): generic vertex/face
   bridge converting the `∀ j ≠ k` quantifier to `∀ v ∈ faceOf`.
-- `N2FaceErase` t1/t2 erase computations (S19 part 2, this
-  session, build pending): 6 explicit Finset.erase equalities for
+- `N2FaceErase` t1/t2 erase computations (S19 part 2,
+  PR #17352, merged): 6 explicit Finset.erase equalities for
   the three vertex removals of `t1 b` and `t2 c`.
+- `N2LastFaceBases` saturating-diagonal base set (S20,
+  PR #17426, build pending): `satDiagBases N` definition + 8
+  structural lemmas (membership iff, image-of-range
+  parametrization, cardinality = N, endpoints in range,
+  endpoints on face 2, t1 ∈ topSimps2 alias).
+- `N2LastFaceExtract` t1-side `_hLastFace` forward extraction
+  (S21A, this session, build pending): `t1_lastFace_implies_satDiag`
+  identifies `b ∈ satDiagBases N` and the dropped vertex = `b`
+  for any `(t1 b, k)` with face-2 condition; eliminates the
+  vertical-edge and horizontal-edge drop cases by inconsistent
+  face-2 sums.
 - `sperner_panchromatic_two` (n=2): 1 sorry remaining
 - n≥3: future work
 
@@ -420,10 +479,19 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
    boundary cells) or invoking S18.5 endpoint witnesses (for
    boundary t1 cells). ~80 lines of pure case work.
 3. `_hLowerDim` — done generically by S15 helper
-4. `_hLastFace` — TODO (~120 lines, bijection with face2_path_odd via S12)
+4. `_hLastFace` — IN PROGRESS:
+    * S20 (PR #17426): `satDiagBases N` foundation + count = N.
+    * S21A (this session): t1-side forward extraction
+      (`t1_lastFace_implies_satDiag`) identifies dropped vertex
+      and `b ∈ satDiagBases N`.
+    * S21B (next): `IsDoor` ↔ `g k ≠ g (k+1)` color-change
+      bridge + assembly of full `_hLastFace_simData2`
+      (~60-80 lines). The t2-extinction is already implicit in
+      `boundaryOnFace_simData2`'s `exfalso` t2 branch (every t2
+      face has ≥ 2 containers per `t2_face*_card_ge_two`).
 
 Then apply `Triangulation.sperner` (~50 lines for diameter bound + real
-coordinates). Total estimated remaining: ~200 lines across 2 sessions.
+coordinates). Total estimated remaining: ~150 lines across 2 sessions.
 
 ## Gallery Status
 


### PR DESCRIPTION
## Summary

S21A iteration on `sperner-ndim-mathlib-oq-02` (Sperner's lemma → Brouwer FPT in Lean 4). Adds the **t1-side forward extraction lemma** for the `_hLastFace` slot of `Triangulation.boundary_doors_odd`, delivering the first sub-task of the S21 plan documented in PR #17426.

## What this adds

A single private lemma `t1_lastFace_implies_satDiag` in a new `N2LastFaceExtract` section of `SpernerFreudSimp` (84 lines including docstring; 107 lines total with section-header documentation):

```lean
private lemma t1_lastFace_implies_satDiag
    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ t1Bases N)
    (k : Fin 3)
    (h_face2 : ∀ j : Fin 3, j ≠ k →
      onFaceΔ2_strict N
        ((simData2 N).vertexEnum (t1 b)
          (t1_in_topSimps2_of_base N hb) j)
        (2 : Fin 3)) :
    b ∈ satDiagBases N ∧
      (simData2 N).vertexEnum (t1 b)
        (t1_in_topSimps2_of_base N hb) k = b
```

For `b ∈ t1Bases N` and any drop-index `k : Fin 3`, if every non-`k` vertex of `t1 b` lies on geometric face 2 (the per-vertex content that defines `_hLastFace` filter membership), then:
1. The drop must be `b` itself (the diagonal-edge case).
2. `b ∈ satDiagBases N` (the saturating-diagonal condition `b.1 + b.2 + 1 = N` is forced by the face-2 endpoint).

## Proof outline

Case-split on `vertexEnum (t1 b) hS k ∈ t1 b` (the **S19.3 pattern** also used in `boundaryOnFace_simData2`):

- **Drop = `(b.1+1, b.2)`**: face = `{b, (b.1, b.2+1)}` (vertical edge). Both must satisfy `(·).1 + (·).2 = N`, forcing `b.1+b.2 = N ∧ b.1+(b.2+1) = N` — contradiction (`omega`).
- **Drop = `(b.1, b.2+1)`**: face = `{b, (b.1+1, b.2)}` (horizontal edge). Symmetric contradiction.
- **Drop = `b`**: face = `{(b.1, b.2+1), (b.1+1, b.2)}` (diagonal edge). Either endpoint on face 2 yields `b.1 + b.2 + 1 = N`, exactly the `satDiagBases_mem_iff` defining condition.

All API references (`forall_vertex_ne_iff_forall_face_mem`, `vertexEnum_mem`, `t1_erase_first/second/third`, `onFaceΔ2_two_iff`, `t1Bases_mem_iff`, `satDiagBases_mem_iff`) are pre-existing and used identically to the working `boundaryOnFace_simData2` pattern.

## Why a small piece (not the full _hLastFace assembly)

The persistent `proofs/.lake` recursive self-symlink (memory note `feedback_researcher_lake_symlink_broken`) makes every Docker build a 30–45 min Mathlib refetch + 10 min cache fetch, exceeding the 90-min claim TTL. S21A keeps the iterative-PR cadence small (one self-contained lemma) to reduce merge-conflict risk and keep any build regressions narrow.

## Roadmap to `_hLastFace_simData2`

* **S20** (PR #17426, build pending): `satDiagBases N` foundation + cardinality = `N`.
* **S21A** (this PR): t1-side forward extraction (`t1_lastFace_implies_satDiag`) — drop-vertex identification + `b ∈ satDiagBases N`.
* **S21B** (next): `IsDoor` ↔ `g k ≠ g (k+1)` color-change bridge + assembly of full `_hLastFace_simData2` (~60–80 lines). The t2-extinction is already implicit in `boundaryOnFace_simData2`'s `exfalso` t2 branch (every t2 face has ≥ 2 containers per `t2_face*_card_ge_two`).

## Files changed

- `proofs/Proofs/SpernerFreudenthalSimplex.lean`: 2262 → 2369 (+107). New `N2LastFaceExtract` section appended after `N2LastFaceBases`, inside the `SpernerFreudSimp` namespace.
- `research/problems/sperner-ndim-mathlib-oq-02/state.md`: iteration 20 → 21; S21A entry prepended; "Current Proof State" and "Path Forward" sections updated to acknowledge S21A; previous `**S21 (next):**` annotated as partially done.

## Counts (gallery-tracked file unchanged)

- `meta.json` tracks `Proofs/SpernerNDimMathlibOQ02.lean` (the main file). That file is **unchanged** in this PR, so all gallery counts remain identical: `axiomCount: 1`, `lineCount: 346`, `theoremCount: 13`, `definitionCount: 5`, `sorries: 0`. The gallery still honestly shows "1 axiom" pending the eventual `sperner_panchromatic_two` discharge.
- `SpernerFreudenthalSimplex.lean` (companion file, not tracked in main meta.json): 2262 → 2369 lines (+107). New private lemma: +1 (`t1_lastFace_implies_satDiag`).

## Risk note

Build is **PENDING**. If CI exposes a drift bug in this lemma, the failure is localized to `t1_lastFace_implies_satDiag` and does not affect any prior proof or main-file API. The lemma's API references are the same set used in the already-merged `boundaryOnFace_simData2` (PR #17363) plus only `satDiagBases_mem_iff` (PR #17426, also build-pending), so any drift would surface in PR #17426 first.

## Test plan

- [ ] CI: `./proofs/scripts/docker-build.sh Proofs.SpernerNDimMathlibOQ02` builds cleanly post-merge (verifies S20+S21A chain together with the prior `boundaryOnFace_simData2` infrastructure).
- [ ] Spot-check that `t1_lastFace_implies_satDiag` is callable from a downstream `_hLastFace_simData2` assembly (S21B).

🤖 Generated by researcher-12