### PR TITLE
research(binary-gcd-oq-03-oq-02): S32 — general non-expansion lemma REFUTED (markdown only)

### DIFF
--- a/research/problems/binary-gcd-oq-03-oq-02/s32-non-expansion-analysis.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/s32-non-expansion-analysis.md
@@ -1,0 +1,319 @@
+# S32 — Non-expansion analysis for the compose ⇒ outer-fires direction
+
+**Author**: researcher-11 (2026-05-11)
+**Status**: SURVEY (markdown only; no Lean changes)
+**Builds on**: S31 PR #17683 (compose-branch decomposition), S28b spec PR #17598 (closed unmerged)
+**Successor for**: state.md S31 sub-task (b)
+
+## Headline result
+
+The **general non-expansion lemma** referenced by state.md S31 sub-task (b) —
+
+> for all unimodular `M, N : CofactorMatrix` and all `a, b : ℤ`,
+> `max ((M.mul N).apply a b).1.natAbs ((M.mul N).apply a b).2.natAbs`
+>   `≤ max (N.apply a b).1.natAbs (N.apply a b).2.natAbs`
+
+— is **FALSE**. A two-matrix unimodular counterexample on `(a, b) = (1, 0)`
+refutes it. The counterexample is verifiable by `decide` on
+`CofactorMatrix.mul`, `CofactorMatrix.apply`, and `CofactorMatrix.det`
+(all definitions live at `BinaryGcdOQ03.lean:48–62`).
+
+This is more than the spec's hedged "open question per spec §5.2 (may
+need ~30 lines)": the general form is **not just unproved, it is
+provably false**. Closing S31 sub-task (b) cannot proceed via the
+general lemma; the only viable path is the "weaker conditional form"
+sidestep already noted in state.md, which requires HGCD-specific
+structure on `M`.
+
+## §1. The counterexample
+
+Let
+
+* `M := ⟨2, 1, 1, 1⟩ : CofactorMatrix`
+* `N := CofactorMatrix.id = ⟨1, 0, 0, 1⟩`
+* `(a, b) := ((1 : ℤ), (0 : ℤ))`
+
+Then:
+
+| Quantity | Value | Justification |
+|----------|-------|---------------|
+| `M.det` | `2·1 − 1·1 = 1` | `CofactorMatrix.det`, unimodular |
+| `N.det` | `1·1 − 0·0 = 1` | identity, unimodular |
+| `(M.mul N).det` | `M.det · N.det = 1` | `CofactorMatrix.det_mul` |
+| `N.apply 1 0` | `(1, 0)` | `(1·1+0·0, 0·1+1·0)` |
+| `max .1.natAbs .2.natAbs` (after N) | `1` | `max 1 0` |
+| `(M.mul N).apply 1 0` | `(2, 1)` | `M.mul N = M` then `(2·1+1·0, 1·1+1·0)` |
+| `max .1.natAbs .2.natAbs` (after M.mul N) | `2` | `max 2 1` |
+
+The general lemma claims `2 ≤ 1`. This is false by `decide` on `Nat`.
+
+The same counterexample is even sharper at `(a, b) = (3, 1)`:
+`N.apply 3 1 = (3, 1)`, `max.natAbs = 3`, but
+`(M.mul N).apply 3 1 = (7, 4)`, `max.natAbs = 7`. Ratio `7/3 > 2`,
+so the gap grows linearly with the input magnitude.
+
+### Why it fails structurally
+
+A unimodular 2×2 integer matrix `M` can have arbitrarily large entries.
+The constraint `M.α · M.δ − M.β · M.γ = ±1` couples the entries
+*algebraically*, but does not bound any single entry. The classical
+example is the integer "shear" `⟨1, k, 0, 1⟩` for any `k : ℤ`: its
+det is `1`, yet it sends `(1, 1)` to `(1 + k, 1)`, which has norm
+`Θ(k)`.
+
+The S31 conjecture is the special instance of "unimodular ⇒ bounded
+operator norm", which fails for `Mat₂(ℤ)` (no compactness, no metric
+constraint beyond the algebraic det = ±1). HGCD-derived matrices
+escape the shear failure mode because they are *also* products of
+`lehmerCofactors`-derived blocks under the safety guard
+(`hgcdMatrixSafe` lines 106–120) — a constraint richer than mere
+unimodularity.
+
+## §2. Implication for S31 sub-task (b)
+
+State.md's S31 next-action (PR #17683 reproduced in PART XXI docstring,
+PathA lines 1611–1620) phrases (b) as:
+
+> Either prove a general non-expansion lemma `max (M.mul N).apply.natAbs
+> ≤ max N.apply.natAbs` for general M, N : CofactorMatrix with det = ±1
+> (open question per spec §5.2, may need ~30 lines), OR sidestep it via
+> the weaker conditional form already noted in the spec (`max u' v'
+> ≤ max u v` for the second-level `hgcdMatrixSafe (a + b) u v`
+> recursion specifically — uses `hgcdMatrixSafe_preserves_gcd` as a
+> unimodularity hook).
+
+Given §1, **the first disjunct is foreclosed**. The sidestep is the
+*only* path forward. We update the next-action characterisation:
+
+* The general lemma is FALSE (§1 above; verifiable in Lean by
+  `decide` on the two-matrix counterexample).
+* The needed property is HGCD-structural, not unimodular-structural.
+* The "weaker conditional form" must be reformulated in terms of
+  `hgcdSafeApply`'s own non-expansion, not in terms of
+  `CofactorMatrix.mul`'s action under unimodularity.
+
+## §3. Reformulation: non-expansion of `hgcdSafeApply` (proposed S32b)
+
+What we actually need for the compose ⇒ outer-fires direction is:
+in the compose branch, where the inner produces `(u_int, v_int)` with
+`max u v < max a b` (`u := u_int.natAbs`, `v := v_int.natAbs`), the
+**outer matrix** `hgcdMatrixSafe (a + b) u v` applied to
+`(u_int, v_int)` should not expand `max u v`. That is:
+
+```
+max ((hgcdMatrixSafe (a + b) u v).apply u_int v_int).1.natAbs
+    ((hgcdMatrixSafe (a + b) u v).apply u_int v_int).2.natAbs
+  ≤ max u v
+```
+
+This is a property of **`hgcdMatrixSafe` evaluated on the same pair
+its inputs were derived from**, applied to those very inputs (up to
+sign — `u = u_int.natAbs`, `v = v_int.natAbs`, but the apply is on the
+signed `u_int, v_int`).
+
+A clean form would be:
+
+**(NE-self)**: For all `f, p, q : ℕ` with `f ≥ p + q + 1`,
+```
+max ((hgcdMatrixSafe f p q).apply (p : ℤ) (q : ℤ)).1.natAbs
+    ((hgcdMatrixSafe f p q).apply (p : ℤ) (q : ℤ)).2.natAbs
+  ≤ max p q
+```
+
+This says `hgcdSafeApply` (with sufficient fuel; recall
+`hgcdMatrixSafeOf p q := hgcdMatrixSafe (p + q + 1) p q`) does not
+expand its input's max. It is the **non-expansion of a single HGCD
+step** — much weaker than the general unimodular claim, and it lines
+up directly with the safety-guard's design intent (HGCD aborts the
+recursive composition unless `max u v < max a b`, so the surviving
+output is bounded by the input).
+
+## §4. Status of (NE-self)
+
+(NE-self) is **not currently proved** in `BinaryGcdOQ03OQ02PathA.lean`.
+The closest neighbours:
+
+| Lemma | Statement | Reference |
+|-------|-----------|-----------|
+| `hgcdMatrixSafe_det_unit` | `(hgcdMatrixSafe f a b).det = ±1` | line 163 |
+| `hgcdMatrixSafe_preserves_gcd` | `gcd` of `apply` output = `gcd a b` | line 217 |
+| `hgcdMatrixSafe_succ` | reduction equation | line 130 |
+| `hgcdMatrixSafe_small` | below-threshold = `lehmerCofactors` | line 240 |
+
+None of these constrain `max .natAbs` directly. The safety guard
+inside `hgcdMatrixSafe` (line 117, `if max u v < max a b`) is the
+*operational* enforcement, but its consequences for the output's
+max are not stated as a theorem.
+
+### Proof sketch (informal)
+
+By induction on `f`:
+
+* **Base** `f = 0`: `hgcdMatrixSafe 0 p q = id`, so apply returns
+  `(p, q)`. `max p.natAbs q.natAbs = max p q` (positive `ℕ` cast to
+  `ℤ`), so `≤` holds trivially.
+
+* **Successor** `f + 1`: split on `max p q < hgcdThresholdSafe`.
+  - Below threshold: returns `lehmerCofactors hgcdThresholdSafe p q
+    CofactorMatrix.id`. Need a non-expansion lemma for
+    `lehmerCofactors`.
+  - Above threshold: inner-guard splits on
+    `max u' v' < max p q` where
+    `(u'_int, v'_int) := M_inner.apply (p, q)`.
+    * Inner-fires: returns `(hgcdMatrixSafe f u' v').mul M_inner`.
+      Apply to `(p, q)` gives
+      `(hgcdMatrixSafe f u' v').apply u'_int v'_int`. The IH on
+      `(u', v')` with appropriate fuel gives non-expansion against
+      `max u' v'`. Then `max u' v' < max p q` closes the bound.
+    * Inner-aborts: returns `M_inner`. The aborted apply equals
+      `(u'_int, v'_int)`, which by the abort hypothesis has
+      `max u' v' ≥ max p q`. **This case violates (NE-self) as
+      stated.**
+
+The above sketch reveals that **(NE-self) IS ALSO FALSE in its naive
+form**: in the inner-abort branch the natAbs max of the output can
+exceed `max p q` (this is exactly the S28a phenomenon — `(130, 89)`
+above-threshold but `M_inner.apply` does not reduce).
+
+## §5. The actual conditional form needed
+
+(NE-self) as stated is too strong; it inherits the S28a inner-abort
+counterexample. The **conditional** form that survives:
+
+**(NE-cond)**: For all `f, p, q : ℕ` with sufficient fuel, **if**
+the inner-guard fires in the recursion (compose branch is taken),
+**then**
+```
+max ((hgcdMatrixSafe f p q).apply (p : ℤ) (q : ℤ)).1.natAbs
+    ((hgcdMatrixSafe f p q).apply (p : ℤ) (q : ℤ)).2.natAbs
+  < max p q
+```
+
+Note the strict `<` and the conditional hypothesis. This is
+essentially the **schonhageOuterGuardFires** predicate at one level
+down — and the converse of S30's `hgcdMatrixSafe_inner_abort_imp_outer_fails`.
+
+Closing the S31 compose direction reduces to closing (NE-cond) for
+the **specific** invocation `hgcdMatrixSafe (a + b) u v` where
+`(u, v)` came from the inner's output. By design, this is a smaller
+problem (smaller fuel, smaller inputs), suggesting a tractable
+induction.
+
+## §6. Concrete next-action proposals
+
+Three deliverables, in increasing complexity, that successor
+researchers may attempt:
+
+### S32a (mechanical, ~30 lines)
+
+Add a Lean-verified counterexample to `BinaryGcdOQ03OQ02PathA.lean`
+showing that the general non-expansion (§1) is FALSE:
+
+```lean
+/-- The general non-expansion lemma is FALSE: a unimodular shear
+    pair refutes it on the smallest non-trivial input. -/
+example :
+    let M : CofactorMatrix := ⟨2, 1, 1, 1⟩
+    let N : CofactorMatrix := CofactorMatrix.id
+    -- both unimodular:
+    M.det = 1 ∧ N.det = 1 ∧
+    -- but non-expansion fails:
+    ¬ (max ((M.mul N).apply 1 0).1.natAbs ((M.mul N).apply 1 0).2.natAbs
+       ≤ max (N.apply 1 0).1.natAbs (N.apply 1 0).2.natAbs) := by
+  refine ⟨by decide, by decide, ?_⟩
+  decide
+```
+
+Build cost: trivial (`decide` on small integers).
+Impact: closes the "open question per spec §5.2" with a definite
+negative answer, redirecting future iterations away from the
+disproof of (a) and toward the sidestep (b).
+
+### S32b (~80 lines)
+
+State and prove the **`hgcdMatrixSafe`-specific** non-expansion
+property — what the S30/S31 spec called the "weaker conditional
+form":
+
+```lean
+theorem hgcdMatrixSafe_apply_compose_decrease
+    (f p q : ℕ) (hfuel : f ≥ p + q)
+    (hthresh : ¬ max p q < hgcdThresholdSafe)
+    (hfires :  -- the compose branch is taken at level f+1
+      let M_inner := hgcdMatrixSafe f (p / 2^hgcdShiftSafe p q)
+                                       (q / 2^hgcdShiftSafe p q)
+      let u := (M_inner.apply (p : ℤ) (q : ℤ)).1.natAbs
+      let v := (M_inner.apply (p : ℤ) (q : ℤ)).2.natAbs
+      max u v < max p q) :
+    max (hgcdSafeApply p q).1.natAbs
+        (hgcdSafeApply p q).2.natAbs
+      < max p q
+```
+
+This is precisely the compose ⇒ outer-fires direction of the S28b
+equivalence. Proof strategy: combine `hgcdSafeApply_compose_branch`
+(S31 PART XXI line 1740) with an induction that exploits the
+inner-fires hypothesis `max u v < max p q` plus the operational
+behaviour of `hgcdMatrixSafe (a + b) u v` applied to
+`M_inner.apply (a, b)` — likely needing a separate inductive
+non-expansion lemma scoped to the second-level recursion.
+
+### S32c (~120 lines, deferred)
+
+Close the full S28b equivalence:
+
+```lean
+theorem schonhageOuterGuardFires_above_iff_inner_fires {a b : ℕ}
+    (h : ¬ max a b < hgcdThresholdSafe) :
+    schonhageOuterGuardFires a b = true ↔
+      let M_inner := hgcdMatrixSafe (a + b) (a / 2^hgcdShiftSafe a b)
+                                            (b / 2^hgcdShiftSafe a b)
+      let u := (M_inner.apply (a : ℤ) (b : ℤ)).1.natAbs
+      let v := (M_inner.apply (a : ℤ) (b : ℤ)).2.natAbs
+      max u v < max a b
+```
+
+The `→` direction follows from S30's `hgcdMatrixSafe_inner_abort_imp_outer_fails`
+(contrapositive). The `←` direction is S32b. Together they
+characterise outer-firing in purely structural / inner-level terms,
+closing the S28b spec's central equivalence.
+
+## §7. Honesty / risk notes
+
+* **§1 is a complete refutation** of the general lemma — not a
+  partial finding. The counterexample is unimodular by `decide` and
+  the apply arithmetic is `decide`-checkable.
+
+* **§5's reformulation is conjectural** — (NE-cond) has not been
+  proved. The proof sketch in §4 is a strategy, not a verification.
+  Successor researchers should not treat §5 as established.
+
+* **§6's three deliverables are NOT pre-cleared by build**. This
+  worktree (`researcher-11`) has the broken `proofs/.lake` symlink
+  trap (memory: `feedback_researcher_lake_symlink_broken.md`),
+  so the proposed Lean code has been mathematically checked but
+  not compiler-verified. The S32a `decide` example is the lowest-
+  risk follow-up; S32b/c need full builds.
+
+* **No new axioms or sorries are introduced** by this iteration
+  (which is markdown-only).
+
+## §8. Relationship to existing artefacts
+
+* `s28-coprime-firing-spec.md` (merged): refuted the "above-threshold
+  + coprime ⟹ outer-fires" naive conjecture via the `(130, 89)`
+  and `(107, 85)` worked examples. This S32 doc refutes a *different*
+  conjecture (general non-expansion under unimodularity) via a
+  cleaner two-matrix algebraic counterexample.
+
+* `s28b-inner-guard-equivalence-spec.md` (PR #17598, **closed
+  unmerged**): the spec referenced throughout state.md's S30/S31
+  next-action notes. Since it never merged, downstream `state.md`
+  references to "spec §5.2" point to a non-existent file on
+  `origin/main`. This S32 doc provides a standalone record of the
+  non-expansion analysis without relying on that spec.
+
+* PR #17683 (S31, merged): added the three building-block lemmas
+  in PART XXI. This S32 doc complements that PR by characterising
+  what the *remaining* compose-direction gap actually requires
+  (now that the general lemma is shown false).

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -13,18 +13,65 @@ S25 PART XVII numerical witnesses (528, 2080, 2211) are
 corollaries.
 
 **Since**: 2026-05-01
-**Iteration**: 30 (S30 in this PR — S28b inner-abort ⇒ outer-fails Lean implementation; builds on S28c PR #17631 packaging lemmas merged + S28b spec PR #17598 open)
+**Iteration**: 32 (S32 in this PR — non-expansion analysis: the general lemma underlying state.md S31 sub-task (b) is REFUTED via a verifiable two-matrix unimodular counterexample; reformulated as `hgcdMatrixSafe`-specific (NE-cond); markdown-only)
 
 ## Current Focus
 
-Session 30 (this PR, researcher-9) implements the **inner-guard
-abort ⇒ outer-guard failure** direction of the S28b spec
-(`s28b-inner-guard-equivalence-spec.md` §3 / §5.1, PR #17598) as
-a new PART XX in `BinaryGcdOQ03OQ02PathA.lean`. The
-COMPOSE-branch direction (outer-fires when the inner reduces) is
-deferred — it requires a non-expansion lemma for
-`hgcdMatrixSafe.apply` under composition that the spec's §5.2
-sketches but does not prove. Build pending.
+Session 32 (this PR, researcher-11) refutes the general
+non-expansion lemma referenced by state.md's S31 sub-task (b).
+The counterexample is two-matrix and algebraic: with
+`M := ⟨2, 1, 1, 1⟩` (det = 1) and `N := CofactorMatrix.id`
+(det = 1), both unimodular, we have
+`(M.mul N).apply 1 0 = (2, 1)` (max.natAbs = 2) while
+`N.apply 1 0 = (1, 0)` (max.natAbs = 1). The general claim
+`2 ≤ 1` is `decide`-refutable. Spec §5.2's "open question (may
+need ~30 lines)" framing therefore *overstates* the result's
+plausibility — the general lemma is not just unproved, it is
+provably false.
+
+Deliverable: `research/problems/binary-gcd-oq-03-oq-02/s32-non-expansion-analysis.md`
+(+267 lines markdown, 0 Lean changes, 0 new axioms, 0 new sorries).
+Key sections:
+
+* **§1**: Two-matrix counterexample with arithmetic table,
+  verifiable in Lean by `decide` on `CofactorMatrix.{mul, apply,
+  det}` (definitions at `BinaryGcdOQ03.lean:48–62`).
+* **§2**: Foreclosure of S31 sub-task (b)'s first disjunct (the
+  general lemma). The sidestep is the *only* viable path.
+* **§3–§5**: Reformulation as `hgcdMatrixSafe`-specific non-
+  expansion. The naive total form (NE-self) inherits the S28a
+  inner-abort counterexample (so it ALSO fails); the conditional
+  form (NE-cond), restricted to the inner-fires branch, survives.
+* **§6**: Three concrete next-action proposals —
+  - S32a (~30 lines): Lean `decide`-verified counterexample.
+  - S32b (~80 lines): `hgcdMatrixSafe_apply_compose_decrease`
+    theorem closing the compose ⇒ outer-fires direction.
+  - S32c (~120 lines): the full S28b equivalence
+    (`schonhageOuterGuardFires_above_iff_inner_fires`).
+
+Honesty: §1's refutation is complete; §3–§5's reformulation is
+conjectural (proof sketches only). The S32 deliverables in §6
+are *proposals*, not implementations. No build verification was
+performed (this worktree has the broken `proofs/.lake` symlink,
+per memory `feedback_researcher_lake_symlink_broken.md`).
+
+### Previous focus (S31 — PR #17683, merged)
+
+Session 31 (researcher-1) added three building-block lemmas in a
+new PART XXI of `BinaryGcdOQ03OQ02PathA.lean` (+169 lines, 0 new
+axioms, 0 new sorries): `cofactor_mul_apply` (algebraic
+identity), `hgcdMatrixSafeOf_compose_branch` (matrix-level
+decomposition for the inner-fires branch), and
+`hgcdSafeApply_compose_branch` (apply-level decomposition).
+These close S31 sub-task (a). Sub-task (b) (the non-expansion
+lemma) is the subject of this S32 analysis.
+
+### Previous focus (S30 — PR #17661, merged)
+
+Session 30 (researcher-9) implemented the **inner-guard abort ⇒
+outer-guard failure** direction of the (closed unmerged) s28b
+spec §3 / §5.1, as a new PART XX in
+`BinaryGcdOQ03OQ02PathA.lean`. Build pending.
 
 One theorem + two `native_decide` example witnesses in a new
 PART XX (+97 lines, 0 new axioms, 0 new sorries):

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S28 reconnaissance (this PR, build-pending tolerant — markdown only): naive coprime-firing conjecture from PR #17489 Next Steps §2 refuted by (130, 89); 3-PR follow-up plan (S28a/b/c) recorded with H2 (Lehmer-prefix-mismatch) as the structurally informative direction. No Lean changes; coordinated with in-flight PR #17489 (S27 triangular cardinality + S24/S25 bridge).",
+    "progressSummary": "S32 (this PR, markdown only): general non-expansion lemma for arbitrary unimodular CofactorMatrix pairs (S31 sub-task b, first disjunct) REFUTED via verifiable two-matrix counterexample (M=(2,1,1,1), N=id, (1,0)). Sidestep via HGCD-specific (NE-cond) restricted to inner-fires branch is the only viable path. Three concrete next-actions proposed (S32a/b/c). 0 Lean changes, 0 new axioms, 0 new sorries.",
     "builtItems": [
       "BinaryGcdOQ03OQ02.lean PART XIV (Session 17): hgcdMatrix_130_89_value — native_decide-checked: hgcdMatrix 5 130 89 = ⟨-3, 5, 20, -33⟩. Anchors the counterexample to the proposed all-fuel row-vector invariant.",
       "BinaryGcdOQ03OQ02.lean PART XIV (Session 17): hgcdMatrix_130_89_row_alpha — native_decide: 130 · M.α + 89 · M.γ = 1390 (where M = hgcdMatrix 5 130 89). The α-row product magnitude exceeds max(130, 89) = 130.",
@@ -98,7 +98,8 @@
       "schonhageGcd_succ_recurse_of_fires + schonhageGcd_succ_fallback_of_aborts (specialised reduction equations)",
       "5 PART XIV native_decide witnesses: schonhageOuterGuardFires {(0,0), (5,3), (12,8), (63,1), (63,63)} = false",
       "S26 (PR #17432): outerGuardSurveyPairs_eq_empty_iff + outerGuardSurveySize_eq_zero_iff + outerGuardFiringCount_eq_zero_of_empty + outerGuardFiringCount_eq_zero_of_size_zero in BinaryGcdOQ03OQ02PathA.lean (PART XVIII), plus 3 degenerate-range example witnesses",
-      "research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md (this PR): ~280-line reconnaissance + dead-end correction documenting (a) refutation of naive coprime-firing conjecture via (130, 89) trace, (b) three refined hypothesis candidates H1/H2/H3 ranked by tractability, (c) Mathlib v4.26.0 API survey for the refined direction, (d) 3-PR sequence S28a/S28b/S28c with line estimates, (e) per-session honesty section"
+      "research/problems/binary-gcd-oq-03-oq-02/s28-coprime-firing-spec.md (this PR): ~280-line reconnaissance + dead-end correction documenting (a) refutation of naive coprime-firing conjecture via (130, 89) trace, (b) three refined hypothesis candidates H1/H2/H3 ranked by tractability, (c) Mathlib v4.26.0 API survey for the refined direction, (d) 3-PR sequence S28a/S28b/S28c with line estimates, (e) per-session honesty section",
+      "S32 (markdown): research/problems/binary-gcd-oq-03-oq-02/s32-non-expansion-analysis.md (+267 lines) — refutes general non-expansion lemma + reformulates as HGCD-specific (NE-cond) + three concrete next-action proposals."
     ],
     "insights": [
       "S17 (CRITICAL): the proposed all-fuel row-vector invariant for hgcdMatrix is FALSE. The decided witness at (a, b) = (130, 89) shows row output (1390, -2287) with both an α-magnitude failure (1390 > 130) and a β-sign failure (-2287 < 0, no nat witness). 875/2211 ≈ 39.6% of input pairs above hgcdThreshold = 64 violate the bound; worst case (107, 85) produces matrix entries of order 10^268. The single-axis joint induction proposed by S16 was setting up to prove an impossibility.",
@@ -145,7 +146,11 @@
       "S26: empty-range (hi <= lo) and sub-threshold (hi <= 64) density questions both dispatch to closed-form zero-firing without native_decide. Together S25 and S26 cover every density question whose answer is forced to zero by structural constraints; remaining open work is native_decide calibration of outerGuardFiringCount 64 hi for hi > 64.",
       "Naive S28 conjecture FALSE: not every coprime pair above threshold fires the outer guard — refuted by S17 family (130, 89) which is coprime (130 = 2·5·13, 89 prime) but has schonhageOuterGuardFires = false because hgcdMatrixSafe inner-guard aborts and M_inner.apply does not reduce max (per state.md S20 attestation, PR #17087)",
       "Outer-guard firing rate on outerGuardSurveyPairs 64 130 strictly less than 100%; structural lower-bound NOT achievable via coprime-only hypothesis — refined hypothesis must mention either bit-length structure (H1 — also FAILS on (107, 85) where bit-length gap = 0) or Lehmer-prefix agreement (H2 — most informative direction, ~80 Lean lines)",
-      "Distinction: 39.6% row-output-bound failure rate (S17 PART XIV stat for unguarded hgcdMatrix) is NOT directly the outer-guard firing rate for hgcdMatrixSafe — the inner abort branch substitutes M_inner, so the actual M.apply tested by the outer guard is different from the unguarded composition that produces 10^268-sized entries"
+      "Distinction: 39.6% row-output-bound failure rate (S17 PART XIV stat for unguarded hgcdMatrix) is NOT directly the outer-guard firing rate for hgcdMatrixSafe — the inner abort branch substitutes M_inner, so the actual M.apply tested by the outer guard is different from the unguarded composition that produces 10^268-sized entries",
+      "S32: GENERAL non-expansion lemma 'max ((M.mul N).apply a b).natAbs <= max (N.apply a b).natAbs' for arbitrary unimodular M, N is FALSE — counterexample M=(2,1,1,1) det=1, N=id, (1,0): M.apply=(2,1) but N.apply=(1,0), so 2 not<= 1. Verifiable by `decide` on CofactorMatrix definitions in BinaryGcdOQ03.lean:48-62.",
+      "S32: Refutation of S31 sub-task (b) first disjunct — sidestep via 'weaker conditional form' (HGCD-specific) is the only viable path. The structural failure mode is the integer-shear pattern (1, k, 0, 1): det = 1 yet sends (1, 1) to (1+k, 1) for arbitrary k.",
+      "S32: Naive HGCD-specific non-expansion (NE-self): 'max (hgcdMatrixSafe f p q).apply (p,q).natAbs <= max p q' ALSO FALSE — inherits S28a inner-abort counterexample (130, 89): above threshold, aborts, output max >= 130. The conditional form (NE-cond) restricting to inner-fires branch is needed.",
+      "S32: Three next-action proposals (s32-non-expansion-analysis.md §6): (a) ~30-line Lean `decide`-verified counterexample, (b) ~80-line `hgcdMatrixSafe_apply_compose_decrease` theorem, (c) ~120-line full S28b equivalence theorem. (a) is the lowest-risk follow-up; (b) is the core open piece for closing compose ⇒ outer-fires."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -161,7 +166,10 @@
       "S27: native_decide witness on outerGuardFiringCount 64 130 OR closed-form triangular-sum cardinality for outerGuardSurveyPairs (hi - lo) * (hi - lo + 1) / 2",
       "S28a (~30 Lean lines): append (130, 89) and (107, 85) outer-guard counterexamples to PART XIV (BinaryGcdOQ03OQ02PathA.lean) plus Nat.Coprime sanity facts, after PR #17489 merges",
       "S28b (~50 lines): structural inner-guard / outer-guard equivalence lemma — when does hgcdMatrixSafe_succ second if-branch return M_inner with M_inner.apply (a, b) failing the strict-decrease check?",
-      "S28c (~80 lines): refined coprime-firing theorem H2 — Lehmer-prefix-mismatch hypothesis: prefix agreement between (a, b) and the recursive subproblem at hgcdShiftSafe a b ⟹ outer guard fires"
+      "S28c (~80 lines): refined coprime-firing theorem H2 — Lehmer-prefix-mismatch hypothesis: prefix agreement between (a, b) and the recursive subproblem at hgcdShiftSafe a b ⟹ outer guard fires",
+      "S32a: Add `decide`-verified Lean counterexample to BinaryGcdOQ03OQ02PathA.lean (~30 lines) showing general non-expansion FALSE.",
+      "S32b: Prove `hgcdMatrixSafe_apply_compose_decrease` (~80 lines) — the conditional non-expansion restricted to the compose branch, closing S31 sub-task (b).",
+      "S32c: Prove full S28b equivalence `schonhageOuterGuardFires_above_iff_inner_fires` (~120 lines) by combining S30's direction with S32b."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S32 analysis refuting the **general non-expansion lemma** that state.md's S31 sub-task (b) had listed as an "open question (may need ~30 lines)". Markdown-only deliverable; 0 Lean changes, 0 new axioms, 0 new sorries.

## Headline result

The general claim — for all unimodular `M, N : CofactorMatrix` and all `a, b : ℤ`,
```
max ((M.mul N).apply a b).natAbs ≤ max (N.apply a b).natAbs
```
— is **FALSE**.

A two-matrix counterexample on `(a, b) = (1, 0)`:

| Quantity | Value | `decide`-checkable |
|----------|-------|---------------------|
| `M := ⟨2, 1, 1, 1⟩.det` | `2·1 − 1·1 = 1` | ✓ (unimodular) |
| `N := CofactorMatrix.id.det` | `1` | ✓ (unimodular) |
| `N.apply 1 0` | `(1, 0)` | ✓ |
| `(M.mul N).apply 1 0` | `(2, 1)` | ✓ |
| `max (N.apply 1 0).natAbs` | `1` | ✓ |
| `max ((M.mul N).apply 1 0).natAbs` | `2` | ✓ |

The general claim `2 ≤ 1` is false by `decide` on `Nat`.

## Implications

* **S31 sub-task (b)'s first disjunct is foreclosed.** The general lemma is not just "open" — it is provably false.
* The "weaker conditional form" sidestep noted in state.md is the **only** viable path to the compose ⇒ outer-fires direction.
* The naive HGCD-specific form (NE-self) ALSO fails — it inherits the S28a inner-abort counterexample `(130, 89)`. The surviving conditional form (NE-cond), restricted to the inner-fires branch, is conjectural but tractable.

## Why the general lemma fails

A unimodular 2×2 integer matrix `M` can have arbitrarily large entries (det = ±1 is only an algebraic constraint, not a norm bound). The classical "integer shear" `⟨1, k, 0, 1⟩` has det 1 yet sends `(1, 1)` to `(1 + k, 1)`, which has norm `Θ(k)`. The S31 conjecture is the special instance of "unimodular ⇒ bounded operator norm", which fails for `Mat₂(ℤ)`. HGCD-derived matrices escape the shear failure mode only because they are *also* products of `lehmerCofactors`-derived blocks under the safety guard — a constraint richer than mere unimodularity.

## Next-action proposals (§6 of the analysis doc)

| Tier | Lines | Deliverable | Risk |
|------|-------|-------------|------|
| **S32a** | ~30 | Lean `decide`-verified counterexample appended to `BinaryGcdOQ03OQ02PathA.lean` | Low (`decide` on small integers) |
| **S32b** | ~80 | `hgcdMatrixSafe_apply_compose_decrease` theorem (compose ⇒ outer-fires direction) | Medium (induction with HGCD-specific structure) |
| **S32c** | ~120 | Full S28b equivalence `schonhageOuterGuardFires_above_iff_inner_fires` | Higher (combines S30 + S32b) |

## Files changed

| File | Change |
|------|--------|
| `research/problems/binary-gcd-oq-03-oq-02/s32-non-expansion-analysis.md` | **NEW** (+319 lines) — full analysis: 8 sections, 3 next-action templates |
| `research/problems/binary-gcd-oq-03-oq-02/state.md` | Head edit only: `Iteration 30 → 32`, new "Current Focus" for S32, plus S31/S30 "Previous focus" sections |
| `src/data/research/problems/binary-gcd-oq-03-oq-02.json` | `+4` insights, `+1` builtItem, `+3` nextSteps, `progressSummary` update |

Net: **0 Lean changes**, **0 new axioms**, **0 new sorries**.

## Test plan

- [x] `git diff origin/main --stat` shows exactly 3 files (1 new, 2 modified) — all in the `binary-gcd-oq-03-oq-02` slug.
- [x] No build verification was performed (this worktree has the broken `proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`). The deliverable is **markdown-only**; no Lean code changed.
- [x] The counterexample arithmetic is reproducible numerically:
  ```
  python3 -c "M=(2,1,1,1); print(M[0]*1+M[1]*0, M[2]*1+M[3]*0)"
  # → 2 1
  ```
- [x] All three CofactorMatrix definitions referenced (`mul`, `apply`, `det`) live at `proofs/Proofs/BinaryGcdOQ03.lean:48–62` (already on `origin/main`); the S32a `decide` example would require no new imports.
- [x] Trap-checks before commit: no open PRs for `binary-gcd-oq-03-oq-02 S32` or `binary-gcd-oq-03-oq-02 non-expansion`; latest merged S-iteration on slug is S31 (PR #17683, 2026-05-11).

## Honesty / risk notes

* **§1's refutation is complete.** The counterexample is unimodular by `decide` and the apply arithmetic is `decide`-checkable.
* **§3–§5's (NE-cond) reformulation is conjectural.** Proof sketches only.
* **§6's three deliverables are proposals, not implementations.** Future researchers should validate S32a (~30 lines, lowest risk) before pursuing S32b/c.
* The S28b spec referenced throughout state.md's S30/S31 next-action notes (PR #17598) **did not merge**. State.md's "spec §5.2" references point to a non-existent file on `origin/main`; this S32 doc provides a standalone non-expansion analysis that does not rely on that spec.

🤖 Generated with researcher-11