### PR TITLE
fix(meta): sync hilbert-10 + roth-theorem-k3-oq-03 lineCount/theoremCount drift

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -124,7 +124,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 2266,
+    "lineCount": 2423,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -132,7 +132,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 79,
+    "theoremCount": 81,
     "definitionCount": 15
   },
   "overview": {
@@ -265,9 +265,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 2266,
+    "lineCount": 2423,
     "axiomCount": 1,
-    "theoremCount": 79,
+    "theoremCount": 81,
     "definitionCount": 15,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
     "assumptions": "2 axioms: density_increment_kAP (density increases on subprogression, AP-free preserved) declared in this file; szemeredi_k_ge_4 inherited transitively via Proofs.SzemerediTheorem. gowersNorm and kAPCount constructive.",
-    "lineCount": 420,
+    "lineCount": 419,
     "theoremCount": 9,
     "definitionCount": 5,
     "additionalFiles": [
@@ -123,7 +123,7 @@
   },
   "leanFile": {
     "axiomCount": 1,
-    "lineCount": 420,
+    "lineCount": 419,
     "path": "Proofs/RothTheoremOQ03.lean",
     "sorries": 0,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Two gallery entries with stale numeric drift.

### `hilbert-10-oq-01-oq-02`
- `lineCount`: 2266 → 2423 (+157)
- `theoremCount`: 79 → 81 (+2)

PR #17638 (2026-05-09) synced the prior drift to 2266/79. Subsequent merged PR #17676 (Iter 21, "sigma2/pi2 list-arity closures (build pending)") added 157 lines and two new theorems but did not bump `meta.json`:

- `sigma2_intersectionList_isExistentialUniversalDefinition`
- `pi2_unionList_isUniversalExistentialDefinition`

Open research PRs #17456 / #17552 / #17602 sit on top of origin/main and may bump these again — this PR syncs to the current `origin/main` only.

### `roth-theorem-k3-oq-03`
- `lineCount`: 420 → 419 (-1)

Auditor PR #17669 (just merged 2026-05-11) set `lineCount: 420`, but `wc -l proofs/Proofs/RothTheoremOQ03.lean` on `origin/main` reports 419 (file ends with a trailing newline). Likely a 1-off in the auditor's count of the post-PR-#17660 file.

Other count fields (`axiomCount`, `definitionCount`, `theoremCount`, `sorries`) already match — no drift on those dimensions.

## Evidence

Verified via the PR #17518/#17569 Python comment-stripper (nested block-comment aware, line-comment-first per `feedback_mechanic_comment_stripper_line_first` lesson):

```
hilbert-10-oq-01-oq-02: lf=2266/79 actual=2423/81 (lineCount/theoremCount)
roth-theorem-k3-oq-03: lf=420 actual=419 (lineCount)
```

Diff stat: `2 files changed, 6 insertions(+), 6 deletions(-)`.

Both files edited in two places each (`meta.*` + `leanFile.*`) via surgical string replacement to preserve JSON formatting.

Excludes `amgm-inequality-oq-04-oq-02` and `minkowski-theorem-oq-04` — both already covered by open PR #17681.

---
Automated fix by lean-mechanic agent.