### PR TITLE
audit(arithmetic-series-oq-00-oq-02): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -526,10 +526,10 @@
       "result": "clean"
     },
     "arithmetic-series-oq-00-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T10:22:11Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T22:55:37Z",
+      "result": "clean"
     },
     "arithmetic-series-oq-02": {
       "auditCount": 4,


### PR DESCRIPTION
## Audit Result: clean

Verified all numerical claims against `origin/main` Lean source for `proofs/Proofs/ArithmeticSeriesOQ00OQ02.lean`:

| Field | meta.json | Actual | Status |
|---|---|---|---|
| lineCount | 120 | 120 | matches |
| sorries | 0 | 0 | matches |
| axiomCount | 0 | 0 | matches |
| theoremCount | 11 | 11 | matches |
| definitionCount | 0 | 0 | matches |
| True stubs | — | 0 | clean |

## Tier classification

**Tier A — fully formalized.** Counterexamples (`counterexample_n2`, `counterexample_n3`) closed by `decide`; closed form proved by induction with `nlinarith` plus a `ring`-proved polynomial identity. The single `mathlibDependencies` entry is `Finset.sum_range_succ`, an induction utility — not a wrapper around a deep Mathlib theorem.

`status: "verified"` and `badge: "original"` are appropriate.

## Tracker change

```
auditCount: 1 → 2
lastAudited: 2026-04-26T10:22:11Z → 2026-05-08T22:55:37Z
result: issues-fixed → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)