### PR TITLE
Enrich four-square-distribution: 7 references, Jacobi-validator annotation, more mainTheorems

### DIFF
--- a/src/data/proofs/four-square-distribution/annotations.json
+++ b/src/data/proofs/four-square-distribution/annotations.json
@@ -67,6 +67,28 @@
     ]
   },
   {
+    "id": "ann-4sq-jacobi-checks",
+    "proofId": "four-square-distribution",
+    "range": { "startLine": 186, "endLine": 226 },
+    "type": "insight",
+    "title": "Jacobi-Formula Numerical Validators: r₄_4 / r₄_9 / r₄_10 Match 8·σ*(n)",
+    "content": "The three theorems `r₄_4_distribution`, `r₄_9_distribution`, `r₄_10_distribution` are the *cross-validation layer* between the type decomposition (this file) and Jacobi's classical formula $r_4(n) = 8 \\sigma^*(n)$:\n\n- `r₄_4_distribution` (L186): $8 + 16 = 24 = 8\\sigma^*(4) = 8(1+3) = 24$. Note $4 \\nmid d$ excludes $d = 4$ from $\\sigma^*(4) = 1 + 3 = 4$, but $4$ is included in $\\sigma(4) = 1+2+4=7$ — the $4 \\nmid d$ filter is *essential* for Jacobi's identity.\n- `r₄_9_distribution` (L211): $8 + 96 = 104 = 8\\sigma^*(9) = 8(1+3+9)$. All divisors of 9 satisfy $4 \\nmid d$, so $\\sigma^*(9) = \\sigma(9) = 13$.\n- `r₄_10_distribution` (L221): $48 + 96 = 144 = 8\\sigma^*(10) = 8(1+2+5+10) = 144$. Again $4 \\nmid d$ for any $d \\mid 10$.\n\nProof method: each is a direct two-step `rw` chaining the individual contribution theorems — the *arithmetic* check ($x + y = z$) lives in the kernel and is closed by `rfl` once the contributions are unfolded.\n\nWhy this matters: these four arithmetic identities are the only place where the type-decomposition viewpoint *meets* Jacobi's formula. Without them, the file would be a self-contained combinatorial study with no link to classical analytic number theory. Each successful match is empirical evidence (verified by `native_decide`) that the contribution formula computes the same thing as Jacobi's $\\theta^4$ Fourier coefficient — a finite check that, if extended to all $n$, would constitute a proof of Jacobi's identity (the open problem `four-square-distribution-oq-01`).",
+    "mathContext": "Jacobi: $r_4(n) = 8 \\sigma^*(n)$, $\\sigma^*(n) = \\sum_{d \\mid n,\\,4 \\nmid d} d$. Validation table:\n- $n=4$: $\\sigma^*(4) = 1+3 = 4$; types contribute $8+16 = 24 = 8 \\cdot \\sigma^*(4)$. ✓\n- $n=9$: $\\sigma^*(9) = 1+3+9 = 13$; types contribute $8+96 = 104 = 8 \\cdot \\sigma^*(9)$. ✓\n- $n=10$: $\\sigma^*(10) = 1+2+5+10 = 18$; types contribute $48+96 = 144 = 8 \\cdot \\sigma^*(10)$. ✓",
+    "significance": "critical",
+    "prerequisites": [
+      "Jacobi's four-square formula r₄(n) = 8σ*(n)",
+      "σ*(n) = Σ_{d∣n, 4∤d} d definition",
+      "Individual contribution theorems"
+    ],
+    "relatedConcepts": [
+      "r₄_4_distribution",
+      "r₄_9_distribution",
+      "r₄_10_distribution",
+      "σ*(n) divisor function",
+      "four-square-distribution-oq-01"
+    ]
+  },
+  {
     "id": "ann-4sq-structural-bounds",
     "proofId": "four-square-distribution",
     "range": { "startLine": 228, "endLine": 271 },

--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -182,6 +182,57 @@
       "statement": "type_4_a.contribution + type_4_b.contribution = 24",
       "description": "For n=4: type (0,0,0,2) contributes 8, type (1,1,1,1) contributes 16, total 24 = 8·σ*(4) = 8·(1+3) = 24.",
       "significance": "Smallest non-trivial multi-type case — exhibits both the trivial-type contribution (8) and the all-equal nonzero contribution (16) in a single decomposition. Confirms Jacobi's formula numerically for n = 4."
+    },
+    {
+      "name": "r₄_9_distribution",
+      "type": "supporting",
+      "statement": "type_9_a.contribution + type_9_b.contribution = 104",
+      "description": "For n=9: type (0,0,0,3) contributes 8, type (0,1,2,2) contributes 96, total 104 = 8·σ*(9) = 8·(1+3+9) = 104. (4 ∤ d for d ∈ {1,3,9}, all divisors counted.)",
+      "significance": "First multi-type case with a *prime-power-free* divisor sum (σ*(9) = σ(9) since 4 ∤ 9). Demonstrates the 8 + 96 = 8 × 13 split for a perfect square that is *not* a power of 2 — every perfect square contains the trivial type (0,0,0,k) contributing 8, plus additional types reflecting the divisor structure of n."
+    },
+    {
+      "name": "r₄_10_distribution",
+      "type": "supporting",
+      "statement": "type_10_a.contribution + type_10_b.contribution = 144",
+      "description": "For n=10: type (0,0,1,3) contributes 48, type (1,1,2,2) contributes 96, total 144 = 8·σ*(10) = 8·(1+2+5+10) = 144.",
+      "significance": "Composite n = 2·5 with all 4 divisors contributing (4 ∤ d for any d | 10). Shows the 48 + 96 split — neither type is the trivial (0,0,0,k) form (since 10 is not a perfect square), and yet the σ*-sum still resolves cleanly. Useful test case for understanding how the type decomposition handles non-square n."
+    }
+  ],
+  "references": [
+    {
+      "type": "research-paper",
+      "citation": "Jacobi, C.G.J. (1829). \"Fundamenta Nova Theoriae Functionum Ellipticarum.\" Königsberg: Borntraeger. (English summary in Hardy & Wright, *An Introduction to the Theory of Numbers*, §20.12.)",
+      "relevance": "Original derivation of $r_4(n) = 8 \\sigma^*(n)$ via Fourier coefficients of $\\theta(q)^4$. The factor of 8 — quantified here as the per-divisor contribution of the type decomposition — first appears in Jacobi's identity for $\\theta^4$ as a weight-2 Eisenstein series."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Lagrange, J.-L. (1770). \"Démonstration d'un théorème d'arithmétique.\" Nouveaux Mémoires de l'Académie royale des Sciences et Belles-Lettres de Berlin.",
+      "relevance": "Original existence proof: every $n \\in \\mathbb{N}$ is a sum of four squares, $r_4(n) > 0$. The distribution analysis here is the *quantitative* refinement of Lagrange's qualitative existence theorem."
+    },
+    {
+      "type": "textbook",
+      "citation": "Hardy, G.H. & Wright, E.M. (2008). *An Introduction to the Theory of Numbers*, 6th ed., Oxford University Press. Chapter XX (\"The Representation of a Number by Two or Four Squares\").",
+      "relevance": "Standard exposition of $r_2$ and $r_4$ formulas, including Jacobi's proof via theta functions and the elementary divisor-sum identities. The contribution formula $\\binom{4}{m_1,\\ldots,m_k} \\cdot 2^k$ is the explicit form of Hardy–Wright's symmetry-counting argument."
+    },
+    {
+      "type": "textbook",
+      "citation": "Conway, J.H. & Smith, D.A. (2003). *On Quaternions and Octonions*, A K Peters / CRC Press. Chapter 2 (\"Quaternions and 4D Symmetry\") and Chapter 5 (\"Hurwitz Integers\").",
+      "relevance": "The hyperoctahedral group $B_4 = S_4 \\ltimes (\\mathbb{Z}/2)^4$ of order 384 is the group of left-units of the Hurwitz order $\\mathbb{H}(\\mathbb{Z})$. The contribution $2^k \\cdot 4!/\\prod m_i!$ counts $B_4$-orbits on signed sorted tuples — making the elementary combinatorial formula here the orbit-counting shadow of the deep algebraic structure of Hurwitz quaternions."
+    },
+    {
+      "type": "textbook",
+      "citation": "Iwaniec, H. (1997). *Topics in Classical Automorphic Forms*, Graduate Studies in Mathematics 17, AMS. §10 on Theta Functions and §11 on Eisenstein Series.",
+      "relevance": "Modern modular-forms treatment of $r_k(n)$ via theta functions: $\\theta(q)^4 \\in M_2(\\Gamma_0(4))$ is a weight-2 modular form, and the identity $\\theta(q)^4 = 1 + 8\\sum_{n \\geq 1} \\sigma^*(n) q^n$ is the Eisenstein series decomposition. This is the analytic counterpart to the combinatorial decomposition formalized here."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.NumberTheory.SumFourSquares.\" (accessed 2026).",
+      "relevance": "Lagrange's four-square theorem in Mathlib (`Nat.sum_four_squares`). This formalization builds on top of the existence theorem to provide the quantitative type decomposition; the long-term integration would prove `Nat.r4_eq_eight_sigmaStar` connecting the two."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Deza, M. & Grishukhin, V.P. (1996). \"Hypermetrics in Geometry of Numbers.\" In *Geometric Combinatorics* (DIMACS Series, AMS), pp. 1–109.",
+      "relevance": "Survey of the hyperoctahedral group action on lattice points and its appearance in lattice-point-counting problems beyond four squares — provides the abstract framework in which the $S_4 \\ltimes (\\mathbb{Z}/2)^4$ action appearing here is one instance."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `four-square-distribution` (distribution of $r_4(n)$ representations among signed-permutation symmetry types; 38 theorems, 0 sorries, 0 axioms).

## Quality improvements

**References array 0 → 7.** The entry previously had only `mathlibDependencies`; now connects to:
- **Jacobi (1829)** — original derivation of $r_4(n) = 8\\sigma^*(n)$ via $\\theta(q)^4$ Fourier coefficients.
- **Lagrange (1770)** — original existence proof; the type decomposition is the *quantitative* refinement.
- **Hardy & Wright** — standard exposition; the contribution formula is the explicit form of their symmetry-counting argument.
- **Conway & Smith, *On Quaternions and Octonions*** — the hyperoctahedral group $B_4 = S_4 \\ltimes (\\mathbb{Z}/2)^4$ of order 384 is the left-unit group of Hurwitz integers acting on representations.
- **Iwaniec, *Topics in Classical Automorphic Forms*** — modern modular-forms viewpoint: $\\theta^4$ as a weight-2 modular form on $\\Gamma_0(4)$.
- **Mathlib `Nat.sum_four_squares`** — Lagrange's theorem the formalization builds on.
- **Deza & Grishukhin** — abstract framework for hyperoctahedral lattice actions.

**New annotation `ann-4sq-jacobi-checks`** (L186–226). A dedicated annotation on the three Jacobi-formula validators:
- `r₄_4_distribution`: $8 + 16 = 24 = 8\\sigma^*(4) = 8(1+3)$
- `r₄_9_distribution`: $8 + 96 = 104 = 8\\sigma^*(9) = 8(1+3+9)$
- `r₄_10_distribution`: $48 + 96 = 144 = 8\\sigma^*(10) = 8(1+2+5+10)$

Frames these as the cross-validation layer where the type-decomposition viewpoint meets Jacobi's classical $r_4(n) = 8\\sigma^*(n)$. Without them the file would be a self-contained combinatorial study with no link to analytic number theory; the $4 \\nmid d$ filter in $\\sigma^*$ becomes especially visible at $n = 4$ where it excludes $d = 4$.

**`mainTheorems` 6 → 8.** Added `r₄_9_distribution` (perfect-square multi-type case, divisor sum 1+3+9) and `r₄_10_distribution` (composite non-square case, all 4 divisors of 10 contribute).

## Verification

JSON structure verified by direct parse: annotations 7 → 8, mainTheorems 6 → 8, references 0 → 7, keyInsights 7, openQuestions 4. All annotations carry mathContext, significance, relatedConcepts, prerequisites; ranges in-bounds.

## Axiom integrity

`status: \"verified\"`, `badge: \"original\"`, `axiomCount: 0`, `sorries: 0` — all confirmed against the Lean file. Jacobi's general formula $r_4(n) = 8\\sigma^*(n)$ is *not* assumed (tracked as `four-square-distribution-oq-01`); only the elementary contribution-bound theorems and finite numerical validations are proved here.