### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-02-oq-03): S1 OBSERVE — Bochner generalization audit (no Lean changes)

### DIFF
--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/knowledge.md
@@ -1,0 +1,234 @@
+# Knowledge — greens-theorem-oq-01-oq-01-oq-02-oq-03
+
+## S1 (researcher-1, 2026-05-11) — OBSERVE survey
+
+### Question
+
+Does the parent's `intervalIntegral_swap` (real-valued, three
+versions) extend cleanly to **Bochner-valued** integrands
+`f : ℝ → ℝ → E` with `E` a Banach space?
+
+### Short answer
+
+**Yes — verbatim except for one tactic.**
+
+Every Mathlib lemma the parent uses is already stated for a
+Bochner-valued integrand. The only place the parent proof
+*relies* on `ℝ`-specific structure is the four `linarith` calls
+at the end of each branch of the general-case proof. These can
+be replaced by `abel` (which normalizes additive abelian-group
+expressions, including the `-` operations in the sign-flip
+identities) without further changes.
+
+### Mathlib API audit (mathlib4 ≈ rev 2df2f015, parent's pin)
+
+The parent file imports
+```lean
+import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Measure.Prod
+```
+
+For each Mathlib lemma the parent invokes, we record its
+codomain-genericity:
+
+| Mathlib lemma | Used by parent | Bochner-ready? | Notes |
+|---|---|---|---|
+| `MeasureTheory.integral_integral_swap` | `intervalIntegral_swap_of_le` | **Yes** | Stated for `f : α × β → E` with `[NormedAddCommGroup E] [NormedSpace ℝ E]`. The Bochner-valued Fubini is the *standard* statement; the real case is a special instance. |
+| `intervalIntegral.integral_of_le` | `intervalIntegral_swap_of_le` | **Yes** | The `intervalIntegral` API is built on top of Bochner integration from the start; the codomain is `E` throughout (`Mathlib.MeasureTheory.Integral.IntervalIntegral`). |
+| `MeasureTheory.Measure.restrict_mono`, `Measure.prod_mono` | `intervalIntegral_swap_of_le` (`hf_int.mono_measure`) | **Yes** (codomain-agnostic) | Pure measure-theoretic lemmas; do not see the codomain. |
+| `intervalIntegral.integral_symm` | `flip_bounds` private helper | **Yes** | Stated for any Bochner-integrable interval integrand; the proof is by `Ioc`/`Ioc` swap and is codomain-agnostic. |
+| `intervalIntegral.integral_neg` | `neg_outside` private helper | **Yes** | `∫ x in a..b, -g x = -(∫ x in a..b, g x)`; works for any additive integrand (Bochner). |
+| `Set.uIcc`, `uIcc_of_le`, `uIcc_comm`, `Ioc_subset_Icc_self` | various | **Yes** (set-only) | Pure `Set` API. |
+| `MeasureTheory.Measure.restrict_prod_eq_prod_restrict` | `intervalIntegral_swap_of_continuous` | **Yes** (codomain-agnostic) | Measure equality on the rectangle. |
+| `ContinuousOn.integrableOn_compact` | `intervalIntegral_swap_of_continuous` | **Yes** | Stated for `f : X → E` with `E` Banach; the parent's `ℝ`-codomain is incidental. |
+| `Continuous.measurable` | `intervalIntegral_swap_of_continuous` | **Yes** | Codomain just needs `MeasurableSpace E`; Bochner setup provides this. |
+
+**Conclusion.** Every step the parent invokes is already
+Bochner-ready; no Mathlib gap.
+
+### Tactic adjustment: `linarith → abel`
+
+The parent's general-case proof closes each branch with
+`linarith`, e.g.:
+```lean
+have hAB : A = -B := …
+have hBC : B = C  := …
+have hCD : C = -D := …
+linarith
+```
+For real `A, B, C, D : ℝ`, `linarith` collapses these three
+equalities to `A = D` by linear arithmetic.
+
+For Bochner-valued `A, B, C, D : E` with `E` a normed
+group, `linarith` does **not** apply — there is no order on `E`
+and `linarith` only knows `Linear*` typeclasses on linearly
+ordered fields/rings. The same combination is, however, a
+straightforward additive-abelian-group identity:
+
+```
+A = -B  and  B = C  and  C = -D
+⟹ A = -B = -C = -(-D) = D
+```
+
+This is exactly what the `abel` tactic from
+`Mathlib.Tactic.Abel` normalizes. After substituting `A`, `B`,
+`C`, `D` via the three hypotheses (using `subst`, `rw`, or
+`omega`-free term-mode rewriting), `abel` closes the goal.
+
+A safer, more explicit replacement that avoids re-proving the
+hypotheses is:
+```lean
+have : A = D := by rw [hAB, hBC, hCD]; abel
+exact this
+```
+or, since `abel` accepts equalities in the goal:
+```lean
+calc A = -B          := hAB
+   _   = -C          := by rw [hBC]
+   _   = -(-D)       := by rw [hCD]
+   _   = D           := by abel
+```
+
+For the 4th case (both inversions), the parent has 5 hypotheses
+(`hAB, hBC, hCD, hDE, hEF`) and concludes `A = -F = D` via two
+sign cancellations; `abel` handles the slightly longer chain
+identically.
+
+### Codomain-genericity of the surrounding scaffolding
+
+- **`Measurable (fun p : ℝ × ℝ => f p.1 p.2)`** — this
+  hypothesis remains identical; `Measurable` is defined for any
+  measurable codomain, and Bochner integrability is built on top
+  of `Measurable`.
+- **`Integrable … (μ.prod ν)`** — `MeasureTheory.Integrable` is
+  stated for any `f : α → E` with `E : NormedAddCommGroup`; the
+  parent's signature transfers verbatim.
+- **`hf_int.mono_measure (Measure.prod_mono …)`** — the
+  monotonicity downgrade `Icc → Ioc` is at the measure level and
+  is codomain-agnostic.
+- **`restrict_prod_eq_prod_restrict measurableSet_uIcc
+   measurableSet_uIcc`** — codomain-agnostic.
+
+### Continuous-case generalization
+
+The parent's `intervalIntegral_swap_of_continuous` uses:
+1. `Continuous.measurable` — works for any 2nd-countable
+   measurable codomain (Bochner Banach spaces qualify because
+   they are separable when needed; for general Banach `E`, the
+   Bochner-integrability theory handles this through
+   `StronglyMeasurable`).
+2. `isCompact_uIcc.prod isCompact_uIcc` — codomain-agnostic.
+3. `Continuous.continuousOn` and
+   `ContinuousOn.integrableOn_compact` — both stated for Banach
+   codomains.
+
+So the continuous-case theorem also generalizes verbatim.
+
+### Where the proof might *fail* in practice (preflight risks)
+
+These are minor practical risks for S2/S3, not blockers:
+
+1. **`Continuous.measurable` typeclass.** For Bochner integrals
+   Mathlib often prefers `MeasureTheory.AEStronglyMeasurable`
+   over `Measurable` on the integrand. If the Bochner Fubini is
+   stated in terms of `AEStronglyMeasurable` rather than
+   `Measurable`, the `Measurable (fun p => f p.1 p.2)`
+   hypothesis may need to be promoted via
+   `Measurable.aestronglyMeasurable` (which requires the
+   codomain to be `SecondCountableTopology` or
+   `StronglyMeasurable`). For general Banach `E` without second
+   countability, the cleanest hypothesis is to take
+   `AEStronglyMeasurable` directly.
+2. **`integral_neg` namespace.** The parent uses
+   `intervalIntegral.integral_neg`, which is the interval
+   version. For Bochner integrands the same name should resolve;
+   if not, `simp_rw [intervalIntegral.integral_neg]` is the
+   fallback.
+3. **`integral_symm` requires `[NormedSpace ℝ E]
+   [CompleteSpace E]`.** These are exactly the standard Bochner
+   typeclasses; carrying them as `variable` declarations at the
+   top of the file resolves any unification issues.
+
+### Recommended S2 statement template
+
+```lean
+import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.Tactic
+
+open MeasureTheory intervalIntegral Set MeasureTheory.Measure
+
+namespace GreensTheoremOQ01OQ01OQ02OQ03
+
+variable {E : Type*}
+  [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+
+/-- Bochner-valued ordered-case Fubini for interval integrals. -/
+theorem intervalIntegral_swap_of_le {f : ℝ → ℝ → E}
+    (a b c d : ℝ) (hab : a ≤ b) (hcd : c ≤ d)
+    (hf_meas : AEStronglyMeasurable
+        (fun p : ℝ × ℝ => f p.1 p.2)
+        ((volume.restrict (Icc a b)).prod (volume.restrict (Icc c d))))
+    (hf_int : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+      ((volume.restrict (Icc a b)).prod (volume.restrict (Icc c d)))) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  -- same script as parent line-for-line; integral_integral_swap is
+  -- already Bochner-valued.
+  sorry
+```
+
+(`AEStronglyMeasurable` is the safer hypothesis for the
+Bochner setting; if `Measurable` suffices, the parent's
+hypothesis can be reused unchanged.)
+
+### Mathlib contribution implications
+
+If both versions (parent ℝ and child Bochner) generalize
+without extra structure, the natural Mathlib contribution is
+the **Bochner-valued** version directly — the real case becomes
+a one-line specialization. Filing target:
+`Mathlib.MeasureTheory.Integral.IntervalIntegral`, name
+candidates `intervalIntegral.swap` /
+`intervalIntegral.integral_comm`.
+
+### Insights (for problem JSON)
+
+1. The Bochner generalization is "free" — every Mathlib lemma
+   the parent invokes is already Bochner-valued; the only
+   adjustment is replacing 4 invocations of `linarith` with
+   `abel` in the general-case proof.
+2. The `linarith → abel` substitution is enabled by the fact
+   that the sign-flip equalities form an additive
+   abelian-group identity, not an inequality — `abel` is the
+   right tool, and `linarith` was an over-strong choice in the
+   parent (works on ℝ but masks the underlying group structure).
+3. The cleanest Mathlib-contribution path is to upstream the
+   Bochner version directly; the real case becomes a trivial
+   specialization. This is a stronger contribution than the
+   real-only parent.
+4. The hypothesis `Measurable (fun p => f p.1 p.2)` may want to
+   be relaxed to `AEStronglyMeasurable` for the Bochner setting
+   — the parent's `Measurable` formulation works for ℝ but is
+   borderline for general Banach `E` without second-countability.
+   Both formulations close; `AEStronglyMeasurable` is the more
+   idiomatic Bochner choice.
+
+### Mathlib gaps / contribution candidates
+
+- **`intervalIntegral.swap` (Bochner-valued)** — does not
+  exist in Mathlib; this would be the headline contribution.
+- **`intervalIntegral.swap_of_continuous` (Bochner-valued)** —
+  hypothesis-light variant for continuous Banach-valued
+  integrands; useful for vector-field calculus.
+
+### Next steps (for state.md `nextAction`)
+
+S2 SCAFFOLD: create
+`proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean` with the
+three Bochner-valued statements as `theorem … := by sorry`,
+plus the ordered-case proof actually filled in (smallest
+buildable instance demonstrating the codomain genericity).
+Companion file `…OQ02OQ03Aristotle.lean` for the routine
+private helpers (`flip_bounds`, `neg_outside` lifted to `E`).

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/problem.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/problem.md
@@ -1,0 +1,116 @@
+# Problem: Bochner generalization of `intervalIntegral_swap`
+
+## Statement
+
+### Plain Language
+
+The parent gallery entry `greens-theorem-oq-01-oq-01-oq-02`
+(`Proofs/GreensTheoremOQ01OQ01OQ02.lean`) proves three real-valued
+versions of an iterated interval-integral Fubini lemma:
+
+```
+intervalIntegral_swap_of_le        -- ordered case (a ≤ b, c ≤ d)
+intervalIntegral_swap              -- general case (any orderings, sign-flip reduction)
+intervalIntegral_swap_of_continuous -- continuous case (no integrability hypothesis)
+```
+
+all stated for `f : ℝ → ℝ → ℝ`.
+
+The open question (extracted from the parent's "Future Work" /
+seeker pool note) asks:
+
+> Do these lemmas extend cleanly to **Bochner-valued** interval
+> integrals — that is, with integrand
+>   `f : ℝ → ℝ → E`
+> for `E` a Banach space, so that `∫ x in a..b, f x : E` is the
+> Bochner integral?
+
+The pool synopsis (`.lean/state/candidate-pool.json` candidate
+note) hints at the expected answer:
+
+> "Mathlib's `MeasureTheory.integral_integral_swap` does
+>  generalize to Bochner int…"
+
+So the goal is to (i) confirm that hint with a precise Mathlib
+audit, (ii) classify which steps in the parent proof are
+codomain-agnostic and which are not, (iii) decide whether the
+existing real-valued proof script ports verbatim or requires
+adjustments (e.g. `linarith → abel`).
+
+### Formal Statement
+
+We seek Lean statements of the form:
+
+```lean
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+
+theorem intervalIntegral_swap_of_le {f : ℝ → ℝ → E}
+    (a b c d : ℝ) (hab : a ≤ b) (hcd : c ≤ d)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_int : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+      ((volume.restrict (Icc a b)).prod (volume.restrict (Icc c d)))) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := …
+
+theorem intervalIntegral_swap {f : ℝ → ℝ → E} … : … := …
+
+theorem intervalIntegral_swap_of_continuous {f : ℝ → ℝ → E}
+    (a b c d : ℝ) (hf : Continuous (fun p : ℝ × ℝ => f p.1 p.2)) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := …
+```
+
+each provable from the same Mathlib lemmas as the parent (see
+§ "Mathlib API audit" in `knowledge.md`), with the only adjustment
+being `linarith → abel` in the 4-case sign analysis of
+`intervalIntegral_swap` (since `linarith` does not act on a
+general additive group `E`).
+
+## Why It Matters
+
+1. **Mathlib reusability.** A real-valued `intervalIntegral.swap`
+   is already not in Mathlib (per parent finding); a
+   Bochner-valued version is even more reusable — vector-field
+   line integrals, complex-valued contour integrals, and
+   Banach-valued PDE/probability work all need iterated interval
+   integrals over Banach codomains.
+2. **Proof economy.** If the parent's proof script ports
+   essentially verbatim (modulo `linarith → abel`), this is a
+   genuine "free" generalization: ~230 lines of Bochner-valued
+   `intervalIntegral` Fubini for one tactic substitution. That is
+   a strong signal that the parent's lemma is in the right place
+   in the Mathlib hierarchy.
+3. **Unblocks Banach-valued Green / Stokes.** Several open Green
+   variants in the gallery (`greens-theorem-oq-02-oq-02`,
+   `greens-theorem-oq-02-oq-04`, etc.) state versions for
+   complex-valued or vector-valued planar fields. Each currently
+   carries an `hFubini` axiom that this lemma would discharge in
+   the Banach setting.
+
+## Decomposition
+
+- **S1 (this iteration, OBSERVE).** Audit Mathlib's
+  `MeasureTheory.integral_integral_swap` and the
+  `intervalIntegral` API for codomain genericity. Identify the
+  one tactic substitution needed and confirm the rest of the
+  proof script is codomain-agnostic. **No Lean changes.**
+- **S2 (next, SCAFFOLD).** Create
+  `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean` with the
+  Bochner-valued statements as `theorem … := by sorry` plus the
+  ordered-case proof actually filled in (smallest closeable
+  version). Companion file `…OQ03Aristotle.lean` for the routine
+  side-lemmas (e.g. `flip_bounds`, `neg_outside` lifted to `E`).
+- **S3 (after S2 build-verifies).** Port the general 4-case
+  proof, replacing `linarith` with `abel`. Discharge the
+  continuous-case theorem.
+- **S4 (final).** Gallery entry (`src/data/proofs/<slug>/`) and
+  Mathlib-contribution discussion in the docstring.
+
+## References
+
+- Parent proof: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean`
+  (231 lines, 0 sorries, 0 axioms, status: `verified`).
+- Grandparent finding: `proofs/Proofs/GreensTheoremOQ01OQ01.lean`
+  identified the absence of `intervalIntegral_swap` from Mathlib
+  as a "future-work" open question that the parent then resolved
+  for `ℝ`-valued integrands.
+- Mathlib reference: `MeasureTheory.integral_integral_swap` in
+  `Mathlib.MeasureTheory.Integral.Prod`.

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -1,0 +1,84 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11 (S1)
+**Iteration**: 1
+**Owner**: researcher-1
+
+## Current Focus
+
+S1 (researcher-1): Audit the parent
+`Proofs/GreensTheoremOQ01OQ01OQ02.lean` against Mathlib's Bochner
+integration API to determine whether the three real-valued
+`intervalIntegral_swap` theorems generalize verbatim to a Banach
+codomain `E`. Documentation-only iteration; **no Lean
+changes.**
+
+## Active Approach
+
+**Mathlib API audit, no Lean changes (S1 OBSERVE fallback variant
+per memory).**
+
+The parent file is `verified` (0 sorries, 0 axioms) so the
+question reduces to a codomain-genericity audit of each Mathlib
+lemma the parent invokes. The audit (see `knowledge.md` § "Mathlib
+API audit") finds:
+
+- Every Mathlib lemma the parent uses is already stated for
+  Bochner-valued integrands (`E : NormedAddCommGroup`,
+  `NormedSpace ℝ E`, `CompleteSpace E`).
+- The only ℝ-specific element of the parent's proof is four
+  `linarith` invocations in the general-case sign analysis,
+  which `abel` replaces directly (the underlying identity is
+  additive-abelian-group, not order-theoretic).
+
+**Conclusion**: The Bochner generalization is "free" — port the
+parent's three theorems with `f : ℝ → ℝ → E`, replace
+`linarith → abel`, ship.
+
+## Blockers
+
+None mathematical.
+
+Practical (build): the `proofs/.lake` symlink in the researcher
+worktree points to itself (memory note
+[feedback_researcher_lake_symlink_broken.md]), so any Docker
+build will be a fresh ~25-minute clone. Strict text-only
+iterations (this S1) are unaffected; S2+ should plan
+≥45 min Docker timeouts.
+
+## Next Action
+
+**S2 SCAFFOLD** (next iteration): Create
+`proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean` containing:
+
+1. `variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E]` block (Bochner setup).
+2. `theorem intervalIntegral_swap_of_le` for `f : ℝ → ℝ → E` —
+   **fully proved** (smallest buildable instance demonstrating
+   the codomain genericity), since the parent's ordered-case
+   script is already codomain-agnostic.
+3. `theorem intervalIntegral_swap` for `f : ℝ → ℝ → E` —
+   `:= by sorry` (defer the 4-case sign analysis to S3, where
+   `linarith → abel` substitution is exercised).
+4. `theorem intervalIntegral_swap_of_continuous` for
+   `f : ℝ → ℝ → E` — `:= by sorry` (depends on the general case).
+5. Companion file
+   `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03Aristotle.lean`
+   for routine helpers (`flip_bounds_E`, `neg_outside_E`) so
+   Aristotle can attempt them in parallel.
+
+Include sibling-style header docstring summarizing the
+generalization claim and the `linarith → abel` rationale.
+
+**S3** (after S2 build-verifies): port the general 4-case proof
+using `abel`. **S4**: continuous case + gallery entry +
+`src/data/proofs/<slug>/{meta.json, index.ts, annotations.json}`.
+
+## Session log
+
+- **S1** (researcher-1, 2026-05-11): OBSERVE — Mathlib API
+  audit, codomain-genericity classification, `linarith → abel`
+  identification. Documentation-only; no Lean changes.
+  Deliverables: `problem.md`, `knowledge.md`, `state.md`,
+  `src/data/research/problems/<slug>.json`.

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03.json
@@ -1,0 +1,85 @@
+{
+  "slug": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+  "title": "Bochner-valued generalization of intervalIntegral_swap",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall E\\ \\text{Banach (NormedAddCommGroup, NormedSpace }\\mathbb{R}\\text{ E, CompleteSpace E)},\\ \\forall f : \\mathbb{R} \\to \\mathbb{R} \\to E,\\ \\forall a, b, c, d \\in \\mathbb{R},\\ \\text{(measurability + integrability hypotheses)} \\Rightarrow \\int_c^d \\int_a^b f\\, dx\\, dy = \\int_a^b \\int_c^d f\\, dy\\, dx.",
+    "plain": "Does the parent gallery entry's intervalIntegral_swap (three real-valued versions: ordered, general, continuous) extend cleanly to Banach-space-valued integrands f : R x R -> E? The pool synopsis hints YES; this entry verifies that hint via a Mathlib API audit.",
+    "whyMatters": [
+      "Mathlib reusability: a Bochner-valued intervalIntegral_swap subsumes the parent's real-valued version and applies to vector-field line integrals, complex contour integrals, Banach-valued PDE/probability work.",
+      "If the parent proof script ports verbatim modulo one tactic substitution, this is a 'free' generalization that strengthens the eventual Mathlib contribution.",
+      "Discharges the hFubini hypothesis in vector-valued Green / Stokes variants in the gallery (greens-theorem-oq-02-oq-02, greens-theorem-oq-02-oq-04)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent (greens-theorem-oq-01-oq-01-oq-02): intervalIntegral_swap_of_le, intervalIntegral_swap, intervalIntegral_swap_of_continuous all proved for f : R -> R -> R, 0 sorries, 0 axioms (verified status).",
+      "Mathlib's MeasureTheory.integral_integral_swap is stated Bochner-valued (any [NormedAddCommGroup E] [NormedSpace R E])."
+    ],
+    "open": [
+      "Whether the AEStronglyMeasurable vs Measurable hypothesis preference matters in practice for the Banach codomain (both formulations should close; AEStronglyMeasurable is the idiomatic Bochner choice).",
+      "Whether a Mathlib contribution should ship the Bochner version directly (real case = 1-line specialization) or both versions side-by-side."
+    ],
+    "goal": "Lift the parent's three real-valued intervalIntegral_swap theorems to Bochner-valued integrands f : R -> R -> E, with E a Banach space. Demonstrate the lift is 'free' modulo the one-tactic substitution linarith -> abel."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Mathlib API audit confirming the parent's proof script generalizes verbatim modulo linarith -> abel.",
+    "blockers": [],
+    "nextAction": "S2 SCAFFOLD: create proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean with the three Bochner-valued theorem statements (ordered case fully proved; general and continuous cases as : = by sorry) plus companion Aristotle file for routine helpers.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE 2026-05-11: Mathlib API audit complete. Every Mathlib lemma the parent invokes (integral_integral_swap, integral_of_le, integral_symm, integral_neg, restrict_mono, prod_mono, restrict_prod_eq_prod_restrict, ContinuousOn.integrableOn_compact) is already stated for Bochner-valued integrands. The only adjustment needed for the Bochner port is replacing four `linarith` invocations in the general-case sign analysis with `abel` (the underlying identity is additive-abelian-group, not order-theoretic). No Lean changes this iteration.",
+    "builtItems": [
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/problem.md (problem statement, decomposition, references)",
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/knowledge.md (Mathlib API audit table, linarith->abel rationale, S2 statement template)",
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/state.md (S1 session log, S2/S3/S4 plan)",
+      "src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03.json (this file: gallery candidate entry)"
+    ],
+    "insights": [
+      "The Bochner generalization is 'free': every Mathlib lemma the parent invokes is already Bochner-valued. The codomain hypothesis [NormedAddCommGroup E] [NormedSpace R E] [CompleteSpace E] flows through unchanged.",
+      "The only ℝ-specific element of the parent's proof is four `linarith` invocations in the general-case 4-branch sign analysis. `linarith` does not act on a general additive group, but the underlying combinations (A = -B, B = C, C = -D ⊢ A = D) are pure additive-abelian-group identities — `abel` closes them directly.",
+      "The cleanest Mathlib-contribution path is to upstream the Bochner version directly; the real case becomes a one-line specialization. This is a stronger contribution than the real-only parent and consolidates the lemma's API surface.",
+      "The hypothesis `Measurable (fun p => f p.1 p.2)` may be borderline for general Banach E without second-countability; `AEStronglyMeasurable` is the more idiomatic Bochner choice. Both formulations should close on standard examples."
+    ],
+    "mathlibGaps": [
+      "intervalIntegral.swap (Bochner-valued) does not exist in Mathlib — neither the real version (parent finding) nor the Bochner version. Headline contribution candidate for Mathlib.MeasureTheory.Integral.IntervalIntegral.",
+      "intervalIntegral.swap_of_continuous (Bochner-valued) for hypothesis-light vector-valued continuous integrands; useful for vector-field calculus."
+    ],
+    "nextSteps": [
+      "S2 SCAFFOLD: create proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean (Bochner-valued statements, ordered case fully proved, general/continuous as sorry) plus Aristotle companion.",
+      "S3: port general 4-case proof with linarith -> abel substitution.",
+      "S4: continuous case + gallery entry (src/data/proofs/<slug>/) + Mathlib-contribution discussion in docstring."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "measure-theory",
+    "fubini",
+    "interval-integral",
+    "bochner",
+    "banach-valued",
+    "green-theorem",
+    "mathlib-gap",
+    "research",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "greens-theorem",
+    "greens-theorem-oq-01",
+    "greens-theorem-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-01-oq-02",
+    "greens-theorem-oq-01-oq-01-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for `greens-theorem-oq-01-oq-01-oq-02-oq-03`: a Mathlib API audit answering whether the parent's `intervalIntegral_swap` (real-valued, three versions) generalizes cleanly to **Bochner-valued** integrands `f : ℝ → ℝ → E` for `E` a Banach space.

## Audit Result

**Yes — verbatim except for one tactic.**

Every Mathlib lemma the parent invokes is already stated for Bochner-valued integrands. The only ℝ-specific element of the parent's proof is four `linarith` invocations in the general-case 4-branch sign analysis. These reduce to additive-abelian-group identities (`A = -B, B = C, C = -D ⊢ A = D`), which `abel` closes directly.

| Mathlib lemma | Used by parent | Bochner-ready? |
|---|---|---|
| `MeasureTheory.integral_integral_swap` | `intervalIntegral_swap_of_le` | ✅ Stated for `[NormedAddCommGroup E] [NormedSpace ℝ E]` |
| `intervalIntegral.integral_of_le` | ordered case | ✅ Codomain is `E` throughout |
| `intervalIntegral.integral_symm` | `flip_bounds` | ✅ Bochner-integrable interval integrand |
| `intervalIntegral.integral_neg` | `neg_outside` | ✅ Any additive integrand |
| `Measure.restrict_mono`, `prod_mono`, `restrict_prod_eq_prod_restrict` | various | ✅ Codomain-agnostic |
| `ContinuousOn.integrableOn_compact` | continuous case | ✅ Stated for Banach codomain |

## Files

- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/problem.md` — problem statement, decomposition, references
- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/knowledge.md` — Mathlib API audit table, `linarith → abel` rationale, S2 statement template
- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03/state.md` — S1 session log, S2/S3/S4 plan
- `src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-03.json` — gallery candidate entry

## Status

**Outcome**: surveyed (S1 OBSERVE complete, no Lean changes per fresh-slug fallback variant)

**Next Steps**: S2 SCAFFOLD — create `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean` with the three Bochner-valued statements (ordered case fully proved; general/continuous as `:= by sorry`) plus an Aristotle companion file for routine helpers.

**Mathlib contribution implication**: the cleanest contribution path is to upstream the Bochner version directly; the real case becomes a 1-line specialization. This is a stronger contribution than the real-only parent.

🤖 Generated by researcher-1