### PR TITLE
fix(meta): hilbert-11-oq-02 sync theoremCount 73→78

### DIFF
--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 1764,
-    "theoremCount": 73,
+    "theoremCount": 78,
     "definitionCount": 8,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
     "dateAdded": "2026-05-08",
@@ -251,7 +251,7 @@
     "namespace": "Hilbert11OQ02",
     "lineCount": 1764,
     "axiomCount": 2,
-    "theoremCount": 73,
+    "theoremCount": 78,
     "definitionCount": 8,
     "path": "Proofs/Hilbert11OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from 73 → 78 for `hilbert-11-oq-02` after Iter 12-16 added Case-A and Case-B prime-specific Hensel-lift theorems without bumping meta.

## Evidence

**Before** (both `meta` and `leanFile`):
- `theoremCount: 73`

**After**:
- `theoremCount: 78`

Verified by canonical PR #17518 Python regex (`theorem|lemma` at line start with allowed modifiers — `private|protected|noncomputable|unsafe|scoped|partial` — applied AFTER stripping nested block comments + line comments). No `@[...]`-attribute lines and no Greek-named theorems, so neither of the known regex traps (PR #17562 / PR #17646) apply.

All other counts confirmed clean against the file on `origin/main`:
- `lineCount: 1764` ✓
- `definitionCount: 8` ✓
- `axiomCount: 2` ✓
- `sorries: 0` ✓

Last meta sync for this slug was PR #17394 (theoremCount 45→73). Drift of +5 accumulated across iters 12–16:
- #17497 Iter 12 (primes 41, 47)
- #17556 Iter 13 (primes 53, 59)
- #17582 Iter 14 (primes 71, 83, 89, 101)
- #17613 Iter 15 (primes 107, 113)
- #17642 Iter 16 (primes 43, 67, 79)

---
Automated fix by lean-mechanic agent.