### PR TITLE
fix(meta): batch sync definitionCount drift (4 entries, euler-polyhedral + RH)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
@@ -60,7 +60,7 @@
     "assumptions": "0 sorries but 10 structure-encoded assumptions: Gauss-Bonnet theorem (CompactRiemannianSurface.gauss_bonnet), chi-genus formula (OrientableClosedSurface.chi_genus), Chern-Gauss-Bonnet (ChernGaussBonnetManifold), Gauss-Bonnet with boundary, geodesic polygon formula, constant curvature formula, geodesic triangle Gauss-Bonnet, Poincaré-Hopf index theorem, nonvanishing vector field index, Morse relation. Core differential geometry axiomatized due to Mathlib lacking Riemannian geometry.",
     "mathlib_version": "4.26.0",
     "theoremCount": 60,
-    "definitionCount": 4
+    "definitionCount": 13
   },
   "sections": [
     {
@@ -242,7 +242,7 @@
     "lineCount": 786,
     "axiomCount": 0,
     "theoremCount": 60,
-    "definitionCount": 4,
+    "definitionCount": 13,
     "path": "Proofs/EulerPolyhedralOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -43,7 +43,7 @@
     "assumptions": "1 axiom (euler_formula_axiom: V-E+F=2 for PolyhedralGraph, needed because Mathlib lacks planarity). The constructive ConstructiblePoly proof is axiom-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 65,
-    "definitionCount": 27
+    "definitionCount": 33
   },
   "overview": {
     "historicalContext": "Euler discovered this formula in 1758 while studying polyhedra, though René Descartes had noticed a closely related result in 1639 (remaining unpublished until 1860). The formula V - E + F = 2 is one of the most beautiful results in mathematics, connecting three apparently unrelated counts — vertices, edges, and faces — through a single universal constant.\n\nCauchy provided the first rigorous proof in 1813 using triangulation, reducing a general polyhedron to the sphere. Legendre gave an independent spherical geometry proof the same year. The formula is equivalent to the topological statement that every convex polyhedron is homeomorphic to a sphere, whose Euler characteristic χ = 2. Poincaré generalized this in 1895 to all compact orientable surfaces: χ = 2 − 2g for genus g, founding algebraic topology. The Euler characteristic became the first example of a topological invariant preserved under continuous deformation.",
@@ -267,7 +267,7 @@
     "lineCount": 1092,
     "axiomCount": 1,
     "theoremCount": 65,
-    "definitionCount": 27,
+    "definitionCount": 33,
     "path": "Proofs/EulerPolyhedralFormula.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 786,
     "theoremCount": 60,
-    "definitionCount": 4,
+    "definitionCount": 13,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -116,7 +116,7 @@
     "lineCount": 786,
     "axiomCount": 7,
     "theoremCount": 60,
-    "definitionCount": 4,
+    "definitionCount": 13,
     "path": "Proofs/EulerPolyhedralOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -67,7 +67,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 6594,
     "theoremCount": 363,
-    "definitionCount": 50
+    "definitionCount": 63
   },
   "overview": {
     "historicalContext": "The Riemann zeta function $\\zeta(s) = \\sum n^{-s}$ was first studied by Euler (1737), who discovered the Euler product $\\zeta(s) = \\prod_p (1-p^{-s})^{-1}$ — the key link between $\\zeta$ and prime numbers. But it was Bernhard Riemann who, in his extraordinary 1859 paper 'Ueber die Anzahl der Primzahlen unter einer gegebenen Grösse' (just 8 pages), transformed the subject by extending $\\zeta$ to a meromorphic function on all of $\\mathbb{C}$, establishing the functional equation $\\xi(s) = \\xi(1-s)$, and stating the hypothesis that all non-trivial zeros have $\\text{Re}(s) = 1/2$.\n\nRiemann's paper was revolutionary: he showed that the distribution of primes is governed by the zeros of $\\zeta(s)$ through his explicit formula $\\psi(x) = x - \\sum_\\rho x^\\rho/\\rho - \\log(2\\pi) - \\frac{1}{2}\\log(1-x^{-2})$. The Prime Number Theorem — proved independently by Hadamard and de la Vallée Poussin in 1896 — is equivalent to $\\zeta(s) \\neq 0$ on $\\text{Re}(s) = 1$, while RH is the far stronger assertion that the zero-free region extends to $\\text{Re}(s) > 1/2$.\n\nHardy (1914) proved infinitely many zeros lie on the critical line, using the Hardy Z-function $Z(t) = e^{i\\theta(t)}\\zeta(1/2+it)$ which is real for real $t$. Selberg (1942) showed a positive proportion of zeros are on the critical line, Levinson (1974) proved $>1/3$, and Conrey (1989) improved this to $>40\\%$ — the current record. Montgomery (1973) discovered that the pair correlation of zeta zeros matches that of eigenvalues of random GUE matrices, inaugurating the deep connection to random matrix theory (Keating-Snaith 2000). Rodgers and Tao (2018) proved the de Bruijn-Newman constant $\\Lambda \\geq 0$, establishing that RH, if true, is 'just barely' true.\n\nIn 2000, the Clay Mathematics Institute designated RH as one of seven Millennium Prize Problems, offering $1,000,000 for its resolution. Despite 166 years of effort and the verification of the first $10^{13}$ zeros (Platt 2004, Gourdon 2004), the hypothesis remains open. Hilbert listed it as the 8th of his 23 problems (1900), and it appears on virtually every list of the most important open problems in mathematics.",
@@ -357,7 +357,7 @@
     "lineCount": 6594,
     "axiomCount": 44,
     "theoremCount": 363,
-    "definitionCount": 50,
+    "definitionCount": 63,
     "path": "Proofs/RiemannHypothesis.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `definitionCount` fields in `meta.json` against current Lean source for 4 stable gallery entries, using the canonical convention from PR #17518 / #17569 / #17589: count `def + abbrev + opaque + structure + inductive + class` declarations (excluding `instance`) at file scope, allowing `partial / private / protected / noncomputable / unsafe / scoped` modifiers, after stripping nested block comments **and** line comments.

## Per-entry deltas

| slug | before | after | delta |
|------|--------|-------|-------|
| euler-polyhedral-formula | 27 | 33 | +6 |
| euler-polyhedral-formula-oq-02-oq-01 | 4 | 13 | +9 |
| euler-polyhedral-oq-02-oq-01 | 4 | 13 | +9 |
| riemann-hypothesis | 50 | 63 | +13 |

The two `euler-polyhedral-*-oq-02-oq-01` entries share `proofs/Proofs/EulerPolyhedralOQ02OQ01.lean` and must move together.

## Comment-stripper fix

While scanning, I caught a bug in my own stripper: line comments must take precedence over the `/-` block-open token, or a `--` comment containing `+/-` will silently open a fake block comment that swallows the rest of the file. This caused `area-of-circle-oq-03-oq-02-oq-02` to falsely report 5 actual theorems vs claimed 15 (true count is 15 — that slug is **not** in this PR). Fixed stripper used here.

## Stability

All four `.lean` files are stable on origin/main (no merges since the gallery's earliest research-phase commits per `git log --all`):

- `EulerPolyhedralFormula.lean` — last touched #2842
- `EulerPolyhedralOQ02OQ01.lean` — last touched #3553 (Gauss-Bonnet)
- `RiemannHypothesis.lean` — last touched #4707 (zeta_conj)

No open research / mechanic / audit PR touches these slugs.

## Excludes

Skips slugs already covered by open PRs #17588 (erdos-9xx), #17589 (mixed batch), #17590 (audit loop), #17591 (hilbert-*). Skips high-delta millennium-prize files (Hodge, Navier-Stokes, Yang-Mills, BSD, Poincaré) and erdos-643 oscillation history, matching the exclusion set used by PR #17589.

## Diff

8 lines (4 files × 2 occurrences each). Each entry has both `meta.definitionCount` and `leanFile.definitionCount` synced to the same value.

---
Automated fix by lean-mechanic agent.