### PR TITLE
fix(meta): schauder-fp-oq03-oq01 sync after S13 brouwer_fpt body merge

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact",
@@ -39,7 +39,7 @@
       "IsGraphApproxSelection: Definition of ε-graph-approximate continuous selections (Cellina–Browder form)",
       "brouwer_unit_ball: Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (AXIOMATIZED, S11.A strict-weakening 2026-05-09; replaces the previous brouwer_fpt axiom — strictly weaker mathematical commitment, identical axiom count)",
       "exists_continuous_proj_convex: Continuous nearest-point retraction onto compact convex sets in EuclideanSpace (LEMMA, sorry-stubbed; S11.B work item)",
-      "brouwer_fpt: Brouwer's FPT for general compact convex S, derived from brouwer_unit_ball + exists_continuous_proj_convex via the nearest-point retraction reduction (THEOREM, sorry-stubbed; S11.A.body work item)",
+      "brouwer_fpt: Brouwer's FPT for general compact convex S, derived from brouwer_unit_ball + exists_continuous_proj_convex via the nearest-point retraction reduction (THEOREM, body landed S13/2026-05-09 — no sorry in body; transitively depends on the sorry-stubbed exists_continuous_proj_convex helper)",
       "approx_selection_exists: UHC + convex → continuous ε-graph-approximate selections (AXIOMATIZED, Cellina–Browder form; pointwise form is provably false under USC alone — see S6 analysis)",
       "seq_compact_of_compact: Sequential compactness derived from Mathlib's IsCompact.isSeqCompact",
       "approx_fixedpoint_implies_fixedpoint: Limit argument for approximate fixed points (proved)",
@@ -47,14 +47,14 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 517,
+    "lineCount": 668,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
       "Convex sets in Euclidean space",
       "Upper hemicontinuity"
     ],
-    "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; currently sorry-stubbed pending S11.B helper + S11.A.body fill — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
+    "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free, but it transitively depends on the sorry-stubbed `exists_continuous_proj_convex` helper pending S11.B — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
     "definitionCount": 4
@@ -202,12 +202,12 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 517,
+    "lineCount": 668,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "references": [
     {
@@ -239,5 +239,5 @@
       "leanType": "Combination of Brouwer's FPT and approximate selections; the limit argument is encapsulated in approx_fixedpoint_implies_fixedpoint."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Gallery integrity audit fix

PR #17575 (S13, merged 2026-05-09) added the `S11.A.body` retraction reduction to `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`, growing the file from 517 → 668 lines and reducing sorry count from 2 → 1, but `meta.json` was not updated. This is the standard "research PR (build pending)" metadata-drift pattern.

## Verified counts (from `git show origin/main:proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`)

| Field | Before | After (actual) |
|---|---|---|
| `meta.lineCount` | 517 | 668 |
| `meta.sorries` | 2 | 1 |
| `leanFile.lineCount` | 517 | 668 |
| `leanFile.sorries` | 2 | 1 |
| top-level `sorries` | 2 | 1 |
| `axiomCount` | 2 | 2 (unchanged) |
| `theoremCount` | 5 | 5 (unchanged) |
| `definitionCount` | 4 | 4 (unchanged) |

The single remaining `sorry` is in `lemma exists_continuous_proj_convex` (line 130). All five `theorem`/`lemma` declarations are still present (1 lemma + 4 theorems).

## Narrative refreshes

- `originalContributions[brouwer_fpt]` previously claimed `(THEOREM, sorry-stubbed; S11.A.body work item)`. The body landed in S13 with no `sorry` token in the body (lines 173–318); the theorem still transitively depends on the `sorry`-stubbed `exists_continuous_proj_convex` helper. New text reflects this.
- `assumptions` previously said `currently sorry-stubbed pending S11.B helper + S11.A.body fill`. Replaced with the post-S13 status (S11.A.body landed, only S11.B remains).

## What is unchanged

- `status: "axiomatized"` (file still has 2 `axiom` declarations: `brouwer_unit_ball`, `approx_selection_exists`)
- `badge: "axiom"` (correct for axiomatized status)
- All cross-references, references, mainTheorems blocks
- Section line ranges (these are stale — the file restructure between lines ~110–320 invalidates them — but updating them belongs to a separate enrichment pass; this PR is scoped to count drift + the two sentences whose meaning is now wrong)

## Discovered during gallery integrity audit

Audit-tracker entry will be marked `issues-fixed` once this merges.