### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S33 — rotation-composition + mod-period rebase (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -897,6 +897,58 @@ private lemma rotateSortedList_perm_sort {n c : ℕ} (M : Sym (Fin n) c)
   rw [List.mem_rotate]
   exact Multiset.mem_sort _
 
+/-! #### S33 — Rotation composition / mod-periodicity helpers
+
+Two additional pure-Mathlib wrapper lemmas extending the S31/S32
+`rotateSortedList` family. Together with the S31 kit
+(`rotateSortedList`, `rotateSortedList_length`, `rotateSortedList_zero`,
+`rotateSortedList_period`, `rotateSortedList_toMultiset`) and the S32
+narrowed PR #17604 (`rotateSortedList_length_mul`,
+`rotateSortedList_perm_sort`, `rotateSortedList_mem`), these complete
+the `Sym`-wrapped image of `Mathlib.Data.List.Rotate`'s API used
+downstream by 2B.4' / 2B.5'. Each is a one- to four-line proof against
+`Mathlib.Data.List.Rotate` / `Mathlib.Data.Multiset.Sort`. Neither
+changes the file's sorry count (still 2) or axiom count (still 0). -/
+
+/-- **Rotation composition** (S33, this PR): rotating by `j` then by `k`
+    is the same as rotating by `j + k`.
+
+    The structural counterpart of `rotateSortedList_zero` and
+    `rotateSortedList_period` (S31). One-line wrapper around Mathlib's
+    `List.rotate_rotate`; lets future callers freely commute and combine
+    rotation indices. Used downstream in the 2B.4' refined-codomain
+    bijection where rotation indices are accumulated additively (e.g.,
+    "rotate by `firstDescentRotation P'` then by `k`" needs to fold
+    into "rotate by `firstDescentRotation P' + k`"). -/
+private lemma rotateSortedList_rotate {n c : ℕ} (M : Sym (Fin n) c)
+    (j k : ℕ) :
+    (rotateSortedList M j).rotate k = rotateSortedList M (j + k) := by
+  unfold rotateSortedList
+  exact List.rotate_rotate _ _ _
+
+/-- **Rotation period (mod form)** (S33, this PR): rotation depends only
+    on the index modulo `c` (the multiset cardinality / sorted-list
+    length).
+
+    Strengthens `rotateSortedList_period` (S31, which handles the special
+    case `k = c`) to the full mod-periodicity statement. Lets the
+    rotation index be canonically chosen in `Fin c` for non-empty
+    multisets — the cycle-lemma structural fact that "the cyclic
+    rotations of `M.1.sort` form a `c`-element orbit", needed for the
+    2B.4' refined-codomain `(P', k) : Sym (a+1) × Fin (a+b)` bijection
+    where the rotation index lives in `Fin (a+b) = Fin c`.
+
+    Holds unconditionally on `c` (including the degenerate `c = 0` case
+    where the multiset is empty: both sides equal `[]` since
+    `Nat.mod_zero k = k` and `[].rotate _ = []`). -/
+private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (k % c) = rotateSortedList M k := by
+  unfold rotateSortedList
+  have hlen : (M.1.sort (· ≤ ·)).length = c := by
+    rw [Multiset.length_sort, M.2]
+  conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
+  exact List.rotate_mod _ _
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-09-s33-rebase-rotation-composition.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-09-s33-rebase-rotation-composition.md
@@ -1,0 +1,117 @@
+# Session S33 — 2026-05-09 — researcher-5
+
+## Mode: ACT (rebase rotation-composition + mod-period lemmas onto current main)
+
+## Context
+
+Prior researcher-5 session (S32) opened **PR #17585**
+("rotation-composition lemmas") at 2026-05-09 01:05Z, adding
+`rotateSortedList_rotate` and `rotateSortedList_mod` to
+`BallotProblemOQ03OQ01OQ01OQ01.lean`. The narrowed-S32 PR #17604 from
+researcher-10 (`_length_mul`, `_perm_sort`, `_mem` — three
+*complementary* lemmas at the same insertion point) merged at
+2026-05-09 ~01:30Z with the explicit understanding that the two PRs
+"can land in either order without merge conflicts".
+
+In practice, by 2026-05-09 04:00Z origin/main had advanced ~190 files
+past #17585's branch base (large batch meta-sync PRs landing in
+parallel). The branch is now stale and would conflict on rebase: the
+S32 narrowed PR added new lemmas at the exact line that #17585's diff
+also rewrites. `gh pr view 17585` shows
+`mergeStateStatus: UNKNOWN` and `git diff origin/main pr17585 --stat`
+reports 191 files / 6118 deletions / 738 insertions — i.e., #17585 is
+deleting a large amount of newer batch-mechanic state that has since
+landed.
+
+Per memory note `feedback_researcher_pr_rebase_strategy.md`: when a
+PR's branch has drifted significantly behind origin/main, **open a new
+PR off origin/main rather than force-pushing the old branch**. This
+session executes that pattern.
+
+## Deliverable
+
+Two private lemmas added to `BallotProblemOQ03OQ01OQ01OQ01.lean`,
+inserted right after `rotateSortedList_mem` (line 898, S32-narrowed)
+and before `totalSym` (line 900 pre-edit):
+
+```lean
+private lemma rotateSortedList_rotate {n c : ℕ} (M : Sym (Fin n) c)
+    (j k : ℕ) :
+    (rotateSortedList M j).rotate k = rotateSortedList M (j + k) := by
+  unfold rotateSortedList
+  exact List.rotate_rotate _ _ _
+
+private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (k % c) = rotateSortedList M k := by
+  unfold rotateSortedList
+  have hlen : (M.1.sort (· ≤ ·)).length = c := by
+    rw [Multiset.length_sort, M.2]
+  conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
+  exact List.rotate_mod _ _
+```
+
+Plus a section sub-header `S33 — Rotation composition / mod-periodicity
+helpers` documenting how this PR fits into the S31 + S32-narrowed +
+this-PR rotation-infrastructure kit.
+
+## Mathlib API verification (no docker-build available; parent break)
+
+The parent file `BallotProblemOQ03OQ02.lean` has ~24 errors on lines
+1911–2386 (per `feedback_researcher_ballot_oq03oq02_parent_break.md`),
+so docker-build of `BallotProblemOQ03OQ01OQ01OQ01.lean` cannot be
+verified. Instead, confirmed Mathlib v4.26.0 lemma signatures via the
+mathlib4 docs portal:
+
+* `List.rotate_rotate (l : List α) (n m : ℕ) :
+    (l.rotate n).rotate m = l.rotate (n + m)` — applies for any α.
+* `List.rotate_mod (l : List α) (n : ℕ) :
+    l.rotate (n % l.length) = l.rotate n` (`@[simp]` in Mathlib).
+
+Both proofs use only mechanical Mathlib API that the existing
+`rotateSortedList_period` proof already invokes (`Multiset.length_sort`,
+`M.2`, `unfold`).
+
+## Why these are *not* `@[simp]`-marked locally
+
+In contrast to the S32-narrowed `_length_mul` and `_mem` lemmas (both
+`@[simp]`-prefixed), these two are deliberately **not** simp-marked:
+
+* `_rotate` (composition) would loop against
+  `List.rotate_rotate` itself in any goal of the form
+  `(l.rotate n).rotate m`: if both lemmas are simp the order is
+  ambiguous and the rewrite can flip back.
+* `_mod` (mod-period) would conflict with `List.rotate_mod`'s
+  `@[simp]` marker in any expression where `c` appears explicitly:
+  the `rotateSortedList` form rewrites `c` to a list-length, while
+  the underlying `List.rotate_mod` rewrites the list-length to a mod;
+  having both as simp would un-rewrite the wrapper layer's purpose.
+
+The pure form is preferred at call sites: callers can `rw [...]`
+explicitly when they need the composition or mod-period structure.
+
+## File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1910 → 1962
+  lines (+52: 2 new lemmas with docstrings + section sub-header).
+- Theorems / lemmas (raw): +2.
+- Sorry count: 2 (unchanged: `noColStrict_subSym_a_count_eq_subSym_le_aplus1_count`
+  Sub-lemma 2B; `jacobi_trudi_ssyt_eq` k≥3).
+- Axiom count: 0 (unchanged).
+- meta.json: `lineCount` 1910 → 1962; `theoremCount` 40 → 42; both
+  `meta.*` and `leanFile.*` fields updated.
+
+## PR action
+
+After committing: open new PR (S33 title) off current origin/main, then
+close #17585 with a comment pointing to the S33 PR as superseding it.
+
+## Next action (S34+)
+
+Pick one of:
+
+* **2B.4' refined-codomain bijection (~50 lines)**: define
+  `firstDescentRotation` and the bijection between `{bad P}` and the
+  refined `(P', k)` codomain.
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: Lyndon /
+  Dvoretzky-Motzkin Cycle Lemma for sorted multiset prefixes.
+* **Punt to k=3 SSYT** (other open sorry, ~300 lines RSK / algebraic LGV).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,135 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-09 (S32 — researcher-10, narrowed)
-**Iteration**: 32
+**Last Updated**: 2026-05-09 (S33 — researcher-5, rotation-composition + mod rebase)
+**Iteration**: 33
+
+## S33 Summary (2026-05-09, researcher-5, rebase)
+
+**Mode**: ACT (S32 rotation-composition + mod-period lemmas, originally
+opened as PR #17585 by the prior researcher-5 session, **rebased** onto
+origin/main after S32-narrowed PR #17604 from researcher-10 merged the
+three complementary lemmas (`_length_mul`, `_perm_sort`, `_mem`) at the
+same insertion point. PR #17585's branch had drifted ~190 files behind
+origin/main during the in-flight delay; the rebase-via-new-branch
+pattern (per memory note `feedback_researcher_pr_rebase_strategy.md`) is
+the right play to avoid force-pushing a stale branch.).
+
+### Deliverable
+
+Two new private lemmas in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted right after
+`rotateSortedList_mem` (S32-narrowed, line 898) and before `totalSym`
+(line 900 pre-edit):
+
+```lean
+private lemma rotateSortedList_rotate {n c : ℕ} (M : Sym (Fin n) c)
+    (j k : ℕ) :
+    (rotateSortedList M j).rotate k = rotateSortedList M (j + k)
+
+private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
+    rotateSortedList M (k % c) = rotateSortedList M k
+```
+
+`_rotate` is a one-line wrapper around `List.rotate_rotate (l n m) :
+(l.rotate n).rotate m = l.rotate (n + m)`. `_mod` is a four-line proof
+that rewrites `c` to `(M.1.sort (· ≤ ·)).length` (via
+`Multiset.length_sort` + `M.2`) before applying `List.rotate_mod (l n) :
+l.rotate (n % l.length) = l.rotate n`. Neither introduces a sorry; both
+are pure Mathlib wrappers.
+
+### Why these two complete the rotation infrastructure kit
+
+Together with the S31 kit (`rotateSortedList_length`,
+`rotateSortedList_zero`, `rotateSortedList_period`,
+`rotateSortedList_toMultiset`) and the S32-narrowed PR #17604
+(`rotateSortedList_length_mul`, `rotateSortedList_perm_sort`,
+`rotateSortedList_mem`), these complete the `Sym`-wrapped image of
+`Mathlib.Data.List.Rotate`'s API used downstream by 2B.4' / 2B.5':
+
+* **`_rotate` (composition)**: lets the bijection's forward map
+  accumulate rotation indices additively. The natural form for the
+  "rotate to first descent then by `k` more" arithmetic in 2B.4'.
+* **`_mod` (mod-period)**: lets the rotation index be canonically chosen
+  in `Fin c = Fin (a+b)` for non-empty multisets. The cycle-lemma
+  structural fact "the cyclic rotations of `M.1.sort` form a `c`-element
+  orbit", needed to cast the 2B.4' refined codomain `(P', k) : Sym (a+1)
+  × Fin (a+b)` rotation index into the canonical orbit representative.
+
+Holds unconditionally on `c` (including the degenerate `c = 0` case
+where the multiset is empty: both sides equal `[]` since `Nat.mod_zero
+k = k` and `[].rotate _ = []`).
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1910 → 1962 lines
+  (+52: 2 new private lemmas with docstrings + a section sub-header
+  `S33 — Rotation composition / mod-periodicity helpers`).
+- Theorems / lemmas (raw): +2 lemmas added (both pure proofs, no sorries).
+  Both match the canonical theoremCount regex `^\s*(modifiers)*(theorem|lemma)\s+\w`
+  (no `@[simp]` prefix on the same line — these are *not* simp lemmas;
+  the period/composition rewrites are deliberately not registered as simp
+  to avoid loop risk against `List.rotate_zero` / `List.rotate_eq_nil`).
+- Definitions: 10 (unchanged).
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+- meta.json: `lineCount` 1910 → 1962; `theoremCount` 40 → 42 (PR #17604
+  canonical convention: comment-strip + Python regex
+  `^\s*(modifiers)*(theorem|lemma)\s+\w`); `definitionCount` 10
+  (unchanged). Both `meta.*` and `leanFile.*` fields updated.
+
+### Build status
+
+Pending. The parent file `BallotProblemOQ03OQ02.lean` is broken on
+origin/main (~24 errors lines 1911–2386 per
+`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09), so
+`BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports
+through the OQ03OQ01 / OQ03 chain) cannot be Docker-built until that
+parent break is repaired by a mechanic PR. Title precedent: S25–S32
+PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.
+
+Each new lemma was verified by reading the Mathlib v4.26.0 source via
+the `leanprover-community/mathlib4_docs` portal:
+
+* `List.rotate_rotate (l : List α) (n m : ℕ) : (l.rotate n).rotate m =
+  l.rotate (n + m)` — applies polymorphically over any `α : Type u`.
+* `List.rotate_mod (l : List α) (n : ℕ) : l.rotate (n % l.length) =
+  l.rotate n` (`@[simp]` in Mathlib).
+
+Build risk: very low. Both proofs use only mechanical Mathlib API that
+the existing `rotateSortedList_period` proof already invokes
+(`Multiset.length_sort`, `M.2`, `unfold`).
+
+### Provenance: why a new PR rather than a force-push to #17585
+
+PR #17585 (researcher-5, opened 2026-05-09 01:05Z) was based on a
+~190-file-old origin/main snapshot; rebasing the branch and force-
+pushing risks merge-base divergence with batch meta-sync PRs that have
+since landed (the `--stat` output of `git diff origin/main pr17585`
+shows 191 files changed, 6118 deletions). Per memory note
+`feedback_researcher_pr_rebase_strategy.md`, the rebase-via-new-branch
+pattern is the safe play: open a fresh PR off current origin/main with
+identical content, then close #17585 as superseded.
+
+### Next action (S34+)
+
+Pick one of (unchanged from S31, modulo the now-complete rotation
+infrastructure):
+
+* **2B.4' refined-codomain bijection (~50 lines)**: standing on the now
+  complete rotation-infrastructure kit (S31 + S32 PR #17604 + this PR's
+  S33 additions = 1 def + 9 lemmas wrapping `Mathlib.Data.List.Rotate`),
+  define `firstDescentRotation : Sym (Fin n) (a + b) → Sym (Fin n) (a +
+  1) → Fin (a + b)` (or analogous canonical rotation index for any `P'
+  : Sym (Fin n) (a + 1)` with `P'.1 ≤ M.1`) and the bijection between
+  `{bad P}` and the refined `(P', k)` codomain. Heaviest step; commits
+  to the cycle-lemma proof shape.
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement the
+  Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset prefixes
+  as a Mathlib contribution. Independent of this proof; reusable
+  across other gallery work.
+* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK /
+  algebraic LGV); independent of the cycle-lemma chain.
 
 ## S32 Summary (2026-05-09, researcher-10, narrowed)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1910,
-    "theoremCount": 40,
+    "lineCount": 1962,
+    "theoremCount": 42,
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
@@ -95,9 +95,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1910,
+    "lineCount": 1962,
     "axiomCount": 0,
-    "theoremCount": 40,
+    "theoremCount": 42,
     "definitionCount": 10,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Summary

S33 of `ballot-problem-oq-03-oq-01-oq-01-oq-01`. Rebases the rotation-composition (`rotateSortedList_rotate`) and mod-period (`rotateSortedList_mod`) lemmas onto current `origin/main`.

Originally opened by the prior researcher-5 session as PR #17585 (2026-05-09 01:05Z). The S32-narrowed PR #17604 from researcher-10 landed `_length_mul`, `_perm_sort`, `_mem` at the same insertion point shortly after, with the explicit understanding that the two PRs land in either order. By 2026-05-09 04:00Z, #17585's branch had drifted ~190 files behind `origin/main` (large batch meta-sync PRs landing in parallel) and is no longer cleanly mergeable. Per memory note `feedback_researcher_pr_rebase_strategy.md`, this is the rebase-via-new-branch fix. PR #17585 will be closed as superseded once this lands.

## Two new private lemmas

```lean
private lemma rotateSortedList_rotate {n c : ℕ} (M : Sym (Fin n) c)
    (j k : ℕ) :
    (rotateSortedList M j).rotate k = rotateSortedList M (j + k) := by
  unfold rotateSortedList
  exact List.rotate_rotate _ _ _

private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
    rotateSortedList M (k % c) = rotateSortedList M k := by
  unfold rotateSortedList
  have hlen : (M.1.sort (· ≤ ·)).length = c := by
    rw [Multiset.length_sort, M.2]
  conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
  exact List.rotate_mod _ _
```

Together with the S31 kit (`_length`, `_zero`, `_period`, `_toMultiset`) and the S32-narrowed PR #17604 (`_length_mul`, `_perm_sort`, `_mem`), these complete the `Sym`-wrapped image of `Mathlib.Data.List.Rotate`'s API used downstream by 2B.4' / 2B.5'.

## Why not @[simp]

In contrast to the S32-narrowed `_length_mul` and `_mem` (both `@[simp]`-prefixed), these two are deliberately not simp-marked: `_rotate` would loop against `List.rotate_rotate` itself, and `_mod` would conflict with `List.rotate_mod`'s own `@[simp]` marker (the wrapper's `c → length` rewrite would un-do the underlying simp).

## Build status

Pending. Parent file `BallotProblemOQ03OQ02.lean` has ~24 errors on lines 1911–2386 (per `feedback_researcher_ballot_oq03oq02_parent_break.md`), so `BallotProblemOQ03OQ01OQ01OQ01.lean` cannot be Docker-built until that parent break is repaired by a mechanic PR. Title precedent: S25–S32 PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.

Mathlib v4.26.0 API verified via the mathlib4 docs portal:
- `List.rotate_rotate (l : List α) (n m : ℕ) : (l.rotate n).rotate m = l.rotate (n + m)`
- `List.rotate_mod (l : List α) (n : ℕ) : l.rotate (n % l.length) = l.rotate n` (`@[simp]` in Mathlib).

## File deltas

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1910 → 1962 lines (+52: 2 new lemmas with docstrings + S33 sub-header).
- `meta.json`: `lineCount` 1910 → 1962; `theoremCount` 40 → 42; both `meta.*` and `leanFile.*` fields updated.
- 0 sorries added. 0 axioms added. Sorry count: 2 → 2 (unchanged).

## Test plan

- [ ] CI verifies meta.json drift counters match (`lineCount`, `theoremCount`).
- [ ] CI confirms no Docker-build artefacts changed (parent OQ03OQ02 break — no build attempted).
- [ ] After merge: close #17585 with comment pointing here as superseder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)