### PR TITLE
research(erdos-101-oq-01): S2 ACT — Solymosi–Stojaković lower bound + Erdős Θ(n³ᐟ²) refuted

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -53,6 +53,9 @@ Reference: https://erdosproblems.com/101
 -/
 
 import Proofs.Erdos101Problem
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Sqrt
 
 namespace Erdos101OQ01
 
@@ -239,15 +242,84 @@ paper, and we defer it to a follow-up iteration.
 
 ## Next iterations
 
-* **S2**: formalise the Solymosi–Stojaković lower-bound *statement*
-  (without the construction) as a recorded fact, witnessing
-  $\Omega(n^{2 - O(1/\sqrt{\log n})})$ existential lower bound; this
-  refutes Erdős's $\Theta(n^{3/2})$ original conjecture.
 * **S3**: connect `fourPointLineCount_le_quadratic` to a
   `Asymptotics.IsBigO` style statement using `Mathlib.Analysis.
   Asymptotics`; investigate whether the existing `improved_upper_bound`
   can yield a $1 - o(1)$ leading constant via per-point Cauchy–Schwarz
   beyond `fourCollinearThrough_bound`.
+
+## S2 (this iteration): Solymosi–Stojaković lower bound
+
+S2 records the Solymosi–Stojaković (2013) existential lower bound as a
+`theorem ... := by sorry` (the construction itself is well beyond
+elementary Lean and is deferred to a much later iteration).  The
+statement is enough to *refute* Erdős's original $\Theta(n^{3/2})$
+conjecture: the lower bound $n^{2 - C / \sqrt{\log n}}$ grows
+asymptotically faster than $n^{3/2}$ for any fixed $C > 0$, so the
+$\Theta(n^{3/2})$ conjecture is false in the upper-bound direction.
+
+The conjecture sits between the trivial $O(n^2)$ upper bound and the
+Solymosi–Stojaković $\Omega(n^{2 - O(1/\sqrt{\log n})})$ lower bound;
+OQ-01 asks whether the upper side can be improved to $o(n^2)$.
 -/
+
+/- ## S2 ACT: Solymosi–Stojaković 2013 existential lower bound
+
+The following two `theorem ... := by sorry` declarations record:
+
+1. The Solymosi–Stojaković (2013) lower bound on the maximum
+   four-point line count, witnessed by an explicit construction over
+   finite fields (we do **not** formalise the construction; we record
+   only the statement as a deferred proof obligation).
+2. The corollary that Erdős's $\Theta(n^{3/2})$ conjecture is refuted
+   by the same construction.
+
+Both are recorded as `theorem ... := by sorry` rather than `axiom`
+declarations, so the file remains axiom-free (the assumption is a
+deferred *proof obligation* rather than a permanent assumption).
+-/
+
+/-- **Solymosi–Stojaković 2013 lower bound** (existential statement).
+
+For every $C > 0$, all sufficiently large $n$ admit a no-five-collinear
+planar point set of size $n$ with at least
+$n^{2 - C / \sqrt{\log n}}$ four-point lines.
+
+Reference: J. Solymosi and M. Stojaković, "Many collinear k-tuples
+with no $k+1$ collinear points," *Discrete & Computational Geometry*
+50 (2013), 811–820.
+
+The construction uses algebraic geometry over finite fields and is
+deferred to a much later iteration.  We record the statement as a
+`theorem ... := by sorry` so it can be consumed by other theorems
+without introducing a permanent `axiom`. -/
+theorem solymosi_stojakovic_lower_bound :
+    ∀ C : ℝ, 0 < C → ∃ N : ℕ, ∀ n : ℕ, N ≤ n →
+      ∃ P : PlanarPointSet, P.points.card = n ∧ NoFiveCollinear P ∧
+        (fourPointLineCount P : ℝ) ≥
+          (n : ℝ) ^ (2 - C / Real.sqrt (Real.log n)) := by
+  sorry
+
+/-- **Refutation of Erdős's original $\Theta(n^{3/2})$ conjecture.**
+
+Erdős originally conjectured that the maximum number of four-point
+lines under no-five-collinear is $\Theta(n^{3/2})$.  The Solymosi–
+Stojaković lower bound refutes the upper half of that conjecture: for
+every $C > 0$ and sufficiently large $n$, there exists a
+no-five-collinear planar point set of size $n$ with strictly more than
+$n^{3/2}$ four-point lines, i.e. there is no global $O(n^{3/2})$
+upper bound.
+
+This corollary follows from `solymosi_stojakovic_lower_bound` together
+with the elementary asymptotic
+$2 - C / \sqrt{\log n} > 3/2$ for sufficiently large $n$.
+
+The corollary is recorded as `theorem ... := by sorry`; discharging it
+in a follow-up iteration is a real-analysis exercise that does not
+require the construction itself. -/
+theorem erdos_three_halves_conjecture_refuted :
+    ¬ (∃ N : ℕ, ∀ (P : PlanarPointSet), NoFiveCollinear P → N ≤ P.points.card →
+        (fourPointLineCount P : ℝ) ≤ (P.points.card : ℝ) ^ (3 / 2 : ℝ)) := by
+  sorry
 
 end Erdos101OQ01

--- a/research/problems/erdos-101-oq-01/knowledge.md
+++ b/research/problems/erdos-101-oq-01/knowledge.md
@@ -104,3 +104,64 @@ only well-established Mathlib API. The one risky step is the
 `bounds_at_rate_quadratic_over_twelve`; this is a standard ℕ→ℝ
 manipulation. If CI fails, the fall-back is to weaken the rate to
 the unconditional $n^2$ alone (already provable).
+
+## S2 (researcher-1, 2026-05-12) — Solymosi–Stojaković lower bound
+
+### S2 deliverable (this iteration)
+
+Two new `theorem ... := by sorry` declarations appended to
+`Erdos101OQ01.lean` (file grows 253 → 325 lines, sorries 1 → 3,
+theorems 6 → 8, axioms unchanged at 0):
+
+| Theorem | Type | Status |
+|---|---|---|
+| `solymosi_stojakovic_lower_bound` | $\forall C > 0, \exists N, \forall n \geq N, \exists P, \lvert P \rvert = n \land \text{NoFiveCollinear } P \land \text{fourPointLineCount } P \geq n^{2 - C/\sqrt{\log n}}$ | sorry (construction deferred) |
+| `erdos_three_halves_conjecture_refuted` | $\neg (\exists N, \forall P, \text{NoFiveCollinear } P \to N \leq \lvert P \rvert \to \text{fourPointLineCount } P \leq \lvert P \rvert ^ {3/2})$ | sorry (real-analysis arithmetic) |
+
+Three new Mathlib imports added (no other changes to existing code):
+
+- `Mathlib.Analysis.SpecialFunctions.Pow.Real` — `Real.rpow` for the
+  $n^{2 - C / \sqrt{\log n}}$ expression and the $\lvert P \rvert ^ {3/2}$
+  corollary.
+- `Mathlib.Analysis.SpecialFunctions.Log.Basic` — `Real.log` in the
+  $\sqrt{\log n}$ denominator.
+- `Mathlib.Analysis.SpecialFunctions.Sqrt` — `Real.sqrt` for
+  $\sqrt{\log n}$.
+
+### Why record the lower bound as a theorem-stub rather than an axiom
+
+Memory's axiom-integrity policy: every `axiom` declaration is a
+*permanent* assumption.  A `theorem ... := by sorry` is a *deferred
+proof obligation* that future iterations can discharge; the file
+remains formally axiom-free.  This matches the project's
+"axiomCount = 0 wherever possible" preference (see
+`feedback_mechanic_axiomcount_pattern.md`).
+
+### S3 next-action candidates
+
+1. **Discharge `erdos_three_halves_conjecture_refuted`** from the
+   Solymosi–Stojaković lower bound by elementary real-analysis
+   arithmetic.  Estimated 30–60 lines using `Real.rpow_lt_rpow`,
+   `Real.log_pos`, `Real.sqrt_lt_sqrt`, and the fact that
+   $C / \sqrt{\log n} \to 0$.
+
+2. **Connect to `Asymptotics.IsBigO` / `IsLittleO`** by defining
+   `maxFourPointLines : ℕ → ℕ` via `Finset.sup'` over all
+   no-five-collinear sets of fixed size; convert
+   `fourPointLineCount_le_quadratic` to an `IsBigO` statement and
+   record the conjecture as an `IsLittleO` sorry.
+
+3. **Cauchy–Schwarz refinement** of `fourCollinearThrough_bound`
+   $\leq (n-1)/3$ to potentially yield a $1 - o(1)$ leading constant
+   on the elementary $n^2/12$ bound (not $o(n^2)$, but a real
+   improvement on the constant).
+
+### Build risk
+
+S2 introduces no proof tactics — both new theorems are pure
+sorry stubs with no `by ...` body beyond `sorry`.  The only build
+risk is in the *type signatures*: `Real.rpow`, `Real.sqrt`, and
+`Real.log` are all in the imported modules.  The
+`(n : ℝ) ^ (real exponent)` syntax resolves to `Real.rpow` by
+inheriting the `HPow ℝ ℝ ℝ` instance from
+`Mathlib.Analysis.SpecialFunctions.Pow.Real`.

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,75 +1,81 @@
 # Current State
 
-**Phase**: OBSERVE
-**Since**: 2026-05-11 (S1)
-**Iteration**: 1
-**Last Updated**: 2026-05-11 (researcher-3)
+**Phase**: ACT
+**Since**: 2026-05-12 (S2)
+**Iteration**: 2
+**Last Updated**: 2026-05-12 (researcher-1)
 
 ## Current Focus
 
-S1 (researcher-3): Initial scaffold for OQ-01 of Erdős Problem #101.
-Records the formal $\Sigma_2$-style statement of the $\$100$ open
-conjecture, the asymptotic vocabulary (`IsLittleOh_n_squared`,
-`BoundsAtRate`), and the small-case lemmas the conjecture subsumes
-— all unconditional except the main theorem.
+S2 (researcher-1) delivered the Solymosi–Stojaković 2013 existential
+lower bound as a `theorem ... := by sorry` together with the corollary
+that Erdős's original $\Theta(n^{3/2})$ conjecture is refuted by the
+same construction.  Both new theorems are sorry stubs — the
+construction itself uses algebraic geometry over finite fields and is
+deferred to a much later iteration.  No new axioms were introduced.
 
 ## Active Approach
 
-**Statement-first scaffold; small cases first.**
+**Statement-first scaffold; small cases + recorded lower bound.**
 
-The conjecture is OPEN; this iteration does NOT attempt a proof.
-Instead it:
+Following S1's "statement-first" pattern, S2 records:
 
-1. Pins the formal Σ₂ statement in Lean syntax.
-2. Records the equivalent rate-form via `BoundsAtRate`.
-3. Proves the small-case (`|P| ≤ 3`) lemma unconditionally so the
-   ε–N form is meaningful only in the regime $|P| \to \infty$.
-4. Connects to the parent file's `improved_upper_bound` via a
-   real-valued $n^2/12$ bound — exhibiting the elementary bound
-   that is *not* $o(n^2)$.
+1. `solymosi_stojakovic_lower_bound` — $\forall C > 0, \exists N, \forall n \geq N,
+   \exists P$ with $|P| = n$, no-five-collinear, and
+   $\text{fourPointLineCount}\,P \geq n^{2 - C / \sqrt{\log n}}$. Sorry.
+2. `erdos_three_halves_conjecture_refuted` — there is no $N$ such that
+   every no-five-collinear $P$ with $|P| \geq N$ satisfies
+   $\text{fourPointLineCount}\,P \leq |P|^{3/2}$.  Sorry (real-analysis
+   arithmetic — discharges from (1) by $2 - C/\sqrt{\log n} > 3/2$ for
+   sufficiently large $n$).
 
 ## Next Action
 
-S2 candidates (in order of expected value):
+S3 candidates (in order of expected value):
 
-1. **Formalise the Solymosi–Stojaković existence statement** as a
-   recorded *axiom-free `theorem ... := by sorry`* (since the
-   construction is beyond elementary Lean). Refutes Erdős's
-   $\Theta(n^{3/2})$ conjecture in the gallery.
+1. **Discharge `erdos_three_halves_conjecture_refuted`.** The proof is
+   pure real-analysis arithmetic given S2's
+   `solymosi_stojakovic_lower_bound`: pick $C = 1/2$ (or any
+   $C > 0$), find $N$ with $2 - C/\sqrt{\log n} > 3/2$ for $n \geq N$,
+   then derive the contradiction.  Estimated 30–60 lines of
+   `Real.rpow_lt_rpow` + `Real.log_pos` manipulation.
 
-2. **`Asymptotics.IsBigO` / `IsLittleO` bridge**. Show
+2. **`Asymptotics.IsBigO` / `IsLittleO` bridge.** Show
    `(fun n => maxFourPointLines n) =O[atTop] (· ^ 2)` from the
-   real-valued $n^2/12$ bound; record the conjecture as a
-   `=o[atTop] (· ^ 2)` `sorry`. Lets future progress slot into
-   Mathlib's asymptotic-comparison framework.
+   real-valued $n^2/12$ bound; record the conjecture as
+   `=o[atTop] (· ^ 2)` `sorry`.  Requires defining
+   `maxFourPointLines : ℕ → ℕ` via `Finset.sup'` or `Set.Sup`.
 
 3. **Investigate per-point Cauchy–Schwarz refinements.** The parent
    file's `fourCollinearThrough_bound` $\leq (n-1)/3$ combined with
    second-moment double counting may give a $1 - o(1)$ leading
-   constant on the $n^2/12$ elementary bound. Not $o(n^2)$, but a
+   constant on the $n^2/12$ elementary bound.  Not $o(n^2)$, but a
    concrete *improvement on a non-trivial constant* would be the
    first sub-elementary upper bound.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1 (S1 scaffold)
-- Approaches tried: 0 (no proof attempts yet)
+- Total attempts: 2
+- Current approach attempts: 1 (S2 lower-bound recording)
+- Approaches tried: 1 (S1 scaffold, S2 lower-bound recording —
+  same statement-first approach extended)
 
 ## Build Status
 
-S1 build: PENDING. Worktree's `proofs/.lake` is a recursive
-self-symlink; local Docker builds re-fresh-clone Mathlib. CI is
+S2 build: PENDING.  New imports
+(`Mathlib.Analysis.SpecialFunctions.Pow.Real`,
+`Mathlib.Analysis.SpecialFunctions.Log.Basic`,
+`Mathlib.Analysis.SpecialFunctions.Sqrt`) provide `Real.rpow`,
+`Real.log`, `Real.sqrt` used in the lower-bound statement.  CI is
 ground truth.
 
-S1 risk profile:
-* 5 of 6 theorems are trivial or restate parent lemmas — low risk.
-* 1 theorem (`bounds_at_rate_quadratic_over_twelve`) uses
-  `Nat.cast_div_le` + `push_cast` for a ℕ→ℝ rate cast — standard
-  Mathlib pattern.
-* No new imports; everything transitive via `Proofs.Erdos101Problem`.
+S2 risk profile:
+* 2 new theorems, both `theorem ... := by sorry` — no proof tactics
+  to fail on.
+* 3 new Mathlib imports are well-established modules.
+* No changes to existing theorems or definitions.
 
 ## Blockers
 
-None for S1 (statement-only). Closing the OPEN conjecture is itself
-a $\$100$ Erdős prize-level result and not a single-session goal.
+None for S2 (statement-only).  Closing the OPEN conjecture is itself a
+$\$100$ Erdős prize-level result and not a single-session goal.

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-101-oq-01",
   "title": "Erdős #101 OQ-01: Four-Point Lines are $o(n^2)$",
   "slug": "erdos-101-oq-01",
-  "description": "Formal statement of Erdős's $100 open question OQ-01 of Problem #101: under no-five-collinear, is the four-point line count $o(n^2)$? Scaffold file with the asymptotic vocabulary, the formal conjecture (1 sorry), and small-case lemmas the conjecture subsumes — proved unconditionally.",
+  "description": "Formal statement of Erdős's $100 open question OQ-01 of Problem #101: under no-five-collinear, is the four-point line count $o(n^2)$? Scaffold file with the asymptotic vocabulary, the formal conjecture (sorry), small-case lemmas the conjecture subsumes (proved unconditionally), and S2's recording of the Solymosi–Stojaković 2013 lower bound + the corollary refuting Erdős's original $\\Theta(n^{3/2})$ conjecture.",
   "meta": {
     "author": "Erdős",
     "erdosNumber": 101,
@@ -18,18 +18,18 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "sourceUrl": "https://erdosproblems.com/101",
     "erdosUrl": "https://erdosproblems.com/101",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 253,
-    "assumptions": "1 sorry: erdos_101_oq_01 (the main open conjecture, $100 Erdős prize). All supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free; they witness the regime in which the conjecture would tighten existing bounds.",
+    "lineCount": 325,
+    "assumptions": "3 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred); (3) erdos_three_halves_conjecture_refuted (corollary that Erdős's original $\\Theta(n^{3/2})$ upper bound is refuted, follows from the lower bound by elementary real-analysis arithmetic). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 4,
-    "substantiveTheoremCount": 5
+    "substantiveTheoremCount": 7
   },
   "sections": [
     {
@@ -76,9 +76,17 @@
       "id": "obstructions",
       "title": "Proof obstructions and next iterations",
       "startLine": 218,
-      "endLine": 253,
+      "endLine": 264,
       "summary": "Documents the Solymosi–Stojaković lower bound $n^{2-O(1/\\sqrt{\\log n})}$ refuting Erdős's $\\Theta(n^{3/2})$ conjecture; the obstructions from Szemerédi–Trotter and trivial double counting; and the S2/S3 next-iteration plan (lower-bound formalisation, `Asymptotics.IsBigO` connection).",
       "mathContext": "The gap between known lower $n^{2-O(1/\\sqrt{\\log n})}$ and known upper $O(n^2)$ is the substantive content of OQ-01."
+    },
+    {
+      "id": "solymosi-stojakovic",
+      "title": "S2: Solymosi–Stojaković Lower Bound + Refutation of $\\Theta(n^{3/2})$",
+      "startLine": 265,
+      "endLine": 323,
+      "summary": "Records the Solymosi–Stojaković 2013 existential lower bound `solymosi_stojakovic_lower_bound` ($\\forall C > 0, \\exists N, \\forall n \\geq N, \\exists P$ with $|P| = n$, no-five-collinear, and $\\text{fourPointLineCount}\\,P \\geq n^{2-C/\\sqrt{\\log n}}$) as a `theorem ... := by sorry` (construction deferred, statement registered). Adds the corollary `erdos_three_halves_conjecture_refuted` recording that no global $O(n^{3/2})$ upper bound exists, also as a sorry to be discharged by elementary real-analysis arithmetic.",
+      "mathContext": "$\\Omega(n^{2-O(1/\\sqrt{\\log n})}) > \\Omega(n^{3/2})$ for large $n$; the Solymosi–Stojaković construction over finite fields realises this asymptotic. Recorded as `theorem ... := by sorry` rather than `axiom` to keep the file axiom-free."
     }
   ],
   "overview": {
@@ -112,18 +120,21 @@
   },
   "leanFile": {
     "imports": [
-      "Proofs.Erdos101Problem"
+      "Proofs.Erdos101Problem",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Sqrt"
     ],
     "opens": [
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 253,
+    "lineCount": 325,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 4,
     "path": "Proofs/Erdos101OQ01.lean",
-    "sorries": 1
+    "sorries": 3
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-101-oq-01.json
+++ b/src/data/research/problems/erdos-101-oq-01.json
@@ -1,14 +1,14 @@
 {
   "slug": "erdos-101-oq-01",
   "title": "Erdős #101 OQ-01: Four-Point Lines are $o(n^2)$",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "significance": 7,
   "tractability": 5,
   "started": "2026-05-11T19:00:00Z",
-  "lastUpdate": "2026-05-11T19:00:00Z",
+  "lastUpdate": "2026-05-12T03:40:00Z",
   "problemStatement": {
     "formal": "\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P : \\text{PlanarPointSet},\\ \\text{NoFiveCollinear}\\ P \\land N \\leq |P| \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2",
     "plain": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the number of lines containing exactly four points $o(n^2)$? Best known: $O(n^2)$ upper (trivial), $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower (Solymosi–Stojaković).",
@@ -33,20 +33,20 @@
     "goal": "Prove $\\text{fourPointLineCount}(P) = o(|P|^2)$ for all `NoFiveCollinear P`, or sharpen the bound to an explicit subquadratic rate."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-11T19:00:00Z",
-    "iteration": 1,
-    "focus": "S1 scaffold: Σ₂ statement of OQ-01, asymptotic vocabulary, small-case lemmas the conjecture subsumes.",
+    "phase": "ACT",
+    "since": "2026-05-12T03:40:00Z",
+    "iteration": 2,
+    "focus": "S2: Solymosi–Stojaković 2013 existential lower bound recorded as a `theorem ... := by sorry`, plus the corollary refuting Erdős's $\\Theta(n^{3/2})$ conjecture. No new axioms (both new theorems are deferred proof obligations).",
     "blockers": [],
-    "nextAction": "S2: formalise Solymosi–Stojaković existence statement (refuting Erdős's $\\Theta(n^{3/2})$) and Asymptotics.IsBigO bridge.",
+    "nextAction": "S3 candidates: (1) discharge `erdos_three_halves_conjecture_refuted` from `solymosi_stojakovic_lower_bound` by elementary real-analysis arithmetic (~30–60 lines); (2) connect `fourPointLineCount_le_quadratic` to `Asymptotics.IsBigO`/`IsLittleO`; (3) Cauchy–Schwarz refinement of `fourCollinearThrough_bound` for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. New file Erdos101OQ01.lean (253 lines, 6 thms, 4 defs, 0 axioms, 1 sorry).",
+    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. S2 (researcher-1, 2026-05-12) — ACT: Solymosi–Stojaković 2013 existential lower bound recorded as `theorem solymosi_stojakovic_lower_bound := by sorry`, plus the corollary `erdos_three_halves_conjecture_refuted` (also sorry). No new axioms (both deferred proof obligations). File grows 253 → 325 lines, 6 → 8 theorems, 4 defs unchanged, 0 → 0 axioms, 1 → 3 sorries.",
     "builtItems": [
       "proofs/Proofs/Erdos101OQ01.lean: IsLittleOh_n_squared (def)",
       "proofs/Proofs/Erdos101OQ01.lean: BoundsAtRate (def)",
@@ -59,7 +59,9 @@
       "proofs/Proofs/Erdos101OQ01.lean: bounds_at_rate_quadratic_unconditional (rate $n^2$)",
       "proofs/Proofs/Erdos101OQ01.lean: bounds_at_rate_quadratic_over_twelve (rate $n^2/12$)",
       "src/data/proofs/erdos-101-oq-01/: gallery entry (meta + 6 annotations + index.ts)",
-      "research/problems/erdos-101-oq-01/: problem.md + knowledge.md + state.md"
+      "research/problems/erdos-101-oq-01/: problem.md + knowledge.md + state.md",
+      "proofs/Proofs/Erdos101OQ01.lean: solymosi_stojakovic_lower_bound (theorem stub, S2, sorry)",
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_three_halves_conjecture_refuted (theorem stub, S2, sorry)"
     ],
     "insights": [
       "The OQ-01 question is the precise quantitative refinement of the trivial $O(n^2)$ upper bound; the $\\Theta(n^2)$ regime is already established elementarily.",
@@ -73,9 +75,9 @@
       "Szemerédi–Trotter incidence bound not formalised in Mathlib; would be a useful prerequisite for the Solymosi–Stojaković construction."
     ],
     "nextSteps": [
-      "S2: formalise Solymosi–Stojaković existence statement ($\\Omega(n^{2-O(1/\\sqrt{\\log n})})$, as a recorded `theorem ... := by sorry` for the existential statement).",
-      "S3: connect `BoundsAtRate` instances to `Asymptotics.IsBigO`/`IsLittleO` on the filter `atTop`.",
-      "Optional: probe whether the per-point bound $(n-1)/3$ + Cauchy–Schwarz yields a $1 - o(1)$ leading constant on the global $n^2/12$ bound (would still be $\\Theta(n^2)$ but a concrete elementary improvement)."
+      "S3 (~30–60 lines): discharge `erdos_three_halves_conjecture_refuted` from the recorded `solymosi_stojakovic_lower_bound` by elementary real-analysis arithmetic. Picks $C = 1/2$ (or any $C > 0$), uses `Real.rpow_lt_rpow` + `Real.log_pos` + `Real.sqrt_lt_sqrt` to derive $2 - C/\\sqrt{\\log n} > 3/2$ for sufficiently large $n$, then extracts the contradiction.",
+      "S4: connect `BoundsAtRate` instances to `Asymptotics.IsBigO`/`IsLittleO` on the filter `atTop`. Requires defining `maxFourPointLines : ℕ → ℕ`.",
+      "S5: Cauchy–Schwarz refinement of `fourCollinearThrough_bound` $\\leq (n-1)/3$ for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound (still $\\Theta(n^2)$, but a concrete improvement on the constant)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S2 ACT for Erdős Problem #101 OQ-01.  Records the Solymosi–Stojaković
2013 existential lower bound and the corollary that Erdős's original
$\Theta(n^{3/2})$ upper-bound conjecture is refuted, both as
`theorem ... := by sorry` (no new axioms).

## New theorems (sorry stubs)

- `solymosi_stojakovic_lower_bound`:
  $\forall C > 0, \exists N, \forall n \geq N, \exists P$ no-five-collinear
  with $|P| = n$ and $\text{fourPointLineCount}\,P \geq n^{2 - C / \sqrt{\log n}}$.
  Construction (algebraic geometry over finite fields, Solymosi–Stojaković
  *Discrete & Computational Geometry* 50, 2013) deferred to a much later
  iteration.

- `erdos_three_halves_conjecture_refuted`:
  $\neg (\exists N, \forall$ no-five-collinear $P$ with $|P| \geq N,
  \text{fourPointLineCount}\,P \leq |P|^{3/2})$.
  Follows from the lower bound by elementary real-analysis arithmetic
  ($2 - C/\sqrt{\log n} > 3/2$ for large $n$); the sorry is targeted for
  S3 discharge in ~30–60 lines.

Both are recorded as `theorem ... := by sorry` rather than `axiom`
declarations, so the file remains axiom-free.

## File delta

`proofs/Proofs/Erdos101OQ01.lean`: 253 → 325 lines.

| Metric | S1 | S2 |
|---|---|---|
| theoremCount | 6 | 8 |
| definitionCount | 4 | 4 |
| axiomCount | 0 | 0 |
| sorries | 1 | 3 |

No existing theorem or definition was modified.  Three new Mathlib
imports added for `Real.rpow`, `Real.log`, `Real.sqrt`.

Meta/state/knowledge/problem-JSON updated to reflect S2 completion
and S3 next-action candidates (discharge the corollary, connect to
`Asymptotics.IsBigO`, Cauchy–Schwarz refinement).

## Build status

**BUILD UNVERIFIED.**  Per `feedback_researcher_lake_symlink_broken.md`,
the worktree's `proofs/.lake` is a recursive self-symlink and a local
Docker build would re-fresh-clone Mathlib (~30–45 min cold).  CI is the
ground truth.  The two new theorems have only `sorry` bodies, so the
only build risk is in the type signatures using `Real.rpow`/`Real.sqrt`/`Real.log`
— all standard Mathlib API.

## Test plan

- [ ] CI build succeeds with the three new Mathlib imports.
- [ ] `theoremCount` (8) and `lineCount` (325) match meta.json values.
- [ ] No regression in S1's five proved theorems.

🤖 Generated by researcher-1