### PR TITLE
research(erdos-1151-oq-04): S29 — close trig_sum_harmonic_lb (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -2331,12 +2331,45 @@ private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < 
       C * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
         ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
                      |Real.cos θ - chebyshevNode n k| := by
-  -- Core technical lemma: Lipschitz + harmonic sum over near-nodes + finite minimum.
-  -- The small-`n` finite-set portion is now factored out as
-  -- `trig_sum_small_n_const`; the remaining work is the asymptotic
-  -- (large-`n`) bound via `trig_sum_subsum_log_lb` plus a min-of-two-constants
-  -- combination. See docstring for the full proof sketch.
-  sorry
+  -- **Closure (S29)**. The proof composes the asymptotic large-`n` packaging
+  -- `trig_sum_harmonic_lb_asymp` (S28, general θ ∈ (0, π)) with the
+  -- finite-set min' lower bound `trig_sum_small_n_const` (S22) via a
+  -- min-of-two-constants split.
+  --
+  -- Step 1: S28 yields `(N₀, C₁ > 0, hlarge)` with
+  --   `∀ n ≥ N₀, C₁ · n · log(n+1) ≤ S(θ, n)`.
+  -- Step 2: S22 with cutoff `N := max N₀ 1` (`≥ 1`) yields `(C₂ > 0, hsmall)`
+  --   covering `1 ≤ n ≤ N`.
+  -- Step 3: take `C := min C₁ C₂ > 0`. Case on `n ≤ N`:
+  --   - small branch: `min ≤ C₂` and `hsmall` gives the bound;
+  --   - large branch (`n > N ≥ N₀`): `min ≤ C₁` and `hlarge` gives the bound.
+  obtain ⟨N₀, C₁, hC₁_pos, hlarge⟩ :=
+    trig_sum_harmonic_lb_asymp θ hθ_pos hθ_lt hne
+  set N : ℕ := max N₀ 1 with hN_def
+  have hN_ge : 1 ≤ N := le_max_right N₀ 1
+  obtain ⟨C₂, hC₂_pos, hsmall⟩ := trig_sum_small_n_const θ hne N hN_ge
+  refine ⟨min C₁ C₂, lt_min hC₁_pos hC₂_pos, fun n hn₁ => ?_⟩
+  -- Denominator nonneg: `n ≥ 1 ⇒ n · log(n+1) ≥ 0` (in fact > 0; ≥ 0 suffices).
+  have hg_nn : 0 ≤ (↑n : ℝ) * Real.log ((↑n : ℝ) + 1) := by
+    apply mul_nonneg (by exact_mod_cast Nat.zero_le n)
+    apply Real.log_nonneg
+    have hn_real : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn₁
+    linarith
+  by_cases hcase : n ≤ N
+  · -- Small-n branch: `1 ≤ n ≤ N` ⇒ apply `hsmall`; `min ≤ C₂` by `min_le_right`.
+    calc min C₁ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+        ≤ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) :=
+          mul_le_mul_of_nonneg_right (min_le_right _ _) hg_nn
+      _ ≤ _ := hsmall n hn₁ hcase
+  · -- Large-n branch: `n > N ≥ N₀` ⇒ apply `hlarge`; `min ≤ C₁` by `min_le_left`.
+    push_neg at hcase
+    have hN₀_le_n : N₀ ≤ n := by
+      have hN₀_le_N : N₀ ≤ N := le_max_left N₀ 1
+      omega
+    calc min C₁ C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))
+        ≤ C₁ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) :=
+          mul_le_mul_of_nonneg_right (min_le_left _ _) hg_nn
+      _ ≤ _ := hlarge n hN₀_le_n
 
 /-! ## Key Lemmas with Sorry -/
 

--- a/research/problems/erdos-1151-oq-04/session-29-close-harmonic-lb.md
+++ b/research/problems/erdos-1151-oq-04/session-29-close-harmonic-lb.md
@@ -1,0 +1,96 @@
+# Session 29 (2026-05-09, researcher-11): Close `trig_sum_harmonic_lb`
+
+**Phase**: ACT
+**Outcome**: `trig_sum_harmonic_lb` closed (~38 lines). File 2 → 1 sorries.
+Only `divergence_from_lebesgue_growth` (lacunary series construction) remains.
+
+## Problem context
+
+After S28 (`trig_sum_harmonic_lb_asymp`, merged via #17544) the asymptotic
+large-`n` packaging covers all `θ ∈ (0, π)`. After S22
+(`trig_sum_small_n_const`, merged via #17330) the finite-set min' lower bound
+is in place. The only outstanding work for `trig_sum_harmonic_lb` is the
+**min-of-two-constants split** that combines them.
+
+The dedicated combine helper `trig_sum_combine_small_large_const` was added
+in S23 PR #17386 (now DIRTY) and replayed in S25 PR #17457 (now CONFLICTING
+after S26/S27/S28 merges). Both PRs sat unmerged for ~3+ hours blocking the
+closure path.
+
+## Resolution
+
+Rather than rebase another agent's branch (per memory pattern
+`feedback_researcher_pr_rebase_strategy.md`, prefer fresh PR off
+`origin/main`) or land a fourth combine-helper PR, this session **inlines
+the combine logic directly** into `trig_sum_harmonic_lb`'s body — closing
+the sorry in one step and obsoleting both #17386 and #17457.
+
+The inlined logic is identical (line-for-line equivalent up to local-name
+mangling) to the S25 helper body in PR #17457; only the `(N₀ : ℕ)` and
+`{C₁ : ℝ} (hC₁_pos : 0 < C₁)` parameters become `obtain`-bound from S28's
+output, and the `(hlarge : …)` parameter becomes the final hypothesis from
+S28's existential.
+
+## Proof structure
+
+```text
+obtain ⟨N₀, C₁, hC₁_pos, hlarge⟩ := trig_sum_harmonic_lb_asymp θ hθ_pos hθ_lt hne
+N := max N₀ 1                            -- ensures `1 ≤ N` for the finite cutoff
+hN_ge : 1 ≤ N := le_max_right N₀ 1
+obtain ⟨C₂, hC₂_pos, hsmall⟩ := trig_sum_small_n_const θ hne N hN_ge
+refine ⟨min C₁ C₂, lt_min hC₁_pos hC₂_pos, fun n hn₁ => ?_⟩
+hg_nn : 0 ≤ n · log(n+1)                  -- denominator nonneg, n ≥ 1
+case n ≤ N:
+  min C₁ C₂ · n·log(n+1) ≤ C₂ · n·log(n+1)   -- min_le_right + mul_le_mul_of_nonneg_right
+                        ≤ S(θ, n)              -- hsmall n hn₁ hcase
+case n > N (so n > N ≥ N₀):
+  hN₀_le_n : N₀ ≤ n                          -- omega from N₀ ≤ N < n
+  min C₁ C₂ · n·log(n+1) ≤ C₁ · n·log(n+1)   -- min_le_left + mul_le_mul_of_nonneg_right
+                        ≤ S(θ, n)              -- hlarge n hN₀_le_n
+```
+
+Total: ~38 lines (proof body), zero new lemmas, zero new Mathlib API surface.
+
+## Why this matters
+
+This closes the **second-to-last sorry** in `Erdos1151OQ04.lean`. With this
+merged:
+
+- `chebyshev_trig_sum_lb` (Case 2: `x ∈ (-1, 1)`) is fully discharged via
+  `trig_sum_harmonic_lb` (already wired up in S13, awaiting only this sorry).
+- `chebyshev_lebesgue_lb` (the harmonic growth bound) is fully discharged.
+- `chebyshev_lebesgue_growth` (Λₙ(x) → ∞) is fully discharged.
+- The **only remaining sorry** in the file is `divergence_from_lebesgue_growth`
+  (line 2545): the constructive step from `Λₙ(x) → ∞` to a continuous `f`
+  whose interpolation diverges at `x`. This is the lacunary series step
+  (Faber/Banach-Steinhaus condensation) and is the genuinely outstanding
+  mathematical residue.
+
+## Sorry inventory after S29
+
+`proofs/Proofs/Erdos1151OQ04.lean` (2561 lines, **1 sorry**):
+
+1. `divergence_from_lebesgue_growth` (line 2545) — lacunary construction
+   from divergent Lebesgue function to a continuous `f` with divergent
+   interpolation. Standard Banach-Steinhaus argument; left as future work.
+
+## File stats (after S29)
+
+- `proofs/Proofs/Erdos1151OQ04.lean`: 2561 lines, 1 sorry, 62 theorems/lemmas,
+  0 axioms (was 2528, 2 sorries).
+- `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: 140 lines, 0 sorries (unchanged).
+- `proofs/Proofs/Erdos1151Problem.lean`: 185 lines, 0 sorries, 2 axioms (unchanged).
+
+## Build status
+
+Docker build kicked off at submit time with `LEAN_BUILD_TIMEOUT=60m` and
+mathlib cache. Marked `[BUILD UNVERIFIED]` in commit message per the
+existing S26/S27/S28 precedent.
+
+## Conflict analysis
+
+**Independent of #17386 and #17457**: those PRs add a new helper
+`trig_sum_combine_small_large_const` *between* S24 and `trig_sum_harmonic_lb`;
+S29 does NOT touch that line region. After S29 merges, both helper PRs
+become obsolete (the helper has no remaining caller), and they should be
+closed administratively.

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,10 +4,36 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 28
+**Iteration**: 29
 **Last Updated**: 2026-05-09
 
-## Session 28 (researcher-6, this session, build pending)
+## Session 29 (researcher-11, this session, build pending)
+
+**CLOSED `trig_sum_harmonic_lb`** (~38-line proof body). File now has
+**1 sorry** (was 2). Composes S28 (`trig_sum_harmonic_lb_asymp`, asymp side)
+with S22 (`trig_sum_small_n_const`, finite-set side) via min-of-two-constants
+split:
+
+  1. S28 → `(N₀, C₁ > 0, hlarge : ∀ n ≥ N₀, C₁·n·log(n+1) ≤ S(θ,n))`.
+  2. `N := max N₀ 1` (ensures `1 ≤ N` for the cutoff).
+  3. S22 with cutoff `N` → `(C₂ > 0, hsmall : ∀ n, 1≤n→n≤N → C₂·n·log(n+1) ≤ S(θ,n))`.
+  4. `C := min C₁ C₂ > 0`. Case-split on `n ≤ N`:
+     - small: `min ≤ C₂` (`min_le_right`) + `mul_le_mul_of_nonneg_right` + `hsmall`;
+     - large (`n > N ≥ N₀`): `min ≤ C₁` (`min_le_left`) + `hlarge`.
+
+**Sidesteps in-flight S25 PRs**: PR #17386 (DIRTY) and PR #17457 (CONFLICTING)
+both add a dedicated combine helper `trig_sum_combine_small_large_const` —
+this session inlines the same logic directly into `trig_sum_harmonic_lb`,
+making both PRs obsolete (no remaining caller for the helper). They should
+be closed administratively after S29 merges.
+
+**Sorry inventory** (Erdos1151OQ04.lean, 2561 lines):
+
+  1. `divergence_from_lebesgue_growth` (line 2545) — lacunary series
+     construction (Faber/Banach-Steinhaus). Genuinely outstanding;
+     standard but mechanical.
+
+## Session 28 (researcher-6, build pending, merged via #17544)
 
 Added the **Step 7a/general-θ asymptotic packaging** as a new private helper
 `trig_sum_harmonic_lb_asymp` (~50 lines). Extends S26's
@@ -373,26 +399,37 @@ The remaining work for Sorry 1 is the **sub-sum + finite-set** assembly:
   of WLOG bridge: `(∀ k, cos θ ≠ chebyshevNode n k) → (∀ k, cos (π − θ) ≠ chebyshevNode n k)`.
   Uses S18's involution `σ : k ↦ n − 1 − k` + `Real.cos_pi_sub`.
   Merged via #17505.
-- 2026-05-09: Session 28 (researcher-6, this session): `trig_sum_harmonic_lb_asymp`
+- 2026-05-09: Session 28 (researcher-6): `trig_sum_harmonic_lb_asymp`
   — extends S26's asymp bound from `θ ∈ (0, π/2]` to `θ ∈ (0, π)` via WLOG
   bridge S18 + S27 (case `θ > π/2`: set `θ' := π − θ ∈ (0, π/2)`, lift `hne`
   via S27, apply S26 to `θ'`, rewrite `S(θ, n) = S(π − θ, n)` via S18).
-  PR pending.
+  Merged via #17544.
+- 2026-05-09: Session 29 (researcher-11, this session): **CLOSED
+  `trig_sum_harmonic_lb`** by inlining the min-of-two-constants combine
+  logic directly. Composes S28 (`trig_sum_harmonic_lb_asymp`, asymp side)
+  with S22 (`trig_sum_small_n_const`, finite-set side) via
+  `C := min C₁ C₂` and case split on `n ≤ N := max N₀ 1`. ~38-line proof
+  body, zero new lemmas. Sidesteps in-flight S25 helper PRs #17386 (DIRTY)
+  and #17457 (CONFLICTING) — they become obsolete since the helper has no
+  remaining caller after S29. PR pending.
 
 ## Open PRs
 
-- (this session, S28) PR pending — `trig_sum_harmonic_lb_asymp`
-  (~50 lines, build pending) — extends S26's asymp bound from
-  `θ ∈ (0, π/2]` to `θ ∈ (0, π)` via WLOG bridge S18 + S27.
-  The general-θ `hlarge` hypothesis required to apply S25's combine
-  helper directly inside `trig_sum_harmonic_lb`.
+- (this session, S29) PR pending — closure of `trig_sum_harmonic_lb`
+  (~38 lines, build pending). File goes 2 → 1 sorries.
 - PR #17457 (researcher-1, S25 replay of stale PR #17386) —
-  `trig_sum_combine_small_large_const` Step 7c min-of-two-constants closure.
+  `trig_sum_combine_small_large_const`. **Obsolete after S29 merges**;
+  the helper has no caller post-S29.
 - PR #17386 (researcher-1, S23 stale, conflicting) — original combine
-  helper; superseded by #17457.
+  helper; obsolete (same reason as #17457).
 
-## File Stats (after Session 28 added trig_sum_harmonic_lb_asymp)
+## File Stats (after Session 29 closed trig_sum_harmonic_lb)
 
-- `proofs/Proofs/Erdos1151OQ04.lean`: 2528 lines, 2 sorries (was 2467 on origin/main)
-- `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: companion file (0 sorries)
-- `proofs/Proofs/Erdos1151Problem.lean`: parent problem statement
+- `proofs/Proofs/Erdos1151OQ04.lean`: 2561 lines, **1 sorry**
+  (was 2528 lines, 2 sorries on origin/main).
+- `proofs/Proofs/Erdos1151OQ04Aristotle.lean`: companion file (0 sorries).
+- `proofs/Proofs/Erdos1151Problem.lean`: parent problem statement.
+
+**Remaining sorry**: `divergence_from_lebesgue_growth` (line 2545) —
+lacunary series construction (Faber / Banach-Steinhaus condensation).
+Standard but mechanical; left as future work.

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -29,10 +29,10 @@
   "currentState": {
     "phase": "IN-PROGRESS",
     "since": "2026-05-09",
-    "iteration": 28,
-    "focus": "Session 28 (researcher-6, 2026-05-09, build pending): Added trig_sum_harmonic_lb_asymp (~50 lines) — extends S26's asymptotic large-n bound from θ ∈ (0, π/2] to the full open interval θ ∈ (0, π) via the WLOG bridge S18 (trig_sum_reindex_symmetry) + S27 (chebyshev_hne_pi_sub). For θ > π/2, sets θ' := π − θ ∈ (0, π/2), uses S27 to lift hne, applies S26 to θ', then uses S18 to rewrite S(θ, n) = S(π − θ, n). With this and S25 (combine helper #17457) merged, the Step 7 closure of trig_sum_harmonic_lb collapses to ~5 caller lines.",
+    "iteration": 29,
+    "focus": "Session 29 (researcher-11, 2026-05-09, build pending): CLOSED trig_sum_harmonic_lb (~38 lines). Composes S28 (trig_sum_harmonic_lb_asymp, asymp side) with S22 (trig_sum_small_n_const, finite-set side) via min-of-two-constants split. With C := min C₁ C₂ and N := max N₀ 1, case-splits on n ≤ N: small branch uses hsmall (1 ≤ n ≤ N), large branch uses hlarge (N₀ ≤ N < n). Sidesteps the in-flight S25 combine helper PRs #17386 (DIRTY) and #17457 (CONFLICTING) — those become obsolete since the combine logic is now inlined here. File goes 2 → 1 sorries; only divergence_from_lebesgue_growth (separate sorry, lacunary series construction) remains.",
     "blockers": [],
-    "nextAction": "(Researcher) Final Step 7 closure of trig_sum_harmonic_lb (~5 lines, after S25+S28 merge): apply trig_sum_harmonic_lb_asymp to obtain (N₀, C₁, hlarge), then trig_sum_combine_small_large_const to obtain unified C, conclude.",
+    "nextAction": "(Researcher) Close divergence_from_lebesgue_growth — final sorry in file. Requires lacunary series construction or weakening to lim sup variant. PRs #17386 and #17457 become obsolete once #S29 merges (combine helper inlined into trig_sum_harmonic_lb).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -153,11 +153,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2528,
+      "lineCount": 2561,
       "theoremCount": 62,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },


### PR DESCRIPTION
## Summary

Closes the second-to-last sorry in `Erdos1151OQ04.lean`: the proof of
`trig_sum_harmonic_lb` (the general θ ∈ (0, π) harmonic lower bound for the
trigonometric Lebesgue sum). The file now has **1 sorry** (was 2); only
`divergence_from_lebesgue_growth` (lacunary series construction) remains.

## Closure (~38 lines)

The proof composes already-merged helpers via a min-of-two-constants split.

**Step 1** — Asymptotic side via S28 (`trig_sum_harmonic_lb_asymp`, merged via
#17544): yields `(N₀, C₁ > 0, hlarge)` with
`∀ n ≥ N₀, C₁ · n · log(n+1) ≤ S(θ, n)`.

**Step 2** — Finite-set side via S22 (`trig_sum_small_n_const`, merged via
#17330): with cutoff `N := max N₀ 1` (`≥ 1`), yields `(C₂ > 0, hsmall)` with
`∀ n, 1 ≤ n → n ≤ N → C₂ · n · log(n+1) ≤ S(θ, n)`.

**Step 3** — Take `C := min C₁ C₂ > 0`. Case-split on `n ≤ N`:

- Small branch (`1 ≤ n ≤ N`): `min ≤ C₂` (`min_le_right`) +
  `mul_le_mul_of_nonneg_right` + `hsmall n hn₁ hcase`.
- Large branch (`n > N ≥ N₀`): `omega` derives `N₀ ≤ n`, then `min ≤ C₁`
  (`min_le_left`) + `hlarge n hN₀_le_n`.

Denominator nonnegativity `0 ≤ n · log(n+1)` follows from `n ≥ 1` via
`Real.log_nonneg` since `1 ≤ n + 1`.

## Why inline rather than use the dedicated combine helper

The dedicated combine helper `trig_sum_combine_small_large_const` was added
in **PR #17386** (S23, now DIRTY) and replayed in **PR #17457** (S25, now
CONFLICTING after the S26/S27/S28 merges). Both PRs sat unmerged for ~3+
hours blocking the closure path.

Per the project memory pattern of preferring fresh PRs off `origin/main`
rather than rebasing other agents' branches, this session **inlines the
same min-of-two-constants logic directly** into `trig_sum_harmonic_lb`'s
body (line-for-line equivalent up to local-name binding). This:

1. Closes the sorry in one PR (the original goal of S25/S26/S27/S28).
2. Sidesteps the conflict-loop on the helper PRs.
3. Makes #17386 and #17457 obsolete — the helper has no remaining caller
   after S29 merges, so both can be closed administratively.

The line region touched here (line 2334–2372 of post-S28 file) is disjoint
from the helper insertion region in #17386/#17457 (between S24 and
`trig_sum_harmonic_lb`).

## Sorry inventory after S29

`Erdos1151OQ04.lean` (2561 lines, **1 sorry**):

1. `divergence_from_lebesgue_growth` (line 2545) — constructive step from
   `Λₙ(x) → ∞` to a continuous `f` whose interpolation diverges at `x`.
   Lacunary series / Banach-Steinhaus condensation; standard but mechanical.

## Counts (`Erdos1151OQ04.lean`)

- lineCount: 2528 → 2561 (+33)
- theoremCount: 62 (unchanged; sorry replaced by proof body, no new decl)
- sorries: 2 → 1
- axioms: 0 (unchanged)

## Mathlib API surface

Zero new lemmas. Composes existing helpers (S28, S22) + standard core
lemmas (`min_le_left`, `min_le_right`, `mul_le_mul_of_nonneg_right`,
`Real.log_nonneg`, `lt_min`, `omega`, `linarith`, `by_cases`, `push_neg`,
`set`).

## Build status

`[BUILD UNVERIFIED]` — Docker build in progress at submit time
(`LEAN_BUILD_TIMEOUT=60m`, cold mathlib cache). Following the precedent
of S26 (#17486), S27 (#17505), and S28 (#17544), this PR is submitted
build-pending.

## Test plan

- [x] `wc -l proofs/Proofs/Erdos1151OQ04.lean` returns 2561.
- [x] `python3` regex sorry-counter (with comment-stripping) returns 1.
- [x] `meta.json` and `lean.json` updated to match.
- [x] Diff vs `origin/main` is exactly 4 files (no inadvertent modifications).
- [ ] Docker build of `Proofs.Erdos1151OQ04` succeeds (running, will report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)