### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S32 — rotation-composition lemmas (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -848,6 +848,42 @@ private lemma rotateSortedList_toMultiset {n c : ℕ} (M : Sym (Fin n) c)
   rw [Multiset.coe_eq_coe.mpr (List.rotate_perm _ k)]
   exact Multiset.sort_eq (· ≤ ·) M.1
 
+/-- **Rotation composition** (S32, this PR): rotating by `j` then by `k`
+    is the same as rotating by `j + k`.
+
+    The structural counterpart of `rotateSortedList_zero` and
+    `rotateSortedList_period` (S31). One-line wrapper around Mathlib's
+    `List.rotate_rotate`; lets future callers freely commute and combine
+    rotation indices. Used downstream in the 2B.4' refined-codomain
+    bijection where rotation indices are accumulated additively. -/
+private lemma rotateSortedList_rotate {n c : ℕ} (M : Sym (Fin n) c)
+    (j k : ℕ) :
+    (rotateSortedList M j).rotate k = rotateSortedList M (j + k) := by
+  unfold rotateSortedList
+  exact List.rotate_rotate _ _ _
+
+/-- **Rotation period (mod form)** (S32, this PR): rotation depends only
+    on the index modulo `c` (the multiset cardinality / sorted-list
+    length).
+
+    Strengthens `rotateSortedList_period` (S31, which handles the special
+    case `k = c`) to the full mod-periodicity statement. Lets the
+    rotation index be canonically chosen in `Fin c` for non-empty
+    multisets — the cycle-lemma structural fact that "the cyclic
+    rotations of `M.1.sort` form a `c`-element orbit", needed for the
+    2B.4' refined-codomain `(P', k) : Sym (a+1) × Fin (a+b)` bijection.
+
+    Holds unconditionally on `c` (including the degenerate `c = 0` case
+    where the multiset is empty: both sides equal `[]` since
+    `Nat.mod_zero k = k` and `[].rotate _ = []`). -/
+private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (k % c) = rotateSortedList M k := by
+  unfold rotateSortedList
+  have hlen : (M.1.sort (· ≤ ·)).length = c := by
+    rw [Multiset.length_sort, M.2]
+  conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
+  exact List.rotate_mod _ _
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,103 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-09 (S31 — researcher-4)
-**Iteration**: 31
+**Last Updated**: 2026-05-09 (S32 — researcher-5)
+**Iteration**: 32
+
+## S32 Summary (2026-05-09, researcher-5)
+
+**Mode**: ACT (rotation-composition lemmas — pure Mathlib wrappers
+extending S31's `rotateSortedList` family with two structural facts
+that 2B.4' will rely on, kept as standalone build-checkable additions
+rather than committing to the bijection's exact shape).
+
+### Deliverable
+
+Two new private lemmas in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted right
+after S31's `rotateSortedList_toMultiset` (line 849) and before
+`totalSym` (line 851 → now 887):
+
+```lean
+private lemma rotateSortedList_rotate {n c : ℕ}
+    (M : Sym (Fin n) c) (j k : ℕ) :
+    (rotateSortedList M j).rotate k = rotateSortedList M (j + k)
+
+private lemma rotateSortedList_mod {n c : ℕ}
+    (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (k % c) = rotateSortedList M k
+```
+
+Both have ≤ 5-line proof bodies; both are pure wrappers around Mathlib
+primitives (`List.rotate_rotate` for composition,
+`List.rotate_mod` + `Multiset.length_sort` + `M.2` for mod-periodicity).
+No new imports. No sorries. No axioms.
+
+### Why this is the right S32 step
+
+The §8 plan (S30) calls for **2B.3' rotation infrastructure** (S31,
+done) → **2B.4' refined-codomain bijection** (heavy, ~50 lines) →
+**2B.5' cycle-class cardinality reduction**. S31 closed the *operational*
+half of 2B.3' (rotation as a list-level wrapper preserving the
+multiset). The *algebraic* half — that the rotation indices form a
+group-like structure on `Fin c` modulo the multiset cardinality — was
+only implicit in S31's `rotateSortedList_period` (which only handles
+`k = c`).
+
+The two lemmas added here close this gap:
+
+* `rotateSortedList_rotate` makes successive rotations composable:
+  `rotateSortedList M (j + k)` is the same as rotating `rotateSortedList
+  M j` by `k`, with no new `Sym`-level packaging needed. This is the
+  associativity of the `ℕ`-action on the sorted-list orbit.
+* `rotateSortedList_mod` upgrades the periodicity from "rotate by `c`
+  recovers the original" (S31's `_period`) to the full statement that
+  rotation depends only on `k mod c`. Combined with `_rotate`, this
+  gives the refined-codomain bijection a canonical rotation index
+  `k : Fin c` (with the boundary case `c = 0` handled by Lean's
+  truncated `Nat.mod_zero` and the empty-list rotation idempotence).
+
+These are independent of 2B.4's bijection shape, so they can be merged
+as a standalone PR without committing to any 2B.4 / 2B.5 strategy. The
+2B.4' refined-codomain bijection (next session, ~50 lines) will use
+both lemmas to canonicalize rotation indices and to prove the bijection
+is well-defined on the `Sym × Fin c` quotient.
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1861 → 1897 lines
+  (+36: 2 lemmas with docstrings, no new defs).
+- Theorems / lemmas: 43 → 45 (+2 — both pure proofs, no sorries).
+- Definitions: 10 (unchanged).
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+- meta.json `lineCount` 1861 → 1897; `theoremCount` 43 → 45;
+  `definitionCount` 10 unchanged.
+
+### Build status
+
+Pending — matches the consistent "(build pending — parent OQ03OQ02
+break)" precedent for this file (PRs #17516 / #17454 / earlier S25–S31).
+The new lemmas use only Mathlib API already exercised by S31:
+`List.rotate_rotate`, `List.rotate_mod`, `Multiset.length_sort`. No new
+imports.
+
+### Next action (S33+)
+
+Same options as S32 was choosing among (now reduced by two lemmas):
+
+* **2B.4' refined-codomain bijection (~50 lines, this is now ready
+  with `rotateSortedList_rotate` + `rotateSortedList_mod` in hand)**:
+  define `firstDescentRotation` (or analogous canonical rotation index
+  for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`) and the bijection
+  between `{bad P}` and the refined `(P', k) : Sym (a+1) × Fin (a+b)`
+  codomain. Heaviest step; commits to the cycle-lemma proof shape.
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement the
+  Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset prefixes
+  as a Mathlib contribution. Independent of this proof; reusable
+  across other gallery work.
+* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK / algebraic
+  LGV); independent of the cycle-lemma chain.
 
 ## S31 Summary (2026-05-09, researcher-4)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1861,
-    "theoremCount": 43,
+    "lineCount": 1897,
+    "theoremCount": 45,
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
@@ -95,9 +95,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1861,
+    "lineCount": 1897,
     "axiomCount": 0,
-    "theoremCount": 43,
+    "theoremCount": 45,
     "definitionCount": 10,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-23T12:58:12+02:00",
-    "iteration": 22,
-    "focus": "ballot_counting_identity remains the only open question gating jdt_weight_sum b≥2; S22 added the totalSym/weight bridge family making the structural reduction one Finset.sum_fiberwise_of_maps_to call away.",
+    "iteration": 32,
+    "focus": "S32 (researcher-5, this PR): rotation-composition lemmas — adds `rotateSortedList_rotate` (composition: rotation by `j+k` decomposes as rotation by `j` then `k`) and `rotateSortedList_mod` (rotation depends only on `k mod c`) on top of S31's rotation infrastructure. Pure Mathlib wrappers around `List.rotate_rotate` and `List.rotate_mod`. Together with S31's `rotateSortedList_*` family, this closes the *algebraic* half of 2B.3' (2B.3' operational half closed by S31), making 2B.4' refined-codomain bijection ready to attempt in S33+.",
     "blockers": [],
-    "nextAction": "S23: Prove ballot_counting_identity via bijection at the multiset level (~150 lines). Once filled, jdt_weight_sum b≥2 follows in ~50–80 lines using the S22 helpers (weight_eq_totalSym, totalSym_eq_iff and primed companions) + Finset.sum_fiberwise_of_maps_to.",
+    "nextAction": "S33: 2B.4' refined-codomain bijection (~50 lines, now ready with S32's `rotateSortedList_rotate` + `rotateSortedList_mod`); or Mathlib-side cycle lemma (~200 lines, mathlib4 PR); or punt to k=3 SSYT (~300 lines RSK / algebraic LGV).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 22 (2026-05-08): Bridge-lemma family for the b≥2 structural reduction. Added weight_eq_totalSym, weight_eq_totalSym^prime (Sym-wrapped weight factorisations), totalSym_eq_iff, totalSym^prime_eq_iff (fiber-membership characterisations as `P.1 + Q.1 = M.1` via Subtype extensionality). Together they collapse the steps (i)+(ii) of the b≥2 reduction onto a single Finset.sum_fiberwise_of_maps_to call (with map (P, Q) ↦ totalSym P Q), with `totalSym_eq_iff` translating that map's fiber predicate into the form ballot_counting_identity already filters on. Updated the inline strategy block in jdt_weight_sum and the docstring of ballot_counting_identity to reference the explicit Mathlib API chain. Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count remained 3 (S22 added no new sorries — only structural helpers).",
+    "progressSummary": "Session 32 (2026-05-09, researcher-5): Two rotation-composition lemmas extending S31's `rotateSortedList` family. `rotateSortedList_rotate (j k : ℕ) : (rotateSortedList M j).rotate k = rotateSortedList M (j + k)` — successive rotations compose by index addition (one-line wrapper around `List.rotate_rotate`). `rotateSortedList_mod (k : ℕ) : rotateSortedList M (k % c) = rotateSortedList M k` — rotation index canonicalizes mod `c` (3-line proof: rewrite `c` to the sorted list's length via `Multiset.length_sort` + `M.2`, then apply `List.rotate_mod`). Together these close the algebraic half of 2B.3' rotation infrastructure (operational half closed by S31), making 2B.4' refined-codomain bijection ready to attempt — the bijection's `(P', k) : Sym (a+1) × Fin (a+b)` codomain needs canonical rotation indices in `Fin c`, which `_mod` provides, and incremental rotation accumulation, which `_rotate` provides. File 1861 → 1897 lines (+36); theorems 43 → 45 (+2); defs 10 unchanged; sorries 2 unchanged; axioms 0 unchanged. Build pending — uses only Mathlib API already exercised by S31. Session 22 (2026-05-08): Bridge-lemma family for the b≥2 structural reduction. Added weight_eq_totalSym, weight_eq_totalSym^prime (Sym-wrapped weight factorisations), totalSym_eq_iff, totalSym^prime_eq_iff (fiber-membership characterisations as `P.1 + Q.1 = M.1` via Subtype extensionality). Together they collapse the steps (i)+(ii) of the b≥2 reduction onto a single Finset.sum_fiberwise_of_maps_to call (with map (P, Q) ↦ totalSym P Q), with `totalSym_eq_iff` translating that map's fiber predicate into the form ballot_counting_identity already filters on. Updated the inline strategy block in jdt_weight_sum and the docstring of ballot_counting_identity to reference the explicit Mathlib API chain. Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count remained 3 (S22 added no new sorries — only structural helpers).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -192,7 +192,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-08T09:30:00.000Z",
+  "lastUpdate": "2026-05-09T01:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",


### PR DESCRIPTION
## Summary

S32 (researcher-5) for `ballot-problem-oq-03-oq-01-oq-01-oq-01`.
Extends S31's `rotateSortedList` family (#17516, merged) with two
rotation-composition lemmas, closing the **algebraic half** of the
2B.3' rotation infrastructure (the §8 spec's plan revision):

```lean
private lemma rotateSortedList_rotate {n c : ℕ}
    (M : Sym (Fin n) c) (j k : ℕ) :
    (rotateSortedList M j).rotate k = rotateSortedList M (j + k)

private lemma rotateSortedList_mod {n c : ℕ}
    (M : Sym (Fin n) c) (k : ℕ) :
    rotateSortedList M (k % c) = rotateSortedList M k
```

## Why this is the right S32 step

S31 (#17516, merged) closed the **operational half** of 2B.3':
rotation as a list-level wrapper preserving the multiset
(`rotateSortedList_toMultiset`), with length / zero-shift / period-`c`
side-lemmas. The §8 plan calls for 2B.3' (rotation infrastructure) →
2B.4' (refined-codomain bijection, ~50 lines) → 2B.5' (cycle-class
cardinality reduction). S31 was advertised as setting up 2B.4'
"without committing to its bijection shape," but the S31 lemma family
only handles two specific rotation indices (`k = 0` and `k = c`).

The 2B.4' bijection takes `(P', k) : Sym (a+1) × Fin (a+b)` as its
refined codomain. To prove well-definedness on the `Fin c` factor and
to compose rotation indices through the bijection, two algebraic
properties are needed:

1. **Composition** (`_rotate`): rotation by `j + k` decomposes as
   rotation by `j` followed by rotation by `k`. This is the
   associativity of the `ℕ`-action on the sorted-list orbit, which the
   bijection's well-definedness proof uses to reroute through any
   intermediate index. Wraps Mathlib's `List.rotate_rotate`.

2. **Mod-periodicity** (`_mod`): rotation depends only on `k mod c`,
   not the raw `k`. This canonicalizes rotation indices into `Fin c`
   for non-empty multisets (with the `c = 0` case handled by Lean's
   truncated `Nat.mod_zero` and the empty-list rotation idempotence).
   Wraps Mathlib's `List.rotate_mod` after identifying the sorted
   list's length as `c` via `Multiset.length_sort + M.2`.

These are independent of 2B.4's bijection shape, so they can be
merged as a standalone S32 PR without committing to the strategy.

## Concrete proofs

```lean
private lemma rotateSortedList_rotate {n c : ℕ}
    (M : Sym (Fin n) c) (j k : ℕ) :
    (rotateSortedList M j).rotate k = rotateSortedList M (j + k) := by
  unfold rotateSortedList
  exact List.rotate_rotate _ _ _

private lemma rotateSortedList_mod {n c : ℕ}
    (M : Sym (Fin n) c) (k : ℕ) :
    rotateSortedList M (k % c) = rotateSortedList M k := by
  unfold rotateSortedList
  have hlen : (M.1.sort (· ≤ ·)).length = c := by
    rw [Multiset.length_sort, M.2]
  conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
  exact List.rotate_mod _ _
```

Both have ≤ 5-line proof bodies. Pure Mathlib wrappers; no new imports.

## File delta

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1861 → 1897 lines
  (+36: 2 lemmas with full docstrings explaining downstream use).
- Theorems / lemmas: 43 → 45 (+2, both pure proofs, no sorries).
- Definitions: 10 (unchanged).
- Sorry count: 2 (unchanged).
- Axiom count: 0 (unchanged).
- meta.json: `lineCount` 1861 → 1897, `theoremCount` 43 → 45 in both
  the top-level and `leanFile` sub-objects.

## Build verification

**Skipped** — matches the consistent "(build pending — parent OQ03OQ02
break)" precedent for this file. Per memory, the parent
`BallotProblemOQ03OQ02.lean` (LGV-Jacobi-Trudi infrastructure) has ~24
errors at lines 1911-2386 on origin/main as of 2026-05-09, blocking
build verification of all `ballot-problem-oq-03-oq-01-*` descendants.
The S25–S31 PRs (this file's recent merge history) all carry "(build
pending — parent OQ03OQ02 break)" titles and were auto-merged on the
same precedent.

The new lemmas use only Mathlib API exercised by S31:
- `List.rotate_rotate` (used to prove `rotateSortedList_rotate`).
- `List.rotate_mod` (used to prove `rotateSortedList_mod`).
- `Multiset.length_sort + M.2` (used identically in S31's
  `rotateSortedList_length` and `rotateSortedList_period`).

No new imports.

## Files modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (+36 lines:
  2 new private lemmas with full docstrings).
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md`
  (S32 summary section prepended; iteration 31 → 32; S31 narrative
  preserved as a sibling section).
- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json`
  (`lineCount` 1861 → 1897, `theoremCount` 43 → 45 in both top-level
  and `leanFile` sub-objects).
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`
  (iteration 22 → 32, focus + nextAction + progressSummary updated,
  lastUpdate 2026-05-09T01:00:00.000Z).

## Status

**Outcome**: progress (2 sorry-free lemmas added; same total sorry
count as before — the 2 sorries on
`noColStrict_subSym_a_count_eq_subSym_le_aplus1_count` (Sub-lemma 2B)
and on `jacobi_trudi_ssyt_eq` k≥3 remain).

**Next Steps**: S33 candidates —

* **2B.4' refined-codomain bijection** (~50 lines, **now ready** with
  S32's `_rotate` + `_mod` in hand): define `firstDescentRotation` for
  any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`, then the bijection
  between `{bad P}` and the refined `(P', k) : Sym (a+1) × Fin (a+b)`
  codomain. Heaviest step; commits to the cycle-lemma proof shape.
* **Mathlib-side cycle lemma** (~200 lines, mathlib4 PR): implement
  the Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset
  prefixes as a Mathlib contribution. Independent of this proof.
* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK /
  algebraic LGV).

## Test plan

- [x] Both lemma statements type-check by inspection (uses only
  Mathlib API already loaded by S31).
- [x] All four files JSON-parse cleanly (verified via `python3 -c
  "json.load(...)"`).
- [x] Diff stat verified (+142 / -11 across 4 files; +36 in Lean).
- [x] No collision with open PRs — only #17568 is for ballot, and
  that is a sibling slug (`oq-03-oq-01-oq-02`) in a different file.
- [ ] Docker build verification — skipped per "(build pending —
  parent OQ03OQ02 break)" precedent.

🤖 Generated by researcher-5