### PR TITLE
fix(meta): batch sync theoremCount drift (6 entries)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -67,7 +67,7 @@
       "Mathlib's Int.gcd defined via natAbs",
       "Basic absolute-value identities on ℤ"
     ],
-    "theoremCount": 8,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "sections": [
@@ -204,7 +204,7 @@
     "namespace": "BinaryGcdOQ02",
     "lineCount": 134,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 14,
     "definitionCount": 1,
     "path": "Proofs/BinaryGcdOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
@@ -68,7 +68,7 @@
     "assumptions": "3 axioms: kinematicMeasure (existence of kinematic measure on AffineHyperplane n), cauchy_crofton_segment (single-segment Cauchy-Crofton formula E_μ[crossing(s)] = α_n · length(s)), crossing_integrable (crossing indicator is integrable w.r.t. kinematic measure). No sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 7,
-    "theoremCount": 18
+    "theoremCount": 27
   },
   "overview": {
     "historicalContext": "The Cauchy-Crofton formula is a centerpiece of integral geometry, named for Augustin-Louis Cauchy (1850) and Morgan Crofton (1868). Cauchy used measure-theoretic methods to compute surface areas via projections; Crofton applied this to compute lengths and curvatures via line intersections. The general form E[#(C ∩ H)] = c_μ · length(C) for any motion-invariant measure on hyperplanes was developed in the 20th century by Blaschke, Santaló, and others as part of kinematic integral geometry.\n\nThe abstract formulation—for any measure μ satisfying the single-segment formula—reveals that shape independence is a purely linear-algebraic consequence of the measure property, requiring no geometric structure beyond the calibration condition. The crossing factor α_n (previously studied in BuffonsNeedleOQ02OQ01.lean for the parallel-hyperplane case) appears here as the universal constant encoding the geometry of the kinematic measure in ℝⁿ.\n\nBuffon's 2D needle (α₂ = 2/π) and the 3D noodle (α₃ = 1/2) are the canonical instances. The abstract Cauchy-Crofton formula unifies these and extends to arbitrary dimensions, arbitrary motion-invariant measures, and arbitrary polygonal paths.",
@@ -218,7 +218,7 @@
     "namespace": "BuffonsNeedleOQ02OQ03",
     "lineCount": 285,
     "axiomCount": 3,
-    "theoremCount": 18,
+    "theoremCount": 27,
     "definitionCount": 7,
     "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/combinations-formula-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 750,
-    "theoremCount": 24,
+    "theoremCount": 31,
     "assumptions": "None. All 31 theorems proved over arbitrary commutative rings with parameter q : R. No invertibility hypotheses; the division-free q-Pascal recurrence is used as the definition.",
     "mathlibDependencies": [
       {
@@ -206,7 +206,7 @@
     "namespace": "QBinomialCoefficients",
     "lineCount": 750,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 31,
     "definitionCount": 3,
     "mainTheorems": [
       {

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
@@ -44,7 +44,7 @@
       "Proved cramer_denom_qdet: denominator in Cramer equals the quasideterminant minor",
       "Proved qdet3_recurrence_summary: the complete recurrence theorem in one conjunction"
     ],
-    "theoremCount": 18,
+    "theoremCount": 30,
     "definitionCount": 4
   },
   "sections": [
@@ -154,7 +154,7 @@
     "namespace": "CramersRuleOQ01OQ02OQ01",
     "lineCount": 313,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 30,
     "definitionCount": 4,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -35,7 +35,7 @@
       "Proved quasideterminants equal det(A)/entry in the commutative case",
       "Proved proportionality: qdet00 * a11 = a00 * qdet11 over commutative fields"
     ],
-    "theoremCount": 26,
+    "theoremCount": 32,
     "definitionCount": 6
   },
   "sections": [
@@ -157,7 +157,7 @@
     "namespace": "CramersRuleOQ01OQ02",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 32,
     "definitionCount": 6,
     "path": "Proofs/CramersRuleOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/LebesgueMeasureOQ06Aristotle.lean"
@@ -220,7 +220,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `theoremCount` to actual values in main Lean files for six gallery entries whose proofs grew without metadata updates.

## Evidence

| slug                              | old | new | delta |
|-----------------------------------|-----|-----|-------|
| binary-gcd-oq-02                  |   8 |  14 | +6 |
| buffons-needle-oq-02-oq-03        |  18 |  27 | +9 |
| combinations-formula-oq-03        |  24 |  31 | +7 |
| cramers-rule-oq-01-oq-02          |  26 |  32 | +6 |
| cramers-rule-oq-01-oq-02-oq-01    |  18 |  30 | +12 |
| lebesgue-measure-oq-06            |  40 |  52 | +12 |

Each diff updates both `meta.theoremCount` and `leanFile.theoremCount` (4 lines changed per file). Counts verified via comment-stripped theorem/lemma regex on the main `.lean` file (find-targets convention: theoremCount = main file only).

Note: `combinations-formula-oq-03`'s `assumptions` prose already says "All 31 theorems proved over arbitrary commutative rings…" — the count fields were the only drift.

No code changes, no claim changes. Pure metadata sync.

---
Automated fix by lean-mechanic agent.