### PR TITLE
fix(meta): batch sync theoremCount drift (5 entries, batch h-z)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-02/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02/meta.json
@@ -54,7 +54,7 @@
     ],
     "assumptions": "0 axioms, 0 sorries. All q-analog definitions built from scratch. Cyclotomic factorization of q-numbers from Mathlib; all else original.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 4
   },
   "overview": {
@@ -183,7 +183,7 @@
     "namespace": "KummerTheoremOQ02",
     "lineCount": 412,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 4,
     "path": "Proofs/KummerTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -31,7 +31,7 @@
       "Recovery theorems: K=1 gives spherical law, K=-1 gives hyperbolic law",
       "Algebraic equivalences: unified formula ↔ scaled spherical/hyperbolic laws for all K≠0"
     ],
-    "theoremCount": 22,
+    "theoremCount": 28,
     "definitionCount": 2
   },
   "overview": {
@@ -195,7 +195,7 @@
     "namespace": "UnifiedLawOfCosines",
     "lineCount": 693,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 28,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ05.lean",
     "sorries": 0

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/LebesgueMeasureOQ06Aristotle.lean"
@@ -220,7 +220,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 562,
-    "theoremCount": 8,
+    "lineCount": 606,
+    "theoremCount": 10,
     "definitionCount": 0,
     "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Status flag remains `axiomatized` and badge remains `axiom` pending Docker CI verification of the post-S14 source \u2014 the broken `proofs/.lake` recursive self-symlink in this repo forces every full build into a 30\u201345 min Mathlib refetch, so build verification is gated on a separate Mechanic infra-repair pass. Once CI confirms a green build, the entry will graduate to status `verified` / badge `original` via a follow-up Mechanic/Auditor PR. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
     "dateAdded": "2026-05-07",
@@ -170,8 +170,8 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 562,
-    "theoremCount": 8,
+    "lineCount": 606,
+    "theoremCount": 10,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/shannon-channel-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04/meta.json
@@ -58,7 +58,7 @@
       "Basic real analysis inequalities"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 2
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "InformationTheory.BinaryEntropy",
     "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/ShannonChannelCodingOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` (and one `meta.lineCount`) to match actual Lean source for 5 entries in the h-z range.

| Slug | Field | Before | After |
|---|---|---|---|
| kummer-theorem-oq-02 | theoremCount | 16 | 21 |
| law-of-cosines-oq-01-oq-05 | theoremCount | 22 | 28 |
| lebesgue-measure-oq-06 | theoremCount | 40 | 52 |
| minkowski-theorem-oq-04 | theoremCount | 8 | 10 |
| minkowski-theorem-oq-04 | lineCount | 562 | 606 |
| shannon-channel-coding-oq-04 | theoremCount | 10 | 12 |

## Evidence

Counts verified via comment-stripped regex against actual `proofs/Proofs/*.lean` files at `origin/main` (ec8cbd1562f). Both `meta.*` and `leanFile.*` blocks updated for each entry.

Complementary scope to in-flight #17518 (c-g) and #17521 (a-c gap); no overlap.

## Test plan

- [x] meta.theoremCount and meta.lineCount sync verified by re-running the strip-comments scanner; all 5 entries now report zero drift.
- [x] No Lean source changes; pure metadata.
- [ ] Deployer auto-merges as standard mechanic batch.

---
Automated fix by lean-mechanic agent.