### PR TITLE
Enrich basel-problem-oq-01-oq-01-oq-02-oq-03: fix stale section ranges (~80 line drift)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -90,32 +90,32 @@
     {
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
-      "startLine": 67,
-      "endLine": 328,
+      "startLine": 73,
+      "endLine": 411,
       "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), prime_pow_dvd_lcmRange (specialization to the maximal prime-power p^⌊log_p n⌋ — the prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^⌊log_p n⌋), coprime_prime_pow_pow_of_ne (distinct prime powers are coprime), the helper prod_dvd_of_pairwise_coprime (Finset induction packaging), prod_prime_powers_dvd_lcmRange (forward direction of Chebyshev's decomposition: ∏_p p^⌊log_p n⌋ ∣ lcmRange n), lcmRange_dvd_prod_prime_powers (reverse direction: lcmRange n ∣ ∏_p p^⌊log_p n⌋, via Nat.factorization), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 330,
-      "endLine": 349,
+      "startLine": 413,
+      "endLine": 432,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 351,
-      "endLine": 373,
+      "startLine": 434,
+      "endLine": 456,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 375,
-      "endLine": 403,
+      "startLine": 458,
+      "endLine": 488,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }


### PR DESCRIPTION
## Summary

Fixes a **stale-section-ranges** drift in `meta.json` for `basel-problem-oq-01-oq-01-oq-02-oq-03` (Hanson's bound `lcm(1,...,n) ≤ 3^n`). The four sections claim `startLine`/`endLine` values from a much earlier, smaller version of the Lean file. The current file is **488 lines**; sections only claimed coverage to line 403, and each section's location was **~80 lines off** from the actual `-- PART N` separators.

Concrete drift example: `ann-hanson-axiom` (which describes the `axiom hanson_bound` declaration) currently points to lines 379-394, where the actual content is `lcmRange_dvd_lcmRange_of_le` — the axiom declaration is at line 477. The "axiom" section had the same problem.

## What changes

Realigned all four section ranges to match the current `-- =====================================================================` PART separators in `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`:

| Section | Old Range | New Range |
|---|---|---|
| `definition` (Part 1-2) | 67-328 | 73-411 |
| `elementary-bounds` (Part 3) | 330-349 | 413-432 |
| `numerical` (Part 4) | 351-373 | 434-456 |
| `axiom` (Part 5) | 375-403 | 458-488 |

After this fix:
- Sections are non-overlapping
- `axiom` section actually contains the `axiom hanson_bound` declaration (line 477) and the `hanson_strictly_stronger_than_factorial` corollary (line 484)
- Coverage extends to the end of the file (line 488)

## What does NOT change

- Section `id`, `title`, `summary`, `mathContext` — content untouched
- All other meta.json fields (status, badge, axiomCount, theoremCount, definitionCount, lineCount, overview, mainTheorems, references, crossReferences, conclusion, originalContributions)
- `annotations.json` — **left for a follow-up**: several annotations (`ann-hanson-axiom`, `ann-hanson-strictness`, `ann-hanson-recursion`, etc.) have the same ~80-line drift. Fixing those requires per-annotation textual realignment beyond mere range edits — annotation `content` fields describe a different theorem than the lines now contain.

## Test plan

- [x] JSON round-trip via `python3 json.load` passes
- [x] All 4 section ranges fall within `1..lineCount` (488)
- [x] Section ranges are monotonically increasing and non-overlapping
- [x] `axiom` section now contains line 477 (`axiom hanson_bound`)
- [x] `tsx scripts/annotations/build.ts` still reports only the pre-existing `ann-hanson-chebyshev-reverse` issue (annotations follow-up)
- [x] Diff is exactly 1 file, +8 / -8 (8 numeric edits), no content changes
- [x] Branch is unique (`enrich/basel-problem-oq-01-oq-01-oq-02-oq-03-1778278584`) and rebased on fresh `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)