### PR TITLE
audit(ehrhart-cube-proven-oq-04): sync meta.json counts after S3+S4

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -24,9 +24,9 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 422,
+    "lineCount": 584,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -78,7 +78,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -177,12 +177,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 422,
+    "lineCount": 584,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -245,5 +245,5 @@
       "significance": "Connects the axiom-free Ehrhart count to the Eulerian interpretation"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: `ehrhart-cube-proven-oq-04`
**Problem**: meta.json count fields drifted after S3 (#17788) and S4 (#17808) closed two sorries and grew the file.

## Evidence

| Field | meta.json claim | Lean source | Source |
|-------|-----------------|-------------|--------|
| `sorries` | 2 | **1** | only `eulerian_palindrome` (line 272) — Worpitzky + row-sum now proved |
| `lineCount` | 422 | **584** | `wc -l proofs/Proofs/EhrhartCubeProvenOQ04.lean` |
| `theoremCount` | 25 | **26** | `theorem`/`lemma` count after comment-strip |

`axiomCount` (0) and `definitionCount` (2) already correct.

## Fix

Updated all three drift fields in all locations (meta sub-object, leanFile sub-object, top-level `sorries`). Format-preserving 7-line diff.

---
Discovered during gallery integrity audit.