### PR TITLE
audit(angle-trisection-cos-20-gal-oq-01-oq-03): fix theoremCount drift 23 → 24

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
@@ -26,7 +26,7 @@
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to the irreducibility of minimal polynomials of cosines. For specific primes the gallery already has formalizations: cos(20°) = cos(π/9) (Eisenstein at 3), cos(π/5) (Eisenstein at 5), cos(π/7) (Eisenstein at 7). The pattern Y → Y − 2 and the resulting Eisenstein-at-p form for the minimal polynomial of 2 + 2cos(π/p) is conjectured to hold for every odd prime p ≥ 3. The cyclotomic perspective ties this to Φ_{2p}(−1) = Φ_p(1) = p, a Mathlib-available identity, and the standard ramification theory of cyclotomic fields developed by Kummer, Hilbert, and Hensel.",
     "proofStrategy": "Per-prime: define the explicit polynomial r_p ∈ ℤ[X] and apply Mathlib's `Polynomial.IsEisensteinAt` constructor with three obligations: leadingCoeff = 1 ∉ (p), all sub-leading coefficients in (p), constant term ∉ (p)². Each obligation reduces to `decide` or `interval_cases k <;> norm_num` after coefficient unfolding. For p ∈ {11, 13}, derive irreducibility via `Polynomial.irreducible_of_eisenstein_criterion`. General conjecture (sorry): cyclotomic ramification — (1+ζ_{2p}) is uniformizer of unique prime above p in ℤ[ζ_{2p}] (Mathlib's `IsCyclotomicExtension.Rat.totallyRamified`), descends to (2 + 2cos(π/p)) as uniformizer in the real subfield with ramification index (p−1)/2, hence minimal polynomial is Eisenstein by local-field theory.",
-    "theoremCount": 23,
+    "theoremCount": 24,
     "definitionCount": 1,
     "originalContributions": [
       "Parametric definition r : ℕ → ℤ[X] explicit for p ∈ {5, 7, 11, 13}",


### PR DESCRIPTION
## Summary

Gallery integrity fix: `theoremCount` was 23 in `meta.json` but the Lean source has 24 top-level `theorem` declarations.

## Evidence

`proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` contains:

- 5 theorems per prime × 4 primes (`r_{p}_eq`, `r_{p}_natDegree`, `r_{p}_degree`, `r_{p}_monic`, `r_{p}_isEisensteinAt` for p ∈ {5, 7, 11, 13}) = 20
- 4 wrap-up theorems: `eisenstein_verified_small_primes`, `r_11_irreducible`, `r_13_irreducible`, `eisenstein_conjecture_cos_pi_p`

Total: **24** theorems.

`meta.json` previously claimed `theoremCount: 23`. This PR corrects it to 24.

All other counts already match: sorries=1, axiomCount=0, definitionCount=1, lineCount=301.

## Test plan

- [x] `meta.json` parses as valid JSON
- [x] Single-field change; no other drift detected

Discovered during gallery integrity audit (Auditor agent).