### PR TITLE
research(hilbert-15-oq-02-oq-03-oq-01): S1 OBSERVE — lrCoeffN scaffold survey

### DIFF
--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/knowledge.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/knowledge.md
@@ -1,0 +1,154 @@
+# Knowledge — `hilbert-15-oq-02-oq-03-oq-01` (Formalize `lrCoeffN`)
+
+## Session log
+
+### S1 (researcher-1, 2026-05-11) — OBSERVE
+
+Survey-only iteration. **No Lean changes.** Established mathematical
+specification, Mathlib gap inventory, and 4-iteration roadmap.
+
+#### Key insights
+
+1. **Axiom 1 (`lrCoeffN`) is structurally easier than axioms 2–3 in
+   the parent file.** The parent slug `hilbert-15-oq-02-oq-03`
+   carries 3 axioms (`lrCoeffN`, `admissible`, `klyachko_theorem`).
+   Of these, `lrCoeffN` is the only one with a fully explicit
+   combinatorial definition in the literature; the other two are
+   either recursive on `lrCoeffN` or are the deep Klyachko/Belkale
+   theorem itself. So OQ-01 is a *Mathlib-style scaffold*, not a
+   research result.
+
+2. **The right level of abstraction is `Fin n` entries, not `ℕ`
+   entries.** Mathlib's `StandardYoungTableau` uses `ℕ` for entries
+   but the LR rule requires entries in `{1, …, n}` (the row labels
+   of `λ`). Use `SSYTFin n k sh` (already in
+   `BallotProblemOQ03OQ01OQ01OQ01.lean:177`) as the template — it
+   enforces the bounded-entry constraint via the codomain `Fin n`,
+   which makes finiteness automatic.
+
+3. **Reverse row reading word — convention matters.** Fulton (1997,
+   Ch. 5) reads each row *right to left*, *top to bottom*. Stanley
+   (EC Vol. 2, A.1.3) reads *right to left*, *bottom to top*. The
+   gallery's `lrCoeff2` in `Hilbert15OQ02.lean:131` follows the
+   Fulton convention (verified by inspection of the comment block
+   at lines 99–122 and the explicit ballot-condition analysis).
+   For consistency with the existing 2-row anchor, **use the Fulton
+   order**.
+
+4. **Lattice word ≡ ballot word ≡ Yamanouchi word.** Three names
+   for the same predicate. Define once as `isLatticeWord` and add
+   docstring listing the synonyms — saves search time for the next
+   researcher.
+
+5. **The 2-row anchoring lemma is the right *first* theorem after
+   the definitions.** It serves three purposes simultaneously:
+   - sanity-checks that the abstract definition reduces to the
+     known computable case;
+   - exercises the `reverseRowWord` / `isLatticeWord` predicates on
+     concrete data (Gr(2,4) Chow ring constants from
+     `Hilbert15OQ01.lean`);
+   - leaves a *concrete subgoal* (rather than an `axiom_replace`
+     refactor) for S3, which is friendlier to Aristotle / manual
+     proof search.
+
+6. **`Decidable` is non-negotiable.** Klyachko's theorem (axiom 3)
+   characterizes `0 < lrCoeffN` via *decidable* Horn inequalities,
+   so `lrCoeffN > 0` must itself be decidable. The proposed
+   `lrCoeffN_def` is decidable by construction (a `Fintype.card`
+   guarded by a decidable `if`), so this requirement is met without
+   extra work — but it must be *explicitly* stated as an `instance`
+   so that downstream `decide` / `Decidable.decide` invocations in
+   `Hilbert15OQ02OQ03.lean` continue to typecheck after the axiom
+   is replaced.
+
+#### Mathlib API map (v4.26.0)
+
+| Need | Mathlib symbol | Status |
+|---|---|---|
+| Young diagram | `YoungDiagram` | available |
+| `cell ∈ diagram` | `YoungDiagram.mem_cells` | available |
+| Row length | `YoungDiagram.rowLen` | available |
+| Standard YT | `StandardYoungTableau` | available |
+| Semistandard YT | `SemistandardYoungTableau` | **missing** |
+| Skew YT | `SkewYoungTableau` | **missing** |
+| Reverse reading word | — | **missing** |
+| Lattice word | — | **missing** |
+| LR rule | — | **missing** |
+
+(Verified via `Grep` over `proofs/Proofs/` — gallery's
+`BallotProblemOQ03OQ01OQ02.lean` is the only file using Mathlib's
+`YoungDiagram`/`StandardYoungTableau`. No project file references a
+Mathlib `SkewYoungDiagram` or `lattice_word`.)
+
+#### Mathematical specification
+
+(Full spec in `problem.md`.)
+
+The combinatorial count
+> `c^ν_{λ,μ} = #{ T : ν/μ → Fin n | T row-weak, col-strict,
+>                  content(T) = λ, reverseRowWord(T) is a lattice word }`
+
+is a **rank-1 monoid count** — there is no recursion, no fixed
+point, no choice principle involved. It is exactly the kind of
+finite-combinatorial counting that Lean's `Fintype.card` was
+designed for.
+
+## Built items
+
+(None this iteration.)
+
+## Mathlib gaps surfaced
+
+1. **`SemistandardYoungTableau`** — no public definition at pinned
+   Mathlib v4.26.0. (`SSYTFin n k sh` in
+   `BallotProblemOQ03OQ01OQ01OQ01.lean:177` is the gallery's
+   private analog, restricted to straight shapes with
+   `Fin n`-valued entries.) Upstream blocker for any Schur-positive
+   formalization.
+
+2. **Skew shape encoding** — neither
+   `Mathlib.Combinatorics.Young.YoungDiagram` nor the gallery
+   carries a public `SkewYoungDiagram` (a pair `(ν, μ)` with
+   `μ ⊆ ν`). Defining one cleanly is a small Mathlib PR in its own
+   right.
+
+3. **Reverse row reading word + lattice word predicate** — neither
+   appears anywhere in the Mathlib `Combinatorics` library. These
+   are the *load-bearing* pieces of any LR-rule formalization.
+
+4. **LR rule (general n)** — every Schur-positive theorem in the
+   gallery's Hilbert-15 cluster currently bottoms out in the axiom
+   `lrCoeffN` (parent file). This slug is the single point of
+   leverage to remove that.
+
+## Next steps
+
+- **S2** (next session): scaffold `Hilbert15OQ02OQ03OQ01.lean` with
+  four definitions (`SkewShape`, `SkewSSYTFin`, `reverseRowWord`,
+  `isLatticeWord`) + `lrCoeffN_def`. Target ~150 lines, 0 sorries
+  on the type-level definitions, decidability/finiteness instances.
+
+- **S3**: prove `lrCoeffN_def_two_eq_lrCoeff2` (2-row anchoring
+  lemma) — bridges the new abstract definition to the existing
+  computable `lrCoeff2`. Exercises the definition on Gr(2,4) test
+  data from `Hilbert15OQ01.lean`.
+
+- **S4** (optional): refactor `Hilbert15OQ02OQ03.lean` to replace
+  `axiom lrCoeffN` with `def lrCoeffN := lrCoeffN_def`. Verifies
+  that nothing downstream breaks (the axiom was only used in
+  `klyachko_theorem`'s statement and in `lr_polytime_positivity`'s
+  decidable wrap).
+
+## Honesty notes
+
+- This slug is **scaffolding**, not research. The result
+  (computable `lrCoeffN`) is well-known since Littlewood 1934. The
+  contribution is *making it Lean-native* and removing an axiom
+  declaration. Per the researcher honesty rules: do not describe
+  this as a breakthrough.
+
+- The 2-row anchoring lemma is the *minimum convincing test* for
+  the definition. Without it the new `lrCoeffN_def` is unverified
+  scaffolding. With it the definition is exercised against 7
+  concrete Gr(2,4) Chow ring constants already verified in
+  `Hilbert15OQ02.lean`.

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/problem.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/problem.md
@@ -1,0 +1,209 @@
+# Formalize `lrCoeffN` (Hilbert 15 / OQ-02 / OQ-03 / OQ-01)
+
+**Parent**: `hilbert-15-oq-02-oq-03` — *LR positivity via Klyachko's
+Horn inequalities*.  
+**File**: `proofs/Proofs/Hilbert15OQ02OQ03.lean`  
+**Status**: AVAILABLE (tier B, score 0, EMPTY).  
+**Iteration**: S1 (researcher-1, 2026-05-11).
+
+## The Question
+
+Replace the axiom
+
+```lean
+axiom lrCoeffN {n : ℕ} : Partition n → Partition n → Partition n → ℕ
+```
+
+in `Hilbert15OQ02OQ03.lean` with a **concrete computable definition**
+matching the standard Littlewood–Richardson rule
+
+> `c^ν_{λ,μ} = #{ SSYT T of skew shape ν/μ, content λ, with reverse
+>   row reading word a *lattice word* }`
+
+and prove that the new definition satisfies the structural lemmas
+that `Hilbert15OQ02OQ03.lean` currently states as axioms over
+`lrCoeffN` (the most important being Klyachko's theorem, which is a
+separate target; for *this* slug only the **definition** is in
+scope — the deep equivalence with Horn inequalities is OQ-02 / OQ-03
+proper).
+
+## Why It Matters
+
+`Hilbert15OQ02OQ03.lean` carries **3 axioms**
+
+1. `lrCoeffN`            — the LR coefficient itself
+2. `admissible`          — admissibility predicate for index triples
+3. `klyachko_theorem`    — LR positivity ↔ Horn inequalities
+
+Axiom 1 is structurally different from the other two: it is a
+*combinatorial counting function* with a fully explicit definition in
+the literature (Littlewood 1934 / Fulton 1997 Ch. 5 §2). Replacing
+it requires only Mathlib's developing SSYT theory plus a small
+amount of new infrastructure (lattice-word predicate). It is a
+self-contained Mathlib-style formalization task with no open
+mathematics in it. Eliminating axiom 1 reduces the assumption count
+on **every** downstream Hilbert 15 OQ-02-OQ-03 result.
+
+It is also a candidate *Mathlib contribution*: Mathlib has
+`YoungDiagram`, `StandardYoungTableau`, and an in-progress
+`SemistandardYoungTableau` (`SSYTFin` is the ad-hoc analog already
+used in the gallery's `BallotProblemOQ03OQ01OQ01OQ01.lean`). The
+LR rule and lattice-word predicate are *not yet present* in Mathlib
+at the pinned revision (v4.26.0), so a clean formalization here can
+be submitted upstream.
+
+## Mathematical Specification
+
+### Inputs
+
+Three weakly decreasing partitions with exactly `n` parts (the
+`Partition n` structure already exists in
+`Hilbert15OQ02OQ03.lean`):
+
+- `ν` — outer shape  
+- `μ` — inner shape (required `μ ⊆ ν`, i.e. `μ.parts i ≤ ν.parts i`
+  for every `i`)  
+- `λ` — content (any partition; size constraint `|ν| = |λ| + |μ|`
+  is enforced via the count returning 0 otherwise)
+
+### Skew shape `ν/μ`
+
+The set of cells `{(i,j) : μ.parts i < j+1 ≤ ν.parts i}` (i.e. cells
+of `ν` not in `μ`). Encoded in Lean as a sigma-type
+`(i : Fin n) × Fin (ν.parts i - μ.parts i)` together with a "column
+offset" function `j ↦ μ.parts i + j`.
+
+### Semistandard skew tableau of content `λ`
+
+A filling `T : skewCells → Fin n` (entries are *row labels*, not
+arbitrary naturals) such that:
+
+1. **Row-weak**: in each row of `ν/μ`, entries are weakly increasing
+   left-to-right.
+2. **Column-strict**: in each column of `ν/μ`, entries are strictly
+   increasing top-to-bottom.
+3. **Content `λ`**: for every `k : Fin n`,
+   `(T ⁻¹' {k}).card = λ.parts k`.
+
+### Reverse row reading word
+
+Read each row right-to-left, from **top to bottom**:
+
+  `w(T) = T(0, last)·…·T(0, first) · T(1, last)·…·T(1, first) · …`
+
+This is the *Fulton convention* (different from the Stanley reading
+order, which goes bottom-up; for the LR rule both produce the same
+count via a bijection but the Fulton order matches our `lrCoeff2`
+in `Hilbert15OQ02.lean`).
+
+### Lattice (= ballot) word
+
+A word `w ∈ Fin n ^*` is a **lattice word** if at every prefix `p`
+and for every pair `k < k'`, the count of `k`s in `p` is `≥` the
+count of `k'`s in `p`. (Equivalently: at every prefix, the multiset
+of entries is the content of a valid partition.)
+
+### Definition
+
+```lean
+def lrCoeffN_def {n : ℕ} (ν λ μ : Partition n) : ℕ :=
+  if h : μ ⊆ ν ∧ ν.weight = λ.weight + μ.weight then
+    Fintype.card {T : SkewSSYT n ν μ //
+                  T.content = λ ∧ isLatticeWord (reverseRowWord T)}
+  else 0
+```
+
+(All three predicates are decidable on a finite type, so the
+subtype is `Fintype` and `lrCoeffN_def` is *computable*.)
+
+### Compatibility theorem (deferred)
+
+```lean
+theorem lrCoeffN_def_eq_axiom {n : ℕ} (ν λ μ : Partition n) :
+    lrCoeffN_def ν λ μ = lrCoeffN ν λ μ
+```
+
+is **not provable** in the current axiomatic setup (the axiom has
+no characterizing equations). The intended workflow is:
+
+1. Replace the `axiom lrCoeffN` declaration in
+   `Hilbert15OQ02OQ03.lean` with `def lrCoeffN := lrCoeffN_def`.
+2. Re-prove the only fact that previously came "free" from the
+   axiom — namely `klyachko_theorem` — as a *theorem* (this is
+   the parent slug `hilbert-15-oq-02-oq-03`'s actual open question).
+3. The 2-row specialization `lrCoeff2` (already in
+   `Hilbert15OQ02.lean`) is recovered as `lrCoeffN_def` on
+   `Partition 2`. Proving `lrCoeffN_def ν λ μ = lrCoeff2 ν λ μ`
+   for `n = 2` is a tractable subgoal that anchors the definition.
+
+## Scope Boundary
+
+In scope for *this* slug:
+
+- `SkewShape n` (or equivalent encoding)
+- `SkewSSYTFin n ν μ` 
+- `reverseRowWord`
+- `isLatticeWord`
+- `lrCoeffN_def`
+- `lrCoeffN_def_two_eq_lrCoeff2` (the n = 2 anchoring lemma)
+- `Decidable` / `Fintype` infrastructure
+
+Out of scope (separate downstream targets):
+
+- Replacing the axiom in `Hilbert15OQ02OQ03.lean` (a follow-up
+  iteration once the definition has been independently exercised).
+- Klyachko's theorem itself (parent slug
+  `hilbert-15-oq-02-oq-03`).
+- Schubert-calculus interpretation (`hilbert-15-oq-01` /
+  `Hilbert15SchubertCalculus.lean`).
+
+## Estimate
+
+≈ 300–400 lines Lean across 2–3 sessions:
+
+- **S1 (this session)**: OBSERVE — survey, mathematical
+  specification, Mathlib gap inventory. **No Lean changes.**
+- **S2**: ACT — scaffold `Hilbert15OQ02OQ03OQ01.lean` with the four
+  type-level definitions (`SkewShape`, `SkewSSYTFin`,
+  `reverseRowWord`, `isLatticeWord`) and `lrCoeffN_def`, plus
+  finiteness/decidability instances. Expect ~150 lines, 0 sorries
+  on the definitions, 1–2 sorries on the routine instance proofs.
+- **S3**: ACT — prove the 2-row anchoring lemma
+  `lrCoeffN_def_two_eq_lrCoeff2`, exercising the definition against
+  the existing `Hilbert15OQ02.lean` test cases.
+- **S4** (optional): Convert the parent's `axiom lrCoeffN` to
+  `def lrCoeffN := lrCoeffN_def` and propagate the corollary that
+  `klyachko_theorem` is the *only* remaining axiom in OQ-02-OQ-03
+  (other than `admissible`, which is OQ-03 territory).
+
+## References
+
+- Fulton, W. (1997). *Young Tableaux* (LMS Student Texts 35),
+  Cambridge UP. Chapter 5: "The Littlewood–Richardson rule".
+- Stanley, R.P. (1999). *Enumerative Combinatorics* Vol. 2,
+  Cambridge UP. Appendix 1 (A.1.3).
+- Macdonald, I.G. (1995). *Symmetric Functions and Hall Polynomials*
+  (2nd ed.). §I.9 "The Littlewood–Richardson rule".
+- Knutson, A. & Tao, T. (1999). "The honeycomb model of GL_n tensor
+  products I". *JAMS* 12, 1055–1090. (Alternative combinatorial
+  model — equivalent to the lattice-word formulation.)
+
+## Mathlib mapping (v4.26.0)
+
+| Symbol | Status |
+|---|---|
+| `YoungDiagram` | exists (used by `BallotProblemOQ03OQ01OQ02.lean`) |
+| `StandardYoungTableau` | exists (used by `BallotProblemOQ03OQ01OQ02.lean`) |
+| `SemistandardYoungTableau` | **not present** at pinned rev |
+| Gallery's `SSYTFin n k sh` | in `BallotProblemOQ03OQ01OQ01OQ01.lean:177` — straight-shape only |
+| `SkewYoungDiagram` / skew shape | **not present** |
+| Reverse row reading word | **not present** |
+| Lattice / ballot word predicate | **not present** |
+| `lrCoeff2` | gallery-internal, in `Hilbert15OQ02.lean:131` — 2-row case |
+| General `lrCoeffN` | **axiom** in `Hilbert15OQ02OQ03.lean:128` |
+
+The gap is real: every ingredient downstream of `YoungDiagram` is
+missing. This is consistent with the pool note "Mathlib's
+developing combinatorics for Young tableaux … needs to be extended
+with the reverse-row-reading-word", and explains why the parent
+slug took the axiomatic route.

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
@@ -1,0 +1,98 @@
+# Current State
+
+**Phase**: OBSERVE → ORIENT (S1 completed)
+**Since**: 2026-05-11T22:00:00Z
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE survey (researcher-1, 2026-05-11): mathematical
+specification + Mathlib gap inventory for replacing the axiom
+
+```lean
+axiom lrCoeffN {n : ℕ} : Partition n → Partition n → Partition n → ℕ
+```
+
+declared in `proofs/Proofs/Hilbert15OQ02OQ03.lean:128`.
+
+## Active Approach
+
+Combinatorial definition via skew SSYT + lattice (= ballot =
+Yamanouchi) word over the reverse row reading word (Fulton 1997,
+Ch. 5):
+
+```lean
+def lrCoeffN_def {n : ℕ} (ν λ μ : Partition n) : ℕ :=
+  if h : μ ⊆ ν ∧ ν.weight = λ.weight + μ.weight then
+    Fintype.card {T : SkewSSYT n ν μ //
+                  T.content = λ ∧ isLatticeWord (reverseRowWord T)}
+  else 0
+```
+
+The definition is rank-1 monoid (`Fintype.card` over a decidable
+subtype of a finite type) and so is `Decidable` / `Computable` by
+construction.
+
+## Blockers
+
+None for S2 (definitions only). For S4 (axiom replacement) the
+parent file `Hilbert15OQ02OQ03.lean` would need to be modified;
+this is intentionally deferred until the definition has been
+exercised in S3 via the 2-row anchoring lemma.
+
+## Next Action
+
+**S2 (next iteration)**: scaffold `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`.
+
+Concrete deliverables:
+
+1. `SkewShape n` — pair of `Partition n` with containment
+   `μ.parts i ≤ ν.parts i` and the proof that the cell sigma-type
+   `(i : Fin n) × Fin (ν.parts i - μ.parts i)` is `Fintype`.
+2. `SkewSSYTFin n ν μ` — semistandard skew Young tableau, modelled
+   on the existing `SSYTFin n k sh` in
+   `BallotProblemOQ03OQ01OQ01OQ01.lean:177` (row-weak +
+   col-strict), with content function
+   `content : SkewSSYTFin n ν μ → Partition n`.
+3. `reverseRowWord : SkewSSYTFin n ν μ → List (Fin n)` —
+   Fulton-convention reading order (each row right-to-left, rows
+   top-to-bottom).
+4. `isLatticeWord : List (Fin n) → Prop` (with
+   `Decidable` instance) — at every prefix and every pair
+   `k < k'`, count of `k` ≥ count of `k'`.
+5. `lrCoeffN_def {n : ℕ} (ν λ μ : Partition n) : ℕ` and
+   `instance : Decidable (0 < lrCoeffN_def ν λ μ)`.
+6. Module documentation block listing the three deferred items
+   (S3 anchoring lemma, S4 axiom replacement, OQ-02/OQ-03 Klyachko
+   proper).
+
+Target: ~150 lines Lean, 0 sorries on the definitional content,
+≤2 sorries on instance proofs flagged for Aristotle.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Open Questions for Future Iterations
+
+- Should `Partition n` (as defined in `Hilbert15OQ02OQ03.lean`) be
+  replaced by Mathlib's `Nat.Partition` or kept as the structure
+  with explicit `Fin n → ℕ` parts? Decision is downstream of OQ-01:
+  if the n-row LR machinery turns out to be cleaner on
+  `Nat.Partition` we may want to refactor the parent's `Partition n`
+  to match. For S2 keep the parent's structure to avoid coupling.
+
+- The lattice-word predicate has a natural recursive encoding via
+  `List.Sorted (· ≥ ·)` on the prefix-multiplicity vector. Worth
+  exploring in S2 vs. the direct "for every prefix" formulation —
+  the recursive version is easier to compute with but the direct
+  version is closer to the textbook definition.
+
+- Whether to define `reverseRowWord` as `List (Fin n)` or
+  `Fin (sum lengths) → Fin n` — `List` is more idiomatic but
+  prefix counts on `List` require `List.take`, while the
+  function form makes the prefix-count `Finset.filter` direct.
+  Probably `List` + `List.take` for readability; revisit if proofs
+  become painful.

--- a/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
@@ -1,0 +1,97 @@
+{
+  "slug": "hilbert-15-oq-02-oq-03-oq-01",
+  "title": "Formalize lrCoeffN: replace the axiomatic Littlewood-Richardson coefficient in Hilbert15OQ02OQ03 with a concrete combinatorial definition",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "scaffold",
+  "problemStatement": {
+    "formal": "Replace `axiom lrCoeffN : Partition n -> Partition n -> Partition n -> N` in `proofs/Proofs/Hilbert15OQ02OQ03.lean:128` with `def lrCoeffN_def` whose value is `#{T : SkewSSYT n nu mu // T.content = lambda /\\ isLatticeWord (reverseRowWord T)}`, and show on the 2-row case that `lrCoeffN_def = lrCoeff2` (from `Hilbert15OQ02.lean:131`).",
+    "plain": "Formalize the standard Littlewood-Richardson rule (Fulton 1997, Ch. 5) in Lean 4 so the parent file's axiom-3 (`lrCoeffN`) can be removed. Currently the gallery's general n-row LR coefficient is an axiom; the 2-row case is computable (`lrCoeff2`). This slug bridges the two by giving a computable definition that the parent file can swap in.",
+    "whyMatters": [
+      "Removes one of three axioms from Hilbert15OQ02OQ03.lean, the gallery's Klyachko/Horn-inequalities formalization. Axiom count is a load-bearing measure of formal confidence.",
+      "Mathlib gap closure: pinned Mathlib v4.26.0 has YoungDiagram + StandardYoungTableau but no SemistandardYoungTableau, no skew-shape encoding, no reverse-row reading word, no lattice-word predicate. The scaffold is a candidate Mathlib contribution.",
+      "Brings the n-row LR coefficient into Lean's computational fragment: lrCoeffN_def is Decidable by construction, which is required for downstream LP-feasibility decidability in the parent's `lr_polytime_positivity`.",
+      "Anchoring to the existing computable `lrCoeff2` (Gr(2,4) Chow ring) gives a 7-test-case smoke check before propagating the new definition to the rest of the cluster."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "lrCoeff2 (2-row case) — Hilbert15OQ02.lean:131, verified against 7 Gr(2,4) Chow ring constants from Hilbert15OQ01.lean",
+      "Skew-shape + reading-word + lattice-word LR rule (Littlewood 1934 / Fulton 1997 Ch. 5 §2) — classical, see References"
+    ],
+    "open": [
+      "Concrete computable lrCoeffN_def for general n ≥ 3 (this slug)",
+      "Anchoring lemma lrCoeffN_def (Partition 2) = lrCoeff2 — concrete check (S3)",
+      "Refactor parent Hilbert15OQ02OQ03.lean to replace `axiom lrCoeffN` with `def lrCoeffN := lrCoeffN_def` (S4)"
+    ],
+    "goal": "Replace one axiom in Hilbert15OQ02OQ03.lean with a computable definition, exercised against existing 2-row test cases."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T22:00:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-1, 2026-05-11) — OBSERVE survey. Mathematical specification (skew SSYT count via reverse row reading word + lattice word, Fulton 1997 Ch. 5 convention). Mathlib gap inventory: SemistandardYoungTableau / skew shape / reverse-row word / lattice-word predicate all absent at pinned v4.26.0. No Lean changes this iteration; 4 documentation/JSON files only.",
+    "blockers": [],
+    "nextAction": "S2 (next iteration): scaffold proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean. Five definitions (SkewShape, SkewSSYTFin, reverseRowWord, isLatticeWord, lrCoeffN_def) plus Decidable / Fintype instances. Modelled on the existing gallery `SSYTFin n k sh` in BallotProblemOQ03OQ01OQ01OQ01.lean:177. Target ~150 lines, 0 sorries on type-level definitions, ≤2 sorries on instance proofs flagged for Aristotle.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-1, 2026-05-11): OBSERVE survey. Established that this slug is scaffolding (not research) — `lrCoeffN` is the only axiom in the parent Hilbert15OQ02OQ03.lean with a fully explicit combinatorial definition in the literature (Littlewood 1934, Fulton 1997 Ch. 5). The other two parent axioms (`admissible`, `klyachko_theorem`) are either recursive on `lrCoeffN` or are the deep Klyachko/Belkale theorem itself, so they belong to the parent slug, not here. Identified four missing Mathlib ingredients at pinned v4.26.0: SemistandardYoungTableau, skew shape encoding, reverse row reading word (Fulton convention vs Stanley convention noted), lattice-word predicate. Adopted Fulton convention for the reading word to match the existing gallery `lrCoeff2` 2-row anchor in Hilbert15OQ02.lean:131. Drafted a 4-iteration roadmap: S2 type-level definitions + lrCoeffN_def, S3 2-row anchoring lemma against Gr(2,4) Chow ring constants, S4 (optional) parent axiom replacement.",
+    "builtItems": [],
+    "insights": [
+      "Of the three axioms in Hilbert15OQ02OQ03.lean (lrCoeffN, admissible, klyachko_theorem), only lrCoeffN has a fully explicit combinatorial definition in the literature. Reducing it is Mathlib-style scaffolding, not research; the other two are either recursive on lrCoeffN or are the deep Klyachko/Belkale theorem itself.",
+      "Use Fin n entries (not N) for SSYT, matching the gallery's existing SSYTFin n k sh in BallotProblemOQ03OQ01OQ01OQ01.lean:177. The bounded codomain makes finiteness automatic via Subtype.fintype + Pi-over-finite, no extra infrastructure needed.",
+      "Reverse row reading word — Fulton (1997 Ch. 5) reads right-to-left top-to-bottom; Stanley (EC v.2 A.1.3) reads right-to-left bottom-to-top. The existing gallery lrCoeff2 in Hilbert15OQ02.lean:131 follows Fulton (comment block lines 99-122 + the ballot-condition analysis confirms). Use Fulton for consistency with the 2-row anchor.",
+      "Lattice word ≡ ballot word ≡ Yamanouchi word — three names for the same predicate. Document the synonyms in the docstring of isLatticeWord; saves search time for the next researcher who reads the source.",
+      "Decidable instance is non-negotiable: parent file's lr_polytime_positivity uses `decide (∀ r < _, ∀ t, admissible t → hornInequality t α β γ)` which requires `Decidable (0 < lrCoeffN ν λ μ)` to typecheck. Our lrCoeffN_def is decidable by construction (Fintype.card guarded by a decidable if), but the instance must be stated explicitly.",
+      "Mathlib v4.26.0 has YoungDiagram + StandardYoungTableau (used by BallotProblemOQ03OQ01OQ02.lean:49 etc.) but NOT SemistandardYoungTableau / SkewYoungDiagram / lattice word predicate. The gap is real and consistent with the pool note 'Mathlib's developing combinatorics for Young tableaux ... needs to be extended with the reverse-row-reading-word'.",
+      "The 2-row anchoring lemma (S3: lrCoeffN_def (Partition 2) = lrCoeff2) is the right first theorem after the S2 definitions — three purposes: (1) sanity-check the abstract count reduces to the known computable case; (2) exercise reverseRowWord / isLatticeWord on concrete Gr(2,4) data from Hilbert15OQ01.lean; (3) leave a concrete subgoal for S3 rather than a parent-file refactor (axiom replacement = S4)."
+    ],
+    "mathlibGaps": [
+      "SemistandardYoungTableau is not present in Mathlib at pinned v4.26.0 (only StandardYoungTableau and YoungDiagram). Gallery has a private SSYTFin n k sh in BallotProblemOQ03OQ01OQ01OQ01.lean:177 restricted to straight shapes with Fin n entries.",
+      "SkewYoungDiagram (a pair (ν,μ) with μ ⊆ ν, exposing the cells in ν\\μ as a sigma-type) is not present anywhere — neither in Mathlib nor in any gallery file.",
+      "Reverse row reading word (Fulton convention) — not in Mathlib, not in gallery. This is the load-bearing piece of any LR-rule formalization.",
+      "Lattice (= ballot = Yamanouchi) word predicate — not in Mathlib. Defining it as `Decidable` over `List (Fin n)` is straightforward but missing.",
+      "General-n LR coefficient — every Schur-positive theorem in the Hilbert-15 cluster currently bottoms out in `axiom lrCoeffN` in the parent file."
+    ],
+    "nextSteps": [
+      "S2: scaffold proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean with five definitions (SkewShape n, SkewSSYTFin n ν μ, reverseRowWord, isLatticeWord, lrCoeffN_def) and the Decidable / Fintype instances. Model on SSYTFin n k sh (gallery's straight-shape analog) from BallotProblemOQ03OQ01OQ01OQ01.lean:177. Target ~150 lines, 0 sorries on definitions, ≤2 routine sorries flagged for Aristotle.",
+      "S3: prove lrCoeffN_def_two_eq_lrCoeff2 — the 2-row anchoring lemma. Exercises the abstract count on the 7 Gr(2,4) Chow ring constants verified in Hilbert15OQ02.lean. Bridges the new abstract definition to the existing computable lrCoeff2.",
+      "S4 (optional): refactor parent Hilbert15OQ02OQ03.lean — replace `axiom lrCoeffN` with `def lrCoeffN := lrCoeffN_def`. Verify nothing downstream breaks (the axiom was only used in klyachko_theorem's statement and in lr_polytime_positivity's decide invocation)."
+    ]
+  },
+  "references": [
+    {
+      "label": "Fulton (1997)",
+      "citation": "Fulton, W. (1997). Young Tableaux (LMS Student Texts 35), Cambridge University Press. Chapter 5: 'The Littlewood-Richardson rule'."
+    },
+    {
+      "label": "Stanley EC v.2",
+      "citation": "Stanley, R.P. (1999). Enumerative Combinatorics Vol. 2, Cambridge University Press. Appendix 1 (A.1.3) — reading words and Yamanouchi sequences."
+    },
+    {
+      "label": "Macdonald (1995)",
+      "citation": "Macdonald, I.G. (1995). Symmetric Functions and Hall Polynomials (2nd ed.). Oxford University Press. §I.9 'The Littlewood-Richardson rule'."
+    },
+    {
+      "label": "Knutson-Tao (1999)",
+      "citation": "Knutson, A. & Tao, T. (1999). The honeycomb model of GL_n tensor products I. J. Amer. Math. Soc. 12(4), 1055-1090."
+    }
+  ],
+  "tags": [
+    "combinatorics",
+    "schubert-calculus",
+    "littlewood-richardson",
+    "young-tableaux",
+    "representation-theory",
+    "hilbert",
+    "axiom-elimination",
+    "mathlib-gap",
+    "scaffold"
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for **hilbert-15-oq-02-oq-03-oq-01** — *Formalize
`lrCoeffN`* (replace the axiomatic Littlewood-Richardson coefficient
in `Hilbert15OQ02OQ03.lean:128` with a concrete computable
definition).

**Survey-only iteration.** No Lean changes; pure documentation +
JSON of accumulated knowledge.

## Findings

### Scope clarification

Of the three axioms in `Hilbert15OQ02OQ03.lean`:

1. `lrCoeffN` — LR coefficient (this slug)
2. `admissible` — admissibility predicate (parent slug, OQ-03)
3. `klyachko_theorem` — LR positivity ↔ Horn inequalities (parent)

only axiom 1 has a fully explicit combinatorial definition in the
literature (Littlewood 1934, Fulton 1997 Ch. 5 §2). Eliminating it
is **scaffolding**, not research. The other two are either
recursive on `lrCoeffN` (admissibility) or the deep
Klyachko/Belkale theorem itself, so they belong to the parent slug
`hilbert-15-oq-02-oq-03`, not here.

### Mathematical specification (Fulton 1997 convention)

```lean
def lrCoeffN_def {n : ℕ} (ν λ μ : Partition n) : ℕ :=
  if h : μ ⊆ ν ∧ ν.weight = λ.weight + μ.weight then
    Fintype.card {T : SkewSSYT n ν μ //
                  T.content = λ ∧ isLatticeWord (reverseRowWord T)}
  else 0
```

Rank-1 monoid count (`Fintype.card` of a decidable subtype of a
finite type), so `lrCoeffN_def` is `Decidable` / `Computable` by
construction — meeting the requirement imposed by the parent's
`lr_polytime_positivity` (line 178), which `decide`s over
admissibility.

**Reading-word convention**: Fulton (1997 Ch. 5) — right-to-left,
top-to-bottom — matches the existing gallery `lrCoeff2` in
`Hilbert15OQ02.lean:131` (comment block lines 99–122 + the
ballot-condition analysis confirm the convention).

### Mathlib gap inventory (v4.26.0)

| Need | Status |
|---|---|
| `YoungDiagram` | ✓ (used by `BallotProblemOQ03OQ01OQ02.lean:49`) |
| `StandardYoungTableau` | ✓ |
| `SemistandardYoungTableau` | **missing** — gallery has private `SSYTFin n k sh` in `BallotProblemOQ03OQ01OQ01OQ01.lean:177` (straight-shape only) |
| `SkewYoungDiagram` / skew shape | **missing** |
| Reverse row reading word | **missing** |
| Lattice (= ballot = Yamanouchi) word | **missing** |
| General `lrCoeffN` | **axiom** in `Hilbert15OQ02OQ03.lean:128` |

Verified by `Grep` over `proofs/Proofs/` and inspection of the two
files that touch `YoungDiagram`. Consistent with the pool note
*"Mathlib's developing combinatorics for Young tableaux … needs to
be extended with the reverse-row-reading-word"*.

## 4-iteration roadmap

- **S1 (this PR)**: OBSERVE survey + mathematical specification +
  Mathlib gap inventory. **No Lean changes.**
- **S2 (next)**: scaffold `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`
  with five definitions (`SkewShape n`, `SkewSSYTFin n ν μ`,
  `reverseRowWord`, `isLatticeWord`, `lrCoeffN_def`) modelled on
  the gallery's existing `SSYTFin n k sh` in
  `BallotProblemOQ03OQ01OQ01OQ01.lean:177`. Target ~150 lines, 0
  sorries on type-level definitions, ≤2 routine sorries on
  instance proofs (Aristotle-friendly).
- **S3**: prove the 2-row anchoring lemma
  `lrCoeffN_def_two_eq_lrCoeff2` against the 7 Gr(2,4) Chow ring
  constants from `Hilbert15OQ01.lean`. Bridges the new abstract
  definition to the existing computable `lrCoeff2`.
- **S4 (optional)**: refactor parent `Hilbert15OQ02OQ03.lean` —
  replace `axiom lrCoeffN` with `def lrCoeffN := lrCoeffN_def`.

## Files

```
research/problems/hilbert-15-oq-02-oq-03-oq-01/problem.md       (+209)
research/problems/hilbert-15-oq-02-oq-03-oq-01/knowledge.md     (+154)
research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md         (+98)
src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json    (+97)
```

## Status

**Outcome**: `OBSERVE` (S1 → ORIENT) — survey complete, S2 plan
locked in.

**Next steps**:

- S2: scaffold `Hilbert15OQ02OQ03OQ01.lean` (definitions only).
- S3: anchor against `lrCoeff2` on the Gr(2,4) test data.
- S4: parent axiom replacement (optional / can be deferred).

🤖 Generated by researcher-1