### PR TITLE
fix(meta): batch sync lineCount drift (2 entries)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -271,7 +271,7 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1186,
+    "lineCount": 1248,
     "axiomCount": 1,
     "theoremCount": 26,
     "substantiveTheoremCount": 18,

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 606,
+    "lineCount": 714,
     "theoremCount": 10,
     "definitionCount": 0,
     "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Status flag remains `axiomatized` and badge remains `axiom` pending Docker CI verification of the post-S14 source \u2014 the broken `proofs/.lake` recursive self-symlink in this repo forces every full build into a 30\u201345 min Mathlib refetch, so build verification is gated on a separate Mechanic infra-repair pass. Once CI confirms a green build, the entry will graduate to status `verified` / badge `original` via a follow-up Mechanic/Auditor PR. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
@@ -170,7 +170,7 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 606,
+    "lineCount": 714,
     "theoremCount": 10,
     "definitionCount": 0,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

Sync `lineCount` fields to actual Lean file line counts for 2 gallery entries with stale counts.

## Per-entry deltas (claimed → actual)

| slug | location | claimed | actual |
|------|----------|---------|--------|
| abel-ruffini-galois-extensions-oq-07 | leanFile.lineCount | 1186 | 1248 |
| minkowski-theorem-oq-04 | meta.lineCount + leanFile.lineCount | 606 | 714 |

## Evidence

`wc -l` on the source files in `proofs/Proofs/`:

```
1248 proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
 714 proofs/Proofs/MinkowskiTheoremOQ04.lean
```

**abel-ruffini-galois-extensions-oq-07**: `meta.lineCount=1248` is already correct (from PR #17416), but the structurally-paired `leanFile.lineCount=1186` was not updated by the subsequent S12–S14 research PRs (#17450, #17472, #17536) that added 62 lines.

**minkowski-theorem-oq-04**: both `meta.lineCount` and `leanFile.lineCount` were `606` (per PR #17479's pre-S13/S14 sync); the post-PR file is 714 lines. (Note: the theoremCount drift for this slug is already covered by open PR #17553.)

Surgical 1- and 2-line `Edit` replacements; no other formatting changed. No overlap with currently-open mechanic PRs (#17543, #17545, #17547, #17553, #17557).

---
Automated fix by lean-mechanic agent.