### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S3 — channelMI_le_capacity + capacity_le_log_card (build pending)

### DIFF
--- a/proofs/Proofs/ShannonChannelCoding.lean
+++ b/proofs/Proofs/ShannonChannelCoding.lean
@@ -10,9 +10,10 @@
 
   Axioms: 3 (channel_coding_achievability, channel_coding_converse,
     bsc_capacity_eq)
-  Theorems: 9 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
-    channelMI_le_log_card, capacity_nonneg, rate_of_code_pos,
-    fano_inequality, bsc_capacity_le_one, bsc_capacity_nonneg)
+  Theorems: 11 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
+    channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity,
+    capacity_le_log_card, rate_of_code_pos, fano_inequality,
+    bsc_capacity_le_one, bsc_capacity_nonneg)
   Sorries: 0
 -/
 import Mathlib
@@ -122,6 +123,48 @@ theorem capacity_nonneg {α β : Type*} [Fintype α] [Fintype β]
       hr ▸ channelMI_le_log_card ch inp⟩
   · exact ⟨inp₀, rfl⟩
   · exact channelMI_nonneg ch inp₀
+
+/-- **Single-letter capacity upper bound.** For every input distribution `inp`,
+    the mutual information `I(X;Y)` is bounded by the channel capacity.
+
+    This is the immediate consequence of `channelCapacity` being defined as a
+    supremum over input distributions: any particular `inp` sits below the sup.
+    `BddAbove` is witnessed by `log |β|` via `channelMI_le_log_card`.
+
+    This lemma is the single-letter ingredient used in the converse direction
+    of the channel coding theorem (Fano's inequality + this bound rearrange
+    into `(1 - P_e) log M ≤ I(X;Y) + h(P_e) ≤ C + h(P_e)`). -/
+theorem channelMI_le_capacity {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (ch : DMChannel α β) (inp : InputDist α) :
+    channelMI ch inp ≤ channelCapacity ch := by
+  unfold channelCapacity
+  apply le_csSup
+  · exact ⟨Real.log (Fintype.card β), fun _ ⟨inp', hr⟩ =>
+      hr ▸ channelMI_le_log_card ch inp'⟩
+  · exact ⟨inp, rfl⟩
+
+/-- **Capacity upper bound by output alphabet.** Channel capacity is at most
+    `log |β|`. Combined with `capacity_nonneg`, this localises the capacity
+    of every DMChannel `α → β` to `[0, log |β|]`.
+
+    Immediate from `channelMI_le_log_card` and the supremum definition of
+    `channelCapacity`. Used downstream in the bsc analysis to bound the
+    capacity-achieving rate `1 - h(p)` from above. -/
+theorem capacity_le_log_card {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β] [Nonempty α]
+    (ch : DMChannel α β) :
+    channelCapacity ch ≤ Real.log (Fintype.card β) := by
+  unfold channelCapacity
+  have ⟨a⟩ := ‹Nonempty α›
+  let inp₀ : InputDist α :=
+    { p := fun x => if x = a then 1 else 0
+      nonneg := fun x => by split_ifs <;> norm_num
+      sum_one := by simp [Finset.sum_ite_eq', Finset.mem_univ] }
+  apply csSup_le
+  · exact ⟨channelMI ch inp₀, inp₀, rfl⟩
+  · rintro r ⟨inp, rfl⟩
+    exact channelMI_le_log_card ch inp
 
 /- ## Block codes -/
 

--- a/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
@@ -1,66 +1,81 @@
 # Current State
 
 **Phase**: ACT-PROGRESS
-**Since**: 2026-05-12T03:55:00Z
-**Iteration**: 2
+**Since**: 2026-05-12T04:45:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Step 4 (deferred from iteration 1) executed: in
-`proofs/Proofs/ShannonChannelCoding.lean`, the `axiom fano_inequality`
-declaration is replaced by a `theorem` whose body delegates to
-`FanoFromConditionalEntropy.fano_inequality_proved` (the dispatcher added in
-iteration 1, PR #17739). A new top-of-file
-`import Proofs.ShannonChannelCodingOQ02OQ01` makes the dispatcher visible.
+Iteration 3 follows on from S2 (PR #17796, merged: axiom `fano_inequality`
+discharged into a theorem via the `FanoFromConditionalEntropy` dispatcher).
+The next-action item from S2's state.md asked: *can `channel_coding_converse`
+be discharged via the new `fano_inequality` theorem combined with a
+data-processing-inequality lemma already in the gallery?* The full
+asymptotic converse is multi-step (Fano + chain rule + uniform-X entropy +
+sub-additivity for the block extension `(X^n, Y^n)`), so this iteration
+contributes the **single-letter capacity bounds** that sit underneath any
+Fano-style converse, exposing them as named lemmas in
+`ShannonChannelCoding.lean`:
+
+1. `channelMI_le_capacity` — for every input distribution `inp`,
+   `channelMI ch inp ≤ channelCapacity ch`. Proof: `le_csSup` against the
+   `BddAbove` witness `Real.log (Fintype.card β)` supplied by the existing
+   `channelMI_le_log_card`.
+2. `capacity_le_log_card` — `channelCapacity ch ≤ Real.log (Fintype.card β)`
+   when `[Nonempty α]`. Proof: `csSup_le` against the same uniform-`log|β|`
+   bound, nonempty witness via the point-mass `inp₀` already used in
+   `capacity_nonneg`.
+
+Together with `capacity_nonneg`, this localises every DMChannel `α → β` to
+capacity in the closed interval `[0, log|β|]` (proof-level, not only at
+the definition level).
 
 Gallery-entry counts on the parent slug `shannon-channel-coding` are synced
-in this PR (axiomCount 4→3, theoremCount 8→9, lineCount 228→233, assumptions
-string rewritten to reflect Fano discharge).
+in this PR (theoremCount 9 → 11, lineCount 233 → 275, assumptions string
+extended).
 
 ## Active Approach
 
-Term-mode reference:
+The two new theorems mirror the proof skeleton of `capacity_nonneg` (already
+in-file) modulo a duality flip (`le_csSup_of_le` ↔ `le_csSup` for the lower
+bound; `csSup_le` for the upper bound). The same `BddAbove` witness and
+nonempty witness are reused unchanged.
 
-```lean
-theorem fano_inequality {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    (pXY : α × β → ℝ) (hp : ∀ x, 0 ≤ pXY x) (hsum : ∑ x, pXY x = 1) :
-    let pX : α → ℝ := fun x => ∑ y : β, pXY (x, y)
-    let P_e := 1 - ∑ y : β, ∑ x : α, pXY (x, y) ^ 2 / (∑ x' : α, pXY (x', y))
-    conditionalEntropy pXY ≤
-      InformationTheory.BinaryEntropy.h P_e +
-        P_e * Real.log (Fintype.card α - 1) :=
-  FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum
-```
-
-The dispatcher's stated type matches the axiom's modulo:
-* the unused `let pX` (drops out under defeq unfolding),
-* `conditionalEntropy` vs `InformationTheory.conditionalEntropy` (same symbol
-  after `open InformationTheory` at the call site),
-* `InformationTheory.BinaryEntropy.h` vs `h` (same after the dispatcher's
-  `open ... InformationTheory.BinaryEntropy`),
-* `Real.log (Fintype.card α - 1)` vs `Real.log ((Fintype.card α : ℝ) - 1)` —
-  both elaborate to the same expression because `Real.log : ℝ → ℝ` forces
-  the argument's expected type to ℝ before the subtraction is resolved.
+These are explicitly named so that the next iteration's Fano-step converse
+can write `(1 - P_e) * Real.log M ≤ channelMI ch inp + h P_e ≤ channelCapacity ch + h P_e`
+in two trivial `linarith` steps once an `entropy_of_uniform_eq_log_card`
+lemma is in place.
 
 ## Blockers
 
-* Same `proofs/.lake` recursive self-symlink — verification deferred per
-  established "(build pending)" PR-title convention. If a follow-up build
-  flags a defeq mismatch, the fallback is a tactic-mode proof:
-  `:= by exact FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum`.
+* `proofs/.lake` recursive self-symlink persists (per memory feedback) — S3
+  follows the "(build pending)" PR-title convention. Both new lemmas are
+  syntactic transcriptions of standard Mathlib `csSup`/`le_csSup` calling
+  conventions and should compile without metavariable strands; if a follow-up
+  build flags an issue, the fallback is to inline the `BddAbove` witness as
+  a named `have` before each `apply`, mirroring `capacity_nonneg`.
 
 ## Next Action
 
-* Mechanic / audit pass: re-sync any sibling meta.json that still cites
-  4-axiom counts on shannon-channel-coding.
-* Generated follow-up question (axiom elimination): can
-  `channel_coding_converse` be discharged via the new `fano_inequality`
-  theorem combined with a data-processing-inequality lemma already in the
-  gallery?
+* Mechanic / audit pass: verify any sibling meta.json that still cites
+  9-theorem counts on `shannon-channel-coding` (parent slug now bumped to
+  11; the OQ-02-OQ-01 / OQ-02 / OQ-04 / etc. sub-galleries describe their
+  own proof files and should not need an update).
+* S4 candidate: stand up `entropy_of_uniform_eq_log_card` (H(uniform) =
+  log|α|) in `ShannonEntropy.lean` (or here, if it's easier as a special
+  case of an existing entropy_le_log_card with equality witness), so that
+  the Fano-step converse `(1 - P_e) log M ≤ channelMI ch inp + h P_e`
+  becomes a direct corollary of the now-named `channelMI_le_capacity`
+  combined with `fano_inequality` + chain rule.
+* Alternative S4: build the `IndepWith` / DPI-style lemma for the joint
+  `(X^n, Y^n)` extension under a memoryless channel — this is the second
+  half of the converse but requires an asymptotic `nR ≤ I(X^n;Y^n)` chain
+  rule which is much heavier and likely needs its own `OQ-02-OQ-01-OQ-02`
+  slug.
 
 ## Attempt Counts
 
-- Total attempts: 2
+- Total attempts: 3
 - Current approach attempts: 1
-- Approaches tried: 2 (S1 dispatcher; S2 axiom swap)
+- Approaches tried: 3 (S1 dispatcher; S2 axiom swap; S3 single-letter
+  capacity bounds)

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -39,10 +39,10 @@
       "Channel capacity definition (placeholder returning 0)",
       "Theorem statements for Fano inequality, achievability, converse, and BSC capacity (all placeholder stubs proving True)"
     ],
-    "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 9 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01). 0 sorries.",
+    "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 11 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 233,
+    "lineCount": 275,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",
@@ -51,7 +51,7 @@
       "Fano's inequality and the channel coding converse"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 8
   },
   "overview": {
@@ -172,9 +172,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 233,
+    "lineCount": 275,
     "axiomCount": 3,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iteration 3 of the `shannon-channel-coding-oq-02-oq-01-oq-01` line. Adds **two
single-letter capacity bounds** to `proofs/Proofs/ShannonChannelCoding.lean`:

- `channelMI_le_capacity` — `channelMI ch inp ≤ channelCapacity ch` for every input distribution.
- `capacity_le_log_card` — `channelCapacity ch ≤ Real.log (Fintype.card β)` when `[Nonempty α]`.

Combined with the existing `capacity_nonneg`, every DMChannel `α → β` is now
proof-level bounded by `[0, log|β|]`. These are the single-letter ingredients
that any Fano-based converse must use; naming them at top level makes the next
iteration's Fano-step bound `(1 - P_e) log M ≤ C + h(P_e)` a two-`linarith`
chain once an `entropy_of_uniform_eq_log_card` lemma is in place (planned S4).

## Why this iteration

The next-action item from S2's state.md (PR #17796) asked whether
`channel_coding_converse` could be discharged via the new `fano_inequality`
theorem + a data-processing-inequality lemma already in the gallery. The full
asymptotic converse is multi-step (Fano + chain rule + entropy_of_uniform +
block-extension sub-additivity for `(X^n, Y^n)`), so S3 starts at the bottom
of that chain and lifts the capacity-sup bounds out of the definition into
named lemmas.

## Proof structure

Both proofs mirror `capacity_nonneg` (already in-file):

| Lemma | Pattern | Witness |
|---|---|---|
| `channelMI_le_capacity` | `le_csSup` | BddAbove via `channelMI_le_log_card` |
| `capacity_le_log_card` | `csSup_le` | Nonempty via point-mass `inp₀` |

## Build status

**"(build pending)"** per the established convention for this repo: the
`proofs/.lake` recursive self-symlink (memory-tracked blocker) prevents
local Docker builds from completing in a reasonable window. Both new lemmas
are syntactic transcriptions of standard Mathlib `csSup`/`le_csSup` calling
conventions and should compile without metavariable strands; fallback if
they don't is to inline the `BddAbove` witness as a named `have` before each
`apply`, mirroring `capacity_nonneg`.

## Gallery sync

Parent slug `shannon-channel-coding`:
- `theoremCount`: 9 → 11
- `lineCount`: 233 → 275
- `assumptions` string extended with the two new theorem names

Sub-galleries (OQ-02-OQ-01 / OQ-02 / OQ-04 / OQ-03 / etc.) describe their own
files and need no update.

## Test plan

- [ ] `proofs/Proofs/ShannonChannelCoding.lean` compiles (deferred — see "Build status")
- [x] No new axioms or sorries
- [x] `axiomCount` unchanged (still 3: `channel_coding_achievability`,
  `channel_coding_converse`, `bsc_capacity_eq`)
- [x] Theorem count and lineCount synced between meta.json and the Lean file
- [x] Pre-push race check passed (no overlapping S3 PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)