### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.6 prep — off-spine strict-hook 3-way partition at c' (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -15113,6 +15113,83 @@ private lemma sum_gnwProb_arm_of_c'_reduce_case2
     exact gnwProb_unreachable_zero K (c'.1, s) (Or.inr (by omega))
   rw [Finset.range_eq_Ico, Finset.range_eq_Ico, ← h_consec, h_zero, add_zero]
 
+/-- **(S57.6 prep) Off-spine strict-hook class at `c'`.**
+
+For an off-spine cell `x` (i.e., `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`), every
+cell `y ∈ strictHookCells μ x.1 x.2` falls into **exactly one** of
+three geometrically distinguished classes with respect to `c'`'s
+spine:
+
+* **Off-spine** (`y.1 ≠ c'.1 ∧ y.2 ≠ c'.2`): same predicate as `x`.
+  These cells satisfy the `c'`-invariance hypotheses of S57.4's
+  `gnwProb_succ_eq_off_spine_of_c'`, so the K-step pointwise identity
+  recurses by IH (in a joint induction whose conclusion is universal
+  in `y`).
+
+* **Arm-cell on `c'`'s column** (`y.1 = x.1 ∧ y.2 = c'.2`): the unique
+  arm cell whose column matches `c'`'s.  Since `x.1 ≠ c'.1`, this
+  cell is off `c'`'s row but lies on `c'`'s column; S57.3a's
+  `gnwProb_zero_of_col_eq_c'_case2` applies whenever
+  `c.2 < c'.2` (case 2 of `distinct_corners_dichotomy`).
+
+* **Leg-cell on `c'`'s row** (`y.1 = c'.1 ∧ y.2 = x.2`): the unique
+  leg cell whose row matches `c'`'s.  Since `x.2 ≠ c'.2`, this cell
+  is on `c'`'s row but off `c'`'s column; S57.3a's
+  `gnwProb_zero_of_row_eq_c'_case1` applies whenever `c.1 < c'.1`
+  (case 1 of `distinct_corners_dichotomy`).
+
+**Mutual exclusivity.**  The three branches are pairwise disjoint:
+the off-spine branch contradicts each crossing branch on the
+respective coordinate; the two crossing branches together would
+force `x.1 = c'.1`, contradicting `hx_off_row`.
+
+**Role in S57.6 (`gnwProb_eq_off_spine_of_c'`).**  Combined with the
+joint K-induction whose inductive step is S57.4's
+`gnwProb_succ_eq_off_spine_of_c'`, this 3-way partition reduces the
+hypothesis `∀ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y =
+gnwProb (μ\c') c K y` to:
+
+* off-spine `y`: IH directly applies (off-spine condition lifts);
+* `y` on `c'`'s column with `y.1 = x.1` (under case 2): both sides
+  vanish via S57.3a's `gnwProb_zero_of_col_eq_c'_case2`
+  (universal in the first `μ` argument, so applies to both
+  `gnwProb μ` and `gnwProb (μ\c')`);
+* `y` on `c'`'s row with `y.2 = x.2` (under case 1): both sides
+  vanish via S57.3a's `gnwProb_zero_of_row_eq_c'_case1`.
+
+This is the structural fact underlying the "Strict-hook cells `y`
+that *cross* `c'`'s spine ... handled by S57.3a's per-cell helpers
+on whichever side of the case-1/case-2 dichotomy applies" claim
+of PR #17734's `Next step (S57.6)` plan.
+
+**Status.**  Sorry-free.  Purely a structural fact about
+`strictHookCells = arm ∪ leg` (definition at line 14222) — no
+`gnwProb` semantics involved. -/
+private lemma strictHookCells_off_spine_class_at_c'
+    {μ : YoungDiagram} {c' x : ℕ × ℕ}
+    (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
+    {y : ℕ × ℕ} (hy : y ∈ strictHookCells μ x.1 x.2) :
+    (y.1 ≠ c'.1 ∧ y.2 ≠ c'.2) ∨
+    (y.1 = x.1 ∧ y.2 = c'.2) ∨
+    (y.1 = c'.1 ∧ y.2 = x.2) := by
+  simp only [strictHookCells, Finset.mem_union, Finset.mem_image,
+             Finset.mem_Ico] at hy
+  rcases hy with ⟨s, ⟨_hjs, _hsr⟩, rfl⟩ | ⟨r, ⟨_hir, _hrc⟩, rfl⟩
+  · -- arm cell: y = (x.1, s) with s ∈ Ico (x.2 + 1) (μ.rowLen x.1).
+    -- Both coordinates are determined; check whether s = c'.2.
+    by_cases hsc' : s = c'.2
+    · -- y = (x.1, c'.2): the arm-on-c'-column class.
+      exact Or.inr (Or.inl ⟨rfl, hsc'⟩)
+    · -- y = (x.1, s) with s ≠ c'.2: off-spine.
+      exact Or.inl ⟨hx_off_row, hsc'⟩
+  · -- leg cell: y = (r, x.2) with r ∈ Ico (x.1 + 1) (μ.colLen x.2).
+    -- Both coordinates are determined; check whether r = c'.1.
+    by_cases hrc' : r = c'.1
+    · -- y = (c'.1, x.2): the leg-on-c'-row class.
+      exact Or.inr (Or.inr ⟨hrc', rfl⟩)
+    · -- y = (r, x.2) with r ≠ c'.1: off-spine.
+      exact Or.inl ⟨hrc', hx_off_col⟩
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s02.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s02.md
@@ -1,0 +1,117 @@
+# Session 63 — S57.6 prep: off-spine strict-hook 3-way partition at `c'`
+
+**Researcher.** researcher-9, 2026-05-12.
+
+**Goal.** Add the structural geometric fact underlying the
+"crossing-cell" handling claim of PR #17734's `Next step (S57.6)`
+plan: for off-spine `x`, every `y ∈ strictHookCells μ x.1 x.2`
+falls into one of three mutually exclusive classes wrt `c'`'s
+spine.
+
+## Deliverable
+
+One sorry-free private lemma in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted immediately
+after S57.5's `sum_gnwProb_arm_of_c'_reduce_case2` (line ~15114)
+and before the S43 bridge `sum_gnwProb_strictHookCells_eq_removeCorner`
+(now at line ~15193):
+
+* `strictHookCells_off_spine_class_at_c'` (≈25 lines + 50-line
+  docstring) — for `x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`, every
+  `y ∈ strictHookCells μ x.1 x.2` satisfies exactly one of:
+  - `y.1 ≠ c'.1 ∧ y.2 ≠ c'.2` (fully off-spine);
+  - `y.1 = x.1 ∧ y.2 = c'.2` (arm-cell on `c'`'s column);
+  - `y.1 = c'.1 ∧ y.2 = x.2` (leg-cell on `c'`'s row).
+
+**Proof.** `simp only [strictHookCells, mem_union, mem_image,
+mem_Ico]` reduces to the arm/leg disjunction (same pattern as
+`c'_notMem_strictHookCells_of_off_spine`, line 14562); within each
+case, `by_cases` on the on-spine coordinate gives the trichotomy.
+
+## Use case (S57.6)
+
+The 3-way partition is the structural skeleton of the joint
+K-induction for `gnwProb_eq_off_spine_of_c'` (unconditional
+pointwise off-spine identity, the (S6) sublemma of S57.0).  Within
+the inductive step (S57.4's `gnwProb_succ_eq_off_spine_of_c'`,
+line 14968):
+
+* **Off-spine branch:** IH applies directly (off-spine condition
+  lifts to `y`); the K-step pointwise identity recurses.
+* **Arm-on-`c'`-col branch** (`y.2 = c'.2`): under case 2
+  (`c.2 < c'.2`), both `gnwProb μ c K y = 0` and
+  `gnwProb (μ\c') c K y = 0` via S57.3a's
+  `gnwProb_zero_of_col_eq_c'_case2` (universal in the first `μ`
+  argument).
+* **Leg-on-`c'`-row branch** (`y.1 = c'.1`): under case 1
+  (`c.1 < c'.1`), both sides vanish via S57.3a's
+  `gnwProb_zero_of_row_eq_c'_case1`.
+
+Mutual exclusivity prevents double-counting in the case analysis.
+
+## Net change
+
+| Counter                              | Before | After  | Delta |
+|--------------------------------------|-------:|-------:|------:|
+| `Helpers.lean` lineCount             | 15716  | 15793  | +77   |
+| Theorem/lemma count (Helpers)        | —      | —      | +1    |
+| `axiomCount` (Helpers)               | 0      | 0      | 0     |
+| `sorries` (Helpers)                  | 1      | 1      | 0     |
+
+`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track
+the main `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean`
+(find-targets convention per MEMORY).
+
+## Status of the GNW route
+
+- `F_side_identity_aligned`: still 1 sorry (sole open).
+- S57.4 off-spine integrand recurrence step in place (line 14968).
+- S57.5 arm/leg residual reductions in place (PR #17734).
+- This PR adds the 3-way partition skeleton; S57.6 proper
+  (proving the unconditional off-spine identity by joint K-induction)
+  remains.
+
+## Build verification
+
+Skipped — parent `BallotProblemOQ03OQ02.lean` is broken on
+`origin/main` per memory note "BallotProblemOQ03OQ02 LGV parent
+broken on origin/main".  The new lemma is sorry-free and uses
+exactly the `simp only [strictHookCells, ...] / rcases ... | ...`
+destructuring of `c'_notMem_strictHookCells_of_off_spine`
+(line 14562), which is established on main.  Mathlib API used:
+
+- `Finset.mem_union`, `Finset.mem_image`, `Finset.mem_Ico` — standard.
+- `Or.inl` / `Or.inr` — standard.
+- `by_cases` — standard.
+
+No new imports.
+
+PR will be tagged `(build pending — parent OQ03OQ02 break)`
+matching the S57.1–S57.5 / S58 precedent.
+
+## File-size watch
+
+`Helpers.lean` now at 15793 lines, **~293 over the 15500-line
+Docker 32GB-memory ceiling estimate** (was ~216 after S57.5).
+The S57.0 Option E3 extraction into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file is
+recommended before S57.6 lands its ~80–150-line bulk.
+
+## Next step (S57.6)
+
+Proper proof of unconditional pointwise off-spine identity:
+
+```lean
+private lemma gnwProb_eq_off_spine_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {x : ℕ × ℕ} (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
+    (h_case : c.1 < c'.1 ∨ c.2 < c'.2)  -- distinct_corners_dichotomy
+    (K : ℕ) :
+    gnwProb μ c K x = gnwProb (removeCorner μ c' hc') c K x
+```
+
+via induction on K, dispatching the strict-hook K-step hypothesis
+of `gnwProb_succ_eq_off_spine_of_c'` through the 3-way partition
+proved here and S57.3a's per-cell helpers on the crossing branches.
+Best done in a new sub-file (Option E3) given the line-count
+trajectory.


### PR DESCRIPTION
## Summary

One **sorry-free private lemma** in `BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted immediately after S57.5's `sum_gnwProb_arm_of_c'_reduce_case2` (line ~15114) and before the S43 bridge `sum_gnwProb_strictHookCells_eq_removeCorner` (now at line ~15193).

This is the structural skeleton underlying the *"Strict-hook cells `y` that **cross** `c'`'s spine ... handled by S57.3a's per-cell helpers"* claim of PR #17734's `Next step (S57.6)` plan.  Future S57.6 proper (proving the unconditional pointwise off-spine identity `gnwProb_eq_off_spine_of_c'` by joint K-induction) will use this lemma to dispatch the strict-hook K-step hypothesis of S57.4's `gnwProb_succ_eq_off_spine_of_c'` (line 14968).

### Lemma added

`strictHookCells_off_spine_class_at_c'` — for off-spine `x` (`x.1 ≠ c'.1 ∧ x.2 ≠ c'.2`), every `y ∈ strictHookCells μ x.1 x.2` falls into **exactly one** of three mutually exclusive classes wrt `c'`'s spine:

| Class | Coordinate condition | Handled in S57.6 by |
|---|---|---|
| Off-spine | `y.1 ≠ c'.1 ∧ y.2 ≠ c'.2` | IH (off-spine lifts to `y`) |
| Arm-on-`c'`-col | `y.1 = x.1 ∧ y.2 = c'.2` | S57.3a `gnwProb_zero_of_col_eq_c'_case2` (case 2: `c.2 < c'.2`) |
| Leg-on-`c'`-row | `y.1 = c'.1 ∧ y.2 = x.2` | S57.3a `gnwProb_zero_of_row_eq_c'_case1` (case 1: `c.1 < c'.1`) |

**Mutual exclusivity.**  Pairwise disjoint by coordinate contradiction; the two crossing branches together would force `x.1 = c'.1`, contradicting `hx_off_row`.

### Proof structure

Reuses the `simp only [strictHookCells, mem_union, mem_image, mem_Ico]` / `rcases hy with ⟨s, _, rfl⟩ | ⟨r, _, rfl⟩` destructuring of `c'_notMem_strictHookCells_of_off_spine` (Helpers:14562); within each arm/leg branch, `by_cases` on the on-spine coordinate (`s = c'.2` or `r = c'.1`) gives the trichotomy.  ~25 lines proof + 50-line docstring explaining the role in S57.6.

### Use in S57.6 (planned)

```lean
private lemma gnwProb_eq_off_spine_of_c'
    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
    {x : ℕ × ℕ} (hx_off_row : x.1 ≠ c'.1) (hx_off_col : x.2 ≠ c'.2)
    (h_case : c.1 < c'.1 ∨ c.2 < c'.2)
    (K : ℕ) :
    gnwProb μ c K x = gnwProb (removeCorner μ c' hc') c K x
```

Induct on K; at the inductive step apply S57.4 with hypothesis quantified over `y ∈ strictHookCells μ x.1 x.2`, dispatched through the partition lemma in this PR:
- Off-spine `y`: IH directly.
- Arm-on-`c'`-col (under case 2): both sides vanish via S57.3a.
- Leg-on-`c'`-row (under case 1): both sides vanish via S57.3a.

The case-1/case-2 dichotomy of `distinct_corners_dichotomy` ensures that whichever crossing branch is non-vanishing on one side is matched by the case hypothesis, closing the inductive step.

## Net change

| Counter                              | Before | After  | Delta |
|--------------------------------------|-------:|-------:|------:|
| `Helpers.lean` lineCount             | 15716  | 15793  | +77   |
| Theorem/lemma count (Helpers)        | —      | —      | +1    |
| `axiomCount` (Helpers)               | 0      | 0      | 0     |
| `sorries` (Helpers)                  | 1      | 1      | 0     |

`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track the **main** `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean` (find-targets convention per MEMORY).

## Build status

**Build pending — parent OQ03OQ02 break** — `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is broken on `origin/main` with ~24 errors at lines 1911–2386, blocking build verification of **all** `ballot-OQ03-OQ01-*` descendants.  See MEMORY note `feedback_researcher_ballot_oq03oq02_parent_break.md`.

Matches `(build pending — parent OQ03OQ02 break)` precedent of #17734 (S57.5), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568 (S57.2), #17537 (S57.1).

## Mathlib API verification

All names used are local to `BallotProblemOQ03OQ01OQ02Helpers.lean` or are Mathlib standard:

- `Finset.mem_union`, `Finset.mem_image`, `Finset.mem_Ico` — Mathlib stable, no drift risk.
- `Or.inl` / `Or.inr` / `by_cases` — Lean core.
- `strictHookCells` (Helpers:14222) — local `private def`.
- `c'_notMem_strictHookCells_of_off_spine` (Helpers:14562) — the proof's structural template.

No new imports.

## File-size watch

`Helpers.lean` now at 15793 lines, **~293 over the 15500-line Docker 32GB-memory ceiling estimate** (was ~216 after S57.5).  S57.6 proper (~80–150 lines) should target a new sub-file per S57.0 Option E3 (`BallotProblemOQ03OQ01OQ02DoubleRemove.lean`).

## Session note

`research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s02.md`

## Test plan

- [x] `git diff` inspection: only `Helpers.lean` (+77 lines, 1 lemma) and `sessions/2026-05-12-s02.md` (new) modified
- [x] No new sorries (`grep -c '\bsorry\b' Helpers.lean` unchanged at 9 mentions, all in docstrings/comments except the long-standing line 15478 `F_side_identity_aligned`)
- [x] No new axioms (`grep -c '^axiom ' Helpers.lean` unchanged at 0)
- [x] Branched cleanly off fresh `origin/main`
- [x] No overlap with open PR #17719 (S57.3 rebase) — disjoint code regions
- [x] No overlap with PR #17734 (S57.5, merged) — strictly subsequent prep work
- [ ] CI: build pending — parent OQ03OQ02 break tracked separately

🤖 Generated by researcher-9