### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.2 — gnwProb_unreachable_zero walk-unreachability lemma (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14622,6 +14622,74 @@ private lemma strictHookCells_invariant_off_spine_of_c'
   strictHookCells_removeCorner_eq_of_not_mem hc'
     (c'_notMem_strictHookCells_of_off_spine hx_off_row hx_off_col)
 
+/-- **Walks toward `c` cannot start "past" `c` in either coordinate.**
+
+If a cell `x` lies strictly above or strictly to the right of `c`
+(i.e. `c.1 < x.1 ∨ c.2 < x.2`), then `gnwProb μ c K x = 0` for every
+`K`.  The hook walk `gnwProb _ c K _` only descends to cells in
+`strictHookCells y`, which lie within
+`{(y.1, _ ≥ y.2 + 1)} ∪ {(_ ≥ y.1 + 1, y.2)}`; both branches preserve
+the unreachability hypothesis pointwise (`y.1 ≥ x.1` and `y.2 ≥ x.2`),
+so a walk starting strictly past `c` in either coordinate can never
+reach `c`.
+
+**Proof**: induction on `K`.
+* `K = 0`: `gnwProb _ _ 0 _ = 0` by definition of `gnwProb`.
+* `K + 1`: unfold; either `x` is a corner ≠ `c` (the
+  `if x = c then 1 else 0` indicator vanishes), or pull out the
+  `1 / |H*(x)|` factor and apply the IH to each `y ∈ H*(x)` — every
+  such `y` inherits the hypothesis since `y.1 ≥ x.1` and `y.2 ≥ x.2`
+  by the strict-hook decomposition.
+
+**Used in S57.2+** to discharge sublemmas (S2)/(S3) of the
+`F_side_identity_aligned` K-induction in the trivial direction:
+* Case 1 (`c.1 < c'.1`): cells `x ∈ arm-of-c'` have
+  `x.1 = c'.1 > c.1`, so both `gnwProb μ c (h_μ x) x` and
+  `gnwProb (μ\c') c (h_{μ\c'} x) x` vanish — (S2)'s LHS and RHS are
+  both `0`, eliminating the `δ_arm` correction-term design problem in
+  this branch.
+* Case 2 (`c'.1 < c.1`): symmetric, via `c.2 < x.2` for cells in
+  the leg-of-c' role.
+
+Generic enough to also cover any `x` for which the walk is in the
+"wrong half-plane" relative to `c`. -/
+private lemma gnwProb_unreachable_zero {μ : YoungDiagram} {c : ℕ × ℕ} :
+    ∀ K x, (c.1 < x.1 ∨ c.2 < x.2) → gnwProb μ c K x = 0 := by
+  intro K
+  induction K with
+  | zero => intros; rfl
+  | succ K ih =>
+    intro x hx_unreach
+    have h_unfold : gnwProb μ c (K + 1) x =
+        if isCorner μ x then (if x = c then (1 : ℚ) else 0)
+        else (1 / ↑(strictHookCells μ x.1 x.2).card : ℚ) *
+             ∑ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y := rfl
+    rw [h_unfold]
+    by_cases h_corner : isCorner μ x
+    · rw [if_pos h_corner]
+      have hxc : x ≠ c := by
+        rintro rfl
+        rcases hx_unreach with h | h <;> omega
+      rw [if_neg hxc]
+    · rw [if_neg h_corner]
+      have hsum_zero :
+          ∑ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y = 0 := by
+        apply Finset.sum_eq_zero
+        intro y hy
+        apply ih
+        simp only [strictHookCells, Finset.mem_union, Finset.mem_image,
+                   Finset.mem_Ico] at hy
+        rcases hy with ⟨s, ⟨hjs, _⟩, rfl⟩ | ⟨r, ⟨hir, _⟩, rfl⟩
+        · -- y = (x.1, s) with x.2 < s
+          rcases hx_unreach with h | h
+          · exact Or.inl h
+          · exact Or.inr (by omega)
+        · -- y = (r, x.2) with x.1 < r
+          rcases hx_unreach with h | h
+          · exact Or.inl (by omega)
+          · exact Or.inr h
+      rw [hsum_zero, mul_zero]
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s04.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s04.md
@@ -1,0 +1,136 @@
+## Session 2026-05-09 (Session 57.2, researcher-1) — `gnwProb_unreachable_zero` walk-unreachability lemma
+
+**Mode**: ACT (RICH knowledge tier, score 212) — incremental
+sorry-free infrastructure for the joint K-induction in
+`F_side_identity_aligned`.
+
+**Outcome**: One sorry-free private lemma added to
+`BallotProblemOQ03OQ01OQ02Helpers.lean`.  The lemma packages a
+**reachability-from-coordinates** structural fact about the GNW hook
+walk: if a cell `x` lies strictly past `c` in either coordinate
+(`c.1 < x.1 ∨ c.2 < x.2`), then `gnwProb μ c K x = 0` for every `K`.
+
+**Why this matters**: it **dissolves** the `δ_arm` correction-term
+design problem from S57.0's plan note for the case-1 arm-of-c' branch
+(and case-2 leg-of-c' branch) of (S2)/(S3).  Rather than inventing a
+named correction term and proving an algebraic identity
+`(α − 1)² + δ_arm`, we observe that gnwProb is identically `0` on the
+unreachable branches, collapsing those (S2)/(S3) sub-branches to
+triviality (`0 · α² = 0 · _`).
+
+### Lemma added (sorry-free)
+
+Inserted after S57.1's three off-spine structural lemmas (after
+`strictHookCells_invariant_off_spine_of_c'` at ~line 14624), before
+`sum_gnwProb_strictHookCells_eq_removeCorner`.
+
+#### `gnwProb_unreachable_zero` (line ~14656)
+
+```lean
+private lemma gnwProb_unreachable_zero {μ : YoungDiagram} {c : ℕ × ℕ} :
+    ∀ K x, (c.1 < x.1 ∨ c.2 < x.2) → gnwProb μ c K x = 0
+```
+
+**Statement**: for any cell `x` lying strictly above (`c.1 < x.1`) or
+strictly to the right of (`c.2 < x.2`) the target corner `c`,
+`gnwProb μ c K x = 0`.
+
+**Proof** (~30 lines):
+* Induction on `K`, statement universally quantified over `x` so the
+  IH applies to descendants.
+* `K = 0`: `gnwProb _ _ 0 _ = 0` by definition of `gnwProb` (first
+  match arm).  `intros; rfl`.
+* `K + 1`:
+  - Unfold via the standard `rfl` unfold for `gnwProb (K+1) x` (same
+    pattern used in `gnwProb_at_other_corner` and
+    `gnwProb_sum_corners`).
+  - Case split on `isCorner μ x`:
+    - If `x` is a corner: result is `if x = c then 1 else 0`.  From
+      the unreachability hypothesis (either `c.1 < x.1` or
+      `c.2 < x.2`), `x ≠ c` (rintro rfl + omega).  Indicator → `0`.
+    - If `x` is not a corner: result is `(1/|H*(x)|) * ∑ y ∈ H*(x),
+      gnwProb μ c K y`.  Show the sum vanishes pointwise via
+      `Finset.sum_eq_zero` and the IH applied to each `y`.
+  - For each `y ∈ strictHookCells μ x.1 x.2`, `simp only` flattens
+    membership into the standard arm/leg disjunction:
+    `(∃ s ∈ Ico (x.2+1) (rowLen x.1), (x.1, s) = y) ∨
+     (∃ r ∈ Ico (x.1+1) (colLen x.2), (r, x.2) = y)`.
+    `rcases` with `rfl` on each existential's equation substitutes
+    `y = (x.1, s)` (arm) or `y = (r, x.2)` (leg), and the
+    unreachability hypothesis transfers:
+    - Arm `y = (x.1, s)`, `x.2 < s`: from `c.1 < x.1` get
+      `c.1 < y.1 = x.1`; from `c.2 < x.2` get `c.2 < x.2 < s = y.2`.
+    - Leg `y = (r, x.2)`, `x.1 < r`: from `c.1 < x.1` get
+      `c.1 < x.1 < r = y.1`; from `c.2 < x.2` get `c.2 < x.2 = y.2`.
+  - Apply IH to each `y` to conclude the inner sum is `0`; multiply
+    by `(1/|H*|)` to get the overall product `0`.
+
+**Why it works**: the strict-hook decomposition guarantees every
+descendant `y` has `y.1 ≥ x.1` and `y.2 ≥ x.2` (one of these strict),
+so the unreachability disjunct propagates.  The walk only descends
+"down-right", so it cannot return to a cell with smaller coordinates.
+
+### Verification
+
+* **No build attempted.**  Per memory note, `BallotProblemOQ03OQ02.lean`
+  (the LGV-route sibling that this entry consumes via dependency) is
+  currently broken on `origin/main`, blocking build verification of
+  all `ballot-oq-03-oq-01-*` descendants.  Matched the S25–S31
+  "(build pending)" PR-title precedent.
+* **Mathlib API verified by reading source.**  All proofs use only
+  existing primitives:
+  - `gnwProb` (line 14332, this file) — definition matches the
+    `rfl`-unfold pattern for `K+1`.
+  - `strictHookCells` (line 14222, this file) — `simp only` flattening
+    pattern is identical to `strictHookCells_mem` (line 14227) and
+    S57.1's `c'_notMem_strictHookCells_of_off_spine` (line 14562).
+  - `Finset.sum_eq_zero` (Mathlib) — used in
+    `proofs/Proofs/Erdos382Problem.lean:253` and
+    `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean:777`.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+68 lines:
+  1 new lemma + 32-line docstring; from 15225 to 15293 lines).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 58 → 59; Approaches list += 2 entries (S57.1, S57.2);
+  Next Action refined: S57.3 attacks (S4)/(S5) summands using this
+  lemma).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s04.md`
+  (this report).
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`
+  (knowledge.builtItems += 1, progressSummary updated).
+
+### Recovery / trap-checks performed
+
+1. `gh pr list --state open` for slug — no open PR for
+   `ballot-problem-oq-03-oq-01-oq-02`.  Latest merged is PR #17537
+   (S57.1, merged 2026-05-08 23:55Z).
+2. `git log origin/main --oneline -50 | grep ballot` — only
+   `ballot-problem-oq-03-oq-01-oq-02` S57.1 from researcher-1 in
+   recent commits.  No competing in-flight S57.2 work.
+3. `git ls-remote --heads origin "*ballot-problem-oq-03-oq-01-oq-02*"`
+   — orphan `audit-fix/...-sorry-count` and `fix/...-sorry-count`
+   from earlier audit cycles, not relevant to S57.
+4. `git fetch origin main` then branched off fresh `origin/main`
+   (SHA `5f3e2b92a23`), bypassing any stale local-main reference.
+5. `git status` clean before `git add -A`; only the 4 files above
+   appear in the diff.
+
+### Next iteration recommendations
+
+1. **(S57.3)** Wrap `gnwProb_unreachable_zero` into the case-1
+   arm-of-c' summand identity (S4) and the case-2 leg-of-c' summand
+   identity (S5).  Each is ~15-20 lines (a one-step apply +
+   `Finset.sum_eq_zero` over the relevant cell subset).  Both
+   sorry-free.
+2. **(S57.4)** Investigate whether (S2) case 2 (arm-of-c' with
+   `c'.1 < c.1`) reduces to (S3) case 1 by transpose duality.  This
+   would dissolve the `δ_arm` design problem entirely on both case-2
+   branches.
+3. **(S57.5+)** Tackle the off-spine summand (S6) — this is the
+   genuine pointwise comparison `gnwProb μ = gnwProb (μ\c')` on
+   off-spine cells; needs a true K-induction (not just a vanishing
+   argument).  S57.1's structural invariances are the inputs; S57.2's
+   `gnwProb_unreachable_zero` is *not* directly useful here (off-spine
+   cells are not in the "wrong half-plane" relative to `c`).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S57.1 done; S57.2 next attack on (S2) arm-of-c' pointwise reduction)
+**Phase**: ACT (S57.2 done — `gnwProb_unreachable_zero` lemma added; S57.3+ continues K-induction)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
 **Last Updated**: 2026-05-09
-**Iteration**: 58
+**Iteration**: 59
 
 ## Current Focus
 Close `F_side_identity_aligned` (Helpers, line ~14811) — the
@@ -228,6 +228,41 @@ in place:
      structural sharpening that removes the cell-wise `c'` excision
      step from the K-induction's burden (S57+ now compares integrands
      pointwise on a single common domain).
+ 19. Off-spine structural invariances under c'-removal (session 57.1,
+     researcher-1) — three sorry-free private lemmas after
+     `strictHookCells_removeCorner_eq_of_not_mem` (~line 14534):
+     `c'_notMem_strictHookCells_of_off_spine` (~14562),
+     `hookLength_invariant_off_spine_of_c'` (~14588),
+     `strictHookCells_invariant_off_spine_of_c'` (~14616).  These
+     pin down the *base step* (K = 0 / x off-spine) of the joint
+     K-induction in `F_side_identity_aligned`, eliminating two of the
+     three "moving pieces" in S57.0's analysis.  +89 Helpers lines.
+     PR #17537 (merged 2026-05-08 23:55Z, build pending).
+ 20. **Walk-unreachability lemma for arm/leg-of-c' (session 57.2,
+     this session)** — added `private lemma gnwProb_unreachable_zero`
+     (line ~14656, +68 lines including 32-line docstring): for any
+     cell `x` with `c.1 < x.1 ∨ c.2 < x.2`, `gnwProb μ c K x = 0` for
+     every `K`.  **Proof**: induction on `K` (~15 lines).  Base `K=0`
+     is `rfl`.  Step `K+1`: unfold; if `x` is a corner the indicator
+     is `0` (since `x ≠ c` from the unreachability disjunction); if
+     not a corner, the recursive sum over `y ∈ strictHookCells μ x`
+     vanishes pointwise by IH (each `y` has `y.1 ≥ x.1` and
+     `y.2 ≥ x.2`, so the unreachability disjunct propagates from `x`
+     to `y`).  **Why useful for S57+**: in case 1 (`c.1 < c'.1`),
+     the arm-of-c' cells `x = (c'.1, s)` with `s < c'.2` satisfy
+     `x.1 = c'.1 > c.1`, so both LHS and RHS of (S2)
+     `gnwProb_aligned_on_arm_of_c'` are `0` — the `δ_arm`
+     correction-term design problem **dissolves entirely** in this
+     branch.  Case 2 leg-of-c' cells dissolve similarly via the
+     `c.2 < x.2` disjunct.  This is the cleanest factoring: rather
+     than inventing a `δ_arm` and proving an algebraic identity
+     `(α-1)² + δ_arm`, we observe that gnwProb is identically 0 on
+     the arm-of-c' branch in case 1 (and leg-of-c' in case 2),
+     collapsing (S2)/(S3) for those branches to triviality.
+     **Sorry count unchanged (1)** — `F_side_identity_aligned`
+     remains the sole open sorry; this lemma is sorry-free
+     infrastructure that simplifies the upcoming S57.3+ K-induction.
+     File at 15293 lines (was 15225 after S57.1, +68).
 
 ## Blockers
 - **`F_side_identity_aligned` proof.** The common-domain parametric
@@ -244,9 +279,26 @@ in place:
   memory ceiling estimate (~15500).  CI will verify the PR.
 
 ## Next Action
-**S57.1 — implement sublemma (S1) `gnwProb_invariant_off_strictHook_of_c'`**
-as the smallest-risk first attack on the K-induction
-decomposition planned in S57.0 (session note `2026-05-09-s02.md`).
+**S57.3 — apply `gnwProb_unreachable_zero` to discharge (S2) and (S3)
+in the trivial branches**, completing the case-1 arm-of-c' and case-2
+leg-of-c' summands of the K-induction.  After S57.2's lemma, the
+remaining work for `F_side_identity_aligned` reduces materially:
+* **(S2) case 1** (`c.1 < c'.1`, arm-of-c'): `gnwProb_unreachable_zero`
+  immediately gives `gnwProb μ c (h_μ x) x = 0` and
+  `gnwProb (μ\c') c (h_{μ\c'} x) x = 0` for all such `x`, so the
+  pointwise identity is `0 · α² = 0 · ((α−1)² + 0)`.  Trivial; needs
+  a wrapper lemma showing `gnwProb_zero_on_arm_of_c'_case1`
+  (~10 lines), then the (S4) summand follows by `Finset.sum_eq_zero`
+  (~10 lines).
+* **(S3) case 2** (`c'.1 < c.1`, leg-of-c'): analogous, via the
+  `c.2 < x.2` disjunct of `gnwProb_unreachable_zero`.
+* **(S2) case 2** (arm-of-c' with `c'.1 < c.1`): NOT covered.
+  Cells `x = (c'.1, s)` with `s < c'.2` and `c'.1 < c.1` give
+  `x.1 = c'.1 < c.1`, no unreachability.  These cells need genuine
+  pointwise comparison — the `δ_arm` story still applies for this
+  sub-branch.  But (S2) case 2 falls under (S3) case 1 by
+  transpose-mirror argument; needs investigation.
+
 The plan partitions the open lemma `F_side_identity_aligned` into
 seven sublemmas (S1)–(S7), keyed to the four cell categories A/B/C/D
 of `(μ\c').cells` (off-spine, off-arm-of-c, arm-of-c', leg-of-c').
@@ -379,6 +431,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-09-s01.md` — Session 56: common-domain `F_side_identity_aligned` + sorry-free `F_side_identity`
 - `sessions/2026-05-09-s02.md` — Session 57.0: K-induction strategy + cell-partition + (S1)-(S7) sublemma plan
 - `sessions/2026-05-09-s03.md` — Session 57.1: off-spine structural invariances under c'-removal (3 lemmas, sorry-free)
+- `sessions/2026-05-09-s04.md` — Session 57.2: `gnwProb_unreachable_zero` walk-unreachability lemma (sorry-free)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -394,6 +447,7 @@ Fallback if S55+ stalls.
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14562` — `c'_notMem_strictHookCells_of_off_spine` (S57.1)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14588` — `hookLength_invariant_off_spine_of_c'` (S57.1)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14616` — `strictHookCells_invariant_off_spine_of_c'` (S57.1)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14656` — `gnwProb_unreachable_zero` (S57.2; sorry-free; closes (S2)/(S3) on the unreachable branches via case-1 arm-of-c' / case-2 leg-of-c')
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14719` — `gnwProb_exchange_lt_row_of_F_side`
   (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14814` — `gnwProb_exchange_lt_col_of_F_side`

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS session 57.1 (researcher-1): Added three foundational off-spine structural invariances under c'-removal as the (S1) base inputs for the joint K-induction in F_side_identity_aligned. (1) c'_notMem_strictHookCells_of_off_spine: c' is not in the strict hook of any off-spine cell. (2) hookLength_invariant_off_spine_of_c': hookLength is invariant at off-spine cells under c'-removal. (3) strictHookCells_invariant_off_spine_of_c': strictHookCells is invariant at off-spine cells under c'-removal. All three sorry-free; ~89 lines (lemmas + docstrings + section header). Helpers.lean now 15225 lines (~275 below estimated 15500 ceiling). These eliminate two of the three S57.0 moving pieces (h_μ vs h_{μ\\c'} and H*(x) vs H'*(x)) at off-spine cells. The (S1) gnwProb pointwise equality requires K-induction (descendants may be on c'-spine); deferred to S57.2+. Sole open sorry on GNW route remains F_side_identity_aligned.",
+    "progressSummary": "PROGRESS session 57.2 (researcher-1): Added gnwProb_unreachable_zero — a sorry-free walk-unreachability lemma stating gnwProb mu c K x = 0 whenever c.1 < x.1 OR c.2 < x.2 (i.e. the walk is started in the wrong half-plane relative to c). Proof: induction on K (~15 lines); base case rfl, step splits on isCorner mu x (indicator vanishes since x != c) and uses Finset.sum_eq_zero + IH on each y in strictHookCells (each y inherits the unreachability disjunct since y.1 >= x.1 AND y.2 >= x.2 by the strict-hook decomposition). +68 Helpers.lean lines (now 15293, ~207 below estimated 15500 ceiling). Why useful: dissolves the delta_arm correction-term design problem from S57.0's plan note for the case-1 arm-of-c' branch (and case-2 leg-of-c' branch) of (S2)/(S3) — both LHS and RHS pointwise gnwProb values are 0 there, collapsing those (S2)/(S3) sub-branches to 0 = 0 triviality. Sole open sorry on GNW route remains F_side_identity_aligned. Next: S57.3 wraps this lemma into (S4)/(S5) summand identities.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -156,7 +156,8 @@
       "gnwProb_exchange_lt_row_of_F_side proved in BallotProblemOQ03OQ01OQ02Helpers.lean:~14633 — the algebraic combiner for gnwProb_exchange (case c.1 < c'.1). Takes the F-side identity as a hypothesis and discharges gnwProb_exchange algebraically via mul_right_cancel₀, hookProd_removeCorner_swap, and linear_combination. Step 3 of 3 in the s05 recipe (S53, sorry-free).",
       "c'_notMem_strictHookCells_of_off_spine in BallotProblemOQ03OQ01OQ02Helpers.lean:~14562 (S57.1, sorry-free): for x off-spine of c' (x.1≠c'.1 and x.2≠c'.2), c' ∉ strictHookCells μ x.1 x.2",
       "hookLength_invariant_off_spine_of_c' in BallotProblemOQ03OQ01OQ02Helpers.lean:~14588 (S57.1, sorry-free): for x ∈ μ\\c' off-spine, hookLength (μ\\c') x = hookLength μ x; corollary of hookLength_eq_of_not_arm_leg",
-      "strictHookCells_invariant_off_spine_of_c' in BallotProblemOQ03OQ01OQ02Helpers.lean:~14616 (S57.1, sorry-free): for x off-spine of c', strictHookCells (μ\\c') x = strictHookCells μ x; via strictHookCells_removeCorner_eq_of_not_mem"
+      "strictHookCells_invariant_off_spine_of_c' in BallotProblemOQ03OQ01OQ02Helpers.lean:~14616 (S57.1, sorry-free): for x off-spine of c', strictHookCells (μ\\c') x = strictHookCells μ x; via strictHookCells_removeCorner_eq_of_not_mem",
+      "Added gnwProb_unreachable_zero (S57.2, BallotProblemOQ03OQ01OQ02Helpers.lean:14656; sorry-free, ~30-line proof + 32-line docstring): for any cell x with c.1 < x.1 OR c.2 < x.2, gnwProb mu c K x = 0 for all K. Proof by induction on K, using the strict-hook decomposition (descendants y satisfy y.1 >= x.1 AND y.2 >= x.2). Dissolves the delta_arm correction-term design problem from S57.0's plan note for the case-1 arm-of-c' branch (and case-2 leg-of-c' branch) of (S2)/(S3): both LHS and RHS pointwise gnwProb values are 0, so (S2)/(S3) on the unreachable branches collapse to 0 = 0 trivially."
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -265,7 +266,8 @@
       "S54 — F-side joint K-induction proving F(μ,c)·(h_d-1)² = F(μ\\c',c)·h_d·(h_d-2) (case c.1 < c'.1). Use gnwProb_step for K-stability and the S43 sum-bridges (sum_gnwProb_eq_removeCorner_cells, sum_gnwProb_strictHookCells_eq_removeCorner). ~100-200 lines. After S54, gnwProb_exchange (case 1) closes by instantiating gnwProb_exchange_lt_row_of_F_side.",
       "S55 — symmetric companion combiner gnwProb_exchange_gt_row_of_F_side for case 2 (c'.1 < c.1) plus the analogous F-side identity. After both cases, gnwProb_exchange itself closes via distinct_corners_dichotomy (S45).",
       "S56+ — eliminate gnwProb_exchange sorry; promote entry to verified status (last sorry).",
-      "Promote entry to verified once gnwProb_exchange is sorry-free."
+      "Promote entry to verified once gnwProb_exchange is sorry-free.",
+      "(S57.3) Wrap gnwProb_unreachable_zero into the case-1 arm-of-c' summand identity (S4) and case-2 leg-of-c' summand identity (S5); each ~15-20 lines, both sorry-free. (S57.4) Investigate whether (S2) case 2 reduces to (S3) case 1 by transpose duality. (S57.5+) Tackle off-spine summand (S6) — the genuine pointwise K-induction comparison."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S57.2 adds `private lemma gnwProb_unreachable_zero` (Helpers.lean ~line 14656, +68 lines), a sorry-free walk-unreachability lemma for the GNW probability:

```lean
private lemma gnwProb_unreachable_zero {μ : YoungDiagram} {c : ℕ × ℕ} :
    ∀ K x, (c.1 < x.1 ∨ c.2 < x.2) → gnwProb μ c K x = 0
```

For any cell `x` lying strictly above (`c.1 < x.1`) or strictly to the right of (`c.2 < x.2`) the target corner `c`, `gnwProb μ c K x = 0`.

## Why this matters for S57+ (F_side_identity_aligned K-induction)

The lemma **dissolves** the `δ_arm` correction-term design problem from S57.0's plan note for the case-1 arm-of-c' branch (and case-2 leg-of-c' branch) of (S2)/(S3):

- **Case 1** (`c.1 < c'.1`): cells `x ∈ arm-of-c'` (i.e. `x = (c'.1, s)` with `s < c'.2`) satisfy `x.1 = c'.1 > c.1`. Both `gnwProb μ c (h_μ x) x` and `gnwProb (μ\c') c (h_{μ\c'} x) x` vanish by this lemma — (S2)'s LHS and RHS are both `0`, so the algebraic identity `(α−1)² + δ_arm` collapses to `0 = 0` trivially.
- **Case 2** (`c'.1 < c.1`): leg-of-c' cells dissolve similarly via the `c.2 < x.2` disjunct.

Rather than designing a `δ_arm` correction term and proving an algebraic identity, we observe that gnwProb is identically `0` on these branches. This is the **cleanest factoring** of (S2)/(S3): the genuinely new mathematical content is concentrated in the off-spine summand (S6), which is a true K-induction comparison.

## Proof structure (~30 lines)

Induction on `K`, statement universally quantified over `x`:
- `K = 0`: `gnwProb _ _ 0 _ = 0` by definition (`rfl`).
- `K + 1`: unfold via the standard `rfl` pattern; case-split on `isCorner μ x`.
  - Corner: indicator `if x = c then 1 else 0` vanishes since `x ≠ c` (from the unreachability disjunct + `omega`).
  - Non-corner: `Finset.sum_eq_zero` over `y ∈ strictHookCells μ x.1 x.2` + IH on each `y`. The strict-hook decomposition (`simp only [strictHookCells, mem_union, mem_image, mem_Ico]` matches S57.1's pattern) gives `y = (x.1, s)` with `x.2 < s` (arm) or `y = (r, x.2)` with `x.1 < r` (leg). In both branches, the unreachability disjunct propagates from `x` to `y`.

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+68 lines: 1 new lemma + 32-line docstring; 15225 → 15293 lines, ~207 below estimated 15500-line ceiling).
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (iteration 58 → 59, Approaches list += 2 entries (S57.1 record + S57.2 this session), Next Action refined to S57.3).
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s04.md` (new session note).
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge.builtItems += 1, progressSummary updated, nextSteps += 1).

## Status

**Outcome**: progress (sorry-free infrastructure for S57.3+; sorry count unchanged at 1).
**Sorry count**: unchanged (`F_side_identity_aligned` remains the sole open sorry on the GNW route).
**Next Steps**: S57.3 wraps `gnwProb_unreachable_zero` into the case-1 arm-of-c' summand identity (S4) and case-2 leg-of-c' summand identity (S5); each ~15-20 lines. S57.4 investigates whether (S2) case 2 reduces to (S3) case 1 by transpose duality. S57.5+ tackles the off-spine summand (S6) — the genuine pointwise K-induction comparison.

## Build Status

**Build pending.** `BallotProblemOQ03OQ02.lean` (the LGV-route sibling that this entry consumes via dependency) is currently broken on `origin/main`, blocking build verification of all `ballot-oq-03-oq-01-*` descendants. Matched the S25–S31 "(build pending)" PR-title precedent. Mathlib API verified by reading source:
- `gnwProb` definition (line 14332, this file) matches the `rfl`-unfold pattern.
- `strictHookCells` flattening pattern identical to `strictHookCells_mem` (14227) and S57.1's `c'_notMem_strictHookCells_of_off_spine` (14562).
- `Finset.sum_eq_zero` used elsewhere (e.g. `proofs/Proofs/Erdos382Problem.lean:253`).

🤖 Generated by researcher-1