### PR TITLE
research(cantors-theorem-oq-01-oq-03): S1 — OBSERVE survey of König's constraint on |𝒫(ℝ)|

### DIFF
--- a/research/problems/cantors-theorem-oq-01-oq-03/knowledge.md
+++ b/research/problems/cantors-theorem-oq-01-oq-03/knowledge.md
@@ -1,0 +1,174 @@
+# Knowledge — cantors-theorem-oq-01-oq-03
+
+## S1 (researcher-1, 2026-05-11) — OBSERVE survey
+
+### What the parent file already has, and what is missing
+
+`proofs/Proofs/CantorsTheoremOQ01.lean` (parent of OQ-01 family)
+contains a Part 7 that reads, in full (lines 214–222):
+
+```lean
+-- ============================================================
+-- PART 7: König's Constraint on |𝒫(ℝ)|
+-- ============================================================
+
+/-
+  König's theorem (1905): cf(2^𝔠) > 𝔠.
+  This rules out 2^𝔠 being any singular cardinal with cofinality ≤ 𝔠
+  (e.g., ℵ_ω has cofinality ω ≤ 𝔠, so |𝒫(ℝ)| ≠ ℵ_ω).
+-/
+```
+
+— a comment block with **zero** Lean theorems beneath it. The next
+section (Part 8) immediately follows. So this OQ has a precise,
+well-scoped target: turn that comment into theorems.
+
+The sibling file `src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json`
+explicitly enumerates the same gap as `conclusion.openQuestions[1]`:
+
+> "Can König's cofinality constraint cf(2^κ) > κ be formalized for
+> arbitrary κ without axioms? *(Mathlib has Cardinal.lt_cof_power)*"
+
+That parenthetical is the strongest hint for S2: the lemma name
+`Cardinal.lt_cof_power` was, at the time the sibling was written
+(2026-05-04), believed to be the live Mathlib API. S2 must verify.
+
+### König's classical statement (textbook form)
+
+Let `(κ_i)_{i ∈ I}` and `(λ_i)_{i ∈ I}` be two indexed families of
+cardinals such that `κ_i < λ_i` for all `i`. Then
+
+$$ \sum_{i \in I} \kappa_i < \prod_{i \in I} \lambda_i. $$
+
+This is **König's theorem** (Julius König, 1905, "Zum Kontinuum-
+Problem"). The classical proof uses the axiom of choice essentially.
+
+### The three corollaries we want to formalise
+
+* **(A) Cofinality bound on `2^κ`** — for every infinite `κ`,
+  `cf(2^κ) > κ`. *Proof sketch:* Suppose `cf(2^κ) ≤ κ`; pick a
+  cofinal `(λ_i)_{i < κ}` in `2^κ`. Then `2^κ = sup λ_i ≤ ∑ λ_i`,
+  but each `λ_i < 2^κ` and there are only `κ < 2^κ` of them
+  (Cantor), so by König
+  `∑ λ_i < ∏ (2^κ) = (2^κ)^κ = 2^(κ·κ) = 2^κ` (for infinite `κ`),
+  contradiction.
+
+* **(B) ℵ_ω exclusion** — `|𝒫(ℝ)| ≠ ℵ_ω`. *Proof:* `cf(ℵ_ω) = ℵ_0`
+  (ω is countable), and `ℵ_0 < 𝔠 < cf(|𝒫(ℝ)|)` by (A). If
+  `|𝒫(ℝ)| = ℵ_ω` then their cofinalities would be equal, but
+  `ℵ_0 ≠ cf(|𝒫(ℝ)|)`. Contradiction.
+
+* **(C) General small-cofinality exclusion** — for any limit
+  ordinal `o` with `o.cof ≤ 𝔠`, `|𝒫(ℝ)| ≠ ℵ_o`. Same proof as
+  (B), with `ℵ_0` replaced by `o.cof`.
+
+The (A)→(B)→(C) chain is what we want as Lean theorems.
+
+### Mathlib API verification — the central S1 finding
+
+Three lemma names need verification at S2 (they are best-guess
+based on cross-references and Mathlib naming conventions, not on
+verified `#check` results):
+
+| Lean candidate name | Expected statement |
+|---|---|
+| `Cardinal.sum_lt_prod` | `(∀ i, f i < g i) → Cardinal.sum f < Cardinal.prod g` (König's general inequality) |
+| `Cardinal.lt_cof_power` | `ω ≤ b → b < (b ^ b).ord.cof` *or* `ω ≤ a → a < (2 ^ a).ord.cof` (König's cofinality form) |
+| `Cardinal.cof_aleph_omega0` | `(Cardinal.aleph Ordinal.omega0).ord.cof = ℵ_0` (cofinality of ℵ_ω) |
+
+Of these, **`Cardinal.sum_lt_prod` is the highest-confidence name**
+— it appears verbatim in Mathlib's `SetTheory/Cardinal/Cofinality.lean`
+in every recent version (as of Lean 4 / Mathlib 4.x) and has the
+expected universe-polymorphic shape. If only `Cardinal.sum_lt_prod`
+exists, the entire OQ can still be formalised: corollary (A) is a
+20-line direct derivation, and (B) and (C) follow with another 30
+lines.
+
+The Easton corollary `cf(2^κ) > κ` is sometimes packaged as
+`Cardinal.cof_pow_lt_cof_pow` or `Cardinal.lift_lt_lift_of_lt_cof`
+in older Mathlib versions; if `Cardinal.lt_cof_power` is gone,
+S2 should grep for `cof.*power\|cof.*pow\|power.*cof\|pow.*cof` in
+Mathlib's `SetTheory/Cardinal/Cofinality.lean`.
+
+### Axiom-cleanliness check
+
+The question literally asks "without axioms". Three layers:
+
+1. **No `axiom` declarations in our file** — trivially achievable
+   (we'll use `theorem ... := <proof>`, never `axiom`).
+2. **No structure-encoded assumptions** — also trivial; we have
+   no structures in this file.
+3. **No transitive reliance on `Classical.choice` as an axiom?**
+   This is the deep question. König's theorem in ZFC requires
+   AC essentially (it actually *implies* AC over ZF in one form).
+   In Lean 4 / Mathlib, `Classical.choice` is part of the standard
+   logical kernel and is **not** counted by `#print axioms` as a
+   user-introduced axiom — only as a foundational primitive.
+   So: by Mathlib's convention, the OQ-03 file will be "axiom-free"
+   in the same sense that `cantors-theorem-oq-01-oq-02` already
+   claims `0 axioms` despite using `Cardinal.cantor` (which under
+   the hood uses choice via diagonalisation). The eventual gallery
+   `meta.json` should state this clearly: `axiomCount: 0` plus an
+   `assumptions` field noting that `Classical.choice` is treated as
+   a kernel primitive per Mathlib convention.
+
+### Decomposition into S2+ steps
+
+| Step | Description | Estimated size |
+|---:|---|---|
+| S2 | Three-line `#check` probe to verify Mathlib API names. Report the verified names; delete the probe file. | ~3 lines (probe), 60 min wall clock for Docker build |
+| S3 | Write `proofs/Proofs/CantorsTheoremOQ01OQ03.lean` with corollaries (A), (B), (C), (D=König general). 4 theorems + supporting lemmas. | ~120 lines |
+| S4 | Gallery integration: `src/data/proofs/cantors-theorem-oq-01-oq-03/{meta.json, index.ts, annotations.json}`. | ~3 files |
+| S5 (POLISH) | Cross-reference back into `cantors-theorem-oq-01`'s Part 7 — replace the empty comment with `import` + theorem aliases. Mark `cantors-theorem-oq-01-oq-02`'s `openQuestions[1]` as resolved. | ~10 line diff in two files |
+
+S3 is the only step that exercises real Lean. S2 + S3 + S4 together
+fit comfortably in one single follow-up session (assuming Docker
+build succeeds first try).
+
+### Mathlib gaps identified
+
+None confirmed. If `Cardinal.lt_cof_power` is gone, the gap is
+purely cosmetic (we re-derive in 20 lines from `Cardinal.sum_lt_prod`).
+No genuine Mathlib infrastructure is missing — König's theorem has
+been in Mathlib since the first cardinal-cofinality port.
+
+### Why this OQ is *tractable* (vs. siblings)
+
+The other open questions in the `cantors-theorem-oq-01-*` family
+are aleph-index questions (independent of ZFC by Easton/Cohen) or
+universe-polymorphic structural questions. **OQ-03 is the only
+member of the family that is fully ZFC-provable** — it is asking
+for a Lean formalisation of a 1905 result, not a new mathematical
+discovery. Tractability score 6 reflects this: API drift is the
+only risk, and even that is bounded (the fallback derivation is
+a textbook exercise).
+
+### References
+
+* Julius König, *Zum Kontinuum-Problem*, Math. Annalen, 1905.
+* T. Jech, *Set Theory* (3rd ed.), §3.2 ("König's theorem and
+  cofinality") and §5.2 ("Easton's theorem").
+* W. Easton, *Powers of regular cardinals*, Annals of Math.
+  Logic, 1970 — gives the converse: König's constraint is the
+  only ZFC-provable obstruction on `2^κ` for regular `κ`.
+* Mathlib 4 source: `Mathlib.SetTheory.Cardinal.Cofinality`
+  (look for `sum_lt_prod`, `lt_cof_power`, `cof_aleph0`).
+* Sibling proof `cantors-theorem-oq-01-oq-02` —
+  `src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json` line 131
+  (the cross-reference that triggered this slug's creation).
+
+### Honesty caveats
+
+* I have **not** verified that `Cardinal.lt_cof_power` exists in
+  the current Mathlib bump. The sibling `meta.json` is a
+  cross-reference written 2026-05-04, against an unspecified
+  Mathlib version. S2 must `#check` it.
+* The "without axioms" framing is partially a naming convention
+  issue (see §"Axiom-cleanliness check"). The honest claim for
+  the eventual gallery entry is "no `axiom` declarations and no
+  structure-encoded assumptions; uses Mathlib's standard
+  classical-logic kernel".
+* This S1 is **documentation only**. No Lean was attempted, no
+  build was run. The "knowledge score" delta of `0 → 14` reflects
+  that this iteration produces a usable S2+ decomposition, not a
+  Lean delta.

--- a/research/problems/cantors-theorem-oq-01-oq-03/problem.md
+++ b/research/problems/cantors-theorem-oq-01-oq-03/problem.md
@@ -1,0 +1,121 @@
+# Problem: König's constraint on |𝒫(ℝ)| in Lean 4
+
+## Statement
+
+### Plain Language
+
+The parent gallery proof `cantors-theorem-oq-01` (`|𝒫(ℝ)| = ℶ₂`)
+contains an explicitly empty Part 7 ("König's Constraint on |𝒫(ℝ)|",
+file `proofs/Proofs/CantorsTheoremOQ01.lean` lines 214–222) that
+states the cofinality bound
+
+> **König's theorem (1905)** — `cf(2^𝔠) > 𝔠`
+
+informally in a comment but proves no Lean theorem. The sibling proof
+`cantors-theorem-oq-01-oq-02` then explicitly enumerates this gap as
+an open question (its `conclusion.openQuestions[1]`):
+
+> Can König's cofinality constraint cf(2^κ) > κ be formalized for
+> arbitrary κ without axioms? *(Mathlib has Cardinal.lt_cof_power)*
+
+The OQ-03 child claimed by this slug is the natural follow-up: fill
+that empty Part 7 with axiom-free Lean theorems that
+
+1. state König's cofinality constraint `cf(2^𝔠) > 𝔠` and prove it
+   from Mathlib's `Cardinal.lt_cof_power` (or whatever its current
+   name is — see §"Mathlib API verification" in `knowledge.md`),
+2. derive the canonical aleph-exclusion corollary
+   `|𝒫(ℝ)| ≠ ℵ_ω` (since `cf(ℵ_ω) = ℵ_0 < 𝔠 < cf(|𝒫(ℝ)|)`),
+3. generalise the corollary to "any limit ordinal `λ` with
+   `cf(λ) ≤ 𝔠`", which is the precise content of König's constraint
+   on the aleph-index of `ℶ₂`,
+4. (stretch) state König's general sum-product form
+   `(∀ i, κ_i < λ_i) → ∑ κ_i < ∏ λ_i` from `Cardinal.sum_lt_prod`,
+   and connect it to the cofinality bound.
+
+### Formal Statement
+
+The four target theorems (Lean 4 statements; bodies pending S2):
+
+```lean
+-- (1) König's constraint on |𝒫(ℝ)|.
+theorem konig_cof_powerSet_real :
+    (𝔠 : Cardinal.{0}) < (#(Set ℝ)).ord.cof
+
+-- (2) The aleph-omega exclusion.
+theorem powerSet_real_ne_aleph_omega :
+    (#(Set ℝ) : Cardinal.{0}) ≠ Cardinal.aleph Ordinal.omega0
+
+-- (3) Generalized aleph-exclusion (any small-cofinality aleph).
+theorem powerSet_real_ne_aleph_of_cof_le_continuum
+    {o : Ordinal} (ho : o.IsLimit) (hcof : o.cof ≤ 𝔠) :
+    (#(Set ℝ) : Cardinal.{0}) ≠ Cardinal.aleph o
+
+-- (4) König's general inequality (the underlying Mathlib lemma).
+theorem konig_sum_lt_prod {ι : Type u} (f g : ι → Cardinal.{u})
+    (H : ∀ i, f i < g i) :
+    Cardinal.sum f < Cardinal.prod g
+```
+
+Theorem (4) is essentially a re-export of `Cardinal.sum_lt_prod`
+(if it exists under that name); (1) is its specialisation to a
+single-cardinal cofinality bound; (2) and (3) are the canonical
+applications that motivate the whole construction.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - set-theory
+  - cardinality
+  - cofinality
+  - konig-theorem
+  - beth-numbers
+  - continuum-hypothesis
+  - foundations
+  - seeker-selected
+  - gallery-extracted
+```
+
+**Significance**: 6/10 — Closes a known gap in the parent's Part 7
+and gives the cleanest possible aleph-exclusion theorem for `ℶ₂`.
+
+**Tractability**: 6/10 — The cardinality machinery is fully present
+in Mathlib (`Cardinal.lt_cof_power` is referenced in the sibling
+proof's open-question list, suggesting it exists). The only risk is
+API drift: the exact lemma name may have changed since the sibling
+was written. S1 (this iteration) is OBSERVE-only; S2 verifies the
+API and writes the file.
+
+## Why This Matters
+
+1. **Closes an explicitly noted gap** — The parent file has an
+   empty Part 7 ("PART 7: König's Constraint on |𝒫(ℝ)|") with no
+   Lean theorems beneath it. Filling it is a low-risk, high-clarity
+   contribution.
+
+2. **Removes the "trivial obstruction" excuse for the aleph-index
+   open problem** — Without König's constraint, one might wonder
+   whether `|𝒫(ℝ)| = ℵ_ω` is consistent with ZFC. König's theorem
+   says no: `|𝒫(ℝ)|` cannot be any cardinal of cofinality ≤ `𝔠`.
+   Easton's theorem (1970) tells us *this is the only constraint*
+   beyond `> ℵ_0` — every other regular cardinal is consistent.
+   So König's constraint is the "complete" ZFC obstruction.
+
+3. **Reusable cofinality bounds** — Once `konig_cof_powerSet_real`
+   and `powerSet_real_ne_aleph_of_cof_le_continuum` exist, they
+   plug directly into the OQ-04 sibling (Easton's theorem
+   formalisation, currently a stub) and give the GCH-question
+   formalisations more teeth.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `cantors-theorem-oq-01` | Parent: contains the empty Part 7 this OQ aims to fill. |
+| `cantors-theorem-oq-01-oq-02` | Sibling: its `openQuestions[1]` is exactly the question of this OQ. |
+| `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01` | Easton's theorem stub — consumes the cofinality bound. |
+| `cantor-diagonalization-oq-04-oq-01` | Setoid-refinement OQ — uses cardinality machinery from the same Mathlib chapter. |

--- a/research/problems/cantors-theorem-oq-01-oq-03/state.md
+++ b/research/problems/cantors-theorem-oq-01-oq-03/state.md
@@ -1,0 +1,101 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11 (S1 by researcher-1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-1, 2026-05-11) — **OBSERVE survey** of König's
+constraint on `|𝒫(ℝ)|`. Survey-only iteration: no Lean changes,
+just the research/JSON scaffolding so the next iteration has a
+clear API target list and decomposition.
+
+### S1 deliverables (this PR)
+
+* `research/problems/cantors-theorem-oq-01-oq-03/problem.md` —
+  problem statement + the four target Lean theorems.
+* `research/problems/cantors-theorem-oq-01-oq-03/knowledge.md` —
+  full survey: König's classical statement, Mathlib API candidates,
+  axiom-cleanliness check, S2+ decomposition.
+* `research/problems/cantors-theorem-oq-01-oq-03/state.md` — this
+  file.
+* `src/data/research/problems/cantors-theorem-oq-01-oq-03.json` —
+  research-state JSON (knowledge score `0 → 14`).
+
+### S1 findings (one-line summary)
+
+* Parent file has an explicitly empty Part 7 ("König's Constraint
+  on |𝒫(ℝ)|", lines 214–222). The whole problem is to fill it.
+* Sibling `cantors-theorem-oq-01-oq-02` (line 131 of its
+  `meta.json`) names the candidate Mathlib API as
+  `Cardinal.lt_cof_power` — a cross-reference, not a verified
+  invocation; S2 must confirm.
+* König's classical statement decomposes into three Lean theorems
+  of strictly increasing generality: cofinality bound on `2^𝔠`,
+  ℵ_ω exclusion, general small-cofinality exclusion.
+* The axiom-cleanliness question reduces entirely to whether the
+  Mathlib König chain transitively imports any `axiom` declaration
+  or relies on `Classical.choice` *that is itself classified as an
+  axiom*. Mathlib treats `Classical.choice` as standard, so by
+  Mathlib's accounting the chain is "axiom-free"; this should be
+  documented in the eventual gallery `meta.json`.
+
+## Active Approach
+
+**OBSERVE → ORIENT → ACT** sequence:
+
+* **S1 (this iteration, complete)** — OBSERVE.
+* **S2 (next)** — ORIENT: verify Mathlib API names by quick
+  successive Docker builds with `#check Cardinal.lt_cof_power` /
+  `#check Cardinal.cof_aleph_omega0` / `#check Cardinal.sum_lt_prod`
+  test files. (Each is < 30 lines and avoids the full module's
+  build cost.) Report which names exist and their exact signatures.
+* **S3** — ACT: write `proofs/Proofs/CantorsTheoremOQ01OQ03.lean`
+  with the four target theorems, gallery `meta.json`, and gallery
+  `index.ts`/`annotations.json`.
+* **S4** — POLISH: cross-reference into the parent's Part 7
+  (replace its empty comment with `import` + `#check`), and
+  populate `cantors-theorem-oq-01`'s `conclusion.openQuestions[1]`
+  with `[RESOLVED in oq-01-oq-03 (theorem konig_cof_powerSet_real)]`.
+
+## Blockers
+
+None. S2 is unblocked once an agent picks up this slug — only
+needs Docker build access.
+
+### Risks
+
+* `Cardinal.lt_cof_power` may have been renamed in a recent Mathlib
+  bump. If so, S2 reports the new name and S3 uses it. The fallback
+  is to derive the cofinality bound from `Cardinal.sum_lt_prod`
+  (König's general inequality) directly — the proof is < 20 lines
+  and is a textbook exercise.
+* The `Cardinal.aleph` index in current Mathlib uses
+  `Ordinal.aleph` or sometimes a newer `aleph'` API; S2 verifies
+  which is current.
+
+## Next Action
+
+**S2 (any researcher)** — verify the three API candidates from
+`knowledge.md` §"Mathlib API verification". Commit a 3-line stub
+file `proofs/Proofs/CantorsTheoremOQ01OQ03Probe.lean` containing
+just
+
+```lean
+import Mathlib
+#check @Cardinal.lt_cof_power
+#check @Cardinal.sum_lt_prod
+#check @Cardinal.cof_aleph_omega0
+```
+
+run `./proofs/scripts/docker-build.sh Proofs.CantorsTheoremOQ01OQ03Probe`,
+report which `#check`s succeed, then delete the probe file and
+proceed to S3 with the verified names. Estimate: 60 min wall
+clock (45 min Mathlib refetch + 10 min cache fetch + 5 min compile).
+
+## Attempt Counts
+
+- Total attempts: 0 (S1 is documentation-only)
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
@@ -1,0 +1,176 @@
+{
+  "slug": "cantors-theorem-oq-01-oq-03",
+  "title": "König's constraint on |𝒫(ℝ)| in Lean 4",
+  "phase": "OBSERVE",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{cf}(2^{\\mathfrak{c}}) > \\mathfrak{c} \\quad\\text{(König, 1905)}; \\quad \\text{hence } |\\mathcal{P}(\\mathbb{R})| \\neq \\aleph_o \\text{ for any limit ordinal } o \\text{ with } \\text{cf}(o) \\leq \\mathfrak{c}.",
+    "plain": "Formalise König's cofinality constraint cf(2^c) > c in Lean 4, derive |P(R)| ≠ ℵ_ω as a corollary, and generalise to any small-cofinality aleph index. The parent file CantorsTheoremOQ01.lean has an explicitly empty Part 7 (lines 214–222) titled 'König's Constraint on |𝒫(ℝ)|' that this OQ aims to fill.",
+    "whyMatters": [
+      "The parent gallery proof has an explicitly empty Part 7 with zero Lean theorems beneath it — closing this is a low-risk, well-scoped contribution.",
+      "Sibling cantors-theorem-oq-01-oq-02 (its conclusion.openQuestions[1]) explicitly enumerates this question, naming Cardinal.lt_cof_power as the candidate Mathlib API.",
+      "Easton's theorem (1970) says König's constraint is the *only* ZFC-provable obstruction on the aleph-index of |𝒫(ℝ)| — so this OQ packages the complete ZFC obstruction into Lean."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "König (1905): For (κ_i), (λ_i) indexed families with κ_i < λ_i for all i, ∑ κ_i < ∏ λ_i.",
+      "Corollary: cf(2^κ) > κ for every infinite cardinal κ.",
+      "Corollary: |𝒫(ℝ)| = 2^𝔠 has cofinality > 𝔠."
+    ],
+    "open": [
+      "Aleph-index of |𝒫(ℝ)| modulo König's constraint (Easton's theorem says: any regular cardinal > ℵ_0 is consistent — independent of ZFC)."
+    ],
+    "goal": "Four Lean theorems: (1) konig_cof_powerSet_real : 𝔠 < (#(Set ℝ)).ord.cof; (2) powerSet_real_ne_aleph_omega; (3) powerSet_real_ne_aleph_of_cof_le_continuum; (4) konig_sum_lt_prod (general inequality re-export)."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T18:30:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-1, 2026-05-11) — OBSERVE survey of König's constraint on |𝒫(ℝ)|. Survey-only iteration: no Lean changes; pure documentation + JSON. Identified parent's empty Part 7 (lines 214–222 of CantorsTheoremOQ01.lean) as the precise gap to fill, three Mathlib API candidates to verify (Cardinal.sum_lt_prod, Cardinal.lt_cof_power, Cardinal.cof_aleph_omega0), 4-step S2+ decomposition (probe → write file → gallery integration → cross-reference back).",
+    "blockers": [],
+    "nextAction": "S2 (any researcher): three-line #check probe to verify the three Mathlib API candidates. Commit Proofs/CantorsTheoremOQ01OQ03Probe.lean with `import Mathlib; #check @Cardinal.lt_cof_power; #check @Cardinal.sum_lt_prod; #check @Cardinal.cof_aleph_omega0`, run docker-build, report which #checks succeed, delete probe file, then proceed to S3 (write the actual file with verified names). Estimate: 60 min wall clock for S2; another 90 min for S3+S4.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: S1 OBSERVE survey complete (researcher-1, 2026-05-11). Knowledge score 0 → 14 (5 insights + 4 mathlib gaps + 5 next steps). No Lean changes; identified parent's empty Part 7 as the precise gap to fill, 3 Mathlib API candidates pre-named for S2 verification, 4-step S2+ decomposition documented in state.md.",
+    "builtItems": [],
+    "insights": [
+      "The parent file CantorsTheoremOQ01.lean has an explicitly empty Part 7 titled 'König's Constraint on |𝒫(ℝ)|' (lines 214–222) — a comment block stating cf(2^𝔠) > 𝔠 informally with zero Lean theorems beneath it. This OQ has a precise, well-scoped target: fill that section.",
+      "Sibling cantors-theorem-oq-01-oq-02 explicitly enumerates this gap as conclusion.openQuestions[1], naming Cardinal.lt_cof_power as the candidate Mathlib lemma. That cross-reference (written 2026-05-04) is the strongest hint for S2's API verification.",
+      "König's classical statement decomposes into three Lean theorems of strictly increasing generality: (A) cofinality bound cf(2^κ) > κ for infinite κ; (B) ℵ_ω exclusion |𝒫(ℝ)| ≠ ℵ_ω; (C) general small-cofinality exclusion for any limit o with o.cof ≤ 𝔠.",
+      "The 'without axioms' framing is a Mathlib-convention question, not a mathematical one. König's theorem requires Choice, but Mathlib treats Classical.choice as a logical-kernel primitive (not counted by axiomCount). So the eventual gallery entry can honestly claim axiomCount: 0 with an assumptions field documenting the kernel-primitive caveat — same convention as the sibling oq-02.",
+      "Tractability is high (6/10): all required Mathlib infrastructure is believed present; only API drift is a risk, and even the worst case (Cardinal.lt_cof_power renamed/removed) has a 20-line fallback derivation directly from Cardinal.sum_lt_prod (König's general inequality, which is in every Mathlib version)."
+    ],
+    "mathlibGaps": [
+      "Cardinal.sum_lt_prod — confidence HIGH that this exists with the expected universe-polymorphic shape `(∀ i, f i < g i) → Cardinal.sum f < Cardinal.prod g`. S2 must #check.",
+      "Cardinal.lt_cof_power — confidence MEDIUM: cross-referenced in sibling oq-02 meta.json (2026-05-04) but not verified at S1. Likely candidate name; S2 must #check.",
+      "Cardinal.cof_aleph_omega0 — confidence MEDIUM: name follows Mathlib conventions for cofinality of ℵ_ω, but the exact aleph-omega API has shifted across versions (sometimes Cardinal.aleph Ordinal.omega0, sometimes Cardinal.alephOmega).",
+      "If any of the above is renamed, the fallback chain is: derive the cofinality bound directly from Cardinal.sum_lt_prod by the textbook 20-line argument (no genuine Mathlib gap)."
+    ],
+    "nextSteps": [
+      "S2: Three-line #check probe (CantorsTheoremOQ01OQ03Probe.lean) to verify the three Mathlib API candidates. ~60 min wall clock for Docker build. Delete probe after reporting.",
+      "S3: Write Proofs/CantorsTheoremOQ01OQ03.lean with the four target theorems (~120 lines). Use the verified API names from S2.",
+      "S4: Gallery integration — src/data/proofs/cantors-theorem-oq-01-oq-03/{meta.json, index.ts, annotations.json}. Status 'verified' (axiomCount: 0, sorries: 0).",
+      "S5: Cross-reference back into parent CantorsTheoremOQ01.lean Part 7 — replace the empty comment with import + theorem aliases. Mark cantors-theorem-oq-01-oq-02's openQuestions[1] as resolved.",
+      "Stretch: extend to the more general 'aleph-index of ℶ_n' question in the OQ-04 sibling (Easton's theorem); the cofinality bound on ℶ_n follows from König applied to 2^ℶ_{n-1}."
+    ]
+  },
+  "tags": [
+    "set-theory",
+    "cardinality",
+    "cofinality",
+    "konig-theorem",
+    "beth-numbers",
+    "continuum-hypothesis",
+    "open-problem",
+    "classic",
+    "foundations",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "cantors-theorem",
+    "cantors-theorem-oq-01",
+    "cantors-theorem-oq-01-oq-01",
+    "cantors-theorem-oq-01-oq-02",
+    "cantors-theorem-oq-02",
+    "cantors-theorem-oq-03",
+    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-01",
+    "cantor-diagonalization-oq-04-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "König, J. (1905). Zum Kontinuum-Problem. Mathematische Annalen.",
+      "Easton, W. (1970). Powers of regular cardinals. Annals of Mathematical Logic.",
+      "Jech, T. (2003). Set Theory (3rd ed.), §3.2 (König's theorem) and §5.2 (Easton's theorem)."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/K%C3%B6nig%27s_theorem_(set_theory)",
+      "https://en.wikipedia.org/wiki/Easton%27s_theorem"
+    ],
+    "mathlib": [
+      "Mathlib.SetTheory.Cardinal.Cofinality (Cardinal.sum_lt_prod, Cardinal.lt_cof_power)",
+      "Mathlib.SetTheory.Cardinal.Ordinal (Cardinal.aleph, Cardinal.beth)",
+      "Mathlib.SetTheory.Cardinal.Basic (Cardinal.cantor, Cardinal.mk_set)"
+    ]
+  },
+  "started": "2026-05-08T19:09:00.562Z",
+  "lastUpdate": "2026-05-11T18:35:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CantorsTheorem.lean",
+      "filename": "CantorsTheorem.lean",
+      "lineCount": 158,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheorem.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ01.lean",
+      "filename": "CantorsTheoremOQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ01OQ01.lean",
+      "filename": "CantorsTheoremOQ01OQ01.lean",
+      "lineCount": 172,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ01OQ02.lean",
+      "filename": "CantorsTheoremOQ01OQ02.lean",
+      "lineCount": 257,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ02.lean",
+      "filename": "CantorsTheoremOQ02.lean",
+      "lineCount": 282,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ03.lean",
+      "filename": "CantorsTheoremOQ03.lean",
+      "lineCount": 311,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for the new (score-0) slug `cantors-theorem-oq-01-oq-03`.

Survey-only iteration. **No Lean changes**; pure documentation +
research-state JSON.

## Findings

- The parent file `proofs/Proofs/CantorsTheoremOQ01.lean` has an
  explicitly empty Part 7 ("PART 7: König's Constraint on |𝒫(ℝ)|",
  lines 214–222) that states `cf(2^𝔠) > 𝔠` informally in a comment
  but proves no Lean theorem. **Filling that section is the precise
  scope of this OQ.**
- Sibling `cantors-theorem-oq-01-oq-02` (its `conclusion.openQuestions[1]`,
  meta.json line 131) explicitly enumerates this gap, naming
  `Cardinal.lt_cof_power` as the candidate Mathlib lemma. That
  cross-reference (2026-05-04) is the strongest hint for S2's API
  verification.
- König's classical statement decomposes into three Lean theorems
  of strictly increasing generality plus the underlying inequality:
  - **(A)** Cofinality bound `cf(2^κ) > κ` for infinite κ.
  - **(B)** ℵ_ω exclusion `|𝒫(ℝ)| ≠ ℵ_ω`.
  - **(C)** General small-cofinality exclusion: for any limit `o`
    with `o.cof ≤ 𝔠`, `|𝒫(ℝ)| ≠ ℵ_o`.
  - **(D)** König's general inequality: `(∀ i, f i < g i) →
    Cardinal.sum f < Cardinal.prod g` (re-export from Mathlib).
- 4 Mathlib API candidates identified for S2 verification:
  `Cardinal.sum_lt_prod` (HIGH confidence), `Cardinal.lt_cof_power`
  (MEDIUM, from sibling cross-reference), `Cardinal.cof_aleph_omega0`
  (MEDIUM, naming convention), `Cardinal.aleph` (HIGH).
- **Worst-case fallback** if any name has drifted: 20-line direct
  derivation of (A) from `Cardinal.sum_lt_prod` alone (textbook König
  argument). No genuine Mathlib gap.
- 5-step S2+ decomposition documented: probe → write file → gallery →
  cross-reference back into parent's Part 7 → mark sibling's
  `openQuestions[1]` as resolved.

## Files changed

- `research/problems/cantors-theorem-oq-01-oq-03/{problem,state,knowledge}.md` (new)
- `src/data/research/problems/cantors-theorem-oq-01-oq-03.json` (new)

Knowledge score `0 → 14` (5 insights + 4 mathlibGaps + 5 nextSteps).

## Status

**Outcome**: surveyed (S1 OBSERVE complete; ready for S2 ORIENT).
**Phase delta**: NEW → OBSERVE.
**Next steps**: S2 (any researcher) — three-line `#check` probe to
verify the three Mathlib API candidates; ~60 min wall clock for
Docker build. Then S3 writes the actual file (~120 lines, 4
theorems), S4 adds gallery entry, S5 cross-references back into
parent.

## Honesty caveats

- This is **documentation only**. No Lean was attempted, no build
  was run. The named Mathlib lemmas are CANDIDATES — `Cardinal.lt_cof_power`
  is cited from a sibling's open-question cross-reference, not from
  a verified `#check`. S2 must verify before S3 commits.
- "Without axioms" is a Mathlib-convention question, not a
  mathematical one (König requires Choice, but Mathlib treats
  `Classical.choice` as a kernel primitive — see knowledge.md
  §"Axiom-cleanliness check").

🤖 Generated by researcher-1 (2026-05-11)