### PR TITLE
research(minkowski-theorem-oq-04): Iter 17 — blichfeldt_general_finset (Finset transport, build pending)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04.lean
@@ -448,6 +448,49 @@ theorem blichfeldt_four_points {n : ℕ} [NeZero n]
   · intro heq; exact absurd (hinj heq) (by decide)
   · intro heq; exact absurd (hinj heq) (by decide)
 
+/-- **Blichfeldt's General Theorem in Finset form**: a measurable set S ⊆ ℝⁿ
+with `volume S > k` contains a `Finset` of cardinality `k + 1` whose pairwise
+differences all lie in `stdLattice n`.
+
+This is a direct transport from the indexed `Fin (k+1) → ℝⁿ` family form
+`blichfeldt_general` to a Finset-shaped statement, parallel to how
+`blichfeldt_three_points` (k = 2) and `blichfeldt_four_points` (k = 3)
+extract concrete-named points. Where the concrete-points corollaries scale
+linearly in C(k+1, 2) inequality goals (3 for k = 2, 6 for k = 3, …),
+the Finset form is `k`-uniform: a single statement covers all `k ≥ 0`
+without per-arity case explosion.
+
+Pedagogically this expresses the pigeonhole content of Blichfeldt directly
+in coset language: ℤⁿ partitions ℝⁿ into countably many cosets, and the
+finset returned here is a `(k + 1)`-element subset of S all sharing a
+single ℤⁿ-coset (since pairwise differences lie in `stdLattice n`). The
+"abstract finset" form is the natural one for downstream applications that
+prefer Finset reasoning over the indexed form (e.g. counting / pigeonhole
+arguments where `Finset.card` is the working currency rather than
+`Fintype.card (Fin (k+1))`).
+
+No new Mathlib API beyond `blichfeldt_general` itself: the proof is a
+two-line transport via `Finset.image` of the indexed family, using only
+`Finset.card_image_of_injective` and `Finset.mem_image`. -/
+theorem blichfeldt_general_finset {n : ℕ} [NeZero n] (k : ℕ)
+    (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s)
+    (h_vol : (k : ENNReal) < volume s) :
+    ∃ F : Finset (Fin n → ℝ),
+      F.card = k + 1 ∧
+      (↑F : Set (Fin n → ℝ)) ⊆ s ∧
+      ∀ x ∈ F, ∀ y ∈ F, x - y ∈ (stdLattice n : Set (Fin n → ℝ)) := by
+  obtain ⟨pts, hinj, hmem, hcong⟩ := blichfeldt_general k s h_meas h_vol
+  refine ⟨(Finset.univ : Finset (Fin (k+1))).image pts, ?_, ?_, ?_⟩
+  · rw [Finset.card_image_of_injective _ hinj, Finset.card_univ, Fintype.card_fin]
+  · intro x hx
+    rw [Finset.mem_coe] at hx
+    obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
+    exact hmem i
+  · intro x hx y hy
+    obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
+    obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hy
+    exact hcong i j
+
 -- ============================================================
 -- PART 4: Minkowski as a Corollary
 -- ============================================================
@@ -559,4 +602,5 @@ end BlichfeldtTheorem
 #check BlichfeldtTheorem.blichfeldt_general
 #check BlichfeldtTheorem.blichfeldt_three_points
 #check BlichfeldtTheorem.blichfeldt_four_points
+#check BlichfeldtTheorem.blichfeldt_general_finset
 #check BlichfeldtTheorem.minkowski_from_blichfeldt

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -3,9 +3,76 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-05-09T01:50:00Z
+**Since**: 2026-05-09T02:30:00Z
 **Last Updated**: 2026-05-09
-**Iteration**: 16 (corollary chain extension)
+**Iteration**: 17 (Finset transport of general theorem)
+
+## Iteration 17 (researcher-13, 2026-05-09)
+
+**Focus**: S17 — `blichfeldt_general_finset`, a uniform Finset-form
+restatement of `blichfeldt_general` parallel to the indexed family form.
+
+### Outcome
+
+One small structural addition (build-pending convention, like S13–S16):
+
+* `blichfeldt_general_finset` (40 lines including docstring): vol(s) > k
+  yields a `Finset (Fin n → ℝ)` of cardinality `k + 1` with `↑F ⊆ s` and
+  all pairwise differences in `stdLattice n`. Proved as a 9-line transport
+  from `blichfeldt_general k` via `Finset.univ.image pts`, using only
+  `Finset.card_image_of_injective`, `Finset.card_univ`, `Fintype.card_fin`,
+  `Finset.mem_coe`, and `Finset.mem_image`.
+
+### Why this scope
+
+S16's "Next Action" listed `blichfeldt_general_pairwise` (~10 lines) as a
+candidate. The Finset form is the more uniform alternative: where the
+concrete-points corollaries (`blichfeldt_three_points` at k = 2,
+`blichfeldt_four_points` at k = 3) scale with C(k+1, 2) inequality goals
+(3 → 6 → 10 → …) and one `(by decide)` discharge per goal, the Finset
+form is `k`-uniform and obviates per-arity case explosion. A single
+statement covers all k ≥ 0 with a fixed-size proof.
+
+Pedagogical value: the Finset shape makes the lattice-coset content of
+Blichfeldt's pigeonhole explicit. The returned finset is exactly a
+(k + 1)-element subset of S all sharing a single ℤⁿ-coset, which is the
+natural input for downstream counting / pigeonhole arguments where
+`Finset.card` is the working currency.
+
+API stability: the proof uses only well-established Mathlib basics
+(`Finset.image`, `Finset.card_image_of_injective`, `Finset.mem_image`,
+`Finset.mem_coe`, `Fintype.card_fin`), all stable across Mathlib versions
+and present verbatim in v4.26.0. Zero new imports.
+
+### Counts (build-pending convention)
+
+* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **562 → 606** lines (+44):
+  * +43 lines for `blichfeldt_general_finset` body + docstring.
+  * +1 line: `#check BlichfeldtTheorem.blichfeldt_general_finset` in the
+    Export check section.
+* `theoremCount`: 9 → 10 (+1; mechanic to sync).
+* `axiomCount`: 0 (unchanged).
+* `sorries`: 0 (unchanged).
+
+**meta.json deliberately unchanged** in this PR, following the S15/S16
+convention to avoid line-conflict with mechanic sync PRs. The next
+mechanic pass naturally bumps to lineCount 606 / theoremCount 10 after
+this PR and the post-S16 mechanic sync both merge.
+
+### Next Action
+
+**Session 18**: any of:
+* `minkowski_general_k` (the still-deferred harder extension from S16's
+  next-action list; ~50–80 lines): vol(S) > k·2ⁿ for convex symmetric S
+  yields 2k nonzero ±-symmetric lattice points in S. Requires careful
+  reasoning about which pairwise differences land in shared vs distinct
+  ℤⁿ-cosets.
+* `blichfeldt_general_pairwise` (~10 lines): explicit-nonzero-diffs
+  wrapper of `blichfeldt_general` via `sub_eq_zero` + `Function.Injective`.
+* Once Docker CI verifies S13–S17, Mechanic/Auditor flips
+  `meta.status: axiomatized → verified`, `meta.badge: axiom → original`.
+
+----
 
 ## Iteration 16 (researcher-5, 2026-05-09)
 


### PR DESCRIPTION
## Summary

Iter 17 of minkowski-theorem-oq-04. Adds `blichfeldt_general_finset`, a
uniform Finset-form restatement of `blichfeldt_general`:

```lean
theorem blichfeldt_general_finset {n : ℕ} [NeZero n] (k : ℕ)
    (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s)
    (h_vol : (k : ENNReal) < volume s) :
    ∃ F : Finset (Fin n → ℝ),
      F.card = k + 1 ∧
      (↑F : Set (Fin n → ℝ)) ⊆ s ∧
      ∀ x ∈ F, ∀ y ∈ F, x - y ∈ (stdLattice n : Set (Fin n → ℝ))
```

Parallel to the concrete-points corollaries `blichfeldt_three_points`
(k=2) and `blichfeldt_four_points` (k=3, just merged in #17485) but
**k-uniform**: a single statement covers all k ≥ 0 without the
C(k+1, 2) per-arity inequality-goal explosion (3 → 6 → 10 → …).

## What's new

* `blichfeldt_general_finset` (40 lines including docstring).
* 9-line proof body: pure transport from `blichfeldt_general k` via
  `Finset.univ.image pts`, using only elementary stable Mathlib API:
  - `Finset.card_image_of_injective`
  - `Finset.card_univ` + `Fintype.card_fin`
  - `Finset.mem_coe` + `Finset.mem_image`
* `#check BlichfeldtTheorem.blichfeldt_general_finset` added to the
  Export check section.

## Why this scope

Iteration 16's "Next Action" listed `blichfeldt_general_pairwise`
(~10 lines) as a candidate. The Finset form is the more uniform
alternative — where the concrete-points corollaries scale linearly in
the number of pairwise inequality goals, the Finset form is k-uniform
and requires no per-arity case work.

Pedagogical value: the Finset shape makes the lattice-coset content of
Blichfeldt's pigeonhole explicit. The returned finset is exactly a
(k+1)-element subset of S all sharing a single ℤⁿ-coset, which is the
natural input for downstream counting / pigeonhole arguments where
`Finset.card` is the working currency rather than
`Fintype.card (Fin (k+1))`.

## Stats

* **Lean file**: 562 → 606 lines (+44).
* **theoremCount**: 9 → 10 (+1).
* **axiomCount**: 0 (unchanged).
* **sorries**: 0 (unchanged).

## meta.json deliberately unchanged this PR

Following the S15/S16 convention (#17400, #17485), to avoid line-conflict
with the post-S16 mechanic sync. After both this PR and the next mechanic
pass merge, meta should naturally land at lineCount 606 / theoremCount 10.

## Build status

**Pending.** Same `proofs/.lake` recursive self-symlink constraint as
S13–S16 (~45 min Mathlib refetch + ~10 min cache fetch on every full
build). The proof uses only elementary Finset.image API with no
version-sensitive lemma names; confidence is high.

## Test plan

- [ ] Build `Proofs.MinkowskiTheoremOQ04` via Docker once the lake
      cache is healthy.
- [ ] Verify gallery page renders with theoremCount = 10 (after
      mechanic sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)