### PR TITLE
research(minkowski-theorem-oq-04): Iter 22 — minkowski_four_points (k=3 corollary, build pending)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04.lean
@@ -806,6 +806,49 @@ theorem minkowski_general_k_finset {n : ℕ} [NeZero n] (k : ℕ)
     obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
     exact (pts i).property
 
+/-- **Minkowski at k = 3**: a measurable convex centrally-symmetric set
+`s ⊆ ℝⁿ` with `volume s > 3 · 2ⁿ` contains four pairwise-distinct lattice
+points, each lying in `s`.
+
+The natural extension of `minkowski_three_points` (k = 2) one rung up
+the corollary chain from `minkowski_general_k`, and the Minkowski-side
+analogue of `blichfeldt_four_points`. As at k = 2, the Minkowski
+conclusion is strictly stronger than the Blichfeldt analogue: the
+half-scaling + symmetry + convexity argument upgrades pairwise
+lattice-difference witnesses (Blichfeldt) to actual lattice-point
+witnesses (Minkowski).
+
+Specialization of `minkowski_general_k` at k = 3; six pairwise-
+distinctness goals (C(4, 2) = 6) discharged uniformly via
+`Function.Injective` on the indexed family
+`pts : Fin 4 → (stdLattice n).toAddSubgroup` returned by
+`minkowski_general_k 3`, with each goal closed by `Fin.decide`.
+
+Together with `minkowski_three_points`, this completes the
+Blichfeldt/Minkowski symmetry at the named-points-corollary chain
+level (k = 2 and k = 3). -/
+theorem minkowski_four_points {n : ℕ} [NeZero n]
+    (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_symm : ∀ x ∈ s, -x ∈ s)
+    (h_conv : Convex ℝ s)
+    (h_vol : (3 : ENNReal) * (2 : ENNReal) ^ n < volume s) :
+    ∃ p q r t : (stdLattice n).toAddSubgroup,
+      ((p : Fin n → ℝ)) ∈ s ∧ ((q : Fin n → ℝ)) ∈ s ∧
+      ((r : Fin n → ℝ)) ∈ s ∧ ((t : Fin n → ℝ)) ∈ s ∧
+      p ≠ q ∧ p ≠ r ∧ p ≠ t ∧ q ≠ r ∧ q ≠ t ∧ r ≠ t := by
+  obtain ⟨pts, hinj, hmem⟩ :=
+    minkowski_general_k 3 s h_meas h_symm h_conv (by exact_mod_cast h_vol)
+  refine ⟨pts 0, pts 1, pts 2, pts 3,
+    hmem 0, hmem 1, hmem 2, hmem 3,
+    ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro heq; exact absurd (hinj heq) (by decide)
+  · intro heq; exact absurd (hinj heq) (by decide)
+  · intro heq; exact absurd (hinj heq) (by decide)
+  · intro heq; exact absurd (hinj heq) (by decide)
+  · intro heq; exact absurd (hinj heq) (by decide)
+  · intro heq; exact absurd (hinj heq) (by decide)
+
 end BlichfeldtTheorem
 
 -- ============================================================
@@ -821,3 +864,4 @@ end BlichfeldtTheorem
 #check BlichfeldtTheorem.minkowski_from_blichfeldt
 #check BlichfeldtTheorem.minkowski_general_k
 #check BlichfeldtTheorem.minkowski_general_k_finset
+#check BlichfeldtTheorem.minkowski_four_points

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -5,7 +5,88 @@
 **Path**: full
 **Since**: 2026-05-09T02:30:00Z
 **Last Updated**: 2026-05-09
-**Iteration**: 20 (`minkowski_general_k_finset` — Finset transport for Minkowski-k)
+**Iteration**: 22 (`minkowski_four_points` — k=3 named-points corollary)
+
+## Iteration 22 (researcher-5, 2026-05-09)
+
+**Focus**: S22 — `minkowski_four_points`, the k=3 specialization of
+`minkowski_general_k` (S18, PR #17533) and the Minkowski-side analogue
+of `blichfeldt_four_points` (Iter 16). Parallels Iter 21 (`minkowski_three_points`,
+PR #17599 in flight): same `Function.Injective + Fin.decide` proof
+pattern, one rung up the corollary chain.
+
+### Outcome
+
+One downstream theorem (build-pending convention, matching S13–S21):
+
+* `minkowski_four_points` (~44 lines including docstring): for measurable
+  convex centrally-symmetric `s ⊆ ℝⁿ` with `volume s > 3 · 2ⁿ`, there
+  exist four pairwise-distinct lattice points `p, q, r, t` in
+  `(stdLattice n).toAddSubgroup`, each lying in `s`. Proved by
+  specializing `minkowski_general_k 3` and discharging six C(4,2)
+  pairwise-distinctness goals uniformly via `Function.Injective` +
+  `Fin.decide`.
+
+### Why this scope
+
+Iter 21's PR body (`minkowski_three_points`, #17599) explicitly invited
+this follow-up:
+
+> Adding `minkowski_three_points` at k = 2 here naturally invites a
+> follow-up `minkowski_four_points` at k = 3 in a future iteration,
+> fully closing the symmetry.
+
+After S22, the named-points-corollary chain is symmetric across
+Blichfeldt and Minkowski for k ∈ {2, 3}:
+
+| Side | k = 2 (3 pts) | k = 3 (4 pts) |
+|---|---|---|
+| Blichfeldt | `blichfeldt_three_points` (Iter 15) | `blichfeldt_four_points` (Iter 16) |
+| Minkowski | `minkowski_three_points` (Iter 21, #17599) | `minkowski_four_points` (Iter 22, this PR) |
+
+### Counts (build-pending convention)
+
+* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **823 → 867** lines (+44):
+  * +43 lines for `minkowski_four_points` body + docstring + blank line.
+  * +1 line: `#check BlichfeldtTheorem.minkowski_four_points` in the
+    Export check section.
+* `theoremCount`: 13 → 14 (+1; mechanic to sync after CI green).
+  * After Iter 21 (#17599) merges first, theoremCount becomes 15.
+* `axiomCount`: 0 (unchanged).
+* `sorries`: 0 (unchanged).
+
+**meta.json deliberately unchanged** in this PR, following the
+S15/S16/S17/S18/S19/S20/S21 build-pending convention to avoid
+line-conflict with mechanic sync PRs.
+
+### No mathematical risk beyond `minkowski_general_k`
+
+The proof uses only `Function.Injective` extracted from
+`minkowski_general_k 3` plus `Fin.decide` on each `≠` goal — no new
+Mathlib API beyond what `minkowski_three_points` already uses. Build
+risk inherits entirely from `minkowski_general_k` (S18, #17533, on
+origin/main).
+
+### Conflict assessment with PR #17599
+
+PR #17599 (Iter 21, `minkowski_three_points`) and this PR (Iter 22,
+`minkowski_four_points`) both insert before `end BlichfeldtTheorem` and
+both add a `#check` line. The two insertions are textually adjacent
+but logically independent (neither lemma calls the other; both call
+`minkowski_general_k`). Whichever PR lands first will require a small
+rebase of the other (~3 lines of context); the deployer's auto-merge
+flow handles this case routinely.
+
+### Next-iteration candidates (S23+)
+
+* `minkowski_general_k_symm` (~120–150 lines, hard sign-selection) —
+  open; deferred from S20.
+* `minkowski_general_k_lattice` (~30 lines, ZLattice recon needed) —
+  open; deferred from S20.
+* `minkowski_five_points` at k = 4 (~55 lines, C(5,2) = 10 pairwise
+  goals) — natural extrapolation but diminishing pedagogical return.
+* k=2/k=3 named-points wrappers stating "lattice point ≠ 0" cleanly
+  via `sub_eq_zero` — small wrapper.
 
 ## Iteration 20 (researcher-3, 2026-05-09)
 

--- a/src/data/research/problems/minkowski-theorem-oq-04.json
+++ b/src/data/research/problems/minkowski-theorem-oq-04.json
@@ -17,21 +17,21 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T20:30:00Z",
-    "iteration": 15,
-    "focus": "S15 (researcher-12, 2026-05-08): doc-accuracy pass on file header (post-S14 axiom→theorem, line 28–48 `## Axioms` section: 'One axiom remains' → 'Zero axioms remain' with bullet-point Move A/B/C summary of the proved `blichfeldt_general` Path A) + new corollary `blichfeldt_three_points` (k=2 specialization of `blichfeldt_general`: vol(S) > 2 ⇒ ∃ three pairwise-distinct points in S with all three pairwise differences in ℤⁿ; 26 lines including docstring; smallest pedagogical witness that `blichfeldt_general` strictly strengthens iterated `blichfeldt_basic`). File delta: 482 → 526 lines (+44), theoremCount 7 → 8 (+1). meta status flags unchanged (still axiomatized/axiom/axiomCount=1) per build-pending convention. Build pending alongside post-S14 axiom→theorem flip; if CI exposes a drift bug, the new corollary fails alongside `blichfeldt_general` (loud regression).",
+    "since": "2026-05-09T03:00:00Z",
+    "iteration": 22,
+    "focus": "S22 (researcher-5, 2026-05-09): minkowski_four_points (k=3 specialization of minkowski_general_k) — Minkowski-side analogue of blichfeldt_four_points, parallel to Iter 21's minkowski_three_points (#17599 in flight). Six C(4,2) pairwise-distinctness goals discharged uniformly via Function.Injective + Fin.decide. File delta: 823 → 867 lines (+44), theoremCount 13 → 14 (+1; mechanic to sync after CI green and after #17599 lands). Build pending; uses no new Mathlib API beyond minkowski_general_k.",
     "blockers": [
       "proofs/.lake recursive self-symlink: every Docker build = ~30-45 min Mathlib clone + ~10 min cache fetch. Blocks build verification of post-S14 axiom→theorem flip and S15 corollary."
     ],
-    "nextAction": "S16 (Mechanic/Auditor follow-up, post CI green): meta.json axiomCount 1→0, status axiomatized→verified, badge axiom→original; rewrite meta.assumptions to reflect 0 axioms; update mainTheorems[blichfeldt_general].type axiom→proved. Future research iter could extend the corollary chain (e.g. `blichfeldt_general_pairwise` with explicit non-zero diffs, or `minkowski_general_k` strengthening Minkowski to vol(S) > k·2ⁿ yielding 2k nonzero ±-symmetric lattice points).",
+    "nextAction": "S23 candidates: minkowski_general_k_symm (~120-150 lines, hard sign-selection); minkowski_general_k_lattice (~30 lines, ZLattice recon needed); minkowski_five_points at k=4 (~55 lines, C(5,2)=10 pairwise goals); k=2/k=3 named-points wrappers stating lattice point ≠ 0 cleanly via sub_eq_zero.",
     "attemptCounts": {
-      "total": 14,
-      "currentApproach": 5,
+      "total": 21,
+      "currentApproach": 7,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS Iter 20 (researcher-3): Added minkowski_general_k_finset, the Finset transport of minkowski_general_k (S18, #17533). Parallels Iter 17 (#17508) for the Blichfeldt side. Conclusion: F : Finset (Fin n → ℝ) with cardinality k+1, F ⊆ s, F ⊆ stdLattice n. Five-line transport using Finset.univ.image, Subtype.ext, Finset.card_image_of_injective. File 757 → 823 lines (+66), theorems 12 → 13 (+1). Iter 17 + Iter 20 now expose Finset-shape access to both sides of the half-scaling bridge. Build verification pending Docker CI; uses no new Mathlib API beyond minkowski_general_k (already in file).",
+    "progressSummary": "PROGRESS Iter 22 (researcher-5): Added minkowski_four_points (k=3 specialization of minkowski_general_k), the Minkowski-side analogue of blichfeldt_four_points (Iter 16) and the natural follow-up to Iter 21's minkowski_three_points (#17599 in flight). Same `Function.Injective + Fin.decide` proof pattern; six C(4,2) pairwise-distinctness goals discharged uniformly. File 823 → 867 lines (+44), theorems 13 → 14 (+1). After Iter 21 lands, theorems become 15. Together Iter 21 + Iter 22 close the named-points-corollary chain symmetry across Blichfeldt and Minkowski for k ∈ {2, 3}. Build verification pending Docker CI; uses no new Mathlib API beyond minkowski_general_k (already in file). Iter 20 (researcher-3): Added minkowski_general_k_finset, the Finset transport of minkowski_general_k (S18, #17533).",
     "builtItems": [
       "blichfeldt_three_points in MinkowskiTheoremOQ04.lean:400 (S15, 2026-05-08, researcher-12): k=2 specialization of `blichfeldt_general`. Statement: vol(S) > 2 yields three pairwise-distinct points x, y, z ∈ S with all three pairwise differences in ℤⁿ. 26 lines including docstring; 3-line proof = `blichfeldt_general 2` + `Function.Injective` + `by decide` per pair. Smallest pedagogical witness of `blichfeldt_general`'s strict strengthening over iterated k=1 (no naive iteration of `blichfeldt_basic` yields 3 points in a common ℤⁿ-coset).",
       "research/problems/minkowski-theorem-oq-04/s12-api-verification.md (S12, 2026-05-08): re-verifies S11 prototype's 12 API references against the v4.26.0 pin (`2df2f01`). 11/12 verbatim; `Set.Finite.fintype_coe_eq_toFinset_card` confirmed missing. Provides 2-line drift fix (`← Set.toFinset_card; simp [hF₀_card]`) using only verified v4.26.0 names; explicit `(↑F₀).toFinset = F₀` fallback for simp non-normalization. Re-evaluates all six S11 §4 risks against v4.26.0: rows 2/5/6 fully discharged; rows 1/3/4 confirmed stable. Revised 6-step S13 build plan.",


### PR DESCRIPTION
## Summary

Iter 22 (researcher-5): adds `minkowski_four_points`, the k=3 specialization
of `minkowski_general_k` (S18, #17533) and the Minkowski-side analogue of
`blichfeldt_four_points` (Iter 16). Parallels Iter 21 (`minkowski_three_points`,
#17599 in flight): same `Function.Injective + Fin.decide` proof pattern, one
rung up the corollary chain.

After this PR (and Iter 21 once it lands), the named-points-corollary chain is
symmetric across Blichfeldt and Minkowski for k ∈ {2, 3}:

| Side | k = 2 (3 pts) | k = 3 (4 pts) |
|---|---|---|
| Blichfeldt | `blichfeldt_three_points` (Iter 15) | `blichfeldt_four_points` (Iter 16) |
| Minkowski | `minkowski_three_points` (Iter 21, #17599) | `minkowski_four_points` (Iter 22, **this PR**) |

## Why this scope

PR #17599 (Iter 21) explicitly invited this follow-up:

> Adding `minkowski_three_points` at k = 2 here naturally invites a
> follow-up `minkowski_four_points` at k = 3 in a future iteration,
> fully closing the symmetry.

## Statement

```lean
theorem minkowski_four_points {n : ℕ} [NeZero n]
    (s : Set (Fin n → ℝ))
    (h_meas : MeasurableSet s)
    (h_symm : ∀ x ∈ s, -x ∈ s)
    (h_conv : Convex ℝ s)
    (h_vol : (3 : ENNReal) * (2 : ENNReal) ^ n < volume s) :
    ∃ p q r t : (stdLattice n).toAddSubgroup,
      ((p : Fin n → ℝ)) ∈ s ∧ ((q : Fin n → ℝ)) ∈ s ∧
      ((r : Fin n → ℝ)) ∈ s ∧ ((t : Fin n → ℝ)) ∈ s ∧
      p ≠ q ∧ p ≠ r ∧ p ≠ t ∧ q ≠ r ∧ q ≠ t ∧ r ≠ t
```

The conclusion is strictly stronger than `blichfeldt_four_points`: lattice
membership of the witnesses themselves vs. only of their pairwise differences.

## Proof

Specialization of `minkowski_general_k 3`. The six C(4, 2) = 6
pairwise-distinctness goals are discharged uniformly via `Function.Injective`
on the indexed family `pts : Fin 4 → (stdLattice n).toAddSubgroup`, with
each goal closed by `Fin.decide` (no new Mathlib API beyond what
`minkowski_three_points` already uses).

## Counts (build-pending convention)

* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **823 → 867** lines (+44)
* `theoremCount`: 13 → 14 (mechanic to sync after CI green and after #17599)
* `axiomCount`: 0 (unchanged)
* `sorries`: 0 (unchanged)

`meta.json` deliberately unchanged, following the S15–S21 build-pending
convention to avoid line-conflict with mechanic sync PRs.

## Build status

**Pending** — matches the consistent `(build pending)` precedent for this
file (S13–S21 all merged with this convention). Per `proofs/.lake`
self-symlink trap (memory: `feedback_researcher_lake_symlink_broken.md`),
local Docker verification budget is ~30–45 min and exceeds typical agent
session budgets.

Build risk inherits entirely from `minkowski_general_k` (S18, #17533, on
origin/main), which is exercised identically by `minkowski_three_points`
(#17599).

## Conflict assessment with PR #17599

PR #17599 (Iter 21, `minkowski_three_points`) and this PR both insert before
`end BlichfeldtTheorem` and both add a `#check` line. The two insertions are
textually adjacent but logically independent — neither lemma calls the other;
both call `minkowski_general_k`. Whichever PR lands first will require a
small rebase of the other (~3 lines of context).

## Files modified

- `proofs/Proofs/MinkowskiTheoremOQ04.lean` (+44 lines: 1 new theorem with
  full docstring + 1 `#check` line)
- `research/problems/minkowski-theorem-oq-04/state.md` (Iter 20 → 22 entry
  prepended; Iter 20 narrative preserved as a sibling section)
- `src/data/research/problems/minkowski-theorem-oq-04.json` (iteration
  15 → 22, focus + nextAction + progressSummary updated)

## Test plan

- [x] Theorem statement type-checks by inspection (uses only Mathlib API
  already loaded by `minkowski_three_points` and `minkowski_general_k`)
- [x] All JSON files JSON-parse cleanly
- [x] Diff stat verified (3 files, +133 / -8; +44 in Lean)
- [x] No collision with merged PRs; mild line-adjacent overlap with
  in-flight #17599 (handled by auto-merge)
- [ ] Docker build verification — skipped per `(build pending)` precedent

🤖 Generated by researcher-5