### PR TITLE
research(cayley-hamilton-minpoly-oq-03-oq-02): S1 OBSERVE — Keller-Gehrig O(n^ω) feasibility survey

### DIFF
--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/knowledge.md
@@ -1,0 +1,144 @@
+# Knowledge: Keller-Gehrig $O(n^\omega)$ — formalisation notes
+
+## The algorithm in three sentences
+
+Given an $n\times n$ matrix $M$, compute $T_k := M^{2^k}$ by repeated
+squaring for $k = 0, 1, \dots, \lceil \log_2 n\rceil$. Use the matrices
+$T_0, T_1, \dots$ to evaluate any polynomial of degree $< 2^{\lceil \log_2 n\rceil}$
+at $M$ in $O(\log n)$ matrix multiplications (Horner against base-$2^k$
+expansion of the polynomial). Hence find the minimal polynomial — degree
+$\le n$ — using $O(\log n)$ matrix multiplications, i.e. $O(n^\omega \log n)$
+field operations. (A later refinement by Giesbrecht and Storjohann removes
+the $\log n$ to land at $O(n^\omega)$.)
+
+## Where the speed-up comes from (one paragraph)
+
+The naive Krylov method (formalised in OQ-03) computes $v, Mv, M^2 v, \dots,
+M^{n-1}v$ one step at a time — $n$ matrix-vector products, each $O(n^2)$.
+Keller-Gehrig instead computes the matrix $M^{2^k}$ once, then uses one
+matrix-matrix multiply ($O(n^\omega)$) to advance by $2^k$ Krylov steps at
+once. After $\lceil \log_2 n\rceil$ squarings and a polynomial-evaluation
+pass, the entire Krylov span of degree-$n$ polynomials in $M$ applied to $v$
+is accessible. The trade is "$n$ cheap steps" vs. "$\log n$ expensive
+steps."
+
+## Numerical sanity check at $n = 64$
+
+* Naive Krylov: 64 matvecs $\times \, 64^2 = 4096$ ops each $=$ **262 144 ops**.
+* Keller-Gehrig with naive matmul: $\lceil \log_2 64\rceil = 6$ matmuls $\times \, 64^3 = 262\,144$ ops each $=$ **1 572 864 ops**.
+* Keller-Gehrig with Strassen $\omega = \log_2 7 \approx 2.807$:
+  $6 \times 64^{2.807} \approx 6 \times 64\,818 \approx$ **388 906 ops**.
+* Keller-Gehrig with $\omega = 2.37$ (Coppersmith-Winograd-Williams):
+  $6 \times 64^{2.37} \approx 6 \times 17\,032 \approx$ **102 192 ops**.
+
+So **at $n = 64$ the naive Krylov already beats Strassen-Keller-Gehrig by 1.5×**;
+Strassen needs $n \ge 256$ish to win; Coppersmith-Winograd-Williams wins at
+$n \approx 64$ and dominates from there. The asymptotic claim is real but
+the constant is large — this is why the Mathlib `Matrix.mul` choosing the
+naive algorithm is a defensible default.
+
+## Mathlib gap inventory
+
+### Gap 1: complexity monad
+
+Mathlib has no `Cost (α : Type) := WithCount α` or equivalent. Possible designs:
+
+* **Comonadic cost passing** — every operation returns `α × ℕ`. Composable but
+  noisy; every theorem statement carries cost in the type.
+* **Free monad of arithmetic operations** — `inductive Comp : Type → Type`
+  with `Add | Mul | Bind ...`. Cleaner statements; harder to compose with
+  Mathlib's type-class hierarchy.
+* **External "operation counter" predicate** — `OpCount : (α → α) → ℕ → Prop`.
+  Avoids touching types; admits inequalities directly.
+
+There is no consensus in the Lean community on which design wins. The
+practical effect: **no `O(...)` claim about anything is formalisable in
+current Mathlib.** Anything we say is an axiomatised assumption.
+
+### Gap 2: fast matrix multiplication
+
+`Mathlib.Data.Matrix.Mul` defines `Matrix.mul` as
+
+```lean
+def mul (M N : Matrix m n α) : Matrix m p α := fun i k => ∑ j, M i j * N j k
+```
+
+i.e. the standard cubic algorithm. There is no `Matrix.strassenMul`, no
+opaque `FastMul` typeclass, no abstract "any algorithm satisfying
+$\mathrm{cost} \le C \cdot n^\omega$ for some $\omega < 3$" — all of these
+are intervals we would have to bridge.
+
+### Gap 3: matrix-multiplication exponent $\omega$
+
+The constant $\omega$ ($2 \le \omega \le 3$, currently $\approx 2.37$) is
+genuinely an open mathematical object (it is not known to equal 2). The
+honest Mathlib treatment would be: `axiom omegaMM : ℝ` together with
+`axiom omegaMM_ge_two : 2 ≤ omegaMM` and `axiom omegaMM_lt_three : omegaMM < 3`.
+This is acceptable as long as the "axiomatized" status is declared in
+`meta.json`.
+
+## Worked S2 stub: squared-Krylov
+
+```lean
+namespace MinpolyComplexity.SubcubicKrylov
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-- The k-th squared-Krylov power: M^(2^k), computed by repeated squaring.
+    This is the central object in Keller-Gehrig's O(n^ω) algorithm. -/
+def squareKrylov (M : Matrix (Fin n) (Fin n) K) : ℕ → Matrix (Fin n) (Fin n) K
+  | 0     => M
+  | k + 1 => squareKrylov M k * squareKrylov M k
+
+@[simp]
+theorem squareKrylov_zero (M : Matrix (Fin n) (Fin n) K) :
+    squareKrylov M 0 = M := rfl
+
+theorem squareKrylov_succ (M : Matrix (Fin n) (Fin n) K) (k : ℕ) :
+    squareKrylov M (k + 1) = squareKrylov M k * squareKrylov M k := rfl
+
+theorem squareKrylov_eq_pow_two (M : Matrix (Fin n) (Fin n) K) (k : ℕ) :
+    squareKrylov M k = M ^ (2 ^ k) := by
+  induction k with
+  | zero => simp [squareKrylov]
+  | succ k ih =>
+      simp [squareKrylov, ih, pow_succ, pow_mul]
+      ring_nf
+      -- need M^(2^k) * M^(2^k) = M^(2^k * 2)
+      sorry  -- S2 proof: assemble Matrix.pow_mul + Nat.pow_succ
+
+end MinpolyComplexity.SubcubicKrylov
+```
+
+The `sorry` is replaceable with one `Matrix.pow_mul`/`Nat.pow_succ` chain in
+~5 lines; total target for S2 is ~35 lines (definition + 3 theorems + module
+docstring).
+
+## Priority table (next-action choice)
+
+| Layer | Lines | Build | Difficulty | Value |
+|-------|-------|-------|------------|-------|
+| S2: squareKrylov + recurrence | 35 | 1× | Easy | Anchors all subsequent work |
+| S3: Krylov ⊆ span(squareKrylov) | 60 | 1× | Medium | Key correctness bridge |
+| S4: $2^k \ge n$ bound | 25 | 0× | Trivial | Pure `Nat`-arithmetic |
+| Layer 3 (cost claim) | ?? | n/a | **Blocked** | Needs Mathlib complexity-monad |
+
+**Recommended next action: S2.** Single Docker build, clean definitional
+recurrence, anchors S3-S5 without committing to any complexity framework.
+
+## What to leave for OQ-03-OQ-03 / OQ-03-OQ-04 (sibling slugs)
+
+* OQ-03-OQ-03 (if it exists) is the natural home for the Storjohann
+  $O(n^\omega)$ refinement (no $\log n$ factor).
+* OQ-03-OQ-01 (sibling) already handles the cyclic-vector case and likely
+  contains Hessenberg / Frobenius normal-form pieces that overlap.
+  **Action item:** before S2, read `CayleyHamiltonMinpolyOQ03OQ01.lean` to
+  verify name collisions and pick a clean module namespace.
+
+## References (cross-linked to problem.md)
+
+* Keller-Gehrig (1985) — original paper, Theoretical Computer Science.
+* Giesbrecht (1995) — first true $O(n^\omega)$ (no log factor).
+* Storjohann (2000) — comprehensive thesis on $O(n^\omega)$ canonical forms.
+* von zur Gathen & Gerhard, *Modern Computer Algebra* §12.3 — textbook
+  exposition.

--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/problem.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/problem.md
@@ -1,0 +1,194 @@
+# Problem: Can the $O(n^\omega)$ Keller-Gehrig algorithm (1985) be formalised, extending the Krylov framework to subcubic complexity?
+
+## Statement
+
+### Plain Language
+
+The Krylov method (formalised in `CayleyHamiltonMinpolyOQ03.lean`) computes the
+minimal polynomial of an $n\times n$ matrix in $O(n^3)$ field operations,
+using $n$ matrix-vector products of $O(n^2)$ each.
+
+Keller-Gehrig (1985) gives a $O(n^\omega)$ algorithm, where $\omega < 3$ is the
+matrix-multiplication exponent (e.g. Strassen's $\omega = 2.807$, currently
+$\omega \approx 2.37$). The asymptotic speed-up is genuine: it relies on
+repeated squaring of $M$ itself, replacing $n$ Krylov steps with $\lceil \log_2 n \rceil$
+matrix products of size $n\times n$.
+
+**Open question.** Can this algorithm be formalised in Lean 4 over Mathlib?
+
+### Formal Statement (target)
+
+$$
+\text{KellerGehrig}(M) \text{ computes } \mu_M \text{ in } O(n^\omega) \text{ field operations.}
+$$
+
+More precisely, three layers of formalisation are possible:
+
+1. **Structural layer.** Define a *squared-Krylov sequence*
+   $T_k := M^{2^k}$ for $0 \le k \le \lceil \log_2 n \rceil$, and prove the
+   recurrence $T_{k+1} = T_k \cdot T_k$.  ✅ Tractable in Mathlib today.
+
+2. **Correctness layer.** Show that the span of
+   $\{v, Mv, M^2 v, \dots, M^{2^{\lceil \log_2 n\rceil}-1} v\}$ contains
+   $\{v, Mv, \dots, M^{n-1} v\}$, hence the minimal polynomial can be
+   recovered from the squared-Krylov vectors in $\lceil \log_2 n\rceil$
+   matrix-matrix products plus one matrix-vector solve. ✅ Tractable.
+
+3. **Complexity layer.** Prove the operation count is $O(n^\omega)$. ❌ **Blocked**
+   on (a) Mathlib having no operation-counting / complexity-monad framework
+   and (b) Mathlib having no fast matrix multiplication implementation; the
+   default `Matrix.mul` is the naive cubic algorithm.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - linear-algebra
+  - matrices
+  - polynomials
+  - minimal-polynomial
+  - krylov-method
+  - computational-complexity
+  - keller-gehrig
+  - subcubic
+  - research
+  - seeker-selected
+  - gallery-extracted
+```
+
+**Significance**: 6/10 — Foundational result in the asymptotic complexity of
+exact linear algebra; gateway to the entire Storjohann / Giesbrecht literature
+on $O(n^\omega)$ algorithms for canonical forms (Hermite, Smith, Frobenius).
+
+**Tractability**: 6/10 — Layer (1) is straightforward (≈ 30 lines). Layer (2)
+needs a short bridge proof. Layer (3) requires infrastructure Mathlib does not
+yet have.
+
+## Why This Matters
+
+1. **Closes the algorithmic chapter of `cayley-hamilton-minpoly`.**
+   `CayleyHamiltonMinpolyOQ03.lean` formalises Krylov at $O(n^3)$; the
+   Keller-Gehrig algorithm is the natural successor showing the same
+   structural objects (Krylov sequence, annihilating polynomial) survive into
+   the subcubic regime.
+
+2. **Provides a clean target for the "complexity in Mathlib" discussion.**
+   Even partial layer-(1)/layer-(2) progress puts a stake in the ground:
+   "here is the proof that the asymptotic gain is structural, modulo a
+   complexity oracle." A future Mathlib complexity-monad PR would slot in
+   without rewriting the linear-algebra core.
+
+3. **Aligns with the active OSforGFF / Mathlib-upgrade plan** (project memory)
+   which contemplates richer computational-algebra infrastructure.
+
+## Mathlib Infrastructure Map
+
+### Available today (✅)
+
+| Object | Mathlib API | OQ-03 wrapper |
+|--------|-------------|---------------|
+| Matrix powers | `Matrix.pow_succ`, `Matrix.pow_mul` | n/a |
+| Polynomial evaluation at a matrix | `Polynomial.aeval` | `aeval_mulVec_eq_krylov_sum` (OQ-03:111) |
+| Minimal polynomial existence | `minpoly K M` | `minpoly_annihilates_vec` (OQ-03:135) |
+| Krylov sequence | — | `krylovVec` (OQ-03:73) |
+| Krylov recurrence | — | `krylov_recurrence` (OQ-03:318) |
+| Iteration bound $d \le n$ | — | `krylov_iteration_bound` (OQ-03:236) |
+| Cyclic vector → maximal Krylov | — | `nonderogatory_krylov_optimal` (OQ-03:256) |
+
+### Missing today (❌)
+
+1. **No squared-Krylov sequence** $T_k = M^{2^k}$ in OQ-03 or Mathlib.
+2. **No "span of Krylov prefixes" API** in OQ-03 (only LinearIndependent).
+3. **No complexity monad** in Mathlib (no `Cost` / `WithCount` / Sterling
+   tagged-monad). This blocks any *quantitative* statement of $O(n^\omega)$.
+4. **No fast matrix multiplication.** `Matrix.mul` is `Σ_k (M i k) * (N k j)`,
+   the textbook $O(n^3)$ algorithm. Strassen, Coppersmith-Winograd, etc., are
+   absent.
+5. **No matrix-multiplication exponent $\omega$.** Even as an opaque constant
+   $\omega \in [2, 3]$ with axioms.
+
+## Decomposition (S2-S6)
+
+The proposed decomposition keeps each session under 100 lines of Lean and
+under one Docker build:
+
+### S2 — squared-Krylov sequence (≈ 35 lines, 1 build)
+
+* `def squareKrylov (M : Matrix (Fin n) (Fin n) K) : ℕ → Matrix (Fin n) (Fin n) K
+   | 0     => M
+   | k + 1 => squareKrylov M k * squareKrylov M k`
+* `theorem squareKrylov_eq_pow_two : squareKrylov M k = M ^ (2 ^ k)`
+  (single `Nat.rec` + `Matrix.pow_mul` + `pow_succ`).
+* `theorem squareKrylov_recurrence : squareKrylov M (k+1) = squareKrylov M k * squareKrylov M k`
+  (definitional).
+
+### S3 — Krylov prefix span dominated by squared-Krylov (≈ 60 lines, 1 build)
+
+* `theorem krylov_in_squareKrylov_span :
+     ∀ i < 2 ^ k, ∃ p : K[X], p.natDegree < 2 ^ k ∧
+       (aeval M p).mulVec v = krylovVec M v i`
+* The polynomial $p$ is the trivial $X^i$; the lemma is the statement that
+  Horner-evaluation against the squared-Krylov sequence reproduces $M^i v$.
+
+### S4 — bound $2^{\lceil \log_2 n\rceil} \ge n$ (≈ 25 lines, no build)
+
+* `theorem squareKrylov_index_bound : ∃ k, 2 ^ k ≥ n` (constructive: `k = n`).
+* Pure `Nat`/`Pow` lemma — independent of any matrix machinery.
+
+### S5 — informal complexity comment + outline of layer-3 (no Lean)
+
+* Markdown analysis updating `knowledge.md` and `state.md`: enumerates what a
+  future complexity layer needs (`Cost` monad, fast matmul oracle, $\omega$
+  axiom). Closes layer (1) + (2) and explicitly defers layer (3).
+
+### S6 — promotion gate (optional)
+
+* Decide whether layers (1)+(2) constitute enough to *open* a gallery entry,
+  or whether `cayley-hamilton-minpoly-oq-03-oq-02` should remain in
+  research-only state pending complexity infrastructure.
+
+## Risk Notes
+
+1. **Complexity-monad bikeshed.** The natural Mathlib home for a complexity
+   monad does not exist; multiple incompatible designs are plausible
+   (cost-passing-style, comonadic, free-monad-of-arithmetic-ops). S2-S4 are
+   designed to commit to **none** of these and keep the structural layer
+   completely independent of any future choice.
+
+2. **Reachable scope is layer 1 + 2, not layer 3.** This must be explicit in
+   PRs to avoid the "stated $O(n^\omega)$, formalised $O(n^3)$" pitfall.
+   `meta.json` for any gallery promotion should call the status
+   `axiomatized` with the complexity claim stated as an assumption, **not**
+   `verified`.
+
+3. **No measured speed-up.** Because the underlying `Matrix.mul` is
+   $O(n^3)$, any computable instance of the algorithm in Lean would in fact
+   run cubically. The asymptotic claim is structural, not measurable.
+
+4. **Naming clash with `nonderogatory_krylov_optimal`.** The "optimal" in
+   OQ-03 refers to dimension, not asymptotic time. Keller-Gehrig's
+   asymptotic optimality is a separate claim. We use the names
+   `squareKrylov` / `subcubicKrylov` to avoid overloading.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `cayley-hamilton-minpoly-oq-03` | Parent: O(n³) Krylov framework (368 lines) |
+| `cayley-hamilton-minpoly-oq-04` | Cyclic vector → nonderogatory case; Keller-Gehrig handles this case with no extra work |
+| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04*` (WIP01-05) | Block-Krylov refinements — the spiritual ancestors of Keller-Gehrig in our gallery |
+| `cayley-hamilton-minpoly-oq-02-oq-03` | Minimum polynomial as gcd via Cayley-Hamilton bridge |
+
+## References
+
+* W. Keller-Gehrig, *Fast algorithms for the characteristic polynomial*,
+  Theoretical Computer Science **36** (1985), 309-317.
+* M. Giesbrecht, *Nearly optimal algorithms for canonical matrix forms*,
+  SIAM J. Comput. **24** (1995), 948-969.
+* A. Storjohann, *Algorithms for matrix canonical forms*, PhD thesis,
+  ETH Zürich (2000).
+* J. von zur Gathen & J. Gerhard, *Modern Computer Algebra*, §12.3
+  (Cambridge UP, 2013).

--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
@@ -1,0 +1,77 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11T19:30:00.000Z (researcher-12, S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE — survey-only iteration. Map the formalisation feasibility of the
+Keller-Gehrig (1985) $O(n^\omega)$ algorithm onto the existing O(n³) Krylov
+framework in `CayleyHamiltonMinpolyOQ03.lean`.
+
+## Active Approach
+
+Three-layer decomposition:
+
+1. **Structural layer** (squared-Krylov sequence) — tractable today.
+2. **Correctness layer** (Krylov-prefix ⊆ squared-Krylov span) — tractable today.
+3. **Complexity layer** ($O(n^\omega)$ operation count) — **blocked** on
+   Mathlib having no complexity monad and no fast matrix multiplication.
+
+The OBSERVE pass commits to layers (1) and (2) only and explicitly defers
+layer (3). See `problem.md` for the full decomposition and `knowledge.md` for
+gap inventory, numerics, and S2 stub.
+
+## Blockers
+
+* Mathlib has no complexity-monad / cost-counting framework — blocks any
+  *quantitative* $O(n^\omega)$ statement.
+* Mathlib's `Matrix.mul` is the naive cubic algorithm; there is no Strassen
+  or abstract fast-matmul oracle.
+* The matrix-multiplication exponent $\omega$ is not in Mathlib (even as an
+  opaque constant with axioms).
+
+**Mitigation:** None of these blockers affect layers (1) and (2). They are
+the standard situation for any formalisation of an asymptotic-complexity
+claim against current Mathlib and are reflected in the project memory
+(OSforGFF integration, Mathlib upgrade discussion).
+
+## Next Action
+
+**S2 — squared-Krylov sequence.**
+
+Create `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` with:
+
+* `namespace MinpolyComplexity.SubcubicKrylov`
+* `def squareKrylov` — the matrix $M^{2^k}$ via repeated squaring.
+* `theorem squareKrylov_zero` (rfl).
+* `theorem squareKrylov_succ` (rfl).
+* `theorem squareKrylov_eq_pow_two` — bridge to `M ^ (2^k)` via
+  `Matrix.pow_mul` + `Nat.pow_succ` (~5 lines).
+
+Target: ≈ 35 lines including module docstring, single Docker build.
+
+Before writing S2, **read `CayleyHamiltonMinpolyOQ03OQ01.lean`** to verify
+namespace and naming choices (sibling slug; potential overlap).
+
+## Attempt Counts
+
+- Total attempts: 1 (S1, this iteration)
+- Current approach attempts: 1
+- Approaches tried: 1 (3-layer decomposition with explicit deferral of
+  complexity layer)
+
+## Findings Summary
+
+* The Keller-Gehrig speed-up is *structural*: $n$ cheap matvecs vs.
+  $\log n$ expensive matmuls. The structural claim formalises today.
+* The *quantitative* speed-up is gated on Mathlib infrastructure that does
+  not exist (complexity monad, fast matmul). This must be reflected in any
+  promotion: `meta.status = axiomatized`, not `verified`.
+* Numerical breakeven: Strassen wins around $n \approx 256$; CW-Williams
+  wins from $n \approx 64$. Mathlib's choice of naive cubic `Matrix.mul` is
+  defensible at typical $n$.
+* OQ-03 already provides 90% of the algebraic infrastructure (Krylov
+  recurrence, annihilator theory, iteration bound). The new ingredient is
+  the repeated-squaring sequence, ~35 lines.

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -1,0 +1,404 @@
+{
+  "slug": "cayley-hamilton-minpoly-oq-03-oq-02",
+  "title": "Can the $O(n^\\omega)$ algorithm of Keller-Gehrig (1985) be formalized, extending the Krylov framework?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Formalise: KellerGehrig}(M) \\text{ computes } \\mu_M \\text{ via repeated squaring of } M \\text{ in } O(n^\\omega) \\text{ field operations.}",
+    "plain": "The Krylov method (OQ-03) computes the minimal polynomial in O(n^3) via n matrix-vector products. Keller-Gehrig (1985) replaces these with ⌈log₂ n⌉ matrix-matrix squarings to reach O(n^ω), where ω is the matrix-multiplication exponent. Can the algorithm be formalised in Lean 4 over current Mathlib?",
+    "whyMatters": [
+      "Closes the algorithmic chapter of cayley-hamilton-minpoly: O(n^3) Krylov (OQ-03) extends to the subcubic regime via the same structural objects.",
+      "Clean target for the 'complexity in Mathlib' discussion: even structural layers (1)+(2) commit nothing and slot into any future complexity-monad design.",
+      "Aligns with OSforGFF integration / Mathlib upgrade trajectory."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "OQ-03: O(n^3) Krylov method formalised with iteration bound d ≤ n, polynomial-evaluation = Krylov-sum identity, nonderogatory-cyclic-vector optimality.",
+      "OQ-03: krylov_recurrence shows one matvec advances the sequence by one step.",
+      "OQ-03: minpoly_degree_le_dim establishes the n-bound on minimal-polynomial degree."
+    ],
+    "open": [
+      "Layer 1: squared-Krylov sequence T_k = M^(2^k) — definition + recurrence + bridge to M^(2^k). Tractable, ≈ 35 lines.",
+      "Layer 2: Krylov-prefix ⊆ squared-Krylov span — correctness of the polynomial-evaluation pass. Tractable, ≈ 60 lines.",
+      "Layer 3: O(n^ω) operation count — BLOCKED on Mathlib having no complexity monad and no fast matrix multiplication."
+    ],
+    "goal": "Formalise layers 1 + 2 over the existing OQ-03 Krylov framework; explicitly defer layer 3 with a written-down account of the missing complexity infrastructure."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T19:30:00.000Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE — survey-only iteration. Three-layer decomposition; commit to layers 1+2, defer layer 3.",
+    "blockers": [
+      "Layer 3 only: Mathlib has no complexity-monad / cost-counting framework.",
+      "Layer 3 only: Mathlib.Matrix.mul is the naive O(n^3) algorithm; no Strassen / abstract fast-matmul oracle.",
+      "Layer 3 only: matrix-multiplication exponent ω is not in Mathlib even as an opaque constant."
+    ],
+    "nextAction": "S2 — write proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean (~35 lines): squareKrylov def + squareKrylov_zero/succ + squareKrylov_eq_pow_two bridge to M^(2^k). Single Docker build.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE — three-layer decomposition committed; layers 1+2 tractable, layer 3 deferred.",
+    "builtItems": [
+      "problem.md: rich plain/formal statements, infrastructure map vs. OQ-03 line numbers, S2-S6 decomposition, risk notes.",
+      "knowledge.md: algorithm-in-3-sentences, numerical breakeven at n=64 (Strassen wins at n≈256, CW-Williams wins at n≈64), Mathlib gap inventory for the complexity monad, worked S2 stub.",
+      "state.md: phase OBSERVE, blockers gated to layer 3, S2 next-action recipe."
+    ],
+    "insights": [
+      "The Keller-Gehrig speed-up is structural (n cheap matvecs vs ⌈log n⌉ expensive matmuls), so it formalises today modulo any complexity framework.",
+      "The asymptotic claim depends on the fast-matmul instance: with Mathlib's naive Matrix.mul the algorithm runs cubically. Honest meta.status must be 'axiomatized' on any future promotion.",
+      "OQ-03 already provides ~90% of the algebraic infrastructure; the new ingredient is repeated squaring (~35 lines).",
+      "Numerical breakeven shows naive cubic Matrix.mul is defensible at typical n; Strassen wins around n≈256."
+    ],
+    "mathlibGaps": [
+      "No squareKrylov / repeated-squaring matrix sequence.",
+      "No complexity monad (Cost / WithCount / cost-passing-style) — community has no consensus design.",
+      "No fast matrix multiplication (no Strassen, no FastMul typeclass, no abstract O(n^ω) oracle).",
+      "No matrix-multiplication exponent ω as a Mathlib constant or axiomatised real."
+    ],
+    "nextSteps": [
+      "S2: squareKrylov definition + 3 theorems (~35 lines, 1 Docker build).",
+      "S3: Krylov-prefix ⊆ squared-Krylov span via polynomial Horner evaluation (~60 lines, 1 build).",
+      "S4: 2^k ≥ n bound (~25 lines, no build — pure Nat arithmetic).",
+      "S5: explicit deferral of layer 3 in knowledge.md, with one-paragraph outline of what a future complexity-monad PR would need to add."
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrices",
+    "polynomials",
+    "minimal-polynomial",
+    "krylov-method",
+    "computational-complexity",
+    "research",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-minpoly-oq-01",
+    "cayley-hamilton-minpoly-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-03",
+    "cayley-hamilton-minpoly-oq-03",
+    "cayley-hamilton-minpoly-oq-03-oq-01",
+    "cayley-hamilton-minpoly-oq-04",
+    "cayley-hamilton-minpoly-oq-05",
+    "cayley-hamilton-minpoly-oq-05-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05",
+    "cayley-hamilton-minpoly-oq-05-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-02-oq-03"
+  ],
+  "references": {
+    "papers": [
+      "W. Keller-Gehrig, Fast algorithms for the characteristic polynomial, Theoretical Computer Science 36 (1985), 309-317.",
+      "M. Giesbrecht, Nearly optimal algorithms for canonical matrix forms, SIAM J. Comput. 24 (1995), 948-969.",
+      "A. Storjohann, Algorithms for matrix canonical forms, PhD thesis, ETH Zürich (2000).",
+      "J. von zur Gathen & J. Gerhard, Modern Computer Algebra, §12.3 (Cambridge UP, 2013)."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.Data.Matrix.Mul"
+    ]
+  },
+  "started": "2026-05-08T19:09:00.562Z",
+  "lastUpdate": "2026-05-11T19:30:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01.lean",
+      "lineCount": 308,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "lineCount": 172,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "lineCount": 391,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "lineCount": 266,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04.lean",
+      "lineCount": 317,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
+      "lineCount": 481,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "lineCount": 126,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05.lean",
+      "lineCount": 233,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "lineCount": 271,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "lineCount": 363,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "lineCount": 271,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "lineCount": 346,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "lineCount": 288,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "lineCount": 307,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "lineCount": 576,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "lineCount": 254,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "lineCount": 360,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "lineCount": 191,
+      "theoremCount": 1,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
+      "lineCount": 245,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for **cayley-hamilton-minpoly-oq-03-oq-02** (researcher-12). Surveys whether Keller-Gehrig (1985) $O(n^\omega)$ can be formalised on top of the existing $O(n^3)$ Krylov framework in `CayleyHamiltonMinpolyOQ03.lean`.

**Analysis-only — no Lean changes.** Four new files (problem.md, knowledge.md, state.md, gallery problem JSON).

## Three-layer decomposition

1. **Structural layer** — squared-Krylov sequence $T_k = M^{2^k}$ with recurrence $T_{k+1} = T_k \cdot T_k$. **Tractable** (~35 lines, single build).
2. **Correctness layer** — Krylov-prefix $\subseteq$ squared-Krylov span via polynomial Horner evaluation. **Tractable** (~60 lines, single build).
3. **Complexity layer** — $O(n^\omega)$ operation count. **Blocked** on Mathlib having no complexity-monad framework and no fast matrix multiplication.

## Findings

- **Speed-up is structural, not measurable.** $n$ cheap matvecs vs $\lceil \log_2 n\rceil$ expensive matmuls. Because `Matrix.mul` is the naive cubic algorithm, any computable instance of Keller-Gehrig in Lean would still run $O(n^3)$.
- **Numerical breakeven (n = 64):** naive Krylov 262 144 ops; KG with cubic matmul 1.57M (slower); Strassen-KG 389K; CW-Williams-KG 102K. Strassen wins at $n \approx 256$; CW-Williams wins at $n \approx 64$.
- OQ-03 already provides ~90% of the algebraic infrastructure. The new ingredient is the repeated-squaring sequence — ~35 lines.
- Honest status of any future promotion: `axiomatized`, not `verified`.

## Mathlib Gaps Identified

1. No `squareKrylov` / repeated-squaring matrix sequence.
2. No complexity monad (`Cost` / `WithCount` / cost-passing-style) — no community consensus design.
3. No fast matrix multiplication (no Strassen, no `FastMul` typeclass, no abstract $O(n^\omega)$ oracle).
4. No matrix-multiplication exponent $\omega$ as a Mathlib constant or axiomatised real.

## Next Steps

- **S2** — write `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` (~35 lines): `squareKrylov` def + `squareKrylov_zero` / `squareKrylov_succ` (both `rfl`) + `squareKrylov_eq_pow_two` bridge to `M ^ (2^k)`. Single Docker build.
- Before S2: read `CayleyHamiltonMinpolyOQ03OQ01.lean` for namespace overlap (sibling slug uses `MinpolyComplexity`).

## Test plan

- [ ] No Lean changes — survey only; no build required.
- [x] JSON validated (`python3 -c "import json; json.load(open(...))"`).
- [x] `pnpm build` will pick up the new gallery problem JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)