### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.3 — case-1 arm-of-c' / case-2 leg-of-c' summand vanishings (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14690,6 +14690,71 @@ private lemma gnwProb_unreachable_zero {μ : YoungDiagram} {c : ℕ × ℕ} :
           · exact Or.inr h
       rw [hsum_zero, mul_zero]
 
+/-- **(S57.3, S4) Arm-of-c' summand vanishes — case 1.**
+
+In case 1 of `distinct_corners_dichotomy` (i.e., `c.1 < c'.1`), the summand
+`gnwProb μ c K (c'.1, s)` is identically zero for every `s ∈ Finset.range c'.2`,
+because the cell `(c'.1, s)` satisfies `c.1 < c'.1 = (c'.1, s).1`, so
+`gnwProb_unreachable_zero` applies via the `Or.inl` (row-disjunct) branch.
+
+**Geometric content.** The index set `{(c'.1, s) | s < c'.2}` is exactly the
+arm-of-c' cells of `(μ\c').cells` — i.e. cells in the row `c'.1` of `μ\c'`,
+which has length `c'.2` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(c'.1, 0), …, (c'.1, c'.2 − 1)`).
+
+**Role in S57.0's K-induction plan for `F_side_identity_aligned`.**  This is
+the (S4) summand vanishing.  When the joint K-induction case-splits the sum
+domain `(μ\c').cells` into off-spine / arm-of-c / leg-of-c / arm-of-c' /
+leg-of-c' subsets, the case-1 arm-of-c' contribution to both LHS and RHS
+sums of `F_side_identity_aligned` collapses to `0 · α² = 0 · ((α − 1)² + 0)`,
+sidestepping the `δ_arm` correction-term design problem flagged in S57.0.
+
+**Genericity in `μ`.**  The lemma is universal in its `μ` argument, so it
+applies equally to the LHS sum (`gnwProb μ c (h_μ x) x` over `(μ\c').cells`)
+and to the RHS sum (`gnwProb (μ\c') c (h_{μ\c'} x) x`).  Specializing
+`K := hookLength μ x.1 x.2` for the LHS or `K := hookLength (μ\c') x.1 x.2`
+for the RHS gives the integrand-level vanishing used in (S4) of the K-induction. -/
+private lemma sum_gnwProb_arm_of_c'_eq_zero_case1
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc1 : c.1 < c'.1) (K : ℕ) :
+    ∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0 := by
+  apply Finset.sum_eq_zero
+  intro s _
+  exact gnwProb_unreachable_zero K (c'.1, s) (Or.inl hc1)
+
+/-- **(S57.3, S5) Leg-of-c' summand vanishes — case 2.**
+
+In case 2 of `distinct_corners_dichotomy` (i.e., `c'.1 < c.1`, equivalently
+`c.2 < c'.2` by `corner_row_lt_of_col_lt`), the summand
+`gnwProb μ c K (r, c'.2)` is identically zero for every
+`r ∈ Finset.range c'.1`, because the cell `(r, c'.2)` satisfies
+`c.2 < c'.2 = (r, c'.2).2`, so `gnwProb_unreachable_zero` applies via the
+`Or.inr` (column-disjunct) branch.
+
+**Geometric content.** The index set `{(r, c'.2) | r < c'.1}` is exactly the
+leg-of-c' cells of `(μ\c').cells` — i.e. cells in the column `c'.2` of `μ\c'`,
+which has length `c'.1` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(0, c'.2), …, (c'.1 − 1, c'.2)`).
+
+**Role in S57.0's K-induction plan for `F_side_identity_aligned`.**  This is
+the mirror of (S4): the (S5) summand vanishing for case 2.  Combined with
+`sum_gnwProb_arm_of_c'_eq_zero_case1`, both `c'`-coboundary contributions
+to `F_side_identity_aligned` are now handled by direct vanishing rather than
+genuine pointwise comparison, completing the cleanup of the "easy" branches
+of S57.0's cell partition.  The remaining work for S57.4+ targets the
+"hard" off-spine branch (S6), where genuine K-induction is required.
+
+**Genericity in `μ`.**  Universal in its `μ` argument, so it applies to both
+LHS (`gnwProb μ c (h_μ x) x`) and RHS (`gnwProb (μ\c') c (h_{μ\c'} x) x`)
+forms appearing in `F_side_identity_aligned`. -/
+private lemma sum_gnwProb_leg_of_c'_eq_zero_case2
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc2 : c.2 < c'.2) (K : ℕ) :
+    ∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0 := by
+  apply Finset.sum_eq_zero
+  intro r _
+  exact gnwProb_unreachable_zero K (r, c'.2) (Or.inr hc2)
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s05.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s05.md
@@ -1,0 +1,155 @@
+## Session 2026-05-09 (Session 57.3, researcher-9) — case-1 arm-of-c' / case-2 leg-of-c' summand vanishings
+
+**Mode**: ACT (RICH knowledge tier, score 214) — incremental sorry-free
+infrastructure for the joint K-induction in `F_side_identity_aligned`.
+
+**Outcome**: Two sorry-free private lemmas added to
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, packaging the `gnwProb_unreachable_zero`
+S57.2 lemma into summand-level vanishing identities for the case-1 arm-of-c' and
+case-2 leg-of-c' branches of S57.0's K-induction cell partition.  Each lemma is
+3 lines of proof (`Finset.sum_eq_zero` + `gnwProb_unreachable_zero` with the
+appropriate `Or.inl`/`Or.inr` disjunct).
+
+**Why this matters**: dissolves the (S4) and (S5) summand contributions of
+`F_side_identity_aligned` to the trivial form `0 = 0`, sidestepping the
+`δ_arm` correction-term design problem flagged in S57.0's plan note.  After
+S57.3, the remaining open piece for S57.4+ is whether the cross-case
+sub-branches (e.g. (S2) case 2 — arm-of-c' with `c'.1 < c.1`) reduce to the
+trivial branches by transpose duality, or whether genuine pointwise comparison
+via δ_arm is required.
+
+### Lemmas added (sorry-free)
+
+Inserted after S57.2's `gnwProb_unreachable_zero` (line ~14692), before
+`sum_gnwProb_strictHookCells_eq_removeCorner`.
+
+#### `sum_gnwProb_arm_of_c'_eq_zero_case1` (line ~14717)
+
+```lean
+private lemma sum_gnwProb_arm_of_c'_eq_zero_case1
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc1 : c.1 < c'.1) (K : ℕ) :
+    ∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0 := by
+  apply Finset.sum_eq_zero
+  intro s _
+  exact gnwProb_unreachable_zero K (c'.1, s) (Or.inl hc1)
+```
+
+**Statement**: in case 1 of `distinct_corners_dichotomy` (`c.1 < c'.1`), the
+sum of `gnwProb μ c K (c'.1, s)` over `s ∈ Finset.range c'.2` is zero.
+
+**Proof** (3 lines): apply `Finset.sum_eq_zero`; for each `s` in the range,
+the cell `(c'.1, s)` satisfies `c.1 < c'.1 = (c'.1, s).1` definitionally, so
+`gnwProb_unreachable_zero K (c'.1, s) (Or.inl hc1) : gnwProb μ c K (c'.1, s) = 0`.
+
+**Geometric content**: the index set `{(c'.1, s) | s < c'.2}` is exactly the
+arm-of-c' cells of `(μ\c').cells` — i.e. cells in the row `c'.1` of `μ\c'`,
+which has length `c'.2` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(c'.1, 0), …, (c'.1, c'.2 − 1)`).
+
+#### `sum_gnwProb_leg_of_c'_eq_zero_case2` (line ~14750)
+
+```lean
+private lemma sum_gnwProb_leg_of_c'_eq_zero_case2
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc2 : c.2 < c'.2) (K : ℕ) :
+    ∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0 := by
+  apply Finset.sum_eq_zero
+  intro r _
+  exact gnwProb_unreachable_zero K (r, c'.2) (Or.inr hc2)
+```
+
+**Statement**: in case 2 of `distinct_corners_dichotomy` (`c'.1 < c.1`,
+equivalently `c.2 < c'.2` by `corner_row_lt_of_col_lt`), the sum of
+`gnwProb μ c K (r, c'.2)` over `r ∈ Finset.range c'.1` is zero.
+
+**Proof** (3 lines): mirror of case 1, using `Or.inr hc2` for the column-disjunct
+of `gnwProb_unreachable_zero`.
+
+**Geometric content**: the index set `{(r, c'.2) | r < c'.1}` is exactly the
+leg-of-c' cells of `(μ\c').cells` — i.e. cells in the column `c'.2` of `μ\c'`,
+which has length `c'.1` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(0, c'.2), …, (c'.1 − 1, c'.2)`).
+
+### Why universal in `μ`
+
+Both lemmas are universal in their `μ` argument, since `gnwProb_unreachable_zero`
+is.  This means the same lemma applies to:
+* The LHS sum of `F_side_identity_aligned`: `gnwProb μ c (h_μ x) x`,
+  specializing `K := hookLength μ x.1 x.2`.
+* The RHS sum: `gnwProb (μ\c') c (h_{μ\c'} x) x`, specializing
+  `K := hookLength (μ\c') x.1 x.2`.
+
+No "primed" variant is needed — a single statement handles both sides of the
+identity.
+
+### Verification
+
+* **No build attempted.**  Per the standing memory note, `BallotProblemOQ03OQ02.lean`
+  (the LGV-route sibling that this entry consumes via dependency) is currently
+  broken on `origin/main`, blocking build verification of all
+  `ballot-oq-03-oq-01-*` descendants.  Matched the S25–S31 / S57.1 / S57.2
+  "(build pending)" PR-title precedent.
+* **Mathlib API verified by reading source.**  All proofs use only existing
+  primitives:
+  - `gnwProb_unreachable_zero` (line 14656, this file) — added in S57.2 with
+    signature `∀ K x, (c.1 < x.1 ∨ c.2 < x.2) → gnwProb μ c K x = 0`.
+  - `Finset.sum_eq_zero` (Mathlib) — used in
+    `proofs/Proofs/Erdos382Problem.lean:253` and S57.2's
+    `gnwProb_unreachable_zero` proof itself (line 14677).
+  - `Finset.range` (Mathlib core).
+  - The cell coordinate access `(c'.1, s).1 = c'.1` and `(r, c'.2).2 = c'.2`
+    reduces definitionally (`Prod.fst`/`Prod.snd` on a literal pair).
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+65 lines:
+  2 new lemmas + ~50 lines of docstrings; from 15293 to 15358 lines).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 59 → 60; Approaches list += 1 entry (S57.3); Next Action
+  refined to S57.4 (transpose duality investigation); references and
+  session pointers updated).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s05.md`
+  (this report).
+
+### Recovery / trap-checks performed
+
+1. `gh pr list --state open --search "ballot-problem-oq-03-oq-01-oq-02"`
+   — only PR #17585 returned, but its slug is
+   `ballot-problem-oq-03-oq-01-oq-01-oq-01` (different — note the extra
+   `-oq-01`).  No open PR for `ballot-problem-oq-03-oq-01-oq-02`.
+2. `git log origin/main --oneline -30 | grep "ballot-problem-oq-03-oq-01-oq-02"`
+   — latest merged is PR #17568 (S57.2, merged 2026-05-09 01:06Z; ~21 min
+   before this session start).  No competing in-flight S57.3 work.
+3. `git branch -r | grep ballot-problem-oq-03-oq-01-oq-02` — only orphan
+   `audit-fix/...-sorry-count` from earlier audit cycles, not relevant.
+4. `git fetch origin main` then branched off fresh `origin/main`
+   (SHA `b624721903c`), bypassing any stale local-main reference.
+5. **Worktree path trap caught.**  First attempt edited files using
+   absolute paths under `/Users/rwalters/GitHub/lean-genius/...` (the
+   MAIN REPO), and concurrent activity reset those edits.  Second
+   attempt used worktree absolute paths
+   `/Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-9/...`
+   and `git status` confirms changes staged in the worktree before
+   commit.  Lesson: always prefer worktree-prefixed absolute paths for
+   `Edit`/`Write` tools.
+
+### Next iteration recommendations
+
+1. **(S57.4)** Investigate whether (S2) case 2 (arm-of-c' with `c'.1 < c.1`)
+   reduces to (S3) case 1 by transpose duality.  If yes, both case-2 sub-branches
+   dissolve via vanishing arguments, and only the off-spine summand (S6) requires
+   genuine K-induction.  If no, a `δ_arm` correction term is unavoidable for
+   (S2) case 2.
+2. **(S57.5)** Lift `sum_gnwProb_arm_of_c'_eq_zero_case1` from `Finset.range c'.2`
+   indexing to `Finset.image (fun s => (c'.1, s)) (Finset.range c'.2)` indexing
+   (a subset of `(μ\c').cells`).  This is the form the K-induction will consume
+   directly when partitioning `(μ\c').cells` into cell-type subsets.  ~10 lines
+   via `Finset.sum_image` (the indexing function `s ↦ (c'.1, s)` is injective).
+   Mirror lift for `sum_gnwProb_leg_of_c'_eq_zero_case2`.
+3. **(S57.6+)** Tackle the off-spine summand (S6) — this is the genuine pointwise
+   comparison `gnwProb μ = gnwProb (μ\c')` on off-spine cells; needs a true
+   K-induction (not just a vanishing argument).  S57.1's structural invariances
+   are the inputs; S57.2's `gnwProb_unreachable_zero` and S57.3's summand
+   vanishings are *not* directly useful here (off-spine cells are not in the
+   "wrong half-plane" relative to `c`).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S57.2 done — `gnwProb_unreachable_zero` lemma added; S57.3+ continues K-induction)
+**Phase**: ACT (S57.3 done — case-1 arm-of-c' and case-2 leg-of-c' summand vanishings added; S57.4+ continues K-induction)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
 **Last Updated**: 2026-05-09
-**Iteration**: 59
+**Iteration**: 60
 
 ## Current Focus
 Close `F_side_identity_aligned` (Helpers, line ~14811) — the
@@ -238,8 +238,33 @@ in place:
      K-induction in `F_side_identity_aligned`, eliminating two of the
      three "moving pieces" in S57.0's analysis.  +89 Helpers lines.
      PR #17537 (merged 2026-05-08 23:55Z, build pending).
+ 21. **Case-1 arm-of-c' / case-2 leg-of-c' summand vanishings
+     (session 57.3, this session)** — added two sorry-free private
+     lemmas after `gnwProb_unreachable_zero` (line ~14693):
+     `sum_gnwProb_arm_of_c'_eq_zero_case1` (~14717,
+     `∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0` when
+     `c.1 < c'.1`) and `sum_gnwProb_leg_of_c'_eq_zero_case2` (~14750,
+     `∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0` when
+     `c.2 < c'.2`).  Each is a 3-line proof — `Finset.sum_eq_zero`
+     + `gnwProb_unreachable_zero` with the appropriate
+     `Or.inl`/`Or.inr` disjunct.  These package the (S4) and (S5)
+     summand vanishings of S57.0's K-induction plan: when the joint
+     K-induction case-splits `(μ\c').cells` by cell type, the
+     case-1 arm-of-c' (cells `(c'.1, s)` with `s < c'.2`) and case-2
+     leg-of-c' (cells `(r, c'.2)` with `r < c'.1`) contributions to
+     both LHS and RHS sums of `F_side_identity_aligned` collapse to
+     `0 = 0` — sidestepping the `δ_arm` correction-term design
+     problem flagged in S57.0.  Both lemmas are universal in `μ`,
+     so they apply to LHS (`gnwProb μ c (h_μ x) x`) and RHS
+     (`gnwProb (μ\c') c (h_{μ\c'} x) x`) sums alike.  +65 Helpers
+     lines (was 15293; now 15358).  **Sorry count unchanged (1)** —
+     `F_side_identity_aligned` remains the sole open sorry on the
+     GNW route; this lemma pair is sorry-free infrastructure that
+     materially shrinks the K-induction's case-analysis burden in
+     S57.4+.
+
  20. **Walk-unreachability lemma for arm/leg-of-c' (session 57.2,
-     this session)** — added `private lemma gnwProb_unreachable_zero`
+     prior session)** — added `private lemma gnwProb_unreachable_zero`
      (line ~14656, +68 lines including 32-line docstring): for any
      cell `x` with `c.1 < x.1 ∨ c.2 < x.2`, `gnwProb μ c K x = 0` for
      every `K`.  **Proof**: induction on `K` (~15 lines).  Base `K=0`
@@ -279,19 +304,22 @@ in place:
   memory ceiling estimate (~15500).  CI will verify the PR.
 
 ## Next Action
-**S57.3 — apply `gnwProb_unreachable_zero` to discharge (S2) and (S3)
-in the trivial branches**, completing the case-1 arm-of-c' and case-2
-leg-of-c' summands of the K-induction.  After S57.2's lemma, the
-remaining work for `F_side_identity_aligned` reduces materially:
-* **(S2) case 1** (`c.1 < c'.1`, arm-of-c'): `gnwProb_unreachable_zero`
-  immediately gives `gnwProb μ c (h_μ x) x = 0` and
-  `gnwProb (μ\c') c (h_{μ\c'} x) x = 0` for all such `x`, so the
-  pointwise identity is `0 · α² = 0 · ((α−1)² + 0)`.  Trivial; needs
-  a wrapper lemma showing `gnwProb_zero_on_arm_of_c'_case1`
-  (~10 lines), then the (S4) summand follows by `Finset.sum_eq_zero`
-  (~10 lines).
-* **(S3) case 2** (`c'.1 < c.1`, leg-of-c'): analogous, via the
-  `c.2 < x.2` disjunct of `gnwProb_unreachable_zero`.
+**S57.4 — investigate transpose duality for the cross-case branches**,
+specifically whether (S2) case 2 (arm-of-c' with `c'.1 < c.1`) reduces
+to (S3) case 1 by transpose-mirror argument.  S57.3 (this session)
+discharged the two trivial branches with summand-level vanishing
+lemmas; the remaining open piece is whether the cross-case sub-branches
+also dissolve via duality, or whether genuine pointwise comparison
+(with a `δ_arm` correction term) is needed.
+
+After S57.3, the remaining work for `F_side_identity_aligned`
+partitions as:
+* **(S2) case 1** (`c.1 < c'.1`, arm-of-c'): ✓ trivial via
+  `sum_gnwProb_arm_of_c'_eq_zero_case1` (S57.3, this session) + a
+  Finset.image lift.  Both LHS and RHS sums vanish on this subset.
+* **(S3) case 2** (`c'.1 < c.1`, leg-of-c'): ✓ trivial via
+  `sum_gnwProb_leg_of_c'_eq_zero_case2` (S57.3, this session) + a
+  Finset.image lift.
 * **(S2) case 2** (arm-of-c' with `c'.1 < c.1`): NOT covered.
   Cells `x = (c'.1, s)` with `s < c'.2` and `c'.1 < c.1` give
   `x.1 = c'.1 < c.1`, no unreachability.  These cells need genuine
@@ -432,6 +460,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-09-s02.md` — Session 57.0: K-induction strategy + cell-partition + (S1)-(S7) sublemma plan
 - `sessions/2026-05-09-s03.md` — Session 57.1: off-spine structural invariances under c'-removal (3 lemmas, sorry-free)
 - `sessions/2026-05-09-s04.md` — Session 57.2: `gnwProb_unreachable_zero` walk-unreachability lemma (sorry-free)
+- `sessions/2026-05-09-s05.md` — Session 57.3: case-1 arm-of-c' / case-2 leg-of-c' summand vanishings (2 sorry-free lemmas, +65 Helpers lines)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -448,6 +477,8 @@ Fallback if S55+ stalls.
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14588` — `hookLength_invariant_off_spine_of_c'` (S57.1)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14616` — `strictHookCells_invariant_off_spine_of_c'` (S57.1)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14656` — `gnwProb_unreachable_zero` (S57.2; sorry-free; closes (S2)/(S3) on the unreachable branches via case-1 arm-of-c' / case-2 leg-of-c')
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14717` — `sum_gnwProb_arm_of_c'_eq_zero_case1` (S57.3; sorry-free; case-1 arm-of-c' summand vanishes via `Finset.sum_eq_zero` + `gnwProb_unreachable_zero`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14750` — `sum_gnwProb_leg_of_c'_eq_zero_case2` (S57.3; sorry-free; case-2 leg-of-c' summand vanishes via `Finset.sum_eq_zero` + `gnwProb_unreachable_zero`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14719` — `gnwProb_exchange_lt_row_of_F_side`
   (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14814` — `gnwProb_exchange_lt_col_of_F_side`


### PR DESCRIPTION
## Summary

S57.3 adds two sorry-free private lemmas in
`BallotProblemOQ03OQ01OQ02Helpers.lean` packaging S57.2's
`gnwProb_unreachable_zero` into summand-level vanishing identities for the
(S4) and (S5) summand contributions of S57.0's K-induction plan for
`F_side_identity_aligned` (the sole open sorry on the GNW route).

- `sum_gnwProb_arm_of_c'_eq_zero_case1` (line ~14717):
  in case 1 (`c.1 < c'.1`),
  `∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0`.
- `sum_gnwProb_leg_of_c'_eq_zero_case2` (line ~14750):
  in case 2 (`c.2 < c'.2`),
  `∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0`.

Each proof is 3 lines (`Finset.sum_eq_zero` + `gnwProb_unreachable_zero`
with the appropriate `Or.inl`/`Or.inr` disjunct).  Both lemmas are
universal in `μ`, so a single statement covers both LHS
(`gnwProb μ c (h_μ x) x`) and RHS (`gnwProb (μ\c') c (h_{μ\c'} x) x`) sums
of `F_side_identity_aligned`.

## Effect on the K-induction plan

This dissolves the case-1 arm-of-c' and case-2 leg-of-c' branches of
S57.0's cell partition to the trivial form `0 = 0`, sidestepping the
`δ_arm` correction-term design problem flagged in S57.0.  After S57.3,
the remaining open piece is whether the cross-case sub-branches (e.g.
(S2) case 2 — arm-of-c' with `c'.1 < c.1`) reduce to the trivial branches
by transpose duality, or whether genuine pointwise comparison is required
(targeted in S57.4).

**Sorry count unchanged (1)** — `F_side_identity_aligned` remains the
sole open sorry on the GNW route; this lemma pair is sorry-free
infrastructure that shrinks the K-induction's case-analysis burden.

## File-size

Helpers.lean: 15293 → 15358 lines (+65 lines, ~140 lines under the
Docker 32GB-memory ceiling estimate ~15500).

## Test plan

- [ ] CI build of `Proofs.BallotProblemOQ03OQ01OQ02Helpers` (build pending
      due to known LGV-sibling break on origin/main per memory note;
      matches S25–S31 / S57.1 / S57.2 \"build pending\" precedent).
- [x] Mathlib API verified by reading source:
      `Finset.sum_eq_zero`, `Finset.range`, `gnwProb_unreachable_zero`
      (S57.2, line 14656).
- [x] Definitional reduction `(c'.1, s).1 = c'.1` and `(r, c'.2).2 = c'.2`
      confirmed against `Prod.fst`/`Prod.snd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)