### PR TITLE
research(angle-trisection-oq-05-oq-04): S3 partial — constructive HH-1 + geometric core of straight_fold_recovers_HH (build pending)

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ05OQ04.lean
+++ b/proofs/Proofs/AngleTrisectionOQ05OQ04.lean
@@ -209,6 +209,92 @@ theorem straight_fold_recovers_HH (c : CurvedCrease)
     (_h_distinct : c.γ 0 ≠ c.γ c.L) :
     c.ExistsHHFold := by
   sorry  -- S3 ACT: reduce κ_g ≡ 0 case to HHAxioms.hh1 / line characterisation.
+         -- S3 partial discharge (this file): the *geometric* line-through-
+         -- two-distinct-points content is now constructive via
+         -- `lineThrough`, `hh1_existence`, and
+         -- `straight_fold_endpoints_collinear` below. The remaining gap
+         -- is the construction of a full `HHAxioms` witness (HH-2..HH-7).
+
+-- ============================================================
+-- PART 3b: Constructive HH-1 — line through two distinct points (S3)
+-- ============================================================
+
+/-
+### S3 partial discharge: HH-1 standalone construction
+
+The S3 conservativity target `straight_fold_recovers_HH` decomposes into
+two ingredients:
+
+1. **Geometric**: given two distinct points in the plane, produce a line
+   through both. This is the content of HH-1 (`HHAxioms.hh1`).
+2. **Axiomatic**: produce a full `HHAxioms` witness (HH-1 through HH-7).
+
+Ingredient 1 is finite and self-contained; this section discharges it.
+Ingredient 2 requires proving each of the remaining six HH axioms (HH-2
+through HH-7), which is a separate undertaking (HH-6 alone requires the
+Beloch-fold cubic-solving construction). Future iterations should attack
+these in turn.
+
+After this section the geometric core of S3 is constructive: a straight
+curved crease with distinct endpoints does admit a line through both
+endpoints, and that line is computable from the endpoint coordinates.
+-/
+
+/-- The line through two points `p₁ ≠ p₂` in ℝ². Coefficients
+`(a, b, c) = (y₂ - y₁, x₁ - x₂, x₂·y₁ - x₁·y₂)` cast the standard
+two-point form into the `ax + by + c = 0` normalisation. The
+non-degeneracy clause `(a, b) ≠ (0, 0)` follows because `p₁ ≠ p₂`
+forces at least one coordinate to differ. -/
+noncomputable def lineThrough (p₁ p₂ : Point) (h : p₁ ≠ p₂) : Line where
+  a := p₂.2 - p₁.2
+  b := p₁.1 - p₂.1
+  c := p₂.1 * p₁.2 - p₁.1 * p₂.2
+  nondeg := by
+    by_contra hcontra
+    push_neg at hcontra
+    obtain ⟨ha, hb⟩ := hcontra
+    apply h
+    have hx : p₁.1 = p₂.1 := by linarith [sub_eq_zero.mp hb]
+    have hy : p₁.2 = p₂.2 := by linarith [sub_eq_zero.mp ha]
+    exact Prod.ext hx hy
+
+/-- The line `lineThrough p₁ p₂ h` contains `p₁`. -/
+theorem lineThrough_contains_left (p₁ p₂ : Point) (h : p₁ ≠ p₂) :
+    (lineThrough p₁ p₂ h).contains p₁ := by
+  simp only [lineThrough, Line.contains]
+  ring
+
+/-- The line `lineThrough p₁ p₂ h` contains `p₂`. -/
+theorem lineThrough_contains_right (p₁ p₂ : Point) (h : p₁ ≠ p₂) :
+    (lineThrough p₁ p₂ h).contains p₂ := by
+  simp only [lineThrough, Line.contains]
+  ring
+
+/-- **HH-1 (existence form, standalone).** Given two distinct points in
+the plane, there exists a line containing both. This is the geometric
+content of the HH-1 field of `HHAxioms`; proving it independently is
+the first ingredient of the eventual full `HHAxioms` instance and the
+witness consumed by `straight_fold_endpoints_collinear`. -/
+theorem hh1_existence : ∀ (p₁ p₂ : Point), p₁ ≠ p₂ →
+    ∃ l : Line, l.contains p₁ ∧ l.contains p₂ := by
+  intro p₁ p₂ h
+  exact ⟨lineThrough p₁ p₂ h,
+         lineThrough_contains_left p₁ p₂ h,
+         lineThrough_contains_right p₁ p₂ h⟩
+
+/-- **Geometric core of S3.** For a curved crease whose endpoints are
+distinct, there exists a line through both endpoints. This is the
+content of `straight_fold_recovers_HH` modulo the `HHAxioms` wrapper;
+the straightness hypothesis is unused for this fragment because the
+two-point form of a line does not depend on the curvature data along
+`γ`. The straightness hypothesis re-enters in the full theorem when it
+witnesses that `γ` actually traces a line segment between the
+endpoints (rather than a more general curve happening to share the
+endpoints), which is needed for the full reduction to an HH-1 fold. -/
+theorem straight_fold_endpoints_collinear (c : CurvedCrease)
+    (h_distinct : c.γ 0 ≠ c.γ c.L) :
+    ∃ l : Line, l.contains (c.γ 0) ∧ l.contains (c.γ c.L) :=
+  hh1_existence (c.γ 0) (c.γ c.L) h_distinct
 
 -- ============================================================
 -- PART 4: S4 Target — Algebraic-Curve Sharpness


### PR DESCRIPTION
## Summary

S3 partial discharge of \`straight_fold_recovers_HH\`. The **geometric** fragment (line through two distinct curve endpoints) is now constructive. The **axiomatic** fragment — a full \`HHAxioms\` witness covering HH-2 through HH-7 — remains and is enumerated as the S4 next-action in state.md.

The S2 ORIENT scaffold's intended S3 plan was \`sorries 3 → 2\` via a 120-line proof, but the architect under-estimated: \`CurvedCrease.ExistsHHFold\` requires \`∃ _ : HHAxioms\` head, and constructing an \`HHAxioms\` instance means proving all seven existential fields. HH-6 (Beloch fold / cubic-solving) alone is 80-150 lines. A single-session full discharge is unrealistic. This PR delivers the first of the seven ingredients — HH-1 — plus the geometric core that consumes it.

## New content (PART 3b, between S3 sorry and PART 4)

1. \`lineThrough p₁ p₂ h : Line\` — noncomputable constructor of the line through two distinct points. Coefficients \`(a, b, c) = (y₂-y₁, x₁-x₂, x₂y₁-x₁y₂)\`; non-degeneracy from \`p₁ ≠ p₂\`.
2. \`lineThrough_contains_left\` / \`lineThrough_contains_right\` — both endpoints satisfy the constructed line's \`contains\` predicate. One-line \`simp + ring\` proof each.
3. \`hh1_existence\` — standalone HH-1: given two distinct points there exists a line containing both. First of seven ingredients needed for a full \`HHAxioms\` instance.
4. \`straight_fold_endpoints_collinear\` — the geometric core of S3: a curved crease with distinct endpoints admits a line through both. Proved from \`hh1_existence\` in one line. The straightness hypothesis is unused here (it re-enters in the full theorem to witness γ traces a line segment).

The \`straight_fold_recovers_HH\` sorry remains; its docstring is amended to point to the new constructive geometric content and flag the remaining HHAxioms gap.

## Stats

- Lean file: 351 → 437 (+86 lines)
- theoremCount: 4 → 8 (+4)
- definitionCount: 5 → 6 (+1, \`lineThrough\`)
- sorries: 3 (unchanged — S3 partial)
- axiomCount: 1 (unchanged — ftCompatible structure field)

## S4+ next-action (per state.md)

Build HH-2..HH-7 in separate iterations, then assemble \`HHAxioms.standard\` and discharge the S3 sorry. Rough split:

- S4: HH-2 (perp bisector) + HH-4 (perp through point) — both small.
- S5: HH-3 (angle bisector) + HH-7 (Hatori's axiom).
- S6: HH-5 (place P₁ on ℓ through P₂; quadratic).
- S7: HH-6 (Beloch fold; cubic — hardest).
- S8: package into \`HHAxioms\` instance; discharge S3 sorry (sorries 3 → 2).

## Build status

**Pending.** Four new proved theorems are short (≤8 tactic lines each) using only standard Mathlib API (Prod.ext, sub_eq_zero, linarith, Line.contains unfold + ring).

## Disjointness

No open PR on this slug at session start; PR #17883 (S2 ORIENT scaffold) was the most recent merge. No name collisions with S2 declarations.

## Test plan

- [ ] Independent build verification on next deployer cycle.
- [ ] Gallery render check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)