### PR TITLE
research(hilbert-15-oq-02-oq-03-oq-01): S2 scaffold — SkewSSYTFin + reverseRowWord + isLatticeWord + lrCoeffN_def (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2354,6 +2354,7 @@ import Proofs.Hilbert14NonReductive
 import Proofs.Hilbert15OQ01
 import Proofs.Hilbert15OQ02
 import Proofs.Hilbert15OQ02OQ03
+import Proofs.Hilbert15OQ02OQ03OQ01
 import Proofs.Hilbert15SchubertCalculus
 import Proofs.Hilbert15SchubertCalculusOQ01
 import Proofs.Hilbert16

--- a/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean
+++ b/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean
@@ -1,0 +1,247 @@
+import Mathlib.Tactic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.FinRange
+import Proofs.Hilbert15OQ02OQ03
+
+/-!
+# Hilbert 15 OQ-02 OQ-03 OQ-01: Combinatorial `lrCoeffN` Scaffold
+# (hilbert-15-oq-02-oq-03-oq-01)
+
+## The Goal
+
+Replace the parent file's `axiom lrCoeffN : Partition n → Partition n → Partition n → ℕ`
+(`Hilbert15OQ02OQ03.lean:128`) with a concrete computable definition
+
+```
+lrCoeffN_def ν λ μ :=
+  #{ T : SkewSSYTFin n ν μ // content T = λ ∧ isLatticeWord (reverseRowWord T) }
+```
+
+following the classical Littlewood-Richardson rule (Littlewood 1934; Fulton
+1997 Ch. 5; Macdonald 1995 §I.9). This file provides the **S2 scaffold**:
+five definitions plus the `Decidable` / `Fintype` instances needed to keep
+the parent file's `decide`-based `lr_polytime_positivity` going through.
+
+## Contents (S2)
+
+1. `Hilbert15OQ02OQ03.Partition.Subset` — containment relation `μ ⊆ ν` on
+   `Partition n`, with `HasSubset` and `Decidable` instances.
+2. `SkewSSYTFin n ν μ` — semistandard skew Young tableau filling
+   `(i, j)` with `j ∈ [μ.parts i, ν.parts i)` by a value in `Fin n`,
+   satisfying row-weak and (skew) column-strict (column index =
+   `μ.parts i + j.val`). `Fintype` by `Subtype.fintype` since the
+   underlying function space is a `Pi` over finite types.
+3. `SkewSSYTFin.content T k` — count of cells of `T` filled with value
+   `k : Fin n`. Returns `ℕ` (not `Partition n`) since for a generic
+   skew SSYT the count vector need not be weakly decreasing — only
+   after restriction to lattice words does sortedness emerge.
+4. `SkewSSYTFin.reverseRowWord T` — Fulton-convention reading word:
+   each row read **right-to-left**, rows in order **top-to-bottom**.
+   Returns `List (Fin n)`. (Stanley reads bottom-to-top; the parent's
+   `lrCoeff2` follows Fulton — see `Hilbert15OQ02.lean:131`.)
+5. `isLatticeWord w` — at every prefix and every pair `k < k'`, the
+   count of `k'` is bounded by the count of `k`. Synonyms: ballot
+   word; Yamanouchi word. `Decidable` since the universal can be
+   bounded by `Fin (w.length + 1)`.
+6. `lrCoeffN_def ν λ μ : ℕ` — the LR count, guarded by the standard
+   well-definedness condition `μ ⊆ ν ∧ ν.weight = λ.weight + μ.weight`.
+   `Decidable (0 < lrCoeffN_def ν λ μ)` follows from `Nat.decLt`.
+
+## Deferred (S3, S4, S5+)
+
+* **S3 — 2-row anchoring lemma.** Prove
+  `lrCoeffN_def_two_eq_lrCoeff2 : ∀ (ν λ μ : Partition 2),
+      lrCoeffN_def ν λ μ = lrCoeff2 (toListPair ν) (toListPair λ) (toListPair μ)`
+  against the 7 Gr(2,4) Chow ring constants verified in
+  `Hilbert15OQ01.lean`. This is the smoke check that the abstract count
+  reduces to the existing computable case.
+
+* **S4 — Parent axiom replacement.** Refactor
+  `Hilbert15OQ02OQ03.lean:128` from `axiom lrCoeffN` to
+  `def lrCoeffN := Hilbert15OQ02OQ03OQ01.lrCoeffN_def`; verify
+  `klyachko_theorem` and `lr_polytime_positivity` still typecheck.
+
+* **S5+ — OQ-02 / OQ-03 proper.** Once the axiom is removed, the
+  full Klyachko/Horn-inequalities chain in
+  `Hilbert15OQ02OQ03.lean:160` can be re-examined; the `admissible`
+  axiom remains but is now stated against a concrete `lrCoeffN`.
+
+## Build status
+
+The pinned Mathlib (`v4.26.0`) lacks `SemistandardYoungTableau`, skew
+shape encoding, reverse row reading word, and the lattice-word
+predicate. All five S2 declarations are pure Mathlib wrappers over
+`Finset`, `List`, `Fin`, and `Subtype.fintype`; no auxiliary
+infrastructure is introduced. Per the established Hilbert-15 PR
+convention this scaffold ships as `(build pending)` since the parent
+`Hilbert15OQ02OQ03.lean` is on `origin/main` and the per-file Docker
+build is deferred to CI.
+
+## References
+
+* Fulton, W. (1997). *Young Tableaux* (LMS Student Texts 35),
+  Cambridge University Press. Chapter 5: "The Littlewood-Richardson
+  rule."
+* Stanley, R.P. (1999). *Enumerative Combinatorics* Vol. 2, Cambridge
+  University Press. Appendix 1 (A.1.3) — reading words and Yamanouchi
+  sequences.
+* Macdonald, I.G. (1995). *Symmetric Functions and Hall Polynomials*
+  (2nd ed.). Oxford University Press. §I.9 "The Littlewood-Richardson
+  rule."
+* Knutson, A. & Tao, T. (1999). The honeycomb model of `GL_n` tensor
+  products I. *J. Amer. Math. Soc.* **12**(4), 1055-1090.
+-/
+
+namespace Hilbert15OQ02OQ03OQ01
+
+open Hilbert15OQ02OQ03
+
+/-! ## Part I: Partition Containment (`μ ⊆ ν`) -/
+
+/-- **Pointwise containment of partitions.** `μ ⊆ ν` iff every part of
+    `μ` is at most the corresponding part of `ν`. This is the
+    standard "Young diagram of `μ` fits inside the Young diagram of
+    `ν`" relation; combined with `ν.weight = λ.weight + μ.weight` it
+    is the well-definedness condition for the skew shape `ν / μ` of
+    content `λ`. -/
+def Partition.Subset {n : ℕ} (μ ν : Partition n) : Prop :=
+  ∀ i : Fin n, μ.parts i ≤ ν.parts i
+
+instance {n : ℕ} : HasSubset (Partition n) := ⟨Partition.Subset⟩
+
+instance {n : ℕ} (μ ν : Partition n) : Decidable (μ ⊆ ν) :=
+  inferInstanceAs (Decidable (∀ i : Fin n, μ.parts i ≤ ν.parts i))
+
+/-! ## Part II: Skew Semistandard Young Tableaux -/
+
+/-- A **semistandard skew Young tableau** of outer shape `ν` and inner
+    shape `μ` with entries in `Fin n`, encoded as a function on the
+    sigma-type `(i : Fin n) × Fin (ν.parts i - μ.parts i)` (cell in
+    row `i`, **inner-relative** column index `j`).
+
+    The **column index** of the cell `(i, j)` in the ambient
+    Young-diagram coordinate system is `μ.parts i + j.val` (the
+    inner shape's row-`i` length, plus the `j`-offset into the skew
+    strip). Truncated subtraction in `ν.parts i - μ.parts i` gives
+    the natural empty type when `μ.parts i > ν.parts i`, which is
+    why no containment hypothesis is required here.
+
+    Conditions:
+
+    * **Row-weak**: along each row, entries are weakly increasing.
+    * **Skew column-strict**: entries with the same ambient column
+      index `μ.parts i₁ + j₁.val = μ.parts i₂ + j₂.val` and `i₁ < i₂`
+      are strictly increasing.
+
+    Modelled on `BallotProblemOQ03OQ01OQ01OQ01.SSYTFin n k sh` (line
+    177), generalised from straight shapes `sh : Fin k → ℕ` to skew
+    shapes `(ν, μ)`. -/
+def SkewSSYTFin (n : ℕ) (ν μ : Partition n) :=
+  { f : ((i : Fin n) × Fin (ν.parts i - μ.parts i)) → Fin n //
+    -- Rows are weakly increasing (entries non-decreasing left to right within the skew strip)
+    (∀ (i : Fin n) (j₁ j₂ : Fin (ν.parts i - μ.parts i)),
+      j₁ < j₂ → f ⟨i, j₁⟩ ≤ f ⟨i, j₂⟩) ∧
+    -- Columns are strictly increasing under the **ambient** column index
+    -- `μ.parts i + j.val`, which is the correct skew-tableau column key.
+    (∀ (i₁ i₂ : Fin n)
+       (j₁ : Fin (ν.parts i₁ - μ.parts i₁))
+       (j₂ : Fin (ν.parts i₂ - μ.parts i₂)),
+      μ.parts i₁ + j₁.val = μ.parts i₂ + j₂.val → i₁ < i₂ →
+      f ⟨i₁, j₁⟩ < f ⟨i₂, j₂⟩) }
+
+instance {n : ℕ} {ν μ : Partition n} : Fintype (SkewSSYTFin n ν μ) :=
+  Subtype.fintype _
+
+/-- **Content of a skew SSYT** — the count of cells filled with each
+    value. `content T k` = number of cells `(i, j)` with `T ⟨i, j⟩ = k`.
+
+    Returns `Fin n → ℕ` (not `Partition n`): for a generic skew SSYT
+    the count vector need not be weakly decreasing. Only the
+    sub-family of *lattice-word* skew SSYT carries content that is
+    naturally a partition (this is part of why the Littlewood-
+    Richardson rule restricts to lattice / Yamanouchi reading
+    words). -/
+def SkewSSYTFin.content {n : ℕ} {ν μ : Partition n}
+    (T : SkewSSYTFin n ν μ) (k : Fin n) : ℕ :=
+  (Finset.univ.filter
+    (fun p : (i : Fin n) × Fin (ν.parts i - μ.parts i) => T.1 p = k)).card
+
+/-! ## Part III: Reverse Row Reading Word (Fulton Convention) -/
+
+/-- **Reverse row reading word** (Fulton 1997 Ch. 5 convention):
+    each row of `T` is read **right-to-left**, and rows are
+    enumerated **top-to-bottom** (`i = 0` first).
+
+    Matches the convention used by the gallery's existing
+    `lrCoeff2` in `Hilbert15OQ02.lean:131` (verified against the 7
+    Gr(2,4) Chow ring constants from `Hilbert15OQ01.lean`).
+
+    Stanley (EC v.2 A.1.3) uses the opposite vertical order
+    (bottom-to-top). We commit to Fulton here for consistency with
+    the 2-row anchor. -/
+def SkewSSYTFin.reverseRowWord {n : ℕ} {ν μ : Partition n}
+    (T : SkewSSYTFin n ν μ) : List (Fin n) :=
+  (List.finRange n).flatMap (fun i =>
+    ((List.finRange (ν.parts i - μ.parts i)).reverse).map
+      (fun j => T.1 ⟨i, j⟩))
+
+/-! ## Part IV: Lattice (Ballot / Yamanouchi) Word Predicate -/
+
+/-- **Lattice word predicate.** A word `w : List (Fin n)` is a
+    *lattice word* (equivalently: ballot word, Yamanouchi word) if
+    at every prefix and every pair `k < k'`, the count of `k'` is
+    bounded by the count of `k`.
+
+    Restricting the universal to `p : Fin (w.length + 1)` makes the
+    predicate decidable; the unbounded version (`∀ p : ℕ`) is
+    equivalent since `w.take p = w` for `p ≥ w.length`. -/
+def isLatticeWord {n : ℕ} (w : List (Fin n)) : Prop :=
+  ∀ p : Fin (w.length + 1), ∀ k k' : Fin n, k < k' →
+    (w.take p.val).count k' ≤ (w.take p.val).count k
+
+instance {n : ℕ} (w : List (Fin n)) : Decidable (isLatticeWord w) :=
+  inferInstanceAs (Decidable
+    (∀ p : Fin (w.length + 1), ∀ k k' : Fin n, k < k' →
+      (w.take p.val).count k' ≤ (w.take p.val).count k))
+
+/-! ## Part V: `lrCoeffN_def` — the Computable LR Coefficient -/
+
+/-- **Computable LR coefficient** (Littlewood 1934; Fulton 1997
+    Ch. 5 §2). The Littlewood-Richardson coefficient `c^ν_{λ,μ}` is
+    the number of skew SSYT of shape `ν / μ` whose content is `λ`
+    and whose reverse row reading word is a lattice word.
+
+    Outside the well-definedness range `μ ⊆ ν ∧ ν.weight = λ.weight +
+    μ.weight` the coefficient is `0` by convention (no skew shape
+    exists, or no content of the prescribed total can fit). The `if`
+    guard makes the function definitionally `0` in those cases and
+    keeps the count finite and decidable.
+
+    Designed to be `def`-equal to (and ultimately replace) the
+    parent file's `axiom lrCoeffN` at
+    `Hilbert15OQ02OQ03.lean:128`. The replacement is deferred to
+    S4 once the 2-row anchoring lemma (S3) has been proved. -/
+def lrCoeffN_def {n : ℕ} (ν lam μ : Partition n) : ℕ :=
+  if μ ⊆ ν ∧ ν.weight = lam.weight + μ.weight then
+    Fintype.card { T : SkewSSYTFin n ν μ //
+                   (∀ k : Fin n, T.content k = lam.parts k) ∧
+                   isLatticeWord T.reverseRowWord }
+  else 0
+
+instance {n : ℕ} (ν lam μ : Partition n) : Decidable (0 < lrCoeffN_def ν lam μ) :=
+  Nat.decLt _ _
+
+/-- **Symmetric pruning lemma**: `lrCoeffN_def` vanishes outside the
+    LR support `μ ⊆ ν ∧ ν.weight = λ.weight + μ.weight`. Direct from
+    the `if`-guard in the definition; useful for `simp` rewriting in
+    downstream proofs. -/
+@[simp] theorem lrCoeffN_def_eq_zero_of_not_support {n : ℕ}
+    (ν lam μ : Partition n)
+    (h : ¬ (μ ⊆ ν ∧ ν.weight = lam.weight + μ.weight)) :
+    lrCoeffN_def ν lam μ = 0 := by
+  unfold lrCoeffN_def
+  exact if_neg h
+
+end Hilbert15OQ02OQ03OQ01

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/sessions/2026-05-12-s2-scaffold.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/sessions/2026-05-12-s2-scaffold.md
@@ -1,0 +1,107 @@
+# S2 Session — Combinatorial `lrCoeffN` Scaffold
+
+**Researcher**: researcher-3 (Opus 4.7), 2026-05-12
+**Phase**: ACT (scaffold)
+**Iteration**: 2
+**Output**: `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean` (~250 lines, 0 sorries, 0 axioms)
+
+## Deliverable
+
+New per-slug file containing the six S1-spec items needed to make
+`lrCoeffN` definable (and to enable the subsequent S3 2-row anchoring
+lemma).
+
+### Declarations (12 total — 6 defs, 5 instances, 1 theorem)
+
+| Symbol | Kind | Purpose |
+|---|---|---|
+| `Partition.Subset` | `def` | Pointwise containment `μ ⊆ ν` on `Partition n` |
+| `HasSubset (Partition n)` | `instance` | Enables `μ ⊆ ν` syntax |
+| `Decidable (μ ⊆ ν)` | `instance` | Required for `lrCoeffN_def`'s `if`-guard |
+| `SkewSSYTFin n ν μ` | `def` | Skew SSYT subtype (row-weak + ambient-column-strict) |
+| `Fintype (SkewSSYTFin n ν μ)` | `instance` | Needed for `Fintype.card` in `lrCoeffN_def` |
+| `SkewSSYTFin.content` | `def` | `T : SkewSSYTFin n ν μ → Fin n → ℕ` cell-count function |
+| `SkewSSYTFin.reverseRowWord` | `def` | Fulton-convention reading word via `List.flatMap` |
+| `isLatticeWord` | `def` | Ballot/Yamanouchi predicate, bounded by `Fin (w.length + 1)` |
+| `Decidable (isLatticeWord w)` | `instance` | Auto-derived from bounded `∀` over `Fin × Fin × Fin` |
+| `lrCoeffN_def` | `def` | The LR count, `if`-guarded by well-definedness |
+| `Decidable (0 < lrCoeffN_def …)` | `instance` | Via `Nat.decLt` |
+| `lrCoeffN_def_eq_zero_of_not_support` | `@[simp] theorem` | Out-of-support pruning lemma |
+
+## Design choices (worth recording for S3+)
+
+### `SkewSSYTFin` does **not** carry the `μ ⊆ ν` proof
+
+Reason: with truncated `Nat.sub` in `Fin (ν.parts i - μ.parts i)`,
+the cell sigma-type is empty wherever `μ.parts i > ν.parts i`. Adding
+a containment hypothesis to the type would force every consumer to
+thread the proof through. The `μ ⊆ ν` gate lives at `lrCoeffN_def`
+instead.
+
+### Skew column-strictness uses the **ambient** column index
+
+`μ.parts i₁ + j₁.val = μ.parts i₂ + j₂.val` is the correct
+column-coincidence condition for skew tableaux — not `j₁.val = j₂.val`
+(that's the straight-shape version, used by `SSYTFin n k sh` in
+`BallotProblemOQ03OQ01OQ01OQ01.lean:177`). Aligning entries from
+different rows requires going back to absolute Young-diagram
+coordinates.
+
+### `content` returns `Fin n → ℕ`, not `Partition n`
+
+For a generic skew SSYT the count vector need not be weakly
+decreasing — only after restricting to lattice-word reading does
+sortedness emerge (and that is part of what the LR rule itself
+proves). Forcing `Partition n` would require either a `sorry` on
+sortedness or a `Partition.ofCounts` auxiliary constructor.
+
+### `lam` instead of `λ` as the content argument name
+
+Lean 4 reserves `λ` for lambda abstractions in some contexts; the
+spelling `lam` is unambiguous and matches the Mathlib convention
+of shadowing reserved notation.
+
+### `isLatticeWord` bound by `Fin (w.length + 1)`, not `∀ p : ℕ`
+
+`w.take p = w` for `p ≥ w.length`, so the universal collapses to
+`p ≤ w.length` without loss of generality. Bounding to
+`Fin (w.length + 1)` makes the `Decidable` instance immediate via
+`inferInstanceAs`.
+
+### `reverseRowWord` via `List.flatMap`, not `List.bind`
+
+`List.bind` was renamed to `List.flatMap` in recent Mathlib — the
+new spelling is the v4.26.0 canonical one. Each row is reversed
+via `List.finRange (ν.parts i - μ.parts i) |>.reverse |>.map …`,
+which gives the Fulton right-to-left order.
+
+## What S3 will look like
+
+The S3 anchoring lemma `lrCoeffN_def_two_eq_lrCoeff2` exercises
+exactly the API surface introduced here:
+
+1. **`SkewSSYTFin 2 ν μ`** — `Fintype.card` reduces to enumerating
+   the 4 (= 2²) functions on `Fin 1 × Fin 1` (or fewer for
+   non-rectangular skew shapes); decidable case-split.
+2. **`content`** — counts a 2-cell tableau's entries; trivially
+   computes to a 2-valued vector.
+3. **`reverseRowWord`** — for a 2-row tableau, this is
+   `[T ⟨0, 0⟩, T ⟨1, 0⟩]` or shorter strings; the lattice condition
+   simplifies to `T ⟨0, 0⟩ ≤ T ⟨1, 0⟩` (the standard 2-row LR
+   ballot condition).
+4. **`isLatticeWord`** — at `n = 2` only one inequality matters
+   (`k = 0`, `k' = 1`).
+5. **`lrCoeffN_def`** — the `if`-guard reduces to a Nat equality
+   on partition weights; with the seven Gr(2,4) constants from
+   `Hilbert15OQ01.lean` the count is `decide`-checkable.
+
+S3 is consequently `decide` heavy and short (~50-80 lines).
+Whether it should be one theorem with seven `decide` invocations
+or seven separate theorems is an aesthetic call deferred to S3.
+
+## Build status
+
+Pending. Per the Hilbert-15 cluster PR convention this S2 scaffold
+ships build-pending; per-file Docker build is deferred to CI. All
+declarations are pure Mathlib wrappers (`Finset`, `List`, `Fin`,
+`Subtype.fintype`); the only theorem is a one-line `if_neg`.

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
@@ -1,10 +1,102 @@
 # Current State
 
-**Phase**: OBSERVE → ORIENT (S1 completed)
+**Phase**: ACT (S2 scaffold landed; advancing to S3 anchoring lemma)
 **Since**: 2026-05-11T22:00:00Z
-**Iteration**: 1
+**Last Updated**: 2026-05-12 (S2 scaffold by researcher-3)
+**Iteration**: 2
 
-## Current Focus
+## S2 Summary (2026-05-12, researcher-3)
+
+**Mode**: ACT (scaffold the five Mathlib-gap definitions identified
+by S1 in a fresh per-slug file, leaving the parent `Hilbert15OQ02OQ03.lean`
+axiom untouched until the S3 2-row anchoring lemma has been proved).
+
+### Deliverable
+
+New file `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean` (~250 lines,
+0 sorries, 0 axioms) containing:
+
+1. `Hilbert15OQ02OQ03OQ01.Partition.Subset` — pointwise containment
+   `μ ⊆ ν` on `Partition n` (defined via `HasSubset` instance), plus
+   the `Decidable (μ ⊆ ν)` instance via `Fintype.decidableForallFintype`.
+2. `SkewSSYTFin n ν μ` — semistandard skew Young tableau encoded as
+   the subtype of `((i : Fin n) × Fin (ν.parts i - μ.parts i)) → Fin n`
+   satisfying row-weak + **skew column-strict** (ambient column index
+   `μ.parts i + j.val`, not the inner-relative `j` itself). Truncated
+   subtraction makes the cell sigma-type empty when `μ.parts i >
+   ν.parts i`, so no `μ ⊆ ν` hypothesis is required on the type
+   itself. `Fintype` via `Subtype.fintype`.
+3. `SkewSSYTFin.content T k` — count of cells of `T` filled with
+   value `k : Fin n`; returns `ℕ` (not `Partition n`).
+4. `SkewSSYTFin.reverseRowWord` — Fulton-convention reading word
+   (each row right-to-left, rows top-to-bottom), via
+   `List.finRange n |>.flatMap ...`. Returns `List (Fin n)`.
+5. `isLatticeWord w` — predicate (synonyms: ballot, Yamanouchi)
+   bounded by `Fin (w.length + 1)` for decidability; `Decidable`
+   instance via `inferInstanceAs`.
+6. `lrCoeffN_def ν lam μ` — the LR count, with `if`-guard on
+   `μ ⊆ ν ∧ ν.weight = lam.weight + μ.weight`. `Decidable
+   (0 < lrCoeffN_def ν lam μ)` via `Nat.decLt`.
+7. `lrCoeffN_def_eq_zero_of_not_support` — `@[simp]` pruning lemma
+   for the out-of-support case.
+
+Added to `proofs/Proofs.lean` import list between `Hilbert15OQ02OQ03`
+and `Hilbert15SchubertCalculus` (alphabetic order).
+
+### Design choices
+
+* **No containment hypothesis on `SkewSSYTFin`.** With truncated
+  natural subtraction in `Fin (ν.parts i - μ.parts i)`, the cell
+  sigma-type is automatically empty wherever `μ.parts i > ν.parts i`.
+  Carrying `μ ⊆ ν` as a type parameter would force every consumer
+  to thread the proof through, and the S1 spec sketch in `state.md`
+  did not lock in a particular API. Cleaner to gate at the
+  `lrCoeffN_def` level where the well-definedness condition lives
+  anyway.
+
+* **Skew column-strict on ambient column index.** Column-strictness
+  for skew tableaux is about the ambient Young-diagram column
+  position `μ.parts i + j.val`, NOT the inner-relative `j` of the
+  skew strip. This is what distinguishes skew from straight column-
+  strictness: aligning entries in different rows requires going
+  back to absolute coordinates.
+
+* **`content` returns `ℕ`, not `Partition n`.** For a generic skew
+  SSYT, the count vector is not weakly decreasing — only after
+  restricting to lattice-word reading does sortedness emerge as
+  part of the LR-rule theorem. Forcing the return type to
+  `Partition n` would either require a `sorry` on the sortedness
+  proof or a `Partition.ofCounts`-style auxiliary construction.
+
+* **`lam` instead of `λ`.** Lean 4 reserves `λ` for lambda
+  abstractions in some contexts; the spelling `lam` is unambiguous
+  and matches Mathlib's convention for shadowing reserved
+  notation.
+
+### File deltas
+
+- `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`: NEW, 250 lines.
+- `proofs/Proofs.lean`: +1 import line.
+- Sorry count: 0.
+- Axiom count: 0.
+- Theorem count: 1 (`lrCoeffN_def_eq_zero_of_not_support`).
+- Definition count: 5 (`Partition.Subset`, `SkewSSYTFin`,
+  `SkewSSYTFin.content`, `SkewSSYTFin.reverseRowWord`,
+  `isLatticeWord`, `lrCoeffN_def`) — actually 6 if we count
+  `Partition.Subset` (yes), so 6 total.
+- Instance count: 5 (`HasSubset`, `Decidable (μ ⊆ ν)`, `Fintype`
+  on `SkewSSYTFin`, `Decidable (isLatticeWord w)`, `Decidable (0 <
+  lrCoeffN_def ν lam μ)`).
+
+### Build status
+
+Pending. Per the Hilbert-15 cluster PR convention this S2 scaffold
+ships build-pending; the per-file Docker build is deferred to CI.
+All five definitions are pure Mathlib wrappers (`Finset`, `List`,
+`Fin`, `Subtype.fintype`), and the only theorem is a one-line
+`if_neg` invocation.
+
+## Current Focus (legacy S1 — kept for history)
 
 S1 OBSERVE survey (researcher-1, 2026-05-11): mathematical
 specification + Mathlib gap inventory for replacing the axiom
@@ -42,37 +134,39 @@ exercised in S3 via the 2-row anchoring lemma.
 
 ## Next Action
 
-**S2 (next iteration)**: scaffold `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`.
+**S3 (next iteration)**: 2-row anchoring lemma
+`lrCoeffN_def_two_eq_lrCoeff2` against the 7 Gr(2,4) Chow ring
+constants verified in `Hilbert15OQ01.lean`. The anchoring lemma
+serves three roles:
 
-Concrete deliverables:
+1. Sanity-check the abstract count reduces to the existing
+   computable case.
+2. Exercise `SkewSSYTFin.reverseRowWord` and `isLatticeWord` on
+   concrete `Partition 2` data, surfacing any API gaps that the
+   S2 scaffold did not anticipate.
+3. Leave a concrete subgoal — `decide`-checkable for each of the 7
+   anchor constants — before committing to the parent-file
+   refactor (S4).
 
-1. `SkewShape n` — pair of `Partition n` with containment
-   `μ.parts i ≤ ν.parts i` and the proof that the cell sigma-type
-   `(i : Fin n) × Fin (ν.parts i - μ.parts i)` is `Fintype`.
-2. `SkewSSYTFin n ν μ` — semistandard skew Young tableau, modelled
-   on the existing `SSYTFin n k sh` in
-   `BallotProblemOQ03OQ01OQ01OQ01.lean:177` (row-weak +
-   col-strict), with content function
-   `content : SkewSSYTFin n ν μ → Partition n`.
-3. `reverseRowWord : SkewSSYTFin n ν μ → List (Fin n)` —
-   Fulton-convention reading order (each row right-to-left, rows
-   top-to-bottom).
-4. `isLatticeWord : List (Fin n) → Prop` (with
-   `Decidable` instance) — at every prefix and every pair
-   `k < k'`, count of `k` ≥ count of `k'`.
-5. `lrCoeffN_def {n : ℕ} (ν λ μ : Partition n) : ℕ` and
-   `instance : Decidable (0 < lrCoeffN_def ν λ μ)`.
-6. Module documentation block listing the three deferred items
-   (S3 anchoring lemma, S4 axiom replacement, OQ-02/OQ-03 Klyachko
-   proper).
+Suggested approach: case-split `Partition 2` data into the
+`(p, q) | p ≥ q` shape, evaluate `lrCoeffN_def` symbolically via
+`Fintype.card` reduction + Decidable enumeration, and compare
+against `lrCoeff2`'s closed-form output for each pair.
 
-Target: ~150 lines Lean, 0 sorries on the definitional content,
-≤2 sorries on instance proofs flagged for Aristotle.
+**S4 (later)**: parent-axiom replacement. Modify
+`proofs/Proofs/Hilbert15OQ02OQ03.lean:128` from `axiom lrCoeffN`
+to `def lrCoeffN := Hilbert15OQ02OQ03OQ01.lrCoeffN_def`. Verify
+`klyachko_theorem` and `lr_polytime_positivity` still typecheck;
+the `decide` call in the latter is what made the Decidable
+instance non-negotiable in S2.
+
+**S5+ (later)**: OQ-02 / OQ-03 proper — the Klyachko/Horn
+chain. Out of scope for this slug.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 2 (S1 OBSERVE, S2 scaffold)
+- Current approach attempts: 2
 - Approaches tried: 1
 
 ## Open Questions for Future Iterations

--- a/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "hilbert-15-oq-02-oq-03-oq-01",
   "title": "Formalize lrCoeffN: replace the axiomatic Littlewood-Richardson coefficient in Hilbert15OQ02OQ03 with a concrete combinatorial definition",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "scaffold",
@@ -28,21 +28,23 @@
     "goal": "Replace one axiom in Hilbert15OQ02OQ03.lean with a computable definition, exercised against existing 2-row test cases."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-05-11T22:00:00.000Z",
-    "iteration": 1,
-    "focus": "S1 (researcher-1, 2026-05-11) — OBSERVE survey. Mathematical specification (skew SSYT count via reverse row reading word + lattice word, Fulton 1997 Ch. 5 convention). Mathlib gap inventory: SemistandardYoungTableau / skew shape / reverse-row word / lattice-word predicate all absent at pinned v4.26.0. No Lean changes this iteration; 4 documentation/JSON files only.",
+    "iteration": 2,
+    "focus": "S2 (researcher-3, 2026-05-12) — ACT scaffold. New file proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean (~250 lines, 0 sorries, 0 axioms) with the six S1-spec deliverables: Partition.Subset + HasSubset/Decidable, SkewSSYTFin n ν μ + Fintype, SkewSSYTFin.content (returns Fin n → ℕ), SkewSSYTFin.reverseRowWord (Fulton convention via List.flatMap), isLatticeWord + Decidable (bounded by Fin (w.length + 1)), lrCoeffN_def + Decidable (0 < ·) instance. Added @[simp] pruning lemma lrCoeffN_def_eq_zero_of_not_support. Added Hilbert15OQ02OQ03OQ01 import to proofs/Proofs.lean.",
     "blockers": [],
-    "nextAction": "S2 (next iteration): scaffold proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean. Five definitions (SkewShape, SkewSSYTFin, reverseRowWord, isLatticeWord, lrCoeffN_def) plus Decidable / Fintype instances. Modelled on the existing gallery `SSYTFin n k sh` in BallotProblemOQ03OQ01OQ01OQ01.lean:177. Target ~150 lines, 0 sorries on type-level definitions, ≤2 sorries on instance proofs flagged for Aristotle.",
+    "nextAction": "S3: 2-row anchoring lemma lrCoeffN_def_two_eq_lrCoeff2 against the 7 Gr(2,4) Chow ring constants from Hilbert15OQ01.lean. Case-split Partition 2 data, evaluate lrCoeffN_def symbolically via Fintype.card reduction + Decidable enumeration, compare against lrCoeff2 closed-form. Three roles: (1) sanity-check abstract count reduces to existing computable case; (2) exercise reverseRowWord/isLatticeWord on concrete data; (3) leave a decide-checkable subgoal before committing to parent-file refactor (S4).",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-1, 2026-05-11): OBSERVE survey. Established that this slug is scaffolding (not research) — `lrCoeffN` is the only axiom in the parent Hilbert15OQ02OQ03.lean with a fully explicit combinatorial definition in the literature (Littlewood 1934, Fulton 1997 Ch. 5). The other two parent axioms (`admissible`, `klyachko_theorem`) are either recursive on `lrCoeffN` or are the deep Klyachko/Belkale theorem itself, so they belong to the parent slug, not here. Identified four missing Mathlib ingredients at pinned v4.26.0: SemistandardYoungTableau, skew shape encoding, reverse row reading word (Fulton convention vs Stanley convention noted), lattice-word predicate. Adopted Fulton convention for the reading word to match the existing gallery `lrCoeff2` 2-row anchor in Hilbert15OQ02.lean:131. Drafted a 4-iteration roadmap: S2 type-level definitions + lrCoeffN_def, S3 2-row anchoring lemma against Gr(2,4) Chow ring constants, S4 (optional) parent axiom replacement.",
-    "builtItems": [],
+    "progressSummary": "S1 (researcher-1, 2026-05-11): OBSERVE survey. Established this slug is scaffolding (not research) — lrCoeffN is the only axiom in Hilbert15OQ02OQ03.lean with a fully explicit literature definition (Littlewood 1934, Fulton 1997 Ch. 5). Identified four Mathlib gaps at v4.26.0: SemistandardYoungTableau, skew shape, reverse row reading word (Fulton convention), lattice-word predicate. Adopted Fulton convention to match existing 2-row anchor lrCoeff2. S2 (researcher-3, 2026-05-12): ACT scaffold. New file proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean (~250 lines, 0 sorries, 0 axioms): Partition.Subset + HasSubset/Decidable instances; SkewSSYTFin n ν μ subtype (row-weak + skew-column-strict on ambient column index μ.parts i + j.val) with Fintype; content returning Fin n → ℕ (not Partition n — sortedness emerges only on lattice-word sub-family); reverseRowWord via List.flatMap (Fulton); isLatticeWord bounded by Fin (w.length + 1) for Decidability; lrCoeffN_def gated by μ ⊆ ν ∧ ν.weight = lam.weight + μ.weight; @[simp] pruning lemma for the out-of-support case. Imported into proofs/Proofs.lean.",
+    "builtItems": [
+      "proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean — S2 scaffold (~250 lines, 0 sorries, 0 axioms): Partition.Subset + HasSubset/Decidable; SkewSSYTFin + Fintype; SkewSSYTFin.content : Fin n → ℕ; SkewSSYTFin.reverseRowWord (Fulton); isLatticeWord + Decidable; lrCoeffN_def + Decidable (0 < ·); @[simp] lrCoeffN_def_eq_zero_of_not_support pruning lemma."
+    ],
     "insights": [
       "Of the three axioms in Hilbert15OQ02OQ03.lean (lrCoeffN, admissible, klyachko_theorem), only lrCoeffN has a fully explicit combinatorial definition in the literature. Reducing it is Mathlib-style scaffolding, not research; the other two are either recursive on lrCoeffN or are the deep Klyachko/Belkale theorem itself.",
       "Use Fin n entries (not N) for SSYT, matching the gallery's existing SSYTFin n k sh in BallotProblemOQ03OQ01OQ01OQ01.lean:177. The bounded codomain makes finiteness automatic via Subtype.fintype + Pi-over-finite, no extra infrastructure needed.",
@@ -60,8 +62,7 @@
       "General-n LR coefficient — every Schur-positive theorem in the Hilbert-15 cluster currently bottoms out in `axiom lrCoeffN` in the parent file."
     ],
     "nextSteps": [
-      "S2: scaffold proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean with five definitions (SkewShape n, SkewSSYTFin n ν μ, reverseRowWord, isLatticeWord, lrCoeffN_def) and the Decidable / Fintype instances. Model on SSYTFin n k sh (gallery's straight-shape analog) from BallotProblemOQ03OQ01OQ01OQ01.lean:177. Target ~150 lines, 0 sorries on definitions, ≤2 routine sorries flagged for Aristotle.",
-      "S3: prove lrCoeffN_def_two_eq_lrCoeff2 — the 2-row anchoring lemma. Exercises the abstract count on the 7 Gr(2,4) Chow ring constants verified in Hilbert15OQ02.lean. Bridges the new abstract definition to the existing computable lrCoeff2.",
+      "S3: prove lrCoeffN_def_two_eq_lrCoeff2 — the 2-row anchoring lemma. Exercises the abstract count on the 7 Gr(2,4) Chow ring constants verified in Hilbert15OQ02.lean. Bridges the new abstract definition to the existing computable lrCoeff2. Approach: case-split Partition 2 data into (p, q) | p ≥ q shape, evaluate lrCoeffN_def symbolically via Fintype.card reduction + Decidable enumeration, compare against lrCoeff2's closed form.",
       "S4 (optional): refactor parent Hilbert15OQ02OQ03.lean — replace `axiom lrCoeffN` with `def lrCoeffN := lrCoeffN_def`. Verify nothing downstream breaks (the axiom was only used in klyachko_theorem's statement and in lr_polytime_positivity's decide invocation)."
     ]
   },


### PR DESCRIPTION
## Summary

S1 (researcher-1, PR #17848) laid out a 6-item spec for replacing the axiomatic `lrCoeffN` in `Hilbert15OQ02OQ03.lean:128` with a Fulton-style combinatorial definition. This **S2** lands all six in a new per-slug file.

### New file `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean` (247 lines, 0 sorries, 0 axioms)

- **`Partition.Subset`** + `HasSubset` + `Decidable (μ ⊆ ν)` instances.
- **`SkewSSYTFin n ν μ`** — skew SSYT subtype on the cell sigma `(i : Fin n) × Fin (ν.parts i - μ.parts i) → Fin n`, row-weak + **ambient**-column-strict (key `μ.parts i + j.val`, not inner-relative `j`). Truncated `Nat.sub` makes the cell type empty wherever `μ.parts i > ν.parts i` ⇒ no containment hypothesis on the type. `Fintype` via `Subtype.fintype`.
- **`SkewSSYTFin.content`** — `Fin n → ℕ` cell-count (not `Partition n`: sortedness emerges only on the lattice-word sub-family).
- **`SkewSSYTFin.reverseRowWord`** — Fulton convention (each row right-to-left, rows top-to-bottom) via `(List.finRange n).flatMap (… List.finRange (…) |>.reverse |>.map …)`.
- **`isLatticeWord`** — ballot / Yamanouchi predicate, bounded by `Fin (w.length + 1)` for `Decidable` via `inferInstanceAs`.
- **`lrCoeffN_def`** — `if`-guarded by `μ ⊆ ν ∧ ν.weight = lam.weight + μ.weight`. `Decidable (0 < lrCoeffN_def …)` via `Nat.decLt` (needed for parent's `decide`-based `lr_polytime_positivity`).
- **`@[simp] lrCoeffN_def_eq_zero_of_not_support`** — one-line `if_neg` pruning lemma.

### Other deltas

- `proofs/Proofs.lean`: +1 import, alphabetic between `Hilbert15OQ02OQ03` and `Hilbert15SchubertCalculus`.
- `state.md` → S2 / iteration 2 / ACT phase.
- `src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json` → phase ACT, iteration 2, focus / nextAction / builtItems / nextSteps regenerated.
- Session note added.

### Next action (S3)

2-row anchoring lemma `lrCoeffN_def_two_eq_lrCoeff2` against the 7 Gr(2,4) Chow ring constants in `Hilbert15OQ01.lean`. Case-split `Partition 2`, evaluate `lrCoeffN_def` via `Fintype.card` reduction + `decide`, compare to `lrCoeff2`. Exercises every API introduced here.

## Test plan

- [ ] CI Docker build of `Proofs.Hilbert15OQ02OQ03OQ01` (deferred — `(build pending)` per Hilbert-15 cluster convention).
- [x] `List.flatMap` confirmed in v4.26.0 by gallery usage: `Erdos1099Problem.lean:598`.
- [x] `List.finRange` confirmed in v4.26.0: import `Mathlib.Data.List.FinRange`, also used in `DescartesRuleOfSignsOQ02.lean`.
- [x] Modelled on the existing gallery `SSYTFin n k sh` straight-shape analog in `BallotProblemOQ03OQ01OQ01OQ01.lean:177` (Fintype via `Subtype.fintype`).
- [x] No new axioms, no new sorries (file totals: 0 / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)