### PR TITLE
fix(meta): batch sync definitionCount drift (24 entries, erdos-6xx batch)

### DIFF
--- a/src/data/proofs/erdos-600/meta.json
+++ b/src/data/proofs/erdos-600/meta.json
@@ -81,7 +81,7 @@
       }
     ],
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1987, building on the influential work of Ruzsa and Szemerédi from 1978 on triple systems. Their seminal paper proved that in any graph on n vertices where every edge is in at least one triangle, if the graph has o(n²) edges then one cannot guarantee that some edge is in many triangles — equivalently, e(n,r) = o(n²) for fixed r. This result is intimately connected to the triangle removal lemma, one of the cornerstones of extremal graph theory.\n\nThe problem asks two specific questions about the fine structure of the function e(n,r). Question 1 asks whether the absolute gap e(n,r+1) - e(n,r) grows without bound as n → ∞, meaning that requiring one additional triangle per edge always costs significantly more edges for large graphs. Question 2 asks whether the ratio e(n,r+1)/e(n,r) → 1, meaning that while the absolute cost may grow, the relative cost becomes negligible. If both are true, the thresholds grow at the same asymptotic rate but with unbounded absolute separation.\n\nThe known bounds place e(n,r) at roughly n²/log n from above and n^{2-o(1)} from below, leaving a significant gap even for the basic asymptotics. Both questions remain completely open. The problem connects to Turán-type extremal theory, the Szemerédi regularity lemma, and the broader study of how graph density forces local substructure.",
@@ -222,7 +222,7 @@
     "lineCount": 167,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos600Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 287,
     "assumptions": "1 axiom (Komjáth's theorem for ≠1 case). The ≠2 upper bound (ℵ₀ suffices for countable I) is now proved.",
     "theoremCount": 6,
-    "definitionCount": 18
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "Erdős Problem #603 originates from Péter Komjáth and was recorded in [Er87], Erdős's 1987 problem compilation. Komjáth, a leading Hungarian combinatorialist working in set-theoretic combinatorics, proposed this as a natural extension of his own theorem: for families of countably infinite sets with pairwise intersection size $\\neq 1$, exactly $\\aleph_0$ colors suffice to avoid monochromatic sets. The $\\neq 2$ variant remains open and is surprisingly resistant to the same techniques.\n\nThe problem sits at the intersection of infinite combinatorics and hypergraph coloring theory. In finite combinatorics, the chromatic number of hypergraphs with restricted edge intersections is well-studied — the Erdős–Ko–Rado theorem (1961) and the Sunflower Lemma (Erdős and Rado, 1960) are foundational results in this area. The infinite setting introduces cardinal arithmetic complications: the answer could be any finite number, $\\aleph_0$, or conceivably larger. The contrast between the $\\neq 1$ case (solved, $C = \\aleph_0$) and the $\\neq 2$ case (open) illustrates how sensitive these problems are to the exact intersection constraint.",
@@ -209,7 +209,7 @@
     "lineCount": 287,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos603Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-605/meta.json
+++ b/src/data/proofs/erdos-605/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 250,
     "assumptions": "1 axiom: erdos_605_superlinear (superlinear growth of D repeated distances for D>1, Swanepoel-Valtr result). Problem solved. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "**The Unit Distance Problem on Spheres**\n\nErdős Problem #605 extends the classical unit distance problem from the plane to spherical surfaces. The unit distance problem asks: among n points in ℝ², how many pairs can be at the same distance? For the plane, the answer grows slightly superlinearly. Erdős asked whether the spherical version also admits superlinear growth.\n\n**Key Historical Developments:**\n\n- **1989**: Erdős, Hickerson, and Pach proved the first superlinear bound u_D(n) ≫ n·log*(n) for spheres of radius D > 1, where log* is the iterated logarithm. This resolved the problem affirmatively, though the growth rate log*(n) is incredibly slow.\n- **2004**: Swanepoel and Valtr significantly improved the lower bound to u_D(n) ≫ n·√(log n), using algebraic constructions on the sphere.\n- **Special case D = √2**: The sphere of radius √2 is uniquely suited for these constructions because it can inscribe a cube. For this radius, the tight bound u(n) ≍ n^{4/3} is achieved, matching the general upper bound from incidence geometry.",
@@ -196,7 +196,7 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos605Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "12 axioms: numDistinctLines, numDistinctLines_collinear, numDistinctLines_general_position, numDistinctLines_min_noncollinear, sylvester_gallai, not_achievable_max_minus_1, not_achievable_max_minus_3, achievable_max_minus_2, erdos_density_result, beck_theorem, szemeredi_trotter_bound, erdos_salamon_characterization. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**The Distinct Lines Problem**\n\nThis classic problem in discrete geometry asks: given $n$ points in the plane, how many distinct lines can they determine? The answer ranges from 1 (all collinear) to $\\binom{n}{2}$ (general position).\n\n**Key Historical Results**:\n- **Sylvester (1893)**: Posed the question of whether $n$ non-collinear points always determine an ordinary line (one with exactly 2 points). This went unresolved for 50 years.\n- **Gallai (1944)**: Proved Sylvester's conjecture using an elegant extremal argument. The result is now called the Sylvester-Gallai theorem.\n- **Motzkin (1951)**: Gave a shorter proof and established that non-collinear points determine at least $n$ distinct lines.\n- **Beck (1983)**: Proved the fundamental dichotomy — either many points are collinear, or the number of lines is $\\Omega(n^2)$.\n- **Szemerédi-Trotter (1983)**: Established the tight incidence bound $O((nm)^{2/3} + n + m)$, a cornerstone of combinatorial geometry.\n- **Erdős (1985)**: Posed the complete characterization problem as Problem #606.\n- **Erdős-Salamon (1988)**: Solved it for large $n$ — all values from $n$ to $\\binom{n}{2}$ are achievable except exactly two: $\\binom{n}{2}-1$ and $\\binom{n}{2}-3$.\n\n**Why These Exceptions?**\n- $\\binom{n}{2}-1$: Three collinear points reduce the line count by $\\binom{3}{2}-1 = 2$, not 1. More generally, $k$ collinear points reduce by $\\binom{k}{2}-1 \\ge 2$. No combination of collinearities can yield a reduction of exactly 1.\n- $\\binom{n}{2}-3$: The possible reductions from collinearities are sums of numbers $\\ge 2$, so the achievable reductions are $\\{0, 2, 4, 5, 6, \\ldots\\}$. Since 3 is not in this set, $\\binom{n}{2}-3$ is excluded.\n\n**Related Theorems**: Beck's theorem, the Szemerédi-Trotter incidence bound, the orchard problem, and the Dirac-Motzkin conjecture (proved by Green-Tao, 2013) are all closely connected.",
@@ -160,7 +160,7 @@
     "lineCount": 243,
     "axiomCount": 12,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "path": "Proofs/Erdos606Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -70,7 +70,7 @@
     "assumptions": "10 axioms: incidenceSignature, incidence_at_least_two, incidence_at_most_n, incidence_pair_constraint, F, F_two, F_three, szemeredi_trotter_incidence, sz_trotter_upper_bound, f_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The Szemerédi-Trotter theorem (1983) is one of the most influential results in combinatorial geometry. Endre Szemerédi and William T. Trotter proved that the number of incidences between $n$ points and $m$ lines in $\\mathbb{R}^2$ is at most $O((nm)^{2/3} + n + m)$, resolving a conjecture of Erdős. This bound is tight, achieved by grid configurations.\n\nProblem #607 applies the Szemerédi-Trotter machinery to a counting problem: given $n$ points $P \\subset \\mathbb{R}^2$, the 'incidence signature' $A = \\{|\\ell \\cap P| : \\ell \\text{ determined by } P\\}$ records how many points lie on each line. Let $F(n)$ count the number of distinct achievable signatures. Erdős asked whether $F(n) \\leq \\exp(O(\\sqrt{n}))$ and noted this would be optimal. Szemerédi and Trotter confirmed the upper bound using their incidence theorem.\n\nThe $\\sqrt{n}$ growth connects to the Hardy-Ramanujan partition asymptotic $p(n) \\sim \\frac{1}{4n\\sqrt{3}} \\exp(\\pi\\sqrt{2n/3})$: signatures correspond to constrained integer partitions of $\\binom{n}{2}$ into parts $\\binom{k_i}{2}$, and the partition count grows as $\\exp(\\Theta(\\sqrt{n}))$. This problem carried a \\$250 prize.",
@@ -192,7 +192,7 @@
     "lineCount": 224,
     "axiomCount": 10,
     "theoremCount": 2,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/Erdos607Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-616/meta.json
+++ b/src/data/proofs/erdos-616/meta.json
@@ -69,7 +69,7 @@
       }
     ],
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's extensive work on extremal hypergraph theory during the late 1980s and early 1990s. The covering number (transversal number) τ(G) is a fundamental parameter in combinatorial optimization, dual to the matching number by König-type theorems. The question of how local structure constrains global covering was formalized by Erdős, Hajnal, and Tuza in their 1991 paper 'Local constraints ensuring small representing sets' published in the *Journal of Combinatorial Theory, Series A* (vol. 58, pp. 78-84). The problem sits at the intersection of Helly-type combinatorics (where local intersection properties imply global ones) and extremal set theory. András Hajnal was Erdős's longtime collaborator on set-theoretic combinatorics, while Zsolt Tuza contributed deep expertise in hypergraph transversals. The problem is reminiscent of the classical Helly theorem (1923), which states that for convex sets in $\\mathbb{R}^d$, pairwise intersection in every $d+1$ sets implies a common point. Here the 'dimension' is replaced by the uniformity $r$, and the threshold $3r-3$ plays the role of $d+1$. The bounds $(3/16)r \\le t(r) \\le (1/5)r$ have stood unchanged since 1991, making this one of the more persistent open problems in extremal hypergraph theory.",
@@ -217,7 +217,7 @@
     "lineCount": 281,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos616Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-618/meta.json
+++ b/src/data/proofs/erdos-618/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 250,
     "assumptions": "2 axioms: main_conjecture_proved, threshold_is_sharp. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #618 was posed by Erdős, Gyárfás, and Ruszinkó in their 1998 Combinatorica paper 'How to decrease the diameter of triangle-free graphs.' For a triangle-free graph G on n vertices, h₂(G) denotes the minimum number of edges that must be added so that the resulting graph has diameter at most 2 while remaining triangle-free. The authors proved that for bounded degree graphs (Δ = O(1)) with no isolated vertices, h₂(G) = O(n log n).\n\nSimonovits showed the complementary direction: there exist triangle-free graphs with maximum degree ≫ √n for which h₂(G) = Θ(n²). This established that √n is a critical threshold for the maximum degree. The central conjecture asked whether Δ = o(√n) always implies h₂(G) = o(n²). Noga Alon resolved this conjecture affirmatively, observing that the problem is essentially identical to Erdős Problem #134.\n\nThe √n threshold arises naturally from the interplay between Mantel's theorem (triangle-free graphs have at most n²/4 edges) and the structural requirements for diameter 2. A graph with degree ≈ √n has roughly n^{3/2} edges, which is the scale at which triangle-free diameter-2 graphs transition between sparse and dense behavior. Alon's proof uses probabilistic and extremal graph theory methods.",
@@ -151,7 +151,7 @@
     "lineCount": 250,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos618Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-62/meta.json
+++ b/src/data/proofs/erdos-62/meta.json
@@ -59,7 +59,7 @@
     "assumptions": "3 axiom(s): oddCycle, oddCycle_chromatic, erdos_hajnal_shelah. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Erdős posed this problem at the intersection of infinite combinatorics and chromatic graph theory. The question asks whether graphs with uncountable chromatic number (χ = ℵ₁) must share 'rich' common subgraphs. The Erdős-Hajnal-Shelah theorem (1974) provides the key partial answer: every graph with χ = ℵ₁ contains all sufficiently large odd cycles, so any two such graphs share common subgraphs with χ = 3. The gap between χ = 3 (achieved) and χ = 4 (conjectured) represents a fundamental barrier in infinite combinatorics. Erdős generalized the problem to finite collections (1987) and raised it repeatedly through the 1990s. The problem connects to partition calculus, the De Bruijn-Erdős compactness theorem, and the structure theory of graphs with large chromatic number. Under ZFC, graphs with χ = ℵ₁ exist (e.g., shift graphs on ω₁), but controlling their common subgraph structure remains elusive.",
@@ -184,7 +184,7 @@
     "lineCount": 207,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "mainTheorems": [
       {
         "name": "odd_cycles_are_common",

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 268,
     "assumptions": "2 axiom(s) and 19 sorry(s). See the Lean source for details.",
     "theoremCount": 19,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Erdos625ProblemAristotle.lean"
     ]
@@ -152,7 +152,7 @@
     "lineCount": 268,
     "axiomCount": 2,
     "theoremCount": 19,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "sorries": 19,
     "path": "Proofs/Erdos625Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-63/meta.json
+++ b/src/data/proofs/erdos-63/meta.json
@@ -31,7 +31,7 @@
     "assumptions": "1 axiom: erdos_63_theorem. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "This problem was conjectured by Peter Mihók and Paul Erdős during the period 1993-1997, building on earlier work connecting chromatic number to cycle structure. Penman first observed that the result holds when the chromatic number is uncountable, using the Erdős-Hajnal theorem (which gives arbitrarily large $K_{m,m}$ subgraphs, each containing all even cycles up to $2m$). The countable case was much harder and remained open for over two decades. The breakthrough came from Hong Liu and Richard Montgomery in 2020, who proved a key result connecting high chromatic number to high minimum degree subgraphs: every graph with $\\chi > k$ contains a subgraph with $\\delta > k/2$. Combined with the de Bruijn-Erdős compactness theorem (1951) and the Bondy-Simonovits theorem on even cycles in dense graphs, this resolved the full problem. Liu and Montgomery's result was part of their broader work on Mader's conjecture about clique subdivisions in $C_4$-free graphs.",
@@ -149,7 +149,7 @@
     "lineCount": 224,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos63Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -56,7 +56,7 @@
     "assumptions": "0 axiom(s) and 8 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 12
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "This problem concerns the geometry of triangle dissections — partitioning a triangle into congruent triangular pieces. Every triangle can be dissected into n² congruent copies by subdividing each side into n equal segments and connecting corresponding points, forming an n × n grid of congruent sub-triangles.\n\nThe question is: are there triangles where n² is the ONLY achievable dissection count? Alexander Soifer investigated this systematically in his book 'How Does One Cut a Triangle?' (2009). He showed that the triangle with sides √2, √3, √4 has this 'square-only' property — it cannot be dissected into any non-square number of congruent triangles. The key constraint comes from the irrational side lengths: any tiling must respect algebraic relationships between the sides, and the only way to achieve area compatibility with matching angles forces the count to be a perfect square.\n\nSoifer's analysis connects to the concept of 'integral independence' of angles: if the three angles α, β, γ of a triangle satisfy no non-trivial integer linear relation (beyond α + β + γ = π), then dissection constraints force square-only counts. Equilateral triangles (angles π/3, π/3, π/3 — integrally dependent via α = β = γ) can be dissected into 3 pieces, and right isosceles triangles (π/4, π/4, π/2 — integrally dependent via α = β, γ = 2α) can be dissected into 2 pieces.\n\nThe complete classification of square-only triangles remains OPEN with a $25 Erdős prize. The conjecture is that integral independence of angles is the precise characterization.",
@@ -154,7 +154,7 @@
     "lineCount": 236,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 12,
+    "definitionCount": 15,
     "sorries": 8,
     "path": "Proofs/Erdos633Problem.lean"
   },

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries: congruent_implies_similar (sorry pending), squares_dissectable, two_squares_dissectable, three_squares_dissectable, six_squares_dissectable, sum_squares_dissectable (all pending explicit dissection constructions with Heron-formula area equality). The Dissection structure was strengthened from a placeholder positivity condition to a proper area-partition requirement via Heron's formula — removing a prior internal inconsistency where trivial constant-function witnesses made IsDissectable provable for all n ≥ 1, contradicting the Beeson axioms.",
     "lineCount": 331,
     "theoremCount": 16,
-    "definitionCount": 18
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "**Triangle Dissection Problem — A Bridge Between Geometry and Number Theory**\n\nPaul Erdős posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erdős and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
@@ -199,7 +199,7 @@
     "lineCount": 331,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "sorries": 6,
     "path": "Proofs/Erdos634Problem.lean"
   },

--- a/src/data/proofs/erdos-639/meta.json
+++ b/src/data/proofs/erdos-639/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 202,
     "assumptions": "3 axioms: ramsey_3_3, keevash_sudakov_main, keevash_sudakov_complete. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Monochromatic Triangle Coverage: From Ramsey Theory to Exact Thresholds**\n\nThis problem sits at the intersection of Ramsey theory and extremal graph theory, asking a natural quantitative question: in a 2-coloring of $K_n$, how many edges can escape all monochromatic triangles?\n\n**The Ramsey Foundation**: Ramsey's theorem (1930) guarantees that any 2-coloring of a sufficiently large complete graph contains a monochromatic clique of prescribed size. For triangles specifically, Greenwood and Gleason (1955) established $R(3,3) = 6$: every 2-coloring of $K_6$ contains a monochromatic triangle. The unique (up to isomorphism) triangle-free 2-coloring of $K_5$ is the cycle $C_5$ in one color with its complement in the other — this is the Ramsey $(3,3)$ graph.\n\n**The Phase Transition**: The value $R(3,3) = 6$ creates a sharp phase transition:\n- For $n \\le 5$: there exist 2-colorings with NO monochromatic triangle at all, so every edge avoids one.\n- For $n = 6$: monochromatic triangles are forced, but at most 10 edges can still avoid them.\n- For $n \\ge 7$: the monochromatic structure becomes dominant, with at most $\\lfloor n^2/4 \\rfloor$ edges escaping.\n\n**Erdős's Conjecture**: Erdős asked whether the balanced bipartite coloring — coloring cross-edges between two equal halves red and within-half edges blue — is extremal. This coloring creates $\\lfloor n^2/4 \\rfloor$ edges (the cross-edges between halves) that form a complete bipartite graph with no triangles in either color among the cross-edges.\n\n**The Solution Path**:\n- **Erdős-Rousseau-Schelp** (unpublished): Proved the conjecture asymptotically for large $n$.\n- **Pyber (1986)**: Showed that $\\lfloor n^2/4 \\rfloor + 2$ monochromatic cliques suffice to cover all edges of any 2-colored $K_n$. As Alon observed, this implies the bound on uncovered edges.\n- **Keevash-Sudakov (2004)**: Completely resolved the problem by determining the exact threshold for ALL $n$, not just asymptotically. Their proof uses a careful structural analysis of the non-monochromatic edge set, showing it must be 'almost bipartite'.",
@@ -165,7 +165,7 @@
     "lineCount": 202,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos639Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -94,7 +94,7 @@
     "lineCount": 205,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős and Gyárfás posed this problem in the 1990s, conjecturing that the answer is NO: for every $r$, there should exist a graph with minimum degree $r$ avoiding all $2^k$-length cycles. This belief stemmed from the seeming rigidity of exponential cycle lengths compared to the flexibility available in dense graphs. The problem carries a $1000 Erdős prize, one of his highest bounties, reflecting its perceived difficulty. A breakthrough came from Hong Liu and Richard Montgomery (2020), who proved that for sufficiently large minimum degree $D$, every graph must contain a cycle of length $2^k$. Their proof, published as part of a broader result on even cycle lengths in graphs of large average degree, leverages the regularity method and a deep structural analysis showing that dense graphs contain cycles of every even length in a geometric range $[(\\log \\ell)^8, \\ell]$. Since this range contains a power of 2 whenever $\\ell \\ge 16$, the Erdős-Gyárfás conjecture is disproved for large $r$. However, the exact value of the threshold $D$ is not known, and the critical case $r = 3$ (minimum degree exactly 3) remains completely open. The problem connects to Dirac's theorem (1952), Bondy's pancyclicity theorem (1971), and the broader study of unavoidable cycle lengths in graph theory.",
@@ -273,7 +273,7 @@
     "lineCount": 205,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos64Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 263,
     "assumptions": "1 axiom: dmms_2024 (DMMS 2024 result). 6 sorries.",
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Cycles with More Vertices than Diagonals: An Open Extremal Problem**\n\nA 'diagonal' (or 'chord') of a cycle $C$ in a graph $G$ is an edge of $G$ connecting two non-adjacent vertices of $C$. The condition '$|V(C)| > |\\text{diag}(C)|$' says every cycle has strictly more vertices than chords — a natural sparsity condition on how densely cycles can be chorded.\n\n**Origins**: This problem was posed by Hamburger and Szegedy and appears in Erdős's problem collections. It asks for the maximum number of edges $f(n)$ in an $n$-vertex graph satisfying this condition.\n\n**The Critical Threshold at $k = 5$**: Short cycles ($k \\le 4$) always satisfy the condition: a triangle has 0 possible diagonals, and a $C_4$ has at most 2 (both satisfying $k > \\text{diag}$). But a pentagon $C_5$ has 5 possible diagonals, and $5 \\not> 5$, so a $C_5$ with all diagonals (which is $K_5$) violates the condition. This critical transition at $k = 5$ explains why girth-5 graphs are the natural construction for the lower bound.\n\n**Progress on the Upper Bound**:\n- **Chen-Erdős-Staton (1996)**: Proved $f(n) = O(n^{3/2})$. Their argument uses neighborhood counting: in a dense graph, vertices have large neighborhoods, and the overlap of neighborhoods creates cycles with many chords. This was the state of the art for nearly 30 years.\n- **Draganić-Methuku-Munhá Correia-Sudakov (2024)**: Dramatically improved to $f(n) = O(n(\\log n)^8)$ using sublinear expander techniques. The key insight: any graph with $\\gg n(\\log n)^8$ edges contains a sublinear expander subgraph, and random walks in such expanders efficiently find cycles with many chords.\n\n**The Lower Bound**: Girth-5 graphs (no $C_3$ or $C_4$) trivially satisfy the condition (their cycles have very few diagonals). By the Kővári-Sós-Turán theorem and algebraic constructions (incidence graphs of projective planes, Reiman 1958), such graphs can have $\\Theta(n^{3/2})$ edges. This gives $f(n) = \\Omega(n^{3/2})$.\n\n**The Open Question**: Is $f(n) = o(n)$? Even $f(n) = O(n)$ is unknown. The current bounds $\\Omega(n^{3/2}) \\le f(n) \\le O(n(\\log n)^8)$ leave a gap of $(\\log n)^8/\\sqrt{n}$ in multiplicative terms, which tends to 0 — but this does not resolve the conjecture.",
@@ -197,7 +197,7 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "sorries": 6,
     "path": "Proofs/Erdos642Problem.lean"
   },

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -69,7 +69,7 @@
     "assumptions": "3 axiom(s) and 16 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos644ProblemAristotle.lean"
     ]
@@ -154,7 +154,7 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 19,
-    "definitionCount": 14,
+    "definitionCount": 16,
     "sorries": 16,
     "path": "Proofs/Erdos644Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -69,7 +69,7 @@
     "lineCount": 222,
     "assumptions": "1 axiom: f_tends_to_infinity (isosceles-free point sets must determine superlinearly many distinct distances). See Lean source for complete statement.",
     "theoremCount": 6,
-    "definitionCount": 16
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "**Erdős Problem #657: Isosceles-Free Point Sets and Distinct Distances**\n\n**Origin (1973):** Erdős and Davies formulated this problem in [Er73], asking about the relationship between avoiding isosceles triangles and forcing many distinct distances. A point set $A \\subset \\mathbb{R}^2$ is *isosceles-free* if for every triple $\\{p, q, r\\} \\subset A$, the distances $d(p,q), d(p,r), d(q,r)$ are all distinct.\n\n**The Central Question:** Define $f(n) = \\min\\{|\\Delta(A)|/n : A \\subset \\mathbb{R}^2,\\; |A| = n,\\; A \\text{ isosceles-free}\\}$. Is $f(n) \\to \\infty$? This asks whether the isosceles-free condition forces *superlinearly* many distinct distances.\n\n**The 3-AP Connection:** In one dimension, a set $A \\subset \\mathbb{R}$ is isosceles-free iff it is 3-AP-free (contains no three-term arithmetic progression $a, a+d, a+2d$). This connects the problem to Roth's theorem (1953) and the function $r_3(N)$ measuring the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$.\n\n**Dumitrescu's Breakthrough (2008):** Adrian Dumitrescu established both directions: $(\\log n)^c \\le f(n) \\le 2^{O(\\sqrt{\\log n})}$. The lower bound answers Erdős's question affirmatively ($f(n) \\to \\infty$), while the upper bound uses **Behrend's construction** (1946) of large 3-AP-free sets to build isosceles-free point sets with few distances.\n\n**Kelley-Meka Revolution (2023):** Zander Kelley and Raghu Meka proved the breakthrough bound $r_3(N) \\le N/2^{c(\\log N)^{1/9}}$, dramatically improving all previous 3-AP bounds. Via the 3-AP connection, this translates to $f(n) \\ge 2^{c(\\log n)^{1/9}}$, a super-polylogarithmic lower bound. Bloom and Sisask further refined the constant.\n\n**Straus's Observation:** In high dimensions ($\\mathbb{R}^k$ with $2^k \\ge n$), isosceles-free $n$-point sets can have as few as $n - 1$ distances (using hypercube vertices). This shows the problem is intrinsically low-dimensional.",
@@ -190,7 +190,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 6,
-    "definitionCount": 16,
+    "definitionCount": 17,
     "path": "Proofs/Erdos657Problem.lean"
   },
   "references": [

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 220,
     "assumptions": "1 axiom: moreeOsburnWorks. 1 sorry.",
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "This problem explores the interplay between local constraints (every 4 points determine many distances) and global behavior (few total distances). It belongs to the rich tradition of Erdős distance problems, initiated by Erdős himself in 1946 when he asked for the minimum number of distinct distances determined by $n$ points in the plane — a question that drove combinatorial geometry for decades and was finally resolved by Guth and Katz (2015) who proved the $\\Omega(n/\\log n)$ lower bound using algebraic methods.\n\nErdős believed configurations satisfying the 4-point property with few distances should exist, and that their study would illuminate the structure of extremal distance sets. The solution came from an unexpected direction: algebraic number theory. Moree and Osburn (2006) discovered that points on a 'stretched' integer lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ have the remarkable property of avoiding regular geometric configurations while having few distinct distances. The key insight is that squared distances in this lattice are integers of the form $x^2 + 2y^2$ — a positive definite binary quadratic form of discriminant $-8$.\n\nBy Landau's theorem (1908), the count of positive integers $\\leq N$ representable as $x^2 + Dy^2$ is asymptotic to $C_D \\cdot N/\\sqrt{\\log N}$, where $C_D$ depends on the class number of $\\mathbb{Q}(\\sqrt{-D})$. For $D = 2$, the class number of $\\mathbb{Q}(\\sqrt{-2})$ is 1, and $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$. This controls the distinct distance count.\n\nLund and Sheffer independently found this construction. The 4-point property was verified by classifying all six configurations of 4 points with exactly 2 distances (the square, two types of rhombus, two isosceles trapezoids, and a pentagon subset) and showing the $\\sqrt{2}$-stretching eliminates each. Grayzel later completed the proof by ruling out the pentagon configuration using computer-assisted verification.",
@@ -131,7 +131,7 @@
     "lineCount": 220,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-664/meta.json
+++ b/src/data/proofs/erdos-664/meta.json
@@ -71,7 +71,7 @@
     "lineCount": 236,
     "assumptions": "2 axioms: alon_disproof, alon_construction. Structure fields are object definitions, not assumptions.",
     "theoremCount": 4,
-    "definitionCount": 18
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**Origins: Erdős and Blocking Sets (1981)**\n\nErdős posed Problem #664 in [Er81] (1981), in his influential paper \"On the combinatorial problems I would most like to see solved.\" The question arose from the study of blocking sets in finite geometries and transversal theory: given a family of large sets with small pairwise intersections, can we always find a 'nice' transversal that hits each set without over-concentrating?\n\n**The Near-Linear Setting**\n\nThe hypothesis — $|A_i| > c\\sqrt{n}$ with $|A_i \\cap A_j| \\leq 1$ — defines a *near-linear* (or *almost disjoint*) set family. Such families arise naturally from lines in projective planes, where each line has $q+1 \\approx \\sqrt{n}$ points and any two lines meet in exactly one point. Erdős asked whether the near-linear structure is rigid enough to force the existence of a well-distributed transversal.\n\n**Alon's Disproof via Projective Planes**\n\nNils Alon disproved the conjecture using a probabilistic construction based on the Desarguesian projective plane $\\text{PG}(2,q)$. Starting with the $q^2+q+1$ lines of $\\text{PG}(2,q)$, Alon randomly retains each point on each line independently with probability $\\approx 2/5$. The thinned lines maintain: (1) size $\\approx (2/5)(q+1) > (2/5)\\sqrt{n}$; (2) pairwise intersection $\\leq 1$ (since thinning can only reduce intersections); and crucially (3) any transversal must concentrate $\\Omega(\\log n)$ points on at least one line, by a coupon-collector-type covering argument.\n\n**The Logarithmic Barrier**\n\nThe key quantitative result is that for any blocker $B$, there exists $j$ with $|B \\cap A_j| \\geq \\Omega(\\log n)$. Since $\\log n \\to \\infty$, no uniform constant $k = O_c(1)$ can bound all intersections — answering Erdős's question in the negative. The logarithmic growth is tight: the ESS (Erdős-Simonovits-Sós) construction for Problem #1159 shows that $O(\\log n)$-bounded blocking sets do exist in projective planes.\n\n**The Open Balanced Design Version**\n\nErdős's original 1981 formulation used balanced block designs (every pair in exactly one block) rather than general near-linear families. Since BBDs have strictly more structure, Alon's counterexample doesn't directly apply, and this version remains open. Alon conjectured that the BBD version is also false, but this has not been established.",
@@ -202,7 +202,7 @@
     "lineCount": 236,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos664Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-665/meta.json
+++ b/src/data/proofs/erdos-665/meta.json
@@ -28,7 +28,7 @@
     "assumptions": "5 axioms: h, erdos_larson_bound, prime_power_planes_implies_unbounded, largestPrimeGap, h_correlates_with_prime_gap. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #665, posed by Erdős and Larson, concerns pairwise balanced designs (PBDs) with nearly equal block sizes. A PBD for {1,...,n} is a collection of sets where every pair of elements appears in exactly one block, with block sizes between 2 and n-1. The question asks whether block sizes can all exceed √n - C for some absolute constant C. Erdős and Larson proved block sizes satisfy |Aᵢ| > √n - h(n) where h(n) ≪ n^{1/2-c}. The answer may be negative: Shrikhande and Singhi showed it is 'no' conditional on the prime power conjecture for projective planes. The problem is closely tied to understanding prime gaps in number theory, as near-square primes play a key role in projective plane constructions.",
@@ -138,7 +138,7 @@
     "lineCount": 170,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos665Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 263,
     "assumptions": "1 axiom: chung_1992. 1 sorries.",
     "theoremCount": 4,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
@@ -175,7 +175,7 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 128,
     "assumptions": "1 axiom: k3_limit. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Grünbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n²/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with ≥ k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) ≤ C(n,2)/C(k,2), or asymptotically F_k(n)/n² ≤ 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n² = lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 2.",
@@ -153,7 +153,7 @@
     "lineCount": 128,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos669Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -71,7 +71,7 @@
     "lineCount": 397,
     "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
     "theoremCount": 15,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos671ProblemAristotle.lean"
     ]
@@ -157,7 +157,7 @@
     "lineCount": 397,
     "axiomCount": 3,
     "theoremCount": 15,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "sorries": 7,
     "path": "Proofs/Erdos671Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-674/meta.json
+++ b/src/data/proofs/erdos-674/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos674ProblemAristotle.lean"
     ]
@@ -181,7 +181,7 @@
     "lineCount": 283,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "sorries": 22,
     "path": "Proofs/Erdos674Problem.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Batch sync stale `meta.definitionCount` and `leanFile.definitionCount` for 24 erdos entries (mostly erdos-600s, plus erdos-62/63/64) where the Lean source files added definitions since the last meta update.

## Counts

Counted with the standard mechanic regex:
`^(?:(?:partial|private|protected|noncomputable|unsafe|scoped)\s+)*(def|abbrev|opaque|structure|inductive|class)\s+\w+`
after stripping nested `/-…-/` and `--` comments.

The `partial` modifier is included per the erdos-643 lesson (PR #17335→#17365 revert).

| slug | claimed | actual | delta |
|---|---|---|---|
| erdos-600 | 9 | 10 | +1 |
| erdos-603 | 18 | 19 | +1 |
| erdos-605 | 14 | 15 | +1 |
| erdos-606 | 8 | 10 | +2 |
| erdos-607 | 4 | 6 | +2 |
| erdos-616 | 11 | 12 | +1 |
| erdos-618 | 10 | 11 | +1 |
| erdos-62 | 12 | 13 | +1 |
| erdos-625 | 10 | 12 | +2 |
| erdos-63 | 13 | 14 | +1 |
| erdos-633 | 12 | 15 | +3 |
| erdos-634 | 18 | 20 | +2 |
| erdos-639 | 15 | 16 | +1 |
| erdos-64 | 11 | 12 | +1 |
| erdos-642 | 15 | 16 | +1 |
| erdos-644 | 14 | 16 | +2 |
| erdos-657 | 16 | 17 | +1 |
| erdos-659 | 9 | 10 | +1 |
| erdos-664 | 18 | 19 | +1 |
| erdos-665 | 5 | 6 | +1 |
| erdos-666 | 10 | 11 | +1 |
| erdos-669 | 9 | 10 | +1 |
| erdos-671 | 12 | 13 | +1 |
| erdos-674 | 12 | 13 | +1 |

## Scope

Pure metadata sync. No Lean source changes. 48 lines across 24 files (each file: 2 occurrences in `meta` and `leanFile` blocks).

Excludes erdos-643 (controversial — see prior PR #17335→#17365 revert) and any slugs already covered by open PRs #17519, #17526, #17532.

---
Automated fix by lean-mechanic agent.