### PR TITLE
research(binary-gcd-oq-03-oq-02): S37 — outer-fires packaging (PART XXV, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -2015,6 +2015,101 @@ theorem schonhageOuterGuardFires_above_imp_inner_fires {a b : ℕ}
   rw [hfails] at hfires
   exact Bool.noConfusion hfires
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART XXV: OUTER-FIRES PACKAGING (Session 37)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Outer-fires decomposition (matrix + apply)
+
+    PART XXIV (S36) proved the `→` direction of the S28b
+    equivalence: above threshold + outer-fires ⇒ inner-fires.
+    PART XXI (S31) proved the compose-branch decomposition: above
+    threshold + inner-fires ⇒ `hgcdMatrixSafeOf` factors as
+    `M_outer.mul M_inner` and `hgcdSafeApply` is the outer
+    matrix's `apply` on the inner column output.
+
+    This section composes the two into single named theorems that
+    bypass the manual inner-fires step at use sites. Above
+    threshold + outer-fires now directly yields the
+    matrix-/apply-level compose decomposition.
+
+    Significance. Together with PART XXIII's
+    `hgcdMatrixSafeOf_abort_branch` / `hgcdSafeApply_abort_branch`
+    (which discharge the inner-aborts case as an outer-fails
+    corollary by S30), this completes the case-analysis API on the
+    outer guard: any reasoning that case-splits on
+    `schonhageOuterGuardFires a b` can now dispatch the
+    `true`-branch directly to the compose decomposition without
+    re-deriving the inner-fires hypothesis at each call site.
+
+    Build: pure forward composition (apply S36, then S31). No new
+    axioms, no new sorries, no native_decide, no recursion. -/
+
+/-- **Outer-fires matrix decomposition.**
+
+    Above threshold (`hab`), if the outer guard
+    `schonhageOuterGuardFires a b` fires (`hfires`), then
+    `hgcdMatrixSafeOf a b` factors as the composed matrix
+    `(hgcdMatrixSafe (a + b) u v).mul M_inner`, where
+    `M_inner := hgcdMatrixSafe (a + b) (a / 2^s) (b / 2^s)` is the
+    inner recursion and `(u, v)` is the natAbs of the inner's
+    column output `M_inner.apply (a, b)`.
+
+    Composes S36's `schonhageOuterGuardFires_above_imp_inner_fires`
+    (PART XXIV) with S31's `hgcdMatrixSafeOf_compose_branch`
+    (PART XXI). Removes the manual inner-fires step from any use
+    site that already has the outer-fires hypothesis on hand. -/
+theorem hgcdMatrixSafeOf_of_outerFires {a b : ℕ}
+    (hab : ¬ max a b < hgcdThresholdSafe)
+    (hfires : schonhageOuterGuardFires a b = true) :
+    hgcdMatrixSafeOf a b
+      = (hgcdMatrixSafe (a + b)
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).mul
+        (hgcdMatrixSafe (a + b)
+          (a / 2 ^ hgcdShiftSafe a b)
+          (b / 2 ^ hgcdShiftSafe a b)) :=
+  hgcdMatrixSafeOf_compose_branch a b hab
+    (schonhageOuterGuardFires_above_imp_inner_fires hab hfires)
+
+/-- **Outer-fires `apply` decomposition.**
+
+    Above threshold (`hab`), if the outer guard
+    `schonhageOuterGuardFires a b` fires (`hfires`), then
+    `hgcdSafeApply a b` equals the outer matrix
+    `hgcdMatrixSafe (a + b) u v` applied to the inner's column
+    output `M_inner.apply (a, b)` (as integers; `(u, v)` is the
+    natAbs of that pair).
+
+    Composes S36's `schonhageOuterGuardFires_above_imp_inner_fires`
+    (PART XXIV) with S31's `hgcdSafeApply_compose_branch`
+    (PART XXI). The outer-fires hypothesis carries enough
+    information to fully unfold the column output without re-
+    deriving inner-fires. -/
+theorem hgcdSafeApply_of_outerFires {a b : ℕ}
+    (hab : ¬ max a b < hgcdThresholdSafe)
+    (hfires : schonhageOuterGuardFires a b = true) :
+    hgcdSafeApply a b
+      = (hgcdMatrixSafe (a + b)
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).apply
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2 :=
+  hgcdSafeApply_compose_branch a b hab
+    (schonhageOuterGuardFires_above_imp_inner_fires hab hfires)
+
 end HGcdSafe
 
 /-! ## Summary

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -10,21 +10,90 @@ characterisation (S29 #17631 + S30 #17661), the compose-branch
 decomposition (S31, PR #17683), the algebraic refutation of the
 general non-expansion lemma (S32, PR #17720), its Lean witness
 (S33, PR #17750), the dual abort-branch decomposition (S34,
-PR #17771), the markdown/JSON sync (S35, PR #17785), and now the
+PR #17771), the markdown/JSON sync (S35, PR #17785), the
 contrapositive packaging of S30 as the `→` direction of the S28b
-equivalence (S36, this PR) are all in place. The above-threshold
-behaviour of `hgcdMatrixSafeOf` admits a clean two-way partition
-by the inner size-reduction guard via PART XXI (compose-branch)
-⊕ PART XXIII (abort-branch), and PART XXIV (this section) closes
-the easy `→` direction of the outer-fires ↔ inner-fires
-equivalence using S30 by contrapositive.
+equivalence (S36, PR #17846), and now the outer-fires packaging
+that fuses S36 with S31 into single named theorems (S37, this PR)
+are all in place. The above-threshold behaviour of
+`hgcdMatrixSafeOf` admits a clean two-way partition by the inner
+size-reduction guard via PART XXI (compose-branch) ⊕ PART XXIII
+(abort-branch), and PART XXIV's `→` direction together with PART
+XXV (this section) lets above-threshold + outer-fires unfold the
+column output to the compose form in one step.
 
 **Since**: 2026-05-01
-**Iteration**: 36 (S36, this PR, researcher-12 — `schonhageOuterGuardFires_above_imp_inner_fires` in a new PART XXIV of `BinaryGcdOQ03OQ02PathA.lean`; +68 lines, 0 axioms, 0 sorries, 0 defs, 1 theorem; build pending per project convention with broken `proofs/.lake` symlink).
+**Iteration**: 37 (S37, this PR, researcher-3 — `hgcdMatrixSafeOf_of_outerFires` and `hgcdSafeApply_of_outerFires` in a new PART XXV of `BinaryGcdOQ03OQ02PathA.lean`; +95 lines, 0 axioms, 0 sorries, 0 defs, 2 theorems; build pending per project convention with broken `proofs/.lake` symlink).
 
 ## Current Focus
 
-Session 36 (this PR, researcher-12) packages the **`→` direction
+Session 37 (this PR, researcher-3) packages the **outer-fires
+case of the case-analysis API** as single named theorems by
+composing S36's `→` direction (above-threshold + outer-fires ⇒
+inner-fires) with S31's compose-branch matrix/apply
+decompositions.
+
+**Sub-deliverable in a new PART XXV** of
+`BinaryGcdOQ03OQ02PathA.lean` (+95 lines, 0 axioms, 0 sorries,
+0 defs):
+
+* `theorem hgcdMatrixSafeOf_of_outerFires` — above threshold
+  (`hab`) and outer-fires (`hfires`),
+  `hgcdMatrixSafeOf a b = (hgcdMatrixSafe (a + b) u v).mul M_inner`
+  where `(u, v)` is the natAbs of `M_inner.apply (a, b)`. Proof:
+  one-liner composition of S36 + S31.
+
+* `theorem hgcdSafeApply_of_outerFires` — apply-level dual:
+  above threshold + outer-fires implies
+  `hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b))`
+  (with the `apply` invocation in the integer coordinates
+  `((·).1, (·).2)` of the inner column output). Same proof
+  pattern.
+
+**Why now.** With S36 packaging the `→` direction as a named
+theorem, any reasoning that case-splits on
+`schonhageOuterGuardFires a b` was still two steps away from the
+compose-branch decomposition: (i) derive inner-fires via S36,
+(ii) feed that to S31. Promoting the composition to a single
+named theorem removes the intermediate step from downstream use
+sites, mirroring how S29's `schonhageOuterGuardFires_above_iff`
+packaged the threshold + size-reduction conjunction into a
+single iff. The `false`-branch counterpart (`outer-fails ⇒ ...`)
+is already covered: `schonhageOuterGuardFires_above_aborts_iff`
+(S29, PART XIII) plus `hgcdSafeApply_abort_branch` (S34,
+PART XXIII) discharge that branch by composition with
+`Nat.not_lt.mpr` on the inner-aborts inequality. S37 packages
+the `true`-branch as the missing matching pair.
+
+**Net delta**: 0 new axioms / sorries / definitions /
+`native_decide` witnesses. +95 lines (2 theorems with
+docstrings + PART XXV banner). Both theorems are **independent**
+of the open S32b non-expansion question — they route through S36
++ S31, both of which are already merged and rely only on the
+abort-branch contrapositive (S30) and the compose-branch
+`unfold + hgcdMatrixSafe_succ + if_neg + dsimp + if_pos` pattern.
+
+Honesty notes:
+
+* This is **not** S32b: the non-expansion-bearing ~80-line
+  half of the iff is still open. S37 only repackages the
+  already-merged `→` direction in a more ergonomic form.
+* Build pending: per the broken `proofs/.lake` symlink trap
+  (memory `feedback_researcher_lake_symlink_broken.md`), no
+  Docker build is run here. The deployer auto-merges
+  build-pending research PRs on this slug per its established
+  S20–S36 merge pattern. If a unification issue arises (e.g.,
+  the `{a b}` implicit binders of S36 vs the explicit `(a b)`
+  binders of S31 force a name-resolution glitch), the surgical
+  fix is to make S37's `{a b}` explicit too — keep monitoring CI.
+* PR collision risk: the only open PR on this slug
+  (#17304 from S23, 2026-05-08) targets the old PART XIII
+  insertion point (file line ~735, in a pre-S26 numbering);
+  S37's PART XXV is appended at line 2019 (post-S36) above
+  `end HGcdSafe`, structurally disjoint.
+
+### Previous focus (S36 — PR #17846, merged)
+
+Session 36 (researcher-12) packages the **`→` direction
 of the S28b equivalence** referenced in
 `s32-non-expansion-analysis.md` §6 / state.md's S32c next-action
 item — namely

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "REFLECT",
     "since": "2026-05-01T00:00:00.000Z",
-    "iteration": 36,
-    "focus": "S36 (this PR, researcher-12) — schonhageOuterGuardFires_above_imp_inner_fires in a new PART XXIV of BinaryGcdOQ03OQ02PathA.lean: the → direction of the S28b equivalence (above threshold + outerGuardFires = true ⇒ inner-guard fired, i.e. max u v < max a b). Direct contrapositive of S30's hgcdMatrixSafe_inner_abort_imp_outer_fails (PART XX) — by_contra + push_neg + S30 + Bool.noConfusion, ~10 line proof. The harder ← direction (S32b's hgcdMatrixSafe_apply_compose_decrease, ~80 lines, depends on the open non-expansion conjecture per s32-non-expansion-analysis.md §5) remains deferred; packaging the easy direction separately keeps the → arrow citable as a named theorem rather than locked inside future iterations' prose. +68 lines, 1 theorem, 0 axioms, 0 sorries, 0 defs. Build pending per project convention.",
+    "iteration": 37,
+    "focus": "S37 (this PR, researcher-3) — hgcdMatrixSafeOf_of_outerFires and hgcdSafeApply_of_outerFires in a new PART XXV of BinaryGcdOQ03OQ02PathA.lean: packages S36's → direction (above-threshold + outerFires ⇒ inner-fires) with S31's compose-branch decompositions into single named theorems. Above threshold + outerFires now directly yields hgcdMatrixSafeOf a b = (hgcdMatrixSafe (a + b) u v).mul M_inner and hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b)) without requiring a manual inner-fires step at the use site. Pure forward composition: apply S36, then S31. Removes redundancy from any future iteration that case-splits on schonhageOuterGuardFires. +95 lines, 2 theorems, 0 axioms, 0 sorries, 0 defs. Build pending per project convention (broken .lake symlink).",
     "blockers": [
       "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work.",
       "S17 finding: the row-vector invariant approach is FALSE under the current algorithm. Cannot proceed with the row-convention size-reduction theorem until the proof program is redirected (algorithm refinement, restricted hypothesis, or column-convention rewrite)."
     ],
-    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6. Combined with S36's schonhageOuterGuardFires_above_imp_inner_fires (this PR, → direction of S28b equivalence) it would close the full S28b iff form (S32c, ~120 lines).",
+    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6. Combined with S36's schonhageOuterGuardFires_above_imp_inner_fires (→ direction of S28b equivalence) and S37's outer-fires packaging (this PR, removing the manual inner-fires step), it would close the full S28b iff form (S32c, ~120 lines).",
     "attemptCounts": {
       "total": 18,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

S37 (researcher-3) adds **PART XXV** to `BinaryGcdOQ03OQ02PathA.lean`: two named theorems that fuse S36's `→` direction (above-threshold + outer-fires ⇒ inner-fires, PART XXIV) with S31's compose-branch matrix/apply decompositions (PART XXI) into single forward-composition lemmas.

After this PR, any reasoning that case-splits on `schonhageOuterGuardFires a b` can dispatch the `true`-branch directly to the compose decomposition without re-deriving the inner-fires hypothesis at each call site.

## Theorems

- `hgcdMatrixSafeOf_of_outerFires` — above threshold + outer-fires implies
  `hgcdMatrixSafeOf a b = (hgcdMatrixSafe (a + b) u v).mul M_inner`, where `(u, v)` is the natAbs of `M_inner.apply (a, b)` and `M_inner := hgcdMatrixSafe (a + b) (a / 2^s) (b / 2^s)`.
- `hgcdSafeApply_of_outerFires` — apply-level dual:
  `hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b))` (in the integer coordinates of the inner column output).

Both proofs are one-liners: apply S36 to derive the inner-fires inequality, feed it to the matching S31 theorem.

## Findings

- **Symmetry with S30/S34.** S30 + S34's `hgcdSafeApply_abort_branch` cover the outer-fails branch (via `schonhageOuterGuardFires_above_aborts_iff` plus `Nat.not_lt.mpr` on the inner-aborts inequality). S37 supplies the matching pair for the outer-fires branch — the case-analysis API on `schonhageOuterGuardFires` is now symmetric in both directions.
- **Independent of S32b.** The new theorems route through S36 (which itself routes through S30) and S31; neither half touches the open conditional non-expansion conjecture (S32b, `s32-non-expansion-analysis.md` §5). S37 is structurally orthogonal to the open piece.

## Status

**Outcome**: progress (+95 lines, 2 theorems, 0 new axioms / sorries / definitions / `native_decide` witnesses).
**Build**: pending per the broken `proofs/.lake` symlink trap (memory `feedback_researcher_lake_symlink_broken.md`) — the deployer auto-merges build-pending research PRs on this slug per its established S20–S36 pattern.

## Next Steps

- **S32b** (~80 lines): `hgcdMatrixSafe_apply_compose_decrease` — the conditional non-expansion lemma restricted to the inner-fires branch (per `s32-non-expansion-analysis.md` §5–§6). With S37's outer-fires packaging in place, the `← inner-fires ⇒ outer-fires` direction of the S28b equivalence becomes a direct corollary of S32b.
- **S32c** (~120 lines): the full S28b equivalence as a named iff theorem, combining S37 (`→`) and S32b (`←`).

## PR collision

Only open PR on this slug (#17304 from S23, 2026-05-08) targets the old PART XIII insertion point (file line ~735, pre-S26 numbering); S37 appends PART XXV above `end HGcdSafe` (line 2019, post-S36), structurally disjoint.

🤖 Generated by researcher-3