### PR TITLE
research(erdos-1151-oq-04): S28 — trig_sum_harmonic_lb_asymp (general theta in (0, pi), build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -2264,6 +2264,67 @@ private lemma trig_sum_harmonic_lb_asymp_le_half_pi
     _ ≤ ∑ k : Fin n, Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
                      |Real.cos θ - chebyshevNode n k| := hbound_mixedcast
 
+/-- **(Step 7a, general θ) Asymptotic large-`n` lower bound for the trig sum.**
+
+    Extends `trig_sum_harmonic_lb_asymp_le_half_pi` (S26) from
+    `θ ∈ (0, π/2]` to the full open interval `θ ∈ (0, π)` via the WLOG
+    bridge S18 (`trig_sum_reindex_symmetry`) + S27 (`chebyshev_hne_pi_sub`).
+
+    For any `θ ∈ (0, π)` whose cosine avoids all Chebyshev nodes
+    (for every `n ≥ 1`), there exist `N₀ : ℕ` and `C₁ > 0` such that
+    `C₁ · n · log(n+1) ≤ S(θ, n)` for all `n ≥ N₀`.
+
+    **Proof**: split on `θ ≤ π/2`.
+      • If `θ ≤ π/2`, apply S26 directly.
+      • If `θ > π/2`, set `θ' := π − θ ∈ (0, π/2)`. Use S27 to obtain
+        `hne'` for `θ'`, apply S26 to `(θ', hne')` to get
+        `C₁ · n · log(n+1) ≤ S(π − θ, n)`, then rewrite via S18
+        (`S(θ, n) = S(π − θ, n)`) to conclude.
+
+    **Why packaged independently of S25**: S25's combine helper
+    (`trig_sum_combine_small_large_const`, in flight as PR #17457) consumes
+    a `hlarge` hypothesis of exactly this shape but parameterised over the
+    same `θ` it concludes for. By extending S26's reach to all `θ ∈ (0, π)`,
+    this helper closes the angle-domain gap so the final `trig_sum_harmonic_lb`
+    can apply S25 directly without an additional in-line WLOG case split. -/
+private lemma trig_sum_harmonic_lb_asymp
+    (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
+    ∃ (N₀ : ℕ) (C₁ : ℝ), 0 < C₁ ∧ ∀ n : ℕ, N₀ ≤ n →
+      C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k| := by
+  by_cases hcase : θ ≤ Real.pi / 2
+  · -- Branch 1: `θ ≤ π/2`. Direct application of S26.
+    exact trig_sum_harmonic_lb_asymp_le_half_pi θ hθ_pos hcase hne
+  · -- Branch 2: `θ > π/2`. WLOG bridge via `θ' := π − θ ∈ (0, π/2)`.
+    push_neg at hcase
+    -- Build the hypotheses for S26 at `θ' := π − θ`.
+    have hθ'_pos : 0 < Real.pi - θ := by linarith
+    have hθ'_le : Real.pi - θ ≤ Real.pi / 2 := by linarith
+    -- S27 supplies the `hne` side of the bridge for each `n`.
+    have hne' : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n),
+        Real.cos (Real.pi - θ) ≠ chebyshevNode n k := by
+      intro n hn k
+      exact chebyshev_hne_pi_sub n hn θ (hne n hn) k
+    -- Apply S26 to `(π − θ)` to get `(N₀, C₁, hbound')` for the reindexed sum.
+    obtain ⟨N₀, C₁, hC₁_pos, hbound'⟩ :=
+      trig_sum_harmonic_lb_asymp_le_half_pi (Real.pi - θ) hθ'_pos hθ'_le hne'
+    -- Bump `N₀` to `max N₀ 1` so we can apply `trig_sum_reindex_symmetry`
+    -- (which requires `0 < n`). This costs nothing: at `n = 0` the sum is
+    -- empty and the bound is trivially `0 ≤ 0`, so adding a 1-floor only
+    -- prunes the trivial entry.
+    refine ⟨max N₀ 1, C₁, hC₁_pos, ?_⟩
+    intro n hn_max
+    have hN₀_le : N₀ ≤ n := le_of_max_le_left hn_max
+    have hn_pos : 0 < n := by
+      have h1_le : 1 ≤ n := le_of_max_le_right hn_max
+      omega
+    -- S18: `S(θ, n) = S(π − θ, n)`. Rewrite the goal LHS sum.
+    have hsym := trig_sum_reindex_symmetry n hn_pos θ
+    rw [hsym]
+    exact hbound' n hN₀_le
+
 private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
     (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
     ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →

--- a/research/problems/erdos-1151-oq-04/session-28-asymp-general.md
+++ b/research/problems/erdos-1151-oq-04/session-28-asymp-general.md
@@ -1,0 +1,162 @@
+# Session 28 (2026-05-09, researcher-6): Asymptotic large-n packaging for general θ ∈ (0, π)
+
+**Phase**: ACT
+**Outcome**: `trig_sum_harmonic_lb_asymp` helper added (~50 lines). Extends
+S26's `trig_sum_harmonic_lb_asymp_le_half_pi` from `θ ∈ (0, π/2]` to the
+full open interval `θ ∈ (0, π)` via the WLOG bridge S18 + S27. Together
+with S25 (`trig_sum_combine_small_large_const`, in flight as PR #17457),
+the Step 7 closure of `trig_sum_harmonic_lb` collapses to ~5 caller lines.
+
+## Problem context
+
+After S26 (`trig_sum_harmonic_lb_asymp_le_half_pi`, merged via #17486)
+and S27 (`chebyshev_hne_pi_sub`, merged via #17505), the Step 7 helper
+inventory was complete on the asymptotic side **but only for θ ≤ π/2**:
+
+| Step | Helper | Status | θ range |
+|------|--------|--------|---------|
+| 7a (half-π asymp) | `trig_sum_harmonic_lb_asymp_le_half_pi` | merged (S26, #17486) | (0, π/2] |
+| 7b (small n)      | `trig_sum_small_n_const`                | merged (S22, #17330) | (0, π) |
+| 7c (combine)      | `trig_sum_combine_small_large_const`    | in flight (S25, #17457) | (0, π) |
+| WLOG bridge (sum) | `trig_sum_reindex_symmetry`             | merged (S18, #17050) | (0, π) |
+| WLOG bridge (hne) | `chebyshev_hne_pi_sub`                  | merged (S27, #17505) | (0, π) |
+
+The missing piece was the **caller-glue** that uses the WLOG bridge to
+extend S26's asymptotic bound from `θ ∈ (0, π/2]` to the full `θ ∈ (0, π)`
+hypothesis required by `trig_sum_harmonic_lb`. Two strategies:
+
+  - **A**: write the full Step 7 closure of `trig_sum_harmonic_lb` in one
+    monolithic proof inside the theorem (uses S26 + S25 + S18 + S27 in-line).
+  - **B (chosen)**: factor the WLOG bridge into a standalone helper
+    (this session), so the final `trig_sum_harmonic_lb` becomes ~5 lines:
+    apply S28 → `(N₀, C₁, hlarge)`, apply S25 → unified `(C, h)`, conclude.
+
+Strategy B respects the existing modularity: S26 packages large-n for
+`θ ≤ π/2`, S28 packages large-n for general `θ`, S25 combines large+small.
+
+## Helper added
+
+**Location**: `proofs/Proofs/Erdos1151OQ04.lean`, after S26's
+`trig_sum_harmonic_lb_asymp_le_half_pi` (line 2181) and before
+`trig_sum_harmonic_lb` (line 2328 after this session).
+
+**Signature**:
+
+```lean
+private lemma trig_sum_harmonic_lb_asymp
+    (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
+    ∃ (N₀ : ℕ) (C₁ : ℝ), 0 < C₁ ∧ ∀ n : ℕ, N₀ ≤ n →
+      C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k|
+```
+
+**Proof structure** (2 branches via `by_cases θ ≤ π/2`, ~50 body lines):
+
+  - **Branch 1 (`θ ≤ π/2`)**: directly apply S26.
+  - **Branch 2 (`θ > π/2`)**:
+    1. Set `θ' := π − θ`, with `0 < θ'` (from `θ < π`) and
+       `θ' ≤ π/2` (from `θ ≥ π/2`).
+    2. Use S27 (`chebyshev_hne_pi_sub`) per-`n` to lift `hne` from `θ`
+       to `θ'`: `∀ n hn k, cos (π − θ) ≠ chebyshevNode n k`.
+    3. Apply S26 to `(π − θ, hθ'_pos, hθ'_le, hne')` to obtain
+       `(N₀, C₁, hC₁_pos, hbound')` with
+       `C₁ · n · log(n+1) ≤ S(π − θ, n)` for `n ≥ N₀`.
+    4. Bump `N₀` to `max N₀ 1` so we can apply S18 (which requires
+       `0 < n`); this costs nothing since the `n = 0` case of the conclusion
+       is trivially `0 ≤ 0`.
+    5. Apply S18 (`trig_sum_reindex_symmetry`) for the rewrite
+       `S(θ, n) = S(π − θ, n)`; `rw [hsym]` flips the goal LHS sum.
+    6. `exact hbound' n hN₀_le` closes the goal.
+
+The angle expressions in S18's RHS, S26's conclusion, and the S28 goal
+are all `(2 * (k.val : ℝ) + 1) * π / (2 * n)` (or the definitionally
+equal `(2 * k.val + 1 : ℝ) * π / (2 * n)`), so no cast bridge is needed
+beyond what Lean does automatically via `rfl` unification.
+
+## Counts delta
+
+|              | Before (S27)     | After (S28)       | Δ    |
+|--------------|-----------------:|------------------:|-----:|
+| Lines        | 2467             | 2528              | +61  |
+| Theorems     | 61               | 62                | +1   |
+| Axioms       | 0 (file-local)   | 0                 | 0    |
+| Sorries      | 2                | 2                 | 0    |
+
+(meta: file-local axiomCount is 0; the 2 axioms tracked in meta.json live
+in `Erdos1151Problem.lean`.)
+
+The meta.json `lineCount`/`theoremCount` for `Erdos1151OQ04.lean` were
+also stale by 2 iterations (showing 2415/60 — pre-S26/S27 baseline). This
+session syncs them to 2528/62 in passing.
+
+## Mathlib API surface
+
+Zero new lemmas. Composes from existing helpers + standard Mathlib:
+- File-local: `trig_sum_harmonic_lb_asymp_le_half_pi` (S26),
+  `chebyshev_hne_pi_sub` (S27), `trig_sum_reindex_symmetry` (S18).
+- Mathlib: `le_of_max_le_left`, `le_of_max_le_right`, `linarith`, `omega`,
+  `push_neg`, `by_cases`.
+
+No new imports.
+
+## Step 7 closure picture (after this PR)
+
+| Step | Helper | Status |
+|------|--------|--------|
+| 7a (half-π) | `trig_sum_harmonic_lb_asymp_le_half_pi` | merged (S26, #17486) |
+| 7a (general θ) | `trig_sum_harmonic_lb_asymp` | **this PR (S28)** |
+| 7b   | `trig_sum_small_n_const`         | merged (S22, #17330) |
+| 7c   | `trig_sum_combine_small_large_const` | in flight (S25, #17457) |
+| WLOG (sum) | `trig_sum_reindex_symmetry` | merged (S18, #17050) |
+| WLOG (hne) | `chebyshev_hne_pi_sub` | merged (S27, #17505) |
+
+**Remaining for `trig_sum_harmonic_lb`** (~5 caller lines, post-merge):
+
+```lean
+obtain ⟨N₀, C₁, hC₁_pos, hlarge⟩ :=
+  trig_sum_harmonic_lb_asymp θ hθ_pos hθ_lt hne
+exact trig_sum_combine_small_large_const θ hne N₀ hC₁_pos hlarge
+```
+
+## Build status
+
+**[BUILD UNVERIFIED]** — Docker build queued at session start
+(LEAN_BUILD_TIMEOUT=45m). Per memory `feedback_researcher_lake_symlink_broken.md`,
+local builds re-clone Mathlib (~10–15 min) then build (~15+ min); risk profile
+is identical to other build-pending Step 7 PRs (#17386, #17457, #17486, #17505).
+
+The proof is high-confidence — the only Mathlib tactics used are
+`by_cases`, `push_neg`, `linarith`, `omega`, `le_of_max_le_left/right`,
+all of which are stable across Mathlib versions. The S26 + S27 + S18
+helpers it composes are all merged on `origin/main`.
+
+## Conflict-resolution plan
+
+This PR inserts at the same file location as PR #17457 (immediately after
+`trig_sum_harmonic_lb_asymp_le_half_pi`, before `trig_sum_harmonic_lb`).
+The two helpers are **independent** — neither references the other.
+Whichever lands first triggers a trivial rebase in the other (just
+relocate the insertion point by ~60 lines).
+
+PR #17386 (the stale S23 combine helper) is superseded by #17457; this
+session does not interact with it.
+
+## References
+
+- PR #17505 (S27, merged, researcher-11) — `chebyshev_hne_pi_sub`
+- PR #17486 (S26, merged, researcher-12) — `trig_sum_harmonic_lb_asymp_le_half_pi`
+- PR #17457 (S25, in flight, researcher-1) — `trig_sum_combine_small_large_const`
+- PR #17438 (S24, merged, researcher-4) — `chebyshev_quarter_floor_log_asymp_lb`
+- PR #17396 (S23, merged, researcher-3) — `chebyshev_quarter_floor_hm_le_and_cap_max`
+- PR #17324 (S22, merged, researcher-3) — `chebyshev_h_interior_of_close_and_max_index_cap`
+- PR #17330 (S22, merged, researcher-11) — `trig_sum_small_n_const`
+- PR #17050 (S18, merged, researcher-10) — `trig_sum_reindex_symmetry`
+- PR #17046 (S21, merged, doctor) — `trig_sum_subsum_log_lb`
+
+## Outcome
+
+**Progress** (1 helper added; closes the half-π → (0, π) gap on the
+asymptotic side; final `trig_sum_harmonic_lb` proof now ~5 lines pending
+S25 #17457).

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,10 +4,61 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 26
+**Iteration**: 28
 **Last Updated**: 2026-05-09
 
-## Session 26 (researcher-12, this session, build pending)
+## Session 28 (researcher-6, this session, build pending)
+
+Added the **Step 7a/general-θ asymptotic packaging** as a new private helper
+`trig_sum_harmonic_lb_asymp` (~50 lines). Extends S26's
+`trig_sum_harmonic_lb_asymp_le_half_pi` from `θ ∈ (0, π/2]` to the full
+open interval `θ ∈ (0, π)` via the WLOG bridge:
+
+```
+∃ N₀ : ℕ, ∃ C₁ : ℝ, 0 < C₁ ∧ ∀ n ≥ N₀,
+  C₁ · n · log(n+1) ≤ S(θ, n)
+```
+
+with no constraint on `θ ∈ (0, π)` beyond the cosine-not-a-Chebyshev-node
+hypothesis.
+
+**Composition** (purely from already-merged helpers):
+
+  1. Case split on `θ ≤ π/2` vs `θ > π/2`.
+  2. **`θ ≤ π/2`**: directly apply S26.
+  3. **`θ > π/2`**: set `θ' := π − θ ∈ (0, π/2)`.
+     a. S27 (`chebyshev_hne_pi_sub`) → `hne'` for `θ'` from `hne` for `θ`.
+     b. S26 applied to `θ'` → `(N₀, C₁, hbound')` for `S(π − θ, n)`.
+     c. S18 (`trig_sum_reindex_symmetry`) → `S(θ, n) = S(π − θ, n)`.
+     d. Bump `N₀` to `max N₀ 1` so we can apply S18 (which requires `0 < n`).
+     e. `rw [hsym]` flips the goal LHS sum, then `exact hbound' n hN₀_le`.
+
+**Why this matters**: this is the **last gap** between the half-π asymp
+bound (S26) and the general (0, π) hypothesis required by
+`trig_sum_combine_small_large_const` (S25, in flight as PR #17457).
+Once S25 + S28 both merge, the `trig_sum_harmonic_lb` proof closes in
+~5 lines: apply S28 → `(N₀, C₁, hlarge)`, apply S25 → unified `(C, h)`.
+
+**No conflict with PR #17457 or PR #17386**: this S28 helper inserts
+AT a NEW POSITION (immediately after S26, before `trig_sum_harmonic_lb`),
+which is the same insertion point as S25 (#17457) and the stale S23
+(#17386). All three are independent helpers with disjoint signatures
+(`trig_sum_harmonic_lb_asymp` vs `trig_sum_combine_small_large_const`);
+whichever lands first triggers a trivial relocation in the others.
+
+## Session 27 (researcher-11, build pending, merged via #17505)
+
+Added `chebyshev_hne_pi_sub` (~50 lines): `hne` side of WLOG bridge.
+For any `n > 0`, `θ ∈ ℝ`, `(hne : ∀ k, cos θ ≠ chebyshevNode n k)`,
+yields `∀ k, cos (π − θ) ≠ chebyshevNode n k`. Uses the same involution
+`σ : Fin n ≃ Fin n`, `k ↦ n − 1 − k` as S18; key step is
+`chebyshevNode n (σ k) = − chebyshevNode n k` via `Real.cos_pi_sub`.
+
+Combined with S18 (which provides the **sum side** `S(θ, n) = S(π − θ, n)`),
+S27 constitutes the entire WLOG-bridge machinery for extending `θ ∈ (0, π/2]`
+results to `θ ∈ (0, π)`. Used by S28 (this session).
+
+## Session 26 (researcher-12, merged via #17486)
 
 Added the **Step 7a/asymptotic side packaging** as a new private helper
 `trig_sum_harmonic_lb_asymp_le_half_pi` (~120 lines). For any
@@ -242,23 +293,20 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
 
 ## Next Steps
 
-1. Prove `trig_sum_harmonic_lb` using the existing scaffolding (~30–60 lines remaining):
-   - **Step 7a (asymptotic, large `n`)**: WLOG `θ ∈ (0, π/2]` via
-     `trig_sum_reindex_symmetry`; pick `m := ⌊n·θ/(4π)⌋` (with `Nat.floor_le`
-     supplying the `(m : ℝ) ≤ n·θ/(4π)` hypothesis), then chain
-     `chebyshev_quarter_floor_hm_le_and_cap_max` (S23) →
-     `chebyshev_h_interior_of_close_and_max_index_cap` (S22) →
-     `trig_sum_subsum_log_lb` to obtain
-     `sin(θ/2) · (2n/π) · ((1/2) · log(m+2) − 1) ≤ S(θ, n)` for `n ≥ N₀(θ)`.
-     Asymptotically dominates `C₁ · n · log(n+1)` with `C₁ ≈ sin(θ/2)/π`,
-     once `log(m+2) ≥ (1/2)·log(n+1)` is established (use
-     `Nat.lt_floor_add_one` + log-monotonicity).
+1. Prove `trig_sum_harmonic_lb` (~5 caller lines after S25 + S28 merge):
+   - **Step 7a (asymptotic, large `n`)**: ✅ **closed in S26 (half-π) + S28 (general θ)**.
+     `trig_sum_harmonic_lb_asymp` returns `(N₀, C₁, hC₁_pos, hlarge)` for any
+     `θ ∈ (0, π)` with `cos θ` not a Chebyshev node.
    - **Step 7b (small `n`, finite-set min')**: ✅ **closed in S22** by
      `trig_sum_small_n_const`. Returns `C₂ > 0` with
      `C₂ · n · log(n+1) ≤ S(θ, n)` for `1 ≤ n ≤ N₀(θ) − 1`.
-   - **Step 7c (combine)**: `C := min C₁ C₂`. Both halves use the
+   - **Step 7c (combine)**: `C := min C₁ C₂`. In flight as
+     `trig_sum_combine_small_large_const` (PR #17457). Both halves use the
      same `n · log(n+1)` shape, so the unified bound follows by case
      split on `n < N₀(θ)` vs `n ≥ N₀(θ)`.
+   - **Final glue** (post-merge of S25 + S28): `obtain ⟨N₀, C₁, hC₁_pos, hlarge⟩ :=
+     trig_sum_harmonic_lb_asymp θ hθ_pos hθ_lt hne` then
+     `exact trig_sum_combine_small_large_const θ hne N₀ hC₁_pos hlarge`.
 
 2. For Sorry 2 (`divergence_from_lebesgue_growth`):
    - **Option A (recommended)**: weaken statement to `Filter.Tendsto … atTop`
@@ -314,25 +362,37 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
 - 2026-05-08: Session 25 (researcher-1, in flight): `trig_sum_combine_small_large_const`
   — Step 7c min-of-two-constants closure, replay of stale PR #17386 onto
   fresh `origin/main`. Open as PR #17457.
-- 2026-05-09: Session 26 (researcher-12, this session): `trig_sum_harmonic_lb_asymp_le_half_pi`
+- 2026-05-09: Session 26 (researcher-12): `trig_sum_harmonic_lb_asymp_le_half_pi`
   — asymptotic large-`n` packaging for `θ ∈ (0, π/2]`. Composes
   `exists_nearest_chebyshev_angle` (S14), `chebyshev_quarter_floor_hm_le_and_cap_max`
   (S23), `chebyshev_h_interior_of_close_and_max_index_cap` (S22),
   `trig_sum_subsum_log_lb` (S21), and `chebyshev_quarter_floor_log_asymp_lb`
   (S24) into the single `hlarge` hypothesis consumed by S25's
-  combine helper. PR pending.
+  combine helper. Merged via #17486.
+- 2026-05-09: Session 27 (researcher-11): `chebyshev_hne_pi_sub` — `hne` side
+  of WLOG bridge: `(∀ k, cos θ ≠ chebyshevNode n k) → (∀ k, cos (π − θ) ≠ chebyshevNode n k)`.
+  Uses S18's involution `σ : k ↦ n − 1 − k` + `Real.cos_pi_sub`.
+  Merged via #17505.
+- 2026-05-09: Session 28 (researcher-6, this session): `trig_sum_harmonic_lb_asymp`
+  — extends S26's asymp bound from `θ ∈ (0, π/2]` to `θ ∈ (0, π)` via WLOG
+  bridge S18 + S27 (case `θ > π/2`: set `θ' := π − θ ∈ (0, π/2)`, lift `hne`
+  via S27, apply S26 to `θ'`, rewrite `S(θ, n) = S(π − θ, n)` via S18).
+  PR pending.
 
 ## Open PRs
 
-- (this session, S26) PR pending — `trig_sum_harmonic_lb_asymp_le_half_pi`
-  (~140 lines, build TBD) — packages the asymptotic large-`n` side for
-  `θ ∈ (0, π/2]`; exactly the `hlarge` hypothesis #17457's combine
-  helper expects.
+- (this session, S28) PR pending — `trig_sum_harmonic_lb_asymp`
+  (~50 lines, build pending) — extends S26's asymp bound from
+  `θ ∈ (0, π/2]` to `θ ∈ (0, π)` via WLOG bridge S18 + S27.
+  The general-θ `hlarge` hypothesis required to apply S25's combine
+  helper directly inside `trig_sum_harmonic_lb`.
 - PR #17457 (researcher-1, S25 replay of stale PR #17386) —
   `trig_sum_combine_small_large_const` Step 7c min-of-two-constants closure.
+- PR #17386 (researcher-1, S23 stale, conflicting) — original combine
+  helper; superseded by #17457.
 
-## File Stats (after Session 26 added trig_sum_harmonic_lb_asymp_le_half_pi)
+## File Stats (after Session 28 added trig_sum_harmonic_lb_asymp)
 
-- `proofs/Proofs/Erdos1151OQ04.lean`: 2415 lines, 2 sorries (was 2288 on origin/main)
+- `proofs/Proofs/Erdos1151OQ04.lean`: 2528 lines, 2 sorries (was 2467 on origin/main)
 - `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: companion file (0 sorries)
 - `proofs/Proofs/Erdos1151Problem.lean`: parent problem statement

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "IN-PROGRESS",
-    "since": "2026-05-08",
-    "iteration": 21,
-    "focus": "Session 21 (doctor, 2026-05-08): Added trig_sum_subsum_log_lb (Step 6c, ~36 lines) — combined log lower bound composing Step 6a (odd_harmonic_sum_shifted_lb) and Step 6b (trig_sum_subsum_lb) via mul_le_mul_of_nonneg_left + Real.sin_nonneg_of_nonneg_of_le_pi. Yields the ready-to-apply n·log(m) lower bound sin(d/2)·(2n/π)·((1/2)·log(m+2)-1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|. Recovers Step 6c content from PR #17046 after the symmetry helper portion (chebyshev_lebesgue_sum_pi_sub) became redundant with #17050's trig_sum_reindex_symmetry already on main.",
+    "since": "2026-05-09",
+    "iteration": 28,
+    "focus": "Session 28 (researcher-6, 2026-05-09, build pending): Added trig_sum_harmonic_lb_asymp (~50 lines) — extends S26's asymptotic large-n bound from θ ∈ (0, π/2] to the full open interval θ ∈ (0, π) via the WLOG bridge S18 (trig_sum_reindex_symmetry) + S27 (chebyshev_hne_pi_sub). For θ > π/2, sets θ' := π − θ ∈ (0, π/2), uses S27 to lift hne, applies S26 to θ', then uses S18 to rewrite S(θ, n) = S(π − θ, n). With this and S25 (combine helper #17457) merged, the Step 7 closure of trig_sum_harmonic_lb collapses to ~5 caller lines.",
     "blockers": [],
-    "nextAction": "(Researcher) Step 7 closure of trig_sum_harmonic_lb: use trig_sum_reindex_symmetry to WLOG θ ∈ (0, π/2]; choose m = ⌊nθ/(8π)⌋ with d := min(θ, π−θ); verify hm_le and h_interior for j ∈ Fin m; apply trig_sum_subsum_log_lb (Step 6c) for the n·log(m) lower bound; pick N₀(d) for the asymptotic side; finite-set min over 1 ≤ n < N₀ via Finset.min'.",
+    "nextAction": "(Researcher) Final Step 7 closure of trig_sum_harmonic_lb (~5 lines, after S25+S28 merge): apply trig_sum_harmonic_lb_asymp to obtain (N₀, C₁, hlarge), then trig_sum_combine_small_large_const to obtain unified C, conclude.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -146,15 +146,15 @@
     "mathlib": []
   },
   "started": "2026-04-21T19:30:00.000Z",
-  "lastUpdate": "2026-05-08T11:00:00Z",
+  "lastUpdate": "2026-05-09T03:00:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2415,
-      "theoremCount": 60,
+      "lineCount": 2528,
+      "theoremCount": 62,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary

Adds `trig_sum_harmonic_lb_asymp` (~50 lines) — extends S26's
`trig_sum_harmonic_lb_asymp_le_half_pi` from `θ ∈ (0, π/2]` to the full
open interval `θ ∈ (0, π)` via the WLOG bridge S18 + S27. Closes the
half-π → general-θ gap on the asymptotic large-`n` side of
`trig_sum_harmonic_lb`.

With this and S25 (`trig_sum_combine_small_large_const`, in flight as
PR #17457) merged, the Step 7 closure of `trig_sum_harmonic_lb` collapses
to ~5 caller lines.

## Helper added

```lean
private lemma trig_sum_harmonic_lb_asymp
    (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
    ∃ (N₀ : ℕ) (C₁ : ℝ), 0 < C₁ ∧ ∀ n : ℕ, N₀ ≤ n →
      C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
                     |Real.cos θ - chebyshevNode n k|
```

**Proof** (~50 lines): `by_cases θ ≤ π/2`.
- Branch 1 (`θ ≤ π/2`): direct application of S26.
- Branch 2 (`θ > π/2`): set `θ' := π − θ ∈ (0, π/2)`. Use S27 to lift
  `hne` from `θ` to `θ'`. Apply S26 to `θ'` to obtain `(N₀, C₁, hbound')`
  with `C₁ · n · log(n+1) ≤ S(π − θ, n)`. Bump `N₀` to `max N₀ 1` (so S18
  applies). Use S18 (`trig_sum_reindex_symmetry`) for the rewrite
  `S(θ, n) = S(π − θ, n)`, then close.

## Step 7 closure picture (after this PR)

| Step | Helper | Status |
|------|--------|--------|
| 7a (half-π) | `trig_sum_harmonic_lb_asymp_le_half_pi` | merged (S26, #17486) |
| 7a (general θ) | `trig_sum_harmonic_lb_asymp` | **this PR (S28)** |
| 7b   | `trig_sum_small_n_const`         | merged (S22, #17330) |
| 7c   | `trig_sum_combine_small_large_const` | in flight (S25, #17457) |
| WLOG (sum) | `trig_sum_reindex_symmetry` | merged (S18, #17050) |
| WLOG (hne) | `chebyshev_hne_pi_sub` | merged (S27, #17505) |

**Remaining for `trig_sum_harmonic_lb`** (~5 caller lines, post-merge):

```lean
obtain ⟨N₀, C₁, hC₁_pos, hlarge⟩ :=
  trig_sum_harmonic_lb_asymp θ hθ_pos hθ_lt hne
exact trig_sum_combine_small_large_const θ hne N₀ hC₁_pos hlarge
```

## Counts

|              | Before (S27)     | After (S28)       | Δ    |
|--------------|-----------------:|------------------:|-----:|
| Lines        | 2467             | 2528              | +61  |
| Theorems     | 61               | 62                | +1   |
| Axioms       | 0 (file-local)   | 0                 | 0    |
| Sorries      | 2                | 2                 | 0    |

The meta.json `lineCount`/`theoremCount` for `Erdos1151OQ04.lean` were
also stale by 2 iterations (showing 2415/60 — pre-S26/S27). This
session syncs them to 2528/62 in passing.

## Mathlib API surface

Zero new lemmas. Composes from existing helpers + standard Mathlib:
- File-local: `trig_sum_harmonic_lb_asymp_le_half_pi` (S26),
  `chebyshev_hne_pi_sub` (S27), `trig_sum_reindex_symmetry` (S18).
- Mathlib: `le_of_max_le_left`, `le_of_max_le_right`, `linarith`, `omega`,
  `push_neg`, `by_cases`.

No new imports.

## Build status

**[BUILD UNVERIFIED]** — Docker build (`./proofs/scripts/docker-build.sh
Proofs.Erdos1151OQ04`) in progress at submit time (cold cache;
`mathlib v4.26.0` fresh-clone in progress; `LEAN_BUILD_TIMEOUT=45m`).
Outcome will be reported in a follow-up comment if any drift surfaces.

The proof is high-confidence — every step uses an existing merged helper
on `origin/main` (S26 #17486, S27 #17505, S18 #17050) plus standard
core tactics. Per `feedback_basel_oq03_iter12_three_fixes.md`, when ≥3
build-pending merges accumulate on a slug, drift can compound silently;
the pre-existing build state of `Erdos1151OQ04.lean` is reported as
build-pending across S25/S26/S27, and this PR's helper does not introduce
new constructs that touch that area.

## Conflict-resolution plan

This PR inserts at the same file location as PR #17457 (immediately after
`trig_sum_harmonic_lb_asymp_le_half_pi`, before `trig_sum_harmonic_lb`).
The two helpers are **independent** — neither references the other.
Whichever lands first triggers a trivial rebase in the other (just
relocate the insertion point by ~60 lines).

PR #17386 (the stale S23 combine helper) is superseded by #17457; this
session does not interact with it.

## Files modified

- `proofs/Proofs/Erdos1151OQ04.lean` — new helper at lines 2268–2327
  (~60 lines including 20-line docstring; insertion between
  `trig_sum_harmonic_lb_asymp_le_half_pi` and `trig_sum_harmonic_lb`)
- `src/data/research/problems/erdos-1151-oq-04.json` — leanFile
  `lineCount` 2415→2528, `theoremCount` 60→62; `currentState.iteration` 21→28;
  `currentState.focus`/`nextAction` updated for S28; `lastUpdate` bumped
- `research/problems/erdos-1151-oq-04/state.md` — Iteration 28/27 sections;
  Open PRs / File Stats / History updated; Step 7 closure picture refreshed
- `research/problems/erdos-1151-oq-04/session-28-asymp-general.md` — session note (NEW)

## Outcome

**Progress** (1 helper added; closes the half-π → (0, π) gap on the
asymptotic side; final `trig_sum_harmonic_lb` proof now ~5 lines pending
S25 #17457).

🤖 Generated by researcher-6