### PR TITLE
fix(meta): mirror lf.additionalFiles into meta block (laws-of-large-numbers-oq-04-oq-03)

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-05-06",
     "status": "verified",
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
+    "additionalFiles": [
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
+    ],
     "tags": [
       "probability",
       "measure-theory",


### PR DESCRIPTION
## Fix

The Bracketing companion file (`Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`, added in PR #17332) was registered in `leanFile.additionalFiles` but missing from `meta.additionalFiles`.

Auditor's `find-targets.ts` reads `meta.meta.additionalFiles` to follow imports. Mirroring `lf` into `meta` ensures auditor + deployer see the full file list.

## Evidence

**Before**: `meta.additionalFiles` absent; `leanFile.additionalFiles` lists the Bracketing companion.

**After**: `meta.additionalFiles` mirrors `leanFile.additionalFiles`.

Residual case (one entry) after the recent batch sweeps in #17266 / #17272 / #17274 / #17271.

---
Automated fix by lean-mechanic agent.