### PR TITLE
Enrich greens-theorem-oq-01-oq-01-oq-02-oq-03: 6 annotations + conclusion

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/annotations.json
@@ -1,1 +1,127 @@
-[]
+[
+  {
+    "id": "ann-audit-header",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "S1 OBSERVE Audit: Codomain Genericity Confirmed",
+    "content": "The header records the S1 audit (PR #17769) that decided this question is mathematically routine: every Mathlib lemma invoked by the parent file's real-valued proofs is *already* codomain-generic. The audit explicitly catalogues the five Bochner-generic lemmas (`MeasureTheory.integral_integral_swap`, `Measure.prod_mono`, `Measure.restrict_mono`, `integral_of_le`, `Integrable.mono_measure`) and the lone ℝ-specific tactic (`linarith` in the sign-analysis sub-cases), pinpointing `linarith → abel` as the only non-mechanical substitution required for the Bochner port. This audit-then-port pattern — rather than blind reproof — is how this gallery handles codomain-generalization questions efficiently.",
+    "mathContext": "Audit conclusion: for $f : \\mathbb{R} \\times \\mathbb{R} \\to E$ with $E$ a Banach space ($\\mathrm{NormedAddCommGroup}\\ E$, $\\mathrm{NormedSpace}\\ \\mathbb{R}\\ E$, $\\mathrm{CompleteSpace}\\ E$), the parent's three real-valued $\\mathrm{intervalIntegral\\_swap}$ theorems generalize verbatim, modulo replacing four $\\mathrm{linarith}$ calls (over $\\mathbb{R}$) with $\\mathrm{abel}$ (over any additive abelian group).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Bochner integral",
+      "codomain genericity",
+      "Mathlib refactoring discipline",
+      "audit-then-port pattern"
+    ],
+    "prerequisites": [
+      "Mathlib's Bochner integration setup",
+      "the parent slug greens-theorem-oq-01-oq-01-oq-02"
+    ]
+  },
+  {
+    "id": "ann-imports-setup",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 41, "endLine": 54 },
+    "type": "definition",
+    "title": "Banach Codomain Variable Block",
+    "content": "The three-instance variable block `[NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]` is the canonical Mathlib4 setup for Bochner-valued integration. Completeness is essential: the Bochner integral is defined as the unique continuous linear extension of the simple-function integral, and the limit exists only in a Banach space. `NormedSpace ℝ` (rather than over an arbitrary scalar field) is required because `intervalIntegral.integral_symm` and `integral_neg` are proved in Mathlib for ℝ-modules; the result is *not* a scalar-genericity result but specifically a real-scalar Bochner-genericity result. The three imports cover (i) `intervalIntegral` notation, (ii) product-measure Fubini, and (iii) product-measure mass and monotonicity.",
+    "mathContext": "Banach setup: $\\langle E, \\|\\cdot\\| \\rangle$ a Banach space over $\\mathbb{R}$, i.e. a complete normed $\\mathbb{R}$-vector space. The Bochner integral $\\int_X f\\,d\\mu \\in E$ is defined for strongly-measurable $f : X \\to E$ with $\\int_X \\|f\\|\\,d\\mu < \\infty$ as the limit of integrals of simple-function approximants, using completeness of $E$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Banach space",
+      "Bochner-Pettis measurability",
+      "strong measurability",
+      "completion of normed spaces"
+    ],
+    "prerequisites": [
+      "normed vector spaces",
+      "completeness in metric spaces",
+      "Mathlib's MeasureTheory namespace"
+    ]
+  },
+  {
+    "id": "ann-ordered-case",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 56, "endLine": 81 },
+    "type": "technique",
+    "title": "Ordered Case: Icc-to-Ioc Bridge, Then Bochner Fubini",
+    "content": "The proof of the ordered case follows a three-step pattern that is the canonical bridge from interval-integral notation `∫ x in a..b, f x` to product-measure Fubini. (1) `integral_of_le hab` rewrites each `∫ x in a..b` as `∫ x in Ioc a b, f x ∂volume`, which exposes the underlying restricted Lebesgue integral. (2) The hypothesis is upgraded from `Integrable f ((volume.restrict (Icc a b)).prod (volume.restrict (Icc c d)))` to the Ioc-restricted version via `Integrable.mono_measure` plus `Measure.prod_mono` applied to `Measure.restrict_mono Ioc_subset_Icc_self`. This is the *only* point in the proof where the Icc-vs-Ioc distinction matters, and it is purely a measure-monotonicity step — completely independent of the codomain. (3) `MeasureTheory.integral_integral_swap` (Mathlib's Bochner Fubini) closes the goal, with `.symm` flipping the conclusion. Every lemma in this chain is already stated for Banach codomains, which is why the port is verbatim.",
+    "mathContext": "Reduction: $\\int_c^d \\int_a^b f(x,y)\\,dx\\,dy \\;=\\; \\int_{Ioc(c,d)}\\!\\!\\int_{Ioc(a,b)} f\\;d\\mathrm{vol}\\;d\\mathrm{vol} \\;\\stackrel{\\text{Fubini}}{=}\\; \\int_{Ioc(a,b)}\\!\\!\\int_{Ioc(c,d)} f\\;d\\mathrm{vol}\\;d\\mathrm{vol} \\;=\\; \\int_a^b \\int_c^d f(x,y)\\,dy\\,dx$, valid for $a \\le b$, $c \\le d$, $f$ measurable and integrable on the product rectangle.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fubini's theorem",
+      "product measure",
+      "interval integral",
+      "Lebesgue measure restriction",
+      "measure monotonicity"
+    ],
+    "prerequisites": [
+      "Bochner Fubini (Mathlib MeasureTheory.Integral.Prod)",
+      "interval integral notation",
+      "Measure.restrict",
+      "Ioc_subset_Icc_self"
+    ]
+  },
+  {
+    "id": "ann-sign-helpers",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "technique",
+    "title": "Sign-Flip and Negation-Extraction (Codomain-Generic)",
+    "content": "The two `private` lemmas `flip_bounds_E` and `neg_outside_E` are one-line ports of the parent's real-valued helpers. `flip_bounds_E` packages `intervalIntegral.integral_symm`, which is the convention that swapping the limits of `∫ x in a..b, f x` negates the integral — this convention is purely *definitional* in Mathlib (the interval integral is `∫ x in Ioc a b - ∫ x in Ioc b a`), so the lemma costs only a `rw`. `neg_outside_E` is `intervalIntegral.integral_neg` repackaged with the codomain made explicit; the underlying fact is that the Bochner integral is an *additive* operation on $E$, so it commutes with negation. Both are codomain-generic in Mathlib because Mathlib's interval integral is defined for any `NormedAddCommGroup` codomain.",
+    "mathContext": "Sign-flip: $\\int_a^b f\\,dx \\;=\\; -\\int_b^a f\\,dx$ (Mathlib's interval-integral convention). Negation: $\\int_a^b (-g)\\,dx \\;=\\; -\\int_a^b g\\,dx$ (linearity, codomain-generic). These two identities together generate the parent's full sign analysis in the general case.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval-integral sign convention",
+      "linearity of integration",
+      "abelian group homomorphism"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_symm",
+      "intervalIntegral.integral_neg"
+    ]
+  },
+  {
+    "id": "ann-general-case",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 97, "endLine": 121 },
+    "type": "insight",
+    "title": "General Case (Deferred S3): Four-Way Sign Analysis, linarith → abel",
+    "content": "The general case drops the ordering hypotheses on `(a,b)` and `(c,d)`. The strategy is a four-way case split — `(a ≤ b) × (c ≤ d)`, `(a ≤ b) × (c > d)`, `(a > b) × (c ≤ d)`, `(a > b) × (c > d)` — where each branch reduces to the ordered case via `flip_bounds_E` (to swap unordered bounds) followed by `neg_outside_E` (to push negations through the outer integral). The parent file closes the resulting algebraic identities (e.g., `α + β = -(-α - β)`) using `linarith`, which is real-specific. Here, the same identities hold in any additive abelian group, so `abel` (Mathlib's tactic for abelian-group ring rearrangements) closes them directly. This is the heart of why codomain genericity is `free`: the sign analysis is *not* an order-theoretic argument disguised as algebra; it really is just additive-abelian.",
+    "mathContext": "General Fubini for interval integrals: $\\int_c^d \\int_a^b f(x,y)\\,dx\\,dy \\;=\\; \\int_a^b \\int_c^d f(x,y)\\,dy\\,dx$ for *arbitrary* $a, b, c, d \\in \\mathbb{R}$, provided $f$ is jointly measurable and integrable on $\\mathrm{uIcc}(a,b) \\times \\mathrm{uIcc}(c,d)$. The four sign sub-cases coalesce because the parent identities are of the form $X = -(-X)$ over an additive abelian group.",
+    "significance": "key",
+    "relatedConcepts": [
+      "abelian-group rearrangement",
+      "linarith vs abel tactic boundary",
+      "uIcc (unordered closed interval)",
+      "case analysis on order"
+    ],
+    "prerequisites": [
+      "Mathlib's abel tactic",
+      "uIcc (Set.uIcc)",
+      "ordered case (above)"
+    ]
+  },
+  {
+    "id": "ann-continuous-case",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 123, "endLine": 141 },
+    "type": "insight",
+    "title": "Continuous Case (Deferred S3): Hypothesis-Free Specialization",
+    "content": "The continuous case is the ergonomically important specialization: for `f : ℝ × ℝ → E` continuous, the iterated interval integrals coincide on *any* rectangle, with no separate measurability or integrability obligations. Both hypotheses are automatic from continuity on a compact rectangle: `Continuous.measurable` (Mathlib) supplies joint measurability via the Borel σ-algebra on E, and `ContinuousOn.intervalIntegrable` / `ContinuousOn.integrableOn_compact` supplies integrability because a continuous function on a compact set is bounded and hence integrable against Lebesgue measure restricted to that set. Both helpers are codomain-generic in Mathlib, which is what makes this case a one-line consequence of the general case rather than a separate analytic argument.",
+    "mathContext": "Continuous Fubini: for $f : \\mathbb{R}^2 \\to E$ continuous and $a,b,c,d \\in \\mathbb{R}$, $\\int_c^d \\int_a^b f(x,y)\\,dx\\,dy = \\int_a^b \\int_c^d f(x,y)\\,dy\\,dx$, with measurability and integrability automatic. The key fact: $f$ continuous on $[a,b] \\times [c,d]$ (compact) implies $\\|f\\|$ bounded, hence $f$ is Bochner-integrable on the rectangle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Continuous.measurable",
+      "ContinuousOn.integrableOn_compact",
+      "Borel measurability",
+      "compactness implies boundedness"
+    ],
+    "prerequisites": [
+      "general case (above)",
+      "Continuous.measurable",
+      "ContinuousOn.intervalIntegrable"
+    ]
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -143,6 +143,15 @@
       "mathContext": "Continuous Fubini: for $f: \\mathbb{R}^2 \\to E$ continuous, the iterated interval integrals on any $(a,b) \\times (c,d)$ rectangle coincide automatically."
     }
   ],
+  "conclusion": {
+    "summary": "This S2 SCAFFOLD ports the parent's first `intervalIntegral_swap` theorem (ordered case) to a Banach codomain `E` (NormedAddCommGroup, NormedSpace ℝ, CompleteSpace) by *verbatim* reuse of the parent's real-valued proof. The two private sign-flip helpers (`flip_bounds_E`, `neg_outside_E`) are also fully proven for E. The general case and the continuous-function specialization are stated for E with `sorry`, awaiting S3 (a 4-way sign analysis where the parent's four `linarith` calls become `abel`).",
+    "implications": "The Bochner integral is the standard tool for Banach-valued integration in analysis and probability — empirical processes, vector measures, stochastic processes, Banach-valued differential forms. Having a working `intervalIntegral_swap` for Banach codomains is a building block for any one-dimensional vector-calculus development (Green's theorem, Stokes' theorem, divergence theorem) phrased over Mathlib's `∫ x in a..b, f x` notation rather than the lower-level `∫ x in s, f x ∂μ`. More broadly, the audit-then-port workflow demonstrated here is a template for handling Mathlib codomain-generalization questions efficiently: catalog the dependencies, identify the *only* tactic that is codomain-specific (`linarith`), and substitute (`abel`). This pattern keeps the gallery's Banach-valued extensions in lockstep with their real-valued parents without duplicating mathematical effort.",
+    "openQuestions": [
+      "Does the same audit-then-port pattern work for the *signed* measure setting (replacing `volume` with a general signed measure of bounded variation)? The Mathlib API around `Measure.prod` is structured for `MeasureTheory.Measure` (positive), so signed-measure Fubini would need an additional Jordan-decomposition step.",
+      "Can `intervalIntegral_swap` be extended to a *locally convex* codomain (not necessarily normed), using Pettis integration in place of Bochner? Mathlib does not currently have a developed Pettis-integral API, so this would require infrastructure work.",
+      "What is the cleanest way to phrase the Banach-valued analogue of Green's theorem (∮ closed-curve integral = ∬ region integral) on top of this Fubini lemma? The natural target is `f : ℝ² → E` with `E` Banach, where the line integral is the standard Riemann-Stieltjes type and the area integral is Bochner."
+    ]
+  },
   "crossReferences": [
     {
       "type": "parent",


### PR DESCRIPTION
## Summary

Enrichment pass for `greens-theorem-oq-01-oq-01-oq-02-oq-03` (Bochner generalization of `intervalIntegral_swap`).

Quality gaps closed:
- `annotations.json` was empty `[]`; added **6 annotations** covering the full 143-line Lean file (header/audit, codomain setup, ordered case, sign-flip helpers, general case, continuous case). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- `meta.json` had no `conclusion`; added one with `summary`, `implications`, and 3 substantive `openQuestions` (signed-measure Fubini, Pettis integration for locally convex codomains, Banach-valued Green's theorem phrasing).

## Notes

- No changes to the Lean file or to existing meta fields.
- All annotation ranges align with actual Lean constructs (verified via `tsx scripts/annotations/build.ts` — no warnings for this slug).
- Axiom integrity: this is an S2 SCAFFOLD with 2 sorries and 0 axioms; `status: "axiomatized"` and `badge: "axiom"` already reflect that. No discrepancy.

## Test plan

- [x] JSON validates (`python3 -c "import json; json.load(...)"`)
- [x] Annotations build emits no warnings for this slug (`tsx scripts/annotations/build.ts`)
- [x] No unrelated TypeScript regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)