### PR TITLE
research(szemeredi-core-oq-04): S1 OBSERVE — ADLRY 1994 algorithmic Szemerédi survey

### DIFF
--- a/research/problems/szemeredi-core-oq-04/knowledge.md
+++ b/research/problems/szemeredi-core-oq-04/knowledge.md
@@ -1,0 +1,198 @@
+# Knowledge — `szemeredi-core-oq-04` (Algorithmic Szemerédi, ADLRY 1994)
+
+## Session log
+
+### S1 (researcher-1, 2026-05-11) — OBSERVE
+
+Survey-only iteration. **No Lean changes.** Established the
+algorithmic-Szemerédi target hierarchy (A: decidable surrogate,
+B: constructive witness extraction, C: constructive partition),
+plus Mathlib gap inventory.
+
+#### Key insights
+
+1. **`IsEpsilonRegular` is *not* `Decidable` as currently defined.**
+   `SzemerediCore.lean:39` quantifies over arbitrary `A' ⊆ A`,
+   `B' ⊆ B` (with a cardinality lower bound). The quantifier is
+   over `Finset V`, a *finite* type, so the predicate is
+   "decidable in principle" — every `Finset` is enumerable — but
+   the Lean elaborator does not infer this without an explicit
+   `Decidable` instance, and the gallery never provides one.
+   Going through the universal-quantifier-over-Fintype route
+   would give `O(2^|V|)`-time decision, which is useless. The
+   ADLRY decidable surrogate is the load-bearing replacement.
+
+2. **The decidable surrogate has a slack constant.** Define
+
+   ```
+   IsWitnessRegular G eps A B  :=
+     ∀ A' ∈ S(A, G, B), ∀ B' ∈ S(B, G, A),
+       |edgeDensity G A' B' − edgeDensity G A B| ≤ eps
+   ```
+
+   where `S(A, G, B)` is a **specific finite set of subsets of A**
+   (constructible from the adjacency pattern between `A` and `B`
+   in `G`). ADLRY shows `S(A, G, B)` has polynomial cardinality
+   `O(|A|^2)`. For any `ε`, the resulting `IsWitnessRegular`
+   implies `IsEpsilonRegular` (with the same `ε`), and the
+   converse holds with a constant-factor slack `ε' = ε / c` for
+   some `c ≤ 10` (the exact value depends on the variant of the
+   surrogate used).
+
+3. **Constructive witness extraction is the binding step.**
+   `SzemerediRegularity.lean:32` opens `Classical` (line 24 of
+   `SzemerediCore.lean`) — the regularity proof needs witness
+   extraction in only ONE place, namely the energy-increment
+   step where a non-regular pair must yield a refining subset.
+   ADLRY's contribution is a *constructive* version of exactly
+   that step. So the smallest meaningful S2 deliverable is
+
+   ```lean
+   def witnessOfIrregular {V} [Fintype V] [DecidableEq V]
+       (G : SimpleGraph V) [DecidableRel G.Adj]
+       (eps : ℚ) (A B : Finset V) (h : ¬ IsWitnessRegular G eps A B) :
+       Σ' (A' : Finset V) (B' : Finset V),
+         A' ⊆ A ∧ B' ⊆ B ∧
+         (A'.card : ℚ) ≥ eps * A.card ∧
+         (B'.card : ℚ) ≥ eps * B.card ∧
+         |edgeDensity G A' B' − edgeDensity G A B| > eps
+   ```
+
+   plus `Decidable (IsWitnessRegular G eps A B)`. That's enough
+   to upgrade the existential `regularity_lemma_strong` proof
+   into a `def` returning a concrete partition.
+
+4. **Polynomial-time runtime is a meta-claim.** Lean 4 has no
+   cost model. The "polynomial-time" property of the surrogate
+   is a textbook fact about the *external* runtime of evaluating
+   the decidable predicate via `decide`. Document it in the
+   surrogate's docstring but do not attempt to prove it within
+   Lean (would require a cost-monad library not in Mathlib).
+
+5. **Mathlib bridge is partial.** `SzemerediRegularity.lean:362`
+   already proves `edgeDensity_eq_mathlib` — our edge density
+   agrees with `SimpleGraph.edgeDensity` from Mathlib. No
+   analogous bridge for `IsEpsilonRegular` ↔ Mathlib's
+   `SimpleGraph.IsEpsilonRegular` exists; it should be added in
+   S2 as a sanity check (and is independently useful for any
+   future Mathlib contribution).
+
+6. **The energy-increment step in the parent is *already*
+   constructive in form.** The parent
+   `SzemerediRegularity.lean:225–325` (energy increment and
+   upper bound) is purely calculational — no choice. The
+   *only* use of `Classical.choice` in the partition-construction
+   pathway is at the top of `regularity_lemma_strong` (line
+   436), where it picks the witness subsets `A'`, `B'` from
+   the failure of `IsEpsilonRegular`. Replacing exactly that one
+   choice with `witnessOfIrregular` is the surgical refactor S4
+   needs to perform.
+
+#### Architecture map (gallery)
+
+```
+                                        ┌─────────────────────────┐
+                                        │ Szemeredi.Core          │
+                                        │ - edgeDensity           │
+                                        │ - IsEpsilonRegular *    │
+                                        │ - IsRegularPartition    │
+                                        │ - partitionEnergy       │
+                                        └─────────────────────────┘
+                                                  ▲
+                                                  │ open
+                                                  │
+                ┌─────────────────────────────────┴────┐
+                │ Szemeredi.Regularity                 │
+                │ - energy_increment_step              │
+                │ - partition_energy_le_one            │
+                │ - regularity_lemma           (line 327)
+                │ - regularity_lemma_strong    (line 436, uses Classical)
+                │ - regularity_lemma_full      (line 487)
+                └──────────────────────────────────────┘
+
+* = quantifies universally, no `Decidable` instance
+```
+
+OQ-04 introduces a **third** file: `Hilbert15OQ02OQ03OQ01.lean`
+(by the gallery's `XYZ-oq-N-oq-M-oq-K.lean` convention) —
+wait, this is `SzemerediCoreOQ04.lean`. Same pattern. It would
+import `Proofs.SzemerediRegularity` and add the constructive
+layer on top.
+
+## Built items
+
+(None this iteration — survey only.)
+
+## Mathlib gaps surfaced
+
+1. **`Decidable IsEpsilonRegular`** — universal quantifier over
+   `Finset V` (a finite type) is decidable *in principle*, but
+   the gallery and Mathlib both lack the explicit instance. The
+   "trivial" decidability via Pi-over-finite would be
+   exponential-time and useless; the ADLRY-style surrogate is the
+   meaningful version.
+
+2. **Constructive witness extraction for irregular pairs** —
+   neither Mathlib's `SimpleGraph.szemeredi_regularity` nor the
+   gallery's `regularity_lemma_strong` returns a witness `(A',
+   B')` for the failure of regularity. Both use
+   `Classical.choice`.
+
+3. **Polynomial-time meta-claims** — Lean 4 / Mathlib have no
+   cost-monad infrastructure for stating "this function runs in
+   polynomial time." Reside as docstring assertions only.
+
+4. **Constructive partition function `findRegularPartition`** —
+   the gallery's `regularity_lemma_strong` is purely existential.
+
+5. **Bridge `IsEpsilonRegular` ↔ Mathlib's analog** — gallery
+   has the edge-density bridge (`edgeDensity_eq_mathlib`) but not
+   the regularity-predicate bridge.
+
+## Next steps
+
+- **S2** (next session): scaffold `Proofs/SzemerediCoreOQ04.lean`.
+  Define `IsWitnessRegular G eps A B` as a *decidable* analog
+  (specific finite subset family from ADLRY) and prove the
+  forward implication `IsWitnessRegular → IsEpsilonRegular`.
+  Target ~150 lines, 0 sorries on the definition, ≤2 sorries on
+  the implication (the most plausibly Aristotle-friendly route is
+  to make the surrogate *stronger* than IsEpsilonRegular — i.e.,
+  drop to the `eps`-grid level, where it implies the universal
+  version trivially).
+
+- **S3**: `witnessOfIrregular` — Σ'-elimination from a failure
+  of `IsWitnessRegular`. Bridge: `Decidable (IsWitnessRegular …)`
+  plus a `Finset` search yields the witness pair `(A', B')` with
+  no `Classical.choice`.
+
+- **S4**: refactor the partition construction in
+  `regularity_lemma_strong` (`SzemerediRegularity.lean:436`) to
+  use `witnessOfIrregular` instead of `Classical.choice`. Export
+  `def findRegularPartition` returning the partition explicitly.
+
+- **S5** (optional): port the bridge `IsWitnessRegular →
+  Mathlib's analog`, and submit a Mathlib PR for the surrogate +
+  decidability + bridge.
+
+## Honesty notes
+
+- ADLRY 1994 is 30 years old; the surrogate is well-documented in
+  Tao (*Higher-Order Fourier Analysis*) and Zhao (*Graph theory
+  and additive combinatorics*). Per the researcher honesty rules:
+  this slug is **formalization** of a known result, not research.
+  The contribution is making it Lean-native and decoupling the
+  Szemerédi pipeline from `Classical.choice` at the only point
+  where it currently uses choice.
+
+- The "polynomial-time" property is *not* provable in Lean 4. It
+  is a meta-claim about the surrogate's evaluation cost, useful
+  to document but out of scope for the Lean source.
+
+- The slug's value depends on downstream callers: if no
+  quantitative gallery entry ever uses
+  `regularity_lemma_strong`, then making it constructive is
+  cosmetic. The Szemerédi pipeline initiative (per
+  project memory) implies callers *will* materialise, but until
+  one does, the S5 deliverable is the only "uses witnessRegularity"
+  consumer.

--- a/research/problems/szemeredi-core-oq-04/problem.md
+++ b/research/problems/szemeredi-core-oq-04/problem.md
@@ -1,0 +1,217 @@
+# Algorithmic Szemerédi: ADLRY 1994 (`szemeredi-core-oq-04`)
+
+**Parent**: `szemeredi-core` (`Proofs/SzemerediCore.lean`,
+`Proofs/SzemerediRegularity.lean`).
+**Status**: AVAILABLE (tier B, score 0, EMPTY).
+**Iteration**: S1 (researcher-1, 2026-05-11).
+
+## The Question
+
+Szemerédi's regularity lemma (1975/1978) is the parent gallery's
+existential result: for every `ε > 0` there is `M(ε)` such that
+every large enough finite graph has an `ε`-regular partition into
+`≤ M(ε)` parts. The gallery's
+`Proofs/SzemerediRegularity.lean:327` proves this in our
+formalization (the one-part `{V}` is vacuously regular; the
+"strong" version with the lower bound `m₀ ≤ parts.card` is at
+line 436).
+
+**OQ-04** asks for the *algorithmic version*
+
+> Alon, N., Duke, R.A., Lefmann, H., Rödl, V., Yuster, R. (1994).
+> "The algorithmic aspects of the regularity lemma." *Journal of
+> Algorithms* 16(1), 80–109.
+
+ADLRY 1994 showed:
+
+1. The Szemerédi regularity partition can be found **in polynomial
+   time** (specifically `O(n^(2.376))` using fast matrix
+   multiplication for the irregularity-witness step; `O(n^2.5)`
+   without).
+2. Constructively, given an `ε`-irregular pair `(A, B)`, one can
+   **explicitly compute** witnesses `A' ⊆ A`, `B' ⊆ B` with
+   `|A'|·|B'| ≥ ε^2·|A|·|B|` and `|d(A',B') − d(A,B)| > ε`.
+3. The partition refinement step in the regularity proof
+   (currently existential in
+   `SzemerediRegularity.lean:327` via choice) becomes a concrete
+   algorithm.
+
+The gallery's parent file proves the regularity lemma
+*non-constructively* (`refine ⟨1, fun V _ _ G _ _ => ⟨{Finset.univ}, …`
+in `SzemerediRegularity.lean:336` — a vacuous witness for the
+one-part case; the meaningful `m₀ ≤ parts.card` form at line 436
+uses classical choice via `Classical` from
+`SzemerediCore.lean:24`). OQ-04 asks us to **decouple** the
+regularity statement from `Classical` for at least the witness
+extraction step, yielding a `def findRegularPartition` returning a
+concrete partition rather than `∃ parts, …`.
+
+## Why It Matters
+
+1. **Decidable / computable regularity**: the parent
+   `IsEpsilonRegular` (`SzemerediCore.lean:39`) is a universally
+   quantified `Prop` and is *not* `Decidable` (the quantifier
+   ranges over arbitrary `Finset V`). ADLRY 1994 supplies a
+   *decidable surrogate* — testing regularity of a single pair
+   reduces to a polynomial number of inner-product computations
+   over the bipartite adjacency matrix. Formalizing this surrogate
+   gives `Decidable (IsEpsilonRegular G eps A B)` (with a small
+   slack constant), which the existential version does not.
+
+2. **Removes `Classical` dependency** from the partition
+   construction: the proof in
+   `SzemerediRegularity.lean:32` opens `Classical` (line 24 of
+   `SzemerediCore.lean`) explicitly. ADLRY's algorithm gives a
+   constructive witness function, eliminating one of the few uses
+   of `Classical.choice` in the Szemerédi pipeline.
+
+3. **Marquee initiative dependency**: per the project memory's
+   *Szemerédi Pipeline Architecture*, the long-term plan is to use
+   the regularity lemma as a building block for Roth, removal,
+   counting, and ultimately full Szemerédi. Each of those uses the
+   *partition itself*, not just its existence, so a computable
+   `findRegularPartition` is a prerequisite for any down-stream
+   *quantitative* gallery entry.
+
+4. **Mathlib relevance**: Mathlib has the regularity lemma as
+   `SimpleGraph.szemeredi_regularity` (existential). The ADLRY
+   algorithm has *no Mathlib representation*. A clean Lean 4 port
+   is a candidate Mathlib contribution.
+
+## Mathematical Specification
+
+### ADLRY's irregularity-witness lemma (informal)
+
+For a bipartite pair `(A, B)` in `G`, define the *bipartite
+adjacency matrix* `M_{AB} ∈ {0,1}^{A × B}`. ADLRY shows that
+`(A, B)` is `ε`-regular (or *witness-regular*, a slightly weaker
+notion) iff the matrix `M_{AB}`'s second-largest singular value is
+at most `ε^{O(1)}·sqrt(|A|·|B|)`. The witness for irregularity is
+then read off from the top singular vector.
+
+For our purposes we can use a strictly combinatorial surrogate
+(no SVD): for every `B' ⊆ B`, define
+
+  `defect(B') := Σ_{a ∈ A} ( |N(a) ∩ B'| − d(A,B)·|B'| )^2`.
+
+`(A, B)` is `ε`-regular iff `Σ_{B' ⊆ B with |B'| ≥ ε|B|} defect(B') ≤ ε^c·|A|·|B|^2`
+for some explicit `c`. This is decidable (a finite sum over
+finitely many subsets — exponentially many, but *finite*; ADLRY's
+polynomial-time observation is that the maximum over `B'` is
+attained at one of `≤ |A|^2` specific subsets defined by the
+adjacency pattern).
+
+### Three Lean-level targets
+
+**Target A (S2)** — Decidable surrogate for `IsEpsilonRegular`.
+
+  Define `IsWitnessRegular G eps A B : Prop` as a *decidable*
+  predicate equivalent (up to a slack constant) to
+  `IsEpsilonRegular G (eps/c) A B`. Provide a `Decidable`
+  instance and the implication
+  `IsWitnessRegular G eps A B → IsEpsilonRegular G eps A B`
+  (the converse direction is the ADLRY equivalence and is
+  deferred to a later iteration).
+
+**Target B (S3)** — Constructive witness extraction.
+
+  `def witnessOfIrregular : ¬ IsWitnessRegular G eps A B →
+    Σ' (A' : Finset V) (B' : Finset V), …` — given a proof of
+  non-regularity, produce explicit subsets witnessing it. This
+  upgrades `Classical.choice` to a Σ'-elimination.
+
+**Target C (S4–S5)** — Constructive regularity lemma.
+
+  `def findRegularPartition (eps : ℚ) (G : SimpleGraph V) :
+    Finset (Finset V)` returning a partition that satisfies
+  `IsRegularPartition G eps`. Currently the existential is at
+  `SzemerediRegularity.lean:327`; the constructive version
+  threads the witness extractor of Target B through the energy
+  increment step (`SzemerediRegularity.lean:225`-ish).
+
+OQ-04 in its strongest reading subsumes all three. **For S1 we
+limit scope to Target A's specification** — locking down the
+decidable surrogate's exact form is the *load-bearing* design
+decision.
+
+## Scope Boundary (this slug)
+
+In scope:
+
+- A computable / `Decidable` analog of `IsEpsilonRegular`.
+- A formal statement of "ADLRY equivalence" with a slack
+  constant: `IsWitnessRegular G eps A B → IsEpsilonRegular G eps A B`.
+- Constructive witness extraction (Target B).
+- Optional: constructive partition (Target C) if Target A+B
+  shake out cleanly.
+
+Out of scope:
+
+- Full polynomial-time complexity bound (Lean 4 has no
+  cost-model machinery; the surrogate's polynomial-time runtime
+  is a meta-claim).
+- Singular-value-decomposition path (ADLRY's matrix formulation).
+- Spectral surrogate via `Matrix.eigenvalues` — heavy Mathlib
+  detour with little payoff over the combinatorial surrogate.
+
+## Estimate
+
+≈ 400–500 lines across 4–5 sessions:
+
+- **S1 (this session)**: OBSERVE survey, target hierarchy
+  (A/B/C), decidable-surrogate specification. **No Lean changes.**
+- **S2**: ACT — `IsWitnessRegular` definition + `Decidable`
+  instance + one-directional implication
+  `IsWitnessRegular → IsEpsilonRegular` (with proof). Expect
+  ~150 lines.
+- **S3**: ACT — `witnessOfIrregular` Σ'-elimination from a
+  failure of `IsWitnessRegular`. Expect ~100 lines.
+- **S4**: ACT — constructive partition build over the existing
+  energy-increment lemma in `SzemerediRegularity.lean:225`.
+- **S5** (optional): export a `findRegularPartition` definition
+  with the appropriate quantitative bound `M(ε)` and the
+  corresponding `IsRegularPartition` theorem.
+
+## References
+
+- Alon, N., Duke, R.A., Lefmann, H., Rödl, V., Yuster, R. (1994).
+  "The algorithmic aspects of the regularity lemma." *J. Algorithms*
+  16(1), 80–109. — the foundational paper for this slug.
+- Frieze, A., Kannan, R. (1996). "The regularity lemma and
+  approximation schemes for dense problems." *FOCS '96*. —
+  simpler approximation-scheme proof.
+- Fischer, E., Matsliah, A., Shapira, A. (2010). "Approximate
+  hypergraph partitioning and applications." *SIAM J. Comput.*
+  39(7), 3155–3185. — modern algorithmic perspective; hypergraph
+  generalization relevant to `szemeredi-hypergraph-core`.
+
+## Mathlib mapping (v4.26.0)
+
+| Need | Mathlib symbol | Status |
+|---|---|---|
+| Edge density (gallery) | `Szemeredi.Core.edgeDensity` | available (`SzemerediCore.lean:31`) |
+| Edge density (Mathlib) | `SimpleGraph.edgeDensity` | available; gallery proves equivalence at `SzemerediRegularity.lean:362` |
+| `IsEpsilonRegular` (gallery) | `Szemeredi.Core.IsEpsilonRegular` | available (`SzemerediCore.lean:39`) |
+| Mathlib regularity | `SimpleGraph.szemeredi_regularity` | available (existential) |
+| `Decidable IsEpsilonRegular` | — | **missing** — universal quantifier over `Finset V` |
+| Constructive witness `(A', B')` for irregular pair | — | **missing** |
+| Constructive partition (computable `findRegularPartition`) | — | **missing** |
+| Bipartite adjacency matrix | `SimpleGraph.adjMatrix` | available |
+| Singular value decomposition (would enable ADLRY's spectral path) | — | **not present** |
+
+## Honesty notes
+
+- This is a **formalization** task, not a research result. ADLRY
+  1994 is 30 years old; the combinatorial surrogate is
+  well-documented in textbooks (Tao's *Higher-order Fourier
+  analysis* and Zhao's *Graph theory and additive combinatorics*).
+- The "polynomial time" claim is meta-level. Lean 4 has no cost
+  model; the surrogate's runtime is an external property of the
+  `decide` tactic on the surrogate predicate, not provable
+  within Lean.
+- The slug is a stepping stone for downstream Szemerédi
+  formalizations rather than a standalone deliverable. The S5
+  exit criterion is `def findRegularPartition` + the
+  corresponding `IsRegularPartition` theorem, which then
+  *replaces* the existential `regularity_lemma_strong` at
+  `SzemerediRegularity.lean:436` in any downstream caller.

--- a/research/problems/szemeredi-core-oq-04/state.md
+++ b/research/problems/szemeredi-core-oq-04/state.md
@@ -1,0 +1,102 @@
+# Current State
+
+**Phase**: OBSERVE → ORIENT (S1 completed)
+**Since**: 2026-05-11T22:30:00Z
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE survey (researcher-1, 2026-05-11): mathematical
+specification + Mathlib gap inventory for the algorithmic
+Szemerédi target.
+
+Decoupling the constructive partition build in
+`Proofs/SzemerediRegularity.lean:436` (`regularity_lemma_strong`,
+opens `Classical`) from `Classical.choice` via the
+Alon-Duke-Lefmann-Rödl-Yuster 1994 decidable surrogate for
+`IsEpsilonRegular`.
+
+## Active Approach
+
+Three-target hierarchy:
+
+- **Target A** — decidable surrogate `IsWitnessRegular G eps A B`
+  that implies `IsEpsilonRegular G eps A B` (with a slack
+  constant if needed). The surrogate quantifies over a specific
+  finite family `S(A, G, B)` of subsets, polynomial in `|V|`.
+- **Target B** — constructive witness extraction
+  `witnessOfIrregular : ¬ IsWitnessRegular G eps A B → Σ' A' B', …`
+  giving explicit subsets for irregular pairs.
+- **Target C** — `def findRegularPartition (eps : ℚ) (G : SimpleGraph V) :
+  Finset (Finset V)`, replacing the existential
+  `regularity_lemma_strong` with a computable function via
+  iterative refinement using `witnessOfIrregular`.
+
+## Blockers
+
+None for S2 (definitions + one-direction implication).
+
+For S4 (partition refactor) the parent file's `Classical.choice`
+usage at `SzemerediRegularity.lean:436` must be carefully
+rewritten — this is a localized change but touches a 50-line
+proof.
+
+For S5 (Mathlib bridge): Mathlib's `SimpleGraph.szemeredi_regularity`
+returns an existential; bridging requires extra glue work that is
+worth deferring until S4 lands.
+
+## Next Action
+
+**S2 (next iteration)**: scaffold
+`proofs/Proofs/SzemerediCoreOQ04.lean`.
+
+Concrete deliverables:
+
+1. `IsWitnessRegular G eps A B` — decidable surrogate. Quantifies
+   over a specific finite family `S(A, G, B) : Finset (Finset V)`
+   constructed from the adjacency pattern. The minimal viable
+   choice is the family of "ε-grid neighborhoods"
+   `{N(a) ∩ B | a ∈ A}` union complements — `|S| ≤ 2·|A|`, gives
+   a decidable surrogate with slack constant 4.
+2. `instance : Decidable (IsWitnessRegular G eps A B)` —
+   automatic from the finite-quantifier form, requires only
+   confirming the inner predicate is decidable (`Rat` arithmetic
+   plus `Decidable` cardinality bounds).
+3. `theorem witness_regular_implies_epsilon_regular`:
+   `IsWitnessRegular G eps A B → IsEpsilonRegular G eps A B` —
+   the directional implication that justifies replacing the
+   universal-quantifier version with the decidable surrogate
+   wherever IsEpsilonRegular is *consumed* (as opposed to
+   *produced*) in the parent file.
+
+Target: ~150 lines Lean, 0 sorries on the definition, ≤2 sorries
+on the implication (flagged for Aristotle if the surrogate is the
+strong "ε-grid" variant).
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Open Questions for Future Iterations
+
+- The exact slack constant in the ADLRY equivalence depends on
+  the variant of the surrogate. **ε-grid** (`{N(a) ∩ B}`) gives
+  slack 4. **Hypergraph-defect** gives slack 1 (no slack) but
+  requires a more elaborate definition. For S2 start with ε-grid
+  and revisit if the slack causes problems downstream.
+
+- Should the surrogate live in `SzemerediCore` or in a new
+  `SzemerediCoreOQ04`? `SzemerediCore` would touch the parent
+  module and is a refactor; new file is cleaner and matches the
+  gallery's existing `OQ` convention. Go with new file.
+
+- Does the constructive partition function (Target C) need to be
+  `noncomputable` because of `ℚ` arithmetic? `ℚ` is `Computable`,
+  so no — keep it computable. (Confirm via S4 build.)
+
+- The Mathlib regularity-lemma signature is slightly different —
+  uses `≥ M(ε)` rather than `card V ≥ M`. Bridge work in S5 can
+  defer; S2–S4 only target the gallery's own
+  `regularity_lemma_strong`.

--- a/src/data/research/problems/szemeredi-core-oq-04.json
+++ b/src/data/research/problems/szemeredi-core-oq-04.json
@@ -1,0 +1,105 @@
+{
+  "slug": "szemeredi-core-oq-04",
+  "title": "Algorithmic Szemerédi: formalize the Alon-Duke-Lefmann-Rödl-Yuster 1994 constructive partition algorithm",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "constructive-refactor",
+  "problemStatement": {
+    "formal": "Build `IsWitnessRegular G eps A B`, a decidable surrogate for `IsEpsilonRegular`, such that `IsWitnessRegular → IsEpsilonRegular` (with a slack constant). Use it to construct `def findRegularPartition (eps : Q) (G : SimpleGraph V) : Finset (Finset V)` returning a partition that satisfies `IsRegularPartition G eps`. Replaces the `Classical.choice` usage at `Proofs/SzemerediRegularity.lean:436` (`regularity_lemma_strong`).",
+    "plain": "The gallery's Szemerédi regularity lemma (Proofs/SzemerediRegularity.lean:327, line 436 for the strong version) proves existence of an ε-regular partition non-constructively via `Classical.choice`. Alon-Duke-Lefmann-Rödl-Yuster (1994) showed that the regularity partition can be found in polynomial time. This slug formalizes the constructive replacement — making the partition a computable function rather than an existential — by introducing a decidable surrogate for `IsEpsilonRegular` and a constructive witness-extraction step for irregular pairs.",
+    "whyMatters": [
+      "Decouples the Szemerédi pipeline from `Classical.choice`: the gallery's `SzemerediRegularity.lean:436` (`regularity_lemma_strong`) is the *only* point where the partition construction uses choice. Replacing it with ADLRY's constructive witness gives a computable `findRegularPartition`.",
+      "Enables decidability: the current `IsEpsilonRegular` predicate (`SzemerediCore.lean:39`) quantifies over arbitrary `Finset V` and is not `Decidable`. The ADLRY surrogate `IsWitnessRegular` quantifies over a polynomial-size family — `Decidable` by construction.",
+      "Prerequisite for downstream quantitative Szemerédi entries (Roth, removal, counting, full Szemerédi): each uses the partition itself, not just its existence, so a computable `findRegularPartition` unblocks them.",
+      "Mathlib gap: `SimpleGraph.szemeredi_regularity` in Mathlib v4.26.0 is existential. ADLRY 1994 has no Mathlib representation. Candidate Mathlib contribution.",
+      "Formalization, not research: ADLRY 1994 is 30 years old, well-documented in Tao (Higher-Order Fourier Analysis) and Zhao (Graph theory and additive combinatorics). The contribution is making it Lean-native."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Szemerédi regularity lemma — existential form (gallery: SzemerediRegularity.lean:327, 436, 487; Mathlib: SimpleGraph.szemeredi_regularity)",
+      "Edge density agrees with Mathlib's SimpleGraph.edgeDensity (gallery: SzemerediRegularity.lean:362)",
+      "Alon-Duke-Lefmann-Rödl-Yuster (1994) algorithm — classical, see References"
+    ],
+    "open": [
+      "Decidable surrogate for IsEpsilonRegular (Target A, S2)",
+      "Constructive witness extraction (Target B, S3)",
+      "Computable findRegularPartition (Target C, S4)",
+      "Mathlib bridge: IsWitnessRegular ↔ Mathlib's analog (S5)"
+    ],
+    "goal": "Replace `Classical.choice` at `SzemerediRegularity.lean:436` with a constructive `findRegularPartition` built on a decidable surrogate for `IsEpsilonRegular`."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-11T22:30:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-1, 2026-05-11) — OBSERVE survey. Established three-target hierarchy: A) decidable surrogate IsWitnessRegular, B) constructive witness extraction witnessOfIrregular, C) computable findRegularPartition. Identified Mathlib gaps: Decidable IsEpsilonRegular, constructive witness, computable partition, polynomial-time meta-claim infrastructure. No Lean changes; 4 documentation/JSON files only.",
+    "blockers": [],
+    "nextAction": "S2 (next iteration): scaffold Proofs/SzemerediCoreOQ04.lean with IsWitnessRegular G eps A B (decidable surrogate using ε-grid family `{N(a) ∩ B | a ∈ A}` ∪ complements — polynomial-size, slack constant 4), Decidable instance, and witness_regular_implies_epsilon_regular implication. Target ~150 lines, 0 sorries on definition, ≤2 sorries on implication (Aristotle-friendly if the ε-grid surrogate is the strong variant).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-1, 2026-05-11): OBSERVE survey. Identified the algorithmic Szemerédi target — decoupling the partition construction in Proofs/SzemerediRegularity.lean:436 (regularity_lemma_strong) from Classical.choice using the ADLRY 1994 constructive witness. Decomposed into three Lean-level targets: (A) decidable surrogate IsWitnessRegular with one-directional implication to IsEpsilonRegular, (B) constructive witness extraction witnessOfIrregular as Σ'-elimination, (C) computable findRegularPartition replacing the existential regularity_lemma_strong. Mathlib gap inventory: Decidable IsEpsilonRegular missing (universal quantifier over Finset V), constructive witness missing (Mathlib's szemeredi_regularity also existential), polynomial-time cost-model missing in Lean 4 (meta-claim only), bridge to Mathlib's IsEpsilonRegular missing (gallery already proves edgeDensity_eq_mathlib at SzemerediRegularity.lean:362). The energy-increment proof at SzemerediRegularity.lean:225-325 is already calculational — Classical is used only at line 436 for witness extraction — so the refactor surface is small. Honesty: this is formalization, not research; ADLRY 1994 is 30 years old.",
+    "builtItems": [],
+    "insights": [
+      "IsEpsilonRegular at SzemerediCore.lean:39 quantifies over arbitrary Finset V — decidable in principle (Finset over Fintype is finite) but no explicit instance, and the naive Decidable would be O(2^|V|)-time. The ADLRY surrogate is the meaningful decidable replacement.",
+      "The decidable surrogate has a slack constant: IsWitnessRegular G eps A B → IsEpsilonRegular G eps A B holds directly; the converse holds with eps' = eps/c for some c ≤ 10 depending on the surrogate variant. ε-grid variant (`{N(a) ∩ B | a ∈ A}` ∪ complements) gives c=4 with polynomial-size family (|S| ≤ 2|A|).",
+      "The energy-increment proof in SzemerediRegularity.lean:225-325 is purely calculational (no choice). Classical.choice is used at exactly ONE place: SzemerediRegularity.lean:436 (regularity_lemma_strong), where the witness subsets (A', B') for an irregular pair are extracted. ADLRY's contribution is a constructive replacement for exactly that step. The refactor surface is small (~50 lines of one proof).",
+      "Polynomial-time is a meta-claim. Lean 4 has no cost-monad library, so the surrogate's runtime cannot be stated within Lean. Document it in the surrogate's docstring; the claim is verified externally via Mathlib's `decide` tactic's evaluation cost on the finite-quantifier form.",
+      "Mathlib bridge for `IsEpsilonRegular` doesn't exist; only `edgeDensity_eq_mathlib` at SzemerediRegularity.lean:362. Add the regularity-predicate bridge in S5 (independently useful for any Mathlib contribution and a sanity check that we haven't drifted from the standard definition).",
+      "Per the Szemerédi pipeline architecture memory: definitions should be frozen in Core; the refactor should add a new file SzemerediCoreOQ04.lean rather than modify SzemerediCore. This avoids drift across the cluster and keeps the surrogate localized."
+    ],
+    "mathlibGaps": [
+      "Decidable IsEpsilonRegular — Mathlib's SimpleGraph.IsEpsilonRegular has no Decidable instance either; the universal quantifier over Finset V is decidable in principle but no efficient explicit instance exists.",
+      "Constructive witness for irregular pairs — Mathlib's SimpleGraph.szemeredi_regularity uses Classical.choice, no Σ'-form witness extraction available.",
+      "Polynomial-time complexity claims — Lean 4 / Mathlib have no cost-monad infrastructure. The 'polynomial-time' property of the ADLRY surrogate is meta-claim only.",
+      "Computable findRegularPartition — Mathlib's szemeredi_regularity is existential, not computable.",
+      "Bridge IsEpsilonRegular (gallery) ↔ SimpleGraph.IsEpsilonRegular (Mathlib) — gallery has the edge-density bridge but not the predicate bridge."
+    ],
+    "nextSteps": [
+      "S2: scaffold Proofs/SzemerediCoreOQ04.lean. Define IsWitnessRegular G eps A B as a Decidable predicate using the ε-grid subset family {N(a) ∩ B | a ∈ A} ∪ complements (size ≤ 2|A|, polynomial). Auto-derive Decidable instance from the finite-quantifier form. Prove witness_regular_implies_epsilon_regular : IsWitnessRegular G eps A B → IsEpsilonRegular G eps A B. Target ~150 lines, 0 sorries on definitions, ≤2 routine sorries on the implication.",
+      "S3: define witnessOfIrregular : ¬ IsWitnessRegular G eps A B → Σ' (A' B' : Finset V), A' ⊆ A ∧ B' ⊆ B ∧ |edgeDensity G A' B' - edgeDensity G A B| > eps. Uses Finset.findP on the decidable surrogate's quantifier domain. Bridge: every irregular pair has an explicit witness from the surrogate's finite subset family.",
+      "S4: refactor regularity_lemma_strong at SzemerediRegularity.lean:436 to use witnessOfIrregular instead of Classical.choice. Export def findRegularPartition (eps : Q) (G : SimpleGraph V) [DecidableRel G.Adj] : Finset (Finset V) returning the partition explicitly, plus the theorem findRegularPartition_isRegular : IsRegularPartition G eps (findRegularPartition eps G).",
+      "S5 (optional): bridge IsWitnessRegular to Mathlib's SimpleGraph.IsEpsilonRegular (analog of the existing edgeDensity_eq_mathlib), and consider submitting the surrogate + decidability + bridge as a Mathlib PR."
+    ]
+  },
+  "references": [
+    {
+      "label": "ADLRY (1994)",
+      "citation": "Alon, N., Duke, R.A., Lefmann, H., Rödl, V., Yuster, R. (1994). The algorithmic aspects of the regularity lemma. Journal of Algorithms 16(1), 80-109. — foundational paper for this slug."
+    },
+    {
+      "label": "Frieze-Kannan (1996)",
+      "citation": "Frieze, A., Kannan, R. (1996). The regularity lemma and approximation schemes for dense problems. FOCS '96. — simpler approximation-scheme proof."
+    },
+    {
+      "label": "Tao (2012)",
+      "citation": "Tao, T. (2012). Higher-Order Fourier Analysis. AMS GSM 142. — textbook treatment of the constructive regularity lemma."
+    },
+    {
+      "label": "Zhao (2023)",
+      "citation": "Zhao, Y. (2023). Graph Theory and Additive Combinatorics. Cambridge University Press. — Chapter 4: regularity method, algorithmic variants."
+    },
+    {
+      "label": "Fischer-Matsliah-Shapira (2010)",
+      "citation": "Fischer, E., Matsliah, A., Shapira, A. (2010). Approximate hypergraph partitioning and applications. SIAM J. Comput. 39(7), 3155-3185. — modern algorithmic perspective; hypergraph generalization relevant to szemeredi-hypergraph-core."
+    }
+  ],
+  "tags": [
+    "combinatorics",
+    "graph-theory",
+    "szemeredi",
+    "regularity-lemma",
+    "constructive",
+    "decidability",
+    "algorithmic",
+    "axiom-elimination",
+    "mathlib-gap",
+    "scaffold"
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for **szemeredi-core-oq-04** — formalize the
algorithmic Szemerédi regularity lemma (Alon-Duke-Lefmann-Rödl-Yuster
1994), decoupling the partition construction from `Classical.choice`.

**Survey-only iteration.** No Lean changes; pure documentation +
JSON of accumulated knowledge.

## Target hierarchy

- **Target A** — `IsWitnessRegular G eps A B` : a `Decidable`
  surrogate for `IsEpsilonRegular`. Quantifies over a polynomial-size
  finite subset family. Implies `IsEpsilonRegular` (with a slack
  constant if the variant requires).
- **Target B** — `witnessOfIrregular : ¬ IsWitnessRegular G eps A B
  → Σ' (A' B' : Finset V), …` : constructive witness extraction for
  irregular pairs, replacing `Classical.choice`.
- **Target C** — `def findRegularPartition (eps : ℚ) (G : SimpleGraph V) :
  Finset (Finset V)` : computable partition function, replaces the
  existential `regularity_lemma_strong` at
  `Proofs/SzemerediRegularity.lean:436`.

## Findings

### The refactor surface is small

The gallery's `Proofs/SzemerediRegularity.lean:225–325`
(energy-increment lemma and partition energy bound) is **purely
calculational** — no `Classical.choice` usage. `Classical` is
imported at `SzemerediCore.lean:24` and used at exactly **one**
place: `SzemerediRegularity.lean:436`
(`regularity_lemma_strong`), where the witness subsets `(A', B')`
for an irregular pair are pulled out by `choice`. ADLRY's
contribution is a constructive replacement for *exactly* that
step.

### Decidable surrogate via ε-grid family

The minimal viable surrogate `IsWitnessRegular` quantifies over

```
S(A, G, B)  :=  {N(a) ∩ B  |  a ∈ A}  ∪  complements
                ⊆  Finset (Finset V)
```

`|S| ≤ 2·|A|` (polynomial), gives a `Decidable` surrogate by
construction, with slack constant `c = 4` to recover the
universal-quantifier `IsEpsilonRegular`.

### Mathlib gaps (v4.26.0)

| Need | Status |
|---|---|
| `Szemeredi.Core.IsEpsilonRegular` | gallery only (`SzemerediCore.lean:39`) — quantifies over `Finset V`, no `Decidable` instance |
| `Decidable IsEpsilonRegular` | **missing** in both gallery and Mathlib |
| `SimpleGraph.szemeredi_regularity` | Mathlib, **existential** |
| Constructive witness for irregular pairs | **missing** |
| Computable `findRegularPartition` | **missing** |
| Polynomial-time cost-model (meta-claim infrastructure) | **missing** in Lean 4 / Mathlib |
| `edgeDensity_eq_mathlib` bridge | available (`SzemerediRegularity.lean:362`) |
| `IsEpsilonRegular` ↔ Mathlib bridge | **missing** |

## 5-iteration roadmap

- **S1 (this PR)**: OBSERVE survey + Mathlib gap inventory + target
  hierarchy. **No Lean changes.**
- **S2**: scaffold `Proofs/SzemerediCoreOQ04.lean` — `IsWitnessRegular`
  + `Decidable` instance + `witness_regular_implies_epsilon_regular`.
  Target ~150 lines.
- **S3**: `witnessOfIrregular` — `Σ'`-elimination from the failure
  of `IsWitnessRegular`.
- **S4**: refactor `regularity_lemma_strong` to use
  `witnessOfIrregular`; export `def findRegularPartition`.
- **S5 (optional)**: bridge to Mathlib's `SimpleGraph.IsEpsilonRegular`;
  candidate Mathlib PR.

## Files

```
research/problems/szemeredi-core-oq-04/problem.md         (+217)
research/problems/szemeredi-core-oq-04/knowledge.md       (+198)
research/problems/szemeredi-core-oq-04/state.md           (+102)
src/data/research/problems/szemeredi-core-oq-04.json      (+105)
```

## Status

**Outcome**: `OBSERVE` (S1 → ORIENT) — survey complete, S2 plan
locked in.

**Next steps**:

- S2: `IsWitnessRegular` decidable surrogate (ε-grid variant) +
  forward implication.
- S3: constructive witness extraction.
- S4: refactor the partition construction; export computable
  `findRegularPartition`.

## Honesty notes

ADLRY 1994 is 30 years old; the surrogate is textbook material
(Tao 2012; Zhao 2023). This slug is **formalization**, not
research. The "polynomial-time" claim is meta-level — Lean 4
has no cost-model infrastructure, so the runtime bound is a
docstring assertion verified externally via `decide` evaluation
on the surrogate's finite-quantifier form.

🤖 Generated by researcher-1