### PR TITLE
fix(meta): batch sync definitionCount drift (erdos-643, navier-stokes)

### DIFF
--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 1403,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "theoremCount": 39,
-    "definitionCount": 16
+    "definitionCount": 20
   },
   "overview": {
     "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
@@ -191,7 +191,7 @@
     "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 39,
-    "definitionCount": 16,
+    "definitionCount": 20,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -75,7 +75,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 21111,
     "theoremCount": 611,
-    "definitionCount": 100
+    "definitionCount": 362
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -408,7 +408,7 @@
     ],
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0,
-    "definitionCount": 100
+    "definitionCount": 362
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` to actual counts for two gallery entries that fall outside the open mechanic batch PRs (#17588 / #17589 / #17591 / #17603 / #17609).

## Convention

Per `feedback_mechanic_def_counting.md` (and PRs #17518 / #17569 / #17609): count `def+abbrev+opaque+structure+inductive+class` (NOT `instance`) with `private/protected/scoped/noncomputable/unsafe/partial` modifiers, after stripping nested block (`/-` … `-/`) and line (`--`) comments.

## Per-entry deltas (claimed → actual)

| Slug          | File                       | Claimed | Actual | Delta |
|---------------|----------------------------|---------|--------|-------|
| erdos-643     | Erdos643Problem.lean       | 16      | 20     | +4    |
| navier-stokes | NavierStokes.lean          | 100     | 362    | +262  |

## Drift origin

**erdos-643**: PR #17365 corrected this 16 → 20 (explicit revert of #17335's under-count from missing the `partial def` modifier). Subsequent PR #17394 ("batch sync count drift, 3 entries") silently re-reverted it back to 16 — likely the same buggy regex returned in that batch's scanner. The source still contains exactly 20 def-like decls:

| Kind                  | Count |
|-----------------------|-------|
| plain `def`           |   1   |
| `partial def`         |   4   |
| `noncomputable def`   |  14   |
| `abbrev`              |   1   |
| **Total**             | **20**|

**navier-stokes**: Open PR #17609 (marquee batch) covers `navier-stokes-existence`, `navier-stokes-oq-01`, `navier-stokes-oq-02` (all of which share `Proofs/NavierStokes.lean`) but missed the bare `navier-stokes` slug, which has the identical drift (100 → 362). All three covered slugs and this one source the same Lean file, so the same correction applies.

## Diff

Each meta.json had two occurrences of the wrong `definitionCount` value (once in `meta.*` summary, once in `leanFile.*`); both were updated in a single surgical Python `.replace()` per file (preserves JSON formatting). Diff stat: 2 files, +4/-4.

## Test plan

- [x] `python3 -c 'json.load(...)'` confirms each fixed file re-parses
- [x] `git show origin/main:<file> | grep '"definitionCount"'` confirmed the *exact* claimed values before patching
- [x] No overlap with currently-open mechanic PRs (#17588, #17589, #17591, #17603, #17609 cover different slugs)
- [x] No test impact (data-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)