### PR TITLE
audit(schauder-fp-oq03-oq01): tracker update — issues-fixed via PR #17620

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12930,11 +12930,12 @@
       "result": "clean"
     },
     "schauder-fixed-point-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
-        "sorries 2→0, axiomCount 3→2, theoremCount 2→3, lineCount 280→349; prose drift in description/assumptions/originalContributions/sections (PR #16834)"
+        "sorries 2→0, axiomCount 3→2, theoremCount 2→3, lineCount 280→349; prose drift in description/assumptions/originalContributions/sections (PR #16834)",
+        "sorries 2→1, lineCount 517→668; brouwer_fpt body landed S13 (#17575); fix in PR #17620"
       ],
-      "lastAudited": "2026-05-08T00:53:24Z",
+      "lastAudited": "2026-05-09T02:45:00Z",
       "result": "issues-fixed"
     },
     "schroeder-bernstein": {


### PR DESCRIPTION
## Summary

Audit-tracker entry for `schauder-fixed-point-oq-03-oq-01`:
- `auditCount` 3 → 4
- `lastAudited` → 2026-05-09T02:45:00Z
- `result` stays `issues-fixed`
- New issues entry appended: `sorries 2→1, lineCount 517→668; brouwer_fpt body landed S13 (#17575); fix in PR #17620`

The meta.json content fix is in PR #17620.

## Test plan

- [x] tracker-only change; no gallery / Lean code touched
- [x] follows existing `audit(...)` commit-message convention (cf. #17583, #17558)

🤖 Generated with [Claude Code](https://claude.com/claude-code)