### PR TITLE
research(amgm-inequality-oq-04-oq-02): S9 part 4 — K-side integral identity (build pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -1325,4 +1325,104 @@ theorem integral_auxFnK_deriv_eq_zero (hk : k ^ 2 < 1) :
   show auxFnK k (π / 2) - auxFnK k 0 = 0
   rw [auxFnK_pi_div_two, auxFnK_zero, sub_zero]
 
+-- ============================================================================
+-- § 16. K-side Integral Identity (S9 part 4 — IBP closure for `dIntegrandK`)
+-- ============================================================================
+
+/-
+Combining §15's `integral_auxFnK_deriv_eq_zero` (FTC closure on `auxFnK`)
+with §12's `integral_cos_sq_div_sqrt_denom` discharges the K-side integral
+identity:
+
+    ∫₀^{π/2} dIntegrandK k θ dθ
+      = (E(k) − (1 − k²) · K(k)) / (k · (1 − k²)).
+
+This is the K-analog of §8's `integral_dIntegrandE_eq` and the final
+ingredient for the S10 `dK_dk` assembly via the parametric-integral lemma
+of Mathlib (`hasDerivAt_integral_of_dominated_loc_of_deriv_le`).
+
+Proof sketch.
+
+  • S9 part 3 yields  ∫ cos²θ/√D − (1−k²) sin²θ/(D·√D) dθ = 0,
+    i.e. ∫ cos²θ/√D dθ = (1−k²) ∫ sin²θ/(D·√D) dθ.
+  • Pointwise, dIntegrandK k θ = k · sin²θ / (D·√D), so
+    ∫ sin²θ/(D·√D) dθ = (∫ dIntegrandK k θ dθ) / k.
+  • S8 (`integral_cos_sq_div_sqrt_denom`) yields
+    ∫ cos²θ/√D dθ = (E − (1−k²) K) / k².
+  • Combining: (1−k²) · (∫ dIntegrandK)/k = (E − (1−k²) K)/k², hence
+    ∫ dIntegrandK = (E − (1−k²) K) / (k · (1−k²)).
+-/
+
+/-- **K-side integral identity** (S9 part 4 — IBP closure for `dIntegrandK`).
+
+    For `0 < k < 1`,
+    `∫₀^{π/2} dIntegrandK k θ dθ = (E(k) − (1 − k²) · K(k)) / (k · (1 − k²))`.
+
+    Proof: apply `integral_auxFnK_deriv_eq_zero` (S9 part 3) to obtain the FTC
+    boundary-vanishing identity; rewrite its `(1 − k²) · sin²θ / (D · √D)`
+    term as `(1 − k²) / k · dIntegrandK k θ` (pointwise, via the definition of
+    `dIntegrandK`); split via `intervalIntegral.integral_sub`; pull the
+    constant `(1 − k²) / k` out via `intervalIntegral.integral_const_mul`;
+    substitute `integral_cos_sq_div_sqrt_denom` (S8) for the `cos²θ / √D`
+    integral; solve the resulting linear equation for `∫ dIntegrandK k θ dθ`.
+
+    This is the K-analog of `integral_dIntegrandE_eq` (§8). The conclusion
+    feeds the `h_int_eq` rewrite of the S10 `dK_dk` assembly. -/
+theorem integral_dIntegrandK_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
+    ∫ θ in (0 : ℝ)..π / 2, dIntegrandK k θ
+      = (ellipticE k - (1 - k ^ 2) * AmgmInequalityOQ04OQ01.ellipticK k)
+          / (k * (1 - k ^ 2)) := by
+  have hk_sq : k ^ 2 < 1 := by nlinarith
+  have hk_ne : k ≠ 0 := ne_of_gt hk_pos
+  have h1mk2_pos : 0 < 1 - k ^ 2 := by linarith
+  have h1mk2_ne : (1 - k ^ 2) ≠ 0 := h1mk2_pos.ne'
+  have hk_sq_ne : (k : ℝ) ^ 2 ≠ 0 := pow_ne_zero 2 hk_ne
+  -- Apply S9 part 3 (FTC closure for `auxFnK`).
+  have h_ftc := integral_auxFnK_deriv_eq_zero (k := k) hk_sq
+  -- Pointwise rewrite: the FTC integrand's second term equals
+  -- `(1 - k²) / k * dIntegrandK k θ` (via the definition of `dIntegrandK`).
+  have h_pw : ∀ θ ∈ Set.uIcc (0 : ℝ) (π / 2),
+      Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+        - (1 - k ^ 2) * Real.sin θ ^ 2 /
+          ((1 - k ^ 2 * Real.sin θ ^ 2)
+            * Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+      = Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2)
+          - (1 - k ^ 2) / k * dIntegrandK k θ := by
+    intro θ _
+    have hp : 0 < 1 - k ^ 2 * Real.sin θ ^ 2 :=
+      AmgmInequalityOQ04OQ01.denom_pos hk_sq θ
+    have hsp : 0 < Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) :=
+      AmgmInequalityOQ04OQ01.sqrt_denom_pos hk_sq θ
+    have hp_ne : (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hp.ne'
+    have hsp_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hsp.ne'
+    unfold dIntegrandK
+    field_simp
+    ring
+  rw [intervalIntegral.integral_congr h_pw] at h_ftc
+  -- Split the integral and pull the constant `(1-k²)/k` outside.
+  have h_cos_int : IntervalIntegrable
+      (fun θ : ℝ => Real.cos θ ^ 2 / Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2))
+      MeasureTheory.volume 0 (π / 2) := by
+    apply Continuous.intervalIntegrable
+    refine Continuous.div₀ (continuous_cos.pow 2) ?_ ?_
+    · exact Real.continuous_sqrt.comp
+        (Continuous.sub continuous_const
+          (continuous_const.mul (continuous_sin.pow 2)))
+    · intro θ
+      exact (AmgmInequalityOQ04OQ01.sqrt_denom_pos hk_sq θ).ne'
+  have h_dK_int : IntervalIntegrable (dIntegrandK k) MeasureTheory.volume 0 (π / 2) :=
+    dIntegrandK_integrable hk_sq
+  rw [intervalIntegral.integral_sub h_cos_int
+        (h_dK_int.const_mul ((1 - k ^ 2) / k))] at h_ftc
+  rw [intervalIntegral.integral_const_mul] at h_ftc
+  -- Substitute the S8 cos² integral identity.
+  rw [integral_cos_sq_div_sqrt_denom hk_pos hk_lt] at h_ftc
+  -- h_ftc: (E - (1-k²)·K) / k² - (1-k²)/k · ∫ dIntegrandK = 0
+  -- Solve for ∫ dIntegrandK = (E - (1-k²)·K) / (k·(1-k²)).
+  rw [eq_div_iff (mul_ne_zero hk_ne h1mk2_ne)]
+  -- Clear denominators in h_ftc (multiply by k²) to obtain a polynomial form,
+  -- then close by `linear_combination` (which uses `ring` for commutativity).
+  field_simp at h_ftc
+  linear_combination -h_ftc
+
 end AmgmInequalityOQ04OQ02

--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part4-k-integral-identity.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part4-k-integral-identity.md
@@ -1,0 +1,143 @@
+# Session 9 part 4 — K-side integral identity (`integral_dIntegrandK_eq`)
+
+**Researcher**: researcher-9
+**Date**: 2026-05-09
+**Branch**: `research/amgm-oq04oq02-s9-part4-k-integral-1778285537`
+**Build status**: docker build queued (cold cache; lake clone + cache get
+in progress; ~45 min cycles).
+
+## Summary
+
+Adds a single ~95-line public theorem (`integral_dIntegrandK_eq`) — new
+§16 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — that closes the
+**K-side integral identity** by combining S9 part 3 (FTC closure on
+`auxFnK`, merged via #17540) with S8 (`integral_cos_sq_div_sqrt_denom`,
+merged via #17451):
+
+```lean
+theorem integral_dIntegrandK_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
+    ∫ θ in (0 : ℝ)..π / 2, dIntegrandK k θ
+      = (ellipticE k - (1 - k ^ 2) * AmgmInequalityOQ04OQ01.ellipticK k)
+          / (k * (1 - k ^ 2))
+```
+
+This is the K-analog of §8's `integral_dIntegrandE_eq` and the final
+ingredient that the S10 `dK_dk` assembly (~30 lines, parallel to PR
+#17371's `dE_dk` template) needs to feed
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`.
+
+## Proof structure
+
+1. Apply S9 part 3 (`integral_auxFnK_deriv_eq_zero`) to get the
+   FTC identity
+   `∫₀^{π/2} (cos²θ/√D − (1−k²) sin²θ/(D·√D)) dθ = 0` (where
+   `D = 1 − k² sin²θ`).
+2. **Pointwise rewrite**: `(1−k²) · sin²θ / (D · √D) = (1−k²)/k · dIntegrandK k θ`
+   (definition of `dIntegrandK = k · sin²θ / (D · √D)`); discharged by
+   `unfold dIntegrandK; field_simp; ring`.
+3. **Split** via `intervalIntegral.integral_sub` (with cos² and
+   `dIntegrandK` integrability hypotheses) and
+   `intervalIntegral.integral_const_mul` to pull the `(1−k²)/k` factor
+   outside.
+4. **Substitute** S8 (`integral_cos_sq_div_sqrt_denom`) for the
+   `∫ cos²θ/√D dθ = (E − (1−k²)·K)/k²` term.
+5. **Solve** the resulting linear equation
+   `(E − (1−k²)·K)/k² − (1−k²)/k · ∫ dIntegrandK = 0` for
+   `∫ dIntegrandK`, via `eq_div_iff`, `field_simp`, `linarith`.
+
+## Mathlib API surface
+
+Zero new lemmas. Composes from existing helpers + standard Mathlib:
+
+- File-local helpers (all merged on `origin/main`): `integral_auxFnK_deriv_eq_zero`
+  (S9 part 3, §15, #17540), `integral_cos_sq_div_sqrt_denom` (S8, §12,
+  #17451), `dIntegrandK_integrable` (§10, #17373), `dIntegrandK` (def, §10).
+- Mathlib core: `intervalIntegral.integral_congr`, `intervalIntegral.integral_sub`,
+  `intervalIntegral.integral_const_mul`, `IntervalIntegrable.const_mul`,
+  `Continuous.div₀`, `eq_div_iff`, `mul_ne_zero`, `pow_ne_zero`,
+  `field_simp`, `linarith`, `nlinarith`.
+- Imported from `AmgmInequalityOQ04OQ01`: `denom_pos`, `sqrt_denom_pos`,
+  `ellipticK`.
+
+No new imports.
+
+## Counts
+
+|              | Before (S9 part 3) | After (S9 part 4) | Δ    |
+|--------------|-------------------:|------------------:|-----:|
+| Lines        | 1328               | 1426              | +98  |
+| Theorems     | 45                 | 46                | +1   |
+| Defs         | 10                 | 10                | 0    |
+| Axioms       | 1                  | 1                 | 0    |
+| Sorries      | 0                  | 0                 | 0    |
+
+The meta.json `lineCount`/`theoremCount`/`definitionCount` for
+`AmgmInequalityOQ04OQ02.lean` were stale (showing 697/33/8 — pre-S5).
+This session syncs them to 1426/46/10 in passing.
+
+## Independence from open PRs (#17371, #17445, #17471, #17477)
+
+This PR appends §16 strictly after §15 (S9 part 3, merged on
+`origin/main`), at the very end of the file. The four currently-open
+PRs are all `CONFLICTING` (per `gh pr view`) — they were opened against
+older `origin/main` snapshots and have been superseded by intermediate
+merges. None modify §16 or its insertion point. No textual conflict.
+
+## Step toward Wronskian closure (S11)
+
+After this PR + S10 (`dK_dk` assembly, ~30 lines), the entire `dK/dk`
+machinery is in place. The remaining work to discharge the
+`legendre_relation` axiom is:
+
+| Step | Helper | Status |
+|------|--------|--------|
+| §3 cmod chain rule | `complModulus_hasDerivAt` | merged (S9 orth, #17500) |
+| §8 E pointwise + integral | `dIntegrandE_mul_k`, `integral_dIntegrandE_eq` | merged |
+| §10 K pointwise | `integrandK_hasDerivAt_in_k` | merged (S6, #17373) |
+| §11 K bound | `dIntegrandK_abs_le_bound` | merged (S7, #17431) |
+| §12 K integral building blocks | `integral_sin_sq_div_sqrt_denom`, `integral_cos_sq_div_sqrt_denom` | merged (S8, #17451) |
+| §13 auxFnK endpoints | `auxFnK_zero`, `auxFnK_pi_div_two` | merged (S9 part 1) |
+| §14 auxFnK chain rule | `auxFnK_hasDerivAt` | merged (S9 part 2, #17482) |
+| §15 auxFnK FTC | `integral_auxFnK_deriv_eq_zero` | merged (S9 part 3, #17540) |
+| **§16 K integral identity** | **`integral_dIntegrandK_eq`** | **this PR (S9 part 4)** |
+| S10 `dK_dk` assembly | `ellipticK_hasDerivAt` | next session, ~30 lines |
+| S11 Wronskian closure | discharges `legendre_relation` axiom | last step, ~50 lines |
+
+Estimated 2 more sessions to discharge the `legendre_relation` axiom
+entirely.
+
+## Build status
+
+**[BUILD UNVERIFIED]** — Docker build started this session (cold cache;
+mathlib v4.26.0 fresh-clone in progress at submit time;
+`LEAN_BUILD_TIMEOUT=45m`). The proof body uses only Mathlib-core tactics
+(`field_simp`, `linarith`, `unfold`, `ring`) plus a handful of
+`intervalIntegral` lemmas already used throughout this file (`integral_sub`,
+`integral_congr`, `integral_const_mul`). No new Mathlib API surface.
+
+Per `feedback_basel_oq03_iter12_three_fixes.md`, when ≥3 build-pending
+merges accumulate on a slug, drift can compound silently. The S6/S7/S8/S9
+chain has been all "build pending" — but S9 part 3 (`integral_auxFnK_deriv_eq_zero`)
+is the most direct ancestor, and our consumption of its conclusion
+matches exactly the published statement.
+
+## Files modified
+
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — new §16 at lines 1329–1424
+  (~95 lines incl. ~30-line section header + docstring; insertion at very
+  end of file, immediately before `end AmgmInequalityOQ04OQ02`).
+- `src/data/research/problems/amgm-inequality-oq-04-oq-02.json` — leanFile
+  `lineCount` 697→1426, `theoremCount` 33→46, `definitionCount` 8→10;
+  `currentState.iteration` 10→11, focus/nextAction updated for S9 part 4;
+  `lastUpdate` bumped.
+- `research/problems/amgm-inequality-oq-04-oq-02/state.md` — Iteration 11
+  section appended.
+- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part4-k-integral-identity.md`
+  — this note (NEW).
+
+## Outcome
+
+**Progress** (1 helper added; closes the K-side integral identity via
+IBP boundary-vanishing on `auxFnK` + the cos² building block; the S10
+`dK_dk` assembly now reduces to a direct invocation of Mathlib's
+parametric-integral lemma).

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,10 +1,58 @@
 # Current State
 
-**Phase**: ACT (S9 part 3 — FTC closure on auxFnK landing here; S9 part 4 next)
-**Since**: 2026-05-08T23:48:00Z
-**Iteration**: 10
+**Phase**: ACT (S9 part 4 — K-side integral identity landing here; S10 dK_dk assembly next)
+**Since**: 2026-05-09T02:00:00Z
+**Iteration**: 11
 
-## Iteration 10 (2026-05-08T23:48Z, researcher-5): S9 part 3 — FTC closure on auxFnK
+## Iteration 11 (2026-05-09T02:00Z, researcher-9): S9 part 4 — K-side integral identity
+
+Session 9 part 4 (ACT, this PR) closes the **K-side integral identity**
+via IBP boundary-vanishing on `auxFnK` + the cos² building block:
+
+```lean
+theorem integral_dIntegrandK_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
+    ∫ θ in (0 : ℝ)..π / 2, dIntegrandK k θ
+      = (ellipticE k - (1 - k ^ 2) * AmgmInequalityOQ04OQ01.ellipticK k)
+          / (k * (1 - k ^ 2))
+```
+
+New §16 in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (~95 lines).
+The proof composes:
+
+  1. `integral_auxFnK_deriv_eq_zero` (S9 part 3, §15, merged via #17540)
+     yields `∫ (cos²θ/√D − (1−k²) sin²θ/(D·√D)) dθ = 0`.
+  2. Pointwise: `(1−k²) sin²θ / (D·√D) = (1−k²)/k · dIntegrandK k θ`
+     (from the definition `dIntegrandK = k · sin²θ / (D·√D)`).
+  3. Split via `intervalIntegral.integral_sub` + pull the constant
+     `(1−k²)/k` out via `intervalIntegral.integral_const_mul`.
+  4. Substitute `integral_cos_sq_div_sqrt_denom` (S8, §12, merged via
+     #17451) for the cos² integral: `(E − (1−k²)·K)/k²`.
+  5. Solve the resulting linear equation for `∫ dIntegrandK`:
+     `(E − (1−k²)·K) / (k · (1−k²))`.
+
+**K-analog of §8's `integral_dIntegrandE_eq`**. After this PR, the S10
+`dK_dk` assembly (~30 lines, parallel to PR #17371's `dE_dk` template)
+reduces to a direct invocation of
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` with
+§10 (chain rule, merged), §11 (uniform bound, merged), and §16 (this PR,
+integral identity) as the seven-hypothesis discharge.
+
+**Net new content**: 0 definitions, 1 theorem, 0 axioms, 0 sorries.
+**Updated total**: 10 definitions, 46 theorems, 1 axiom, 0 sorries,
+1426 lines (was 1328 on origin/main).
+
+**Independence from open PRs (#17371, #17445, #17471, #17477)**: this
+PR appends §16 strictly after §15 (S9 part 3, merged on origin/main),
+at the very end of the file. The four currently-open PRs are all
+`CONFLICTING` (superseded by intermediate merges) — none modify §16 or
+its insertion point.
+
+**Mathlib API surface**: zero new lemmas. Composes from existing helpers
++ standard Mathlib (`integral_sub`, `integral_congr`, `integral_const_mul`,
+`Continuous.div₀`, `eq_div_iff`, `field_simp`, `linarith`).
+No new imports.
+
+## Iteration 10 (2026-05-08T23:48Z, researcher-5, merged via #17540): S9 part 3 — FTC closure on auxFnK
 
 Session 10 (ACT, this PR) adds **§15** to
 `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`: the **fundamental theorem

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
@@ -26,11 +26,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-09T01:45:00Z",
-    "iteration": 10,
-    "focus": "S9 part 2 (researcher-13, this PR, stacked on PR #17471): auxFnK chain rule in θ. New §14 in proofs/Proofs/AmgmInequalityOQ04OQ02.lean: auxFnK_deriv_form_eq (algebraic equivalence of two derivative forms) + auxFnK_hasDerivAt (chain rule via HasDerivAt.mul + HasDerivAt.sqrt + HasDerivAt.div). ~170 lines, 0 sorries, 0 axioms changed. legendre_relation axiom unchanged. Stacked on PR #17471 (auxFnK definition + endpoint vanishings).",
+    "since": "2026-05-09T02:00:00Z",
+    "iteration": 11,
+    "focus": "S9 part 4 (researcher-9, this PR): K-side integral identity. New §16 in proofs/Proofs/AmgmInequalityOQ04OQ02.lean: integral_dIntegrandK_eq combines integral_auxFnK_deriv_eq_zero (S9 part 3, §15) with integral_cos_sq_div_sqrt_denom (S8, §12) to discharge ∫ dIntegrandK k θ dθ = (E - (1-k²)·K) / (k·(1-k²)). ~95 lines, 0 sorries, 0 axioms changed. legendre_relation axiom unchanged.",
     "blockers": [],
-    "nextAction": "S9 part 3 (~15 lines): apply intervalIntegral.integral_eq_sub_of_hasDerivAt to the chain rule (this PR) on [0, π/2], discharging the boundary terms via §13 endpoint vanishings (auxFnK_zero, auxFnK_pi_div_two from PR #17471). Then S9 part 4 (~15 lines) combines with §12 to extract the K-side integral identity. Then S10 (dK_dk assembly, ~30 lines, parallel to PR #17371 dE_dk template) and S11 (Wronskian closure, ~50 lines, discharges legendre_relation axiom).",
+    "nextAction": "S10 (dK_dk assembly, ~30 lines): use intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le with §10 (chain rule), §11 (uniform bound), §16 (this PR's integral identity) to prove HasDerivAt ellipticK ((E(k) - (1-k²) K(k))/(k (1-k²))) k. Parallel to PR #17371's dE_dk template. Then S11 (Wronskian closure, ~50 lines, discharges legendre_relation axiom) via eq_of_hasDerivAt_eq_zero on f(k) = E·K' + E'·K - K·K', plus the §4 chain rule complModulus_hasDerivAt (merged via #17500) for k'-derivatives.",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 3,
@@ -147,17 +147,17 @@
     ]
   },
   "started": "2026-05-06T14:45:58.507Z",
-  "lastUpdate": "2026-05-08T22:15:00Z",
+  "lastUpdate": "2026-05-09T02:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
-      "lineCount": 697,
+      "lineCount": 1426,
       "sorries": 0,
       "axiomCount": 1,
-      "theoremCount": 33,
-      "definitionCount": 8
+      "theoremCount": 46,
+      "definitionCount": 10
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `integral_dIntegrandK_eq` (~95 lines) — new §16 in
`proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — that closes the **K-side
integral identity** by combining S9 part 3 (FTC closure on `auxFnK`,
merged via #17540) with S8 (`integral_cos_sq_div_sqrt_denom`, merged via
#17451):

```lean
theorem integral_dIntegrandK_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
    ∫ θ in (0 : ℝ)..π / 2, dIntegrandK k θ
      = (ellipticE k - (1 - k ^ 2) * AmgmInequalityOQ04OQ01.ellipticK k)
          / (k * (1 - k ^ 2))
```

K-analog of §8's `integral_dIntegrandE_eq`. Final ingredient for the
S10 `dK_dk` assembly via Mathlib's parametric-integral lemma
`hasDerivAt_integral_of_dominated_loc_of_deriv_le`.

## Proof structure (~95 lines)

1. Apply S9 part 3 (`integral_auxFnK_deriv_eq_zero`) to obtain the FTC
   identity `∫ (cos²θ/√D − (1−k²) sin²θ/(D·√D)) dθ = 0`
   (where `D = 1 − k² sin²θ`).
2. **Pointwise rewrite**: `(1−k²) sin²θ / (D·√D) = (1−k²)/k · dIntegrandK k θ`
   (from `dIntegrandK = k · sin²θ / (D·√D)`); discharged by
   `unfold dIntegrandK; field_simp; ring`.
3. **Split** via `intervalIntegral.integral_sub` (with cos² and
   `dIntegrandK` integrability) and `intervalIntegral.integral_const_mul`
   to pull the `(1−k²)/k` factor out.
4. **Substitute** S8 (`integral_cos_sq_div_sqrt_denom`) for the cos²
   integral: `(E − (1−k²)·K)/k²`.
5. **Solve** the resulting linear equation
   `(E − (1−k²)·K)/k² − (1−k²)/k · ∫ dIntegrandK = 0`
   for `∫ dIntegrandK`, via `eq_div_iff`, `field_simp`, `linear_combination`.

## Step toward Wronskian closure (S11)

| Step | Helper | Status |
|------|--------|--------|
| §3 cmod chain rule | `complModulus_hasDerivAt` | merged (S9 orth, #17500) |
| §8 E integral identity | `integral_dIntegrandE_eq` | merged |
| §10 K chain rule | `integrandK_hasDerivAt_in_k` | merged (S6, #17373) |
| §11 K bound | `dIntegrandK_abs_le_bound` | merged (S7, #17431) |
| §12 K integral building blocks | `integral_sin_sq_div_sqrt_denom`, `integral_cos_sq_div_sqrt_denom` | merged (S8, #17451) |
| §13 auxFnK endpoints | `auxFnK_zero`, `auxFnK_pi_div_two` | merged (S9 part 1) |
| §14 auxFnK chain rule | `auxFnK_hasDerivAt` | merged (S9 part 2, #17482) |
| §15 auxFnK FTC | `integral_auxFnK_deriv_eq_zero` | merged (S9 part 3, #17540) |
| **§16 K integral identity** | **`integral_dIntegrandK_eq`** | **this PR (S9 part 4)** |
| S10 `dK_dk` assembly | `ellipticK_hasDerivAt` | next, ~30 lines |
| S11 Wronskian closure | discharges `legendre_relation` axiom | last, ~50 lines |

Estimated 2 more sessions to fully discharge the `legendre_relation` axiom.

## Counts

|              | Before (S9 part 3) | After (S9 part 4) | Δ    |
|--------------|-------------------:|------------------:|-----:|
| Lines        | 1328               | 1426              | +98  |
| Theorems     | 45                 | 46                | +1   |
| Defs         | 10                 | 10                | 0    |
| Axioms       | 1                  | 1                 | 0    |
| Sorries      | 0                  | 0                 | 0    |

The meta.json `lineCount`/`theoremCount`/`definitionCount` for
`AmgmInequalityOQ04OQ02.lean` were stale (showing 697/33/8 — pre-S5).
This session syncs them to 1426/46/10 in passing.

## Mathlib API surface

Zero new lemmas. Composes from existing helpers + standard Mathlib:

- File-local (all merged on `origin/main`): `integral_auxFnK_deriv_eq_zero`
  (S9 part 3, §15, #17540), `integral_cos_sq_div_sqrt_denom` (S8, §12,
  #17451), `dIntegrandK_integrable` (§10, #17373), `dIntegrandK` (def, §10).
- Mathlib core: `intervalIntegral.integral_congr`, `intervalIntegral.integral_sub`,
  `intervalIntegral.integral_const_mul`, `IntervalIntegrable.const_mul`,
  `Continuous.div₀`, `eq_div_iff`, `mul_ne_zero`, `pow_ne_zero`,
  `field_simp`, `linear_combination`, `linarith`, `nlinarith`, `unfold`, `ring`.
- Imported from `AmgmInequalityOQ04OQ01`: `denom_pos`, `sqrt_denom_pos`,
  `ellipticK`.

No new imports.

## Independence from open PRs

This PR appends §16 strictly **after §15 (S9 part 3, merged on origin/main)**,
at the very end of the file (line 1328 → 1426). The four currently-open
PRs are all `CONFLICTING` (per `gh pr view`):

- #17371 (S6 dE/dk replay) — superseded by intermediate merges.
- #17445 (S8 dE_dk replay of #17371) — superseded.
- #17471 (S9 part 1 auxFnK + endpoints) — already merged via direct push (commit `0540c6fdb81`).
- #17477 (S9 orthogonal complModulus boundary) — superseded by #17500 chain rule.

None of these modify §16 or its insertion point. **No textual conflict.**

## Build status

**[BUILD UNVERIFIED]** — Docker build started this session (cold cache;
mathlib v4.26.0 fresh-clone in progress at submit time;
`LEAN_BUILD_TIMEOUT=45m`). The proof body uses only Mathlib-core tactics
(`field_simp`, `linarith`, `unfold`, `ring`, `linear_combination`) plus
`intervalIntegral` lemmas already used throughout this file. No new
Mathlib API surface; structural risk minimal.

Per `feedback_basel_oq03_iter12_three_fixes.md`, when ≥3 build-pending
merges accumulate on a slug, drift can compound silently. The S6/S7/S8/S9
chain has been all "build pending" — but S9 part 3 (immediate ancestor)
is the most recent merge, and our consumption of its conclusion matches
exactly the published statement. Outcome reported in a follow-up comment
if any drift surfaces.

## Files modified

- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — new §16 at lines 1329–1424
  (~95 lines incl. ~30-line section header + docstring; insertion at very
  end of file, immediately before `end AmgmInequalityOQ04OQ02`).
- `src/data/research/problems/amgm-inequality-oq-04-oq-02.json` — leanFile
  `lineCount` 697→1426, `theoremCount` 33→46, `definitionCount` 8→10;
  `currentState.iteration` 10→11; focus/nextAction updated; `lastUpdate`
  bumped.
- `research/problems/amgm-inequality-oq-04-oq-02/state.md` — Iteration 11
  section prepended.
- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-09-s09-part4-k-integral-identity.md`
  (NEW) — session note.

## Outcome

**Progress** (1 helper added; closes the K-side integral identity via
IBP boundary-vanishing on `auxFnK` + the cos² building block; S10
`dK_dk` assembly now reduces to a direct invocation of Mathlib's
parametric-integral lemma).

🤖 Generated by researcher-9