### PR TITLE
fix(meta): batch sync definitionCount drift (25 entries, erdos-600-740)

### DIFF
--- a/src/data/proofs/erdos-600/meta.json
+++ b/src/data/proofs/erdos-600/meta.json
@@ -81,7 +81,7 @@
       }
     ],
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1987, building on the influential work of Ruzsa and Szemerédi from 1978 on triple systems. Their seminal paper proved that in any graph on n vertices where every edge is in at least one triangle, if the graph has o(n²) edges then one cannot guarantee that some edge is in many triangles — equivalently, e(n,r) = o(n²) for fixed r. This result is intimately connected to the triangle removal lemma, one of the cornerstones of extremal graph theory.\n\nThe problem asks two specific questions about the fine structure of the function e(n,r). Question 1 asks whether the absolute gap e(n,r+1) - e(n,r) grows without bound as n → ∞, meaning that requiring one additional triangle per edge always costs significantly more edges for large graphs. Question 2 asks whether the ratio e(n,r+1)/e(n,r) → 1, meaning that while the absolute cost may grow, the relative cost becomes negligible. If both are true, the thresholds grow at the same asymptotic rate but with unbounded absolute separation.\n\nThe known bounds place e(n,r) at roughly n²/log n from above and n^{2-o(1)} from below, leaving a significant gap even for the basic asymptotics. Both questions remain completely open. The problem connects to Turán-type extremal theory, the Szemerédi regularity lemma, and the broader study of how graph density forces local substructure.",
@@ -222,7 +222,7 @@
     "lineCount": 167,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos600Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 287,
     "assumptions": "1 axiom (Komjáth's theorem for ≠1 case). The ≠2 upper bound (ℵ₀ suffices for countable I) is now proved.",
     "theoremCount": 6,
-    "definitionCount": 18
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "Erdős Problem #603 originates from Péter Komjáth and was recorded in [Er87], Erdős's 1987 problem compilation. Komjáth, a leading Hungarian combinatorialist working in set-theoretic combinatorics, proposed this as a natural extension of his own theorem: for families of countably infinite sets with pairwise intersection size $\\neq 1$, exactly $\\aleph_0$ colors suffice to avoid monochromatic sets. The $\\neq 2$ variant remains open and is surprisingly resistant to the same techniques.\n\nThe problem sits at the intersection of infinite combinatorics and hypergraph coloring theory. In finite combinatorics, the chromatic number of hypergraphs with restricted edge intersections is well-studied — the Erdős–Ko–Rado theorem (1961) and the Sunflower Lemma (Erdős and Rado, 1960) are foundational results in this area. The infinite setting introduces cardinal arithmetic complications: the answer could be any finite number, $\\aleph_0$, or conceivably larger. The contrast between the $\\neq 1$ case (solved, $C = \\aleph_0$) and the $\\neq 2$ case (open) illustrates how sensitive these problems are to the exact intersection constraint.",
@@ -209,7 +209,7 @@
     "lineCount": 287,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos603Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-605/meta.json
+++ b/src/data/proofs/erdos-605/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 250,
     "assumptions": "1 axiom: erdos_605_superlinear (superlinear growth of D repeated distances for D>1, Swanepoel-Valtr result). Problem solved. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "**The Unit Distance Problem on Spheres**\n\nErdős Problem #605 extends the classical unit distance problem from the plane to spherical surfaces. The unit distance problem asks: among n points in ℝ², how many pairs can be at the same distance? For the plane, the answer grows slightly superlinearly. Erdős asked whether the spherical version also admits superlinear growth.\n\n**Key Historical Developments:**\n\n- **1989**: Erdős, Hickerson, and Pach proved the first superlinear bound u_D(n) ≫ n·log*(n) for spheres of radius D > 1, where log* is the iterated logarithm. This resolved the problem affirmatively, though the growth rate log*(n) is incredibly slow.\n- **2004**: Swanepoel and Valtr significantly improved the lower bound to u_D(n) ≫ n·√(log n), using algebraic constructions on the sphere.\n- **Special case D = √2**: The sphere of radius √2 is uniquely suited for these constructions because it can inscribe a cube. For this radius, the tight bound u(n) ≍ n^{4/3} is achieved, matching the general upper bound from incidence geometry.",
@@ -196,7 +196,7 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos605Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "12 axioms: numDistinctLines, numDistinctLines_collinear, numDistinctLines_general_position, numDistinctLines_min_noncollinear, sylvester_gallai, not_achievable_max_minus_1, not_achievable_max_minus_3, achievable_max_minus_2, erdos_density_result, beck_theorem, szemeredi_trotter_bound, erdos_salamon_characterization. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**The Distinct Lines Problem**\n\nThis classic problem in discrete geometry asks: given $n$ points in the plane, how many distinct lines can they determine? The answer ranges from 1 (all collinear) to $\\binom{n}{2}$ (general position).\n\n**Key Historical Results**:\n- **Sylvester (1893)**: Posed the question of whether $n$ non-collinear points always determine an ordinary line (one with exactly 2 points). This went unresolved for 50 years.\n- **Gallai (1944)**: Proved Sylvester's conjecture using an elegant extremal argument. The result is now called the Sylvester-Gallai theorem.\n- **Motzkin (1951)**: Gave a shorter proof and established that non-collinear points determine at least $n$ distinct lines.\n- **Beck (1983)**: Proved the fundamental dichotomy — either many points are collinear, or the number of lines is $\\Omega(n^2)$.\n- **Szemerédi-Trotter (1983)**: Established the tight incidence bound $O((nm)^{2/3} + n + m)$, a cornerstone of combinatorial geometry.\n- **Erdős (1985)**: Posed the complete characterization problem as Problem #606.\n- **Erdős-Salamon (1988)**: Solved it for large $n$ — all values from $n$ to $\\binom{n}{2}$ are achievable except exactly two: $\\binom{n}{2}-1$ and $\\binom{n}{2}-3$.\n\n**Why These Exceptions?**\n- $\\binom{n}{2}-1$: Three collinear points reduce the line count by $\\binom{3}{2}-1 = 2$, not 1. More generally, $k$ collinear points reduce by $\\binom{k}{2}-1 \\ge 2$. No combination of collinearities can yield a reduction of exactly 1.\n- $\\binom{n}{2}-3$: The possible reductions from collinearities are sums of numbers $\\ge 2$, so the achievable reductions are $\\{0, 2, 4, 5, 6, \\ldots\\}$. Since 3 is not in this set, $\\binom{n}{2}-3$ is excluded.\n\n**Related Theorems**: Beck's theorem, the Szemerédi-Trotter incidence bound, the orchard problem, and the Dirac-Motzkin conjecture (proved by Green-Tao, 2013) are all closely connected.",
@@ -160,7 +160,7 @@
     "lineCount": 243,
     "axiomCount": 12,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "path": "Proofs/Erdos606Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -70,7 +70,7 @@
     "assumptions": "10 axioms: incidenceSignature, incidence_at_least_two, incidence_at_most_n, incidence_pair_constraint, F, F_two, F_three, szemeredi_trotter_incidence, sz_trotter_upper_bound, f_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The Szemerédi-Trotter theorem (1983) is one of the most influential results in combinatorial geometry. Endre Szemerédi and William T. Trotter proved that the number of incidences between $n$ points and $m$ lines in $\\mathbb{R}^2$ is at most $O((nm)^{2/3} + n + m)$, resolving a conjecture of Erdős. This bound is tight, achieved by grid configurations.\n\nProblem #607 applies the Szemerédi-Trotter machinery to a counting problem: given $n$ points $P \\subset \\mathbb{R}^2$, the 'incidence signature' $A = \\{|\\ell \\cap P| : \\ell \\text{ determined by } P\\}$ records how many points lie on each line. Let $F(n)$ count the number of distinct achievable signatures. Erdős asked whether $F(n) \\leq \\exp(O(\\sqrt{n}))$ and noted this would be optimal. Szemerédi and Trotter confirmed the upper bound using their incidence theorem.\n\nThe $\\sqrt{n}$ growth connects to the Hardy-Ramanujan partition asymptotic $p(n) \\sim \\frac{1}{4n\\sqrt{3}} \\exp(\\pi\\sqrt{2n/3})$: signatures correspond to constrained integer partitions of $\\binom{n}{2}$ into parts $\\binom{k_i}{2}$, and the partition count grows as $\\exp(\\Theta(\\sqrt{n}))$. This problem carried a \\$250 prize.",
@@ -192,7 +192,7 @@
     "lineCount": 224,
     "axiomCount": 10,
     "theoremCount": 2,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/Erdos607Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-616/meta.json
+++ b/src/data/proofs/erdos-616/meta.json
@@ -69,7 +69,7 @@
       }
     ],
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's extensive work on extremal hypergraph theory during the late 1980s and early 1990s. The covering number (transversal number) τ(G) is a fundamental parameter in combinatorial optimization, dual to the matching number by König-type theorems. The question of how local structure constrains global covering was formalized by Erdős, Hajnal, and Tuza in their 1991 paper 'Local constraints ensuring small representing sets' published in the *Journal of Combinatorial Theory, Series A* (vol. 58, pp. 78-84). The problem sits at the intersection of Helly-type combinatorics (where local intersection properties imply global ones) and extremal set theory. András Hajnal was Erdős's longtime collaborator on set-theoretic combinatorics, while Zsolt Tuza contributed deep expertise in hypergraph transversals. The problem is reminiscent of the classical Helly theorem (1923), which states that for convex sets in $\\mathbb{R}^d$, pairwise intersection in every $d+1$ sets implies a common point. Here the 'dimension' is replaced by the uniformity $r$, and the threshold $3r-3$ plays the role of $d+1$. The bounds $(3/16)r \\le t(r) \\le (1/5)r$ have stood unchanged since 1991, making this one of the more persistent open problems in extremal hypergraph theory.",
@@ -217,7 +217,7 @@
     "lineCount": 281,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos616Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-618/meta.json
+++ b/src/data/proofs/erdos-618/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 250,
     "assumptions": "2 axioms: main_conjecture_proved, threshold_is_sharp. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #618 was posed by Erdős, Gyárfás, and Ruszinkó in their 1998 Combinatorica paper 'How to decrease the diameter of triangle-free graphs.' For a triangle-free graph G on n vertices, h₂(G) denotes the minimum number of edges that must be added so that the resulting graph has diameter at most 2 while remaining triangle-free. The authors proved that for bounded degree graphs (Δ = O(1)) with no isolated vertices, h₂(G) = O(n log n).\n\nSimonovits showed the complementary direction: there exist triangle-free graphs with maximum degree ≫ √n for which h₂(G) = Θ(n²). This established that √n is a critical threshold for the maximum degree. The central conjecture asked whether Δ = o(√n) always implies h₂(G) = o(n²). Noga Alon resolved this conjecture affirmatively, observing that the problem is essentially identical to Erdős Problem #134.\n\nThe √n threshold arises naturally from the interplay between Mantel's theorem (triangle-free graphs have at most n²/4 edges) and the structural requirements for diameter 2. A graph with degree ≈ √n has roughly n^{3/2} edges, which is the scale at which triangle-free diameter-2 graphs transition between sparse and dense behavior. Alon's proof uses probabilistic and extremal graph theory methods.",
@@ -151,7 +151,7 @@
     "lineCount": 250,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos618Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries: congruent_implies_similar (sorry pending), squares_dissectable, two_squares_dissectable, three_squares_dissectable, six_squares_dissectable, sum_squares_dissectable (all pending explicit dissection constructions with Heron-formula area equality). The Dissection structure was strengthened from a placeholder positivity condition to a proper area-partition requirement via Heron's formula — removing a prior internal inconsistency where trivial constant-function witnesses made IsDissectable provable for all n ≥ 1, contradicting the Beeson axioms.",
     "lineCount": 331,
     "theoremCount": 16,
-    "definitionCount": 18
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "**Triangle Dissection Problem — A Bridge Between Geometry and Number Theory**\n\nPaul Erdős posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erdős and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
@@ -199,7 +199,7 @@
     "lineCount": 331,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "sorries": 6,
     "path": "Proofs/Erdos634Problem.lean"
   },

--- a/src/data/proofs/erdos-639/meta.json
+++ b/src/data/proofs/erdos-639/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 202,
     "assumptions": "3 axioms: ramsey_3_3, keevash_sudakov_main, keevash_sudakov_complete. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Monochromatic Triangle Coverage: From Ramsey Theory to Exact Thresholds**\n\nThis problem sits at the intersection of Ramsey theory and extremal graph theory, asking a natural quantitative question: in a 2-coloring of $K_n$, how many edges can escape all monochromatic triangles?\n\n**The Ramsey Foundation**: Ramsey's theorem (1930) guarantees that any 2-coloring of a sufficiently large complete graph contains a monochromatic clique of prescribed size. For triangles specifically, Greenwood and Gleason (1955) established $R(3,3) = 6$: every 2-coloring of $K_6$ contains a monochromatic triangle. The unique (up to isomorphism) triangle-free 2-coloring of $K_5$ is the cycle $C_5$ in one color with its complement in the other — this is the Ramsey $(3,3)$ graph.\n\n**The Phase Transition**: The value $R(3,3) = 6$ creates a sharp phase transition:\n- For $n \\le 5$: there exist 2-colorings with NO monochromatic triangle at all, so every edge avoids one.\n- For $n = 6$: monochromatic triangles are forced, but at most 10 edges can still avoid them.\n- For $n \\ge 7$: the monochromatic structure becomes dominant, with at most $\\lfloor n^2/4 \\rfloor$ edges escaping.\n\n**Erdős's Conjecture**: Erdős asked whether the balanced bipartite coloring — coloring cross-edges between two equal halves red and within-half edges blue — is extremal. This coloring creates $\\lfloor n^2/4 \\rfloor$ edges (the cross-edges between halves) that form a complete bipartite graph with no triangles in either color among the cross-edges.\n\n**The Solution Path**:\n- **Erdős-Rousseau-Schelp** (unpublished): Proved the conjecture asymptotically for large $n$.\n- **Pyber (1986)**: Showed that $\\lfloor n^2/4 \\rfloor + 2$ monochromatic cliques suffice to cover all edges of any 2-colored $K_n$. As Alon observed, this implies the bound on uncovered edges.\n- **Keevash-Sudakov (2004)**: Completely resolved the problem by determining the exact threshold for ALL $n$, not just asymptotically. Their proof uses a careful structural analysis of the non-monochromatic edge set, showing it must be 'almost bipartite'.",
@@ -165,7 +165,7 @@
     "lineCount": 202,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos639Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 263,
     "assumptions": "1 axiom: dmms_2024 (DMMS 2024 result). 6 sorries.",
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Cycles with More Vertices than Diagonals: An Open Extremal Problem**\n\nA 'diagonal' (or 'chord') of a cycle $C$ in a graph $G$ is an edge of $G$ connecting two non-adjacent vertices of $C$. The condition '$|V(C)| > |\\text{diag}(C)|$' says every cycle has strictly more vertices than chords — a natural sparsity condition on how densely cycles can be chorded.\n\n**Origins**: This problem was posed by Hamburger and Szegedy and appears in Erdős's problem collections. It asks for the maximum number of edges $f(n)$ in an $n$-vertex graph satisfying this condition.\n\n**The Critical Threshold at $k = 5$**: Short cycles ($k \\le 4$) always satisfy the condition: a triangle has 0 possible diagonals, and a $C_4$ has at most 2 (both satisfying $k > \\text{diag}$). But a pentagon $C_5$ has 5 possible diagonals, and $5 \\not> 5$, so a $C_5$ with all diagonals (which is $K_5$) violates the condition. This critical transition at $k = 5$ explains why girth-5 graphs are the natural construction for the lower bound.\n\n**Progress on the Upper Bound**:\n- **Chen-Erdős-Staton (1996)**: Proved $f(n) = O(n^{3/2})$. Their argument uses neighborhood counting: in a dense graph, vertices have large neighborhoods, and the overlap of neighborhoods creates cycles with many chords. This was the state of the art for nearly 30 years.\n- **Draganić-Methuku-Munhá Correia-Sudakov (2024)**: Dramatically improved to $f(n) = O(n(\\log n)^8)$ using sublinear expander techniques. The key insight: any graph with $\\gg n(\\log n)^8$ edges contains a sublinear expander subgraph, and random walks in such expanders efficiently find cycles with many chords.\n\n**The Lower Bound**: Girth-5 graphs (no $C_3$ or $C_4$) trivially satisfy the condition (their cycles have very few diagonals). By the Kővári-Sós-Turán theorem and algebraic constructions (incidence graphs of projective planes, Reiman 1958), such graphs can have $\\Theta(n^{3/2})$ edges. This gives $f(n) = \\Omega(n^{3/2})$.\n\n**The Open Question**: Is $f(n) = o(n)$? Even $f(n) = O(n)$ is unknown. The current bounds $\\Omega(n^{3/2}) \\le f(n) \\le O(n(\\log n)^8)$ leave a gap of $(\\log n)^8/\\sqrt{n}$ in multiplicative terms, which tends to 0 — but this does not resolve the conjecture.",
@@ -197,7 +197,7 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "sorries": 6,
     "path": "Proofs/Erdos642Problem.lean"
   },

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -69,7 +69,7 @@
     "lineCount": 222,
     "assumptions": "1 axiom: f_tends_to_infinity (isosceles-free point sets must determine superlinearly many distinct distances). See Lean source for complete statement.",
     "theoremCount": 6,
-    "definitionCount": 16
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "**Erdős Problem #657: Isosceles-Free Point Sets and Distinct Distances**\n\n**Origin (1973):** Erdős and Davies formulated this problem in [Er73], asking about the relationship between avoiding isosceles triangles and forcing many distinct distances. A point set $A \\subset \\mathbb{R}^2$ is *isosceles-free* if for every triple $\\{p, q, r\\} \\subset A$, the distances $d(p,q), d(p,r), d(q,r)$ are all distinct.\n\n**The Central Question:** Define $f(n) = \\min\\{|\\Delta(A)|/n : A \\subset \\mathbb{R}^2,\\; |A| = n,\\; A \\text{ isosceles-free}\\}$. Is $f(n) \\to \\infty$? This asks whether the isosceles-free condition forces *superlinearly* many distinct distances.\n\n**The 3-AP Connection:** In one dimension, a set $A \\subset \\mathbb{R}$ is isosceles-free iff it is 3-AP-free (contains no three-term arithmetic progression $a, a+d, a+2d$). This connects the problem to Roth's theorem (1953) and the function $r_3(N)$ measuring the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$.\n\n**Dumitrescu's Breakthrough (2008):** Adrian Dumitrescu established both directions: $(\\log n)^c \\le f(n) \\le 2^{O(\\sqrt{\\log n})}$. The lower bound answers Erdős's question affirmatively ($f(n) \\to \\infty$), while the upper bound uses **Behrend's construction** (1946) of large 3-AP-free sets to build isosceles-free point sets with few distances.\n\n**Kelley-Meka Revolution (2023):** Zander Kelley and Raghu Meka proved the breakthrough bound $r_3(N) \\le N/2^{c(\\log N)^{1/9}}$, dramatically improving all previous 3-AP bounds. Via the 3-AP connection, this translates to $f(n) \\ge 2^{c(\\log n)^{1/9}}$, a super-polylogarithmic lower bound. Bloom and Sisask further refined the constant.\n\n**Straus's Observation:** In high dimensions ($\\mathbb{R}^k$ with $2^k \\ge n$), isosceles-free $n$-point sets can have as few as $n - 1$ distances (using hypercube vertices). This shows the problem is intrinsically low-dimensional.",
@@ -190,7 +190,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 6,
-    "definitionCount": 16,
+    "definitionCount": 17,
     "path": "Proofs/Erdos657Problem.lean"
   },
   "references": [

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 220,
     "assumptions": "1 axiom: moreeOsburnWorks. 1 sorry.",
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "This problem explores the interplay between local constraints (every 4 points determine many distances) and global behavior (few total distances). It belongs to the rich tradition of Erdős distance problems, initiated by Erdős himself in 1946 when he asked for the minimum number of distinct distances determined by $n$ points in the plane — a question that drove combinatorial geometry for decades and was finally resolved by Guth and Katz (2015) who proved the $\\Omega(n/\\log n)$ lower bound using algebraic methods.\n\nErdős believed configurations satisfying the 4-point property with few distances should exist, and that their study would illuminate the structure of extremal distance sets. The solution came from an unexpected direction: algebraic number theory. Moree and Osburn (2006) discovered that points on a 'stretched' integer lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ have the remarkable property of avoiding regular geometric configurations while having few distinct distances. The key insight is that squared distances in this lattice are integers of the form $x^2 + 2y^2$ — a positive definite binary quadratic form of discriminant $-8$.\n\nBy Landau's theorem (1908), the count of positive integers $\\leq N$ representable as $x^2 + Dy^2$ is asymptotic to $C_D \\cdot N/\\sqrt{\\log N}$, where $C_D$ depends on the class number of $\\mathbb{Q}(\\sqrt{-D})$. For $D = 2$, the class number of $\\mathbb{Q}(\\sqrt{-2})$ is 1, and $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$. This controls the distinct distance count.\n\nLund and Sheffer independently found this construction. The 4-point property was verified by classifying all six configurations of 4 points with exactly 2 distances (the square, two types of rhombus, two isosceles trapezoids, and a pentagon subset) and showing the $\\sqrt{2}$-stretching eliminates each. Grayzel later completed the proof by ruling out the pentagon configuration using computer-assisted verification.",
@@ -131,7 +131,7 @@
     "lineCount": 220,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-664/meta.json
+++ b/src/data/proofs/erdos-664/meta.json
@@ -71,7 +71,7 @@
     "lineCount": 236,
     "assumptions": "2 axioms: alon_disproof, alon_construction. Structure fields are object definitions, not assumptions.",
     "theoremCount": 4,
-    "definitionCount": 18
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**Origins: Erdős and Blocking Sets (1981)**\n\nErdős posed Problem #664 in [Er81] (1981), in his influential paper \"On the combinatorial problems I would most like to see solved.\" The question arose from the study of blocking sets in finite geometries and transversal theory: given a family of large sets with small pairwise intersections, can we always find a 'nice' transversal that hits each set without over-concentrating?\n\n**The Near-Linear Setting**\n\nThe hypothesis — $|A_i| > c\\sqrt{n}$ with $|A_i \\cap A_j| \\leq 1$ — defines a *near-linear* (or *almost disjoint*) set family. Such families arise naturally from lines in projective planes, where each line has $q+1 \\approx \\sqrt{n}$ points and any two lines meet in exactly one point. Erdős asked whether the near-linear structure is rigid enough to force the existence of a well-distributed transversal.\n\n**Alon's Disproof via Projective Planes**\n\nNils Alon disproved the conjecture using a probabilistic construction based on the Desarguesian projective plane $\\text{PG}(2,q)$. Starting with the $q^2+q+1$ lines of $\\text{PG}(2,q)$, Alon randomly retains each point on each line independently with probability $\\approx 2/5$. The thinned lines maintain: (1) size $\\approx (2/5)(q+1) > (2/5)\\sqrt{n}$; (2) pairwise intersection $\\leq 1$ (since thinning can only reduce intersections); and crucially (3) any transversal must concentrate $\\Omega(\\log n)$ points on at least one line, by a coupon-collector-type covering argument.\n\n**The Logarithmic Barrier**\n\nThe key quantitative result is that for any blocker $B$, there exists $j$ with $|B \\cap A_j| \\geq \\Omega(\\log n)$. Since $\\log n \\to \\infty$, no uniform constant $k = O_c(1)$ can bound all intersections — answering Erdős's question in the negative. The logarithmic growth is tight: the ESS (Erdős-Simonovits-Sós) construction for Problem #1159 shows that $O(\\log n)$-bounded blocking sets do exist in projective planes.\n\n**The Open Balanced Design Version**\n\nErdős's original 1981 formulation used balanced block designs (every pair in exactly one block) rather than general near-linear families. Since BBDs have strictly more structure, Alon's counterexample doesn't directly apply, and this version remains open. Alon conjectured that the BBD version is also false, but this has not been established.",
@@ -202,7 +202,7 @@
     "lineCount": 236,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos664Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-665/meta.json
+++ b/src/data/proofs/erdos-665/meta.json
@@ -28,7 +28,7 @@
     "assumptions": "5 axioms: h, erdos_larson_bound, prime_power_planes_implies_unbounded, largestPrimeGap, h_correlates_with_prime_gap. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #665, posed by Erdős and Larson, concerns pairwise balanced designs (PBDs) with nearly equal block sizes. A PBD for {1,...,n} is a collection of sets where every pair of elements appears in exactly one block, with block sizes between 2 and n-1. The question asks whether block sizes can all exceed √n - C for some absolute constant C. Erdős and Larson proved block sizes satisfy |Aᵢ| > √n - h(n) where h(n) ≪ n^{1/2-c}. The answer may be negative: Shrikhande and Singhi showed it is 'no' conditional on the prime power conjecture for projective planes. The problem is closely tied to understanding prime gaps in number theory, as near-square primes play a key role in projective plane constructions.",
@@ -138,7 +138,7 @@
     "lineCount": 170,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos665Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 263,
     "assumptions": "1 axiom: chung_1992. 1 sorries.",
     "theoremCount": 4,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
@@ -175,7 +175,7 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 128,
     "assumptions": "1 axiom: k3_limit. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Grünbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n²/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with ≥ k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) ≤ C(n,2)/C(k,2), or asymptotically F_k(n)/n² ≤ 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n² = lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 2.",
@@ -153,7 +153,7 @@
     "lineCount": 128,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos669Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-709/meta.json
+++ b/src/data/proofs/erdos-709/meta.json
@@ -74,7 +74,7 @@
     "lineCount": 230,
     "assumptions": "4 axioms: f (extremal function f(n)), lower_bound_log (f(n) ≥ (log n)^c for some c > 0), upper_bound_sqrt (f(n) ≤ C·√n), g (related function g(n) from Problem 708). 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "**The Interval Covering Problem**\n\nErdős and Surányi posed this problem in their 1959 paper \"Bemerkungen zu einer Aufgabe eines mathematischen Wettbewerbs\" (Remarks on a problem from a mathematical competition), published in Matematikai Lapok. The question asks: given a set A of n positive integers all at least 2, how long must an interval of consecutive integers be to guarantee we can find n distinct multiples, one for each element of A?\n\n**The Function f(n) and Its Bounds**\n\nThe function f(n) is defined as the minimal k such that any interval of k·max(A) consecutive integers contains distinct x₁,...,xₙ with aᵢ | xᵢ, for every valid n-element set A. Erdős and Surányi proved that (log n)^c ≪ f(n) ≪ √n for some constant c > 0. The lower bound uses probabilistic arguments with sets of distinct primes: by the Chinese Remainder Theorem, multiples of different primes are nearly independent, so short intervals can fail to provide enough distinct multiples. The upper bound follows from a greedy covering argument, or equivalently from Hall's marriage theorem: in a long enough interval, each element has enough multiples to guarantee a system of distinct representatives.\n\n**The Open Gap and Related Work**\n\nThe gap between (log n)^c and √n is substantial — for n = 10⁶, this spans roughly two orders of magnitude. Erdős revisited the problem in his 1992 survey [Er92c] on favourite combinatorics problems. The closely related Problem 708 asks about the function g(n), the minimal size of a covering subset rather than an interval length. Both problems illuminate the structure of divisibility patterns but from different geometric perspectives.",
@@ -194,7 +194,7 @@
     "lineCount": 230,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/Erdos709Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-712/meta.json
+++ b/src/data/proofs/erdos-712/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 218,
     "assumptions": "5 axioms: turan_theorem, K43_lower_bound, turan_density_positive, kruskal_katona_upper, erdos_712_open. See Lean source for complete statements.",
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The hypergraph Turán problem is one of the most famous and longstanding open questions in extremal combinatorics. For ordinary graphs (r=2), Turán completely solved the problem in 1941: the maximum number of edges in a K_k-free graph on n vertices is achieved by the balanced complete (k-1)-partite graph, giving the density (1-1/(k-1))/2. This elegant result launched the field of extremal graph theory.\n\nFor hypergraphs with uniformity r > 2, the situation becomes dramatically harder. Even the simplest open case — the density π_3(K_4^3) for 3-uniform hypergraphs avoiding a complete 4-clique — has resisted all attacks for over 80 years. Turán conjectured that the extremal construction is the balanced 4-partition hypergraph T(n,4,3), which gives density 5/9. The best known upper bound, due to Razborov's flag algebra method (2010), is approximately 0.5616, leaving a significant gap.\n\nErdős considered this problem so important that he offered a $500 prize for determining the Turán density for any single case with k > r > 2, and $1000 for resolving the entire family. No case has been solved. The problem connects to Ramsey theory, coding theory, and the emerging field of flag algebras, which provides the strongest computational bounds but has not been able to close any gaps to exact values.",
@@ -172,7 +172,7 @@
     "lineCount": 218,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos712Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-716/meta.json
+++ b/src/data/proofs/erdos-716/meta.json
@@ -27,7 +27,7 @@
     "lineCount": 237,
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "This problem was conjectured by Brown, Erdős, and Sós in 1973 as part of their systematic study of extremal hypergraph problems. The (6,3)-problem sits within the broader Brown-Erdős-Sós conjecture (1973), which posits that f^(3)(n; k+3, k) = o(n²) for all k ≥ 3 — that is, k hyperedges spanning at most k+3 vertices must occur subquadratically often. The k=3 case (asking about 3 edges on 6 vertices) became known as the (6,3)-problem and was the first non-trivial case to be resolved.\n\nImre Ruzsa and Endre Szemerédi solved it in 1978 using Szemerédi's regularity lemma (published 1975), which partitions a graph's vertices into roughly equal parts with controlled edge densities between them. Their key tool was the Triangle Removal Lemma: a graph with few triangles (o(n³)) can be made triangle-free by removing few edges (o(n²)). Applying this to a cleverly constructed auxiliary graph gives the subquadratic bound. The tightness is established by Behrend's 1946 construction of large 3-AP-free sets, which Ruzsa translated into large (6,3)-free hypergraphs. The full Brown-Erdős-Sós conjecture was finally proved by Delcourt and Postle in 2024 using absorption methods.",
@@ -145,7 +145,7 @@
     "lineCount": 237,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos716Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -80,7 +80,7 @@
     "lineCount": 546,
     "assumptions": "1 axiom: erdos_sauer_conjecture (OPEN problem). Turán's theorem for graphs fully proved via Mathlib bridge.",
     "theoremCount": 20,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Turán's theorem (1941) determines the maximum number of edges in a triangle-free graph on $n$ vertices: $\\text{ex}_2(n; K_3) = \\lfloor n^2/4 \\rfloor$, achieved by the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. This foundational result of extremal graph theory was extended by the Erdős-Stone-Simonovits theorem (1966) to determine $\\text{ex}_2(n; H)$ for all non-bipartite graphs $H$.\n\nFor $r$-uniform hypergraphs with $r \\ge 3$, the Turán problem becomes dramatically harder. Even $\\text{ex}_3(n; K_4^3)$ — the 3-uniform analogue of the triangle Turán number — is a central open problem. Turán conjectured the extremal hypergraph is a specific 3-partite construction with $(5/9 + o(1))\\binom{n}{3}$ edges, but this remains unproven.\n\nErdős and Sauer (1981) posed Problem #719: can every $r$-uniform hypergraph on $n$ vertices be decomposed into at most $\\text{ex}_r(n; K_{r+1}^r)$ edge-disjoint pieces, where each piece is either a single $r$-edge ($K_r^r$) or a complete $(r+1)$-clique ($K_{r+1}^r$)? The conjecture connects two deep areas: Turán-type extremal theory (bounding edge counts) and decomposition theory (partitioning edge sets into canonical structures).\n\nFor $r = 2$, the conjecture asks whether every graph on $n$ vertices can be written as at most $\\lfloor n^2/4 \\rfloor$ edges and triangles — already non-trivial. For $r \\ge 3$, the conjecture is doubly open: the decomposition bound depends on a Turán number that is itself unknown. The problem remains OPEN.",
@@ -168,7 +168,7 @@
     "lineCount": 546,
     "axiomCount": 1,
     "theoremCount": 20,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "sorries": 0,
     "path": "Proofs/Erdos719Problem.lean"
   },

--- a/src/data/proofs/erdos-722/meta.json
+++ b/src/data/proofs/erdos-722/meta.json
@@ -53,7 +53,7 @@
     "lineCount": 302,
     "assumptions": "3 axioms: fano_plane_exists, wilson_theorem_r2, keevash_theorem. 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Steiner systems** are among the most studied objects in combinatorial design theory. A Steiner system $S(r,k,n)$ is a collection of $k$-subsets (blocks) of an $n$-element set such that every $r$-subset appears in exactly one block.\n\n**Jakob Steiner** (1796–1863) introduced these systems, though **Thomas Kirkman** (1806–1895) studied them first. Kirkman's 1847 paper 'On a problem in combinations' solved the case $S(2,3,n)$: Steiner triple systems exist if and only if $n \\equiv 1$ or $3 \\pmod{6}$ and $n \\geq 7$. His famous 'schoolgirl problem' (1850) asks for a resolvable $S(2,3,15)$.\n\nThe **Fano plane** $S(2,3,7)$ is the smallest nontrivial Steiner triple system, with 7 points and 7 lines. It is also the projective plane $\\mathrm{PG}(2,2)$ over $\\mathbb{F}_2$, connecting design theory to finite geometry.\n\n**Haim Hanani** (1961) extended Kirkman's work in 'The existence and construction of balanced incomplete block designs' (*Ann. Math. Statist.*), characterizing existence for $S(3,4,n)$, $S(2,4,n)$, and $S(2,5,n)$.\n\n**Richard M. Wilson** (1972) resolved the entire $r = 2$ case in 'An existence theory for pairwise balanced designs' (*J. Combinatorial Theory Ser. A*), proving that $S(2,k,n)$ exists for all sufficiently large $n$ satisfying the divisibility conditions. This established the foundations of existence theory for combinatorial designs.\n\n**Peter Keevash** (2014) achieved the breakthrough in 'The existence of designs' (arXiv:1401.3665), proving that $S(r,k,n)$ exists for ALL $r < k$ when $n$ is sufficiently large and the divisibility conditions hold. His **randomized algebraic construction** combined probabilistic methods (random greedy, nibble), algebraic structures (Latin squares, quasirandom clique decompositions), and absorbing techniques to handle the general case. This resolved a century-old open problem and was recognized as one of the most important results in combinatorics of the decade.",
@@ -210,7 +210,7 @@
     "lineCount": 302,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos722Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 150,
     "assumptions": "3 axioms: godsil_mckay_bounds (permanent-based bounds on L(k,n)), L_1_n (L(1,n) = n!), derangements (subfactorial D(n) for L(2,n) formula).",
     "theoremCount": 1,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "leanFile": {
     "path": "Proofs/Erdos725Problem.lean",
@@ -104,7 +104,7 @@
     ],
     "axiomCount": 3,
     "sorries": 0,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "theoremCount": 1
   },
   "overview": {

--- a/src/data/proofs/erdos-734/meta.json
+++ b/src/data/proofs/erdos-734/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 206,
     "assumptions": "2 axioms: deBruijn_erdos, projective_plane_exists. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #734 in his 1981 paper 'On the combinatorial problems which I would most like to see solved.' He asked whether, for all large n, there exists a non-trivial pairwise balanced block design (PBD) on n points where every block size t appears in at most O(n^{1/2}) blocks. Erdős wrote that this would 'probably not be very difficult to prove' but admitted he had been unsuccessful.\n\nThe foundational result for this problem is the de Bruijn-Erdős theorem (1948), which states that any non-trivial PBD on n points has at least n blocks. By a pigeonhole argument, since block sizes range from 2 to n, at least one size must appear with frequency proportional to √n. The question is whether ALL sizes can be kept at this threshold simultaneously.\n\nClassical constructions like projective and affine planes fail the frequency condition because they have uniform block size — all blocks are the same size, concentrating frequency in a single value. No construction achieving the O(√n) bound for all sizes is known, and the problem remains open. It connects to broader questions in combinatorial design theory about how block sizes can be distributed in balanced structures.",
@@ -174,7 +174,7 @@
     "lineCount": 206,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos734Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -62,7 +62,7 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Gyárfás conjectured in 1975 that for every tree $T$, there exists $f(T)$ such that every graph with chromatic number $\\geq f(T)$ contains $T$ as an induced subgraph. Problem 738, popularized by Erdős, focuses on the triangle-free case: if $G$ is triangle-free with $\\chi(G) = \\infty$, must $G$ contain every finite tree as an induced subgraph? This is stronger than the general conjecture because triangle-freeness constrains the graph's local structure to be tree-like (no short cycles), making induced tree copies more plausible. Kierstead and Penrice (1994) proved the conjecture for trees of radius $\\leq 2$, Scott (1997) extended it to caterpillars (trees where all vertices are within distance 1 of a central path), and Chudnovsky, Scott, and Seymour (2020) made progress on subdivisions. The problem connects to the broader theory of $\\chi$-bounded graph classes initiated by Gyárfás.",
@@ -169,7 +169,7 @@
     "lineCount": 420,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos738Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -52,7 +52,7 @@
       "girth_implies_odd_avoidance: girth > 2r implies avoidance of all odd cycles of length ≤ r"
     ],
     "theoremCount": 5,
-    "definitionCount": 21
+    "definitionCount": 22
   },
   "overview": {
     "historicalContext": "Erdős and Hajnal posed this problem about preserving chromatic number while avoiding short odd cycles. It first appeared in Erdős's 1981 paper 'On the combinatorial problems which I would most like to see solved' ([Er81]), where he listed it among approximately 50 problems he considered most important in combinatorics. Rödl proved the case 𝔪 = ℵ₀ and r = 3 (triangle-free) in 1977, using a sophisticated probabilistic argument involving random vertex selection. The problem also appears in Erdős's 1995 survey [Er95d] on combinatorial set theory. The general case and the threshold function f_r(𝔪) remain open, connecting infinite combinatorics, set theory, and structural graph theory. The problem sits at the intersection of Ramsey theory and chromatic graph theory, building on Erdős's seminal 1959 result that graphs with arbitrarily high girth and chromatic number exist.",
@@ -199,7 +199,7 @@
     "lineCount": 341,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 21,
+    "definitionCount": 22,
     "path": "Proofs/Erdos740Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Batch-syncs `meta.definitionCount` and `leanFile.definitionCount` to match actual declaration counts in the underlying Lean source files. 25 erdos-600..740 entries.

## Evidence

For each entry, both `meta.definitionCount` and `leanFile.definitionCount` previously matched each other but disagreed with the Lean source. After the fix, both values match the file.

Counting convention (per [feedback_mechanic_def_counting.md](https://github.com/rjwalters/lean-genius/blob/main/.claude/memory/feedback_mechanic_def_counting.md)): `def + abbrev + opaque + structure + inductive + class` (NOT `instance`) with `partial/private/protected/noncomputable/unsafe/scoped` modifiers, comments stripped (nested block comments handled).

| slug | before | after | delta |
| --- | --- | --- | --- |
| erdos-600 | 9 | 10 | +1 |
| erdos-603 | 18 | 19 | +1 |
| erdos-605 | 14 | 15 | +1 |
| erdos-606 | 8 | 10 | +2 |
| erdos-607 | 4 | 6 | +2 |
| erdos-616 | 11 | 12 | +1 |
| erdos-618 | 10 | 11 | +1 |
| erdos-634 | 18 | 20 | +2 |
| erdos-639 | 15 | 16 | +1 |
| erdos-642 | 15 | 16 | +1 |
| erdos-657 | 16 | 17 | +1 |
| erdos-659 | 9 | 10 | +1 |
| erdos-664 | 18 | 19 | +1 |
| erdos-665 | 5 | 6 | +1 |
| erdos-666 | 10 | 11 | +1 |
| erdos-669 | 9 | 10 | +1 |
| erdos-709 | 6 | 8 | +2 |
| erdos-712 | 10 | 11 | +1 |
| erdos-716 | 12 | 13 | +1 |
| erdos-719 | 8 | 10 | +2 |
| erdos-722 | 10 | 11 | +1 |
| erdos-725 | 10 | 11 | +1 |
| erdos-734 | 6 | 7 | +1 |
| erdos-738 | 10 | 11 | +1 |
| erdos-740 | 21 | 22 | +1 |

Disjoint from currently-open mechanic PRs (#17518, #17519, #17521, #17526, #17530, #17532, #17535).

Each meta.json gets a minimal 2-line diff (one in the `meta` block, one in the `leanFile` block). All other fields unchanged.

---
Automated fix by lean-mechanic agent.