### PR TITLE
Fix: lagrange-theorem-oq-02-oq-02-oq-01 badge → mathlib (Mathlib wrapper)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "lagrange-theorem-oq-02-oq-02-oq-01",
   "title": "Burnside's Lemma from the Conjugation-Action Class Equation",
   "slug": "lagrange-theorem-oq-02-oq-02-oq-01",
-  "description": "Resolves OQ-01 of `lagrange-theorem-oq-02-oq-02`: yes, Burnside's lemma (Σ_g |Fix(g)| = |X/G| · |G|) can be formally proved in Lean 4 using only the infrastructure developed in the parent's class equation file. The proof recognises that the class equation and Burnside's lemma are the same orbit-decomposition identity applied to two different actions — G ↷ G by conjugation versus G ↷ X arbitrary. The general statement comes from Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`; the conjugation specialisation is recovered by instantiating G = X and the action by `ConjAct`. The file ships three statements (sum form, average form, conjugation specialisation) and packages them as `oq01_resolution`.",
+  "description": "Resolves OQ-01 of `lagrange-theorem-oq-02-oq-02`: yes, Burnside's lemma (Σ_g |Fix(g)| = |X/G| · |G|) can be formally stated in Lean 4 by recognising that the class equation and Burnside's lemma are two specialisations of Mathlib's general orbit-counting identity `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`. This entry is a thin pedagogical wrapper, not new mathematics: the general statement is the Mathlib lemma directly; the conjugation specialisation is recovered by instantiating G = X and the action by `ConjAct`. The file ships three statements (sum form, average form, conjugation specialisation) and packages them as `oq01_resolution`.",
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-12",
@@ -17,7 +17,7 @@
       "mulaction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 195,


### PR DESCRIPTION
## Fix

`src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json` — change `meta.badge` from `"verified"` to `"mathlib"` and soften the top-level description to call the entry what it is: a thin pedagogical wrapper around a Mathlib lemma.

## Evidence

**Before**:
- `meta.badge`: `"verified"` (suggests Tier A — original / fully formalized)
- `description`: "…can be formally proved in Lean 4 using only the infrastructure developed in the parent's class equation file."

**After**:
- `meta.badge`: `"mathlib"` — matches gallery policy for Tier B / failure-mode-#5 entries (0 sorries but main result is a Mathlib invocation).
- `description`: explicit "thin pedagogical wrapper, not new mathematics" disclaimer and the auditor's recommended wording.

The Lean file's four theorems are direct Mathlib wrappers:
- `burnside_lemma_sum_form` — one-line invocation of `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`.
- `conjugation_burnside_form` — same lemma at `G := ConjAct G, X := G`.
- `burnside_lemma_average_form` — `Nat.mul_div_cancel` corollary.
- `oq01_resolution` — trivial conjunction.

None of the parent file's specific infrastructure (`conj_orbit_eq_carrier`, `conj_stabilizer_eq_centralizer`, `card_conjClass_eq_centralizer_index`) is used in the proofs; only the general Mathlib `MulAction` API does the work.

Status `"verified"` is preserved (0 sorries, 0 axioms, 0 structure-encoded assumptions). `originalContributions` is unchanged — its four entries already honestly call out "namespace-local restatement", "instantiates", and "packaged conjunction".

Closes #17911

---
Automated fix by lean-mechanic agent.