### PR TITLE
fix(meta): sync lineCount drift (3 entries)

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 158,
+    "lineCount": 157,
     "theoremCount": 4,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
@@ -175,7 +175,7 @@
       "ProbabilityTheory",
       "Set"
     ],
-    "lineCount": 158,
+    "lineCount": 157,
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 4,

--- a/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 235,
+    "lineCount": 231,
     "theoremCount": 14,
     "defCount": 3,
     "assumptions": "1 axiom: glivenko_cantelli_uniform (finite bracketing argument for uniform convergence — needs CDF continuity-point density infrastructure not in Mathlib 4.26). The two integration facts thresholdIndicator_integrable and integral_thresholdIndicator_eq_cdf are now fully proved. Pointwise convergence theorem is fully proved via SLLN.",
@@ -208,7 +208,7 @@
       "Set"
     ],
     "namespace": "GlivenkoCantelli",
-    "lineCount": 235,
+    "lineCount": 231,
     "axiomCount": 1,
     "theoremCount": 14,
     "definitionCount": 3,

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 929,
+    "lineCount": 930,
     "prerequisites": [
       "Probability distributions and discrete random variables",
       "Logarithm and convexity (Jensen's inequality)",
@@ -179,7 +179,7 @@
     ],
     "opens": [],
     "namespace": "InformationTheory",
-    "lineCount": 929,
+    "lineCount": 930,
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync `lineCount` in meta.json + leanFile blocks for 3 entries whose Lean files changed since the last drift sweep (PR #17794).

## Evidence

| Slug | Old | New | Driver |
|------|-----|-----|--------|
| `laws-of-large-numbers-oq-04` | 235 | 231 | PR #17864 trimmed integral proof |
| `laws-of-large-numbers-oq-04-oq-03` | 158 | 157 | PR #17864 trimmed integral proof |
| `shannon-entropy` | 929 | 930 | PR #17879 added `entropy_of_uniform_eq_log_card` |

Each entry updated in both `meta.lineCount` and `leanFile.lineCount`. Verified via `wc -l proofs/Proofs/<file>.lean` (231, 157, 930).

---
Automated fix by lean-mechanic agent.