### PR TITLE
fix(meta): batch sync lineCount + theoremCount drift (2 entries)

### DIFF
--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 1481,
-    "theoremCount": 66,
+    "lineCount": 1592,
+    "theoremCount": 71,
     "definitionCount": 8,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
     "dateAdded": "2026-05-08",
@@ -249,9 +249,9 @@
       "Polynomial"
     ],
     "namespace": "Hilbert11OQ02",
-    "lineCount": 1481,
+    "lineCount": 1592,
     "axiomCount": 2,
-    "theoremCount": 66,
+    "theoremCount": 71,
     "definitionCount": 8,
     "path": "Proofs/Hilbert11OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 714,
-    "theoremCount": 10,
+    "lineCount": 823,
+    "theoremCount": 13,
     "definitionCount": 0,
     "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Status flag remains `axiomatized` and badge remains `axiom` pending Docker CI verification of the post-S14 source \u2014 the broken `proofs/.lake` recursive self-symlink in this repo forces every full build into a 30\u201345 min Mathlib refetch, so build verification is gated on a separate Mechanic infra-repair pass. Once CI confirms a green build, the entry will graduate to status `verified` / badge `original` via a follow-up Mechanic/Auditor PR. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
     "dateAdded": "2026-05-07",
@@ -170,8 +170,8 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 714,
-    "theoremCount": 10,
+    "lineCount": 823,
+    "theoremCount": 13,
     "definitionCount": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` to the actual values in the underlying Lean source for two gallery entries.

## Convention

- `lineCount`: count of `\n` bytes (plus 1 if file ends without newline). Matches PR #17576 / #17563 batch convention.
- `theoremCount`: top-level `(theorem|lemma)` decl count after stripping nested block + line comments, allowing modifiers `private/protected/noncomputable/partial/unsafe/scoped`. Matches PR #17518 / #17553 convention.

## Per-entry deltas (claimed → actual)

| slug | field | claimed | actual | delta |
|------|-------|---------|--------|-------|
| `hilbert-11-oq-02` | `lineCount` | 1481 | 1592 | +111 |
| `hilbert-11-oq-02` | `theoremCount` | 66 | 71 | +5 |
| `minkowski-theorem-oq-04` | `lineCount` | 714 | 823 | +109 |
| `minkowski-theorem-oq-04` | `theoremCount` | 10 | 13 | +3 |

Both `meta.<field>` and `leanFile.<field>` synced per entry.

## Drift origin

- `hilbert-11-oq-02`: research merges grew the file by 111 lines and 5 theorems since the last meta sync; no open research PRs touch this slug.
- `minkowski-theorem-oq-04`: post-S16 narrative + Iter 17–20 merges (PRs #17402, #17459, #17485, #17508, #17533, #17554, #17570) grew the file by 109 lines and 3 theorems since the last meta sync (#17479 set 482→526; subsequent merges added more). No open research PR for this slug.

## Excluded from this batch

Other lineCount drifts deferred until upstream research PRs settle:

- `abel-ruffini-galois-extensions-oq-07` (+42) — open PRs #17528, #17586, #17587.
- `amgm-inequality-oq-04-oq-02` (+100) — open PRs #17371, #17445, #17471, #17477.
- `schauder-fixed-point-oq-03-oq-01` (+151) — covered by audit PR #17590.

## Evidence

**Before**: `meta.<field>` = `leanFile.<field>` = stale.
**After**: both fields = actual count.

Surgical Python `.replace()` per file (preserves JSON formatting). Diff stat: 2 files, +8/-8.

---
Automated fix by lean-mechanic agent.