### PR TITLE
fix(meta): batch sync definitionCount drift (10 entries, marquee batch)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -86,7 +86,7 @@
     "lineCount": 7435,
     "mathlib_version": "4.26.0",
     "theoremCount": 254,
-    "definitionCount": 164
+    "definitionCount": 261
   },
   "overview": {
     "historicalContext": "The BSD conjecture arose from pioneering computational experiments by Bryan Birch and Peter Swinnerton-Dyer at Cambridge in the early 1960s. Using the EDSAC computer, they computed the product of local factors $N_p/p$ for many elliptic curves and observed that the growth rate as $p \\to \\infty$ correlated with the number of rational points. In 1965, they published their conjecture: the rank of the Mordell-Weil group $E(\\mathbb{Q})$ equals the order of vanishing of $L(E, s)$ at $s = 1$.\n\nThe first major progress came from Coates and Wiles (1977), who proved BSD for elliptic curves with complex multiplication when $L(E, 1) \\neq 0$. The breakthrough decade was the 1980s-90s: Gross and Zagier (1986) established their celebrated formula relating $L'(E, 1)$ to the height of Heegner points, and Kolyvagin (1990) introduced Euler systems to prove the rank 0 and rank 1 cases. These results established that if $L(E, 1) \\neq 0$ then rank $= 0$, and if $L(E, 1) = 0$ but $L'(E, 1) \\neq 0$ then rank $= 1$, with the Shafarevich-Tate group finite in both cases.\n\nWiles' proof of the modularity theorem for semistable curves (1995) -- which famously proved Fermat's Last Theorem as a corollary -- was essential for BSD because it guaranteed that $L(E, s)$ has analytic continuation, making the order of vanishing at $s = 1$ well-defined. Breuil-Conrad-Diamond-Taylor (2001) completed the modularity theorem for all elliptic curves over $\\mathbb{Q}$.\n\nIn 2000, the Clay Mathematics Institute designated BSD as one of seven Millennium Prize Problems, carrying a $1,000,000 prize. Despite massive computational evidence (verified for all curves with conductor $\\leq 500{,}000$ with no counterexamples), the conjecture remains open for rank $\\geq 2$. Bhargava and Shankar (2015) showed the average rank of elliptic curves is at most 7/6, providing statistical evidence that BSD is 'usually true', but a proof for individual curves of higher rank remains elusive.",
@@ -725,7 +725,7 @@
     "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean",
-    "definitionCount": 164,
+    "definitionCount": 261,
     "theoremCount": 254,
     "additionalFiles": [
       "Proofs/BirchSwinnertonDyerAristotle.lean"

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -41,7 +41,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 10517,
     "theoremCount": 430,
-    "definitionCount": 89
+    "definitionCount": 192
   },
   "overview": {
     "historicalContext": "The Hodge Conjecture was proposed by Sir William Vallance Douglas Hodge at the 1950 International Congress of Mathematicians in Cambridge. Hodge developed his theory of harmonic integrals in the 1930s–1940s, building on Solomon Lefschetz's 1924 theorem that every (1,1) integral Hodge class is algebraic (the Lefschetz theorem on (1,1) classes). Hodge conjectured this should extend to all codimensions p.\n\nFor over 70 years the conjecture has resisted resolution. Key milestones: Atiyah–Hirzebruch (1962) disproved the integral version using topological K-theory and Steenrod operations, showing rational coefficients are essential. Grothendieck (1968) proposed his Standard Conjectures, which would imply the Hodge Conjecture as a corollary; they also remain open. Deligne proved the Weil conjectures (1974), which are related but distinct. Voisin (2002) proved the conjecture fails for compact Kähler manifolds that are not projective, confirming projectivity is an essential hypothesis.\n\nIn 2000, the Clay Mathematics Institute designated the Hodge Conjecture as one of seven Millennium Prize Problems with a $1,000,000 prize. The only proven cases are: divisors on any variety (Lefschetz (1,1)), curves, surfaces, and special abelian varieties (Deligne, Hazama). The conjecture stands as one of the deepest open questions in mathematics.",
@@ -293,7 +293,7 @@
     ],
     "path": "Proofs/HodgeConjecture.lean",
     "sorries": 0,
-    "definitionCount": 89
+    "definitionCount": 192
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -32,7 +32,7 @@
       "Algebraic equivalences: unified formula ↔ scaled spherical/hyperbolic laws for all K≠0"
     ],
     "theoremCount": 22,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The question of whether the Euclidean, spherical, and hyperbolic laws of cosines can be unified into a single formula has been understood geometrically since the 19th century, with the development of non-Euclidean geometry by Lobachevsky, Bolyai, and later Riemann. The key insight is that constant-curvature spaces admit a unified trigonometry parametrized by the sectional curvature K. For K > 0 (spherical), the natural trigonometric functions are circular; for K < 0 (hyperbolic), they are hyperbolic; and for K = 0 (Euclidean), the functions degenerate to their linear/constant limits. This parametric approach was formalized in the context of Riemannian geometry by Killing, Clifford, and others. The unified law cs_K(c) = cs_K(a)·cs_K(b) + K·sn_K(a)·sn_K(b)·cos(C) appears in modern treatments of Riemannian geometry, differential geometry textbooks (e.g., Thurston), and is closely related to the Jacobi equation for geodesic deviation. The Lean formalization presented here gives a purely algebraic treatment: defining cs_K and sn_K as piecewise functions of K and proving key identities from Mathlib's existing circular and hyperbolic trigonometry.",
@@ -196,7 +196,7 @@
     "lineCount": 693,
     "axiomCount": 1,
     "theoremCount": 22,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/LawOfCosinesOQ05.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 21111,
     "mathlib_version": "4.26.0",
     "theoremCount": 611,
-    "definitionCount": 100
+    "definitionCount": 362
   },
   "overview": {
     "historicalContext": "**Navier-Stokes Existence and Smoothness (Millennium Prize Problem)**\n\nThe Navier-Stokes equations describe fluid motion: $\\partial_t u + (u \\cdot \\nabla)u = \\nu\\Delta u - \\nabla p + f$ with $\\nabla \\cdot u = 0$. The Millennium Prize asks whether smooth solutions exist globally in 3D. Leray (1934) proved weak solutions exist; Ladyzhenskaya (1962/1969) solved the 2D case; Caffarelli-Kohn-Nirenberg (1982) showed the 3D singular set has Hausdorff dimension at most 1. The 3D problem remains open after 90+ years.\n\nThis formalization is the largest single proof file in the gallery at 20,000+ lines across 110 parts, containing 1200+ definitions/theorems with 0 sorries. The 3D conditional result uses the NSAxioms structure (5 structure-encoded assumptions).",
@@ -269,7 +269,7 @@
     "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 611,
-    "definitionCount": 100,
+    "definitionCount": 362,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -70,7 +70,7 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 611,
-    "definitionCount": 100
+    "definitionCount": 362
   },
   "overview": {
     "historicalContext": "The two-dimensional Navier-Stokes equations have been known to have global smooth solutions since Ladyzhenskaya's work in 1969. The key is that vortex stretching — the primary mechanism that might cause blowup in 3D — is absent in 2D. In 2D, the vorticity ω satisfies a transport-diffusion equation without the dangerous (ω·∇)u stretching term.\n\nThe enstrophy E(t) = ∫|ω(x,t)|² dx is the squared L² norm of vorticity. In 2D, enstrophy satisfies the ODE dE/dt = -2νP where P = ∫|∇ω|² is the palinstrophy. Under a Poincaré inequality P ≥ μ₁E (where μ₁ is the first eigenvalue of -Δ on the domain), this becomes dE/dt ≤ -2νμ₁E, giving exponential decay.\n\nThis formalization extends the existing NavierStokes.lean (which already proved the asymptotic bound E(t) ≤ E(0)·exp(-2νμ₁t)) with new quantitative results: decay between arbitrary times, exact FTC integration of the enstrophy ODE, and total dissipation bounds.",
@@ -186,7 +186,7 @@
     "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 611,
-    "definitionCount": 100,
+    "definitionCount": 362,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0",
     "theoremCount": 611,
-    "definitionCount": 100
+    "definitionCount": 362
   },
   "overview": {
     "historicalContext": "The theory of well-posedness for 2D Navier-Stokes equations has a rich history beginning with Jean Leray's pioneering 1934 paper, which established the existence of weak solutions in both 2D and 3D. For 2D, Leray showed that solutions remain regular for all time — a result that fails (or at least remains unproven) in 3D.\n\nThe concept of well-posedness itself was formalized by Jacques Hadamard in his 1902 lectures: a problem is well-posed if it has (1) existence, (2) uniqueness, and (3) continuous dependence on data. Hadamard argued that physically meaningful problems should satisfy all three criteria.\n\nOlga Ladyzhenskaya's landmark 1969 monograph 'The Mathematical Theory of Viscous Incompressible Flow' provided the definitive treatment of 2D well-posedness. Her key contribution was the Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4(\\mathbb{R}^2)} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$, which gives the stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ for the difference energy $W(t) = \\|u_1 - u_2\\|_{L^2}^2$. The critical feature of 2D: enstrophy $E(t) = \\|\\nabla u\\|_{L^2}^2$ is bounded by its initial value $E(0)$, making the Gronwall growth rate $K = C \\cdot E(0)$ finite.\n\nThomas Gronwall's 1919 inequality — if $u'(t) \\leq \\beta(t) u(t)$ then $u(t) \\leq u(0) \\exp(\\int_0^t \\beta)$ — is the analytic engine of the proof. Combined with bounded enstrophy, it yields exponential stability $W(t) \\leq W(0) e^{CE(0)t}$ and hence uniqueness.\n\nIn 3D, enstrophy could potentially blow up ($E(t) \\to \\infty$), making $K(t) = C \\cdot E(t)$ unbounded and the Gronwall argument ineffective. This is precisely the obstruction at the heart of the Clay Millennium Prize Problem: proving or disproving 3D global regularity. The 2D well-posedness result formalized here serves as a template showing exactly where the 3D argument breaks down.\n\nThis formalization in Lean 4 is novel: the `NSSolutionPair2D` structure encodes the Ladyzhenskaya stability estimate as a structural hypothesis, abstracting away the PDE-specific Sobolev space analysis (not yet available in Mathlib) and focusing on the Gronwall argument itself.",
@@ -207,7 +207,7 @@
     "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 611,
-    "definitionCount": 100,
+    "definitionCount": 362,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -79,7 +79,7 @@
     "lineCount": 17675,
     "mathlib_version": "4.26.0",
     "theoremCount": 941,
-    "definitionCount": 382
+    "definitionCount": 596
   },
   "overview": {
     "historicalContext": "Henri Poincaré posed the conjecture in 1904 in his fifth complement to Analysis Situs, after discovering that homology alone does not characterize the 3-sphere (the Poincaré homology sphere $\\Sigma(2,3,5)$ has $H_*(M) \\cong H_*(S^3)$ but $|\\pi_1| = 120$). The problem resisted all attempts for nearly a century.\n\nRichard Hamilton introduced Ricci flow in his landmark 1982 paper in J. Differential Geometry, proving that closed 3-manifolds with positive Ricci curvature are diffeomorphic to $S^3$. Grigori Perelman extended this in three arXiv preprints (2002–2003): 'The entropy formula for the Ricci flow' (math/0211159), 'Ricci flow with surgery on three-manifolds' (math/0303109), and 'Finite extinction time for the solutions to the Ricci flow' (math/0307245). His proof also established Thurston's Geometrization Conjecture.\n\nPerelman was awarded the Fields Medal in 2006 (declined) and the Clay Millennium Prize of $1 million in 2010 (also declined), saying 'I'm not interested in money or fame.' The detailed verification was completed by Kleiner–Lott (2008), Morgan–Tian (2007), and Cao–Zhu (2006).",
@@ -348,7 +348,7 @@
     "axiomCount": 34,
     "sorries": 0,
     "theoremCount": 941,
-    "definitionCount": 382,
+    "definitionCount": 596,
     "lemmaCount": 0
   }
 }

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "theoremCount": 1787,
-    "definitionCount": 641
+    "definitionCount": 1022
   },
   "overview": {
     "historicalContext": "Two-dimensional Yang-Mills theory occupies a unique position: it is the only dimension where non-abelian gauge theory is exactly solvable. Migdal (1975) derived the celebrated formula $\\langle W_R(C)\\rangle = (\\dim R) e^{-\\sigma A}$ by exploiting the fact that in 2D the partition function factorizes over plaquettes — a property that fails in higher dimensions where plaquettes share links. The exact solution was placed on rigorous mathematical footing by Driver (1989) using stochastic analysis, Sengupta (1997) via measure-theoretic methods on path spaces, and Lévy (2003) who constructed the Yang-Mills measure on arbitrary compact surfaces. Witten (1991, 1992) connected 2D Yang-Mills to topological field theory, showing that the partition function computes intersection numbers on moduli spaces of flat connections — a deep link between physics and algebraic geometry. The Casimir scaling property $\\sigma_R \\propto C_2(R)$, which holds exactly in 2D, has been verified to high precision in 4D lattice QCD simulations by Bali (2000) and others, suggesting that 2D mechanisms partially survive in higher dimensions. The 2D theory serves as the primary testing ground for techniques aimed at the Clay Millennium Prize problem: proving the mass gap in 4D Yang-Mills.",
@@ -222,7 +222,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "definitionCount": 641,
+    "definitionCount": 1022,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -38,7 +38,7 @@
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "theoremCount": 1787,
-    "definitionCount": 641
+    "definitionCount": 1022
   },
   "overview": {
     "historicalContext": "Kenneth Wilson introduced lattice gauge theory in 1974, providing the first non-perturbative definition of Yang-Mills theory and earning the 1982 Nobel Prize in Physics. By discretizing spacetime into a hypercubic lattice and placing gauge group elements $U_\\ell \\in G$ on links (edges), Wilson showed that gauge invariance is exact on the lattice — not an approximate symmetry that must be recovered in a limit, but an exact property of the discretized theory. Wilson's key insight was that confinement (area law for Wilson loops) emerges naturally in the strong coupling regime: at large $g^2$, the lattice path integral is dominated by disordered configurations that produce area-law decay $\\langle W(C) \\rangle \\sim e^{-\\sigma A}$ with positive string tension $\\sigma$. This framework enabled Michael Creutz's pioneering Monte Carlo simulations (1980), which provided the first numerical evidence for confinement in SU(2) and SU(3) gauge theories. Today, lattice QCD is the standard tool for non-perturbative calculations in the Standard Model — hadronic spectra, decay constants, and form factors computed on the lattice agree with experiment to percent-level precision. The Clay Millennium Prize problem asks whether the continuum limit ($a \\to 0$) of lattice Yang-Mills exists rigorously and exhibits a mass gap, connecting Wilson's practical framework to fundamental questions in mathematical physics.",
@@ -153,7 +153,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "definitionCount": 641,
+    "definitionCount": 1022,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -38,7 +38,7 @@
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "theoremCount": 1787,
-    "definitionCount": 641
+    "definitionCount": 1022
   },
   "overview": {
     "historicalContext": "The transfer matrix method was introduced to lattice gauge theory by Wilson (1974) and developed into a rigorous tool by Osterwalder and Seiler (1978) and Creutz (1983). The key insight is that the Euclidean lattice partition function $Z = \\operatorname{Tr}(T^{N_t})$ connects to Hamiltonian quantum mechanics through the Perron-Frobenius theorem: the transfer matrix $T$ is a strictly positive operator, so it has a unique largest eigenvalue $\\lambda_0$ (the vacuum) with a spectral gap to $\\lambda_1$ (the first excited state). Kogut and Susskind (1975) established the Hamiltonian formulation, decomposing $T = T_E^{1/2} T_B T_E^{1/2}$ into electric (kinetic) and magnetic (potential) parts. Glimm and Jaffe (1987) placed the mass gap extraction on firm mathematical footing in their constructive QFT framework. The finite-volume mass gap is a theorem for any coupling; the Clay Millennium Prize asks whether it persists in the continuum and infinite-volume limits.",
@@ -143,7 +143,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "definitionCount": 641,
+    "definitionCount": 1022,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"


### PR DESCRIPTION
## Summary

Re-counts `definitionCount` for 10 gallery entries spanning 6 unique main files. All entries under-claimed; brings `meta.definitionCount` and `leanFile.definitionCount` into sync with source.

## Drift table

| Slug | File | Claimed → Actual |
|------|------|------------------|
| birch-swinnerton-dyer | BirchSwinnertonDyer.lean | 164 → 261 |
| hodge-conjecture | HodgeConjecture.lean | 89 → 192 |
| law-of-cosines-oq-01-oq-05 | LawOfCosinesOQ05.lean | 2 → 3 |
| navier-stokes-existence | NavierStokes.lean | 100 → 362 |
| navier-stokes-oq-01 | NavierStokes.lean | 100 → 362 |
| navier-stokes-oq-02 | NavierStokes.lean | 100 → 362 |
| poincare-conjecture | PoincareConjecture.lean | 382 → 596 |
| yang-mills-2d | YangMills/Exploration.lean | 641 → 1022 |
| yang-mills-lattice | YangMills/Exploration.lean | 641 → 1022 |
| yang-mills-transfer-matrix | YangMills/Exploration.lean | 641 → 1022 |

## Convention

Per `feedback_mechanic_def_counting.md`: count `def+abbrev+opaque+structure+inductive+class` (NOT `instance`) with `private/protected/scoped/noncomputable/unsafe/partial` modifiers, after stripping nested block comments and line comments.

For BSD example: 261 = 92 structures + 143 defs + 21 opaques + 5 inductives. All 261 declaration names unique (no double-counting). No `@[...]`-attribute prefixed declarations missed.

## Test plan

- [x] Surgical 2-line diffs (string `.replace()`, no JSON reformatting)
- [x] All 10 files re-parse as valid JSON
- [x] No overlap with open mechanic PRs (#17588, #17589, #17591, #17603 — different slugs)
- [x] No test impact (data-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)