### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S17 — Cellina–Browder Step 1 scaffold helper (build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -72,6 +72,43 @@ def IsUpperHemicontinuous {X Y : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] (F : SetValuedMap X Y) : Prop :=
   ∀ V : Set Y, IsOpen V → IsOpen {x | F x ⊆ V}
 
+/-- **S17 scaffold helper for `approx_selection_exists` (Cellina–Browder
+    Step 1):** For any upper-hemicontinuous set-valued map `F : X → 2^Y`
+    with `Y` a pseudo-metric space, at every basepoint `x₀ : X` and every
+    `ε > 0` there is an open neighborhood `U ∋ x₀` on which `F` is contained
+    in the `ε`-thickening of `F(x₀)`.
+
+    This unpacks the abstract UHC definition (`{x | F x ⊆ V}` open for
+    every open `V`) into the metric form used in the cover-by-thickening
+    step of the PartitionOfUnity proof outlined in the
+    `approx_selection_exists` docstring (Axiom 2 below). It introduces no
+    new axioms and no new definitions; the proof is a one-line application
+    of UHC at `V = Metric.thickening ε (F x₀)` together with the standard
+    `Metric.self_subset_thickening`. Building this scaffold helper up
+    front lets the eventual S12+ Cellina–Browder construction reuse a
+    typechecked Step-1 lemma instead of re-deriving it inline.
+
+    **Cellina–Browder construction outline** (for reference; Steps 2–5
+    are the unrealized S12+ work):
+
+    1. ✓ (this lemma) — for each `x ∈ S`, pick `y_x ∈ F(x)` and obtain an
+       open `U_x ∋ x` with `F(U_x) ⊆ ε`-thickening of `F(x)`.
+    2. Compactness extracts a finite subcover `U_{x_1}, …, U_{x_k}`.
+    3. Subordinate partition of unity `{φ_i}` with `supp φ_i ⊆ U_{x_i}`.
+    4. Define `f(x) := Σ φ_i(x) · y_{x_i}`. Convexity of `S` gives `f x ∈ S`.
+    5. Graph bound: at any `x`, pick `i` with `φ_i(x) > 0`; then
+       `x ∈ U_{x_i}` and `(x_i, y_{x_i})` witnesses graph-distance `< ε`. -/
+lemma uhc_local_thickening {X Y : Type*} [TopologicalSpace X]
+    [PseudoMetricSpace Y]
+    {F : SetValuedMap X Y} (hF : IsUpperHemicontinuous F)
+    (x₀ : X) (ε : ℝ) (hε : 0 < ε) :
+    ∃ U : Set X, IsOpen U ∧ x₀ ∈ U ∧
+      ∀ x ∈ U, F x ⊆ Metric.thickening ε (F x₀) := by
+  refine ⟨{x | F x ⊆ Metric.thickening ε (F x₀)},
+          hF _ Metric.isOpen_thickening,
+          ?_, fun _ hx => hx⟩
+  exact Metric.self_subset_thickening hε _
+
 -- ============================================================
 -- Part II: Key Axioms
 -- ============================================================


### PR DESCRIPTION
## Summary

S17 (researcher-1) adds `lemma uhc_local_thickening` to
`SchauderFixedPointOQ03OQ01.lean`, encoding **Step 1 of the
Cellina–Browder PartitionOfUnity construction** referenced in the
`approx_selection_exists` (Axiom 2) docstring.

**Statement.** For any upper-hemicontinuous set-valued map
`F : X → 2^Y` with `Y` a pseudo-metric space, at every basepoint
`x₀ : X` and every `ε > 0` there is an open neighborhood `U ∋ x₀` on
which `F ⊆ Metric.thickening ε (F x₀)`.

**Proof.** One-line `refine`: instantiate the UHC definition at
`V = Metric.thickening ε (F x₀)` (open by `Metric.isOpen_thickening`)
and use `Metric.self_subset_thickening` to discharge `x₀ ∈ {x | F x ⊆ V}`.

## Why this scaffold (and why now)

The next substantive axiom-elimination work on this file is **S18+**:
proving `axiom approx_selection_exists` (graph-form Cellina–Browder
selection) via the PartitionOfUnity construction outlined in the S16
docstring. That construction has five steps; this PR captures the first
one (UHC → local thickening cover) as a typechecked lemma so future S18
iterations can reuse it instead of inlining the UHC unpacking.

The lemma is intentionally generic (`X` topological, `Y` pseudo-metric)
so it can be reused beyond the immediate Schauder-FP context if the
in-file `SetValuedMap` predicate is later upstreamed.

## Honesty note

This is a **scaffold helper**, not an axiom-elimination advance:

- Axiom count unchanged at 2 (`brouwer_unit_ball`, `approx_selection_exists`).
- Sorry count unchanged at 0.
- The lemma is a one-line application of the UHC definition; it does
  not produce new mathematics.

Its value is making **Step 1** of the eventual S18+ Cellina–Browder
proof (Steps 2–5 outstanding) a one-line reuse. Estimated 200–500 Lean
lines remain to fully eliminate `axiom approx_selection_exists`.

## Mathlib API verification

Verified against pinned mathlib4 rev
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via the GitHub contents API
(S10 methodology, since the on-disk `proofs/.lake` symlink is broken):

| API | Module | Line |
|---|---|---|
| `Metric.isOpen_thickening` | `Mathlib/Topology/MetricSpace/Thickening.lean` | 77 |
| `Metric.self_subset_thickening` | `Mathlib/Topology/MetricSpace/Thickening.lean` | 318 |

## Net change

| Counter | Before | After | Delta |
|---|---|---|---|
| `lineCount` | 779 | 816 | +37 |
| `theoremCount` (lemmas + theorems) | 5 | 6 | +1 |
| `axiomCount` | 2 | 2 | 0 |
| `definitionCount` | 4 | 4 | 0 |
| `sorries` | 0 | 0 | 0 |

Base `779` reflects S16 docstring sync (#17697) merging on origin/main
during this session; my branch was rebased onto `origin/main` post-S16
before push to avoid conflicts with the in-flight docstring tweak to
`approx_selection_exists`.

## Files

- `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` — new lemma + 30-line
  docstring with the Cellina–Browder construction outline.
- `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` —
  `lineCount` 779 → 816, `theoremCount` 5 → 6 (both `meta` and
  `leanFile` sub-objects).
- `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md` —
  S17 entry + S18+ next-action plan with named Mathlib API targets.

## Build status

**Build pending.** Follows the precedent established by S11
(`#17501`/`#17493`), S13 (`#17575`), S14 (`#17601`), S15 (`#17654`),
S16 (`#17697`). No Docker access this session; the change is mechanical
and the API references are pinned-rev verified.

## S18+ next action (from state.md)

- **Step 2** (compactness subcover): `IsCompact.elim_finite_subcover`.
- **Step 3** (subordinate partition of unity): `PartitionOfUnity.exists_isSubordinate`.
- **Step 4** (convex sum stays in `S`): `Convex.sum_mem`.
- **Step 5** (graph bound): combine the partition support with this PR's
  lemma.

🤖 Generated by researcher-1