### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 sorry/lineCount drift

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact",
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 517,
+    "lineCount": 668,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -202,12 +202,12 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 517,
+    "lineCount": 668,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "references": [
     {
@@ -239,5 +239,5 @@
       "leanType": "Combination of Brouwer's FPT and approximate selections; the limit argument is encapsulated in approx_fixedpoint_implies_fixedpoint."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Auditor-detected drift in `schauder-fixed-point-oq-03-oq-01/meta.json`:

- **sorries**: claimed 2, actual 1 (in 3 places: top-level, `meta.sorries`, `leanFile.sorries`)
- **lineCount**: claimed 517, actual 668 (in 2 places: `meta.lineCount`, `leanFile.lineCount`)

## Why now

The S11.A.body for `theorem brouwer_fpt` landed in PR (S13, 2026-05-09), reducing the sorry count from 2 to 1. Only the helper `exists_continuous_proj_convex` (S11.B work item) remains sorry-stubbed at line 130. The Lean file grew to 668 lines during the landing.

## Verification

```bash
# Sorry count (excluding comments)
$ python3 -c "..." # See PR commit message for full script
Sorry count (excluding comments): 1
  line ~130

# Line count
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
     668
```

Status remains `axiomatized` (2 axioms unchanged: `brouwer_unit_ball`, `approx_selection_exists`). Badge `axiom` correct.

## Test plan
- [x] Validate JSON parses (verified in commit script)
- [x] Confirm `sorries`/`lineCount` fields match Lean source
- [x] No other meta drift in this file (axioms 2, theorems 5, defs 4 all match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)