### PR TITLE
research(angle-trisection-cos-20-gal-oq-01-oq-03): S1 OBSERVE — Eisenstein conjecture for cos(π/p) on general odd primes

### DIFF
--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md
@@ -1,0 +1,183 @@
+# Knowledge — angle-trisection-cos-20-gal-oq-01-oq-03
+
+## Problem Summary
+
+**Title.** For which primes p does the minimal polynomial of cos(π/p) have Eisenstein form (after a linear translation)?
+
+**Setting.** For odd prime p ≥ 3, let θ_p := 2 cos(π/p) = ζ + ζ⁻¹ where ζ = ζ_{2p} = exp(iπ/p). The element θ_p generates the maximal real subfield Q(ζ_{2p})⁺ ⊂ Q(ζ_{2p}). Its minimal polynomial μ_p(Y) ∈ Z[Y] is monic of degree (p−1)/2.
+
+**Question.** Does the shifted polynomial r_p(Y) := μ_p(Y − 2) (equivalently, the minimal polynomial of 2 + θ_p over Q) satisfy Eisenstein's criterion at the prime p?
+
+**Empirically verified cases** (gallery formalizations):
+
+| Slug                                | p  | n=(p−1)/2 | Eisenstein polynomial r_p(Y) |
+|-------------------------------------|----|-----------|------------------------------|
+| `angle-trisection-cos-20-gal-oq-01-oq-02` | 5  | 2         | Y² − 5Y + 5                  |
+| `angle-trisection-cos-20-gal-oq-01`       | 7  | 3         | Y³ − 7Y² + 14Y − 7           |
+
+The substitution used in both cases is **Y = 2X + 2**, where X = cos(π/p). The Eisenstein-at-p form has constant ±p, all sub-leading coefficients divisible by p, and constant term not divisible by p².
+
+(Note: the cos(20°) case at `angle-trisection-cos-20-gal` uses cos(π/9), not cos(π/p) for prime p; the relevant Eisenstein prime there is 3, the unique odd prime dividing 9. It is **not** a member of the family this slug asks about, though it is structurally analogous via the same Y = 2X + 2 substitution.)
+
+## Conjecture (informal)
+
+For every odd prime p ≥ 3, the minimal polynomial of 2 + 2 cos(π/p) over Q is Eisenstein at p.
+
+The substitution rule Y = 2X + 2 produces an integer monic polynomial r_p(Y) ∈ Z[Y] of degree (p−1)/2 satisfying:
+- leading coefficient 1;
+- all coefficients of Y^k for 0 ≤ k < (p−1)/2 are divisible by p;
+- constant term r_p(0) = N_{Q(θ_p)/Q}(2 + θ_p) is not divisible by p².
+
+In particular, r_p is irreducible over Q, hence so is μ_p, hence the minimal polynomial of cos(π/p) has degree exactly (p−1)/2.
+
+## Proof Strategy via Cyclotomic Ramification
+
+This is the canonical proof structure; the gallery's individual p=5 and p=7 files use it implicitly via Eisenstein at p, but a unified proof for all primes uses cyclotomic theory.
+
+### Step 1 — Norm identity
+
+Let η := 1 + ζ_{2p}. Then
+  (1 + ζ)(1 + ζ⁻¹) = 1 + ζ + ζ⁻¹ + 1 = 2 + θ_p.
+
+Hence 2 + θ_p = η · η̄ ∈ Q(θ_p), and
+  N_{Q(ζ_{2p})/Q}(η) = Φ_{2p}(−1).
+
+For p odd prime, Φ_{2p}(X) = Φ_p(−X) (standard identity), so
+  Φ_{2p}(−1) = Φ_p(1) = p.
+
+Therefore N_{Q(ζ_{2p})/Q}(η) = p.
+
+Restricting to Q(θ_p): since each conjugate pair {ζ^k, ζ^{−k}} of ζ contributes one conjugate (1+ζ^k)(1+ζ^{−k}) = 2 + θ_p^{(k)} to Q(θ_p), the norm in Q(θ_p) is the same product:
+
+  N_{Q(θ_p)/Q}(2 + θ_p) = ∏_{k odd, 1 ≤ k ≤ p−2} (2 + 2 cos(kπ/p)) = p.
+
+Thus the constant term of the minimal polynomial of 2 + θ_p over Q equals (−1)^{(p−1)/2} · p, and in particular has p-adic valuation exactly 1.
+
+### Step 2 — Eisenstein from totally-ramified uniformizer
+
+Standard ramification theory of Q(ζ_{2p})/Q:
+- The prime p is totally ramified with ramification index e = φ(2p) = p − 1.
+- The unique prime 𝔭 above p in Z[ζ_{2p}] is (1 − ζ_{2p}), and (1 − ζ_{2p}) is a uniformizer.
+- The real subfield Q(θ_p) has [Q(θ_p) : Q] = (p−1)/2, and p is totally ramified with e = (p−1)/2 in Z[θ_p]. The prime above p in Z[θ_p] is denoted 𝔭_θ.
+
+Since (1 + ζ) = (1 − (−ζ)) = (1 − ζ^{p+1}) and ζ^{p+1} is also a primitive 2p-th root of unity (since gcd(p+1, 2p) = 1 for p odd), 1 + ζ is also a uniformizer of 𝔭. Hence v_𝔭(1 + ζ) = v_𝔭(1 + ζ⁻¹) = 1.
+
+In Q(θ_p), with e(𝔭 / 𝔭_θ) = 2 (complex conjugation), we get
+  v_{𝔭_θ}(2 + θ_p) = (1/2) · v_𝔭(2 + θ_p) = (1/2) · 2 = 1.
+
+So **2 + θ_p is a uniformizer of 𝔭_θ**.
+
+**General fact** (local field theory): If L/Q_p is totally ramified of degree e and α ∈ O_L is a uniformizer, then the minimal polynomial of α over Q_p is Eisenstein at p. (Reference: Neukirch ANT II.6, Serre LF I.6.)
+
+Applied to L = (Q(θ_p))_𝔭_θ, the completion at 𝔭_θ, with α = 2 + θ_p:
+- The minimal polynomial of α over Q_p is Eisenstein at p.
+- This local minimal polynomial coincides with the global minimal polynomial r_p(Y) ∈ Z[Y] (since p totally ramifies, the local and global minimal polynomials agree).
+
+Therefore r_p(Y) is Eisenstein at p. ∎
+
+### Step 3 — Empirical verification
+
+For p = 5: r_5(Y) = Y² − 5Y + 5. Eisenstein at 5: ✓ (verified in `AngleTrisectionCos20GalOQ01OQ02.lean`).
+
+For p = 7: r_7(Y) = Y³ − 7Y² + 14Y − 7. Eisenstein at 7: ✓ (verified in `AngleTrisectionCos20GalOQ01.lean`).
+
+For p = 11: r_{11}(Y) should have degree 5. Computing μ_{11}(X) (minimal polynomial of cos(π/11) up to scale 2^5) and shifting Y = 2X + 2 gives r_{11}(Y) = Y⁵ − 11Y⁴ + 44Y³ − 77Y² + 55Y − 11. Eisenstein at 11: leading 1, sub-coefficients (−11, 44, −77, 55, −11) all divisible by 11, constant −11 not divisible by 121. ✓
+
+For p = 13: r_{13}(Y) should be Y⁶ − 13Y⁵ + 65Y⁴ − 156Y³ + 182Y² − 91Y + 13. Eisenstein at 13 (modulo verification): leading 1, sub-coefficients (−13, 65, −156, 182, −91, 13), need each divisible by 13: 65 = 5·13 ✓, 156 = 12·13 ✓, 182 = 14·13 ✓, 91 = 7·13 ✓, 13 ✓. Constant 13 not divisible by 169. ✓
+
+The pattern is consistent with the cyclotomic proof.
+
+## Mathlib Infrastructure Survey
+
+What exists in Mathlib (as of 2026-05):
+
+- `Polynomial.cyclotomic n R` — cyclotomic polynomial Φ_n over commutative ring R.
+- `Polynomial.IsCyclotomicExtension` — predicate for cyclotomic extensions.
+- `IsPrimitiveRoot` — primitive roots of unity API.
+- `Polynomial.IsEisensteinAt` — predicate "polynomial is Eisenstein at ideal I".
+- `Polynomial.irreducible_of_eisenstein_criterion` — classical statement that Eisenstein → irreducible.
+- `Polynomial.Cyclotomic.irreducible_rat` — cyclotomic Φ_n is irreducible over Q.
+- `IsCyclotomicExtension.Rat` — when L/K is a cyclotomic extension over Q, useful APIs.
+- `IsCyclotomicExtension.Rat.cyclotomicComp_eq_X_pow_sub_one_pow_prime` — possibly relevant.
+- `IsCyclotomicExtension.Rat.totallyRamified` / similar lemmas — ramification theory for cyclotomic fields.
+
+What is NOT (or not fully) in Mathlib:
+
+- **Uniformizer ⇒ Eisenstein minimal polynomial** for general totally ramified extensions. The statement
+    *L/Q_p totally ramified of degree e, π uniformizer ⇒ min poly is Eisenstein*
+  may exist for `IsCyclotomicExtension` but a general version using `IsLocalRing` / `LocalRing` / `DiscreteValuationRing` infrastructure may not be packaged.
+- **Maximal real subfield** Q(ζ_n + ζ_n⁻¹): the API `IsCyclotomicExtension.Rat.subfield_real` or similar is sparse. May need to be built locally.
+- **Explicit normalization Y = 2X + 2**: this is gallery-specific. No Mathlib API expected.
+
+The two prior formalizations (p=5, p=7) avoid all of this by directly computing r_p coefficient-by-coefficient and applying `Polynomial.irreducible_of_eisenstein_criterion` to the integer polynomial. This works for each fixed p but does NOT yield a uniform statement for general p.
+
+## Three Levels of Formal Statement
+
+Three increasingly ambitious deliverables, in order of effort:
+
+**Level 1 — Existence for many primes** (lowest effort, recipe-style):
+- For each p ∈ {3, 5, 7, 11, 13, 17, 19, 23} (or similar), define the explicit polynomial r_p ∈ Z[Y] (degree (p−1)/2) and prove `IsEisensteinAt r_p p` and `Irreducible (r_p : Q[X])`.
+- Each case is mechanical; the gallery already has 5 and 7.
+- This is enumeration, not a unified theorem. **Anti-pattern alert**: borderline busywork unless it surfaces a structural lemma.
+
+**Level 2 — Uniform statement, with proof per-prime** (medium effort):
+- Define `r_p : ℕ → ℤ[Y]` parametric in p, prove `∀ p, p.Prime → p ≥ 3 → IsEisensteinAt (r_p p) p` by reducing the coefficient claim to a finite computation from Φ_{2p} or from a Chebyshev recurrence.
+- The proof for the constant term uses N(2+θ_p) = p, derivable from Φ_{2p}(−1) = p, which IS known in Mathlib via `Polynomial.cyclotomic_eq_minpoly` + value at −1.
+- Sub-leading coefficient claim (p | a_k for k < (p−1)/2) is the hard part. Two approaches:
+  - (a) Direct: write r_p as the symmetric function of {2 + 2 cos(kπ/p) : k odd in [1, p−2]}; each elementary symmetric polynomial is a sum of products of (2 + ζ^j)(2 + ζ^{−j}); show each lands in p·Z via ramification.
+  - (b) Local: complete at 𝔭_θ; verify uniformizer; quote the local-to-global theorem.
+
+**Level 3 — Full ramification-theoretic proof** (highest effort, most general):
+- Build the lemma `Uniformizer of totally ramified Q_p-extension ⇒ Eisenstein min poly` if not in Mathlib.
+- Apply to L = Q(θ_p)_𝔭, α = 2 + θ_p.
+- This is the "right" proof but may require 300–500 lines of local-field theory infrastructure if Mathlib gaps are deep.
+
+## Recommended Next Step
+
+**Pursue Level 2 in a follow-up session.** Specifically:
+
+1. Define `r_p : (p : ℕ) → ℤ[Y]` in terms of a Chebyshev-type recursion or in terms of `Polynomial.cyclotomic` composed with appropriate substitution.
+2. Prove the constant term `r_p p (0) = ±p` using `Polynomial.cyclotomic.eval` at −1 (this is in Mathlib).
+3. Prove p-divisibility of sub-leading coefficients via Newton's identities + the fact that each power sum p_k(θ_p^{(1)}, ..., θ_p^{((p−1)/2)}) lands in p·Z (this is the trace of θ_p^k, computable from Φ_{2p}).
+4. Apply `Polynomial.irreducible_of_eisenstein_criterion`.
+
+Estimated size: 250–400 lines. Tractability: 6/10 (would be 8 if Mathlib had the local-uniformizer lemma).
+
+## Risks and Anti-Patterns to Avoid
+
+- **Enumeration theater**: just doing p=11, 13, 17, ... is not progress beyond the gallery's existing p=5, p=7 cases. Must produce a uniform statement.
+- **Premature blocking**: do not claim "Mathlib lacks X ⇒ blocked" without checking `IsCyclotomicExtension.Rat` and `IsPrimitiveRoot` APIs. Cyclotomic theory in Mathlib is mature.
+- **Sign confusion**: r_p has constant ±p with sign (−1)^{(p−1)/2}. Keep track.
+- **Off-by-one on definition of θ_p**: some sources use θ = 2 cos(2π/p), others 2 cos(π/p). The relevant cyclotomic root here is ζ_{2p}, NOT ζ_p.
+
+## Session Log
+
+### Session 2026-05-11 (S1) — OBSERVE — Eisenstein conjecture for general primes
+
+**Mode**: FRESH
+
+**Outcome**: scouted
+
+**What I did**:
+- Surveyed existing gallery proofs for cos(π/5) (`AngleTrisectionCos20GalOQ01OQ02.lean`, r = Y²−5Y+5 Eisenstein at 5) and cos(π/7) (`AngleTrisectionCos20GalOQ01.lean`, r = Y³−7Y²+14Y−7 Eisenstein at 7).
+- Verified that both use the same substitution Y = 2X + 2 and the same Eisenstein-at-p pattern.
+- Computed r_{11}(Y) = Y⁵ − 11Y⁴ + 44Y³ − 77Y² + 55Y − 11 and r_{13}(Y) by hand; both pass Eisenstein at p.
+- Identified the unified cyclotomic-ramification proof: 2 + θ_p is a uniformizer of the unique prime above p in Z[θ_p], hence its minimal polynomial is Eisenstein at p (local field theory).
+- Surveyed Mathlib infrastructure: `Polynomial.IsEisensteinAt`, `Polynomial.cyclotomic`, `IsCyclotomicExtension.Rat`, `IsPrimitiveRoot` all exist. The "uniformizer ⇒ Eisenstein min poly" general lemma may be missing.
+- Identified three levels of formal statement (per-prime enumeration; uniform with per-prime proof; full ramification-theoretic).
+
+**Key findings**:
+- The conjecture is true for all odd primes p ≥ 3 by the standard cyclotomic ramification argument.
+- The proof reduces to two facts: (i) N_{Q(θ_p)/Q}(2 + θ_p) = p, from Φ_{2p}(−1) = Φ_p(1) = p; (ii) all sub-leading coefficients of the minimal polynomial of 2 + θ_p land in p·Z, from local uniformizer structure.
+- The gallery's per-prime proofs (p=5, p=7) are special cases that bypass the general structure by direct coefficient checks.
+
+**Files modified**: none (Lean code deferred to S2).
+
+**Next steps for S2+**:
+1. Decide between Level 1 (more primes, gallery-style) and Level 2 (unified statement). **Recommend Level 2.**
+2. Define `r_p : ℕ → ℤ[Y]` parametrically.
+3. Prove the constant term equals ±p via Mathlib's cyclotomic API at −1.
+4. Prove sub-leading coefficient p-divisibility via Newton's identities or via Mathlib's cyclotomic-extension ramification API if available.
+5. If unification proves too costly, fall back to Level 1 by adding p ∈ {11, 13} cases as concrete witnesses, but only after attempting Level 2.
+
+**Aristotle**: not used in this OBSERVE session (no Lean code yet).

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/problem.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/problem.md
@@ -1,0 +1,34 @@
+# Problem: For which primes p does the minimal polynomial of cos(π/p) have Eisenstein fo...
+
+## Statement
+
+### Plain Language
+Formal mathematical investigation: For which primes p does the minimal polynomial of cos(π/p) have Eisenstein fo....
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md
@@ -1,0 +1,59 @@
+# Current State
+
+**Phase**: ORIENT
+**Since**: 2026-05-11T00:00:00Z
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE — Survey the conjecture and identify proof strategy.
+
+## Active Approach
+
+**Unified cyclotomic-ramification proof** of the conjecture:
+
+> For every odd prime p ≥ 3, the minimal polynomial of 2 + 2cos(π/p) over ℚ is Eisenstein at p (and the minimal polynomial of cos(π/p) is the de-shift of this by Y = 2X + 2).
+
+The proof strategy is:
+1. Show 2 + θ_p = (1+ζ)(1+ζ⁻¹) where ζ = ζ_{2p} and θ_p = 2cos(π/p).
+2. Show N_{ℚ(ζ_{2p})/ℚ}(1 + ζ) = Φ_{2p}(−1) = Φ_p(1) = p.
+3. Conclude N_{ℚ(θ_p)/ℚ}(2 + θ_p) = p, giving the constant-term-of-min-poly = ±p.
+4. Show 2 + θ_p is a uniformizer of the unique prime 𝔭_θ above p in ℤ[θ_p] (totally ramified).
+5. Quote: uniformizer of totally ramified extension ⇒ min poly is Eisenstein at p.
+
+## Blockers
+
+None firm. Potential blocker: Mathlib may lack the general lemma
+> *L/ℚ_p totally ramified of degree e, π uniformizer ⇒ min poly is Eisenstein*
+
+If so, we can either build it (~200–400 lines) or fall back to a direct Newton-identity argument that uses only `Polynomial.cyclotomic` value-at-−1 and the trace structure of ℚ(θ_p)/ℚ.
+
+## Next Action
+
+**S2 next action**: Begin Level 2 implementation. Specifically:
+
+1. Create `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` with:
+   - `namespace AngleTrisectionCos20GalOQ01OQ03`.
+   - Define `theta : (p : ℕ) → ℝ := fun p => 2 * Real.cos (π / p)` (informal/Real, for documentation).
+   - Define the abstract minimal polynomial `minpoly_cos_pi_p : ℕ → ℤ[X]` parametric in p (use `Polynomial.cyclotomic (2*p) ℤ` and trace down to the real subfield, OR use the explicit Chebyshev recurrence-based definition).
+   - State the main theorem: `∀ p : ℕ, p.Prime → p ≥ 3 → IsEisensteinAt (r_p p) (Ideal.span {(p : ℤ)})`.
+   - For S2: focus on the *statement* and on a concrete `decide`-style verification at p ∈ {5, 7, 11, 13}, leaving the general proof as a `sorry`.
+
+2. Update `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json` and `index.ts` to register the new entry.
+
+3. Sanity-check that Mathlib has `Polynomial.cyclotomic`, `Polynomial.IsEisensteinAt`, `IsPrimitiveRoot.minpoly_eq_cyclotomic`.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (cyclotomic ramification, surveyed only)
+
+## Key Files
+
+- `proofs/Proofs/AngleTrisectionCos20Gal.lean` — cos(20°) case, p=3 via cos(π/9); Eisenstein at 3.
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01.lean` — cos(π/7); Eisenstein at 7.
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ01.lean` — unified cos(20°) ⊕ cos(π/7) for p ∈ {3, 7}.
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean` — cos(π/5); Eisenstein at 5.
+
+These collectively confirm the pattern empirically; OQ01OQ03 asks for the general statement.

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -1,0 +1,155 @@
+{
+  "slug": "angle-trisection-cos-20-gal-oq-01-oq-03",
+  "title": "For which primes p does the minimal polynomial of cos(\u03c0/p) have Eisenstein fo...",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: For which primes p does the minimal polynomial of cos(\u03c0/p) have Eisenstein fo....",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-05-08T19:09:00.559Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT - S1 surveyed; identified unified cyclotomic-ramification proof. Empirically verified for p in {5,7,11,13}. Recommended Level 2 (parametric statement + per-prime proof) for S2; main Mathlib risk is the local-uniformizer-to-Eisenstein lemma.",
+    "builtItems": [],
+    "insights": [
+      "Gallery has two empirically-verified instances of the conjecture: cos(pi/5) at OQ01OQ02 with r=Y^2-5Y+5 Eisenstein at 5, and cos(pi/7) at OQ01 with r=Y^3-7Y^2+14Y-7 Eisenstein at 7. Both use the substitution Y = 2X + 2 to convert the minimal polynomial of cos(pi/p) into Eisenstein-at-p form.",
+      "Cyclotomic-ramification proof of the general conjecture: 2 + 2cos(pi/p) = (1+zeta_{2p})(1+zeta_{2p}^{-1}). Norm computation via Phi_{2p}(-1) = Phi_p(1) = p (using Phi_{2p}(X) = Phi_p(-X) for p odd prime) gives N_{Q(theta_p)/Q}(2+theta_p) = p, so the constant term of the minimal polynomial is plus or minus p, hence has p-adic valuation exactly 1.",
+      "Local-field argument: 1 + zeta_{2p} is a uniformizer of the unique prime above p in Z[zeta_{2p}] (totally ramified, e = p-1). Restricting to the real subfield gives ramification index 2 from full cyclotomic, hence v_p(2+theta_p) = 1 in Z[theta_p], i.e., 2+theta_p is a uniformizer at the prime above p in the real subfield. A uniformizer of a totally ramified extension has Eisenstein minimal polynomial; this is the unified proof.",
+      "Empirical verification beyond gallery: r_{11}(Y) = Y^5 - 11Y^4 + 44Y^3 - 77Y^2 + 55Y - 11 is Eisenstein at 11 (all sub-leading coefficients are multiples of 11, constant -11 not divisible by 121). r_{13}(Y) = Y^6 - 13Y^5 + 65Y^4 - 156Y^3 + 182Y^2 - 91Y + 13 likewise Eisenstein at 13.",
+      "Three formalization levels identified: (1) per-prime enumeration (anti-pattern: just more cases like p=11, 13); (2) parametric statement r_p(Y) with per-prime proof via cyclotomic value-at-1 and Newton identities (recommended for S2); (3) full ramification-theoretic proof using a uniformizer-implies-Eisenstein general lemma (highest-value but Mathlib gap risk)."
+    ],
+    "mathlibGaps": [
+      "General lemma 'L/Q_p totally ramified of degree e, pi uniformizer implies minimal polynomial of pi over Q_p is Eisenstein at p' may not be packaged in Mathlib for the general DVR / IsLocalRing context. If missing, build locally (~200-400 lines) or use a Newton-identity workaround.",
+      "Maximal real subfield API: Q(zeta_n + zeta_n^{-1}) inside Q(zeta_n) may have sparse coverage. The ramification index (p-1)/2 of p in Z[theta_p] for the real subfield may need to be derived from IsCyclotomicExtension.Rat results.",
+      "Norm-via-Phi_{2p}(-1) = Phi_p(1) = p identity: should follow from Polynomial.cyclotomic_prime_eval_one or similar Mathlib API but may require an explicit chain of rewrites bridging Phi_{2p}(-1) and Phi_p(1)."
+    ],
+    "nextSteps": [
+      "S2: Create proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean with parametric definition r_p : N -> Z[X] and main statement: for all p prime >= 3, IsEisensteinAt (r_p p) (Ideal.span {(p:Z)}). Stub general proof with sorry; verify by decide/native_decide for concrete p in {5, 7, 11, 13}.",
+      "S2 alt: Add gallery entry src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/ with meta.json, problem.md, index.ts, annotations.json placeholders.",
+      "S3: Replace sorry with the Phi_{2p}(-1) = p constant-term argument using Mathlib's cyclotomic value-at-1 and the identity Phi_{2p}(X) = Phi_p(-X) for p odd prime.",
+      "S4: Prove p-divisibility of sub-leading coefficients. Two paths: (a) symmetric-function path via trace_{theta_p^k} computation from cyclotomic; (b) local-uniformizer path via Mathlib's ramification API for IsCyclotomicExtension.Rat. Try (a) first as it's more elementary.",
+      "S5+: Polish, eliminate remaining sorries, gallery entry build verification."
+    ]
+  },
+  "tags": [
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
+    "angle-trisection-cos-20-gal-oq-01-oq-01",
+    "angle-trisection-cos-20-gal-oq-01-oq-02",
+    "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02",
+    "angle-trisection-cos-20-gal-oq-03",
+    "angle-trisection-cos-20-gal-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-08T19:09:00.559Z",
+  "lastUpdate": "2026-05-12T02:28:59Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AngleTrisectionCos20Gal.lean",
+      "filename": "AngleTrisectionCos20Gal.lean",
+      "lineCount": 475,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01OQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01OQ01.lean",
+      "lineCount": 183,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
+      "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
+      "lineCount": 440,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
+      "filename": "AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
+      "lineCount": 339,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
+      "filename": "AngleTrisectionCos20GalOQ03.lean",
+      "lineCount": 435,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ03.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ03OQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ03OQ01.lean",
+      "lineCount": 463,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ03OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE on a new slug. No Lean code; pure survey + scaffold.

**Question.** For which odd primes p does the minimal polynomial of cos(π/p) admit an Eisenstein-at-p form after a linear translation?

**Empirical evidence** (already in gallery):
- p=5 (`AngleTrisectionCos20GalOQ01OQ02.lean`): r₅(Y) = Y² − 5Y + 5, Eisenstein at 5.
- p=7 (`AngleTrisectionCos20GalOQ01.lean`): r₇(Y) = Y³ − 7Y² + 14Y − 7, Eisenstein at 7.
- Both use the substitution Y = 2X + 2 to convert μ_p(X) → r_p(Y).

**Conjecture (this slug).** For every odd prime p ≥ 3, the minimal polynomial of 2 + 2cos(π/p) over ℚ is Eisenstein at p.

## Unified Proof Strategy

Cyclotomic-ramification proof (works uniformly in p):

1. **Norm.** 2 + θ_p = (1 + ζ_{2p})(1 + ζ_{2p}⁻¹), so N_{ℚ(θ_p)/ℚ}(2+θ_p) = Φ_{2p}(−1) = Φ_p(1) = p. Hence the constant term of the shifted minimal polynomial is ±p.

2. **Uniformizer.** (1 + ζ_{2p}) is a uniformizer at the (totally ramified) prime above p in ℤ[ζ_{2p}], so 2 + θ_p is a uniformizer at the prime above p in ℤ[θ_p].

3. **Eisenstein.** A uniformizer of a totally ramified extension has Eisenstein minimal polynomial (standard local field theory).

Empirically verified by hand for p ∈ {5, 7, 11, 13} (r₁₁(Y) = Y⁵−11Y⁴+44Y³−77Y²+55Y−11; r₁₃(Y) = Y⁶−13Y⁵+65Y⁴−156Y³+182Y²−91Y+13, both pass).

## Three Formalization Levels

- **Level 1** — Per-prime enumeration (anti-pattern; gallery already has p=5,7).
- **Level 2** — Parametric statement + per-prime proof via cyclotomic value-at-1 (recommended for S2).
- **Level 3** — Full ramification-theoretic proof using uniformizer-implies-Eisenstein (best, but Mathlib gap risk).

## Deliverables (no Lean code)

- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md` — 183 lines, full survey.
- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/problem.md` — seeker stub recovered.
- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md` — Phase ORIENT, S2 next-action.
- `src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json` — 5 insights, 3 Mathlib gaps, 5 next-step entries.

## S2 Next Action

Create `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` with parametric `r_p : ℕ → ℤ[X]` and main theorem `∀ p prime ≥ 3, IsEisensteinAt (r_p p) (Ideal.span {(p:ℤ)})`. Stub general proof with `sorry`; verify by `decide`/`native_decide` at p ∈ {5,7,11,13}.

## Honesty Note

This is a survey session. No proof was attempted. The actual content is in `knowledge.md` and the JSON's `insights/mathlibGaps/nextSteps` arrays. The build is unaffected (markdown + JSON only).

## Test plan

- [x] `git diff origin/main --stat` shows only 4 files (no stray Lean changes).
- [x] JSON validates: `python3 -c "import json; json.load(open('src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json'))"`.
- [x] No Lean files modified — no build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)