### PR TITLE
audit(combinations-formula-oq-02): restore sorries 0→1 (Aristotle companion)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -94,7 +94,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Catalan numbers fully formalized: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. 0 sorries, 0 axioms.",
+    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. The main file has 0 sorries and 0 axioms; the *Aristotle.lean companion exposes a duplicate `catalan_mul_succ` statement as an Aristotle proof-search target (1 sorry).",
     "implications": "This formalization connects the gallery's binomial coefficient work (CombinationsFormula) to the ballot problem proofs (BallotProblemOQ03). The central binomial bound C(2n,n) <= 4^n is independently useful (e.g., for the Ap\u00e9ry irrationality proof).",
     "openQuestions": [
       "Prove the generating function C(x) = (1 - sqrt(1-4x))/(2x)",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Audit finding

**Slug**: `combinations-formula-oq-02`
**Severity**: HIGH (sorry count mismatch)

PR #17717 set `sorries: 1 → 0` claiming both files had 0 sorries, but origin/main's `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean` has a `sorry` on line 89 (the duplicate `catalan_mul_succ` Aristotle proof-search target):

```
$ git show origin/main:proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean | grep -cE '\bsorry\b'
1
$ git show origin/main:proofs/Proofs/CombinationsFormulaOQ02.lean | grep -cE '\bsorry\b'
0
```

The `find-targets.ts` convention totals sorries across all resolved files (main file + `additionalFiles`), so `meta.sorries` and top-level `sorries` should be **1**, not 0.

## Fix

3 surgical edits to `src/data/proofs/combinations-formula-oq-02/meta.json`:
- `meta.sorries`: `0` → `1`
- top-level `sorries`: `0` → `1`
- `conclusion.summary`: scope the "0 sorries, 0 axioms" claim to the main file and note the Aristotle companion's open Aristotle target

`leanFile.sorries` remains `0` (main file only — convention unchanged).

## Why this matters

The `catalan_mul_succ` theorem is fully proved at `proofs/Proofs/CombinationsFormulaOQ02.lean:112–120`. The Aristotle companion file restates the same theorem as a `sorry` stub for the proof-search system to attempt — that's the intended pattern (`research/SORRY-CLASSIFICATION.md`). It does not undermine the main proof, but per gallery integrity policy the count fields must match what `find-targets.ts` measures, otherwise the audit queue surfaces this entry repeatedly.

Discovered during gallery integrity audit (audit-tracker queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)