### PR TITLE
Enrich Infinitely Many Primes ≡ 1 (mod 4): upgrade mainTheorems schema

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -72,23 +72,31 @@
   "mainTheorems": [
     {
       "name": "infinitely_many_primes_1_mod_4",
-      "type": "theorem",
-      "description": "$\\forall n \\in \\mathbb{N}, \\exists p$ prime with $p > n$ and $p \\equiv 1 \\pmod 4$. Direct answer to OQ-03 from `infinitude-primes-4k3`. Proof is one line — re-export of `InfinitudePrimes4k1.infinitely_many_primes_1_mod_4`, whose construction is $N = (2(n+1)!)^2 + 1$ followed by Euler's criterion to extract a prime factor $p \\equiv 1 \\pmod 4$."
+      "type": "core",
+      "statement": "$\\forall n \\in \\mathbb{N}, \\; \\exists p$ prime, $p > n$ and $p \\equiv 1 \\pmod 4$",
+      "significance": "Direct answer to OQ-03 from `infinitude-primes-4k3`. Proof is a one-line re-export of `InfinitudePrimes4k1.infinitely_many_primes_1_mod_4`, whose construction is $N = (2(n+1)!)^2 + 1$ followed by Euler's criterion to extract a prime factor $p \\equiv 1 \\pmod 4$. The construction is $\\Phi_4(x) = x^2 + 1$ evaluated at $2(n+1)!$, which is an instance of the general cyclotomic pattern: any prime $p \\nmid 4$ dividing $\\Phi_4(k)$ has $\\mathrm{ord}_p(k) = 4$, so $4 \\mid p - 1$.",
+      "description": "Main theorem: infinitely many primes ≡ 1 (mod 4), by re-export from InfinitudePrimes4k1."
     },
     {
       "name": "both_classes_infinite",
-      "type": "theorem",
-      "description": "$\\{p \\text{ prime} \\mid p \\equiv 1 \\pmod 4\\}$ and $\\{p \\text{ prime} \\mid p \\equiv 3 \\pmod 4\\}$ are both `Set.Infinite`. Proof packages `InfinitudePrimes4k1.primes_1_mod_4_infinite` and `InfinitudePrimes4k3.primes_3_mod_4_infinite` into a conjunction. The pair of infinite sets covers every odd prime (by the classification theorem below)."
+      "type": "core",
+      "statement": "$\\{p \\text{ prime} \\mid p \\equiv 1 \\pmod 4\\}$ and $\\{p \\text{ prime} \\mid p \\equiv 3 \\pmod 4\\}$ are both $\\mathrm{Set.Infinite}$",
+      "significance": "Packages the conjunction of `InfinitudePrimes4k1.primes_1_mod_4_infinite` and `InfinitudePrimes4k3.primes_3_mod_4_infinite`. Combined with `odd_prime_mod_four_classification`, this gives a fully elementary, machine-verified mod-4 special case of Dirichlet's theorem — without any L-function machinery.",
+      "description": "Both residue classes mod 4 are infinite."
     },
     {
       "name": "odd_prime_mod_four_classification",
-      "type": "theorem",
-      "description": "Every prime $p \\neq 2$ satisfies $p \\equiv 1 \\pmod 4$ or $p \\equiv 3 \\pmod 4$. A basic modular-arithmetic fact (odd primes have $p \\bmod 4 \\in \\{1, 3\\}$ since $p \\bmod 4 \\in \\{0, 2\\}$ would force $p$ to be even), re-exported from `InfinitudePrimes4k3.prime_mod_four`."
+      "type": "supporting",
+      "statement": "$\\forall p$ prime, $p \\neq 2 \\Rightarrow p \\equiv 1 \\pmod 4$ or $p \\equiv 3 \\pmod 4$",
+      "significance": "Basic modular-arithmetic fact: odd primes have $p \\bmod 4 \\in \\{1, 3\\}$ because $p \\bmod 4 \\in \\{0, 2\\}$ would force $p$ even. Re-exported from `InfinitudePrimes4k3.prime_mod_four`. The disjunction is what makes the two-class partition of odd primes a *complete* classification, not just a pair of nonempty disjoint classes.",
+      "description": "Every odd prime is ≡ 1 or ≡ 3 (mod 4)."
     },
     {
       "name": "constructions_cover_all_odd_primes",
-      "type": "theorem",
-      "description": "For every odd prime $p$, exhibits $p$ as a witness in one of the two infinite families with $n = 0$, $q = p$. Proof structure: `rcases` on `odd_prime_mod_four_classification` to split $p \\equiv 1$ vs $p \\equiv 3$, then supply the trivial witness $(0, p)$. Demonstrates the disjunctive cover at the constructive level — every odd prime is *named* by one of the two constructions, not just classified abstractly."
+      "type": "supporting",
+      "statement": "$\\forall p$ odd prime, $\\exists\\, n, q$: $(p \\equiv 1 \\pmod 4 \\wedge q > n \\wedge q \\equiv 1 \\pmod 4 \\wedge q = p)$ or $(p \\equiv 3 \\pmod 4 \\wedge q > n \\wedge q \\equiv 3 \\pmod 4 \\wedge q = p)$",
+      "significance": "Demonstrates the disjunctive cover at the constructive level: every odd prime is *named* by one of the two constructions, not just classified abstractly. Proof structure: `rcases` on the classification theorem to split, then supply the trivial witness $(0, p)$, valid since `Prime.two_le` gives $p \\geq 2 > 0$.",
+      "description": "Each odd prime is exhibited as a witness in one of the two infinite families."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-4k3-oq-03` (quality 98, pass 0).

## Scope
This entry was already at the high-quality bar (9 detailed annotations with mathContext/significance/relatedConcepts/prerequisites, 8 keyInsights including the cyclotomic generalization and Murty's criterion, 9 references including Euler 1749, Dirichlet 1837, Murty 1988, and Selberg 1949). The one remaining gap was the `mainTheorems` schema: each entry had only a `description` field doing double duty as both the formal claim and the proof-architecture commentary.

## Changes
- Split each of the four `mainTheorems` entries into three canonical fields:
  - `statement`: the LaTeX-formatted formal claim
  - `significance`: the proof-architecture rationale (delegation pattern, cyclotomic interpretation, classification role)
  - `description`: a one-line summary for tooltip/listing display
- Upgraded `type` from generic `"theorem"` to `"core"` / `"supporting"` to align with the convention used in other gallery entries (`mean-value-theorem-oq-04`, `lebesgue-measure-oq-01-oq-03`, `perfect-numbers-oq-03`, `minkowski-theorem-oq-04`).

## Untouched
- All other meta.json content (overview, conclusion, sections, references, crossReferences, annotations) — already at depth.
- `index.ts` — already uses the correct sync `?raw` template.
- No content was removed; the prior `description` text was redistributed between `significance` and `description`.

## Axiom integrity
- `axiomCount: 0`, `sorries: 0`, `status: "verified"`, `badge: "original"`. The Lean file is a 103-line integration layer importing `InfinitudePrimes4k1` and `InfinitudePrimes4k3`; no `axiom` declarations and no assumption-carrying structures. Status correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)