### PR TITLE
fix(meta): batch sync definitionCount drift (25 entries, batch m-s)

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Binomial coefficients and absorption identities",
       "Real arithmetic and polynomial inequalities"
     ],
-    "theoremCount": 22,
+    "theoremCount": 21,
     "definitionCount": 2,
     "additionalFiles": [
       "Proofs/NewtonInductiveStepOQ01Aristotle.lean"

--- a/src/data/proofs/randomized-maxcut-oq-02/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The MaxCut problem — partition the vertices of a graph to maximize the number of edges crossing the cut — is NP-hard (Garey-Johnson, 1976) and was one of Karp's 21 NP-complete problems. The randomized 1/2-approximation is folklore: assign each vertex to side $S$ or $\\overline{S}$ independently with probability $1/2$; by linearity of expectation, $\\mathbb{E}[\\text{cut}] = |E|/2 \\geq \\text{OPT}/2$ (since OPT $\\leq |E|$). For weighted graphs, the same argument gives $\\mathbb{E}[\\text{cut weight}] = W/2$ where $W$ is the total edge weight. The landmark 1995 paper by Goemans and Williamson introduced semidefinite programming (SDP) relaxation followed by random hyperplane rounding, achieving the approximation ratio $\\alpha_{GW} = \\min_{0 \\leq \\theta \\leq \\pi} \\frac{2(1-\\cos\\theta)}{\\pi\\theta} \\approx 0.87856$. Under the Unique Games Conjecture (Khot, 2002), $\\alpha_{GW}$ is the optimal polynomial-time approximation ratio for MaxCut — this was proved by Khot-Kindler-Mossel-O'Donnell (2007).",
@@ -132,7 +132,7 @@
     "lineCount": 127,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/RandomizedMaxcutOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -30,7 +30,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "In 1910, Bertrand Russell and Alfred North Whitehead published Principia Mathematica, an ambitious attempt to derive all mathematical truths from a small set of logical axioms. The famous claim that it took 362 pages to prove 1+1=2 has become a popular meme about mathematical rigor—though it's slightly misleading. Those 362 pages were building the entire logical machinery needed to even state what numbers are, not just proving one equation.\n\nRussell was motivated by the foundational crisis in mathematics, particularly paradoxes like his own Russell's Paradox which showed naive set theory was inconsistent. Principia introduced a ramified type theory to avoid these paradoxes, defining numbers as equivalence classes of sets with the same cardinality.",
@@ -164,7 +164,7 @@
     "lineCount": 197,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/OnePlusOne.lean",
     "sorries": 0
   },

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -52,7 +52,7 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 5
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Shannon's noisy channel coding theorem is arguably the most important result in information theory and one of the great theorems of 20th-century mathematics. Published in 1948, it answered a question that engineers had struggled with since the invention of the telegraph: is it possible to communicate reliably over a noisy channel, and if so, at what rate?\n\nBefore Shannon, the prevailing belief was that reducing error probability required reducing the communication rate to zero. Shannon's shocking result was that reliable communication is possible at any positive rate below the channel capacity C = max I(X;Y), and impossible above it. The channel capacity is a single number that completely characterizes the communication capability of a noisy channel.\n\nThe achievability proof uses random coding: choose a codebook at random and show that the average error probability over all codebooks is small. This is a probabilistic method argument -- one of the earliest and most influential. The converse uses Fano's inequality, which bounds the conditional entropy H(X|Y) in terms of the error probability, showing that rates above capacity force large errors.\n\nThe theorem launched the fields of coding theory and telecommunications engineering, leading to error-correcting codes (turbo codes, LDPC codes, polar codes) that approach channel capacity in practice.",
@@ -175,7 +175,7 @@
     "lineCount": 228,
     "axiomCount": 4,
     "theoremCount": 8,
-    "definitionCount": 5,
+    "definitionCount": 8,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0
   },

--- a/src/data/proofs/shannon-source-coding-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01/meta.json
@@ -84,7 +84,7 @@
         "relationship": "Related: channel capacity for specific models — the C parameter in the separation theorem"
       }
     ],
-    "definitionCount": 7
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Shannon's 1948 paper established the entropy H(X) as the fundamental limit of lossless data compression. But most practical communication involves lossy compression: images, audio, and video are routinely compressed with acceptable quality loss. In 1959, Shannon published 'Coding Theorems for a Discrete Source with a Fidelity Criterion' in IRE National Convention Record, extending source coding theory to the lossy regime.\n\nThe key insight was to parametrize the quality-rate tradeoff by a distortion measure d(x, x̂) and seek the minimum mutual information I(X; X̂) over all conditional distributions p(x̂|x) satisfying the distortion constraint E[d(X, X̂)] ≤ D. This infimum R(D) — the rate-distortion function — is the lossy analogue of entropy: it gives the minimum number of bits per source symbol needed for reproduction at distortion level D.\n\nShannon proved that R(D) is convex and non-increasing in D, with R(0) = H(X) (recovering the lossless theorem) and R(D_max) = 0. For a Gaussian source with squared-error distortion, R(D) = ½ log(σ²/D), which is the theoretical foundation for all modern lossy codecs (JPEG, MP3, H.264, etc.).\n\nThe rate-distortion coding theorem — achievability and converse — shows that R(D) is both achievable (via random coding) and tight (via the data processing inequality). Berger (1971) provided a comprehensive treatment in his monograph 'Rate Distortion Theory', and Blahut (1972) gave the iterative algorithm (Blahut-Arimoto) for computing R(D) numerically.",
@@ -235,7 +235,7 @@
     "lineCount": 292,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "mainTheorems": [
       {
         "name": "jointDist_nonneg",

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -55,7 +55,7 @@
             "Fintype.prod_sum (bigoperators sum-product exchange)"
         ],
         "mathlib_version": "4.26.0",
-        "definitionCount": 7
+        "definitionCount": 8
     },
     "overview": {
         "historicalContext": "The Asymptotic Equipartition Property (AEP) is the information-theoretic analogue of the Law of Large Numbers. Shannon (1948) observed informally that for i.i.d. sources, -1/n log P(X₁,...,Xₙ) → H(X) in probability, concentrating probability mass on roughly 2^(nH) 'typical' sequences. McMillan (1953) gave the first rigorous proof (showing convergence almost surely), and Breiman (1957) extended it to ergodic sources. The finitary version via Chebyshev's inequality provides explicit concentration rates.",
@@ -204,7 +204,7 @@
         "lineCount": 476,
         "axiomCount": 0,
         "theoremCount": 13,
-        "definitionCount": 7,
+        "definitionCount": 8,
         "path": "Proofs/ShannonSourceCodingOQ03.lean",
         "sorries": 0
     },

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -65,7 +65,7 @@
     "mathlib_version": "4.26.0",
     "relatedProblems": [],
     "theoremCount": 12,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "additionalFiles": [
       "Proofs/ShapleyFolkmanAristotle.lean"
     ]
@@ -214,7 +214,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "imports": [
       "import Mathlib"
     ],

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-03-28",
     "lineCount": 89,
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "status": "verified",
   "badge": "mathlib",
@@ -99,7 +99,7 @@
     "path": "Proofs/SolutionOfCubicOQ03OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "theoremCount": 3
   },
   "sorries": 0

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -13,7 +13,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 17,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "lineCount": 732,
     "tags": [
       "combinatorics",
@@ -112,7 +112,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 17,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "imports": [
       "import Mathlib.Algebra.Order.BigOperators.Group.Finset",
       "import Mathlib.Algebra.Ring.Parity",

--- a/src/data/proofs/sperner-ndim-mathlib/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib/meta.json
@@ -33,7 +33,7 @@
       "sperner: Sperner's lemma for abstract cell complexes"
     ],
     "theoremCount": 13,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "leanFile": {
     "path": "Proofs/SpernerNDimMathlib.lean",
@@ -41,7 +41,7 @@
     "axiomCount": 0,
     "lineCount": 521,
     "theoremCount": 13,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Sperner's lemma was proved by Emanuel Sperner in his 1928 paper *Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes* (Abh. Math. Sem. Univ. Hamburg 6, 265–272), where it served as the combinatorial substrate for an elementary proof of the *invariance of dimension* and *invariance of domain* — results previously known only via the homological / Brouwer-degree machinery of Brouwer (1911) and Lebesgue (1911). Sperner's contribution was to recast a topological invariance question as a finite combinatorial counting argument: given any *Sperner coloring* of the vertices of a triangulated simplex (vertex $i$ on the original face opposite $i$ never receives color $i$), the number of fully-coloured small simplices is *odd*, hence at least one exists.\n\nThe modern *door-counting* proof — assigning each $(d-1)$-facet of each $d$-simplex a 'door' label and observing that interior doors pair up while exterior doors do not — was popularised by Donald Knuth in *The Art of Computer Programming* Vol. 1, §1.2.6 Ex. 47, and is now standard in combinatorial textbooks (Aigner-Ziegler, *Proofs from THE BOOK*, Ch. 27). The door-counting proof is essentially constructive (it gives an explicit pivoting algorithm for finding a fully-coloured cell, used in algorithmic fair-division and in the Lemke-Howson algorithm for bimatrix Nash equilibria).\n\nThe *abstract cell complex* formulation in this file is the natural Mathlib-shaped abstraction: rather than committing to a specific triangulation scheme (Freudenthal, barycentric subdivision, Kuhn), the proof axiomatises adjacency directly via three axioms — `adj_symm` (adjacency is symmetric), `adj_vertices` (adjacent cells share a $(d-1)$-face), and `adj_ne` (distinct cells stay distinct). Concrete triangulations and CW-style polyhedral complexes both instantiate this structure. The argument works over `ZMod 2`-counts, and the combinatorial heart is the lemma `even_card_fpf_invol` (a fixed-point-free involution on a finite set has even cardinality), which is independently useful and a standalone Mathlib-worthy contribution. The full Sperner-via-CellComplex argument lives in 521 lines without sorries or axioms, and is part of an active push (Spring 2026) to upstream Sperner's lemma to Mathlib (mathlib4#25231 *Sperner's Lemma*, ongoing).",

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -46,7 +46,7 @@
     "assumptions": "1 axiom: bdry_all_even_of_no_fc_walks — when all boundary-door walks fail to reach FC, the boundary-door set B has even cardinality (used for parity contradiction in kuhn_path_existential). Mathematical proof: under hfail, τ: B→B defined by τ(s₀,Fin.last d) = (kuhnPathStart s₀, Fin.last d) is a FPF involution; hMem and hNe proved; hInv (τ∘τ=id, walkTrace_reversal) requires ~150-line kuhnWalkSeq infrastructure and is axiomatized after 9+ sessions BLOCKED.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Harold Kuhn (1968) gave the first algorithmic proof of Sperner's lemma, showing that a fully-colored simplex can be found in polynomial time by path-following in the door graph. This constructive approach contrasts with the combinatorial parity argument of Cohen (1967), which proves existence by counting doors modulo 2 but gives no algorithm to find one. The same year, Herbert Scarf (1967) independently developed a pivoting algorithm for computing approximate fixed points, also based on door-traversal in simplicial subdivisions — the two methods are closely related.\n\nKuhn's algorithm belongs to the broader family of **complementary pivot algorithms**: algorithms that follow a unique path determined by local complementarity or door conditions. Lemke and Howson (1964) had already used this idea for Nash equilibrium computation, following edges of the Nash equilibrium polytope. The realization that Sperner-type path-following and Nash equilibrium computation share the same combinatorial structure eventually led to the PPAD complexity class (Papadimitriou, 1994), which captures all problems reducible to finding a degree-1 vertex in a directed graph on an exponentially large implicit structure. Sperner's lemma is PPAD-complete, so Kuhn's constructive proof is, in complexity-theoretic terms, a PPAD algorithm.",
@@ -253,7 +253,7 @@
     "lineCount": 948,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/sperner-ndim/meta.json
+++ b/src/data/proofs/sperner-ndim/meta.json
@@ -35,7 +35,7 @@
     "assumptions": "0 axioms, 0 sorries. The main theorem (sperner_ndim) takes a boundary-door-oddness hypothesis, which for concrete triangulations follows by induction on dimension. The Sperner Parity Theorem (sperner_parity) is unconditional.",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "**Emanuel Sperner** proved his lemma in 1928 (*Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes*, Hamburg) as a combinatorial tool for a new proof of Brouwer's fixed point theorem. Sperner's original goal was proving the topological invariance of dimension number — the lemma was a means, not an end. The result states that any \"properly colored\" triangulation of a $d$-simplex must contain a fully-colored simplex.\n\n**D. I. A. Cohen** (1967, J. Comb. Theory) gave the elegant **door-counting** proof formalized here: count all door-facets, pair interior doors (even), and show boundary doors are odd — no topology needed. This completely combinatorial argument is the basis for this Lean formalization.\n\n**Hans Freudenthal** (1942, Ann. of Math.) introduced the triangulation bearing his name, where each simplex in the grid is indexed by a permutation $\\sigma \\in S_d$; adjacency corresponds to transpositions of adjacent elements. The `SpernerTriangulation` abstract structure here captures the shared axioms of Freudenthal, Kuhn, and all other standard triangulations.\n\n**Harold Kuhn** (1960, IBM J. Res. Dev.) introduced the **path-following (simplicial pivot)** algorithm that makes Sperner constructive: start at a boundary door on face $d$, walk through simplices following the unique opposite door, and terminate at a fully-colored simplex. This algorithm underlies the Scarf (1967) and Lemke-Howson fixed-point algorithms used in equilibrium computation.\n\n**Christos Papadimitriou** (1994) formalized **PPAD-completeness**: computing Brouwer fixed points is complete for the class PPAD (Polynomial Parity Argument on Directed graphs), reflecting that Sperner paths must terminate but finding the endpoint may be hard. Chen and Deng (2009) showed the problem is PPAD-complete even for 2D Lipschitz maps.",
@@ -219,7 +219,7 @@
     "lineCount": 669,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/SpernerNDim.lean",
     "sorries": 0
   },

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -43,7 +43,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 994,
     "theoremCount": 28,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -99,7 +99,7 @@
     "lineCount": 994,
     "axiomCount": 0,
     "theoremCount": 28,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "path": "Proofs/SpernerSimplicialInstance.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/spherical-law-of-cosines/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 341,
     "theoremCount": 24,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "originalContributions": [
       "IsUnitVec predicate and inner product properties: inner_unit_self, inner_unit_le_one, inner_unit_ge_neg_one",
       "arcLength definition via Real.arccos and properties: nonneg, le_pi, cos_arcLength recovery theorem, self-distance, symmetry",
@@ -147,7 +147,7 @@
     "path": "Proofs/SphericalLawOfCosines.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "theoremCount": 24
   },
   "sorries": 0

--- a/src/data/proofs/sylow-theorem-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-01/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 387,
     "theoremCount": 21,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "originalContributions": [
       "cyclic_of_both_sylow_normal: full original proof that normal Sylow subgroups of coprime order make G cyclic",
       "sylow_q_count_constraint: explicit derivation of n_q | p and n_q ≡ 1 (mod q) for pq-groups",
@@ -126,7 +126,7 @@
     "path": "Proofs/SylowTheoremOQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "theoremCount": 21
   },
   "sorries": 0

--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "0 axiom declarations, 0 sorries. All 3 previously sorry'd theorems proved: cyclic_when_coprime via commutator argument + order calculation, nonabelian_sylow_p_count by contradiction, pq_cyclic_classification by universal instantiation.",
     "lineCount": 387,
     "theoremCount": 21,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Ludwig Sylow (1872) published three landmark theorems about finite groups in Mathematische Annalen: existence of p-Sylow subgroups (subgroups of order p^k where p^k exactly divides |G|), conjugacy (all Sylow p-subgroups are conjugate), and counting (their number n_p satisfies n_p ≡ 1 mod p and n_p | |G|/p^k). These results, proved when group theory itself was nascent, became the primary tool for classifying finite groups by order. The classification of groups of order pq for distinct primes p < q was one of the first explicit applications: worked out in the late 19th century and consolidated by William Burnside in his 1911 textbook 'Theory of Groups of Finite Order.' The result is a model of beautiful algebra: the entire isomorphism type of a pq-group is determined by the single arithmetic condition p | (q-1). When p ∤ (q-1), both Sylow subgroups are normal, G is isomorphic to their direct product ℤ/p × ℤ/q ≅ ℤ/pq (cyclic since gcd(p,q)=1). When p | (q-1), a non-trivial homomorphism φ : ℤ/p → Aut(ℤ/q) ≅ ℤ/(q-1) exists (since p | (q-1) = |Aut(ℤ/q)|), giving a non-abelian semidirect product ℤ/q ⋊_φ ℤ/p. For order 6: p=2, q=3, 2 | 2, the non-abelian group is S₃. For order 15: p=3, q=5, 3 ∤ 4, only ℤ/15. This formalization uses Mathlib's Sylow API and proves all main cases including the hardest — the cyclic result — via a commutator argument.",
@@ -120,7 +120,7 @@
     "axiomCount": 0,
     "theoremCount": 21,
     "sorryTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/SylowTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-03-25",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 2
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Jean-Pierre Serre (born 1926) generalized the Sylow theorems to profinite groups in his foundational 1965 work 'Cohomologie Galoisienne'. A profinite group is a compact, Hausdorff, totally disconnected topological group — equivalently, an inverse limit of finite groups. The absolute Galois group Gal(k̄/k) of any field is profinite, making pro-p Sylow theory essential for Galois cohomology and class field theory.\n\nThe pro-p Sylow theorem states that every profinite group G has maximal pro-p closed subgroups (the Sylow pro-p subgroups), that these are all conjugate, and that they arise as inverse limits of the finite Sylow p-subgroups in the quotient system of G. The existence proof uses Zorn's lemma on the poset of closed pro-p subgroups, with compactness guaranteeing that the closure of a chain's union is still pro-p.",
@@ -213,7 +213,7 @@
     "lineCount": 393,
     "sorries": 0,
     "path": "Proofs/SylowTheoremOQ02.lean",
-    "definitionCount": 2,
+    "definitionCount": 5,
     "theoremCount": 9
   }
 }

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -50,7 +50,7 @@
     "assumptions": "Infrastructure file: 0 sorries, 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. A previously-attempted naive_implies_gowers theorem was removed; the obstruction (sub-complex topCliques are not generally transversals of vertex sub-parts) is documented in-file (Part VII), and three provable surrogates are supplied instead (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty).",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Szemerédi's 1975 theorem (Acta Arith. 27, 199–245) — every set of integers of positive upper density contains arbitrarily long arithmetic progressions — was originally proved using an extremely intricate combinatorial argument that introduced the regularity lemma for graphs as a key tool. Furstenberg (1977) gave a fundamentally different proof via ergodic theory, opening the door to vast generalizations (multidimensional Szemerédi, polynomial Szemerédi, density Hales-Jewett). The Gowers (2007) hypergraph regularity lemma is a far-reaching generalization of Szemerédi's graph regularity (2-uniform) to k-uniform hypergraphs, and provides a purely combinatorial proof of the multidimensional Szemerédi theorem. The classical graph regularity measures how much the edge density changes when restricting to sub-parts of a bipartition. For hypergraphs, the correct notion — introduced by Gowers and independently by Rödl-Skokan (2004) and Nagle-Rödl-Schacht (2006) — is *relative regularity*: measuring density relative to an underlying system of lower-dimensional hypergraphs (the 'complex'), and requiring density stability under dense sub-complexes. The technical heart of the modern hypergraph approach is that ordinary 'flat' regularity is too weak for k≥3 (a counterexample of Gowers and Wolf shows the counting lemma fails); the relative formulation tracks how each dimension level depends on the levels below, making the inductive removal lemma feasible. This file formalizes the foundational data structures and consistency lemmas needed for any subsequent counting lemma formalization.",
@@ -173,7 +173,7 @@
     "lineCount": 322,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -44,7 +44,7 @@
     "lineCount": 267,
     "assumptions": "hypergraph_regularity_lemma (Gowers 2007, Rödl–Skokan 2004): the existence of a regular partition is stated as a sorry pending the full formalization.",
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Szemerédi's graph regularity lemma (1978) decomposed any dense graph into quasi-random bipartite pieces, enabling the k=3 case of the arithmetic progression theorem via the triangle removal lemma. Extending this to k-uniform hypergraphs — needed for k≥4 arithmetic progressions — proved substantially harder. The naive generalisation (density between large vertex-subsets) is insufficient: unlike graphs, it does not control density for embedded cliques.\n\nGowers (2007) and Rödl–Skokan (2004) independently resolved this by introducing regularity *relative to a simplicial complex*. A k-uniform hypergraph is Gowers-regular when its edge density is stable under restriction to any dense sub-(k-1)-complex. The key payoff is the hypergraph counting lemma (Nagle–Rödl–Schacht 2006): Gowers-regular hypergraphs contain the expected count of embedded complete hypergraphs. Together, these give the multidimensional Szemerédi theorem: every set of positive upper density contains a k-dimensional arithmetic progression.\n\nGowers received the Fields Medal in 1998 for his earlier work on quantitative bounds in Szemerédi's theorem (using higher-order Fourier analysis / Gowers norms), predating the hypergraph regularity paper. The wowzer-type bounds in the hypergraph regularity lemma — a tower of towers — were shown by Gowers to be essentially necessary, making it one of the most extreme known examples of a mathematically natural but computationally intractable result.\n\nFurstenberg and Katznelson gave an independent ergodic-theoretic proof of the multidimensional Szemerédi theorem (1978), avoiding hypergraph regularity entirely. The two approaches — regularity and ergodic — remain the two main proof strategies, with Gowers' quantitative bounds being inaccessible to the ergodic method.",
@@ -171,7 +171,7 @@
     "theoremCount": 10,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
-    "definitionCount": 9,
+    "definitionCount": 11,
     "path": "Proofs/SzemerediHypergraphCoreOQ01.lean",
     "sorries": 1
   },

--- a/src/data/proofs/szemeredi-hypergraph-core/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core/meta.json
@@ -54,7 +54,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Szemerédi's regularity lemma (1975) for graphs is one of the most powerful tools in combinatorics, but many applications require a hypergraph version. The challenge is that naive generalizations of graph regularity to hypergraphs fail: knowing that pairs of vertex sets have uniform density does not suffice to count k-uniform structures.\n\nGowers (2007) and independently Rödl–Skokan (2004) and Nagle–Rödl–Schacht (2006) solved this by introducing regularity relative to an underlying simplicial complex. In their framework, a k-uniform hypergraph is regular not when large vertex subsets preserve density, but when restricting to dense sub-complexes of the (k-1)-skeleton preserves density. This relative regularity is what makes the hypergraph counting lemma work.\n\nThis module formalizes the foundational definitions: k-uniform hypergraphs, k-partite density via transversals, and the naive epsilon-regularity condition. The naive version captures the density-deviation idea and specializes to the graph case (k=2), serving as a stepping stone to the full Gowers regularity.",
@@ -154,7 +154,7 @@
     "lineCount": 213,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/SzemerediHypergraphCore.lean",
     "sorries": 0
   },

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 175,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Three-place (relative) identity was introduced by Peter Geach in his 1967 paper 'Identity' (Review of Metaphysics), where he argued against the absoluteness of identity: the same object can be 'the same F' but 'a different G' for sortals F and G. This challenged Leibniz's law and sparked decades of philosophical debate between Geach and W.V.O. Quine, who insisted that numerical identity must be absolute. Tom Etter, working at the Boundary Institute, proposed a formal reconciliation in his 2001 paper 'Equalities and Quine Identities': two equivalence relations ('stereo equality', by analogy with stereoscopic vision) suffice to model relative identity, providing a two-predicate foundation that avoids Quine's objections. This formalization proves Etter's theorem in Lean 4, establishing both the forward construction (stereo pair → relative identity) and the reverse (relative identity → stereo pair), along with the negative result that a single equivalence relation is insufficient — it produces only a 'flat' (viewpoint-independent) identity.",
@@ -110,7 +110,7 @@
     "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/ThreePlaceIdentityOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/three-place-identity/meta.json
+++ b/src/data/proofs/three-place-identity/meta.json
@@ -39,7 +39,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 10
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "The question 'what is the primitive concept of mathematics?' has occupied logicians since Frege. The standard answer—set membership—proved technically successful but philosophically troubling. Benacerraf's problem (why is 2 = {empty, {empty}} rather than {{empty}}?) suggests sets don't capture mathematical essence.\n\nTom Etter, working at the Boundary Institute, proposed a radical alternative: three-place relative identity Id(x,y,z)—read 'x regards y as identical to z'—is the true primitive, with existence derived as distinguishability from non-existence. This formalizes Gian-Carlo Rota's slogan 'Identity precedes existence.'",
@@ -208,7 +208,7 @@
     "lineCount": 425,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 10,
+    "definitionCount": 13,
     "path": "Proofs/ThreePlaceIdentity.lean",
     "sorries": 0
   },

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 1230,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms.",
     "theoremCount": 41,
-    "definitionCount": 26
+    "definitionCount": 31
   },
   "overview": {
     "historicalContext": "The Tractatus Logico-Philosophicus (1921) is Wittgenstein's only book-length philosophical work published in his lifetime. It presents a logical atomist ontology: the world consists of facts (obtaining states of affairs), propositions picture possible states of affairs, and all meaningful propositions are truth-functions of elementary propositions. The work culminates in proposition 6.54 — the famous ladder that must be thrown away — and the closing injunction: 'Whereof one cannot speak, thereof one must be silent.'",
@@ -270,7 +270,7 @@
     "lineCount": 1230,
     "axiomCount": 1,
     "theoremCount": 41,
-    "definitionCount": 26,
+    "definitionCount": 31,
     "path": "Proofs/TractatusOntology.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/triangle-angle-sum-oq-01/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-01/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "saccheri_legendre (angle sum ≤ π in neutral geometry), defect_transitivity_axiom (zero defect propagates), angle_sum_pi_implies_playfair (main characterization), parallel_implies_angle_sum (forward direction). All are classical theorems of neutral geometry requiring ~1000 lines of infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "The relationship between angle sums and Euclidean geometry is one of the oldest results in foundations of mathematics. Euclid's parallel postulate (Book I, Postulate 5) was suspected to be provable from the other axioms, but this was never achieved. In the 18th and 19th centuries, Saccheri (1733) and Legendre (1794, 1823) proved what we now call the Saccheri-Legendre theorem: in neutral geometry (without the parallel postulate), the angle sum of any triangle cannot exceed π.\n\nThe deeper result — that angle sum = π for all triangles is EQUIVALENT to the parallel postulate — was understood by Legendre and confirmed when Bolyai and Lobachevsky (1830s) constructed consistent hyperbolic geometries where angle sum < π. This settled the 2000-year-old question: the parallel postulate cannot be proved from neutral geometry, and angle sum characterizes the Euclidean case.",
@@ -131,7 +131,7 @@
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ01.lean",
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Batch sync stale `theoremCount` / `definitionCount` in `meta.json` for 25 gallery entries (slugs starting `m`–`s`, excluding ranges already covered by open mechanic PRs #17479/#17481 and slugs with active research churn).

Both occurrences (top-level `.meta` block and `.leanFile` block) are updated to the actual count from the Lean source, computed via the same comment-stripper used in `scripts/auditor/find-targets.ts`. No Lean source changes — pure metadata.

## Evidence

For each entry:
- **Before**: claimed `theoremCount` / `definitionCount` lagged the source (delta 1-5)
- **After**: both `meta.*` and `leanFile.*` match the actual count

Sample diff (`sperner-ndim`):

```diff
-    "definitionCount": 6
+    "definitionCount": 8
```

Filter: delta ≤ 5 to keep each fix surgical and avoid touching entries with large structural drift (Navier-Stokes, Poincaré, Riemann, Yang-Mills) that warrant manual review.

## Slug list

`newton-inductive-step-oq-01, randomized-maxcut-oq-02, roth-theorem-k3-oq-02, russell-1-plus-1, shannon-channel-coding, shannon-source-coding-oq-01, shannon-source-coding-oq-03, shapley-folkman, solution-of-cubic-oq-03-oq-01, sperner-mathlib4, sperner-ndim, sperner-ndim-mathlib, sperner-ndim-oq-04, sperner-simplicial-instance, spherical-law-of-cosines, sylow-theorem-oq-01, sylow-theorems-oq-01, sylow-theorems-oq-02, szemeredi-hypergraph-core, szemeredi-hypergraph-core-oq-01, szemeredi-hypergraph-core-oq-01-incomplete-01, three-place-identity, three-place-identity-oq-02, tractatus-ontology, triangle-angle-sum-oq-01`

---
Automated fix by lean-mechanic agent.