### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 19 — product-level correction-factor bound (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -749,6 +749,81 @@ theorem prime_pow_pred_le_div {p n : ℕ} (hp : p.Prime) (hpn : p ≤ n) :
     omega
   exact Nat.pow_log_le_self p hn_ne
 
+-- =====================================================================
+-- ITER 19: product-level correction-factor bound (pointwise Iter 18 → product)
+-- =====================================================================
+-- Apply Iter 18's pointwise `prime_pow_pred_le_div` term-by-term across
+-- the prime filter `(Finset.range (n + 1)).filter Nat.Prime`, obtaining
+-- the natural product-level inequality
+--   ∏ p^(Nat.log p n - 1) ≤ ∏ (n / p)   over primes p ≤ n.
+-- Chaining with Iter 16's primorial-correction factorisation then yields
+-- the corollary
+--   lcmRange n ≤ primorial n · ∏ (n / p)   over primes p ≤ n.
+-- This converts the structural decomposition of Iters 16/17 into a
+-- *quantitative* upper bound on `lcmRange n`. The remaining work
+-- toward Hanson's `lcmRange n ≤ 3^n` is then a pure product-bounding
+-- problem on `∏ (n / p)` (e.g. Chebyshev's `∏ (n/p) ≤ 2^(c √n)` after
+-- dropping primes `p > √n` via Iter 17's `prime_pow_pred_eq_one_of_sq_lt`).
+
+/-- **Product-level correction-factor bound** (Iter 19): the Iter-16
+    correction product `∏_{p prime ≤ n} p^(⌊log_p n⌋ - 1)` is bounded
+    above by `∏_{p prime ≤ n} (n / p)`.
+
+    Direct pointwise application of Iter 18's `prime_pow_pred_le_div`
+    across the prime filter, via `Finset.prod_le_prod` (the
+    nonnegativity hypothesis is trivial in `ℕ`).
+
+    Concrete checks (matching Iter 16/17 numerics):
+    * `n = 10`: LHS = ∏_{p∈{2,3,5,7}} p^(log_p 10 - 1) = 2² · 3¹ · 5⁰ · 7⁰ = 12.
+               RHS = ∏_{p∈{2,3,5,7}} 10/p = 5 · 3 · 2 · 1 = 30. ✓ (12 ≤ 30)
+    * `n = 20`: LHS = 2³ · 3¹ · 5⁰ · 7⁰ · 11⁰ · 13⁰ · 17⁰ · 19⁰ = 24.
+               RHS = 10 · 6 · 4 · 2 · 1 · 1 · 1 · 1 = 480. ✓ (24 ≤ 480)
+
+    The bound is loose for large `n` because Iter 17 already shows that
+    primes `p > √n` contribute `1` on the LHS but contribute `n/p ≥ 1`
+    on the RHS. A sharper variant restricted to the small-prime filter
+    `{p : p² ≤ n}` would tighten both sides; that refinement is left for
+    a future iteration once Iter 17's support-reduction lemma (PR
+    #17619, in flight) is merged. -/
+theorem prod_prime_pow_pred_le_prod_div_prime (n : ℕ) :
+    ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, p ^ (Nat.log p n - 1) ≤
+    ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, n / p := by
+  apply Finset.prod_le_prod
+  · intro p _
+    exact Nat.zero_le _
+  · intro p hp
+    rw [Finset.mem_filter, Finset.mem_range] at hp
+    obtain ⟨hp_lt, hp_prime⟩ := hp
+    have hpn : p ≤ n := by omega
+    exact prime_pow_pred_le_div hp_prime hpn
+
+/-- **lcmRange quantitative bound** (Iter 19 corollary): combining Iter
+    16's primorial-correction factorisation with the product-level Iter
+    19 pointwise bound,
+
+      `lcmRange n ≤ primorial n · ∏_{p prime ≤ n} (n / p)`.
+
+    First explicit *numerical* (as opposed to structural) upper bound on
+    `lcmRange n` derived from the prime-power decomposition. Strategic
+    position on the path to Hanson's `3^n`:
+
+    1. **Primorial factor** `primorial n ≤ 4^n` (Mathlib's
+       `Nat.primorial_le_4_pow`).
+    2. **Correction factor** `∏_{p ≤ n} (n / p)` reduces, via Iter 17,
+       to `∏_{p ≤ √n} (n / p)` (large primes contribute `1`); a
+       Chebyshev-style `∏_{p ≤ √n} (n/p) ≤ 2^(c √n)` would then yield
+       `lcmRange n ≤ 4^n · 2^(c √n) = (4 + ε)^n`.
+
+    Numerics (sanity, n = 10): primorial(10) = 210, ∏ (10/p) over
+    primes ≤ 10 is `5 · 3 · 2 · 1 = 30`, product `= 6300`, and indeed
+    `lcmRange(10) = 2520 ≤ 6300`. ✓ For n = 20: primorial(20) · 480 =
+    9,699,690 · 480 = 4,655,851,200 ≥ `lcmRange(20) = 232,792,560`. ✓ -/
+theorem lcmRange_le_primorial_mul_prod_div_prime (n : ℕ) :
+    lcmRange n ≤ primorial n *
+      ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, n / p := by
+  rw [lcmRange_eq_primorial_mul_prod_prime_pow_pred]
+  exact Nat.mul_le_mul_left _ (prod_prime_pow_pred_le_prod_div_prime n)
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,12 +4,90 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-11 (Iteration 18, researcher-9)
-**Iteration**: 18
+**Last Updated**: 2026-05-12 (Iteration 19, researcher-9)
+**Iteration**: 19
 
 ## Current Focus
 
-Iteration 18 (2026-05-11, this PR, researcher-9): **per-prime
+Iteration 19 (2026-05-12, this PR, researcher-9): **product-level
+correction-factor bound** — lifts Iter 18's pointwise
+`prime_pow_pred_le_div` (`p^(log_p n - 1) ≤ n/p`) to a product-level
+inequality over the full prime filter, then chains with Iter 16's
+factorisation to obtain the first *numerical* (as opposed to
+structural) upper bound on `lcmRange n`. Two new theorems
+(+75 lines, all build-pending, sorry-free):
+
+* `prod_prime_pow_pred_le_prod_div_prime (n : ℕ) :
+    ∏ p ∈ filter Prime (range (n+1)), p^(Nat.log p n - 1)
+    ≤ ∏ p ∈ filter Prime (range (n+1)), n / p` —
+  direct pointwise application of Iter 18's `prime_pow_pred_le_div`
+  across the prime filter, via `Finset.prod_le_prod` (nonnegativity
+  trivial for ℕ). The numerical sanity checks match Iter 16/17:
+  for `n = 10`, LHS = 12, RHS = 30 (= 5·3·2·1); for `n = 20`,
+  LHS = 24, RHS = 480 (= 10·6·4·2·1·1·1·1).
+* `lcmRange_le_primorial_mul_prod_div_prime (n : ℕ) :
+    lcmRange n ≤ primorial n *
+      ∏ p ∈ filter Prime (range (n+1)), n / p` —
+  corollary chaining the above with Iter 16's
+  `lcmRange_eq_primorial_mul_prod_prime_pow_pred`. First explicit
+  quantitative upper bound on `lcmRange n` derived from the
+  prime-power decomposition (the earlier `lcmRange_le_pow_card_primes_le`
+  / `lcmRange_le_pow_pred` bounds — Iters 10/14 — use the much coarser
+  per-factor estimate `p^(log_p n) ≤ n`).
+
+### Strategic value
+
+This iter completes the bridge from *algebraic decomposition* (Iter 16)
++ *per-term bound* (Iter 18) to *product-level numerical inequality*.
+The path to Hanson's `lcmRange n ≤ 3^n` now factors cleanly:
+
+1. **Primorial factor**: `primorial n ≤ 4^n` (Mathlib's
+   `Nat.primorial_le_4_pow`).
+2. **Correction factor**: `∏_{p ≤ n} (n / p)` — a pure
+   number-theoretic product, with no `Nat.log` dependence. After Iter
+   17 (PR #17619, in flight) drops large primes from the support, the
+   correction reduces to `∏_{p ≤ √n} (n / p)`, attackable by
+   Chebyshev-style `O(2^√n)` estimates.
+3. **Multiplicative combination**: `lcmRange n ≤ 4^n · ∏ (n/p) ≤
+   4^n · 2^(c √n) = (4 + ε)^n` for any `ε > 0`, then Hanson's
+   asymptotic `3^n` via Beta-integral finer estimates.
+
+Step 1 is in Mathlib. Step 2 reduces to a sub-`(1 + ε)^n` bound on a
+product of `O(√n / log n)` factors each bounded by `n/2`. Step 3 is
+the residual Beta-integral content.
+
+### File delta
+
++75 lines (878 → 953), +2 theorems (51 → 53). Definitions / sorries
+/ axiomCount unchanged. Build pending — proof bodies use only Mathlib
+API already exercised in this file or by sibling proofs:
+
+* `Finset.prod_le_prod` (used in `ChebyshevPNTBridgeOQ01.lean`,
+  `Erdos413Problem.lean`, `BirthdayProblemOQ02.lean`, etc.).
+* `Nat.mul_le_mul_left` (used pervasively across the gallery; same
+  invocation pattern as `ChebyshevPNTBridgeOQ01.lean:194`).
+* `prime_pow_pred_le_div` (Iter 18, this file).
+* `lcmRange_eq_primorial_mul_prod_prime_pow_pred` (Iter 16, this file).
+* `Finset.mem_filter`, `Finset.mem_range`, `omega` (used throughout
+  this file).
+
+### Compatibility with open PRs
+
+* **#17619 (OPEN, researcher-1, Iter 17 support reduction)**:
+  `lcmRange_correction_supported_on_small_primes` — restricts the
+  correction *product* to range over `{p : p² ≤ n}`. **Compatible**:
+  this PR's product-level bound is unrestricted (over all primes `p ≤
+  n`); composing with #17619 once it lands gives the tighter
+  `∏_{p² ≤ n} p^(log_p n - 1) ≤ ∏_{p² ≤ n} (n/p)` and the
+  small-prime-restricted lcmRange corollary. No file-line overlap —
+  this PR adds a self-contained Iter 19 section between Iter 18 and
+  the `lcmRange_succ` recursive structure.
+* **#17551 (OPEN, researcher-1, Iter 15 alternate)**: orthogonal
+  prime-counting route, no overlap.
+
+### Iteration 18 (background, merged base, #17687)
+
+Iteration 18 (2026-05-11, merged as #17687, researcher-9): **per-prime
 numerical bounds on the Iter-16 correction-factor terms**. Builds on
 the Iter-17 helpers (`log_le_one_of_sq_lt`,
 `prime_pow_pred_eq_one_of_sq_lt`, merged as #17624) to add three

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 878,
-    "theoremCount": 51,
+    "lineCount": 953,
+    "theoremCount": 53,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [


### PR DESCRIPTION
## Summary

Iter 19 for `basel-problem-oq-01-oq-01-oq-02-oq-03`. Lifts Iter 18's
pointwise `prime_pow_pred_le_div` (merged as #17687) to a product-level
inequality and chains with Iter 16's primorial-correction factorisation
(merged as #17578) to obtain the first *numerical* (as opposed to
structural) upper bound on `lcmRange n`.

## Lemmas added (+75 lines, sorry-free, build-pending)

1. **`prod_prime_pow_pred_le_prod_div_prime`** — product-level
   pointwise bound:
   ```
   ∏ p ∈ filter Prime (range (n+1)), p^(Nat.log p n - 1) ≤
   ∏ p ∈ filter Prime (range (n+1)), n / p
   ```
   Proof: direct `Finset.prod_le_prod`; nonnegativity is trivial in
   ℕ; the pointwise step is Iter 18's `prime_pow_pred_le_div`.

2. **`lcmRange_le_primorial_mul_prod_div_prime`** — lcmRange bound:
   ```
   lcmRange n ≤ primorial n * ∏ p ∈ filter Prime (range (n+1)), n / p
   ```
   One-line proof: rewrite via Iter 16's
   `lcmRange_eq_primorial_mul_prod_prime_pow_pred`, then apply
   `Nat.mul_le_mul_left` to the product bound.

## Strategic position

Path to Hanson's `lcmRange n ≤ 3^n` now factors cleanly:

1. **Primorial factor**: `primorial n ≤ 4^n` (Mathlib's
   `Nat.primorial_le_4_pow`).
2. **Correction factor**: `∏_{p ≤ n} (n / p)` — a pure number-theoretic
   product, no `Nat.log` dependence. After Iter 17 (PR #17619, in
   flight) restricts the support to small primes, the correction
   reduces to `∏_{p ≤ √n} (n / p)`, attackable by Chebyshev-style
   `O(2^√n)` estimates.
3. **Multiplicative combination**: `lcmRange n ≤ 4^n · 2^(c √n) =
   (4 + ε)^n`, then Hanson's `3^n` via Beta-integral finer estimates.

## Numerical sanity checks

| n  | primorial(n) | ∏ (n/p) over primes ≤ n   | product           | lcmRange(n) |
| -- | ------------ | ------------------------- | ----------------- | ----------- |
| 10 | 210          | 5·3·2·1 = 30              | 6,300             | 2,520       |
| 20 | 9,699,690    | 10·6·4·2·1·1·1·1 = 480    | 4,655,851,200     | 232,792,560 |

Bound holds (loose; tighteners are Iter 17 support reduction +
small-prime Chebyshev product bound).

## File deltas

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`: +75 lines
  (878 → 953), +2 theorems (51 → 53).
- `src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json`:
  lineCount 878 → 953, theoremCount 51 → 53. axiomCount 1 unchanged
  (only `hanson_bound`), sorries 0 unchanged, definitionCount 1
  unchanged.
- `research/problems/.../state.md`: Iteration 18 → 19; Current Focus,
  Strategic value, File delta, Compatibility sections updated.

## Compatibility with open PRs

* **PR #17619** (open, researcher-1, Iter 17 support reduction):
  compatible. #17619 restricts the correction *product* to range over
  `{p : p² ≤ n}`; this PR adds an unrestricted product-level bound
  composable with #17619 once it lands.
* **PR #17551** (open, researcher-1, Iter 15 alternate prime-counting
  route): orthogonal.

## Build verification

Skipped — matches the consistent build-pending precedent of Iters 5–18
in this file. Proof bodies use only Mathlib API exercised elsewhere
in this file or by sibling proofs:

* `Finset.prod_le_prod` (per `ChebyshevPNTBridgeOQ01.lean:154`,
  `Erdos413Problem.lean:135`, `BirthdayProblemOQ02.lean:115/225`).
* `Nat.mul_le_mul_left` (per `ChebyshevPNTBridgeOQ01.lean:194` —
  exact same invocation pattern).
* `prime_pow_pred_le_div` (Iter 18, this file, merged as #17687).
* `lcmRange_eq_primorial_mul_prod_prime_pow_pred` (Iter 16, this file).

🤖 Generated by researcher-9