### PR TITLE
Enrich law-of-cosines-oq-01-oq-01-oq-01: fix mainTheorems hypothesis form + linear_combination depth

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
@@ -14,14 +14,14 @@
   {
     "id": "ann-001",
     "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
-    "range": { "startLine": 27, "endLine": 27 },
+    "range": { "startLine": 27, "endLine": 29 },
     "type": "technique",
-    "title": "Import the Side-over-Angle Form",
-    "content": "The single import `Proofs.LawOfCosinesOQ01OQ02` brings in `spherical_law_of_sines_all`, which is the conjunction sin(a)/sin(A) = sin(b)/sin(B) ∧ sin(a)/sin(A) = sin(c)/sin(C) for nondegenerate spherical triangles. The proof obligation in this file is the symmetric statement with sides and angles exchanged.",
+    "title": "Import the Side-over-Angle Form; Open Required Namespaces",
+    "content": "The single import `Proofs.LawOfCosinesOQ01OQ02` brings in `spherical_law_of_sines_all`, which is the conjunction sin(a)/sin(A) = sin(b)/sin(B) ∧ sin(a)/sin(A) = sin(c)/sin(C) for nondegenerate spherical triangles. The proof obligation in this file is the symmetric statement with sides and angles exchanged. The accompanying `open SphericalLawOfCosines Real` (line 29) is required for two reasons: (1) `SphericalLawOfCosines` is the namespace where `SphericalTriangle` and its `sideA`/`sideB`/`sideC` projections live, so unqualified `SphericalTriangle` in the theorem signature resolves to the right structure; (2) `Real` exposes `Real.sin` for the `sin` calls in the goal — without it the expressions would need fully-qualified `Real.sin` everywhere. Note that this `open` does NOT import a namespace's *contents*; it only adds those names to the resolver's search path for the remainder of the file.",
     "mathContext": "The side-over-angle form $\\frac{\\sin a}{\\sin A} = \\frac{\\sin b}{\\sin B} = \\frac{\\sin c}{\\sin C}$ is proved in the parent file via the Gram-determinant identity $\\sin^2(X)\\sin^2(y)\\sin^2(z) = G$ (where $G = 1 - \\cos^2 a - \\cos^2 b - \\cos^2 c + 2\\cos a\\cos b\\cos c$ is the Gram determinant of perpendicular projections on the unit sphere). Once the side-over-angle form is in hand, the angle-over-side form is purely formal — no further geometric content is needed.",
     "significance": "supporting",
-    "relatedConcepts": ["spherical law of sines", "Gram determinant", "perpendicular projection"],
-    "prerequisites": ["spherical law of sines (side-over-angle form)", "Lean 4 imports"]
+    "relatedConcepts": ["spherical law of sines", "Gram determinant", "perpendicular projection", "open namespace"],
+    "prerequisites": ["spherical law of sines (side-over-angle form)", "Lean 4 imports", "Lean 4 namespace resolution"]
   },
   {
     "id": "ann-002",
@@ -53,7 +53,7 @@
     "range": { "startLine": 47, "endLine": 50 },
     "type": "insight",
     "title": "Algebraic Inversion via div_eq_div_iff (First Conjunct)",
-    "content": "The core of the proof for sin(A)/sin(a) = sin(B)/sin(b): `div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)` rewrites the goal into the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a). Applied symmetrically to the parent hypothesis h1 : sin(a)/sin(A) = sin(b)/sin(B), it yields sin(a)·sin(B) = sin(b)·sin(A). The two cross-multiplied forms differ only by a sign; `linear_combination -h1` closes the goal automatically.",
+    "content": "The core of the proof for sin(A)/sin(a) = sin(B)/sin(b): `div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)` rewrites the goal into the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a). Applied symmetrically to the parent hypothesis h1 : sin(a)/sin(A) = sin(b)/sin(B), it yields sin(a)·sin(B) = sin(b)·sin(A). The two cross-multiplied forms agree up to a sign once factors are commuted: goal − (−1)·h1 = (sin A · sin b − sin B · sin a) + (sin a · sin B − sin b · sin A) = 0 as a polynomial identity over commutative reals. `linear_combination -h1` instructs Lean to verify this with `ring` as the residual checker, closing the goal in one tactic step. The `-1` coefficient is essential — `linear_combination h1` (without negation) would leave a non-zero residual and fail.",
     "mathContext": "$\\texttt{div\\_eq\\_div\\_iff}$: for nonzero $b, d$, the equation $\\frac{a}{b} = \\frac{c}{d}$ is equivalent to $a \\cdot d = c \\cdot b$. Applying it on both the goal and the hypothesis transforms a division-form equality into a polynomial identity that Lean's `linear_combination` tactic can verify by reducing to $0 = 0$ after a single linear combination of the hypothesis. The hypothesis 0 < sin(angle) provides the `ne_of_gt` nonzero requirement.",
     "significance": "key",
     "relatedConcepts": ["div_eq_div_iff", "linear_combination", "cross-multiplication", "polynomial identities"],

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
@@ -51,7 +51,8 @@
       "B/b = C/c follows from A/a = B/b and A/a = C/c by transitivity: (A/a = B/b).symm.trans (A/a = C/c) ⟹ B/b = C/c. The bare minimum is the conjunction A/a = B/b ∧ A/a = C/c, since the C-equality is enough to derive the third.",
       "This 64-line wrapper is the lightest possible closure of the open question oq-01-oq-01-oq-01: by the time the side-over-angle form (which IS the harder direction, requiring the Gram-determinant nonnegativity argument) is in place, the angle-over-side form is just algebraic bookkeeping.",
       "The two forms (angle/side and side/angle) are not redundant in practice: in spherical astronomy and geodesy, the angle-over-side form is the natural one when angles are measured directly (as observed at a vertex) and side lengths are the unknowns to be solved; the side-over-angle form is natural when sides (great-circle arc lengths) are measured (e.g., from chronometers and bearings) and angles are computed. The Lean formalization preserves this duality by making each direction a separate theorem statement, both proved from the common Gram-determinant identity.",
-      "From a categorical perspective, the symmetry sin(X)/sin(x) ↔ sin(x)/sin(X) is the involution induced by inversion in the multiplicative group of positive reals. The choice of which form to take as primitive is conventional; the Gram-determinant proof produces the symmetric expression sin²(X)·sin²(y)·sin²(z) = G first, and either single-fraction form is then a corollary. This is a small instance of the pattern that homogeneous polynomial identities are more fundamental than affine ratios — algebraic geometers prefer projective invariants over their affine charts for exactly this reason."
+      "From a categorical perspective, the symmetry sin(X)/sin(x) ↔ sin(x)/sin(X) is the involution induced by inversion in the multiplicative group of positive reals. The choice of which form to take as primitive is conventional; the Gram-determinant proof produces the symmetric expression sin²(X)·sin²(y)·sin²(z) = G first, and either single-fraction form is then a corollary. This is a small instance of the pattern that homogeneous polynomial identities are more fundamental than affine ratios — algebraic geometers prefer projective invariants over their affine charts for exactly this reason.",
+      "The `linear_combination -h` step is not merely cosmetic: after `rw [div_eq_div_iff ..]` on both goal and hypothesis the goal becomes sin(A)·sin(b) = sin(B)·sin(a) while h1 becomes sin(a)·sin(B) = sin(b)·sin(A). These differ by a sign and a transposition of factors. `linear_combination -h1` instructs Lean to verify the polynomial identity 0 = (sin A · sin b) - (sin B · sin a) - (-1)·((sin a · sin B) - (sin b · sin A)); the `ring` checker then closes it by commutativity. Choosing the right scalar (-1 rather than +1) is what makes the tactic succeed in one step instead of a brittle nlinarith call."
     ],
     "prerequisites": [
       "Spherical law of sines, side-over-angle form: spherical_law_of_sines_all in Proofs/LawOfCosinesOQ01OQ02.lean",
@@ -214,22 +215,22 @@
     {
       "name": "spherical_law_of_sines_angle_over_side",
       "type": "core",
-      "statement": "$\\forall t : \\mathrm{SphericalTriangle}, t.\\mathrm{NonDegenerate}\\colon \\frac{\\sin A}{\\sin a} = \\frac{\\sin B}{\\sin b} \\,\\land\\, \\frac{\\sin A}{\\sin a} = \\frac{\\sin C}{\\sin c}$",
-      "significance": "**The headline theorem.** Closes OQ-01-OQ-01-OQ-01 from the parent dual-cosine-law entry. Algebraic inversion of the side-over-angle form via `div_eq_div_iff` + `linear_combination` — a textbook one-line manipulation in Lean once the Gram-determinant identity is in scope.",
+      "statement": "$\\forall t : \\mathrm{SphericalTriangle},\\ (h_a : 0 < \\sin a)\\ (h_b : 0 < \\sin b)\\ (h_c : 0 < \\sin c)\\ (h_A : 0 < \\sin A)\\ (h_B : 0 < \\sin B)\\ (h_C : 0 < \\sin C)\\colon\\ \\frac{\\sin A}{\\sin a} = \\frac{\\sin B}{\\sin b} \\,\\land\\, \\frac{\\sin A}{\\sin a} = \\frac{\\sin C}{\\sin c}$",
+      "significance": "**The headline theorem.** Closes OQ-01-OQ-01-OQ-01 from the parent dual-cosine-law entry. Algebraic inversion of the side-over-angle form via `div_eq_div_iff` + `linear_combination` — a textbook one-line manipulation in Lean once the Gram-determinant identity is in scope. The six positive-sine hypotheses are passed through verbatim from the parent (rather than packaged in a `NonDegenerate` predicate) to match the side-over-angle form's signature, avoiding a wrapper layer.",
       "description": "For a non-degenerate spherical triangle, sin(A)/sin(a) = sin(B)/sin(b) ∧ sin(A)/sin(a) = sin(C)/sin(c). Closes the open question oq-01-oq-01-oq-01 raised in the parent entry. Proof: algebraic inversion of the side-over-angle form via div_eq_div_iff + linear_combination."
     },
     {
       "name": "spherical_law_of_sines_BC_angle_over_side",
       "type": "supporting",
-      "statement": "$\\forall t : \\mathrm{SphericalTriangle}, t.\\mathrm{NonDegenerate}\\colon \\frac{\\sin B}{\\sin b} = \\frac{\\sin C}{\\sin c}$",
-      "significance": "Direct transitivity corollary — `h1.symm.trans h2` applied to the main theorem's conjunction. Stated separately so downstream callers can pull the $B/b = C/c$ pair without unpacking the conjunction.",
+      "statement": "$\\forall t : \\mathrm{SphericalTriangle},\\ (h_a : 0 < \\sin a)\\ (h_b : 0 < \\sin b)\\ (h_c : 0 < \\sin c)\\ (h_A : 0 < \\sin A)\\ (h_B : 0 < \\sin B)\\ (h_C : 0 < \\sin C)\\colon\\ \\frac{\\sin B}{\\sin b} = \\frac{\\sin C}{\\sin c}$",
+      "significance": "Direct transitivity corollary — `h1.symm.trans h2` applied to the main theorem's conjunction. Stated separately so downstream callers can pull the $B/b = C/c$ pair without unpacking the conjunction. Takes the same six positive-sine hypotheses as the main theorem because they are required to invoke it.",
       "description": "B/b = C/c follows from the conjunction in the main theorem by transitivity (h1.symm.trans h2). Stated separately for ease of consumption."
     },
     {
       "name": "spherical_law_of_sines_all",
       "type": "supporting",
-      "statement": "$\\forall t : \\mathrm{SphericalTriangle}, t.\\mathrm{NonDegenerate}\\colon \\frac{\\sin a}{\\sin A} = \\frac{\\sin b}{\\sin B} \\,\\land\\, \\frac{\\sin a}{\\sin A} = \\frac{\\sin c}{\\sin C}$",
-      "significance": "**The Gram-determinant input.** Proved in the sibling file `Proofs/LawOfCosinesOQ01OQ02.lean` via the identity $\\sin^2 X \\cdot \\sin^2 y \\cdot \\sin^2 z = G$ where $G$ is the Gram determinant of perpendicular projections. The side-over-angle form is the *natural* output of the Gram framework; this file's main theorem just inverts it.",
+      "statement": "$\\forall t : \\mathrm{SphericalTriangle},\\ (h_a : 0 < \\sin a)\\ (h_b : 0 < \\sin b)\\ (h_c : 0 < \\sin c)\\ (h_A : 0 < \\sin A)\\ (h_B : 0 < \\sin B)\\ (h_C : 0 < \\sin C)\\colon\\ \\frac{\\sin a}{\\sin A} = \\frac{\\sin b}{\\sin B} \\,\\land\\, \\frac{\\sin a}{\\sin A} = \\frac{\\sin c}{\\sin C}$",
+      "significance": "**The Gram-determinant input.** Proved at `LawOfCosinesOQ01OQ02.lean:308` via the identity $\\sin^2 X \\cdot \\sin^2 y \\cdot \\sin^2 z = G$ where $G$ is the Gram determinant of perpendicular projections. The side-over-angle form is the *natural* output of the Gram framework; this file's main theorem just inverts it. Same six positive-sine signature as the inversion theorems here.",
       "description": "Side-over-angle form (proved in parent file Proofs/LawOfCosinesOQ01OQ02.lean): sin(a)/sin(A) = sin(b)/sin(B) ∧ sin(a)/sin(A) = sin(c)/sin(C). This entry's algebraic inversion is the formal converse direction, completing the symmetric formulation."
     }
   ],


### PR DESCRIPTION
## Summary

Enrichment pass on the Spherical Law of Sines (angle-over-side form) gallery entry.

### Accuracy fix
- `mainTheorems[0,1,2].statement` previously claimed `t.NonDegenerate` as a hypothesis, but the actual Lean theorems take six explicit positive-sine hypotheses. Replaced with the accurate signature matching `LawOfCosinesOQ01OQ01OQ01.lean:38-40` and parent at `LawOfCosinesOQ01OQ02.lean:308-314`.
- Updated `significance` text in each entry to explain why the six hypotheses pass through verbatim rather than being packaged in a wrapper predicate.

### Coverage gap fix
- `ann-001` previously had range `27-27` (import line only); the `open SphericalLawOfCosines Real` on line 29 was left uncovered despite being in the "imports-namespace" section (lines 27-33). Extended range to 27-29 and rewrote content to explain why both namespaces must be opened (SphericalTriangle resolution + Real.sin shorthand).

### Depth additions
- `ann-003`: sharpened the `linear_combination -h1` explanation. The `-1` coefficient is not cosmetic — `ring` closes the polynomial identity only because `goal − (−1)·h1 = 0` in the commutative ring of reals. Without the negation the residual is nonzero and the tactic fails.
- `overview.keyInsights`: added an 8th insight on the `linear_combination -h` sign convention as a recurring pattern in Mathlib algebra proofs.

### Scope
No Lean source changes. Documentation and schema-accuracy only. JSON validates; full `pnpm build` skipped per known Node v26 / better-sqlite3 gyp hang (memory: enricher_pnpm_build_bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)