### PR TITLE
research(four-square-distribution-oq-01): S16 — Part 25 σ*-side atomic-axiom uniqueness (build pending)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -1900,4 +1900,169 @@ example : jacobiR4 (2 ^ 3) = 24 := jacobiR4_two_pow (by decide)
 /-- r4Count (2^2) = 24, axiomatic via Jacobi's formula. -/
 example : r4Count (2 ^ 2) = 24 := r4Count_two_pow (by decide)
 
+-- =====================================================================
+-- PART 25: σ*-side atomic-axiom uniqueness theorem (S16)
+--
+-- S15 (Part 24) named two of S11.alt's three atomic axioms on the
+-- σ*-side AXIOM-FREE — `(Hodd_σ)` `jacobiR4_eq_eight_sigmaOne_of_odd`
+-- and `(HtwoPow_σ)` `jacobiR4_two_pow`. The third leg, `(Hmul_σ)`, has
+-- been on the σ*-side as `jacobiR4_mul_of_coprime` (Part 20, S10),
+-- AXIOM-FREE.
+--
+-- This Part 25 closes the σ*-side atomic-axiom analysis: it proves
+-- that ANY function `f : ℕ → ℕ` satisfying the three σ*-side
+-- hypotheses is uniquely determined on positive `n` and equals
+-- `jacobiR4`. This is the σ*-side dual of S11.alt's r4Count-side
+-- reduction (PR #17388, `jacobi_r4_formula_from_atomic`).
+--
+-- *Significance*: closing the parallel r4Count-side three hypotheses
+-- (axiom-free) WOULD discharge `jacobi_r4_formula`. The σ*-side
+-- decomposition is internally complete; only the bridge from
+-- `r4Count` to `jacobiR4` remains. This formalises the "what's left"
+-- boundary of the open conjecture in axiomatic terms.
+-- =====================================================================
+
+/-- **σ*-side atomic-axiom uniqueness theorem (S16).** Any function
+    `f : ℕ → ℕ` satisfying the σ*-side images of S11.alt's three atomic
+    axioms equals `jacobiR4` on every positive `n`:
+
+    * `(Hodd_σ)`: `f n = 8 · σ(n)` whenever `¬ 2 ∣ n` (vacuous at
+      `n = 0` since `2 ∣ 0`).
+    * `(HtwoPow_σ)`: `f (2^k) = 24` for every `k ≥ 1`.
+    * `(Hmul_σ)`: `8 · f (m·n) = f m · f n` for coprime `m, n > 0`
+      (the factor of `8` reflects the `f(1) = 8` artifact from
+      `(Hodd_σ)` at `n = 1`).
+
+    AXIOM-FREE: does **not** invoke `jacobi_r4_formula`.
+
+    *Proof structure*: split on parity of `n`. If `n` is odd
+    (`n.factorization 2 = 0`), then `ord_compl[2] n = n`, and `(Hodd_σ)`
+    matches `jacobiR4_factorization_form` (Part 18) directly. If `n`
+    is even (`n.factorization 2 ≥ 1`), apply `(Hmul_σ)` to the coprime
+    factorisation `n = 2^k · m` (with `m = ord_compl[2] n`, `k =
+    n.factorization 2`), then substitute `(HtwoPow_σ)` for `f(2^k)`
+    and `(Hodd_σ)` for `f(m)`. Solving for `f(n)` gives `24·σ(m)`,
+    matching `jacobiR4_factorization_form`'s even-case output.
+
+    *Significance*: closing the parallel r4Count-side hypotheses
+    AXIOM-FREE — i.e., proving `r4Count n = 8·σ(n)` for odd `n`,
+    `r4Count(2^k) = 24` for `k ≥ 1`, and the multiplicativity bridge
+    `8·r4Count(m·n) = r4Count(m)·r4Count(n)` for coprime `m, n > 0`
+    — would discharge `axiom jacobi_r4_formula` via the specialisation
+    `f := r4Count`. Currently each r4Count-side leg is proven only
+    axiomatically (S15's `r4Count_eq_eight_sigmaOne_of_odd` and
+    `r4Count_two_pow`, Part 20's `r4Count_mul_of_coprime`), via
+    `jacobi_r4_formula` itself. -/
+theorem jacobiR4_uniqueness_from_atomic_hypotheses
+    (f : ℕ → ℕ)
+    (Hodd : ∀ n : ℕ, ¬ 2 ∣ n → f n = 8 * sigmaOne n)
+    (HtwoPow : ∀ k : ℕ, 1 ≤ k → f (2 ^ k) = 24)
+    (Hmul : ∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
+        8 * f (m * n) = f m * f n) :
+    ∀ n : ℕ, 0 < n → f n = jacobiR4 n := by
+  intro n hn
+  have hne : n ≠ 0 := hn.ne'
+  have hkm : 2 ^ n.factorization 2 * ord_compl[2] n = n :=
+    Nat.ord_proj_mul_ord_compl_eq_self n 2
+  have hm_pos : 0 < ord_compl[2] n := Nat.ord_compl_pos 2 hne
+  have hm_odd : ¬ 2 ∣ ord_compl[2] n :=
+    Nat.not_dvd_ord_compl Nat.prime_two hne
+  rw [jacobiR4_factorization_form hn]
+  by_cases h2n : 2 ∣ n
+  · -- Even case: k := n.factorization 2 ≥ 1.
+    have hk_one_le : 1 ≤ n.factorization 2 :=
+      (Nat.Prime.dvd_iff_one_le_factorization Nat.prime_two hne).mp h2n
+    have h2k_pos : 0 < 2 ^ n.factorization 2 :=
+      pow_pos (by decide : (0 : ℕ) < 2) _
+    have h2_cop : Nat.Coprime 2 (ord_compl[2] n) :=
+      (Nat.Prime.coprime_iff_not_dvd Nat.prime_two).mpr hm_odd
+    have hcop : Nat.Coprime (2 ^ n.factorization 2) (ord_compl[2] n) :=
+      h2_cop.pow_left _
+    have h_mul := Hmul (2 ^ n.factorization 2) (ord_compl[2] n)
+        hcop h2k_pos hm_pos
+    rw [hkm] at h_mul
+    rw [HtwoPow _ hk_one_le, Hodd _ hm_odd] at h_mul
+    -- h_mul : 8 * f n = 24 * (8 * sigmaOne (ord_compl[2] n))
+    rw [if_pos h2n]
+    -- Goal: f n = 24 * sigmaOne (ord_compl[2] n)
+    have h8 : (0 : ℕ) < 8 := by decide
+    have target :
+        8 * f n = 8 * (24 * sigmaOne (ord_compl[2] n)) := by
+      rw [h_mul]; ring
+    exact Nat.eq_of_mul_eq_mul_left h8 target
+  · -- Odd case: n.factorization 2 = 0, so ord_compl[2] n = n.
+    have hk_zero : n.factorization 2 = 0 := by
+      by_contra hk_ne
+      apply h2n
+      exact (Nat.Prime.dvd_iff_one_le_factorization Nat.prime_two hne).mpr
+        (Nat.one_le_iff_ne_zero.mpr hk_ne)
+    have h_eq : ord_compl[2] n = n := by
+      have hn_factored : n = 2 ^ n.factorization 2 * ord_compl[2] n := hkm.symm
+      rw [hk_zero, pow_zero, one_mul] at hn_factored
+      exact hn_factored.symm
+    rw [if_neg h2n, h_eq]
+    exact Hodd n h2n
+
+/-- **Self-validation: `jacobiR4` satisfies the three σ*-side atomic
+    hypotheses.** AXIOM-FREE bundling of `jacobiR4_eq_eight_sigmaOne_of_odd`
+    (Part 24, S15), `jacobiR4_two_pow` (Part 24, S15), and
+    `jacobiR4_mul_of_coprime` (Part 20, S10). Specialising
+    `jacobiR4_uniqueness_from_atomic_hypotheses` at `f = jacobiR4`
+    yields the trivial `jacobiR4 n = jacobiR4 n`; this self-validation
+    confirms `jacobiR4` is in the class of functions characterised. -/
+theorem jacobiR4_satisfies_atomic_hypotheses :
+    (∀ n : ℕ, ¬ 2 ∣ n → jacobiR4 n = 8 * sigmaOne n) ∧
+    (∀ k : ℕ, 1 ≤ k → jacobiR4 (2 ^ k) = 24) ∧
+    (∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
+        8 * jacobiR4 (m * n) = jacobiR4 m * jacobiR4 n) :=
+  ⟨fun _ hn => jacobiR4_eq_eight_sigmaOne_of_odd hn,
+   fun _ hk => jacobiR4_two_pow hk,
+   fun _ _ hcop hm hn => jacobiR4_mul_of_coprime hcop hm hn⟩
+
+/-- **σ*-side dual of S11.alt's atomic-axiom decomposition (PR #17388).**
+    Specialising `jacobiR4_uniqueness_from_atomic_hypotheses` at
+    `f := r4Count`: GIVEN AXIOM-FREE proofs of the three r4Count-side
+    atomic hypotheses parallel to S15's σ*-side ones, we conclude
+    `r4Count n = jacobiR4 n` for every `0 < n` — i.e., we discharge
+    `axiom jacobi_r4_formula` WITHOUT using it.
+
+    AXIOM-FREE relative to the three r4Count-side hypotheses: the proof
+    invokes `jacobiR4_uniqueness_from_atomic_hypotheses` only.
+
+    Currently each r4Count-side hypothesis is proven only axiomatically
+    via `jacobi_r4_formula`:
+    * (Hodd) — S15's `r4Count_eq_eight_sigmaOne_of_odd`.
+    * (HtwoPow) — S15's `r4Count_two_pow`.
+    * (Hmul) — Part 20's `r4Count_mul_of_coprime`.
+
+    An axiom-free proof of any one of these three would NOT close the
+    open conjecture in isolation, but axiom-free proofs of all three
+    together WOULD (via this theorem). The three legs decompose Jacobi's
+    1834 modular-form proof into three independently attackable pieces
+    — the elementary route documented in S11.alt and the modular-form
+    route documented in S13/S14 (Part 23) target different subsets of
+    these. -/
+theorem jacobi_r4_formula_from_atomic_via_jacobiR4
+    (Hodd : ∀ n : ℕ, ¬ 2 ∣ n → r4Count n = 8 * sigmaOne n)
+    (HtwoPow : ∀ k : ℕ, 1 ≤ k → r4Count (2 ^ k) = 24)
+    (Hmul : ∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
+        8 * r4Count (m * n) = r4Count m * r4Count n) :
+    ∀ n : ℕ, 0 < n → r4Count n = jacobiR4 n :=
+  jacobiR4_uniqueness_from_atomic_hypotheses r4Count Hodd HtwoPow Hmul
+
+-- ---------------------------------------------------------------------
+-- Cross-validation: `jacobiR4` is in the uniqueness class
+-- (`jacobiR4_satisfies_atomic_hypotheses`), and specialising the
+-- uniqueness theorem at `f = jacobiR4` yields the trivial identity.
+-- ---------------------------------------------------------------------
+
+/-- Specialising `jacobiR4_uniqueness_from_atomic_hypotheses` at
+    `f = jacobiR4` reduces to `jacobiR4 = jacobiR4` on positive `n`,
+    confirming the uniqueness statement is non-vacuously satisfiable. -/
+example : ∀ n : ℕ, 0 < n → jacobiR4 n = jacobiR4 n :=
+  jacobiR4_uniqueness_from_atomic_hypotheses jacobiR4
+    jacobiR4_satisfies_atomic_hypotheses.1
+    jacobiR4_satisfies_atomic_hypotheses.2.1
+    jacobiR4_satisfies_atomic_hypotheses.2.2
+
 end FourSquareDistributionOQ01

--- a/research/problems/four-square-distribution-oq-01/state.md
+++ b/research/problems/four-square-distribution-oq-01/state.md
@@ -2,9 +2,25 @@
 
 ## Current State
 **Phase**: ACT
-**Phase note**: S15 (this PR, researcher-9) names the σ*-side images
-of two of S11.alt's three elementary atomic axioms — `(Hodd)` and
-`(HtwoPow)` — as standalone, AXIOM-FREE theorems on `jacobiR4`:
+**Phase note**: S16 (this PR, researcher-9) closes the σ*-side
+atomic-axiom analysis with a UNIQUENESS theorem
+`jacobiR4_uniqueness_from_atomic_hypotheses`. The theorem states that
+any function `f : ℕ → ℕ` satisfying the σ*-side images of S11.alt's
+three atomic axioms — `(Hodd_σ)`, `(HtwoPow_σ)`, and `(Hmul_σ)` — is
+uniquely determined on positive `n` and equals `jacobiR4`. AXIOM-FREE
+(does not invoke `jacobi_r4_formula`). Specialising at `f := r4Count`
+gives `jacobi_r4_formula_from_atomic_via_jacobiR4`: AXIOM-FREE proofs
+of the three r4Count-side hypotheses parallel to S15's σ*-side ones
+WOULD discharge `jacobi_r4_formula`. Bundles S15 and S10 with a clean
+self-validation (`jacobiR4_satisfies_atomic_hypotheses`). +165 lines
+(1903 → 2068), +3 theorems (118 → 121), 0 new axioms, 0 new sorries.
+Significance: this is the σ*-side dual of S11.alt's
+`jacobi_r4_formula_from_atomic` (PR #17388). The σ*-side
+three-hypothesis structure is internally complete; only the bridge
+from `r4Count` to `jacobiR4` remains. This formalises the "what's
+left" boundary of `axiom jacobi_r4_formula` in axiomatic terms.
+S15 (PR #17635, merged): Part 24 — σ*-side images of (Hodd) and
+(HtwoPow) as standalone, AXIOM-FREE theorems on `jacobiR4`:
 * `jacobiR4_eq_eight_sigmaOne_of_odd`: for odd `n`,
   `jacobiR4 n = 8 · σ(n)` (axiom-free via `sigmaStar_eq_sigmaOne_of_odd`,
   Part 6).
@@ -46,8 +62,8 @@ S12 (PR #17490, merged): Part 22 — `jacobiR4(p^k) = 8·σ(p^k)` and
 `r4Count(p^k) = 8·σ(p^k)` for odd prime `p`, any `k ≥ 0`.
 **Path**: full
 **Since**: 2026-05-08T21:33:45+03:00
-**Last Updated**: 2026-05-09 (S15, researcher-9; Part 24 σ*-side atomic-axiom images)
-**Iteration**: 15
+**Last Updated**: 2026-05-09 (S16, researcher-9; Part 25 σ*-side atomic-axiom uniqueness theorem)
+**Iteration**: 16
 
 ## Current Focus
 S13 (this session, analysis-only) adds
@@ -173,7 +189,7 @@ Currently still blocked on Mathlib infrastructure:
 
 ## Attempt Count
 
-- Total attempts: 15.
+- Total attempts: 16.
 - S1 (researcher-?): OBSERVE/ORIENT bootstrap (axiomatize, n = 1..10).
 - S2 (researcher-10): ACT — σ*(n) = σ(n) − 4·σ(n/4)·[4∣n] structural.
 - S3 (researcher-?): σ* on odd prime powers, σ*(2n)/σ*(4n) = 3·σ(n).
@@ -226,15 +242,39 @@ Currently still blocked on Mathlib infrastructure:
   `jacobi_r4_formula_from_modular_form` axiom-free 2-hypothesis
   implication theorem on parameter `QC : ℕ → ℕ`, transcribing S13's
   spec without adding new axioms. +121 lines, 0 new sorries.
-- S15 (researcher-9, 2026-05-09, this PR): Part 24 — σ*-side images of
-  S11.alt's atomic-axiom decomposition: `jacobiR4_eq_eight_sigmaOne_of_odd`
-  (axiom-free, generalising Part 21/22's odd-prime/odd-prime-power
-  cases to ALL odd `n`), `r4Count_eq_eight_sigmaOne_of_odd` (axiomatic
-  via `jacobi_r4_formula`), `jacobiR4_two_pow` (axiom-free via
+- S15 (researcher-9, 2026-05-09, PR #17635 merged): Part 24 — σ*-side
+  images of S11.alt's atomic-axiom decomposition:
+  `jacobiR4_eq_eight_sigmaOne_of_odd` (axiom-free, generalising Part
+  21/22's odd-prime/odd-prime-power cases to ALL odd `n`),
+  `r4Count_eq_eight_sigmaOne_of_odd` (axiomatic via
+  `jacobi_r4_formula`), `jacobiR4_two_pow` (axiom-free via
   `sigmaStar_two_pow`, Part 13), `r4Count_two_pow` (axiomatic). These
   name S11.alt's (Hodd) and (HtwoPow) on both sides; the third leg
   (Hmul) is already named axiomatically as Part 20's
   `r4Count_mul_of_coprime`. +121 lines, 0 new axioms, 0 new sorries.
+- S16 (researcher-9, 2026-05-09, this PR): Part 25 — σ*-side
+  atomic-axiom uniqueness theorem
+  `jacobiR4_uniqueness_from_atomic_hypotheses`. AXIOM-FREE: any
+  `f : ℕ → ℕ` satisfying the three σ*-side hypotheses — (Hodd_σ)
+  `f n = 8·σ(n)` for odd n, (HtwoPow_σ) `f(2^k) = 24` for k ≥ 1, and
+  (Hmul_σ) `8·f(m·n) = f(m)·f(n)` for coprime positive m, n —
+  equals `jacobiR4` on every positive `n`. Proof splits on parity of
+  n via `Nat.factorization` / `ord_compl[2]`; even case applies
+  (Hmul_σ) on coprime (2^k, m), substitutes (HtwoPow_σ) and (Hodd_σ),
+  solves for `f(n) = 24·σ(m)`; odd case reduces `ord_compl[2] n = n`
+  and applies (Hodd_σ) directly. Companion theorems
+  `jacobiR4_satisfies_atomic_hypotheses` (self-validation, AXIOM-FREE
+  bundling of S15's two σ*-side images and S10's Part 20
+  multiplicativity) and `jacobi_r4_formula_from_atomic_via_jacobiR4`
+  (specialisation at `f := r4Count`: AXIOM-FREE proofs of the three
+  r4Count-side hypotheses parallel to S15's σ*-side ones WOULD
+  discharge `jacobi_r4_formula`). +165 lines (1903 → 2068),
+  +3 theorems (118 → 121), 0 new axioms, 0 new sorries.
+  Significance: σ*-side dual of S11.alt's
+  `jacobi_r4_formula_from_atomic` (PR #17388). The σ*-side
+  three-hypothesis structure is internally complete; only the bridge
+  from `r4Count` to `jacobiR4` remains. This formalises the "what's
+  left" boundary of `axiom jacobi_r4_formula` in axiomatic terms.
 - Approaches tried: 1 (Approach A — modular form bridge).
 
 ## Blockers

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1774,
-    "theoremCount": 114,
+    "lineCount": 2068,
+    "theoremCount": 121,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [

--- a/src/data/research/problems/four-square-distribution-oq-01.json
+++ b/src/data/research/problems/four-square-distribution-oq-01.json
@@ -31,8 +31,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08",
-    "iteration": 13,
-    "focus": "S13 (2026-05-09, researcher-3, analysis-only): Modular-form atomic decomposition spec at `research/problems/four-square-distribution-oq-01/s13-modular-form-atomic-decomposition.md`. Documents a parallel route to S11.alt's elementary 3-hypothesis decomposition (PR #17388): two atomic axioms (Hθ4Coef) `r4Count n = qCoeff_n((jacobiTheta τ)^4)` for `n > 0` and (Hθ4Eis) `(jacobiTheta τ)^4 = 1 + 8·(E₂(τ) − 4·E₂(4τ))`. With these plus Mathlib's eventual `EisensteinSeries.E2_qExpansion` and S9's `r4Count_factorization_form`, `jacobi_r4_formula` is discharged via finite arithmetic on n-th coefficients tying back to S2's structural identity `σ*(n) = σ(n) − 4·σ(n/4)·[4∣n]`. The spec details per-axiom Mathlib API status (both currently absent from v4.26.0), the 6-step closure proof skeleton, comparison with S11.alt's elementary route (neither route subsumes the other; closing either pair of hypotheses discharges the open axiom), an implementation plan for a follow-up S13-implement session (~60–80 lines of Part 23 axiomatic scaffolding + 2-3 cross-validation `example`s), and a 9-month Mathlib upstream contribution sequence (q-expansion → E₂ Hecke completion → Γ₀(4) dimension → r₄ closure). Why analysis-only: `FourSquareDistributionOQ01.lean` has accumulated 4–5 build-pending PRs (S9 #17347, S10 #17359, S11 #17395, S11.alt #17388, S12 #17490). Adding more Lean code under contention risks build/merge conflicts without unblocking downstream work; a written specification captures the modular-form route at axiom-statement granularity for transcription in a single follow-up session once contention subsides. S12 (PR #17490, merged): Part 22 — `jacobiR4(p^k) = 8·σ(p^k)` and `r4Count(p^k) = 8·σ(p^k)` for odd prime `p`, any `k ≥ 0`. With Part 15's pure 2-power closed form and Part 12's σ*-multiplicativity, jacobiR4(n) is now explicitly pinned on every prime power.",
+    "iteration": 16,
+    "focus": "S16 (2026-05-09, researcher-9, this PR): σ*-side atomic-axiom UNIQUENESS theorem `jacobiR4_uniqueness_from_atomic_hypotheses` (Part 25). AXIOM-FREE: any function `f : ℕ → ℕ` satisfying the σ*-side images of S11.alt's three atomic axioms — (Hodd_σ) `f n = 8·σ(n)` whenever `¬ 2 ∣ n`, (HtwoPow_σ) `f(2^k) = 24` for `k ≥ 1`, and (Hmul_σ) `8·f(m·n) = f(m)·f(n)` for coprime `m, n > 0` — equals `jacobiR4` on every positive `n`. Proof splits on parity via `Nat.factorization` / `ord_compl[2]`; the even case applies (Hmul_σ) on coprime (2^k, m), substitutes (HtwoPow_σ) for `f(2^k)` and (Hodd_σ) for `f(m)`, solves for `f(n) = 24·σ(m)`; the odd case reduces `ord_compl[2] n = n` and applies (Hodd_σ) directly. Companion theorems: `jacobiR4_satisfies_atomic_hypotheses` (AXIOM-FREE self-validation bundling S15's `jacobiR4_eq_eight_sigmaOne_of_odd` + `jacobiR4_two_pow` and S10's Part 20 `jacobiR4_mul_of_coprime`), and `jacobi_r4_formula_from_atomic_via_jacobiR4` (specialisation at `f := r4Count`: AXIOM-FREE proofs of the three r4Count-side hypotheses parallel to S15's σ*-side ones WOULD discharge `jacobi_r4_formula`). +165 lines (1903 → 2068), +3 theorems (118 → 121), 0 new axioms, 0 new sorries. Significance: σ*-side dual of S11.alt's `jacobi_r4_formula_from_atomic` (PR #17388). The σ*-side three-hypothesis structure is internally complete; only the bridge from `r4Count` to `jacobiR4` remains. This formalises the 'what's left' boundary of `axiom jacobi_r4_formula` in axiomatic terms. S15 (PR #17635, merged): Part 24 — σ*-side images of (Hodd) and (HtwoPow) as standalone, AXIOM-FREE theorems on `jacobiR4`. S14 (PR #17524, merged): Part 23 — `jacobi_r4_formula_from_modular_form` axiom-free 2-hypothesis implication theorem on parameter `QC : ℕ → ℕ`. S13 (researcher-3, analysis-only): modular-form atomic decomposition spec.",
     "blockers": [
       "Mathlib q-expansion machinery for `jacobiTheta` is absent (no Fourier-coefficient extraction lemma for the upper-half-plane theta function).",
       "Mathlib Eisenstein-coefficient identification absent (needed to identify θ⁴ with E₂(τ) − 4·E₂(4τ) up to normalization).",
@@ -41,7 +41,7 @@
     ],
     "nextAction": "(easy, mechanical) S13-implement: transcribe the spec into Part 23 of FourSquareDistributionOQ01.lean — state `theta_pow_four_qCoeff` (Hθ4Coef) and `theta_pow_four_eq_eisenstein` (Hθ4Eis) plus the closure-skeleton theorem `jacobi_r4_formula_from_modular_form` with documented `sorry` body. ~60–80 lines, single session. Defer until file contention subsides (currently 4–5 build-pending PRs). (productive, modular-form route, S13 SPEC) Two atomic axioms targeting Mathlib roadmap; with (Hθ4Coef) + (Hθ4Eis) + Mathlib's `EisensteinSeries.E2_qExpansion`, S9's `r4Count_factorization_form` closes `jacobi_r4_formula`. See `s13-modular-form-atomic-decomposition.md`. Parallel to S11.alt's elementary 3-hypothesis route (PR #17388); closing either discharges the axiom. (elementary, hard) Direct combinatorial proof of `r4Count(2n) = 3·r4Count(n)` for odd n via the pairing bijection (~300–500 lines). Speculative. (speculative) Hurwitz-quaternion route — multi-month upstream. (skip) Brute-force extension beyond n = 10.",
     "attemptCounts": {
-      "total": 13,
+      "total": 16,
       "currentApproach": 1,
       "approachesTried": 1
     }
@@ -205,7 +205,7 @@
     ]
   },
   "started": "2026-05-06T16:07:09+03:00",
-  "lastUpdate": "2026-05-08",
+  "lastUpdate": "2026-05-09",
   "significance": 7,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S16 closes the σ*-side atomic-axiom analysis with a UNIQUENESS theorem
`jacobiR4_uniqueness_from_atomic_hypotheses`. AXIOM-FREE: any function
`f : ℕ → ℕ` satisfying the σ*-side images of S11.alt's three atomic
axioms (PR #17388) — (Hodd_σ) `f n = 8·σ(n)` for `¬ 2 ∣ n`,
(HtwoPow_σ) `f(2^k) = 24` for `k ≥ 1`, and (Hmul_σ) `8·f(m·n) =
f(m)·f(n)` for coprime `m, n > 0` — equals `jacobiR4` on every
positive `n`. AXIOM-FREE: does not invoke `jacobi_r4_formula`.

Companion theorems:

- `jacobiR4_satisfies_atomic_hypotheses` (AXIOM-FREE self-validation
  bundling S15's `jacobiR4_eq_eight_sigmaOne_of_odd` +
  `jacobiR4_two_pow` and S10's Part 20 `jacobiR4_mul_of_coprime`).
- `jacobi_r4_formula_from_atomic_via_jacobiR4` (specialisation at
  `f := r4Count`: AXIOM-FREE proofs of the three r4Count-side
  hypotheses parallel to S15's σ*-side ones WOULD discharge
  `axiom jacobi_r4_formula`).

### Significance

This is the σ*-side dual of S11.alt's `jacobi_r4_formula_from_atomic`
(PR #17388). The σ*-side three-hypothesis structure is internally
complete; only the bridge from `r4Count` to `jacobiR4` remains. The
theorem formalises the "what's left" boundary of
`axiom jacobi_r4_formula` in axiomatic terms: closing the parallel
r4Count-side three-hypothesis structure (axiom-free) discharges the
open conjecture.

### Proof sketch

```lean
theorem jacobiR4_uniqueness_from_atomic_hypotheses
    (f : ℕ → ℕ)
    (Hodd : ∀ n : ℕ, ¬ 2 ∣ n → f n = 8 * sigmaOne n)
    (HtwoPow : ∀ k : ℕ, 1 ≤ k → f (2 ^ k) = 24)
    (Hmul : ∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
        8 * f (m * n) = f m * f n) :
    ∀ n : ℕ, 0 < n → f n = jacobiR4 n
```

Split on parity of `n` via `Nat.factorization` / `ord_compl[2]`:

- **Even case** (`2 ∣ n`, so `k := n.factorization 2 ≥ 1`): apply
  (Hmul_σ) on coprime `(2^k, ord_compl[2] n)`, substitute (HtwoPow_σ)
  for `f(2^k)` and (Hodd_σ) for `f(ord_compl[2] n)`, solve for
  `f(n) = 24·σ(ord_compl[2] n)`. Matches the even branch of
  `jacobiR4_factorization_form` (Part 18).
- **Odd case** (`¬ 2 ∣ n`, so `n.factorization 2 = 0`): reduce
  `ord_compl[2] n = n` from `n = 2^0 * ord_compl[2] n = ord_compl[2] n`,
  then apply (Hodd_σ) directly. Matches the odd branch of
  `jacobiR4_factorization_form`.

### File deltas

- File: 1903 → 2068 lines (+165), 118 → 121 theorems (+3),
  1 axiom unchanged, 0 sorries unchanged.
- meta.json: lineCount 1774 → 2068, theoremCount 114 → 121.
- state.md: appended S16 entry, iteration 15 → 16, last updated
  2026-05-09.
- Research JSON: currentState.iteration 13 → 16, focus rewritten for
  S16, lastUpdate 2026-05-09.

### Mathlib API used

All already exercised in this file (e.g.
`sigmaStar_factorization_form` Part 18, `sigmaStar_two_pow_mul_odd`
Part 15):

- `Nat.ord_proj_mul_ord_compl_eq_self`
- `Nat.ord_compl_pos`, `Nat.not_dvd_ord_compl`
- `Nat.Prime.dvd_iff_one_le_factorization`
- `Nat.Prime.coprime_iff_not_dvd`, `Nat.Coprime.pow_left`
- `Nat.eq_of_mul_eq_mul_left`, `pow_pos`, `pow_zero`, `one_mul`

### Build status

Build pending: Docker `.lake` self-symlink ⇒ 45+ min cycles; CI
verifies. The new theorems compose only on already-merged S15 (Part
24) and S10 (Part 20) lemmas plus existing Mathlib API; no new
imports.

## Test plan

- [ ] CI passes (Docker build of `Proofs.FourSquareDistributionOQ01`).
- [ ] Auditor pipeline confirms axiom count unchanged (1) and sorry
  count unchanged (0).
- [ ] Spot-check the three atomic hypotheses are AXIOM-FREE on
  `jacobiR4`: `jacobiR4_satisfies_atomic_hypotheses` resolves to
  S15's two σ*-side images + S10's Part 20 multiplicativity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)