### PR TITLE
fix(meta): batch sync definitionCount drift (18 entries, erdos-7xx batch)

### DIFF
--- a/src/data/proofs/erdos-7/meta.json
+++ b/src/data/proofs/erdos-7/meta.json
@@ -67,7 +67,7 @@
     "assumptions": "3 axiom(s): balister_odd_squarefree, hough_nielsen, odd_covering_lcm_constraint. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 18
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "Erdős Problem #7, also known as the Erdős-Selfridge Conjecture, asks whether there exists a covering system whose moduli are all odd. A covering system is a finite collection of congruence classes {aᵢ mod mᵢ} such that every integer belongs to at least one class. The simplest covering system uses moduli {2, 3, 4, 6, 12}, and all known constructions require at least one even modulus.\n\nSignificant partial results have been obtained. Hough and Nielsen (2019) proved that every covering system must contain at least one modulus divisible by 2 or 3, meaning an odd covering would necessarily include moduli divisible by 3. Balister, Bollobas, Morris, Sahasrabudhe, and Tiba (2022) proved the stronger result that no covering system exists with all moduli both odd and squarefree, ruling out a natural class of potential counterexamples.\n\nThe problem carries prizes from both Erdős ($25 for proving no odd covering exists) and Selfridge ($2000 specifically for an explicit construction). The LCM of any hypothetical odd covering must be divisible by 9 or 15, further constraining what such a system could look like. Despite these restrictions, the general conjecture remains open.",
@@ -253,7 +253,7 @@
     "lineCount": 274,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "path": "Proofs/Erdos7Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -85,7 +85,7 @@
     "lineCount": 209,
     "assumptions": "No axioms. 15 sorries remain in the formalization.",
     "theoremCount": 13,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos715ProblemAristotle.lean"
     ]
@@ -192,7 +192,7 @@
     "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos715Problem.lean",
     "sorries": 15,
     "additionalFiles": [

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 344,
     "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 1 sorries.",
     "theoremCount": 8,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
@@ -189,7 +189,7 @@
     "lineCount": 344,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -50,7 +50,7 @@
     "lineCount": 298,
     "assumptions": "0 axioms, 0 sorries. critical_giant_size, komlos_sulyok_szemeredi, second_largest_lower_bound are theorem declarations using True-stub proofs (∃ c, c > 0 ∧ True), not real axiom declarations.",
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "**Erdős Problem #745: Random Graph Components**\n\nThis problem concerns the Erdős-Rényi random graph model G(n, p), one of the foundational models in probabilistic combinatorics.\n\n**Historical Timeline:**\n- 1959-1960: Erdős and Rényi introduce the random graph model G(n, p)\n- 1960: They discover the phase transition at p = 1/n\n- 1960s-70s: The structure of the giant component is studied\n- 1980: Komlós, Sulyok, and Szemerédi prove Erdős's conjecture about the second largest component\n- 1980s-90s: Łuczak and others refine understanding of the critical window\n\n**The Phase Transition:**\nAt p = 1/n, the random graph undergoes a dramatic change:\n- p < 1/n: All components small (size O(log n))\n- p = 1/n: Giant emerges with size Θ(n^{2/3})\n- p > 1/n: Unique giant of size Θ(n)",
@@ -162,7 +162,7 @@
     "lineCount": 298,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos745Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-747/meta.json
+++ b/src/data/proofs/erdos-747/meta.json
@@ -70,7 +70,7 @@
     "lineCount": 313,
     "assumptions": "5 axioms: johansson_kahn_vu, kahn_precise_threshold, below_threshold_fails, above_threshold_succeeds, erdos_747. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "**Erdős Problem #747 (Shamir's Problem)**\n\nA famous problem in probabilistic combinatorics.\n\n**Key History:**\n- 1979: Shamir asked Erdős about perfect matchings in random 3-uniform hypergraphs\n- Erdős's response: 'Here we have no idea of the answer' (unlike most random hypergraph problems)\n- 2008: Johansson, Kahn, and Vu proved the threshold is ≍ n log n\n- 2023: Kahn determined the precise asymptotic ~ n log n, also for general r-uniform hypergraphs\n\n**Mathematical Significance:**\n- One of the most important results in random hypergraph theory\n- The answer (same threshold for all r) was unexpected",
@@ -199,7 +199,7 @@
     "lineCount": 313,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos747Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős, Hajnal, and Szemerédi posed this question in the context of infinite graph colouring theory, a field Erdős helped create. The classical bound α(G)·χ(G) ≥ |V(G)| shows that for finite graphs, large chromatic number forces small independence ratio. For infinite graphs with uncountable chromatic number (χ(G) ≥ ℵ₁), the situation is fundamentally different: the global colouring complexity does not directly constrain the independence structure of finite subgraphs. Known constructions of graphs with χ ≥ ℵ₁ include shift graphs on ordinals, Todorčević's partition graphs, and forcing-based constructions, but these typically have finite subgraphs with poor independence ratios (α(H) = O(√n) or O(n/log n)). Problem 75 asks whether there exists a graph combining uncountable chromatic number with near-linear independence (α(H) > n^{1-ε} for all ε > 0) in every large finite subgraph. Erdős suggested this might even hold with linear independence (α ≥ cn), and offered $1000 for a complete solution—one of the largest Erdős prizes, reflecting the problem's difficulty and importance. The problem connects to the Erdős-Hajnal conjecture (polynomial clique/independent set in H-free graphs), Ramsey theory on uncountable sets, and the set-theoretic foundations of infinite combinatorics.",
@@ -115,7 +115,7 @@
     "lineCount": 214,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 10,
     "path": "Proofs/Erdos75Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-758/meta.json
+++ b/src/data/proofs/erdos-758/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 128,
     "assumptions": "3 axioms: z_1 (z(1) = 1), z_12 (z(12) = 4, Bhavik Mehta computational), known_values_correct (z(i+1) = knownValues(i) for all i < 19).",
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Erdős Problem #758: Cochromatic Number**\n\nThis problem was posed by Erdős and Gimbel and concerns the cochromatic number of graphs.\n\n**Key History:**\n- **Erdős-Gimbel:** Established 4 ≤ z(12) ≤ 5 and 5 ≤ z(15) ≤ 6\n- **Gimbel [Gi86]:** Proved z(n) ~ n/log n asymptotically\n- **Bhavik Mehta:** Computationally verified z(12) = 4 by finding the unique extremal graph\n\n**Mathematical Context:**\nThe cochromatic number generalizes both chromatic number (independent sets only) and clique cover number (cliques only). It connects to Ramsey theory since R(3) = 6 and R(4) = 18 control the growth of z(n).",
@@ -155,7 +155,7 @@
     "lineCount": 128,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos758Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 295,
     "assumptions": "6 axioms: cochromaticNumber, chromaticNumber, maxCochromaticNumber, gimbel_lower_bound, gimbel_thomassen_theorem, heawood_number. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 19
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "Erdős Problem #759, posed by Erdős and John Gimbel, asks for the growth rate of the maximum cochromatic number on orientable surfaces of genus $n$. The cochromatic number $\\zeta(G)$, introduced by Lesniak and Straight (1977), partitions vertices into classes that are each either a clique or an independent set — a natural generalization of chromatic coloring where classes must be independent. On orientable surfaces $S_n$ (connected sums of $n$ tori), graph embedding constraints from Euler's formula ($V - E + F = 2 - 2n$) limit the density of embeddable graphs, which in turn bounds their cochromatic number.\n\nGimbel (1986) established the initial bounds $c_1 \\sqrt{n}/\\log n \\leq z(S_n) \\leq c_2 \\sqrt{n}$ in his paper 'Three extremal problems in cochromatic theory'. The lower bound used probabilistic arguments to construct high-girth graphs embeddable on $S_n$ with large cochromatic number. Eleven years later, Gimbel and Carsten Thomassen (1997) closed the gap by proving $z(S_n) = \\Theta(\\sqrt{n}/\\log n)$ in 'Coloring graphs with fixed genus and girth' (Trans. Amer. Math. Soc.), showing the log factor in Gimbel's lower bound was essential. The contrast with the Heawood number $H(n) = \\Theta(\\sqrt{n})$ (maximum chromatic number on $S_n$, resolved by the Ringel-Youngs theorem in 1968) shows that cochromatic number grows more slowly by a factor of $\\log n$.",
@@ -232,7 +232,7 @@
     "lineCount": 295,
     "axiomCount": 6,
     "theoremCount": 3,
-    "definitionCount": 19,
+    "definitionCount": 20,
     "path": "Proofs/Erdos759Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -94,7 +94,7 @@
     "lineCount": 246,
     "assumptions": "3 axioms (Gruslys-Letzter theorem, balanced bound tightness, extremal stability) + 1 sorry (packing upper bound). See the Lean source for details.",
     "theoremCount": 4,
-    "definitionCount": 15
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "Ramsey's theorem (1930) guarantees that any 2-coloring of $K_6$ contains a monochromatic triangle, since $R(3,3) = 6$. This qualitative existence result naturally leads to quantitative questions: how many monochromatic triangles must appear, and how many can be packed edge-disjointly?\n\nErdős, Faudree, and Ordman posed Problem #76: in any 2-coloring of $K_n$, what is the minimum number of edge-disjoint monochromatic triangles? They conjectured the answer is $(1 + o(1)) n^2/12$, achieved by the balanced bipartition coloring — partition $[n]$ into two equal halves, color within-half edges blue and between-half edges red. The red graph $K_{n/2, n/2}$ is bipartite (triangle-free), and each blue clique $K_{n/2}$ packs $\\approx (n/2)(n/2-1)/6 \\approx n^2/24$ edge-disjoint triangles via Steiner triple systems (Kirkman 1847). Two halves yield $n^2/12$ total.\n\nThe conjecture was confirmed by Vytautas Gruslys and Shoham Letzter in their 2020 Combinatorica paper. Their proof applies a variant of the Szemerédi regularity lemma (1978) to decompose the 2-colored $K_n$ into structured regular pairs, then uses a greedy-absorption method to build the packing. They also established a stability result: any coloring achieving the bound must be close to the balanced bipartition (up to isomorphism).\n\nThe problem connects Ramsey theory (existence of monochromatic subgraphs), extremal graph theory (extremal constructions and stability), packing theory (edge-disjointness constraints), and design theory (Steiner triple systems for optimal packings).",
@@ -224,7 +224,7 @@
     "lineCount": 246,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 15,
+    "definitionCount": 17,
     "path": "Proofs/Erdos76Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -42,7 +42,7 @@
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation` (which had become transitively in scope and blocked iterations since 2026-04-27). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "sections": [
     {
@@ -129,7 +129,7 @@
     "lineCount": 262,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos761Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-775/meta.json
+++ b/src/data/proofs/erdos-775/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 281,
     "assumptions": "3 axioms: spencer_graph_construction, gao_upper_bound, gaoFunction_tendsto_infinity. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #775**\n\nThis problem explores the combinatorial structure of hypergraphs, specifically asking about the diversity of clique sizes.\n\n**Key History:**\n- Moon and Moser (1965): Proved that graphs on n vertices have at most n - log₂n + O(1) different clique sizes\n- Spencer (1971): Constructed graphs achieving this optimal bound\n- Erdős: Constructed 3-uniform hypergraphs with n - log*n different clique sizes, and asked if n - O(1) is achievable\n- Gao (2025): Proved the answer is NO for all k ≥ 3\n\n**Mathematical Setting:**\nA k-uniform hypergraph has edges that are exactly k-element subsets of vertices. For k=2, this is an ordinary graph. A clique (maximal complete subgraph) is a set where every k-subset is an edge. The question asks: how many different sizes of cliques can coexist?",
@@ -191,7 +191,7 @@
     "lineCount": 281,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos775Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 225,
     "assumptions": "3 axioms: playGame, malekshahian_spiro_alice_n_bob_n123, malekshahian_spiro_alice_n_bob_n12_degree. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 18
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "**Erdős Problem #778: Clique-Building Games on Complete Graphs**\n\nThis problem, posed by Erdős (referenced in Gu83), concerns competitive edge-coloring games on complete graphs — a topic at the intersection of combinatorial game theory and Ramsey theory.\n\n**Three Game Variants:**\nAlice and Bob alternate coloring edges of K_n red (Alice) and blue (Bob), with Alice going first. Variant 1 (Clique Game): Alice wins if her largest red clique exceeds Bob's largest blue clique. Variant 2 (Modified Game): Bob colors 2 edges per turn; he wins if his largest clique strictly exceeds Alice's. Variant 3 (Degree Game): Alice wins if the maximum degree in the red subgraph exceeds that of the blue.\n\n**Erdős's Belief:** Erdős conjectured that Bob should always have a winning strategy in the clique game for n ≥ 3, reflecting the general principle that the second player often has a structural advantage in such games.\n\n**Recent Progress:** Malekshahian and Spiro (arXiv:2410.18304, 2024) proved significant partial results. For the clique game, they showed Bob wins for a set of n with natural density at least 3/4, and that if Alice ever wins at some n, then Bob wins at the next three values n+1, n+2, n+3. For the degree game, Bob wins with density at least 2/3, with a similar recovery property over two consecutive values. These results strongly support Erdős's conjecture but the complete answer remains open.",
@@ -171,7 +171,7 @@
     "lineCount": 225,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 18,
+    "definitionCount": 20,
     "path": "Proofs/Erdos778Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-78/meta.json
+++ b/src/data/proofs/erdos-78/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "1 axiom: ramseyNumber. Structure fields are object definitions, not assumptions.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "sections": [
     {
@@ -110,7 +110,7 @@
     "lineCount": 56,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos78Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "2 axioms: alon_frankl_lovasz_1986 (Alon-Frankl-Lovász 1986 matching bound), kneser_conjecture (chromatic number of Kneser graph KG(n,r) = n-2r+2, Lovász 1978). 0 sorries.",
     "lineCount": 221,
     "theoremCount": 7,
-    "definitionCount": 11
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős Problem #780 generalizes the famous Kneser conjecture to hypergraphs. **Kneser (1955)** conjectured that $\\chi(KG(n,r)) = n - 2r + 2$, i.e., any $(n - 2r + 1)$-coloring of the $r$-subsets of $[n]$ must contain two disjoint sets of the same color. This remained open until **Lovász's landmark 1978 proof** (*J. Comb. Theory A* 25, 319-324), which was the **first major application of algebraic topology to combinatorics**, using the Borsuk-Ulam theorem via the neighborhood complex $\\mathcal{N}(KG(n,r))$. Schrijver simultaneously found a vertex-critical subgraph (the stable Kneser graph) with the same chromatic number.\n\n**Alon, Frankl, and Lovász (1986)** extended this to $r$-uniform hypergraphs (*Trans. AMS* 298, 359-370): if $n \\geq kr + (t-1)(k-1)$, any $t$-coloring of $\\binom{[n]}{r}$ contains $k$ pairwise disjoint monochromatic edges. Their proof generalizes the topological approach using the independence complex and a Borsuk-Ulam-type argument via the Lusternik-Schnirelmann category. **Matoušek (2004)** later gave a purely combinatorial proof using Tucker's lemma. The problem connects to the Erdős-Ko-Rado theorem (1961): the maximum intersecting family gives $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$, and the fractional chromatic number is $\\chi_f(KG(n,r)) = n/r$.",
@@ -214,7 +214,7 @@
     "lineCount": 221,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos780Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -56,7 +56,7 @@
     "assumptions": "5 axioms (BEF_lower_bound, alon_spencer_cubic, f_1, f_2, f_3) and 0 sorries. Key bounds axiomatized from Brown-Erdos-Freedman (1990) and Alon-Spencer (1989). The disproof theorem is fully proved from axiomatized small values.",
     "lineCount": 265,
     "theoremCount": 6,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdős Problem #781: Descending Waves in 2-Colorings**\n\nThis problem concerns monochromatic patterns in 2-colorings of integers, specifically \"descending waves\" where successive gaps are non-increasing.\n\n**Key History:**\n- Brown, Erdős, Freedman (1990): Introduced the problem, proved k² - k + 1 ≤ f(k) ≤ (k³ - 4k + 9)/3\n- Alon, Spencer (1989): DISPROVED the conjecture by showing f(k) ≫ k³\n\n**Mathematical Setting:**\nA descending wave x₁ < x₂ < ... < xₖ satisfies x_j ≥ (x_{j-1} + x_{j+1})/2 for all interior points. Equivalently, the gaps (x_{i+1} - x_i) form a non-increasing sequence.",
@@ -206,7 +206,7 @@
     "lineCount": 265,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos781Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 242,
     "assumptions": "3 axioms: h, straus_1966_upper, erdos_choi_1974_lower. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erdős's Original Work (1962)**\\n\\nErdős proved h(n) ≪ n^{5/6} and h(n) ≫ n^{1/3}. The lower bound used a beautiful probabilistic construction: for random α, the set of elements whose fractional parts {αa} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) ≪ √n using a clever counting argument on sum representations.\\n\\n**Erdős-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) ≫ (n log n)^{1/3} by refining Erdős's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and √n is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
@@ -179,7 +179,7 @@
     "lineCount": 242,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos789Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-793/meta.json
+++ b/src/data/proofs/erdos-793/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "5 axiom(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1938 paper 'On sequences of integers no one of which divides the product of two others', one of his earliest contributions to multiplicative number theory and extremal combinatorics. The concept of primitive sets — where no element divides another — goes back to Besicovitch (1934) and Behrend (1935), who studied their density properties. Erdős strengthened the condition: instead of just pairwise non-divisibility, he required that no element $a$ divides the product $bc$ of any two other distinct elements. In his 1969 paper 'Some applications of graph theory to number theory', Erdős introduced an elegant bipartite graph construction to prove the upper bound, pioneering the use of extremal graph theory in number-theoretic problems. The graph has small integers and large primes as vertices, with edges encoding products in the set; the divisibility condition forces this graph to be $P_3$-free (no path of length 3), hence a forest. This technique — reducing a number theory problem to a forbidden subgraph problem — became a template for many later results in combinatorial number theory, including work by Pomerance and Alon on primitive sets and their generalizations. The exact constant $C$ in the secondary term remains open, connecting to deep questions about the distribution of smooth numbers and the multiplicative structure of integers.",
@@ -134,7 +134,7 @@
     "lineCount": 199,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos793Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-794/meta.json
+++ b/src/data/proofs/erdos-794/meta.json
@@ -87,7 +87,7 @@
     "lineCount": 256,
     "assumptions": "3 axiom(s): balogh_observation, harris_counterexample_exists, frankl_furedi_lower. See Lean source for complete statements.",
     "theoremCount": 7,
-    "definitionCount": 9
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**3-Uniform Hypergraph Turán Density: A Disproved Conjecture**\n\nErdős posed Problem #794 in 1969, asking whether 3n vertices with n³+1 edges in a 3-uniform hypergraph must contain either K₄⁻ (4 vertices, 3 edges) or a 5-vertex configuration with 7 edges.\n\n**Balogh's Simplification**\n\nBalogh made the crucial observation that the 5-7 condition is redundant: any 5 vertices with 7 of the possible 10 edges must contain a 4-vertex subset with 3 of the possible 4 edges. The counting argument is elegant: each edge is counted by 2 of the 5 possible 4-vertex subsets, so 7 edges give 14 total across 5 subsets, averaging 2.8 per subset — at least one has ≥ 3.\n\n**Harris's Counterexample**\n\nHarris disproved the conjecture with a concrete construction for n=3 (9 vertices, 28 = 3³+1 edges). Partition {1,...,9} into A = {1,2,3}, B = {4,5,6}, C = {7,8,9}. Take all 27 cross-product triples {a,b,c} with a ∈ A, b ∈ B, c ∈ C, then add the single edge {1,2,3}. The tripartite structure prevents K₄⁻: any 4 vertices span at most 2 cross-product edges (since each edge uses one vertex per part), and the intra-partition edge {1,2,3} can't combine with cross-product edges to reach 3.\n\n**The True Density Threshold**\n\nFrankl and Füredi (1984) proved that the Turán density for K₄⁻ is at least 2/7 ≈ 0.286, using the 'Fano complement' construction. The n³+1 threshold on 3n vertices corresponds to density approximately 2/9 ≈ 0.222, which is well below 2/7 — so the conjecture was asking about a threshold that was too low. The exact Turán density for K₄⁻ is conjectured to be exactly 2/7, but proving the matching upper bound remains a major open problem in extremal hypergraph theory.\n\n**Connection to Turán's Conjecture**\n\nTurán had earlier conjectured that the Turán density for K₄⁻ was 1/4 (based on the complete balanced tripartite 3-graph). Since 2/7 > 1/4, Turán's conjecture was also disproved for this specific forbidden hypergraph.",
@@ -196,7 +196,7 @@
     "lineCount": 256,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 11,
     "path": "Proofs/Erdos794Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `meta.definitionCount` and `leanFile.definitionCount` for 18
erdos-7xx entries where the Lean source files added definitions since
the last meta update.

## Counting convention

Standard mechanic regex (PR #17545):

```
^\s*(?:(?:partial|private|protected|noncomputable|unsafe|scoped)\s+)*(def|abbrev|opaque|structure|inductive|class)\s+\w
```

after stripping nested `/-...-/` and `--` comments. The `partial`
modifier is included per the erdos-643 lesson (PR #17335→#17365 revert,
later re-applied by #17545).

## Per-entry deltas (claimed → actual)

| slug | claimed | actual | delta |
|---|---|---|---|
| erdos-7 | 18 | 20 | +2 |
| erdos-715 | 10 | 11 | +1 |
| erdos-744 | 10 | 11 | +1 |
| erdos-745 | 7 | 8 | +1 |
| erdos-747 | 12 | 13 | +1 |
| erdos-75 | 7 | 10 | +3 |
| erdos-758 | 3 | 4 | +1 |
| erdos-759 | 19 | 20 | +1 |
| erdos-76 | 15 | 17 | +2 |
| erdos-761 | 6 | 7 | +1 |
| erdos-775 | 8 | 9 | +1 |
| erdos-778 | 18 | 20 | +2 |
| erdos-78 | 3 | 4 | +1 |
| erdos-780 | 11 | 12 | +1 |
| erdos-781 | 10 | 11 | +1 |
| erdos-789 | 6 | 7 | +1 |
| erdos-793 | 12 | 13 | +1 |
| erdos-794 | 9 | 11 | +2 |

## Scope

Pure metadata sync. No Lean source changes. 36 lines across 18 files
(each file: 2 occurrences in `meta` and `leanFile` blocks).

Skipped: erdos-643 (controversial — see prior PR #17335→#17365 revert).
Skipped: any slugs covered by currently-open PRs.

---
Automated fix by lean-mechanic agent.