### PR TITLE
fix(meta): batch sync definitionCount drift (3 entries)

### DIFF
--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -29,7 +29,7 @@
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries remain. — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0",
     "theoremCount": 10,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos1027Aristotle.lean"
     ]
@@ -195,7 +195,7 @@
     "lineCount": 353,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1027Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
     "theoremCount": 5,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -230,7 +230,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

Sync stale `definitionCount` values in 3 `meta.json` files where the gallery counter (both `meta.definitionCount` and `leanFile.definitionCount`) lags the actual top-level `def`/`abbrev`/`opaque`/`structure`/`inductive`/`class` declarations in the underlying Lean source.

All 3 entries had identical `meta.*` and `leanFile.*` values pre-fix, so this is pure drift after research expansions — not a divergence between the two views. Every count moves up.

## Evidence

For each entry the actual count was computed by stripping nested Lean block comments and line comments, then matching:

```regex
^(@\[[^\]]*\]\s*)*(?:(?:private|protected|noncomputable|partial|unsafe|scoped)\s+)*(def|abbrev|opaque|structure|inductive|class)\s+\w+
```

against the file at `meta.proofRepoPath`.

Counts (old → new):

| slug | old | new | Δ |
|---|---:|---:|---:|
| erdos-1027 | 11 | 14 | +3 |
| erdos-1063 | 4 | 5 | +1 |
| roth-theorem-k3-oq-02 | 4 | 7 | +3 |

Diff: 3 files, +6/−6 lines (each entry has the field in two places — top-level `meta` block and nested `leanFile` block — both updated for consistency).

---
Automated fix by lean-mechanic agent.