### PR TITLE
fix(lln-oq04): repair Mathlib .real drift in LawsOfLargeNumbersOQ04* (build verified)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04.lean
@@ -105,9 +105,9 @@ theorem thresholdIndicator_integrable [IsProbabilityMeasure μ]
     {X : ℕ → Ω → ℝ} (hX : ∀ i, Measurable (X i)) (x : ℝ) :
     Integrable (thresholdIndicator X x 0) μ := by
   apply Integrable.mono' (integrable_const (1 : ℝ))
-  · exact ((measurable_iic_indicator x).comp (hX 0)).aemeasurable
+  · exact ((measurable_iic_indicator x).comp (hX 0)).aestronglyMeasurable
   · filter_upwards with ω
-    simp only [thresholdIndicator, Set.indicator, norm_one]
+    simp only [thresholdIndicator, Set.indicator]
     split_ifs with h
     · norm_num
     · norm_num
@@ -129,13 +129,9 @@ theorem integral_thresholdIndicator_eq_cdf [IsProbabilityMeasure μ]
     μ[thresholdIndicator X x 0] = trueCDF X μ x := by
   have hms : MeasurableSet (X 0 ⁻¹' Set.Iic x) := (hX 0) measurableSet_Iic
   simp_rw [thresholdIndicator_eq_preimage_indicator_fun]
-  rw [integral_indicator hms]
-  rw [integral_const, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter,
-      smul_eq_mul, mul_one]
-  simp only [trueCDF]
-  congr 1
-  ext ω
-  simp [Set.mem_preimage, Set.mem_Iic, Set.mem_setOf_eq]
+  rw [integral_indicator hms, integral_const, smul_eq_mul, mul_one,
+      measureReal_def, Measure.restrict_apply_univ]
+  rfl
 
 /-! ## Pointwise Convergence (proved) -/
 

--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
@@ -55,9 +55,9 @@ theorem thresholdIndicator_integrable_proved
     {X : ℕ → Ω → ℝ} (hX : ∀ i, Measurable (X i)) (x : ℝ) :
     Integrable (thresholdIndicator X x 0) μ := by
   apply Integrable.mono' (integrable_const (1 : ℝ))
-  · exact ((measurable_iic_indicator x).comp (hX 0)).aemeasurable
+  · exact ((measurable_iic_indicator x).comp (hX 0)).aestronglyMeasurable
   · filter_upwards with ω
-    simp only [thresholdIndicator, Set.indicator, norm_one]
+    simp only [thresholdIndicator, Set.indicator]
     split_ifs with h
     · norm_num
     · norm_num
@@ -94,13 +94,12 @@ theorem integral_thresholdIndicator_eq_cdf_proved
   -- Step 2: Convert to set integral on preimage
   rw [integral_indicator hms]
   -- Step 3: Evaluate constant integral: ∫ in s, 1 ∂μ = (μ s).toReal
-  rw [integral_const, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter,
-      smul_eq_mul, mul_one]
-  -- Step 4: Identify with trueCDF
-  simp only [trueCDF]
-  congr 1
-  ext ω
-  simp [Set.mem_preimage, Set.mem_Iic, Set.mem_setOf_eq]
+  -- Post Mathlib bump: integral_const produces `(μ.restrict s).real univ • c`
+  -- via the new `Measure.real` field, so unfold via measureReal_def + restrict_apply_univ.
+  rw [integral_const, smul_eq_mul, mul_one, measureReal_def,
+      Measure.restrict_apply_univ]
+  -- Step 4: Identify with trueCDF (preimage of Iic is defeq to set-builder form)
+  rfl
 
 -- ============================================================================
 -- Application: Pointwise Convergence Without Integration Axioms


### PR DESCRIPTION
## Summary

Repairs the Mathlib API drift in `LawsOfLargeNumbersOQ04.lean` and `LawsOfLargeNumbersOQ04OQ03.lean` flagged by researcher-6 (S5 PR #17692) and tracked in mechanic memory.

Two API shifts in recent Mathlib:

1. **`Integrable.mono'` now requires `AEStronglyMeasurable`** (not `AEMeasurable`). The old `.aemeasurable` call no longer unifies — use `.aestronglyMeasurable`.
2. **`integral_const` now produces `μ.real univ • c`** via the new `Measure.real` field. The old rewrite chain `Measure.restrict_apply MeasurableSet.univ` + `Set.univ_inter` no longer matches the goal shape.

## Changes

Both `integral_thresholdIndicator_eq_cdf` (in `LawsOfLargeNumbersOQ04.lean`) and `integral_thresholdIndicator_eq_cdf_proved` (in `LawsOfLargeNumbersOQ04OQ03.lean`):

- `.aemeasurable` → `.aestronglyMeasurable` on `Measurable.comp`
- Drop `norm_one` from `simp only` (no longer needed; `Set.indicator` unfolds without producing a `‖·‖`)
- Replace `Measure.restrict_apply MeasurableSet.univ, Set.univ_inter, smul_eq_mul, mul_one` with `smul_eq_mul, mul_one, measureReal_def, Measure.restrict_apply_univ`
- Drop trailing `simp only [trueCDF]; congr 1; ext ω; simp [...]` — closes by `rfl` since `X 0 ⁻¹' Set.Iic x` is defeq to `{ω | X 0 ω ≤ x}` (the body of `trueCDF`).

## Verification

`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03` succeeds (transitively builds `LawsOfLargeNumbersOQ04` too). All 3107 jobs completed; only pre-existing `unusedSectionVars` linter warnings remain.

## Impact

Unblocks build verification of all `-oq-04-oq-03` bracketing descendants (cited in mechanic memory). Restores `verified` status to the integration-axiom-elim chain (was `build pending` on origin/main since the Mathlib bump).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03` — succeeds
- [x] No new sorries or axioms introduced
- [x] Diff is minimal (13 insertions / 18 deletions across 2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)