### PR TITLE
fix(meta): batch sync theoremCount/definitionCount drift (25 entries, batch e-l)

### DIFF
--- a/src/data/proofs/factor-remainder-nullstellensatz/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/meta.json
@@ -46,7 +46,7 @@
     "axiomCount": 0,
     "lineCount": 286,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 2
   },
   "overview": {
@@ -159,7 +159,7 @@
     "namespace": null,
     "lineCount": 286,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 20,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
     "definitionCount": 2,

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 201,
     "assumptions": "2 axioms with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p) and fermatLastTheoremFive (FermatLastTheoremFor 5). The n=3 and n=4 cases are fully proved via Mathlib. FreyCurve_is_semistable and RibetTheorem were placeholder True-stubs and have been replaced with documentation comments. 2 with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p, the consequence of Modularity+Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n). 3 placeholder axioms concluding with True (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem) — these serve as proof-structure markers documenting the Frey-Ribet-Wiles chain without encoding actual mathematical statements. The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -288,7 +288,7 @@
     "namespace": "FermatsLastTheorem",
     "lineCount": 201,
     "axiomCount": 2,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/FermatsLastTheorem.lean",
     "sorries": 0

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -40,7 +40,7 @@
       "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T₀)"
     ],
     "theoremCount": 17,
-    "definitionCount": 48,
+    "definitionCount": 50,
     "additionalFiles": [
       "Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
     ]
@@ -171,7 +171,7 @@
     "theoremCount": 17,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
-    "definitionCount": 48,
+    "definitionCount": 50,
     "path": "Proofs/FeuerbachsTheoremOQ02.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 15
+    "theoremCount": 20
   },
   "meta": {
     "wiedijkNumber": 76,
@@ -98,7 +98,7 @@
     "axiomCount": 0,
     "lineCount": 451,
     "assumptions": "0 axioms. Fully verified.",
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 0,
         "assumptions": "None. Fully machine-verified.",
         "lineCount": 220,
-        "theoremCount": 13,
+        "theoremCount": 18,
         "definitionCount": 0,
         "originalContributions": [
             "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
@@ -112,7 +112,7 @@
         "namespace": "FundamentalArithmeticOQ01OQ01",
         "axiomCount": 0,
         "lineCount": 220,
-        "theoremCount": 13,
+        "theoremCount": 18,
         "sorries": 0,
         "definitionCount": 0
     },

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
@@ -73,7 +73,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 2
   },
   "overview": {
@@ -214,7 +214,7 @@
     "namespace": "FTAUniqueAlgebraicClosure",
     "lineCount": 207,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 2,
     "mainTheorems": [
       {

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -59,7 +59,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The core existence result delegates to Mathlib's `Complex.exists_root` (proved via Liouville's theorem: a non-vanishing polynomial yields a bounded entire function $1/p(z)$, contradicting Liouville). Original contributions (`no_roots_implies_constant`, `card_roots_eq_degree`, `monic_prod_roots`, `quadratic_has_root`) are pedagogical wrappers composing Mathlib's `IsAlgClosed` infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -265,7 +265,7 @@
     "namespace": "FundamentalTheoremAlgebra",
     "lineCount": 214,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 0,
     "substantiveTheoremCount": 2,
     "trivialSpecializations": 4,

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 413,
     "assumptions": "0 axioms. 0 sorries. Survey file with demonstrated infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 8,
     "definitionCount": 2
   },
   "sections": [
@@ -171,7 +171,7 @@
     "namespace": "FurstenbergOQ02",
     "lineCount": 413,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 8,
     "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/FurstenbergCorrespondenceOQ02.lean"

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Depends on GCDAlgorithmOQ01 (euclideanSteps, decimalDigits, lame_step_bound).",
     "lineCount": 280,
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 2,
     "originalContributions": [
       "lame_five_digit_bound_general: euclideanSteps(a,b) ≤ 5·decimalDigits(b) for ALL b > 0",
@@ -62,7 +62,7 @@
     "namespace": "GCDAlgorithmOQ01OQ03",
     "lineCount": 280,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/GCDAlgorithmOQ01OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -57,7 +57,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -220,7 +220,7 @@
     "namespace": "GeometricSeriesOQ01",
     "lineCount": 250,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/GeometricSeriesOQ01.lean"

--- a/src/data/proofs/geometric-series/meta.json
+++ b/src/data/proofs/geometric-series/meta.json
@@ -54,7 +54,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {
@@ -252,7 +252,7 @@
     "namespace": "GeometricSeries",
     "lineCount": 171,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "substantiveTheoremCount": 5,
     "trivialSpecializations": 5,
     "definitionCount": 0,

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-01/meta.json
@@ -62,7 +62,7 @@
       }
     ],
     "theoremCount": 11,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Gödel's 1931 incompleteness theorem used ω-consistency as a hypothesis: if the system proves ∃n P(n), then the system is not ω-consistent if it also proves ¬P(n̄) for every specific n. Many logicians felt this was an 'unnatural' or overly strong assumption. J. Barkley Rosser (1936) addressed this by constructing a different self-referential sentence that makes the unprovability argument work under plain consistency alone.\n\nRosser's modification is now the standard form of the First Incompleteness Theorem. Every modern statement of Gödel's theorem uses 'consistent' rather than 'ω-consistent' — Rosser's improvement is invisible in the standard formulation but is mathematically essential.",
@@ -191,7 +191,7 @@
     "lineCount": 308,
     "sorries": 0,
     "path": "Proofs/GodelFirstIncompletenessOQ01OQ01.lean",
-    "definitionCount": 4,
+    "definitionCount": 5,
     "theoremCount": 11
   }
 }

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -59,7 +59,7 @@
         "note": "Original vacuous formalization; OQ-01 and OQ-04 provide non-vacuous versions"
       }
     ],
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The Diagonal Lemma (also called the Fixed-Point Lemma or Self-Reference Lemma) is the key engine behind Gödel's 1931 incompleteness theorems, Tarski's undefinability theorem, and many other results in mathematical logic. It was implicit in Gödel's original paper and made explicit by later authors including Carnap and Smullyan.\n\nThe lemma states: for any formula φ(x) with one free variable, there is a sentence σ such that the formal system F proves σ ↔ φ(⌈σ⌉). In other words, σ 'says about itself' that it has property φ. Applied to φ(x) = ¬Prov(x) ('x is not provable'), the Diagonal Lemma yields the Gödel sentence G: 'G is not provable'.\n\nThis file formalizes the Diagonal Lemma in its meta-level form and shows it is the single combinatorial principle from which G's self-reference property flows.",
@@ -167,7 +167,7 @@
     "lineCount": 241,
     "axiomCount": 5,
     "theoremCount": 9,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/GodelFirstIncompletenessOQ01OQ04.lean",
     "sorries": 0
   }

--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -56,7 +56,7 @@
       }
     ],
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Gödel's First Incompleteness Theorem (1931) established that any consistent formal system capable of expressing basic arithmetic contains statements that are neither provable nor refutable within the system. This shattered Hilbert's program — the dream of a complete, consistent, finitely axiomatizable foundation for mathematics.\n\nThe standard formalization challenge is that a complete proof requires thousands of lines of infrastructure: formal syntax for first-order arithmetic, Gödel numbering via prime factorization, primitive recursive functions, Σ₁⁰-completeness, and the Diagonal Lemma. Paulson's formalization in Isabelle spans ~15,000 lines.\n\nTwo approaches exist for gallery-style formalizations:\n1. **Pedagogical scaffold** (GodelIncompleteness.lean): Define Provable := fun _ => False and write the proof structure as comments. All theorems hold vacuously.\n2. **Axiomatic treatment** (this file): Declare Provable as an opaque axiom, state the key properties as explicit axioms, and prove First Incompleteness as a genuine logical consequence.\n\nThis file takes the axiomatic approach. The axioms precisely encode what Gödel's construction provides: representability (D1), the diagonal lemma (G_self_reference and neg_G_prov_G), and ω-consistency. The proofs are real deductions from these axioms, not type-level trivialities.",
@@ -171,7 +171,7 @@
     "lineCount": 271,
     "sorries": 0,
     "path": "Proofs/GodelFirstIncompletenessOQ01.lean",
-    "definitionCount": 6,
+    "definitionCount": 7,
     "theoremCount": 5
   }
 }

--- a/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "lineCount": 259,
     "theoremCount": 9,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {
@@ -84,7 +84,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "openQuestions": [
     {

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 507,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
     "theoremCount": 19,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "**Classical Green's theorem** (George Green, 1828) requires:\n1. **C¹ boundary**: the curve γ must have a continuous derivative everywhere\n2. **C¹ vector field**: P and Q must have continuous partial derivatives\n\n**Hasbrouck Whitney (1957)** proved these conditions can be drastically weakened. His minimal regularity theorem shows Green's theorem holds when:\n1. The boundary is merely **Lipschitz** (derivative exists a.e. but may have jumps at corners)\n2. The curl is merely **L¹** (Lebesgue integrable, not necessarily continuous)\n\nThe key mechanism is **Rademacher's theorem** (1919): every Lipschitz function is differentiable at Lebesgue-almost-every point. This gives a well-defined a.e. tangent vector to any Lipschitz curve, making the line integral meaningful.\n\nThis generalization is practically important: the boundary of a square, polygon, or any piecewise-smooth domain is Lipschitz but NOT C¹ (corners cause derivative jumps).",
@@ -218,7 +218,7 @@
     "lineCount": 507,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/GreensTheoremOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -84,7 +84,7 @@
     "assumptions": "2 axiom declarations: greens_theorem_typeI (Green's theorem for Type I regions), disk_area_eq_pi (area of disk = πr²). greens_theorem_general appears only in a block-comment code example, not as an actual axiom.",
     "mathlib_version": "4.26.0",
     "theoremCount": 31,
-    "definitionCount": 12
+    "definitionCount": 14
   },
   "sections": [
     {
@@ -226,7 +226,7 @@
     "lineCount": 557,
     "axiomCount": 2,
     "theoremCount": 31,
-    "definitionCount": 12,
+    "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -87,7 +87,7 @@
       "Proofs/GreensTheoremOQ03.lean"
     ],
     "theoremCount": 23,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Green's theorem for multiply-connected regions is the natural generalization needed when the domain has holes (non-trivial topology). The classical treatment appears in Ahlfors' 'Complex Analysis' (1953) and Apostol's 'Mathematical Analysis' (1974). The key insight is that the boundary integral must account for all boundary components with correct orientation: the outer boundary counterclockwise, inner boundaries (holes) clockwise. This ensures the region always lies to the left of the traversed boundary.\n\nThe multiply-connected extension is foundational to:\n- **Complex analysis**: Cauchy's integral formula and the residue theorem require circulation around punctured disks\n- **De Rham cohomology**: Non-trivial first cohomology H^1(D) = R^n arises from n holes, with each hole contributing an independent 'period'\n- **Physics**: Gauss's law with interior conductors, the Aharonov-Bohm effect, and vortex dynamics in fluid mechanics all rely on this extension",
@@ -245,7 +245,7 @@
     "lineCount": 587,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/greens-theorem/meta.json
+++ b/src/data/proofs/greens-theorem/meta.json
@@ -61,7 +61,7 @@
     "assumptions": "1 axiom: greens_theorem_rectangle. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 14
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "George Green (1793–1841) was a self-taught British mathematician who published his landmark 'An Essay on the Application of Mathematical Analysis to the Theories of Electricity and Magnetism' in 1828, printed privately in only 52 copies. The work introduced what is now called Green's theorem, Green's function, and the concept of potential. It was largely ignored until William Thomson (Lord Kelvin) rediscovered it in 1845 and brought it to wider attention.\n\nThe theorem is the 2-dimensional special case of the generalized Stokes' theorem $\\int_{\\partial M} \\omega = \\int_M d\\omega$, first stated in full generality by Élie Cartan in the language of differential forms. In the standard formulation, it relates the circulation $\\oint_C \\mathbf{F} \\cdot d\\mathbf{r}$ of a vector field around a closed curve to the integral of the curl over the enclosed region.\n\nGreen's theorem is fundamental to electromagnetism (Maxwell's equations), fluid dynamics (vorticity and circulation), and complex analysis (Cauchy's integral theorem as a consequence). It appears as #21 on Wiedijk's list of 100 greatest theorems.",
@@ -209,7 +209,7 @@
     "lineCount": 358,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 14,
+    "definitionCount": 19,
     "path": "Proofs/GreensTheorem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 5,
     "lineCount": 250,
     "theoremCount": 10,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {
@@ -157,7 +157,7 @@
     "path": "Proofs/Hilbert10OQ04.lean",
     "lineCount": 250,
     "theoremCount": 10,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "axiomCount": 5,
     "sorries": 0
   }

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -35,7 +35,7 @@
     "assumptions": "3 axiom declarations: diagonalForm (existence of diagonal quadratic forms), sylvester_law_of_inertia (real classification by signature), selmer_curve_no_rational_points (Selmer's counterexample to Hasse for cubics). Two former axioms (hasse_minkowski_alt, rational_classification_complete) are now placeholder theorems with sorry, since their conclusions reduce to True ↔ True via True-placeholder definitions; converting to sorry makes the gap visible to #check_sorry instead of asserting a vacuous axiom. Five additional placeholder theorems carry sorry: weak_hasse_principle, ternary_representation, witt_cancellation, dimension_five_always_isotropic, hilbert_reciprocity (their formal statements depend on tensor products with R/Q_p that are not yet formalized). Three definitions still use True as a placeholder body (RepresentsZeroOverReals, RepresentsZeroOverPadic, HasseMinkowskiNumberField), and HilbertSymbol is hardcoded to 1. Only four_squares_connection is fully proved (via Mathlib's Nat.sum_four_squares).",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 17
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "Hilbert's 11th Problem, posed in his famous 1900 address at the International Congress of Mathematicians in Paris, asks for the classification of quadratic forms $Q(x_1, \\ldots, x_n) = \\sum a_{ij} x_i x_j$ with coefficients in algebraic number fields. The roots of this question trace to Gauss's *Disquisitiones Arithmeticae* (1801), which classified binary quadratic forms over $\\mathbb{Z}$ using genera and class numbers. Hermann Minkowski, Hilbert's close friend and colleague at Gottingen, proved the local-global principle for ternary quadratic forms in 1890 using his geometry of numbers. Helmut Hasse, a student of Kurt Hensel (inventor of $p$-adic numbers), extended this in his 1923 dissertation to all dimensions, establishing the full Hasse-Minkowski theorem: a quadratic form over $\\mathbb{Q}$ represents zero nontrivially if and only if it does so over $\\mathbb{R}$ and over $\\mathbb{Q}_p$ for every prime $p$. Ernst Witt developed the algebraic theory of quadratic forms in 1937, introducing the Witt ring $W(F)$ and proving Witt cancellation. James Sylvester's law of inertia (1852) had earlier provided the classification over $\\mathbb{R}$ via the signature $(p,q)$. The discovery by Ernst Selmer in 1951 that the cubic curve $3x^3 + 4y^3 + 5z^3 = 0$ violates the Hasse principle showed this beautiful local-global approach is special to quadratic forms. Yuri Manin's introduction of the Brauer-Manin obstruction (1970) provided a systematic explanation for such failures.",
@@ -210,7 +210,7 @@
     "lineCount": 498,
     "axiomCount": 3,
     "theoremCount": 9,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "path": "Proofs/Hilbert11_QuadraticForms.lean",
     "sorries": 7
   },

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -69,7 +69,7 @@
       }
     ],
     "theoremCount": 9,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "crossReferences": [
     {
@@ -192,7 +192,7 @@
     "axiomCount": 6,
     "sorries": 0,
     "lineCount": 480,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "theoremCount": 9
   },
   "mainTheorems": [

--- a/src/data/proofs/hilbert-13/meta.json
+++ b/src/data/proofs/hilbert-13/meta.json
@@ -42,7 +42,7 @@
     "assumptions": "4 axioms: kolmogorov_arnold_theorem, no_radical_solution_septic, vitushkin_smooth_obstruction, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "In 1900, Hilbert asked whether the roots of the general degree-7 polynomial equation could be expressed using continuous functions of only two variables. The Bring-Jerrard form reduces the septic to three essential parameters, so Hilbert conjectured that functions of three variables are genuinely necessary.\n\nThe answer came as a complete surprise: Kolmogorov (1956) and Arnold (1957) proved that not only can the septic be solved with two-variable functions, but ANY continuous function of n variables can be expressed using only ONE-variable functions!\n\nThis stunning result completely disproved Hilbert's conjecture. However, for smooth (differentiable) functions, Vitushkin showed that Hilbert's intuition was correct - some smooth functions genuinely require more variables.",
@@ -147,7 +147,7 @@
     "lineCount": 399,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert13Superposition.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 323,
     "theoremCount": 12,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -180,7 +180,7 @@
     "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/Hilbert14NonReductive.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -49,7 +49,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Hilbert's fourteenth problem arose from 19th century invariant theory, which sought to describe polynomial functions unchanged by group transformations. In 1890, Hilbert revolutionized the field by proving that finitely many invariants always suffice for classical groups like GL_n and SL_n, using his new Basis Theorem.\n\nIn 1900, Hilbert posed the general question: Is the ring of invariants always finitely generated? This remained open for nearly 60 years.\n\n**Timeline:**\n- 1890: Hilbert proves finiteness for classical invariant theory\n- 1900: Hilbert poses the general problem\n- 1959: Nagata constructs a counterexample\n- 1965: Mumford proves finiteness for reductive groups (char 0)\n- 1975: Haboush extends to all characteristics",
@@ -139,7 +139,7 @@
     "lineCount": 364,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Hilbert14Invariants.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Batch sync stale `theoremCount` / `definitionCount` in `meta.json` for 25 gallery entries (slugs starting `e/f/g/h/i/j/k/l`, excluding ranges already covered by open mechanic PRs #17441/#17446/#17458/#17462/#17466/#17469).

Both occurrences (top-level `.meta` block and `.leanFile` block) are updated to the actual count from the Lean source, computed via the same comment-stripper used in `scripts/auditor/find-targets.ts`. No Lean source changes — pure metadata.

## Evidence

For each entry:
- **Before**: claimed `theoremCount` / `definitionCount` lagged the source (delta 1-5)
- **After**: both meta.* and leanFile.* match the actual count

Sample diff (`fermats-last-theorem`):

```diff
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
```

Filter: delta ≤ 5 to keep each fix surgical and avoid touching entries with large structural drift (e.g. Hodge, inclusion-exclusion-oq-01) that warrant manual review.

## Slug list

`factor-remainder-nullstellensatz, fermats-last-theorem, feuerbachs-theorem-oq-02, fourier-series, fundamental-arithmetic-oq-01-oq-01, fundamental-theorem-algebra, fundamental-theorem-algebra-oq-04, furstenberg-correspondence-oq-02, gcd-algorithm-oq-01-oq-03, geometric-series, geometric-series-oq-01, godel-first-incompleteness-oq01, godel-first-incompleteness-oq01-oq-01, godel-first-incompleteness-oq01-oq-04, greens-theorem, greens-theorem-oq-02, greens-theorem-oq-02-oq-04, greens-theorem-oq-03, greens-theorem-oq-04, hilbert-10-oq-04, hilbert-11, hilbert-13, hilbert-13-oq-04, hilbert-14, hilbert-14-oq-01`

---
Automated fix by lean-mechanic agent.