### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 17 — Finset transport of list-arity Σ₁/Π₁ closures (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -76,6 +76,9 @@ import Mathlib.Algebra.Order.Ring.Lemmas
 -- S12 (iter 12, Path B): `linarith` to discharge the conclusion
 -- `a*a + b*b = 0  ∧  0 ≤ a*a  ∧  0 ≤ b*b  →  a*a = 0  ∧  b*b = 0`.
 import Mathlib.Tactic.Linarith
+-- Iter 17 (Path B): `Finset.toList` and `Finset.mem_toList` for Finset
+-- transports of the iter 10 / iter 14 / iter 15 list closures.
+import Mathlib.Data.Finset.Basic
 
 namespace Hilbert10Rationals
 
@@ -1674,6 +1677,158 @@ theorem finIntersectionList_isExistentialUniversalDefinition
     IsExistentialUniversalDefinition (fun q : Rat => ∀ S ∈ l, S q) :=
   codiophantine_implies_existentialUniversal _
     (finIntersectionList_isCoDiophantineDefinition l h)
+
+-- ============================================================
+-- Part VIII.19 (iter 17, Path B): Finset transport of the singleton-list
+-- closure of iter 10 (S11.4).
+-- ============================================================
+
+/-- Iter 17, Path B: **every `Finset Rat`-indexed finite subset of ℚ is
+    Σ₁-definable**.
+
+    Direct Finset transport of iter 10's
+    `finUnionList_singletons_isDiophantineDefinition`: for any
+    `s : Finset Rat`, the predicate `q ∈ s` is Σ₁-definable. Routed
+    through the Mathlib bridge `Finset.mem_toList : a ∈ s.toList ↔ a ∈ s`
+    via the iter 4 Σ₁ class congruence helper. The polynomial witness is
+    iter 10's inductive product polynomial on `s.toList`, unchanged.
+
+    **Significance**: completes the iter-13 next-action priority **S11.4**
+    (Finset arity for the singletons-list closure). Pairs with iter 10's
+    List version to give Σ₁-definability of every finite subset of ℚ
+    indexed either by `List Rat` or by `Finset Rat`. The OPEN content
+    remains unchanged: it is still the COUNTABLY-INFINITE union
+    `⋃_{n : ℤ} {n}` that requires a UNIFORM Σ₁ witness. Iter 17 only
+    promotes the FINITE side from list-indexing to set-indexing, not
+    the open Σ₁ question. -/
+theorem finUnionFinset_singletons_isDiophantineDefinition (s : Finset Rat) :
+    IsDiophantineDefinition (fun q : Rat => q ∈ s) := by
+  have hbridge : ∀ q : Rat, (fun q : Rat => q ∈ s) q ↔
+      (fun q : Rat => q ∈ s.toList) q := by
+    intro q; exact Finset.mem_toList.symm
+  exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finUnionList_singletons_isDiophantineDefinition s.toList)
+
+/-- Iter 17 dual, Path B: **every `Finset Rat`-indexed cofinite subset of
+    ℚ is Π₁-definable**.
+
+    Direct Finset transport of iter 10's
+    `finIntersectionList_complement_singletons_isCoDiophantineDefinition`:
+    for any `s : Finset Rat`, the predicate `q ∉ s` is Π₁-definable.
+    Routed through `not_congr Finset.mem_toList` + iter 4 Π₁ congruence. -/
+theorem finIntersectionFinset_complement_singletons_isCoDiophantineDefinition
+    (s : Finset Rat) :
+    IsCoDiophantineDefinition (fun q : Rat => q ∉ s) := by
+  have hbridge : ∀ q : Rat, (fun q : Rat => q ∉ s) q ↔
+      (fun q : Rat => q ∉ s.toList) q := by
+    intro q; exact (not_congr Finset.mem_toList).symm
+  exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finIntersectionList_complement_singletons_isCoDiophantineDefinition s.toList)
+
+/-- Iter 17 corollary, Path B: **every `Finset Rat`-indexed finite subset
+    of ℚ is Π₂-definable** via the trivial inclusion `Σ₁ ⊆ Π₂`. -/
+theorem finUnionFinset_singletons_isUniversalExistentialDefinition
+    (s : Finset Rat) :
+    IsUniversalExistentialDefinition (fun q : Rat => q ∈ s) :=
+  diophantine_implies_universal_existential _
+    (finUnionFinset_singletons_isDiophantineDefinition s)
+
+/-- Iter 17 corollary, Path B: **every `Finset Rat`-indexed cofinite
+    subset of ℚ is Σ₂-definable** via the trivial inclusion `Π₁ ⊆ Σ₂`. -/
+theorem finIntersectionFinset_complement_singletons_isExistentialUniversalDefinition
+    (s : Finset Rat) :
+    IsExistentialUniversalDefinition (fun q : Rat => q ∉ s) :=
+  codiophantine_implies_existentialUniversal _
+    (finIntersectionFinset_complement_singletons_isCoDiophantineDefinition s)
+
+-- ============================================================
+-- Part VIII.20 (iter 17, Path B): Finset transport of the arbitrary-
+-- subset list closures of iter 14 / iter 15.
+-- ============================================================
+
+/-- Iter 17, Path B: **the Σ₁ class is closed under `Finset RatSubset`-
+    indexed intersection of arbitrary Σ₁-definable subsets**.
+
+    Finset analog of iter 14's `finIntersectionList_isDiophantineDefinition`,
+    transported via `Finset.mem_toList`. The witness polynomial is the
+    inductive sum-of-squares + interleave on `s.toList` from iter 14
+    (which itself unfolds to iter 12 per cons step). -/
+theorem finIntersectionFinset_isDiophantineDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsDiophantineDefinition S) :
+    IsDiophantineDefinition (fun q : Rat => ∀ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsDiophantineDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∀ S ∈ s, S q) q ↔
+      (fun q : Rat => ∀ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · intro hall S hS; exact hall S (Finset.mem_toList.mp hS)
+    · intro hall S hS; exact hall S (Finset.mem_toList.mpr hS)
+  exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finIntersectionList_isDiophantineDefinition s.toList h_list)
+
+/-- Iter 17, Path B: **the Π₁ class is closed under `Finset RatSubset`-
+    indexed union of arbitrary Π₁-definable subsets**.
+
+    Finset analog of iter 14's `finUnionList_isCoDiophantineDefinition`,
+    transported via `Finset.mem_toList`. -/
+theorem finUnionFinset_isCoDiophantineDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsCoDiophantineDefinition S) :
+    IsCoDiophantineDefinition (fun q : Rat => ∃ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsCoDiophantineDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∃ S ∈ s, S q) q ↔
+      (fun q : Rat => ∃ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mpr hS, hSq⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mp hS, hSq⟩
+  exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finUnionList_isCoDiophantineDefinition s.toList h_list)
+
+/-- Iter 17, Path B: **the Σ₁ class is closed under `Finset RatSubset`-
+    indexed union of arbitrary Σ₁-definable subsets**.
+
+    Finset analog of iter 15's `finUnionList_isDiophantineDefinition`,
+    transported via `Finset.mem_toList`. The witness polynomial is the
+    inductive product polynomial on `s.toList` from iter 15 (which
+    itself unfolds to iter 9 per cons step). -/
+theorem finUnionFinset_isDiophantineDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsDiophantineDefinition S) :
+    IsDiophantineDefinition (fun q : Rat => ∃ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsDiophantineDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∃ S ∈ s, S q) q ↔
+      (fun q : Rat => ∃ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mpr hS, hSq⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mp hS, hSq⟩
+  exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finUnionList_isDiophantineDefinition s.toList h_list)
+
+/-- Iter 17, Path B: **the Π₁ class is closed under `Finset RatSubset`-
+    indexed intersection of arbitrary Π₁-definable subsets**.
+
+    Finset analog of iter 15's `finIntersectionList_isCoDiophantineDefinition`,
+    transported via `Finset.mem_toList`. -/
+theorem finIntersectionFinset_isCoDiophantineDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsCoDiophantineDefinition S) :
+    IsCoDiophantineDefinition (fun q : Rat => ∀ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsCoDiophantineDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∀ S ∈ s, S q) q ↔
+      (fun q : Rat => ∀ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · intro hall S hS; exact hall S (Finset.mem_toList.mp hS)
+    · intro hall S hS; exact hall S (Finset.mem_toList.mpr hS)
+  exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr
+    (finIntersectionList_isCoDiophantineDefinition s.toList h_list)
 
 -- ============================================================
 -- Part IX: The landscape, sharpened

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -2,12 +2,82 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T22:00:00Z
-**Iteration**: 13
-**Last Updated**: 2026-05-08 (researcher-12)
+**Iteration**: 17
+**Last Updated**: 2026-05-08 (researcher-11)
 
 ## Current Focus
 
-Iteration 13 (2026-05-08, researcher-12, this PR): **Π₁ closed under
+Iteration 17 (2026-05-08, researcher-11, this PR): **Finset transport
+of the list-indexed Σ₁/Π₁ closures (S11.4 + arbitrary-subset Finset
+analogs)**.
+
+Eight new theorems in two clean blocks (Part VIII.19 + Part VIII.20),
+all axiom-free and using a single new Mathlib lemma
+(`Finset.mem_toList`):
+
+**Part VIII.19 — Finset transport of iter 10's singletons-list
+closure (S11.4)**:
+
+- `finUnionFinset_singletons_isDiophantineDefinition (s : Finset Rat)`
+  — every `Finset Rat`-indexed finite subset of ℚ is Σ₁-definable,
+  via `Finset.mem_toList.symm` + iter 4 congruence + iter 10.
+- `finIntersectionFinset_complement_singletons_isCoDiophantineDefinition`
+  — Π₁ dual via `not_congr Finset.mem_toList`.
+- Two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ and Π₁ ⊆ Σ₂.
+
+**Part VIII.20 — Finset transport of iter 14/15's arbitrary-subset
+list closures**:
+
+- `finIntersectionFinset_isDiophantineDefinition` — Σ₁ ∩ over Finset.
+- `finUnionFinset_isCoDiophantineDefinition` — Π₁ ∪ over Finset.
+- `finUnionFinset_isDiophantineDefinition` — Σ₁ ∪ over Finset.
+- `finIntersectionFinset_isCoDiophantineDefinition` — Π₁ ∩ over Finset.
+
+All four arbitrary-subset Finset closures route the iter 14/15 list
+witnesses through the membership bridge `∀/∃ S ∈ s, S q ↔ ∀/∃ S ∈
+s.toList, S q` (proved via `Finset.mem_toList.mp/mpr`) and the iter 4
+class congruence helper.
+
+**Significance**: completes the iter-13 "S11.4" priority and lifts
+iter 14/15's list-arity 2×2 closure grid to Finset-arity. The
+underlying polynomial witnesses are unchanged from iter 9/12/13/14/15
+— only the indexing structure is promoted from `List` to `Finset`.
+The 2×2 finite Boolean closure grid for Σ₁/Π₁ over ℚ is now populated
+at three arities:
+
+    | Class | binary    | list      | Finset    |
+    |-------|-----------|-----------|-----------|
+    | Σ₁ ∪ ∩ | iter 9, 12 | iter 14,15| iter 17 |
+    | Π₁ ∪ ∩ | iter 13, 9 | iter 14,15| iter 17 |
+
+The OPEN content remains unchanged: it is still the COUNTABLY-INFINITE
+union ⋃_{n : ℤ} {n} that requires a UNIFORM Σ₁ witness; iter 17 only
+extends the FINITE side.
+
+**File status**: 1904 → 2059 lines (+155). Theorems 69 → 77 (+8).
+Definitions 15 (unchanged). Axioms 1 (unchanged). Sorries 0
+(unchanged). One new import: `Mathlib.Data.Finset.Basic` for
+`Finset.mem_toList`.
+
+**Build risk**: low. `Finset.mem_toList` is a standard Mathlib lemma
+(used elsewhere in this repo, e.g., `Hilbert3ScissorsCongruence.lean`).
+The 8 new theorems use only `Finset.mem_toList.mp`/`.mpr`/`.symm` plus
+`not_congr` (Mathlib core); no new tactics. Worktree's `proofs/.lake`
+is a recursive self-symlink (per
+`feedback_researcher_lake_symlink_broken.md`), so a local Docker
+build would re-fresh-clone Mathlib (~30-45 min). CI is the ground
+truth, per the slug's iter 14/15/16 build-pending pattern.
+
+---
+
+(Historical iteration 13 narrative below preserved for context. Iter
+14, 15, 16 PRs landed but did not advance the state.md iteration
+counter; iter 17 is the next user-visible state advancement after
+iter 13's record.)
+
+## Iteration 13 historical record
+
+Iteration 13 (2026-05-08, researcher-12): **Π₁ closed under
 binary union (S12.2)** — the missing dual of iter 9's Σ₁-union
 closure. Combined with iter 9 (Σ₁ ∪, Π₁ ∩) and iter 12 (Σ₁ ∩), the
 **2×2 finite Boolean closure grid** for Σ₁ and Π₁ over ℚ is now
@@ -453,24 +523,39 @@ With iter 13 the 2×2 finite Boolean closure grid for Σ₁ and Π₁ over
 
 ## Next Action
 
-Commit, push, create PR for iteration 13 (this).
+Commit, push, create PR for iteration 17 (this).
 
-If S12.2 lands cleanly, S12+ candidates (in priority order):
+After iter 17 the FINITE-arity Boolean closure grid is fully populated
+for Σ₁/Π₁ over ℚ at three arities (binary, list, Finset). Remaining
+S11+/S13+ candidates:
 
-- **S12.1**: List version of `intersection_isDiophantineDefinition`.
-- **S12.3**: List version of `union_isCoDiophantineDefinition`.
 - **S11.3**: Daans 2021 (10-quantifier reduction of Koenigsmann) as a
   separate axiomatized witness — adds 1 axiom, documentary value only.
-- **S11.4**: Finset version of `finUnionList_singletons`.
+  Anti-axiom-policy: deferred.
+- **S13+ list arity for level 2** (after iter 16 PR #17456 lands):
+  list versions of iter 16's `pi2_intersection_isUniversalExistentialDefinition`
+  (Π₂ list ∩) and `sigma2_union_isExistentialUniversalDefinition`
+  (Σ₂ list ∪). Direct list lifts via the same iter 14/15 induction
+  template.
+- **S13+ finset arity for level 2** (after the S13+ list versions
+  land): Finset transports of the level-2 list closures, mirroring
+  iter 17's Σ₁/Π₁ Finset transports.
+- **S13+ open cells**: Σ₂ ∩ and Π₂ ∪ (the genuine quantifier-flip
+  obstruction at level 2). Iter 16's PR description flags these as
+  "deferred as a genuine future-work gap" — they are not derivable
+  from the existing closures and would require non-trivial new
+  argument (potentially axiomatized).
 
 ## Attempt Counts
 
-- Total attempts: 13
-- Current approach attempts: 1 (S12.2 — Π₁ binary union closure via
-  iter 5 duality + iter 12 Σ₁ ∩ closure + iter 4 congruence)
-- Approaches tried: 12 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+- Total attempts: 17
+- Current approach attempts: 1 (S11.4 — Finset transport via
+  `Finset.mem_toList`)
+- Approaches tried: 16 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
   congruence, S5 symmetric duality + trivial sets, S6 smallest
   non-trivial subset, S7 ¬¬-shadow, S8 arbitrary singletons, S9 binary
   union/intersection closure, S10 finite-list closure, S11.1 Π₁ ⊆ Π₂
   via polynomial inversion, S11.2 Σ₁ binary intersection via
-  sum-of-squares, S12.2 Π₁ binary union via duality bridging)
+  sum-of-squares, S12.2 Π₁ binary union via duality bridging, S12.1
+  Σ₁ list ∩, S12.3 Π₁ list ∪, S12.4 Σ₁ list ∪ + Π₁ list ∩, iter 16
+  level-2 binary closures, S11.4 Finset transport)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -51,6 +51,11 @@
         "theorem": "linarith",
         "description": "Linear arithmetic tactic; used in S12 to discharge `a*a + b*b = 0  ∧  0 ≤ a*a  ∧  0 ≤ b*b  →  a*a = 0  ∧  b*b = 0`.",
         "module": "Mathlib.Tactic.Linarith"
+      },
+      {
+        "theorem": "Finset.mem_toList",
+        "description": "a ∈ s.toList ↔ a ∈ s for s : Finset α; used in iter 17 (Path B) to transport iter 10's list-indexed singletons closure and iter 14/15's list-indexed arbitrary-subset closures to the Finset-indexed analogs via the iter 4 class congruence helpers (Σ₁/Π₁/Π₂/Σ₂). No new polynomial witnesses; the underlying construction is unchanged from the List versions.",
+        "module": "Mathlib.Data.Finset.Basic"
       }
     ],
     "originalContributions": [
@@ -107,11 +112,19 @@
       "finUnionList_isDiophantineDefinition: Σ₁ class is closed under finite list union of arbitrary Σ₁-definable subsets of ℚ — list lift of iter 9's union_isDiophantineDefinition by induction on the list, with the empty list giving the empty set (vacuous existential ↔ False). Generalizes iter 10's finUnionList_singletons_isDiophantineDefinition (which restricted to SINGLETONS) to arbitrary Σ₁ subsets. Underlying polynomial witness is iter 9's product polynomial P₁·P₂ via mul_eq_zero (no sum-of-squares needed). No new Mathlib lemmas, no new imports (iter 15 Path B; axiom-free)",
       "finUnionList_isUniversalExistentialDefinition: trivial Π₂ corollary of finUnionList_isDiophantineDefinition via Σ₁ ⊆ Π₂ (iter 15, axiom-free)",
       "finIntersectionList_isCoDiophantineDefinition: Π₁ class is closed under finite list intersection of arbitrary Π₁-definable subsets of ℚ — list lift of iter 9's intersection_isCoDiophantineDefinition by induction on the list, with the empty list giving the universe set (vacuous quantifier ↔ True). Generalizes iter 10's finIntersectionList_complement_singletons_isCoDiophantineDefinition (which restricted to COMPLEMENTS-OF-SINGLETONS) to arbitrary Π₁ subsets. Underlying polynomial witness is iter 9's product polynomial P₁·P₂ via the contrapositive of mul_eq_zero (no sum-of-squares needed). No new Mathlib lemmas, no new imports (iter 15 Path B; axiom-free)",
-      "finIntersectionList_isExistentialUniversalDefinition: trivial Σ₂ corollary of finIntersectionList_isCoDiophantineDefinition via Π₁ ⊆ Σ₂ (iter 15, axiom-free); together with iter 15's union list lift and iter 14's two list closures fully populates the 2×2 finite Boolean closure grid for Σ₁ and Π₁ over ℚ at arbitrary finite-list arity for ARBITRARY Σ₁/Π₁-definable subsets (not just singletons)"
+      "finIntersectionList_isExistentialUniversalDefinition: trivial Σ₂ corollary of finIntersectionList_isCoDiophantineDefinition via Π₁ ⊆ Σ₂ (iter 15, axiom-free); together with iter 15's union list lift and iter 14's two list closures fully populates the 2×2 finite Boolean closure grid for Σ₁ and Π₁ over ℚ at arbitrary finite-list arity for ARBITRARY Σ₁/Π₁-definable subsets (not just singletons)",
+      "finUnionFinset_singletons_isDiophantineDefinition: every `Finset Rat`-indexed finite subset of ℚ is Σ₁-definable — Finset transport of iter 10's list-indexed singletons closure via Mathlib's `Finset.mem_toList : a ∈ s.toList ↔ a ∈ s` and the iter 4 Σ₁ class congruence helper. Polynomial witness unchanged from iter 10 (inductive product polynomial on `s.toList`). Completes iter-13's S11.4 priority. Iter 17 Path B; axiom-free.",
+      "finIntersectionFinset_complement_singletons_isCoDiophantineDefinition: every complement of a `Finset Rat`-indexed finite subset of ℚ is Π₁-definable — Finset dual of iter 17's singletons closure, routed through `not_congr Finset.mem_toList` + iter 4 Π₁ class congruence (iter 17 Path B; axiom-free)",
+      "finUnionFinset_singletons_isUniversalExistentialDefinition: every `Finset Rat`-indexed finite subset of ℚ is Π₂-definable — trivial Π₂ corollary via Σ₁ ⊆ Π₂ (iter 17 Path B; axiom-free)",
+      "finIntersectionFinset_complement_singletons_isExistentialUniversalDefinition: every complement of a `Finset Rat`-indexed finite subset of ℚ is Σ₂-definable — trivial Σ₂ corollary via Π₁ ⊆ Σ₂ (iter 17 Path B; axiom-free)",
+      "finIntersectionFinset_isDiophantineDefinition: Σ₁ class is closed under `Finset RatSubset`-indexed intersection of arbitrary Σ₁-definable subsets — Finset analog of iter 14's `finIntersectionList_isDiophantineDefinition`, transported via `Finset.mem_toList` and iter 4 class congruence (iter 17 Path B; axiom-free)",
+      "finUnionFinset_isCoDiophantineDefinition: Π₁ class is closed under `Finset RatSubset`-indexed union of arbitrary Π₁-definable subsets — Finset analog of iter 14's `finUnionList_isCoDiophantineDefinition` (iter 17 Path B; axiom-free)",
+      "finUnionFinset_isDiophantineDefinition: Σ₁ class is closed under `Finset RatSubset`-indexed union of arbitrary Σ₁-definable subsets — Finset analog of iter 15's `finUnionList_isDiophantineDefinition`, completing the Finset-indexed parity with iter 14/15's list-indexed 2×2 grid (iter 17 Path B; axiom-free)",
+      "finIntersectionFinset_isCoDiophantineDefinition: Π₁ class is closed under `Finset RatSubset`-indexed intersection of arbitrary Π₁-definable subsets — Finset analog of iter 15's `finIntersectionList_isCoDiophantineDefinition`. Together with the other three Finset closures and the four singletons-only Finset transports, the 2×2 finite Boolean closure grid for Σ₁/Π₁ over ℚ is now populated at three arities: BINARY (iter 9, 12, 13), LIST (iter 14, 15), and FINSET (iter 17). The OPEN question — countably-infinite ⋃_{n : ℤ} {n} — is unchanged: iter 17 only extends the FINITE side (iter 17 Path B; axiom-free)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 1904,
+    "lineCount": 2059,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -119,7 +132,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 69,
+    "theoremCount": 77,
     "definitionCount": 15
   },
   "overview": {
@@ -247,13 +260,14 @@
       "Mathlib.Algebra.Group.Basic",
       "Mathlib.Algebra.GroupWithZero.Basic",
       "Mathlib.Algebra.Order.Ring.Lemmas",
-      "Mathlib.Tactic.Linarith"
+      "Mathlib.Tactic.Linarith",
+      "Mathlib.Data.Finset.Basic"
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 1904,
+    "lineCount": 2059,
     "axiomCount": 1,
-    "theoremCount": 69,
+    "theoremCount": 77,
     "definitionCount": 15,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iteration 17 of `hilbert-10-oq-01-oq-02` (Σ₁ vs Π₂ definability of ℤ ⊂ ℚ). Completes the **iter-13 next-action priority S11.4** ("Finset version of `finUnionList_singletons` via `Finset.toList`") and lifts iter 14/15's arbitrary-subset list closures to the Finset analog. Eight new theorems split into two structurally identical blocks (Part VIII.19 + Part VIII.20), all axiom-free, using a single new Mathlib lemma `Finset.mem_toList`.

This PR is structurally **independent of iter 16's open PR #17456** (Π₂ ∩ ⊆ Π₂ and Σ₂ ∪ ⊆ Σ₂ at the level-2 binary arity). Branched from `origin/main` post-iter-15. Section numbers chosen as VIII.19 / VIII.20 to leave VIII.18 free for iter 16 to claim on merge.

## What's New

### Part VIII.19 — Finset transport of iter 10's singletons-list closure (S11.4)

- **`finUnionFinset_singletons_isDiophantineDefinition (s : Finset Rat)`**: every `Finset Rat`-indexed finite subset of ℚ is Σ₁-definable. Proof: `Finset.mem_toList.symm` lifts `q ∈ s ↔ q ∈ s.toList` through iter 4 Σ₁ class congruence, then iter 10's `finUnionList_singletons_isDiophantineDefinition s.toList` discharges the goal. Polynomial witness unchanged from iter 10 (inductive product polynomial on `s.toList`).
- **`finIntersectionFinset_complement_singletons_isCoDiophantineDefinition`**: dual via `not_congr Finset.mem_toList`.
- Two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ and Π₁ ⊆ Σ₂.

### Part VIII.20 — Finset transport of iter 14/15's arbitrary-subset list closures

For each of the four iter 14/15 list closures, the corresponding Finset analog:

- **`finIntersectionFinset_isDiophantineDefinition`** — Σ₁ ∩ over Finset (analog of iter 14).
- **`finUnionFinset_isCoDiophantineDefinition`** — Π₁ ∪ over Finset (analog of iter 14).
- **`finUnionFinset_isDiophantineDefinition`** — Σ₁ ∪ over Finset (analog of iter 15).
- **`finIntersectionFinset_isCoDiophantineDefinition`** — Π₁ ∩ over Finset (analog of iter 15).

All four route the iter 14/15 list witnesses through the membership bridge `∀/∃ S ∈ s, S q ↔ ∀/∃ S ∈ s.toList, S q` (proved via `Finset.mem_toList.mp/mpr`) and the iter 4 class congruence helper. Polynomial witnesses unchanged from iter 9/12/13 (per cons step).

### Mathlib API surface

ONE new lemma (`Finset.mem_toList`), ONE new import (`Mathlib.Data.Finset.Basic`). No new tactics; all proofs are pure term mode + `intro`/`refine`/`rintro`/`exact`/`constructor`.

## Significance — three-arity 2×2 closure grid

After iter 17 the 2×2 finite Boolean closure grid for Σ₁/Π₁ over ℚ is populated at **three arities**:

| Class       | binary arity | list arity   | Finset arity |
|-------------|--------------|--------------|--------------|
| Σ₁ ∪        | iter 9       | iter 15      | iter 17      |
| Σ₁ ∩        | iter 12      | iter 14      | iter 17      |
| Π₁ ∪        | iter 13      | iter 14      | iter 17      |
| Π₁ ∩        | iter 9       | iter 15      | iter 17      |

The OPEN content is unchanged: it remains the COUNTABLY-INFINITE union ⋃_{n : ℤ} {n} that requires a UNIFORM Σ₁ witness. Iter 17 only promotes the FINITE side from list indexing to set indexing, NOT the open Σ₁ question.

The Finset arity is the natural container for "ℤ as a finite set of rationals" — every finite truncation `(Finset.Icc (-N) N).image (Int.cast : Int → Rat)` is now Σ₁-definable directly via `finUnionFinset_singletons_isDiophantineDefinition`, without needing a `List Rat` intermediate.

## Per-session honesty

- Sorry count delta: 0 → 0 (unchanged).
- Axiom count delta: 1 → 1 (unchanged).
- Theorem count delta: 69 → 77 (+8).
- Definition count delta: 15 → 15 (unchanged).
- Line count delta: 1904 → 2059 (+155).
- This PR is **completion / parity work**, not a sorry-discharger. It fills a documented gap (S11.4) and lifts iter 14/15's grid from list to Finset indexing. The novelty is moderate — the underlying constructions are unchanged from the List versions; only the indexing structure is promoted via a standard Mathlib bridge.

## Build risk

**Low.** `Finset.mem_toList` is a standard Mathlib lemma (already used in this repo's `Hilbert3ScissorsCongruence.lean`). All 8 theorems use only `Finset.mem_toList.mp`/`.mpr`/`.symm` plus `not_congr` (Mathlib core); no new tactics. The bridge proofs are pure constructive logic (`refine`, `rintro`, `exact`, `constructor`).

**Build status: pending.** Worktree's `proofs/.lake` is a recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), so a local Docker build would re-fresh-clone Mathlib (~30-45 min). CI is the ground truth, per the slug's iter 14/15/16 build-pending pattern.

## Test plan

- [x] All 8 new theorems and 0 new definitions type-check (review-time inspection)
- [x] No new sorries, no new axioms
- [x] Branch off fresh origin/main (post-iter-15); no conflicts with concurrent open PRs (iter 16 #17456 is in a separate Part VIII.18; iter 17 uses VIII.19 + VIII.20)
- [x] meta.json + state.md counts synced (theoremCount 77, lineCount 2059, new mathlibDependency entry)
- [x] meta.json validates as JSON
- [ ] CI: Docker build of Proofs.Hilbert10OQ01OQ02 (ground truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)