### PR TITLE
fix(meta): batch sync definitionCount drift (25 entries, batch erdos-mixed)

### DIFF
--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 82,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Rousseau, appearing in Erdős's 1993 paper [Er93, p.344] and also in the Erdős-Rousseau paper [ErRo93]. It asks whether a local density condition — every large induced subgraph being dense — forces a global structure (a triangle). The problem sits at the intersection of extremal graph theory and Ramsey-type forcing, asking for the precise threshold at which local density guarantees global substructure.\n\nThe constant $1/50$ is motivated by the balanced blow-up of the 5-cycle $C_5$: partition $n$ vertices into 5 equal parts and connect parts $i$ and $i+1 \\pmod{5}$. This graph is triangle-free (since $C_5$ contains no $K_3$), has $n^2/5$ total edges, and any induced subgraph on $\\geq n/2$ vertices has at most $\\approx n^2/50$ edges. The Petersen graph (the $n=10$ case) is the smallest such extremal example.\n\nThe first major result was by Erdős, Faudree, Rousseau, and Schelp (1994), who proved the conjecture with $50$ replaced by $16$. They also proved a generalized form: for any $0 < \\alpha < 1$, if every set of $\\geq \\alpha n$ vertices induces $> \\alpha^3 n^2/2$ edges, then the graph contains a triangle. Krivelevich (1995) obtained a different trade-off, proving the result with the subgraph size increased to $3n/5$ but the constant improved to $25$. Keevash and Sudakov (2006) proved the conjecture under additional structural assumptions: either when the total edge count is $\\leq n^2/12$ or $\\geq n^2/5$. Norin and Yepremyan (2015) extended this to graphs with $\\geq (1/5 - c)n^2$ edges for some $c > 0$. The current best result is by Razborov (2022), who used his flag algebra method to improve the constant to $27/1024 \\approx 0.0264$, narrowing the gap with $1/50 = 0.02$ to a factor of $\\approx 1.32$. Erdős offered $250 for the resolution.",
@@ -128,7 +128,7 @@
     "opens": [],
     "path": "Proofs/Erdos128Problem.lean",
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "sections": [
     {
@@ -132,7 +132,7 @@
     "lineCount": 103,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos130Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-149/meta.json
+++ b/src/data/proofs/erdos-149/meta.json
@@ -69,7 +69,7 @@
     "assumptions": "3 axioms: conjecture_is_tight, hurley_joannis_kang_2022, cliqueNumber_LineSquare. Structure fields are object definitions, not assumptions.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**Erdős Problem #149 (Strong Chromatic Index Conjecture)**\n\n**Origins:**\nErdős and Nešetřil conjectured in 1985 that the strong chromatic index of any graph with maximum degree $\\Delta$ satisfies $\\chi'_s(G) \\leq \\frac{5}{4}\\Delta^2$. A **strong edge coloring** assigns colors to edges so that any two edges within distance 2 in the line graph $L(G)$ receive different colors — equivalently, edges sharing a vertex or both touching a common vertex must be colored differently.\n\n**Why $\\frac{5}{4}\\Delta^2$?**\nThe **$C_5$ blow-up** construction achieves this bound exactly: replace each vertex of the 5-cycle $C_5$ with $\\Delta/2$ independent copies, connecting copies of adjacent vertices by complete bipartite graphs. The resulting graph has max degree $\\Delta$, and the edges of each 'blow-up' copy of a $C_5$-edge form a $K_{\\Delta/2, \\Delta/2}$, creating $\\frac{5}{4}\\Delta^2$ pairwise conflicting edges (forming a clique in $L(G)^2$). Since all these edges need distinct colors, $\\chi'_s \\geq \\frac{5}{4}\\Delta^2$.\n\n**Progress on Upper Bounds:**\n- **Trivial bound:** $\\chi'_s(G) \\leq 2\\Delta^2 - 2\\Delta + 1$ (each edge conflicts with at most $2\\Delta^2 - 2\\Delta$ others)\n- **Molloy and Reed (1997):** $1.998\\Delta^2$ for large $\\Delta$ — first to break the factor-2 barrier using the **Lovász Local Lemma**\n- **Bruhn and Joos (2018):** $1.93\\Delta^2$ — using the **entropy compression** method\n- **Bonamy, Perrett, and Postle (2022):** $1.835\\Delta^2$ — refined probabilistic coloring\n- **Hurley, de Joannis de Verclos, and Kang (2022):** $1.772\\Delta^2$ — current best, via the **cluster expansion** method from statistical physics\n\n**Related Structural Results:**\n- **Clique number of $L(G)^2$:** Faron-Postle (2019) showed $\\omega(L(G)^2) \\leq \\frac{4}{3}\\Delta^2$, improving Śleszyńska-Nowak (2015)'s $\\frac{3}{2}\\Delta^2$\n- **Special classes:** $C_4$-free graphs admit $O(\\Delta^2/\\log \\Delta)$ (Mahdian); bipartite graphs satisfy the conjecture with $c < \\frac{5}{4}$\n- **Chung-Gyárfás-Tuza-Trotter (1990):** If $|E(G)| \\geq \\frac{5}{4}\\Delta^2$, then $G$ has two strongly independent edges\n\n**Current Status:** The gap between the best bound ($1.772\\Delta^2$) and the conjecture ($\\frac{5}{4}\\Delta^2 = 1.25\\Delta^2$) is $0.522\\Delta^2$. The conjecture remains one of the most important open problems in graph coloring theory.",
@@ -157,7 +157,7 @@
     "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos149Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -26,7 +26,7 @@
     "lineCount": 237,
     "assumptions": "4 axioms: discrepancyF, discrepancyF_mono_alpha, discrepancy_lower, discrepancy_upper. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Erdős posed this problem around 1990, asking for the precise asymptotic of F(n, α) — the largest k such that some 2-colouring of K_n has every induced subgraph on at least k vertices α-balanced (each colour appears on more than α fraction of edges). The problem sits at the intersection of Ramsey theory and discrepancy theory.\n\nThe probabilistic method readily establishes that F(n, α) = Θ(log n) for each fixed 0 < α ≤ 1/2: a random 2-colouring of K_n is α-balanced on all sets of size ≤ c₁ log n with positive probability (via Chernoff bounds and a union bound over subsets), while a Ramsey-type counting argument shows any colouring must have an imbalanced induced subgraph of size ≤ c₂ log n.\n\nThe conjecture goes beyond these order-of-magnitude bounds to assert that the ratio F(n, α)/log n converges to a definite limit c_α. Determining this constant as a function of α would give a precise quantitative understanding of how balanced large 2-colourings can be. The case α = 1/2 is extremal (requiring near-equal colour distribution) and is related to Problems #161, #163, and #617 on balanced colourings. The formalization at 237 lines covers the full structure; all supporting lemmas are proved and only the four-axiom skeleton encodes the open conjecture.",
@@ -128,7 +128,7 @@
     "lineCount": 237,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos162Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-173/meta.json
+++ b/src/data/proofs/erdos-173/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 234,
     "assumptions": "4 axioms: shader_theorem, equilateral_not_monochromatic_strip, erdos_173_conjecture, and 1 more. See Lean source for complete statements.",
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "This problem belongs to Euclidean Ramsey theory, a field initiated by Erdős, Graham, Montgomery, Rothschild, Spencer, and Straus in the 1970s. The classical Ramsey theorem guarantees monochromatic cliques in edge-colored complete graphs; Euclidean Ramsey theory asks which geometric configurations must appear monochromatically in finite colorings of $\\mathbb{R}^d$. Erdős posed Problem #173 [Er75f, Er83c] asking whether all but at most one triangle shape must have a monochromatic congruent copy in any 2-coloring of $\\mathbb{R}^2$. Shader's 1976 breakthrough [Sh76] proved all right triangles are Ramsey using geometric constructions that exploit orthogonal reflections. The equilateral triangle is the natural candidate exception: a simple strip coloring demonstrates that specific equilateral triangles cannot be placed monochromatically. Kříž (1991) later developed permutation group methods for Euclidean Ramsey problems, and Frankl–Rödl (1990) established deep connections to partition regularity. The problem remains open and is central to the field.",
@@ -169,7 +169,7 @@
     "lineCount": 234,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos173Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 242,
     "assumptions": "5 axioms: decompNumber, lower_bound_from_bipartite, bucic_montgomery_bound, conlon_fox_sudakov, coverNumber. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 11
   },
   "sections": [
     {
@@ -177,7 +177,7 @@
     "lineCount": 242,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 11,
     "path": "Proofs/Erdos184Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -68,7 +68,7 @@
     "lineCount": 1104,
     "assumptions": "2 axioms: density_hales_jewett_k3, meshulam_upper_bound. 0 sorries.",
     "theoremCount": 73,
-    "definitionCount": 30
+    "definitionCount": 31
   },
   "overview": {
     "historicalContext": "Cap sets — subsets of $\\{0,1,2\\}^n$ with no three collinear points (i.e., no $x,y,z$ with $x+z=2y$ in $\\mathbb{F}_3^n$) — arose from the study of arithmetic progressions in finite geometry. Leo Moser posed the problem and constructed cap sets of size $\\Omega(3^n/\\sqrt{n})$ using coordinate-sum restrictions. Hillel Furstenberg and Yitzhak Katznelson (1991) proved the density Hales-Jewett theorem using ergodic theory, implying $f_3(n) = o(3^n)$. Roy Meshulam (1995) gave the first quantitative bound $f_3(n) \\leq 3^n/n$ using Fourier-analytic methods. The breakthrough came in 2016 when Jordan Ellenberg and Dion Gijswijt, building on Croot-Lev-Pach's polynomial method, proved $f_3(n) \\leq c^n$ with $c = 3 \\cdot (207 + 33\\sqrt{33})^{1/3}/8 \\approx 2.756$. This resolved a central problem in additive combinatorics and had immediate implications for the sunflower conjecture and other problems.",
@@ -206,7 +206,7 @@
     "lineCount": 1104,
     "axiomCount": 2,
     "theoremCount": 73,
-    "definitionCount": 30,
+    "definitionCount": 31,
     "path": "Proofs/Erdos185Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-19-oq-01/meta.json
+++ b/src/data/proofs/erdos-19-oq-01/meta.json
@@ -64,7 +64,7 @@
     "openQuestionOf": "erdos-19",
     "lineCount": 394,
     "theoremCount": 19,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The Erdős-Faber-Lovász (EFL) conjecture was proposed in 1972: if G is the union of n edge-disjoint copies of the complete graph K_n, then the chromatic number χ(G) = n. This was one of Erdős's favorite combinatorics conjectures, with a $500 prize — a remarkably clean statement about the interaction of clique structure and graph coloring. The conjecture is tight: the n cliques provide an n-coloring if one assigns color i to all vertices belonging exclusively to clique i, but vertices shared between cliques (at most one per pair of cliques, by the edge-disjointness condition) require careful treatment.\n\nFor nearly five decades, the EFL conjecture resisted proof. Kahn (1992) proved the weakened bound χ(G) ≤ (1+o(1))n, an important but incomplete step. The breakthrough came in 2021 when Kang, Kelly, Kühn, Methuku, and Osthus proved the conjecture for all 'sufficiently large' n using the absorbing method and fractional relaxations. Meanwhile, Hindman (1981) had verified the conjecture for small cases n ≤ 9. Together, these two results prove EFL for all n outside a finite gap [10, N₀), where N₀ is the explicit threshold from the asymptotic proof.\n\nThe remaining open question — the focus of this formalization — is: what is N₀? The Kang et al. paper establishes existence but gives only tower-type bounds on N₀ from the absorbing method. Closing the gap would either require (a) making the asymptotic constants explicit (reducing N₀ to something computationally tractable), or (b) proving EFL directly for n in [10, N₀) through targeted case analysis or flag algebra methods. This Lean formalization establishes the structural framework: the threshold N₀ exists and is well-defined, the finite reduction theorem shows EFL is equivalent to checking [10, N₀), and various gap properties (counterexample forcing, gap decidability) are formally verified.",
@@ -144,7 +144,7 @@
     "lineCount": 394,
     "path": "Proofs/Erdos19OQ01Problem.lean",
     "sorries": 0,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "theoremCount": 19
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 296,
     "assumptions": "2 axioms: chaotic_ordering_rationals, chaotic_ordering_k_term. 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdos Problem #194**\n\nThis problem asks about the structure of orderings (enumerations) of the real numbers, specifically whether they must contain monotone arithmetic progressions.\n\n**The Question:**\nGiven any way of listing the real numbers in a sequence, must there exist three terms that form both an arithmetic progression and are monotone (increasing or decreasing) in the listing order?\n\n**Resolution:**\nArdal, Brown, and Jungic (2011) showed the surprising answer is NO. They constructed \"chaotic orderings\" of the rationals (and by extension, the reals) that contain no monotone 3-term arithmetic progressions. This disproves the natural intuition that dense sets must have such structures in any enumeration.",
@@ -185,7 +185,7 @@
     "lineCount": 296,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos194Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-2/meta.json
+++ b/src/data/proofs/erdos-2/meta.json
@@ -40,7 +40,7 @@
     "assumptions": "3 axioms: balister_bound, owens_construction, reciprocal_sum_ge_one. hough_bound proved from balister_bound (616000 ≤ 10^16).",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 17
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "Covering systems were introduced by Erdős around 1950. He asked whether the minimum modulus of a covering system with distinct moduli can be made arbitrarily large, calling it 'perhaps my favourite problem' and offering a $1000 prize. Constructions pushed the minimum modulus steadily upward: 2 (Erdős 1950), 3 (Choi 1971), 20 (Krukenberg 1971), 36 (Gibson 2009), 40 (Nielsen 2009), and 42 (Owens 2014). Most experts expected the answer to be YES. In a stunning surprise, Hough (2015) proved the answer is NO — every covering system must contain a modulus $\\leq 10^{16}$ — using the Lovász Local Lemma and building on work of Filaseta, Ford, Konyagin, Pomerance, and Yu (2007). The bound was dramatically improved to $616{,}000$ by Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (2022) using their novel 'distortion method', published in the Annals of Mathematics. The exact maximum possible minimum modulus remains unknown, lying between 42 and 616,000.",
@@ -255,7 +255,7 @@
     "lineCount": 267,
     "axiomCount": 3,
     "theoremCount": 9,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "path": "Proofs/Erdos2Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-21/meta.json
+++ b/src/data/proofs/erdos-21/meta.json
@@ -64,7 +64,7 @@
     ],
     "assumptions": "9 axioms: f (exact value function f(n)), f_one/f_two/f_three/f_four/f_five (known values f(1)=1, f(2)=3, f(3)=6, f(4)=9, f(5)=13), erdos_lovasz_lower_bound (Erdős-Lovász lower bound from counting), kahn_1994_linear_bound (Kahn 1994: f(n) ≤ Cn), f_general (generalized function f_k(n) for k-element covering sets). 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #21: Covering Intersecting Families**\n\nThis $500 prize problem was conjectured by Erdős and Lovász in 1975 and asked whether an intersecting family of n-sets that covers all (n-1)-sets can have size O(n).\n\n**Historical Development:**\n- **1975:** Erdős-Lovász proved (8/3)n - 3 ≤ f(n) ≤ O(n^{3/2} log n)\n- **1992:** Kahn improved upper bound to f(n) ≤ O(n log n)\n- **1994:** Kahn proved f(n) = O(n), winning the $500 prize\n- **2014:** Tripathi computed f(3)=6, f(4)=9\n- **2021:** Barát-Wanless computed f(5)=13",
@@ -171,7 +171,7 @@
     "lineCount": 273,
     "axiomCount": 9,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "path": "Proofs/Erdos21Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-22/meta.json
+++ b/src/data/proofs/erdos-22/meta.json
@@ -65,7 +65,7 @@
     ],
     "assumptions": "6 axioms: edgeCount, independenceNumber, rt, fox_loh_zhao_2015, rt_lower_bound, fox_loh_zhao_sublinear. See Lean source for complete statements.",
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Erdős Problem #22 is the Bollobás-Erdős conjecture from 1976, arising from their systematic study of Ramsey-Turán problems. Turán's theorem (1941) tells us the maximum number of edges in a K₄-free graph on n vertices is about n²/3, achieved by the complete tripartite graph T(n,3). However, T(n,3) has independence number n/3, which is linear in n. The natural question is: what happens if we also demand small independence number?\n\nBollobás and Erdős conjectured that for any ε > 0 and sufficiently large n, there exist K₄-free graphs on n vertices with at least n²/8 edges and independence number at most εn. They proved a weaker version with (1/8 + o(1))n² edges. The bound n²/8 corresponds to the Ramsey-Turán density ρ₄ = 1/4, which measures the asymptotic edge density achievable under both clique-free and small-independence constraints.\n\nFox, Loh, and Zhao resolved the conjecture fully in 2015 using pseudorandom Cayley graph constructions over finite fields. Their result is actually much stronger than the conjecture: the independence number achieved is only O((log log n)^{3/2} / (log n)^{1/2} · n), which is far smaller than any εn. This polylogarithmic bound demonstrates the power of algebraic and probabilistic methods in extremal combinatorics.",
@@ -169,7 +169,7 @@
     "lineCount": 182,
     "axiomCount": 6,
     "theoremCount": 4,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos22Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-23/meta.json
+++ b/src/data/proofs/erdos-23/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 216,
     "assumptions": "2 axioms: edgeCount (edge count function — axiomatized), bipartiteEdgeDeletion (bipartite edge deletion number — axiomatized). 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1971, asking a fundamental question in extremal graph theory: how far can a triangle-free graph be from bipartite? Triangle-freeness is a local property (no $K_3$), while bipartiteness is global (no odd cycles at all). The blow-up of $C_5$ — replacing each vertex of the 5-cycle with $n$ independent vertices and connecting all vertices between adjacent parts — gives a triangle-free graph on $5n$ vertices requiring exactly $n^2$ edge deletions to become bipartite.\n\nErdős conjectured that $n^2$ always suffices, which would make the $C_5$ blow-up extremal. In 1992, he generalized: for graphs on $(2k+1)n$ vertices with odd girth $\\geq 2k+1$, the blow-up of $C_{2k+1}$ should be extremal with $n^2$ deletions.\n\nThe best known upper bound is $1.064n^2$ by Balogh, Clemen, and Lidický (2021) using flag algebra computations. Earlier results by Krivelevich (1995) and others gave weaker bounds. The problem is falsifiable — a finite counterexample would disprove it — but no such counterexample has been found.",
@@ -170,7 +170,7 @@
     "lineCount": 216,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "path": "Proofs/Erdos23Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "3 axioms inherited from Erdos25LogDensity.lean: naturalDensity_implies_logDensity (natural density implies logarithmic density), exists_logDensity_no_naturalDensity (existence of sets with log density but no natural density), davenport_erdos (Davenport-Erdős theorem on log density). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1995 (reference [Er95]), asking about a fundamental property of sets defined by congruence exclusions. The question connects to a rich tradition in analytic number theory: the study of how sieve-theoretic constructions interact with different notions of density. Logarithmic density, which weights each integer $m$ by $1/m$, is a weaker notion than natural density—it exists more often. For example, the set of integers whose prime factorization has an odd number of factors (related to the Liouville function) has logarithmic density $1/2$ even though its natural density oscillates. The classical sieve of Eratosthenes produces congruence-sieved sets (with prime moduli and residue 0), and the density of primes can be understood through this lens. Erdős's question generalizes this to arbitrary moduli and residues, asking whether the logarithmic density is always well-defined. The problem is a special case of the broader Problem 486, which asks the same question for more general sieve constructions. The key difficulty is that while finite sieves yield periodic sets (whose density trivially exists), infinite sieves can produce sets with complex, non-periodic structure where the limit defining the density may oscillate.",
@@ -154,7 +154,7 @@
     "lineCount": 208,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos25Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -71,7 +71,7 @@
     ],
     "assumptions": "4 axioms for deep mathematical results: (1) erdos_27_ffkpy — FFKPY 2007 main disproof (JAMS Theorem 1.1); (2) growing_C_achieves — FFKPY 2007 positive direction (Theorem 1.2); (3) averaging_bound_exists — probabilistic averaging argument; (4) bbmst_2024 — Bloom-Briggs-Maynard-Smith-Tao 2024 minimum modulus bound. All are published theorems.",
     "theoremCount": 11,
-    "definitionCount": 16
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "**Erdős Problem #27: Almost Covering Systems**\n\nThis $\\$100$ Erdős prize problem sits at the heart of the theory of covering systems — one of Erdős's most sustained research interests.\n\n**Background: Covering Systems**\nA covering system is a finite collection of congruence classes $a_i \\pmod{n_i}$ with distinct moduli $n_1 < \\ldots < n_k$ such that every integer belongs to at least one class. Erdős initiated the systematic study of these objects in 1950 and posed dozens of problems about them over the next five decades.\n\n**The Almost-Covering Question:**\nErdős asked a natural relaxation: instead of covering *every* integer, what if we only need to cover all but a small fraction? An $\\varepsilon$-almost covering leaves at most density $\\varepsilon$ of integers uncovered. The specific question was whether a fixed constant $C > 1$ suffices to achieve $\\varepsilon$-almost covering with all moduli in the bounded range $[N, CN]$, for *all* $\\varepsilon > 0$ and $N \\geq 1$.\n\n**The FFKPY Disproof:**\nFilaseta, Ford, Konyagin, Pomerance, and Yu resolved this negatively. Their key insight: for moduli in $[N, CN]$ with fixed $C$, the total 'coverage capacity' is $\\sum_{n=N}^{CN} 1/n \\approx \\ln C$, which is bounded. Using a critical exponent $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$, they showed that for $C \\leq N^{\\alpha(N)}$ (which includes all constants), the uncovered density is bounded below by approximately $1/(2C)$. No fixed $C$ can make this arbitrarily small.\n\n**What Does Work:**\nIf $C$ is allowed to grow with $N$ (e.g., $C(N) = N^{1/\\log\\log N}$), then $\\varepsilon$-almost coverings exist for any fixed $\\varepsilon$. The boundary between success and failure lies at the growth rate of the critical exponent.\n\n**Connection to Perfect Coverings:**\nThe related question for perfect coverings (covering *every* integer) was resolved by Hough (2015): covering systems cannot have all moduli exceeding some absolute bound. Bloom, Briggs, Maynard, Smith, and Tao (2024) improved the bound to $616{,}000$.",
@@ -196,7 +196,7 @@
     "lineCount": 340,
     "axiomCount": 4,
     "theoremCount": 11,
-    "definitionCount": 16,
+    "definitionCount": 18,
     "path": "Proofs/Erdos27Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 2
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Paul Erdős posed this problem in the 1970s–1980s as part of his systematic investigation of Diophantine equations involving products of consecutive integers. The foundational result in this area is the Erdős–Selfridge theorem (1975, Illinois J. Math.), which proved that a product of two or more consecutive positive integers is never a perfect power — settling a conjecture that had been open since the 19th century (partial results by Obláth, 1956). Problem #388 asks the next natural question: when can two *disjoint* blocks of consecutive integers have the same product? The connection to factorials $(m+1) \\cdots (m+k) = (m+k)!/m!$ means this is equivalent to asking when two factorial ratios can be equal. The threshold $k > 3$ is essential because for small $k$, parametric families of solutions exist. The problem also connects to the Brocard–Ramanujan problem ($n! + 1 = m^2$) and to Erdős Problems #363 and #931 on related product identities.",
@@ -113,7 +113,7 @@
     "lineCount": 111,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 2,
+    "definitionCount": 4,
     "path": "Proofs/Erdos388Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 558,
     "assumptions": "1 axiom: factorizationMax_asymptotic. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham first discussed this problem in their 1980 monograph. The key breakthrough came in the 1982 paper by Erdős, Richard Guy, and John Selfridge ('Another property of 239 and some related questions', Congress. Numer. 35), which established that the excess $f(n) - 2n$ has order of magnitude $n/\\log n$. The title refers to the surprising fact that $239$ is the smallest prime $p$ such that $p \\cdot (p+1)/2$ is not a product of primes $\\leq p$ — a related factorization curiosity. The problem asks whether the normalized excess $(f(n) - 2n) \\cdot \\log n / n$ converges to a specific constant, which would reveal the precise structure of optimal large-factor factorizations of $n!$. The function $f(n)$ is recorded as OEIS sequence A193429. This problem sits at the intersection of factorial arithmetic, prime number theory, and optimization over integer partitions.",
@@ -110,7 +110,7 @@
     "lineCount": 558,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos390Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 227,
     "assumptions": "5 axioms: easy_upper_bound, limit_is_one_over_e, second_order_correction, upper_bound_explicit, lower_bound_explicit. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős Problem #391 asks about the most balanced way to write n! as a product of exactly n positive integers. Define t(n) as the maximum over all such factorizations of the minimum factor. The central question is: what is the asymptotic behavior of t(n)/n? It is easy to show that lim sup t(n)/n ≤ 1/e using Stirling's approximation, and Erdős asked whether the limit equals 1/e and whether a second-order correction of the form c/log(n) exists.\n\nThe problem has a remarkable history. Erdős, Selfridge, and Straus claimed to have proved lim t(n)/n = 1/e, and Straus was tasked with writing up the proof. However, Straus died suddenly and no trace of his notes was ever found. Erdős and Selfridge could never reconstruct the proof, so the result reverted to conjecture status. The problem also appears as B22 in Guy's \"Unsolved Problems in Number Theory\" and was studied by Guy and Selfridge (1998), who made explicit conjectures about upper and lower bounds.\n\nIn 2025, Alexeev, Conway, Rosenfeld, Sutherland, Tao, Uhr, and Ventullo resolved both questions completely. They proved t(n)/n = 1/e - c₀/log(n) + O(1/(log n)^{1+c}), where c₀ ≈ 0.3044 is an explicit constant. They also verified Guy-Selfridge conjectures: t(n) ≤ n/e for all n except 1, 2, and 4, and t(n) ≥ n/3 for n ≥ 43632, with 43632 being the optimal threshold.",
@@ -183,7 +183,7 @@
     "lineCount": 227,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos391Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -70,7 +70,7 @@
     "lineCount": 310,
     "assumptions": "1 axiom: lin_bound_meaning (2^255 never divides such sums). lin_bound was derived from lin_bound_meaning. 0 sorries.",
     "theoremCount": 10,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -208,7 +208,7 @@
     "lineCount": 310,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos404Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-405/meta.json
+++ b/src/data/proofs/erdos-405/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "3 axioms: brindza_erdos_1991, yu_liu_1996, divisible_case_analysis. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in the 1970s, observing that $(p-1)! + a^{p-1}$ is rarely a perfect power of $p$. The factorial grows super-exponentially while $p^k$ grows only exponentially, so solutions should be sparse.\n\nBrindza and Erdős (1991) proved finiteness using Baker's theory of linear forms in logarithms. Baker's method (1966) gives effective bounds for Diophantine equations involving exponentials: if $\\Lambda = b_1 \\log \\alpha_1 + \\cdots + b_n \\log \\alpha_n \\neq 0$, then $|\\Lambda| > B^{-C}$ for an explicit $C$ depending on the $\\alpha_i$. Applied to $(p-1)! + a^{p-1} = p^k$, this yields an effective (though astronomically large) bound on all solution parameters.\n\nYu and Liu (1996) achieved a complete resolution by refining these bounds through careful $p$-adic analysis and exhaustive case checking for small primes. Their strategy: (1) show $p \\geq 7$ is impossible via factorial growth, (2) for $p = 3$, solve $2 + a^2 = 3^k$ (a generalized Ramanujan-Nagell equation), (3) for $p = 5$, solve $24 + a^4 = 5^k$ by $p$-adic methods.\n\nThe problem connects to Brocard's problem ($n! + 1 = m^2$, still open for $n > 7$) and Catalan's conjecture (proved by Mihailescu 2002: the only consecutive perfect powers are $8$ and $9$). The example $6! + 2^6 = 28^2$ (noted by Erdős-Graham) shows the perfect-power phenomenon extends beyond prime-power bases.",
@@ -192,7 +192,7 @@
     "lineCount": 299,
     "axiomCount": 3,
     "theoremCount": 15,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos405Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-440/meta.json
+++ b/src/data/proofs/erdos-440/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 200,
     "assumptions": "2 axioms: tao_elementary_proof, van_doorn_sharp_bound. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős Problem #440 originated from a problem in the American Mathematical Monthly. It asks about the growth of a counting function A(x) that measures how many consecutive pairs in an infinite sequence have small least common multiple. Erdős and Szemerédi solved it completely in their 1980 paper published in Mat. Lapok.\n\nThe key insight is that the natural numbers form the extremal sequence: for A = ℕ, consecutive integers n and n+1 are always coprime, so lcm(n, n+1) = n(n+1). This gives A(x) ≈ √x, and the liminf of A(x)/√x equals 1. Erdős and Szemerédi proved that no sequence can consistently exceed this — liminf A(x)/√x ≤ 1 for every sequence.\n\nTerence Tao later provided an elegant elementary proof of the O(√x) bound using a GCD decomposition argument. Wouter van Doorn established the sharp constant: A(x) ≤ (c + o(1))√x where c = Σ_{n≥1} 1/(√n(n+1)) ≈ 1.86, confirming and refining the Erdős-Szemerédi result.",
@@ -147,7 +147,7 @@
     "lineCount": 200,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos440Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -20,7 +20,7 @@
     "lineCount": 142,
     "axiomCount": 1,
     "sorries": 0,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "theoremCount": 4
   },
   "meta": {
@@ -81,7 +81,7 @@
     "lineCount": 142,
     "assumptions": "1 axiom: erdos_455_conjecture (the open conjecture stated as an abstract Prop).",
     "theoremCount": 4,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "**Erdős Problem #455: Monotone Prime Gap Sequences**\n\nThis problem concerns sequences of primes where consecutive gaps never decrease — a discrete convexity condition. Such sequences must spread out increasingly, but the question is: how fast?\n\n**Historical Development:**\n- **Erdős** posed the problem: if $q_1 < q_2 < \\cdots$ are primes with $q_{n+1} - q_n \\geq q_n - q_{n-1}$, must $\\lim q_n/n^2 = \\infty$?\n- **Bernd Richter (1976)**, in *Über die Monotonie von Differenzenfolgen* (Acta Arithmetica), proved the partial result $\\liminf q_n/n^2 > 0.352$, establishing at least quadratic growth.\n- The full conjecture — superquadratic growth — remains open.\n\n**Context:** The sequence of all consecutive primes $(2, 3, 5, 7, 11, 13, \\ldots)$ does NOT satisfy the monotone-gap condition, since the gaps $1, 2, 2, 4, 2, \\ldots$ are not non-decreasing. Monotone-gap prime sequences must be carefully chosen subsequences. The problem connects to the Prime Number Theorem (which gives average gap $\\sim \\log n$) and to Cramér's conjecture on maximal gaps.",

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -90,7 +90,7 @@
     "lineCount": 256,
     "assumptions": "3 axioms: sarkozy_1976, konyagin_2001, problem_466_lower_bound. Structure fields are object definitions, not assumptions.",
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "**Points with Distances Avoiding Integers: From Sublinear to √X**\n\nErdős posed Problem #465 asking about the function N(X,δ) — the maximum number of points in a circle of radius X such that all pairwise distances avoid integers by at least δ. The problem sits at the intersection of combinatorial geometry and Diophantine approximation.\n\n**The First Wave: Sárközy (1976)**\n\nSárközy proved N(X,δ) ≤ C·δ⁻³·X/log log X, establishing sublinear growth. The proof uses analytic number theory: among n points, the binom(n,2) pairwise distances have a distribution modulo 1 that is controlled by exponential sums. The condition ‖d_{ij}‖ ≥ δ forces the distances into 'gaps' around integers, and counting arguments show this limits n. The bound X/log log X is tantalizingly close to linear — log log X grows so slowly that it barely reduces X.\n\n**The Breakthrough: Konyagin (2001)**\n\nTwenty-five years later, Konyagin proved the dramatically stronger bound N(X,δ) ≤ C_δ·X^{1/2} using Fourier analysis and exponential sum estimates. The key insight: consider the exponential sums S(t) = Σ_{i≠j} e^{2πi t d_{ij}}. The distance-avoidance condition creates constructive interference at integer t, while L² estimates on S(t) bound the total 'energy.' Balancing these gives n ≤ O(X^{1/2}).\n\n**Optimality: Problem #466**\n\nThe companion Problem #466 provides matching lower bounds: N(X,δ) ≥ c_δ·X^{1/2}. The construction uses carefully chosen point sets (related to lattice perturbations) achieving ~√X points with all distances avoiding integers. Together, this gives N(X,δ) ≍ X^{1/2}.\n\n**The Improvement Factor**\n\nFor X = 10⁶: Sárközy allows ~400,000 points while Konyagin allows only ~1,000 — a factor of 400. The jump from exponent 1 (minus iterated logarithm) to exponent 1/2 required fundamentally new techniques.",
@@ -189,7 +189,7 @@
     "lineCount": 256,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos465Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -37,7 +37,7 @@
     "lineCount": 79,
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "sections": [
     {
@@ -137,7 +137,7 @@
     "lineCount": 79,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/Erdos466Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -56,7 +56,7 @@
     "assumptions": "1 axiom: erdos_467_conjecture (the main open conjecture). CRT and Mertens estimate now fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph (p.93), asking whether the redundancy in prime residue classes — captured by the divergence of $\\sum 1/p$ — is sufficient to split primes into two halves that each independently cover everything. The original quantifier structure is subtle: 'for sufficiently large $x$' means $\\exists X,\\, \\forall x \\geq X$. The problem connects covering congruences (a classical Erdős theme) to the Chinese Remainder Theorem and Mertens' product estimates.",
@@ -158,7 +158,7 @@
     "lineCount": 277,
     "axiomCount": 1,
     "theoremCount": 25,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos467Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` to the actual
declaration count in each Lean source file, for 25 entries not covered
by the existing in-flight defcount batches (#17462 a-b, #17506 a-e,
#17503 erdos-200-499 partial, #17507 erdos-110-1182 partial).

## Counting convention

Per `feedback_mechanic_def_counting.md`: count `def + abbrev + opaque +
structure + inductive + class` declarations with optional `partial /
private / protected / noncomputable / unsafe / scoped` modifiers; do
NOT count `instance`. Comments stripped (nested-block-comment aware)
before regex.

## Evidence

For each entry, the claimed value appears in BOTH `meta.definitionCount`
and `leanFile.definitionCount` (matching), and disagrees with the actual
count in the Lean file at `meta.proofRepoPath`. Both fields updated
surgically via 2-line text replacement (formatting preserved).

| slug | claimed | actual | delta |
|---|---|---|---|
| erdos-2 | 17 | 19 | +2 |
| erdos-19-oq-01 | 6 | 7 | +1 |
| erdos-21 | 8 | 10 | +2 |
| erdos-22 | 4 | 5 | +1 |
| erdos-23 | 8 | 10 | +2 |
| erdos-25 | 6 | 7 | +1 |
| erdos-27 | 16 | 18 | +2 |
| erdos-128 | 5 | 6 | +1 |
| erdos-130 | 9 | 10 | +1 |
| erdos-149 | 6 | 7 | +1 |
| erdos-162 | 4 | 5 | +1 |
| erdos-173 | 11 | 12 | +1 |
| erdos-184 | 8 | 11 | +3 |
| erdos-185 | 30 | 31 | +1 |
| erdos-194 | 8 | 9 | +1 |
| erdos-388 | 2 | 4 | +2 |
| erdos-390 | 9 | 10 | +1 |
| erdos-391 | 7 | 8 | +1 |
| erdos-404 | 8 | 9 | +1 |
| erdos-405 | 5 | 6 | +1 |
| erdos-440 | 6 | 7 | +1 |
| erdos-455 | 1 | 2 | +1 |
| erdos-465 | 11 | 12 | +1 |
| erdos-466 | 2 | 3 | +1 |
| erdos-467 | 6 | 7 | +1 |

---

Automated fix by lean-mechanic agent.