### PR TITLE
Enrich four-square-distribution: add intro-docstring section

### DIFF
--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -52,6 +52,14 @@
   },
   "sections": [
     {
+      "id": "intro-docstring",
+      "title": "Imports and Open-Question Framing",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Imports `Mathlib.NumberTheory.SumFourSquares`, `Finset.Basic`/`Card`, `Multiset.Basic`, `List.Sort`, `Mathlib.Tactic`. The module docstring states the gallery open question OQ-02 ('How do representations distribute among the possible orderings?'), summarizes the four contributions of the file (computable representation types, symmetry multipliers, small-n enumeration, structural properties), and records the key insight that Jacobi's factor of 8 arises from the signed-permutation symmetry group acting on 4-tuples.",
+      "mathContext": "$r_4(n) = \\sum_{\\text{types } t \\text{ for } n} \\text{contribution}(t)$, where $\\text{contribution}(t) = \\binom{4}{m_1, m_2, \\ldots}^{\\!*}\\cdot 2^{\\text{nz}(t)}$ — the multinomial coefficient over multiplicities times $2^k$ for $k$ nonzero positions. The factor of 8 in Jacobi's formula $r_4(n) = 8\\sigma^*(n)$ is the GCD of all type contributions."
+    },
+    {
       "id": "rep-types",
       "title": "Part 1: Representation Types and Symmetry",
       "startLine": 36,


### PR DESCRIPTION
## Summary

Single-section enrichment pass for \`four-square-distribution\`. Quality score lifted **98 → 100** (find-targets.ts).

### Added: §0 intro-docstring section
The pre-enrichment \`sections\` array had four entries starting at line 36 — the file's imports and module docstring (lines 1–35) were not covered. The new §0 section:

- Names the imports (\`SumFourSquares\`, \`Finset.Basic/Card\`, \`Multiset.Basic\`, \`List.Sort\`, \`Mathlib.Tactic\`)
- Cites the gallery open-question framing OQ-02
- Records the file's four contributions
- Includes a \`mathContext\` relating type contributions to Jacobi's factor-of-8 via the signed-permutation symmetry group

Sections bucket: 8 → 10 points.

## Test plan

- [x] \`python3 -m json.tool\` validates \`meta.json\`
- [x] \`npx tsx scripts/enricher/find-targets.ts --json\` reports quality 100/100
- [ ] CI build (\`pnpm build\`) — local install fails on Node 26 / better-sqlite3 (see memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)