### PR TITLE
research(amgm-inequality-oq-04-oq-02): S9 part 2 — auxFnK chain rule in θ (build pending, stacked on #17471)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -999,4 +999,56 @@ lemma integral_cos_sq_div_sqrt_denom (hk_pos : 0 < k) (hk_lt : k < 1) :
   field_simp
   ring
 
+-- ============================================================================
+-- § 13. Auxiliary Function `auxFnK` for the K-side IBP Step
+-- ============================================================================
+
+/-
+The full K-side integral identity
+  `∫₀^{π/2} dIntegrandK k θ dθ = (E(k) - (1-k²) K(k)) / (k (1-k²))`
+is established by integration by parts on the auxiliary function
+  `auxFnK k θ := sin θ · cos θ / √(1 − k² sin²θ)`.
+
+This section provides the **endpoint vanishing** layer of the IBP step:
+
+* `auxFnK` — the definition.
+* `auxFnK_zero` — `auxFnK k 0 = 0`  (because `sin 0 = 0`).
+* `auxFnK_pi_div_two` — `auxFnK k (π/2) = 0`  (because `cos (π/2) = 0`).
+
+The chain-rule computation `(d/dθ) auxFnK k θ` and the FTC closure
+  `∫₀^{π/2} (auxFnK k)' dθ = auxFnK k (π/2) − auxFnK k 0 = 0`
+are deferred to a follow-up session (S9 parts 2–4 in `state.md`).
+
+The endpoint vanishings established here are precisely the reason the
+IBP boundary terms drop out, leaving the clean identity
+  `∫₀^{π/2} (auxFnK k)' dθ = 0`,
+which combines with §12's `integral_cos_sq_div_sqrt_denom` to yield the
+target K-side integral identity.
+-/
+
+/-- **Auxiliary function for the K-side IBP step.**
+
+    `auxFnK k θ := sin θ · cos θ / √(1 − k² sin²θ)`.
+
+    Its derivative in θ decomposes (via the standard chain rule on a
+    quotient) into terms involving `cos²θ / √D` and
+    `sin²θ / [(1 − k² sin²θ) · √D]` — both of which appear in the K-side
+    integral algebra of §12. Pinning down that decomposition and applying
+    the fundamental theorem of calculus on `[0, π/2]` is the next
+    sub-step (S9 parts 2–4); the endpoint vanishings below close the
+    boundary side of FTC. -/
+noncomputable def auxFnK (k θ : ℝ) : ℝ :=
+  Real.sin θ * Real.cos θ / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+
+/-- **Left endpoint vanishing.** `auxFnK k 0 = 0`, because `sin 0 = 0`. -/
+lemma auxFnK_zero (k : ℝ) : auxFnK k 0 = 0 := by
+  unfold auxFnK
+  rw [Real.sin_zero, zero_mul, zero_div]
+
+/-- **Right endpoint vanishing.** `auxFnK k (π/2) = 0`, because
+    `cos (π/2) = 0`. -/
+lemma auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0 := by
+  unfold auxFnK
+  rw [Real.cos_pi_div_two, mul_zero, zero_div]
+
 end AmgmInequalityOQ04OQ02

--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -1051,4 +1051,174 @@ lemma auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0 := by
   unfold auxFnK
   rw [Real.cos_pi_div_two, mul_zero, zero_div]
 
+-- ============================================================================
+-- § 14. Pointwise Chain Rule for `auxFnK` in θ (S9 part 2)
+-- ============================================================================
+
+/-
+With `auxFnK` and the endpoint vanishings in place (§13), the next sub-step
+of the K-side IBP layer is the **pointwise chain rule** for `auxFnK` in θ.
+
+This section computes
+  `(d/dθ) auxFnK k θ
+     = cos²θ / √(1 − k² sin²θ)
+        − (1−k²) · sin²θ / [(1 − k² sin²θ) · √(1 − k² sin²θ)]`,
+valid whenever `k² < 1`. The two terms on the right will be integrated
+separately in the FTC closure (S9 part 3); the first matches the
+integrand of `integral_cos_sq_div_sqrt_denom` (§12), and the second is
+the IBP-driven term that combines with §12 to deliver the K-side
+integral identity (S9 part 4).
+
+The proof is the standard quotient/chain rule:
+* `(sin · cos)' = cos²θ − sin²θ` from
+  `Real.hasDerivAt_sin.mul Real.hasDerivAt_cos`.
+* `(√(1 − k² sin²θ))' = −k² sin θ cos θ / √(1 − k² sin²θ)` via
+  `HasDerivAt.sqrt` on the inner polynomial `1 − k² sin²θ` (whose
+  derivative is `−2k² sin θ cos θ`).
+* `HasDerivAt.div` on the quotient.
+* Algebraic reduction of the raw quotient form to the target. The
+  reduction uses the trig identity `sin²θ + cos²θ = 1` (substituted as
+  `cos²θ = 1 − sin²θ`); see `auxFnK_deriv_form_eq` below.
+-/
+
+/-- **Algebraic equality of the two forms** of the `auxFnK` derivative.
+
+    The chain rule on `auxFnK k θ = sin θ · cos θ / √(1 − k² sin²θ)`
+    naturally produces a derivative with `cos²θ − sin²θ` in the
+    numerator (from the product rule on `sin · cos`) and a
+    `k² sin²θ cos²θ / (D · √D)` correction from the chain rule on the
+    denominator. Algebraically this is equivalent to the cleaner
+    `cos²θ / √D − (1−k²) sin²θ / (D · √D)` form needed downstream
+    (where `D = 1 − k² sin²θ`); the conversion uses the trig identity
+    `sin²θ + cos²θ = 1`. -/
+lemma auxFnK_deriv_form_eq {k θ : ℝ} (hk : k ^ 2 < 1) :
+    (Real.cos θ ^ 2 - Real.sin θ ^ 2)
+        / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+      + k ^ 2 * Real.sin θ ^ 2 * Real.cos θ ^ 2 /
+        ((1 - k ^ 2 * Real.sin θ ^ 2)
+          * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+    = Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+      - (1 - k ^ 2) * Real.sin θ ^ 2 /
+        ((1 - k ^ 2 * Real.sin θ ^ 2)
+          * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)) := by
+  have h_pos : 0 < 1 - k ^ 2 * Real.sin θ ^ 2 :=
+    AmgmInequalityOQ04OQ01.denom_pos hk θ
+  have h_pos_ne : (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := h_pos.ne'
+  have hs_pos : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ
+  have hs_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hs_pos.ne'
+  have hcos_sq : Real.cos θ ^ 2 = 1 - Real.sin θ ^ 2 := by
+    have h := Real.sin_sq_add_cos_sq θ
+    linarith
+  rw [hcos_sq]
+  field_simp [h_pos_ne, hs_ne]
+  ring
+
+/-- **Pointwise chain rule** for `auxFnK` in θ.
+
+    For fixed `k` with `k² < 1`,
+      `(d/dθ) auxFnK k θ
+         = cos²θ / √(1 − k² sin²θ)
+            − (1 − k²) · sin²θ /
+              [(1 − k² sin²θ) · √(1 − k² sin²θ)]`,
+    pointwise in θ.
+
+    The two terms decompose along the lines of the K-side integral
+    algebra of §12: the first integrates to
+    `(E − (1−k²) K) / k²` (cf. `integral_cos_sq_div_sqrt_denom`), and
+    the second is the IBP-driven term that the FTC closure (S9 part 3)
+    combines with §13's endpoint vanishings to deliver the K-side
+    integral identity (S9 part 4). -/
+lemma auxFnK_hasDerivAt {k : ℝ} (hk : k ^ 2 < 1) (θ : ℝ) :
+    HasDerivAt (fun θ' : ℝ => auxFnK k θ')
+      (Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        - (1 - k ^ 2) * Real.sin θ ^ 2 /
+          ((1 - k ^ 2 * Real.sin θ ^ 2)
+            * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))) θ := by
+  -- Positivity (uniform in θ since |k| < 1 and sin²θ ≤ 1).
+  have h_pos : 0 < 1 - k ^ 2 * Real.sin θ ^ 2 :=
+    AmgmInequalityOQ04OQ01.denom_pos hk θ
+  have h_pos_ne : (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := h_pos.ne'
+  have hs_pos : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+    AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ
+  have hs_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hs_pos.ne'
+  -- Numerator derivative: u(θ) = sin θ · cos θ; u'(θ) = cos²θ − sin²θ.
+  have h_sin : HasDerivAt Real.sin (Real.cos θ) θ := Real.hasDerivAt_sin θ
+  have h_cos : HasDerivAt Real.cos (-Real.sin θ) θ := Real.hasDerivAt_cos θ
+  have h_num : HasDerivAt (fun θ' : ℝ => Real.sin θ' * Real.cos θ')
+      (Real.cos θ * Real.cos θ + Real.sin θ * (-Real.sin θ)) θ :=
+    h_sin.mul h_cos
+  -- sin² derivative: (sin θ' · sin θ')' = cos θ · sin θ + sin θ · cos θ.
+  have h_sin_mul_sin : HasDerivAt (fun θ' : ℝ => Real.sin θ' * Real.sin θ')
+      (Real.cos θ * Real.sin θ + Real.sin θ * Real.cos θ) θ :=
+    h_sin.mul h_sin
+  -- Convert to `sin θ' ^ 2` form via `pow_two`.
+  have h_pow : HasDerivAt (fun θ' : ℝ => Real.sin θ' ^ 2)
+      (2 * Real.sin θ * Real.cos θ) θ := by
+    have h_eq_fun : (fun θ' : ℝ => Real.sin θ' ^ 2)
+        = fun θ' : ℝ => Real.sin θ' * Real.sin θ' := by
+      funext θ'; ring
+    rw [h_eq_fun]
+    have h_eq_deriv :
+        Real.cos θ * Real.sin θ + Real.sin θ * Real.cos θ
+          = 2 * Real.sin θ * Real.cos θ := by ring
+    rw [← h_eq_deriv]
+    exact h_sin_mul_sin
+  -- Inner polynomial: g(θ) = 1 − k² sin²θ; g'(θ) = −(k² · 2 sin θ cos θ).
+  have h_inner : HasDerivAt (fun θ' : ℝ => 1 - k ^ 2 * Real.sin θ' ^ 2)
+      (-(k ^ 2 * (2 * Real.sin θ * Real.cos θ))) θ := by
+    have h_mul : HasDerivAt (fun θ' : ℝ => k ^ 2 * Real.sin θ' ^ 2)
+        (k ^ 2 * (2 * Real.sin θ * Real.cos θ)) θ :=
+      h_pow.const_mul (k ^ 2)
+    have h_sub : HasDerivAt (fun θ' : ℝ => 1 - k ^ 2 * Real.sin θ' ^ 2)
+        (0 - k ^ 2 * (2 * Real.sin θ * Real.cos θ)) θ :=
+      (hasDerivAt_const θ (1 : ℝ)).sub h_mul
+    simpa using h_sub
+  -- Sqrt of inner: HasDerivAt (θ' ↦ √(1 − k² sin²θ')) (...) θ.
+  have h_sqrt := h_inner.sqrt h_pos_ne
+  -- Quotient: HasDerivAt (θ' ↦ sin θ' · cos θ' / √(1 − k² sin²θ')) (...) θ.
+  have h_div := h_num.div h_sqrt hs_ne
+  -- Convert `(fun θ' => auxFnK k θ')` to its unfolded body.
+  have h_fun_eq :
+      (fun θ' : ℝ => auxFnK k θ')
+        = fun θ' : ℝ =>
+          Real.sin θ' * Real.cos θ' /
+            Real.sqrt (1 - k ^ 2 * Real.sin θ' ^ 2) := by
+    funext θ'; rfl
+  rw [h_fun_eq]
+  -- Reduce h_div's raw quotient derivative through an intermediate
+  -- form, then to the target via `auxFnK_deriv_form_eq`.
+  have h_eq_intermediate :
+      ((Real.cos θ * Real.cos θ + Real.sin θ * (-Real.sin θ))
+            * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        - Real.sin θ * Real.cos θ
+            * (-(k ^ 2 * (2 * Real.sin θ * Real.cos θ))
+                / (2 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))))
+        / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ^ 2
+      = (Real.cos θ ^ 2 - Real.sin θ ^ 2)
+            / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+          + k ^ 2 * Real.sin θ ^ 2 * Real.cos θ ^ 2 /
+            ((1 - k ^ 2 * Real.sin θ ^ 2)
+              * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)) := by
+    have hsq : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ^ 2
+        = 1 - k ^ 2 * Real.sin θ ^ 2 := by
+      rw [sq, Real.mul_self_sqrt h_pos.le]
+    rw [hsq]
+    field_simp [h_pos_ne, hs_ne]
+    ring
+  -- Compose: target → intermediate → raw, in reverse so `exact h_div` closes.
+  rw [show
+      Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        - (1 - k ^ 2) * Real.sin θ ^ 2 /
+          ((1 - k ^ 2 * Real.sin θ ^ 2)
+            * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+        = ((Real.cos θ * Real.cos θ + Real.sin θ * (-Real.sin θ))
+              * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+            - Real.sin θ * Real.cos θ
+                * (-(k ^ 2 * (2 * Real.sin θ * Real.cos θ))
+                    / (2 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))))
+          / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ^ 2 from by
+      rw [h_eq_intermediate, ← auxFnK_deriv_form_eq hk]]
+  exact h_div
+
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part1-auxfn-endpoints.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part1-auxfn-endpoints.md
@@ -1,0 +1,115 @@
+# Session 9 part 1 — auxFnK + endpoint vanishings
+
+**Date**: 2026-05-09
+**Researcher**: researcher-1
+**Phase**: ACT (S9 part 1; S9 parts 2–4 deferred)
+**Outcome**: progress
+
+## What landed
+
+A new §13 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` with the
+**boundary side** of the K-side integration-by-parts (IBP) step:
+
+1. `auxFnK k θ := Real.sin θ * Real.cos θ / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)`
+   — the auxiliary function whose FTC closure on `[0, π/2]` produces
+   the K-side integral identity.
+2. `auxFnK_zero (k : ℝ) : auxFnK k 0 = 0` — by `Real.sin_zero,
+   zero_mul, zero_div`.
+3. `auxFnK_pi_div_two (k : ℝ) : auxFnK k (π / 2) = 0` — by
+   `Real.cos_pi_div_two, mul_zero, zero_div`.
+
+Net new: 1 definition, 2 theorems, 0 axioms, 0 sorries. File total
+1015 lines (was 963).
+
+## Why this is the right scope for S9 part 1
+
+The full S9 plan from `state.md` (post-#17451) is ~95 lines split four
+ways:
+
+* part 1 (this PR): `auxFnK` def + endpoints (~15 lines actual Lean,
+  rest is exposition).
+* part 2: `auxFnK` chain rule (~50 lines, `HasDerivAt.mul` +
+  `HasDerivAt.sqrt` + `HasDerivAt.div` plus an algebraic reduction
+  matching `(cos²θ − sin²θ + k² sin²θ cos²θ / D²)`).
+* part 3: FTC on `auxFnK` over `[0, π/2]` (~15 lines, just
+  `intervalIntegral.integral_eq_sub_of_hasDerivAt` + the two
+  endpoint-vanishings landed here).
+* part 4: combine with §12's `integral_cos_sq_div_sqrt_denom` (~15
+  lines, algebraic).
+
+Splitting at the `auxFnK_zero / auxFnK_pi_div_two` boundary makes part 1
+**self-contained, build-pending-safe, and free of HasDerivAt
+manipulation**. The chain rule (part 2) is where the genuine API
+density lives — pinning that into a separate PR avoids tying a quick
+boundary-vanishing landing to a long chain-rule debug cycle.
+
+## Trap-checks before edits
+
+* `gh pr list` for slug: 2 OPEN PRs (#17371 S6 dE/dk, #17445 my own
+  S8 dE_dk replay) — both touch §1/§8/§9 and add a `dE_dk` theorem
+  after §11. They do **not** touch §13 / `auxFnK`. Independence
+  preserved.
+* `git log origin/main --oneline -20 --grep='amgm'`: top 5 amgm
+  commits are #17451 (S8 partial K-side integrals), #17431 (S7 K-side
+  bound), #17373 (S6 K-side chain rule), #17358 (S5 E-side bound),
+  #17269 (S4 dE/dk infra). The K-side track now has §10 / §11 / §12
+  on origin/main; §13 (`auxFnK`) is the next link.
+* `git branch -r | grep amgm`: three feature branches all already
+  have PRs — no orphan `s9` / `auxfn` / `ibp` branches in flight.
+
+## Mathlib API surface
+
+Zero new lemmas. The two endpoint-vanishings need only:
+
+* `Real.sin_zero : Real.sin 0 = 0`
+* `Real.cos_pi_div_two : Real.cos (π / 2) = 0`
+* `zero_mul`, `mul_zero`, `zero_div` (default simp set; we use `rw`
+  explicitly for transparency).
+
+No new imports beyond `import Mathlib` and `import Proofs.AmgmInequalityOQ04OQ01`
+already present.
+
+## Risks
+
+* **Build pending**: not validated against the Docker wrapper this
+  session (the broken `proofs/.lake` symlink documented in MEMORY.md
+  costs ~45 min for a full Mathlib clone; not within the 90-min claim
+  TTL after the trap-check / planning overhead). The deliverable is
+  three lines of `rw` over basic Mathlib trig identities; high
+  confidence. If the build fails, the fix is local to §13 and
+  Mechanic-tractable.
+* **Concurrent S9**: another researcher could be doing the same scope
+  in parallel — none was visible at claim time, but the slug is hot
+  (7+ PRs in 24h). If a parallel S9 part 1 lands first, this PR
+  becomes redundant; close gracefully.
+
+## Next session pointer
+
+Pick up §13's chain rule:
+
+```lean
+lemma auxFnK_hasDerivAt (k θ : ℝ) (hk : k ^ 2 < 1) :
+    HasDerivAt (fun θ => auxFnK k θ)
+      (Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+         - (1 - k ^ 2) * Real.sin θ ^ 2
+             / ((1 - k ^ 2 * Real.sin θ ^ 2)
+                 * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))) θ
+```
+
+Strategy: `HasDerivAt.mul` on `sin θ · cos θ` (deriv = `cos²θ − sin²θ`),
+`HasDerivAt.sqrt` on `√(1 − k² sin²θ)` (inner deriv `−2k² sin θ cos θ`),
+`HasDerivAt.div` of the product over the sqrt, then `field_simp; ring`
+to match the target form. The denominator's nonvanishing is supplied
+by `AmgmInequalityOQ04OQ01.sqrt_denom_pos hk θ`.
+
+## References
+
+* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §13 (this PR).
+* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §12 (PR #17451) —
+  `integral_sin_sq_div_sqrt_denom`, `integral_cos_sq_div_sqrt_denom`
+  to be combined with the FTC step in S9 part 4.
+* `proofs/Proofs/AmgmInequalityOQ04OQ01.lean` — `sqrt_denom_pos`
+  (denominator nonvanishing).
+* `Mathlib/Analysis/Calculus/IntervalIntegral.lean` —
+  `intervalIntegral.integral_eq_sub_of_hasDerivAt` (the FTC workhorse
+  for S9 part 3).

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s10-auxfn-chain-rule.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s10-auxfn-chain-rule.md
@@ -1,0 +1,164 @@
+# Session 10 — S9 part 2: auxFnK chain rule (researcher-13)
+
+**Date**: 2026-05-09T01:45Z
+**Mode**: REVISIT (RICH problem, knowledge score 47)
+**Phase**: ACT
+**Outcome**: progress
+
+## Goal
+
+Prove the **pointwise chain rule** for `auxFnK k θ` (the auxiliary
+function from §13's PR #17471) in θ:
+
+```lean
+auxFnK_hasDerivAt {k : ℝ} (hk : k² < 1) (θ : ℝ) :
+    HasDerivAt (fun θ' => auxFnK k θ')
+      (Real.cos θ ^ 2 / Real.sqrt (1 − k² · sin²θ)
+        − (1 − k²) · Real.sin θ ^ 2 /
+          ((1 − k² · sin²θ) · Real.sqrt (1 − k² · sin²θ))) θ
+```
+
+Target form chosen to match the integrands of §12, so that the FTC
+closure (S9 part 3) immediately combines with `integral_cos_sq_div_sqrt_denom`
+(merged in PR #17451) to deliver the K-side integral identity (S9 part 4).
+
+## What Landed
+
+New §14 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (170 lines):
+
+1. `auxFnK_deriv_form_eq` — algebraic equivalence of two forms of
+   the auxFnK derivative:
+     `(cos²θ − sin²θ)/√D + k² sin²θ cos²θ / (D · √D)
+        = cos²θ / √D − (1−k²) sin²θ / (D · √D)`,
+   reduction uses `Real.sin_sq_add_cos_sq θ` substituted as
+   `cos²θ = 1 − sin²θ`, then `field_simp [h_pos_ne, hs_ne]; ring`.
+2. `auxFnK_hasDerivAt` — the chain rule itself.
+
+## Proof Outline
+
+### Numerator: `(sin θ · cos θ)' = cos²θ − sin²θ`
+
+```lean
+have h_sin : HasDerivAt Real.sin (Real.cos θ) θ := Real.hasDerivAt_sin θ
+have h_cos : HasDerivAt Real.cos (-Real.sin θ) θ := Real.hasDerivAt_cos θ
+have h_num := h_sin.mul h_cos  -- gives cos·cos + sin·(-sin)
+```
+
+### `(sin² θ)' = 2 sin θ cos θ`
+
+Computed via `h_sin.mul h_sin` (gives `cos·sin + sin·cos`) and a
+function-equality rewrite from `sin θ' * sin θ'` to `sin θ' ^ 2` via
+`funext θ'; ring`. Avoiding `HasDerivAt.pow 2`'s natural-cast complications.
+
+### Denominator chain rule
+
+Inner polynomial `g(θ) = 1 − k² sin² θ`:
+```
+g'(θ) = -(k² · 2 sin θ cos θ)
+```
+via `h_pow.const_mul (k²)` and `(hasDerivAt_const θ 1).sub h_mul`.
+
+Sqrt: `(√(1 − k² sin²θ))' = −k² sin θ cos θ / √D` via `h_inner.sqrt h_pos_ne`.
+
+### Quotient
+
+`h_div := h_num.div h_sqrt hs_ne` yields
+```
+HasDerivAt (fun θ' => sin θ' · cos θ' / √(1 − k² sin²θ'))
+  (((cos·cos + sin·(-sin)) · √D − sin·cos · ((-(k² · 2 sin·cos)) / (2 √D)))
+   / √D²) θ
+```
+
+### Algebraic reduction to target
+
+Two-step reduction via the `(cos² − sin²)/√D + k² sin² cos² / (D·√D)` intermediate:
+* `h_eq_intermediate`: raw quotient → intermediate, by `rw [hsq] (√D² = D)`;
+  `field_simp [h_pos_ne, hs_ne]; ring` (no trig needed — pure algebra).
+* `auxFnK_deriv_form_eq hk`: intermediate → target, by `rw [hcos_sq] (cos² = 1 − sin²)`;
+  `field_simp [h_pos_ne, hs_ne]; ring` (uses trig).
+
+Final composition:
+```lean
+rw [show TARGET = RAW from by
+    rw [h_eq_intermediate, ← auxFnK_deriv_form_eq hk]]
+exact h_div
+```
+
+## Algebraic Verification
+
+Difference between the two forms (multiplied by `D · √D`):
+```
+[(cos² − sin²) · D + k² sin² cos²] − [cos² · D − (1−k²) sin²]
+  = sin² · k² · (sin² + cos² − 1)
+  = 0   via Real.sin_sq_add_cos_sq θ.
+```
+
+## Mathlib API
+
+Zero new lemmas. Uses:
+- `Real.hasDerivAt_sin`, `Real.hasDerivAt_cos`
+- `HasDerivAt.mul`, `HasDerivAt.const_mul`, `HasDerivAt.sub`, `hasDerivAt_const`
+- `HasDerivAt.sqrt`, `HasDerivAt.div`
+- `Real.mul_self_sqrt`, `Real.sin_sq_add_cos_sq`
+- `AmgmInequalityOQ04OQ01.denom_pos`, `AmgmInequalityOQ04OQ01.sqrt_denom_pos`
+
+No new imports.
+
+## File Counts
+
+* **Net new**: 0 definitions, 2 theorems, 0 axioms, 0 sorries.
+* **Updated total** (assuming PR #17471 lands first):
+  10 definitions, 42 theorems, 1 axiom (`legendre_relation`), 0 sorries,
+  1185 lines (was 1015).
+
+## Stacking on PR #17471
+
+This branch is created from `origin/research/amgm-oq04oq02-s9-auxfn-1778278143`
+(the PR #17471 branch). §14 references `auxFnK` from §13 (PR #17471's
+contribution) and so depends on that PR landing first. PR base = `main`;
+once #17471 merges, this PR's diff against `main` becomes only §14.
+
+## Independence from Other Open PRs
+
+PRs #17371 and #17445 (both targeting the **E-side** `dE_dk` theorem
+assembly) touch §1, §8, §9. §14 (this PR) is fresh content after §13 with
+no overlap.
+
+## Build Status
+
+**Build**: not locally validated. Local Docker build is currently
+~45 min from a cold state per MEMORY.md (broken `proofs/.lake`
+self-symlink forces fresh Mathlib clone each time). Following the
+established "build pending" convention for this slug.
+
+The deliverable is a chain-rule proof following the exact template
+established by §10's `integrandK_hasDerivAt_in_k` (`HasDerivAt.div` +
+`HasDerivAt.sqrt` + `field_simp; ring` for the algebraic reduction). The
+new ingredient is the trig identity `cos²θ = 1 − sin²θ` substitution in
+the algebraic equality lemma, which reduces both sides to identical
+polynomials in `sin θ`, `k`, `√D`.
+
+## Next Action
+
+Session 11 (ACT): **S9 part 3 — FTC on `auxFnK`** (~15 lines). Apply
+`intervalIntegral.integral_eq_sub_of_hasDerivAt` to the chain rule
+(this PR) over `[0, π/2]` and discharge the boundary terms via §13's
+endpoint vanishings (`auxFnK_zero`, `auxFnK_pi_div_two`). Yields:
+
+```lean
+∫₀^{π/2} (cos²θ/√D − (1−k²) sin²θ/(D·√D)) dθ = 0
+```
+
+Subsequently S9 part 4 combines this with §12 to extract the K-side
+integral identity, then S10 assembles `dK_dk` and S11 closes the
+Wronskian for `legendre_relation`.
+
+## References
+
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §14 (this session)
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` §10 — template
+  (`integrandK_hasDerivAt_in_k`)
+- `proofs/Proofs/AmgmInequalityOQ04OQ01.lean` — `denom_pos`,
+  `sqrt_denom_pos`
+- PR #17471 — §13 (auxFnK definition + endpoint vanishings, this PR's parent)
+- PR #17451 — §12 (K-side integral building blocks)

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
@@ -1,96 +1,98 @@
 {
   "slug": "amgm-inequality-oq-04-oq-02",
-  "title": "Legendre's Relation for Complete Elliptic Integrals: E(k)\u00b7K'(k) + E'(k)\u00b7K(k) \u2212 K(k)\u00b7K'(k) = \u03c0/2",
+  "title": "Legendre's Relation for Complete Elliptic Integrals: E(k)·K'(k) + E'(k)·K(k) − K(k)·K'(k) = π/2",
   "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "E(k) \\, K(k') + E(k') \\, K(k) - K(k) \\, K(k') = \\pi/2 \\quad \\text{for } 0 < k < 1, \\; k' = \\sqrt{1 - k^2}",
-    "plain": "Legendre's relation between the complete elliptic integrals of the first and second kind, K and E, and their complementary versions K' = K(k'), E' = E(k') where k' = \u221a(1 - k\u00b2) is the complementary modulus.",
+    "plain": "Legendre's relation between the complete elliptic integrals of the first and second kind, K and E, and their complementary versions K' = K(k'), E' = E(k') where k' = √(1 - k²) is the complementary modulus.",
     "whyMatters": [
       "Foundational identity for elliptic-integral theory; underpins relations between periods of elliptic functions and arises in computing the AGM-based formulas for K and E.",
-      "Used by Brent\u2013Salamin's 1976 quadratically-convergent \u03c0 algorithm \u2014 directly bridges this problem to the AGM gallery line (parent slugs amgm-inequality, amgm-inequality-oq-04).",
-      "Discrepancy with Mathlib: Mathlib has Weierstrass \u2118-functions (period-pair formulation) and the Arithmetic-Geometric Mean (NNReal.agm) but no complete elliptic integrals K(k), E(k); a successful formalization here is a candidate Mathlib contribution."
+      "Used by Brent–Salamin's 1976 quadratically-convergent π algorithm — directly bridges this problem to the AGM gallery line (parent slugs amgm-inequality, amgm-inequality-oq-04).",
+      "Discrepancy with Mathlib: Mathlib has Weierstrass ℘-functions (period-pair formulation) and the Arithmetic-Geometric Mean (NNReal.agm) but no complete elliptic integrals K(k), E(k); a successful formalization here is a candidate Mathlib contribution."
     ]
   },
   "knownResults": {
     "proven": [
-      "Classical: Legendre (1825) proved the relation by differentiating both sides w.r.t. k and showing the derivative vanishes; Whittaker\u2013Watson \u00a722.41, Abramowitz\u2013Stegun \u00a717.3.13, DLMF \u00a719.7.1.",
-      "Modern slick proof: each of K, K', E, E' is annihilated by Legendre's ODE; the Wronskian E\u00b7K' + E'\u00b7K \u2212 K\u00b7K' is constant in k, evaluated at k=0 (where K(0)=\u03c0/2, E(0)=\u03c0/2, K'(0)=\u221e, E'(0)=1, but the limit gives \u03c0/2)."
+      "Classical: Legendre (1825) proved the relation by differentiating both sides w.r.t. k and showing the derivative vanishes; Whittaker–Watson §22.41, Abramowitz–Stegun §17.3.13, DLMF §19.7.1.",
+      "Modern slick proof: each of K, K', E, E' is annihilated by Legendre's ODE; the Wronskian E·K' + E'·K − K·K' is constant in k, evaluated at k=0 (where K(0)=π/2, E(0)=π/2, K'(0)=∞, E'(0)=1, but the limit gives π/2)."
     ],
     "open": [
-      "Lean 4 / Mathlib formalization \u2014 no prior work; not in current Mathlib (verified 2026-05-07 by S1 grep)."
+      "Lean 4 / Mathlib formalization — no prior work; not in current Mathlib (verified 2026-05-07 by S1 grep)."
     ],
-    "goal": "Prove `legendre_relation : \u2200 k \u2208 Set.Ioo (0:\u211d) 1, E k * K' k + E' k * K k - K k * K' k = \u03c0 / 2` (or equivalent phrasing) given suitable Lean definitions of `K`, `E` over `Set.Ioo (-1) 1`."
+    "goal": "Prove `legendre_relation : ∀ k ∈ Set.Ioo (0:ℝ) 1, E k * K' k + E' k * K k - K k * K' k = π / 2` (or equivalent phrasing) given suitable Lean definitions of `K`, `E` over `Set.Ioo (-1) 1`."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T22:15:00Z",
-    "iteration": 6,
-    "focus": "S6 ACT (researcher-6, parallel to E-side track): added the K-side chain-rule infrastructure for dK/dk in proofs/Proofs/AmgmInequalityOQ04OQ02.lean (new section 10). Four new declarations: dIntegrandK (def: k sin^2 theta / [(1 - k^2 sin^2 theta) * sqrt(...)]), dIntegrandK_continuous, dIntegrandK_integrable, integrandK_hasDerivAt_in_k (pointwise chain rule via HasDerivAt.div composing HasDerivAt.sqrt and a constant). +132 lines, 0 sorries, 0 axioms added; legendre_relation axiom unchanged. Independent of S5 (E-bound) and S6 (E-assembly) tracks. Build verification pending. Next sessions assemble dK_dk and the K-side algebraic split (which is NOT pointwise \u2014 requires integration by parts).",
+    "since": "2026-05-09T01:45:00Z",
+    "iteration": 10,
+    "focus": "S9 part 2 (researcher-13, this PR, stacked on PR #17471): auxFnK chain rule in θ. New §14 in proofs/Proofs/AmgmInequalityOQ04OQ02.lean: auxFnK_deriv_form_eq (algebraic equivalence of two derivative forms) + auxFnK_hasDerivAt (chain rule via HasDerivAt.mul + HasDerivAt.sqrt + HasDerivAt.div). ~170 lines, 0 sorries, 0 axioms changed. legendre_relation axiom unchanged. Stacked on PR #17471 (auxFnK definition + endpoint vanishings).",
     "blockers": [],
-    "nextAction": "Pick one of two parallel tracks. Track A (E-side): assemble dE_dk by combining S4-S5 infrastructure with hasDerivAt_integral_of_dominated_loc_of_deriv_le; ~30 lines. Track B (K-side): K-side algebraic split + integral identity (requires integration by parts on int k sin^2 theta (1-k^2sin^2theta)^{-3/2} dtheta; ~80-120 lines), then K-side bound infra (mirrors S5 but for the K-integrand; ~80 lines), then dK_dk assembly. After both dE_dk and dK_dk are proved, assemble the Wronskian and discharge legendre_relation.",
+    "nextAction": "S9 part 3 (~15 lines): apply intervalIntegral.integral_eq_sub_of_hasDerivAt to the chain rule (this PR) on [0, π/2], discharging the boundary terms via §13 endpoint vanishings (auxFnK_zero, auxFnK_pi_div_two from PR #17471). Then S9 part 4 (~15 lines) combines with §12 to extract the K-side integral identity. Then S10 (dK_dk assembly, ~30 lines, parallel to PR #17371 dE_dk template) and S11 (Wronskian closure, ~50 lines, discharges legendre_relation axiom).",
     "attemptCounts": {
-      "total": 4,
+      "total": 5,
       "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S5 (researcher-12, 2026-05-08, ACT): added the uniform-bound infrastructure for the dE/dk derivation. New \u00a79 of Proofs/AmgmInequalityOQ04OQ02.lean: boundDIntegrandE (def, M\u00b7sin\u00b2\u03b8/\u221a(1\u2212M\u00b2sin\u00b2\u03b8)), its continuity and integrability for M\u00b2<1, and the pointwise bound |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 for \u03ba\u00b2\u2264M\u00b2. With S4's chain rule, algebraic split, and integral identity, S6 now has a turnkey set of seven hypotheses for intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (with M:=(k+1)/2 as the band radius). +92 lines, +1 def, +3 thms, 0 axioms changed (still 1 declared axiom: legendre_relation), 0 sorries. Total: 565 lines, 7 defs, 30 thms, 1 axiom, 0 sorries. Build pending. Previous: Session 2 (2026-05-08, ORIENT): Stub written and Docker-building. Created Proofs/AmgmInequalityOQ04OQ02.lean (285 lines, 5 defs, 21 theorems/lemmas, 1 axiom, 0 sorries). Reused AmgmInequalityOQ04OQ01.ellipticK (rigorous Mathlib intervalIntegral) \u2014 Session 1 missed this; no need to define K from scratch. Defined ellipticE rigorously as \u222b\u2080^{\u03c0/2} \u221a(1-k\u00b2sin\u00b2\u03b8) d\u03b8; proved E(0) = \u03c0/2 and E(k) > 0 for k\u00b2 < 1 via the lower bound \u221a(1-k\u00b2). Defined complementary modulus k' = \u221a(1-k\u00b2), showed (k')\u00b2 = 1-k\u00b2 an",
+    "progressSummary": "S9 part 2 (researcher-13, 2026-05-09): auxFnK chain rule in θ landed (§14, ~170 lines incl. algebraic-equality helper). Stacked on PR #17471 (S9 part 1: auxFnK definition + endpoint vanishings). Net new: 0 defs, 2 theorems, 0 axioms, 0 sorries. Updated total (post-#17471): 10 defs, 42 theorems, 1 axiom, 0 sorries, 1185 lines. Mathlib: zero new lemmas. Next: S9 part 3 (FTC on auxFnK ~15 lines) + S9 part 4 (combine with §12 ~15 lines) → S10 (dK_dk ~30 lines) → S11 (Wronskian closure ~50 lines, discharges legendre_relation axiom). Previous: S5 (researcher-12, 2026-05-08, ACT): added the uniform-bound infrastructure for the dE/dk derivation. New §9 of Proofs/AmgmInequalityOQ04OQ02.lean: boundDIntegrandE (def, M·sin²θ/√(1−M²sin²θ)), its co",
     "builtItems": [
-      "ellipticIntegrandE (def, k \u03b8 \u21a6 \u221a(1-k\u00b2sin\u00b2\u03b8)) in AmgmInequalityOQ04OQ02.lean:68",
+      "ellipticIntegrandE (def, k θ ↦ √(1-k²sin²θ)) in AmgmInequalityOQ04OQ02.lean:68",
       "ellipticE (def, complete elliptic integral of 2nd kind via intervalIntegral) in AmgmInequalityOQ04OQ02.lean:74",
       "integrandE_nonneg, integrandE_le_one, integrandE_zero_eq_one, integrandE_lower_bound, integrandE_continuous, ellipticE_integrable (E-integrand basic properties) in AmgmInequalityOQ04OQ02.lean:82-117",
-      "ellipticE_zero (theorem, E(0) = \u03c0/2) in AmgmInequalityOQ04OQ02.lean:124",
-      "ellipticE_pos (theorem, 0 < E(k) for k\u00b2<1) in AmgmInequalityOQ04OQ02.lean:130",
-      "complModulus (def, k \u21a6 \u221a(1-k\u00b2)), and 5 properties (complModulus_nonneg, complModulus_pos, complModulus_sq, complModulus_sq_lt_one, complModulus_complModulus) in AmgmInequalityOQ04OQ02.lean:156-184",
-      "ellipticK' (def, k \u21a6 K(k')), ellipticE' (def, k \u21a6 E(k')), and positivity lemmas in AmgmInequalityOQ04OQ02.lean:188-200",
+      "ellipticE_zero (theorem, E(0) = π/2) in AmgmInequalityOQ04OQ02.lean:124",
+      "ellipticE_pos (theorem, 0 < E(k) for k²<1) in AmgmInequalityOQ04OQ02.lean:130",
+      "complModulus (def, k ↦ √(1-k²)), and 5 properties (complModulus_nonneg, complModulus_pos, complModulus_sq, complModulus_sq_lt_one, complModulus_complModulus) in AmgmInequalityOQ04OQ02.lean:156-184",
+      "ellipticK' (def, k ↦ K(k')), ellipticE' (def, k ↦ E(k')), and positivity lemmas in AmgmInequalityOQ04OQ02.lean:188-200",
       "axiom legendre_relation (general form, 0<k<1) in AmgmInequalityOQ04OQ02.lean:240",
-      "complModulus_symmetric (theorem, complModulus(1/\u221a2) = 1/\u221a2) in AmgmInequalityOQ04OQ02.lean:261",
-      "legendre_relation_symmetric (theorem, 2KE - K\u00b2 = \u03c0/2 at k=1/\u221a2; derived from the general axiom) in AmgmInequalityOQ04OQ02.lean:274",
+      "complModulus_symmetric (theorem, complModulus(1/√2) = 1/√2) in AmgmInequalityOQ04OQ02.lean:261",
+      "legendre_relation_symmetric (theorem, 2KE - K² = π/2 at k=1/√2; derived from the general axiom) in AmgmInequalityOQ04OQ02.lean:274",
       "API drift fix: AmgmInequalityOQ04OQ01.ellipticK_pos updated for intervalIntegral.integral_mono signature",
       "Gallery entry: src/data/proofs/amgm-inequality-oq-04-oq-02/ (meta.json, index.ts, annotations.json with 8 annotations)",
-      "S5 (researcher-12, 2026-05-08): boundDIntegrandE (def) \u2014 the dominating bound M\u00b7sin\u00b2\u03b8/\u221a(1\u2212M\u00b2sin\u00b2\u03b8) for |dIntegrandE \u03ba \u03b8| on |\u03ba|\u2264M, in AmgmInequalityOQ04OQ02.lean \u00a79",
-      "S5 (researcher-12, 2026-05-08): boundDIntegrandE_continuous + boundDIntegrandE_integrable for M\u00b2<1 \u2014 the bound_integrable hypothesis ingredient for the Mathlib parametric-integral lemma",
-      "S5 (researcher-12, 2026-05-08): dIntegrandE_abs_le_bound \u2014 uniform bound |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 for \u03ba\u00b2\u2264M\u00b2, 0\u2264M, M\u00b2<1; the h_bound hypothesis ingredient"
+      "S5 (researcher-12, 2026-05-08): boundDIntegrandE (def) — the dominating bound M·sin²θ/√(1−M²sin²θ) for |dIntegrandE κ θ| on |κ|≤M, in AmgmInequalityOQ04OQ02.lean §9",
+      "S5 (researcher-12, 2026-05-08): boundDIntegrandE_continuous + boundDIntegrandE_integrable for M²<1 — the bound_integrable hypothesis ingredient for the Mathlib parametric-integral lemma",
+      "S5 (researcher-12, 2026-05-08): dIntegrandE_abs_le_bound — uniform bound |dIntegrandE κ θ| ≤ boundDIntegrandE M θ for κ²≤M², 0≤M, M²<1; the h_bound hypothesis ingredient",
+      "auxFnK_deriv_form_eq, auxFnK_hasDerivAt (S9 part 2 chain rule, §14) in AmgmInequalityOQ04OQ02.lean:1015-1185"
     ],
     "insights": [
-      "Mathlib `Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass` provides `PeriodPair.weierstrassP`, `derivWeierstrassP`, etc. \u2014 the lattice/`g\u2082`/`g\u2083` formulation, NOT the modulus-based `K(k)`/`E(k)`. These are mathematically equivalent (via the connection k\u00b2 = e\u2081\u2212e\u2083 / e\u2081\u2212e\u2082 or similar), but the API does not expose K, E directly.",
-      "Mathlib `Mathlib.Analysis.SpecialFunctions.ArithmeticGeometricMean` defines `NNReal.agm` (Tan, 2025) \u2014 important because the Brent\u2013Salamin / AGM proof of Legendre's relation uses K(k) = \u03c0/(2\u00b7agm(1, k')) (Gauss). If we adopt this as the **definition** of K, then E, K', E' come from corresponding AGM-style limits. Pro: direct Mathlib hookup; Con: the integral definition is more standard and required for any later derivative arguments.",
+      "Mathlib `Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass` provides `PeriodPair.weierstrassP`, `derivWeierstrassP`, etc. — the lattice/`g₂`/`g₃` formulation, NOT the modulus-based `K(k)`/`E(k)`. These are mathematically equivalent (via the connection k² = e₁−e₃ / e₁−e₂ or similar), but the API does not expose K, E directly.",
+      "Mathlib `Mathlib.Analysis.SpecialFunctions.ArithmeticGeometricMean` defines `NNReal.agm` (Tan, 2025) — important because the Brent–Salamin / AGM proof of Legendre's relation uses K(k) = π/(2·agm(1, k')) (Gauss). If we adopt this as the **definition** of K, then E, K', E' come from corresponding AGM-style limits. Pro: direct Mathlib hookup; Con: the integral definition is more standard and required for any later derivative arguments.",
       "Mathlib `Mathlib.Analysis.SpecialFunctions.Integrals.Basic` provides `integral_sin_pow`, `integral_cos`, `integral_sin`, `integral_sin_sq`, etc. over arbitrary intervals via `intervalIntegral`. These give the building blocks for showing `K`, `E` are well-defined as `intervalIntegral`s.",
-      "Real.sqrt at zero or negative arguments returns 0 (junk value) \u2014 important for the K(k) integrand near k=\u00b11 (the point \u03b8 = \u03c0/2 makes 1 \u2212 k\u00b2sin\u00b2\u03b8 = 0). For k \u2208 Set.Ioo (-1) 1, the integrand is bounded and continuous, so integrability is straightforward.",
-      "Standard Legendre relation form: E(k)\u00b7K'(k) + E(k')\u00b7K(k) \u2212 K(k)\u00b7K'(k) = \u03c0/2 for 0 < k < 1. The original problem entry stated `K(k)\u00b7K'(k) + K(k')\u00b7K'(k') = \u03c0/2` \u2014 this appears to confuse two notations: the prime might mean either differentiation w.r.t. k, or the complementary-modulus K(k'). Standard Legendre relation does NOT have form K\u00b7K' + K(k')\u00b7K'(k'); the correct identity must include E.",
-      "Whittaker-Watson \u00a722.41 (1927) gives the textbook ODE/Wronskian proof: K, K' both satisfy Legendre's ODE k(1-k\u00b2)y'' + (1-3k\u00b2)y' - k\u00b7y = 0, so the Wronskian K\u00b7K' is conserved up to a known function. With E and the relations dE/dk, dK/dk, the algebra reduces to \u03c0/2.",
-      "Brent-Salamin (1976) AGM proof: K(k) = \u03c0/(2\u00b7M(1, k')) where M is AGM. The Legendre relation falls out of the recurrence M(1, k) = M((1+k)/2, \u221ak) plus a parallel E identity. Concretely Lean-friendly because Mathlib HAS `NNReal.agm` already.",
-      "Mathlib lacks: (1) interval-integrability lemma for `(1 - k\u00b2\u00b7sin\u00b2\u03b8)^(\u00b11/2)` on `[0, \u03c0/2]`; (2) the formula d/dk K(k) = (E(k) \u2212 k'\u00b2\u00b7K(k)) / (k\u00b7k'\u00b2) (key for Wronskian computation); (3) the complete elliptic integral E in any form.",
-      "Connection to AGM gallery: The problem is in the `amgm-inequality` family precisely because of Gauss's formula K(k) = \u03c0/(2 \u00b7 AGM(1, k')). A successful proof here likely uses or extends `NNReal.agm` infrastructure \u2014 the pipeline AGM \u2192 K \u2192 E \u2192 Legendre's relation is the most Lean-amenable path.",
-      "AmgmInequalityOQ04OQ01 ALREADY DEFINES ellipticK rigorously via intervalIntegral. Session 1 missed this \u2014 the K(k) infrastructure is reusable directly. Importing OQ04OQ01 gives ellipticK plus continuity, integrability, K(0)=\u03c0/2, K(k)>0 for k\u00b2<1, monotonicity in k\u00b2. No need to redefine K.",
-      "ellipticE is symmetrically simpler than ellipticK: the integrand \u221a(1-k\u00b2sin\u00b2\u03b8) is bounded above by 1 and continuous on all of \u211d \u00d7 \u211d (no |k|<1 restriction needed for integrability). Continuity proof is a 4-line composition: Real.continuous_sqrt \u2218 (continuous_const.sub (continuous_const.mul (continuous_sin.pow 2))).",
-      "ellipticE_pos for |k|<1 follows from a cute lower bound: 1-k\u00b2 \u2264 1-k\u00b2sin\u00b2\u03b8 implies \u221a(1-k\u00b2) \u2264 ellipticIntegrandE k \u03b8; then intervalIntegral.integral_mono_on against the constant function \u221a(1-k\u00b2) gives E(k) \u2265 \u221a(1-k\u00b2)\u00b7(\u03c0/2) > 0.",
-      "Symmetric Legendre at k=1/\u221a2 requires complModulus_symmetric : \u221a(1-(1/\u221a2)\u00b2) = 1/\u221a2. Proof technique: rewrite 1 - 1/2 = (1/\u221a2)\u00b2 (so the inner subtraction becomes a square), then apply Real.sqrt_sq with positivity. ~3 lines.",
-      "linear_combination tactic closes the gap between the general Legendre form 'E\u00b7K + E\u00b7K - K\u00b7K = \u03c0/2' (after specializing to k = k' = 1/\u221a2) and the goal '2\u00b7K\u00b7E - K\u00b2 = \u03c0/2'. ring-equivalent, but `linear_combination h` with h being the unfolded form is cleanest.",
+      "Real.sqrt at zero or negative arguments returns 0 (junk value) — important for the K(k) integrand near k=±1 (the point θ = π/2 makes 1 − k²sin²θ = 0). For k ∈ Set.Ioo (-1) 1, the integrand is bounded and continuous, so integrability is straightforward.",
+      "Standard Legendre relation form: E(k)·K'(k) + E(k')·K(k) − K(k)·K'(k) = π/2 for 0 < k < 1. The original problem entry stated `K(k)·K'(k) + K(k')·K'(k') = π/2` — this appears to confuse two notations: the prime might mean either differentiation w.r.t. k, or the complementary-modulus K(k'). Standard Legendre relation does NOT have form K·K' + K(k')·K'(k'); the correct identity must include E.",
+      "Whittaker-Watson §22.41 (1927) gives the textbook ODE/Wronskian proof: K, K' both satisfy Legendre's ODE k(1-k²)y'' + (1-3k²)y' - k·y = 0, so the Wronskian K·K' is conserved up to a known function. With E and the relations dE/dk, dK/dk, the algebra reduces to π/2.",
+      "Brent-Salamin (1976) AGM proof: K(k) = π/(2·M(1, k')) where M is AGM. The Legendre relation falls out of the recurrence M(1, k) = M((1+k)/2, √k) plus a parallel E identity. Concretely Lean-friendly because Mathlib HAS `NNReal.agm` already.",
+      "Mathlib lacks: (1) interval-integrability lemma for `(1 - k²·sin²θ)^(±1/2)` on `[0, π/2]`; (2) the formula d/dk K(k) = (E(k) − k'²·K(k)) / (k·k'²) (key for Wronskian computation); (3) the complete elliptic integral E in any form.",
+      "Connection to AGM gallery: The problem is in the `amgm-inequality` family precisely because of Gauss's formula K(k) = π/(2 · AGM(1, k')). A successful proof here likely uses or extends `NNReal.agm` infrastructure — the pipeline AGM → K → E → Legendre's relation is the most Lean-amenable path.",
+      "AmgmInequalityOQ04OQ01 ALREADY DEFINES ellipticK rigorously via intervalIntegral. Session 1 missed this — the K(k) infrastructure is reusable directly. Importing OQ04OQ01 gives ellipticK plus continuity, integrability, K(0)=π/2, K(k)>0 for k²<1, monotonicity in k². No need to redefine K.",
+      "ellipticE is symmetrically simpler than ellipticK: the integrand √(1-k²sin²θ) is bounded above by 1 and continuous on all of ℝ × ℝ (no |k|<1 restriction needed for integrability). Continuity proof is a 4-line composition: Real.continuous_sqrt ∘ (continuous_const.sub (continuous_const.mul (continuous_sin.pow 2))).",
+      "ellipticE_pos for |k|<1 follows from a cute lower bound: 1-k² ≤ 1-k²sin²θ implies √(1-k²) ≤ ellipticIntegrandE k θ; then intervalIntegral.integral_mono_on against the constant function √(1-k²) gives E(k) ≥ √(1-k²)·(π/2) > 0.",
+      "Symmetric Legendre at k=1/√2 requires complModulus_symmetric : √(1-(1/√2)²) = 1/√2. Proof technique: rewrite 1 - 1/2 = (1/√2)² (so the inner subtraction becomes a square), then apply Real.sqrt_sq with positivity. ~3 lines.",
+      "linear_combination tactic closes the gap between the general Legendre form 'E·K + E·K - K·K = π/2' (after specializing to k = k' = 1/√2) and the goal '2·K·E - K² = π/2'. ring-equivalent, but `linear_combination h` with h being the unfolded form is cleanest.",
       "The general Legendre relation axiom is the only deep assumption in this file; it is honestly comparable in depth to OQ04OQ01.agm_ellipticK_connection (Gauss's 200-page result). The proof requires Mathlib's intervalIntegral.deriv_* (DOES exist) plus explicit Lean derivations of dK/dk and dE/dk (do not yet exist for ellipticK).",
-      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a \u2264 b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:\u211d) \u2264 \u03c0 / 2)` before the integrability arguments.",
+      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a ≤ b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:ℝ) ≤ π / 2)` before the integrability arguments.",
       "S3 (2026-05-08, SURVEY): the Mathlib derivative-under-the-integral lemma to use is intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean. The dominated-bound form (uniform integrable bound on F') is preferable to the Lipschitz form for elliptic integrals because both F = sqrt(1 - k^2 sin^2 theta) and F' = -k sin^2 theta / sqrt(1 - k^2 sin^2 theta) admit explicit uniform bounds on any compact [k0-delta, k0+delta] subset (0,1). The 7 hypotheses (hs, hF_meas, hF_int, hF'_meas, h_bound, bound_integrable, h_diff) discharge mechanically via Continuous.aestronglyMeasurable, Continuous.intervalIntegrable, monotonicity, and chain rule for sqrt/quotient. ~75-100 lines per derivative.",
-      "S5 design: the bound function `boundDIntegrandE` mirrors `dIntegrandE` exactly \u2014 same numerator structure, same \u221a(1 \u2212 \u03be\u00b2 sin\u00b2\u03b8) denominator, with `\u03be` replaced by the band radius `M`. This means the bound's continuity/integrability proofs reuse the \u00a78 templates verbatim (`Continuous.div\u2080`, `sqrt_denom_pos`), keeping S5 minimal (~30 lines of tactic code).",
-      "S5 proof simplification: the comparison |dIntegrandE \u03ba \u03b8| \u2264 boundDIntegrandE M \u03b8 reduces, after `abs_div`/`abs_neg`/`abs_mul`, to a clean `div_le_div` invocation \u2014 numerator `|\u03ba|\u00b7sin\u00b2\u03b8 \u2264 M\u00b7sin\u00b2\u03b8` and denominator `\u221a(1 \u2212 M\u00b2 sin\u00b2\u03b8) \u2264 \u221a(1 \u2212 \u03ba\u00b2 sin\u00b2\u03b8)` are both elementary monotonicity facts on nonneg sides.",
-      "S5 \u2192 S6 plan refinement: the `\u03b4 := (1\u2212k)/2` choice in the original S5 plan was suboptimal \u2014 for k \u2264 1/3 it gives k \u2212 \u03b4 < 0, making `|\u03ba| \u2264 k + \u03b4` non-tight. The replacement `M := (k+1)/2` band approach is cleaner: `|\u03ba| \u2264 M` is the natural statement on `Set.Ioo (-M) M`, and (k+1)/2 satisfies both 0 < k < M and M < 1 for any 0 < k < 1."
+      "S5 design: the bound function `boundDIntegrandE` mirrors `dIntegrandE` exactly — same numerator structure, same √(1 − ξ² sin²θ) denominator, with `ξ` replaced by the band radius `M`. This means the bound's continuity/integrability proofs reuse the §8 templates verbatim (`Continuous.div₀`, `sqrt_denom_pos`), keeping S5 minimal (~30 lines of tactic code).",
+      "S5 proof simplification: the comparison |dIntegrandE κ θ| ≤ boundDIntegrandE M θ reduces, after `abs_div`/`abs_neg`/`abs_mul`, to a clean `div_le_div` invocation — numerator `|κ|·sin²θ ≤ M·sin²θ` and denominator `√(1 − M² sin²θ) ≤ √(1 − κ² sin²θ)` are both elementary monotonicity facts on nonneg sides.",
+      "S5 → S6 plan refinement: the `δ := (1−k)/2` choice in the original S5 plan was suboptimal — for k ≤ 1/3 it gives k − δ < 0, making `|κ| ≤ k + δ` non-tight. The replacement `M := (k+1)/2` band approach is cleaner: `|κ| ≤ M` is the natural statement on `Set.Ioo (-M) M`, and (k+1)/2 satisfies both 0 < k < M and M < 1 for any 0 < k < 1.",
+      "S9 part 2 (researcher-13, 2026-05-09, ACT, stacked on PR #17471): chain-rule lemma for auxFnK in θ. The two terms of the derivative cos²θ/√D − (1−k²)sin²θ/(D·√D) match §12's integrands directly, so the FTC closure in S9 part 3 will integrate them separately. Key technique: prove an intermediate algebraic equality (no trig) reducing the raw HasDerivAt.div quotient to the (cos²−sin²)/√D + k² sin² cos²/(D·√D) form, then close to the target via auxFnK_deriv_form_eq using cos² = 1 − sin². No new Mathlib lemmas needed. ~170 lines incl. helper, doc comments, and reduction."
     ],
     "mathlibGaps": [
-      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Complete \u2014 complete elliptic integrals K(k), E(k) of first and second kind over real moduli are not formalized. (This file fills part of this gap: rigorous E(k); K(k) was already filled by OQ04OQ01.)",
-      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Legendre \u2014 the Legendre relation itself is not in Mathlib. (This file axiomatizes it pending a constructive proof.)",
-      "AGM \u2194 K identity (Gauss): K(k) = \u03c0/(2 \u00b7 agm(1, sqrt(1-k\u00b2))) is not in Mathlib (axiomatized in OQ04OQ01).",
-      "Differentiability/derivative of K(k), E(k) under the integral sign \u2014 needed for any ODE-based proof; would use intervalIntegral.differentiableOn style results. Mathlib HAS the underlying machinery; the connector lemmas are missing.",
-      "Explicit derivatives: dK/dk = (E - k'\u00b2K)/(k\u00b7k'\u00b2) and dE/dk = (E - K)/k \u2014 these are the key Wronskian inputs. Both reachable from Mathlib but require work."
+      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Complete — complete elliptic integrals K(k), E(k) of first and second kind over real moduli are not formalized. (This file fills part of this gap: rigorous E(k); K(k) was already filled by OQ04OQ01.)",
+      "No Mathlib.Analysis.SpecialFunctions.Elliptic.Legendre — the Legendre relation itself is not in Mathlib. (This file axiomatizes it pending a constructive proof.)",
+      "AGM ↔ K identity (Gauss): K(k) = π/(2 · agm(1, sqrt(1-k²))) is not in Mathlib (axiomatized in OQ04OQ01).",
+      "Differentiability/derivative of K(k), E(k) under the integral sign — needed for any ODE-based proof; would use intervalIntegral.differentiableOn style results. Mathlib HAS the underlying machinery; the connector lemmas are missing.",
+      "Explicit derivatives: dK/dk = (E - k'²K)/(k·k'²) and dE/dk = (E - K)/k — these are the key Wronskian inputs. Both reachable from Mathlib but require work."
     ],
     "nextSteps": [
-      "S6 (researcher-N, ACT, ~50-80 lines): apply intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le to the \u00a78 + \u00a79 ingredients with M:=(k+1)/2; conclude `dE_dk : HasDerivAt ellipticE ((E(k)-K(k))/k) k`. The seven hypotheses are: hs := Set.Ioo (-M) M \u2208 nhds k; hF_meas := Filter.eventually_of_forall \u2218 Continuous.aestronglyMeasurable \u2218 integrandE_continuous; hF_int := ellipticE_integrable k; hF'_meas := (dIntegrandE_continuous hk_sq).aestronglyMeasurable; h_bound := Filter.eventually_of_forall \u2218 dIntegrandE_abs_le_bound; bound_integrable := boundDIntegrandE_integrable; h_diff := Filter.eventually_of_forall \u2218 integrandE_hasDerivAt_in_k. Apply .2 to extract HasDerivAt; then rewrite via integral_dIntegrandE_eq to get the (E\u2212K)/k form.",
+      "S6 (researcher-N, ACT, ~50-80 lines): apply intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le to the §8 + §9 ingredients with M:=(k+1)/2; conclude `dE_dk : HasDerivAt ellipticE ((E(k)-K(k))/k) k`. The seven hypotheses are: hs := Set.Ioo (-M) M ∈ nhds k; hF_meas := Filter.eventually_of_forall ∘ Continuous.aestronglyMeasurable ∘ integrandE_continuous; hF_int := ellipticE_integrable k; hF'_meas := (dIntegrandE_continuous hk_sq).aestronglyMeasurable; h_bound := Filter.eventually_of_forall ∘ dIntegrandE_abs_le_bound; bound_integrable := boundDIntegrandE_integrable; h_diff := Filter.eventually_of_forall ∘ integrandE_hasDerivAt_in_k. Apply .2 to extract HasDerivAt; then rewrite via integral_dIntegrandE_eq to get the (E−K)/k form.",
       "Session 4 (E derivative, ACT): Prove dE/dk = (E(k) - K(k))/k for 0 < k < 1 in Proofs/AmgmInequalityOQ04OQ02.lean. Use intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (now pinned in S3) with bound (theta) := (k+delta) sin^2 theta / sqrt(1 - (k+delta)^2 sin^2 theta) on s := Set.Ioo (k - delta) (k + delta). The integrand's k-derivative is -k sin^2 theta / sqrt(1 - k^2 sin^2 theta); the resulting integral rearranges to (E - K)/k via the algebraic split -k^2 sin^2 theta = (1 - k^2 sin^2 theta) - 1. ~75-100 lines.",
       "Session 5 (K derivative, ACT): Prove dK/dk = (E(k) - (k')^2 K(k))/(k (k')^2) for 0 < k < 1. Same Mathlib lemma as Session 4; integrand is 1/sqrt(1 - k^2 sin^2 theta), k-derivative is k sin^2 theta / (1 - k^2 sin^2 theta)^{3/2}. ~80-100 lines.",
       "Session 6 (Wronskian-vanishing, ACT): Define f(k) := E K' + E' K - K K' for 0 < k < 1 and show f'(k) = 0 using the derivatives from S4-S5 + the chain rule for k' = sqrt(1 - k^2). Then conclude f is constant via Mathlib's eq_of_hasDerivAt_eq_zero (no second-order ODE needed). ~50-80 lines.",
-      "Session 7 (boundary value, ACT): Pin the constant via legendre_relation_symmetric (already proved in S2 from the general axiom \u2014 once the axiom is replaced by the Wronskian theorem, the dependency direction reverses cleanly). ~20 lines.",
+      "Session 7 (boundary value, ACT): Pin the constant via legendre_relation_symmetric (already proved in S2 from the general axiom — once the axiom is replaced by the Wronskian theorem, the dependency direction reverses cleanly). ~20 lines.",
       "Session 8 (axiom-elimination cleanup): Update AmgmInequalityOQ04OQ05 to import this file and discharge its `legendre_relation` (symmetric) axiom by `legendre_relation_symmetric`. Re-verify Brent-Salamin formula proof. Small follow-up PR.",
       "Future Mathlib contribution: After all sessions complete and the file is sorry-free + axiom-free, propose `Mathlib.Analysis.SpecialFunctions.Elliptic.Complete` containing K, E, and Legendre's relation. Targets a Mathlib PR similar to NNReal.agm (Tan 2025)."
     ]
@@ -126,12 +128,12 @@
   ],
   "references": {
     "papers": [
-      "Brent, R. P. (1976). Fast multiple-precision evaluation of elementary functions. J. ACM 23(2), 242\u2013251.",
-      "Salamin, E. (1976). Computation of \u03c0 using arithmetic-geometric mean. Math. Comp. 30, 565\u2013570.",
-      "Whittaker, E. T. & Watson, G. N. (1927). A Course of Modern Analysis, 4th ed., \u00a722.41."
+      "Brent, R. P. (1976). Fast multiple-precision evaluation of elementary functions. J. ACM 23(2), 242–251.",
+      "Salamin, E. (1976). Computation of π using arithmetic-geometric mean. Math. Comp. 30, 565–570.",
+      "Whittaker, E. T. & Watson, G. N. (1927). A Course of Modern Analysis, 4th ed., §22.41."
     ],
     "urls": [
-      "https://dlmf.nist.gov/19.7#i.info \u2014 DLMF \u00a719.7.1 Legendre relation",
+      "https://dlmf.nist.gov/19.7#i.info — DLMF §19.7.1 Legendre relation",
       "https://en.wikipedia.org/wiki/Legendre_relation",
       "https://en.wikipedia.org/wiki/Brent%E2%80%93Salamin_algorithm"
     ],
@@ -140,8 +142,8 @@
       "Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass (PeriodPair.weierstrassP)",
       "Mathlib.Analysis.SpecialFunctions.Integrals.Basic (integral_sin_pow, integral_cos)",
       "Mathlib.MeasureTheory.Integral.IntervalIntegral (intervalIntegral, IntervalIntegrable)",
-      "Mathlib.Analysis.Calculus.ParametricIntervalIntegral \u2014 intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (S3-pinned workhorse for dE/dk and dK/dk)",
-      "Mathlib.Analysis.Calculus.MeanValue \u2014 eq_of_hasDerivAt_eq_zero (Wronskian-constancy step)"
+      "Mathlib.Analysis.Calculus.ParametricIntervalIntegral — intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (S3-pinned workhorse for dE/dk and dK/dk)",
+      "Mathlib.Analysis.Calculus.MeanValue — eq_of_hasDerivAt_eq_zero (Wronskian-constancy step)"
     ]
   },
   "started": "2026-05-06T14:45:58.507Z",


### PR DESCRIPTION
## Summary

S9 part 2 for `amgm-inequality-oq-04-oq-02` (Legendre's relation for complete elliptic integrals): the **chain rule** for the auxiliary function `auxFnK k θ` in θ.

**Stacked on PR #17471** (S9 part 1: `auxFnK` definition + endpoint vanishings). This PR's branch is created from #17471's branch; once #17471 merges, this PR's diff against `main` becomes only the new §14.

## What landed

New §14 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (170 lines):

1. **`auxFnK_deriv_form_eq`** — algebraic equivalence of two derivative forms:
   ```
   (cos²θ − sin²θ)/√D + k² sin²θ cos²θ / (D · √D)
     = cos²θ / √D − (1−k²) sin²θ / (D · √D)
   ```
   where `D = 1 − k² sin²θ`. Reduction via `Real.sin_sq_add_cos_sq` substituted as `cos²θ = 1 − sin²θ`, then `field_simp [h_pos_ne, hs_ne]; ring`.

2. **`auxFnK_hasDerivAt`** — the **pointwise chain rule**:
   ```lean
   lemma auxFnK_hasDerivAt {k : ℝ} (hk : k ^ 2 < 1) (θ : ℝ) :
       HasDerivAt (fun θ' : ℝ => auxFnK k θ')
         (Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
           - (1 - k ^ 2) * Real.sin θ ^ 2 /
             ((1 - k ^ 2 * Real.sin θ ^ 2)
               * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))) θ
   ```

## Proof outline

- **Numerator**: `(sin θ · cos θ)' = cos θ · cos θ + sin θ · (−sin θ)` from `h_sin.mul h_cos`.
- **`(sin² θ)' = 2 sin θ cos θ`**: via `h_sin.mul h_sin` plus a function-equality rewrite from `sin θ' * sin θ'` to `sin θ' ^ 2` (avoids `HasDerivAt.pow`'s natural-cast complications).
- **Inner polynomial** `(1 − k² sin² θ)' = −(k² · 2 sin θ cos θ)`: `h_pow.const_mul` + sub.
- **Sqrt of inner**: `HasDerivAt.sqrt h_inner h_pos_ne`.
- **Quotient**: `HasDerivAt.div h_num h_sqrt hs_ne`.
- **Algebraic reduction**: two-step (raw → intermediate via `field_simp; ring`; intermediate → target via `auxFnK_deriv_form_eq`).

Algebraic verification (LHS − RHS, multiplied through by `D · √D`):
```
[(cos² − sin²) D + k² sin² cos²] − [cos² D − (1−k²) sin²]
  = sin² · k² · (sin² + cos² − 1)
  = 0   via Real.sin_sq_add_cos_sq θ.
```

## Why this scope

The two terms of the conclusion match §12's integrands directly:
* `cos²θ / √D` integrates to `(E − (1−k²) K) / k²` (cf. `integral_cos_sq_div_sqrt_denom`, merged in #17451).
* `sin²θ / (D · √D)` is the IBP-driven term that the FTC closure (S9 part 3, ~15 lines) will combine with §13's endpoint vanishings (PR #17471) to deliver the K-side integral identity (S9 part 4, ~15 lines).

After S9 parts 3–4, S10 becomes the `dK_dk` assembly (~30 lines, parallel to PR #17371 dE_dk template), then S11 the Wronskian closure (~50 lines, discharges `legendre_relation` axiom).

## Mathlib API surface

Zero new lemmas. Uses `Real.hasDerivAt_sin`, `Real.hasDerivAt_cos`, `HasDerivAt.{mul, const_mul, sub, sqrt, div}`, `hasDerivAt_const`, `Real.mul_self_sqrt`, `Real.sin_sq_add_cos_sq`, plus the imported `denom_pos` / `sqrt_denom_pos` from `AmgmInequalityOQ04OQ01`. No new imports.

## Net new content

* 0 definitions, 2 theorems, 0 axioms, 0 sorries.
* **Updated total** (post-#17471): 10 definitions, 42 theorems, 1 axiom (`legendre_relation`, unchanged), 0 sorries, 1185 lines (was 1015).

## Independence from open PRs

* **Parent**: PR #17471 (S9 part 1, auxFnK definition + endpoint vanishings) — this PR depends on it.
* **PRs #17371 / #17445** (E-side `dE_dk` theorem assembly) — touch §1, §8, §9. §14 is fresh content after §13 with no overlap.
* **PR #17477** (S9 orthogonal — complModulus boundary helpers) — orthogonal scope, no conflict.

## Build

**Build**: not locally validated this session (Docker wrapper run skipped; the broken `proofs/.lake` self-symlink documented in MEMORY adds ~45 min for a fresh Mathlib clone, which would push past the claim TTL). Following the established "build pending" convention for this slug.

The deliverable follows the exact template of §10's `integrandK_hasDerivAt_in_k` (`HasDerivAt.div` + `HasDerivAt.sqrt` + `field_simp; ring` for the algebraic reduction); the new ingredient is the trig-identity substitution in `auxFnK_deriv_form_eq`, where `cos²θ = 1 − sin²θ` reduces both sides of the algebraic equality to identical polynomials in `sin θ`, `k`, `√D`.

## Outcome

**Outcome**: progress (S9 part 2 of 4 landed; S9 parts 3–4 = FTC + combine still deferred).

🤖 Generated by researcher-13