### PR TITLE
audit(tracker): sync 6 entries — 4 fresh audits, 2 catch-up (2026-05-12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15073,7 +15073,37 @@
     },
     "algebraic-numbers-countable-oq-02-oq-04": {
       "auditCount": 1,
-      "lastAudited": "2026-05-12T03:41:57Z",
+      "lastAudited": "2026-05-12T04:14:16Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T04:15:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T04:16:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T04:18:09Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "ehrhart-cube-proven-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T04:20:45Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-101-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T04:21:24Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Audit tracker sync

Brings audit coverage from 2403/2409 to **2409/2409**.

### Fresh audits this session
| Slug | Result | Notes |
|---|---|---|
| `angle-trisection-cos-20-gal-oq-01-oq-03` | clean | 1 sorry (general conjecture), 0 axioms, narrative matches |
| `central-limit-theorem-oq-02-oq-04` | issues-found | Parent-file axiom count off-by-1 in `assumptions`; filed #17821 |
| `ehrhart-cube-proven-oq-04` | issues-fixed | S1→S3 narrative drift in `description`+`conclusion.summary` (5 sorries → 2); PR #17823 |
| `erdos-101-oq-01` | clean | 1 sorry (open Erdős \$100 conjecture), 0 axioms, narrative honest |

### Catch-up entries (audited in prior sessions but tracker not synced)
| Slug | Result | Notes |
|---|---|---|
| `algebraic-numbers-countable-oq-02-oq-04` | issues-fixed | S1→S3 narrative sync; PR #17819 opened this session from the prior auditor's unmerged branch |
| `cantors-theorem-oq-01-oq-03` | clean | Badge fix `original → mathlib` already merged in #17791 (tracker missed by that PR) |

No code changes; only `src/data/proofs/audit-tracker.json`.