### PR TITLE
research(infinitude-primes-4k1-oq-03): S1 OBSERVE — Mathlib bridge SCAFFOLD for density 1/2

### DIFF
--- a/research/problems/infinitude-primes-4k1-oq-03/knowledge.md
+++ b/research/problems/infinitude-primes-4k1-oq-03/knowledge.md
@@ -1,0 +1,190 @@
+# Knowledge — infinitude-primes-4k1-oq-03
+
+## S1 (researcher-1, 2026-05-12) — OBSERVE survey
+
+### Concrete numerical data
+
+For `q = 4`, the reduced residue classes are exactly `{1, 3}`:
+
+| residue `a mod 4` | `gcd(a, 4)` | reduced? | first few primes in class |
+|------------------:|:-----------:|:--------:|:--------------------------|
+| 0                 | 4           | no       | (none) |
+| 1                 | 1           | yes      | 5, 13, 17, 29, 37, 41, 53, 61, 73, 89, … |
+| 2                 | 2           | no       | 2 (only) |
+| 3                 | 1           | yes      | 3, 7, 11, 19, 23, 31, 43, 47, 59, 67, … |
+
+Counts of primes ≤ N in each class:
+
+| `N`     | `π(N)` | `π(N; 4, 1)` | `π(N; 4, 3)` | ratio 4k+1 | ratio 4k+3 |
+|--------:|-------:|-------------:|-------------:|:-----------|:-----------|
+| 100     | 25     | 11           | 13           | 0.440      | 0.520      |
+| 1000    | 168    | 80           | 87           | 0.476      | 0.518      |
+| 10⁴     | 1229   | 609          | 619          | 0.495      | 0.504      |
+| 10⁵     | 9592   | 4783         | 4808         | 0.499      | 0.501      |
+| 10⁶     | 78498  | 39175        | 39322        | 0.499      | 0.501      |
+
+The famous "Chebyshev bias" (Chebyshev 1853, Knapowski-Turán)
+favours `4k+3` over `4k+1` for small `N`, but both ratios
+converge to `1/2` as `N → ∞`. This is the natural-density form of
+the OQ-03 target.
+
+**Reference**: OEIS A002145 (primes ≡ 3 mod 4), A002144 (primes ≡ 1 mod 4).
+
+### Density value derivation
+
+For `(q, a)` coprime: density = `1/φ(q)`.
+
+| `q` | `(ℤ/qℤ)ˣ` | `φ(q)` | density per class |
+|----:|:----------|:------:|:------------------|
+| 3   | {1, 2}    | 2      | 1/2               |
+| 4   | {1, 3}    | 2      | 1/2               |
+| 5   | {1, 2, 3, 4} | 4   | 1/4               |
+| 6   | {1, 5}    | 2      | 1/2               |
+| 8   | {1, 3, 5, 7} | 4   | 1/4               |
+| 12  | {1, 5, 7, 11} | 4  | 1/4               |
+
+For OQ-03: `q = 4, a = 1, φ(4) = 2`, density = **1/2**.
+
+### Why no elementary proof
+
+**Chebyshev (1853)** showed `π(N; 4, 1)/π(N) ∈ (1/2 - ε, 1/2 + ε)`
+for any `ε > 0` and large `N` — but only with the constant of
+proportionality depending on `ε` via Chebyshev's bounds. The *limit*
+statement requires either:
+
+- **Dirichlet's analytic method (1837)**: L-function nonvanishing at
+  `s = 1`. Gives the *Dirichlet density* directly.
+
+- **De la Vallée-Poussin (1899)**: Extension of PNT to APs. Gives
+  the *natural density* form. Requires L-function nonvanishing on
+  the full line `Re s = 1`.
+
+No fully elementary proof is known for either density form.
+**Mertens (1874)** proved the logarithmic density
+`∑_{p ≤ N, p ≡ 1 [4]} 1/p ~ (1/2) log log N` semi-elementarily,
+but the natural-density limit eluded all elementary attacks until
+Selberg-Erdős's elementary PNT (1949) and its later extension to APs.
+
+### Mathlib status (Lean 4, pinned revision)
+
+**Already in Mathlib** (with high confidence, names approximate):
+
+- `Mathlib.NumberTheory.DirichletCharacter.Basic` — full theory of
+  Dirichlet characters, including the mod-4 instance.
+- `Mathlib.NumberTheory.LSeries.DirichletContinuation` — L-functions
+  of Dirichlet characters with analytic continuation.
+- `Mathlib.NumberTheory.LSeries.NonvanishingOne` — nonvanishing of
+  `L(s, χ)` on `Re s = 1` for nontrivial `χ`.
+- `Mathlib.NumberTheory.LSeries.PrimesInAP` — the PNT-AP statements
+  (added 2024-2025). Probably contains the natural-density form
+  under a name like `Nat.setOf_prime_and_eq_mod_*_tendsto_*`.
+- `Mathlib.NumberTheory.Totient` — `Nat.totient`, computation
+  `Nat.totient 4 = 2` via `decide` or `Nat.totient_prime_pow`.
+- `Mathlib.NumberTheory.SumTwoSquares` — Fermat two-square theorem
+  (already imported by the parent `InfinitudePrimes4k1.lean`).
+
+**Mathlib gaps** (best-guess; may already be filled at pinned revision):
+
+- A *clean ratio form* `(π(N; q, a) : ℝ) / (π(N) : ℝ) → 1/φ(q)`. The
+  Mathlib statement is more likely phrased via the inverse:
+  `π(N; q, a) ~ (1/φ(q)) · (N / log N)` as an asymptotic equivalence.
+  Translating between these is a 10-15 line ratio lemma.
+
+- A `(q=4, a=1)` specialization. Mathlib's statements are typically
+  parametric in `(q, a)`; the user must instantiate.
+
+- A "primes representable as sums of two squares" density corollary
+  (combining S2 + Fermat-2-square).
+
+### Parent file (already verified)
+
+`Proofs/InfinitudePrimes4k1.lean` (178 lines, 5 theorems, 0 sorries, 0 axioms)
+proves:
+
+- `prime_dvd_sq_add_one_mod_four` — key Euler-criterion lemma
+- `exists_odd_prime_factor` — basic combinatorics
+- `infinitely_many_primes_1_mod_4` — main result (existence form)
+- `primes_1_mod_4_infinite` — `Set.Infinite` form
+- `no_largest_prime_1_mod_4` — `¬∃ max` form
+
+This OQ-03 sits *above* the parent: the parent gives
+`Set.Infinite {p | p.Prime ∧ p % 4 = 1}`, while OQ-03 strengthens
+to the asymptotic density form.
+
+### Density vs Dirichlet density
+
+For the OQ statement "density 1/2 among primes" both natural and
+Dirichlet density give the same value, but they are *different
+theorems* in Mathlib:
+
+- **Dirichlet form (analytic):** Easier; follows from L-function
+  nonvanishing at the single point `s = 1`.
+  Statement involves a limit `s ↘ 1` of an L-series ratio.
+
+- **Natural form:** Harder; equivalent to PNT-AP. Statement involves
+  a direct ratio of prime-counting functions.
+
+For a maximally clean gallery deliverable, the *natural-density* form
+is the preferred target — it matches the human-language reading of
+"density 1/2" and connects directly to the Chebyshev bias data above.
+
+### S1 scope (this iteration)
+
+This S1 is **survey-only** per the SCAFFOLD pattern (no Lean changes).
+Produced:
+
+- `problem.md` (~250 lines, theoretical content + Mathlib map +
+  decomposition table)
+- `state.md` (current file inventory + next-action plan)
+- `knowledge.md` (this file: numerical data + Mathlib status)
+- `src/data/research/problems/infinitude-primes-4k1-oq-03.json`
+  updated: phase NEW → OBSERVE, focus + insights + nextSteps populated
+
+No Lean files modified; no axiom/sorry deltas.
+
+### Next-action sketch (for S2)
+
+The cleanest S2 is to create `Proofs/InfinitudePrimes4k1OQ03.lean`
+with the structure:
+
+```lean
+import Proofs.InfinitudePrimes4k1
+import Mathlib.NumberTheory.LSeries.PrimesInAP
+import Mathlib.NumberTheory.Totient
+
+namespace InfinitudePrimes4k1OQ03
+
+open Nat Filter Topology
+
+-- The key auxiliary computation
+lemma totient_four : Nat.totient 4 = 2 := by decide
+
+-- Specialize Mathlib's PNT-AP to (q=4, a=1)
+theorem primes_4k1_density :
+    Tendsto
+      (fun N : ℕ => ((Finset.range N).filter
+        (fun p => p.Prime ∧ p % 4 = 1)).card / (N.primeCounting : ℝ))
+      atTop (𝓝 (1/2)) := by
+  -- Use Mathlib's `Nat.setOf_prime_and_eq_mod_*_tendsto_*` family
+  have := Nat.[PNT_AP_API_NAME] (q := 4) (a := 1) (by decide : (1 : ZMod 4).IsUnit)
+  -- Convert via totient_four; ratio gymnastics
+  sorry  -- placeholder for the API wiring
+
+end InfinitudePrimes4k1OQ03
+```
+
+The `sorry` is the wiring step against the (recently-stabilized)
+PNT-AP API. Once the Mathlib name is confirmed (`exact?` /
+`#check Nat.` autocomplete in a REPL), the proof is mechanical.
+
+### Risks for S2
+
+- **API name churn** in `Mathlib.NumberTheory.LSeries.PrimesInAP` —
+  the precise name of the density-form theorem may have shifted.
+  Plan a name-discovery step before writing the proof.
+- **Ratio-form vs asymptotic-equivalent form**: Mathlib's statement
+  may be `IsEquivalent` (~) rather than `Tendsto`. Conversion is
+  routine but worth budgeting.
+- **`primeCounting` namespace**: `Nat.primeCounting` vs
+  `Nat.Prime.count` vs the new `Nat.nth Nat.Prime`-based form —
+  several flavors exist; pick the one matching the PNT-AP signature.

--- a/research/problems/infinitude-primes-4k1-oq-03/problem.md
+++ b/research/problems/infinitude-primes-4k1-oq-03/problem.md
@@ -1,0 +1,255 @@
+# Problem: Primes ≡ 1 (mod 4) have density 1/2 among primes
+
+## Statement
+
+### Plain Language
+
+The parent proof `cube-root-3-irrational`'s sibling
+`infinitude-primes-4k1` (`Proofs/InfinitudePrimes4k1.lean`) establishes
+the **infinitude** of primes congruent to `1 (mod 4)` by an elementary
+argument (Fermat sums-of-two-squares + Euler's criterion: any odd prime
+dividing `k² + 1` is `≡ 1 (mod 4)`).
+
+This OQ asks for the much stronger **density** form:
+
+$$
+\lim_{N \to \infty} \frac{\#\{p \le N : p \text{ prime},\, p \equiv 1 \pmod{4}\}}{\pi(N)} \;=\; \tfrac{1}{2}
+$$
+
+This is a specialization of the **prime number theorem for arithmetic
+progressions** (PNT-AP), or equivalently — at weaker resolution — of
+**Dirichlet's density theorem** of 1837.
+
+For `q = 4`, the reduced residues are `{1, 3}` (i.e. `(ℤ/4ℤ)ˣ` has
+order `φ(4) = 2`), so each class is hit by half the primes.
+
+### Formal Statement
+
+Two natural targets in Lean, corresponding to the two flavors of density:
+
+**Natural-density form (PNT-AP, harder)**:
+
+```lean
+-- Density in N (`π(N; 4, 1) / π(N) → 1/2`)
+theorem primes_4k1_natural_density :
+    Tendsto
+      (fun N => ((Nat.primeCounting N).filter (· % 4 = 1)).card / (Nat.primeCounting N) : ℕ → ℝ)
+      atTop (𝓝 (1/2)) := by sorry
+```
+
+**Dirichlet-density form (analytic / log-scale, easier)**:
+
+```lean
+-- ∑_{p ≡ 1 [4]} p^{-s}  ~  (1/2) · ∑_p p^{-s}  as s ↘ 1
+theorem primes_4k1_dirichlet_density :
+    Tendsto
+      (fun s : ℝ => (∑' p : {p : ℕ // p.Prime ∧ p % 4 = 1}, (p : ℝ) ^ (-s))
+                  / (∑' p : {p : ℕ // p.Prime}, (p : ℝ) ^ (-s)))
+      (𝓝[>] 1) (𝓝 (1/2)) := by sorry
+```
+
+The natural-density form implies the Dirichlet-density form; the
+converse requires Tauberian techniques.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - number-theory
+  - prime-numbers
+  - modular-arithmetic
+  - dirichlet-theorem
+  - sum-of-two-squares
+  - mathlib-bridge
+```
+
+**Significance**: 6/10 — Specialization of a marquee result (PNT-AP /
+Dirichlet density). The `q = 4` case is the simplest non-trivial
+arithmetic progression that requires the full L-function machinery; it
+is also the case most accessible to elementary readers because of the
+Euler-criterion / sum-of-two-squares connection at the level of
+infinitude. Density 1/2 makes a particularly clean theorem statement.
+
+**Tractability**: 6/10 — Tractable only as a **Mathlib bridge**: the
+deep work (Dirichlet character theory, L-function nonvanishing,
+Ikehara Tauberian theorem) is already in Mathlib at the pinned
+revision. The OQ-03 deliverable is to **wire up** these results to
+the `q = 4, a = 1` instance, not to reprove them. The wiring itself
+is straightforward `Mathlib.NumberTheory.LSeries.PrimesInAP` API +
+`Nat.totient 4 = 2` computation.
+
+## Why This Matters
+
+1. **Gallery completeness** — `infinitude-primes-4k1` proves the
+   *infinitude* form elementarily but stops short of the quantitative
+   density. Pairing them gives a 1-2 punch: "infinitely many" (the
+   easy half of Dirichlet 1837) plus "with density 1/2" (the hard
+   half, via L-functions). This is the canonical pedagogical sequence
+   for introducing Dirichlet's theorem.
+
+2. **First Mathlib PNT-AP instance in the gallery** — Mathlib's
+   `Mathlib.NumberTheory.LSeries.PrimesInAP` was completed in 2024-2025
+   (Stoll, Stephan, Mehta and collaborators). It establishes the
+   density form for **all** valid `(q, a)`. The gallery has no
+   specialization of it yet; this OQ would be the first.
+
+3. **Companion to sum-of-two-squares** — Primes ≡ 1 (mod 4) are
+   exactly the primes that are sums of two squares (Fermat's two-square
+   theorem). The density 1/2 statement therefore says: *half* of all
+   primes are sums of two squares. This is a striking fact that's
+   easy to state, hard to prove, and not in the gallery.
+
+4. **Drift-robust target** — Mathlib's PNT-AP infrastructure is recent
+   and active; locking in a specific specialization here gives the
+   project a CI canary for L-function-related drift.
+
+## Theoretical Path
+
+### The deep input: PNT for arithmetic progressions
+
+The **prime number theorem for arithmetic progressions** states: for
+coprime `a, q`,
+
+$$
+\pi(N; q, a) \;:=\; \#\{p \le N : p \equiv a \pmod q,\; p \text{ prime}\}
+\;\sim\; \frac{1}{\varphi(q)} \cdot \frac{N}{\log N}.
+$$
+
+This is equivalent (after dividing by `π(N) ~ N/log N`) to
+
+$$
+\frac{\pi(N; q, a)}{\pi(N)} \;\longrightarrow\; \frac{1}{\varphi(q)}.
+$$
+
+For `q = 4, a = 1`: `φ(4) = #(ℤ/4ℤ)ˣ = #{1, 3} = 2`, giving
+`density = 1/2`.
+
+### Proof strategy in Mathlib
+
+The path goes through Dirichlet characters and L-functions:
+
+1. The Dirichlet characters mod 4 are the trivial character `χ₀` and
+   the unique nontrivial real character `χ₁` (the Legendre symbol
+   `n ↦ (-1)^((n-1)/2)` extended by 0 on even `n`).
+
+2. The associated L-function is `L(s, χ₁) = β(s)`, the Dirichlet
+   beta function (Mathlib: `DirichletCharacter.LFunction`).
+
+3. **Nonvanishing on Re s = 1** is established in Mathlib
+   (`DirichletCharacter.LFunction_ne_zero_of_re_eq_one`).
+
+4. **Ikehara Tauberian theorem** (Mathlib:
+   `NumberTheory.LSeries.Wiener` / `LSeries.IkeharaTauberian`) extracts
+   the natural-density asymptotic from the L-function analytic data.
+
+5. Combining the trivial and nontrivial character contributions via
+   orthogonality (Mathlib: `DirichletCharacter.sum_apply_eq_indicator`)
+   isolates the residue class `1 mod 4`.
+
+### Tractable subgoals
+
+For OQ-03 work, the targets in increasing depth are:
+
+| Subgoal | Mathlib leverage | Difficulty |
+|---------|-------------------|------------|
+| `φ(4) = 2` computation | `Nat.totient_prime_pow_one_lt` / `decide` | Trivial |
+| Reduced residues mod 4 are `{1, 3}` | `ZMod.unitsEquivCoprime` | Easy |
+| Dirichlet density form `(q=4, a=1) → 1/2` | `Nat.setOf_prime_and_eq_mod_dirichletDensity` (or its current name) | Medium |
+| Natural density form `π(N; 4, 1)/π(N) → 1/2` | `Nat.setOf_prime_and_eq_mod_div_smul_tendsto_inv_totient` (or its current name) | Medium |
+| End-to-end clean statement | Combine the above | Medium |
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `infinitude-primes-4k1` (parent) | Provides the elementary infinitude statement; this OQ upgrades to density |
+| `infinitude-primes` | Euclid's classical proof, the great-grandparent |
+| `infinitude-primes-4k3` (sibling) | Same density question for the other residue class mod 4 (also 1/2) |
+| `dirichlet-theorem` (if present) | The general statement that this OQ specializes |
+| `prime-number-theorem` | The unrestricted analog (`π(N) ~ N/log N`); the density form quotients this away |
+| `sum-of-two-squares` | Fermat's theorem; the residue class `1 mod 4` is exactly the representable primes |
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib name (Lean 4, approximate) | Module |
+|------|------------------------------------|--------|
+| Dirichlet characters | `DirichletCharacter` | `Mathlib.NumberTheory.DirichletCharacter.Basic` |
+| L-function of a Dirichlet character | `DirichletCharacter.LFunction` | `Mathlib.NumberTheory.LSeries.DirichletContinuation` |
+| L-function nonvanishing on `Re s = 1` | `DirichletCharacter.LFunction_ne_zero_of_re_eq_one` | `Mathlib.NumberTheory.LSeries.NonvanishingOne` |
+| Prime counting in AP, density form | `Nat.setOf_prime_and_eq_mod_*_tendsto_*` (PNT-AP family) | `Mathlib.NumberTheory.LSeries.PrimesInAP` |
+| Ikehara Tauberian theorem | `LSeries.IkeharaTauberian` (or `LSeriesHasSum_*`) | `Mathlib.NumberTheory.LSeries.Wiener` |
+| `Nat.totient`, `Nat.totient 4 = 2` | `Nat.totient`, `Nat.totient_prime_pow` | `Mathlib.NumberTheory.Totient` |
+| Reduced-residue indexing of `(ℤ/4ℤ)ˣ` | `ZMod.unitsEquivCoprime`, `ZMod.unitsEquivProd` | `Mathlib.Data.ZMod.Units` |
+| `Mathlib.NumberTheory.SumTwoSquares` already imported | the parent file's main lemma | `Mathlib.NumberTheory.SumTwoSquares` |
+
+**Caveat**: API names in `Mathlib.NumberTheory.LSeries.PrimesInAP` have
+churned during 2024-2025 as the file matured. Any S2 implementation
+should `exact?` / `apply?` against the live `_root_` and
+`DirichletCharacter` namespaces rather than hard-coding names.
+
+## Suggested Next-Action Decomposition
+
+This is **OBSERVE** phase. No Lean changes yet — only a survey and a
+concrete specialization-target list:
+
+1. **S2: Wire Mathlib PNT-AP into a `q=4, a=1` statement.** Locate
+   the current Mathlib name for the density form (likely something
+   like `Nat.setOf_prime_and_eq_mod_div_smul_tendsto_inv_totient`).
+   Specialize with `q = 4`, `a = 1`, and compute `Nat.totient 4 = 2`
+   via `decide` or `Nat.totient_prime_pow`. Produces
+   `Proofs/InfinitudePrimes4k1OQ03.lean` (~80 lines).
+
+2. **S3: Sum-of-two-squares corollary.** Combine S2 with Fermat's
+   two-square theorem (`Mathlib.NumberTheory.SumTwoSquares`,
+   `Nat.Prime.prime_of_mod_four_eq_one_or_two`) to conclude: the
+   primes expressible as sums of two squares have density 1/2
+   among all primes (excluding `p = 2`, which is a single point of
+   density 0). ~30 line corollary.
+
+3. **S4 (optional): Dirichlet-density form as a corollary of the
+   natural-density form.** Show the Abel-summation transform from
+   `π(N; 4, 1)/π(N) → 1/2` to the L-series quotient. This is mostly
+   a Mathlib bookkeeping step but useful as a separate theorem
+   because some readers know only the analytic form.
+
+4. **S5: Pair-with-4k3 corollary.** State and prove that primes
+   `≡ 3 (mod 4)` also have density 1/2; their union covers all but
+   `{2}`. This is direct from PNT-AP with `(q=4, a=3)`.
+
+## Theoretical Subtlety: Three "Densities"
+
+| Density flavor | Definition | Source theorem |
+|----------------|-----------|----------------|
+| **Natural** | `lim π(N; q, a) / π(N)` | PNT-AP (deep) |
+| **Dirichlet (analytic)** | `lim_{s↘1} (∑_{p ≡ a [q]} p^{-s}) / (∑_p p^{-s})` | Dirichlet 1837 (medium) |
+| **Logarithmic** | `lim ∑_{p ≤ N, p ≡ a [q]} 1/p · 1/(log log N)` | Mertens-style (medium) |
+
+All three give the same value `1/φ(q)` for `(q, a)` coprime. The
+**Dirichlet density** form is what Dirichlet originally proved in 1837;
+the natural-density form is essentially equivalent to PNT-AP and was
+established by de la Vallée-Poussin (1899) in the wake of PNT.
+
+For Mathlib, both should be available; the natural-density form is
+the more recent addition.
+
+## Risk Notes
+
+- **Mathlib API churn**: `PrimesInAP.lean` is recent; names may have
+  shifted between the seeker run (when the slug was added) and this
+  OBSERVE pass. Any S2 implementation should `#check` the candidate
+  names against the pinned revision before committing.
+- **No axioms required**: all infrastructure is `verified` in
+  Mathlib; the OQ-03 specialization stays in the `verified` track.
+- **Docker build cost**: a fresh build with full Mathlib imports
+  (`Mathlib.NumberTheory.LSeries.PrimesInAP` pulls in the whole
+  analytic stack) is ~45 min in this worktree per the broken
+  `.lake` symlink. Plan accordingly; the SCAFFOLD itself is
+  text-only and incurs no build.
+- **Density quotient gymnastics**: PNT-AP statements in Mathlib
+  often phrase the asymptotic as `(π(N; q, a) - N/(φ(q) log N)) / (N/log N) → 0`,
+  not as the clean ratio `π(N; q, a) / π(N) → 1/φ(q)`. Converting
+  between these is routine but adds ~10-15 lines.

--- a/research/problems/infinitude-primes-4k1-oq-03/state.md
+++ b/research/problems/infinitude-primes-4k1-oq-03/state.md
@@ -1,0 +1,123 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-1, 2026-05-12): Initial OBSERVE survey. Documented the
+question — does Lean 4 have a proof that primes `≡ 1 (mod 4)` have
+density `1/2` among primes — together with the Mathlib infrastructure
+that should make this a 1-PR specialization (`PrimesInAP` + `totient 4`)
+rather than a fresh formalization.
+
+## Active Approach
+
+**Mathlib bridge.**
+
+The parent file `Proofs/InfinitudePrimes4k1.lean` (verified, 0 axioms,
+0 sorries) proves the *infinitude* of primes `≡ 1 (mod 4)`
+elementarily. This OQ asks for the strictly stronger *density 1/2*
+statement.
+
+The infinitude form is in principle weaker than the density form, but
+in practice they live in different worlds:
+
+- **Infinitude**: elementary Euclid-style proof via `(2·n!)² + 1` and
+  Euler's criterion (done in the parent file, ~140 lines).
+- **Density**: requires PNT for arithmetic progressions —
+  Dirichlet characters, L-function nonvanishing on `Re s = 1`,
+  Ikehara Tauberian theorem.
+
+Mathlib has all of the latter at the pinned revision
+(`Mathlib.NumberTheory.LSeries.PrimesInAP` and friends). The OQ-03
+deliverable is to **specialize** these results to `(q, a) = (4, 1)`,
+not to reprove them.
+
+## Blockers
+
+None mathematical.
+
+Practical:
+
+- The `proofs/.lake` symlink in the researcher worktree
+  points to itself, so any Docker build will be a fresh ~45-minute
+  clone-and-rebuild cycle. Strict text-only iterations (this S1) are
+  unaffected.
+- Mathlib's `PrimesInAP.lean` API matured during 2024-2025 and the
+  exact theorem name may have churned. S2 should `exact?` /
+  `#check` against the pinned revision before committing the
+  specialization.
+
+## Next Action
+
+**S2 (any researcher)**: Create `proofs/Proofs/InfinitudePrimes4k1OQ03.lean`
+with the density-form theorem statement, wired through Mathlib's
+PNT-AP API.
+
+Skeleton (per knowledge.md):
+
+```lean
+import Proofs.InfinitudePrimes4k1
+import Mathlib.NumberTheory.LSeries.PrimesInAP
+
+namespace InfinitudePrimes4k1OQ03
+open Nat Filter Topology
+
+lemma totient_four : Nat.totient 4 = 2 := by decide
+
+theorem primes_4k1_density :
+    Tendsto (fun N : ℕ =>
+      ((Finset.range N).filter (fun p => p.Prime ∧ p % 4 = 1)).card
+        / (N.primeCounting : ℝ))
+      atTop (𝓝 (1/2)) := by
+  -- Specialize Mathlib's PNT-AP to (q=4, a=1)
+  have := Nat.[PNT_AP_API_NAME] (q := 4) (a := 1) (by decide : (1 : ZMod 4).IsUnit)
+  -- 1/φ(4) = 1/2 via totient_four
+  rw [show (1 : ℝ)/2 = 1/(Nat.totient 4 : ℝ) by simp [totient_four]; norm_num]
+  sorry
+
+end InfinitudePrimes4k1OQ03
+```
+
+The `sorry` is the wiring step. Once the precise Mathlib name for
+the density form is identified, the proof is ~10 lines.
+
+Optional follow-up in same S2 (if API wiring goes smoothly):
+
+- S2b: corollary "primes representable as sums of two squares have
+  density 1/2 among primes" via Fermat's two-square theorem
+  (`Mathlib.NumberTheory.SumTwoSquares`).
+- S2c: corollary `primes_4k3_density` for the sister class.
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 survey)
+- Current approach attempts: 1 (Mathlib bridge)
+- Approaches tried: 1
+
+## Open files
+
+- `problem.md` — theoretical context, Mathlib infrastructure map,
+  decomposition table, three-density theory comparison.
+- `knowledge.md` — S1 session notes: numerical prime-counting data,
+  Chebyshev-bias context, Mathlib status, S2 skeleton.
+
+## S1 Deliverable
+
+This iteration is **survey-only**:
+- 0 new theorems
+- 0 new sorries
+- 0 axiom changes
+- 0 Lean files modified
+
+Produced:
+- `problem.md` (~250 lines) — full problem statement, Mathlib map,
+  decomposition into S2/S3/S4/S5 sessions.
+- `state.md` (this file) — phase NEW → OBSERVE.
+- `knowledge.md` — numerical prime-counts up to `N = 10⁶`,
+  three-density theory comparison, S2 skeleton.
+- `src/data/research/problems/infinitude-primes-4k1-oq-03.json` —
+  phase NEW → OBSERVE, focus + insights + mathlibGaps + nextSteps
+  populated.

--- a/src/data/research/problems/infinitude-primes-4k1-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-03.json
@@ -1,0 +1,116 @@
+{
+  "slug": "infinitude-primes-4k1-oq-03",
+  "title": "Lean 4 proof that primes \\equiv 1 \\pmod 4 have density 1/2 among primes",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\lim_{N\\to\\infty} \\dfrac{\\#\\{p \\le N : p\\text{ prime},\\, p \\equiv 1 \\pmod 4\\}}{\\pi(N)} = \\tfrac{1}{2}",
+    "plain": "Strengthen the parent infinitude theorem to the density form: primes ≡ 1 (mod 4) form a half-density subset of all primes. This is the (q=4, a=1) specialization of the prime number theorem for arithmetic progressions (PNT-AP); for q=4 the totient is 2 so the density is 1/φ(4) = 1/2.",
+    "whyMatters": [
+      "Pairs with the elementary infinitude proof to give Dirichlet 1837 → PNT-AP density 1/φ(q) at the simplest non-trivial modulus.",
+      "First specialization of Mathlib.NumberTheory.LSeries.PrimesInAP in the project gallery (the file matured in 2024–2025).",
+      "Density form makes Fermat's two-square theorem density-quantitative: exactly half of all primes are sums of two squares."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T05:10:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-1, 2026-05-12): OBSERVE survey scaffold. Question: does Lean 4 have a proof that primes ≡ 1 (mod 4) have density 1/2 among primes? Documented the strategy as a Mathlib bridge — specialize Mathlib's PNT-AP infrastructure (`Mathlib.NumberTheory.LSeries.PrimesInAP`) at (q=4, a=1), wire through `Nat.totient 4 = 2`. No Lean changes this iteration; produced problem.md (~250 lines), state.md, knowledge.md with numerical Chebyshev-bias data up to N=10⁶, three-density theory comparison, and S2 skeleton.",
+    "blockers": [],
+    "nextAction": "S2: create proofs/Proofs/InfinitudePrimes4k1OQ03.lean specializing Mathlib's PNT-AP density form at (q=4, a=1). Skeleton in knowledge.md; the proof reduces to: identify the precise current name of the density-form theorem in `Mathlib.NumberTheory.LSeries.PrimesInAP` (likely `Nat.setOf_prime_and_eq_mod_*_tendsto_*`), specialize with q=4 a=1, and use `totient_four : Nat.totient 4 = 2 := by decide`. ~80 lines, 0 axioms expected.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-1, 2026-05-12): OBSERVE survey. Established that this is a Mathlib bridge, not a fresh formalization — the deep PNT-AP machinery is in `Mathlib.NumberTheory.LSeries.PrimesInAP` (added 2024–2025), and the OQ-03 deliverable is to specialize at (q=4, a=1) using `Nat.totient 4 = 2`. Documented the three-density distinction (natural / Dirichlet / log) and the Chebyshev bias data showing convergence to 1/2 for both 4k+1 and 4k+3 classes by N=10⁶. Parent file InfinitudePrimes4k1.lean (verified, 0 axioms, 178 lines) provides the infinitude form; OQ-03 strengthens to density.",
+    "builtItems": [
+      "research/problems/infinitude-primes-4k1-oq-03/problem.md (new, ~250 lines): full problem statement, two formal-statement variants (natural-density and Dirichlet-density forms), Mathlib infrastructure map, theoretical path through Dirichlet characters + L-function nonvanishing + Ikehara Tauberian, decomposition into S2–S5 sessions.",
+      "research/problems/infinitude-primes-4k1-oq-03/state.md (new): phase NEW → OBSERVE; concrete S2 skeleton for proofs/Proofs/InfinitudePrimes4k1OQ03.lean.",
+      "research/problems/infinitude-primes-4k1-oq-03/knowledge.md (new): Chebyshev bias data N=100..10⁶ (4k+1 ratio rises 0.440 → 0.499, 4k+3 ratio falls 0.520 → 0.501), Mathlib status with module names, three-density comparison table, S2 skeleton."
+    ],
+    "insights": [
+      "Density 1/2 derivation: for q=4 the reduced residues are exactly {1, 3} so |(ℤ/4ℤ)ˣ| = φ(4) = 2, giving density 1/φ(4) = 1/2 per class by PNT-AP.",
+      "Chebyshev bias (1853): for small N, π(N; 4, 1) < π(N; 4, 3) — e.g. at N=10⁶, 39175 vs 39322. Both converge to half of π(N), but 4k+3 leads. The OQ density-1/2 statement is the asymptotic limit, not a finite-N inequality.",
+      "Three densities (natural / Dirichlet / log) all give 1/φ(q) for coprime (q, a). Natural is PNT-AP-equivalent (deepest); Dirichlet is the 1837 original (medium); log is Mertens-level (semi-elementary). For OQ-03 the natural-density form is the cleaner target because it matches the human-language reading.",
+      "Parent file already imports Mathlib.NumberTheory.SumTwoSquares for the Euler-criterion lemma; the density-form file can chain through it for free to get the \"sum-of-two-squares primes have density 1/2\" corollary.",
+      "Mathlib's PNT-AP statement family (Nat.setOf_prime_and_eq_mod_*_tendsto_*) is recent (2024–2025) and the precise name may have shifted; S2 should `exact?` against the pinned revision before hard-coding.",
+      "No elementary proof of the density form is known. Chebyshev (1853) gave ε-bounds on the ratio but the limit required L-function machinery (Dirichlet 1837 for log-density, de la Vallée-Poussin 1899 for natural density)."
+    ],
+    "mathlibGaps": [
+      "(possibly already filled) A clean ratio form `(π(N; q, a) : ℝ) / (π(N) : ℝ) → 1/φ(q)`; Mathlib likely phrases the asymptotic as `π(N; q, a) ~ (1/φ(q)) * (N / log N)` via IsEquivalent. Converting to the ratio form is a 10–15 line lemma.",
+      "(possibly already filled) A (q=4, a=1) specialization with `Nat.totient 4 = 2` plugged in. Mathlib's statements are typically parametric in (q, a).",
+      "A density-form `sum_of_two_squares_density = 1/2` corollary that explicitly chains through Fermat's two-square theorem. Likely never stated in Mathlib because both inputs are general; the gallery is the right place for this corollary."
+    ],
+    "nextSteps": [
+      "S2: create proofs/Proofs/InfinitudePrimes4k1OQ03.lean (~80 lines). Specialize Mathlib's PNT-AP density form at (q=4, a=1) using `Nat.totient 4 = 2`. Use `exact?` / `#check Nat.` autocomplete in a Lean REPL to identify the precise current name of the density-form theorem; then specialize and ratio-convert if needed.",
+      "S3 (optional): density-form corollary for sum-of-two-squares primes, chaining through Fermat's two-square theorem. ~30 lines.",
+      "S4 (optional): sister class density theorem for primes ≡ 3 (mod 4); direct from PNT-AP with (q=4, a=3). Pair-with-4k3 corollary in the same file.",
+      "S5 (optional): finer-grained statement: π(N; 4, 1) = (N / (2 log N)) + o(N/log N), peeling the asymptotic equivalent."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "prime-numbers",
+    "modular-arithmetic",
+    "dirichlet-theorem",
+    "sum-of-two-squares",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "infinitude-primes-4k1",
+    "infinitude-primes",
+    "infinitude-primes-4k3",
+    "prime-number-theorem",
+    "sum-of-two-squares",
+    "dirichlet-theorem"
+  ],
+  "references": {
+    "papers": [
+      "Dirichlet, P. G. L. (1837). Über den Satz, dass jede unbegrenzte arithmetische Progression... unendlich viele Primzahlen enthält.",
+      "Chebyshev, P. L. (1853). Letter to M. Fuss on the residues of primes.",
+      "de la Vallée-Poussin, C. J. (1899). Recherches analytiques sur la théorie des nombres premiers.",
+      "Knapowski, S. & Turán, P. (1962–1977). Comparative prime-number theory I–VIII."
+    ],
+    "urls": [
+      "https://oeis.org/A002144",
+      "https://oeis.org/A002145"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.LSeries.PrimesInAP",
+      "Mathlib.NumberTheory.DirichletCharacter.Basic",
+      "Mathlib.NumberTheory.LSeries.DirichletContinuation",
+      "Mathlib.NumberTheory.LSeries.NonvanishingOne",
+      "Mathlib.NumberTheory.Totient",
+      "Mathlib.NumberTheory.SumTwoSquares",
+      "Mathlib.Data.ZMod.Units"
+    ]
+  },
+  "started": "2026-05-12T04:48:16.449Z",
+  "lastUpdate": "2026-05-12T05:10:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/InfinitudePrimes4k1.lean",
+      "filename": "InfinitudePrimes4k1.lean",
+      "lineCount": 178,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InfinitudePrimes4k1.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for `infinitude-primes-4k1-oq-03` (fresh tier-B
slug; 0 prior PRs, 0 recent merges at claim time). Question: does
Lean 4 have a proof that primes $\equiv 1 \pmod 4$ have **density
$1/2$** among primes?

The parent file `Proofs/InfinitudePrimes4k1.lean` (verified, 178
lines, 0 axioms) proves the *infinitude* form elementarily via
Fermat sums-of-two-squares + Euler's criterion. This OQ asks for
the strictly stronger density form, which is the $(q=4, a=1)$
specialization of PNT-AP via $\varphi(4) = 2$.

**Strategy**: Mathlib bridge — specialize
`Mathlib.NumberTheory.LSeries.PrimesInAP` (matured 2024–2025) at
$(q, a) = (4, 1)$ using `Nat.totient 4 = 2` (`decide`). The deep
machinery (Dirichlet characters, L-function nonvanishing on
$\text{Re}\,s = 1$, Ikehara Tauberian theorem) is already in
Mathlib at the pinned revision.

## Progress

S1 deliverable (text-only, no Lean changes):

| File | Type | Size | Content |
|------|------|-----:|---------|
| `research/problems/infinitude-primes-4k1-oq-03/problem.md` | new | 255 lines | Two formal-statement variants (natural + Dirichlet density), Mathlib infrastructure map, theoretical path, S2–S5 decomposition. |
| `research/problems/infinitude-primes-4k1-oq-03/knowledge.md` | new | 190 lines | Chebyshev-bias numerical data $N=100..10^6$, Mathlib status with module names, three-density comparison table, S2 skeleton. |
| `research/problems/infinitude-primes-4k1-oq-03/state.md` | new | 123 lines | Phase NEW → OBSERVE; S2 concrete skeleton. |
| `src/data/research/problems/infinitude-primes-4k1-oq-03.json` | new | 116 lines | Gallery entry; orphan in main-repo working tree was untracked, recreated here from scratch with phase=OBSERVE, 6 insights, 3 mathlib gaps, 4 next-steps. |

**Totals**: +684 lines, 0 Lean files modified, 0 axiom/sorry deltas.

## Findings

### Numerical (Chebyshev bias data)

| $N$ | $\pi(N)$ | $\pi(N; 4, 1)$ | $\pi(N; 4, 3)$ | $\frac{\pi(N;4,1)}{\pi(N)}$ |
|----:|---------:|---------------:|---------------:|:----------------------------|
| $10^2$ | 25 | 11 | 13 | 0.440 |
| $10^3$ | 168 | 80 | 87 | 0.476 |
| $10^4$ | 1229 | 609 | 619 | 0.495 |
| $10^5$ | 9592 | 4783 | 4808 | 0.499 |
| $10^6$ | 78498 | 39175 | 39322 | 0.499 |

The famous "Chebyshev bias" (1853) favours $4k+3$ over $4k+1$ for
small $N$; both ratios converge to $\tfrac{1}{2}$ in the limit.
The OQ-03 statement is the asymptotic limit, not a finite-$N$
inequality.

### Three-density framework

| Flavor | Theorem source | Difficulty |
|--------|---------------|-----------|
| Natural | PNT-AP (de la Vallée-Poussin 1899) | deepest |
| Dirichlet (analytic) | Dirichlet (1837) | medium |
| Logarithmic | Mertens-style | semi-elementary |

All three give value $1/\varphi(q)$. For OQ-03 the **natural-density**
form is the preferred target — it matches the human-language reading
of "density 1/2" and connects directly to the Chebyshev-bias data
above.

### Mathlib status (Lean 4, pinned revision)

- `Mathlib.NumberTheory.LSeries.PrimesInAP` — PNT-AP statements
  (added 2024–2025); contains the density form under a name in the
  family `Nat.setOf_prime_and_eq_mod_*_tendsto_*`.
- `Mathlib.NumberTheory.DirichletCharacter.Basic` — Dirichlet
  characters; the mod-4 nontrivial real character is the Legendre
  symbol.
- `Mathlib.NumberTheory.LSeries.NonvanishingOne` — L-function
  nonvanishing on $\text{Re}\,s = 1$.
- `Mathlib.NumberTheory.SumTwoSquares` (already imported by the
  parent file) — Fermat's two-square theorem; the density-form
  corollary "sum-of-two-squares primes have density 1/2" follows
  for free.

## Status

**Outcome**: progress (1 OBSERVE-phase SCAFFOLD PR for a fresh tier-B
slug; no Lean changes, all infrastructure documented for the S2 ACT
iteration).

**Build**: not applicable — text-only S1; no Lean files changed.

## Next Steps

**S2**: Create `proofs/Proofs/InfinitudePrimes4k1OQ03.lean` (~80
lines, 0 axioms expected). Specialize Mathlib's PNT-AP density form
at $(q, a) = (4, 1)$ using `totient_four : Nat.totient 4 = 2 := by decide`.
Use `exact?` / `#check Nat.` autocomplete in a Lean REPL to identify
the precise current name of the density-form theorem in
`Mathlib.NumberTheory.LSeries.PrimesInAP`. Skeleton in
`knowledge.md`.

Optional follow-ups (S3–S5): sum-of-two-squares density corollary
(via the parent's `Mathlib.NumberTheory.SumTwoSquares` import); sister
class $(q, a) = (4, 3)$; finer-grained asymptotic
$\pi(N; 4, 1) = N/(2 \log N) + o(N/\log N)$.

🤖 Generated by researcher-1