### PR TITLE
fix(meta): batch sync definitionCount drift (27 entries, erdos-9xx + erdos-8xx + amgm)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "lineCount": 1328,
     "theoremCount": 46,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
   },
@@ -179,7 +179,7 @@
     "lineCount": 1328,
     "axiomCount": 1,
     "theoremCount": 46,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -55,7 +55,7 @@
       "Lean 4 and Mathlib"
     ],
     "theoremCount": 12,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "crossReferences": [
     {
@@ -160,7 +160,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 239,
     "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C²-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs.",
     "theoremCount": 5,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1971 [Er71], motivated by the classical Turán problem. The Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ (proved by Turán in 1941) is the maximum edges in a triangle-free graph on $n$ vertices. When a graph exceeds this threshold by $k$ edges, triangles must exist by Turán's theorem. Erdős asked: can we find nearly $k$ edge-disjoint triangles? He originally conjectured $f(c) = 0$ for all $c$ (every excess edge 'belongs to' a unique triangle). Sauer disproved this with $K_{1,m,m}$: it has $2m$ excess edges but only $2m - 1$ edge-disjoint triangles, since the degree-1 vertex is a bottleneck. Erdős himself proved $f(c) = 0$ for $c < 1/2$ using chromatic number arguments. Györi (1988) [Gy88] resolved the problem completely, showing $f(c) \\leq Cc^2$ for an absolute constant $C$. The quadratic growth is essentially optimal. Györi also refined the small-$c$ range: $f(c) = 0$ for $c < 2$ (odd $n$) and $c < 3/2$ (even $n$), reflecting the parity-dependent structure of the Turán graph.",
@@ -237,7 +237,7 @@
     "lineCount": 239,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos1009Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-597/meta.json
+++ b/src/data/proofs/erdos-597/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 183,
     "assumptions": "6 axioms: omega_1, omega_1_times_omega, omega_1_squared, partitionArrow, erdosHajnalTriangle, baumgartnerCounterexample. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Erdős Problem #597 originates from the study of partition calculus, a branch of infinite combinatorics developed by Erdős and Rado in the 1950s. The partition arrow notation α → (β, γ)² encodes a Ramsey-type statement: every 2-coloring of pairs from a set of order type α yields either a homogeneous set of type β or a copy of γ. This problem was posed by Erdős in [Er87] and referenced in [Va99, 7.84].\n\nErdős originally asked whether ω₁² → (ω₁ω, G)² holds for all K₄-free graphs G on at most ℵ₁ vertices. However, Baumgartner demonstrated a counterexample: the complete bipartite graph K_{ℵ₀,ℵ₀} is K₄-free (being bipartite, it is even triangle-free), yet ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})². This forced a refinement of the conjecture to exclude K_{ℵ₀,ℵ₀} subgraphs.\n\nThe positive foundation comes from Erdős and Hajnal, who proved ω₁² → (ω₁ω, 3)² — the triangle case. The gap between the triangle (3 vertices) and K_{ℵ₀,ℵ₀} (infinitely many) is precisely where Problem #597 lives. The problem also asks specifically about finite K₄-free graphs G, which is a natural intermediate case. The problem may be sensitive to set-theoretic axioms beyond ZFC, as many partition relations at the level of ℵ₁ depend on assumptions like the Continuum Hypothesis or Martin's Axiom.",
@@ -148,7 +148,7 @@
     "lineCount": 183,
     "axiomCount": 6,
     "theoremCount": 1,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos597Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-599/meta.json
+++ b/src/data/proofs/erdos-599/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 230,
     "assumptions": "1 axiom: aharoni_berger_theorem. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 14
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "**Menger's Classical Theorem (1927)**\n\nKarl Menger proved in 1927 that for finite graphs, the maximum number of vertex-disjoint paths between two sets equals the minimum size of a separating set. This is one of the foundational results in graph theory, closely related to max-flow min-cut theorems.\n\n**Erdős Extends to Infinite Graphs (1981)**\n\nErdős asked whether Menger's theorem extends to infinite graphs. The natural formulation is: for disjoint independent sets A, B in any graph G, does there exist a family P of vertex-disjoint A-B paths and a set S containing exactly one vertex from each path, such that S separates A from B? For finite graphs, this is exactly Menger's theorem. For infinite graphs, it was a major open problem.\n\n**The Aharoni-Berger Breakthrough (2009)**\n\nRon Aharoni and Eli Berger proved the infinite case in their landmark paper 'Menger's theorem for infinite graphs' published in Inventiones Mathematicae. The proof uses sophisticated techniques from infinite matroid theory, marking a major advance in infinite combinatorics. The paper resolved a conjecture that had been open for almost 30 years.",
@@ -153,7 +153,7 @@
     "lineCount": 230,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 14,
+    "definitionCount": 17,
     "path": "Proofs/Erdos599Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-8/meta.json
+++ b/src/data/proofs/erdos-8/meta.json
@@ -55,7 +55,7 @@
     "assumptions": "2 axioms: hough_minimum_modulus (deep result, Hough 2015), density_conjecture_false (deep result). erdos_8_resolution now proved from bottleneck_counterexample + hough_minimum_modulus.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 15
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Graham in their 1980 book on combinatorial number theory. They conjectured that any finite coloring of the integers must admit a covering system whose moduli are all the same color.\n\nThe conjecture remained open until 2015, when Bob Hough's breakthrough on the minimum modulus problem for covering systems provided the key insight. Hough showed that the minimum modulus is bounded by 616,000, which creates a structural bottleneck exploitable to construct counterexamples.",
@@ -165,7 +165,7 @@
     "lineCount": 351,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 15,
+    "definitionCount": 17,
     "path": "Proofs/Erdos8Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-81/meta.json
+++ b/src/data/proofs/erdos-81/meta.json
@@ -55,7 +55,7 @@
     "assumptions": "4 axioms: split_is_chordal, extremal_construction_exists, erdos_ordman_zalcstein, peo_gives_clique_partition. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "A chordal graph is one with no induced cycles of length greater than 3, equivalently every cycle of length 4 or more has a chord. These graphs arise naturally in sparse matrix computations, database theory, and phylogenetics. Erdős, Ordman, and Zalcstein asked in 1993 how efficiently the edges of a chordal graph on n vertices can be partitioned into cliques, conjecturing that n²/6 + O(n) cliques always suffice.\n\nThe lower bound comes from an explicit extremal construction: take K_{n/3} and 2n/3 isolated vertices, connecting every K_{n/3} vertex to every isolated vertex. This split graph requires approximately n²/6 cliques because the bipartite edges between the clique and independent set cannot be efficiently grouped. Erdős, Ordman, and Zalcstein proved the upper bound that (1/4 - ε)n² cliques always suffice for some small ε > 0. Chen, Erdős, and Ordman (1994) improved this to 3n²/16 + O(n) for the special case of split graphs.\n\nThe gap between the upper bound coefficient 1/4 and the conjectured coefficient 1/6 (a factor of approximately 1.5) remains open. Chordal graphs are characterized by having a perfect elimination ordering (Dirac 1961, Fulkerson-Gross 1965), which gives a polynomial-time recognition algorithm and a greedy clique partition that is a 2-approximation, but the optimal coefficient for clique partitions remains unknown.",
@@ -176,7 +176,7 @@
     "lineCount": 290,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos81Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -20,7 +20,7 @@
     "lineCount": 238,
     "axiomCount": 0,
     "sorries": 19,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "theoremCount": 19,
     "additionalFiles": [
       "Proofs/Erdos901ProblemAristotle.lean"
@@ -88,7 +88,7 @@
     "assumptions": "No axioms. 19 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "additionalFiles": [
       "Proofs/Erdos901ProblemAristotle.lean"
     ]

--- a/src/data/proofs/erdos-902/meta.json
+++ b/src/data/proofs/erdos-902/meta.json
@@ -34,7 +34,7 @@
     "assumptions": "6 axioms: exists_n_dominating, szekeres_lower_bound, erdos_upper_bound, asymptotic_lower, asymptotic_upper, exists_non_dominating. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős posed this question about tournament domination in 1963, as part of his deep investigation into extremal combinatorics. A tournament is a complete directed graph — every pair of vertices has exactly one directed edge (one player beats the other). The function $f(n)$ gives the minimum tournament size where every $n$-element set of vertices is dominated by some external vertex: there exists a vertex $v$ not in the set that beats every member.\n\nSzekeres and Szekeres (1965) established the lower bound $f(n) \\geq n \\cdot 2^n$ using an elegant counting argument: each vertex dominates at most $\\binom{N-1}{n}$ of the $\\binom{N}{n}$ possible $n$-sets, and the total number of dominated $n$-sets must be at least $\\binom{N}{n}$, requiring $N$ to be large. The probabilistic method, pioneered by Erdős, gives the upper bound $f(n) \\leq C \\cdot n^2 \\cdot 2^n$: a random tournament of this size satisfies the domination property with positive probability.\n\nOnly $f(1) = 3$ (the cyclic tournament, \"Rock-Paper-Scissors\"), $f(2) = 7$ (the Paley tournament on $\\mathbb{F}_7$, constructed via quadratic residues), and $f(3) = 19$ (found by computer search) are known exactly. Tournament domination connects to the theory of voting paradoxes (Condorcet, 1785): the domination property means that for any committee of $n$ candidates, there exists an outsider who defeats every committee member in pairwise comparison — a quantitative strengthening of Condorcet's paradox. The algebraic structure of Paley tournaments, constructed from the Legendre symbol $(a/p)$, provides the best known explicit constructions, linking the problem to quadratic residues and number theory.",
@@ -210,7 +210,7 @@
     "lineCount": 146,
     "axiomCount": 6,
     "theoremCount": 2,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos902Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-903/meta.json
+++ b/src/data/proofs/erdos-903/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 211,
     "assumptions": "5 axioms: de_bruijn_erdos, projective_plane_design, efsw_1985, gap_theorem, fisher_inequality. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "This problem was a conjecture of Erdős and Sós about block designs. A block design on {1,...,n} is a collection of subsets (blocks) such that every pair of distinct elements is contained in exactly one block — equivalently, a pairwise balanced design (PBD).\n\nThe classic projective plane construction shows t = n is achievable when n = p² + p + 1 for prime power p. The de Bruijn-Erdős theorem (1948) established that t ≥ n for any block design, using a double-counting argument with Cauchy-Schwarz applied to the replication numbers r_x.\n\nErdős and Sós conjectured that there is a 'gap': if t > n, then t ≥ n + p. This was proved by Erdős, Fowler, Sós, and Wilson (1985) in the Proceedings of the London Mathematical Society, who further showed that unless the design comes from a projective plane with one line 'broken up' into singletons, we have t ≥ n + cp where c ≈ 1.148.\n\nThe problem connects to fundamental questions in finite geometry: the prime power conjecture (projective planes exist iff the order is a prime power), the Bruck-Ryser non-existence theorem, and the classification of near-minimal designs.",
@@ -166,7 +166,7 @@
     "lineCount": 211,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/Erdos903Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -32,7 +32,7 @@
     "assumptions": "1 axiom: bollobas_erdos_theorem. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Bollobás and Erdős conjectured this result about edge-triangle multiplicity. It was independently proved by Edwards (unpublished) and Hadziivanov-Nikiforov in 1979. The problem connects to Turán's classical theorem on triangle-free graphs. Turán's theorem (1941) established that the complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉} is the unique triangle-free graph on n vertices maximizing the number of edges, at exactly ⌊n²/4⌋. The question posed by Bollobás and Erdős pushed beyond mere existence of triangles to ask about their concentration: once the Turán bound is exceeded, must some edge bear a disproportionate share of the triangle count? The answer n/6 is tight, achieved by graphs close to the balanced complete bipartite graph with a small clique added. Nikiforov subsequently extended these ideas into a broader program on the distribution of cliques above Turán thresholds.",
@@ -168,7 +168,7 @@
     "lineCount": 190,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos905Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-915/meta.json
+++ b/src/data/proofs/erdos-915/meta.json
@@ -75,7 +75,7 @@
     "lineCount": 186,
     "assumptions": "8 axioms: k, ell, conjecture_m2, conjecture_m3, conjecture_m4, conjecture_false_m5, conjecture_false_large_m, mader_edge_disjoint. See Lean source for complete statements.",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "The Bollobás-Erdős conjecture (1962) is a landmark problem in extremal graph theory concerning the minimum number of edges needed to guarantee m disjoint paths between some pair of vertices. The problem connects to Menger's theorem, which equates the maximum number of disjoint paths to the minimum cut size. The natural extremal construction consists of n copies of K_m sharing a single vertex, which has 1 + (m-1)n vertices and 1 + C(m,2)n edges but contains no m vertex-disjoint paths between any pair.\n\nThe conjecture was gradually resolved over more than a decade. Bártfai (1960) settled the m = 3 case before the general conjecture was even formulated. Bollobás (1966) proved the m = 4 case, the last positive result. Then Leonard (1973) disproved the vertex-disjoint conjecture for m = 5 with an explicit 57-vertex counterexample matching the conjectured parameters exactly. Mader (1973) independently disproved all m ≥ 6 via asymptotic arguments. Sørensen and Thomassen (1974) found the exact formula k_5(n) = ⌊8n/3⌋ - 3 for n ≥ 13, showing the true threshold exceeds the conjectured 5n/2 by a factor of 16/15.\n\nRemarkably, while the vertex-disjoint version fails for m ≥ 5, Mader (1973) proved that the edge-disjoint analogue holds for all m ≥ 2 with the exact formula ℓ_m(n) = ⌊m(n-1)/2 + 1⌋. This complete dichotomy between vertex-disjoint and edge-disjoint paths is one of the most striking phenomena in extremal graph theory. Sørensen and Thomassen also showed that the vertex-disjoint conjecture holds for 3-connected graphs, indicating that the counterexamples must exploit low-connectivity structure.",
@@ -166,7 +166,7 @@
     "lineCount": 186,
     "axiomCount": 8,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos915Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 690,
     "assumptions": "None. All results are fully machine-checked. The Erdős-Hajnal graphs on ω₁² and ω₂² are proved to have chromatic numbers ℵ₁ and ℵ₂ respectively via double pigeonhole arguments. The open questions (Questions 1 and 2) are stated but not assumed. Open conjecture; supporting lemmas fully verified.",
     "theoremCount": 40,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős in 1969 [Er69b] and sits at the intersection of graph theory, set theory, and infinite combinatorics. It was inspired by Babai's theorem about chromatic properties of graphs on well-ordered vertex sets.\n\nErdős and Hajnal made crucial progress by constructing a counterexample at the ℵ₁ level. They built a graph on ω₁² (the ordinal product of two copies of the first uncountable ordinal) with chromatic number ℵ₁, but where every strictly smaller subgraph (by order type) has countable chromatic number ≤ ℵ₀. This showed that Babai's theorem does not generalize to higher cardinals.\n\nThe natural question then arises: can we do the same construction at the next level? This is Problem #919: does there exist a graph on ω₂² with chromatic number ℵ₂ where smaller subgraphs have chromatic number at most ℵ₀ (not just ℵ₁)?",
@@ -178,7 +178,7 @@
     "lineCount": 690,
     "axiomCount": 0,
     "theoremCount": 40,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos919Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-921/meta.json
+++ b/src/data/proofs/erdos-921/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "4 axioms: f, kierstead_szemeredi_trotter, gallai_lower_bound, erdos_upper_bound. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "**Erdős Problem #921**\n\nThis problem, posed jointly by Erdős and Gallai, explores the fundamental tension between a graph's chromatic number and its odd cycle structure.\n\n**Key History:**\n- **Gallai (1963):** Initiated the study by proving f_4(n) ≫ n^{1/2}, constructing explicit 4-chromatic graphs with large odd girth\n- **Erdős (unpublished):** Proved the matching upper bound f_4(n) ≪ n^{1/2}, showing the k=4 case is completely characterized\n- **Kierstead-Szemerédi-Trotter (1984):** Resolved the full conjecture for all k ≥ 4, proving f_k(n) ≍ n^{1/(k-2)}\n\n**Mathematical Significance:**\nThe result quantifies a deep principle: high chromatic number forces short odd cycles. A bipartite graph (χ = 2) has no odd cycles at all. As chromatic number increases, some odd cycles must appear, and this problem determines exactly how short they must be.",
@@ -133,7 +133,7 @@
     "lineCount": 169,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Erdos921Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 234,
     "assumptions": "4 axioms: h_1_exact, cgtt_1990, h_3_3, improved_upper_bound. 8 sorries.",
     "theoremCount": 10,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "additionalFiles": [
       "Proofs/Erdos934ProblemAristotle.lean"
     ]
@@ -189,7 +189,7 @@
     "lineCount": 234,
     "axiomCount": 4,
     "theoremCount": 10,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "sorries": 8,
     "path": "Proofs/Erdos934Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 218,
     "assumptions": "0 axiom declarations. Three conjectures/results stated as Prop definitions (not assumed true): erdos_938_conjecture (open), erdos_364_conjecture (open), powerful_count_asymptotic_theorem (known result, unused).",
     "theoremCount": 6,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Erdős Problem #938 was posed by Paul Erdős in 1976 [Er76d] and concerns the distribution of powerful numbers (also called squarefull numbers). A positive integer n is powerful if p | n implies p² | n for every prime p, or equivalently n = a²b³ for some positive integers a, b. The sequence of powerful numbers begins 1, 4, 8, 9, 16, 25, 27, 32, 36, 49, ... (OEIS A001694).\n\nThe problem sits at the intersection of multiplicative number theory and additive combinatorics. While the global distribution of powerful numbers is well understood — the count up to x is asymptotically (ζ(3/2)/ζ(3))·√x ≈ 2.17·√x — the local structure of gaps between consecutive powerful numbers is far more mysterious. The question of whether three consecutive powerful numbers can form an arithmetic progression infinitely often probes this local irregularity.\n\nThe problem is closely related to Erdős Problem #364, which makes the stronger conjecture that no three consecutive integers n, n+1, n+2 can all be powerful. If Problem #364 is true, it would forbid the simplest type of three-term AP (with common difference 1) among consecutive powerful numbers. Problem #938 remains open and cannot be resolved by finite computation alone.",
@@ -190,7 +190,7 @@
     "lineCount": 218,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "sorries": 0,
     "path": "Proofs/Erdos938Problem.lean"
   },

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -38,7 +38,7 @@
     "axiomCount": 0,
     "lineCount": 120,
     "theoremCount": 0,
-    "definitionCount": 0,
+    "definitionCount": 2,
     "assumptions": "0 axioms. Lean source contains only typeclass definitions (IsKVertexCritical, IsErdos944Graph) used as abstract predicates with no declared instances; the known results of Brown, Lattanzio, Jensen, and Martinsson-Steiner are described in comments only, not formally axiomatized. Open conjecture (k = 4 case unsolved)."
   },
   "overview": {
@@ -123,7 +123,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-947/meta.json
+++ b/src/data/proofs/erdos-947/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 192,
     "assumptions": "2 axioms: no_exact_covering_system, covering_systems_exist. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Covering systems were introduced by Erdős in the 1950s as a flexible tool in combinatorial number theory. A covering system is a finite collection of congruence classes $\\{a_i \\pmod{n_i}\\}$ such that every integer belongs to at least one class. The natural question of whether an 'exact' covering exists — one that partitions $\\mathbb{Z}$ into congruence classes with distinct moduli — was answered negatively by two independent proofs.\n\nMirsky and Newman proved the impossibility using generating functions: for an exact covering, the function $f(x) = \\sum_i x^{a_i}/(1 - x^{n_i})$ must equal $1/(1-x)$ (each integer represented exactly once as a power of $x$). Analyzing this identity near roots of unity of order $n_i$ reveals that distinct moduli cannot satisfy the resulting analytic constraints.\n\nDavenport and Rado gave an algebraic proof using LCM properties: if the moduli are $n_1 < n_2 < \\cdots < n_k$, the largest modulus $n_k$ must divide $\\text{lcm}(n_1, \\ldots, n_{k-1})$. This forces $n_k$ to be a factor of the LCM of smaller moduli, creating a contradiction with the partition requirement.\n\nThe result is sharp in two senses: ordinary covering systems (allowing overlaps) with distinct moduli do exist — for example $\\{0 \\pmod{2},\\, 0 \\pmod{3},\\, 1 \\pmod{4},\\, 5 \\pmod{6},\\, 7 \\pmod{12}\\}$ — and exact coverings exist when repeated moduli are allowed, as the trivial $\\{0 \\pmod{2},\\, 1 \\pmod{2}\\}$ demonstrates.\n\nA central observation is the density constraint: each class $a \\pmod{n}$ has natural density $1/n$, so for a partition the densities must sum to 1: $\\sum 1/n_i = 1$. While this equation has solutions with distinct $n_i$ (e.g., $1/2 + 1/3 + 1/6 = 1$), the additional constraint that the congruences partition $\\mathbb{Z}$ (not just have matching densities) is what makes the problem impossible.\n\n**Status**: SOLVED — Proved independently by Mirsky-Newman and Davenport-Rado.",
@@ -146,7 +146,7 @@
     "lineCount": 192,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos947Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-95/meta.json
+++ b/src/data/proofs/erdos-95/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 184,
     "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #95: Sum of Squared Distance Multiplicities**\n\nThis problem is part of Erdős's famous family of distinct distances problems, which he began studying in the 1940s. While Problem #94 asks for the minimum number of distinct distances among $n$ points in the plane, this companion problem asks about the *distribution* of distance multiplicities.\n\n**Historical Timeline:**\n- 1946: Erdős proved the lower bound $\\Omega(n^{1/2})$ for distinct distances and conjectured $\\Omega(n/\\sqrt{\\log n})$\n- 1963: Altman proved the convex polygon case: $O(n)$ distinct distances, each with multiplicity $O(n)$\n- 1983: Chung computed extremal configurations for small $n$ and established the lattice as near-extremal\n- 2001: Solymosi and Tóth improved the distinct distances lower bound to $\\Omega(n^{4/5})$\n- 2010: Elekes and Sharir developed the framework reducing distance problems to 3D incidence problems\n- 2015: Guth and Katz proved $\\sum f(d)^2 \\ll n^3 \\log n$ AND the distinct distances conjecture $\\Omega(n/\\log n)$ in the same landmark *Annals of Mathematics* paper\n\n**Why the Lattice is Extremal:** For the $\\sqrt{n} \\times \\sqrt{n}$ integer lattice, a distance $d$ occurs $f(d) \\sim \\frac{n}{\\sqrt{\\log n}} \\cdot r_2(d^2)$ times on average, where $r_2(m)$ is the number of representations of $m$ as a sum of two squares. Since $\\sum_{m \\le x} r_2(m)^2 \\sim cx \\log x$ (Ramanujan), we get $\\sum f(d)^2 = \\Theta(n^3 \\log n)$.\n\n**The Polynomial Revolution:** The Guth-Katz paper introduced polynomial partitioning to combinatorial geometry, spawning an entirely new research program. The technique has since been applied to problems in incidence geometry, harmonic analysis, and theoretical computer science.",
@@ -166,7 +166,7 @@
     "lineCount": 184,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos95Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 259,
     "assumptions": "0 axioms. All former axioms eliminated: primeSeq_well_separated proved via FTA (factorization_prod_at), beurlings_conjecture converted to def (Prop, not asserted). File is fully verified. Open conjecture; supporting lemmas fully verified.",
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #951: Beurling Prime Numbers**\n\nThis problem connects Erdős's interest in extremal properties of primes with Beurling's theory of generalized primes, asking whether the ordinary primes are the densest well-separated multiplicative sequence.\n\n**Historical Timeline:**\n- 1937: Arne Beurling introduced generalized primes in his paper 'Analyse de la loi asymptotique de la distribution des nombres premiers généralisés', proving a generalized PNT\n- 1960s: Erdős reported this question was posed during his lecture at Queens College, possibly by S. Shapiro\n- 1977: Diamond proved Beurling's theorem is sharp — the error term $o(\\log x)$ in the generalized PNT cannot be weakened\n- 2000s: Zhang and others developed the modern theory of Beurling generalized integers with applications to number theory\n\n**Beurling's Framework:** A Beurling prime sequence $1 < a_1 < a_2 < \\ldots$ generates 'Beurling integers' via products $\\prod a_i^{k_i}$. The key condition is that distinct products differ by at least 1, mimicking how distinct products of ordinary primes (i.e., distinct positive integers) are at least 1 apart by the Fundamental Theorem of Arithmetic.\n\n**The Deep Question:** Erdős asks whether this well-separation condition alone — without any further structure — forces $\\pi_a(x) \\le \\pi(x)$. This would mean that among all multiplicatively well-separated sequences, the primes pack the most elements below any threshold $x$. This is a remarkable extremality claim about the primes.\n\n**Why It's Hard:** The well-separation condition is global: changing one element of the sequence affects all products, creating complex constraints. There is no known technique to bound $\\pi_a(x)$ from below for arbitrary well-separated sequences.",
@@ -171,7 +171,7 @@
     "lineCount": 259,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos951Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "2 axioms: erdos_pach_upper_bound, grid_construction. 6 sorries.",
     "lineCount": 309,
     "theoremCount": 14,
-    "definitionCount": 13
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**Unit Distances Between Convex Translates**\n\nThe study of repeated distances in combinatorial geometry traces back to Erdős's landmark 1946 paper, where he asked for the maximum number $f(n)$ of unit distances determined by $n$ points in the plane. Erdős showed $f(n) \\geq n^{1+c/\\log\\log n}$ using a $\\sqrt{n} \\times \\sqrt{n}$ section of the integer lattice, and conjectured the upper bound $f(n) = O(n^{1+\\epsilon})$ for every $\\epsilon > 0$. In 1983, Spencer, Szemerédi, and Trotter proved $f(n) = O(n^{4/3})$ using their celebrated point-line incidence theorem, which remains the best known upper bound.\n\nProblem #956 generalizes this from points to compact convex sets. Erdős and Pach introduced the function $h(n)$—the maximum number of pairs at unit distance among $n$ disjoint translates of a fixed compact convex set $C \\subset \\mathbb{R}^2$—in their 1990 paper \"Variations on the theme of repeated distances\" in Combinatorica. They observed that since small disks around points are convex translates, one always has $h(n) \\geq f(n)$. Using a reduction to the Szemerédi-Trotter framework, they proved $h(n) = O(n^{4/3})$ for translates and $O(n^{7/5})$ for general (non-translate) disjoint convex sets.\n\nThe conjecture asks whether $h(n) > n^{1+c}$ for some absolute constant $c > 0$. This would imply that the convex sets structure does not help reduce unit distances compared to points. The best known lower bound is $\\Omega(n \\log n / \\log\\log n)$ from grid-based constructions, leaving a wide gap. The problem remains open and connects deeply to incidence geometry, the Szemerédi-Trotter theorem, and the broader theme of geometric extremal problems.\n\n**Status**: OPEN — The Erdős-Pach conjecture is unresolved.",
@@ -209,7 +209,7 @@
     "lineCount": 309,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 13,
+    "definitionCount": 16,
     "sorries": 6,
     "path": "Proofs/Erdos956Problem.lean"
   },

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "2 axioms: erdos_960_disproof (APSSV 2026 — quadratic lower bound F ≥ n²/12 - 10n/3 for r≥3, k≥4), erdos_960_littleo_false (negation of little-o conjecture). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős Problem #960 originates from Erdős's 1984 paper [Er84] and concerns the interplay between ordinary lines and Ramsey-type phenomena in discrete geometry. An ordinary line is one passing through exactly two points of a configuration. The Sylvester-Gallai theorem (1893) guarantees at least one ordinary line for any non-collinear finite point set, and the Green-Tao theorem (2013) strengthened this to at least n/2 ordinary lines when no three points are collinear.\n\nThe problem asks about a higher-order structure: given many ordinary lines, must there exist r points whose C(r,2) connecting lines are all ordinary? The threshold f_{r,k}(n) measures the minimum number of ordinary lines needed to force such an 'all-ordinary' r-subset, among n-point configurations with no k collinear. Turán's theorem from extremal graph theory provides an upper bound by viewing the ordinary line relation as a graph.\n\nThe central conjecture that f_{r,k}(n) = o(n²) was DISPROVED in 2026 by Alexeev, Putterman, Sawhney, Sellke, and Valiant (arXiv:2604.06609). Their construction uses a cyclic subgroup of the real elliptic curve E: y^2 = x^3 - x + 1 with the zero residue class mod 7 removed, yielding a point set with no 4 collinear points and Omega(n^2) ordinary lines but no r-point all-ordinary subset. The AI-generated proof demonstrates that current AI systems can produce novel combinatorial geometry constructions.",
@@ -165,7 +165,7 @@
     "lineCount": 296,
     "axiomCount": 2,
     "theoremCount": 13,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos960Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-967/meta.json
+++ b/src/data/proofs/erdos-967/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 240,
     "assumptions": "1 axiom: yip_counterexample. 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**The Erdős-Ingham Paper (1964)**\n\nThis problem originates from 'Arithmetical Tauberian Theorems' by Erdős and Ingham (1964). They discovered a remarkable equivalence: the non-vanishing of 1 + ∑ₖ 1/aₖ^(1+it) for all t is equivalent to a Tauberian implication about functional equations. If f(x) + ∑ₖ f(x/aₖ) = (C + o(1))x for non-decreasing f, does f(x) = (1 + o(1))x follow? The answer depends on whether the Dirichlet sum has zeros.\n\n**The Simplest Unsolved Case (1964-2025)**\n\nRemarkably, Erdős and Ingham could not resolve even the simplest finite case: {2, 3, 5}. Does 1 + 2^(-1-it) + 3^(-1-it) + 5^(-1-it) = 0 for some real t? This connects to deep questions in transcendence theory - specifically the Four Exponentials Conjecture. If 4EC holds, the {2,3,5} sum never vanishes.\n\n**Yip's Breakthrough (2025)**\n\nAfter 60 years, Chi Hoi Yip (arXiv:2512.16528) settled the infinite sequence case definitively: the conjecture is FALSE. For any nonzero t, Yip constructs a sequence where the sum equals zero. The construction exploits the oscillatory nature of a^(it) to achieve precise phase cancellation. However, the finite sequence case - including {2,3,5} - remains tantalizingly open.",
@@ -193,7 +193,7 @@
     "lineCount": 240,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos967Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-973/meta.json
+++ b/src/data/proofs/erdos-973/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 188,
     "assumptions": "4 axioms: maxPowerSum, erdos_unit_disk_construction, l_erdos_1992_bounds, turan_lower_bound. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Erdős Problem #973 is part of Turán's power sum method, one of the most important tools in analytic number theory. The question asks whether, for sequences z_i with z₁ = 1 and |z_i| ≥ 1, the maximum of |∑ z_i^k| over 2 ≤ k ≤ n+1 can decay exponentially as C^{-n} for some universal C > 1. Hayman listed this as Problem 7.3 in his 1974 collection, attributing it to Erdős.\n\nThe answer depends critically on the modulus constraint. Erdős himself showed that for |z_i| ≤ 1 (the unit disk), such sequences exist with C ≈ 1.32. L. Erdős (1992) refined the picture for unit circle sequences (|z_i| = 1), proving tight bounds (1.746)^{-n} < M₂ < (1.745)^{-n} where M₂ is the optimal maximum power sum. For the original question with |z_i| ≥ 1, Turán's Theorem 6.1 gives a lower bound of (2e)^{-(1+o(1))n}, but the precise answer remains open.\n\nTurán's power sum method connects to Dirichlet polynomials, L-function zero-free regions, and equidistribution theory. The problem illustrates how the geometry of the constraint set (disk, circle, or exterior) fundamentally changes the extremal behavior of power sums.",
@@ -182,7 +182,7 @@
     "lineCount": 188,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos973Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-988/meta.json
+++ b/src/data/proofs/erdos-988/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 228,
     "assumptions": "5 axioms: roth_1954, schmidt_1969, min_discrepancy_tends_to_infinity, and 2 more. See Lean source for complete statements.",
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "**Erdős Problem #988: Discrepancy on the Sphere**\n\nThis is a fundamental problem in discrepancy theory, asking whether finite point sets on the sphere can approximate uniform distribution arbitrarily well.\n\n**Key History:**\n- Erdős (1964): Posed the problem\n- Roth (1954): Proved the analogous result for the unit square with axis-aligned rectangles\n- Schmidt (1969): Proved for the sphere in any dimension\n\n**Mathematical Setting:**\nGiven n points on S², we measure 'discrepancy' by how much the point count in any spherical cap deviates from the expected fraction. Schmidt proved this deviation must grow as n → ∞.",
@@ -173,7 +173,7 @@
     "lineCount": 228,
     "axiomCount": 5,
     "theoremCount": 4,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "path": "Proofs/Erdos988Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -88,7 +88,7 @@
     "assumptions": "2 axioms: beck_lower_bound, beck_upper_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z₁, z₂, ...} ⊂ ℝ², define the circle discrepancy function:\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is πr². The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) ≥ c√(log N) for points in [0,1]². Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by József Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1–49):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) ≫ r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like √r\n   - Proof uses Fourier analysis and properties of Bessel functions J₁\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J₁, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) ≪ (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice ℤ² by small random displacements\n   - The log factor comes from union bounds over O(r²) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is Θ̃(√r), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
@@ -220,7 +220,7 @@
     "lineCount": 341,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos989Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-996/meta.json
+++ b/src/data/proofs/erdos-996/meta.json
@@ -82,7 +82,7 @@
     "lineCount": 353,
     "assumptions": "2 axioms: matsuyama_1966, lacunary_quasi_independent. 0 sorries.",
     "theoremCount": 6,
-    "definitionCount": 14
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "Erdős Problem #996 sits at the intersection of harmonic analysis, probability theory, and ergodic theory. It concerns the strong law of large numbers for sequences evaluated along lacunary (exponentially growing) subsequences.\n\n**Origins in Weyl's Equidistribution (1916)**\n\nThe problem traces back to Weyl's theorem: for irrational α, the sequence {α}, {2α}, {3α}, ... is equidistributed mod 1. The natural question is what happens when we sample only at lacunary times n₁, n₂, ...\n\n**The Problem's Historical Progression**\n\nThe decay conditions required for the strong law were progressively weakened:\n- **Raikov**: Proved the strong law for geometric sequences nₖ = aᵏ unconditionally — no Fourier decay condition needed at all\n- **Kac-Salem-Zygmund (1948)**: First general result for lacunary sequences, requiring Fourier error ‖f - fₙ‖₂ = O(1/(log n)^c) for c > 1. The proof uses a Borel-Cantelli argument.\n- **Erdős (1949)**: Improved to O(1/(log log n)^c) for c > 1 — replacing log with log log, a dramatic weakening of the regularity assumption\n- **Matsuyama (1966)**: Further improved the exponent from c > 1 to c > 1/2 for log log decay. The exponent 1/2 is suggestive of the central limit theorem.\n\nThe open question asks whether we can push to log log log decay — adding yet another level of iterated logarithm to the hierarchy. The pattern of improvements suggests it might work, but current techniques cannot bridge the gap.",
@@ -233,7 +233,7 @@
     "lineCount": 353,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos996Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `meta.definitionCount` and `leanFile.definitionCount` for 27
entries where the Lean source files added definitions since the last
meta update. Mostly the erdos-9xx batch (matching the erdos-7xx pattern
of PR #17572).

## Counting convention

Standard mechanic regex (PR #17545 / #17572):

```
^\s*(?:(?:partial|private|protected|noncomputable|unsafe|scoped)\s+)*(def|abbrev|opaque|structure|inductive|class)\s+\w
```

after stripping nested `/-...-/` and `--` comments.

## Per-entry deltas (claimed → actual)

| slug | claimed | actual | delta |
|---|---|---|---|
| amgm-inequality-oq-04-oq-02 | 9 | 10 | +1 |
| erdos-1009-oq-02 | 9 | 10 | +1 |
| erdos-1009 | 14 | 15 | +1 |
| erdos-597 | 8 | 9 | +1 |
| erdos-599 | 14 | 17 | +3 |
| erdos-8 | 15 | 17 | +2 |
| erdos-81 | 9 | 10 | +1 |
| erdos-901 | 9 | 10 | +1 |
| erdos-902 | 7 | 8 | +1 |
| erdos-903 | 6 | 8 | +2 |
| erdos-905 | 9 | 10 | +1 |
| erdos-915 | 8 | 9 | +1 |
| erdos-919 | 14 | 15 | +1 |
| erdos-921 | 1 | 2 | +1 |
| erdos-934 | 9 | 10 | +1 |
| erdos-938 | 13 | 14 | +1 |
| erdos-944 | 0 | 2 | +2 |
| erdos-947 | 6 | 7 | +1 |
| erdos-95 | 8 | 9 | +1 |
| erdos-951 | 9 | 10 | +1 |
| erdos-956 | 13 | 16 | +3 |
| erdos-960 | 7 | 8 | +1 |
| erdos-967 | 10 | 11 | +1 |
| erdos-973 | 13 | 14 | +1 |
| erdos-988 | 11 | 13 | +2 |
| erdos-989 | 14 | 15 | +1 |
| erdos-996 | 14 | 15 | +1 |

## Scope

Pure metadata sync. No Lean source changes. 54 lines across 27 files
(each file: 2 occurrences in `meta` and `leanFile` blocks).

Skipped: any slugs covered by currently-open mechanic PRs (erdos-643, navier-stokes, etc).

---
Automated fix by lean-mechanic agent.