### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): Iter 2 — prime-value lemmas (build pending)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
@@ -176,31 +176,55 @@ theorem selbergSum2_mono : Monotone selbergSum2 := by
   · intro k _ _
     exact selbergLambda2_nonneg k
 
+/-! ### Prime values
+
+For prime `p`, `(Λ ∗ Λ)(p) = 0` (the only divisors of `p` are `1` and
+`p`, and each summand contains a factor `Λ(1) = 0`). Combined with
+`Λ(p) = log p`, this gives the clean closed form `Λ₂(p) = (log p)²`,
+the simplest non-trivial value of the auxiliary function. -/
+
+/-- `(Λ ∗ Λ)(p) = 0` for every prime `p`. The sum over `p.divisors =
+    {1, p}` is `Λ(1)·Λ(p) + Λ(p)·Λ(1) = 0`. -/
+theorem vonMangoldtConv_prime (p : ℕ) (hp : Nat.Prime p) :
+    vonMangoldtConv p = 0 := by
+  unfold vonMangoldtConv
+  rw [Nat.divisors_prime hp]
+  have hne : (1 : ℕ) ≠ p := hp.one_lt.ne
+  rw [Finset.sum_pair hne]
+  rw [Nat.div_one, Nat.div_self hp.pos, vonMangoldt_apply_one]
+  ring
+
+/-- `Λ₂(p) = (log p)²` for every prime `p`. The first summand contributes
+    `Λ(p)·log p = (log p)²` (by `vonMangoldt_apply_prime`) and the
+    convolution summand vanishes (by `vonMangoldtConv_prime`). -/
+theorem selbergLambda2_prime (p : ℕ) (hp : Nat.Prime p) :
+    selbergLambda2 p = (Real.log p) ^ 2 := by
+  unfold selbergLambda2
+  rw [vonMangoldtConv_prime p hp, vonMangoldt_apply_prime hp]
+  ring
+
 /-! ## Future Work
 
-The next-iteration deliverables are, in order of increasing difficulty:
+The remaining next-iteration deliverables are, in order of increasing
+difficulty:
 
-1. **`vonMangoldtConv_prime`**: `(Λ ∗ Λ)(p) = 0` for prime `p`. Routine
-   from `Nat.Prime.divisors`.
-
-2. **`selbergLambda2_prime`**: `Λ₂(p) = (log p)²`. Direct from (1) and
-   `vonMangoldt_apply_prime`.
-
-3. **`selbergLambda2_eq_moebius_log_sq`**: the identity
+1. **`selbergLambda2_eq_moebius_log_sq`**: the identity
         Λ₂(n) = Σ_{d ∣ n} μ(d) · (log (n/d))²    (n ≥ 1).
    Provable from the Mathlib `moebius_mul_coe_zeta` machinery once one
    knows Λ = μ ∗ log (the standard expansion).
 
-4. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula
+2. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula
         S₂(N) = 2 N · log N + O(N).
    This is the central identity. The error-term step requires summation
    by parts and quantitative control of Σ_{d ≤ x} μ(d) — but only its
    `O(x)` form, which is well within elementary bounds.
 
-5. **Tauberian step → PNT**: Erdős–Selberg's combinatorial finishing
+3. **Tauberian step → PNT**: Erdős–Selberg's combinatorial finishing
    argument, the longest part of the elementary proof.
 
-The total estimated formalization size is several thousand lines, but
-each step decomposes into Mathlib-friendly pieces. -/
+Iteration 2 (this commit) closes the easy prime-value lemmas
+`vonMangoldtConv_prime` and `selbergLambda2_prime`. The total estimated
+formalization size for the remaining roadmap is several thousand lines,
+but each step decomposes into Mathlib-friendly pieces. -/
 
 end ChebyshevBoundsOQ04OQ01

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
@@ -2,7 +2,7 @@
     "id": "chebyshev-bounds-oq-04-oq-01",
     "title": "Toward an Elementary PNT (Selberg-Erdős): Λ₂ Framework",
     "slug": "chebyshev-bounds-oq-04-oq-01",
-    "description": "The OQ-04-OQ-01 follow-up question asks whether the axiom chebyshevPsi_asymptotic (ψ(n)/n → 1) of ChebyshevBoundsOQ04.lean can be discharged elementarily, in the spirit of Selberg's and Erdős's 1949 proofs of the Prime Number Theorem without complex analysis. This iteration scaffolds the Selberg-Erdős strategy: it defines the auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n), the partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n), and proves routine non-negativity, base-value, and monotonicity lemmas. The Lean file is axiom-free and adds 0 sorries, but does not yet attempt the central Selberg symmetry formula — that is left as the next-iteration target with a documented roadmap.",
+    "description": "The OQ-04-OQ-01 follow-up question asks whether the axiom chebyshevPsi_asymptotic (ψ(n)/n → 1) of ChebyshevBoundsOQ04.lean can be discharged elementarily, in the spirit of Selberg's and Erdős's 1949 proofs of the Prime Number Theorem without complex analysis. This iteration scaffolds the Selberg-Erdős strategy: it defines the auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n), the partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n), and proves routine non-negativity, base-value, and monotonicity lemmas. Iteration 2 (2026-05-11) extends the framework with the prime-value lemmas vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0) and selbergLambda2_prime (Λ₂(p) = (log p)²) — the file's documented next-iteration deliverables. The Lean file remains axiom-free and adds 0 sorries; the central Selberg symmetry formula remains the next major target.",
     "meta": {
         "author": "Lean Genius",
         "date": "2026-05-09",
@@ -25,8 +25,8 @@
         "dateAdded": "2026-05-09",
         "axiomCount": 0,
         "assumptions": "No new axioms. The parent file ChebyshevBoundsOQ04.lean contributes 2 axioms (chebyshevPsi_asymptotic, pnt_equivalence) inherited via import; this OQ-04-OQ-01 file adds none of its own. The ultimate goal is to discharge chebyshevPsi_asymptotic by proving Selberg's symmetry formula and the Erdős-Selberg combinatorial finishing argument.",
-        "lineCount": 206,
-        "theoremCount": 10,
+        "lineCount": 230,
+        "theoremCount": 12,
         "definitionCount": 3,
         "additionalFiles": [],
         "originalContributions": [
@@ -35,6 +35,7 @@
             "Routine base-value lemmas: vonMangoldtConv_zero (divisors 0 = ∅), vonMangoldtConv_one (only divisor is 1, Λ(1) = 0), selbergLambda2_zero, selbergLambda2_one — all axiom-free, sorry-free",
             "Non-negativity lemmas: vonMangoldtConv_nonneg, selbergLambda2_nonneg, selbergSum2_nonneg via Finset.sum_nonneg + vonMangoldt_nonneg + Real.log_nonneg (with case-split on n = 0)",
             "Partial-sum recurrence selbergSum2_succ and monotonicity selbergSum2_mono via Finset.sum_le_sum_of_subset_of_nonneg",
+            "Iteration 2 prime-value lemmas: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime and Finset.sum_pair) and selbergLambda2_prime (Λ₂(p) = (log p)² via vonMangoldt_apply_prime) — both axiom-free, sorry-free, completing the documented next-iteration deliverables #1 and #2",
             "Documented roadmap for the elementary PNT proof: Selberg symmetry formula (S₂(N) = 2N log N + O(N)) → Tauberian oscillation control → Erdős combinatorial finishing → ψ(n)/n → 1",
             "Identification of three concrete Mathlib gaps: (i) no Selberg symmetry formula, (ii) no Möbius–log identity Σ_{d|n} μ(d) log²(n/d), (iii) no Λ₂-specific partial-summation framework"
         ]
@@ -58,8 +59,8 @@
         ]
     },
     "conclusion": {
-        "summary": "This iteration scaffolds Selberg's auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n) and the partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n) in Lean 4, proving routine non-negativity and base-value lemmas. No new axioms are introduced; the parent's chebyshevPsi_asymptotic axiom remains the open target. The file documents the four-stage Selberg-Erdős roadmap (auxiliary function → symmetry formula → Tauberian step → Erdős finishing) and identifies three Mathlib gaps that future iterations will need to fill.",
-        "implications": "An elementary Lean formalization of PNT would be a milestone result: Mathlib currently has no PNT proof at all. If this scaffold can be extended to Selberg's symmetry formula (estimated ~1500 additional lines), the remaining Erdős combinatorial step is largely independent of the analytic side and could be formalized as a self-contained lemma family. Concurrent work in the gallery on chebyshev-pnt-bridge already provides ψ ↔ π equivalences that would chain with this work for the full PNT statement.",
+        "summary": "This iteration (2) extends the Selberg-Erdős scaffold with the prime-value lemmas vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0) and selbergLambda2_prime (Λ₂(p) = (log p)²). Combined with iteration 1's auxiliary function definition, partial sum, and non-negativity infrastructure, the file now establishes Λ₂'s value on primes — the simplest non-trivial computation and a prerequisite for the Möbius–log identity Λ₂ = μ ∗ log² that drives Selberg's symmetry formula. No new axioms are introduced; the parent's chebyshevPsi_asymptotic axiom remains the open target.",
+        "implications": "An elementary Lean formalization of PNT would be a milestone result: Mathlib currently has no PNT proof at all. With the prime-value lemmas now in place, the next analytic step is the Möbius–log identity, after which Selberg's symmetry formula (estimated ~1500 additional lines) and the Erdős combinatorial finishing argument complete the program. Concurrent work in the gallery on chebyshev-pnt-bridge already provides ψ ↔ π equivalences that would chain with this work for the full PNT statement.",
         "openQuestions": [
             "Prove the Möbius–log identity Σ_{d ∣ n} μ(d) · log²(n/d) = Λ₂(n) for n ≥ 1 — provable from the standard expansion Λ = μ ∗ log via Möbius inversion",
             "Prove Selberg's symmetry formula S₂(N) = 2N·log N + O(N) — the central analytic step of the elementary proof",
@@ -104,11 +105,18 @@
             "summary": "Proves selbergSum2_zero (= 0), selbergSum2_succ (recurrence), selbergSum2_nonneg (from Λ₂ ≥ 0), and selbergSum2_mono (Monotone selbergSum2) via Finset.sum_le_sum_of_subset_of_nonneg."
         },
         {
-            "id": "sec-future-work",
-            "title": "Future Work (docstring)",
+            "id": "sec-prime-values",
+            "title": "Prime values",
             "startLine": 179,
             "endLine": 204,
-            "summary": "Documents the next-iteration targets in increasing order of difficulty: vonMangoldtConv_prime, selbergLambda2_prime, the Möbius–log identity Λ₂ = μ ∗ log², Selberg's symmetry formula, and the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic."
+            "summary": "Iteration 2 lemmas: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime and Finset.sum_pair, using Λ(1) = 0 on both endpoints of the {1, p} divisor set) and selbergLambda2_prime (Λ₂(p) = (log p)² from the convolution lemma plus vonMangoldt_apply_prime). These close items #1 and #2 from Iteration 1's documented Future Work."
+        },
+        {
+            "id": "sec-future-work",
+            "title": "Future Work (docstring)",
+            "startLine": 206,
+            "endLine": 228,
+            "summary": "Documents the remaining roadmap after iteration 2: the Möbius–log identity Λ₂ = μ ∗ log² (provable from Λ = μ ∗ log), Selberg's symmetry formula S₂(N) = 2N log N + O(N), and the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic."
         }
     ],
     "crossReferences": [


### PR DESCRIPTION
## Summary

Closes the two documented next-iteration deliverables from Iter 1's Future Work docstring on the elementary-PNT (Selberg-Erdős) scaffold:

- **`vonMangoldtConv_prime`**: For prime `p`, `(Λ ∗ Λ)(p) = 0`. Proof: `Nat.divisors_prime hp` gives `p.divisors = {1, p}`; `Finset.sum_pair` reduces the divisor sum to `Λ(1)·Λ(p) + Λ(p)·Λ(1)`, both summands containing the factor `Λ(1) = 0`.
- **`selbergLambda2_prime`**: For prime `p`, `Λ₂(p) = (log p)²`. Direct from (1) plus `vonMangoldt_apply_prime`.

The file remains axiom-free, sorry-free.

## Remaining roadmap

After this iteration:

3. **`selbergLambda2_eq_moebius_log_sq`**: Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d) — provable from Λ = μ ∗ log.
4. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula S₂(N) = 2N·log N + O(N) — the central analytic identity.
5. **Tauberian step → PNT**: Erdős-Selberg combinatorial finishing → discharges `chebyshevPsi_asymptotic`.

## Meta updates

- `lineCount`: 206 → 230
- `theoremCount`: 10 → 12
- Added `sec-prime-values` section between partial-sum properties and Future Work
- Refreshed `description`, `conclusion.summary`, `conclusion.implications`, `originalContributions`, `sec-future-work` ranges/summary
- Future Work docstring renumbered to start from #3

## Build status

**Build pending** — Docker daemon was unavailable in this researcher env. The proof pattern (`Nat.divisors_prime` + `Finset.sum_pair`) is byte-identical to usages elsewhere in the gallery (e.g. `SpernerNDimMathlib.lean:216`, `Erdos321Problem.lean:123`, `Erdos839Problem.lean:107`), and the `vonMangoldt_apply_prime` / `vonMangoldt_apply_one` lemmas are already used in the parent `ChebyshevBoundsOQ04.lean:63,93,347`.

Iteration follows the convention from Iter 1 (PR #17658, "build pending").

## Test plan

- [ ] CI green
- [ ] Lean build succeeds for `Proofs.ChebyshevBoundsOQ04OQ01`
- [ ] Gallery render verifies new prime-values section

🤖 Generated with [Claude Code](https://claude.com/claude-code)