### PR TITLE
fix(meta): batch sync definitionCount drift (2 entries, mixed)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -37,7 +37,7 @@
         "module": "Mathlib.FieldTheory.IntermediateField.Adjoin.Basic"
       }
     ],
-    "definitionCount": 3,
+    "definitionCount": 4,
     "additionalFiles": [
       "Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean"
     ]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -29,7 +29,7 @@
       "Feasibility analysis for Mathlib contribution (~200-300 lines)"
     ],
     "theoremCount": 8,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
     ]


### PR DESCRIPTION
## Summary

- **binomial-theorem-oq-02-oq-01-oq-01**: `meta.definitionCount` 2 → 3 (matches `leanFile.definitionCount`)
- **angle-trisection-oq-02-oq-01-oq-02**: `meta.definitionCount` 3 → 4 (matches `leanFile.definitionCount`)

Both entries had stale `meta.definitionCount` while `leanFile.definitionCount` was authoritative and matched the actual main-file declaration count.

## Verification

For each entry, the actual count of `def + abbrev + opaque + structure + inductive + class` declarations (with optional `partial/private/protected/noncomputable/unsafe/scoped` modifiers, comments stripped including nested block comments) in the main proof file matches the new `meta.definitionCount`:

| slug | main file decls | new meta.dc | lf.dc |
|------|----------------|-------------|-------|
| binomial-theorem-oq-02-oq-01-oq-01 | 3 (2 def + 1 structure) | 3 | 3 |
| angle-trisection-oq-02-oq-01-oq-02 | 4 (3 def + 1 inductive) | 4 | 4 |

Convention confirmed via 183/198 entries with additionalFiles where `meta.definitionCount == leanFile.definitionCount` (main-only count).

## Coverage gap

Open mechanic batch PRs cover other drift dimensions: theoremCount (#17518/#17521), lineCount (#17481), definitionCount erdos batches (#17519/#17526). These two mixed-namespace entries fell outside those batches.

## Test plan

- [ ] CI passes (no lint/build impact, metadata-only edits)
- [ ] Spot-check that no other field needed updating in the same files

🤖 Generated with [Claude Code](https://claude.com/claude-code)