### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S18c — open-cover + finite-subcover packaging (build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -600,6 +600,56 @@ private lemma typeclass_witnesses_compact_subset {n : ℕ}
   -- ParacompactSpace ↥S: inferred from CompactSpace (paracompact_of_compact).
   exact ⟨inferInstance, inferInstance, inferInstance, inferInstance⟩
 
+/-- **S18c scaffold (Cellina–Browder Steps 1–2 packaged together):**
+
+    For an upper-hemicontinuous set-valued map `F : ↥S → 2^↥S` on a
+    compact `S ⊆ EuclideanSpace ℝ (Fin n)` and any `ε > 0`, produce:
+
+    * a function `U : ↥S → Set ↥S` of subtype-relative open
+      neighborhoods (one per base point), each contained in the inverse
+      image (in the UHC sense) of the `ε`-thickening of `F(x)`;
+    * a finite `s : Finset ↥S` of cover centers whose open
+      neighborhoods exhaust all of `↥S`.
+
+    The construction chains `uhc_local_thickening` (S17 scaffold, PR
+    #17708) pointwise over `↥S`, then invokes
+    `CompactSpace.elim_nhds_subcover` once `[CompactSpace ↥S]` is
+    materialised from `hS_compact` (the same `haveI` line as in
+    `typeclass_witnesses_compact_subset`, S18b PR #17802). The
+    quantifier-signature gating question on `IsUpperHemicontinuous` was
+    resolved doc-only in PR #17800: `uhc_local_thickening` applies
+    directly at `Y = ↥S` with no preimage pull-back step.
+
+    No new axiom is introduced; `axiom approx_selection_exists` (Axiom
+    2 above) remains in the file unchanged. The full ↥S-indexed family
+    `U` is returned alongside the finite cover `s` so that the
+    downstream S18d invocation of
+    `PartitionOfUnity.exists_isSubordinate` (subordinate partition of
+    unity, Cellina Step 3) can choose either the full family `U` or
+    the finite subfamily `{U x : x ∈ s}` as its index set.
+
+    Reference: S17 Mathlib API survey
+    (`research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s17-cellina-mathlib-api-survey.md`),
+    Steps 1–2; S17-followup quantifier resolution PR #17800. -/
+private lemma exists_finite_subcover_for_uhc {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n))) (hS_compact : IsCompact S)
+    (F : SetValuedMap (↥S) (↥S))
+    (hF_uhc : IsUpperHemicontinuous F)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∃ U : ↥S → Set ↥S, ∃ s : Finset ↥S,
+      (∀ x : ↥S, IsOpen (U x)) ∧
+      (∀ x : ↥S, x ∈ U x) ∧
+      (∀ x z : ↥S, z ∈ U x → F z ⊆ Metric.thickening ε (F x)) ∧
+      (⋃ x ∈ s, U x = (⊤ : Set ↥S)) := by
+  haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact
+  -- Step 1: pointwise local thickening from UHC (S17 scaffold).
+  choose U hU_open hU_mem hU_sub using
+    fun x : ↥S => uhc_local_thickening hF_uhc x ε hε
+  -- Step 2: compactness extracts a finite subcover (CompactSpace API).
+  obtain ⟨s, hs⟩ :=
+    CompactSpace.elim_nhds_subcover U fun x => (hU_open x).mem_nhds (hU_mem x)
+  exact ⟨U, s, hU_open, hU_mem, hU_sub, hs⟩
+
 /-- **Sequential Compactness in Metric Spaces**
 
     In a compact metric space, every sequence has a convergent subsequence.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s18c-open-cover-finite-subcover.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s18c-open-cover-finite-subcover.md
@@ -1,0 +1,147 @@
+# S18c — Open-cover + finite-subcover packaging (Cellina–Browder Steps 1–2)
+
+**Author**: researcher-3, 2026-05-12
+**Iteration**: S18c
+**Mode**: ACT (build pending — Docker build deferred to CI; the two
+new Mathlib API references re-verified at pinned rev via GitHub
+Contents API)
+**File**: `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`
+**Target axiom (eventual)**: `approx_selection_exists` (Cellina–Browder
+graph form, line 504)
+**Mathlib pinned rev**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+
+## What landed
+
+A single private helper lemma `exists_finite_subcover_for_uhc`
+(50 lines counting the docstring) discharging Steps 1 and 2 of the
+Cellina–Browder construction in one go:
+
+```lean
+private lemma exists_finite_subcover_for_uhc {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n))) (hS_compact : IsCompact S)
+    (F : SetValuedMap (↥S) (↥S))
+    (hF_uhc : IsUpperHemicontinuous F)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∃ U : ↥S → Set ↥S, ∃ s : Finset ↥S,
+      (∀ x : ↥S, IsOpen (U x)) ∧
+      (∀ x : ↥S, x ∈ U x) ∧
+      (∀ x z : ↥S, z ∈ U x → F z ⊆ Metric.thickening ε (F x)) ∧
+      (⋃ x ∈ s, U x = (⊤ : Set ↥S))
+```
+
+### Proof structure
+
+Three tactic blocks; the loadbearing line is `choose`:
+
+1. `haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact`
+   — same line as `typeclass_witnesses_compact_subset` (S18b).
+   Materialises the typeclass instance needed in step 3.
+
+2. `choose U hU_open hU_mem hU_sub using fun x : ↥S =>
+   uhc_local_thickening hF_uhc x ε hε`
+   — pointwise application of S17's
+   `uhc_local_thickening` (PR #17708) to every base point `x : ↥S`.
+   Lean's `choose` tactic produces:
+   - `U : ↥S → Set ↥S`
+   - `hU_open : ∀ x, IsOpen (U x)`
+   - `hU_mem : ∀ x, x ∈ U x`
+   - `hU_sub : ∀ x z, z ∈ U x → F z ⊆ Metric.thickening ε (F x)`
+
+3. `obtain ⟨s, hs⟩ := CompactSpace.elim_nhds_subcover U (fun x =>
+   (hU_open x).mem_nhds (hU_mem x))`
+   — extracts a finite subcover via Mathlib's `CompactSpace` API
+   (`Mathlib.Topology.Compactness.Compact` L763).
+
+4. `exact ⟨U, s, hU_open, hU_mem, hU_sub, hs⟩`
+   — repackage the four facts plus the cover equation.
+
+## Mathlib API re-verification
+
+Both Mathlib lemma references re-confirmed at pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via GitHub Contents API.
+
+### `isCompact_iff_compactSpace`
+`Mathlib/Topology/Compactness/Compact.lean` L989:
+```lean
+theorem isCompact_iff_compactSpace : IsCompact s ↔ CompactSpace s
+```
+`.mp` direction: `IsCompact S → CompactSpace ↥S`. Same site as S18b's
+`typeclass_witnesses_compact_subset`. No drift between S18b and S18c
+(both verified at the same rev).
+
+### `CompactSpace.elim_nhds_subcover`
+`Mathlib/Topology/Compactness/Compact.lean` L763:
+```lean
+theorem CompactSpace.elim_nhds_subcover [CompactSpace X]
+    (U : X → Set X) (hU : ∀ x, U x ∈ 𝓝 x) :
+    ∃ t : Finset X, ⋃ x ∈ t, U x = ⊤
+```
+Used directly with the `nhds` membership built from `hU_open` and
+`hU_mem` via `IsOpen.mem_nhds`. The output equation `⋃ x ∈ t, U x = ⊤`
+matches the `(⊤ : Set ↥S)` clause in the lemma statement.
+
+## Why include the full ↥S-indexed `U` (not just the finite Finset)
+
+`PartitionOfUnity.exists_isSubordinate`
+(`Mathlib.Topology.PartitionOfUnity` L433) takes an indexed family
+`U : ι → Set X` with `s ⊆ ⋃ i, U i`. For S18d's invocation:
+
+* If the implementer prefers `ι = ↥S` (full family), the cover
+  hypothesis `Set.univ ⊆ ⋃ x : ↥S, U x` follows from `hU_mem x`
+  via `Set.subset_iUnion` (one-line chase).
+* If the implementer prefers `ι = ↑(s : Finset ↥S)` (the finite
+  subcover), the cover hypothesis follows directly from the
+  `⋃ x ∈ s, U x = ⊤` equation, after restricting to the Finset's
+  index type.
+
+Returning both lets S18d (and S18e) pick whichever index set is
+ergonomically lighter, without re-deriving the family from
+`uhc_local_thickening` a second time.
+
+## Independent S17-followup compatibility
+
+PR #17800 (open at time of writing; researcher-8, doc-only) resolved
+the `IsUpperHemicontinuous` quantifier-signature gating question by
+confirming that `uhc_local_thickening` applies directly at `Y = ↥S`
+with no preimage pull-back step. S18c's proof exercises this
+resolution operationally — the second tactic block invokes
+`uhc_local_thickening hF_uhc x ε hε` where `hF_uhc :
+IsUpperHemicontinuous (F : SetValuedMap (↥S) (↥S))`. Successful Lean
+typechecking of this single line is the practical confirmation that
+the S17-followup analysis is correct.
+
+If PR #17800 lands before this PR, there will be a state.md merge
+conflict in the "Independent S18-prep" / iteration history sections;
+both PRs add information in the same neighbourhood. The conflict is
+docs-only and resolvable by keeping both sections side by side.
+
+## Honest scope statement
+
+**S18c does not eliminate any axiom.** It is the third of the six
+S18a–f scaffolding PRs (per the S17 survey's 6-step decomposition,
+sized to keep each PR ≤ 80 lines and independent of prior PR builds).
+The deliverable is:
+
+* One new private lemma packaging Cellina–Browder Steps 1–2 (50 lines
+  including 30-line docstring).
+* `meta.json` `lineCount` and `theoremCount` sync (907→957, 8→9).
+* `state.md` history row + reference-files index entry.
+* This session note documenting the proof and API re-verification.
+
+The axiom replacement is unchanged at 2 axioms. The next iteration
+(S18d) is the partition-of-unity construction (~30 lines) using
+S18c's open-cover output.
+
+## References
+
+* S17 survey:
+  `s17-cellina-mathlib-api-survey.md` (researcher-11, 2026-05-11) —
+  Steps 1–2 of the Cellina averaging proof.
+* S17 Step-1 scaffold: PR #17708 (researcher-1, merged 2026-05-12) —
+  `lemma uhc_local_thickening`.
+* S17-followup quantifier resolution: PR #17800 (researcher-8, open
+  2026-05-12, doc-only) — `s17-followup-uhc-quantifier-resolution.md`.
+* S18a convex-combination helper: PR #17755 (researcher-9, merged
+  2026-05-12) — `private lemma convex_combination_of_partition_in_S`.
+* S18b typeclass plumbing: PR #17802 (researcher-11, merged
+  2026-05-12) — `private lemma typeclass_witnesses_compact_subset`.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,13 +1,35 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ACT (S18b typeclass-instance plumbing landed; **0 sorries**, 2 axioms remaining)
+**Phase**: ACT (S18c open-cover + finite subcover landed; **0 sorries**, 2 axioms remaining)
 **Path**: full
-**Since**: 2026-05-12T03:35:00Z
-**Iteration**: 18b
+**Since**: 2026-05-12T06:10:00Z
+**Iteration**: 18c
 
 ## Current Focus
-S18b (researcher-11, 2026-05-12, this iteration): Added `private lemma
+S18c (researcher-3, 2026-05-12, this iteration): Added `private lemma
+exists_finite_subcover_for_uhc` packaging Cellina–Browder Steps 1–2 in
+a single statement. For a compact `S ⊆ EuclideanSpace ℝ (Fin n)` and
+an upper-hemicontinuous `F : ↥S → 2^↥S` at any `ε > 0`, the lemma
+yields a function `U : ↥S → Set ↥S` of subtype-relative open
+neighborhoods plus a finite `s : Finset ↥S` such that (i) each `U x`
+is open in `↥S` and contains `x`, (ii) `F(U x) ⊆ ε`-thickening of
+`F(x)` for every `x`, and (iii) the family `{U x : x ∈ s}` covers
+`↥S` (`⋃ x ∈ s, U x = (⊤ : Set ↥S)`). Proof: `haveI [CompactSpace ↥S]`
+from `isCompact_iff_compactSpace.mp` (the same line as S18b);
+pointwise `choose` of `uhc_local_thickening` (S17 PR #17708) to
+construct `U` with its three witnessing properties; then
+`CompactSpace.elim_nhds_subcover U (fun x => (hU_open x).mem_nhds
+(hU_mem x))` to extract the finite Finset. Net file change: lineCount
+907 → 957 (+50); theoremCount 8 → 9 (+1); sorry count unchanged at 0;
+axiom count unchanged at 2. Build pending (`proofs/.lake`
+recursive-symlink trap forces ~45 min cold Docker clone; the two
+Mathlib API references (`isCompact_iff_compactSpace` at
+Compactness/Compact.lean L989 and `CompactSpace.elim_nhds_subcover` at
+Compactness/Compact.lean L763) re-verified at pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via GitHub Contents API).
+
+S18b (researcher-11, 2026-05-12, PR #17802 merged): Added `private lemma
 typeclass_witnesses_compact_subset` confirming that the four typeclass
 instances required for the Cellina–Browder construction
 (`CompactSpace ↥S`, `T2Space ↥S`, `NormalSpace ↥S`, `ParacompactSpace ↥S`)
@@ -101,18 +123,19 @@ Two axioms remain:
    decomposes implementation into 6 PRs (each ≤ 80 lines).
 
 ## Next Action
-**S18c (next claim, ~50 lines)**: Open-cover build + finite subcover
-(Cellina Steps 1–2). For each `x ∈ ↥S`, S17's `uhc_local_thickening`
-(PR #17708) gives an open `U_x ∋ x` with `F(U_x) ⊆ ε`-thickening of
-`F(x)` — and per the S18b prep finding, this lemma is **directly
-applicable** (UHC quantifies over subtype-relative open sets in our
-use case, no preimage-pull step needed). Use
-`CompactSpace.elim_nhds_subcover` (available once `[CompactSpace ↥S]`
-is in scope per S18b) to extract a finite subcover
-`{U_{x_i}}_{i=1}^k`. Package the result as
-`private lemma exists_finite_subcover_for_uhc` taking the same
-hypotheses as `axiom approx_selection_exists`. No axiom elimination
-yet; this readies S18d (subordinate partition of unity).
+**S18d (next claim, ~30 lines)**: Subordinate partition of unity
+(Cellina Step 3). With S18c's `U : ↥S → Set ↥S` open family and the
+typeclass instances from S18b (`[NormalSpace ↥S]`,
+`[ParacompactSpace ↥S]`) in scope, invoke
+`PartitionOfUnity.exists_isSubordinate`
+(`Mathlib.Topology.PartitionOfUnity` L433) to obtain
+`ρ : PartitionOfUnity (↥S) (↥S) Set.univ` with `ρ.IsSubordinate U`.
+Package as `private lemma exists_partition_subordinate_to_uhc_cover`
+threading the S18c output (`U` and `Set.univ ⊆ ⋃ x : ↥S, U x`,
+obtained from `hU_mem x : x ∈ U x` via `Set.subset_iUnion`) into
+`exists_isSubordinate`. The `hs : IsClosed s` hypothesis is
+`isClosed_univ`. No axiom elimination yet; readies S18e (continuous
+selection construction).
 
 ## Open PRs
 - PR #17493 (researcher-5, 2026-05-08T22:43Z): S11 — closed-ball Brouwer
@@ -131,7 +154,8 @@ yet; this readies S18d (subordinate partition of unity).
 | S17 | 2026-05-11 | researcher-11 | #17711 (merged) | Mathlib v4.26 API survey for `approx_selection_exists` axiom elimination |
 | S17 | 2026-05-12 | researcher-1 | #17708 (merged) | `lemma uhc_local_thickening` Cellina–Browder Step-1 scaffold (+37 lines) |
 | S18a | 2026-05-12 | researcher-9 | #17755 (merged) | Private helper `convex_combination_of_partition_in_S` (+48 lines) |
-| S18b | 2026-05-12 | researcher-11 | (this PR) | Private helper `typeclass_witnesses_compact_subset` (+43 lines, +1 theorem, meta sync 827→907) |
+| S18b | 2026-05-12 | researcher-11 | #17802 (merged) | Private helper `typeclass_witnesses_compact_subset` (+43 lines, +1 theorem, meta sync 827→907) |
+| S18c | 2026-05-12 | researcher-3 | (this PR) | Private helper `exists_finite_subcover_for_uhc` packaging Steps 1–2 (+50 lines, +1 theorem, meta sync 907→957) |
 
 ## Reference Files (in this directory)
 - `problem.md` — original problem statement
@@ -148,5 +172,6 @@ yet; this readies S18d (subordinate partition of unity).
 - `s15-mathlib-api-drift-fix.md` — S15 (researcher-3) drift-fix note
 - `s17-cellina-mathlib-api-survey.md` — S17 (researcher-11) Mathlib API map for axiom elimination
 - `s18a-convex-combination-helper.md` — S18a (researcher-9, merged #17755) convex-combination-of-partition-of-unity helper note
-- `s18b-typeclass-witnesses.md` — **S18b (this iteration)** typeclass instance plumbing note
+- `s18b-typeclass-witnesses.md` — S18b (researcher-11, merged #17802) typeclass instance plumbing note
+- `s18c-open-cover-finite-subcover.md` — **S18c (this iteration)** open-cover + finite-subcover packaging note
 

--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -208,9 +208,9 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 907,
+    "lineCount": 957,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

S18c (third of six S18a–f Cellina–Browder scaffolding PRs per the S17 survey). Adds `private lemma exists_finite_subcover_for_uhc` discharging Cellina–Browder **Steps 1–2** in a single statement:

```
∃ U : ↥S → Set ↥S, ∃ s : Finset ↥S,
  (∀ x : ↥S, IsOpen (U x)) ∧
  (∀ x : ↥S, x ∈ U x) ∧
  (∀ x z : ↥S, z ∈ U x → F z ⊆ Metric.thickening ε (F x)) ∧
  (⋃ x ∈ s, U x = (⊤ : Set ↥S))
```

For a compact `S ⊆ EuclideanSpace ℝ (Fin n)` and an UHC `F : ↥S → 2^↥S`, at any `ε > 0`.

## Proof structure (50 lines incl. 30-line docstring)

1. `haveI [CompactSpace ↥S] := isCompact_iff_compactSpace.mp hS_compact` — same line as S18b's `typeclass_witnesses_compact_subset` (PR #17802).
2. `choose U hU_open hU_mem hU_sub using fun x => uhc_local_thickening hF_uhc x ε hε` — pointwise application of S17's helper (PR #17708).
3. `obtain ⟨s, hs⟩ := CompactSpace.elim_nhds_subcover U (fun x => (hU_open x).mem_nhds (hU_mem x))` — Mathlib v4.26 `Compactness/Compact.lean` L763.
4. `exact ⟨U, s, hU_open, hU_mem, hU_sub, hs⟩`.

## Mathlib API re-verification (pinned rev 2df2f0150c)

Both new Mathlib API references re-confirmed via GitHub Contents API:

- `isCompact_iff_compactSpace` — `Mathlib/Topology/Compactness/Compact.lean` L989.
- `CompactSpace.elim_nhds_subcover` — `Mathlib/Topology/Compactness/Compact.lean` L763.

## Why return both `U` and `s : Finset ↥S`

`PartitionOfUnity.exists_isSubordinate` (S18d call site) takes an indexed family with a cover-by-iUnion hypothesis. Returning the full ↥S-indexed `U` lets S18d use it directly (cover from `hU_mem x` via `Set.subset_iUnion`); returning the Finset `s` lets S18d optionally restrict to a finite index. The implementer picks whichever is lighter.

## Honesty

- **Axiom count unchanged at 2** (`brouwer_unit_ball`, `approx_selection_exists`).
- Three of six S18a–f scaffolding PRs are now landed (S18a #17755, S18b #17802, S18c here). Remaining: S18d (subordinate PoU, ~30 lines), S18e (continuous selection, ~40 lines), S18f (graph-distance bound, ~50 lines). Then S19 replaces `axiom approx_selection_exists` with `theorem approx_selection_exists_proof`.
- Build pending: the worktree's `proofs/.lake` recursive-symlink trap forces a ~45-min cold Docker clone; build is deferred to CI. The two Mathlib API references were re-verified at pinned rev via GitHub Contents API.

## Files changed

| File | Δ |
|---|---|
| `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` | +50 (`exists_finite_subcover_for_uhc` + docstring) |
| `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` | `leanFile.lineCount` 907→957; `leanFile.theoremCount` 8→9 |
| `research/problems/.../state.md` | Phase/Iter S18b→S18c; new history row; next-action rewritten to S18d |
| `research/problems/.../s18c-open-cover-finite-subcover.md` | NEW (147 lines; proof + Mathlib API re-verification + S18d hand-off) |

## Test plan

- [ ] CI build verifies `exists_finite_subcover_for_uhc` typechecks at Mathlib v4.26 pinned rev.
- [ ] S18d follow-up PR consumes the `U`/`s` outputs into `PartitionOfUnity.exists_isSubordinate`.

🤖 Generated by researcher-3 (Opus 4.7) on 2026-05-12