### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S3 — 4 kernel-decide regression checks for the S2 Decidable instance (build pending)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -106,4 +106,44 @@ instance instDecidableIsAdmissible (H : Finset ℕ) :
     Decidable (IsAdmissible H) :=
   decidable_of_iff (IsAdmissibleBdd H) (isAdmissible_iff_bdd H).symm
 
+/-! ## S3: Regression checks exercising the Decidable instance
+
+The following kernel-`decide` checks confirm the S2 instance reduces correctly
+on a few concrete tuples. They serve two purposes:
+
+1. **Regression**: any future refactor of `IsAdmissibleBdd` or the
+   `isAdmissible_iff_bdd` proof script must keep these calls fast and correct.
+2. **Path A foundation**: per `knowledge.md` §3.3, small-case decisions are
+   the first deliverable of the verified-backtracking path; these examples are
+   the simplest such cases.
+
+We use kernel `decide` rather than `native_decide` to keep `axiomCount = 0`
+(the latter would introduce `Lean.ofReduceBool`). For larger Engelsma-analogue
+checks (`(k, w) = (6, 16)` and beyond), `native_decide` is necessary; that
+step is deferred to S4 along with the explicit axiom-bookkeeping update.
+-/
+
+/-- The S2 `Decidable` instance correctly certifies the twin-prime pattern
+`{0, 2}` as admissible. Kernel `decide` reduces through `decidable_of_iff`
+to `Finset.decidableDforallFinset` over `Finset.range 3`. -/
+theorem admissible_twin_via_S2 : IsAdmissible ({0, 2} : Finset ℕ) := by decide
+
+/-- The S2 `Decidable` instance correctly certifies the triple `{0, 2, 6}`
+as admissible. (Same triple proved manually in `BoundedPrimeGaps` as
+`admissible_triple_0_2_6`; here we re-derive it via the S2 instance to
+exercise the `Finset.range 4` reduction path.) -/
+theorem admissible_triple_via_S2 : IsAdmissible ({0, 2, 6} : Finset ℕ) := by decide
+
+/-- The S2 `Decidable` instance correctly certifies the quadruple `{0, 2, 6, 8}`
+as admissible. (Same quadruple proved manually in `BoundedPrimeGaps` as
+`admissible_quadruple_0_2_6_8`; re-derived here through the S2 instance.) -/
+theorem admissible_quadruple_via_S2 :
+    IsAdmissible ({0, 2, 6, 8} : Finset ℕ) := by decide
+
+/-- *Negative case*: the S2 `Decidable` instance correctly refutes
+admissibility of `{0, 1}`. The pair mod 2 covers both residues (0%2 = 0,
+1%2 = 1), so card 2 = 2, violating the `< 2` condition. -/
+theorem not_admissible_zero_one_via_S2 :
+    ¬ IsAdmissible ({0, 1} : Finset ℕ) := by decide
+
 end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,13 +1,34 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-11T19:35:00Z
-**Iteration**: 2
-**Researcher**: researcher-12 (S2; researcher-10 wrote S1)
+**Since**: 2026-05-12T05:35:00Z
+**Iteration**: 3
+**Researcher**: researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
 
 ## Current Focus
 
-S2 (this PR) — `Decidable (IsAdmissible H)` infrastructure
+S3 (this PR) — Kernel-`decide` regression checks for the S2 `Decidable`
+instance: four theorems demonstrating correct reduction on small tuples.
+
+* `admissible_twin_via_S2`         — `IsAdmissible {0, 2}` via S2 instance.
+* `admissible_triple_via_S2`       — `IsAdmissible {0, 2, 6}` via S2 instance.
+* `admissible_quadruple_via_S2`    — `IsAdmissible {0, 2, 6, 8}` via S2 instance.
+* `not_admissible_zero_one_via_S2` — `¬ IsAdmissible {0, 1}` via S2 instance
+  (negative case; `(·%2)` image card = 2 ≥ 2).
+
+All four use kernel `decide` (not `native_decide`), keeping `axiomCount = 0`.
+These are the simplest Path-A (verified-backtracking) sanity checks per
+`knowledge.md` §3.3 — exercising the new instance on tuples already proven
+admissible in `BoundedPrimeGaps.lean` (via hand-written calculation) plus one
+negative case to confirm the decider rejects non-admissible inputs.
+
+`native_decide`-based Engelsma-analogue checks (`(k, w) = (6, 16)` and
+beyond) are explicitly deferred to S4, where the introduction of the
+`Lean.ofReduceBool` axiom needs to be accounted for in meta.json.
+
+### Previous focus (S2)
+
+S2 — `Decidable (IsAdmissible H)` infrastructure
 landed in a new file
 `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+109 lines,
 1 abbrev, 1 theorem, 1 instance, 0 axioms, 0 sorries):
@@ -59,46 +80,34 @@ but cannot be assessed until at least S4.
 
 ## Next Action
 
-**S3 — Path A small-case sanity `native_decide`** per
-knowledge.md §3.3. Suggested first probe (no algorithmic
-content; just exercises the S2 instance through
-elaboration):
+**S4 — `native_decide` Engelsma-analogue at `(k, w) = (6, 16)`** per
+knowledge.md §3.3. Concrete target:
 
 ```lean
-example :
-    ∀ H ∈ (Finset.range 10).powersetCard 5,
-      Decidable (IsAdmissible H) := by
-  intro H _; infer_instance
-```
-
-After that lands, escalate to the actual small-Engelsma
-analogue at `(k, w) = (6, 16)` (`Finset.range 16` has
-`Nat.choose 16 6 = 8008` subsets of size 6; tractable):
-
-```lean
-example :
+theorem engelsma_analogue_6_16 :
     ∀ H ∈ (Finset.range 16).powersetCard 6,
       0 ∈ H → IsAdmissible H → 12 ≤ Finset.max' H ⟨0, ‹_›⟩ := by
   native_decide
 ```
 
-(Exact statement to be hardened in the S3 PR; the above is a
-sketch.)
+`Nat.choose 16 6 = 8008` subsets — tractable for `native_decide`. The
+`Lean.ofReduceBool` axiom introduced by `native_decide` must be reflected
+in meta.json (`axiomCount` 0 → 1).
 
-**S4 onward (deferred)**:
+**S5 onward (deferred)**:
 
-- S4 — `(k, w) = (10, 30)` or larger small-case Engelsma
+- S5 — `(k, w) = (10, 30)` or larger small-case Engelsma
   analogue. `Nat.choose 30 10 ≈ 3 × 10^7`; pushes
   `native_decide`'s compute budget into the 1–10 min range
   and helps calibrate the §6.4 runtime extrapolation toward
   `(50, 246)`.
-- S5 — `engelsma_lower_bound_of_finitary` bridge lemma
+- S6 — `engelsma_lower_bound_of_finitary` bridge lemma
   (Option B prerequisite) per knowledge.md §2.4.
-- S6+ — Path B verified-backtracking prototype, building on
-  the S3/S4 `native_decide` infrastructure as a unit-test
+- S7+ — Path B verified-backtracking prototype, building on
+  the S4/S5 `native_decide` infrastructure as a unit-test
   harness.
 - Path C (Selberg sieve fallback) remains an alternative if
-  Path B's runtime extrapolation fails at S4.
+  Path B's runtime extrapolation fails at S5.
 
 ## Attempt Counts
 
@@ -111,4 +120,13 @@ sketch.)
 - **S1 (2026-05-11, researcher-10)**: OBSERVE. Located the axiom, reduced to the finitary
   decidable form, surveyed three approach paths (A/B/C in `knowledge.md`), identified
   Path B as target, identified S2 as a foundational `Decidable (IsAdmissible H)` instance.
-  Doc-only iteration. No Lean changes. PR pending.
+  Doc-only iteration. No Lean changes. PR #17774 merged.
+- **S2 (2026-05-11, researcher-12)**: ACT. New file
+  `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (109 lines): `IsAdmissibleBdd`,
+  `isAdmissible_iff_bdd`, `instDecidableIsAdmissible`. 0 axioms, 0 sorries.
+  Build pending. PR #17790 merged.
+- **S3 (2026-05-12, researcher-8)**: ACT. Extended S2 file (109 → 149 lines, +40):
+  4 kernel-`decide` regression theorems exercising the S2 instance on
+  `{0, 2}`, `{0, 2, 6}`, `{0, 2, 6, 8}` (positive) and `{0, 1}` (negative).
+  Kernel decide preserves `axiomCount = 0`; `native_decide`-based larger
+  Engelsma analogues deferred to S4.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-11T19:35:00Z",
-    "iteration": 2,
-    "focus": "S2 (this PR) — Decidable infrastructure for IsAdmissible. New file BoundedPrimeGapsOQ03OQ02.lean (+109 lines, 1 abbrev, 1 theorem, 1 instance, 0 axioms, 0 sorries): abbrev IsAdmissibleBdd as the Finset-bounded variant of IsAdmissible, theorem isAdmissible_iff_bdd for the equivalence (forward by restriction; backward by case-split on p ≤ H.card, with Finset.card_image_le discharging p > H.card), and instance instDecidableIsAdmissible via decidable_of_iff. Discharges §3.1 of knowledge.md and unblocks Path B small-case prototypes (§3.3, §4). Build pending (broken proofs/.lake symlink in current worktree per memory feedback_researcher_lake_symlink_broken.md); proof script is stable Mathlib API + omega only.",
+    "since": "2026-05-12T05:35:00Z",
+    "iteration": 3,
+    "focus": "S3 (this PR) — Kernel-`decide` regression checks. Extends BoundedPrimeGapsOQ03OQ02.lean (109 → 149 lines, +40) with 4 theorems exercising the S2 Decidable instance: `admissible_twin_via_S2` ({0, 2}), `admissible_triple_via_S2` ({0, 2, 6}), `admissible_quadruple_via_S2` ({0, 2, 6, 8}), and `not_admissible_zero_one_via_S2` (negative case for {0, 1}). All four use kernel `decide` (not `native_decide`), preserving `axiomCount = 0`. These are the simplest Path-A sanity checks per knowledge.md §3.3 — exercising the new instance on tuples already proven admissible in BoundedPrimeGaps.lean (via hand-written calculation) plus one negative case to confirm rejection of non-admissible inputs. Build pending; proof script is `decide` only on small Finsets.",
     "blockers": [],
-    "nextAction": "S3 — small-case sanity native_decide via §3.3 of knowledge.md (e.g. `∀ H ∈ (Finset.range 16).powersetCard 6, 0 ∈ H → IsAdmissible H → H.max' ... ≥ 12` — ~8008 admissibility checks, tractable). This stress-tests the S2 Decidable instance before committing to S4 Path-B prototyping at `(k, w) = (6, 16)` or `(10, 30)`.",
+    "nextAction": "S4 — `native_decide` Engelsma-analogue at `(k, w) = (6, 16)`: `∀ H ∈ (Finset.range 16).powersetCard 6, 0 ∈ H → IsAdmissible H → 12 ≤ Finset.max' H ...` (~8008 admissibility checks). Will introduce `Lean.ofReduceBool` axiom — must reflect this in meta.json (`axiomCount` 0 → 1).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
       "filename": "BoundedPrimeGapsOQ03OQ02.lean",
-      "lineCount": 109,
-      "theoremCount": 1,
+      "lineCount": 149,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (109 → 149 lines, +40) with 4 theorems that exercise the S2 `Decidable (IsAdmissible H)` instance on concrete small tuples.

### New theorems

| Theorem | Tuple | Result |
|---|---|---|
| `admissible_twin_via_S2` | `{0, 2}` | admissible ✓ |
| `admissible_triple_via_S2` | `{0, 2, 6}` | admissible ✓ |
| `admissible_quadruple_via_S2` | `{0, 2, 6, 8}` | admissible ✓ |
| `not_admissible_zero_one_via_S2` | `{0, 1}` | **not** admissible ✓ |

All four use **kernel `decide`** (not `native_decide`), preserving `axiomCount = 0`. The S2 `Decidable` instance reduces through `decidable_of_iff` → `Finset.decidableDforallFinset` over the small range `Finset.range (H.card + 1)`, so the decision is bounded and fast.

### Rationale

- **Path-A sanity checks** per `knowledge.md` §3.3: simplest verified-backtracking tests.
- **Regression coverage**: each positive case re-derives an `IsAdmissible` fact already proven by hand in `BoundedPrimeGaps.lean` (`admissible_twin`, `admissible_triple_0_2_6`, `admissible_quadruple_0_2_6_8`). Any future refactor of `IsAdmissibleBdd` or the `isAdmissible_iff_bdd` proof must keep these reductions correct.
- **Negative case** confirms the decider rejects non-admissible inputs (the pair `{0, 1}` mod 2 covers both residues).
- **No `native_decide`**: the larger Engelsma-analogue checks at `(k, w) = (6, 16)` (~8008 subsets) are explicitly deferred to S4 along with the `Lean.ofReduceBool` axiom-bookkeeping.

### File-level changes

- `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean`: **109 → 149 lines**, **1 → 5 theorems**; sorries 0; axioms 0.
- `research/problems/bounded-prime-gaps-oq-03-oq-02/state.md`: S3 entry in session log; nextAction updated to point at S4 `(k, w) = (6, 16)` native_decide.
- `src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json`: `leanFiles[]` entry for `BoundedPrimeGapsOQ03OQ02.lean` updated (`lineCount` 109 → 149, `theoremCount` 1 → 5); `currentState` bumped to S3.

### Notes

- **Build status**: pending. Per memory `feedback_researcher_lake_symlink_broken.md`, this worktree's Docker build path is unreliable. Proof script is `by decide` only on tiny concrete Finsets — build risk is minimal.
- **Consistency**: S2 (#17790) was also build-pending; this PR follows the same precedent.

## Test plan

- [ ] CI lake build verifies `decide` reduces correctly on all 4 cases.
- [ ] Subsequent S4 PR can build on these examples as a unit-test harness for the `native_decide` Engelsma-analogue.