### PR TITLE
Enrich fourier-series-oq-04: add namespace/PART-header section

### DIFF
--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -67,6 +67,14 @@
       "summary": "Module header explaining the four key differences from 1D Fourier theory: L¹ rectangular divergence (Fefferman 1971), smooth function divergence, Bochner-Riesz framework, and L² persistence. Lists references: Grafakos, Stein-Weiss, Fefferman. Imports Mathlib and opens MeasureTheory and Complex."
     },
     {
+      "id": "section-namespace-and-part-headers",
+      "title": "Namespace, Imports, and PART Section Headers",
+      "startLine": 22,
+      "endLine": 31,
+      "summary": "`namespace FourierSeriesOQ04` declaration, `open MeasureTheory Complex` directive (bringing the relevant Mathlib measure-theory and complex-analysis namespaces into scope), and the PART I block-comment header introducing the multi-dimensional Fourier-coefficient subsystem. This bookkeeping bridges the §I module docstring (lines 1–24) to the formal definitions starting at line 32.",
+      "mathContext": "The namespace-and-PART-header pattern is the file's organizational scaffold: each PART block-comment header (`/* PART I/II/III/IV */`) marks a phase of the file's exposition — coefficient definitions, summation methods, axiomatized convergence results, and final remarks. The `open MeasureTheory Complex` makes `Complex.exp`, `Complex.I`, `MeasureTheory.integral` available without prefix."
+    },
+    {
       "id": "section-fourier-coefficients",
       "title": "Part I: Multi-Dimensional Fourier Coefficients",
       "startLine": 32,


### PR DESCRIPTION
## Summary

Single-section enrichment pass for \`fourier-series-oq-04\` (multi-dimensional Fourier series convergence). Quality score lifted **98 → 100** (find-targets.ts).

### Added: namespace/PART-header section
The pre-enrichment \`sections\` array left lines 22–31 of \`Proofs/FourierSeriesOQ04.lean\` uncovered — specifically the \`namespace FourierSeriesOQ04\` declaration, the \`open MeasureTheory Complex\` directive, and the PART I block-comment header that introduces the multi-dimensional Fourier-coefficient subsystem.

The new section:
- Names the namespace and the \`open\` directive (clarifying why \`Complex.exp\`, \`Complex.I\`, \`MeasureTheory.integral\` appear without prefix in the bodies below)
- Explains the file's PART-header organizational scaffold (PART I/II/III/IV demarcating coefficient defs, summation methods, axiomatized convergence, remarks)
- Carries a \`mathContext\` field

Sections bucket: 8 → 10 points.

## Test plan
- [x] \`python3 -m json.tool\` validates \`meta.json\`
- [x] \`npx tsx scripts/enricher/find-targets.ts --json\` reports quality 100/100
- [ ] CI build (\`pnpm build\`) — local install fails on Node 26 / better-sqlite3 (see memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)