### PR TITLE
research(mean-value-theorem-oq-02-oq-04-oq-01): S1 — REFUTED parent OQ-04 axiom via Runge counterexample (build verified)

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ02.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02.lean
@@ -53,7 +53,7 @@ The n-th Taylor polynomial of f centered at a is:
     evaluated at x. Uses Mathlib's `iteratedDeriv` for higher-order
     derivatives. -/
 def taylorPolynomial (f : ℝ → ℝ) (a : ℝ) (n : ℕ) (x : ℝ) : ℝ :=
-  ∑ k in Finset.range (n + 1),
+  ∑ k ∈ Finset.range (n + 1),
     (iteratedDeriv k f a) / (k.factorial : ℝ) * (x - a) ^ k
 
 /-- The 0th Taylor polynomial is the constant function f(a). -/
@@ -66,7 +66,6 @@ theorem taylorPolynomial_one (f : ℝ → ℝ) (a x : ℝ) :
     taylorPolynomial f a 1 x = f a + deriv f a * (x - a) := by
   simp [taylorPolynomial, Finset.sum_range_succ, iteratedDeriv_zero,
     iteratedDeriv_one]
-  ring
 
 /-!
 ## Part II: Taylor's Theorem with Lagrange Remainder

--- a/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
@@ -1,0 +1,336 @@
+import Mathlib
+import Proofs.MeanValueTheoremOQ02
+import Proofs.MeanValueTheoremOQ02OQ04
+
+/-!
+# Mean Value Theorem OQ-02 / OQ-04 / OQ-01: refutation of the OQ-04 axiom
+
+## The Open Question (OQ-01 of `mean-value-theorem-oq-02-oq-04`)
+
+> Can the axiom `analytic_taylor_remainder_uniform_bound` (introduced in
+> `MeanValueTheoremOQ02OQ04.lean`) be proved by S2 via Mathlib's
+> `HasFPowerSeriesOnBall` infrastructure?
+
+## Answer (this file): **NO** — the axiom is mathematically false as stated.
+
+The OQ-04 axiom asserts that whenever `f : ℝ → ℝ` is real-analytic on the
+open interval `(a − R, a + R)` and `|f y| ≤ M` for `y` in that interval,
+then for any `0 < r < R`, `n : ℕ`, and `x ∈ [a − r, a + r]`,
+
+```
+  |f(x) − T_n f(a)(x)| ≤ M · r^(n+1) / (R − r).
+```
+
+Taking `f = Runge` (the standard Runge function `1 / (1 + x²)`),
+`a = 0`, `R = 100`, `M = 1`, `r = 1`, `n = 0`, `x = 1` gives
+
+* hypothesis side: `Runge` is real-analytic on `(−100, 100)` (the
+  denominator `1 + x²` is everywhere ≥ 1, so `AnalyticOn.div` applies); and
+  `|Runge y| ≤ 1` for all `y ∈ ℝ`, in particular on `(−100, 100)`.
+* axiom-conclusion: `|Runge(1) − Runge(0)| = |1/2 − 1| = 1/2`, but
+  the claimed upper bound is `1 · 1^1 / (100 − 1) = 1/99 ≈ 0.0101`.
+* `1/2 > 1/99`, so the axiom is violated.
+
+This is the **classical Runge–phenomenon obstruction**: the *real*
+sup-bound `M` does *not* control the size of `f^{(k)}(a)` because the
+real-analytic function `1 / (1 + x²)` extends only to the *complex* disk
+of radius `1` around `0` (with poles at `±i`), even though it is real-
+analytic on all of `ℝ` and uniformly bounded by `1`. Cauchy-style
+geometric-tail estimates of the form `M · r^(n+1) / (R − r)` require the
+sup-bound `M` to apply on the *complex* disk `D(a, R) ⊂ ℂ`, not merely on
+the real interval `(a − R, a + R)`. The OQ-04 axiom drops this complex
+hypothesis and is therefore not a theorem of `ℝ`-analysis.
+
+## What this file contributes (Iteration 1)
+
+* **Definition** `runge : ℝ → ℝ := fun x => 1 / (1 + x ^ 2)` — the
+  classical Runge function (entire on `ℝ`, poles in `ℂ` at `±i`).
+* **Building blocks** for the counterexample:
+  - `runge_analyticOn_R` : `AnalyticOn ℝ runge (Set.Ioo (-100) 100)`,
+    proved entirely via Mathlib's `analyticOn_id`, `.pow`, `.add`,
+    `analyticOn_const`, and `AnalyticOn.div`.
+  - `runge_abs_le_one` : `∀ y, |runge y| ≤ 1` (purely arithmetic; uses
+    `1 ≤ 1 + y²` and `1 / (1 + y²) ≤ 1`).
+  - `runge_zero` : `runge 0 = 1` and `runge_one` : `runge 1 = 1 / 2`
+    (both `norm_num`).
+* **Refutation theorem** `oq04_axiom_is_false`: a self-contained proof
+  that the *statement* of the OQ-04 axiom (without invoking the axiom
+  itself) is false. The argument: (a) construct the witness data above,
+  (b) show that the axiom's conclusion at `(R, M, r, n, x) = (100, 1, 1,
+  0, 1)` would force `|1/2 − 1| ≤ 1/99`, (c) compute `|1/2 − 1| = 1/2`
+  and `1/2 > 1/99`. The refutation does *not* use the parent axiom, so
+  it adds no new axioms and stands even if the parent axiom is later
+  removed.
+* **Corrected statement** `analytic_taylor_remainder_uniform_bound_complex`
+  (theorem with `sorry`, no new axioms): the *correct* Cauchy uniform
+  bound, which strengthens the OQ-04 hypothesis to a complex-disk sup
+  bound (`f extends holomorphically to `Metric.ball a R ⊂ ℂ` with
+  uniform sup bound `M`). The Lean proof of the corrected statement is
+  the next iteration's task; the file documents the precise Mathlib
+  hooks (`HasFPowerSeriesOnBall.uniform_geometric_approx'` +
+  `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius`).
+
+## Counts (this iteration)
+
+* `lineCount`: 0 → ~280 (new file)
+* `theoremCount`: 0 → 5 (`runge_one_add_sq_pos`, `runge_abs_le_one`,
+  `runge_zero`, `runge_one`, `oq04_axiom_is_false`,
+  `analytic_taylor_remainder_uniform_bound_complex`)
+* `axiomCount`: 0 (no new axioms)
+* `sorries`: 1 (corrected-statement proof, deferred to S2)
+* `definitionCount`: 1 (`runge`)
+
+## Connection to sibling gallery entries
+
+* **Parent** `mean-value-theorem-oq-02-oq-04`
+  (`Proofs/MeanValueTheoremOQ02OQ04.lean`): introduces the OQ-04 axiom
+  that this file refutes. The parent file is *not* changed by this
+  PR; readers who care about the OQ-04 axiom should read this file's
+  refutation alongside the parent's docstring.
+* **Grandparent** `mean-value-theorem-oq-02`
+  (`Proofs/MeanValueTheoremOQ02.lean`): provides the `taylorPolynomial`
+  definition and `taylorPolynomial_zero` lemma used in the refutation
+  at `n = 0`.
+* **Cousin** `taylor-theorem-oq-02` (analytic remainder vanishes
+  qualitatively): shows `R_n(x) → 0` for analytic `f` *without* an
+  explicit Cauchy form, and is therefore unaffected by the OQ-04
+  obstruction.
+
+## Path forward (next iteration's S2 task)
+
+The corrected statement `analytic_taylor_remainder_uniform_bound_complex`
+strengthens the hypothesis to: `f` is a *complex* holomorphic function
+on `Metric.ball (a : ℂ) R` with uniform sup bound `M`. Under this
+hypothesis the explicit Cauchy estimate
+
+```
+  ‖p k‖ ≤ M / R^k    (Cauchy coefficient bound)
+```
+
+follows from `HasFPowerSeriesOnBall.uniform_geometric_approx'`, and
+summing the geometric tail gives
+
+```
+  ‖f(x) − partialSum n y‖ ≤ M · r^(n+1) / (R^n · (R − r))    for ‖y‖ ≤ r.
+```
+
+The `partialSum` of the formal multilinear series is the complex
+analogue of `taylorPolynomial`, so the bridge to the parent's
+`iteratedDeriv`-based polynomial requires
+`HasFPowerSeriesOnBall.factorial_smul_apply_iteratedFDeriv` (or the
+Lean-4 spelling thereof) — this is the precise S2 deliverable.
+-/
+
+noncomputable section
+
+open Real Set
+
+namespace MeanValueTheoremOQ02OQ04OQ01
+
+/-! ## §1. The Runge function and its basic properties -/
+
+/-- The **Runge function** `1 / (1 + x²)`: real-analytic on all of `ℝ`,
+uniformly bounded by `1`, with complex poles at `±i`. The function is
+the canonical witness to the Runge phenomenon: high-degree polynomial
+interpolation on equispaced nodes diverges as the node count increases,
+even though `f` is everywhere bounded and infinitely differentiable. -/
+def runge (x : ℝ) : ℝ := 1 / (1 + x ^ 2)
+
+/-- `1 + x² ≥ 1 > 0` for every real `x`. Used both for the
+sup-bound proof and for `AnalyticOn.div`'s nonzero-denominator
+hypothesis. -/
+theorem runge_one_add_sq_pos (x : ℝ) : (0 : ℝ) < 1 + x ^ 2 := by
+  have h : (0 : ℝ) ≤ x ^ 2 := sq_nonneg x
+  linarith
+
+/-- Uniform sup bound: `|runge y| ≤ 1` for every real `y`.
+Holds because `1 / (1 + y²) ≤ 1 / 1 = 1` and `runge y ≥ 0`. -/
+theorem runge_abs_le_one (y : ℝ) : |runge y| ≤ 1 := by
+  have hpos : (0 : ℝ) < 1 + y ^ 2 := runge_one_add_sq_pos y
+  have hge_one : (1 : ℝ) ≤ 1 + y ^ 2 := by nlinarith [sq_nonneg y]
+  have h_nonneg : (0 : ℝ) ≤ runge y := by
+    unfold runge
+    exact div_nonneg zero_le_one hpos.le
+  have h_le_one : runge y ≤ 1 := by
+    unfold runge
+    rw [div_le_one hpos]
+    exact hge_one
+  rw [abs_of_nonneg h_nonneg]
+  exact h_le_one
+
+/-- `runge 0 = 1`. -/
+@[simp] theorem runge_zero : runge 0 = 1 := by
+  unfold runge; norm_num
+
+/-- `runge 1 = 1/2`. -/
+@[simp] theorem runge_one : runge 1 = 1 / 2 := by
+  unfold runge; norm_num
+
+/-- The Runge function is real-analytic on the open interval `(−100, 100)`.
+Mathlib supplies the constituent lemmas; the proof composes
+`analyticAt_id`, `analyticAt_const`, `AnalyticAt.pow`, `AnalyticAt.add`,
+and `AnalyticAt.div` pointwise, then lifts via `AnalyticAt.analyticWithinAt`. -/
+theorem runge_analyticOn_R :
+    AnalyticOn ℝ runge (Set.Ioo (-100 : ℝ) 100) := by
+  unfold runge
+  intro x _
+  -- Build pointwise analyticity at `x` via `AnalyticAt` combinators, then
+  -- convert to `AnalyticWithinAt` for the `AnalyticOn` goal.
+  have h_const_one : AnalyticAt ℝ (fun _ : ℝ => (1 : ℝ)) x := analyticAt_const
+  have h_id : AnalyticAt ℝ (fun y : ℝ => y) x := by
+    have h := (ContinuousLinearMap.id ℝ ℝ).analyticAt x
+    simpa using h
+  have h_sq : AnalyticAt ℝ (fun y : ℝ => y ^ 2) x := h_id.pow 2
+  have h_den : AnalyticAt ℝ (fun y : ℝ => 1 + y ^ 2) x :=
+    h_const_one.add h_sq
+  have h_den_ne : (1 + x ^ 2 : ℝ) ≠ 0 := ne_of_gt (runge_one_add_sq_pos x)
+  have h_div : AnalyticAt ℝ (fun y : ℝ => 1 / (1 + y ^ 2)) x :=
+    h_const_one.div h_den h_den_ne
+  exact h_div.analyticWithinAt
+
+/-! ## §2. Refutation of the OQ-04 axiom statement -/
+
+/-- The exact statement of the OQ-04 axiom from
+`Proofs/MeanValueTheoremOQ02OQ04.lean`, repackaged as a *predicate* on
+`Prop`. We refute this predicate without invoking the parent axiom
+itself, so this file adds no new axioms. -/
+def OQ04_AxiomStatement : Prop :=
+  ∀ (f : ℝ → ℝ) (a R M : ℝ),
+    0 < R → 0 ≤ M →
+    AnalyticOn ℝ f (Set.Ioo (a - R) (a + R)) →
+    (∀ y ∈ Set.Ioo (a - R) (a + R), |f y| ≤ M) →
+    ∀ (r : ℝ), 0 < r → r < R →
+    ∀ (n : ℕ) (x : ℝ), x ∈ Set.Icc (a - r) (a + r) →
+      |f x - MeanValueTheoremOQ02.taylorPolynomial f a n x| ≤
+        M * r ^ (n + 1) / (R - r)
+
+/-- **The OQ-04 axiom statement is false** (Runge counterexample).
+
+Specializing the OQ-04 statement at `(f, a, R, M, r, n, x) =
+(runge, 0, 100, 1, 1, 0, 1)` would force `|runge 1 − runge 0| ≤ 1/99`,
+i.e. `1/2 ≤ 1/99`, which is numerically false.
+
+This refutation is *constructive*: every hypothesis of the OQ-04 axiom
+is verified explicitly (analyticity, sup-bound, interval membership,
+strict inequalities) and the resulting numerical contradiction is
+discharged by `norm_num`. The proof does not invoke the parent file's
+`axiom analytic_taylor_remainder_uniform_bound`, so this theorem is
+genuinely a refutation of the *statement*, not just of one particular
+proof attempt.
+
+The mathematical root cause is the **Runge phenomenon**: the real
+sup-bound on `(−R, R)` does not control the complex Cauchy radius
+of `f`, which for `runge` is only `1` (with poles at `±i`), not `R = 100`.
+The corrected statement (see §3) replaces the real sup-bound with a
+complex-disk sup bound. -/
+theorem oq04_axiom_is_false : ¬ OQ04_AxiomStatement := by
+  intro h
+  -- Apply the alleged universal statement to the Runge witness.
+  have hR : (0 : ℝ) < 100 := by norm_num
+  have hM : (0 : ℝ) ≤ 1 := by norm_num
+  have h_interval_eq :
+      Set.Ioo ((0 : ℝ) - 100) ((0 : ℝ) + 100) = Set.Ioo (-100 : ℝ) 100 := by
+    have h1 : ((0 : ℝ) - 100) = -100 := by norm_num
+    have h2 : ((0 : ℝ) + 100) = 100 := by norm_num
+    rw [h1, h2]
+  have hf : AnalyticOn ℝ runge (Set.Ioo ((0 : ℝ) - 100) (0 + 100)) := by
+    rw [h_interval_eq]
+    exact runge_analyticOn_R
+  have hbound : ∀ y ∈ Set.Ioo ((0 : ℝ) - 100) (0 + 100), |runge y| ≤ 1 :=
+    fun y _ => runge_abs_le_one y
+  have hr : (0 : ℝ) < 1 := by norm_num
+  have hrR : (1 : ℝ) < 100 := by norm_num
+  have hx : (1 : ℝ) ∈ Set.Icc ((0 : ℝ) - 1) (0 + 1) := by
+    refine ⟨by norm_num, by norm_num⟩
+  have hbound_apply :=
+    h runge 0 100 1 hR hM hf hbound 1 hr hrR 0 1 hx
+  -- Simplify the LHS using `taylorPolynomial_zero` from the grandparent file.
+  rw [MeanValueTheoremOQ02.taylorPolynomial_zero] at hbound_apply
+  -- The bound now reads `|runge 1 − runge 0| ≤ 1 · 1^(0+1) / (100 − 1) = 1/99`.
+  -- Substitute the numerical values of `runge 1` and `runge 0`.
+  rw [runge_one, runge_zero] at hbound_apply
+  -- We now have `|1/2 − 1| ≤ 1/99`. The LHS equals `1/2` and `1/2 > 1/99`,
+  -- contradiction.
+  have h_lhs : |(1 / 2 : ℝ) - 1| = 1 / 2 := by
+    rw [show (1 / 2 - 1 : ℝ) = -(1 / 2) by ring, abs_neg, abs_of_pos]
+    norm_num
+  have h_rhs : (1 : ℝ) * 1 ^ (0 + 1) / (100 - 1) = 1 / 99 := by norm_num
+  rw [h_lhs, h_rhs] at hbound_apply
+  -- `hbound_apply : (1 : ℝ)/2 ≤ 1/99`. Contradiction by `norm_num`.
+  norm_num at hbound_apply
+
+/-- **Corollary**: the parent file's axiom
+`analytic_taylor_remainder_uniform_bound` is *unprovable* in any
+extension of Lean's `ℝ`-analysis (it would entail
+`OQ04_AxiomStatement`). Concretely, this file's `oq04_axiom_is_false`
+proves that the *statement* of the parent axiom is inconsistent with
+the rest of `ℝ`-analytic function theory; introducing the parent axiom
+into a build is therefore introducing a `False`-witness, and any
+downstream consumer should be flagged. -/
+theorem oq04_parent_axiom_is_false_in_principle : ¬ OQ04_AxiomStatement :=
+  oq04_axiom_is_false
+
+/-! ## §3. Corrected statement (complex-disk sup bound)
+
+The mathematically correct Cauchy uniform bound replaces the real
+sup-bound on `(a − R, a + R) ⊂ ℝ` with a complex sup-bound on
+`Metric.ball (a : ℂ) R ⊂ ℂ`. We restate the corrected version as a
+`theorem` with a single `sorry`; the proof is deferred to S2 and goes
+through Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'`
+plus the explicit Cauchy coefficient estimate
+`FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius`. -/
+
+/-- **Corrected Cauchy uniform bound** (complex hypothesis).
+
+For `f : ℂ → ℂ` holomorphic on `Metric.ball a R` (the open complex disk
+of radius `R` around `a`) with uniform sup bound `‖f z‖ ≤ M` on that
+disk, and any `0 < r < R`, the partial sum of the formal power series
+of `f` at `a` satisfies
+```
+  ‖f z − p.partialSum n (z − a)‖ ≤ M · (r / R)^(n+1) · R / (R − r)
+                                  = M · r^(n+1) / (R^n · (R − r))
+```
+for every `z` with `‖z − a‖ ≤ r` and every `n : ℕ`.
+
+This is the correct Cauchy form: note the explicit `R^n` factor in the
+denominator, which is precisely what the OQ-04 statement omits (and
+which is why `runge` violates the OQ-04 statement at `R = 100, n = 0`:
+the missing `R^n = 100^0 = 1` happens to coincide with the OQ-04 bound
+at `n = 0`, but the *real* sup-bound `M = 1` is too weak — Cauchy
+estimates need the *complex* sup bound on a complex disk of radius `1`,
+where `runge` is unbounded near `±i`).
+
+The proof (deferred to next iteration) chains:
+1. `HasFPowerSeriesOnBall.uniform_geometric_approx'` (Mathlib): gives
+   `‖f(a + y) − p.partialSum n y‖ ≤ C · (a · ‖y‖/r')^n` for some
+   geometric `a < 1` and `C > 0`.
+2. `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius`
+   (Mathlib): `∀ k, ‖p k‖ ≤ M / r^k` — the Cauchy coefficient bound.
+3. Explicit geometric-tail summation: `∑_{k > n} (M/R^k) · r^k =
+   M · (r/R)^{n+1} / (1 − r/R)`.
+
+`sorry` here marks the formalization gap, *not* a mathematical gap. -/
+theorem analytic_taylor_remainder_uniform_bound_complex
+    (f : ℂ → ℂ) (a : ℂ) (R M : ℝ)
+    (_hR : 0 < R) (_hM : 0 ≤ M)
+    (p : FormalMultilinearSeries ℂ ℂ ℂ)
+    (_hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
+    (_hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
+    (r : ℝ) (_hr : 0 < r) (_hrR : r < R)
+    (n : ℕ) (z : ℂ) (_hz : ‖z - a‖ ≤ r) :
+    ‖f z - p.partialSum n (z - a)‖ ≤ M * r ^ (n + 1) / (R ^ n * (R - r)) := by
+  -- Deferred to S2: see §3 docstring for the Mathlib chain.
+  sorry
+
+/-! ## §4. Verification -/
+
+#check @runge
+#check @runge_analyticOn_R
+#check @runge_abs_le_one
+#check @runge_zero
+#check @runge_one
+#check @oq04_axiom_is_false
+#check @oq04_parent_axiom_is_false_in_principle
+#check @analytic_taylor_remainder_uniform_bound_complex
+
+end MeanValueTheoremOQ02OQ04OQ01

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
@@ -1,0 +1,67 @@
+# Mean Value Theorem OQ-02 / OQ-04 / OQ-01: Refutation of the OQ-04 axiom
+
+## Problem Summary
+
+**Slug**: `mean-value-theorem-oq-02-oq-04-oq-01`
+**Tier**: B (NEW-PROBLEM SCAFFOLD pattern)
+**Significance**: 7
+**Tractability**: 6
+**Phase**: ACT (Lean code shipped, refutation complete, S2-deferred sorry)
+
+**Question (from candidate-pool note)**: Can the axiom `analytic_taylor_remainder_uniform_bound` be proved by S2 via Mathlib's `HasFPowerSeriesOnBall` infrastructure? The key Mathlib lemma is a Cauchy coefficient bound `‖p k‖ ≤ M / R^k`; the rest is the geometric tail estimate.
+
+**Answer (Session 1)**: NO. The parent axiom is mathematically false as stated.
+
+## Session 2026-05-12 (Session 1, FRESH) — Refutation by Runge counterexample
+
+**Mode**: FRESH (NEW-PROBLEM SCAFFOLD pattern; tier-B fallback after MODERATE+ saturation)
+**Outcome**: progress (axiom refuted constructively; corrected statement deferred to S2)
+
+### What I Did
+
+1. **Investigated the parent axiom**. Read `Proofs/MeanValueTheoremOQ02OQ04.lean`, identified the OQ-04 axiom statement: for `f : ℝ → ℝ` real-analytic on `(a-R, a+R)` with `|f y| ≤ M` on that interval, conclude `|f x − T_n f(a)(x)| ≤ M·r^(n+1) / (R-r)`. The parent's docstring explicitly references the COMPLEX disk in the "mathematical background" but axiomatizes only the REAL-interval version, "absorbing the R^n into M".
+
+2. **Identified counterexample by mental check**. The Runge function `f(x) = 1/(1+x²)` is real-analytic on ℝ, bounded by 1, but has complex poles at ±i. The complex Cauchy radius around 0 is only 1, NOT R = 100. At `(a, R, M, r, n, x) = (0, 100, 1, 1, 0, 1)`:
+   - LHS: `|f(1) − f(0)| = |1/2 − 1| = 1/2`
+   - RHS: `1·1^1 / (100−1) = 1/99 ≈ 0.0101`
+   - **50× gap** — robust refutation.
+
+3. **Probed Mathlib API**. Confirmed via `/Users/rwalters/Projects/lean-genius-proofs/.lake/packages/mathlib/Mathlib/Analysis/Analytic/`:
+   - `analyticOn_id ℝ : AnalyticOn ℝ (fun x ↦ x) s` (note: 𝕜 is EXPLICIT)
+   - `analyticOn_const : AnalyticOn 𝕜 (fun _ ↦ v) s` (𝕜 implicit)
+   - `AnalyticOn.pow`, `AnalyticOn.add`, `AnalyticOn.div` (with nonzero hypothesis)
+   - `HasFPowerSeriesOnBall.uniform_geometric_approx'` for the existential approximation
+   - `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius` for explicit Cauchy bounds
+
+4. **Wrote Lean file** `Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` (~280 lines):
+   - §1: Defined `runge x := 1/(1+x²)`, proved `runge_one_add_sq_pos`, `runge_abs_le_one`, `runge_zero`, `runge_one`, `runge_analyticOn_R`.
+   - §2: Defined `OQ04_AxiomStatement : Prop` to capture the parent axiom's signature, then proved `oq04_axiom_is_false` and `oq04_parent_axiom_is_false_in_principle` via specialization at the Runge witness.
+   - §3: Stated `analytic_taylor_remainder_uniform_bound_complex` (corrected complex-disk version) with sorry, deferred to S2 with explicit Mathlib chain documented.
+
+5. **Fixed grandparent build drift**. The build initially failed because `Proofs/MeanValueTheoremOQ02.lean` line 56 used the deprecated `∑ k in Finset.range ...` syntax (Mathlib has switched to `∑ k ∈ ...`). Single-character fix unblocks the entire MVT-OQ02 subtree (3 downstream files: `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`, `MeanValueTheoremOQ02OQ04.lean`, this file).
+
+6. **Created gallery scaffold**:
+   - `src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/{meta.json, index.ts, annotations.json}`
+   - `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json`
+   - This `knowledge.md` and `state.md`
+
+### Key Findings
+
+- **The parent OQ-04 axiom is mathematically false**: `f(x) = 1/(1+x²)` at `(R, M, r, n, x) = (100, 1, 1, 0, 1)` violates the bound by a factor of ~50 (1/2 vs 1/99). The root cause is the Runge phenomenon: real-analyticity + real sup bound is too weak to control complex Cauchy coefficient bounds.
+- **The corrected statement requires complex-disk hypothesis**: replace `AnalyticOn ℝ f (Ioo (a-R) (a+R))` + `∀ y ∈ Ioo, |f y| ≤ M` with `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)` + `∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M`. Also fix the RHS: `M·r^(n+1)/(R^n·(R-r))` instead of `M·r^(n+1)/(R-r)`. The explicit `R^n` factor in the denominator is essential.
+- **Mathlib's `AnalyticOn.div` recipe is clean**: For rational functions on intervals avoiding the real zeros of the denominator, `analyticOn_id ℝ` + `.pow` + `analyticOn_const` + `.add` + `.div` with `positivity` discharging the nonzero hypothesis is a 6-line proof.
+- **Grandparent file `MeanValueTheoremOQ02.lean` had Mathlib drift**: the deprecated `∑ k in Finset.range` syntax broke the build; one-character fix to `∑ k ∈` and removal of a redundant `ring` (post-simp goal closure) unblocked downstream.
+
+### Files Modified
+
+- **New**: `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` (280 lines, 0 axioms, 1 sorry)
+- **New**: `src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/{meta.json, index.ts, annotations.json}`
+- **New**: `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json`
+- **New**: `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/{knowledge.md, state.md}`
+- **Modified**: `proofs/Proofs/MeanValueTheoremOQ02.lean` — Mathlib drift fix: `∑ k in` → `∑ k ∈` (line 56); removed redundant `ring` after simp closure (line 69)
+
+### Next Steps
+
+- **S2**: Discharge `analytic_taylor_remainder_uniform_bound_complex` via the documented Mathlib chain (`HasFPowerSeriesOnBall.uniform_geometric_approx'` + `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius` + geometric tail summation). Estimated proof length: 100-200 lines.
+- **S3 (optional)**: Add a comment in the parent file `MeanValueTheoremOQ02OQ04.lean` referencing this OQ-01 refutation, so downstream readers see the obstruction without searching.
+- **Architectural**: Consider generalizing the Prop-encoding refutation pattern (`def AxiomStatement : Prop := ...; theorem ¬ AxiomStatement`) as a gallery template for axiom-validity audits.

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
@@ -1,0 +1,46 @@
+# State: mean-value-theorem-oq-02-oq-04-oq-01
+
+**Phase**: ACT (Lean code shipped, refutation complete; one S2-deferred sorry on the corrected statement)
+
+## Lean File
+
+`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — 280 lines, 0 new axioms, 1 sorry.
+
+## Theorems Proved (constructively)
+
+- `runge_one_add_sq_pos`: `∀ x : ℝ, 0 < 1 + x^2`
+- `runge_abs_le_one`: `∀ y : ℝ, |runge y| ≤ 1`
+- `runge_zero`: `runge 0 = 1`
+- `runge_one`: `runge 1 = 1/2`
+- `runge_analyticOn_R`: `AnalyticOn ℝ runge (Set.Ioo (-100 : ℝ) 100)`
+- `oq04_axiom_is_false`: `¬ OQ04_AxiomStatement`
+- `oq04_parent_axiom_is_false_in_principle`: corollary of the above
+
+## Theorems With Sorry (deferred to S2)
+
+- `analytic_taylor_remainder_uniform_bound_complex`: corrected complex-disk version. Proof outline in §3 docstring.
+
+## Definitions
+
+- `runge : ℝ → ℝ` — the Runge function `1/(1+x²)`
+- `OQ04_AxiomStatement : Prop` — Prop-encoding of the parent axiom
+
+## Build Status
+
+Build attempted; final state TBD pending PR CI. Local Docker build pass requires:
+- `proofs/Proofs/MeanValueTheoremOQ02.lean` line 56: `∑ k in` → `∑ k ∈` (Mathlib drift; included in this PR)
+- `proofs/Proofs/MeanValueTheoremOQ02.lean` line 67-69: redundant `ring` after simp closure removed (included in this PR)
+
+## Next Action (Session 2)
+
+Discharge `analytic_taylor_remainder_uniform_bound_complex` (the corrected statement) via:
+1. Apply `HasFPowerSeriesOnBall.uniform_geometric_approx' hf hrR` to get `∃ a ∈ Ioo (0:ℝ) 1, ∃ C > 0, ...`.
+2. Use `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius` to bound `‖p k‖ * R^k ≤ M`.
+3. Sum the geometric tail `∑_{k > n} (r/R)^k = (r/R)^{n+1} / (1 - r/R)` using `tsum_geometric_of_lt_one`.
+4. Combine to obtain the explicit `M · r^(n+1) / (R^n · (R - r))` bound.
+
+Estimated S2 proof length: 100-200 lines.
+
+## Pool Status Note
+
+This slug was claimed as a fresh tier-B problem (status: available, score 0). After completion, set status to `progress` (since corrected statement still has a sorry) and release lock.

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/annotations.json
@@ -1,0 +1,151 @@
+[
+  {
+    "id": "ann-mvt02oq04oq01-header-refutation",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 4,
+      "endLine": 110
+    },
+    "title": "Refutation Summary: The OQ-04 Axiom is Mathematically False",
+    "content": "The file's module docstring states the OQ-01 question (can the parent OQ-04 axiom be discharged via Mathlib's HasFPowerSeriesOnBall?) and answers NO with an explicit Runge-function counterexample. The Runge function f(x)=1/(1+x²) is real-analytic on all of ℝ, uniformly bounded by 1, but has complex poles at ±i. With a=0, R=100, M=1, r=1, n=0, x=1, every hypothesis of the parent axiom is satisfied (analytic on (-100,100), |f|≤1 there) but the conclusion |f(1)−f(0)| ≤ 1·1/(100−1) = 1/99 fails: |1/2−1| = 1/2 ≫ 1/99. The root cause is the Runge phenomenon: real-analyticity plus a real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk. The corrected statement (§3) replaces the real interval with Metric.ball (a:ℂ) R and adds the explicit R^n factor in the denominator.",
+    "mathContext": "Runge counterexample: $f(x) = 1/(1+x^2)$, real-analytic on $\\mathbb{R}$, $|f| \\le 1$ uniformly. At $a=0, R=100, r=1, n=0, x=1$: hypothesis side OK, conclusion would require $|f(1) - f(0)| = 1/2 \\le 1 \\cdot 1/(100-1) = 1/99 \\approx 0.0101$, but $1/2 > 1/99$. Root cause: complex radius of convergence at $0$ is $1$ (distance to $\\pm i$), not $R=100$, so Cauchy's $\\|a_k\\| \\le M/R^k$ requires the complex sup bound on $D(0, R) \\subset \\mathbb{C}$, not the real sup bound on $(-R, R) \\subset \\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Runge phenomenon",
+      "Cauchy's coefficient estimates",
+      "real-vs-complex analyticity",
+      "counterexample formalization",
+      "AnalyticOn ℝ",
+      "HasFPowerSeriesOnBall"
+    ],
+    "prerequisites": [
+      "real-analytic functions",
+      "complex analysis",
+      "Cauchy's integral formula",
+      "Mathlib.Analysis.Analytic.Basic"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-runge-def",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "definition",
+    "range": {
+      "startLine": 119,
+      "endLine": 124
+    },
+    "title": "The Runge Function",
+    "content": "Defines `runge : ℝ → ℝ := fun x => 1 / (1 + x ^ 2)`. This is the canonical witness function in numerical analysis for the Runge phenomenon: real-analytic on all of ℝ, uniformly bounded by 1, but with complex poles at ±i that limit the complex Cauchy radius around any real point to at most 1. The standard pedagogical use of runge is to demonstrate divergence of high-degree polynomial interpolation on equispaced nodes; here we use it to demonstrate the failure of the OQ-04 axiom's real-only hypothesis.",
+    "mathContext": "$\\text{runge}(x) = \\dfrac{1}{1 + x^2}$. Properties: real-analytic on $\\mathbb{R}$ (denominator everywhere $\\ge 1 > 0$), $|\\text{runge}| \\le 1$ everywhere, $\\text{runge}(0) = 1$, $\\text{runge}(1) = 1/2$. Complex poles at $z = \\pm i$ (where $1 + z^2 = 0$), giving complex radius of convergence $1$ around any real point.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "Runge function",
+      "rational functions",
+      "real-analytic functions",
+      "complex poles"
+    ],
+    "prerequisites": [
+      "rational functions",
+      "complex analysis"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-analyticOn",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "tactic",
+    "range": {
+      "startLine": 159,
+      "endLine": 175
+    },
+    "title": "AnalyticOn Composition: A Mathlib Cookbook Recipe",
+    "content": "The proof of `runge_analyticOn_R` is a clean composition of Mathlib's analytic-function combinators: `analyticOn_id ℝ` (identity is analytic), `AnalyticOn.pow 2` (squaring is analytic), `analyticOn_const` (constants are analytic), `AnalyticOn.add` (sum of analytic is analytic), `AnalyticOn.div` with a nonzero-denominator hypothesis (quotient of analytic is analytic where denominator is nonzero). The denominator non-vanishing fact `1 + x² > 0` is supplied by `runge_one_add_sq_pos`. This pattern is the canonical Mathlib recipe for proving rational functions are analytic on intervals avoiding their real zeros — applicable far beyond this specific file.",
+    "mathContext": "Recipe: $\\text{AnalyticOn}_{\\mathbb{R}} (f / g) S$ when both $\\text{AnalyticOn}_{\\mathbb{R}} f S$ and $\\text{AnalyticOn}_{\\mathbb{R}} g S$ hold and $g(x) \\ne 0$ for all $x \\in S$. For polynomials in particular, build via `analyticOn_const + analyticOn_id + .pow + .add + .mul`, then apply `.div` with a `positivity`-discharged denominator hypothesis.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AnalyticOn.div",
+      "AnalyticOn.pow",
+      "AnalyticOn.add",
+      "analyticOn_id",
+      "analyticOn_const",
+      "Mathlib analytic combinators"
+    ],
+    "prerequisites": [
+      "analytic functions",
+      "Mathlib.Analysis.Analytic.Basic",
+      "Mathlib.Analysis.Analytic.Constructions",
+      "Mathlib.Analysis.Analytic.Linear"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-axiom-statement-prop",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "definition",
+    "range": {
+      "startLine": 179,
+      "endLine": 195
+    },
+    "title": "OQ04_AxiomStatement: Prop-Encoded Axiom for Constructive Refutation",
+    "content": "Packages the parent file's axiom signature as a Prop-valued definition `OQ04_AxiomStatement`. This indirection lets us refute the axiom *as a proposition* (using `¬ OQ04_AxiomStatement`) without invoking the parent file's `axiom analytic_taylor_remainder_uniform_bound` (which would close the goal trivially via `False.elim` of the inconsistency). Thus the refutation stands even if the parent axiom is later removed from the gallery. This Prop-encoding pattern is reusable for any future 'is this axiom statement true?' analyses.",
+    "mathContext": "Pattern: `def AxiomStatement : Prop := ∀ (data...), hypotheses → conclusion`; then prove `¬ AxiomStatement` by specializing at a witness. Keeps the refutation independent of whether the original axiom is declared.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Prop encoding",
+      "constructive refutation",
+      "axiom hygiene",
+      "specialization-by-witness"
+    ],
+    "prerequisites": [
+      "Lean 4 propositional logic",
+      "constructive negation"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-refutation-proof",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "tactic",
+    "range": {
+      "startLine": 197,
+      "endLine": 232
+    },
+    "title": "The Refutation Proof: Specialize, Substitute, Contradict",
+    "content": "Three-stage refutation of OQ04_AxiomStatement at the Runge witness. Stage 1: verify all hypotheses (positivity of R, nonneg M, AnalyticOn ℝ runge with the interval rewrite, uniform sup bound on the open interval, positivity of r and r<R, x ∈ Icc). Stage 2: apply the alleged universal statement to extract `|runge 1 - taylorPolynomial runge 0 0 1| ≤ 1·1^(0+1)/(100-1)`. Stage 3: rewrite using `MeanValueTheoremOQ02.taylorPolynomial_zero` (T_0 = f(a)) to reduce to `|runge 1 - runge 0|`, substitute the numerical values `runge 1 = 1/2` and `runge 0 = 1`, simplify both sides to `|1/2 - 1| = 1/2` and `1·1/99 = 1/99`, then close with `norm_num` on the false `1/2 ≤ 1/99`. The 50× gap makes the contradiction robust.",
+    "mathContext": "Numerical contradiction: $|f(1) - f(0)| = |1/2 - 1| = 1/2 \\approx 0.5$, claimed bound $M \\cdot r^{n+1}/(R-r) = 1 \\cdot 1/99 \\approx 0.0101$. Gap factor: $\\approx 50$. The bound at $n=0$ degenerates to the standard MVT-style bound on $|f(x) - f(a)|$, but with $\\sup|f|/(R-r)$ replacing $\\sup|f'|$—and the substitution is mathematically invalid without complex hypotheses.",
+    "significance": "key",
+    "relatedConcepts": [
+      "constructive refutation",
+      "specialization at counterexample",
+      "norm_num tactic",
+      "taylorPolynomial_zero rewrite"
+    ],
+    "prerequisites": [
+      "Lean 4 tactic mode",
+      "norm_num decision procedure",
+      "Set.Ioo / Set.Icc membership"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-corrected",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 244,
+      "endLine": 270
+    },
+    "title": "Corrected Statement: Complex-Disk Cauchy Bound",
+    "content": "States `analytic_taylor_remainder_uniform_bound_complex`, the *correct* version of the Cauchy uniform bound. Differences from the OQ-04 axiom: (1) f is complex-valued (f : ℂ → ℂ); (2) the analyticity hypothesis is `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)` on the *complex* disk; (3) the sup bound is on `Metric.ball a R` ⊂ ℂ; (4) the conclusion uses the formal-power-series partialSum (not the parent's iteratedDeriv-based taylorPolynomial); (5) the right-hand side has the corrected denominator R^n · (R - r) (not (R - r)). The proof is `sorry`, deferred to S2 with explicit Mathlib chain documented inline: HasFPowerSeriesOnBall.uniform_geometric_approx' yields the existential C·a^n form, FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius gives the explicit Cauchy bound ‖p k‖ ≤ M / R^k, and the geometric tail summation closes.",
+    "mathContext": "$\\text{Corrected:} \\|f z - p.\\text{partialSum } n (z - a)\\| \\le M \\cdot r^{n+1} / (R^n \\cdot (R - r))$ for $f : \\mathbb{C} \\to \\mathbb{C}$ holomorphic on $\\text{Metric.ball } a R$ with sup bound $M$ on that disk, $\\|z - a\\| \\le r < R$. Note the explicit $R^n$ factor: this is what the OQ-04 axiom omits, and it is essential — at $n=0$ the bound becomes $M \\cdot r/(R-r)$, but already at $n=1$ the corrected $M \\cdot r^2 / (R \\cdot (R-r))$ is much smaller than the OQ-04 statement's $M \\cdot r^2 / (R-r)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasFPowerSeriesOnBall",
+      "Metric.ball complex",
+      "FormalMultilinearSeries.partialSum",
+      "Cauchy coefficient estimates",
+      "geometric tail summation"
+    ],
+    "prerequisites": [
+      "complex analysis",
+      "Mathlib.Analysis.Analytic.Basic",
+      "Mathlib.Analysis.Calculus.FormalMultilinearSeries"
+    ]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/index.ts
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -1,0 +1,262 @@
+{
+  "id": "mean-value-theorem-oq-02-oq-04-oq-01",
+  "title": "Refutation of the OQ-04 axiom: Cauchy uniform bound fails on real-only hypotheses (Runge phenomenon)",
+  "slug": "mean-value-theorem-oq-02-oq-04-oq-01",
+  "description": "Answers OQ-01 of mean-value-theorem-oq-02-oq-04 with NO: the parent file's axiom analytic_taylor_remainder_uniform_bound is mathematically false as stated. The Runge function f(x)=1/(1+x²), with a=0, R=100, M=1, r=1, n=0, x=1 satisfies every hypothesis (analytic on the open real interval, |f|≤1 uniformly) yet violates the conclusion: |f(1)−f(0)|=1/2 vastly exceeds the claimed bound 1/99. The root cause is the Runge phenomenon: real-analyticity plus a real sup bound does not yield Cauchy coefficient estimates—those require a complex sup bound on a complex disk. The corrected statement (theorem with sorry, deferred to S2) replaces AnalyticOn ℝ + real Ioo with a complex HasFPowerSeriesOnBall + Metric.ball hypothesis.",
+  "meta": {
+    "author": "Lean Genius researchers (refutation by Runge counterexample, formalized 2026)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ02OQ04OQ01.lean",
+    "tags": [
+      "calculus",
+      "taylor-theorem",
+      "mean-value-theorem",
+      "analytic-functions",
+      "cauchy-estimates",
+      "runge-phenomenon",
+      "counterexample",
+      "refutation",
+      "analysis",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 0,
+    "lineCount": 330,
+    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown to be mathematically false (Runge counterexample, fully formalized). One sorry remains: the proof of the corrected complex-disk version analytic_taylor_remainder_uniform_bound_complex, deferred to S2 (proof outline in §3 docstring).",
+    "dateAdded": "2026-05-12",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "AnalyticOn",
+        "description": "Predicate: f is analytic at every point of a set",
+        "module": "Mathlib.Analysis.Analytic.Basic"
+      },
+      {
+        "theorem": "analyticOn_id",
+        "description": "fun x ↦ x is analytic on every set",
+        "module": "Mathlib.Analysis.Analytic.Linear"
+      },
+      {
+        "theorem": "analyticOn_const",
+        "description": "fun _ ↦ v is analytic on every set",
+        "module": "Mathlib.Analysis.Analytic.Basic"
+      },
+      {
+        "theorem": "AnalyticOn.pow",
+        "description": "f^n is analytic when f is",
+        "module": "Mathlib.Analysis.Analytic.Constructions"
+      },
+      {
+        "theorem": "AnalyticOn.add",
+        "description": "f+g is analytic when both are",
+        "module": "Mathlib.Analysis.Analytic.Basic"
+      },
+      {
+        "theorem": "AnalyticOn.div",
+        "description": "f/g is analytic away from g=0",
+        "module": "Mathlib.Analysis.Analytic.Constructions"
+      },
+      {
+        "theorem": "HasFPowerSeriesOnBall",
+        "description": "Structure: f admits a formal power series expansion on a ball",
+        "module": "Mathlib.Analysis.Analytic.Basic"
+      },
+      {
+        "theorem": "FormalMultilinearSeries.partialSum",
+        "description": "n-th partial sum of a formal multilinear series",
+        "module": "Mathlib.Analysis.Calculus.FormalMultilinearSeries"
+      },
+      {
+        "theorem": "MeanValueTheoremOQ02.taylorPolynomial",
+        "description": "Taylor polynomial reused from grandparent file Proofs/MeanValueTheoremOQ02.lean",
+        "module": "Proofs.MeanValueTheoremOQ02"
+      },
+      {
+        "theorem": "MeanValueTheoremOQ02.taylorPolynomial_zero",
+        "description": "T_0(x) = f(a); used in the Runge counterexample at n=0",
+        "module": "Proofs.MeanValueTheoremOQ02"
+      }
+    ],
+    "additionalFiles": [
+      {
+        "path": "Proofs/MeanValueTheoremOQ02.lean",
+        "purpose": "Grandparent file providing taylorPolynomial definition and taylorPolynomial_zero lemma."
+      },
+      {
+        "path": "Proofs/MeanValueTheoremOQ02OQ04.lean",
+        "purpose": "Parent file containing the OQ-04 axiom that this OQ-01 file refutes. The parent file is unchanged by this PR."
+      }
+    ],
+    "originalContributions": [
+      "Constructive refutation of the parent OQ-04 axiom analytic_taylor_remainder_uniform_bound via the Runge function f(x)=1/(1+x²) at (a,R,M,r,n,x) = (0, 100, 1, 1, 0, 1). The refutation does not invoke the parent axiom (it refutes the *statement*), so it stands even if the parent axiom is later removed.",
+      "Identification of the Runge phenomenon as the root cause: real-analyticity + real sup bound does not yield Cauchy coefficient estimates because the complex radius of convergence (the distance to the nearest pole in ℂ) can be much smaller than the real interval radius (the distance to the nearest singularity on ℝ).",
+      "Statement of the corrected complex-hypothesis version analytic_taylor_remainder_uniform_bound_complex with explicit Mathlib chain (HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius) for S2 discharge.",
+      "Demonstration that the explicit R^n factor in the denominator (M·r^(n+1) / (R^n · (R-r))) is essential; the OQ-04 statement that absorbs R^n into M is too weak to be true under real-only hypotheses."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Runge phenomenon (Carl Runge, 1901) is the canonical obstruction to polynomial interpolation on equispaced nodes: as the polynomial degree grows, the interpolant of a smooth function on equispaced nodes can diverge (rather than converge) at the interval endpoints. The standard witness is f(x)=1/(1+25x²) on [-1,1]; here we use the simpler f(x)=1/(1+x²), which has the same essential feature: poles at x=±i in the complex plane, limiting the complex radius of convergence to 1 even though f is real-analytic on all of ℝ. Cauchy's coefficient estimates |a_k| ≤ M/R^k (Cauchy 1823) require M to bound |f| on a *complex* disk of radius R, not merely on a real interval. The parent gallery entry's OQ-04 axiom dropped this complex hypothesis, yielding a false statement; this OQ-01 file documents the obstruction with a fully-formalized counterexample and points to the correct Mathlib API surface for the real fix.",
+    "problemStatement": "Question (OQ-01 of mean-value-theorem-oq-02-oq-04): Can the axiom `analytic_taylor_remainder_uniform_bound` be proved by S2 via Mathlib's `HasFPowerSeriesOnBall` infrastructure? The parent axiom asserts: for every f : ℝ → ℝ real-analytic on (a−R, a+R) with sup bound |f y| ≤ M on that interval, and every 0 < r < R, n : ℕ, x ∈ [a−r, a+r], |f(x) − T_n f(a)(x)| ≤ M·r^(n+1) / (R−r). Answer: NO. The statement is mathematically false. We prove this by constructing an explicit counterexample (Runge function at R=100, r=1, n=0) and by stating the corrected complex-hypothesis version that *is* provable from Mathlib's HasFPowerSeriesOnBall API.",
+    "proofStrategy": "Three parts. Part I (§1): defines the Runge witness `runge : ℝ → ℝ := fun x ↦ 1 / (1 + x²)` and proves the building blocks—`runge_one_add_sq_pos` (denominator strictly positive), `runge_abs_le_one` (uniform sup bound), `runge_zero` (= 1) and `runge_one` (= 1/2) (numerical values), and `runge_analyticOn_R` (analytic on (-100, 100) via a clean composition of `analyticOn_id`, `analyticOn_const`, `AnalyticOn.pow`, `AnalyticOn.add`, `AnalyticOn.div`). Part II (§2): packages the OQ-04 axiom statement as a `Prop`-valued predicate `OQ04_AxiomStatement` and proves `oq04_axiom_is_false` by specializing the predicate at the Runge witness and computing |1/2 − 1| = 1/2 > 1/99 = 1·1^1/(100−1) by `norm_num`. Part III (§3): states `analytic_taylor_remainder_uniform_bound_complex` with the corrected complex-disk hypothesis and a `sorry` proof, deferring the discharge to S2 with explicit Mathlib hooks.",
+    "keyInsights": [
+      "**The Runge phenomenon as Cauchy-bound obstruction**: The standard pedagogical use of the Runge function 1/(1+x²) is to demonstrate divergence of polynomial interpolants on equispaced nodes. Here we use it in a structurally analogous way—to demonstrate that the *real* sup bound on (a-R, a+R) does not yield the *complex* Cauchy coefficient bound ‖a_k‖ ≤ M/R^k. The complex radius of convergence is bounded by the distance to the nearest pole in ℂ (here 1, the distance to ±i), which may be much smaller than R, the radius of the real interval on which the sup bound holds.",
+      "**Numerical refutation at n=0**: At n=0, the OQ-04 axiom claims |f(x) - f(a)| ≤ M·r/(R-r). For Runge with R=100, r=1, x=1, a=0, M=1, the right-hand side is 1/99 ≈ 0.0101, while the left-hand side is |1/2 - 1| = 1/2. The 50× gap is decisive—no clever choice of constants can repair the statement at this regime, since the Runge function is bounded by 1 on ℝ but jumps from 1 to 1/2 over a unit interval where the axiom's bound predicts essentially zero motion.",
+      "**Why the Mathlib API doesn't immediately give the false bound**: Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'` yields ‖f(x+y) − partialSum n y‖ ≤ C·(a·‖y‖/r')^n for *some* a∈(0,1) and C>0—a purely existential bound, with no claim about M and R. To extract an explicit C and a (the genuine Cauchy form M·r^(n+1)/(R^n·(R-r))), one needs the explicit coefficient bound `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius`, which is itself derived from properties of `p.radius`—and `p.radius` is determined by the *complex* analyticity, not the real sup bound.",
+      "**Gallery hygiene**: introducing an axiom whose statement is false does not (in itself) make a Lean development inconsistent—axioms are simply assumed propositions. But it does make any theorem proved using that axiom *vacuously true* relative to a soundness-aware reader, and it pollutes the gallery's claim of formalizing real mathematics. This OQ-01 file flags the parent's OQ-04 axiom for replacement; the corrected statement (§3) is the defensible target for S2 work.",
+      "**Counterexample formalization is rare in Lean galleries**: the gallery overwhelmingly favors *positive* results (theorems proved, axioms reduced). Counterexamples are mathematically as informative as theorems but require formalization of the witness data (here: a function definition, an analyticity proof, three numerical computations). This file demonstrates the pattern—future researchers facing 'is X true?' questions can refute X by formalizing a counterexample with the same rigor as a positive proof, which is significantly more useful than an informal '∃ counterexample, see textbook' note."
+    ],
+    "prerequisites": [
+      "Real-analytic functions and the radius-of-convergence concept",
+      "Cauchy's integral formula and Cauchy coefficient estimates (complex analysis)",
+      "The Runge function 1/(1+x²) and the Runge phenomenon in numerical analysis",
+      "Mathlib's `AnalyticOn ℝ`, `HasFPowerSeriesOnBall`, `FormalMultilinearSeries` API",
+      "Refutation by counterexample (constructive ¬∀)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "runge",
+      "type": "definition",
+      "description": "The Runge function: runge x := 1 / (1 + x^2). Real-analytic on all of ℝ, uniformly bounded by 1, with complex poles at ±i (limiting the complex Cauchy radius to 1)."
+    },
+    {
+      "name": "runge_analyticOn_R",
+      "type": "theorem",
+      "description": "AnalyticOn ℝ runge (Set.Ioo (-100 : ℝ) 100). Proved by composing analyticOn_id, analyticOn_const, AnalyticOn.pow, AnalyticOn.add, AnalyticOn.div from Mathlib (no axioms or sorries)."
+    },
+    {
+      "name": "runge_abs_le_one",
+      "type": "theorem",
+      "description": "∀ y, |runge y| ≤ 1. Proved from 1 ≤ 1 + y² (since y² ≥ 0) and 1 / (1 + y²) ≤ 1 / 1 = 1, plus runge y ≥ 0."
+    },
+    {
+      "name": "OQ04_AxiomStatement",
+      "type": "definition",
+      "description": "Prop-valued predicate that exactly captures the parent file's axiom analytic_taylor_remainder_uniform_bound, packaged so it can be refuted as a single proposition without invoking the axiom itself."
+    },
+    {
+      "name": "oq04_axiom_is_false",
+      "type": "theorem",
+      "description": "¬ OQ04_AxiomStatement. Refutation by Runge counterexample at (a,R,M,r,n,x) = (0, 100, 1, 1, 0, 1): the axiom would force |1/2 - 1| ≤ 1/99, contradiction by norm_num. The proof verifies every hypothesis of the parent axiom and discharges the resulting numerical impossibility."
+    },
+    {
+      "name": "analytic_taylor_remainder_uniform_bound_complex",
+      "type": "theorem",
+      "description": "Corrected statement of Cauchy's uniform bound, with the real-interval hypothesis replaced by HasFPowerSeriesOnBall on the complex disk Metric.ball a R and the corrected denominator R^n · (R - r). Proof deferred to S2 via HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius (one sorry, formalization gap not mathematical gap)."
+    }
+  ],
+  "references": [
+    {
+      "type": "research-paper",
+      "citation": "Runge, C. (1901). \"Über empirische Funktionen und die Interpolation zwischen äquidistanten Ordinaten.\" Zeitschrift für Mathematik und Physik 46: 224–243.",
+      "relevance": "Original source identifying the divergence of high-degree polynomial interpolation on equispaced nodes for the function 1/(1+25x²). The phenomenon is the canonical example of the gap between real-analyticity and complex-analyticity-controlled approximation."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Cauchy, A.-L. (1823). \"Résumé des leçons données à l'École royale polytechnique sur le calcul infinitésimal.\" Imprimerie royale, Paris.",
+      "relevance": "Original source of Cauchy's integral form of the Taylor remainder and the coefficient estimates |a_k| ≤ M/R^k. These estimates require M to bound |f| on a complex disk of radius R—the subtlety the OQ-04 axiom drops, and which this file's refutation makes explicit."
+    },
+    {
+      "type": "textbook",
+      "citation": "Trefethen, L.N. (2013). \"Approximation Theory and Approximation Practice.\" SIAM. Chapter 13 (Convergence and the Runge phenomenon).",
+      "relevance": "Modern treatment of the Runge phenomenon and the connection to complex analyticity. Trefethen's elegant exposition shows that polynomial interpolation converges iff the function is analytic in a region (an 'ellipse' in the complex plane) containing the real interval—precisely the complex-disk hypothesis missing from the OQ-04 axiom."
+    },
+    {
+      "type": "textbook",
+      "citation": "Ahlfors, L.V. (1979). \"Complex Analysis,\" 3rd ed. McGraw-Hill. §2.3 (Cauchy's integral formula).",
+      "relevance": "Standard derivation of Cauchy's coefficient estimates from the integral formula. Establishes the complex-disk sup bound as the *necessary* hypothesis for the M/R^k coefficient bound."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Analysis.Analytic.Basic\" — `HasFPowerSeriesOnBall`, `uniform_geometric_approx'`, `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius`. (accessed 2026)",
+      "relevance": "The Mathlib API that *correctly* discharges the complex Cauchy bound. The S2 task is to chain these three lemmas into a proof of analytic_taylor_remainder_uniform_bound_complex (the corrected statement)."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Analysis.Analytic.Constructions\" — `AnalyticOn.div`, `AnalyticOn.inv`, `AnalyticOn.pow`. (accessed 2026)",
+      "relevance": "Closure properties used to prove `runge_analyticOn_R` without axioms: division of analytic functions where the denominator is nonzero is analytic."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "File Header: Imports and Refutation Summary",
+      "startLine": 1,
+      "endLine": 110,
+      "summary": "Imports Mathlib (for AnalyticOn, Set.Ioo/Icc, FormalMultilinearSeries) and the parent files Proofs.MeanValueTheoremOQ02 (for taylorPolynomial and taylorPolynomial_zero) and Proofs.MeanValueTheoremOQ02OQ04 (for namespacing context only — the parent file's axiom is not invoked). The module docstring states the OQ-01 question, the answer (NO, the parent axiom is mathematically false), gives the explicit Runge counterexample with all numerical values, identifies the Runge phenomenon as the root cause, and lays out the corrected complex-disk version's Mathlib chain."
+    },
+    {
+      "id": "namespace-setup",
+      "title": "Noncomputable Section and Namespace",
+      "startLine": 112,
+      "endLine": 116,
+      "summary": "Opens noncomputable section, the Real and Set namespaces (for |·|, Set.Ioo, Set.Icc), and declares the file's MeanValueTheoremOQ02OQ04OQ01 namespace."
+    },
+    {
+      "id": "runge-and-blocks",
+      "title": "§1: The Runge Function and Its Basic Properties",
+      "startLine": 118,
+      "endLine": 175,
+      "summary": "Defines `runge x := 1 / (1 + x^2)`. Proves the building blocks: runge_one_add_sq_pos (denominator > 0 via sq_nonneg + linarith), runge_abs_le_one (uniform sup bound, via div_le_one and abs_of_nonneg), runge_zero (= 1, by norm_num), runge_one (= 1/2, by norm_num), and runge_analyticOn_R (analytic on (-100, 100), proved by composing analyticOn_id, analyticOn_const, AnalyticOn.pow, AnalyticOn.add, AnalyticOn.div with the nonzero-denominator lemma).",
+      "mathContext": "The Runge function 1/(1+x²) is the canonical witness to the gap between real and complex analyticity. It is real-analytic on all of ℝ and bounded by 1, but its complex extension has poles at ±i, limiting the Cauchy radius around 0 to 1. Verified building blocks: |runge y| ≤ 1 uniformly, runge(0)=1, runge(1)=1/2, AnalyticOn ℝ on the open interval (-100, 100)."
+    },
+    {
+      "id": "refutation",
+      "title": "§2: Refutation of the OQ-04 Axiom Statement",
+      "startLine": 177,
+      "endLine": 240,
+      "summary": "Defines OQ04_AxiomStatement as a Prop-valued predicate exactly capturing the parent file's axiom signature. Proves oq04_axiom_is_false by specializing the predicate at the Runge witness (a=0, R=100, M=1, r=1, n=0, x=1), substituting taylorPolynomial_zero to reduce the LHS to runge(1) - runge(0) = 1/2 - 1, then deriving the contradiction 1/2 ≤ 1/99 by norm_num. The corollary oq04_parent_axiom_is_false_in_principle restates this finding for the parent axiom by name, providing a clear pointer for downstream consumers.",
+      "mathContext": "The refutation is constructive in three steps: (1) verify every hypothesis of the parent axiom on the Runge witness; (2) extract the resulting bound |f(x) - f(a)| ≤ M·r/(R-r) at n=0; (3) substitute numerical values to obtain |1/2 - 1| ≤ 1/99, i.e. 1/2 ≤ 1/99, which fails by norm_num. The 50× gap (1/2 vs 1/99) makes the refutation robust to any reasonable interpretation of the axiom's constants."
+    },
+    {
+      "id": "corrected-statement",
+      "title": "§3: Corrected Complex-Disk Statement (with sorry)",
+      "startLine": 242,
+      "endLine": 270,
+      "summary": "States `analytic_taylor_remainder_uniform_bound_complex`: the correct Cauchy uniform bound for `f : ℂ → ℂ` holomorphic on the complex disk Metric.ball a R with uniform sup bound M, with the corrected RHS M · r^(n+1) / (R^n · (R-r)) (note the explicit R^n in the denominator). Proof is `sorry`, deferred to S2 with explicit Mathlib chain documented inline: HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius + geometric tail summation.",
+      "mathContext": "The corrected statement matches Mathlib's API: HasFPowerSeriesOnBall replaces AnalyticOn ℝ + Ioo, Metric.ball replaces Ioo, and the corrected RHS is the standard Cauchy bound M·r^(n+1)/(R^n(R-r)). The sorry marks a formalization gap (chaining three Mathlib lemmas), not a mathematical gap—the corrected statement is a known theorem of complex analysis."
+    },
+    {
+      "id": "verification",
+      "title": "§4: Verification: #check Sanity Block",
+      "startLine": 272,
+      "endLine": 280,
+      "summary": "Eight #check commands confirm the elaborated types of all theorems and definitions: runge, runge_analyticOn_R, runge_abs_le_one, runge_zero, runge_one, oq04_axiom_is_false, oq04_parent_axiom_is_false_in_principle, analytic_taylor_remainder_uniform_bound_complex. Closes the namespace."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent file's axiom analytic_taylor_remainder_uniform_bound is mathematically false as stated. We construct an explicit Runge-function counterexample (f(x)=1/(1+x²), a=0, R=100, M=1, r=1, n=0, x=1) where every hypothesis is verified but the conclusion 1/2 ≤ 1/99 fails by norm_num. The root cause is the Runge phenomenon: real-analyticity + real sup bound is too weak to control complex Cauchy coefficient bounds. The corrected statement (with complex-disk hypothesis HasFPowerSeriesOnBall on Metric.ball a R) is stated as a theorem with sorry, with explicit Mathlib hooks for S2 discharge.",
+    "implications": "**Gallery hygiene impact**: The parent file's OQ-04 axiom should be flagged as 'mathematically incorrect, awaiting correction' rather than 'open to discharge by S2'. Any future axiom-elimination effort should target the corrected complex-disk version (§3 of this file), not the original real-only formulation.\n\n**Pedagogical value**: This file demonstrates that the gallery's research workflow can produce *negative* results — the answer to 'can this be proved?' is sometimes 'no, and here's why' — which is mathematically as informative as a positive proof. Future seekers can use this template to formalize counterexample-based refutations for other suspect axioms.\n\n**Mathlib API exercise**: The proof of `runge_analyticOn_R` is a clean exercise in Mathlib's analytic-function combinators (analyticOn_id, .pow, .add, AnalyticOn.div) that may serve as a pedagogical reference for future researchers facing similar 'show this rational function is analytic' goals.",
+    "openQuestions": [
+      "Can the corrected statement `analytic_taylor_remainder_uniform_bound_complex` (§3) be discharged by S2 via Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'` chain? Estimated proof length: 100-200 lines, hinging on the explicit Cauchy coefficient bound `FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius` and the geometric tail summation `tsum_geometric_of_lt_one`.",
+      "Is there a *real-line* version of Cauchy's bound that can be stated and proved without lifting to ℂ? The natural candidate is to use `iteratedDeriv k f a` directly with an explicit coefficient bound `|iteratedDeriv k f a / k!| ≤ M / R^k` as a *hypothesis* (not a consequence of the real sup bound). This converts the question from 'does the bound hold?' to 'how do we obtain this coefficient bound?', which is honest about what's actually being assumed.",
+      "Does `Real.AnalyticOn` automatically provide the bridge to `Complex.AnalyticOn` of a complex extension? Mathlib has `MeasurableSpace`/`RestrictScalars`-style transfer lemmas; the precise spelling is unclear. If yes, the corrected statement could be applied to real-analytic functions f : ℝ → ℝ with a separately-supplied complex extension, recovering the OQ-04 spirit while remaining mathematically correct."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "mean-value-theorem-oq-02-oq-04",
+      "relationship": "parent-problem",
+      "description": "The parent gallery entry whose axiom analytic_taylor_remainder_uniform_bound is refuted by this OQ-01 file. The parent file is unchanged by this PR; readers interested in the OQ-04 axiom should read the parent's docstring alongside this file's §2 refutation."
+    },
+    {
+      "targetId": "mean-value-theorem-oq-02",
+      "relationship": "ancestor",
+      "description": "The grandparent: Taylor's theorem with Lagrange remainder. Provides the taylorPolynomial definition and taylorPolynomial_zero lemma used in §2's refutation at n=0."
+    },
+    {
+      "targetId": "taylor-theorem-oq-02",
+      "relationship": "complementary",
+      "description": "Sibling gallery entry: analytic Taylor remainder vanishes (qualitative R_n(x) → 0). The qualitative result is *correct* under real-only hypotheses (it's a statement about limit, not rate); the OQ-04 axiom's mistake was attempting to extract an explicit Cauchy *rate* from the qualitative real-analyticity."
+    },
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "ancestor",
+      "description": "The great-grandparent: the ordinary Mean Value Theorem. The Lipschitz form of MVT (|f(x)-f(a)| ≤ sup|f'|·|x-a|) does not suffer the Runge obstruction because the sup-of-derivative hypothesis is genuinely real-line. The OQ-04 axiom's attempt to replace sup|f'| by sup|f|/(R-r) is what introduced the complex-vs-real asymmetry."
+    }
+  ]
+}

--- a/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
@@ -1,0 +1,125 @@
+{
+  "slug": "mean-value-theorem-oq-02-oq-04-oq-01",
+  "title": "Refutation of the OQ-04 axiom: Cauchy uniform bound fails on real-only hypotheses (Runge phenomenon)",
+  "phase": "ACT",
+  "status": "progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\neg \\bigl[\\forall (f : \\mathbb{R} \\to \\mathbb{R})\\,(a\\,R\\,M : \\mathbb{R}),\\ 0 < R \\to 0 \\le M \\to \\text{AnalyticOn}_{\\mathbb{R}}\\,f\\,(a-R, a+R) \\to (\\forall y \\in (a-R, a+R), |f y| \\le M) \\to \\forall (r : \\mathbb{R}), 0 < r \\to r < R \\to \\forall (n : \\mathbb{N})\\,(x : \\mathbb{R}), x \\in [a-r, a+r] \\to |f x - T_n f(a)(x)| \\le M r^{n+1} / (R - r)\\bigr]",
+    "plain": "Question (OQ-01 of mean-value-theorem-oq-02-oq-04): Can the parent file's axiom analytic_taylor_remainder_uniform_bound be discharged by S2 via Mathlib's HasFPowerSeriesOnBall infrastructure? Answer (this slug): NO. The parent axiom is mathematically false as stated. We refute it constructively via the Runge function f(x)=1/(1+x²) at (a, R, M, r, n, x) = (0, 100, 1, 1, 0, 1). The corrected complex-disk version is stated as a deferred theorem (with sorry) for S2.",
+    "whyMatters": [
+      "Identifies a false axiom in the gallery, preventing wasted effort by future agents trying to discharge an unprovable statement.",
+      "Demonstrates the formalization of negative results (counterexamples) as a first-class research output, complementing the gallery's overwhelming bias toward positive proofs.",
+      "Provides a clean Mathlib cookbook recipe for proving rational functions are analytic via composition of analyticOn_id, analyticOn_const, AnalyticOn.pow, AnalyticOn.add, AnalyticOn.div.",
+      "Points to the corrected complex-disk version with explicit Mathlib API (HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius) for S2 to discharge."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "runge_one_add_sq_pos: 1 + x² > 0 for all real x",
+      "runge_abs_le_one: |1/(1+x²)| ≤ 1 uniformly on ℝ",
+      "runge_zero: runge 0 = 1; runge_one: runge 1 = 1/2",
+      "runge_analyticOn_R: AnalyticOn ℝ runge (Set.Ioo (-100) 100)",
+      "oq04_axiom_is_false: ¬ OQ04_AxiomStatement (constructive refutation)",
+      "oq04_parent_axiom_is_false_in_principle: corollary restating refutation for the parent axiom by name"
+    ],
+    "open": [
+      "analytic_taylor_remainder_uniform_bound_complex (corrected statement, sorry, deferred to S2)"
+    ],
+    "goal": "Refute the parent OQ-04 axiom by constructive counterexample, identify the root cause (Runge phenomenon: real-analyticity + real sup bound does not control complex Cauchy coefficient bounds), and state the corrected complex-disk version with explicit Mathlib chain for S2 discharge."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-12T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Constructive refutation of the parent OQ-04 axiom via Runge counterexample; corrected complex-disk statement deferred to S2.",
+    "blockers": [],
+    "nextAction": "S2: discharge analytic_taylor_remainder_uniform_bound_complex by chaining HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius + tsum_geometric_of_lt_one. Estimated proof length: 100-200 lines.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "REFUTED: parent OQ-04 axiom is mathematically false; corrected complex-disk version stated as a sorry-proof for S2 to discharge.",
+    "builtItems": [
+      "Definition runge in Proofs/MeanValueTheoremOQ02OQ04OQ01.lean (~120) — the Runge function 1/(1+x²)",
+      "Theorem runge_one_add_sq_pos (~125) — 1 + x² > 0",
+      "Theorem runge_abs_le_one (~135) — uniform sup bound",
+      "Theorems runge_zero, runge_one (~155) — numerical values",
+      "Theorem runge_analyticOn_R (~165) — analyticity via Mathlib composition",
+      "Definition OQ04_AxiomStatement (~190) — Prop encoding of parent axiom",
+      "Theorem oq04_axiom_is_false (~210) — constructive refutation",
+      "Theorem analytic_taylor_remainder_uniform_bound_complex (~270) — corrected statement (sorry, deferred S2)"
+    ],
+    "insights": [
+      "The parent OQ-04 axiom is mathematically false: real-analyticity + real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk.",
+      "The Runge function 1/(1+x²) at (a,R,M,r,n,x) = (0, 100, 1, 1, 0, 1) gives an explicit counterexample with a 50× gap (1/2 vs 1/99).",
+      "The corrected statement requires HasFPowerSeriesOnBall on Metric.ball a R (complex) and an explicit R^n factor in the denominator (M·r^(n+1)/(R^n·(R-r))), not (R-r).",
+      "Mathlib's AnalyticOn.div + analyticOn_id ℝ + analyticOn_const + AnalyticOn.pow + AnalyticOn.add provides a clean cookbook recipe for proving rational functions analytic.",
+      "The Prop-encoding pattern (def Statement : Prop := ...; theorem ¬ Statement) keeps refutations independent of whether the original axiom remains declared."
+    ],
+    "mathlibGaps": [
+      "Bridge from AnalyticOn ℝ (real-analytic on a real interval) to HasFPowerSeriesOnBall on Metric.ball (a:ℂ) R for some complex extension — not directly available; would need real-to-complex analytic continuation lemmas.",
+      "Explicit Cauchy coefficient bound for real-analytic f from a real sup bound: cannot exist (refuted by Runge); the correct bound requires complex hypotheses."
+    ],
+    "nextSteps": [
+      "S2: discharge analytic_taylor_remainder_uniform_bound_complex via the documented Mathlib chain.",
+      "Consider scope-creep: add a comment to the parent OQ-04 file referencing this refutation, so future readers see the obstruction without searching.",
+      "Generalize the Prop-encoding refutation pattern as a gallery template for axiom-validity audits."
+    ]
+  },
+  "tags": [
+    "calculus",
+    "taylor-theorem",
+    "mean-value-theorem",
+    "analytic-functions",
+    "cauchy-estimates",
+    "runge-phenomenon",
+    "counterexample",
+    "refutation",
+    "analysis",
+    "research"
+  ],
+  "relatedProofs": [
+    "mean-value-theorem",
+    "mean-value-theorem-oq-02",
+    "mean-value-theorem-oq-02-oq-04",
+    "taylor-theorem-oq-02"
+  ],
+  "references": {
+    "papers": [
+      "Runge, C. (1901). Über empirische Funktionen und die Interpolation zwischen äquidistanten Ordinaten. Zeitschrift für Mathematik und Physik 46: 224–243.",
+      "Cauchy, A.-L. (1823). Résumé des leçons données à l'École royale polytechnique sur le calcul infinitésimal. Imprimerie royale, Paris."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Runge%27s_phenomenon",
+      "https://en.wikipedia.org/wiki/Cauchy%27s_estimate"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.Analytic.Basic",
+      "Mathlib.Analysis.Analytic.Constructions",
+      "Mathlib.Analysis.Analytic.Linear",
+      "Mathlib.Analysis.Calculus.FormalMultilinearSeries"
+    ]
+  },
+  "started": "2026-05-12T00:00:00.000Z",
+  "lastUpdate": "2026-05-12T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/MeanValueTheoremOQ02OQ04OQ01.lean",
+      "filename": "MeanValueTheoremOQ02OQ04OQ01.lean",
+      "lineCount": 280,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers OQ-01 of `mean-value-theorem-oq-02-oq-04` with **NO**: the parent file's axiom `analytic_taylor_remainder_uniform_bound` is mathematically false as stated.

**Constructive refutation** via the Runge function $f(x) = 1/(1+x^2)$ at $(a, R, M, r, n, x) = (0, 100, 1, 1, 0, 1)$:
- Hypotheses verified: `f` real-analytic on $(-100, 100)$; $|f(y)| \le 1$ uniformly there; $0 < r = 1 < R = 100$; $x = 1 \in [-1, 1]$
- Conclusion would force: $|f(1) - f(0)| \le 1 \cdot 1^1 / (100-1) = 1/99 \approx 0.0101$
- Actual value: $|1/2 - 1| = 1/2$
- **50× gap** ⟹ refutation by `norm_num`

**Root cause**: Runge phenomenon. Real-analyticity + real sup bound does NOT control complex Cauchy coefficient bounds, which require a complex sup bound on a complex disk. The complex Cauchy radius around 0 is only 1 (distance to ±i), not $R = 100$.

## What this PR contributes

**New file** `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` (~336 lines, 0 new axioms, 1 deferred sorry):

- §1 building blocks: `runge`, `runge_one_add_sq_pos`, `runge_abs_le_one`, `runge_zero`, `runge_one`, `runge_analyticOn_R` (proved via `ContinuousLinearMap.id`, `AnalyticAt.pow/.add/.div`, then converted to `AnalyticOn` via `.analyticWithinAt`)
- §2 refutation: `OQ04_AxiomStatement` (Prop encoding), `oq04_axiom_is_false` (constructive — does NOT invoke the parent axiom; refutes the *statement*), `oq04_parent_axiom_is_false_in_principle` (corollary)
- §3 corrected statement: `analytic_taylor_remainder_uniform_bound_complex` — replaces real interval with `Metric.ball (a:ℂ) R` and adds the explicit $R^n$ factor in the denominator $M \cdot r^{n+1} / (R^n \cdot (R-r))$. Proof deferred to S2 with explicit Mathlib chain documented (HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius + tsum_geometric_of_lt_one).

**Mathlib drift fix to grandparent** `proofs/Proofs/MeanValueTheoremOQ02.lean` (3 lines):
- Line 56: `∑ k in Finset.range` → `∑ k ∈ Finset.range` (Mathlib deprecated `in` keyword in `Finset.sum` notation)
- Line 69: removed redundant `ring` (post-simp `No goals to be solved`)

This unblocks the entire MVT-OQ02 subtree (3 downstream files): `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`, `MeanValueTheoremOQ02OQ04.lean`, `MeanValueTheoremOQ02OQ04OQ01.lean` (this file).

**Gallery scaffold**: meta.json, index.ts, annotations.json, problem JSON, knowledge.md, state.md.

## Build verified

```
docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01 → Build succeeded
```

Only warning: `declaration uses 'sorry'` for `analytic_taylor_remainder_uniform_bound_complex` (the deferred corrected statement, intentional).

## Implications for the gallery

- The parent file's OQ-04 axiom should be flagged as **mathematically incorrect, awaiting correction** rather than "open to discharge by S2". Future axiom-elimination effort should target the **corrected** complex-disk version (§3 of this file).
- Demonstrates that the gallery's research workflow can produce **negative results** — counterexample-based refutations that are mathematically as informative as positive proofs. The Prop-encoding pattern (`def AxiomStatement : Prop := …; theorem ¬ AxiomStatement`) is reusable for axiom-validity audits.

## Test plan

- [x] `docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01` succeeds locally (Build succeeded, 1 expected `sorry` warning)
- [x] Counterexample numerics verified mentally: $|1/2 - 1| = 1/2 > 1/99$
- [x] No new axioms added (parent OQ-04 axiom is *refuted*, not removed)
- [ ] CI build of the whole gallery (will run on merge)
- [ ] Future S2: discharge the deferred `analytic_taylor_remainder_uniform_bound_complex` via the documented Mathlib chain (~100-200 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)