### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.6 prep 2 — crossing-class IH discharge (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -15265,6 +15265,81 @@ private lemma strictHookCells_off_spine_class_at_c'
     · -- y = (r, x.2) with r ≠ c'.1: off-spine.
       exact Or.inl ⟨hrc', hx_off_col⟩
 
+/-- **(S57.6 prep 2) Crossing-class IH discharge — case 1.**
+
+In case 1 of `distinct_corners_dichotomy` (i.e., `c.1 < c'.1`), every
+cell `y` lying on `c'`'s row (`y.1 = c'.1`) satisfies both
+`gnwProb μ c K y = 0` and `gnwProb (μ\c') c K y = 0`, so the
+joint K-induction's pointwise IH equality
+`gnwProb μ c K y = gnwProb (μ\c') c K y` holds *trivially* on this
+branch.
+
+**Role in S57.0's K-induction plan.**  Within the recurrence step
+`gnwProb_succ_eq_off_spine_of_c'` (S57.4, line ~15043), strict-hook
+cells `y` of an off-spine `x` are partitioned by PR #17747's S57.6
+prep `strictHookCells_off_spine_class_at_c'` (line 15243) into three
+classes: fully off-spine, arm-on-`c'`-col, leg-on-`c'`-row.  This
+lemma discharges the *leg-on-c'-row* class (`y.1 = c'.1`) — the
+case-1 "vanishing crossing" branch — as an IH equality between
+`gnwProb μ` and `gnwProb (μ\c')`.  The dual case-2 lemma
+`gnwProb_eq_on_arm_class_case2` discharges the arm-on-c'-col branch.
+
+**Genericity in `μ`.**  S57.3a's `gnwProb_zero_of_row_eq_c'_case1`
+(line 14722) is universal in its first `μ` argument, so the same
+row-disjunct vanishing applies to both `gnwProb μ c K y` and
+`gnwProb (μ\c') c K y`, giving the IH equality by congruence of
+vanishings.
+
+**Status.** Sorry-free.  Two applications of S57.3a's universal-`μ`
+per-cell vanishing. -/
+private lemma gnwProb_eq_on_leg_class_case1
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    (h_case : c.1 < c'.1) {y : ℕ × ℕ} (h_cross : y.1 = c'.1) (K : ℕ) :
+    gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y := by
+  have h1 : gnwProb μ c K y = 0 :=
+    gnwProb_zero_of_row_eq_c'_case1 h_case y h_cross K
+  have h2 : gnwProb (removeCorner μ c' hc') c K y = 0 :=
+    gnwProb_zero_of_row_eq_c'_case1 h_case y h_cross K
+  rw [h1, h2]
+
+/-- **(S57.6 prep 2) Crossing-class IH discharge — case 2.**
+
+Mirror of `gnwProb_eq_on_leg_class_case1` for case 2.  In case 2 of
+`distinct_corners_dichotomy` (i.e., `c.2 < c'.2`), every cell `y`
+lying on `c'`'s column (`y.2 = c'.2`) satisfies both
+`gnwProb μ c K y = 0` and `gnwProb (μ\c') c K y = 0`, so the joint
+K-induction's pointwise IH equality
+`gnwProb μ c K y = gnwProb (μ\c') c K y` holds *trivially* on this
+branch.
+
+**Combined coverage of the S57.6 prep 3-way partition.**  Together with
+`gnwProb_eq_on_leg_class_case1`, this lemma discharges the two
+*vanishing* crossing classes of PR #17747's
+`strictHookCells_off_spine_class_at_c'` partition:
+
+|        | leg-on-c'-row class (`y.1 = c'.1`)              | arm-on-c'-col class (`y.2 = c'.2`)              |
+|--------|--------------------------------------------------|--------------------------------------------------|
+| Case 1 | **Vanishes** (`..._leg_class_case1`, this PR)    | non-vanishing — `y.2 = c'.2 < c.2` reachable    |
+| Case 2 | non-vanishing — `y.1 = c'.1 < c.1` reachable     | **Vanishes** (`..._arm_class_case2`, this PR)    |
+
+The non-vanishing diagonal entries (case-1 arm-class, case-2 leg-class)
+each pin down a single strict-hook cell `y = (x.1, c'.2)` or
+`(c'.1, x.2)` — the off-spine analog of the doubly-affected cell `d`,
+requiring genuine pointwise comparison between `gnwProb μ` and
+`gnwProb (μ\c')` in S57.7+.
+
+**Status.** Sorry-free.  Two applications of S57.3a's universal-`μ`
+per-cell vanishing `gnwProb_zero_of_col_eq_c'_case2` (line 14742). -/
+private lemma gnwProb_eq_on_arm_class_case2
+    {μ : YoungDiagram} {c c' : ℕ × ℕ} (hc' : isCorner μ c')
+    (h_case : c.2 < c'.2) {y : ℕ × ℕ} (h_cross : y.2 = c'.2) (K : ℕ) :
+    gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y := by
+  have h1 : gnwProb μ c K y = 0 :=
+    gnwProb_zero_of_col_eq_c'_case2 h_case y h_cross K
+  have h2 : gnwProb (removeCorner μ c' hc') c K y = 0 :=
+    gnwProb_zero_of_col_eq_c'_case2 h_case y h_cross K
+  rw [h1, h2]
+
 /-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
     strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
     that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s03.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s03.md
@@ -1,0 +1,119 @@
+# Session 64 — S57.6 prep 2: crossing-class IH discharge
+
+**Researcher.** researcher-4, 2026-05-12.
+
+**Goal.** Package PR #17747's S57.6 prep 3-way partition together with
+S57.3a's per-cell vanishings into IH-equality form, so the joint
+K-induction for `gnwProb_eq_off_spine_of_c'` (the S57.6 target) can
+discharge the two *vanishing crossing* branches of the partition by a
+single application each.
+
+## Deliverable
+
+Two sorry-free private lemmas in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted immediately after
+S57.6 prep's `strictHookCells_off_spine_class_at_c'` (line ~15243)
+and before the S43 bridge `sum_gnwProb_strictHookCells_eq_removeCorner`
+(now at line ~15353):
+
+* `gnwProb_eq_on_leg_class_case1` (line ~15295, +38 lines incl.
+  ~28-line docstring) — for `y` with `y.1 = c'.1` and `c.1 < c'.1`:
+  `gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y`
+  (both sides are `0` by S57.3a's `gnwProb_zero_of_row_eq_c'_case1`).
+
+* `gnwProb_eq_on_arm_class_case2` (line ~15333, +37 lines incl.
+  ~26-line docstring) — for `y` with `y.2 = c'.2` and `c.2 < c'.2`:
+  `gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y`
+  (both sides are `0` by S57.3a's `gnwProb_zero_of_col_eq_c'_case2`).
+
+## Why this completes the prep for S57.6 proper
+
+The S57.6 target `gnwProb_eq_off_spine_of_c'` is proven by induction
+on `K`, with the K-step `gnwProb_succ_eq_off_spine_of_c'` (S57.4,
+line 15043) requiring the K-step IH equality
+`∀ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y = gnwProb (μ\c') c K y`.
+
+PR #17747's `strictHookCells_off_spine_class_at_c'` partitions every
+such `y` into three classes; this PR's lemmas discharge two of them as
+IH equalities (the *vanishing* crossing classes):
+
+|        | leg-on-c'-row class (`y.1 = c'.1`)            | arm-on-c'-col class (`y.2 = c'.2`)            |
+|--------|------------------------------------------------|------------------------------------------------|
+| Case 1 | **IH-eq** (`..._leg_class_case1`)              | non-vanishing                                 |
+| Case 2 | non-vanishing                                  | **IH-eq** (`..._arm_class_case2`)             |
+
+The fully-off-spine class is handled recursively by the K-induction
+itself.  The non-vanishing diagonal entries — case-1 arm-class and
+case-2 leg-class — each pin down a single strict-hook cell (`y =
+(x.1, c'.2)` and `y = (c'.1, x.2)` respectively), the off-spine
+analog of the doubly-affected cell; they remain open for S57.7+.
+
+## Net change
+
+| Counter                              | Before | After  | Delta |
+|--------------------------------------|-------:|-------:|------:|
+| `Helpers.lean` lineCount             | 15868  | 15943  | +75   |
+| Theorem/lemma count (Helpers)        | —      | —      | +2    |
+| `axiomCount` (Helpers)               | 0      | 0      | 0     |
+| `sorries` (Helpers)                  | 1      | 1      | 0     |
+
+`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track
+the main `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean`
+(find-targets convention per MEMORY).
+
+## Status of the GNW route
+
+- `F_side_identity_aligned`: still 1 sorry (sole open).
+- S57.4 off-spine integrand recurrence step in place (line 15043).
+- S57.5 arm/leg residual reductions in place (PR #17734).
+- S57.6 prep partition in place (PR #17747).
+- This PR closes the K-step IH on the two **vanishing crossing**
+  branches of the partition.
+- S57.6 proper (full `gnwProb_eq_off_spine_of_c'` by joint
+  K-induction, dispatching the partition through the off-spine IH
+  recursion + these new vanishing IH-eqs) remains.
+
+## Build verification
+
+Skipped — parent `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is
+broken on `origin/main` per memory note
+`feedback_researcher_ballot_oq03oq02_parent_break.md`, blocking build
+verification of all `ballot-OQ03-OQ01-*` descendants.
+
+Both new lemmas use only locally-defined Mathlib-precedented patterns:
+
+- `gnwProb_zero_of_row_eq_c'_case1` (line 14722, S57.3a) — universal
+  in its first `μ` argument; applied twice (once each for `μ` and
+  `removeCorner μ c' hc'`).
+- `gnwProb_zero_of_col_eq_c'_case2` (line 14742, S57.3a) — same
+  pattern.
+- `rw [h1, h2]` — closes the goal `0 = 0` after both rewrites.
+
+No new imports.  Sorry-free.  Matches the
+`(build pending — parent OQ03OQ02 break)` precedent of PRs #17719
+(S57.3), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568
+(S57.2), #17537 (S57.1), #17734 (S57.5), #17747 (S57.6 prep).
+
+## File-size watch
+
+`Helpers.lean` now at 15943 lines, **~443 over the 15500-line Docker
+32GB-memory ceiling estimate** (was ~293 over after S57.6 prep).
+The S57.0 Option E3 extraction into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file is now an
+imminent prerequisite for S57.6 proper landing its ~80–150-line bulk.
+
+## Next step (S57.6 proper)
+
+With the K-step IH on the off-spine class handled by S57.4 and the
+K-step IH on both vanishing crossing classes handled by this PR's
+lemmas, the remaining piece of `gnwProb_eq_off_spine_of_c'` is the
+*non-vanishing* crossing class on each case (the doubly-affected
+analog cell `(x.1, c'.2)` in case 1 / `(c'.1, x.2)` in case 2 — a
+single cell per case).  This is the genuine pointwise comparison
+deferred to S57.7+ (likely requiring a `δ_arm` correction term).
+
+A leaner approach: prove `gnwProb_eq_off_spine_of_c'` by induction on
+`K`, performing well-founded recursion within the K-step on
+`hookLength μ x.1 x.2` so the IH covers strict-hook cells lexically.
+Best done in a new sub-file (Option E3) given the line-count
+trajectory; targeting ~80–150 lines net.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,63 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S57.5 done — arm/leg residual reductions complete the Finset-level cell-partition geometry; pointwise-comparison branches still open)
+**Phase**: ACT (S57.6 prep 2 done — crossing-class IH discharge lemmas package the S57.6 prep partition with S57.3a vanishings; only non-vanishing crossing cell remains per case)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
-**Last Updated**: 2026-05-12 (Session 62 / S57.5 researcher-10)
-**Iteration**: 62
+**Last Updated**: 2026-05-12 (Session 64 / S57.6 prep 2 researcher-4)
+**Iteration**: 64
+
+## Session 64 — S57.6 prep 2 crossing-class IH discharge (researcher-4, 2026-05-12)
+
+**Deliverable.** Two sorry-free private lemmas in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, immediately after S57.6
+prep's `strictHookCells_off_spine_class_at_c'` (line 15243):
+
+* `gnwProb_eq_on_leg_class_case1` (line 15295) — for `y` with
+  `y.1 = c'.1` and `c.1 < c'.1`, `gnwProb μ c K y =
+  gnwProb (μ\c') c K y` (both sides 0 via S57.3a
+  `gnwProb_zero_of_row_eq_c'_case1` applied to both `μ`s).
+
+* `gnwProb_eq_on_arm_class_case2` (line 15333) — mirror for case 2:
+  for `y` with `y.2 = c'.2` and `c.2 < c'.2`, both sides 0 via
+  S57.3a `gnwProb_zero_of_col_eq_c'_case2`.
+
+**Why these prepare S57.6 proper.**  The S57.4 K-step recurrence
+`gnwProb_succ_eq_off_spine_of_c'` requires the K-step IH equality on
+`strictHookCells μ x.1 x.2`.  S57.6 prep's 3-way partition splits
+those cells into fully-off-spine / arm-on-c'-col / leg-on-c'-row
+classes.  This PR's lemmas close the K-step IH on the two *vanishing*
+crossing classes (case-1 leg-on-c'-row, case-2 arm-on-c'-col).  The
+fully-off-spine class is handled recursively by the K-induction; the
+*non-vanishing* crossing diagonal (case-1 arm-class single cell,
+case-2 leg-class single cell) is the only open piece, deferred to
+S57.7+ pointwise comparison.
+
+**Net change.**  Helpers.lean: 15868 → 15943 lines (+75, two new
+private lemmas with comprehensive docstrings).  sorries: 1 → 1
+(unchanged — `F_side_identity_aligned` remains).  No new imports.
+
+**Build status.**  Build pending — `BallotProblemOQ03OQ02.lean`
+remains broken on `origin/main` (LGV-route parent, ~24 errors lines
+1911–2386), blocking build verification of all `ballot-OQ03-OQ01-*`
+descendants.  Matches `(build pending — parent OQ03OQ02 break)`
+precedent of PRs #17747 (S57.6 prep), #17734 (S57.5), #17719 (S57.3
+rebase), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568
+(S57.2), #17537 (S57.1).
+
+**File-size watch.**  Helpers.lean now at 15943 lines, ~443 over the
+~15500-line Docker 32GB-memory ceiling estimate (was ~293 after
+S57.6 prep).  S57.0 Option E3 extraction into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file is now an
+imminent prerequisite for S57.6 proper landing its ~80–150-line bulk.
+
+## Session 63 — S57.6 prep: off-spine strict-hook 3-way partition (researcher-9, 2026-05-12)
+
+Added `strictHookCells_off_spine_class_at_c'` (line 15243, +77
+Helpers lines), classifying every strict-hook cell of an off-spine
+`x` into fully-off-spine / arm-on-c'-col / leg-on-c'-row.  PR #17747.
+
+## Session 62 — S57.5 arm/leg residual reductions (researcher-10, 2026-05-12)
 
 ## Session 62 — S57.5 arm/leg residual reductions (researcher-10, 2026-05-12)
 
@@ -679,3 +731,9 @@ Fallback if S55+ stalls.
   (proved modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`; `gnwProb_exchange` itself is sorry-free as of S55a)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15204` — `hook_walk_identity_gnw`
   (sorry-free dispatcher, transitive on `F_side_identity_aligned`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15243` — `strictHookCells_off_spine_class_at_c'`
+  (S57.6 prep, sorry-free; 3-way partition of off-spine `x`'s strict hook wrt `c'`'s spine — PR #17747)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15295` — `gnwProb_eq_on_leg_class_case1`
+  (S57.6 prep 2, sorry-free; K-step IH equality on the case-1 vanishing crossing class — this PR)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:15333` — `gnwProb_eq_on_arm_class_case2`
+  (S57.6 prep 2, sorry-free; K-step IH equality on the case-2 vanishing crossing class — this PR)


### PR DESCRIPTION
## Summary

Two **sorry-free private lemmas** in `BallotProblemOQ03OQ01OQ02Helpers.lean` packaging PR #17747's S57.6 prep 3-way partition (`strictHookCells_off_spine_class_at_c'`) together with S57.3a's per-cell vanishings (`gnwProb_zero_of_row_eq_c'_case1` / `gnwProb_zero_of_col_eq_c'_case2`) into **K-step IH equality form**, so the joint K-induction for the S57.6 target `gnwProb_eq_off_spine_of_c'` can discharge the two *vanishing* crossing branches of the partition by a single application each.

### Lemmas added (after S57.6 prep's `strictHookCells_off_spine_class_at_c'`, line ~15243)

- `gnwProb_eq_on_leg_class_case1` (line ~15295): for `y` with `y.1 = c'.1` and `c.1 < c'.1`,
  `gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y`
  (both sides `0` via S57.3a's `gnwProb_zero_of_row_eq_c'_case1`, universal in `μ`).

- `gnwProb_eq_on_arm_class_case2` (line ~15333): mirror for case 2 — for `y` with `y.2 = c'.2` and `c.2 < c'.2`,
  `gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y`
  (both sides `0` via S57.3a's `gnwProb_zero_of_col_eq_c'_case2`).

### Coverage of the S57.6 prep 3-way partition

|        | leg-on-c'-row class (`y.1 = c'.1`)            | arm-on-c'-col class (`y.2 = c'.2`)            |
|--------|------------------------------------------------|------------------------------------------------|
| Case 1 | **IH-eq** (this PR `..._leg_class_case1`)      | non-vanishing — `y.2 = c'.2 < c.2` reachable  |
| Case 2 | non-vanishing — `y.1 = c'.1 < c.1` reachable   | **IH-eq** (this PR `..._arm_class_case2`)      |

The fully-off-spine class is handled recursively by the K-induction itself (via S57.4's `gnwProb_succ_eq_off_spine_of_c'`).  The two non-vanishing diagonal entries — case-1 arm-class single cell `y = (x.1, c'.2)`, case-2 leg-class single cell `y = (c'.1, x.2)` — are the off-spine analog of the doubly-affected cell `d` and require genuine pointwise comparison, deferred to S57.7+.

## Why this is small and useful

Each lemma is **3 lines of body** (two `have`s + `rw`) plus comprehensive docstring.  No new imports.  Sorry-free.  The proofs leverage S57.3a's universality in the first `μ` argument — `gnwProb_zero_of_row_eq_c'_case1 h_case y h_cross K` proves vanishing equally for `μ` and `removeCorner μ c' hc'`, so the IH equality between the two reduces to `0 = 0`.

## Net change

| Counter                              | Before | After  | Delta |
|--------------------------------------|-------:|-------:|------:|
| `Helpers.lean` lineCount             | 15868  | 15943  | +75   |
| Theorem/lemma count (Helpers)        | —      | —      | +2    |
| `axiomCount` (Helpers)               | 0      | 0      | 0     |
| `sorries` (Helpers)                  | 1      | 1      | 0     |

`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track the main `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean` (find-targets convention per MEMORY).

## Build status

**Build pending** — `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is broken on `origin/main` with ~24 errors at lines 1911–2386, blocking build verification of **all** `ballot-OQ03-OQ01-*` descendants.  See MEMORY note `feedback_researcher_ballot_oq03oq02_parent_break.md`.

Matches the `(build pending — parent OQ03OQ02 break)` precedent of PRs #17747 (S57.6 prep), #17734 (S57.5), #17719 (S57.3 rebase), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568 (S57.2), #17537 (S57.1).

## Mathlib API verification

All names used are precedented in `BallotProblemOQ03OQ01OQ02Helpers.lean`:

- `gnwProb_zero_of_row_eq_c'_case1` (S57.3a, line 14722) — universal in `μ`; applied twice.
- `gnwProb_zero_of_col_eq_c'_case2` (S57.3a, line 14742) — universal in `μ`; applied twice.
- `rw [h1, h2]` — closes the goal `0 = 0` after both rewrites.

No new imports.

## File-size watch

`Helpers.lean` now at 15943 lines, **~443 over the ~15500-line Docker 32GB-memory ceiling estimate** (was ~293 over after S57.6 prep).  The S57.0 Option E3 extraction into a new `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file is now an imminent prerequisite for S57.6 proper landing its ~80–150-line bulk.

## Next step (S57.6 proper)

With the K-step IH on the off-spine class handled by S57.4 and the K-step IH on both vanishing crossing classes handled by this PR's lemmas, the remaining piece of `gnwProb_eq_off_spine_of_c'` is the *non-vanishing* crossing class on each case (single cell per case).  This is the genuine pointwise comparison deferred to S57.7+ (likely requiring a `δ_arm` correction term).

🤖 Generated by researcher-4