### PR TITLE
fix(meta): batch sync lineCount drift (3 entries, follow-on to #17794)

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01/meta.json
@@ -62,7 +62,7 @@
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 0,
-    "lineCount": 272,
+    "lineCount": 295,
     "assumptions": "0 axioms, 0 sorries. Core cardinal facts (Cantor's theorem, mk_set, mk_real, beth hierarchy) from Mathlib; original work combines these to establish |𝒫(ℝ)| = ℶ₂ and conditional CH/GCH results.",
     "theoremCount": 17,
     "definitionCount": 2
@@ -236,7 +236,7 @@
       "Cardinal"
     ],
     "namespace": "CantorsTheoremOQ01",
-    "lineCount": 272,
+    "lineCount": 295,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 2,

--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 154,
+    "lineCount": 153,
     "assumptions": "1 axiom: taylor_lagrange_remainder (converting Mathlib's integral remainder to Lagrange form). 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -166,7 +166,7 @@
       "Set"
     ],
     "namespace": "MeanValueTheoremOQ02",
-    "lineCount": 154,
+    "lineCount": 153,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 1,

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -42,7 +42,7 @@
     "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 11 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 275,
+    "lineCount": 276,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",
@@ -172,7 +172,7 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 275,
+    "lineCount": 276,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount` and `meta.lineCount` (the inner-meta mirror) in 3 `meta.json` files where the count lags `wc -l` of the canonical `leanFile.path`.

All 3 entries had identical `leanFile.lineCount` and `meta.lineCount` values pre-fix, so this is pure drift after research/audit edits to the underlying Lean source, not a divergence between the two views.

Follow-on to PR #17794 (41-entry lineCount sweep, 2026-05-12):

```
  cantors-theorem-oq-01           272 → 295  (+23)
  mean-value-theorem-oq-02        154 → 153  (-1)
  shannon-channel-coding          275 → 276  (+1)
```

## Evidence

**Before**: `wc -l proofs/Proofs/CantorsTheoremOQ01.lean` → 295, but `meta.lineCount` and `leanFile.lineCount` both claim 272 (drift after +23 lines from recent edits). Similar pattern on the other two.

**After**: `meta.lineCount` and `leanFile.lineCount` match `wc -l` for all three.

## Scope

- **In scope**: `leanFile.lineCount` and `meta.lineCount` per entry, surgically updated via regex; `additionalFiles` and all other fields preserved (plumbing-edit precedent: PR #16297).
- **Out of scope**:
  - `ehrhart-cube-proven-oq-04` lineCount drift (584 → 677) excluded — actively contested (5 open PRs targeting different sync dimensions, including #17855, #17868, #17871, #17876, #17878).
  - `leanFile.theoremCount` drift (17 entries) deferred: pre-existing ambiguity in counting `@[simp]`-prefixed lemmas (PR #17839 canonical convention strips them; older entries followed an attribute-inclusive convention). Needs project decision before bulk sync.
  - `leanFile.axiomCount` drift (25 entries) deferred: needs per-entry `opaque` vs `axiom` disambiguation (PR #16441 precedent: cutting away `opaque` undercounts assumption-bearing constants).
  - `meta.sorries` / `meta.meta.sorries` looked drifty against `leanFile.sorries`, but the canonical `scripts/auditor/find-targets.ts` convention follows Aristotle companion imports (`import Proofs.XAristotle`), so the top-level totals correctly sum main-file + companion sorries. No actual drift under the auditor convention.

---
Automated fix by lean-mechanic agent.
