### PR TITLE
fix(meta): schauder-fp-oq-03-oq-01 — sync sorries 2→1, lineCount 517→668

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact",
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 517,
+    "lineCount": 668,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -202,12 +202,12 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 517,
+    "lineCount": 668,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "references": [
     {
@@ -239,5 +239,5 @@
       "leanType": "Combination of Brouwer's FPT and approximate selections; the limit argument is encapsulated in approx_fixedpoint_implies_fixedpoint."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Drift fix

`src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` overstates
sorries and lineCount vs the actual Lean file
`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` on origin/main.

| Field | Claimed | Actual |
|-------|---------|--------|
| `meta.sorries` (and `leanFile.sorries`, top-level `sorries`) | 2 | **1** |
| `meta.lineCount` (and `leanFile.lineCount`) | 517 | **668** |

## Why 2→1, not 2→0

`brouwer_fpt`'s body landed in S13 (#17575). It is no longer top-level
sorry-stubbed but still calls the still-sorry-stubbed helper
`exists_continuous_proj_convex` (LOOKUP-2 / S11.B work item, line ~130).
So the file went from 2 sorries to 1 sorry — not 0.

The `originalContributions` and `assumptions` text (mentioning
"sorry-stubbed" for `brouwer_fpt`) is left untouched here; this PR is
narrowly scoped to count-field drift. A follow-up enrichment can
clarify the wording.

## Other count fields verified

- `axiomCount: 2` ✓ (matches `axiom brouwer_unit_ball` + `axiom approx_selection_exists`)
- `theoremCount: 5` ✓
- `definitionCount: 4` ✓

Discovered via `npx tsx scripts/auditor/find-targets.ts --issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)