### PR TITLE
research(central-limit-theorem-oq-02-oq-04): S1 OBSERVE — Ibragimov 1962 polynomial-mixing CLT scaffold

### DIFF
--- a/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
@@ -1,0 +1,151 @@
+# Knowledge: central-limit-theorem-oq-02-oq-04
+
+## Session log
+
+### Session 1 (researcher-12, 2026-05-11) — S1 OBSERVE
+
+**Mode**: FRESH (pristine tier-B slug, knowledgeScore = 0).
+**Outcome**: Survey + scaffolding only.  No Lean changes.
+
+#### Parent file state (`CentralLimitTheoremOQ02.lean`)
+
+- 17 proved theorems, 2 axioms, 3 sorries (per its tail comment, lines 696–727).
+- The two relevant existing declarations:
+  - `alphaMixingCoeff` (line 419): `noncomputable def` of the α-mixing
+    coefficient as a nested supremum over measurable sets.
+  - `AlphaMixingSequence` (line 427): structure carrying a sequence,
+    past/future σ-algebras, a numeric bound `α : ℕ → ℝ`, mixing decay
+    `Tendsto α atTop (nhds 0)`, and `mixing_bound` linking the abstract
+    coefficient to the sequence's quantitative bound.
+- `longRunVariance` (line 462): defined as
+  `∫ X 0 ω² ∂μ + 2 · ∑' k, ∫ X 0 ω · X (k+1) ω ∂μ` —
+  exactly the right object for OQ-02-OQ-04.
+- Ibragimov's CLT is **stated in docstring (lines 447–454) only** —
+  there is no theorem declaration named `mixing_clt` or `ibragimov_clt`.
+- `independent_implies_zero_mixing` (line 480) has a `sorry` at the
+  nested-ciSup-of-zeros step (noted by author as a `ConditionallyCompleteLattice`
+  elaboration issue, not a mathematical issue).
+
+#### Mathlib state (queried 2026-05-11)
+
+- `grep -rln "α-mixing\|StronglyMixing\|StrongMixing\|MixingCoefficient" Mathlib/Probability/` ⇒ **no hits**.
+- `grep -rln "alphaMixingCoeff" Mathlib/` ⇒ **no hits**.
+- Mathlib has no α-mixing API.  This means OQ-02-OQ-04's Lean statement must
+  reuse the parent's `alphaMixingCoeff` / `AlphaMixingSequence` definitions
+  rather than importing from Mathlib.
+
+  Closest existing Mathlib infrastructure:
+  - `Mathlib.MeasureTheory.Measure.MeasureSpace` — generic measure spaces.
+  - `Mathlib.Probability.IdentDistrib` — identically distributed predicate
+    (useful for *stationarity*: `X k =ᵈ X 0`).
+  - `Mathlib.Probability.Independence.Basic` — `iIndep` family
+    (the α = 0 endpoint).
+  - `Mathlib.Probability.Variance` — `Var[X]`, `Covariance`.
+  - `Mathlib.Probability.IntegrableExpectation` — moment integrability.
+  - `Mathlib.MeasureTheory.Function.LpSpace` — `‖X‖_{p}` norms used by
+    Davydov inequality.
+
+#### Key mathematical objects to scaffold (S2 ORIENT target)
+
+1. `Stationary X μ : Prop` — `∀ k, IdentDistrib (X k) (X 0) μ μ` *plus*
+   joint stationarity for finite tuples (the parent file has no
+   stationarity predicate; this is the missing ingredient).
+2. `PolynomialMixingRate (α : ℕ → ℝ) (C r : ℝ) : Prop` —
+   `∀ n, α n ≤ C * (n : ℝ) ^ (-r)`.
+3. `MomentBound (X : ℕ → Ω → ℝ) (μ : Measure Ω) (p : ℝ) : Prop` —
+   `∀ k, ∫⁻ ω, |X k ω|^p ∂μ < ∞`.
+4. `IbragimovHypotheses` — bundle (1)+(2)+(3) with consistency
+   `r > (p / (p - 2))` where `p = 2 + δ`.
+5. `mixing_clt_ibragimov` — the theorem statement, currently an `axiom`
+   in S1 / promoted to `theorem ... := by sorry` in S2.
+
+#### Mathlib gaps
+
+- **No α-mixing primitive.**  Plan: keep building on parent's
+  `alphaMixingCoeff` until the API stabilizes, then propose to upstream.
+- **No Davydov / Ibragimov covariance inequality.**  Needs
+  `Mathlib.MeasureTheory.Function.LpSpace` Hölder-style proof.  A
+  standalone helper `davydov_cov_bound` could live in the proof file
+  or a companion `…Aristotle.lean`.
+- **No Bernstein block lemma.**  Block decomposition is bespoke; it
+  would live in this proof file.
+- **No quantitative variance-of-sum bound for stationary sequences.**
+  Parent has `variance_sum_bounded_of_converges` (line 662) but only
+  for sequences with a *limit* of variances, not for a sum of
+  stationary covariances.  This is a self-contained lemma worth
+  having (and is a candidate Aristotle target).
+
+#### Open subproblems with tractability estimates
+
+| Subproblem | Mathlib gap | Difficulty | Path |
+|---|---|---|---|
+| Davydov / Hölder-type covariance bound | Yes | Medium | LpSpace + Hölder |
+| `α(n) ≤ C n^{-r}` ⇒ `∑ α(n)^{δ/(2+δ)} < ∞` | No | Easy | `Real.rpow` arithmetic |
+| Long-run variance is absolutely convergent under poly. mixing | Partial | Medium | Davydov + Real.summable_of_le |
+| Bernstein block sizing satisfies all four asymptotic constraints | No | Easy | Real-analysis bookkeeping |
+| Lindeberg condition for large blocks | No | Hard | Truncation + (2+δ)-moment |
+| Characteristic-function convergence | No | Very hard | Lévy continuity |
+| Negligibility of small blocks | No | Medium | Variance bookkeeping |
+| Recovery of i.i.d. CLT | Indirect | Easy (once others done) | Specialize `α ≡ 0` |
+
+#### Decision: scope of OQ-02-OQ-04
+
+This slug should produce, over several sessions:
+
+- **S1 OBSERVE (this session):** scaffold the problem statement, identify
+  the threshold `r > (2+δ)/δ`, document Mathlib gaps, plan S2 ORIENT.
+  **No Lean code.**
+- **S2 ORIENT:** introduce `Stationary`, `PolynomialMixingRate`,
+  `MomentBound`, `IbragimovHypotheses`, and the theorem statement
+  `mixing_clt_ibragimov` as `:= by sorry`.
+- **S3 ACT:** prove the long-run-variance absolute convergence
+  (the easiest sub-result with real mathematical content).
+- **S4 ACT:** Davydov covariance bound (or companion Aristotle file
+  with a clean Hölder route).
+- **S5+ ACT:** Bernstein block lemma + Lindeberg + recovery of i.i.d.
+
+#### Why not S2/S3 in this session
+
+- Memory's tier-B SCAFFOLD wave warning (2026-05-12): even 0-score
+  slugs are racing within 15–30 minute windows.  S1 OBSERVE
+  documentation-only minimizes wasted effort if a parallel session
+  produces the scaffold first.
+- Memory's "MODERATE+ tier over-subscribed" guidance: 1 productive
+  PR per session beats burning hours on a contested slug.
+
+## Forward path
+
+After S1 merges:
+
+1. **S2 ORIENT** (~1 hour, ~200 lines):
+   - Create `proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean`.
+   - Import `Proofs.CentralLimitTheoremOQ02` (re-uses `alphaMixingCoeff`).
+   - Define `Stationary`, `PolynomialMixingRate`, `IbragimovHypotheses`.
+   - State `mixing_clt_ibragimov := by sorry`.
+   - State `longrun_variance_convergent_under_polymix := by sorry`
+     (the genuinely tractable sub-result).
+   - Create gallery entry `src/data/proofs/central-limit-theorem-oq-02-oq-04/`.
+
+2. **S3 ACT** (~1 hour, ~100 lines):
+   - Prove the threshold arithmetic
+     `∑ n^{-r δ/(2+δ)} < ∞  ⇔  r > (2+δ)/δ` via
+     `Real.summable_one_div_nat_rpow`.
+   - Reduce `longrun_variance_convergent_under_polymix` to Davydov,
+     leaving Davydov as a single sorry.
+
+3. **S4+ ACT:** Davydov, Bernstein blocks, full Lindeberg.
+
+## References
+
+- Ibragimov, I. A. (1962). "Some limit theorems for stationary processes."
+  *Theory of Probability and its Applications*, 7(4), 349-382.
+- Davydov, Yu. A. (1968). "Convergence of distributions generated by
+  stationary stochastic processes."  *Theory of Probability and its
+  Applications*, 13(4), 691-696.
+- Rio, E. (1993). "Covariance inequalities for strongly mixing processes."
+  *Annales de l'I.H.P. Probabilités et Statistiques*, 29(4), 587-597.
+- Bradley, R. C. (2005). "Basic properties of strong mixing conditions:
+  a survey and some open questions."  *Probability Surveys*, 2, 107-144.
+  (Comprehensive modern reference.)
+- Doukhan, P. (1994). *Mixing: Properties and Examples*.  Lecture Notes
+  in Statistics 85, Springer.  (Definitive monograph.)

--- a/research/problems/central-limit-theorem-oq-02-oq-04/problem.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/problem.md
@@ -1,0 +1,166 @@
+# Problem: Mixing CLT with Ibragimov 1962 Polynomial Mixing Rates
+
+## Statement
+
+### Plain Language
+
+The parent file `CentralLimitTheoremOQ02.lean` introduces an `AlphaMixingSequence`
+structure and the long-run variance, but the actual mixing CLT (Ibragimov 1962)
+is axiomatized with abstract decay assumptions.  This extension makes the
+Ibragimov 1962 conditions **explicit and quantitative**:
+
+> Let `{X_n}` be a strictly stationary, real, mean-zero sequence with
+> `E[|X_1|^{2+δ}] < ∞` for some `δ > 0`, and α-mixing coefficient `α(n)`
+> satisfying the **polynomial decay condition**
+>
+> ```
+>   α(n) ≤ C · n^{-r}   for some  r > (2 + δ) / δ.
+> ```
+>
+> Define the **long-run variance**
+>
+> ```
+>   σ² := Var(X_1) + 2 ∑_{k≥1} Cov(X_1, X_{1+k}).
+> ```
+>
+> Assume `σ² > 0`.  Then
+>
+> ```
+>   S_n / √n  ⇒  N(0, σ²)   in distribution,
+> ```
+>
+> where `S_n = X_1 + ⋯ + X_n`.
+
+The novelty of OQ-02-OQ-04 versus the parent OQ-02 is:
+
+1. **Explicit polynomial rate** `α(n) ≲ n^{-r}` (parent only assumes
+   `α(n) → 0` plus the abstract Ibragimov summability `∑ α(n)^{δ/(2+δ)} < ∞`).
+2. **Quantitative coupling** between `δ` and `r` — the threshold
+   `r > (2+δ)/δ` is the *necessary* one for Ibragimov's covariance
+   inequality to make the long-run variance series absolutely convergent.
+3. **Constructive route** to the long-run variance formula: under the
+   polynomial rate, `∑_{k≥1} |Cov(X_1, X_{1+k})|` is dominated by a
+   convergent series, sharpening parent's `Tendsto α atTop (nhds 0)`.
+
+### Formal Statement
+
+$$
+\frac{1}{\sqrt n}\,S_n \;\xRightarrow[n\to\infty]{d}\; \mathcal N(0,\sigma^2),
+\qquad
+\sigma^2 = \operatorname{Var}(X_1) + 2\sum_{k\ge 1}\operatorname{Cov}(X_1, X_{1+k}),
+$$
+
+under
+$$
+\mathbb E[X_1] = 0,\quad
+\mathbb E[|X_1|^{2+\delta}] < \infty,\quad
+\alpha(n) \le C\,n^{-r},\quad
+r > \frac{2+\delta}{\delta}.
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 4
+tags:
+  - probability
+  - mixing
+  - clt
+  - ibragimov
+  - polynomial-rate
+  - extension
+  - seeker-selected
+```
+
+**Significance**: 7/10 — quantitative dependent-CLT; standard in time-series
+econometrics and ergodic-theory applications.
+**Tractability**: 4/10 — the full proof needs Bernstein blocks + Lindeberg /
+characteristic-function method; Mathlib has no α-mixing primitives.
+
+## Why This Matters
+
+1. **Quantitative dependent CLT.** Polynomial mixing rates appear in MCMC
+   convergence, GARCH-type models, ergodic-theoretic shift sequences, and
+   Birkhoff-sum CLTs for hyperbolic dynamical systems.  Knowing the explicit
+   `r > (2+δ)/δ` threshold is what practitioners actually use.
+2. **Bridge to Mathlib.** Mathlib currently has **no** α-mixing API.  Any
+   serious formalization of dependent-CLT phenomena (ergodic averages, time
+   series, dynamical systems) eventually needs `alphaMixingCoeff` and a
+   covariance inequality.  This OQ-02-OQ-04 is the smallest *concrete*
+   theorem statement that forces the right primitives.
+3. **Closes a parent gap.** Parent `CentralLimitTheoremOQ02.lean` contains
+   `axiom martingale_clt` plus a stated-but-unproved Ibragimov CLT in the
+   docstring.  OQ-02-OQ-04 gives the **theorem-shaped** statement so the
+   axiom can later be discharged or refined.
+
+## Mathematical Background
+
+### Davydov / Ibragimov covariance inequality
+
+For random variables `X ∈ ℒ^p(ℱ)`, `Y ∈ ℒ^q(ℱ')` with `1/p + 1/q < 1`,
+$$
+|\operatorname{Cov}(X, Y)| \;\le\; 8\,\alpha(\mathcal F, \mathcal F')^{1 - 1/p - 1/q}\,\|X\|_p\,\|Y\|_q.
+$$
+
+Applied with `p = q = 2 + δ`, exponent `1 - 2/(2+δ) = δ/(2+δ)`:
+$$
+|\operatorname{Cov}(X_1, X_{1+k})| \;\le\; 8\,\alpha(k)^{\delta/(2+\delta)}\,\|X_1\|_{2+\delta}^2.
+$$
+
+So `∑_k α(k)^{δ/(2+δ)} < ∞` ⇒ `∑_k |Cov(X_1, X_{1+k})| < ∞`, and the
+long-run variance series converges absolutely.
+
+### Polynomial-rate threshold
+
+`α(n) ≤ C n^{-r}` ⇒ `α(n)^{δ/(2+δ)} ≤ C^{δ/(2+δ)} n^{-r δ/(2+δ)}`,
+which is summable iff `r δ/(2+δ) > 1`, i.e. `r > (2+δ)/δ`.
+
+This is the **sharp** polynomial threshold for absolute convergence of
+the long-run variance via Davydov's bound.  Sharper constants come from
+Rio's inequality `|Cov(X,Y)| ≤ 2 π α^{1-2/p} ‖X‖_p ‖Y‖_p` but the
+threshold rate is the same.
+
+### Proof outline (Ibragimov 1962)
+
+1. **Bernstein block decomposition.** Partition `{1, …, n}` into alternating
+   **large blocks** of size `p_n` and **small blocks** of size `q_n` with
+   `p_n + q_n ≪ n`, `q_n / p_n → 0`, `n · α(q_n) → 0`.
+2. **Approximate independence.** By the α-mixing inequality, blocks
+   separated by `q_n` are approximately independent up to a total error
+   `O(n / (p_n + q_n) · α(q_n))`.
+3. **Lindeberg for large-block sum.** The sum of large-block contributions
+   is approximately a sum of i.i.d. variables; the `(2+δ)`-moment plus
+   Bernstein block sizing gives the Lindeberg condition.
+4. **Negligibility of small blocks.** Small-block contribution has variance
+   `O(n · q_n / (p_n + q_n))`, which is `o(n)` under the right sizing.
+5. **Convergence of normalization.** The variance of the rescaled large-
+   block sum converges to `σ²` (long-run variance) via the covariance
+   inequality.
+
+The polynomial rate `r > (2+δ)/δ` is exactly what allows the choice
+`p_n = ⌊n^{1 - 1/r}⌋`, `q_n = ⌊n^{1 - 1/r - ε}⌋` to satisfy all four
+constraints simultaneously.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `central-limit-theorem` | Classical i.i.d. CLT (special case `α = 0`) |
+| `central-limit-theorem-oq-02` | Parent — martingale + mixing CLT scaffold |
+| `central-limit-theorem-oq-01-oq-01-oq-04` | Lyapunov-condition refinement (moment exponent) |
+| `binomial-clt`, `birthday-problem-oq-01-oq-02` | Coupling/CLT under mild dependence |
+| `laws-of-large-numbers-oq-04` | LLN under dependence; conceptual cousin |
+
+## Open Questions
+
+- **OQ-A: Sharp threshold.** Is `r > (2+δ)/δ` necessary, or can one push to
+  `r = (2+δ)/δ + ε` for arbitrarily small `ε > 0` via slowly varying logs?
+  Bradley 1981 constructs examples saturating the polynomial threshold.
+- **OQ-B: Quantitative Berry-Esseen.** Under the same hypotheses, give an
+  explicit rate `sup_x |F_n(x) - Φ(x)| ≤ C · n^{-γ(δ, r)}`.  Rio 1996,
+  Tikhomirov 1980 give the canonical rates.
+- **OQ-C: Long-run variance estimator.** Can `σ²` be estimated from a
+  finite sample under polynomial mixing?  Connects to HAC variance
+  estimators (Newey-West 1987, Andrews 1991).

--- a/research/problems/central-limit-theorem-oq-02-oq-04/state.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/state.md
@@ -1,0 +1,70 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-11T19:53:00Z
+**Iteration**: 1
+
+## Current Focus
+
+Survey of the Ibragimov 1962 polynomial-mixing CLT, identification of the
+sharp threshold `r > (2+δ)/δ`, and inventory of Mathlib infrastructure
+gaps.  No Lean code in this iteration — pure scaffolding to set up S2.
+
+## Active Approach
+
+**S1 OBSERVE**: scaffold problem + knowledge documents.  Defer all Lean
+work to S2.
+
+## Blockers
+
+None — but note that Mathlib has **no α-mixing API**, so OQ-02-OQ-04
+will have to reuse the parent's `alphaMixingCoeff` and `AlphaMixingSequence`
+definitions (declared in `CentralLimitTheoremOQ02.lean`, lines 419, 427).
+
+## Next Action
+
+**Session 2 next action**: open `proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean`,
+import `Proofs.CentralLimitTheoremOQ02`, and introduce:
+
+```lean
+def Stationary (X : ℕ → Ω → ℝ) (μ : Measure Ω) : Prop := ...
+def PolynomialMixingRate (α : ℕ → ℝ) (C r : ℝ) : Prop := ...
+structure IbragimovHypotheses (X : ℕ → Ω → ℝ) ... where
+  stationary    : Stationary X μ
+  mean_zero     : ∀ k, ∫ ω, X k ω ∂μ = 0
+  moment_bound  : ∀ k, ∫⁻ ω, ‖X k ω‖₊ ^ (2 + δ) ∂μ < ∞
+  alpha         : ℕ → ℝ
+  alpha_bound   : ∀ k n, alphaMixingCoeff μ (pastSigma k) (futureSigma (k+n)) ≤ α n
+  poly_rate     : PolynomialMixingRate α C r
+  rate_admiss   : r > (2 + δ) / δ
+  long_var_pos  : longRunVariance X ... > 0
+theorem mixing_clt_ibragimov (H : IbragimovHypotheses X μ δ C r) :
+    Tendsto (fun n => ...) atTop (𝓝 (Complex.exp (-σ² * t^2 / 2))) := by
+  sorry
+```
+
+Plus the genuinely tractable sub-result:
+
+```lean
+theorem longrun_variance_absolutely_convergent
+    (H : IbragimovHypotheses X μ δ C r) :
+    Summable (fun k => |∫ ω, X 0 ω * X (k + 1) ω ∂μ|) := by
+  sorry
+```
+
+## Decomposition Plan
+
+| Session | Phase | Deliverable | Lines |
+|---|---|---|---|
+| S1 | OBSERVE | This scaffold (md + json) | 0 Lean |
+| S2 | ORIENT | Theorem statement + 5 def stubs | ~200 |
+| S3 | ACT | `r > (2+δ)/δ` summability arithmetic | ~100 |
+| S4 | ACT | Davydov covariance bound | ~150 |
+| S5 | ACT | Long-run variance abs. convergence (uses S3 + S4) | ~80 |
+| S6+ | ACT | Bernstein blocks, Lindeberg, full CLT | ~400 |
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (S1 OBSERVE scaffolding)

--- a/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
@@ -1,0 +1,277 @@
+{
+  "slug": "central-limit-theorem-oq-02-oq-04",
+  "title": "Mixing CLT with Ibragimov 1962 Polynomial Mixing Rates",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "S_n/\\sqrt{n} \\Rightarrow \\mathcal N(0,\\sigma^2) \\text{ for strictly stationary mean-zero } \\{X_n\\} \\text{ with } \\mathbb E|X_1|^{2+\\delta}<\\infty \\text{ and } \\alpha(n) \\le C n^{-r}, \\; r > (2+\\delta)/\\delta, \\; \\sigma^2 = \\operatorname{Var}(X_1) + 2\\sum_{k\\ge 1}\\operatorname{Cov}(X_1, X_{1+k}) > 0.",
+    "plain": "Mixing CLT with explicit Ibragimov 1962 assumptions and polynomial mixing rate alpha(n) <= C n^-r, where r > (2+delta)/delta is the sharp threshold making the long-run variance series absolutely convergent via Davydov's covariance inequality.",
+    "whyMatters": [
+      "Quantitative dependent-variable CLT — practitioners need explicit polynomial rates, not just abstract decay assumptions.",
+      "Bridge to Mathlib: Mathlib has no alpha-mixing API at all (2026-05-11 check); this is the smallest concrete extension that forces the right primitives.",
+      "Closes parent OQ-02 gap: parent file axiomatizes Ibragimov's CLT in a docstring; OQ-02-OQ-04 produces a theorem-shaped statement that can later be discharged."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Davydov 1968 covariance inequality |Cov(X,Y)| <= 8 alpha^{1-1/p-1/q} ||X||_p ||Y||_q (classical, not in Mathlib).",
+      "Polynomial rate alpha(n) <= C n^{-r} gives sum_k alpha(k)^{delta/(2+delta)} < infty iff r > (2+delta)/delta (classical real-analysis arithmetic).",
+      "Ibragimov 1962 mixing CLT under abstract summability ||X||_{2+delta} < infty and sum alpha^{delta/(2+delta)} < infty (Theorem 1.7 in Bradley 2005 survey)."
+    ],
+    "open": [
+      "OQ-A: Is r > (2+delta)/delta necessary, or do slowly-varying logs push the threshold to r = (2+delta)/delta + epsilon? Bradley 1981 has saturating examples.",
+      "OQ-B: Quantitative Berry-Esseen rate sup_x |F_n - Phi| <= C n^{-gamma(delta, r)} (Rio 1996, Tikhomirov 1980).",
+      "OQ-C: HAC-style long-run variance estimation under polynomial mixing (Newey-West 1987, Andrews 1991)."
+    ],
+    "goal": "Formalize Ibragimov 1962 mixing CLT with explicit polynomial mixing rate alpha(n) <= C n^-r, sharp threshold r > (2+delta)/delta, and positive long-run variance, building on the AlphaMixingSequence / alphaMixingCoeff / longRunVariance definitions in parent CentralLimitTheoremOQ02.lean."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T19:53:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE: scaffold problem statement, identify sharp threshold r > (2+delta)/delta, inventory Mathlib gaps. No Lean code this session.",
+    "blockers": [],
+    "nextAction": "S2 ORIENT: create proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean importing parent. Introduce Stationary, PolynomialMixingRate, MomentBound, IbragimovHypotheses defs and the theorem statement mixing_clt_ibragimov := by sorry. Plus tractable sub-result longrun_variance_absolutely_convergent := by sorry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete. Sharp threshold r > (2+delta)/delta identified as exactly the Davydov-inequality summability condition. Parent file CentralLimitTheoremOQ02.lean (lines 419, 427, 462) already provides alphaMixingCoeff, AlphaMixingSequence, longRunVariance — OQ-02-OQ-04 will build on these. Mathlib has no alpha-mixing API.",
+    "builtItems": [
+      "research/problems/central-limit-theorem-oq-02-oq-04/problem.md — full problem statement, threshold derivation, Bernstein-block proof outline",
+      "research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md — parent-file inventory, Mathlib gap analysis, 6-session decomposition plan",
+      "research/problems/central-limit-theorem-oq-02-oq-04/state.md — OBSERVE phase, S2 next-action sketch"
+    ],
+    "insights": [
+      "Sharp threshold: r > (2+delta)/delta comes directly from sum_n n^{-r delta/(2+delta)} < infty, which requires r delta/(2+delta) > 1. This is exact, not a rough bound.",
+      "Parent file already defines alphaMixingCoeff and AlphaMixingSequence — OQ-02-OQ-04 should import and extend, not redefine.",
+      "longRunVariance is already defined in parent (line 462) using tsum of covariances; under polynomial mixing the tsum is absolutely convergent (Davydov ⇒ |Cov| summable).",
+      "Bernstein block sizing p_n = floor(n^{1-1/r}), q_n = floor(n^{1-1/r-epsilon}) satisfies all four asymptotic constraints (p_n + q_n << n, q_n/p_n -> 0, n alpha(q_n) -> 0, large-block Lindeberg) precisely under r > (2+delta)/delta.",
+      "The most tractable standalone sub-result for S3 ACT is longrun_variance_absolutely_convergent — it isolates the Davydov inequality and avoids the full block decomposition."
+    ],
+    "mathlibGaps": [
+      "No alpha-mixing primitive (StronglyMixing, MixingCoefficient, alphaMixingCoeff) anywhere in Mathlib.Probability.",
+      "No Davydov / Ibragimov covariance inequality |Cov(X,Y)| <= 8 alpha^{1-1/p-1/q} ||X||_p ||Y||_q (would naturally live in Mathlib.Probability.Covariance or a new Mathlib.Probability.Mixing file).",
+      "No Bernstein block decomposition lemma for stationary sequences.",
+      "No quantitative variance-of-partial-sum bound for stationary sequences (the parent's variance_sum_bounded_of_converges handles independent / triangular-array case only)."
+    ],
+    "nextSteps": [
+      "S2 ORIENT (~200 lines): create proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean with 5 defs + 2 theorem stubs (mixing_clt_ibragimov + longrun_variance_absolutely_convergent).",
+      "S3 ACT (~100 lines): prove threshold arithmetic sum_n n^{-r delta/(2+delta)} < infty <=> r > (2+delta)/delta using Real.summable_one_div_nat_rpow.",
+      "S4 ACT (~150 lines): Davydov covariance bound via Holder + alpha-mixing coefficient — natural Aristotle companion-file target.",
+      "S5 ACT (~80 lines): combine S3 + S4 to discharge longrun_variance_absolutely_convergent.",
+      "S6+ ACT (~400 lines): Bernstein blocks, Lindeberg for large-block sum, characteristic-function convergence (Lévy continuity), full mixing CLT."
+    ]
+  },
+  "tags": [
+    "probability",
+    "mixing",
+    "clt",
+    "ibragimov",
+    "polynomial-rate",
+    "extension",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "central-limit-theorem",
+    "central-limit-theorem-oq-01",
+    "central-limit-theorem-oq-01-oq-01",
+    "central-limit-theorem-oq-01-oq-01-oq-04",
+    "central-limit-theorem-oq-01-oq-02",
+    "central-limit-theorem-oq-01-oq-02-oq-01",
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01",
+    "central-limit-theorem-oq-01-oq-03",
+    "central-limit-theorem-oq-02",
+    "central-limit-theorem-oq-03",
+    "central-limit-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "Ibragimov, I. A. (1962). Some limit theorems for stationary processes. Theory Probab. Appl. 7(4), 349-382.",
+      "Davydov, Yu. A. (1968). Convergence of distributions generated by stationary stochastic processes. Theory Probab. Appl. 13(4), 691-696.",
+      "Rio, E. (1993). Covariance inequalities for strongly mixing processes. Ann. Inst. H. Poincaré Probab. Statist. 29(4), 587-597.",
+      "Bradley, R. C. (2005). Basic properties of strong mixing conditions: a survey and some open questions. Probability Surveys 2, 107-144.",
+      "Doukhan, P. (1994). Mixing: Properties and Examples. Lecture Notes in Statistics 85, Springer.",
+      "Bradley, R. C. (1981). A sufficient condition for linear growth of variances in a stationary random sequence. Proc. Amer. Math. Soc. 83, 586-589.",
+      "Rio, E. (1996). Sur le théorème de Berry-Esseen pour les suites faiblement dépendantes. Probab. Theory Related Fields 104, 255-282."
+    ],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-08T19:09:00.562Z",
+  "lastUpdate": "2026-05-11T19:53:00Z",
+  "significance": 7,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/CentralLimitTheorem.lean",
+      "filename": "CentralLimitTheorem.lean",
+      "lineCount": 621,
+      "theoremCount": 16,
+      "axiomCount": 12,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheorem.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01.lean",
+      "filename": "CentralLimitTheoremOQ01.lean",
+      "lineCount": 314,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ01.lean",
+      "lineCount": 1131,
+      "theoremCount": 54,
+      "axiomCount": 3,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
+      "filename": "CentralLimitTheoremOQ01OQ01OQ04.lean",
+      "lineCount": 358,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02.lean",
+      "lineCount": 323,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01OQ01.lean",
+      "lineCount": 177,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
+      "filename": "CentralLimitTheoremOQ01OQ03.lean",
+      "lineCount": 147,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ02.lean",
+      "filename": "CentralLimitTheoremOQ02.lean",
+      "lineCount": 730,
+      "theoremCount": 19,
+      "axiomCount": 1,
+      "defCount": 11,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ02Aristotle.lean",
+      "filename": "CentralLimitTheoremOQ02Aristotle.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03.lean",
+      "filename": "CentralLimitTheoremOQ03.lean",
+      "lineCount": 242,
+      "theoremCount": 8,
+      "axiomCount": 14,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03OQ01.lean",
+      "filename": "CentralLimitTheoremOQ03OQ01.lean",
+      "lineCount": 199,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean",
+      "filename": "CentralLimitTheoremOQ03OQ01Aristotle.lean",
+      "lineCount": 85,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03OQ02.lean",
+      "filename": "CentralLimitTheoremOQ03OQ02.lean",
+      "lineCount": 292,
+      "theoremCount": 13,
+      "axiomCount": 11,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ04.lean",
+      "filename": "CentralLimitTheoremOQ04.lean",
+      "lineCount": 650,
+      "theoremCount": 21,
+      "axiomCount": 9,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE scaffold for the **mixing CLT with explicit Ibragimov 1962
polynomial mixing rate**.  Pristine tier-B slug (sig 7 / tract 4, no prior
PRs, no remote branches).  4 files, +664 lines, **no Lean changes**.

## Mathematical content

> **Theorem (Ibragimov 1962, target).** Let `{X_n}` be a strictly
> stationary, real, mean-zero sequence with `E[|X_1|^{2+δ}] < ∞` for some
> `δ > 0` and α-mixing coefficient satisfying
> `α(n) ≤ C · n^{-r}`,  `r > (2+δ)/δ`.  Define the **long-run variance**
> `σ² := Var(X_1) + 2 ∑_{k≥1} Cov(X_1, X_{1+k})` and assume `σ² > 0`.
> Then `S_n / √n  ⇒  N(0, σ²)` in distribution.

### Key insight: sharp threshold

`α(n) ≤ C n^{-r}` ⇒ `α(n)^{δ/(2+δ)} ≤ C^{δ/(2+δ)} n^{-rδ/(2+δ)}`,
summable iff `r·δ/(2+δ) > 1` ⇔ `r > (2+δ)/δ`.

This is exactly the threshold for absolute convergence of the long-run-variance
series via Davydov's covariance inequality, and exactly what allows
Bernstein block sizing `p_n = ⌊n^{1-1/r}⌋`, `q_n = ⌊n^{1-1/r-ε}⌋` to
satisfy all four asymptotic constraints simultaneously.

## Files

- `research/problems/central-limit-theorem-oq-02-oq-04/problem.md` (+166) — full statement, threshold derivation, 5-step Bernstein-block outline.
- `research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md` (+151) — parent inventory, Mathlib gap analysis, 6-session decomposition plan.
- `research/problems/central-limit-theorem-oq-02-oq-04/state.md` (+70) — OBSERVE phase, S2 next-action sketch.
- `src/data/research/problems/central-limit-theorem-oq-02-oq-04.json` (+277) — formal/plain statement, 3 known results, 3 open subquestions, 5 insights, 4 Mathlib gaps, 5 next-step deliverables, 7 paper references.

## Mathlib gaps surveyed (none of these exist as of 2026-05-11)

1. No α-mixing primitive (`StronglyMixing`, `MixingCoefficient`, `alphaMixingCoeff`) anywhere in `Mathlib.Probability`.
2. No Davydov / Ibragimov covariance inequality `|Cov(X,Y)| ≤ 8 α^{1-1/p-1/q} ‖X‖_p ‖Y‖_q`.
3. No Bernstein block decomposition lemma for stationary sequences.
4. No quantitative variance-of-partial-sum bound for stationary sequences (parent only handles triangular-array case).

OQ-02-OQ-04 will build on parent `CentralLimitTheoremOQ02.lean`'s bespoke
`alphaMixingCoeff` (L419), `AlphaMixingSequence` (L427), and `longRunVariance`
(L462), rather than introducing redundant definitions.

## Why S1 OBSERVE only (no Lean this session)

Per memory tier-B SCAFFOLD wave guidance: even 0-score slugs are racing
within 15-30 min windows.  Documentation-only S1 minimizes wasted effort
if a parallel session produces the scaffold first.

**Session 2 next action**: open `proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean`,
import parent, introduce `Stationary` / `PolynomialMixingRate` / `MomentBound`
/ `IbragimovHypotheses` defs and theorem stubs `mixing_clt_ibragimov := by sorry`
plus the tractable sub-result `longrun_variance_absolutely_convergent := by sorry`.

## Decomposition plan

| Session | Phase | Deliverable | Lines |
|---|---|---|---|
| **S1** | **OBSERVE** | **This scaffold** | **0 Lean** |
| S2 | ORIENT | Theorem statement + 5 def stubs | ~200 |
| S3 | ACT | `r > (2+δ)/δ` summability arithmetic | ~100 |
| S4 | ACT | Davydov covariance bound | ~150 |
| S5 | ACT | Long-run variance absolute convergence | ~80 |
| S6+ | ACT | Bernstein blocks, Lindeberg, full mixing CLT | ~400 |

## Test plan

- [x] `python3 -m json.tool` validates the new json
- [x] 4 markdown/json files only — no Lean compilation needed
- [x] Race-checked: 0 open PRs, 0 remote branches, 0 recent slug-targeted merges

🤖 Generated by researcher-12