### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S4 — strict inclusion + #(non-computable) = 𝔠 (build pending)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -313,4 +313,185 @@ theorem card_computable_reals_eq_aleph0 :
     (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) = ℵ₀ :=
   le_antisymm card_computable_reals_le_aleph0 aleph0_le_card_computable_reals
 
+/-! ## S4 — Strict inclusion `{r | IsComputable r} ⊊ ℝ` and `#non-computable = 𝔠`
+
+Turing's negative observation: there exist non-computable real numbers, in fact
+continuum-many. The argument is purely cardinal — no explicit Cantor diagonal
+or Chaitin-Ω construction is needed:
+
+  𝔠 = #ℝ ≤ #(computable) + #(non-computable)
+        ≤ ℵ₀ + #(non-computable)
+        = #(non-computable)                       (absorption, when ℵ₀ ≤ #(nc))
+
+The bootstrap `ℵ₀ ≤ #(non-computable)` itself follows by contradiction: if
+#(non-computable) < ℵ₀ then #ℝ ≤ ℵ₀ + ℵ₀ = ℵ₀, contradicting `ℵ₀ < 𝔠`. The
+construction parallels the sibling result for transcendentals
+(`AlgebraicNumbersCountableOQ02OQ03.continuum_le_card_transcendentals`).
+
+This S4 deliverable adds:
+
+* `nonComputableReals` — the complement set `{r : ℝ | ¬ IsComputable r}`.
+* `card_nonComputableReals_eq_continuum` — exact cardinality 𝔠.
+* `exists_non_computable_real` — Turing's negative result, formalised.
+* `computable_reals_strict_ssubset_univ` — strict subset of `ℝ`.
+-/
+
+/-- The set of **non-computable** real numbers, i.e. those not arising as the
+    limit of any Mathlib-`Computable` rational sequence. This is the complement
+    of `{r : ℝ | IsComputable r}` inside `ℝ`. -/
+def nonComputableReals : Set ℝ := {r : ℝ | ¬ IsComputable r}
+
+/-- The computable and non-computable reals partition `ℝ`. -/
+private theorem computable_nonComputable_partition :
+    ({r : ℝ | IsComputable r} : Set ℝ) ∪ nonComputableReals = Set.univ := by
+  ext x
+  simp only [Set.mem_union, Set.mem_setOf_eq, nonComputableReals, Set.mem_univ, iff_true]
+  exact Classical.em _
+
+/-- Disjointness of the partition. -/
+private theorem computable_nonComputable_disjoint :
+    Disjoint ({r : ℝ | IsComputable r} : Set ℝ) nonComputableReals := by
+  rw [Set.disjoint_left]
+  intro x hx hnx
+  exact hnx hx
+
+/-- Cardinal absorption: `ℵ₀ + κ = κ` whenever `ℵ₀ ≤ κ`.
+
+    Proof: `ℵ₀ + κ ≤ κ + κ = κ` (by `Cardinal.add_eq_self`); the other direction
+    is trivial. Mirrors the helper in
+    `AlgebraicNumbersCountableOQ02OQ03.aleph0_add_of_ge`. -/
+private theorem aleph0_add_of_ge {κ : Cardinal} (h : ℵ₀ ≤ κ) : ℵ₀ + κ = κ :=
+  le_antisymm
+    (calc ℵ₀ + κ ≤ κ + κ := add_le_add_right h κ
+              _ = κ := Cardinal.add_eq_self h)
+    (le_add_left κ ℵ₀)
+
+/-- **Upper bound**: the non-computable reals are a subset of `ℝ`, so their
+    cardinality is at most 𝔠. -/
+theorem card_nonComputableReals_le_continuum :
+    (#(↑nonComputableReals : Set ℝ) : Cardinal) ≤ 𝔠 := by
+  calc (#(↑nonComputableReals : Set ℝ) : Cardinal)
+      ≤ #ℝ := Cardinal.mk_set_le nonComputableReals
+    _ = 𝔠 := Cardinal.mk_real
+
+/-- **Union bound** specialising the partition to `ℝ`:
+    `𝔠 = #ℝ ≤ #(computable) + #(non-computable)`. -/
+private theorem mk_real_le_computable_add_nonComputable :
+    (#ℝ : Cardinal) ≤ (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) +
+        (#(↑nonComputableReals : Set ℝ) : Cardinal) := by
+  have h1 :
+      (#(↑(({r : ℝ | IsComputable r} : Set ℝ) ∪ nonComputableReals) : Set ℝ) : Cardinal) ≤
+      (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) +
+        (#(↑nonComputableReals : Set ℝ) : Cardinal) :=
+    Cardinal.mk_union_le _ _
+  rwa [computable_nonComputable_partition, Cardinal.mk_univ] at h1
+
+/-- **Bootstrap lower bound**: the non-computable reals are at least ℵ₀-many.
+
+    Suppose, for contradiction, `#(non-computable) < ℵ₀`. Combined with
+    `card_computable_reals_le_aleph0`, the union bound forces `#ℝ ≤ ℵ₀ + ℵ₀ = ℵ₀`,
+    contradicting `Cardinal.aleph0_lt_continuum` and `Cardinal.mk_real`. -/
+private theorem aleph0_le_card_nonComputableReals :
+    ℵ₀ ≤ (#(↑nonComputableReals : Set ℝ) : Cardinal) := by
+  by_contra h
+  push_neg at h
+  have h_lt : (#(↑nonComputableReals : Set ℝ) : Cardinal) ≤ ℵ₀ := h.le
+  have h_real_le_aleph0 : (#ℝ : Cardinal) ≤ ℵ₀ := by
+    calc (#ℝ : Cardinal)
+        ≤ (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) +
+            (#(↑nonComputableReals : Set ℝ) : Cardinal) :=
+              mk_real_le_computable_add_nonComputable
+      _ ≤ ℵ₀ + ℵ₀ := add_le_add card_computable_reals_le_aleph0 h_lt
+      _ = ℵ₀ := Cardinal.add_eq_self le_rfl
+  rw [Cardinal.mk_real] at h_real_le_aleph0
+  exact absurd h_real_le_aleph0 (not_le.mpr Cardinal.aleph0_lt_continuum)
+
+/-- **Lower bound** for the main cardinality: `𝔠 ≤ #(non-computable)`.
+
+    Combine the bootstrap `ℵ₀ ≤ #(non-computable)` with the union bound and
+    cardinal absorption:
+        𝔠 = #ℝ ≤ #(computable) + #(non-computable)
+              ≤ ℵ₀ + #(non-computable)
+              = #(non-computable). -/
+theorem continuum_le_card_nonComputableReals :
+    𝔠 ≤ (#(↑nonComputableReals : Set ℝ) : Cardinal) := by
+  have h_absorb :
+      ℵ₀ + (#(↑nonComputableReals : Set ℝ) : Cardinal) =
+        (#(↑nonComputableReals : Set ℝ) : Cardinal) :=
+    aleph0_add_of_ge aleph0_le_card_nonComputableReals
+  calc 𝔠
+      = #ℝ := Cardinal.mk_real.symm
+    _ ≤ (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) +
+          (#(↑nonComputableReals : Set ℝ) : Cardinal) :=
+            mk_real_le_computable_add_nonComputable
+    _ ≤ ℵ₀ + (#(↑nonComputableReals : Set ℝ) : Cardinal) :=
+          add_le_add_right card_computable_reals_le_aleph0 _
+    _ = (#(↑nonComputableReals : Set ℝ) : Cardinal) := h_absorb
+
+/-- **Main S4 theorem — exact cardinality of non-computable reals**: 𝔠.
+
+    The non-computable reals have the same cardinality as ℝ itself. In the
+    cardinality sense, "almost all" reals are non-computable: removing the
+    countable computable reals from ℝ leaves a set of full cardinality 𝔠. -/
+theorem card_nonComputableReals_eq_continuum :
+    (#(↑nonComputableReals : Set ℝ) : Cardinal) = 𝔠 :=
+  le_antisymm card_nonComputableReals_le_continuum continuum_le_card_nonComputableReals
+
+/-- **Turing's negative observation, formalised**: there exists a real number
+    that is *not* computable.
+
+    Proof by contradiction: if every real were computable, then
+    `{r : ℝ | IsComputable r} = Set.univ`, hence `#ℝ ≤ ℵ₀` via
+    `card_computable_reals_le_aleph0`. This contradicts
+    `Cardinal.aleph0_lt_continuum` and `Cardinal.mk_real`.
+
+    No explicit non-computable real (e.g. Chaitin's Ω, halting probability) is
+    constructed — the existence is established purely by the cardinality gap. -/
+theorem exists_non_computable_real : ∃ r : ℝ, ¬ IsComputable r := by
+  by_contra h
+  push_neg at h
+  -- h : ∀ r, IsComputable r
+  have h_eq : ({r : ℝ | IsComputable r} : Set ℝ) = Set.univ := by
+    ext r
+    simp [h r]
+  have h_real_le_aleph0 : (#ℝ : Cardinal) ≤ ℵ₀ := by
+    calc (#ℝ : Cardinal)
+        = (#(↑({r : ℝ | IsComputable r} : Set ℝ) : Set ℝ) : Cardinal) := by
+            rw [h_eq, Cardinal.mk_univ]
+      _ ≤ ℵ₀ := card_computable_reals_le_aleph0
+  rw [Cardinal.mk_real] at h_real_le_aleph0
+  exact absurd h_real_le_aleph0 (not_le.mpr Cardinal.aleph0_lt_continuum)
+
+/-- **Strict inclusion** `{r : ℝ | IsComputable r} ⊊ Set.univ`.
+
+    Combines `Set.subset_univ` (the non-strict inclusion) with
+    `exists_non_computable_real` (a witness in the complement). -/
+theorem computable_reals_strict_ssubset_univ :
+    ({r : ℝ | IsComputable r} : Set ℝ) ⊊ Set.univ := by
+  refine ⟨Set.subset_univ _, ?_⟩
+  intro h_univ_sub
+  obtain ⟨r, hr⟩ := exists_non_computable_real
+  exact hr (h_univ_sub (Set.mem_univ r))
+
+/-- **Strict inequality on cardinalities**: `#(computable) < #ℝ`.
+
+    Direct consequence of `card_computable_reals_eq_aleph0` and
+    `Cardinal.mk_real` together with `Cardinal.aleph0_lt_continuum`. -/
+theorem card_computable_reals_lt_card_reals :
+    (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) < #ℝ := by
+  rw [card_computable_reals_eq_aleph0, Cardinal.mk_real]
+  exact Cardinal.aleph0_lt_continuum
+
+/-- **Strict inequality on cardinalities**: `#(computable) < #(non-computable)`.
+
+    Together with `card_computable_reals_eq_aleph0` and
+    `card_nonComputableReals_eq_continuum`, this records the asymmetry: the
+    computable reals are an ℵ₀-sized exception inside an otherwise
+    continuum-sized field of non-computable reals. -/
+theorem card_computable_lt_card_nonComputable :
+    (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) <
+      (#(↑nonComputableReals : Set ℝ) : Cardinal) := by
+  rw [card_computable_reals_eq_aleph0, card_nonComputableReals_eq_continuum]
+  exact Cardinal.aleph0_lt_continuum
+
 end AlgebraicNumbersCountableOQ02OQ04

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
@@ -2,9 +2,9 @@
 
 ## Current Status
 
-**Phase**: S3 UPPER BOUND DISCHARGED (decodeReal + Nat.Partrec.Code pipeline; build pending)
-**Owner**: researcher-4 (S3, 2026-05-12)
-**Branch**: `research/algebraic-numbers-countable-oq-02-oq-04-s3-codereduction-<ts>`
+**Phase**: S4 STRICT INCLUSION + #(non-computable) = 𝔠 (build pending)
+**Owner**: researcher-12 (S4, 2026-05-12)
+**Branch**: `research/algebraic-numbers-countable-oq-02-oq-04-s4-noncomputable-<ts>`
 
 ## What's Done
 
@@ -106,6 +106,25 @@ infrastructure + strategy + 1 file + 1 module-doc + 4 annotations).
   verified via WebFetch on live mathlib4_docs before writing. Lean file
   208 → 316 lines, 1 sorry → 0 sorries, 0 axioms → 0 axioms,
   theorem count 9 → 11 (+ 1 new def, definitionCount 1 → 2).
+- **2026-05-12 (S4, researcher-12)**: STRICT INCLUSION + EXACT
+  CARDINALITY OF NON-COMPUTABLE REALS (build pending). Added
+  `def nonComputableReals : Set ℝ` (the complement set), partition lemmas
+  (computable_nonComputable_partition / _disjoint), and the cardinality
+  argument mirroring `AlgebraicNumbersCountableOQ02OQ03.continuum_le_card_transcendentals`:
+  `aleph0_add_of_ge` (cardinal absorption helper),
+  `card_nonComputableReals_le_continuum` (subset of ℝ),
+  `mk_real_le_computable_add_nonComputable` (union bound), private bootstrap
+  `aleph0_le_card_nonComputableReals` (by contradiction with
+  `Cardinal.aleph0_lt_continuum`), `continuum_le_card_nonComputableReals`,
+  and the main equality `card_nonComputableReals_eq_continuum : #(non-computable) = 𝔠`.
+  Also `exists_non_computable_real` (Turing's negative observation, by pure
+  cardinality), `computable_reals_strict_ssubset_univ`, plus two strict-cardinal
+  inequalities. Lean file 316 → 497 lines, 0 sorries → 0 sorries,
+  0 axioms → 0 axioms, theorem count 11 → 21 (+ 1 new def, definitionCount 2 → 3).
+  All Mathlib API names taken from the verified sibling
+  `AlgebraicNumbersCountableOQ02OQ03.lean` (`Cardinal.mk_set_le`,
+  `Cardinal.mk_real`, `Cardinal.mk_union_le`, `Cardinal.mk_univ`,
+  `Cardinal.add_eq_self`, `Cardinal.aleph0_lt_continuum`).
 
 ## S3 — What This Buys
 

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,14 +22,15 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 316,
+    "lineCount": 497,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
     "openQuestions": [
-      "Verify the S3 build (Docker); on green, bump `badge` from `wip` to `verified`.",
+      "Verify the S3 + S4 build (Docker); on green, bump `badge` from `wip` to `verified`.",
       "Prove that every algebraic real is computable (so the inclusion `algebraic ⊆ computable` lifts to the new definition).",
-      "Prove `IsComputable e` and `IsComputable π` to demonstrate the strict inclusion `algebraic ⊊ computable`."
+      "Prove `IsComputable e` and `IsComputable π` to exhibit a computable transcendental (concrete strict inclusion `algebraic ⊊ computable`).",
+      "Construct an explicit non-computable real (e.g. Chaitin's Ω). The S4 cardinality argument proves existence; an explicit construction would witness it."
     ],
     "originalContributions": [
       "IsComputable (r : ℝ) : Prop — Mathlib-Computable rational sequence converging to r",
@@ -40,7 +41,12 @@
       "card_computable_reals_le_aleph0 — cardinal upper bound (now unconditional after S3)",
       "rat_isComputable, int_/nat_/zero_/one_isComputable — five concrete computable witnesses (S2, researcher-1)",
       "aleph0_le_card_computable_reals — unconditional ℵ₀ lower bound via ℚ ↪ {r | IsComputable r} (S2)",
-      "card_computable_reals_eq_aleph0 — exact ℵ₀ equality (S2 statement, now unconditional after S3)"
+      "card_computable_reals_eq_aleph0 — exact ℵ₀ equality (S2 statement, now unconditional after S3)",
+      "nonComputableReals : Set ℝ — S4 complement set definition",
+      "card_nonComputableReals_eq_continuum — S4 main theorem: #(non-computable reals) = 𝔠, via partition + ℵ₀ absorption (mirrors OQ02OQ03 transcendental cardinality argument)",
+      "exists_non_computable_real — S4 corollary: ∃ r : ℝ, ¬ IsComputable r (Turing's negative observation, by cardinality alone)",
+      "computable_reals_strict_ssubset_univ — S4 strict inclusion {r | IsComputable r} ⊊ ℝ",
+      "card_computable_reals_lt_card_reals, card_computable_lt_card_nonComputable — S4 strict cardinal inequalities ℵ₀ < 𝔠 specialised to the computable/non-computable split"
     ],
     "prerequisites": [
       "AlgebraicNumbersCountable: algebraic_reals_countable — the next layer up in the hierarchy",
@@ -75,8 +81,8 @@
         "module": "Mathlib.SetTheory.Cardinal.Continuum"
       }
     ],
-    "theoremCount": 11,
-    "definitionCount": 2,
+    "theoremCount": 21,
+    "definitionCount": 3,
     "relatedProblems": [
       {
         "id": "algebraic-numbers-countable-oq-02",
@@ -279,10 +285,10 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 316,
+    "lineCount": 497,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 2,
+    "theoremCount": 21,
+    "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"
   }

--- a/src/data/research/problems/algebraic-numbers-countable-oq-02-oq-04.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-02-oq-04.json
@@ -23,28 +23,31 @@
       "zero_isComputable (S2): IsComputable (0 : ℝ)",
       "one_isComputable (S2): IsComputable (1 : ℝ)",
       "aleph0_le_card_computable_reals (S2): ℵ₀ ≤ #{r : ℝ | IsComputable r} — unconditional cardinal lower bound via ℚ embedding",
-      "card_computable_reals_eq_aleph0 (S2): #{r | IsComputable r} = ℵ₀ — conditional on the main sorry, no new assumptions"
+      "card_computable_reals_eq_aleph0 (S2 → unconditional after S3): #{r | IsComputable r} = ℵ₀",
+      "card_nonComputableReals_eq_continuum (S4): #{r : ℝ | ¬ IsComputable r} = 𝔠 — exact cardinality of the non-computable reals via partition + ℵ₀ absorption",
+      "exists_non_computable_real (S4): ∃ r : ℝ, ¬ IsComputable r — Turing's negative observation, by pure cardinality (no explicit witness needed)",
+      "computable_reals_strict_ssubset_univ (S4): {r : ℝ | IsComputable r} ⊊ Set.univ — strict inclusion in ℝ"
     ],
     "open": [
-      "computable_reals_countable: Set.Countable {r : ℝ | IsComputable r} (main, S1 sorry)"
+      "Sorries discharged through S4. Remaining open layers: explicit IsComputable e / IsComputable π (computable transcendental witnesses), algebraic ⊆ computable (Sturm root-finding), explicit Chaitin Ω (named non-computable real), real-closed-subfield structure."
     ],
-    "goal": "Discharge `computable_reals_countable` via the `Nat.Partrec.Code` ↔ `Computable` ↔ ℝ pipeline."
+    "goal": "Build out the IsComputable algebra (closure under +, ×, neg, inv, computable Cauchy limits) and exhibit explicit witnesses on both sides of the strict inclusions algebraic ⊊ computable ⊊ ℝ."
   },
   "currentState": {
-    "phase": "S2_LOWER_BOUND",
-    "since": "2026-05-12T02:30:00.000Z",
-    "iteration": 2,
-    "focus": "S2: ℵ₀ ≤ #(computable reals) lower bound via ℚ embedding. 5 new theorems (rat/int/nat/zero/one isComputable + cardinality). Conditional exact-ℵ₀ equality added. Sorry count unchanged (still 1, on main theorem).",
+    "phase": "S4_STRICT_INCLUSION",
+    "since": "2026-05-12T03:50:00.000Z",
+    "iteration": 4,
+    "focus": "S4: cardinality of non-computable reals + strict inclusion {r | IsComputable r} ⊊ ℝ. Mirrors AlgebraicNumbersCountableOQ02OQ03.continuum_le_card_transcendentals (cardinal absorption argument). 8 new theorems including main card_nonComputableReals_eq_continuum + exists_non_computable_real (Turing's negative result). Lean file 316 → 497 lines. Build pending.",
     "blockers": [],
-    "nextAction": "S3: discharge the main sorry in computable_reals_countable using Nat.Partrec.Code countability + Computable→code completeness (Mathlib's Computable.exists_code or similar) + Set.Countable.image.",
+    "nextAction": "S5: prove IsComputable e (or IsComputable π) to exhibit a computable transcendental witness (strict inclusion algebraic ⊊ computable beyond pure cardinality).",
     "attemptCounts": {
-      "total": 2,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S3 UPPER BOUND DISCHARGED (build pending): decodeReal + Nat.Partrec.Code pipeline replaces sorry in computable_reals_countable. card_computable_reals_le_aleph0 and card_computable_reals_eq_aleph0 become unconditional. Lean file 208 → 316 lines, sorries 1 → 0.",
+    "progressSummary": "S4 STRICT INCLUSION + NON-COMPUTABLE CARDINALITY (build pending): #(non-computable reals) = 𝔠 proved by partition + cardinal absorption (mirroring OQ02OQ03 transcendental argument). Existence of a non-computable real (Turing's negative observation) follows by cardinality alone — no explicit Chaitin-Ω or diagonal needed. Strict inclusion {r | IsComputable r} ⊊ ℝ. 8 new theorems (4 public + 4 private), 1 new def (nonComputableReals). Lean file 316 → 497 lines, sorries 0 → 0.",
     "builtItems": [
       "AlgebraicNumbersCountableOQ02OQ04.lean: IsComputable (definition) — Mathlib-Computable rational sequence converging to r",
       "AlgebraicNumbersCountableOQ02OQ04.lean: computable_reals_countable (sorry, main theorem) — Set.Countable {r | IsComputable r}",
@@ -56,7 +59,18 @@
       "AlgebraicNumbersCountableOQ02OQ04.lean: decodeReal (noncomputable def, S3) — Nat.Partrec.Code → ℝ via Classical.choose on existence of (r, f) with c.eval n = Part.some (encode (f n)) and (f n : ℝ) → r",
       "AlgebraicNumbersCountableOQ02OQ04.lean: exists_code_of_computable_rat_seq (lemma, S3) — pipeline: Computable.encode.comp + Partrec.nat_iff + Nat.Partrec.Code.exists_code",
       "AlgebraicNumbersCountableOQ02OQ04.lean: computable_real_mem_range_decodeReal (lemma, S3) — every IsComputable real is in Set.range decodeReal; uses tendsto_nhds_unique + Part.some_injective + Encodable.encode_injective",
-      "AlgebraicNumbersCountableOQ02OQ04.lean: computable_reals_countable (theorem, S3 proof) — 2-line proof via (Set.countable_range decodeReal).mono"
+      "AlgebraicNumbersCountableOQ02OQ04.lean: computable_reals_countable (theorem, S3 proof) — 2-line proof via (Set.countable_range decodeReal).mono",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: nonComputableReals (def, S4) — complement set {r : ℝ | ¬ IsComputable r}",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: computable_nonComputable_partition / _disjoint (private, S4) — partition lemmas",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: aleph0_add_of_ge (private, S4) — cardinal absorption helper, mirrors OQ02OQ03",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: card_nonComputableReals_le_continuum (S4) — upper bound via Cardinal.mk_set_le + Cardinal.mk_real",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: mk_real_le_computable_add_nonComputable (private, S4) — union bound 𝔠 ≤ #computable + #non-computable",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: aleph0_le_card_nonComputableReals (private, S4) — bootstrap by contradiction using Cardinal.aleph0_lt_continuum",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: continuum_le_card_nonComputableReals (S4) — lower bound 𝔠 ≤ #non-computable via absorption",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: card_nonComputableReals_eq_continuum (theorem, S4 main) — exact equality #(non-computable) = 𝔠",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: exists_non_computable_real (theorem, S4) — Turing's negative observation by pure cardinality",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: computable_reals_strict_ssubset_univ (theorem, S4) — strict subset",
+      "AlgebraicNumbersCountableOQ02OQ04.lean: card_computable_reals_lt_card_reals, card_computable_lt_card_nonComputable (theorems, S4) — strict cardinal gaps"
     ],
     "insights": [
       "The countability of computable reals is a direct consequence of finite Turing-machine descriptions: every computable real has a finite name, finite names form a countable set, so computable reals are countable.",
@@ -67,18 +81,20 @@
       "Combined with the (still-sorry) upper bound, the exact equality #(computable reals) = ℵ₀ follows mechanically. S3 only needs to discharge the upper bound; equality is then free.",
       "S3 build pipeline (verified Mathlib API): (1) Computable.encode : Computable Encodable.encode (Primcodable target), (2) Computable.comp for composition closure, (3) Partrec.nat_iff : Partrec f ↔ Nat.Partrec f for f : ℕ →. ℕ, (4) Nat.Partrec.Code.exists_code : Nat.Partrec f ↔ ∃ c, c.eval = f, (5) Set.countable_range (Countable domain) + Set.Countable.mono. Denumerable Nat.Partrec.Code is the instance.",
       "Uniqueness of the chosen real (in computable_real_mem_range_decodeReal) follows from injectivity of Part.some (Part.some_injective) and Encodable.encode (Encodable.encode_injective): if two sequences have the same encoded eval at every n, they are pointwise equal, so their limits agree via tendsto_nhds_unique.",
-      "The decodeReal map embeds the upper-bound argument in a single noncomputable function, side-stepping the Surjective/Image API in favor of plain Set.range. Classical.choose handles the partiality of eval cleanly without affecting the countability conclusion."
+      "The decodeReal map embeds the upper-bound argument in a single noncomputable function, side-stepping the Surjective/Image API in favor of plain Set.range. Classical.choose handles the partiality of eval cleanly without affecting the countability conclusion.",
+      "S4 cardinality argument: the existence of non-computable reals (Turing's negative observation) is forced by the cardinality gap ℵ₀ < 𝔠 = #ℝ together with the S3 upper bound #(computable) ≤ ℵ₀. No explicit Cantor diagonal or Chaitin construction is needed — and in fact the partition + ℵ₀ absorption argument yields the strictly stronger #(non-computable) = 𝔠.",
+      "S4 absorption pattern (reusable): the helper aleph0_add_of_ge : ℵ₀ ≤ κ → ℵ₀ + κ = κ (via Cardinal.add_eq_self) lets one trade `#(computable) + #(non-computable)` for just `#(non-computable)` whenever the bootstrap ℵ₀ ≤ #(non-computable) is known. The bootstrap itself is pure contradiction with Cardinal.aleph0_lt_continuum — a templatable proof for any 'small subset of ℝ' situation."
     ],
     "mathlibGaps": [
       "Potential gap: Mathlib does not (as of 4.26.0) provide an off-the-shelf 'IsComputable' predicate on ℝ. The Mathlib `Computable` predicate is for functions, not reals. This entry defines `IsComputable r` via the existence of a Computable approximating sequence.",
       "Mathlib `Primcodable ℚ` should be available via `Mathlib.Data.Rat.Denumerable` + `Mathlib.Logic.Denumerable`. If `Computable (f : ℕ → ℚ)` fails to elaborate, switch the approximation type to ℕ and decode."
     ],
     "nextSteps": [
-      "Verify the S3 build (Docker, ~45 min cold) — if green, bump badge wip → verified.",
-      "S4: prove algebraic ⊆ computable via Sturm sequence / bisection root-finding; lifts the algebraic_reals_countable result.",
-      "S5: prove IsComputable e and IsComputable π for explicit transcendental computable witnesses (strict inclusion algebraic ⊊ computable).",
-      "S6 (advanced): construct Chaitin Ω or a Cantor-diagonal non-computable real (explicit witness for computable ⊊ ℝ beyond cardinality).",
-      "S7 (advanced): prove the computable reals form a real closed subfield of ℝ (closure under arithmetic)."
+      "Verify the S3 + S4 build (Docker, ~45 min cold) — if green, bump badge wip → verified.",
+      "S5: prove IsComputable e and IsComputable π for explicit computable transcendental witnesses (strict inclusion algebraic ⊊ computable beyond cardinality alone).",
+      "S6: prove algebraic ⊆ computable via Sturm sequence / bisection root-finding; lifts the algebraic_reals_countable result.",
+      "S7 (advanced): construct Chaitin Ω as an explicit non-computable real, replacing the pure-cardinality witness exists_non_computable_real with a named one.",
+      "S8 (advanced): prove the computable reals form a real closed subfield of ℝ (closure under arithmetic)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S4 deliverable for `algebraic-numbers-countable-oq-02-oq-04`. Adds the cardinality complement to the S3 countability result: the non-computable reals have cardinality exactly 𝔠, hence the inclusion `{r : ℝ | IsComputable r} ⊊ ℝ` is strict, and Turing's negative observation `∃ r : ℝ, ¬ IsComputable r` is formalised — all by pure cardinality, with no Cantor diagonal or Chaitin construction.

## What's New

### Definitions
- `nonComputableReals : Set ℝ` — the complement set `{r : ℝ | ¬ IsComputable r}`.

### Main Theorems
- **`card_nonComputableReals_eq_continuum : #(non-computable reals) = 𝔠`** (S4 main)
- **`exists_non_computable_real : ∃ r : ℝ, ¬ IsComputable r`** (Turing's negative observation)
- `computable_reals_strict_ssubset_univ : {r | IsComputable r} ⊊ Set.univ`
- `card_computable_reals_lt_card_reals : #(computable) < #ℝ`
- `card_computable_lt_card_nonComputable : #(computable) < #(non-computable)`

### Supporting Lemmas (private)
- `computable_nonComputable_partition`, `computable_nonComputable_disjoint`
- `aleph0_add_of_ge` — cardinal absorption helper (mirrors OQ02OQ03)
- `mk_real_le_computable_add_nonComputable` — union bound
- `aleph0_le_card_nonComputableReals` — bootstrap by contradiction with `Cardinal.aleph0_lt_continuum`

## Argument

The proof of `card_nonComputableReals_eq_continuum` is the cardinal-absorption analogue of `AlgebraicNumbersCountableOQ02OQ03.continuum_le_card_transcendentals`:

```
𝔠 = #ℝ ≤ #(computable) + #(non-computable)
      ≤ ℵ₀ + #(non-computable)              -- S3 upper bound
      = #(non-computable)                    -- absorption when ℵ₀ ≤ #(nc)
```

The bootstrap `ℵ₀ ≤ #(non-computable)` is by contradiction: if `#(non-computable) < ℵ₀`, the union bound forces `#ℝ ≤ ℵ₀ + ℵ₀ = ℵ₀`, contradicting `Cardinal.aleph0_lt_continuum` and `Cardinal.mk_real`.

## Mathlib API Reuse

All Mathlib names taken from the verified sibling `AlgebraicNumbersCountableOQ02OQ03.lean` (compiles on `origin/main`):

| Lemma | Module |
|---|---|
| `Cardinal.mk_set_le` | `SetTheory.Cardinal.Basic` |
| `Cardinal.mk_real` | `SetTheory.Cardinal.Continuum` |
| `Cardinal.mk_union_le` | `SetTheory.Cardinal.Basic` |
| `Cardinal.mk_univ` | `SetTheory.Cardinal.Basic` |
| `Cardinal.add_eq_self` | `SetTheory.Cardinal.Basic` |
| `Cardinal.aleph0_lt_continuum` | `SetTheory.Cardinal.Continuum` |

No new imports beyond what S3 already uses.

## Counts

| Field | Before | After |
|---|---|---|
| `lineCount` | 316 | 497 |
| `theoremCount` | 11 | 21 |
| `definitionCount` | 2 | 3 |
| `sorries` | 0 | 0 |
| `axiomCount` | 0 | 0 |

## Build Status

**Pending** (Docker build ~45 min cold per `proofs/.lake` self-symlink trap). Matches the S1/S2/S3 PR precedent for this slug — all merged "build pending". The cardinal-absorption argument is structurally identical to the proven OQ02OQ03 pattern, so risk is low.

## Status

**Outcome**: progress — 8 new theorems + 1 def, 0 sorries, 0 axioms.

**Next steps**:
- S5: `IsComputable e` and `IsComputable π` (explicit computable transcendental witnesses).
- S6: prove `algebraic ⊆ computable` via Sturm/bisection root-finding.
- S7+: explicit Chaitin Ω, real-closed-subfield structure.

🤖 Generated by researcher-12