### PR TITLE
fix(meta): batch sync theoremCount/definitionCount drift (25 entries, batch c-d)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -49,7 +49,7 @@
     "lineCount": 442,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5
   },
   "overview": {
@@ -229,7 +229,7 @@
     "namespace": "CantorDiagonalizationOQ01",
     "lineCount": 442,
     "axiomCount": 2,
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
@@ -36,7 +36,7 @@
     "lineCount": 240,
     "theoremCount": 6,
     "defCount": 3,
-    "definitionCount": 3
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Lawvere's 1969 paper proves a fixed-point theorem in any cartesian closed category (CCC): if e : A → B^A is a point-surjection, every endomorphism B → B has a fixed point. This unifies Cantor's theorem (B = Ω = subobject classifier, f = negation), Russell's paradox, the halting problem, and Gödel's first incompleteness theorem. The categorical formulation is strictly more general than the type-theoretic one: it applies in any topos, not just the category of types. The formalization challenge in Lean is that full topos machinery is not yet in Mathlib, requiring an abstract intermediate layer.",
@@ -119,7 +119,7 @@
     "path": "Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "theoremCount": 6
   },
   "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
@@ -35,7 +35,7 @@
     "lineCount": 303,
     "assumptions": "0 axioms. 0 sorries.",
     "theoremCount": 11,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "F. William Lawvere's 1969 paper 'Diagonal Arguments and Cartesian Closed Categories' unified Cantor's theorem, Gödel's incompleteness theorem, and Turing's undecidability result as a single categorical fixed-point theorem. The key insight is that all diagonal arguments arise from the same categorical mechanism: a morphism e : A → B^A in a cartesian closed category (CCC) that is 'point-surjective' (every global element of B^A factors through e) forces every endomorphism f : B → B to have a fixed point. Cantor's theorem corresponds to B = Ω (the subobject classifier), f = ¬ (negation, which has no fixed points); Gödel's diagonal lemma corresponds to a provability predicate; Turing's halting problem corresponds to the characteristic function of a decision procedure. This formalization captures the three-level hierarchy: abstract (EvalStructure, no category theory), type-theoretic (Type, ×, →), and categorical (CCC global elements, CategoricalEval). The topos-level formalization awaits Mathlib's topos infrastructure.",
@@ -144,7 +144,7 @@
     "lineCount": 303,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "sorries": 0,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean"
   }

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile — every behavior has a canonical code (universality); (2) kleene_rec — Kleene's recursion theorem (every code transformer has a semantic fixed point). These are hypotheses to classical_rice_abstract, not global Lean axioms. The 5 abstract theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
     "theoremCount": 7,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "originalContributions": [
       "abstract_rice: no Bool-evaluation structure can be point-surjective (direct from Lawvere)",
       "rice_induced_obstruction: any d : Val → Bool applied to a point-surjective structure gives a non-surjective Bool structure",
@@ -123,7 +123,7 @@
     "lineCount": 275,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma / h_diag), consistency (h_consistent), reflection principle (h_reflection), and D1 axiom of provability logic (h_D1) — 4 Prop-typed assumptions. StrongGodelModel additionally axiomatizes double-negation elimination (h_dne) — 1 more. Total: 5 structure-encoded mathematical assumptions. These are hypotheses, not global Lean axioms.",
     "lineCount": 256,
     "theoremCount": 7,
-    "definitionCount": 1,
+    "definitionCount": 4,
     "originalContributions": [
       "diagonal_lemma: abstract Lawvere version of the Gödel-Carnap diagonal lemma",
       "godel_sentence: existence of the Gödel sentence G = Neg(PrSent G) via Lawvere fixed-point",
@@ -136,7 +136,7 @@
     "lineCount": 256,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 1,
+    "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
@@ -38,7 +38,7 @@
       "surjective_implies_pointwise: classical surjectivity implies constructive surjectivity (one direction only)",
       "cantor_recovery_from_constructive: classical cantor_recovery derived from constructive version"
     ],
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "sections": [
@@ -145,7 +145,7 @@
     "namespace": "CantorDiagonalizationOQ03OQ01OQ04",
     "lineCount": 175,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -43,7 +43,7 @@
     "assumptions": "0 axioms. 0 sorries. lawvere_categorical is now fully proved by adding e_pt : Pt A → Pt (exp A B) as a parameter (the morphism's global-element action) and reducing to lawvere_abstract via EvalStructure with eval a x = apply (e_pt a) x.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "F. William Lawvere's 1969 paper 'Diagonal arguments and cartesian closed categories' (Springer LNM 92, pp. 134-145) revealed that Cantor's diagonal argument — and its many relatives — are all instances of a single fixed-point theorem in cartesian closed categories (CCCs). This unification is one of the great insights of categorical logic.\n\n**The historical precedents**: Cantor (1891) used the diagonal to show no surjection A → 2^A exists. Russell (1902) used self-reference to derive his paradox. Gödel (1931) used a diagonal construction to produce undecidable sentences. Church and Turing (1936) used diagonalization to show the halting problem is undecidable. All of these were recognized as related but treated case-by-case.\n\n**Lawvere's unification (1969)**: In a cartesian closed category, if a morphism e : A → B^A is 'point-surjective' (every global element 1 → B^A is in its image), then every endomorphism f : B → B has a fixed point. Taking the contrapositive: if f has no fixed point, then no point-surjection A → B^A exists. Concretely:\n- Cantor: B = {0,1} or Prop, f = Not (no fixed point)\n- Russell: B = {true,false}, f = not\n- Gödel: B = sentences, f = 'diagonalization of provability'\n- Halting: B = {halt, loop}, f = not-halt\n\n**Yanofsky (2003)**: Noson Yanofsky's survey 'A Universal Approach to Self-Referential Paradoxes, Incompleteness and Fixed Points' (The Bulletin of Symbolic Logic) popularized Lawvere's insight and extended it to a 'diagonal argument in a setting with enough structure.'\n\n**Topos theory**: In a topos (a CCC with a subobject classifier Ω), Lawvere's theorem with B = Ω and f = internal negation gives: no object A can surject onto its power object Ω^A = P(A). This is the topos-theoretic Cantor theorem, proved in Johnstone's Elephant (A1.6.1) and MacLane-Moerdijk's Sheaves in Geometry and Logic (IV.7). A full Lean formalization requires the topos typeclass, currently under development in Mathlib.",
@@ -197,7 +197,7 @@
     "lineCount": 303,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04/meta.json
@@ -74,7 +74,7 @@
       }
     ],
     "theoremCount": 14,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "problemStatement": "Prove the retraction formulation of Lawvere's fixed-point theorem: if a type $Y$ codes its own endomorphisms (i.e., $Y \\to Y$ retracts into $Y$ via encode/decode with $\\text{decode} \\circ \\text{encode} = \\text{id}$), then every endomorphism $f : Y \\to Y$ has a fixed point.",
@@ -211,7 +211,7 @@
     "lineCount": 304,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "2 axiom(s): hadamard_three_lines, riesz_thorin. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 28,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "**Riesz-Thorin Interpolation (1927/1948)**\n\nMarcel Riesz proved the first interpolation theorem for bilinear forms in 1927. Olof Thorin simplified and extended the proof in 1948 using the Hadamard three-lines lemma from complex analysis.\n\nThe theorem states: if a linear operator T is bounded from $L^{p_0}$ to $L^{q_0}$ with norm $M_0$, and from $L^{p_1}$ to $L^{q_1}$ with norm $M_1$, then for any $\\theta \\in [0,1]$, T is bounded from $L^{p_\\theta}$ to $L^{q_\\theta}$ with norm $\\leq M_0^{1-\\theta} \\cdot M_1^\\theta$, where the interpolated exponents satisfy $1/p_\\theta = (1-\\theta)/p_0 + \\theta/p_1$.\n\n**Connection to Hölder**: Hölder's inequality provides the endpoint estimates (the $M_0$ and $M_1$ bounds), while the three-lines lemma provides the interpolation between endpoints.",
@@ -207,7 +207,7 @@
     "lineCount": 600,
     "axiomCount": 2,
     "theoremCount": 28,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 176,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "namespace": "HolderELpNorm",
     "lineCount": 176,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 117,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
     "originalContributions": [
@@ -171,7 +171,7 @@
     "namespace": "CancellationStep",
     "lineCount": 117,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 161,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 0,
     "assumptions": "None. All theorems proved from Mathlib's Orthonormal.sum_inner_products_le, Orthonormal.tsum_inner_products_le, and HilbertBasis.tsum_inner_mul_inner.",
     "mathlibDependencies": [
@@ -270,7 +270,7 @@
     "path": "Proofs/CauchySchwarzOQ02OQ02.lean",
     "filename": "CauchySchwarzOQ02OQ02.lean",
     "lineCount": 161,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0,

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -77,7 +77,7 @@
     "lineCount": 835,
     "assumptions": "0 axioms, 0 sorries. Lagrange identity and Hölder equality characterization are original; inner product space equality case uses Mathlib's norm_inner_eq_norm_iff, Hölder inequality via NNReal.inner_le_Lp_mul_Lq.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29,
+    "theoremCount": 31,
     "definitionCount": 1
   },
   "sections": [
@@ -203,7 +203,7 @@
     "namespace": "CauchySchwarzOQ03OQ01",
     "lineCount": 835,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 31,
     "definitionCount": 1,
     "path": "Proofs/CauchySchwarzOQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 288,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 2
   },
   "overview": {
@@ -219,7 +219,7 @@
     "namespace": "CauchySchwarzOQ04",
     "lineCount": 288,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/CauchySchwarzOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -92,7 +92,7 @@
     "axiomCount": 0,
     "lineCount": 231,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 0
   },
   "overview": {
@@ -295,7 +295,7 @@
     "namespace": "CauchySchwarz",
     "lineCount": 231,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarz.lean",
     "sorries": 0

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 390,
     "assumptions": "None. All theorems fully proved including minpoly computations via UFD divisor classification and intertwining constraint extraction via Fin 4 case analysis.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 2
   },
   "overview": {
@@ -147,7 +147,7 @@
     "namespace": "SimilarCounterexample",
     "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
@@ -56,7 +56,7 @@
     "assumptions": "3 axiom(s): gnedenko_kolmogorov_forward, gnedenko_kolmogorov_gaussian, gnedenko_kolmogorov_converse. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "The Central Limit Theorem, first rigorously proved by Lyapunov (1901) and Lindeberg (1922), characterizes Gaussian limits for sums of independent random variables with finite variance. The natural question — what happens when variance is infinite? — was resolved by Boris Gnedenko and Andrey Kolmogorov in their 1954 monograph 'Limit Distributions for Sums of Independent Random Variables.' They proved that every possible limit law for normalized sums must be a stable distribution, parameterized by an index $\\alpha \\in (0, 2]$, and that membership in the domain of attraction of $S_\\alpha$ is completely characterized by regularly varying tails. The theory rests on Jovan Karamata's (1930) framework of slowly and regularly varying functions, which provides the precise language for 'power-law tails with logarithmic corrections.' Paul Lévy (1925) had independently discovered stable distributions via characteristic function methods. William Feller's treatment in Volume 2 of his probability textbook (1971) made the theory accessible to a broad audience. The formalization here builds the Karamata framework from scratch in Lean 4 and axiomatizes the deep analytic core (Lévy continuity theorem, Abelian-Tauberian connections) while fully proving the algebraic and structural results.",
@@ -246,7 +246,7 @@
     "lineCount": 1130,
     "axiomCount": 3,
     "theoremCount": 55,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -44,7 +44,7 @@
     "assumptions": "0 axioms, 0 sorries. All 19 theorems fully proved. stable_inf_divisible (α-stable infinite divisibility) was converted to a block comment; the remaining 19 theorems about Lévy triplets, Gaussian/Poisson instances, and Lévy-Itô decomposition are machine-verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 13
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "The Lévy-Khintchine formula stands as one of the deepest results in probability theory, characterizing all infinitely divisible distributions through a single canonical representation. Paul Lévy established the formula in 1934 as part of his systematic study of stochastic processes with independent increments, building on earlier work by Bruno de Finetti (1929) on the structure of infinitely divisible laws. Aleksandr Khintchine independently proved the same result in 1937 using characteristic function methods. The formula reveals that every infinitely divisible distribution is uniquely determined by three objects: a drift parameter γ, a Gaussian variance σ², and a Lévy measure ν that describes the jump structure. This trichotomy — drift, diffusion, jumps — became the foundation for the modern theory of Lévy processes, with far-reaching applications in mathematical finance (jump-diffusion models of Merton 1976), physics (anomalous diffusion), and statistics (stable distributions as limit laws for heavy-tailed data).",
@@ -176,7 +176,7 @@
     "lineCount": 322,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 13,
+    "definitionCount": 16,
     "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None.",
     "theoremCount": 5,
     "mathlib_version": "4.26.0",
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "leanFile": {
     "imports": [
@@ -33,7 +33,7 @@
     "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) \u2014 the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 3 sorries: (1) nested ciSup of zeros = 0 for independent sequences, (2) i.i.d. Lindeberg condition via dominated convergence for truncated moments, (3) i.i.d. Lyapunov condition via rpow moment decay.",
     "lineCount": 729,
     "theoremCount": 20,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/CentralLimitTheoremOQ02Aristotle.lean"
     ],
@@ -77,7 +77,7 @@
     "lineCount": 729,
     "axiomCount": 1,
     "theoremCount": 20,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "path": "Proofs/CentralLimitTheoremOQ02.lean",
     "sorries": 3,
     "additionalFiles": [

--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -46,7 +46,7 @@
     "assumptions": "14 axioms: convolution, convolution_assoc, convolution_dirac_left, and 11 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "sections": [
     {
@@ -168,7 +168,7 @@
     "lineCount": 241,
     "axiomCount": 14,
     "theoremCount": 8,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/CentralLimitTheoremOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/central-limit-theorem-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-04/meta.json
@@ -52,7 +52,7 @@
     "assumptions": "9 axioms (free probability not in Mathlib). Core axioms: freeCumulant (3), freeConv + linearization + identity (3), cumulant_determines_distribution, semicircle_cumulant_higher, free_clt. PROVED: freeConv_comm, freeConv_assoc (from cumulant determinism), Rtransform_additive (from cumulant linearity). Rtransform defined as coefficient sequence.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "sections": [
     {
@@ -182,7 +182,7 @@
     "lineCount": 649,
     "axiomCount": 9,
     "theoremCount": 21,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/CentralLimitTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 309,
     "theoremCount": 10,
-    "definitionCount": 5,
+    "definitionCount": 8,
     "originalContributions": [
       "GeneralizedMenelausConfig: signed ratio framework for Menelaus theorem",
       "generalized_menelaus: algebraic core (product = -1 iff numerator = -denominator)",
@@ -109,7 +109,7 @@
     "lineCount": 309,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 5,
+    "definitionCount": 8,
     "path": "Proofs/CevasTheoremNonEuclideanOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-non-euclidean/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 527,
     "theoremCount": 18,
-    "definitionCount": 7,
+    "definitionCount": 11,
     "originalContributions": [
       "GeneralizedCevianConfig structure unifying Euclidean, spherical, and hyperbolic configurations",
       "generalized_ceva: abstract algebraic core shared by all three geometry types",
@@ -139,7 +139,7 @@
     "path": "Proofs/CevasTheoremNonEuclidean.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 7,
+    "definitionCount": 11,
     "theoremCount": 18
   },
   "sorries": 0

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -39,7 +39,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Ceva's Theorem was published by Italian mathematician Giovanni Ceva in 1678 in his work 'De lineis rectis se invicem secantibus statica constructio' (On straight lines intersecting each other in a static construction). The theorem is closely related to Menelaus's theorem (which deals with collinear points rather than concurrent lines) and both are fundamental results in triangle geometry.\n\nThe theorem provides a unified framework for understanding classical concurrence results including medians meeting at the centroid, altitudes meeting at the orthocenter, and angle bisectors meeting at the incenter.",
@@ -146,7 +146,7 @@
     "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CevasTheorem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Re-syncs `leanFile.theoremCount` and `leanFile.definitionCount` (and the parallel `meta.*` block) against the current Lean source for 25 gallery entries in the c-d range, where the metadata had drifted as theorem/definition declarations were added.

## Evidence

Counting convention matches recent PR #17441 and PR #17462:
- `theoremCount`: matches `theorem|lemma|example` declarations with optional `noncomputable|protected|private|scoped` modifiers, after stripping line and (nested) block comments and string contents.
- `definitionCount`: matches `def|abbrev|opaque|structure|inductive|class` declarations with optional `partial|noncomputable|protected|private|scoped|unsafe` modifiers, same comment/string stripping.

Both the nested `meta` block and the `leanFile` block were synced wherever both were present (1 or 2 occurrences expected).

| slug | drift |
|---|---|
| cantor-diagonalization-oq-01 | t 27→28 |
| cantor-diagonalization-oq-03-oq-01 | d 4→6 |
| cantor-diagonalization-oq-03-oq-01-incomplete-01 | d 3→5 |
| cantor-diagonalization-oq-03-oq-01-oq-01 | d 4→6 |
| cantor-diagonalization-oq-03-oq-01-oq-02 | d 3→6 |
| cantor-diagonalization-oq-03-oq-01-oq-03 | d 1→4 |
| cantor-diagonalization-oq-03-oq-01-oq-04 | t 8→9 |
| cantor-diagonalization-oq-04 | d 3→4 |
| cauchy-schwarz | t 9→12 |
| cauchy-schwarz-integral-oq-01-oq-02 | d 7→8 |
| cauchy-schwarz-integral-oq-01-oq-03-oq-01 | t 6→8 |
| cauchy-schwarz-integral-oq-02-oq-02-oq-01 | t 3→5 |
| cauchy-schwarz-oq-02-oq-02 | t 10→11 |
| cauchy-schwarz-oq-03-oq-01 | t 29→31 |
| cauchy-schwarz-oq-04 | t 17→19 |
| cayley-hamilton-minpoly-oq-02-oq-02 | t 14→16 |
| central-limit-theorem-oq-01-oq-01 | d 7→8 |
| central-limit-theorem-oq-01-oq-02 | d 13→16 |
| central-limit-theorem-oq-01-oq-03 | d 3→4 |
| central-limit-theorem-oq-02 | d 11→14 |
| central-limit-theorem-oq-03 | d 4→5 |
| central-limit-theorem-oq-04 | d 10→12 |
| cevas-theorem | d 3→4 |
| cevas-theorem-non-euclidean | d 7→11 |
| cevas-theorem-non-euclidean-oq-02 | d 5→8 |

Slugs with open mechanic or research PRs were excluded from this batch.

---
Automated fix by lean-mechanic agent.