### PR TITLE
fix(meta): four-square-distribution-oq-01 theoremCount 107 → 114

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 1774,
-    "theoremCount": 107,
+    "theoremCount": 114,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `theoremCount` drift on `four-square-distribution-oq-01`: meta says 107, actual is 114 (after S9–S14 research PRs added 7 theorem/lemma declarations to `Proofs/FourSquareDistributionOQ01.lean` without bumping the count).

Last meta sync was #16893 (2026-05-08). Subsequent merges that added theorems but did not touch meta.json:

- #17347 (S9 — r4Count Eisenstein-coefficient form)
- #17359 (S10 — multiplicativity bridge)
- #17395 (S11 — positivity, 8-divisibility, odd-prime corollary)
- #17490 (S12 — Part 22 odd-prime-power closed form)
- #17524 (S14 — Part 23 modular-form atomic decomposition)

## Evidence

| Field             | Claimed | Actual | Status |
|-------------------|---------|--------|--------|
| `lineCount`       | 1774    | 1774   | ✓      |
| `theoremCount`    | **107** | **114**| ❌ → fixed |
| `definitionCount` | 6       | 6      | ✓      |
| `axiomCount`      | 1       | 1      | ✓      |
| `sorries`         | 0       | 0      | ✓      |

Count obtained by depth-tracking comment stripper (handles nested `/-…-/` and `--`) followed by regex `^(modifiers)*(theorem|lemma)\s+\w+` on the cleaned source. 114 unique declaration names; no duplicates.

## Diff

```diff
-    "theoremCount": 107,
+    "theoremCount": 114,
```

Single-field, format-preserving 1-line diff. JSON parses cleanly.

The `leanFile` sub-object is structurally empty (`{}`) for this entry, so no `lf.theoremCount` mirror exists to update.

---
Automated fix by lean-mechanic agent.