### PR TITLE
audit(cantors-theorem-oq-01-oq-03): badge original → mathlib (Tier B)

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "power-set",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 206,


### PR DESCRIPTION
## Integrity audit finding

**Proof**: `cantors-theorem-oq-01-oq-03`
**Issue**: Badge `original` overstates the originality of a Mathlib wrapper.

### Evidence

The main theorem in `proofs/Proofs/CantorsTheoremOQ01OQ03.lean`:

```lean
theorem konig_general {κ : Cardinal.{0}} (hκ : ℵ₀ ≤ κ) :
    κ < (2 ^ κ).ord.cof :=
  Cardinal.lt_cof_power hκ (by norm_num)
```

is a one-line wrapper of Mathlib's `Cardinal.lt_cof_power`. The four corollaries
in this file specialize the wrapper (to 𝔠, to ℵ_α, to |𝒫(ℝ)|) and combine it
with the parent's `card_powerSet_real_formula`.

Per `.claude/commands/lean-auditor.md`:

> **Tier B — Formalized using Mathlib theorem**
> Core argument relies on a Mathlib theorem. Our file provides definitions,
> bridge, or infrastructure. Badge: `mathlib`.

And from the "Five Narrative Failure Modes":

> **5. "0 sorries" with hidden imports** — File has 0 sorries but obtains its
> main result by calling a deep Mathlib theorem. Technically sorry-free but
> misleadingly presented as independent work. Fix: Badge must be `mathlib`,
> not `original` or `verified`.

### Note

The `description` and `assumptions` fields already credit Mathlib correctly
("follows from Mathlib's `Cardinal.lt_cof_power`"). Only the badge was off.
Most sibling Cantor entries (`cantors-theorem`, `cantors-theorem-oq-01`, etc.)
already use `mathlib`; this one was an outlier.

### Change

`src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json`:
- `"badge": "original"` → `"badge": "mathlib"`

(`status: verified` is preserved — counts match: sorries=0, axiomCount=0, no True stubs.)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)