### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S6 — Set-level structural API (build pending)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -78,13 +78,22 @@ The proof rests on the Mathlib infrastructure for partial recursive functions:
 - **S2** (researcher-1, #17759): unconditional lower bound `ℵ₀ ≤ #(computable reals)`
   via rational embedding; five concrete computable witnesses (rat/int/nat/0/1);
   exact equality stated (contingent on the S1 sorry).
-- **S3** (this PR): full proof of `computable_reals_countable` via `decodeReal` +
+- **S3** (#17768): full proof of `computable_reals_countable` via `decodeReal` +
   `Nat.Partrec.Code.exists_code` pipeline. **Build pending** — verification
   relies on the named Mathlib API (`Computable.encode`, `Computable.comp`,
   `Partrec.nat_iff`, `Nat.Partrec.Code.exists_code`, `Set.countable_range`,
   `Set.Countable.mono`, `tendsto_nhds_unique`, `Encodable.encode_injective`,
   `Part.some_injective`). With S3 landed, `card_computable_reals_le_aleph0`
   and `card_computable_reals_eq_aleph0` (from S2) become unconditional.
+- **S4** (#17806): strict-inclusion + `#(non-computable) = 𝔠` via partition +
+  ℵ₀-absorption mirroring the OQ02OQ03 transcendental cardinality argument.
+- **S5** (#17860): cross-cardinal consolidation (`card_computable_reals_eq_card_algebraic_reals`,
+  `card_nonComputableReals_eq_card_reals`, `cardinality_trichotomy`).
+- **S6** (this PR): Set-level structural API derived from the S2-S4 cardinal
+  results — `computable_reals_nonempty/_infinite` and
+  `nonComputableReals_nonempty/_uncountable/_infinite`. Five short corollaries,
+  no new Mathlib API dependencies beyond `Set.infinite_range_of_injective`,
+  `Rat.cast_injective`, and `Set.Finite.countable`.
 
 ## References
 
@@ -566,5 +575,75 @@ theorem cardinality_trichotomy :
   ⟨AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0,
    card_computable_reals_eq_aleph0,
    card_nonComputableReals_eq_continuum⟩
+
+/-! ## S6 — Set-theoretic structural API: nonempty, infinite, uncountable
+
+The cardinal results of S2-S4 (`ℵ₀ ≤ #computable`, `#(non-computable) = 𝔠`)
+immediately yield Set-level structural facts that are the natural form for
+downstream consumers (e.g. measure theory, descriptive set theory, dense subset
+constructions). This deliverable extracts the four standard predicates —
+`Nonempty`, `Infinite`, `Countable`/`Uncountable` — across the partition,
+keeping each proof as a one-liner that cites the corresponding S2-S4 cardinal
+result.
+
+* **Computable side** (cardinality ℵ₀):
+  - `computable_reals_nonempty` — 0 is computable, so the set is inhabited.
+  - `computable_reals_infinite` — every rational is computable and ℚ is infinite,
+    so the set contains an infinite subset.
+
+* **Non-computable side** (cardinality 𝔠):
+  - `nonComputableReals_nonempty` — direct from `exists_non_computable_real`.
+  - `nonComputableReals_uncountable` — from `#(non-computable) = 𝔠 > ℵ₀`.
+  - `nonComputableReals_infinite` — every uncountable set is infinite.
+
+These results round out the API and make the strict-inclusion structure of
+`{r | IsComputable r} ⊊ ℝ` available in Set-level form without forcing callers
+to round-trip through `Cardinal.mk`. -/
+
+/-- **S6 — computable reals are nonempty**: 0 is a witness (via `zero_isComputable`). -/
+theorem computable_reals_nonempty :
+    ({r : ℝ | IsComputable r} : Set ℝ).Nonempty :=
+  ⟨0, zero_isComputable⟩
+
+/-- **S6 — computable reals are infinite**.
+
+    The image of `Rat.cast : ℚ → ℝ` lies inside the computable reals (every
+    rational is computable, by `rat_isComputable`), and the cast is injective,
+    so its range is infinite. The computable reals then dominate an infinite
+    subset and are themselves infinite. -/
+theorem computable_reals_infinite :
+    ({r : ℝ | IsComputable r} : Set ℝ).Infinite := by
+  have h_subset : Set.range ((↑) : ℚ → ℝ) ⊆ {r : ℝ | IsComputable r} := by
+    rintro x ⟨q, rfl⟩
+    exact rat_isComputable q
+  exact (Set.infinite_range_of_injective Rat.cast_injective).mono h_subset
+
+/-- **S6 — non-computable reals are nonempty**, formalising Turing's negative
+    observation in the Set-level form. Direct restatement of
+    `exists_non_computable_real`. -/
+theorem nonComputableReals_nonempty : nonComputableReals.Nonempty :=
+  exists_non_computable_real
+
+/-- **S6 — non-computable reals are uncountable**.
+
+    From `card_nonComputableReals_eq_continuum` and `Cardinal.aleph0_lt_continuum`
+    we get `ℵ₀ < #(non-computable)`, which by `le_aleph0_iff_set_countable`
+    refutes countability.
+
+    This is the strongest classical statement that "almost all reals are
+    non-computable": no enumeration `ℕ → ℝ` can list them all. -/
+theorem nonComputableReals_uncountable : ¬ nonComputableReals.Countable := by
+  intro h
+  have h_le : (#(↑nonComputableReals : Set ℝ) : Cardinal) ≤ ℵ₀ :=
+    le_aleph0_iff_set_countable.mpr h
+  rw [card_nonComputableReals_eq_continuum] at h_le
+  exact absurd h_le (not_le.mpr Cardinal.aleph0_lt_continuum)
+
+/-- **S6 — non-computable reals are infinite**.
+
+    Direct from `nonComputableReals_uncountable`: every finite set is countable,
+    so an uncountable set is infinite. -/
+theorem nonComputableReals_infinite : nonComputableReals.Infinite := fun h =>
+  nonComputableReals_uncountable h.countable
 
 end AlgebraicNumbersCountableOQ02OQ04

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
@@ -2,9 +2,9 @@
 
 ## Current Status
 
-**Phase**: S4 STRICT INCLUSION + #(non-computable) = 𝔠 (build pending)
-**Owner**: researcher-12 (S4, 2026-05-12)
-**Branch**: `research/algebraic-numbers-countable-oq-02-oq-04-s4-noncomputable-<ts>`
+**Phase**: S6 SET-LEVEL STRUCTURAL API (build pending)
+**Owner**: researcher-9 (S6, 2026-05-12)
+**Branch**: `research/algebraic-numbers-countable-oq-02-oq-04-s6-structural-<ts>`
 
 ## What's Done
 
@@ -125,6 +125,29 @@ infrastructure + strategy + 1 file + 1 module-doc + 4 annotations).
   `AlgebraicNumbersCountableOQ02OQ03.lean` (`Cardinal.mk_set_le`,
   `Cardinal.mk_real`, `Cardinal.mk_union_le`, `Cardinal.mk_univ`,
   `Cardinal.add_eq_self`, `Cardinal.aleph0_lt_continuum`).
+- **2026-05-12 (S5, #17860)**: CROSS-CARDINAL CONSOLIDATION (build pending).
+  Three short consolidation theorems lifting the imported sibling
+  `AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0` alongside the
+  S2–S4 cardinality facts: `card_computable_reals_eq_card_algebraic_reals`
+  (both = ℵ₀), `card_nonComputableReals_eq_card_reals` (both = 𝔠 = #ℝ), and
+  `cardinality_trichotomy` (3-tuple summary, mirroring sibling
+  `cardinality_dichotomy`). No new imports/defs/sorries/axioms. Lean file
+  497 → 570 lines.
+- **2026-05-12 (S6, researcher-9)**: SET-LEVEL STRUCTURAL API
+  (build pending). Extracted the standard Set-level predicates
+  (`Nonempty`, `Infinite`, `Countable`/`Uncountable`) for the
+  computable/non-computable partition, with each proof a one-liner citing
+  S2–S4 cardinal results. Five new theorems:
+  - `computable_reals_nonempty` — `⟨0, zero_isComputable⟩`.
+  - `computable_reals_infinite` — ℚ-image ⊆ S via `rat_isComputable`,
+    dominate `Set.infinite_range_of_injective Rat.cast_injective`.
+  - `nonComputableReals_nonempty` — restates `exists_non_computable_real`.
+  - `nonComputableReals_uncountable` — `card_nonComputableReals_eq_continuum`
+    + `Cardinal.aleph0_lt_continuum` via `le_aleph0_iff_set_countable`.
+  - `nonComputableReals_infinite` — `Set.Finite → .Countable` contradiction.
+  Lean file 570 → 649 lines; no new defs, no new sorries, no new axioms;
+  theorem count synced to 31 (pre-S6 stale meta value was 24, drift +2 from
+  S5 + audit cleanup).
 
 ## S3 — What This Buys
 

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 570,
+    "lineCount": 649,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -46,7 +46,10 @@
       "card_nonComputableReals_eq_continuum — S4 main theorem: #(non-computable reals) = 𝔠, via partition + ℵ₀ absorption (mirrors OQ02OQ03 transcendental cardinality argument)",
       "exists_non_computable_real — S4 corollary: ∃ r : ℝ, ¬ IsComputable r (Turing's negative observation, by cardinality alone)",
       "computable_reals_strict_ssubset_univ — S4 strict inclusion {r | IsComputable r} ⊊ ℝ",
-      "card_computable_reals_lt_card_reals, card_computable_lt_card_nonComputable — S4 strict cardinal inequalities ℵ₀ < 𝔠 specialised to the computable/non-computable split"
+      "card_computable_reals_lt_card_reals, card_computable_lt_card_nonComputable — S4 strict cardinal inequalities ℵ₀ < 𝔠 specialised to the computable/non-computable split",
+      "card_computable_reals_eq_card_algebraic_reals, card_nonComputableReals_eq_card_reals, cardinality_trichotomy — S5 cross-cardinal consolidation lifting the cardinal coordinates of the hierarchy from the imported sibling AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0",
+      "computable_reals_nonempty, computable_reals_infinite — S6 Set-level structural API for the computable side (0 ∈ S; infinite via ℚ ↪ S and Set.infinite_range_of_injective + Rat.cast_injective)",
+      "nonComputableReals_nonempty, nonComputableReals_uncountable, nonComputableReals_infinite — S6 Set-level structural API for the non-computable side (uncountable from card = 𝔠 > ℵ₀; infinite from Set.Finite.countable contradiction)"
     ],
     "prerequisites": [
       "AlgebraicNumbersCountable: algebraic_reals_countable — the next layer up in the hierarchy",
@@ -81,7 +84,7 @@
         "module": "Mathlib.SetTheory.Cardinal.Continuum"
       }
     ],
-    "theoremCount": 24,
+    "theoremCount": 31,
     "definitionCount": 3,
     "relatedProblems": [
       {
@@ -284,9 +287,9 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 570,
+    "lineCount": 649,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 31,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"


### PR DESCRIPTION
## Summary

**S6 deliverable**: Set-level structural API (`Nonempty`/`Infinite`/`Uncountable`) for the computable / non-computable real partition, derived from the S2-S4 cardinal results already in the file.

Each new theorem is a one-liner citing prior cardinal lemmas — no new defs, no new sorries, no new axioms, no new Mathlib imports.

### Five new theorems

**Computable side** (cardinality ℵ₀):
- `computable_reals_nonempty` — `⟨0, zero_isComputable⟩`
- `computable_reals_infinite` — ℚ-image ⊆ {r | IsComputable r} via `rat_isComputable`; dominate `Set.infinite_range_of_injective Rat.cast_injective`

**Non-computable side** (cardinality 𝔠):
- `nonComputableReals_nonempty` — direct restatement of `exists_non_computable_real`
- `nonComputableReals_uncountable` — `card_nonComputableReals_eq_continuum` + `Cardinal.aleph0_lt_continuum` via `le_aleph0_iff_set_countable`
- `nonComputableReals_infinite` — `Set.Finite → .Countable` contradiction

### Motivation

The cardinal results are sharp but cumbersome at call sites that need predicates instead of `#·`-valued statements. Downstream consumers (measure theory, descriptive set theory, dense subset constructions) naturally use Set-level predicates; this PR makes them available without round-tripping through `Cardinal.mk`.

### Meta sync

- `lineCount`: 570 → 649
- `theoremCount`: 24 → 31 (5 new + 2 drift catch-up from S5)
- `definitionCount`: 3 (unchanged)
- `sorries`: 0, `axiomCount`: 0 (unchanged)

### Build risk

**Low** — only uses well-established Mathlib API (`Set.infinite_range_of_injective`, `Rat.cast_injective`, `Set.Finite.countable`, `le_aleph0_iff_set_countable`, `Cardinal.aleph0_lt_continuum`). Build pending — Docker `proofs/.lake` symlink trap per `feedback_researcher_lake_symlink_broken.md`.

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ04`
- [ ] On green: bump `badge` from `wip` to `verified`
- [ ] Optional follow-up: lift the same five lemmas to sibling `AlgebraicNumbersCountableOQ02OQ03` for the algebraic/transcendental split

🤖 Generated with [Claude Code](https://claude.com/claude-code)