### PR TITLE
fix(meta): batch sync theoremCount drift (17 entries, batch c-g)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
@@ -38,7 +38,7 @@
       "surjective_implies_pointwise: classical surjectivity implies constructive surjectivity (one direction only)",
       "cantor_recovery_from_constructive: classical cantor_recovery derived from constructive version"
     ],
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "sections": [
@@ -145,7 +145,7 @@
     "namespace": "CantorDiagonalizationOQ03OQ01OQ04",
     "lineCount": 175,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 176,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "namespace": "HolderELpNorm",
     "lineCount": 176,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 117,
-    "theoremCount": 5,
+    "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
     "originalContributions": [
@@ -171,7 +171,7 @@
     "namespace": "CancellationStep",
     "lineCount": 117,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 161,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 0,
     "assumptions": "None. All theorems proved from Mathlib's Orthonormal.sum_inner_products_le, Orthonormal.tsum_inner_products_le, and HilbertBasis.tsum_inner_mul_inner.",
     "mathlibDependencies": [
@@ -270,7 +270,7 @@
     "path": "Proofs/CauchySchwarzOQ02OQ02.lean",
     "filename": "CauchySchwarzOQ02OQ02.lean",
     "lineCount": 161,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0,

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -77,7 +77,7 @@
     "lineCount": 835,
     "assumptions": "0 axioms, 0 sorries. Lagrange identity and Hölder equality characterization are original; inner product space equality case uses Mathlib's norm_inner_eq_norm_iff, Hölder inequality via NNReal.inner_le_Lp_mul_Lq.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 29,
     "definitionCount": 1
   },
   "sections": [
@@ -203,7 +203,7 @@
     "namespace": "CauchySchwarzOQ03OQ01",
     "lineCount": 835,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 29,
     "definitionCount": 1,
     "path": "Proofs/CauchySchwarzOQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 288,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 2
   },
   "overview": {
@@ -219,7 +219,7 @@
     "namespace": "CauchySchwarzOQ04",
     "lineCount": 288,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 2,
     "path": "Proofs/CauchySchwarzOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -92,7 +92,7 @@
     "axiomCount": 0,
     "lineCount": 231,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 12,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -295,7 +295,7 @@
     "namespace": "CauchySchwarz",
     "lineCount": 231,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarz.lean",
     "sorries": 0

--- a/src/data/proofs/factor-remainder-nullstellensatz/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/meta.json
@@ -46,7 +46,7 @@
     "axiomCount": 0,
     "lineCount": 286,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 20,
+    "theoremCount": 15,
     "definitionCount": 2
   },
   "overview": {
@@ -159,7 +159,7 @@
     "namespace": null,
     "lineCount": 286,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 15,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
     "definitionCount": 2,

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 201,
     "assumptions": "2 axioms with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p) and fermatLastTheoremFive (FermatLastTheoremFor 5). The n=3 and n=4 cases are fully proved via Mathlib. FreyCurve_is_semistable and RibetTheorem were placeholder True-stubs and have been replaced with documentation comments. 2 with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p, the consequence of Modularity+Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n). 3 placeholder axioms concluding with True (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem) — these serve as proof-structure markers documenting the Frey-Ribet-Wiles chain without encoding actual mathematical statements. The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -288,7 +288,7 @@
     "namespace": "FermatsLastTheorem",
     "lineCount": 201,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/FermatsLastTheorem.lean",
     "sorries": 0

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 20
+    "theoremCount": 15
   },
   "meta": {
     "wiedijkNumber": 76,
@@ -98,7 +98,7 @@
     "axiomCount": 0,
     "lineCount": 451,
     "assumptions": "0 axioms. Fully verified.",
-    "theoremCount": 20,
+    "theoremCount": 15,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 0,
         "assumptions": "None. Fully machine-verified.",
         "lineCount": 220,
-        "theoremCount": 18,
+        "theoremCount": 13,
         "definitionCount": 0,
         "originalContributions": [
             "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
@@ -112,7 +112,7 @@
         "namespace": "FundamentalArithmeticOQ01OQ01",
         "axiomCount": 0,
         "lineCount": 220,
-        "theoremCount": 18,
+        "theoremCount": 13,
         "sorries": 0,
         "definitionCount": 0
     },

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
@@ -73,7 +73,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2
   },
   "overview": {
@@ -214,7 +214,7 @@
     "namespace": "FTAUniqueAlgebraicClosure",
     "lineCount": 207,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2,
     "mainTheorems": [
       {

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -59,7 +59,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The core existence result delegates to Mathlib's `Complex.exists_root` (proved via Liouville's theorem: a non-vanishing polynomial yields a bounded entire function $1/p(z)$, contradicting Liouville). Original contributions (`no_roots_implies_constant`, `card_roots_eq_degree`, `monic_prod_roots`, `quadratic_has_root`) are pedagogical wrappers composing Mathlib's `IsAlgClosed` infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -265,7 +265,7 @@
     "namespace": "FundamentalTheoremAlgebra",
     "lineCount": 214,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 6,
     "definitionCount": 0,
     "substantiveTheoremCount": 2,
     "trivialSpecializations": 4,

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 413,
     "assumptions": "0 axioms. 0 sorries. Survey file with demonstrated infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 4,
     "definitionCount": 2
   },
   "sections": [
@@ -171,7 +171,7 @@
     "namespace": "FurstenbergOQ02",
     "lineCount": 413,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 4,
     "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/FurstenbergCorrespondenceOQ02.lean"

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Depends on GCDAlgorithmOQ01 (euclideanSteps, decimalDigits, lame_step_bound).",
     "lineCount": 280,
-    "theoremCount": 27,
+    "theoremCount": 22,
     "definitionCount": 2,
     "originalContributions": [
       "lame_five_digit_bound_general: euclideanSteps(a,b) ≤ 5·decimalDigits(b) for ALL b > 0",
@@ -62,7 +62,7 @@
     "namespace": "GCDAlgorithmOQ01OQ03",
     "lineCount": 280,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 22,
     "definitionCount": 2,
     "path": "Proofs/GCDAlgorithmOQ01OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -57,7 +57,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 13,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -220,7 +220,7 @@
     "namespace": "GeometricSeriesOQ01",
     "lineCount": 250,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 13,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/GeometricSeriesOQ01.lean"

--- a/src/data/proofs/geometric-series/meta.json
+++ b/src/data/proofs/geometric-series/meta.json
@@ -54,7 +54,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -252,7 +252,7 @@
     "namespace": "GeometricSeries",
     "lineCount": 171,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 10,
     "substantiveTheoremCount": 5,
     "trivialSpecializations": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` to the actual `(theorem|lemma)` decl count in each main `.lean` file. All 17 entries had `meta` and `leanFile` values matching each other but overcounting the source by 1–5.

## Convention

Strip block + line comments (nested `/-` ... `-/` honored), then count top-level decls matching:

```
^\s*(?:(?:private|protected|noncomputable|partial|unsafe|scoped)\s+)*(theorem|lemma)\s+
```

Same convention as PR #17441 / #17462.

## Per-entry deltas (claimed → actual)

| slug | claimed | actual |
|------|---------|--------|
| cantor-diagonalization-oq-03-oq-01-oq-04 | 9 | 8 |
| cauchy-schwarz | 12 | 9 |
| cauchy-schwarz-integral-oq-01-oq-03-oq-01 | 8 | 6 |
| cauchy-schwarz-integral-oq-02-oq-02-oq-01 | 5 | 3 |
| cauchy-schwarz-oq-02-oq-02 | 11 | 10 |
| cauchy-schwarz-oq-03-oq-01 | 31 | 29 |
| cauchy-schwarz-oq-04 | 19 | 17 |
| factor-remainder-nullstellensatz | 20 | 15 |
| fermats-last-theorem | 8 | 6 |
| fourier-series | 20 | 15 |
| fundamental-arithmetic-oq-01-oq-01 | 18 | 13 |
| fundamental-theorem-algebra | 9 | 6 |
| fundamental-theorem-algebra-oq-04 | 10 | 9 |
| furstenberg-correspondence-oq-02 | 8 | 4 |
| gcd-algorithm-oq-01-oq-03 | 27 | 22 |
| geometric-series | 13 | 10 |
| geometric-series-oq-01 | 16 | 13 |

## Evidence

Each meta.json had two occurrences of the wrong `theoremCount` value (once in `meta.*` summary, once in `leanFile.*`); both were updated to match the live count produced by the verified counting convention. Diff is exactly 34/34 lines (17 entries × 2 occurrences).

---
Automated fix by lean-mechanic agent.