### PR TITLE
fix(meta): ehrhart-cube-proven-oq-04 sync sorries/lineCount/theoremCount post-S4

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -24,9 +24,9 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 422,
+    "lineCount": 584,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -78,7 +78,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -177,12 +177,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 422,
+    "lineCount": 584,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -245,5 +245,5 @@
       "significance": "Connects the axiom-free Ehrhart count to the Eulerian interpretation"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

After PR #17808 (S4 WORPITZKY — closed `worpitzky_identity_cube` via induction on d), the Lean file grew and one sorry was discharged, but `meta.json` counts were not updated.

## Evidence

`proofs/Proofs/EhrhartCubeProvenOQ04.lean` (current origin/main):
- `wc -l` → **584** lines (meta claimed 422)
- `grep -c \"^sorry\"` after comment-stripping → **1** sorry (line 272, `eulerian_palindrome`) (meta claimed 2)
- `grep -cE \"^(private |protected |noncomputable |partial |unsafe |scoped )*(theorem |lemma )\"` → **26** (meta claimed 25)
- def/abbrev/opaque/structure/inductive/class count → 2 (unchanged)
- `axiom` count → 0 (unchanged)

`scripts/auditor/find-targets.ts --issues --json` flagged the sorry drift:
> \"sorry mismatch: claims 2, actual 1\"

## Before / After

All nine stale references updated:

| Path | Before | After |
|---|---|---|
| `meta.sorries` | 2 | 1 |
| `meta.lineCount` | 422 | 584 |
| `meta.theoremCount` | 25 | 26 |
| `leanFile.lineCount` | 422 | 584 |
| `leanFile.theoremCount` | 25 | 26 |
| `leanFile.sorries` | 2 | 1 |
| top-level `sorries` | 2 | 1 |

(`meta.definitionCount` and `leanFile.definitionCount` already correct at 2; `axiomCount` already 0.)

## Coordination with #17823

PR #17823 (open, audit narrative sync) touches `description` and `conclusion.summary` only — no overlap with the count fields edited here. Its narrative is also slightly stale (mentions \"two remaining sorrys\" pre-S4), so the auditor or a follow-up audit will need to update it after #17808 + this PR land.

---
Automated fix by lean-mechanic agent.