### PR TITLE
fix(meta): batch sync definitionCount drift (25 entries, batch a-e)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -28,7 +28,7 @@
     "historicalContext": "This entry answers the natural question raised by two near-identical proofs in the gallery: both AngleTrisectionCos20Gal (8X³−6X−1, the minimal polynomial of cos(20°)) and AngleTrisectionCos20GalOQ01 (8X³−4X²−4X+1, the minimal polynomial of cos(π/7)) have Galois groups of order 3, but each proof uses a different Eisenstein prime (p=2 vs p=7). The parameterized unification reveals the common structure: both belong to a family of cyclic cubics over ℚ reducible to Eisenstein form by a suitable linear substitution. The CyclicCubicData typeclass captures the common interface, providing a template extensible to other angles whose minimal polynomials are cyclic cubics.",
     "proofStrategy": "The unification abstracts the shared structure into a trisectionPoly family and CyclicCubicData typeclass. Two instances are given: one for cos(20°) with Eisenstein prime p=2, one for cos(π/7) with p=7. Unified theorems (unified_galois_order, unified_splitting_field) are proved by rcases case splitting, reducing each case to the already-established individual results. The eisensteinConnection section explicitly identifies the Eisenstein prime for each instance.",
     "theoremCount": 7,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The question of which angles can be trisected by compass and straightedge — one of the three classical Greek problems — was resolved by Pierre Wantzel in 1837, who proved that only angles whose cosine satisfies a rational polynomial of 2-power degree are constructible. Trisecting 60° requires that cos(20°) satisfy a degree-3 polynomial 8X³−6X−1 (its minimal polynomial over ℚ), which is irreducible and not of 2-power degree.\n\nThe Galois theory viewpoint clarifies the impossibility: irreducible degree-3 polynomials over ℚ have Galois groups of order divisible by 3, while constructibility requires 2-power order. Computing that |Gal| = 3 for both cos(20°) and cos(π/7) proves their non-constructibility.\n\nBoth minimal polynomials arise from the same algebraic pattern: an Eisenstein cubic (primitive with prime-p divisibility conditions) composed with a linear shift. This common structure — recognized independently for p=3 and p=7 in separate proofs — is unified here into a single parameterized theorem.",
@@ -107,7 +107,7 @@
     "lineCount": 182,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "structureCount": 1,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/angle-trisection-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05/meta.json
@@ -71,7 +71,7 @@
     "assumptions": "0 axioms, 0 sorries. All theorems are proved directly from definitions and Mathlib. The Huzita-Hatori axioms are stated as a structure (existence assertions about fold lines), not assumed. The algebraic characterization (degree divides 2^a * 3^b) is encoded as the definition of IsOrigamiConstructible. The equivalence with neusis holds by definitional equality.",
     "mathlib_version": "4.26.0",
     "theoremCount": 27,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "leanFile": {
     "imports": [
@@ -88,7 +88,7 @@
     "axiomCount": 0,
     "theoremCount": 27,
     "lemmaCount": 0,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/AngleTrisectionOQ05.lean",
     "sorries": 0
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/meta.json
@@ -37,7 +37,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 1071,
     "theoremCount": 33,
-    "definitionCount": 17,
+    "definitionCount": 20,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -79,7 +79,7 @@
     "lineCount": 1071,
     "axiomCount": 0,
     "theoremCount": 33,
-    "definitionCount": 17,
+    "definitionCount": 20,
     "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -38,7 +38,7 @@
     "axiomCount": 1,
     "lineCount": 519,
     "theoremCount": 15,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Nash's original 1950 proof of equilibrium existence occupies only a paragraph in his 2-page PNAS paper. The key idea: define a continuous map on the product of mixed strategy simplices whose fixed points are Nash equilibria. Each player shifts weight toward pure strategies that offer improvement over their current mixed strategy. The normalization ensures the result is a valid mixed strategy. Brouwer's fixed point theorem guarantees a fixed point, and the algebra of the fixed-point equation implies all players are in equilibrium. Nash later gave a Kakutani-based proof in his 1951 Annals paper, but the Brouwer version is more direct and avoids upper hemicontinuity.",
@@ -150,7 +150,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
-    "definitionCount": 9,
+    "definitionCount": 10,
     "theoremCount": 15
   },
   "sorries": 0

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -40,14 +40,14 @@
       "FiniteGame structure and MixedStrategy type (Nash application stub)",
       "Fixed point theorem hierarchy table (Brouwer, Schauder, Kakutani, Fan-Glicksberg, Eilenberg-Montgomery)"
     ],
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "leanFile": {
     "namespace": "BrouwerOQ04OQ03",
     "lineCount": 156,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "mainTheorems": [
       {
         "name": "brouwer_from_kakutani_finite",

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -56,7 +56,7 @@
     "lineCount": 505,
     "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries.",
     "theoremCount": 22,
-    "definitionCount": 11
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Shizuo Kakutani proved his fixed point theorem in 1941, motivated by von Neumann's 1937 minimax theorem and its use of Brouwer's theorem for existence proofs in economics. Kakutani's insight was that many economic and game-theoretic models naturally involve set-valued maps (e.g., a consumer's demand given prices is a set of optimal bundles, not a single point), and that Brouwer's theorem could be extended to handle these. John Nash's 1950 proof of equilibrium existence in non-cooperative games — for which he received the 1994 Nobel Prize in Economics — relies essentially on Kakutani's theorem applied to the best-response correspondence. The Arrow-Debreu proof of general competitive equilibrium (1954), which earned Arrow the 1972 Nobel Prize, also depends on it. The theorem has since become indispensable in mathematical economics, optimal control theory (Filippov's lemma for differential inclusions, 1962), and nonlinear analysis. The infinite-dimensional generalization by Glicksberg (1952) and Fan (1952) extends it to locally convex spaces, enabling applications to infinite-horizon economic models.",
@@ -209,7 +209,7 @@
     "lineCount": 505,
     "axiomCount": 2,
     "theoremCount": 22,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "path": "Proofs/BrouwerFixedPointOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
     "lineCount": 568,
     "theoremCount": 30,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",
       "cauchyCroftonConst: c_n = 2*sigma_{n-2}/((n-1)*sigma_{n-1})",
@@ -114,7 +114,7 @@
     "lineCount": 568,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "2 axiom declarations (easton_permitted_realizable and easton_consistency) state the realizability direction of Easton's 1970 theorem: every regular κ > ℵ₀ is realizable as 2^ℵ₀, and every Easton function is realizable as the continuum function on regular cardinals. Both axioms have True as codomain (placeholder), since a genuine Consistent (ZFC ∪ ⟦...⟧) predicate would require Gödel-encoding ZFC formulas — deferred to a future Phase-3b file. All 7 supporting theorems are now fully machine-checked from Mathlib (axiom-free): IsPermittedValue scaffold, aleph_one_permitted, aleph_two_permitted, aleph_succ_permitted, permitted_satisfies_konig, permitted_unbounded, IsEastonFunction structure, isEastonFunction_continuum, isEastonFunction_nonempty. The previous Phase-3a sorries (aleph_succ_permitted, isEastonFunction_continuum.monotone) were closed in Phase-3a-fix: the ℵ₀ < ℵ_(succ α) step uses ℵ₀ = aleph 0 ≤ aleph α < succ (aleph α) (via Cardinal.aleph_zero, Cardinal.aleph_le_aleph, Order.lt_succ); the monotone field uses Cardinal.power_le_power_right (the previous comment claiming it varies the base was incorrect — confirmed exponent-monotonic in current Mathlib via the sibling OQ-02-OQ-03 file).",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Easton's 1970 theorem (PhD thesis, Annals of Math. Logic 1) is one of the most striking results in set-theoretic cardinal arithmetic. It completely answers the question 'how arbitrary can the continuum function 2^κ be on regular cardinals?' — by showing that ALL functions F : Reg → Card satisfying three minimal constraints (F(κ) ≥ κ⁺, monotonicity, cf(F(κ)) > κ) are realizable in some forcing extension of ZFC. The constraints are necessary (provable from Mathlib's lt_cof_power and power_le_power_right) but the realizability direction requires class-sized partial orders — Easton product forcing — which extends Cohen's 1963 set-forcing technique to violate GCH simultaneously at every regular cardinal. This file formalizes the converse to OQ-01-OQ-01-OQ-02 (which lists EXCLUDED values): instead of enumerating what 2^ℵ₀ cannot be, it characterizes what 2^ℵ₀ CAN be.",
@@ -110,7 +110,7 @@
     "lineCount": 257,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "lineCount": 166,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "badge": "original",
     "originalContributions": [
       "CodesEndomorphismsSetoid: pointwise-equivalence retract structure",
@@ -240,7 +240,7 @@
     "lineCount": 166,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ04OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 340,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "originalContributions": [
       "menelaus_algebraic_core: unified algebraic core for all three geometries (product = -1 iff numerator = -denominator)",
       "SphericalMenelausConfig: signed arc framework with sin non-degeneracy constraints",
@@ -120,7 +120,7 @@
     "lineCount": 340,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 907,
     "theoremCount": 39,
-    "definitionCount": 23,
+    "definitionCount": 26,
     "originalContributions": [
       "GeomCevianConfig: concrete cevian configuration in ℝ² with parametric line representation",
       "cevaCondition: algebraic predicate d·e·f = (1-d)·(1-e)·(1-f)",
@@ -71,7 +71,7 @@
     "lineCount": 907,
     "axiomCount": 0,
     "theoremCount": 39,
-    "definitionCount": 23,
+    "definitionCount": 26,
     "path": "Proofs/CevasTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 301,
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "originalContributions": [
       "HyperbolicCevianConfig: cevian weight structure (α, β) with sinh distance model",
       "hyp_sinh_BD / hyp_sinh_DC: sinh distance ratios for cevian points in hyperboloid model",
@@ -68,7 +68,7 @@
     "lineCount": 301,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CevasTheoremOQ02OQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 17,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Ceva's theorem (1678) for triangles states that cevians AD, BE, CF are concurrent iff (BD/DC)·(CE/EA)·(AF/FB) = 1. The spherical version (proved in CevasTheoremOQ02OQ01.lean) replaces length ratios with sin-ratios and uses weight parameters: sin(BD)/sin(DC) = β/α for D = normalize(α·B + β·C).\n\nThe natural question (OQ-02-OQ-02) is: does this generalize to polygons? For an n-gon P₁...Pₙ with cevian points Qᵢ on each side PᵢPᵢ₊₁, when are the n cevians from a central point C concurrent?\n\nThis formalization answers YES: the concurrency condition is ∏ᵢ αᵢ = ∏ᵢ βᵢ, where (αᵢ, βᵢ) are the weight parameters defining each cevian point.",
@@ -160,7 +160,7 @@
     "lineCount": 320,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CevasTheoremOQ02OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02/meta.json
@@ -65,7 +65,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
-    "definitionCount": 9
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Ceva's theorem was proved by Giovanni Ceva in 1678 (though Menelaus treated the dual result in ~100 AD). The Euclidean version states: in a triangle ABC, cevians AD, BE, CF are concurrent if and only if (BD/DC)·(CE/EA)·(AF/FB) = 1.\n\nThe generalization to non-Euclidean geometries replaces the ratio BD/DC with sin(BD)/sin(DC) (spherical) or sinh(BD)/sinh(DC) (hyperbolic), where the measures are now arc lengths or hyperbolic distances rather than Euclidean lengths.\n\nMenelaus's theorem is the 'dual': a transversal line cuts the sides of a triangle such that the SIGNED product of ratios equals -1 (rather than 1 for Ceva). The Ceva-Menelaus duality is a deep algebraic relationship: negating exactly one ratio converts one condition to the other.\n\nThe Gauss-Bonnet theorem (angle sum = π + κ·Area for constant curvature κ) ties everything together: it explains WHY spherical triangles have angle sum > π (positive curvature) and hyperbolic triangles have angle sum < π (negative curvature), and this angle sum directly relates to the 'excess' or 'defect' that appears in the non-Euclidean Ceva/Menelaus conditions.",
@@ -156,7 +156,7 @@
     "lineCount": 501,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 9,
+    "definitionCount": 11,
     "path": "Proofs/CevasTheoremOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -59,7 +59,7 @@
     "assumptions": "Fully verified. 0 axioms, 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Mass point geometry traces its roots to Archimedes' lever principle (c. 250 BCE): a lever balances when $m_1 d_1 = m_2 d_2$. August Ferdinand Möbius formalized barycentric coordinates in 'Der barycentrische Calcul' (1827), giving the first rigorous algebraic framework for mass-weighted point combinations. Giovanni Ceva's original theorem (De lineis rectis, 1678) states that cevians $AD$, $BE$, $CF$ of triangle $ABC$ are concurrent if and only if $(BD/DC)(CE/EA)(AF/FB) = 1$.\n\nThe mass point technique assigns positive real masses $m_A, m_B, m_C$ to vertices and computes cevian foot positions as centers of mass. This approach is widely taught in mathematical olympiad preparation (AMC/AIME/Olympiad curricula) as an elementary method for solving concurrence and ratio problems without coordinates. The key insight is that mass assignments ARE barycentric coordinates, so mass points provide a constructive algebraic certificate for Ceva configurations.\n\nThis formalization proves the complete biconditional: the Ceva condition $d \\cdot e \\cdot f = (1-d)(1-e)(1-f)$ holds if and only if there exists a mass assignment realizing the ratios. Both directions are constructive, using only basic real arithmetic (field_simp, ring, nlinarith) — no affine geometry infrastructure needed.",
@@ -151,7 +151,7 @@
     "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/CevasTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
     "dateAdded": "2026-05-03",
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic. The question of which moduli to use is critical for hardware efficiency. Power-of-2 moduli are attractive because x mod 2^k reduces to a bitwise AND operation (x &&& (2^k - 1)), requiring a single hardware instruction. However, the CRT foundation requires pairwise coprimality, which limits how many powers of 2 can appear in a base. This entry resolves the question by proving that exactly one power of 2 can appear alongside any collection of pairwise coprime odd moduli.",
@@ -105,7 +105,7 @@
     "path": "Proofs/ChineseRemainderConstructiveOQ03OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "theoremCount": 19
   },
   "sorries": 0

--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. All theorems fully proved. mersenne_coprime_of_coprime proved via Euclidean algorithm on exponents (strong induction). primorial_growth_lower proved for k ≤ 6 (lookup table range). dynamicRange_le_pow, RNS encode/add/mul correctness all verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 31,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The Chinese Remainder Theorem (Sun Tzu, ~5th century AD) gave the first mathematical account of solving systems of congruences. Its use for representing large integers via residues was formalized in the modern Residue Number System (RNS) by Harvey Garner in 1959 ('The residue number system'), motivated by parallel arithmetic in early computers. Nikolai Szabó and Richard Tanaka's 1967 monograph 'Residue Arithmetic and Its Applications to Computer Technology' established the field. RNS processors were deployed in NASA applications and DSP hardware in the 1980s for real-time signal processing, where parallel channel arithmetic outperforms carry-propagation arithmetic. Mersenne-friendly bases (using 2^p - 1) were preferred in hardware because modular reduction reduces to bit shifts: x mod (2^p - 1) can be computed by adding the upper and lower halves repeatedly. The identity gcd(2^a - 1, 2^b - 1) = 2^gcd(a,b) - 1 — proved here via the Euclidean algorithm on exponents — ensures that Mersenne numbers at coprime exponents are coprime, a prerequisite for CRT.",
@@ -119,7 +119,7 @@
     "path": "Proofs/ChineseRemainderConstructiveOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "theoremCount": 31
   },
   "sorries": 0

--- a/src/data/proofs/collatz-cycles-oq-04/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-04/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 209,
     "theoremCount": 13,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "originalContributions": [
       "CycleConfig structure: encodes j-step Collatz cycle with odd elements, halving counts, and step relation 2^mᵢ · n_{i+1} = 3nᵢ + 1",
       "cycle_product_equation: ∏ᵢ(3nᵢ+1) = 2^M · ∏ᵢnᵢ via cyclic permutation (σ is bijection on Fin j)",
@@ -169,7 +169,7 @@
     "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/CollatzCyclesOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
@@ -12,7 +12,7 @@
     "axiomCount": 0,
     "lineCount": 241,
     "theoremCount": 11,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "assumptions": "None. All theorems proved for arbitrary CommRing k with parameter q : k. The VermaData structure is abstract (universal); no invertibility hypotheses needed for the Verma module action proofs.",
     "tags": [
       "quantum-groups",
@@ -38,7 +38,7 @@
     "axiomCount": 0,
     "lineCount": 241,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Quantum groups were introduced by Drinfeld and Jimbo in 1985-1986, arising from the study of integrable systems and the quantum Yang-Baxter equation. The quantum group U_q(𝔰𝔩₂) is the prototypical example: a one-parameter deformation of the universal enveloping algebra of 𝔰𝔩₂ that reduces to the classical case when q=1. Verma modules for quantum groups were studied extensively in the 1990s; their structure — particularly the divided power formula F^n·v₀ = [n]_q!·vₙ — is foundational for quantum representation theory and connects to knot invariants, quantum topology, and the Jones polynomial. This formalization uses the q-number (qNumber) and q-factorial (qFactorial) infrastructure from combinations-formula-oq-03.",

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -35,7 +35,7 @@
     "lineCount": 640,
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos1040Aristotle.lean"
     ]
@@ -240,7 +240,7 @@
     "theoremCount": 22,
     "substantiveTheoremCount": 19,
     "trivialSpecializations": 0,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "path": "Proofs/Erdos1040Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -69,7 +69,7 @@
     "assumptions": "1 axiom: pommerenke_diameter_vanishes. Structure fields are object definitions, not assumptions.",
     "lineCount": 234,
     "theoremCount": 12,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos1048ProblemAristotle.lean"
     ]
@@ -252,7 +252,7 @@
     "theoremCount": 12,
     "substantiveTheoremCount": 2,
     "sorryTheorems": 10,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "mainTheorems": [
       {
         "name": "EHP_false_for_r_gt_1",

--- a/src/data/proofs/erdos-1078/meta.json
+++ b/src/data/proofs/erdos-1078/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 205,
     "assumptions": "4 axioms: threshold_tight, haxell_theorem, haxell_szabo_theorem, threshold_sharp. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Bollobás, Erdős, and Szemerédi conjectured in 1975 that in balanced r-partite graphs, minimum degree at least (r - 3/2 - o(1))n forces a complete r-clique K_r. They also constructed examples showing the constant r - 3/2 is best possible, with extremal graphs avoiding K_r via subtle parity arguments.\n\nHaxell proved the conjecture in 2001 using connections to list coloring theory. Her proof showed that the minimum degree condition forces a rainbow clique through a reduction to vertex list coloring problems, resolving the question after 25 years.\n\nHaxell and Szabó determined the exact sharp threshold in 2006: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋. This precise formula reveals the role of parity in the problem — the floor of r/2 appears because the extremal constructions depend on whether r is even or odd. Asymptotically, ⌈sn/(2s-1)⌉ ≈ n/2, recovering the (r - 3/2)n threshold.",
@@ -261,7 +261,7 @@
     "lineCount": 205,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1078Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -26,7 +26,7 @@
     "badge": "axiom",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 5
+    "definitionCount": 7
   },
   "sections": [
     {
@@ -164,7 +164,7 @@
     "theoremCount": 23,
     "substantiveTheoremCount": 16,
     "sorryTheorems": 0,
-    "definitionCount": 5,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1084OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -24,7 +24,7 @@
     "badge": "axiom",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 2
+    "definitionCount": 4
   },
   "sections": [
     {
@@ -160,7 +160,7 @@
     "theoremCount": 7,
     "substantiveTheoremCount": 7,
     "sorryTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1084Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1086/meta.json
+++ b/src/data/proofs/erdos-1086/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 150,
     "assumptions": "4 axioms: lower_bound_erdos_purdy, upper_bound_raz_sharir_2017, g_dim, bound_g3_2_dst. See Lean source for complete statements.",
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1086: Triangles of Equal Area**\n\nOriginally posed by Oppenheim, this problem asks: given n points in the plane, how many triangles with the same area can they determine? The function g(n) measures this maximum.\n\n**Historical Development:**\n- **Oppenheim:** Posed the original question about equal-area triangles\n- **Erdős-Purdy (1971):** Established the first bounds: n² log log n ≪ g(n) ≪ n^{5/2}\n- **Pach-Sharir (1992):** Improved the upper bound using point-curve incidence techniques\n- **Dumitrescu-Sharir-Tóth (2009):** Further improvements to the upper bound\n- **Apfelbaum-Sharir (2010):** Continued refinements\n- **Raz-Sharir (2017):** Current best upper bound g(n) ≪ n^{20/9}\n\n**Key Connection:** The problem reduces to counting point-curve incidences. For a fixed base edge (A,B), the locus of points C giving a triangle of area α is a pair of parallel lines. The Szemerédi-Trotter incidence theorem is the main tool for upper bounds.",
@@ -249,7 +249,7 @@
     "lineCount": 150,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos1086Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `leanFile.definitionCount` and `meta.definitionCount` for 25 gallery
entries where the claimed count drifted below the actual count in the
underlying Lean source files.

## Convention

Counts `def + abbrev + opaque + structure + inductive + class` (NOT
`instance`) with `partial/private/protected/noncomputable/unsafe/scoped`
modifiers, after stripping nested block and line comments.

## Entries (claimed → actual)

| slug | claimed | actual |
|------|---------|--------|
| angle-trisection-cos-20-gal-oq-01-oq-01 | 4 | 5 |
| angle-trisection-oq-05 | 10 | 12 |
| brouwer-fixed-point-oq-02-oq-01 | 17 | 20 |
| brouwer-fixed-point-oq-04 | 11 | 14 |
| brouwer-fixed-point-oq-04-oq-02 | 9 | 10 |
| brouwer-fixed-point-oq-04-oq-03 | 8 | 9 |
| buffons-needle-oq-01-oq-01-oq-04 | 4 | 5 |
| cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 | 1 | 2 |
| cantor-diagonalization-oq-04-oq-01 | 3 | 4 |
| cevas-theorem-non-euclidean-oq-02-oq-01 | 3 | 4 |
| cevas-theorem-oq-01 | 23 | 26 |
| cevas-theorem-oq-02 | 9 | 11 |
| cevas-theorem-oq-02-oq-01-oq-02 | 3 | 4 |
| cevas-theorem-oq-02-oq-02 | 3 | 4 |
| cevas-theorem-oq-04 | 3 | 4 |
| chinese-remainder-constructive-oq-03 | 9 | 10 |
| chinese-remainder-constructive-oq-03-oq-03 | 2 | 3 |
| collatz-cycles-oq-04 | 2 | 3 |
| combinations-formula-oq-03-oq-06 | 0 | 1 |
| erdos-1040 | 19 | 20 |
| erdos-1048 | 13 | 14 |
| erdos-1078 | 5 | 6 |
| erdos-1084 | 2 | 4 |
| erdos-1084-oq-01 | 5 | 7 |
| erdos-1086 | 9 | 10 |

## Evidence

Each meta.json had two occurrences of the wrong `definitionCount` value
(once in `meta.*` summary, once in `leanFile.*`); both were updated to
match the live count produced by the verified counting convention. Diff
is exactly 50/50 lines (25 entries × 2 occurrences).

---
Automated fix by lean-mechanic agent.