### PR TITLE
research(erdos-szekeres-oq-03): S2 ACT-A — RamseyHypergraph API scaffold (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2449,6 +2449,7 @@ import Proofs.LagrangeTheoremOQ01OQ03
 import Proofs.LagrangeTheoremOQ02
 import Proofs.LagrangeTheoremOQ02OQ01
 import Proofs.LagrangeTheoremOQ02OQ02
+import Proofs.LagrangeTheoremOQ02OQ02OQ01
 import Proofs.LagrangeTheoremOQ03
 import Proofs.LagrangeTheoremOQ05
 import Proofs.LawOfCosines
@@ -2503,6 +2504,7 @@ import Proofs.MathematicalInductionOQ03
 import Proofs.MeanValueTheorem
 import Proofs.MeanValueTheoremOQ02
 import Proofs.MeanValueTheoremOQ02OQ04
+import Proofs.MeanValueTheoremOQ02OQ04OQ01
 import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
 import Proofs.MinkowskiFundamentalTheorem
@@ -2610,6 +2612,7 @@ import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityOQ03
 import Proofs.RamanujanSumFallacy
+import Proofs.RamseyHypergraph
 import Proofs.RamseyR4k
 import Proofs.RamseyR4kExtensions
 import Proofs.RamseyR4kOQ01

--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -1,0 +1,151 @@
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fin.Basic
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib.Data.Nat.Lattice
+import Mathlib.Tactic
+
+/-
+# Ramsey Numbers for k-Uniform Hypergraphs (OQ-03 of erdos-szekeres)
+
+## What This Establishes
+
+Erdős–Szekeres (Wiedijk #73, formalized in `Proofs/ErdosSzekeres.lean`) is the
+*sequence* refinement of graph Ramsey (`k = 2`). OQ-03 of `erdos-szekeres` asks
+for the generalization to `k`-uniform hypergraphs: for `k ≥ 2`, define the
+diagonal hypergraph Ramsey number `R_k(s,t)` as the least `n` such that every
+2-coloring of `[n]^{(k)}` (the `k`-subsets of `{0,...,n-1}`) contains a
+monochromatic `s`-clique of one color or a monochromatic `t`-clique of the
+other.
+
+This file is the **S2 scaffold** — it sets up the API and states the main
+existence theorem (`ramsey_existence`, OQ-03a) as a `sorry`. The two-layer
+neighborhood induction (Ramsey 1930) and the Erdős–Rado tower upper bound
+(OQ-03b) are deferred to later sessions per
+`research/problems/erdos-szekeres-oq-03/state.md`.
+
+## Status
+
+- [x] Definitions: `kColoring`, `IsMonochromatic`, `IsRamsey`, `ramseyNumber`.
+- [x] `IsMonochromatic_of_card_lt_k`: any subset smaller than `k` is trivially
+  monochromatic of every color (the `powersetCard` is empty).
+- [x] `is_ramsey_zero_clique`: the degenerate `s = 0` case (every coloring has
+  a `0`-clique).
+- [ ] `ramsey_existence` (OQ-03a): the main result, stated as `sorry`. Proof
+  strategy in `state.md`.
+- [ ] `ramseyNumber_one` (k=1 pigeonhole sanity check): stated as `sorry` and
+  scheduled for S3 alongside the existence theorem.
+
+## Approach
+
+- We model `k`-subsets of `{0,...,n-1}` as elements of
+  `(Finset.univ : Finset (Fin n)).powersetCard k`, and a 2-coloring as
+  `Finset (Fin n) → Bool` (only the values on `k`-subsets matter for
+  `IsMonochromatic`).
+- `ramseyNumber k s t` is defined as `sInf {n | IsRamsey n k s t}`; for
+  parameter values where the set is empty (e.g. degenerate inputs), this
+  returns `0`. Once `ramsey_existence` is proved, the value is the true
+  Ramsey number for all `k ≥ 2`, `s, t ≥ k`.
+
+## References
+
+- F. P. Ramsey, *On a problem of formal logic*, Proc. London Math. Soc. (2)
+  30 (1930), 264–286 — original proof of OQ-03a.
+- P. Erdős, R. Rado, *A partition calculus in set theory*, Bull. AMS 62
+  (1956), 427–489 — the tower upper bound (OQ-03b).
+- P. Erdős, A. Hajnal, *On Ramsey like theorems*, Combinatorics (Oxford 1972),
+  123–140 — stepping-up lower bound (OQ-03c).
+-/
+
+namespace RamseyK
+
+open Finset
+
+/-- A 2-coloring of the `k`-subsets of `{0,...,n-1}`. We model it as a
+function on all of `Finset (Fin n)`; only the values on subsets of cardinality
+`k` are inspected by `IsMonochromatic`. -/
+abbrev kColoring (n : ℕ) := Finset (Fin n) → Bool
+
+/-- A subset `S ⊆ {0,...,n-1}` is **monochromatic of color `c`** for a coloring
+`χ` at uniformity `k` if every `k`-subset of `S` is colored `c`. -/
+def IsMonochromatic {n : ℕ} (χ : kColoring n) (k : ℕ)
+    (S : Finset (Fin n)) (c : Bool) : Prop :=
+  ∀ T ∈ S.powersetCard k, χ T = c
+
+/-- The **Ramsey condition** `IsRamsey n k s t`: every 2-coloring of the
+`k`-subsets of `{0,...,n-1}` contains either a monochromatic `false` `s`-clique
+or a monochromatic `true` `t`-clique. -/
+def IsRamsey (n k s t : ℕ) : Prop :=
+  ∀ χ : kColoring n,
+    (∃ S : Finset (Fin n), S.card = s ∧ IsMonochromatic χ k S false) ∨
+    (∃ S : Finset (Fin n), S.card = t ∧ IsMonochromatic χ k S true)
+
+/-- The **k-uniform hypergraph Ramsey number**: the least `n` such that
+`IsRamsey n k s t` holds. By `sInf` convention on `ℕ`, this is `0` if no
+such `n` exists; once `ramsey_existence` is proved for `k ≥ 2`, `s, t ≥ k`,
+this returns the true Ramsey number. -/
+noncomputable def ramseyNumber (k s t : ℕ) : ℕ :=
+  sInf {n | IsRamsey n k s t}
+
+/-- A subset smaller than the uniformity `k` has no `k`-subsets and is
+trivially monochromatic of every color. -/
+lemma isMonochromatic_of_card_lt {n k : ℕ} (χ : kColoring n)
+    (S : Finset (Fin n)) (c : Bool) (h : S.card < k) :
+    IsMonochromatic χ k S c := by
+  intro T hT
+  rw [Finset.mem_powersetCard] at hT
+  obtain ⟨hTsub, hTcard⟩ := hT
+  have hTle : T.card ≤ S.card := Finset.card_le_card hTsub
+  exfalso
+  omega
+
+/-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
+and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
+every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.
+
+This is the main result of the OQ-03 entry. The proof (Ramsey 1930) is by
+two-layer induction on `k` and `s + t`; see `state.md` for the strategy.
+Deferred to S3. -/
+theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
+    ∃ n, IsRamsey n k s t := by
+  sorry
+
+/-- The empty set is a `0`-clique, monochromatic of every color. -/
+lemma isMonochromatic_empty_zero {n k : ℕ} (χ : kColoring n) (c : Bool)
+    (hk : 1 ≤ k) :
+    IsMonochromatic χ k (∅ : Finset (Fin n)) c := by
+  apply isMonochromatic_of_card_lt
+  rw [Finset.card_empty]
+  exact hk
+
+/-- Degenerate base case: when the `false`-target size is `0`, every coloring
+trivially has a `0`-monochromatic `false` "clique" — the empty set. Hence
+`IsRamsey n k 0 t` holds for all `n, k, t` with `k ≥ 1`. -/
+lemma is_ramsey_zero_false (n k t : ℕ) (hk : 1 ≤ k) : IsRamsey n k 0 t := by
+  intro χ
+  refine Or.inl ⟨∅, ?_, ?_⟩
+  · exact Finset.card_empty
+  · exact isMonochromatic_empty_zero χ false hk
+
+/-- Symmetric degenerate base case for the `true`-target. -/
+lemma is_ramsey_zero_true (n k s : ℕ) (hk : 1 ≤ k) : IsRamsey n k s 0 := by
+  intro χ
+  refine Or.inr ⟨∅, ?_, ?_⟩
+  · exact Finset.card_empty
+  · exact isMonochromatic_empty_zero χ true hk
+
+/-- (k=1 sanity check, scheduled for S3.) The `k = 1` Ramsey number is the
+pigeonhole bound `s + t - 1`. Stated here for the API; proof deferred to S3
+(it needs both the pigeonhole-forward direction and an explicit bad coloring
+for the lower bound).
+
+The forward direction (showing `IsRamsey (s+t-1) 1 s t` via `Finset.filter`
+counting) is straightforward; the reverse `¬ IsRamsey (s+t-2) 1 s t` requires
+constructing the coloring with `s-1` `false`-singletons and `t-1`
+`true`-singletons. -/
+theorem ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
+    ramseyNumber 1 s t = s + t - 1 := by
+  sorry
+
+end RamseyK

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,25 +1,36 @@
 # Current State
 
-**Phase**: ORIENT
-**Since**: 2026-05-12 (S1 OBSERVE → ORIENT, researcher-8)
-**Iteration**: 1
+**Phase**: ACT (S2 scaffold landed; existence + k=1 sanity check remain `sorry`)
+**Since**: 2026-05-12 (S2 ACT-A scaffold, researcher-9)
+**Iteration**: 2
 
 ## Current Focus
 
-Session 1 (S1, researcher-8, 2026-05-12): Survey of the hypergraph
-Ramsey-number literature for the OQ-03 generalization of Erdős–Szekeres.
-No Lean changes — pure OBSERVE/ORIENT pass to set up future ACT sessions.
+Session 2 (S2 ACT-A, researcher-9, 2026-05-12): create the
+`RamseyHypergraph.lean` API surface and state the main existence theorem
+(OQ-03a) as a `sorry`.
 
 Output of this session:
 
-* `problem.md` — formal restatement of OQ-03 as three sub-goals
-  (existence OQ-03a, Erdős–Rado upper bound OQ-03b, Erdős–Hajnal lower bound
-  OQ-03c) with explicit tower-function bounds.
-* `knowledge.md` — literature survey covering Ramsey (1930), Erdős–Rado
-  (1952), Erdős–Hajnal (1972) stepping-up, and Conlon–Fox–Sudakov (2010);
-  Mathlib API audit; suggested `RamseyK.ramseyNumber` API surface.
-* This `state.md` update advancing NEW → ORIENT and pinning the
-  S2 next-action.
+* `proofs/Proofs/RamseyHypergraph.lean` (~147 lines, 2 sorries, 0 axioms).
+  Definitions: `kColoring`, `IsMonochromatic`, `IsRamsey`, `ramseyNumber`
+  (via `sInf`).
+  Proved API lemmas: `isMonochromatic_of_card_lt` (subsets smaller than
+  the uniformity have no `k`-subsets, hence are trivially monochromatic),
+  `isMonochromatic_empty_zero`, `is_ramsey_zero_false`, `is_ramsey_zero_true`
+  (degenerate `s=0` / `t=0` cases — the empty set is the witness).
+  Two sorries:
+  - `ramsey_existence` (the OQ-03a main theorem) — to be discharged in S3.
+  - `ramseyNumber_one` (k=1 pigeonhole sanity check) — postponed to S3
+    because the lower-bound construction (a coloring with `s-1`
+    `false`-singletons and `t-1` `true`-singletons) takes more space than
+    initially estimated.
+* `proofs/Proofs.lean` regenerated to include the new file.
+
+## Prior Session Outputs (S1, researcher-8)
+
+* `problem.md` — formal restatement of OQ-03 as three sub-goals.
+* `knowledge.md` — literature survey + Mathlib API audit.
 
 ## Active Approach
 
@@ -54,25 +65,44 @@ adequate but verbose.
 
 ## Next Action
 
-**S2 ACT-A.** Create `proofs/Proofs/RamseyHypergraph.lean` with:
+**S3 ACT-B.** Two parallel tasks (can be done in either order):
 
-* `def IsMonochromatic {n k : ℕ} (χ : Finset (Fin n) → Bool) (S : Finset (Fin n)) (c : Bool) : Prop`
-* `def IsRamsey (n k s t : ℕ) : Prop`
-* `def ramseyNumber (k s t : ℕ) : ℕ := Nat.find ...`
-* `lemma ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) : ramseyNumber 1 s t = s + t - 1`
-* `theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) : ∃ n, IsRamsey n k s t := by sorry`
+1. **Pigeonhole base case `ramseyNumber_one s t = s + t - 1`.**
+   - Forward (`IsRamsey (s+t-1) 1 s t`): partition `Fin (s+t-1)` by
+     `i ↦ χ {i}`; if `|filter (χ{·}=false)| ≥ s` use that as the s-clique,
+     else (by pigeonhole) the complement gives a t-clique.
+   - Backward (`¬ IsRamsey (s+t-2) 1 s t`): explicit coloring with the
+     first `s-1` singletons `false` and the remaining `t-1` `true`.
+   - Combine via `sInf_eq_iff` (or by showing both `sInf ≤ s+t-1` and
+     `s+t-1 ≤ sInf`).
+2. **Existence theorem `ramsey_existence` (OQ-03a).**
+   The standard two-layer induction (Ramsey 1930). Induct on `s + t`
+   for fixed `k`; the inductive step is the "neighborhood-tree" argument:
+   fix any vertex `v`, the `(k-1)`-restrictions of `k`-subsets through
+   `v` give a `(k-1)`-coloring on `[n] \ {v}`, then apply induction at
+   uniformity `k-1`.
+   - Base case `k = 2`: reuse `SimpleGraph.ramseyNumber` from Mathlib
+     (or re-prove inline). 
+   - Inductive step (k ≥ 3): the harder half; ~150-300 lines depending on
+     how much Mathlib API is built up.
 
-Add the gallery shim: `src/data/research/problems/erdos-szekeres-oq-03.json`
-should list this new file under `leanFiles` (or leave unchanged if the
-file is not yet created; S2 will add the entry).
+S4 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (literature survey + Lean API design)
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: 2 (literature survey + Lean API design; S2 scaffold)
 
 ## Outcome of S1
 
 ORIENT complete. Three sub-goals (existence, Erdős–Rado upper, Erdős–Hajnal
 lower) cleanly stated; Mathlib gaps identified; S2 ACT-A is unblocked.
+
+## Outcome of S2
+
+S2 SCAFFOLD landed (build pending). `RamseyHypergraph.lean` adds 4
+definitions and 4 sorry-free supporting lemmas alongside 2 sorries
+(`ramsey_existence`, `ramseyNumber_one`). The `IsMonochromatic`-of-too-small
+helper and the `s=0` / `t=0` degenerate Ramsey base cases form the
+foundation for S3's pigeonhole and inductive arguments.

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -28,24 +28,25 @@
     "goal": "Lean-formalize the finiteness theorem (OQ-03a) and the Erdős–Rado upper bound (OQ-03b) via a new RamseyK.ramseyNumber API, then state the stepping-up lower bound (OQ-03c) as a theorem with sorry."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 1,
-    "focus": "S1 OBSERVE → ORIENT (researcher-8): literature survey + Lean API design. No Lean changes this session.",
+    "iteration": 2,
+    "focus": "S2 ACT-A scaffold (researcher-9): create RamseyHypergraph.lean with the RamseyK API surface (kColoring / IsMonochromatic / IsRamsey / ramseyNumber); 4 sorry-free degenerate-case lemmas; ramsey_existence and ramseyNumber_one stated as sorries.",
     "blockers": [],
-    "nextAction": "S2 ACT-A: create proofs/Proofs/RamseyHypergraph.lean with RamseyK.ramseyNumber definition, the k=1 pigeonhole base case, and ramsey_existence stated as a sorry.",
+    "nextAction": "S3 ACT-B: discharge ramseyNumber_one via pigeonhole (forward + lower-bound coloring) and start the ramsey_existence two-layer induction.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals — (a) finiteness, (b) Erdős–Rado tower upper bound, (c) Erdős–Hajnal stepping-up lower bound — with explicit Lean API surface for a new RamseyK module. Identified Mathlib gap: no Hypergraph / RamseyK definition yet; existing SimpleGraph.ramseyNumber covers only k=2.",
+    "progressSummary": "S2 ACT-A scaffold (researcher-9 2026-05-12): created proofs/Proofs/RamseyHypergraph.lean with the four-element RamseyK API surface (kColoring, IsMonochromatic, IsRamsey, ramseyNumber via sInf), four sorry-free supporting lemmas (`isMonochromatic_of_card_lt`, `isMonochromatic_empty_zero`, `is_ramsey_zero_false`, `is_ramsey_zero_true`), and two sorry-bearing main theorems (`ramsey_existence` for OQ-03a, `ramseyNumber_one` for the k=1 sanity check). 147 lines, 0 axioms, 2 sorries. S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals — (a) finiteness, (b) Erdős–Rado tower upper bound, (c) Erdős–Hajnal stepping-up lower bound — with explicit Lean API surface for a new RamseyK module.",
     "builtItems": [
-      "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals.",
-      "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey (Ramsey 1930, Erdős–Rado 1952, Erdős–Hajnal 1972, Conlon–Fox–Sudakov 2010) + Mathlib API audit + suggested RamseyK API surface.",
-      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced NEW → ORIENT with S2 next-action pinned."
+      "proofs/Proofs/RamseyHypergraph.lean — RamseyK API + 4 sorry-free degenerate-case lemmas + 2 sorry-bearing theorems (S2).",
+      "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals (S1).",
+      "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey + Mathlib API audit + suggested API surface (S1).",
+      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S3 next-action pinned."
     ],
     "insights": [
       "OQ-03 cleanly factors into existence + upper + lower bounds; the existence and upper bound share the same two-layer neighborhood induction.",
@@ -59,8 +60,7 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S2: implement RamseyK module with definitions + k=1 pigeonhole + ramsey_existence sorry.",
-      "S3: discharge ramsey_existence by the two-layer induction.",
+      "S3: discharge ramseyNumber_one via pigeonhole (forward direction is straightforward; lower-bound construction takes an explicit coloring) and start ramsey_existence via the two-layer induction.",
       "S4: state erdos_rado_upper as a tower-function bound and prove it by unwinding the recursive R_k ≤ R_{k-1}(...) inequality.",
       "S5: spawn the stepping-up lower bound as a separate sub-OQ if S4 lands cleanly."
     ]
@@ -95,10 +95,21 @@
     ]
   },
   "started": "2026-05-12T04:48:16.447Z",
-  "lastUpdate": "2026-05-12T15:00:00.000Z",
+  "lastUpdate": "2026-05-12T06:15:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
+    {
+      "path": "Proofs/RamseyHypergraph.lean",
+      "filename": "RamseyHypergraph.lean",
+      "lineCount": 147,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RamseyHypergraph.lean"
+    },
     {
       "path": "Proofs/ErdosSzekeres.lean",
       "filename": "ErdosSzekeres.lean",


### PR DESCRIPTION
## Summary

S1 (#17899, merged ~1h ago) set up the OQ-03 plan as three sub-goals
(existence, Erdős–Rado upper bound, Erdős–Hajnal stepping-up lower bound).
This **S2 ACT-A** lands the API surface in a new file
`proofs/Proofs/RamseyHypergraph.lean`.

## What's new

**Lean (`proofs/Proofs/RamseyHypergraph.lean`, 147 lines, 0 axioms, 2 sorries):**

- 1 abbrev: `kColoring n = Finset (Fin n) → Bool`.
- 3 defs:
  - `IsMonochromatic χ k S c`
  - `IsRamsey n k s t`
  - `noncomputable def ramseyNumber k s t := sInf {n | IsRamsey n k s t}`.
- 4 sorry-free supporting lemmas:
  - `isMonochromatic_of_card_lt`: any subset smaller than the uniformity
    `k` has no `k`-subsets, hence is trivially monochromatic.
  - `isMonochromatic_empty_zero`: the empty set is mono of every color.
  - `is_ramsey_zero_false` / `is_ramsey_zero_true`: degenerate `s=0` / `t=0`
    cases — the empty set is the witness `0`-clique.
- 2 sorries (both scheduled for S3):
  - `ramsey_existence` (OQ-03a, main theorem) — Ramsey 1930's two-layer
    induction.
  - `ramseyNumber_one` — the `k=1` pigeonhole sanity check.

**Manifest:** `proofs/Proofs.lean` regenerated. Picks up two pre-existing
catch-up imports for `LagrangeTheoremOQ02OQ02OQ01` and
`MeanValueTheoremOQ02OQ04OQ01` (both already in `proofs/Proofs/` but not
imported on origin/main).

**Research bookkeeping:**

- `research/problems/erdos-szekeres-oq-03/state.md` — phase advanced
  ORIENT → ACT, S3 next-action pinned.
- `src/data/research/problems/erdos-szekeres-oq-03.json` — `leanFiles`
  now lists `RamseyHypergraph.lean` alongside `ErdosSzekeres.lean`;
  `progressSummary`, `builtItems`, `nextSteps`, `currentState` updated.

## Test plan

- [x] No new Mathlib imports beyond well-established modules.
- [x] No new axioms.
- [x] No new Lean file for the gallery — this is a research entry only;
  the live gallery entry remains `ErdosSzekeres.lean`.
- [ ] Docker build pending (cold Mathlib re-clone; sibling slugs land
  under "(build pending)" title per established pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)