### PR TITLE
research(sperner-ndim-mathlib-oq-02): S22 — Sperner-restricted IsDoor ↔ color-change bridge (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1909,6 +1909,79 @@ lemma isDoor_dim_two_iff
       rw [← h1_cast] at hi_color
       exact ⟨i, hi_ne, hi_color⟩
 
+/-- Helper: in `Fin 3`, given two distinct indices `i₁, i₂` both
+differing from a third index `k`, every fourth index `j` differing
+from `k` equals one of `i₁` or `i₂`. Used to convert "every non-`k`
+vertex" into "the two specific non-`k` vertices `i₁` and `i₂`" in the
+proof of `isDoor_dim_two_iff_color_change_of_no_color_two`.
+
+Proved by full enumeration over `Fin 3` with `decide`; all 81 (k, i₁,
+i₂, j)-combinations are eliminated by the four hypotheses. -/
+private lemma fin_three_other_eq :
+    ∀ k i₁ i₂ j : Fin 3, i₁ ≠ k → i₂ ≠ k → i₁ ≠ i₂ → j ≠ k →
+      j = i₁ ∨ j = i₂ := by
+  decide
+
+/-- Sperner-restricted specialization of `isDoor_dim_two_iff`: when
+neither non-`k` vertex of `s` carries color `2` (which the Sperner
+condition automatically forces whenever both lie on geometric face
+`2`), the door condition collapses to "the two non-`k` vertices have
+different colors".
+
+Concretely, for any two distinct non-`k` indices `i₁ ≠ i₂` (which
+together exhaust the non-`k` vertices of a 2-cell), `IsDoor c K s k`
+is equivalent to `c (K.vertex s i₁) ≠ c (K.vertex s i₂)`.
+
+This is the abstract bridge consumed by `_hLastFace` discharges of
+n = 2 Sperner-on-Triangulation instances. The hypothesis `h_no2`
+typically arises by combining `IsSpernerColoring c onFace` with the
+assumption that both non-`k` vertices satisfy `onFace v 2`. The
+conclusion is in the canonical "color-change" shape that matches the
+`g k ≠ g (k + 1)` predicate of the diagonal-path coloring used in
+`face2_path_odd`. -/
+lemma isDoor_dim_two_iff_color_change_of_no_color_two
+    {V : Type*} [DecidableEq V] (K : CellComplex V 2)
+    (c : V → Fin 3) (s : K.Cell) (k : Fin 3)
+    (h_no2 : ∀ i : Fin 3, i ≠ k → c (K.vertex s i) ≠ (2 : Fin 3))
+    {i₁ i₂ : Fin 3} (h_i₁_ne : i₁ ≠ k) (h_i₂_ne : i₂ ≠ k)
+    (h_i_distinct : i₁ ≠ i₂) :
+    CellComplex.IsDoor c K s k ↔
+      c (K.vertex s i₁) ≠ c (K.vertex s i₂) := by
+  rw [isDoor_dim_two_iff]
+  have hc1_no2 : c (K.vertex s i₁) ≠ (2 : Fin 3) := h_no2 i₁ h_i₁_ne
+  have hc2_no2 : c (K.vertex s i₂) ≠ (2 : Fin 3) := h_no2 i₂ h_i₂_ne
+  refine ⟨fun ⟨h0, h1⟩ => ?_, fun h_ne => ?_⟩
+  · -- Forward direction (contrapositive): if `c (vertex s i₁)` and
+    -- `c (vertex s i₂)` were equal, the existence of color-`0` and
+    -- color-`1` witnesses among non-`k` vertices `= {i₁, i₂}` would
+    -- force `0 = 1`, contradicting `decide`.
+    intro h_eq
+    obtain ⟨j₀, hj₀_ne, hj₀_color⟩ := h0
+    obtain ⟨j₁, hj₁_ne, hj₁_color⟩ := h1
+    have hj₀_cases :=
+      fin_three_other_eq k i₁ i₂ j₀ h_i₁_ne h_i₂_ne h_i_distinct hj₀_ne
+    have hj₁_cases :=
+      fin_three_other_eq k i₁ i₂ j₁ h_i₁_ne h_i₂_ne h_i_distinct hj₁_ne
+    have h_j_colors_eq : c (K.vertex s j₀) = c (K.vertex s j₁) := by
+      rcases hj₀_cases with rfl | rfl
+      · rcases hj₁_cases with rfl | rfl
+        · rfl
+        · exact h_eq
+      · rcases hj₁_cases with rfl | rfl
+        · exact h_eq.symm
+        · rfl
+    rw [hj₀_color, hj₁_color] at h_j_colors_eq
+    exact absurd h_j_colors_eq (by decide)
+  · -- Reverse direction: distinct colors `c (vertex s i₁), c (vertex s i₂)`
+    -- with both `≠ 2` forces one to be `0` and the other to be `1`,
+    -- supplying the two existential witnesses required by
+    -- `isDoor_dim_two_iff`. Pure `Fin 3` case enumeration via `decide`.
+    have h_pair : ∀ x y : Fin 3, x ≠ 2 → y ≠ 2 → x ≠ y →
+        (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 0) := by decide
+    rcases h_pair _ _ hc1_no2 hc2_no2 h_ne with ⟨hc1, hc2⟩ | ⟨hc1, hc2⟩
+    · exact ⟨⟨i₁, h_i₁_ne, hc1⟩, ⟨i₂, h_i₂_ne, hc2⟩⟩
+    · exact ⟨⟨i₂, h_i₂_ne, hc2⟩, ⟨i₁, h_i₁_ne, hc1⟩⟩
+
 end SimplicialAdjFnHelper
 
 -- ============================================================

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,16 +2,58 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-08 (Iteration 21, researcher-12)
-**Iteration**: 21
+**Last Updated**: 2026-05-09 (Iteration 22, researcher-10)
+**Iteration**: 22
 
 ## Current Focus
 
-Session 21A (this iteration, researcher-12, 2026-05-08, build
-pending): Added the **t1-side forward extraction lemma** for
-`_hLastFace`, eliminating the two non-diagonal drop cases by
-inconsistent face-2 sums and identifying the diagonal-drop case
-with `b ∈ satDiagBases N`.
+Session 22 (this iteration, researcher-10, 2026-05-09, build
+pending): Added the **Sperner-restricted IsDoor ↔ color-change**
+bridge in `SimplicialAdjFnHelper`, specializing S21B's generic
+`isDoor_dim_two_iff` to the case where neither non-`k` vertex carries
+color `2` (which the Sperner condition forces whenever both lie on
+geometric face `2`). The conclusion is in the canonical "the two
+non-`k` vertices have different colors" shape, ready to match
+`face2_path_odd`'s `g k ≠ g (k+1)` predicate.
+
+New lemmas in `SimplicialAdjFnHelper` (~73 lines added to
+`SpernerFreudenthalSimplex.lean` after `isDoor_dim_two_iff`):
+
+* `fin_three_other_eq` (private): For `i₁, i₂ : Fin 3` distinct and
+  both `≠ k`, every `j : Fin 3` with `j ≠ k` satisfies `j = i₁ ∨ j = i₂`.
+  Pure `Fin 3` enumeration via `decide`.
+* `isDoor_dim_two_iff_color_change_of_no_color_two`:
+  `IsDoor c K s k ↔ c (K.vertex s i₁) ≠ c (K.vertex s i₂)` under
+  hypothesis `h_no2 : ∀ i ≠ k, c (K.vertex s i) ≠ 2` for any choice
+  of two distinct non-`k` indices `i₁, i₂`. Forward direction is the
+  contrapositive (equal colors at `i₁, i₂` would force the color-`0`
+  and color-`1` witnesses of `isDoor_dim_two_iff` to share a vertex,
+  hence `0 = 1`). Reverse direction: distinct colors `≠ 2` are
+  necessarily `0` and `1` in some order, supplying both witnesses.
+
+Together with S21B's `isDoor_dim_two_iff` (PR #17502, merged) and
+S21A's `t1_lastFace_implies_satDiag` (PR #17464, merged), the n=2
+`_hLastFace` discharge for `simData2 N` now has all abstract bridges
+in place. The remaining S23+ work is the concrete bijection between
+the `_hLastFace` filter and `(Finset.range N).filter (fun k => g k ≠ g (k+1))`,
+parametrized by `b.1` from `satDiagBases N` (since for
+`b ∈ satDiagBases N` with `b.1 + b.2 + 1 = N`, the diagonal endpoints
+`(b.1, b.2+1)` and `(b.1+1, b.2)` correspond to path positions
+`b.1` and `b.1+1` of the index-`k → (k, N-k)` face-2 path).
+
+S22 keeps the iterative-PR cadence small (one self-contained
+abstract bridge lemma + supporting `decide` helper) to reduce
+merge-conflict risk and keep any build regressions narrow, given
+the persistent `proofs/.lake` recursive-symlink build infrastructure
+issue (every Docker build is a 30–45 min Mathlib refetch + 10 min
+cache fetch).
+
+## Previous Focus
+
+Session 21A (PR #17464, merged): Added the **t1-side forward
+extraction lemma** for `_hLastFace`, eliminating the two non-diagonal
+drop cases by inconsistent face-2 sums and identifying the
+diagonal-drop case with `b ∈ satDiagBases N`.
 
 New private lemma in a new `N2LastFaceExtract` section appended
 to `SpernerFreudSimp` (84 lines added to
@@ -455,11 +497,21 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
   parametrization, cardinality = N, endpoints in range,
   endpoints on face 2, t1 ∈ topSimps2 alias).
 - `N2LastFaceExtract` t1-side `_hLastFace` forward extraction
-  (S21A, this session, build pending): `t1_lastFace_implies_satDiag`
+  (S21A, PR #17464, merged): `t1_lastFace_implies_satDiag`
   identifies `b ∈ satDiagBases N` and the dropped vertex = `b`
   for any `(t1 b, k)` with face-2 condition; eliminates the
   vertical-edge and horizontal-edge drop cases by inconsistent
   face-2 sums.
+- `SimplicialAdjFnHelper.isDoor_dim_two_iff` (S21B,
+  PR #17502, merged): generic d=2 IsDoor characterization
+  (colors `0` and `1` both appear among non-`k` vertices).
+- `SimplicialAdjFnHelper.isDoor_dim_two_iff_color_change_of_no_color_two`
+  + `fin_three_other_eq` (S22, this session, build pending):
+  Sperner-restricted specialization of S21B; under
+  `∀ i ≠ k, c (vertex s i) ≠ 2`, the door condition is
+  `c (vertex s i₁) ≠ c (vertex s i₂)` for any two distinct
+  non-`k` indices. Bridges to `face2_path_odd`'s color-change
+  predicate.
 - `sperner_panchromatic_two` (n=2): 1 sorry remaining
 - n≥3: future work
 
@@ -480,15 +532,27 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
    boundary t1 cells). ~80 lines of pure case work.
 3. `_hLowerDim` — done generically by S15 helper
 4. `_hLastFace` — IN PROGRESS:
-    * S20 (PR #17426): `satDiagBases N` foundation + count = N.
-    * S21A (this session): t1-side forward extraction
+    * S20 (PR #17426, merged): `satDiagBases N` foundation +
+      count = N.
+    * S21A (PR #17464, merged): t1-side forward extraction
       (`t1_lastFace_implies_satDiag`) identifies dropped vertex
       and `b ∈ satDiagBases N`.
-    * S21B (next): `IsDoor` ↔ `g k ≠ g (k+1)` color-change
-      bridge + assembly of full `_hLastFace_simData2`
-      (~60-80 lines). The t2-extinction is already implicit in
-      `boundaryOnFace_simData2`'s `exfalso` t2 branch (every t2
-      face has ≥ 2 containers per `t2_face*_card_ge_two`).
+    * S21B (PR #17502, merged): generic d=2
+      `isDoor_dim_two_iff` (`IsDoor ↔ colors 0 and 1 both
+      appear among non-`k` vertices`).
+    * S22 (this session, build pending): Sperner-restricted
+      `isDoor_dim_two_iff_color_change_of_no_color_two`,
+      collapsing the door condition to "two non-`k` vertices
+      have different colors" under the no-color-`2` hypothesis
+      (forced by Sperner + face-`2` membership).
+    * S23 (next): assemble `_hLastFace_simData2` by combining
+      `t1_lastFace_implies_satDiag` (S21A) →
+      `isDoor_dim_two_iff_color_change_of_no_color_two` (S22) →
+      bijection with `(Finset.range N).filter (g k ≠ g (k+1))`
+      via `b.1`-parametrization on `satDiagBases N`. Then apply
+      `face2_path_odd` for oddness. ~80-100 lines. The
+      t2-extinction side is already implicit in
+      `boundaryOnFace_simData2`'s `exfalso` t2 branch.
 
 Then apply `Triangulation.sperner` (~50 lines for diameter bound + real
 coordinates). Total estimated remaining: ~150 lines across 2 sessions.


### PR DESCRIPTION
## Summary

Adds the **Sperner-restricted IsDoor ↔ color-change bridge** in
`SimplicialAdjFnHelper`, specializing S21B's generic
`isDoor_dim_two_iff` (PR #17502) to the case where neither non-`k`
vertex carries color `2`.

Under hypothesis `∀ i ≠ k, c (vertex s i) ≠ 2` (forced by the Sperner
condition whenever both non-`k` vertices lie on geometric face `2`),
the door condition collapses to:

```
IsDoor c K s k ↔ c (K.vertex s i₁) ≠ c (K.vertex s i₂)
```

for any two distinct non-`k` indices `i₁, i₂` (which exhaust the
non-`k` vertices of a 2-cell). This matches `face2_path_odd`'s
`g k ≠ g (k+1)` shape, ready for the S23+ cardinality bijection.

## New lemmas

- `fin_three_other_eq` (private): For `i₁, i₂ : Fin 3` distinct and
  both `≠ k`, every `j : Fin 3` with `j ≠ k` satisfies `j = i₁ ∨ j = i₂`.
  Pure `Fin 3` enumeration via `decide`.
- `isDoor_dim_two_iff_color_change_of_no_color_two`: The main bridge.
  Forward direction: contrapositive (equal colors at `i₁, i₂` would
  force the color-`0` and color-`1` witnesses of `isDoor_dim_two_iff`
  to share a vertex, hence `0 = 1`). Reverse: distinct colors `≠ 2`
  are necessarily `0` and `1` in some order, supplying both witnesses.

## Diff

- `proofs/Proofs/SpernerFreudenthalSimplex.lean`: +73 lines after
  `isDoor_dim_two_iff` (S21B), within `SimplicialAdjFnHelper`
  namespace.
- `research/problems/sperner-ndim-mathlib-oq-02/state.md`: S22 entry
  + path-forward update (S23 = full `_hLastFace_simData2` assembly).

## Build status

**Pending.** Infrastructure issue: `proofs/.lake` is a recursive
self-symlink, forcing every Docker build to refetch Mathlib (~30-45
min) + cache (~10 min). Following the established
`(build pending)` convention used by recent `simData2`-track PRs
(#17426 S20, #17464 S21A, #17502 S21B).

## Test plan

- [ ] Build verification (deferred to consolidated build)
- [x] Diff is purely additive (new lemma + new private helper)
- [x] No conflict with current `origin/main` (branch base = fresh `5f3e2b92a23`)
- [x] Lemma signature compatible with future S23 consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)