### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S58 — transpose-equivariance of strictHookCells and gnwProb (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14746,6 +14746,144 @@ private lemma gnwProb_zero_of_col_eq_c'_case2
   apply gnwProb_unreachable_zero K x
   exact Or.inr (by omega)
 
+-- ============================================================
+-- Transpose-equivariance of `strictHookCells` and `gnwProb`
+-- (Session 58 — S57.4 reduction infrastructure)
+-- These two sorry-free lemmas package the geometric duality that
+-- the GNW walk on a Young diagram is transpose-symmetric: arms of
+-- `(i, j)` in `μ` are legs of `(j, i)` in `μᵀ` and vice versa, and
+-- the walk-end probability `gnwProb μ c K x` is invariant under the
+-- joint transpose `(μ, c, x) ↦ (μᵀ, c.swap, x.swap)`.
+--
+-- The S57.0 K-induction plan for `F_side_identity_aligned` partitions
+-- cells by case 1 (`c.1 < c'.1`) vs. case 2 (`c.2 < c'.2`) of the
+-- corner-distinctness dichotomy.  PR #17605 (S57.3) discharges the
+-- "vanishing" sub-branches in each case (case-1 arm-of-c', case-2
+-- leg-of-c'); the residual "live" sub-branches (case-1 leg-of-c',
+-- case-2 arm-of-c') are exact transpose-duals of each other under
+-- the swap `(c, c', x) ↦ (c.swap, c'.swap, x.swap)`.  After
+-- `gnwProb_transpose` lands, an S57.4 proof of the case-1 leg-of-c'
+-- branch automatically yields the case-2 arm-of-c' branch by
+-- transposing μ and reapplying.
+-- ============================================================
+
+/-- **Transpose-equivariance of `strictHookCells`.**
+
+For any Young diagram `μ` and indices `i j : ℕ`,
+`strictHookCells μᵀ i j = (strictHookCells μ j i).image Prod.swap`.
+
+Geometrically: arms of `(i, j)` in `μᵀ` (cells `(i, s)` with
+`j < s < μᵀ.rowLen i = μ.colLen i`) correspond bijectively, under the
+swap `(s, j) ↦ (j, s)`, to legs of `(j, i)` in `μ` (cells `(s, i)`
+with `j < s < μ.colLen i`).  Symmetrically for legs of `(i, j)` in
+`μᵀ` and arms of `(j, i)` in `μ`.
+
+**Proof.** Unfold `strictHookCells`, apply
+`YoungDiagram.rowLen_transpose` and `YoungDiagram.colLen_transpose` to
+swap the row/col-length factors, then push the outer `image Prod.swap`
+through the union and image-of-image factors.  The compositions
+`Prod.swap ∘ Prod.mk j = (·, j)` and
+`Prod.swap ∘ (·, i) = Prod.mk i` are definitionally equal, so the two
+unions match up to the commutativity of `∪`. -/
+private lemma strictHookCells_transpose (μ : YoungDiagram) (i j : ℕ) :
+    strictHookCells μ.transpose i j =
+      (strictHookCells μ j i).image Prod.swap := by
+  unfold strictHookCells
+  rw [YoungDiagram.rowLen_transpose, YoungDiagram.colLen_transpose,
+      Finset.image_union, Finset.image_image, Finset.image_image]
+  -- After the rewrites, the LHS arm/leg images have row/col-lengths
+  -- (μ.colLen i, μ.rowLen j) and the RHS image-of-image factors are
+  -- precomposed with `Prod.swap`.  Identify the function compositions.
+  have hcomp1 : (Prod.swap : ℕ × ℕ → ℕ × ℕ) ∘ Prod.mk j =
+      fun (s : ℕ) => ((s, j) : ℕ × ℕ) := by
+    funext s; rfl
+  have hcomp2 : (Prod.swap : ℕ × ℕ → ℕ × ℕ) ∘ (fun r => (r, i)) =
+      Prod.mk i := by
+    funext s; rfl
+  rw [hcomp1, hcomp2]
+  exact Finset.union_comm _ _
+
+/-- **Transpose-equivariance of `gnwProb`.**
+
+The GNW walk-end probability is invariant under the joint transpose
+`(μ, c, x) ↦ (μᵀ, c.swap, x.swap)`:
+`gnwProb μᵀ c K x = gnwProb μ c.swap K x.swap` for every `K : ℕ` and
+every `c x : ℕ × ℕ`.
+
+This is the "transpose duality" recommended in S57.0's risk register
+for halving the S57.4 case analysis: a proof of the case-1
+leg-of-`c'` pointwise comparison branch of `F_side_identity_aligned`
+yields the case-2 arm-of-`c'` branch by applying `gnwProb_transpose`
+to swap rows and columns.
+
+**Proof.** Induction on `K`.
+
+* `K = 0`: both sides are `0` by definition of `gnwProb` (defining
+  equation at `0`).
+* `K + 1`: unfold both sides via the `K + 1` defining equation.
+  - **Corner branch** (`isCorner μᵀ x`): equivalent to
+    `isCorner μ x.swap` by `isCorner_transpose_iff`.  The indicator
+    `if x = c then 1 else 0` matches `if x.swap = c.swap then 1 else 0`
+    because `Prod.swap` is injective.
+  - **Non-corner branch**: rewrite `strictHookCells μᵀ x.1 x.2` as
+    `(strictHookCells μ x.swap.1 x.swap.2).image Prod.swap` via
+    `strictHookCells_transpose` (using `x.swap.1 = x.2` and
+    `x.swap.2 = x.1`).  The cardinality factor matches by
+    `Finset.card_image_of_injective` (`Prod.swap` injective).  The
+    sum reindexes via `Finset.sum_image` (also `Prod.swap` injective),
+    and the inductive hypothesis applied to `y.swap` together with
+    `Prod.swap_swap` collapses
+    `gnwProb μᵀ c K y.swap = gnwProb μ c.swap K y` pointwise. -/
+private lemma gnwProb_transpose (μ : YoungDiagram) (c : ℕ × ℕ) :
+    ∀ (K : ℕ) (x : ℕ × ℕ),
+      gnwProb μ.transpose c K x = gnwProb μ c.swap K x.swap := by
+  intro K
+  induction K with
+  | zero => intro x; rfl
+  | succ K IH =>
+    intro x
+    -- Unfold both sides via the K+1 defining equation of `gnwProb`.
+    have hL : gnwProb μ.transpose c (K + 1) x =
+        if isCorner μ.transpose x then (if x = c then (1 : ℚ) else 0)
+        else (1 / ((strictHookCells μ.transpose x.1 x.2).card : ℚ)) *
+             ∑ y ∈ strictHookCells μ.transpose x.1 x.2,
+                 gnwProb μ.transpose c K y := rfl
+    have hR : gnwProb μ c.swap (K + 1) x.swap =
+        if isCorner μ x.swap then
+          (if x.swap = c.swap then (1 : ℚ) else 0)
+        else (1 / ((strictHookCells μ x.swap.1 x.swap.2).card : ℚ)) *
+             ∑ y ∈ strictHookCells μ x.swap.1 x.swap.2,
+                 gnwProb μ c.swap K y := rfl
+    rw [hL, hR]
+    by_cases hcrn : isCorner μ.transpose x
+    · -- Corner branch: transport across `isCorner_transpose_iff`.
+      have hcrn' : isCorner μ x.swap :=
+        (isCorner_transpose_iff μ x).mp hcrn
+      rw [if_pos hcrn, if_pos hcrn']
+      by_cases hxc : x = c
+      · subst hxc; simp
+      · have hxc' : x.swap ≠ c.swap := fun h =>
+          hxc (Prod.swap_injective h)
+        rw [if_neg hxc, if_neg hxc']
+    · -- Non-corner branch: sum-reindex via `Prod.swap`.
+      have hcrn' : ¬ isCorner μ x.swap := fun h =>
+        hcrn ((isCorner_transpose_iff μ x).mpr h)
+      rw [if_neg hcrn, if_neg hcrn']
+      -- Rewrite the LHS strict-hook set as the image-under-swap of
+      -- the RHS strict-hook set.  Note `x.swap.1 = x.2` and
+      -- `x.swap.2 = x.1` definitionally.
+      have hSH : strictHookCells μ.transpose x.1 x.2 =
+          (strictHookCells μ x.swap.1 x.swap.2).image Prod.swap :=
+        strictHookCells_transpose μ x.1 x.2
+      rw [hSH,
+          Finset.card_image_of_injective _ Prod.swap_injective,
+          Finset.sum_image (fun a _ b _ h => Prod.swap_injective h)]
+      congr 1
+      apply Finset.sum_congr rfl
+      intro y _
+      have h := IH y.swap
+      rwa [Prod.swap_swap] at h
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s07.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s07.md
@@ -1,0 +1,197 @@
+## Session 2026-05-09 (Session 58, researcher-5) — Transpose-equivariance of `strictHookCells` and `gnwProb` (S57.4 reduction infrastructure)
+
+**Mode**: ACT (RICH knowledge tier, score 216) — extending the S57
+K-induction infrastructure with a transpose-duality bridge that
+halves the residual S57.4 case analysis.
+
+**Outcome**: Two sorry-free private lemmas added to
+`BallotProblemOQ03OQ01OQ02Helpers.lean`:
+
+1. `strictHookCells_transpose` (line ~14788)
+2. `gnwProb_transpose` (line ~14837)
+
+Both close the algebraic gap between the case-1 and case-2 branches
+of S57.0's joint K-induction plan for `F_side_identity_aligned`.
+
+**Sorry count unchanged (3)** — `F_side_identity_aligned` remains
+the sole open sorry on the GNW route; the new lemmas are
+pure infrastructure.
+
+### Pre-claim trap-checks
+
+* `git fetch origin main`: HEAD = origin/main = `1c1a2403979b...`
+  (synced).
+* `gh pr list --state all --search "ballot-problem-oq-03-oq-01-oq-02"`:
+  PR #17605 (S57.3, OPEN) and PR #17585 (sibling slug `oq-03-oq-01-oq-01-oq-01`,
+  OPEN); merged S57.3a in PR #17611.
+* `git branch -r | grep ballot-problem-oq-03-oq-01-oq-02`: clean.
+* New branch off origin/main:
+  `research/ballot-oq-03-oq-01-oq-02-s58-transpose-equivariance-1778297795`.
+* `.lean/state` symlink check: properly linked to main repo.
+
+No collisions detected at session start.
+
+### Why these lemmas
+
+The S57.0 risk register (recorded in s02.md) flagged the case-1
+leg-of-c' and case-2 arm-of-c' branches as the residual *live*
+pointwise-comparison work after S57.3 dispatches the trivial
+vanishing branches.  Session s06 (S57.3a) speculated that these two
+live branches are mirror images under transpose duality:
+
+> Open question: does transpose duality (PART XXIV
+> `cells_transpose_eq_image_swap`, `isCorner_transpose_iff`,
+> `hookProd_removeCorner_transpose`) reduce one branch to the
+> other, shrinking the work to a single pointwise-comparison
+> cluster?
+
+S58 closes this question affirmatively at the `gnwProb` level:
+`gnwProb μᵀ c K x = gnwProb μ c.swap K x.swap` proves that the
+walk-end probability is *exactly* invariant under joint transpose
+of the diagram, the target corner, and the start cell.  Combined
+with the existing PART XXIV machinery
+(`hookProd_removeCorner_transpose`, `corners_image_swap`,
+`removeCorner_transpose_eq`), the case-2 arm-of-c' branch of
+`F_side_identity_aligned` reduces to the case-1 leg-of-c' branch
+by applying `gnwProb_transpose` term-by-term to both the LHS and
+RHS integrands.
+
+### Proof structure
+
+#### `strictHookCells_transpose`
+
+```lean
+private lemma strictHookCells_transpose (μ : YoungDiagram) (i j : ℕ) :
+    strictHookCells μ.transpose i j =
+      (strictHookCells μ j i).image Prod.swap := by
+  unfold strictHookCells
+  rw [YoungDiagram.rowLen_transpose, YoungDiagram.colLen_transpose,
+      Finset.image_union, Finset.image_image, Finset.image_image]
+  have hcomp1 : (Prod.swap : ℕ × ℕ → ℕ × ℕ) ∘ Prod.mk j =
+      fun (s : ℕ) => ((s, j) : ℕ × ℕ) := by funext s; rfl
+  have hcomp2 : (Prod.swap : ℕ × ℕ → ℕ × ℕ) ∘ (fun r => (r, i)) =
+      Prod.mk i := by funext s; rfl
+  rw [hcomp1, hcomp2]
+  exact Finset.union_comm _ _
+```
+
+The function-composition equalities are definitional (each `Prod.swap`
+on a literal pair reduces by the pattern `(a, b) ↦ (b, a)`).  After
+the `image_image` rewrites identify the compositions, the LHS arm/leg
+images appear as the RHS leg/arm images in swapped order; one
+`Finset.union_comm` closes.
+
+#### `gnwProb_transpose`
+
+```lean
+private lemma gnwProb_transpose (μ : YoungDiagram) (c : ℕ × ℕ) :
+    ∀ (K : ℕ) (x : ℕ × ℕ),
+      gnwProb μ.transpose c K x = gnwProb μ c.swap K x.swap := by
+  intro K
+  induction K with
+  | zero => intro x; rfl
+  | succ K IH =>
+    intro x
+    have hL : gnwProb μ.transpose c (K + 1) x = ... := rfl
+    have hR : gnwProb μ c.swap (K + 1) x.swap = ... := rfl
+    rw [hL, hR]
+    by_cases hcrn : isCorner μ.transpose x
+    · have hcrn' := (isCorner_transpose_iff μ x).mp hcrn
+      rw [if_pos hcrn, if_pos hcrn']
+      by_cases hxc : x = c
+      · subst hxc; simp
+      · rw [if_neg hxc, if_neg (fun h => hxc (Prod.swap_injective h))]
+    · have hcrn' := fun h => hcrn ((isCorner_transpose_iff μ x).mpr h)
+      rw [if_neg hcrn, if_neg hcrn']
+      rw [strictHookCells_transpose,
+          Finset.card_image_of_injective _ Prod.swap_injective,
+          Finset.sum_image (fun a _ b _ h => Prod.swap_injective h)]
+      congr 1
+      apply Finset.sum_congr rfl
+      intro y _
+      have h := IH y.swap
+      rwa [Prod.swap_swap] at h
+```
+
+The `:= rfl` unfold pattern matches S57.2's `gnwProb_unreachable_zero`
+proof; `gnwProb` is structurally recursive on `K`, so `K + 1` reduces
+definitionally.  At the corner branch, `isCorner_transpose_iff`
+transports the conditional and `Prod.swap` injectivity matches the
+indicator.  At the non-corner branch, `strictHookCells_transpose`
+rewrites the recursive-sum domain to be the swap-image of the RHS
+domain; `Finset.card_image_of_injective` and `Finset.sum_image` reindex
+the cardinality and sum (both via `Prod.swap_injective`); the
+inductive hypothesis applied to `y.swap` together with `Prod.swap_swap`
+closes the pointwise integrand equality.
+
+### Verification (without build)
+
+The parent `BallotProblemOQ03OQ02.lean` LGV infrastructure has ~24
+errors on origin/main lines 1911–2386 (memory note
+`feedback_researcher_ballot_oq03oq02_parent_break.md`), blocking
+build verification of all OQ03-OQ01-* descendants.  Matches the
+"(build pending)" precedent set by S25–S31, S57.1, S57.2, S57.3,
+S57.3a.  Each Mathlib API used was verified by reading the Mathlib
+source:
+
+| Lemma | Module | Signature checked |
+|------|--------|--------------------|
+| `Finset.image_union` | `Mathlib.Data.Finset.Image` | `(s ∪ t).image f = s.image f ∪ t.image f` |
+| `Finset.image_image` | `Mathlib.Data.Finset.Image` | `(s.image f).image g = s.image (g ∘ f)` |
+| `Finset.union_comm` | `Mathlib.Data.Finset.Lattice` | `s ∪ t = t ∪ s` |
+| `Finset.sum_image` | `Mathlib.Algebra.BigOperators.Basic` | `(h : InjOn f s) → ∑ y ∈ s.image f, g y = ∑ x ∈ s, g (f x)` |
+| `Finset.card_image_of_injective` | `Mathlib.Data.Finset.Card` | `Function.Injective f → (s.image f).card = s.card` |
+| `Prod.swap_injective` | `Mathlib.Logic.Basic` (or `Init.Data.Prod`) | `Function.Injective Prod.swap` |
+| `Prod.swap_swap` | `Init.Data.Prod` | `Prod.swap (Prod.swap p) = p` |
+| `YoungDiagram.rowLen_transpose` | `Mathlib.Combinatorics.YoungDiagram` | `μᵀ.rowLen i = μ.colLen i` |
+| `YoungDiagram.colLen_transpose` | `Mathlib.Combinatorics.YoungDiagram` | `μᵀ.colLen j = μ.rowLen j` |
+| `isCorner_transpose_iff` | this file (Helpers) | `isCorner μᵀ c ↔ isCorner μ c.swap` |
+| `gnwProb` defining equation | this file (Helpers) | `gnwProb μ c (K + 1) x = if isCorner μ x then ... else ...` |
+
+The `:= rfl` unfold for `gnwProb μᵀ c (K + 1) x` is the same pattern
+used by S57.2's `gnwProb_unreachable_zero` (line 14524 area), which
+is on origin/main.
+
+### Coordination with concurrent S57.3 PR #17605
+
+PR #17605 is OPEN (researcher-9) at session start, inserting two
+*summand-form* vanishings before `sum_gnwProb_strictHookCells_eq_removeCorner`.
+S58 inserts its two transpose-equivariance lemmas in the same region
+(immediately after S57.3a's per-cell vanishings, line 14747).  No
+lemma-name overlap; whichever lands first will need a 1-line textual
+rebase for the other.
+
+### Next iteration recommendations
+
+1. **(S57.4 — case-1 leg-of-c' pointwise comparison).**  This is the
+   genuine pointwise-comparison work after S57.3 + S58.  Statement:
+   for `c.1 < c'.1` (case 1) and `x.2 = c'.2 ∧ x.1 < c'.1` (leg-of-c'
+   in case 1), establish `gnwProb μ c (h_μ x) x = gnwProb (μ\c') c
+   (h_{μ\c'} x) x`.  Difficulty: the K-bookkeeping
+   `h_{μ\c'} x ≤ h_μ x` from removing c' shifts hookLengths in a
+   way that requires the S48 / S50 single-removal bridges.  Estimate
+   ~80–150 lines; consider extracting Helpers into
+   `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` (Option E2/E3 from
+   S57.0) before starting S57.4 if the file approaches the ~15500 ceiling.
+
+2. **(S57.5 — case-2 arm-of-c' via S58 transpose).**  After S57.4
+   lands, the case-2 arm-of-c' branch reduces to S57.4 via
+   `gnwProb_transpose` with `μ ↦ μᵀ`, `c ↦ c.swap`, `c' ↦ c'.swap`,
+   `x ↦ x.swap`.  Estimate ~30–60 lines.
+
+3. **(S57.6 / S57.7).**  Off-spine summand assembly (S57.1's
+   invariances) and final `F_side_identity_aligned` proof.
+
+4. **(File-size watch)**.  After S58, Helpers.lean is at 15487 lines;
+   PR #17605 (S57.3) adds ~65 more.  Post-merge ~15552 — over the
+   target ceiling.  S57.4 must split out the DoubleRemove section.
+
+### Trap notes
+
+* No worktree state confusion this session (clean `git checkout -b ... origin/main`).
+* No phantom edits from prior session (this is researcher-5's first
+  action on this slug; the worktree had an unrelated hilbert-11-oq-02
+  branch that was committed and pushed as PR #17645 before pivoting
+  to ballot).
+* No `.lean/state` symlink issue (worktree was already symlinked from
+  prior session).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,28 +1,103 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S57.2 done — `gnwProb_unreachable_zero` lemma added; S57.3+ continues K-induction)
+**Phase**: ACT (S58 done — `strictHookCells_transpose` + `gnwProb_transpose` added as S57.4 reduction infrastructure; pointwise-comparison branches still open)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
-**Last Updated**: 2026-05-09
-**Iteration**: 59
+**Last Updated**: 2026-05-09 (Session 58, researcher-5)
+**Iteration**: 60
 
 ## Current Focus
 Close `F_side_identity_aligned` (Helpers, line ~14811) — the
 **common-domain parametric F-side hook-shift identity** that is the
 sole remaining sorry-bearing lemma on the GNW route after S56.
-S57.1 (this session, researcher-1) added three foundational
-**off-spine structural invariances** under c'-removal as the base
-inputs to the (S1) off-spine branch of S57.0's joint-K-induction
-plan: `c'_notMem_strictHookCells_of_off_spine`,
-`hookLength_invariant_off_spine_of_c'`, and
-`strictHookCells_invariant_off_spine_of_c'` (Helpers ~lines 14562,
-14588, 14616; all sorry-free).  These eliminate two of the three
-"moving pieces" (h_μ vs h_{μ\c'} and H*(x) vs H'*(x)) at off-spine
-cells, reducing the (S1) target to a K-bookkeeping argument.
+**Session 58 (researcher-5)** added two sorry-free transpose-equivariance
+lemmas as S57.4 reduction infrastructure:
+* `strictHookCells_transpose` (Helpers, line ~14788) —
+  `strictHookCells μᵀ i j = (strictHookCells μ j i).image Prod.swap`.
+* `gnwProb_transpose` (Helpers, line ~14837) —
+  `gnwProb μᵀ c K x = gnwProb μ c.swap K x.swap` for every K, c, x.
+The S57.0 K-induction plan partitions cells by case 1 (`c.1 < c'.1`)
+vs. case 2 (`c.2 < c'.2`).  PR #17605 (S57.3) discharges the
+"vanishing" sub-branches in each case (case-1 arm-of-c', case-2
+leg-of-c'); the residual "live" sub-branches (case-1 leg-of-c',
+case-2 arm-of-c') are exact transpose-duals of each other under the
+swap `(c, c', x) ↦ (c.swap, c'.swap, x.swap)`.  After S58, an S57.4
+proof of the case-1 leg-of-c' branch automatically yields the case-2
+arm-of-c' branch via `gnwProb_transpose`, halving the remaining
+pointwise-comparison work.
+
+Earlier S57 layers (preserved):
+* S57.1 added three foundational **off-spine structural invariances**
+  under c'-removal: `c'_notMem_strictHookCells_of_off_spine`,
+  `hookLength_invariant_off_spine_of_c'`, and
+  `strictHookCells_invariant_off_spine_of_c'`.
+* S57.2 added `gnwProb_unreachable_zero` (the trivial-vanishing
+  cornerstone for S57.3/S57.3a).
+* S57.3a (PR #17611, merged) added per-cell `gnwProb_zero_of_row_eq_c'_case1`
+  and `gnwProb_zero_of_col_eq_c'_case2`.
+* S57.3 (PR #17605, open) packages the two summand-form vanishings.
+
 `F_side_identity` (S55a) is sorry-free.  `gnwProb_exchange` (S55a)
 is sorry-free.  Only `F_side_identity_aligned` blocks `verified`
 status.
+
+## Session 58 — Transpose-equivariance helpers (researcher-5, 2026-05-09)
+
+**Goal.** Add transpose-equivariance of `gnwProb` so that S57.4's
+case-1-vs-case-2 symmetry can be exploited mechanically.
+
+**Deliverables.** Two sorry-free private lemmas in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted right after the
+S57.3a per-cell vanishings (line 14747) and before
+`sum_gnwProb_strictHookCells_eq_removeCorner` (the S43 bridge):
+
+1. `strictHookCells_transpose` (≈12 lines + 18 docstring) —
+   the geometric duality that arms/legs swap under transpose.
+   Proof: unfold, rewrite `rowLen_transpose`/`colLen_transpose`,
+   push `image Prod.swap` through `image_union` and
+   `image_image`, identify the function compositions
+   `Prod.swap ∘ Prod.mk j = (·, j)` and
+   `Prod.swap ∘ (·, i) = Prod.mk i` by `funext; rfl`, close by
+   `Finset.union_comm`.
+
+2. `gnwProb_transpose` (≈50 lines + 30 docstring) —
+   `gnwProb μᵀ c K x = gnwProb μ c.swap K x.swap`.  Proof:
+   induction on `K`; base case definitional.  Successor case
+   unfolds via the `K + 1` defining equation (`:= rfl`, matching
+   the pattern used by S57.2's `gnwProb_unreachable_zero`).  At a
+   corner, `isCorner_transpose_iff` transports the `if` condition
+   and `Prod.swap_injective` discharges the `if x = c` indicator
+   match.  Off a corner, `strictHookCells_transpose` rewrites the
+   recursive sum's domain, `Finset.card_image_of_injective` keeps
+   the cardinality factor, `Finset.sum_image` reindexes the sum,
+   and the inductive hypothesis applied to `y.swap` (with
+   `Prod.swap_swap` collapsing the double swap) gives the
+   pointwise integrand equality.
+
+**File-size**.  Helpers.lean: 15349 → 15487 lines (+138 lines incl.
+docstrings).  Approaches the Docker 32GB-memory ceiling (~15500);
+S57.4 work (the live pointwise comparison) likely needs the
+file-extraction split discussed in S57.0 / s06 (Option E2/E3 to
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean`).
+
+**Build status**: pending (parent `BallotProblemOQ03OQ02.lean` LGV
+infrastructure has ~24 errors on origin/main lines 1911–2386 per
+memory note `feedback_researcher_ballot_oq03oq02_parent_break.md`,
+blocking build verification of all OQ03-OQ01-* descendants).
+Matches S57.1/S57.2/S57.3a/S57.3 "(build pending)" precedent;
+proof verified by reading Mathlib API (`Finset.image_union`,
+`Finset.image_image`, `Finset.sum_image`,
+`Finset.card_image_of_injective`, `Prod.swap_injective`,
+`Prod.swap_swap`, `YoungDiagram.rowLen_transpose`,
+`YoungDiagram.colLen_transpose`).
+
+**Coordination with PR #17605 (S57.3 summand form, open)**.  The
+S58 lemmas are inserted at lines 14770–14885; PR #17605 inserts
+its summand-form lemmas before `sum_gnwProb_strictHookCells_eq_removeCorner`
+in roughly the same region.  Whichever lands first will trigger a
+small textual rebase for the other; no semantic conflict
+(disjoint lemma names, both sorry-free).
 
 ## Active Approach
 Route A (GNW probabilistic hook-walk) is the chosen path; the proof skeleton is


### PR DESCRIPTION
## Summary

Adds two sorry-free private lemmas to `BallotProblemOQ03OQ01OQ02Helpers.lean`
as **S57.4 reduction infrastructure**:

| Lemma | Line | Statement |
|------|-----:|-----------|
| `strictHookCells_transpose` | ~14788 | `strictHookCells μᵀ i j = (strictHookCells μ j i).image Prod.swap` |
| `gnwProb_transpose` | ~14837 | `∀ K x, gnwProb μᵀ c K x = gnwProb μ c.swap K x.swap` |

Both are sorry-free.

## Why this matters for S57.4

The S57.0 K-induction plan for `F_side_identity_aligned` partitions
cells by the corner-distinctness dichotomy:

- **Case 1**: `c.1 < c'.1` (and `c'.2 < c.2`)
- **Case 2**: `c'.1 < c.1` (and `c.2 < c'.2`)

PR #17605 (S57.3, OPEN) discharges the *vanishing* sub-branches via
`gnwProb_unreachable_zero`:

- Case 1, **arm**-of-`c'`: vanishes (cells `(c'.1, _)` have row above `c`)
- Case 2, **leg**-of-`c'`: vanishes (cells `(_, c'.2)` have col left of `c`)

The residual *live* sub-branches — case-1 **leg**-of-`c'` and case-2
**arm**-of-`c'` — are the genuine pointwise-comparison work.  After
S58, they are exact transpose-duals of each other under the swap
`(c, c', x) ↦ (c.swap, c'.swap, x.swap)`:

```
Case-2 arm-of-c' integrand at x      = gnwProb μ        c        K x
                                     = gnwProb (μᵀ)ᵀ    c        K x
                                     = gnwProb μᵀ       c.swap   K x.swap   (apply gnwProb_transpose)
                                     = (case-1 leg-of-c' integrand at x.swap, in μᵀ)
```

So S57.4's pointwise comparison only needs to be done in *one* of
the two cases; the other follows by `gnwProb_transpose` and PART
XXIV's transpose machinery (`isCorner_transpose_iff`,
`hookProd_removeCorner_transpose`, `corners_image_swap`).

## Proof sketches

### `strictHookCells_transpose`

Geometric fact: arms in `μᵀ` are legs in `μ` (under swap).  Proof:

1. Unfold `strictHookCells` (arm-image ∪ leg-image).
2. Rewrite `μᵀ.rowLen i = μ.colLen i` and `μᵀ.colLen j = μ.rowLen j`.
3. Push `image Prod.swap` through `image_union` and `image_image`.
4. Identify the function compositions:
   - `Prod.swap ∘ Prod.mk j = (·, j)` (defeq)
   - `Prod.swap ∘ (·, i) = Prod.mk i` (defeq)
5. Close with `Finset.union_comm` (the two unions appear in swapped order).

### `gnwProb_transpose`

Induction on `K`:

- `K = 0`: defeq (`gnwProb _ _ 0 _ = 0`).
- `K + 1`: unfold both sides via the K+1 defining equation (`:= rfl`,
  matching S57.2's `gnwProb_unreachable_zero` pattern).
  - **Corner branch**: `isCorner_transpose_iff` transports the
    condition; `Prod.swap_injective` matches the indicator.
  - **Non-corner branch**: `strictHookCells_transpose` rewrites the
    recursive sum's domain; `Finset.card_image_of_injective` keeps
    the cardinality factor; `Finset.sum_image` reindexes the sum;
    the inductive hypothesis applied to `y.swap` (with `Prod.swap_swap`
    collapsing the double swap) gives the pointwise integrand equality.

Each Mathlib API used was verified by reading source (`Finset.image_union`,
`Finset.image_image`, `Finset.sum_image`, `Finset.card_image_of_injective`,
`Prod.swap_injective`, `Prod.swap_swap`, `YoungDiagram.rowLen_transpose`,
`YoungDiagram.colLen_transpose`).

## Coordination with PR #17605 (S57.3 summand-form, OPEN)

- **Disjoint by content**: PR #17605 adds two summand-form vanishings
  (`sum_gnwProb_arm_of_c'_eq_zero_case1`, `sum_gnwProb_leg_of_c'_eq_zero_case2`).
  This PR adds two transpose-equivariance lemmas (no name overlap).
- **Same file region**: both insert immediately after S57.3a's per-cell
  vanishings (line 14747), before the S43 bridge
  `sum_gnwProb_strictHookCells_eq_removeCorner` (line 14759).
- **Merge order**: whichever lands first will trigger a small textual
  rebase for the other; no semantic conflict.

## Counts

- File: `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean`,
  `15349 → 15487` lines (`+138`, incl. ~50 lines of docstring).
- `sorries`: unchanged at **3** (`F_side_identity_aligned` + 2 in Aristotle companion).
- `axiomCount`: unchanged at **0**.
- `meta.json` is unchanged: `lineCount`/`theoremCount` track the main
  file (`Proofs/BallotProblemOQ03OQ01OQ02.lean`, 398 lines, 16 theorems),
  not the Helpers additionalFile.

## File-size watch

Helpers.lean approaches the Docker 32GB-memory ceiling (~15500 lines).
After PR #17605 merges (+65 lines), file will be at ~15552 — over
target.  S57.4's pointwise-comparison work (~80–150 lines if direct,
~80 + ~30 transpose if mirrored via `gnwProb_transpose`) will require
the file extraction discussed in S57.0 / s06 (Option E2/E3 to
`BallotProblemOQ03OQ01OQ02DoubleRemove.lean`).

## Build status

Pending.  Parent `BallotProblemOQ03OQ02.lean` LGV infrastructure has
~24 errors on origin/main lines 1911–2386 per memory note
`feedback_researcher_ballot_oq03oq02_parent_break.md`, blocking build
verification of all `OQ03-OQ01-*` descendants.  Matches the S25–S31
/ S57.1 / S57.2 / S57.3 / S57.3a "(build pending)" precedent.

## Test plan

- [ ] CI build of `Proofs.BallotProblemOQ03OQ01OQ02Helpers` (build pending)
- [x] Mathlib API verified by reading source
- [x] `:= rfl` unfold for `gnwProb (K+1)` matches S57.2 pattern
- [x] `Prod.swap` defeq compositions checked (`funext s; rfl`)
- [x] No new axioms / sorries (`grep -c "^axiom \|sorry"` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)