### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 21 — sigma2/pi2 list-arity closures (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -2014,6 +2014,159 @@ theorem pi2_union_isUniversalExistentialDefinition
     (fun q => S₁ q ∨ S₂ q)).mpr hd
 
 -- ============================================================
+-- Part VIII.23 (iter 21, Path B): list version of Σ₂ ∩ closure
+-- ============================================================
+
+/-- Iter 21, Path B: **the Σ₂ class is closed under finite list intersection**.
+
+    Direct list lift of iter 20's `sigma2_intersection_isExistentialUniversalDefinition`
+    by induction on the list, with the empty list giving the universe set
+    (vacuous universal `∀ S ∈ [], S q ↔ True`).
+
+    **Strategy** (mirrors iter 14's `finIntersectionList_isDiophantineDefinition`
+    at level 1, one level higher): induction on `l : List RatSubset`,
+    base case via `universe_isExistentialUniversalDefinition` + iter-4 Σ₂
+    class congruence bridge, step case via iter-20
+    `sigma2_intersection_isExistentialUniversalDefinition` applied to the
+    head and the inductive hypothesis on the tail.
+
+    **Significance**: lifts iter 20's binary Σ₂ ∩ closure to arbitrary
+    finite list arity. Combined with iter 18 (Σ₂ list ∪, in PR #17552
+    stacked on iter 16 PR #17456), the list-arity Σ₂ binary-Boolean
+    closure grid is fully populated:
+
+        | Class | binary ∪          | binary ∩          | list ∪      | list ∩      |
+        |-------|-------------------|-------------------|-------------|-------------|
+        | Σ₂    | iter 16 (#17456)  | iter 20 (on main) | iter 18 (#17552) | iter 21 (this) |
+        | Π₂    | iter 20 (on main) | iter 16 (#17456)  | iter 21 (this) | iter 18 (#17552) |
+
+    See `pi2_unionList_isUniversalExistentialDefinition` (just below)
+    for the Π₂ side.
+
+    **Mathlib API surface**: ZERO new imports, ZERO new lemmas. Uses
+    only iter 20's binary `sigma2_intersection_isExistentialUniversalDefinition`
+    (already on origin/main via #17628), iter 5's
+    `universe_isExistentialUniversalDefinition`, iter 4's Σ₂ class
+    congruence helper `existentialUniversalDefinition_iff_of_pred_iff`,
+    and the standard Lean-core list helpers `List.mem_cons_self`,
+    `List.mem_cons_of_mem`, `List.mem_cons`.
+
+    **OPEN content unchanged**: the central Σ₁ question for ℤ ⊂ ℚ is
+    unaffected. Iter 21 only sharpens the level-2 list-arity closure
+    properties. -/
+theorem sigma2_intersectionList_isExistentialUniversalDefinition
+    (l : List RatSubset) (h : ∀ S ∈ l, IsExistentialUniversalDefinition S) :
+    IsExistentialUniversalDefinition (fun q : Rat => ∀ S ∈ l, S q) := by
+  induction l with
+  | nil =>
+    have hbridge : ∀ q : Rat,
+        (fun q : Rat => ∀ S ∈ ([] : List RatSubset), S q) q ↔
+        (fun _ : Rat => True) q := by
+      intro q; simp
+    exact (existentialUniversalDefinition_iff_of_pred_iff hbridge).mpr
+      universe_isExistentialUniversalDefinition
+  | cons a t ih =>
+    have h_head : IsExistentialUniversalDefinition a :=
+      h a (List.mem_cons_self a t)
+    have h_tail : ∀ S ∈ t, IsExistentialUniversalDefinition S :=
+      fun S hS => h S (List.mem_cons_of_mem a hS)
+    have ih_def : IsExistentialUniversalDefinition
+        (fun q : Rat => ∀ S ∈ t, S q) :=
+      ih h_tail
+    have h_inter : IsExistentialUniversalDefinition
+        (fun q : Rat => a q ∧ (∀ S ∈ t, S q)) :=
+      sigma2_intersection_isExistentialUniversalDefinition h_head ih_def
+    have hbridge : ∀ q : Rat,
+        (fun q : Rat => ∀ S ∈ (a :: t), S q) q ↔
+        (fun q : Rat => a q ∧ (∀ S ∈ t, S q)) q := by
+      intro q
+      constructor
+      · intro hall
+        refine ⟨hall a (List.mem_cons_self a t),
+          fun S hS => hall S (List.mem_cons_of_mem a hS)⟩
+      · rintro ⟨ha, htail⟩ S hS
+        rcases List.mem_cons.mp hS with rfl | hSt
+        · exact ha
+        · exact htail S hSt
+    exact (existentialUniversalDefinition_iff_of_pred_iff hbridge).mpr h_inter
+
+-- ============================================================
+-- Part VIII.24 (iter 21, Path B): list version of Π₂ ∪ closure
+-- ============================================================
+
+/-- Iter 21, Path B: **the Π₂ class is closed under finite list union**.
+
+    Direct list lift of iter 20's `pi2_union_isUniversalExistentialDefinition`
+    by induction on the list, with the empty list giving the empty set
+    (vacuous existential `∃ S ∈ [], S q ↔ False`).
+
+    **Strategy** (mirrors iter 14's `finUnionList_isCoDiophantineDefinition`
+    at level 1, one level higher): induction on `l : List RatSubset`,
+    base case via `empty_isUniversalExistentialDefinition` + iter-4 Π₂
+    class congruence bridge, step case via iter-20
+    `pi2_union_isUniversalExistentialDefinition` applied to the head and
+    the inductive hypothesis on the tail.
+
+    **Significance**: completes the list-arity row of the level-2 binary
+    Boolean closure grid (alongside iter 21's
+    `sigma2_intersectionList_isExistentialUniversalDefinition` above and
+    iter 18 PR #17552 for the iter-16-based cells). Every finite list
+    union of Π₂-definable subsets is itself Π₂-definable.
+
+    **Strictly bigger than iter 14's transports**: iter 14 only handles
+    diagonal-input cases (Σ₁ list ∪ → Π₂ via Σ₁ ⊆ Π₂); iter 21 handles
+    arbitrary Π₂ inputs (e.g., a list containing the Π₂ predicate
+    `IntSubset` from `koenigsmann_2016_universal`, or any of the Π₂
+    subsets produced by trivial inclusions Σ₁ ⊆ Π₂ from iter 11).
+
+    **Mathlib API surface**: ZERO new imports, ZERO new lemmas. Uses
+    only iter 20's binary `pi2_union_isUniversalExistentialDefinition`
+    (already on origin/main via #17628), iter 5's
+    `empty_isUniversalExistentialDefinition`, iter 4's Π₂ class
+    congruence helper `universalExistentialDefinition_iff_of_pred_iff`,
+    and the standard Lean-core list helpers `List.mem_cons_self`,
+    `List.mem_cons_of_mem`, `List.mem_cons`.
+
+    **OPEN content unchanged**: the central Σ₁ question for ℤ ⊂ ℚ is
+    unaffected. Iter 21 only sharpens the level-2 list-arity closure
+    properties. -/
+theorem pi2_unionList_isUniversalExistentialDefinition
+    (l : List RatSubset) (h : ∀ S ∈ l, IsUniversalExistentialDefinition S) :
+    IsUniversalExistentialDefinition (fun q : Rat => ∃ S ∈ l, S q) := by
+  induction l with
+  | nil =>
+    have hbridge : ∀ q : Rat,
+        (fun q : Rat => ∃ S ∈ ([] : List RatSubset), S q) q ↔
+        (fun _ : Rat => False) q := by
+      intro q; simp
+    exact (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr
+      empty_isUniversalExistentialDefinition
+  | cons a t ih =>
+    have h_head : IsUniversalExistentialDefinition a :=
+      h a (List.mem_cons_self a t)
+    have h_tail : ∀ S ∈ t, IsUniversalExistentialDefinition S :=
+      fun S hS => h S (List.mem_cons_of_mem a hS)
+    have ih_def : IsUniversalExistentialDefinition
+        (fun q : Rat => ∃ S ∈ t, S q) :=
+      ih h_tail
+    have h_union : IsUniversalExistentialDefinition
+        (fun q : Rat => a q ∨ (∃ S ∈ t, S q)) :=
+      pi2_union_isUniversalExistentialDefinition h_head ih_def
+    have hbridge : ∀ q : Rat,
+        (fun q : Rat => ∃ S ∈ (a :: t), S q) q ↔
+        (fun q : Rat => a q ∨ (∃ S ∈ t, S q)) q := by
+      intro q
+      constructor
+      · rintro ⟨S, hSmem, hSq⟩
+        rcases List.mem_cons.mp hSmem with rfl | hSt
+        · exact Or.inl hSq
+        · exact Or.inr ⟨S, hSt, hSq⟩
+      · rintro (ha | ⟨S, hSt, hSq⟩)
+        · exact ⟨a, List.mem_cons_self a t, ha⟩
+        · exact ⟨S, List.mem_cons_of_mem a hSt, hSq⟩
+    exact (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr h_union
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -2196,6 +2349,8 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `union_isExistentialUniversalDefinition` (Π₁ ∪ Π₁ ⊆ Σ₂ corollary, iter 13)
   - `sigma2_intersection_isExistentialUniversalDefinition` (Σ₂ closed under binary intersection via product polynomial + interleave on existential block, iter 20)
   - `pi2_union_isUniversalExistentialDefinition` (Π₂ closed under binary union via iter 5 duality + iter 20 Σ₂ ∩ closure, iter 20)
+  - `sigma2_intersectionList_isExistentialUniversalDefinition` (Σ₂ closed under finite list intersection via iter 20 + list induction, iter 21)
+  - `pi2_unionList_isUniversalExistentialDefinition` (Π₂ closed under finite list union via iter 20 + list induction, iter 21)
 -/
 
 #check @IsDiophantineDefinition
@@ -2262,5 +2417,7 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @finIntersectionList_isExistentialUniversalDefinition
 #check @sigma2_intersection_isExistentialUniversalDefinition
 #check @pi2_union_isUniversalExistentialDefinition
+#check @sigma2_intersectionList_isExistentialUniversalDefinition
+#check @pi2_unionList_isUniversalExistentialDefinition
 
 end Hilbert10Rationals


### PR DESCRIPTION
## Summary

Iteration 21 of `hilbert-10-oq-01-oq-02` (Σ₁ vs Π₂ definability of ℤ ⊂ ℚ). Direct **list-arity lift** of iter 20's binary Σ₂ ∩ and Π₂ ∪ closures (already on origin/main via PR #17628), mirroring the iter 14 list-induction template one level higher.

## What's New (Part VIII.23, VIII.24)

### `sigma2_intersectionList_isExistentialUniversalDefinition` (Σ₂ list ∩ ⊆ Σ₂)

Induction on the list `l : List RatSubset`:
- **nil case**: `(∀ S ∈ [], S q) ↔ True` (by `simp`), then apply `universe_isExistentialUniversalDefinition` lifted by iter 4 Σ₂ class congruence (`existentialUniversalDefinition_iff_of_pred_iff`).
- **cons case**: extract `h_head : Σ₂ a` and `h_tail : ∀ S ∈ t, Σ₂ S`; apply the induction hypothesis to get `Σ₂ (∀ S ∈ t, S q)`; combine with iter 20's binary `sigma2_intersection_isExistentialUniversalDefinition` to get `Σ₂ (a q ∧ (∀ S ∈ t, S q))`; bridge `(∀ S ∈ a :: t, S q) ↔ a q ∧ (∀ S ∈ t, S q)` via `List.mem_cons` + iter 4 Σ₂ congruence.

Mirrors iter 14's `finIntersectionList_isDiophantineDefinition` template (origin/main L1418), substituting iter 20's Σ₂ ∩ for `intersection_isDiophantineDefinition` and the level-2 Σ₂ congruence helper for the level-1 Σ₁ one.

### `pi2_unionList_isUniversalExistentialDefinition` (Π₂ list ∪ ⊆ Π₂)

Symmetric induction on `l : List RatSubset`:
- **nil case**: `(∃ S ∈ [], S q) ↔ False` (by `simp`), then apply `empty_isUniversalExistentialDefinition` lifted by iter 4 Π₂ class congruence (`universalExistentialDefinition_iff_of_pred_iff`).
- **cons case**: extract head/tail Π₂ witnesses, recurse via IH, combine with iter 20's binary `pi2_union_isUniversalExistentialDefinition`, bridge `(∃ S ∈ a :: t, S q) ↔ a q ∨ (∃ S ∈ t, S q)` via `List.mem_cons` + iter 4 Π₂ congruence.

Mirrors iter 14's `finUnionList_isCoDiophantineDefinition` template (origin/main L1485), substituting iter 20's Π₂ ∪ for `union_isCoDiophantineDefinition` and the level-2 Π₂ congruence helper for the level-1 Π₁ one.

## Significance — completes the list-arity row for the iter-20 level-2 cells

| Class | binary ∪              | binary ∩              | list ∪                    | list ∩                    |
|-------|-----------------------|-----------------------|---------------------------|---------------------------|
| Σ₁    | ✅ iter 9 (on main)   | ✅ iter 12 (on main)  | ✅ iter 15 (on main)      | ✅ iter 14 (on main)      |
| Π₁    | ✅ iter 13 (on main)  | ✅ iter 9 (on main)   | ✅ iter 14 (on main)      | ✅ iter 15 (on main)      |
| Σ₂    | open in #17456 (iter 16) | ✅ iter 20 (on main) | open in #17552 (iter 18) | **this PR (iter 21)** |
| Π₂    | ✅ iter 20 (on main)  | open in #17456 (iter 16) | **this PR (iter 21)** | open in #17552 (iter 18) |

**Strictly bigger than iter 14's transports**: iter 14 only handled diagonal-input cases (Σ₁ list ∪ → Π₂ via the trivial inclusion Σ₁ ⊆ Π₂; Π₁ list ∩ → Σ₂ via Π₁ ⊆ Σ₂). Iter 21 handles arbitrary Π₂/Σ₂ inputs (e.g., a list containing `IntSubset` from `koenigsmann_2016_universal`, or any properly Π₂ subset).

**OPEN content unchanged**: the central Σ₁ question for ℤ ⊂ ℚ is unaffected; iter 21 only sharpens the structural understanding of level-2 finite-arity closure properties.

## Orthogonality to open PRs

This PR is independently rebasable onto origin/main; it does **not** stack on, nor conflict with, any of:
- #17456 (iter 16 — Π₂ ∩, Σ₂ ∪ binary; distinct cells, names `pi2_intersection_*`, `sigma2_union_*`)
- #17552 (iter 18 — `pi2_intersectionList_*`, `sigma2_unionList_*`; distinct list-arity cells, stacked on #17456)
- #17602 (iter 19 — pi2/sigma2 Finset transport; distinct finset cells, stacked on #17552)

Iter 21's new theorem names (`sigma2_intersectionList_*`, `pi2_unionList_*`) are disjoint from all three open PRs. Insertion point (after Part VIII.22, before Part IX) is below all sites touched by the three open PRs.

## Mathlib API surface

**ZERO new imports, ZERO new lemmas.** Reuses only:
- iter 20's binary `sigma2_intersection_isExistentialUniversalDefinition` and `pi2_union_isUniversalExistentialDefinition` — already on origin/main via PR #17628.
- iter 4 class congruence helpers (`universalExistentialDefinition_iff_of_pred_iff`, `existentialUniversalDefinition_iff_of_pred_iff`) — already on origin/main since iter 4 (#17026).
- iter 5 trivial-set facts (`universe_isExistentialUniversalDefinition`, `empty_isUniversalExistentialDefinition`) — already on origin/main since iter 5 (#17065).
- `List.mem_cons_self`, `List.mem_cons_of_mem`, `List.mem_cons` (Lean core; already used by iter 14 list closures on origin/main).

## Counts (post-PR)

- `lineCount`: 2266 → 2423 (+157)
- `theoremCount`: 79 → 81 (+2)
- `definitionCount`: 15 (unchanged)
- `axiomCount`: 1 (unchanged, still `koenigsmann_2016_universal`)
- `sorries`: 0 (unchanged)

`meta.json` and `state.md` deliberately untouched (build-pending convention; deferred to mechanic sync after this PR lands).

## Build

**Pending.** Worktree's `proofs/.lake` is a recursive self-symlink (per memory note `feedback_researcher_lake_symlink_broken.md`), so a local Docker build re-fresh-clones Mathlib (~30-45 min). CI is the ground truth.

**Confidence: high.** The proof structure is byte-for-byte parallel to iter 14's `finIntersectionList_isDiophantineDefinition` and `finUnionList_isCoDiophantineDefinition` on origin/main (CI-verified since 2026-05-07). The only structural difference is the substitution of iter 20's binary lemmas for iter 9/13's binary lemmas, and the substitution of the level-2 class-congruence helpers for the level-1 ones — both uniform across the four Σ₁/Π₁/Σ₂/Π₂ classes. No new imports, no new tactics, no new Mathlib API references.

## Test plan

- [x] All 2 new theorems and 0 new definitions type-check (review-time inspection, parallel to iter 14 / iter 18)
- [x] No new sorries, no new axioms (`grep -c sorry` → 0; `grep -c '^axiom '` → 1, unchanged)
- [x] Branched cleanly off origin/main (no stack; no merge with open PRs)
- [ ] CI: Docker build of `Proofs.Hilbert10OQ01OQ02` after this PR is merged
- [ ] After landing, mechanic sync of `meta.json` / `state.md` to reflect iter 21 counts (theoremCount 81, lineCount 2423)

## Status

**Outcome**: progress — list-arity Σ₂ ∩ and Π₂ ∪ closures completed, completing the list-arity row of the level-2 binary Boolean closure grid for the iter-20 cells.

**Next Steps**:
1. CI build verification.
2. After landing, mechanic sync of `meta.json` / `state.md` counts.
3. **S13+ finset arity for level 2**: Finset transports of these list closures, mirroring iter 17's level-1 finset transports. Direct via `Finset.toList` lift (~80 lines, low risk). Currently iter 19 (PR #17602) is doing this for the iter-16 cells; the iter-21 finset variant would mirror that pattern.
4. **Other level-2 OPEN content**: Σ₂ closure under complement (equivalent to Σ₂ = Π₂, OPEN at level 2 just as Σ₁ = Π₁ is OPEN at level 1).

🤖 Generated by researcher-8