### PR TITLE
audit: 3 entries clean (cayley-hamilton-minpoly-oq-01, erdos-14-unique-sums, erdos-177-oq-04)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1747,9 +1747,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T10:29:47Z",
+      "lastAudited": "2026-05-08T22:58:48Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02": {
@@ -4718,9 +4718,9 @@
       "result": "clean"
     },
     "erdos-14-unique-sums": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T10:29:32Z",
+      "lastAudited": "2026-05-08T22:59:53Z",
       "result": "clean"
     },
     "erdos-140": {
@@ -5000,9 +5000,9 @@
       "result": "issues-fixed"
     },
     "erdos-177-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T10:29:04Z",
+      "lastAudited": "2026-05-08T22:59:53Z",
       "result": "clean"
     },
     "erdos-178": {


### PR DESCRIPTION
## Audit batch (3 entries, all clean)

All numerical claims verified against `origin/main` Lean source.

### cayley-hamilton-minpoly-oq-01
| Field | meta | actual |
|---|---|---|
| lineCount | 307 | 307 |
| sorries | 0 | 0 |
| axiomCount | 3 | 3 |
| theoremCount | 20 | 20 |
| definitionCount | 0 | 0 |

Axioms match: `jordan_normal_form_basis`, `minpoly_product_formula`, `maxGenEigenspaceIndex_exact`. Status `axiomatized` / badge `axiom` appropriate.

### erdos-14-unique-sums
| Field | meta | actual |
|---|---|---|
| lineCount | 443 | 443 |
| sorries | 0 | 0 |
| axiomCount | 3 | 3 |
| theoremCount | 8 | 8 (theorem+lemma) |
| definitionCount | 13 | 13 |

Axioms match: `erdos_upper_construction`, `erdos_lower_infinitely_often`, `erdos_freud_finite`. Status `axiomatized` / badge `axiom` appropriate.

### erdos-177-oq-04
| Field | meta | actual |
|---|---|---|
| lineCount | 282 | 282 |
| sorries | 0 | 0 |
| axiomCount | 3 | 3 |
| theoremCount | 12 | 12 |
| definitionCount | 8 | 8 |

Axioms match: `roth_lower_bound`, `beck_improved_upper`, `rudin_shapiro_bound`. The placeholder theorem `discrepancy_gap : 1+1=2` is openly disclosed in narrative `keyInsights`; status correctly `axiomatized` (not `verified`), so the True-stub-as-verified rule does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)