### PR TITLE
fix(meta): schauder-fp-oq03-oq01 sync lineCount 766 → 779

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 766,
+    "lineCount": 779,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -202,7 +202,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 766,
+    "lineCount": 779,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `schauder-fixed-point-oq-03-oq-01` after recent research PRs extended the Lean source.

## Evidence

`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` on `origin/main` (HEAD `4d9d2c83d19`):
- `wc -l` reports **779** lines.

`src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` had stale `lineCount: 766` in both the top-level `meta` block and the `leanFile` block.

**Before**: `lineCount: 766` (×2)
**After**:  `lineCount: 779` (×2)

Drift origin: PRs #17601 (S14 helper landed), #17654 (S15 Mathlib API drift fix), and #17697 (S16 docstring sync) extended the file by 13 lines after the most recent meta sync in #17647 (`lineCount: 668 → 766`).

Other counts unchanged and verified accurate against the Lean source:
- `axiomCount: 2` ✓ (`brouwer_unit_ball`, `approx_selection_exists`)
- `theoremCount: 5` ✓
- `definitionCount: 4` ✓
- `sorries: 0` ✓

Surgical text replacement preserves all other formatting (no JSON reformat).

---
Automated fix by lean-mechanic agent.