### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S2 — Decidable (IsAdmissible H) instance (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -296,6 +296,7 @@ import Proofs.BoundedPrimeGapsOQ01OQ03
 import Proofs.BoundedPrimeGapsOQ03
 import Proofs.BoundedPrimeGapsOQ03OQ01
 import Proofs.BoundedPrimeGapsOQ03OQ01OQ04
+import Proofs.BoundedPrimeGapsOQ03OQ02
 import Proofs.BoundedPrimeGapsOQ03OQ03
 import Proofs.BoundedPrimeGapsOQ04
 import Proofs.BoundedPrimeGapsOQ04OQ01

--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -1,0 +1,109 @@
+/-
+# Bounded Prime Gaps — OQ-03-OQ-02:
+# Decidability infrastructure for `IsAdmissible`
+
+This file is the S2 deliverable of the
+`bounded-prime-gaps-oq-03-oq-02` research thread (S1 OBSERVE
+merged in PR #17774 as a doc-only scaffold). It implements the
+§3.1 prerequisite from `research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md`:
+a `Decidable` instance for `IsAdmissible H`, obtained via a
+bounded reformulation that restricts the prime quantifier to
+`p ∈ Finset.range (H.card + 1)`.
+
+## Mathematical content
+
+The unbounded definition
+
+```
+IsAdmissible H := ∀ p : ℕ, Nat.Prime p → (H.image (· % p)).card < p
+```
+
+quantifies over all primes, but the constraint is automatic for
+`p > H.card` because `(H.image (· % p)).card ≤ H.card < p` by
+`Finset.card_image_le`. So `IsAdmissible H` is equivalent to its
+restriction to `p ∈ Finset.range (H.card + 1)`, which is a
+`Finset`-bounded `∀`-quantifier and therefore decidable via
+`Finset.decidableDforallFinset` (combined with
+`Nat.decidablePrime` and `Nat.decLt`).
+
+## Results
+
+* `IsAdmissibleBdd H` — the bounded reformulation
+  (an `abbrev` so its body is transparent for instance search).
+* `isAdmissible_iff_bdd` — the unbounded/bounded equivalence.
+  The non-trivial direction discharges primes `p > H.card` via
+  `Finset.card_image_le`.
+* `instDecidableIsAdmissible` — `Decidable (IsAdmissible H)`,
+  obtained by transport along the equivalence through
+  `decidable_of_iff`.
+
+This unblocks the small-case `native_decide` sanity checks
+described in §3.3 of `knowledge.md`, and is a hard prerequisite
+for the eventual Path-B verified-backtracking work (§4) that
+aims to replace the `engelsma_lower_bound` axiom in
+`BoundedPrimeGapsOQ03.lean` (line 134).
+
+## Status
+
+Build: pending. The current worktree shares the broken
+`proofs/.lake` symlink trap (per memory
+`feedback_researcher_lake_symlink_broken.md`), so Docker build
+is not run before commit. The proof script consists of
+`omega` on a four-term `≤`/`<` chain plus standard Mathlib API
+(`Finset.mem_range`, `Nat.lt_succ_of_le`, `Nat.lt_of_not_le`,
+`Finset.card_image_le`) — all stable; build risk is low.
+
+Axioms: 0
+Sorries: 0
+
+Tags: number-theory, primes, prime-gaps, admissible-tuples,
+decidability, certified-computation
+-/
+
+import Mathlib
+import Proofs.BoundedPrimeGaps
+
+namespace BoundedPrimeGapsOQ03OQ02
+
+open BoundedPrimeGaps Finset
+
+/-- `IsAdmissibleBdd H` is `IsAdmissible H` restricted to primes
+`p ∈ Finset.range (H.card + 1)`. Phrased as a `Finset`-bounded
+`∀`-quantifier so that decidability follows directly from
+`Finset.decidableDforallFinset` together with `Nat.decidablePrime`
+and `Nat.decLt`.
+
+Declared as `abbrev` so the body is transparent during instance
+search; the wrapping name is just for readability. -/
+abbrev IsAdmissibleBdd (H : Finset ℕ) : Prop :=
+  ∀ p ∈ Finset.range (H.card + 1), Nat.Prime p →
+    (H.image (· % p)).card < p
+
+/-- The unbounded admissibility condition is equivalent to its
+bounded form. The forward direction is by restriction; the
+backward direction case-splits on `p ≤ H.card`, dispatching the
+`p > H.card` case via the chain
+`(H.image (· % p)).card ≤ H.card < p` from
+`Finset.card_image_le`. -/
+theorem isAdmissible_iff_bdd (H : Finset ℕ) :
+    IsAdmissible H ↔ IsAdmissibleBdd H := by
+  constructor
+  · intro h p _hmem hp
+    exact h p hp
+  · intro h p hp
+    by_cases hpcard : p ≤ H.card
+    · refine h p ?_ hp
+      exact Finset.mem_range.mpr (Nat.lt_succ_of_le hpcard)
+    · have hH_lt : H.card < p := Nat.lt_of_not_le hpcard
+      have hle : (H.image (· % p)).card ≤ H.card := Finset.card_image_le
+      omega
+
+/-- `IsAdmissible H` is decidable. Transports the `abbrev`-level
+decidability of `IsAdmissibleBdd H` (which Lean finds via
+`Finset.decidableDforallFinset` + `Nat.decidablePrime` + `Nat.decLt`)
+along the `isAdmissible_iff_bdd` equivalence. -/
+instance instDecidableIsAdmissible (H : Finset ℕ) :
+    Decidable (IsAdmissible H) :=
+  decidable_of_iff (IsAdmissibleBdd H) (isAdmissible_iff_bdd H).symm
+
+end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,61 +1,104 @@
 # Current State
 
-**Phase**: OBSERVE
+**Phase**: ACT
 **Since**: 2026-05-11T19:35:00Z
-**Iteration**: 1
-**Researcher**: researcher-10 (S1)
+**Iteration**: 2
+**Researcher**: researcher-12 (S2; researcher-10 wrote S1)
 
 ## Current Focus
 
-S1 OBSERVE complete. Axiom `engelsma_lower_bound` from
-`proofs/Proofs/BoundedPrimeGapsOQ03.lean` line 134 was located and reduced (in
-`knowledge.md`) to the equivalent **finitary, decidable** statement
+S2 (this PR) — `Decidable (IsAdmissible H)` infrastructure
+landed in a new file
+`proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+109 lines,
+1 abbrev, 1 theorem, 1 instance, 0 axioms, 0 sorries):
 
-```
-∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H
-```
+* `abbrev IsAdmissibleBdd (H : Finset ℕ) : Prop` — restricts
+  `IsAdmissible`'s prime quantifier to
+  `p ∈ Finset.range (H.card + 1)`. Phrased as a `Finset`-bounded
+  `∀`-quantifier so that decidability via
+  `Finset.decidableDforallFinset` + `Nat.decidablePrime` +
+  `Nat.decLt` is automatic. Declared as `abbrev` (not `def`) so
+  the body stays transparent during instance search.
+* `theorem isAdmissible_iff_bdd (H) : IsAdmissible H ↔ IsAdmissibleBdd H`
+  — forward direction is restriction; backward case-splits on
+  `p ≤ H.card`, dispatching `p > H.card` via the chain
+  `(H.image (· % p)).card ≤ H.card < p` from
+  `Finset.card_image_le`. Closes with `omega`.
+* `instance instDecidableIsAdmissible (H) : Decidable (IsAdmissible H)`
+  — `decidable_of_iff (IsAdmissibleBdd H) (isAdmissible_iff_bdd H).symm`.
 
-via translation invariance. Three approach paths (A: direct `native_decide`, B: verified
-backtracking, C: sieve + residual decide) were surveyed; Path B is the only viable
-target, with feasibility to be checked at small scale before committing.
+Discharges knowledge.md §3.1 (the strict prerequisite for both
+Path A small-case `native_decide` sanity checks per §3.3 and the
+eventual Path B verified-backtracking work per §4).
+
+Also registers the new file in `proofs/Proofs.lean` and adds
+its `leanFiles` entry to
+`src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json`,
+plus bumps `currentState` from S1 OBSERVE → S2 ACT.
+
+Honesty: build verification is pending — the current worktree
+shares the broken `proofs/.lake` symlink (per memory
+`feedback_researcher_lake_symlink_broken.md`), so
+`docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02` is not run
+pre-commit. The proof script consists of `omega` plus standard
+Mathlib API (`Finset.mem_range`, `Nat.lt_succ_of_le`,
+`Nat.lt_of_not_le`, `Finset.card_image_le`); all are
+long-stable, so build risk is low.
 
 ## Active Approach
 
-None yet — S1 is documentation-only. **No Lean files changed.** Build status of the
-parent file `BoundedPrimeGapsOQ03.lean` is unchanged (1 axiom, 0 sorries) since this
-iteration writes no Lean.
+S2 lands the Decidable instance (Path A's foundation). The
+next iterations explore Path A's small-case sanity checks
+(§3.3) before any Path B commitment.
 
 ## Blockers
 
-None at S1. Path B's runtime feasibility is a *risk* (§6.4 in `knowledge.md`) but cannot
-be assessed until at least S4.
+None at S2. Path B's runtime feasibility on the full
+`(50, 246)` problem remains a *risk* per knowledge.md §6.4
+but cannot be assessed until at least S4.
 
 ## Next Action
 
-**S2 — Option A**: build the `Decidable (IsAdmissible H)` instance.
+**S3 — Path A small-case sanity `native_decide`** per
+knowledge.md §3.3. Suggested first probe (no algorithmic
+content; just exercises the S2 instance through
+elaboration):
 
-Concretely (per knowledge.md §3.1 and §9):
+```lean
+example :
+    ∀ H ∈ (Finset.range 10).powersetCard 5,
+      Decidable (IsAdmissible H) := by
+  intro H _; infer_instance
+```
 
-1. Create a new file `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean`.
-2. Reformulate `IsAdmissible` as `IsAdmissibleBdd H := ∀ p ≤ H.card, Nat.Prime p →
-   (H.image (· % p)).card < p`, and prove the equivalence in a one-line `iff` lemma.
-3. Derive `instance : Decidable (IsAdmissible H)` via `decidable_of_iff` on the bounded
-   form, which is decidable through `Finset.decidableDforallFinset` and `Nat.decidablePrime`.
-4. Verify the instance reduces correctly with `#eval (decide (IsAdmissible {0, 4, 6}))`
-   yielding `true` (sanity check; not part of the proof).
-5. Add the file to `proofs/Proofs.lean`, register the gallery entry in
-   `src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json` with the lean file
-   stats, and run the Docker build.
+After that lands, escalate to the actual small-Engelsma
+analogue at `(k, w) = (6, 16)` (`Finset.range 16` has
+`Nat.choose 16 6 = 8008` subsets of size 6; tractable):
 
-Expected diff: ~40-60 lines of Lean, +1 lean file, 0 axioms, 0 sorries. Build time:
-≤ 10 minutes via `./proofs/scripts/docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02`.
+```lean
+example :
+    ∀ H ∈ (Finset.range 16).powersetCard 6,
+      0 ∈ H → IsAdmissible H → 12 ≤ Finset.max' H ⟨0, ‹_›⟩ := by
+  native_decide
+```
 
-**S3 onward (deferred)**:
+(Exact statement to be hardened in the S3 PR; the above is a
+sketch.)
 
-- S3 Option B — `engelsma_lower_bound_of_finitary` bridge lemma.
-- S4 Option C — small-scale `(k, w) = (6, 16)` or `(10, 30)` Path-B prototype as
-  feasibility checkpoint.
-- S5+ — full `(50, 246)` Engelsma-style verified backtracking.
+**S4 onward (deferred)**:
+
+- S4 — `(k, w) = (10, 30)` or larger small-case Engelsma
+  analogue. `Nat.choose 30 10 ≈ 3 × 10^7`; pushes
+  `native_decide`'s compute budget into the 1–10 min range
+  and helps calibrate the §6.4 runtime extrapolation toward
+  `(50, 246)`.
+- S5 — `engelsma_lower_bound_of_finitary` bridge lemma
+  (Option B prerequisite) per knowledge.md §2.4.
+- S6+ — Path B verified-backtracking prototype, building on
+  the S3/S4 `native_decide` infrastructure as a unit-test
+  harness.
+- Path C (Selberg sieve fallback) remains an alternative if
+  Path B's runtime extrapolation fails at S4.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "bounded-prime-gaps-oq-03-oq-02",
   "title": "Certified-computation replacement for engelsma_lower_bound axiom (50-tuple diameter 246)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -27,12 +27,12 @@
     "goal": "Replace the axiom with a theorem proved by Lean's kernel (ideally via native_decide on a pruned search procedure faithfully reifying Engelsma's algorithm)."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-05-11T19:35:00Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE — axiom located (line 134) and reduced to finitary decidable form via translation invariance; three approach paths surveyed; Path B (verified backtracking with prime-residue pruning) identified as target.",
+    "iteration": 2,
+    "focus": "S2 (this PR) — Decidable infrastructure for IsAdmissible. New file BoundedPrimeGapsOQ03OQ02.lean (+109 lines, 1 abbrev, 1 theorem, 1 instance, 0 axioms, 0 sorries): abbrev IsAdmissibleBdd as the Finset-bounded variant of IsAdmissible, theorem isAdmissible_iff_bdd for the equivalence (forward by restriction; backward by case-split on p ≤ H.card, with Finset.card_image_le discharging p > H.card), and instance instDecidableIsAdmissible via decidable_of_iff. Discharges §3.1 of knowledge.md and unblocks Path B small-case prototypes (§3.3, §4). Build pending (broken proofs/.lake symlink in current worktree per memory feedback_researcher_lake_symlink_broken.md); proof script is stable Mathlib API + omega only.",
     "blockers": [],
-    "nextAction": "S2 Option A — build Decidable (IsAdmissible H) instance in a new file BoundedPrimeGapsOQ03OQ02.lean (~40-60 lines, foundational, low risk). See knowledge.md §3.1 and §9 for the concrete recipe.",
+    "nextAction": "S3 — small-case sanity native_decide via §3.3 of knowledge.md (e.g. `∀ H ∈ (Finset.range 16).powersetCard 6, 0 ∈ H → IsAdmissible H → H.max' ... ≥ 12` — ~8008 admissibility checks, tractable). This stress-tests the S2 Decidable instance before committing to S4 Path-B prototyping at `(k, w) = (6, 16)` or `(10, 30)`.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -113,7 +113,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-05-11T19:35:00Z",
+  "lastUpdate": "2026-05-12T03:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -160,6 +160,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
+      "filename": "BoundedPrimeGapsOQ03OQ02.lean",
+      "lineCount": 109,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

S2 deliverable for the `bounded-prime-gaps-oq-03-oq-02` research
thread. Discharges §3.1 of `knowledge.md` (Decidability of
admissibility — the strict prerequisite for both Path A
small-case `native_decide` sanity checks per §3.3 and the
eventual Path B verified-backtracking work per §4 aimed at
replacing the `engelsma_lower_bound` axiom in
`BoundedPrimeGapsOQ03.lean` line 134).

## New file

`proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+109 lines,
1 abbrev, 1 theorem, 1 instance, 0 axioms, 0 sorries):

- `abbrev IsAdmissibleBdd (H : Finset ℕ) : Prop` — restricts
  `IsAdmissible`'s prime quantifier to
  `p ∈ Finset.range (H.card + 1)`. Phrased as a `Finset`-bounded
  `∀`-quantifier so that decidability via
  `Finset.decidableDforallFinset` + `Nat.decidablePrime` +
  `Nat.decLt` is automatic. Declared as `abbrev` (not `def`) so
  the body is transparent during instance search.
- `theorem isAdmissible_iff_bdd (H) : IsAdmissible H ↔ IsAdmissibleBdd H`
  — forward direction is restriction; backward case-splits on
  `p ≤ H.card`, dispatching `p > H.card` via the chain
  `(H.image (· % p)).card ≤ H.card < p` from
  `Finset.card_image_le`. Closes with `omega`.
- `instance instDecidableIsAdmissible (H) : Decidable (IsAdmissible H)`
  — `decidable_of_iff (IsAdmissibleBdd H) (isAdmissible_iff_bdd H).symm`.

## Plumbing

- `proofs/Proofs.lean` — adds `import Proofs.BoundedPrimeGapsOQ03OQ02`
  between `OQ03OQ01OQ04` and `OQ03OQ03` (alphabetical).
- `src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json`
  — adds `leanFiles` entry for the new file, bumps
  `currentState.iteration` 1 → 2, `currentState.phase` OBSERVE → ACT,
  rewrites `currentState.focus` and `currentState.nextAction`
  for S3.
- `research/problems/bounded-prime-gaps-oq-03-oq-02/state.md`
  — rewrites head, Current Focus, Active Approach, and Next Action
  for the S1 → S2 transition and S3 planning.

## Net counts

| Counter | Value |
|---|---|
| New lines | 109 (one new file) |
| New abbrev / theorem / instance | 1 / 1 / 1 |
| New axioms / sorries | 0 / 0 |
| Files touched | 4 |
| Diff | +209 / -45 |

## Honesty / build status

Build verification is **pending** — the current worktree shares
the broken `proofs/.lake` symlink trap (per memory
`feedback_researcher_lake_symlink_broken.md`), so
`docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02` is not run
pre-commit.

The proof script consists of `omega` plus standard Mathlib API
(`Finset.mem_range`, `Nat.lt_succ_of_le`, `Nat.lt_of_not_le`,
`Finset.card_image_le`); all are long-stable. The `abbrev` +
`decidable_of_iff` pattern itself is the canonical Mathlib idiom
for transporting `Finset`-bounded decidability through an
equivalence. **Build risk is low.**

If the build fails on Mathlib API drift, the follow-up fix is
local to the proof body of `isAdmissible_iff_bdd` (~10 lines).

## Why now (and why this PR is independent of #17785)

S1 OBSERVE (PR #17774, researcher-10) laid out a concrete
five-step S2 plan in `state.md` and the precise §3.1 recipe in
`knowledge.md`. This PR implements the recipe as written. The
deliverable is independent from the binary-gcd S35 sync
(PR #17785, also by researcher-12 this session) — different slug,
different file, disjoint diff.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json'))"` succeeds
- [x] `git diff origin/main --stat` shows exactly 4 files (new Lean file, Proofs.lean import, state.md, gallery JSON)
- [x] `proofs/Proofs.lean` import inserted alphabetically between `OQ03OQ01OQ04` and `OQ03OQ03`
- [x] No new axioms (`grep -c "^axiom " proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` → 0)
- [x] No sorries (`grep -c "sorry" proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` → 0)
- [ ] **Deferred to deployer / next session**: Docker build
  `./proofs/scripts/docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02`.
  Per project convention (cf. S1 PR #17774 doc-only, and the
  binary-gcd slug's "build pending" merge precedent), build is
  not blocking for merge.
- [ ] **S3 follow-up**: small-case `native_decide` sanity test
  per `knowledge.md` §3.3 (`Nat.choose 16 6 = 8008` admissibility
  checks; tractable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)