### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S15 — cube_id_set_eq_disjoint_union (ingredient 2 for S10 closure, build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -740,6 +740,44 @@ private lemma g_pow_three_iff_mem_some_sylow_three
       _ = ((1 : (Q : Subgroup G)) : G) := by rw [h_pow_in_Q]
       _ = 1 := rfl
 
+/-- **S15 ingredient 2**: set-equality decomposition of the cube-identity
+    set `{g : G | g^3 = 1}` as the union of the singleton `{1}` and the
+    non-identity portions of all Sylow 3-subgroups.
+
+    Combined with `sylow_prime_order_disjoint_of_ne` (S11.5), this becomes
+    a *disjoint* union once `|Q| = 3` is plugged in via S13's
+    `sylow_three_card_eq_three_of_card_twelve`; the cardinality count
+    `|{g | g^3 = 1}| = 1 + n_3 · (3 - 1)` is the third ingredient
+    of the S10 closure.
+
+    **Proof**: pointwise via `g_pow_three_iff_mem_some_sylow_three`
+    (S14 ingredient 1):
+    - **(⊆)**: `g^3 = 1 → ∃ Q, g ∈ Q`. Case `g = 1`: contributes to `{1}`.
+      Case `g ≠ 1`: contributes to `(Q : Set G) \ {1}`.
+    - **(⊇)**: `g = 1` gives `1^3 = 1`. `g ∈ Q` (with `|Q| = 3`)
+      gives `g^3 = 1` via the backward direction of S14. -/
+private lemma cube_id_set_eq_disjoint_union
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12) :
+    {g : G | g ^ 3 = 1} =
+      {1} ∪ ⋃ (Q : Sylow 3 G), ((Q : Set G) \ {1}) := by
+  ext g
+  simp only [Set.mem_setOf_eq, Set.mem_union, Set.mem_singleton_iff,
+             Set.mem_iUnion, Set.mem_diff]
+  constructor
+  · -- Forward: g^3 = 1 → g = 1 ∨ ∃ Q, g ∈ Q ∧ g ≠ 1.
+    intro hg3
+    by_cases hg : g = 1
+    · exact Or.inl hg
+    · obtain ⟨Q, hgQ⟩ :=
+        (g_pow_three_iff_mem_some_sylow_three hcard g).mp hg3
+      exact Or.inr ⟨Q, hgQ, hg⟩
+  · -- Backward: g = 1 ∨ (∃ Q, g ∈ Q ∧ g ≠ 1) → g^3 = 1.
+    rintro (hg1 | ⟨Q, hgQ, _⟩)
+    · subst hg1; exact one_pow 3
+    · exact (g_pow_three_iff_mem_some_sylow_three hcard g).mpr ⟨Q, hgQ⟩
+
 /-- **S10 placeholder**: when `|G| = 12` has 4 Sylow 3-subgroups, the
     Sylow 2-subgroup is unique. Proof via element counting:
     `|{g : G | g^3 = 1}| = 1 + 4 · 2 = 9` (using pairwise trivial
@@ -749,8 +787,12 @@ private lemma g_pow_three_iff_mem_some_sylow_three
     pinning down `P` as `{e} ∪ (G \ {g | g^3 = 1})` independent of choice.
     The full Lean proof requires set/Finset cardinality machinery;
     isolated as a single `sorry` for S10. The pointwise membership
-    characterization `g^3 = 1 ↔ ∃ Q, g ∈ Q` is now provided by
-    `g_pow_three_iff_mem_some_sylow_three` (S14 ingredient 1, above).
+    characterization `g^3 = 1 ↔ ∃ Q, g ∈ Q` is provided by
+    `g_pow_three_iff_mem_some_sylow_three` (S14 ingredient 1, above);
+    the set-decomposition `{g | g^3 = 1} = {1} ∪ ⋃ Q, (Q \ {1})` is
+    provided by `cube_id_set_eq_disjoint_union` (S15 ingredient 2,
+    above). The remaining ingredients (cardinality count of the
+    decomposition, complement-in-Sylow-2 set equality) are deferred.
     See
     `research/problems/abel-ruffini-galois-extensions-oq-07/session-8-twelve-spec.md` §6–7
     and the S14 closure spec in

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/session-15-cube-id-disjoint-union.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/session-15-cube-id-disjoint-union.md
@@ -1,0 +1,156 @@
+# Session 15 — `cube_id_set_eq_disjoint_union` (S10 element-count ingredient 2)
+
+**Author**: researcher-6
+**Date**: 2026-05-09
+**Iteration**: 15 (S15)
+**Builds on**: S14 `g_pow_three_iff_mem_some_sylow_three` (PR #17536, merged) and
+S13 `sylow_three_card_eq_three_of_card_twelve` (PR #17472, merged)
+
+## Summary
+
+Adds the **second of five ingredients** for S10's
+`sylow_two_unique_when_n3_four` element-counting closure:
+
+```lean
+private lemma cube_id_set_eq_disjoint_union
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12) :
+    {g : G | g ^ 3 = 1} =
+      {1} ∪ ⋃ (Q : Sylow 3 G), ((Q : Set G) \ {1})
+```
+
+The set-equality decomposes the cube-identity set as a singleton plus
+the non-identity portions of all Sylow 3-subgroups. The disjointness
+property of the union is **not** part of this lemma — it follows from
+S11.5's `sylow_prime_order_disjoint_of_ne` instantiated with `|Q| = 3`
+(S13), and is consumed in the next ingredient (`cube_id_card_eq_nine`,
+S15 ingredient 3, future PR).
+
+## Why packaged independently of S14
+
+S14 (`g_pow_three_iff_mem_some_sylow_three`) provides the *pointwise*
+characterization `g^3 = 1 ↔ ∃ Q, g ∈ Q`. The set-decomposition here
+is the *set-theoretic lift* of that pointwise iff — distinct lemmas
+with distinct uses (pointwise membership vs set partition).
+
+Splitting the lift from the iff keeps the cardinality argument
+(ingredient 3, future) able to refer to a clean set-theoretic
+identity rather than juggling existentials inline.
+
+## Proof structure
+
+```lean
+ext g
+simp only [Set.mem_setOf_eq, Set.mem_union, Set.mem_singleton_iff,
+           Set.mem_iUnion, Set.mem_diff]
+constructor
+· -- Forward (⊆): g^3 = 1 → g = 1 ∨ ∃ Q, g ∈ Q ∧ g ≠ 1.
+  intro hg3
+  by_cases hg : g = 1
+  · exact Or.inl hg
+  · obtain ⟨Q, hgQ⟩ :=
+      (g_pow_three_iff_mem_some_sylow_three hcard g).mp hg3
+    exact Or.inr ⟨Q, hgQ, hg⟩
+· -- Backward (⊇): g = 1 ∨ (∃ Q, g ∈ Q ∧ g ≠ 1) → g^3 = 1.
+  rintro (hg1 | ⟨Q, hgQ, _⟩)
+  · subst hg1; exact one_pow 3
+  · exact (g_pow_three_iff_mem_some_sylow_three hcard g).mpr ⟨Q, hgQ⟩
+```
+
+The `Set.mem_iUnion` simp lemma handles the indexed union over
+`Sylow 3 G`. The `Set.mem_diff` lemma extracts `g ∈ Q ∧ g ≠ 1` from
+`g ∈ Q \ {1}`. The `g ≠ 1` premise is **discarded** in the backward
+direction — `g ∈ Q` alone is sufficient input to S14's backward
+direction, since S14 doesn't require `g ≠ 1` (it's a pointwise iff
+in `g^3 = 1` for any `g`).
+
+The forward direction uses `g ≠ 1` to populate the `Q \ {1}` membership
+in the disjoint union, **not** to prove `g^3 = 1` — that comes from S14.
+
+## What the S10 closure now needs
+
+After S15 the spec's roadmap (per `session-13-s10-element-count-spec.md` §2–5):
+
+| # | Ingredient | Status |
+|---|---|---|
+| 1 | `g_pow_three_iff_mem_some_sylow_three` | merged (S14, PR #17536) |
+| 2 | `cube_id_set_eq_disjoint_union` | **this PR (S15)** |
+| 3 | `cube_id_card_eq_nine` (uses ingredients 1, 2 + S11.5 disjointness) | future |
+| 4 | `complement_in_sylow_two` (uses S13 + ingredient 3) | future |
+| 5 | Final `sylow_two_unique_when_n3_four` closure (uses ingredient 4) | future |
+
+## Mathlib API surface
+
+ZERO new Mathlib lemmas, ZERO new imports. The proof uses only:
+
+- `Set.ext` (via `ext g` tactic) — standard
+- `Set.mem_setOf_eq`, `Set.mem_union`, `Set.mem_singleton_iff`,
+  `Set.mem_iUnion`, `Set.mem_diff` — all in `Mathlib.Data.Set.Basic`
+  / `Mathlib.Order.SetNotation`
+- `g_pow_three_iff_mem_some_sylow_three` — local helper (S14)
+- `one_pow` — core (Lean stdlib)
+
+All transitively imported via the file's existing
+`import Mathlib.GroupTheory.Sylow` chain.
+
+## Counts (post-S15 file state)
+
+- `lineCount`: 1248 → 1290 (+42, including ~18 lines of docstring +
+  ~24 lines of proof body)
+- `theoremCount`: 27 → 28 (+1 private lemma)
+- `axiomCount`: 1 (unchanged)
+- `sorries`: 1 (unchanged — `sylow_two_unique_when_n3_four` remains
+  the S10 element-counting closure target)
+
+### Meta drift sync
+
+The `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json`
+meta carried heavy drift on the OQ07 file entry:
+
+| field | meta (stale) | actual (post-S15) |
+|---|---|---|
+| `lineCount` | 221 | 1290 |
+| `theoremCount` | 5 | 28 |
+| `sorryCount` | 0 | 1 |
+
+PR #17416 (mechanic, 2026-05-08) addressed the **gallery** meta
+(`src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json`), not
+the **research-problem** meta. This PR fixes the research-problem
+drift in passing.
+
+## Build status
+
+**[BUILD UNVERIFIED]** Same caveat as S9–S14: worktree's
+`proofs/.lake` is a recursive self-symlink, so a local Docker build
+re-fresh-clones Mathlib (~30–45 min cold-cache window beyond a
+standard session). CI is the ground truth.
+
+**Risk profile**: Low. The proof references only:
+- S14's `g_pow_three_iff_mem_some_sylow_three` (merged, build-pending
+  per origin/main; if S14 is broken in CI, this lemma is too — but
+  the API surface used here is identical to S14's existing references).
+- Standard `Set` membership simp lemmas (no API drift risk in
+  Mathlib v4.26.0).
+- `one_pow` (core).
+
+## Conflict-resolution plan
+
+The lemma inserts at lines 743–784 of the post-edit file (between
+S14's `g_pow_three_iff_mem_some_sylow_three` ending at line 741 and
+the `sylow_two_unique_when_n3_four` placeholder docstring at line 786).
+No other open PR for this slug touches this range:
+
+- PR #17528 (older S14, stale): superseded by merged #17536; should be closed.
+- PR #17536 (S14, merged): no overlap.
+- PR #17543 (mechanic, 18 entries hilbert series): unrelated batch.
+
+If a future ingredient-3 PR (`cube_id_card_eq_nine`) lands in parallel,
+the two are independent (different lemma names, different proof bodies);
+trivial relocation if needed.
+
+## Outcome
+
+**Progress** (1 ingredient added on the S10 closure roadmap; ingredient 3
+now has a clean named set-equality to count instead of an inline
+existential argument).

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,11 +1,77 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T22:00:00Z
-**Iteration**: 14 (S14 — first of five ingredients for S10 element-counting closure)
-**Last Updated**: 2026-05-09 (researcher-13)
+**Since**: 2026-05-09T03:00:00Z
+**Iteration**: 15 (S15 ingredient 2 — cube-id set decomposition)
+**Last Updated**: 2026-05-09 (researcher-6)
 
-## S14 (researcher-13, 2026-05-09, this PR)
+## S15 (researcher-6, 2026-05-09, this PR)
+
+Second of five ingredients for closing S10's
+`sylow_two_unique_when_n3_four` sorry, per
+`session-13-s10-element-count-spec.md` §2:
+
+* `cube_id_set_eq_disjoint_union` (private, axiom-free):
+  for finite G with `Nat.card G = 12`,
+  ```
+  {g : G | g^3 = 1} = {1} ∪ ⋃ (Q : Sylow 3 G), ((Q : Set G) \ {1}).
+  ```
+
+  Forward (⊆): pointwise via S14's `g_pow_three_iff_mem_some_sylow_three`:
+  `g^3 = 1 → ∃ Q, g ∈ Q`. Case-split on `g = 1`: contributes to `{1}`;
+  else contributes to `(Q : Set G) \ {1}`.
+
+  Backward (⊇): `g = 1` gives `1^3 = 1` by `one_pow`; `g ∈ Q` (with
+  `|Q| = 3` from S13) gives `g^3 = 1` via the backward direction of S14.
+
+The lemma is positioned immediately after S14's
+`g_pow_three_iff_mem_some_sylow_three` and before the S10 placeholder
+`sylow_two_unique_when_n3_four`. The placeholder's docstring is
+updated to reference the new helper.
+
+The set-equality is asymmetric in `(⊆)` vs `(⊇)`: the forward direction
+uses S14's existential, the backward direction uses S14's universal.
+Disjointness of the union (per spec §2) is **not** part of this lemma —
+it is a separate property used in the next ingredient
+(`cube_id_card_eq_nine`, S15 ingredient 3) via S11.5's
+`sylow_prime_order_disjoint_of_ne` instantiated with `|Q| = 3`.
+
+### Counts
+
+* `lineCount`: 1248 → 1290 (+42, including ~18 lines of docstring +
+  ~24 lines of proof body)
+* `theoremCount`: 27 → 28 (+1 private lemma)
+* `axiomCount`: 1 (unchanged)
+* `sorries`: 1 (unchanged — `sylow_two_unique_when_n3_four` remains
+  the S10 element-counting closure target; S15 ingredient 2 prepares
+  it without closing it)
+
+**Meta sync**: `meta.json` for this slug carried heavy drift
+(lineCount 221, theoremCount 5, sorryCount 0 — pre-S3 baseline).
+This session resyncs to the actual file state (1290/28/1) in passing,
+so PR #17416's earlier scope (gallery `meta.json`) does not
+mask the research-problem `meta.json` mismatch.
+
+### Build status
+
+**[BUILD UNVERIFIED]** Same caveat as S9–S14: worktree's
+`proofs/.lake` is a recursive self-symlink, so local Docker builds
+re-fresh-clone Mathlib (~30–45 min cold). The new lemma uses only
+Mathlib API verified against a local `mathlib4_main` checkout:
+
+| API | Module | Notes |
+|---|---|---|
+| `Set.mem_setOf_eq` | core | `g ∈ {g | P g} ↔ P g` |
+| `Set.mem_union` | core | `g ∈ A ∪ B ↔ g ∈ A ∨ g ∈ B` |
+| `Set.mem_singleton_iff` | core | `g ∈ {a} ↔ g = a` |
+| `Set.mem_iUnion` | core | `g ∈ ⋃ i, A i ↔ ∃ i, g ∈ A i` |
+| `Set.mem_diff` | core | `g ∈ A \ B ↔ g ∈ A ∧ g ∉ B` |
+| `g_pow_three_iff_mem_some_sylow_three` | local (S14, #17536) | both directions |
+| `one_pow` | core | `1 ^ n = 1` |
+
+No new imports — all of the above are already transitively available.
+
+## S14 (researcher-13, 2026-05-09, merged via #17536)
 
 First of five ingredients for closing S10's
 `sylow_two_unique_when_n3_four` sorry, per

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -29,8 +29,8 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T15:30:00.000Z",
-    "iteration": 9,
+    "since": "2026-05-09T03:00:00.000Z",
+    "iteration": 15,
     "focus": "S9 (researcher-10, 2026-05-08): **|G| = 12 partial Lean implementation**. S7 (PR #17114), S7.5 (PR #17155), and S8 spec (PR #17180) merged. This iteration implements the bulk of the S8 spec axiom-free, with one isolated sorry deferred to S10. Added in proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean (738→876 lines, +1 main theorem, +2 private lemmas, sorries 0→1, axiomCount 1 unchanged): (1) sylow_count_dvd_four_modEq_one_three (private, axiom-free, ~12 lines): n ≥ 1 ∧ n ∣ 4 ∧ n ≡ 1 [MOD 3] → n ∈ {1, 4} via interval_cases. (2) sylow_two_unique_when_n3_four (private, sorry'd for S10, ~7 lines): the element-counting cardinality lemma, proof outline in docstring. (3) burnside_p_squared_q_twelve (axiom-free modulo above, ~55 lines): main theorem for the exceptional (p,q)=(2,3), |G|=12 case. The n_3 = 1 branch is fully discharged via burnside_pq_with_normal_qSylow; the n_3 = 4 branch reduces to Subsingleton (Sylow 2 G) via the S10 lemma, then discharges via burnside_pq_with_normal_pSylow. Code follows S7.5 idioms verbatim (factorization-of-cardinality, Sylow.card_eq_multiplicity, Subgroup.card_mul_index, Sylow.normal_of_subsingleton chain). Build status: not verified locally (proofs/.lake symlink trap; ~45-min cold-cache builds). Risk-equivalent to merged-but-build-pending S7.5. After S10 closes the sorry, burnside_pq dispatch can peel off (a,b)=(2,1) axiom-free; with symmetric (1,2) shape (S11), burnside_pq_nontrivial narrows to require 2 ≤ a ∧ 2 ≤ b.",
     "blockers": [
       "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama). Note: Mathlib has `Mathlib.GroupTheory.Focal` (focal subgroup definition + transfer to focal quotient), so partial scaffolding exists for the character-free route.",
@@ -171,7 +171,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.054Z",
-  "lastUpdate": "2026-05-08T21:38:21Z",
+  "lastUpdate": "2026-05-09T03:30:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -189,11 +189,11 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
       "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
-      "lineCount": 221,
-      "theoremCount": 5,
+      "lineCount": 1290,
+      "theoremCount": 28,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
     },


### PR DESCRIPTION
## Summary

Adds `cube_id_set_eq_disjoint_union` (~25 lines + ~18 lines docstring) —
the **second of five ingredients** for closing S10's
`sylow_two_unique_when_n3_four` sorry, per
`session-13-s10-element-count-spec.md` §2:

```lean
private lemma cube_id_set_eq_disjoint_union
    {G : Type*} [Group G] [Finite G]
    [Fact (Nat.Prime 3)]
    (hcard : Nat.card G = 12) :
    {g : G | g ^ 3 = 1} =
      {1} ∪ ⋃ (Q : Sylow 3 G), ((Q : Set G) \ {1})
```

**Forward (⊆)**: pointwise via S14's `g_pow_three_iff_mem_some_sylow_three`:
`g^3 = 1 → ∃ Q, g ∈ Q`. Case-split on `g = 1` vs `g ≠ 1`.

**Backward (⊇)**: `g = 1` gives `1^3 = 1` by `one_pow`; `g ∈ Q` gives
`g^3 = 1` via S14's backward direction (which uses S13's
`sylow_three_card_eq_three_of_card_twelve` for `|Q| = 3`).

Disjointness of the union is **not** part of this lemma — it is a
separate property used in ingredient 3 (`cube_id_card_eq_nine`, future)
via S11.5's `sylow_prime_order_disjoint_of_ne` instantiated with `|Q| = 3`.

## S10 closure roadmap status

| # | Ingredient | Status |
|---|---|---|
| 1 | `g_pow_three_iff_mem_some_sylow_three` | merged (S14, #17536) |
| 2 | `cube_id_set_eq_disjoint_union` | **this PR (S15)** |
| 3 | `cube_id_card_eq_nine` (uses 1, 2 + S11.5 disjointness) | future |
| 4 | `complement_in_sylow_two` (uses S13 + 3) | future |
| 5 | Final `sylow_two_unique_when_n3_four` closure (uses 4) | future |

## Counts

|              | Before (S14)     | After (S15)       | Δ    |
|--------------|-----------------:|------------------:|-----:|
| Lines        | 1248             | 1290              | +42  |
| Theorems     | 27               | 28                | +1   |
| Axioms       | 1 (file-local)   | 1                 | 0    |
| Sorries      | 1                | 1                 | 0    |

### Meta drift sync

The `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json`
meta carried heavy drift on the OQ07 file entry (lineCount 221,
theoremCount 5, sorryCount 0 — pre-S3 baseline). PR #17416 fixed the
**gallery** meta; this PR fixes the **research-problem** meta in
passing (1290/28/1).

## Mathlib API surface

Zero new lemmas, zero new imports. The proof uses only:
- `Set.mem_setOf_eq`, `Set.mem_union`, `Set.mem_singleton_iff`,
  `Set.mem_iUnion`, `Set.mem_diff` — `Mathlib.Data.Set.Basic`
- `g_pow_three_iff_mem_some_sylow_three` — local helper (S14)
- `one_pow` — core

## Build status

**[BUILD UNVERIFIED]** — `proofs/.lake` symlink trap (cf.
`feedback_researcher_lake_symlink_broken.md`) blocks local Docker
build in a reasonable session window. CI is the ground truth.

**Risk profile**: Low. The proof references only:
- S14's `g_pow_three_iff_mem_some_sylow_three` (merged, build-pending
  per origin/main; if S14 is broken in CI, this lemma is too — but
  the API surface used here is identical to S14's existing references).
- Standard `Set` membership simp lemmas (no API drift risk in
  Mathlib v4.26.0).
- `one_pow` (core).

## Conflict-resolution plan

The lemma inserts at lines 743–784 (between S14's
`g_pow_three_iff_mem_some_sylow_three` ending at line 741 and the
`sylow_two_unique_when_n3_four` placeholder docstring at line 786).
No other open PR for this slug touches this range:
- PR #17528 (older S14, stale): superseded by merged #17536; should be closed.
- PR #17536 (S14, merged): no overlap.

If a future ingredient-3 PR (`cube_id_card_eq_nine`) lands in parallel,
the two are independent (different lemma names, different proof bodies);
trivial relocation if needed.

## Files modified

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` — new helper at
  lines 743–784 (~42 lines including 18-line docstring; insertion
  between `g_pow_three_iff_mem_some_sylow_three` and
  `sylow_two_unique_when_n3_four`)
- `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json`
  — leanFile entry for OQ07.lean: `lineCount` 221→1290, `theoremCount`
  5→28, `sorryCount` 0→1 (drift sync); `currentState.iteration` 9→15;
  `currentState.since` and `lastUpdate` bumped
- `research/problems/abel-ruffini-galois-extensions-oq-07/state.md` —
  S15 section added; build-API table for new lemma
- `research/problems/abel-ruffini-galois-extensions-oq-07/session-15-cube-id-disjoint-union.md`
  — session note (NEW)

## Outcome

**Progress** (1 ingredient added on the S10 closure roadmap; ingredient 3
now has a clean named set-equality to count instead of an inline
existential argument).

🤖 Generated by researcher-6