### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S32 — rotateSortedList length_mul/perm_sort/mem (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -848,6 +848,55 @@ private lemma rotateSortedList_toMultiset {n c : ℕ} (M : Sym (Fin n) c)
   rw [Multiset.coe_eq_coe.mpr (List.rotate_perm _ k)]
   exact Multiset.sort_eq (· ≤ ·) M.1
 
+/-! #### S32 — Length-multiple / Perm / membership helpers
+
+Three additional pure-Mathlib wrapper lemmas extending the S31
+`rotateSortedList` family. None of these change the file's sorry count
+(still 2) or axiom count (still 0); each is a one-to-three-line proof
+against `Mathlib.Data.List.Rotate` / `Mathlib.Data.Multiset.Sort`. They
+are complementary to the `_rotate` / `_mod` composition lemmas (added
+elsewhere in S32 by a parallel PR): together the five additions form the
+full `Sym`-wrapped image of `Mathlib.Data.List.Rotate`'s API used
+downstream by 2B.4' / 2B.5'. -/
+
+/-- **Rotation by a multiple of `c` is the canonical sorted list.**
+    Generalises `rotateSortedList_period` (the `k = 1` case): for every
+    `k : ℕ`, `rotateSortedList M (c * k) = M.1.sort (· ≤ ·)`. Direct from
+    `List.rotate_length_mul`. Useful for cycle-class size identities
+    (2B.5') where the orbit of a rotation has size `c / period` and the
+    trivial period acts as the identity. -/
+@[simp] private lemma rotateSortedList_length_mul {n c : ℕ}
+    (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (c * k) = M.1.sort (· ≤ ·) := by
+  unfold rotateSortedList
+  have hlen : (M.1.sort (· ≤ ·)).length = c := by
+    rw [Multiset.length_sort, M.2]
+  rw [← hlen]
+  exact List.rotate_length_mul _ k
+
+/-- **List-level permutation invariance.** Every rotation of the sorted-list
+    representative of `M` is a `List.Perm` (`~`) of the canonical sorted
+    form. A list-level strengthening of `rotateSortedList_toMultiset`; used
+    when the downstream argument needs list-level multiset structure
+    (`List.Perm.count_eq`, `List.Perm.nodup_iff`, etc.) rather than the
+    coercion-to-`Multiset` form. Direct from `List.rotate_perm`. -/
+private lemma rotateSortedList_perm_sort {n c : ℕ} (M : Sym (Fin n) c)
+    (k : ℕ) : (rotateSortedList M k) ~ (M.1.sort (· ≤ ·)) := by
+  unfold rotateSortedList
+  exact List.rotate_perm _ k
+
+/-- **Membership invariance.** An element `x : Fin n` belongs to
+    `rotateSortedList M k` iff it belongs to the underlying multiset `M.1`.
+    Combines `List.mem_rotate` with `Multiset.mem_sort`. Useful for
+    membership-driven decompositions of the cycle-lemma bijection codomain
+    (e.g., "the rotated list contains exactly the elements of `M.1`,
+    counted with multiplicity"). -/
+@[simp] private lemma rotateSortedList_mem {n c : ℕ} (M : Sym (Fin n) c)
+    (k : ℕ) {x : Fin n} : x ∈ rotateSortedList M k ↔ x ∈ M.1 := by
+  unfold rotateSortedList
+  rw [List.mem_rotate]
+  exact Multiset.mem_sort _
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,135 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-09 (S31 — researcher-4)
-**Iteration**: 31
+**Last Updated**: 2026-05-09 (S32 — researcher-10, narrowed)
+**Iteration**: 32
+
+## S32 Summary (2026-05-09, researcher-10, narrowed)
+
+**Mode**: ACT (S31 rotation infrastructure extension — three additional
+pure Mathlib wrapper lemmas extending `rotateSortedList`. Originally drafted
+as five lemmas; **narrowed** post-claim to the three not covered by parallel
+PR #17585 — `_length_mul`, `_perm_sort`, `_mem` — which adds the
+complementary `_rotate` (composition) and `_mod` (mod-period) lemmas at
+the same insertion point. The five together form the full `Sym`-wrapped
+image of `Mathlib.Data.List.Rotate`'s API; this PR contributes the three
+non-overlapping lemmas.).
+
+### Deliverable
+
+Three new private lemmas in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted right after
+`rotateSortedList_toMultiset` (S31, line 845) and before `totalSym`:
+
+```lean
+@[simp] private lemma rotateSortedList_length_mul {n c : ℕ}
+    (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (c * k) = M.1.sort (· ≤ ·)
+
+private lemma rotateSortedList_perm_sort {n c : ℕ} (M : Sym (Fin n) c)
+    (k : ℕ) : (rotateSortedList M k) ~ (M.1.sort (· ≤ ·))
+
+@[simp] private lemma rotateSortedList_mem {n c : ℕ} (M : Sym (Fin n) c)
+    (k : ℕ) {x : Fin n} : x ∈ rotateSortedList M k ↔ x ∈ M.1
+```
+
+All three lemmas have ≤ 4-line proof bodies. Direct wrappers around
+`List.rotate_length_mul`, `List.rotate_perm`, `List.mem_rotate`, plus
+`Multiset.length_sort` / `Multiset.mem_sort` for the multiset-level
+connection. Together with the S31 kit (`rotateSortedList_length`,
+`rotateSortedList_zero`, `rotateSortedList_period`,
+`rotateSortedList_toMultiset`) and the parallel S32 PR #17585
+(`_rotate`, `_mod`), they form a complete pure Mathlib wrapper around
+`List.rotate` for the sorted-list representative of a `Sym`.
+
+### Why these three (and not all five)?
+
+PR #17585 (researcher-5, opened 2026-05-09 01:05Z, ~25 min before this
+claim) covers `rotateSortedList_rotate` (composition) and
+`rotateSortedList_mod` (mod-period) — the two algebraic-structure
+lemmas. After verifying the overlap, this PR is **narrowed** to the
+three non-overlapping additions:
+
+1. **Multi-period collapse** (`_length_mul`): `rotateSortedList M (c *
+   k) = sort` for every `k`. Generalises S31's `_period` (the `k = 1`
+   case). Necessary for cycle-class size identities (2B.5') where the
+   orbit of a rotation has size `c / period` and the trivial period
+   acts as the identity.
+2. **Perm-with-sort** (`_perm_sort`): list-level strengthening of S31's
+   `_toMultiset`. Necessary when the downstream argument needs
+   list-level multiset structure (`List.Perm.count_eq`,
+   `List.Perm.nodup_iff`, etc.) rather than the coercion-to-`Multiset`
+   form.
+3. **Membership** (`_mem`): an element belongs to the rotated list iff
+   it belongs to `M.1`. A `simp`-marked specialisation useful for
+   membership-driven decompositions of the bijection codomain.
+
+The three lemmas are the natural counterparts of the corresponding
+`List.rotate` lemmas in `Mathlib.Data.List.Rotate`; each is the
+`Sym`-wrapped form of an existing Mathlib statement. None introduces a
+sorry; none introduces an axiom. None of the three names overlaps with
+PR #17585's two lemma names — so the PRs can land in either order
+without merge conflicts.
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1861 → 1910 lines
+  (+49: 3 new private lemmas with docstrings, plus a section
+  sub-header). Stacks cleanly atop PR #17585's +36 lines if it merges
+  first; the diffs are at adjacent insertion points (both right after
+  `rotateSortedList_toMultiset`).
+- Theorems / lemmas (raw): +3 lemmas added (all pure proofs, no sorries).
+- Definitions: 10 (unchanged).
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+- meta.json: `lineCount` 1861 → 1910; `theoremCount` 39 → 40 (PR #17553
+  / PR #17569 canonical convention: comment-strip + Python regex
+  `^\s*(modifiers)*(theorem|lemma)\s+\w`; `@[simp]` on the same line
+  excludes a decl from the count). Of the 3 new lemmas, 1 (`_perm_sort`)
+  matches the canonical pattern and 2 (`_length_mul`, `_mem`) are
+  `@[simp]`-prefixed — consistent with how the existing
+  `rotateSortedList_length` and `rotateSortedList_zero` are treated.
+  Both `meta.*` and `leanFile.*` fields updated.
+
+### Build status
+
+Pending. The parent file `BallotProblemOQ03OQ02.lean` is broken on
+origin/main (~24 errors lines 1911–2386 per
+`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09), so
+`BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports
+through the OQ03OQ01 / OQ03 chain) cannot be Docker-built until that
+parent break is repaired by a mechanic PR. Title precedent: S25–S31
+PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.
+
+Each new lemma was verified by reading the Mathlib v4.26.0 source at
+`Mathlib/Data/List/Rotate.lean` and `Mathlib/Data/Multiset/Sort.lean`:
+
+* `List.rotate_length_mul (l n) : l.rotate (l.length * n) = l` — line 148
+* `List.rotate_perm (l n) : l.rotate n ~ l` — line 151
+* `List.mem_rotate : a ∈ l.rotate n ↔ a ∈ l` — line 109 (`@[simp]`)
+* `Multiset.length_sort {s} : (sort r s).length = card s` — line 47
+* `Multiset.mem_sort {s a} : a ∈ sort r s ↔ a ∈ s` — line 44
+
+Build risk: very low. The three proofs use only mechanical Mathlib API
+already used throughout the file.
+
+### Next action (S33+)
+
+Pick one of (unchanged from S31, modulo the narrowing):
+
+* **2B.4' refined-codomain bijection (~50 lines)**: standing on a
+  complete rotation-infrastructure kit (S31 + S32 PR #17585 + this
+  PR), define `firstDescentRotation : Sym (Fin n) (a + b) → Sym (Fin
+  n) (a + 1) → Fin (a + b)` (or analogous canonical rotation index for
+  any `P' : Sym (Fin n) (a + 1)` with `P'.1 ≤ M.1`) and the bijection
+  between `{bad P}` and the refined `(P', k)` codomain. Heaviest step;
+  commits to the cycle-lemma proof shape.
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement the
+  Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset prefixes
+  as a Mathlib contribution. Independent of this proof; reusable
+  across other gallery work.
+* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK /
+  algebraic LGV); independent of the cycle-lemma chain.
 
 ## S31 Summary (2026-05-09, researcher-4)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1861,
-    "theoremCount": 39,
+    "lineCount": 1910,
+    "theoremCount": 40,
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
@@ -95,9 +95,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1861,
+    "lineCount": 1910,
     "axiomCount": 0,
-    "theoremCount": 39,
+    "theoremCount": 40,
     "definitionCount": 10,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Summary

Three pure Mathlib wrapper lemmas extending S31's `rotateSortedList` family,
**narrowed** to non-overlap with the parallel PR #17585 (researcher-5, also
S32, which adds `_rotate` and `_mod` at the same insertion point):

- `rotateSortedList_length_mul` (`@[simp]`): `rotateSortedList M (c * k) =
  M.1.sort (· ≤ ·)`. Generalises S31's `_period` (`k = 1` case). Useful for
  cycle-class size identities (2B.5').
- `rotateSortedList_perm_sort`: `(rotateSortedList M k) ~ (M.1.sort (· ≤ ·))`.
  List-level strengthening of S31's `_toMultiset`; needed when downstream
  arguments use `List.Perm.count_eq` / `List.Perm.nodup_iff` rather than the
  coercion-to-`Multiset` form.
- `rotateSortedList_mem` (`@[simp]`): `x ∈ rotateSortedList M k ↔ x ∈ M.1`.
  Combines `List.mem_rotate` with `Multiset.mem_sort`.

All three proofs ≤ 4 lines; direct wrappers around named Mathlib lemmas.
None of the names overlaps with PR #17585's `_rotate` / `_mod` — the PRs
land cleanly in either order.

## Why narrowed

PR #17585 (open, 2026-05-09 01:05Z, researcher-5) covers the algebraic-
structure pair (`_rotate`, `_mod`). My initial draft included all five but
was narrowed post-claim to the three non-overlapping additions per the
gallery's "narrow to unique deliverable on parallel PR overlap" pattern.

Together with S31 (`_length`, `_zero`, `_period`, `_toMultiset`) and
PR #17585, the eight `rotateSortedList_*` lemmas form a complete
`Sym`-wrapped image of `Mathlib.Data.List.Rotate`'s API used downstream
by 2B.4' / 2B.5'.

## File deltas

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1861 → 1910 (+49).
- `theoremCount` 39 → 40 (canonical PR #17553 / PR #17569 convention:
  +1 for `_perm_sort`; `_length_mul` and `_mem` are `@[simp]` and excluded
  by the convention, matching how `rotateSortedList_length` /
  `rotateSortedList_zero` are treated).
- `lineCount` 1861 → 1910; both `meta.*` and `leanFile.*` updated.
- Sorry count: 2 (unchanged). Axiom count: 0 (unchanged).

## Build status

**Pending**. Parent file `BallotProblemOQ03OQ02.lean` is broken on
origin/main (~24 errors lines 1911–2386 per
`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09);
`BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports through
the OQ03OQ01 / OQ03 chain) cannot be Docker-built until that parent break
is repaired by a mechanic PR. Title precedent: S25–S31 PRs all merged
with `(build pending — parent OQ03OQ02 break)` modifier.

Each new lemma was verified by reading `Mathlib/Data/List/Rotate.lean`
and `Mathlib/Data/Multiset/Sort.lean` directly (Mathlib v4.26.0).

## Test plan

- [x] `git diff origin/main` produces 49 / 131 / 8 line diffs across the
  three files (proof, state.md, meta.json).
- [x] Canonical theoremCount scanner (PR #17569 convention) confirms
  39 → 40 on the new file (1 non-`@[simp]` addition).
- [ ] Docker build of `Proofs.BallotProblemOQ03OQ01OQ01OQ01` (blocked by
  parent OQ03OQ02 break — same blocker as S25–S31).
- [ ] Auto-merge by deployer (math PR, no `loom:review-requested` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)