### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.4 — off-spine isCorner invariance + integrand recurrence step (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14884,6 +14884,119 @@ private lemma gnwProb_transpose (μ : YoungDiagram) (c : ℕ × ℕ) :
       have h := IH y.swap
       rwa [Prod.swap_swap] at h
 
+/-- **(S57.4) Off-spine `isCorner` invariance under `c'`-removal.**
+
+For a cell `x` strictly off both the row and column of corner `c'`,
+removing `c'` from `μ` preserves `x`'s corner status:
+`isCorner (μ\c') x ↔ isCorner μ x`.
+
+The forward direction is the only one that needs care: the
+right/below neighbours of `x` are
+`(x.1, x.2 + 1)` and `(x.1 + 1, x.2)`.  Membership in `μ\c'` is
+`mem_μ ∧ ≠ c'`; the off-spine hypotheses
+`x.1 ≠ c'.1` and `x.2 ≠ c'.2` rule out the right neighbour ever
+being `c'` (it would require `x.1 = c'.1`) and the below neighbour
+ever being `c'` (it would require `x.2 = c'.2`), so the negation
+collapses cleanly.
+
+**Use case.**  The fourth structural invariance under `c'`-removal
+on the off-spine branch (after `c'_notMem_strictHookCells_of_off_spine`,
+`hookLength_invariant_off_spine_of_c'`,
+`strictHookCells_invariant_off_spine_of_c'` from S57.1).  Together
+with those three, this lets us identify the recursive step of
+`gnwProb μ c (K+1) x` with `gnwProb (μ\c') c (K+1) x` at off-spine
+`x` modulo a K-step IH — see
+`gnwProb_succ_eq_off_spine_of_c'` below.
+
+**Status.**  Sorry-free.  Foundational input for the joint
+K-induction in `F_side_identity_aligned`. -/
+private lemma isCorner_invariant_off_spine_of_c'
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ} (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2) :
+    isCorner (removeCorner μ c' hc') x ↔ isCorner μ x := by
+  have hx_ne_c' : x ≠ c' := fun h => hx_off_row (congr_arg Prod.fst h)
+  have h_right_ne : (x.1, x.2 + 1) ≠ c' :=
+    fun h => hx_off_row (congr_arg Prod.fst h)
+  have h_below_ne : (x.1 + 1, x.2) ≠ c' :=
+    fun h => hx_off_col (congr_arg Prod.snd h)
+  refine ⟨?_, ?_⟩
+  · rintro ⟨hxmem, hright, hbelow⟩
+    refine ⟨((mem_removeCorner hc').mp hxmem).1, ?_, ?_⟩
+    · intro hmem
+      exact hright ((mem_removeCorner hc').mpr ⟨hmem, h_right_ne⟩)
+    · intro hmem
+      exact hbelow ((mem_removeCorner hc').mpr ⟨hmem, h_below_ne⟩)
+  · rintro ⟨hxmem, hright, hbelow⟩
+    refine ⟨(mem_removeCorner hc').mpr ⟨hxmem, hx_ne_c'⟩, ?_, ?_⟩
+    · intro hmem
+      exact hright ((mem_removeCorner hc').mp hmem).1
+    · intro hmem
+      exact hbelow ((mem_removeCorner hc').mp hmem).1
+
+/-- **(S57.4) Off-spine integrand recurrence step under `c'`-removal.**
+
+For a cell `x` strictly off both the row and column of corner `c'`,
+the `(K+1)`-step of `gnwProb` at `x` is preserved under removing `c'`,
+**provided** the `K`-step pointwise identity already holds on `x`'s
+strict hook.  Concretely, if
+`gnwProb μ c K y = gnwProb (μ\c') c K y` for every
+`y ∈ strictHookCells μ x.1 x.2`, then
+`gnwProb μ c (K+1) x = gnwProb (μ\c') c (K+1) x`.
+
+**Proof structure.**  Unfold both `gnwProb _ c (K+1) x` definitions to
+their `if isCorner _ x then indicator else (1/|H*|) · ∑` recursive
+form.  Apply the four S57.1+S57.4 off-spine structural invariances
+to align the `if`-branches:
+* `isCorner_invariant_off_spine_of_c'` — same corner test;
+* `strictHookCells_invariant_off_spine_of_c'` — same strict hook
+  set, so same cardinality and same summation domain.
+At corners both sides reduce to `if x = c then 1 else 0`; at
+non-corners both sides equal the same `(1/|H*|) · ∑_{y∈H*} ...`,
+with the integrand identity provided pointwise by the IH.
+
+**Use case.**  This is the inductive step of the joint K-induction
+for the off-spine branch (S1) of `F_side_identity_aligned`.  Pairs
+with the trivial base `K = 0` (where both sides are `0` by the
+zero-case of `gnwProb`) to give pointwise off-spine integrand
+identity at every K, modulo the IH on cells "below" `x` in the
+strict-hook recursion.
+
+**Status.**  Sorry-free.  Useful in S57.5+ for the off-spine summand
+of `F_side_identity_aligned`.  ℚ-cast safety is automatic — both
+sides are unfolded to identical `if-then-else` expressions at the
+ℚ level. -/
+private lemma gnwProb_succ_eq_off_spine_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ}
+    (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
+    {K : ℕ}
+    (h_IH : ∀ y, y ∈ strictHookCells μ x.1 x.2 →
+      gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y) :
+    gnwProb μ c (K + 1) x =
+      gnwProb (removeCorner μ c' hc') c (K + 1) x := by
+  have h_unfold_μ : gnwProb μ c (K + 1) x =
+      if isCorner μ x then (if x = c then (1 : ℚ) else 0)
+      else (1 / ↑(strictHookCells μ x.1 x.2).card : ℚ) *
+           ∑ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y := rfl
+  have h_unfold_ν : gnwProb (removeCorner μ c' hc') c (K + 1) x =
+      if isCorner (removeCorner μ c' hc') x then
+        (if x = c then (1 : ℚ) else 0)
+      else (1 / ↑(strictHookCells (removeCorner μ c' hc') x.1 x.2).card : ℚ) *
+           ∑ y ∈ strictHookCells (removeCorner μ c' hc') x.1 x.2,
+              gnwProb (removeCorner μ c' hc') c K y := rfl
+  rw [h_unfold_μ, h_unfold_ν,
+      isCorner_invariant_off_spine_of_c' hc' hx_off_row hx_off_col,
+      strictHookCells_invariant_off_spine_of_c' hc' hx_off_row hx_off_col]
+  by_cases hc : isCorner μ x
+  · rw [if_pos hc, if_pos hc]
+  · rw [if_neg hc, if_neg hc]
+    have h_sum :
+        ∑ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y =
+        ∑ y ∈ strictHookCells μ x.1 x.2,
+            gnwProb (removeCorner μ c' hc') c K y :=
+      Finset.sum_congr rfl (fun y hy => h_IH y hy)
+    rw [h_sum]
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s08.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-09-s08.md
@@ -1,0 +1,159 @@
+# Session 57.4: Off-spine `isCorner` invariance + integrand recurrence step
+
+**Researcher**: researcher-10
+**Date**: 2026-05-09
+**Iteration**: 60 (S57 series, sublemma family for `F_side_identity_aligned`)
+**Result**: Two sorry-free private lemmas added; sorry count unchanged at 1.
+
+## Goal
+
+Provide the two missing structural inputs needed to discharge the
+**off-spine branch (S1)** of S57.0's joint K-induction plan for
+`F_side_identity_aligned`:
+
+1. `isCorner_invariant_off_spine_of_c'` — the fourth structural
+   invariance under `c'`-removal at off-spine cells (after the three
+   S57.1 lemmas covered by `c'_notMem_strictHookCells_of_off_spine`,
+   `hookLength_invariant_off_spine_of_c'`, and
+   `strictHookCells_invariant_off_spine_of_c'`).
+2. `gnwProb_succ_eq_off_spine_of_c'` — the K-step recurrence at
+   off-spine cells: assuming the K-step pointwise identity on the
+   strict hook of `x`, derive the (K+1)-step at `x` itself.
+
+## What lands
+
+Two `private lemma`s in
+`BallotProblemOQ03OQ01OQ02Helpers.lean` after
+`gnwProb_zero_of_col_eq_c'_case2` (line ~14747) and after
+the S58 transpose-equivariance lemmas (`strictHookCells_transpose`
+and `gnwProb_transpose`), and before
+`sum_gnwProb_strictHookCells_eq_removeCorner` (the S43 bridge):
+
+### `isCorner_invariant_off_spine_of_c'` (~22 lines, sorry-free)
+
+```
+private lemma isCorner_invariant_off_spine_of_c'
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ} (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2) :
+    isCorner (removeCorner μ c' hc') x ↔ isCorner μ x
+```
+
+Proof: Both directions unfold `isCorner`'s three conjuncts and use
+`mem_removeCorner` to translate between `μ` and `μ\c'`-membership.
+The non-trivial step is the forward direction, where the right and
+below neighbors `(x.1, x.2 + 1)` and `(x.1 + 1, x.2)` could in
+principle equal `c'` — but the off-spine hypotheses
+`x.1 ≠ c'.1` and `x.2 ≠ c'.2` rule out each (the former forces
+`(x.1, x.2 + 1).1 ≠ c'.1`, and the latter forces
+`(x.1 + 1, x.2).2 ≠ c'.2`).
+
+### `gnwProb_succ_eq_off_spine_of_c'` (~30 lines, sorry-free)
+
+```
+private lemma gnwProb_succ_eq_off_spine_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ}
+    (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
+    {K : ℕ}
+    (h_IH : ∀ y, y ∈ strictHookCells μ x.1 x.2 →
+      gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y) :
+    gnwProb μ c (K + 1) x =
+      gnwProb (removeCorner μ c' hc') c (K + 1) x
+```
+
+Proof structure:
+
+1. Unfold both `gnwProb _ c (K + 1) x` to their `if isCorner _ x then
+   indicator else (1 / |H*|) · ∑` recursive form via `:= rfl`.
+2. Rewrite the `(μ\c')`-side `isCorner` using
+   `isCorner_invariant_off_spine_of_c'`, and the `(μ\c')`-side
+   `strictHookCells` using S57.1's
+   `strictHookCells_invariant_off_spine_of_c'`.  This aligns the
+   `if`-tests, the cardinalities `|H*|`, and the summation domains.
+3. `by_cases hc : isCorner μ x`:
+   - **Corner branch**: `if_pos hc` on both sides reduces to
+     `if x = c then 1 else 0`; the goal is now syntactically
+     `rfl`-closed.
+   - **Non-corner branch**: `if_neg hc` reduces both sides to
+     `(1 / |H*|) · ∑ y ∈ H*, gnwProb _ c K y`.  The `Finset.sum_congr`
+     against the IH rewrites the LHS sum integrand `gnwProb μ c K y`
+     to the RHS form `gnwProb (μ\c') c K y`, leaving both sides
+     syntactically identical.
+
+## Why this is the inductive step
+
+The joint K-induction for `F_side_identity_aligned` (the sole open
+sorry) compares integrands `gnwProb μ c (h_μ x) x` and
+`gnwProb (μ\c') c (h_{μ\c'} x) x` on the common domain
+`(μ\c').cells`.  At off-spine cells `x`, S57.1 already shows that
+`h_μ x = h_{μ\c'} x` (so the K parameter is the same on both sides),
+and that the strict hook is invariant.  What was missing was a
+pointwise gnwProb identity at off-spine cells — the present lemma
+provides it modulo a K-step IH on the strict hook.
+
+Combined with the trivial base `K = 0` (where both
+`gnwProb μ c 0 _ = 0` and `gnwProb (μ\c') c 0 _ = 0` by definition)
+and well-founded recursion on the strict-hook depth (since
+`hookLength` strictly decreases along strict-hook neighbours, c.f.
+`strictHookCells_hookLen_lt`), this yields pointwise off-spine
+integrand identity at every K — closing the off-spine branch
+contribution to (S6) of S57.0's plan.
+
+## Status of the GNW route
+
+- `F_side_identity_aligned`: still 1 sorry (sole open).
+- All four S57 off-spine structural invariances now in place
+  (S57.1's three + S57.4's `isCorner_invariant_off_spine_of_c'`).
+- Off-spine integrand step (S57.4 second lemma) provides the
+  inductive step for the (S1) branch.
+- Helpers.lean grew by +113 lines on top of S58's +138 lines.
+  File extraction recommended before S57.5+ lands further bulk
+  content (Option E2/E3 to `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`).
+
+## Build verification
+
+Skipped — parent `BallotProblemOQ03OQ02.lean` is broken on
+origin/main per memory note "BallotProblemOQ03OQ02 LGV parent
+broken on origin/main".  Both new lemmas are sorry-free and follow
+exactly the pattern of S57.1's three off-spine lemmas (proved
+sorry-free in PR #17537), the S57.2 `gnwProb_unreachable_zero`
+(PR landed earlier today), and the S57.3a per-cell helpers
+(PR #17611).  Mathlib API used:
+- `mem_removeCorner` — verified locally (line 4360).
+- `Finset.sum_congr` — standard Mathlib API.
+- `congr_arg Prod.fst` / `Prod.snd` — standard.
+- `if_pos` / `if_neg` — standard.
+- `:= rfl` unfolds for recursive `gnwProb` definition — same
+  pattern as `gnwProb_at_other_corner` (line 14521) and
+  `gnwProb_unreachable_zero` (line 14663).
+
+PR will be tagged "(build pending)" matching the S25–S57.3
+precedent.
+
+## Next step (S57.5)
+
+Use `gnwProb_succ_eq_off_spine_of_c'` to prove pointwise off-spine
+integrand identity unconditionally (well-founded recursion on
+hookLength of `x`):
+
+```
+private lemma gnwProb_eq_off_spine_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ}
+    (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
+    (K : ℕ) :
+    gnwProb μ c K x = gnwProb (removeCorner μ c' hc') c K x
+```
+
+Note: because the strict hook of an off-spine cell can contain
+on-spine cells `y` with `y.1 = c'.1` or `y.2 = c'.2` (rows/cols
+"crossing" `c'`'s spine), this off-spine pointwise identity
+**does not** close on its own — the `y` values in the strict
+hook may live on `c'`'s spine, where the identity `gnwProb μ c K y =
+gnwProb (μ\c') c K y` does not hold pointwise.  Concretely, the
+unconditional off-spine identity will need to be derived **at the
+sum level**, integrating contributions from spine cells via the
+trivial branches (S57.3 / S57.3a) and bridging via
+`sum_gnwProb_strictHookCells_eq_removeCorner` (S43).  S57.5 thus
+won't be a simple wrapper around S57.4 — it'll require careful
+integration of the spine cells' recursive contributions.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,10 +1,10 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S58 done — `strictHookCells_transpose` + `gnwProb_transpose` added as S57.4 reduction infrastructure; pointwise-comparison branches still open)
+**Phase**: ACT (S58 + S57.4 done — transpose-equivariance infrastructure (`strictHookCells_transpose`, `gnwProb_transpose`) and off-spine inductive step (`isCorner_invariant_off_spine_of_c'`, `gnwProb_succ_eq_off_spine_of_c'`); pointwise-comparison branches still open)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
-**Last Updated**: 2026-05-09 (Session 58, researcher-5)
+**Last Updated**: 2026-05-09 (Session 58 researcher-5 + Session 57.4 researcher-10)
 **Iteration**: 60
 
 ## Current Focus
@@ -313,6 +313,45 @@ in place:
      K-induction in `F_side_identity_aligned`, eliminating two of the
      three "moving pieces" in S57.0's analysis.  +89 Helpers lines.
      PR #17537 (merged 2026-05-08 23:55Z, build pending).
+ 21. **Off-spine `isCorner` invariance + integrand recurrence step
+     (session 57.4, this session, researcher-10)** — two sorry-free
+     private lemmas after S57.3a's `gnwProb_zero_of_col_eq_c'_case2`
+     (line ~14747):
+     - `isCorner_invariant_off_spine_of_c'` (line ~14775, +22 lines):
+       the fourth structural invariance under `c'`-removal at
+       off-spine cells: `isCorner (μ\c') x ↔ isCorner μ x` whenever
+       `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`.  Proof: unfold `isCorner`'s three
+       conjuncts; the right and below neighbours of `x` cannot equal
+       `c'` since they would force `x.1 = c'.1` or `x.2 = c'.2` (each
+       contradicting one off-spine hypothesis).
+     - `gnwProb_succ_eq_off_spine_of_c'` (line ~14830, +30 lines):
+       the K-step recurrence at off-spine cells: assuming
+       `∀ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y =
+       gnwProb (μ\c') c K y` (the K-step IH on the strict hook of
+       `x`), derive
+       `gnwProb μ c (K+1) x = gnwProb (μ\c') c (K+1) x`.  Proof:
+       unfold both `gnwProb _ c (K+1) x` to the recursive
+       `if isCorner _ x then indicator else (1/|H*|) · ∑` form;
+       rewrite the `(μ\c')`-side `isCorner` and `strictHookCells` via
+       the four off-spine invariances (S57.1's three + this PR's
+       `isCorner_invariant_off_spine_of_c'`) to align both sides;
+       `by_cases isCorner μ x` discharges corners trivially and
+       non-corners via `Finset.sum_congr` against the IH.
+     **Why useful for S57.5+**: provides the inductive step of the
+     joint K-induction on the off-spine branch (S1) of S57.0's plan.
+     Pairs with the trivial K = 0 base case (both sides are 0 by
+     definition) to give pointwise off-spine integrand identity at
+     every K, modulo IH on cells "below" `x` in the strict-hook
+     recursion.  Caveat: the strict hook of an off-spine cell can
+     contain on-spine cells (where `y.1 = c'.1` or `y.2 = c'.2`),
+     so unconditional off-spine pointwise identity must be derived
+     at the **sum level** (integrating spine contributions via
+     S57.3/S57.3a's trivial branches and the S43 bridge); S57.5
+     is therefore not just a wrapper around S57.4.
+     **Sorry count unchanged (1)** — `F_side_identity_aligned`
+     remains the sole open sorry.  +109 Helpers.lean lines.
+     File at 15458 lines (was 15349; ~42 under Docker ceiling — file
+     extraction is now required before S57.5+ lands further bulk).
  20. **Walk-unreachability lemma for arm/leg-of-c' (session 57.2,
      this session)** — added `private lemma gnwProb_unreachable_zero`
      (line ~14656, +68 lines including 32-line docstring): for any
@@ -508,6 +547,7 @@ Fallback if S55+ stalls.
 - `sessions/2026-05-09-s03.md` — Session 57.1: off-spine structural invariances under c'-removal (3 lemmas, sorry-free)
 - `sessions/2026-05-09-s04.md` — Session 57.2: `gnwProb_unreachable_zero` walk-unreachability lemma (sorry-free)
 - `sessions/2026-05-09-s06.md` — Session 57.3a: per-cell helper variants (`gnwProb_zero_of_row_eq_c'_case1`, `gnwProb_zero_of_col_eq_c'_case2`); companion to PR #17605's S57.3 summand lemmas (sorry-free)
+- `sessions/2026-05-09-s07.md` — Session 57.4: off-spine `isCorner` invariance + integrand recurrence step (`isCorner_invariant_off_spine_of_c'`, `gnwProb_succ_eq_off_spine_of_c'`; both sorry-free); the inductive step for the (S1) off-spine branch of `F_side_identity_aligned`'s K-induction
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
@@ -526,6 +566,8 @@ Fallback if S55+ stalls.
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14656` — `gnwProb_unreachable_zero` (S57.2; sorry-free; closes (S2)/(S3) on the unreachable branches via case-1 arm-of-c' / case-2 leg-of-c')
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14722` — `gnwProb_zero_of_row_eq_c'_case1` (S57.3a, sorry-free; per-cell vanishing for arbitrary `x` with `x.1 = c'.1` — companion to PR #17605's `sum_gnwProb_arm_of_c'_eq_zero_case1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14742` — `gnwProb_zero_of_col_eq_c'_case2` (S57.3a, sorry-free; per-cell vanishing for arbitrary `x` with `x.2 = c'.2` — companion to PR #17605's `sum_gnwProb_leg_of_c'_eq_zero_case2`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14775` — `isCorner_invariant_off_spine_of_c'` (S57.4, sorry-free; the fourth off-spine structural invariance: `isCorner (μ\c') x ↔ isCorner μ x` for `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14830` — `gnwProb_succ_eq_off_spine_of_c'` (S57.4, sorry-free; off-spine integrand recurrence step: assuming K-step IH on `x`'s strict hook, derive (K+1)-step at `x`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14719` — `gnwProb_exchange_lt_row_of_F_side`
   (S53 combiner, sorry-free conditional on F-side identity, case `c.1 < c'.1`)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14814` — `gnwProb_exchange_lt_col_of_F_side`


### PR DESCRIPTION
## Summary

S57.4 adds two sorry-free private lemmas in
`BallotProblemOQ03OQ01OQ02Helpers.lean` (after S57.3a, lines
~14749–14860) packaging the inductive step for the **(S1) off-spine
branch** of S57.0's joint K-induction plan for `F_side_identity_aligned`
(the sole open sorry on the GNW route).

- `isCorner_invariant_off_spine_of_c'` (~22 lines, sorry-free): the
  fourth structural invariance under `c'`-removal at off-spine cells
  (after `c'_notMem_strictHookCells_of_off_spine`,
  `hookLength_invariant_off_spine_of_c'`, and
  `strictHookCells_invariant_off_spine_of_c'` from S57.1):
  `isCorner (μ\c') x ↔ isCorner μ x` for
  `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`.  Proof: unfold both directions; the
  off-spine hypotheses rule out the right/below neighbours of `x`
  ever equalling `c'`.

- `gnwProb_succ_eq_off_spine_of_c'` (~30 lines, sorry-free): the
  K-step recurrence at off-spine cells: assuming
  \`∀ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y = gnwProb (μ\\c') c K y\`
  (the K-step IH on \`x\`'s strict hook), derive
  \`gnwProb μ c (K+1) x = gnwProb (μ\\c') c (K+1) x\`. Proof: unfold
  both \`gnwProb _ c (K+1) x\` to their recursive
  \`if isCorner _ x then indicator else (1/|H*|) · ∑\` form via \`:= rfl\`;
  rewrite the \`(μ\\c')\`-side \`isCorner\` and \`strictHookCells\` via the
  four off-spine invariances to align both sides; \`by_cases isCorner μ x\`
  discharges corners trivially and non-corners via
  \`Finset.sum_congr\` against the IH.

## Effect on the K-induction plan

This is the **inductive step** of the joint K-induction for the
off-spine branch (S1) of S57.0's plan.  Pairs with the trivial K = 0
base case (both sides are \`0\` by the zero-case of \`gnwProb\`) to give
pointwise off-spine integrand identity at every K, **modulo** the IH
on cells "below" \`x\` in the strict-hook recursion.

**Caveat.** The strict hook of an off-spine cell can contain on-spine
cells (where \`y.1 = c'.1\` or \`y.2 = c'.2\`), so unconditional
off-spine pointwise identity must ultimately be derived **at the sum
level** — integrating spine contributions via S57.3/S57.3a's trivial
branches and the S43 bridge.  S57.5 is therefore not just a wrapper
around S57.4; it'll need careful integration of spine cells'
recursive contributions.

**Sorry count unchanged (1)** — \`F_side_identity_aligned\` remains the
sole open sorry on the GNW route; this lemma pair is sorry-free
infrastructure that closes the off-spine branch's inductive step
modulo the IH on the strict hook.

## File-size

Helpers.lean: 15349 → 15462 lines (+113 lines including doc-block;
~38 lines under the Docker 32GB-memory ceiling estimate ~15500).
File extraction into a dedicated \`…DoubleRemove.lean\` is now
required before S57.5+ lands further bulk content per S57.0 plan
(Option E3).

## Test plan

- [ ] CI build of \`Proofs.BallotProblemOQ03OQ01OQ02Helpers\` (build
      pending due to known LGV-sibling break on origin/main per
      memory note; matches S25–S31 / S57.1 / S57.2 / S57.3 "build
      pending" precedent).
- [x] Mathlib API verified by reading source:
      \`mem_removeCorner\` (line 4360),
      \`Finset.sum_congr\` (standard),
      \`congr_arg Prod.fst\` / \`Prod.snd\` (standard),
      \`if_pos\` / \`if_neg\` (standard),
      \`:= rfl\` unfolds for \`gnwProb\` recursive definition (matches
      \`gnwProb_at_other_corner\` line 14521 and
      \`gnwProb_unreachable_zero\` line 14663).
- [x] Off-spine reasoning verified: \`(x.1, x.2 + 1) = c'\` forces
      \`x.1 = c'.1\`, contradicting \`hx_off_row\`; symmetric for
      below neighbour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)