### PR TITLE
fix(meta): batch sync theoremCount drift (8 entries, +1 each)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -161,7 +161,7 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -102,7 +102,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -306,7 +306,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,

--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "assumptions": ""
     },
@@ -106,7 +106,7 @@
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "sorries": 0
     },

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Logarithmic functions on naturals",
       "Well-founded recursion and termination proofs"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2
   },
   "overview": {
@@ -177,7 +177,7 @@
     "namespace": "BinaryGcdOQ01",
     "lineCount": 215,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -51,7 +51,7 @@
     "lineCount": 391,
     "assumptions": "0 axioms, 0 sorries. 1D fixed point existence uses Mathlib's exists_mem_Icc_isFixedPt_of_mapsTo (Brouwer FPT).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 5
   },
   "overview": {
@@ -221,7 +221,7 @@
     "namespace": "BrouwerOQ02",
     "lineCount": 391,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 5,
     "path": "Proofs/BrouwerFixedPointOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -49,7 +49,7 @@
     "lineCount": 442,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5
   },
   "overview": {
@@ -229,7 +229,7 @@
     "namespace": "CantorDiagonalizationOQ01",
     "lineCount": 442,
     "axiomCount": 2,
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -47,7 +47,7 @@
     "lineCount": 400,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2
   },
   "overview": {
@@ -129,7 +129,7 @@
     "namespace": "CombinationsFormula",
     "lineCount": 400,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "path": "Proofs/CombinationsFormula.lean",
     "sorries": 0

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 600,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 30,
+    "theoremCount": 31,
     "definitionCount": 12
   },
   "overview": {
@@ -196,7 +196,7 @@
     "namespace": "SternBrocot",
     "lineCount": 600,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 31,
     "definitionCount": 12,
     "path": "Proofs/DenumerabilityRationalsOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Routine post-research `theoremCount` drift across 8 gallery entries.

## Evidence

For each entry, the Lean source file (`leanFile.path`) has one more
`theorem`/`lemma` declaration than `meta.theoremCount` and
`leanFile.theoremCount` claim. Likely the result of recent research/audit
PRs that added a theorem and bumped `lineCount` but did not bump
`theoremCount`.

Counts validated by Python regex against each entry's `leanFile.path`,
with a Lean comment stripper that handles nested block comments. Both
`meta.theoremCount` and `leanFile.theoremCount` updated via string
replace to preserve formatting (per `feedback_mechanic_plumbing_json_format.md`).

Entries (all old → new = N → N+1):

| slug | old | new |
| --- | --- | --- |
| amgm-inequality-oq-02 | 25 | 26 |
| amgm-inequality-oq-02-oq-02 | 17 | 18 |
| bezout-identity-oq-03-oq-03 | 7 | 8 |
| binary-gcd-oq-01 | 3 | 4 |
| brouwer-fixed-point-oq-02 | 12 | 13 |
| cantor-diagonalization-oq-01 | 27 | 28 |
| combinations-formula | 25 | 26 |
| denumerability-rationals-oq-03 | 30 | 31 |

Diff: 8 files changed, 16 insertions(+), 16 deletions(-).

---
Automated fix by lean-mechanic agent.