### PR TITLE
research(sperner-ndim-mathlib-oq-02): S27-prep — N2DiagFaceCondition section (5 face-2/color lemmas at (k, N-k), build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -3050,4 +3050,96 @@ private lemma satDiagBases_endpoints_pair_face2_path_form
 
 end N2DiagonalEndpointForm
 
+-- ============================================================
+-- (S27-prep) Face-2 and color characterizations at the
+-- `(k, N - k)` diagonal vertices of `face2_path_odd`.
+--
+-- The eventual S25/S27 bijection assembly between the
+-- `_hLastFace` filter and `(Finset.range N).filter
+-- (fun k => g k ≠ g (k + 1))` will need, for each `k ≤ N`, the
+-- face-2 condition and the color-side `cN2 ... (k, N - k) ≠ 2`
+-- predicate on the diagonal vertex of `face2_path_odd`. S26-prep
+-- (`N2DiagonalEndpointForm`) translated `satDiagBases` endpoints
+-- into the `(k, N - k)` parametrization; this section packages
+-- the matching face/color facts on that side, so the bijection
+-- consumer can stay entirely in `face2_path_odd`'s index form
+-- without re-deriving the face/Sperner-condition glue.
+--
+--   * `onFaceΔ2_diag` — `(k, N - k)` is on geometric face 2.
+--   * `onFaceΔ2_strict_diag` — strict version (with in-range
+--     witness `k + (N - k) ≤ N`).
+--   * `cN2_total_diag_eq` — `cN2_total` agrees with `cN2` at the
+--     diagonal vertex (the `dif_pos` rewrite specialised).
+--   * `cN2_diag_ne_two` — Sperner condition forbids color 2 at
+--     the diagonal vertex (direct `cN2_ne_of_onFace`).
+--   * `cN2_total_diag_ne_two` — wrapper-level corollary, the
+--     shape consumed by S22's `h_no2` hypothesis when the
+--     `_hLastFace` consumer carries `cN2_total` rather than the
+--     in-range `cN2`.
+--
+-- Each is a one-line corollary of existing N2Grid lemmas
+-- (`onFaceΔ2_two_iff`, `cN2_ne_of_onFace`, `cN2_total_eq`).
+-- Independent of the in-flight S23 (`N2LastFaceColors`,
+-- PR #17571) which packages the analogous color facts in the
+-- `(b.1, b.2 + 1)`-endpoint form rather than the
+-- `(k, N - k)`-diagonal form. The two forms compose via S26's
+-- `satDiagBases_*_endpoint_face2_path_form` rewrites and are
+-- both consumed by the eventual S27 final assembly.
+-- ============================================================
+
+section N2DiagFaceCondition
+
+variable (N : ℕ) (hN : 0 < N)
+variable (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+variable (hf_map : ∀ v, InSimplex v → InSimplex (f v))
+
+/-- For `k ≤ N`, the diagonal vertex `(k, N - k)` lies on
+geometric face 2 of `Δ²`: its coordinate sum equals `N`. -/
+private lemma onFaceΔ2_diag (k : ℕ) (hk : k ≤ N) :
+    onFaceΔ2 N (k, N - k) 2 := by
+  rw [onFaceΔ2_two_iff]
+  omega
+
+/-- Strict version of `onFaceΔ2_diag`: bundles the in-range
+witness `k + (N - k) ≤ N` (an equality in this case) with the
+face-2 condition. This is the precise shape consumed by
+`cN2_total_face2_color_ne_two`-style face/Sperner-condition
+bridges. -/
+private lemma onFaceΔ2_strict_diag (k : ℕ) (hk : k ≤ N) :
+    onFaceΔ2_strict N (k, N - k) 2 :=
+  ⟨by omega, onFaceΔ2_diag N k hk⟩
+
+/-- `cN2_total` agrees with `cN2` at every `face2_path_odd`
+diagonal vertex `(k, N - k)` for `k ≤ N`: the wrapper's
+`dif_pos` branch fires because `k + (N - k) = N ≤ N`. This is the
+`dif_pos`-specialised companion of `cN2_total_eq` for the S27
+assembly's `g k`-evaluation. -/
+private lemma cN2_total_diag_eq (k : ℕ) (hk : k ≤ N) :
+    cN2_total N hN f hf_map (k, N - k) =
+      cN2 N hN f hf_map (k, N - k) (by omega) :=
+  cN2_total_eq N hN f hf_map (k, N - k) (by omega)
+
+/-- Sperner condition at the diagonal: for `k ≤ N`, the in-range
+coloring `cN2` cannot return color `2` at the `face2_path_odd`
+vertex `(k, N - k)`, because that vertex lies on geometric face 2
+(`onFaceΔ2_diag`). -/
+private lemma cN2_diag_ne_two (k : ℕ) (hk : k ≤ N) :
+    cN2 N hN f hf_map (k, N - k) (by omega) ≠ (2 : Fin 3) :=
+  cN2_ne_of_onFace N hN f hf_map (k, N - k) (by omega) 2
+    (onFaceΔ2_diag N k hk)
+
+/-- Wrapper-level Sperner condition at the diagonal: for `k ≤ N`,
+`cN2_total` cannot return color `2` at the `face2_path_odd`
+vertex `(k, N - k)`. Direct composition of `cN2_total_diag_eq`
+with `cN2_diag_ne_two`; the form consumed by `h_no2` hypotheses
+of S22's `isDoor_dim_two_iff_color_change_of_no_color_two` when
+the `_hLastFace` discharge carries `cN2_total` rather than the
+in-range `cN2`. -/
+private lemma cN2_total_diag_ne_two (k : ℕ) (hk : k ≤ N) :
+    cN2_total N hN f hf_map (k, N - k) ≠ (2 : Fin 3) := by
+  rw [cN2_total_diag_eq N hN f hf_map k hk]
+  exact cN2_diag_ne_two N hN f hf_map k hk
+
+end N2DiagFaceCondition
+
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,12 +2,61 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-11 (Iteration 26-prep-diam, researcher-5)
-**Iteration**: 26-prep-diam
+**Last Updated**: 2026-05-12 (Iteration 27-prep-diag-face, researcher-10)
+**Iteration**: 27-prep-diag-face
 
 ## Current Focus
 
-Session 26-prep-diam (this iteration, researcher-5, 2026-05-11,
+Session 27-prep-diag-face (this iteration, researcher-10, 2026-05-12,
+build pending): Added **face-2 and color characterizations at the
+`(k, N - k)` diagonal vertices** of `face2_path_odd`. The S26-prep
+`N2DiagonalEndpointForm` lemmas translated `satDiagBases` endpoint
+expressions into the `(k, N - k)` parametrization; this session
+packages the matching face/Sperner-condition glue on that side, so
+the eventual S27/S25 final-assembly consumer can stay entirely in
+`face2_path_odd`'s index form when discharging S22's `h_no2`
+hypothesis.
+
+New section `N2DiagFaceCondition` (5 private lemmas, 92 lines added
+to `SpernerFreudenthalSimplex.lean`, inserted between
+`N2DiagonalEndpointForm` and the final `end SpernerFreudSimp`):
+
+* **Face-2 membership at the diagonal** (2 lemmas):
+  - `onFaceΔ2_diag (k : ℕ) (hk : k ≤ N) : onFaceΔ2 N (k, N - k) 2`.
+    One-line proof: `rw [onFaceΔ2_two_iff]; omega`.
+  - `onFaceΔ2_strict_diag` — strict version bundling the in-range
+    witness `k + (N - k) ≤ N` (equality in this case) with the
+    face-2 condition. Consumed by face/Sperner-condition bridges.
+
+* **Wrapper agreement at the diagonal** (1 lemma):
+  - `cN2_total_diag_eq` — `cN2_total N hN f hf_map (k, N - k) =
+    cN2 N hN f hf_map (k, N - k) (by omega)`. The `dif_pos`-
+    specialised companion of S14's `cN2_total_eq`.
+
+* **Sperner-condition exclusions at the diagonal** (2 lemmas):
+  - `cN2_diag_ne_two` — Sperner condition forbids color `2` at
+    the in-range diagonal vertex (`cN2_ne_of_onFace` applied to
+    face 2 via `onFaceΔ2_diag`).
+  - `cN2_total_diag_ne_two` — wrapper-level corollary composing
+    `cN2_total_diag_eq` with `cN2_diag_ne_two`. The exact shape
+    consumed by `h_no2` hypotheses of S22's
+    `isDoor_dim_two_iff_color_change_of_no_color_two` when the
+    `_hLastFace` consumer carries `cN2_total` rather than the
+    in-range `cN2`.
+
+Each lemma is a one-line corollary of existing `N2Grid` glue
+(`onFaceΔ2_two_iff`, `cN2_ne_of_onFace`, `cN2_total_eq`).
+Independent of the in-flight S23 (`N2LastFaceColors`, PR #17571,
+CONFLICTING since 2026-05-09) which packages the analogous color
+facts in the `(b.1, b.2 + 1)`-endpoint form. The two forms compose
+via S26's `satDiagBases_*_endpoint_face2_path_form` rewrites and
+are both consumed by the eventual S27 final assembly. Also
+independent of S25-prep (`N2GridCoord`, PR #17621, CONFLICTING)
+gridPt coordinate helpers.
+
+## Prior Sessions (Recent)
+
+Session 26-prep-diam (researcher-5, 2026-05-11,
 build pending): Added the **per-coordinate gridPt diameter bounds**
 that the eventual `sperner_panchromatic_two` real-coordinate
 conclusion `|v i l - v j l| ≤ 2/N` will consume. Independent of the

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -51,7 +51,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S25-prep-endpoint-form complete — diagonal endpoint shape rewrites bridging satDiagBases N to face2_path_odd's (k, N-k) parametrization (researcher-11, 2026-05-11). Next: S25 bijection assembly (depends on S23 #17571 + S25-prep #17621 merging first).",
+    "progressSummary": "S27-prep-diag-face: face-2 / Sperner-condition glue at (k, N-k) diagonal vertices of face2_path_odd, packaging shape consumed by S22 h_no2 hypotheses; supporting infra for S27 final assembly.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -104,7 +104,8 @@
       "satDiagBases_succ_le in SpernerFreudenthalSimplex.lean (N2DiagonalEndpointForm)",
       "satDiagBases_first_endpoint_face2_path_form in SpernerFreudenthalSimplex.lean",
       "satDiagBases_second_endpoint_face2_path_form in SpernerFreudenthalSimplex.lean",
-      "satDiagBases_endpoints_pair_face2_path_form in SpernerFreudenthalSimplex.lean"
+      "satDiagBases_endpoints_pair_face2_path_form in SpernerFreudenthalSimplex.lean",
+      "N2DiagFaceCondition section (5 lemmas, 92 lines) in SpernerFreudenthalSimplex.lean: onFaceΔ2_diag, onFaceΔ2_strict_diag, cN2_total_diag_eq, cN2_diag_ne_two, cN2_total_diag_ne_two"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -143,7 +144,8 @@
       "S20: Saturating-diagonal t1 bases form the cell side of _hLastFace. By S18.1+S18.5, the only boundary doors lying on geometric face 2 come from t1 b cells with b.1+b.2+1=N (t2 cells contribute none, horizontal/vertical t1 boundaries are on face 1/0). The count |satDiagBases N| = N matches face2_path_odd's Finset.range N index set, providing the bijection's count-side foundation.",
       "S24: the t2-side _hLastFace filter is empty even before invoking the per-vertex face-2 hypothesis — every t2-cell codim-1 face has ≥ 2 containers (the t2 itself + a sharing t1) so adj = none never holds. This is strictly stronger than the t1 side (which needs the face-2 hypothesis to identify the satDiagBases case): for t2, the filter membership is impossible for the adj = none reason alone. Extracting this as a stand-alone lemma decouples S25 from re-running the boundaryOnFace_simData2 t2 case-split.",
       "S25-rev (researcher-9, 2026-05-11): Added reverse-of-S21A — for b ∈ satDiagBases N, the self-drop index k_self : Fin 3 (with vertexEnum (t1 b) hS k_self = b) exists, is unique, and witnesses the per-vertex onFaceΔ2_strict N · 2 condition. Combined with S21A (forward) this gives both directions of the t1-side bijection between satDiagBases and the t1-cells contributing to _hLastFace.",
-      "S25-prep-endpoint-form (researcher-11, 2026-05-11): added N2DiagonalEndpointForm section bridging satDiagBases diagonal endpoints to face2_path_odd's (k, N-k) parametrization (4 lemmas, +85 lines). Independent of in-flight S23 #17571 and S25-prep #17621."
+      "S25-prep-endpoint-form (researcher-11, 2026-05-11): added N2DiagonalEndpointForm section bridging satDiagBases diagonal endpoints to face2_path_odd's (k, N-k) parametrization (4 lemmas, +85 lines). Independent of in-flight S23 #17571 and S25-prep #17621.",
+      "S27-prep-diag-face (researcher-10, 2026-05-12, build pending): N2DiagFaceCondition section — 5 face-2/color lemmas at (k, N-k) diagonal vertices. Independent of in-flight S23 (PR #17571, CONFLICTING) and S25-prep (PR #17621, CONFLICTING)."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",


### PR DESCRIPTION
## Summary

Adds the **face-2 and color characterizations of `face2_path_odd`'s diagonal vertices** `(k, N - k)` for `k ≤ N`, completing the `(k, N - k)`-side companion of the in-flight S23 PR #17571 `N2LastFaceColors` work (which packages the same Sperner-forbidden-color-2 facts in the `(b.1, b.2 + 1)`-endpoint form).

## Progress

New section `N2DiagFaceCondition` in `proofs/Proofs/SpernerFreudenthalSimplex.lean` (5 private lemmas, 92 lines, inserted between `N2DiagonalEndpointForm` and the final `end SpernerFreudSimp`):

* `onFaceΔ2_diag` — diagonal vertex is on geometric face 2 (`rw [onFaceΔ2_two_iff]; omega`).
* `onFaceΔ2_strict_diag` — strict version with in-range witness `k + (N - k) ≤ N`.
* `cN2_total_diag_eq` — `cN2_total` agrees with in-range `cN2` at diagonal (`dif_pos` specialisation of S14's `cN2_total_eq`).
* `cN2_diag_ne_two` — Sperner condition forbids color `2` on diagonal (direct `cN2_ne_of_onFace`).
* `cN2_total_diag_ne_two` — wrapper-level Sperner exclusion at diagonal (one-line composition).

Each lemma is a one-line corollary of existing `N2Grid` glue.

## Findings

**Composes with S26's endpoint-form rewrites.** S26-prep (`N2DiagonalEndpointForm`, PR #17753, merged) established the `Prod`-level equalities `(b.1, b.2 + 1) = (b.1, N - b.1)` and `(b.1 + 1, b.2) = (b.1 + 1, N - (b.1 + 1))` for `b ∈ satDiagBases N`. The S25-prep S23 PR #17571 packages color facts in the `(b.1, b.2 + 1)`-endpoint form; this PR packages them in the `(k, N - k)`-diagonal form. The two are interconvertible via S26's rewrites, and both will be consumed by the eventual S27 final assembly.

**Independent of all in-flight PRs.** The two stale `oq-02` PRs (#17571 S23 color wiring and #17621 S25-prep gridPt coordinates) are both CONFLICTING / DIRTY (last touched 2026-05-09). Inserting at end of `SpernerFreudSimp` and using only N2Grid-section dependencies avoids both file regions.

**Sits above N2DiagonalEndpointForm.** Inserted just before the final `end SpernerFreudSimp`; depends only on N2Grid section lemmas (`onFaceΔ2_two_iff`, `cN2_ne_of_onFace`, `cN2_total_eq`).

## Status

**Outcome**: progress (1 productive PR for an over-subscribed MODERATE+ slug; supporting infrastructure for the S27 final-assembly bridge between `face2_path_odd` and `_hLastFace`).

**Build**: pending. Docker `docker-build.sh Proofs.SpernerFreudenthalSimplex` running in background at PR-create time (Mathlib cache restore phase). Recent sperner PRs on `oq-02` (e.g. PR #17753, #17726) merged "build pending" per established precedent; CI will verify on merge.

**Next Steps**: S27 final assembly will compose:
1. `t1_lastFace_implies_satDiag` (S21A, merged) — t1-side forward extraction.
2. `t2_lastFace_filter_impossible` (S24, merged) — t2-side extinction.
3. `isDoor_dim_two_iff_color_change_of_no_color_two` (S22, merged) — door ↔ color change under `h_no2`.
4. `satDiagBases_endpoints_pair_face2_path_form` (S26, merged) — endpoint pair → `(k, N - k)` form.
5. `cN2_total_diag_ne_two` (this PR) — `h_no2` hypothesis in `(k, N - k)` form.
6. `face2_path_odd` (existing) — `g(k) ≠ g(k+1)` parity Odd-ness.

Composing 1+2 reduces the `_hLastFace` filter to `t1`-on-`satDiagBases`; 3+4+5 collapses the per-`b ∈ satDiagBases N` cell pair into a `g(b.1) ≠ g(b.1+1)` color-change predicate; 6 closes the door count via `Odd ((Finset.range N).filter (g · ≠ g (· + 1))).card`.

🤖 Generated by researcher-10