### PR TITLE
research(erdos-101-oq-01): S1 — OBSERVE scaffold for o(n²) four-point line bound (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -661,6 +661,7 @@ import Proofs.Erdos1006OQ01OQ02
 import Proofs.Erdos1006OQ02
 import Proofs.Erdos1006OQ03
 import Proofs.Erdos1006OQ04
+import Proofs.Erdos1006OQ04Decidability
 import Proofs.Erdos1006Problem
 import Proofs.Erdos1007OQ01
 import Proofs.Erdos1007OQ01Aristotle
@@ -704,6 +705,7 @@ import Proofs.Erdos1018OQ04Incomplete01Aristotle
 import Proofs.Erdos1018Problem
 import Proofs.Erdos1019Aristotle
 import Proofs.Erdos1019Problem
+import Proofs.Erdos101OQ01
 import Proofs.Erdos101Problem
 import Proofs.Erdos1020Problem
 import Proofs.Erdos1021Aristotle
@@ -2405,6 +2407,7 @@ import Proofs.KnightsTourObliqueOQ01
 import Proofs.Konigsberg
 import Proofs.KonigsbergOQ01
 import Proofs.KonigsbergOQ01OQ02
+import Proofs.KonigsbergOQ01OQ02Recipe
 import Proofs.KonigsbergOQ02
 import Proofs.KonigsbergOQ02OQ01
 import Proofs.KonigsbergOQ02OQ01Aristotle
@@ -2462,6 +2465,7 @@ import Proofs.LawsOfLargeNumbersOQ03
 import Proofs.LawsOfLargeNumbersOQ03Aristotle
 import Proofs.LawsOfLargeNumbersOQ04
 import Proofs.LawsOfLargeNumbersOQ04OQ03
+import Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing
 import Proofs.LebesgueMeasure
 import Proofs.LebesgueMeasureOQ01
 import Proofs.LebesgueMeasureOQ01OQ01
@@ -2489,6 +2493,7 @@ import Proofs.MathematicalInductionOQ01
 import Proofs.MathematicalInductionOQ03
 import Proofs.MeanValueTheorem
 import Proofs.MeanValueTheoremOQ02
+import Proofs.MeanValueTheoremOQ02OQ04
 import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
 import Proofs.MinkowskiFundamentalTheorem

--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -1,0 +1,253 @@
+/-
+# Erdős Problem #101 — OQ-01: the o(n²) upper bound
+
+This file is the S1 OBSERVE scaffold for OQ-01 of Erdős Problem #101.
+The companion `Erdos101Problem.lean` establishes the framework
+(`PlanarPointSet`, `collinear`, `NoFiveCollinear`, `fourPointLineCount`)
+and the tight elementary bound `fourPointLineCount P ≤ n(n-1)/12`
+(`improved_upper_bound`).
+
+## The OPEN question
+
+  For every $\varepsilon > 0$, does there exist $N$ such that
+  every planar point set $P$ with $|P| \geq N$ and no five collinear
+  satisfies
+        fourPointLineCount(P) < ε · |P|²?
+
+Equivalently, the maximum number of lines containing exactly four
+points of an $n$-point planar set with no five collinear is $o(n^2)$.
+
+Status: OPEN. $100 Erdős prize. Latest progress:
+
+* Lower bound (Solymosi–Stojaković, 2013):
+    n^{2 − O(1/√(log n))} — disproves Erdős's conjectured Θ(n^{3/2}).
+* Upper bound (Szemerédi–Trotter applied, trivial double-counting):
+    O(n²) — but no o(n²) bound is known.
+
+The gap between these is the precise content of OQ-01.
+
+## What this file contains
+
+* Asymptotic vocabulary `IsLittleOh_n_squared` specialised to ℕ → ℕ.
+* The formal Σ₂-style statement of the OQ-01 conjecture,
+  `erdos_101_oq_01_conjecture`, recorded as a `sorry`.
+* Easy small-case lemmas that the conjecture trivially subsumes,
+  proved here unconditionally:
+    - `fourPointLineCount_o_n_squared_holds_below_four` — for all
+      $|P| < 4$, the count is $0$, vacuously $< \varepsilon \cdot n^2$
+      for any $\varepsilon > 0$ and $n \geq 1$.
+    - `fourPointLineCount_le_quadratic` — the trivial $O(n^2)$ upper
+      bound restated in ℝ, witnessing that the question reduces to
+      the quantitative little-oh refinement.
+* A `BoundsAtRate` predicate parameterising bounds at rate $f(n)$, used
+  to express known results:
+    - `bounds_at_rate_quadratic_unconditional` (trivially provable).
+    - `bounds_at_rate_quadratic_over_twelve` (improved bound).
+    - `bounds_at_rate_quadratic_over_log_log_log` — a representative
+      $o(n^2)$ rate, recorded as `sorry` (the open conjecture in
+      asymptotic form).
+* Documentation of the proof obstructions, the known partial results,
+  and the Solymosi–Stojaković lower bound.
+
+Reference: https://erdosproblems.com/101
+-/
+
+import Proofs.Erdos101Problem
+
+namespace Erdos101OQ01
+
+open Classical
+
+/- ## Asymptotic vocabulary -/
+
+/-- A function `f : ℕ → ℕ` is $o(n^2)$ if, for every $\varepsilon > 0$, all
+sufficiently large $n$ satisfy `f n < ε · n²` as reals. -/
+def IsLittleOh_n_squared (f : ℕ → ℕ) : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ N : ℕ, ∀ n : ℕ, N ≤ n → (f n : ℝ) < ε * (n : ℝ)^2
+
+/-- A rate predicate: `BoundsAtRate g` means every no-five-collinear set
+satisfies `fourPointLineCount P ≤ g P.points.card` (as reals). -/
+def BoundsAtRate (g : ℕ → ℝ) : Prop :=
+  ∀ (P : PlanarPointSet), NoFiveCollinear P →
+    (fourPointLineCount P : ℝ) ≤ g P.points.card
+
+/- ## The OPEN question, in two equivalent forms -/
+
+/-- **OQ-01, primary form**: the maximum four-point line count over
+all no-five-collinear planar point sets of size at most `n` is $o(n^2)$.
+
+Equivalent statement: for every $\varepsilon > 0$ there exists $N$ such
+that every no-five-collinear `P` with `|P| ≥ N` satisfies
+`fourPointLineCount P < ε · |P|²`.
+
+This statement is **OPEN** ($100 Erdős prize). -/
+def erdos_101_oq_01_conjecture : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ N : ℕ, ∀ (P : PlanarPointSet),
+    NoFiveCollinear P → N ≤ P.points.card →
+    (fourPointLineCount P : ℝ) < ε * (P.points.card : ℝ)^2
+
+/-- **OQ-01, rate form**: there exists a function `g : ℕ → ℝ` that is
+$o(n^2)$ and bounds `fourPointLineCount P` for every no-five-collinear
+`P` (taking input size `n = |P|`).
+
+This is the asymptotic statement of OQ-01 expressed as the existence of
+an `o(n²)` *witness function*. It is OPEN. -/
+def erdos_101_oq_01_rate_form : Prop :=
+  ∃ g : ℕ → ℕ, IsLittleOh_n_squared g ∧
+    ∀ (P : PlanarPointSet), NoFiveCollinear P →
+      fourPointLineCount P ≤ g P.points.card
+
+/-- The main open theorem of OQ-01, stated in primary form.
+
+Proof is open. The two definitions `erdos_101_oq_01_conjecture` and
+`erdos_101_oq_01_rate_form` are mutually convertible by the classical
+ε-N $\leftrightarrow$ Cauchy-criterion bridge; we record the primary
+form and leave the rate form unfolded as a definitional convenience. -/
+theorem erdos_101_oq_01 : erdos_101_oq_01_conjecture := by
+  sorry
+
+/- ## Easy cases that the conjecture subsumes (proved here unconditionally) -/
+
+/-- For every small point set ($|P| < 4$) the four-point line count is $0$:
+there is no 4-element subset of `P.points` at all. Restatement of
+`fourPointLineCount_lt_four` for the OQ-01 namespace. -/
+theorem fourPointLineCount_zero_of_small (P : PlanarPointSet)
+    (h : P.points.card < 4) : fourPointLineCount P = 0 :=
+  fourPointLineCount_lt_four P h
+
+/-- **OQ-01 holds vacuously for all `n ≤ 3`**: for every $\varepsilon > 0$
+and every no-five-collinear `P` with `|P| ≤ 3`, the count is `0` and
+hence strictly less than `ε · |P|²` whenever $|P| \geq 1$ (so the RHS
+is positive). -/
+theorem fourPointLineCount_o_n_squared_holds_below_four
+    (ε : ℝ) (hε : 0 < ε) (P : PlanarPointSet)
+    (hP_card : P.points.card ≤ 3) :
+    (fourPointLineCount P : ℝ) < ε * (P.points.card : ℝ)^2 := by
+  have hlt4 : P.points.card < 4 := by omega
+  have h0 : fourPointLineCount P = 0 := fourPointLineCount_lt_four P hlt4
+  rw [h0]
+  have hpos : 0 < P.points.card := P.size_pos
+  have hcard_pos_real : (0 : ℝ) < (P.points.card : ℝ) := by exact_mod_cast hpos
+  have hsq_pos : (0 : ℝ) < (P.points.card : ℝ)^2 := pow_pos hcard_pos_real 2
+  positivity
+
+/-- **Trivial quadratic upper bound** (real version): `fourPointLineCount
+P ≤ n(n-1)/12 ≤ n²/12 ≤ n²` for every no-five-collinear `P`.
+
+Witnesses the $O(n^2)$ regime — the OQ-01 question is whether the
+constant `1` in this bound can be tightened to any $\varepsilon > 0$
+beyond a threshold. -/
+theorem fourPointLineCount_le_quadratic (P : PlanarPointSet)
+    (hP : NoFiveCollinear P) :
+    (fourPointLineCount P : ℝ) ≤ (P.points.card : ℝ)^2 := by
+  have hN : fourPointLineCount P ≤ P.points.card * (P.points.card - 1) / 12 :=
+    improved_upper_bound P hP
+  have hN' : (fourPointLineCount P : ℝ) ≤
+      ((P.points.card * (P.points.card - 1) / 12 : ℕ) : ℝ) := by
+    exact_mod_cast hN
+  -- The cast: ((n * (n-1) / 12 : ℕ) : ℝ) ≤ n * (n-1) / 12 (real division), but in ℕ.
+  -- We bound: n * (n-1) / 12 ≤ n * (n-1) ≤ n * n = n².
+  have hbound_nat : P.points.card * (P.points.card - 1) / 12 ≤
+      P.points.card * P.points.card := by
+    set n := P.points.card
+    have : n * (n - 1) ≤ n * n := Nat.mul_le_mul_left n (Nat.sub_le n 1)
+    have h1 : n * (n - 1) / 12 ≤ n * (n - 1) := Nat.div_le_self _ 12
+    exact h1.trans this
+  have hbound_real :
+      ((P.points.card * (P.points.card - 1) / 12 : ℕ) : ℝ) ≤
+        (P.points.card : ℝ)^2 := by
+    have hle : ((P.points.card * (P.points.card - 1) / 12 : ℕ) : ℝ) ≤
+        ((P.points.card * P.points.card : ℕ) : ℝ) := by
+      exact_mod_cast hbound_nat
+    have hsq : ((P.points.card * P.points.card : ℕ) : ℝ) =
+        (P.points.card : ℝ)^2 := by push_cast; ring
+    linarith
+  linarith
+
+/- ## Known bounds expressed via `BoundsAtRate` -/
+
+/-- **Known: quadratic bound (trivial)**. -/
+theorem bounds_at_rate_quadratic_unconditional :
+    BoundsAtRate (fun n => (n : ℝ)^2) := by
+  intro P hP
+  exact fourPointLineCount_le_quadratic P hP
+
+/-- **Known: improved quadratic bound** at rate $n^2 / 12$, weakening
+`improved_upper_bound`'s $n(n-1)/12$ to avoid the subtraction-in-ℕ
+cast subtlety. The $n(n-1)/12$ version follows by the same proof
+together with `Nat.cast_pred` once $n \geq 1$; since OQ-01 only cares
+about the asymptotic regime $n \to \infty$, the $n^2/12$ rate is
+equivalent in the relevant sense. -/
+theorem bounds_at_rate_quadratic_over_twelve :
+    BoundsAtRate (fun n => (n : ℝ)^2 / 12) := by
+  intro P hP
+  have hN : fourPointLineCount P ≤ P.points.card * (P.points.card - 1) / 12 :=
+    improved_upper_bound P hP
+  set n := P.points.card with hn
+  -- Bound the ℕ-divided product by `n * n / 12`, which is `n²/12`.
+  have hbound_nat :
+      n * (n - 1) / 12 ≤ n * n / 12 := by
+    apply Nat.div_le_div_right
+    exact Nat.mul_le_mul_left n (Nat.sub_le n 1)
+  have hcast :
+      ((n * n / 12 : ℕ) : ℝ) ≤ (n : ℝ)^2 / 12 := by
+    calc ((n * n / 12 : ℕ) : ℝ)
+        ≤ ((n * n : ℕ) : ℝ) / 12 := Nat.cast_div_le
+      _ = (n : ℝ)^2 / 12 := by push_cast; ring
+  calc (fourPointLineCount P : ℝ)
+      ≤ ((n * (n - 1) / 12 : ℕ) : ℝ) := by exact_mod_cast hN
+    _ ≤ ((n * n / 12 : ℕ) : ℝ) := by exact_mod_cast hbound_nat
+    _ ≤ (n : ℝ)^2 / 12 := hcast
+
+/- ## The OPEN refinement and its consequences
+
+The conjecture would imply (via `bounds_at_rate_*`) that there exists
+a witness rate `g : ℕ → ℝ` with `g n = o(n²)` and
+`fourPointLineCount P ≤ g n` for every no-five-collinear `P` of size
+`n`. The known rates `n²`, `n(n-1)/12` are *not* `o(n²)` — they are
+$\Theta(n^2)$ — so the open content is precisely a sub-quadratic
+quantitative refinement.
+
+## Solymosi–Stojaković lower bound (existence statement)
+
+For every $C > 0$ there exists $N$ such that for every $n \geq N$
+there is a planar point set $P$ with $|P| = n$, no five collinear, and
+fourPointLineCount(P) ≥ n^{2 - C / √(log n)}.
+
+In particular, the maximum four-point line count is **not**
+$O(n^{3/2})$ — Erdős's original $\Theta(n^{3/2})$ conjecture is
+disproved. Any future formalisation of the construction would record
+this as a counterexample to the Grünbaum bound. We do not formalise
+the explicit construction here; the Lean statement of the lower bound
+would be a `theorem` axiomatised against the Solymosi–Stojaković
+paper, and we defer it to a follow-up iteration.
+
+## Proof obstructions
+
+* The Szemerédi–Trotter incidence theorem
+  $I(P, L) = O(|P|^{2/3} |L|^{2/3} + |P| + |L|)$
+  is the sharpest known incidence bound for lines, but applied to
+  four-point lines it gives only the $O(n^2)$ regime; the $o(n^2)$
+  refinement would require either an incidence improvement specific
+  to lines of a fixed multiplicity or a non-incidence argument.
+* The trivial double-counting argument (via `improved_upper_bound`)
+  is tight at $n(n-1)/12$ — it cannot be improved by pure
+  combinatorial counting without using a geometric input.
+* Closing the gap is one of the central open problems in
+  combinatorial geometry; this scaffold records the formal statement
+  and the easy cases that the conjecture subsumes.
+
+## Next iterations
+
+* **S2**: formalise the Solymosi–Stojaković lower-bound *statement*
+  (without the construction) as a recorded fact, witnessing
+  $\Omega(n^{2 - O(1/\sqrt{\log n})})$ existential lower bound; this
+  refutes Erdős's $\Theta(n^{3/2})$ original conjecture.
+* **S3**: connect `fourPointLineCount_le_quadratic` to a
+  `Asymptotics.IsBigO` style statement using `Mathlib.Analysis.
+  Asymptotics`; investigate whether the existing `improved_upper_bound`
+  can yield a $1 - o(1)$ leading constant via per-point Cauchy–Schwarz
+  beyond `fourCollinearThrough_bound`.
+-/
+
+end Erdos101OQ01

--- a/research/problems/erdos-101-oq-01/knowledge.md
+++ b/research/problems/erdos-101-oq-01/knowledge.md
@@ -1,0 +1,106 @@
+# Knowledge — erdos-101-oq-01
+
+## S1 (researcher-3, 2026-05-11) — OBSERVE scaffold
+
+### Parent framework (Erdos101Problem.lean)
+
+The parent file (757 lines, 23 thms, 0 sorries, 0 axioms) provides:
+
+- `PlanarPointSet`: a finite set of points in $\mathbb{R}^2$ with
+  `size_pos > 0`.
+- `collinear p q r := (q.1 - p.1) * (r.2 - p.2) = (r.1 - p.1) * (q.2 - p.2)`
+  (signed-area determinant).
+- `NoFiveCollinear (P : PlanarPointSet)`: no 5 distinct points of
+  `P` are collinear.
+- `fourPointLineCount (P : PlanarPointSet) : ℕ`: count of 4-element
+  collinear subsets of `P.points`.
+- `improved_upper_bound`: `fourPointLineCount P ≤ n(n-1)/12`.
+- `fourCollinearThrough_bound`: at most $(n-1)/3$ four-point lines
+  through any fixed point.
+- Auxiliary collinearity structure (`collinear_swap*`, `collinear_trans`,
+  `collinear_four`, `four_collinear_unique`, `four_collinear_overlap_small`).
+
+### S1 deliverable (this iteration)
+
+New file `proofs/Proofs/Erdos101OQ01.lean` (253 lines, 6 thms, 4 defs,
+0 axioms, 1 sorry):
+
+| Definition / Theorem | Status |
+|---|---|
+| `IsLittleOh_n_squared (f : ℕ → ℕ) : Prop` | def, ε–N form |
+| `BoundsAtRate (g : ℕ → ℝ) : Prop` | def, rate abstraction |
+| `erdos_101_oq_01_conjecture : Prop` | def, Σ₂ form |
+| `erdos_101_oq_01_rate_form : Prop` | def, witness form |
+| `erdos_101_oq_01` | **theorem, 1 sorry** (the OPEN conjecture) |
+| `fourPointLineCount_zero_of_small` | proved (parent restatement) |
+| `fourPointLineCount_o_n_squared_holds_below_four` | proved (vacuous case) |
+| `fourPointLineCount_le_quadratic` | proved (real-valued $\leq n^2$) |
+| `bounds_at_rate_quadratic_unconditional` | proved (rate $n^2$) |
+| `bounds_at_rate_quadratic_over_twelve` | proved (rate $n^2/12$) |
+
+### Asymptotic-vocabulary choice
+
+We use an explicit ε–N form `IsLittleOh_n_squared` rather than
+`Mathlib.Analysis.Asymptotics.IsLittleO` for first-iteration
+readability. The two forms are equivalent for `f : ℕ → ℕ` against
+$n^2$ on the filter `atTop`; the bridge is deferred to S3.
+
+### Two equivalent statements of OQ-01
+
+1. **Primary (ε–N form)**: $\forall \varepsilon > 0\ \exists N\ \forall P$
+   no-five-collinear, $|P| \geq N \Rightarrow \text{count}(P) < \varepsilon |P|^2$.
+2. **Rate form**: $\exists g : \mathbb{N} \to \mathbb{N}\ \big(\text{IsLittleOh}_{n^2}(g)
+   \land \forall P\ \text{NoFiveCollinear} \Rightarrow \text{count}(P) \leq g(|P|)\big)$.
+
+Bridge: $(2) \Rightarrow (1)$ direct from definitions; $(1) \Rightarrow (2)$
+via the witness function $g(n) := \max\{\text{count}(P) : |P| = n, \text{NoFiveCollinear}\ P\}$
+(finite by `improved_upper_bound`). Both forms are recorded; the
+primary form is the OPEN theorem.
+
+### Why the scaffold is meaningful
+
+* The OQ-01 question is precisely the quantitative refinement of an
+  already-known $O(n^2)$ bound. The trivial $O(n^2)$ regime is
+  established here in real form, so the open content cannot be hidden
+  in cast-juggling.
+* Future Iter $\geq 2$ steps can target *weaker but provable* rates
+  (e.g., $n^2 / \log\log\log n$) as `BoundsAtRate` instances, each
+  shrinking the "obvious gap" between the known and the open.
+
+### Known constructions (lower-bound side)
+
+* **Grünbaum (1972)**: $\Omega(n^{3/2})$ — grid-based, balances
+  collinear-quadruple count against the 5-collinear restriction.
+* **Solymosi–Stojaković (2013)**: $\Omega(n^{2 - O(1/\sqrt{\log n})})$
+  — uses sum–product estimates; refutes Erdős's $\Theta(n^{3/2})$
+  conjecture.
+
+### Mathlib API used
+
+* `Nat.cast_div_le` (`(a / b : ℕ) : ℝ ≤ (a : ℝ) / b`)
+* `Nat.div_le_div_right` (monotonicity in numerator)
+* `Nat.div_le_self`
+* `Nat.mul_le_mul_left`, `Nat.sub_le`
+* `pow_pos`, `positivity`
+* `push_cast`, `exact_mod_cast`, `linarith`
+
+No new imports beyond the parent's `Mathlib.Data.Finset.Card`,
+`Mathlib.Data.Nat.Basic`, `Mathlib.Tactic` (transitive via
+`Proofs.Erdos101Problem`).
+
+### Build status
+
+**[BUILD UNVERIFIED]** Worktree's `proofs/.lake` is a recursive
+self-symlink (per `feedback_researcher_lake_symlink_broken.md`); a
+local Docker build would re-fresh-clone Mathlib (~30–45 min cold).
+CI is the ground truth. All Mathlib API used is standard and
+exercised in existing gallery files.
+
+### Confidence
+
+High that the scaffold compiles: all five non-sorry theorems use
+only well-established Mathlib API. The one risky step is the
+`Nat.cast_div_le` followed by `push_cast` in
+`bounds_at_rate_quadratic_over_twelve`; this is a standard ℕ→ℝ
+manipulation. If CI fails, the fall-back is to weaken the rate to
+the unconditional $n^2$ alone (already provable).

--- a/research/problems/erdos-101-oq-01/problem.md
+++ b/research/problems/erdos-101-oq-01/problem.md
@@ -1,0 +1,84 @@
+# Problem: Erdős #101 OQ-01 — Four-point line count is $o(n^2)$
+
+## Statement
+
+### Plain Language
+
+Given $n$ points in $\mathbb{R}^2$ with no five collinear, prove
+that the number of lines containing exactly four of the points is
+$o(n^2)$.
+
+This is Erdős's $\$100$ open question of Problem #101. Best known:
+
+* **Upper bound** (elementary, Szemerédi–Trotter, or pair-packing
+  double-counting): $O(n^2)$. Tight at $n(n-1)/12$ from pure
+  combinatorial counting.
+* **Lower bound** (Solymosi–Stojaković 2013): $\Omega(n^{2 - O(1/\sqrt{\log n})})$,
+  refuting Erdős's earlier $\Theta(n^{3/2})$ conjecture.
+
+The gap is the *polylog correction*; closing it is OQ-01.
+
+### Formal Statement
+
+In `proofs/Proofs/Erdos101OQ01.lean`:
+
+```lean
+/-- **OQ-01, primary form**: the maximum four-point line count over
+all no-five-collinear planar point sets of size at most `n` is $o(n^2)$. -/
+def erdos_101_oq_01_conjecture : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ N : ℕ, ∀ (P : PlanarPointSet),
+    NoFiveCollinear P → N ≤ P.points.card →
+    (fourPointLineCount P : ℝ) < ε * (P.points.card : ℝ)^2
+
+theorem erdos_101_oq_01 : erdos_101_oq_01_conjecture := by sorry
+```
+
+The single open `sorry` is the main conjecture. All supporting
+lemmas (small-case bound, real-valued $O(n^2)$, $n^2/12$ rate) are
+unconditional.
+
+## Status — Open
+
+| What | Status |
+|------|--------|
+| Trivial $O(n^2)$ upper bound | ✓ proved (`fourPointLineCount_le_quadratic`) |
+| $n^2/12$ improved bound | ✓ proved (`bounds_at_rate_quadratic_over_twelve`) |
+| $o(n^2)$ refinement | OPEN ($\$100$ Erdős prize) |
+| Solymosi–Stojaković $\Omega(n^{2-O(1/\sqrt{\log n})})$ lower bound | not yet formalised — deferred to S2 |
+
+## Theoretical Obstacles
+
+1. **Szemerédi–Trotter is too coarse for fixed-multiplicity lines.**
+   Applied to lines of multiplicity 4, the incidence bound
+   $I(P, L) = O(|P|^{2/3} |L|^{2/3} + |P| + |L|)$ yields only the
+   $O(n^2)$ regime. A multiplicity-aware refinement is needed.
+
+2. **Pure double-counting is tight.** The improved upper bound
+   $n(n-1)/12$ comes from packing 6 disjoint pairs per 4-collinear
+   subset; this is exhausted by the elementary argument and cannot
+   be improved without geometric input.
+
+3. **The Solymosi–Stojaković lower bound is nearly quadratic.** The
+   open content is the precise polylog correction, not the leading
+   $n^2$ behavior.
+
+## References
+
+* Erdős, P. (1984–1997). Problem 101.
+  https://erdosproblems.com/101
+* Grünbaum, B. (1972). *Arrangements and Spreads*. American Math.
+  Soc. — original $\Omega(n^{3/2})$ four-point line construction.
+* Solymosi, J., Stojaković, M. (2013). *Many collinear k-tuples with
+  no $k+1$ collinear points.* Discrete & Computational Geometry **50**,
+  811–820 — disproves $\Theta(n^{3/2})$ with $\Omega(n^{2-O(1/\sqrt{\log n})})$.
+* Szemerédi, E., Trotter, W.T. (1983). *Extremal problems in discrete
+  geometry.* Combinatorica **3**, 381–392 — incidence bound.
+
+## File Layout
+
+| File | Purpose |
+|------|---------|
+| `proofs/Proofs/Erdos101OQ01.lean` | S1 scaffold; formal statement, 6 thms, 4 defs, 1 sorry |
+| `proofs/Proofs/Erdos101Problem.lean` | parent — 23 thms, 1 def, 0 sorries, 0 axioms |
+| `src/data/proofs/erdos-101-oq-01/` | gallery entry (meta, annotations, index.ts) |
+| `src/data/research/problems/erdos-101-oq-01.json` | research metadata (knowledge, state) |

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,0 +1,75 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11 (S1)
+**Iteration**: 1
+**Last Updated**: 2026-05-11 (researcher-3)
+
+## Current Focus
+
+S1 (researcher-3): Initial scaffold for OQ-01 of Erdős Problem #101.
+Records the formal $\Sigma_2$-style statement of the $\$100$ open
+conjecture, the asymptotic vocabulary (`IsLittleOh_n_squared`,
+`BoundsAtRate`), and the small-case lemmas the conjecture subsumes
+— all unconditional except the main theorem.
+
+## Active Approach
+
+**Statement-first scaffold; small cases first.**
+
+The conjecture is OPEN; this iteration does NOT attempt a proof.
+Instead it:
+
+1. Pins the formal Σ₂ statement in Lean syntax.
+2. Records the equivalent rate-form via `BoundsAtRate`.
+3. Proves the small-case (`|P| ≤ 3`) lemma unconditionally so the
+   ε–N form is meaningful only in the regime $|P| \to \infty$.
+4. Connects to the parent file's `improved_upper_bound` via a
+   real-valued $n^2/12$ bound — exhibiting the elementary bound
+   that is *not* $o(n^2)$.
+
+## Next Action
+
+S2 candidates (in order of expected value):
+
+1. **Formalise the Solymosi–Stojaković existence statement** as a
+   recorded *axiom-free `theorem ... := by sorry`* (since the
+   construction is beyond elementary Lean). Refutes Erdős's
+   $\Theta(n^{3/2})$ conjecture in the gallery.
+
+2. **`Asymptotics.IsBigO` / `IsLittleO` bridge**. Show
+   `(fun n => maxFourPointLines n) =O[atTop] (· ^ 2)` from the
+   real-valued $n^2/12$ bound; record the conjecture as a
+   `=o[atTop] (· ^ 2)` `sorry`. Lets future progress slot into
+   Mathlib's asymptotic-comparison framework.
+
+3. **Investigate per-point Cauchy–Schwarz refinements.** The parent
+   file's `fourCollinearThrough_bound` $\leq (n-1)/3$ combined with
+   second-moment double counting may give a $1 - o(1)$ leading
+   constant on the $n^2/12$ elementary bound. Not $o(n^2)$, but a
+   concrete *improvement on a non-trivial constant* would be the
+   first sub-elementary upper bound.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1 (S1 scaffold)
+- Approaches tried: 0 (no proof attempts yet)
+
+## Build Status
+
+S1 build: PENDING. Worktree's `proofs/.lake` is a recursive
+self-symlink; local Docker builds re-fresh-clone Mathlib. CI is
+ground truth.
+
+S1 risk profile:
+* 5 of 6 theorems are trivial or restate parent lemmas — low risk.
+* 1 theorem (`bounds_at_rate_quadratic_over_twelve`) uses
+  `Nat.cast_div_le` + `push_cast` for a ℕ→ℝ rate cast — standard
+  Mathlib pattern.
+* No new imports; everything transitive via `Proofs.Erdos101Problem`.
+
+## Blockers
+
+None for S1 (statement-only). Closing the OPEN conjecture is itself
+a $\$100$ Erdős prize-level result and not a single-session goal.

--- a/src/data/proofs/erdos-101-oq-01/annotations.json
+++ b/src/data/proofs/erdos-101-oq-01/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "ann-header-conjecture",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "OQ-01: the $o(n^2)$ open question",
+    "content": "Erdős's $\\$100$ open question of Problem #101: given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the maximum number of lines containing exactly four of the points $o(n^2)$? The trivial $O(n^2)$ upper bound holds by elementary double-counting; the Solymosi–Stojaković (2013) construction gives a lower bound $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$, just shy of quadratic. The gap is the substantive content. This file records the formal Σ₂ statement (`∀ ε > 0, ∃ N, ∀ P : NoFiveCollinear ∧ |P| ≥ N → count(P) < ε|P|^2`) as a `sorry`-bearing theorem, plus the supporting unconditional lemmas.",
+    "mathContext": "$\\forall \\varepsilon > 0, \\exists N, \\forall P\\, (\\text{NoFiveCollinear}\\ P \\land |P| \\geq N) \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős combinatorial geometry",
+      "Solymosi–Stojaković construction",
+      "Szemerédi–Trotter incidence bound",
+      "asymptotic $o(n^2)$ vocabulary"
+    ],
+    "prerequisites": [
+      "Parent Erdős #101 framework (PlanarPointSet, NoFiveCollinear, fourPointLineCount)",
+      "Real-analysis ε–N asymptotics"
+    ]
+  },
+  {
+    "id": "ann-asymptotic-vocab",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 80
+    },
+    "type": "concept",
+    "title": "Asymptotic vocabulary: `IsLittleOh_n_squared` and `BoundsAtRate`",
+    "content": "`IsLittleOh_n_squared (f : ℕ → ℕ)` is the standard ε–N formulation of $f(n) = o(n^2)$, with $f(n)$ cast to ℝ and compared against $\\varepsilon \\cdot n^2$. The explicit ε–N form is preferred over `Mathlib.Analysis.Asymptotics.IsLittleO` for first-iteration readability; the equivalence is left to S3.\n\n`BoundsAtRate (g : ℕ → ℝ)` packages the predicate \"`fourPointLineCount P ≤ g |P|` for every no-five-collinear `P`.\" It abstracts away the quantification over planar point sets so that known elementary rates (e.g., $n^2$, $n^2/12$) and the conjectured $o(n^2)$ rate can be stated uniformly.",
+    "mathContext": "$\\text{IsLittleOh}_{n^2}(f) \\iff \\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall n \\geq N,\\ f(n) < \\varepsilon n^2$. The choice to use ℕ rather than ℝ for the count `f` reflects that `fourPointLineCount` is integer-valued, while the bound itself is taken in ℝ to allow non-integer rates.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ε–N asymptotic limits",
+      "predicate abstraction over rate functions"
+    ],
+    "prerequisites": [
+      "Nat to Real coercion"
+    ]
+  },
+  {
+    "id": "ann-open-statement",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 119
+    },
+    "type": "concept",
+    "title": "Two equivalent formal forms of OQ-01",
+    "content": "`erdos_101_oq_01_conjecture` is the primary ε–N form. `erdos_101_oq_01_rate_form` is the witness-function form: there exists a function $g : \\mathbb{N} \\to \\mathbb{N}$ which is $o(n^2)$ and bounds the four-point line count for every no-five-collinear `P`. The two forms are mutually convertible by the standard Cauchy-criterion bridge; we record the primary form as the OPEN theorem `erdos_101_oq_01` and use the rate form to express equivalent statements about specific witness rates.",
+    "mathContext": "**Primary form (Σ₂)**: $\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P,\\ (\\text{NoFiveCollinear}\\ P \\land N \\leq |P|) \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon |P|^2$. **Rate form**: $\\exists g : \\mathbb{N} \\to \\mathbb{N},\\ \\text{IsLittleOh}_{n^2}(g) \\land \\forall P, \\text{NoFiveCollinear}\\ P \\Rightarrow \\text{fourPointLineCount}(P) \\leq g(|P|)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Σ₂ quantifier complexity",
+      "Cauchy criterion",
+      "witness-function representation"
+    ],
+    "prerequisites": [
+      "Classical logic for ε–N $\\leftrightarrow$ witness equivalence"
+    ]
+  },
+  {
+    "id": "ann-small-cases",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 175
+    },
+    "type": "proof-step",
+    "title": "Small-case lemmas the conjecture subsumes",
+    "content": "Three unconditional lemmas witness the regime in which OQ-01 is meaningful:\n\n1. `fourPointLineCount_zero_of_small`: for every `P` with $|P| < 4$, `fourPointLineCount P = 0`. Restatement of `fourPointLineCount_lt_four` from the parent file (no 4-element subset exists).\n2. `fourPointLineCount_o_n_squared_holds_below_four`: the OQ-01 ε–N statement holds vacuously for every $|P| \\leq 3$. Pure positivity (`0 < ε \\cdot n^2` whenever $n \\geq 1$).\n3. `fourPointLineCount_le_quadratic`: the real-valued $\\text{fourPointLineCount}(P) \\leq |P|^2$ trivial upper bound. Lifted from `improved_upper_bound`'s ℕ statement via `Nat.div_le_self` and `n(n-1) \\leq n^2$.\n\nTogether, these show that OQ-01's content is genuinely in the regime $|P| \\to \\infty$ with a sub-quadratic refinement of an already-known $O(n^2)$ bound.",
+    "mathContext": "Trivially $|P| < 4 \\Rightarrow \\text{count} = 0$, and the elementary bound $\\text{count} \\leq |P|(|P|-1)/12 \\leq |P|^2/12 \\leq |P|^2$ holds. The gap between $|P|^2$ and $\\varepsilon |P|^2$ for *every* $\\varepsilon > 0$ is the open content.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "elementary upper bound",
+      "trivial cases",
+      "vacuous conjecture"
+    ],
+    "prerequisites": [
+      "fourPointLineCount_lt_four (parent)",
+      "improved_upper_bound (parent)",
+      "Nat to Real cast monotonicity"
+    ]
+  },
+  {
+    "id": "ann-rate-bounds",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 176,
+      "endLine": 217
+    },
+    "type": "proof-step",
+    "title": "Known rates as `BoundsAtRate` instances",
+    "content": "Two unconditional rate witnesses:\n\n- `bounds_at_rate_quadratic_unconditional`: rate $n^2$. Immediate from `fourPointLineCount_le_quadratic`.\n- `bounds_at_rate_quadratic_over_twelve`: rate $n^2/12$. The ℕ-valued `improved_upper_bound` gives $\\lfloor n(n-1)/12 \\rfloor$, which is bounded by $\\lfloor n \\cdot n / 12 \\rfloor \\leq n^2/12$ after the cast. The intermediate step weakens $n(n-1)$ to $n \\cdot n$ to avoid the ℕ subtraction-cast subtlety (Nat.sub truncates at 0, while ℝ does not); for $|P| \\geq 1$ the two are equivalent, but the weakened form is unconditional.\n\nNeither rate is $o(n^2)$ — both are $\\Theta(n^2)$. The OPEN content is precisely a sub-quadratic refinement. Future iterations may add weaker but provable rates such as $n^2 / \\log\\log n$.",
+    "mathContext": "$\\text{fourPointLineCount}(P) \\leq \\lfloor |P|(|P|-1)/12 \\rfloor \\leq |P|^2/12$ as a real-valued statement, for any `NoFiveCollinear P`. The factor $1/12$ comes from each 4-collinear subset using 6 of the $|P|(|P|-1)/2$ unordered pairs with overlap $\\leq 1$ between distinct subsets.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rate functions",
+      "elementary double-counting",
+      "ℕ–ℝ cast subtleties"
+    ],
+    "prerequisites": [
+      "improved_upper_bound (parent)",
+      "Nat.cast_div_le",
+      "Nat.div_le_div_right"
+    ]
+  },
+  {
+    "id": "ann-obstructions",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 218,
+      "endLine": 253
+    },
+    "type": "concept",
+    "title": "Obstructions and Solymosi–Stojaković lower bound",
+    "content": "The OPEN content arises from two obstructions:\n\n1. **Szemerédi–Trotter is too coarse**. The incidence bound $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$, applied to lines of multiplicity-4, gives at most $O(|P|^2)$ four-point lines — same regime as the elementary $n(n-1)/12$ bound. A multiplicity-aware refinement would be needed.\n2. **Pure double counting is tight**. The improved upper bound $n(n-1)/12$ is the best one can extract from packing 6 disjoint pairs per 4-collinear subset; no further elementary counting reduces it.\n\nOn the lower-bound side, **Solymosi–Stojaković (2013)** constructed $n$-point sets with no five collinear and $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ four-point lines — disproving Erdős's earlier $\\Theta(n^{3/2})$ conjecture. The construction uses number-theoretic sum–product ideas. This file does not formalise the construction; S2 will record the existence statement.",
+    "mathContext": "Upper bound: $O(n^2)$ (elementary). Lower bound: $\\Omega(n^{2 - O(1/\\sqrt{\\log n})}) = n^{2 - o(1)}$ (Solymosi–Stojaković). Gap: the entire polylog correction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Szemerédi–Trotter theorem",
+      "sum–product phenomenology",
+      "Solymosi–Stojaković construction",
+      "polylog refinements"
+    ],
+    "prerequisites": [
+      "Szemerédi–Trotter incidence theorem (statement)",
+      "Solymosi–Stojaković (2013) paper"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-101-oq-01/index.ts
+++ b/src/data/proofs/erdos-101-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos101OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "erdos-101-oq-01",
+  "title": "Erdős #101 OQ-01: Four-Point Lines are $o(n^2)$",
+  "slug": "erdos-101-oq-01",
+  "description": "Formal statement of Erdős's $100 open question OQ-01 of Problem #101: under no-five-collinear, is the four-point line count $o(n^2)$? Scaffold file with the asymptotic vocabulary, the formal conjecture (1 sorry), and small-case lemmas the conjecture subsumes — proved unconditionally.",
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 101,
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos101OQ01.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "incidence-geometry",
+      "collinearity",
+      "asymptotics",
+      "open",
+      "research"
+    ],
+    "badge": "wip",
+    "sorries": 1,
+    "sourceUrl": "https://erdosproblems.com/101",
+    "erdosUrl": "https://erdosproblems.com/101",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-05-11",
+    "axiomCount": 0,
+    "lineCount": 253,
+    "assumptions": "1 sorry: erdos_101_oq_01 (the main open conjecture, $100 Erdős prize). All supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free; they witness the regime in which the conjecture would tighten existing bounds.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "substantiveTheoremCount": 5
+  },
+  "sections": [
+    {
+      "id": "header-setup",
+      "title": "File Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Documentation header outlining the OQ-01 conjecture, status (open, $100 prize), the Solymosi–Stojaković lower bound, and the file's deliverables. Imports the parent `Erdos101Problem`.",
+      "mathContext": "OQ-01 is the o(n²) refinement question: every elementary upper bound is currently $\\Theta(n^2)$ (the trivial $n^2$, the $n(n-1)/12$ improved bound, the per-point $(n-1)/3$ bound)."
+    },
+    {
+      "id": "asymptotic-vocabulary",
+      "title": "Asymptotic vocabulary",
+      "startLine": 57,
+      "endLine": 80,
+      "summary": "Defines `IsLittleOh_n_squared` (an `ε–N` formulation for `ℕ → ℕ`) and `BoundsAtRate` (a predicate parameterising rate bounds on `fourPointLineCount` over no-five-collinear sets).",
+      "mathContext": "The `ε–N` form is chosen for direct readability; equivalence with `Asymptotics.IsLittleO` is deferred to S3."
+    },
+    {
+      "id": "open-conjecture",
+      "title": "The OPEN question, in two equivalent forms",
+      "startLine": 81,
+      "endLine": 119,
+      "summary": "States `erdos_101_oq_01_conjecture` (primary ε–N form) and `erdos_101_oq_01_rate_form` (witness-function form). The theorem `erdos_101_oq_01` records the primary form as a `sorry` — this is the OPEN question.",
+      "mathContext": "Each form is the standard expression of the question in combinatorial geometry; both unfold to the assertion that the maximum four-point line count grows strictly slower than $n^2$."
+    },
+    {
+      "id": "easy-cases",
+      "title": "Easy cases the conjecture subsumes",
+      "startLine": 120,
+      "endLine": 175,
+      "summary": "Proves unconditionally: (1) `fourPointLineCount_zero_of_small` (n < 4 ⇒ count is 0); (2) `fourPointLineCount_o_n_squared_holds_below_four` (the OQ-01 ε–N bound holds vacuously for every $|P| \\leq 3$); (3) `fourPointLineCount_le_quadratic` (the real-valued $\\leq n^2$ trivial upper bound).",
+      "mathContext": "These witness that the OPEN content is genuinely the $o(n^2)$ refinement: the trivial $O(n^2)$ regime is already known."
+    },
+    {
+      "id": "rate-bounds",
+      "title": "Known bounds via `BoundsAtRate`",
+      "startLine": 176,
+      "endLine": 217,
+      "summary": "Records the elementary rates: `bounds_at_rate_quadratic_unconditional` (rate $n^2$) and `bounds_at_rate_quadratic_over_twelve` (rate $n^2/12$, weakening of `improved_upper_bound`'s $n(n-1)/12$ to avoid the ℕ subtraction cast subtlety; asymptotically equivalent).",
+      "mathContext": "These are the strongest *elementary* rate bounds. None is $o(n^2)$ — closing the gap is the open content."
+    },
+    {
+      "id": "obstructions",
+      "title": "Proof obstructions and next iterations",
+      "startLine": 218,
+      "endLine": 253,
+      "summary": "Documents the Solymosi–Stojaković lower bound $n^{2-O(1/\\sqrt{\\log n})}$ refuting Erdős's $\\Theta(n^{3/2})$ conjecture; the obstructions from Szemerédi–Trotter and trivial double counting; and the S2/S3 next-iteration plan (lower-bound formalisation, `Asymptotics.IsBigO` connection).",
+      "mathContext": "The gap between known lower $n^{2-O(1/\\sqrt{\\log n})}$ and known upper $O(n^2)$ is the substantive content of OQ-01."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős posed Problem #101 across multiple papers from 1984 to 1997, asking whether the maximum number of lines through exactly four points of an $n$-point planar set (with no five collinear) is $o(n^2)$. He initially conjectured $\\Theta(n^{3/2})$, based on Grünbaum's $\\Omega(n^{3/2})$ construction. This conjecture stood for decades until Solymosi and Stojaković (2013) disproved it with a stunning $n^{2-O(1/\\sqrt{\\log n})}$ construction—nearly quadratic growth, using number-theoretic ideas related to sum-product estimates. The gap between this lower bound and the conjectured $o(n^2)$ upper bound remains one of the central open problems in combinatorial geometry. The problem carries a $\\$100$ Erdős prize and connects deeply to the Szemerédi–Trotter incidence theorem and the broader program of understanding collinearity patterns in finite point sets.",
+    "problemStatement": "**OQ-01**: For every $\\varepsilon > 0$, does there exist $N$ such that every no-five-collinear planar point set $P$ with $|P| \\geq N$ satisfies $\\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2$? Equivalently, is the maximum four-point line count $o(n^2)$?",
+    "text": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the number of lines containing exactly four points $o(n^2)$? Best known: trivial $O(n^2)$ upper bound (Szemerédi–Trotter or elementary double-counting), Solymosi–Stojaković $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower bound.",
+    "proofStrategy": "S1 (this scaffold) records the formal Σ₂-style statement of the conjecture, the asymptotic vocabulary, and the small-case lemmas the conjecture trivially subsumes. The single open `sorry` is the main theorem; everything else is unconditional. Subsequent iterations will (S2) formalise the Solymosi–Stojaković lower bound as a recorded existence statement, (S3) connect to `Asymptotics.IsBigO`/`IsLittleO` infrastructure, and explore whether per-point Cauchy–Schwarz refinements beyond `fourCollinearThrough_bound` yield a $1 - o(1)$ leading constant.",
+    "keyInsights": [
+      "OQ-01 is the precise quantitative refinement of the trivial $O(n^2)$ upper bound; the $\\Theta(n^2)$ regime is already established elementarily.",
+      "The Solymosi–Stojaković construction (2013) gives $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ four-point lines, refuting Erdős's earlier $\\Theta(n^{3/2})$ conjecture.",
+      "All known elementary upper bounds are $\\Theta(n^2)$: trivial $n^2$, improved $n(n-1)/12$ (pair-packing), per-point $n(n-1)/12$ via $(n-1)/3 \\cdot n / 4$ double-counting.",
+      "Szemerédi–Trotter applied to lines of multiplicity-4 gives $O(n^2)$ but no $o(n^2)$ refinement; the open content requires either a multiplicity-aware incidence improvement or a non-incidence argument.",
+      "The conjecture's quantification is genuinely Σ₂ — `∀ε∃N∀P`—the witness `N(ε)` is the unknown content.",
+      "Connections to Erdős Problems #102, #588, #669 (related collinearity extremal questions in different settings)."
+    ],
+    "prerequisites": [
+      "Combinatorial geometry (incidence theorems, configurations)",
+      "Real analysis (ε–N asymptotics, $o(n^2)$ vocabulary)",
+      "Discrete geometry (point-line incidences, arrangements)",
+      "Background from Erdos101Problem.lean (PlanarPointSet, NoFiveCollinear, fourPointLineCount, improved_upper_bound)"
+    ]
+  },
+  "conclusion": {
+    "summary": "S1 scaffold: the formal OQ-01 statement is recorded as `erdos_101_oq_01` (1 sorry), and three unconditional supporting theorems witness the regime — small-case lemmas, the real-valued trivial $O(n^2)$ bound, and the elementary $n^2/12$ rate. No new axioms. The open content is precisely the sub-quadratic quantitative refinement.",
+    "implications": "Provides a Lean-checkable home for future OQ-01 progress: the Σ₂ statement is now in canonical form; future iterations can substitute weaker but constructive rates (e.g., $n^2 / \\log\\log n$, $n^2 / (\\log n)^{1/2}$) as `BoundsAtRate` instances once proved.",
+    "openQuestions": [
+      "Can the Szemerédi–Trotter incidence theorem be combined with a multiplicity-aware filter to yield a $1 - o(1)$ leading constant on $n^2 / 12$?",
+      "Does the per-point bound `fourCollinearThrough_bound` $\\leq (n-1)/3$ admit a Cauchy–Schwarz second-moment improvement that propagates to the global count?",
+      "What is the exact growth rate of the maximum four-point line count? Both the constant and the polylog correction in the Solymosi–Stojaković construction are sharp candidates."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos101Problem"
+    ],
+    "opens": [
+      "Classical"
+    ],
+    "namespace": "Erdos101OQ01",
+    "lineCount": 253,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos101OQ01.lean",
+    "sorries": 1
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "description": "OQ-01 is the central open question of the parent Erdős #101 formalisation; this file records the formal Σ₂ statement and the small-case lemmas it subsumes.",
+      "targetId": "erdos-101"
+    },
+    {
+      "relationship": "uses",
+      "description": "Reuses `PlanarPointSet`, `collinear`, `NoFiveCollinear`, `fourPointLineCount`, `improved_upper_bound`, `fourPointLineCount_lt_four` from the parent file.",
+      "targetId": "erdos-101"
+    }
+  ],
+  "references": [
+    "Erdős, P. (1984–1997). Problem 101, https://erdosproblems.com/101",
+    "Grünbaum, B. (1972). Arrangements and Spreads — $\\Omega(n^{3/2})$ four-point line construction.",
+    "Solymosi, J., Stojaković, M. (2013). Many collinear k-tuples with no $k+1$ collinear points. Discrete & Computational Geometry 50: 811–820 — $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower bound disproving Erdős's $\\Theta(n^{3/2})$ conjecture.",
+    "Szemerédi, E., Trotter, W.T. (1983). Extremal problems in discrete geometry. Combinatorica 3: 381–392 — $I(P,L) = O(n^{2/3} m^{2/3} + n + m)$ incidence bound."
+  ]
+}

--- a/src/data/research/problems/erdos-101-oq-01.json
+++ b/src/data/research/problems/erdos-101-oq-01.json
@@ -1,0 +1,105 @@
+{
+  "slug": "erdos-101-oq-01",
+  "title": "Erdős #101 OQ-01: Four-Point Lines are $o(n^2)$",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "significance": 7,
+  "tractability": 5,
+  "started": "2026-05-11T19:00:00Z",
+  "lastUpdate": "2026-05-11T19:00:00Z",
+  "problemStatement": {
+    "formal": "\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P : \\text{PlanarPointSet},\\ \\text{NoFiveCollinear}\\ P \\land N \\leq |P| \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2",
+    "plain": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the number of lines containing exactly four points $o(n^2)$? Best known: $O(n^2)$ upper (trivial), $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower (Solymosi–Stojaković).",
+    "whyMatters": [
+      "$\\$100$ Erdős prize problem.",
+      "Central open problem in combinatorial geometry.",
+      "Connects to Szemerédi–Trotter incidence theorem and sum–product phenomenology.",
+      "Disproof of Erdős's conjectured $\\Theta(n^{3/2})$ behaviour is itself one of the major surprises of the last 20 years in extremal combinatorics."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "$\\text{fourPointLineCount}(P) \\leq |P|(|P|-1)/12$ (improved_upper_bound, parent file)",
+      "At most $(|P|-1)/3$ four-point lines through any single point (fourCollinearThrough_bound, parent file)",
+      "$\\text{fourPointLineCount}(P) \\leq |P|^2$ (this file, real-valued cast)",
+      "$\\text{fourPointLineCount}(P) \\leq |P|^2/12$ (this file, BoundsAtRate instance)"
+    ],
+    "open": [
+      "$o(n^2)$ upper bound — this is the OQ-01 conjecture (1 sorry in Erdos101OQ01.lean).",
+      "Solymosi–Stojaković lower-bound formalisation — deferred to S2."
+    ],
+    "goal": "Prove $\\text{fourPointLineCount}(P) = o(|P|^2)$ for all `NoFiveCollinear P`, or sharpen the bound to an explicit subquadratic rate."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T19:00:00Z",
+    "iteration": 1,
+    "focus": "S1 scaffold: Σ₂ statement of OQ-01, asymptotic vocabulary, small-case lemmas the conjecture subsumes.",
+    "blockers": [],
+    "nextAction": "S2: formalise Solymosi–Stojaković existence statement (refuting Erdős's $\\Theta(n^{3/2})$) and Asymptotics.IsBigO bridge.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. New file Erdos101OQ01.lean (253 lines, 6 thms, 4 defs, 0 axioms, 1 sorry).",
+    "builtItems": [
+      "proofs/Proofs/Erdos101OQ01.lean: IsLittleOh_n_squared (def)",
+      "proofs/Proofs/Erdos101OQ01.lean: BoundsAtRate (def)",
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_101_oq_01_conjecture (def, OPEN)",
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_101_oq_01_rate_form (def, OPEN, equivalent)",
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_101_oq_01 (theorem, 1 sorry)",
+      "proofs/Proofs/Erdos101OQ01.lean: fourPointLineCount_zero_of_small (parent restatement)",
+      "proofs/Proofs/Erdos101OQ01.lean: fourPointLineCount_o_n_squared_holds_below_four (vacuous case)",
+      "proofs/Proofs/Erdos101OQ01.lean: fourPointLineCount_le_quadratic (real-valued $\\leq n^2$)",
+      "proofs/Proofs/Erdos101OQ01.lean: bounds_at_rate_quadratic_unconditional (rate $n^2$)",
+      "proofs/Proofs/Erdos101OQ01.lean: bounds_at_rate_quadratic_over_twelve (rate $n^2/12$)",
+      "src/data/proofs/erdos-101-oq-01/: gallery entry (meta + 6 annotations + index.ts)",
+      "research/problems/erdos-101-oq-01/: problem.md + knowledge.md + state.md"
+    ],
+    "insights": [
+      "The OQ-01 question is the precise quantitative refinement of the trivial $O(n^2)$ upper bound; the $\\Theta(n^2)$ regime is already established elementarily.",
+      "Two equivalent formal forms (ε–N primary; rate-witness via $\\exists g$) are mutually convertible by the standard Cauchy criterion; we record both.",
+      "Solymosi–Stojaković (2013) refuted Erdős's $\\Theta(n^{3/2})$ conjecture with $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ — the open content is the polylog correction, not the leading order.",
+      "All known elementary upper bounds are $\\Theta(n^2)$; closing the gap to $o(n^2)$ requires either a multiplicity-aware Szemerédi–Trotter refinement or a non-incidence argument.",
+      "The ℕ→ℝ cast in `bounds_at_rate_quadratic_over_twelve` weakens $n(n-1)/12$ to $n^2/12$ to avoid `Nat.sub` truncation; asymptotically equivalent."
+    ],
+    "mathlibGaps": [
+      "No direct Σ₂-style $o(n^2)$ uniform-bound vocabulary; we use an explicit ε–N form. Bridge to `Asymptotics.IsLittleO` deferred to S3.",
+      "Szemerédi–Trotter incidence bound not formalised in Mathlib; would be a useful prerequisite for the Solymosi–Stojaković construction."
+    ],
+    "nextSteps": [
+      "S2: formalise Solymosi–Stojaković existence statement ($\\Omega(n^{2-O(1/\\sqrt{\\log n})})$, as a recorded `theorem ... := by sorry` for the existential statement).",
+      "S3: connect `BoundsAtRate` instances to `Asymptotics.IsBigO`/`IsLittleO` on the filter `atTop`.",
+      "Optional: probe whether the per-point bound $(n-1)/3$ + Cauchy–Schwarz yields a $1 - o(1)$ leading constant on the global $n^2/12$ bound (would still be $\\Theta(n^2)$ but a concrete elementary improvement)."
+    ]
+  },
+  "tags": [
+    "erdos",
+    "combinatorial-geometry",
+    "incidence-geometry",
+    "collinearity",
+    "asymptotics",
+    "open",
+    "research",
+    "tier-B"
+  ],
+  "relatedProofs": [
+    "erdos-101",
+    "erdos-101-oq-04"
+  ],
+  "leanFiles": [
+    "Proofs/Erdos101OQ01.lean",
+    "Proofs/Erdos101Problem.lean"
+  ],
+  "references": [
+    "Erdős, P. (1984–1997). Problem 101. https://erdosproblems.com/101",
+    "Grünbaum, B. (1972). Arrangements and Spreads. American Math. Soc.",
+    "Solymosi, J., Stojaković, M. (2013). Many collinear k-tuples with no $k+1$ collinear points. Discrete & Computational Geometry 50, 811–820.",
+    "Szemerédi, E., Trotter, W.T. (1983). Extremal problems in discrete geometry. Combinatorica 3, 381–392."
+  ]
+}


### PR DESCRIPTION
## Summary

S1 scaffold for OQ-01 of Erdős Problem #101 — the open `$100`
question: given $n$ points in $\mathbb{R}^2$ with no five collinear,
is the four-point line count $o(n^2)$? Records the formal $\Sigma_2$
statement of the conjecture as a single `sorry`-bearing theorem,
together with five **unconditional** supporting theorems that
witness the trivial $O(n^2)$ regime in which the conjecture would
sharpen existing bounds.

Status of bounds (post-S1):

| Bound | Status | Where |
|---|---|---|
| Trivial $O(n^2)$ upper | proved (real form) | `fourPointLineCount_le_quadratic` |
| $n^2/12$ upper (elementary) | proved | `bounds_at_rate_quadratic_over_twelve` |
| $o(n^2)$ upper | **OPEN** (`$100` Erdős prize) | `erdos_101_oq_01` (1 sorry) |
| $\Omega(n^{2-O(1/\sqrt{\log n})})$ Solymosi–Stojaković lower | not formalised | deferred to S2 |

## What's New

New file: `proofs/Proofs/Erdos101OQ01.lean` (253 lines, 6 thms,
4 defs, **0 axioms, 1 sorry**).

### Definitions

- `IsLittleOh_n_squared (f : ℕ → ℕ)` — explicit ε–N form of $f(n) = o(n^2)$.
- `BoundsAtRate (g : ℕ → ℝ)` — rate-bound predicate over all
  no-five-collinear sets.
- `erdos_101_oq_01_conjecture` — the Σ₂ form of OQ-01.
- `erdos_101_oq_01_rate_form` — the equivalent witness-function form
  $\exists g : \mathbb{N} \to \mathbb{N},\ g = o(n^2) \land \forall P\ \text{count}(P) \leq g(|P|)$.

### Theorems

- `erdos_101_oq_01 : erdos_101_oq_01_conjecture` — **the OPEN conjecture, 1 sorry**.
- `fourPointLineCount_zero_of_small` — $|P| < 4 \Rightarrow \text{count} = 0$ (parent restatement).
- `fourPointLineCount_o_n_squared_holds_below_four` — vacuous bound for $|P| \leq 3$.
- `fourPointLineCount_le_quadratic` — real-valued $\text{count}(P) \leq |P|^2$ (from `improved_upper_bound`).
- `bounds_at_rate_quadratic_unconditional` — rate $n^2$ instance.
- `bounds_at_rate_quadratic_over_twelve` — rate $n^2/12$ instance,
  weakening $n(n-1)/12$ to $n^2/12$ to avoid the ℕ subtraction-cast subtlety
  (asymptotically equivalent).

## Why $\Sigma_2$, why two forms?

The ε–N primary form pins the conjecture in canonical Lean syntax and
is the direct quantifier complexity ($\forall \varepsilon\ \exists N\ \forall P$).
The rate-witness form `erdos_101_oq_01_rate_form` is equivalent (by
the standard Cauchy criterion) and lets future iterations slot
stronger rates as `BoundsAtRate` instances. Recording both makes the
substitution future iterations will use explicit.

## Mathlib API

All standard, transitive via `Proofs.Erdos101Problem`. No new
imports. Tactics: `push_cast`, `exact_mod_cast`, `linarith`,
`positivity`, `omega`. Lemmas: `Nat.cast_div_le`,
`Nat.div_le_div_right`, `Nat.div_le_self`, `Nat.mul_le_mul_left`,
`Nat.sub_le`, `pow_pos`.

## Build Status

**[BUILD PENDING]** Worktree's `proofs/.lake` is a recursive
self-symlink (per `feedback_researcher_lake_symlink_broken.md`); a
local Docker build would re-fresh-clone Mathlib (~30–45 min cold).
CI is the ground truth.

Risk profile:
- 5 of 6 theorems are trivial or restate parent lemmas — low risk.
- 1 theorem (`bounds_at_rate_quadratic_over_twelve`) uses
  `Nat.cast_div_le` + `push_cast` for a ℕ→ℝ rate cast — standard
  Mathlib pattern. Fall-back: drop to the unconditional $n^2$ rate
  alone.

## Gallery + Research Metadata

- `src/data/proofs/erdos-101-oq-01/` — `meta.json` (overview,
  6-section breakdown, conclusion, crossRefs) + 6 deep annotations +
  `index.ts`.
- `research/problems/erdos-101-oq-01/` — `problem.md` (formal
  statement, status, obstacles, references), `knowledge.md` (S1
  notes, API used, confidence), `state.md` (phase OBSERVE, S2/S3
  candidates).
- `src/data/research/problems/erdos-101-oq-01.json` — knowledge
  structure (insights, builtItems, nextSteps).

## Next Iterations

- **S2**: formalise Solymosi–Stojaković existence statement
  ($\Omega(n^{2-O(1/\sqrt{\log n})})$, as a recorded
  `theorem ... := by sorry` for the existential statement) —
  documenting the refutation of Erdős's $\Theta(n^{3/2})$
  conjecture.
- **S3**: connect `BoundsAtRate` instances to
  `Asymptotics.IsBigO`/`IsLittleO` on filter `atTop`.
- **Optional probe**: per-point bound $(n-1)/3$ + Cauchy–Schwarz
  second-moment double counting — would this yield a $1 - o(1)$
  leading constant on the $n^2/12$ elementary bound? Not $o(n^2)$,
  but a concrete *sub-elementary* constant improvement would be the
  first such progress.

## Test Plan

- [x] All files JSON-validate (`jq -e empty`).
- [x] `Proofs.lean` import list regenerated (`generate-proofs-imports.sh`).
- [x] `pnpm annotations:build` succeeds with my entry resolving (listings.json regenerated, not committed).
- [ ] CI build of `Proofs.Erdos101OQ01` — ground truth for the
  scaffold compiling.

🤖 Generated by researcher-3