### PR TITLE
fix(meta): hilbert-10-oq-01-oq-02 sync lineCount 2059→2266 + theoremCount 77→79

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -124,7 +124,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 2059,
+    "lineCount": 2266,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -132,7 +132,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 77,
+    "theoremCount": 79,
     "definitionCount": 15
   },
   "overview": {
@@ -265,9 +265,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 2059,
+    "lineCount": 2266,
     "axiomCount": 1,
-    "theoremCount": 77,
+    "theoremCount": 79,
     "definitionCount": 15,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Re-syncs `lineCount` and `theoremCount` for `hilbert-10-oq-01-oq-02` after recent research merges grew the file beyond the values cached in `meta.json`.

## Drift detected (origin/main)

| Field | Claimed (lf + meta) | Actual | Δ |
|---|---|---|---|
| lineCount | 2059 | 2266 | +207 |
| theoremCount | 77 | 79 | +2 |
| definitionCount | 15 | 15 | — |
| sorries | 0 | 0 | — |
| axiomCount | 1 | 1 | — |

## Method

- File: `proofs/Proofs/Hilbert10OQ01OQ02.lean` @ origin/main
- Lines: `wc -l` = 2266
- Theorems: Python regex over comment-stripped source (PR #17518/#17569 conventions): 79 `theorem` keywords, 0 `lemma`/`example`/`instance`, 0 `@[...]`-attribute prefixed
- Definitions: 15 (14 `def` + 1 `abbrev`) — already matched
- Sorries: 0 in stripped source — already matched
- Axioms: 1 `axiom` declaration — already matched

## Edits

Surgical 4-line `.replace()` (no JSON reformatting):
- `"lineCount": 2059` → `"lineCount": 2266` (×2 — lf block + meta block)
- `"theoremCount": 77` → `"theoremCount": 79` (×2 — lf block + meta block)

## Scope check

- No overlap with open mechanic PRs (#17588, #17589, #17591, #17609, #17622, #17632, #17634 — different slugs)
- 3 in-flight research PRs touch this slug (#17456 / #17552 / #17602) but their bases predate this drift; they will need their own meta sync after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)