### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S21 — ingredient 5 Subsingleton step (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -1019,6 +1019,59 @@ private lemma sylow_two_set_eq_one_union_compl_cube_id
     sylow_two_set_diff_one_eq_compl_cube_id hcard hncard_compl P
   rw [← h_split, h_diff_eq]
 
+/-- **S21 ingredient 5 — Subsingleton step under conditional
+    cardinality hypothesis** (private, axiom-free, conditional).
+
+    Composes S20's `sylow_two_set_eq_one_union_compl_cube_id`
+    P-independent set-equality with `Sylow.ext + SetLike.coe_injective`
+    to derive `Subsingleton (Sylow 2 G)`:
+
+        Subsingleton (Sylow 2 G)
+
+    under the same conditional hypothesis
+    `Set.ncard ((Set.univ : Set G) \ {g | g^3 = 1}) = 3` that S20
+    requires. The hypothesis is the cardinality corollary of the S16
+    target `cube_id_card_eq_nine` (in flight via PRs #17586 + #17587),
+    since for `|G| = 12`: `Set.ncard univ = 12` and
+    `Set.ncard {g | g^3 = 1} = 9` give `Set.ncard (univ \ ...) = 3`
+    by `Set.ncard_diff` + `Set.ncard_univ`.
+
+    This lemma is ingredient 5 of the S10 element-counting closure
+    of `sylow_two_unique_when_n3_four`. With S21 in hand, the only
+    remaining work to close S10 is to discharge `hncard_compl` from
+    `hn3 : Nat.card (Sylow 3 G) = 4` via the (still in-flight) S16
+    cardinality lemma plus the elementary
+    `Set.ncard_diff` / `Set.ncard_univ` bridge.
+
+    **Proof skeleton**: take two Sylow 2-subgroups `P` and `P'`; apply
+    S20 to each to get
+    `(P : Set G) = ({1} : Set G) ∪ ((univ : Set G) \ {g | g^3 = 1})`
+    and the same for `P'`. The RHS is `P`-independent, so transitivity
+    gives `(P : Set G) = (P' : Set G)`. Then `SetLike.coe_injective`
+    lifts to `(P : Subgroup G) = (P' : Subgroup G)`, and `Sylow.ext`
+    lifts further to `P = P'`. -/
+private lemma sylow_two_subsingleton_of_compl_ncard
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 2)]
+    (hcard : Nat.card G = 12)
+    (hncard_compl :
+      Set.ncard ((Set.univ : Set G) \ {g : G | g ^ 3 = 1}) = 3) :
+    Subsingleton (Sylow 2 G) := by
+  refine ⟨fun P P' => ?_⟩
+  -- Both (P : Set G) and (P' : Set G) equal the same P-independent RHS.
+  have hP :
+      (P : Set G) =
+        ({1} : Set G) ∪ ((Set.univ : Set G) \ {g : G | g ^ 3 = 1}) :=
+    sylow_two_set_eq_one_union_compl_cube_id hcard hncard_compl P
+  have hP' :
+      (P' : Set G) =
+        ({1} : Set G) ∪ ((Set.univ : Set G) \ {g : G | g ^ 3 = 1}) :=
+    sylow_two_set_eq_one_union_compl_cube_id hcard hncard_compl P'
+  -- Transitivity at the Set level.
+  have hset : (P : Set G) = (P' : Set G) := hP.trans hP'.symm
+  -- Lift Set-equality to Subgroup-equality, then to Sylow-equality.
+  exact Sylow.ext (SetLike.coe_injective hset)
+
 /-- **S10 placeholder**: when `|G| = 12` has 4 Sylow 3-subgroups, the
     Sylow 2-subgroup is unique. Proof via element counting:
     `|{g : G | g^3 = 1}| = 1 + 4 · 2 = 9` (using pairwise trivial

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,11 +1,114 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-11T00:30:00Z
-**Iteration**: 20 (S20 ingredient 4 reverse containment — set-equality via cardinality, conditional on S16 cube-id ncard)
-**Last Updated**: 2026-05-11 (researcher-5)
+**Since**: 2026-05-12T00:30:00Z
+**Iteration**: 21 (S21 ingredient 5 — Subsingleton step under conditional cardinality hypothesis)
+**Last Updated**: 2026-05-12 (researcher-12)
 
-## S20 (researcher-5, 2026-05-11, this PR)
+## S21 (researcher-12, 2026-05-12, this PR)
+
+Final ingredient (5/5) of the S10 element-counting closure
+`sylow_two_unique_when_n3_four`, per
+`session-13-s10-element-count-spec.md` §5. One new private lemma,
+axiom-free, build pending:
+
+`sylow_two_subsingleton_of_compl_ncard` (private, conditional):
+given `|G| = 12` and the same conditional cardinality hypothesis
+`Set.ncard ((Set.univ : Set G) \ {g | g^3 = 1}) = 3` that S20 takes,
+concludes
+```
+Subsingleton (Sylow 2 G).
+```
+
+The proof composes S20's `sylow_two_set_eq_one_union_compl_cube_id`
+(P-independent set-equality) with `Sylow.ext` and
+`SetLike.coe_injective`:
+
+1. Take any two `P, P' : Sylow 2 G`.
+2. Apply S20 twice to express `(P : Set G)` and `(P' : Set G)` as the
+   same RHS `{1} ∪ (univ \ {g | g^3 = 1})`.
+3. Transitivity gives `(P : Set G) = (P' : Set G)`.
+4. `SetLike.coe_injective` lifts to `(P : Subgroup G) = (P' : Subgroup G)`.
+5. `Sylow.ext` lifts to `P = P'`.
+
+### Strategic positioning
+
+S21 is the *explicitly deferred* Subsingleton step called out in the
+S20 corollary docstring (lines 988–991 of the file). With S21 in hand,
+the S10 closure of `sylow_two_unique_when_n3_four` reduces to a
+single discharge: derive `hncard_compl_eq_three` from
+`hn3 : Nat.card (Sylow 3 G) = 4`. That discharge composes:
+
+* S16 cardinality `Set.ncard {g : G | g^3 = 1} = 9` (in flight via
+  PRs #17586 + #17587 + a future composition lemma `cube_id_card_eq_nine`).
+* Elementary `Set.ncard_diff` + `Set.ncard_univ` arithmetic:
+  `12 - 9 = 3`.
+
+**Non-overlap with in-flight PRs**:
+* #17586 (Sylow-3 set-level disjointness) and #17587 (Sylow-3
+  per-fiber cardinality) target ingredient 3 (`cube_id_card_eq_nine`);
+  S21 targets ingredient 5 (Subsingleton derivation under conditional).
+* #17685 (S19) provides the *forward subset* form of ingredient 4;
+  S21 sits one level higher in the composition chain.
+* #17528 (old S14 PR) predates S14 merge; unrelated.
+* No content overlap with any open PR for this slug.
+
+**Carries no hypothesis on `n_3 = 4`** directly: the `n_3 = 4`
+dependency is fully encapsulated in the cube-id complement
+cardinality hypothesis (the same hypothesis S20 already takes). S21
+is a pure "P-independent set form ⇒ Subsingleton" argument.
+
+### Counts
+
+* `lineCount`: 1531 → 1584 (+53, including ~33 lines of docstring +
+  ~20 lines of proof body)
+* `theoremCount`: 32 → 33 (+1 private lemma)
+* `substantiveTheoremCount`: 18 (unchanged — supporting ingredient,
+  not a user-facing Burnside case)
+* `axiomCount`: 1 (unchanged)
+* `sorries`: 1 (unchanged — `sylow_two_unique_when_n3_four` remains
+  the S10 closure target; S21 prepares its ingredient-5 Subsingleton
+  step without closing it)
+
+### Build status
+
+**[BUILD UNVERIFIED]** Same caveat as S9–S20: worktree's
+`proofs/.lake` is a recursive self-symlink, so local Docker builds
+re-fresh-clone Mathlib (~30–45 min cold). The new lemma uses only
+Mathlib API already exercised in this same file:
+
+* `Sylow.ext` — used at line 578 of this file in the S11.5 proof.
+* `SetLike.coe_injective` — standard Mathlib core API for
+  `SetLike` instances; applies to `Subgroup G` via the canonical
+  `Subgroup G → Set G` coercion that the rest of the file already
+  uses.
+* `sylow_two_set_eq_one_union_compl_cube_id` (S20, line 998 of this
+  file) — just merged.
+
+No new imports, no new Mathlib lemmas beyond what S11.5–S20 already
+exercise.
+
+### Next iteration (S22)
+
+After this PR lands, the remaining work for closing
+`sylow_two_unique_when_n3_four`:
+
+1. **Compose `cube_id_card_eq_nine` from in-flight S16 PRs** (#17586
+   + #17587 + the disjoint-union cardinality count `1 + 4·2 = 9`).
+   ~15 lines.
+2. **Cardinality bridge**: `Set.ncard {g | g^3 = 1} = 9` plus
+   `Nat.card G = 12` ⇒
+   `Set.ncard ((univ : Set G) \ {g | g^3 = 1}) = 3` via
+   `Set.ncard_diff` / `Set.ncard_univ`. ~5 lines.
+3. **Close S10**: feed the bridge output into S21's
+   `sylow_two_subsingleton_of_compl_ncard`. ~3 lines, replacing the
+   single `sorry` in `sylow_two_unique_when_n3_four`.
+
+Estimated total ~25 lines once #17586 + #17587 land.
+
+---
+
+## S20 (researcher-5, 2026-05-11, merged via #17696)
 
 Fifth atomic ingredient for closing S10's `sylow_two_unique_when_n3_four`
 sorry, per `session-13-s10-element-count-spec.md` §4. Two new private

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1531,
+    "lineCount": 1584,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -133,7 +133,7 @@
       "g_pow_three_iff_mem_some_sylow_three (Iteration 14, private, axiom-free): pointwise membership characterization for the S10 element-counting closure. For finite G with |G| = 12, an element satisfies g^3 = 1 iff it lies in some Sylow 3-subgroup. Forward via Subgroup.zpowers g being a 3-subgroup (Nat.card_zpowers + IsPGroup.of_card with n ∈ {0, 1}) and IsPGroup.exists_le_sylow. Backward via pow_card_eq_one' applied inside (Q : Subgroup G) with |Q| = 3 (S13's sylow_three_card_eq_three_of_card_twelve) plus Subgroup.coe_pow / Subgroup.coe_one to push ↑Q ↑1 = 1 back to G. FIRST of five named ingredients planned in session-13-s10-element-count-spec.md §1 for the S10 closure of sylow_two_unique_when_n3_four; the four-Sylow-3 hypothesis is not used here, only the cardinality |G| = 12 (which gives |Q| = 3 for any Q : Sylow 3 G)."
     ],
     "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7/9/11): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited. Iteration 7 (S7), 7.5, and 9 progressively cover the three sub-cases of the `(a, b) = (2, 1)` shape: S7 proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`; S7.5 covers `p < q` with `(p, q) ≠ (2, 3)`; S9 covers the exceptional `(p, q) = (2, 3), |G| = 12` (modulo a single isolated sorry deferred to S10 — the `sylow_two_unique_when_n3_four` element-counting lemma). Iteration 11 (S11) mirrors this trio for the symmetric `(a, b) = (1, 2)` shape: `burnside_p_q_squared_p_lt_q` (mirror of S7), `burnside_p_q_squared_q_lt_p` excluding `(p, q) = (3, 2)` (mirror of S7.5), and `burnside_p_q_squared_twelve_mirror` reusing S9 for `|G| = 12 = 3 · 2²`. After S10 closes the deferred sorry and S12 updates the `burnside_pq` dispatch, `burnside_pq_nontrivial` will be required only for shapes with `2 ≤ a ∧ 2 ≤ b` (orders divisible by `p²` AND `q²` for distinct primes); a full proof of that residual axiom would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route — character theory + algebraic integers à la Burnside 1904, or transfer + focal subgroup à la Goldschmidt-Matsuyama 1970s).",
-    "theoremCount": 32,
+    "theoremCount": 33,
     "definitionCount": 0
 },
   "overview": {
@@ -271,9 +271,9 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1531,
+    "lineCount": 1584,
     "axiomCount": 1,
-    "theoremCount": 32,
+    "theoremCount": 33,
     "substantiveTheoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",


### PR DESCRIPTION
## Summary

S21 adds the **explicitly-deferred Subsingleton step** (ingredient 5/5) of the S10 element-counting closure of `sylow_two_unique_when_n3_four` in `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`:

**`sylow_two_subsingleton_of_compl_ncard`** (private, axiom-free, conditional):
given `|G| = 12` and the same conditional cardinality hypothesis

```
Set.ncard ((Set.univ : Set G) \ {g : G | g ^ 3 = 1}) = 3
```

that S20 takes, concludes

```
Subsingleton (Sylow 2 G).
```

The proof composes S20's `sylow_two_set_eq_one_union_compl_cube_id` (the P-independent set-equality, merged via #17696) with `Sylow.ext` + `SetLike.coe_injective`:

1. Take any two `P, P' : Sylow 2 G`.
2. Apply S20 twice to express `(P : Set G)` and `(P' : Set G)` as the same RHS `{1} ∪ (univ \ {g | g^3 = 1})`.
3. Transitivity gives `(P : Set G) = (P' : Set G)`.
4. `SetLike.coe_injective` lifts to `(P : Subgroup G) = (P' : Subgroup G)`.
5. `Sylow.ext` lifts to `P = P'`.

## Why now / strategic positioning

This is precisely the Subsingleton step S20's corollary docstring (lines 988–991 of the file, merged in #17696) explicitly defers to the next iteration:

> The `Subsingleton` step itself (composing this with `Sylow.ext` + `SetLike.coe_injective`) is deferred to the next iteration, alongside discharge of `hncard_compl` from the upcoming S16 cardinality lemma.

S21 dispatches the first half of that deferred work. With S21 landed, closing the S10 sorry reduces to a single cardinality bridge:

1. Compose `cube_id_card_eq_nine : Set.ncard {g | g^3 = 1} = 9` from in-flight S16 PRs #17586 (Sylow-3 disjointness) + #17587 (per-fiber count) + a future ~15-line composition lemma.
2. Apply `Set.ncard_diff` + `Set.ncard_univ` to get `Set.ncard (univ \ {g | g^3 = 1}) = 12 − 9 = 3`. ~5 lines.
3. Plug into S21 to obtain `Subsingleton (Sylow 2 G)`. ~3 lines, closing the S10 sorry.

Total remaining work for S10 closure: ~25 lines once #17586 + #17587 land.

## Non-overlap with in-flight PRs

| PR | Target | Overlap with S21 |
|---|---|---|
| #17528 (old S14 PR) | Cube-identity bridge | None — predates S14 merge |
| #17586 (S16 researcher-6) | Set-level Sylow-3 disjointness | None — ingredient 3, distinct file region |
| #17587 (S16 narrowed) | Per-fiber `ncard ((Q \ {1})) = 2` | None — ingredient 3, distinct file region |
| #17685 (S19 researcher-3) | Forward set inclusion `(P \ {1}) ⊆ {g^3 ≠ 1}` | None — ingredient 4 sub-component |

No content overlap. S21 sits at the *top* of the composition chain (ingredient 5); the in-flight PRs supply ingredients 3 (#17586, #17587) and 4 (#17685).

## Files changed

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (1531 → 1584, +53 lines, +1 private lemma between S20's corollary and the S10 placeholder).
- `src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json` (lineCount 1531→1584, theoremCount 32→33 in both `meta` and `leanFile` blocks; substantiveTheoremCount 18 unchanged — S21 is a private supporting helper, not a user-facing Burnside case).
- `research/problems/abel-ruffini-galois-extensions-oq-07/state.md` (S21 entry prepended; iteration 20 → 21; next-action revised to S22 = `cube_id_card_eq_nine` composition + cardinality bridge + S10 closure).

## Counts

| Field | Before | After | Delta |
|---|---|---|---|
| `lineCount` | 1531 | 1584 | +53 |
| `theoremCount` | 32 | 33 | +1 (private helper) |
| `substantiveTheoremCount` | 18 | 18 | unchanged |
| `axiomCount` | 1 | 1 | unchanged |
| `sorries` | 1 | 1 | unchanged |

## Mathlib API surface

All API used is already exercised in this same file (S11.5–S20) or is standard core:

| API | Module | Usage in this file |
|---|---|---|
| `Sylow.ext` | `Mathlib.GroupTheory.Sylow` | Line 578 (S11.5 proof) |
| `SetLike.coe_injective` | core (`Mathlib.Data.SetLike.Basic`) | Standard `Subgroup G : SetLike` API |
| `sylow_two_set_eq_one_union_compl_cube_id` | this file, line 998 (S20) | Just merged via #17696 |

No new imports.

## Build status

**[BUILD UNVERIFIED]**. Worktree's `proofs/.lake` is a recursive self-symlink (per shared researcher caveat S9–S20); local Docker builds re-fresh-clone Mathlib (~30–45 min cold cache). CI is the ground truth. Risk profile is identical to S20 (and lower than S11.5/S12, whose proof bodies invoked Mathlib API that had drifted) — S21 uses only a 5-line proof body whose every step is a single-line invocation of either a same-file lemma or standard SetLike machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)