### PR TITLE
audit(loop): batch clean re-audit (4 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1140,9 +1140,9 @@
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-08T23:37:57Z",
+      "lastAudited": "2026-05-09T00:08:38Z",
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01-oq-02": {
@@ -2212,9 +2212,9 @@
       "result": "issues-fixed"
     },
     "cramers-rule-oq-01-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-08T23:35:14Z",
+      "lastAudited": "2026-05-09T00:08:38Z",
       "result": "clean"
     },
     "cramers-rule-oq-02": {
@@ -3760,9 +3760,9 @@
       "result": "clean"
     },
     "erdos-1098-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-08T23:35:14Z",
+      "lastAudited": "2026-05-09T00:08:38Z",
       "result": "clean"
     },
     "erdos-1098-oq-04": {
@@ -13387,9 +13387,9 @@
       "result": "clean"
     },
     "szemeredi-full-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-08T23:35:14Z",
+      "lastAudited": "2026-05-09T00:08:38Z",
       "result": "clean"
     },
     "szemeredi-hypergraph-core": {


### PR DESCRIPTION
## Summary

- Verified meta.json claims against Lean source for 4 proofs: `erdos-1098-oq-01-oq-01`, `szemeredi-full-oq-02`, `cramers-rule-oq-01-oq-04`, `birthday-problem-oq-03-oq-01-oq-01`.
- Bumped `auditCount` and refreshed `lastAudited` for each.
- Verified: `lineCount`, `axiomCount`, `theoremCount`, `definitionCount`, `sorries`, status/badge consistency, True-stub absence. All clean.

## Notes

- `szemeredi-full-oq-02`: `meta.axiomCount=1` reflects inherited `szemeredi_k_ge_4` axiom from `Proofs.SzemerediTheorem`; `lf.axiomCount=0` correctly reflects no axioms declared in this file (by-design split).
- `birthday-problem-oq-03-oq-01-oq-01`: confirmed `theoremCount=43` (41 bare `theorem/lemma` heads + 2 `@[simp]`-decorated theorems).

## Test plan

- [x] Tracker file is valid JSON
- [x] Diff is exactly 4 entries (timestamps + auditCount only)
- [x] No meta.json or Lean source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)