### PR TITLE
audit(erdos-659-oq-01): fix phantom theorem name in section summary

### DIFF
--- a/src/data/proofs/erdos-659-oq-01/meta.json
+++ b/src/data/proofs/erdos-659-oq-01/meta.json
@@ -90,8 +90,8 @@
       "title": "Proof Body: Contradiction and Biconditional Optimality Theorem",
       "startLine": 161,
       "endLine": 207,
-      "summary": "Continuation of the no_improvement_possible proof: after extracting N₀ from isLittleO_iff and taking n = max(N₀, 4), establishes a contradiction between the little-o upper bound (< c/2 · n/√(log n)) and the Landau lower bound (≥ c · n/√(log n)). Closes with moreeosburn_is_optimal: the biconditional theorem stating that O(n/√(log n)) is the exact asymptotic rate for families with the 4-point property.",
-      "mathContext": "The contradiction uses the halving trick: little-o at ε = c/2 gives distinctDistances < (c/2)·n/√(log n), while the axiom gives distinctDistances ≥ c·n/√(log n). Since c/2 < c, this is the desired contradiction. The final theorem moreeosburn_is_optimal: ∀ family with 4-point property, distinctDistances = Θ(n/√(log n)), formalized as both directions: ≤ from Moree-Osburn upper bound axiom and ≥ from uniform_landau_lower_bound."
+      "summary": "Continuation of the no_improvement_possible proof: after extracting N₀ from isLittleO_iff and taking n = max(N₀, 4), establishes a contradiction between the little-o upper bound (< c/2 · n/√(log n)) and the Landau lower bound (≥ c · n/√(log n)). Closes with bound_is_tight: the biconditional theorem stating that O(n/√(log n)) is the exact asymptotic rate for families with the 4-point property.",
+      "mathContext": "The contradiction uses the halving trick: little-o at ε = c/2 gives distinctDistances < (c/2)·n/√(log n), while the axiom gives distinctDistances ≥ c·n/√(log n). Since c/2 < c, this is the desired contradiction. The final theorem bound_is_tight: ∀ family with 4-point property, distinctDistances = Θ(n/√(log n)), formalized as both directions: ≤ from Moree-Osburn upper bound axiom and ≥ from uniform_landau_lower_bound."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Section `proof-body` in `src/data/proofs/erdos-659-oq-01/meta.json` referenced a theorem named `moreeosburn_is_optimal` as the closing biconditional optimality theorem. That theorem does not exist in `proofs/Proofs/Erdos659OQ01.lean` — the actual closing theorem is `bound_is_tight` (line 189), which already states the same biconditional content.

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos659OQ01.lean | grep -nE "moreeosburn_is_optimal|bound_is_tight"
189:theorem bound_is_tight :
```

Three theorems exist in the file: `no_improvement_possible` (135), `erdos_659_oq01` (180), `bound_is_tight` (189). No `moreeosburn_is_optimal`.

## Fix

Renamed the references in `sections[proof-body].summary` and `sections[proof-body].mathContext`. Functional description (biconditional Θ(n/√(log n)) optimality) is unchanged.

## Test plan

- [x] Diff is two surgical string replacements; no other changes
- [x] meta-json structure preserved
- [x] No counts/numerical fields touched

---
Discovered during gallery integrity audit.