### PR TITLE
fix(meta): shannon-channel-coding-oq-02-oq-01 — sync lineCount 181→312, theoremCount 3→6

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -40,14 +40,14 @@
     "assumptions": "0 axioms in this file. Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file).",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 181,
+    "lineCount": 312,
     "prerequisites": [
       "Fano's inequality (OQ-03): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1)",
       "Binary entropy function and concavity (OQ-04)",
       "Conditional entropy definition from ShannonEntropy.lean"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 3,
+    "theoremCount": 6,
     "definitionCount": 0,
     "additionalFiles": [
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
@@ -152,11 +152,11 @@
       "FanoInequality"
     ],
     "namespace": "FanoFromConditionalEntropy",
-    "lineCount": 181,
+    "lineCount": 312,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
-    "theoremCount": 3,
+    "theoremCount": 6,
     "definitionCount": 0,
     "additionalFiles": [
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"


### PR DESCRIPTION
## Fix

`src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json`: sync stale counts after research expansion.

## Evidence

**Before**:
- `meta.lineCount`: 181
- `meta.theoremCount`: 3
- `leanFile.lineCount`: 181
- `leanFile.theoremCount`: 3

**After** (matches `proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean`):
- `meta.lineCount`: 312
- `meta.theoremCount`: 6
- `leanFile.lineCount`: 312
- `leanFile.theoremCount`: 6

```
$ wc -l proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean
     312 proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean
$ grep -cE '^(private |protected )?(theorem|lemma) ' proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean
6
```

The 6 theorems are:
1. `conditional_entropy_defs_agree` (line 49)
2. `fano_from_oq03` (line 68)
3. `fano_trivial_singleton` (line 143)
4. `fano_from_oq03_std` (line 201)
5. `fano_singleton_card_one` (line 216)
6. `fano_inequality_proved` (line 288)

`sorries` (4 total across files), `axiomCount` (0), and `definitionCount` (0) are unchanged.

## Out of scope

Section line ranges in `meta.json` still reflect the 181-line layout and do not cover the new theorems on lines 201/216/288. Section reflow requires re-identifying section boundaries from prose context — left for a follow-up pass per the one-fix-per-PR scope discipline.

---
Automated fix by lean-mechanic agent.