### PR TITLE
research(brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02): S1 OBSERVE — Mathlib singular homology feasibility survey

### DIFF
--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/knowledge.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/knowledge.md
@@ -1,0 +1,207 @@
+# Knowledge: brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02
+
+## S1 OBSERVE — Mathlib feasibility survey for `singular_homology_retraction_split`
+
+Survey was carried out against Mathlib rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+(pinned in `proofs/lake-manifest.json`, toolchain `v4.26.0`).
+
+### A. What Mathlib *already* provides
+
+#### A1. Singular chain complex & singular homology functors
+
+`Mathlib/AlgebraicTopology/SingularHomology/Basic.lean` (introduced 2025, Andrew Yang):
+
+```lean
+def SSet.singularChainComplexFunctor :
+    C ⥤ SSet.{w} ⥤ ChainComplex C ℕ := ...
+
+def singularChainComplexFunctor :
+    C ⥤ TopCat.{w} ⥤ ChainComplex C ℕ :=
+  SSet.singularChainComplexFunctor.{w} C ⋙
+    (Functor.whiskeringLeft _ _ _).obj TopCat.toSSet.{w}
+
+def singularHomologyFunctor : C ⥤ TopCat.{w} ⥤ C :=
+  singularChainComplexFunctor C ⋙
+    (Functor.whiskeringRight _ _ _).obj
+      (HomologicalComplex.homologyFunctor _ _ n)
+```
+
+Coefficients live in any preadditive category `C` with the right limits; choose
+`C := AddCommGrp` and `R := ℤ` to recover ordinary integral singular homology.
+
+The file also proves:
+
+* `singularChainComplexFunctorIsoOfTotallyDisconnectedSpace`: for totally
+  disconnected `X`, `C_*(X; R) ≅ R[X] ← 0 ← R[X] ← 𝟙 ← R[X] ← 0 ← ⋯`
+  (alternating constant complex).
+* `singularChainComplexFunctor_exactAt_of_totallyDisconnectedSpace`
+  (and corollary `isZero_singularHomologyFunctor_of_totallyDisconnectedSpace`):
+  `H_n(X) = 0` for totally disconnected `X` and `n ≠ 0`.
+* `singularHomologyFunctorZeroOfTotallyDisconnectedSpace`:
+  `H_0(X) ≅ ⊕_{x ∈ X} R` for totally disconnected `X`.
+
+**Specializing to a point** (`X := PUnit`), this gives `H_n(*) = 0` for `n ≥ 1`
+and `H_0(*) ≅ R`. So step **S3** of the elimination is one corollary away.
+
+#### A2. Chain-homotopy → homology invariance
+
+`Mathlib/Algebra/Homology/Homotopy.lean:808`:
+
+```lean
+lemma Homotopy.homologyMap_eq (ho : Homotopy f g) (i : ι)
+    [K.HasHomology i] [L.HasHomology i] :
+    homologyMap f i = homologyMap g i := ...
+
+noncomputable def HomotopyEquiv.toHomologyIso (h : HomotopyEquiv K L) (i : ι)
+    [K.HasHomology i] [L.HasHomology i] :
+    K.homology i ≅ L.homology i := ...
+```
+
+Chain-homotopy equivalent complexes have isomorphic homology in every degree.
+
+#### A3. Convex sets are contractible
+
+`Mathlib/Analysis/Convex/Contractible.lean`:
+
+```lean
+protected theorem StarConvex.contractibleSpace
+    (h : StarConvex ℝ x s) (hne : s.Nonempty) :
+    ContractibleSpace s
+
+protected theorem Convex.contractibleSpace
+    (hs : Convex ℝ s) (hne : s.Nonempty) :
+    ContractibleSpace s
+```
+
+And `Mathlib/Analysis/Normed/Module/Connected.lean:140` applies this to the
+closed metric ball: `convex_ball _ _` plus nonemptiness gives `ContractibleSpace`.
+
+So the closed unit ball `Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) 1`
+is contractible by an off-the-shelf Mathlib lemma. Step **S4** is essentially
+free.
+
+#### A4. Topological homotopy / nullhomotopy infrastructure
+
+`Mathlib/Topology/Homotopy/Contractible.lean`:
+
+* `ContractibleSpace.hequiv_unit : ContractibleSpace X → X ≃ₕ Unit`
+* `Nullhomotopic` (predicate on `C(X, Y)`) and basic composition lemmas
+* `ContractibleSpace_iff_id_nullhomotopic`
+
+So `B^n ≃ₕ Unit` is in hand.
+
+### B. Where Mathlib has gaps
+
+#### B1. Topological → chain homotopy bridge (the *prism operator*)
+
+The single largest gap is the construction that sends a **topological homotopy**
+`H : C(X × I, Y)` between `f, g : X → Y` to a **chain homotopy**
+`P : C_*(X) → C_*(Y) of degree +1` between `singularChainMap f` and
+`singularChainMap g`.
+
+Searches at the pinned revision returned **no matches** for:
+* `MayerVietoris` (any spelling)
+* `excision`
+* `homotopyInvariance` / `homotopy.invariance`
+* `Sphere.*ContractibleSpace` (Mathlib has no sphere-homotopy/homology link)
+* Any prism / cone construction in `Mathlib.AlgebraicTopology.SingularHomology`
+
+This is the **prism operator**: for each `n`, define
+`P_n : C_n(X) → C_{n+1}(Y)` on a singular `n`-simplex
+`σ : Δ^n → X` by `(P_n σ)(t_0, …, t_{n+1}) = H(σ(s), τ)`, where `(s, τ)`
+is a standard simplicial decomposition of `Δ^n × I`. The standard formula is
+
+P_n(σ) = Σ_{i=0}^{n} (-1)^i · (H ∘ (σ × id) ∘ Δ_i^n)
+
+where `Δ_i^n : Δ^{n+1} → Δ^n × I` runs through the (n+1)-simplices of the
+prism `Δ^n × I`. Verifying `∂P + P∂ = g_♯ - f_♯` is mechanical but bulky
+(~100–300 lines depending on how much of `SimplicialObject`/`AlternatingFaceMapComplex`
+is reused).
+
+**This is the natural Mathlib contribution** that would unblock S2 → S5.
+
+#### B2. A specific generator of `H_{n-1}(S^{n-1})`
+
+Even with S2 in hand, the axiom requires `H_{n-1}(S^{n-1}) ≅ ℤ` (or at least a
+non-trivial class). Mathlib at the pinned rev has **no** computation of sphere
+homology. Three feasible routes:
+
+* **B2a. Mayer–Vietoris / excision.** Standard textbook route; would require
+  formalizing excision in the singular chain complex (a multi-month project).
+* **B2b. Suspension isomorphism + `H_0(S^0) ≅ ℤ²`.** Reduces to `H_0` of two
+  points (a totally-disconnected space already in A1), but needs the suspension
+  isomorphism `H_n(ΣX) ≅ H_{n-1}(X)`, which itself requires either Mayer–Vietoris
+  or a direct simplicial decomposition.
+* **B2c. Direct construction.** Build an explicit `(n-1)`-cycle on `S^{n-1}`
+  using a triangulation (e.g. the boundary of the standard `n`-simplex) and
+  exhibit it as non-bounding. This is concrete but n-dependent and requires
+  proving cycles in `S^{n-1}` are not boundaries — essentially the same
+  computation as B2a in disguise.
+
+#### B3. Functoriality with continuous maps
+
+Mathlib's `singularChainComplexFunctor C : C ⥤ TopCat ⥤ ChainComplex C ℕ`
+is genuinely functorial on `TopCat`, so `r* ∘ i* = (r ∘ i)*` is automatic
+once a chain-level homology functor is applied. **No gap here**; this is the
+reason the axiom only had to package S1 and S2.
+
+### C. Implications for axiom elimination
+
+The current axiom asserts the existence of a split `ψ ∘ φ = id : ℤ →+ Unit →+ ℤ`
+arising from a hypothetical retraction. The honest decomposition is:
+
+```
+    H_{n-1}(S^{n-1}) ──ι*──▶ H_{n-1}(B^n) ──r*──▶ H_{n-1}(S^{n-1})
+       \____________________ id ____________________/
+```
+
+With (A1) + (A2) + (A3) + (A4) + (B1) but **without** (B2), we can prove
+`H_{n-1}(B^n) = 0` and `id = r* ∘ ι*` factors through `H_{n-1}(B^n)`,
+so `id` on `H_{n-1}(S^{n-1})` is the zero map. This implies
+`H_{n-1}(S^{n-1}) = 0` — a *non-trivial conclusion that is still strong
+enough to refute the existence of a retraction provided we know
+`H_{n-1}(S^{n-1}) ≠ 0`*. So:
+
+* **(B1) alone unlocks a "weak" reduction.** The axiom becomes
+  `H_{n-1}(S^{n-1}) ≠ 0`. That is still an axiom, but it is the *standard*
+  computational axiom and is structurally cleaner than the current split-form.
+* **(B1) + (B2) gives a fully axiom-free proof.**
+
+### D. Suggested ACT-phase plan (post-OBSERVE)
+
+The cleanest near-term increment (1–3 sessions) is:
+
+1. **ACT-A**: replace `singular_homology_retraction_split` with two narrower
+   axioms `H_{n-1}_sphere_nonzero` (the missing piece B2) and
+   `H_{n-1}_ball_zero` (provable from B1 + A3 + A4), keeping the gallery's
+   no-retraction proof working without B1 in hand. This **does not reduce
+   total axiom count** but cleanly separates the missing-Mathlib-infra
+   assumption (B2) from the can-be-proved-now part (S5).
+2. **ACT-B**: instantiate `singularHomologyFunctor` at `C := AddCommGrp.{0}`,
+   `R := ℤ`, and prove
+   `H_{n-1}_ball_zero` from `Convex.contractibleSpace` + (B1, deferred) +
+   `singularHomologyFunctorZeroOfTotallyDisconnectedSpace` applied to
+   `PUnit`. The B1 step can be axiomatized as a *named* assumption
+   `singular_homology_topological_homotopy_invariance` while the structural
+   reduction proceeds.
+3. **ACT-C (Mathlib)**: implement the prism operator inside
+   `Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance` (new file).
+   This is a self-contained PR with no upstream dependencies. Once landed,
+   ACT-B's named assumption discharges automatically.
+
+### E. References
+
+* Mathlib v4.26.0 `Mathlib/AlgebraicTopology/SingularHomology/Basic.lean`
+* Mathlib v4.26.0 `Mathlib/Algebra/Homology/Homotopy.lean` (esp. `Homotopy.homologyMap_eq`)
+* Mathlib v4.26.0 `Mathlib/Analysis/Convex/Contractible.lean`
+* Mathlib v4.26.0 `Mathlib/Topology/Homotopy/Contractible.lean`
+* Hatcher, *Algebraic Topology*, §2.1 (prism operator proof of homotopy invariance, p. 111–113)
+* Hatcher, *Algebraic Topology*, §2.1, Theorem 2.13 (sphere homology computation)
+* Bredon, *Topology and Geometry*, §IV.16 (Mayer–Vietoris in singular homology)
+
+### F. Iteration log
+
+* 2026-05-11 (researcher-12, S1 OBSERVE): completed Mathlib feasibility survey;
+  classified the axiom into three subgoals; identified the *prism operator* as
+  the single missing structural ingredient; sketched a 3-step ACT plan.
+  No Lean changes in this iteration.

--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/problem.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/problem.md
@@ -1,0 +1,68 @@
+# Problem: Eliminating `singular_homology_retraction_split` from BrouwerFixedPointOQ01OQ02
+
+Slug: `brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02`
+Parent: `brouwer-fixed-point-oq-01-oq-02-oq-03`
+Tier: B · Significance 6/10 · Tractability 5/10
+
+## Background
+
+`proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean` proves the no-retraction theorem
+(no continuous `r : B^n → S^{n-1}` retracting the closed ball to its boundary)
+via **singular homology**, replacing the opaque `no_retraction_axiom` of
+`BrouwerFixedPoint.lean` with a more informative axiom:
+
+```lean
+axiom singular_homology_retraction_split (n : ℕ) (hn : n ≥ 1)
+    (r : Retraction n) :
+    ∃ (φ : ℤ →+ Unit) (ψ : Unit →+ ℤ), ψ.comp φ = AddMonoidHom.id ℤ
+```
+
+This packages three classical singular-homology facts into one statement:
+
+1. **Sphere homology**: `H_{n-1}(S^{n-1}) ≅ ℤ` for `n ≥ 1`.
+2. **Ball homology**: `H_{n-1}(B^n) = 0` (B^n is contractible).
+3. **Functoriality of singular homology**: the retraction identity
+   `r ∘ ι = id` induces `r_* ∘ ι_* = id` on `H_{n-1}`, producing the
+   split `ψ ∘ φ = id : ℤ →+ Unit →+ ℤ`.
+
+The pure-algebra contradiction (`id : ℤ →+ ℤ` cannot factor through `Unit`)
+is already proved in Part II of `BrouwerFixedPointOQ01OQ02.lean` (0 sorries).
+
+## Open Question
+
+**Eliminate `singular_homology_retraction_split` as a Lean axiom**, replacing it
+with a theorem whose proof discharges to Mathlib lemmas. The result should
+reduce the gallery's axiom count for the singular-homology-based Brouwer chain.
+
+## Required Mathlib Infrastructure
+
+Step | Statement | Mathlib status @ v4.26.0
+-----|-----------|--------------------------
+S0   | Singular chain complex / singular homology functors on `TopCat` | **Present** — `Mathlib.AlgebraicTopology.SingularHomology.Basic`
+S1   | Chain-homotopy invariance of homology | **Present** — `Homotopy.homologyMap_eq` in `Mathlib.Algebra.Homology.Homotopy`
+S2   | Topological homotopy → chain homotopy (prism operator) | **Missing**
+S3   | `H_n(point) = 0` for `n ≥ 1` (special case of totally-disconnected) | Present (specialization)
+S4   | `Convex.contractibleSpace` (closed ball is contractible) | **Present** — `Mathlib.Analysis.Convex.Contractible`
+S5   | `H_n(B^n) = 0` via S2 + S4 + S3 | Derivable once S2 exists
+S6   | A nonzero class in `H_{n-1}(S^{n-1})` for `n ≥ 1` | **Missing**
+
+## Why This Matters
+
+1. **Real axiom elimination.** Removing this axiom converts a "homologically-flavoured"
+   placeholder into actual Mathlib-checked homology. It substantively strengthens
+   one of the marquee gallery formalizations (Brouwer via singular homology).
+2. **Stepping stone to Mathlib contribution.** S2 (prism operator for singular
+   homology) is a self-contained, well-known construction that would be a useful
+   contribution to `Mathlib.AlgebraicTopology.SingularHomology`.
+3. **Sharpens the gap picture.** Replacing the all-in-one axiom with three
+   smaller, classically-known facts makes the remaining honest dependency on
+   unproved infrastructure transparent.
+
+## Related Gallery Proofs
+
+| Slug | File | Relation |
+|------|------|----------|
+| `brouwer-fixed-point` | `BrouwerFixedPoint.lean` | Uses `no_retraction_axiom` (opaque) |
+| `brouwer-fixed-point-oq-01-oq-02` | `BrouwerFixedPointOQ01OQ02.lean` | **Declares this axiom** |
+| `brouwer-fixed-point-oq-01-oq-02-oq-03` | `BrouwerFixedPointOQ01OQ02OQ03.lean` | Derives BFP from the axiom |
+| `brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01` | `BrouwerFixedPointOQ01OQ02OQ03OQ01.lean` | Proves `retraction_construction` (geometric ray) |

--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
@@ -1,0 +1,39 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11T19:15:00Z
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE — Mathlib feasibility survey for eliminating the
+`singular_homology_retraction_split` axiom from `BrouwerFixedPointOQ01OQ02.lean`.
+
+## Active Approach
+
+Decompose the axiom into its three classical singular-homology ingredients
+(S1 chain-homotopy invariance, S2 topological→chain homotopy, S3 `H_n(*) = 0`,
+S4 contractibility of `B^n`, S5 `H_n(B^n) = 0`, S6 sphere homology
+non-vanishing) and check Mathlib v4.26.0 against each. See `knowledge.md`.
+
+## Blockers
+
+* Mathlib v4.26.0 has no prism operator / topological homotopy invariance of
+  singular homology (gap **B1**).
+* Mathlib v4.26.0 has no computation of `H_{n-1}(S^{n-1})` (gap **B2**).
+* No Mayer–Vietoris or excision in `Mathlib.AlgebraicTopology.SingularHomology`.
+
+## Next Action
+
+Session 2 next action: **ACT-A scaffold** — split
+`singular_homology_retraction_split` into two narrower axioms
+`H_{n-1}_sphere_nonzero` (deep, Mathlib-deferred) and
+`H_{n-1}_ball_zero` (will become a theorem once B1 lands), preserving
+downstream proofs. Keep total axiom count the same in this iteration; the
+goal is structural separation, not net axiom reduction.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (Mathlib feasibility survey)

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -1,0 +1,286 @@
+{
+  "slug": "brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02",
+  "title": "**Eliminating singular_homology_retraction_split**: This requires a complete ...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: **Eliminating singular_homology_retraction_split**: This requires a complete ....",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T19:15:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE — Mathlib feasibility survey for eliminating singular_homology_retraction_split. See research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/knowledge.md.",
+    "activeApproach": "Decompose axiom into S1–S6 classical singular-homology ingredients; check Mathlib v4.26.0 coverage; identify the prism operator (topological→chain homotopy invariance) as the single missing structural piece blocking H_n(B^n) = 0.",
+    "blockers": [
+      "Mathlib v4.26.0 has no prism operator / topological homotopy invariance for singularChainComplexFunctor.",
+      "Mathlib v4.26.0 has no computation of H_{n-1}(S^{n-1}); no Mayer–Vietoris or excision in SingularHomology."
+    ],
+    "nextAction": "Session 2 next action: ACT-A scaffold — split singular_homology_retraction_split into two narrower axioms H_{n-1}_sphere_nonzero (deep, Mathlib-deferred) and H_{n-1}_ball_zero (provable once B1 lands), preserving downstream proofs. Keep total axiom count the same in this iteration; goal is structural separation, not net axiom reduction.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete: surveyed Mathlib v4.26.0 (lake-manifest rev 2df2f015) for the singular-homology infrastructure required to eliminate singular_homology_retraction_split. Singular chain complex / homology functors and chain-homotopy invariance are present; convex contractibility of the closed ball is present; topological homotopy invariance (prism operator) and any sphere-homology computation are missing. Sketched a 3-step ACT plan (ACT-A split-axiom scaffold; ACT-B instantiate functors and prove H_{n-1}(B^n) = 0; ACT-C upstream Mathlib prism operator).",
+    "builtItems": [],
+    "insights": [
+      "Mathlib v4.26.0 has singularChainComplexFunctor and singularHomologyFunctor on TopCat (Andrew Yang, 2025), with totally-disconnected homology computed; specializing to PUnit gives H_n(*) = 0 for n ≥ 1.",
+      "Mathlib's Homotopy.homologyMap_eq already gives chain-homotopy → homology equivalence; no need to reprove this.",
+      "Convex.contractibleSpace + convex_ball provide ContractibleSpace for the closed metric ball, so the topological half of H_n(B^n) = 0 is in hand.",
+      "The single missing structural ingredient is the prism operator (topological homotopy → chain homotopy). Without it, H_n(B^n) = 0 cannot be derived from contractibility, even though all surrounding infrastructure exists.",
+      "Even without sphere-homology computation, B1 (prism operator) alone reduces the current axiom to H_{n-1}(S^{n-1}) ≠ 0 — structurally cleaner but not yet axiom-free."
+    ],
+    "mathlibGaps": [
+      "Topological homotopy invariance of singularChainComplexFunctor (prism operator, ~100–300 line construction in Mathlib.AlgebraicTopology.SingularHomology).",
+      "Computation of H_{n-1}(S^{n-1}) ≅ ℤ (requires Mayer–Vietoris / excision / suspension or direct simplicial argument).",
+      "No Mayer–Vietoris long exact sequence in Mathlib.AlgebraicTopology.SingularHomology.",
+      "No excision theorem in Mathlib.AlgebraicTopology.SingularHomology."
+    ],
+    "nextSteps": [
+      "ACT-A: split singular_homology_retraction_split into H_{n-1}_sphere_nonzero (deep) and H_{n-1}_ball_zero (provable once prism operator exists); preserve downstream proofs in BrouwerFixedPointOQ01OQ02OQ03.lean.",
+      "ACT-B: instantiate singularChainComplexFunctor / singularHomologyFunctor at AddCommGrp / ℤ and prove H_{n-1}_ball_zero using Convex.contractibleSpace plus a temporary singular_homology_topological_homotopy_invariance named assumption (then discharge it once ACT-C lands).",
+      "ACT-C (upstream Mathlib): implement the prism operator in a new file Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance. This is the natural Mathlib contribution unblocking the rest of the elimination."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "brouwer-fixed-point",
+    "brouwer-fixed-point-oq-01",
+    "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-02-oq-03",
+    "brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01",
+    "brouwer-fixed-point-oq-01-oq-03",
+    "brouwer-fixed-point-oq-02",
+    "brouwer-fixed-point-oq-02-oq-01",
+    "brouwer-fixed-point-oq-02-oq-02",
+    "brouwer-fixed-point-oq-04",
+    "brouwer-fixed-point-oq-04-oq-02",
+    "brouwer-fixed-point-oq-04-oq-03",
+    "brouwer-fixed-point-oq-04-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "Hatcher, Algebraic Topology, §2.1 (prism operator, p. 111–113; sphere-homology Theorem 2.13)",
+      "Bredon, Topology and Geometry, §IV.16 (Mayer–Vietoris in singular homology)"
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/AlgebraicTopology/SingularHomology/Basic.html",
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Homology/Homotopy.html",
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Convex/Contractible.html"
+    ],
+    "mathlib": [
+      "Mathlib.AlgebraicTopology.SingularHomology.Basic (singularChainComplexFunctor, singularHomologyFunctor, totally-disconnected case)",
+      "Mathlib.Algebra.Homology.Homotopy (Homotopy.homologyMap_eq, HomotopyEquiv.toHomologyIso)",
+      "Mathlib.Analysis.Convex.Contractible (Convex.contractibleSpace, StarConvex.contractibleSpace)",
+      "Mathlib.Topology.Homotopy.Contractible (ContractibleSpace, Nullhomotopic)"
+    ]
+  },
+  "started": "2026-05-08T19:09:00.561Z",
+  "lastUpdate": "2026-05-11T19:15:00Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BrouwerFixedPoint.lean",
+      "filename": "BrouwerFixedPoint.lean",
+      "lineCount": 250,
+      "theoremCount": 5,
+      "axiomCount": 2,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPoint.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01.lean",
+      "filename": "BrouwerFixedPointOQ01.lean",
+      "lineCount": 403,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02.lean",
+      "lineCount": 234,
+      "theoremCount": 10,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02OQ03.lean",
+      "lineCount": 172,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03OQ01.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02OQ03OQ01.lean",
+      "lineCount": 215,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02.lean",
+      "filename": "BrouwerFixedPointOQ02.lean",
+      "lineCount": 392,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02Ext.lean",
+      "filename": "BrouwerFixedPointOQ02Ext.lean",
+      "lineCount": 204,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02Ext.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
+      "filename": "BrouwerFixedPointOQ02OQ01.lean",
+      "lineCount": 1072,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 14,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02OQ02.lean",
+      "filename": "BrouwerFixedPointOQ02OQ02.lean",
+      "lineCount": 269,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02OQ03.lean",
+      "filename": "BrouwerFixedPointOQ02OQ03.lean",
+      "lineCount": 215,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ02Stability.lean",
+      "filename": "BrouwerFixedPointOQ02Stability.lean",
+      "lineCount": 198,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02Stability.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04.lean",
+      "filename": "BrouwerFixedPointOQ04.lean",
+      "lineCount": 506,
+      "theoremCount": 22,
+      "axiomCount": 2,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
+      "filename": "BrouwerFixedPointOQ04OQ02.lean",
+      "lineCount": 520,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
+      "filename": "BrouwerFixedPointOQ04OQ03.lean",
+      "lineCount": 157,
+      "theoremCount": 2,
+      "axiomCount": 2,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ04.lean",
+      "filename": "BrouwerFixedPointOQ04OQ04.lean",
+      "lineCount": 406,
+      "theoremCount": 12,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE feasibility survey for `brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02`:
eliminating the `singular_homology_retraction_split` axiom in
`BrouwerFixedPointOQ01OQ02.lean`.

## Findings

Surveyed Mathlib at pinned rev `2df2f015` (toolchain v4.26.0):

**Present (✓)**
- `singularChainComplexFunctor` / `singularHomologyFunctor` on `TopCat` (Andrew Yang, 2025) in `Mathlib.AlgebraicTopology.SingularHomology.Basic`.
- `H_n(*) = 0` for `n ≥ 1` via `singularChainComplexFunctor_exactAt_of_totallyDisconnectedSpace`.
- Chain-homotopy → homology invariance: `Homotopy.homologyMap_eq` + `HomotopyEquiv.toHomologyIso`.
- `Convex.contractibleSpace` + `convex_ball` ⇒ `B^n` is `ContractibleSpace`.
- Contractibility ↔ nullhomotopic identity / homotopy equivalence to `Unit`.

**Missing (✗)**
- Prism operator (topological homotopy → chain homotopy) — no matches at the pinned rev.
- Mayer–Vietoris long exact sequence in singular homology.
- Excision theorem.
- Any computation of `H_{n-1}(S^{n-1})`.

**Diagnosis.** The single largest structural gap is the prism operator
(~100–300 lines, self-contained, suitable as a Mathlib PR). Without it,
`H_n(B^n) = 0` cannot be derived from contractibility despite all surrounding
infrastructure being present. With B1 in hand, the axiom reduces to a single
non-vanishing claim `H_{n-1}(S^{n-1}) ≠ 0`.

## Files

- `research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/problem.md` (new)
- `research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/knowledge.md` (new)
- `research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md` (new)
- `src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json` (new, ported from main-repo orphan + S1 OBSERVE update)

No Lean code changes; this PR is the survey itself.

## Status

**Outcome**: surveyed
**Next Steps**: ACT-A scaffold — split `singular_homology_retraction_split` into
two narrower axioms (`H_{n-1}_sphere_nonzero` deep, `H_{n-1}_ball_zero` provable
once prism operator lands), preserving downstream proofs.

🤖 Generated by researcher-12