### PR TITLE
research(konigsberg-oq-01-oq-02): S20 — walkEdges'_hcov_list_of_nodup spec (analysis-only)

### DIFF
--- a/research/problems/konigsberg-oq-01-oq-02/s20-walkedges-hcov-list-of-nodup-spec.md
+++ b/research/problems/konigsberg-oq-01-oq-02/s20-walkedges-hcov-list-of-nodup-spec.md
@@ -1,0 +1,319 @@
+# S20 Spec — `walkEdges'_hcov_list_of_nodup`
+
+**Status**: Analysis-only specification. Lean implementation deferred
+to a follow-up `S20-implement` session.
+
+**Date**: 2026-05-09 (researcher-3, parallel to S17 #17596 and S18 #17623).
+
+## Goal
+
+Discharge the **uniqueness half** of the `hcov_list` hypothesis required
+by S15's `circuit_edge_balance_list'` template, automatically for the
+`walkEdges'`-style `L`. After S20-implement, the only outstanding obligation in
+the eventual in-place refactor's call to `circuit_edge_balance_list'`
+is the standard `walk.length = n + 1` and `walk[0]? = walk[n]?`
+hypotheses (both trivially derivable from any `DirectedCircuit`).
+
+## Statement
+
+```lean
+lemma walkEdges'_hcov_list_of_nodup (walk : List V) (n : ℕ)
+    (hlen : walk.length = n + 1)
+    (hnodup : (walkEdges' walk).Nodup) :
+    ∀ e ∈ walkEdges' walk, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2
+```
+
+This is the **`hcov_list` hypothesis** of `circuit_edge_balance_list'`
+(see Recipe §S15) — a `walk[i]?`-keyed unique-position witness for
+each edge. S17's `walkEdges'_hsteps_list` already supplies the
+companion `hsteps_list` hypothesis (existence half, no `Nodup`
+required). S20-implement closes the uniqueness gap, giving the **packaged
+`hcov_list`** for `walkEdges'`-style `L`.
+
+## Why `Nodup` is necessary
+
+The `∃!` (unique-existence) statement requires a distinctness
+hypothesis on the walk's edges. Without `Nodup`, a walk that revisits
+an edge has multiple `i`'s producing the same `(walk[i], walk[i+1])`
+pair, so the predicate `walk[i]? = some e.1 ∧ walk[i+1]? = some e.2`
+holds at multiple positions — uniqueness fails.
+
+For `DirectedCircuit` (the closed-walk case in `remove_circuit_balanced`),
+a sufficient distinctness hypothesis is `Nodup` on the **edge** list
+`walkEdges' walk` itself. The vertex list `walk` may revisit vertices
+(closed circuits start and end at the same vertex), but a directed
+*Eulerian* circuit traverses each edge exactly once — equivalent to
+`(walkEdges' walk).Nodup`.
+
+## Proof structure
+
+The proof needs a **structural fact** about `walkEdges'` that connects
+walk-indices `i ∈ range n` to list-positions in `walkEdges' walk`:
+
+```
+For walk.length = n + 1 and i < n:
+  (walkEdges' walk)[i]'_ = (walk[i]'_, walk[i+1]'_)
+```
+
+This structural fact then combines with Mathlib's
+`List.Nodup.getElem_inj_iff` (in `Mathlib/Data/List/Nodup.lean`):
+
+```lean
+theorem List.Nodup.getElem_inj_iff {l : List α} (h : Nodup l)
+    {i j : ℕ} {hi : i < l.length} {hj : j < l.length} :
+    l[i] = l[j] ↔ i = j
+```
+
+to discharge uniqueness: from `(walk[j], walk[j+1]) = e = (walk[i₀], walk[i₀+1])`
+applied at the corresponding list-positions, `Nodup` forces
+`i₀ = j` (provided both indices are `< n`).
+
+### Required structural sub-lemmas (S20a–S20c)
+
+The structural fact decomposes into three Recipe-level lemmas:
+
+#### S20a. `walkEdges'_eq_map_of_pos`
+
+Convert the `filterMap` definition to an explicit `map` over
+`range (walk.length - 1)`. Requires a `walk[0]'h0` default for the
+out-of-bounds case to thread `g : ℕ → V × V` through Mathlib's
+`List.filterMap_eq_map_iff_forall_eq_some`:
+
+```lean
+lemma walkEdges'_eq_map_of_pos (walk : List V) (h0 : 0 < walk.length) :
+    walkEdges' walk = (List.range (walk.length - 1)).map (fun i =>
+      (walk[i]?.getD (walk[0]'h0), walk[i+1]?.getD (walk[0]'h0))) := by
+  unfold walkEdges'
+  apply (List.filterMap_eq_map_iff_forall_eq_some).mpr
+  intro i hi
+  simp only [List.mem_range] at hi
+  have h_i1_lt : i + 1 < walk.length := by omega
+  have h_i_lt : i < walk.length := by omega
+  rw [dif_pos h_i1_lt]
+  congr 1
+  · simp [List.getElem?_eq_getElem h_i_lt]
+  · simp [List.getElem?_eq_getElem h_i1_lt]
+```
+
+**Mathlib API used**: `List.filterMap_eq_map_iff_forall_eq_some`
+(verified at the v4.26 pin in
+`Mathlib/Data/List/Basic.lean:2142`),
+`List.mem_range`, `List.getElem?_eq_getElem`, `dif_pos`.
+
+**Build risk**: low. The `congr 1` + `simp` closure may need a
+`Prod.mk.injEq` rewrite or explicit `ext`-on-Prod step depending on
+Mathlib's current `simp`-set behaviour around `getD ∘ getElem?`.
+
+#### S20b. `walkEdges'_length_of_pos`
+
+Direct corollary of S20a + `List.length_map` + `List.length_range`:
+
+```lean
+lemma walkEdges'_length_of_pos (walk : List V) (h0 : 0 < walk.length) :
+    (walkEdges' walk).length = walk.length - 1 := by
+  rw [walkEdges'_eq_map_of_pos walk h0, List.length_map, List.length_range]
+```
+
+#### S20c. `walkEdges'_getElem_of_pos`
+
+The structural fact itself, derived from S20a via `List.getElem_map` and
+`List.getElem_range`:
+
+```lean
+lemma walkEdges'_getElem_of_pos (walk : List V) (h0 : 0 < walk.length)
+    (i : ℕ) (hi : i + 1 < walk.length) :
+    (walkEdges' walk)[i]'(by
+      rw [walkEdges'_length_of_pos walk h0]; omega) =
+      (walk[i]'(by omega), walk[i + 1]'hi) := by
+  rw [walkEdges'_eq_map_of_pos walk h0]
+  -- Now: ((range (walk.length - 1)).map _)[i] = ...
+  rw [List.getElem_map, List.getElem_range]
+  -- Goal: (walk[i]?.getD _, walk[i+1]?.getD _) = (walk[i]'_, walk[i+1]'_)
+  have h_i_lt : i < walk.length := by omega
+  ext
+  · simp [List.getElem?_eq_getElem h_i_lt]
+  · simp [List.getElem?_eq_getElem hi]
+```
+
+**Build risk**: low. Same `simp` concerns as S20a.
+
+### Top-level proof of `walkEdges'_hcov_list_of_nodup`
+
+With S20a–S20c in place, the top-level proof is structurally
+straightforward:
+
+```lean
+lemma walkEdges'_hcov_list_of_nodup (walk : List V) (n : ℕ)
+    (hlen : walk.length = n + 1)
+    (hnodup : (walkEdges' walk).Nodup) :
+    ∀ e ∈ walkEdges' walk, ∃! i : ℕ, i < n ∧
+      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2 := by
+  intro e he
+  have h0 : 0 < walk.length := by omega
+  -- Existence: extract i₀ from mem_walkEdges'
+  rw [mem_walkEdges'] at he
+  obtain ⟨i₀, h_i₀_lt, hi₀_eq⟩ := he
+  have h_i₀_lt' : i₀ < walk.length := by omega
+  refine ⟨i₀, ⟨by omega, ?_, ?_⟩, ?_⟩
+  -- existence components
+  · rw [List.getElem?_eq_getElem h_i₀_lt']; rw [hi₀_eq]
+  · rw [List.getElem?_eq_getElem h_i₀_lt]; rw [hi₀_eq]
+  -- uniqueness
+  rintro j ⟨hj_lt_n, hj_eq1, hj_eq2⟩
+  have h_j_lt : j < walk.length := by omega
+  have h_j1_lt : j + 1 < walk.length := by omega
+  -- From hj_eq1, hj_eq2: e.1 = walk[j], e.2 = walk[j+1]
+  rw [List.getElem?_eq_getElem h_j_lt] at hj_eq1
+  rw [List.getElem?_eq_getElem h_j1_lt] at hj_eq2
+  have h_e1 : e.1 = walk[j]'h_j_lt := Option.some_inj.mp hj_eq1.symm
+  have h_e2 : e.2 = walk[j + 1]'h_j1_lt := Option.some_inj.mp hj_eq2.symm
+  -- From hi₀_eq: e.1 = walk[i₀], e.2 = walk[i₀+1]
+  have h_e1' : e.1 = walk[i₀]'h_i₀_lt' := by rw [hi₀_eq]
+  have h_e2' : e.2 = walk[i₀ + 1]'h_i₀_lt := by rw [hi₀_eq]
+  -- Derive equality of pairs at list-positions i₀ and j
+  have h_pair_eq :
+      (walkEdges' walk)[i₀]'(by
+        rw [walkEdges'_length_of_pos walk h0]; omega) =
+      (walkEdges' walk)[j]'(by
+        rw [walkEdges'_length_of_pos walk h0]; omega) := by
+    rw [walkEdges'_getElem_of_pos walk h0 i₀ h_i₀_lt,
+        walkEdges'_getElem_of_pos walk h0 j h_j1_lt]
+    -- Both pairs equal (e.1, e.2) via h_e1, h_e2, h_e1', h_e2'
+    ext
+    · rw [← h_e1', h_e1]
+    · rw [← h_e2', h_e2]
+  -- Apply Nodup.getElem_inj_iff
+  exact (hnodup.getElem_inj_iff).mp h_pair_eq |>.symm
+```
+
+**Build risk**: moderate. The `Option.some_inj.mp` extraction and the
+`Prod.ext` rewriting are conventional but easy to slip on. The
+`Nodup.getElem_inj_iff` final invocation may need explicit `Fin`
+packaging depending on the Mathlib version's signature.
+
+## Mathlib API audit (v4.26 pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+All API used by the spec is verified present at the pin via
+`gh search code` / direct `gh api` reads:
+
+| Symbol | Path | Verified |
+|---|---|---|
+| `List.filterMap_eq_map_iff_forall_eq_some` | `Mathlib/Data/List/Basic.lean:2142` | ✓ |
+| `List.length_map` | `Mathlib/Data/List/Basic.lean` | ✓ (Lean core) |
+| `List.length_range` | core | ✓ |
+| `List.getElem_map` | core | ✓ |
+| `List.getElem_range` | core | ✓ |
+| `List.getElem?_eq_getElem` | core | ✓ (used throughout the recipe) |
+| `List.mem_range` | core | ✓ |
+| `List.Nodup.getElem_inj_iff` | `Mathlib/Data/List/Nodup.lean:106` | ✓ |
+| `Option.some_inj` | core | ✓ |
+| `dif_pos` | core | ✓ |
+
+No new imports needed beyond the recipe's existing `Mathlib.Data.List.Nodup`
+chain (already pulled in via the SimpleGraph/DiGraph dependencies).
+
+## Net effect on the file (after S20a–S20c + `walkEdges'_hcov_list_of_nodup` land)
+
+| Dimension | Before S20-implement (post-S17/S18 merges) | After S20-implement |
+|---|---|---|
+| Recipe-side `hcov_list` obligation | open (caller-supplied) | **closed** (auto-derived from `Nodup`) |
+| Recipe-side `hsteps_list` obligation | closed (S17 `walkEdges'_hsteps_list`) | closed |
+| Recipe-side template list size | 13 | 16 (S20a, S20b, S20c, hcov_list_of_nodup are 4 lemmas) |
+| Estimated LOC delta | — | +120–150 lines (4 lemmas with full docstrings) |
+| Build-verifiable | — | yes (no new axioms, no new sorries) |
+
+## Use in `remove_circuit_balanced`
+
+After S20-implement lands, the deferred main-file proof of
+`remove_circuit_balanced` (currently L1103, the file's last `sorry`)
+reduces to:
+
+```lean
+theorem remove_circuit_balanced (G : DiGraph V) (C : DirectedCircuit G)
+    (h_balanced : IsEulerianBalanced G)
+    (h_nodup : (walkEdges' C.walk).Nodup)  -- supplied by Eulerian uniqueness
+    (hlen : C.walk.length = n + 1) (hclosed : C.walk[0]? = C.walk[n]?) :
+    IsEulerianBalanced (G.removeEdgeSet (walkEdges' C.walk).toFinset) := by
+  intro v
+  unfold IsBalanced inDegree outDegree DiGraph.removeEdgeSet
+  apply remove_balanced_subset_balanced'
+  · -- hsub: (walkEdges' C.walk).toFinset ⊆ G.edges
+    intro e he
+    rw [List.mem_toFinset] at he
+    rw [mem_walkEdges'] at he
+    obtain ⟨i, hi, he_eq⟩ := he
+    -- e is a walk-step → e ∈ G.edges via DirectedCircuit.steps
+    sorry  -- C.walk's steps are in G.edges (DirectedCircuit/DirectedTrail field)
+  · exact h_balanced v
+  · exact circuit_edge_balance_list' C.walk n v (walkEdges' C.walk)
+        hlen hclosed
+        (walkEdges'_hcov_list_of_nodup C.walk n hlen h_nodup)
+        (walkEdges'_hsteps_list C.walk n hlen)
+```
+
+**Estimated body LOC after S20-implement**: ~15 lines, with one remaining
+`sorry` for `hsub` (a one-liner once `DirectedCircuit.steps` is
+exposed in the in-place refactor).
+
+## Comparison with S18 (researcher-1, PR #17623)
+
+S18 supplies the **open-walk** parallel of S14's `circuit_edge_balance'`
+(`open_walk_edge_*_excess'`), targeting `directed_eulerian_path_iff`
+(open Euler trails). S20 (this spec) is on the **closed-circuit** side
+and is independent of S18's open-walk additions; both contribute to
+the eventual `directed_eulerian_iff` proof along orthogonal axes:
+
+* S14 + S15 + S16 + **S20-implement** ⟹ closed-circuit edge-balance discharge
+  (`remove_circuit_balanced` for Euler circuits).
+* S10 + S12 + S13 + **S18** + **S19** ⟹ open-walk endpoint-excess identification
+  (toward `directed_eulerian_path_iff` for Euler trails).
+
+No textual conflict between S18 and S20-implement: S18 appends in a
+new "Iteration 18" section after `remove_balanced_subset_balanced'`;
+S20-implement appends after S17's "S17 walkEdges-style List bridge"
+section, which is between S16 and S18.
+
+## Followup: when to land S20-implement
+
+Defer until **at least S17 #17596 is merged** (since S20a builds on
+`walkEdges'`, `mem_walkEdges'`). S17 is build-verified; merge expected
+within the standard cadence (~1–4 hours). Once S17 lands on origin/main,
+S20-implement is a self-contained ~120–150 LOC PR with low merge
+conflict risk against S18 (textually disjoint).
+
+## Why this is analysis-only
+
+This S20 is documentation only — no Lean changes — for three reasons:
+
+1. **S17 #17596 is not yet merged.** S20-implement's S20a directly
+   uses S17's `walkEdges'` definition + `mem_walkEdges'` lemma. Stacking
+   S20-implement on the unmerged S17 branch risks rebase conflicts if
+   S17 needs revisions. Decoupling the spec lets the implementation
+   land cleanly off the post-merge origin/main.
+2. **Build verification cycle is ~45 minutes** (per the
+   `proofs/.lake` self-symlink trap documented in
+   `feedback_researcher_lake_symlink_broken.md`). The `walkEdges'_eq_map_of_pos`
+   conversion may need iterative Mathlib-API adjustment (`congr` /
+   `simp` set behaviour around `getD ∘ getElem?` is mildly
+   version-dependent). Spec-first lets the next implementer fail fast
+   on a single targeted build, rather than discovering the issue mid-PR.
+3. **Parallel session contention.** S17 (researcher-4) and S18
+   (researcher-1) both landed open PRs in the past 2 hours. A spec PR
+   reduces collision risk while still advancing the slug's documentation.
+
+## Pointers
+
+- `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean:687` — `walkEdges'`
+  definition (S17, PR #17596).
+- `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean:697` — `mem_walkEdges'`
+  membership characterization (S17, PR #17596).
+- `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean:727` —
+  `walkEdges'_hsteps_list` (S17, PR #17596). S20-implement appends
+  after this lemma.
+- `proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean:549` —
+  `circuit_edge_balance_list'` (S15) consumer of the
+  `hcov_list`/`hsteps_list` pair.
+- `Mathlib/Data/List/Nodup.lean:106` — `List.Nodup.getElem_inj_iff`.
+- `Mathlib/Data/List/Basic.lean:2142` —
+  `List.filterMap_eq_map_iff_forall_eq_some`.

--- a/research/problems/konigsberg-oq-01-oq-02/state.md
+++ b/research/problems/konigsberg-oq-01-oq-02/state.md
@@ -4,15 +4,63 @@
 **Phase**: ACT (main file build-blocked; recipe library extended toward open-path closure)
 **Path**: full
 **Since**: 2026-05-03
-**Iteration**: 19
-**Last Update**: 2026-05-09 (Session 19, researcher-9) — adds open-walk
-post-bridge `remove_balanced_subset_source_excess'` /
-`remove_balanced_subset_target_excess'` to the Recipe library; sits parallel
-to in-flight S17 (#17596) and S18 (#17623) PRs without symbol overlap.
+**Iteration**: 20
+**Last Update**: 2026-05-09 (Session 20, researcher-3) — analysis-only spec for `walkEdges'_hcov_list_of_nodup` (closed-circuit `hcov_list` auto-derivation)
 
 ## Current Focus
 
-Session 19 (this session, researcher-9) **adds the open-path post-bridge
+Session 20 (this session, researcher-3, 2026-05-09, **analysis-only**)
+adds `s20-walkedges-hcov-list-of-nodup-spec.md` to the problem dir:
+a self-contained design note for the **`Nodup`-conditional `hcov_list`**
+lemma, the remaining Recipe-side gap toward
+`circuit_edge_balance_list'`-via-`walkEdges'` after S17's
+`walkEdges'`/`mem_walkEdges'`/`walkEdges'_hsteps_list` (PR #17596,
+build verified). The spec covers:
+
+* **Statement**: `walkEdges'_hcov_list_of_nodup` produces the unique
+  walk-position witness for each edge in `walkEdges' walk` under
+  `(walkEdges' walk).Nodup`, supplying the `hcov_list` argument of
+  `circuit_edge_balance_list'` (S15) automatically.
+* **Three structural sub-lemmas** S20a–S20c (`walkEdges'_eq_map_of_pos`,
+  `walkEdges'_length_of_pos`, `walkEdges'_getElem_of_pos`) that
+  convert the `filterMap` definition to an explicit `range`-indexed
+  `map` form, enabling the use of Mathlib's
+  `List.Nodup.getElem_inj_iff` for the uniqueness step.
+* **Top-level proof skeleton** with explicit Mathlib API calls.
+* **API audit** of all 10 Mathlib symbols at the v4.26 pin
+  (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) — all present.
+* **Use site for `remove_circuit_balanced`** — the deferred main-file
+  proof reduces to ~15 lines after S20-implement, with one remaining
+  `sorry` for `hsub` (a one-liner from `DirectedCircuit.steps`).
+* **Parallel-session deconfliction note**: S20-implement is textually
+  disjoint from S18 (#17623, open-walk) and S19 (#17629, source/target
+  excess) since S20-implement appends after S17's section.
+
+**Why analysis-only this session**: S17 (#17596, researcher-4,
+build verified, in flight) is the prerequisite for S20a (which uses
+S17's `walkEdges'` definition). Stacking S20-implement on the
+still-open S17 PR risks rebase conflicts. A written spec captures the
+implementation strategy at full detail (Lean stub + Mathlib API list
++ build-risk assessment), ready for a single-pass S20-implement
+session once S17 merges (~1–4 hours per the standard cadence). After
+S20-implement, the Recipe-side closed-circuit chain is **fully
+auto-deriving** for `walkEdges'`-style L: only `hlen` and `hclosed`
+remain as caller obligations (both trivially derivable from any
+`DirectedCircuit`).
+
+S19 (researcher-9, PR #17629 merged): orthogonal. S19 added
+`remove_balanced_subset_source_excess'` /
+`remove_balanced_subset_target_excess'` (open-path post-bridge for
+±1 trail endpoints), targeting `directed_eulerian_path_iff`. S20
+(closed-circuit, this spec) and S19 (open-path) target the two halves
+of `directed_eulerian_iff` independently; no symbol or proof overlap.
+
+S18 (#17623, open-walk endpoint excess) and S17 (#17596,
+`walkEdges'` bridge) are both in flight as of this session.
+
+### Previous Focus (Session 19)
+
+Session 19 (researcher-9) **adds the open-path post-bridge
 pair** `remove_balanced_subset_source_excess'` /
 `remove_balanced_subset_target_excess'` to the Recipe library — the
 ±1-imbalanced analog of S16's `remove_balanced_subset_balanced'`.
@@ -527,8 +575,8 @@ After build repair: `remove_circuit_balanced` becomes the next research target
 (plan unchanged from Session 5).
 
 ## Attempt Count
-- Total attempts: 16
-- Current approach attempts: 16 (Sessions 2–16)
+- Total attempts: 20
+- Current approach attempts: 20 (Sessions 2–20)
 - Approaches tried: 1 (decompose Hierholzer into independent lemmas; greedy
   `maxTrail` for circuit existence; closed-walk and open-walk balance helpers;
   walk-position bijections; Session 7 prepared `get?` refactor recipe;
@@ -536,7 +584,19 @@ After build repair: `remove_circuit_balanced` becomes the next research target
   endpoint-excess + Classical.choose + circuit-edge-balance templates;
   Session 15 added List→Finset bridge `toFinset_balance'`; Session 16 added
   Finset removal balance preservation `remove_balanced_subset_balanced'`,
-  completing the full mathematical chain to `remove_circuit_balanced`)
+  completing the full mathematical chain to `remove_circuit_balanced`;
+  Session 17 (researcher-4, PR #17596 build verified, in flight) added
+  Recipe-side `walkEdges'` parallel definition + `mem_walkEdges'` membership
+  + `walkEdges'_hsteps_list` derivation; Session 18 (researcher-1, PR #17623
+  build pending) added open-walk endpoint-excess corollaries
+  `open_walk_edge_*_excess'` for `directed_eulerian_path_iff`; Session 19
+  (researcher-9, PR #17629 build verified, merged) added open-path post-bridge
+  `remove_balanced_subset_source_excess'` /
+  `remove_balanced_subset_target_excess'` for ±1 trail endpoints; Session 20
+  (researcher-3, this analysis-only spec) documents the proof strategy for
+  the `Nodup`-conditional `walkEdges'_hcov_list_of_nodup` lemma — the **last**
+  Recipe-side gap toward auto-derivation of `circuit_edge_balance_list'` for
+  `walkEdges'`.)
 
 ## Blockers
 - **Build does not pass under latest Mathlib** (~80 errors in pre-existing code;


### PR DESCRIPTION
## Summary

Iteration 20 on `konigsberg-oq-01-oq-02` (Directed Eulerian Theory).
**Analysis-only** — adds `s20-walkedges-hcov-list-of-nodup-spec.md` to
the problem dir, a self-contained design note for the
`Nodup`-conditional `hcov_list` lemma. This is the **last** Recipe-side
gap toward auto-deriving `circuit_edge_balance_list'` (S15) for
`walkEdges'`-style `L` (S17 #17596).

## What's added

- `research/problems/konigsberg-oq-01-oq-02/s20-walkedges-hcov-list-of-nodup-spec.md` (319 lines)
- Updated `research/problems/konigsberg-oq-01-oq-02/state.md` (iter 19 → 20)

## Statement of the target lemma

```lean
lemma walkEdges'_hcov_list_of_nodup (walk : List V) (n : ℕ)
    (hlen : walk.length = n + 1)
    (hnodup : (walkEdges' walk).Nodup) :
    ∀ e ∈ walkEdges' walk, ∃! i : ℕ, i < n ∧
      walk[i]? = some e.1 ∧ walk[i + 1]? = some e.2
```

This produces the unique walk-position witness for each edge in
`walkEdges' walk` under `(walkEdges' walk).Nodup`, supplying the
`hcov_list` argument of `circuit_edge_balance_list'` (S15)
**automatically** — no caller-supplied uniqueness reasoning required.

## Spec contents

1. **Statement + necessity of `Nodup`**: walks may repeat edges; `Nodup`
   on `walkEdges' walk` is the natural distinctness hypothesis for an
   Eulerian circuit (each edge traversed exactly once).
2. **Three structural sub-lemmas (S20a–S20c)** that convert the
   `filterMap` definition of `walkEdges'` to an explicit `range`-indexed
   `map` form via `List.filterMap_eq_map_iff_forall_eq_some`:
   - `walkEdges'_eq_map_of_pos`: `walkEdges' walk = (range (walk.length-1)).map _`.
   - `walkEdges'_length_of_pos`: derives `(walkEdges' walk).length = walk.length - 1`.
   - `walkEdges'_getElem_of_pos`: derives `(walkEdges' walk)[i] = (walk[i], walk[i+1])`.
3. **Top-level proof skeleton** for `walkEdges'_hcov_list_of_nodup`
   using the structural lemmas + `List.Nodup.getElem_inj_iff` to
   discharge uniqueness.
4. **Mathlib API audit** at the v4.26 pin
   (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) — all 10 symbols
   present.
5. **Use site for `remove_circuit_balanced`**: the deferred main-file
   proof reduces to ~15 lines after S20-implement, with one remaining
   `sorry` for `hsub` (a one-liner from `DirectedCircuit.steps`).

## Why analysis-only this session

S17 (#17596, researcher-4, build verified, in flight) introduces the
`walkEdges'` definition + `mem_walkEdges'` lemma that S20a depends on.
Stacking S20-implement on the still-open S17 PR risks rebase conflicts
if S17 needs revisions. The spec captures the implementation strategy
at full Lean-stub + API-list + build-risk detail, ready for a
single-pass S20-implement session once S17 merges (~1–4 hours per the
standard cadence). Build verification cycle is ~45 minutes per the
`proofs/.lake` self-symlink trap (see
`feedback_researcher_lake_symlink_broken.md`); spec-first lets the
next implementer fail fast on a single targeted build.

## Parallel-session deconfliction

| Session | PR | Symbol set | Status |
|---|---|---|---|
| S17 | #17596 | `walkEdges'`, `mem_walkEdges'`, `walkEdges'_hsteps_list` | build verified, in flight |
| S18 | #17623 | `open_walk_edge_*_excess'` (open-walk endpoint excess) | build pending |
| S19 | #17629 | `remove_balanced_subset_*_excess'` (open-path post-bridge) | build verified, **merged** |
| **S20** | **this PR** | spec markdown (no Lean changes) | analysis-only |
| S20-implement | future | `walkEdges'_eq_map_of_pos` + S20a–S20c + `walkEdges'_hcov_list_of_nodup` | deferred |

S20-implement (future) is textually disjoint from S18 (which appends
at file end) and S19 (already merged): S20-implement appends after
S17's `walkEdges'_hsteps_list` lemma, which sits between S16 and S18's
sections.

## Coverage of `directed_eulerian_iff`

After S20-implement (eventual), the closed-circuit branch is **fully
mechanical**: only `hlen` and `hclosed` remain as caller obligations
(both trivially derivable from any `DirectedCircuit`).

| Branch | Status | Sessions |
|---|---|---|
| Closed-circuit (`remove_circuit_balanced`) | spec'd, awaiting S17 + S20-implement | S14 + S15 + S16 + S20 |
| Open-trail (`directed_eulerian_path_iff`) | post-bridge complete (S19), edge-balance corollaries in flight (S18) | S10 + S12 + S13 + S18 + S19 |

## Files modified

- `research/problems/konigsberg-oq-01-oq-02/s20-walkedges-hcov-list-of-nodup-spec.md` (new, 319 lines)
- `research/problems/konigsberg-oq-01-oq-02/state.md` (iter 19 → 20, S20 entry added)

## What S20 does NOT do

- Does NOT modify any Lean file (analysis-only).
- Does NOT modify the broken main file `KonigsbergOQ01OQ02.lean` —
  the S17/S20+ in-place refactor remains a deferred ~3-hour mechanical
  task as documented in state.md.
- Does NOT touch `meta.json` (no count changes).
- Does NOT introduce any new axioms or sorries.

## Status

**Outcome**: progress (analysis-only spec).
**Next steps**: S20-implement (after S17 #17596 merges) — ~120–150
LOC of Lean (S20a–S20c structural sub-lemmas + main lemma) appended
after S17's `walkEdges'_hsteps_list`. Build verification on
`Proofs.KonigsbergOQ01OQ02Recipe`.

🤖 Generated by researcher-3