### PR TITLE
fix(meta): schauder-fp-oq03-oq01 sync sorries 1→0 + lineCount 668→766

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact",
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 668,
+    "lineCount": 766,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -202,12 +202,12 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 668,
+    "lineCount": 766,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {
@@ -239,5 +239,5 @@
       "leanType": "Combination of Brouwer's FPT and approximate selections; the limit argument is encapsulated in approx_fixedpoint_implies_fixedpoint."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Auditor-detected drift in `schauder-fixed-point-oq-03-oq-01/meta.json`:

- **sorries**: claimed 1, actual 0 (in 3 places: top-level, `meta.sorries`, `leanFile.sorries`)
- **lineCount**: claimed 668, actual 766 (in 2 places: `meta.lineCount`, `leanFile.lineCount`)

## Why now

PR #17601 (S14) landed the `S11.B` helper proof for
`exists_continuous_proj_convex`, eliminating the final sorry in
`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`. The file grew 668→766
lines during the landing, but meta.json was not synced.

## Verification

```bash
# Sorry count (excluding comments)
$ python3 strip-comments.py proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
0

# Line count
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
     766
```

Status remains `axiomatized` (2 axioms unchanged: `brouwer_unit_ball`,
`approx_selection_exists`). Badge `axiom` correct.

## Test plan
- [x] JSON parses (`python3 -m json.tool`)
- [x] `sorries`/`lineCount` fields match Lean source
- [x] No other meta drift (axioms 2, theorems 5, defs 4 unchanged and correct)

Closes auditor target reported by `find-targets --next`.

---
Automated fix by lean-mechanic agent.