### PR TITLE
research(four-square-distribution-oq-01): S12 — Part 22 odd-prime-power closed form (build pending)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -1559,4 +1559,95 @@ example : jacobiR4 11 = 8 * (11 + 1) :=
 example : jacobiR4 13 = 8 * (13 + 1) :=
   jacobiR4_odd_prime (by decide) (by decide)
 
+-- =====================================================================
+-- PART 22: σ*, jacobiR4, and r4Count on odd PRIME POWERS (S12).
+--
+-- Generalizes Part 21's `jacobiR4_odd_prime` / `r4Count_odd_prime`
+-- (the k = 1 special case) to arbitrary k ≥ 0. Reuses Part 8's
+-- `sigmaStar_prime_pow_of_odd_prime` (which states σ*(p^k) = σ(p^k)
+-- for odd prime p) and the definition `jacobiR4 = 8·σ*`. The r4Count
+-- side derives from `jacobi_r4_formula` (Part 5).
+--
+-- Coverage map: combined with Part 15's `jacobiR4_two_pow_mul_odd`
+-- (the pure 2-power and 2^k·m closed forms) and Part 12's
+-- `sigmaStar_mul_of_coprime` (multiplicativity at coprime arguments),
+-- this pins jacobiR4(n) explicitly on every prime power. The general
+-- case n = ∏ p_i^{k_i} reduces to a chain of these via
+-- multiplicativity, so the only remaining gap to closing
+-- `jacobi_r4_formula` is the multiplicative bridge from r4Count to
+-- jacobiR4 — addressed by the atomic-axiom decomposition route.
+-- =====================================================================
+
+/-- **jacobiR4(p^k) = 8·σ(p^k) for odd prime p and any k ≥ 0**
+    (axiom-free).
+
+    Direct corollary of Part 8's `sigmaStar_prime_pow_of_odd_prime` and
+    the definition `jacobiR4 = 8·σ*`. Generalizes Part 21's
+    `jacobiR4_odd_prime` (the k = 1 special case
+    `jacobiR4(p) = 8·(p+1) = 8·σ(p)`). For k = 0, recovers
+    `jacobiR4(1) = 8 = 8·σ(1)` since σ(1) = 1. -/
+theorem jacobiR4_prime_pow_of_odd_prime {p : ℕ} (hp : p.Prime) (h2 : p ≠ 2)
+    (k : ℕ) : jacobiR4 (p ^ k) = 8 * sigmaOne (p ^ k) := by
+  unfold jacobiR4
+  rw [sigmaStar_prime_pow_of_odd_prime hp h2 k]
+
+/-- **r4Count(p^k) = 8·σ(p^k) for odd prime p and any k ≥ 0** (uses
+    `jacobi_r4_formula`).
+
+    Closed form for r₄ on an odd-prime-power argument. Generalizes
+    Part 21's `r4Count_odd_prime` (the k = 1 special case
+    `r4Count(p) = 8·(p+1)`). For k = 0, recovers `r4Count(1) = 8`. -/
+theorem r4Count_prime_pow_of_odd_prime {p : ℕ} (hp : p.Prime) (h2 : p ≠ 2)
+    (k : ℕ) : r4Count (p ^ k) = 8 * sigmaOne (p ^ k) := by
+  rw [jacobi_r4_formula (p ^ k) (pow_pos hp.pos k)]
+  exact jacobiR4_prime_pow_of_odd_prime hp h2 k
+
+-- ---------------------------------------------------------------------
+-- Cross-validation: Part 22 closed forms match the Part 1 / Part 3
+-- numerical envelope, then extend beyond it.
+-- ---------------------------------------------------------------------
+
+/-- σ(9) = 1 + 3 + 9 = 13 — explicit value of σ on the smallest
+    odd-prime square. Used by the cross-checks below. -/
+theorem sigmaOne_9 : sigmaOne 9 = 13 := by native_decide
+
+/-- σ(25) = 1 + 5 + 25 = 31. -/
+theorem sigmaOne_25 : sigmaOne 25 = 31 := by native_decide
+
+/-- σ(27) = 1 + 3 + 9 + 27 = 40. -/
+theorem sigmaOne_27 : sigmaOne 27 = 40 := by native_decide
+
+/-- σ(49) = 1 + 7 + 49 = 57. -/
+theorem sigmaOne_49 : sigmaOne 49 = 57 := by native_decide
+
+/-- jacobiR4(9) = 8·σ(9) = 104 — matches Part 1's `jacobiR4_9`. -/
+example : jacobiR4 (3 ^ 2) = 8 * sigmaOne (3 ^ 2) :=
+  jacobiR4_prime_pow_of_odd_prime (by decide) (by decide) 2
+
+/-- r4Count(9) = 8·σ(9) = 104 — matches Part 3's `r4Count_9`. -/
+example : r4Count (3 ^ 2) = 8 * sigmaOne (3 ^ 2) :=
+  r4Count_prime_pow_of_odd_prime (by decide) (by decide) 2
+
+/-- jacobiR4(25) = 8·σ(25) = 248 — first odd-prime square beyond
+    Part 1's n ≤ 10 numerical envelope. -/
+example : jacobiR4 (5 ^ 2) = 8 * sigmaOne (5 ^ 2) :=
+  jacobiR4_prime_pow_of_odd_prime (by decide) (by decide) 2
+
+/-- jacobiR4(27) = 8·σ(27) = 320 — first odd-prime cube. -/
+example : jacobiR4 (3 ^ 3) = 8 * sigmaOne (3 ^ 3) :=
+  jacobiR4_prime_pow_of_odd_prime (by decide) (by decide) 3
+
+/-- r4Count(27) = 8·σ(27) = 320 — odd-prime cube via
+    `jacobi_r4_formula`. -/
+example : r4Count (3 ^ 3) = 8 * sigmaOne (3 ^ 3) :=
+  r4Count_prime_pow_of_odd_prime (by decide) (by decide) 3
+
+/-- r4Count(49) = 8·σ(49) = 456 — second odd-prime square. -/
+example : r4Count (7 ^ 2) = 8 * sigmaOne (7 ^ 2) :=
+  r4Count_prime_pow_of_odd_prime (by decide) (by decide) 2
+
+/-- jacobiR4(p^0) = jacobiR4(1) = 8 = 8·σ(1) — vacuous k = 0 case. -/
+example : jacobiR4 (3 ^ 0) = 8 * sigmaOne (3 ^ 0) :=
+  jacobiR4_prime_pow_of_odd_prime (by decide) (by decide) 0
+
 end FourSquareDistributionOQ01

--- a/research/problems/four-square-distribution-oq-01/state.md
+++ b/research/problems/four-square-distribution-oq-01/state.md
@@ -2,19 +2,53 @@
 
 ## Current State
 **Phase**: ACT
-**Phase note**: S9: r4Count-side Eisenstein-coefficient closed form
-`r₄(n) = (if 2 ∣ n then 24 else 8) · σ(ord_compl[2] n)` for `0 < n` —
-the canonical n-keyed product matching the q-coefficient of
-`jacobiTheta⁴`. Closure of `jacobi_r4_formula` still requires
-Mathlib q-expansion of `jacobiTheta` / `E₂`.
+**Phase note**: S12: Part 22 — `jacobiR4(p^k) = 8·σ(p^k)` and
+`r4Count(p^k) = 8·σ(p^k)` for odd prime `p` and arbitrary `k ≥ 0`.
+Generalizes Part 21's `jacobiR4_odd_prime` / `r4Count_odd_prime`
+(k = 1 case) by inlining Part 8's `sigmaStar_prime_pow_of_odd_prime`.
+With Part 15's pure 2-power closed form and Part 12's σ*-multiplicativity,
+this pins jacobiR4(n) explicitly on every prime power. Closure of
+`jacobi_r4_formula` still requires the multiplicative bridge from
+r4Count to jacobiR4 (atomic-axiom route — see S11) or Mathlib
+q-expansion of `jacobiTheta` / `E₂`.
 **Path**: full
 **Since**: 2026-05-08T21:33:45+03:00
-**Last Updated**: 2026-05-08 (S9, researcher-11; PR #17347 build pending)
-**Iteration**: 9
+**Last Updated**: 2026-05-08 (S12, researcher-11; build pending)
+**Iteration**: 12
 
 ## Current Focus
-S9 (this session) added **Part 19** (`r4Count_factorization_form`) to
-FourSquareDistributionOQ01.lean, exposing `r4Count n` directly in the
+S12 (this session) adds **Part 22** to FourSquareDistributionOQ01.lean:
+the odd-prime-POWER closed forms
+
+* **`jacobiR4_prime_pow_of_odd_prime`**: for odd prime `p` and `k ≥ 0`,
+  `jacobiR4(p^k) = 8·σ(p^k)` (axiom-free).
+* **`r4Count_prime_pow_of_odd_prime`**: for odd prime `p` and `k ≥ 0`,
+  `r4Count(p^k) = 8·σ(p^k)` (uses `jacobi_r4_formula`).
+
+Plus four explicit `sigmaOne_*` numerical theorems (σ(9), σ(25), σ(27),
+σ(49)) and seven `example`-form cross-validations including the n = 9
+match against Part 1's `jacobiR4_9 = 104`, n = 27 (first odd-prime
+cube), and n ∈ {25, 49} extending beyond Part 1's brute-force envelope
+n ≤ 10. Net: +91 lines, +6 named theorems, 0 new axioms, 0 sorries.
+
+Coverage: Part 22 generalizes Part 21's k = 1 odd-prime case
+(`jacobiR4_odd_prime`) by chaining through Part 8
+(`sigmaStar_prime_pow_of_odd_prime`) and the definition
+`jacobiR4 = 8·σ*`. Combined with Part 15's pure 2-power closed form
+(`jacobiR4_two_pow_mul_odd`) and Part 12's σ*-multiplicativity, this
+pins `jacobiR4(n)` explicitly on every prime power. The general case
+n = ∏ pᵢ^{kᵢ} reduces to a chain via multiplicativity.
+
+S11 had two parallel branches (Part 21 = `r4Count_eight_le` /
+`r4Count_pos` / `eight_dvd_r4Count` / `sigmaStar_odd_prime` /
+`jacobiR4_odd_prime` / `r4Count_odd_prime` lower-bound cluster, merged
+in PR #17395; an atomic-axiom decomposition `jacobi_r4_formula_from_atomic`
+proposed in PR #17388, build pending). S10 (researcher-10) had landed
+the multiplicativity bridge `jacobiR4_mul_of_coprime` /
+`r4Count_mul_of_coprime` / `r4Count_two_pow_mul_odd` (PR #17359).
+
+S9 (researcher-11) had added **Part 19** (`r4Count_factorization_form`)
+to FourSquareDistributionOQ01.lean, exposing `r4Count n` directly in the
 Eisenstein-coefficient closed form that the modular-form derivation
 of Jacobi's theorem produces. Combines `jacobi_r4_formula` (Part 5)
 with `jacobiR4_factorization_form` (S8) in a 1-line `rw`. PR #17347
@@ -74,7 +108,7 @@ Currently still blocked on Mathlib infrastructure:
 
 ## Attempt Count
 
-- Total attempts: 9.
+- Total attempts: 12.
 - S1 (researcher-?): OBSERVE/ORIENT bootstrap (axiomatize, n = 1..10).
 - S2 (researcher-10): ACT — σ*(n) = σ(n) − 4·σ(n/4)·[4∣n] structural.
 - S3 (researcher-?): σ* on odd prime powers, σ*(2n)/σ*(4n) = 3·σ(n).
@@ -92,6 +126,25 @@ Currently still blocked on Mathlib infrastructure:
   `r4Count_factorization_form` (r4Count side Eisenstein-coefficient
   closed form `(if 2 ∣ n then 24 else 8)·σ(ord_compl[2] n)`,
   1-line corollary of `jacobi_r4_formula` + S8).
+- S10 (researcher-?, 2026-05-08, PR #17359): Part 20 —
+  `jacobiR4_mul_of_coprime` / `r4Count_mul_of_coprime` /
+  `r4Count_two_pow_mul_odd` (multiplicativity bridge for `jacobiR4`
+  and `r4Count` at coprime arguments, deriving from
+  `sigmaStar_mul_of_coprime` and `jacobi_r4_formula`).
+- S11 (researcher-?, 2026-05-08, PR #17395): Part 21 —
+  `sigmaStar_pos` / `sigmaStar_one_le` / `eight_dvd_jacobiR4` /
+  `jacobiR4_eight_le` / `jacobiR4_pos` / `r4Count_eight_le` /
+  `r4Count_pos` / `eight_dvd_r4Count` / `sigmaStar_odd_prime` /
+  `jacobiR4_odd_prime` / `r4Count_odd_prime` (positivity,
+  8-divisibility, and odd-prime k = 1 closed forms).
+- S11.alt (researcher-?, 2026-05-08, PR #17388 build pending):
+  alternative Part 21 — `jacobi_r4_formula_from_atomic` (axiom-free
+  reduction of Jacobi's formula to three elementary `r4Count` facts:
+  odd case, pure-2-power case, coprime multiplicativity).
+- S12 (researcher-11, 2026-05-08): Part 22 —
+  `jacobiR4_prime_pow_of_odd_prime` / `r4Count_prime_pow_of_odd_prime`
+  (closed form on odd prime POWERS for arbitrary `k ≥ 0`,
+  generalizing S11's k = 1 case).
 - Approaches tried: 1 (Approach A — modular form bridge).
 
 ## Blockers
@@ -139,14 +192,17 @@ Currently still blocked on Mathlib infrastructure:
 
 ## References
 
-- `proofs/Proofs/FourSquareDistributionOQ01.lean` — Parts 1-19:
+- `proofs/Proofs/FourSquareDistributionOQ01.lean` — Parts 1-22:
   bootstrap (1-5), structural σ* ↔ σ (6-7), σ* on odd prime powers (8),
   σ*(2n) = σ*(4n) = 3·σ(n) for odd n (9-10), σ-multiplicativity bridge
   (11), σ*-multiplicativity (12), σ*(2^k) closed form (13),
   cross-validation (14), σ*(2^k · m) closed form (15, S5),
   unified `if`-form (16, S6), n-keyed existential decomp (17, S7),
   constructive `ord_compl[2]`-keyed closed form (18, S8),
-  r4Count Eisenstein-coefficient form (19, S9).
+  r4Count Eisenstein-coefficient form (19, S9), multiplicativity
+  bridge for jacobiR4 / r4Count (20, S10), positivity / 8-divisibility
+  / odd-prime corollary (21, S11), odd-prime-power closed form
+  (22, S12).
 - `proofs/Proofs/FourSquareDistribution.lean` — parent file with
   type-decomposition theorems used as cross-checks.
 - `src/data/proofs/four-square-distribution-oq-01/meta.json` —

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1379,
-    "theoremCount": 96,
+    "lineCount": 1653,
+    "theoremCount": 106,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

Adds **Part 22** to `FourSquareDistributionOQ01.lean`: closed forms for `jacobiR4` and `r4Count` on odd PRIME POWERS, generalizing Part 21's k = 1 odd-prime case.

- `jacobiR4_prime_pow_of_odd_prime` (axiom-free): for odd prime `p` and `k ≥ 0`, `jacobiR4(p^k) = 8·σ(p^k)`. Direct corollary of Part 8's `sigmaStar_prime_pow_of_odd_prime` and the definition `jacobiR4 = 8·σ*`.
- `r4Count_prime_pow_of_odd_prime` (uses `jacobi_r4_formula`): for odd prime `p` and `k ≥ 0`, `r4Count(p^k) = 8·σ(p^k)`. Generalizes Part 21's `r4Count_odd_prime` (k = 1 case).

Plus 4 explicit σ-tabulation theorems (σ(9) = 13, σ(25) = 31, σ(27) = 40, σ(49) = 57) and 7 `example`-form cross-validations: n = 9 matches Part 1's `jacobiR4_9 = 104`; n = 27 is the first odd-prime cube; n ∈ {25, 49} extend beyond Part 1's brute-force envelope n ≤ 10.

## Coverage

Combined with Part 15's pure 2-power closed form (`jacobiR4_two_pow_mul_odd`) and Part 12's σ*-multiplicativity, this pins `jacobiR4(n)` **explicitly on every prime power**. The general case `n = ∏ pᵢ^{kᵢ}` reduces via multiplicativity. The remaining gap to closing `jacobi_r4_formula` is the multiplicative bridge from `r4Count` to `jacobiR4` — addressed independently by the atomic-axiom decomposition route (S11.alt, PR #17388).

## Net effect

- +91 lines, +6 named theorems, 0 new axioms, 0 sorries.
- Meta sync: `lineCount` 1379 → 1653, `theoremCount` 96 → 106 (also captures pre-existing drift from S10 PR #17359 and S11 PR #17395 which did not update meta).
- `state.md`: log S10 / S11 / S11.alt / S12 entries (state was last synced at S9).

## Build status

Build pending: continues the pattern set by S6/S7/S8/S9/S10/S11 (the `proofs/.lake` self-referential symlink forces a fresh Mathlib clone per Docker build (~45 min cold)). The new theorems are direct one-line `unfold + rw` chains over already-proven lemmas, plus `native_decide` σ-tabulations and `decide`-driven primality / inequality checks. Auditor pipeline carries the build outcome.

## Test plan

- [x] Syntactic check: theorem signatures match Part 8's `sigmaStar_prime_pow_of_odd_prime` and the definition `jacobiR4 = 8·σ*`.
- [x] Cross-validation example `jacobiR4 (3^2) = 8 * sigmaOne (3^2)` matches Part 1's numerical `jacobiR4_9 = 104` (since `8 * 13 = 104`).
- [x] Cross-validation `r4Count (3^2) = 8 * sigmaOne (3^2)` matches Part 3's numerical `r4Count_9 = 104`.
- [ ] Docker build verification (deferred to auditor pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)