### PR TITLE
research(birthday-problem-oq-01-oq-02): S1 OBSERVE — Markov + Paley-Zygmund coupling survey

### DIFF
--- a/research/problems/birthday-problem-oq-01-oq-02/knowledge.md
+++ b/research/problems/birthday-problem-oq-01-oq-02/knowledge.md
@@ -1,0 +1,166 @@
+# Knowledge — birthday-problem-oq-01-oq-02
+
+## S1 (researcher-12, 2026-05-11) — OBSERVE survey
+
+### Problem snapshot
+
+The OQ asks: can the **coupling between expected shared-birthday pairs and
+the collision probability** be formalised? Two existing gallery proofs
+treat the birthday problem from complementary angles:
+
+| Source | Quantity | Type | Approach |
+|--------|----------|------|----------|
+| `BirthdayProblemOQ01.lean` | `expectedPairs n d = C(n,2)/d` | `ℚ` | linearity of expectation over pair indicators |
+| `BirthdayProblemOQ02.lean` | `probCollision k d = 1 - ∏(1 - i/d)` | `ℝ` | finite-product collision probability |
+| `BirthdayProblemOQ01OQ01.lean` | `collisionCount f : ℕ` | random variable | finite sample space `(Fin n → Fin d)` |
+
+There is **no current formal proof** that these viewpoints sandwich
+the same collision probability. The two natural couplings are:
+
+```
+(MARKOV)         probCollision n d ≤ ↑(expectedPairs n d)
+(PALEY-ZYGMUND)  probCollision n d ≥ (expectedPairs n d)² / E[X²]
+```
+
+### Markov bound — the one-line proof
+
+```
+1 - ∏_{i<n} (1 - i/d)  ≤  ∑_{i<n} i/d  =  n(n-1)/(2d)  =  C(n,2)/d
+```
+
+The middle equality is `gauss_sum_div` (`BirthdayProblemOQ02.lean:145`).
+The first inequality is the **union bound for products**, provable by
+induction on the index set:
+
+| Step | Identity | Comment |
+|------|----------|---------|
+| Base | `1 - ∏ ∅ = 0 ≤ 0` | `Finset.prod_empty`, `Finset.sum_empty`. |
+| Step | `1 - (1-a)·P = a + (1-a)·(1-P) ≤ a + (1-P) ≤ a + ∑ rest` | `(1-a) ≤ 1` since `a ≥ 0`; `(1-P) ≥ 0` by inductive nonnegativity. |
+
+Critical micro-fact: `(1-a)·(1-P) ≤ 1-P` when `0 ≤ 1-a ≤ 1` and
+`0 ≤ 1-P`. Direct `nlinarith` or `mul_le_one_of_nonneg`.
+
+### Paley–Zygmund bound
+
+The discrete form: for a nonneg random variable `X` with `E[X²] > 0`,
+```
+P(X > 0) ≥ E[X]² / E[X²]
+```
+Proof: Cauchy-Schwarz, `E[X · 1_{X>0}]² ≤ E[X²] · P(X > 0)`,
+and `E[X · 1_{X>0}] = E[X]` when `X ≥ 0`.
+
+Substituting `X = collisionCount f` and using `E[X] = expectedPairs n d`
+(`OQ01OQ01:?`) and `E[X²] ≤ E[X] + E[X]²` (from `Var(X) ≤ E[X]` which
+is `variancePairs_le_expected`, `OQ01:164`) gives an explicit lower
+bound:
+```
+probCollision n d ≥ (C(n,2)/d)² / (C(n,2)/d + (C(n,2)/d)²)
+                  = (C(n,2)/d) / (1 + C(n,2)/d)
+```
+
+For `C(n,2)/d ≥ 1` (i.e. `n ≥ 28` when `d = 365`) this gives
+`probCollision ≥ 1/2`, matching the classical threshold.
+
+### Worked numerics (for sanity)
+
+`d = 365`, `n = 23`: `C(23,2) = 253`, `expectedPairs = 253/365 ≈ 0.6932`.
+`probAllDistinct 23 365 ≈ 0.4927`, `probCollision ≈ 0.5073`.
+
+Check Markov: `0.5073 ≤ 0.6932` ✓ (gap ≈ 0.186).
+Check Paley-Zygmund: `≥ 0.6932/(1 + 0.6932) = 0.4097` ✓ (gap ≈ 0.097).
+Check exponential (`OQ02.probCollision_ge`): `≥ 1 - exp(-253/365) ≈
+0.5000`. Gap ≈ 0.007 — the exponential bound is sharper here than
+Paley-Zygmund.
+
+`n = 50`: `C(50,2)/365 ≈ 3.36`, `probCollision ≈ 0.9704`.
+- Markov: `0.9704 ≤ 3.36` ✓ (vacuous when E[X] > 1).
+- Paley-Zygmund: `≥ 3.36/4.36 ≈ 0.7706` ✓.
+- Exponential: `≥ 1 - exp(-3.36) ≈ 0.9653`. Again sharper.
+
+**Conclusion**: the exponential bound (OQ02) is tighter than
+Paley-Zygmund for moderate `n`, but Markov has the **strictly simpler
+proof** and gives a sharp **upper** bound that the exponential argument
+does not provide. The two couplings are complementary, not redundant.
+
+### Bridge between OQ02 product formula and OQ01OQ01 counting
+
+`OQ02.probAllDistinct n d = ∏_{i=0}^{n-1} (1 - i/d)` is a real product.
+
+`OQ01OQ01` characterises injective `f : Fin n → Fin d` and proves
+`#injective = Nat.descFactorial d n` (`Fintype.card_embedding_eq`,
+`OQ01OQ01:?`). The probability `P(X = 0) = P(f injective) =
+descFactorial(d,n) / d^n`.
+
+These two real numbers are **equal** by the identity
+```
+∏_{i=0}^{n-1} (1 - i/d)  =  ∏_{i=0}^{n-1} (d - i) / d  =  descFactorial(d,n) / d^n
+```
+(provided `n ≤ d`; for `n > d`, both equal 0). Direct telescoping
+proof, ~30 lines.
+
+**Without this bridge** the Markov bound (states a real ≤ real) and the
+Paley-Zygmund bound (needs the finite-sample-space `X`) are speaking
+to slightly different `probCollision`s. The bridge unifies them.
+
+### Insights
+
+1. **Markov coupling is one-line**: just `one_sub_prod_le_sum` + `gauss_sum_div`.
+   Likely a 50–60 line single-PR S2/S3 deliverable.
+2. **Paley-Zygmund is heavier** (~80 lines) because it needs the
+   bridge S6 between OQ02's product and OQ01OQ01's counting. Best done
+   in two sessions: S5 (Paley-Zygmund proof skeleton) after S6 (bridge).
+3. **The exponential bound (OQ02) is generally sharper than Paley-Zygmund**
+   for the birthday parameter range, but Markov gives an **upper** bound
+   that complements OQ02's lower bound exclusively.
+4. **`variancePairs_le_expected` (OQ01:164) gets a downstream client** as
+   soon as Paley-Zygmund lands. Currently it sits unused.
+5. **No new axioms needed.** The file stays `verified` once all sorries
+   close (target: 0 sorries after S2/S3/S5/S6).
+
+### Mathlib gaps (at the pinned revision)
+
+1. **No `Finset.one_sub_prod_le_sum` lemma** that fires directly on the
+   product/sum form `1 - ∏(1 - f i) ≤ ∑ f i`. Provable in ~25 lines as
+   `one_sub_prod_le_sum` in this file's S2.
+2. **No discrete-sample-space `Markov` / `Paley-Zygmund`** that mirrors
+   the measure-theoretic `MeasureTheory.measure_*_inv_le_*` family.
+   Mathlib's measure-theoretic versions require setting up a
+   `MeasureSpace` / probability measure on `Fin n → Fin d`, which is
+   non-trivial in `decide`-style proofs. A direct combinatorial statement
+   sidesteps this entirely.
+3. **No worked `descFactorial`-to-`probAllDistinct` bridge** in Mathlib;
+   `Fintype.card_embedding_eq` exists but the explicit product-to-counting
+   identity for the birthday problem is not in the Probability namespace.
+
+### Mathlib API names
+
+- `Finset.prod_range_succ`, `Finset.prod_range_succ_comm` — induction step API
+- `Finset.sum_range_succ` — sum induction step
+- `Finset.prod_empty`, `Finset.sum_empty` — base cases
+- `mul_le_one`, `mul_le_one_of_nonneg` — `(1-a)·(1-P) ≤ 1-P` step
+- `nlinarith` / `linarith` for `0 ≤ (1-a)·(something nonneg)`
+- `pushCast`, `norm_cast`, `Rat.cast_div` — ℚ → ℝ bridging
+- `gauss_sum_div` (in-gallery, `OQ02:145`)
+- `two_mul_choose_two` (in-gallery, `OQ01:109`)
+- `Nat.descFactorial` (Mathlib `Combinatorics.Choose.Factorial`)
+- `Fintype.card_embedding_eq` (Mathlib `Data.Fintype.Pi`)
+
+### Risk Notes
+
+- The `proofs/.lake` symlink is broken (`feedback_researcher_lake_symlink_broken`),
+  costing ~25–45 minutes per Docker build. S2 is short enough to finish
+  with one end-of-S2 build; S5 likely needs two sessions.
+- `Rat.cast` elaboration can be slow on long chains; pre-emptively
+  `push_cast` between steps.
+- Aristotle is a good target for the `one_sub_prod_le_sum` helper
+  (`S2`) once the inductive proof skeleton is committed.
+
+### Next-Action priority list
+
+| Session | Target | Est. lines | Build |
+|---------|--------|-----------:|-------|
+| S2 | `one_sub_prod_le_sum` helper | ~25 | yes |
+| S3 | `probCollision_le_expectedPairs` (Markov) | ~40 | yes |
+| S6 | `probAllDistinct_eq_descFactorial_div` (bridge) | ~30 | yes |
+| S4 | second moment `E[X²]` formula | ~50 | yes |
+| S5 | `probCollision_ge_paley_zygmund` | ~80 | maybe split |

--- a/research/problems/birthday-problem-oq-01-oq-02/problem.md
+++ b/research/problems/birthday-problem-oq-01-oq-02/problem.md
@@ -1,0 +1,204 @@
+# Problem: Coupling between expected pairs and collision probability
+
+**Slug**: `birthday-problem-oq-01-oq-02`
+**Parent**: `birthday-problem-oq-01` (Expected Number of Shared Birthday Pairs, verified, 0 sorries / 0 axioms)
+**Sibling proofs**: `birthday-problem-oq-01-oq-01` (collision-count distribution), `birthday-problem-oq-02` (tight collision asymptotics)
+
+## Plain Statement
+
+Two quantitative measures of "how likely is a birthday collision among `n` people choosing from `d` equally-likely birthdays" appear in the gallery:
+
+1. **Expected shared-pair count** (parent `birthday-problem-oq-01`):
+   ```
+   expectedPairs n d = (Nat.choose n 2 : ℚ) / (d : ℚ) = n(n-1) / (2d)
+   ```
+   A purely *first-moment* quantity computed by linearity of expectation
+   over the C(n,2) pair-indicators `I_{f(i)=f(j)}`, each Bernoulli(1/d).
+
+2. **Collision probability** (sibling `birthday-problem-oq-02`):
+   ```
+   probCollision k d = 1 - probAllDistinct k d
+                     = 1 - ∏_{i=0}^{k-1} (1 - i/d)
+   ```
+   The actual probability that at least one pair shares a birthday under
+   the uniform model. Already bounded above by the exponential approximation
+   `1 - exp(-k(k-1)/(2d))` (`probCollision_ge`, `BirthdayProblemOQ02.lean:175–181`).
+
+**The open question** is to formalise the **direct Markov coupling**
+between these two quantities, plus its second-moment lower-bound companion:
+
+```
+(MARKOV)            probCollision n d ≤ ↑(expectedPairs n d)
+(PALEY-ZYGMUND)     probCollision n d ≥ (expectedPairs n d)² / E[X²]
+```
+
+where `E[X²]` is the second moment of the shared-pair count
+`X(f) = collisionCount f` (defined in
+`BirthdayProblemOQ01OQ01.lean:50–58`).
+
+## Why this Matters
+
+1. **Closes a methodology gap.** The gallery contains both moment-based
+   (`OQ01`: `expectedPairs`, `variancePairs`) and probability-based
+   (`OQ02`: `probCollision`) treatments of the birthday problem, but no
+   formal proof that the two viewpoints **bracket the same quantity**.
+   The Markov bound is the natural one-line bridge.
+2. **First-moment ↔ second-moment coupling.** Formalising both Markov
+   (uses `E[X]`) and Paley-Zygmund (uses `E[X²]`) exercises the variance
+   bound `variancePairs_le_expected` (`OQ01:164`) — the latter sits unused
+   in the gallery without a coupling theorem to give it a downstream
+   client.
+3. **Companion to the exponential bound.** The OQ02 exponential bound
+   `probCollision ≥ 1 - exp(-k(k-1)/(2d))` and this coupling's Markov
+   bound `probCollision ≤ k(k-1)/(2d)` together sandwich `probCollision`
+   between two closed forms — neither implies the other in general
+   (different regimes: Markov is sharpest at small `k(k-1)/d`, exponential
+   bound is sharpest near the threshold).
+4. **Mathlib gap.** The first-moment / second-moment Markov / Paley-Zygmund
+   bounds are well-known but, at the pinned Mathlib revision, are not
+   stated for *deterministic* (finite-sample-space) random variables in a
+   form that mirrors the explicit `probAllDistinct` product. A
+   gallery-side formalisation has standalone teaching value and may
+   propagate upstream.
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib name (Lean 4) | Module |
+|------|----------------------|--------|
+| Finset product `∏ i ∈ range n, f i` | `Finset.prod_range_succ` | `Mathlib.Algebra.BigOperators.Group.Finset` |
+| Finset sum `∑ i ∈ range n, f i` | `Finset.sum_range_succ` | `Mathlib.Algebra.BigOperators.Group.Finset` |
+| `(1 - a)(1 - b) ≥ 1 - a - b` | `mul_self_nonneg` + `nlinarith` | (algebra) |
+| `Finset.one_sub_prod_le_sum` (union bound) | **not in Mathlib at pin** | (gap; provable by induction) |
+| `Finset.card_filter_le` | `Finset.card_filter` family | `Mathlib.Data.Finset.Card` |
+| `Real.exp` and `add_one_le_exp` | `Real.add_one_le_exp` | `Mathlib.Analysis.SpecialFunctions.Exp` |
+| Markov inequality (measure-theoretic) | `MeasureTheory.measure_inv_le_inv_mul_lintegral_of_*` family | `Mathlib.MeasureTheory.Function.LpSpace.*` |
+| Rat → Real cast | `Rat.cast`, `Nat.cast_div_le`, `pushcast` tactic | `Mathlib.Data.Rat.Cast.Defs` |
+| Variance ≤ E[X] | `variancePairs_le_expected` | `BirthdayProblemOQ01:164–172` |
+| Gauss sum `∑ i/d = k(k-1)/(2d)` | `gauss_sum_div` | `BirthdayProblemOQ02:145–150` |
+| collisionCount `X(f)` random variable | `collisionCount`, `collisionCount_eq_zero_iff_injective` | `BirthdayProblemOQ01OQ01:50–58` |
+| `descFactorial(d,n)` for # injective | (`Fintype.card_embedding_eq`) | `Mathlib.Data.Fintype.Pi` |
+
+### Existing in-gallery infrastructure (no Mathlib search needed)
+
+- `expectedPairs n d : ℚ` and `expectedPairs_eq_rational : 2*d*expectedPairs n d = n*(n-1)` (`OQ01:138`).
+- `variancePairs n d : ℚ` and `variancePairs_le_expected` (`OQ01:164`).
+- `probAllDistinct k d : ℝ` and `probCollision k d : ℝ = 1 - probAllDistinct k d` (`OQ02:67–73`).
+- `gauss_sum_div k d : ∑ i ∈ range k, (i:ℝ)/d = k*(k-1)/(2*d)` (`OQ02:145`).
+- `probAllDistinct_le_exp` and `probCollision_ge` (`OQ02:158–181`).
+- `collisionCount : (Fin n → Fin d) → ℕ` and `collisionCount_eq_zero_iff_injective` (`OQ01OQ01:50–60`).
+
+## Suggested Next-Action Decomposition
+
+S1 (this iteration) is **OBSERVE** — no Lean changes, only the
+problem statement, infrastructure map, and S2+ decomposition below.
+
+### S2 — Generic union bound for products
+
+State and prove the standalone lemma
+
+```lean
+theorem one_sub_prod_le_sum {n : ℕ} (f : ℕ → ℝ)
+    (hnn : ∀ i, i < n → 0 ≤ f i) (hle : ∀ i, i < n → f i ≤ 1) :
+    1 - ∏ i ∈ Finset.range n, (1 - f i) ≤ ∑ i ∈ Finset.range n, f i
+```
+
+in a new file `proofs/Proofs/BirthdayProblemOQ01OQ02.lean`. Proof by
+induction on `n` (~25 lines):
+
+- **Base `n = 0`**: `1 - ∏ ∅ (...) = 1 - 1 = 0 ≤ 0 = ∑ ∅ (...)`. `simp`.
+- **Step**: with `a := f n` and `P := ∏ i ∈ range n, (1 - f i)`,
+  `1 - (1 - a) · P = a + (1 - a) · (1 - P)`.
+  Both `(1 - a) ∈ [0, 1]` and `(1 - P) ∈ [0, 1]` (chain of inductive
+  positivity), so `(1 - a) · (1 - P) ≤ 1 - P`, giving
+  `1 - (1 - a) · P ≤ a + (1 - P) ≤ a + ∑ rest = ∑ all`.
+
+### S3 — Specialisation to birthday product (the Markov bound)
+
+```lean
+theorem probCollision_le_expectedPairs (n d : ℕ) (hd : 0 < d) :
+    probCollision n d ≤ ((expectedPairs n d : ℚ) : ℝ) := by
+  unfold probCollision probAllDistinct expectedPairs
+  -- 1 - ∏(1 - i/d) ≤ ∑ i/d  by `one_sub_prod_le_sum`
+  -- ∑ i/d = n(n-1)/(2d)      by `gauss_sum_div`
+  -- n(n-1)/(2d) = C(n,2)/d  by `two_mul_choose_two` (rearranged)
+  sorry
+```
+
+Chains S2's union bound with `gauss_sum_div` (OQ02) and
+`two_mul_choose_two : 2 * n.choose 2 = n * (n - 1)` (OQ01:109).
+~40 lines once the casts are stabilised (`Rat.cast`, `pushcast`).
+
+### S4 — Variance / second-moment computation
+
+Compute `E[X²] = Var(X) + E[X]²` formally in OQ01-OQ02 style:
+
+```lean
+theorem expectedPairs_sq_le_expected_add_expected_sq (n d : ℕ) (hd : 1 ≤ d) :
+    ((expectedPairs n d : ℚ) : ℝ) ^ 2
+      ≤ ((variancePairs n d + expectedPairs n d ^ 2 : ℚ) : ℝ)
+```
+
+(equality is provable but inequality is what feeds Paley-Zygmund).
+Direct algebraic rearrangement using `variancePairs n d ≥ 0`
+(provable from `OQ01.variancePairs_nonneg`).
+
+### S5 — Paley-Zygmund lower bound
+
+```lean
+theorem probCollision_ge_paley_zygmund (n d : ℕ) (hd : 1 ≤ d) (hn : 2 ≤ n) :
+    probCollision n d ≥
+      (((expectedPairs n d : ℚ) : ℝ) ^ 2) /
+      (((variancePairs n d + expectedPairs n d ^ 2 : ℚ) : ℝ))
+```
+
+Uses the discrete Paley-Zygmund identity
+`E[X]² ≤ E[X · 1_{X ≥ 1}] · P(X ≥ 1)` (Cauchy-Schwarz),
+then `E[X · 1_{X ≥ 1}] ≤ E[X²]^{1/2} · P(X ≥ 1)^{1/2}` etc.
+Substantially heavier (~80 lines) because it requires bridging
+`probAllDistinct` (OQ02 product formulation) and `collisionCount` /
+`Fintype.card` (OQ01OQ01 finite-sample-space formulation).
+
+### S6 — Bridge between OQ02 product and OQ01OQ01 counting
+
+Standalone helper:
+
+```lean
+theorem probAllDistinct_eq_descFactorial_div (n d : ℕ) (hd : 0 < d) :
+    probAllDistinct n d
+      = (Nat.descFactorial d n : ℝ) / ((d : ℝ) ^ n)
+```
+
+i.e. `∏_{i=0}^{n-1}(1 - i/d) = d!/((d-n)! · d^n)`. Both formulations
+should be PROVED equal so that the Markov bound (S3) and the
+Paley-Zygmund bound (S5) can speak to a common P(collision).
+~30 lines: telescoping the product `∏(1 - i/d) = ∏(d - i)/d` and
+identifying with `descFactorial`.
+
+S6 can be done **before** S5 to give the latter a clean foundation.
+
+## Risk Notes
+
+- The `proofs/.lake` symlink in researcher worktrees is broken
+  (`feedback_researcher_lake_symlink_broken.md`); each Docker build
+  costs ~25–45 minutes of fresh Mathlib clone. S2 is short enough
+  that an end-of-S2 Docker build is feasible; S5 may need to be
+  split into multiple sessions.
+- No axioms required. `status` will be `verified` once all sorries
+  close.
+- The `Rat.cast` / `Real.cast` chain can produce surprising elaboration
+  delays. Pre-emptively use `push_cast` / `norm_cast` between coupling
+  steps.
+- Paley-Zygmund in S5 requires bridging the product (OQ02) and counting
+  (OQ01OQ01) formulations of `probCollision`. The bridge S6 is the
+  key prerequisite.
+
+## References
+
+- Markov's inequality: standard probability text (e.g.
+  Grimmett & Stirzaker §3.6).
+- Paley–Zygmund inequality: Kahane (1985) *Some Random Series of
+  Functions*, Theorem 6.1.
+- Birthday problem second moment: covered in Mitzenmacher & Upfal
+  *Probability and Computing* §3.3.
+- Union bound: any introductory probability text;
+  Bonferroni's inequality of order 1.

--- a/research/problems/birthday-problem-oq-01-oq-02/state.md
+++ b/research/problems/birthday-problem-oq-01-oq-02/state.md
@@ -1,0 +1,115 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-12): Initial survey of the coupling between
+`BirthdayProblemOQ01.expectedPairs` (first-moment quantity, `ℚ`) and
+`BirthdayProblemOQ02.probCollision` (probability quantity, `ℝ`).
+Establishes:
+
+1. **Markov coupling** `probCollision ≤ ↑expectedPairs` is a direct
+   chain of `one_sub_prod_le_sum` (union bound for products) + the
+   existing `gauss_sum_div` (`OQ02`). ~40 lines.
+2. **Paley-Zygmund coupling** `probCollision ≥ E[X]² / E[X²]` is
+   heavier — requires (a) the second-moment formula in OQ02-style and
+   (b) a bridge to the OQ01OQ01 finite-sample-space `collisionCount`
+   random variable. ~80 lines split over S5/S6.
+3. **Bridge** `probAllDistinct n d = descFactorial(d,n) / d^n` unifies
+   OQ02's product formulation and OQ01OQ01's counting formulation;
+   needed for Paley-Zygmund but stands as its own ~30-line lemma.
+
+## Active Approach
+
+**Two complementary couplings, Markov first.**
+
+The Markov path (S2 → S3) is mechanical: a new helper
+`one_sub_prod_le_sum` + the existing `gauss_sum_div` + `two_mul_choose_two`
++ casts. This delivers the upper-bound half of the coupling.
+
+The Paley-Zygmund path (S4 → S6 → S5) is heavier and depends on the
+bridge S6 between OQ02 and OQ01OQ01. Deferred to multiple sessions.
+
+The two couplings together place `probCollision` strictly between
+`(C(n,2)/d) / (1 + C(n,2)/d)` (P-Z lower) and `C(n,2)/d` (Markov upper).
+For `n ≥ 28` (`d = 365`) the lower bound is ≥ 1/2, recovering the
+classical birthday threshold without invoking the exponential bound.
+
+## Blockers
+
+None mathematical. Practical: the `proofs/.lake` symlink is broken in
+researcher worktrees (~25-45 min cost per Docker build), but S2/S3 are
+short enough that one end-of-S3 Docker build is feasible.
+
+## Next Action
+
+**S2 (any researcher)**: Create
+`proofs/Proofs/BirthdayProblemOQ01OQ02.lean` and add the helper:
+
+```lean
+import Mathlib.Tactic
+import Mathlib.Algebra.BigOperators.Group.Finset
+import Proofs.BirthdayProblemOQ01
+import Proofs.BirthdayProblemOQ02
+
+namespace BirthdayProblemOQ01OQ02
+
+open BirthdayProblemOQ01 BirthdayProblemOQ02 BigOperators
+
+/-- Union-bound form: for `f` valued in `[0, 1]`,
+    `1 - ∏ (1 - f i) ≤ ∑ f i`. -/
+theorem one_sub_prod_le_sum {n : ℕ} (f : ℕ → ℝ)
+    (hnn : ∀ i, i < n → 0 ≤ f i) (hle : ∀ i, i < n → f i ≤ 1) :
+    1 - ∏ i ∈ Finset.range n, (1 - f i)
+      ≤ ∑ i ∈ Finset.range n, f i := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    -- ... use `Finset.prod_range_succ`, `Finset.sum_range_succ`,
+    -- and the algebraic identity
+    --   1 - (1-a)·P = a + (1-a)·(1-P)
+    -- with the bound (1-a)·(1-P) ≤ 1-P from 0 ≤ 1-a ≤ 1.
+    sorry
+
+end BirthdayProblemOQ01OQ02
+```
+
+Verify with Docker build (`./proofs/scripts/docker-build.sh
+Proofs.BirthdayProblemOQ01OQ02`) at the end of S2; ~25-45 min wall-clock
+with the broken `.lake` symlink.
+
+**S3 (next session after S2)**: Add the Markov coupling
+`probCollision_le_expectedPairs`. Chains `one_sub_prod_le_sum` with
+`gauss_sum_div` (OQ02:145) and `two_mul_choose_two` (OQ01:109) plus
+`push_cast` for the ℚ → ℝ bridge.
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 survey)
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Open files
+
+- `problem.md` — Plain statement, why-it-matters, Mathlib infrastructure
+  map, S2-through-S6 decomposition, risk notes.
+- `knowledge.md` — S1 session note: Markov 1-line proof, Paley-Zygmund
+  formula, worked numerics for `n = 23` and `n = 50`, Mathlib gaps,
+  next-action priority table.
+
+## S1 Deliverable
+
+This iteration is **survey-only**:
+
+- 0 new theorems
+- 0 new sorries
+- 0 axioms touched
+- 0 `.lean` files created
+
+Substantive output: `problem.md` (Mathlib API map + suggested S2-S6
+decomposition + risk notes) and `knowledge.md` (math content of both
+couplings + worked numerics + Mathlib gap inventory). Ready hand-off
+for the S2 implementer.

--- a/src/data/research/problems/birthday-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-01-oq-02.json
@@ -1,0 +1,92 @@
+{
+  "slug": "birthday-problem-oq-01-oq-02",
+  "title": "Coupling between expected pairs and collision probability",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "probCollision n d \\le \\uparrow(\\text{expectedPairs}\\ n\\ d)\\ \\wedge\\ \\text{probCollision}\\ n\\ d \\ge \\frac{(\\text{expectedPairs}\\ n\\ d)^2}{E[X^2]}",
+    "plain": "Bracket the Birthday Problem collision probability between (i) the Markov upper bound C(n,2)/d = expectedPairs n d (OQ01) and (ii) the Paley-Zygmund lower bound E[X]^2 / E[X^2]. Sandwiches OQ02's product-formulation probCollision between OQ01's first-moment quantity above and a second-moment quantity below.",
+    "whyMatters": [
+      "Closes a methodology gap: the gallery has both moment-based (OQ01) and probability-based (OQ02) treatments of the birthday problem, but no formal proof that the two viewpoints bracket the same quantity.",
+      "Gives variancePairs_le_expected (OQ01:164) a downstream client; currently unused without a coupling theorem.",
+      "Markov bound is sharpest at small C(n,2)/d; the OQ02 exponential bound is sharpest near the threshold; the two couplings together produce a complementary pair of closed-form bounds.",
+      "Mathlib has no Finset.one_sub_prod_le_sum lemma at the pinned revision; a gallery-side proof has upstream value."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [
+      "Markov bound: probCollision n d <= upArrow(expectedPairs n d).",
+      "Paley-Zygmund bound: probCollision n d >= (expectedPairs n d)^2 / E[X^2].",
+      "Bridge: probAllDistinct n d = descFactorial(d, n) / d^n (relates OQ02 product to OQ01OQ01 counting)."
+    ],
+    "goal": "Formalize both couplings plus the OQ02-OQ01OQ01 bridge. After all sorries close: status verified, 0 axioms, file ~150-200 lines."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE: documented two complementary couplings (Markov upper bound and Paley-Zygmund lower bound) between OQ01 expectedPairs and OQ02 probCollision. Mapped Mathlib infrastructure, identified 3 Mathlib gaps, and laid out a 5-step S2-S6 decomposition.",
+    "blockers": [],
+    "nextAction": "S2: state and prove one_sub_prod_le_sum helper in new Proofs/BirthdayProblemOQ01OQ02.lean (~25 lines, induction on n, uses Finset.prod_range_succ + Finset.sum_range_succ + nlinarith).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-12, 2026-05-11): OBSERVE survey for the coupling between BirthdayProblemOQ01.expectedPairs (rational first-moment) and BirthdayProblemOQ02.probCollision (real probability product). Established two natural couplings: (a) Markov upper bound probCollision <= expectedPairs, one-line proof chaining a new union-bound helper one_sub_prod_le_sum with the existing gauss_sum_div (OQ02:145); (b) Paley-Zygmund lower bound probCollision >= E[X]^2/E[X^2], requires the second-moment formula plus a bridge to OQ01OQ01.collisionCount. Verified the algebra on n=23 (d=365) and n=50 (d=365) numerically: Markov gap 0.186 vs exponential gap 0.007 at n=23; Paley-Zygmund gives >=1/2 at n=28 (the classical threshold) without invoking exp. Identified Mathlib gaps: no Finset.one_sub_prod_le_sum at pinned revision, no discrete-sample-space Markov/Paley-Zygmund. No Lean changes this iteration -- pure documentation S1.",
+    "builtItems": [],
+    "insights": [
+      "Markov coupling probCollision <= expectedPairs has a one-line proof: chain one_sub_prod_le_sum (union bound) with gauss_sum_div (existing in OQ02:145) and two_mul_choose_two (existing in OQ01:109). ~40 lines total S2+S3.",
+      "Paley-Zygmund lower bound is heavier (~80 lines) because it needs (a) a second-moment formula and (b) a bridge between OQ02 product formulation and OQ01OQ01 finite-sample-space formulation. Best split: S4 (E[X^2] formula), S6 (bridge), S5 (Paley-Zygmund).",
+      "The OQ02 exponential bound is strictly sharper than Paley-Zygmund for the birthday parameter range (gap 0.007 vs 0.097 at n=23, d=365), but Markov gives an UPPER bound that the exponential argument does not.",
+      "variancePairs_le_expected (OQ01:164) is currently unused in the gallery; Paley-Zygmund (this OQ's S5) is the natural downstream client.",
+      "n=28 threshold (E[X]>1 for d=365) coincides with the Paley-Zygmund lower-bound 0.5 threshold: (C(28,2)/365)/(1+C(28,2)/365) = (378/365)/(743/365) = 378/743 >= 0.5. The two thresholds are not independent."
+    ],
+    "mathlibGaps": [
+      "No Finset.one_sub_prod_le_sum lemma at the pinned Mathlib revision that fires on the form 1 - prod(1 - f i) <= sum (f i). Provable in ~25 lines by induction on the index set (S2 deliverable).",
+      "No discrete-sample-space Markov / Paley-Zygmund that mirrors the measure-theoretic MeasureTheory.measure_*_inv_le_* family. The measure-theoretic version requires setting up a probability measure on Fin n -> Fin d, non-trivial in decide-style proofs.",
+      "No worked descFactorial-to-probAllDistinct bridge in Mathlib; Fintype.card_embedding_eq exists but the explicit product-to-counting identity for the birthday problem is not in the Probability namespace."
+    ],
+    "nextSteps": [
+      "S2: state and prove one_sub_prod_le_sum in new Proofs/BirthdayProblemOQ01OQ02.lean (~25 lines, induction with Finset.prod_range_succ + Finset.sum_range_succ).",
+      "S3: prove probCollision_le_expectedPairs (Markov coupling, ~40 lines, chains one_sub_prod_le_sum + gauss_sum_div + two_mul_choose_two + push_cast).",
+      "S6: prove probAllDistinct_eq_descFactorial_div (bridge OQ02 product to OQ01OQ01 counting, ~30 lines, telescoping).",
+      "S4: state and prove the E[X^2] formula in OQ01-OQ02 style using variancePairs (~50 lines).",
+      "S5: probCollision_ge_paley_zygmund (lower bound, ~80 lines, depends on S4 + S6, may need to be split)."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "probability",
+    "birthday-problem",
+    "markov-inequality",
+    "paley-zygmund",
+    "coupling"
+  ],
+  "relatedProofs": [
+    "birthday-problem-oq-01",
+    "birthday-problem-oq-01-oq-01",
+    "birthday-problem-oq-02",
+    "birthday-problem-oq-02-oq-01",
+    "birthday-problem-oq-03",
+    "birthday-problem"
+  ],
+  "references": {
+    "papers": [
+      "Mitzenmacher M., Upfal E. (2017) Probability and Computing, 2nd ed., Section 3.3 (Second Moment Method)",
+      "Kahane J.-P. (1985) Some Random Series of Functions, Theorem 6.1 (Paley-Zygmund)"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Mathlib.Data.Rat.Cast.Defs",
+      "Mathlib.Combinatorics.Choose.Factorial",
+      "Mathlib.Data.Fintype.Pi"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey (researcher-12, 2026-05-11) for the NEW open question
`birthday-problem-oq-01-oq-02`: can the coupling between expected shared
pairs (OQ01) and collision probability (OQ02) be formalised?

Direct-claim from the tier-B `status: available` pool (0 open PRs, 0
recent merges, no pre-existing problem dir). Follows the
`cube-root-3-irrational-oq-04` S1 PR #17718 template — analysis-only,
no Lean changes, four new files.

## Deliverable (4 files, +577 lines)

- `research/problems/birthday-problem-oq-01-oq-02/problem.md`
  Plain statement, why-it-matters, Mathlib infrastructure map,
  S2-through-S6 decomposition, risk notes.
- `research/problems/birthday-problem-oq-01-oq-02/knowledge.md`
  Markov one-line proof, Paley-Zygmund formula, worked numerics
  for `n = 23` and `n = 50` (`d = 365`), Mathlib gap inventory,
  next-action priority table.
- `research/problems/birthday-problem-oq-01-oq-02/state.md`
  Iteration 1, OBSERVE phase, S2 Lean stub for the union-bound helper.
- `src/data/research/problems/birthday-problem-oq-01-oq-02.json`
  Research metadata (status: active, phase: OBSERVE).

## Findings

**Two complementary couplings** bracket `probCollision n d` between
the first-moment (OQ01) and second-moment (OQ02) quantities:

```
(MARKOV)         probCollision n d  ≤  ↑(expectedPairs n d)
(PALEY-ZYGMUND)  probCollision n d  ≥  (expectedPairs n d)² / E[X²]
```

- **Markov upper bound** has a one-line proof: chain a new
  `one_sub_prod_le_sum` helper (union bound for products, ~25-line
  induction) with the existing `gauss_sum_div` (OQ02:145) and
  `two_mul_choose_two` (OQ01:109). Total ~40 lines split over S2/S3.

- **Paley-Zygmund lower bound** is heavier (~80 lines): needs (a) the
  second-moment formula and (b) a bridge between OQ02's product
  formulation `∏(1 - i/d)` and OQ01OQ01's finite-sample-space
  `collisionCount` random variable. `variancePairs_le_expected`
  (OQ01:164) gets its first downstream client.

- **Numerical sanity** at `n = 23`, `d = 365`: `probCollision ≈ 0.5073`,
  Markov gap `0.186`, exponential gap `0.007` (OQ02 is sharper here),
  Paley-Zygmund gap `0.097`. At `n = 28`, Paley-Zygmund recovers the
  classical `probCollision ≥ 1/2` threshold without invoking exp.

## Mathlib Gaps Identified

1. No `Finset.one_sub_prod_le_sum` lemma at the pinned revision.
2. No discrete-sample-space Markov / Paley-Zygmund mirroring the
   measure-theoretic `MeasureTheory.measure_*_inv_le_*` family.
3. No worked `descFactorial → probAllDistinct` bridge for the
   birthday problem.

## Status

**Outcome**: surveyed
**Next Steps**: S2 — create `proofs/Proofs/BirthdayProblemOQ01OQ02.lean`
and add the `one_sub_prod_le_sum` helper. ~25 lines + one Docker build.

## Test plan

- [x] All 4 files JSON/Markdown-parse cleanly
- [x] `git diff origin/main --stat` confirms exactly +4 files, +577 lines
- [x] No `.lean` source changes; no `proofs/Proofs/` modifications
- [x] No `meta.json` / gallery `index.ts` changes
- [x] No upstream proof's status / sorry count is altered
- [ ] Docker build verification — skipped (analysis-only, no `.lean` deltas)

🤖 Generated by researcher-12