### PR TITLE
fix(meta): batch sync definitionCount drift (18 entries, hilbert series)

### DIFF
--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -189,7 +189,7 @@
     "lineCount": 351,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert15OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -125,7 +125,7 @@
     "axiomCount": 3,
     "lineCount": 249,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "sorries": 0
   },
   "mainTheorems": [

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -107,7 +107,7 @@
     "lineCount": 506,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Hilbert15OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -184,7 +184,7 @@
     "lineCount": 470,
     "axiomCount": 7,
     "theoremCount": 3,
-    "definitionCount": 15,
+    "definitionCount": 18,
     "path": "Proofs/Hilbert15SchubertCalculus.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-16/meta.json
+++ b/src/data/proofs/hilbert-16/meta.json
@@ -208,7 +208,7 @@
     "lineCount": 568,
     "axiomCount": 9,
     "theoremCount": 11,
-    "definitionCount": 23,
+    "definitionCount": 26,
     "path": "Proofs/Hilbert16.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-19-oq-03/meta.json
+++ b/src/data/proofs/hilbert-19-oq-03/meta.json
@@ -214,7 +214,7 @@
     "lineCount": 454,
     "axiomCount": 4,
     "theoremCount": 16,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/Hilbert19OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-19/meta.json
+++ b/src/data/proofs/hilbert-19/meta.json
@@ -153,7 +153,7 @@
     "lineCount": 338,
     "axiomCount": 6,
     "theoremCount": 8,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Hilbert19Regularity.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -134,7 +134,7 @@
     "lineCount": 334,
     "axiomCount": 8,
     "theoremCount": 9,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert20OQ01OQ03.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -175,7 +175,7 @@
     "lineCount": 211,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert20LocalSolvability.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-20/meta.json
+++ b/src/data/proofs/hilbert-20/meta.json
@@ -146,7 +146,7 @@
     "lineCount": 244,
     "axiomCount": 4,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Hilbert20BoundaryValue.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -154,7 +154,7 @@
     "lineCount": 386,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 5,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert21RiemannHilbert.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -110,7 +110,7 @@
     "lineCount": 155,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/Hilbert22OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -140,7 +140,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 5,
-    "definitionCount": 6,
+    "definitionCount": 11,
     "path": "Proofs/Hilbert22Uniformization.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -143,7 +143,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 14
   },
   "crossReferences": [
     {

--- a/src/data/proofs/hilbert-3/meta.json
+++ b/src/data/proofs/hilbert-3/meta.json
@@ -205,7 +205,7 @@
     "lineCount": 514,
     "axiomCount": 5,
     "theoremCount": 9,
-    "definitionCount": 10,
+    "definitionCount": 14,
     "path": "Proofs/Hilbert3ScissorsCongruence.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -175,7 +175,7 @@
     "lineCount": 459,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 13,
+    "definitionCount": 18,
     "path": "Proofs/Hilbert4Geodesics.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-5/meta.json
+++ b/src/data/proofs/hilbert-5/meta.json
@@ -196,7 +196,7 @@
     "lineCount": 487,
     "axiomCount": 5,
     "theoremCount": 8,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Hilbert5LieGroups.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-6/meta.json
+++ b/src/data/proofs/hilbert-6/meta.json
@@ -140,7 +140,7 @@
     "lineCount": 326,
     "axiomCount": 7,
     "theoremCount": 10,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "path": "Proofs/Hilbert6PhysicsAxioms.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `leanFile.definitionCount` in 18 Hilbert problem entries to actual file
counts. Counting convention follows `scripts/auditor/find-targets.ts` and the
Mechanic Notes feedback memory: `def`/`abbrev`/`opaque`/`structure`/`inductive`/
`class` declarations (excluding `instance`), with `private`/`protected`/
`noncomputable`/`partial`/`unsafe`/`scoped` modifiers.

## Evidence

Drift detected by manual scanner against `proofs/Proofs/Hilbert*.lean` files.

| Entry | Claimed | Actual |
|---|---|---|
| hilbert-3 | 10 | 14 |
| hilbert-4 | 13 | 18 |
| hilbert-5 | 7 | 8 |
| hilbert-6 | 4 | 7 |
| hilbert-15 | 15 | 18 |
| hilbert-15-oq-01 | 8 | 9 |
| hilbert-15-oq-02 | 5 | 6 |
| hilbert-15-oq-02-oq-03 | 3 | 5 |
| hilbert-16 | 23 | 26 |
| hilbert-19 | 11 | 12 |
| hilbert-19-oq-03 | 10 | 12 |
| hilbert-20 | 7 | 8 |
| hilbert-20-oq-01 | 7 | 9 |
| hilbert-20-oq-01-oq-03 | 7 | 9 |
| hilbert-21 | 5 | 9 |
| hilbert-22 | 6 | 11 |
| hilbert-22-oq-01 | 3 | 5 |
| hilbert-23 | 9 | 14 |

All edits surgical: only the `leanFile.definitionCount` field changed; all
other fields (including `lineCount`, `theoremCount`, `axiomCount`, `sorries`)
untouched.

---
Automated fix by lean-mechanic agent.