### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 13 — primeCounting subordination chain (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -359,6 +359,78 @@ theorem lcmRange_le_pow_primeCounting (n : ℕ) :
   rw [hpi] at h
   exact h
 
+/-- **Trivial bound on the prime-counting function**: `π(n) ≤ n`.
+
+    Holds for every `n` because the count of primes in `{0, 1, …, n}`
+    excludes `0` (which is not prime), so the prime filter is a subset
+    of `(Finset.range (n+1)).erase 0`, whose cardinality is `n`.
+
+    Used in Iter 13 to chain `lcmRange n ≤ n^π(n) ≤ n^n`, making
+    explicit that the prime-counting bound from Iter 11
+    (`lcmRange_le_pow_primeCounting`) is at least as strong as the
+    factorial-derived `lcmRange_le_self_pow` (Part 3). -/
+theorem primeCounting_le_self (n : ℕ) : Nat.primeCounting n ≤ n := by
+  have hpi : ((Finset.range (n + 1)).filter Nat.Prime).card =
+      Nat.primeCounting n := by
+    unfold Nat.primeCounting Nat.primeCounting'
+    exact (Nat.count_eq_card_filter_range Nat.Prime (n + 1)).symm
+  rw [← hpi]
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · -- n = 0: range 1 = {0}, 0 isn't prime, so the filter is empty,
+    -- card = 0 ≤ 0.
+    simp [Finset.range_one, Finset.filter_singleton, Nat.not_prime_zero]
+  -- n ≥ 1: filter ⊆ (range (n+1)).erase 0, card erase = n.
+  have h_subset :
+      (Finset.range (n + 1)).filter Nat.Prime ⊆
+        (Finset.range (n + 1)).erase 0 := by
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_erase] at hp ⊢
+    refine ⟨?_, hp.1⟩
+    intro h0
+    rw [h0] at hp
+    exact Nat.not_prime_zero hp.2
+  have h_card : ((Finset.range (n + 1)).erase 0).card = n := by
+    rw [Finset.card_erase_of_mem (Finset.mem_range.mpr (Nat.succ_pos n))]
+    simp
+  calc ((Finset.range (n + 1)).filter Nat.Prime).card
+      ≤ ((Finset.range (n + 1)).erase 0).card :=
+        Finset.card_le_card h_subset
+    _ = n := h_card
+
+/-- **Monotone exponent**: `n^π(n) ≤ n^n` for `n ≥ 1`.
+
+    A one-line consequence of `Nat.pow_le_pow_right` applied to
+    `primeCounting_le_self`. Packaged as a named lemma so the Iter 13
+    chain `lcmRange n ≤ n^π(n) ≤ n^n` reads cleanly. -/
+theorem pow_primeCounting_le_pow_self (n : ℕ) (hn : 1 ≤ n) :
+    n ^ Nat.primeCounting n ≤ n ^ n :=
+  Nat.pow_le_pow_right hn (primeCounting_le_self n)
+
+/-- **Re-derivation of `lcmRange_le_self_pow` via the prime-counting
+    route**: `lcmRange n ≤ n^n` proved through the chain
+    `lcmRange n ≤ n^π(n) ≤ n^n`.
+
+    Documents that the Iter 10/11 prime-counting bound subordinates
+    the trivial Part 3 bound: every value reachable by
+    `lcmRange_le_pow_primeCounting` is also covered by
+    `lcmRange_le_self_pow`. The chain makes the dependency
+    `Iter 11 ⟹ Iter 13 ⟹ Part 3` explicit:
+
+    ```
+    lcmRange n  ≤  n ^ π(n)        -- Iter 11 (Chebyshev decomposition)
+                ≤  n ^ n            -- Iter 13 (since π(n) ≤ n)
+    ```
+
+    The `n = 0` boundary case (`lcmRange 0 = 1 = 0^0`) is handled
+    directly by `lcmRange_zero` because `Nat.pow_le_pow_right`
+    requires the base to be `≥ 1`. -/
+theorem lcmRange_le_pow_self_via_primeCounting (n : ℕ) :
+    lcmRange n ≤ n ^ n := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp [lcmRange_zero]
+  exact le_trans (lcmRange_le_pow_primeCounting n)
+    (pow_primeCounting_le_pow_self n hn)
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,18 +4,33 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-09 (Iteration 12, researcher-10)
-**Iteration**: 12
+**Last Updated**: 2026-05-09 (Iteration 13, researcher-10)
+**Iteration**: 13
 
 ## Current Focus
-Iteration 12 (2026-05-09, this PR): **three independent surgical fixes**
-to unblock the build for iters 5–11 (which all merged with
-`(build pending)` status). Empirically discovered by docker-build of
-iter 11 plus targeted re-investigation: the original "single drift"
-diagnosis from the iter 11 PR was incomplete — only one of the three
-errors is true Mathlib drift; the other two are subtle elaboration
-issues introduced by iter 8 / iter 2 that survived because the file
-has not had a clean build since iter 4.
+Iteration 13 (2026-05-09, this PR): **prime-counting subordination
+chain**. Three new theorems make the dependency
+`Iter 11 ⟹ Iter 13 ⟹ Part 3` explicit by establishing the chain
+`lcmRange n ≤ n^π(n) ≤ n^n`. The middle step is the trivial
+`π(n) ≤ n` bound (`primeCounting_le_self`), proved by observing
+that the prime filter on `Finset.range (n+1)` excludes `0` and so
+fits inside `(Finset.range (n+1)).erase 0`, which has `n` elements.
+Build pending; proof bodies use only Mathlib API already exercised
+by earlier iters (`Nat.count_eq_card_filter_range`,
+`Finset.card_erase_of_mem`, `Nat.pow_le_pow_right`). File 488 → 560
+lines (+72), theorems 37 → 40 (+3), definitions/sorries/axiomCount
+unchanged.
+
+----
+
+Iteration 12 (2026-05-09, retained for context): **three independent
+surgical fixes** to unblock the build for iters 5–11 (which all
+merged with `(build pending)` status). Empirically discovered by
+docker-build of iter 11 plus targeted re-investigation: the original
+"single drift" diagnosis from the iter 11 PR was incomplete — only
+one of the three errors is true Mathlib drift; the other two are
+subtle elaboration issues introduced by iter 8 / iter 2 that survived
+because the file has not had a clean build since iter 4.
 
 ### Fix 1 (line 118 — `pow_dvd_lcmRange`): true Mathlib drift
 
@@ -211,7 +226,7 @@ Currently blocked on:
   `4^n` intermediate.
 
 ## Attempt Count
-- Total attempts: 12.
+- Total attempts: 13.
 - Current approach attempts: 0 (Approach 1 not started; awaits Mathlib).
 - Approaches tried: bootstrap with elementary bounds + axiom (iter 1);
   structural-lemma layer for inductive proofs (iter 2); generic
@@ -230,7 +245,12 @@ Currently blocked on:
   three-fix build unblock — Mathlib drift `Nat.pos_pow_of_pos → Nat.pow_pos`
   (line 118), `rw [h1]` cascade fix `→ conv_lhs => rw [h1]` (line 262),
   and `lcmRange_succ` forward-chain re-routing through `dvd_lcmRange`
-  (line 376) — iter 12, this PR; restores build for iters 5–11.
+  (line 376) — iter 12, #17448; restores build for iters 5–11;
+  prime-counting subordination chain `primeCounting_le_self`,
+  `pow_primeCounting_le_pow_self`, `lcmRange_le_pow_self_via_primeCounting`
+  (iter 13, this PR, build pending) — makes explicit that Iter 11's
+  `lcmRange ≤ n^π(n)` subordinates Part 3's `lcmRange ≤ n^n` via
+  the trivial `π(n) ≤ n` bound.
 
 ## Blockers
 - **Mathlib Beta-integral over ℚ**: not in usable form.
@@ -239,16 +259,28 @@ Currently blocked on:
 
 ## Next Action
 
-**Iteration 13 candidate** (was: iter 12 pre-drift-discovery): state
-and prove the chain `lcmRange n ≤ n ^ Nat.primeCounting n ≤ n ^ n`
-(the second inequality holds for n ≥ 1 because `Nat.primeCounting n ≤ n`
-— primes ≤ n are a subset of {2,...,n} hence at most n - 1 ≤ n in
-cardinality). This makes explicit that Iter 10/11 sharpen
-`lcmRange_le_self_pow` (Part 3 of the file). The bound
-`Nat.primeCounting n ≤ n` should be a short proof from
-`Finset.card_filter_le` plus the fact that primes ≥ 2 exclude 0 and
-1 from the count. Deferred from iter 12 because the build was broken;
-once iter 12 (drift fix) merges, iter 13 can land cleanly.
+**Iteration 13 (this PR, build pending)**: prime-counting subordination
+chain. Three new theorems realise the explicit chain
+`lcmRange n ≤ n^π(n) ≤ n^n`:
+
+* `primeCounting_le_self (n : ℕ) : Nat.primeCounting n ≤ n` — the prime
+  filter on `(Finset.range (n+1))` is a subset of the (n+1)-element
+  range with `0` removed (since `0` is not prime), giving cardinality
+  `≤ n`.
+* `pow_primeCounting_le_pow_self (n : ℕ) (hn : 1 ≤ n) :
+  n ^ Nat.primeCounting n ≤ n ^ n` — one-line via
+  `Nat.pow_le_pow_right`.
+* `lcmRange_le_pow_self_via_primeCounting (n : ℕ) :
+  lcmRange n ≤ n ^ n` — re-derives the trivial Part 3 bound by
+  routing through `lcmRange_le_pow_primeCounting` (Iter 11) and the
+  new `pow_primeCounting_le_pow_self`. Documents that the Iter 10/11
+  prime-counting bound subordinates Part 3.
+
+**File delta**: +72 lines (488 → 560), +3 theorems (37 → 40),
+definitions/sorries/axiomCount unchanged. Build pending — proof bodies
+use only standard Mathlib API already exercised by Iter 7/8/9/11
+(`Nat.count_eq_card_filter_range`, `Finset.card_erase_of_mem`,
+`Nat.pow_le_pow_right`).
 
 **Iteration 14 candidate**: connect the prime-counting bound to
 asymptotic Chebyshev-style improvements. Mathlib has

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 488,
-    "theoremCount": 37,
+    "lineCount": 560,
+    "theoremCount": 40,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [


### PR DESCRIPTION
## Summary

Iteration 13 of `basel-problem-oq-01-oq-01-oq-02-oq-03` (Hanson's
bound `lcm(1,...,n) ≤ 3^n`). Three new theorems make the explicit
chain `lcmRange n ≤ n^π(n) ≤ n^n` and document that Iter 10/11's
prime-counting bound subordinates Part 3's trivial factorial bound.

This was the **`Next Action`** in `state.md` after Iter 12 (#17448)
unblocked the build.

## What's New

### `primeCounting_le_self`

```lean
theorem primeCounting_le_self (n : ℕ) : Nat.primeCounting n ≤ n
```

Trivial bound on the prime-counting function. Proof: the prime filter
on `(Finset.range (n+1))` is a subset of `(Finset.range (n+1)).erase 0`
(since `0` is not prime), which has cardinality `n`. Three-line case
split for `n = 0` (filter is empty) vs `n ≥ 1` (subset + card_erase).

### `pow_primeCounting_le_pow_self`

```lean
theorem pow_primeCounting_le_pow_self (n : ℕ) (hn : 1 ≤ n) :
    n ^ Nat.primeCounting n ≤ n ^ n
```

One-line via `Nat.pow_le_pow_right hn (primeCounting_le_self n)`.
Packaged as a named lemma so the chain reads cleanly.

### `lcmRange_le_pow_self_via_primeCounting`

```lean
theorem lcmRange_le_pow_self_via_primeCounting (n : ℕ) :
    lcmRange n ≤ n ^ n
```

Re-derives the trivial `lcmRange_le_self_pow` (Part 3) by routing
through `lcmRange_le_pow_primeCounting` (Iter 11) and the new
`pow_primeCounting_le_pow_self`. The two-step chain makes the
dependency `Iter 11 ⟹ Iter 13 ⟹ Part 3` explicit:

```
lcmRange n  ≤  n ^ π(n)        -- Iter 11 (Chebyshev decomposition)
            ≤  n ^ n            -- Iter 13 (since π(n) ≤ n)
```

The `n = 0` boundary case (`lcmRange 0 = 1 = 0^0`) is handled
directly by `lcmRange_zero` because `Nat.pow_le_pow_right` requires
the base to be `≥ 1`.

## Mathematical Significance

**Subordination check.** Iter 10/11 introduced the prime-counting
bound `lcmRange n ≤ n^π(n)` as a sharpening of the trivial Part 3
bound `lcmRange n ≤ n^n`. This iteration verifies that the new
bound is *at least as strong* — a sanity check that the
prime-counting reformulation is not somehow weaker than the
factorial route.

**Chebyshev gap.** The chain `n^π(n) ≤ n^n` exposes the slack
between the two bounds: it is `n^(n - π(n))`. Since
`π(n) ~ n / ln(n)` by PNT, this slack grows nearly as fast as the
trivial bound itself, confirming that the prime-counting bound is
the substantive sharpening.

**Path to Hanson.** The natural next step (Iter 14 candidate) is
to bound `n^π(n)` further via Chebyshev's `π(n) ≤ C n / log n`
estimates, giving `n^(C n / log n) = e^(C n)` and discharging the
parent file's `lcm_hanson_bound` axiom up to a constant in the
exponent (Hanson 1972 saves the specific constant `log 3 ~ 1.099`).

## Mathlib API surface

ZERO new Mathlib lemmas introduced. The new code uses only API
already exercised by earlier iterations:

* `Nat.count_eq_card_filter_range` (Iter 11)
* `Finset.card_erase_of_mem` (standard)
* `Finset.card_le_card` (standard)
* `Nat.pow_le_pow_right` (used in `BinaryGcdOQ01OQ04.lean:97`,
  `Erdos820Aristotle.lean:171`, etc.)
* `Nat.eq_zero_or_pos`, `Nat.succ_pos`, `Nat.not_prime_zero` (standard)
* `Finset.range_one`, `Finset.filter_singleton` (simp lemmas)

## Counts

* `lineCount`: 488 → 560 (+72, including ~30 lines of docstrings
  and ~42 lines of proof bodies)
* `theoremCount`: 37 → 40 (+3)
* `definitionCount`: 1 unchanged
* `axiomCount`: 1 unchanged
* `sorries`: 0 unchanged

## Build

**Pending.** Worktree's `proofs/.lake` is a recursive self-symlink
(per `feedback_researcher_lake_symlink_broken.md`), so a local
Docker build re-fresh-clones Mathlib (~30-45 min cold). CI is the
ground truth.

**Confidence: high.** The three new theorems use only Mathlib API
already exercised by Iter 11's `lcmRange_le_pow_primeCounting`
(verified to compile after Iter 12's drift fix #17448). The proof
of `primeCounting_le_self` is direct (no novel API), and the chain
combinator is one application of `Nat.pow_le_pow_right` + `le_trans`.

## Test plan

- [x] All 3 new theorems type-check by review against patterns in
  Iter 11 + standard Mathlib API
- [x] No new sorries, no new axioms, no new definitions
- [x] Branch off fresh `origin/main` (post-Iter-12 build-fix);
  0 commits behind, 1 commit ahead
- [x] meta.json + state.md counts synced (lineCount 560, theoremCount 40)
- [ ] CI: Docker build of `Proofs.BaselProblemOQ01OQ01OQ02OQ03` (ground truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)