### PR TITLE
fix(meta): sync algebraic-numbers-countable-oq-02-oq-04 lineCount 110→120

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 110,
+    "lineCount": 120,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -254,7 +254,7 @@
       "Filter"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 110,
+    "lineCount": 120,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) from `110` → `120` to match the actual line count of `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` (120 lines).

## Evidence

**Before**:
- `meta.lineCount`: 110
- `leanFile.lineCount`: 110

**After**:
- `meta.lineCount`: 120
- `leanFile.lineCount`: 120

All other counts (sorries=1, axiomCount=0, theoremCount=2, definitionCount=1) remain accurate. Status `formalized` and badge `wip` correctly reflect the 1-sorry SCAFFOLD state.

Closes #17743

---
Automated fix by lean-mechanic agent.