### PR TITLE
audit(laws-of-large-numbers-oq-04-oq-03): demote verified→axiomatized, axiomCount 0→1

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-06",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
     "additionalFiles": [
       "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
@@ -19,9 +19,9 @@
       "integration",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 158,
     "theoremCount": 4,
     "definitionCount": 0,
@@ -54,7 +54,7 @@
       "empiricalCDF_pointwise_convergence_no_axiom: pointwise SLLN for empirical CDF with no integration axioms",
       "Reduction of Glivenko-Cantelli axiom count from 3 to 1: only glivenko_cantelli_uniform remains"
     ],
-    "assumptions": "0 sorries. 0 axiom declarations. Two integration axioms from LawsOfLargeNumbersOQ04 are now fully machine-checked."
+    "assumptions": "0 sorries in main file. The associated companion file LawsOfLargeNumbersOQ04OQ03Bracketing.lean introduces 1 new axiom (`bracketingGrid_exists`) supporting the separate uniform-convergence reduction; chain axiom count is 1. The two integration axioms from LawsOfLargeNumbersOQ04 (thresholdIndicator_integrable, integral_thresholdIndicator_eq_cdf) are fully machine-checked in the main file."
   },
   "overview": {
     "historicalContext": "The Glivenko-Cantelli theorem (1933) — the uniform law of large numbers — states that the empirical CDF Fₙ(x) = |{i ≤ n : Xᵢ ≤ x}|/n converges to the true CDF F(x) uniformly in x, almost surely. This is a fundamental result in statistics and is the basis for Kolmogorov-Smirnov tests.\n\nThe key steps in the proof are: (1) for each fixed x, apply the SLLN to get Fₙ(x) → F(x) a.s. (pointwise convergence); and (2) upgrade to uniform convergence via a finite bracketing argument using continuity points of F.\n\nStep (1) requires two integration facts: that 1_{Xᵢ ≤ x} is integrable (so SLLN applies) and that its expectation equals F(x) (so the SLLN limit is identified). These are mathematically obvious but require careful Mathlib API navigation to formalize.\n\nStep (2) — the bracketing uniformity — is the genuinely hard part and requires finite covering of ℝ by continuity points of F with controlled jump sizes, infrastructure not yet available in Mathlib 4.26.",


### PR DESCRIPTION
## Issue

Gallery audit (`find-targets.ts`) flagged: `axiom undercount: claims 0, actual declarations 1`.

## Root Cause

The companion file `Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (registered in `meta.additionalFiles` since PR #17597) introduces a new axiom `bracketingGrid_exists` for the separate uniform-convergence reduction. Per the axiom integrity policy, `meta.axiomCount` must reflect ALL chain assumptions, and `status: "verified"` requires 0 axioms in the chain.

## Changes

- `meta.status`: `verified` → `axiomatized`
- `meta.badge`: `original` → `axiom`
- `meta.axiomCount`: `0` → `1`
- `meta.assumptions`: clarify that the main file is axiom-free; chain count is 1

## Why this is the right call

- The MAIN file (`LawsOfLargeNumbersOQ04OQ03.lean`) is genuinely axiom-free (0 axioms, 0 sorries, 158 lines).
- The originalContributions (`thresholdIndicator_integrable_proved`, `integral_thresholdIndicator_eq_cdf_proved`, `empiricalCDF_pointwise_convergence_no_axiom`) are all fully proved.
- BUT the COMPANION file deliberately introduces `bracketingGrid_exists` as a working axiom to support the bracketing-based uniform-convergence step.
- Per the gallery's axiom integrity policy ("axiomCount must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields"), the chain count must be honest.

The originalContributions and the rest of the entry's narrative are unchanged.

## Verification

```bash
$ python3 -c "import re; nb=re.sub(r'--[^\n]*','', re.sub(r'/-.*?-/','',open('proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean').read(),flags=re.DOTALL)); print(len(re.findall(r'^axiom\s', nb, re.MULTILINE)))"
1
```

---
Discovered during gallery integrity audit.

🤖 Generated by lean-auditor agent