### PR TITLE
Enrich erdos101-problem: orchard regime context + Furedi-Palasti citations

### DIFF
--- a/src/data/proofs/erdos101-problem/annotations.json
+++ b/src/data/proofs/erdos101-problem/annotations.json
@@ -285,19 +285,21 @@
     "proofId": "erdos101-problem",
     "type": "definition",
     "range": {
-      "startLine": 600,
+      "startLine": 590,
       "endLine": 612
     },
-    "title": "fourCollinearFamily and the Bridge to fourPointLineCount",
-    "content": "`noncomputable def fourCollinearFamily (P : PlanarPointSet) : Finset (Finset (ℝ × ℝ))` \n\nReifies the family $F$ of 4-element collinear subsets as a `Finset` (rather than as a count), enabling per-point sub-families and biUnion arguments.\n\n`theorem fourPointLineCount_eq_family : fourPointLineCount P = (fourCollinearFamily P).card` — a one-line `rfl` that bridges the two views.\n\n**Why two definitions?** `fourPointLineCount` returns a `Nat` directly (good for stating bounds), while `fourCollinearFamily` returns the actual family (good for set-theoretic reasoning, e.g. taking sub-families like `fourCollinearThrough` or for biUnion-of-pair-sets in `improved_upper_bound`). The `rfl` bridge means we get both views *for free* once one is set up — a common Lean pattern for definition/cardinality dualities.\n\nThe `noncomputable` modifier and `open Classical in` block reflect the underlying use of `Classical.dec` to decide membership in a set defined by an existential predicate over ℝ.",
+    "title": "Related Observations and the fourCollinearFamily Bridge",
+    "content": "Two structural items between the headline bounds and the per-point argument.\n\n**Related-observations docstrings (L590–597)** record the parallel regimes the formalization deliberately *avoids* relying on:\n- *Burr–Grünbaum–Sloane / Füredi–Palásti*: configurations achieving ~n²/6 collinear triples but no four-point lines. Cited as a structural foil — these constructions break instantly under the no-5-collinear hypothesis, showing why #101's hypothesis sits at exactly the right calibration.\n- *Szemerédi–Trotter*: $|I(P,L)| \\leq C(|P|^{2/3}|L|^{2/3} + |P| + |L|)$ — the natural Mathlib-importable tool for any future o(n²) attempt. Stated for a given incidence count, not universally quantified, so importing it would require formalising the incidence-counting infrastructure first.\n\n**`noncomputable def fourCollinearFamily P : Finset (Finset (ℝ × ℝ))`** (L600–606) reifies the family $F$ of 4-element collinear subsets as a `Finset` (rather than as a count), enabling per-point sub-families and biUnion arguments.\n\n**`theorem fourPointLineCount_eq_family : fourPointLineCount P = (fourCollinearFamily P).card`** (L610–612) — a one-line `rfl` that bridges the two views.\n\n**Why two definitions?** `fourPointLineCount` returns a `Nat` directly (good for stating bounds), while `fourCollinearFamily` returns the actual family (good for set-theoretic reasoning, e.g. taking sub-families like `fourCollinearThrough` or for biUnion-of-pair-sets in `improved_upper_bound`). The `rfl` bridge means we get both views *for free* once one is set up — a common Lean pattern for definition/cardinality dualities.\n\nThe `noncomputable` modifier and `open Classical in` block reflect the underlying use of `Classical.dec` to decide membership in a set defined by an existential predicate over ℝ.",
     "significance": "supporting",
-    "mathContext": "The family $F = \\{S \\subseteq P : |S| = 4 \\wedge \\exists a \\neq b \\in S, \\forall p \\in S\\ \\text{collinear}(a,b,p)\\}$ is the central object of study. Per-point sub-families $F_p = \\{S \\in F : p \\in S\\}$ are the input to the per-point bound `fourCollinearThrough_bound`.",
+    "mathContext": "The family $F = \\{S \\subseteq P : |S| = 4 \\wedge \\exists a \\neq b \\in S, \\forall p \\in S\\ \\text{collinear}(a,b,p)\\}$ is the central object of study. Per-point sub-families $F_p = \\{S \\in F : p \\in S\\}$ are the input to the per-point bound `fourCollinearThrough_bound`. The related-observations comments locate this family in the broader landscape: triples without quadruples (orchard problem) lies one collinearity-level below, while Szemerédi–Trotter sits one tool-strength level above.",
     "relatedConcepts": [
       "fourPointLineCount",
       "fourCollinearThrough",
       "Finset.powerset.filter",
       "noncomputable / Classical reasoning",
-      "definition-cardinality duality"
+      "definition-cardinality duality",
+      "Burr–Grünbaum–Sloane orchard problem",
+      "Szemerédi–Trotter incidence bound"
     ],
     "prerequisites": [
       "Finset.powerset and Finset.filter",
@@ -309,7 +311,7 @@
     "proofId": "erdos101-problem",
     "type": "theorem",
     "range": {
-      "startLine": 631,
+      "startLine": 614,
       "endLine": 757
     },
     "title": "fourCollinearThrough_bound: At Most (n-1)/3 Four-Point Lines Through One Point",

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -51,7 +51,8 @@
       "**fourCollinearThrough per-point bound**: By erasing p from each 4-subset through p, we get disjoint 3-element subsets of P \\ {p}. Packing into n-1 points gives at most (n-1)/3 four-collinear subsets through p.",
       "**Lean's Finset API in action**: The proof uses Finset.powerset, Finset.filter, Finset.biUnion, Finset.card_biUnion (for disjoint unions), and Finset.powersetCard — a comprehensive workout of Lean 4's combinatorics library.",
       "**Why the n^{3/2} conjecture failed (Solymosi-Stojaković)**: The lower-bound constructions are *not* of the simple Grünbaum projective-plane type. Solymosi-Stojaković took an n × n integer grid, fixed a sparse subset, and used random-perturbation arguments to drive the count of four-point lines to n^{2 - O(1/√log n)}. The takeaway for this formalization: any pair-packing or per-point argument that depends only on the no-5-collinear condition cannot beat C·n²; closing the o(n²) gap will require structural information that the present proof doesn't use (incidences, additive combinatorics, or arithmetic structure of coordinates).",
-      "**Determinant vs. parametric collinearity** — a Lean design choice: the formalization defines $\\text{collinear}(p,q,r)$ via the signed-area determinant $(q_1{-}p_1)(r_2{-}p_2) = (r_1{-}p_1)(q_2{-}p_2)$ rather than the parametric form $\\exists t \\in \\mathbb{R}, r = p + t(q - p)$. The determinant is *polynomial* in the coordinates, so every collinearity manipulation closes under `ring`, `linarith`, `nlinarith`, or `polyrith` without case-splitting on slope existence or invoking `Classical` to extract an explicit $t$. The cost is that the predicate is *not symmetric a priori* in $\\{p,q,r\\}$ — paid for by the seven-lemma symmetry suite (`collinear_swap23`, `collinear_swap12`, `collinear_rotate`, `collinear_cycle`, plus three reflexivity cases). The benefit accrues at scale: `collinear_trans` only needs a single vertical/non-vertical case split, and the downstream `four_collinear_*` arguments never touch real-analytic machinery."
+      "**Determinant vs. parametric collinearity** — a Lean design choice: the formalization defines $\\text{collinear}(p,q,r)$ via the signed-area determinant $(q_1{-}p_1)(r_2{-}p_2) = (r_1{-}p_1)(q_2{-}p_2)$ rather than the parametric form $\\exists t \\in \\mathbb{R}, r = p + t(q - p)$. The determinant is *polynomial* in the coordinates, so every collinearity manipulation closes under `ring`, `linarith`, `nlinarith`, or `polyrith` without case-splitting on slope existence or invoking `Classical` to extract an explicit $t$. The cost is that the predicate is *not symmetric a priori* in $\\{p,q,r\\}$ — paid for by the seven-lemma symmetry suite (`collinear_swap23`, `collinear_swap12`, `collinear_rotate`, `collinear_cycle`, plus three reflexivity cases). The benefit accrues at scale: `collinear_trans` only needs a single vertical/non-vertical case split, and the downstream `four_collinear_*` arguments never touch real-analytic machinery.",
+      "**The Füredi–Palásti / Burr–Grünbaum–Sloane parallel regime**: Without the no-5-collinear constraint, one can construct sets achieving $\\sim n^2/6$ *collinear triples* (Burr, Grünbaum, Sloane, 1974; Füredi-Palásti, 1984), with the construction featuring no four-point lines at all. This is a structural complement to Erdős #101: relaxing the upper-collinearity bound from 5 to 4 *eliminates* four-point lines entirely in the extremal examples, demonstrating that the no-5-collinear hypothesis is genuinely calibrated to allow four-point lines to be the dominant 'rich-line' species. The current Lean file makes this connection explicit in its 'Related Observations' docstring (lines 590–597), gesturing at both the Füredi-Palásti triple regime and the Szemerédi-Trotter incidence bound as the two natural lenses through which any o(n²) improvement on the four-point-line count must filter."
     ],
     "prerequisites": [
       "Combinatorial geometry and point-line incidences",
@@ -88,6 +89,11 @@
       "targetId": "erdos-104",
       "relationship": "related",
       "description": "Erdős #104 ($100 prize): given n points in ℝ², how many unit circles contain at least 3 points? Direct curve-analogue of #101 — same $100 prize level, same Ω(n^{3/2}) ≤ answer ≤ O(n²) gap, same conjecture (subquadratic). The standard Szemerédi-Trotter-style attack for #104 (circles ↔ pseudo-lines via inversion) suggests that the o(n²) bound on #101 will require similar incidence-geometry inputs; both problems share the structural obstruction that Solymosi-Stojaković-style random constructions reach n^{2−o(1)} from below."
+    },
+    {
+      "targetId": "erdos-107",
+      "relationship": "related",
+      "description": "Erdős–Szekeres #107 (Happy Ending Problem, 1935): minimum number f(n) of planar points in general position (no three collinear) forcing a convex n-gon. Stricter no-three-collinear constraint than #101 (no-five-collinear), but the same finite-planar-configuration setting. Both ask quantitative extremal questions controlled by Ramsey-type and incidence-geometric tools; the Happy Ending lower-bound construction (Erdős-Szekeres' projective grid) parallels Grünbaum's projective construction for #101."
     }
   ],
   "leanFile": {
@@ -210,6 +216,16 @@
       "type": "textbook",
       "citation": "Grünbaum, B. (1976). \"New views on some old questions of combinatorial geometry.\" Colloq. Internat. Théorie Combin. Atti dei Convegni Lincei 17:451-468.",
       "relevance": "Source of the projective-plane construction giving Ω(n^{3/2}) four-point lines — the lower-bound that Erdős's failed n^{3/2} upper-bound conjecture matched."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Füredi, Z. & Palásti, I. (1984). \"Arrangements of lines with a large number of triangles.\" Proceedings of the American Mathematical Society 92(4):561-566.",
+      "relevance": "Companion construction in the parallel regime: arrangements with many collinear triples but no four-point lines. Cited in the Lean file's 'Related Observations' docstring (L592–593) as a structural foil — drops the upper-collinearity bound from 5 to 4 and the four-point-line count collapses to zero, illustrating why the no-5-collinear hypothesis is the right calibration for #101."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Burr, S.A., Grünbaum, B. & Sloane, N.J.A. (1974). \"The orchard problem.\" Geometriae Dedicata 2:397-424.",
+      "relevance": "Original construction of n-point sets with ~n²/6 collinear triples and no four-point lines (the 'orchard problem'). Predecessor to Füredi-Palásti; establishes the lower-bound structure for the triples-without-quadruples regime that complements #101's four-point-line counting."
     },
     {
       "type": "blog",


### PR DESCRIPTION
Enrichment pass for `erdos101-problem` (Erdős Problem #101: Four-Point Lines from Planar Point Sets).

(Re-opened replacement for #17723, which was closed after a force-push on the shared `feature/enricher-1` branch clobbered its commit. This PR is pinned to a unique `enrich/erdos101-problem-<ts>` branch per the trap-guidance.)

## Improvements

**New `keyInsight` (7th)** — *The Füredi–Palásti / Burr–Grünbaum–Sloane parallel regime*: explains why the no-5-collinear hypothesis sits at the right calibration. Without it, classical orchard-problem constructions (Burr-Grünbaum-Sloane 1974; Füredi-Palásti 1984) yield ~n²/6 collinear triples but no four-point lines — relaxing the upper-collinearity bound from 5 to 4 *eliminates* four-point lines entirely.

**New `crossReference`** to `erdos-107` (Erdős–Szekeres Happy Ending Problem, 1935) — same finite-planar-configuration setting, stricter no-three-collinear constraint, parallel projective-grid lower-bound constructions.

**Two new research-paper references**:
- Füredi, Z. & Palásti, I. (1984). "Arrangements of lines with a large number of triangles." *Proc. AMS* 92(4).
- Burr, S.A., Grünbaum, B. & Sloane, N.J.A. (1974). "The orchard problem." *Geom. Dedicata* 2.

Both are cited by name in the Lean file's "Related Observations" docstring (L592–593) but were missing from the gallery references.

**Annotation range extensions**:
- `e101-family-bridge`: L600–612 → L590–612 (now covers the "Related Observations" docstring section). Content rewritten to explicitly discuss the Burr-Grünbaum-Sloane / Füredi-Palásti and Szemerédi-Trotter context.
- `e101-per-point-bound`: L631–757 → L614–757 (now covers the section header and `fourCollinearThrough` definition immediately preceding the main theorem).

## Verification

- `python3 -m json.tool` parses both JSON files cleanly.
- `pnpm build` (vite) completed successfully (exit 0).
- No content removed; only additions and range extensions.