### PR TITLE
Enrich Erdős #101: definitions/small-case annotations + erdos-104 sibling

### DIFF
--- a/src/data/proofs/erdos101-problem/annotations.json
+++ b/src/data/proofs/erdos101-problem/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "e101-definitions",
+    "proofId": "erdos101-problem",
+    "type": "definition",
+    "range": {
+      "startLine": 22,
+      "endLine": 48
+    },
+    "title": "Foundational Definitions: PlanarPointSet, collinear, NoFiveCollinear, fourPointLineCount",
+    "content": "Four definitions that fix the formal vocabulary of the proof.\n\n1. **`PlanarPointSet`** (L24–27): a `structure` carrying a finite set `points : Finset (ℝ × ℝ)` together with a positivity proof `size_pos : points.card > 0`. The bundled positivity proof lets every downstream theorem assume a non-empty point set without having to discharge an `n ≥ 1` precondition.\n\n2. **`collinear p q r`** (L30–31): the *signed-area* (cross-product) definition `(q.1 − p.1) · (r.2 − p.2) = (r.1 − p.1) · (q.2 − p.2)`. Equivalent to `r − p ∥ q − p` but avoids division, division-by-zero case splits at the definition site, and the parametric `∃ t, …` form.\n\n3. **`NoFiveCollinear P`** (L34–40): pointwise unfolded — for any choice of 5 distinct points $a, b, c, d, e \\in P$ at least one of `collinear a b c`, `collinear a b d`, `collinear a b e` fails. Unfolded form chosen so that `noFiveCollinear_line_bound` can attack the proof by destructuring directly without going through a Finset-on-Finset existential.\n\n4. **`fourPointLineCount`** (L44–48): the central counting target — `Finset.card` of the powerset filter `{S ⊆ P.points : |S| = 4 ∧ ∃ a ≠ b ∈ S, ∀ p ∈ S, collinear a b p}`. The `open Classical in` block + `noncomputable` modifier reflect that membership in this set is decided by an existential over $\\mathbb{R}$.",
+    "significance": "key",
+    "mathContext": "Three choices that shape every downstream proof:\n- **Determinant vs. parametric collinearity**: `(q_1-p_1)(r_2-p_2) = (r_1-p_1)(q_2-p_2)` is polynomial (no division) and ring/linarith-friendly, but it is *not a priori symmetric* in $\\{p,q,r\\}$ — hence the symmetry suite in the next block.\n- **`NoFiveCollinear` as an unfolded $\\forall^{15}$ formula**: avoids `Finset`-level existentials, making the proof of `noFiveCollinear_line_bound` a series of `Finset.erase`/`Finset.card_pos` calls rather than a `Finset.choose` argument.\n- **`fourPointLineCount` over Finset powersets**: filtering `P.points.powerset` is finite ($2^n$ subsets) so the count is well-defined, but requires `Classical` decidability of the existential collinearity predicate."
+    ,
+    "relatedConcepts": [
+      "signed area determinant",
+      "Finset.powerset",
+      "Finset.filter",
+      "Classical.dec",
+      "noncomputable"
+    ],
+    "prerequisites": [
+      "Finset and Finset.powerset",
+      "Classical reasoning over ℝ (DecidablePred)"
+    ]
+  },
+  {
     "id": "e101-symmetries",
     "proofId": "erdos101-problem",
     "type": "technique",
@@ -66,6 +91,30 @@
     "prerequisites": [
       "collinear_trans",
       "Lean by_cases tactic"
+    ]
+  },
+  {
+    "id": "e101-small-cases",
+    "proofId": "erdos101-problem",
+    "type": "theorem",
+    "range": {
+      "startLine": 130,
+      "endLine": 162
+    },
+    "title": "Small-Case Sanity Lemmas: noFiveCollinear_small and fourPointLineCount_lt_four",
+    "content": "Two vacuous-base-case lemmas that pin down the boundary behavior of the bounds.\n\n**`noFiveCollinear_small`** (L131–149): For any `P` with `|P.points| ≤ 4`, the predicate `NoFiveCollinear P` holds vacuously. Proof builds the literal 5-element `Finset` `{a, b, c, d, e}` from the 15 distinctness hypotheses, computes its cardinality as `5` by four nested `Finset.card_insert_of_notMem` rewrites, then derives `5 = |{a,…,e}| ≤ |P.points| ≤ 4` for an `omega`-closed contradiction. This makes the hypothesis statement-of-record harmless even on tiny configurations — the theorems below remain true *and informative* (the bound $n(n-1)/12$ becomes vacuous at $n \\leq 4$).\n\n**`fourPointLineCount_lt_four`** (L153–162): For any `P` with `|P.points| < 4`, `fourPointLineCount P = 0`. Proof: any 4-element subset $S$ of a $<4$-point set would have $|S| \\leq |P.\\text{points}| < 4$, contradicting $|S| = 4$. Closed via `Finset.filter_eq_empty_iff` + `omega`.\n\nTogether these establish: *the bounds in this file are meaningful only at $n \\geq 4$, and degenerate gracefully below.*",
+    "significance": "supporting",
+    "mathContext": "Boundary behavior: $|F| \\leq n(n-1)/12$ at $n = 4$ gives $|F| \\leq 1$ (a single 4-collinear subset is allowed), at $n = 5$ gives $|F| \\leq 20/12 = 1$ (still one), at $n = 12$ gives $|F| \\leq 11$ (matching Grünbaum's projective-plane lower bound qualitatively). The small-case lemmas certify that the formal statements remain *true* throughout this regime by ensuring the no-5-collinear hypothesis cannot fail vacuously and the count cannot be negative.",
+    "relatedConcepts": [
+      "Finset.card_insert_of_notMem",
+      "Finset.filter_eq_empty_iff",
+      "vacuous truth",
+      "boundary cases"
+    ],
+    "prerequisites": [
+      "NoFiveCollinear definition",
+      "Finset.card_le_card",
+      "omega tactic"
     ]
   },
   {

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -50,7 +50,8 @@
       "**Pair-packing argument**: Each 4-collinear subset contributes C(4,2)=6 pairs. Disjoint overlaps → disjoint pair-sets. Packing into the C(n,2) total pairs gives the 6× improvement: |F| ≤ n(n-1)/12.",
       "**fourCollinearThrough per-point bound**: By erasing p from each 4-subset through p, we get disjoint 3-element subsets of P \\ {p}. Packing into n-1 points gives at most (n-1)/3 four-collinear subsets through p.",
       "**Lean's Finset API in action**: The proof uses Finset.powerset, Finset.filter, Finset.biUnion, Finset.card_biUnion (for disjoint unions), and Finset.powersetCard — a comprehensive workout of Lean 4's combinatorics library.",
-      "**Why the n^{3/2} conjecture failed (Solymosi-Stojaković)**: The lower-bound constructions are *not* of the simple Grünbaum projective-plane type. Solymosi-Stojaković took an n × n integer grid, fixed a sparse subset, and used random-perturbation arguments to drive the count of four-point lines to n^{2 - O(1/√log n)}. The takeaway for this formalization: any pair-packing or per-point argument that depends only on the no-5-collinear condition cannot beat C·n²; closing the o(n²) gap will require structural information that the present proof doesn't use (incidences, additive combinatorics, or arithmetic structure of coordinates)."
+      "**Why the n^{3/2} conjecture failed (Solymosi-Stojaković)**: The lower-bound constructions are *not* of the simple Grünbaum projective-plane type. Solymosi-Stojaković took an n × n integer grid, fixed a sparse subset, and used random-perturbation arguments to drive the count of four-point lines to n^{2 - O(1/√log n)}. The takeaway for this formalization: any pair-packing or per-point argument that depends only on the no-5-collinear condition cannot beat C·n²; closing the o(n²) gap will require structural information that the present proof doesn't use (incidences, additive combinatorics, or arithmetic structure of coordinates).",
+      "**Determinant vs. parametric collinearity** — a Lean design choice: the formalization defines $\\text{collinear}(p,q,r)$ via the signed-area determinant $(q_1{-}p_1)(r_2{-}p_2) = (r_1{-}p_1)(q_2{-}p_2)$ rather than the parametric form $\\exists t \\in \\mathbb{R}, r = p + t(q - p)$. The determinant is *polynomial* in the coordinates, so every collinearity manipulation closes under `ring`, `linarith`, `nlinarith`, or `polyrith` without case-splitting on slope existence or invoking `Classical` to extract an explicit $t$. The cost is that the predicate is *not symmetric a priori* in $\\{p,q,r\\}$ — paid for by the seven-lemma symmetry suite (`collinear_swap23`, `collinear_swap12`, `collinear_rotate`, `collinear_cycle`, plus three reflexivity cases). The benefit accrues at scale: `collinear_trans` only needs a single vertical/non-vertical case split, and the downstream `four_collinear_*` arguments never touch real-analytic machinery."
     ],
     "prerequisites": [
       "Combinatorial geometry and point-line incidences",
@@ -82,6 +83,11 @@
       "targetId": "erdos-105",
       "relationship": "related",
       "description": "Erdős #105: given n non-collinear points A and n−3 \"avoidance\" points B, must some line hit ≥2 points of A and miss B? Disproved by Xichuan via explicit counterexample. Same incidence-geometry flavour as #101: rich-line counts under collinearity / avoidance constraints in finite planar configurations."
+    },
+    {
+      "targetId": "erdos-104",
+      "relationship": "related",
+      "description": "Erdős #104 ($100 prize): given n points in ℝ², how many unit circles contain at least 3 points? Direct curve-analogue of #101 — same $100 prize level, same Ω(n^{3/2}) ≤ answer ≤ O(n²) gap, same conjecture (subquadratic). The standard Szemerédi-Trotter-style attack for #104 (circles ↔ pseudo-lines via inversion) suggests that the o(n²) bound on #101 will require similar incidence-geometry inputs; both problems share the structural obstruction that Solymosi-Stojaković-style random constructions reach n^{2−o(1)} from below."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `erdos101-problem` (claimed by enricher-1).

## Changes

**annotations.json** (12 → 14):
- `e101-definitions` (L22–48): foundational vocabulary — `PlanarPointSet`, `collinear` (signed-area determinant), `NoFiveCollinear` (unfolded $\forall^{15}$ form), `fourPointLineCount` (Classical/noncomputable powerset filter). Closes the largest uncovered range above the existing annotation start at L52.
- `e101-small-cases` (L130–162): the two vacuous-base-case lemmas `noFiveCollinear_small` and `fourPointLineCount_lt_four`, with a note on why the bounds degenerate gracefully at $n \leq 4$.

**meta.json**:
- New cross-reference: `erdos-104` (unit circles through 3 points — direct \$100/Ω(n^{3/2})/O(n²) sibling to #101 in the rich-curve programme).
- New `keyInsights` entry: the determinant-vs-parametric design choice — why the polynomial signed-area form was preferred over $\exists t, r = p + t(q-p)$, and what it buys (ring/linarith friendliness, single case-split in `collinear_trans`) vs. what it costs (the seven-lemma symmetry suite).

## Verification

- JSON validity confirmed via Python json.load on both files.
- `pnpm build` could not be run in this worktree: `pnpm install` preflight aborts on `better-sqlite3` gyp build under Node v26 (known infrastructure issue tracked in agent memory; affects multiple roles).
- Changes are purely additive — diff vs origin/main is +56/-1 across two files, no edits to existing content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)