### PR TITLE
Enrich Indicator of Any Null Set Has Zero Lebesgue Integral

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/index.ts
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/index.ts
@@ -1,1 +1,38 @@
-export { default } from './meta.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LebesgueMeasureOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lebesgueMeasureOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lebesgueMeasureOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lebesgueMeasureOQ01OQ03Data: ProofData = {
+  proof: lebesgueMeasureOQ01OQ03Proof,
+  annotations: lebesgueMeasureOQ01OQ03Annotations,
+}
+
+export default lebesgueMeasureOQ01OQ03Data

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -78,6 +78,14 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Header: Question, Strategy, and Mathematical Context",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Module docstring stating OQ-01-OQ-03 (extension to arbitrary null sets), the three-step proof strategy, and examples (\u211a, countable sets, singletons, Cantor set). Imports Mathlib's Lebesgue basics and Bochner integral.",
+      "mathContext": "Goal: $\\mu(S) = 0 \\Rightarrow \\int \\mathbf{1}_S \\, d\\mu = 0$ for any measurable null $S$. Three steps: (1) `compl_mem_ae_iff.mpr`: $\\mu(S)=0 \\Rightarrow S^c \\in \\mu.ae$; (2) `Set.indicator_of_notMem`: $x \\notin S \\Rightarrow \\mathbf{1}_S(x)=0$; (3) `integral_eq_zero_of_ae`: a.e.-zero $\\Rightarrow$ integral zero."
+    },
+    {
       "id": "sec-core",
       "title": "Part I: Core Abstract Theorem",
       "startLine": 58,
@@ -108,6 +116,14 @@
       "endLine": 210,
       "summary": "Changing a function on a null set doesn't affect the integral; a.e.-zero functions integrate to zero.",
       "mathContext": "If $f = g$ off a null set $S$, then $\\int f \\, d\\mu = \\int g \\, d\\mu$. This is the abstract principle behind all null-set invisibility."
+    },
+    {
+      "id": "sec-oq01-closure",
+      "title": "Part V: OQ-01 Corollary and Summary",
+      "startLine": 213,
+      "endLine": 244,
+      "summary": "One-line term-mode example deriving the OQ-01 Dirichlet result ∫_{[0,1]} 𝟙_ℚ dλ = 0 from `integral_indicator_of_null_on_set`. Concludes with a 15-theorem catalogue.",
+      "mathContext": "$\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}\\cap\\mathbb{R}} \\, d\\lambda = 0$ via `integral_indicator_of_null_on_set _ _ (Set.countable_range (Rat.cast) |>.measure_zero volume)`. The original OQ-01 proof shrinks to a single composition."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `lebesgue-measure-oq-01-oq-03` (quality 98, pass 0).

## Critical fix
- `index.ts` was a stub: `export { default } from './meta.json'`. With Vite's `import.meta.glob` this resolves but does not expose the `Proof` / `Annotation` / `ProofData` shape the gallery loader expects, so the proof page shows "proof not found" on the live site even though the entry appears in the listing.
- Replaced with the standard template that loads `LebesgueMeasureOQ01OQ03.lean?raw` and exports `lebesgueMeasureOQ01OQ03Proof / Annotations / Data` plus a default `ProofData`.

## Section coverage
- Existing `sections` only spanned lines 58-210 (Parts I-IV) out of the 244-line file. Added:
  - `sec-header` (lines 1-57): module docstring stating OQ-01-OQ-03 and the three-step strategy.
  - `sec-oq01-closure` (lines 213-244): Part V's one-line term-mode example and the 15-theorem summary.
- Each new section has a `mathContext` LaTeX block consistent with the existing four.

## Untouched
- Annotations already meet the quality bar (9 entries, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`).
- `overview.keyInsights` has 6 entries; `conclusion` has summary + implications + 2 open questions.
- `crossReferences` and `mainTheorems` already populated.

## Axiom integrity
- `meta.json` reports `axiomCount: 0`, `sorries: 0`, `status: "verified"`, `badge: "verified"`. The Lean file has no `axiom` declarations and no structure-encoded assumptions; the `Measure` typeclass it relies on is a standard mathematical structure (not an axiom shim). Status correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)