### PR TITLE
fix(meta): batch sync definitionCount drift (25 entries, batch erdos-1000-104)

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "Two deep axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0",
     "theoremCount": 61,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "This problem originates in Cassels' 1950 work on Diophantine approximation, where he introduced the generalized totient φ_A to study the distribution of 'new' reduced denominators in increasing integer sequences. Cassels proved that for some sequences, the liminf of the Cesàro average of φ_A(k)/n_k is zero, and connected this to metric Diophantine approximation via the Khinchin-Groshev theorem. Erdős (1964) made the problem sharper: he proved that for any sequence, the individual ratio φ_A(k)/n_k cannot converge to 0, and established a remarkable dichotomy — if liminf = 0 then limsup = 1 — showing the density ratio must oscillate maximally. Erdős then asked whether the Cesàro average itself could vanish, conjecturing it could not. The lower bound φ_A(k) ≥ φ(n_k) (Euler's totient) and the fact that φ(n)/n averages to 6/π² supported his intuition. Haight's subsequent construction proved Erdős wrong: carefully chosen sequences of highly composite numbers force the average to 0 while the individual terms oscillate between 0 and 1. The problem illustrates the subtle gap between pointwise and averaged behavior of arithmetic functions.",
@@ -207,7 +207,7 @@
     "lineCount": 1149,
     "axiomCount": 2,
     "theoremCount": 61,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos1000Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "1 axiom: longestSimilarRun (definition of longest-similar-run function, axiomatized pending full Farey sequence construction). longestSimilarRun_lower, longestSimilarRun_upper (van Doorn 2025 bounds), erdos_1005_conjecture now proved. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Farey sequence $F_n$ — the set of reduced fractions $a/b$ with $0 \\leq a \\leq b \\leq n$ arranged in increasing order — has been studied since the early 19th century (independently by Haros in 1802 and Farey in 1816). Cauchy gave the first proof that adjacent Farey fractions $a/b, c/d$ satisfy $|ad - bc| = 1$, a property connecting them to the modular group $SL_2(\\mathbb{Z})$ and continued fractions. In 1942, Mayer observed that consecutive Farey fractions tend to be 'similarly ordered' — meaning their numerators and denominators move in the same direction, i.e., $(a_k - a_l)(b_k - b_l) \\geq 0$ — and proved that the longest such run $f(n) \\to \\infty$. Erdős (1943) strengthened this to $f(n) \\gg n$, establishing linear growth. For over 80 years, no explicit constants were known. van Doorn (2025) finally established $(1/12 - o(1))n \\leq f(n) \\leq n/4 + O(1)$, with the upper bound using the determinant property of adjacent Farey fractions and the lower bound via explicit constructions. van Doorn conjectures $f(n)/n \\to 1/4$, but the factor-of-3 gap between the bounds remains a significant challenge. The problem connects to Stern-Brocot trees, lattice point geometry, and longest chain problems in partial orders.",
@@ -197,7 +197,7 @@
     "lineCount": 140,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/Erdos1005Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "3 axioms: cover_graph_characterization (Pretzel-Brightwell 1985: G admits robustly acyclic orientation ↔ G is a cover graph of some poset), chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation).",
     "lineCount": 277,
     "theoremCount": 6,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "originalContributions": [
       "admitsRobustAcyclicOrientation: predicate — G has an orientation that stays acyclic under any single edge reversal",
       "isCoverGraph / isCoverGraphOf: G is a cover graph of a poset P if G = Hasse diagram of P",
@@ -116,7 +116,7 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1006OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -68,7 +68,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #1006 asks about graphs where the chromatic number is less than the girth. The Fisher-Fraughnaugh-Langley-West (FFLLW) theorem (1997) establishes: if χ(G) < girth(G), then G admits a robustly acyclic orientation. The classical proof uses the coloring orientation: given col: V → {1,...,k}, orient u→v when col(u) < col(v). This orientation is acyclic (colors strictly increase), and the girth condition ensures no reversal creates a cycle.\n\nThis Lean 4 formalization uses a rank-based reformulation of robustly acyclic that makes the proof simpler: an arc is dependent if, for every consistent ranking of other arcs, the ranking forces rank(v) ≤ rank(u). Under this definition, the coloring orientation has NO dependent arcs regardless of girth.\n\nThe key insight revealed by the formalization: under the rank-based definition, FFLLW is a tautology for finite graphs — every finite graph is properly colorable (by colorable_of_fintype), and any properly colored graph has a robust orientation. The girth condition χ < girth is mathematically unnecessary for this formulation.",
@@ -182,7 +182,7 @@
     "lineCount": 247,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1006OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -53,7 +53,7 @@
     "assumptions": "1 axiom: ffllw_classical (Fisher-Fraughnaugh-Langley-West classical lower bound for non-robust graphs). Previously axiomatized k3_egirth_eq_3 and k3_chromaticNumber_eq_3 are now proved from Mathlib. 0 sorries remain.",
     "mathlib_version": "4.26.0",
     "theoremCount": 17,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Erdős Problem #1006 concerns robustly acyclic orientations — acyclic orientations of an undirected graph that remain acyclic after any single edge reversal. Nešetřil and Rödl (1978) disproved the conjecture that all high-girth graphs admit such orientations, showing counterexamples exist for all girths g ≥ 3.\n\nThe natural follow-up asks: for graphs of girth g that do fail robust orientability, how large must the chromatic number be? Fisher, Fraughnaugh, Langley, and West (1997) proved the key sufficient condition: if χ(G) < girth(G), then G admits a robustly acyclic orientation. This establishes a lower bound: any girth-g graph without robust orientation must satisfy χ(G) ≥ g.\n\nThe bound is tight: the Grötzsch graph (11 vertices, girth 4, χ = 4) admits no robustly acyclic orientation, matching χ = girth = 4. More generally, for each g ≥ 3, constructions combining the Nešetřil-Rödl approach with chromatic minimization yield girth-g graphs with χ(G) = g failing robust orientability.",
@@ -180,7 +180,7 @@
     "lineCount": 469,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1006OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1006/meta.json
+++ b/src/data/proofs/erdos-1006/meta.json
@@ -50,7 +50,7 @@
       "Main theorem ores_conjecture_false: derives contradiction from Nešetřil-Rödl at g=5"
     ],
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "This problem, credited to Ore by Erdős (1971), explores whether high-girth graphs have particularly stable acyclic orientations. Every graph admits an acyclic orientation (just order the vertices and direct edges from lower to higher), but some orientations are 'fragile' — reversing a single edge creates a directed cycle. Ore asked whether avoiding short cycles (girth > 4) guarantees the existence of a 'robust' orientation that stays acyclic after any single edge reversal.\n\nEarly counterexamples at small girth were known: Ore found a girth-4 graph without this property, and Gallai observed the Grötzsch graph (11 vertices, girth 4, chromatic number 4) also fails. These examples relied on high chromatic number relative to girth, suggesting that chromatic structure, not just cycle length, governs robust orientability.\n\nNešetřil and Rödl (1978) settled the question completely by proving counterexamples exist for ALL girths g ≥ 3. Their proof uses the probabilistic method: by the Erdős theorem on graphs with high girth and high chromatic number, such graphs exist, and their high chromatic number forces every acyclic orientation to contain a 'fragile' edge whose reversal creates a directed cycle. The formalization axiomatizes the Nešetřil-Rödl theorem and derives the falsity of Ore's conjecture as a corollary.",
@@ -196,7 +196,7 @@
     "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1006Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -60,7 +60,7 @@
     "assumptions": "0 axioms, 0 sorries. All 32 theorems fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 32,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "sections": [
     {
@@ -168,7 +168,7 @@
     "lineCount": 388,
     "axiomCount": 0,
     "theoremCount": 32,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1007OQ01OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -73,7 +73,7 @@
     "assumptions": "0 axioms. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 89,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos1007OQ01Aristotle.lean"
     ]
@@ -231,7 +231,7 @@
     "lineCount": 1337,
     "axiomCount": 0,
     "theoremCount": 89,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1007OQ01.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1007/meta.json
+++ b/src/data/proofs/erdos-1007/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "4 axioms: hasUnitEmbedding_exists, min_edges_dimension_4, k33_unique_minimum, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The notion of graph dimension was introduced by Erdős, Harary, and Tutte in their 1965 paper 'On the dimension of a graph,' published in *Mathematika*. They defined the dimension of a graph $G$ as the smallest $d$ such that $G$ can be embedded in $\\mathbb{R}^d$ with every edge realized as a unit-length segment. This concept connects combinatorial graph theory with the classical study of distance geometry, which traces back to Cayley (1841) and Menger (1928), who studied when a set of pairwise distances can be realized in Euclidean space.\n\nThe dimension ladder for complete graphs follows from regular simplex geometry: $K_2$ has dimension 1 (a single edge), $K_3$ has dimension 2 (equilateral triangle), $K_4$ has dimension 3 (regular tetrahedron), and in general $K_{n+1}$ has dimension $n$. But at dimension 4, the minimum-edge graph is *not* $K_5$ (which has 10 edges) but $K_{3,3}$, a bipartite graph with only 9 edges — a surprising break from the simplex pattern.\n\nErdős posed this specific question to Alexander Soifer in January 1992, asking for the minimum number of edges in a 4-dimensional graph. House resolved it in 2013 in 'A 4-dimensional graph has at least 9 edges' (*Discrete Mathematics*), proving the lower bound and showing $K_{3,3}$ is the unique achiever. Chaffee and Noble (2016) gave an alternative proof and extended the analysis to dimension 5, finding the minimum is 15 edges, achieved by both $K_6$ and the tripartite graph $K_{1,3,3}$. The loss of uniqueness at dimension 5 suggests the combinatorial landscape of minimum-edge embeddings grows rapidly with dimension.",
@@ -121,7 +121,7 @@
     "lineCount": 129,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1007Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "sections": [
     {
@@ -249,7 +249,7 @@
     "lineCount": 757,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos101Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -57,7 +57,7 @@
       "directed_hamiltonian_threshold (fully proved): arc count > (n-1)² + SC implies Hamiltonicity via probabilistic union bound over n! permutations (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le)"
     ],
     "theoremCount": 25,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos1012OQ03Aristotle.lean"
     ]
@@ -267,7 +267,7 @@
     "sorries": 0,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 25,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos1012OQ03Aristotle.lean"
     ]

--- a/src/data/proofs/erdos-1015/meta.json
+++ b/src/data/proofs/erdos-1015/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "2 axioms: ramseyNumber (Ramsey number function — axiomatized, requires finite combinatorics), burr_erdos_spencer (Burr-Erdős-Spencer — f(t) = R(t,t-1) + x for 0 ≤ x < t). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "This problem lies at the intersection of Ramsey theory and graph partitioning—two pillars of combinatorics that grew from the same soil in the mid-20th century. Ramsey's theorem (1930) guarantees monochromatic cliques in any edge-coloring, but says nothing about how efficiently one can *pack* such cliques. Erdős posed the question: if we greedily tile a 2-colored $K_n$ with vertex-disjoint monochromatic copies of $K_t$, how many vertices must remain uncovered?\n\nThe first breakthrough came from Moon (1966), who proved $f(3) = 4$ for $n \\ge 8$: when packing monochromatic triangles in any 2-colored complete graph on 8 or more vertices, at most 4 vertices are left over. Moon's proof combined a careful case analysis of the red/blue degree sequence with an extremal argument about triangle-free subgraphs.\n\nErdős himself observed that $f(t) < R(t,t) \\le 4^t$ by a simple but elegant argument: the leftover vertices, together with their induced coloring, form a 2-colored complete graph containing no monochromatic $K_t$ (otherwise we could extend the partition). By definition, the size of such a graph is bounded by $R(t,t) - 1$. The upper bound $R(t,t) \\le \\binom{2t-2}{t-1} \\le 4^t$ is the classical Erdős-Szekeres (1935) result, proved by double induction on the Ramsey numbers.\n\nThis led Erdős to ask two more refined questions: (1) Does $f(t)^{1/t} \\to 1$, meaning the leftover grows subexponentially? (2) Is $f(t) = O(t)$, meaning linear growth? Both questions hoped that the $4^t$ Ramsey bound was a massive overestimate.\n\nBurr, Erdős, and Spencer (1975) settled both questions negatively with an exact formula. They proved that for $t \\ge 3$ and $n$ sufficiently large, $f(t) = R(t, t-1) + x$ where $0 \\le x < t$ is determined by $n \\pmod{t}$. The key shift is from the *diagonal* Ramsey number $R(t,t)$ to the *off-diagonal* $R(t, t-1)$: the leftover vertices can contain a monochromatic $K_{t-1}$ but not $K_t$, so the controlling quantity is $R(t, t-1)$, not $R(t,t)$. Since $R(t, t-1)$ still grows exponentially (at rate $\\sim 4^t / \\sqrt{t}$ by the Erdős-Szekeres recursion), we get $f(t)^{1/t} \\to 4$ and $f(t)$ is far from linear.\n\nThe Burr-Erdős-Spencer result exemplifies a common theme in Ramsey theory: the transition from crude exponential bounds to exact or near-exact formulas often requires replacing diagonal Ramsey numbers with off-diagonal ones. This pattern recurs in the Ramsey multiplicity problem, the Folkman number problem, and the Erdős-Hajnal conjecture.",
@@ -212,7 +212,7 @@
     "lineCount": 149,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos1015Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -22,7 +22,7 @@
     "lineCount": 696,
     "axiomCount": 2,
     "sorries": 0,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "theoremCount": 37
   },
   "meta": {
@@ -79,7 +79,7 @@
       "Axiom reduction: eliminated redundant gyori_keszegh_triangles axiom (m distinct 3-cliques, logically weaker than the partition formula and unused in the file)"
     ],
     "theoremCount": 37,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "The clique partition problem — decomposing a graph's edges into complete subgraphs — emerged from the interplay of extremal graph theory and combinatorial optimization. Erdős, Goodman, and Pósa (1966) proved the foundational bound $\\text{cp}(G) \\leq \\lfloor n^2/4 \\rfloor$ using a greedy triangle extraction followed by Turán's theorem on the triangle-free remainder. This was connected to earlier work by Mantel (1907) on triangle-free graphs and Turán (1941) on extremal graph density.\n\nThe bound is tight for $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$, which is triangle-free and needs one clique per edge. Erdős asked whether dense graphs (with more than $\\lfloor n^2/4 \\rfloor$ edges) — which must contain triangles by Turán's theorem — allow improvement. Győri and Keszegh (2017) resolved the $K_4$-free case by proving that every excess edge yields an edge-disjoint triangle, reducing the partition count by exactly 1 per excess edge. The general case, when $K_4$ and larger cliques are present, remains open and connects to NP-hard optimization problems in graph decomposition.",

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "2 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), k4free_partition_number (K₄-free partition number bound). gyori_keszegh_triangles was removed. 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 37,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "The clique partition problem has roots in the early days of graph decomposition theory. The fundamental question—how many complete subgraphs are needed to partition all edges of a graph?—connects to classical work of König (1931) on bipartite matching, Dilworth (1950) on chain decompositions, and the broader program of decomposing combinatorial structures into 'simple' pieces.\n\nErdős, Goodman, and Pósa (1966) proved the elegant theorem that $f(n,k) \\le \\lfloor n^2/4 \\rfloor$ for all $n$ and $k$, where $f(n,k)$ is the minimum number of complete subgraphs needed to partition any graph with $n$ vertices and $k$ edges. Their proof uses only edges ($K_2$'s) and triangles ($K_3$'s)—larger cliques are never required. The key insight is that a maximal set of edge-disjoint triangles leaves behind a triangle-free graph, which by Ramsey theory (or equivalently König's theorem) is bipartite. The triangle-free part then needs at most $\\lfloor n^2/4 \\rfloor$ individual edges for its partition, by Turán's theorem applied to its complement.\n\nThe bound $\\lfloor n^2/4 \\rfloor$ is tight: the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ (the Turán graph $T(n,2)$) has exactly $\\lfloor n^2/4 \\rfloor$ edges and no triangles, so every edge must be its own clique in any partition. This extremal example is sparse—it has the maximum number of edges a triangle-free graph can have, by Turán's theorem.\n\nErdős then asked the natural follow-up: when $k > n^2/4$ (more edges than any triangle-free graph), the graph *must* contain triangles. Can these triangles be exploited to bring the partition count *below* $n^2/4$? This is the core of Problem #1017.\n\nThe major partial result came from Győri and Keszegh (2017), who completely resolved the $K_4$-free case. They proved: if $G$ is $K_4$-free with $\\lfloor n^2/4 \\rfloor + m$ edges, then $G$ contains $m$ edge-disjoint triangles. Since each triangle replaces 3 edges with 1 clique (saving 2 from the count), the clique partition number drops to $\\lfloor n^2/4 \\rfloor - m$ for such graphs. Their proof uses a sophisticated induction on $m$, combined with the Kruskal-Katona theorem to control the triangle distribution.\n\nThe general case—when $K_4$ and larger cliques are allowed—remains open. The difficulty is combinatorial: larger cliques offer bigger savings ($K_r$ replaces $\\binom{r}{2}$ edges with 1 piece), but edges may belong to multiple overlapping cliques, creating a complex optimization problem related to fractional relaxations and potentially NP-hard in the worst case.",
@@ -192,7 +192,7 @@
     "lineCount": 696,
     "axiomCount": 2,
     "theoremCount": 37,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1017OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -38,7 +38,7 @@
       "Explicit 3-uniform case as the first non-trivial instance (K₇³ in R⁴)"
     ],
     "theoremCount": 11,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős Problem #1018 asked whether every dense graph (with n^{1+ε} edges) must contain a non-planar subgraph on only O_ε(1) vertices. Kostochka and Pyber (1988) answered affirmatively: n^{1+ε} edges force a K₅ topological minor on a bounded number of vertices. The key insight was that K₅ non-planarity is the topological obstruction for graphs: by Kuratowski, every non-planar graph contains K₅ or K_{3,3} as a minor. For r-uniform hypergraphs viewed as (r-1)-dimensional simplicial complexes, the natural analogue of planarity is embeddability in R^{2(r-1)}: a generic (r-1)-dimensional complex embeds in R^{2(r-1)+1} by general position, so R^{2(r-1)} is the first dimension where non-embeddability can occur. The van Kampen-Flores theorem, proved independently by van Kampen and Flores in 1933 using the newly proved Borsuk-Ulam theorem, establishes the minimal obstruction: K_{2r+1}^{(r)} is not embeddable in R^{2(r-1)}. The proof uses deleted products and Z/2-equivariant topology — the same framework used by Lovász in his proof of the Kneser conjecture (1978). For r=2 this gives K₅ non-planarity; for r=3 it gives K₇^{(3)} non-embeddability in R⁴. The Turán density of K₄^{(3)} — asking for the maximum edges in a K₄^{(3)}-free 3-uniform hypergraph — is one of the most famous open problems in extremal combinatorics (Turán 1941, still unsolved). The super-linear density threshold n^{r-1+ε} exceeds these Turán numbers for large n, making the conjecture well-motivated.",
@@ -195,7 +195,7 @@
     "lineCount": 318,
     "axiomCount": 4,
     "theoremCount": 11,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos1018OQ04.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "3 axioms: cyclePlus2K1_saturated_planar, erdos_construction_exists, simonovits_theorem. K4_saturated_planar converted from axiom to theorem (1 sorry remains for edge count: C(4,2)=6 on generic 4-element type). isPlanar defined via Wagner forbidden minor characterization. K3_saturated_planar and bipartite_not_saturated fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "additionalFiles": [
       "Proofs/Erdos1019Aristotle.lean"
     ]
@@ -284,7 +284,7 @@
     "lineCount": 478,
     "axiomCount": 3,
     "theoremCount": 13,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "path": "Proofs/Erdos1019Problem.lean",
     "sorries": 1,
     "additionalFiles": [

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -50,7 +50,7 @@
     "lineCount": 173,
     "assumptions": "1 axiom: connection_101. 0 sorries.",
     "theoremCount": 10,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Erdős and Purdy posed this problem in their foundational surveys of combinatorial geometry in the 1970s–1980s, building on the Sylvester–Gallai tradition of studying collinearity in finite point sets. The question asks: if a planar point set of size $n$ has 'many' rich lines (at least $cn^2$ lines each containing $\\ge 4$ points), how large must the maximum collinear subset be?\n\nErdős conjectured that $h_c(n) \\gg \\sqrt{n}$, meaning that many rich lines force a large collinear subset of roughly square-root size. This was disproved by Zach Hunter, who constructed lattice-point configurations in $\\{1,\\ldots,m\\}^d$ showing $h_c(n) \\ll n^{1/\\log(1/c)}$ — much slower growth than $\\sqrt{n}$ for small $c$. Hunter's construction exploits the arithmetic structure of integer lattice points and the abundance of collinear quadruples in high-dimensional lattices projected to the plane.\n\nThe upper bound $h_c(n) \\le C\\sqrt{n}$ follows from the Szemerédi–Trotter incidence theorem (1983), the landmark result of Endre Szemerédi and William T. Trotter bounding point-line incidences by $O(n^{2/3}m^{2/3} + n + m)$. This was later reproved by László Székely (1997) using the crossing number inequality, and is now one of the central tools in discrete geometry. The fundamental question — whether $h_c(n) \\to \\infty$ at all for fixed $c$ — remains open and is closely connected to Problem #101 about the count of 4-point lines, to Problem #588 on $k$-rich lines, and to the Orchard Problem (#669).",
@@ -218,7 +218,7 @@
     "lineCount": 173,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos102Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "6 axiom declarations: erdos_gallai_graphs (Erdős-Gallai theorem for graphs), luczak_mieczkowska (r=3 case, Łuczak-Mieczkowska 2014), huang_loh_sudakov (large n regime), frankl_upper_bound (Frankl's (k-1)·C(n-1,r-1) upper bound), construction1_lower (first extremal construction), construction2_lower (second extremal construction). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős posed this conjecture around 1965, asking for the maximum number of edges in an r-uniform hypergraph on n vertices with no k pairwise disjoint edges. For ordinary graphs (r=2), the answer was already known: the Erdős-Gallai theorem (1959) gives the exact value as max(C(2k-1,2), n(k-1) - C(k,2)). For r≥3, Erdős conjectured that the extremum is always achieved by one of two natural constructions: either taking all r-subsets of a (rk-1)-element set (too few vertices for k disjoint r-edges), or taking all r-subsets meeting a fixed (k-1)-element set (a 'sunflower' obstruction). The problem attracted decades of work. Kleitman (1968) proved an early upper bound. Bollobás, Daykin, and Erdős made further partial progress. Frankl (1987) proved the influential upper bound f(n;r,k) ≤ (k-1)·C(n-1,r-1) using the shifting technique. A major breakthrough came when Łuczak and Mieczkowska (2014) confirmed the conjecture for r=3 (3-uniform hypergraphs) using a sophisticated container method argument. Huang, Loh, and Sudakov (2012) proved the conjecture for sufficiently large n (n ≥ 3kr²) using dependent random choice. Frankl (2013, 2017) obtained further improvements. Despite this progress, the general conjecture remains open for r≥4 and is considered one of the most important problems in extremal set theory.",
@@ -189,7 +189,7 @@
     "lineCount": 326,
     "axiomCount": 6,
     "theoremCount": 4,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos1020Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -64,7 +64,7 @@
     "assumptions": "1 axiom: weighted_erdos_szekeres (deep: Tidor-Wang-Yang 2016). lis_lds_bound now proved from Erdős-Szekeres via sSup contradiction. erdos_szekeres proved from Mathlib (Theorems100.erdos_szekeres via Finset.orderEmbOfFin bridge).",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 11
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "**The Monotonic Subsequence Sum Problem**\n\nErdős (1971) posed this optimization problem: given a sequence of distinct real numbers, what is the maximum sum achievable by a monotonic subsequence?\n\n**Timeline:**\n- **1935**: Erdős-Szekeres prove every sequence of n²+1 elements has a monotonic subsequence of length n+1\n- **1957**: Hanani shows every sequence decomposes into ≤ (√2+o(1))√n monotonic parts, giving c ≥ 1/√2\n- **1995**: Steele surveys variations on the Erdős-Szekeres theme, highlighting open weighted versions\n- **2016**: Tidor-Wang-Yang prove the weighted version, showing c = 1; Cambie independently conjectures and proves the upper bound c ≤ 1\n- **2017**: Wagner gives an independent proof via tournament theory\n\nThe problem sits at the intersection of extremal combinatorics and optimization. The classical Erdős-Szekeres theorem guarantees long monotonic subsequences; Erdős's question asks the deeper 'weighted' version: not just how many elements, but how much total value can a monotonic subsequence capture? The answer c = 1 is remarkably clean.",
@@ -267,7 +267,7 @@
     "lineCount": 328,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1026Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 367,
     "assumptions": "3 axiom(s), 0 sorries remain.(s). isometry2D_surjective (Mazur-Ulam consequence: isometries of R^2 are surjective), h (counting function), h_pos (existence of optimal configs for n>=2).",
     "theoremCount": 23,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Erdős Problem #103, first appearing in his 1994 collection \"Some of my favourite unsolved problems,\" asks whether h(n) → ∞, where h(n) counts the number of incongruent sets of n points in ℝ² that minimize diameter subject to pairwise distances ≥ 1. The problem connects to the classical theory of optimal point configurations studied by Fejes Tóth (1953) and to modern questions about the structure of extremal packings. The parent formalization contained a subtle logical error: it claimed that \"h unbounded\" and \"h tends to infinity\" are equivalent, but this requires monotonicity of h, which is itself an interesting open structural question about how the space of optimal configurations evolves as the number of points increases.",
@@ -236,7 +236,7 @@
     "lineCount": 367,
     "axiomCount": 3,
     "theoremCount": 23,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos103OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 253,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "theoremCount": 7,
-    "definitionCount": 19
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in [Er94b] (1994). The question concerns the diversity of optimal point configurations in the plane.\n\nGiven n points with minimum pairwise separation 1, we seek configurations minimizing the diameter (largest distance). h(n) counts how many 'essentially different' (incongruent) optimal configurations exist.\n\nThe problem connects to classical circle packing - placing n non-overlapping unit circles in the smallest possible containing circle. The hexagonal lattice is optimal for large n (Thue-Minkowski).\n\nRelated to Erdős Problem #99. Even very weak versions of the conjecture remain open.",
@@ -281,7 +281,7 @@
     "lineCount": 253,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "path": "Proofs/Erdos103Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 1018,
     "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower). 0 sorries (h_as_min, turan_plus_one, h_four, h_spec all proved). Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal).",
     "theoremCount": 28,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos1033Aristotle.lean"
     ]
@@ -311,7 +311,7 @@
     "lineCount": 1018,
     "axiomCount": 3,
     "theoremCount": 28,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "sorries": 0,
     "path": "Proofs/Erdos1033Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -30,7 +30,7 @@
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "additionalFiles": [
       "Proofs/Erdos1034Aristotle.lean"
     ]
@@ -281,7 +281,7 @@
     "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 22,
+    "definitionCount": 23,
     "path": "Proofs/Erdos1034Problem.lean",
     "sorries": 3,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -60,7 +60,7 @@
       "random_polynomial_expected axiom: expected inscribed disc radius for random roots ≫ 1/n"
     ],
     "theoremCount": 9,
-    "definitionCount": 16,
+    "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039ProblemAristotle.lean"
     ]
@@ -244,7 +244,7 @@
     "lineCount": 303,
     "axiomCount": 5,
     "theoremCount": 9,
-    "definitionCount": 16,
+    "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 3,
     "additionalFiles": [

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "0 axioms, 0 sorries. All geometric lemmas fully proved: two_points_no_circle (triangle inequality), two_points_one_circle (parallelogram law uniqueness), strong_implies_weak, quadratic_at_most_two_roots. The main conjecture O(n^{3/2}) remains open. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős in 1975 as part of his extensive program on combinatorial and discrete geometry, and carries a $100 prize. It sits in the family of unit distance and incidence problems that have driven much of modern computational geometry. The fundamental observation is that any two points at distance at most 2 determine at most 2 unit circles through both (the centers lie on the perpendicular bisector), giving a trivial O(n²) upper bound on the number of unit circles with 3+ points from an n-point set. Harborth and Mengersen (1986) refined this to n(n-1)/3 using the fact that each 3-rich circle contributes at least 3 pairs. Elekes (1984) proved the matching lower bound Ω(n^{3/2}) by constructing point sets on a grid-like structure that create many triple incidences with unit circles. This established the conjectured growth rate as Θ(n^{3/2}), but proving the O(n^{3/2}) upper bound has remained stubbornly open. The problem is closely related to the Szemerédi-Trotter incidence theorem (1983), which bounds point-line incidences as O(n^{2/3}m^{2/3} + n + m). Analogous bounds hold for algebraic curves (Pach-Sharir), but naively applying them to unit circles only recovers the O(n²) trivial bound. The difficulty is that unit circles form a special 2-parameter family (parameterized by center position), and exploiting this algebraic structure has resisted all known techniques including polynomial partitioning (Guth-Katz 2015).",
@@ -148,7 +148,7 @@
     "lineCount": 330,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos104Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` to actual `def+abbrev+opaque+structure+inductive+class` count in the primary Lean file across 25 erdos slugs. Both fields were stale by the same amount in every entry; both updated together.

## Counting convention

Per memory note `feedback_mechanic_def_counting`:
`def + abbrev + opaque + structure + inductive + class` with modifiers (`noncomputable`, `private`, `protected`, `partial`, `scoped`, `unsafe`); `instance` excluded.

## Slugs (claimed → actual)

| Slug | Δ |
| --- | --- |
| erdos-1000 | 11 → 12 |
| erdos-1005 | 2 → 3 |
| erdos-1006 | 7 → 8 |
| erdos-1006-oq-01 | 12 → 13 |
| erdos-1006-oq-02 | 8 → 9 |
| erdos-1006-oq-02-oq-03 | 5 → 6 |
| erdos-1007 | 3 → 4 |
| erdos-1007-oq-01 | 13 → 14 |
| erdos-1007-oq-01-oq-01 | 3 → 4 |
| erdos-101 | 5 → 6 |
| erdos-1012-oq-03 | 13 → 14 |
| erdos-1015 | 9 → 10 |
| erdos-1017 | 8 → 9 |
| erdos-1017-oq-01 | 8 → 9 |
| erdos-1018-oq-04 | 11 → 12 |
| erdos-1019 | 22 → 23 |
| erdos-102 | 3 → 4 |
| erdos-1020 | 11 → 12 |
| erdos-1026 | 11 → 13 |
| erdos-103 | 19 → 20 |
| erdos-103-oq-01 | 13 → 14 |
| erdos-1033 | 19 → 20 |
| erdos-1034 | 22 → 23 |
| erdos-1039 | 16 → 17 |
| erdos-104 | 12 → 13 |

## Coordination

Complements in-flight m-r theoremCount batch (#17441) which covers `erdos-1009`, `erdos-1009-oq-02`, `erdos-263`, `erdos-662` (different field, no overlap). No alphabetic conflict with merged a-c (#17407), d-e (#17429), f-l (#17430), m-p (#17453), m-r (#17446).

---
Automated fix by lean-mechanic agent.