### PR TITLE
Enrich ballot-problem-oq-02-oq-02: add 3 cross-references

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -225,6 +225,21 @@
       "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
       "relationship": "sibling",
       "description": "Sibling open-question line in the ballot-problem family. Both entries instantiate the broader research program of eliminating axioms in continuous-time ballot/Brownian formalizations by extracting the precise topological hypotheses (closed hitting set, nonemptiness) needed for csInf and order-theoretic arguments to discharge the original assumptions."
+    },
+    {
+      "proofId": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "Classical discrete ballot problem (Bertrand 1887, Whitworth 1878): in an election with $p > q$ votes, $\\Pr[A\\text{ leads throughout}] = (p-q)/(p+q)$. The continuous-time first-passage-time identity formalized here is the limiting / continuum analog of the discrete reflection-principle proof of the ballot problem. The two share their proof DNA — André's 1887 reflection at the diagonal, the simple random walk in the discrete case, Brownian motion in the continuous case — so reading the discrete entry first gives the combinatorial intuition that the csInf machinery here makes rigorous in the continuous limit."
+    },
+    {
+      "proofId": "ballot-problem-oq-03",
+      "relationship": "sibling",
+      "description": "Higher-dimensional sibling: 2D Crossing Lemma and Lindström-Gessel-Viennot infrastructure via lattice-path reflection. Where the present entry handles a single 1D continuous path and the level-crossing identity, OQ-03 handles families of non-intersecting 2D lattice paths and their sign-weighted determinant counts. Both descend from the same reflection-principle ancestor (André 1887) but make disjoint formalization choices: this entry uses csInf + IVT + IsClosed.csInf_mem on $\\mathbb{R}_{\\ge 0}$, while OQ-03 uses bijective combinatorics on $\\mathbb{Z}^2$."
+    },
+    {
+      "proofId": "intermediate-value-theorem-oq-01",
+      "relationship": "uses-shared-tool",
+      "description": "Bisection method for constructive root-finding from IVT. Where this entry uses IVT once to *witness existence* of a level-crossing (`ivt_first_crossing` invokes `isPreconnected_Icc.intermediate_value₂` non-constructively), the bisection entry uses IVT recursively to *constructively approximate* a root (each step halves the bracketing interval, giving a $1/2^n$ convergence rate). Both establish the same kind of result — a witness $s \\in [0,T]$ with a continuous path attaining a target value — but trade off differently between existence proof and constructivity. The non-emptiness conclusion in `hittingSet_nonempty_of_ivt` would in principle be replaceable by a bisection-style constructive witness for use cases that need the actual value of $\\tau$, not just that it exists."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Enrichment pass for `ballot-problem-oq-02-oq-02` (First Passage Time Characterization via csInf Theory). The entry's `crossReferences` array previously had only 3 entries (parent, IVT, single sibling), leaving it disconnected from natural relatives in the gallery despite the historicalContext explicitly invoking André 1887 / Bachelier 1900 / Lévy 1939.

## What changes

3 new entries appended to `crossReferences`:

1. **`ballot-problem` (ancestor)** — Classical discrete Bertrand-1887 ballot problem. The continuous-time first-passage-time identity formalized here is the limiting / continuum analog of the discrete reflection-principle proof of the ballot problem. Reading the discrete entry first gives the combinatorial intuition that the csInf machinery here makes rigorous in the Brownian limit.

2. **`ballot-problem-oq-03` (sibling)** — Lindström-Gessel-Viennot infrastructure via 2D lattice-path reflection. Both descend from the same reflection-principle ancestor (André 1887) but make disjoint formalization choices: this entry uses csInf + IVT + IsClosed.csInf_mem on $\mathbb{R}_{\ge 0}$, while OQ-03 uses bijective combinatorics on $\mathbb{Z}^2$.

3. **`intermediate-value-theorem-oq-01` (uses-shared-tool)** — Bisection method for constructive root-finding. The present entry uses IVT to *witness existence* of a level-crossing (via `isPreconnected_Icc.intermediate_value₂`); the bisection entry uses IVT recursively to *constructively approximate* a root. Same theorem, complementary use cases.

## What does NOT change

- `status` (`verified`), `badge` (`original`), `axiomCount` (0), `sorries` (0)
- `theoremCount` (11), `definitionCount` (3), `lineCount` (185)
- All `mainTheorems`, `overview`, `originalContributions`, `sections`, `references`, `conclusion`, `annotations.json`

## Disjoint from open PR #17468

PR #17468 (still open at time of this PR) only touches `mainTheorems` (adds 2 entries to bring 9→11). The present PR only touches `crossReferences` (adds 3 entries). Diffs do not overlap and either order of merge produces the same combined state.

## Verification

- JSON syntax validated.
- All 3 new `proofId` values resolve to existing gallery entries.
- `vite build` succeeds (1m46s, 2052 modules) — full production build clean.
- Diff is exactly 1 file, +15/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)