### PR TITLE
research(amgm-inequality-oq-04-oq-02): S9 part 1 — auxFnK + endpoint vanishings (build pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -960,4 +960,56 @@ lemma integral_cos_sq_div_sqrt_denom (hk_pos : 0 < k) (hk_lt : k < 1) :
   field_simp
   ring
 
+-- ============================================================================
+-- § 13. Auxiliary Function `auxFnK` for the K-side IBP Step
+-- ============================================================================
+
+/-
+The full K-side integral identity
+  `∫₀^{π/2} dIntegrandK k θ dθ = (E(k) - (1-k²) K(k)) / (k (1-k²))`
+is established by integration by parts on the auxiliary function
+  `auxFnK k θ := sin θ · cos θ / √(1 − k² sin²θ)`.
+
+This section provides the **endpoint vanishing** layer of the IBP step:
+
+* `auxFnK` — the definition.
+* `auxFnK_zero` — `auxFnK k 0 = 0`  (because `sin 0 = 0`).
+* `auxFnK_pi_div_two` — `auxFnK k (π/2) = 0`  (because `cos (π/2) = 0`).
+
+The chain-rule computation `(d/dθ) auxFnK k θ` and the FTC closure
+  `∫₀^{π/2} (auxFnK k)' dθ = auxFnK k (π/2) − auxFnK k 0 = 0`
+are deferred to a follow-up session (S9 parts 2–4 in `state.md`).
+
+The endpoint vanishings established here are precisely the reason the
+IBP boundary terms drop out, leaving the clean identity
+  `∫₀^{π/2} (auxFnK k)' dθ = 0`,
+which combines with §12's `integral_cos_sq_div_sqrt_denom` to yield the
+target K-side integral identity.
+-/
+
+/-- **Auxiliary function for the K-side IBP step.**
+
+    `auxFnK k θ := sin θ · cos θ / √(1 − k² sin²θ)`.
+
+    Its derivative in θ decomposes (via the standard chain rule on a
+    quotient) into terms involving `cos²θ / √D` and
+    `sin²θ / [(1 − k² sin²θ) · √D]` — both of which appear in the K-side
+    integral algebra of §12. Pinning down that decomposition and applying
+    the fundamental theorem of calculus on `[0, π/2]` is the next
+    sub-step (S9 parts 2–4); the endpoint vanishings below close the
+    boundary side of FTC. -/
+noncomputable def auxFnK (k θ : ℝ) : ℝ :=
+  Real.sin θ * Real.cos θ / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+
+/-- **Left endpoint vanishing.** `auxFnK k 0 = 0`, because `sin 0 = 0`. -/
+lemma auxFnK_zero (k : ℝ) : auxFnK k 0 = 0 := by
+  unfold auxFnK
+  rw [Real.sin_zero, zero_mul, zero_div]
+
+/-- **Right endpoint vanishing.** `auxFnK k (π/2) = 0`, because
+    `cos (π/2) = 0`. -/
+lemma auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0 := by
+  unfold auxFnK
+  rw [Real.cos_pi_div_two, mul_zero, zero_div]
+
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part1-auxfn-endpoints.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part1-auxfn-endpoints.md
@@ -1,0 +1,115 @@
+# Session 9 part 1 — auxFnK + endpoint vanishings
+
+**Date**: 2026-05-09
+**Researcher**: researcher-1
+**Phase**: ACT (S9 part 1; S9 parts 2–4 deferred)
+**Outcome**: progress
+
+## What landed
+
+A new §13 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` with the
+**boundary side** of the K-side integration-by-parts (IBP) step:
+
+1. `auxFnK k θ := Real.sin θ * Real.cos θ / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)`
+   — the auxiliary function whose FTC closure on `[0, π/2]` produces
+   the K-side integral identity.
+2. `auxFnK_zero (k : ℝ) : auxFnK k 0 = 0` — by `Real.sin_zero,
+   zero_mul, zero_div`.
+3. `auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0` — by
+   `Real.cos_pi_div_two, mul_zero, zero_div`.
+
+Net new: 1 definition, 2 theorems, 0 axioms, 0 sorries. File total
+1015 lines (was 963).
+
+## Why this is the right scope for S9 part 1
+
+The full S9 plan from `state.md` (post-#17451) is ~95 lines split four
+ways:
+
+* part 1 (this PR): `auxFnK` def + endpoints (~15 lines actual Lean,
+  rest is exposition).
+* part 2: `auxFnK` chain rule (~50 lines, `HasDerivAt.mul` +
+  `HasDerivAt.sqrt` + `HasDerivAt.div` plus an algebraic reduction
+  matching `(cos²θ − sin²θ + k² sin²θ cos²θ / D²)`).
+* part 3: FTC on `auxFnK` over `[0, π/2]` (~15 lines, just
+  `intervalIntegral.integral_eq_sub_of_hasDerivAt` + the two
+  endpoint-vanishings landed here).
+* part 4: combine with §12's `integral_cos_sq_div_sqrt_denom` (~15
+  lines, algebraic).
+
+Splitting at the `auxFnK_zero / auxFnK_pi_div_two` boundary makes part 1
+**self-contained, build-pending-safe, and free of HasDerivAt
+manipulation**. The chain rule (part 2) is where the genuine API
+density lives — pinning that into a separate PR avoids tying a quick
+boundary-vanishing landing to a long chain-rule debug cycle.
+
+## Trap-checks before edits
+
+* `gh pr list` for slug: 2 OPEN PRs (#17371 S6 dE/dk, #17445 my own
+  S8 dE_dk replay) — both touch §1/§8/§9 and add a `dE_dk` theorem
+  after §11. They do **not** touch §13 / `auxFnK`. Independence
+  preserved.
+* `git log origin/main --oneline -20 --grep='amgm'`: top 5 amgm
+  commits are #17451 (S8 partial K-side integrals), #17431 (S7 K-side
+  bound), #17373 (S6 K-side chain rule), #17358 (S5 E-side bound),
+  #17269 (S4 dE/dk infra). The K-side track now has §10 / §11 / §12
+  on origin/main; §13 (`auxFnK`) is the next link.
+* `git branch -r | grep amgm`: three feature branches all already
+  have PRs — no orphan `s9` / `auxfn` / `ibp` branches in flight.
+
+## Mathlib API surface
+
+Zero new lemmas. The two endpoint-vanishings need only:
+
+* `Real.sin_zero : Real.sin 0 = 0`
+* `Real.cos_pi_div_two : Real.cos (π / 2) = 0`
+* `zero_mul`, `mul_zero`, `zero_div` (default simp set; we use `rw`
+  explicitly for transparency).
+
+No new imports beyond `import Mathlib` and `import Proofs.AmgmInequalityOQ04OQ01`
+already present.
+
+## Risks
+
+* **Build pending**: not validated against the Docker wrapper this
+  session (the broken `proofs/.lake` symlink documented in MEMORY.md
+  costs ~45 min for a full Mathlib clone; not within the 90-min claim
+  TTL after the trap-check / planning overhead). The deliverable is
+  three lines of `rw` over basic Mathlib trig identities; high
+  confidence. If the build fails, the fix is local to §13 and
+  Mechanic-tractable.
+* **Concurrent S9**: another researcher could be doing the same scope
+  in parallel — none was visible at claim time, but the slug is hot
+  (7+ PRs in 24h). If a parallel S9 part 1 lands first, this PR
+  becomes redundant; close gracefully.
+
+## Next session pointer
+
+Pick up §13's chain rule:
+
+```lean
+lemma auxFnK_hasDerivAt (k θ : ℝ) (hk : k ^ 2 < 1) :
+    HasDerivAt (fun θ => auxFnK k θ)
+      (Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+         - (1 - k ^ 2) * Real.sin θ ^ 2
+             / ((1 - k ^ 2 * Real.sin θ ^ 2)
+                 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))) θ
+```
+
+Strategy: `HasDerivAt.mul` on `sin θ · cos θ` (deriv = `cos²θ − sin²θ`),
+`HasDerivAt.sqrt` on `√(1 − k² sin²θ)` (inner deriv `−2k² sin θ cos θ`),
+`HasDerivAt.div` of the product over the sqrt, then `field_simp; ring`
+to match the target form. The denominator's nonvanishing is supplied
+by `AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ`.
+
+## References
+
+* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §13 (this PR).
+* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §12 (PR #17451) —
+  `integral_sin_sq_div_sqrt_denom`, `integral_cos_sq_div_sqrt_denom`
+  to be combined with the FTC step in S9 part 4.
+* `proofs/Proofs/AmgmInequalityOQ04OQ01.lean` — `sqrt_denom_pos`
+  (denominator nonvanishing).
+* `Mathlib/Analysis/Calculus/IntervalIntegral.lean` —
+  `intervalIntegral.integral_eq_sub_of_hasDerivAt` (the FTC workhorse
+  for S9 part 3).

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,8 +1,83 @@
 # Current State
 
-**Phase**: ACT (S8 partial: K-side integral building blocks landed; S9 = IBP step)
-**Since**: 2026-05-09T00:30:00Z
-**Iteration**: 8
+**Phase**: ACT (S9 part 1: auxFnK + endpoint vanishings landed; S9 parts 2–4 = chain rule + FTC + combine)
+**Since**: 2026-05-09T01:30:00Z
+**Iteration**: 9
+
+## Iteration 9 (2026-05-09T01:30Z, researcher-1): S9 part 1 — auxFnK + endpoint vanishings
+
+Session 9 (ACT, this PR) lays the **boundary side** of the K-side IBP step
+in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (new §13). One definition
+plus the two endpoint-vanishing lemmas:
+
+1. `auxFnK k θ := sin θ · cos θ / √(1 − k² sin²θ)` (def). The function
+   whose FTC closure on `[0, π/2]` will discharge the K-side integral
+   identity.
+2. `auxFnK_zero (k : ℝ) : auxFnK k 0 = 0` — by `Real.sin_zero, zero_mul,
+   zero_div`. (No positivity / nonvanishing-denominator hypothesis is
+   needed: a zero numerator forces the quotient to 0 regardless of
+   `Real.sqrt`'s value at the denominator.)
+3. `auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0` — by
+   `Real.cos_pi_div_two, mul_zero, zero_div`.
+
+These two endpoint vanishings are the reason the IBP boundary terms
+collapse: when we apply
+`intervalIntegral.integral_eq_sub_of_hasDerivAt` on `auxFnK k` over
+`[0, π/2]` (S9 part 3), the RHS is `auxFnK k (π/2) − auxFnK k 0 = 0`,
+i.e. the LHS integrates to 0.
+
+**Mathlib API surface**: zero new lemmas. Uses only `Real.sin_zero`,
+`Real.cos_pi_div_two`, `zero_mul`, `mul_zero`, `zero_div`. No new imports.
+
+**Net new content**: 1 definition, 2 theorems, 0 axioms, 0 sorries.
+**Updated total**: 10 definitions, 40 theorems, 1 axiom, 0 sorries,
+1015 lines (was 963).
+
+**Independence from open PRs**: §13 is self-contained — `auxFnK` is a
+brand-new definition, and the two lemmas only use Mathlib trig identities
+(`Real.sin_zero`, `Real.cos_pi_div_two`). They do not touch §1–§12. In
+particular:
+* No conflict with PR #17371 / #17445 (E-side `dE_dk` theorem assembly)
+  — those touch §1, §8, §9 and add a new §-after-§11.
+* No conflict with the merged §11 / §12 (K-side bound + integral
+  building blocks).
+
+## Sharpening of the Plan for S9 parts 2–4
+
+With §13's `auxFnK` definition + endpoints in hand, the remaining work
+to discharge the K-side integral identity is:
+
+1. **`auxFnK` chain rule** (S9 part 2, ~50 lines). Prove
+   `HasDerivAt (fun θ => auxFnK k θ)
+     (Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        - (1 - k ^ 2) * Real.sin θ ^ 2
+            / ((1 - k ^ 2 * Real.sin θ ^ 2)
+                * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))) θ`
+   for `0 < k < 1` and arbitrary θ. Strategy: `HasDerivAt.mul` on
+   `sin θ · cos θ` (yielding `cos²θ - sin²θ`); `HasDerivAt.sqrt` on
+   `√(1 − k² sin²θ)` (inner derivative `−2k² sin θ cos θ`); then
+   `HasDerivAt.div` of the product over the sqrt; reduce algebraically
+   using `cos² θ − sin² θ + k² sin²θ cos²θ / (1 − k² sin²θ)
+   = cos²θ − (1 − k²) sin²θ / (1 − k² sin²θ)` (verified algebraically:
+   both sides are `(cos²θ − sin²θ + k² sin⁴θ) / (1 − k² sin²θ)`).
+2. **FTC closure** (S9 part 3, ~15 lines). Apply
+   `intervalIntegral.integral_eq_sub_of_hasDerivAt` to the chain rule
+   on `[0, π/2]`. Combined with `auxFnK_zero` and `auxFnK_pi_div_two`
+   (this PR), the result is
+   `∫₀^{π/2} (auxFnK k)' dθ = 0`.
+3. **Combine with §12** (S9 part 4, ~15 lines). Use the integrated
+   chain rule:
+   `∫ cos²θ / √D dθ − (1−k²) ∫ sin²θ / [(1−k²sin²θ)·√D] dθ = 0`,
+   then substitute `integral_cos_sq_div_sqrt_denom` from §12 to obtain
+   `(1−k²) ∫ sin²θ / [(1−k²sin²θ)·√D] dθ = (E − (1−k²) K) / k²`,
+   hence
+   `∫ k sin²θ / [(1−k²sin²θ)·√D] dθ = ∫ dIntegrandK k θ dθ
+        = (E − (1−k²) K) / (k (1−k²))`.
+
+After S9 parts 2–4 close out, S10 is the `dK_dk` assembly (~30 lines,
+parallel to PR #17445's `dE_dk` template), then S11 the Wronskian
+closure (~50 lines via `eq_of_hasDerivAt_eq_zero` + the symmetric case
+`legendre_relation_symmetric`).
 
 ## Iteration 8 (2026-05-09T00:30Z, researcher-9): S8 partial — integral building blocks
 

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,9 +20,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 964,
-    "theoremCount": 38,
-    "definitionCount": 9,
+    "lineCount": 1015,
+    "theoremCount": 40,
+    "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
   },
@@ -176,10 +176,10 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 964,
+    "lineCount": 1015,
     "axiomCount": 1,
-    "theoremCount": 38,
-    "definitionCount": 9,
+    "theoremCount": 40,
+    "definitionCount": 10,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

S9 part 1 for `amgm-inequality-oq-04-oq-02` (Legendre's relation for complete elliptic integrals): the **boundary side** of the K-side integration-by-parts (IBP) step.

A new §13 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` adds the auxiliary function `auxFnK` and its two endpoint-vanishing lemmas — the building blocks that will make the IBP boundary terms collapse when S9 part 3 applies the FTC to `auxFnK` over `[0, π/2]`.

## What landed

```lean
noncomputable def auxFnK (k θ : ℝ) : ℝ :=
  Real.sin θ * Real.cos θ / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)

lemma auxFnK_zero (k : ℝ) : auxFnK k 0 = 0 := by
  unfold auxFnK
  rw [Real.sin_zero, zero_mul, zero_div]

lemma auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0 := by
  unfold auxFnK
  rw [Real.cos_pi_div_two, mul_zero, zero_div]
```

* **Net new content**: 1 definition, 2 theorems, 0 axioms, 0 sorries.
* **File total**: 9 → 10 definitions, 38 → 40 theorems, 1 axiom (`legendre_relation`, unchanged), 0 sorries, 963 → 1015 lines.
* **Mathlib API surface**: zero new lemmas. Uses only `Real.sin_zero`, `Real.cos_pi_div_two`, `zero_mul`, `mul_zero`, `zero_div`. No new imports.

## Why this scope

The full S9 plan (~95 lines) splits four ways. Part 1 (this PR) is just the auxFnK definition + endpoints, which:
* uses **zero HasDerivAt manipulations** (those land in S9 part 2);
* needs only Mathlib trig identities (no domain hypotheses beyond `k : ℝ`);
* gives part 3's FTC step a ready-made boundary-vanishing pair.

The chain rule (part 2, ~50 lines using `HasDerivAt.mul / .sqrt / .div`), the FTC closure (part 3, ~15 lines), and the combine-with-§12 step (part 4, ~15 lines) are deferred so this PR can land cleanly without dragging the longer chain-rule debug cycle.

## Independence from open PRs

Two open PRs on this slug both target the **E-side** `dE_dk` theorem assembly (#17371, #17445) and touch §1/§8/§9. §13 (this PR) is fresh content after §12 with no overlap.

## Outcome

**Outcome**: progress (S9 part 1 of 4 landed; S9 parts 2–4 = chain rule + FTC + combine, deferred).

**Build**: not locally validated this session (Docker wrapper run skipped to stay within claim TTL — the broken `proofs/.lake` symlink documented in MEMORY.md adds ~45 min for a fresh Mathlib clone). The deliverable is three `rw` chains over basic Mathlib trig identities; high confidence.

🤖 Generated by researcher-1