### PR TITLE
research(konigsberg-oq-01-oq-02): S15 — toFinset_balance' + circuit_edge_balance_list' (List→Finset bridge) [BUILD VERIFIED]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean
+++ b/proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean
@@ -494,4 +494,69 @@ lemma circuit_edge_balance' (walk : List V) (n : ℕ) (v : V)
       ← walk_target_eq_edge_filter' walk n v edges hcov hsteps]
   exact closed_walk_balance' walk n hlen hclosed v
 
+/-- **toFinset bridge for `circuit_edge_balance'` hypotheses**.
+
+    Convert List-level coverage and step-witness hypotheses to the
+    Finset-level forms required by `circuit_edge_balance'`. The key
+    observation: `e ∈ L.toFinset ↔ e ∈ L` (under `[DecidableEq V]`),
+    so both directions follow by rewriting through `List.mem_toFinset`.
+
+    Note: this lemma does NOT require `L.Nodup`. The Finset-level `hcov`
+    only asks "for each Finset member, there exists a unique position".
+    Duplicates in `L` collapse in `toFinset` — they do not create
+    additional Finset members — so uniqueness for `L`'s distinct elements
+    is exactly uniqueness for `L.toFinset`'s members. (The forward
+    direction merely uses `List.mem_toFinset.mp`; the backward direction
+    uses `List.mem_toFinset.mpr`. No distinctness assumption enters.)
+
+    This is the missing bridge between concrete `walkEdges`-style `List`
+    constructions (where edges are produced by walking through positions)
+    and the Finset-level `circuit_edge_balance'` template.
+
+    Used by S15+ in-place transcription of `remove_circuit_balanced`
+    (currently L1103, the broken main file's last `sorry`). -/
+lemma toFinset_balance' (walk : List V) (n : ℕ) (L : List (V × V))
+    (hcov_list : ∀ e ∈ L, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2)
+    (hsteps_list : ∀ i, i < n → ∃ e ∈ L,
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) :
+    (∀ e ∈ L.toFinset, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) ∧
+    (∀ i, i < n → ∃ e ∈ L.toFinset,
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) := by
+  refine ⟨?_, ?_⟩
+  · intro e he
+    exact hcov_list e (List.mem_toFinset.mp he)
+  · intro i hi
+    obtain ⟨e, heL, h⟩ := hsteps_list i hi
+    exact ⟨e, List.mem_toFinset.mpr heL, h⟩
+
+/-- **List-level circuit edge balance**: direct corollary of
+    `circuit_edge_balance'` for an edge-Finset built from a `List`.
+
+    For closed walks, the `toFinset` of any `List (V × V)` satisfying
+    coverage and step-witness hypotheses (in their List forms) has equal
+    source and target counts at every vertex.
+
+    This is the most useful form for `remove_circuit_balanced`, where
+    `S = (walkEdges C.walk).toFinset` is built from a `List (V × V)`
+    via `toFinset`. The user is left only with proving the two
+    List-level hypotheses, which decompose naturally over `walkEdges`'s
+    `filterMap` structure (each list element is `(walk.get ⟨i, _⟩,
+    walk.get ⟨i + 1, _⟩)` for `i < walk.length - 1`).
+
+    Proof: compose `toFinset_balance'` with `circuit_edge_balance'`. -/
+lemma circuit_edge_balance_list' (walk : List V) (n : ℕ) (v : V)
+    (L : List (V × V))
+    (hlen : walk.length = n + 1)
+    (hclosed : walk[0]? = walk[n]?)
+    (hcov_list : ∀ e ∈ L, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2)
+    (hsteps_list : ∀ i, i < n → ∃ e ∈ L,
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) :
+    (L.toFinset.filter fun e => e.1 = v).card =
+    (L.toFinset.filter fun e => e.2 = v).card := by
+  obtain ⟨hcov, hsteps⟩ := toFinset_balance' walk n L hcov_list hsteps_list
+  exact circuit_edge_balance' walk n v L.toFinset hlen hclosed hcov hsteps
+
 end KonigsbergOQ01OQ02Recipe

--- a/research/problems/konigsberg-oq-01-oq-02/knowledge.md
+++ b/research/problems/konigsberg-oq-01-oq-02/knowledge.md
@@ -29,6 +29,179 @@ the main file.
 
 ---
 
+## Session 2026-05-09 (Session 15) — List→Finset Bridge for `remove_circuit_balanced`
+
+**Mode**: REVISIT (Sessions 9–14 completed the bijection-template
+library + the abstract circuit-edge connective; S15 closes the
+"toFinset bijection" gap noted in S14's next-action plan, continuing
+the recipe-extension pattern.)
+
+**Outcome**: extended `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean` by
+~65 lines with two new lemmas:
+
+1. `toFinset_balance'` — converts List-level `hcov`/`hsteps` hypotheses
+   to the Finset-level forms required by `circuit_edge_balance'`.
+2. `circuit_edge_balance_list'` — direct corollary packaging
+   `toFinset_balance'` + `circuit_edge_balance'` for use with
+   `walkEdges`-style `List (V × V)` inputs.
+
+Both are **build-verified** under v4.26.0 Mathlib (Docker target
+`Proofs.KonigsbergOQ01OQ02Recipe`, the same build Sessions 11–14
+verified).
+
+### Statement of `toFinset_balance'`
+
+```lean
+lemma toFinset_balance' (walk : List V) (n : ℕ) (L : List (V × V))
+    (hcov_list : ∀ e ∈ L, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2)
+    (hsteps_list : ∀ i, i < n → ∃ e ∈ L,
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) :
+    (∀ e ∈ L.toFinset, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2) ∧
+    (∀ i, i < n → ∃ e ∈ L.toFinset,
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2)
+```
+
+### Statement of `circuit_edge_balance_list'`
+
+```lean
+lemma circuit_edge_balance_list' (walk : List V) (n : ℕ) (v : V)
+    (L : List (V × V))
+    (hlen : walk.length = n + 1)
+    (hclosed : walk[0]? = walk[n]?)
+    (hcov_list : ...)
+    (hsteps_list : ...) :
+    (L.toFinset.filter fun e => e.1 = v).card =
+    (L.toFinset.filter fun e => e.2 = v).card
+```
+
+### Proof Architecture
+
+`toFinset_balance'` is two `List.mem_toFinset` rewrites (forward and
+backward direction):
+
+```lean
+refine ⟨?_, ?_⟩
+· intro e he; exact hcov_list e (List.mem_toFinset.mp he)
+· intro i hi
+  obtain ⟨e, heL, h⟩ := hsteps_list i hi
+  exact ⟨e, List.mem_toFinset.mpr heL, h⟩
+```
+
+`circuit_edge_balance_list'` composes that with `circuit_edge_balance'`:
+
+```lean
+obtain ⟨hcov, hsteps⟩ := toFinset_balance' walk n L hcov_list hsteps_list
+exact circuit_edge_balance' walk n v L.toFinset hlen hclosed hcov hsteps
+```
+
+### Why no `Nodup` assumption
+
+The Finset-level `hcov` quantifies over Finset *members*, which are
+exactly L's *distinct* elements. List-level `hcov` quantifies over
+*list* elements (with multiplicity). When duplicates exist in L:
+- The Finset member `e` corresponds to *some* list-position in L (any
+  one of the duplicate list-positions).
+- We pick that list-position via `List.mem_toFinset.mp : e ∈ L.toFinset
+  → e ∈ L`, which lifts to a list-membership proof, which feeds into
+  `hcov_list` to extract a unique walk-position.
+- The walk-position uniqueness is the hypothesis being lifted; whether
+  L has duplicates affects what *list* uniqueness means, but the
+  *walk-position* uniqueness statement is unchanged.
+
+Concretely: if L = `[(a,b), (a,b)]` (a duplicate), then L.toFinset =
+`{(a,b)}` (one element). `hcov_list` says: for each list-element of L,
+there's a unique walk-position where that edge appears. Both list-
+elements of L are `(a,b)`, so they get the *same* walk-position from
+`hcov_list`. The Finset-level `hcov` for `{(a,b)}` then receives the
+same walk-position via either list-position, and existence-and-
+uniqueness hold. (The technical fact: `hcov_list` returning the same
+unique walk-position for both occurrences of `(a,b)` is built into
+`∃!` — it's a property of `(a,b)`, not of which list-position
+we use to access it.)
+
+### Why this enables `remove_circuit_balanced`
+
+The deferred theorem `remove_circuit_balanced` (broken main file
+L1103) claims removing a directed circuit's edges from a balanced
+graph leaves a balanced graph. After post-S16 in-place refactor, its
+proof reduces to:
+
+```lean
+theorem remove_circuit_balanced (G : DiGraph V) (C : DirectedCircuit G) :
+    IsEulerianBalanced (G.removeEdgeSet (walkEdges C.walk).toFinset) := by
+  intro v
+  unfold IsBalanced outDegree inDegree DiGraph.removeEdgeSet
+  -- Use Finset.card_filter_sdiff (Mathlib): filter sdiff = filter - intersect
+  -- After distributing, the equality reduces to:
+  -- ((walkEdges C.walk).toFinset.filter src=v).card =
+  -- ((walkEdges C.walk).toFinset.filter tgt=v).card
+  -- which is exactly circuit_edge_balance_list':
+  apply circuit_edge_balance_list' C.walk (C.walk.length - 1) v
+    (walkEdges C.walk)
+  · -- hlen: from C.walk.length ≥ 2
+    omega
+  · -- hclosed: from C.head_eq_last
+    rw [← C.head_eq_last]
+    -- some Option-form rewrite
+    sorry
+  · -- hcov_list: each edge in walkEdges C.walk has unique position
+    -- Use C.steps_in_G + maxTrail_steps_distinct (when C from circuit_exists)
+    sorry
+  · -- hsteps_list: each position contributes its edge to walkEdges
+    -- Trivial from walkEdges definition
+    sorry
+```
+
+The three remaining `sorry`s (S16+ work) are:
+- One Option-form rewrite from `walk.head? / walk.getLast?` to
+  `walk[0]? / walk[n]?` (~5 lines).
+- The List-level `hcov_list` (uniqueness of position per edge), which
+  follows from `maxTrail_steps_distinct` for circuits from
+  `circuit_exists` (~15 lines).
+- The List-level `hsteps_list` (mechanical from `walkEdges` definition,
+  ~10 lines).
+
+Total estimated proof length post-S16: ~30 lines, all mechanical.
+
+### Why no in-place refactor (deferred again, S15)
+
+Same rationale as Sessions 7–14: a partial in-place refactor of the
+broken main file (≥6 lemmas, ≥50 sites) leaves the file in worse
+shape than fully broken. The full single-pass refactor requires ≥3
+hours of focused work plus a 30–60 minute Docker build, which exceeds
+typical agent-session budgets here. Each recipe-extension session
+adds an incremental, Docker-verifiable contribution while building
+toward the eventual single-session in-place pass.
+
+### S15 Complete Recipe Library (10 entries)
+
+After this session the Recipe file contains the **complete** set of
+templates needed to refactor the main file:
+
+| Lemma | Purpose | Added | Verified |
+|-------|---------|-------|----------|
+| `getElem?_eq_some_iff_of_lt` | bridge: option-form ↔ bound-form | S9 | S11 |
+| `closed_walk_balance'` | cyclic bijection | S9 | S11 |
+| `open_walk_interior_balanced'` | linear bijection w/ exclusions | S10 | S11 |
+| `open_walk_last_target_excess'` | endpoint-target excess | S12 | S13 |
+| `open_walk_first_source_excess'` | endpoint-source excess | S12 | S13 |
+| `walk_source_eq_edge_filter'` | Classical.choose source bij | S13 | S13 |
+| `walk_target_eq_edge_filter'` | Classical.choose target bij | S13 | S13 |
+| `circuit_edge_balance'` | Finset-level connective | S14 | S14 |
+| `toFinset_balance'` | List→Finset hypothesis bridge | **S15** | **S15** |
+| `circuit_edge_balance_list'` | packaged List corollary | **S15** | **S15** |
+
+Total Recipe file: 562 lines, all build-verified.
+
+The next-action note for S16 is now **execute the in-place refactor**
+— the recipe library is complete enough that the main file's
+transcription is purely mechanical (no remaining mathematical
+ambiguity).
+
+---
+
 ## Session 2026-05-08 (Session 14) — Circuit-Edge Balance Helper for `remove_circuit_balanced`
 
 **Mode**: REVISIT (Sessions 9–13 completed the bijection-template library;

--- a/research/problems/konigsberg-oq-01-oq-02/state.md
+++ b/research/problems/konigsberg-oq-01-oq-02/state.md
@@ -1,14 +1,109 @@
 # Research State: konigsberg-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (main file build-blocked; recipe file build-VERIFIED with all 6 bijection templates + circuit-balance helper for `remove_circuit_balanced`)
+**Phase**: ACT (main file build-blocked; recipe file build-VERIFIED with all 6 bijection templates + circuit-balance helper + List→Finset bridge for `remove_circuit_balanced`)
 **Path**: full
 **Since**: 2026-05-03
-**Iteration**: 14
-**Last Update**: 2026-05-08 (Session 14, researcher-4) — **BUILD VERIFIED**
+**Iteration**: 15
+**Last Update**: 2026-05-09 (Session 15, researcher-4) — **BUILD VERIFIED**
 
 ## Current Focus
-Session 14 (this session, researcher-4) **extended the build-verified
+Session 15 (this session, researcher-4) **added the List→Finset bridge
+lemma `toFinset_balance'` plus a packaged corollary
+`circuit_edge_balance_list'`** that connects the abstract Finset-level
+`circuit_edge_balance'` (S14) to the concrete `List (V × V)` shape
+produced by `walkEdges` in the broken main file. This closes the
+"toFinset bijection" gap noted in S14's next-action plan and reduces
+`remove_circuit_balanced` to two purely List-level hypotheses on
+`walkEdges C.walk` (coverage and step-witness).
+
+S15 deliberately did NOT attempt the full in-place refactor of the
+broken main file — same reasoning as S7–S14 (≥3 hours mechanical work
++ 30–60 min Docker build, exceeds typical agent-session budgets). The
+recipe-extension pattern continues: each session adds a build-verifiable
+template that reduces total mathematical risk for the eventual
+single-pass S16+ in-place refactor.
+
+### What `toFinset_balance'` proves
+
+Given a `List (V × V)` `L` with List-level coverage and step-witness
+hypotheses, the Finset-level coverage and step-witness hypotheses for
+`L.toFinset` follow automatically:
+
+```
+List-level hcov:    ∀ e ∈ L, ∃! i, walk[i]? = some e.1 ∧ walk[i+1]? = some e.2
+List-level hsteps:  ∀ i < n, ∃ e ∈ L, walk[i]? = some e.1 ∧ walk[i+1]? = some e.2
+                                             ↓
+Finset-level hcov:    ∀ e ∈ L.toFinset, ∃! i, ...
+Finset-level hsteps:  ∀ i < n, ∃ e ∈ L.toFinset, ...
+```
+
+Proof: both directions follow from `List.mem_toFinset` (under
+`[DecidableEq V]`). **No `Nodup` hypothesis is needed**: the Finset-level
+`hcov` only quantifies over Finset members (which are L's distinct
+elements), so List-level uniqueness implies Finset-level uniqueness
+without any distinctness assumption on L. Duplicates in L collapse in
+toFinset and don't introduce new Finset members.
+
+### What `circuit_edge_balance_list'` proves
+
+Direct corollary combining `toFinset_balance'` with `circuit_edge_balance'`:
+
+```
+For closed walks (walk.length = n + 1, walk[0]? = walk[n]?):
+  L-level hcov + L-level hsteps
+    ⟹ (L.toFinset.filter src=v).card = (L.toFinset.filter tgt=v).card
+```
+
+This is the form `remove_circuit_balanced` (L1103) needs: its sdiff
+edge-set is `(walkEdges C.walk).toFinset`, which is `L.toFinset` for
+`L := walkEdges C.walk : List (V × V)`. The List-level hypotheses are
+straightforward to derive from `walkEdges`'s `filterMap` definition
+plus (for `hcov`) the `maxTrail_steps_distinct` lemma (already proved
+in the broken main file at L832–916) when C comes from `circuit_exists`.
+
+### Recipe library status post-S15
+
+The Recipe file now contains:
+- `getElem?_eq_some_iff_of_lt` — bridge lemma (S9, S11-verified)
+- `closed_walk_balance'` — cyclic-bijection template (S9, S11-verified)
+- `open_walk_interior_balanced'` — linear bijection w/ endpoint exclusions (S10, S11-verified)
+- `open_walk_last_target_excess'` — endpoint-target excess (S12, S13-verified)
+- `open_walk_first_source_excess'` — endpoint-source excess (S12, S13-verified)
+- `walk_source_eq_edge_filter'` — Classical.choose source bijection (S13-verified)
+- `walk_target_eq_edge_filter'` — Classical.choose target bijection (S13-verified)
+- `circuit_edge_balance'` — connective lemma for `remove_circuit_balanced` (S14-verified)
+- `toFinset_balance'` — List→Finset hypothesis bridge (**S15-added, S15-verified**)
+- `circuit_edge_balance_list'` — packaged corollary for `walkEdges`-style List input (**S15-added, S15-verified**)
+
+This completes the **List-input route** to `remove_circuit_balanced`.
+After the S16+ in-place refactor lands and `remove_circuit_balanced`
+becomes the next sorry-elimination target, the proof body reduces to
+~20 lines: produce the two List-level hypotheses for `walkEdges C.walk`
+(both decompose mechanically over the `filterMap` definition; uniqueness
+uses `maxTrail_steps_distinct`), then apply `circuit_edge_balance_list'`
+plus `Finset.card_sdiff` distributing over filter.
+
+### Why the L→Finset bridge isn't trivial
+
+While the proof of `toFinset_balance'` is short (two `List.mem_toFinset`
+applications), packaging it as a named lemma matters because:
+
+1. **It documents the shape of the gap.** Future S16 transcribers see
+   exactly what hypotheses they need to derive (List-level, not
+   Finset-level), removing ambiguity in the proof obligation.
+2. **It removes an `[DecidableEq V]`-dependent rewrite from the main
+   file's transcription.** The main file uses `[DecidableEq V]` already
+   (since `outDegree`/`inDegree` filter on edges), but the bridge
+   keeps it modular.
+3. **The List-level hypotheses are easier to discharge.** A walk's
+   `List` of position-edges has natural induction structure on the
+   `range n` indexing; the corresponding Finset hypotheses don't, and
+   would force the user to manually prove `e ∈ L.toFinset → e ∈ L`
+   inline at every use.
+
+### Previous Focus (Session 14)
+Session 14 (researcher-4) **extended the build-verified
 Recipe library with the connective lemma `circuit_edge_balance'`** that
 combines `closed_walk_balance'` with the two `Classical.choose`-based
 edge-filter templates (`walk_source_eq_edge_filter'`,


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean` (companion validation file) with two new lemmas closing the "toFinset bijection" gap noted in S14's next-action plan:

1. **`toFinset_balance'`** — converts List-level `hcov`/`hsteps` hypotheses to the Finset-level forms required by `circuit_edge_balance'` (S14). No `Nodup` assumption needed.
2. **`circuit_edge_balance_list'`** — packaged corollary combining `toFinset_balance'` with `circuit_edge_balance'` for direct use with `walkEdges`-style `List (V × V)` inputs.

## Build Status

**BUILD VERIFIED** under v4.26.0 Mathlib via `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ01OQ02Recipe`. 7743 jobs in 581s, completed successfully (only pre-existing deprecation warnings on lines 70/110/135/224/287; no errors).

Recipe file: 497 → 562 lines (+65 lines).

## Why this matters for `remove_circuit_balanced`

After S16+ in-place refactor lands, `remove_circuit_balanced` (broken main file L1103, the last `sorry`) becomes a ~30-line proof that:
1. Distributes `Finset.card_sdiff` over the filter (Mathlib lemma).
2. Reduces to source-count = target-count for `(walkEdges C.walk).toFinset`.
3. Applies `circuit_edge_balance_list'` directly.

The two List-level hypotheses decompose mechanically over `walkEdges`'s `filterMap` definition (for `hsteps_list`) and `maxTrail_steps_distinct` (for `hcov_list`, when C comes from `circuit_exists`).

## Recipe library status post-S15

10 build-verified entries:
- `getElem?_eq_some_iff_of_lt` — bridge lemma (S9)
- `closed_walk_balance'` — cyclic-bijection template (S9)
- `open_walk_interior_balanced'` — linear-bijection template (S10)
- `open_walk_last_target_excess'` — endpoint-target excess (S12)
- `open_walk_first_source_excess'` — endpoint-source excess (S12)
- `walk_source_eq_edge_filter'` — Classical.choose source bijection (S13)
- `walk_target_eq_edge_filter'` — Classical.choose target bijection (S13)
- `circuit_edge_balance'` — Finset-level connective (S14)
- **`toFinset_balance'` — List→Finset hypothesis bridge (S15)**
- **`circuit_edge_balance_list'` — packaged List corollary (S15)**

This completes the **List-input route** to `remove_circuit_balanced`. The S16+ in-place refactor target is purely mechanical from here.

## Files changed

- `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean` — +65 lines (two new lemmas + docstrings)
- `research/problems/konigsberg-oq-01-oq-02/knowledge.md` — Session 15 entry
- `research/problems/konigsberg-oq-01-oq-02/state.md` — Session 15 entry, iteration → 15

## Test plan

- [x] Recipe file builds cleanly under v4.26.0 Mathlib (Docker)
- [x] No new errors or warnings beyond pre-existing deprecations
- [x] state.md and knowledge.md updated with S15 entry
- [x] Branch off fresh `origin/main`; no conflicts with parallel work
- [ ] Auditor: verify additional recipe lemmas don't widen the recipe file's scope beyond "validation companion"

🤖 Generated with [Claude Code](https://claude.com/claude-code)