### PR TITLE
fix(meta): batch sync theoremCount drift (18 entries)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
@@ -68,7 +68,7 @@
     "assumptions": "3 axioms: kinematicMeasure (existence of kinematic measure on AffineHyperplane n), cauchy_crofton_segment (single-segment Cauchy-Crofton formula E_μ[crossing(s)] = α_n · length(s)), crossing_integrable (crossing indicator is integrable w.r.t. kinematic measure). No sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 7,
-    "theoremCount": 27
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "The Cauchy-Crofton formula is a centerpiece of integral geometry, named for Augustin-Louis Cauchy (1850) and Morgan Crofton (1868). Cauchy used measure-theoretic methods to compute surface areas via projections; Crofton applied this to compute lengths and curvatures via line intersections. The general form E[#(C ∩ H)] = c_μ · length(C) for any motion-invariant measure on hyperplanes was developed in the 20th century by Blaschke, Santaló, and others as part of kinematic integral geometry.\n\nThe abstract formulation—for any measure μ satisfying the single-segment formula—reveals that shape independence is a purely linear-algebraic consequence of the measure property, requiring no geometric structure beyond the calibration condition. The crossing factor α_n (previously studied in BuffonsNeedleOQ02OQ01.lean for the parallel-hyperplane case) appears here as the universal constant encoding the geometry of the kinematic measure in ℝⁿ.\n\nBuffon's 2D needle (α₂ = 2/π) and the 3D noodle (α₃ = 1/2) are the canonical instances. The abstract Cauchy-Crofton formula unifies these and extends to arbitrary dimensions, arbitrary motion-invariant measures, and arbitrary polygonal paths.",
@@ -218,7 +218,7 @@
     "namespace": "BuffonsNeedleOQ02OQ03",
     "lineCount": 285,
     "axiomCount": 3,
-    "theoremCount": 27,
+    "theoremCount": 18,
     "definitionCount": 7,
     "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 390,
     "assumptions": "None. All theorems fully proved including minpoly computations via UFD divisor classification and intertwining constraint extraction via Fin 4 case analysis.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 2
   },
   "overview": {
@@ -147,7 +147,7 @@
     "namespace": "SimilarCounterexample",
     "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 249,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 22,
+    "theoremCount": 20,
     "definitionCount": 1
   },
   "overview": {
@@ -163,7 +163,7 @@
     "namespace": "ChineseRemainderNonCoprimeOQ01OQ01",
     "lineCount": 249,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 20,
     "definitionCount": 1,
     "path": "Proofs/ChineseRemainderNonCoprimeOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 256,
-    "theoremCount": 27,
+    "theoremCount": 25,
     "definitionCount": 4,
     "originalContributions": [
       "collatz_no_fixpoint: collatz(n) = n implies n = 0 (no fixed points)",
@@ -161,7 +161,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 27
+    "theoremCount": 25
   },
   "sorries": 0
 }

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -39,7 +39,7 @@
     "lineCount": 256,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 27,
+    "theoremCount": 25,
     "definitionCount": 4
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 256,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 25,
     "lemmaCount": 0,
     "imports": [
       "Mathlib.Tactic"

--- a/src/data/proofs/collatz-structured/meta.json
+++ b/src/data/proofs/collatz-structured/meta.json
@@ -34,7 +34,7 @@
     "lineCount": 207,
     "assumptions": "1 axiom: collatz_conjecture. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 18,
+    "theoremCount": 16,
     "definitionCount": 4
   },
   "overview": {
@@ -168,7 +168,7 @@
     "namespace": "Collatz",
     "lineCount": 207,
     "axiomCount": 1,
-    "theoremCount": 18,
+    "theoremCount": 16,
     "definitionCount": 4,
     "path": "Proofs/CollatzStructured.lean",
     "sorries": 0

--- a/src/data/proofs/combinations-formula-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 750,
-    "theoremCount": 31,
+    "theoremCount": 24,
     "assumptions": "None. All 31 theorems proved over arbitrary commutative rings with parameter q : R. No invertibility hypotheses; the division-free q-Pascal recurrence is used as the definition.",
     "mathlibDependencies": [
       {
@@ -206,7 +206,7 @@
     "namespace": "QBinomialCoefficients",
     "lineCount": 750,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 24,
     "definitionCount": 3,
     "mainTheorems": [
       {

--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -47,7 +47,7 @@
     "lineCount": 400,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 2
   },
   "overview": {
@@ -129,7 +129,7 @@
     "namespace": "CombinationsFormula",
     "lineCount": 400,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 2,
     "path": "Proofs/CombinationsFormula.lean",
     "sorries": 0

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
@@ -44,7 +44,7 @@
       "Proved cramer_denom_qdet: denominator in Cramer equals the quasideterminant minor",
       "Proved qdet3_recurrence_summary: the complete recurrence theorem in one conjunction"
     ],
-    "theoremCount": 30,
+    "theoremCount": 18,
     "definitionCount": 4
   },
   "sections": [
@@ -154,7 +154,7 @@
     "namespace": "CramersRuleOQ01OQ02OQ01",
     "lineCount": 313,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 18,
     "definitionCount": 4,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -35,7 +35,7 @@
       "Proved quasideterminants equal det(A)/entry in the commutative case",
       "Proved proportionality: qdet00 * a11 = a00 * qdet11 over commutative fields"
     ],
-    "theoremCount": 32,
+    "theoremCount": 26,
     "definitionCount": 6
   },
   "sections": [
@@ -157,7 +157,7 @@
     "namespace": "CramersRuleOQ01OQ02",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 26,
     "definitionCount": 6,
     "path": "Proofs/CramersRuleOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 600,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 12
   },
   "overview": {
@@ -196,7 +196,7 @@
     "namespace": "SternBrocot",
     "lineCount": 600,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 30,
     "definitionCount": 12,
     "path": "Proofs/DenumerabilityRationalsOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -34,7 +34,7 @@
         "relationship": "OQ-02-OQ-01 proves Budan's building blocks; Sturm's exact count goes further, using GCD-based sequences instead of derivative towers."
       }
     ],
-    "theoremCount": 28,
+    "theoremCount": 26,
     "definitionCount": 6
   },
   "overview": {
@@ -53,7 +53,7 @@
     "namespace": "SturmTheorem",
     "lineCount": 458,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 26,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -30,7 +30,7 @@
         "relationship": "Proves the budan_upper_bound_axiom from OQ-02"
       }
     ],
-    "theoremCount": 9,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "overview": {
@@ -49,7 +49,7 @@
     "namespace": "BudanUpperBound",
     "lineCount": 239,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 6,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -48,7 +48,7 @@
     "dateAdded": "2026-04-03",
     "axiomCount": 1,
     "lineCount": 328,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 5
   },
   "overview": {
@@ -145,7 +145,7 @@
     "namespace": "DissectionOfCubesOQ01OQ01",
     "lineCount": 328,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -43,7 +43,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Note: `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` (line 55-56) is a stub placeholder definition — not an axiom declaration or structure-encoded assumption. Dehn’s theorem is taken as an explicit hypothesis in `hilbert_third_problem`, not as an axiom declaration. The core number-theoretic result (arccos(1/3)/π is irrational via Chebyshev recurrence) is fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 18,
     "definitionCount": 7
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "DissectionOfCubesOQ02",
     "lineCount": 379,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 18,
     "definitionCount": 7,
     "opens": [
       "Real"

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 2,
     "lineCount": 239,
     "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C²-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs.",
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 15
   },
   "overview": {
@@ -236,7 +236,7 @@
     "namespace": null,
     "lineCount": 239,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 15,
     "path": "Proofs/Erdos1009Problem.lean",
     "sorries": 0

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 10,
     "assumptions": "hurwitz_euclidean: For any Hurwitz quaternions a and nonzero b, there exist q, r ∈ H with a = b·q + r and N(r) < N(b). This Euclidean property requires the covering radius argument from algebraic topology to prove fully.",
     "originalContributions": [
@@ -31,7 +31,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 10
   },
   "overview": {

--- a/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 453,
     "assumptions": "1 axiom: two_points_determine_chord. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 21
   },
   "sections": [
@@ -158,7 +158,7 @@
     "namespace": "BeltramiKlein",
     "lineCount": 453,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 17,
     "definitionCount": 21,
     "path": "Proofs/ParallelPostulateIndependenceOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` values in 18 `meta.json` files where both `meta.theoremCount` and `leanFile.theoremCount` exceed the actual count of `^theorem`/`^lemma` declarations in the underlying Lean file.

All three counting conventions agree on the actual count for every entry:
- strict (`^theorem|^lemma`)
- modifier-permissive (`^(private|protected|noncomputable)? (theorem|lemma)`)
- raw (no comment-stripping)

So this is unambiguous post-refactor drift, not a counting-convention disagreement.

## Evidence

Each diff is exactly **2 lines per file** (one inside `meta` sub-object, one inside the top-level `leanFile` sub-object). No `additionalFiles`, no other count fields, no JSON re-format.

| Slug | claimed | actual | delta |
|---|---|---|---|
| buffons-needle-oq-02-oq-03 | 27 | 18 | -9 |
| cayley-hamilton-minpoly-oq-02-oq-02 | 16 | 14 | -2 |
| chinese-remainder-non-coprime-oq-01-oq-01 | 22 | 20 | -2 |
| collatz-cycles | 27 | 25 | -2 |
| collatz-structured | 18 | 16 | -2 |
| collatz-structured-oq-02 | 27 | 25 | -2 |
| combinations-formula | 26 | 25 | -1 |
| combinations-formula-oq-03 | 31 | 24 | -7 |
| cramers-rule-oq-01-oq-02 | 32 | 26 | -6 |
| cramers-rule-oq-01-oq-02-oq-01 | 30 | 18 | -12 |
| denumerability-rationals-oq-03 | 31 | 30 | -1 |
| descartes-rule-of-signs-oq-02-oq-01 | 9 | 6 | -3 |
| descartes-rule-of-signs-oq-02-oq-01-oq-02 | 28 | 26 | -2 |
| dissection-of-cubes-oq-01-oq-01 | 29 | 26 | -3 |
| dissection-of-cubes-oq-02 | 20 | 18 | -2 |
| erdos-1009 | 7 | 5 | -2 |
| fermat-two-squares-oq-01-oq-03 | 18 | 15 | -3 |
| parallel-postulate-independence-oq-02 | 19 | 17 | -2 |

## Safety

All 18 slugs had **zero open PRs** at fix time (verified via `gh pr list --state=open --search=<slug>`), so no merge-conflict risk with in-flight research/enricher work.

---
Automated batch repair by lean-mechanic agent.