### PR TITLE
fix(meta): batch sync theoremCount drift (2 entries, mixed)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
     "lineCount": 204,
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
+    "theoremCount": 5,
     "definitionCount": 2
   },
   "overview": {
@@ -159,7 +159,7 @@
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
     "lineCount": 204,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 5,
     "definitionCount": 2,
     "mainTheorems": [
       "dalzell_polynomial_identity",

--- a/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 453,
     "assumptions": "1 axiom: two_points_determine_chord. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 21
   },
   "sections": [
@@ -158,7 +158,7 @@
     "namespace": "BeltramiKlein",
     "lineCount": 453,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 21,
     "path": "Proofs/ParallelPostulateIndependenceOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` and `leanFile.theoremCount` for two entries
where the Lean source file diverged from the recorded counts.

| Slug | claimed | actual | delta |
|---|---|---|---|
| `area-of-circle-oq-03-oq-02-oq-02` | 15 | 5 | -10 |
| `parallel-postulate-independence-oq-02` | 19 | 17 | -2 |

## Evidence

Counted with the standard mechanic regex: `^(?:(?:private\|protected\|noncomputable)\s+)*(theorem\|lemma)\s+\w+` after stripping nested `/-…-/` and `--` comments.

`area-of-circle-oq-03-oq-02-oq-02` actual 5:

```
theorem dalzell_polynomial_identity
theorem dalzell_integrand_decomposition
theorem dalzell_integrand_nonneg
theorem dalzell_integrand_pos
theorem hasDerivAt_dalzellAntideriv
```

`parallel-postulate-independence-oq-02` actual 17:

```
P_not_on_xaxis, P_on_par₁, P_on_par₂, par₁_ne_par₂,
par₁_parallel_xaxis, par₂_parallel_xaxis, hyperbolic_parallel_property,
bk_not_playfair, three_noncollinear, disk_nontrivial, chord_has_two_points,
euc_satisfies_playfair, bk_not_satisfies_playfair, parallel_postulate_independent,
euclidean_parallel_implies_bk_parallel, P_on_secant, secant_not_parallel_xaxis
```

These two entries fall outside the alphabetical ranges of the open theoremCount batches (`a-c gap`, `c-g`, `h-z`).

## Scope

Pure metadata sync. No Lean source changes. 4 lines across 2 files.

---
Automated fix by lean-mechanic agent.