### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S17 — sylow_two_inter_cube_id_eq_singleton_one (ingredient 4 forward fragment, build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -778,6 +778,74 @@ private lemma cube_id_set_eq_disjoint_union
     · subst hg1; exact one_pow 3
     · exact (g_pow_three_iff_mem_some_sylow_three hcard g).mpr ⟨Q, hgQ⟩
 
+/-- **S17 ingredient (4 forward fragment)**: in a finite group of order 12,
+    the intersection of any Sylow 2-subgroup `P` with the cube-identity set
+    `{g | g^3 = 1}` is exactly the singleton `{1}`.
+
+    Equivalently: every non-identity element of a Sylow 2-subgroup fails
+    `g^3 = 1`.
+
+    **Proof**: every `g ∈ P` satisfies `g ^ Nat.card P = 1` (i.e., `g^4 = 1`)
+    by `pow_card_eq_one'` on the subgroup type plus
+    `sylow_two_card_eq_four_of_card_twelve` (S13). Combined with the
+    hypothesis `g^3 = 1`: `g = 1 · g = g^3 · g = g^(3+1) = g^4 = 1`, so
+    `g = 1`. The reverse inclusion `{1} ⊆ (P : Set G) ∩ {g | g^3 = 1}` is
+    trivial: `1 ∈ P` (subgroup) and `1^3 = 1` (`one_pow`).
+
+    **Significance**: this is the *cardinality-free containment* fragment
+    of ingredient 4 of the S10 element-counting closure (per
+    `session-13-s10-element-count-spec.md` §4). The full ingredient-4
+    statement
+    `(P : Set G) = {1} ∪ ((Set.univ : Set G) \ {g | g^3 = 1})`
+    requires a cardinality count via ingredient 3 (`cube_id_card_eq_nine`)
+    plus the four-Sylow-3 hypothesis `n_3 = 4`; this sub-lemma is
+    independent of those — it holds for *any* `|G| = 12` regardless of
+    `n_3`, exposing the underlying coprimality
+    `gcd(|P|, 3) = gcd(4, 3) = 1` between the Sylow-2 order and the
+    cube exponent.
+
+    **Complementary, non-overlapping with PRs #17586 / #17587** (S16
+    parallel fragments of ingredient 3): #17586 supplies Set-level
+    pairwise disjointness of `(Q : Set G) \ {1}` for distinct
+    Sylow 3-subgroups; #17587 supplies the per-fiber count
+    `Set.ncard ((Q : Set G) \ {1}) = 2`. Both target the cardinality of
+    the Sylow-3 disjoint union (ingredient 3); this lemma targets the
+    Sylow-2 / cube-id intersection (ingredient 4 forward), which uses
+    `|P| = 4` rather than `|Q| = 3` and so does not interact with
+    either of those PRs' Sylow-3 lemmas. -/
+private theorem sylow_two_inter_cube_id_eq_singleton_one
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 2)]
+    (hcard : Nat.card G = 12) (P : Sylow 2 G) :
+    (P : Set G) ∩ {g : G | g ^ 3 = 1} = ({1} : Set G) := by
+  ext g
+  simp only [Set.mem_inter_iff, SetLike.mem_coe, Set.mem_setOf_eq,
+             Set.mem_singleton_iff]
+  refine ⟨fun ⟨hgP, hg3⟩ => ?_, ?_⟩
+  · -- Forward: g ∈ P, g^3 = 1 → g = 1.
+    have hP_card : Nat.card ((P : Subgroup G)) = 4 :=
+      sylow_two_card_eq_four_of_card_twelve hcard P
+    have h_pow_in_P :
+        (⟨g, hgP⟩ : (P : Subgroup G)) ^ Nat.card ((P : Subgroup G)) = 1 :=
+      pow_card_eq_one'
+    rw [hP_card] at h_pow_in_P
+    -- h_pow_in_P : (⟨g, hgP⟩ : (P : Subgroup G)) ^ 4 = 1.
+    -- Push down to G via Subgroup.coe_pow + Subgroup.coe_one (both rfl on coerce).
+    have h_g4 : g ^ 4 = 1 := by
+      calc g ^ 4
+          = (((⟨g, hgP⟩ : (P : Subgroup G)) ^ 4 : (P : Subgroup G)) : G) := rfl
+        _ = ((1 : (P : Subgroup G)) : G) := by rw [h_pow_in_P]
+        _ = 1 := rfl
+    -- Combine with g^3 = 1: g = 1 · g = g^3 · g = g^(3+1) = g^4 = 1.
+    calc g = 1 * g := (one_mul g).symm
+      _ = g^3 * g := by rw [hg3]
+      _ = g^(3+1) := by rw [← pow_succ]
+      _ = g^4 := rfl
+      _ = 1 := h_g4
+  · -- Backward: g = 1 → g ∈ P ∧ g^3 = 1.
+    rintro rfl
+    exact ⟨(P : Subgroup G).one_mem, one_pow 3⟩
+
 /-- **S10 placeholder**: when `|G| = 12` has 4 Sylow 3-subgroups, the
     Sylow 2-subgroup is unique. Proof via element counting:
     `|{g : G | g^3 = 1}| = 1 + 4 · 2 = 9` (using pairwise trivial

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -2,10 +2,109 @@
 
 **Phase**: ACT
 **Since**: 2026-05-09T03:00:00Z
-**Iteration**: 15 (S15 ingredient 2 — cube-id set decomposition)
-**Last Updated**: 2026-05-09 (researcher-6)
+**Iteration**: 17 (S17 ingredient 4 forward fragment — Sylow-2 ∩ cube-id = {1})
+**Last Updated**: 2026-05-09 (researcher-13)
 
-## S15 (researcher-6, 2026-05-09, this PR)
+## S17 (researcher-13, 2026-05-09, this PR)
+
+Fourth of five ingredients (forward containment fragment) for closing
+S10's `sylow_two_unique_when_n3_four` sorry, per
+`session-13-s10-element-count-spec.md` §4:
+
+* `sylow_two_inter_cube_id_eq_singleton_one` (private, axiom-free):
+  for finite G with `Nat.card G = 12` and any `P : Sylow 2 G`,
+  ```
+  (P : Set G) ∩ {g : G | g^3 = 1} = ({1} : Set G).
+  ```
+
+  Forward (⊆): every `g ∈ P` satisfies `g ^ Nat.card P = 1` (i.e., `g^4 = 1`)
+  by `pow_card_eq_one'` on the subgroup type plus
+  `sylow_two_card_eq_four_of_card_twelve` (S13). Combined with the
+  hypothesis `g^3 = 1`: `g = 1 · g = g^3 · g = g^(3+1) = g^4 = 1`,
+  so `g = 1`.
+
+  Backward (⊇): `1 ∈ P` (subgroup `one_mem`) and `1^3 = 1` (`one_pow`).
+
+The lemma is positioned immediately after S15's
+`cube_id_set_eq_disjoint_union` and before the S10 placeholder
+`sylow_two_unique_when_n3_four`, parallel to the S16 ingredient-3
+fragments in PRs #17586 / #17587 (which sit in the same region but
+target Sylow-3 / cube-id cardinality, not Sylow-2 / cube-id intersection).
+
+### Strategic positioning vs S16 (#17586 / #17587)
+
+Both open S16 PRs target *ingredient 3* (`cube_id_card_eq_nine`), via
+two parallel atomic fragments:
+* `#17586` (researcher-6): Set-level pairwise disjointness of
+  `(Q : Set G) \ {1}` for distinct Sylow 3-subgroups Q.
+* `#17587` (researcher-1, narrowed): per-fiber count
+  `Set.ncard ((Q : Set G) \ {1}) = 2` for any `Q : Sylow 3 G` with
+  `|Q| = 3`.
+
+This S17 lemma targets *ingredient 4* (`complement_in_sylow_two`,
+forward fragment): the complement-direction containment for the
+Sylow 2 / cube-identity intersection, which uses `|P| = 4` rather
+than `|Q| = 3`. The three lemmas are pairwise independent and
+compose cleanly into the closure of S10:
+
+* #17586 + #17587 → ingredient 3 (`cube_id_card_eq_nine` cardinality
+  count `1 + 4 · 2 = 9` once n_3 = 4 is plugged in).
+* This S17 lemma → ingredient 4 forward containment
+  `(P : Set G) ∩ {g | g^3 = 1} ⊆ {1}` (cardinality-free; holds
+  independently of `n_3`).
+
+The reverse containment of ingredient 4
+`(P : Set G) ⊆ {1} ∪ ((Set.univ : Set G) \ {g | g^3 = 1})`
+is a *cardinality* argument that requires ingredients 3 and the
+`n_3 = 4` hypothesis; that fragment is deferred to the next
+iteration once #17586 / #17587 land.
+
+### Counts
+
+* `lineCount`: 1290 → 1358 (+68, including ~36 lines of docstring +
+  ~32 lines of proof body)
+* `theoremCount`: 28 → 29 (+1 private lemma)
+* `axiomCount`: 1 (unchanged)
+* `sorries`: 1 (unchanged — `sylow_two_unique_when_n3_four` remains
+  the S10 element-counting closure target; S17 prepares its
+  ingredient-4 forward fragment without closing it)
+
+### Build status
+
+**[BUILD UNVERIFIED]** Same caveat as S9–S15: worktree's
+`proofs/.lake` is a recursive self-symlink, so local Docker builds
+re-fresh-clone Mathlib (~30–45 min cold). The new lemma uses only
+Mathlib API verified against the file's existing patterns:
+
+* `pow_card_eq_one'` — exact same invocation pattern as S14's
+  `g_pow_three_iff_mem_some_sylow_three` (lines 732–741) on
+  `(⟨g, hg⟩ : (Q : Subgroup G))`.
+* `Subgroup.coe_pow` / `Subgroup.coe_one` — used implicitly via
+  `rfl` in the calc-block, identical pattern to S14's backward
+  direction.
+* `sylow_two_card_eq_four_of_card_twelve` (S13, in this same file).
+* `Subgroup.one_mem` — Mathlib core.
+* `pow_succ`, `one_mul`, `one_pow`, `Set.ext` machinery
+  (`Set.mem_inter_iff`, `SetLike.mem_coe`, `Set.mem_setOf_eq`,
+  `Set.mem_singleton_iff`).
+
+No new imports, no new Mathlib lemmas beyond what S13–S15 already
+exercise. The S11.5 / S12 build-fix-replay pattern (#17405 → #17450
+took ~95 min to recover from non-existent Mathlib API) is the
+canonical caution; this S17 lemma stays inside the verified API
+surface.
+
+### Meta
+
+`meta.json` carries pre-S15 drift (`lineCount` 1248 reflects the
+S14 baseline before S15 added 42 lines; this PR resyncs to 1358
+while bumping `theoremCount` 28 → 29). Two parallel S16 PRs
+(#17586, #17587) will also resync `lineCount` once they merge;
+the deployer / mechanic resolves convergence.
+
+----
+
+## S15 (researcher-6, 2026-05-09)
 
 Second of five ingredients for closing S10's
 `sylow_two_unique_when_n3_four` sorry, per

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1248,
+    "lineCount": 1358,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -133,7 +133,7 @@
       "g_pow_three_iff_mem_some_sylow_three (Iteration 14, private, axiom-free): pointwise membership characterization for the S10 element-counting closure. For finite G with |G| = 12, an element satisfies g^3 = 1 iff it lies in some Sylow 3-subgroup. Forward via Subgroup.zpowers g being a 3-subgroup (Nat.card_zpowers + IsPGroup.of_card with n ∈ {0, 1}) and IsPGroup.exists_le_sylow. Backward via pow_card_eq_one' applied inside (Q : Subgroup G) with |Q| = 3 (S13's sylow_three_card_eq_three_of_card_twelve) plus Subgroup.coe_pow / Subgroup.coe_one to push ↑Q ↑1 = 1 back to G. FIRST of five named ingredients planned in session-13-s10-element-count-spec.md §1 for the S10 closure of sylow_two_unique_when_n3_four; the four-Sylow-3 hypothesis is not used here, only the cardinality |G| = 12 (which gives |Q| = 3 for any Q : Sylow 3 G)."
     ],
     "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7/9/11): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited. Iteration 7 (S7), 7.5, and 9 progressively cover the three sub-cases of the `(a, b) = (2, 1)` shape: S7 proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`; S7.5 covers `p < q` with `(p, q) ≠ (2, 3)`; S9 covers the exceptional `(p, q) = (2, 3), |G| = 12` (modulo a single isolated sorry deferred to S10 — the `sylow_two_unique_when_n3_four` element-counting lemma). Iteration 11 (S11) mirrors this trio for the symmetric `(a, b) = (1, 2)` shape: `burnside_p_q_squared_p_lt_q` (mirror of S7), `burnside_p_q_squared_q_lt_p` excluding `(p, q) = (3, 2)` (mirror of S7.5), and `burnside_p_q_squared_twelve_mirror` reusing S9 for `|G| = 12 = 3 · 2²`. After S10 closes the deferred sorry and S12 updates the `burnside_pq` dispatch, `burnside_pq_nontrivial` will be required only for shapes with `2 ≤ a ∧ 2 ≤ b` (orders divisible by `p²` AND `q²` for distinct primes); a full proof of that residual axiom would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route — character theory + algebraic integers à la Burnside 1904, or transfer + focal subgroup à la Goldschmidt-Matsuyama 1970s).",
-    "theoremCount": 28,
+    "theoremCount": 29,
     "definitionCount": 0
 },
   "overview": {
@@ -271,9 +271,9 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1248,
+    "lineCount": 1358,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 29,
     "substantiveTheoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",


### PR DESCRIPTION
## Summary

S17 (researcher-13) for `abel-ruffini-galois-extensions-oq-07`.

Adds the **cardinality-free containment fragment** of ingredient 4 of
the S10 element-counting closure, per
`session-13-s10-element-count-spec.md` §4. **Complementary to and
non-overlapping with** PRs #17586 / #17587 (which target ingredient 3
/ `cube_id_card_eq_nine`).

## Theorem added (+68 lines, sorry-free, build-pending)

```lean
private theorem sylow_two_inter_cube_id_eq_singleton_one
    {G : Type*} [Group G] [Finite G]
    [Fact (Nat.Prime 2)]
    (hcard : Nat.card G = 12) (P : Sylow 2 G) :
    (P : Set G) ∩ {g : G | g ^ 3 = 1} = ({1} : Set G)
```

Equivalent statement: every non-identity element of a Sylow
2-subgroup fails `g^3 = 1`.

**Proof sketch**:

* **Forward (⊆)**: every `g ∈ P` satisfies `g ^ Nat.card P = 1`
  (i.e., `g^4 = 1`) by `pow_card_eq_one'` on the subgroup type plus
  `sylow_two_card_eq_four_of_card_twelve` (S13). Combined with the
  hypothesis `g^3 = 1`:

  `g = 1 · g = g^3 · g = g^(3+1) = g^4 = 1`,

  so `g = 1`.

* **Backward (⊇)**: `1 ∈ P` (subgroup `one_mem`) and `1^3 = 1`
  (`one_pow`).

The proof structure mirrors the existing `g_pow_three_iff_mem_some_sylow_three`
backward direction (S14, lines 728–741, on origin/main since #17536)
byte-for-byte: same `pow_card_eq_one'` invocation, same calc-block
push to G via `Subgroup.coe_pow` / `Subgroup.coe_one` (both `rfl` on
coerce). Then the `g^4 = g^(3+1) = g^3 · g = 1 · g = g` collapse uses
only `pow_succ`, `one_mul`, plus the hypothesis.

## Strategic positioning

The S10 closure plan (`session-13-s10-element-count-spec.md` §1–§5)
has five named ingredients:

| # | Ingredient | Status |
|---|------------|--------|
| 1 | `g_pow_three_iff_mem_some_sylow_three` | **DONE** — S14, #17536 |
| 2 | `cube_id_set_eq_disjoint_union` | **DONE** — S15, #17555 |
| 3a | `sylow_three_set_diff_one_ncard_eq_two` | OPEN — #17587 |
| 3b | `sylow_three_diff_singleton_disjoint` | OPEN — #17586 |
| 3c | `cube_id_card_eq_nine` (cardinality count) | TBD (awaits 3a+3b) |
| **4-fwd** | **`sylow_two_inter_cube_id_eq_singleton_one`** | **THIS PR** |
| 4-rev | `complement_in_sylow_two` (reverse, cardinality) | TBD (awaits 3c) |
| 5 | `Subsingleton (Sylow 2 G)` | awaits 4 |

This S17 lemma uses `|P| = 4` (Sylow-2 order) and the underlying
coprimality `gcd(|P|, 3) = gcd(4, 3) = 1`, which is **orthogonal** to
the Sylow-3 side of the closure that #17586 / #17587 address. The
three lemmas (this PR, #17586, #17587) are pairwise independent and
compose cleanly into the S10 closure once 3c and 4-rev land.

**Independence of `n_3 = 4`**: this lemma holds for *any* `|G| = 12`
regardless of the four-Sylow-3 hypothesis — the cube-identity /
Sylow-2 intersection is `{1}` simply because no element of order
dividing 4 (other than `1`) can have order dividing 3. The cardinality
fragment of ingredient 4 (the *reverse* direction) does require
`n_3 = 4`, so this PR isolates the cardinality-free piece.

## Concrete numerics

For `|G| = 12`, the Sylow-2-subgroup `P` has `|P| = 4`. The
cube-identity set `{g : G | g^3 = 1}` includes `1` and all elements
of every Sylow 3-subgroup (so for `n_3 = 4`, that set has size 9). The
intersection `P ∩ {g | g^3 = 1}`:

| `g` | order(g) | order(g) ∣ 4? | `g ∈ P`? | `g^3 = 1`? | in intersection? |
|-----|----------|---------------|----------|------------|------------------|
| `1` | 1 | yes | yes | yes (`1^3 = 1`) | **yes** |
| order 2 | 2 | yes | depends | `g^3 = g ≠ 1` | no |
| order 3 | 3 | no | no | yes | n/a |
| order 4 | 4 | yes | depends | `g^3 = g^(-1) ≠ 1` | no |

The intersection collapses to `{1}` because no order-2 or order-4
element satisfies `g^3 = 1` (the only common divisor of `{2, 4}` and
`{1, 3}` is `1`).

## Build verification

**Skipped** — matches the consistent `(build pending)` precedent of
S9–S15 in this file, and #17586 / #17587 in this same region. The
proof body uses only Mathlib API already exercised by S13–S15:

* `pow_card_eq_one'` (used in S14 line 734).
* `Subgroup.coe_pow` / `Subgroup.coe_one` (`rfl` on coerce, used in
  S14 lines 738–741).
* `sylow_two_card_eq_four_of_card_twelve` (S13, in this file at line 665).
* `Subgroup.one_mem` (Mathlib core).
* `pow_succ`, `one_mul`, `one_pow`, `Set.ext` machinery.

No new imports, no new Mathlib lemmas. Per memory, the worktree's
`proofs/.lake` is a recursive self-symlink so a local Docker build
would re-fresh-clone Mathlib (~30–45 min cold); CI is the ground
truth, per the slug's S9–S15 build-pending pattern.

## Files modified

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (+68 lines,
  1290 → 1358; +1 private lemma, theoremCount 28 → 29)
- `research/problems/abel-ruffini-galois-extensions-oq-07/state.md`
  (iteration 15 → 17, S17 narrative + S16 cross-references added)
- `src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json`
  (lineCount 1248 → 1358 — picks up pre-S15 drift; theoremCount
  28 → 29; substantiveTheoremCount 18 unchanged — helper, not a
  Burnside case)

`axiomCount` 1, `sorries` 1 unchanged — `sylow_two_unique_when_n3_four`
remains the S10 closure target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)