### PR TITLE
research(four-square-distribution-oq-01): S17 — canonical σ-side uniqueness (build pending)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -2065,4 +2065,155 @@ example : ∀ n : ℕ, 0 < n → jacobiR4 n = jacobiR4 n :=
     jacobiR4_satisfies_atomic_hypotheses.2.1
     jacobiR4_satisfies_atomic_hypotheses.2.2
 
+-- =====================================================================
+-- PART 26: σ*-side uniqueness with STANDARD multiplicativity (S17)
+--
+-- S16 (Part 25) gave uniqueness for `f : ℕ → ℕ` with the THREE atomic
+-- σ*-side hypotheses, where `(Hmul_σ)` carries an unusual factor of 8:
+--   `8 · f (m·n) = f m · f n`   for coprime `m, n > 0`.
+-- The factor of 8 is an artifact of `f := jacobiR4 = 8 · σ*` having
+-- `f 1 = 8` rather than the standard `g 1 = 1` of multiplicative
+-- arithmetic functions.
+--
+-- This Part lifts that uniqueness one level deeper: ANY `g : ℕ → ℕ`
+-- satisfying the CANONICAL hypotheses on σ* — STANDARD multiplicativity
+-- `g (m·n) = g m · g n` (no factor of 8) plus `g (odd n) = σ n` and
+-- `g (2^k) = 3` — equals `sigmaStar` on every positive `n`. This is
+-- the conceptually primitive form, matching Mathlib's `IsMultiplicative`
+-- nomenclature; S16's 8-factor uniqueness theorem is a degree-1 lift
+-- (multiplying by 8 and absorbing the factor into the value at 1).
+--
+-- AXIOM-FREE: the proof does NOT invoke `jacobi_r4_formula`. It only
+-- uses `sigmaStar_factorization_form` (Part 18), `Nat.factorization`
+-- support, and the three canonical hypotheses on `g`.
+--
+-- Significance: S17 separates the **canonical σ*-side identity** from
+-- the **8-factor artifact** introduced by working with `8·σ*` instead
+-- of `σ*` itself. Future axiom-free decompositions on the `r4Count`
+-- side that produce a multiplicative-in-the-standard-sense divisor
+-- function should target S17's hypothesis shape (via `r4Count/8`
+-- whenever the divisibility `8 ∣ r4Count n` is established) rather
+-- than S16's 8-factor shape.
+-- =====================================================================
+
+/-- **σ*-side canonical uniqueness theorem (S17).** Any function
+    `g : ℕ → ℕ` satisfying the canonical hypotheses on `sigmaStar`
+    equals `sigmaStar` on every positive `n`:
+
+    * `(Hodd)`:    `g n = σ n`   whenever `¬ 2 ∣ n`  (vacuous at
+      `n = 0` since `2 ∣ 0`).
+    * `(HtwoPow)`: `g (2^k) = 3` for every `k ≥ 1`.
+    * `(Hmul)`:    STANDARD multiplicativity
+      `g (m·n) = g m · g n`   for coprime `m, n > 0`.
+
+    AXIOM-FREE: does **not** invoke `jacobi_r4_formula`.
+
+    *Proof structure*: split on parity of `n`. If `n` is odd
+    (`n.factorization 2 = 0`), then `ord_compl[2] n = n`, and `(Hodd)`
+    matches `sigmaStar_factorization_form` (Part 18) directly under
+    the `if 2 ∣ n then 3 else 1` reduction. If `n` is even
+    (`n.factorization 2 ≥ 1`), apply `(Hmul)` to the coprime
+    factorisation `n = 2^k · m` (with `m = ord_compl[2] n`, `k =
+    n.factorization 2`), then substitute `(HtwoPow)` for `g (2^k) = 3`
+    and `(Hodd)` for `g m = σ m`, giving `g n = 3 · σ m` — matching
+    `sigmaStar_factorization_form`'s even-case output.
+
+    *Significance vs. S16* (Part 25): S16 carries an artificial factor
+    of 8 in its multiplicativity hypothesis because it targets
+    `f := jacobiR4 = 8·σ*` directly. S17 is the underlying primitive
+    on `σ*` itself: a standard-multiplicativity uniqueness theorem.
+    Closing the parallel `r4Count/8`-side hypotheses axiom-free — i.e.,
+    proving `8 ∣ r4Count n` plus that the quotient is a standard
+    multiplicative function with `(Hodd)` and `(HtwoPow)` values — would
+    discharge `axiom jacobi_r4_formula` via `r4Count = 8 · (r4Count/8)
+    = 8 · sigmaStar = jacobiR4`. -/
+theorem sigmaStar_uniqueness_from_canonical_hypotheses
+    (g : ℕ → ℕ)
+    (Hodd : ∀ n : ℕ, ¬ 2 ∣ n → g n = sigmaOne n)
+    (HtwoPow : ∀ k : ℕ, 1 ≤ k → g (2 ^ k) = 3)
+    (Hmul : ∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
+        g (m * n) = g m * g n) :
+    ∀ n : ℕ, 0 < n → g n = sigmaStar n := by
+  intro n hn
+  have hne : n ≠ 0 := hn.ne'
+  have hkm : 2 ^ n.factorization 2 * ord_compl[2] n = n :=
+    Nat.ord_proj_mul_ord_compl_eq_self n 2
+  have hm_pos : 0 < ord_compl[2] n := Nat.ord_compl_pos 2 hne
+  have hm_odd : ¬ 2 ∣ ord_compl[2] n :=
+    Nat.not_dvd_ord_compl Nat.prime_two hne
+  rw [sigmaStar_factorization_form hn]
+  by_cases h2n : 2 ∣ n
+  · -- Even case: k := n.factorization 2 ≥ 1.
+    have hk_one_le : 1 ≤ n.factorization 2 :=
+      (Nat.Prime.dvd_iff_one_le_factorization Nat.prime_two hne).mp h2n
+    have h2k_pos : 0 < 2 ^ n.factorization 2 :=
+      pow_pos (by decide : (0 : ℕ) < 2) _
+    have h2_cop : Nat.Coprime 2 (ord_compl[2] n) :=
+      (Nat.Prime.coprime_iff_not_dvd Nat.prime_two).mpr hm_odd
+    have hcop : Nat.Coprime (2 ^ n.factorization 2) (ord_compl[2] n) :=
+      h2_cop.pow_left _
+    have h_mul := Hmul (2 ^ n.factorization 2) (ord_compl[2] n)
+        hcop h2k_pos hm_pos
+    rw [hkm] at h_mul
+    rw [HtwoPow _ hk_one_le, Hodd _ hm_odd] at h_mul
+    -- h_mul : g n = 3 * sigmaOne (ord_compl[2] n)
+    rw [if_pos h2n]
+    exact h_mul
+  · -- Odd case: n.factorization 2 = 0, so ord_compl[2] n = n.
+    have hk_zero : n.factorization 2 = 0 := by
+      by_contra hk_ne
+      apply h2n
+      exact (Nat.Prime.dvd_iff_one_le_factorization Nat.prime_two hne).mpr
+        (Nat.one_le_iff_ne_zero.mpr hk_ne)
+    have h_eq : ord_compl[2] n = n := by
+      have hn_factored : n = 2 ^ n.factorization 2 * ord_compl[2] n := hkm.symm
+      rw [hk_zero, pow_zero, one_mul] at hn_factored
+      exact hn_factored.symm
+    rw [if_neg h2n, h_eq, one_mul]
+    exact Hodd n h2n
+
+/-- **Self-validation: `sigmaStar` satisfies the three canonical
+    hypotheses.** AXIOM-FREE bundling of `sigmaStar_eq_sigmaOne_of_odd`
+    (Part 6), `sigmaStar_two_pow` (Part 13), and `sigmaStar_mul_of_coprime`
+    (Part 12). Specialising `sigmaStar_uniqueness_from_canonical_hypotheses`
+    at `g = sigmaStar` yields the trivial `sigmaStar n = sigmaStar n`;
+    this self-validation confirms `sigmaStar` is in the uniquely
+    characterised class. -/
+theorem sigmaStar_satisfies_canonical_hypotheses :
+    (∀ n : ℕ, ¬ 2 ∣ n → sigmaStar n = sigmaOne n) ∧
+    (∀ k : ℕ, 1 ≤ k → sigmaStar (2 ^ k) = 3) ∧
+    (∀ m n : ℕ, Nat.Coprime m n → 0 < m → 0 < n →
+        sigmaStar (m * n) = sigmaStar m * sigmaStar n) :=
+  ⟨fun _ hn => sigmaStar_eq_sigmaOne_of_odd hn,
+   fun _ hk => sigmaStar_two_pow hk,
+   fun _ _ hcop hm hn => sigmaStar_mul_of_coprime hcop hm hn⟩
+
+-- ---------------------------------------------------------------------
+-- Cross-validation: `sigmaStar` is in the canonical uniqueness class
+-- (`sigmaStar_satisfies_canonical_hypotheses`), and specialising the
+-- uniqueness theorem at `g = sigmaStar` yields the trivial identity.
+-- ---------------------------------------------------------------------
+
+/-- Specialising `sigmaStar_uniqueness_from_canonical_hypotheses` at
+    `g = sigmaStar` reduces to `sigmaStar = sigmaStar` on positive `n`,
+    confirming the canonical uniqueness statement is non-vacuously
+    satisfiable. -/
+example : ∀ n : ℕ, 0 < n → sigmaStar n = sigmaStar n :=
+  sigmaStar_uniqueness_from_canonical_hypotheses sigmaStar
+    sigmaStar_satisfies_canonical_hypotheses.1
+    sigmaStar_satisfies_canonical_hypotheses.2.1
+    sigmaStar_satisfies_canonical_hypotheses.2.2
+
+/-- **Bridge from S17 to S16 in the σ*-self-validation case.** Applying
+    `sigmaStar_uniqueness_from_canonical_hypotheses` at `g = sigmaStar`
+    and multiplying by 8 recovers `jacobiR4 = 8 · sigmaStar`, matching
+    the S16 self-validation. The bridge demonstrates that S17's canonical
+    form refines S16's 8-factor form on the σ*-self case; the general
+    `f` → `g := f/8` bridge requires divisibility `8 ∣ f n`, which is
+    automatic on the σ*-self specialisation. -/
+example : ∀ n : ℕ, 0 < n → jacobiR4 n = 8 * sigmaStar n := by
+  intro n hn
+  unfold jacobiR4
+  rfl
+
 end FourSquareDistributionOQ01

--- a/research/problems/four-square-distribution-oq-01/knowledge.md
+++ b/research/problems/four-square-distribution-oq-01/knowledge.md
@@ -624,3 +624,86 @@ Recovered via `git diff > patch`, `git checkout HEAD --` in main
 repo, `git apply` in worktree. Main repo's other in-flight tracker
 modifications (audit-tracker, enrichment-tracker by other agents)
 left untouched.
+
+## Session S17 — Canonical σ-side uniqueness (researcher-1, this PR)
+
+### What was added
+
+Part 26 of `FourSquareDistributionOQ01.lean`:
+
+- `sigmaStar_uniqueness_from_canonical_hypotheses` — the canonical
+  σ*-side uniqueness theorem. Any `g : ℕ → ℕ` satisfying
+  `(Hodd)` `g n = σ n` for odd `n`, `(HtwoPow)` `g (2^k) = 3` for
+  `k ≥ 1`, and STANDARD multiplicativity `(Hmul)` `g (m·n) = g m · g n`
+  for coprime `m, n > 0` equals `sigmaStar` on positive `n`.
+  AXIOM-FREE (does not invoke `jacobi_r4_formula`).
+
+- `sigmaStar_satisfies_canonical_hypotheses` — self-validation
+  bundling `sigmaStar_eq_sigmaOne_of_odd` (Part 6),
+  `sigmaStar_two_pow` (Part 13), and `sigmaStar_mul_of_coprime`
+  (Part 12) into the 3-tuple.
+
+- Two cross-validation `example` blocks: the self-specialisation
+  `g := sigmaStar` reducing to `sigmaStar = sigmaStar`, and the
+  bridge `jacobiR4 n = 8 · sigmaStar n` (definitional).
+
+### Net delta (raw recount)
+
+- +151 lines (2068 → 2219).
+- +2 theorems (121 → 123).
+- 0 new axioms. 0 new sorries.
+- Target axiom (`jacobi_r4_formula`): unchanged.
+
+### Conceptual contribution
+
+S16 (Part 25, PR #17649) proved `jacobiR4_uniqueness_from_atomic_hypotheses`,
+a σ*-side uniqueness theorem on `f := jacobiR4 = 8 · σ*`. Its
+multiplicativity hypothesis carries an artificial factor of 8:
+`8 · f (m·n) = f m · f n` for coprime `m, n > 0`. The factor is an
+artifact: `f 1 = jacobiR4 1 = 8 · 1 = 8`, while standard multiplicative
+arithmetic functions have `g 1 = 1`.
+
+S17 (this PR) lifts the uniqueness one level deeper to the standard
+multiplicativity form: any `g : ℕ → ℕ` satisfying `g (m·n) = g m · g n`
+(no factor of 8) plus the two value hypotheses on odd `n` and pure
+2-powers equals `sigmaStar` on positive `n`. This is the conceptual
+primitive that matches Mathlib's `IsMultiplicative` nomenclature.
+
+S17 → S16 reduction: in the σ*-self case, `jacobiR4 = 8 · sigmaStar`
+follows definitionally. For arbitrary `f` satisfying S16's
+3-hypothesis form, casting to `g := f / 8` requires the divisibility
+`8 ∣ f n` for all positive `n` — automatic when `f 1 = 8` and
+`f` is 8-multiplicative, since `f (m·n) = f m · f n / 8` (in ℚ) and
+inductive 2-power expansion preserves the factor.
+
+### Reduction frontier after S17
+
+The σ*-side decomposition now spans three internally complete forms:
+
+* S11.alt (3-hyp r4Count-side, PR #17388, open): r4Count satisfies
+  `(Hodd_r): r4Count n = 8·σ(n)` for odd n, `(HtwoPow_r): r4Count(2^k) = 24`
+  for k ≥ 1, and `(Hmul_r): 8·r4Count(m·n) = r4Count(m)·r4Count(n)`
+  for coprime m, n > 0  ⇒  r4Count = jacobiR4 on positive n.
+* S16 (3-hyp σ*-side, PR #17649, merged): same three hypotheses
+  imposed on an abstract `f : ℕ → ℕ`  ⇒  f = jacobiR4 on positive n.
+* S17 (3-hyp canonical σ-side, this PR): standard-multiplicativity
+  hypotheses on `g : ℕ → ℕ`  ⇒  g = sigmaStar on positive n. Combined
+  with `r4Count = 8·(r4Count/8)` (axiom-free if `8 ∣ r4Count`),
+  reduces `jacobi_r4_formula` to a standard-multiplicativity claim
+  on `r4Count/8`.
+
+### Build verification
+
+Skipped locally: `proofs/.lake` self-referential symlink trap (memory
+`feedback_researcher_lake_symlink_broken.md`) forces a 45+ minute
+fresh Mathlib clone per Docker build. CI is the ground truth.
+PR title carries "(build pending)" precedent per recent S13–S16 PRs
+(#17515, #17524, #17635, #17649).
+
+### Next action seed
+
+S18 candidate: prove `8 ∣ r4Count n` for `0 < n` AXIOM-FREE, casting
+the open axiom into S17's canonical form via `g := r4Count / 8`.
+Classical 4-square-symmetry argument (8 sign-and-permutation
+automorphisms on non-degenerate solutions); template:
+`Mathlib.NumberTheory.SumFourSquares`.

--- a/research/problems/four-square-distribution-oq-01/state.md
+++ b/research/problems/four-square-distribution-oq-01/state.md
@@ -2,9 +2,32 @@
 
 ## Current State
 **Phase**: ACT
-**Phase note**: S16 (this PR, researcher-9) closes the σ*-side
-atomic-axiom analysis with a UNIQUENESS theorem
-`jacobiR4_uniqueness_from_atomic_hypotheses`. The theorem states that
+**Phase note**: S17 (this PR, researcher-1) lifts S16's σ*-side
+uniqueness one level deeper to the CANONICAL form:
+`sigmaStar_uniqueness_from_canonical_hypotheses` (Part 26) states
+that any `g : ℕ → ℕ` satisfying `(Hodd)` `g n = σ n` for `¬ 2 ∣ n`,
+`(HtwoPow)` `g (2^k) = 3` for `k ≥ 1`, and STANDARD multiplicativity
+`(Hmul)` `g (m·n) = g m · g n` for coprime `m, n > 0`, equals
+`sigmaStar` on every positive `n`. AXIOM-FREE: does NOT invoke
+`jacobi_r4_formula`. The 8-factor in S16's `(Hmul_σ)`
+(`8·f(m·n) = f m · f n`) is exposed as an artifact of working with
+`f := jacobiR4 = 8·σ*` instead of `σ*` itself; S17 is the conceptual
+primitive that matches Mathlib's `IsMultiplicative` nomenclature.
+Self-validation `sigmaStar_satisfies_canonical_hypotheses` bundles
+`sigmaStar_eq_sigmaOne_of_odd` (Part 6), `sigmaStar_two_pow`
+(Part 13), and `sigmaStar_mul_of_coprime` (Part 12) into the
+3-tuple. +151 lines (2068 → 2219), +2 theorems (121 → 123), 0 new
+axioms, 0 new sorries. Significance: closing the parallel
+`r4Count/8`-side hypotheses axiom-free — i.e., proving `8 ∣ r4Count n`
+plus that the quotient is a standard multiplicative arithmetic
+function satisfying `(Hodd)` and `(HtwoPow)` — would discharge
+`axiom jacobi_r4_formula` via `r4Count = 8·(r4Count/8) = 8·sigmaStar
+= jacobiR4`. The decomposition surface now spans S11.alt (3-hyp
+r4Count-side, PR #17388), S16 (3-hyp σ*-side, PR #17649), and S17
+(3-hyp canonical σ-side, this PR).
+
+S16 (PR #17649, merged) closed the σ*-side atomic-axiom analysis
+with a UNIQUENESS theorem `jacobiR4_uniqueness_from_atomic_hypotheses`. The theorem states that
 any function `f : ℕ → ℕ` satisfying the σ*-side images of S11.alt's
 three atomic axioms — `(Hodd_σ)`, `(HtwoPow_σ)`, and `(Hmul_σ)` — is
 uniquely determined on positive `n` and equals `jacobiR4`. AXIOM-FREE
@@ -292,15 +315,19 @@ Currently still blocked on Mathlib infrastructure:
 
 ## Next Action
 
-0. **(easy, mechanical) S13-implement**: transcribe the
-   `s13-modular-form-atomic-decomposition.md` spec into a new Part 23
-   of `FourSquareDistributionOQ01.lean`: state the two atomic axioms
-   `theta_pow_four_qCoeff` (Hθ4Coef) and `theta_pow_four_eq_eisenstein`
-   (Hθ4Eis) plus the closure-skeleton theorem
-   `jacobi_r4_formula_from_modular_form` with a documented `sorry`
-   body for the Mathlib-API-dependent finite arithmetic step.
-   ~60–80 lines, single session. Defer until file contention
-   subsides (currently 4–5 build-pending PRs).
+0. **(structural, S18 candidate) `r4Count/8` quotient existence.**
+   Prove `8 ∣ r4Count n` for all `0 < n` AXIOM-FREE — i.e., without
+   invoking `jacobi_r4_formula`. This is the divisibility prerequisite
+   for casting the open axiom into S17's canonical σ-side form: if
+   `h₈ : 8 ∣ r4Count n` is axiom-free, then `r4Count/8` is a
+   well-defined `ℕ → ℕ` function, and S17 applied to `g := r4Count/8`
+   (under axiom-free proofs of its three canonical hypotheses) would
+   discharge the open conjecture. The divisibility itself is a
+   classical 4-square-symmetry argument (8 sign-and-permutation
+   automorphisms acting on non-degenerate solutions) but the
+   degenerate-solution census needs care.
+   See Lagrange's four-square theorem variant proofs (Mathlib
+   `Nat.sum_four_squares`) for the action-counting template.
 1. **(opportunistic, σ*-side AND r4Count-side closed)** When Mathlib
    gains q-expansion for `jacobiTheta` / `EisensteinSeries.E₂`, apply
    `r4Count_factorization_form` (S9) directly — the LHS of the

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 2068,
-    "theoremCount": 121,
+    "lineCount": 2219,
+    "theoremCount": 123,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

Part 26 (S17) adds `sigmaStar_uniqueness_from_canonical_hypotheses` — a canonical σ*-side uniqueness theorem with **standard** multiplicativity. Any function `g : ℕ → ℕ` satisfying

* `(Hodd)`     `g n = σ n` for `¬ 2 ∣ n`
* `(HtwoPow)`  `g (2^k) = 3` for `k ≥ 1`
* `(Hmul)`     `g (m·n) = g m · g n` for coprime `m, n > 0`

equals `sigmaStar` on every positive `n`. **Axiom-free**: does not invoke `jacobi_r4_formula`.

## Progress

### Conceptual refinement over S16

S16 (Part 25, PR #17649) proved a parallel uniqueness theorem on `f := jacobiR4 = 8·σ*` whose multiplicativity hypothesis carried an artificial factor of 8:

    8 · f (m·n) = f m · f n   for coprime m, n > 0

The factor of 8 is an artifact: `f 1 = jacobiR4 1 = 8 · 1 = 8`, while standard multiplicative arithmetic functions have `g 1 = 1`. S17 exposes the artifact and lifts the uniqueness one level deeper to the canonical form — matching Mathlib's `IsMultiplicative` nomenclature.

### Files modified

- `proofs/Proofs/FourSquareDistributionOQ01.lean` — Part 26 (+151 lines):
  - `sigmaStar_uniqueness_from_canonical_hypotheses` — main S17 theorem.
  - `sigmaStar_satisfies_canonical_hypotheses` — self-validation bundling `sigmaStar_eq_sigmaOne_of_odd` (Part 6), `sigmaStar_two_pow` (Part 13), `sigmaStar_mul_of_coprime` (Part 12).
  - Two cross-validation `example` blocks: self-specialisation at `g := sigmaStar`, and the definitional bridge `jacobiR4 n = 8 · sigmaStar n`.
- `src/data/proofs/four-square-distribution-oq-01/meta.json` — lineCount 2068 → 2219, theoremCount 121 → 123.
- `research/problems/four-square-distribution-oq-01/state.md` — S17 Phase note + Next Action (S18 = `8 ∣ r4Count n` axiom-free).
- `research/problems/four-square-distribution-oq-01/knowledge.md` — S17 session entry.

### Net delta

- +151 lines, +2 theorems (121 → 123).
- 0 new axioms, 0 new sorries.
- Target axiom (`jacobi_r4_formula`): unchanged.

## Findings

### Reduction frontier

The σ*-side decomposition surface now spans three internally complete forms:

* S11.alt (3-hyp r4Count-side, PR #17388, open): r4Count satisfies `(Hodd_r)`, `(HtwoPow_r)`, `(Hmul_r)` ⇒ r4Count = jacobiR4 on positive n.
* S16 (3-hyp σ*-side, PR #17649, merged): same three hypotheses on abstract `f` ⇒ f = jacobiR4 on positive n.
* S17 (3-hyp canonical σ-side, **this PR**): canonical hypotheses on `g` ⇒ g = sigmaStar on positive n.

### S17 → axiom discharge route

Closing the parallel `r4Count/8`-side hypotheses AXIOM-FREE — i.e., proving `8 ∣ r4Count n` plus that the quotient is a standard multiplicative arithmetic function with `(Hodd)` and `(HtwoPow)` — would discharge `axiom jacobi_r4_formula` via:

    r4Count = 8 · (r4Count/8) = 8 · sigmaStar = jacobiR4.

S18 candidate (state.md Next Action): the divisibility step `8 ∣ r4Count n`, which is a classical 4-square-symmetry argument (8 sign-and-permutation automorphisms).

## Status

**Outcome**: progress — fresh structural theorem, axiom-free.
**Next Steps**: S18 — prove `8 ∣ r4Count n` for `0 < n` axiom-free, casting the open axiom into S17's canonical form.

### Build verification

Skipped locally: `proofs/.lake` self-referential symlink trap (memory `feedback_researcher_lake_symlink_broken.md`) forces a 45+ minute fresh Mathlib clone per Docker build. CI carries the build outcome — title carries `(build pending)` per the S13–S16 precedent (PRs #17515, #17524, #17635, #17649). The S17 proof structurally parallels Part 25's S16 proof (same `Nat.factorization` infrastructure, same case split on parity); structural lemmas referenced (`sigmaStar_factorization_form`, `sigmaStar_eq_sigmaOne_of_odd`, `sigmaStar_two_pow`, `sigmaStar_mul_of_coprime`) are all stable in current `origin/main`.

🤖 Generated by researcher-1