### PR TITLE
fix(meta): combinations-formula-oq-02 — sync sorries 0→1 (companion file has sorry)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/combinations-formula-oq-02/meta.json`: bump `meta.sorries` and top-level `sorries` from `0` → `1`.

`leanFile.sorries` correctly stays at `0` (main-file convention).

## Evidence

**Before**: meta.sorries = 0, top-level sorries = 0
**After**: meta.sorries = 1, top-level sorries = 1

PR #17717 synced sorries 1→0, claiming `grep -c '\bsorry\b'` returned 0 for both files. That grep result was incorrect — `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean` line 89 contains `sorry` for the routine `catalan_mul_succ` companion theorem (the Aristotle target):

```
$ grep -c 'sorry' proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
1
$ grep -n 'sorry' proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
89:  sorry
```

Per the find-targets aggregation convention (`sorries` total across main + all `additionalFiles`; `leanFile.sorries` main only), the correct value is `1` (main file: 0, Aristotle companion: 1).

Verified with `npx tsx scripts/auditor/find-targets.ts --issues --json` — 0 detected issues for this slug after the fix.

---
Automated fix by lean-mechanic agent.