### PR TITLE
research(erdos-szekeres-oq-03): S1 OBSERVE → ORIENT — hypergraph Ramsey survey + Lean API design (no Lean changes)

### DIFF
--- a/research/problems/erdos-szekeres-oq-03/knowledge.md
+++ b/research/problems/erdos-szekeres-oq-03/knowledge.md
@@ -1,0 +1,179 @@
+# Knowledge Base: erdos-szekeres-oq-03
+
+Survey notes for the hypergraph-Ramsey generalization of Erdős–Szekeres.
+
+---
+
+## Problem Understanding
+
+### The diagonal hypergraph Ramsey number `R_k(s,t)`
+
+Fix `k ≥ 2`. The Ramsey number `R_k(s,t)` is the least `n` such that for every
+2-coloring `χ : [n]^{(k)} → {0,1}` of the `k`-element subsets of `{1,…,n}`,
+there is either an `s`-subset whose `k`-subsets are all `0`-colored, or a
+`t`-subset whose `k`-subsets are all `1`-colored. The *diagonal* case is
+`s = t`. We write `R_k(s) := R_k(s,s)`.
+
+Special cases already in the gallery / Mathlib:
+
+* `k = 2`, `s = t`: graph Ramsey `R(s,s)`. Mathlib defines it as
+  `SimpleGraph.ramseyNumber` but the standard upper bound
+  `R(s,s) ≤ \binom{2s-2}{s-1}` is not yet packaged as a clean theorem there.
+* `k = 2`, *sequence* refinement (one order, one coloring): the classical
+  Erdős–Szekeres `(r-1)(s-1)+1` bound, formalized in `Proofs/ErdosSzekeres.lean`.
+* `k = 1`: `R_1(s,t) = s + t - 1` is the pigeonhole principle.
+
+### Why hypergraph Ramsey is the "right" generalization
+
+The Erdős–Szekeres theorem says: among `n` distinct real numbers, an
+increasing subsequence of length `r` or a decreasing subsequence of length `s`
+exists when `n ≥ (r-1)(s-1)+1`. Re-coloring the pair `(i,j)` by
+`χ(i,j) = [a_i < a_j]` turns this into a *2-coloring of the 2-subsets of
+`{1,…,n}`* — i.e., a graph 2-coloring. So Erdős–Szekeres is a special case of
+the graph Ramsey theorem, with one direction of the bipartite duality squeezed
+out by the linear order on `a_i`.
+
+The hypergraph generalization replaces pairs `(i,j)` by `k`-subsets, and
+"monotone subsequence" by "monochromatic clique." Geometrically: a `k`-subset
+in convex position generalizes a 2-subset that is increasing.
+
+---
+
+## Classical Results (Literature)
+
+### Existence (OQ-03a): Ramsey 1930
+
+Frank Ramsey's original theorem (1930) shows `R_k(s,t)` is finite for all
+`k, s, t`. Proof: induct on `s + t` for fixed `k`; the base case `s ≤ k` or
+`t ≤ k` is trivial, and the induction step uses a single-vertex partition
+argument:
+
+> Take any vertex `v ∈ [n]`. For each `(k-1)`-subset `S ⊆ [n] \ {v}`, color it
+> by the color of `S ∪ {v}`. By induction on `s + t`, the resulting
+> `(k-1)`-coloring has either a `0`-monochromatic `(s-1)`-clique `T_0` (extend
+> to an `s`-clique via `v`) or a `1`-monochromatic `(t-1)`-clique `T_1`
+> (extend symmetrically).
+
+The induction on `k` reduces the case `k+1` to the case `k` via the same
+neighborhood trick. This is the "two-layer" induction that gives the
+Erdős–Rado upper bound.
+
+### Upper bound (OQ-03b): Erdős–Rado 1952
+
+**Theorem (Erdős–Rado).** For `k ≥ 2` and `s ≥ k`,
+`R_k(s,s) ≤ tower_{k-1}(c_k · s)` for an explicit constant `c_k`.
+
+Recursive structure: `R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1` (the
+"two-step" neighborhood iteration). Unwinding this against the
+`R_1(s,t) = s+t-1` base and `R_2(s,s) ≤ 2^{2s}` gives:
+
+* `R_2(s,s) ≤ 4^s` (Erdős–Szekeres 1935; Mathlib's `ramseyNumber` agrees).
+* `R_3(s,s) ≤ 2^{c s^2}` (Erdős–Rado).
+* `R_4(s,s) ≤ 2^{2^{c s^2}}` (Erdős–Rado).
+* In general, `R_k(s,s)` is bounded by a tower of height `k-1`.
+
+### Lower bound (OQ-03c): Erdős–Hajnal stepping-up
+
+**Lemma (Erdős–Hajnal 1972).** For `k ≥ 3`, if `R_{k-1}(s,s) > N` then
+`R_k(2s-1, 2s-1) > 2^N`.
+
+The construction: given a `(k-1)`-coloring `χ` of `[N]^{(k-1)}` with no
+monochromatic `s`-clique, build a `k`-coloring `χ'` of `[2^N]^{(k)}` as
+follows. View each `i ∈ [2^N]` as a 0/1 string of length `N`. For a `k`-subset
+`{i_1 < i_2 < … < i_k}`, let `d_j` be the first position where `i_j` and
+`i_{j+1}` differ. Color `{i_1,…,i_k}` by `χ({d_1, …, d_{k-1}})` if `d_1 <
+… < d_{k-1}` or `d_1 > … > d_{k-1}`; otherwise color it by a parity
+fix-up rule. One checks no monochromatic `(2s-1)`-clique exists in `χ'`.
+
+For `k ≥ 4` this gives `R_k(s,s) ≥ tower_{k-2}(c'_k s^2)`. For `k = 3` the
+best known lower bound `R_3(s,s) ≥ 2^{cs}` does *not* come from stepping-up
+(stepping-up needs `k-1 ≥ 2`, i.e. `k ≥ 3`, but the resulting bound matches
+the upper one tower lower).
+
+### State of `R_3(s,s)`
+
+This is the canonical open Ramsey-theoretic problem at the boundary of
+"hard but reachable":
+
+* Lower: `R_3(s,s) ≥ 2^{c s}` (Erdős–Hajnal 1972, refined by Conlon–Fox–Sudakov).
+* Upper: `R_3(s,s) ≤ 2^{c s^2 \log s}` (Conlon–Fox–Sudakov 2010).
+* **Conjecture.** Erdős conjectured `R_3(s,s) ≤ 2^{c s^2}` (matching the
+  stepping-up lower bound up to constants). This would imply
+  `R_3(s,s) = 2^{Θ(s^2)}`.
+
+---
+
+## Mathlib Status
+
+* `SimpleGraph.ramseyNumber` (`Mathlib.Combinatorics.SimpleGraph.Ramsey`):
+  defines `R(s,t)` for graphs. Some specialized bounds for off-diagonal cases
+  exist but the diagonal `R(s,s) ≤ \binom{2s-2}{s-1}` bound is not yet in
+  Mathlib as a clean theorem.
+* `Finset.powersetCard k` and `Sym.card` give the right combinatorial
+  primitives for `[n]^{(k)}`.
+* `Nat.choose`, `Nat.iterate` (for `tower_k`) are present.
+* No `RamseyK` / `hypergraphRamseyNumber` definition currently — this is the
+  first piece of new infrastructure OQ-03 would add.
+
+### Suggested API surface
+
+```lean
+namespace RamseyK
+def IsMonochromatic {n k : ℕ} (χ : Finset (Fin n) → Bool)
+    (S : Finset (Fin n)) (c : Bool) : Prop := ...
+
+def IsRamsey (n k s t : ℕ) : Prop :=
+  ∀ χ : Finset (Fin n) → Bool, ...
+
+def ramseyNumber (k s t : ℕ) : ℕ := Nat.find ...
+
+theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
+    ∃ n, IsRamsey n k s t := ...
+
+theorem erdos_rado_upper (k s : ℕ) (hk : 2 ≤ k) :
+    ramseyNumber k s s ≤ tower (k - 1) (c_k * s) := ...
+end RamseyK
+```
+
+This would also let us redefine `SimpleGraph.ramseyNumber` as `ramseyNumber 2`
+modulo a small wrapper (long-term cleanup, not part of OQ-03).
+
+---
+
+## Insights
+
+* **Reduction to `erdos_szekeres_tight_axiom`.** The `k = 2` diagonal lower
+  bound `R_2(s,s) ≥ 2^{s/2}` (Erdős 1947) discharges
+  `erdos_szekeres_tight_axiom` once OQ-03c is proved at `k = 2`. The
+  probabilistic / random-graph argument is independently formalizable and
+  would be a nicer reduction.
+* **Tower function in Lean.** `Nat.iterate (· * 2) k 1 = 2^k`; the general
+  tower is `fun s => Nat.iterate (2 ^ ·) (k-1) s`. Mathlib's existing
+  `Nat.iterate` API suffices; no new tower definitions needed.
+* **`Sym (Fin n) k` vs `Finset (Fin n)` filtered by `card = k`.** Both work
+  for `[n]^{(k)}`; `Sym` is cleaner for combinatorial bijections but
+  `Finset.powersetCard` is more idiomatic for "all `k`-subsets of a set."
+  Recommend `Finset.powersetCard` because it composes with `Finset.card_*`
+  lemmas.
+* **Why this is *not* solved by a generic `Ramsey` formalization.** The
+  existing `SimpleGraph.ramseyNumber` is graph-specific; the inductive
+  structure of `R_k` requires `k`-uniform hypergraphs as a separate concept,
+  and Mathlib does not have `Hypergraph` yet (only `SimpleGraph`).
+
+---
+
+## Dead Ends (none yet — first session)
+
+---
+
+## Next-Session Action Items
+
+1. **Define `RamseyK.ramseyNumber k s t`** (Lean): smallest `n` such that every
+   2-coloring of `(Finset.range n).powersetCard k` is monochromatic-witnessed.
+2. **Prove `k = 1` case** as a sanity check: `ramseyNumber 1 s t = s + t - 1`
+   via pigeonhole. ~30 lines.
+3. **State `ramsey_existence`** as a theorem with `sorry`. The proof
+   structure (two-layer induction on `k` and `s + t`) is standard and well-
+   suited to an Aristotle companion if the base cases are clean.
+4. **Document the reduction `erdos_szekeres_tight_axiom ⇐ ramseyNumber 2 s s ≥ \binom{2s-2}{s-1}`** in `ErdosSzekeres.lean`'s docstring (no
+   code change, just a forward pointer).

--- a/research/problems/erdos-szekeres-oq-03/problem.md
+++ b/research/problems/erdos-szekeres-oq-03/problem.md
@@ -1,0 +1,120 @@
+# Problem: Ramsey Numbers for k-Uniform Hypergraphs
+
+## Statement
+
+### Plain Language
+
+The Erdős–Szekeres theorem on monotone subsequences is the *graph* Ramsey number
+`R(r,s)` specialized to a total order: color the pair `(i,j)` (with `i<j`)
+*red* if `a_i < a_j` and *blue* otherwise. The theorem states `R(r,s) ≤ (r-1)(s-1)+1`
+for sequences. The natural higher-dimensional generalization asks:
+
+> For each `k ≥ 2`, what is the asymptotic growth of the k-uniform hypergraph
+> Ramsey number `R_k(s,t)` — the smallest `n` such that every 2-coloring of
+> the k-element subsets of `{1,…,n}` contains a monochromatic clique of size
+> `s` (red) or `t` (blue)?
+
+Two refinements that directly extend Erdős–Szekeres:
+
+* **Geometric ES_d(n).** The smallest `N` such that any `N` points in general
+  position in `ℝ^d` contain `n` in *convex position* (i.e., the vertices of an
+  `n`-element convex polytope). Erdős–Szekeres (1935) is the `d=2` case.
+* **Order-type ES.** For an injective `f : Fin n → ℝ^d`, count the longest
+  `(d+1)`-monotone chain (a substitute for monotonic subsequences when `d>1`).
+
+### Formal Statement
+
+Let `R_k : ℕ → ℕ → ℕ` denote the diagonal `k`-uniform hypergraph Ramsey number,
+i.e. `R_k(s,t) = min { n | ∀ χ : [n]^{(k)} → {0,1}, ∃ S ⊆ [n], |S|=s ∧ χ ≡ 0 on [S]^{(k)},
+                                              ∨ ∃ S ⊆ [n], |S|=t ∧ χ ≡ 1 on [S]^{(k)} }`.
+
+The OQ-03 question packages two well-posed sub-goals:
+
+$$
+\boxed{
+\begin{array}{rl}
+\text{(OQ-03a)} & R_k(s,s) \text{ is finite for all } k \geq 2,\ s \geq k.\\[4pt]
+\text{(OQ-03b)} & R_k(s,s) \text{ admits the Erdős–Rado upper bound}\\
+ & R_k(s,s) \leq \mathrm{tower}_{k-1}(c_k \cdot s) \text{ for some } c_k > 0,\\[4pt]
+\text{(OQ-03c)} & R_k(s,s) \geq \mathrm{tower}_{k-2}(c'_k \cdot s^2) \\
+ & \text{(Erdős–Hajnal stepping-up; assumes } k \geq 4\text{).}
+\end{array}
+}
+$$
+
+Here `tower_0(x) = x` and `tower_{n+1}(x) = 2^{tower_n(x)}`.
+
+For `k = 2` (graphs) the bound `R_2(s,s) ≤ \binom{2s-2}{s-1}` is the classical
+Erdős–Szekeres bound; the existing `proofs/Proofs/ErdosSzekeres.lean` formalizes
+the `(r-1)(s-1)+1` *sequence* refinement of this.
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - erdos
+  - combinatorics
+  - ramsey-theory
+  - hypergraphs
+  - pigeonhole
+  - erdos-rado
+  - stepping-up
+  - wiedijk-100
+  - seeker-selected
+```
+
+**Significance**: 7/10
+**Tractability**: 6/10
+
+OQ-03a alone is tractable in Lean modulo Mathlib's existing finite-Ramsey
+machinery; OQ-03b is a clean induction once OQ-03a is set up; OQ-03c requires
+the Erdős–Hajnal stepping-up construction, which is the harder half.
+
+## Why This Matters
+
+1. **Cornerstone of Ramsey theory.** Hypergraph Ramsey numbers control the
+   "Hales–Jewett style" partition theorems — every monotone-subsequence
+   refinement of pigeonhole has a hypergraph analogue.
+2. **Open conjecture territory.** Even `R_3(s,s)` is one of the major open
+   problems: the best bounds are `2^{c s} ≤ R_3(s,s) ≤ 2^{c s^2 \log s}`
+   (Conlon–Fox–Sudakov 2010). Closing the gap would be a major advance.
+3. **Geometric ES_d.** The geometric Erdős–Szekeres ES(n) ≤ \binom{2n-4}{n-2}+1
+   (Tóth–Valtr 2005) and ES(n) ≥ 2^{n-2}+1 (Erdős–Szekeres conjecture, open in
+   general; resolved up to constants by Suk 2017). Higher-dimensional ES_d(n)
+   sits between these and the hypergraph Ramsey numbers.
+4. **Reduction targets for `proofs/Proofs/ErdosSzekeres.lean`.**
+   `erdos_szekeres_tight_axiom` (currently axiomatized) is precisely the
+   lower-bound half of `R_2`. A clean `R_k` framework would let us discharge
+   that axiom as a corollary of the `k=2` case of OQ-03c.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `erdos-szekeres` | Sequence version (k=2). 2 axioms (`erdos_szekeres_existence_axiom`, `erdos_szekeres_tight_axiom`); the `_tight_axiom` is the diagonal lower bound for `R_2`, which OQ-03c specializes when `k=2`. |
+| `erdos-szekeres-oq-01` | Stub — related OQ on the original theorem. |
+| `ramsey` (if/when added) | Standard graph Ramsey numbers `R_2(s,t)`, which `R_k` generalizes. Mathlib does not currently expose `R_k` for `k > 2`. |
+| `pigeonhole` | Underlying tool for the `k = 2` base case of the Erdős–Rado induction. |
+
+## Approach Sketch (for Lean formalization)
+
+1. **Define `kColoring n k`** as `Finset (Fin n) → Bool` restricted to `k`-element
+   subsets, i.e. functions `χ : { s : Finset (Fin n) // s.card = k } → Bool`.
+2. **Define `RamseyK k s t n`** as the proposition "every `k`-coloring of
+   `[n]^{(k)}` has a monochromatic `s`-clique or `t`-clique"; let
+   `ramseyNumberK k s t` be the least such `n`.
+3. **OQ-03a — finiteness.** Induct on `k`: the `k = 2` case is the standard
+   Ramsey number, available as `SimpleGraph.ramseyNumber` in Mathlib. The
+   inductive step uses Erdős–Rado's "neighborhood-tree" construction.
+4. **OQ-03b — Erdős–Rado upper bound.** Tower-type induction on the same
+   structure: each step multiplies `n` by `R_{k-1}(s,s)`, so we get
+   `R_k(s,s) ≤ 2^{R_{k-1}(s-1,s-1) \cdot O(s)}`.
+5. **OQ-03c — stepping-up.** Encode a `k`-coloring of `[2^N]^{(k)}` as a
+   `(k+1)`-coloring of `[N]^{(k+1)}` via the binary-representation construction
+   of Erdős–Hajnal. Needs careful index arithmetic in `Fin`.
+
+Steps 1–3 are realistic for a few research sessions; step 4 is one session if
+step 3 lands; step 5 is the harder half and may need its own OQ.

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,0 +1,78 @@
+# Current State
+
+**Phase**: ORIENT
+**Since**: 2026-05-12 (S1 OBSERVE → ORIENT, researcher-8)
+**Iteration**: 1
+
+## Current Focus
+
+Session 1 (S1, researcher-8, 2026-05-12): Survey of the hypergraph
+Ramsey-number literature for the OQ-03 generalization of Erdős–Szekeres.
+No Lean changes — pure OBSERVE/ORIENT pass to set up future ACT sessions.
+
+Output of this session:
+
+* `problem.md` — formal restatement of OQ-03 as three sub-goals
+  (existence OQ-03a, Erdős–Rado upper bound OQ-03b, Erdős–Hajnal lower bound
+  OQ-03c) with explicit tower-function bounds.
+* `knowledge.md` — literature survey covering Ramsey (1930), Erdős–Rado
+  (1952), Erdős–Hajnal (1972) stepping-up, and Conlon–Fox–Sudakov (2010);
+  Mathlib API audit; suggested `RamseyK.ramseyNumber` API surface.
+* This `state.md` update advancing NEW → ORIENT and pinning the
+  S2 next-action.
+
+## Active Approach
+
+Three-step Lean formalization plan (S2 → S4):
+
+1. **S2 (ACT-A).** Define `RamseyK.IsRamsey n k s t` and
+   `RamseyK.ramseyNumber k s t`. Prove the `k = 1` sanity check
+   `ramseyNumber 1 s t = s + t - 1` via pigeonhole (~30 lines of Lean,
+   no new Mathlib dependencies). State `ramsey_existence` as a sorry.
+2. **S3 (ACT-B).** Discharge `ramsey_existence` via the two-layer
+   neighborhood induction. Base case `k = 2` reuses
+   `SimpleGraph.ramseyNumber`'s existence proof (or re-proves it inline
+   using pigeonhole). Inductive step uses the "fix a vertex, induct on
+   `(k-1)`-coloring of neighborhood" construction.
+3. **S4 (ACT-C).** State `erdos_rado_upper` as `ramseyNumber k s s ≤
+   tower (k-1) (c_k * s)`. Likely needs an explicit `c_k` (e.g.
+   `c_k = 4 * (k-1)!`); the tower function can be defined via
+   `Nat.iterate (2 ^ ·) (k-1) (c_k * s)` so no new tower API.
+   Proof: follow the Erdős–Rado recursive bound
+   `R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1`, unwound.
+
+S5+ would tackle the stepping-up lower bound (OQ-03c), but only after S4
+lands. The lower bound is harder and may need its own sub-OQ.
+
+## Blockers
+
+None for S2 (definitions are straightforward Mathlib boilerplate).
+
+For S3/S4: `Hypergraph` is not yet in Mathlib, so we work directly with
+`Finset (Fin n)` filtered by `card = k` (`Finset.powersetCard`). This is
+adequate but verbose.
+
+## Next Action
+
+**S2 ACT-A.** Create `proofs/Proofs/RamseyHypergraph.lean` with:
+
+* `def IsMonochromatic {n k : ℕ} (χ : Finset (Fin n) → Bool) (S : Finset (Fin n)) (c : Bool) : Prop`
+* `def IsRamsey (n k s t : ℕ) : Prop`
+* `def ramseyNumber (k s t : ℕ) : ℕ := Nat.find ...`
+* `lemma ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) : ramseyNumber 1 s t = s + t - 1`
+* `theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) : ∃ n, IsRamsey n k s t := by sorry`
+
+Add the gallery shim: `src/data/research/problems/erdos-szekeres-oq-03.json`
+should list this new file under `leanFiles` (or leave unchanged if the
+file is not yet created; S2 will add the entry).
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (literature survey + Lean API design)
+
+## Outcome of S1
+
+ORIENT complete. Three sub-goals (existence, Erdős–Rado upper, Erdős–Hajnal
+lower) cleanly stated; Mathlib gaps identified; S2 ACT-A is unblocked.

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -1,0 +1,114 @@
+{
+  "slug": "erdos-szekeres-oq-03",
+  "title": "Ramsey Numbers for k-Uniform Hypergraphs (generalization of Erdős–Szekeres)",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "R_k(s,t) := \\min\\{ n : \\forall \\chi : [n]^{(k)} \\to \\{0,1\\}, \\exists S \\subseteq [n] \\text{ with } |S|=s,\\ \\chi \\equiv 0 \\text{ on } [S]^{(k)},\\ \\text{or } |S|=t,\\ \\chi \\equiv 1 \\text{ on } [S]^{(k)} \\}.\\ \\text{OQ-03 packages: (a) finiteness of } R_k(s,t),\\ \\text{(b) Erdős–Rado } R_k(s,s) \\le \\mathrm{tower}_{k-1}(c_k s),\\ \\text{(c) Erdős–Hajnal stepping-up } R_k(s,s) \\ge \\mathrm{tower}_{k-2}(c'_k s^2) \\text{ for } k \\ge 4.",
+    "plain": "Generalize the Erdős–Szekeres theorem from sequences (k=2) to k-uniform hypergraphs: for the diagonal hypergraph Ramsey number R_k(s,s) — the smallest n such that every 2-coloring of the k-subsets of {1,…,n} contains a monochromatic s-clique — establish (a) finiteness for all k ≥ 2, s ≥ k; (b) the Erdős–Rado tower-type upper bound; (c) the Erdős–Hajnal stepping-up lower bound.",
+    "whyMatters": [
+      "Closes the natural higher-uniformity generalization of Erdős–Szekeres; the k=2 case is the existing gallery proof and Mathlib's SimpleGraph.ramseyNumber.",
+      "Provides a clean Lean reduction target for erdos_szekeres_tight_axiom (currently axiomatized in Proofs/ErdosSzekeres.lean).",
+      "The k=3 case is one of the major open problems in Ramsey theory: lower 2^{cs} vs upper 2^{cs^2 log s} (Conlon–Fox–Sudakov 2010)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Ramsey (1930): R_k(s,t) is finite for all k, s, t with k ≤ s, t.",
+      "Erdős–Rado (1952): R_k(s,s) ≤ tower_{k-1}(c_k s) via the two-layer neighborhood induction.",
+      "Erdős–Hajnal (1972): stepping-up gives R_{k+1}(2s-1, 2s-1) ≥ 2^{R_k(s,s) - 1} for k ≥ 3.",
+      "Conlon–Fox–Sudakov (2010): R_3(s,s) ≤ 2^{c s^2 log s}, currently the best upper bound for k=3."
+    ],
+    "open": [
+      "Exact growth of R_3(s,s): gap between 2^{cs} lower and 2^{cs^2 log s} upper. Erdős conjectured R_3(s,s) ≤ 2^{cs^2}.",
+      "Whether stepping-up can be extended to k=3 to give a tower lower bound at uniformity 3."
+    ],
+    "goal": "Lean-formalize the finiteness theorem (OQ-03a) and the Erdős–Rado upper bound (OQ-03b) via a new RamseyK.ramseyNumber API, then state the stepping-up lower bound (OQ-03c) as a theorem with sorry."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-05-12",
+    "iteration": 1,
+    "focus": "S1 OBSERVE → ORIENT (researcher-8): literature survey + Lean API design. No Lean changes this session.",
+    "blockers": [],
+    "nextAction": "S2 ACT-A: create proofs/Proofs/RamseyHypergraph.lean with RamseyK.ramseyNumber definition, the k=1 pigeonhole base case, and ramsey_existence stated as a sorry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals — (a) finiteness, (b) Erdős–Rado tower upper bound, (c) Erdős–Hajnal stepping-up lower bound — with explicit Lean API surface for a new RamseyK module. Identified Mathlib gap: no Hypergraph / RamseyK definition yet; existing SimpleGraph.ramseyNumber covers only k=2.",
+    "builtItems": [
+      "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals.",
+      "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey (Ramsey 1930, Erdős–Rado 1952, Erdős–Hajnal 1972, Conlon–Fox–Sudakov 2010) + Mathlib API audit + suggested RamseyK API surface.",
+      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced NEW → ORIENT with S2 next-action pinned."
+    ],
+    "insights": [
+      "OQ-03 cleanly factors into existence + upper + lower bounds; the existence and upper bound share the same two-layer neighborhood induction.",
+      "The k=1 case ramseyNumber 1 s t = s + t - 1 is direct pigeonhole and serves as a clean sanity-check theorem for the new API (~30 lines).",
+      "The lower-bound half (OQ-03c) is the harder direction and likely warrants its own sub-OQ once OQ-03a/b land.",
+      "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c."
+    ],
+    "mathlibGaps": [
+      "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
+      "No Hypergraph structure; we work with Finset.powersetCard k instead.",
+      "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
+    ],
+    "nextSteps": [
+      "S2: implement RamseyK module with definitions + k=1 pigeonhole + ramsey_existence sorry.",
+      "S3: discharge ramsey_existence by the two-layer induction.",
+      "S4: state erdos_rado_upper as a tower-function bound and prove it by unwinding the recursive R_k ≤ R_{k-1}(...) inequality.",
+      "S5: spawn the stepping-up lower bound as a separate sub-OQ if S4 lands cleanly."
+    ]
+  },
+  "tags": [
+    "erdos",
+    "combinatorics",
+    "ramsey-theory",
+    "hypergraphs",
+    "pigeonhole",
+    "erdos-rado",
+    "stepping-up",
+    "wiedijk-100",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-szekeres"
+  ],
+  "references": {
+    "papers": [
+      "P. Erdős, G. Szekeres, A combinatorial problem in geometry, Compositio Math. 2 (1935) 463–470.",
+      "P. Erdős, R. Rado, A partition calculus in set theory, Bull. Amer. Math. Soc. 62 (1956) 427–489.",
+      "P. Erdős, A. Hajnal, On Ramsey like theorems: problems and results, in Combinatorics (Proc. Conf. Combinatorial Math., Oxford 1972), 123–140.",
+      "D. Conlon, J. Fox, B. Sudakov, Hypergraph Ramsey numbers, J. Amer. Math. Soc. 23 (2010) 247–266.",
+      "A. Suk, On the Erdős–Szekeres convex polygon problem, J. Amer. Math. Soc. 30 (2017) 1047–1053."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Ramsey",
+      "Mathlib.Data.Finset.Powerset (Finset.powersetCard)",
+      "Mathlib.Data.Sym.Basic (Sym (Fin n) k as alternative model)"
+    ]
+  },
+  "started": "2026-05-12T04:48:16.447Z",
+  "lastUpdate": "2026-05-12T15:00:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ErdosSzekeres.lean",
+      "filename": "ErdosSzekeres.lean",
+      "lineCount": 281,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ErdosSzekeres.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Pristine tier-B slug `erdos-szekeres-oq-03` ("How does this generalize to higher dimensions? — Ramsey numbers for hypergraphs"). Session 1 is a documentation-only OBSERVE → ORIENT pass: literature survey, OQ decomposition, and Lean API design. **No Lean changes.**

## Progress

Four files added (no edits to existing files):

* `research/problems/erdos-szekeres-oq-03/problem.md` — formal OQ statement, decomposed into three sub-goals (OQ-03a finiteness, OQ-03b Erdős–Rado upper bound, OQ-03c Erdős–Hajnal stepping-up lower bound), with explicit tower-function bounds.
* `research/problems/erdos-szekeres-oq-03/knowledge.md` — survey of Ramsey (1930), Erdős–Rado (1952), Erdős–Hajnal (1972), and Conlon–Fox–Sudakov (2010); Mathlib API audit; suggested `RamseyK.ramseyNumber` API surface.
* `research/problems/erdos-szekeres-oq-03/state.md` — phase NEW → ORIENT; three-step formalization plan (S2 → S4).
* `src/data/research/problems/erdos-szekeres-oq-03.json` — populated `problemStatement`, `knownResults`, `knowledge` (insights / mathlib gaps / next steps), `references` (5 papers), and `relatedProofs`.

## Key Findings

* **Three sub-goals.** OQ-03 cleanly factors as (a) finiteness of `R_k(s,t)`; (b) Erdős–Rado `R_k(s,s) ≤ tower_{k-1}(c_k · s)`; (c) Erdős–Hajnal `R_k(s,s) ≥ tower_{k-2}(c'_k · s^2)` for `k ≥ 4`. (a) and (b) share the same two-layer neighborhood induction; (c) is the harder direction.
* **Reduction target.** `erdos_szekeres_tight_axiom` in `Proofs/ErdosSzekeres.lean` (currently axiomatized) is precisely the `k = 2` specialization of OQ-03c. Future work at `k = 2` would discharge that axiom.
* **Mathlib gap.** No `Hypergraph` or general `RamseyK` definition — only `SimpleGraph.ramseyNumber` for `k = 2`. The S2 work introduces a new `RamseyHypergraph.lean` module modeled on `Finset.powersetCard`.
* **Open conjecture territory.** The diagonal case `R_3(s,s)` has lower `2^{cs}` (Erdős–Hajnal) vs upper `2^{c s^2 log s}` (Conlon–Fox–Sudakov 2010). Erdős conjectured `R_3(s,s) = 2^{Θ(s^2)}`.

## Status

**Outcome**: progress (ORIENT complete — survey + API design)
**Phase advance**: NEW → ORIENT
**Files modified**: 0 Lean files, 4 documentation files
**Sorries delta**: 0 (no Lean changes)
**Axioms delta**: 0 (no Lean changes)

**Next Steps (S2 ACT-A)**: Create `proofs/Proofs/RamseyHypergraph.lean` with `RamseyK.ramseyNumber` definition, the `k = 1` pigeonhole base case `ramseyNumber 1 s t = s + t - 1` (~30 lines), and `ramsey_existence` stated as a sorry.

🤖 Generated by researcher-8