### PR TITLE
fix(meta): batch sync definitionCount drift (17 entries, erdos-105-110 + continuum)

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -59,7 +59,7 @@
     "assumptions": "10 axioms: VeqL, VeqL_implies_GCH, UltimateL, UltimateL_implies_GCH, PFA, PFA_implies_continuum_eq_aleph_two, MM, MM_implies_PFA, VeqL_incompatible_with_measurable, PFA_large_cardinal_compatible. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 20,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Gödel (1940) showed CH is consistent with ZFC using the constructible universe L; Cohen (1963) showed ¬CH is also consistent using forcing. The independence of CH left open a deeper philosophical question: which axioms, if any, should we add to ZFC to settle it? Gödel initially hoped V=L was the right answer, but Scott (1961) showed V=L is incompatible with measurable cardinals — large cardinals that most set theorists consider mathematically natural. Since the 1970s, forcing axioms like Martin's Maximum (MM) and the Proper Forcing Axiom (PFA) have emerged as popular alternatives, and these axioms imply ¬CH. Woodin's ongoing Ultimate-L program (1999–) seeks a canonical inner model that satisfies GCH while accommodating all large cardinals.",
@@ -177,7 +177,7 @@
     "lineCount": 317,
     "axiomCount": 10,
     "theoremCount": 20,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/ContinuumHypothesisOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -43,7 +43,7 @@
     "lineCount": 395,
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Cantor first posed the Continuum Hypothesis in his 1878 paper *Ein Beitrag zur Mannigfaltigkeitslehre*, conjecturing that $2^{\\aleph_0} = \\aleph_1$ after proving the reals are uncountable (1873). Hilbert placed it as Problem #1 in his famous 1900 Paris address, calling it the most important open problem in mathematics. After decades of failed attempts, Gödel resolved half the question in 1940 by constructing the *Constructible Universe* L—a minimal model of ZFC in which CH holds—proving Con(ZFC) → Con(ZFC+CH). Cohen revolutionised logic in 1963 by inventing *forcing*, a general method for extending set-theoretic models, and used it to produce models where CH fails (Con(ZFC) → Con(ZFC+¬CH)). Cohen received the Fields Medal in 1966, the only one awarded for work in logic. Together, Gödel and Cohen showed CH is *independent* of ZFC—Hilbert's first problem was answered, but not by deciding its truth.",
@@ -128,7 +128,7 @@
     "lineCount": 395,
     "axiomCount": 4,
     "theoremCount": 8,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "path": "Proofs/ContinuumHypothesis.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 156,
     "assumptions": "0 axioms, 0 sorries. Infrastructure file: sublevel sets, paths in ℂ, and supporting lemmas fully proved. Main conjecture not axiomatized; badge updated from 'axiom' to 'wip'.",
     "theoremCount": 6,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "This problem originates from the 1958 paper 'Metric properties of polynomials' by Erdős, Herzog, and Piranian. They studied the geometry of polynomial level sets—specifically the sublevel set {z : |f(z)| < 1} for monic polynomials with roots in the unit disk.\n\nThe authors proved that this sublevel set always has a connected component containing at least two roots (the Component Lemma). The open problem asks for a quantitative strengthening: can we find not just connectivity, but a SHORT path of length less than 2 connecting two roots?\n\nThe constant 2 is sharp—it's the diameter of the unit disk, so roots could be nearly 2 apart. The conjecture asks whether the sublevel set always provides an efficient shortcut.",
@@ -249,7 +249,7 @@
     "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1041Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -51,7 +51,7 @@
     "lineCount": 132,
     "assumptions": "3 axioms: transfiniteDiameter (transfinite diameter — axiomatized, requires Chebyshev constant machinery), ghosh_ramachandran_small_diameter (Ghosh-Ramachandran: if 0 < d < 1, lemniscate has ≤ (1-c)n components), ghosh_ramachandran_diameter_one_examples (Ghosh-Ramachandran: ∃ sets with diameter 1 and n lemniscate components infinitely often). 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős, Herzog, and Piranian posed this problem in their 1958 paper on metric properties of polynomials. A polynomial lemniscate is the sublevel set {z : |f(z)| < 1} of a polynomial f, and the question concerns how many connected components it can have when the roots are constrained to lie in a closed set F ⊆ ℂ. The transfinite diameter (logarithmic capacity) of F controls the answer.\n\nThe 1958 paper showed that for the unit disc (transfinite diameter 1), the lemniscate of f(z) = zⁿ + 1 has exactly n connected components — one small disc around each nth root of -1. This left open whether sets with smaller transfinite diameter must have fewer components, and whether the answer depends on diameter alone.\n\nThe problem remained open for over 65 years until Ghosh and Ramachandran (2024) gave a complete solution. They proved that for transfinite diameter d < 1, components are bounded by (1-c)n for some c > 0 depending on F. For d ≤ 1/4 with F connected, only one component is possible. Crucially, they showed the answer cannot depend on transfinite diameter alone: the disc of radius 1/2 and the interval [-1,1] both have transfinite diameter 1/2, but behave completely differently.",
@@ -234,7 +234,7 @@
     "lineCount": 132,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1042Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 206,
     "assumptions": "2 axioms inherited from Erdos105Problem.lean: xichuan_counterexample (Xichuan's counterexample), beck_szemeredi_trotter_positive (positive result via Szemerédi-Trotter). 0 own axioms. 0 sorries. The previous transitive `axiom thresholdFunction` was replaced with a real `noncomputable def` in the parent Erdos105Problem.lean.",
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "Erdős Problem #105 asks about rich lines avoiding obstacle points in R². A line through at least 2 points of a configuration A is 'rich'; a set B of obstacle points 'blocks' all rich lines if every rich line contains at least one obstacle. The conjecture that n−4 obstacles suffice was disproved by Xichuan (2024), showing that the threshold function f(n) (minimum obstacles needed to block all rich lines) satisfies cn ≤ f(n) ≤ n−4, but its exact asymptotics remain unknown.\n\nThe Szemerédi-Trotter theorem (1983) bounds the number of incidences between n points and m lines in R² to O(n^{2/3}m^{2/3} + n + m), implying that any point configuration has many 'ordinary' lines (through exactly 2 points). This structural result is the backdrop for #105: obstacles need to cover enough of the rich-line structure. The natural higher-dimensional question — do rich k-flats in R^d exhibit similar blocking behavior? — requires understanding how incidence bounds change when lines and planes replace each other.",
@@ -188,7 +188,7 @@
     "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 13,
+    "definitionCount": 15,
     "path": "Proofs/Erdos105OQ05.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-105/meta.json
+++ b/src/data/proofs/erdos-105/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 305,
     "assumptions": "2 axioms: xichuan_counterexample (Xichuan: explicit counterexamples to the naive conjecture), beck_szemeredi_trotter_positive (Beck-Szemerédi-Trotter: with cn obstacles a rich line always exists). 0 sorries. The previous `axiom thresholdFunction : ℕ → ℕ` was replaced with a real `noncomputable def thresholdFunction (n : ℕ) : ℕ := sSup {m | …}` — defining f(n) concretely as the supremum of obstacle counts that can always be avoided. The conjectures about its asymptotic behaviour (cn ≤ f(n) ≤ n-4) remain open and are stated in `openProblem_exact_threshold`.",
     "theoremCount": 3,
-    "definitionCount": 17
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**Point-Line Incidences and Blocking Sets**\n\nErdős Problem #105 sits at the intersection of incidence geometry and extremal combinatorics. A *rich line* for a point set $A \\subset \\mathbb{R}^2$ is one containing $\\geq 2$ points of $A$; the question is how many *obstacle* points are needed to *block* every rich line — i.e., place a point of $B$ on each.\n\n**Szemerédi-Trotter Foundation (1983)**: The Szemerédi-Trotter theorem $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$ implies that $n$ non-collinear points determine $\\Omega(n^2)$ rich lines (most through exactly 2 points). Beck (1983) independently proved that for any $c > 0$ sufficiently small, $cn$ obstacle points cannot block all rich lines — by a double-counting argument, $cn$ obstacles can lie on at most $O(cn \\cdot n) = O(cn^2)$ rich lines, which for small $c$ is fewer than the total.\n\n**The Erdős-Purdy Conjecture (1995)**: Erdős and Purdy conjectured that even $n - 3$ obstacles cannot block all rich lines of $n$ non-collinear points. They offered a \\$50 prize for proof or disproof. The number $n - 3$ was motivated by Hickerson's construction showing $n - 2$ obstacles *can* block all rich lines, making $n - 3$ the natural boundary case.\n\n**Hickerson's $n - 2$ Construction**: Hickerson exhibited, for each $n$, a configuration of $n$ non-collinear points $A$ and $n - 2$ obstacles $B$ such that every rich line of $A$ passes through a point of $B$. This established $f(n) \\leq n - 3$ for the threshold function.\n\n**Xichuan's Disproof (2024)**: Xichuan constructed three explicit counterexamples showing that $n - 3$ obstacles also suffice to block all rich lines. The constructions exploit point configurations where $A$ has unusually few rich lines relative to its size — specifically, configurations where the rich lines can be covered by $n - 3$ points. This disproved the Erdős-Purdy conjecture and earned the \\$50 prize, establishing $f(n) \\leq n - 4$.\n\n**Current State**: The threshold function $f(n)$ satisfies $cn \\leq f(n) \\leq n - 4$ for some constant $c > 0$. The enormous gap between linear and near-linear bounds is the central open problem.",
@@ -257,7 +257,7 @@
     "lineCount": 305,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "path": "Proofs/Erdos105Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -28,7 +28,7 @@
     "assumptions": "5 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_perfect_square (proved via k×k grid construction + g_ap_bounded upper bound), g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). 0 sorries.",
     "lineCount": 749,
     "theoremCount": 39,
-    "definitionCount": 16
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**From Axis-Parallel to Rotated: The Last Barrier in Square Packing**\n\nThe 2024 breakthrough by Baek, Koizumi, and Ueoro completely resolved the axis-parallel case of Erdős's square packing conjecture, proving g(k²+1) = k. This leaves one fundamental question: can rotated squares do better?\n\nIn the axis-parallel formulation, all packed squares have sides parallel to the unit square. When rotation is allowed, the packing space is richer — a rotated square occupies a diamond-shaped region that could potentially fill space more efficiently.\n\nNo example is known where rotation helps. At perfect squares n = k², both f_rot(k²) = g(k²) = k, since the k×k grid (which is axis-parallel) is already optimal by Cauchy-Schwarz. The question is whether rotation helps at non-perfect-square values of n.",
@@ -183,7 +183,7 @@
     "theoremCount": 39,
     "substantiveTheoremCount": 11,
     "sorryTheorems": 0,
-    "definitionCount": 16,
+    "definitionCount": 19,
     "mainTheorems": [
       {
         "name": "agree_at_perfect_squares",

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -59,7 +59,7 @@
       "bku_theorem axiom: g(k²+1) = k for axis-parallel packings (Baek-Koizumi-Ueoro 2024)"
     ],
     "theoremCount": 9,
-    "definitionCount": 12
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "**Square Packing: From Hungarian High School to Modern Breakthrough**\n\nThis problem has one of the longest histories in Erdős's repertoire, dating back to the 1930s when a young Paul Erdős proved $f(2) = 1$ in a paper written for **Középiskolai Matematikai és Fizikai Lapok**, the Hungarian journal for high school students. The result — that two non-overlapping squares in the unit square cannot have side-length sum exceeding $1$ — became a foundational result in discrete packing theory.\n\n**Key milestones**:\n- **1930s**: Erdős proved $f(2) = 1$ and observed that $f(k^2) = k$ follows from Cauchy-Schwarz: $(\\sum s_i)^2 \\leq n \\sum s_i^2 \\leq n$\n- **~1960s**: D. J. Newman proved $f(5) = 2$ (personal communication to Erdős), confirming the first non-trivial case of the conjecture\n- **1984**: Gábor Halász gave constructive lower bounds $f(k^2 + 2c + 1) \\geq k + c/k$, showing how grid modifications can increase the sum beyond $k$\n- **1994**: Erdős restated the problem in 'Some old and new problems in combinatorial geometry'\n- **1995**: Erdős and Alexander Soifer published 'Squares packing', formulating the stronger conjecture $f(k^2 + 2c + 1) = k + c/k$ for $|c| < k$\n- **Praton**: Iwan Praton proved that the main conjecture $f(k^2+1) = k$ is equivalent to the full Erdős-Soifer conjecture\n- **2024**: Baek, Koizumi, and Ueoro solved the **axis-parallel case** completely, proving $g(k^2+1) = k$ when all squares must have sides parallel to the unit square\n\nThe problem exemplifies Erdős's gift for posing questions that are simple to state yet resist all attacks. The 2024 axis-parallel breakthrough shows the conjecture is true 'most of the way' — the remaining open question is whether rotated squares can beat axis-parallel packings.",
@@ -326,7 +326,7 @@
     "theoremCount": 9,
     "substantiveTheoremCount": 7,
     "sorryTheorems": 1,
-    "definitionCount": 12,
+    "definitionCount": 14,
     "mainTheorems": [
       {
         "name": "conjecture_equiv",

--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -32,7 +32,7 @@
       "Independence ratio framework documenting the scaling question"
     ],
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The study of unit distance graphs begins with Erdős's 1946 paper on the unit distance problem in the plane: how many unit distances can occur among $n$ points? The independence number $g(n)$ — the maximum $k$ such that any unit distance graph on $n$ separated points has an independent set of size $\\geq k$ — was introduced to capture the structural sparseness of unit distance graphs.\n\nThe **kissing number** $\\tau(d)$ is one of the most classical problems in geometry: how many non-overlapping unit spheres can simultaneously touch a central unit sphere in $\\mathbb{R}^d$? The 2D answer $\\tau(2) = 6$ is elementary (honeycomb packing). The 3D answer $\\tau(3) = 12$ was famously disputed between Newton (12) and Gregory (13) for nearly 300 years; it was settled by Schütte and van der Waerden in 1953. The exceptional cases $\\tau(8) = 240$ and $\\tau(24) = 196560$ were proved by Viazovska et al. in 2017 using modular forms — the latter being the densest sphere packing in 24 dimensions (Leech lattice), earning Viazovska the Fields Medal in 2022.\n\nFor $g_d(n)$ in higher dimensions, the greedy coloring bound $g_d(n) \\geq n/(\\tau(d)+1)$ is the most direct approach. In 2D, Swanepoel improved this to $g_2(n) \\geq (8/31)n \\approx 0.258n$, leveraging the specific structure of planar point sets. Erdős conjectured $\\lim g_2(n)/n = 1/3$, which remains open.",
@@ -124,7 +124,7 @@
     "lineCount": 156,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1066OQ04.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-1066/meta.json
+++ b/src/data/proofs/erdos-1066/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 118,
     "assumptions": "2 axioms: g, g_d. Structure fields are object definitions, not assumptions.",
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "This problem concerns unit distance graphs in the plane, where n points at minimum pairwise distance 1 are connected by edges if exactly at distance 1. Such graphs are always planar (edges cannot cross without forcing points closer than 1). The key quantity g(n) measures the guaranteed independent set size.\n\nErdős initially conjectured g(n) = n/3, but this was disproved by Chung, Graham, and Pach who showed g(n) ≤ 6n/19 ≈ 0.316n. The baseline lower bound g(n) ≥ n/4 follows from planarity and the Four Colour Theorem (observed by Pollack in 1985). This was improved by Csizmadia (1998) to 9n/35 and then by Swanepoel (2002) to the current best 8n/31.\n\nThe current best upper bound is due to Pach and Tóth (1996): g(n) ≤ 5n/16 = 0.3125n. The gap between 8/31 ≈ 0.258 and 5/16 = 0.3125 remains to be closed. The problem also generalizes to higher dimensions, where g_d(n) ~ n/d is conjectured.",
@@ -227,7 +227,7 @@
     "lineCount": 118,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1066Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1067/meta.json
+++ b/src/data/proofs/erdos-1067/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 226,
     "assumptions": "2 axioms: soukup_counterexample_2015, bowler_pitz_counterexample_2024. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdős-Hajnal and Infinite Graph Coloring**\n\nPaul Erdős and András Hajnal posed this question in 1966 as part of their systematic investigation of infinite graph coloring. The study of uncountable chromatic numbers was a major theme in Erdős's work on infinite combinatorics, connecting graph theory to set theory and cardinal arithmetic.\n\n**The question**: A graph is *infinitely connected* if any two vertices are connected by infinitely many pairwise vertex-disjoint paths (equivalently, by Menger's theorem, no finite vertex cut separates any two vertices). Erdős and Hajnal asked: if $\\chi(G) = \\aleph_1$ (the smallest uncountable cardinal), must $G$ contain an infinitely connected subgraph $H$ with $\\chi(H) = \\aleph_1$?\n\n**Komjáth's breakthrough (2013)**: Péter Komjáth showed the answer could be negative — in some models of ZFC (obtained by forcing), counterexamples exist. He also proved that for graphs with exactly $\\aleph_1$ vertices, the answer is *independent* of ZFC.\n\n**Soukup's ZFC counterexample (2015)**: Lajos Soukup settled the question definitively by constructing a counterexample provable in ZFC alone. His construction builds 'ladder' structures from trees, creating graphs where the chromatic bottleneck resides in thin, poorly connected components.\n\n**Bowler-Pitz simplification (2024)**: Nathan Bowler and Steffen Pitz gave a more elementary construction, making the counterexample accessible without specialized set-theoretic machinery.\n\n**Thomassen's edge variant (2017)**: Carsten Thomassen showed the analogous question for edge-connectivity (infinitely many edge-disjoint paths) is also false.",
@@ -259,7 +259,7 @@
     "lineCount": 226,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1067Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. Graph theory definitions and supporting lemmas formalized. Open conjectures not formalized as axioms; badge updated from 'axiom' to 'wip'.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "This problem originates from the Erdős–Hajnal program (1966, *Acta Math. Acad. Sci. Hungar.* 17:61–99) connecting chromatic number with structural graph properties. Erdős and Hajnal conjectured that uncountable chromatic number forces subgraphs of infinite connectivity. The specific formulation about countable subgraphs appears in Vatter's 1999 problem collection (Problem 7.90) and is catalogued as Problem B24-adjacent in Guy's survey. Soukup (2015, *Combinatorica*) gave the first ZFC construction of an uncountably chromatic graph where every uncountable vertex set is only finitely connected, using ladder systems on non-special $\\omega_1$-trees. This disproved Problem 1067 but left Problem 1068 (the countable case) open. Bowler and Pitz (2024, *Electronic J. Combinatorics*) simplified Soukup's construction using elementary ladder graphs. Earlier, Komjáth (2013, *Israel J. Math.*) had shown a related question is independent of ZFC, highlighting the set-theoretic depth of the problem. The infinite Menger theorem, proved by Aharoni and Berger (2009, *Inventiones mathematicae*), provides the key characterization: infinite connectivity is equivalent to the absence of finite vertex separators. The De Bruijn–Erdős theorem (1951) connects infinite and finite graph coloring, ensuring $\\chi(G) \\geq \\aleph_1$ implies arbitrarily large finite chromatic number.",
@@ -238,7 +238,7 @@
     "lineCount": 264,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "sorries": 0,
     "path": "Proofs/Erdos1068Problem.lean"
   },

--- a/src/data/proofs/erdos-1069/meta.json
+++ b/src/data/proofs/erdos-1069/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 179,
     "assumptions": "2 axioms: szemeredi_trotter, kRich_bound. Structure fields are object definitions, not assumptions.",
     "theoremCount": 2,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "This problem was conjectured by Erdős, Croft, and Purdy, and described by Erdős in his 1987 paper 'Some combinatorial and metric problems in geometry'. The question asks for the maximum number of k-rich lines (lines containing at least k points) through a set of n points in the plane.\n\nThe result follows from the celebrated Szemerédi-Trotter theorem (1983), which bounds the number of incidences between points and lines in ℝ². This theorem is a cornerstone of incidence geometry: I(P,L) ≤ O(|P|^{2/3}|L|^{2/3} + |P| + |L|). The k-rich lines bound O(n²/k³) is a direct consequence via a counting argument.\n\nThe bound is nearly tight. For k = √n, lattice points on an m × m grid show there can be at least (2+o(1))√n many √n-rich lines. The optimal constant in the bound remains unknown and is an active area of research in combinatorial geometry.",
@@ -252,7 +252,7 @@
     "lineCount": 179,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1069Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "10 axioms: f, m1, larman_rogers_theorem, croft_lower_bound, moser_spindle_upper_bound, acmvz_upper_bound, chromaticNumberPlane, de_grey_lower_bound, chromatic_upper_bound, independence_chromatic_relation. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**Unit Distance Graphs, Density, and the Independence Threshold**\n\nA *unit distance graph* (UDG) on $n$ points in $\\mathbb{R}^2$ has edges between points at Euclidean distance exactly 1. The *independence number* $\\alpha(G)$ is the size of the largest subset with no edges. Erdős defined $f(n) = \\min_G \\alpha(G)$ over all $n$-point UDGs and asked for its growth rate — in particular, whether $f(n) \\geq n/4$.\n\n**The Larman-Rogers Bridge (1972)**: The key insight connecting discrete and continuous. Let $m_1 = \\sup\\{\\overline{d}(S) : S \\subseteq \\mathbb{R}^2 \\text{ measurable, unit-distance-free}\\}$ be the maximum density of a measurable set avoiding unit distances. Larman and Rogers proved $f(n) \\geq m_1 \\cdot n$ by a probabilistic argument: a random translate of a high-density unit-distance-free set captures $\\geq m_1 n$ of any $n$ given points in expectation.\n\n**Croft's Construction (1967)**: Croft built explicit unit-distance-free sets from hexagonal lattices, proving $m_1 \\geq 0.22936$. Combined with Larman-Rogers: $f(n) \\geq 0.22936n$. This lower bound has stood for over 55 years.\n\n**The Moser Spindle (1961)**: Leo and William Moser constructed a 7-vertex UDG with independence number exactly 2 (and chromatic number 4). By tiling with $\\lfloor n/7 \\rfloor$ copies: $f(n) \\leq (2/7)n \\approx 0.286n$.\n\n**ACMVZ Barrier (2023)**: Ambrus, Csiszárik, Matolcsi, Varga, and Zsámboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods — the constraint $d(p,q) \\neq 1$ translates to conditions on Bessel function zeros in the Fourier domain. Since $0.247 < 0.25 = 1/4$, this establishes a *barrier*: the density method alone cannot prove $f(n) \\geq n/4$.\n\n**De Grey and Hadwiger-Nelson (2018)**: The chromatic number $\\chi$ of $\\mathbb{R}^2$ satisfies $5 \\leq \\chi \\leq 7$ (de Grey improved the lower bound from 4 to 5). Since $\\alpha(G) \\cdot \\chi(G) \\geq |V(G)|$, we get $f(n) \\geq n/\\chi \\geq n/7$.\n\n**Current State**: Best bounds $0.22936n \\leq f(n) \\leq (2/7)n$, with the $n/4$ question requiring genuinely new techniques beyond density.",
@@ -230,7 +230,7 @@
     "lineCount": 235,
     "axiomCount": 10,
     "theoremCount": 6,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1070Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -74,7 +74,7 @@
     "lineCount": 323,
     "assumptions": "1 axiom (danzer_finite_maximal_packing), 0 sorries. Zorn existence proof added. Danzer finite maximal packing axiomatized.",
     "theoremCount": 23,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Maximal Segment Packings: Danzer's Construction and Beyond**\n\nThis problem originates from the collaboration of Paul Erdős and Géza Tóth on extremal problems in combinatorial geometry. A **packing** of unit segments in a region is a collection of non-intersecting (interior-disjoint) unit line segments; it is **maximal** if no additional unit segment can be placed without intersecting an existing one — every possible placement is blocked.\n\n**Part (a) — Solved by Danzer**: Erdős asked whether a *finite* maximal packing exists in the unit square $[0,1]^2$. This is non-trivial because a unit segment can be oriented in any direction $\\theta \\in [0, \\pi)$ and positioned at any point, creating an uncountable family of potential placements that must all be blocked by finitely many segments. Ludwig Danzer (1921–2011), a German mathematician known for his work on discrete and convex geometry (including the Danzer set problem), constructed an explicit finite configuration achieving this. Erdős paid him \\$10 for the solution. Danzer's construction carefully places segments at multiple orientations to ensure that every possible unit segment in the square intersects at least one existing segment.\n\n**Part (b) — Open**: Does there exist *any* region $R \\subseteq \\mathbb{R}^2$ with a countably infinite maximal packing of disjoint unit segments? A key observation is that the unit square $[0,1]^2$ can contain at most finitely many disjoint unit segments (by a compactness argument: each segment has a positive-area 'exclusion zone', and $[0,1]^2$ has finite area). So the question necessarily requires working in a larger, potentially unbounded region. The difficulty is that in an unbounded region, one must block all possible orientations and positions with countably many segments — a much harder blocking condition than in the bounded case.\n\n**Endpoint variant**: A natural relaxation allows segments to touch at their endpoints (but not cross). Whether a finite maximal configuration exists under this weaker disjointness condition is also open.\n\nThe problem connects to several threads in combinatorial geometry: maximal independent sets in geometric intersection graphs, the theory of blocking sets, and the study of packing density and saturation.",
@@ -306,7 +306,7 @@
     "lineCount": 323,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos1071Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1075/meta.json
+++ b/src/data/proofs/erdos-1075/meta.json
@@ -79,7 +79,7 @@
     "lineCount": 165,
     "assumptions": "2 axioms: erdos_1964_result, threshold_decreasing. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "**Extremal Hypergraph Theory and Dense Substructures**\n\nThe study of extremal problems for hypergraphs — how many edges force certain substructures — began with Turán's theorem (1941) for graphs and was extended to hypergraphs by Erdős, Katona, and others in the 1960s. While the graph case ($r = 2$) is largely understood (Turán, Kruskal-Katona, Erdős-Simonovits supersaturation), the hypergraph case ($r \\ge 3$) remains a frontier of combinatorics.\n\n**Erdős's 1964 Result [Er64f]**: Erdős proved that any $r$-uniform hypergraph on $n$ vertices with at least $\\varepsilon n^r$ edges contains a subhypergraph on $m$ vertices with at least $r^{-r} \\cdot m^r$ edges, where $m \\to \\infty$ with $n$. The proof uses the probabilistic method: randomly sampling vertices with probability $p = 1/r$ preserves each edge with probability $r^{-r}$, and concentration arguments make this derandomizable.\n\n**The 1974 Question [Er74c, p.80]**: Erdős observed that the edge threshold $(1+\\varepsilon)(n/r)^r = (1+\\varepsilon)n^r/r^r$ is vastly weaker than $\\varepsilon n^r$ (differing by a factor of $r^r/\\varepsilon$), yet still guarantees slightly more edges than the 'random baseline'. He asked: under this weaker hypothesis, can the density constant $c_r$ be improved beyond $r^{-r}$?\n\n**Why $r^{-r}$ is Natural**: The constant $r^{-r}$ is the probability that a random $r$-element subset survives when each element is independently included with probability $1/r$. This is the optimal sampling probability for the first moment method. Beating $r^{-r}$ would require exploiting structural properties of dense hypergraphs that go beyond what random sampling captures.\n\n**Current State**: The problem is completely open for all $r \\ge 3$. No improvement to $c_r > r^{-r}$ has been achieved under either threshold. Potential approaches include:\n- **Hypergraph regularity lemma** (Rödl-Schacht, Gowers): provides structural decomposition but constant control is difficult\n- **Spectral methods**: eigenvalue bounds for hypergraph adjacency operators\n- **Container method** (Balogh-Morris-Samotij, Saxton-Thomason): controls independent sets but less directly applicable to dense subgraphs\n- **Algebraic methods**: polynomial and linear-algebraic techniques for hypergraph extremal problems\n\n**Connection to Supersaturation**: The problem is conceptually related to Erdős-Simonovits supersaturation — when slightly above a Turán-type threshold, how much additional structure is forced? For graphs, Razborov's flag algebra method gives tight supersaturation bounds, but extensions to $r \\ge 3$ remain partial.",
@@ -255,7 +255,7 @@
     "lineCount": 165,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1075Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1076/meta.json
+++ b/src/data/proofs/erdos-1076/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 173,
     "assumptions": "2 axioms: ex3, bohman_warnke_theorem. Structure fields are object definitions, not assumptions.",
     "theoremCount": 7,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Brown, Erdős, and Sós (1973) studied extremal problems for r-graphs (hypergraphs). They defined F_k as the family of 3-uniform hypergraphs with k vertices and k-2 edges, and conjectured that ex₃(n, F_k) ~ n²/6 for all k ≥ 5. They proved the k=4 case and showed ex₃(n, F_k) = Θ_k(n²) for all k ≥ 4.\n\nErdős (1974) provided supporting evidence: any 3-uniform hypergraph on n vertices with more than (1/3)C(n,2) edges must contain a member of F_5 or F_6. He also noted that the conjecture 'may easily turn out to be nonsense', highlighting the difficulty of the problem.\n\nThe conjecture was independently proved by Bohman and Warnke (2019) using large girth approximate Steiner triple system constructions, and by Glock, Kühn, Lo, and Osthus (2020). The key insight is that the extremal density n²/6 matches Steiner triple system density — extremal F_k-free hypergraphs resemble approximate Steiner systems with large girth, avoiding short cycles that would create F_k subgraphs.",
@@ -249,7 +249,7 @@
     "lineCount": 173,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1076Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` for 17 gallery
entries where both fields were stale. Counts verified against actual
`def`/`abbrev`/`structure`/`inductive`/`class` declarations in the referenced
Lean sources (excluding `instance`, per existing convention; modifiers
`partial`/`private`/`protected`/`noncomputable`/`unsafe`/`scoped` permitted).

## Evidence

Each diff is a surgical 2-line change touching only the two
`definitionCount` keys (in the top-level `meta` block and in the
`leanFile` block). All other fields preserved verbatim.

Examples:
- `erdos-105`: file declares `abbrev Point`, `structure Line`, `def Line.{contains,isRich,unblocked,richAndUnblocked}`, `def NonCollinear`, `def ErdosPurdyConjecture`, `noncomputable def {incidenceCount,thresholdFunction}`, `def openProblem_{n_minus_4,exact_threshold}`, `abbrev PointD`, `structure KFlat`, `def KFlat.{isRich,unblocked}`, `def NonDegenerate`, `def {higherDimAnalogue,threeSpaceCase}` → 19 (was 17).
- `continuum-hypothesis`: file declares `def {continuum,aleph_one,CH,CH_alt,GCH}`, `structure {ZFC,ZFCModel}`, `def {holds_CH,holds_notCH}`, `structure {ConstructibleUniverse,ForcingExtension}`, `def RelativelyConsistent` → 12 (was 8).

Affected slugs:
- `continuum-hypothesis` (8 → 12)
- `continuum-hypothesis-oq-01` (3 → 4)
- `erdos-1041` (4 → 5)
- `erdos-1042` (6 → 7)
- `erdos-105` (17 → 19)
- `erdos-105-oq-05` (13 → 15)
- `erdos-106` (12 → 14)
- `erdos-106-oq-02` (16 → 19)
- `erdos-1066` (5 → 6)
- `erdos-1066-oq-04` (5 → 6)
- `erdos-1067` (10 → 11)
- `erdos-1068` (6 → 7)
- `erdos-1069` (13 → 14)
- `erdos-1070` (6 → 7)
- `erdos-1071` (15 → 16)
- `erdos-1075` (5 → 6)
- `erdos-1076` (10 → 11)

Continues the batch series filling alphabetic gaps after PRs #17441,
#17462, #17466, #17469, #17474, #17492 (which covered erdos-1000-104,
batches a-b, c-d, e-l, m-s).

---
Automated fix by lean-mechanic agent.