### PR TITLE
fix(meta): fair-games-theorem-oq-03 sections — add startLine/endLine, rename description→summary

### DIFF
--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -74,7 +74,9 @@
     {
       "id": "martingale-time-invariance",
       "title": "Part I: Martingale Expected Value Time-Invariance",
-      "description": "E[f_n] = E[f_0] for martingales, proved via Martingale.setIntegral_eq",
+      "startLine": 52,
+      "endLine": 85,
+      "summary": "E[f_n] = E[f_0] for martingales, proved via Martingale.setIntegral_eq",
       "theorems": [
         {
           "name": "martingale_time_invariance",
@@ -87,7 +89,9 @@
     {
       "id": "gamblers-ruin-formula",
       "title": "Part II: Gambler's Ruin Probability Formula",
-      "description": "Algebraic derivation of win probability from fair game condition",
+      "startLine": 86,
+      "endLine": 134,
+      "summary": "Algebraic derivation of win probability from fair game condition",
       "theorems": [
         {
           "name": "gamblers_ruin_win_prob",
@@ -112,7 +116,9 @@
     {
       "id": "betting-systems-fail",
       "title": "Part III: Betting Systems Fail",
-      "description": "Any bounded stopping strategy preserves the expected value, proved via sub/supermartingale sandwich",
+      "startLine": 135,
+      "endLine": 187,
+      "summary": "Any bounded stopping strategy preserves the expected value, proved via sub/supermartingale sandwich",
       "theorems": [
         {
           "name": "any_bounded_strategy_preserves_expectation",
@@ -131,7 +137,9 @@
     {
       "id": "option-pricing",
       "title": "Part IV: Option Pricing Neutrality",
-      "description": "Risk-neutral pricing: exercise timing preserves expected payoff, delegates to Part III",
+      "startLine": 188,
+      "endLine": 213,
+      "summary": "Risk-neutral pricing: exercise timing preserves expected payoff, delegates to Part III",
       "theorems": [
         {
           "name": "risk_neutral_pricing_neutrality",
@@ -144,7 +152,9 @@
     {
       "id": "submartingale-characterization",
       "title": "Part V: Submartingale Characterization (Axiom Elimination)",
-      "description": "Proves the converse of optional stopping monotonicity from Mathlib's iff",
+      "startLine": 214,
+      "endLine": 250,
+      "summary": "Proves the converse of optional stopping monotonicity from Mathlib's iff",
       "theorems": [
         {
           "name": "submartingale_of_stoppedValue_mono_proved",
@@ -157,7 +167,9 @@
     {
       "id": "doobs-inequality",
       "title": "Part VI: Doob's Maximal Inequality",
-      "description": "P(max f_n ≥ thresh) ≤ E[f_N]/thresh for submartingales",
+      "startLine": 251,
+      "endLine": 330,
+      "summary": "P(max f_n ≥ thresh) ≤ E[f_N]/thresh for submartingales",
       "theorems": [
         {
           "name": "doobs_maximal_inequality",


### PR DESCRIPTION
## Fix

`fair-games-theorem-oq-03/meta.json` had 6 sections using a non-canonical schema (`description` + `theorems`) and was missing `startLine`/`endLine`/`summary`. As a result:
- Table of Contents rendered each section title with empty summary text (`section.summary` was undefined).
- Clicking a section scrolled to `NaN` (`section.startLine` was undefined → `(undefined - 1) * 24 = NaN`).
- TOC current-section highlight (`currentLine >= startLine && currentLine <= endLine`) never matched.

## Repair

Renamed `description` → `summary` and added `startLine`/`endLine` for each of the 6 parts, mapped from `proofs/Proofs/FairGamesTheoremOQ03.lean` (330 lines):

| Section | Lines |
|---|---|
| Part I — Martingale Time-Invariance | 52–85 |
| Part II — Gambler's Ruin Formula | 86–134 |
| Part III — Betting Systems Fail | 135–187 |
| Part IV — Option Pricing Neutrality | 188–213 |
| Part V — Submartingale Characterization | 214–250 |
| Part VI — Doob's Maximal Inequality | 251–330 |

`theorems` sub-arrays are kept (extra metadata; ignored by the renderer but harmless).

## Evidence

- Schema source: `src/types/proof.ts:381` (`ProofSection { id, title, startLine, endLine, summary }`).
- Renderer: `src/components/proof/TableOfContents.tsx:67` reads `section.summary`; `src/pages/ProofPage.tsx:59` reads `section.startLine`.
- 5 sibling slugs (`brouwer-fixed-point-oq-04-oq-03`, `collatz-cycles-oq-04`, `de-moivre-oq-03-oq-01`, `erdos-1155-oq-01-oq-06`, `hilbert-15-oq-02-oq-03`) have the same drift; they will be addressed in subsequent PRs (hilbert-15 currently has an open enrichment PR #17700 and is excluded to avoid conflict).

---
Automated fix by lean-mechanic agent.