### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 21 — small-prime correction-factor product bound (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -885,6 +885,74 @@ example :
     ((Finset.range 101).filter (fun p => Nat.Prime p ∧ p ^ 2 ≤ 100)).card = 4 := by
   decide
 
+/-- **Pointwise division bound** (Iter 21 helper): for any prime `p`, the
+    division `n / p` is bounded by `n / 2`.
+
+    Since every prime is `≥ 2`, dividing by a larger value yields a smaller
+    quotient (`Nat.div_le_div_left`). This is the pointwise atom of the
+    multiplicative combination step in the four-step Hanson bridge:
+
+    1. Iter 19: product bound `∏ p^(log_p n - 1) ≤ ∏ (n/p)`.
+    2. Iter 17 (PR #17619, in flight): support reduction `p² > n → factor = 1`.
+    3. Iter 20: cardinality bound `|{p prime : p² ≤ n}| ≤ √n`.
+    4. **This iter (pointwise)**: `n / p ≤ n / 2` for any prime `p`.
+    5. Iter 21 (this PR, main): `∏_{p prime, p² ≤ n} (n/p) ≤ (n/2) ^ card`.
+
+    Concrete numerics:
+    * `p = 2, n = 10`: `10 / 2 = 5 ≤ 5`. ✓ (tight)
+    * `p = 3, n = 10`: `10 / 3 = 3 ≤ 5`. ✓
+    * `p = 5, n = 10`: `10 / 5 = 2 ≤ 5`. ✓
+    * `p = 7, n = 10`: `10 / 7 = 1 ≤ 5`. ✓ -/
+theorem div_prime_le_div_two {p : ℕ} (hp : p.Prime) (n : ℕ) :
+    n / p ≤ n / 2 :=
+  Nat.div_le_div_left hp.two_le (by norm_num)
+
+/-- **Small-prime correction-factor product bound** (Iter 21): the product
+    `∏_{p prime, p² ≤ n} (n / p)` is bounded above by `(n / 2)` raised to
+    the cardinality of the small-prime filter.
+
+    Step 5 of the four-step Hanson bridge (post-Iter-20 documented plan):
+    combines Iter 21's pointwise `div_prime_le_div_two` with `Mathlib`'s
+    `Finset.prod_le_pow_card` (`∀ x ∈ s, f x ≤ b → ∏ f ≤ b ^ s.card`).
+
+    Combined with Iter 20's `small_prime_card_le_sqrt`, this yields the
+    Chebyshev-style `(n/2) ^ √n` envelope for the small-prime correction
+    product. The final assembly (a future iter) folds this with Iter 17's
+    support-reduction (PR #17619, in flight) and Iter 19's product bound
+    to discharge the correction factor `∏_{p ≤ n} (n/p) ≤ (n/2) ^ √n`,
+    then combines with `Nat.primorial_le_4_pow` for the structural
+    Chebyshev envelope `lcmRange n ≤ 4^n · (n/2) ^ √n`.
+
+    Concrete numerics:
+    * `n = 10`: small primes `{2, 3}` (`2² = 4 ≤ 10`, `3² = 9 ≤ 10`),
+                LHS = `(10/2)·(10/3) = 5·3 = 15`,
+                RHS = `(10/2)^2 = 5² = 25`. ✓ (15 ≤ 25)
+    * `n = 20`: small primes `{2, 3}` (`3² = 9 ≤ 20`, `5² = 25 > 20`),
+                LHS = `(20/2)·(20/3) = 10·6 = 60`,
+                RHS = `(20/2)^2 = 10² = 100`. ✓ (60 ≤ 100)
+    * `n = 100`: small primes `{2, 3, 5, 7}`,
+                 LHS = `50·33·20·14 = 462000`,
+                 RHS = `50^4 = 6,250,000`. ✓ -/
+theorem prod_div_small_prime_le_pow_card (n : ℕ) :
+    ∏ p ∈ (Finset.range (n + 1)).filter (fun p => p.Prime ∧ p ^ 2 ≤ n), n / p
+      ≤ (n / 2) ^
+        ((Finset.range (n + 1)).filter (fun p => p.Prime ∧ p ^ 2 ≤ n)).card := by
+  apply Finset.prod_le_pow_card
+  intro p hp
+  rw [Finset.mem_filter] at hp
+  exact div_prime_le_div_two hp.2.1 n
+
+/-- **Concrete numerical witness** (Iter 21): at `n = 100` the small-prime
+    product `∏_{p ∈ {2,3,5,7}} (100 / p) = 462000` is bounded by
+    `(100 / 2) ^ 4 = 6,250,000`.
+
+    Sanity check for `prod_div_small_prime_le_pow_card`. -/
+example :
+    ∏ p ∈ (Finset.range 101).filter (fun p => p.Prime ∧ p ^ 2 ≤ 100), 100 / p
+      ≤ (100 / 2) ^
+        ((Finset.range 101).filter (fun p => p.Prime ∧ p ^ 2 ≤ 100)).card := by
+  native_decide
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,10 +4,74 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-12 (Iteration 20, researcher-11)
-**Iteration**: 20
+**Last Updated**: 2026-05-12 (Iteration 21, researcher-11)
+**Iteration**: 21
 
 ## Current Focus
+
+Iteration 21 (2026-05-12, this PR, researcher-11): **small-prime
+correction-factor product bound** — combines the pointwise atom
+`n / p ≤ n / 2` (any prime `p`, since primes are `≥ 2`) with
+`Finset.prod_le_pow_card` to obtain
+
+```
+∏_{p prime, p² ≤ n} (n / p) ≤ (n / 2) ^ |{small primes}|
+```
+
+over the Iter-20 small-prime filter. Two new theorems
+(+68 lines, sorry-free, axiom-free):
+
+* `div_prime_le_div_two {p : ℕ} (hp : p.Prime) (n : ℕ) : n / p ≤ n / 2`
+  — pointwise atom. Single-line proof:
+  `Nat.div_le_div_left hp.two_le (by norm_num)`.
+* `prod_div_small_prime_le_pow_card (n : ℕ)` — main lemma. Three-line
+  proof via `Finset.prod_le_pow_card` applied to the Iter-20 filter,
+  invoking `div_prime_le_div_two` pointwise.
+* `example` decide-witness at `n = 100` (LHS = `50·33·20·14 = 462000`,
+  RHS = `50⁴ = 6,250,000`, well below the loose bound).
+
+### Strategic value
+
+Step 5 of the four-step Hanson bridge (the "multiplicative combination"
+Iter 20 candidate):
+
+1. ✓ Iter 19 (#17710): product bound `∏ p^(log_p n - 1) ≤ ∏ (n/p)`.
+2. ⏳ Iter 17 (PR #17619): support reduction (`p² > n → factor = 1`).
+3. ✓ Iter 20 (#17767): cardinality bound `|small primes| ≤ √n`.
+4. **This iter (atom)**: `n / p ≤ n / 2` for any prime `p`.
+5. **This iter (main)**: `∏_{p² ≤ n} (n/p) ≤ (n/2) ^ card`.
+6. ⏳ Iter 22+: chain through Iter 20 (card ≤ √n) + pow-monotonicity
+   (with `n ≥ 2` hypothesis) to get `≤ (n/2) ^ √n`, then assemble
+   with Iter 17 + Iter 19 for the full correction-factor envelope.
+
+Iter 21 is **structurally independent** of #17619 (Iter 17): it bounds
+the product *over the small-prime filter directly*, regardless of how
+the large-prime tail is handled.
+
+### File delta
+
++68 lines (1014 → 1082), +2 theorems + 1 example (54 → 56). Definitions
+(1) / sorries (0) / axiomCount (1) unchanged. Build pending — proof
+uses only:
+
+* `Nat.div_le_div_left` (`k ≤ m → 0 < k → n / m ≤ n / k`,
+  exercised in `Erdos1009OQ02Problem.lean:234` and
+  `Erdos404Problem.lean:115`).
+* `Nat.Prime.two_le` (every prime is `≥ 2`).
+* `Finset.prod_le_pow_card` (Mathlib generic, exercised in
+  `Erdos678Problem.lean:210`).
+* `Finset.mem_filter` (used pervasively).
+
+### Compatibility with open PRs
+
+* **#17619 (OPEN, Iter 17 support reduction)**: orthogonal — Iter 21
+  is the multiplicative-combination step for the *small-prime
+  product* directly; Iter 17 is the upstream support-reduction step
+  that lets us *also* bound the full prime product by the small-prime
+  product (when assembled).
+* **#17551 (OPEN, Iter 15 alternate)**: orthogonal, no overlap.
+
+### Iteration 20 (background, merged base, #17767)
 
 Iteration 20 (2026-05-12, this PR, researcher-11): **cardinality bound
 on small-prime filter** — proves that the number of primes `p` with

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1014,
-    "theoremCount": 54,
+    "lineCount": 1082,
+    "theoremCount": 56,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -31,16 +31,16 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T20:50:00Z",
-    "iteration": 20,
-    "focus": "Iter 20 (this PR, researcher-11): cardinality bound on small-prime filter — |{p prime : p^2 ≤ n}| ≤ Nat.sqrt n. Pure combinatorial counting step (Step 3 of the four-step Hanson bridge documented in state.md). Independent of in-flight PR #17619 (Iter 17 support-reduction). +58 lines, +1 theorem + 1 example.",
+    "iteration": 21,
+    "focus": "Iter 21 (this PR, researcher-11): small-prime correction-factor product bound — ∏_{p prime, p² ≤ n} (n / p) ≤ (n / 2) ^ |{small primes}|. Two new theorems: div_prime_le_div_two (pointwise n/p ≤ n/2 for any prime p, one-line proof via Nat.div_le_div_left + Nat.Prime.two_le), and prod_div_small_prime_le_pow_card (the product bound, three-line proof via Finset.prod_le_pow_card). Pairs with Iter 20's small_prime_card_le_sqrt to obtain the (n/2)^√n envelope after a future card-monotonicity step. +68 lines (1014 → 1082), +2 theorems + 1 example (54 → 56). Sorries / axioms / defs unchanged.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
       "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Iter 21: combine small_prime_card_le_sqrt with prod_prime_pow_pred_le_prod_div_prime (Iter 19) and the eventual lcmRange_correction_supported_on_small_primes (PR #17619, in flight) to derive the small-prime restricted product bound. Specifically, prove `∏_{p prime, p^2 ≤ n} (n / p) ≤ (n / 2) ^ Nat.sqrt n` via `Finset.prod_le_pow_card` and `n / p ≤ n / 2` for prime `p ≥ 2`. Combined with `Nat.primorial_le_4_pow`, this is the structural envelope `lcmRange n ≤ 4^n · (n/2)^√n`, sub-`(4 + ε)^n` for any ε > 0 and large n.",
+    "nextAction": "Iter 22 candidate: card-monotonicity step `(n/2) ^ card ≤ (n/2) ^ √n` for n ≥ 2 (using small_prime_card_le_sqrt + Nat.pow_le_pow_right with `1 ≤ n/2`). Then chain Iter 21's product bound through it to obtain `∏_{p prime, p² ≤ n} (n/p) ≤ (n/2) ^ √n` (with the appropriate `n ≥ 2` hypothesis, since for `n = 1` the LHS = 1 but RHS = 0^1 = 0). Long-term Iter 23+: combine with Iter 17 support reduction (PR #17619) and Iter 19 product bound to discharge full correction factor `∏_{p ≤ n} (n/p) ≤ (n/2) ^ √n`; then with Nat.primorial_le_4_pow → `lcmRange n ≤ 4^n · (n/2)^√n`, the structural Chebyshev envelope.",
     "attemptCounts": {
-      "total": 20,
-      "currentApproach": 4,
+      "total": 21,
+      "currentApproach": 5,
       "approachesTried": 2
     }
   },


### PR DESCRIPTION
## Summary

**Iter 21** closes Step 5 of the four-step Hanson bridge documented in
the post-Iter-20 `state.md`: the multiplicative-combination step for
the small-prime correction product.

Two new theorems (+68 lines, sorry-free, axiom-free, build pending):

* **`div_prime_le_div_two`** (Iter 21 helper, pointwise atom):
  ```
  ∀ {p : ℕ}, p.Prime → ∀ (n : ℕ), n / p ≤ n / 2
  ```
  One-line proof: `Nat.div_le_div_left hp.two_le (by norm_num)`. Since
  every prime is `≥ 2`, dividing by a larger value yields a smaller
  quotient.
* **`prod_div_small_prime_le_pow_card`** (Iter 21 main):
  ```
  ∀ (n : ℕ),
    ∏ p ∈ (range (n+1)).filter (fun p => p.Prime ∧ p^2 ≤ n), n / p
      ≤ (n / 2) ^
        ((range (n+1)).filter (fun p => p.Prime ∧ p^2 ≤ n)).card
  ```
  Three-line proof via `Finset.prod_le_pow_card` applied pointwise
  through `div_prime_le_div_two`.
* **Concrete witness** (`example`): at `n = 100`, the small-prime
  product `∏_{p ∈ {2,3,5,7}} (100/p) = 462,000` is bounded by
  `50⁴ = 6,250,000` (a `~13×` loose bound, demonstrating the
  envelope is not tight).

## Strategic position (Hanson bridge)

1. ✓ **Iter 19** (#17710, merged): product bound `∏ p^(log_p n - 1) ≤ ∏ (n/p)`.
2. ⏳ **Iter 17** (PR #17619, in flight): support reduction (`p² > n → factor = 1`).
3. ✓ **Iter 20** (#17767, merged): cardinality bound `|{p prime : p² ≤ n}| ≤ √n`.
4. ✓ **Iter 21 (this PR, helper)**: pointwise `n / p ≤ n / 2`.
5. ✓ **Iter 21 (this PR, main)**: small-prime product `∏_{p² ≤ n} (n/p) ≤ (n/2)^card`.
6. ⏳ **Iter 22+**: chain through Iter 20 (card ≤ √n) + pow-monotonicity
   (with `n ≥ 2` hypothesis since `n=1` gives `(1/2)^1 = 0` but
   empty product `= 1`) → `(n/2)^√n` envelope.
7. ⏳ **Iter 23+**: combine with Iter 17 + Iter 19 + `Nat.primorial_le_4_pow`
   → `lcmRange n ≤ 4^n · (n/2)^√n`, the structural Chebyshev envelope.

Iter 21 is **structurally independent of #17619** (Iter 17): it
bounds the product *over the small-prime filter directly*, regardless
of how the large-prime tail is handled.

## Files

| File | Change |
| --- | --- |
| `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` | +68 lines; +2 theorems (`div_prime_le_div_two`, `prod_div_small_prime_le_pow_card`) + 1 `example` (decide witness at n=100). Inserted between Iter 20's `example` and `lcmRange_succ`. |
| `research/problems/.../state.md` | iteration 20 → 21; document Iter 22 next-action (card-monotonicity step). |
| `src/data/research/problems/....json` | iteration 20 → 21; focus, nextAction, builtItems. |
| `src/data/proofs/.../meta.json` | `lineCount` 1014 → 1082, `theoremCount` 54 → 56. |

## Build status

Marked `(build pending)` per the file's convention. Uses only standard
Mathlib API exercised elsewhere in this codebase:

* `Nat.div_le_div_left` — `k ≤ m → 0 < k → n / m ≤ n / k`
  (used at `Erdos1009OQ02Problem.lean:234`, `Erdos404Problem.lean:115`).
* `Nat.Prime.two_le` — `p.Prime → 2 ≤ p` (standard).
* `Finset.prod_le_pow_card` — `(∀ x ∈ s, f x ≤ b) → ∏ f ≤ b^card`
  (used at `Erdos678Problem.lean:210`).
* `Finset.mem_filter` (used pervasively).

No new sorries, no new axioms.

## Compatibility with open PRs

* **#17619 (OPEN, Iter 17 support reduction)**: orthogonal — Iter 21
  bounds the small-prime *product* directly; Iter 17 is the
  upstream support-reduction step that lets us also bound the full
  prime product by the small-prime product (when assembled).
* **#17551 (OPEN, Iter 15 alternate)**: orthogonal, no overlap.

## Test plan

- [ ] CI Docker build of `Proofs.BaselProblemOQ01OQ01OQ02OQ03` succeeds.
- [ ] `pnpm build` passes (gallery JSON validates).
- [ ] No regression in other Basel files (`BaselProblemOQ01OQ01OQ02.lean`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)