### PR TITLE
research(hilbert-11-oq-02): Iter 16 — Section 26 Case-B primes 43, 67, 79 via lift-z (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -1633,6 +1633,92 @@ theorem selmer_padic_solubility_extended_caseA_primes_v4 :
    selmer_padic_solubility_p107_hensel,
    selmer_padic_solubility_p113_hensel⟩
 
+/-! ## Section 26: Case-B Primes 43, 67, 79 via Lift-z
+
+Sections 22–25 extended the discharged sub-collection along the Case-A
+parametric theorem (`selmer_padic_solubility_caseA`); this section
+extends the parallel Case-B collection along
+`selmer_padic_solubility_lift_z` (Section 15).
+
+Eligibility (per Section 15): a prime `p` is reachable by the lift-z
+shape `(x₀, y₀, z₀)` whenever `p ∣ 3·x₀³ + 4·y₀³ + 5·z₀³`,
+`gcd(15·z₀², p) = 1`, and `(x₀, y₀) ≠ (0, 0)`. This works for any prime
+`p` admitting such a witness; in practice, every prime `p ≡ 1 (mod 3)`
+beyond `{2, 5, 13, 19, 31, 37}` admits a small witness, since the cube
+map on `(ZMod p)ˣ` has image of size `(p - 1) / 3` and the linear forms
+`3·x³ + 4·y³ + 5·z³` exhaust (modulo cubes) at `p ≡ 1 (mod 3)` Case-B
+primes by Chevalley-Warning.
+
+| p  | (x₀, y₀, z₀) | 3·x₀³ + 4·y₀³ + 5·z₀³  | matches `(mod p)`         | gcd(15·z₀², p) |
+|----|--------------|------------------------|---------------------------|-----------------|
+| 43 | (1, 0, 2)    | 3 + 0 + 40 = 43        | 43 = 43·1                 | 1               |
+| 67 | (1, 0, 12)   | 3 + 0 + 8640 = 8643    | 8643 = 67·129             | 1               |
+| 79 | (0, 1, 17)   | 0 + 4 + 24565 = 24569  | 24569 = 79·311            | 1               |
+
+These primes (like the Sections 22/23/24/25 primes) are not part of the
+Hasse-failure pipeline (which consumes only the Section-8 primes plus
+the four Section-9 table primes `{11, 17, 23, 29}`). They serve the
+parallel purpose to the Case-A extensions: demonstrate the parametric
+lift-z theorem's reach beyond the four primes `{13, 19, 31, 37}` of
+Section 15, and provide additional axiom-free citation points for
+`ℚ_[p]`-solubility at Case-B primes outside the original list.
+
+Together with `selmer_padic_solubility_extended_caseA_primes_v4` (10
+extended Case-A primes) and `selmer_padic_solubility_section8_primes`
+(the 12 Section-8 primes), this section brings the discharged
+sub-collection to `12 + 10 + 3 = 25` primes total. -/
+
+instance : Fact (Nat.Prime 43) := ⟨by decide⟩
+instance : Fact (Nat.Prime 67) := ⟨by decide⟩
+instance : Fact (Nat.Prime 79) := ⟨by decide⟩
+
+/-- ℚ_[43] solubility of the Selmer cubic via the `(1, 0, 2)` Case-B witness.
+    Witness data: `43 ∣ 3·1³ + 4·0³ + 5·2³ = 43 = 43·1` and
+    `gcd(15·2², 43) = gcd(60, 43) = 1`. Here `x₀ = 1 ≠ 0` discharges the
+    non-triviality `Or.inl one_ne_zero`. -/
+theorem selmer_padic_solubility_p43_hensel :
+    ∃ (x y z : ℚ_[43]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 1 0 2
+    (Or.inl one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- ℚ_[67] solubility of the Selmer cubic via the `(1, 0, 12)` Case-B witness.
+    Witness data: `67 ∣ 3·1³ + 4·0³ + 5·12³ = 8643 = 67·129` and
+    `gcd(15·12², 67) = gcd(2160, 67) = 1`. -/
+theorem selmer_padic_solubility_p67_hensel :
+    ∃ (x y z : ℚ_[67]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 1 0 12
+    (Or.inl one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- ℚ_[79] solubility of the Selmer cubic via the `(0, 1, 17)` Case-B witness.
+    Witness data: `79 ∣ 3·0³ + 4·1³ + 5·17³ = 24569 = 79·311` and
+    `gcd(15·17², 79) = gcd(4335, 79) = 1`. Here `y₀ = 1 ≠ 0` discharges the
+    non-triviality `Or.inr one_ne_zero`. -/
+theorem selmer_padic_solubility_p79_hensel :
+    ∃ (x y z : ℚ_[79]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 0 1 17
+    (Or.inr one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- **Bundled Case-B solubility extension v1** — covers all three
+    extended Case-B primes `p ∈ {43, 67, 79}`. Each is an axiom-free
+    application of the Section-15 parametric lift-z theorem; together
+    with `selmer_padic_solubility_section8_primes` (the 12 Section-8
+    primes) and `selmer_padic_solubility_extended_caseA_primes_v4` (the
+    10 extended Case-A primes), this gives an axiom-free 25-prime
+    sub-collection of the universal axiom `selmer_padic_solubility`. -/
+theorem selmer_padic_solubility_extended_caseB_primes :
+    (∃ x y z : ℚ_[43], (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) ∧
+    (∃ x y z : ℚ_[67], (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) ∧
+    (∃ x y z : ℚ_[79], (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) :=
+  ⟨selmer_padic_solubility_p43_hensel,
+   selmer_padic_solubility_p67_hensel,
+   selmer_padic_solubility_p79_hensel⟩
+
 #check @selmerCubic_real_solution
 #check @selmer_rat_implies_real
 #check @selmer_rat_implies_padic
@@ -1670,5 +1756,9 @@ theorem selmer_padic_solubility_extended_caseA_primes_v4 :
 #check @selmer_padic_solubility_p107_hensel
 #check @selmer_padic_solubility_p113_hensel
 #check @selmer_padic_solubility_extended_caseA_primes_v4
+#check @selmer_padic_solubility_p43_hensel
+#check @selmer_padic_solubility_p67_hensel
+#check @selmer_padic_solubility_p79_hensel
+#check @selmer_padic_solubility_extended_caseB_primes
 
 end Hilbert11OQ02

--- a/research/problems/hilbert-11-oq-02/state.md
+++ b/research/problems/hilbert-11-oq-02/state.md
@@ -606,3 +606,26 @@ required to discharge this axiom.
     no new Mathlib API surface; new theorems are structurally identical
     to existing `selmer_padic_solubility_p17_hensel`/`p23_hensel`/`p29_hensel`
     with only the prime literal and witness `z₀` differing.
+  - Iter 16 (researcher-9): Section 26 — first Case-B (lift-z) extension
+    beyond the four Section-15 primes `{13, 19, 31, 37}`. Adds three
+    additional Case-B primes `p ∈ {43, 67, 79}` as one-line corollaries
+    of `selmer_padic_solubility_lift_z`, plus a bundled 3-fold
+    conjunction `selmer_padic_solubility_extended_caseB_primes`.
+    Witness data: `(x₀, y₀, z₀) = (1, 0, 2)` for `p = 43`
+    (3 + 0 + 40 = 43 = 43·1, `gcd(60, 43) = 1`); `(1, 0, 12)` for
+    `p = 67` (3 + 0 + 8640 = 8643 = 67·129, `gcd(2160, 67) = 1`);
+    `(0, 1, 17)` for `p = 79` (0 + 4 + 24565 = 24569 = 79·311,
+    `gcd(4335, 79) = 1`). Mirrors the Sections 22/23/24/25 Case-A
+    extension pattern but along the parallel lift-z parametric
+    theorem; introduces no new axioms, no new definitions, no new
+    sorries. File 1674 → 1764 lines (+90), theorems 69 → 73 (+4),
+    definitions unchanged at 8, axioms unchanged at 2. Build pending —
+    no new Mathlib API surface; new theorems are structurally identical
+    to existing `selmer_padic_solubility_p13_hensel`/`p19_hensel`/`p31_hensel`/`p37_hensel`
+    with only the prime literal and witness `(x₀, y₀, z₀)` differing.
+    Brings the discharged sub-collection from 22 (Section-8 + extended
+    Case-A v4) to 25 primes total: 12 Section-8 + 10 extended Case-A
+    + 3 extended Case-B. Note: PR #17610 (universal Case-A theorem,
+    Iter 15 in flight) is parallel to this work — universal Case-A
+    subsumes the per-prime Case-A corollaries but does not subsume the
+    Case-B chain that Section 26 begins extending.

--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 1674,
-    "theoremCount": 69,
+    "lineCount": 1764,
+    "theoremCount": 73,
     "definitionCount": 8,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
     "dateAdded": "2026-05-08",
@@ -249,9 +249,9 @@
       "Polynomial"
     ],
     "namespace": "Hilbert11OQ02",
-    "lineCount": 1674,
+    "lineCount": 1764,
     "axiomCount": 2,
-    "theoremCount": 69,
+    "theoremCount": 73,
     "definitionCount": 8,
     "path": "Proofs/Hilbert11OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -222,8 +222,8 @@
     {
       "path": "Proofs/Hilbert11OQ02.lean",
       "filename": "Hilbert11OQ02.lean",
-      "lineCount": 1299,
-      "theoremCount": 59,
+      "lineCount": 1764,
+      "theoremCount": 73,
       "axiomCount": 2,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

First Case-B (lift-z) extension beyond the four Section-15 primes `{13, 19, 31, 37}`. Mirrors the Section 22/23/24/25 Case-A extension pattern along the parallel `selmer_padic_solubility_lift_z` parametric theorem.

- 3 new per-prime axiom-free `ℚ_[p]`-solubility theorems via `selmer_padic_solubility_lift_z`:
  - `selmer_padic_solubility_p43_hensel` — witness `(x₀, y₀, z₀) = (1, 0, 2)`; `43 ∣ 3 + 0 + 40 = 43 = 43·1`, `gcd(60, 43) = 1`
  - `selmer_padic_solubility_p67_hensel` — witness `(1, 0, 12)`; `67 ∣ 3 + 0 + 8640 = 8643 = 67·129`, `gcd(2160, 67) = 1`
  - `selmer_padic_solubility_p79_hensel` — witness `(0, 1, 17)`; `79 ∣ 0 + 4 + 24565 = 24569 = 79·311`, `gcd(4335, 79) = 1`
- 1 new bundled theorem `selmer_padic_solubility_extended_caseB_primes` (3-fold conjunction across `{43, 67, 79}`)
- Brings the discharged sub-collection of `selmer_padic_solubility` from **22 primes** (Section-8 + extended Case-A v4) to **25 primes total**: 12 Section-8 + 10 extended Case-A + 3 extended Case-B.

## Witness verification

All three witnesses are decidable from `Int.isCoprime_iff_gcd_eq_one.mpr (by decide)` + numeric divisibility `(by decide)`. Verified by Python:

| p  | (x₀, y₀, z₀) | 3·x₀³ + 4·y₀³ + 5·z₀³ | matches `(mod p)` | gcd(15·z₀², p) |
|----|--------------|------------------------|-------------------|-----------------|
| 43 | (1, 0, 2)    | 43                     | 43·1              | 1               |
| 67 | (1, 0, 12)   | 8643                   | 67·129            | 1               |
| 79 | (0, 1, 17)   | 24569                  | 79·311            | 1               |

## Counts

- File: 1674 → **1764** lines (+90)
- theoremCount: 69 → **73** (+4: three per-prime + one bundle)
- definitionCount: unchanged at 8
- axiomCount: unchanged at 2
- sorries: unchanged at 0
- meta.json + research/problems/.../json + state.md synced

## Build status

Build pending. New theorems are structurally identical to existing
`selmer_padic_solubility_p13_hensel`/`p19_hensel`/`p31_hensel`/`p37_hensel`
with only the prime literal and witness `(x₀, y₀, z₀)` differing — no
new Mathlib API surface required.

## Coordination

PR #17610 (Iter 15 universal Case-A theorem) is parallel to this work.
Universal Case-A subsumes the per-prime Case-A corollaries (Sections 22-25)
but does NOT subsume the Case-B chain that Section 26 begins extending.
Both PRs touch the same file but in disjoint regions; merge order
should not affect correctness.

## Test plan

- [ ] CI compiles `proofs/Proofs/Hilbert11OQ02.lean` without error
- [ ] No new `axiom` declarations introduced (`grep -c "^axiom " proofs/Proofs/Hilbert11OQ02.lean` unchanged at 2)
- [ ] Gallery `pnpm build` succeeds (counts in meta.json match file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)