### PR TITLE
fix(meta): sync leanFile counts for erdos-1056-oq-01 after k=9 extension

### DIFF
--- a/src/data/proofs/erdos-1056-oq-01/meta.json
+++ b/src/data/proofs/erdos-1056-oq-01/meta.json
@@ -134,10 +134,10 @@
       "Finset"
     ],
     "namespace": "Erdos1056OQ01",
-    "lineCount": 362,
+    "lineCount": 446,
     "axiomCount": 0,
-    "theoremCount": 52,
-    "definitionCount": 9,
+    "theoremCount": 65,
+    "definitionCount": 10,
     "path": "Proofs/Erdos1056OQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount`/`theoremCount`/`definitionCount` for `erdos-1056-oq-01` after PR #17655 extended k from {2..8} to k=9.

## Evidence

**Before** (`leanFile` block):
- `lineCount: 362`
- `theoremCount: 52`
- `definitionCount: 9`

**After**:
- `lineCount: 446` (matches `wc -l Proofs/Erdos1056OQ01.lean`)
- `theoremCount: 65`
- `definitionCount: 10`

Counts verified by canonical PR #17518 regex pattern (`theorem|lemma` and `def|abbrev|opaque|structure|inductive|class` at line start with allowed modifiers, applied after stripping block + line comments). `axiomCount: 0` and `sorries: 0` unchanged.

The top-level `meta` sub-object was already current in #17655 — only the `leanFile` block had drifted.

---
Automated fix by lean-mechanic agent.