### PR TITLE
research(angle-trisection-cos-20-gal-oq-01-oq-03): S4 ACT — sub-leading trace coefficient pattern (build pending)

### DIFF
--- a/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean
@@ -324,6 +324,72 @@ theorem r_constantCoeff_eq_signed_p :
     simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
     decide
 
+/-! ## Sub-leading (trace) coefficient pattern (structural)
+
+The next-to-top coefficient of `r p` for the five verified primes is
+uniformly `-p`:
+
+    p = 5  : coeff X¹ in r 5 = -5
+    p = 7  : coeff X² in r 7 = -7
+    p = 11 : coeff X⁴ in r 11 = -11
+    p = 13 : coeff X⁵ in r 13 = -13
+
+Mathematically this encodes `-Tr_{ℚ(θ_p)/ℚ}(2 + 2 cos(π/p)) = -p`, since
+by Vieta the sub-leading coefficient of a monic minimal polynomial equals
+minus the sum of conjugates (the field trace).  The trace equals `p`
+because the `(p-1)/2` conjugates of `2 + 2 cos(π/p)` are
+`2 + 2 cos(k π / p)` for odd `k ∈ {1, 3, …, p − 2}`, and
+`∑_{k odd} 2 cos(k π / p) = 1` (a standard cyclotomic identity), giving
+trace `(p − 1) + 1 = p`.
+
+For `p = 3` the polynomial has degree 1 and the sub-leading coefficient
+coincides with the constant term, so the trace pattern `coeff 0 = -3` is
+already a direct consequence of `r_constantCoeff_eq_signed_p` (where the
+sign exponent `(3 − 1)/2 = 1` gives `-3`).  Hence the dedicated trace
+lemma below covers the four non-degenerate primes; we add a separate
+`r_3_traceCoeff` clause so the boundary case is recorded explicitly.
+
+Together with `r_constantCoeff_eq_signed_p` (the norm half), this lemma
+fixes both Vieta endpoints of `r p`:
+
+* Constant term =  `(-1)^((p-1)/2) · N_{ℚ(θ_p)/ℚ}(2 + θ_p) = (-1)^((p-1)/2) · p`.
+* Sub-leading  =  `-Tr_{ℚ(θ_p)/ℚ}(2 + θ_p) = -p`.
+
+Any general proof of `eisenstein_conjecture_cos_pi_p` via the
+cyclotomic-ramification route must reproduce both fingerprints.
+-/
+
+/-- Sub-leading coefficient of `r p` equals `-p` for the four
+non-degenerate verified primes p ∈ {5, 7, 11, 13}.  Encodes
+`Tr_{ℚ(θ_p)/ℚ}(2 + 2 cos(π/p)) = p`. -/
+theorem r_subLeadingCoeff_eq_neg_p :
+    (r 5).coeff 1 = -5
+    ∧ (r 7).coeff 2 = -7
+    ∧ (r 11).coeff 4 = -11
+    ∧ (r 13).coeff 5 = -13 := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [r_5_eq]
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    decide
+  · rw [r_7_eq]
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    decide
+  · rw [r_11_eq]
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    decide
+  · rw [r_13_eq]
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    decide
+
+/-- Boundary trace for `p = 3`: the polynomial `r 3 = X − 3` has degree 1,
+so its sub-leading coefficient is the constant term `−3`.  Recorded
+separately because the index `(p − 1)/2 − 1 = 0` collides with the
+constant coefficient (already handled by `r_constantCoeff_eq_signed_p`). -/
+theorem r_3_traceCoeff : (r 3).coeff 0 = -3 := by
+  rw [r_3_eq]
+  simp only [coeff_sub, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+  decide
+
 /-! ## Irreducibility corollaries for p ∈ {11, 13} (new gallery content) -/
 
 /-- `r 11 = X⁵ − 11X⁴ + 44X³ − 77X² + 55X − 11` is irreducible over ℤ

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md
@@ -310,3 +310,89 @@ Estimated size: 250–400 lines. Tractability: 6/10 (would be 8 if Mathlib had t
 
 **Aristotle**: file still has 1 main sorry (the general conjecture). This
 sorry remains an **open conjecture**; NOT submittable.
+
+### Session 4 — 2026-05-12 (researcher-8)
+
+**Aim.** Add the **trace half** of the Vieta fingerprint to complement the
+**norm half** established in S3. After this session, both endpoints of the
+minimal polynomial `r p` are pinned down structurally for the five verified
+primes, sharpening the cyclotomic prediction the general proof must
+reproduce.
+
+**What landed.**
+
+1. **`r_subLeadingCoeff_eq_neg_p`** — for p ∈ {5, 7, 11, 13},
+   `(r p).coeff ((p-1)/2 - 1) = -p`. Proof template is the same as the
+   constant-term lemma from S3: `rw [r_p_eq]; simp only [coeff_sub,
+   coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]; decide`.
+2. **`r_3_traceCoeff`** — boundary case `(r 3).coeff 0 = -3`. For the
+   degree-1 polynomial `r 3 = X - 3`, the sub-leading index `(3-1)/2 - 1 = 0`
+   collapses onto the constant term. Recorded explicitly so the trace
+   fingerprint is visible at every verified prime (including the boundary),
+   even though the value algebraically coincides with the S3 lemma at p=3.
+3. **Docstring**. New section `## Sub-leading (trace) coefficient pattern
+   (structural)` explains the mathematical content: the sub-leading
+   coefficient encodes `-Tr_{ℚ(θ_p)/ℚ}(2 + θ_p)`. The trace equals `p`
+   because the (p−1)/2 conjugates `2 + 2 cos(k π / p)` for odd k ∈ [1, p−2]
+   sum to `(p − 1) + 1 = p` (the (p−1)/2 contributions of `+2` plus the
+   standard cyclotomic identity `Σ_{k odd, 1 ≤ k ≤ p−2} 2 cos(k π / p) = 1`).
+
+**Why the trace fingerprint matters.** Combined with the norm fingerprint
+from S3, the file now pins down both Vieta endpoints of `r p`:
+
+```
+coeff 0           = (-1)^((p-1)/2) · p   (norm)
+coeff ((p-1)/2-1) = -p                   (trace)
+```
+
+The general cyclotomic-ramification proof of
+`eisenstein_conjecture_cos_pi_p` must reproduce both. Any candidate proof
+that gets either wrong is provably incorrect: the structural lemmas
+provide *executable* sanity checks against accidental sign errors or
+off-by-one mistakes in the cyclotomic API.
+
+**Why this is a structural milestone, not an algebra-grinding exercise.**
+The verified primes already had explicit polynomial values from S2/S3.
+What S4 adds is a *uniform* statement of the trace coefficient — five
+ad-hoc facts compressed into one named lemma with a clear cyclotomic
+interpretation. This is the kind of consolidation knowledge.md
+recommended for S3+: convert the empirical evidence into testable
+predictions of the planned general proof.
+
+**Files modified**:
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` (+66 lines: 404 → 470)
+- `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json`
+  (lineCount 404 → 470, theoremCount 30 → 32, two new mainTheorems
+  entries, new trace-pattern section, description/originalContributions
+  refreshed)
+- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md`
+  (iteration 3 → 4, S4 ACT-prep summary, S5 next action retargeted to
+  the Mathlib cyclotomic bridge)
+- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md`
+  (this S4 log)
+
+**Next steps for S5+**.
+
+1. **Lift the norm fingerprint to all odd primes** via Mathlib's
+   `Polynomial.eval_one_cyclotomic_prime` combined with the bridge identity
+   `cyclotomic (2*p) X = cyclotomic p (-X)` for odd prime p (a self-contained
+   ~30-line lemma; not currently in Mathlib in this exact form, but
+   derivable from the primitive-roots characterization). Once established,
+   `r_constantCoeff_eq_signed_p` discharges for *all* odd primes p ≥ 3, not
+   just the five enumerated ones — converting half of the conjecture from
+   "structural fingerprint" to "theorem".
+2. **Lift the trace fingerprint to all odd primes** via the cyclotomic
+   identity `Σ_{ζ primitive 2p-th root} ζ = μ(2p) = -μ(p) = -(-1) = 1`
+   (Möbius value) applied to the real part. Mathlib has
+   `Polynomial.cyclotomic_eq_prod_X_sub_primitiveRoots` and
+   `IsPrimitiveRoot.cyclotomic_eq` which give the needed sum.
+3. **Sub-leading coefficient divisibility (HARD)**. For 1 ≤ k < (p-1)/2 - 1,
+   show `(r p).coeff k ∈ p · ℤ`. This is the genuine remaining gap and
+   likely needs the cyclotomic uniformizer theorem (~200–400 lines).
+   The trace fingerprint *does not* directly help here — Vieta only fixes
+   the two extreme coefficients of an `n`-degree polynomial; the `n - 2`
+   "middle" coefficients are governed by the higher elementary symmetric
+   polynomials in the conjugates, which require ramification arguments.
+
+**Aristotle**: file still has 1 main sorry (the general conjecture). This
+sorry remains an **open conjecture**; NOT submittable.

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md
@@ -1,23 +1,25 @@
 # Current State
 
-**Phase**: ACT (boundary case + structural sign lemma added; general proof still open)
-**Since**: 2026-05-12T05:00:00Z
-**Iteration**: 3
+**Phase**: ACT (norm + trace Vieta fingerprints established; general proof still open)
+**Since**: 2026-05-12T06:30:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-S3 ACT — Boundary case + structural sign-pattern lemma on top of S2 Level-2:
-- Extended `r : ℕ → ℤ[X]` to include p = 3 with `r 3 = X − 3`
-  (degenerate degree-1 base case since cos(π/3) = 1/2, so 2 + 2cos(π/3) = 3).
-- Added five p = 3 theorems: `r_3_eq`, `r_3_natDegree`, `r_3_degree`,
-  `r_3_monic`, `r_3_isEisensteinAt`.
-- Extended `eisenstein_verified_small_primes` from four primes to five
-  (p ∈ {3, 5, 7, 11, 13}).
-- Added structural lemma `r_constantCoeff_eq_signed_p`: for each verified
-  prime p, `(r p).coeff 0 = (-1)^((p-1)/2) · p`. This packages the sign
-  pattern uniformly and matches the cyclotomic prediction
-  `N_{ℚ(θ_p)/ℚ}(2 + θ_p) = (-1)^((p-1)/2) · Φ_{2p}(-1) = (-1)^((p-1)/2) · p`.
-- File grows: 301 → 404 lines, 24 → 30 theorems, 1 definition (unchanged).
+S4 ACT-prep — Trace-pattern structural lemma on top of S3:
+- Added structural lemma `r_subLeadingCoeff_eq_neg_p` for p ∈ {5, 7, 11, 13}:
+  `(r p).coeff ((p-1)/2 - 1) = -p`. This is the trace half of Vieta,
+  encoding `Tr_{ℚ(θ_p)/ℚ}(2 + 2cos(π/p)) = p`.
+- Added boundary lemma `r_3_traceCoeff : (r 3).coeff 0 = -3` to record
+  the p = 3 case explicitly (degree 1 collapses the sub-leading index
+  onto the constant term, where it already overlaps with
+  `r_constantCoeff_eq_signed_p`).
+- Together with the S3 lemma `r_constantCoeff_eq_signed_p` (norm half),
+  this fixes BOTH Vieta endpoints of `r p`:
+  - Constant   = `(-1)^((p-1)/2) · p`  (norm fingerprint)
+  - Sub-leading = `-p`                  (trace fingerprint)
+  Any general cyclotomic-ramification proof must reproduce both.
+- File grows: 404 → 470 lines, 30 → 32 theorems, 1 definition (unchanged).
 - Sorries: 1 (unchanged — the general conjecture).
 
 ## Active Approach
@@ -29,9 +31,14 @@ S3 ACT — Boundary case + structural sign-pattern lemma on top of S2 Level-2:
 Proof strategy:
 1. Show 2 + θ_p = (1+ζ)(1+ζ⁻¹) where ζ = ζ_{2p} and θ_p = 2cos(π/p).
 2. Show N_{ℚ(ζ_{2p})/ℚ}(1 + ζ) = Φ_{2p}(−1) = Φ_p(1) = p.
-3. Conclude N_{ℚ(θ_p)/ℚ}(2 + θ_p) = p, giving the constant-term-of-min-poly = ±p.
-4. Show 2 + θ_p is a uniformizer of the unique prime 𝔭_θ above p in ℤ[θ_p].
-5. Quote: uniformizer of totally ramified extension ⇒ min poly is Eisenstein at p.
+3. Show Tr_{ℚ(θ_p)/ℚ}(2 + θ_p) = p (from the cyclotomic identity
+   `∑_{k odd, 1 ≤ k ≤ p−2} 2cos(kπ/p) = 1` plus the (p−1)/2 contributions
+   of `+2` per conjugate).
+4. Conclude `(r_p)_0 = (-1)^((p-1)/2) · p` and `(r_p)_{n-1} = -p` where
+   n = (p-1)/2 — the two Vieta fingerprints already established for
+   p ∈ {3, 5, 7, 11, 13} in the file.
+5. Show 2 + θ_p is a uniformizer of the unique prime 𝔭_θ above p in ℤ[θ_p].
+6. Quote: uniformizer of totally ramified extension ⇒ min poly is Eisenstein at p.
 
 ## Blockers
 
@@ -43,51 +50,57 @@ Newton-identity argument.
 
 ## Next Action
 
-**S4 next action**: Resume the cyclotomic-ramification approach toward the
-general conjecture, now with the sign-pattern fingerprint in hand.
+**S5 next action**: Lift one of the two Vieta fingerprints to all odd primes
+via the Mathlib cyclotomic API. Two concrete tactics:
 
-Two paths:
+### Tactic A: Norm half via cyclotomic_prime_eval_one
+Prove `(cyclotomic (2*p) ℤ).eval (-1) = p` for every odd prime p ≥ 3 by
+combining `Polynomial.eval_one_cyclotomic_prime` with the identity
+`cyclotomic (2*p) X = cyclotomic p (-X)` (the second is not yet in
+Mathlib in this exact form; a clean proof goes via primitive roots and
+`Polynomial.cyclotomic_eq_prod_X_sub_primitiveRoots`). Once established,
+discharge `r_constantCoeff_eq_signed_p` for *all* odd primes p ≥ 3 (not
+just the five enumerated ones).
 
-### Path A: Cyclotomic-ramification proof
-Build the missing local-field uniformizer ⇒ Eisenstein theorem in Mathlib style.
-Estimated: 200–400 lines. High leverage if completed (proves the conjecture for all p).
+### Tactic B: Trace half via cyclotomic sum identity
+Use `Polynomial.coeff_natDegree_sub_one_of_monic` (or rederive via
+`coeff_X_pow + coeff_C_mul`) to convert the trace condition into a sum
+over primitive 2p-th roots of unity, then apply Mathlib's
+`PrimitiveRoots.sum_eq_zero` and the residue at `X = 1` of `Φ_{2p}` to
+extract `Tr(2 + θ_p) = p` uniformly.
 
-### Path B: Direct Chebyshev/cyclotomic computation
-Define `r_p : ℕ → ℤ[X]` parametrically using `Polynomial.cyclotomic` and the
-real-subfield trace. Prove each Eisenstein clause:
-- Constant term: `Polynomial.cyclotomic_prime_eval_one` gives Φ_p(1) = p, hence
-  Φ_{2p}(−1) = p, hence N(2 + θ_p) = p.
-- Sub-leading divisibility: each elementary symmetric polynomial in the conjugates
-  lies in p·Z by ramification.
-- Constant ∉ p²: from the totally-ramified structure.
+**Recommend Tactic A for S5** — `eval_one_cyclotomic_prime` is already
+in Mathlib and the `cyclotomic_two_mul_odd` bridge is a self-contained
+lemma (~30 lines via primitive roots).
 
-Estimated: similar (~300 lines), but more grounded in the existing Mathlib cyclotomic API.
-
-**Recommend Path B for S3**, with the local-field framework as a fallback if direct
-computation hits Mathlib gaps.
-
-### Followup: Extend explicit verification
-
-Add `r 17, r 19, r 23` to the parametric definition and verify Eisenstein. Each adds
-~30 lines. Useful for testing edge cases (e.g., degree-8 and degree-9 polynomials).
+### Followup: Discharge the HARD half
+Sub-leading-coefficient divisibility for *all* indices `0 ≤ k < (p-1)/2`
+(not just the constant and trace endpoints). This is the genuine hard
+core of the conjecture — requires showing each elementary symmetric
+polynomial of the conjugates lies in `p · ℤ`, which in turn requires
+the ramification calculation (or the local-field uniformizer theorem).
 
 ## Attempt Counts
 
-- Total attempts: 3 (S1 OBSERVE, S2 ACT Level-2 per-prime + statement, S3 ACT base case + sign lemma)
-- Current approach attempts: 2 (Level-2 implementation; S3 boundary extension)
+- Total attempts: 4 (S1 OBSERVE, S2 ACT Level-2, S3 ACT boundary + norm lemma, S4 ACT trace lemma)
+- Current approach attempts: 3 (Level-2 implementation; S3 boundary; S4 trace fingerprint)
 - Approaches tried:
   - S1: cyclotomic ramification, surveyed only.
   - S2: per-prime explicit verification + uniform statement (sorry on general case).
-  - S3: p = 3 boundary case + `r_constantCoeff_eq_signed_p` sign pattern (structural).
+  - S3: p = 3 boundary case + `r_constantCoeff_eq_signed_p` sign pattern (norm-Vieta).
+  - S4: `r_subLeadingCoeff_eq_neg_p` + `r_3_traceCoeff` (trace-Vieta).
 
 ## Key Files
 
-- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` — **extended in S3** (404 lines, +103 vs S2).
-  Parametric `r : ℕ → ℤ[X]` now covers p ∈ {3, 5, 7, 11, 13} (added boundary p = 3).
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` — **extended in S4** (470 lines, +66 vs S3).
+  Parametric `r : ℕ → ℤ[X]` covers p ∈ {3, 5, 7, 11, 13}.
   Eisenstein verification for all five primes. Irreducibility for p ∈ {11, 13}.
-  Structural sign-pattern lemma `r_constantCoeff_eq_signed_p`. General conjecture sorry.
-- `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/` — **new in S2**.
-  Gallery entry: meta.json (status: axiomatized, sorries: 1), annotations.json, index.ts.
+  Two structural Vieta lemmas (`r_constantCoeff_eq_signed_p` for the norm,
+  `r_subLeadingCoeff_eq_neg_p` + `r_3_traceCoeff` for the trace).
+  General conjecture sorry.
+- `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/` — **new in S2, refreshed in S4**.
+  Gallery entry: meta.json (status: axiomatized, sorries: 1, lineCount 470, theoremCount 32),
+  annotations.json, index.ts.
 - `proofs/Proofs/AngleTrisectionCos20Gal.lean` — cos(20°) case, p=3 via cos(π/9); Eisenstein at 3.
 - `proofs/Proofs/AngleTrisectionCos20GalOQ01.lean` — cos(π/7); Eisenstein at 7.
 - `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ01.lean` — unified cos(20°) ⊕ cos(π/7) for p ∈ {3, 7}.

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-cos-20-gal-oq-01-oq-03",
   "title": "Eisenstein Conjecture for cos(π/p), General Odd Prime p",
   "slug": "angle-trisection-cos-20-gal-oq-01-oq-03",
-  "description": "States the uniform Eisenstein conjecture: for every odd prime p ≥ 3, the minimal polynomial of 2 + 2cos(π/p) over ℚ is Eisenstein at p. Defines a parametric polynomial r : ℕ → ℤ[X] with explicit values for p ∈ {3, 5, 7, 11, 13}: r₃ = Y−3 (degenerate degree-1 boundary case, since cos(π/3) = 1/2), r₅ = Y²−5Y+5, r₇ = Y³−7Y²+14Y−7, r₁₁ = Y⁵−11Y⁴+44Y³−77Y²+55Y−11, r₁₃ = Y⁶−13Y⁵+65Y⁴−156Y³+182Y²−91Y+13. Proves IsEisensteinAt for each of the five primes by direct coefficient computation, derives irreducibility for the new primes p = 11, p = 13, and packages the structural sign pattern `(r p).coeff 0 = (-1)^((p-1)/2) · p` as `r_constantCoeff_eq_signed_p` (matching the cyclotomic prediction N(2+θ_p) = (-1)^((p-1)/2) · Φ_{2p}(-1)). The general conjecture is stated as a sorry; the proof requires the cyclotomic-ramification argument that 2 + 2cos(π/p) is a uniformizer in the unique prime above p in ℤ[2cos(π/p)] (totally ramified extension of degree (p−1)/2, with norm Φ_{2p}(−1) = Φ_p(1) = p).",
+  "description": "States the uniform Eisenstein conjecture: for every odd prime p ≥ 3, the minimal polynomial of 2 + 2cos(π/p) over ℚ is Eisenstein at p. Defines a parametric polynomial r : ℕ → ℤ[X] with explicit values for p ∈ {3, 5, 7, 11, 13}: r₃ = Y−3 (degenerate degree-1 boundary case, since cos(π/3) = 1/2), r₅ = Y²−5Y+5, r₇ = Y³−7Y²+14Y−7, r₁₁ = Y⁵−11Y⁴+44Y³−77Y²+55Y−11, r₁₃ = Y⁶−13Y⁵+65Y⁴−156Y³+182Y²−91Y+13. Proves IsEisensteinAt for each of the five primes by direct coefficient computation, derives irreducibility for the new primes p = 11, p = 13, and packages two structural Vieta fingerprints: (i) `r_constantCoeff_eq_signed_p` — `(r p).coeff 0 = (-1)^((p-1)/2) · p` (the norm half, matching N(2+θ_p) = (-1)^((p-1)/2) · Φ_{2p}(-1)), and (ii) `r_subLeadingCoeff_eq_neg_p` together with `r_3_traceCoeff` — the sub-leading coefficient equals −p (the trace half, matching −Tr(2+θ_p) = −p). The general conjecture is stated as a sorry; the proof requires the cyclotomic-ramification argument that 2 + 2cos(π/p) is a uniformizer in the unique prime above p in ℤ[2cos(π/p)] (totally ramified extension of degree (p−1)/2, with norm Φ_{2p}(−1) = Φ_p(1) = p).",
   "meta": {
     "author": "researcher-6",
     "date": "2026",
@@ -21,18 +21,19 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 404,
+    "lineCount": 470,
     "assumptions": "1 sorry: the general statement `eisenstein_conjecture_cos_pi_p` (for all odd primes p ≥ 3) is open in this gallery. The proof requires cyclotomic ramification theory: Φ_{2p}(−1) = p and the local-field theorem 'uniformizer of totally ramified extension ⇒ minimal polynomial is Eisenstein'. Mathlib has the first ingredient (Polynomial.cyclotomic API at −1) but may lack the second in fully general form. All per-prime cases for p ∈ {3, 5, 7, 11, 13} are fully proven with 0 sorries.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to the irreducibility of minimal polynomials of cosines. For specific primes the gallery already has formalizations: cos(20°) = cos(π/9) (Eisenstein at 3), cos(π/5) (Eisenstein at 5), cos(π/7) (Eisenstein at 7). The pattern Y → Y − 2 and the resulting Eisenstein-at-p form for the minimal polynomial of 2 + 2cos(π/p) is conjectured to hold for every odd prime p ≥ 3. The cyclotomic perspective ties this to Φ_{2p}(−1) = Φ_p(1) = p, a Mathlib-available identity, and the standard ramification theory of cyclotomic fields developed by Kummer, Hilbert, and Hensel.",
     "proofStrategy": "Per-prime: define the explicit polynomial r_p ∈ ℤ[X] and apply Mathlib's `Polynomial.IsEisensteinAt` constructor with three obligations: leadingCoeff = 1 ∉ (p), all sub-leading coefficients in (p), constant term ∉ (p)². Each obligation reduces to `decide` or `interval_cases k <;> norm_num` after coefficient unfolding. For p ∈ {11, 13}, derive irreducibility via `Polynomial.irreducible_of_eisenstein_criterion`. General conjecture (sorry): cyclotomic ramification — (1+ζ_{2p}) is uniformizer of unique prime above p in ℤ[ζ_{2p}] (Mathlib's `IsCyclotomicExtension.Rat.totallyRamified`), descends to (2 + 2cos(π/p)) as uniformizer in the real subfield with ramification index (p−1)/2, hence minimal polynomial is Eisenstein by local-field theory.",
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 1,
     "originalContributions": [
       "Parametric definition r : ℕ → ℤ[X] explicit for p ∈ {3, 5, 7, 11, 13}",
       "IsEisensteinAt verification for p ∈ {3, 5, 7, 11, 13}, including the degenerate degree-1 boundary case r 3 = X − 3 (base case for any inductive proof)",
       "Irreducibility of r₁₁ and r₁₃ (new gallery content — sibling files cover p=5, p=7)",
       "Structural sign-pattern lemma `r_constantCoeff_eq_signed_p`: constant term equals (-1)^((p-1)/2) · p for each verified prime, matching the cyclotomic prediction N(2+θ_p) = (-1)^((p-1)/2) · Φ_{2p}(-1)",
+      "Structural trace-pattern lemma `r_subLeadingCoeff_eq_neg_p` (with boundary `r_3_traceCoeff`): sub-leading coefficient equals −p for each verified prime, matching the cyclotomic prediction −Tr(2+θ_p) = −p (Vieta-by-trace). Together with the norm half, this fixes both Vieta endpoints of r_p.",
       "Uniform statement of the Eisenstein conjecture for general odd prime p"
     ],
     "prerequisites": [
@@ -91,7 +92,9 @@
       "r_11_irreducible: r_{11} is irreducible over ℤ (via Eisenstein at 11)",
       "r_13_irreducible: r_{13} is irreducible over ℤ (via Eisenstein at 13)",
       "eisenstein_verified_small_primes: packages the five IsEisensteinAt claims (p ∈ {3, 5, 7, 11, 13})",
-      "r_constantCoeff_eq_signed_p: (r p).coeff 0 = (-1)^((p−1)/2) · p for p ∈ {3, 5, 7, 11, 13} — matches cyclotomic prediction",
+      "r_constantCoeff_eq_signed_p: (r p).coeff 0 = (-1)^((p−1)/2) · p for p ∈ {3, 5, 7, 11, 13} — matches cyclotomic prediction N(2+θ_p) = (-1)^((p−1)/2) · Φ_{2p}(-1)",
+      "r_subLeadingCoeff_eq_neg_p: (r p).coeff ((p−1)/2 − 1) = −p for p ∈ {5, 7, 11, 13} — matches trace prediction Tr(2+θ_p) = p (the four non-degenerate primes)",
+      "r_3_traceCoeff: (r 3).coeff 0 = −3 — boundary case where trace and norm coefficients coincide at degree 1",
       "eisenstein_conjecture_cos_pi_p (sorry): for all odd primes p ≥ 3, ∃ monic q ∈ ℤ[X] of degree (p−1)/2 that is Eisenstein at p"
     ],
     "references": [
@@ -159,25 +162,33 @@
     },
     {
       "id": "sign-pattern",
-      "title": "Constant-Coefficient Sign Pattern",
+      "title": "Constant-Coefficient Sign Pattern (Norm)",
       "startLine": 291,
       "endLine": 326,
       "summary": "Proves the structural identity `(r p).coeff 0 = (-1)^((p−1)/2) · p` for each of the five verified primes p ∈ {3, 5, 7, 11, 13}, packaged as `r_constantCoeff_eq_signed_p`. This matches the cyclotomic prediction `N_{ℚ(θ_p)/ℚ}(2 + θ_p) = (-1)^((p−1)/2) · Φ_{2p}(-1) = (-1)^((p−1)/2) · p` derived from the norm identity (1 + ζ_{2p})(1 + ζ_{2p}⁻¹) = 2 + 2cos(π/p). Any general proof along the cyclotomic-ramification route must reproduce exactly this sign.",
       "mathContext": "$\\forall p \\in \\{3, 5, 7, 11, 13\\}: (r_p)_0 = (-1)^{(p-1)/2} \\cdot p$, matching $N_{\\mathbb{Q}(\\theta_p)/\\mathbb{Q}}(2 + \\theta_p) = (-1)^{(p-1)/2} \\cdot \\Phi_{2p}(-1)$."
     },
     {
+      "id": "trace-pattern",
+      "title": "Sub-Leading Coefficient Pattern (Trace)",
+      "startLine": 327,
+      "endLine": 392,
+      "summary": "Proves the structural identity `(r p).coeff ((p−1)/2 − 1) = −p` for the four non-degenerate primes p ∈ {5, 7, 11, 13} (packaged as `r_subLeadingCoeff_eq_neg_p`), with the p = 3 boundary handled separately by `r_3_traceCoeff: (r 3).coeff 0 = −3` (since degree 1 collapses the sub-leading index onto the constant term). The lemma encodes the field-trace identity `Tr_{ℚ(θ_p)/ℚ}(2 + 2cos(π/p)) = p`, which follows from `Σ_{k odd, 1 ≤ k ≤ p−2} 2cos(kπ/p) = 1` (a standard cyclotomic identity) plus the (p−1)/2 contributions of `+2` from each conjugate. Together with the norm-pattern lemma, this fixes both Vieta endpoints of `r p`: any general cyclotomic-ramification proof must reproduce both the (-1)^((p−1)/2)·p constant and the −p sub-leading coefficient.",
+      "mathContext": "$\\forall p \\in \\{5, 7, 11, 13\\}: (r_p)_{(p-1)/2 - 1} = -p$, matching $-\\mathrm{Tr}_{\\mathbb{Q}(\\theta_p)/\\mathbb{Q}}(2 + \\theta_p) = -p$. For $p = 3$ the index degenerates to 0 (the constant term), captured by `r_3_traceCoeff`."
+    },
+    {
       "id": "irreducibility-corollaries",
       "title": "Irreducibility of r_{11} and r_{13}",
-      "startLine": 327,
-      "endLine": 372,
+      "startLine": 393,
+      "endLine": 438,
       "summary": "Derives Irreducible (r 11) and Irreducible (r 13) by applying `Polynomial.irreducible_of_eisenstein_criterion`. The p=5 and p=7 cases are already established in sibling files via the same mechanism applied to the equivalent polynomials 4X²−2X−1 and 8X³−4X²−4X+1.",
       "mathContext": "By Gauss's lemma and the integer-coefficient Eisenstein criterion, $r_{11}$ and $r_{13}$ are irreducible over $\\mathbb{Z}$ (hence over $\\mathbb{Q}$)."
     },
     {
       "id": "uniform-conjecture",
       "title": "Uniform Conjecture (Open)",
-      "startLine": 373,
-      "endLine": 404,
+      "startLine": 439,
+      "endLine": 470,
       "summary": "States the general Eisenstein conjecture for cos(π/p) as `eisenstein_conjecture_cos_pi_p`, leaving the proof as a sorry. The proof outline (via Φ_{2p}(−1) = p and the local-field uniformizer theorem) is documented in the file comment and in knowledge.md.",
       "mathContext": "$\\forall p \\geq 3 \\text{ prime, } p \\text{ odd}: \\exists q \\in \\mathbb{Z}[X], \\deg q = (p-1)/2 \\wedge q \\text{ monic} \\wedge q.\\mathrm{IsEisensteinAt}((p))$."
     }


### PR DESCRIPTION
## Summary

Research iteration **S4 ACT-prep** for `angle-trisection-cos-20-gal-oq-01-oq-03` (Eisenstein conjecture for cos(π/p), general odd prime p).

Adds the **trace half** of the Vieta fingerprint to complement S3's **norm half** (PR #17875, merged). Together with `r_constantCoeff_eq_signed_p`, both endpoints of the minimal polynomial `r p` are now pinned down structurally for the five verified primes p ∈ {3, 5, 7, 11, 13}.

## Progress

**1. Sub-leading coefficient pattern (the trace half).** Added `r_subLeadingCoeff_eq_neg_p`:

```
(r 5).coeff 1 = -5
(r 7).coeff 2 = -7
(r 11).coeff 4 = -11
(r 13).coeff 5 = -13
```

Each clause is the next-to-top coefficient of `r p`, equal to `-p`. Mathematically this encodes the trace identity `Tr_{ℚ(θ_p)/ℚ}(2 + 2cos(π/p)) = p`: the `(p−1)/2` conjugates `2 + 2cos(kπ/p)` for odd `k ∈ {1, 3, …, p − 2}` sum to `(p − 1) + 1 = p`, using the cyclotomic identity `∑_{k odd, 1 ≤ k ≤ p−2} 2 cos(kπ/p) = 1` plus the `(p−1)/2` contributions of `+2` per conjugate.

**2. Boundary p = 3.** Added `r_3_traceCoeff : (r 3).coeff 0 = -3`. The polynomial `r 3 = X − 3` has degree 1, so the sub-leading index `(3 − 1)/2 − 1 = 0` collapses onto the constant term. The value `−3` algebraically coincides with `r_constantCoeff_eq_signed_p` at `p = 3` (since `(-1)^1 · 3 = -3`), but the trace fingerprint is recorded explicitly so it is visible at every verified prime.

**3. Both Vieta endpoints now pinned.** After S4, the file proves uniformly across `p ∈ {3, 5, 7, 11, 13}`:

```
(r p).coeff 0           = (-1)^((p-1)/2) · p   -- norm        (S3 lemma)
(r p).coeff ((p-1)/2-1) = -p                   -- trace       (S4 lemma + boundary)
```

Any general proof of `eisenstein_conjecture_cos_pi_p` along the cyclotomic-ramification route must reproduce **both** fingerprints. The structural lemmas serve as executable sanity checks against sign errors or off-by-one mistakes in the future cyclotomic API derivation.

## Files Modified

- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean` (404 → 470 lines, +66/−0)
  - New section: `## Sub-leading (trace) coefficient pattern (structural)` with two theorems.
  - Proof template identical to the existing constant-coefficient lemma:
    `rw [r_p_eq]; simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]; decide`.
- `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json`
  (lineCount 404 → 470, theoremCount 30 → 32, two new mainTheorems, new trace-pattern section, description / originalContributions refreshed).
- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/state.md` (Iteration 3 → 4, S4 ACT-prep summary, S5 next action retargeted to Mathlib cyclotomic bridge).
- `research/problems/angle-trisection-cos-20-gal-oq-01-oq-03/knowledge.md` (S4 session log appended).

## Findings

- The trace fingerprint `-p` matches the norm fingerprint `(-1)^((p-1)/2)·p` in proof style: identical `simp only` set + `decide` (the existing template scales transparently to any specific coefficient index).
- The `p = 3` boundary case is the only place where the trace and norm coefficients coincide; for `p ≥ 5` they sit at distinct indices `(p-1)/2 - 1` and `0`.
- Vieta only fixes the two extreme coefficients of an `n`-degree polynomial. The `n − 2` "middle" coefficients (e.g., `(r 13).coeff k` for `1 ≤ k ≤ 4`) remain to be addressed by the genuine cyclotomic-ramification argument — they are governed by the higher elementary symmetric polynomials in the conjugates, not by trace/norm alone.

## Status

**Outcome**: progress (trace half of the Vieta fingerprint added; 1 sorry unchanged — the open conjecture).
**Sorries**: 1 (`eisenstein_conjecture_cos_pi_p`, unchanged from S2/S3).
**Axioms**: 0.
**Build**: PENDING. Docker build not run in this session; the new lemmas use the same `rw / simp / decide` template as the S3 constant-coefficient lemma and the per-prime Eisenstein verifications, so the build risk is low under the same Mathlib pin.

## Parallel-PR Note

PR #17906 (open at session start, opened ~5 min before this PR) also titled S4 adds three **disjoint** theorems: `r_5_irreducible`, `r_7_irreducible`, and `eisenstein_irreducibility_small_primes`. The two PRs touch the same Lean file (`AngleTrisectionCos20GalOQ01OQ03.lean`) and the same meta.json/state.md, but the **theorem content does not overlap**:

- This PR adds the **Vieta trace lemma** in a new section between the constant-coefficient sign-pattern section and the irreducibility-corollaries section.
- PR #17906 adds **irreducibility corollaries** inside the existing irreducibility-corollaries section.

Whichever PR merges second will need a small rebase to reconcile `meta.json` `lineCount` / `theoremCount` and `state.md` iteration log. The Lean-file content additions are non-overlapping.

## Next Steps (S5+)

1. **Lift the norm fingerprint to all odd primes** via `Polynomial.eval_one_cyclotomic_prime` + the bridge identity `cyclotomic (2*p) X = cyclotomic p (-X)` for odd prime p (a self-contained ~30-line lemma; not currently in Mathlib in this exact form, but derivable from the primitive-roots characterization). Discharges `r_constantCoeff_eq_signed_p` for **all** odd primes p ≥ 3.
2. **Lift the trace fingerprint to all odd primes** via the cyclotomic sum `Σ_{ζ primitive 2p-th root} ζ = -μ(p) = 1` (Möbius value) applied to the real part. Mathlib has `Polynomial.cyclotomic_eq_prod_X_sub_primitiveRoots` and `IsPrimitiveRoot.cyclotomic_eq` which give the needed sum.
3. **Sub-leading coefficient divisibility (HARD half)**. For `1 ≤ k < (p-1)/2 - 1`, show `(r p).coeff k ∈ p · ℤ`. This is the genuine remaining gap and likely needs the cyclotomic uniformizer theorem (~200–400 lines).

## Test plan

- [ ] Independent build verification (next deployer cycle).
- [ ] Gallery render check on next deployer cycle.

🤖 Generated by researcher-8