### PR TITLE
fix(meta): sync erdos-526 definitionCount (4 → 5)

### DIFF
--- a/src/data/proofs/erdos-526/meta.json
+++ b/src/data/proofs/erdos-526/meta.json
@@ -73,7 +73,7 @@
     "lineCount": 242,
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Dvoretzky posed this problem in 1956, asking for a characterization of when random arcs on a circle provide complete coverage. Kahane (1959) showed a_n = (1+c)/n covers with probability 1. Erdős (unpublished) proved a_n = 1/n is the critical case: it covers, but a_n = (1-c)/n fails. Shepp (1972) gave the complete answer via the elegant criterion Σ exp(S_n)/n² = ∞, where S_n is the partial sum of arc lengths. The random coverage problem connects to the Poisson process on the circle and to Borel-Cantelli type arguments; the logarithmic threshold a_n ~ 1/n is a one-dimensional analogue of the threshold for covering a d-dimensional cube, where a_n ~ (d log n)/n is required, as proved by Flajolet, Grabner, Kirschenhofer, and Prodinger in 1993.",
@@ -161,7 +161,7 @@
     "lineCount": 242,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos526Problem.lean",
     "sorries": 0
   },
@@ -178,5 +178,5 @@
     }
   ],
   "sorries": 0,
-  "definitionCount": 4
+  "definitionCount": 5
 }


### PR DESCRIPTION
## Fix

Sync stale `definitionCount` for `erdos-526` across all three meta.json blocks (top-level, `meta` sub-object, `leanFile` sub-object).

## Evidence

`proofs/Proofs/Erdos526Problem.lean` defines 5 declarations under the standard counting convention (`def + abbrev + opaque + structure + inductive + class`, with `partial/private/protected/noncomputable/unsafe/scoped` modifiers, excluding `instance`):

1. `def UnitCircle` (line 50)
2. `def Arc` (line 53)
3. `structure ArcSequence` (line 62)
4. `noncomputable def partialSum` (line 75)
5. `def SheppCriterion` (line 83)

All three `definitionCount` fields claimed `4`; corrected to `5`. Other counts (`theoremCount: 2`, `axiomCount: 4`, `lineCount: 242`, `sorries: 0`) verified against the source and unchanged.

**Before**: `definitionCount: 4` (in meta + leanFile + top-level)
**After**:  `definitionCount: 5` (in meta + leanFile + top-level)

Surgical text replacement; no JSON reformat. Validated parseable post-edit.

---
Automated fix by lean-mechanic agent.