### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 20 — small-prime filter cardinality ≤ √n (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -824,6 +824,67 @@ theorem lcmRange_le_primorial_mul_prod_div_prime (n : ℕ) :
   rw [lcmRange_eq_primorial_mul_prod_prime_pow_pred]
   exact Nat.mul_le_mul_left _ (prod_prime_pow_pred_le_prod_div_prime n)
 
+/-- **Cardinality of small-prime filter** (Iter 20): the set of primes `p`
+    with `p² ≤ n` (the *non-trivial* support of the Iter-16 correction
+    factor by Iter 17's `prime_pow_pred_eq_one_of_sq_lt`) has at most
+    `Nat.sqrt n` elements.
+
+    This is a purely combinatorial cardinality lemma — no number-theoretic
+    estimate is needed beyond the basic fact `p² ≤ n ↔ p ≤ √n`. The bound
+    is used in the next stage of the bridge toward Hanson's `lcmRange n ≤ 3^n`:
+
+    1. Iter 19's `prod_prime_pow_pred_le_prod_div_prime` gives
+       `∏ p^(log_p n - 1) ≤ ∏ (n/p)` over all primes `p ≤ n`.
+    2. Iter 17's `prime_pow_pred_eq_one_of_sq_lt` (once PR #17619 lands)
+       drops the large-prime tail (`p² > n`): both products reduce to
+       `∏_{p² ≤ n} (n / p)`.
+    3. **This iteration**: the number of small primes `p² ≤ n` is at
+       most `√n`, so the small-prime product is `≤ (n/2)^√n` (using
+       `n/p ≤ n/2` for any prime `p ≥ 2`).
+    4. Combined with `Nat.primorial_le_4_pow`, this gives a
+       sub-`(4 + ε)^n` bound on `lcmRange n`, the structural envelope
+       around Hanson's asymptotic `3^n`.
+
+    Concrete checks:
+    * `n = 4`: small primes are `{2}` (`2² = 4 ≤ 4`), card = 1, `√4 = 2`. ✓
+    * `n = 9`: small primes are `{2, 3}` (`9 ≤ 9`), card = 2, `√9 = 3`. ✓
+    * `n = 25`: small primes are `{2, 3, 5}`, card = 3, `√25 = 5`. ✓
+    * `n = 100`: small primes are `{2, 3, 5, 7}` (`7² = 49 ≤ 100 < 121 = 11²`),
+      card = 4, `√100 = 10`. ✓
+
+    Proof: the filter is contained in `Finset.Ico 2 (Nat.sqrt n + 1)`
+    (primes are `≥ 2`; the `p² ≤ n` condition is equivalent to
+    `p ≤ Nat.sqrt n` by `Nat.le_sqrt`). The Ico has cardinality
+    `Nat.sqrt n + 1 - 2 = Nat.sqrt n - 1 ≤ Nat.sqrt n`. -/
+theorem small_prime_card_le_sqrt (n : ℕ) :
+    ((Finset.range (n + 1)).filter (fun p => Nat.Prime p ∧ p ^ 2 ≤ n)).card
+      ≤ Nat.sqrt n := by
+  have h_sub :
+      ((Finset.range (n + 1)).filter (fun p => Nat.Prime p ∧ p ^ 2 ≤ n))
+        ⊆ Finset.Ico 2 (Nat.sqrt n + 1) := by
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_range] at hp
+    obtain ⟨_, hp_prime, hp_sq_le⟩ := hp
+    simp only [Finset.mem_Ico]
+    refine ⟨hp_prime.two_le, ?_⟩
+    have hp_le_sqrt : p ≤ Nat.sqrt n := by
+      -- Convert `p^2 ≤ n` to the `p * p ≤ n` form expected by `Nat.le_sqrt`
+      rw [pow_two] at hp_sq_le
+      exact Nat.le_sqrt.mpr hp_sq_le
+    omega
+  calc ((Finset.range (n + 1)).filter (fun p => Nat.Prime p ∧ p ^ 2 ≤ n)).card
+      ≤ (Finset.Ico 2 (Nat.sqrt n + 1)).card := Finset.card_le_card h_sub
+    _ = Nat.sqrt n + 1 - 2 := Nat.card_Ico 2 (Nat.sqrt n + 1)
+    _ ≤ Nat.sqrt n := by omega
+
+/-- **Concrete cardinality witness** (Iter 20): at `n = 100` the small-prime
+    filter `{p prime : p² ≤ 100}` has cardinality `4` (= `{2, 3, 5, 7}`).
+    Sanity check for `small_prime_card_le_sqrt` (which only gives `≤ √100 = 10`,
+    much looser than the true count). -/
+example :
+    ((Finset.range 101).filter (fun p => Nat.Prime p ∧ p ^ 2 ≤ 100)).card = 4 := by
+  decide
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,12 +4,67 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-12 (Iteration 19, researcher-9)
-**Iteration**: 19
+**Last Updated**: 2026-05-12 (Iteration 20, researcher-11)
+**Iteration**: 20
 
 ## Current Focus
 
-Iteration 19 (2026-05-12, this PR, researcher-9): **product-level
+Iteration 20 (2026-05-12, this PR, researcher-11): **cardinality bound
+on small-prime filter** — proves that the number of primes `p` with
+`p² ≤ n` is at most `Nat.sqrt n`. This is the pure combinatorial
+counting step (no number theory beyond `Nat.le_sqrt`) that converts the
+small-prime correction-factor product into a `(n/2)^√n` bound after
+Iter 19's pointwise reduction. Two new declarations
+(+58 lines, all build-pending, sorry-free):
+
+* `small_prime_card_le_sqrt (n : ℕ) :
+    ((Finset.range (n+1)).filter (fun p => Nat.Prime p ∧ p^2 ≤ n)).card
+      ≤ Nat.sqrt n` —
+  the **main lemma**. Proof: the filter is a subset of
+  `Finset.Ico 2 (Nat.sqrt n + 1)` (each prime `p ≥ 2`, and `p² ≤ n ↔
+  p ≤ Nat.sqrt n` via `Nat.le_sqrt`). The Ico has cardinality
+  `Nat.sqrt n - 1 ≤ Nat.sqrt n` by `Nat.card_Ico` + `omega`.
+* `example : ((Finset.range 101).filter (fun p => Nat.Prime p ∧ p^2 ≤ 100)).card = 4 := by decide` —
+  concrete witness for `n = 100`: small primes are `{2, 3, 5, 7}`
+  (since `11² = 121 > 100`), giving cardinality 4 vs the loose
+  `√100 = 10` bound.
+
+### Strategic value
+
+Step 3 of the four-step Hanson bridge (the documented Iter 20 candidate):
+
+1. Iter 19 — product bound `∏_{p ≤ n} p^(log_p n - 1) ≤ ∏_{p ≤ n} (n/p)`. ✓ (merged)
+2. Iter 17 (PR #17619) — `p² > n → p^(log_p n - 1) = 1` (support reduction). ⏳ (in flight)
+3. **Iter 20 (this PR)** — `|{p prime : p² ≤ n}| ≤ √n` (cardinality of small-prime tail). ✓ (this PR)
+4. Multiplicative combination — `∏_{p ≤ √n} (n/p) ≤ (n/2)^√n = 2^(√n · log₂(n/2))`,
+   then `lcmRange n ≤ primorial n · ∏_{p ≤ √n} (n/p) ≤ 4^n · n^(c√n) ≤ (4 + ε)^n`. ⏳ (S21+)
+
+Iter 20 is **structurally independent of #17619** (Iter 17): the
+cardinality bound stands on its own and does not require the
+support-reduction lemma to be merged first.
+
+### File delta
+
++58 lines (953 → 1011), +1 theorem + 1 example (53 → 54). Definitions /
+sorries / axiomCount unchanged. Build pending — proof uses only:
+
+* `Finset.mem_filter`, `Finset.mem_range`, `Finset.mem_Ico` (used pervasively).
+* `Finset.card_le_card` (subset → card-le, standard).
+* `Nat.card_Ico` (Mathlib `Finset.card_Ico` for `ℕ`).
+* `Nat.Prime.two_le` (from `hp_prime : Nat.Prime p`).
+* `Nat.le_sqrt` (the `m * m ≤ n` form; pow_two converts the `^2` form).
+
+### Compatibility with open PRs
+
+* **#17619 (OPEN, Iter 17 support reduction)**: orthogonal — Iter 20
+  is a cardinality counting lemma on the small-prime *set*, while
+  Iter 17 reduces the *product support*. Together they yield the
+  small-prime-restricted bound `∏_{p² ≤ n} (n/p) ≤ (n/2)^√n`.
+* **#17551 (OPEN, Iter 15 alternate)**: orthogonal, no overlap.
+
+### Iteration 19 (background, merged base, #17710)
+
+Iteration 19 (2026-05-12, merged as #17710, researcher-9): **product-level
 correction-factor bound** — lifts Iter 18's pointwise
 `prime_pow_pred_le_div` (`p^(log_p n - 1) ≤ n/p`) to a product-level
 inequality over the full prime filter, then chains with Iter 16's

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 953,
-    "theoremCount": 53,
+    "lineCount": 1014,
+    "theoremCount": 54,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -31,16 +31,16 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T20:50:00Z",
-    "iteration": 16,
-    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n. Iteration 5 (#17021 merged) specialized to the prime case: prime_pow_dvd_lcmRange. Iteration 6 (#17128 merged) added pairwise-coprimality of distinct prime-power factors: coprime_prime_pow_pow_of_ne. Iteration 7 (this PR) closes the **easy direction of Chebyshev's decomposition**: prod_prime_powers_dvd_lcmRange : (∏ p ∈ filter Prime (range (n+1)), p^⌊log_p n⌋) ∣ lcmRange n. Adds the helper prod_dvd_of_pairwise_coprime (Finset induction packaging) which combines Nat.Coprime.prod_right and Nat.Coprime.mul_dvd_of_dvd_of_dvd. The reverse direction (lcmRange ∣ prod) — needing Nat.factorization — is the next structural target.",
+    "iteration": 20,
+    "focus": "Iter 20 (this PR, researcher-11): cardinality bound on small-prime filter — |{p prime : p^2 ≤ n}| ≤ Nat.sqrt n. Pure combinatorial counting step (Step 3 of the four-step Hanson bridge documented in state.md). Independent of in-flight PR #17619 (Iter 17 support-reduction). +58 lines, +1 theorem + 1 example.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
       "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Iter 10: leverage the new equality to reduce hanson_bound to a Chebyshev-type prime-counting inequality. Two natural sub-targets: (a) prove ∑_{p prime ≤ n} ⌊log_p n⌋ · log p ≤ n · log 3 using primorial_le_4_pow + Bertrand-style bounds (Mathlib has Nat.primorial_le_4_pow but the conversion to log-summed inequality requires real analysis); (b) the cleaner combinatorial route via Erdős/Nair: lcm(1,...,n) ∣ n · binomial(2n, n) (Erdős 1932), then 4^n bound via central-binomial (Nat.centralBinom_lt_pow_of_le_pow_of_pos in Mathlib v4.26).",
+    "nextAction": "Iter 21: combine small_prime_card_le_sqrt with prod_prime_pow_pred_le_prod_div_prime (Iter 19) and the eventual lcmRange_correction_supported_on_small_primes (PR #17619, in flight) to derive the small-prime restricted product bound. Specifically, prove `∏_{p prime, p^2 ≤ n} (n / p) ≤ (n / 2) ^ Nat.sqrt n` via `Finset.prod_le_pow_card` and `n / p ≤ n / 2` for prime `p ≥ 2`. Combined with `Nat.primorial_le_4_pow`, this is the structural envelope `lcmRange n ≤ 4^n · (n/2)^√n`, sub-`(4 + ε)^n` for any ε > 0 and large n.",
     "attemptCounts": {
-      "total": 6,
-      "currentApproach": 2,
+      "total": 20,
+      "currentApproach": 4,
       "approachesTried": 2
     }
   },
@@ -66,7 +66,8 @@
       "hanson_bound (axiom): the open target ∀ n, lcmRange n ≤ 3^n",
       "hanson_strictly_stronger_than_factorial: 3^n < n^n for n ≥ 4",
       "Theorem lcmRange_eq_prod_prime_powers: lcm(1,...,n) = ∏ p prime ≤ n, p^Nat.log p n in BaselProblemOQ01OQ01OQ02OQ03.lean (iter 9). Two-line proof: Nat.dvd_antisymm of lcmRange_dvd_prod_prime_powers and prod_prime_powers_dvd_lcmRange. Closes Chebyshev decomposition started in iters 7-8.",
-      "Theorem lcmRange_eq_primorial_mul_prod_prime_pow_pred: lcm(1,...,n) = primorial n * ∏ p prime ≤ n, p^(Nat.log p n - 1) in BaselProblemOQ01OQ01OQ02OQ03.lean (iter 16, this PR). Refines iter 15's primorial_dvd_lcmRange (#17559) from divisibility to explicit equality, factoring lcmRange as the primorial times a correction factor that only sees primes p ≤ √n (since p > √n ⇒ Nat.log p n ≤ 1 ⇒ exponent 0). Combined with Mathlib's primorial_le_4_pow, isolates the asymptotic challenge into the correction factor — bounding it by Chebyshev-style small-prime estimates would yield Hanson's 3^n via (3/4)^n · 4^n = 3^n. Proof: lcmRange_eq_prod_prime_powers + Finset.prod_mul_distrib + pointwise pow_succ' / Nat.sub_add_cancel."
+      "Theorem lcmRange_eq_primorial_mul_prod_prime_pow_pred: lcm(1,...,n) = primorial n * ∏ p prime ≤ n, p^(Nat.log p n - 1) in BaselProblemOQ01OQ01OQ02OQ03.lean (iter 16, this PR). Refines iter 15's primorial_dvd_lcmRange (#17559) from divisibility to explicit equality, factoring lcmRange as the primorial times a correction factor that only sees primes p ≤ √n (since p > √n ⇒ Nat.log p n ≤ 1 ⇒ exponent 0). Combined with Mathlib's primorial_le_4_pow, isolates the asymptotic challenge into the correction factor — bounding it by Chebyshev-style small-prime estimates would yield Hanson's 3^n via (3/4)^n · 4^n = 3^n. Proof: lcmRange_eq_prod_prime_powers + Finset.prod_mul_distrib + pointwise pow_succ' / Nat.sub_add_cancel.",
+      "small_prime_card_le_sqrt (Iter 20, this PR, researcher-11): |{p prime in range (n+1) : p^2 ≤ n}| ≤ Nat.sqrt n. Pure combinatorial cardinality lemma — the filter is contained in Finset.Ico 2 (Nat.sqrt n + 1) (primes are ≥ 2, and p² ≤ n ↔ p ≤ Nat.sqrt n via Nat.le_sqrt), and Nat.card_Ico gives card ≤ Nat.sqrt n - 1 ≤ Nat.sqrt n. Concrete witness: at n = 100 the small primes are {2, 3, 5, 7} (card 4 ≤ √100 = 10). Closes Step 3 of the four-step Hanson bridge documented in state.md."
     ],
     "insights": [
       "Apéry's proof of ζ(3) irrationality requires the exact constant 3 (threshold c ≈ 3.245); the easier 4^n is insufficient.",


### PR DESCRIPTION
## Summary

**Iter 20** closes Step 3 of the four-step Hanson bridge documented in
the post-Iter-19 `state.md`: the cardinality bound on the small-prime
filter.

```
small_prime_card_le_sqrt (n : ℕ) :
    ((Finset.range (n + 1)).filter (fun p => Nat.Prime p ∧ p^2 ≤ n)).card
      ≤ Nat.sqrt n
```

**Proof**: the filter is a subset of `Finset.Ico 2 (Nat.sqrt n + 1)`
(each prime `p ≥ 2`, and `p² ≤ n ↔ p ≤ Nat.sqrt n` via `Nat.le_sqrt`
after `pow_two`). `Nat.card_Ico` then gives
`card ≤ Nat.sqrt n + 1 - 2 = Nat.sqrt n - 1 ≤ Nat.sqrt n`.

A concrete `decide` witness verifies the bound is loose: at `n = 100`
the small primes are `{2, 3, 5, 7}` (card 4) vs the bound `√100 = 10`.

## Strategic position (Hanson bridge)

1. ✓ **Iter 19** (#17710, merged): product bound `∏ p^(log_p n - 1) ≤ ∏ (n/p)` over all primes `p ≤ n`.
2. ⏳ **Iter 17** (PR #17619, in flight): support reduction — drops primes with `p² > n`.
3. ✓ **Iter 20 (this PR)**: cardinality bound on the remaining small-prime set.
4. ⏳ **Iter 21+**: multiplicative combination → `lcmRange n ≤ 4^n · n^(c√n)`.

Iter 20 is **structurally independent of #17619** — pure combinatorial
counting; no dependency on the support-reduction lemma.

## Files

| File | Change |
| --- | --- |
| `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` | +58 lines; +1 theorem (`small_prime_card_le_sqrt`) + 1 `example` (decide witness for n=100). Inserted between Iter 19 corollary and `lcmRange_succ`. |
| `research/problems/.../state.md` | iteration 19 → 20; document Iter 21 next-action. |
| `src/data/research/problems/....json` | iteration 16 → 20; focus, nextAction, builtItems. |
| `src/data/proofs/.../meta.json` | `lineCount` 953 → 1014, `theoremCount` 53 → 54. |

## Build status

Marked `(build pending)` per the file's convention. Uses only standard
Mathlib API exercised throughout the file:

* `Finset.mem_filter` / `Finset.mem_range` / `Finset.mem_Ico`
* `Finset.card_le_card`, `Nat.card_Ico`
* `Nat.Prime.two_le`
* `Nat.le_sqrt` (with `pow_two` to convert `^2 ↔ * *`)
* `omega`

No new sorries, no new axioms.

## Test plan

- [ ] CI Docker build of `Proofs.BaselProblemOQ01OQ01OQ02OQ03` succeeds.
- [ ] `pnpm build` passes (gallery JSON validates).
- [ ] No regression in other Basel files (`BaselProblemOQ01OQ01OQ02.lean`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)