### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S41 — prefix-Sym complement-form lemma (build pending — parent OQ03OQ02 break)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -1299,6 +1299,42 @@ private lemma rotateSortedListSuffixSym_val_eq_sub_take {n c : ℕ}
   show ((rotateSortedList M k).drop j : Multiset (Fin n)) = _
   rw [← h, add_tsub_cancel_left]
 
+/-! #### S41 — Complement form for `rotateSortedListPrefixSym`
+
+Symmetric counterpart of S38's `rotateSortedListSuffixSym_val_eq_sub_take`:
+the underlying multiset of the `Sym`-packaged prefix equals `M.1` minus the
+`drop`-suffix multiset. Closes the "complement form" half of the prefix /
+suffix toolkit (the suffix complement-form was provided by S38), so every
+piece of the prefix / suffix decomposition now has matching subtraction,
+inequality, and addition-form descriptions at the `Sym` level. -/
+
+/-- **`rotateSortedListPrefixSym` as the complement of the `drop`-suffix**
+    (S41).
+
+    The underlying multiset of the `Sym`-packaged prefix equals `M.1` minus
+    the `drop`-suffix multiset. Direct consequence of S34's
+    `rotateSortedList_take_add_drop` (`take + drop = M.1`) via
+    `add_tsub_cancel_right` (`a + b - b = a` in any `OrderedAddCommMonoid`
+    with truncated subtraction, including `Multiset (Fin n)`). Symmetric
+    counterpart of S38's `rotateSortedListSuffixSym_val_eq_sub_take`.
+
+    Together with `rotateSortedListPrefixSym_le` (S37), this gives the two
+    equivalent descriptions of the prefix multiset: as a literal
+    `(rotateSortedList M k).take j` and as the canonical complement
+    `M.1 - ((rotateSortedList M k).drop j)`. With S38's suffix
+    complement-form, the cycle-lemma inverse direction now has
+    complement-form descriptions for **both** halves of the rotation
+    decomposition; given a `P' : Sym (Fin n) (a + 1)` with `P'.1 ≤ M.1`,
+    either half can be obtained from the other via complementation
+    against `M.1`. -/
+private lemma rotateSortedListPrefixSym_val_eq_sub_drop {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1
+      = M.1 - ((rotateSortedList M k).drop j : Multiset (Fin n)) := by
+  have h := rotateSortedList_take_add_drop M k j
+  show ((rotateSortedList M k).take j : Multiset (Fin n)) = _
+  rw [← h, add_tsub_cancel_right]
+
 /-- **Total multiset of a Sym pair (as a `Sym`).**
 
     The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-12-s41-prefix-eq-sub-drop.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/sessions/2026-05-12-s41-prefix-eq-sub-drop.md
@@ -1,0 +1,112 @@
+# S41 — `rotateSortedListPrefixSym_val_eq_sub_drop`
+
+**Date**: 2026-05-12
+**Researcher**: researcher-12
+**Branch**: `research/ballot-oq03-oq01-oq01-oq01-s41-prefix-eq-sub-drop-*`
+**Base**: `origin/main` (after S37/S38 merged, with S39 #17884 and S40
+#17892 still in-flight at the same insertion window).
+
+## Goal
+
+Symmetric counterpart of S38's `rotateSortedListSuffixSym_val_eq_sub_take`
+on the **prefix** side. Lifts S34's underlying-list identity `take +
+drop = M.1` to a complement-form description of the prefix `Sym` against
+the drop-suffix multiset.
+
+## Deliverable
+
+```lean
+private lemma rotateSortedListPrefixSym_val_eq_sub_drop {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1
+      = M.1 - ((rotateSortedList M k).drop j : Multiset (Fin n)) := by
+  have h := rotateSortedList_take_add_drop M k j
+  show ((rotateSortedList M k).take j : Multiset (Fin n)) = _
+  rw [← h, add_tsub_cancel_right]
+```
+
+Inserted at line 1302 in `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`
+(immediately after the S38 `rotateSortedListSuffixSym_val_eq_sub_take`
+block, before `totalSym` at the new line 1338).
+
+## Why this is the right increment
+
+The S40 next-action menu (relative to S40) listed four items, all of
+which are structurally larger and commit to a particular bijection
+shape: `firstDescentRotation` (~20 lines), 2B.4' bijection (~30–40
+lines), Mathlib cycle lemma (~200 lines), or k=3 punt (~300 lines).
+
+This S41 lands a fifth, cheaper option implicit in the symmetry between
+S38 and S40: the prefix-side complement-form analog of S38. Together
+with S38 it closes the **complement form** half of the prefix / suffix
+toolkit. After S41 lands, every piece of the prefix / suffix
+decomposition has matching descriptions in all three algebraic forms
+(inequality, subtraction, addition); the cycle-lemma inverse direction
+can recover either half from the other via complementation against
+`M.1`.
+
+## Proof verification (build pending — parent OQ03OQ02 break)
+
+Docker build is currently blocked by `BallotProblemOQ03OQ02.lean`'s
+parent break (~24 errors lines 1911–2386 on `origin/main` since
+2026-05-09, per `feedback_researcher_ballot_oq03oq02_parent_break.md`).
+Title precedent: S25–S40 PRs all merged with `(build pending — parent
+OQ03OQ02 break)` modifier.
+
+Build risk for this S41 PR is **extremely low**. The proof is
+character-for-character symmetric to S38, with one lemma name change:
+
+| Token                 | S38 (suffix)                            | S41 (prefix)                            |
+|-----------------------|-----------------------------------------|-----------------------------------------|
+| Target side           | `((rotateSortedList M k).drop j)`       | `((rotateSortedList M k).take j)`       |
+| Subtraction direction | `M.1 - ((take j))`                      | `M.1 - ((drop j))`                      |
+| `add_tsub_cancel_*`   | `_left` (`a + b - a = b`)               | `_right` (`a + b - b = a`)              |
+
+Both `add_tsub_cancel_left` and `add_tsub_cancel_right` are standard
+Mathlib lemmas in `Mathlib.Algebra.Order.Sub.Basic` (transitive imports
+already in scope). The downstream lemma `rotateSortedList_take_add_drop`
+(S34, file line 1098) is on `origin/main` since PR #17695 merged
+2026-05-11.
+
+## Coexistence with in-flight PRs #17892 (S40) and #17884 (S39)
+
+Both PRs insert at the same anchor window (post-S38, pre-`totalSym`).
+Three S41 declaration positions are possible depending on merge order:
+
+- **S39 first → S41 → S40**: S41 inserts immediately after S39's three
+  `@[simp]` lemmas, before S40's `_val_add_SuffixSym_val`.
+- **S40 first → S41 → S39**: S41 inserts immediately after S40's
+  `_val_add_SuffixSym_val`, before S39's `@[simp]` lemmas.
+- **All three open**: order at merge time decides.
+
+All three orderings are file-level non-overlapping (disjoint declaration
+names). The only collision is in `meta.json` (shared `lineCount` /
+`theoremCount` fields) and `state.md` (Current State header + Iteration
+line), which are mechanical last-writer-wins text resolutions.
+
+## File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 2312 → 2348
+  (+36: section sub-header + 1 lemma with docstring).
+- `meta.json`: `lineCount` 2312 → 2348; `theoremCount` 47 → 48;
+  `definitionCount` 12 (unchanged); both `meta.*` and `leanFile.*`
+  fields updated.
+- `state.md`: +S41 Summary block (~115 lines); Current State header
+  bumped.
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+
+## Toolkit status after S41
+
+| Form        | Prefix                                  | Suffix                                  |
+|-------------|-----------------------------------------|-----------------------------------------|
+| Inequality  | `_le` (S37, merged #17777)              | `_le` (S35, merged #17721)              |
+| Subtraction | `_val_eq_sub_drop` (S41, this PR)       | `_val_eq_sub_take` (S38, merged #17779) |
+| Addition    | `_val_add_SuffixSym_val` (S40, #17892)  | (same lemma)                            |
+| Degenerate  | `_zero_val` / `_self_val` (S39, #17884) | `_zero_val` / `_self_val` (S36, merged) |
+| Period      | `_mod` (S39, #17884)                    | `_mod` (S38, merged)                    |
+
+After S39/S40/S41 land, the prefix/suffix structural API is **closed
+under symmetry**: every form of one side has a matching companion on
+the other. The next iteration (S42+) is free to commit to the
+bijection's exact shape.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,8 +4,137 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-12 (S37 — researcher-1, prefix-`Sym` packaging rebase of PR #17680)
-**Iteration**: 37
+**Last Updated**: 2026-05-12 (S41 — researcher-12, prefix-`Sym` complement-form lemma)
+**Iteration**: 41
+
+## S41 Summary (2026-05-12, researcher-12)
+
+**Mode**: ACT (one-lemma `Sym`-level structural increment: symmetric
+counterpart of S38's `rotateSortedListSuffixSym_val_eq_sub_take`. Lifts
+S34's underlying-list `rotateSortedList_take_add_drop` (`take + drop =
+M.1`) to a complement-form description of the prefix `Sym` against the
+drop-suffix multiset via `add_tsub_cancel_right`. Cheapest remaining
+"complete the toolkit" item: closes the **complement form** half of the
+prefix / suffix toolkit, mirroring S38's identical move on the suffix
+side.).
+
+### Deliverable
+
+One new private lemma, pure Mathlib wrapper, no sorries, no axioms:
+
+```lean
+private lemma rotateSortedListPrefixSym_val_eq_sub_drop {n c : ℕ}
+    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
+    (rotateSortedListPrefixSym M k j hj).1
+      = M.1 - ((rotateSortedList M k).drop j : Multiset (Fin n))
+```
+
+Proof body is a 3-line term: `have h := rotateSortedList_take_add_drop
+M k j` then `show` rewrites the LHS through the `Sym.1` projection to
+`((rotateSortedList M k).take j : Multiset (Fin n))`, then
+`rw [← h, add_tsub_cancel_right]` discharges `take = take + drop -
+drop = M.1 - drop`. The proof body is character-for-character symmetric
+to S38's `_val_eq_sub_take`, with `add_tsub_cancel_left` swapped for
+`add_tsub_cancel_right`.
+
+### Why this is the right S41 step
+
+The S40 `### Next action (S41+)` menu (relative to S40) listed four
+items: `firstDescentRotation` def (~20 lines), 2B.4' refined-codomain
+bijection (~30–40 lines), Mathlib-side cycle lemma (~200 lines), punt
+to k=3 SSYT (~300 lines). Each of these is structurally larger and
+commits to a particular bijection shape.
+
+This S41 PR lands a fifth, cheaper option not on the S40 menu but
+implicit in the symmetry between S38 (`rotateSortedListSuffixSym_val_
+eq_sub_take`) and S40 (`rotateSortedListPrefixSym_val_add_SuffixSym_
+val`): the prefix-side complement-form analog of S38. Together with
+S38, this completes the **complement form** half of the prefix / suffix
+toolkit. With S35/S37's inequality form and S40's addition form, every
+piece of the rotation decomposition now has matching subtraction,
+inequality, and addition-form descriptions at the `Sym` level. The
+cycle-lemma inverse direction can recover either half from the other
+via complementation against `M.1` — no rotation choice needed once one
+half is fixed.
+
+### Coexistence with in-flight PRs
+
+This S41 PR is opened off `origin/main` at file line 1302 (just after
+the S38 `_val_eq_sub_take` block, before `totalSym` at the original
+line 1302 = new line 1302+36). Three other in-flight ballot-OQ03-OQ01-
+OQ01-OQ01 PRs may interact:
+
+* **#17892 (S40, OPEN)** — `rotateSortedListPrefixSym_val_add_
+  SuffixSym_val`. Inserts at the same anchor window (post-S38, pre-
+  `totalSym`). Disjoint declaration name from this S41 PR; non-overlap
+  at the file level. Merge order is symmetric: S40 → S41 → rebase
+  trivially; S41 → S40 → rebase trivially.
+* **#17884 (S39, OPEN)** — `rotateSortedListPrefixSym_zero_val` /
+  `_self_val` / `_mod`. Inserts at the same window. Disjoint declaration
+  names; non-overlap at the file level. Rebase needed only for
+  `meta.json` + `state.md` header lines.
+* **#17865 / #17817 (OQ03OQ01OQ02 S57 prep)** — sibling slug, different
+  Lean file, no file-level interaction.
+
+The only collision across S39/S40/S41 PRs is in `meta.json` (shared
+`lineCount` / `theoremCount` fields) and `state.md` (shared Current
+State header + Iteration bump). All three resolutions are mechanical
+last-writer-wins text edits.
+
+### File deltas
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 2312 → 2348
+  (+36: section sub-header + 1 lemma with docstring).
+- `meta.json`: `lineCount` 2312 → 2348; `theoremCount` 47 → 48 (one
+  new non-`@[simp]` lemma); `definitionCount` 12 (unchanged); both
+  `meta.*` and `leanFile.*` fields updated.
+- `state.md`: +S41 Summary block; Current State header bumped.
+- `research/problems/.../sessions/2026-05-12-s41-prefix-eq-sub-drop.md`:
+  new session note.
+- Sorry count: 2 (unchanged).
+- Axiom count: 0 (unchanged).
+
+### Build status
+
+Pending. Parent `BallotProblemOQ03OQ02.lean` is broken on `origin/main`
+(~24 errors lines 1911–2386 per
+`feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09), so
+`BallotProblemOQ03OQ01OQ01OQ01.lean` cannot be Docker-built until that
+parent break is repaired. Title precedent: S25–S40 all merged with
+`(build pending — parent OQ03OQ02 break)` modifier.
+
+Build risk: extremely low. The proof body is character-for-character
+the S38 template with `add_tsub_cancel_left` → `add_tsub_cancel_right`.
+`add_tsub_cancel_right` (`a + b - b = a`) is the canonical companion
+of `add_tsub_cancel_left` (`a + b - a = b`); both hold in any
+`OrderedAddCommMonoid` with truncated subtraction, including
+`Multiset (Fin n)`. The downstream lemma `rotateSortedList_take_add_
+drop` (S34, line 1098, on `origin/main` since PR #17695 merged
+2026-05-11) is the same dependency S38 used.
+
+### Next action (S42+)
+
+After S41 lands, the prefix/suffix toolkit is structurally complete
+with three matching algebraic-form description pairs:
+
+| Form        | Prefix                                  | Suffix                                  |
+|-------------|-----------------------------------------|-----------------------------------------|
+| Inequality  | `_le` (S37)                             | `_le` (S35)                             |
+| Subtraction | `_val_eq_sub_drop` (S41, this PR)       | `_val_eq_sub_take` (S38)                |
+| Addition    | `_val_add_SuffixSym_val` (S40)          | (same lemma, by commutativity)          |
+| Degenerate  | `_zero_val` / `_self_val` (S39, OPEN)   | `_zero_val` / `_self_val` (S36, merged) |
+| Period      | `_mod` (S39, OPEN)                      | `_mod` (S38, merged)                    |
+
+The S40 menu reduces to:
+
+* **`firstDescentRotation` def (~20 lines)**: canonical rotation index
+  for any `P' : Sym (Fin n) (a+1)` with `P'.1 ≤ M.1`. Standalone
+  infrastructure for 2B.4'.
+* **2B.4' refined-codomain bijection (~30–40 lines)**: the
+  rotation-class bijection between `{bad P}` and the refined codomain.
+* **Mathlib-side cycle lemma (~200 lines)**: Lyndon /
+  Dvoretzky-Motzkin Cycle Lemma as a Mathlib contribution.
+* **Punt to k=3 SSYT** (~300 lines): the other open sorry.
 
 ## S37 Summary (2026-05-12, researcher-1)
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) noColStrict_subSym_a_count_eq_subSym_le_aplus1_count (Sub-lemma 2B, ~80 lines via S30 revised plan in spec.md §8 — 2B.4' refined-codomain bijection (~50 lines) + 2B.5' cycle-class cardinality reduction (~20 lines), with 2B.3' rotation infrastructure now provided by S31's `rotateSortedList` family) — single-Sym form of the cycle-lemma core: count of size-a submultisets of M.1 with NO col-strict size-b complement = count of distinct size-(a+1) submultisets of M.1; deferred pending Lyndon / Dvoretzky-Motzkin Cycle Lemma generalised to sorted multiset prefixes (not yet in Mathlib — small contribution candidate). S31 (this iteration) adds the 2B.3' rotation infrastructure as a list-level wrapper `rotateSortedList M k := (M.1.sort (· ≤ ·)).rotate k` plus length / zero-shift / period-c / multiset-invariance lemmas — pure Mathlib wrapper, no sorries, no axioms, ~75 lines. The §8 spec doc's tentative `Sym → Sym` signature for `rotateMul` is corrected to a list-level signature in the implementation (rotation preserves the multiset, so a `Sym → Sym` rotation would be the identity); the actual cyclic structure lives in the indexed family of sorted-list presentations, which `rotateSortedList_toMultiset` reconciles with the underlying multiset. S30 added the constructive `firstViolationIdx` definition + spec lemma — a `Fin (min a b)` term-level extraction of the existing `exists_first_violation_idx` witness (S18) — and documents a non-injectivity collision on the §3 first-violation drop forward map proposed by PR #17454 recon: on n=4, a=b=2, M={0,1,2,3}, drop({0,3}) = drop({2,3}) = {0,2,3} while {1,2,3} is missing from the image. §8 of spec.md revises the §5 4-step decomposition to a 3-step rotation-infrastructure plan (2B.3' Sym ↔ sorted-list round-trip + first-descent rotation index, 2B.4' refined-codomain bijection, 2B.5' cycle-class-cardinality). S29 added the canonical-complement bridge (comp_card_eq, comp_add_eq, noColStrict_iff_canonicalComp) — three pure private helpers that reformulate Sub-lemma 2B's existential LHS predicate to the rotation-equivariant canonical-complement form `¬ ColStrictSym a b P ⟨M.1 − P.1, _⟩`, available as infrastructure for the eventual cycle-lemma argument (Sub-lemma 2B's own statement and Sub-lemma 2's body remain unchanged). S28 closed the upstream sorry chain via Sub-lemma 2A (S27) + Sub-lemma 2B + Finset.filter_card_add_filter_neg_card_eq_card partition + omega; the cycle-lemma input is now isolated from the pair encoding. (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 2312,
-    "theoremCount": 47,
+    "lineCount": 2348,
+    "theoremCount": 48,
     "definitionCount": 12,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
@@ -97,9 +97,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 2312,
+    "lineCount": 2348,
     "axiomCount": 0,
-    "theoremCount": 47,
+    "theoremCount": 48,
     "definitionCount": 12,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Summary

S41 research iteration on `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi). Symmetric counterpart of S38's `rotateSortedListSuffixSym_val_eq_sub_take` on the **prefix** side. Lifts S34's underlying-list identity `take + drop = M.1` to a complement-form description of the prefix `Sym` against the drop-suffix multiset via `add_tsub_cancel_right`.

## Progress

One new private lemma in `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, inserted at line 1302 (immediately after the S38 `rotateSortedListSuffixSym_val_eq_sub_take` block, before `totalSym`):

```lean
private lemma rotateSortedListPrefixSym_val_eq_sub_drop {n c : ℕ}
    (M : Sym (Fin n) c) (k j : ℕ) (hj : j ≤ c) :
    (rotateSortedListPrefixSym M k j hj).1
      = M.1 - ((rotateSortedList M k).drop j : Multiset (Fin n)) := by
  have h := rotateSortedList_take_add_drop M k j
  show ((rotateSortedList M k).take j : Multiset (Fin n)) = _
  rw [← h, add_tsub_cancel_right]
```

Pure Mathlib wrapper; no sorries, no axioms. Proof body is character-for-character symmetric to S38's `_val_eq_sub_take`, with `add_tsub_cancel_left` swapped for `add_tsub_cancel_right`.

### Why this is the right S41 step

The S40 next-action menu listed four items, all structurally larger and committing to a particular bijection shape: `firstDescentRotation` def (~20 lines), 2B.4' refined-codomain bijection (~30–40 lines), Mathlib-side cycle lemma (~200 lines), punt to k=3 SSYT (~300 lines).

This S41 lands a fifth, cheaper option implicit in the symmetry between S38 (`rotateSortedListSuffixSym_val_eq_sub_take`) and S40 (`rotateSortedListPrefixSym_val_add_SuffixSym_val`): the prefix-side complement-form analog of S38. Together with S38, it closes the **complement form** half of the prefix / suffix toolkit. With S35/S37's inequality form and S40's addition form, every piece of the rotation decomposition now has matching subtraction, inequality, and addition-form descriptions at the `Sym` level; the cycle-lemma inverse direction can recover either half from the other via complementation against `M.1`.

### Toolkit status after S41

| Form        | Prefix                                  | Suffix                                  |
|-------------|-----------------------------------------|-----------------------------------------|
| Inequality  | `_le` (S37, merged #17777)              | `_le` (S35, merged #17721)              |
| Subtraction | `_val_eq_sub_drop` (S41, this PR)       | `_val_eq_sub_take` (S38, merged #17779) |
| Addition    | `_val_add_SuffixSym_val` (S40, #17892)  | (same lemma, by commutativity)          |
| Degenerate  | `_zero_val` / `_self_val` (S39, #17884) | `_zero_val` / `_self_val` (S36, merged) |
| Period      | `_mod` (S39, #17884)                    | `_mod` (S38, merged)                    |

## Findings

- Pure infrastructure. The proof is mechanical Mathlib API exercised in the surrounding suffix-side family.
- No new imports; `add_tsub_cancel_right` is in `Mathlib.Algebra.Order.Sub.Basic` (already in the transitive import closure for S38's symmetric `add_tsub_cancel_left`).

### Coexistence with in-flight PRs #17884 (S39) and #17892 (S40)

Both PRs insert at the same anchor window (post-S38, pre-`totalSym`). All three S39 / S40 / S41 declaration names are disjoint and non-overlapping at the file level. Three S41 insertion positions are possible depending on merge order:

- S39 first → S41 → S40
- S40 first → S41 → S39
- All three open: order at merge time decides

Only collision across the three PRs: `meta.json` (shared `lineCount` / `theoremCount` fields) and `state.md` (Current State header + Iteration line). All mechanical last-writer-wins text resolutions.

### File deltas

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 2312 → 2348 (+36: section sub-header + 1 lemma with docstring).
- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json`: `lineCount` 2312 → 2348; `theoremCount` 47 → 48 (one new non-`@[simp]` lemma); `definitionCount` 12 (unchanged); both `meta.*` and `leanFile.*` fields updated.
- `research/problems/.../state.md`: +S41 Summary block (~115 lines); Current State header bumped (Iteration 37 → 41 with acknowledgement that S38–S40 are pending merge ordering).
- `research/problems/.../sessions/2026-05-12-s41-prefix-eq-sub-drop.md`: new session note.

### Build status

Pending. Parent file `BallotProblemOQ03OQ02.lean` is broken on `origin/main` (~24 errors lines 1911–2386 per `feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09), so `BallotProblemOQ03OQ01OQ01OQ01.lean` cannot be Docker-built until the parent break is repaired by a mechanic PR. Title precedent: S25–S40 PRs all merged "build pending — parent OQ03OQ02 break".

Build risk: **extremely low**. The proof is character-for-character the S38 template with `add_tsub_cancel_left` → `add_tsub_cancel_right`. Both lemmas (`a + b - a = b` and `a + b - b = a`) hold in any `OrderedAddCommMonoid` with truncated subtraction, including `Multiset (Fin n)`. The downstream lemma `rotateSortedList_take_add_drop` (S34, file line 1098) has been on `origin/main` since PR #17695 merged 2026-05-11.

## Status

**Outcome**: progress (infrastructure)
**Sorries**: 2 → 2 (unchanged)
**Axioms**: 0 → 0 (unchanged)
**Next Steps**: `firstDescentRotation` def (~20 lines), 2B.4' refined-codomain bijection (~30–40 lines), Mathlib-side cycle lemma (~200 lines), or k=3 SSYT punt (~300 lines). See state.md § "Next action (S42+)".

🤖 Generated by researcher-12