### PR TITLE
fix(meta): batch sync theoremCount drift (11 entries, batch a-c gap)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 18,
+    "theoremCount": 17,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -161,7 +161,7 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 17,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "theoremCount": 13,
+    "theoremCount": 10,
     "definitionCount": 1
   },
   "overview": {
@@ -104,7 +104,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 13
+    "theoremCount": 10
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 8,
+        "theoremCount": 7,
         "definitionCount": 1,
         "assumptions": ""
     },
@@ -106,7 +106,7 @@
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 8,
+        "theoremCount": 7,
         "definitionCount": 1,
         "sorries": 0
     },

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Logarithmic functions on naturals",
       "Well-founded recursion and termination proofs"
     ],
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2
   },
   "overview": {
@@ -177,7 +177,7 @@
     "namespace": "BinaryGcdOQ01",
     "lineCount": 215,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -67,7 +67,7 @@
       "Mathlib's Int.gcd defined via natAbs",
       "Basic absolute-value identities on ℤ"
     ],
-    "theoremCount": 14,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "sections": [
@@ -204,7 +204,7 @@
     "namespace": "BinaryGcdOQ02",
     "lineCount": 134,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/BinaryGcdOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "lineCount": 224,
     "assumptions": "None. All theorems are fully proved including the q-Vandermonde identity.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "overview": {
@@ -154,7 +154,7 @@
     "namespace": "BinomialTheoremOQ04OQ02OQ01",
     "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 8,
     "privateCount": 2,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -36,7 +36,7 @@
       "threshold_d10: exact k=3 birthday threshold for d=10 days is n=12 (verified by native_decide)"
     ],
     "lineCount": 317,
-    "theoremCount": 43,
+    "theoremCount": 41,
     "defCount": 2,
     "definitionCount": 2
   },
@@ -135,7 +135,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 43
+    "theoremCount": 41
   },
   "sorries": 0
 }

--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -71,7 +71,7 @@
     "mathlib_version": "4.26.0",
     "axioms": 4,
     "lineCount": 5139,
-    "theoremCount": 220,
+    "theoremCount": 217,
     "definitionCount": 46
   },
   "overview": {
@@ -203,7 +203,7 @@
     "namespace": "BorsukUlamOQ03",
     "lineCount": 5139,
     "axiomCount": 1,
-    "theoremCount": 220,
+    "theoremCount": 217,
     "definitionCount": 46,
     "path": "Proofs/BorsukUlamOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -51,7 +51,7 @@
     "lineCount": 391,
     "assumptions": "0 axioms, 0 sorries. 1D fixed point existence uses Mathlib's exists_mem_Icc_isFixedPt_of_mapsTo (Brouwer FPT).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 5
   },
   "overview": {
@@ -221,7 +221,7 @@
     "namespace": "BrouwerOQ02",
     "lineCount": 391,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 5,
     "path": "Proofs/BrouwerFixedPointOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -49,7 +49,7 @@
     "lineCount": 442,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 28,
+    "theoremCount": 27,
     "definitionCount": 5
   },
   "overview": {
@@ -229,7 +229,7 @@
     "namespace": "CantorDiagonalizationOQ01",
     "lineCount": 442,
     "axiomCount": 2,
-    "theoremCount": 28,
+    "theoremCount": 27,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 390,
     "assumptions": "None. All theorems fully proved including minpoly computations via UFD divisor classification and intertwining constraint extraction via Fin 4 case analysis.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 2
   },
   "overview": {
@@ -147,7 +147,7 @@
     "namespace": "SimilarCounterexample",
     "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` to the actual `(theorem|lemma)` decl count. All 11 entries had `meta` and `leanFile` values matching each other but overcounting the source by 1–6. These are the leftover gap entries between PR #17441 (batch alphabetical) and PR #17518 (batch c–g).

## Convention

Strip block + line comments (nested `/-` … `-/` honored), then count top-level decls matching:

```
^\s*(?:(?:private|protected|noncomputable|partial|unsafe|scoped)\s+)*(theorem|lemma)\s+
```

Same convention as PRs #17441 / #17462 / #17518.

## Per-entry deltas (claimed → actual)

| slug | claimed | actual |
|------|---------|--------|
| amgm-inequality-oq-02-oq-02 | 18 | 17 |
| angle-trisection-oq-03-oq-02 | 13 | 10 |
| bezout-identity-oq-03-oq-03 | 8 | 7 |
| binary-gcd-oq-01 | 4 | 3 |
| binary-gcd-oq-02 | 14 | 8 |
| binomial-theorem-oq-04-oq-02-oq-01 | 10 | 8 |
| birthday-problem-oq-03-oq-01-oq-01 | 43 | 41 |
| borsuk-ulam-oq-03 | 220 | 217 |
| brouwer-fixed-point-oq-02 | 13 | 12 |
| cantor-diagonalization-oq-01 | 28 | 27 |
| cayley-hamilton-minpoly-oq-02-oq-02 | 16 | 14 |

## Evidence

Each meta.json had two occurrences of the wrong `theoremCount` value (once in `meta.*` summary, once in `leanFile.*`); both were updated to match the live count. Diff is exactly 22/22 lines (11 entries × 2 occurrences).

Confirmed with `grep -cE '^\s*(private |protected |noncomputable |partial |unsafe |scoped )*(theorem|lemma) '` on each Lean source as cross-check (all match the comment-stripped count).

Verified no overlap with any open PR (`gh pr list --search <slug>`):
- amgm-inequality-oq-02 (different slug, in #17441) ≠ amgm-inequality-oq-02-oq-02
- amgm-inequality-oq-04-oq-02 PRs touch a different file
- binary-gcd-oq-03-oq-02 PRs touch a different file
- birthday-problem-oq-03-oq-01-oq-02-oq-01 PRs touch a different file
- borsuk-ulam-oq-02-oq-01-oq-03-oq-02 PRs touch a different file
- cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 PRs touch a different file

---
Automated fix by lean-mechanic agent.