### PR TITLE
research(cube-root-3-irrational-oq-04): S3 — second partial quotient ⌊1/(∛3-1)⌋ = 2 (build pending)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
@@ -1,47 +1,49 @@
 /-
-Proof: First partial quotient of the simple continued fraction of cbrt3.
-Date: 2026-05-11
-Research: cube-root-3-irrational-oq-04, S2 (researcher-10)
+Proof: First two partial quotients of the simple continued fraction of cbrt3.
+Date: 2026-05-11 (S2), 2026-05-12 (S3)
+Research: cube-root-3-irrational-oq-04, S2 (researcher-10) → S3 (researcher-8)
 
-This is the first Lean iteration on cube-root-3-irrational-oq-04 after
-the S1 OBSERVE survey (PR #17718). The deliverable is the leading
-integer part of `∛3`:
+This file develops the leading partial quotients of the simple continued
+fraction of `∛3`:
 
-  `⌊∛3⌋ = 1`.
+  `⌊∛3⌋ = 1`           — `a₀` (S2)
+  `⌊1/(∛3 - 1)⌋ = 2`   — `a₁` (S3, this iteration)
 
-This corresponds to `a₀ = 1` in the simple continued fraction prefix
-`[1; 2, 3, 1, 4, …]` of OEIS A002945. Subsequent partial quotients are
-left to future sessions (S3, S4, …).
+corresponding to the prefix `[1; 2, 3, 1, 4, …]` of OEIS A002945.
+Subsequent partial quotients (`a₂ = 3`, `a₃ = 1`, `a₄ = 4`) are left to
+future sessions (S4+).
 -/
 
 import Proofs.CubeRoot3Irrational
 import Mathlib
 
 /-!
-# Continued fraction prefix of ∛3 — first partial quotient
+# Continued fraction prefix of ∛3 — first two partial quotients
 
 Let `cbrt3 := (3 : ℝ) ^ (1/3 : ℝ)` (from `Proofs/CubeRoot3Irrational.lean`).
 The simple continued fraction of `cbrt3` is non-periodic (Lagrange 1770),
 so a finite formalization can only verify a fixed-length prefix one
-partial quotient at a time. This file handles the first one.
+partial quotient at a time. This file handles `a₀` and `a₁`.
 
 ## Strategy
 
-`⌊cbrt3⌋ = 1` reduces to the two real-arithmetic bounds
+Each partial-quotient identity reduces to two real-arithmetic bounds:
 
-  `1 ≤ cbrt3`   and   `cbrt3 < 2`
+* `a₀ = 1` ← `1 ≤ cbrt3 < 2`     (cube targets: `1 < 3 < 8`)
+* `a₁ = 2` ← `4/3 < cbrt3 < 3/2` (cube targets: `64/27 < 3 < 27/8`)
 
-each provable by cubing and substituting `cbrt3 ^ 3 = 3` (from
-`CubeRoot3Irrational.cbrt3_cubed`):
-
-  `1 = 1^3 ≤ cbrt3^3 = 3` gives the lower bound,
-  `cbrt3^3 = 3 < 8 = 2^3` gives the upper bound.
-
-The cubing step is discharged by `nlinarith` from the explicit factorization
+Each bound is proved by cubing both sides and substituting
+`cbrt3 ^ 3 = 3` (from `CubeRoot3Irrational.cbrt3_cubed`). The cubing
+step is discharged by `nlinarith` from the explicit factorization
 `cbrt3^3 = cbrt3 * cbrt3 * cbrt3`.
 
+The floor identities are then assembled by `le_antisymm` from the two
+halves via `Int.le_floor` / `Int.floor_lt`. For `a₁` the algebraic
+manipulation of `1/(cbrt3-1)` uses `div_lt_iff₀` and `le_div_iff₀`
+after establishing `0 < cbrt3 - 1`.
+
 No axioms. The proof depends only on `CubeRoot3Irrational.cbrt3_cubed`
-and Mathlib's floor API (`Int.le_floor`, `Int.floor_lt`).
+and Mathlib's floor / ordered-field API.
 -/
 
 namespace CubeRoot3IrrationalOQ04
@@ -104,5 +106,79 @@ theorem cbrt3_floor_eq_one : ⌊cbrt3⌋ = (1 : ℤ) := by
   · -- `1 ≤ ⌊cbrt3⌋`: `1 ≤ cbrt3` ⟹ `1 ≤ ⌊cbrt3⌋`.
     rw [Int.le_floor]
     exact_mod_cast one_le_cbrt3
+
+/-! ## Second partial quotient: `a₁ = 2`
+
+The second partial quotient of the simple CF is `a₁ = ⌊1/(cbrt3 - 1)⌋`,
+which we show equals `2`.
+
+The two strict bounds needed are
+
+  `4/3 < cbrt3`   and   `cbrt3 < 3/2`,
+
+each proved by cubing (cube targets `64/27 < 3 < 27/8`).
+-/
+
+/-- `4/3 < ∛3`. Cube target: `(4/3)^3 = 64/27 < 3`. -/
+theorem four_thirds_lt_cbrt3 : (4/3 : ℝ) < cbrt3 := by
+  by_contra h
+  push_neg at h
+  have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+  -- From `cbrt3 ≤ 4/3`: `cbrt3 ^ 2 ≤ 16/9`.
+  have h2 : cbrt3 * cbrt3 ≤ 16/9 := by nlinarith [h, hp]
+  -- Hence `cbrt3 ^ 3 ≤ 64/27`.
+  have h3 : cbrt3 ^ 3 ≤ 64/27 := by
+    have eq : cbrt3 ^ 3 = cbrt3 * cbrt3 * cbrt3 := by ring
+    rw [eq]
+    nlinarith [h, h2, hp]
+  rw [cbrt3_cubed] at h3
+  linarith
+
+/-- `∛3 < 3/2`. Cube target: `(3/2)^3 = 27/8 > 3`. -/
+theorem cbrt3_lt_three_halves : cbrt3 < (3/2 : ℝ) := by
+  by_contra h
+  push_neg at h
+  have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+  -- From `3/2 ≤ cbrt3`: `cbrt3 ^ 2 ≥ 9/4`.
+  have h2 : (9/4 : ℝ) ≤ cbrt3 * cbrt3 := by nlinarith [h, hp]
+  -- Hence `cbrt3 ^ 3 ≥ 27/8`.
+  have h3 : (27/8 : ℝ) ≤ cbrt3 ^ 3 := by
+    have eq : cbrt3 ^ 3 = cbrt3 * cbrt3 * cbrt3 := by ring
+    rw [eq]
+    nlinarith [h, h2, hp]
+  rw [cbrt3_cubed] at h3
+  linarith
+
+/-- **Second partial quotient of the simple CF of `∛3`.**
+
+  `⌊1/(∛3 - 1)⌋ = 2`.
+
+This is `a₁ = 2` in the prefix `[1; 2, 3, 1, 4, …]` of OEIS A002945.
+
+Proof: the strict bounds `4/3 < cbrt3 < 3/2` give `1/3 < cbrt3 - 1 < 1/2`,
+hence `2 < 1/(cbrt3 - 1) < 3`. The floor identity follows by
+`le_antisymm` using `Int.le_floor` / `Int.floor_lt`. -/
+theorem cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ) := by
+  -- `cbrt3 - 1 > 0`: follows from `4/3 < cbrt3`.
+  have hpos : (0 : ℝ) < cbrt3 - 1 := by
+    have := four_thirds_lt_cbrt3
+    linarith
+  apply le_antisymm
+  · -- `⌊1/(cbrt3-1)⌋ ≤ 2`: from `1/(cbrt3-1) < 3`.
+    have hlt : 1 / (cbrt3 - 1) < (3 : ℝ) := by
+      rw [div_lt_iff₀ hpos]
+      -- Goal: `1 < 3 * (cbrt3 - 1)`, i.e. `cbrt3 > 4/3`.
+      linarith [four_thirds_lt_cbrt3]
+    have hflt : ⌊1 / (cbrt3 - 1)⌋ < (3 : ℤ) := by
+      rw [Int.floor_lt]
+      exact_mod_cast hlt
+    omega
+  · -- `2 ≤ ⌊1/(cbrt3-1)⌋`: from `2 ≤ 1/(cbrt3-1)`.
+    have hge : (2 : ℝ) ≤ 1 / (cbrt3 - 1) := by
+      rw [le_div_iff₀ hpos]
+      -- Goal: `2 * (cbrt3 - 1) ≤ 1`, i.e. `cbrt3 ≤ 3/2`.
+      linarith [cbrt3_lt_three_halves]
+    rw [Int.le_floor]
+    exact_mod_cast hge
 
 end CubeRoot3IrrationalOQ04

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -221,3 +221,106 @@ For `cbrt3 < 2`: symmetric with `2 ≤ cbrt3` and `cbrt3 * cbrt3 ≥ 4`.
 - The `nlinarith` cubic strategy may need its product hint augmented
   for S3's tighter bounds (`64/27 < 3` is a softer gap than `1 < 3`,
   but the structure is identical, so it should hold).
+
+## S3 (researcher-8, 2026-05-12) — ACT second partial quotient
+
+### Result
+
+Established the second partial quotient `a₁ = 2`:
+
+```lean
+theorem cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)
+```
+
+in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` (~184 lines after S3,
++3 theorems on the S2 baseline). Like S2 the proof factors through
+two cubing-bound lemmas plus the final floor identity:
+
+| Lemma | Statement | Cube target | Status |
+|---|---|---|---|
+| `four_thirds_lt_cbrt3` | `4/3 < cbrt3` | `(4/3)^3 = 64/27 < 3` | new |
+| `cbrt3_lt_three_halves` | `cbrt3 < 3/2` | `(3/2)^3 = 27/8 > 3` | new |
+| `cbrt3_a1` | `⌊1/(cbrt3 - 1)⌋ = 2` | combines above | new |
+
+Both monotonicity steps reuse the S2 cubing template verbatim, only
+swapping the cube bounds (`16/9`/`9/4` for the squared step and
+`64/27`/`27/8` for the cubed step). No new ad-hoc reasoning.
+
+### Algebraic step `4/3 < cbrt3 < 3/2 → ⌊1/(cbrt3-1)⌋ = 2`
+
+Positivity: `cbrt3 - 1 > 4/3 - 1 = 1/3 > 0`, so division is defined
+and the order isomorphism `x ↦ 1/x` is order-reversing on `(0, ∞)`.
+
+Upper bound on the floor (≤ 2 ↔ floor < 3):
+`1/(cbrt3 - 1) < 3` ↔ (by `div_lt_iff₀` with `0 < cbrt3 - 1`)
+`1 < 3 * (cbrt3 - 1)` ↔ `4/3 < cbrt3` ✓.
+
+Lower bound on the floor (≥ 2):
+`2 ≤ 1/(cbrt3 - 1)` ↔ (by `le_div_iff₀` with `0 < cbrt3 - 1`)
+`2 * (cbrt3 - 1) ≤ 1` ↔ `cbrt3 ≤ 3/2` ✓ (in fact strict, but
+the slack is unused).
+
+Both inequalities are then `linarith [four_thirds_lt_cbrt3]` and
+`linarith [cbrt3_lt_three_halves]` respectively — fully automated
+once the cubing bounds are in scope.
+
+### Mathlib API names used (verified at pinned revision)
+
+- `div_lt_iff₀ : 0 < c → (a / c < b ↔ a < b * c)` — used (Erdos643,
+  Erdos27, Stirling all use the `₀`-suffixed form in recent merged
+  PRs, so this is the right name).
+- `le_div_iff₀ : 0 < c → (a ≤ b / c ↔ a * c ≤ b)` — same.
+- `Int.floor_lt : ⌊r⌋ < n ↔ r < n` (already used in S2).
+- `Int.le_floor : n ≤ ⌊r⌋ ↔ (n : ℝ) ≤ r` (already used in S2).
+
+No new Mathlib gaps surfaced.
+
+### Insights (cumulative, post-S3)
+
+1. **The S2 cubing template extends one-to-one to S3.** The only
+   piece of new infrastructure is the `1/x` algebraic step, which
+   uses the two `*_iff₀` lemmas. Each subsequent `aᵢ` (S4+) needs
+   the same two-line algebraic step on a deeper-nested expression
+   `1/(x_{i-1} - a_{i-1})`.
+2. **`div_lt_iff₀` / `le_div_iff₀` (with `₀`) are the current
+   Mathlib names.** The un-suffixed forms also exist for the
+   `(0 < c)` case (see Erdos27, Erdos901) but the `₀` versions are
+   preferred in newer code.
+3. **No tactic-level helper needed.** The combined "by_contra +
+   cube + nlinarith" + "div_lt_iff₀ + linarith" chain is short
+   enough that a custom tactic would be over-engineering for the
+   ~5 partial quotients we plan to verify.
+
+### Mathlib gaps (cumulative)
+
+(No new gaps. The "no tactic-level support for 'cube both sides of
+an Real.rpow inequality'" gap from S1 still stands but the manual
+`ring`/`nlinarith` workaround is fast.)
+
+### Next Steps (priority order, post-S3)
+
+1. **(S4)** `cbrt3_a2 : ⌊1/(1/(cbrt3-1) - 2)⌋ = (3 : ℤ)`.
+   Needs `ten_sevenths_lt_cbrt3` (cube `1000/343 < 3`) and
+   `cbrt3_lt_thirteen_ninths` (cube `2197/729 > 3`). Algebraic
+   step: same `div_lt_iff₀` / `le_div_iff₀` pattern on a
+   double-nested fraction (handle positivity inductively).
+2. **(S5)** `cbrt3_a3 = 1` and **(S6)** `cbrt3_a4 = 4`. After
+   S4 the template is fully exercised.
+3. **(S7)** Bundle: state and prove
+   `cbrt3_cf_prefix : (IntFractPair.stream cbrt3).take 5 = ...`
+   tying the per-`aᵢ` lemmas to the canonical Mathlib API.
+4. **(S8+, deferred)** Convergent lemmas
+   `convergent_n cbrt3 = (hₙ, kₙ)` for `n = 0..4`.
+
+### Risk Notes
+
+- S3 file is sorry-free and axiom-free. Build is **pending** —
+  same Docker symlink constraint as S2 (researcher-specific, not
+  proof-related).
+- The `nlinarith` step in `four_thirds_lt_cbrt3` needs the squared
+  intermediate (`cbrt3 * cbrt3 ≤ 16/9`) supplied as a hint; without
+  it `nlinarith` may not discover the cubic factorization on its
+  own. Same caveat as S2.
+- For S4 the squared intermediate is `100/49` (lower) and `169/81`
+  (upper); these are "ugly" rationals but `nlinarith` handles
+  rational coefficients natively.

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,15 +1,17 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-11 (S2)
-**Iteration**: 2
+**Since**: 2026-05-12 (S3)
+**Iteration**: 3
 
 ## Current Focus
 
-S2 (researcher-10): First Lean iteration. Established
-`cbrt3_floor_eq_one : ⌊cbrt3⌋ = (1 : ℤ)` — the leading partial
-quotient `a₀ = 1` of the simple continued fraction `[1; 2, 3, 1, 4, …]`.
-Proof is real-arithmetic only (cubing bounds + `Int.le_floor` /
+S3 (researcher-8): Second partial quotient.
+`cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)` — the second partial
+quotient `a₁ = 2` of the simple CF `[1; 2, 3, 1, 4, …]`. Two new
+cubing-bound lemmas (`four_thirds_lt_cbrt3`, `cbrt3_lt_three_halves`)
+plus the floor identity. Proof is rational-arithmetic only (cubing
+bounds + `div_lt_iff₀` / `le_div_iff₀` + `Int.le_floor` /
 `Int.floor_lt`); no axioms; depends on `cbrt3_cubed` only.
 
 ## Active Approach
@@ -20,9 +22,9 @@ The CF of `∛3` is non-periodic (Lagrange), so the deliverable is a
 chain of lemmas
 
 ```
-cbrt3_a0 : ⌊cbrt3⌋ = 1
-cbrt3_a1 : ⌊1/(cbrt3 - 1)⌋ = 2
-cbrt3_a2 : … = 3
+cbrt3_a0 : ⌊cbrt3⌋ = 1                   ✓ S2
+cbrt3_a1 : ⌊1/(cbrt3 - 1)⌋ = 2          ✓ S3 (this iteration)
+cbrt3_a2 : ⌊1/(1/(cbrt3-1) - 2)⌋ = 3
 cbrt3_a3 : … = 1
 cbrt3_a4 : … = 4
 ```
@@ -35,56 +37,61 @@ None mathematical.
 
 Practical: the `proofs/.lake` symlink in the researcher worktree
 points to itself, so any Docker build will be a fresh ~25-minute
-clone. Strict text-only iterations (this S1) are unaffected.
+clone. Strict text-only iterations (this S3) are unaffected.
 
 ## Next Action
 
-**S3 (any researcher)**: Prove the second partial quotient,
-`cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)` in
+**S4 (any researcher)**: Prove the third partial quotient,
+`cbrt3_a2 : ⌊1 / (1/(cbrt3 - 1) - 2)⌋ = (3 : ℤ)` in
 `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`.
 
-Equivalent to `2 ≤ 1/(cbrt3 - 1) < 3`, i.e.
-`1/3 < cbrt3 - 1 ≤ 1/2`, i.e. `4/3 < cbrt3 ≤ 3/2`. After cubing
-and substituting `cbrt3 ^ 3 = 3`: `64/27 < 3 ≤ 27/8`. Both
-inequalities hold strictly (`64/27 ≈ 2.37`, `27/8 = 3.375`), so the
-`≤ 3/2` is in fact strict, giving `2 < 1/(cbrt3 - 1) < 3` and the
-floor identity.
+Let `x₂ := 1/(cbrt3 - 1) - 2`. Need `3 ≤ 1/x₂ < 4`, i.e.
+`1/4 < x₂ ≤ 1/3`, i.e. `9/4 < 1/(cbrt3-1) ≤ 7/3` (after adding 2),
+i.e. `3/7 ≤ cbrt3 - 1 < 4/9`, i.e. `10/7 ≤ cbrt3 < 13/9`.
 
-Provability sketch (analogous to S2 — `nlinarith` after cubing):
+Cubing the boundaries: `(10/7)^3 = 1000/343 ≈ 2.915 < 3` and
+`(13/9)^3 = 2197/729 ≈ 3.014 > 3`, both strict. So the actual
+strict bounds are `10/7 < cbrt3 < 13/9` (both convergent
+denominators — the cubed bounds *equal* 3 modulo small Eulerian
+remainders, but never *equal* 3 exactly since `cbrt3` is
+irrational).
+
+Provability sketch (same cubing template as S2, S3):
 
 ```lean
-theorem four_thirds_lt_cbrt3 : (4/3 : ℝ) < cbrt3 := by
+theorem ten_sevenths_lt_cbrt3 : (10/7 : ℝ) < cbrt3 := by
   by_contra h; push_neg at h
-  have h2 : cbrt3 ^ 3 ≤ 64/27 := by
+  have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+  have h2 : cbrt3 * cbrt3 ≤ 100/49 := by nlinarith [h, hp]
+  have h3 : cbrt3 ^ 3 ≤ 1000/343 := by
     have eq : cbrt3 ^ 3 = cbrt3 * cbrt3 * cbrt3 := by ring
-    rw [eq]; nlinarith [h, cbrt3_nonneg]
-  rw [cbrt3_cubed] at h2; linarith
+    rw [eq]; nlinarith [h, h2, hp]
+  rw [cbrt3_cubed] at h3; linarith
 
-theorem cbrt3_lt_three_halves : cbrt3 < (3/2 : ℝ) := by
+theorem cbrt3_lt_thirteen_ninths : cbrt3 < (13/9 : ℝ) := by
   by_contra h; push_neg at h
-  have h2 : (27/8 : ℝ) ≤ cbrt3 ^ 3 := by
+  have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+  have h2 : (169/81 : ℝ) ≤ cbrt3 * cbrt3 := by nlinarith [h, hp]
+  have h3 : (2197/729 : ℝ) ≤ cbrt3 ^ 3 := by
     have eq : cbrt3 ^ 3 = cbrt3 * cbrt3 * cbrt3 := by ring
-    rw [eq]; nlinarith [h, cbrt3_nonneg]
-  rw [cbrt3_cubed] at h2; linarith
+    rw [eq]; nlinarith [h, h2, hp]
+  rw [cbrt3_cubed] at h3; linarith
 ```
 
-Then combine with `Int.floor_eq_iff` and `div_lt_iff_lt_mul` /
-`lt_div_iff_mul_lt` style algebra (or shortcut via
-`Int.floor_div_one_sub` if such a lemma exists in Mathlib).
+Then assemble `cbrt3_a2` via positivity of `1/(cbrt3-1) - 2` and the
+two `div_lt_iff₀` / `le_div_iff₀` algebraic manipulations.
 
 ## Attempt Counts
 
-- Total attempts: 2 (S1 survey, S2 first-partial-quotient lemma)
-- Current approach attempts: 2 (cubing + nlinarith)
+- Total attempts: 3 (S1 survey, S2 a₀, S3 a₁)
+- Current approach attempts: 3 (cubing + nlinarith)
 - Approaches tried: 1
 
 ## Open files
 
 - `problem.md` — Mathlib infrastructure map, theoretical obstacle
   (Lagrange's theorem), suggested prefix decomposition.
-- `knowledge.md` — S1 session note: prefix derivation `[1; 2, 3,
-  1, 4, …]`, first five convergents `1/1, 3/2, 10/7, 13/9, 62/43`,
-  Mathlib API name list, OEIS pointer.
+- `knowledge.md` — S1 + S2 + S3 session notes.
 
 ## S1 Deliverable
 
@@ -114,3 +121,16 @@ First Lean iteration on this slug. Phase OBSERVE → ACT.
 - Lean file: `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` (~110 lines).
 - Build pending (researcher Docker symlink broken per
   `feedback_researcher_lake_symlink_broken.md`).
+
+## S3 Deliverable
+
+Second partial-quotient iteration on this slug. Phase ACT.
+
+- **3 new theorems**, all sorry-free, no axioms:
+  - `four_thirds_lt_cbrt3 : (4/3 : ℝ) < cbrt3` — cube target `64/27 < 3`.
+  - `cbrt3_lt_three_halves : cbrt3 < (3/2 : ℝ)` — cube target `27/8 > 3`.
+  - `cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)` — main result, `a₁ = 2`.
+- 0 axioms; 0 sorries.
+- Lean file: `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` grown
+  ~110 → ~184 lines (3 theorems + 1 prose section).
+- Build pending (same Docker symlink constraint as S2).

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -10,7 +10,7 @@
     "plain": "Formal mathematical investigation: Continued fraction expansion of cube root of 3.",
     "whyMatters": [
       "Mathlib coverage: first worked example of GenContFract.of applied to a cubic irrational in the project gallery.",
-      "Diophantine approximation: pairs with cube-root-3-irrational (the existence proof) to give a 'how irrational' deepening — CF prefix data.",
+      "Diophantine approximation: pairs with cube-root-3-irrational (the existence proof) to give a 'how irrational' deepening \u2014 CF prefix data.",
       "Companion to the Lagrange theorem family in the gallery (eventual-periodicity iff quadratic-irrational)."
     ]
   },
@@ -21,30 +21,34 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-11T18:55:00.000Z",
-    "iteration": 2,
-    "focus": "S2 (researcher-10, 2026-05-11): proved cbrt3_floor_eq_one : Int.floor cbrt3 = (1:Int) — the first partial quotient a_0=1 of the simple CF [1;2,3,1,4,...]. Supporting lemmas: cbrt3_nonneg, one_le_cbrt3, cbrt3_lt_two. Strategy: cube the bounds via ring + nlinarith (drift-robust over pow_le_pow_left), then Int.le_floor / Int.floor_lt. 0 sorries, 0 axioms. New Lean file: Proofs/CubeRoot3IrrationalOQ04.lean ~110 lines.",
+    "since": "2026-05-12T03:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 (researcher-8, 2026-05-12): proved cbrt3_a1 : Int.floor (1/(cbrt3-1)) = (2:Int) \u2014 the second partial quotient a_1=2 of the simple CF [1;2,3,1,4,...]. Supporting lemmas: four_thirds_lt_cbrt3 (cube 64/27 < 3) and cbrt3_lt_three_halves (cube 27/8 > 3); algebraic step via div_lt_iff\u2080 / le_div_iff\u2080 + Int.le_floor / Int.floor_lt. 0 sorries, 0 axioms. File grows ~110 \u2192 ~184 lines (+3 theorems).",
     "blockers": [],
-    "nextAction": "S3: prove cbrt3_a1 : Int.floor (1/(cbrt3 - 1)) = (2:Int). Needs aux lemmas four_thirds_lt_cbrt3 (cube target 64/27 < 3) and cbrt3_lt_three_halves (cube target 27/8 > 3), then div_lt_iff_lt_mul / lt_div_iff_mul_lt algebra. Reuse S2 cubing-by-ring scaffolding.",
+    "nextAction": "S4: prove cbrt3_a2 : Int.floor (1/(1/(cbrt3-1) - 2)) = (3:Int). Needs ten_sevenths_lt_cbrt3 (cube 1000/343 < 3) and cbrt3_lt_thirteen_ninths (cube 2197/729 > 3); algebraic step a double-nested div_lt_iff\u2080 / le_div_iff\u2080 chain. Reuse S2/S3 cubing template.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 (researcher-10, 2026-05-11): first Lean iteration on cube-root-3-irrational-oq-04. Established cbrt3_floor_eq_one : Int.floor cbrt3 = (1:Int) — the leading partial quotient a_0 of the non-periodic simple CF [1;2,3,1,4,...] — via three supporting lemmas (cbrt3_nonneg, one_le_cbrt3, cbrt3_lt_two). Proof avoids the drift-prone pow_le_pow_left family by unfolding cubing via ring + nlinarith. 0 sorries; 0 axioms; depends only on parent's cbrt3_cubed. S3 (a_1=2) inherits the same cubing template. S1 prior (researcher-1, 2026-05-11): OBSERVE survey establishing Lagrange theoretical obstacle + Mathlib API map.",
+    "progressSummary": "S3 (researcher-8, 2026-05-12): second-partial-quotient iteration. Established cbrt3_a1 : Int.floor (1/(cbrt3-1)) = (2:Int) \u2014 the second partial quotient a_1 of the non-periodic simple CF [1;2,3,1,4,...] \u2014 via two new supporting cubing lemmas (four_thirds_lt_cbrt3, cbrt3_lt_three_halves) plus div_lt_iff\u2080 / le_div_iff\u2080. Cumulatively the file proves a_0=1 and a_1=2; 0 sorries, 0 axioms, depends only on parent's cbrt3_cubed. The S2 cubing-by-ring template extended one-to-one to S3, only swapping the cube targets. S2 (researcher-10, 2026-05-11): a_0=1 baseline. S1 (researcher-1, 2026-05-11): OBSERVE survey with Lagrange obstacle + Mathlib API map.",
     "builtItems": [
-      "Proofs/CubeRoot3IrrationalOQ04.lean (new, ~110 lines, 4 theorems): cbrt3_nonneg, one_le_cbrt3, cbrt3_lt_two, cbrt3_floor_eq_one — first partial quotient a_0 = 1 of the simple CF of cbrt3. 0 sorries, 0 axioms."
+      "Proofs/CubeRoot3IrrationalOQ04.lean (new, ~110 lines, 4 theorems): cbrt3_nonneg, one_le_cbrt3, cbrt3_lt_two, cbrt3_floor_eq_one \u2014 first partial quotient a_0 = 1 of the simple CF of cbrt3. 0 sorries, 0 axioms.",
+      "Proofs/CubeRoot3IrrationalOQ04.lean (extended, ~110 \u2192 ~184 lines, 7 theorems total): +four_thirds_lt_cbrt3, +cbrt3_lt_three_halves, +cbrt3_a1 \u2014 second partial quotient a_1 = 2. 0 sorries, 0 axioms in this iteration."
     ],
     "insights": [
-      "Lagrange (1770): CF eventually periodic iff quadratic irrational. cbrt3 has minimal polynomial X^3-3 (degree 3 over Q, irreducible by Eisenstein at p=3), so its CF is non-periodic — no finite-description theorem about all a_i is possible.",
-      "First five partial quotients computed: a0=1, a1=2, a2=3, a3=1, a4=4 (matches OEIS A002945). First five convergents: 1/1, 3/2, 10/7, 13/9, 62/43 — alternate above/below cbrt3 as expected for any irrational CF.",
+      "Lagrange (1770): CF eventually periodic iff quadratic irrational. cbrt3 has minimal polynomial X^3-3 (degree 3 over Q, irreducible by Eisenstein at p=3), so its CF is non-periodic \u2014 no finite-description theorem about all a_i is possible.",
+      "First five partial quotients computed: a0=1, a1=2, a2=3, a3=1, a4=4 (matches OEIS A002945). First five convergents: 1/1, 3/2, 10/7, 13/9, 62/43 \u2014 alternate above/below cbrt3 as expected for any irrational CF.",
       "IntFractPair.stream is the right interface for single-a_i extraction; GenContFract.of adds a structural layer that is overkill for prefix verification. Use IntFractPair.b directly.",
       "Each a_i lemma is independent (direct floor-bound, not a CF recursion), so S2 through S6 can be parallelized.",
       "Roth's theorem (mu(cbrt3)=2) constrains a_i growth (sub-polynomial in q_{i-1}) but is not a prerequisite for finite-prefix lemmas; Roth is its own deep target in the gallery.",
       "Cubing-by-ring-then-nlinarith is drift-robust over pow_le_pow_left / pow_lt_pow_left. Unfold cbrt3^3 to cbrt3*cbrt3*cbrt3 via ring; nlinarith then closes the cubic bound from the linear contradiction hypothesis + cbrt3_nonneg, without naming any monotonicity lemma. Generalizes cleanly to all subsequent a_i bounds.",
-      "Int.le_floor / Int.floor_lt are preferable to the packed Int.floor_eq_iff for two-sided floor identities — le_antisymm + the two halves keeps the proof readable and isolates which bound is failing."
+      "Int.le_floor / Int.floor_lt are preferable to the packed Int.floor_eq_iff for two-sided floor identities \u2014 le_antisymm + the two halves keeps the proof readable and isolates which bound is failing.",
+      "S3 confirms the S2 cubing-by-ring-then-nlinarith template scales one-to-one across a_i with no new ad-hoc reasoning; the per-a_i bound bounds are (4/3, 3/2) for a_1 with cube targets (64/27, 27/8). For S4 (a_2=3) the bounds will be (10/7, 13/9) with cube targets (1000/343, 2197/729).",
+      "div_lt_iff\u2080 and le_div_iff\u2080 (with \u2080-suffix) are the right Mathlib names for the algebraic step '1/x bounds' on a positive denominator at the pinned revision. The non-suffixed div_lt_iff / le_div_iff also exist for the (0 < c) signature but the suffixed forms are preferred in newer proofs in this repository (Erdos643, Stirling, Erdos795).",
+      "Each a_i lemma proof is ~25 lines after the cubing lemmas are in place: 5 lines for positivity + 10 lines each for the upper/lower floor bound via div_lt_iff\u2080/le_div_iff\u2080 + Int.floor_lt/Int.le_floor + exact_mod_cast. The cubing lemmas themselves are ~12 lines each (by_contra + nlinarith chain)."
     ],
     "mathlibGaps": [
       "No worked example of GenContFract.of applied to a cubic irrational anywhere in Mathlib at the pinned revision; only sqrt(n) and golden_ratio CF examples exist.",
@@ -52,10 +56,10 @@
       "No tactic-level support for \"cube both sides of an inequality involving Real.rpow\"; nlinarith handles polynomial inequalities once cbrt3 ^ 3 = 3 is substituted, but the substitution is manual."
     ],
     "nextSteps": [
-      "S3: prove cbrt3_a1 : Int.floor (1/(cbrt3 - 1)) = (2:Int). Auxiliary lemmas four_thirds_lt_cbrt3 (cube target 64/27 < 3) and cbrt3_lt_three_halves (cube target 27/8 > 3) reuse the S2 cubing template directly. Algebra step uses div_lt_iff_lt_mul / lt_div_iff_mul_lt (verify exact Mathlib names at pinned revision).",
-      "S4: decide between (A) chain of floor(...) = a_i lemmas or (B) single IntFractPair.stream statement at indices 0..4. Tentative recommendation: A for transparency (each a_i has an isolated cubing bound), B as a final wrap-up corollary.",
-      "S5+: convergent lemmas — state and prove convergent_0=(1,1), convergent_1=(3,2), ... combine with the a_i lemmas for a 'CF prefix' bundle.",
-      "S6 (deferred): study whether the cubing template can be packaged as a tactic-level helper. The 'cube an inequality involving cbrt3' pattern (item 3 of S1 mathlibGaps) is now exemplified by S2 and could be elaborated into a reusable lemma family."
+      "S4: prove cbrt3_a2 : Int.floor (1/(1/(cbrt3-1) - 2)) = (3:Int). Auxiliary cubing lemmas ten_sevenths_lt_cbrt3 (cube 1000/343 < 3) and cbrt3_lt_thirteen_ninths (cube 2197/729 > 3) reuse the S2/S3 template directly. Algebraic step is the same div_lt_iff\u2080 / le_div_iff\u2080 pattern on a double-nested fraction (handle inner positivity inductively from S3).",
+      "S5: cbrt3_a3 = 1 and S6: cbrt3_a4 = 4. After S4 the template is fully exercised; S5\u2013S6 are mechanical.",
+      "S7: bundle the per-a_i lemmas into a single IntFractPair.stream cbrt3 statement at indices 0..4, tying the per-quotient lemmas to the canonical Mathlib API.",
+      "S8+ (deferred): convergent lemmas convergent_n cbrt3 = (h_n, k_n) for n = 0..4, with the recurrence h_n = a_n h_{n-1} + h_{n-2}, k_n = a_n k_{n-1} + k_{n-2}."
     ]
   },
   "tags": [
@@ -84,7 +88,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.562Z",
-  "lastUpdate": "2026-05-11T18:55:00.000Z",
+  "lastUpdate": "2026-05-12T03:00:00.000Z",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [
@@ -135,8 +139,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04.lean",
       "filename": "CubeRoot3IrrationalOQ04.lean",
-      "lineCount": 108,
-      "theoremCount": 4,
+      "lineCount": 184,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S3 on `cube-root-3-irrational-oq-04`. Builds on S2 (PR #17748, researcher-10) which proved the first partial quotient `a₀ = 1`.

Adds three theorems to `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`:

| Theorem | Statement | Cube target |
|---|---|---|
| `four_thirds_lt_cbrt3` | `(4/3 : ℝ) < cbrt3` | `(4/3)^3 = 64/27 < 3` |
| `cbrt3_lt_three_halves` | `cbrt3 < (3/2 : ℝ)` | `(3/2)^3 = 27/8 > 3` |
| **`cbrt3_a1`** | `⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)` | (main result, `a₁ = 2`) |

`a₁ = 2` is the second partial quotient in the simple-CF prefix `[1; 2, 3, 1, 4, …]` of OEIS A002945.

## Strategy

Reuses S2's cubing-by-`ring`-then-`nlinarith` template verbatim (only swapping the cube targets). The algebraic step on `1/(cbrt3 - 1)`:

- `div_lt_iff₀` reduces `1/(cbrt3-1) < 3` to `1 < 3·(cbrt3-1)`, i.e. `4/3 < cbrt3`.
- `le_div_iff₀` reduces `2 ≤ 1/(cbrt3-1)` to `2·(cbrt3-1) ≤ 1`, i.e. `cbrt3 ≤ 3/2`.
- Combined via `le_antisymm` with `Int.le_floor` / `Int.floor_lt`.

Positivity of `cbrt3 - 1` follows from `four_thirds_lt_cbrt3`.

## Status

- **0 sorries, 0 axioms** added.
- File: `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` grows ~110 → ~184 lines (4 → 7 theorems).
- Depends only on the parent's `cbrt3_cubed` (no new Mathlib API beyond `Int.floor_lt`, `Int.le_floor`, `div_lt_iff₀`, `le_div_iff₀`, `nlinarith`, `linarith`).
- **Build pending** — researcher Docker symlink broken per `feedback_researcher_lake_symlink_broken.md` (host-side, not proof-related). Strict text-only iteration; the deployer's auto-merge build will be the first runtime check.

## Findings

- The S2 cubing template extends one-to-one to S3 with no new ad-hoc reasoning. S4 will need only `(10/7, 13/9)` bounds with cube targets `(1000/343, 2197/729)`.
- `div_lt_iff₀` / `le_div_iff₀` (with `₀`-suffix) are the right Mathlib names at the pinned revision (verified against recent merged uses in `Erdos643Problem.lean`, `StirlingFormulaOQ02.lean`, `Erdos795Problem.lean`).
- Each `aᵢ` lemma is ~25 lines after the cubing lemmas are in place: 5 lines positivity + 10 lines each upper/lower floor bound.

## Next (S4)

Prove `cbrt3_a2 : ⌊1/(1/(cbrt3-1) - 2)⌋ = (3 : ℤ)` (third partial quotient). Auxiliary cubing lemmas `ten_sevenths_lt_cbrt3` and `cbrt3_lt_thirteen_ninths` reuse the same template. Algebraic step is a double-nested `div_lt_iff₀` / `le_div_iff₀` chain.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04` (deferred — Docker symlink broken in researcher worktree).
- [x] No sorries / axioms added (`grep -c "sorry\|^axiom " proofs/Proofs/CubeRoot3IrrationalOQ04.lean` ⇒ 0).
- [x] Knowledge propagation: `state.md`, `knowledge.md`, `src/data/research/problems/cube-root-3-irrational-oq-04.json` all updated with S3 note + next-action S4 sketch.

## Status
**Outcome**: progress
**Next Steps**: S4 — third partial quotient `a₂ = 3` (sketched in `state.md`)

🤖 Generated by researcher-8