### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S14 — Part XX symmetric LPB-eq biconditional (build pending)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -1084,6 +1084,85 @@ theorem largestPrimeBelow_eightynine_lt_ninetyseven :
     largestPrimeBelow 89 < largestPrimeBelow 97 :=
   largestPrimeBelow_strict_mono_at_prime 89 97 (by decide) (by norm_num)
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XX: Symmetric biconditional — drop the order hypothesis
+-- ═══════════════════════════════════════════════════════════════════════
+-- The Part XIX biconditional `largestPrimeBelow_eq_iff_no_prime_in_range`
+-- carries an `n ≤ m` hypothesis.  Equality of `largestPrimeBelow` values
+-- is symmetric in its arguments, so the same characterization holds for
+-- the unordered pair `{n, m}`: the condition becomes "no prime in
+-- `(min n m, max n m]`".
+--
+-- The symmetric form is the canonical statement when the order between
+-- `n` and `m` is unknown or context-dependent (e.g., the conjectured
+-- collapse `symBUDim n d = symBUDim m d` for an unordered pair).
+
+/-- **Symmetric plateau characterization**: for any `n m : ℕ`,
+    `largestPrimeBelow n = largestPrimeBelow m` iff no prime lies in
+    the half-open interval `(min n m, max n m]`.  Drops the `n ≤ m`
+    hypothesis from `largestPrimeBelow_eq_iff_no_prime_in_range` by
+    case-splitting on `le_total n m`.  Axiom-free. -/
+theorem largestPrimeBelow_eq_iff_no_prime_in_range_symm (n m : ℕ) :
+    largestPrimeBelow n = largestPrimeBelow m ↔
+      (∀ k, min n m < k → k ≤ max n m → ¬ Nat.Prime k) := by
+  rcases le_total n m with hnm | hmn
+  · rw [min_eq_left hnm, max_eq_right hnm]
+    exact largestPrimeBelow_eq_iff_no_prime_in_range n m hnm
+  · rw [min_eq_right hmn, max_eq_left hmn]
+    refine ⟨fun h => ?_, fun h => ?_⟩
+    · exact (largestPrimeBelow_eq_iff_no_prime_in_range m n hmn).mp h.symm
+    · exact ((largestPrimeBelow_eq_iff_no_prime_in_range m n hmn).mpr h).symm
+
+/-- **Symmetric strict-monotonicity contrapositive**: if a prime lies in
+    either half-open interval `(n, m]` or `(m, n]`, then `largestPrimeBelow
+    n ≠ largestPrimeBelow m`.  Together with
+    `largestPrimeBelow_eq_iff_no_prime_in_range_symm` this packages both
+    directions of the order-free characterization. -/
+theorem largestPrimeBelow_ne_of_prime_in_range_symm
+    (n m p : ℕ) (hp : Nat.Prime p)
+    (h : (n < p ∧ p ≤ m) ∨ (m < p ∧ p ≤ n)) :
+    largestPrimeBelow n ≠ largestPrimeBelow m := by
+  rcases h with ⟨hnp, hpm⟩ | ⟨hmp, hpn⟩
+  · exact ne_of_lt (largestPrimeBelow_lt_of_prime_in_range n m p hp hnp hpm)
+  · exact (ne_of_lt (largestPrimeBelow_lt_of_prime_in_range m n p hp hmp hpn)).symm
+
+/-- **Unordered symBUDim collapse**: for `n, m ≥ 2` and `d` arbitrary, if
+    no prime lies in `(min n m, max n m]`, then `symBUDim n d = symBUDim
+    m d`.  Combines the symmetric LPB-iff with `symBUDim_eq_of_lpb_eq`
+    (which uses the file axiom).  Conditional on
+    `symBUDim_eq_largestPrime`. -/
+theorem symBUDim_const_in_unordered_no_prime_range
+    (n m d : ℕ) (hn : 2 ≤ n) (hm : 2 ≤ m)
+    (h : ∀ k, min n m < k → k ≤ max n m → ¬ Nat.Prime k) :
+    symBUDim n d = symBUDim m d :=
+  symBUDim_eq_of_lpb_eq n m d hn hm
+    ((largestPrimeBelow_eq_iff_no_prime_in_range_symm n m).mpr h)
+
+/-- **Hypothesis-form** of `symBUDim_const_in_unordered_no_prime_range` —
+    uses explicit `ConjectureLPB` hypothesis instead of the file's axiom. -/
+theorem symBUDim_const_in_unordered_no_prime_range_of
+    (h_conj : ConjectureLPB) (n m d : ℕ) (hn : 2 ≤ n) (hm : 2 ≤ m)
+    (h : ∀ k, min n m < k → k ≤ max n m → ¬ Nat.Prime k) :
+    symBUDim n d = symBUDim m d :=
+  symBUDim_eq_of_lpb_eq_of h_conj n m d hn hm
+    ((largestPrimeBelow_eq_iff_no_prime_in_range_symm n m).mpr h)
+
+/-- **Concrete reverse-order instance**: re-derives the Part XVII LPB
+    plateau equality `largestPrimeBelow 10 = largestPrimeBelow 8` via
+    the symmetric biconditional applied with arguments swapped (LHS:
+    `n = 10 > m = 8`).  Demonstrates that the new iff handles the
+    non-canonical order without going through `Eq.symm`. -/
+theorem largestPrimeBelow_ten_eq_eight :
+    largestPrimeBelow 10 = largestPrimeBelow 8 := by
+  refine (largestPrimeBelow_eq_iff_no_prime_in_range_symm 10 8).mpr ?_
+  intro k hk1 hk2
+  -- min 10 8 = 8, max 10 8 = 10
+  have hmin : min (10 : ℕ) 8 = 8 := by decide
+  have hmax : max (10 : ℕ) 8 = 10 := by decide
+  rw [hmin] at hk1
+  rw [hmax] at hk2
+  exact no_prime_in_eight_to_ten k hk1 hk2
+
 /-
 ## Summary
 
@@ -1304,6 +1383,30 @@ theorem largestPrimeBelow_eightynine_lt_ninetyseven :
   each plateau as a *maximal* level set of `largestPrimeBelow` (rather
   than a possibly-extendable equal-LPB cluster).
 
+### Iteration 14 additions (symmetric biconditional — Part XX)
+- `largestPrimeBelow_eq_iff_no_prime_in_range_symm` — **axiom-free**
+  drop of the `n ≤ m` hypothesis from the Part XIX biconditional.
+  For arbitrary `n m : ℕ`, `largestPrimeBelow n = largestPrimeBelow m`
+  iff no prime lies in `(min n m, max n m]`.  Routine case-split via
+  `le_total n m` reducing each branch to the asymmetric iff with
+  arguments in the canonical order.  This is the order-free statement
+  natural for unordered pairs.
+- `largestPrimeBelow_ne_of_prime_in_range_symm` — symmetric
+  contrapositive: prime in either `(n, m]` or `(m, n]` ⇒
+  `largestPrimeBelow n ≠ largestPrimeBelow m`.  Packages both directions
+  of the order-free characterization.
+- `symBUDim_const_in_unordered_no_prime_range` (conditional on
+  `symBUDim_eq_largestPrime`) and `_of` (hypothesis form): unordered
+  symBUDim collapse — for `n, m ≥ 2`, no prime in `(min n m, max n m]`
+  forces `symBUDim n d = symBUDim m d` at every `d`.  Direct
+  composition of the new iff with `symBUDim_eq_of_lpb_eq` /
+  `symBUDim_eq_of_lpb_eq_of`.
+- `largestPrimeBelow_ten_eq_eight` — concrete demo: re-derives
+  `lpb 10 = lpb 8` by applying the new iff with arguments in the
+  *non-canonical* order (`n = 10 > m = 8`), without going through
+  `Eq.symm` of the existing `largestPrimeBelow_eight_eq_ten`.  Verifies
+  `min`/`max` reduce as expected at concrete values.
+
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
   axiomatizing or proving `symBUDim 3 d ≤ buDim 3 d`; n=3 is *not*
@@ -1373,4 +1476,10 @@ theorem largestPrimeBelow_eightynine_lt_ninetyseven :
 #check @largestPrimeBelow_thirteen_lt_seventeen
 #check @largestPrimeBelow_twentythree_lt_twentynine
 #check @largestPrimeBelow_eightynine_lt_ninetyseven
+
+#check @largestPrimeBelow_eq_iff_no_prime_in_range_symm
+#check @largestPrimeBelow_ne_of_prime_in_range_symm
+#check @symBUDim_const_in_unordered_no_prime_range
+#check @symBUDim_const_in_unordered_no_prime_range_of
+#check @largestPrimeBelow_ten_eq_eight
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-09T02:00:00Z
-**Iteration**: 13
+**Since**: 2026-05-09T02:30:00Z
+**Iteration**: 14
 
 ## Current Focus
 
@@ -577,3 +577,88 @@ the ground truth.
    conjecture for many small-n applications).
 4. Stretch (unchanged): falsification target `buDim 3 3` via
    equivariant cohomology of Z/3 on simple S²-actions.
+
+## Iteration 14 Builds (researcher-13, 2026-05-09)
+
+Focus: **drop the order hypothesis from the Part XIX biconditional** —
+execute Path Forward Item 1 from Iter 13 (`Symmetric biconditional`).
+The Part XIX iff `largestPrimeBelow_eq_iff_no_prime_in_range` requires
+`n ≤ m`; the new symmetric form characterizes the unordered pair via
+`min`/`max`.
+
+### Part XX additions (axiom-free)
+
+- `largestPrimeBelow_eq_iff_no_prime_in_range_symm`: for arbitrary
+  `n m : ℕ` (no order hypothesis), `largestPrimeBelow n =
+  largestPrimeBelow m ↔ ∀ k, min n m < k → k ≤ max n m → ¬ Nat.Prime k`.
+  Routine case-split via `le_total n m`: each branch reduces to the
+  asymmetric Part XIX iff with arguments in the canonical order, with
+  `Eq.symm` bridging the LHS in the reverse case. Six lines.
+- `largestPrimeBelow_ne_of_prime_in_range_symm`: structural
+  contrapositive for the unordered pair — prime in either `(n, m]`
+  *or* `(m, n]` ⇒ `largestPrimeBelow n ≠ largestPrimeBelow m`. Built
+  from `largestPrimeBelow_lt_of_prime_in_range` applied in each
+  direction; the second case finishes via `(ne_of_lt _).symm`.
+
+### Part XX additions (conditional on `symBUDim_eq_largestPrime`)
+
+- `symBUDim_const_in_unordered_no_prime_range`: for `n, m ≥ 2` and
+  arbitrary `d`, no prime in `(min n m, max n m]` ⇒ `symBUDim n d =
+  symBUDim m d`. One-line composition of the new symmetric iff with
+  `symBUDim_eq_of_lpb_eq` (Part XVI's symBUDim-LPB transfer).
+- `symBUDim_const_in_unordered_no_prime_range_of`: hypothesis-form
+  variant taking `ConjectureLPB` explicitly.
+
+### Part XX additions (concrete demo)
+
+- `largestPrimeBelow_ten_eq_eight`: re-derives the Part XVII LPB
+  plateau equality `largestPrimeBelow 10 = largestPrimeBelow 8` via
+  the new symmetric iff applied with arguments in the *non-canonical*
+  order (`n = 10 > m = 8`), without going through `Eq.symm` of the
+  existing `largestPrimeBelow_eight_eq_ten`. Verifies that `min`/`max`
+  reduce as expected at concrete numerics (`min 10 8 = 8` and
+  `max 10 8 = 10`, both by `decide`).
+
+**Counts**: lineCount 1376→1485 (+109), theoremCount 88→93 (+5,
+substantive 86→91), definitionCount 2 (unchanged), axiomCount 1
+(unchanged), sorries 0 (unchanged).
+
+**Significance**: this iteration packages the iter-13 biconditional in
+its order-free form. The asymmetric Part XIX iff was the structural
+result; the Part XX symmetrization is the *canonical statement* for
+unordered pairs `{n, m}` and removes a routine boilerplate every
+downstream caller would otherwise have to apply. It is also a
+prerequisite for downstream symBUDim-side iff packaging where the
+unordered pair is more natural than imposing an arbitrary order.
+
+The downstream `symBUDim_const_in_unordered_no_prime_range` family
+delivers the conjectural collapse `symBUDim n d = symBUDim m d` for
+unordered pairs satisfying the no-prime-in-gap condition — directly
+addressing the structural prediction from Iter 11 Part XVII without
+needing to choose `min`/`max` orientation upfront.
+
+**Build**: pending (Docker rebuild from fresh Mathlib cache —
+worktree's proofs/.lake recursive self-symlink forces ≥45-min cold-cache
+builds per `feedback_researcher_lake_symlink_broken.md`). All new
+content uses only Mathlib API exercised by earlier iterations
+(`le_total`, `min_eq_left`, `min_eq_right`, `max_eq_left`,
+`max_eq_right`, `decide`, `Eq.symm`); the proof-side risk is minimal.
+CI is the ground truth.
+
+**Path forward** (revised post-iter-14):
+1. **symBUDim-side biconditional** (still pending): characterize when
+   `symBUDim n d = symBUDim m d` for *all* `d` in terms of the
+   no-prime-in-range condition. Forward direction is now the new
+   `symBUDim_const_in_unordered_no_prime_range`; the reverse direction
+   needs `symBUDim_cyc` injectivity-across-primes which is not
+   currently axiomatized. May be in scope as a *one-direction* iff
+   bridging Part XVI and the symmetric form.
+2. Stretch (unchanged): n=3 case directly via `symBUDim_three`-style
+   axiom, or n=4 case via Klein-4 V₄ ≤ S₄ structure.
+3. Stretch (unchanged): falsification target `buDim 3 3` via
+   equivariant cohomology of Z/3 on simple S²-actions.
+4. **Concrete unordered-pair instances**: apply
+   `symBUDim_const_in_unordered_no_prime_range` to specific small-n
+   pairs (`{8, 10}`, `{13, 16}`, `{23, 28}`, `{89, 96}`) to package
+   each Part XVII–XVIII plateau as an unordered-pair statement. Likely
+   incremental; gauge value before committing.

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1376,
+    "lineCount": 1485,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -114,7 +114,7 @@
       "largestPrimeBelow_eight_lt_eleven, _thirteen_lt_seventeen, _twentythree_lt_twentynine, _eightynine_lt_ninetyseven (axiom-free, iter 13): plateau-edge witnesses at the four prime-gap intervals from Parts XVII–XVIII. Together with the corresponding eq-instances, pin each plateau as a *maximal* level set of `largestPrimeBelow` rather than a possibly-extendable cluster."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d ≥ 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d − 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d − 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 88,
+    "theoremCount": 93,
     "definitionCount": 2
   },
   "overview": {
@@ -307,10 +307,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1376,
+    "lineCount": 1485,
     "axiomCount": 1,
-    "theoremCount": 88,
-    "substantiveTheoremCount": 86,
+    "theoremCount": 93,
+    "substantiveTheoremCount": 91,
     "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iteration 14 of the symmetric-group Borsuk-Ulam OQ. Adds **Part XX** — the order-free version of the iter-13 Part XIX biconditional, executing **Path Forward Item 1** from iter 13 (`Symmetric biconditional`).

The Part XIX iff `largestPrimeBelow_eq_iff_no_prime_in_range` carried an `n ≤ m` hypothesis. The new symmetric form characterizes the unordered pair `{n, m}`: `largestPrimeBelow n = largestPrimeBelow m ↔ no prime in (min n m, max n m]`. Routine case-split via `le_total n m`.

## Progress

### Axiom-free additions (3 new + 1 demo)

- `largestPrimeBelow_eq_iff_no_prime_in_range_symm`: order-free iff. Six-line proof — each branch of `le_total` reduces to the asymmetric Part XIX iff with arguments in canonical order; the reverse case bridges via `Eq.symm`.
- `largestPrimeBelow_ne_of_prime_in_range_symm`: structural contrapositive. Prime in either `(n, m]` or `(m, n]` ⇒ `largestPrimeBelow n ≠ largestPrimeBelow m`. Built from `largestPrimeBelow_lt_of_prime_in_range` in each direction.
- `largestPrimeBelow_ten_eq_eight`: concrete demo. Re-derives Part XVII's `lpb 10 = lpb 8` via the new iff applied with arguments in *non-canonical* order (`n = 10 > m = 8`), without going through `Eq.symm` of `largestPrimeBelow_eight_eq_ten`. Verifies `min`/`max` reduce as expected at concrete numerics.

### Conditional additions (2 new, on `symBUDim_eq_largestPrime`)

- `symBUDim_const_in_unordered_no_prime_range`: for `n, m ≥ 2` and arbitrary `d`, no prime in `(min n m, max n m]` ⇒ `symBUDim n d = symBUDim m d`. One-line composition of the new symmetric iff with `symBUDim_eq_of_lpb_eq` (Part XVI).
- `symBUDim_const_in_unordered_no_prime_range_of`: hypothesis-form variant taking `ConjectureLPB` explicitly.

## Significance

The asymmetric Part XIX iff is the *structural* result; Part XX symmetrization is the *canonical statement* for unordered pairs `{n, m}`. The symmetric form removes routine boilerplate every downstream caller would otherwise apply, and is the natural form for downstream symBUDim-side packaging where unordered pairs predominate.

The conditional symBUDim-collapse statements (`symBUDim_const_in_unordered_no_prime_range{,_of}`) deliver the conjectural plateau prediction directly on unordered pairs without requiring callers to choose `min`/`max` orientation upfront.

## Independence

No collision with open PRs:
- PR #17286 (S8) is in `CONFLICTING` state, distinct content (concrete LPB at composite n).
- PR #17460 (S11) is in `CONFLICTING` state, superseded by merged PR #17461.

Branched from latest `origin/main` at `79add29bda3` (S13 merge).

## Counts

| Field | Before | After | Δ |
|---|---|---|---|
| lineCount | 1376 | 1485 | +109 |
| theoremCount | 88 | 93 | +5 |
| substantiveTheoremCount | 86 | 91 | +5 |
| definitionCount | 2 | 2 | 0 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

## Files modified

- `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` (+109 lines: Part XX section + Summary subsection + 5 `#check` lines)
- `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json` (lineCount/theoremCount/substantiveTheoremCount sync)
- `research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md` (Iteration 14 entry; Iteration field 13→14)

## Build

**Pending.** No `lake build` run locally per project policy (Docker wrapper required and ~45 min from cold cache; worktree's `proofs/.lake` recursive symlink forces a fresh Mathlib cache build per `feedback_researcher_lake_symlink_broken.md`). All new proofs use only Mathlib API exercised by earlier iterations (`le_total`, `min_eq_left/right`, `max_eq_left/right`, `decide`, `Eq.symm`); proof-side risk is minimal. Verifying via Docker post-merge / CI is recommended.

## Status

**Outcome**: progress (axiom-free + conditional content added; no axioms or sorries introduced).

**Next Steps**: (1) symBUDim-side biconditional packaging — only the forward direction lifts cleanly without `symBUDim_cyc` injectivity. (2) Concrete unordered-pair instances at the four Part XVII–XVIII plateaus. (3) Stretch goals at small n=3, n=4 unchanged.

## Test plan

- [ ] CI build verifies `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` compiles with no new sorries or axioms.
- [ ] All five new theorem signatures appear in the file's `#check` footer (verified before push).
- [ ] meta.json counts match actual file (`grep -c '^theorem '` = 93).

🤖 Generated by researcher-13