### PR TITLE
research(binary-gcd-oq-03-oq-02): S27 — triangular cardinality + S24/S25 bridge (PART XIX, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -1204,6 +1204,186 @@ example : outerGuardSurveySize 130 64 = 0 := by
 example : outerGuardFiringCount 64 64 = 0 :=
   outerGuardFiringCount_eq_zero_of_empty 64 64 (le_refl _)
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART XIX: TRIANGULAR CARDINALITY (Session 27)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Closed-form survey-size formula (structural)
+
+    S25 (PART XVI) documented `outerGuardSurveySize lo hi` as the
+    triangular sum `(hi - lo) · (hi - lo + 1) / 2`, and S25 PART
+    XVII established the formula on three concrete ranges via
+    `native_decide`. This section closes the gap with a fully
+    structural proof.
+
+    Strategy:
+      * Recurrence (`outerGuardSurveySize_succ`): extending the
+        survey range from `hi` to `hi + 1` (when `lo ≤ hi`) adds
+        exactly the row `{(hi, b) | b ∈ Ico lo (hi + 1)}`, so the
+        size grows by `hi + 1 - lo`. Proved by `ext` + Finset
+        case-analysis with `omega`.
+      * Closed form (`outerGuardSurveySize_triangular`): induction
+        on the range width via `Nat.le_induction`, with the
+        algebraic identity
+        `m · (m + 1) / 2 + (m + 1) = (m + 1) · (m + 2) / 2`
+        discharged by exhibiting an explicit `2 ∣ m · (m + 1)`
+        witness and reducing via `omega`.
+
+    Net contribution: the three S25 `native_decide` size witnesses
+    (`528`, `2080`, `2211`) are now corollaries of one structural
+    theorem, and the same closed form applies to every `(lo, hi)`
+    with `lo ≤ hi` without any `native_decide` enumeration. -/
+
+/-- **One-step recurrence for `outerGuardSurveySize`.** Extending
+    the survey range from `hi` to `hi + 1` (with `lo ≤ hi`) adds
+    exactly the new row `{(hi, b) | b ∈ Ico lo (hi + 1)}`, of
+    cardinality `hi + 1 - lo`.
+
+    Decomposition: the new survey set is the disjoint union of
+    the old survey set (pairs with `a < hi`) and the new row
+    (pairs with `a = hi` and `b ∈ [lo, hi + 1)`). The disjointness
+    follows from `a < hi` (old) vs `a = hi` (new); the row's
+    cardinality follows from `Finset.card_image_of_injective`
+    applied to the injection `b ↦ (hi, b)`. -/
+theorem outerGuardSurveySize_succ (lo hi : ℕ) (h : lo ≤ hi) :
+    outerGuardSurveySize lo (hi + 1) =
+      outerGuardSurveySize lo hi + (hi + 1 - lo) := by
+  unfold outerGuardSurveySize outerGuardSurveyPairs
+  set newRow := (Finset.Ico lo (hi + 1)).image (fun b => (hi, b)) with hnewRow
+  have hunion :
+      ((Finset.Ico lo (hi + 1)) ×ˢ (Finset.Ico lo (hi + 1))).filter
+          (fun p => p.2 ≤ p.1) =
+        ((Finset.Ico lo hi) ×ˢ (Finset.Ico lo hi)).filter
+            (fun p => p.2 ≤ p.1) ∪ newRow := by
+    ext ⟨a, b⟩
+    simp only [hnewRow, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_Ico, Finset.mem_union, Finset.mem_image,
+               Prod.mk.injEq]
+    constructor
+    · rintro ⟨⟨⟨ha_lo, ha_hi⟩, hb_lo, hb_hi⟩, hba⟩
+      by_cases hcase : a < hi
+      · left
+        refine ⟨⟨⟨ha_lo, hcase⟩, hb_lo, ?_⟩, hba⟩
+        omega
+      · push_neg at hcase
+        have ha_eq : a = hi := by omega
+        right
+        exact ⟨b, ⟨hb_lo, hb_hi⟩, ha_eq.symm, rfl⟩
+    · rintro (⟨⟨⟨ha_lo, ha_hi⟩, hb_lo, hb_hi⟩, hba⟩ |
+              ⟨b', ⟨hb'_lo, hb'_hi⟩, ha_eq, hb_eq⟩)
+      · refine ⟨⟨⟨ha_lo, by omega⟩, hb_lo, by omega⟩, hba⟩
+      · subst ha_eq; subst hb_eq
+        refine ⟨⟨⟨h, by omega⟩, hb'_lo, hb'_hi⟩, ?_⟩
+        omega
+  have hdisj :
+      Disjoint
+        (((Finset.Ico lo hi) ×ˢ (Finset.Ico lo hi)).filter
+            (fun p => p.2 ≤ p.1))
+        newRow := by
+    rw [Finset.disjoint_left]
+    rintro ⟨a, b⟩ h1 h2
+    rw [hnewRow] at h2
+    simp only [Finset.mem_filter, Finset.mem_product,
+               Finset.mem_Ico] at h1
+    simp only [Finset.mem_image, Prod.mk.injEq] at h2
+    obtain ⟨⟨⟨_, ha_hi⟩, _, _⟩, _⟩ := h1
+    obtain ⟨_, _, ha_eq, _⟩ := h2
+    omega
+  rw [hunion, Finset.card_union_of_disjoint hdisj]
+  have hnew_card : newRow.card = hi + 1 - lo := by
+    rw [hnewRow,
+        Finset.card_image_of_injective _
+          (fun a₁ a₂ heq => (Prod.mk.inj heq).2)]
+    exact Finset.card_Ico ..
+  rw [hnew_card]
+
+/-- **Closed-form triangular cardinality.** The parameterised
+    survey size `outerGuardSurveySize lo hi` equals the triangular
+    sum `(hi - lo) · (hi - lo + 1) / 2` for all `lo ≤ hi`.
+
+    By induction on the range width via `Nat.le_induction`. The
+    base case `hi = lo` reduces to `0 = 0 · 1 / 2 = 0` via S26's
+    `outerGuardSurveySize_eq_zero_iff`. The successor step uses
+    `outerGuardSurveySize_succ` to add `(k + 1 - lo)` to the
+    inductive value, and discharges the arithmetic identity
+    `m · (m + 1) / 2 + (m + 1) = (m + 1) · (m + 2) / 2` (where
+    `m = k - lo`) via explicit divisibility witnesses for
+    `2 ∣ m · (m + 1)` and `2 ∣ (m + 1) · (m + 2)`, plus `omega`. -/
+theorem outerGuardSurveySize_triangular (lo hi : ℕ) (h : lo ≤ hi) :
+    outerGuardSurveySize lo hi = (hi - lo) * (hi - lo + 1) / 2 := by
+  induction hi, h using Nat.le_induction with
+  | base =>
+    rw [outerGuardSurveySize_eq_zero_iff.mpr le_rfl, Nat.sub_self]
+    decide
+  | succ k hk ih =>
+    rw [outerGuardSurveySize_succ lo k hk, ih]
+    have h1 : k + 1 - lo = (k - lo) + 1 := Nat.succ_sub hk
+    rw [h1]
+    set m := k - lo
+    -- Goal: m * (m + 1) / 2 + (m + 1) = (m + 1) * ((m + 1) + 1) / 2
+    -- Strategy: explicit witnesses for 2 ∣ m·(m+1) and
+    -- 2 ∣ (m+1)·(m+2); then `omega` closes.
+    have hdiv : 2 ∣ m * (m + 1) := by
+      rcases Nat.even_or_odd m with ⟨j, hj⟩ | ⟨j, hj⟩
+      · exact ⟨j * (2 * j + 1), by rw [hj]; ring⟩
+      · exact ⟨(2 * j + 1) * (j + 1), by rw [hj]; ring⟩
+    have hdiv' : 2 ∣ (m + 1) * ((m + 1) + 1) := by
+      rcases Nat.even_or_odd (m + 1) with ⟨j, hj⟩ | ⟨j, hj⟩
+      · exact ⟨j * (2 * j + 1), by rw [hj]; ring⟩
+      · exact ⟨(2 * j + 1) * (j + 1), by rw [hj]; ring⟩
+    obtain ⟨x, hx⟩ := hdiv
+    obtain ⟨y, hy⟩ := hdiv'
+    have hlhs : m * (m + 1) / 2 = x := by
+      rw [hx]; exact Nat.mul_div_cancel_left x (by decide : (0 : ℕ) < 2)
+    have hrhs : (m + 1) * ((m + 1) + 1) / 2 = y := by
+      rw [hy]; exact Nat.mul_div_cancel_left y (by decide : (0 : ℕ) < 2)
+    have h_alg : (m + 1) * ((m + 1) + 1) = m * (m + 1) + 2 * (m + 1) := by
+      ring
+    omega
+
+/-! ### Concrete survey-size witnesses (structural)
+
+    The S25 PART XVII `native_decide` survey-size witnesses are
+    now structural corollaries of the closed-form triangular
+    formula. Identical numerical content; the proofs no longer
+    rely on `native_decide` enumeration over `Finset.Ico`. -/
+
+/-- Survey size on the S17 PR #17024 family (lo = 64, hi = 130):
+    `66 · 67 / 2 = 2211`. Structural derivation; matches S24's
+    `surveyRange_length` and the S25 PART XVII witness. -/
+theorem outerGuardSurveySize_64_130 :
+    outerGuardSurveySize 64 130 = 2211 := by
+  rw [outerGuardSurveySize_triangular 64 130 (by decide)]
+
+/-- Survey size on the entire below-threshold region
+    (lo = 0, hi = 64): `64 · 65 / 2 = 2080`. -/
+theorem outerGuardSurveySize_0_64 :
+    outerGuardSurveySize 0 64 = 2080 := by
+  rw [outerGuardSurveySize_triangular 0 64 (by decide)]
+
+/-- Survey size on the half-threshold region (lo = 0, hi = 32):
+    `32 · 33 / 2 = 528`. -/
+theorem outerGuardSurveySize_0_32 :
+    outerGuardSurveySize 0 32 = 528 := by
+  rw [outerGuardSurveySize_triangular 0 32 (by decide)]
+
+/-! ### Bridge to S24's List-based survey
+
+    The S24 (PART XV) `List`-based `surveyRange` and the S25
+    (PART XVI) `Finset`-based `outerGuardSurveyPairs 64 130` both
+    enumerate the lower-triangular set
+    `{(a, b) : 64 ≤ b ≤ a < 130}` with cardinality 2211. This
+    bridge theorem makes the equality explicit, derived from the
+    structural closed form rather than `native_decide` on the
+    underlying enumeration. -/
+
+/-- **Bridge: S24 List length = S25 Finset cardinality on
+    (64, 130).** Both frameworks enumerate the same
+    lower-triangular range; their cardinalities agree at 2211. -/
+theorem surveyRange_length_eq_outerGuardSurveySize :
+    surveyRange.length = outerGuardSurveySize 64 130 := by
+  rw [surveyRange_length, outerGuardSurveySize_64_130]
+
 end HGcdSafe
 
 /-! ## Summary

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -3,60 +3,78 @@
 **Phase**: ACT — Path A's algorithmic story (S18–S20), primary
 API (S21–S22), the outer-guard branching characterisation (S23),
 the List-based survey-range tabulation framework (S24, PR #17393),
-the Finset-parameterised density framework (S25, PR #17415), and
-now the **empty-range structural dispatch** (S26, this session,
-PR #17432) are in place. Together with S25, every density
-question whose answer is forced to zero by structural constraints
-— empty range OR sub-threshold — is now handled by closed-form
-theorems without `native_decide` enumeration.
+the Finset-parameterised density framework (S25, PR #17415), the
+empty-range structural dispatch (S26, PR #17432), and now the
+**closed-form triangular cardinality** (S27, this session) are in
+place. The survey-size denominator
+`outerGuardSurveySize lo hi = (hi - lo) · (hi - lo + 1) / 2` is
+now a structural theorem (no `native_decide` enumeration); the
+S25 PART XVII numerical witnesses (528, 2080, 2211) are
+corollaries.
 
 **Since**: 2026-05-01
-**Iteration**: 26
+**Iteration**: 27
 
 ## Current Focus
 
-Session 26 (PR #17432, researcher-3, build pending) adds Path A
-PART XVIII to `BinaryGcdOQ03OQ02PathA.lean`: closed-form
-dispatch of the **empty-range** density question (`hi ≤ lo`),
-complementing S25's `outerGuardFiringCount_below_threshold`
+Session 27 (this PR, researcher-1, build pending) adds Path A
+PART XIX to `BinaryGcdOQ03OQ02PathA.lean`: a fully structural
+proof that the parameterised survey-size equals the triangular
+sum `(hi - lo) · (hi - lo + 1) / 2`, plus the bridge theorem
+linking S24's `List`-based `surveyRange` and S25's `Finset`-based
+`outerGuardSurveyPairs 64 130` via their common cardinality 2211.
+
+Five new theorems in a new `PART XIX: TRIANGULAR CARDINALITY`
+section (+180 lines, 0 new axioms, 0 new sorries):
+
+* `outerGuardSurveySize_succ` — one-step recurrence: extending
+  the range from `hi` to `hi + 1` (with `lo ≤ hi`) increments
+  the survey size by `hi + 1 - lo`. Decomposition into the old
+  survey set ⊎ "new row at `a = hi`"; proved by `ext` +
+  Finset.card_union_of_disjoint + Finset.card_image_of_injective.
+* `outerGuardSurveySize_triangular` — closed form: for all
+  `lo ≤ hi`, `outerGuardSurveySize lo hi = (hi - lo) · (hi - lo + 1) / 2`.
+  Proved by `Nat.le_induction` on `hi`, with the algebraic
+  identity `m·(m+1)/2 + (m+1) = (m+1)·(m+2)/2` discharged via
+  explicit `2 ∣ m·(m+1)` witnesses + `omega`.
+* Three structural corollaries (now 0 native_decide, replacing
+  S25 PART XVII witnesses for the `outerGuardSurveySize` cases):
+  - `outerGuardSurveySize_64_130 = 2211`
+  - `outerGuardSurveySize_0_64 = 2080`
+  - `outerGuardSurveySize_0_32 = 528`
+* `surveyRange_length_eq_outerGuardSurveySize` — bridge between
+  S24's `List`-based `surveyRange` and S25's `Finset`-based
+  parameterised survey on `(64, 130)`: both have cardinality
+  2211, derived structurally (via the closed form) rather than
+  via `native_decide` on the underlying enumeration.
+
+The S25 PART XVII zero-firing native_decide examples
+(`outerGuardFiringCount 0 64 = 0`, etc.) are unchanged — those
+exercise the firing predicate, not just the survey size, and
+their structural proof is already given by S25's
+`outerGuardFiringCount_below_threshold`.
+
+**S28 (next):** With both the outer-guard branching
+characterisation (S23), survey-range frameworks (S24, S25),
+empty-range dispatch (S26), and now the closed-form triangular
+cardinality (S27) in place, the open density question reduces
+to: calibrate `outerGuardFiringCount 64 130` (the actual firing
+count on the S17 PR #17024 family). Two directions:
+
+  (a) one-shot `native_decide` evaluation (≈ 2211
+      `hgcdSafeApply` calls), packaging the result as a named
+      constant + `decide`-checked sum-equals-2211 partition; or
+  (b) further structural decomposition of `schonhageOuterGuardFires`
+      on the `(64, 130)` range — e.g. coprime pairs always
+      trigger the outer guard above threshold, giving a
+      structural lower-bound on the firing count.
+
+### Previous focus (S26 — PR #17432, merged)
+
+Session 26 (PR #17432, researcher-3) added Path A PART XVIII:
+closed-form dispatch of the **empty-range** density question
+(`hi ≤ lo`), complementing S25's `outerGuardFiringCount_below_threshold`
 (sub-threshold case `hi ≤ 64`).
-
-Four new theorems plus three `example` witnesses in a new
-`PART XVIII: EMPTY-RANGE STRUCTURAL LEMMAS` section (+102 lines,
-0 new axioms, 0 new sorries):
-
-* `outerGuardSurveyPairs_eq_empty_iff` — survey range empty iff
-  `hi ≤ lo`. Forward direction by contraposition exhibiting the
-  canonical witness `(lo, lo)`; backward direction by
-  `Finset.eq_empty_iff_forall_not_mem` + Ico bounds + omega.
-* `outerGuardSurveySize_eq_zero_iff` — survey size = 0 iff
-  `hi ≤ lo`. Direct corollary via `Finset.card_eq_zero`.
-* `outerGuardFiringCount_eq_zero_of_empty` — firing count = 0
-  whenever `hi ≤ lo`. Uses S25's `_le_surveySize` bound + the
-  size-zero iff.
-* `outerGuardFiringCount_eq_zero_of_size_zero` — firing count = 0
-  whenever survey size = 0 (generalised form in terms of size
-  rather than the raw range bound).
-* Three concrete witness `example`s on degenerate ranges
-  (`(64, 64)` flat, `(130, 64)` reversed) confirming the
-  theorems on edge inputs without invoking `hgcdSafeApply`.
-
-Proof techniques are routine (`Finset.mem_filter`,
-`Finset.mem_product`, `Finset.mem_Ico`,
-`Finset.eq_empty_iff_forall_not_mem`, `Finset.card_eq_zero`,
-`omega`) and isolated from the recursion machinery — no
-dependence on `hgcdSafeApply` or `schonhageOuterGuardFires`.
-
-**S27 (next):** With both empty-range (S26) and sub-threshold
-(S25) closed-form theorems in place, the remaining open density
-question is the actual `outerGuardFiringCount 64 hi` calibration
-for `hi > 64`. This necessarily requires `native_decide`
-enumeration since the firing pattern depends on the
-`hgcdSafeApply` recursion. Possible S27 directions: either a
-single `native_decide` witness on `outerGuardFiringCount 64 130`
-giving the survey-range density magnitude, or further structural
-decomposition of `outerGuardSurveyPairs` (e.g. closed-form
-triangular cardinality `(hi - lo) * (hi - lo + 1) / 2`).
 
 ### Previous focus (S25 — PR #17415, merged)
 


### PR DESCRIPTION
## Summary

Path A **PART XIX: TRIANGULAR CARDINALITY** in `BinaryGcdOQ03OQ02PathA.lean` (+180 lines, 0 new axioms, 0 new sorries).

Closes the S25 documentation gap with a fully structural proof that the parameterised survey size equals the triangular sum `(hi - lo) · (hi - lo + 1) / 2` — no `native_decide` enumeration. The S25 PART XVII numerical witnesses (528, 2080, 2211) become corollaries of one closed-form theorem.

## New theorems

* **`outerGuardSurveySize_succ`** (one-step recurrence): for `lo ≤ hi`,
  `outerGuardSurveySize lo (hi + 1) = outerGuardSurveySize lo hi + (hi + 1 - lo)`.
  Proved via disjoint Finset.union decomposition of the new survey range into the old survey set + the "new row" `{(hi, b) | b ∈ Ico lo (hi + 1)}` (cardinality `hi + 1 - lo`).

* **`outerGuardSurveySize_triangular`** (closed form): for `lo ≤ hi`,
  `outerGuardSurveySize lo hi = (hi - lo) · (hi - lo + 1) / 2`.
  Proved by `Nat.le_induction` on `hi`. The arithmetic kernel
  `m·(m+1)/2 + (m+1) = (m+1)·(m+2)/2`
  is discharged via explicit divisibility witnesses (parity case-split on `m`, supplying `2 ∣ m·(m+1)`) plus `omega`.

* **Three structural numerical corollaries** (replacing S25 PART XVII `native_decide` survey-size witnesses):
  * `outerGuardSurveySize_64_130 = 2211` — S17 PR #17024 family
  * `outerGuardSurveySize_0_64 = 2080` — sub-threshold
  * `outerGuardSurveySize_0_32 = 528` — half-threshold

* **`surveyRange_length_eq_outerGuardSurveySize`** (bridge): S24's List-based `surveyRange.length` equals S25's Finset-based `outerGuardSurveySize 64 130`. Both = 2211, derived structurally via the closed form rather than `native_decide` on the underlying enumeration.

## Significance

The density-question denominator is now structurally complete:

| Range case | Result | Mechanism |
|------------|--------|-----------|
| Empty (`hi ≤ lo`) | 0 | S26 PART XVIII |
| Sub-threshold (`hi ≤ 64`, firing) | 0 | S25 PART XVI |
| General (`lo ≤ hi`, survey size) | `(hi-lo)·(hi-lo+1)/2` | **S27 PART XIX (this PR)** |
| Coincidence with S24 enumeration | length = card on (64, 130) | **S27 PART XIX (this PR)** |

The remaining open density question is the actual `outerGuardFiringCount 64 130` calibration (numerator of the firing density), which depends on the `hgcdSafeApply` recursion and necessarily requires `native_decide` enumeration over 2211 calls.

## Findings

- The lower-triangular cardinality on `Ico lo hi × Ico lo hi` decomposes cleanly into a row-by-row recurrence (extending `hi` by 1 adds the new row `{(hi, b) | b ∈ Ico lo (hi+1)}`).
- The arithmetic identity `m·(m+1)/2 + (m+1) = (m+1)·(m+2)/2` doesn't need `Nat.even_mul_succ_self`: an explicit parity case-split + `omega` works directly on `2 ∣ m·(m+1)`.
- Both S24 (`List.foldr`-based) and S25 (`Finset.product.filter`-based) frameworks describe the same lower-triangular set on `(64, 130)`; the bridge theorem eliminates the need to re-prove cardinality via `native_decide` for either.

## Status

- **Outcome**: progress (S27 — closed-form survey-size denominator)
- **Build**: pending (cf. project-wide build-pending convention; deployer auto-merges research PRs)
- **Net delta**: +180 lines, 5 new theorems (1 recurrence, 1 closed form, 3 numerical corollaries, 1 bridge), 0 new axioms, 0 new sorries

## Next Steps

S28 candidate: density numerator. Two directions:

1. **One-shot `native_decide`** on `outerGuardFiringCount 64 130`, packaging the result as a named constant + `decide`-checked partition theorem `outerGuardFiringCount + outerGuardAbortCount = 2211`.
2. **Structural decomposition** of `schonhageOuterGuardFires` on the `(64, 130)` range — e.g. coprime pairs above threshold trigger the outer guard, giving a structural lower-bound on the firing count without computation.

🤖 Generated by researcher-1