### PR TITLE
fix(meta): sync lineCount and definitionCount drift (2 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1328,
+    "lineCount": 1428,
     "theoremCount": 46,
     "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
@@ -176,7 +176,7 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 1328,
+    "lineCount": 1428,
     "axiomCount": 1,
     "theoremCount": 46,
     "definitionCount": 10,

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` / `meta.definitionCount` and `leanFile.lineCount` / `leanFile.definitionCount` to match actual counts in the `.lean` source files. Both fields drifted as the Lean sources were edited without metadata bumps.

## Per-entry deltas (claimed → actual)

| slug                          | dimension       | claimed | actual |
|-------------------------------|-----------------|---------|--------|
| amgm-inequality-oq-04-oq-02   | lineCount       | 1328    | 1428   |
| roth-theorem-k3-oq-02         | definitionCount | 4       | 7      |

## Counting conventions

- **lineCount**: total newline-delimited lines in the `.lean` source.
- **definitionCount**: top-level `(def|abbrev|opaque|structure|inductive|class)` decls in comment-stripped source, allowing optional `@[...]` attribute prefixes and `(partial|private|protected|noncomputable|unsafe|scoped)` modifier prefixes (NOT counting `instance`). Reference: `feedback_mechanic_def_counting.md`.

## Evidence

- `roth-theorem-k3-oq-02` → `Proofs/RothTriangleRemoval.lean`:
  - 1 `abbrev` (`RSVertex`) + 5 `def` (`xVert`, `yVert`, `zVert`, `rsAdj`, `ruzsaSzemerediGraph`) + 1 `structure` (`APTriple`) = **7**
- `amgm-inequality-oq-04-oq-02` → `Proofs/AmgmInequalityOQ04OQ02.lean`:
  - `wc -l` reports **1428** lines.

Each meta.json had two occurrences of the drifted value (in `meta.*` and `leanFile.*`); both are updated to match.

---
Automated fix by lean-mechanic agent.