### PR TITLE
Enrich greens-theorem-oq-01-oq-01-oq-03: 3 new annotations + §VI section

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-volume-singleton-zero",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 46,
+      "endLine": 48
+    },
+    "type": "technique",
+    "title": "volume_singleton_zero: Atomlessness via Countability",
+    "content": "Private one-liner showing that any singleton {a} has Lebesgue measure zero. Rather than invoking the standard atomless-measure lemma directly, this proof routes through countability — singletons are countable, and Mathlib's `Set.Countable.measure_zero` gives the conclusion uniformly for any sigma-finite measure. This phrasing generalizes seamlessly to finite/countable subsets of the boundary.",
+    "mathContext": "For Lebesgue measure $\\text{vol}$ on $\\mathbb{R}$: $\\text{vol}(\\{a\\}) = 0$. Proved as $\\text{vol}(\\{a\\}) = \\text{vol}(\\text{(countable set)}) = 0$ via $\\text{Set.Countable.measure\\_zero}$ rather than the more direct $\\text{volume\\_singleton}$. The choice matters when boundaries can have $\\geq 2$ points — a uniform countable-union argument applies.",
+    "significance": "technical",
+    "relatedConcepts": ["atomless measure", "countable null sets", "Lebesgue measure", "singletons"],
+    "prerequisites": ["Set.Countable.measure_zero", "Set.countable_singleton"]
+  },
+  {
     "id": "ann-volume-Icc-sdiff-Ioo",
     "proofId": "greens-theorem-oq-01-oq-01-oq-03",
     "range": {
@@ -45,6 +60,21 @@
     "prerequisites": ["volume_restrict_Icc_eq_Ioo", "Measure.prod"]
   },
   {
+    "id": "ann-fubini-core",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 106,
+      "endLine": 125
+    },
+    "type": "technique",
+    "title": "fubini_core: Inlined Icc Fubini Step",
+    "content": "Private theorem proving Fubini for ordered intervals under the standard Icc-integrability hypothesis. The proof rewrites both interval integrals as set integrals over Ioc via `integral_of_le`, monotonically transfers integrability from `Icc` to `Ioc` (using `Measure.prod_mono` with `Ioc ⊆ Icc`), then invokes Mathlib's abstract `integral_integral_swap`. Inlined here for self-containedness rather than depending on the OQ-01-OQ-01 module.",
+    "mathContext": "Given $f$ measurable and integrable on $[a,b] \\times [c,d]$ (product of Icc-restricted Lebesgue measures), Fubini swap holds: $\\int_c^d \\int_a^b f\\,dx\\,dy = \\int_a^b \\int_c^d f\\,dy\\,dx$. The bridge from interval integrals to Mathlib's product-integral form is `intervalIntegral.integral_of_le`, which rewrites $\\int_a^b$ as $\\int_{(a,b]}$ for $a \\leq b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fubini's theorem", "interval integral", "Ioc vs Icc", "monotonic transfer"],
+    "prerequisites": ["intervalIntegral.integral_of_le", "MeasureTheory.integral_integral_swap", "Measure.prod_mono", "Set.Ioc_subset_Icc_self"]
+  },
+  {
     "id": "ann-main-theorem",
     "proofId": "greens-theorem-oq-01-oq-01-oq-03",
     "range": {
@@ -73,5 +103,20 @@
     "significance": "supporting",
     "relatedConcepts": ["integrable predicate", "measure equality", "iff"],
     "prerequisites": ["volume_prod_restrict_Icc_eq_Ioo"]
+  },
+  {
+    "id": "ann-greens-application",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 163,
+      "endLine": 175
+    },
+    "type": "context",
+    "title": "greens_fubini_open_rectangle: Application to Green's Theorem Pipeline",
+    "content": "Specializes the main Fubini result to the uncurried form `dPdy : ℝ × ℝ → ℝ` that arises in Green's theorem (where `dPdy` is the partial derivative of `P` with respect to `y`). The proof is one line: `dPdy (x, y)` and `fun p => dPdy (p.1, p.2)` are definitionally equal, so `intervalIntegral_swap_of_Ioo_integrable` applies directly. This closes the open question by demonstrating drop-in usability in the Green's theorem proof.",
+    "mathContext": "For the standard Green's theorem $\\oint_{\\partial R} P\\,dx + Q\\,dy = \\iint_R (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dA$ on a rectangle $R = [a,b] \\times [c,d]$, the iterated integral swap is needed for the $\\partial P/\\partial y$ term. The hypothesis $\\partial P/\\partial y$ integrable on $(a,b) \\times (c,d)$ suffices, matching how continuous partial derivatives are typically established only on open neighborhoods.",
+    "significance": "context",
+    "relatedConcepts": ["Green's theorem", "uncurried functions", "iterated integrals", "open neighborhood"],
+    "prerequisites": ["intervalIntegral_swap_of_Ioo_integrable", "function uncurrying"]
   }
 ]

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
@@ -86,7 +86,8 @@
       "For any atomless Borel measure (such as Lebesgue), the restriction to any of Ioo, Ioc, Ico, Icc gives the same result: boundaries are countable (finite in this case) and therefore null.",
       "The key lemma `volume_restrict_Icc_eq_Ioo` is NOT in Mathlib (as of current revision). Mathlib tends to use Ioc as the canonical interval (it forms a π-system), but the Icc = Ioo equivalence is derivable and could be contributed.",
       "The proof uses only subadditivity of measure (measure_union_le), not sigma-additivity. This means the result extends to any outer measure, not just sigma-additive measures.",
-      "The equivalence `integrable_Icc_iff_Ioo` is a clean corollary: since the measures are literally equal, the Integrable predicate (which depends only on the measure) is identical for both."
+      "The equivalence `integrable_Icc_iff_Ioo` is a clean corollary: since the measures are literally equal, the Integrable predicate (which depends only on the measure) is identical for both.",
+      "Mathematically the result is a one-line corollary of measure extensionality, but its formal expression highlights a subtle Mathlib design choice: `intervalIntegral` is built around `Ioc` (half-open, π-system-friendly), while applications in differential geometry and PDE typically have integrability data on open sets. This file builds the explicit bridge so applications need not redo the boundary-null argument case-by-case."
     ]
   },
   "sections": [
@@ -118,7 +119,7 @@
       "id": "main-theorems",
       "title": "§ IV. Main Theorems",
       "startLine": 127,
-      "endLine": 162,
+      "endLine": 159,
       "summary": "Main results: intervalIntegral_swap_of_Ioo_integrable (Fubini with Ioo hypothesis) and integrable_Icc_iff_Ioo (explicit equivalence).",
       "mathContext": "The main theorem converts Ioo integrability to Icc integrability using §II, then applies §III. The equivalence theorem is a one-liner from the product measure equality."
     },
@@ -129,6 +130,14 @@
       "endLine": 175,
       "summary": "greens_fubini_open_rectangle: for uncurried dPdy : ℝ × ℝ → ℝ, the Fubini swap holds under open rectangle integrability.",
       "mathContext": "Direct application of intervalIntegral_swap_of_Ioo_integrable with the uncurried form of the partial derivative, relevant for the standard Green's theorem setup."
+    },
+    {
+      "id": "mathlib-gap",
+      "title": "§ VI. Mathlib Gap Analysis",
+      "startLine": 177,
+      "endLine": 226,
+      "summary": "Block-comment analysis documenting why volume.restrict (Icc a b) = volume.restrict (Ioo a b) is not in Mathlib, the contribution path to Mathlib.MeasureTheory.Measure.Lebesgue.Basic as a @[simp] lemma, and a summary table of all six theorems proved in this file.",
+      "mathContext": "Mathlib's interval-measure infrastructure canonically uses Ioc (left-open right-closed) because Ioc forms a π-system on $\\mathbb{R}$, which is the right combinatorial input for Carathéodory-style measure construction. The Icc↔Ioo equivalence under any atomless measure is mathematically trivial but absent as a standalone lemma — exactly the kind of gap a gallery proof can highlight for upstream contribution."
     }
   ],
   "conclusion": {
@@ -136,7 +145,9 @@
     "implications": "The key novel contribution is vol.restrict(Icc a b) = vol.restrict(Ioo a b) — a useful lemma for any context where Lebesgue integration on intervals must relate Icc and Ioo hypotheses. This could be contributed to Mathlib's MeasureTheory.Measure.Lebesgue.Basic.",
     "openQuestions": [
       "Can this restriction equality be generalized to any atomless Borel measure (not just Lebesgue), giving vol.restrict(Icc a b) = vol.restrict(Ioo a b) for any measure that assigns zero to singletons?",
-      "Does Mathlib contain (or could one contribute) a simp lemma stating vol.restrict(Icc a b) = vol.restrict(Ioo a b) directly, avoiding the need for each application to reprove it?"
+      "Does Mathlib contain (or could one contribute) a simp lemma stating vol.restrict(Icc a b) = vol.restrict(Ioo a b) directly, avoiding the need for each application to reprove it?",
+      "Does the analogous statement hold in higher dimensions for the closed cube $[a_1,b_1] \\times \\cdots \\times [a_n,b_n]$ versus the open cube, and can the boundary-null argument be unified across dimensions via a general 'positive-codimension faces have measure zero' lemma?",
+      "For non-Lebesgue measures arising in geometric measure theory (e.g., Hausdorff measure $\\mathcal{H}^s$ on a fractal set), the boundary $\\{a,b\\}$ may have positive $\\mathcal{H}^0$ — at what regularity threshold (e.g., $s > 0$ continuous) does the Icc/Ioo restriction equality recover?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Enrichment pass for `greens-theorem-oq-01-oq-01-oq-03` (Icc↔Ioo interval-integrability for Fubini).

### Annotations: 5 → 8

Added coverage for previously-unannotated theorems:

- **`ann-volume-singleton-zero`** (line 47): atomlessness routed through `Set.Countable.measure_zero` rather than `volume_singleton` — the countable framing generalizes to any boundary $\subseteq$ countable union of singletons.
- **`ann-fubini-core`** (lines 106-125): inlined Icc-Fubini step using `integral_of_le` to convert interval → set integrals, then `Measure.prod_mono` to transfer integrability from Icc to Ioc before invoking `integral_integral_swap`.
- **`ann-greens-application`** (lines 163-175): one-line application to the uncurried `dPdy : ℝ×ℝ → ℝ` form in Green's theorem; relies on definitional equality between `dPdy (x,y)` and `fun p => dPdy (p.1, p.2)`.

### Sections: 5 → 6

Added **§VI Mathlib Gap Analysis** (lines 177-226). The Lean file already documents (in its trailing block comment) why `volume.restrict (Icc a b) = volume.restrict (Ioo a b)` is absent from Mathlib (canonical π-system is Ioc) and proposes contribution to `Mathlib.MeasureTheory.Measure.Lebesgue.Basic`. The new section surfaces this analysis as a navigable gallery section with explanatory `mathContext`.

Also fixed §IV `main-theorems` endLine 162→159 (it was overshooting into §V's territory; the equivalence theorem ends at line 159).

### keyInsights: 4 → 5

Added: Mathlib's design choice favors `Ioc` (forms a π-system → Carathéodory measure construction), while applications in differential geometry / PDE typically have integrability data on open sets. This file is the bridge.

### openQuestions: 2 → 4

Added:

1. Higher-dimensional analogue: does the Icc↔Ioo restriction equality extend to the closed cube $[a_1,b_1] \times \cdots \times [a_n,b_n]$ versus the open cube, and is there a uniform "positive-codimension faces are null" lemma?
2. Non-Lebesgue measures: for Hausdorff $\mathcal{H}^s$ on a fractal, the boundary $\{a,b\}$ may have positive $\mathcal{H}^0$. At what regularity threshold (e.g., $s>0$ continuous) does the restriction equality recover?

## Test plan
- [x] JSON parses (`python3 -c "import json; json.load(open(...))"`).
- [x] Schema preserved — only additive changes plus 1 numeric correction.
- [x] `git diff origin/main HEAD --stat` = 2 files (no index pollution).
- [ ] `pnpm build` blocked locally by Node 26 + better-sqlite3 gyp issue (per project memory); CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)