### PR TITLE
research(erdos-101-oq-01): S3 — discharge erdos_three_halves_conjecture_refuted (build pending)

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -314,12 +314,70 @@ This corollary follows from `solymosi_stojakovic_lower_bound` together
 with the elementary asymptotic
 $2 - C / \sqrt{\log n} > 3/2$ for sufficiently large $n$.
 
-The corollary is recorded as `theorem ... := by sorry`; discharging it
-in a follow-up iteration is a real-analysis exercise that does not
-require the construction itself. -/
+**S3 (this iteration)**: discharge.  Specialise the lower bound to
+$C = 1/2$.  For $m \geq 3$, $\log m > 1$ (since $m > e$, using
+`Real.exp_one_lt_d9 : \exp 1 < 2.7182818286 < 3`), so
+$\sqrt{\log m} > 1$, hence $\tfrac{1/2}{\sqrt{\log m}} < 1/2$ and
+$2 - \tfrac{1/2}{\sqrt{\log m}} > 3/2$.  The strict monotonicity of
+`Real.rpow` in its exponent (for base $> 1$) then yields
+$m^{2 - 1/(2\sqrt{\log m})} > m^{3/2}$, which contradicts the
+hypothesised $m^{3/2}$ upper bound on the four-point line count of
+the Solymosi–Stojaković witness set. -/
 theorem erdos_three_halves_conjecture_refuted :
     ¬ (∃ N : ℕ, ∀ (P : PlanarPointSet), NoFiveCollinear P → N ≤ P.points.card →
         (fourPointLineCount P : ℝ) ≤ (P.points.card : ℝ) ^ (3 / 2 : ℝ)) := by
-  sorry
+  rintro ⟨N₀, hN₀⟩
+  -- Apply the Solymosi–Stojaković lower bound with `C = 1/2`.
+  obtain ⟨N₁, hN₁⟩ :=
+    solymosi_stojakovic_lower_bound (1 / 2 : ℝ) (by norm_num)
+  -- Pick a single $m$ that simultaneously beats `N₀`, `N₁`, and `3`.
+  set m : ℕ := max N₀ (max N₁ 3) with hm_def
+  have hm_N₀ : N₀ ≤ m := le_max_left _ _
+  have hm_N₁ : N₁ ≤ m :=
+    (le_max_left N₁ 3).trans (le_max_right _ _)
+  have hm_three : (3 : ℕ) ≤ m :=
+    (le_max_right N₁ 3).trans (le_max_right _ _)
+  -- Solymosi–Stojaković witness at size `m`.
+  obtain ⟨P, hcard, hP_no5, hP_lb⟩ := hN₁ m hm_N₁
+  -- Hypothesised $m^{3/2}$ upper bound applied to the same `P`.
+  have hP_card_ge : N₀ ≤ P.points.card := hcard.symm ▸ hm_N₀
+  have hP_ub : (fourPointLineCount P : ℝ) ≤
+      (P.points.card : ℝ) ^ (3 / 2 : ℝ) :=
+    hN₀ P hP_no5 hP_card_ge
+  -- Real coercions for `m`.
+  have hm_real_ge_three : (3 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm_three
+  have hm_gt_one : (1 : ℝ) < (m : ℝ) := by linarith
+  -- `Real.log m > 1` since `m ≥ 3 > exp 1`.
+  have h_exp_lt_three : Real.exp 1 < (3 : ℝ) := by
+    linarith [Real.exp_one_lt_d9]
+  have h_exp_lt_m : Real.exp 1 < (m : ℝ) := by linarith
+  have hlog_gt_one : (1 : ℝ) < Real.log (m : ℝ) := by
+    have h := Real.log_lt_log (Real.exp_pos 1) h_exp_lt_m
+    rwa [Real.log_exp] at h
+  -- `Real.sqrt (Real.log m) > 1`.
+  have hsqrt_gt_one : (1 : ℝ) < Real.sqrt (Real.log (m : ℝ)) := by
+    have h := Real.sqrt_lt_sqrt (by norm_num : (0 : ℝ) ≤ 1) hlog_gt_one
+    rwa [Real.sqrt_one] at h
+  have hsqrt_pos : (0 : ℝ) < Real.sqrt (Real.log (m : ℝ)) := by linarith
+  -- `(1/2) / sqrt (log m) < 1/2` and hence `2 - … > 3/2`.
+  have h_frac_lt_half :
+      (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) < 1 / 2 := by
+    rw [div_lt_iff hsqrt_pos]
+    nlinarith [hsqrt_gt_one]
+  have h_exp_gt :
+      (3 / 2 : ℝ) < 2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) := by
+    linarith
+  -- Strict monotonicity of `Real.rpow` in the exponent (base `> 1`).
+  have h_rpow_lt :
+      (m : ℝ) ^ (3 / 2 : ℝ) <
+        (m : ℝ) ^ (2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ))) :=
+    Real.rpow_lt_rpow_of_exponent_lt hm_gt_one h_exp_gt
+  -- Rewrite the hypothesised upper bound in terms of `m`.
+  have hP_ub_m : (fourPointLineCount P : ℝ) ≤ (m : ℝ) ^ (3 / 2 : ℝ) := by
+    rw [hcard] at hP_ub; exact hP_ub
+  -- The Solymosi–Stojaković lower bound is already phrased in `m`.
+  -- Chain: `m^(2-1/2/sqrt log m) ≤ count ≤ m^(3/2)` but
+  -- `m^(3/2) < m^(2-1/2/sqrt log m)` — contradiction.
+  linarith [hP_lb, hP_ub_m, h_rpow_lt]
 
 end Erdos101OQ01

--- a/research/problems/erdos-101-oq-01/knowledge.md
+++ b/research/problems/erdos-101-oq-01/knowledge.md
@@ -165,3 +165,105 @@ risk is in the *type signatures*: `Real.rpow`, `Real.sqrt`, and
 `(n : ℝ) ^ (real exponent)` syntax resolves to `Real.rpow` by
 inheriting the `HPow ℝ ℝ ℝ` instance from
 `Mathlib.Analysis.SpecialFunctions.Pow.Real`.
+
+## S3 (researcher-5, 2026-05-12) — Discharge of $\Theta(n^{3/2})$ refutation
+
+### S3 deliverable (this iteration)
+
+The S2 corollary `erdos_three_halves_conjecture_refuted` is no
+longer a `sorry`.  Its proof is now an elementary 50-line discharge
+from S2's `solymosi_stojakovic_lower_bound`.  No new theorems, no
+new definitions, no new imports.
+
+| Metric | Before S3 | After S3 |
+|---|---|---|
+| Sorries | 3 | 2 (main conjecture + SS construction) |
+| Theorems | 8 | 8 |
+| Definitions | 4 | 4 |
+| Axioms | 0 | 0 |
+| Line count | 325 | 383 |
+
+### Proof sketch (real-analysis arithmetic)
+
+Specialise SS to $C = 1/2$:
+
+* For $m \geq 3$, the inequality $m > e$ holds (using
+  `Real.exp_one_lt_d9 : \exp 1 < 2.7182818286`, hence $\exp 1 < 3$).
+* Therefore $\log m > 1$ (by `Real.log_lt_log` applied to
+  $\exp 1 < m$ and `Real.log_exp`).
+* Therefore $\sqrt{\log m} > 1$ (by `Real.sqrt_lt_sqrt 0 ≤ 1 < \log m`
+  and `Real.sqrt_one`).
+* Therefore $\frac{1/2}{\sqrt{\log m}} < 1/2$ (by `div_lt_iff`).
+* Therefore $2 - \frac{1/2}{\sqrt{\log m}} > 3/2$ (by `linarith`).
+* Therefore $m^{3/2} < m^{2 - (1/2)/\sqrt{\log m}}$ (by
+  `Real.rpow_lt_rpow_of_exponent_lt`, requires `1 < m`).
+
+Now combine with the SS witness $P$ at size $m \geq N_1$
+(`fourPointLineCount P \geq m^{2 - (1/2)/\sqrt{\log m}}$`) and the
+hypothesised global $m^{3/2}$ upper bound on
+`fourPointLineCount P` for $|P| \geq N_0$, taking
+$m := \max(N_0, N_1, 3)$:
+
+\[
+m^{2 - (1/2)/\sqrt{\log m}} \leq
+\text{fourPointLineCount } P \leq m^{3/2} <
+m^{2 - (1/2)/\sqrt{\log m}}.
+\]
+
+The terminal `linarith` closes the contradiction.
+
+### Mathlib API used (all in existing imports)
+
+* `Real.exp_one_lt_d9` — `Real.exp 1 < 2.7182818286`
+* `Real.exp_pos` — `0 < Real.exp x`
+* `Real.log_exp` — `Real.log (Real.exp x) = x`
+* `Real.log_lt_log` — `0 < x → x < y → Real.log x < Real.log y`
+* `Real.sqrt_one` — `Real.sqrt 1 = 1`
+* `Real.sqrt_lt_sqrt` — `0 ≤ x → x < y → Real.sqrt x < Real.sqrt y`
+* `Real.rpow_lt_rpow_of_exponent_lt` — `1 < b → x < y → b^x < b^y`
+* `div_lt_iff` — `0 < b → (a/b < c ↔ a < c * b)`
+* `le_max_left`, `le_max_right` (ℕ max ordering)
+* `exact_mod_cast`, `linarith`, `nlinarith`, `norm_num`
+
+### Why S3 is meaningful
+
+S3 fully discharges a sorry whose statement is mathematically
+substantive (the refutation of Erdős's 1980s conjecture) but whose
+proof is short.  This is the canonical "easy half" of a deferred
+proof obligation: the S2 SS bound is reused as a hypothesis, and
+only elementary real-analysis arithmetic separates that hypothesis
+from the corollary.  The file now has only two remaining sorries:
+
+1. `erdos_101_oq_01` — the OPEN conjecture itself ($\$100$ Erdős
+   prize, not a single-session result).
+2. `solymosi_stojakovic_lower_bound` — the SS construction over
+   finite fields, requiring substantial algebraic-geometry
+   infrastructure absent from Mathlib at present.
+
+Both remaining sorries are external proof obligations — neither
+admits an elementary discharge.
+
+### Confidence
+
+**High** that the new proof compiles.  Every step uses a one-line
+Mathlib API call.  The only potential pitfall is the
+`(1/2 : ℝ)` literal matching the SS theorem's `C` parameter, which
+is verified by inspection: the `1 / 2 : ℝ` and `(1 / 2 : ℝ)` forms
+in Lean 4 elaborate to the same rational literal.
+
+### S4 next-action candidates
+
+1. **`Asymptotics.IsBigO` / `IsLittleO` bridge**: convert the
+   real-valued $O(n^2)$ statement to `Asymptotics.IsBigO atTop`
+   and record the OPEN conjecture as `Asymptotics.IsLittleO atTop
+   (· ^ 2)` `sorry`.
+
+2. **Positive (constructive) form of the refutation**: rewrite
+   `erdos_three_halves_conjecture_refuted` as
+   `∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧
+   (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)`
+   (de Morgan dual of the negated existence), then unfold the
+   sorry in the OPEN main conjecture against this positive form.
+
+3. **Per-point Cauchy–Schwarz refinement** to chase a $1 - o(1)$
+   leading constant on `improved_upper_bound`'s $n(n-1)/12$.

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,81 +1,90 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S2)
-**Iteration**: 2
-**Last Updated**: 2026-05-12 (researcher-1)
+**Since**: 2026-05-12 (S3)
+**Iteration**: 3
+**Last Updated**: 2026-05-12 (researcher-5)
 
 ## Current Focus
 
-S2 (researcher-1) delivered the Solymosi–Stojaković 2013 existential
-lower bound as a `theorem ... := by sorry` together with the corollary
-that Erdős's original $\Theta(n^{3/2})$ conjecture is refuted by the
-same construction.  Both new theorems are sorry stubs — the
-construction itself uses algebraic geometry over finite fields and is
-deferred to a much later iteration.  No new axioms were introduced.
+S3 (researcher-5) discharges `erdos_three_halves_conjecture_refuted`
+from S2's `solymosi_stojakovic_lower_bound` by elementary real-analysis
+arithmetic.  The sorry count drops from 3 → 2; the file is still axiom
+free.
 
 ## Active Approach
 
-**Statement-first scaffold; small cases + recorded lower bound.**
+**Specialise SS to `C = 1/2` and use the strict monotonicity of
+`Real.rpow` in the exponent.**
 
-Following S1's "statement-first" pattern, S2 records:
-
-1. `solymosi_stojakovic_lower_bound` — $\forall C > 0, \exists N, \forall n \geq N,
-   \exists P$ with $|P| = n$, no-five-collinear, and
-   $\text{fourPointLineCount}\,P \geq n^{2 - C / \sqrt{\log n}}$. Sorry.
-2. `erdos_three_halves_conjecture_refuted` — there is no $N$ such that
-   every no-five-collinear $P$ with $|P| \geq N$ satisfies
-   $\text{fourPointLineCount}\,P \leq |P|^{3/2}$.  Sorry (real-analysis
-   arithmetic — discharges from (1) by $2 - C/\sqrt{\log n} > 3/2$ for
-   sufficiently large $n$).
+1. Apply `solymosi_stojakovic_lower_bound (1/2 : ℝ)` to obtain `N₁` and
+   a witness `P` for every `n ≥ N₁`.
+2. Choose `m := max N₀ (max N₁ 3)`, so the hypothesised global upper
+   bound applies at `P` of cardinality `m` and `m ≥ 3` gives the
+   asymptotic threshold.
+3. For `m ≥ 3 > Real.exp 1` (via `Real.exp_one_lt_d9`), `Real.log m > 1`,
+   so `Real.sqrt (Real.log m) > 1`, so
+   `(1/2) / Real.sqrt (Real.log m) < 1/2`, so the SS exponent
+   `2 - (1/2) / Real.sqrt (Real.log m)` strictly exceeds `3/2`.
+4. `Real.rpow_lt_rpow_of_exponent_lt hm_gt_one h_exp_gt` then gives
+   `m^(3/2) < m^(2 - (1/2)/sqrt log m)`, which combined with the
+   hypothesised `count ≤ m^(3/2)` and the SS bound
+   `m^(2 - (1/2)/sqrt log m) ≤ count` produces a contradiction by
+   `linarith`.
 
 ## Next Action
 
-S3 candidates (in order of expected value):
+S4 candidates (in order of expected value):
 
-1. **Discharge `erdos_three_halves_conjecture_refuted`.** The proof is
-   pure real-analysis arithmetic given S2's
-   `solymosi_stojakovic_lower_bound`: pick $C = 1/2$ (or any
-   $C > 0$), find $N$ with $2 - C/\sqrt{\log n} > 3/2$ for $n \geq N$,
-   then derive the contradiction.  Estimated 30–60 lines of
-   `Real.rpow_lt_rpow` + `Real.log_pos` manipulation.
+1. **`Asymptotics.IsBigO` / `IsLittleO` bridge.** Define
+   `maxFourPointLines : ℕ → ℕ` via `Finset.sup'` or `Set.Sup` over the
+   (finite-by-Mathlib-decidable-equality) set of no-five-collinear
+   sets of fixed size at most `n`.  Convert
+   `fourPointLineCount_le_quadratic` into a `Asymptotics.IsBigO ⟨atTop⟩`
+   statement against `n^2`, and record the OPEN conjecture as the
+   `Asymptotics.IsLittleO` form `sorry`.  Bridge to the existing
+   `IsLittleOh_n_squared` definition by direct unfolding.
 
-2. **`Asymptotics.IsBigO` / `IsLittleO` bridge.** Show
-   `(fun n => maxFourPointLines n) =O[atTop] (· ^ 2)` from the
-   real-valued $n^2/12$ bound; record the conjecture as
-   `=o[atTop] (· ^ 2)` `sorry`.  Requires defining
-   `maxFourPointLines : ℕ → ℕ` via `Finset.sup'` or `Set.Sup`.
+2. **Refute Erdős's $\Theta(n^{3/2})$ via `Real.rpow` lower-bound
+   formalisation**: extend the S3 refutation to a positive
+   strict-inequality statement `∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P|
+   ∧ (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)`.
+   This is the "constructive" (rather than negated-existence) form of
+   the same fact and is a one-step rephrasing of the S3 proof.
 
-3. **Investigate per-point Cauchy–Schwarz refinements.** The parent
-   file's `fourCollinearThrough_bound` $\leq (n-1)/3$ combined with
-   second-moment double counting may give a $1 - o(1)$ leading
-   constant on the $n^2/12$ elementary bound.  Not $o(n^2)$, but a
-   concrete *improvement on a non-trivial constant* would be the
-   first sub-elementary upper bound.
+3. **Cauchy–Schwarz refinement** of `fourCollinearThrough_bound`
+   $\leq (n-1)/3$ to potentially yield a $1 - o(1)$ leading constant
+   on the elementary $n^2/12$ bound (not $o(n^2)$, but a real
+   improvement on the constant).
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (S2 lower-bound recording)
-- Approaches tried: 1 (S1 scaffold, S2 lower-bound recording —
-  same statement-first approach extended)
+- Total attempts: 3
+- Current approach attempts: 1 (S3 discharge of refutation corollary)
+- Approaches tried: 2 (S1 scaffold + S2 lower-bound recording;
+  S3 elementary real-analysis discharge)
 
 ## Build Status
 
-S2 build: PENDING.  New imports
-(`Mathlib.Analysis.SpecialFunctions.Pow.Real`,
-`Mathlib.Analysis.SpecialFunctions.Log.Basic`,
-`Mathlib.Analysis.SpecialFunctions.Sqrt`) provide `Real.rpow`,
-`Real.log`, `Real.sqrt` used in the lower-bound statement.  CI is
-ground truth.
+S3 build: **PENDING** (Docker not available in worktree;
+`proofs/.lake` is a self-symlink and CI is ground truth).  S3
+introduces *no new imports* — all required Mathlib API
+(`Real.exp_one_lt_d9`, `Real.exp_pos`, `Real.log_exp`,
+`Real.log_lt_log`, `Real.sqrt_one`, `Real.sqrt_lt_sqrt`,
+`Real.rpow_lt_rpow_of_exponent_lt`, `div_lt_iff`) is already in
+the S2 import set and is exercised by other gallery files
+(see e.g. `Erdos1039Problem.lean`, `Erdos1201Problem.lean`,
+`BinomialTheoremOQ03OQ02OQ03.lean`).
 
-S2 risk profile:
-* 2 new theorems, both `theorem ... := by sorry` — no proof tactics
-  to fail on.
-* 3 new Mathlib imports are well-established modules.
-* No changes to existing theorems or definitions.
+S3 risk profile:
+* One discharge, no new theorem statements — the existing
+  `erdos_three_halves_conjecture_refuted` is unchanged.
+* The proof uses only well-established Mathlib API.
+* The single tricky cast is `(m : ℕ) → (m : ℝ)`: handled by
+  `exact_mod_cast hm_three : (3 : ℝ) ≤ (m : ℝ)`.
 
 ## Blockers
 
-None for S2 (statement-only).  Closing the OPEN conjecture is itself a
-$\$100$ Erdős prize-level result and not a single-session goal.
+None for S3.  The remaining OPEN content is the main conjecture
+`erdos_101_oq_01` (a $\$100$ Erdős prize) and the SS construction
+itself (algebraic geometry over finite fields, deferred).

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -18,14 +18,14 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "sourceUrl": "https://erdosproblems.com/101",
     "erdosUrl": "https://erdosproblems.com/101",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 325,
-    "assumptions": "3 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred); (3) erdos_three_halves_conjecture_refuted (corollary that Erdős's original $\\Theta(n^{3/2})$ upper bound is refuted, follows from the lower bound by elementary real-analysis arithmetic). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
+    "lineCount": 383,
+    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 4,
@@ -82,11 +82,11 @@
     },
     {
       "id": "solymosi-stojakovic",
-      "title": "S2: Solymosi–Stojaković Lower Bound + Refutation of $\\Theta(n^{3/2})$",
+      "title": "S2/S3: Solymosi–Stojaković Lower Bound + Refutation of $\\Theta(n^{3/2})$",
       "startLine": 265,
-      "endLine": 323,
-      "summary": "Records the Solymosi–Stojaković 2013 existential lower bound `solymosi_stojakovic_lower_bound` ($\\forall C > 0, \\exists N, \\forall n \\geq N, \\exists P$ with $|P| = n$, no-five-collinear, and $\\text{fourPointLineCount}\\,P \\geq n^{2-C/\\sqrt{\\log n}}$) as a `theorem ... := by sorry` (construction deferred, statement registered). Adds the corollary `erdos_three_halves_conjecture_refuted` recording that no global $O(n^{3/2})$ upper bound exists, also as a sorry to be discharged by elementary real-analysis arithmetic.",
-      "mathContext": "$\\Omega(n^{2-O(1/\\sqrt{\\log n})}) > \\Omega(n^{3/2})$ for large $n$; the Solymosi–Stojaković construction over finite fields realises this asymptotic. Recorded as `theorem ... := by sorry` rather than `axiom` to keep the file axiom-free."
+      "endLine": 381,
+      "summary": "Records the Solymosi–Stojaković 2013 existential lower bound `solymosi_stojakovic_lower_bound` ($\\forall C > 0, \\exists N, \\forall n \\geq N, \\exists P$ with $|P| = n$, no-five-collinear, and $\\text{fourPointLineCount}\\,P \\geq n^{2-C/\\sqrt{\\log n}}$) as a `theorem ... := by sorry` (construction deferred, statement registered). The corollary `erdos_three_halves_conjecture_refuted` (no global $O(n^{3/2})$ upper bound exists) is fully discharged in S3 from the lower bound via elementary real-analysis arithmetic: specialise $C = 1/2$, use $\\exp 1 < 3 \\leq m$ to get $\\log m > 1$, hence $\\sqrt{\\log m} > 1$, hence $2 - 1/(2\\sqrt{\\log m}) > 3/2$, then `Real.rpow_lt_rpow_of_exponent_lt`.",
+      "mathContext": "$\\Omega(n^{2-O(1/\\sqrt{\\log n})}) > \\Omega(n^{3/2})$ for large $n$; the Solymosi–Stojaković construction over finite fields realises this asymptotic. S3 separates the easy half (refutation from the lower bound) from the hard half (the construction itself, deferred). Recorded as `theorem ... := by sorry` rather than `axiom` to keep the file axiom-free."
     }
   ],
   "overview": {
@@ -129,12 +129,12 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 325,
+    "lineCount": 383,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 4,
     "path": "Proofs/Erdos101OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-101-oq-01.json
+++ b/src/data/research/problems/erdos-101-oq-01.json
@@ -8,7 +8,7 @@
   "significance": 7,
   "tractability": 5,
   "started": "2026-05-11T19:00:00Z",
-  "lastUpdate": "2026-05-12T03:40:00Z",
+  "lastUpdate": "2026-05-12T05:00:00Z",
   "problemStatement": {
     "formal": "\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P : \\text{PlanarPointSet},\\ \\text{NoFiveCollinear}\\ P \\land N \\leq |P| \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2",
     "plain": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the number of lines containing exactly four points $o(n^2)$? Best known: $O(n^2)$ upper (trivial), $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower (Solymosi–Stojaković).",
@@ -27,26 +27,26 @@
       "$\\text{fourPointLineCount}(P) \\leq |P|^2/12$ (this file, BoundsAtRate instance)"
     ],
     "open": [
-      "$o(n^2)$ upper bound — this is the OQ-01 conjecture (1 sorry in Erdos101OQ01.lean).",
-      "Solymosi–Stojaković lower-bound formalisation — deferred to S2."
+      "$o(n^2)$ upper bound — this is the OQ-01 conjecture (1 sorry on `erdos_101_oq_01` in Erdos101OQ01.lean).",
+      "Solymosi–Stojaković lower-bound formalisation — 1 sorry on the existential statement (construction over finite fields deferred)."
     ],
     "goal": "Prove $\\text{fourPointLineCount}(P) = o(|P|^2)$ for all `NoFiveCollinear P`, or sharpen the bound to an explicit subquadratic rate."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T03:40:00Z",
-    "iteration": 2,
-    "focus": "S2: Solymosi–Stojaković 2013 existential lower bound recorded as a `theorem ... := by sorry`, plus the corollary refuting Erdős's $\\Theta(n^{3/2})$ conjecture. No new axioms (both new theorems are deferred proof obligations).",
+    "since": "2026-05-12T05:00:00Z",
+    "iteration": 3,
+    "focus": "S3: discharged S2's corollary `erdos_three_halves_conjecture_refuted` from the Solymosi–Stojaković lower bound via elementary real-analysis arithmetic. Sorry count drops 3 → 2. Specialise $C = 1/2$, use `Real.exp_one_lt_d9` to obtain $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`.",
     "blockers": [],
-    "nextAction": "S3 candidates: (1) discharge `erdos_three_halves_conjecture_refuted` from `solymosi_stojakovic_lower_bound` by elementary real-analysis arithmetic (~30–60 lines); (2) connect `fourPointLineCount_le_quadratic` to `Asymptotics.IsBigO`/`IsLittleO`; (3) Cauchy–Schwarz refinement of `fourCollinearThrough_bound` for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound.",
+    "nextAction": "S4 candidates: (1) `Asymptotics.IsBigO`/`IsLittleO` bridge — define `maxFourPointLines : ℕ → ℕ`, convert `fourPointLineCount_le_quadratic` to a `Filter.IsBigO atTop` statement; (2) positive (constructive) form of the refutation as `∀ N, ∃ P, … (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)`; (3) Cauchy–Schwarz refinement of `fourCollinearThrough_bound` for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. S2 (researcher-1, 2026-05-12) — ACT: Solymosi–Stojaković 2013 existential lower bound recorded as `theorem solymosi_stojakovic_lower_bound := by sorry`, plus the corollary `erdos_three_halves_conjecture_refuted` (also sorry). No new axioms (both deferred proof obligations). File grows 253 → 325 lines, 6 → 8 theorems, 4 defs unchanged, 0 → 0 axioms, 1 → 3 sorries.",
+    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. S2 (researcher-1, 2026-05-12) — ACT: Solymosi–Stojaković 2013 existential lower bound recorded as `theorem solymosi_stojakovic_lower_bound := by sorry`, plus the corollary `erdos_three_halves_conjecture_refuted` (also sorry). No new axioms. S3 (researcher-5, 2026-05-12) — ACT: discharged `erdos_three_halves_conjecture_refuted` from S2's lower bound via elementary real-analysis arithmetic (50-line proof, no new theorems, no new definitions, no new imports). File grows 325 → 383 lines; sorries 3 → 2; axioms unchanged at 0; theorems unchanged at 8.",
     "builtItems": [
       "proofs/Proofs/Erdos101OQ01.lean: IsLittleOh_n_squared (def)",
       "proofs/Proofs/Erdos101OQ01.lean: BoundsAtRate (def)",
@@ -60,8 +60,8 @@
       "proofs/Proofs/Erdos101OQ01.lean: bounds_at_rate_quadratic_over_twelve (rate $n^2/12$)",
       "src/data/proofs/erdos-101-oq-01/: gallery entry (meta + 6 annotations + index.ts)",
       "research/problems/erdos-101-oq-01/: problem.md + knowledge.md + state.md",
-      "proofs/Proofs/Erdos101OQ01.lean: solymosi_stojakovic_lower_bound (theorem stub, S2, sorry)",
-      "proofs/Proofs/Erdos101OQ01.lean: erdos_three_halves_conjecture_refuted (theorem stub, S2, sorry)"
+      "proofs/Proofs/Erdos101OQ01.lean: solymosi_stojakovic_lower_bound (theorem stub, S2, sorry — construction deferred)",
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_three_halves_conjecture_refuted (theorem, S3, fully discharged from SS bound via real-analysis arithmetic)"
     ],
     "insights": [
       "The OQ-01 question is the precise quantitative refinement of the trivial $O(n^2)$ upper bound; the $\\Theta(n^2)$ regime is already established elementarily.",
@@ -75,9 +75,9 @@
       "Szemerédi–Trotter incidence bound not formalised in Mathlib; would be a useful prerequisite for the Solymosi–Stojaković construction."
     ],
     "nextSteps": [
-      "S3 (~30–60 lines): discharge `erdos_three_halves_conjecture_refuted` from the recorded `solymosi_stojakovic_lower_bound` by elementary real-analysis arithmetic. Picks $C = 1/2$ (or any $C > 0$), uses `Real.rpow_lt_rpow` + `Real.log_pos` + `Real.sqrt_lt_sqrt` to derive $2 - C/\\sqrt{\\log n} > 3/2$ for sufficiently large $n$, then extracts the contradiction.",
-      "S4: connect `BoundsAtRate` instances to `Asymptotics.IsBigO`/`IsLittleO` on the filter `atTop`. Requires defining `maxFourPointLines : ℕ → ℕ`.",
-      "S5: Cauchy–Schwarz refinement of `fourCollinearThrough_bound` $\\leq (n-1)/3$ for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound (still $\\Theta(n^2)$, but a concrete improvement on the constant)."
+      "S4: connect `BoundsAtRate` instances to `Asymptotics.IsBigO`/`IsLittleO` on the filter `atTop`. Requires defining `maxFourPointLines : ℕ → ℕ` (e.g., via `Finset.sup'` over the set of no-five-collinear sets of fixed size at most $n$).",
+      "S5: positive (constructive) form of the refutation — rewrite `erdos_three_halves_conjecture_refuted` as `∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)` (the de Morgan dual of the S3 negated-existence form).",
+      "S6: Cauchy–Schwarz refinement of `fourCollinearThrough_bound` $\\leq (n-1)/3$ for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound (still $\\Theta(n^2)$, but a concrete improvement on the constant)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

**S3** of the OQ-01 of Erdős Problem #101 (four-point line count is $o(n^2)$).

S2 (PR #17799, merged) introduced two new `theorem ... := by sorry`
declarations recording (1) the Solymosi–Stojaković 2013 existential
lower bound $\Omega(n^{2 - C / \sqrt{\log n}})$ and (2) the corollary
`erdos_three_halves_conjecture_refuted` (no global $O(n^{3/2})$ upper
bound).  S2 explicitly deferred discharging (2) to S3.

**This PR discharges (2)**, dropping the sorry count from 3 → 2.  No
new theorems, definitions, or imports.

## Proof sketch

Specialise SS to $C = 1/2$ and pick `m := max N₀ (max N₁ 3)`:

* For $m \geq 3$, `Real.exp_one_lt_d9 : exp 1 < 2.7182818286` gives
  $\exp 1 < 3 \leq m$, so $\log m > 1$.
* So $\sqrt{\log m} > 1$, so $\frac{1/2}{\sqrt{\log m}} < 1/2$, so
  $2 - \frac{1/2}{\sqrt{\log m}} > 3/2$.
* `Real.rpow_lt_rpow_of_exponent_lt` then gives
  $m^{3/2} < m^{2 - (1/2)/\sqrt{\log m}}$.

This contradicts the chain
$m^{2 - (1/2)/\sqrt{\log m}} \leq \text{fourPointLineCount}\,P \leq m^{3/2}$
(combining the SS lower bound with the hypothesised global $m^{3/2}$
upper bound on the SS witness set).

## File deltas

| Metric                  | Before S3 | After S3 |
| ----------------------- | --------- | -------- |
| Sorries                 | 3         | 2        |
| Theorems                | 8         | 8        |
| Definitions             | 4         | 4        |
| Axioms                  | 0         | 0        |
| `Erdos101OQ01.lean` LOC | 325       | 383      |

Remaining sorries:

1. `erdos_101_oq_01` — the OPEN main conjecture ($\$100$ Erdős prize).
2. `solymosi_stojakovic_lower_bound` — the SS construction over
   finite fields (algebraic geometry, deferred).

Both remaining sorries are external proof obligations.

## Build status — pending

Worktree's `proofs/.lake` is a recursive self-symlink and Docker isn't
available locally; CI is ground truth.  All Mathlib API used
(`Real.exp_one_lt_d9`, `Real.exp_pos`, `Real.log_exp`,
`Real.log_lt_log`, `Real.sqrt_one`, `Real.sqrt_lt_sqrt`,
`Real.rpow_lt_rpow_of_exponent_lt`, `div_lt_iff`) is exercised by
other gallery files (`Erdos1039Problem.lean`, `Erdos1201Problem.lean`,
`BinomialTheoremOQ03OQ02OQ03.lean`).

## Test plan

- [ ] CI Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ01`
- [ ] Gallery: `pnpm build` (no schema changes)
- [ ] sorries count: 2 (verified by `grep -nE '^\s*sorry$' proofs/Proofs/Erdos101OQ01.lean`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)