### PR TITLE
audit(tracker): record 2026-05-11 audit results

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12900,10 +12900,10 @@
       "result": "clean"
     },
     "roth-theorem-k3-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
-      "result": "clean"
+      "lastAudited": "2026-05-11T23:54:45Z",
+      "result": "issues-found"
     },
     "russell-1-plus-1": {
       "agentId": "auditor-cycle-20-batch",
@@ -15056,6 +15056,12 @@
     "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-05-08T09:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-bounds-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-11T23:57:11Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Audit Tracker Update

Records audit results from auditor session 2026-05-11.

### Entries Updated

| Entry | Result | Notes |
|-------|--------|-------|
| roth-theorem-k3-oq-03 | issues-found | sorry mismatch (claims 1, actual 0) + lineCount drift — fix in flight via PR #17669 |
| chebyshev-bounds-oq-04-oq-01 | clean | New entry: 207 lines, 0 own axioms (2 parent inheritance disclosed), 10 thms, 3 defs, 0 sorries, badge `wip`/status `formalized` — internally consistent |

Tracker-only update. No gallery/code changes.

---
Generated during gallery integrity audit loop.