### PR TITLE
audit(ehrhart-cube-proven-oq-04): sync meta.json (sorries 2->1, lineCount 422->584, +worpitzky in contributions)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "ehrhart-cube-proven-oq-04",
   "title": "Eulerian-Number Interpretation of the h*-Vector of the Unit Cube",
   "slug": "ehrhart-cube-proven-oq-04",
-  "description": "Open question from `ehrhart-cube-proven`: formalize the classical identity that the Ehrhart h*-vector of the unit d-cube is the sequence of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)). Equivalently, Worpitzky's identity: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d). S1 SCAFFOLD: defines `eulerianNumber d k` via the standard recurrence, verifies values for d ≤ 4 by `rfl`, proves Worpitzky for d = 1 and d = 2 explicitly, and states the general Worpitzky identity, the row-sum identity Σ A(d, k) = d!, and the palindrome A(d, k) = A(d, d-1-k) as deferred theorems.",
+  "description": "Open question from `ehrhart-cube-proven`: formalize the classical identity that the Ehrhart h*-vector of the unit d-cube is the sequence of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)). Equivalently, Worpitzky's identity: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d). Defines `eulerianNumber d k` via the standard recurrence, verifies values for d ≤ 4 by `rfl`, and proves the row-sum identity Σ A(d, k) = d! (S3) and the general Worpitzky identity (S4) by induction on d. The palindrome A(d, k) = A(d, d-1-k) remains as a single deferred theorem.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eulerian_number",
@@ -24,14 +24,13 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 422,
+    "lineCount": 584,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
     "openQuestions": [
-      "Prove `worpitzky_identity_cube`: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d) for all d ≥ 1 and n ≥ 0. The proof can proceed by induction on d via Pascal's identity and the Eulerian recurrence, or via a combinatorial bijection between (n+1)^d colour-sequences and (descent-pattern, position-pattern) pairs. S3 helpers (`eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`) discharge the standard boundary terms.",
       "Prove `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for k < d, by exhibiting the involution σ ↦ σ ∘ reverse on `Equiv.Perm (Fin d)` which bijects k-descent permutations with (d-1-k)-descent permutations."
     ],
     "originalContributions": [
@@ -43,7 +42,11 @@
       "Definition `cubeHStarPoly d : Polynomial ℕ` as the Eulerian generating polynomial",
       "Helper lemma `eulerian_zero_eq_one`: A(d, 0) = 1 for all d (S3, proven by Nat recursion)",
       "Helper lemma `eulerian_eq_zero_of_le`: A(d, k) = 0 for d ≥ 1, k ≥ d (S3, proven by double Nat recursion)",
-      "Row-sum identity `eulerian_row_sum_factorial`: Σ_{k<d} A(d, k) = d! for d ≥ 1 (S3, proven by induction on d via sum reorganisation and `A(d, d) = 0`)"
+      "Row-sum identity `eulerian_row_sum_factorial`: Σ_{k<d} A(d, k) = d! for d ≥ 1 (S3, proven by induction on d via sum reorganisation and `A(d, d) = 0`)",
+      "Algebraic step `worpitzky_step`: (k+1)·C(n+1+k, d+1) + (d-k)·C(n+2+k, d+1) = (n+1)·C(n+1+k, d), via Pascal and `Nat.choose_succ_right_eq` (S4)",
+      "Main theorem `worpitzky_identity_cube`: (n+1)^d = Σ_{k<d} A(d, k) · C(n+1+k, d) for all d ≥ 1 and n ≥ 0, proven by induction on d using `worpitzky_step` and the Eulerian recurrence (S4)",
+      "Coefficient identity `cube_h_star_eulerian`: (cubeHStarPoly d).coeff k = A(d, k) for 0 ≤ k < d",
+      "Lattice-count form `cube_lattice_count_eulerian`: |(Fin d → Fin (n+1))| = Σ_{k<d} A(d, k) · C(n+1+k, d), bridging the Fin-tuple count to the Eulerian sum"
     ],
     "prerequisites": [
       "EhrhartCubeProven: `cube_lattice_count` — L([0,1]^d, n) = (n+1)^d, axiom-free (companion file)",
@@ -78,7 +81,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -177,12 +180,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 422,
+    "lineCount": 584,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Auditor finding

`ehrhart-cube-proven-oq-04` meta.json overstated remaining sorries and understated proved contributions after S3+S4 landed.

## Verification

Against `proofs/Proofs/EhrhartCubeProvenOQ04.lean` on origin/main (`e0518146774`):

- `grep -c '\\bsorry\\b'` (comments stripped): **1** (`eulerian_palindrome` at line 272). Meta claimed **2**.
- `wc -l`: **584**. Meta claimed **422** (drift of 162 lines from S3 + S4 additions).
- `^theorem ` + `^lemma ` count: **26** (25 theorems + 1 lemma `worpitzky_step`). Meta claimed **25**.

`worpitzky_identity_cube` is fully proved at lines 348-466 (induction on d using `worpitzky_step` + Eulerian recurrence). It was still listed in `openQuestions` and absent from `originalContributions`.

## Changes (meta.json only, Lean source untouched)

- `sorries`: 2 -> 1 (top-level and `leanFile`)
- `lineCount`: 422 -> 584 (top-level and `leanFile`)
- `theoremCount`: 25 -> 26 (top-level and `leanFile`)
- `openQuestions`: drop `worpitzky_identity_cube`, keep only `eulerian_palindrome`
- `description`: rewrite "states the general Worpitzky identity ... as deferred" to reflect that only `eulerian_palindrome` remains
- `originalContributions`: add `worpitzky_step`, `worpitzky_identity_cube`, `cube_h_star_eulerian`, `cube_lattice_count_eulerian`

`badge` stays `wip` and `status` stays `formalized` since 1 sorry remains.

---

Discovered during gallery integrity audit (lean-auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)