### PR TITLE
fix(meta): sync amgm + minkowski lineCount/theoremCount drift

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,8 +20,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1428,
-    "theoremCount": 46,
+    "lineCount": 1559,
+    "theoremCount": 47,
     "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
     "mathlib_version": "4.26.0"
@@ -176,9 +176,9 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 1428,
+    "lineCount": 1559,
     "axiomCount": 1,
-    "theoremCount": 46,
+    "theoremCount": 47,
     "definitionCount": 10,
     "path": "Proofs/AmgmInequalityOQ04OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 714,
-    "theoremCount": 10,
+    "lineCount": 921,
+    "theoremCount": 15,
     "definitionCount": 0,
     "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Status flag remains `axiomatized` and badge remains `axiom` pending Docker CI verification of the post-S14 source \u2014 the broken `proofs/.lake` recursive self-symlink in this repo forces every full build into a 30\u201345 min Mathlib refetch, so build verification is gated on a separate Mechanic infra-repair pass. Once CI confirms a green build, the entry will graduate to status `verified` / badge `original` via a follow-up Mechanic/Auditor PR. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
     "dateAdded": "2026-05-07",
@@ -170,8 +170,8 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 714,
-    "theoremCount": 10,
+    "lineCount": 921,
+    "theoremCount": 15,
     "definitionCount": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Fix

Two gallery entries had stale `lineCount` and `theoremCount` after recent research PRs grew the underlying Lean files.

### `amgm-inequality-oq-04-oq-02`
- `lineCount`: 1428 → 1559 (+131)
- `theoremCount`: 46 → 47

File `Proofs/AmgmInequalityOQ04OQ02.lean` grew through S6–S9 research merges (PRs that landed dE/dk and complModulus boundary helpers). Active research PRs #17371, #17445, #17477 sit on top of origin/main but the meta values were never bumped.

### `minkowski-theorem-oq-04`
- `lineCount`: 714 → 921 (+207)
- `theoremCount`: 10 → 15

File `Proofs/MinkowskiTheoremOQ04.lean` grew significantly through merged iter-N research PRs (blichfeldt_general, minkowski_general_k, finset/pairwise variants). Five new theorems were added: `blichfeldt_general_pairwise`, `blichfeldt_general_finset`, `minkowski_general_k_pairwise`, `minkowski_general_k_finset`, `minkowski_four_points`.

## Evidence

Verified actual decl counts via Python comment-stripper (nested block-comment aware, string-literal aware, processes `--` line comments before `/-` block-opens per `feedback_mechanic_comment_stripper_line_first` lesson) + regex from PR #17518 pattern:

```
amgm-inequality-oq-04-oq-02: lineCount lf=1428 actual=1559 ; theoremCount lf=46 actual=47
minkowski-theorem-oq-04:     lineCount lf=714  actual=921  ; theoremCount lf=10 actual=15
```

`definitionCount`, `axiomCount`, and `sorries` all already match — no drift on those dimensions for either entry.

Both files updated in two places each (`meta.*` and `leanFile.*`) via surgical string replacement to preserve formatting. Diff: `2 files changed, 8 insertions(+), 8 deletions(-)`.

Excludes 40 entries already covered by open PR #17672 (lineCount +1 batch).

---
Automated fix by lean-mechanic agent.