### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S5 — fano_converse_step single-letter identity (build pending)

### DIFF
--- a/proofs/Proofs/ShannonChannelCoding.lean
+++ b/proofs/Proofs/ShannonChannelCoding.lean
@@ -10,10 +10,10 @@
 
   Axioms: 3 (channel_coding_achievability, channel_coding_converse,
     bsc_capacity_eq)
-  Theorems: 11 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
+  Theorems: 12 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
     channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity,
     capacity_le_log_card, rate_of_code_pos, fano_inequality,
-    bsc_capacity_le_one, bsc_capacity_nonneg)
+    fano_converse_step, bsc_capacity_le_one, bsc_capacity_nonneg)
   Sorries: 0
 -/
 import Mathlib
@@ -206,6 +206,54 @@ theorem fano_inequality {α β : Type*} [Fintype α] [Fintype β]
       InformationTheory.BinaryEntropy.h P_e +
         P_e * Real.log (Fintype.card α - 1) :=
   FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum
+
+/-- **Fano-form converse intermediate identity** (single-letter form).
+
+    For any joint distribution `pXY : α × β → ℝ` whose X-marginal achieves the
+    maximum-entropy bound `H(X) = log |α|` (i.e., X is uniform on α),
+
+    `log |α| ≤ I(X;Y) + h(P_e) + P_e · log(|α| - 1)`
+
+    where `P_e := 1 - ∑ y, ∑ x, pXY(x,y)² / pY(y)` is the Fano error term.
+
+    Equivalently, `log |α| - h(P_e) - P_e · log(|α| - 1) ≤ I(X;Y)`. Combined
+    with `channelMI_le_capacity` (which gives `I(X;Y) ≤ channelCapacity ch`),
+    this yields the canonical single-letter converse
+    `(1 − P_e) · log |α| ≤ channelCapacity ch + h(P_e)` (after rearranging
+    `P_e · log(|α| / (|α| − 1)) ≥ 0` for `|α| ≥ 2`).
+
+    The proof is a single `linarith` step on:
+    * `chain_rule pXY`  — `I(X;Y) = H(X-marginal) − H(X|Y)`
+    * `h_uniform`       — `H(X-marginal) = log |α|`  (hypothesis)
+    * `fano_inequality pXY` — `H(X|Y) ≤ h(P_e) + P_e · log(|α| - 1)`
+
+    The `h_uniform` hypothesis is satisfied for uniform X via
+    `entropy_of_uniform_eq_log_card` (in `ShannonEntropy.lean`); stating it
+    abstractly here keeps the lemma applicable to any X-marginal achieving
+    the max-entropy bound, and avoids importing additional uniform-distribution
+    plumbing into this file. -/
+theorem fano_converse_step {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (pXY : α × β → ℝ) (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1)
+    (h_uniform : shannonEntropy (fun x : α => ∑ y : β, pXY (x, y)) =
+                 Real.log (Fintype.card α)) :
+    let P_e := 1 - ∑ y : β, ∑ x : α, pXY (x, y) ^ 2 / (∑ x' : α, pXY (x', y))
+    Real.log (Fintype.card α) ≤
+      mutualInformation pXY +
+      InformationTheory.BinaryEntropy.h P_e +
+      P_e * Real.log ((Fintype.card α : ℝ) - 1) := by
+  intro P_e
+  -- I(X;Y) = H(X) - H(X|Y); with h_uniform: H(X) = log |α|,
+  -- this gives mutualInformation pXY = log |α| - conditionalEntropy pXY.
+  have hchain : mutualInformation pXY =
+      shannonEntropy (fun x : α => ∑ y : β, pXY (x, y)) -
+        conditionalEntropy pXY := chain_rule hp hsum
+  rw [h_uniform] at hchain
+  -- Fano: H(X|Y) ≤ h(P_e) + P_e · log(|α| - 1).
+  have hfano := fano_inequality pXY hp hsum
+  -- Combine algebraically.
+  linarith
 
 /- ## Main theorems -/
 

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -17,19 +17,19 @@
   },
   "currentState": {
     "phase": "ACT-PROGRESS",
-    "since": "2026-05-12T03:55:00Z",
-    "iteration": 2,
-    "focus": "Step 4 executed: swap axiom fano_inequality -> theorem (dispatcher reference). Axiom count on parent shannon-channel-coding entry drops 4->3.",
+    "since": "2026-05-12T05:40:00Z",
+    "iteration": 5,
+    "focus": "S5: fano_converse_step named lemma in ShannonChannelCoding.lean — single-letter Fano-form converse log|α| ≤ I(X;Y) + h(P_e) + P_e·log(|α|-1) under abstract uniform-entropy hypothesis. Decoupled from S4 PR #17879.",
     "blockers": [],
-    "nextAction": "Aristotle/mechanic refresh on parent shannon-channel-coding meta. Verify Docker build; if defeq issue, switch to tactic-mode proof.",
+    "nextAction": "S6 candidate: discharge channel_coding_converse axiom (asymptotic regime) using fano_converse_step + channelMI_le_capacity + OQ02OQ03's converse_from_combined_bound algebra. Alt: prove entropy_uniform_implies_uniform_marginal converse.",
     "attemptCounts": {
-      "total": 2,
+      "total": 5,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 5
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Step 4 executed \u2014 axiom fano_inequality converted to theorem in ShannonChannelCoding.lean using FanoFromConditionalEntropy.fano_inequality_proved dispatcher. Parent gallery entry axiomCount 4->3, theoremCount 8->9, lineCount 228->233. Build pending.",
+    "progressSummary": "S5 (researcher-5, 2026-05-12): fano_converse_step lemma added to ShannonChannelCoding.lean (line 200 region, +47 lines). Proves log|\u03b1| \u2264 I(X;Y) + h(P_e) + P_e\u00b7log(|\u03b1|-1) under explicit uniform-entropy hypothesis, decoupled from S4 PR #17879. Parent gallery: theoremCount 11\u219212, lineCount 275\u2192324. Build pending.",
     "builtItems": [
       "fano_from_oq03_std (ShannonChannelCodingOQ02OQ01.lean:201): bridge via InformationTheory.conditionalEntropy by definitional equality (rfl)",
       "fano_singleton_card_one (ShannonChannelCodingOQ02OQ01.lean:216): |\u03b1|=1 case via Subsingleton + h_nonneg",
@@ -70,16 +70,16 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.565Z",
-  "lastUpdate": "2026-05-12T03:55:00Z",
+  "lastUpdate": "2026-05-12T05:40:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
+      "lineCount": 324,
+      "theoremCount": 12,
+      "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Iteration 5 of `shannon-channel-coding-oq-02-oq-01-oq-01` (MODERATE+ tier).
Adds `fano_converse_step` to `ShannonChannelCoding.lean` — the single-letter
Fano-form converse intermediate identity:

```
log |α| ≤ I(X;Y) + h(P_e) + P_e · log(|α| - 1)
```

for joint distributions `pXY : α × β → ℝ` whose X-marginal achieves the
max-entropy bound `H(X) = log |α|`.

### Decoupled from S4 PR #17879

The uniform-entropy fact `H(X-marginal) = log |α|` is taken as an **explicit
hypothesis** `h_uniform`. This decouples S5 from S4 (which adds
`entropy_of_uniform_eq_log_card` to `ShannonEntropy.lean`); the two PRs can
land in either order without merge conflicts (they touch different files).

Once S4 lands, callers discharge `h_uniform` directly with one rewrite.
Until then, S5 stands alone and is usable for any X-marginal hitting the
max-entropy bound (including near-uniform asymptotic cases).

### Proof

5 lines, in `proofs/Proofs/ShannonChannelCoding.lean` immediately after
`fano_inequality` (line 200):

```lean
theorem fano_converse_step (pXY : α × β → ℝ)
    (hp : ∀ xy, 0 ≤ pXY xy) (hsum : ∑ xy, pXY xy = 1)
    (h_uniform : shannonEntropy (X-marginal) = Real.log (Fintype.card α)) :
    let P_e := 1 - ∑ y, ∑ x, pXY (x, y) ^ 2 / (∑ x', pXY (x', y))
    Real.log (Fintype.card α) ≤
      mutualInformation pXY +
      InformationTheory.BinaryEntropy.h P_e +
      P_e * Real.log ((Fintype.card α : ℝ) - 1) := by
  intro P_e
  have hchain := chain_rule hp hsum    -- I(X;Y) = H(X) - H(X|Y)
  rw [h_uniform] at hchain              -- H(X) ↦ log |α|
  have hfano := fano_inequality pXY hp hsum  -- H(X|Y) ≤ h(P_e) + P_e · log(|α|-1)
  linarith
```

### Combined single-letter converse

S5 + S3's `channelMI_le_capacity` (PR #17852, same file line 137) compose:

```
log |α|  ≤  I(X;Y) + h(P_e) + P_e · log(|α| - 1)        — S5
         ≤  channelCapacity ch + h(P_e) + P_e · log(|α| - 1)   — S3
```

Rearranges to `(1 − P_e) · log |α| ≤ channelCapacity ch + h(P_e)` after
adding the always-nonneg `P_e · log(|α|/(|α|−1))` to both sides
(positive for `|α| ≥ 2`). This is the canonical Fano-converse bound; the
asymptotic regime `n → ∞` is S6 (next-action), bridging via OQ02OQ03's
`converse_from_combined_bound` algebra.

### Gallery sync

`src/data/proofs/shannon-channel-coding/meta.json`:
* `lineCount`: 275 → 324
* `theoremCount`: 11 → 12
* `assumptions` string extended to mention `fano_converse_step`

### Build status

Not built locally (host `proofs/.lake` recursive self-symlink per memory
feedback). Per the established convention, the PR title is tagged
"(build pending)". The proof relies only on stable Mathlib lemmas via:
* `chain_rule` (already at line 375 of `ShannonEntropy.lean`, on origin/main)
* `fano_inequality` (line 200 of `ShannonChannelCoding.lean`, in this file)
* `linarith`

If a follow-up build flags a let-binder metavariable strand from
`fano_inequality`'s `let P_e := …` binders, the fallback is to `show` the
conclusion with `P_e` unfolded before invoking `linarith`.

## Test plan

- [ ] CI Lean build of `Proofs.ShannonChannelCoding` succeeds (uses only
      stable Mathlib lemmas via chain_rule + fano_inequality + linarith)
- [ ] Gallery `pnpm build` succeeds (meta.json schema unchanged, count fields only)
- [ ] No regressions in dependents: `Proofs.ShannonChannelCodingOQ02OQ03`,
      `Proofs.ShannonChannelCodingOQ02OQ04` (which transitively import this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)