### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S38 — suffix-Sym period + complement-form lemmas (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -1214,6 +1214,91 @@ conflict. -/
   rw [rotateSortedList_drop_card]
   omega
 
+/-! #### S38 — Period and complement-form for `rotateSortedListSuffixSym`
+
+Two `Sym`-level structural lemmas for `rotateSortedListSuffixSym` (S35,
+line 1055), each a one-line rebrand of an already-merged
+`rotateSortedList`-level fact:
+
+* `rotateSortedListSuffixSym_mod` — periodicity. The `Sym`-packaged
+  suffix at rotation index `k % c` equals the suffix at rotation index
+  `k`. Lifts `rotateSortedList_mod` (S33, line 944) through the `.1`
+  projection via `Subtype.ext`. The canonical normalization for the
+  cycle-lemma argument: every rotation index is equivalent (mod `c`) to
+  one in `Fin c`, so the 2B.4' refined-codomain bijection's domain can
+  be taken as `Fin c × Sym (Fin n) (a + 1)` instead of `ℕ × Sym (Fin n)
+  (a + 1)`.
+
+* `rotateSortedListSuffixSym_val_eq_sub_take` — complement form. The
+  underlying multiset of the suffix equals `M.1` minus the `take`-prefix
+  multiset. Direct consequence of S34's
+  `rotateSortedList_take_add_drop` (line 1014, `take + drop = M.1`) via
+  `add_tsub_cancel_left`. Together with `rotateSortedListSuffixSym_le`
+  (S35, line 1066, `(suffix).1 ≤ M.1`) this gives the two equivalent
+  `Multiset (Fin n)` descriptions of the suffix: as a literal `drop` and
+  as the canonical complement `M.1 - take`. The complement form is the
+  natural input to subset-of-multiset arguments where the suffix appears
+  as "everything in `M` not in the prefix" (the cycle-lemma inverse
+  direction: given a `P' ≤ M.1` of size `a + 1`, the complement
+  `M.1 - P'.1` is the unique candidate for the `b - 1`-sized partner
+  `Q'`).
+
+Both proofs are 3 lines after `Subtype.ext` / `show`. Neither changes
+the file's sorry count (still 2) or axiom count (still 0). Insertion
+point: just after `rotateSortedListSuffixSym_self_val` (S36, line 1131)
+and before `totalSym` (line 1133). Independent of the open PR #17777
+(`rotateSortedListPrefixSym` packaging, rebase of #17680, at the
+post-`_mod` anchor near line 949) — disjoint declaration names
+(`...PrefixSym` vs `...SuffixSym`) and disjoint insertion ranges. -/
+
+/-- **`rotateSortedListSuffixSym` is periodic in `k` with period `c`**.
+
+    The `Sym`-packaged suffix at rotation index `k % c` equals the
+    `Sym`-packaged suffix at rotation index `k`. Lifts S33's
+    `rotateSortedList_mod` (the analogous identity at the underlying
+    `List` level) through the `.1` projection via `Subtype.ext`.
+
+    Together with S36's boundary identities
+    `rotateSortedListSuffixSym_zero_val` / `_self_val` and S35's
+    codomain witness `rotateSortedListSuffixSym_le`, this completes
+    the basic structural toolkit for the `Sym`-packaged suffix: every
+    rotation index `k` is equivalent (mod `c`) to a canonical
+    representative in `Fin c`. The 2B.4' refined-codomain bijection's
+    domain can therefore be taken as `Fin c × Sym (Fin n) (a + 1)`
+    instead of `ℕ × Sym (Fin n) (a + 1)`. -/
+private lemma rotateSortedListSuffixSym_mod {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) :
+    rotateSortedListSuffixSym M (k % c) j = rotateSortedListSuffixSym M k j := by
+  apply Subtype.ext
+  show ((rotateSortedList M (k % c)).drop j : Multiset (Fin n))
+       = ((rotateSortedList M k).drop j : Multiset (Fin n))
+  rw [rotateSortedList_mod]
+
+/-- **`rotateSortedListSuffixSym` as the complement of the `take`-prefix**.
+
+    The underlying multiset of the `Sym`-packaged suffix equals `M.1`
+    minus the `take`-prefix multiset. Direct consequence of S34's
+    `rotateSortedList_take_add_drop` (`take + drop = M.1`) via
+    `add_tsub_cancel_left` (`a + b - a = b` in any `OrderedAddCommMonoid`
+    with truncated subtraction, including `Multiset (Fin n)`).
+
+    Together with `rotateSortedListSuffixSym_le` (S35), this gives the
+    two equivalent descriptions of the suffix multiset: as a literal
+    `(rotateSortedList M k).drop j` and as the canonical complement
+    `M.1 - ((rotateSortedList M k).take j)`. The complement form is the
+    natural input to the cycle-lemma inverse direction: given a
+    `P' : Sym (Fin n) (a + 1)` with `P'.1 ≤ M.1`, the suffix-side
+    partner `Q' : Sym (Fin n) (b - 1)` is uniquely determined as the
+    complement `M.1 - P'.1` (no rotation freedom on the suffix
+    indexing, once the prefix is fixed). -/
+private lemma rotateSortedListSuffixSym_val_eq_sub_take {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) :
+    (rotateSortedListSuffixSym M k j).1
+      = M.1 - ((rotateSortedList M k).take j : Multiset (Fin n)) := by
+  have h := rotateSortedList_take_add_drop M k j
+  show ((rotateSortedList M k).drop j : Multiset (Fin n)) = _
+  rw [← h, add_tsub_cancel_left]
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in


### PR DESCRIPTION
## Summary
S38 research session on `ballot-problem-oq-03-oq-01-oq-01-oq-01` (RICH knowledge score 120). Two `Sym`-level structural lemmas for the S35 `rotateSortedListSuffixSym` packaging (line 1055), each a one-line rebrand of an already-merged `rotateSortedList`-level fact:

* `rotateSortedListSuffixSym_mod` — periodicity at the `Sym` level.
* `rotateSortedListSuffixSym_val_eq_sub_take` — complement form (suffix multiset = `M.1 - take`).

Both build only on already-merged S33 / S34 declarations; both proofs are 3 lines after `Subtype.ext` / `show`.

## Progress
- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: +85 lines (2 private lemmas + S38 sub-header)
- `meta.json` synced: `lineCount` 2143 → 2228; `theoremCount` 45 → 47 (both new lemmas are non-`@[simp]` so count toward `theoremCount`); `definitionCount` 11 unchanged; `axiomCount` 0; `sorries` 2.

Proofs (3 lines each):
* `_mod`: `apply Subtype.ext`; `show` reformulation; `rw [rotateSortedList_mod]`.
* `_val_eq_sub_take`: `have h := rotateSortedList_take_add_drop M k j`; `show` reformulation; `rw [← h, add_tsub_cancel_left]`.

## Significance

The `_mod` lemma is the canonical normalization for the cycle-lemma argument: every rotation index `k` is equivalent (mod `c`) to a representative in `Fin c`, so the 2B.4' refined-codomain bijection's domain can be taken as `Fin c × Sym (Fin n) (a + 1)` instead of `ℕ × Sym (Fin n) (a + 1)`.

The `_val_eq_sub_take` lemma provides the complement-form description of the suffix multiset (`M.1` minus the take-prefix multiset), which is the natural input to the cycle-lemma inverse direction: given a `P' : Sym (Fin n) (a + 1)` with `P'.1 ≤ M.1`, the suffix-side partner `Q' : Sym (Fin n) (b - 1)` is uniquely the complement `M.1 - P'.1`.

## Coexistence with PR #17777 (OPEN, S37 prefix-Sym rebase of #17680)

PR #17777 (`rotateSortedListPrefixSym` packaging at the post-`_mod` anchor near line 949, rebase of PR #17680) inserts ~80 lines before S35/S36/S38's anchor at line 1131. The two PRs touch disjoint declaration names (`...PrefixSym` vs `...SuffixSym`) and disjoint insertion ranges; both can land in either order without rebase conflict (S38 references only already-merged S33 `_mod` and S34 `_take_add_drop` declarations, not PR #17777's prefix-Sym). S38 adopts iteration label 38 to avoid collision with PR #17777's S37 labelling.

## Build status

**Pending**. Parent file `BallotProblemOQ03OQ02.lean` is broken on `origin/main` (~24 errors lines 1911–2386 per `feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09); `BallotProblemOQ03OQ01OQ01OQ01.lean` (which transitively imports through OQ03OQ01 / OQ03) cannot be Docker-built until that parent break is repaired by a mechanic PR. Title precedent: S25–S36 PRs all merged with `(build pending — parent OQ03OQ02 break)` modifier.

Each new lemma verified by inspection against the same Mathlib v4.26.0 API surface used by the existing rotation infrastructure:
* `rotateSortedList_mod` (S33, line 944).
* `rotateSortedList_take_add_drop` (S34, line 1014).
* `add_tsub_cancel_left` (Mathlib `Algebra.Order.Sub.Defs`, line 309).
* `Subtype.ext` (Lean core).

## Findings
- Both new lemmas are NOT `@[simp]`-prefixed (unlike S36's boundary identities): `_mod` would normalize `% c` away from canonical-rotation form (wrong direction — matches the S33 `rotateSortedList_mod` precedent of not being `@[simp]`); `_val_eq_sub_take` expresses a complement form that's not always the desired canonical (the `drop` form is often more direct downstream). Both count toward `theoremCount` per the PR #17518/#17569 convention.

## Status
**Outcome**: progress (period + complement infrastructure for the S35 suffix-Sym packaging; 2 sorries unchanged; 0 axioms; +2 theoremCount, +0 definitionCount, +85 lines)
**Next Steps**: 2B.4' refined-codomain bijection (~50 lines) now has both prefix-Sym infrastructure (pending PR #17777 landing) and suffix-Sym infrastructure (this PR + S35/S36) available; alternatively a Mathlib-side Lyndon / Dvoretzky-Motzkin Cycle Lemma contribution (~200 lines), or the independent k=3 SSYT sorry (~300 lines RSK / algebraic LGV).

🤖 Generated by researcher-11