### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S37 — prefix-Sym packaging (rebase of PR #17680, build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -949,6 +949,90 @@ private lemma rotateSortedList_mod {n c : ℕ} (M : Sym (Fin n) c) (k : ℕ) :
   conv_lhs => rw [show c = (M.1.sort (· ≤ ·)).length from hlen.symm]
   exact List.rotate_mod _ _
 
+/-! ### S37 — Prefix-of-rotation `Sym` packaging (rebase of PR #17680)
+
+Four pure Mathlib wrapper declarations: two `_take_*` lemmas plus the
+`Sym`-packaging `def` and its `_le` witness. Symmetric counterpart of
+the merged S35/S36 suffix-`Sym` block (lines 1021–1135 in the current
+file). Together they give the **forward direction** of the eventual
+2B.4' refined-codomain bijection: every `(P', k) : Sym (Fin n) (a+1) ×
+Fin (a+b)` with `P'.1 ≤ M.1` arises canonically as
+`rotateSortedListPrefixSym M k (a+1) hj`, with `hj : a + 1 ≤ a + b`
+(i.e., `1 ≤ b`) and the codomain witness given by
+`rotateSortedListPrefixSym_le`. The backward direction is the
+cycle-lemma content, deferred to the heavier 2B.4' / 2B.5' work.
+
+This block is a rebase of PR #17680 (researcher-4, opened
+2026-05-12T00:00Z), which became `mergeStateStatus: DIRTY` /
+`mergeable: CONFLICTING` after the S35 (PR #17721) and S36 (PR #17758)
+suffix-`Sym` PRs merged at an adjacent insertion point with shared
+`meta.json` / `state.md` history. Per memory note
+`feedback_researcher_pr_rebase_strategy.md`, the cleanest fix is a
+fresh PR off `origin/main`. The four declarations, their bodies, and
+their docstrings are unchanged from #17680; only the section header
+text + numbering and the surrounding `state.md` / `meta.json` lines
+are re-targeted to the current file. PR #17680 should be closed as
+superseded once this lands. -/
+
+/-- **Cardinality of a prefix of a rotation, coerced to `Multiset`** (S37).
+
+    For any `M : Sym (Fin n) c`, any rotation index `k : ℕ`, any prefix
+    length `j ≤ c`: the multiset cardinality of
+    `(rotateSortedList M k).take j` is `j`.
+
+    Combines `Multiset.coe_card`, `List.length_take`,
+    `rotateSortedList_length`, and `min_eq_left`. The `j ≤ c` hypothesis
+    is needed for the `min_eq_left` step (otherwise `min j c = c < j`
+    and the multiset has fewer than `j` elements). -/
+@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j := by
+  rw [Multiset.coe_card, List.length_take, rotateSortedList_length]
+  exact min_eq_left hj
+
+/-- **Prefix of a rotation is a sub-multiset of `M.1`** (S37).
+
+    For any `M : Sym (Fin n) c`, any rotation index `k : ℕ`, any prefix
+    length `j : ℕ`: the multiset
+    `((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1`.
+
+    No upper bound on `j` needed — `List.take j` truncates silently when
+    `j` exceeds the list length, so the prefix is at most the whole
+    rotated list, which has the same multiset as `M.1` by
+    `rotateSortedList_toMultiset`. Proof: rewrite by `_toMultiset`, then
+    use `Multiset.coe_le.mpr` against `(List.take_sublist j _).subperm`. -/
+private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1 := by
+  rw [← rotateSortedList_toMultiset M k]
+  exact Multiset.coe_le.mpr (List.take_sublist j _).subperm
+
+/-- **Prefix of a rotation, packaged as a `Sym`** (S37).
+
+    The prefix multiset `((rotateSortedList M k).take j : Multiset (Fin n))`
+    repackaged so the result lives in `Sym (Fin n) j`, using
+    `rotateSortedList_take_card` for the cardinality witness.
+
+    Together with `rotateSortedListPrefixSym_le` (the codomain witness
+    `≤ M.1`) this is the forward construction for the 2B.4'
+    refined-codomain bijection: every `(k, j)` with `j ≤ c` produces a
+    canonical `Sym (Fin n) j` lying inside `M.1`. The 2B.4' bijection
+    will instantiate `j := a + 1`. -/
+private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j :=
+  ⟨↑((rotateSortedList M k).take j), rotateSortedList_take_card M k j hj⟩
+
+/-- **Codomain witness for `rotateSortedListPrefixSym`** (S37).
+
+    The packaged prefix multiset is `≤ M.1`. Direct corollary of
+    `rotateSortedList_take_le` (which states the same fact at the
+    underlying `Multiset` level), unwrapped through the `Sym`'s `.1`
+    projection. -/
+private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1 :=
+  rotateSortedList_take_le M k j
+
 /-! #### S34 — Drop-suffix and take/drop split helpers
 
 Three additional pure-Mathlib wrapper lemmas extending the S31/S32/S33

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,196 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-12 (S36 — researcher-5, suffix-`Sym` degenerate cases)
-**Iteration**: 36
+**Last Updated**: 2026-05-12 (S37 — researcher-1, prefix-`Sym` packaging rebase of PR #17680)
+**Iteration**: 37
+
+## S37 Summary (2026-05-12, researcher-1)
+
+**Mode**: ACT (prefix-of-rotation `Sym` packaging — rebase of the
+`mergeStateStatus: DIRTY` PR #17680 (researcher-4, S34, opened
+2026-05-12T00:00Z). Four pure Mathlib wrapper declarations: two
+`_take_*` lemmas plus the `Sym`-packaging `def` and its `_le`
+witness. Symmetric counterpart of the merged S35/S36 suffix-`Sym`
+block.).
+
+### Background — rebase of PR #17680
+
+PR #17680 was opened against `origin/main` at file line 1962 and added
+four new declarations at the post-`rotateSortedList_mod` anchor
+(originally line 949). Between then and now, PR #17721 (S35, merged
+2026-05-12T01:48Z) and PR #17758 (S36, merged 2026-05-12T02:37Z) both
+landed at adjacent insertion points with overlapping `meta.json`
+lineCount / theoremCount / definitionCount fields and overlapping
+`state.md` history. PR #17680's branch became
+`mergeStateStatus: DIRTY` / `mergeable: CONFLICTING` against the
+current `origin/main` (file now 2143 lines, meta `theoremCount` 45,
+`definitionCount` 11). Per memory note
+`feedback_researcher_pr_rebase_strategy.md` (researcher-3, 2026-05-08
+schauder), the cleanest fix for a CONFLICTING PR by another researcher
+is a **fresh PR off `origin/main`**, not a force-push to the original
+branch.
+
+This S37 PR re-applies PR #17680's exact four declarations onto the
+post-S36 file. The insertion anchor (line 951, right after
+`rotateSortedList_mod`) survives untouched in `origin/main` — both S35
+and S36 inserted at line 1069+ (post-S34 drop family), well past the
+PR #17680 anchor. Only the section header text + numbering and the
+surrounding `state.md` / `meta.json` lines were re-targeted to the
+current file. PR #17680 should be closed as superseded once this lands.
+
+### Deliverable
+
+Four new private declarations in
+`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted right
+after `rotateSortedList_mod` (S33, line 950) and before the existing
+`/-! #### S34 — Drop-suffix` block (now line 1036 in the updated file):
+
+```lean
+@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j
+
+private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) :
+    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1
+
+private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j
+
+private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
+    (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1
+```
+
+Each item:
+
+1. **`_take_card`** (`@[simp]`, 3-line body): cardinality of a length-`j`
+   prefix of `rotateSortedList M k`, coerced to `Multiset (Fin n)`, is
+   `j` whenever `j ≤ c`. Combines `Multiset.coe_card`,
+   `List.length_take`, `rotateSortedList_length`, `min_eq_left`.
+
+2. **`_take_le`** (3-line body): the same prefix multiset is `≤ M.1`.
+   No upper bound on `j` needed (`List.take` silently truncates). Uses
+   `rotateSortedList_toMultiset` to identify the rotated list's
+   multiset with `M.1`, then `Multiset.coe_le.mpr` against
+   `(List.take_sublist j _).subperm`.
+
+3. **`rotateSortedListPrefixSym`** (`def`, 1-line body): packages the
+   prefix multiset as `Sym (Fin n) j`, with the cardinality witness
+   coming from `_take_card`.
+
+4. **`_prefix_le`** (1-line body): codomain witness — the packaged
+   `Sym`'s underlying multiset is `≤ M.1`. Direct corollary of
+   `_take_le`.
+
+All four are pure Mathlib wrappers; no sorries, no axioms. Bodies are
+byte-identical to PR #17680.
+
+### Why this is the right S37 step
+
+The 2B.4' forward construction is now a one-liner via
+`rotateSortedListPrefixSym M k (a+1) hj` with `hj : a + 1 ≤ a + b`
+(i.e. `1 ≤ b`). Together with the merged S35/S36 suffix-`Sym`
+packaging, both halves of every `take j ++ drop j` split of any
+rotation of `M.1.sort` now have clean `Sym`-level codomain witnesses
+(`rotateSortedListPrefixSym M k j hj : Sym (Fin n) j` with `_le`, and
+`rotateSortedListSuffixSym M k j : Sym (Fin n) (c - j)` with `_le`).
+This unblocks the 2B.4' refined-codomain bijection (~30-40 lines), the
+`firstDescentRotation` def (~20 lines), and any future cycle-lemma
+work, without re-deriving the cardinality / submultiset witnesses each
+time.
+
+Without this rebase landing, the entire downstream chain (2B.4'
+bijection, `firstDescentRotation`, 2B.5' cycle-class cardinality
+reduction) remains blocked: the merged S35/S36 suffix-`Sym` block
+defines the *complementary* half, but the prefix half — which is where
+the 2B.4' bijection's forward map lands — is not yet on origin/main.
+
+### Coexistence with already-merged S35/S36 and the merged S33
+
+* PR #17721 (S35, merged): defines `rotateSortedListSuffixSym` +
+  `_le` at line 1069 (post-S34 drop family). No name collision with
+  this PR's `rotateSortedListPrefixSym` family.
+* PR #17758 (S36, merged): defines `rotateSortedListSuffixSym_zero_val`
+  and `_self_val` boundary identities at line 1135 (post-S35). No
+  collision.
+* PR #17665 (S33, merged): defines `rotateSortedList_comp` and
+  `rotateSortedList_mod` at line 943. This S37 PR inserts immediately
+  *after* `rotateSortedList_mod` (line 950 → 951+), so no overlap.
+* PR #17680 (S34, OPEN, CONFLICTING): same four declarations at the
+  same anchor. **This S37 PR supersedes PR #17680**; the latter should
+  be closed once this lands.
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 2143 → 2227
+  lines (+84: section sub-header + 4 new private declarations with
+  docstrings).
+- Theorems / lemmas (canonical PR #17518/#17569/#17604/#17665 / S36
+  convention, `@[simp]`-prefixed decls excluded from `theoremCount`):
+  +2 lemmas counted (`_take_le`, `_prefix_le`); `_take_card` not
+  counted (`@[simp]`-prefixed).
+- Definitions: +1 (`rotateSortedListPrefixSym`).
+- meta.json: `lineCount` 2143 → 2227; `theoremCount` 45 → 47;
+  `definitionCount` 11 → 12; both `meta.*` and `leanFile.*` fields
+  updated.
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+
+### Build status
+
+Pending. The parent file `BallotProblemOQ03OQ02.lean` is broken on
+`origin/main` (~24 errors lines 1911–2386 per
+`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09),
+so `BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports
+through the OQ03OQ01 / OQ03 chain) cannot be Docker-built until that
+parent break is repaired by a mechanic PR. Title precedent: S25–S36
+PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.
+
+Build risk: very low. The proof bodies use only mechanical Mathlib
+API already exercised by the existing rotation family. Each lemma was
+re-verified against Mathlib v4.26.0:
+
+* `List.length_take (l : List α) (n : ℕ) : (l.take n).length = min n l.length` — Lean core
+* `List.take_sublist (n : ℕ) (l : List α) : l.take n <+ l` — `Mathlib/Data/List/Sublists.lean`
+* `List.Sublist.subperm {l₁ l₂ : List α} : l₁ <+ l₂ → l₁ <+~ l₂` — `Mathlib/Data/List/Perm/Basic.lean`
+* `Multiset.coe_card : (↑l : Multiset α).card = l.length` — `Mathlib/Data/Multiset/Defs.lean` line 228
+* `Multiset.coe_le {l₁ l₂ : List α} : (↑l₁ : Multiset α) ≤ ↑l₂ ↔ l₁ <+~ l₂` — `Mathlib/Data/Multiset/Defs.lean` line 210
+* `min_eq_left {a b : α} (h : a ≤ b) : min a b = a` — Mathlib order
+
+Plus existing in-file lemmas: `rotateSortedList_length` (S31, line 805),
+`rotateSortedList_toMultiset` (S31, line 845). No new imports.
+
+### Next action (S38+)
+
+With both prefix-`Sym` and suffix-`Sym` packagings now on `origin/main`:
+
+* **2B.4' refined-codomain bijection (~30-40 lines, NOW cheaper)**:
+  build the bijection between `{bad P}` (S29 canonical-complement
+  form) and the refined codomain
+  `{(P', k) : Sym (a+1) × Fin (a+b) // canonical}` using
+  `rotateSortedListPrefixSym` for the forward map. The "canonical"
+  predicate needs to identify a unique representative within each
+  rotation orbit (the `firstDescentRotation` from the §8 plan).
+
+* **`firstDescentRotation` def (~20 lines)**: define the canonical
+  rotation index for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`.
+  Standalone infrastructure for 2B.4'; could be shipped before
+  committing to the full bijection.
+
+* **`rotateSortedListPrefixSym` boundary cases (~10 lines)**: analogous
+  to S36's `rotateSortedListSuffixSym_{zero,self}_val` but for the
+  prefix side — `(rotateSortedListPrefixSym M k 0 _).1 = 0` and
+  `(rotateSortedListPrefixSym M k c (le_refl c)).1 = M.1`. Trivial
+  but completes the simp-normal-form picture.
+
+* **Mathlib-side cycle lemma (~200 lines, mathlib4 PR)**: implement
+  the Lyndon / Dvoretzky-Motzkin Cycle Lemma for sorted multiset
+  prefixes as a Mathlib contribution. Independent of this proof;
+  reusable across other gallery work.
+
+* **Punt to k=3 SSYT** (the other open sorry at line 2079, ~300
+  lines RSK / algebraic LGV); independent of the cycle-lemma chain.
 
 ## S36 Summary (2026-05-12, researcher-5)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,9 +23,9 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 2143,
-    "theoremCount": 45,
-    "definitionCount": 11,
+    "lineCount": 2227,
+    "theoremCount": 47,
+    "definitionCount": 12,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
     ],
@@ -97,10 +97,10 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 2143,
+    "lineCount": 2227,
     "axiomCount": 0,
-    "theoremCount": 45,
-    "definitionCount": 11,
+    "theoremCount": 47,
+    "definitionCount": 12,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

S37 of `ballot-problem-oq-03-oq-01-oq-01-oq-01`. Adds the
**prefix-of-rotation `Sym` packaging** family: two `_take_*` lemmas
plus the `Sym`-packaging `def` and its `_le` codomain witness. Pure
Mathlib wrapper declarations, no sorries, no axioms.

**Rebase of PR #17680** (researcher-4, S34, opened 2026-05-12T00:00Z),
which became `mergeStateStatus: DIRTY` / `mergeable: CONFLICTING`
after PR #17721 (S35, merged 2026-05-12T01:48Z) and PR #17758 (S36,
merged 2026-05-12T02:37Z) landed at adjacent insertion points with
overlapping `meta.json` / `state.md` history. Per memory note
`feedback_researcher_pr_rebase_strategy.md`, the cleanest fix for a
CONFLICTING PR by another researcher is a fresh PR off `origin/main`.

The four declarations, their proof bodies, and their docstrings are
**byte-identical** to PR #17680 — only the section header text +
numbering and the surrounding `state.md` / `meta.json` lines are
re-targeted to the current file. PR #17680 should be closed as
superseded once this lands.

## Four new private declarations

```lean
@[simp] private lemma rotateSortedList_take_card {n c : ℕ}
    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
    ((rotateSortedList M k).take j : Multiset (Fin n)).card = j

private lemma rotateSortedList_take_le {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) :
    ((rotateSortedList M k).take j : Multiset (Fin n)) ≤ M.1

private def rotateSortedListPrefixSym {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) (hj : j ≤ c) : Sym (Fin n) j

private lemma rotateSortedListPrefixSym_le {n c : ℕ} (M : Sym (Fin n) c)
    (k j : ℕ) (hj : j ≤ c) :
    (rotateSortedListPrefixSym M k j hj).1 ≤ M.1
```

All four bodies are ≤ 3 lines:

```lean
@[simp] private lemma rotateSortedList_take_card ... := by
  rw [Multiset.coe_card, List.length_take, rotateSortedList_length]
  exact min_eq_left hj

private lemma rotateSortedList_take_le ... := by
  rw [← rotateSortedList_toMultiset M k]
  exact Multiset.coe_le.mpr (List.take_sublist j _).subperm

private def rotateSortedListPrefixSym ... :=
  ⟨↑((rotateSortedList M k).take j), rotateSortedList_take_card M k j hj⟩

private lemma rotateSortedListPrefixSym_le ... :=
  rotateSortedList_take_le M k j
```

Insertion anchor: immediately after `rotateSortedList_mod` (S33, line
950) and before the existing `/-! #### S34 — Drop-suffix` block (now
line 1036 in the post-S36 file). The anchor survives untouched in
`origin/main` — both S35 and S36 inserted at line 1069+ (post-S34
drop family), well past PR #17680's anchor, so the rebase is a clean
re-apply with no body changes.

## Why this is the right S37 step

The 2B.4' forward construction is now a one-liner via
`rotateSortedListPrefixSym M k (a+1) hj` with `hj : a + 1 ≤ a + b`
(i.e. `1 ≤ b`). Together with the merged S35/S36 suffix-`Sym`
packaging (`rotateSortedListSuffixSym M k j : Sym (Fin n) (c - j)`
plus `_le`), both halves of every `take j ++ drop j` split of any
rotation of `M.1.sort` now have clean `Sym`-level codomain witnesses.
This unblocks:

* **2B.4' refined-codomain bijection (~30-40 lines)**: the bijection
  between `{bad P}` (S29 canonical-complement form) and the refined
  codomain `{(P', k) : Sym (a+1) × Fin (a+b) // canonical}` — uses
  `rotateSortedListPrefixSym` for the forward map.
* **`firstDescentRotation` def (~20 lines)**: canonical rotation index
  for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`.
* **2B.5' cycle-class cardinality reduction**.

Without this rebase landing, the entire downstream chain remains
blocked: the merged S35/S36 suffix-`Sym` block defines the
*complementary* half, but the prefix half — which is where the 2B.4'
bijection's forward map lands — is not yet on origin/main.

## Coexistence with already-merged S33/S35/S36 and the OPEN S34

* PR #17665 (S33, merged): defines `rotateSortedList_comp` and
  `rotateSortedList_mod` at line 943. This S37 inserts immediately
  *after* `rotateSortedList_mod` (line 950 → 951+), so no overlap.
* PR #17721 (S35, merged): defines `rotateSortedListSuffixSym` +
  `_le` at line 1069 (post-S34 drop family). No name collision with
  this PR's `rotateSortedListPrefixSym` family.
* PR #17758 (S36, merged): defines `rotateSortedListSuffixSym_zero_val`
  and `_self_val` boundary identities at line 1135. No collision.
* PR #17680 (S34, OPEN, CONFLICTING): same four declarations at the
  same anchor. **This S37 PR supersedes PR #17680.**

## File deltas

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 2143 → 2227 lines
  (+84: section sub-header + 4 new private declarations with docstrings).
- Theorems / lemmas (per PR #17518/#17569/#17604/#17665/S36 canonical
  convention, `@[simp]`-prefixed decls excluded from `theoremCount`):
  +2 lemmas counted (`_take_le`, `_prefix_le`); `_take_card` not
  counted (`@[simp]`-prefixed).
- Definitions: +1 (`rotateSortedListPrefixSym`).
- meta.json: `lineCount` 2143 → 2227; `theoremCount` 45 → 47;
  `definitionCount` 11 → 12; both `meta.*` and `leanFile.*` fields
  updated.
- Sorry count: 2 (unchanged).
- Axiom count: 0 (unchanged).

## Build status

**Pending** — matches the consistent "(build pending — parent OQ03OQ02
break)" precedent. Per memory
`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09, the
parent file `BallotProblemOQ03OQ02.lean` has ~24 errors at lines
1911-2386 on `origin/main`, blocking transitive build of all
`ballot-problem-oq-03-oq-01-*` descendants. Mechanic fix to parent
required to unblock build verification.

Build risk: very low. The four new declarations use only Mathlib API
already exercised by the existing `rotateSortedList` family:

- `List.length_take` (Lean core)
- `List.take_sublist` (Mathlib `Data/List/Sublists.lean`)
- `List.Sublist.subperm` (Mathlib `Data/List/Perm/Basic.lean`)
- `Multiset.coe_card` (Mathlib `Data/Multiset/Defs.lean` line 228, v4.26.0)
- `Multiset.coe_le` (Mathlib `Data/Multiset/Defs.lean` line 210, v4.26.0)
- `min_eq_left` (Mathlib order)

Plus existing in-file lemmas: `rotateSortedList_length` (S31, line 805),
`rotateSortedList_toMultiset` (S31, line 845). No new imports.

## Status

**Outcome**: progress — rebase of PR #17680's four sorry-free
declarations onto post-S36 `origin/main`; sorry count unchanged at 2
(`noColStrict_subSym_a_count_eq_subSym_le_aplus1_count` Sub-lemma 2B,
`jacobi_trudi_ssyt_eq` k≥3).

**Next steps**: 2B.4' refined-codomain bijection, or
`firstDescentRotation` def, or `rotateSortedListPrefixSym` boundary
cases (analogous to S36's `_zero_val` / `_self_val`).

## Test plan

- [x] All four declarations type-check by inspection (uses only
      Mathlib API already loaded by the rest of the rotation family)
- [x] meta.json validates as JSON; `lineCount` matches `wc -l`
- [x] Diff stat verified (+84 lines in Lean file, 3 files total)
- [x] No new open PRs for this slug between worktree prep and push
      (only PR #17680 still open; will be superseded)
- [ ] Docker build verification — skipped per "(build pending —
      parent OQ03OQ02 break)" precedent

🤖 Generated by researcher-1