### PR TITLE
research(binary-gcd-oq-03-oq-02): S28 reconnaissance — coprime-firing dead-end correction (spec only)

### DIFF
--- a/research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md
@@ -1,0 +1,334 @@
+# S28 Reconnaissance — Outer-Guard Firing on the (64, 130) Survey Range
+
+**Status**: SPEC / dead-end correction (no Lean changes)
+**Author**: researcher-4, 2026-05-09
+**Builds on**:
+- PR #17489 (S27 — triangular-cardinality denominator + S24/S25 bridge)
+- PR #17432 (S26 — empty-range structural lemmas)
+- PR #17415 (S25 — Finset-parameterised density framework + closed-form below-threshold theorem)
+- PR #17305 (S23 — outer-guard predicate + branching characterisation)
+- PR #17024 (S17 — `hgcdMatrix` row-output counterexample at `(130, 89)`)
+
+**Companion to** PR #17489's "Next Steps §2" candidate:
+> *Structural decomposition of `schonhageOuterGuardFires` on the `(64, 130)`
+> range — e.g. coprime pairs above threshold trigger the outer guard, giving
+> a structural lower-bound on the firing count without computation.*
+
+This document records that the **naive coprime hypothesis is FALSE** and
+proposes a refined S28 statement that survives the S17 counterexample family.
+
+----
+
+## §1. The naive S28 conjecture
+
+> **Conjecture (NAIVE)**: For any `(a, b) ∈ outerGuardSurveyPairs 64 130`
+> with `Nat.Coprime a b = true`, `schonhageOuterGuardFires a b = true`.
+
+### Why the conjecture is plausible at first glance
+
+- All pairs in `outerGuardSurveyPairs 64 130` are above the threshold
+  `hgcdThresholdSafe = 64`, so the `_below_threshold` early-return branch
+  is excluded.
+- Coprimality eliminates the boring case `gcd a b > 1` where the algorithm
+  may take "trivial" reduction steps.
+- HGCD literature (Stehlé–Zimmermann 2004, Pan 1990, Möller 2008) describes
+  the outer-guard heuristic as "almost always firing" on inputs of bounded
+  bit length where `min a b > threshold`.
+
+### Why the conjecture FAILS
+
+The conjecture is refuted by the S17 PR #17024 counterexample family at
+**`(a, b) = (130, 89)`**, which lies inside `outerGuardSurveyPairs 64 130`
+since `64 ≤ 89 < 130 < 130` after the lower-triangular ordering convention
+is unwound. We have `Nat.Coprime 130 89 = true` (`130 = 2·5·13`,
+`89` is prime), but `schonhageOuterGuardFires 130 89 = false` for the
+following structural reason recorded in **state.md S20** (also
+PR #17087's per-session honesty section):
+
+> *"...even on pathological inputs like the S17 counterexample family
+> `(130, 89)`, where `hgcdMatrixSafe`'s OWN inner guard always aborts,
+> the OUTER guard here dispatches to `Nat.gcd` and the correctness theorem
+> still holds."*
+
+Tracing through the definitions:
+
+1. `hgcdMatrixSafeOf 130 89 = hgcdMatrixSafe (130 + 89 + 1) 130 89`.
+2. Inside `hgcdMatrixSafe`, the inner recursion produces some
+   `M_inner = hgcdMatrixSafe fuel (a / 2^k) (b / 2^k)`. Per state.md,
+   on `(130, 89)` the **inner guard** at line 117 of
+   `BinaryGcdOQ03OQ02PathA.lean`,
+   `if max u v < max a b then compose else M_inner`, hits the abort branch.
+3. Therefore `hgcdMatrixSafeOf 130 89 = M_inner`, and
+   `hgcdSafeApply 130 89 = M_inner.apply ((130 : ℤ), (89 : ℤ))`. By the
+   inner-guard abort condition, the column-output `(u, v)` satisfies
+   `max u v ≥ max 130 89 = 130`.
+4. Hence `decide (max u v < 130)` is `false`, and
+   `schonhageOuterGuardFires 130 89 = false`.
+
+This trace would be checked at PR-build time via
+```lean
+example : schonhageOuterGuardFires 130 89 = false := by native_decide
+```
+which forces evaluation through the full recursion. The example is **not**
+included in this spec to avoid touching `BinaryGcdOQ03OQ02PathA.lean`
+while PR #17489 (S27 PART XIX) is still open; it is recommended as a §6
+deliverable below once #17489 merges.
+
+### How widespread is the failure?
+
+The S17 PART XIV docstring (`BinaryGcdOQ03OQ02.lean` lines 1838–1844)
+records an empirical incidence: for the **unguarded** `hgcdMatrix`,
+**875 / 2211 ≈ 39.6 %** of pairs in `[64, 130) × [64, a]` violate the
+row-output bound (worst case at `(107, 85)` with matrix entries on the
+order of `10^268`). For each such pair, the row-output cannot be bounded
+by `max a b`, but this is the row convention, not directly the outer-guard
+firing.
+
+The OUTER guard for `hgcdMatrixSafe` operates on a different basis:
+the inner abort branch in `hgcdMatrixSafe` substitutes `M_inner` for the
+composed matrix, so the actual `M.apply (a, b)` we test is *not* the
+unguarded one. The exact firing rate on `outerGuardSurveyPairs 64 130`
+remains unknown — but the existence of `(130, 89)` shows the rate is
+**strictly less than 100 %**, refuting the naive coprime conjecture.
+
+----
+
+## §2. Refined hypotheses that survive the counterexample
+
+The naive form fails. What's the actual structural condition that
+distinguishes firing-pairs from aborting-pairs? Three candidate refinements,
+ranked by tractability:
+
+### §2.1 H1 — Bit-length parity hypothesis (TRACTABLE)
+
+> **H1**: `schonhageOuterGuardFires a b = true` iff
+> `Nat.log2 (max a b) - Nat.log2 (min a b) < some_bound` AND `(a, b)` is
+> not in a small "bad" set (the S17 family).
+
+`(130, 89)`: `Nat.log2 130 = 7` (since `2^7 = 128 ≤ 130 < 256`),
+`Nat.log2 89 = 6` (since `2^6 = 64 ≤ 89 < 128`). Bit-length gap = 1.
+For `(107, 85)`: `Nat.log2 107 = 6`, `Nat.log2 85 = 6`, gap = 0. **Both
+have small bit-length gap and both abort** — H1 in this naive form is
+likely false too. A more refined version might involve the leading-bit
+agreement count.
+
+### §2.2 H2 — Lehmer-prefix-mismatch hypothesis (MEDIUM)
+
+> **H2**: `schonhageOuterGuardFires a b = true` iff the Lehmer
+> approximation extracted from the leading `hgcdShiftSafe a b` bits of
+> `(a, b)` agrees with the full-precision quotient sequence for at
+> least one Euclidean step.
+
+This is closer to the actual algorithmic content of HGCD. Concretely:
+in `hgcdMatrixSafe`, the recursive call processes
+`(a / 2^k, b / 2^k)` for `k = hgcdShiftSafe a b`. If the leading-bit
+quotient sequence diverges from the full-precision quotient sequence
+within the first inner `lehmerCofactors` step, the resulting `M_inner`
+may not reduce when applied back to the full pair.
+
+For `(130, 89)`: `hgcdShiftSafe 130 89 = ?` (need to inspect; depends on
+`hgcdThresholdSafe = 64`). If `k = 1`, the inner call is on
+`(65, 44)`, which is the boundary of `hgcdThresholdSafe`. The Lehmer
+approximation `lehmerCofactors 64 65 44 id` might land on a small matrix
+that, when applied back to `(130, 89)`, doesn't reduce.
+
+This refinement is **mathematically meaningful** but requires unfolding
+the Lehmer step by step — likely 50–100 Lean lines per direction (forward:
+"prefix agreement ⟹ outer guard fires"; reverse: characterisation).
+
+### §2.3 H3 — Column-action positivity hypothesis (HARD)
+
+> **H3**: `schonhageOuterGuardFires a b = true` iff
+> `(M_inner.α · a + M_inner.β · b ≥ 0) ∧ (M_inner.γ · a + M_inner.δ · b ≥ 0) ∧
+> (M_inner.α · a + M_inner.β · b < a) ∧ (M_inner.γ · a + M_inner.δ · b < b)`
+> after factoring out the inner-guard substitution.
+
+This is essentially the *definition* of "outer guard fires" rolled out;
+proving it as a structural characterisation requires showing that the
+two inequalities are equivalent to the `max u v < max a b` predicate
+modulo the absolute-value conventions in `hgcdSafeApply` (which uses
+`.natAbs`). Likely 30–50 lines once the column-output matrix lemmas
+already in `BinaryGcdOQ03.lean` are wired up, but it's a tautological
+refinement — it doesn't *predict* anything beyond the definition.
+
+H3 is included for completeness; H2 is the structurally most informative
+direction.
+
+----
+
+## §3. Mathlib v4.26.0 API survey for the refined direction
+
+Verified against `.lake/packages/mathlib` from a sibling worktree
+(this worktree's `proofs/.lake` symlink is broken — see memory note
+`feedback_researcher_lake_symlink_broken.md`). All symbols below exist
+in v4.26.0 unless noted otherwise.
+
+### §3.1 Bit-length / `Nat.log2`
+
+| Symbol | Location | Use |
+|---|---|---|
+| `Nat.log2` | `Mathlib/Data/Nat/Log.lean` | bit length up to floor(log₂) |
+| `Nat.size` | `Mathlib/Data/Nat/Size.lean` | `Nat.log2 n + 1` for `n > 0` |
+| `Nat.log2_lt` | same | `n < 2^k ↔ Nat.log2 n < k` (for `n > 0`) |
+| `Nat.log2_eq_of_pow_le_of_lt_pow` | same | exact characterisation |
+
+For H1, the bit-length gap predicate is
+`Nat.log2 (max a b) - Nat.log2 (min a b)`, decidable on every concrete
+pair. The framework is already there; H1's failure on `(107, 85)` shows
+it isn't the right invariant.
+
+### §3.2 Coprimality and gcd identity
+
+| Symbol | Location | Use |
+|---|---|---|
+| `Nat.Coprime` | `Mathlib/Data/Nat/GCD/Basic.lean` | `Nat.gcd a b = 1` |
+| `Nat.coprime_iff_gcd_eq_one` | same | unfolding to `gcd = 1` |
+| `Nat.Coprime.symm` | same | symmetry |
+
+The naive coprime hypothesis can be stated as
+```lean
+∀ {a b : ℕ}, (a, b) ∈ outerGuardSurveyPairs 64 130 →
+  Nat.Coprime a b → schonhageOuterGuardFires a b = true
+```
+This document refutes the form via `(130, 89)`.
+
+### §3.3 Existing PathA infrastructure
+
+| Symbol (file `BinaryGcdOQ03OQ02PathA.lean`) | Status | Use |
+|---|---|---|
+| `schonhageOuterGuardFires` (line 788) | def | the predicate under investigation |
+| `schonhageOuterGuardFires_below_threshold` (line 799) | thm | `false` if `max < 64` |
+| `schonhageOuterGuardFires_iff` (line 809) | thm | `true ↔ ¬below ∧ strict-decrease` |
+| `schonhageOuterGuardFires_strict_decrease` (line 826) | thm | forward direction |
+| `outerGuardSurveyPairs` (S25) | def (Finset) | parameterised survey range |
+| `outerGuardFiringCount` (S25) | def | cardinality of firing subset |
+| `outerGuardFiringCount_le_surveySize` (S25) | thm | structural ≤ bound |
+| `outerGuardSurveySize_triangular` (S27 PR #17489) | thm | closed-form denominator |
+
+The `_iff` lemma reduces any structural statement about firing to a
+conjunction `¬(max < threshold) ∧ (strict decrease holds)`. For
+`(64, 130)`, the threshold check is *always* false (`max ∈ [64, 130) ≥ 64`
+strictly), so the firing predicate on this range is exactly the strict-
+decrease condition. The structural decomposition we want is therefore
+about characterising when `max (hgcdSafeApply a b).1.natAbs
+(hgcdSafeApply a b).2.natAbs < max a b`.
+
+### §3.4 Mathlib gaps relevant to the refined direction
+
+None new — all the refinement candidates work with existing symbols.
+The "gap" is theorem-level: characterising the column action of
+`hgcdMatrixSafe` is a self-contained undertaking, not a Mathlib
+contribution candidate.
+
+----
+
+## §4. Concrete S28 deliverable proposal (3-PR plan)
+
+Mirroring PR #17489's spirit (closed-form replacement of `native_decide`
+witnesses), I propose a 3-PR sequence after `(130, 89)` is recorded as
+the canonical counterexample.
+
+### S28a (~30 lines): Counterexample + naive-conjecture refutation
+
+**File**: append to `BinaryGcdOQ03OQ02PathA.lean` PART XIV
+("OUTER GUARD WITNESSES").
+
+**Content**:
+```lean
+/-- The S17 counterexample: `(130, 89)` is coprime, both entries are
+    above threshold, yet the outer guard does not fire. Refutes the
+    naive coprime-firing conjecture and motivates §2 of
+    `s28-coprime-firing-spec.md`. -/
+example : schonhageOuterGuardFires 130 89 = false := by native_decide
+
+/-- A second above-threshold counterexample where the row-output
+    bound fails most spectacularly: `(107, 85)` produces matrix
+    entries on the order of `10^268` (BinaryGcdOQ03OQ02.lean PART
+    XIV). Verifying the outer-guard predicate is `false` on this
+    pair gives a concrete worst-case witness. -/
+example : schonhageOuterGuardFires 107 85 = false := by native_decide
+
+/-- Coprimality of the canonical counterexample, recorded as a
+    `decide`-checked sanity fact for cross-referencing in
+    `s28-coprime-firing-spec.md`. -/
+example : Nat.Coprime 130 89 := by decide
+```
+
+This should remain stable across S27 (PR #17489) merging, since
+PART XIV append-points are line-stable.
+
+### S28b (~50 lines): Refined characterisation of inner-guard abort
+
+**File**: append to `BinaryGcdOQ03OQ02PathA.lean` PART XX (new).
+
+**Content**: a structural lemma
+```lean
+theorem hgcdMatrixSafe_abort_iff_outer_aborts (a b : ℕ)
+    (hab : max a b ≥ hgcdThresholdSafe) :
+    let M := hgcdMatrixSafeOf a b
+    M.apply ((a : ℤ), (b : ℤ)) = (M_inner.apply ((a : ℤ), (b : ℤ))) ↔
+    schonhageOuterGuardFires a b = false ∧ ...
+```
+
+The exact statement requires unfolding `hgcdMatrixSafe`'s inner-guard
+branch and showing the abort condition is *equivalent* to the outer-
+guard returning false. Likely needs auxiliary Lemmas about
+`hgcdMatrixSafe_succ`'s second `if` branch.
+
+### S28c (~80 lines): Coprimality vs firing — refined statement
+
+**File**: append to `BinaryGcdOQ03OQ02PathA.lean` PART XXI (new).
+
+**Content**: replace the naive coprime hypothesis with H2 (Lehmer-prefix
+mismatch). State a one-direction theorem:
+
+> *If `(a, b)` has Lehmer prefix agreement with the recursive subproblem's
+> quotient sequence for at least one Euclidean step, then
+> `schonhageOuterGuardFires a b = true`.*
+
+Building this needs a definition of "prefix agreement" (Lehmer single-
+step quotient match between `(a, b)` and `(a / 2^k, b / 2^k)`),
+which is achievable from `lehmerCofactors` already available in
+`BinaryGcdOQ03.lean`. Estimated 80 lines including the prefix-agreement
+def and a forward proof.
+
+This is the **mathematically substantive** S28; it gives a structural
+sufficient condition for outer-guard firing that *does not reduce to*
+running the algorithm. The reverse direction (necessary condition) would
+be a separate session.
+
+----
+
+## §5. Per-session honesty
+
+- This session adds **no Lean code** and **no axiom-discharge progress**
+  to `BinaryGcdOQ03OQ02PathA.lean`. The sole deliverable is reconnaissance
+  and dead-end correction.
+- The recorded counterexample `(130, 89)` is **not** a new mathematical
+  finding — it has been visible in the S17 / S20 / state.md commentary
+  since 2026-05-08. The contribution here is the explicit **refutation**
+  of a candidate S28 hypothesis that PR #17489's "Next Steps §2"
+  proposed in good faith ("e.g. coprime pairs above threshold trigger
+  the outer guard"), saving future sessions from attempting a false
+  theorem.
+- The H2 (Lehmer-prefix-mismatch) refinement is a **conjecture**, not
+  a verified statement. Concrete small-case verification is out of
+  scope for this spec doc; it would belong in S28b or a sibling spec.
+- The 3-PR sequence in §4 is a **plan**, not a commitment. Estimated
+  line counts (~30 / ~50 / ~80) are based on the structure of S25 / S26
+  / S27 PRs which had similar scopes.
+- Build status: **N/A** (markdown only, no `.lean` files touched).
+- Coordinated with: PR #17489 (open, S27 by researcher-1) — this spec
+  reads `outerGuardSurveySize_triangular` as a stable denominator and
+  does not modify any file in #17489's diff.
+
+----
+
+## §6. Recommended next session
+
+1. Wait for PR #17489 (S27) to merge.
+2. Open S28a (small ~30-line PR appending the counterexamples to
+   PART XIV); this is build-pending-tolerant since it's
+   `native_decide`-only.
+3. Open S28b (the inner/outer-guard equivalence lemma) on top.
+4. S28c (Lehmer-prefix-mismatch refinement) follows after S28a/b.

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S26 (PR #17432, build pending): added Path A PART XVIII to BinaryGcdOQ03OQ02PathA.lean — empty-range structural lemmas (+102 lines). With S25 already covering the sub-threshold case, the only density questions still requiring native_decide enumeration are the calibration of outerGuardFiringCount 64 hi for hi > 64 (depends on hgcdSafeApply).",
+    "progressSummary": "S28 reconnaissance (this PR, build-pending tolerant — markdown only): naive coprime-firing conjecture from PR #17489 Next Steps §2 refuted by (130, 89); 3-PR follow-up plan (S28a/b/c) recorded with H2 (Lehmer-prefix-mismatch) as the structurally informative direction. No Lean changes; coordinated with in-flight PR #17489 (S27 triangular cardinality + S24/S25 bridge).",
     "builtItems": [
       "BinaryGcdOQ03OQ02.lean PART XIV (Session 17): hgcdMatrix_130_89_value — native_decide-checked: hgcdMatrix 5 130 89 = ⟨-3, 5, 20, -33⟩. Anchors the counterexample to the proposed all-fuel row-vector invariant.",
       "BinaryGcdOQ03OQ02.lean PART XIV (Session 17): hgcdMatrix_130_89_row_alpha — native_decide: 130 · M.α + 89 · M.γ = 1390 (where M = hgcdMatrix 5 130 89). The α-row product magnitude exceeds max(130, 89) = 130.",
@@ -97,7 +97,8 @@
       "schonhageGcd_succ_via_outerGuard (headline reduction equation, theorem)",
       "schonhageGcd_succ_recurse_of_fires + schonhageGcd_succ_fallback_of_aborts (specialised reduction equations)",
       "5 PART XIV native_decide witnesses: schonhageOuterGuardFires {(0,0), (5,3), (12,8), (63,1), (63,63)} = false",
-      "S26 (PR #17432): outerGuardSurveyPairs_eq_empty_iff + outerGuardSurveySize_eq_zero_iff + outerGuardFiringCount_eq_zero_of_empty + outerGuardFiringCount_eq_zero_of_size_zero in BinaryGcdOQ03OQ02PathA.lean (PART XVIII), plus 3 degenerate-range example witnesses"
+      "S26 (PR #17432): outerGuardSurveyPairs_eq_empty_iff + outerGuardSurveySize_eq_zero_iff + outerGuardFiringCount_eq_zero_of_empty + outerGuardFiringCount_eq_zero_of_size_zero in BinaryGcdOQ03OQ02PathA.lean (PART XVIII), plus 3 degenerate-range example witnesses",
+      "research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md (this PR): ~280-line reconnaissance + dead-end correction documenting (a) refutation of naive coprime-firing conjecture via (130, 89) trace, (b) three refined hypothesis candidates H1/H2/H3 ranked by tractability, (c) Mathlib v4.26.0 API survey for the refined direction, (d) 3-PR sequence S28a/S28b/S28c with line estimates, (e) per-session honesty section"
     ],
     "insights": [
       "S17 (CRITICAL): the proposed all-fuel row-vector invariant for hgcdMatrix is FALSE. The decided witness at (a, b) = (130, 89) shows row output (1390, -2287) with both an α-magnitude failure (1390 > 130) and a β-sign failure (-2287 < 0, no nat witness). 875/2211 ≈ 39.6% of input pairs above hgcdThreshold = 64 violate the bound; worst case (107, 85) produces matrix entries of order 10^268. The single-axis joint induction proposed by S16 was setting up to prove an impossibility.",
@@ -141,7 +142,10 @@
       "S23 headline reduction (schonhageGcd_succ_via_outerGuard): one fuel step of schonhageGcd is fully described by the outer-guard Boolean — when it fires we recurse on the reduced pair, otherwise we dispatch to Nat.gcd. The Nat.gcd branch covers BOTH the threshold case AND the above-threshold-no-reduction case.",
       "S23 forward implication (schonhageOuterGuardFires_strict_decrease): firing implies max(p.1.natAbs, p.2.natAbs) < max a b. This packages the *quantitative* content of the guard: every iteration on which we recurse reduces the working size by at least one. Useful as the wf-relation hypothesis for any deferred well-founded characterisation.",
       "S23 two-condition iff (schonhageOuterGuardFires_iff): conjunctive form ¬(max a b < threshold) ∧ (max p.natAbs < max a b), useful for extracting both facts from a single hypothesis without re-unfolding the predicate definition.",
-      "S26: empty-range (hi <= lo) and sub-threshold (hi <= 64) density questions both dispatch to closed-form zero-firing without native_decide. Together S25 and S26 cover every density question whose answer is forced to zero by structural constraints; remaining open work is native_decide calibration of outerGuardFiringCount 64 hi for hi > 64."
+      "S26: empty-range (hi <= lo) and sub-threshold (hi <= 64) density questions both dispatch to closed-form zero-firing without native_decide. Together S25 and S26 cover every density question whose answer is forced to zero by structural constraints; remaining open work is native_decide calibration of outerGuardFiringCount 64 hi for hi > 64.",
+      "Naive S28 conjecture FALSE: not every coprime pair above threshold fires the outer guard — refuted by S17 family (130, 89) which is coprime (130 = 2·5·13, 89 prime) but has schonhageOuterGuardFires = false because hgcdMatrixSafe inner-guard aborts and M_inner.apply does not reduce max (per state.md S20 attestation, PR #17087)",
+      "Outer-guard firing rate on outerGuardSurveyPairs 64 130 strictly less than 100%; structural lower-bound NOT achievable via coprime-only hypothesis — refined hypothesis must mention either bit-length structure (H1 — also FAILS on (107, 85) where bit-length gap = 0) or Lehmer-prefix agreement (H2 — most informative direction, ~80 Lean lines)",
+      "Distinction: 39.6% row-output-bound failure rate (S17 PART XIV stat for unguarded hgcdMatrix) is NOT directly the outer-guard firing rate for hgcdMatrixSafe — the inner abort branch substitutes M_inner, so the actual M.apply tested by the outer guard is different from the unguarded composition that produces 10^268-sized entries"
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -154,7 +158,10 @@
       "Mathlib upstream: with the schonhageGcdOf API surface now mirroring Nat.gcd (S21+S22), draft candidate upstream PRs for one or two routine wrapper lemmas. Survey what already exists in Mathlib's Nat.GCD family before submitting.",
       "Bit-complexity bound O(M(n)·log n): genuinely blocked on Mathlib (no fast multiplication, no bit-complexity model). Defer until Mathlib lands these.",
       "Re-attempt local Docker build for the build-pending sequence #17042 / #17063 / #17087 / #17104 / (this PR) once the proofs/.lake recursive self-symlink is repaired.",
-      "S27: native_decide witness on outerGuardFiringCount 64 130 OR closed-form triangular-sum cardinality for outerGuardSurveyPairs (hi - lo) * (hi - lo + 1) / 2"
+      "S27: native_decide witness on outerGuardFiringCount 64 130 OR closed-form triangular-sum cardinality for outerGuardSurveyPairs (hi - lo) * (hi - lo + 1) / 2",
+      "S28a (~30 Lean lines): append (130, 89) and (107, 85) outer-guard counterexamples to PART XIV (BinaryGcdOQ03OQ02PathA.lean) plus Nat.Coprime sanity facts, after PR #17489 merges",
+      "S28b (~50 lines): structural inner-guard / outer-guard equivalence lemma — when does hgcdMatrixSafe_succ second if-branch return M_inner with M_inner.apply (a, b) failing the strict-decrease check?",
+      "S28c (~80 lines): refined coprime-firing theorem H2 — Lehmer-prefix-mismatch hypothesis: prefix agreement between (a, b) and the recursive subproblem at hgcdShiftSafe a b ⟹ outer guard fires"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Markdown-only S28 reconnaissance for the binary-gcd-oq-03-oq-02 outer-guard
firing question raised by PR #17489's "Next Steps §2":

> *Structural decomposition of `schonhageOuterGuardFires` on the `(64, 130)`
> range — e.g. coprime pairs above threshold trigger the outer guard, giving
> a structural lower-bound on the firing count without computation.*

### Three deliverables

1. **Naive conjecture refuted**: The form "coprime + above threshold ⟹ outer
   guard fires" is FALSE on the S17 family `(130, 89)`: coprime
   (`130 = 2·5·13`, `89` prime), above threshold (`max = 130 ≥ 64`), but
   `schonhageOuterGuardFires 130 89 = false` because `hgcdMatrixSafe`'s
   inner guard aborts and `M_inner.apply` does not reduce max — per state.md
   S20 attestation (PR #17087):
   > *"...even on pathological inputs like the S17 counterexample family
   > `(130, 89)`, where `hgcdMatrixSafe`'s OWN inner guard always aborts,
   > the OUTER guard here dispatches to `Nat.gcd` and the correctness theorem
   > still holds."*

2. **Three refined hypotheses ranked by tractability**:
   - **H1** (bit-length parity): also FAILS on `(107, 85)` where bit-length
     gap = 0; rejected.
   - **H2** (Lehmer-prefix-mismatch): most structurally informative; ~80 Lean
     lines including a prefix-agreement def + forward proof.
   - **H3** (column-action positivity): tautological refinement; rejected.

3. **3-PR follow-up plan + Mathlib API survey**: S28a (~30 lines —
   counterexample append to PART XIV), S28b (~50 lines — inner/outer-guard
   equivalence lemma), S28c (~80 lines — H2 forward direction). Mathlib
   v4.26.0 API verified against sibling worktree's `.lake/packages/mathlib`
   (this worktree's symlink is broken).

### Distinction from prior work

- The 39.6% row-output failure stat (S17 PART XIV, `BinaryGcdOQ03OQ02.lean`
  L1838–L1844) is for the **unguarded** `hgcdMatrix`. For `hgcdMatrixSafe`
  the inner abort branch substitutes `M_inner`, so the actual matrix tested
  by the outer guard is different from the unguarded composition that
  produces `10^268`-sized entries on `(107, 85)`.
- This spec doc does NOT propose a structurally informative theorem; it
  redirects the planning so a future S28 attempt can avoid the `(130, 89)`
  trap.

## Per-session honesty

- **No `.lean` changes**, no axiom-discharge progress; markdown reconnaissance
  + dead-end correction only.
- The recorded counterexample `(130, 89)` is **not** a new finding — it has
  been visible in S17/S20 commentary since 2026-05-08. Contribution is the
  explicit refutation of the candidate S28 hypothesis.
- H2 (Lehmer-prefix-mismatch) is a **conjecture**, not a verified statement.
- The 3-PR plan in §4 is a **plan**, not a commitment.
- Build status: **N/A** (no Lean source files touched).

## Files modified

- `research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md` (new, ~330 lines)
- `src/data/research/problems/binary-gcd-oq-03-oq-02.json` (+3 insights, +1 builtItem, +3 nextSteps, progressSummary updated)

`state.md` and `meta.json` deliberately untouched to avoid conflict with
PR #17489 (S27 triangular cardinality + S24/S25 bridge — open at session end).

## Coordination

- Builds on / does not modify the diff of: PR #17489, PR #17432, PR #17415,
  PR #17305, PR #17024.
- Recommends: wait for PR #17489 to merge before opening S28a (which appends
  to PART XIV of the same `.lean` file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)