### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S6 — §2.5 glivenko_cantelli_uniform_proved (build pending)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
@@ -444,4 +444,78 @@ theorem bracketing_uniform_from_grid [IsProbabilityMeasure μ]
     _ ≤ η + 2 * ε := by linarith
     _ = 2 * ε + η := by ring
 
+-- ============================================================================
+-- §2.5: Uniform convergence (proved modulo `bracketingGrid_exists`)
+-- ============================================================================
+
+/-! ### §2.5 Glivenko–Cantelli uniform convergence
+
+Composes §2.2 (`bracketingGrid_exists`), §2.3 (`bracketing_simultaneous_pointwise`)
+and §2.4 (`bracketing_uniform_from_grid`) along the diagonal `ε := 1 / (m+1)`,
+`m : ℕ`. The countably many simultaneous-pointwise full-measure sets are
+combined via `MeasureTheory.ae_all_iff` into a single full-measure set on
+which, for every accuracy `δ > 0`, picking `m` with `1/(m+1) < δ/3` and
+applying §2.4 with `η := 1/(m+1)` gives `⨆x |Fₙ − F| ≤ 3/(m+1) < δ` eventually.
+
+This is the exact statement of the parent file's `glivenko_cantelli_uniform`
+axiom; with this theorem in place the parent axiom becomes redundant and can
+be retired in a follow-up, leaving `bracketingGrid_exists` as the sole
+remaining axiom in the chain. -/
+theorem glivenko_cantelli_uniform_proved [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ}
+    (hX_meas : ∀ i, Measurable (X i))
+    (hX_iid : iIndepFun X μ)
+    (hX_ident : ∀ i, IdentDistrib (X i) (X 0) μ μ) :
+    ∀ᵐ ω ∂μ,
+      Filter.Tendsto
+        (fun n => ⨆ x : ℝ, |empiricalCDF X n x ω - trueCDF X μ x|)
+        Filter.atTop (nhds 0) := by
+  -- Diagonal accuracy schedule: ε m := 1 / (m + 1)
+  let ε : ℕ → ℝ := fun m => 1 / ((m : ℝ) + 1)
+  have hε_pos : ∀ m : ℕ, 0 < ε m := fun m => by
+    show (0 : ℝ) < 1 / ((m : ℝ) + 1)
+    positivity
+  -- Pick a bracketing grid for each accuracy ε m
+  let G : (m : ℕ) → BracketingGrid (trueCDF X μ) (ε m) := fun m =>
+    (bracketingGrid_exists hX_meas (hε_pos m)).some
+  -- Per-m simultaneous pointwise convergence at grid points
+  have h_per_m : ∀ m : ℕ, ∀ᵐ ω ∂μ, ∀ j : Fin ((G m).k + 2),
+      Filter.Tendsto (fun n => empiricalCDF X n ((G m).q j) ω)
+        Filter.atTop (nhds (trueCDF X μ ((G m).q j))) := by
+    intro m
+    exact bracketing_simultaneous_pointwise hX_meas hX_iid hX_ident (G m).q
+  -- Combine the countably many full-measure sets via `ae_all_iff`
+  have h_all : ∀ᵐ ω ∂μ, ∀ m : ℕ, ∀ j : Fin ((G m).k + 2),
+      Filter.Tendsto (fun n => empiricalCDF X n ((G m).q j) ω)
+        Filter.atTop (nhds (trueCDF X μ ((G m).q j))) := by
+    rw [ae_all_iff]
+    exact h_per_m
+  filter_upwards [h_all] with ω h_pw_all
+  -- Show `Tendsto (⨆x ...) atTop (nhds 0)` via the metric characterisation
+  rw [Metric.tendsto_atTop]
+  intro δ hδ
+  -- Choose `m : ℕ` with `1 / (m + 1) < δ / 3` (so `3 · ε m < δ`)
+  obtain ⟨m, hm⟩ := exists_nat_one_div_lt
+    (div_pos hδ (by norm_num : (0 : ℝ) < 3))
+  -- Apply §2.4 with this `m` and slack `η := ε m`
+  have h_event :=
+    bracketing_uniform_from_grid (hε_pos m) (G m) (h_pw_all m) (ε m) (hε_pos m)
+  -- Extract the eventual index from `∀ᶠ n, ...`
+  rw [Filter.eventually_atTop] at h_event
+  obtain ⟨N, hN⟩ := h_event
+  refine ⟨N, fun n hn => ?_⟩
+  -- Bound the sup-error: ⨆ ≤ 2 ε m + ε m = 3 ε m
+  have hUle :
+      (⨆ x : ℝ, |empiricalCDF X n x ω - trueCDF X μ x|) ≤ 2 * ε m + ε m :=
+    hN n hn
+  -- ⨆ ≥ 0 since the integrand is a pointwise absolute value
+  have hUnn : 0 ≤ ⨆ x : ℝ, |empiricalCDF X n x ω - trueCDF X μ x| :=
+    Real.iSup_nonneg (fun _ => abs_nonneg _)
+  -- 3 · ε m < δ
+  have h3εm : 3 * ε m < δ := by
+    have hεlt : ε m < δ / 3 := hm
+    linarith
+  rw [Real.dist_eq, sub_zero, abs_of_nonneg hUnn]
+  linarith
+
 end GlivenkoCantelli

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
@@ -255,3 +255,80 @@ against the parent file's already-built declarations and against my prior
 familiarity with Mathlib 4.26's `Finset.sup'`, `ciSup_le`, `Metric`, and
 `Filter` APIs. PR uses "(build pending)" suffix matching the precedent
 established for recent §2.3 work on this slug.
+
+---
+
+## Session 2026-05-12 (Session 6) — §2.5 glivenko_cantelli_uniform_proved
+
+**Mode**: ITERATIVE
+**Outcome**: progress (axiom shift complete on the bracketing companion side)
+
+### What I Did
+
+1. Claimed slug, fetched origin/main (parent file fixed by mechanic PR #17864
+   on 2026-05-12 — `.real` integral_const drift resolved per memory).
+2. Read S5's state.md next-steps: §2.5 (~20 lines, composition of §2.2 +
+   §2.3 + §2.4 along `ε = 1/(m+1)`).
+3. Verified Mathlib API names against the actual source files
+   (`/Users/rwalters/Projects/lean-genius-proofs/.lake/packages/mathlib`):
+   `Real.iSup_nonneg` (`Mathlib.Data.Real.Archimedean:225`),
+   `exists_nat_one_div_lt` (`Mathlib.Algebra.Order.Archimedean:191`),
+   `Metric.tendsto_atTop` (`Mathlib.Topology.MetricSpace.Pseudo.Defs:932`),
+   `MeasureTheory.ae_all_iff` (`Mathlib.MeasureTheory.OuterMeasure.AE:93`).
+4. Wrote `glivenko_cantelli_uniform_proved` in the bracketing companion.
+   Substituted S5's prep-note hint `ae_iInter_iff` with `ae_all_iff` — same
+   countable-conjunction lemma, used at the ℕ layer here rather than the
+   `Fin (k+2)` layer §2.3 used it at. Net: 47 tactic lines.
+
+### Key Findings
+
+- **`ae_all_iff` at the ℕ layer**: the same lemma §2.3 invoked over `Fin (k+2)`
+  applies verbatim over `ℕ` (also countable). The proof grew by one outer
+  `ae_all_iff` call to thread the diagonal `m : ℕ`.
+- **`exists_nat_one_div_lt` for the diagonal step**: `(0 < ε) → ∃ n : ℕ,
+  1 / (n + 1) < ε`. With `ε := δ / 3 > 0` this gives `m` such that
+  `3 / (m + 1) < δ`. Applying §2.4 with `η := 1 / (m + 1)` yields the
+  eventual sup-error bound `2 · 1/(m+1) + 1/(m+1) = 3/(m+1) < δ`.
+- **`Real.iSup_nonneg` is unconditional**: per Mathlib source,
+  `0 ≤ ⨆ i, f i` when `∀ i, 0 ≤ f i`, with no `BddAbove` requirement —
+  the default value of `Real.sSup` for unbounded or empty sets is 0,
+  which is also ≥ 0. This lets us flip
+  `dist (⨆ ...) 0 = |⨆ ... - 0| = ⨆ ...` cleanly without any extra
+  bookkeeping about boundedness.
+- **`Metric.tendsto_atTop`**: namespace-`Metric` (lines 344–977 of the
+  `Pseudo/Defs.lean` namespace block), characterises `Tendsto u atTop
+  (nhds a)` by `∀ ε > 0, ∃ N, ∀ n ≥ N, dist (u n) a < ε`. Drop-in for
+  the `Real.dist_eq` + `abs_of_nonneg` chain.
+
+### Files Modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (447 → 522 lines,
+  +1 theorem `glivenko_cantelli_uniform_proved`).
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/state.md` (S6 entry).
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md`
+  (this S6 entry).
+
+Per gallery convention `meta.lineCount` / `theoremCount` track the main
+file only — no `src/data/proofs/.../meta.json` update needed.
+
+### Next Steps
+
+- **S7**: retire the parent's `axiom glivenko_cantelli_uniform` in
+  `LawsOfLargeNumbersOQ04.lean`. The cleanest path is to move the proved
+  variant from the bracketing companion *into* the parent file (or split
+  the parent so the bracketing companion can be imported earlier in the
+  chain). After retirement: chain axiom count goes 2 → 1, with the sole
+  remaining axiom (`bracketingGrid_exists`) being purely real-analytic.
+- **S8+ (Mathlib upstream)**: discharge `bracketingGrid_exists` itself by
+  contributing `Monotone.exists_increasing_continuity_seq` to Mathlib.
+  This is the last open mathematical content in the entire Glivenko–
+  Cantelli chain.
+
+### Honesty
+
+Build verification attempted with `LEAN_BUILD_TIMEOUT=55m
+./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`.
+The broken `proofs/.lake` self-symlink forces a cold Mathlib fetch; result
+may not finish within session window. PR title bears the "(build pending)"
+suffix matching S3–S5 precedent on this slug. API names verified against
+Mathlib 4.26 source by file-path lookup before commit (not by build).

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -2,9 +2,107 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T20:43:00Z
-**Iteration**: 5 (S5 — bracketing_uniform_sup_bound + bracketing_uniform_from_grid)
+**Iteration**: 6 (S6 — `glivenko_cantelli_uniform_proved` via diagonal ε = 1/(m+1))
 
-## S5 (this session, researcher-6, 2026-05-11) — §2.4 deterministic + limit form
+## S6 (this session, researcher-5, 2026-05-12) — §2.5 diagonal composition
+
+S5 landed §2.4 (`bracketing_uniform_sup_bound` + `bracketing_uniform_from_grid`).
+S6 (this session) lands the last theorem of the bracketing decomposition, §2.5
+(`glivenko_cantelli_uniform_proved`), closing the loop on the axiom shift.
+
+### What landed
+
+`glivenko_cantelli_uniform_proved`: same signature as the parent's
+`glivenko_cantelli_uniform` axiom; proves
+`∀ᵐ ω ∂μ, Tendsto (fun n => ⨆ x, |Fₙ(x, ω) - F(x)|) atTop (nhds 0)`. Proof
+is a diagonal composition of §2.2–§2.4:
+
+1. Pick the accuracy schedule `ε m := 1 / (m + 1)`. Each is positive.
+2. For each `m : ℕ`, take a bracketing grid `G m :=
+   (bracketingGrid_exists hX_meas (hε_pos m)).some` via the §2.2 axiom.
+3. For each `m`, §2.3 supplies a full-measure set on which the empirical CDF
+   converges to the true CDF at every grid point `(G m).q j`.
+4. The countable family `{m ↦ "full-measure set for G m"}` is combined into
+   a single full-measure set via `MeasureTheory.ae_all_iff` (`ℕ` is
+   countable).
+5. On this single full-measure set, for any `δ > 0`, choose `m` with
+   `1 / (m + 1) < δ / 3` via `exists_nat_one_div_lt`. Apply §2.4 with the
+   slack `η := ε m`; eventually `⨆ x, |Fₙ(x, ω) - F(x)| ≤ 2 ε m + ε m =
+   3 ε m < δ`. Combined with `Real.iSup_nonneg` (the iSup is non-negative)
+   this gives `dist (⨆ ...) 0 < δ` eventually.
+
+### Mathlib API used
+
+* `MeasureTheory.ae_all_iff` (combining countably many full-measure sets) —
+  same lemma §2.3 used at the finite Fin (k+2) layer, here re-used at the
+  countably-infinite ℕ layer.
+* `Metric.tendsto_atTop` (Mathlib.Topology.MetricSpace.Pseudo.Defs:932) —
+  metric characterisation of `Tendsto u atTop (nhds a)`.
+* `Filter.eventually_atTop` — to extract an explicit threshold `N` from
+  `∀ᶠ n in atTop, ...`.
+* `exists_nat_one_div_lt` (Mathlib.Algebra.Order.Archimedean:191) — to pick
+  `m` with `1 / (m + 1) < δ / 3`.
+* `Real.iSup_nonneg` (Mathlib.Data.Real.Archimedean:225) — to flip
+  `dist (⨆ ...) 0 = |⨆ ... - 0|` to `⨆ ...`.
+* `Real.dist_eq`, `abs_of_nonneg`, `sub_zero` — standard distance/abs
+  manipulations on `ℝ`.
+
+### Counts
+
+The bracketing companion file went 447 → 522 lines (+75 lines), 3 → 4
+theorems (added `glivenko_cantelli_uniform_proved`). Axiom count for the
+companion is unchanged at 1 (`bracketingGrid_exists`); no new axioms or
+sorries introduced. The main file `LawsOfLargeNumbersOQ04OQ03.lean` is
+unchanged (158 lines, 4 theorems, 0 sorries, 0 axioms). Per gallery
+convention `meta.lineCount` / `theoremCount` track the main file only —
+no meta.json update needed.
+
+### Build status
+
+Pending. Build attempted under Docker
+(`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`);
+expected ~45 min cold under the broken `proofs/.lake` self-symlink. PR
+title bears the "(build pending)" suffix per the recent precedent for
+§2.3+ work on this slug. API names were verified against Mathlib 4.26
+source (`Real.iSup_nonneg`, `exists_nat_one_div_lt`, `Metric.tendsto_atTop`,
+`ae_all_iff`).
+
+### Status of the bracketing decomposition
+
+After S6 lands, the bracketing decomposition of `bracketing-decomposition-draft.md`
+§2 is fully complete:
+
+| Section | Theorem | Status |
+|---------|---------|--------|
+| §2.1 | `BracketingGrid` structure | Landed S3 |
+| §2.2 | `bracketingGrid_exists` axiom | Landed S3 (axiom; Mathlib-side gap) |
+| §2.3 | `bracketing_simultaneous_pointwise` | Landed S4 |
+| §2.4 | `bracketing_uniform_sup_bound` + `bracketing_uniform_from_grid` | Landed S5 |
+| §2.5 | `glivenko_cantelli_uniform_proved` | **Landed S6 (this session)** |
+
+The chain has the parent's `glivenko_cantelli_uniform` AND the bracketing
+companion's `bracketingGrid_exists`. After S6, the parent's monolithic
+axiom is **logically redundant**: the bracketing companion now proves it
+modulo a purely real-analytic axiom. Retiring the parent's axiom is a
+mechanical follow-up (S7) — rename `glivenko_cantelli_uniform_proved` to
+`glivenko_cantelli_uniform` and delete the original axiom, or have the
+parent's theorem re-export the companion's.
+
+### Remaining work
+
+- **S7 (next session)**: retire parent's `axiom glivenko_cantelli_uniform`
+  in `LawsOfLargeNumbersOQ04.lean`. Replace with `theorem ...` proved by
+  `glivenko_cantelli_uniform_proved` from the bracketing companion (which
+  requires a re-export or shim because the bracketing companion imports
+  the parent, not vice versa — the cleanest path is to move the proved
+  variant into the parent file, or split the parent file to break the
+  cycle).
+- **S8+ (future Mathlib upstream)**: discharge `bracketingGrid_exists`
+  itself by formalising `Monotone.exists_increasing_continuity_seq`
+  (purely real-analytic; the only Mathlib gap remaining in the entire
+  Glivenko-Cantelli chain).
+
+## S5 (researcher-6, 2026-05-11) — §2.4 deterministic + limit form
 
 S4 landed §2.3 (`bracketing_simultaneous_pointwise`). S5 (this session) lands
 the second of the three remaining theorems, §2.4


### PR DESCRIPTION
## Summary

Lands **§2.5** of the bracketing decomposition — `glivenko_cantelli_uniform_proved` — closing the diagonal composition of §2.2 + §2.3 + §2.4. This is the final theorem of the `bracketing-decomposition-draft.md` §2 programme; with it in place the parent file's `glivenko_cantelli_uniform` axiom becomes logically redundant (a mechanical S7 follow-up retires it).

Builds on S5 (PR #17692). The parent file's Mathlib drift was repaired by mechanic PR #17864 (2026-05-12), so origin/main is build-ready when this lands.

## Deliverables

**Edited** `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (447 → 522 lines, +75 lines, +1 theorem):

| Decl | Kind | Sorries |
|------|------|---------|
| `glivenko_cantelli_uniform_proved` | theorem | **0** |

Same signature as the parent's `glivenko_cantelli_uniform` axiom; proves

\`\`\`lean
∀ᵐ ω ∂μ,
  Filter.Tendsto
    (fun n => ⨆ x : ℝ, |empiricalCDF X n x ω - trueCDF X μ x|)
    Filter.atTop (nhds 0)
\`\`\`

## Proof sketch

Diagonal composition along `ε m := 1 / (m + 1)`:

1. For each `m : ℕ`, take a bracketing grid `G m := (bracketingGrid_exists hX_meas (hε_pos m)).some` via the §2.2 axiom.
2. §2.3 (`bracketing_simultaneous_pointwise`) supplies, for each `m`, a full-measure set on which `Fₙ(qⱼ) → F(qⱼ)` simultaneously at every grid point.
3. `MeasureTheory.ae_all_iff` (countable conjunction; same lemma §2.3 used at the `Fin (k+2)` layer, here at the ℕ layer) combines the family into a single full-measure set.
4. For any `δ > 0`, pick `m` with `1/(m+1) < δ/3` via `exists_nat_one_div_lt`. Apply §2.4 (`bracketing_uniform_from_grid`) with slack `η := ε m`; eventually `⨆ x, |Fₙ(x, ω) − F(x)| ≤ 2 ε m + ε m = 3 ε m < δ`.
5. `Real.iSup_nonneg` flips `dist (⨆ ...) 0 = ⨆ ...` cleanly (unconditional on bounded-above).

## Mathlib API used

- `MeasureTheory.ae_all_iff` — countably indexed conjunction.
- `Metric.tendsto_atTop` — metric `Tendsto` characterisation.
- `exists_nat_one_div_lt` — diagonal accuracy step.
- `Real.iSup_nonneg` — iSup-of-nonneg ≥ 0, unconditional.
- `Filter.eventually_atTop`, `Real.dist_eq`, `abs_of_nonneg`, `sub_zero` — standard.

## Axiom Integrity

- 0 `axiom` declarations added.
- 0 sorries added.
- Bracketing companion's axiom count unchanged at 1 (`bracketingGrid_exists`).
- The parent's `glivenko_cantelli_uniform` axiom is now **logically redundant** (proved here modulo `bracketingGrid_exists`); retirement is a mechanical S7 follow-up (not in this PR).
- Status `axiomatized` per Axiom Integrity Policy unchanged. Gallery `meta.json` not touched (convention: `lineCount` / `theoremCount` track main file only; the companion file is `additionalFiles`).

## Bracketing decomposition — complete after this PR

| Section | Theorem | Status |
|---------|---------|--------|
| §2.1 | `BracketingGrid` structure | Landed S3 |
| §2.2 | `bracketingGrid_exists` axiom | Landed S3 (axiom; Mathlib-side gap) |
| §2.3 | `bracketing_simultaneous_pointwise` | Landed S4 |
| §2.4 | `bracketing_uniform_sup_bound` + `bracketing_uniform_from_grid` | Landed S5 |
| §2.5 | `glivenko_cantelli_uniform_proved` | **Landed this PR (S6)** |

## Honest calibration

This PR does **not** discharge the open mathematical content — that lives in the §2.2 axiom `bracketingGrid_exists` (a purely real-analytic statement: existence of finitely many CDF continuity points with ε-bounded F-jumps). What this PR does is finish the **probabilistic** side of the bracketing argument so that the remaining gap is squeezed entirely into the real-analytic axiom, which is the natural Mathlib upstream target as `Monotone.exists_increasing_continuity_seq`.

## Build verification

**Pending.** The `proofs/.lake` recursive self-symlink (memory: `feedback_researcher_lake_symlink_broken.md`) forces a ~45-min cold Mathlib clone on every build. Build started with `LEAN_BUILD_TIMEOUT=55m`; may not finish within session window.

API names verified against Mathlib 4.26 source by file-path lookup before commit:
- `Real.iSup_nonneg` (`Mathlib/Data/Real/Archimedean.lean:225`)
- `exists_nat_one_div_lt` (`Mathlib/Algebra/Order/Archimedean.lean:191`)
- `Metric.tendsto_atTop` (`Mathlib/Topology/MetricSpace/Pseudo/Defs.lean:932`)
- `MeasureTheory.ae_all_iff` (`Mathlib/MeasureTheory/OuterMeasure/AE.lean:93`)

PR title bears "(build pending)" matching the precedent for S3–S5 on this slug.

## Test plan

- [ ] Docker build completes (`Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`) cleanly.
- [ ] Type-check of `glivenko_cantelli_uniform_proved` against `bracketing_simultaneous_pointwise` / `bracketing_uniform_from_grid` / `bracketingGrid_exists` signatures.
- [ ] No new axioms / sorries introduced.

🤖 Generated by researcher-5