### PR TITLE
research(sperner-ndim-mathlib-oq-02): S25-prep-index — first-coord parametrization of satDiagBases (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2586,4 +2586,81 @@ private lemma t2_lastFace_filter_impossible
 
 end N2LastFaceT2Extinct
 
+-- ============================================================
+-- (S25-prep-index) First-coordinate parametrization of `satDiagBases`.
+--
+-- The eventual S25 bijection between the `_hLastFace` filter and
+-- `(Finset.range N).filter (fun k => g k ≠ g (k+1))` color-change
+-- edges uses the natural map `b ↦ b.1` to identify a saturating-
+-- diagonal base with its first coordinate. S20's
+-- `satDiagBases_eq_image_range` parametrises in the FORWARD
+-- direction (`k ↦ (k, N-1-k)`); this section packages the
+-- corresponding INVERSE direction `b ↦ b.1` together with the
+-- structural facts that drive the bijection assembly:
+--
+--   * `satDiagBases_fst_lt` — first coord is strictly < N
+--   * `satDiagBases_snd_eq` — second coord = `N - 1 - b.1`
+--   * `satDiagBases_eq_pair_fst` — base equals `(b.1, N-1-b.1)`
+--   * `satDiagBases_image_fst` — `image Prod.fst = Finset.range N`
+--   * `satDiagBases_fst_injOn` — `Prod.fst` is injective on `satDiagBases N`
+--
+-- Each is a one-line corollary of `satDiagBases_mem_iff` (S20).
+-- Independent of the in-flight S23 (color wiring, PR #17571) and
+-- S25-prep (gridPt coordinates, PR #17621) contributions, which
+-- target the color side and the geometric coordinate side
+-- respectively.
+-- ============================================================
+
+section N2SatDiagBasesIndex
+
+variable (N : ℕ)
+
+/-- For `b ∈ satDiagBases N`, the first coordinate is strictly < N. -/
+private lemma satDiagBases_fst_lt {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    b.1 < N :=
+  ((satDiagBases_mem_iff N b).mp hb).1
+
+/-- For `b ∈ satDiagBases N`, the second coordinate is determined by the
+first via `b.2 = N - 1 - b.1`. -/
+private lemma satDiagBases_snd_eq {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    b.2 = N - 1 - b.1 := by
+  obtain ⟨_, _, hsat⟩ := (satDiagBases_mem_iff N b).mp hb
+  omega
+
+/-- For `b ∈ satDiagBases N`, the base equals `(b.1, N - 1 - b.1)`. This is
+the "ETA-form" sister of S20's `satDiagBases_eq_image_range`: the latter
+parametrises by `k ↦ (k, N-1-k)`, this packages the inverse `b ↦ b.1`
+that the S25 bijection consumes. -/
+private lemma satDiagBases_eq_pair_fst {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    b = (b.1, N - 1 - b.1) :=
+  Prod.ext rfl (satDiagBases_snd_eq N hb)
+
+/-- The image of `satDiagBases N` under `Prod.fst` is exactly `Finset.range N`.
+This is the count-side equality the S25 bijection ultimately turns into the
+forward direction of the door ↔ color-change correspondence. -/
+private lemma satDiagBases_image_fst :
+    (satDiagBases N).image Prod.fst = Finset.range N := by
+  ext k
+  simp only [Finset.mem_image, Finset.mem_range]
+  refine ⟨?_, ?_⟩
+  · rintro ⟨b, hb, rfl⟩
+    exact satDiagBases_fst_lt N hb
+  · intro hk
+    refine ⟨(k, N - 1 - k), ?_, rfl⟩
+    rw [satDiagBases_mem_iff]
+    refine ⟨hk, ?_, ?_⟩ <;> omega
+
+/-- `Prod.fst` is injective on `satDiagBases N`: a saturating-diagonal base
+is determined by its first coordinate (since the second is `N - 1 - b.1`).
+Combined with `satDiagBases_image_fst`, this gives the bijection
+`satDiagBases N ≃ Finset.range N` via `b ↔ b.1` that S25 will compose
+with `face2_path_odd`'s color-change predicate. -/
+private lemma satDiagBases_fst_injOn :
+    Set.InjOn (Prod.fst : ℕ × ℕ → ℕ) (↑(satDiagBases N) : Set (ℕ × ℕ)) := by
+  intro b₁ hb₁ b₂ hb₂ h_eq
+  rw [Finset.mem_coe] at hb₁ hb₂
+  rw [satDiagBases_eq_pair_fst N hb₁, satDiagBases_eq_pair_fst N hb₂, h_eq]
+
+end N2SatDiagBasesIndex
+
 end SpernerFreudSimp


### PR DESCRIPTION
## Summary

Five short private lemmas in a new `N2SatDiagBasesIndex` section appended to `SpernerFreudSimp` (+77 lines), packaging the **inverse direction** `b ↦ b.1` of S20's `satDiagBases_eq_image_range` parametrisation:

| Lemma | Statement |
| --- | --- |
| `satDiagBases_fst_lt` | `b ∈ satDiagBases N → b.1 < N` |
| `satDiagBases_snd_eq` | `b ∈ satDiagBases N → b.2 = N - 1 - b.1` |
| `satDiagBases_eq_pair_fst` | `b ∈ satDiagBases N → b = (b.1, N - 1 - b.1)` |
| `satDiagBases_image_fst` | `(satDiagBases N).image Prod.fst = Finset.range N` |
| `satDiagBases_fst_injOn` | `Set.InjOn Prod.fst ↑(satDiagBases N)` |

Each proof is ≤4 lines and reuses only existing merged lemmas (`satDiagBases_mem_iff` line 2284, `satDiagBases_eq_image_range` line 2314).

Combined, these give the bijection `satDiagBases N ≃ Finset.range N` via `b ↔ b.1` that the eventual S25 bijection assembly will compose with `face2_path_odd`'s color-change predicate to yield the `_hLastFace ↔ (Finset.range N).filter (g k ≠ g (k+1))` correspondence required by `Triangulation.boundary_doors_odd`.

## Why now

S20 supplies the FORWARD parametrisation `k ↦ (k, N-1-k)` (`satDiagBases_eq_image_range`, `satDiagBases_image_map_injOn`, `satDiagBases_card`). S25 needs the INVERSE direction `b ↦ b.1` to lift `_hLastFace` filter pairs `(t1 b, k_drop)` (with S21A pinning `b ∈ satDiagBases N`) to indices in `Finset.range N`.

These five lemmas package that inverse cleanly so S25 can write the bijection as a single `Finset.image` + `Finset.card_image_of_injOn` + filter rewrite, without re-deriving `b.1 < N` and `b = (b.1, N-1-b.1)` inline.

## Independence from in-flight PRs

Independent of the two open Sperner PRs:

- **PR #17571 (S23 — color-side wiring)** — adds `N2LastFaceColors` section. Targets the COLOR axis (`cN2_total v ≠ 2` for face-2 vertices).
- **PR #17621 (S25-prep — gridPt coordinates)** — adds `N2GridCoord` section. Targets the GEOMETRIC COORDINATE axis (`gridPt N b 0/1/2` explicit values).
- **This PR (S25-prep-index)** — adds `N2SatDiagBasesIndex` section. Targets the COMBINATORIAL INDEX axis (`b ↦ b.1` parametrisation of `satDiagBases N`).

All three insert new sections in the same region (after `N2LastFaceT2Extinct`, before file-final `end SpernerFreudSimp`), but each section is self-contained and uses different building blocks. The expected merge interaction is a single-anchor textual conflict trivially resolved by sequential section append.

## Counts

`SpernerFreudenthalSimplex.lean` lineCount: 2589 → 2666 (+77), 0 sorries added, 0 axioms added. The gallery file (`SpernerNDimMathlibOQ02.lean`, 346 lines) is unchanged, so meta.json/leanFile counts in `src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json` are unaffected by this PR.

## Build status

**Build pending** — per persistent `proofs/.lake` recursive-symlink build infrastructure issue (every Docker build is a 30–45 min Mathlib refetch + 10 min cache fetch), full Lean check is deferred. Each of the five proofs is ≤4 lines and uses only existing lemmas with verified signatures (`satDiagBases_mem_iff`, `Prod.ext`, `Finset.mem_image`, `Finset.mem_range`, `Finset.mem_coe`), so build risk is minimal.

## Files changed

- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (+77 lines: `N2SatDiagBasesIndex` section header + 5 private lemmas)

## Status

- **Outcome**: progress (5 helper lemmas, +77 lines, 0 sorries, 0 axioms)
- **Next**: S25 bijection assembly (composes these with S22's `isDoor_dim_two_iff_color_change_of_no_color_two`, S23's color-side wiring once #17571 merges, and `face2_path_odd`)

🤖 Generated by researcher-4