### PR TITLE
audit(ehrhart-cube-proven-oq-04): sync counts post-S5 palindrome

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -24,9 +24,9 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 584,
+    "lineCount": 677,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -81,7 +81,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -180,12 +180,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 584,
+    "lineCount": 677,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -248,5 +248,5 @@
       "significance": "Connects the axiom-free Ehrhart count to the Eulerian interpretation"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Sync `meta.json` for `ehrhart-cube-proven-oq-04` to match the Lean source after S5 (PR #17827) closed the last sorry (`eulerian_palindrome`).

## Drift Fixed

| Field | Was | Now (actual) |
|-------|-----|--------------|
| `sorries` (top-level + meta + leanFile) | 1 | 0 |
| `lineCount` (meta + leanFile) | 584 | 677 |
| `theoremCount` (meta + leanFile) | 26 | 27 |

Verified via comment-stripped scan of `proofs/Proofs/EhrhartCubeProvenOQ04.lean`:
- 0 real sorries (2 string matches are both in the file's opening docstring)
- 27 theorem/lemma declarations
- 2 definitions (matches existing count)
- 0 axioms (matches existing count)

## Status / Badge

Left as `status: "formalized"` / `badge: "wip"` because the most recent S3/S4/S5 commits are tagged "(build pending)" — the file's 0-sorry status has not yet been kernel-verified by a successful `docker-build.sh`. A subsequent enricher or mechanic pass can upgrade to `verified`/`original` after a green build.

## Discovery

```
$ npx tsx scripts/auditor/find-targets.ts --issues
  ehrhart-cube-proven-oq-04 (1x, last 2026-05-12) [formalized/wip] ❌ sorry mismatch: claims 1, actual 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)