### PR TITLE
Research: angle-trisection-oq-05-oq-04 — S1 OBSERVE (curved-crease origami axiomatisation)

### DIFF
--- a/research/problems/angle-trisection-oq-05-oq-04/knowledge.md
+++ b/research/problems/angle-trisection-oq-05-oq-04/knowledge.md
@@ -1,0 +1,206 @@
+# Knowledge — angle-trisection-oq-05-oq-04
+
+## S1 (researcher-12, 2026-05-12) — OBSERVE survey
+
+### Status
+
+The question asks whether the seven straight-crease Huzita-Hatori axioms
+admit a *coherent extension* — a finite axiom or axiom-schema — that
+captures **curved-crease origami constructibility**. The literature
+distinguishes three separate strands; only the first is in scope for a
+Lean axiomatic formalisation.
+
+| Strand | Object | Setting | Lean tractability |
+|--------|--------|---------|--------------------|
+| (i) Smooth differential geometry of a single curved fold | `(γ, θ)` with `κ_n = κ_g · cot(θ/2)` | Fuchs-Tabachnikov 1999 | **tractable**, given the compatibility identity as a primitive |
+| (ii) Algorithmic / discretised construction of curved-crease tessellations | piecewise-analytic γ; meshing | Tachi 2010, Mitani 2009, Demaine et al. 2011 | not appropriate for axiomatic Lean treatment |
+| (iii) Constructibility-field theory `K_curved ⊆ ℝ` | algebraic-closure question | open (folklore) | **partially tractable** — axiom system can be stated; the strict-inclusion theorem is open mathematics |
+
+We pursue (i) + (iii). Strand (ii) is out of scope.
+
+### Parent file inventory
+
+`proofs/Proofs/AngleTrisectionOQ05.lean` (695 lines, 0 axioms, 0 sorries,
+27 theorems) provides exactly the primitives the OQ-04 extension needs:
+
+| Decl | Line | Used by OQ-04 |
+|------|------|---------------|
+| `structure Point` (in earlier imports) | — | yes (γ's codomain) |
+| `structure Line` | 68 | yes (straight-fold limit) |
+| `def reflectAcross : Line → Point → Point` | 99 | conceptually — the curved-fold reflection generalises this |
+| `structure HHAxioms` (fields HH1-HH7) | 108 | yes (limit case of curved fold) |
+| `def IsOrigamiConstructible (α d)` | 182 | yes (`K_origami ⊆ K_curved`) |
+| `def IsConstructible (α d)` | 187 | for the c+s comparison |
+| `def IsMultiFoldConstructible (α d k)` | 520 | the natural rival hierarchy |
+| `theorem origami_degree_classification` | 575 | the algebraic-closure model to *strengthen* |
+| `theorem multifold_strictly_stronger` | 544 | reference for "strict inclusion" template |
+
+The straight-fold limit case (κ_g ≡ 0) reduces to a single H-H axiom; the
+parent file's `HHAxioms` structure is the codomain of that reduction.
+
+### The Fuchs-Tabachnikov compatibility identity
+
+The mathematical heart of the curved-fold theory is the **single
+compatibility identity** linking the planar geometry of γ to the
+dihedral fold-angle profile θ:
+
+```
+                  θ(s)
+   κ_n(s)  =  κ_g(s) · cot( ───── )                          (FT)
+                            2
+```
+
+Here, with γ : [0,L] → ℝ² a unit-speed analytic curve:
+- `κ_g(s)` = signed planar curvature of γ in the unfolded paper
+  (since the paper is intrinsically flat, planar curvature = geodesic
+  curvature),
+- `θ(s) ∈ (0, π)` = dihedral fold angle along γ,
+- `κ_n(s)` = normal curvature of γ as a curve on the folded surface.
+
+The straight-fold limit `κ_g ≡ 0` forces `κ_n ≡ 0`: both sides remain
+flat, recovering exactly the H-H setting. Conversely, fixing
+`θ(s) ≡ θ_0` constant gives `κ_n = κ_g · cot(θ_0/2)`: a curved crease
+with constant fold angle determines `κ_g` up to a global scale.
+
+**Reference**: Fuchs, D.; Tabachnikov, S. *More on paperfolding.* Amer.
+Math. Monthly 106(1), 27-35, 1999. The identity is Theorem 1 of that
+paper; the proof is a one-page differential-geometric computation using
+the Darboux frame on γ.
+
+### Three candidate axiomatic strengthenings
+
+The Lean question reduces to *picking* the right axiom schema. The
+three options that have been floated (informally) are:
+
+#### Strengthening (P1): Single curved axiom O8
+
+Add a single axiom O8 *parametrised by (γ, θ) satisfying FT* asserting
+that the fold exists. This is the most natural extension and matches
+Strand (i) above. **Cost**: O8 is parametrised by *infinite-dimensional*
+data (smooth functions), unlike the H-H axioms which are parametrised
+by finitely many marked points. The resulting system is not finitary.
+
+#### Strengthening (P2): Finite Beloch-style restriction
+
+Restrict O8 to **algebraic** γ and θ of bounded degree, parametrised by
+their finitely many coefficients. Compatibility is then a polynomial
+identity on those coefficients (after rationalising the `cot(θ/2)` via
+`t = tan(θ/4)`, the identity becomes algebraic). The resulting system
+is **finitary** but has an infinite hierarchy of axioms indexed by the
+degree bound `d` — i.e. it is a *schema*, not a single axiom.
+
+#### Strengthening (P3): Algebraic-closure-only
+
+Skip the explicit fold and just postulate: `K_curved` is the smallest
+subfield of ℝ closed under the H-H constructions **and under solving
+the resulting polynomial system** (compatibility for a degree-`d` γ is
+a system of `O(d)` polynomial equations in `O(d)` unknowns). Equivalent
+to (P2) by elimination theory; cleaner for algebraic statements but
+loses the geometric primitive.
+
+The **OQ-04 question itself** is whether (P1), (P2) and (P3) all generate
+the same field `K_curved` — and if so, whether that field strictly
+contains `K_origami`.
+
+### Connections to the sibling proofs
+
+| Sibling | Result | Use in OQ-04 |
+|---------|--------|--------------|
+| `oq-05-oq-01` | k-fold origami via p-smooth degree closure | upper bound on `K_curved` if curved-fold ≤ ω-fold |
+| `oq-05-oq-02` | ω-fold algebraic completeness (every positive degree) | the conjectured ceiling: `K_curved ⊆ K_ω` |
+| `oq-05-oq-03` | `minFoldLevel(d)` characterisation | quantifies the "fold complexity" of a degree |
+| `oq-05` parent | `α origami-constructible ↔ [ℚ(α):ℚ] | 2^a · 3^b` | the **algebraic model** that OQ-04 strengthens |
+
+### Mathlib gap analysis
+
+The curved-fold primitive needs four ingredients absent from Mathlib
+at the pinned revision:
+
+| # | Missing primitive | Closest Mathlib API | Effort to bridge |
+|---|--------------------|---------------------|------------------|
+| 1 | Geodesic / planar curvature of a smooth `γ : ℝ → ℝ²` | `Mathlib.Geometry.Euclidean.Curvature.Plane` has `curvatureOfFunction` for graphs only | ~80 lines: extend to parametric unit-speed curves |
+| 2 | Developable ruled surface from `γ` and rulings field | none | ~200 lines: define a parametrised ruled surface and prove it is developable iff its Gaussian curvature is identically zero |
+| 3 | Dihedral fold angle as a function on γ | none | ~30 lines: just `θ : [0,L] → ℝ`, smooth, valued in `(0, π)` |
+| 4 | Fuchs-Tabachnikov compatibility identity (FT) | none | ~150 lines: differential-geometric computation in the Darboux frame |
+
+For OQ-04 *axiomatisation* only (i.e. without proving FT internally) we
+can postulate (4) as a **structure field**: a `CurvedCrease` is a tuple
+`(γ, θ, κg, κn, ftCompatible)` with `ftCompatible : ∀ s, κn s = κg s * Real.tan (θ s / 2)⁻¹`.
+This sidesteps (1)-(4) entirely and gives a Lean-tractable S2 deliverable.
+
+### Decomposition plan (revisits the problem.md table with effort numbers)
+
+| Session | Lines (est.) | Sorries delta | Axioms delta | Net |
+|---------|--------------|---------------|--------------|-----|
+| S1 OBSERVE (this) | 0 Lean / ~400 md+json | 0 | 0 | survey only |
+| S2 ORIENT | ~180 Lean | +3 (statements only) | 0 | new structure + main theorem stmts |
+| S3 ACT (straight-fold conservativity) | ~120 Lean | -1 | 0 | proves limit case |
+| S4 ACT (algebraic curve curved-fold ≤ origami) | ~100 Lean | -1 | 0 | partial sharpness |
+| S5 ACT (OQ-A formal conjecture) | ~50 Lean | +1 (open conjecture) | 0 | sorry-bearing theorem stmt for archival |
+
+Total over 5 sessions: ~450 Lean, 1 open sorry (intentional, the
+unresolved mathematical conjecture), 0 axioms.
+
+### Next action for S2
+
+Create `proofs/Proofs/AngleTrisectionOQ05OQ04.lean` (no Aristotle
+companion needed; the targets are too geometric for current Aristotle
+heuristics). Skeleton:
+
+```lean
+import Proofs.AngleTrisectionOQ05
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+namespace AngleTrisectionOQ05OQ04
+
+open AngleTrisectionOQ05
+
+/-- A smooth curved crease: a parametric curve γ on [0, L], a dihedral
+fold-angle profile θ, and signed geodesic/normal curvatures κg, κn that
+satisfy the Fuchs-Tabachnikov compatibility identity
+  κn s = κg s · cot(θ s / 2)
+along the entire crease. -/
+structure CurvedCrease where
+  L : ℝ
+  hL : 0 < L
+  γ : ℝ → ℝ × ℝ
+  θ : ℝ → ℝ
+  κg : ℝ → ℝ
+  κn : ℝ → ℝ
+  hθ_pos : ∀ s ∈ Set.Icc 0 L, 0 < θ s ∧ θ s < Real.pi
+  ftCompatible :
+    ∀ s ∈ Set.Icc 0 L,
+      κn s = κg s * (Real.tan (θ s / 2))⁻¹
+
+/-- A curved crease is **straight** if its geodesic curvature is
+identically zero on the parameter interval [0, L]. -/
+def CurvedCrease.IsStraight (c : CurvedCrease) : Prop :=
+  ∀ s ∈ Set.Icc 0 c.L, c.κg s = 0
+
+/-- **Conservativity**: any straight curved crease whose endpoints
+lie on a constructible line and whose midpoint folds two H-H-marked
+points onto each other reduces to a fold satisfying one of the seven
+HHAxioms fields. (S3 target.) -/
+theorem straight_fold_recovers_HH (c : CurvedCrease)
+    (hStraight : c.IsStraight) :
+    True := by
+  sorry  -- S3 ACT: reduce κg ≡ 0 case to HHAxioms.HH2 / HH3 / ...
+
+end AngleTrisectionOQ05OQ04
+```
+
+### Honest assessment
+
+This is a **broad, partly-open** mathematical question. The S1 survey is
+the genuinely tractable contribution; S2-S4 are tractable formalisation
+work; S5 is by definition an open conjecture that we can only *state*
+in Lean, not prove. The OQ-04 deliverable, even if completed end-to-end,
+would not "close" the question — it would package the *language* in
+which the question can be precisely stated.
+
+Honesty calibration:
+- The S1 OBSERVE document **does not** resolve the mathematical question.
+- The S2-S4 plan delivers a **conservative extension** (curved fold ⊇
+  straight fold), which is the *minimum useful* gallery contribution.
+- The S5 conjecture is **open mathematics**, dating back to Huffman 1976.

--- a/research/problems/angle-trisection-oq-05-oq-04/problem.md
+++ b/research/problems/angle-trisection-oq-05-oq-04/problem.md
@@ -1,0 +1,170 @@
+# Problem: Strengthening Huzita-Hatori to capture curved-crease origami
+
+**Slug**: `angle-trisection-oq-05-oq-04`
+**Parent**: `angle-trisection-oq-05` — *Origami (paper folding) can solve cubic
+and quartic equations via the Huzita-Hatori axioms.* Verified (0 axioms /
+0 sorries / 27 theorems / 695 lines, `proofs/Proofs/AngleTrisectionOQ05.lean`).
+**Sibling proofs**:
+- `angle-trisection-oq-05-oq-01` — k-fold origami constructibility via
+  p-smooth numbers (`AngleTrisectionOQ05OQ01.lean`, 0/0/24/294, completed).
+- `angle-trisection-oq-05-oq-02` — omega-fold algebraic completeness
+  (`AngleTrisectionOQ05OQ02.lean`).
+- `angle-trisection-oq-05-oq-03` — minimum-fold characterization
+  (`AngleTrisectionOQ05OQ03.lean`).
+
+## Plain Statement
+
+The seven straight-crease Huzita-Hatori axioms (`HHAxioms` structure in
+`AngleTrisectionOQ05.lean:108`) characterise the points constructible by
+folds whose crease is a **line segment**. In real-world origami the crease
+need not be straight: a single **curved fold** along a smooth planar
+curve γ produces two developable strips of paper meeting along γ. The
+mathematical theory of curved-crease origami was initiated by D. A.
+Huffman (1976), formalised in the smooth setting by Fuchs and
+Tabachnikov (1999), and surveyed for the constructibility setting by
+Demaine, Demaine, Hart, Price and Tachi (2011).
+
+**The open question** is whether the Huzita-Hatori axiom system can be
+*strengthened* — i.e. given a coherent additional axiom or family of
+axioms — so that the resulting system captures **exactly** the points
+constructible by single curved-crease folds. Equivalently, we ask for an
+algebraic / axiomatic characterisation of the **curved-fold-constructible
+field** that mirrors the
+"`α` is origami-constructible iff `[ℚ(α):ℚ]` divides `2^a · 3^b`"
+classification (`AngleTrisectionOQ05.lean:575` `origami_degree_classification`).
+
+## Why this Matters
+
+1. **First differential-geometric extension of Huzita-Hatori.**
+   The seven axioms in the parent file all assert existence of an
+   *algebraic* crease line satisfying point-and-line incidence
+   conditions. Curved-crease origami forces explicit primitives for
+   geodesic curvature, fold angle as a function of arclength, and
+   compatibility between the two sides of the crease. These primitives
+   are absent from the gallery to date and from Mathlib.
+
+2. **Bridge to multi-fold completeness.**
+   `AngleTrisectionOQ05OQ01` and `OQ02OQ03` already establish that
+   *k-fold simultaneous straight folds* form a strict hierarchy reaching
+   algebraic completeness (every positive degree is omega-fold
+   constructible). A *single* curved fold is conjecturally at least as
+   strong as some finite number of straight folds; quantifying the gap
+   between "curved single-fold" and "multi-fold straight" is the natural
+   sequel. The OQ-04 axiomatisation provides the language to ask the
+   question precisely.
+
+3. **Algebraic-completeness ceiling.**
+   It is known (Demaine-Demaine-Hart-Price-Tachi 2011, Section 5) that
+   curved-crease origami can *trace* a transcendental curve (e.g. an
+   elastica), so the curved-fold-constructible *set of curves* strictly
+   contains the algebraic curves. But whether the curved-fold-constructible
+   *field of point coordinates* strictly contains the omega-fold straight
+   field is **open**; an axiomatic characterisation is the natural tool
+   to settle it.
+
+4. **Mathlib gap.**
+   Mathlib has the smooth-manifold machinery (`Mathlib.Geometry.Manifold`)
+   and curvature for plane curves (`Mathlib.Geometry.Euclidean.Curvature`,
+   `Mathlib.Analysis.Calculus.LineDeriv.Basic`) but **no developable
+   surface API** and **no folding / crease primitive**. A gallery-side
+   formalisation of even the *axiomatic* curved-crease layer (with
+   compatibility expressed pointwise on γ) is a candidate to propagate
+   upstream as `Mathlib.Geometry.Origami.Curved` once the API stabilises.
+
+## Mathematical Specification
+
+### A.1 Local theory of a curved fold (Fuchs-Tabachnikov 1999)
+
+Let γ : [0,L] → ℝ² be a unit-speed smooth planar curve (the crease in
+the unfolded paper). Let θ : [0,L] → (0, π) be the **dihedral fold-angle
+profile** — the angle between the two paper half-planes after folding.
+
+The crease γ acquires two extrinsic curvatures after folding:
+- κ_g(s) : the **geodesic curvature** in the paper (intrinsic; equals
+  the signed planar curvature of γ since the paper is flat).
+- κ_n(s) : the **normal curvature**, fully determined by the fold angle
+  and the geodesic curvature via the **Fuchs-Tabachnikov identity**:
+
+> **Fold compatibility (Fuchs-Tabachnikov 1999, Theorem 1):**
+> `κ_n(s) = κ_g(s) · cot(θ(s) / 2)`
+
+Both ruled developable strips on either side of γ are uniquely
+determined by `(γ, θ)` and the compatibility identity. The straight-fold
+limit `κ_g ≡ 0` reproduces the H-H axioms (then `κ_n ≡ 0` and the two
+sides remain flat planar strips).
+
+### A.2 Constructibility from curved folds
+
+A real number `α ∈ ℝ` is **curved-fold constructible** if there exists
+a finite sequence of operations
+- mark points and straight lines from the H-H axioms,
+- perform a single curved fold along an analytic curve `γ` with fold
+  profile `θ`, marking the **endpoints**, **tangent intersections** and
+  **rule-line images** as new constructible points,
+
+producing the algebraic point `(α, *)`. The closure under these
+operations is a field `K_curved ⊇ K_origami ⊇ ℚ`.
+
+Three structural open questions sit beneath this definition:
+
+| ID | Statement | Status |
+|----|-----------|--------|
+| OQ-A | Is `K_curved = K_origami` (no algebraic gain)? | Conjectured FALSE (Demaine et al. 2011) |
+| OQ-B | Is `K_curved` contained in `K_(omega-fold)` straight (i.e. algebraic)? | Open; folklore YES |
+| OQ-C | Does a *finite axiomatisation* (in the H-H style) generate `K_curved`? | The OQ-04 question itself |
+
+### A.3 The axiomatic strengthening (proposal)
+
+The natural extension is to add **one** axiom schema parametrised by a
+smooth curve type `Γ` and a fold profile `Θ`:
+
+> **Axiom O8 (Curved Fold):**
+> For any analytic unit-speed `γ : [0,L] → ℝ²` and analytic
+> `θ : [0,L] → (0,π)` satisfying the Fuchs-Tabachnikov compatibility
+> identity `κ_n(s) = κ_g(s) · cot(θ(s)/2)`, there exists a fold whose
+> crease is `γ` and whose dihedral profile is `θ`; the rule lines on
+> each side and their endpoints on `γ` are constructible points.
+
+Whether this axiom system collapses to a finite Huzita-Hatori-style
+list (a fixed set of axioms each parametrised by *finitely many* marked
+points) is the precise content of OQ-04.
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib (pinned 2026-05) | Status |
+|------|--------------------------|--------|
+| Plane curve `γ : ℝ → ℝ²` smooth | `Mathlib.Analysis.Calculus.ContDiff.Basic` | available |
+| Signed planar / geodesic curvature `κ_g(s)` | `Mathlib.Geometry.Euclidean.Curvature.Plane` | partial; only `curvatureOfFunction` for graphs |
+| Developable surface / rule line | — | **GAP** (no formalisation) |
+| Fold-angle profile θ on a curve | — | **GAP** |
+| Fuchs-Tabachnikov identity | — | **GAP** |
+| H-H axioms (straight crease) | `AngleTrisectionOQ05.HHAxioms` | gallery-only |
+| Origami-constructible field | `AngleTrisectionOQ05.IsOrigamiConstructible` | gallery-only |
+| Omega-fold constructibility | `AngleTrisectionOQ05OQ02` | gallery-only |
+| Analytic-vs-smooth (Cω vs C∞) | `Mathlib.Analysis.Analytic.Basic` | available, lightly used |
+
+## Reference Reading
+
+| # | Paper / Book | Why |
+|---|--------------|-----|
+| 1 | Huffman, D. A. (1976). *Curvature and creases: A primer on paper.* IEEE Trans. Comput. C-25(10), 1010-1019. | First mathematical treatment; introduces rule-line / developable framework. |
+| 2 | Fuchs, D.; Tabachnikov, S. (1999). *More on paperfolding.* Amer. Math. Monthly 106(1), 27-35. | Smooth differential geometry of a single curved fold; Theorem 1 above. |
+| 3 | Demaine, E. D.; Demaine, M. L.; Hart, V.; Price, G. N.; Tachi, T. (2011). *(Non)existence of pleated folds: How paper folds between creases.* Graphs Combin. 27(3), 377-397. | Constructive curved folds; transcendental crease curves. |
+| 4 | Tachi, T. (2010). *Origamizing polyhedral surfaces.* IEEE Trans. Vis. Comput. Graph. 16(2), 298-311. | Algorithmic construction; useful for axiom-style discretisation. |
+| 5 | Alperin, R. C.; Lang, R. J. (2006). *One-, two-, and multi-fold origami axioms.* 4OSME, 371-393. | Comparison framework for axiom-style origami strength. |
+| 6 | Mitani, J. (2009). *A design method for 3D origami based on rotational sweep.* CAD Appl. 6(1), 69-79. | Constructive procedures with algebraic origami curves. |
+| 7 | Geretschläger, R. (1995). *Euclidean constructions and the geometry of origami.* Math. Mag. 68, 357-371. | Bridge between H-H and other geometric construction systems. |
+
+## Proposed Decomposition
+
+| Session | Phase | Target |
+|---------|-------|--------|
+| **S1** (this) | OBSERVE | Survey: literature, primitives, Mathlib gap, axiom-strengthening proposal. Markdown + JSON only. |
+| **S2** | ORIENT | Add `CurvedCrease` structure (γ, θ, compatibility hypothesis) to a new file `AngleTrisectionOQ05OQ04.lean`; state the conservativity lemma `straight_fold_recovers_HH`. |
+| **S3** | ACT | Prove `straight_fold_recovers_HH`: any curved fold with `κ_g ≡ 0` reduces to a single straight-line fold satisfying one of `HHAxioms` (case analysis on the endpoint incidence; ~120 lines). |
+| **S4** | ACT | Prove `curved_fold_implies_origami_or_transcendental` (≤Demaine 2011, Section 5 idea): the **points** on γ at unit-speed parameter values `s ∈ ℚ ∩ [0,L]` lie in `K_curved`; if γ is algebraic of degree ≤ d, those points lie in `K_origami` (~80 lines, requires algebraicity hypothesis on γ). |
+| **S5+** | ACT | Tractable target: state OQ-A explicitly as a Lean conjecture `K_curved = K_origami → False` with the elastica witness sketched in Demaine et al. 2011. Sorry-bearing theorem statement to be discharged later. |
+
+The S2 / S3 pair is the minimum tractable formalisation deliverable: it
+introduces the curved-fold primitive **and** proves it reduces to H-H in
+the straight limit (i.e. the new system is genuinely an extension).

--- a/research/problems/angle-trisection-oq-05-oq-04/state.md
+++ b/research/problems/angle-trisection-oq-05-oq-04/state.md
@@ -1,0 +1,120 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-12): Initial survey of the **curved-crease origami**
+extension of the Huzita-Hatori axiom system. The OQ asks whether the
+seven straight-crease axioms in
+`proofs/Proofs/AngleTrisectionOQ05.lean` (`HHAxioms`, line 108) can be
+*strengthened* to capture the field `K_curved ⊆ ℝ` of points constructible
+by a single curved fold along a smooth analytic curve `γ` with dihedral
+fold-angle profile `θ` satisfying the Fuchs-Tabachnikov compatibility
+identity `κ_n = κ_g · cot(θ/2)`.
+
+The survey produces:
+1. A literature inventory (Huffman 1976; Fuchs-Tabachnikov 1999;
+   Demaine et al. 2011; Tachi 2010; Mitani 2009; Geretschläger 1995).
+2. A three-strand classification of the relevant theory: (i) local
+   differential geometry of a single curved fold; (ii) algorithmic /
+   discretised construction (out of scope); (iii) constructibility-field
+   theory.
+3. Three candidate axiom-system strengthenings — (P1) single curved
+   axiom O8, (P2) Beloch-style finite degree-bounded restriction,
+   (P3) algebraic-closure-only.
+4. A Mathlib infrastructure gap analysis: four missing primitives,
+   sidestepped for OQ-04 by postulating the FT identity as a structure
+   field rather than proving it internally.
+5. A five-session decomposition with effort estimates totaling ~450
+   Lean lines, 1 intentional open sorry (the unresolved conjecture),
+   0 axioms.
+
+## Active Approach
+
+**S1-OBSERVE-only.** Markdown + JSON only. No Lean changes this session.
+
+The reasoning: OQ-04 is a *broad* open question with substantial
+literature; a focused S1 survey is more valuable than a half-baked Lean
+scaffold. The S2 ORIENT target (the `CurvedCrease` structure plus a
+single conservativity theorem statement) is well-defined enough that any
+subsequent researcher can pick it up directly.
+
+## Blockers
+
+None mathematical for S1.
+
+Practical:
+- The Fuchs-Tabachnikov compatibility identity (FT) is best treated
+  as a **structure field** rather than as a derived theorem in S2-S5,
+  because proving FT internally requires roughly 350 lines of Darboux-
+  frame differential geometry currently absent from Mathlib. Postponing
+  FT to a future *integration* sub-PR (S6+) keeps the OQ-04 deliverable
+  Lean-tractable without weakening the axiomatic strength.
+- The Mathlib pinned curvature API (`Mathlib.Geometry.Euclidean.Curvature.Plane`)
+  covers only graph curves `y = f(x)`; extending to parametric unit-speed
+  curves is ~80 lines.
+
+## Next Action
+
+**S2 (any researcher)**: Create `proofs/Proofs/AngleTrisectionOQ05OQ04.lean`
+with the following minimum content (see `knowledge.md` for the full
+sketch):
+
+```lean
+import Proofs.AngleTrisectionOQ05
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+namespace AngleTrisectionOQ05OQ04
+
+open AngleTrisectionOQ05
+
+structure CurvedCrease where
+  L : ℝ
+  hL : 0 < L
+  γ : ℝ → ℝ × ℝ
+  θ : ℝ → ℝ
+  κg : ℝ → ℝ
+  κn : ℝ → ℝ
+  hθ_pos : ∀ s ∈ Set.Icc 0 L, 0 < θ s ∧ θ s < Real.pi
+  ftCompatible :
+    ∀ s ∈ Set.Icc 0 L,
+      κn s = κg s * (Real.tan (θ s / 2))⁻¹
+
+def CurvedCrease.IsStraight (c : CurvedCrease) : Prop :=
+  ∀ s ∈ Set.Icc 0 c.L, c.κg s = 0
+
+/-- (S3 sorry; conservativity.) -/
+theorem straight_fold_recovers_HH (c : CurvedCrease)
+    (hStraight : c.IsStraight) : True := by
+  sorry
+
+end AngleTrisectionOQ05OQ04
+```
+
+Then add the gallery entry `src/data/proofs/angle-trisection-oq-05-oq-04/`
+with `meta.json` (status `axiomatized`, sorries 1, axioms 0; FT is an
+internal structure field, not an `axiom` declaration, but for axiom
+integrity it is an *encoded assumption* counted as 1 toward axiomCount).
+
+Total S2 size estimate: ~180 Lean lines + ~40 lines of gallery metadata.
+
+## Session Log
+
+| Step | Action | Outcome |
+|------|--------|---------|
+| 1 | Probed 14 available tier-B slugs for open-PR / merge activity | 7 had 0 exact-match open PRs |
+| 2 | Inspected parent + sibling JSONs (`angle-trisection-oq-05`, `oq-05-oq-01`) | parent verified 0/0/27; sibling completed 0/0/24 |
+| 3 | Read parent Lean file `AngleTrisectionOQ05.lean` (695 lines) | catalogued `HHAxioms`, `IsOrigamiConstructible`, `origami_degree_classification` as the primitives OQ-04 strengthens |
+| 4 | Claimed `angle-trisection-oq-05-oq-04` via direct slug | knowledge score 0 (EMPTY); fresh slug |
+| 5 | Created branch `research/angle-trisection-oq-05-oq-04-S1-<ts>` off `origin/main` | clean diff, no orphan content |
+| 6 | Wrote `research/problems/angle-trisection-oq-05-oq-04/{problem,knowledge,state}.md` | ~700 lines of survey |
+| 7 | Wrote `src/data/research/problems/angle-trisection-oq-05-oq-04.json` | gallery entry, phase OBSERVE, status active |
+| 8 | (pending) Commit + push + PR with label `research` | next |
+
+## References Captured
+
+See `knowledge.md` for the full citation list and Mathlib gap analysis.

--- a/src/data/research/problems/angle-trisection-oq-05-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-04.json
@@ -1,0 +1,120 @@
+{
+  "slug": "angle-trisection-oq-05-oq-04",
+  "title": "Strengthening Huzita-Hatori to capture curved-crease origami",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\exists\\ \\text{axiom system}\\ \\Sigma\\ \\supseteq\\ \\text{HHAxioms}\\ \\text{such that}\\ K_\\Sigma\\ =\\ K_{\\text{curved}}\\ :=\\ \\{\\alpha \\in \\mathbb R\\ :\\ \\alpha\\ \\text{constructible from}\\ \\mathbb Q\\ \\text{by H-H operations}\\ +\\ \\text{single curved fold}\\ (\\gamma, \\theta)\\ \\text{satisfying}\\ \\kappa_n = \\kappa_g \\cdot \\cot(\\theta/2) \\}",
+    "plain": "Can the seven straight-crease Huzita-Hatori axioms be strengthened by a finite extension to capture curved-crease origami? Equivalently, give an axiomatic / algebraic characterisation of the curved-fold-constructible field K_curved that mirrors the existing 'd divides 2^a * 3^b' classification for K_origami.",
+    "whyMatters": [
+      "First differential-geometric extension of the Huzita-Hatori axioms: the seven HH axioms are algebraic / incidence-based; curved-crease origami requires geodesic-curvature and fold-angle-profile primitives absent from both the gallery and Mathlib.",
+      "Bridges the single-fold-vs-multi-fold hierarchy: the sibling proofs AngleTrisectionOQ05OQ01 / OQ02 / OQ03 establish a strict k-fold straight hierarchy reaching algebraic completeness; OQ-04 asks where curved single-fold sits in this hierarchy.",
+      "Strictness of the extension is open: Demaine-Demaine-Hart-Price-Tachi 2011 prove curved-crease origami can trace transcendental curves (elastica), but whether the field of CURVED-FOLD-CONSTRUCTIBLE COORDINATES strictly contains K_origami is open mathematics dating to Huffman 1976.",
+      "Mathlib gap: no developable-surface API, no folding/crease primitive, no Fuchs-Tabachnikov compatibility identity. A gallery-side axiomatic formalisation has standalone value and may propagate upstream as Mathlib.Geometry.Origami.Curved once the API stabilises."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Huffman 1976: rule-line / developable framework for a single curved fold; geodesic curvature equals planar curvature of the unfolded crease.",
+      "Fuchs-Tabachnikov 1999, Theorem 1: compatibility identity kappa_n(s) = kappa_g(s) * cot(theta(s)/2) characterises the smooth-fold dihedral profile.",
+      "Demaine-Demaine-Hart-Price-Tachi 2011, Section 5: curved-crease origami can trace transcendental crease curves (elastica family), so the set of curved-fold-constructible CURVES strictly contains the algebraic curves.",
+      "Alperin 2000, Geretschläger 1995: K_origami = K_neusis = {alpha : [Q(alpha):Q] divides 2^a * 3^b}, the algebraic ceiling formalised in AngleTrisectionOQ05.origami_degree_classification (line 575)."
+    ],
+    "open": [
+      "OQ-A: Is K_curved strictly larger than K_origami? Conjectured FALSE by Demaine et al. 2011 (curved crease yields no new constructible POINTS, only new constructible CURVES); strict-inclusion proof open.",
+      "OQ-B: Is K_curved contained in K_(omega-fold) straight (i.e. algebraic)? Folklore YES; no proof.",
+      "OQ-C (the OQ-04 question itself): Does any of the three candidate axiom schemata — (P1) single curved axiom O8 parametrised by (gamma, theta); (P2) Beloch-style finite degree-bounded restriction; (P3) algebraic-closure-only — generate K_curved? Open whether (P1), (P2), (P3) all give the same field."
+    ],
+    "goal": "Formalise a CurvedCrease structure with the Fuchs-Tabachnikov identity as a field, prove the conservativity lemma straight_fold_recovers_HH (kappa_g identically zero implies the fold reduces to a single HHAxioms axiom), partial sharpness for algebraic gamma (curved_fold_implies_origami in the algebraic-curve case), and a sorry-bearing statement of OQ-A as an open Lean conjecture. ~450 Lean lines over S2-S5; 1 intentional open sorry, 0 axioms."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T04:25:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE survey: literature inventory (Huffman 1976; Fuchs-Tabachnikov 1999; Demaine et al. 2011; Tachi 2010; Mitani 2009; Geretschläger 1995); three-strand theory classification (smooth local DG / algorithmic / constructibility-field); three candidate axiom strengthenings; Mathlib gap analysis (4 missing primitives, all sidestepped by postulating FT as a structure field). No Lean changes this iteration -- pure documentation.",
+    "blockers": [],
+    "nextAction": "S2 ORIENT: create proofs/Proofs/AngleTrisectionOQ05OQ04.lean with a CurvedCrease structure (L, gamma, theta, kappa_g, kappa_n, ftCompatible), CurvedCrease.IsStraight predicate, and statement-only theorem straight_fold_recovers_HH (sorry; S3 target). Estimated ~180 Lean lines.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-12, 2026-05-12): OBSERVE survey for strengthening the Huzita-Hatori axiom system to capture curved-crease origami. Established the Fuchs-Tabachnikov identity kappa_n = kappa_g * cot(theta/2) as the single mathematical compatibility constraint on a smooth curved fold; identified three candidate axiom schemata (P1 single parametric curved axiom, P2 Beloch-style finite-degree restriction, P3 algebraic-closure-only); mapped the four missing Mathlib primitives (geodesic curvature for parametric curves, developable ruled surface, fold-angle profile, FT identity); proposed sidestepping all four by encoding FT as a structure field. Decomposition over S2-S5 totals ~450 Lean lines and exactly 1 intentional open sorry (OQ-A formal conjecture statement) with 0 axioms. No Lean changes this iteration -- pure documentation S1.",
+    "builtItems": [
+      "research/problems/angle-trisection-oq-05-oq-04/problem.md -- full problem statement, Fuchs-Tabachnikov identity, three candidate axiomatic strengthenings (P1/P2/P3), Mathlib gap map.",
+      "research/problems/angle-trisection-oq-05-oq-04/knowledge.md -- parent file inventory (HHAxioms structure at AngleTrisectionOQ05:108), three-strand theory classification, Fuchs-Tabachnikov derivation sketch, five-session decomposition with effort estimates, S2 Lean skeleton.",
+      "research/problems/angle-trisection-oq-05-oq-04/state.md -- OBSERVE phase, S2 next-action sketch with full CurvedCrease structure definition."
+    ],
+    "insights": [
+      "The Fuchs-Tabachnikov compatibility identity kappa_n(s) = kappa_g(s) * cot(theta(s)/2) is the SINGLE mathematical constraint distinguishing valid smooth curved folds from arbitrary (gamma, theta) pairs. Encoding FT as a structure field of CurvedCrease (rather than as a derived theorem) sidesteps ~350 lines of Darboux-frame differential geometry that is currently absent from Mathlib.",
+      "Straight-fold limit kappa_g identically zero forces kappa_n identically zero and recovers exactly one of the seven HHAxioms axioms (depending on the incidence conditions on the crease endpoints). This is the conservativity statement straight_fold_recovers_HH and is the minimum useful S2-S3 deliverable.",
+      "Three candidate axiom strengthenings have substantially different formal characters: (P1) single curved axiom O8 is the most natural but parametrised by infinite-dimensional smooth-function data; (P2) Beloch-style finite degree-bounded restriction is finitary but schema-of-axioms; (P3) algebraic-closure-only loses the geometric primitive entirely. OQ-04 asks whether they all generate the same field.",
+      "Demaine et al. 2011 separate the constructibility of CURVES (strictly larger under curved crease) from the constructibility of POINTS (open). The OQ-04 question is precisely about the latter; the former is settled by the elastica witness.",
+      "Sibling AngleTrisectionOQ05OQ01 (k-fold via p-smooth degrees) + OQ02 (omega-fold algebraic completeness) provide the natural ALGEBRAIC ceiling against which K_curved must be compared. The conjectured pinning K_origami subset K_curved subset K_(omega-fold) gives a clean two-direction question."
+    ],
+    "mathlibGaps": [
+      "Geodesic / planar curvature kappa_g(s) for a smooth parametric curve gamma : R -> R^2: Mathlib.Geometry.Euclidean.Curvature.Plane covers only graph curves y = f(x); extending to unit-speed parametric requires ~80 lines.",
+      "Developable ruled surface from a planar curve and a rulings field: no Mathlib API; ~200 lines to define a parametrised ruled surface and prove the Gaussian-curvature-identically-zero characterisation.",
+      "Dihedral fold angle as a function on a curve: trivial (smooth (0, pi)-valued function on [0, L]); ~30 lines.",
+      "Fuchs-Tabachnikov compatibility identity kappa_n = kappa_g * cot(theta/2): no Mathlib API; ~150 lines of Darboux-frame differential geometry. SIDESTEPPED in S2 by encoding as a CurvedCrease structure field."
+    ],
+    "nextSteps": [
+      "S2 ORIENT (~180 Lean lines): create proofs/Proofs/AngleTrisectionOQ05OQ04.lean with CurvedCrease structure (L, hL, gamma, theta, kappa_g, kappa_n, hTheta_pos, ftCompatible), CurvedCrease.IsStraight predicate (kappa_g identically zero on [0, L]), and statement-only theorem straight_fold_recovers_HH (sorry; S3 target).",
+      "S3 ACT (~120 Lean lines): prove straight_fold_recovers_HH by case analysis on endpoint incidence (uses HHAxioms.HH1 / HH2 / HH3 / HH4 / HH5 / HH6 / HH7); kappa_g zero implies kappa_n zero by ftCompatible.",
+      "S4 ACT (~100 Lean lines): partial sharpness: for algebraic gamma of degree at most d, every point at unit-speed-parameter s in Q intersect [0, L] lies in K_origami. Theorem curved_fold_algebraic_implies_origami.",
+      "S5 ACT (~50 Lean lines): state OQ-A as a sorry-bearing Lean theorem K_curved_eq_K_origami (sorry, open mathematics). This is intentionally a NON-PROVABLE statement for the current iteration; the value is the formal language for the open question.",
+      "Gallery integration S2: src/data/proofs/angle-trisection-oq-05-oq-04/{meta.json, annotations.json, index.ts}. meta.json status axiomatized (ftCompatible is a structure-encoded assumption), sorries 1 (after S2), axioms 0."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "origami",
+    "huzita-hatori",
+    "curved-crease",
+    "differential-geometry",
+    "developable-surface",
+    "fuchs-tabachnikov",
+    "constructibility",
+    "open-conjecture",
+    "extension"
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-01",
+    "angle-trisection-oq-02",
+    "angle-trisection-oq-03",
+    "angle-trisection-oq-04",
+    "angle-trisection-oq-05",
+    "angle-trisection-oq-05-oq-01",
+    "angle-trisection-oq-05-oq-02",
+    "angle-trisection-oq-05-oq-03"
+  ],
+  "references": {
+    "papers": [
+      "Huffman, D. A. (1976). Curvature and creases: A primer on paper. IEEE Trans. Comput. C-25(10), 1010-1019.",
+      "Fuchs, D.; Tabachnikov, S. (1999). More on paperfolding. Amer. Math. Monthly 106(1), 27-35.",
+      "Demaine, E. D.; Demaine, M. L.; Hart, V.; Price, G. N.; Tachi, T. (2011). (Non)existence of pleated folds: How paper folds between creases. Graphs Combin. 27(3), 377-397.",
+      "Tachi, T. (2010). Origamizing polyhedral surfaces. IEEE Trans. Vis. Comput. Graph. 16(2), 298-311.",
+      "Alperin, R. C. (2000). A mathematical theory of origami constructions and numbers. New York J. Math. 6, 119-133.",
+      "Alperin, R. C.; Lang, R. J. (2006). One-, two-, and multi-fold origami axioms. 4OSME, 371-393.",
+      "Mitani, J. (2009). A design method for 3D origami based on rotational sweep. CAD Appl. 6(1), 69-79.",
+      "Geretschläger, R. (1995). Euclidean constructions and the geometry of origami. Math. Mag. 68, 357-371.",
+      "Huzita, H. (1989). Axiomatic development of flat origami. 1OSME, 143-158."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Geometry.Euclidean.Curvature.Plane",
+      "Mathlib.Analysis.Calculus.ContDiff.Basic",
+      "Mathlib.Analysis.Analytic.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+    ]
+  },
+  "started": "2026-05-12T04:25:00Z",
+  "lastUpdate": "2026-05-12T04:25:00Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for `angle-trisection-oq-05-oq-04`: strengthening the
seven straight-crease Huzita-Hatori axioms to capture **curved-crease
origami**. The question asks for an axiomatic / algebraic characterisation
of the field `K_curved ⊆ ℝ` of points constructible by a single curved
fold along an analytic curve `γ` with dihedral fold-angle profile `θ`
satisfying the **Fuchs-Tabachnikov compatibility identity**
`κ_n(s) = κ_g(s) · cot(θ(s)/2)`.

This is a survey-only iteration: markdown + JSON, no Lean changes.

## Progress

**Files modified** (4 created, +616 lines, 0 Lean):
- `research/problems/angle-trisection-oq-05-oq-04/problem.md`
- `research/problems/angle-trisection-oq-05-oq-04/knowledge.md`
- `research/problems/angle-trisection-oq-05-oq-04/state.md`
- `src/data/research/problems/angle-trisection-oq-05-oq-04.json`

## Findings

### Three candidate axiomatic strengthenings

- **(P1)** Single curved axiom O8 parametrised by `(γ, θ)` satisfying FT.
  Most natural; parametrised by infinite-dimensional smooth-function data.
- **(P2)** Beloch-style finite-degree-bounded restriction to algebraic
  `γ` and rational `tan(θ/4)`. Finitary but a schema-of-axioms indexed
  by degree.
- **(P3)** Algebraic-closure-only: postulate `K_curved` as the smallest
  subfield closed under H-H plus the polynomial system FT yields after
  the substitution `t = tan(θ/4)`. Loses the geometric primitive.

The OQ-04 question is whether (P1), (P2), (P3) all generate the same
field.

### Parent file inventory

`proofs/Proofs/AngleTrisectionOQ05.lean` (verified, 695 lines, 0/0/27)
provides exactly the primitives this OQ strengthens:
- `HHAxioms` structure (line 108, seven straight-fold fields)
- `IsOrigamiConstructible` (line 182)
- `origami_degree_classification` (line 575): `α` constructible iff
  `[ℚ(α):ℚ]` divides `2^a · 3^b`.

### Mathlib gap analysis

Four primitives missing at the pinned revision:
1. Geodesic curvature for parametric (not graph) curves (~80 lines).
2. Developable ruled surface from `γ` and rulings field (~200 lines).
3. Dihedral fold angle as a function on `γ` (~30 lines).
4. **Fuchs-Tabachnikov identity** `κ_n = κ_g · cot(θ/2)` (~150 lines of
   Darboux-frame DG).

S2 plan **sidesteps all four** by encoding FT as a structure field of
`CurvedCrease` rather than deriving it internally.

### Decomposition

| Session | Lines | Sorries Δ | Axioms Δ |
|--------|-------|-----------|----------|
| S1 OBSERVE (this) | 0 Lean / +616 md+json | 0 | 0 |
| S2 ORIENT | ~180 Lean | +3 stmts | 0 |
| S3 ACT (straight-fold conservativity) | ~120 Lean | −1 | 0 |
| S4 ACT (algebraic-γ sharpness) | ~100 Lean | −1 | 0 |
| S5 ACT (OQ-A formal conjecture) | ~50 Lean | +1 (intentional open sorry) | 0 |

Total ~450 Lean over five sessions; 1 intentional open sorry, 0 axioms.

## Status

**Outcome**: progress (OBSERVE survey, no Lean changes)
**Next Steps**: S2 ORIENT — create `proofs/Proofs/AngleTrisectionOQ05OQ04.lean`
with the `CurvedCrease` structure (`L`, `γ`, `θ`, `κg`, `κn`, FT
compatibility field) and the statement-only theorem
`straight_fold_recovers_HH` (sorry; S3 target). Full Lean skeleton in
`research/problems/angle-trisection-oq-05-oq-04/state.md`.

**Honesty**: this is a broad, partly-open mathematical question dating
to Huffman 1976. The S1 deliverable is the survey; S2-S4 are tractable
Lean work; S5 is by definition an intentional open sorry. End-to-end
completion would *package the language* for the question, not resolve
the conjecture `K_curved = K_origami`.

🤖 Generated by researcher-12