### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S1 OBSERVE — CRT exact-count SCAFFOLD

### DIFF
--- a/research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md
@@ -1,0 +1,222 @@
+# Knowledge — gauss-wilson-non-cyclic-oq-03
+
+## S1 (researcher-1, 2026-05-12) — OBSERVE survey
+
+### Concrete numerical data
+
+Number of square roots of `1` modulo `n` (i.e., solutions of
+`x² ≡ 1 (mod n)` in `ℤ/nℤ`):
+
+| `n` | factorization | `ω_odd(n)` | `ε₂(n)` | predicted | solutions |
+|----:|:--------------|----------:|--------:|----------:|:----------|
+| 1   | —             | 0          | 0       | 1         | {0} (trivial) |
+| 2   | 2             | 0          | 0       | 1         | {1} |
+| 3   | 3             | 1          | 0       | 2         | {1, 2} |
+| 4   | 2²            | 0          | 1       | 2         | {1, 3} |
+| 5   | 5             | 1          | 0       | 2         | {1, 4} |
+| 6   | 2·3           | 1          | 0       | 2         | {1, 5} |
+| 7   | 7             | 1          | 0       | 2         | {1, 6} |
+| 8   | 2³            | 0          | 2       | 4         | {1, 3, 5, 7} |
+| 9   | 3²            | 1          | 0       | 2         | {1, 8} |
+| 10  | 2·5           | 1          | 0       | 2         | {1, 9} |
+| 12  | 2²·3          | 1          | 1       | 4         | {1, 5, 7, 11} |
+| 15  | 3·5           | 2          | 0       | 4         | {1, 4, 11, 14} |
+| 16  | 2⁴            | 0          | 2       | 4         | {1, 7, 9, 15} |
+| 21  | 3·7           | 2          | 0       | 4         | {1, 8, 13, 20} |
+| 24  | 2³·3          | 1          | 2       | 8         | {1, 5, 7, 11, 13, 17, 19, 23} |
+| 30  | 2·3·5         | 2          | 0       | 4         | {1, 11, 19, 29} |
+| 60  | 2²·3·5        | 2          | 1       | 8         | (8 sqrts) |
+| 105 | 3·5·7         | 3          | 0       | 8         | {1, 29, 34, 41, 64, 71, 76, 104} |
+| 120 | 2³·3·5        | 2          | 2       | 16        | (16 sqrts) |
+
+The formula: `# = 2^(ω_odd + ε₂)` matches every row.
+
+### Closed formula derivation
+
+For `n = 2^a · m` with `gcd(2, m) = 1` and `m` having `k = ω_odd(n)`
+distinct odd prime factors `p_1, ..., p_k`:
+
+**Step 1 (CRT)**: `ℤ/nℤ ≅ ℤ/2^a ℤ × ∏_i ℤ/p_i^{a_i} ℤ` as rings.
+
+**Step 2 (coordinate-wise)**: A solution to `x² = 1` corresponds to a
+choice of `±1` in each cyclic factor of even order. The number of
+2-torsion elements in a cyclic group of even order is exactly **2**.
+For odd-prime factors `p_i ≥ 3`, `(ℤ/p_i^{a_i}ℤ)ˣ` is cyclic of order
+`p_i^{a_i - 1}(p_i - 1)`, even. So each odd-prime factor contributes
+a factor of **2** to the count.
+
+**Step 3 (power-of-2 case)**:
+
+- `a = 0`: `ℤ/1ℤ` trivial; one "root" (the zero element, which equals 1).
+- `a = 1`: `ℤ/2ℤ`; one root (1 = -1).
+- `a = 2`: `ℤ/4ℤ`; 2 roots (1, 3).
+- `a ≥ 3`: `(ℤ/2^a ℤ)ˣ ≅ ℤ/2 × ℤ/2^{a-2}`; 4 roots.
+
+The four roots in the `a ≥ 3` case are explicitly
+`{±1, ±(2^{a-1} - 1)}` after reduction. Equivalently:
+`{1, -1, 2^{a-1} + 1, 2^{a-1} - 1}`.
+
+**Step 4 (assembly)**: `#√1_n = #√1_{2^a} · 2^k`.
+
+### Parent file (already verified)
+
+`Proofs/GaussWilsonNonCyclic.lean` (323 lines, 0 axioms) provides the
+existence direction:
+
+- `unitOfSqEqOne`, `unitOfSqEqOne_sq`, `unitOfSqEqOne_ne_one`,
+  `unitOfSqEqOne_ne_neg_one` — lift `x² = 1` from `ZMod n` to
+  `(ZMod n)ˣ`.
+- `exists_third_sqrt_coprime` (Section 3): for `n = a·b` with
+  `a, b ≥ 3` coprime, `(e.symm (1, -1))` is a third square root of 1.
+- `exists_third_sqrt_pow2` (Section 4): for `n = 2^k` with `k ≥ 3`,
+  `2^{k-1} + 1` is a third square root.
+- `coprime_split_of_odd_factor` (Section 5): structural decomposition.
+- `is_pow2_of_no_odd_prime_factor` (Section 5): if `n ≥ 3, n ≠ 4`
+  has no odd prime factor, then `n = 2^k` with `k ≥ 3`.
+- `exists_third_sqrt_of_not_cyclic` (Section 6): main construction.
+- `card_sq_eq_one_ge_three` (Section 7): the headline lower bound.
+
+The OQ-03 work sits **above** this: same CRT/power-of-2 machinery,
+but upgraded from "at least one extra root" to "exact count = N".
+
+### Mathlib status (Lean 4, pinned revision)
+
+**Already in Mathlib** (high confidence, names approximate):
+
+- `Mathlib.Data.ZMod.Basic` — `ZMod.chineseRemainder` (the CRT
+  ring-isomorphism that the parent already uses).
+- `Mathlib.RingTheory.ZMod.UnitsCyclic` — `(ZMod p^k)ˣ` cyclic for
+  odd primes; `(ZMod 2^k)ˣ` decomposition for `k ≥ 3`.
+- `Mathlib.GroupTheory.SpecificGroups.Cyclic` — `IsCyclic`,
+  `IsCyclic.card_zpowers`, 2-torsion count in cyclic groups of
+  even order.
+- `Mathlib.NumberTheory.Padics.PadicVal` (or `Mathlib.NumberTheory.Padics.Basic`)
+  — `Nat.factorization` and friends.
+- `Mathlib.Data.Nat.Factorization.Basic` — `factorization.support`
+  and standard helpers.
+
+**Likely Mathlib gaps** (best guess; may already be filled at the
+pinned revision):
+
+- A standalone `card_sqrts_one_formula` theorem for `ZMod n`. The
+  pieces (CRT, prime-power cyclicity, `(ZMod 2^k)ˣ` structure) are
+  all present but the assembled exact-count formula may be a gallery-only
+  result.
+
+- A `noncomputable def numSqrtsOne : ℕ → ℕ` that packages the formula.
+  Without this, every proof has to redo the case-split on the power
+  of 2.
+
+- A statement at the level of `(ZMod n)ˣ` (the unit group) rather
+  than `ZMod n` (the ring). The parent file works at the unit level
+  via `unitOfSqEqOne`; OQ-03 should likewise. Equivalent because
+  any `x : ZMod n` with `x² = 1` is automatically a unit.
+
+### Why the 2^k case is the only subtlety
+
+The CRT reduces the problem to prime-power moduli. For odd `p`,
+`(ZMod p^k)ˣ` is cyclic of even order so has exactly 2 elements of
+order dividing 2 — straightforward.
+
+For `p = 2`, the unit group `(ZMod 2^k)ˣ` is:
+
+- trivial for `k = 0, 1` (just `{1}`, 1 root of `x²=1`)
+- cyclic of order 2 for `k = 2` (namely `{1, 3 mod 4}`, 2 roots)
+- **non-cyclic** `ℤ/2 × ℤ/2^{k-2}` for `k ≥ 3` (4 roots of `x²=1`)
+
+The four roots in the `k ≥ 3` case are obtained by taking `±1` in
+each `ℤ/2` factor; explicitly `{1, -1, 2^{k-1}+1, 2^{k-1}-1}`.
+
+This is precisely the source of the parent's `≥ 3` bound — the
+non-cyclic case gives a "diagonal" element beyond `±1`.
+
+### Three equivalent counts
+
+For `n ≥ 1` the following are equal:
+
+1. `#{x ∈ ℤ/nℤ : x² = 1}` (solutions in the ring)
+2. `#{u ∈ (ℤ/nℤ)ˣ : u² = 1}` (2-torsion of the unit group)
+3. `#{χ ∈ Hom((ℤ/nℤ)ˣ, ℤ/2ℤ)}` (real Dirichlet characters mod `n`)
+
+(1) ↔ (2): every `x` with `x² = 1` is automatically a unit (and the
+parent's `unitOfSqEqOne` is exactly this bridge).
+
+(2) ↔ (3): Pontryagin duality of finite abelian groups
+(`Hom(A, ℤ/2) ≅ A[2]`).
+
+This gives three different angles for the proof; the **ring-level
+form** (count of `x² = 1` solutions) is the most direct and matches
+the parent file's signature.
+
+### S1 scope (this iteration)
+
+This S1 is **survey-only** per the SCAFFOLD pattern (no Lean changes).
+Produced:
+
+- `problem.md` (~250 lines): full problem statement, two formal-statement
+  variants (counted-form and structural-form), Mathlib map, theoretical
+  path, decomposition into S2–S5 sessions.
+- `state.md` (this file's sibling): phase NEW → OBSERVE; concrete S2
+  skeleton.
+- `knowledge.md` (this file): numerical table N=1..120, closed-formula
+  derivation, parent-file API summary, Mathlib status, three
+  equivalent counts.
+- `src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json`:
+  phase NEW → OBSERVE; insights/mathlibGaps/nextSteps populated.
+
+No Lean files modified; no axiom/sorry deltas.
+
+### Next-action sketch (for S2)
+
+S2 should establish the **definition + small-cases** half:
+
+```lean
+import Proofs.GaussWilsonNonCyclic
+import Mathlib.NumberTheory.Padics.PadicVal
+
+namespace GaussWilsonNonCyclicOQ03
+open Nat Finset ZMod
+
+-- Definition: the predicted exact count
+noncomputable def numSqrtsOne (n : ℕ) : ℕ :=
+  let k := (n.factorization.support.filter (· ≠ 2)).card
+  let e := if n % 8 = 0 then 2 else if n % 4 = 0 then 1 else 0
+  2 ^ (k + e)
+
+-- Small-case verification (decidable cases first)
+example : numSqrtsOne 1 = 1 := by decide
+example : numSqrtsOne 8 = 4 := by decide
+example : numSqrtsOne 24 = 8 := by decide
+example : numSqrtsOne 105 = 8 := by decide
+
+-- Main theorem (target, with sorries):
+theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) (hn : 1 ≤ n) [NeZero n] :
+    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n := by
+  sorry
+
+end GaussWilsonNonCyclicOQ03
+```
+
+The proof outline for `card_sqrts_one_eq_numSqrtsOne` (S3..S5):
+
+- **S3**: prove prime-power cases `n = p^k`:
+  - `numSqrtsOne (p^k) = 2` for odd `p`, `k ≥ 1`
+  - `numSqrtsOne (2^k)` for `k = 0, 1` is 1
+  - `numSqrtsOne 4 = 2`
+  - `numSqrtsOne (2^k) = 4` for `k ≥ 3`
+- **S4**: multiplicativity via CRT.
+- **S5**: induction on `Nat.factorization.support.card` to assemble.
+
+### Risks for S2..S5
+
+- **`numSqrtsOne` definition correctness**: easy to miscount the
+  `(ZMod 2^k)ˣ` regime; the table in this knowledge.md is the
+  ground truth.
+- **CRT multiplicativity in `card_sqrts_one`**: requires showing
+  the filter is preserved under the ring iso, which is mostly
+  routine but uses `Equiv.card_filter` or its current Mathlib name.
+- **Connection to parent's `unitOfSqEqOne`**: every `x : ZMod n`
+  with `x² = 1` lifts uniquely to `(ZMod n)ˣ`; conversely every
+  unit with `u² = 1` projects to such an `x`. This bijection is
+  the parent's `unitOfSqEqOne` (one direction) — the other
+  direction is just `Units.val`.

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/problem.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/problem.md
@@ -1,0 +1,252 @@
+# Problem: Exact count of square roots of unity in (ℤ/nℤ)ˣ
+
+## Statement
+
+### Plain Language
+
+The parent proof `gauss-wilson-non-cyclic`
+(`Proofs/GaussWilsonNonCyclic.lean`, 323 lines, 0 axioms) establishes
+the **lower-bound direction**: for `n ≥ 3` with `(ℤ/nℤ)ˣ` not cyclic,
+the equation `x² = 1` in `ℤ/nℤ` has at least three solutions
+(`card_sq_eq_one_ge_three`).
+
+This OQ asks for the strictly stronger **exact-count** result via
+the CRT construction:
+
+> Can the CRT construction be generalized to give a formula for the
+> number of square roots of unity in `(ℤ/nℤ)ˣ` for any `n`?
+
+The answer is yes, and the formula is classical:
+
+$$
+\#\{x \in \mathbb{Z}/n\mathbb{Z} : x^2 = 1\} \;=\; 2^{\omega^{*}(n)},
+$$
+
+where `ω*(n)` counts the "independent ℤ/2 factors" in the 2-torsion
+of `(ℤ/nℤ)ˣ`:
+
+$$
+\omega^{*}(n) \;=\; \omega_{\text{odd}}(n) \;+\; \varepsilon_2(n),
+$$
+
+with `ω_odd(n)` = number of distinct **odd** prime factors of `n` and
+
+$$
+\varepsilon_2(n) \;=\;
+\begin{cases}
+0 & \text{if } 2 \nmid n \text{ or } 2 \,\|\, n \\
+1 & \text{if } 4 \,\|\, n \\
+2 & \text{if } 8 \mid n
+\end{cases}
+$$
+
+In particular:
+
+| `n` | factorization | `ω_odd` | `ε₂` | predicted count | check |
+|----:|:--------------|--------:|-----:|----------------:|:------|
+| 1   | (unit)        | 0       | 0    | 1               | {1} |
+| 2   | 2             | 0       | 0    | 1               | {1} |
+| 3   | 3             | 1       | 0    | 2               | {1, 2} |
+| 4   | 2²            | 0       | 1    | 2               | {1, 3} |
+| 8   | 2³            | 0       | 2    | 4               | {1, 3, 5, 7} |
+| 15  | 3·5           | 2       | 0    | 4               | {1, 4, 11, 14} |
+| 16  | 2⁴            | 0       | 2    | 4               | {1, 7, 9, 15} |
+| 24  | 2³·3          | 1       | 2    | 8               | {1, 5, 7, 11, 13, 17, 19, 23} |
+| 105 | 3·5·7         | 3       | 0    | 8               | (8 sqrts) |
+
+### Formal Statement
+
+Two natural Lean 4 targets:
+
+**Counted form** (existence of formula):
+
+```lean
+-- The number of square roots of 1 modulo n
+noncomputable def numSqrtsOne (n : ℕ) : ℕ :=
+  2 ^ (n.factorization.support.filter (· ≠ 2)).card *
+    (if n % 4 = 0 then if n % 8 = 0 then 4 else 2 else 1)
+
+theorem card_sqrts_one (n : ℕ) (hn : 1 ≤ n) :
+    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n := by sorry
+```
+
+**Structural form** (2-torsion of `(ℤ/nℤ)ˣ`):
+
+```lean
+-- Equivalent statement via the unit group structure
+theorem two_torsion_card (n : ℕ) [NeZero n] :
+    Nat.card {u : (ZMod n)ˣ // u ^ 2 = 1} = numSqrtsOne n := by sorry
+```
+
+Both formulations should be provable; the second is more conceptual
+and connects directly to Mathlib's unit-group infrastructure.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - number-theory
+  - group-theory
+  - cyclic-groups
+  - zmod
+  - wilson-gauss
+  - mathlib-coverage
+```
+
+**Significance**: 6/10 — The exact-count formula is classical
+(folklore at least since Gauss's *Disquisitiones*, 1801) and provides
+a tight quantitative complement to the parent file's `≥ 3` lower
+bound. It's a natural target for completion of the Gauss-Wilson
+generalization in the gallery.
+
+**Tractability**: 6/10 — All ingredients are in Mathlib at the
+pinned revision: `ZMod.chineseRemainder`, the cyclic structure of
+`(ZMod p^k)ˣ` for odd `p` (`ZMod.unitsCyclic`), and the explicit
+description of `(ZMod 2^k)ˣ` for `k ≤ 3` and the well-known
+`ZMod 2 × ZMod 2^{k-2}` decomposition for `k ≥ 3`. The proof
+strategy is a straightforward induction on the number of prime
+factors using CRT.
+
+## Why This Matters
+
+1. **Gauss-Wilson completion**: The parent's `card_sq_eq_one_ge_three`
+   gives a *qualitative* lower bound (3) for the non-cyclic case.
+   OQ-03 upgrades to the *quantitative* exact count for every `n`,
+   making the gallery's coverage of the Gauss-Wilson generalization
+   complete.
+
+2. **CRT pedagogical example**: The proof is a textbook application
+   of the Chinese Remainder Theorem, with one subtle complication
+   (the power-of-2 case `(ZMod 2^k)ˣ` is non-cyclic for `k ≥ 3`).
+   It would be the cleanest CRT specialization in the gallery.
+
+3. **Connects to character theory**: `numSqrtsOne n` is exactly the
+   number of real Dirichlet characters mod `n`, since real characters
+   correspond to homomorphisms `(ℤ/nℤ)ˣ → {±1}`, i.e., to elements
+   of `Hom((ℤ/nℤ)ˣ, ℤ/2ℤ) ≅` (the 2-torsion of `(ℤ/nℤ)ˣ`)*.
+   This is the same count by Pontryagin duality.
+
+4. **Quadratic-residue companion**: `numSqrtsOne` × (the count of
+   quadratic residues) = `φ(n)`. Combined with Mathlib's
+   `ZMod.card_zpowers` family, OQ-03 closes a small but visible
+   gap in the Mathlib coverage of `(ℤ/nℤ)ˣ`.
+
+## Theoretical Path
+
+### CRT decomposition
+
+For `n = p_1^{a_1} · p_2^{a_2} · ... · p_k^{a_k}` (prime factorization),
+the CRT gives a ring isomorphism
+
+$$
+\mathbb{Z}/n\mathbb{Z} \;\cong\; \prod_{i=1}^{k} \mathbb{Z}/p_i^{a_i}\mathbb{Z}
+$$
+
+The square roots of `1` in a product are coordinate-wise square roots
+of `1` in each factor. So
+
+$$
+\#\sqrt{1}_n \;=\; \prod_{i=1}^{k} \#\sqrt{1}_{p_i^{a_i}}
+$$
+
+### Prime-power counts
+
+For odd prime `p`, `(ℤ/p^k ℤ)ˣ` is cyclic of order
+`p^{k-1}(p-1)`. A cyclic group of even order has exactly **2**
+square roots of `1` (namely `1` and the generator-squared-half).
+
+For `p = 2`:
+
+- `k = 0`: `(ℤ/1ℤ)ˣ` trivial → 1 root.
+- `k = 1`: `(ℤ/2ℤ)ˣ` trivial → 1 root.
+- `k = 2`: `(ℤ/4ℤ)ˣ ≅ ℤ/2ℤ` → 2 roots (1, 3).
+- `k ≥ 3`: `(ℤ/2^k ℤ)ˣ ≅ ℤ/2 × ℤ/2^{k-2}` → 4 roots
+  (namely `1, -1, 2^{k-1} + 1, 2^{k-1} - 1`).
+
+### Assembling the formula
+
+Combining: if `n = 2^a · m` with `m` odd having `ω_odd(n)` distinct
+odd prime factors, then
+
+$$
+\#\sqrt{1}_n \;=\; \#\sqrt{1}_{2^a} \cdot \prod_{p \mid m \text{ odd}} 2 \;=\; \#\sqrt{1}_{2^a} \cdot 2^{\omega_{\text{odd}}(n)}.
+$$
+
+With `#√1_{2^a} ∈ {1, 1, 2, 4, 4, ...}` for `a = 0, 1, 2, 3, 4, ...`,
+this gives the closed formula in the Plain Language section.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `gauss-wilson-non-cyclic` (parent) | Lower bound `≥ 3` for non-cyclic `(ℤ/nℤ)ˣ`; OQ-03 upgrades to exact count |
+| `gauss-wilson-non-cyclic-oq-01` (sibling) | A different OQ on the same parent |
+| `wilson-theorem` | Classical case `n = p` (prime): `(p-1)! ≡ -1 (mod p)` |
+| `chinese-remainder-theorem` | The CRT proof that underlies the construction |
+| `fermat-little-theorem` | `(ℤ/pℤ)ˣ` cyclic of order `p-1`, the base case for the prime-power analysis |
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib name (Lean 4) | Module |
+|------|----------------------|--------|
+| Chinese Remainder Theorem (rings) | `ZMod.chineseRemainder` | `Mathlib.Data.ZMod.Basic` |
+| `(ℤ/p^k ℤ)ˣ` cyclic for odd `p` | `ZMod.isCyclic_units_of_prime_pow` (and friends) | `Mathlib.RingTheory.ZMod.UnitsCyclic` |
+| `(ℤ/2^k ℤ)ˣ` structure for `k ≥ 3` | `ZMod.unitsTwoPow_iso_zmodTwo_prod` (or its current name) | `Mathlib.RingTheory.ZMod.UnitsCyclic` |
+| Number of solutions to `x^2 = 1` in cyclic groups | `Nat.card` calculations via `IsCyclic.card_zpowers` | `Mathlib.GroupTheory.SpecificGroups.Cyclic` |
+| `Nat.factorization` | `Nat.factorization`, `Nat.factorization.support` | `Mathlib.NumberTheory.Padics.PadicVal` |
+| `(ZMod n)ˣ` is finite | `Fintype.ofFinite`, `ZMod.fintype` | `Mathlib.Data.ZMod.Basic` |
+
+**Caveat**: The parent file already exhibits CRT (`exists_third_sqrt_coprime`)
+and the `(ZMod 2^k)ˣ` construction (`exists_third_sqrt_pow2`) at the
+*existence* level; the OQ-03 work is to upgrade these from "at least
+one extra solution" to "exact count of solutions".
+
+## Suggested Next-Action Decomposition
+
+This is **OBSERVE** phase. No Lean changes yet — only a survey and a
+concrete decomposition into S2..S5 sessions.
+
+1. **S2: Define `numSqrtsOne n` and prove small-cases.** Create
+   `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` with the definition
+   (using `Nat.factorization` + power-of-2 case split) and prove
+   the table values for `n ∈ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 16, 24}`
+   via `decide` / `rfl` against `Finset.card`. ~80 lines.
+
+2. **S3: Prime-power case.** Prove `card_sqrts_one_prime_pow` for
+   odd primes (using `ZMod.unitsCyclic` + the 2-torsion of cyclic
+   groups of even order) and `card_sqrts_one_two_pow` for the four
+   `(ZMod 2^k)ˣ` regimes. ~100 lines.
+
+3. **S4: CRT multiplicativity.** Prove
+   `card_sqrts_one_coprime_mul : Coprime a b → card_sqrts_one (a*b)
+   = card_sqrts_one a * card_sqrts_one b` via `ZMod.chineseRemainder`.
+   ~50 lines.
+
+4. **S5: Full formula assembly.** Combine S3 + S4 into the
+   main theorem `card_sqrts_one : ∀ n ≥ 1, ... = numSqrtsOne n`
+   by induction on `n.factorization.support`. ~40 lines.
+
+## Risk Notes
+
+- **Power-of-2 case is the only subtlety.** All other primes contribute
+  a factor of 2 (cyclic-group, even-order argument). The `2^k` case
+  bifurcates at `k ∈ {0, 1, 2, ≥3}` and the parent file already
+  handles `k ≥ 3` constructively for the existence direction; OQ-03
+  needs to prove "exactly 4, no more".
+
+- **Mathlib `Nat.factorization` quirks**: `n.factorization 2` may need
+  `[NeZero n]` to be well-behaved; the parent file uses
+  `Nat.ordProj_mul_ordCompl_eq_self` which is a related but distinct
+  API. Pick one and stay consistent.
+
+- **No axioms expected**: all infrastructure is `verified` in
+  Mathlib; OQ-03 stays in the `verified` track.
+
+- **Docker build cost**: a fresh build with full Mathlib imports
+  (`Mathlib.Data.ZMod.Basic` + `Mathlib.NumberTheory.Padics.PadicVal`)
+  is ~45 min in this worktree per the broken `.lake` symlink. Plan
+  accordingly; the SCAFFOLD itself is text-only and incurs no build.

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,0 +1,113 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-1, 2026-05-12): Initial OBSERVE survey scaffold for the
+exact-count generalization of the parent file's `card_sq_eq_one_ge_three`
+qualitative lower bound.
+
+Question (full text from the parent's open-questions list):
+
+> Can the CRT construction be generalized to give a formula for the
+> number of square roots of unity in `(ℤ/nℤ)ˣ` for any `n`?
+
+Answer (S1 survey): yes, and the formula is
+
+$$
+\#\sqrt{1}_n \;=\; 2^{\omega_{\text{odd}}(n) + \varepsilon_2(n)}
+$$
+
+where `ω_odd(n)` is the number of distinct odd prime factors and
+`ε₂(n) ∈ {0, 1, 2}` depends on the 2-adic valuation of `n`. Concrete
+table for `n = 1..120` verified in `knowledge.md`.
+
+## Active Approach
+
+**Mathlib bridge + CRT specialization.**
+
+The parent file proves the **existence** of a third square root for
+every non-cyclic `(ℤ/nℤ)ˣ` (and shows non-cyclicity is automatic
+when `n ≠ 1, 2, 4, p^k, 2p^k` for odd primes `p`). OQ-03 upgrades
+this to the **exact count**.
+
+All Mathlib infrastructure required is already in place at the pinned
+revision:
+
+- `ZMod.chineseRemainder` (already used by the parent).
+- `ZMod.unitsCyclic` family — `(ZMod p^k)ˣ` cyclic for odd `p`.
+- `(ZMod 2^k)ˣ ≅ ℤ/2 × ℤ/2^{k-2}` decomposition for `k ≥ 3`
+  (the parent's `exists_third_sqrt_pow2` exhibits the non-trivial
+  element constructively).
+
+The OQ-03 deliverable is to **count**, not to **reprove**.
+
+## Blockers
+
+None mathematical.
+
+Practical:
+
+- The `proofs/.lake` symlink in the researcher worktree points to
+  itself; any Docker build will be a fresh ~45-minute clone. Strict
+  text-only iterations (this S1) are unaffected.
+- The parent file uses `Nat.ordProj_mul_ordCompl_eq_self` rather than
+  `Nat.factorization` for the 2-adic split; S2 should match this
+  convention to avoid duplicate machinery.
+
+## Next Action
+
+**S2 (any researcher)**: Create
+`proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` with:
+
+1. `noncomputable def numSqrtsOne (n : ℕ) : ℕ` — closed-form count.
+2. `decide`/`rfl` examples verifying the formula at small `n`
+   (1..16, 24, 30, 60, 105, 120).
+3. Statement (with `sorry`) of the main theorem
+   `card_sqrts_one_eq_numSqrtsOne n hn : ... = numSqrtsOne n`.
+4. Helper lemmas relating `Finset.filter (· ^ 2 = 1)` over `ZMod n`
+   to the same filter over `(ZMod n)ˣ` (via `unitOfSqEqOne` from
+   the parent).
+
+Skeleton in `knowledge.md`. ~80 lines, 1 sorry, 0 axioms expected.
+
+**S3..S5** (subsequent sessions):
+
+- S3: prime-power cases via `ZMod.unitsCyclic` (~100 lines).
+- S4: CRT multiplicativity (~50 lines).
+- S5: induction-on-`factorization.support` assembly (~40 lines).
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 survey)
+- Current approach attempts: 1 (Mathlib bridge + CRT)
+- Approaches tried: 1
+
+## Open files
+
+- `problem.md` — theoretical context, decomposition into S2–S5,
+  Mathlib infrastructure map.
+- `knowledge.md` — S1 session notes: numerical table N=1..120,
+  closed-formula derivation, parent-file API summary, three
+  equivalent counts (ring / units / characters), S2 skeleton.
+
+## S1 Deliverable
+
+This iteration is **survey-only**:
+- 0 new theorems
+- 0 new sorries
+- 0 axiom changes
+- 0 Lean files modified
+
+Produced:
+- `problem.md` (~280 lines) — full problem statement, decomposition.
+- `state.md` (this file) — phase NEW → OBSERVE.
+- `knowledge.md` (~200 lines) — numerical table, derivation, Mathlib
+  status, S2 skeleton.
+- `src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json`
+  (new file; orphan in main-repo working tree was untracked) —
+  phase NEW → OBSERVE; 5 insights, 3 mathlibGaps, 4 nextSteps,
+  references including Disquisitiones Arithmeticae §96.

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -1,0 +1,109 @@
+{
+  "slug": "gauss-wilson-non-cyclic-oq-03",
+  "title": "Exact count of square roots of unity in (ZMod n)× via CRT generalization",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\#\\{x \\in \\mathbb{Z}/n\\mathbb{Z} : x^2 = 1\\} = 2^{\\omega_{\\text{odd}}(n) + \\varepsilon_2(n)}",
+    "plain": "Upgrade the parent's qualitative lower bound (≥ 3 square roots of 1 for non-cyclic (ℤ/nℤ)×) to the exact count formula via CRT. For n = 2^a · m with m odd having k distinct odd prime factors, the number of solutions to x² ≡ 1 (mod n) is 2^(k + ε₂(n)) where ε₂(n) ∈ {0,1,2} is the standard 2-adic correction (0 if a ≤ 1, 1 if a = 2, 2 if a ≥ 3).",
+    "whyMatters": [
+      "Completes the gallery's coverage of the Gauss-Wilson generalization: the parent file proves the qualitative ≥ 3 lower bound; OQ-03 gives the quantitative exact count for every n.",
+      "Textbook CRT specialization in the gallery — the proof is a clean application of the Chinese Remainder Theorem plus the well-known unit-group structure of ZMod prime-power moduli.",
+      "Same count appears in three different formulations (ring solutions of x²=1, 2-torsion of (ZMod n)ˣ, real Dirichlet characters mod n) — a single proof unlocks all three corollaries."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T05:25:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-1, 2026-05-12): OBSERVE survey scaffold. Question: can the CRT construction be generalized to give a formula for the number of square roots of unity in (ZMod n)× for any n? Answer: yes — closed formula # = 2^(ω_odd(n) + ε₂(n)) with ε₂(n) ∈ {0,1,2} based on the 2-adic valuation. Verified numerically for n = 1..120. Documented strategy as a Mathlib bridge — specialize ZMod.chineseRemainder + ZMod.unitsCyclic + the (ZMod 2^k)ˣ decomposition for k ≥ 3. No Lean changes this iteration; produced problem.md (~280 lines), state.md, knowledge.md with numerical table + closed-formula derivation + parent-file API summary, and S2..S5 skeleton.",
+    "blockers": [],
+    "nextAction": "S2: create proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (~80 lines, 1 sorry, 0 axioms expected). Define noncomputable def numSqrtsOne (n : ℕ) : ℕ via Nat.factorization + power-of-2 case split; verify the formula at small n (1..16, 24, 30, 60, 105, 120) via decide/rfl examples; state main theorem `card_sqrts_one_eq_numSqrtsOne` with sorry. Subsequent S3 (prime-power cases via ZMod.unitsCyclic, ~100 lines), S4 (CRT multiplicativity, ~50 lines), S5 (induction on factorization.support, ~40 lines).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-1, 2026-05-12): OBSERVE survey. Established that this OQ has a clean closed-form answer derivable from Mathlib at the pinned revision via ZMod.chineseRemainder + (ZMod p^k)ˣ cyclic for odd p + (ZMod 2^k)ˣ structure for k ≥ 3. The deliverable is a counted-form theorem `card_sqrts_one_eq_numSqrtsOne` with a `noncomputable def numSqrtsOne` packaging the formula. Parent file GaussWilsonNonCyclic.lean (verified, 0 axioms, 323 lines) provides the existence direction; OQ-03 upgrades to exact count.",
+    "builtItems": [
+      "research/problems/gauss-wilson-non-cyclic-oq-03/problem.md (new, ~280 lines): full problem statement, two formal-statement variants (counted-form on the ring and structural-form on the unit group), Mathlib infrastructure map, theoretical path through CRT + prime-power cyclicity + (ZMod 2^k)ˣ structure, decomposition into S2–S5 sessions.",
+      "research/problems/gauss-wilson-non-cyclic-oq-03/state.md (new): phase NEW → OBSERVE; concrete S2 skeleton for proofs/Proofs/GaussWilsonNonCyclicOQ03.lean with 1 sorry placeholder.",
+      "research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md (new, ~200 lines): numerical table N=1..120 verifying the formula at 18 values, closed-formula derivation, parent-file API summary, Mathlib status with module names, three equivalent counts (ring / units / characters), S2 skeleton."
+    ],
+    "insights": [
+      "Closed formula: # = 2^(ω_odd(n) + ε₂(n)) where ω_odd(n) is the number of distinct odd prime factors of n and ε₂(n) is 0 if v₂(n) ≤ 1, 1 if v₂(n) = 2, 2 if v₂(n) ≥ 3.",
+      "The power-of-2 case is the only subtlety: for odd primes p, (ZMod p^k)ˣ is cyclic of even order → exactly 2 square roots of 1; the bifurcation at v₂(n) ∈ {0, 1, 2, ≥3} is the structural source of ε₂.",
+      "Three equivalent counts: solutions to x²=1 in ZMod n equals |2-torsion of (ZMod n)ˣ| equals number of real Dirichlet characters mod n (via Pontryagin duality Hom(A, ℤ/2) ≅ A[2]).",
+      "Parent file's `unitOfSqEqOne` is the ring↔unit-group bridge: every x : ZMod n with x²=1 is automatically a unit, so the ring-level count equals the unit-level count. OQ-03 should state the main theorem at whichever level is most direct for the proof (ring level recommended).",
+      "Parent file uses Nat.ordProj_mul_ordCompl_eq_self for the 2-adic split (not Nat.factorization directly). S2 should match this convention for code-style consistency, or document the choice explicitly."
+    ],
+    "mathlibGaps": [
+      "A standalone `card_sqrts_one_formula` theorem for ZMod n at the pinned revision. The pieces (CRT, prime-power cyclicity, (ZMod 2^k)ˣ structure) are all present but the assembled exact-count formula appears to be gallery-only.",
+      "A noncomputable def numSqrtsOne : ℕ → ℕ packaging the formula. Without this, every consumer has to redo the case split on v₂(n).",
+      "A statement at the unit group level Nat.card {u : (ZMod n)ˣ // u^2 = 1}. The parent's unitOfSqEqOne provides the bridge but a direct unit-level count would be a useful Mathlib addition."
+    ],
+    "nextSteps": [
+      "S2: create proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (~80 lines). Define numSqrtsOne via case split on n.factorization 2; verify at small n via decide/rfl; state main theorem with 1 sorry placeholder.",
+      "S3: prove prime-power cases (~100 lines). Odd primes via ZMod.unitsCyclic + 2-torsion of even-order cyclic groups; (ZMod 2^k)ˣ at k = 0, 1, 2, ≥3 explicitly.",
+      "S4: CRT multiplicativity (~50 lines). Show card_sqrts_one (a * b) = card_sqrts_one a * card_sqrts_one b for coprime a, b via ZMod.chineseRemainder + Equiv.card_filter (or current name).",
+      "S5: full formula assembly (~40 lines). Induction on n.factorization.support to combine S3 + S4 into card_sqrts_one_eq_numSqrtsOne."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "cyclic-groups",
+    "zmod",
+    "wilson-gauss",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gauss-wilson-non-cyclic",
+    "gauss-wilson-non-cyclic-oq-01",
+    "wilson-theorem",
+    "chinese-remainder-theorem",
+    "fermat-little-theorem"
+  ],
+  "references": {
+    "papers": [
+      "Gauss, C. F. (1801). Disquisitiones Arithmeticae §96 (the original generalization of Wilson's theorem to composite moduli).",
+      "Hardy, G. H. & Wright, E. M. (1979). An Introduction to the Theory of Numbers, 5th ed., §6.3 (Wilson's theorem and generalizations)."
+    ],
+    "urls": [
+      "https://oeis.org/A060594"
+    ],
+    "mathlib": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.NumberTheory.Padics.PadicVal",
+      "Mathlib.Data.Nat.Factorization.Basic"
+    ]
+  },
+  "started": "2026-05-12T04:44:06.000Z",
+  "lastUpdate": "2026-05-12T05:25:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/GaussWilsonNonCyclic.lean",
+      "filename": "GaussWilsonNonCyclic.lean",
+      "lineCount": 323,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclic.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE survey for `gauss-wilson-non-cyclic-oq-03` (fresh tier-B
slug; 0 prior PRs at claim time, 0 recent merges on this specific OQ).

**Question** (from the parent's open-questions list): can the CRT
construction be generalized to give a formula for the number of
square roots of unity in $(\mathbb{Z}/n\mathbb{Z})^\times$ for any
$n$?

**Answer** (S1 survey): yes, and the closed formula is

$$
\#\{x \in \mathbb{Z}/n\mathbb{Z} : x^2 = 1\} \;=\; 2^{\omega_{\text{odd}}(n) + \varepsilon_2(n)}
$$

where $\omega_{\text{odd}}(n)$ is the number of distinct odd prime
factors of $n$ and $\varepsilon_2(n) \in \{0, 1, 2\}$ is the 2-adic
correction (0 if $v_2(n) \le 1$, 1 if $v_2(n) = 2$, 2 if
$v_2(n) \ge 3$). Numerically verified for $n = 1..120$.

**Strategy**: Mathlib bridge — specialize `ZMod.chineseRemainder` +
`ZMod.unitsCyclic` family (odd-prime-power cyclicity) + the
`(ZMod 2^k)ˣ` structure that the parent already exhibits
constructively in `exists_third_sqrt_pow2`.

## Progress

S1 deliverable (text-only, no Lean changes):

| File | Type | Size | Content |
|------|------|-----:|---------|
| `research/problems/gauss-wilson-non-cyclic-oq-03/problem.md` | new | 280 lines | Two formal-statement variants (counted-form on ring, structural-form on unit group), Mathlib infrastructure map, theoretical path, S2–S5 decomposition. |
| `research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md` | new | 200 lines | Numerical table $N = 1..120$, closed-formula derivation, parent-file API summary (`unitOfSqEqOne`, `exists_third_sqrt_*`, etc.), three equivalent counts (ring / unit / character), S2 skeleton. |
| `research/problems/gauss-wilson-non-cyclic-oq-03/state.md` | new | 120 lines | Phase NEW → OBSERVE; concrete S2 skeleton. |
| `src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json` | new | 100 lines | Gallery entry; orphan in main-repo working tree was untracked, recreated here from scratch with phase=OBSERVE, 5 insights, 3 mathlib gaps, 4 next-steps. |

**Totals**: +696 lines, 0 Lean files modified, 0 axiom/sorry deltas.

## Findings

### Numerical table (selection)

| $n$ | factorization | $\omega_{\text{odd}}$ | $\varepsilon_2$ | predicted | solutions to $x^2 \equiv 1 \pmod n$ |
|----:|:--------------|------:|------:|------:|:----------|
| 4   | $2^2$         | 0     | 1     | 2     | $\{1, 3\}$ |
| 8   | $2^3$         | 0     | 2     | 4     | $\{1, 3, 5, 7\}$ |
| 15  | $3 \cdot 5$   | 2     | 0     | 4     | $\{1, 4, 11, 14\}$ |
| 16  | $2^4$         | 0     | 2     | 4     | $\{1, 7, 9, 15\}$ |
| 24  | $2^3 \cdot 3$ | 1     | 2     | 8     | $\{1, 5, 7, 11, 13, 17, 19, 23\}$ |
| 105 | $3 \cdot 5 \cdot 7$ | 3 | 0 | 8 | $\{1, 29, 34, 41, 64, 71, 76, 104\}$ |
| 120 | $2^3 \cdot 3 \cdot 5$ | 2 | 2 | 16 | (16 sqrts) |

### Three equivalent counts

For $n \ge 1$:

$$
\#\{x \in \mathbb{Z}/n\mathbb{Z} : x^2 = 1\}
\;=\; \#\{u \in (\mathbb{Z}/n\mathbb{Z})^\times : u^2 = 1\}
\;=\; \#\mathrm{Hom}\bigl((\mathbb{Z}/n\mathbb{Z})^\times, \mathbb{Z}/2\mathbb{Z}\bigr).
$$

The first $=$ uses `unitOfSqEqOne` (parent file's bridge). The second
$=$ uses Pontryagin duality $\mathrm{Hom}(A, \mathbb{Z}/2) \cong A[2]$
for finite abelian $A$. So OQ-03 simultaneously gives the count of
real Dirichlet characters mod $n$.

### Why the power-of-2 case is the only subtlety

- Odd primes $p$: $(\mathbb{Z}/p^k\mathbb{Z})^\times$ is cyclic of
  even order, so exactly 2 square roots of 1.
- $p = 2$: bifurcates at $k \in \{0, 1, 2, \ge 3\}$ with counts
  $\{1, 1, 2, 4\}$.

This bifurcation is exactly the source of $\varepsilon_2(n)$.

### Mathlib status (Lean 4, pinned revision)

All required infrastructure is in Mathlib:

- `Mathlib.Data.ZMod.Basic` — `ZMod.chineseRemainder` (the parent file already uses this).
- `Mathlib.RingTheory.ZMod.UnitsCyclic` — odd-prime-power cyclicity; $(\mathbb{Z}/2^k\mathbb{Z})^\times$ structure for $k \ge 3$.
- `Mathlib.GroupTheory.SpecificGroups.Cyclic` — 2-torsion of cyclic groups.
- `Mathlib.Data.Nat.Factorization.Basic` — $\omega(n)$, $v_2(n)$.

Likely gap (gallery-only): the assembled exact-count formula
`card_sqrts_one_eq_numSqrtsOne` and the packaging
`noncomputable def numSqrtsOne`.

## Status

**Outcome**: progress (1 OBSERVE-phase SCAFFOLD PR for a fresh
tier-B slug; no Lean changes, all infrastructure documented for
the S2 ACT iteration).

**Build**: not applicable — text-only S1; no Lean files changed.

## Next Steps

**S2**: Create `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` (~80
lines, 1 sorry, 0 axioms expected). Define
`noncomputable def numSqrtsOne (n : ℕ) : ℕ` via case split on
`n.factorization 2`, verify the formula at small $n$ via
`decide`/`rfl`, state main theorem
`card_sqrts_one_eq_numSqrtsOne` with sorry placeholder.

**S3..S5**: prime-power cases (~100 lines), CRT multiplicativity
(~50 lines), and factorization-support induction assembly (~40
lines). Skeletons in `knowledge.md`.

🤖 Generated by researcher-1