### PR TITLE
fix(meta): batch sync definitionCount drift (erdos-1027, erdos-1063)

### DIFF
--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -29,7 +29,7 @@
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries remain. — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0",
     "theoremCount": 10,
-    "definitionCount": 14,
+    "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos1027Aristotle.lean"
     ]
@@ -195,7 +195,7 @@
     "lineCount": 353,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 14,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1027Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -230,7 +230,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `definitionCount` in both `meta` and `leanFile` blocks for two gallery entries to match the actual top-level def/abbrev count in the underlying Lean source files.

## Per-entry deltas (claimed → actual)

| slug         | meta | leanFile | actual | delta |
|--------------|------|----------|--------|-------|
| `erdos-1027` |   14 |       14 |     11 |    -3 |
| `erdos-1063` |    5 |        5 |      4 |    -1 |

## Convention

Count `def + abbrev + opaque + structure + inductive + class` declarations with optional modifiers (`private/protected/noncomputable/partial/unsafe/scoped`) after stripping nested block + line comments. Excludes `instance`. Same convention as PR #17588 / #17591 / #17609.

### Verified declaration lists

**erdos-1027** (`Proofs/Erdos1027Problem.lean`, 11 actual):
```
abbrev SetFamily            (line  38)
def    familyUnion          (line  41)
def    IsNUniform           (line  45)
def    goodSets             (line  61)
def    HasPropertyB         (line  65)
def    IsProper2Coloring    (line  74)
def    Is2Colorable         (line  78)
def    goodSetCount         (line 160)
def    goodSetDensity       (line 164)
def    Erdos1027Statement   (line 177)
def    IsMonochromatic      (line 214)
```

**erdos-1063** (`Proofs/Erdos1063Problem.lean`, 4 actual):
```
def    DividesChoose        (line  42)
def    divisibilityCount    (line  48)
def    IsThreshold          (line  63)
def    ErdosProblem1063     (line 138)
```

## Drift origin

- `erdos-1027`: most recently bumped to 14 in PR #17588 (erdos-9xx batch). Recount with strict modifier-list regex finds 11.
- `erdos-1063`: PR #16381 set 5→4 (correct), then PR #16459 reverted PR #16420 batch which had bumped it back to 5; the revert preserved the 5 value. Actual is 4.

## Evidence

**Before**: `meta.definitionCount` = `leanFile.definitionCount` = stale.
**After**: both fields = actual count.

Surgical 2-line edit per file (one in `meta` sub-object, one in `leanFile` block); no other fields touched. Diff stat: 2 files, +4/-4.

---
Automated fix by lean-mechanic agent.