### PR TITLE
audit(erdos-1037): clean — counts and tier verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3228,9 +3228,9 @@
     },
     "erdos-1037": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T00:57:02Z",
       "result": "clean"
     },
     "erdos-1038": {


### PR DESCRIPTION
## Audit Result: CLEAN

Verified `src/data/proofs/erdos-1037/meta.json` against `proofs/Proofs/Erdos1037Problem.lean` (and companion `Proofs/Erdos1037Aristotle.lean`).

### Counts (all match)

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 324 | 324 |
| axiomCount | 3 | 3 (`chenErdos_false`, `cambieChanHunter_construction`, `ramseyNumber`) |
| theoremCount | 12 | 12 |
| definitionCount | 20 | 20 |
| sorries | 0 | 0 (main) + 0 (companion) |

### Tier Classification

Tier C — scaffold/axiomatized. Status `"axiomatized"` + badge `"axiom"` correctly reflect the 3 real axioms. The Cambie-Chan-Hunter counterexample construction and the Chen-Erdős conjecture's falsity are encoded as axioms; the surrounding theorems are real Lean proofs deriving consequences from those axioms.

### Notes

- No True stubs. No sorry-count drift. No Mathlib-wrapper masking.
- Narrative correctly attributes the disproof to Cambie-Chan-Hunter and frames the Lean file as scaffold + axiomatized counterexample.
- Companion (Aristotle target) file has 8 routine support theorems, 0 sorries, 0 axioms.

Tracker updated to record this audit.