### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.3 rebase — case-1 arm-of-c' / case-2 leg-of-c' summand vanishings (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14746,6 +14746,81 @@ private lemma gnwProb_zero_of_col_eq_c'_case2
   apply gnwProb_unreachable_zero K x
   exact Or.inr (by omega)
 
+/-- **(S57.3, S4) Arm-of-c' summand vanishes — case 1.**
+
+In case 1 of `distinct_corners_dichotomy` (i.e., `c.1 < c'.1`), the summand
+`gnwProb μ c K (c'.1, s)` is identically zero for every `s ∈ Finset.range c'.2`,
+because the cell `(c'.1, s)` satisfies `c.1 < c'.1 = (c'.1, s).1`, so
+`gnwProb_unreachable_zero` applies via the `Or.inl` (row-disjunct) branch.
+
+**Geometric content.** The index set `{(c'.1, s) | s < c'.2}` is exactly the
+arm-of-c' cells of `(μ\c').cells` — i.e. cells in the row `c'.1` of `μ\c'`,
+which has length `c'.2` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(c'.1, 0), …, (c'.1, c'.2 − 1)`).
+
+**Role in S57.0's K-induction plan for `F_side_identity_aligned`.**  This is
+the (S4) summand vanishing.  When the joint K-induction case-splits the sum
+domain `(μ\c').cells` into off-spine / arm-of-c / leg-of-c / arm-of-c' /
+leg-of-c' subsets, the case-1 arm-of-c' contribution to both LHS and RHS
+sums of `F_side_identity_aligned` collapses to `0 · α² = 0 · ((α − 1)² + 0)`,
+sidestepping the `δ_arm` correction-term design problem flagged in S57.0.
+
+**Genericity in `μ`.**  The lemma is universal in its `μ` argument, so it
+applies equally to the LHS sum (`gnwProb μ c (h_μ x) x` over `(μ\c').cells`)
+and to the RHS sum (`gnwProb (μ\c') c (h_{μ\c'} x) x`).  Specializing
+`K := hookLength μ x.1 x.2` for the LHS or `K := hookLength (μ\c') x.1 x.2`
+for the RHS gives the integrand-level vanishing used in (S4) of the K-induction.
+
+**Relation to S57.3a per-cell variant.**  The per-cell sibling
+`gnwProb_zero_of_row_eq_c'_case1` (above) takes an arbitrary `x : ℕ × ℕ`
+with `hx : x.1 = c'.1`; this lemma is the literal-pair-summand counterpart
+indexed over a concrete `Finset.range c'.2`. -/
+private lemma sum_gnwProb_arm_of_c'_eq_zero_case1
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc1 : c.1 < c'.1) (K : ℕ) :
+    ∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0 := by
+  apply Finset.sum_eq_zero
+  intro s _
+  exact gnwProb_unreachable_zero K (c'.1, s) (Or.inl hc1)
+
+/-- **(S57.3, S5) Leg-of-c' summand vanishes — case 2.**
+
+In case 2 of `distinct_corners_dichotomy` (i.e., `c'.1 < c.1`, equivalently
+`c.2 < c'.2` by `corner_row_lt_of_col_lt`), the summand
+`gnwProb μ c K (r, c'.2)` is identically zero for every
+`r ∈ Finset.range c'.1`, because the cell `(r, c'.2)` satisfies
+`c.2 < c'.2 = (r, c'.2).2`, so `gnwProb_unreachable_zero` applies via the
+`Or.inr` (column-disjunct) branch.
+
+**Geometric content.** The index set `{(r, c'.2) | r < c'.1}` is exactly the
+leg-of-c' cells of `(μ\c').cells` — i.e. cells in the column `c'.2` of `μ\c'`,
+which has length `c'.1` (since c' = (c'.1, c'.2) was a corner of μ and got
+removed, leaving the prefix `(0, c'.2), …, (c'.1 − 1, c'.2)`).
+
+**Role in S57.0's K-induction plan for `F_side_identity_aligned`.**  This is
+the mirror of (S4): the (S5) summand vanishing for case 2.  Combined with
+`sum_gnwProb_arm_of_c'_eq_zero_case1`, both `c'`-coboundary contributions
+to `F_side_identity_aligned` are now handled by direct vanishing rather than
+genuine pointwise comparison, completing the cleanup of the "easy" branches
+of S57.0's cell partition.  The remaining work for S57.5+ targets the
+"hard" off-spine branch (S6), where genuine K-induction is required.
+
+**Genericity in `μ`.**  Universal in its `μ` argument, so it applies to both
+LHS (`gnwProb μ c (h_μ x) x`) and RHS (`gnwProb (μ\c') c (h_{μ\c'} x) x`)
+forms appearing in `F_side_identity_aligned`.
+
+**Relation to S57.3a per-cell variant.**  The per-cell sibling
+`gnwProb_zero_of_col_eq_c'_case2` (above) takes an arbitrary `x : ℕ × ℕ`
+with `hx : x.2 = c'.2`; this lemma is the literal-pair-summand counterpart
+indexed over a concrete `Finset.range c'.1`. -/
+private lemma sum_gnwProb_leg_of_c'_eq_zero_case2
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc2 : c.2 < c'.2) (K : ℕ) :
+    ∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0 := by
+  apply Finset.sum_eq_zero
+  intro r _
+  exact gnwProb_unreachable_zero K (r, c'.2) (Or.inr hc2)
+
 -- ============================================================
 -- Transpose-equivariance of `strictHookCells` and `gnwProb`
 -- (Session 58 — S57.4 reduction infrastructure)


### PR DESCRIPTION
## Summary

**Rebase of PR #17605** (open since 2026-05-09, 3 days stale) onto current `origin/main`, which now contains S57.3a per-cell variants (PR #17611), S57.4 off-spine inductive step (PR #17652), S58 transpose-equivariance (PR #17650), and S34 prefix-sym (PR #17695).

Two **sorry-free private lemmas** added to `BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted immediately after the merged S57.3a per-cell block (line ~14747) and before the merged S58 transpose-equivariance section (line ~14749):

* `sum_gnwProb_arm_of_c'_eq_zero_case1` — case 1 of `distinct_corners_dichotomy` (`c.1 < c'.1`): `∑ s ∈ Finset.range c'.2, gnwProb μ c K (c'.1, s) = 0` via `Finset.sum_eq_zero` + S57.2's `gnwProb_unreachable_zero` on the `Or.inl` (row-disjunct) branch.

* `sum_gnwProb_leg_of_c'_eq_zero_case2` — case 2 of `distinct_corners_dichotomy` (`c.2 < c'.2`): `∑ r ∈ Finset.range c'.1, gnwProb μ c K (r, c'.2) = 0` via `Finset.sum_eq_zero` + S57.2's `gnwProb_unreachable_zero` on the `Or.inr` (column-disjunct) branch.

Both lemmas are universal in `μ`, so they apply to LHS (`gnwProb μ c (h_μ x) x`) and RHS (`gnwProb (μ\c') c (h_{μ\c'} x) x`) sums of `F_side_identity_aligned` alike, completing the cleanup of the "easy" branches of S57.0's cell partition.

## Why sum-form + per-cell are both needed

Companion to S57.3a (per-cell variants, already merged). The per-cell form uses an arbitrary `x : ℕ × ℕ` with predicate `hx` (suited for `Finset.filter` reductions); the sum-form variants in this PR index over a literal `Finset.range` and construct cells via the pair constructor (no intervening `Finset.sum_image` step). Both forms are referenced (and named) in S57.3a's docstrings as the planned complement — the symmetry is already documented on main.

## Net change

| Counter | Before | After | Delta |
|---|---|---|---|
| `Helpers.lean` lineCount | 15600 | 15675 | +75 |
| Theorem/lemma count (Helpers) | — | — | +2 |
| `axiomCount` (Helpers) | 0 | 0 | 0 |
| `sorries` (Helpers) | 1 | 1 | 0 (`F_side_identity_aligned` remains) |

`meta.json` is unchanged — `meta.lineCount`/`meta.theoremCount` track the **main** file, not `Helpers.lean` (per the find-targets convention noted in MEMORY).

## Build status

**Build pending** — `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is broken on `origin/main` with ~24 errors at lines 1911–2386, blocking build verification of **all** `ballot-OQ03-OQ01-*` descendants. See MEMORY note "BallotProblemOQ03OQ02 LGV parent broken on origin/main".

Matches `(build pending)` precedent of #17695 (S34) / #17652 (S57.4) / #17650 (S58) / #17611 (S57.3a) / #17568 (S57.2) / #17537 (S57.1).

## Mathlib API verification

All names used are local to `BallotProblemOQ03OQ01OQ02Helpers.lean`:
- `gnwProb_unreachable_zero` (S57.2, line 14656 in `Helpers.lean`)
- `Finset.sum_eq_zero`, `Finset.range`, `Prod.fst/snd` projections (Mathlib stable, no drift risk)

No new imports.

## Supersedes

**PR #17605** (same content, refreshed against post-S58 main). Will close #17605 after this PR is approved.

## Test plan

- [x] `git diff` inspection: only `Helpers.lean` (+75 lines, 2 lemmas) and `state.md` (Session 61 entry) modified
- [x] No new sorries (`grep -c 'sorry'` on Helpers.lean unchanged at 1)
- [x] No new axioms (`grep -c '^axiom '` on Helpers.lean unchanged at 0)
- [x] Branched cleanly off fresh `origin/main`
- [ ] CI: build pending — parent OQ03OQ02 break tracked separately

🤖 Generated by researcher-9