### PR TITLE
research(erdos-1151-oq-04): S31 — chebyshevInterp linear helpers (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -151,6 +151,34 @@ theorem chebyshevInterp_smul (n : ℕ) (c : ℝ) (f : ℝ → ℝ) (x : ℝ) :
   simp_rw [mul_assoc]
   exact (Finset.mul_sum _ _ _).symm
 
+/-- Chebyshev interpolation of the zero function is zero.
+
+    Useful when packaging `chebyshevInterp n · x` as a linear functional
+    `C[-1,1] →L[ℝ] ℝ` (S31 UBP closure prep). -/
+theorem chebyshevInterp_zero_fn (n : ℕ) (x : ℝ) :
+    chebyshevInterp n (fun _ : ℝ => 0) x = 0 := by
+  simp only [chebyshevInterp, lagrangeInterp, zero_mul, Finset.sum_const_zero]
+
+/-- Chebyshev interpolation negates with the negated function.
+
+    Composes `chebyshevInterp_smul` with `c := -1`. Useful for the
+    operator-norm packaging in S31 (UBP closure prep). -/
+theorem chebyshevInterp_neg (n : ℕ) (f : ℝ → ℝ) (x : ℝ) :
+    chebyshevInterp n (fun t => -f t) x = -chebyshevInterp n f x := by
+  simp only [chebyshevInterp, lagrangeInterp, neg_mul, Finset.sum_neg_distrib]
+
+/-- Chebyshev interpolation distributes over subtraction.
+
+    Mirrors `chebyshevInterp_add` with `Finset.sum_sub_distrib` in place
+    of `Finset.sum_add_distrib`. Useful for the linear-functional
+    packaging in S31 (UBP closure prep). -/
+theorem chebyshevInterp_sub (n : ℕ) (f g : ℝ → ℝ) (x : ℝ) :
+    chebyshevInterp n (fun t => f t - g t) x =
+    chebyshevInterp n f x - chebyshevInterp n g x := by
+  simp only [chebyshevInterp, lagrangeInterp]
+  simp_rw [sub_mul]
+  exact Finset.sum_sub_distrib
+
 /-! ## Proved Results: Chebyshev Polynomial Connection -/
 
 /-- **Chebyshev identity**: Tₙ(cos θ) = cos(nθ). -/

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,8 +4,137 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 29
+**Iteration**: 31
 **Last Updated**: 2026-05-09
+
+## Session 31 (researcher-13, 2026-05-09, build pending) — linear-functional helpers
+
+**Three small new theorems** added immediately after the existing
+`chebyshevInterp_smul` (line 152 on origin/main), as infrastructure for the
+future `ContinuousLinearMap` packaging in the UBP closure of
+`divergence_from_lebesgue_growth`:
+
+```lean
+theorem chebyshevInterp_zero_fn (n : ℕ) (x : ℝ) :
+    chebyshevInterp n (fun _ : ℝ => 0) x = 0
+
+theorem chebyshevInterp_neg (n : ℕ) (f : ℝ → ℝ) (x : ℝ) :
+    chebyshevInterp n (fun t => -f t) x = -chebyshevInterp n f x
+
+theorem chebyshevInterp_sub (n : ℕ) (f g : ℝ → ℝ) (x : ℝ) :
+    chebyshevInterp n (fun t => f t - g t) x =
+    chebyshevInterp n f x - chebyshevInterp n g x
+```
+
+**Proofs.** Mirror the existing `chebyshevInterp_add` template line-by-line:
+
+  • `_zero_fn`: `simp only [chebyshevInterp, lagrangeInterp, zero_mul,
+    Finset.sum_const_zero]`.
+  • `_neg`: `simp only [chebyshevInterp, lagrangeInterp, neg_mul,
+    Finset.sum_neg_distrib]`.
+  • `_sub`: `simp only [chebyshevInterp, lagrangeInterp]; simp_rw [sub_mul];
+    exact Finset.sum_sub_distrib`.
+
+All three are mechanical 1-line `simp` proofs, cross-checked against
+existing usages of `Finset.sum_sub_distrib` (in `BinomialTheoremOQ02OQ01OQ03`,
+`CauchySchwarzOQ03`) and `Finset.sum_neg_distrib` (in `ArithmeticSeriesOQ02OQ03`)
+to confirm Mathlib API names.
+
+**Why these specifically** (foundation for the post-S30 UBP closure):
+
+1. **Linearity over ℝ-vector-spaces**: `(fun t => f t - g t)` and
+   `(fun t => -f t)` appear pervasively in operator-norm bounds. The
+   `ContinuousLinearMap.opNorm_le_iff` recipe uses
+   `‖A (f - g)‖ ≤ M · ‖f - g‖`; without `chebyshevInterp_sub` and
+   `chebyshevInterp_neg`, every operator-norm calculation needs an inline
+   `simp_rw [sub_mul]; rw [Finset.sum_sub_distrib]` boilerplate.
+
+2. **Zero baseline for `Λₙ_x`**: A `LinearMap` from `C[-1,1] → ℝ` requires a
+   `map_zero'` field; `chebyshevInterp_zero_fn` is exactly that field's
+   witness (composed with the trivial extension of `0 : C[-1,1]` to
+   `0 : ℝ → ℝ`).
+
+3. **Independence from S30 (PR #17593, in flight)**: S30 modifies the
+   trailing two theorems (`divergence_from_lebesgue_growth` and
+   `erdos_1941_divergence_from_growth`) at lines 2535–2606 to refactor
+   Sorry 2's conclusion to the unboundedness form. This PR appends helpers
+   immediately after `chebyshevInterp_smul` (line 152) — over 2300 lines
+   away — so the two PRs are textually disjoint and can both land cleanly.
+
+4. **Independence from open S25 PRs (#17386, #17457)**: those modify the
+   `trig_sum_harmonic_lb` area (line ~2300+); the two PRs are similarly
+   disjoint.
+
+**Net new content**: +3 theorems, 0 definitions, 0 axioms, 0 sorries.
+**Updated total**: 65 theorems, 5 definitions, 0 axioms, 1 sorry, 2589
+lines (was 62/5/0/1/2561 on origin/main; the S30 PR will add ~49 statement-
+doc lines on top of that, but in a different file region).
+
+**Mathlib API surface**: zero new lemmas. Only standard simp-set members
+(`zero_mul`, `Finset.sum_const_zero`, `neg_mul`, `Finset.sum_neg_distrib`,
+`sub_mul`, `Finset.sum_sub_distrib`).
+
+**Build status**: build pending. These three lemmas are 1-line `simp`-style
+proofs over a build-verified template (`chebyshevInterp_add`). Build risk
+is minimal — the only failure mode is Mathlib API drift (e.g. if
+`Finset.sum_sub_distrib` were renamed). Verified usage in two independent
+recent files on `origin/main`; the names are stable.
+
+## Sharpening of the Plan for S32+ (UBP Closure of `divergence_from_lebesgue_growth`)
+
+Once S30 (PR #17593, statement refactor) and S31 (this PR, linear helpers)
+both land, the UBP closure outline is:
+
+  1. **Define `Λₙ_x` as a `ContinuousLinearMap`** (~30–40 lines).
+     Build the bounded-linear-functional `Λₙ_x : C(Set.Icc (-1) 1, ℝ) →L[ℝ] ℝ`,
+     `f ↦ chebyshevInterp n (extension f) x`, where
+     `extension : C(Icc (-1) 1) → (ℝ → ℝ)` extends by the convention
+     `f(t) = f(clip t (-1, 1))` (or zero outside — since the interpolation
+     only sees `f` at the Chebyshev nodes
+     `Set.Icc (-1) 1 ⊃ chebyshevNode n`, both work).
+     Linearity: `chebyshevInterp_add` (existing), `chebyshevInterp_smul`
+     (existing), `chebyshevInterp_zero_fn` / `chebyshevInterp_neg` /
+     `chebyshevInterp_sub` (this PR, S31).
+     Continuity: `chebyshev_upper_bound` (existing) gives the operator-norm
+     bound `‖Λₙ_x f‖ ≤ chebyshevLebesgue n x · ‖f‖_∞`; pack as a
+     `ContinuousLinearMap` via `LinearMap.mkContinuous`.
+
+  2. **Operator-norm equality** (~50–80 lines).
+     Upper bound `‖Λₙ_x‖ ≤ chebyshevLebesgue n x` is direct from step 1's
+     bound. Lower bound (saturation): construct a witness `f₀ : C[-1,1]`
+     with `‖f₀‖_∞ ≤ 1` and `f₀(node_k) = sign(basis_k(x))`; then
+     `Λₙ_x f₀ = ∑_k sign(basis_k(x)) · basis_k(x) = ∑_k |basis_k(x)|
+     = chebyshevLebesgue n x`. Construction: piecewise-linear interpolation
+     between consecutive nodes, or Tietze extension from the finite set
+     `{node_k}`.
+
+  3. **UBP contrapositive** (~10–20 lines). The hypothesis
+     `Filter.Tendsto Λₙ_x atTop atTop` (from S30's refactor: equivalently
+     "norms unbounded") together with
+     `Mathlib.Analysis.NormedSpace.BanachSteinhaus.banach_steinhaus_iff`
+     gives `∃ f : C[-1,1], ¬ Bounded {Λₙ_x f | n}`, i.e.
+     `∃ f, ∀ M, ∃ n, M < |chebyshevInterp n (extension f) x|`. Extending
+     `f` to `ℝ → ℝ` preserves the values at the nodes, hence the conclusion
+     of `divergence_from_lebesgue_growth`.
+
+  4. **Glue** (~5 lines).
+
+Estimated S32–S35 sizes total: ~110–150 lines split into 3–4 PRs.
+
+## Session 30 (researcher-1, 2026-05-09, in flight as PR #17593) — Sorry 2 statement refactor
+
+**Refactors `divergence_from_lebesgue_growth` and the corollary
+`erdos_1941_divergence_from_growth`** from the strictly-stronger
+`Filter.Tendsto … atTop atTop` form to the unboundedness form
+
+```
+∃ f : ℝ → ℝ, Continuous f ∧ ∀ M : ℝ, ∃ n : ℕ, M < |chebyshevInterp n f x|
+```
+
+aligning the conclusion with what Banach–Steinhaus / UBP actually delivers
+(see prior `state.md` "Next Steps" section 2 Option A). Net file change:
+2561 → 2610 lines (statement-doc expansion). Build pending. PR remains
+open at time of S31 (this session).
 
 ## Session 29 (researcher-11, this session, build pending)
 

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "IN-PROGRESS",
-    "since": "2026-05-09",
-    "iteration": 29,
-    "focus": "Session 29 (researcher-11, 2026-05-09, build pending): CLOSED trig_sum_harmonic_lb (~38 lines). Composes S28 (trig_sum_harmonic_lb_asymp, asymp side) with S22 (trig_sum_small_n_const, finite-set side) via min-of-two-constants split. With C := min C₁ C₂ and N := max N₀ 1, case-splits on n ≤ N: small branch uses hsmall (1 ≤ n ≤ N), large branch uses hlarge (N₀ ≤ N < n). Sidesteps the in-flight S25 combine helper PRs #17386 (DIRTY) and #17457 (CONFLICTING) — those become obsolete since the combine logic is now inlined here. File goes 2 → 1 sorries; only divergence_from_lebesgue_growth (separate sorry, lacunary series construction) remains.",
+    "since": "2026-05-09T03:30:00Z",
+    "iteration": 31,
+    "focus": "Session 31 (researcher-13, 2026-05-09, build pending): added 3 small linear-functional helper theorems (chebyshevInterp_zero_fn, chebyshevInterp_neg, chebyshevInterp_sub) immediately after the existing chebyshevInterp_smul lemma. These are infrastructure for the future ContinuousLinearMap packaging that the S31+ UBP closure of divergence_from_lebesgue_growth will need (operator-norm functional Λₙ_x : C[-1,1] →L[ℝ] ℝ requires linearity of evaluation). Mirror chebyshevInterp_add line-by-line with sub_mul/Finset.sum_sub_distrib. Net new: 3 theorems, 0 axioms, 0 sorries. Total: 65 theorems, 1 sorry, 2589 lines (was 62/1/2561).",
     "blockers": [],
-    "nextAction": "(Researcher) Close divergence_from_lebesgue_growth — final sorry in file. Requires lacunary series construction or weakening to lim sup variant. PRs #17386 and #17457 become obsolete once #S29 merges (combine helper inlined into trig_sum_harmonic_lb).",
+    "nextAction": "(Researcher) S32 onwards: build the ContinuousLinearMap Λₙ_x : C(Set.Icc (-1) 1, ℝ) →L[ℝ] ℝ, f ↦ chebyshevInterp n (extension f) x using the new linear helpers (S31 = this PR). Then prove ‖Λₙ_x‖ ≤ chebyshevLebesgue n x (upper, from existing chebyshev_upper_bound) and ‖Λₙ_x‖ = chebyshevLebesgue n x (saturation via sign-pattern witness + Tietze). Apply Banach–Steinhaus contrapositive to discharge divergence_from_lebesgue_growth (under S30's refactored unboundedness conclusion, PR #17593).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2561,
-      "theoremCount": 62,
+      "lineCount": 2589,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary

Add three small linear-functional helpers in \`proofs/Proofs/Erdos1151OQ04.lean\`, immediately after the existing \`chebyshevInterp_smul\` (line 152 on origin/main):

\`\`\`lean
theorem chebyshevInterp_zero_fn (n : ℕ) (x : ℝ) :
    chebyshevInterp n (fun _ : ℝ => 0) x = 0

theorem chebyshevInterp_neg (n : ℕ) (f : ℝ → ℝ) (x : ℝ) :
    chebyshevInterp n (fun t => -f t) x = -chebyshevInterp n f x

theorem chebyshevInterp_sub (n : ℕ) (f g : ℝ → ℝ) (x : ℝ) :
    chebyshevInterp n (fun t => f t - g t) x =
    chebyshevInterp n f x - chebyshevInterp n g x
\`\`\`

These are infrastructure for the future \`ContinuousLinearMap\` packaging in the UBP closure of \`divergence_from_lebesgue_growth\` (the file's remaining Sorry 2) — once S30's statement refactor (PR #17593) lands. The packaging needs \`map_zero'\`, \`map_neg\`, and \`map_sub\` to declare \`Λₙ_x\` as a \`LinearMap\`, which \`chebyshevInterp_smul\` and \`chebyshevInterp_add\` alone don't directly supply.

## Proofs

Mirror the existing \`chebyshevInterp_add\` template line-by-line:

| Theorem | Proof |
| ------- | ----- |
| \`_zero_fn\` | \`simp only [chebyshevInterp, lagrangeInterp, zero_mul, Finset.sum_const_zero]\` |
| \`_neg\` | \`simp only [chebyshevInterp, lagrangeInterp, neg_mul, Finset.sum_neg_distrib]\` |
| \`_sub\` | \`simp only [...]; simp_rw [sub_mul]; exact Finset.sum_sub_distrib\` |

API names cross-checked on origin/main:

- \`Finset.sum_neg_distrib\` used in \`ArithmeticSeriesOQ02OQ03.lean\`
- \`Finset.sum_sub_distrib\` used in \`BinomialTheoremOQ02OQ01OQ03.lean\` and \`CauchySchwarzOQ03.lean\`.

## Net New Content

- 0 definitions, **+3 theorems**, 0 axioms, 0 sorries.
- Updated total: **65 theorems, 5 definitions, 0 axioms, 1 sorry, 2589 lines** (was 62/5/0/1/2561 on origin/main).

## Independence from Open PRs

| PR | Area | Conflict? |
| -- | ---- | --------- |
| #17593 (S30 statement refactor) | lines 2535–2606 | No (this PR ~ line 152) |
| #17386 (S23 combine helper) | lines ~2300+ | No (and obsoleted by S29) |
| #17457 (S25 combine replay) | lines ~2300+ | No (and obsoleted by S29) |

This PR appends helpers near line 152 — over 2300 lines away from the others. No textual conflict.

## Build Status

**Build pending.** The three lemmas are 1-line \`simp\` proofs over the build-verified \`chebyshevInterp_add\` template; the only failure mode is Mathlib API drift (the \`Finset.sum_*_distrib\` naming) which I cross-checked is stable in \`origin/main\`.

## Why these specifically (foundation for the post-S30 UBP closure)

1. **Linearity over ℝ-vector-spaces**: \`(fun t => f t - g t)\` and \`(fun t => -f t)\` appear pervasively in operator-norm bounds. The \`ContinuousLinearMap.opNorm_le_iff\` recipe uses \`‖A (f - g)‖ ≤ M · ‖f - g‖\`; without \`chebyshevInterp_sub\` and \`chebyshevInterp_neg\`, every operator-norm calculation needs an inline \`simp_rw [sub_mul]; rw [Finset.sum_sub_distrib]\` boilerplate.
2. **Zero baseline for \`Λₙ_x\`**: A \`LinearMap\` from \`C[-1,1] → ℝ\` requires a \`map_zero'\` field; \`chebyshevInterp_zero_fn\` is exactly that field's witness.
3. **Independent from S30** (which refactors the conclusion form of Sorry 2 — different file region).

## Sharpening of the Plan for S32+ (UBP Closure)

Once S30 (statement refactor) and S31 (this PR) both land, S32+ outline:

1. Define \`Λₙ_x : C(Set.Icc (-1) 1, ℝ) →L[ℝ] ℝ\` as a \`ContinuousLinearMap\` (~30–40 lines) using \`chebyshevInterp_add\`/\`_smul\`/\`_zero_fn\`/\`_neg\`/\`_sub\` for linearity and \`chebyshev_upper_bound\` for continuity.
2. Operator-norm equality \`‖Λₙ_x‖ = chebyshevLebesgue n x\` (~50–80 lines): upper from step 1; lower (saturation) via piecewise-linear sign-pattern witness.
3. UBP contrapositive (~10–20 lines) via \`Mathlib.Analysis.NormedSpace.BanachSteinhaus.banach_steinhaus_iff\`.
4. Glue (~5 lines) — closes Sorry 2 under S30's refactored conclusion.

## Test plan

- [ ] \`./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04\` — Auditor/Mechanic verify on a refreshed cache.
- [ ] Spot-check linear-helper invocations by S32+ ContinuousLinearMap packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)