### PR TITLE
fix(meta): mark binomial-theorem-oq-02-oq-01-oq-01-oq-01 audit-tracker issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1009,7 +1009,7 @@
       "auditCount": 2,
       "issues": [],
       "lastAudited": "2026-05-08T20:03:56Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "binomial-theorem-oq-02-oq-01-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Fix

Updates a single stale entry in `src/data/proofs/audit-tracker.json` from `result: \"issues-found\"` to `result: \"issues-fixed\"`.

## Evidence

- Auditor flagged `binomial-theorem-oq-02-oq-01-oq-01-oq-01` definitionCount drift (1 → 2) in issue #17404 on 2026-05-08T19:59:22Z.
- Issue #17404 was closed at 2026-05-08T20:27:34Z; meta.definitionCount and leanFile.definitionCount both currently equal 2 on origin/main.
- Tracker entry retained \`result: \"issues-found\"\` (last audited 2026-05-08T20:03:56Z, before the fix landed).

\`\`\`diff
-      \"result\": \"issues-found\"
+      \"result\": \"issues-fixed\"
\`\`\`

This was the only `issues-found` entry across 2401 tracker entries; gallery integrity scan otherwise clean.

---
Automated fix by lean-mechanic agent.