### PR TITLE
fix(meta): batch sync definitionCount/lineCount drift (25 entries, erdos-200-499)

### DIFF
--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,10 +53,10 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 859,
+    "lineCount": 860,
     "assumptions": "3 sorry(s). No axioms.",
     "theoremCount": 40,
-    "definitionCount": 19
+    "definitionCount": 21
   },
   "overview": {
     "historicalContext": "**From Covering Systems to Smooth Number Bounds**\n\n**Erdős** and **Stein** conjectured in the 1960s that $f(N) = o(N)$, where $f(N)$ is the maximum number of pairwise disjoint congruence classes with moduli $\\leq N$. **Erdős** and **Szemerédi** proved this conjecture in 1968 using sieve methods, showing $f(N) < N/(\\log N)^c$ for some $c > 0$.\n\nThe precise asymptotics involve the **subexponential function** $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$, which arises naturally from smooth number theory. **Croot** (2003) established bounds $N/L(N)^{\\sqrt{2}+o(1)} < f(N) < N/L(N)^{1/6-o(1)}$, introducing character sum techniques. **Chen** (2005) and **de la Bretèche–Ford–Vandehey** (2013) tightened these to:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\n\nThe lower bound is conjectured to be tight. The problem connects to the **Erdős covering system conjecture** (disproved by Hough 2015), **smooth number distribution** (Dickman's function), and **sieve theory**. This is one of 798 lines of Lean formalization, with 7 theorems proved by the Aristotle proof search system.",
@@ -177,10 +177,10 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 859,
+    "lineCount": 860,
     "axiomCount": 0,
     "theoremCount": 40,
-    "definitionCount": 19,
+    "definitionCount": 21,
     "path": "Proofs/Erdos202Problem.lean",
     "sorries": 3
   },

--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 279,
     "assumptions": "2 axioms: kirkman_theorem, kwan_sah_sawhney_simkin_2022. 2 sorries.",
     "theoremCount": 5,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos207ProblemAristotle.lean"
     ]
@@ -186,7 +186,7 @@
     "lineCount": 279,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos207Problem.lean",
     "sorries": 2,
     "additionalFiles": [

--- a/src/data/proofs/erdos-209/meta.json
+++ b/src/data/proofs/erdos-209/meta.json
@@ -51,7 +51,7 @@
     "lineCount": 241,
     "assumptions": "1 axiom: escudero_2016. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #209** is a question in incidence geometry about the structure of line arrangements. The classical Sylvester-Gallai theorem (1893) guarantees that any finite set of points not all collinear determines at least one \"ordinary line\" (containing exactly 2 points). Erdős asked: can we extend this to triangles?\n\n**Historical Development:**\n- **1893 (Sylvester-Gallai):** Ordinary points/lines must exist.\n- **1984 (Füredi-Palásti):** Disproved the conjecture for most d.\n- **2016 (Escudero):** Completed the disproof for ALL d ≥ 4.\n\n**Key Insight:** While ordinary points always exist, they can be positioned to avoid forming triangles with only ordinary vertices.",
@@ -150,7 +150,7 @@
     "lineCount": 241,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos209Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 196,
     "assumptions": "9 axioms: OrdinaryLineCount, f, sylvester_gallai, motzkin_theorem, kelly_moser, csima_sawyer, green_tao_even, green_tao_odd, LiesOnCubic. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #210: Ordinary Lines**\n\nThis classic problem in discrete geometry asks about the minimum number of 'ordinary lines' (lines through exactly 2 points) in any point configuration.\n\n**Historical Timeline:**\n- 1893: Sylvester conjectured f(n) ≥ 1\n- 1933: Erdős rediscovered the problem\n- 1944: Gallai proved Sylvester-Gallai theorem (f(n) ≥ 1)\n- 1951: Motzkin proved f(n) → ∞\n- 1958: Kelly-Moser proved f(n) ≥ 3n/7\n- 1993: Csima-Sawyer improved to f(n) ≥ 6n/13\n- 2013: Green-Tao resolved asymptotic: f(n) ≥ n/2 for large even n (tight!)\n\n**The Problem:** How many ordinary lines must exist? The answer depends delicately on n's parity.",
@@ -184,7 +184,7 @@
     "lineCount": 196,
     "axiomCount": 9,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos210Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 246,
     "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #211: Lines Formed by Points in the Plane**\n\nThis problem sits at the heart of combinatorial incidence geometry, asking how bounded collinearity forces many determined lines.\n\n**Origins and Context:**\nThe study of incidences between points and lines has roots in classical geometry (Sylvester 1893, Gallai 1944), but the quantitative theory began with Erdős in the 1960s-70s. Problem #211 was posed by Erdős as part of his systematic investigation of extremal problems in discrete geometry, with a $100 prize attached.\n\n**The Two Independent Solutions (1983):**\n- **József Beck** proved the result in 'On the lattice property of the plane and some problems of Dirac, Motzkin, and Erdős in combinatorial geometry' (Combinatorica, 1983). His approach introduced the now-famous *Beck dichotomy*: either many points are collinear, or many lines are formed. The proof uses double counting and the Cauchy-Schwarz inequality.\n- **Endre Szemerédi and William T. Trotter** independently proved the result in 'Extremal problems in discrete geometry' (Combinatorica, 1983). Their approach established the Szemerédi-Trotter incidence theorem $I(P,L) = O(m^{2/3}n^{2/3} + m + n)$, from which the Erdős bound follows as a corollary. The original proof used a cell decomposition; László Székely gave a simpler proof via the crossing number inequality in 1997.\n\n**The Optimal Constant:**\nErdős further speculated that the bound could be sharpened to $\\geq (1+o(1))kn/6$ lines, with the constant $1/6$ being best possible. This constant arises from Steiner-type configurations where every line contains exactly 3 points, yielding $\\binom{n}{2}/3 \\approx n^2/6$ lines. Burr, Grünbaum, and Sloane constructed explicit extremal configurations.\n\n**Legacy:**\nThe Szemerédi-Trotter theorem became one of the most widely-used tools in combinatorial geometry, with applications to sum-product estimates (Elekes 1997), distinct distances (Guth-Katz 2015), and additive combinatorics. The crossing number technique has been called the most useful application of graph theory to geometry.",
@@ -145,7 +145,7 @@
     "lineCount": 246,
     "axiomCount": 10,
     "theoremCount": 1,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos211Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-227/meta.json
+++ b/src/data/proofs/erdos-227/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 220,
     "assumptions": "3 axioms: clunie_positive_coeffs (Clunie — M(r,f)/A(r,f) → 0 for non-negative coefficients), clunie_hayman_1964 (Clunie-Hayman 1964 — entire functions can achieve any limit in [0,1/2]), ratio_upper_bound (upper bound of 1/2 on M/A ratio). 2 sorries.",
     "theoremCount": 5,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #227: Maximum Term vs Maximum Modulus**\n\nThis problem sits at the heart of classical entire function theory, a subject developed by Weierstrass, Hadamard, Borel, and Wiman in the late 19th and early 20th centuries. The two fundamental growth measures for an entire function $f(z) = \\sum a_n z^n$ are:\n\n- The **maximum term** $\\mu(r) = \\max_n |a_n| r^n$: the largest individual contribution at radius $r$\n- The **maximum modulus** $M(r) = \\max_{|z|=r} |f(z)|$: the actual largest value, accounting for cancellations\n\nWiman (1914) showed that $\\mu(r)/M(r) \\to 0$ for 'most' values of $r$ (outside an exceptional set of finite logarithmic measure). Erdős asked a sharper question: if the limit $\\lim_{r \\to \\infty} \\mu(r)/M(r)$ actually exists, must it be 0?\n\nClunie first proved this is true for functions with all non-negative coefficients — in this case, $M(r) = f(r) = \\sum a_n r^n$, and no cancellation occurs. But in 1964, Clunie and Hayman published their striking counterexample: for any $\\lambda \\in [0, 1/2]$, they constructed an entire function achieving $\\mu(r)/M(r) \\to \\lambda$. Their construction uses oscillating coefficients that create controlled cancellation on the circle $|z| = r$.\n\nThe upper bound $1/2$ is sharp and cannot be exceeded. This revealed that the behavior of entire functions with oscillating coefficients is fundamentally different from those with positive coefficients — a key theme in modern value distribution theory.\n\n**Related**: Erdős Problem #513 concerns similar questions about the growth of entire functions.",
@@ -207,7 +207,7 @@
     "lineCount": 220,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos227Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-230/meta.json
+++ b/src/data/proofs/erdos-230/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "1 axiom: kahane_ultraflat. 3 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Erdos230ProblemAristotle.lean"
     ]
@@ -149,7 +149,7 @@
     "lineCount": 230,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos230Problem.lean",
     "sorries": 3,
     "additionalFiles": [

--- a/src/data/proofs/erdos-242/meta.json
+++ b/src/data/proofs/erdos-242/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 590,
     "assumptions": "1 axiom: dyachenko_box (Dyachenko's Theorem 9.21, arXiv:2511.07465) asserting the existence of ED2 lattice box parameters for primes p = 1 mod 4. Used only for 6 hard residue classes mod 840: {1, 121, 169, 289, 361, 529}. All other cases fully proved.",
     "theoremCount": 50,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The Erdős-Straus conjecture was posed by Paul Erdős and Ernst Straus in 1948. It asks whether every fraction 4/n with n >= 2 can be written as a sum of exactly three unit fractions.\n\nThis is one of the most famous unsolved problems in elementary number theory. Despite its simple statement, it has resisted proof for over 75 years. The conjecture has been verified computationally for all n up to 10^17 (over 100 quadrillion values), yet no general proof exists.\n\nThe problem is related to ancient Egyptian mathematics, where fractions were always written as sums of distinct unit fractions.",
@@ -234,7 +234,7 @@
     "lineCount": 590,
     "axiomCount": 1,
     "theoremCount": 50,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos242Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -53,7 +53,7 @@
     "lineCount": 269,
     "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 3 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result).",
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -166,7 +166,7 @@
     "lineCount": 269,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos260Problem.lean",
     "sorries": 3
   },

--- a/src/data/proofs/erdos-272/meta.json
+++ b/src/data/proofs/erdos-272/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 135,
     "assumptions": "3 axioms: maxAPFamily (maximum AP family function — axiomatized), simonovits_sos_upper (Simonovits-Sós 1981 — t = O(N²)), szabo_theorem (Szabó asymptotic theorem). 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #272 asks for the maximum number of subsets of {1,...,N} such that every pairwise intersection is a non-empty arithmetic progression. The problem was posed by Erdős and Graham, who conjectured that the optimal family consists of all arithmetic progressions passing through the middle element ⌊N/2⌋, giving approximately π²N²/24 sets.\n\nSimonovits and Sós (1981) made two key contributions: they proved the upper bound t = O(N²), establishing the quadratic growth rate, and they disproved the Erdős-Graham conjecture by showing that a simpler construction — all subsets of size ≤ 3 containing a fixed element — gives C(N-1,2) + 1 ≈ N²/2 sets, beating the π²N²/24 ≈ N²/2.4 from arithmetic progressions. The key insight is that any two sets of size ≤ 3 sharing a common element intersect in {k} (a singleton, which is trivially an AP).\n\nSzabó (1999) resolved the problem completely by determining the exact asymptotic: t = N²/2 + O(N^{5/3}(log N)³). He improved the lower bound to C(N,2) + ⌊(N-1)/4⌋ + 1 and conjectured that the exact answer is C(N,2) + O(N) and that every extremal family has a common element contained in all sets.",
@@ -154,7 +154,7 @@
     "lineCount": 135,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos272Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "assumptions": "0 axioms. All 13 theorems fully proved including selfridge_example (explicit {0 mod 2, 1 mod 4, 3 mod 4} construction), covering_reciprocal_sum (LCM/product counting argument), difficulty_even_coverage, min_modulus_ge_4, moduli_even, and the easyPrimes reciprocal sum bounds. Open conjecture; supporting lemmas fully verified.",
     "lineCount": 303,
     "mathlib_version": "4.26.0"
@@ -158,7 +158,7 @@
     "lineCount": 303,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "mainTheorems": [
       {
         "name": "selfridge_example",

--- a/src/data/proofs/erdos-274/meta.json
+++ b/src/data/proofs/erdos-274/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 127,
     "assumptions": "1 axiom: sun_abelian_case. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Herzog-Schönheim conjecture, posed in the 1970s, asks whether a group G can be partitioned by cosets of subgroups with pairwise distinct indices. Erdős included this as Problem #274, specifically asking about the abelian case.\n\nSun Zhi-Wei proved in 2004 that for finite abelian groups (and more generally, when all subgroups are subnormal), the answer is NO - at least two cosets must have the same index. This settled Erdős's original question.\n\nMargolis and Schnabel (2019) verified computationally that the conjecture holds for all groups of order less than 1440. The general case remains open.",
@@ -144,7 +144,7 @@
     "lineCount": 127,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/Erdos274Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-275/meta.json
+++ b/src/data/proofs/erdos-275/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 171,
     "assumptions": "2 axioms: erdos_275_theorem, not_covered_2r_minus_1. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #275** lies at the heart of *covering systems*, a subject Erdős pioneered starting in the 1950s. A covering system is a finite collection of congruence classes $a_i \\pmod{n_i}$ whose union is all of $\\mathbb{Z}$. Erdős asked: if $r$ congruences cover $2^r$ consecutive integers, must they cover all integers?\n\n**Historical Development:**\n- **Erdős (1950s):** Introduced covering systems and formulated numerous problems, including #275. His earliest covering system work dates to his 1950 proof that there exist infinitely many odd integers not of the form $2^k + p$, using a covering system with moduli $\\{2, 3, 4, 8, 12, 24\\}$.\n- **Selfridge (1970):** Independently solved Problem #275, showing $2^r$ is the exact threshold.\n- **Crittenden and Vanden Eynden (1970):** Published the proof in *Proceedings of the AMS*, using induction on the structure of moduli with careful analysis modulo 2.\n- **Hough (2015):** Proved the minimum modulus conjecture (Erdős #2), showing every covering system with distinct moduli $> 1$ must have a modulus $\\leq 10^{16}$ — later improved to $616{,}000$ by Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (2022).\n\n**Key Insight:** The exponential bound $2^r$ reflects binary structure — the optimal counterexample uses powers of 2 as moduli, and coverage depends on the binary digits of integers.",
@@ -186,7 +186,7 @@
     "lineCount": 171,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos275Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 275,
     "assumptions": "1 axiom: haight_theorem. 0 sorries.",
     "theoremCount": 12,
-    "definitionCount": 17
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "Covering systems of congruences were introduced by Erdős in 1950 in his proof that there exist odd integers not representable as a prime plus a power of 2. The concept became central to his research program in combinatorial number theory. In the 1970s, Erdős formulated Problem #277 as part of a cluster of questions (#273-#279) exploring the interplay between covering systems and number-theoretic properties.\n\nThe problem connects two classical threads: the sum of divisors function $\\sigma(n) = \\sum_{d \\mid n} d$, studied since Euler, and the combinatorics of congruence coverings. Gronwall (1913) proved $\\limsup \\sigma(n)/(n \\ln\\ln n) = e^\\gamma$, showing highly abundant numbers exist at every threshold. The question is whether such numbers can simultaneously resist being covered.\n\nJ.A. Haight resolved the problem in 1979 ('Covering systems of congruences, a negative result', Mathematika 26, 53-61). His constructive proof builds $n$ as a product of carefully chosen large primes, ensuring high abundancy while structurally preventing any covering system from using only divisors of $n$ as moduli. The key insight exploits the reciprocal sum constraint: a covering system with distinct moduli $m_1, \\ldots, m_k$ requires $\\sum 1/m_i \\geq 1$, but Haight's numbers have divisors too sparse to satisfy this.\n\nThe result connects to Ramanujan's highly composite numbers (1915), Alaoglu and Erdős's superabundant numbers (1944), and later work by Hough (2015) resolving Erdős's minimum modulus conjecture for covering systems with distinct moduli.",
@@ -275,7 +275,7 @@
     "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 17,
+    "definitionCount": 18,
     "path": "Proofs/Erdos277Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -49,7 +49,7 @@
       "Single modulus base case: coverageDensity_singleton and single_modulus_density via filter characterization"
     ],
     "theoremCount": 29,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage?\n\nCovering systems have a rich history. Erdős introduced them in his 1950 proof that there exist infinitely many odd integers not representable as $2^k + p$ (a prime), using a covering system with moduli $\\{2, 3, 4, 8, 12, 24\\}$. He conjectured that covering systems with arbitrarily large minimum modulus exist — a conjecture that stood for over 60 years until Bob Hough's 2015 proof (Annals of Mathematics) showed that any covering system with distinct moduli must include a modulus at most $10^{16}$, dramatically settling the question in the negative.\n\nR.J. Simpson resolved the minimum question of Problem #278 in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. His proof uses the key observation that uniformly shifting all residues preserves the expected density, so the minimum cannot exceed the equal-residue density. The maximum question remains open and is fundamentally harder: for coprime moduli, the Chinese Remainder Theorem forces all residue choices to yield the same density $1 - \\prod(1 - 1/n_i)$, but for non-coprime moduli, the overlap structure between congruence classes depends delicately on the residue choices. The problem connects to sieve-theoretic methods in analytic number theory and to combinatorial optimization on lattice structures.",
@@ -176,7 +176,7 @@
     "lineCount": 644,
     "axiomCount": 0,
     "theoremCount": 29,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "mainTheorems": [
       {
         "name": "density_bounds",

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their influential 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory,' which collected hundreds of open problems from Erdős's vast collaboration network. The question sits at the intersection of Egyptian fraction theory (expressing rationals as sums of unit fractions, a tradition dating to the Rhind Papyrus c. 1650 BCE) and combinatorial constraints on intervals. Hickerson and Montgomery demonstrated feasibility by constructing 5 non-adjacent intervals [2,7], [9,10], [17,18], [34,35], [84,85] with reciprocal sum exactly 2. The non-adjacency constraint is the essential difficulty: without it, one can decompose any unit fraction representation by splitting and merging adjacent intervals. The problem connects to Croot's 2003 resolution of the Erdős–Graham conjecture (that $\\{n+1, \\ldots, 2n\\}$ contains a subset whose reciprocals sum to 1 for large $n$) and to the broader Egyptian fraction tradition studied by Erdős, Straus, and Graham.",
@@ -122,7 +122,7 @@
     "lineCount": 135,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos289Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-296/meta.json
+++ b/src/data/proofs/erdos-296/meta.json
@@ -69,7 +69,7 @@
     "lineCount": 160,
     "assumptions": "2 axioms: hunter_sawhney_lower, erdos_296_main. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "sections": [
     {
@@ -177,7 +177,7 @@
     "lineCount": 160,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos296Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 386,
+    "lineCount": 387,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 7
@@ -172,7 +172,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 258,
+    "lineCount": 259,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements.",
     "theoremCount": 8,
     "definitionCount": 8
@@ -146,7 +146,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-306/meta.json
+++ b/src/data/proofs/erdos-306/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 242,
     "assumptions": "2 axioms: butler_erdos_graham_theorem, twoPrimeProductCount. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #306 asks about Egyptian fractions - a topic dating back to ancient Egypt, where fractions were typically expressed as sums of distinct unit fractions.\n\n**The Problem**: Can every positive rational a/b (with b squarefree) be written as 1/n₁ + ... + 1/nₖ where each nᵢ is a product of exactly 2 distinct primes?\n\n**Status**:\n- **2 distinct primes**: OPEN - the main conjecture\n- **3 distinct primes**: SOLVED for integers by Butler, Erdős, and Graham (2015)\n\n**Historical Note**: The Butler-Erdős-Graham paper appeared in 2015, 19 years after Erdős's death in 1996. It may be Erdős's last published paper, demonstrating his enduring influence on mathematics.\n\n**Key Example**: The integer 1 can be represented with 2-distinct-prime denominators:\n1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 1\nwhere 6=2×3, 10=2×5, 14=2×7, 15=3×5, 21=3×7, 35=5×7.",
@@ -157,7 +157,7 @@
     "lineCount": 242,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos306Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 258,
     "assumptions": "4 axioms: sylvester_sum_equals_one, vardiConstant_bounds, vardiConstant_is_limit, kamio_li_tang_2025. 0 sorries.",
     "theoremCount": 13,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "**Erdős Problem #315: Sylvester's Sequence and the Vardi Constant**\n\nSylvester's sequence (OEIS A000058) is: 2, 3, 7, 43, 1807, 3263443, ...\n\nIt arises from the greedy algorithm for Egyptian fractions and satisfies the remarkable property that Σ 1/u_n = 1. Egyptian fractions — representations of rationals as sums of distinct unit fractions — date back to the Rhind Papyrus (c. 1550 BCE), making this one of the oldest topics in number theory.\n\n**Key History:**\n- **Sylvester (1880):** James Joseph Sylvester introduced the sequence in the *American Journal of Mathematics* while studying the greedy algorithm for unit fraction decompositions. He showed the recurrence $u_{n+1} = u_n^2 - u_n + 1$ produces the unique greedy Egyptian representation of 1.\n- **Curtiss (1922):** D.R. Curtiss proved the product formula $u_n = \\lfloor E^{2^n} + 1/2 \\rfloor$ where $E \\approx 1.264$ is what would later be called the Vardi constant, establishing the doubly exponential growth rate.\n- **Erdős-Graham (1980):** In their influential monograph *Old and New Problems and Results in Combinatorial Number Theory*, Erdős and Graham conjectured that no other Egyptian sequence for 1 can match Sylvester's growth rate. This appeared as Problem #315.\n- **Vardi (1991):** Ilan Vardi studied the constant $c_0 = \\lim u_n^{1/2^n} \\approx 1.264085$ in *Computational Recreations in Mathematica*, establishing precise numerical bounds.\n- **Tang (correction):** Quanyu Tang identified that the original [ErGr80, p.41] formulation used $u_1 = 1$, which fails the unit sum condition. The correct version uses Sylvester's original $u_1 = 2$.\n- **Kamio (2025), Li-Tang (2025):** The conjecture was independently proved after 45 years. Kamio's proof (arXiv:2503.02317) and Li-Tang's proof (arXiv:2503.12277) both appeared in March 2025, using different analytic techniques to bound the growth rates of competing Egyptian sequences.",
@@ -213,7 +213,7 @@
     "lineCount": 258,
     "axiomCount": 4,
     "theoremCount": 13,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos315Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately φ"
     ],
     "axiomCount": 2,
-    "lineCount": 391,
+    "lineCount": 392,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "theoremCount": 15,
     "definitionCount": 7
@@ -149,7 +149,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 608,
     "assumptions": "0 sorries, 0 axioms. Fully verified. Open conjecture; supporting lemmas fully verified.",
     "theoremCount": 15,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -172,7 +172,7 @@
     "lineCount": 608,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos358Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-363/meta.json
+++ b/src/data/proofs/erdos-363/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 293,
     "assumptions": "3 axioms: pomerance_observation, ulas_theorem, erdos_selfridge. 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "This problem connects to the famous Erdős-Selfridge theorem (1975), which states that the product of consecutive integers is never a perfect power. Erdős asked whether this constraint could be circumvented using multiple disjoint blocks of consecutive integers.\n\nPomerance observed that if we allow intervals of size 3, there are infinitely many counterexamples using blocks built from powers of 2. This motivated the condition |Iᵢ| ≥ 4.\n\nThe conjecture was spectacularly disproved in the 2000s. Ulas (2005) found infinitely many solutions for most values of n using size-4 intervals. Bauer-Bennett (2007) filled in the remaining cases n=3 and n=5. Bennett-Van Luijk (2012) extended the result to size-5 intervals, suggesting a general pattern.",
@@ -198,7 +198,7 @@
     "lineCount": 293,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/Erdos363Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,14 +64,14 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 284,
+    "lineCount": 285,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib.",
     "theoremCount": 16,
     "definitionCount": 7
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 284,
+    "lineCount": 285,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Fix

Re-sync `definitionCount` and `lineCount` in 25 erdos-200..erdos-499 gallery entries to match the actual Lean source. Both `leanFile.*` and `meta.*` blocks are kept consistent.

## Affected entries

| slug | field | old → new |
|------|-------|-----------|
| erdos-202 | lineCount, definitionCount | 859→860, 19→21 |
| erdos-207 | definitionCount | 12→13 |
| erdos-209 | definitionCount | 9→10 |
| erdos-210 | definitionCount | 8→9 |
| erdos-211 | definitionCount | 8→9 |
| erdos-227 | definitionCount | 9→10 |
| erdos-230 | definitionCount | 6→7 |
| erdos-242 | definitionCount | 4→5 |
| erdos-260 | definitionCount | 8→9 |
| erdos-272 | definitionCount | 5→6 |
| erdos-273 | definitionCount | 6→7 |
| erdos-274 | definitionCount | 2→3 |
| erdos-275 | definitionCount | 8→9 |
| erdos-277 | definitionCount | 17→18 |
| erdos-278 | definitionCount | 7→8 |
| erdos-289 | definitionCount | 5→6 |
| erdos-296 | definitionCount | 5→6 |
| erdos-299 | lineCount | 386→387 |
| erdos-303 | lineCount | 258→259 |
| erdos-306 | definitionCount | 10→11 |
| erdos-315 | definitionCount | 11→12 |
| erdos-355 | lineCount | 391→392 |
| erdos-358 | definitionCount | 9→10 |
| erdos-363 | definitionCount | 10→12 |
| erdos-370 | lineCount | 284→285 |

## Validation

Counts verified by re-reading each Lean file: `definitionCount` counts
`def | abbrev | opaque | structure | inductive | class` declarations
(with `partial | private | protected | noncomputable | unsafe | scoped`
modifiers) after stripping nested block comments and line comments;
`lineCount` is the actual newline-based line count.

After patch, all 25 entries pass the drift scanner clean (matches both
`leanFile.*` and `meta.*` blocks).

---
Automated fix by lean-mechanic agent.