### PR TITLE
research(ehrhart-cube-proven-oq-04): S3 ROW-SUM — close eulerian_row_sum_factorial via sum reorganisation (build pending)

### DIFF
--- a/proofs/Proofs/EhrhartCubeProvenOQ04.lean
+++ b/proofs/Proofs/EhrhartCubeProvenOQ04.lean
@@ -2,15 +2,16 @@
   Eulerian Numbers and the h*-Vector of the Unit Cube
   (ehrhart-cube-proven-oq-04)
 
-  S1 SCAFFOLD + S2 STRUCTURAL. The companion file `EhrhartCubeProven.lean`
-  proves `L([0,1]^d, n) = (n+1)^d` axiom-free. The Ehrhart h*-vector of the
-  unit d-cube is conjecturally (and classically) equal to the sequence
-  of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)).
+  S1 SCAFFOLD + S2 STRUCTURAL + S3 ROW-SUM. The companion file
+  `EhrhartCubeProven.lean` proves `L([0,1]^d, n) = (n+1)^d` axiom-free.
+  The Ehrhart h*-vector of the unit d-cube is conjecturally (and classically)
+  equal to the sequence of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)).
 
-  S2 closes the two *structural* sorries (`cube_h_star_eulerian` and
-  `cube_lattice_count_eulerian`); the *combinatorial* sorries
-  (`worpitzky_identity_cube`, `eulerian_row_sum_factorial`,
-  `eulerian_palindrome`) remain for S3+.
+  S2 closed the two *structural* sorries (`cube_h_star_eulerian` and
+  `cube_lattice_count_eulerian`); S3 adds helper lemmas
+  (`eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`) and closes
+  `eulerian_row_sum_factorial` (Σ A(d, k) = d!). The remaining combinatorial
+  sorries (`worpitzky_identity_cube`, `eulerian_palindrome`) are for S4+.
 
   Concretely, Worpitzky's identity states:
 
@@ -42,9 +43,13 @@
   Main theorems:
   • `worpitzky_identity_cube`               — Σ A(d,k) C(n+1+k, d) = (n+1)^d   (deferred)
   • `cube_h_star_eulerian`                  — h_k*([0,1]^d) = A(d, k)          (S2: PROVED)
-  • `eulerian_row_sum_factorial`            — Σ_{k=0}^{d-1} A(d, k) = d!       (deferred)
+  • `eulerian_row_sum_factorial`            — Σ_{k=0}^{d-1} A(d, k) = d!       (S3: PROVED)
   • `eulerian_palindrome`                   — A(d, k) = A(d, d-1-k) for k < d  (deferred)
   • `cube_lattice_count_eulerian`           — bridge to `EhrhartCubeProven`    (S2: PROVED)
+
+  Helper lemmas (S3):
+  • `eulerian_zero_eq_one`                  — A(d, 0) = 1 for all d ≥ 0
+  • `eulerian_eq_zero_of_le`                — A(d, k) = 0 for d ≥ 1, k ≥ d
 
   Concrete (proven, no sorry):
   • `eulerian_1_0`, `eulerian_2_*`, `eulerian_3_*`, `eulerian_4_*` — values by rfl
@@ -105,21 +110,138 @@ theorem eulerian_4_2 : eulerianNumber 4 2 = 11 := rfl
 theorem eulerian_4_3 : eulerianNumber 4 3 = 1 := rfl
 theorem eulerian_4_4 : eulerianNumber 4 4 = 0 := rfl
 
+-- ----- Structural helpers (S3) -----
+
+/--
+  **Leftmost column** (S3): for every `d`, the leftmost Eulerian number is `1`.
+  Combinatorially, the unique permutation of `{1,…,d}` with `0` descents is the
+  identity. The proof follows by induction on `d` directly from the recurrence
+  `A(d+1, 0) = A(d, 0)` and the base case `A(0, 0) = 1`.
+-/
+theorem eulerian_zero_eq_one : ∀ d : ℕ, eulerianNumber d 0 = 1
+  | 0     => rfl
+  | _ + 1 => eulerian_zero_eq_one _
+
+/--
+  **Out-of-range vanishing** (S3): for `d ≥ 1` and `k ≥ d`, `A(d, k) = 0`.
+  Combinatorially, a permutation of `d` elements has at most `d-1` descents.
+  The proof is a double induction on `d` and `k` using the recurrence and the
+  Nat-subtraction truncation `0 - k = 0`. Used in `eulerian_row_sum_factorial`
+  below to discard the boundary term `(d+1)·A(d, d)`.
+-/
+theorem eulerian_eq_zero_of_le : ∀ d k : ℕ, 0 < d → d ≤ k → eulerianNumber d k = 0
+  | 0,     _,     hd, _  => absurd hd (lt_irrefl 0)
+  | _ + 1, 0,     _,  hk => absurd hk (by omega)
+  | d + 1, k + 1, _,  hk => by
+    have hdk : d ≤ k := Nat.succ_le_succ_iff.mp hk
+    show (k + 2) * eulerianNumber d (k + 1) + (d - k) * eulerianNumber d k = 0
+    rcases Nat.eq_zero_or_pos d with rfl | hd_pos
+    · -- d = 0: both factors vanish — `A(0, k+1) = 0` by def and `0 - k = 0`
+      have h1 : eulerianNumber 0 (k + 1) = 0 := rfl
+      have h2 : (0 : ℕ) - k = 0 := by omega
+      rw [h1, h2]; ring
+    · -- d ≥ 1: apply IH to both `A(d, k+1)` and `A(d, k)`
+      rw [eulerian_eq_zero_of_le d (k + 1) hd_pos (Nat.le_succ_of_le hdk),
+          eulerian_eq_zero_of_le d k hd_pos hdk]
+      ring
+
 -- ============================================================
 -- SECTION II: Row-Sum Identity (Eulerian numbers sum to d!)
 -- ============================================================
 
 /--
-  **Row-sum identity** (deferred): the Eulerian numbers on row `d`
+  **Row-sum identity** (S3: PROVED): the Eulerian numbers on row `d`
   partition the symmetric group `S_d` by descent count:
       Σ_{k=0}^{d-1} A(d, k) = d!
   This is the structural sanity check that Eulerian numbers count permutations.
-  Proof strategy: induct on `d`, using the recurrence and the identity
-  `(k+1)! + ... = (k+2)·k! ...` to telescope.
+
+  Proof outline (induction on `d`):
+  * Base `d = 1`: `Σ_{k<1} A(1, k) = A(1, 0) = 1 = 1!`.
+  * Step (`d ≥ 1`, assume IH `Σ_{k<d} A(d, k) = d!`): rewrite
+    `Σ_{k<d+1} A(d+1, k) = (d+1) · Σ_{k<d} A(d, k)` by extending both sums
+    to `range (d+1)` (using `A(d, d) = 0` to drop the boundary term),
+    unfolding the recurrence inside the LHS sum, and combining via the
+    pointwise identity `(k+1)·A(d, k) + (d-k)·A(d, k) = (d+1)·A(d, k)`
+    (valid for `k < d`; for `k = d` both sides are `0` by `A(d, d) = 0`).
+    Then `(d+1) · d! = (d+1)!` by `Nat.factorial_succ`.
 -/
 theorem eulerian_row_sum_factorial (d : ℕ) (hd : 0 < d) :
     ∑ k ∈ Finset.range d, eulerianNumber d k = d.factorial := by
-  sorry
+  induction d with
+  | zero => exact absurd hd (lt_irrefl 0)
+  | succ d ih =>
+    rcases Nat.eq_zero_or_pos d with rfl | hd_pos
+    · -- `d = 0`, so `d + 1 = 1` and the sum has the single term `A(1, 0) = 1 = 1!`
+      simp [Finset.sum_range_succ, Finset.sum_range_zero, eulerian_zero_eq_one,
+            Nat.factorial]
+    · -- `d ≥ 1`, apply IH and recurrence
+      have IH : ∑ k ∈ Finset.range d, eulerianNumber d k = d.factorial := ih hd_pos
+      -- Reduce the goal to `(d+1) · Σ_{k<d} A(d, k) = (d+1)!` via a closed-form rewrite.
+      have lhs_eq : ∑ k ∈ Finset.range (d + 1), eulerianNumber (d + 1) k
+                  = (d + 1) * ∑ k ∈ Finset.range d, eulerianNumber d k := by
+        rw [Finset.mul_sum]
+        -- Extend the RHS sum to `range (d + 1)` using `A(d, d) = 0`.
+        have rhs_extend :
+            ∑ k ∈ Finset.range d, (d + 1) * eulerianNumber d k
+              = ∑ k ∈ Finset.range (d + 1), (d + 1) * eulerianNumber d k := by
+          rw [Finset.sum_range_succ
+                (fun k => (d + 1) * eulerianNumber d k) d,
+              eulerian_eq_zero_of_le d d hd_pos (le_refl d), Nat.mul_zero,
+              Nat.add_zero]
+        rw [rhs_extend]
+        -- Peel off the `k = 0` term on both sides.
+        rw [Finset.sum_range_succ' (fun k => eulerianNumber (d + 1) k) d,
+            eulerian_zero_eq_one (d + 1)]
+        rw [Finset.sum_range_succ' (fun k => (d + 1) * eulerianNumber d k) d,
+            eulerian_zero_eq_one d, Nat.mul_one]
+        -- Unfold the recurrence inside the LHS sum.
+        have lhs_recur : ∀ k ∈ Finset.range d,
+            eulerianNumber (d + 1) (k + 1)
+              = (k + 2) * eulerianNumber d (k + 1) + (d - k) * eulerianNumber d k :=
+          fun k _ => rfl
+        rw [Finset.sum_congr rfl lhs_recur, Finset.sum_add_distrib]
+        -- Re-pack `(∑ k, (k+2)·A(d, k+1)) + 1 = ∑ k ∈ range (d+1), (k+1)·A(d, k)`
+        -- (running `Finset.sum_range_succ'` "backwards" on the indexed form).
+        have lhs_rewrap :
+            (∑ k ∈ Finset.range d, (k + 2) * eulerianNumber d (k + 1)) + 1
+              = ∑ k ∈ Finset.range (d + 1), (k + 1) * eulerianNumber d k := by
+          rw [Finset.sum_range_succ' (fun k => (k + 1) * eulerianNumber d k) d,
+              eulerian_zero_eq_one d, Nat.mul_one]
+        -- Symmetric re-pack on the RHS.
+        have rhs_rewrap :
+            (∑ k ∈ Finset.range d, (d + 1) * eulerianNumber d (k + 1)) + (d + 1)
+              = ∑ k ∈ Finset.range (d + 1), (d + 1) * eulerianNumber d k := by
+          rw [Finset.sum_range_succ' (fun k => (d + 1) * eulerianNumber d k) d,
+              eulerian_zero_eq_one d, Nat.mul_one]
+        -- Rearrange terms on the LHS to expose `(∑ (k+2)·A(d, k+1)) + 1`.
+        have lhs_assoc :
+            (∑ k ∈ Finset.range d, (k + 2) * eulerianNumber d (k + 1))
+              + (∑ k ∈ Finset.range d, (d - k) * eulerianNumber d k) + 1
+            = ((∑ k ∈ Finset.range d, (k + 2) * eulerianNumber d (k + 1)) + 1)
+              + (∑ k ∈ Finset.range d, (d - k) * eulerianNumber d k) := by ring
+        rw [lhs_assoc, lhs_rewrap, rhs_rewrap]
+        -- Extend the remaining `range d` sum to `range (d+1)` (its k=d term vanishes).
+        have rhs_extend2 :
+            ∑ k ∈ Finset.range d, (d - k) * eulerianNumber d k
+              = ∑ k ∈ Finset.range (d + 1), (d - k) * eulerianNumber d k := by
+          rw [Finset.sum_range_succ
+                (fun k => (d - k) * eulerianNumber d k) d,
+              eulerian_eq_zero_of_le d d hd_pos (le_refl d), Nat.mul_zero,
+              Nat.add_zero]
+        rw [rhs_extend2, ← Finset.sum_add_distrib]
+        apply Finset.sum_congr rfl
+        intro k hk
+        have hk' : k < d + 1 := Finset.mem_range.mp hk
+        rcases Nat.lt_or_ge k d with hkd | hkd
+        · -- k < d: combine coefficients cleanly.
+          have hsum : (k + 1) + (d - k) = d + 1 := by omega
+          calc (k + 1) * eulerianNumber d k + (d - k) * eulerianNumber d k
+              = ((k + 1) + (d - k)) * eulerianNumber d k := by ring
+            _ = (d + 1) * eulerianNumber d k := by rw [hsum]
+        · -- k = d: `A(d, d) = 0` makes both sides 0.
+          have hkd' : k = d := by omega
+          rw [hkd', eulerian_eq_zero_of_le d d hd_pos (le_refl d)]; ring
+      rw [lhs_eq, IH, Nat.factorial_succ]
 
 -- Concrete checks (proven by rfl)
 example : eulerianNumber 1 0 = Nat.factorial 1 := rfl

--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -24,15 +24,14 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 300,
+    "lineCount": 422,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
     "openQuestions": [
-      "Prove `worpitzky_identity_cube`: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d) for all d ≥ 1 and n ≥ 0. The proof can proceed by induction on d via Pascal's identity and the Eulerian recurrence, or via a combinatorial bijection between (n+1)^d colour-sequences and (descent-pattern, position-pattern) pairs.",
-      "Prove `eulerian_row_sum_factorial`: Σ_{k=0}^{d-1} A(d, k) = d!. The standard argument inducts on d using the recurrence A(d+1, k) = (k+1) A(d, k) + (d+1-k) A(d, k-1) and the identity Σ_k [(k+1) + (d+1-k)] A(d, k) = (d+2) Σ_k A(d, k).",
+      "Prove `worpitzky_identity_cube`: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d) for all d ≥ 1 and n ≥ 0. The proof can proceed by induction on d via Pascal's identity and the Eulerian recurrence, or via a combinatorial bijection between (n+1)^d colour-sequences and (descent-pattern, position-pattern) pairs. S3 helpers (`eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`) discharge the standard boundary terms.",
       "Prove `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for k < d, by exhibiting the involution σ ↦ σ ∘ reverse on `Equiv.Perm (Fin d)` which bijects k-descent permutations with (d-1-k)-descent permutations."
     ],
     "originalContributions": [
@@ -41,7 +40,10 @@
       "Worpitzky's identity proved explicitly for d = 1 (trivial) and d = 2 (by induction on n)",
       "Five concrete Worpitzky verifications at (d, n) ∈ {(2,0), (2,1), (3,0), (3,1), (3,2), (4,1), (4,2)} by `decide`",
       "Row-sum and palindrome consistency checks at d ≤ 4 by `rfl`",
-      "Definition `cubeHStarPoly d : Polynomial ℕ` as the Eulerian generating polynomial"
+      "Definition `cubeHStarPoly d : Polynomial ℕ` as the Eulerian generating polynomial",
+      "Helper lemma `eulerian_zero_eq_one`: A(d, 0) = 1 for all d (S3, proven by Nat recursion)",
+      "Helper lemma `eulerian_eq_zero_of_le`: A(d, k) = 0 for d ≥ 1, k ≥ d (S3, proven by double Nat recursion)",
+      "Row-sum identity `eulerian_row_sum_factorial`: Σ_{k<d} A(d, k) = d! for d ≥ 1 (S3, proven by induction on d via sum reorganisation and `A(d, d) = 0`)"
     ],
     "prerequisites": [
       "EhrhartCubeProven: `cube_lattice_count` — L([0,1]^d, n) = (n+1)^d, axiom-free (companion file)",
@@ -76,7 +78,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -175,12 +177,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 300,
+    "lineCount": 422,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -243,5 +245,5 @@
       "significance": "Connects the axiom-free Ehrhart count to the Eulerian interpretation"
     }
   ],
-  "sorries": 5
+  "sorries": 2
 }

--- a/src/data/research/problems/ehrhart-cube-proven-oq-04.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-04.json
@@ -24,30 +24,32 @@
       "worpitzky_d2: (n+1)^2 = C(n+1, 2) + C(n+2, 2) — by induction on n using Pascal",
       "cube_h_star_eulerian: h_k*([0,1]^d) = A(d, k) — S2, via Polynomial.finset_sum_coeff + Finset.sum_ite_eq'",
       "cube_lattice_count_eulerian: |Fin d → Fin (n+1)| = Σ A(d,k) C(n+1+k, d) — S2, via Fintype.card_fun + worpitzky",
-      "Seven concrete (d, n) verifications by `decide`"
+      "Seven concrete (d, n) verifications by `decide`",
+      "eulerian_zero_eq_one: ∀ d, A(d, 0) = 1 — S3, by Nat recursion",
+      "eulerian_eq_zero_of_le: ∀ d ≥ 1, ∀ k ≥ d, A(d, k) = 0 — S3, double Nat recursion",
+      "eulerian_row_sum_factorial: Σ_{k<d} A(d, k) = d! for d ≥ 1 — S3, induction on d via sum reorganisation"
     ],
     "open": [
       "worpitzky_identity_cube: (n+1)^d = Σ A(d, k) C(n+1+k, d) for general d ≥ 1, n ≥ 0",
-      "eulerian_row_sum_factorial: Σ_{k<d} A(d, k) = d!",
       "eulerian_palindrome: A(d, k) = A(d, d-1-k) for k < d"
     ],
     "goal": "Close worpitzky_identity_cube via induction on d (Approach A — algebraic)"
   },
   "currentState": {
     "phase": "SCAFFOLDED",
-    "since": "2026-05-12T03:30:00Z",
-    "iteration": 2,
-    "focus": "S2 STRUCTURAL complete: closed cube_h_star_eulerian and cube_lattice_count_eulerian (2 of 5 sorries). 3 combinatorial sorries remain: worpitzky_identity_cube, eulerian_row_sum_factorial, eulerian_palindrome.",
+    "since": "2026-05-12T04:00:00Z",
+    "iteration": 3,
+    "focus": "S3 ROW-SUM complete: helpers (eulerian_zero_eq_one, eulerian_eq_zero_of_le) + eulerian_row_sum_factorial closed. 2 combinatorial sorries remain: worpitzky_identity_cube (main), eulerian_palindrome (descent involution).",
     "blockers": [],
-    "nextAction": "S3: Close worpitzky_identity_cube via induction on d using Pascal's identity and the Eulerian recurrence. Expected ~80-120 lines of Lean.",
+    "nextAction": "S4: Close worpitzky_identity_cube via induction on d. Approach (A) algebraic: Pascal's identity C(n+1+k, d+1) = C(n+k, d+1) + C(n+k, d) plus Eulerian recurrence. S3 helpers (eulerian_zero_eq_one, eulerian_eq_zero_of_le, eulerian_row_sum_factorial) directly support boundary handling; central technical step is rewriting (n+1)^(d+1) = (n+1) · (n+1)^d and reconciling with the binomial recurrence.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 SCAFFOLD + S2 STRUCTURAL (researcher-11, 2026-05-12): S1 established eulerianNumber via recurrence (matches OEIS A008292) with 13 rfl values, cubeHStarPoly definition, Worpitzky d=1, d=2 cases proved. S2 closed two of the five sorries: `cube_h_star_eulerian` (definitional, via Polynomial.finset_sum_coeff + Finset.sum_ite_eq') and `cube_lattice_count_eulerian` (bridging corollary, via Fintype.card_fun + worpitzky_identity_cube as hypothesis). 3 combinatorial sorries remain: worpitzky_identity_cube (main), eulerian_row_sum_factorial, eulerian_palindrome.",
+    "progressSummary": "S1 SCAFFOLD + S2 STRUCTURAL + S3 ROW-SUM (researcher-3, 2026-05-12): S3 adds two helper lemmas (`eulerian_zero_eq_one : ∀ d, A(d, 0) = 1` and `eulerian_eq_zero_of_le : d ≥ 1 → k ≥ d → A(d, k) = 0`) and closes `eulerian_row_sum_factorial : Σ_{k<d} A(d, k) = d!` via direct induction. Proof structure: rewrite LHS into `(d+1) · Σ_{k<d} A(d, k)` form by extending both sums to `range (d+1)` (using `A(d, d) = 0`), unfolding the recurrence inside the LHS sum, and combining via the pointwise identity `(k+1)·A(d, k) + (d-k)·A(d, k) = (d+1)·A(d, k)` (which uses `A(d, d) = 0` for the boundary case `k = d`). 2 combinatorial sorries remain: worpitzky_identity_cube (main), eulerian_palindrome (descent involution).",
     "builtItems": [
       "eulerianNumber : ℕ → ℕ → ℕ (def)",
       "cubeHStarPoly : ℕ → Polynomial ℕ (def)",
@@ -58,14 +60,19 @@
       "cube_h_star_eulerian (S2, proven — definitional via coeff_smul + coeff_X_pow)",
       "cube_lattice_count_eulerian (S2, proven — via Fintype.card_fun + worpitzky)",
       "7 decide-verifications at (d, n) up to (4, 2)",
-      "3 deferred theorems (sorries) with documented proof strategies"
+      "eulerian_zero_eq_one (S3, proven — Nat recursion on d)",
+      "eulerian_eq_zero_of_le (S3, proven — double Nat recursion on d, k)",
+      "eulerian_row_sum_factorial (S3, proven — induction on d, sum reorganisation, A(d, d) = 0 boundary)",
+      "2 deferred theorems (sorries) with documented proof strategies"
     ],
     "insights": [
       "Nat-subtraction in the eulerianNumber recurrence handles the boundary k ≥ d cleanly: both branches collapse to 0 automatically",
       "Worpitzky d=2 requires inductive proof on n using Pascal — non-trivial, demonstrates the Lean proof pattern for general d",
       "Three equivalent statements of OQ-04 (Worpitzky, generating function, h*-vector); Worpitzky form is most tractable in Lean as it avoids PowerSeries",
       "Mathlib does not have Eulerian numbers — first Lean formalization in this gallery; Mathlib contribution path opens",
-      "cubeHStarPoly's k-th coefficient is definitional (Σ A(d,j) • X^j → coeff_smul + coeff_X_pow + Finset.sum_ite_eq') — the substantive content lives entirely in worpitzky_identity_cube"
+      "cubeHStarPoly's k-th coefficient is definitional (Σ A(d,j) • X^j → coeff_smul + coeff_X_pow + Finset.sum_ite_eq') — the substantive content lives entirely in worpitzky_identity_cube",
+      "S3 row-sum technique: extend both row sums to a common `range (d+1)` index set using `A(d, d) = 0`, then combine pointwise via `(k+1) + (d-k) = d+1` (for k < d) and direct A(d, d) = 0 cancellation (for k = d). Avoids `Finset.sum_Ico_eq_sum_range` reindexing.",
+      "Helper `eulerian_eq_zero_of_le` carries the recursion on the FIRST argument (d), with case-split on whether d = 0 or d ≥ 1 for the inner recursion call. Required to discharge `(d - k) * A(d, k) = 0` boundary contributions."
     ],
     "mathlibGaps": [
       "No Eulerian numbers (`Nat.eulerianNumber` or similar)",
@@ -73,8 +80,7 @@
       "PowerSeries 1/(1-X)^{d+1} expansion as Σ C(n+d, d) X^n needs careful lemma chain"
     ],
     "nextSteps": [
-      "S3: Close worpitzky_identity_cube by induction on d (Approach A)",
-      "S4: Close eulerian_row_sum_factorial via the algebraic-recurrence argument (Σ A(d+1,k) = (d+1) Σ A(d,k))",
+      "S4: Close worpitzky_identity_cube by induction on d. Approach (A) algebraic: Pascal's identity C(n+1+k, d+1) = C(n+k, d+1) + C(n+k, d) + Eulerian recurrence. S3 helpers (eulerian_zero_eq_one, eulerian_eq_zero_of_le, eulerian_row_sum_factorial) directly support boundary handling.",
       "S5: Define permutation descents and prove eulerianNumber d k = (filter (descent = k) (univ : Finset (Equiv.Perm (Fin d)))).card",
       "S6: Prove eulerian_palindrome via the descent-reversal involution on Equiv.Perm",
       "S7+: Mathlib upstream PR for Eulerian numbers"
@@ -113,7 +119,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.563Z",
-  "lastUpdate": "2026-05-12T03:30:00Z",
+  "lastUpdate": "2026-05-12T04:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -131,11 +137,11 @@
     {
       "path": "Proofs/EhrhartCubeProvenOQ04.lean",
       "filename": "EhrhartCubeProvenOQ04.lean",
-      "lineCount": 324,
+      "lineCount": 422,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProvenOQ04.lean"
     }


### PR DESCRIPTION
## Summary

S3 ROW-SUM iteration on `ehrhart-cube-proven-oq-04` (Eulerian h*-vector of unit cube): closes one of three remaining combinatorial sorries from S2.

* **New helpers** (proven):
  * `eulerian_zero_eq_one : ∀ d, A(d, 0) = 1` — clean Nat recursion.
  * `eulerian_eq_zero_of_le : 0 < d → d ≤ k → A(d, k) = 0` — double Nat recursion handling the Nat-subtraction `0 - k = 0` corner.
* **Main result** (proven, was a sorry):
  * `eulerian_row_sum_factorial : 0 < d → Σ_{k<d} A(d, k) = d.factorial` — induction on `d`.

## Proof technique

`Σ_{k<d+1} A(d+1, k) = (d+1) · Σ_{k<d} A(d, k)` by:
1. Extending both sums to `range (d+1)` using `A(d, d) = 0` from the new helper.
2. Splitting off the `k = 0` term (`A(d+1, 0) = 1`, `A(d, 0) = 1`).
3. Unfolding `A(d+1, k+1) = (k+2) A(d, k+1) + (d-k) A(d, k)`.
4. Re-packing the indexed sums via `Finset.sum_range_succ'` "backwards" to obtain a common `range (d+1)` form on both sides.
5. Combining the two `range (d+1)` sums via the pointwise identity `(k+1)·A(d, k) + (d-k)·A(d, k) = (d+1)·A(d, k)` — valid for `k < d` (`(k+1)+(d-k)=d+1` via `omega`), and trivial for `k = d` since `A(d, d) = 0`.

Then `(d+1) · d! = (d+1)!` via `Nat.factorial_succ`.

The technique avoids `Finset.sum_Ico_eq_sum_range` reindexing entirely; the index alignment runs through `sum_range_succ'` applied to both peeling and re-packing.

## Counts

| Field         | Before (post-#17761) | After  |
| ------------- | --------------------- | ------ |
| lineCount     | 300                   | 422    |
| theoremCount  | 23                    | 25     |
| sorries       | 3                     | 2      |
| axiomCount    | 0                     | 0      |
| definitionCount| 2                    | 2      |

Both `meta.json` and `src/data/research/problems/ehrhart-cube-proven-oq-04.json` updated to reflect new state.

## Findings

* The S3 helpers (`eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`) are immediately reusable for the remaining sorries (`worpitzky_identity_cube`, `eulerian_palindrome`); they discharge the standard "boundary term vanishes" steps in any induction on `d`.
* `(0 : ℕ) - k = 0` resolves via `omega` cleanly inside the d=0 case of `eulerian_eq_zero_of_le`.

## Remaining sorries (deferred to S4+)

1. `worpitzky_identity_cube`: `(n+1)^d = Σ A(d, k) C(n+1+k, d)` — induction on `d` via Pascal + Eulerian recurrence (S4).
2. `eulerian_palindrome`: `A(d, k) = A(d, d-1-k)` — descent-reversal involution on `Equiv.Perm (Fin d)` (S6).

## Status

**Outcome**: progress (1 sorry closed of 3 combinatorial; helpers also unlock future S4/S6).
**Build status**: NOT verified locally (Docker wrapper unavailable this session). Following the "build pending" convention used by recent merged research PRs.
**Next Steps**: S4 — attempt `worpitzky_identity_cube`. The S3 helpers should streamline boundary handling in the induction.

🤖 Generated by researcher-3