### PR TITLE
Enrich Fundamental Theorem of Calculus via MVT Structure

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-04/index.ts
+++ b/src/data/proofs/mean-value-theorem-oq-04/index.ts
@@ -1,31 +1,38 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MeanValueTheoremOQ04.lean?raw'
 
-const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
 
-const leanSource = () => import('../../../../proofs/Proofs/MeanValueTheoremOQ04.lean?raw')
-
-export const proof: Proof = {
+export const meanValueTheoremOQ04Proof: Proof = {
   id: meta.id,
   title: meta.title,
   slug: meta.slug,
   description: meta.description,
   meta: meta.meta,
   sections: meta.sections,
-  source: '',
+  source: sourceRaw,
   overview: meta.overview,
   conclusion: meta.conclusion,
-  crossReferences: meta.crossReferences
+  crossReferences: meta.crossReferences,
 }
 
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const meanValueTheoremOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
-export const proofData: ProofData = { proof, annotations }
-
-export async function getProofSource(): Promise<string> {
-  const module = await leanSource()
-  return module.default
+export const meanValueTheoremOQ04Data: ProofData = {
+  proof: meanValueTheoremOQ04Proof,
+  annotations: meanValueTheoremOQ04Annotations,
 }
 
-export default proofData
+export default meanValueTheoremOQ04Data

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -26,32 +26,44 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Motivation and Structural Insight",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring contrasting MVT (local, existential: f(b)-f(a) = f'(c)(b-a) for some c) with FTC (global, exact: f(b)-f(a) = \u222b\u2090\u1d47 f'). States the derivation MVT \u21d0 FTC + IVT, lists the 7 headline theorems, and opens namespaces `MeasureTheory`, `intervalIntegral`, `Real`, `Set`.",
+      "mathContext": "Local vs global form of the same fact: $f(b)-f(a) = f'(c)(b-a)$ (MVT) vs $f(b)-f(a) = \\int_a^b f'$ (FTC). The integral mean $\\frac{1}{b-a}\\int_a^b f' \\in [\\min f',\\max f']$, so IVT applied to $f'$ on $[a,b]$ recovers MVT from FTC."
+    },
+    {
       "id": "ftc-parts",
       "title": "Fundamental Theorem of Calculus",
       "startLine": 37,
       "endLine": 83,
-      "summary": "Five FTC theorems. ftc_part1: if f is continuous on [a,b], then x \u21a6 \u222b\u2090\u02e3 f is differentiable with derivative f (differentiation undoes integration). ftc_part1_deriv: the derivative is exactly f. antiderivative_of_integral: \u222b\u2090\u02e3 f is the canonical antiderivative vanishing at a. newton_leibniz: \u222b\u2090\u1d47 F' = F(b) - F(a) for C\u00b9 F (the Newton-Leibniz formula). ftc_part2: a second formulation of Newton-Leibniz with slightly different hypotheses."
+      "summary": "Five FTC theorems. ftc_part1: if f is continuous on [a,b], then x \u21a6 \u222b\u2090\u02e3 f is differentiable with derivative f (differentiation undoes integration). ftc_part1_deriv: the derivative is exactly f. antiderivative_of_integral: \u222b\u2090\u02e3 f is the canonical antiderivative vanishing at a. newton_leibniz: \u222b\u2090\u1d47 F' = F(b) - F(a) for C\u00b9 F (the Newton-Leibniz formula). ftc_part2: a second formulation of Newton-Leibniz with slightly different hypotheses.",
+      "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$ (Part 1) and $\\int_a^b F'(t)\\,dt = F(b)-F(a)$ (Part 2 / Newton-Leibniz). Uses `intervalIntegral.integral_hasDerivAt_right` and `intervalIntegral.integral_eq_sub_of_hasDerivAt`."
     },
     {
       "id": "mvt-ftc-connection",
       "title": "MVT Derived from FTC via IVT",
       "startLine": 84,
       "endLine": 118,
-      "summary": "The structural connection: ftc_implies_mvt shows the Mean Value Theorem follows from FTC + IVT \u2014 the integral mean \u222bf'/(b-a) lies between min and max of f', so IVT gives c with f'(c) equal to that mean. mvt_equals_integral_average: f'(c) = \u222b\u2090\u1d47 f'/(b-a) for the MVT witness c. This reveals FTC is more fundamental than MVT."
+      "summary": "The structural connection: ftc_implies_mvt shows the Mean Value Theorem follows from FTC + IVT \u2014 the integral mean \u222bf'/(b-a) lies between min and max of f', so IVT gives c with f'(c) equal to that mean. mvt_equals_integral_average: f'(c) = \u222b\u2090\u1d47 f'/(b-a) for the MVT witness c. This reveals FTC is more fundamental than MVT.",
+      "mathContext": "By FTC: $\\frac{f(b)-f(a)}{b-a} = \\frac{1}{b-a}\\int_a^b f'$. By integral monotonicity: $\\min_{[a,b]} f' \\leq \\frac{1}{b-a}\\int_a^b f' \\leq \\max_{[a,b]} f'$. By IVT on the continuous $f'$: $\\exists c \\in [a,b],\\; f'(c) = \\frac{f(b)-f(a)}{b-a}$."
     },
     {
       "id": "integral-identities",
       "title": "Integration by Parts, Uniqueness, and Inverse Operations",
       "startLine": 119,
       "endLine": 268,
-      "summary": "Five theorems. integration_by_parts: \u222bf'g = [fg]\u2090\u1d47 - \u222bfg', proved via product rule + Newton-Leibniz. ftc_uniqueness: two antiderivatives of the same function differ by a constant. diff_then_integrate: differentiating then integrating recovers the original. integrate_then_diff: the derivative of \u222b\u2090\u02e3 f is f. ftc_no_loss: differentiating \u222b\u2090\u02e3 f then integrating recovers \u222b\u2090\u02e3 f itself."
+      "summary": "Five theorems. integration_by_parts: \u222bf'g = [fg]\u2090\u1d47 - \u222bfg', proved via product rule + Newton-Leibniz. ftc_uniqueness: two antiderivatives of the same function differ by a constant. diff_then_integrate: differentiating then integrating recovers the original. integrate_then_diff: the derivative of \u222b\u2090\u02e3 f is f. ftc_no_loss: differentiating \u222b\u2090\u02e3 f then integrating recovers \u222b\u2090\u02e3 f itself.",
+      "mathContext": "Integration by parts: $\\int_a^b f'g = [fg]_a^b - \\int_a^b fg'$, from $(fg)' = f'g + fg'$ + Newton-Leibniz. Uniqueness: $F' = G' \\Rightarrow F-G$ constant (via MVT on $F-G$ with zero derivative). Inverse operations: $\\frac{d}{dx}\\int_a^x f = f$ and $\\int_a^b F' = F(b)-F(a)$."
     },
     {
       "id": "approximation",
       "title": "Quantitative Bounds via Lipschitz Theory",
       "startLine": 270,
       "endLine": 293,
-      "summary": "integral_approx_from_mvt: for Lipschitz derivative f', |\u222b\u2090\u1d47 f - f(c)\u00b7(b-a)| \u2264 Lip(f')\u00b7(b-a)\u00b2/2 \u2014 a quantitative error bound for the trapezoidal approximation. lipschitz_dist_bound: for Lipschitz f, |f(x)-f(y)| \u2264 K\u00b7|x-y| \u2014 the Lipschitz condition gives distance control from derivative bounds."
+      "summary": "integral_approx_from_mvt: for Lipschitz derivative f', |\u222b\u2090\u1d47 f - f(c)\u00b7(b-a)| \u2264 Lip(f')\u00b7(b-a)\u00b2/2 \u2014 a quantitative error bound for the trapezoidal approximation. lipschitz_dist_bound: for Lipschitz f, |f(x)-f(y)| \u2264 K\u00b7|x-y| \u2014 the Lipschitz condition gives distance control from derivative bounds.",
+      "mathContext": "For $K$-Lipschitz $F$: $|F(x)-F(y)| \\leq K|x-y|$ via $|F(x)-F(y)| = |\\int_y^x F'| \\leq K|x-y|$. Quadrature error: $|\\int_a^b f - f(c)(b-a)| \\leq \\int_a^b K|t-c|\\,dt \\leq K\\frac{(b-a)^2}{2}$ \u2014 the $O(h^2)$ trapezoidal rule bound."
     }
   ],
   "overview": {
@@ -105,5 +117,56 @@
     ],
     "namespace": "MeanValueTheoremOQ04"
   },
+  "mainTheorems": [
+    {
+      "name": "ftc_part1",
+      "type": "core",
+      "statement": "Continuous $f \\Rightarrow \\mathrm{HasDerivAt}\\;(x \\mapsto \\int_a^x f)\\;(f(x))\\;x$",
+      "significance": "FTC Part 1 in `HasDerivAt` form. Direct application of `intervalIntegral.integral_hasDerivAt_right` requires three Mathlib witnesses: `IntervalIntegrable` at every right endpoint (from `Continuous.intervalIntegrable`), `StronglyMeasurableAtFilter` (from `continuousAt.stronglyMeasurableAtFilter`), and a continuity-at-point witness (`continuousAt`). The resulting derivative is `f(x)` evaluated at the upper endpoint.",
+      "description": "Differentiation undoes integration: the integral function is differentiable with derivative equal to the integrand."
+    },
+    {
+      "name": "newton_leibniz",
+      "type": "core",
+      "statement": "$C^1$ on $[a,b] \\Rightarrow \\int_a^b F' = F(b) - F(a)$",
+      "significance": "FTC Part 2 / Newton-Leibniz formula. Uses `intervalIntegral.integral_eq_sub_of_hasDerivAt`, which requires `HasDerivAt F F' x` for every $x \\in [a,b]$ (note: closed interval, not just interior) AND `ContinuousOn F' [a,b]` (for the integral to exist in Mathlib's Bochner sense). The closed-interval requirement is stronger than the classical statement which often only requires differentiability on the interior — Mathlib's choice simplifies the integration hypotheses.",
+      "description": "Newton-Leibniz: the integral of a derivative recovers the endpoint difference."
+    },
+    {
+      "name": "ftc_implies_mvt",
+      "type": "core",
+      "statement": "$f \\in C^1([a,b])$ and $a < b \\Rightarrow \\exists c \\in [a,b],\\; f'(c) = \\frac{f(b)-f(a)}{b-a}$",
+      "significance": "Structural derivation of MVT from FTC + IVT. The proof chains: (1) Newton-Leibniz gives $\\int f' = f(b)-f(a)$; (2) integral monotonicity bounds the mean by $[\\min f', \\max f']$; (3) `ContinuousOn.image_Icc` and `IsPreconnected.intermediate_value₂` give the IVT witness. This shows MVT is logically downstream of FTC, reversing the textbook order in which MVT is used to prove FTC.",
+      "description": "Mean Value Theorem as a corollary of FTC and IVT applied to the continuous derivative."
+    },
+    {
+      "name": "integration_by_parts",
+      "type": "supporting",
+      "statement": "$f, g \\in C^1([a,b]) \\Rightarrow \\int_a^b f' g = f(b)g(b) - f(a)g(a) - \\int_a^b f g'$",
+      "significance": "Product rule integrated via Newton-Leibniz. Apply `HasDerivAt.mul` to get $\\mathrm{HasDerivAt}\\;(fg)\\;(f'g + fg')$, then Newton-Leibniz on $fg$ gives $\\int (f'g + fg') = f(b)g(b)-f(a)g(a)$. Linearity of the integral rearranges to the canonical form. The algebraic heart of Fourier-series computations, Taylor-with-integral-remainder, and self-adjointness arguments.",
+      "description": "Integration by parts: the integrated product-rule identity."
+    },
+    {
+      "name": "lipschitz_dist_bound",
+      "type": "supporting",
+      "statement": "$F$ $K$-Lipschitz on $[a,b] \\Rightarrow |F(x) - F(y)| \\leq K\\cdot|x-y|$",
+      "significance": "Quantitative displacement bound from a derivative bound. The integral form $|F(x)-F(y)| = |\\int_y^x F'| \\leq \\int_y^x K = K|x-y|$ is the gateway to all quadrature error bounds. Combined with `integral_approx_from_mvt`, gives the $O(h^2)$ trapezoidal rule error — the foundation of verified numerical analysis.",
+      "description": "Lipschitz condition: derivative bounds give distance control."
+    }
+  ],
+  "references": [
+    {
+      "text": "Spivak, M. (1994). Calculus (3rd ed.). Publish or Perish. The standard exposition of FTC as a corollary chain from continuity through Riemann integration.",
+      "url": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_calculus"
+    },
+    {
+      "text": "Rudin, W. (1976). Principles of Mathematical Analysis (3rd ed.). McGraw-Hill. Chapter 6 develops the Riemann-Stieltjes integral and proves FTC + integration by parts in full generality.",
+      "url": "https://en.wikipedia.org/wiki/Lebesgue_integration"
+    },
+    {
+      "text": "Mathlib4: intervalIntegral.integral_hasDerivAt_right, intervalIntegral.integral_eq_sub_of_hasDerivAt, HasDerivAt.mul. The Bochner-integral foundation for FTC in Lean 4.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `mean-value-theorem-oq-04` (quality 98, pass 0).

## Critical fix
- `index.ts` set `source: ''` on the `Proof` object and loaded the Lean source through an async lazy import (`getProofSource()`). The gallery's source-code viewer expects `source` populated synchronously from a Vite `?raw` import. Replaced with the standard template so the Lean code panel renders without an empty fallback.

## Section coverage
- Added a new `Header: Motivation and Structural Insight` section (lines 1-36) covering the module docstring + open namespaces. Sections now span lines 1-293 (the full file).
- Added `mathContext` LaTeX blocks to all five sections (Header, FTC parts, MVT-FTC connection, Integration identities, Lipschitz bounds).

## New metadata blocks
- `mainTheorems`: five headline theorems (`ftc_part1`, `newton_leibniz`, `ftc_implies_mvt`, `integration_by_parts`, `lipschitz_dist_bound`) with statement, significance commentary, and description.
- `references`: Spivak (Calculus), Rudin (Principles of Mathematical Analysis Ch. 6), Mathlib4 (intervalIntegral / HasDerivAt).

## Untouched
- 8 annotations already meet the quality bar with mathContext/significance/relatedConcepts/prerequisites.
- `overview` has 5 keyInsights, full historicalContext (>700 chars), proofStrategy, problemStatement.
- `conclusion` has summary + implications + 3 openQuestions.

## Axiom integrity
- `axiomCount: 0`, `sorries: 0`, `status: "verified"`, `badge: "original"`. The Lean file has no `axiom` declarations and no assumption-carrying structures; it uses Mathlib's `HasDerivAt` and `intervalIntegral` machinery. Status correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)