### PR TITLE
research(cube-root-3-irrational-oq-04): S5-prep — cubing-bound iff helpers + 23/16 < cbrt3 (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -59,6 +59,7 @@ import Proofs.AngleTrisectionCos20GalOQ01
 import Proofs.AngleTrisectionCos20GalOQ01OQ01
 import Proofs.AngleTrisectionCos20GalOQ01OQ02
 import Proofs.AngleTrisectionCos20GalOQ01OQ02OQ02
+import Proofs.AngleTrisectionCos20GalOQ01OQ03
 import Proofs.AngleTrisectionCos20GalOQ03
 import Proofs.AngleTrisectionCos20GalOQ03OQ01
 import Proofs.AngleTrisectionEmbedding
@@ -451,6 +452,7 @@ import Proofs.CentralLimitTheoremOQ01OQ02OQ01OQ01
 import Proofs.CentralLimitTheoremOQ01OQ03
 import Proofs.CentralLimitTheoremOQ02
 import Proofs.CentralLimitTheoremOQ02Aristotle
+import Proofs.CentralLimitTheoremOQ02OQ04
 import Proofs.CentralLimitTheoremOQ03
 import Proofs.CentralLimitTheoremOQ03OQ01
 import Proofs.CentralLimitTheoremOQ03OQ01Aristotle
@@ -532,6 +534,8 @@ import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ02
 import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02
+import Proofs.CubeRoot3IrrationalOQ04
+import Proofs.CubeRoot3IrrationalOQ04Helpers
 import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational
@@ -2312,6 +2316,7 @@ import Proofs.GreensTheoremOQ01OQ01
 import Proofs.GreensTheoremOQ01OQ01OQ01
 import Proofs.GreensTheoremOQ01OQ01OQ01OQ01
 import Proofs.GreensTheoremOQ01OQ01OQ02
+import Proofs.GreensTheoremOQ01OQ01OQ02OQ03
 import Proofs.GreensTheoremOQ01OQ01OQ03
 import Proofs.GreensTheoremOQ01OQ02
 import Proofs.GreensTheoremOQ02

--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -1,0 +1,213 @@
+/-
+Proof: Cubing-bound helpers for the simple continued fraction of cbrt3.
+Date: 2026-05-12 (S5-prep)
+Research: cube-root-3-irrational-oq-04, helper extraction (researcher-1)
+
+Two reusable biconditional helpers that condense the
+"by_contra + cube + nlinarith" template used in S2/S3/S4 of
+`CubeRoot3IrrationalOQ04.lean`, plus the new S5 lower bound
+`23/16 < cbrt3` as a one-line demonstration.
+
+This file is independent of `CubeRoot3IrrationalOQ04.lean`: it only
+depends on `cbrt3` and `cbrt3_cubed` from
+`Proofs/CubeRoot3Irrational.lean`, so subsequent partial-quotient
+iterations (S5, S6, …) can import it without circular dependencies.
+-/
+
+import Proofs.CubeRoot3Irrational
+import Mathlib
+
+/-!
+# Cubing-bound helpers for ∛3
+
+For any nonnegative `q : ℝ`, comparing `q` against `∛3` is equivalent
+to comparing `q³` against `3`. Formalizing this once as a
+biconditional reduces every subsequent partial-quotient cubing-bound
+lemma to a single `norm_num` after the iff rewrite.
+
+## Helpers exposed
+
+```
+cbrt3_nonneg                : (0 : ℝ) ≤ cbrt3
+cbrt3_pos                   : (0 : ℝ) < cbrt3
+lt_cbrt3_iff_cube_lt        : 0 ≤ q → (q < cbrt3 ↔ q^3 < 3)
+cbrt3_lt_iff_three_lt_cube  : 0 ≤ q → (cbrt3 < q ↔ 3 < q^3)
+```
+
+Each `aᵢ` partial-quotient lemma (S2 onward) needs two cubing
+bounds of the form `p/q < cbrt3` and `cbrt3 < r/s`. With these
+helpers the proofs become:
+
+```lean
+theorem p_q_lt_cbrt3 : (p / q : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num
+
+theorem cbrt3_lt_r_s : cbrt3 < (r / s : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num
+```
+
+instead of the ~14-line `by_contra + cube + nlinarith` block.
+
+## Proof technique
+
+The forward (strict) direction uses the polynomial factorization
+
+  `b^3 - a^3 = (b - a) * (b^2 + b*a + a^2)`,
+
+with the second factor strictly positive whenever `b > 0` (hence the
+auxiliary `cbrt3_pos` lemma). The backward direction is symmetric
+by contradiction.
+
+The factorization sidesteps the `pow_lt_pow_left` / `pow_le_pow_left`
+API drift documented in the gallery: only `ring`, `linarith`,
+`mul_pos`, `mul_nonneg`, `sub_pos`, `sub_nonneg`, and `sq_nonneg` are
+used.
+
+## Demonstration
+
+A single new cubing bound — the S5 lower bound
+
+```
+twenty_three_sixteenths_lt_cbrt3 : (23/16 : ℝ) < cbrt3
+```
+
+(cube target `12167/4096 < 12288/4096 = 3`) is proved in two lines
+to exercise the helper. The S2/S3/S4 bounds
+(`four_thirds_lt_cbrt3`, `cbrt3_lt_three_halves`,
+`ten_sevenths_lt_cbrt3`, `cbrt3_lt_thirteen_ninths`) already exist
+in `CubeRoot3IrrationalOQ04.lean` under the manual template; this
+file does not duplicate them.
+
+No axioms; depends only on `CubeRoot3Irrational.cbrt3_cubed`.
+-/
+
+namespace Cbrt3Helpers
+
+open CubeRoot3Irrational
+
+/-- `∛3 ≥ 0`. Immediate from the `rpow` definition: real powers of a
+non-negative base are non-negative. -/
+theorem cbrt3_nonneg : (0 : ℝ) ≤ cbrt3 := by
+  unfold cbrt3
+  exact Real.rpow_nonneg (by norm_num) _
+
+/-- `∛3 > 0`. If `cbrt3 = 0` then `cbrt3³ = 0`, contradicting
+`cbrt3³ = 3`. -/
+theorem cbrt3_pos : (0 : ℝ) < cbrt3 := by
+  rcases lt_or_eq_of_le cbrt3_nonneg with h | h
+  · exact h
+  · exfalso
+    have hc := cbrt3_cubed
+    rw [← h] at hc
+    norm_num at hc
+
+/-- **Cube comparison, lower direction**:
+for nonnegative `q`, `q < ∛3 ↔ q³ < 3`.
+
+Both directions use the polynomial factorization
+`b³ - a³ = (b - a)(b² + b·a + a²)`. The forward direction needs
+`b² + b·a + a² > 0`, which follows from `cbrt3 > 0`. The backward
+direction needs only `≥ 0`, which is immediate from nonnegativity. -/
+theorem lt_cbrt3_iff_cube_lt {q : ℝ} (hq : 0 ≤ q) :
+    q < cbrt3 ↔ q ^ 3 < 3 := by
+  constructor
+  · -- Forward: q < cbrt3 ⟹ q³ < cbrt3³ = 3.
+    intro hqlt
+    have hc : 0 < cbrt3 := cbrt3_pos
+    have h2 : q ^ 3 < cbrt3 ^ 3 := by
+      have eq : cbrt3 ^ 3 - q ^ 3
+              = (cbrt3 - q) * (cbrt3 ^ 2 + cbrt3 * q + q ^ 2) := by ring
+      have e1 : 0 < cbrt3 - q := sub_pos.mpr hqlt
+      have e2 : 0 < cbrt3 ^ 2 + cbrt3 * q + q ^ 2 := by
+        have hc2 : 0 < cbrt3 ^ 2 := pow_pos hc 2
+        have hcq : 0 ≤ cbrt3 * q := mul_nonneg hc.le hq
+        have hq2 : 0 ≤ q ^ 2 := sq_nonneg q
+        linarith
+      have hp := mul_pos e1 e2
+      linarith [eq]
+    rw [cbrt3_cubed] at h2
+    exact h2
+  · -- Backward: q³ < 3 = cbrt3³ ⟹ q < cbrt3 (by contradiction).
+    intro hcube
+    by_contra h
+    push_neg at h  -- `cbrt3 ≤ q`
+    have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+    have h2 : cbrt3 ^ 3 ≤ q ^ 3 := by
+      have eq : q ^ 3 - cbrt3 ^ 3
+              = (q - cbrt3) * (q ^ 2 + q * cbrt3 + cbrt3 ^ 2) := by ring
+      have e1 : 0 ≤ q - cbrt3 := sub_nonneg.mpr h
+      have e2 : 0 ≤ q ^ 2 + q * cbrt3 + cbrt3 ^ 2 := by
+        have hq2 : 0 ≤ q ^ 2 := sq_nonneg q
+        have hqc : 0 ≤ q * cbrt3 := mul_nonneg hq hp
+        have hc2 : 0 ≤ cbrt3 ^ 2 := sq_nonneg cbrt3
+        linarith
+      have hprod := mul_nonneg e1 e2
+      linarith [eq]
+    rw [cbrt3_cubed] at h2
+    linarith
+
+/-- **Cube comparison, upper direction**:
+for nonnegative `q`, `∛3 < q ↔ 3 < q³`.
+
+Symmetric to `lt_cbrt3_iff_cube_lt`. -/
+theorem cbrt3_lt_iff_three_lt_cube {q : ℝ} (hq : 0 ≤ q) :
+    cbrt3 < q ↔ 3 < q ^ 3 := by
+  constructor
+  · -- Forward: cbrt3 < q ⟹ cbrt3³ = 3 < q³.
+    intro hqlt
+    have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+    have hc : 0 < cbrt3 := cbrt3_pos
+    have h2 : cbrt3 ^ 3 < q ^ 3 := by
+      have eq : q ^ 3 - cbrt3 ^ 3
+              = (q - cbrt3) * (q ^ 2 + q * cbrt3 + cbrt3 ^ 2) := by ring
+      have e1 : 0 < q - cbrt3 := sub_pos.mpr hqlt
+      have e2 : 0 < q ^ 2 + q * cbrt3 + cbrt3 ^ 2 := by
+        have hc2 : 0 < cbrt3 ^ 2 := pow_pos hc 2
+        have hqc : 0 ≤ q * cbrt3 := mul_nonneg hq hc.le
+        have hq2 : 0 ≤ q ^ 2 := sq_nonneg q
+        linarith
+      have hprod := mul_pos e1 e2
+      linarith [eq]
+    rw [cbrt3_cubed] at h2
+    exact h2
+  · -- Backward: 3 < q³ ⟹ cbrt3 < q (by contradiction).
+    intro hcube
+    by_contra h
+    push_neg at h  -- `q ≤ cbrt3`
+    have hp : (0 : ℝ) ≤ cbrt3 := cbrt3_nonneg
+    have h2 : q ^ 3 ≤ cbrt3 ^ 3 := by
+      have eq : cbrt3 ^ 3 - q ^ 3
+              = (cbrt3 - q) * (cbrt3 ^ 2 + cbrt3 * q + q ^ 2) := by ring
+      have e1 : 0 ≤ cbrt3 - q := sub_nonneg.mpr h
+      have e2 : 0 ≤ cbrt3 ^ 2 + cbrt3 * q + q ^ 2 := by
+        have hc2 : 0 ≤ cbrt3 ^ 2 := sq_nonneg cbrt3
+        have hcq : 0 ≤ cbrt3 * q := mul_nonneg hp hq
+        have hq2 : 0 ≤ q ^ 2 := sq_nonneg q
+        linarith
+      have hprod := mul_nonneg e1 e2
+      linarith [eq]
+    rw [cbrt3_cubed] at h2
+    linarith
+
+/-! ## S5 prep: new lower bound for `a₃ = 1`
+
+The fourth partial-quotient identity `cbrt3_a3 = 1` (deferred to
+S5+ per the `CubeRoot3IrrationalOQ04.lean` next-action) requires
+bounds `23/16 < cbrt3 ≤ 13/9`. The upper bound is the S4-proved
+`cbrt3_lt_thirteen_ninths` (in `CubeRoot3IrrationalOQ04`); the
+new lower bound `23/16 < cbrt3` is proved here, as a demonstration
+of the helper's brevity.
+
+Cube target: `(23/16)³ = 12167/4096 < 12288/4096 = 3`, strict
+(`12167 < 12288 = 4096 · 3`). -/
+
+/-- `23/16 < ∛3`. Cube target: `(23/16)³ = 12167/4096 < 12288/4096 = 3`.
+
+Two-line proof via `lt_cbrt3_iff_cube_lt`. Compare to the four-step
+`by_contra + nlinarith` proof of `four_thirds_lt_cbrt3` /
+`ten_sevenths_lt_cbrt3` in `CubeRoot3IrrationalOQ04.lean`. -/
+theorem twenty_three_sixteenths_lt_cbrt3 : (23 / 16 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
+end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -324,3 +324,150 @@ an Real.rpow inequality'" gap from S1 still stands but the manual
 - For S4 the squared intermediate is `100/49` (lower) and `169/81`
   (upper); these are "ugly" rationals but `nlinarith` handles
   rational coefficients natively.
+
+## S5-prep (researcher-1, 2026-05-12) — Helper file extraction
+
+### Motivation
+
+S2/S3/S4 (and the deferred S5/S6/…) all share a single proof
+template: "to show `p/q < cbrt3`, by-contra; cube; `nlinarith` with a
+squared-intermediate hint; substitute `cbrt3³ = 3`; `linarith`." Each
+instance is ~14 lines. For five partial quotients the boilerplate
+totals ~70 lines per `aᵢ` (two cubing bounds + one algebraic step),
+i.e. ~350 lines across the prefix.
+
+This iteration extracts the cubing-bound pattern as **two
+biconditional helpers** in a new file
+`proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`:
+
+```lean
+lt_cbrt3_iff_cube_lt        : 0 ≤ q → (q < cbrt3 ↔ q^3 < 3)
+cbrt3_lt_iff_three_lt_cube  : 0 ≤ q → (cbrt3 < q ↔ 3 < q^3)
+```
+
+After the iff rewrite each partial-quotient cubing bound becomes a
+**two-line** proof:
+
+```lean
+theorem twenty_three_sixteenths_lt_cbrt3 : (23/16 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+```
+
+vs. the ~14-line by-contra template.
+
+### File layout
+
+- New file: `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`
+  (~190 lines including docstrings).
+- New namespace `Cbrt3Helpers` (deliberately separate from
+  `CubeRoot3IrrationalOQ04` to avoid `cbrt3_nonneg` /
+  `four_thirds_lt_cbrt3` collisions on future co-import).
+- Independent of `CubeRoot3IrrationalOQ04.lean`: only imports
+  `Proofs.CubeRoot3Irrational` (for `cbrt3` and `cbrt3_cubed`).
+  This prevents the circular dependency that would arise if S5+
+  rewrote `CubeRoot3IrrationalOQ04.lean` to use the helpers.
+
+### Proof technique
+
+Both biconditionals are proved via the polynomial factorization
+
+```
+b³ − a³ = (b − a) · (b² + b·a + a²).
+```
+
+The forward (strict) direction uses `mul_pos` on the factorization,
+which requires the second factor `> 0`. This holds because
+`cbrt3 > 0` (proved as `Cbrt3Helpers.cbrt3_pos` from `cbrt3³ = 3 ≠ 0`).
+The backward direction is by contradiction with the same
+factorization weakened to `mul_nonneg` (no `cbrt3_pos` needed).
+
+Crucially, the factorization sidesteps the `pow_lt_pow_left` /
+`pow_le_pow_left` API drift documented in
+`feedback_researcher_mathlib_descpochhammer_drift.md`: only `ring`,
+`linarith`, `mul_pos`, `mul_nonneg`, `sub_pos`, `sub_nonneg`,
+`pow_pos`, and `sq_nonneg` are used. All are stable names in
+Mathlib v4.26.
+
+### Demonstration
+
+A single new bound — the S5 lower bound
+
+```
+twenty_three_sixteenths_lt_cbrt3 : (23/16 : ℝ) < cbrt3
+```
+
+(cube target `(23/16)³ = 12167/4096 < 12288/4096 = 3`) is proved
+in two lines, exercising `lt_cbrt3_iff_cube_lt`. The S2/S3/S4
+bounds (`four_thirds_lt_cbrt3`, `cbrt3_lt_three_halves`,
+`ten_sevenths_lt_cbrt3`, `cbrt3_lt_thirteen_ninths`) are left intact
+in `CubeRoot3IrrationalOQ04.lean`; this iteration does not refactor
+them.
+
+### Insights (cumulative, post-S5-prep)
+
+1. **Iff-form helpers compress the partial-quotient template by
+   ~7x per cubing bound**: 14 lines (manual) → 2 lines (helper).
+   For S5+ the file growth rate drops from ~70 lines/`aᵢ` to
+   ~35 lines/`aᵢ` (the algebraic inverse-chain step is unchanged).
+
+2. **`cbrt3_pos` is a load-bearing micro-lemma** for the *strict*
+   direction of the iff. The corresponding *non-strict* direction
+   only needs `cbrt3_nonneg`. Future helpers (e.g. for `∛n` with
+   `n ≥ 2`) should follow the same pattern: a `_nonneg` and a
+   `_pos` lemma at the top of the helper file.
+
+3. **Namespace isolation matters**: putting helpers in
+   `Cbrt3Helpers` (not `CubeRoot3IrrationalOQ04`) means a future
+   `open Cbrt3Helpers in …` block can be used inside
+   `CubeRoot3IrrationalOQ04.lean` without name clashes with the
+   existing `cbrt3_nonneg` therein.
+
+### Mathlib gaps (cumulative)
+
+(No new gaps. The "no tactic-level support for 'cube both sides of
+an `Real.rpow` inequality'" gap from S1 is now *closed at the
+proof-engineering level* for `∛3` specifically — the iff-helpers
+serve as a domain-specific tactic-replacement. Closing the gap
+generically (for `∛n` with `n` not a perfect cube) would be a
+genuine Mathlib contribution candidate, but is out of scope here.)
+
+### Next Steps (priority order, post-S5-prep)
+
+1. **(S5)** `cbrt3_a3 : ⌊1/(1/(1/(cbrt3-1) - 2) - 3)⌋ = (1 : ℤ)`.
+   Now needs only:
+   - `twenty_three_sixteenths_lt_cbrt3` (already proved in this
+     helper file — directly importable).
+   - `cbrt3_lt_thirteen_ninths` (already proved in S4 — directly
+     importable from `CubeRoot3IrrationalOQ04`).
+   - The four-level algebraic chain
+     `23/16 < cbrt3 < 13/9 → 7/16 < cbrt3-1 < 4/9 →
+      9/4 < 1/(cbrt3-1) < 16/7 → 1/4 < 1/(cbrt3-1) − 2 < 2/7 →
+      7/2 < 1/(1/(cbrt3-1) − 2) < 4 → 1/2 < x₃ < 1 → 1 ≤ 1/x₃ < 2`.
+2. **(S6)** `cbrt3_a4 = 4`. Needs one more cubing bound, e.g.
+   `cbrt3 < some_tighter_upper_bound`. Helper makes it 2-line.
+3. **(S7+)** Bundle: `cbrt3_cf_prefix : IntFractPair.stream cbrt3
+   takes [1,2,3,1,4]`. Ties per-`aᵢ` lemmas to the canonical
+   Mathlib `IntFractPair` API. No new cubing bounds needed.
+
+### Risk Notes
+
+- Helper file is sorry-free and axiom-free. Build is **pending**
+  (Docker symlink constraint per
+  `feedback_researcher_lake_symlink_broken.md`; not
+  researcher-specific).
+- Proof technique uses only stable Mathlib names
+  (`Real.rpow_nonneg`, `pow_pos`, `sq_nonneg`, `mul_pos`,
+  `mul_nonneg`, `sub_pos`, `sub_nonneg`, `lt_or_eq_of_le`,
+  `le_antisymm`, plus the local lemma `cbrt3_cubed`). API drift
+  risk is minimal.
+- One concurrent PR (#17832) is open against `CubeRoot3IrrationalOQ04.lean`
+  proving `cbrt3_a2 = 3`. The helper file does **not** modify
+  `CubeRoot3IrrationalOQ04.lean`, so the two PRs are conflict-free
+  on the `proofs/` tree.
+- The `Proofs.lean` auto-import file is regenerated in this PR
+  (5 file additions, all real); also picks up three
+  orphan files (`AngleTrisectionCos20GalOQ01OQ03`,
+  `CentralLimitTheoremOQ02OQ04`, `GreensTheoremOQ01OQ01OQ02OQ03`)
+  added by recent PRs that skipped regeneration — pure cleanup, no
+  semantic conflict.


### PR DESCRIPTION
## Summary

S5-prep iteration on `cube-root-3-irrational-oq-04`. Extracts the
S2/S3/S4 cubing-bound template as two reusable biconditional helpers
in a new file, then proves the new S5 lower bound `23/16 < cbrt3`
in two lines as demonstration.

## Progress

- **New file** `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`
  (~190 lines, 4 theorems, 0 sorries, 0 axioms).
- **New namespace** `Cbrt3Helpers` (deliberately isolated from
  `CubeRoot3IrrationalOQ04`).
- **`Proofs.lean` regenerated** (5 additions, all real — picks up
  three orphan files added by recent PRs that skipped regeneration,
  plus the two new entries for this slug).
- **`knowledge.md` appended** with S5-prep session note.

### New theorems

```
Cbrt3Helpers.cbrt3_nonneg                : (0 : ℝ) ≤ cbrt3
Cbrt3Helpers.cbrt3_pos                   : (0 : ℝ) < cbrt3
Cbrt3Helpers.lt_cbrt3_iff_cube_lt        : 0 ≤ q → (q < cbrt3 ↔ q^3 < 3)
Cbrt3Helpers.cbrt3_lt_iff_three_lt_cube  : 0 ≤ q → (cbrt3 < q ↔ 3 < q^3)
Cbrt3Helpers.twenty_three_sixteenths_lt_cbrt3 : (23/16 : ℝ) < cbrt3
```

### Proof technique

Polynomial factorization `b³ − a³ = (b − a)(b² + b·a + a²)` plus
`mul_pos` / `mul_nonneg`. Sidesteps the `pow_lt_pow_left` /
`pow_le_pow_left` API drift documented in
`feedback_researcher_mathlib_descpochhammer_drift.md`. Only stable
Mathlib names are used (`ring`, `linarith`, `mul_pos`,
`mul_nonneg`, `sub_pos`, `sub_nonneg`, `pow_pos`, `sq_nonneg`,
`Real.rpow_nonneg`).

## Findings

- The S2/S3/S4 template costs ~14 lines per cubing bound and is
  used **twice per partial quotient** (lower + upper bound). After
  the iff rewrite each cubing bound becomes a **two-line** proof.
  Net savings for the remaining S5/S6 prefix work: ~50 lines
  (eliminates ~6 cubing-bound block invocations × 12 lines saved
  each).
- `cbrt3_pos` is load-bearing for the strict iff direction. The
  non-strict direction needs only `cbrt3_nonneg`. Future `∛n`
  helpers should follow the same micro-lemma split.
- Iff-form helpers + namespace isolation = no conflict with the
  in-flight S4 PR #17832 (which modifies the sibling file
  `CubeRoot3IrrationalOQ04.lean`).

## Status

**Outcome**: progress (infrastructure, enables future S5/S6 to drop
~50 lines of boilerplate).
**Next Steps**:
1. S5 (`cbrt3_a3 = 1`) — now uses
   `Cbrt3Helpers.twenty_three_sixteenths_lt_cbrt3`
   and `CubeRoot3IrrationalOQ04.cbrt3_lt_thirteen_ninths` (from
   PR #17832 once merged) directly.
2. S6 (`cbrt3_a4 = 4`) — needs one more cubing bound, 2-line proof
   via helper.
3. S7+ — `IntFractPair.stream` bundling for the gallery.

## Coordination

- **No conflict with PR #17832** (S4, open): different files
  (Helpers is new), different namespaces (`Cbrt3Helpers` vs
  `CubeRoot3IrrationalOQ04`).
- **`Proofs.lean` regeneration** also picks up three orphan files
  added by other recent PRs that didn't regenerate:
  `AngleTrisectionCos20GalOQ01OQ03`, `CentralLimitTheoremOQ02OQ04`,
  `GreensTheoremOQ01OQ01OQ02OQ03`. Pure cleanup.

### Build

Build is **pending** in this researcher worktree per
`feedback_researcher_lake_symlink_broken.md` (recursive `.lake`
symlink forces a ~25-minute fresh-clone build every time). Proof
mechanics use only stable Mathlib names; API-drift risk is
minimal.

🤖 Generated by researcher-1