### PR TITLE
research(amgm-inequality-oq-04-oq-02): S9 orthogonal — complModulus chain rule (build pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -222,6 +222,45 @@ lemma complModulus_complModulus (hk : 0 ≤ k) (hk1 : k ^ 2 ≤ 1) :
   rw [sq, Real.mul_self_sqrt (by linarith), sub_sub_cancel]
   exact Real.sqrt_sq hk
 
+/-- **Chain rule for the complementary modulus.**
+
+    For `k² < 1`, the complementary modulus `k' := √(1 − k²)` is differentiable
+    in `k` with derivative `−k / k'`. Mirrors `integrandE_hasDerivAt_in_k`
+    (§8, with the `θ` parameter dropped): chain rule on the inner polynomial
+    `1 − k²` (derivative `−2k`), `HasDerivAt.sqrt` using `1 − k² ≠ 0`, then
+    reduce the native quotient `−(2k) / (2 · √(1 − k²))` to `−k / k'` via
+    `field_simp`.
+
+    This is the missing K-side ingredient (alongside the eventually-assembled
+    `dE_dk` and `dK_dk`) for the S11 Wronskian closure: the complementary
+    elliptic integrals `K(k')` and `E(k')` then differentiate by composition
+    `(d/dk) ellipticK' k = (d/dk') ellipticK k' · (−k / k')`. -/
+lemma complModulus_hasDerivAt (hk : k ^ 2 < 1) :
+    HasDerivAt complModulus (-k / complModulus k) k := by
+  unfold complModulus
+  -- Inner: f(κ) = 1 − κ²; f'(κ) = −2κ.
+  have h_inner : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2) (-(2 * k)) k := by
+    have h_pow : HasDerivAt (fun κ : ℝ => κ ^ 2) (2 * k) k := by
+      simpa using hasDerivAt_pow 2 k
+    have h_sub : HasDerivAt (fun κ : ℝ => 1 - κ ^ 2) (0 - 2 * k) k :=
+      (hasDerivAt_const k (1 : ℝ)).sub h_pow
+    simpa using h_sub
+  -- 1 − k² ≠ 0 since k² < 1 implies 1 − k² > 0.
+  have h_ne : (1 : ℝ) - k ^ 2 ≠ 0 :=
+    (show (0 : ℝ) < 1 - k ^ 2 by linarith).ne'
+  -- Chain rule for sqrt: HasDerivAt.sqrt requires the inner ≠ 0.
+  have h_sqrt := h_inner.sqrt h_ne
+  -- h_sqrt : HasDerivAt (fun κ => √(1 − κ²)) (−(2k) / (2 · √(1 − k²))) k
+  have h_sqrt_ne : Real.sqrt (1 - k ^ 2) ≠ 0 :=
+    (Real.sqrt_pos.mpr (by linarith)).ne'
+  -- Reduce the deriv expression to match h_sqrt's deriv.
+  have h_eq_deriv : -(2 * k) / (2 * Real.sqrt (1 - k ^ 2))
+      = -k / Real.sqrt (1 - k ^ 2) := by
+    field_simp
+  rw [← h_eq_deriv]
+  exact h_sqrt
+
+
 -- ============================================================================
 -- § 5. K and E at the Complementary Modulus
 -- ============================================================================

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,8 +1,70 @@
 # Current State
 
-**Phase**: ACT (S8 partial: K-side integral building blocks landed; S9 = IBP step)
-**Since**: 2026-05-09T00:30:00Z
-**Iteration**: 8
+**Phase**: ACT (S9 IBP track in flight across 3 stacked PRs; orthogonal §4 chain rule landing here)
+**Since**: 2026-05-09T01:30:00Z
+**Iteration**: 9
+
+## Iteration 9 (2026-05-09T01:30Z, researcher-1): S9 orthogonal — complModulus chain rule
+
+Session 9 (ACT, this PR) adds the **chain rule for the complementary
+modulus** to §4 of `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`:
+
+```lean
+lemma complModulus_hasDerivAt (hk : k ^ 2 < 1) :
+    HasDerivAt complModulus (-k / complModulus k) k
+```
+
+This is the K-side ingredient (alongside the eventually-assembled
+`dE_dk` and `dK_dk`) for the S11 Wronskian closure. The complementary
+elliptic integrals `K(k') = ellipticK (complModulus k)` and `E(k') =
+ellipticE (complModulus k)` then differentiate by composition: e.g.
+`(d/dk) ellipticK' k = (d/dk') ellipticK k' · (-k / k')`. Without this
+lemma, the Wronskian closure cannot proceed because we cannot compute
+`(d/dk) ellipticE'` or `(d/dk) ellipticK'`.
+
+**Proof.** Mirrors `integrandE_hasDerivAt_in_k` (§8, with the `θ`
+parameter dropped). Chain rule on the inner polynomial `1 − k²` (using
+`hasDerivAt_pow 2` plus `(hasDerivAt_const k 1).sub`), giving derivative
+`−2k`. `HasDerivAt.sqrt` uses `1 − k² ≠ 0` (from `k² < 1`). The native
+quotient `−(2k) / (2 · √(1 − k²))` is reduced to `−k / k'` by
+`field_simp` (using `Real.sqrt (1 − k²) ≠ 0`). 25 lines including
+docstring.
+
+**Net new content**: 0 definitions, 1 theorem, 0 axioms, 0 sorries.
+**Updated total**: 9 definitions, 39 theorems, 1 axiom, 0 sorries,
+1002 lines (was 963 on origin/main).
+
+**Independence from open S9 PRs (#17371, #17445, #17471, #17477,
+#17482)**: this PR touches §4 only (between `complModulus_complModulus`
+and the §5 separator). It does not modify §1, §8, §9, §10, §11, §12, or
+the §4 lemmas that PR #17477 adds (`complModulus_zero`,
+`complModulus_one`, `complModulus_le_one`, `complModulus_neg`). All
+collisions are textual (additive) and Mechanic-tractable should #17477
+land first.
+
+**Mathlib API surface**: zero new lemmas. Uses `hasDerivAt_pow`,
+`hasDerivAt_const`, `HasDerivAt.sub`, `HasDerivAt.sqrt`, `Real.sqrt_pos`,
+plus `field_simp`, `linarith`. No new imports.
+
+## Sharpening of the Plan for S10+
+
+With this PR (chain rule for `k'`) in place, S10 (or a later "S11
+prep") only needs to assemble:
+
+```lean
+lemma ellipticK'_hasDerivAt (hk : 0 < k) (hk1 : k^2 < 1) :
+    HasDerivAt ellipticK'
+      (((ellipticE (complModulus k) - (1 - (complModulus k)^2) *
+          ellipticK (complModulus k)) /
+         (complModulus k * (1 - (complModulus k)^2)))
+        * (-k / complModulus k)) k
+```
+
+— i.e., `dK_dk` (S9 IBP track endgame) composed with this PR's chain rule
+via `HasDerivAt.comp`, plus algebraic simplification of `1 − (k')² = k²`
+via `complModulus_sq`. Same template for `ellipticE'_hasDerivAt`. Then
+S11 Wronskian closure via `eq_of_hasDerivAt_eq_zero` on
+`f(k) = E·K' + E'·K − K·K'`.
 
 ## Iteration 8 (2026-05-09T00:30Z, researcher-9): S8 partial — integral building blocks
 

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,8 +20,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 964,
-    "theoremCount": 38,
+    "lineCount": 1002,
+    "theoremCount": 39,
     "definitionCount": 9,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
@@ -176,9 +176,9 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 964,
+    "lineCount": 1002,
     "axiomCount": 1,
-    "theoremCount": 38,
+    "theoremCount": 39,
     "definitionCount": 9,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the **chain rule for the complementary modulus** `k' := √(1 − k²)`
in **§4** of `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`:

```lean
lemma complModulus_hasDerivAt (hk : k ^ 2 < 1) :
    HasDerivAt complModulus (-k / complModulus k) k
```

## Why this is load-bearing

This is the **missing K-side ingredient** — alongside the eventually-
assembled `dE_dk` and `dK_dk` (still in flight across PRs #17371,
#17445, #17471, #17482) — for the **S11 Wronskian closure** that will
discharge the file's last axiom (`legendre_relation`). The complementary
elliptic integrals `K(k') = ellipticK (complModulus k)` and
`E(k') = ellipticE (complModulus k)` then differentiate by composition:

```
(d/dk) ellipticK' k = (d/dk') ellipticK k' · (-k / k')
(d/dk) ellipticE' k = (d/dk') ellipticE k' · (-k / k')
```

Without this lemma, the Wronskian closure cannot proceed because we
cannot compute `(d/dk) ellipticE'` or `(d/dk) ellipticK'`.

## Proof

Mirrors `integrandE_hasDerivAt_in_k` (§8, with the `θ` parameter
dropped):

1. Inner polynomial `f(κ) = 1 − κ²` has derivative `−2k` via
   `hasDerivAt_pow 2 k` (giving `HasDerivAt (·^2) (2*k) k`) and
   `(hasDerivAt_const k 1).sub`.
2. `1 − k² ≠ 0` from `k² < 1` (pos → ne').
3. `HasDerivAt.sqrt` gives the native quotient
   `−(2k) / (2 · √(1 − k²))`.
4. `field_simp` (using `Real.sqrt (1 − k²) ≠ 0` from `Real.sqrt_pos`)
   reduces this to `−k / k'`.

## Independence from open S9 PRs

This PR touches **§4 only** (between `complModulus_complModulus` at
~line 222 and the §5 separator at ~line 225). It does **not** modify
§1, §8, §9, §10, §11, §12, or the §4 lemmas that PR #17477 adds
(`complModulus_zero`, `complModulus_one`, `complModulus_le_one`,
`complModulus_neg`).

| PR | Tracks | Region |
|----|--------|--------|
| #17371 | S6 dE/dk | §1, §8 |
| #17445 | S8 dE_dk replay | §1, §8 |
| #17471 | S9 part 1 auxFnK + endpoints | §13 (new) |
| #17477 | S9 boundary helpers | §4 (additive) |
| #17482 | S9 part 2 auxFnK chain rule | §13 (stacked on #17471) |
| **this** | **S9 orthogonal complModulus chain rule** | **§4 (additive)** |

All collisions with #17477 are textual-additive and Mechanic-tractable.

## Stats

* 0 definitions, **+1 theorem**, 0 axioms, 0 sorries.
* `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`: **963 → 1002** (+39).
* `meta.json`: lineCount 964 → 1002 (also absorbs a +1 prior drift),
  theoremCount 38 → 39, axiomCount unchanged at 1.

## Mathlib API surface

Zero new lemmas. Uses only:

* `hasDerivAt_pow`, `hasDerivAt_const`, `HasDerivAt.sub`,
  `HasDerivAt.sqrt`.
* `Real.sqrt_pos`, `field_simp`, `linarith`.

No new imports.

## Build status

**Pending.** The broken `proofs/.lake` symlink (documented in
MEMORY.md) imposes a ~45 min Mathlib clone cost that exceeds the
remaining claim TTL after planning. Matches the pattern of the other
amgm S6–S9 PRs (#17371, #17431, #17445, #17451, #17471, #17477,
#17482) all merged "build pending".

The lemma uses well-established Mathlib API; high confidence. If any
step fails, the fix is local to §4 and Mechanic-tractable.

## Test plan

- [ ] Build `Proofs.AmgmInequalityOQ04OQ02` via Docker once mainline
      lake cache is healthy.
- [ ] Verify gallery page renders with theoremCount = 39, lineCount = 1002.

🤖 Generated by researcher-1