### PR TITLE
fix(meta): batch sync definitionCount drift (15 entries, batch e-y non-erdos)

### DIFF
--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -46,7 +46,7 @@
     "lineCount": 280,
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Paul Erdős and George Szekeres proved this theorem in 1935 in their paper \"A combinatorial problem in geometry.\" It was one of Erdős's first major results, published when he was just 22 years old. The theorem arose from the Happy Ending Problem about convex polygons and has since become a cornerstone of combinatorics and Ramsey theory. The elegant pigeonhole proof gives an exact tight bound. Dilworth's theorem (1950) generalized it: in any finite partially ordered set, the minimum number of chains covering it equals the maximum antichain size; the Erdős-Szekeres theorem is the linear order special case. The result is also a foundational instance of the general Ramsey principle that any large enough structure must contain order.",
@@ -220,7 +220,7 @@
     "lineCount": 280,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/ErdosSzekeres.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -37,7 +37,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 757,
     "theoremCount": 23,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -90,7 +90,7 @@
     "lineCount": 757,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos101Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/meta.json
@@ -51,7 +51,7 @@
     "assumptions": "4 axioms: planar_hereditary, kempe_chain_separation, five_color_axiom, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The **Five Color Theorem** states that every planar graph can be properly colored with at most 5 colors. It was first stated (as part of an attempt at the Four Color Theorem) by Alfred Kempe in 1879, who introduced the **Kempe chain** recoloring technique. Percy Heawood found the flaw in Kempe's four-color proof in 1890 but showed the five-color version was correct.\n\nThe Kempe chain argument proceeds by induction on vertices:\n1. Every planar graph has a vertex of degree ≤ 5 (from E ≤ 3V - 6)\n2. Remove it; color the rest by induction\n3. If degree ≤ 4: at most 4 colors used by neighbors, pick the 5th\n4. If degree = 5: K₅ is non-planar, so two neighbors are non-adjacent. Use a Kempe chain swap to reduce distinct neighbor colors to ≤ 4\n\nThis formalization proves all the combinatorial ingredients (color swap correctness, K₅ non-planarity, color counting) and axiomatizes only the planarity-specific infrastructure that Mathlib currently lacks (vertex deletion, Kempe chain separation).",
@@ -141,7 +141,7 @@
     "lineCount": 507,
     "axiomCount": 4,
     "theoremCount": 25,
-    "definitionCount": 2,
+    "definitionCount": 4,
     "path": "Proofs/FiveColorTheorem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
@@ -55,7 +55,7 @@
     "assumptions": "Fully verified. 0 axioms, 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 60,
-    "definitionCount": 12
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Euler's formula** $V - E + F = 2$ for connected planar graphs (equivalently, convex polyhedra) was first proved by Euler in 1758, though anticipated by Descartes. The formula has profound implications:\n\n- **Planarity**: $E \\leq 3V - 6$ and $E \\leq 2V - 4$ (bipartite), enabling planarity tests\n- **Coloring**: Average degree $< 6$ implies a vertex of degree $\\leq 5$, driving the Six Color Theorem and (via Kempe chains) the Five Color Theorem\n- **Topology**: For surfaces of genus $g$, $V - E + F = 2 - 2g$ (Euler characteristic)\n\nThe **Four Color Theorem** (1976, Appel-Haken; computer-verified by Gonthier 2005) shows planar graphs are actually 4-colorable, but the Six Color Theorem has an elegant elementary proof via degeneracy. The Five Color Theorem has a clean Kempe-chain proof.\n\nThis formalization extends the base `EulerPolyhedralFormula.lean` with deeper structural results: the spanning-tree construction of Euler's formula, graph degeneracy theory, and the Six Color Theorem.",
@@ -179,7 +179,7 @@
     "lineCount": 903,
     "axiomCount": 0,
     "theoremCount": 60,
-    "definitionCount": 12,
+    "definitionCount": 16,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-formula-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "0 axioms, 0 sorries. Structure fields (euler, angle_sum_identity, deficiency_sum, chi_genus) are definitional constraints proved for each concrete instance, not mathematical assumptions.",
     "mathlib_version": "4.26.0",
     "theoremCount": 52,
-    "definitionCount": 7
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Descartes discovered around 1630 that the total angular deficiency of a convex polyhedron equals 4π, though his work remained unpublished until 1860. Euler established V - E + F = 2 in 1758. Gauss (1827) and Bonnet (1848) developed the continuous version relating Gaussian curvature to topology: the Gauss-Bonnet theorem ∫∫ K dA = 2πχ. For polyhedral surfaces, curvature concentrates at vertices as angular deficiency, and the integral becomes a sum. The theorem was extended to all closed surfaces by von Dyck (1888) and to abstract Riemannian manifolds by Chern (1944-1945) using characteristic classes, making it a cornerstone of modern differential topology.",
@@ -124,7 +124,7 @@
     "lineCount": 507,
     "axiomCount": 0,
     "theoremCount": 52,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "path": "Proofs/EulerPolyhedralOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/meta.json
@@ -42,7 +42,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 903,
     "theoremCount": 60,
-    "definitionCount": 12,
+    "definitionCount": 16,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -104,7 +104,7 @@
     "lineCount": 903,
     "axiomCount": 0,
     "theoremCount": 60,
-    "definitionCount": 12,
+    "definitionCount": 16,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
     "lineCount": 2042,
     "theoremCount": 45,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "originalContributions": [
       "NSquareIdentity: structure for bilinear n-square composition identities",
       "admissibleDimensions: Finset {1,2,4,8} — the four normed division algebra dimensions",
@@ -70,7 +70,7 @@
     "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 45,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "path": "Proofs/HurwitzTheorem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "0 sorries, 0 axioms. All 7 Fano upper-triangular residuals (F43, F53, F63, F65, F73, F75, F76) in derEval14_injective were closed by PR #13632 via explicit Fano-line Leibniz proofs using fin_cases, simp, antisymmetry constraints, and linarith. G2_der_dimension is a proved theorem (not an axiom): finrank ℝ Der(𝕆) = 14 via upper bound (injective derEval14 map) and lower bound (derBasis14_linearIndependent, proved in PR #13121).",
     "lineCount": 1646,
     "theoremCount": 65,
-    "definitionCount": 31,
+    "definitionCount": 35,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",
@@ -140,7 +140,7 @@
     "lineCount": 1646,
     "axiomCount": 0,
     "theoremCount": 65,
-    "definitionCount": 31,
+    "definitionCount": 35,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -50,7 +50,7 @@
     "assumptions": "1 sorry: hurwitz_only_if — general non-existence for n ∉ {1,2,3,4,8} (n=3 case proved; remaining cases need Clifford/Radon-Hurwitz argument). The 8-square identity (octonions) is fully proved. No axiom declarations.",
     "mathlib_version": "4.26.0",
     "theoremCount": 45,
-    "definitionCount": 18
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "**Adolf Hurwitz** (1859–1919) published this theorem in 1898 in his paper 'Über die Composition der quadratischen Formen von beliebig vielen Variablen' (On the composition of quadratic forms in any number of variables), establishing one of the deepest constraints in algebra: an identity $(x_1^2 + \\cdots + x_n^2)(y_1^2 + \\cdots + y_n^2) = z_1^2 + \\cdots + z_n^2$ with bilinear $z_i$ exists only for $n = 1, 2, 4, 8$.\n\n**The Individual Identities:**\n- **$n = 1$**: The trivial identity $x^2 y^2 = (xy)^2$, known since antiquity.\n- **$n = 2$**: The Brahmagupta–Fibonacci identity $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$, discovered by **Brahmagupta** in 628 CE in his *Brāhma-sphuṭa-siddhānta*, and rediscovered by **Fibonacci** in 1202. It encodes complex number multiplication.\n- **$n = 4$**: Euler's four-square identity, discovered by **Leonhard Euler** in 1748. Nearly a century later, **William Rowan Hamilton** (1843) recognized it as encoding quaternion multiplication $|q_1 q_2|^2 = |q_1|^2 |q_2|^2$.\n- **$n = 8$**: Published by **Ferdinand Degen** in 1818, later understood through **Arthur Cayley**'s octonions (1845) and **John Graves**'s independent discovery of octonions (1843).\n\n**Hamilton's 15-Year Search:**\nFrom 1828 to 1843, Hamilton searched obsessively for 'triplets'—a three-dimensional analogue of complex numbers that would preserve the norm-multiplication property. On October 16, 1843, while walking along the Royal Canal in Dublin, he had his famous flash of insight: the answer required FOUR dimensions, not three, and he carved the fundamental quaternion equations $i^2 = j^2 = k^2 = ijk = -1$ into Broom Bridge. Hurwitz's theorem explains Hamilton's failure: no 3-square identity can exist.\n\n**Modern Significance:**\nThe theorem connects to deep areas of mathematics and physics. The four normed division algebras $\\mathbb{R}, \\mathbb{C}, \\mathbb{H}, \\mathbb{O}$ correspond to the parallelizable spheres $S^0, S^1, S^3, S^7$ (Bott–Milnor, Kervaire, 1958). Each step in the Cayley–Dickson construction loses a property: $\\mathbb{R} \\to \\mathbb{C}$ (lose ordering), $\\mathbb{C} \\to \\mathbb{H}$ (lose commutativity), $\\mathbb{H} \\to \\mathbb{O}$ (lose associativity). Beyond octonions, the sedenions have zero divisors, breaking the division algebra structure.",
@@ -283,7 +283,7 @@
     "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 45,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "path": "Proofs/HurwitzTheorem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, concrete examples, consequences) are proved from first principles. NOTE 2026-05-08: main file currently does not build under the latest Mathlib (omega tactic API drift on `walk.get ⟨i, by omega⟩` patterns inside Finset.filter expressions, pre-existing from PR #16675). Sessions 7–8 prepared a refactor recipe; Session 9 created `KonigsbergOQ01OQ02Recipe.lean` (companion validation file) containing the bridge lemma `get?_eq_some_iff_of_lt` and a worked-out generic `closed_walk_balance'` in the new `walk.get? = some v` form, verified to compile under v4.26.0. Session 10 will transcribe this into the main file.",
     "lineCount": 1202,
     "theoremCount": 26,
-    "definitionCount": 13,
+    "definitionCount": 15,
     "additionalFiles": [
       "Proofs/KonigsbergOQ01OQ02Recipe.lean"
     ],
@@ -132,7 +132,7 @@
     "lineCount": 1202,
     "axiomCount": 2,
     "theoremCount": 26,
-    "definitionCount": 13,
+    "definitionCount": 15,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
     "sorries": 1,
     "additionalFiles": [

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "2 axioms: directed_euler_circuit_sufficient (balanced digraph → Eulerian circuit exists) and directed_euler_path_sufficient (exactly one source + one sink → Eulerian path exists). The necessary conditions are fully proved; the sufficiency requires an Eulerian circuit construction algorithm (e.g., Hierholzer's algorithm) not yet in Mathlib.",
     "lineCount": 813,
     "theoremCount": 35,
-    "definitionCount": 11,
+    "definitionCount": 15,
     "originalContributions": [
       "Digraph: directed graph definition with finite vertex and edge types",
       "inDegree/outDegree: in-degree and out-degree for each vertex",
@@ -66,7 +66,7 @@
     "lineCount": 813,
     "axiomCount": 2,
     "theoremCount": 35,
-    "definitionCount": 11,
+    "definitionCount": 15,
     "path": "Proofs/KonigsbergOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 4,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The triangle angle sum theorem (α+β+γ=π) has been known since antiquity as a characterization of Euclidean geometry. Its failure in curved geometries was gradually recognized: Girard (1629) proved the spherical excess formula for triangles on a sphere, and Lambert (1761) noted that in hyperbolic geometry the angle sum is less than π, with the defect proportional to area.\n\nGauss (1827) unified these observations via the concept of Gaussian curvature: the angle excess of a geodesic triangle equals the integral of Gaussian curvature over the triangle. This local version of what we now call the Gauss-Bonnet theorem shows that the flat case (K=0, excess=0, sum=π) is a special instance of a deeper principle.\n\nBonnet (1848) extended this to the global theorem: for a closed orientable Riemannian surface, the integral of Gaussian curvature equals 2π times the Euler characteristic. This fundamentally connects geometry (curvature) to topology (Euler characteristic).",
@@ -144,7 +144,7 @@
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 7
   },
   "references": [
     {

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
     "theoremCount": 28,
-    "definitionCount": 11
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "The Osterwalder-Schrader (OS) reconstruction theorem (1973, 1975) is the rigorous mathematical bridge between Euclidean field theory and physical quantum field theory. It states: a system of Schwinger functions (Euclidean correlators) satisfying five axioms — Euclidean covariance (OS1), reflection positivity (OS2), regularity (OS3), symmetry (OS4), and cluster decomposition (OS5) — can be analytically continued via Wick rotation $\\tau \\mapsto it$ to produce a system of Wightman distributions satisfying all Wightman axioms. The Hilbert space is constructed by the GNS (Gelfand-Naimark-Segal) procedure from the reflection-positive bilinear form. The key axiom is OS2: without reflection positivity, the inner product on the GNS Hilbert space might not be positive definite, and unitarity would be lost. In the lattice context, Osterwalder and Seiler (1978) showed that reflection positivity of the lattice action is equivalent to the transfer matrix $T$ being a positive semi-definite operator on the gauge-invariant Hilbert space. The Clay Millennium Prize ($1M) asks whether 4D lattice Yang-Mills theory satisfies all five OS axioms in the continuum limit $a \\to 0$, and whether the resulting Wightman QFT has a positive mass gap.",
@@ -170,7 +170,7 @@
     ],
     "path": "Proofs/YangMillsLatticeOQ01.lean",
     "sorries": 0,
-    "definitionCount": 11
+    "definitionCount": 16
   },
   "references": [
     {

--- a/src/data/proofs/yang-mills-transfer-matrix-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix-oq-01/meta.json
@@ -51,7 +51,7 @@
     "dateAdded": "2026-04-24",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 8
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "The Yang-Mills transfer matrix mass gap at finite volume is a theorem: Δ_L = log(λ₀(L)/λ₁(L))/a > 0 for all L, by the Perron-Frobenius theorem. The deeper question is whether this gap remains bounded away from zero as L → ∞. Wilson's 1974 lattice formulation (Phys. Rev. D 10, 2445) made the strong-coupling expansion accessible: at large g² the partition function reduces to character expansions over single plaquettes, and the spectrum is dominated by the electric energy. Building on this, Osterwalder–Seiler (1978) established the reflection-positivity framework that makes the transfer matrix self-adjoint and Perron–Frobenius applicable. Brydges–Fröhlich–Seiler (1979) and Seiler (1982) proved the gap survives the infinite-volume limit in the strong coupling regime via convergent polymer (cluster) expansions. The general weak-coupling case, including the continuum limit a → 0, was elevated to a Clay Millennium Prize problem in 2000 (Jaffe–Witten). Numerical lattice QCD (Creutz 1980 and successors) has measured the gap to high precision, but a rigorous mathematical proof for SU(N) gauge theory at all couplings, with the continuum limit, remains open. This formalization proves the strong coupling L-independence exactly and axiomatizes the Seiler result, providing a verified anchor for the strong-coupling end of the conjectured uniform gap.",
@@ -184,7 +184,7 @@
     ],
     "path": "Proofs/YangMillsTransferMatrixOQ01.lean",
     "sorries": 0,
-    "definitionCount": 8
+    "definitionCount": 13
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` to the actual count of `def`/`abbrev`/`opaque`/`structure`/`inductive`/`class` decls (allowing `partial`/`private`/`protected`/`noncomputable`/`unsafe`/`scoped` modifiers; `instance` excluded).

Same convention as PRs fca472e (hilbert series), 119a252 (erdos-mixed), f21839a (erdos-500s), 1e0d5c8 (erdos-600-740).

## Per-entry deltas (claimed → actual)

| slug | claimed | actual |
|------|---------|--------|
| erdos-szekeres | 4 | 6 |
| erdos101-problem | 5 | 6 |
| euler-polyhedral-formula-oq-01 | 12 | 16 |
| euler-polyhedral-formula-oq-01-oq-01 | 2 | 4 |
| euler-polyhedral-formula-oq-02 | 7 | 9 |
| euler-polyhedral-oq-01 | 12 | 16 |
| hurwitz-theorem | 18 | 20 |
| hurwitz-theorem-oq-03 | 18 | 20 |
| hurwitz-theorem-oq-04 | 31 | 35 |
| konigsberg-oq-01-oq-02 | 13 | 15 |
| konigsberg-oq-02 | 11 | 15 |
| roth-theorem-k3-oq-02 | 7 | 4 |
| triangle-angle-sum-oq-02 | 2 | 7 |
| yang-mills-lattice-oq-01 | 11 | 16 |
| yang-mills-transfer-matrix-oq-01 | 8 | 13 |

## Evidence

**Before**: `meta.definitionCount` and `leanFile.definitionCount` both equal but mis-counting source.
**After**: both fields equal canonical decl count.

Surgical 2-line `.replace()` per file; no other formatting changed.

---
Automated fix by lean-mechanic agent.