### PR TITLE
research(four-square-distribution-oq-01): S15 — Part 24 σ*-side images of S11.alt's atomic axioms (build pending)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -1771,4 +1771,133 @@ example : r4Count 6 = jacobiR4 6 :=
     (fun _ _ => rfl)
     (by decide : (0 : ℕ) < 6)
 
+-- =====================================================================
+-- PART 24: σ*-side images of S11.alt's elementary atomic axioms (S15)
+--
+-- PR #17388's S11.alt decomposes `jacobi_r4_formula` (Part 5) into three
+-- elementary `r4Count` facts (Hodd, HtwoPow, Hmul). Two of those three —
+-- (Hodd) `r4Count(n) = 8·σ(n)` for odd n, and (HtwoPow) `r4Count(2^k) = 24`
+-- for k ≥ 1 — have AXIOM-FREE σ*-side images on `jacobiR4 = 8·σ*`:
+--
+--   `jacobiR4_eq_eight_sigmaOne_of_odd`: for odd n,
+--      `jacobiR4 n = 8 · σ(n)`     (via `sigmaStar_eq_sigmaOne_of_odd`,
+--                                   Part 6)
+--   `jacobiR4_two_pow`:              for k ≥ 1,
+--      `jacobiR4 (2^k) = 24`        (via `sigmaStar_two_pow`, Part 13)
+--
+-- These are the σ*-side counterparts that hold UNCONDITIONALLY (no
+-- modular-form bridge needed). The corresponding `r4Count`-side facts
+-- (which would be the actual (Hodd) and (HtwoPow) of S11.alt) follow
+-- from the open axiom `jacobi_r4_formula` and so remain axiomatic on
+-- this side; they are recorded here as direct consequences for symmetry
+-- with the σ*-side identities and as named entry points for downstream
+-- chains. Closing (Hodd) or (HtwoPow) axiom-free on the `r4Count` side
+-- (e.g. via the bijection arguments sketched in PR #17388's docstring
+-- and Mordell 1917) would discharge the open axiom on the corresponding
+-- subdomain; the multiplicativity hypothesis (Hmul) of S11.alt is the
+-- third leg and is already named axiomatically as `r4Count_mul_of_coprime`
+-- (Part 20).
+--
+-- This Part is COMPLEMENTARY to Part 23 (S14, modular-form route): Part 23
+-- closes the open axiom from a SINGLE-FUNCTION abstraction `QC : ℕ → ℕ`
+-- representing the q-coefficient extractor; Part 24 names the two
+-- ELEMENTARY ARITHMETIC facts that S11.alt's three-hypothesis route
+-- predicts on the σ*-side. Both Parts 23 and 24 leave the open axiom
+-- in place; the value is in capturing the named decomposition pieces
+-- so that future Mathlib-side or bijection-side advances slot in
+-- without re-proof.
+-- =====================================================================
+
+/-- **σ*-side image of (Hodd).** For odd `n`, `jacobiR4 n = 8 · σ(n)`.
+
+    Axiom-free: definition of `jacobiR4` plus
+    `sigmaStar_eq_sigmaOne_of_odd` (Part 6). Generalises Part 21's
+    `jacobiR4_odd_prime` (odd PRIME, k = 1) and Part 22's
+    `jacobiR4_prime_pow_of_odd_prime` (odd prime POWER) to ALL odd `n`,
+    including odd composites like `n = 15 = 3 · 5`. The hypothesis
+    `0 < n` is not required: `n = 0` gives `jacobiR4 0 = 0 = 8 · 0` and
+    `0 < n → ¬ 2 ∣ n` is the relevant case for the Jacobi-1834 closure;
+    we keep the lemma in the uniform `¬ 2 ∣ n` form since
+    `0 < n` is implied by `¬ 2 ∣ n` only via excluded middle on
+    `n = 0` separately. -/
+theorem jacobiR4_eq_eight_sigmaOne_of_odd {n : ℕ} (hn : ¬ 2 ∣ n) :
+    jacobiR4 n = 8 * sigmaOne n := by
+  unfold jacobiR4
+  rw [sigmaStar_eq_sigmaOne_of_odd hn]
+
+/-- **r4Count-side analogue of (Hodd) (axiomatic).** For odd `n > 0`,
+    `r4Count n = 8 · σ(n)`.
+
+    Chains `jacobi_r4_formula` (Part 5) with
+    `jacobiR4_eq_eight_sigmaOne_of_odd` (this Part). This is exactly the
+    (Hodd) hypothesis of PR #17388's S11.alt decomposition; here it is
+    derived FROM the open axiom rather than assumed. An axiom-free proof
+    of this lemma — e.g. via Mordell's 1917 bijection or a direct
+    Lagrange-identity argument on odd-modulus 4-tuples — would discharge
+    the open conjecture on the odd subdomain. -/
+theorem r4Count_eq_eight_sigmaOne_of_odd {n : ℕ}
+    (hpos : 0 < n) (hn : ¬ 2 ∣ n) :
+    r4Count n = 8 * sigmaOne n := by
+  rw [jacobi_r4_formula n hpos]
+  exact jacobiR4_eq_eight_sigmaOne_of_odd hn
+
+/-- **σ*-side image of (HtwoPow).** For `k ≥ 1`, `jacobiR4 (2^k) = 24`.
+
+    Axiom-free: definition of `jacobiR4` plus `sigmaStar_two_pow`
+    (Part 13). The constant `24 = 8 · 3` reflects `σ*(2^k) = 3` for any
+    `k ≥ 1`. This is the pure-2-power specialisation of Part 15's
+    `jacobiR4_two_pow_mul_odd` at `m = 1` (since `σ(1) = 1`), but
+    presented directly without the multiplicative coupling. -/
+theorem jacobiR4_two_pow {k : ℕ} (hk : 1 ≤ k) : jacobiR4 (2 ^ k) = 24 := by
+  unfold jacobiR4
+  rw [sigmaStar_two_pow hk]
+
+/-- **r4Count-side analogue of (HtwoPow) (axiomatic).** For `k ≥ 1`,
+    `r4Count (2^k) = 24`.
+
+    Chains `jacobi_r4_formula` (Part 5) with `jacobiR4_two_pow`
+    (this Part). This is exactly the (HtwoPow) hypothesis of PR #17388's
+    S11.alt decomposition; here it is derived FROM the open axiom. The
+    statement `r₄(2^k) = 24` for `k ≥ 1` is provable axiom-free via a
+    finite induction + bijection argument on parity-balanced 4-tuples,
+    independent of the modular-form route. -/
+theorem r4Count_two_pow {k : ℕ} (hk : 1 ≤ k) : r4Count (2 ^ k) = 24 := by
+  have h2 : 0 < 2 ^ k := pow_pos (by decide : (0 : ℕ) < 2) k
+  rw [jacobi_r4_formula _ h2]
+  exact jacobiR4_two_pow hk
+
+-- ---------------------------------------------------------------------
+-- Cross-validation against Part 1's brute-force values (`r4Count_n`):
+-- the σ*-side closed form recovers `r4Count n = 8 · σ(n)` for small odd
+-- n and `r4Count(2^k) = 24` for small k.
+-- ---------------------------------------------------------------------
+
+/-- jacobiR4 1 = 8 · σ(1) = 8 · 1 = 8 (matches Part 1's `r4Count_1`
+    via the open axiom). -/
+example : jacobiR4 1 = 8 * sigmaOne 1 :=
+  jacobiR4_eq_eight_sigmaOne_of_odd (by decide)
+
+/-- jacobiR4 3 = 8 · σ(3) = 8 · (1 + 3) = 32. Matches Part 1's
+    `jacobiR4_3` numerical example. -/
+example : jacobiR4 3 = 8 * sigmaOne 3 :=
+  jacobiR4_eq_eight_sigmaOne_of_odd (by decide)
+
+/-- jacobiR4 15 = 8 · σ(15) = 8 · (1 + 3 + 5 + 15) = 8 · 24 = 192. The
+    first odd COMPOSITE value beyond Part 21/22's prime-power coverage:
+    15 = 3 · 5 is coprime, with `sigmaStar 15 = sigmaOne 15` since 15
+    is odd. -/
+example : jacobiR4 15 = 8 * sigmaOne 15 :=
+  jacobiR4_eq_eight_sigmaOne_of_odd (by decide)
+
+/-- jacobiR4 (2^1) = 24. -/
+example : jacobiR4 (2 ^ 1) = 24 := jacobiR4_two_pow (by decide)
+
+/-- jacobiR4 (2^3) = 24. The σ*-side identity `σ*(2^k) = 3` collapses
+    the formula at every k ≥ 1 to a SINGLE constant 24, explaining the
+    "pure-2-power plateau" of `jacobiR4` on `{2, 4, 8, 16, …}`. -/
+example : jacobiR4 (2 ^ 3) = 24 := jacobiR4_two_pow (by decide)
+
+/-- r4Count (2^2) = 24, axiomatic via Jacobi's formula. -/
+example : r4Count (2 ^ 2) = 24 := r4Count_two_pow (by decide)
+
 end FourSquareDistributionOQ01

--- a/research/problems/four-square-distribution-oq-01/state.md
+++ b/research/problems/four-square-distribution-oq-01/state.md
@@ -2,22 +2,39 @@
 
 ## Current State
 **Phase**: ACT
-**Phase note**: S14 (this PR, researcher-6) implements S13's spec
-deliverable AXIOM-FREE: Part 23 in `FourSquareDistributionOQ01.lean`
-states `jacobi_r4_formula_from_modular_form` as a 2-hypothesis
-implication theorem (no new axioms, no sorries) plus 3
-cross-validation `example`s. Departing from S13 spec §4.1 (which
-proposed adding 2 NEW axioms), the implementation abstracts the
-q-coefficient extractor as a parameter `QC : ℕ → ℕ` so the
-hypotheses are stated as `∀`-quantified equations on `r4Count` and
-`jacobiR4` only — pure arithmetic, no modular-form symbols, no
-upstream Mathlib dependence at the file level. Closing the two
-hypotheses (which encode `(Hθ4Coef)` q-coefficient bridge and the
-combined `(Hθ4Eis)` + `E2_qExpansion` Eisenstein-coefficient
-identity, parallel to PR #17388's S11.alt elementary route)
-discharges `jacobi_r4_formula`. axiomCount stays at 1 (only the
-original `jacobi_r4_formula` axiom). Net delta: +121 lines
-(1653 → 1774), +1 theorem (106 → 107), 0 new axioms, 0 new sorries.
+**Phase note**: S15 (this PR, researcher-9) names the σ*-side images
+of two of S11.alt's three elementary atomic axioms — `(Hodd)` and
+`(HtwoPow)` — as standalone, AXIOM-FREE theorems on `jacobiR4`:
+* `jacobiR4_eq_eight_sigmaOne_of_odd`: for odd `n`,
+  `jacobiR4 n = 8 · σ(n)` (axiom-free via `sigmaStar_eq_sigmaOne_of_odd`,
+  Part 6).
+* `jacobiR4_two_pow`: for `k ≥ 1`, `jacobiR4 (2^k) = 24` (axiom-free
+  via `sigmaStar_two_pow`, Part 13).
+The corresponding `r4Count`-side facts (`r4Count_eq_eight_sigmaOne_of_odd`,
+`r4Count_two_pow`) chain via the open axiom `jacobi_r4_formula` and
+match the (Hodd) and (HtwoPow) hypotheses of PR #17388's S11.alt
+elementary three-hypothesis decomposition (the third leg, (Hmul), is
+already named axiomatically as Part 20's `r4Count_mul_of_coprime`).
+Net delta: +121 lines (1774 → 1903), +4 theorems (107 → 111), 0 new
+axioms, 0 new sorries. Generalises Part 21's `jacobiR4_odd_prime`
+(odd prime, k=1) and Part 22's `jacobiR4_prime_pow_of_odd_prime`
+(odd prime power) to ALL odd `n`, including odd composites.
+Complementary to Part 23 (S14, modular-form route) — Part 23 abstracts
+the q-coefficient extractor `QC : ℕ → ℕ` and closes via two ∀-quantified
+hypotheses; Part 24 names the elementary arithmetic facts that S11.alt's
+elementary route consumes.
+S14 (PR #17524, merged): Part 23 — `jacobi_r4_formula_from_modular_form`
+as a 2-hypothesis implication theorem on parameter `QC : ℕ → ℕ`
+(axiom-free).
+S13 (PR #17515, merged): analysis-only modular-form decomposition
+**spec** complementary to S11.alt's elementary 3-hypothesis
+decomposition (PR #17388). Documents the (Hθ4Coef) q-coefficient
+bridge + (Hθ4Eis) modular-form identification + 9-month Mathlib
+upstream contribution sequence. The spec was decoupled from the
+Lean file to avoid contention with build-pending PRs; this PR is
+the implementation transcription, specialised to be axiom-free.
+S12 (PR #17490, merged): Part 22 — `jacobiR4(p^k) = 8·σ(p^k)` and
+`r4Count(p^k) = 8·σ(p^k)` for odd prime `p`, any `k ≥ 0`.
 S13 (PR #17515, merged): analysis-only modular-form decomposition
 **spec** complementary to S11.alt's elementary 3-hypothesis
 decomposition (PR #17388). Documents the (Hθ4Coef) q-coefficient
@@ -29,8 +46,8 @@ S12 (PR #17490, merged): Part 22 — `jacobiR4(p^k) = 8·σ(p^k)` and
 `r4Count(p^k) = 8·σ(p^k)` for odd prime `p`, any `k ≥ 0`.
 **Path**: full
 **Since**: 2026-05-08T21:33:45+03:00
-**Last Updated**: 2026-05-09 (S14, researcher-6; Part 23 implementation)
-**Iteration**: 14
+**Last Updated**: 2026-05-09 (S15, researcher-9; Part 24 σ*-side atomic-axiom images)
+**Iteration**: 15
 
 ## Current Focus
 S13 (this session, analysis-only) adds
@@ -156,7 +173,7 @@ Currently still blocked on Mathlib infrastructure:
 
 ## Attempt Count
 
-- Total attempts: 13.
+- Total attempts: 15.
 - S1 (researcher-?): OBSERVE/ORIENT bootstrap (axiomatize, n = 1..10).
 - S2 (researcher-10): ACT — σ*(n) = σ(n) − 4·σ(n/4)·[4∣n] structural.
 - S3 (researcher-?): σ* on odd prime powers, σ*(2n)/σ*(4n) = 3·σ(n).
@@ -205,6 +222,19 @@ Currently still blocked on Mathlib infrastructure:
   modular-form route at axiom-statement granularity for a follow-up
   S13-implement session (~60–80 lines of Part 23 axiomatic
   scaffolding).
+- S14 (researcher-6, 2026-05-09, PR #17524): Part 23 —
+  `jacobi_r4_formula_from_modular_form` axiom-free 2-hypothesis
+  implication theorem on parameter `QC : ℕ → ℕ`, transcribing S13's
+  spec without adding new axioms. +121 lines, 0 new sorries.
+- S15 (researcher-9, 2026-05-09, this PR): Part 24 — σ*-side images of
+  S11.alt's atomic-axiom decomposition: `jacobiR4_eq_eight_sigmaOne_of_odd`
+  (axiom-free, generalising Part 21/22's odd-prime/odd-prime-power
+  cases to ALL odd `n`), `r4Count_eq_eight_sigmaOne_of_odd` (axiomatic
+  via `jacobi_r4_formula`), `jacobiR4_two_pow` (axiom-free via
+  `sigmaStar_two_pow`, Part 13), `r4Count_two_pow` (axiomatic). These
+  name S11.alt's (Hodd) and (HtwoPow) on both sides; the third leg
+  (Hmul) is already named axiomatically as Part 20's
+  `r4Count_mul_of_coprime`. +121 lines, 0 new axioms, 0 new sorries.
 - Approaches tried: 1 (Approach A — modular form bridge).
 
 ## Blockers


### PR DESCRIPTION
## Summary

Names the σ*-side images of two of [PR #17388 (S11.alt)](https://github.com/rjwalters/lean-genius/pull/17388)'s three elementary atomic axioms as standalone, **axiom-free** theorems on `jacobiR4`. Complementary to [PR #17524 (S14, Part 23)](https://github.com/rjwalters/lean-genius/pull/17524)'s modular-form route.

## Part 24 (4 theorems, 6 cross-validation examples)

**Axiom-free σ\*-side:**
- `jacobiR4_eq_eight_sigmaOne_of_odd {n : ℕ} (hn : ¬ 2 ∣ n) : jacobiR4 n = 8 * sigmaOne n` — via `sigmaStar_eq_sigmaOne_of_odd` (Part 6). Generalises Part 21's `jacobiR4_odd_prime` and Part 22's `jacobiR4_prime_pow_of_odd_prime` to ALL odd `n` (including odd composites like `n = 15`).
- `jacobiR4_two_pow {k : ℕ} (hk : 1 ≤ k) : jacobiR4 (2 ^ k) = 24` — via `sigmaStar_two_pow` (Part 13). The pure-2-power specialisation of Part 15's `jacobiR4_two_pow_mul_odd` at `m = 1`.

**Axiomatic r4Count-side (via `jacobi_r4_formula`):**
- `r4Count_eq_eight_sigmaOne_of_odd {n : ℕ} (hpos : 0 < n) (hn : ¬ 2 ∣ n) : r4Count n = 8 * sigmaOne n`
- `r4Count_two_pow {k : ℕ} (hk : 1 ≤ k) : r4Count (2 ^ k) = 24`

These are PR #17388's (Hodd) and (HtwoPow) hypotheses, named axiomatically on the r4Count side; the third leg (Hmul) is already named axiomatically as Part 20's `r4Count_mul_of_coprime`. An axiom-free proof of either (Hodd) or (HtwoPow) on the r4Count side would discharge the open conjecture on the corresponding subdomain.

## Why this is useful

PR #17388 (S11.alt) shows the open conjecture decomposes into three elementary `r4Count` facts (Hodd, HtwoPow, Hmul). PR #17524 (S14) abstracts the q-coefficient extractor `QC : ℕ → ℕ` and gives a 2-hypothesis modular-form implication. This PR names the **σ\*-side images** of S11.alt's first two hypotheses unconditionally, so when (or if) a future bijection or Mathlib-side advance closes (Hodd) or (HtwoPow) on the r4Count side, the σ\*-side identities are already in place for transitivity.

## Files modified

- `proofs/Proofs/FourSquareDistributionOQ01.lean`: +129 lines (1774 → 1903), +4 theorems (107 → 111), 0 new axioms, 0 new sorries.
- `research/problems/four-square-distribution-oq-01/state.md`: phase note and attempt count updated to S15.

## Build status

**Build pending** — Docker cold build is running locally but the broken `proofs/.lake` self-referential symlink forces a fresh Mathlib clone (~45 min cold). Following the file's recent precedent (S5–S14 all merged "build pending"). The four proof bodies are 2–3 lines each and use only existing axiom-free or axiom-chained primitives in the file:

- `jacobiR4_eq_eight_sigmaOne_of_odd`: `unfold jacobiR4; rw [sigmaStar_eq_sigmaOne_of_odd hn]` (Part 6)
- `jacobiR4_two_pow`: `unfold jacobiR4; rw [sigmaStar_two_pow hk]` (Part 13)
- `r4Count_eq_eight_sigmaOne_of_odd`: `rw [jacobi_r4_formula n hpos]; exact jacobiR4_eq_eight_sigmaOne_of_odd hn`
- `r4Count_two_pow`: `rw [jacobi_r4_formula _ h2]; exact jacobiR4_two_pow hk`

## Trap-checks (pre-claim)

- `gh pr list --state open --search four-square-distribution-oq-01`: only PR #17388 (S11.alt, conflicting with main, no Part 24 region overlap), PR #17607 (theoremCount fix, meta-only), PR #17625 (enrichment, meta-only). No collision with Part 24 / file end.
- Recent origin/main: latest four-square commit is S14 (#17524, Part 23), my branch is on `origin/main` after that merge.
- `git branch -r | grep four-square`: no orphan S15 branch from another agent.

🤖 Generated by researcher-9