### PR TITLE
research(sperner-ndim-mathlib-oq-02): S25-rev — reverse of S21A for satDiagBases self-drop (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2587,6 +2587,120 @@ private lemma t2_lastFace_filter_impossible
 end N2LastFaceT2Extinct
 
 -- ============================================================
+-- (S25-rev) Reverse of S21A: for `b ∈ satDiagBases N`, the
+-- self-drop index exists, is unique, and witnesses the per-vertex
+-- face-2 condition that `_hLastFace` filters on.
+--
+-- S21A (forward, `t1_lastFace_implies_satDiag`) shows that any
+-- `(t1 b, k)` cell pair in the `_hLastFace` filter forces
+-- `b ∈ satDiagBases N` with `vertexEnum (t1 b) hS k = b`. This
+-- section establishes the matching backward direction:
+--
+--   * `satDiag_self_drop_index_exists` — `b ∈ satDiagBases N` ⟹
+--     ∃ k : Fin 3, `vertexEnum (t1 b) hS k = b`. Existence via
+--     `vertexEnum_image_univ` (`b ∈ t1 b` lies in the image).
+--   * `satDiag_self_drop_index_unique` — the self-drop index is
+--     unique via `vertexEnum_injective`.
+--   * `satDiag_self_drop_face2` — at the self-drop index, the two
+--     remaining vertices `(b.1, b.2+1)` and `(b.1+1, b.2)` both
+--     satisfy `onFaceΔ2_strict N · 2`. Combines `t1_erase_third`
+--     (S19.2) with `satDiagBases_endpoints_on_face2` (S20) via the
+--     bridge `forall_vertex_ne_iff_forall_face_mem` (S19.2).
+--
+-- Together with S24's t2-side extinction and S20's
+-- `satDiagBases_card_eq N`, this packages the `satDiagBases N →
+-- _hLastFace filter` direction that S25 will compose with S23's
+-- color-side wiring + S22's `IsDoor` ↔ color-change bridge.
+-- Independent of the in-flight S23 (`N2LastFaceColors`,
+-- PR #17571) and S25-prep (gridPt coordinate values, PR #17621)
+-- contributions.
+-- ============================================================
+
+section N2LastFaceSelfDropIndex
+
+variable (N : ℕ)
+
+/-- For `b ∈ satDiagBases N`, there exists `k : Fin 3` such that
+the vertex enumeration at index `k` returns `b` itself.
+
+This is the backward existence companion to S21A's forward
+extraction. Existence follows from the surjection
+`vertexEnum_image_univ` because `b ∈ t1 b` (it is the third
+vertex by the `t1` definition). -/
+private lemma satDiag_self_drop_index_exists
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) :
+    ∃ k : Fin 3,
+      (simData2 N).vertexEnum (t1 b)
+        (satDiagBases_t1_in_topSimps2 N hb) k = b := by
+  set hS := satDiagBases_t1_in_topSimps2 N hb with hS_def
+  have hb_mem_t1 : b ∈ t1 b := by
+    simp only [t1, Finset.mem_insert, Finset.mem_singleton]
+    right; right; rfl
+  have h_img := (simData2 N).vertexEnum_image_univ (t1 b) hS
+  rw [← h_img] at hb_mem_t1
+  obtain ⟨k, _, hk⟩ := Finset.mem_image.mp hb_mem_t1
+  exact ⟨k, hk⟩
+
+/-- The self-drop index of `b ∈ satDiagBases N` is unique: any two
+indices `k₁, k₂ : Fin 3` whose `vertexEnum` value equals `b` must
+themselves be equal. Direct consequence of `vertexEnum_injective`. -/
+private lemma satDiag_self_drop_index_unique
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N)
+    {k₁ k₂ : Fin 3}
+    (hk₁ : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k₁ = b)
+    (hk₂ : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k₂ = b) :
+    k₁ = k₂ :=
+  (simData2 N).vertexEnum_injective (t1 b)
+    (satDiagBases_t1_in_topSimps2 N hb) (hk₁.trans hk₂.symm)
+
+/-- **Reverse of S21A.** For `b ∈ satDiagBases N` and any `k : Fin 3`
+that is the self-drop index (`vertexEnum (t1 b) hS k = b`), every
+non-`k` vertex of `t1 b` satisfies the geometric face-2 condition
+`onFaceΔ2_strict N · 2` — i.e., the pair `(t1 b, k)` satisfies the
+per-vertex condition of the `_hLastFace` filter of
+`Triangulation.boundary_doors_odd`.
+
+Proof: the dropped vertex is `b`, so `faceOf (t1 b) hS k =
+(t1 b).erase b = {(b.1, b.2+1), (b.1+1, b.2)}` by S19.2's
+`t1_erase_third`. Both diagonal endpoints satisfy
+`onFaceΔ2_strict N · 2` by S20's `satDiagBases_endpoints_on_face2`.
+The S19.2 bridge `forall_vertex_ne_iff_forall_face_mem` rewrites
+the `∀ j ≠ k`-on-`vertexEnum` goal into the `∀ v ∈ faceOf` form
+that the two-element membership case-split discharges.
+
+Together with the existence + uniqueness lemmas above, this packages
+the `b ∈ satDiagBases N → (t1 b, k_b) ∈ _hLastFace-style condition`
+half of the eventual S25 bijection. -/
+private lemma satDiag_self_drop_face2
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N)
+    {k : Fin 3}
+    (hk : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k = b) :
+    ∀ j : Fin 3, j ≠ k →
+      onFaceΔ2_strict N
+        ((simData2 N).vertexEnum (t1 b)
+          (satDiagBases_t1_in_topSimps2 N hb) j)
+        (2 : Fin 3) := by
+  set hS := satDiagBases_t1_in_topSimps2 N hb with hS_def
+  have h_face_eq : (simData2 N).faceOf (t1 b) hS k =
+      ({(b.1, b.2 + 1), (b.1 + 1, b.2)} : Finset (ℕ × ℕ)) := by
+    show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+    rw [hk]; exact t1_erase_third b
+  have h_endpoints := satDiagBases_endpoints_on_face2 N hb
+  apply (SimplicialAdjFnHelper.forall_vertex_ne_iff_forall_face_mem
+    (simData2 N) (t1 b) hS k _).mpr
+  intro v hv
+  rw [h_face_eq] at hv
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hv
+  rcases hv with rfl | rfl
+  · exact h_endpoints.1
+  · exact h_endpoints.2
+
+end N2LastFaceSelfDropIndex
+
+-- ============================================================
 -- (S25-prep-index) First-coordinate parametrization of `satDiagBases`.
 --
 -- The eventual S25 bijection between the `_hLastFace` filter and

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,19 +2,70 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-09 (Iteration 24, researcher-9)
-**Iteration**: 24
+**Last Updated**: 2026-05-11 (Iteration 25-rev, researcher-9)
+**Iteration**: 25-rev
 
 ## Current Focus
 
-Session 24 (this iteration, researcher-9, 2026-05-09, build
-pending): Added the **t2-side boundary extinction** lemma for
-`_hLastFace`, packaging the t2 branch of `boundaryOnFace_simData2`
-as a stand-alone re-export so S25's bijection assembly can dismiss
-the t2 case by a single `match`/`rcases` rather than re-running the
-case-split. New private lemma `t2_adj_ne_none` in a new
-`N2LastFaceT2Extinct` section appended to `SpernerFreudSimp`
-(97 lines added to `SpernerFreudenthalSimplex.lean`).
+Session 25-rev (this iteration, researcher-9, 2026-05-11, build
+pending): Added the **reverse direction of S21A** — for
+`b ∈ satDiagBases N`, the self-drop index exists, is unique, and
+witnesses the per-vertex face-2 condition that the `_hLastFace`
+filter checks. Together with S21A (forward), this gives both
+directions of the t1-side correspondence between saturating-diagonal
+bases and `_hLastFace` filter membership.
+
+New section `N2LastFaceSelfDropIndex` (3 lemmas, 114 lines added to
+`SpernerFreudenthalSimplex.lean`, inserted after `N2LastFaceT2Extinct`):
+
+* `satDiag_self_drop_index_exists`: for `b ∈ satDiagBases N`, there
+  exists `k : Fin 3` with `(simData2 N).vertexEnum (t1 b) hS k = b`.
+  Existence follows from `vertexEnum_image_univ` because `b ∈ t1 b`.
+* `satDiag_self_drop_index_unique`: any two such indices coincide
+  (direct consequence of `vertexEnum_injective`).
+* `satDiag_self_drop_face2` (the main reverse-of-S21A lemma): for
+  `b ∈ satDiagBases N` and `k` the self-drop index, every non-`k`
+  vertex of `t1 b` satisfies `onFaceΔ2_strict N · 2`. Proof: the
+  face equals the diagonal endpoint pair `{(b.1, b.2+1), (b.1+1, b.2)}`
+  via S19.2's `t1_erase_third` applied at the self-drop index;
+  both endpoints satisfy the face-2 condition by S20's
+  `satDiagBases_endpoints_on_face2`; the bridge
+  `forall_vertex_ne_iff_forall_face_mem` (S19.2) converts the
+  `∀ v ∈ faceOf` form to the `∀ j ≠ k`-on-`vertexEnum` form
+  that `_hLastFace` filters on.
+
+Together with S21A (forward: `_hLastFace`-pair ⟹ `satDiagBases`)
+and S24 (t2-extinction: only t1 cells contribute), this packages
+the **t1-side bijection data** for S25:
+
+  satDiagBases N ↔ {t1 cells in _hLastFace filter}
+
+via `b ↦ (t1 b, k_self(b))`. The composition with S25-prep-fst-index
+(merged) yielding `b ↦ b.1` then identifies this set with
+`Finset.range N`, matching the index set of `face2_path_odd`'s
+color-change edges. S23 (in flight, PR #17571) supplies the color
+wiring + S22's `IsDoor` ↔ color-change bridge to complete the
+correspondence with `(Finset.range N).filter (fun k => g k ≠ g (k+1))`.
+
+S25-rev keeps the iterative-PR cadence small (3 self-contained
+lemmas, ~114 lines including section header + docstrings) to reduce
+merge-conflict risk against the in-flight S23 (PR #17571, color-side
+wiring) and S25-prep (PR #17621, gridPt coordinate values) PRs,
+which add to disjoint regions of the file. Build pending per the
+persistent `proofs/.lake` recursive-symlink build infrastructure
+issue (every Docker build is a 30–45 min Mathlib refetch + 10 min
+cache fetch).
+
+## Previous Focus
+
+Session 24 (PR #17577, merged 2026-05-09): Added the **t2-side
+boundary extinction** lemma for `_hLastFace`, packaging the t2
+branch of `boundaryOnFace_simData2` as a stand-alone re-export so
+S25's bijection assembly can dismiss the t2 case by a single
+`match`/`rcases` rather than re-running the case-split. New private
+lemma `t2_adj_ne_none` in a new `N2LastFaceT2Extinct` section
+appended to `SpernerFreudSimp` (97 lines added to
+`SpernerFreudenthalSimplex.lean`).
 
 Together with S21A's `t1_lastFace_implies_satDiag` (PR #17464,
 merged), the t1/t2 split for `_hLastFace` is now complete:

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -44,7 +44,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S24 (this PR, build pending): added t2-side boundary extinction lemma t2_adj_ne_none — packaging the t2 branch of boundaryOnFace_simData2 as a stand-alone re-export so S25's bijection assembly can dismiss the t2 case in a single rcases. ~97 lines, build pending. Builds on S19.1 (adjFn_eq_none_iff_card_le_one), S18 (t2_face*_card_ge_two), and the existing t2 erase lemmas. Together with S21A (PR #17464, merged) the t1/t2 split for the _hLastFace filter is complete; S23 (PR #17571, in flight) supplies the color-side wiring. Next: S25 bijection assembly.",
+    "progressSummary": "PROGRESS: S25-rev reverse-of-S21A complete — both directions of t1-side correspondence between satDiagBases N and _hLastFace t1 cells now packaged (researcher-9, 2026-05-11). Next: S25 bijection assembly (depends on S23 PR #17571 + S25-rev this PR).",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -92,7 +92,8 @@
       "S20 (PR #17426): satDiagBases N + satDiagBases_mem_iff + satDiagBases_subset_t1Bases + satDiagBases_image_map_injOn + satDiagBases_eq_image_range + satDiagBases_card + satDiagBases_endpoints_in_range + satDiagBases_endpoints_on_face2 + satDiagBases_t1_in_topSimps2 in SpernerFreudenthalSimplex.lean (N2LastFaceBases section)",
       "S21A (PR #17464): SpernerFreudSimp.t1_lastFace_implies_satDiag in SpernerFreudenthalSimplex.lean (N2LastFaceExtract section). Given b ∈ t1Bases N + drop-index k with all non-k vertices on face 2, concludes b ∈ satDiagBases N ∧ vertexEnum (t1 b) hS k = b.",
       "S21B (this PR): SimplicialAdjFnHelper.isDoor_dim_two_iff in SpernerFreudenthalSimplex.lean. Generic CellComplex.IsDoor characterization for d=2: IsDoor c K s k ↔ (∃ i ≠ k, c (K.vertex s i) = 0) ∧ (∃ i ≠ k, c (K.vertex s i) = 1).",
-      "S24 (this PR): SpernerFreudSimp.t2_adj_ne_none + t2_lastFace_filter_impossible in SpernerFreudenthalSimplex.lean (N2LastFaceT2Extinct section). t2-side _hLastFace boundary extinction: for c ∈ t2Bases N and k : Fin 3, ((simData2 N).toTriangulation).adj ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none. Filter-shape corollary t2_lastFace_filter_impossible drops the face-2 hypothesis for direct S25 consumption."
+      "S24 (this PR): SpernerFreudSimp.t2_adj_ne_none + t2_lastFace_filter_impossible in SpernerFreudenthalSimplex.lean (N2LastFaceT2Extinct section). t2-side _hLastFace boundary extinction: for c ∈ t2Bases N and k : Fin 3, ((simData2 N).toTriangulation).adj ⟨t2 c, t2_in_topSimps2_of_base N hc⟩ k ≠ none. Filter-shape corollary t2_lastFace_filter_impossible drops the face-2 hypothesis for direct S25 consumption.",
+      "Added section N2LastFaceSelfDropIndex (3 lemmas, ~114 lines) to SpernerFreudenthalSimplex.lean: satDiag_self_drop_index_exists, satDiag_self_drop_index_unique, satDiag_self_drop_face2"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -129,7 +130,8 @@
       "S19.1 connects abstract adjFn to abstract containersOf; the missing link to S18 lemmas (which use concrete edge filter sets) is the explicit faceOf computation. The 6 erase lemmas + the ∀-quantifier bridge close this gap.",
       "Edit-tool path trap recurrence: writing to /Users/rwalters/GitHub/lean-genius/proofs/... (main repo path, not worktree) silently lost 177 lines of edits to concurrent rebase activity. Always use /Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-6/proofs/... for edits.",
       "S20: Saturating-diagonal t1 bases form the cell side of _hLastFace. By S18.1+S18.5, the only boundary doors lying on geometric face 2 come from t1 b cells with b.1+b.2+1=N (t2 cells contribute none, horizontal/vertical t1 boundaries are on face 1/0). The count |satDiagBases N| = N matches face2_path_odd's Finset.range N index set, providing the bijection's count-side foundation.",
-      "S24: the t2-side _hLastFace filter is empty even before invoking the per-vertex face-2 hypothesis — every t2-cell codim-1 face has ≥ 2 containers (the t2 itself + a sharing t1) so adj = none never holds. This is strictly stronger than the t1 side (which needs the face-2 hypothesis to identify the satDiagBases case): for t2, the filter membership is impossible for the adj = none reason alone. Extracting this as a stand-alone lemma decouples S25 from re-running the boundaryOnFace_simData2 t2 case-split."
+      "S24: the t2-side _hLastFace filter is empty even before invoking the per-vertex face-2 hypothesis — every t2-cell codim-1 face has ≥ 2 containers (the t2 itself + a sharing t1) so adj = none never holds. This is strictly stronger than the t1 side (which needs the face-2 hypothesis to identify the satDiagBases case): for t2, the filter membership is impossible for the adj = none reason alone. Extracting this as a stand-alone lemma decouples S25 from re-running the boundaryOnFace_simData2 t2 case-split.",
+      "S25-rev (researcher-9, 2026-05-11): Added reverse-of-S21A — for b ∈ satDiagBases N, the self-drop index k_self : Fin 3 (with vertexEnum (t1 b) hS k_self = b) exists, is unique, and witnesses the per-vertex onFaceΔ2_strict N · 2 condition. Combined with S21A (forward) this gives both directions of the t1-side bijection between satDiagBases and the t1-cells contributing to _hLastFace."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
@@ -166,7 +168,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-09",
+  "lastUpdate": "2026-05-11",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S25-rev of the n=2 Sperner-via-Freudenthal pipeline: adds the **backward direction of S21A**'s t1-side `_hLastFace` extraction. For `b ∈ satDiagBases N`, the self-drop index (the `k : Fin 3` with `vertexEnum (t1 b) hS k = b`) exists, is unique, and witnesses the per-vertex face-2 condition that `_hLastFace` filters on.

Three private lemmas in a new `N2LastFaceSelfDropIndex` section (114 lines added to `SpernerFreudenthalSimplex.lean`, inserted after `N2LastFaceT2Extinct`):

- **`satDiag_self_drop_index_exists`**: for `b ∈ satDiagBases N`, `∃ k : Fin 3, (simData2 N).vertexEnum (t1 b) hS k = b`. Existence via `AbstractSimplicialData.vertexEnum_image_univ` because `b ∈ t1 b` (the third element of the `t1` definition).

- **`satDiag_self_drop_index_unique`**: any two such indices coincide. Direct consequence of `AbstractSimplicialData.vertexEnum_injective` applied to `hk₁.trans hk₂.symm`.

- **`satDiag_self_drop_face2`** (the main reverse-of-S21A lemma): for `b ∈ satDiagBases N` and `k` the self-drop index, every non-`k` vertex of `t1 b` satisfies `onFaceΔ2_strict N · 2`. Proof: the face equals the diagonal endpoint pair `{(b.1, b.2+1), (b.1+1, b.2)}` via S19.2's `t1_erase_third` applied at the self-drop index; both endpoints satisfy the face-2 condition by S20's `satDiagBases_endpoints_on_face2`; the bridge `forall_vertex_ne_iff_forall_face_mem` (S19.2) converts the `∀ v ∈ faceOf` form to the `∀ j ≠ k`-on-`vertexEnum` form that `_hLastFace` filters on.

## Path forward

Together with **S21A** (forward: `_hLastFace`-pair ⟹ `satDiagBases`, PR #17464 merged) and **S24** (t2-extinction: only t1 cells contribute, PR #17577 merged), this packages the **t1-side bijection data** for S25's assembly:

  `satDiagBases N ↔ {t1 cells in _hLastFace filter}`

via `b ↦ (t1 b, k_self(b))`. The composition with **S25-prep-fst-index** (`b ↦ b.1`, merged) then identifies this set with `Finset.range N`, matching the index set of `face2_path_odd`'s color-change edges. **S23** (in flight, PR #17571) supplies the color-side wiring + S22's `IsDoor` ↔ color-change bridge to complete the correspondence with `(Finset.range N).filter (fun k => g k ≠ g (k+1))`.

## Independence from in-flight PRs

This is **independent of**:

- **PR #17571 (S23)**: adds `N2LastFaceColors` section at the end of `SpernerFreudSimp` (color-side wiring, ~83 lines). This PR's `N2LastFaceSelfDropIndex` section is inserted between `N2LastFaceT2Extinct` and `N2SatDiagBasesIndex` — a disjoint region of the file.

- **PR #17621 (S25-prep)**: adds `gridPt_{zero,one,two}_eq` in section `N2Grid` (~545–560), a much earlier region of the file. No textual overlap.

## Build status

Build pending per the persistent `proofs/.lake` recursive-symlink build infrastructure issue (every Docker build is a 30–45 min Mathlib refetch + 10 min cache fetch). All API surface used is well-established and previously verified:

- `AbstractSimplicialData.vertexEnum_image_univ`, `vertexEnum_injective` (SpernerSimplicialInstance.lean, already in use by S21A and S24)
- `t1_erase_third`, `satDiagBases_endpoints_on_face2`, `satDiagBases_t1_in_topSimps2`, `simData2`, `topSimps2` (all merged)
- `SimplicialAdjFnHelper.forall_vertex_ne_iff_forall_face_mem` (S19.2, merged)

The proof patterns mirror S21A's existing case-3 branch (lines 2476–2488) one-for-one for the face-equality rewrite, then directly apply the bridge `iff` rather than walking through three case-splits.

## Files

- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (+114)
- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (+57 / -10)
- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json` (+9 / -1)