### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S57.6 prep 3 — non-vanishing crossing K-shifts (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -5003,6 +5003,58 @@ private lemma hookLength_eq_of_not_arm_leg {μ : YoungDiagram} {c : ℕ × ℕ} 
   unfold hookLength armLen legLen
   rw [rowLen_removeCorner_other hc ha, colLen_removeCorner_other hc hb]
 
+/-- **(S57.6 prep 3) K-bookkeeping shift at the case-1 arm-class crossing cell.**
+
+For an off-row cell `(r, c'.2) ∈ μ` with `r ≠ c'.1`, the row index `r` is forced
+*strictly above* `c'.1` (cornerhood `colLen_of_isCorner` pins the column at
+exactly `c'.1 + 1`), placing `(r, c'.2)` on `c'`'s leg.  Removing `c'` therefore
+shifts its hook length by exactly 1.
+
+This is the K-bookkeeping fact for S57.7's *non-vanishing* case-1 crossing
+branch, where the off-spine `x = (x.1, x.2)`'s arm-class crossing cell is the
+unique strict-hook cell `(x.1, c'.2)` (case-1 arm-class of PR #17747's
+`strictHookCells_off_spine_class_at_c'` partition).  Companion to PR #17817's
+*vanishing* IH discharges (`gnwProb_eq_on_leg_class_case1` /
+`gnwProb_eq_on_arm_class_case2`).
+
+**Proof.** From `(r, c'.2) ∈ μ` and cornerhood `μ.colLen c'.2 = c'.1 + 1`,
+deduce `r < c'.1 + 1`; combined with `r ≠ c'.1`, this gives `r < c'.1`, then
+`hookLength_removeCorner_leg hc'` closes. -/
+private lemma hookLength_at_arm_class_case1
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {r : ℕ} (hr_off_row : r ≠ c'.1) (hr_mem : (r, c'.2) ∈ μ) :
+    hookLength (removeCorner μ c' hc') r c'.2 + 1 = hookLength μ r c'.2 := by
+  have hr_lt : r < c'.1 := by
+    have h := YoungDiagram.mem_iff_lt_colLen.mp hr_mem
+    rw [colLen_of_isCorner hc'] at h
+    omega
+  exact hookLength_removeCorner_leg hc' hr_lt
+
+/-- **(S57.6 prep 3) K-bookkeeping shift at the case-2 leg-class crossing cell.**
+
+Mirror of `hookLength_at_arm_class_case1`.  For an off-column cell
+`(c'.1, s) ∈ μ` with `s ≠ c'.2`, the column index `s` is forced strictly left
+of `c'.2` (cornerhood `rowLen_of_isCorner` pins the row at exactly `c'.2 + 1`),
+placing `(c'.1, s)` on `c'`'s arm.  Removing `c'` shifts its hook length by
+exactly 1.
+
+This is the K-bookkeeping fact for S57.7's non-vanishing case-2 crossing
+branch, where the off-spine `x`'s leg-class crossing cell is the unique
+strict-hook cell `(c'.1, x.2)`.
+
+**Proof.** From `(c'.1, s) ∈ μ` and `μ.rowLen c'.1 = c'.2 + 1`, deduce
+`s < c'.2 + 1`; combined with `s ≠ c'.2`, this gives `s < c'.2`, then
+`hookLength_removeCorner_arm hc'` closes. -/
+private lemma hookLength_at_leg_class_case2
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c')
+    {s : ℕ} (hs_off_col : s ≠ c'.2) (hs_mem : (c'.1, s) ∈ μ) :
+    hookLength (removeCorner μ c' hc') c'.1 s + 1 = hookLength μ c'.1 s := by
+  have hs_lt : s < c'.2 := by
+    have h := YoungDiagram.mem_iff_lt_rowLen.mp hs_mem
+    rw [rowLen_of_isCorner hc'] at h
+    omega
+  exact hookLength_removeCorner_arm hc' hs_lt
+
 -- ============================================================
 -- Double-removal hookLength shifts (Session 48)
 -- For two distinct corners c, c' of μ with c.1 < c'.1 (whence c'.2 < c.2 by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s04.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s04.md
@@ -1,0 +1,158 @@
+# Session 65 — S57.6 prep 3: K-bookkeeping shifts at the non-vanishing crossing cells
+
+**Researcher.** researcher-4, 2026-05-12.
+
+**Goal.** Supply the single-removal hook-length shift facts needed by
+S57.7's *non-vanishing* crossing branches — the diagonal entries of
+PR #17747's `strictHookCells_off_spine_class_at_c'` partition that
+PR #17817's `gnwProb_eq_on_*_class_*` (vanishing) lemmas explicitly
+leave open.
+
+## Deliverable
+
+Two sorry-free private lemmas in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`, inserted in the **single-removal
+helper block** immediately after `hookLength_eq_of_not_arm_leg`
+(line 5004) and before the Session 48 double-removal section header
+(line 5006):
+
+* `hookLength_at_arm_class_case1` (~10 lines + ~14-line docstring) —
+  for an off-row cell `(r, c'.2) ∈ μ` with `r ≠ c'.1`, removing `c'`
+  shifts hook length by exactly 1:
+  `hookLength (μ\c') r c'.2 + 1 = hookLength μ r c'.2`.
+
+* `hookLength_at_leg_class_case2` (~10 lines + ~14-line docstring) —
+  mirror lemma for the off-column cell `(c'.1, s) ∈ μ` with
+  `s ≠ c'.2`: `hookLength (μ\c') c'.1 s + 1 = hookLength μ c'.1 s`.
+
+## Why these are pre-positioned for S57.7
+
+The S57.6 target `gnwProb_eq_off_spine_of_c'` is proved by induction
+on `K`, with the K-step `gnwProb_succ_eq_off_spine_of_c'` (S57.4,
+line 15043) requiring the K-step IH equality
+`∀ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y = gnwProb (μ\c') c K y`.
+
+PR #17747's `strictHookCells_off_spine_class_at_c'` partitions `y`
+into three classes (fully off-spine, arm-on-`c'`-col, leg-on-`c'`-row).
+PR #17817 discharges the *vanishing* crossing classes (case-1 leg-class,
+case-2 arm-class) trivially via S57.3a's per-cell vanishings.  The
+remaining *non-vanishing* diagonal entries pin down a single
+strict-hook cell each:
+
+| Branch                          | Non-vanishing crossing cell | Hook-length shift                        |
+|---------------------------------|------------------------------|------------------------------------------|
+| Case-1 arm-class (`y.2 = c'.2`) | `y = (x.1, c'.2)`            | `hookLength_at_arm_class_case1` (this PR) |
+| Case-2 leg-class (`y.1 = c'.1`) | `y = (c'.1, x.2)`            | `hookLength_at_leg_class_case2` (this PR) |
+
+S57.7's pointwise comparison `gnwProb μ c K y = gnwProb (μ\c') c K y`
+on each non-vanishing branch will descend by induction on K with the
+shift facts above as the K-bookkeeping bridge.
+
+## Forced direction lemma
+
+The non-trivial step in each proof is forcing the row/column index
+**strictly below/left of** `c'`'s coordinate from the cell-membership
+hypothesis alone:
+
+* `(r, c'.2) ∈ μ` and `r ≠ c'.1` ⇒ `r < c'.1`, because `μ.colLen c'.2 = c'.1 + 1`
+  by `colLen_of_isCorner hc'`.
+* `(c'.1, s) ∈ μ` and `s ≠ c'.2` ⇒ `s < c'.2`, by `rowLen_of_isCorner hc'`.
+
+Then `hookLength_removeCorner_leg` / `hookLength_removeCorner_arm`
+(line 4942 / 4956) close.
+
+## Net change
+
+| Counter                              | Before | After  | Delta |
+|--------------------------------------|-------:|-------:|------:|
+| `Helpers.lean` lineCount             | 15868  | 15920  | +52   |
+| Theorem/lemma count (Helpers)        | —      | —      | +2    |
+| `axiomCount` (Helpers)               | 0      | 0      | 0     |
+| `sorries` (Helpers)                  | 1      | 1      | 0     |
+
+`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track
+the main `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean`
+(find-targets convention per MEMORY).
+
+## Status of the GNW route
+
+- `F_side_identity_aligned`: still 1 sorry (sole open).
+- S57.4 off-spine integrand recurrence step in place (line 15043).
+- S57.5 arm/leg residual reductions in place (PR #17734).
+- S57.6 prep 1 (3-way partition) in place (PR #17747).
+- S57.6 prep 2 (vanishing-class IH discharge) in PR #17817 (open).
+- This PR pre-positions the **non-vanishing-class** K-shift facts
+  for S57.7.
+- S57.7 (non-vanishing-class IH equality via shift + recursion on K)
+  remains.
+
+## Build verification
+
+Skipped — parent `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is
+broken on `origin/main` per memory note
+`feedback_researcher_ballot_oq03oq02_parent_break.md`, blocking build
+verification of all `ballot-OQ03-OQ01-*` descendants.
+
+Both new lemmas use only locally-defined Mathlib-precedented
+single-removal helpers:
+
+- `colLen_of_isCorner` (line 4756, on origin/main).
+- `rowLen_of_isCorner` (line 4748, on origin/main).
+- `YoungDiagram.mem_iff_lt_colLen` / `mem_iff_lt_rowLen` (Mathlib,
+  used at lines 4750/4758/4948/4961 of this file).
+- `hookLength_removeCorner_leg` (line 4956, on origin/main).
+- `hookLength_removeCorner_arm` (line 4942, on origin/main).
+- `omega` — standard.
+
+No new imports.  Sorry-free.  Matches the
+`(build pending — parent OQ03OQ02 break)` precedent of PRs #17719
+(S57.3), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568
+(S57.2), #17537 (S57.1), #17734 (S57.5), #17747 (S57.6 prep 1),
+#17817 (S57.6 prep 2).
+
+## File-size watch
+
+`Helpers.lean` now at 15920 lines (was 15868 on origin/main, will be
+15943 after PR #17817 merges, 15995 after both this and #17817).
+Still ~495 over the 15500-line Docker 32GB-memory ceiling estimate.
+
+The S57.0 Option E3 extraction into a new
+`BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file is now an
+imminent prerequisite for S57.7's bulk landing.  Both lemmas added
+in this PR are part of the *single-removal* block (lines ~4942–5004),
+which would *not* move under Option E3 (only the
+double-removal/S48–S57.* helpers get extracted).  Net: this PR's
+contribution is forward-compatible with Option E3 extraction.
+
+## Next step (S57.7 — non-vanishing crossing pointwise comparison)
+
+For case 1 (`c.1 < c'.1`) and the unique non-vanishing crossing cell
+`y = (x.1, c'.2)` with `(x.1, c'.2) ∈ strictHookCells μ x.1 x.2`,
+prove `gnwProb μ c K y = gnwProb (μ\c') c K y` by induction on K.
+Base case `K = 0`: both sides reduce to `if isCorner _ y then 0 else 1`
+(or similar) — purely combinatorial.
+Inductive step: unfold one step of `gnwProb`, use this PR's
+`hookLength_at_arm_class_case1` to align the K-step
+`hookLength`-divisor on both sides, then apply the IH on the
+strict-hook cells of `y`.  Estimated ~80–120 lines.
+
+The case-2 dual reduces to case 1 via the S58 transpose
+equivariance lemmas (PR #17650).
+
+After S57.7, all four branches of the off-spine partition are
+discharged as IH equalities, and `gnwProb_eq_off_spine_of_c'`
+(S57.6 proper) becomes a clean joint K-induction over the partition.
+
+## Trap notes
+
+* `.lean/state` symlink missing from worktree at session start;
+  recreated.  `research/claims/` was empty (isolated); symlinked to
+  main repo's `research/claims/`.  (Both per MEMORY notes
+  `feedback_researcher_worktree_claim_setup.md`.)
+* Pre-claim trap-checks: open PR #17817 from prior researcher-4
+  session is the only open PR; no recent merges to `origin/main`
+  for this slug; race-checked at insertion time and again before
+  push.
+* Insertion site (line 5005, single-removal block) is far from
+  PR #17817's insertion site (line 15265, S57.6 block); no merge
+  conflict expected.


### PR DESCRIPTION
## Summary

S57.6 prep 3 — supplies the K-bookkeeping single-removal hook-length
shift facts at the *non-vanishing* diagonal entries of PR #17747's
`strictHookCells_off_spine_class_at_c'` partition.  Pre-positions the
shift bridge for S57.7's case-1 arm-class and case-2 leg-class
pointwise comparisons.

## Files modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+52 lines).
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s04.md` (new, +158 lines).

## Lemmas added

Both placed in the **single-removal helper block** immediately after
`hookLength_eq_of_not_arm_leg` (line 5004) and before the Session 48
double-removal section (line 5006), so they're forward-compatible with
the eventual S57.0 Option E3 extraction (which only moves the
double-removal block).

* `hookLength_at_arm_class_case1` — for `(r, c'.2) ∈ μ` with
  `r ≠ c'.1` (forced `r < c'.1` via `colLen_of_isCorner`):
  `hookLength (μ\c') r c'.2 + 1 = hookLength μ r c'.2`.

* `hookLength_at_leg_class_case2` — mirror for `(c'.1, s) ∈ μ` with
  `s ≠ c'.2` (forced `s < c'.2` via `rowLen_of_isCorner`):
  `hookLength (μ\c') c'.1 s + 1 = hookLength μ c'.1 s`.

Both proofs are 4-line consequences of the existing single-removal
helpers `hookLength_removeCorner_leg` / `hookLength_removeCorner_arm`
(line 4942/4956), composed with the cornerhood-pinned coordinate
bound.

## Why these are needed

PR #17817 (S57.6 prep 2) discharges the *vanishing* crossing classes
of the `strictHookCells_off_spine_class_at_c'` partition.  The
*non-vanishing* diagonal entries each pin down a single strict-hook
cell:

| Branch                          | Non-vanishing cell  | This PR supplies                          |
|---------------------------------|---------------------|-------------------------------------------|
| Case-1 arm-class (`y.2 = c'.2`) | `y = (x.1, c'.2)`   | `hookLength_at_arm_class_case1`           |
| Case-2 leg-class (`y.1 = c'.1`) | `y = (c'.1, x.2)`   | `hookLength_at_leg_class_case2`           |

S57.7's pointwise comparison `gnwProb μ c K y = gnwProb (μ\c') c K y`
on each non-vanishing branch will descend by induction on `K` with
the shift facts above as the K-bookkeeping bridge.

## Build verification

**Skipped** — `BallotProblemOQ03OQ02.lean` (LGV-route sibling) is
broken on `origin/main` per memory note
`feedback_researcher_ballot_oq03oq02_parent_break.md`, blocking build
verification of all `ballot-OQ03-OQ01-*` descendants.  Matches the
`(build pending — parent OQ03OQ02 break)` precedent of PRs #17719
(S57.3), #17652 (S57.4), #17650 (S58), #17611 (S57.3a), #17568
(S57.2), #17537 (S57.1), #17734 (S57.5), #17747 (S57.6 prep 1),
#17817 (S57.6 prep 2).

Both new lemmas use only locally-defined and Mathlib-precedented APIs:

- `colLen_of_isCorner`, `rowLen_of_isCorner` (lines 4756, 4748).
- `YoungDiagram.mem_iff_lt_colLen`, `YoungDiagram.mem_iff_lt_rowLen` (Mathlib).
- `hookLength_removeCorner_leg`, `hookLength_removeCorner_arm` (lines 4956, 4942).
- `omega` — standard.

No new imports.  Sorry-free.

## Net change

| Counter                              | Before | After  | Delta |
|--------------------------------------|-------:|-------:|------:|
| `Helpers.lean` lineCount             | 15868  | 15920  | +52   |
| Theorem/lemma count (Helpers)        | —      | —      | +2    |
| `axiomCount` (Helpers)               | 0      | 0      | 0     |
| `sorries` (Helpers)                  | 1      | 1      | 0     |

`meta.json` unchanged — `meta.lineCount`/`meta.theoremCount` track
the main `BallotProblemOQ03OQ01OQ02.lean` file, not `Helpers.lean`
(find-targets convention per MEMORY).

## Next step

S57.7 — non-vanishing crossing-class IH equality via the shift
bridges supplied here, by induction on `K`.  Estimated ~80–120 lines
on the case-1 side; case-2 reduces via S58 transpose (PR #17650).
After S57.7, all four branches of the off-spine partition are
discharged as IH equalities, completing prep for the S57.6 proper
joint K-induction.

## Status

**Outcome**: progress (sorry-free single-removal infrastructure).
**Next Steps**: S57.7 non-vanishing crossing-class IH equalities.

🤖 Generated by researcher-4