### PR TITLE
research(cantors-theorem-oq-01-oq-03): S4 — konig_constraint_beth (Ordinal) (build pending)

### DIFF
--- a/proofs/Proofs/CantorsTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/CantorsTheoremOQ01OQ03.lean
@@ -43,9 +43,11 @@ parent question.
 1. `konig_general` — for any infinite κ, κ < cf(2^κ)
 2. `konig_constraint_continuum` — applied to 𝔠 (parallels sibling oq-02)
 3. `konig_constraint_aleph` — applied to ℵ_α
-4. `cf_powerSet_real_gt_continuum` — cf(|𝒫(ℝ)|) > 𝔠
-5. `cf_powerSet_real_ne_aleph0` — cf(|𝒫(ℝ)|) ≠ ℵ₀
-6. `oq01oq03_resolution` — bundle theorem affirmatively answering the OQ
+4. `konig_constraint_beth` — applied to ℶ_α (ordinal generalization of
+   sibling oq-02's `konig_constraint_beth (n : ℕ)`)
+5. `cf_powerSet_real_gt_continuum` — cf(|𝒫(ℝ)|) > 𝔠
+6. `cf_powerSet_real_ne_aleph0` — cf(|𝒫(ℝ)|) ≠ ℵ₀
+7. `oq01oq03_resolution` — bundle theorem affirmatively answering the OQ
 
 ## Relationship to Parent and Sibling
 
@@ -59,6 +61,8 @@ parent question.
 The new content here vs the sibling:
 - `konig_general` (universally quantified, not just specialized to 𝔠).
 - `konig_constraint_aleph` (parameterized over arbitrary aleph index).
+- `konig_constraint_beth` (parameterized over arbitrary *ordinal* index;
+  sibling's version is restricted to `n : ℕ`).
 - `cf_powerSet_real_ne_aleph0` (canonical "rules out ℵ_ω" corollary).
 - `oq01oq03_resolution` (bundles four forms as the OQ resolution).
 -/
@@ -108,6 +112,22 @@ theorem konig_constraint_aleph (α : Ordinal.{0}) :
     (Cardinal.aleph α : Cardinal.{0}) <
       (2 ^ (Cardinal.aleph α : Cardinal.{0})).ord.cof :=
   konig_general (Cardinal.aleph0_le_aleph α)
+
+/-- **König's constraint for ℶ_α (ordinal generalization)**: For any
+    ordinal α, ℶ_α < cf(2^ℶ_α).
+
+    Generalizes sibling `CantorsTheoremOQ01OQ02.konig_constraint_beth`,
+    which is stated only for `n : ℕ`, to arbitrary ordinals. The proof
+    reuses sibling's `beth_zero.symm` + `beth_strictMono.monotone` chain
+    to establish `ℵ₀ ≤ ℶ_α`, then invokes `konig_general`. -/
+theorem konig_constraint_beth (α : Ordinal.{0}) :
+    (Cardinal.beth α : Cardinal.{0}) <
+      (2 ^ (Cardinal.beth α : Cardinal.{0})).ord.cof := by
+  apply konig_general
+  calc (ℵ₀ : Cardinal.{0})
+      = Cardinal.beth 0 := Cardinal.beth_zero.symm
+    _ ≤ Cardinal.beth α :=
+        Cardinal.beth_strictMono.monotone (Ordinal.zero_le _)
 
 -- ============================================================
 -- PART 3: Application to |𝒫(ℝ)|
@@ -201,6 +221,7 @@ end CantorsTheoremOQ01OQ03
 #check CantorsTheoremOQ01OQ03.konig_general
 #check CantorsTheoremOQ01OQ03.konig_constraint_continuum
 #check CantorsTheoremOQ01OQ03.konig_constraint_aleph
+#check CantorsTheoremOQ01OQ03.konig_constraint_beth
 #check CantorsTheoremOQ01OQ03.cf_powerSet_real_gt_continuum
 #check CantorsTheoremOQ01OQ03.cf_powerSet_real_ne_aleph0
 #check CantorsTheoremOQ01OQ03.oq01oq03_resolution

--- a/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
@@ -20,15 +20,16 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 206,
-    "assumptions": "0 axioms, 0 sorries. Uses Mathlib's `Cardinal.lt_cof_power`, `Cardinal.aleph0_le_continuum`, `Cardinal.aleph0_le_aleph`, plus the parent file CantorsTheoremOQ01.lean and sibling CantorsTheoremOQ01OQ02.lean.",
+    "lineCount": 227,
+    "assumptions": "0 axioms, 0 sorries. Uses Mathlib's `Cardinal.lt_cof_power`, `Cardinal.aleph0_le_continuum`, `Cardinal.aleph0_le_aleph`, `Cardinal.beth_zero`, `Cardinal.beth_strictMono`, plus the parent file CantorsTheoremOQ01.lean and sibling CantorsTheoremOQ01OQ02.lean.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
       "konig_general: ∀ infinite κ, κ < cf(2^κ) (general form, not just specialized)",
       "konig_constraint_aleph: König applied to ℵ_α for arbitrary ordinal α",
+      "konig_constraint_beth: König applied to ℶ_α for arbitrary ordinal α (sibling oq-02 has only the ℕ-indexed version)",
       "cf_powerSet_real_ne_aleph0: cf(|𝒫(ℝ)|) ≠ ℵ₀ (canonical 'rules out ℵ_ω' corollary)",
       "oq01oq03_resolution: bundle theorem packaging the affirmative resolution of the open question"
     ],
@@ -46,6 +47,16 @@
       {
         "theorem": "Cardinal.aleph0_le_aleph",
         "description": "ℵ₀ ≤ ℵ_α for any ordinal α",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.beth_zero",
+        "description": "ℶ₀ = ℵ₀ (base of the beth hierarchy)",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.beth_strictMono",
+        "description": "The beth function ℶ : Ordinal → Cardinal is strictly monotone",
         "module": "Mathlib.SetTheory.Cardinal.Ordinal"
       }
     ],

--- a/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
@@ -28,22 +28,23 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 2,
-    "focus": "S2 (researcher-4, 2026-05-12) — ACT implementation of S1's plan. Skipped optional 3-line probe because Cardinal.lt_cof_power is invoked at 5 in-tree call sites that already build (ContinuumHypothesisOQ02 line 159, CantorDiagonalizationOQ01OQ01OQ02 lines 69+75, CantorDiagonalizationOQ01OQ01OQ02OQ03 line 63, CantorsTheoremOQ01OQ02 lines 211+218). Wrote Proofs/CantorsTheoremOQ01OQ03.lean (+206 lines, 6 theorems, 0 axioms, 0 sorries) and full gallery entry. Build pending.",
+    "iteration": 4,
+    "focus": "S4 (researcher-4, 2026-05-12) — minor extension: added `konig_constraint_beth (α : Ordinal)` (6 → 7 theorems, 206 → 227 lines). Generalizes sibling oq-02's ℕ-indexed `konig_constraint_beth` to arbitrary ordinals; proof reuses sibling's `beth_zero.symm + beth_strictMono.monotone` chain. No new Mathlib API surface. Concurrent S3 PR #17781 (researcher-1) covers parent gallery JSON polish; this S4 deliberately avoids state.md to dodge merge conflict. Earlier S2 ACT (PR #17741, researcher-4): wrote Proofs/CantorsTheoremOQ01OQ03.lean. Build still pending.",
     "blockers": [],
-    "nextAction": "S3 audit: run Docker build to verify. S3 polish: cross-reference into parent's empty Part 7 (lines 214–222) — separate PR. S3 sibling cleanup: optionally deprecate sibling oq-02's konig_constraint_powerSet_real in favor of this file's general framework.",
+    "nextAction": "Audit: run Docker build to verify both S2 + S4 changes (~45 min cold per memory). After build verifies, do parent's Part 7 Lean-side cross-reference (deferred from S3 #17781). Optional sibling cleanup: deprecate sibling oq-02's konig_constraint_beth (ℕ-only) in favor of this file's konig_constraint_beth (Ordinal).",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S2 ACT implementation complete (researcher-4, 2026-05-12). Wrote Proofs/CantorsTheoremOQ01OQ03.lean (+206 lines, 6 theorems, 0 axioms, 0 sorries) + gallery entry + manifest import. Affirmatively resolves OQ via Mathlib's Cardinal.lt_cof_power. Skipped S1's recommended 3-line API probe because the API is verified by 5 in-tree call sites. Build pending. Earlier: S1 OBSERVE survey complete (researcher-1, 2026-05-11). Knowledge score 0 → 14 (5 insights + 4 mathlib gaps + 5 next steps).",
+    "progressSummary": "PROGRESS: S4 polish (researcher-4, 2026-05-12) — added konig_constraint_beth for arbitrary ordinal α (6 → 7 theorems, 206 → 227 lines). Generalizes sibling oq-02's ℕ-indexed version. Proof reuses sibling's beth_zero.symm + beth_strictMono.monotone chain. Earlier S2 ACT (researcher-4, 2026-05-12, PR #17741): wrote Proofs/CantorsTheoremOQ01OQ03.lean (+206 lines, 6 theorems, 0 axioms, 0 sorries) + gallery entry + manifest import. Affirmatively resolves OQ via Mathlib's Cardinal.lt_cof_power. S1 OBSERVE (researcher-1, 2026-05-11). Build still pending (S2 + S4 changes). Concurrent S3 PR #17781 covers parent gallery JSON polish (openQuestions[2] resolution + reciprocal crossRef).",
     "builtItems": [
       "konig_general (theorem) : ∀ infinite κ, κ < cf(2^κ)",
       "konig_constraint_continuum (theorem) : 𝔠 < cf(2^𝔠)",
       "konig_constraint_aleph (theorem) : ∀ α, ℵ_α < cf(2^ℵ_α)",
+      "konig_constraint_beth (theorem, S4 2026-05-12) : ∀ ordinal α, ℶ_α < cf(2^ℶ_α) — generalizes sibling oq-02's ℕ-indexed version to arbitrary ordinals",
       "cf_powerSet_real_gt_continuum (theorem) : 𝔠 < (#(Set ℝ)).ord.cof",
       "cf_powerSet_real_ne_aleph0 (theorem) : (#(Set ℝ)).ord.cof ≠ ℵ₀",
       "oq01oq03_resolution (theorem, bundle) : packages the 4 key forms"
@@ -53,7 +54,8 @@
       "Sibling cantors-theorem-oq-01-oq-02 explicitly enumerates this gap as conclusion.openQuestions[1], naming Cardinal.lt_cof_power as the candidate Mathlib lemma. That cross-reference (written 2026-05-04) is the strongest hint for S2's API verification.",
       "König's classical statement decomposes into three Lean theorems of strictly increasing generality: (A) cofinality bound cf(2^κ) > κ for infinite κ; (B) ℵ_ω exclusion |𝒫(ℝ)| ≠ ℵ_ω; (C) general small-cofinality exclusion for any limit o with o.cof ≤ 𝔠.",
       "The 'without axioms' framing is a Mathlib-convention question, not a mathematical one. König's theorem requires Choice, but Mathlib treats Classical.choice as a logical-kernel primitive (not counted by axiomCount). So the eventual gallery entry can honestly claim axiomCount: 0 with an assumptions field documenting the kernel-primitive caveat — same convention as the sibling oq-02.",
-      "Tractability is high (6/10): all required Mathlib infrastructure is believed present; only API drift is a risk, and even the worst case (Cardinal.lt_cof_power renamed/removed) has a 20-line fallback derivation directly from Cardinal.sum_lt_prod (König's general inequality, which is in every Mathlib version)."
+      "Tractability is high (6/10): all required Mathlib infrastructure is believed present; only API drift is a risk, and even the worst case (Cardinal.lt_cof_power renamed/removed) has a 20-line fallback derivation directly from Cardinal.sum_lt_prod (König's general inequality, which is in every Mathlib version).",
+      "S4: The sibling-oq-02 → oq-03 'beth-form generalization' is one-step from the konig_general lemma: combine konig_general with the standard `ℵ₀ = ℶ_0 ≤ ℶ_α` chain (beth_zero + beth_strictMono.monotone), exactly mirroring the sibling's ℕ-indexed proof shape. This pattern (generalize sibling's ℕ-indexed corollary to arbitrary Ordinal via the strict-monotone bound) is reusable for any further beth-indexed extensions."
     ],
     "mathlibGaps": [
       "Cardinal.sum_lt_prod — confidence HIGH that this exists with the expected universe-polymorphic shape `(∀ i, f i < g i) → Cardinal.sum f < Cardinal.prod g`. S2 must #check.",
@@ -108,7 +110,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.562Z",
-  "lastUpdate": "2026-05-12T01:00:00.000Z",
+  "lastUpdate": "2026-05-12T03:30:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -159,8 +161,8 @@
     {
       "path": "Proofs/CantorsTheoremOQ01OQ03.lean",
       "filename": "CantorsTheoremOQ01OQ03.lean",
-      "lineCount": 206,
-      "theoremCount": 6,
+      "lineCount": 227,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S4 follow-up to `cantors-theorem-oq-01-oq-03`. Adds **one new theorem** to
`Proofs/CantorsTheoremOQ01OQ03.lean`:

```lean
theorem konig_constraint_beth (α : Ordinal.{0}) :
    (Cardinal.beth α : Cardinal.{0}) <
      (2 ^ (Cardinal.beth α : Cardinal.{0})).ord.cof := by
  apply konig_general
  calc (ℵ₀ : Cardinal.{0})
      = Cardinal.beth 0 := Cardinal.beth_zero.symm
    _ ≤ Cardinal.beth α :=
        Cardinal.beth_strictMono.monotone (Ordinal.zero_le _)
```

This generalizes sibling `CantorsTheoremOQ01OQ02.konig_constraint_beth`
(stated only for `n : ℕ`) to **arbitrary ordinals** `α`. The proof
reuses the sibling's verified `beth_zero.symm + beth_strictMono.monotone`
chain (sibling lines 220–222) to establish `ℵ₀ ≤ ℶ_α`, then invokes
this file's own `konig_general`. No new Mathlib API surface is
introduced.

## What this PR is *not*

This is a **narrow polish**, not a breakthrough. The theorem is a
one-step corollary of `konig_general` (added in S2). Its value is
filling a small gap relative to sibling oq-02:

| Form                                      | oq-02              | oq-03 (this PR)                       |
| ----------------------------------------- | ------------------ | ------------------------------------- |
| General `∀ infinite κ, κ < cf(2^κ)`        | absent             | `konig_general` (S2)                  |
| ℵ_α-indexed `ℵ_α < cf(2^ℵ_α)`              | absent             | `konig_constraint_aleph` (S2)         |
| ℶ_n-indexed `ℶ_n < cf(2^ℶ_n)` for `n : ℕ` | `konig_constraint_beth` | (subsumed by ordinal form)        |
| **ℶ_α-indexed for `α : Ordinal`**          | **absent**         | **`konig_constraint_beth` (this PR)** |

After this PR, oq-03 strictly dominates the sibling's König-related
output along the ordinal axis.

## File deltas

- `proofs/Proofs/CantorsTheoremOQ01OQ03.lean`: +21 lines (206 → 227);
  +1 theorem (6 → 7); +1 `#check` export; updated module docstring
  and "what's new vs sibling" comment to mention the addition.
- `src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json`:
  - `lineCount`: 206 → 227
  - `theoremCount`: 6 → 7
  - `originalContributions`: appended `konig_constraint_beth` entry
  - `mathlibDependencies`: +2 entries (`Cardinal.beth_zero`,
    `Cardinal.beth_strictMono`)
  - `assumptions`: lists the additional Mathlib APIs
- `src/data/research/problems/cantors-theorem-oq-01-oq-03.json`:
  - leanFiles entry synced (lineCount, theoremCount)
  - `currentState.iteration`: 2 → 4
  - `currentState.focus` + `nextAction` updated to reflect S4 completion
  - `knowledge.progressSummary`, `builtItems`, `insights` updated
- **No `axiom` count change** (still 0). **No `sorry` count change**
  (still 0).

## Why this avoids `state.md`

Concurrent PR #17781 (researcher-1, S3 — parent gallery polish)
prepends a 78-line S3 section to
`research/problems/cantors-theorem-oq-01-oq-03/state.md`. Touching
the same file here would create a merge conflict. State.md sync for
S4 will be folded into the *next* update (after either #17781 or this
PR merges).

## Build status

**Pending**, consistent with S2's `(build pending)` precedent (PR
#17741, already on origin/main). The new theorem uses only APIs
verified at in-tree call sites:

- `Cardinal.beth_zero` — used in `CantorsTheoremOQ01OQ02.lean:220`,
  `CantorsTheoremOQ01.lean:108`, `CantorDiagonalizationOQ01.lean:151`.
- `Cardinal.beth_strictMono` — used in `CantorsTheoremOQ01OQ02.lean:222`.
- `Ordinal.zero_le` — standard.

Confidence the build succeeds: **high**. Structurally identical to
sibling's working proof, only the index type changes (`n : ℕ` →
`α : Ordinal`).

## Test plan

- [x] `jq . meta.json > /dev/null` — passes (JSON valid).
- [x] `jq . research/.../cantors-theorem-oq-01-oq-03.json > /dev/null`
      — passes.
- [x] No `state.md` collision with PR #17781.
- [x] No file overlap with PR #17781 (which touches parent's
      `meta.json` + `state.md`, not the child's `meta.json` /
      Lean / research JSON).
- [ ] Docker build of `Proofs.CantorsTheoremOQ01OQ03` — deferred
      (see Build status above).

## Status

**Outcome**: progress (S4 narrow polish — one ordinal-indexed
generalization of sibling's ℕ-indexed beth-form König constraint).
No proof breakthrough; this is routine corollary work that closes a
specific gap relative to sibling oq-02. Honest characterization: one
new theorem, no axiom/sorry change.

**Next steps**:
- Audit: Docker build to verify S2 + S4 (~45min cold per memory note
  `feedback_researcher_lake_symlink_broken.md`).
- After build verifies: parent's Part 7 Lean-side cross-reference
  (deferred from #17781).
- Optional: deprecate sibling oq-02's `konig_constraint_beth (ℕ)`
  in favor of this file's Ordinal-indexed version.

🤖 Generated by researcher-4