### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S5 — cross-cardinal consolidation (build pending)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -494,4 +494,77 @@ theorem card_computable_lt_card_nonComputable :
   rw [card_computable_reals_eq_aleph0, card_nonComputableReals_eq_continuum]
   exact Cardinal.aleph0_lt_continuum
 
+/-! ## S5 — Cross-cardinal consolidation across the hierarchy layers
+
+The cardinal results of S2-S4 (`card_computable_reals_eq_aleph0 = ℵ₀`,
+`card_nonComputableReals_eq_continuum = 𝔠`) and the imported sibling
+`AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0` together pin the
+exact cardinal coordinates of every layer of the hierarchy
+`ℚ ⊊ algebraic ⊊ computable ⊊ ℝ`.
+
+This S5 deliverable packages three short consolidation theorems:
+
+* `card_computable_reals_eq_card_algebraic_reals` — algebraic and computable
+  reals share cardinality (both ℵ₀); the qualitative inclusion is strict, but
+  the cardinal coordinate is the same.
+* `card_nonComputableReals_eq_card_reals` — non-computable reals match ℝ
+  cardinally; direct from `Cardinal.mk_real` and
+  `card_nonComputableReals_eq_continuum`.
+* `cardinality_trichotomy` — compact summary stating the three cardinalities
+  (algebraic reals subtype, computable reals, non-computable reals).
+
+The constructive (qualitative) inclusion `algebraic ⊆ computable` requires
+exhibiting a Mathlib-`Computable` rational sequence converging to each
+algebraic real (Sturm-chain or bisection-on-minimal-polynomial witnesses);
+that is deferred to a later iteration. The cardinal statement
+`#algebraic = #computable` recorded here is the cardinal coordinate of the
+(still classical) inclusion.
+-/
+
+/-- **S5 lemma — cardinal coincidence of algebraic and computable reals**:
+    both have cardinality ℵ₀, so as cardinals they are equal.
+
+    The qualitative inclusion `algebraic ⊆ computable` is strict (every
+    rational is algebraic, every algebraic is computable, but π and e are
+    computable and not algebraic — the last fact is deferred to a future
+    iteration formalising explicit computable transcendentals). At the
+    cardinal level, however, both share ℵ₀, mirroring the slogan: "qualitative
+    refinement preserves cardinality below 𝔠". -/
+theorem card_computable_reals_eq_card_algebraic_reals :
+    (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) =
+      Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} := by
+  rw [card_computable_reals_eq_aleph0,
+      AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0]
+
+/-- **S5 lemma — cardinal coincidence of non-computable reals and ℝ**:
+    `#(non-computable) = #ℝ = 𝔠`.
+
+    The countable set of computable reals is a cardinality-zero deletion from
+    ℝ: removing it leaves a set with the same cardinality as ℝ. This is the
+    cardinal-level analogue of "almost all reals are non-computable". -/
+theorem card_nonComputableReals_eq_card_reals :
+    (#(↑nonComputableReals : Set ℝ) : Cardinal) = #ℝ := by
+  rw [card_nonComputableReals_eq_continuum, Cardinal.mk_real]
+
+/-- **S5 main — cardinality trichotomy across the hierarchy**:
+    bundles the three cardinal facts that determine where each layer of
+    `ℚ ⊊ algebraic ⊊ computable ⊊ ℝ` sits.
+
+    Reads: algebraic reals and computable reals are both countably infinite
+    (cardinality ℵ₀), while the non-computable reals form a continuum-sized
+    set (cardinality 𝔠 = #ℝ). The strict cardinal inequality ℵ₀ < 𝔠 then
+    explains why the topmost inclusion `computable ⊊ ℝ` must be strict, and
+    why no countable enumeration of the computable reals can hope to cover ℝ.
+
+    Compare with the sibling
+    `AlgebraicNumbersCountableOQ02OQ03.cardinality_dichotomy`, which bundles
+    the algebraic/transcendental dichotomy in the same form. -/
+theorem cardinality_trichotomy :
+    Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = ℵ₀ ∧
+    (#({r : ℝ | IsComputable r} : Set ℝ) : Cardinal) = ℵ₀ ∧
+    (#(↑nonComputableReals : Set ℝ) : Cardinal) = 𝔠 :=
+  ⟨AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0,
+   card_computable_reals_eq_aleph0,
+   card_nonComputableReals_eq_continuum⟩
+
 end AlgebraicNumbersCountableOQ02OQ04

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 497,
+    "lineCount": 570,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -81,7 +81,7 @@
         "module": "Mathlib.SetTheory.Cardinal.Continuum"
       }
     ],
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 3,
     "relatedProblems": [
       {
@@ -284,9 +284,9 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 497,
+    "lineCount": 570,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"


### PR DESCRIPTION
## Summary

S5 deliverable for `algebraic-numbers-countable-oq-02-oq-04`. Bridges the
S2–S4 cardinality results of this file with the imported sibling
`AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0`, packaging three
short consolidation theorems that pin the cardinal coordinates of every
layer of the hierarchy `ℚ ⊊ algebraic ⊊ computable ⊊ ℝ`. No new axioms, no
sorries, no new imports.

## What's New

### Main Theorems (3, all proof-complete)

- **`card_computable_reals_eq_card_algebraic_reals`** —
  `(# {r : ℝ | IsComputable r} : Cardinal) = Cardinal.mk {x : ℝ // IsAlgebraic ℚ x}`.
  Both are ℵ₀ (S2+S3 here; imported from `AlgebraicNumbersCountable`),
  hence equal as cardinals.

- **`card_nonComputableReals_eq_card_reals`** —
  `(# ↑nonComputableReals : Cardinal) = #ℝ`. Both are 𝔠 (S4 here;
  `Cardinal.mk_real` for ℝ), hence equal.

- **`cardinality_trichotomy`** — compact 3-tuple bundling the cardinal
  coordinates `algebraic = ℵ₀`, `computable = ℵ₀`, `non-computable = 𝔠`.
  Mirrors the sibling `AlgebraicNumbersCountableOQ02OQ03.cardinality_dichotomy`.

### Method

All three are 1–2 line `rw`-chains or term-mode tuple constructions over
the already-proven local theorems plus
`AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0`. The proofs
exercise no new Mathlib API beyond what S2–S4 already use; the import
chain (`Proofs.AlgebraicNumbersCountable` at line 12) was already in place.

### File growth

| Field | Before | After |
|---|---|---|
| `lineCount` | 497 | 570 |
| `theoremCount` | 21 | 24 |
| `definitionCount` | 3 | 3 |
| `sorries` | 0 | 0 |
| `axiomCount` | 0 | 0 |

## Build Status

**Pending** — researcher Docker `proofs/.lake` symlink is broken per
`feedback_researcher_lake_symlink_broken.md`. The three new statements use
only existing local theorems and one imported sibling theorem; the proofs
are 1–2 line `rw` chains plus a term-mode tuple, so risk is structurally
low. Matches the S2/S3/S4 PR precedent for this slug — all merged with
"build pending".

## Coexistence with audit PR #17819

#17819 (open) rewrites stale S1-era narrative in `meta.json`
(`description`, `conclusion.summary`, `openQuestions[0..1]`,
`mainTheorems[1].description`). This S5 PR deliberately touches only the
two count fields (`lineCount` × 2, `theoremCount` × 2) so the two PRs
should not conflict at the byte level. If a conflict arises, either side
rebases cleanly.

## Status

**Outcome**: progress — 3 new theorems, 0 sorries, 0 axioms.

**Next steps**:
- S6: prove `algebraic ⊆ computable` constructively via Sturm-chain /
  bisection on the minimal polynomial. The cardinal version is now in
  hand; the qualitative subset claim still requires real computability
  work.
- S7: explicit `IsComputable e` / `IsComputable π` witnesses
  (computable rational partial-sum sequences for the standard series
  expansions).

## Test plan

- [x] 3 new theorems, all proof-complete (no sorry)
- [x] No new axioms or imports
- [x] Proofs use only already-proven local theorems + 1 imported sibling
- [x] meta.json: count-only diff (4 surgical 2-digit edits), no narrative changes
- [ ] Docker build pending (broken `proofs/.lake` symlink — see
      `feedback_researcher_lake_symlink_broken.md`)

🤖 Generated by researcher-8