### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 15 — primorial → lcmRange divisibility bridge (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Nat.Log
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.NumberTheory.Primorial
 import Mathlib.Tactic
 
 /-
@@ -527,6 +528,51 @@ theorem lcmRange_le_pow_pred (n : ℕ) :
     simp [lcmRange_zero]
   exact le_trans (lcmRange_le_pow_primeCounting n)
     (pow_primeCounting_le_pow_pred n hn)
+
+/-- **Primorial divides `lcmRange`** (Iter 15): for every `n`, the primorial
+    `∏_{p ≤ n, p prime} p` divides `lcm(1, ..., n)`.
+
+    The Iter 9 Chebyshev decomposition writes
+    `lcmRange n = ∏ p ∈ primes ≤ n, p ^ Nat.log p n` and the primorial is
+    the same product with all exponents collapsed to `1`. Since each prime
+    `p ≤ n` satisfies `Nat.log p n ≥ 1`, each factor `p` divides
+    `p ^ Nat.log p n`, and the divisibility lifts pointwise across the
+    product via `Finset.prod_dvd_prod_of_dvd`.
+
+    This is the **lower-bound side** of the bridge sketched in the file
+    header (`primorial(n) ≤ lcm(1..n) ≤ n · primorial(n)`); the
+    upper-bound side `lcmRange ≤ n · primorial` requires a Chebyshev-type
+    bound on small primes (`p ≤ √n` contributing `p^(⌊log_p n⌋ - 1) ≤ √n`)
+    and is left for future iterations. -/
+theorem primorial_dvd_lcmRange (n : ℕ) :
+    primorial n ∣ lcmRange n := by
+  unfold primorial
+  rw [lcmRange_eq_prod_prime_powers]
+  apply Finset.prod_dvd_prod_of_dvd
+  intro p hp
+  rw [Finset.mem_filter, Finset.mem_range] at hp
+  have hp_prime := hp.2
+  have hp_le_n : p ≤ n := by omega
+  have h_log_pos : 0 < Nat.log p n :=
+    Nat.log_pos hp_prime.one_lt hp_le_n
+  exact dvd_pow_self p h_log_pos.ne'
+
+/-- **Primorial bound**: `primorial n ≤ lcmRange n` for all `n`.
+
+    Direct corollary of `primorial_dvd_lcmRange` via `Nat.le_of_dvd` plus
+    `lcmRange_pos`. The boundary case `n = 0` is handled separately
+    (`primorial 0 = lcmRange 0 = 1`). For `n ≥ 1`, this gives a
+    non-trivial lower bound on `lcmRange n` since
+    `primorial n ≥ 2^{π(n)}` (each prime ≥ 2). Combined with
+    Mathlib's `primorial_le_4_pow` (`primorial n ≤ 4^n`), this places
+    `lcmRange n` in the band `[primorial n, ...]` whose upper edge is
+    the target of Hanson's bound `≤ 3^n`. -/
+theorem primorial_le_lcmRange (n : ℕ) :
+    primorial n ≤ lcmRange n := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · -- n = 0: primorial 0 = 1 = lcmRange 0.
+    simp [primorial, lcmRange_zero]
+  exact Nat.le_of_dvd (lcmRange_pos n hn) (primorial_dvd_lcmRange n)
 
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,11 +4,47 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-09 (Iteration 14, researcher-12)
-**Iteration**: 14
+**Last Updated**: 2026-05-09 (Iteration 15, researcher-10)
+**Iteration**: 15
 
 ## Current Focus
-Iteration 14 (2026-05-09, this PR): **sharpened prime-counting bound
+Iteration 15 (2026-05-09, this PR): **primorial → lcmRange divisibility
+bridge**. Adds two new theorems wiring Mathlib's
+`NumberTheory.Primorial` API to the file's `lcmRange`, supplying the
+**lower-bound side** of the bridge sketched in the file header
+(`primorial(n) ≤ lcm(1..n) ≤ n · primorial(n)`):
+
+* `primorial_dvd_lcmRange (n : ℕ) : primorial n ∣ lcmRange n` —
+  direct from Iter 9's Chebyshev decomposition
+  `lcmRange n = ∏ p ∈ primes ≤ n, p ^ Nat.log p n`. Each prime
+  `p ≤ n` has `Nat.log p n ≥ 1` (via `Nat.log_pos`), so each factor
+  `p` divides `p ^ Nat.log p n`, and the divisibility lifts pointwise
+  via `Finset.prod_dvd_prod_of_dvd`.
+* `primorial_le_lcmRange (n : ℕ) : primorial n ≤ lcmRange n` —
+  one-line corollary via `Nat.le_of_dvd` + `lcmRange_pos` (with the
+  `n = 0` boundary case `primorial 0 = lcmRange 0 = 1` dispatched by
+  `simp`).
+
+Combined with Mathlib's `primorial_le_4_pow` (`primorial n ≤ 4^n`),
+this places `lcmRange n` in the band `[primorial n, ?]` whose upper
+edge is the target of Hanson's `≤ 3^n`. Future iterations will
+attack the upper-bound side `lcmRange ≤ n · primorial`, which
+requires a Chebyshev-type bound on small primes: each prime
+`p ≤ √n` contributes a factor `p^(⌊log_p n⌋ - 1) ≤ √n` beyond its
+primorial contribution, and bounding the total contribution of
+small primes by `n` is the missing piece for the `4^n` bound.
+
+Build pending; proof bodies use only Mathlib API already exercised
+by Iters 7-14 (`Finset.prod_dvd_prod_of_dvd`, `Nat.log_pos`,
+`dvd_pow_self`, `Nat.le_of_dvd`, `lcmRange_pos`,
+`lcmRange_eq_prod_prime_powers`). New import:
+`Mathlib.NumberTheory.Primorial`. File 657 → 705 lines (+48 in Lean
++ docstrings), theorems 43 → 45 (+2), definitions/sorries/axiomCount
+unchanged.
+
+----
+
+Iteration 14 (PR #17513, merged): **sharpened prime-counting bound
 `π(n) ≤ n - 1` and the resulting chain
 `lcmRange n ≤ n^π(n) ≤ n^(n-1)`**. Three new theorems sharpen Iter 13
 by exploiting that *both* `0` and `1` are non-prime (Iter 13 only


### PR DESCRIPTION
## Summary

Wires Mathlib's `NumberTheory.Primorial` API to the file's `lcmRange`,
supplying the **lower-bound side** of the bridge sketched in the file
header (`primorial(n) ≤ lcm(1..n) ≤ n · primorial(n)`).

## New theorems

- `primorial_dvd_lcmRange (n : ℕ) : primorial n ∣ lcmRange n` —
  direct from Iter 9's `lcmRange_eq_prod_prime_powers`. Each prime
  `p ≤ n` has `Nat.log p n ≥ 1` (via `Nat.log_pos`), so each `p`
  divides `p ^ Nat.log p n`, and divisibility lifts pointwise via
  `Finset.prod_dvd_prod_of_dvd`.
- `primorial_le_lcmRange (n : ℕ) : primorial n ≤ lcmRange n` —
  one-line corollary via `Nat.le_of_dvd` + `lcmRange_pos`. The
  `n = 0` boundary (`primorial 0 = lcmRange 0 = 1`) is dispatched
  by `simp`.

## Significance

Combined with Mathlib's `primorial_le_4_pow` (`primorial n ≤ 4^n`),
this places `lcmRange n` in the band `[primorial n, ?]` whose upper
edge is the target of Hanson's `≤ 3^n`. The companion upper-bound
direction (`lcmRange ≤ n · primorial`) is left for future iterations
— it requires a Chebyshev-type bound on small primes (each `p ≤ √n`
contributes a factor `p^(⌊log_p n⌋ - 1) ≤ √n` beyond its primorial
contribution).

## Diff

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`: +46 lines
  after `lcmRange_le_pow_pred` (Iter 14). New import:
  `Mathlib.NumberTheory.Primorial`.
- `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md`:
  Iter 15 entry.

File 657 → 703 lines, theorems 43 → 45, definitions/sorries/axiomCount
unchanged.

## Build status

**Pending.** Following established `(build pending)` convention used
by recent Iters 7-14 (`proofs/.lake` recursive-symlink build infra
issue). Proof bodies use only Mathlib API already exercised by prior
iterations: `Finset.prod_dvd_prod_of_dvd`, `Nat.log_pos`,
`dvd_pow_self`, `Nat.le_of_dvd`.

## Test plan

- [ ] Build verification (deferred to consolidated build)
- [x] Diff is purely additive (no edits to existing theorems)
- [x] Branch base = fresh `5f3e2b92a23` (post-Iter 14 PR #17513,
      post-Iter 13 PR #17499, post-Iter 12 PR #17448)
- [x] No collision with Iter 14's primeCounting work — different
      direction (primorial divisibility vs prime-counting bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)