### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S15 — Mathlib API drift fix (Metric.mem_closedBall_zero_iff → mem_closedBall_zero_iff, build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -305,11 +305,11 @@ theorem brouwer_fpt {n : ℕ}
       R • ((x : EuclideanSpace ℝ (Fin n)))
         ∈ Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) R := by
     intro x
-    rw [Metric.mem_closedBall_zero_iff, norm_smul,
+    rw [mem_closedBall_zero_iff, norm_smul,
         Real.norm_of_nonneg hR_pos.le]
     have hx_le : ‖(x : EuclideanSpace ℝ (Fin n))‖ ≤ 1 := by
       have hx := x.property
-      rwa [Metric.mem_closedBall_zero_iff] at hx
+      rwa [mem_closedBall_zero_iff] at hx
     calc R * ‖(x : EuclideanSpace ℝ (Fin n))‖
         ≤ R * 1 := mul_le_mul_of_nonneg_left hx_le hR_pos.le
       _ = R := by ring
@@ -323,11 +323,11 @@ theorem brouwer_fpt {n : ℕ}
       R⁻¹ • ((b : EuclideanSpace ℝ (Fin n)))
         ∈ Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) 1 := by
     intro b
-    rw [Metric.mem_closedBall_zero_iff, norm_smul,
+    rw [mem_closedBall_zero_iff, norm_smul,
         Real.norm_of_nonneg hRinv_pos.le]
     have hb_le : ‖(b : EuclideanSpace ℝ (Fin n))‖ ≤ R := by
       have hb := b.property
-      rwa [Metric.mem_closedBall_zero_iff] at hb
+      rwa [mem_closedBall_zero_iff] at hb
     calc R⁻¹ * ‖(b : EuclideanSpace ℝ (Fin n))‖
         ≤ R⁻¹ * R := mul_le_mul_of_nonneg_left hb_le hRinv_pos.le
       _ = 1 := inv_mul_cancel₀ hR_ne


### PR DESCRIPTION
## Summary

Replaces 4 occurrences of `Metric.mem_closedBall_zero_iff` with the
correct namespace-qualified name `mem_closedBall_zero_iff` in
`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`.

The S13 retraction-reduction body (PR #17575) and S14 helper proof
(PR #17601) introduced the elementwise-rescaling step using
`Metric.mem_closedBall_zero_iff`, which **does not exist** in Mathlib
v4.26 (the pinned project rev). The correct lemma is in the **root**
namespace.

## Build error (from `researcher-3-s14-build.log`)

```
error: Proofs/SchauderFixedPointOQ03OQ01.lean:210:8:
  Unknown identifier `Metric.mem_closedBall_zero_iff`
error: Proofs/SchauderFixedPointOQ03OQ01.lean:228:8:
  Unknown identifier `Metric.mem_closedBall_zero_iff`
```

(Line numbers in the previous build refer to a pre-S14 file layout; the
actual call sites in the current `origin/main` file are at lines 308,
312, 326, 330 — all four within the elementwise-rescaling Step 4 of
`theorem brouwer_fpt`'s body.)

## Resolution

Verified via direct GitHub-API inspection of Mathlib at the v4.26.0
tag (the rev pinned in `proofs/lake-manifest.json`):

```lean
-- Mathlib/Analysis/Normed/Group/Basic.lean line 638-640
@[to_additive]
theorem mem_closedBall_one_iff : a ∈ closedBall (1 : E) r ↔ ‖a‖ ≤ r := …
```

The `@[to_additive]` attribute generates `mem_closedBall_zero_iff` in
the **root** namespace (not `Metric.`). The 4 call sites in this file
already use `Metric.closedBall` (with the prefix) for the closed-ball
*type*; only the membership iff *lemma* had the spurious prefix.

## Net file effect

| Field | Before | After |
|-------|--------|-------|
| Sorries (in code) | 0 | 0 |
| Axiom count | 2 | 2 |
| Line count | 766 | 766 |
| Lines changed | — | 4 |

The two axioms remain: `brouwer_unit_ball` (closed-unit-ball Brouwer
FPT) and `approx_selection_exists` (Cellina–Browder graph approximate
selections).

## Test plan

- [ ] Docker build kicked off at PR submission time:
  `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`
- [ ] If green, `theorem brouwer_fpt` is end-to-end sorry-free at
  `axiomCount = 2` and meta.json drift can be synced
  (`sorries: 1 → 0`, `lineCount: 668 → 766`).

## Status

**Outcome**: progress (drift fix, build pending)
**Next Steps**: meta.json sync after build verification; then move
to the harder axiom (PartitionOfUnity proof of `approx_selection_exists`,
per s6/s7 plan).

🤖 Generated by researcher-3