### PR TITLE
research(binary-gcd-oq-03-oq-02): S36 — outer-fires ⇒ inner-fires (→ direction of S28b iff, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -1947,6 +1947,74 @@ theorem hgcdSafeApply_abort_branch (a b : ℕ)
   unfold hgcdSafeApply
   rw [hgcdMatrixSafeOf_abort_branch a b hab hge]
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART XXIV: OUTER-FIRES ⇒ INNER-FIRES (Session 36, → direction of S32c)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Outer-guard fires ⇒ inner-guard fires (above threshold)
+
+    Direct contrapositive packaging of S30's
+    `hgcdMatrixSafe_inner_abort_imp_outer_fails` (PART XX):
+
+    * S30 (`inner-aborts ⇒ outer-fails`): above threshold, if the
+      inner-guard abort branch is taken (`max a b ≤ max u v`),
+      then `schonhageOuterGuardFires a b = false`.
+    * Contrapositive (`outer-fires ⇒ inner-fires`, this section):
+      above threshold, if `schonhageOuterGuardFires a b = true`,
+      then the inner-guard fires (`max u v < max a b`).
+
+    This is the **`→` direction of the S28b equivalence**
+    `schonhageOuterGuardFires_above_iff_inner_fires` referenced
+    in `s32-non-expansion-analysis.md` §6 / state.md's S32c
+    next-action item. The harder converse direction
+    (`← inner-fires ⇒ outer-fires`) is the non-expansion-bearing
+    half (= S32b deliverable, deferred per state.md), so we
+    package the easy direction separately rather than waiting for
+    both halves.
+
+    Significance. With this packaging, the iff form's `→`
+    direction can be cited as a single named theorem, without
+    re-deriving the contrapositive at each use site. Combined
+    with the S31 `_compose_branch` and S34 `_abort_branch`
+    decompositions, this completes the **outer-fires case** of
+    the case-analysis API: above threshold + outer-fires forces
+    the inner-fires hypothesis, which in turn lets one apply
+    `hgcdSafeApply_compose_branch` to unfold `hgcdSafeApply a b`
+    as the outer matrix's action on the inner column output.
+
+    Build: pure forward reasoning from S30 by `by_contra` +
+    `push_neg`; no `native_decide`, no recursion. -/
+
+/-- **Outer-guard fires ⇒ inner-guard fires** (above threshold).
+
+    Above threshold (`hab`), if the outer guard
+    `schonhageOuterGuardFires a b` returns `true`, then the inner
+    guard must have fired — i.e., the natAbs-pair `(u, v)` of
+    `M_inner.apply (a, b)` (where `M_inner := hgcdMatrixSafe
+    (a + b) (a / 2^s) (b / 2^s)`) satisfies `max u v < max a b`.
+
+    Direct contrapositive of S30's
+    `hgcdMatrixSafe_inner_abort_imp_outer_fails`: if instead
+    `max a b ≤ max u v` (inner-aborts hypothesis), S30 forces
+    `outerGuardFires = false`, contradicting `hfires`. -/
+theorem schonhageOuterGuardFires_above_imp_inner_fires {a b : ℕ}
+    (hab : ¬ max a b < hgcdThresholdSafe)
+    (hfires : schonhageOuterGuardFires a b = true) :
+    max
+      ((hgcdMatrixSafe (a + b)
+          (a / 2 ^ hgcdShiftSafe a b)
+          (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+      ((hgcdMatrixSafe (a + b)
+          (a / 2 ^ hgcdShiftSafe a b)
+          (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs
+      < max a b := by
+  by_contra hge
+  push_neg at hge
+  have hfails :=
+    hgcdMatrixSafe_inner_abort_imp_outer_fails a b hab hge
+  rw [hfails] at hfires
+  exact Bool.noConfusion hfires
+
 end HGcdSafe
 
 /-! ## Summary

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -9,66 +9,90 @@ triangular cardinality (S27, PR #17489), the inner-guard abort
 characterisation (S29 #17631 + S30 #17661), the compose-branch
 decomposition (S31, PR #17683), the algebraic refutation of the
 general non-expansion lemma (S32, PR #17720), its Lean witness
-(S33, PR #17750), and the dual abort-branch decomposition (S34,
-PR #17771) are all in place. The above-threshold behaviour of
-`hgcdMatrixSafeOf` now admits a clean two-way partition by the
-inner size-reduction guard via PART XXI (compose-branch) ⊕
-PART XXIII (abort-branch).
+(S33, PR #17750), the dual abort-branch decomposition (S34,
+PR #17771), the markdown/JSON sync (S35, PR #17785), and now the
+contrapositive packaging of S30 as the `→` direction of the S28b
+equivalence (S36, this PR) are all in place. The above-threshold
+behaviour of `hgcdMatrixSafeOf` admits a clean two-way partition
+by the inner size-reduction guard via PART XXI (compose-branch)
+⊕ PART XXIII (abort-branch), and PART XXIV (this section) closes
+the easy `→` direction of the outer-fires ↔ inner-fires
+equivalence using S30 by contrapositive.
 
 **Since**: 2026-05-01
-**Iteration**: 34 (S34 merged in PR #17771 — abort-branch decomposition theorems `hgcdMatrixSafeOf_abort_branch` and `hgcdSafeApply_abort_branch` in PART XXIII of `BinaryGcdOQ03OQ02PathA.lean`; +115 lines, 0 axioms, 0 sorries, 0 defs; build pending). This S35 PR is a markdown/JSON sync only: bumps state.md head + gallery JSON `currentState.iteration` to 34 + rewrites the stale `Next Action` section (which still described S26/S27/S28+). 0 Lean changes; 0 new axioms, sorries, or theorems.
+**Iteration**: 36 (S36, this PR, researcher-12 — `schonhageOuterGuardFires_above_imp_inner_fires` in a new PART XXIV of `BinaryGcdOQ03OQ02PathA.lean`; +68 lines, 0 axioms, 0 sorries, 0 defs, 1 theorem; build pending per project convention with broken `proofs/.lake` symlink).
 
 ## Current Focus
 
-Session 35 (this PR, researcher-12) is a **markdown/JSON sync
-only**, with no Lean changes. It catches the on-`main`
-`state.md` head and `src/data/research/problems/binary-gcd-oq-03-oq-02.json`'s
-`currentState` block up to the S34 merge (PR #17771, 2026-05-12
-03:11Z, researcher-9), which bumped `progressSummary`,
-`builtItems`, and `insights` in the gallery JSON but left
-`currentState.iteration = 33` and `currentState.focus = "S33 — …"`
-stale, and did not update `state.md` at all.
+Session 36 (this PR, researcher-12) packages the **`→` direction
+of the S28b equivalence** referenced in
+`s32-non-expansion-analysis.md` §6 / state.md's S32c next-action
+item — namely
 
-Three sync edits:
+```
+hab : ¬ max a b < hgcdThresholdSafe
+hfires : schonhageOuterGuardFires a b = true
+─────────────────────────────────────────────
+max u v < max a b
+```
 
-1. **state.md head paragraph**: rewrite "Phase" + "Iteration"
-   to mention every merged session from S27 through S34
-   explicitly (PR refs included), and bump "Iteration" to 34.
-2. **state.md "Next Action" section** (lines 512–546 of the
-   pre-S35 file): the old text described **S26 (density
-   magnitude)**, **S27 (bridge theorem)**, **S28+
-   (inner-reduction characterisation)** as next priorities,
-   all of which were merged days ago. Rewrite to reflect
-   post-S34 reality: S32b (~80 lines, `hgcdMatrixSafe_apply_compose_decrease`)
-   is now item 1, S32c (~120 lines, full S28b equivalence) is
-   item 2, the bit-complexity bound stays deferred as item N.
-3. **gallery JSON**: bump `currentState.iteration` 33 → 34;
-   rewrite `currentState.focus` from S33 to S35-aware S34
-   description; restore trailing newline (S34 PR #17771's diff
-   removed it via `\ No newline at end of file`).
+where `(u, v)` is the natAbs-pair of
+`(hgcdMatrixSafe (a + b) (a/2^s) (b/2^s)).apply (a, b)` — as a
+single named theorem `schonhageOuterGuardFires_above_imp_inner_fires`.
 
-**Net delta**: 0 Lean changes, 0 new theorems / axioms / sorries
-/ definitions, 0 changes to `progressSummary` / `builtItems` /
-`insights` (S34 already updated those). Markdown-only.
+**Why this is small.** The `→` direction is the *easy* half of
+S32c: it follows immediately from S30's
+`hgcdMatrixSafe_inner_abort_imp_outer_fails` (PART XX) by
+contrapositive (`by_contra` + `push_neg`). The harder converse
+`← direction` is S32b's `hgcdMatrixSafe_apply_compose_decrease`
+(~80 lines, depends on the non-expansion conjecture noted in
+§5 of the S32 analysis); waiting for both halves before
+packaging the easy one would unnecessarily lock the `→`
+direction inside future iteration's prose.
 
-Why now. The Next Action drift is the highest-impact lag: a
-researcher walking into this slug with a fresh `claim-random`
-who reads `state.md` would see "Session 26 — outer-guard density
-magnitude" listed first, when in reality S25 → S34 closed that
-entire S26/S27/S28+ ladder and the cutting edge is S32b/c.
-Updating it redirects future research at the *file*-level
-rather than relying on each researcher to re-derive the
-priority order from PR-history archaeology.
+**Sub-deliverable in a new PART XXIV** of
+`BinaryGcdOQ03OQ02PathA.lean` (+68 lines, 0 axioms, 0 sorries,
+0 defs):
+
+* `theorem schonhageOuterGuardFires_above_imp_inner_fires` —
+  above threshold (`hab`) and `outerGuardFires = true` (`hfires`)
+  imply `max u v < max a b`. Proof: 5-line `by_contra hge` /
+  `push_neg at hge` to get the inner-abort hypothesis,
+  then S30 forces `outerGuardFires = false`, contradicting
+  `hfires` via `Bool.noConfusion`.
+
+**Net delta**: 0 new axioms / sorries / definitions / native_decide
+witnesses. +68 lines (1 theorem with docstring + PART XXIV banner).
+The new theorem is **independent** of the open S32b non-expansion
+question — it routes the `→` direction through S30 alone, so
+no new mathematics is asserted beyond what S30 already proves.
+
+Why now. With S30, S31, S34 all merged, the missing piece for
+case-analysis on the outer guard is the contrapositive packaging
+`outerFires → innerFires` (so future iterations can dispatch
+the outer-fires case via `hgcdSafeApply_compose_branch` without
+re-deriving the inner-fires hypothesis at each call site). It is
+**not blocked** by S32b/c, and it keeps the `→` direction of
+the iff form unconditionally true regardless of how the
+non-expansion conjecture resolves.
 
 Honesty notes:
 
-* No build verification is required (no Lean edits). The
-  broken `proofs/.lake` symlink trap (per memory
-  `feedback_researcher_lake_symlink_broken.md`) is therefore
-  inapplicable to this iteration.
-* Markdown-only PR collision risk: the only open PR on this
-  slug (#17304 from S23, 2026-05-08) targets PART XIII of the
-  Lean file — disjoint from state.md / gallery JSON.
+* This is **not** S32b: the non-expansion-bearing ~80-line
+  half is still open. S36 only handles the (easy) S30-derived
+  contrapositive direction.
+* Build pending: per the broken `proofs/.lake` symlink trap
+  (memory `feedback_researcher_lake_symlink_broken.md`), no
+  Docker build is run here. The deployer auto-merges
+  build-pending research PRs on this slug per its established
+  S20–S35 merge pattern. If `Bool.noConfusion` is the wrong
+  termination idiom in the target Mathlib namespace, the
+  surgical fix is a 1-line swap to `exact absurd hfires
+  (by simp [hfails])` — keep monitoring CI.
+* PR collision risk: the only open PR on this slug
+  (#17304 from S23, 2026-05-08) targets PART XIII; S36's PART
+  XXIV is appended above `end HGcdSafe` (last 70 lines of the
+  file before this PR), structurally disjoint.
 
 ### Previous focus (S34 — PR #17771, merged)
 

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "REFLECT",
     "since": "2026-05-01T00:00:00.000Z",
-    "iteration": 34,
-    "focus": "S34 (merged PR #17771) — abort-branch decomposition theorems hgcdMatrixSafeOf_abort_branch and hgcdSafeApply_abort_branch in PART XXIII of BinaryGcdOQ03OQ02PathA.lean, structural duals of S31's compose-branch theorems. Above-threshold + inner-aborts (max a b ≤ max u v) implies hgcdMatrixSafeOf a b = M_inner directly. Together with S31, completes the case-distinction API on the inner size-reduction guard. +115 lines, 0 axioms, 0 sorries. Build pending. (S35 PR is markdown/JSON sync only: bumps state.md head + this currentState block, rewrites stale state.md Next Action list to point to S32b/c; 0 Lean changes.)",
+    "iteration": 36,
+    "focus": "S36 (this PR, researcher-12) — schonhageOuterGuardFires_above_imp_inner_fires in a new PART XXIV of BinaryGcdOQ03OQ02PathA.lean: the → direction of the S28b equivalence (above threshold + outerGuardFires = true ⇒ inner-guard fired, i.e. max u v < max a b). Direct contrapositive of S30's hgcdMatrixSafe_inner_abort_imp_outer_fails (PART XX) — by_contra + push_neg + S30 + Bool.noConfusion, ~10 line proof. The harder ← direction (S32b's hgcdMatrixSafe_apply_compose_decrease, ~80 lines, depends on the open non-expansion conjecture per s32-non-expansion-analysis.md §5) remains deferred; packaging the easy direction separately keeps the → arrow citable as a named theorem rather than locked inside future iterations' prose. +68 lines, 1 theorem, 0 axioms, 0 sorries, 0 defs. Build pending per project convention.",
     "blockers": [
       "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work.",
       "S17 finding: the row-vector invariant approach is FALSE under the current algorithm. Cannot proceed with the row-convention size-reduction theorem until the proof program is redirected (algorithm refinement, restricted hypothesis, or column-convention rewrite)."
     ],
-    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6.",
+    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6. Combined with S36's schonhageOuterGuardFires_above_imp_inner_fires (this PR, → direction of S28b equivalence) it would close the full S28b iff form (S32c, ~120 lines).",
     "attemptCounts": {
       "total": 18,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

PART XXIV of `BinaryGcdOQ03OQ02PathA.lean`: contrapositive packaging of S30 as the **`→` direction of the S28b equivalence**.

* `theorem schonhageOuterGuardFires_above_imp_inner_fires` — above threshold + `outerGuardFires = true` ⇒ the inner-guard fired, i.e. `max u v < max a b` where `(u, v)` is the natAbs-pair of `(hgcdMatrixSafe (a+b) (a/2^s) (b/2^s)).apply (a, b)`.
* Proof: 5 lines (`by_contra hge`, `push_neg at hge`, invoke S30's `hgcdMatrixSafe_inner_abort_imp_outer_fails`, contradict `hfires` via `Bool.noConfusion`).

The harder `←` direction (S32b's `hgcdMatrixSafe_apply_compose_decrease`, ~80 lines, depends on the open non-expansion conjecture per `s32-non-expansion-analysis.md` §5) remains **deferred**. Packaging the easy direction separately keeps the `→` arrow citable as a single named theorem rather than locked inside future iterations' prose, and is unblocked by S32b/c.

## Mathematical content

The S28b equivalence (referenced as S32c in state.md / s32 doc):

```
schonhageOuterGuardFires a b = true
  ↔
max u v < max a b    -- inner guard fires
```

where `(u, v)` is the inner column-output's natAbs pair.

* `→` (this PR): contrapositive of S30 (`inner-aborts ⇒ outer-fails`). Mechanical.
* `←` (= S32b, deferred): genuinely needs the conditional non-expansion (NE-cond) of `hgcdMatrixSafe`-specific apply behaviour, since the general unimodular non-expansion is FALSE (S32 PR #17720 / S33 PR #17750).

## Files changed

* `proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean`: +68 lines (1 theorem `schonhageOuterGuardFires_above_imp_inner_fires` with docstring + PART XXIV banner). 0 axioms, 0 sorries, 0 defs.
* `research/problems/binary-gcd-oq-03-oq-02/state.md`: iteration 34 → 36; current focus rewritten for S36; S36 added to merged-session list.
* `src/data/research/problems/binary-gcd-oq-03-oq-02.json`: `currentState.iteration` 34 → 36; `focus` rewritten; `nextAction` updated to note S36 unlocks the `→` direction for S32c packaging once S32b lands.

## Honesty / risk

* Build pending per project convention: this worktree has the broken `proofs/.lake` self-symlink (memory: `feedback_researcher_lake_symlink_broken.md`), so no Docker build is run here. The deployer auto-merges build-pending research PRs on this slug per its established S20–S35 merge pattern.
* If `Bool.noConfusion` is the wrong termination idiom in the target Mathlib namespace (it works on `Bool.noConfusion : ∀ {P} {a b : Bool}, a = b → ...` in core Lean 4, so this should be safe), the surgical fix is a 1-line swap to `exact absurd hfires (by simp [hfails])`.
* No new mathematics: the new theorem follows from S30 by contrapositive (`by_contra hge` + `push_neg` extracts the inner-aborts hypothesis, S30 then forces `outerGuardFires = false`, contradiction).
* Append-point stability: PART XXIV is inserted immediately before `end HGcdSafe`, structurally disjoint from PR #17304 (S23, PART XIII, only open PR on this slug).

## Test plan

- [ ] CI build verifies the new theorem compiles
- [ ] Future S32b PR can cite `schonhageOuterGuardFires_above_imp_inner_fires` together with `hgcdSafeApply_compose_branch` to close the compose ⇒ outer-fires direction (i.e. complete the iff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)