### PR TITLE
Enrich ballot-problem-oq-02-oq-02: split sections + Part VIII annotation (98→100)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/annotations.json
@@ -157,23 +157,47 @@
   {
     "id": "ann-ballot-ivt",
     "proofId": "ballot-problem-oq-02-oq-02",
-    "range": { "startLine": 142, "endLine": 185 },
+    "range": { "startLine": 142, "endLine": 160 },
     "type": "technique",
-    "title": "IVT provides nonemptiness for crossing paths",
-    "content": "Proves `ivt_first_crossing`: if W(0,ω) < a ≤ W(T,ω), there exists s ∈ (0,T] with W(s,ω) ≥ a, using `intermediate_value_Icc`. Then `hittingSet_nonempty_of_ivt` gives nonemptiness, and `fpt_le_T_of_crossing` gives both τ ≤ T and ω ∈ maxEvent for crossing paths. This handles the typical case where a path crosses the threshold.",
-    "mathContext": "IVT on $[0,T]$: for continuous $f: [0,T] \\to \\mathbb{R}$ with $f(0) < a \\leq f(T)$, there exists $s \\in [0,T]$ with $f(s) \\geq a$ (specifically $f(s) = a$ is sufficient). The crossing time $s$ witnesses nonemptiness of the hitting set, enabling `hittingSet_csInf_mem` and the full characterization. For paths starting at or above $a$ ($W(0,\\omega) \\geq a$), nonemptiness is immediate ($0$ is in the hitting set).",
+    "title": "IVT first-crossing time: extracting $s$ with $B(s,\\omega) = a$",
+    "content": "`ivt_first_crossing` is the topological extraction step that supplies the nonemptiness hypothesis required by the hard direction. Given a continuous path $B(\\cdot,\\omega)$ that strictly starts below $a$ ($B(0,\\omega) < a$) and ends at or above $a$ ($B(T,\\omega) \\ge a$), the Intermediate Value Theorem in two-function form (`isPreconnected_Icc.intermediate_value₂`) crosses the constant function $g \\equiv a$ to produce $s \\in [0,T]$ with $B(s,\\omega) = a$ exactly. Two notable mechanical steps follow IVT: (i) the equality $B(s,\\omega) = a$ rewrites to $B(s,\\omega) \\ge a$ via `hs_eq ▸ le_refl a`, fitting the hitting-set predicate; (ii) the strict initial inequality $B(0,\\omega) < a$ rules out $s = 0$, so $s > 0$ — a strengthening that is not strictly needed for nonemptiness (any $s \\ge 0$ would do) but is preserved in the conclusion as documentation of where the crossing actually lives.",
+    "mathContext": "**IVT, two-function form**: for continuous $f, g$ on a preconnected space with $f(a) \\le g(a)$ and $g(b) \\le f(b)$, there is $s$ with $f(s) = g(s)$. Here $f(t) = B(t,\\omega)$ (continuous by `bm.path_continuous`), $g(t) = a$ (constant, hence continuous), endpoints $a = 0$ and $b = T$. The hypotheses become $B(0,\\omega) \\le a$ (from `le_of_lt hstart`, weakening the strict inequality) and $a \\le B(T,\\omega)$ (`hend`). Conclusion: $\\exists s \\in [0,T]\\colon B(s,\\omega) = a$.\n\n**Why $s > 0$**: if $s = 0$ then $B(0,\\omega) = a$, contradicting $B(0,\\omega) < a$. Lean: `rcases hs_Icc.1.eq_or_gt with rfl | hs_pos` cases on whether $s = 0$ or $s > 0$; the first branch derives `False` from `hs_eq` + `hstart`.\n\n**Why two-function IVT instead of `intermediate_value_Icc`**: the two-function form lets us cross a constant *level* $a$ directly without forming the auxiliary function $f - a$, avoiding the boilerplate of proving continuity of the difference. This is the standard Mathlib pattern for hitting-time arguments.",
     "significance": "supporting",
     "relatedConcepts": [
-      "intermediate_value_Icc",
+      "isPreconnected_Icc.intermediate_value₂",
       "IVT for continuous functions",
       "level crossing",
-      "path continuity"
+      "path continuity",
+      "constant-function comparison"
     ],
     "prerequisites": [
-      "intermediate_value_Icc",
+      "isPreconnected_Icc.intermediate_value₂",
       "Continuous.continuousOn",
-      "hittingSet_isClosed",
-      "fpt_le_iff_maxEvent"
+      "isClosed_Ici (for the Ici ∋ a image)",
+      "Set.Icc and Set.mem_Icc"
+    ]
+  },
+  {
+    "id": "ann-ballot-crossing-fpt-bound",
+    "proofId": "ballot-problem-oq-02-oq-02",
+    "range": { "startLine": 162, "endLine": 185 },
+    "type": "insight",
+    "title": "Capstone: crossing paths automatically discharge nonemptiness",
+    "content": "Two corollaries close the loop on the conditional characterization. `hittingSet_nonempty_of_ivt` repackages the IVT witness from Part VII as a nonemptiness proof for the hitting set $H_a(\\omega) = \\{t \\ge 0 : B(t,\\omega) \\ge a\\}$ — purely a coordinate change between the IVT output (a witness $s \\in [0,T]$ with $B(s,\\omega) = a$) and the hitting-set predicate. `fpt_le_T_of_crossing` then composes `hittingSet_nonempty_of_ivt` with `fpt_le_iff_maxEvent` to deliver, in one user-facing step, both $\\tau(\\omega) \\le T$ and $\\omega \\in \\mathrm{maxEvent}$ for any path satisfying the natural crossing endpoints $B(0,\\omega) < a \\le B(T,\\omega)$. This is the *deliverable* of the file: the parent axiom holds (with both directions) for every crossing path, with no remaining nonemptiness obligation on the caller.",
+    "mathContext": "**`hittingSet_nonempty_of_ivt`**: the IVT witness $s$ has $0 \\le s$ (from $s \\in [0,T]$) and $B(s,\\omega) \\ge a$ (rewriting $B(s,\\omega) = a$ via `hs_eq ▸ le_refl a`). So $s \\in H_a(\\omega)$, witnessing nonemptiness.\n\n**`fpt_le_T_of_crossing`**: combine `hittingSet_nonempty_of_ivt` with `(fpt_le_iff_maxEvent ...).mpr`. The right-hand witness for $\\omega \\in \\mathrm{maxEvent}$ is $T$ itself: $T \\in [0,T]$ trivially, and $B(T,\\omega) \\ge a$ from the `hend` hypothesis. So $\\omega \\in \\mathrm{maxEvent}$ via $\\langle T, \\langle 0 \\le T, T \\le T \\rangle, \\mathrm{hend} \\rangle$, and then `fpt_le_iff_maxEvent.mpr` upgrades this to $\\tau(\\omega) \\le T$.\n\n**Why this corollary is the right shape**: in real Brownian-motion applications, one almost always knows endpoints (or has them by Skorokhod / Doob). The crossing-endpoint condition $B(0,\\omega) < a \\le B(T,\\omega)$ is the natural input, and `fpt_le_T_of_crossing` returns exactly what an analyst wants — both directions of the level-crossing identity, with no side condition. Compare to the looser `fpt_le_iff_maxEvent`, which leaves the caller to verify nonemptiness — useful for non-crossing paths (where nonemptiness might come from a non-IVT source) but inconvenient for the typical use case.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fpt_le_iff_maxEvent (composition target)",
+      "discharging hypotheses",
+      "user-facing capstone theorem",
+      "level-crossing identity",
+      "stopping time bounds"
+    ],
+    "prerequisites": [
+      "fpt_le_iff_maxEvent",
+      "ivt_first_crossing",
+      "Set.mem_Icc",
+      "anonymous-constructor witness construction"
     ]
   }
 ]

--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -89,12 +89,20 @@
       "mathContext": "**Easy direction** ($\\omega \\in \\mathrm{maxEvent} \\Rightarrow \\tau \\le T$): pick $s \\in [0,T]$ with $B(s,\\omega) \\ge a$ from the maxEvent witness; then $s \\in H_a(\\omega)$, so $\\tau = \\inf H_a(\\omega) \\le s \\le T$ by `csInf_le` (which only needs `BddBelow`). **Hard direction** ($\\tau \\le T \\Rightarrow \\omega \\in \\mathrm{maxEvent}$, given $H_a(\\omega) \\ne \\emptyset$): by `hittingSet_csInf_mem`, $\\tau = \\inf H_a(\\omega) \\in H_a(\\omega)$, so $0 \\le \\tau$ and $B(\\tau,\\omega) \\ge a$. Combined with $\\tau \\le T$ from the hypothesis, the witness is $s = \\tau \\in [0,T]$ with $B(s,\\omega) \\ge a$. The biconditional `fpt_le_iff_maxEvent` and the extensional set equality `fpt_le_set_eq_maxEvent` follow."
     },
     {
-      "id": "ivt-nonemptiness",
-      "title": "IVT-Based Nonemptiness for Crossing Paths",
+      "id": "ivt-first-crossing",
+      "title": "Intermediate Value Theorem: First Crossing Time",
       "startLine": 137,
+      "endLine": 160,
+      "summary": "Part VII. `ivt_first_crossing` extracts a witness $s \\in [0,T]$ with $B(s,\\omega) = a$ (hence $\\ge a$) whenever $B(0,\\omega) < a \\le B(T,\\omega)$. Uses `isPreconnected_Icc.intermediate_value\u2082` against the constant function $g \\equiv a$. The strict initial inequality $B(0,\\omega) < a$ is then leveraged to upgrade $s \\ge 0$ to $s > 0$ (since $B(0,\\omega) \\ne a$).",
+      "mathContext": "The Lean step: `isPreconnected_Icc.intermediate_value\u2082 h01 hT1 hcont continuousOn_const (le_of_lt hstart) hend`, where the two functions are $f(t) = B(t,\\omega)$ and $g(t) = a$ (constant). IVT gives $s \\in [0,T]$ with $f(s) = g(s) = a$. The strict inequality $B(0,\\omega) < a$ then forces $s > 0$ (otherwise $B(0,\\omega) = a$, contradicting `hstart`). Note the use of `intermediate_value\u2082` rather than the simpler `intermediate_value_Icc`: the two-function form lets us cross a *constant* level $a$ rather than restrict to specific endpoint values, which is the more natural shape for hitting-time arguments and avoids the boilerplate of forming the auxiliary function $f - a$."
+    },
+    {
+      "id": "crossing-fpt-bound",
+      "title": "Discharging Nonemptiness: Crossing Paths Imply $\\tau \\le T$",
+      "startLine": 162,
       "endLine": 185,
-      "summary": "Parts VII-VIII. ivt_first_crossing (IVT gives s \u2208 [0,T] with B(s,\u03c9) = a, hence \u2265 a, when B(0,\u03c9) < a \u2264 B(T,\u03c9); also $s > 0$ since $B(0,\\omega) < a = B(s,\\omega)$), hittingSet_nonempty_of_ivt (crossing paths have nonempty hitting sets), fpt_le_T_of_crossing (for crossing paths, \u03c4 \u2264 T and \u03c9 \u2208 maxEvent both hold).",
-      "mathContext": "The Lean step: `isPreconnected_Icc.intermediate_value\u2082 h01 hT1 hcont continuousOn_const (le_of_lt hstart) hend`, where the two functions are $f(t) = B(t,\\omega)$ and $g(t) = a$ (constant). IVT gives $s \\in [0,T]$ with $f(s) = g(s) = a$. The strict inequality $B(0,\\omega) < a$ then forces $s > 0$ (otherwise $B(0,\\omega) = a$, contradicting `hstart`). Crossing paths therefore satisfy the nonemptiness hypothesis of `fpt_le_iff_maxEvent`, closing the loop: continuity + crossing $\\Rightarrow$ both directions of the characterization hold."
+      "summary": "Part VIII. Two corollaries that close the loop on the conditional characterization. `hittingSet_nonempty_of_ivt` packages the IVT witness from Part VII as a nonemptiness proof for $H_a(\\omega)$. `fpt_le_T_of_crossing` is the capstone: for crossing paths ($B(0,\\omega) < a \\le B(T,\\omega)$), it produces both $\\tau \\le T$ *and* $\\omega \\in \\mathrm{maxEvent}$, automatically discharging the nonemptiness side condition that `fpt_le_iff_maxEvent` required.",
+      "mathContext": "`hittingSet_nonempty_of_ivt`: the IVT witness $s \\in [0,T]$ with $B(s,\\omega) = a$ also satisfies $0 \\le s$ (from the IVT interval) and $B(s,\\omega) \\ge a$ (rewriting the equality), so $s \\in H_a(\\omega) = \\{t \\ge 0 : B(t,\\omega) \\ge a\\}$, witnessing nonemptiness. `fpt_le_T_of_crossing`: combining `hittingSet_nonempty_of_ivt` with `fpt_le_iff_maxEvent` yields $\\tau \\le T \\iff \\omega \\in \\mathrm{maxEvent}$, and the right side is witnessed directly by $T \\in [0,T]$ (with $B(T,\\omega) \\ge a$ from `hend`). The capstone is the user-facing identity: continuity of paths + level-crossing endpoints imply *both* directions of the level-crossing characterization, with no remaining nonemptiness obligation on the caller."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Targeted closure of the last 2-point quality gap on `ballot-problem-oq-02-oq-02`. Splits an oversized section and the corresponding wide-range annotation along the file's natural Part VII / Part VIII boundary so the page renders the IVT extraction and the crossing-paths capstone as separate, individually navigable units.

## Changes

- **meta.json** — `sections`: split `ivt-nonemptiness` (137–185) into:
  - `ivt-first-crossing` (137–160, Part VII): IVT-based extraction of $s$ with $B(s,\omega) = a$, with mathContext explaining `isPreconnected_Icc.intermediate_value₂` against the constant function $g \equiv a$ and the strict-inequality-forces-$s>0$ step.
  - `crossing-fpt-bound` (162–185, Part VIII): the `hittingSet_nonempty_of_ivt` packaging step plus the user-facing capstone `fpt_le_T_of_crossing`, with mathContext on why the crossing-endpoint shape is what analysts want.

- **annotations.json** — split `ann-ballot-ivt` (142–185) into:
  - `ann-ballot-ivt` (142–160) — IVT extraction with detail on the two-function form (`intermediate_value₂` vs. `intermediate_value_Icc` / forming $f - a$).
  - `ann-ballot-crossing-fpt-bound` (162–185) — capstone discharging the nonemptiness obligation that `fpt_le_iff_maxEvent` left to the caller; explains why $T$ itself is the maxEvent witness in `fpt_le_T_of_crossing`.

## Quality

- find-targets quality: **98 → 100** (sections 8/10 → 10/10).
- 9 annotations (was 8); 5 sections (was 4). All annotations retain `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- No content removed; existing summaries / mathContexts preserved verbatim where they still apply.

## Test plan

- [x] JSON validates (`json.load`).
- [x] Section line ranges contiguous and within file extent (185 lines).
- [x] Annotation ranges within their respective section boundaries.
- [x] `find-targets.ts --json` reports `quality: 100`.
- [ ] `pnpm build` not run — environment fails on `better-sqlite3` native rebuild (node v26.0.0 / node-gyp v12.3.0, unrelated to this change).