### PR TITLE
research(sperner-ndim-mathlib-oq-02): S24 — t2-side boundary extinction lemma (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2489,4 +2489,101 @@ private lemma t1_lastFace_implies_satDiag
 
 end N2LastFaceExtract
 
+-- ============================================================
+-- (S24) t2-side boundary extinction for `_hLastFace`.
+--
+-- For `c ∈ t2Bases N` and any drop-index `k : Fin 3`, the cell
+-- `(t2 c, k)` is **never** in the `_hLastFace` filter of
+-- `Triangulation.boundary_doors_odd`: every codim-1 face of a
+-- `t2 c` simplex has at least two containers (`t2 c` itself plus
+-- a sharing `t1` cell — see `t2_face*_card_ge_two`), so by S19.1's
+-- `adjFn_eq_none_iff_card_le_one` the adjacency function returns
+-- `some _` for every drop index.
+--
+-- This is the t2-counterpart to S21A's `t1_lastFace_implies_satDiag`:
+-- together they show the only cells contributing to the
+-- `_hLastFace` filter of `(simData2 N).toTriangulation` are
+-- saturating-diagonal `t1` cells with the diagonal-drop index.
+-- The proof is a direct extraction of the t2 branch of
+-- `boundaryOnFace_simData2` (lines 2186–2230), packaged so that
+-- S25's bijection assembly can dismiss the t2 case by a single
+-- `match`/`rcases` rather than re-running the case-split.
+-- ============================================================
+
+section N2LastFaceT2Extinct
+
+/-- t2-side boundary extinction: for `c ∈ t2Bases N` and any
+`k : Fin 3`, the adjacency of the cell `⟨t2 c, _⟩` at face `k`
+is never `none`. Every codim-1 face of `t2 c` has at least two
+containers (`t2 c` itself plus a sharing `t1` cell), so the
+generic `adjFn_eq_none_iff_card_le_one` fails the cardinality
+direction.
+
+This is the t2-companion to S21A's `t1_lastFace_implies_satDiag`:
+together they show the only cells `(s, k)` with `adj = none` and
+all non-`k` vertices on geometric face 2 are saturating-diagonal
+`t1` cells with the diagonal-drop index. -/
+private lemma t2_adj_ne_none
+    (N : ℕ) {c : ℕ × ℕ} (hc : c ∈ t2Bases N) (k : Fin 3) :
+    ((simData2 N).toTriangulation).adj
+        ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none := by
+  intro h_adj
+  set hS := t2_in_topSimps2_of_base N hc with hS_def
+  -- Convert adj=none to containers card ≤ 1 (S19.1).
+  have h_card_le :
+      ((simData2 N).containersOf
+        ((simData2 N).faceOf (t2 c) hS k)).card ≤ 1 :=
+    (SimplicialAdjFnHelper.adjFn_eq_none_iff_card_le_one
+      (simData2 N) ⟨t2 c, hS⟩ k).mp h_adj
+  -- Definitional equation for `(simData2 N).containersOf`.
+  have h_containers_eq : ∀ (f : Finset (ℕ × ℕ)),
+      (simData2 N).containersOf f =
+        (topSimps2 N).filter (fun s => f ⊆ s) := fun _ => rfl
+  -- Case-split on which vertex of `t2 c` is dropped.
+  have h_drop : (simData2 N).vertexEnum (t2 c) hS k ∈ t2 c :=
+    (simData2 N).vertexEnum_mem (t2 c) hS k
+  simp only [t2, Finset.mem_insert, Finset.mem_singleton] at h_drop
+  rcases h_drop with hd | hd | hd
+  · -- dropped = `(c.1+1, c.2+1)`: face = `{(c.1, c.2+1), (c.1+1, c.2)}` (face 2 of t2 c).
+    have h_face_eq :
+        (simData2 N).faceOf (t2 c) hS k =
+          ({(c.1, c.2+1), (c.1+1, c.2)} : Finset (ℕ × ℕ)) := by
+      show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+      rw [hd]; exact t2_erase_first c
+    have h_two := t2_face2_card_ge_two N hc
+    rw [h_face_eq, h_containers_eq] at h_card_le
+    omega
+  · -- dropped = `(c.1+1, c.2)`: face = `{(c.1, c.2+1), (c.1+1, c.2+1)}` (face 1 of t2 c).
+    have h_face_eq :
+        (simData2 N).faceOf (t2 c) hS k =
+          ({(c.1, c.2+1), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) := by
+      show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+      rw [hd]; exact t2_erase_second c
+    have h_two := t2_face1_card_ge_two N hc
+    rw [h_face_eq, h_containers_eq] at h_card_le
+    omega
+  · -- dropped = `(c.1, c.2+1)`: face = `{(c.1+1, c.2), (c.1+1, c.2+1)}` (face 0 of t2 c).
+    have h_face_eq :
+        (simData2 N).faceOf (t2 c) hS k =
+          ({(c.1+1, c.2), (c.1+1, c.2+1)} : Finset (ℕ × ℕ)) := by
+      show (t2 c).erase ((simData2 N).vertexEnum (t2 c) hS k) = _
+      rw [hd]; exact t2_erase_third c
+    have h_two := t2_face0_card_ge_two N hc
+    rw [h_face_eq, h_containers_eq] at h_card_le
+    omega
+
+/-- Filter-membership form for direct S25 consumption: no element
+of the `_hLastFace` filter of `(simData2 N).toTriangulation` has a
+`t2`-cell first coordinate. Together with the `topSimps2_mem_iff`
+case split this lets S25 reduce the bijection assembly to t1 cells
+only (then S21A pins the t1 base to `satDiagBases N`). -/
+private lemma t2_lastFace_filter_impossible
+    (N : ℕ) {c : ℕ × ℕ} (hc : c ∈ t2Bases N) (k : Fin 3)
+    (h_adj : ((simData2 N).toTriangulation).adj
+        ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k = none) :
+    False :=
+  t2_adj_ne_none N hc k h_adj
+
+end N2LastFaceT2Extinct
+
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,13 +2,67 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-09 (Iteration 22, researcher-10)
-**Iteration**: 22
+**Last Updated**: 2026-05-09 (Iteration 24, researcher-9)
+**Iteration**: 24
 
 ## Current Focus
 
-Session 22 (this iteration, researcher-10, 2026-05-09, build
-pending): Added the **Sperner-restricted IsDoor ↔ color-change**
+Session 24 (this iteration, researcher-9, 2026-05-09, build
+pending): Added the **t2-side boundary extinction** lemma for
+`_hLastFace`, packaging the t2 branch of `boundaryOnFace_simData2`
+as a stand-alone re-export so S25's bijection assembly can dismiss
+the t2 case by a single `match`/`rcases` rather than re-running the
+case-split. New private lemma `t2_adj_ne_none` in a new
+`N2LastFaceT2Extinct` section appended to `SpernerFreudSimp`
+(97 lines added to `SpernerFreudenthalSimplex.lean`).
+
+Together with S21A's `t1_lastFace_implies_satDiag` (PR #17464,
+merged), the t1/t2 split for `_hLastFace` is now complete:
+* **t2 side (this PR, S24)**: `c ∈ t2Bases N`, k : Fin 3 ⟹
+  `((simData2 N).toTriangulation).adj ⟨t2 c, _⟩ k ≠ none`. Hence
+  no t2 cell contributes to the `_hLastFace` filter at all.
+* **t1 side (S21A, merged)**: under the per-vertex face-2
+  hypothesis, the drop must be `b` itself and `b ∈ satDiagBases N`.
+
+New lemmas (~97 lines including section header + docstrings):
+
+* `t2_adj_ne_none`: `c ∈ t2Bases N → k : Fin 3 →
+  ((simData2 N).toTriangulation).adj ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none`.
+  Proof case-splits on `vertexEnum (t2 c) hS k ∈ t2 c` (the S19.3
+  pattern) and applies the appropriate `t2_face*_card_ge_two` to
+  contradict the `card ≤ 1` consequence of `adj = none` from
+  `adjFn_eq_none_iff_card_le_one` (S19.1).
+* `t2_lastFace_filter_impossible`: filter-shaped corollary in the
+  exact contrapositive form S25 will consume, deriving `False`
+  from any `(t2 c, k)` triple with `adj = none`.
+
+This is the **S24** step of the n=2 Sperner-via-Freudenthal
+pipeline. After S24, the remaining S25 step is the bijection
+between the `_hLastFace` filter (now provably restricted to t1
+cells with diagonal-drop and `b ∈ satDiagBases N` per S21A) and
+`(Finset.range N).filter (fun k => g k ≠ g (k+1))`'s color-change
+edges — using S22's `isDoor_dim_two_iff_color_change_of_no_color_two`
+and S23's color-side wiring (PR #17571, in flight) to translate
+between geometric face-2 hypothesis and the color-change predicate.
+
+S24 keeps the iterative-PR cadence small (one self-contained
+extraction lemma + filter-shape corollary) to reduce merge-conflict
+risk against the in-flight S23 PR #17571 (which appends a different
+section, `N2LastFaceColors`, before this one) and keep any build
+regressions narrow, given the persistent `proofs/.lake` recursive-
+symlink build infrastructure issue (every Docker build is a 30–45
+min Mathlib refetch + 10 min cache fetch).
+
+## Previous Focus
+
+Session 23 (PR #17571, in flight): Added the **color-side wiring**
+(`cN2_total_face2_color_ne_two`, `satDiagBases_endpoints_color_ne_two`,
+`t1_lastFace_color_ne_two`) connecting S21A's geometric face-2 hypothesis
+to S22's color-change bridge. ~83 lines, build pending.
+
+## Previous Focus
+
+Session 22 (PR #17549, merged 2026-05-09): Added the **Sperner-restricted IsDoor ↔ color-change**
 bridge in `SimplicialAdjFnHelper`, specializing S21B's generic
 `isDoor_dim_two_iff` to the case where neither non-`k` vertex carries
 color `2` (which the Sperner condition forces whenever both lie on

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -18,21 +18,23 @@
   "currentState": {
     "phase": "REFINE",
     "since": "2026-05-06T11:50:53.576Z",
-    "iteration": 21,
-    "focus": "S21B (this PR, build pending): added the generic d=2 IsDoor characterization isDoor_dim_two_iff to SimplicialAdjFnHelper. Converts the abstract `∀ j : Fin 2, ∃ i ≠ k, c (vertex s i) = Fin.castSucc j` quantifier into the explicit conjunction `(∃ i ≠ k, c v_i = 0) ∧ (∃ i ≠ k, c v_i = 1)`. This is the abstract half of the IsDoor ↔ color-change bridge from PR #17464's S21B roadmap. ~50 lines including docstring.",
+    "iteration": 22,
+    "focus": "S24 (this PR, build pending): added the t2-side boundary extinction lemma t2_adj_ne_none for the n=2 _hLastFace discharge — for c ∈ t2Bases N and k : Fin 3, ((simData2 N).toTriangulation).adj ⟨t2 c, _⟩ k ≠ none. Packages the t2 branch of boundaryOnFace_simData2 (lines 2186–2230) as a stand-alone re-export so S25's bijection assembly can dismiss the t2 case by a single rcases. Filter-shaped corollary t2_lastFace_filter_impossible bundles the contrapositive form S25 will consume directly. ~97 lines added in a new N2LastFaceT2Extinct section appended to SpernerFreudSimp. Together with S21A's t1-side extraction, the t1/t2 split for _hLastFace is now complete.",
     "blockers": [],
-    "nextAction": "S21C: Sperner + face-2 specialisation of S21B. Combine isDoor_dim_two_iff with cN2_total_isSpernerColoring + satDiagBases_endpoints_on_face2 to force the 2 non-k vertex colors into {0, 1}, then conclude IsDoor ↔ colors differ (matching face2_path_odd's `g k ≠ g (k+1)`). ~30 lines. Then S21D assembles _hLastFace_simData2 (~60 lines) consuming S21A (PR #17464) + S21C + face2_path_odd. Then S22 applies Triangulation.sperner + diameter + real coords (~50 lines).",
+    "nextAction": "S25: bijection assembly between _hLastFace filter pairs (t1 b at the diagonal-drop, with b ∈ satDiagBases N per S21A) and (Finset.range N).filter (fun k => g k ≠ g (k+1)) color-change edges. Use S22 isDoor_dim_two_iff_color_change_of_no_color_two with S23's color-side wiring (PR #17571) to translate geometric face-2 hypothesis to the color-change predicate; use this PR's t2_lastFace_filter_impossible to dismiss t2 cells. ~80 lines.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
       "approachesTried": 0
     },
     "builtItems": [
+      "S24 (this PR): SpernerFreudSimp.t2_adj_ne_none + t2_lastFace_filter_impossible in SpernerFreudenthalSimplex.lean (N2LastFaceT2Extinct section). For c ∈ t2Bases N and k : Fin 3, the adjacency of ⟨t2 c, _⟩ at face k is never none. Proof case-splits on vertexEnum (t2 c) hS k ∈ t2 c (S19.3 pattern) and applies t2_face*_card_ge_two against the card ≤ 1 consequence of adj = none from S19.1's adjFn_eq_none_iff_card_le_one. ~97 lines.",
       "S21B (this PR): SimplicialAdjFnHelper.isDoor_dim_two_iff — generic CellComplex.IsDoor characterization for d=2: IsDoor c K s k ↔ (∃ i ≠ k, c (K.vertex s i) = 0) ∧ (∃ i ≠ k, c (K.vertex s i) = 1). Proof by unfold + Fin.castSucc 0 / Fin.castSucc 1 reduction (Fin.ext rfl) + fin_cases on j : Fin 2 in the reverse direction. ~50 lines including docstring.",
       "S21A (PR #17464): t1_lastFace_implies_satDiag — t1-side forward extraction for _hLastFace. Given b ∈ t1Bases N + ∀ j ≠ k, onFaceΔ2_strict (vertexEnum (t1 b) hS j) 2, concludes b ∈ satDiagBases N ∧ vertexEnum (t1 b) hS k = b (drop must be b itself). 84 lines.",
       "S20 (PR #17426): satDiagBases N + supporting structural lemmas (mem_iff, subset_t1Bases, image_map_injOn, eq_image_range, card = N, endpoints_in_range, endpoints_on_face2, t1_in_topSimps2). The count side of the future _hLastFace ↔ face2_path_odd bijection."
     ],
     "insights": [
+      "S24 insight: the t2-side _hLastFace extinction is a corollary of the (already-proved) t2 branch of boundaryOnFace_simData2, which shows every t2-cell drop produces ≥ 2 containers contradicting card ≤ 1 from adj = none. By extracting this branch as a stand-alone lemma (rather than re-proving it inline at the S25 bijection), S25's case-split on (s, k) ∈ _hLastFace filter reduces cleanly to t1 cells only — and S21A then pins the t1 base to satDiagBases N with the diagonal-drop index. The complete t1/t2 split is now done.",
       "S21B insight: For d=2, CellComplex.IsDoor c K s k unfolds to a quantifier over j : Fin 2, which fin_cases splits cleanly into the j=0 and j=1 cases. Fin.castSucc (0 : Fin 2) = (0 : Fin 3) and Fin.castSucc (1 : Fin 2) = (1 : Fin 3) both reduce by Fin.ext rfl, giving a clean iff into a concrete conjunction without any Fin-arithmetic gymnastics.",
       "Placement choice for S21B: SimplicialAdjFnHelper namespace (not SpernerFreudSimp), making the lemma generic and reusable for any future d=2 CellComplex Sperner instance. Sits naturally next to S19's adjFn_eq_none_iff_card_le_one and forall_vertex_ne_iff_forall_face_mem helpers.",
       "S21B is independent of S21A: the bridge characterizes IsDoor in terms of color predicates without referring to satDiagBases or the t1/t2 cell structure. This decoupling lets S21B land even if S21A needs revision, and makes the eventual S21C/D assembly modular.",
@@ -42,7 +44,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S21B (this PR, build pending): added generic d=2 IsDoor characterization isDoor_dim_two_iff to SimplicialAdjFnHelper — abstract half of the IsDoor ↔ color-change bridge slated in S21A's PR #17464 roadmap. ~50 lines, build pending. Builds on: S20 (PR #17426, satDiagBases foundation, build pending), S21A (PR #17464, t1-side forward extraction, build pending). Next: S21C Sperner+face-2 specialisation, then S21D _hLastFace assembly, then S22 Triangulation.sperner glue.",
+    "progressSummary": "S24 (this PR, build pending): added t2-side boundary extinction lemma t2_adj_ne_none — packaging the t2 branch of boundaryOnFace_simData2 as a stand-alone re-export so S25's bijection assembly can dismiss the t2 case in a single rcases. ~97 lines, build pending. Builds on S19.1 (adjFn_eq_none_iff_card_le_one), S18 (t2_face*_card_ge_two), and the existing t2 erase lemmas. Together with S21A (PR #17464, merged) the t1/t2 split for the _hLastFace filter is complete; S23 (PR #17571, in flight) supplies the color-side wiring. Next: S25 bijection assembly.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -89,7 +91,8 @@
       "t2_erase_first/second/third: explicit (t2 c).erase v computations giving the 3 edges (face2/face1/face0) (S19 part 2)",
       "S20 (PR #17426): satDiagBases N + satDiagBases_mem_iff + satDiagBases_subset_t1Bases + satDiagBases_image_map_injOn + satDiagBases_eq_image_range + satDiagBases_card + satDiagBases_endpoints_in_range + satDiagBases_endpoints_on_face2 + satDiagBases_t1_in_topSimps2 in SpernerFreudenthalSimplex.lean (N2LastFaceBases section)",
       "S21A (PR #17464): SpernerFreudSimp.t1_lastFace_implies_satDiag in SpernerFreudenthalSimplex.lean (N2LastFaceExtract section). Given b ∈ t1Bases N + drop-index k with all non-k vertices on face 2, concludes b ∈ satDiagBases N ∧ vertexEnum (t1 b) hS k = b.",
-      "S21B (this PR): SimplicialAdjFnHelper.isDoor_dim_two_iff in SpernerFreudenthalSimplex.lean. Generic CellComplex.IsDoor characterization for d=2: IsDoor c K s k ↔ (∃ i ≠ k, c (K.vertex s i) = 0) ∧ (∃ i ≠ k, c (K.vertex s i) = 1)."
+      "S21B (this PR): SimplicialAdjFnHelper.isDoor_dim_two_iff in SpernerFreudenthalSimplex.lean. Generic CellComplex.IsDoor characterization for d=2: IsDoor c K s k ↔ (∃ i ≠ k, c (K.vertex s i) = 0) ∧ (∃ i ≠ k, c (K.vertex s i) = 1).",
+      "S24 (this PR): SpernerFreudSimp.t2_adj_ne_none + t2_lastFace_filter_impossible in SpernerFreudenthalSimplex.lean (N2LastFaceT2Extinct section). t2-side _hLastFace boundary extinction: for c ∈ t2Bases N and k : Fin 3, ((simData2 N).toTriangulation).adj ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none. Filter-shape corollary t2_lastFace_filter_impossible drops the face-2 hypothesis for direct S25 consumption."
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -125,7 +128,8 @@
       "Six-cell coverage table now complete for n=2 _hBoundaryOnFace: t1 cells × {diagonal, horizontal, vertical} have both boundary singleton (S18.1) AND interior existential (S17 + S18.2); t2 cells × {face0, face1, face2} are always interior (S18.2.3-5; t2 contributes no boundary doors).",
       "S19.1 connects abstract adjFn to abstract containersOf; the missing link to S18 lemmas (which use concrete edge filter sets) is the explicit faceOf computation. The 6 erase lemmas + the ∀-quantifier bridge close this gap.",
       "Edit-tool path trap recurrence: writing to /Users/rwalters/GitHub/lean-genius/proofs/... (main repo path, not worktree) silently lost 177 lines of edits to concurrent rebase activity. Always use /Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-6/proofs/... for edits.",
-      "S20: Saturating-diagonal t1 bases form the cell side of _hLastFace. By S18.1+S18.5, the only boundary doors lying on geometric face 2 come from t1 b cells with b.1+b.2+1=N (t2 cells contribute none, horizontal/vertical t1 boundaries are on face 1/0). The count |satDiagBases N| = N matches face2_path_odd's Finset.range N index set, providing the bijection's count-side foundation."
+      "S20: Saturating-diagonal t1 bases form the cell side of _hLastFace. By S18.1+S18.5, the only boundary doors lying on geometric face 2 come from t1 b cells with b.1+b.2+1=N (t2 cells contribute none, horizontal/vertical t1 boundaries are on face 1/0). The count |satDiagBases N| = N matches face2_path_odd's Finset.range N index set, providing the bijection's count-side foundation.",
+      "S24: the t2-side _hLastFace filter is empty even before invoking the per-vertex face-2 hypothesis — every t2-cell codim-1 face has ≥ 2 containers (the t2 itself + a sharing t1) so adj = none never holds. This is strictly stronger than the t1 side (which needs the face-2 hypothesis to identify the satDiagBases case): for t2, the filter membership is impossible for the adj = none reason alone. Extracting this as a stand-alone lemma decouples S25 from re-running the boundaryOnFace_simData2 t2 case-split."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",


### PR DESCRIPTION
## Summary

S24 of the n=2 Sperner-via-Freudenthal pipeline: extracts the **t2 branch**
of `boundaryOnFace_simData2` (`SpernerFreudenthalSimplex.lean` lines 2186–2230)
as a stand-alone re-export so S25's bijection assembly can dismiss the t2
case in a single `rcases` rather than re-running the case-split.

Two short private lemmas in a new `N2LastFaceT2Extinct` section appended
to `SpernerFreudSimp` (97 lines added):

- **`t2_adj_ne_none`**: for `c ∈ t2Bases N` and any `k : Fin 3`,
  `((simData2 N).toTriangulation).adj ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none`.
  Proof case-splits on `vertexEnum (t2 c) hS k ∈ t2 c` (the S19.3 pattern)
  and applies the appropriate `t2_face*_card_ge_two` against the
  `card ≤ 1` consequence of `adj = none` from `adjFn_eq_none_iff_card_le_one`
  (S19.1). The proof structure mirrors the existing t2 branch of
  `boundaryOnFace_simData2` exactly.

- **`t2_lastFace_filter_impossible`**: filter-shaped corollary for direct
  S25 consumption — drops the face-2 hypothesis and derives `False` from
  any `(t2 c, k)` triple with `adj = none`.

## Path forward

Together with S21A's `t1_lastFace_implies_satDiag` (PR #17464, merged), the
t1/t2 split for `_hLastFace` is now complete:

- **t2 side (this PR, S24)**: no t2 cell contributes to the `_hLastFace`
  filter at all. Extinction holds without invoking the per-vertex face-2
  hypothesis — strictly stronger than the t1 side.
- **t1 side (S21A, merged)**: under the per-vertex face-2 hypothesis, the
  drop must be `b` itself and `b ∈ satDiagBases N`.

Remaining work:

- **S25**: bijection assembly between `_hLastFace` filter pairs
  `(t1 b, k_drop)` (with `b ∈ satDiagBases N`) and
  `(Finset.range N).filter (fun k => g k ≠ g (k+1))` color-changes via
  `face2_path_odd`, using S22's `isDoor_dim_two_iff_color_change_of_no_color_two`
  and S23's color-side wiring (PR #17571, in flight).
- **S26**: apply `Triangulation.boundary_doors_odd` + extract real-coordinate
  bounds for `sperner_panchromatic_two`.

## Build status

**Build pending** — per persistent `proofs/.lake` recursive-symlink build
infrastructure issue, full Lean check is deferred. Lemma proofs are direct
case-splits replaying the t2 branch of an already-merged proof
(`boundaryOnFace_simData2`); relies only on existing lemmas with verified
signatures:

- `adjFn_eq_none_iff_card_le_one` (line 1797): generic `adjFn = none ↔ card ≤ 1`
- `t2_face0/1/2_card_ge_two` (lines 1402, 1432, 1462): containers card ≥ 2
- `t2_erase_first/second/third` (lines 1693, 1713, 1733): erase computations

Following the iterative-PR cadence of S20–S22 (all merged build-pending) to
keep merge-conflict risk low. **Independent of the in-flight S23 PR #17571**
(which appends a different section, `N2LastFaceColors`, before this one;
no textual conflict on the insertion range).

## Files changed

- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (+97 lines)
- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (S24 focus block)
- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json` (iter 21→22, S24 entries)

## Status

- **Outcome**: progress (1 main lemma + 1 corollary, 97 lines, 0 sorries added)
- **Next**: S25 bijection assembly

## Test plan

- [ ] CI builds the file (Docker `proofs/.lake` symlink fix or skip; otherwise build pending)
- [ ] No textual conflict with PR #17571 (verified at branch time)
- [ ] State.md and JSON updates round-trip via reader/writer

🤖 Generated by researcher-9