### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S15 — Part XXII Bertrand-window packaging + hyp-form variants (build pending)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -1163,6 +1163,82 @@ theorem largestPrimeBelow_ten_eq_eight :
   rw [hmax] at hk2
   exact no_prime_in_eight_to_ten k hk1 hk2
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XXII: Bertrand-window packaging + missing hypothesis-form variants
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-! ### Hypothesis-form bridge for the conjecture
+
+`ConjectureLPB` (PART XV) is definitionally the universal closure of the
+file's axiom `symBUDim_eq_largestPrime`. The bridge lemma
+`symBUDim_eq_largestPrime_of` lets a `ConjectureLPB` hypothesis stand in
+for the axiom in any rewrite. Trivial proof, but it is the canonical
+hypothesis-form base for downstream developments that want to track
+conjecture-dependence at the type level. -/
+
+/-- **Hypothesis-form bridge** for the conjecture: under `ConjectureLPB`,
+    the file's axiom statement holds. One-liner via the `Prop`
+    definition. -/
+theorem symBUDim_eq_largestPrime_of (h : ConjectureLPB) (n d : ℕ)
+    (hn : 2 ≤ n) :
+    symBUDim n d = buDim (largestPrimeBelow n) d :=
+  h n d hn
+
+/-! ### Hypothesis-form variants of older closed-form theorems
+
+Mirrors of `symBUDim_even_formula` (PART III) and `symBUDim_prime_even_formula`
+(PART VIII) that take `ConjectureLPB` as a hypothesis instead of relying on
+the file's axiom. Same statements, but conjecture-dependence is explicit. -/
+
+/-- **Hypothesis-form** of `symBUDim_even_formula` (PART III): under
+    `ConjectureLPB`, `symBUDim n (2 * k) = 2 * k - 1` for n ≥ 2 and k ≥ 1. -/
+theorem symBUDim_even_formula_of (h : ConjectureLPB) (n k : ℕ)
+    (hn : 2 ≤ n) (hk : 0 < k) :
+    symBUDim n (2 * k) = 2 * k - 1 := by
+  rw [symBUDim_eq_largestPrime_of h n (2 * k) hn]
+  exact buDim_prime (largestPrimeBelow n) k
+    (largestPrimeBelow_isPrime n hn) hk
+
+/-- **Hypothesis-form** of `symBUDim_prime_even_formula` (PART VIII): under
+    `ConjectureLPB`, at any prime p with k ≥ 1, `symBUDim p (2 * k) = 2 * k - 1`. -/
+theorem symBUDim_prime_even_formula_of (h : ConjectureLPB) (p k : ℕ)
+    (hp : Nat.Prime p) (hk : 0 < k) :
+    symBUDim p (2 * k) = 2 * k - 1 := by
+  rw [symBUDim_eq_buDim_at_prime_of h p (2 * k) hp]
+  exact buDim_prime p k hp hk
+
+/-! ### Bertrand-window packaging of the conjecture
+
+The conjecture pins `symBUDim n d = buDim (largestPrimeBelow n) d`. The
+Bertrand-Chebyshev bound `n / 2 < largestPrimeBelow n ≤ n` (PART VI)
+constrains `largestPrimeBelow n` to the dyadic window `(n/2, n]`.
+Combining the two yields a packaged form of the conjecture's prediction
+that **does not reference `largestPrimeBelow` at all**: `symBUDim n d =
+buDim p d` for *some* prime `p` in `(n/2, n]`. The internal selector
+`largestPrimeBelow` is hidden behind an existential — useful for
+downstream applications that want to think of the prediction as a
+"there exists a Bertrand-window prime" statement rather than a
+"the largest prime ≤ n" statement. -/
+
+/-- **Bertrand-window packaging of the conjecture** (uses file's axiom):
+    for n ≥ 2 and any d, there exists a prime `p` in the Bertrand window
+    `(n/2, n]` with `symBUDim n d = buDim p d`. The witness is
+    `largestPrimeBelow n`; the existential hides the internal selector. -/
+theorem symBUDim_eq_buDim_in_bertrand_window (n d : ℕ) (hn : 2 ≤ n) :
+    ∃ p : ℕ, Nat.Prime p ∧ n / 2 < p ∧ p ≤ n ∧ symBUDim n d = buDim p d :=
+  ⟨largestPrimeBelow n, largestPrimeBelow_isPrime n hn,
+    n_div_two_lt_largestPrimeBelow n hn, largestPrimeBelow_le n,
+    symBUDim_eq_largestPrime n d hn⟩
+
+/-- **Hypothesis-form** of `symBUDim_eq_buDim_in_bertrand_window`: under
+    `ConjectureLPB`, the same packaged Bertrand-window prediction holds. -/
+theorem symBUDim_eq_buDim_in_bertrand_window_of (h : ConjectureLPB)
+    (n d : ℕ) (hn : 2 ≤ n) :
+    ∃ p : ℕ, Nat.Prime p ∧ n / 2 < p ∧ p ≤ n ∧ symBUDim n d = buDim p d :=
+  ⟨largestPrimeBelow n, largestPrimeBelow_isPrime n hn,
+    n_div_two_lt_largestPrimeBelow n hn, largestPrimeBelow_le n,
+    h n d hn⟩
+
 /-
 ## Summary
 
@@ -1482,4 +1558,10 @@ theorem largestPrimeBelow_ten_eq_eight :
 #check @symBUDim_const_in_unordered_no_prime_range
 #check @symBUDim_const_in_unordered_no_prime_range_of
 #check @largestPrimeBelow_ten_eq_eight
+
+#check @symBUDim_eq_largestPrime_of
+#check @symBUDim_even_formula_of
+#check @symBUDim_prime_even_formula_of
+#check @symBUDim_eq_buDim_in_bertrand_window
+#check @symBUDim_eq_buDim_in_bertrand_window_of
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-09T02:30:00Z
-**Iteration**: 14
+**Since**: 2026-05-09T03:30:00Z
+**Iteration**: 15
 
 ## Current Focus
 
@@ -662,3 +662,95 @@ CI is the ground truth.
    pairs (`{8, 10}`, `{13, 16}`, `{23, 28}`, `{89, 96}`) to package
    each Part XVII–XVIII plateau as an unordered-pair statement. Likely
    incremental; gauge value before committing.
+
+## Iteration 15 Builds (researcher-5, 2026-05-09)
+
+Focus: **fill in missing hypothesis-form variants** of foundational
+axiom-using closed-form theorems, **plus a Bertrand-window packaging**
+of the conjecture's prediction. The packaging hides the internal
+selector `largestPrimeBelow` behind an existential, restating the
+conjecture's prediction as "there exists a Bertrand-window prime"
+rather than "the largest prime ≤ n".
+
+### Part XXII additions (axiom-free hypothesis-form bridge)
+
+- `symBUDim_eq_largestPrime_of` (axiom-free under hypothesis): the
+  hypothesis-form base bridge. Under `ConjectureLPB` (PART XV's
+  `Prop`-form of the file's axiom), `symBUDim n d = buDim
+  (largestPrimeBelow n) d` for n ≥ 2. One-liner via the `Prop`
+  definition.  Despite `ConjectureLPB` having existed since iter 9,
+  this canonical bridge was never explicitly written; downstream code
+  using `ConjectureLPB` had to manually unfold the definition.
+
+### Part XXII additions (hypothesis-form variants of older closed forms)
+
+- `symBUDim_even_formula_of` (hypothesis form of PART III): under
+  `ConjectureLPB`, `symBUDim n (2 * k) = 2 * k - 1` for n ≥ 2 and
+  k ≥ 1. Mirrors `symBUDim_even_formula` (which uses the file's
+  axiom). Two-line proof via `symBUDim_eq_largestPrime_of` plus parent's
+  `buDim_prime`.
+- `symBUDim_prime_even_formula_of` (hypothesis form of PART VIII): under
+  `ConjectureLPB`, at any prime p with k ≥ 1, `symBUDim p (2 * k) =
+  2 * k - 1`. Mirrors `symBUDim_prime_even_formula`. Two-line proof
+  via `symBUDim_eq_buDim_at_prime_of` plus parent's `buDim_prime`.
+
+### Part XXII additions (Bertrand-window packaging of the conjecture)
+
+- `symBUDim_eq_buDim_in_bertrand_window` (uses file's axiom): for n ≥ 2
+  and any d, **there exists a prime p in the Bertrand window (n/2, n]**
+  with `symBUDim n d = buDim p d`. The witness is `largestPrimeBelow n`;
+  the existential hides the internal selector. Combines the file's axiom
+  with PART VI's Bertrand-Chebyshev bound `n_div_two_lt_largestPrimeBelow`
+  + `largestPrimeBelow_le`.
+- `symBUDim_eq_buDim_in_bertrand_window_of` (hypothesis form): same
+  packaged statement under `ConjectureLPB`.
+
+**Counts**: lineCount 1485 → 1567 (+82), theoremCount 93 → 98 (+5,
+substantive 91 → 96), definitionCount 2 (unchanged), axiomCount 1
+(unchanged), sorries 0 (unchanged).
+
+**Significance**: the Bertrand-window packaging is the cleanest
+"selector-free" form of the conjecture's prediction. PART VI's
+Bertrand bound shows `largestPrimeBelow n ∈ (n/2, n]` regardless of
+how composite n is. Under the conjecture, then, `symBUDim n d` equals
+`buDim p d` for *some* prime p in this dyadic window — independent of
+how large n is, p never falls below n/2. This is the "scale-invariant
+prediction" form of the conjecture: the prime witness lives in a
+window whose width grows with n but never shrinks below the dyadic
+floor. The hypothesis-form variants make conjecture-dependence
+trackable at the type level for downstream developments.
+
+The hypothesis-form bridge `symBUDim_eq_largestPrime_of` and the two
+older-theorem hypothesis variants close gaps in the iter-9
+hypothesis-form layer: that iteration introduced `ConjectureLPB` and
+hypothesis-form variants of *some* axiom-using theorems
+(`symBUDim_eq_buDim_at_prime_of`, `buDim_largestPrime_lower_z2_of`,
+`buDim_prime_lower_z2_of`) but left several core PART III/VIII
+closed forms only in axiom-using form. PART XXII completes this layer.
+
+**Build**: pending (Docker rebuild from fresh Mathlib cache —
+worktree's proofs/.lake recursive self-symlink forces ≥45-min cold-cache
+builds per `feedback_researcher_lake_symlink_broken.md`). All new
+content reuses only in-file infrastructure exercised by earlier
+iterations (`largestPrimeBelow_isPrime`, `n_div_two_lt_largestPrimeBelow`,
+`largestPrimeBelow_le`, `buDim_prime` from parent, `ConjectureLPB`,
+`symBUDim_eq_largestPrime`, `symBUDim_eq_buDim_at_prime_of`); the
+proof-side risk is minimal. CI is the ground truth.
+
+**Path forward** (revised post-iter-15):
+1. **symBUDim-side biconditional** (still pending, unchanged from
+   iter 14): characterize when `symBUDim n d = symBUDim m d` for
+   *all* `d` in terms of the no-prime-in-range condition. Forward
+   direction is now `symBUDim_const_in_unordered_no_prime_range`; the
+   reverse direction needs `symBUDim_cyc` injectivity-across-primes
+   which is not currently axiomatized.
+2. **Bertrand-window monotonicity packaging** (new follow-up): under
+   the conjecture, `symBUDim n d` only depends on a prime *somewhere*
+   in `(n/2, n]`. As n grows the windows shift but are never disjoint
+   from each other, so `largestPrimeBelow` is monotone (already proved
+   in iter 6). A clean packaging would express the
+   "monotone-in-the-Bertrand-window" form as a one-step corollary.
+3. Stretch (unchanged): n=3 case directly via `symBUDim_three`-style
+   axiom, or n=4 case via Klein-4 V₄ ≤ S₄ structure.
+4. Stretch (unchanged): falsification target `buDim 3 3` via
+   equivariant cohomology of Z/3 on simple S²-actions.

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1485,
+    "lineCount": 1567,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -114,7 +114,7 @@
       "largestPrimeBelow_eight_lt_eleven, _thirteen_lt_seventeen, _twentythree_lt_twentynine, _eightynine_lt_ninetyseven (axiom-free, iter 13): plateau-edge witnesses at the four prime-gap intervals from Parts XVII–XVIII. Together with the corresponding eq-instances, pin each plateau as a *maximal* level set of `largestPrimeBelow` rather than a possibly-extendable cluster."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d ≥ 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d − 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d − 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 93,
+    "theoremCount": 98,
     "definitionCount": 2
   },
   "overview": {
@@ -307,10 +307,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1485,
+    "lineCount": 1567,
     "axiomCount": 1,
-    "theoremCount": 93,
-    "substantiveTheoremCount": 91,
+    "theoremCount": 98,
+    "substantiveTheoremCount": 96,
     "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iter 15 of the symmetric-group Borsuk-Ulam OQ. Adds **Part XXII** — three groups of additions:

1. **Hypothesis-form bridge** (axiom-free under hypothesis):
   - `symBUDim_eq_largestPrime_of` — canonical hypothesis-form base for `ConjectureLPB`. Despite `ConjectureLPB` existing since iter 9, this bridge was never explicitly written; downstream code using `ConjectureLPB` had to manually unfold the definition.

2. **Hypothesis-form variants of older closed-form theorems**:
   - `symBUDim_even_formula_of` — Part III's even-d closed form, hyp form.
   - `symBUDim_prime_even_formula_of` — Part VIII's at-prime even-d closed form, hyp form.

3. **Bertrand-window packaging of the conjecture** (NEW content):
   - `symBUDim_eq_buDim_in_bertrand_window` — under the file's axiom, for n ≥ 2 and any d, **there exists a prime p in the Bertrand window (n/2, n]** with `symBUDim n d = buDim p d`. The witness is `largestPrimeBelow n`; the existential hides the internal selector.
   - `symBUDim_eq_buDim_in_bertrand_window_of` — hypothesis form.

The Bertrand-window packaging restates the conjecture's prediction in "there exists a Bertrand-window prime" form rather than "the largest prime ≤ n" form. Scale-invariant in the sense that the witness window `(n/2, n]` never shrinks below the dyadic floor as n grows.

## Theorems added (5 new)

| Name | Form | Proof shape |
|---|---|---|
| `symBUDim_eq_largestPrime_of` | hyp | one-line via `ConjectureLPB` |
| `symBUDim_even_formula_of` | hyp | rewrite + `buDim_prime` |
| `symBUDim_prime_even_formula_of` | hyp | rewrite + `buDim_prime` |
| `symBUDim_eq_buDim_in_bertrand_window` | uses axiom | refine ⟨lpb n, …⟩ |
| `symBUDim_eq_buDim_in_bertrand_window_of` | hyp | refine ⟨lpb n, …⟩ |

## Counts

| Field | Before | After | Δ |
|---|---|---|---|
| lineCount | 1485 | 1567 | +82 |
| theoremCount | 93 | 98 | +5 |
| substantiveTheoremCount | 91 | 96 | +5 |
| definitionCount | 2 | 2 | 0 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

## Mathlib API surface

**Zero new Mathlib API.** All proofs are syntactic compositions of:

- `largestPrimeBelow_isPrime` (file)
- `n_div_two_lt_largestPrimeBelow` (file, PART VI Bertrand bound)
- `largestPrimeBelow_le` (file)
- `ConjectureLPB` (file, PART XV)
- `symBUDim_eq_largestPrime` (file's axiom)
- `symBUDim_eq_buDim_at_prime_of` (file, hyp form)
- `buDim_prime` (parent's axiom)

## Independence from other open PRs on this slug

This iteration adds a NEW Part XXII section after Part XX. Cleanly separable from the other open PRs:

| PR     | Section            | Risk vs this PR |
|--------|--------------------|-----------------|
| #17286 | adds Part XII/XIII | independent (different numerics) |
| #17460 | adds (7,11) Part XVII per-n  | independent (different lemmas) |
| #17592 | adds (13,17) Part XVII per-n | independent (different lemmas) |
| #17594 | adds Part XXI (gap-14)       | independent (different section #) |
| this   | adds Part XXII (Bertrand-window + _of) | — |

If #17594 (Part XXI) merges first, this PR remains as Part XXII (no change). If this merges first, Part XXII is unused; #17594 still adds Part XXI cleanly. The new theorem names are unique across all four PRs.

## Build status

**[BUILD UNVERIFIED]** — Standard caveat: worktree's `proofs/.lake` is a recursive self-symlink (per memory `feedback_researcher_lake_symlink_broken.md`), so local Docker builds re-fresh-clone Mathlib (~30–45 min cold). All new proofs are 1–4-line syntactic compositions of existing in-file lemmas + parent's `buDim_prime` axiom; the proof-side risk is minimal. CI is the ground truth.

## Test plan

- [ ] CI Docker build of `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` reaches end without new errors
- [ ] Sorries / axioms unchanged (0 / 1)
- [ ] meta.json `lineCount`/`theoremCount`/`substantiveTheoremCount` match `find-targets.ts` baseline post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)