### PR TITLE
audit(ehrhart-cube-proven-oq-04): sync meta.json after S5 palindrome merged

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "ehrhart-cube-proven-oq-04",
   "title": "Eulerian-Number Interpretation of the h*-Vector of the Unit Cube",
   "slug": "ehrhart-cube-proven-oq-04",
-  "description": "Open question from `ehrhart-cube-proven`: formalize the classical identity that the Ehrhart h*-vector of the unit d-cube is the sequence of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)). Equivalently, Worpitzky's identity: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d). Defines `eulerianNumber d k` via the standard recurrence, verifies values for d ≤ 4 by `rfl`, and proves the row-sum identity Σ A(d, k) = d! (S3) and the general Worpitzky identity (S4) by induction on d. The palindrome A(d, k) = A(d, d-1-k) remains as a single deferred theorem.",
+  "description": "Open question from `ehrhart-cube-proven`: formalize the classical identity that the Ehrhart h*-vector of the unit d-cube is the sequence of Eulerian numbers (A(d, 0), A(d, 1), …, A(d, d-1)). Equivalently, Worpitzky's identity: (n+1)^d = Σ_{k=0}^{d-1} A(d, k) · C(n+1+k, d). Defines `eulerianNumber d k` via the standard recurrence, verifies values for d ≤ 4 by `rfl`, and proves the row-sum identity Σ A(d, k) = d! (S3), the general Worpitzky identity (S4) by induction on d, and the palindrome A(d, k) = A(d, d-1-k) (S5) by algebraic induction on d. Source has 0 sorries; build verification pending.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eulerian_number",
@@ -24,15 +24,13 @@
       "seeker-selected"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 584,
+    "lineCount": 677,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
-    "openQuestions": [
-      "Prove `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for k < d, by exhibiting the involution σ ↦ σ ∘ reverse on `Equiv.Perm (Fin d)` which bijects k-descent permutations with (d-1-k)-descent permutations."
-    ],
+    "openQuestions": [],
     "originalContributions": [
       "Definition `eulerianNumber d k` via the standard recurrence (matches OEIS A008292)",
       "Concrete Eulerian-number values for d ≤ 4 proved by `rfl` (closed-form base cases)",
@@ -45,6 +43,8 @@
       "Row-sum identity `eulerian_row_sum_factorial`: Σ_{k<d} A(d, k) = d! for d ≥ 1 (S3, proven by induction on d via sum reorganisation and `A(d, d) = 0`)",
       "Algebraic step `worpitzky_step`: (k+1)·C(n+1+k, d+1) + (d-k)·C(n+2+k, d+1) = (n+1)·C(n+1+k, d), via Pascal and `Nat.choose_succ_right_eq` (S4)",
       "Main theorem `worpitzky_identity_cube`: (n+1)^d = Σ_{k<d} A(d, k) · C(n+1+k, d) for all d ≥ 1 and n ≥ 0, proven by induction on d using `worpitzky_step` and the Eulerian recurrence (S4)",
+      "Recurrence rewrite lemma `eulerianNumber_recurrence`: A(d+1, k+1) = (k+2)·A(d, k+1) + (d-k)·A(d, k) (S5 helper)",
+      "Palindromic symmetry `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for 0 < d, k < d, proven by algebraic induction on d via the recurrence and boundary value A(d+1, d) = 1 (S5)",
       "Coefficient identity `cube_h_star_eulerian`: (cubeHStarPoly d).coeff k = A(d, k) for 0 ≤ k < d",
       "Lattice-count form `cube_lattice_count_eulerian`: |(Fin d → Fin (n+1))| = Σ_{k<d} A(d, k) · C(n+1+k, d), bridging the Fin-tuple count to the Eulerian sum"
     ],
@@ -81,7 +81,7 @@
         "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 2,
     "relatedProblems": [
       {
@@ -125,7 +125,7 @@
       "title": "Section II: Row-Sum Identity",
       "startLine": 96,
       "endLine": 121,
-      "summary": "States `eulerian_row_sum_factorial`: Σ_{k < d} A(d, k) = d!. Deferred (sorry). Concrete row-sum checks at d ≤ 4 proved by `rfl`.",
+      "summary": "Proves `eulerian_row_sum_factorial`: Σ_{k < d} A(d, k) = d! (S3, by induction on d). Concrete row-sum checks at d ≤ 4 proved by `rfl`.",
       "mathContext": "$\\sum_{k=0}^{d-1} A(d, k) = d!$ — descent-count partition of $S_d$."
     },
     {
@@ -133,7 +133,7 @@
       "title": "Section III: Palindromic Symmetry",
       "startLine": 122,
       "endLine": 144,
-      "summary": "States `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for k < d. Deferred (sorry). Concrete checks at (3, 0)↔(3, 2), (4, 0)↔(4, 3), (4, 1)↔(4, 2) by `rfl`.",
+      "summary": "Proves `eulerian_palindrome`: A(d, k) = A(d, d-1-k) for k < d (S5, by algebraic induction on d via the recurrence — descent-reversal involution not required). Concrete checks at (3, 0)↔(3, 2), (4, 0)↔(4, 3), (4, 1)↔(4, 2) by `rfl`.",
       "mathContext": "$A(d, k) = A(d, d-1-k)$ — descent-reversal involution on $S_d$."
     },
     {
@@ -141,7 +141,7 @@
       "title": "Section IV: Worpitzky's Identity (Main Theorem)",
       "startLine": 145,
       "endLine": 224,
-      "summary": "States the main theorem `worpitzky_identity_cube`: (n+1)^d = Σ_{k < d} A(d, k) · C(n+1+k, d), sorry'd. Proves the d = 1 and d = 2 cases explicitly (no sorry) and verifies seven concrete (d, n) instances by `decide`.",
+      "summary": "Proves the main theorem `worpitzky_identity_cube`: (n+1)^d = Σ_{k < d} A(d, k) · C(n+1+k, d) (S4, by induction on d using `worpitzky_step` and the Eulerian recurrence). The d = 1 and d = 2 cases are proved explicitly and seven concrete (d, n) instances are verified by `decide`.",
       "mathContext": "$(n+1)^d = \\sum_{k=0}^{d-1} A(d, k) \\binom{n+1+k}{d}$ — the Worpitzky identity, equivalent statement of the Eulerian-number h*-vector."
     },
     {
@@ -149,7 +149,7 @@
       "title": "Section V: h*-Polynomial of the Cube",
       "startLine": 225,
       "endLine": 250,
-      "summary": "Defines `cubeHStarPoly d : Polynomial ℕ` as Σ_{k < d} A(d, k) · X^k. States `cube_h_star_eulerian`: the k-th coefficient equals A(d, k), sorry'd.",
+      "summary": "Defines `cubeHStarPoly d : Polynomial ℕ` as Σ_{k < d} A(d, k) · X^k. Proves `cube_h_star_eulerian`: the k-th coefficient equals A(d, k) (S2, definitional reduction).",
       "mathContext": "$h^*([0,1]^d, t) = \\sum_{k=0}^{d-1} A(d, k) t^k$ — the Eulerian polynomial of degree d."
     },
     {
@@ -157,16 +157,14 @@
       "title": "Section VI: Coherence with EhrhartCubeProven",
       "startLine": 280,
       "endLine": 300,
-      "summary": "Combines Worpitzky with `EhrhartCubeProven.cube_lattice_count` to state `cube_lattice_count_eulerian`: |n·[0,1]^d ∩ ℤ^d| = Σ A(d, k) C(n+1+k, d). Deferred (sorry).",
+      "summary": "Combines Worpitzky with `EhrhartCubeProven.cube_lattice_count` to prove `cube_lattice_count_eulerian`: |n·[0,1]^d ∩ ℤ^d| = Σ A(d, k) C(n+1+k, d) (S2).",
       "mathContext": "Bridging corollary: cube lattice count = Eulerian h*-vector convolution against binomials."
     }
   ],
   "conclusion": {
-    "summary": "S1 SCAFFOLD for the Eulerian-number interpretation of the unit d-cube's Ehrhart h*-vector. The file establishes:\n\n1. A canonical Lean definition of Eulerian numbers via the standard recurrence (matching OEIS A008292).\n2. Concrete values A(d, k) for d ≤ 4 provable by `rfl`, serving as both unit tests and a `decide`-style lookup for downstream proofs.\n3. The main theorem `worpitzky_identity_cube` stated, with five concrete instances verified by `decide` and the d = 1, d = 2 cases proved explicitly.\n4. Companion theorems (row-sum, palindrome, h*-coefficient extraction, generating-function form) stated and deferred.\n\nAll five `sorry`s are *cleanly localized* in unproven statement-level theorems; no implementation gaps in the definitions or concrete computations. Status: `formalized`.",
-    "implications": "**Closing Worpitzky in S2+** would give a complete axiom-free interpretation of the cube's Ehrhart h*-vector as the Eulerian polynomial. This is one of the first explicit cases where Stanley's general theorem on h*-vector non-negativity (Stanley 1980) admits a combinatorial closed-form interpretation, beyond the simplex (where $h^* = (1, 0, \\ldots, 0)$) and the cross-polytope (where $h^*$ is the Pascal row $\\binom{d}{k}$).\n\n**Connecting to permutation combinatorics**: a full proof of `eulerian_row_sum_factorial` requires defining permutation descents — currently absent from Mathlib (see PR searches above). This would lay groundwork for a broader Mathlib contribution on Eulerian numbers, descents, and permutation statistics, complementing the existing `Equiv.Perm` and `SymmetricGroup` infrastructure.\n\n**Coherence with `EhrhartCubeProven`**: the corollary `cube_lattice_count_eulerian` directly bridges the axiom-free cube counting result with the deferred Worpitzky identity, establishing the full Eulerian h*-vector interpretation as soon as Worpitzky is closed.",
+    "summary": "S1–S5 complete formalization of the Eulerian-number interpretation of the unit d-cube's Ehrhart h*-vector. The file establishes:\n\n1. A canonical Lean definition of Eulerian numbers via the standard recurrence (matching OEIS A008292).\n2. Concrete values A(d, k) for d ≤ 4 by `rfl`, serving as both unit tests and a `decide`-style lookup for downstream proofs.\n3. The main theorem `worpitzky_identity_cube` proved by induction on d (S4) using the helper lemma `worpitzky_step`, with seven concrete instances independently verified by `decide`.\n4. The companion theorems all proved: `eulerian_row_sum_factorial` (S3), `eulerian_palindrome` (S5), `cube_h_star_eulerian` (S2), `cube_lattice_count_eulerian` (S2).\n\nSource has 0 sorries and 0 axiom declarations. Build verification remains pending; once verified, status should be promoted to `verified`.",
+    "implications": "**Closing Worpitzky in S2+** would give a complete axiom-free interpretation of the cube's Ehrhart h*-vector as the Eulerian polynomial. This is one of the first explicit cases where Stanley's general theorem on h*-vector non-negativity (Stanley 1980) admits a combinatorial closed-form interpretation, beyond the simplex (where $h^* = (1, 0, \\ldots, 0)$) and the cross-polytope (where $h^*$ is the Pascal row $\\binom{d}{k}$).\n\n**Connecting to permutation combinatorics**: a full proof of `eulerian_row_sum_factorial` requires defining permutation descents — currently absent from Mathlib (see PR searches above). This would lay groundwork for a broader Mathlib contribution on Eulerian numbers, descents, and permutation statistics, complementing the existing `Equiv.Perm` and `SymmetricGroup` infrastructure.\n\n**Coherence with `EhrhartCubeProven`**: the corollary `cube_lattice_count_eulerian` directly bridges the axiom-free cube counting result with the Worpitzky identity, establishing the full Eulerian h*-vector interpretation of the unit cube.",
     "openQuestions": [
-      "Can `worpitzky_identity_cube` be proved by induction on `d` using only `Nat.choose_succ_succ` (Pascal) and `Finset.sum_range_succ`? Expected length: ~80–120 lines of Lean.",
-      "Can the row-sum identity be proved before Worpitzky by an independent inductive argument (avoiding the permutation-descent definition)?",
       "Can `eulerianNumber` be related to Mathlib's `Equiv.Perm` infrastructure via an explicit bijection between descent-count level sets and `Finset.filter` slices of `Finset.univ : Finset (Equiv.Perm (Fin d))`?",
       "Can the generating-function form be stated and proved using Mathlib's `PowerSeries.invOfUnit`? What is the cleanest way to express `1/(1-X)^{d+1}` as a `PowerSeries`?",
       "Does the Eulerian-number Worpitzky identity admit a `decide`-able tactic for fixed `d`? (Already the case here for `d ≤ 4` at the value level; the question is whether the *general* identity admits a kernel-level reduction.)"
@@ -180,12 +178,12 @@
       "Finset"
     ],
     "namespace": "EhrhartCubeProvenOQ04",
-    "lineCount": 584,
+    "lineCount": 677,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/EhrhartCubeProvenOQ04.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -216,37 +214,37 @@
       "name": "worpitzky_identity_cube",
       "type": "core",
       "statement": "∀ d ≥ 1, ∀ n, (n + 1)^d = ∑ k ∈ range d, eulerianNumber d k * Nat.choose (n + 1 + k) d",
-      "description": "Worpitzky's identity for the cube (main theorem, deferred). Closing this gives the Eulerian h*-vector interpretation.",
+      "description": "Worpitzky's identity for the cube (main theorem, S4-proved by induction on d). Gives the Eulerian h*-vector interpretation.",
       "significance": "Main result — connects the cube Ehrhart polynomial to the Eulerian polynomial"
     },
     {
       "name": "eulerian_row_sum_factorial",
       "type": "structural",
       "statement": "∀ d ≥ 1, ∑ k ∈ range d, eulerianNumber d k = d.factorial",
-      "description": "Row-sum: the Eulerian numbers on row d partition d! permutations (deferred).",
+      "description": "Row-sum: the Eulerian numbers on row d partition d! permutations (S3-proved by induction on d via sum reorganisation and `A(d, d) = 0`).",
       "significance": "Consistency check — Eulerian numbers count permutations"
     },
     {
       "name": "eulerian_palindrome",
       "type": "structural",
       "statement": "∀ d k, 0 < d → k < d → eulerianNumber d k = eulerianNumber d (d - 1 - k)",
-      "description": "Palindromic symmetry from the descent-reversal involution (deferred).",
+      "description": "Palindromic symmetry (S5-proved by algebraic induction on d via the recurrence; descent-reversal involution not required).",
       "significance": "Converts Worpitzky to standard h*-vector form via C(n+d-k, d) basis"
     },
     {
       "name": "cube_h_star_eulerian",
       "type": "corollary",
       "statement": "∀ d k, 0 < d → k < d → (cubeHStarPoly d).coeff k = eulerianNumber d k",
-      "description": "The k-th coefficient of the cube's h*-polynomial is the k-th Eulerian number (deferred).",
+      "description": "The k-th coefficient of the cube's h*-polynomial is the k-th Eulerian number (S2-proved by definitional reduction).",
       "significance": "Direct h*-vector reading of the Eulerian polynomial"
     },
     {
       "name": "cube_lattice_count_eulerian",
       "type": "corollary",
       "statement": "∀ d ≥ 1, ∀ n, Fintype.card (Fin d → Fin (n + 1)) = ∑ k ∈ range d, eulerianNumber d k * Nat.choose (n + 1 + k) d",
-      "description": "Bridging corollary: the EhrhartCubeProven lattice count equals the Eulerian h*-vector convolution against binomials (deferred).",
+      "description": "Bridging corollary: the EhrhartCubeProven lattice count equals the Eulerian h*-vector convolution against binomials (S2-proved).",
       "significance": "Connects the axiom-free Ehrhart count to the Eulerian interpretation"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

After PR #17827 (S5 PALINDROME — close `eulerian_palindrome` by induction on d) merged, meta.json was not re-synced. The Lean source now has 0 sorries and 0 axioms, but meta.json still claimed 1 sorry and described palindrome as deferred.

## Drift (verified against `proofs/Proofs/EhrhartCubeProvenOQ04.lean` at origin/main)

Numeric counts:
- `sorries`: 1 → 0 (top-level, meta, leanFile)
- `lineCount`: 584 → 677 (meta, leanFile)
- `theoremCount`: 26 → 27 (meta, leanFile)

Narrative cleanups:
- `description`: dropped "remains as a single deferred theorem"
- `meta.openQuestions`: emptied (palindrome solved in S5)
- `conclusion.openQuestions`: dropped 2 answered questions (S3 row-sum, S4 worpitzky); kept 3 genuinely open
- `conclusion.summary`: was "S1 SCAFFOLD … All five sorries cleanly localized"; now reflects S1–S5 complete
- 5 `mainTheorems[].description` had "(deferred)" → updated to cite proving session and method
- 5 section summaries had "Deferred (sorry)" / "sorry'd" → proved
- `originalContributions`: added `eulerianNumber_recurrence` (S5 helper) and `eulerian_palindrome` (S5)

## Conservatism

Status/badge unchanged (`formalized`/`wip`) pending build verification — the S5 PR was merged "(build pending)". Per CLAUDE.md axiom integrity policy, once build verifies, status should be promoted to `verified` (0 sorries + 0 axioms + 0 structure-encoded assumptions = Tier A).

## Test plan
- [x] JSON parses (`python3 -c "json.load(...)"`)
- [x] Counts cross-checked against actual Lean file (`grep` for `theorem|lemma`, `sorry`, `axiom`; `wc -l`)
- [x] No `status`/`badge` change (build still pending)
- [ ] CI build passes (Mathlib drift exposed only on full kernel check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)