### PR TITLE
audit(algebraic-numbers-countable-oq-02-oq-04): tracker sync — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15070,6 +15070,12 @@
       "lastAudited": "2026-05-12T01:37:42Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-numbers-countable-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T03:41:57Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: `algebraic-numbers-countable-oq-02-oq-04` — Countability of Computable Real Numbers

### Verified
| Field | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 0 | 0 | ✓ |
| `lineCount` | 316 | 316 | ✓ |
| `theoremCount` | 11 | 11 | ✓ |
| `definitionCount` | 2 | 2 | ✓ |
| True stubs | n/a | 0 | ✓ |

### Notes
- Tier B (Mathlib bridge): main `computable_reals_countable` chains `Nat.Partrec.Code.exists_code` + `Set.countable_range` + `Set.Countable.mono`.
- Badge `wip` correctly signals S3 "build pending" — docstring and `originalContributions` explicitly note this.
- `mathlibDependencies` enumerates the bridge theorems honestly; no overclaiming detected.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)