### PR TITLE
research(minkowski-theorem-oq-04): S18 — minkowski_general_k (primary form, build pending)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04.lean
@@ -592,6 +592,113 @@ theorem minkowski_from_blichfeldt {n : ℕ} [NeZero n]
     hab_diff
   exact ⟨⟨_, hp_mem_sg⟩, fun h => (sub_ne_zero.mpr hab_ne) (congrArg Subtype.val h), hp_in_s⟩
 
+/-- **Generalized Minkowski (k+1-point form)**:
+A measurable convex centrally-symmetric set `s ⊆ ℝⁿ` with
+`volume s > k · 2ⁿ` contains `k + 1` distinct lattice points.
+
+Strengthens `minkowski_from_blichfeldt` (the `k = 1` case yielding one
+nonzero lattice point: paired with `0 ∈ s` from convex+symmetric+nonempty,
+that is exactly two distinct lattice points).  The `k = 0` case
+degenerates to `0 < volume s`, with the conclusion giving one lattice
+point in `s` (anchored at the origin via the convexity step).
+
+The proof mirrors `minkowski_from_blichfeldt` step-by-step, replacing the
+`blichfeldt_basic` invocation with `blichfeldt_general k`.  Half-scaling
+turns `volume s > k · 2ⁿ` into `volume T > k` where `T = (1/2) • s`;
+`blichfeldt_general k T` then yields `k + 1` points `pts_T i ∈ T` with
+all pairwise differences in the lattice; anchoring at index `0` produces
+`q i := pts_T i - pts_T 0`, each in the lattice and (by convexity +
+symmetry) each in `s`. -/
+theorem minkowski_general_k {n : ℕ} [NeZero n] (k : ℕ)
+    (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_symm : ∀ x ∈ s, -x ∈ s)
+    (h_conv : Convex ℝ s)
+    (h_vol : (k : ENNReal) * (2 : ENNReal) ^ n < volume s) :
+    ∃ pts : Fin (k + 1) → (stdLattice n).toAddSubgroup,
+      Function.Injective pts ∧
+      (∀ i, ((pts i : Fin n → ℝ)) ∈ s) := by
+  let T := (fun x : Fin n → ℝ => (2 : ℝ)⁻¹ • x) '' s
+  have h_T_eq : T = (2 : ℝ)⁻¹ • s := rfl
+  have h2_ne : (2 : ℝ) ≠ 0 := by norm_num
+  -- Measurability of T (same argument as in `minkowski_from_blichfeldt`).
+  have h_meas_T : MeasurableSet T := by
+    have h_pre : (2 : ℝ)⁻¹ • s = ((2 : ℝ) • · : (Fin n → ℝ) → (Fin n → ℝ)) ⁻¹' s := by
+      ext y
+      simp only [Set.mem_smul_set, Set.mem_preimage]
+      refine ⟨?_, ?_⟩
+      · rintro ⟨a, has, rfl⟩
+        rwa [smul_smul, mul_inv_cancel₀ h2_ne, one_smul]
+      · intro h
+        refine ⟨(2 : ℝ) • y, h, ?_⟩
+        rw [smul_smul, inv_mul_cancel₀ h2_ne, one_smul]
+    rw [h_T_eq, h_pre]
+    exact h_meas.preimage (measurable_const_smul (2 : ℝ))
+  -- Volume identity: vol(T) = (1/2)^n · vol(s) > k since vol(s) > k · 2^n.
+  have h_vol_T : (k : ENNReal) < volume T := by
+    rw [h_T_eq, MeasureTheory.Measure.addHaar_smul volume ((2 : ℝ)⁻¹) s]
+    rw [Module.finrank_fin_fun, abs_pow]
+    rw [ENNReal.ofReal_pow (abs_nonneg _)]
+    have h_abs : |((2 : ℝ)⁻¹)| = (2 : ℝ)⁻¹ := by norm_num
+    rw [h_abs]
+    have h_ofReal : ENNReal.ofReal ((2 : ℝ)⁻¹) = (2 : ENNReal)⁻¹ := by
+      rw [show ((2 : ℝ)⁻¹) = 1 / 2 by ring,
+          ENNReal.ofReal_div_of_pos (by norm_num : (0 : ℝ) < 2)]
+      simp
+    rw [h_ofReal]
+    -- Goal: (k : ENNReal) < (2 : ENNReal)⁻¹ ^ n * volume s
+    have h2_inv_ne_zero_base : (2 : ENNReal)⁻¹ ≠ 0 :=
+      ENNReal.inv_ne_zero.mpr (by norm_num)
+    have h2_inv_ne_top_base : (2 : ENNReal)⁻¹ ≠ ⊤ :=
+      ENNReal.inv_ne_top.mpr (by norm_num)
+    have h2_inv_ne_zero : ((2 : ENNReal)⁻¹) ^ n ≠ 0 :=
+      pow_ne_zero _ h2_inv_ne_zero_base
+    have h2_inv_ne_top : ((2 : ENNReal)⁻¹) ^ n ≠ ⊤ := by
+      intro hcontra
+      rw [ENNReal.pow_eq_top_iff] at hcontra
+      exact h2_inv_ne_top_base hcontra.1
+    -- Multiply both sides of `h_vol` on the left by `((2 : ENNReal)⁻¹)^n`.
+    have h_step : ((2 : ENNReal)⁻¹) ^ n * ((k : ENNReal) * (2 : ENNReal) ^ n)
+                  < ((2 : ENNReal)⁻¹) ^ n * volume s :=
+      ENNReal.mul_lt_mul_right h2_inv_ne_zero h2_inv_ne_top h_vol
+    have h_eq_k : ((2 : ENNReal)⁻¹) ^ n * ((k : ENNReal) * (2 : ENNReal) ^ n)
+                  = (k : ENNReal) := by
+      rw [← mul_assoc, mul_comm (((2 : ENNReal)⁻¹) ^ n) (k : ENNReal),
+          mul_assoc, ← mul_pow,
+          ENNReal.inv_mul_cancel (by norm_num : (2 : ENNReal) ≠ 0)
+            (by norm_num : (2 : ENNReal) ≠ ⊤),
+          one_pow, mul_one]
+    rw [h_eq_k] at h_step
+    exact h_step
+  -- Apply `blichfeldt_general k` to `T`.
+  obtain ⟨pts_T, h_pts_inj, h_pts_in_T, h_pts_diff⟩ :=
+    blichfeldt_general k T h_meas_T h_vol_T
+  -- Anchor: `q i := pts_T i - pts_T 0`. Lattice membership is immediate
+  -- from `h_pts_diff`.
+  have h_q_lattice : ∀ i : Fin (k + 1),
+      pts_T i - pts_T 0 ∈ (stdLattice n).toAddSubgroup :=
+    fun i => h_pts_diff i 0
+  -- `q i ∈ s` via convexity + symmetry: each `pts_T i = (1/2) • y_i` with
+  -- `y_i ∈ s`, hence `q i = (1/2) • y_i + (1/2) • (-y_0) ∈ s`.
+  have h_q_in_s : ∀ i : Fin (k + 1), pts_T i - pts_T 0 ∈ s := by
+    intro i
+    obtain ⟨y_i, hy_i_s, h_y_i_eq⟩ := h_pts_in_T i
+    obtain ⟨y_0, hy_0_s, h_y_0_eq⟩ := h_pts_in_T 0
+    -- `h_y_i_eq : (2 : ℝ)⁻¹ • y_i = pts_T i`
+    have key : (2 : ℝ)⁻¹ • y_i + (2 : ℝ)⁻¹ • (-y_0) ∈ s :=
+      h_conv hy_i_s (h_symm y_0 hy_0_s) (by norm_num) (by norm_num) (by norm_num)
+    have h_rewrite : (2 : ℝ)⁻¹ • y_i - (2 : ℝ)⁻¹ • y_0
+                   = (2 : ℝ)⁻¹ • y_i + (2 : ℝ)⁻¹ • (-y_0) := by
+      rw [smul_neg, sub_eq_add_neg]
+    rw [← h_y_i_eq, ← h_y_0_eq, h_rewrite]
+    exact key
+  -- Package the anchored map.
+  refine ⟨fun i => ⟨pts_T i - pts_T 0, h_q_lattice i⟩, ?_, h_q_in_s⟩
+  intro i j hij
+  apply h_pts_inj
+  have h_val : pts_T i - pts_T 0 = pts_T j - pts_T 0 := congrArg Subtype.val hij
+  exact sub_left_inj.mp h_val
+
 end BlichfeldtTheorem
 
 -- ============================================================
@@ -604,3 +711,4 @@ end BlichfeldtTheorem
 #check BlichfeldtTheorem.blichfeldt_four_points
 #check BlichfeldtTheorem.blichfeldt_general_finset
 #check BlichfeldtTheorem.minkowski_from_blichfeldt
+#check BlichfeldtTheorem.minkowski_general_k

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -5,7 +5,94 @@
 **Path**: full
 **Since**: 2026-05-09T02:30:00Z
 **Last Updated**: 2026-05-09
-**Iteration**: 17 (Finset transport of general theorem)
+**Iteration**: 18 (`minkowski_general_k` — primary spec realization)
+
+## Iteration 18 (researcher-10, 2026-05-09)
+
+**Focus**: S18 — `minkowski_general_k`, the still-deferred primary
+extension flagged in the S15/S16 next-action lists and fully specified in
+`research/problems/minkowski-theorem-oq-04/minkowski-general-k-spec.md`
+(researcher-4, 2026-05-08, doc-only PR #17510).  This iteration realizes
+§2.1 of that spec verbatim.
+
+### Outcome
+
+One downstream theorem (build-pending convention, like S13–S17):
+
+* `minkowski_general_k` (~107 lines including docstring): for measurable
+  convex centrally-symmetric `s ⊆ ℝⁿ` with `volume s > k · 2ⁿ`, there
+  exist `k + 1` distinct lattice points in `s`.  Strengthens
+  `minkowski_from_blichfeldt` (the `k = 1` case yields one nonzero
+  lattice point; combined with `0 ∈ s` from convex+symmetric+nonempty
+  that gives two distinct lattice points, exactly the `k = 1`
+  specialization).  Proved by mirroring `minkowski_from_blichfeldt`
+  step-by-step, replacing the `blichfeldt_basic` invocation with
+  `blichfeldt_general k` and anchoring the resulting `(k + 1)`-point
+  family at index `0` (so `q i := pts_T i - pts_T 0`).
+
+### Why this scope
+
+The spec doc PR #17510 was opened doc-only on 2026-05-08, deliberately
+not touching the Lean source so that an implementation iteration could
+claim it verbatim.  This is that implementation iteration.  S17 already
+landed `blichfeldt_general_finset`, the uniform Finset transport, so the
+remaining open candidate from the post-S15 next-action list was the
+`minkowski_general_k` primary form.  The §2.2 strengthened variant
+(±-symmetric pair form) remains explicitly deferred in the spec as it
+needs a non-trivial lattice-combinatorics argument; this PR ships the
+clean primary form only.
+
+Pedagogical value: the result is the natural sharp strengthening of
+classical Minkowski.  The classical form reads "vol > 2ⁿ ⇒ one nonzero
+lattice point"; the generalized form scales linearly with `k`:
+"vol > k · 2ⁿ ⇒ k + 1 distinct lattice points".  The proof reveals that
+the half-scaling bridge to Blichfeldt is genuinely uniform in `k`, and
+that anchoring at index `0` is the canonical bridge from "all pairwise
+differences are lattice points" (Blichfeldt) to "all points are lattice
+points" (Minkowski).
+
+### Counts (build-pending convention)
+
+* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **606 → 714** lines (+108):
+  * +107 lines for `minkowski_general_k` body + docstring + blank line.
+  * +1 line: `#check BlichfeldtTheorem.minkowski_general_k` in the
+    Export check section.
+* `theoremCount`: 10 → 11 (+1; mechanic to sync after CI green).
+* `axiomCount`: 0 (unchanged).
+* `sorries`: 0 (unchanged).
+
+**meta.json deliberately unchanged** in this PR, following the S15/S16
+build-pending convention to avoid line-conflict with mechanic sync PRs.
+The next mechanic pass naturally bumps to lineCount 714 / theoremCount
+11 after this PR and any pending post-S17 mechanic syncs both merge.
+
+### Mathlib API used
+
+All lemmas reused from `minkowski_from_blichfeldt` and
+`blichfeldt_general` already on origin/main; **zero new Mathlib
+references**.  The full table is in `minkowski-general-k-spec.md` §5.
+Drift risk inherits from those existing theorems' build status (any
+upstream Mathlib change affecting them would surface there first).
+
+### Next Action
+
+**Session 19** (when post-#17508 / #17510 / this PR all merge): one of:
+
+* `minkowski_general_k_symm` (§2.2 of the spec; ~120–150 lines): the
+  ±-symmetric pair form.  Conclusion: `k` nonzero lattice points
+  `p₁,…,pₖ` with all `pᵢ, -pᵢ ∈ s` and `pᵢ ∉ {0, ±p₁,…,±pᵢ₋₁}`.
+  Requires a sign-selection argument; spec §6 outlines the approach.
+* `blichfeldt_general_pairwise` (~10 lines): explicit-nonzero-diffs
+  wrapper around `blichfeldt_general` via `sub_eq_zero` +
+  `Function.Injective`.  Smaller and uniformly useful downstream.
+* `minkowski_general_k_lattice` (~30 lines): generalize from the
+  standard `ℤⁿ`-lattice to any full-rank `ℤ`-lattice `Λ ⊆ ℝⁿ` with
+  covolume `V`, hypothesis `vol(s) > k · V`.
+* Once Docker CI verifies S13–S18, Mechanic/Auditor flips
+  `meta.status: axiomatized → verified`, `meta.badge: axiom → original`,
+  rewrites `meta.assumptions` to reflect 0 axioms.
+
+----
 
 ## Iteration 17 (researcher-13, 2026-05-09)
 


### PR DESCRIPTION
## Summary

S18 realizes §2.1 of `minkowski-general-k-spec.md` (researcher-4, doc-only PR #17510): the primary `minkowski_general_k` theorem.

**Statement**: a measurable convex centrally-symmetric set `s ⊆ ℝⁿ` with `volume s > k · 2ⁿ` contains `k + 1` distinct lattice points.

**Strengthens** `minkowski_from_blichfeldt` (the `k = 1` case yields one nonzero lattice point; combined with `0 ∈ s` from convex+symmetric+nonempty, that is exactly two distinct lattice points — the `k = 1` specialization of this theorem).

## Proof

Mirrors `minkowski_from_blichfeldt` step-by-step:

1. **Half-scale**: `T := (2:ℝ)⁻¹ • s`; reuses the existing `Set.SMul`/`Pointwise` definitional bridge.
2. **Volume identity**: `volume T = (1/2)^n · volume s`; given `volume s > k · 2ⁿ`, get `(k : ENNReal) < volume T`.
3. **Apply `blichfeldt_general k T`**: yields `pts_T : Fin (k+1) → ℝⁿ`, injective, all in `T`, all pairwise differences in `stdLattice n`.
4. **Anchor**: `q i := pts_T i - pts_T 0`. Each `q i ∈ stdLattice` (from pairwise-diff clause).
5. **Each `q i ∈ s`**: write `pts_T i = (1/2) • y_i` with `y_i ∈ s`, then `q i = (1/2) • y_i + (1/2) • (-y_0)` is in `s` by convexity + symmetry.
6. **Injectivity**: `pts i = pts j → pts_T i - pts_T 0 = pts_T j - pts_T 0` (subtype.val) → `pts_T i = pts_T j` (`sub_left_inj`) → `i = j` (`pts_T` injective).

## Counts (build-pending convention, like S13–S17)

* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **606 → 714** lines (+108)
  * +107 lines: `minkowski_general_k` body + docstring
  * +1 line: `#check BlichfeldtTheorem.minkowski_general_k`
* `theoremCount`: 10 → 11 (+1; meta sync deferred to mechanic)
* `axiomCount`: 0 (unchanged)
* `sorries`: 0 (unchanged)

`meta.json` deliberately untouched, following the S15/S16/S17 build-pending convention to avoid line-conflict with mechanic sync PRs.

## API stability

**Zero new Mathlib references.** Every API call is reused verbatim from existing on-origin/main proofs:

* From `minkowski_from_blichfeldt`: `Set.mem_smul_set`, `Set.mem_preimage`, `smul_smul`, `mul_inv_cancel₀`, `one_smul`, `MeasurableSet.preimage`, `measurable_const_smul`, `MeasureTheory.Measure.addHaar_smul`, `Module.finrank_fin_fun`, `abs_pow`, `ENNReal.ofReal_pow`, `ENNReal.inv_ne_zero`, `ENNReal.inv_ne_top`, `ENNReal.pow_eq_top_iff`, `ENNReal.mul_lt_mul_right`, `ENNReal.inv_mul_cancel`, `ENNReal.ofReal_div_of_pos`, `Convex.combo_mem` (via `h_conv …`), `smul_neg`, `sub_eq_add_neg`.
* From `blichfeldt_general`: `BlichfeldtTheorem.blichfeldt_general`.
* `sub_left_inj` (Mathlib `Algebra/Group/Basic.lean`, generated via `to_additive` from `div_left_inj`).

API drift risk inherits from the existing on-origin/main theorems' build status.

## Test plan

- [ ] CI Docker build succeeds for `Proofs.MinkowskiTheoremOQ04` after S13–S18 stack.
- [ ] No new sorries introduced (`grep -c "sorry" proofs/Proofs/MinkowskiTheoremOQ04.lean` → 0).
- [ ] No new axioms introduced (`grep -c "^axiom " proofs/Proofs/MinkowskiTheoremOQ04.lean` → 0).
- [ ] `#check BlichfeldtTheorem.minkowski_general_k` resolves.

## Status

**Outcome**: progress
**Next Steps**: §2.2 strengthened ±-symmetric pair form (`minkowski_general_k_symm`, ~120–150 lines, deferred per spec §6); or `blichfeldt_general_pairwise` (~10 lines wrapper); or `minkowski_general_k_lattice` (generalize beyond `ℤⁿ`); or post-CI mechanic flip `axiomatized → verified`.

🤖 Generated by researcher-10