### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): Iter 2 — prime values (build pending)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
@@ -7,17 +7,27 @@
   function) elementarily, removing the axiom `chebyshevPsi_asymptotic`
   from `ChebyshevBoundsOQ04.lean`.
 
-  ## Status: Iteration 1 / OBSERVE
+  ## Status: Iteration 2 / ACT
 
-  This file scaffolds the Selberg-Erdős 1949 elementary proof strategy.
-  Concretely, it:
+  Iter 1 scaffolded the Selberg-Erdős 1949 elementary proof strategy
+  (Λ₂ and S₂ definitions, non-negativity, monotonicity, base values
+  at 0 and 1). Iter 2 adds the **prime-case lemmas**:
 
-  - Defines the Selberg auxiliary function
+  - `vonMangoldtConv_prime`: `(Λ ∗ Λ)(p) = 0` for prime `p`.
+  - `selbergLambda2_prime`: `Λ₂(p) = (log p)²` for prime `p`.
+  - `selbergSum2_one`: `S₂(1) = 0` (both summands `Λ₂(0)` and `Λ₂(1)`
+    vanish).
+  - `selbergSum2_two`: `S₂(2) = (log 2)²` (the first non-zero value of
+    the partial sum, via `selbergLambda2_prime Nat.prime_two`).
+
+  Definitions and roadmap from iter 1:
+
+  - The Selberg auxiliary function
         Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n),
     where Λ ∗ Λ denotes Dirichlet convolution.
-  - Defines the Selberg partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n).
-  - Proves routine non-negativity, base-value, and monotonicity lemmas.
-  - Documents the elementary-PNT roadmap and identifies Mathlib gaps.
+  - The Selberg partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n).
+  - Routine non-negativity, base-value, and monotonicity lemmas.
+  - The elementary-PNT roadmap and identified Mathlib gaps.
 
   No new axioms are added; the parent file's `chebyshevPsi_asymptotic`
   axiom remains the open target.
@@ -147,6 +157,44 @@ theorem selbergLambda2_nonneg (n : ℕ) : 0 ≤ selbergLambda2 n := by
   · exact mul_nonneg vonMangoldt_nonneg
       (Real.log_nonneg (by exact_mod_cast h))
 
+/-! ### Prime values
+
+For a prime `p` the divisor sum `(Λ ∗ Λ)(p)` collapses: the only
+divisors are `1` and `p`, and `Λ(1) = 0` annihilates both cross terms.
+Consequently `Λ₂(p)` reduces to the single summand `Λ(p) · log p`, which
+is `(log p)²` by `vonMangoldt_apply_prime`.
+
+These are the iter-2 deliverables flagged as routine in the iter-1
+roadmap (items 1 and 2 of the "Future Work" list). They are the first
+non-zero base-case values of `Λ₂`, and together with the `S₂` recurrence
+established in iter 1 they yield the first non-trivial values of the
+partial Selberg sum (`selbergSum2_two` below). -/
+
+/-- Iter 2: `(Λ ∗ Λ)(p) = 0` for any prime `p`.
+
+    The divisor set is `divisors p = {1, p}` (`Nat.Prime.divisors`), so
+    the convolution expands to two terms:
+      * `d = 1`: `Λ(1) · Λ(p)`. Annihilated by `vonMangoldt_apply_one`.
+      * `d = p`: `Λ(p) · Λ(p / p) = Λ(p) · Λ(1)`. Same annihilator.
+    The Finset sum `Finset.sum_pair` requires `1 ≠ p`, supplied by
+    `hp.one_lt.ne`. No new imports. -/
+theorem vonMangoldtConv_prime {p : ℕ} (hp : Nat.Prime p) :
+    vonMangoldtConv p = 0 := by
+  unfold vonMangoldtConv
+  rw [Nat.Prime.divisors hp, Finset.sum_pair hp.one_lt.ne]
+  simp [vonMangoldt_apply_one, Nat.div_self hp.pos]
+
+/-- Iter 2: `Λ₂(p) = (log p)²` for any prime `p`.
+
+    Immediate from `vonMangoldtConv_prime hp` (annihilates the
+    convolution summand) and `vonMangoldt_apply_prime hp` (rewrites
+    `Λ(p) = log p`, so the first summand becomes `log p · log p`). -/
+theorem selbergLambda2_prime {p : ℕ} (hp : Nat.Prime p) :
+    selbergLambda2 p = (Real.log p) ^ 2 := by
+  unfold selbergLambda2
+  rw [vonMangoldtConv_prime hp, vonMangoldt_apply_prime hp]
+  ring
+
 /-! ### Partial sum properties -/
 
 /-- `S₂(0) = 0`: the only term is `Λ₂(0) = 0`. -/
@@ -176,28 +224,59 @@ theorem selbergSum2_mono : Monotone selbergSum2 := by
   · intro k _ _
     exact selbergLambda2_nonneg k
 
+/-- Iter 2: `S₂(1) = 0`. Both summands `Λ₂(0)` and `Λ₂(1)` vanish, so
+    the partial sum is `0`.
+
+    The first non-zero value of `S₂` occurs at `N = 2`, as recorded by
+    `selbergSum2_two` below. This places the support of the Selberg
+    sequence `(S₂(N))_{N ≥ 0}` precisely on `N ≥ 2`. -/
+theorem selbergSum2_one : selbergSum2 1 = 0 := by
+  have h : selbergSum2 1 = selbergSum2 0 + selbergLambda2 1 :=
+    selbergSum2_succ 0
+  rw [h, selbergSum2_zero, selbergLambda2_one]
+  ring
+
+/-- Iter 2: `S₂(2) = (log 2)²`.
+
+    The first non-zero value of the partial Selberg sum. Computation:
+    `S₂(2) = S₂(1) + Λ₂(2) = 0 + (log 2)²` by `selbergSum2_succ`,
+    `selbergSum2_one`, and `selbergLambda2_prime Nat.prime_two`. -/
+theorem selbergSum2_two : selbergSum2 2 = (Real.log 2) ^ 2 := by
+  have h : selbergSum2 2 = selbergSum2 1 + selbergLambda2 2 :=
+    selbergSum2_succ 1
+  rw [h, selbergSum2_one, selbergLambda2_prime Nat.prime_two]
+  ring
+
 /-! ## Future Work
 
-The next-iteration deliverables are, in order of increasing difficulty:
+Iter-2 status:
 
-1. **`vonMangoldtConv_prime`**: `(Λ ∗ Λ)(p) = 0` for prime `p`. Routine
-   from `Nat.Prime.divisors`.
+- ✅ **`vonMangoldtConv_prime`**: `(Λ ∗ Λ)(p) = 0` for prime `p`.
+  Discharged via `Nat.Prime.divisors` + `Finset.sum_pair`.
+- ✅ **`selbergLambda2_prime`**: `Λ₂(p) = (log p)²`. Discharged via
+  `vonMangoldtConv_prime` + `vonMangoldt_apply_prime`.
+- ✅ **`selbergSum2_one`** / **`selbergSum2_two`**: first non-trivial
+  partial-sum values (`S₂(1) = 0`, `S₂(2) = (log 2)²`).
 
-2. **`selbergLambda2_prime`**: `Λ₂(p) = (log p)²`. Direct from (1) and
-   `vonMangoldt_apply_prime`.
+Remaining deliverables in order of increasing difficulty:
 
-3. **`selbergLambda2_eq_moebius_log_sq`**: the identity
+1. **`vonMangoldtConv_prime_pow`**: `(Λ ∗ Λ)(p^k) = (k-1) · (log p)²`
+   for prime `p` and `k ≥ 1`. Generalizes `vonMangoldtConv_prime`
+   (k = 1 case) via `Nat.divisors_prime_pow` and a small Finset sum
+   over `range (k+1)`. Routine.
+
+2. **`selbergLambda2_eq_moebius_log_sq`**: the identity
         Λ₂(n) = Σ_{d ∣ n} μ(d) · (log (n/d))²    (n ≥ 1).
    Provable from the Mathlib `moebius_mul_coe_zeta` machinery once one
    knows Λ = μ ∗ log (the standard expansion).
 
-4. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula
+3. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula
         S₂(N) = 2 N · log N + O(N).
    This is the central identity. The error-term step requires summation
    by parts and quantitative control of Σ_{d ≤ x} μ(d) — but only its
    `O(x)` form, which is well within elementary bounds.
 
-5. **Tauberian step → PNT**: Erdős–Selberg's combinatorial finishing
+4. **Tauberian step → PNT**: Erdős–Selberg's combinatorial finishing
    argument, the longest part of the elementary proof.
 
 The total estimated formalization size is several thousand lines, but


### PR DESCRIPTION
## Summary

Iteration 2 of `chebyshev-bounds-oq-04-oq-01` (toward an elementary PNT a la Selberg–Erdős 1949). Closes items 1 and 2 of the explicit roadmap recorded in iter 1's "Future Work" block (PR #17658).

This PR delivers the **prime-case values** of Selberg's auxiliary function `Λ₂` and its constituent Dirichlet convolution `Λ ∗ Λ`, plus the first two non-trivial values of the partial Selberg sum `S₂`.

## What's New

### `vonMangoldtConv_prime` — `(Λ ∗ Λ)(p) = 0` for prime p

Direct expansion of the divisor sum: `Nat.Prime.divisors hp` gives `p.divisors = {1, p}`; `Finset.sum_pair` splits the sum into the two divisor cases; both cross terms vanish by `vonMangoldt_apply_one` (`Λ(1) = 0`).

### `selbergLambda2_prime` — `Λ₂(p) = (log p)²` for prime p

Immediate from `vonMangoldtConv_prime hp` (annihilates the convolution summand) and `vonMangoldt_apply_prime hp` (rewrites `Λ(p) = log p`), so `Λ₂(p) = log p · log p + 0 = (log p)²`.

### `selbergSum2_one` — `S₂(1) = 0`

Both `Λ₂(0)` and `Λ₂(1)` vanish (`selbergLambda2_zero`, `selbergLambda2_one` from iter 1), so the partial sum at `N = 1` is `0`. This pins the support of the Selberg sequence `(S₂(N))_{N ≥ 0}` to `N ≥ 2`.

### `selbergSum2_two` — `S₂(2) = (log 2)²`

First non-zero value of the partial sum. By `selbergSum2_succ`, `S₂(2) = S₂(1) + Λ₂(2) = 0 + (log 2)²` via `selbergLambda2_prime Nat.prime_two`.

## Mathlib API surface

**ZERO new imports, ZERO new lemmas.** Reuses only:
- `Nat.Prime.divisors hp` — `p.divisors = {1, p}` (used in `Erdos893Problem`, `Erdos975Problem`, `Erdos673Aristotle`, `Erdos1060Problem`, `FourSquareDistributionOQ01`).
- `Finset.sum_pair` — pair-sum splitter (used in `Erdos321Problem`, `Erdos839Problem`, `Erdos358Problem`, `SpernerNDimMathlib`, `BinomialTheoremOQ02OQ01OQ02`).
- `vonMangoldt_apply_one` — `Λ(1) = 0` (used in `BoundedPrimeGapsOQ04` and the iter-1 base-value lemmas in this very file).
- `vonMangoldt_apply_prime hp` — `Λ(p) = log p` for prime p (used in `ChebyshevBoundsOQ04` parent file, `RiemannHypothesisConsequences`).
- `Nat.div_self hp.pos`, `Nat.prime_two`, `hp.one_lt.ne` (standard).

All Mathlib lemmas referenced are in active use elsewhere in this repo (confirmed by grep).

## Significance

These four small lemmas establish the **first non-zero base cases** of the Selberg auxiliary sequence and pin down the support of `(S₂(N))`. They form the inductive foundation for the next milestone (`vonMangoldtConv_prime_pow`: `(Λ ∗ Λ)(p^k) = (k-1)·(log p)²`), which in turn feeds into the Möbius–log identity `Λ₂(n) = Σ_{d ∣ n} μ(d)·log²(n/d)` (iter-roadmap item 3) and ultimately Selberg's symmetry formula `S₂(N) = 2N·log N + O(N)` (item 4).

The iter-1 file header status is bumped from "Iteration 1 / OBSERVE" to "Iteration 2 / ACT" and the "Future Work" block is updated: items 1 and 2 are marked done; the remaining four steps are re-enumerated.

## Counts (post-PR)

- `lineCount`: 206 → 283 (+77)
- `theoremCount`: 10 → 14 (+4)
- `definitionCount`: 3 (unchanged: `vonMangoldtConv`, `selbergLambda2`, `selbergSum2`)
- `axiomCount`: 0 (unchanged)
- `sorries`: 0 (unchanged)

No new axioms are added; the parent file's `chebyshevPsi_asymptotic` axiom (the OPEN target) remains untouched.

`meta.json` not updated this PR (state.md does not yet exist for this slug; meta sync deferred to mechanic).

## Build

**Pending.** Worktree's `proofs/.lake` is a recursive self-symlink (per memory note `feedback_researcher_lake_symlink_broken.md`), so a local Docker build re-fresh-clones Mathlib (~30-45 min). CI is the ground truth.

**Confidence: high.** All Mathlib references are in active repo use; the proofs are 2-5 lines each, no new tactics, no new imports. The `selbergSum2_one` / `selbergSum2_two` proofs use the `have h := selbergSum2_succ 0` (resp. `1`) pattern which side-steps the `0+1` vs `1` defeq surface issue (Lean's elaborator unifies `selbergSum2 (N+1)` with `selbergSum2 N+1` for concrete N via defeq during type-ascription).

## Test plan

- [x] All 4 new theorems and 0 new definitions type-check (review-time inspection vs known-good Mathlib API)
- [x] No new sorries, no new axioms (`grep -c sorry` → 0; `grep -c '^axiom '` → 0, both unchanged from iter 1)
- [x] Branched cleanly off fresh `origin/main` post-`#17674`/`#17678` merges
- [ ] CI: Docker build of `Proofs.ChebyshevBoundsOQ04OQ01` after this PR merges
- [ ] After landing, mechanic sync of `meta.json` to reflect iter 2 counts (theoremCount 14, lineCount 283)

## Status

**Outcome**: progress — closes iter-1 roadmap items 1 and 2 with 4 clean axiom-free, sorry-free theorems. The Selberg sequence `(S₂(N))_{N ≥ 0}` is now fully computable up to `N = 2`.

**Next Steps**:
1. CI build verification.
2. **Iter 3**: `vonMangoldtConv_prime_pow` (general `(Λ ∗ Λ)(p^k) = (k-1)·(log p)²`) via `Nat.divisors_prime_pow` + small Finset sum on `range (k+1)`.
3. **Iter 4**: Möbius–log identity `Λ₂(n) = Σ_{d ∣ n} μ(d)·log²(n/d)` (n ≥ 1) — the start of the Selberg symmetry formula's algebraic substrate.
4. **Iter 5+**: Selberg's symmetry formula `S₂(N) = 2N·log N + O(N)` (the central identity), then the Tauberian step → PNT.

🤖 Generated by researcher-8