### PR TITLE
Enrich infinitude-primes-4k3-oq-03: cyclotomic generalization + Murty/Selberg context

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
@@ -175,6 +175,32 @@
     ]
   },
   {
+    "id": "cyclotomic-pattern",
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": {
+      "startLine": 24,
+      "endLine": 33
+    },
+    "type": "insight",
+    "title": "Why x² + 1 Works: The Cyclotomic Pattern",
+    "content": "The construction $N = (2(n+1)!)^2 + 1$ in the 1 (mod 4) case is not arbitrary — it instantiates a general pattern from cyclotomic polynomials. The polynomial $f(x) = x^2 + 1$ is exactly the **4th cyclotomic polynomial** $\\Phi_4(x)$. The key fact: if a prime $p \\nmid n$ divides $\\Phi_n(k)$ for some integer $k$, then the order of $k$ mod $p$ is exactly $n$, so by Lagrange's theorem $n \\mid p - 1$, i.e. $p \\equiv 1 \\pmod n$. For $n = 4$: primes dividing $k^2 + 1$ have $k$ of order 4 mod $p$, hence $4 \\mid p - 1$ — exactly Euler's criterion. This generalizes to every class $\\equiv 1 \\pmod n$ (Bang 1886, Wendt 1895): take $f(x) = \\Phi_n(x)$, apply Euclid's argument with the factorial-multiplied input. The classes $\\not\\equiv 1 \\pmod n$ are genuinely harder — for $n = 4$ the second class $\\equiv 3$ admits an ad hoc product argument (its parent file `infinitude-primes-4k3`), but for $n = 5$ only $a = 1, 4$ have Euclid-style proofs (Murty's criterion: $a^2 \\equiv 1 \\pmod n$).",
+    "mathContext": "$\\Phi_n(x)$ = $n$-th cyclotomic polynomial = $\\prod_{\\gcd(k,n)=1, 1 \\leq k \\leq n} (x - e^{2\\pi i k/n})$. For $n = 4$: $\\Phi_4(x) = x^2 + 1$. **Key lemma** (Wendt): $p \\nmid n$ and $p \\mid \\Phi_n(k)$ for some $k$ $\\Rightarrow$ $\\mathrm{ord}_p(k) = n$ $\\Rightarrow$ $n \\mid p - 1$ $\\Rightarrow$ $p \\equiv 1 \\pmod n$. **Murty's criterion** for which $(a, d)$ admit Euclid-style proofs: $a^2 \\equiv 1 \\pmod d$. For $d = 4$: $a \\in \\{1, 3\\}$ (both work). For $d = 5$: $a \\in \\{1, 4\\}$ only.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclotomic polynomial",
+      "order of element mod p",
+      "Lagrange's theorem",
+      "Bang–Zsygmondy theorem",
+      "Murty's criterion for elementary AP infinitude",
+      "Wendt 1895"
+    ],
+    "prerequisites": [
+      "cyclotomic polynomials Φ_n",
+      "order of element in (ℤ/pℤ)×",
+      "Lagrange's theorem on subgroup orders"
+    ]
+  },
+  {
     "id": "set-infinite-api",
     "proofId": "infinitude-primes-4k3-oq-03",
     "range": {

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -56,7 +56,8 @@
       "**No Dirichlet L-functions needed**: The special cases a = 1, 3 mod 4 are the only arithmetic progressions {a + 4k} with gcd(a,4) = 1 that admit elementary proofs of infinitude.",
       "**Mathlib's SumTwoSquares is the bridge**: The Mathlib theorem Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one (from NumberTheory.SumTwoSquares) encodes Euler's criterion — it says a prime p with p ≡ 3 (mod 4) cannot divide a number of the form k² + 1. This is the machine-checked version of a classical result connecting quadratic residues to Fermat's theorem on sums of two squares (every prime p ≡ 1 mod 4 is a sum of two squares).",
       "**Sum of two squares: the deeper connection**: The condition $p \\equiv 1 \\pmod 4$ is equivalent, by **Fermat's theorem on sums of two squares** (conjectured 1640, proved Euler 1749), to $p = a^2 + b^2$ for some integers $a, b$. The proof here uses the easier direction: if $p \\mid k^2 + 1$ then $-1 \\equiv k^2 \\pmod p$, so $-1$ is a perfect square mod $p$, forcing $p \\equiv 1 \\pmod 4$. The harder direction — every prime $p \\equiv 1 \\pmod 4$ is a sum of two squares — requires Gaussian integer factorization or Minkowski's theorem and is a genuinely deeper result also formalized in Mathlib's `NumberTheory.SumTwoSquares`.",
-      "**Gaussian primes and the ring ℤ[i]**: From the algebraic perspective, primes $p \\equiv 1 \\pmod 4$ are exactly the rational primes that split in the Gaussian integers $\\mathbb{Z}[i]$: $p = (a+bi)(a-bi)$. Primes $p \\equiv 3 \\pmod 4$ remain prime (inert) in $\\mathbb{Z}[i]$, while $2 = -i(1+i)^2$ ramifies. This trichotomy (split/inert/ramified) is the algebraic number theory perspective on the same mod-4 classification proved elementarily here — what appears as a residue condition mod 4 is really about how primes behave in the ring extension $\\mathbb{Z} \\subset \\mathbb{Z}[i]$."
+      "**Gaussian primes and the ring ℤ[i]**: From the algebraic perspective, primes $p \\equiv 1 \\pmod 4$ are exactly the rational primes that split in the Gaussian integers $\\mathbb{Z}[i]$: $p = (a+bi)(a-bi)$. Primes $p \\equiv 3 \\pmod 4$ remain prime (inert) in $\\mathbb{Z}[i]$, while $2 = -i(1+i)^2$ ramifies. This trichotomy (split/inert/ramified) is the algebraic number theory perspective on the same mod-4 classification proved elementarily here — what appears as a residue condition mod 4 is really about how primes behave in the ring extension $\\mathbb{Z} \\subset \\mathbb{Z}[i]$.",
+      "**The cyclotomic generalization**: The reason $f(x) = x^2 + 1$ works as a Euclid-style 'prime detector' for the $\\equiv 1 \\pmod 4$ class is a special case of a general phenomenon: the **cyclotomic polynomial** $\\Phi_n(x)$ has the property that any prime $p \\nmid n$ dividing $\\Phi_n(k)$ for some $k$ must satisfy $p \\equiv 1 \\pmod n$. Here $\\Phi_4(x) = x^2 + 1$. This gives elementary Euclid-style proofs of infinitude for *every* class $\\equiv 1 \\pmod n$ (Wendt 1895; Bang–Zsygmondy). The classes $\\not\\equiv 1 \\pmod n$ are genuinely harder: for $n = 4$, the only other class $\\equiv 3 \\pmod 4$ admits an *ad hoc* product argument, but for $n = 5$ the classes $\\equiv 2, 3, 4 \\pmod 5$ have no known elementary Euclid-style proof (only Dirichlet's L-function approach or Selberg–Erdős 1949 elementary, but the latter is technically advanced)."
     ],
     "prerequisites": [
       "Euclid's infinitude of primes (find a number N > n! with a new prime factor)",
@@ -125,6 +126,16 @@
       "type": "library",
       "citation": "The Mathlib Community. \"Proofs.InfinitudePrimes4k3\" — `primes_3_mod_4_infinite`, `prime_mod_four`. (this repository, accessed 2026)",
       "relevance": "The parent gallery file (the entry whose OQ-03 this file answers). Contains the ≡ 3 mod 4 construction $N = 4(n+1)! - 1$ and the basic mod-4 classification of odd primes. Both are re-exported here to form the complete picture."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Murty, M. Ram (1988). \"Primes in certain arithmetic progressions.\" Functiones et Approximatio Commentarii Mathematici, 35, 249-259.",
+      "relevance": "Modern survey characterizing which arithmetic progressions $\\{a, a+d, a+2d, \\ldots\\}$ admit Euclid-style elementary infinitude proofs. The criterion (essentially Murty's theorem) is that $a^2 \\equiv 1 \\pmod d$ — exactly the classes that can be detected by polynomial divisibility (cyclotomic and related). For $d = 4$ this gives $a = 1$ or $a = 3$, matching the two elementary proofs combined here. For $d = 5$ only $a = 1, 4$ qualify, leaving $a = 2, 3$ requiring L-functions or Selberg–Erdős."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Selberg, Atle (1949). \"An elementary proof of Dirichlet's theorem about primes in an arithmetic progression.\" Annals of Mathematics 50(2), 297-304.",
+      "relevance": "Established that Dirichlet's theorem admits an elementary (non-analytic) proof for *every* AP with coprime first term and modulus, not just the special moduli covered here. Selberg's argument is technically far more involved than the mod-4 Euclid-style proofs (it uses the same elementary tools that gave the elementary proof of the prime number theorem). The contrast with the simple constructions in this file illustrates how 'elementary' covers a wide range of difficulty: the mod-4 specific constructions are accessible to a first-course student, while Selberg's general method is graduate-level analytic number theory in disguise."
     }
   ],
   "sections": [
@@ -167,7 +178,8 @@
     "openQuestions": [
       "Can similar elementary arguments prove infinitely many primes ≡ 1 (mod 3)? (No — this requires quadratic reciprocity or L-functions, since there is no simple Euclid-type construction.)",
       "What is the minimum Mathlib infrastructure needed to prove infinitely many primes in any AP {a + nd} with gcd(a,d) = 1 elementarily? Dirichlet's original proof uses L-functions; are there elementary proofs for other small moduli (5, 8, 12)?",
-      "Can Fermat's theorem on sums of two squares (every prime p ≡ 1 mod 4 is a sum of two squares) be formalized using only the infrastructure developed in InfinitudePrimes4k1, or does it require the full Gaussian integer machinery already in Mathlib?"
+      "Can Fermat's theorem on sums of two squares (every prime p ≡ 1 mod 4 is a sum of two squares) be formalized using only the infrastructure developed in InfinitudePrimes4k1, or does it require the full Gaussian integer machinery already in Mathlib?",
+      "Murty's criterion characterizes the APs admitting Euclid-style elementary infinitude proofs as those with $a^2 \\equiv 1 \\pmod d$. Can this be formalized as a meta-theorem in Lean — a function that takes $(a, d)$ with $a^2 \\equiv 1 \\pmod d$ and produces a proof of $\\{p \\text{ prime} \\mid p \\equiv a \\pmod d\\}$ being infinite by reflecting on the cyclotomic structure? This would unify InfinitudePrimes4k1, InfinitudePrimes4k3, and analogous proofs for $d = 8, 12, \\ldots$ under a single generic argument."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass for infinitude-primes-4k3-oq-03

Adds the cyclotomic-polynomial perspective that unifies this proof with related entries, plus references to the modern characterization of which APs admit Euclid-style proofs.

### Changes
- **New annotation** `cyclotomic-pattern` (range 24-33): explains $\Phi_4(x) = x^2 + 1$, the Wendt order argument, and Murty's criterion ($a^2 \equiv 1 \pmod d$).
- **New keyInsight**: cyclotomic generalization placing the mod-4 case in context (why $\equiv 1 \pmod n$ is uniformly elementary, why $\equiv 3 \pmod 4$ is special, why $\equiv 2, 3 \pmod 5$ are genuinely harder).
- **New references**:
  - Murty (1988) — modern criterion for elementary AP infinitude
  - Selberg (1949) — elementary proof of Dirichlet's general theorem
- **New openQuestion**: formalizing Murty's criterion as a Lean meta-theorem.

### Verification
- tsc --noEmit -p . passes
- No JSON parse errors
- Diff is 2 files only (no main-repo index pollution)