### PR TITLE
Enrich chinese-remainder-constructive-oq-04-oq-02: section coverage + universal-property insights

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -74,7 +74,9 @@
       "**val-cast round-trip**: `ZMod.natCast_zmod_val w : (ZMod.val w : ZMod n) = w` allows moving between the ℕ representative and the ZMod element, connecting the two sides of the equivalence.",
       "**Uniqueness as the bridge to canonical form**: The minimal solution uniqueness theorem (`crt_list_minimal_unique`) identifies which ℕ in `[0, m*n)` corresponds to the ring-theoretic preimage, closing the equivalence at the level of canonical representatives.",
       "**Round-trip recipe via the inverse**: To prove a ZMod-derived witness satisfies a congruence system, compose `ZMod.natCast_zmod_val` (turning `↑(val w)` back into `w`) with `RingEquiv.apply_symm_apply` (the iso eats its inverse). This three-step pattern — `bridge ▸ natCast_zmod_val ▸ apply_symm_apply` — is the canonical idiom for any proof that descends from the ring-theoretic side back to ℕ.",
-      "**No new mathematics, only translation**: The unification adds zero axioms and zero sorries because the ring-theoretic CRT is already a theorem in Mathlib. The work here is entirely in *expressing* the equivalence as a definitional bridge, not in reproving CRT — a model for how unification proofs should look."
+      "**No new mathematics, only translation**: The unification adds zero axioms and zero sorries because the ring-theoretic CRT is already a theorem in Mathlib. The work here is entirely in *expressing* the equivalence as a definitional bridge, not in reproving CRT — a model for how unification proofs should look.",
+      "**Universal-property argument scales to k-fold and beyond**: The proof relies on `map_natCast` for the *single* ring iso $\\mathbb{Z}/mn\\mathbb{Z} \\to \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ — but the same recipe extends verbatim to the $k$-fold iso $\\mathbb{Z}/(\\prod m_i)\\mathbb{Z} \\to \\prod \\mathbb{Z}/m_i\\mathbb{Z}$ (Mathlib's `ZMod.prod_chineseRemainder`). The 2-fold case is exhibited here as a *prototype*; the open question 1 in the conclusion notes the natural extension. More broadly, *any* commutative-algebra unification of a constructive ℕ-valued formulation against a ring-theoretic counterpart can use the same `map_natCast` + componentwise NatCast recipe — the technique is universal-property-based, not specific to CRT.",
+      "**Three-step canonical idiom for descending from ZMod to ℕ**: To prove a `ZMod`-derived witness satisfies a ℕ-level congruence system, the proof composes three Mathlib facts in sequence: (1) the bridge theorem `satisfies_pair_iff_chineseRemainder` reformulates the goal in `ZMod` form; (2) `ZMod.natCast_zmod_val w : (↑(val w) : ZMod n) = w` rewrites the cast; (3) `RingEquiv.apply_symm_apply` collapses iso-and-inverse. This `bridge ▸ natCast_zmod_val ▸ apply_symm_apply` pattern is the **canonical idiom** for any ZMod-to-ℕ descent and reappears verbatim in `chineseRemainder_symm_satisfies` (lines 113–120)."
     ],
     "prerequisites": [
       "Nat.ModEq (modular congruences in ℕ)",
@@ -85,9 +87,17 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Module docstring framing the OQ-02 question (unify list-based and ring-theoretic CRT), imports `Mathlib.Data.ZMod.Basic` and the two parent OQ-04 files, sets `maxHeartbeats 400000`, opens `CRTList ZMod Nat`, and declares the `CRTUnification` namespace.",
+      "mathContext": "Two formulations of the same theorem live side by side: the list-based `CRTList.Satisfies` (parent OQ-04, ℕ-valued) and the ring-theoretic `ZMod.chineseRemainder` (Mathlib, $\\mathbb{Z}/mn\\mathbb{Z} \\xrightarrow{\\sim} \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$). The bridge between them is the universal property of $\\mathbb{N} \\to R$."
+    },
+    {
       "id": "structure",
-      "title": "Structure of the 2-Element System",
-      "startLine": 29,
+      "title": "Section 1: Structure of the 2-Element System",
+      "startLine": 38,
       "endLine": 57,
       "summary": "Four helper lemmas: moduli_pair, moduliProd_pair, pairwise_coprime_pair, satisfies_pair_iff. These unpack the 2-element system structure for use in the bridge theorems.",
       "mathContext": "moduli [(a,m),(b,n)] = [m,n]; moduliProd [(a,m),(b,n)] = m*n; Satisfies x [(a,m),(b,n)] ↔ x≡a[m] ∧ x≡b[n]"
@@ -109,12 +119,20 @@
       "mathContext": "Let w = (ZMod.chineseRemainder h).symm (a, b). Then ZMod.val w < m*n (by ZMod.val_lt) and Satisfies (ZMod.val w) [(a,m),(b,n)] (by natCast_zmod_val + apply_symm_apply)."
     },
     {
-      "id": "summary",
-      "title": "Summary Theorems",
+      "id": "existence-uniqueness",
+      "title": "Section 4: Existence and Uniqueness via ZMod",
       "startLine": 139,
+      "endLine": 162,
+      "summary": "`crt_exists_via_zmod`: explicit existence witness `ZMod.val ((chineseRemainder).symm (a, b))` in `[0, m·n)`. `crt_unique_two_fold`: uniqueness of solutions in the same range, by `crt_list_minimal_unique`.",
+      "mathContext": "Existence + uniqueness combined: $\\exists ! x \\in [0, m \\cdot n) : \\text{Satisfies}(x, [(a,m),(b,n)])$, with the witness $\\text{val}(\\phi^{-1}((\\bar a, \\bar b)))$."
+    },
+    {
+      "id": "concrete-example",
+      "title": "Concrete Example",
+      "startLine": 164,
       "endLine": 180,
-      "summary": "Three summary theorems: crt_exists_via_zmod (existence via the inverse iso), crt_unique_two_fold (uniqueness in [0, m*n)), and example_8_mod3_mod5, a concrete verified computation closing the file with native_decide.",
-      "mathContext": "Existence and uniqueness in $[0, mn)$ follow from the canonical bridge; example: $x \\equiv 2 \\pmod 3$, $x \\equiv 3 \\pmod 5$ has unique solution $8$ in $[0,15)$."
+      "summary": "`example_8_mod3_mod5`: regression test verifying that $x \\equiv 2 \\pmod 3$, $x \\equiv 3 \\pmod 5$ has unique solution $x = 8$ in $[0, 15)$. Uses `native_decide` for congruence checks and `crt_unique_two_fold` for uniqueness against an arbitrary candidate.",
+      "mathContext": "$8 \\equiv 2 \\pmod 3$ and $8 \\equiv 3 \\pmod 5$, $0 \\le 8 < 15$. The value $8$ is simultaneously the list-based minimal representative AND $\\text{val}((\\phi^{-1})(\\bar 2, \\bar 3))$ in $\\mathbb{Z}/15\\mathbb{Z}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for `chinese-remainder-constructive-oq-04-oq-02`

### Sections (4 → 6)
- Added `section-header` covering lines 1–28 (module docstring, imports, namespace) — previously sections started at 29.
- Split the omnibus 'summary' section into `existence-uniqueness` (139–162) and `concrete-example` (164–180) for clearer pedagogy.
- Corrected Section 1 startLine 29→38 to match the actual lemma block.

### keyInsights (6 → 8)
- **New insight 7**: The universal-property argument scales to k-fold and beyond. The same `map_natCast` + componentwise `NatCast` recipe works for `ZMod.prod_chineseRemainder` (k-fold iso) and for any constructive ↔ ring-theoretic unification rooted at the canonical $\mathbb{N} \to R$ ring map.
- **New insight 8**: The three-step canonical idiom for descending from `ZMod`-derived witnesses to ℕ: `bridge ▸ natCast_zmod_val ▸ apply_symm_apply`. This pattern reappears verbatim in `chineseRemainder_symm_satisfies` (lines 113–120) and characterizes the file's main proof technique.

No mathematical claims changed; status remains `verified` (0 sorries, 0 axioms).