### PR TITLE
fix(meta): revert #17646 over-bumped roth-theorem-k3-oq-02 definitionCount (7→4)

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 4,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

PR #17646 used a regex that incorrectly counted `@[reducible] def`-prefixed
definitions as separate decls, inflating `definitionCount` for
`roth-theorem-k3-oq-02` from the canonical **4** (set by PR #17557 explicit
sync 7→4) back to **7**.

This is the same regression pattern that PR #17569 reverted for PR #17562 on
`theoremCount`: `@[..]` attribute prefixes are NOT part of the canonical
modifier list per `feedback_mechanic_def_counting.md`.

## Convention (PR #17557 / #17498)

Strip nested block + line comments, then count top-level decls matching:

```
^\s*(?:(?:private|protected|noncomputable|partial|unsafe|scoped)\s+)*(def|abbrev|opaque|structure|inductive|class)\s+\w
```

`@[..]` attribute prefix on the same line is **not** counted under this
convention. `instance` is also NOT counted.

## Per-entry deltas (claimed → actual)

| slug | dimension | before | after |
|------|-----------|--------|-------|
| roth-theorem-k3-oq-02 | definitionCount | 7 | 4 |

Both `meta.definitionCount` and `leanFile.definitionCount` synced to 4.

## Evidence

`Proofs/RothTriangleRemoval.lean` decls under canonical convention:

- L35: `abbrev RSVertex`
- L50: `def rsAdj`
- L86: `noncomputable def ruzsaSzemerediGraph`
- L129: `structure APTriple`

The 3 `@[reducible] def {x,y,z}Vert` lines (L38, L39, L40) are not counted
because the regex requires the line to start with whitespace immediately
followed by the modifier/keyword chain, not an `@[..]` attribute.

## Diff shape

```
1 file changed, 2 insertions(+), 2 deletions(-)
```

Surgical Python `.replace()` — only the two `definitionCount` value
occurrences touched; JSON formatting preserved. Other entry in PR #17646
(`amgm-inequality-oq-04-oq-02` lineCount 1328→1428) is genuine drift from
active research and not affected.

---
Automated fix by lean-mechanic agent.