### PR TITLE
audit(tracker): area-of-circle-oq-01-oq-03-oq-01 clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -429,9 +429,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-12T00:17:48Z",
       "result": "clean"
     },
     "area-of-circle-oq-02": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: `area-of-circle-oq-01-oq-03-oq-01` (Arc-Length Reparametrization for Smooth Closed Curves)

### Counts verified against Lean source
- `proofs/Proofs/AreaOfCircleOQ01OQ03OQ01.lean` (712 lines)
- sorries: 0 ✓
- axiom declarations: 0 ✓
- True stubs: 0 ✓
- opaque decls: 0 ✓
- theorem count: 26 ✓
- definition count: 3 ✓

### Status field consistency
- `status: "verified"` + `badge: "original"` + `sorries: 0` + `axiomCount: 0` — all supported by the kernel (no axioms, no sorries, no True stubs).
- The four historically axiomatized lemmas (`arcLengthInv_hasDerivAt`, `arcLengthInv_contDiff`, `circumference_reparam_preserved`, `area_reparam_preserved`) are now proper `theorem` declarations with proofs.

### Minor cosmetic note (not fixing)
`conclusion.openQuestions` still references "Remove `arcLengthInv_contDiff` axiom" etc. — those axioms have already been removed (per `conclusion.summary` which correctly notes "All 4 originally axiomatized theorems… are now fully proved"). The `openQuestions` text is stale but doesn't affect any count or badge claim. Left for a future enrichment pass.

---
Re-audit per the 20-min auditor loop; previous audit was 2026-04-26.