### PR TITLE
research(binary-gcd-oq-03-oq-02): S28c — outer-guard packaging lemmas (PART XIII, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -829,6 +829,87 @@ theorem schonhageOuterGuardFires_strict_decrease {a b : ℕ}
       < max a b :=
   (schonhageOuterGuardFires_iff.mp h).2
 
+/-- Above-threshold specialisation of `schonhageOuterGuardFires_iff`.
+
+    On any pair `(a, b)` whose `max` is at least `hgcdThresholdSafe`,
+    the early-return branch of `schonhageOuterGuardFires` is excluded,
+    and the predicate reduces purely to the size-reduction inequality.
+
+    This is the workhorse "above-threshold ⇒ guard fires iff size
+    reduces" form referenced by `s28b-inner-guard-equivalence-spec.md`
+    §3, where the proposed S28b structural theorem extends it by
+    relating the size-reduction predicate to the inner-guard branch
+    of `hgcdMatrixSafe`. -/
+theorem schonhageOuterGuardFires_above_iff {a b : ℕ}
+    (h : ¬ max a b < hgcdThresholdSafe) :
+    schonhageOuterGuardFires a b = true ↔
+      max (hgcdSafeApply a b).1.natAbs (hgcdSafeApply a b).2.natAbs
+        < max a b := by
+  rw [schonhageOuterGuardFires_iff, and_iff_right h]
+
+/-- Above-threshold abort iff: the dual of `_above_iff`, packaging
+    the `false` case of `schonhageOuterGuardFires` on above-threshold
+    inputs as the size-NON-reduction inequality `max a b ≤ max u v`.
+
+    Useful for case-splitting on the outer-guard predicate when the
+    interesting information is the abort branch — the canonical
+    setting for the S28a counterexamples `(130, 89)` and `(107, 85)`,
+    which are above threshold and abort. -/
+theorem schonhageOuterGuardFires_above_aborts_iff {a b : ℕ}
+    (h : ¬ max a b < hgcdThresholdSafe) :
+    schonhageOuterGuardFires a b = false ↔
+      max a b ≤ max (hgcdSafeApply a b).1.natAbs
+                    (hgcdSafeApply a b).2.natAbs := by
+  constructor
+  · intro hfalse
+    by_contra hlt
+    push_neg at hlt
+    have htrue : schonhageOuterGuardFires a b = true :=
+      schonhageOuterGuardFires_iff.mpr ⟨h, hlt⟩
+    simp [htrue] at hfalse
+  · intro hge
+    by_contra hne
+    have htrue : schonhageOuterGuardFires a b = true := by
+      cases hb : schonhageOuterGuardFires a b
+      · exact absurd hb hne
+      · rfl
+    exact Nat.not_lt.mpr hge
+      (schonhageOuterGuardFires_strict_decrease htrue)
+
+/-- Disjunctive iff for the outer-guard `false` case. The predicate
+    `schonhageOuterGuardFires a b = false` decomposes into a
+    two-disjunct characterisation: either the input is below the
+    safe-HGCD threshold (early-return branch), or the input is above
+    threshold but `hgcdSafeApply` does not strictly reduce `max a b`
+    (size-reduction failure). The simplification
+
+    `(below) ∨ (max a b ≤ max u v)`
+
+    folds the above-threshold + size-failure clause into a single
+    inequality that holds vacuously below threshold (since both sides
+    of the conjunction are then unconstrained), giving a clean
+    flat disjunction.
+
+    This is the structural counterpart of `schonhageOuterGuardFires_iff`
+    for the negative branch, supporting reasoning patterns where one
+    case-splits on `outer = false` and needs to extract WHY the guard
+    failed (early return vs size-failure). -/
+theorem schonhageOuterGuardFires_eq_false_iff {a b : ℕ} :
+    schonhageOuterGuardFires a b = false ↔
+      max a b < hgcdThresholdSafe ∨
+      max a b ≤ max (hgcdSafeApply a b).1.natAbs
+                    (hgcdSafeApply a b).2.natAbs := by
+  by_cases hsmall : max a b < hgcdThresholdSafe
+  · constructor
+    · intro _; exact Or.inl hsmall
+    · intro _; exact schonhageOuterGuardFires_below_threshold hsmall
+  · rw [schonhageOuterGuardFires_above_aborts_iff hsmall]
+    constructor
+    · exact fun h => Or.inr h
+    · rintro (h | h)
+      · exact absurd h hsmall
+      · exact h
+
 /-- One fuel step of `schonhageGcd` is fully described by the
     outer-guard predicate. **Headline theorem of S23.** When
     `schonhageOuterGuardFires a b = true`, the recursive case

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -13,11 +13,82 @@ S25 PART XVII numerical witnesses (528, 2080, 2211) are
 corollaries.
 
 **Since**: 2026-05-01
-**Iteration**: 28 (S28a in this PR; S27 PR #17489 merged + S28 reconnaissance #17496 merged)
+**Iteration**: 29 (S28c in this PR — outer-guard packaging lemmas; S28a PR #17517 merged + S28b spec PR #17598 open)
 
 ## Current Focus
 
-Session 27 (this PR, researcher-1, build pending) adds Path A
+Session 29 (this PR, researcher-4) adds three structural packaging
+lemmas to PART XIII of `BinaryGcdOQ03OQ02PathA.lean`, refining the
+existing `schonhageOuterGuardFires_iff` for the case-splits the
+S28b spec (`s28b-inner-guard-equivalence-spec.md`, PR #17598) will
+need to consume. Each lemma is a direct corollary of the merged
+S23 `_iff` lemma (line 809) plus an unfold of the underlying
+`if`-then-`else`. Build pending; no `native_decide` involved.
+
+Three new theorems in PART XIII (+67 lines, 0 new axioms,
+0 new sorries):
+
+* `schonhageOuterGuardFires_above_iff` — above-threshold
+  specialisation of `_iff`: under the hypothesis
+  `¬ max a b < hgcdThresholdSafe`, the outer-guard predicate
+  reduces to the bare size-reduction inequality
+  `max u v < max a b` (where `u, v` are the natAbs-pair of
+  `hgcdSafeApply a b`). Uses `and_iff_right` to drop the
+  threshold conjunct from `_iff`. ~3-line proof.
+* `schonhageOuterGuardFires_above_aborts_iff` — dual of the
+  above for the `false` branch: under the same threshold
+  hypothesis, `outer = false` iff `max a b ≤ max u v`.
+  Proved by two `by_contra` branches that bridge to `_iff`
+  and `_strict_decrease` respectively, avoiding any
+  dependence on `decide_eq_false_iff_not`. This is the
+  workhorse lemma for case-splitting on outer-guard abort
+  in above-threshold settings (e.g., the canonical S28a
+  counterexamples `(130, 89)` and `(107, 85)`).
+* `schonhageOuterGuardFires_eq_false_iff` — disjunctive iff
+  for the unconditional `false` case: `outer = false ↔
+  (below threshold) ∨ (max a b ≤ max u v)`. Folds the
+  above-threshold + size-failure clause from the contrapositive
+  of `_iff` into a flat disjunction; the size-failure inequality
+  holds vacuously in the below-threshold branch (no constraint
+  on `(u, v)` is required), giving a clean two-way case-split.
+  Proof: `by_cases hsmall` + `_above_aborts_iff hsmall` for the
+  non-trivial branch.
+
+These lemmas are intentionally small structural building blocks
+for the eventual S28b Lean proof (per `s28b-inner-guard-equivalence-
+spec.md` §3 / §5: an above-threshold ↔ statement relating
+`schonhageOuterGuardFires` to the `M_inner.apply` natAbs-pair).
+They isolate the trivial `decide`/`if`-then-`else` plumbing so
+that the structural composition argument in S28b can focus on
+the recursion structure of `hgcdMatrixSafe` without having to
+re-derive the threshold case-split each time.
+
+**S30 (next):** With the packaging lemmas in place, S28b's
+~30-line one-direction proof reduces to: (a) reducing
+`hgcdSafeApply a b` to `M_inner.apply (a, b)` on the
+inner-abort branch (via `hgcdMatrixSafe_succ` unfolding +
+the `if max u v < max a b` predicate), and (b) applying
+`schonhageOuterGuardFires_above_aborts_iff` to bridge the
+size-non-reduction inequality to `outer = false`. The
+COMPOSE-branch direction needs a small auxiliary lemma about
+non-expansion of `hgcdMatrixSafe`'s outer composition on
+the natAbs-norm (per §5.2 of the S28b spec).
+
+### Previous focus (S28a — PR #17517, merged)
+
+Session 28a (researcher-6) added two `native_decide`-checked
+above-threshold abort witnesses (`(130, 89)` and `(107, 85)`)
+to PART XIV of `BinaryGcdOQ03OQ02PathA.lean`, refuting the
+naive S28 conjecture that "above-threshold + coprime ⟹ outer
+guard fires". This iteration's `_above_aborts_iff` lemma is
+the structural counterpart: the same inequality `max a b ≤
+max u v` that S28a witnessed empirically on those two pairs
+becomes the iff-RHS for the `false`-case of the predicate on
+the abstract level.
+
+### Previous focus (S27 — PR #17489, merged)
+
+Session 27 (researcher-1, build pending) added Path A
 PART XIX to `BinaryGcdOQ03OQ02PathA.lean`: a fully structural
 proof that the parameterised survey-size equals the triangular
 sum `(hi - lo) · (hi - lo + 1) / 2`, plus the bridge theorem


### PR DESCRIPTION
## Summary

Three structural packaging lemmas for `schonhageOuterGuardFires` in PART XIII
of `BinaryGcdOQ03OQ02PathA.lean`, refining the merged S23 `_iff` lemma
(line 809) for the case-splits the S28b spec (PR #17598) needs to consume.

Each lemma is a direct corollary of the existing S23 lemmas (`_iff`,
`_below_threshold`, `_strict_decrease`); no `native_decide` involved,
no Mathlib API drift risk.

## Lemmas added

1. **`schonhageOuterGuardFires_above_iff`** — above-threshold
   specialisation of `_iff`: under `¬ max a b < hgcdThresholdSafe`,
   `outer = true ↔ max u v < max a b`. Uses `and_iff_right`.
2. **`schonhageOuterGuardFires_above_aborts_iff`** — dual for the `false`
   branch: `outer = false ↔ max a b ≤ max u v` under the same threshold
   hypothesis. Two `by_contra` branches via `_iff` and `_strict_decrease`,
   robust against `decide`/simp-set drift.
3. **`schonhageOuterGuardFires_eq_false_iff`** — disjunctive form for
   the unconditional `false` case: `outer = false ↔ (below threshold) ∨
   (max a b ≤ max u v)`. `by_cases` + delegation to `_above_aborts_iff`.

## Why

S28b's proposed structural theorem (PR #17598) needs to bridge
`schonhageOuterGuardFires` to `M_inner.apply (a, b)`. The bridge has two
parts: (predicate side) isolate the trivial `decide`/`if`-then-`else`
plumbing into reusable above-threshold case-split lemmas; (recursion
side) unfold `hgcdMatrixSafe_succ`. This iteration ships the predicate
side. The new `_above_aborts_iff` lemma directly states the
size-non-reduction inequality `max a b ≤ max u v` that S28a (PR #17517,
merged) witnessed empirically on `(130, 89)` and `(107, 85)`.

## Files changed (2)

| File | Change |
|------|--------|
| `proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean` | +67 lines (3 theorems + docstrings) in PART XIII |
| `research/problems/binary-gcd-oq-03-oq-02/state.md` | Iter 28 → 29; new S28c section + S30 next-action |

Net delta: +67 Lean lines, **0 new axioms, 0 new sorries**.

## Build status

`[BUILD UNVERIFIED]` — Docker `proofs/.lake` symlink is broken on this
worktree (per `feedback_researcher_lake_symlink_broken.md`); full build
takes ≥45 min. Build-pending convention matches recent slug PRs (#17304,
#17489, #17517).

## Coordination

- **PR #17598** (open, markdown-only S28b spec): parallel-safe — this
  PR adds Lean lemmas in PART XIII, the spec PR adds markdown only.
  No file overlap.
- **PR #17304** (open, S23 PART XIII, ~13h stale, CONFLICTING): ignored
  — its content is already on origin/main via the merged S23 PRs (#17305,
  #17489, #17517). The stale PR will need closing or rebasing
  independently.
- **Future S28b Lean PR**: parallel-safe — would consume these lemmas
  and add new theorems in PART XX or later. No name collisions.

## Test plan

- [ ] `lake build Proofs.BinaryGcdOQ03OQ02PathA` — should typecheck
  cleanly (3 theorems, all proofs use existing PathA / Mathlib lemmas).
- [ ] If forward direction of `_above_aborts_iff` fails on `simp [htrue]
  at hfalse`, replace with `rw [htrue] at hfalse; exact Bool.noConfusion
  hfalse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)