### PR TITLE
Enrich erdos101-problem: header annotation/section + technique→theorem schema fixes

### DIFF
--- a/src/data/proofs/erdos101-problem/annotations.json
+++ b/src/data/proofs/erdos101-problem/annotations.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "e101-header-context",
+    "proofId": "erdos101-problem",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 21
+    },
+    "title": "Header: Problem Statement, Bounty, and Mathlib Imports",
+    "content": "Lines 1–17 are the file's module docstring stating Erdős Problem #101 verbatim — given n points in ℝ² with no five collinear, prove that the number of lines containing exactly four points is o(n²) — and recording the historical arc: Erdős conjectured Θ(n^(3/2)) (matched below by Grünbaum's construction), but Solymosi and Stojaković subsequently disproved that, building point sets with n^(2 − O(1/√(log n))) four-point lines. The upper bound o(n²) remains open, with a standing $100 bounty (`https://erdosproblems.com/101`). Lines 19–21 import the minimum Mathlib surface needed downstream: `Mathlib.Data.Finset.Card` (for `Finset.card`, `Finset.powersetCard`, `choose_two_right`), `Mathlib.Data.Nat.Basic` (for the arithmetic lemmas like `Nat.le_div_iff_mul_le` used in the n(n-1)/12 packing bound), and `Mathlib.Tactic` (umbrella `ring`/`linarith`/`nlinarith`/`omega` import).",
+    "mathContext": "**The problem**: Let $f_4(n) := \\max_{P \\subset \\mathbb{R}^2,\\ |P|=n,\\ \\text{no 5 collinear}} \\#\\{L \\text{ line} : |L \\cap P| = 4\\}$. Conjecture (Erdős): $f_4(n) = o(n^2)$ but $f_4(n) = \\Omega(n^{3/2})$ tight. Reality (Solymosi–Stojaković, 2013): $f_4(n) = n^{2 - O(1/\\sqrt{\\log n})}$, so it does grow faster than any $n^{2-\\epsilon}$. Open: prove $f_4(n) = o(n^2)$ at all, or even just $f_4(n) \\le n^2/\\log n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős's discrete geometry problems",
+      "extremal combinatorics",
+      "Solymosi–Stojaković construction",
+      "Grünbaum's orchard problem",
+      "Szemerédi–Trotter theorem"
+    ],
+    "prerequisites": [
+      "extremal combinatorics",
+      "asymptotic notation o(·), Θ(·), Ω(·)",
+      "the orchard problem (3-point lines)",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Tactic"
+    ]
+  },
+  {
     "id": "e101-definitions",
     "proofId": "erdos101-problem",
     "type": "definition",
@@ -27,7 +54,7 @@
   {
     "id": "e101-symmetries",
     "proofId": "erdos101-problem",
-    "type": "technique",
+    "type": "theorem",
     "range": {
       "startLine": 52,
       "endLine": 83
@@ -236,7 +263,7 @@
   {
     "id": "e101-powersetcard2-disjoint",
     "proofId": "erdos101-problem",
-    "type": "technique",
+    "type": "theorem",
     "range": {
       "startLine": 504,
       "endLine": 515

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -112,6 +112,14 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Header: Problem Statement and Imports (L1–21)",
+      "startLine": 1,
+      "endLine": 21,
+      "summary": "Module docstring states Erdős Problem #101 verbatim (n points in ℝ², no 5 collinear, prove four-point line count is o(n²)), records the Erdős Θ(n^(3/2)) conjecture, Grünbaum's matching lower bound, and the Solymosi–Stojaković n^(2−O(1/√(log n))) counterexample (refuting tightness of the conjecture). Notes the $100 bounty at erdosproblems.com/101. Lines 19–21 import the minimum Mathlib surface: Finset.Card, Nat.Basic, Tactic.",
+      "mathContext": "$f_4(n) := \\max_{P,\\ |P|=n,\\ \\text{no 5 collinear}} \\#\\{L : |L \\cap P| = 4\\}$; conjectured $\\Theta(n^{3/2})$, in fact at least $n^{2 - O(1/\\sqrt{\\log n})}$ (Solymosi–Stojaković, 2013), upper bound $o(n^2)$ open."
+    },
+    {
       "id": "sec-definitions",
       "title": "Definitions: Collinearity and Four-Point Line Count (L22–48)",
       "startLine": 22,


### PR DESCRIPTION
Enrichment pass for `erdos101-problem` (Erdős Problem #101 — four-point lines from planar point sets, $100 bounty).

## Changes

**Schema fixes** (`src/types/proof.ts:409` defines `AnnotationType = 'theorem' | 'lemma' | 'definition' | 'tactic' | 'concept' | 'insight' | 'warning'`):
- `e101-symmetries` (lines 52–83) and `e101-powersetcard2-disjoint` (lines 504–515) had `type: "technique"`, which is outside the union. The wrapped Lean is `theorem` declarations in both cases (the collinearity symmetry suite is 7 `theorem` decls; `powersetCard2_disjoint` is one `theorem`), so the corrected type is `"theorem"`.

**Coverage**:
- **New annotation** `e101-header-context` (concept, key, lines 1–21) — covers the previously-uncovered file docstring + imports. States Erdős Problem #101 verbatim (n points in ℝ² with no 5 collinear ⇒ four-point line count is o(n²) — bounty $100, open) and traces the historical arc: Erdős's conjectured Θ(n^(3/2)) → Grünbaum's matching lower bound → Solymosi–Stojaković n^(2 − O(1/√(log n))) disproof of tightness.
- **New section** `sec-header` (lines 1–21) — bookends the previously uncovered file header.

## State after this PR

- `sections`: 5 (was 4)
- `annotations`: 15 (was 14)
- Annotation coverage: lines 1–757 covered with only small whitespace/separator gaps; the lines 1–21 header (longest previously-uncovered span) is now annotated.
- `keyInsights`: 7 (unchanged)
- `crossReferences`: 6 (unchanged)
- `mainTheorems`: 9 (unchanged)
- `references`: 9 (unchanged)
- Schema validity: all annotation `type` values now in the documented union.

## Build note

`pnpm build`'s vite step is blocked locally by the Node v26 `better-sqlite3` gyp failure (env issue, documented in agent memory). I validated:
- `pnpm exec tsx scripts/annotations/build.ts` produces zero errors for `erdos101-problem` (3248 pre-existing warnings unrelated to this PR).
- `pnpm exec tsx scripts/research/build.ts` produces the 1255KB listings index successfully.
- `pnpm exec tsc -b` passes.
- `python3 -c "json.load(...)"` validates the JSON.

CI will run the full chain.