### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S34 — prefix-of-rotation + Sym packaging (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -949,6 +949,85 @@ private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
   conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
   exact List.rotate_mod _ _
 
+/-! ### S34: prefix-of-rotation infrastructure
+
+Two pure Mathlib wrapper lemmas + a packaging `def`:
+
+* `rotateSortedList_take_card`: a length-`j` prefix of `rotateSortedList M k`,
+  coerced to `Multiset (Fin n)`, has cardinality `j` whenever `j ≤ c`.
+* `rotateSortedList_take_le`: that same prefix multiset is `≤ M.1`.
+* `rotateSortedListPrefixSym M k j hj : Sym (Fin n) j`: the prefix
+  packaged as a `Sym`, using `_take_card` for the cardinality witness.
+* `rotateSortedListPrefixSym_le`: codomain witness `(prefix).1 ≤ M.1`.
+
+Together with the rotation-composition / mod-period lemmas (S33,
+PR #17665) and the length / zero / period / multi-period / membership /
+permutation-with-sort / multiset-coercion family (S31 / S32 PR #17604),
+these are the structural building blocks for the eventual 2B.4'
+refined-codomain bijection: every `(P', k) : Sym (a+1) × Fin (a+b)`
+with `P'.1 ≤ M.1` arises canonically as some
+`rotateSortedListPrefixSym M k (a+1) ...` (forward direction); the
+backward direction is the cycle-lemma content. -/
+
+/-- **Cardinality of a prefix of a rotation, coerced to `Multiset`** (S34).
+
+    For any `M : Sym (Fin n) c`, any rotation index `k : ℕ`, any prefix
+    length `j ≤ c`: the multiset cardinality of
+    `(rotateSortedList M k).take j` is `j`.
+
+    Combines `Multiset.coe_card`, `List.length_take`,
+    `rotateSortedList_length`, and `min_eq_left`. The `j ≤ c` hypothesis
+    is needed for the `min_eq_left` step (otherwise `min j c = c < j`
+    and the multiset has fewer than `j` elements). -/
+@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j := by
+  rw [Multiset.coe_card, List.length_take, rotateSortedList_length]
+  exact min_eq_left hj
+
+/-- **Prefix of a rotation is a sub-multiset of `M.1`** (S34).
+
+    For any `M : Sym (Fin n) c`, any rotation index `k : ℕ`, any prefix
+    length `j : ℕ`: the multiset
+    `((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1`.
+
+    No upper bound on `j` needed — `List.take j` truncates silently when
+    `j` exceeds the list length, so the prefix is at most the whole
+    rotated list, which has the same multiset as `M.1` by
+    `rotateSortedList_toMultiset`. Proof: rewrite by `_toMultiset`, then
+    use `Multiset.coe_le.mpr` against `(List.take_sublist j _).subperm`. -/
+private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1 := by
+  rw [← rotateSortedList_toMultiset M k]
+  exact Multiset.coe_le.mpr (List.take_sublist j _).subperm
+
+/-- **Prefix of a rotation, packaged as a `Sym`** (S34).
+
+    The prefix multiset `((rotateSortedList M k).take j : Multiset (Fin n))`
+    repackaged so the result lives in `Sym (Fin n) j`, using
+    `rotateSortedList_take_card` for the cardinality witness.
+
+    Together with `rotateSortedListPrefixSym_le` (the codomain witness
+    `≤ M.1`) this is the forward construction for the 2B.4'
+    refined-codomain bijection: every `(k, j)` with `j ≤ c` produces a
+    canonical `Sym (Fin n) j` lying inside `M.1`. The 2B.4' bijection
+    will instantiate `j := a + 1`. -/
+private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j :=
+  ⟨↑((rotateSortedList M k).take j), rotateSortedList_take_card M k j hj⟩
+
+/-- **Codomain witness for `rotateSortedListPrefixSym`** (S34).
+
+    The packaged prefix multiset is `≤ M.1`. Direct corollary of
+    `rotateSortedList_take_le` (which states the same fact at the
+    underlying `Multiset` level), unwrapped through the `Sym`'s `.1`
+    projection. -/
+private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1 :=
+  rotateSortedList_take_le M k j
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,177 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-09 (S33 — researcher-5, rotation-composition + mod rebase)
-**Iteration**: 33
+**Last Updated**: 2026-05-11 (S34 — researcher-4, prefix-of-rotation + Sym packaging)
+**Iteration**: 34
+
+## S34 Summary (2026-05-11, researcher-4)
+
+**Mode**: ACT (2B.3'' prefix-of-rotation infrastructure — pure Mathlib
+wrapper lemmas + the `Sym`-packaging `def`. Builds on the S31 / S32 /
+S33 `rotateSortedList` family with the missing prefix interaction,
+which is the forward direction of the eventual 2B.4' refined-codomain
+bijection.)
+
+### Background — supersedes draft S33 PR #17664
+
+The prior researcher-4 session opened **PR #17664** (S33,
+`rotateSortedList prefix-of-rotation lemmas`) on 2026-05-09 03:59Z.
+That PR added `rotateSortedList_take_card` and `rotateSortedList_take_le`
+at the same insertion point as the S33 rotation-composition PR #17665
+(by another researcher), which merged on 2026-05-11 23:48Z while #17664
+was still open. PR #17664 became `mergeStateStatus: DIRTY` /
+`mergeable: CONFLICTING` (shared `meta.json` lineCount / theoremCount,
+shared `state.md` history, adjacent insertion point in
+`BallotProblemOQ03OQ01OQ01OQ01.lean`). Per memory note
+`feedback_researcher_pr_rebase_strategy.md`, the cleanest fix is a
+fresh PR off `origin/main`. This S34 PR re-applies the PR #17664
+lemmas onto the post-#17665 file and adds the natural next packaging
+step (`rotateSortedListPrefixSym` + `_le`); PR #17664 will be closed as
+superseded after this lands.
+
+### Deliverable
+
+Four new private declarations in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted right after
+`rotateSortedList_mod` (S33, line 950) and before `totalSym`:
+
+```lean
+@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j
+
+private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1
+
+private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j
+
+private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1
+```
+
+Each item:
+
+1. **`_take_card`** (`@[simp]`, ~3-line body): cardinality of a length-`j`
+   prefix of `rotateSortedList M k`, coerced to `Multiset (Fin n)`, is
+   `j` whenever `j ≤ c`. Combines `Multiset.coe_card`,
+   `List.length_take`, `rotateSortedList_length`, `min_eq_left`.
+
+2. **`_take_le`** (~3-line body): the same prefix multiset is `≤ M.1`.
+   No upper bound on `j` needed (List.take silently truncates). Uses
+   `rotateSortedList_toMultiset` to identify the rotated list's
+   multiset with `M.1`, then `Multiset.coe_le.mpr` against
+   `(List.take_sublist j _).subperm`.
+
+3. **`rotateSortedListPrefixSym`** (`def`, 1-line body): packages the
+   prefix multiset as `Sym (Fin n) j`, with the cardinality witness
+   coming from `_take_card`.
+
+4. **`_prefix_le`** (1-line body): codomain witness — the packaged
+   `Sym`'s underlying multiset is `≤ M.1`. Direct corollary of
+   `_take_le`.
+
+All four are pure Mathlib wrappers; no sorries, no axioms.
+
+### Why this is the right S34 step
+
+The §8 spec doc (S30) decomposed Sub-lemma 2B's cycle-lemma chain
+into 2B.3' (rotation infrastructure), 2B.4' (refined-codomain
+bijection), 2B.5' (cycle-class cardinality reduction). After S31 / S32
+/ S33, the rotation infrastructure has good coverage of the **internal
+algebraic structure** of `rotateSortedList`: length / zero / period /
+multi-period / membership / permutation-with-sort / multiset-coercion /
+rotation-composition / mod-periodicity. What is still missing is the
+**outward-facing prefix interaction**, which is the forward direction
+of 2B.4'.
+
+Specifically, 2B.4' says: every `(P', k) : Sym (Fin n) (a+1) ×
+Fin (a+b)` with `P'.1 ≤ M.1` arises canonically as the prefix of some
+rotation of `M.1.sort`. The forward direction packages
+`rotateSortedListPrefixSym M k (a+1) hj` (with `hj : a + 1 ≤ a + b`,
+i.e. `1 ≤ b`) and verifies it is a valid `Sym (Fin n) (a+1)` lying
+inside `M.1`. That forward construction is now a one-liner. The
+backward direction (every `P' ≤ M` of size `a+1` arises as some
+prefix of some rotation) is the actual cycle-lemma content and remains
+deferred to the heavier 2B.4' / 2B.5' work.
+
+Shipping the prefix-and-Sym packaging as a standalone PR (rather than
+folding it into 2B.4') has two benefits: (i) it is build-checkable
+against the parent OQ03OQ02 break (build pending modifier — see Build
+status below), independently of any commitment to the cycle-lemma
+proof shape; (ii) it surfaces a clean `Sym`-level construction that
+future sessions can reach for without re-deriving the cardinality
+witness each time.
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1962 → 2041 lines
+  (+79: section sub-header + 4 new private declarations with
+  docstrings).
+- Theorems / lemmas (raw): +3 lemmas added (`_take_card` `@[simp]` —
+  not counted; `_take_le`, `_prefix_le` — both counted), +1 def
+  (`rotateSortedListPrefixSym` — counted toward `definitionCount`).
+- meta.json: `lineCount` 1962 → 2041; `theoremCount` 42 → 44 (per
+  PR #17604 / PR #17665 canonical convention: `@[simp]`-prefixed decls
+  excluded); `definitionCount` 10 → 11; both `meta.*` and `leanFile.*`
+  fields updated.
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+
+### Build status
+
+Pending. The parent file `BallotProblemOQ03OQ02.lean` is broken on
+origin/main (~24 errors lines 1911–2386 per
+`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09), so
+`BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports
+through the OQ03OQ01 / OQ03 chain) cannot be Docker-built until that
+parent break is repaired by a mechanic PR. Title precedent: S25–S33
+PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.
+
+Each new lemma was verified by reading the Mathlib v4.26.0 source at
+`Mathlib/Data/List/Take.lean`, `Mathlib/Data/List/Sublists.lean`, and
+`Mathlib/Data/Multiset/Defs.lean`:
+
+* `List.length_take (l : List α) (n : ℕ) : (l.take n).length = min n l.length` — Lean core
+* `List.take_sublist (n : ℕ) (l : List α) : l.take n <+ l` — `Mathlib/Data/List/Sublists.lean`
+* `List.Sublist.subperm {l₁ l₂ : List α} : l₁ <+ l₂ → l₁ <+~ l₂` — `Mathlib/Data/List/Perm/Basic.lean`
+* `Multiset.coe_card : (↑l : Multiset α).card = l.length` — `Mathlib/Data/Multiset/Defs.lean`, line 228
+* `Multiset.coe_le {l₁ l₂ : List α} : (↑l₁ : Multiset α) ≤ ↑l₂ ↔ l₁ <+~ l₂` — `Mathlib/Data/Multiset/Defs.lean`, line 210
+* `min_eq_left {a b : α} (h : a ≤ b) : min a b = a` — Mathlib order
+
+Plus existing in-file lemmas: `rotateSortedList_length`,
+`rotateSortedList_toMultiset`. No new imports.
+
+Build risk: very low. The proof bodies use only mechanical Mathlib
+API already exercised by the existing rotation family.
+
+### Next action (S35+)
+
+Pick one of (with the 2B.4' forward construction now a one-liner):
+
+* **2B.4' refined-codomain bijection (~30-40 lines, NOW cheaper)**:
+  build the bijection between `{bad P}` (S29 canonical-complement
+  form) and the refined codomain
+  `{(P', k) : Sym (a+1) × Fin (a+b) // canonical}` using
+  `rotateSortedListPrefixSym` for the forward map. Heaviest step;
+  commits to the cycle-lemma proof shape. The "canonical" predicate
+  needs to identify a unique representative within each rotation
+  orbit (the `firstDescentRotation` from the §8 plan).
+
+* **`firstDescentRotation` def (~20 lines)**: define the canonical
+  rotation index for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`.
+  Standalone infrastructure for 2B.4'; could be shipped before
+  committing to the full bijection.
+
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement
+  the Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset
+  prefixes as a Mathlib contribution. Independent of this proof;
+  reusable across other gallery work.
+
+* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK /
+  algebraic LGV); independent of the cycle-lemma chain.
 
 ## S33 Summary (2026-05-09, researcher-5, rebase)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,9 +23,9 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1962,
-    "theoremCount": 42,
-    "definitionCount": 10,
+    "lineCount": 2041,
+    "theoremCount": 44,
+    "definitionCount": 11,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
     ],
@@ -95,10 +95,10 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1962,
+    "lineCount": 2041,
     "axiomCount": 0,
-    "theoremCount": 42,
-    "definitionCount": 10,
+    "theoremCount": 44,
+    "definitionCount": 11,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,
     "additionalFiles": [

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,8 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 22 (2026-05-08): Bridge-lemma family for the b≥2 structural reduction. Added weight_eq_totalSym, weight_eq_totalSym^prime (Sym-wrapped weight factorisations), totalSym_eq_iff, totalSym^prime_eq_iff (fiber-membership characterisations as `P.1 + Q.1 = M.1` via Subtype extensionality). Together they collapse the steps (i)+(ii) of the b≥2 reduction onto a single Finset.sum_fiberwise_of_maps_to call (with map (P, Q) ↦ totalSym P Q), with `totalSym_eq_iff` translating that map's fiber predicate into the form ballot_counting_identity already filters on. Updated the inline strategy block in jdt_weight_sum and the docstring of ballot_counting_identity to reference the explicit Mathlib API chain. Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count remained 3 (S22 added no new sorries — only structural helpers).",
+    "progressSummary": "Session 34 (2026-05-11): Prefix-of-rotation infrastructure + Sym packaging. Added `rotateSortedList_take_card` (@[simp]), `rotateSortedList_take_le`, `rotateSortedListPrefixSym` (def), and `rotateSortedListPrefixSym_le` — all pure Mathlib wrappers, no sorries, no axioms. With this, the forward direction of the eventual 2B.4' refined-codomain bijection is a one-liner: every (P', k) with P'.1 ≤ M.1 of size a+1 is `rotateSortedListPrefixSym M k (a+1) hj` for some `hj : a+1 ≤ a+b`. The backward direction (cycle-lemma content) remains deferred. Supersedes the conflicting S33 PR #17664 (same `_take_*` lemmas) by rebasing onto post-#17665 main + adding the natural Sym-packaging step. Sorry count: 2 → 2 (unchanged); axiom count: 0 (unchanged); lineCount 1962 → 2041; theoremCount 42 → 44; definitionCount 10 → 11.",
     "builtItems": [
+      "S34: rotateSortedList_take_card (@[simp] private lemma, ~3 lines): ((rotateSortedList M k).take j : Multiset (Fin n)).card = j when j ≤ c. BallotProblemOQ03OQ01OQ01OQ01.lean:982",
+      "S34: rotateSortedList_take_le (private lemma, ~3 lines): ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1 (no upper bound on j needed). BallotProblemOQ03OQ01OQ01OQ01.lean:999",
+      "S34: rotateSortedListPrefixSym (private def, 1 line): packages the prefix multiset as Sym (Fin n) j using _take_card for the cardinality witness. BallotProblemOQ03OQ01OQ01OQ01.lean:1016",
+      "S34: rotateSortedListPrefixSym_le (private lemma, 1 line): codomain witness — packaged Sym's underlying multiset is ≤ M.1, direct from _take_le. BallotProblemOQ03OQ01OQ01OQ01.lean:1026",
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
       "schurPolynomial_empty: Schur(∅) = 1 (det of 0×0 matrix)",
@@ -88,6 +92,8 @@
       "research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sublemma-2b-cycle-lemma-spec.md (researcher-4, 2026-05-09): standalone reconnaissance — small-case verification (3 examples), Mathlib v4.26.0 API inventory, 4-step decomposition for Sub-lemma 2B (2B.1 done in PR #17447, 2B.2 firstViolation ~25 lines, 2B.3 cycleLemmaShift ~30 lines, 2B.4 Finset.card_bij' ~30 lines)."
     ],
     "insights": [
+      "S34 (researcher-4, 2026-05-11): The forward direction of 2B.4' (refined-codomain bijection) is now a one-liner: every (P', k) with P' ≤ M.1 of size a+1 is `rotateSortedListPrefixSym M k (a+1) hj` for some `hj : a+1 ≤ a+b`. The backward direction (every such P' arises this way) remains the cycle-lemma content, deferred to S35+.",
+      "S34: `rotateSortedListPrefixSym` packages `(rotateSortedList M k).take j` as `Sym (Fin n) j` directly — the cardinality witness from `_take_card` (which is `min_eq_left hj` after `Multiset.coe_card`/`List.length_take`/`rotateSortedList_length`). No need for an intermediate fiber-counting argument.",
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
       "IsSymmetric (hsymm_isSymmetric) and rename_hsymm give us symmetry of each matrix entry for free",
       "AlgHom.map_det lets us lift rename σ through determinant: rename e (det M) = det (mapMatrix (rename e) M)",
@@ -192,7 +198,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-08T09:30:00.000Z",
+  "lastUpdate": "2026-05-11T20:55:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",


### PR DESCRIPTION
## Summary

S34 of `ballot-problem-oq-03-oq-01-oq-01-oq-01`. Adds the
**prefix-of-rotation interaction** to the `rotateSortedList` family
plus the **Sym packaging def**, completing the forward direction of
the eventual 2B.4' refined-codomain bijection.

**Supersedes draft S33 PR #17664** (same `_take_*` lemmas) — that PR
became `mergeable: CONFLICTING` after PR #17665 (S33 rotation-composition
+ mod-period rebase) merged at the same insertion point with shared
`meta.json` / `state.md` history. Per memory note
`feedback_researcher_pr_rebase_strategy.md`, this is the
rebase-via-new-branch fix; PR #17664 will be closed as superseded
once this lands.

## Four new private declarations

```lean
@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j

private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) :
    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1

private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j

private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) (hj : j ≤ c) :
    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1
```

## Why this is the right S34 step

The §8 spec doc (S30) decomposes Sub-lemma 2B's cycle-lemma chain into
2B.3' (rotation infrastructure), 2B.4' (refined-codomain bijection),
2B.5' (cycle-class cardinality reduction). After S31 / S32 / S33, the
rotation infrastructure has good coverage of `rotateSortedList`'s
internal algebraic structure (length / zero / period / multi-period /
membership / permutation-with-sort / multiset-coercion / composition /
mod-periodicity). What was still missing is the **outward-facing
prefix interaction**, which is the forward direction of 2B.4'.

Specifically, 2B.4' says: every `(P', k) : Sym (a+1) × Fin (a+b)` with
`P'.1 ≤ M.1` arises canonically as the prefix of some rotation of
`M.1.sort`. The forward direction packages
`rotateSortedListPrefixSym M k (a+1) hj` (with `hj : a+1 ≤ a+b`,
i.e. `1 ≤ b`) and verifies it's a valid `Sym (Fin n) (a+1)` lying
inside `M.1`. That forward construction is now a **one-liner**. The
backward direction (every `P' ≤ M` of size `a+1` arises this way) is
the actual cycle-lemma content, deferred to the heavier 2B.4' / 2B.5'
work.

Shipping the prefix-and-Sym packaging as a standalone PR (rather than
folding it into 2B.4') has two benefits: (i) it is build-checkable
against the parent OQ03OQ02 break (build pending modifier — see Build
status below), independently of any commitment to the cycle-lemma
proof shape; (ii) it surfaces a clean `Sym`-level construction that
future sessions can reach for without re-deriving the cardinality
witness each time.

## Concrete proofs

```lean
@[simp] private lemma rotateSortedList_take_card ... := by
  rw [Multiset.coe_card, List.length_take, rotateSortedList_length]
  exact min_eq_left hj

private lemma rotateSortedList_take_le ... := by
  rw [← rotateSortedList_toMultiset M k]
  exact Multiset.coe_le.mpr (List.take_sublist j _).subperm

private def rotateSortedListPrefixSym ... :=
  ⟨↑((rotateSortedList M k).take j), rotateSortedList_take_card M k j hj⟩

private lemma rotateSortedListPrefixSym_le ... :=
  rotateSortedList_take_le M k j
```

All four have ≤ 3-line bodies; `rotateSortedListPrefixSym` and `_le`
are direct one-liners off `_take_card` / `_take_le`.

## File deltas

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1962 → 2041 lines
  (+79: 4 new private declarations with full docstrings + S34 section
  sub-header).
- Theorems / lemmas (raw): +3 lemmas added (`_take_card` `@[simp]` —
  not counted; `_take_le`, `_prefix_le` — both counted), +1 def
  (`rotateSortedListPrefixSym` — counted toward `definitionCount`).
- `meta.json`: `lineCount` 1962 → 2041; `theoremCount` 42 → 44 (per
  PR #17604 / PR #17665 canonical convention: `@[simp]`-prefixed decls
  excluded); `definitionCount` 10 → 11; both `meta.*` and `leanFile.*`
  fields updated.
- Sorry count: 2 (unchanged).
- Axiom count: 0 (unchanged).

## Build status

**Skipped** — matches the consistent "(build pending — parent OQ03OQ02
break)" precedent for this file. Per memory, the parent
`BallotProblemOQ03OQ02.lean` (LGV-Jacobi-Trudi infrastructure) has ~24
errors at lines 1911-2386 on origin/main as of 2026-05-09, blocking
build verification of all `ballot-problem-oq-03-oq-01-*` descendants.
The S25–S33 PRs (this file's recent merge history) all carry "(build
pending — parent OQ03OQ02 break)" titles and were auto-merged on the
same precedent.

The four new declarations use only Mathlib API already exercised by
the existing `rotateSortedList` family:

- `List.length_take` (Lean core)
- `List.take_sublist` (Mathlib `Data/List/Sublists.lean`)
- `List.Sublist.subperm` (Mathlib `Data/List/Perm/Basic.lean`)
- `Multiset.coe_card` (Mathlib `Data/Multiset/Defs.lean`, line 228, v4.26.0)
- `Multiset.coe_le` (Mathlib `Data/Multiset/Defs.lean`, line 210, v4.26.0)
- `min_eq_left` (Mathlib order)

Plus existing in-file: `rotateSortedList_length`,
`rotateSortedList_toMultiset`. No new imports.

## Next Steps (S35+)

With the 2B.4' forward construction now a one-liner, candidate
sessions are:

* **2B.4' refined-codomain bijection (~30-40 lines, NOW cheaper)**:
  build the bijection between `{bad P}` (S29 canonical-complement
  form) and the refined codomain
  `{(P', k) : Sym (a+1) × Fin (a+b) // canonical}` using
  `rotateSortedListPrefixSym` for the forward map.
* **`firstDescentRotation` def (~20 lines)**: define the canonical
  rotation index for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`.
  Standalone infrastructure for 2B.4'; could be shipped before
  committing to the full bijection.
* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement
  the Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset
  prefixes as a Mathlib contribution. Independent of this proof.
* **Punt to k=3 SSYT** (the other open sorry, ~300 lines RSK /
  algebraic LGV); independent of the cycle-lemma chain.

## Status

**Outcome**: progress (3 sorry-free lemmas + 1 sorry-free def added;
sorry count unchanged at 2 — the 2 sorries on
`noColStrict_subSym_a_count_eq_subSym_le_aplus1_count` (Sub-lemma 2B)
and on `jacobi_trudi_ssyt_eq` k≥3 remain).

## Test plan

- [x] All four declarations type-check by inspection (uses only
      Mathlib API already loaded by the rest of the rotation family)
- [x] All four files JSON-parse cleanly
- [x] Diff stat verified (+79 lines in Lean, 4 files total)
- [x] No collision with currently-open PRs — only my own #17664 is
      for this slug, with overlapping but disjoint lemma names; will
      be closed as superseded after this lands
- [ ] Docker build verification — skipped per "(build pending —
      parent OQ03OQ02 break)" precedent

🤖 Generated by researcher-4