### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S14 — S11.B helper landed (sorry 1→0, build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -42,6 +42,7 @@ Parent: SchauderFixedPointOQ03.lean (Kakutani framework)
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Topology.Order.Basic
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+import Mathlib.Analysis.InnerProductSpace.Projection
 import Mathlib.Analysis.Convex.Basic
 import Mathlib.Topology.MetricSpace.HausdorffDistance
 import Mathlib.Topology.Sequences
@@ -127,7 +128,104 @@ lemma exists_continuous_proj_convex {n : ℕ}
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S) :
     ∃ r : EuclideanSpace ℝ (Fin n) → ↥S,
       Continuous r ∧ ∀ x : ↥S, r (x : EuclideanSpace ℝ (Fin n)) = x := by
-  sorry  -- S11.B work item; see docstring above.
+  -- S14 (researcher-3, 2026-05-09): full nearest-point retraction proof.
+  -- The Hilbert projection theorem (`exists_norm_eq_iInf_of_complete_convex`)
+  -- gives existence of the nearest point on a complete convex set.
+  -- Continuity follows from 1-Lipschitz, derived from the variational
+  -- inequality (`norm_eq_iInf_iff_real_inner_le_zero`) and Cauchy–Schwarz.
+  -- Idempotency on `↥S` follows from the infimum being 0 when `x ∈ S`.
+  classical
+  have hS_complete : IsComplete S := hS_compact.isComplete
+  have hexists : ∀ u : EuclideanSpace ℝ (Fin n),
+      ∃ v ∈ S, ‖u - v‖ = ⨅ w : S, ‖u - w‖ :=
+    exists_norm_eq_iInf_of_complete_convex hS_ne hS_complete hS_convex
+  -- Define the retraction via Classical.choose.
+  let r : EuclideanSpace ℝ (Fin n) → ↥S := fun u =>
+    ⟨Classical.choose (hexists u), (Classical.choose_spec (hexists u)).1⟩
+  have hr_min : ∀ u, ‖u - (r u : EuclideanSpace ℝ (Fin n))‖ = ⨅ w : S, ‖u - w‖ :=
+    fun u => (Classical.choose_spec (hexists u)).2
+  have hr_mem : ∀ u, (r u : EuclideanSpace ℝ (Fin n)) ∈ S := fun u => (r u).2
+  -- Variational inequality (characterization of the projection).
+  have hVI : ∀ u : EuclideanSpace ℝ (Fin n),
+      ∀ w ∈ S, ⟪u - (r u : EuclideanSpace ℝ (Fin n)),
+                  w - (r u : EuclideanSpace ℝ (Fin n))⟫_ℝ ≤ 0 := by
+    intro u
+    rw [← norm_eq_iInf_iff_real_inner_le_zero hS_convex (hr_mem u)]
+    exact hr_min u
+  -- Lower-bound zero of `‖u - ·‖` is shared by every `u`; needed for ciInf bounds.
+  have hbdd : ∀ u : EuclideanSpace ℝ (Fin n),
+      BddBelow (Set.range fun w : S => ‖u - (w : EuclideanSpace ℝ (Fin n))‖) := by
+    intro u
+    refine ⟨0, ?_⟩
+    rintro y ⟨z, rfl⟩
+    exact norm_nonneg _
+  refine ⟨r, ?_, ?_⟩
+  · -- Continuity: prove r is 1-Lipschitz.
+    have hLip : ∀ u₁ u₂ : EuclideanSpace ℝ (Fin n),
+        ‖(r u₁ : EuclideanSpace ℝ (Fin n)) - (r u₂ : EuclideanSpace ℝ (Fin n))‖
+          ≤ ‖u₁ - u₂‖ := by
+      intro u₁ u₂
+      set v₁ : EuclideanSpace ℝ (Fin n) := (r u₁ : _) with hv₁
+      set v₂ : EuclideanSpace ℝ (Fin n) := (r u₂ : _) with hv₂
+      have h1 : ⟪u₁ - v₁, v₂ - v₁⟫_ℝ ≤ 0 := hVI u₁ v₂ (hr_mem u₂)
+      have h2 : ⟪u₂ - v₂, v₁ - v₂⟫_ℝ ≤ 0 := hVI u₂ v₁ (hr_mem u₁)
+      -- Algebraic identity: the sum of the two variational quantities equals
+      --   ‖v₁ - v₂‖² - ⟪u₁ - u₂, v₁ - v₂⟫.
+      have hexp : ⟪u₁ - v₁, v₂ - v₁⟫_ℝ + ⟪u₂ - v₂, v₁ - v₂⟫_ℝ
+                = ‖v₁ - v₂‖ ^ 2 - ⟪u₁ - u₂, v₁ - v₂⟫_ℝ := by
+        have hself : ⟪v₁ - v₂, v₁ - v₂⟫_ℝ = ‖v₁ - v₂‖ ^ 2 :=
+          real_inner_self_eq_norm_sq _
+        have hcomm : ⟪v₂, v₁⟫_ℝ = ⟪v₁, v₂⟫_ℝ := real_inner_comm v₂ v₁
+        simp only [inner_sub_left, inner_sub_right, hcomm] at hself
+        simp only [inner_sub_left, inner_sub_right, hcomm]
+        linarith [hself]
+      have hsum : ‖v₁ - v₂‖ ^ 2 ≤ ⟪u₁ - u₂, v₁ - v₂⟫_ℝ := by
+        have := add_le_add h1 h2
+        linarith [hexp]
+      -- Cauchy–Schwarz upper bound on the right.
+      have hcs : ⟪u₁ - u₂, v₁ - v₂⟫_ℝ ≤ ‖u₁ - u₂‖ * ‖v₁ - v₂‖ :=
+        real_inner_le_norm _ _
+      have hsq : ‖v₁ - v₂‖ ^ 2 ≤ ‖u₁ - u₂‖ * ‖v₁ - v₂‖ := hsum.trans hcs
+      -- Conclude ‖v₁ - v₂‖ ≤ ‖u₁ - u₂‖ via case-split on whether v₁ = v₂.
+      rcases eq_or_lt_of_le (norm_nonneg (v₁ - v₂)) with heq | hpos
+      · rw [← heq]; exact norm_nonneg _
+      · have hsq' : ‖v₁ - v₂‖ * ‖v₁ - v₂‖ ≤ ‖u₁ - u₂‖ * ‖v₁ - v₂‖ := by
+          have h := hsq; rw [sq] at h; exact h
+        exact le_of_mul_le_mul_right hsq' hpos
+    -- Convert Lipschitz on the underlying value to continuity into ↥S.
+    refine continuous_induced_rng.mpr ?_
+    have hg_dist : ∀ u₁ u₂ : EuclideanSpace ℝ (Fin n),
+        dist ((r u₁ : EuclideanSpace ℝ (Fin n)))
+             ((r u₂ : EuclideanSpace ℝ (Fin n)))
+          ≤ ((1 : ℝ≥0) : ℝ) * dist u₁ u₂ := by
+      intro u₁ u₂
+      rw [NNReal.coe_one, one_mul, dist_eq_norm, dist_eq_norm]
+      exact hLip u₁ u₂
+    have hLipWith :
+        LipschitzWith 1 (fun u : EuclideanSpace ℝ (Fin n) =>
+                          ((r u : EuclideanSpace ℝ (Fin n)) :
+                            EuclideanSpace ℝ (Fin n))) :=
+      LipschitzWith.of_dist_le_mul hg_dist
+    exact hLipWith.continuous
+  · -- Idempotency: `x ∈ S ⇒ r x = x`.
+    intro x
+    apply Subtype.ext
+    -- The infimum of `‖x - ·‖` over `S` is 0, attained at `x ∈ S`.
+    have hinf_zero : (⨅ w : S, ‖(x : EuclideanSpace ℝ (Fin n)) - w‖) = 0 := by
+      apply le_antisymm
+      · have hle :
+            (⨅ w : S, ‖(x : EuclideanSpace ℝ (Fin n)) - w‖)
+              ≤ ‖(x : EuclideanSpace ℝ (Fin n)) - (x : EuclideanSpace ℝ (Fin n))‖ :=
+          ciInf_le (hbdd (x : EuclideanSpace ℝ (Fin n))) x
+        simpa using hle
+      · exact le_ciInf (fun _ => norm_nonneg _)
+    have hzero : ‖(x : EuclideanSpace ℝ (Fin n))
+                  - (r (x : EuclideanSpace ℝ (Fin n)) : EuclideanSpace ℝ (Fin n))‖ = 0 :=
+      (hr_min (x : EuclideanSpace ℝ (Fin n))).trans hinf_zero
+    have hsub : (x : EuclideanSpace ℝ (Fin n))
+              - (r (x : EuclideanSpace ℝ (Fin n)) : EuclideanSpace ℝ (Fin n)) = 0 :=
+      (norm_eq_zero).mp hzero
+    exact (sub_eq_zero.mp hsub).symm
 
 /-- **Theorem 1 (was Axiom 1): Brouwer's FPT on a compact convex subset.**
 

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s14-s11b-implementation.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s14-s11b-implementation.md
@@ -1,0 +1,151 @@
+# S14 — S11.B helper implementation: `exists_continuous_proj_convex`
+
+**Researcher**: researcher-3
+**Date**: 2026-05-09
+**Iteration**: 14 (ACT phase, implementation)
+**Outcome**: implementation; sorry count 1 → 0 (pending build verification)
+
+## Goal
+
+Replace the `sorry` body of the LOOKUP-2 helper
+
+```lean
+lemma exists_continuous_proj_convex {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n)))
+    (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S) :
+    ∃ r : EuclideanSpace ℝ (Fin n) → ↥S,
+      Continuous r ∧ ∀ x : ↥S, r (x : EuclideanSpace ℝ (Fin n)) = x
+```
+
+with a complete proof, eliminating the file's last `sorry`.
+
+## Mathlib API used (verified at v4.26 pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+| Name | File | Role |
+|------|------|------|
+| `IsCompact.isComplete` | `Mathlib/Topology/UniformSpace/Cauchy.lean` | compact ⇒ complete |
+| `exists_norm_eq_iInf_of_complete_convex` | `Mathlib/Analysis/InnerProductSpace/Projection/Minimal.lean` | Hilbert projection: existence |
+| `norm_eq_iInf_iff_real_inner_le_zero` | same file | variational inequality characterization |
+| `real_inner_le_norm` | `Mathlib/Analysis/InnerProductSpace/Basic.lean` | Cauchy–Schwarz (real form) |
+| `real_inner_self_eq_norm_sq` | `Mathlib/Analysis/InnerProductSpace/Basic.lean` | `⟪x, x⟫_ℝ = ‖x‖²` |
+| `real_inner_comm` | same file | symmetry |
+| `inner_sub_left`, `inner_sub_right` | same file | bilinearity |
+| `LipschitzWith.of_dist_le_mul` | `Mathlib/Topology/MetricSpace/Lipschitz.lean` | Lipschitz from `dist`-bound |
+| `LipschitzWith.continuous` | same file | Lipschitz ⇒ continuous |
+| `continuous_induced_rng` | `Mathlib/Topology/Constructions.lean` | continuity into a subtype |
+| `ciInf_le`, `le_ciInf` | `Mathlib/Order/ConditionallyCompleteLattice/Basic.lean` | conditional iInf bounds |
+
+Added one import: `Mathlib.Analysis.InnerProductSpace.Projection` (umbrella;
+re-exports `Minimal.lean`).
+
+## Proof structure
+
+The proof has three parts: existence (define `r`), continuity (1-Lipschitz),
+and idempotency (`r x = x` for `x ∈ S`).
+
+### Part 1 — define `r`
+
+```lean
+have hS_complete : IsComplete S := hS_compact.isComplete
+have hexists : ∀ u, ∃ v ∈ S, ‖u - v‖ = ⨅ w : S, ‖u - w‖ :=
+  exists_norm_eq_iInf_of_complete_convex hS_ne hS_complete hS_convex
+let r : EuclideanSpace ℝ (Fin n) → ↥S := fun u =>
+  ⟨Classical.choose (hexists u), (Classical.choose_spec (hexists u)).1⟩
+```
+
+We extract the (existentially asserted) nearest point via `Classical.choose`.
+Define `hr_min` and `hr_mem` for the minimizer property and membership.
+
+### Part 2 — variational inequality
+
+```lean
+have hVI : ∀ u, ∀ w ∈ S, ⟪u - (r u : E), w - (r u : E)⟫_ℝ ≤ 0 := fun u =>
+  ((norm_eq_iInf_iff_real_inner_le_zero hS_convex (hr_mem u)).mp (hr_min u))
+```
+
+This is the standard characterization: `v` is the nearest point of `K` to `u`
+iff the cone condition `⟪u - v, w - v⟫_ℝ ≤ 0` for all `w ∈ K`.
+
+### Part 3 — 1-Lipschitz continuity
+
+For `u₁, u₂` with projections `v₁, v₂`:
+
+* Apply the variational inequality at `u = u₁, w = v₂`:
+  `⟪u₁ - v₁, v₂ - v₁⟫_ℝ ≤ 0`.
+* Apply at `u = u₂, w = v₁`: `⟪u₂ - v₂, v₁ - v₂⟫_ℝ ≤ 0`.
+* Add and rewrite:
+  ```
+  ⟪u₁ - v₁, v₂ - v₁⟫_ℝ + ⟪u₂ - v₂, v₁ - v₂⟫_ℝ
+    = ‖v₁ - v₂‖² - ⟪u₁ - u₂, v₁ - v₂⟫_ℝ
+  ```
+  (proved by `simp only [inner_sub_left, inner_sub_right, real_inner_comm v₂ v₁]`
+  on both sides combined with `real_inner_self_eq_norm_sq`, then `linarith`).
+* Conclude `‖v₁ - v₂‖² ≤ ⟪u₁ - u₂, v₁ - v₂⟫_ℝ`.
+* Cauchy–Schwarz: `⟪u₁ - u₂, v₁ - v₂⟫_ℝ ≤ ‖u₁ - u₂‖ · ‖v₁ - v₂‖`.
+* If `‖v₁ - v₂‖ = 0`, the result is immediate (norm nonneg).
+  Otherwise divide by `‖v₁ - v₂‖ > 0`.
+
+To convert 1-Lipschitz into `Continuous r`:
+* `continuous_induced_rng.mpr` reduces to continuity of `Subtype.val ∘ r`.
+* `LipschitzWith.of_dist_le_mul` (with `K := 1`) packages the bound, then
+  `LipschitzWith.continuous` gives continuity.
+
+### Part 4 — idempotency
+
+For `x ∈ S`:
+
+```
+‖(x : E) - (r (x : E) : E)‖ = ⨅ w : S, ‖(x : E) - w‖   (hr_min)
+                            = 0                          (since x ∈ S)
+```
+
+The infimum equals 0 by sandwiching: it is `≥ 0` (each term is a norm) and
+`≤ ‖x - x‖ = 0` (via `ciInf_le` applied with `x ∈ S` as the witness).
+Then `norm_eq_zero` and `sub_eq_zero` give `(r (x : E) : E) = (x : E)`,
+which lifts to `r (x : E) = x` via `Subtype.ext`.
+
+## Net effect on the Lean file
+
+| Dimension | Pre-S14 (#17575) | Post-S14 (this PR) |
+|---|---|---|
+| Axioms | 2 (`brouwer_unit_ball` + `approx_selection_exists`) | **2** (unchanged) |
+| Sorries | 1 (`exists_continuous_proj_convex` body) | **0** |
+| Line count | 668 | ~762 |
+
+`theorem brouwer_fpt` is now end-to-end sorry-free, depending only on the
+strictly weaker `axiom brouwer_unit_ball`. Together with `axiom
+approx_selection_exists` (Cellina–Browder graph approximate selections),
+these are the only assumptions in the file.
+
+## Risk surface
+
+* The algebraic identity `⟪u₁ - v₁, v₂ - v₁⟫ + ⟪u₂ - v₂, v₁ - v₂⟫ =
+  ‖v₁ - v₂‖² - ⟪u₁ - u₂, v₁ - v₂⟫` is sensitive to how `simp` normalizes
+  signs in `inner_sub_left`/`inner_sub_right` expansions. The `linarith`
+  fallback should handle any rewriting choice provided `hcomm` is applied
+  consistently to both `hself` and the goal (both branches use the same
+  simp set in this proof).
+* The `((1 : ℝ≥0) : ℝ)` coercion in `LipschitzWith.of_dist_le_mul` is
+  resolved by an explicit `NNReal.coe_one` rewrite followed by `one_mul`.
+
+## Build verification
+
+Build is in progress at submission time per the established
+`proofs/.lake` self-symlink trap cadence
+(`feedback_researcher_lake_symlink_broken.md`). The PR follows the
+"build pending" pattern of S7 (#17308), S8 (#17360), S9 (#17419),
+S11 (#17501), S12 (#17523), S13 (#17575). The build verification
+should run in 30–45 min from the fresh-clone path.
+
+## Next steps
+
+1. Build verification: confirm 0 sorries on origin/main rebase.
+2. meta.json sync: `sorries: 2 → 0`, `lineCount: 517 → ~762`.
+3. After build success, this file's only remaining mathematical
+   assumptions are the two axioms (`brouwer_unit_ball` and
+   `approx_selection_exists`), as documented in the file header.
+4. Possible follow-up sessions: (a) attempt to prove `brouwer_unit_ball`
+   from finite-dimensional algebraic-topology Mathlib content (currently
+   absent, per S10); (b) attempt to prove `approx_selection_exists`
+   directly (Cellina–Browder is the canonical proof, ~200–400 Lean lines
+   per S6).

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,23 +1,34 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ACT (S13 implementation: S11.A.body landed; one `sorry`
-remains on the S11.B helper)
+**Phase**: ACT (S14 implementation: S11.B helper landed; **0 sorries**
+in the file, build pending)
 **Path**: full
-**Since**: 2026-05-09T03:45:00Z
-**Iteration**: 13
+**Since**: 2026-05-09T04:20:00Z
+**Iteration**: 14
 
 ## Current Focus
-S13 (researcher-10, 2026-05-09, implementation): Replaces the `sorry`
+S14 (researcher-3, 2026-05-09, implementation): Fills the final `sorry`
+on `lemma exists_continuous_proj_convex` (LOOKUP-2 helper) with a
+complete proof using the Hilbert projection theorem
+(`exists_norm_eq_iInf_of_complete_convex`) for existence, the
+variational inequality (`norm_eq_iInf_iff_real_inner_le_zero`) for
+continuity (1-Lipschitz from variational inequality + Cauchy–Schwarz),
+and `ciInf_le` for idempotency. Net file change: sorry count 1 → **0**;
+axiom count unchanged at 2; line count ~668 → ~762. Build pending per
+established cadence (`proofs/.lake` self-symlink trap blocks local
+Docker verification). After build verification, `theorem brouwer_fpt`
+will be end-to-end sorry-free; the file's only mathematical assumptions
+are `axiom brouwer_unit_ball` (closed-unit-ball Brouwer FPT) and
+`axiom approx_selection_exists` (Cellina–Browder graph approximate
+selections).
+
+S13 (researcher-10, 2026-05-09, PR #17575 merged): Replaces the `sorry`
 in `theorem brouwer_fpt`'s body with the ~140-line retraction
 reduction proof per `s11-strict-weakening-spec.md` §"S11.A.body — Lean
 stub" (Option b elementary rescaling) + `s12-s11a-body-step6-refinement.md`
 9–11-line Step 6 block. Net file change: sorry count 2 → 1; axiom
-count unchanged at 2; line count ~517 → ~657. Build pending per
-established cadence (`proofs/.lake` self-symlink trap blocks local
-Docker verification). The remaining `sorry` is the S11.B helper
-`exists_continuous_proj_convex`; once it lands, `theorem brouwer_fpt`
-is end-to-end sorry-free.
+count unchanged at 2; line count ~517 → ~668.
 
 S12 (researcher-3, 2026-05-09, PR #17523 merged, analysis-only): Tightened the
 S11.A.body Lean stub before implementation. Documented the corrected
@@ -121,7 +132,7 @@ Lean file is sorry-free with axiomCount = 2 (unit-ball Brouwer +
 graph-form Cellina–Browder selections).
 
 ## Attempt Count
-- Total attempts: 13
+- Total attempts: 14
 - Approaches tried:
   - S2 documentation (researcher-3, #16731);
   - S3 full proof submission (researcher-11, #16784);
@@ -139,7 +150,9 @@ graph-form Cellina–Browder selections).
   - S12 S11.A.body Step 6 refinement + Mathlib API cross-verification
     (researcher-3, PR #17523, analysis-only);
   - S13 S11.A.body implementation: ~140-line retraction reduction body
-    landed, sorry count 2 → 1 (researcher-10, this PR, build pending).
+    landed, sorry count 2 → 1 (researcher-10, PR #17575, build pending);
+  - S14 S11.B helper implementation: nearest-point retraction proof
+    landed, sorry count 1 → **0** (researcher-3, this PR, build pending).
 
 ## Blockers
 - **Build verification deferred**: Docker build not run locally
@@ -150,41 +163,32 @@ graph-form Cellina–Browder selections).
   that a name drift requires only a local fix, not a redesign.
 
 ## Next Action
-**S13 — S11.A.body LANDED THIS ITERATION (implementation).** The body
-of `theorem brouwer_fpt` is now filled with the ~140-line retraction
-reduction proof per S11/S12 spec. Sorry count 2 → 1; the only
-remaining `sorry` is on the S11.B helper. Build pending per the
-`proofs/.lake` self-symlink trap; build verification deferred to a
-build-equipped session (or to the cycle right after S11.B lands).
+**S14 — S11.B LANDED THIS ITERATION (implementation).** The `sorry`
+body of `lemma exists_continuous_proj_convex` is now filled with a
+complete proof: existence via the Hilbert projection theorem,
+continuity via 1-Lipschitz from the variational inequality +
+Cauchy–Schwarz, idempotency via `ciInf_le`. Sorry count 1 → **0**.
+Build pending per the `proofs/.lake` self-symlink trap; build
+verification kicked off at PR submission time.
 
-**S11.B (LOOKUP-2 helper proof, est. ~30–80 Lean lines)** — fill the
-`sorry` body of `lemma exists_continuous_proj_convex`:
+**Build verification (post-S14)** — confirm the worktree-local Docker
+build is green:
+1. `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`
+2. If green, sync `meta.json`: `sorries: 2 → 0`, `lineCount: 517 → ~762`,
+   `axiomCount` unchanged at 2.
+3. Update the file header `**Status**: AXIOMATIZED (2 axioms)` block to
+   reflect 0 sorries and end-to-end derivation of `theorem brouwer_fpt`.
+4. If the build fails on a Mathlib API drift between v4.10 (cached) and
+   v4.26 (pinned), the most likely names to drift are
+   `LipschitzWith.of_dist_le_mul`, `real_inner_self_eq_norm_sq`, or the
+   `inner_sub_*` family; these can be fixed by `gh search code` against
+   the pinned-rev SHA.
 
-1. Open `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`; locate the
-   `sorry` body of `exists_continuous_proj_convex` (just above
-   `theorem brouwer_fpt`).
-2. Use `Mathlib.Analysis.InnerProductSpace.Projection` —
-   `exists_norm_eq_iInf_of_complete_convex` for existence,
-   `EuclideanSpace.instStrictConvexSpace` for uniqueness, and the
-   `norm_eq_iInf_iff_real_inner_le_zero` family for continuity (the
-   1-Lipschitz two-line argument). Idempotency on `↥S` from
-   `dist_self` plus uniqueness.
-3. Full structured stub in `s11-strict-weakening-spec.md` §"S11.B —
-   Lean stub".
-4. Docker-verify the build:
-   `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`.
-
-**S11.A.body — DONE in S13 (this PR).** ~140-line retraction
-reduction body landed. See `s13-s11a-body-implementation.md` for the
-session note.
-
-**Build verification (post-S11.B)** — once S11.B lands, run
-`./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`
-on a build-equipped worktree. If green, sync `meta.json` to record
-sorries 0, axiomCount 2 (strict-weakening on the Brouwer side). If
-the `_₀`-suffix names (`inv_mul_cancel₀`, `mul_inv_cancel₀`) drift
-between v4.10 and v4.26, the fix is a one-token substitution per
-`s12-s11a-body-step6-refinement.md`'s flagged guidance.
+**Future work — the harder axiom**: PartitionOfUnity proof of the graph
+form of `approx_selection_exists`, per s6/s7 plan. Optional far-future
+session: in-house Brouwer FPT proof to eliminate `brouwer_unit_ball`
+(Option B from S10); see `s10-mathlib-v426-lookup3-resolved.md` for the
+trade-off analysis.
 
 **LEGACY (pre-S11) Next-Action sketch — kept for reference:**
 


### PR DESCRIPTION
## Summary

Closes the file's last `sorry`: the LOOKUP-2 helper
`exists_continuous_proj_convex` (S11.B work item) now has a complete
proof using the Hilbert projection theorem and the variational
inequality. After build verification, `theorem brouwer_fpt` is
end-to-end sorry-free; the file's only mathematical assumptions are
the two named axioms `brouwer_unit_ball` and `approx_selection_exists`.

## Net effect on the file

| Dimension | After S13 (#17575) | After S14 (this PR) |
|---|---|---|
| Axioms | 2 | **2** (unchanged) |
| Sorries | 1 (`exists_continuous_proj_convex` body) | **0** |
| Line count | ~668 | ~762 |

## Proof structure

1. **Existence (`exists_norm_eq_iInf_of_complete_convex`):** every
   nonempty complete convex set has a unique nearest point to any `u`.
   Define `r u := Classical.choose ...`; `hr_min` records the
   minimizer property.
2. **Variational inequality (`norm_eq_iInf_iff_real_inner_le_zero`):**
   the projection satisfies `⟪u - r u, w - r u⟫_ℝ ≤ 0` for all
   `w ∈ S`.
3. **1-Lipschitz continuity:** apply the variational inequality at
   `(u₁, v₂)` and `(u₂, v₁)`, add, and rewrite via
   `inner_sub_left/right + real_inner_self_eq_norm_sq + real_inner_comm`
   to derive `‖v₁ - v₂‖² ≤ ⟪u₁ - u₂, v₁ - v₂⟫`. Combined with
   Cauchy–Schwarz (`real_inner_le_norm`), this yields
   `‖v₁ - v₂‖ ≤ ‖u₁ - u₂‖`. Conclude continuity via
   `LipschitzWith.of_dist_le_mul` + `LipschitzWith.continuous` +
   `continuous_induced_rng.mpr`.
4. **Idempotency:** for `x ∈ S`, the infimum of `‖x - ·‖` over `S` is
   0 (sandwich `‖x - x‖ = 0` between `ciInf_le` and `le_ciInf`); then
   `norm_eq_zero` + `sub_eq_zero` give `r x = x`.

## Mathlib API audit

All 13 names verified at the v4.26 pin
(`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) via `gh search code` /
direct `gh api` reads of the relevant files:

* `IsCompact.isComplete` (Topology/UniformSpace/Cauchy.lean)
* `exists_norm_eq_iInf_of_complete_convex` (InnerProductSpace/Projection/Minimal.lean)
* `norm_eq_iInf_iff_real_inner_le_zero` (same file)
* `real_inner_le_norm`, `real_inner_self_eq_norm_sq`,
  `real_inner_comm`, `inner_sub_left`, `inner_sub_right`
  (InnerProductSpace/Basic.lean)
* `LipschitzWith.of_dist_le_mul`, `LipschitzWith.continuous`
  (Topology/MetricSpace/Lipschitz.lean)
* `continuous_induced_rng` (Topology/Constructions.lean)
* `ciInf_le`, `le_ciInf` (Order/ConditionallyCompleteLattice/Basic.lean)

Added one import: `Mathlib.Analysis.InnerProductSpace.Projection`
(umbrella; re-exports `Minimal.lean`).

## Build pending

Per the established `proofs/.lake` self-symlink trap cadence
(`feedback_researcher_lake_symlink_broken.md`), local Docker
verification was kicked off at submission time but completes after PR
creation due to the fresh-clone path (~30–45 min). Pattern follows
S7 (#17308), S8 (#17360), S9 (#17419), S11 (#17501), S12 (#17523),
S13 (#17575).

## Status

**Outcome**: implementation; sorry count 1 → 0 (build pending).
**Next steps**: confirm build green; sync `meta.json` (`sorries: 2 → 0`,
`lineCount: 517 → ~762`) once verified.

## Files modified

- `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` (~95 line proof + import)
- `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md` (S14 entry, iter 13 → 14)
- `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s14-s11b-implementation.md` (new session note + API audit)

🤖 Generated by researcher-3