### PR TITLE
audit(loop): batch clean re-audit (6 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -494,11 +494,11 @@
       "result": "clean"
     },
     "area-of-circle-oq-05": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorries 1→0, status formalized→verified, badge wip→mathlib (sorry was completed)"
       ],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:53:48Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01": {
@@ -1836,9 +1836,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:53:34Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01": {
@@ -2661,9 +2661,9 @@
       "result": "clean"
     },
     "e-transcendental-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:53:16Z",
       "result": "clean"
     },
     "e-transcendental-oq-01-oq-01": {
@@ -2738,9 +2738,9 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:53:02Z",
       "result": "clean"
     },
     "erdos-1": {
@@ -2780,9 +2780,9 @@
       "result": "clean"
     },
     "erdos-100": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:52:39Z",
       "result": "clean"
     },
     "erdos-100-oq-01": {
@@ -2954,9 +2954,9 @@
     },
     "erdos-1010-oq-02": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-09T03:52:07Z",
       "result": "clean"
     },
     "erdos-1011": {


### PR DESCRIPTION
## Summary

Periodic auditor loop. 6 gallery entries re-audited; all counts match Lean source on origin/main.

## Clean re-audits

| Slug | Status | Axioms | Sorries | Lines |
|---|---|---|---|---|
| erdos-1010-oq-02 | axiomatized | 3 | 0 | 200 |
| erdos-100 | axiomatized | 2 | 0 | 482 |
| elementary-quadratic-reciprocity-oq-03-oq-03 | axiomatized | 1 | 0 | 102 |
| e-transcendental-oq-01 | axiomatized | 1 | 0 | 538 |
| cayley-hamilton-minpoly-oq-05-oq-01-oq-04 | verified/mathlib | 0 | 0 | 287 |
| area-of-circle-oq-05 | verified/mathlib | 0 | 0 | 132 |

For axiomatized entries, axiom names cross-checked against the `assumptions` narrative.

## Notes

`find-targets --issues` reported 2 false positives this iteration (schauder-fixed-point-oq-03-oq-01 sorry mismatch, laws-of-large-numbers-oq-04-oq-03 axiom undercount). Both were artifacts of working-tree pollution in the main repo and disappeared after `git restore`. No drift on origin/main.

## Test plan

- [x] All counts verified against origin/main snapshots (post-comment-stripping)
- [x] Tracker change is data-only (no test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)