### PR TITLE
research(szemeredi-core-oq-04): S3 ACT — constructive witness extraction (alternate path, build verified)

### DIFF
--- a/proofs/Proofs/SzemerediCoreOQ04.lean
+++ b/proofs/Proofs/SzemerediCoreOQ04.lean
@@ -167,6 +167,56 @@ theorem witness_regular_implies_epsilon_regular
   -- See proof strategy in the docstring above.
   sorry
 
+/-! ## Part 3b: Constructive witness extraction (S3, sorry-free)
+
+When the witness-regular surrogate fails, we want an explicit `B'` that
+exhibits the failure — both for downstream "constructive partition"
+work (Target C in S1's roadmap) and for diagnostic output of any future
+algorithmic-Szemerédi implementation.
+
+The extraction is a pure-logic decomposition of `¬ IsWitnessRegular`:
+unfold the definition, push the negation through the bounded universal,
+and pull out the witness via existential introduction. Since the witness
+family is finite and decidable, no constructive choice is needed beyond
+`push_neg`. -/
+
+/-- **Constructive witness extraction**: if `(A, B)` fails the
+witness-regular surrogate at parameter `eps`, then there exists an
+explicit `B'` in the ε-grid family of large enough size and with
+density bias exceeding `eps`.
+
+The proof is a one-step `push_neg` decomposition of the universally
+quantified definition. The conclusion is the natural negation of
+`IsWitnessRegular`:
+```
+∃ B' ∈ witnessFamilyB G A B,
+  (B'.card : ℚ) ≥ eps * B.card ∧
+  |edgeDensity G A B' - edgeDensity G A B| > eps.
+```
+
+This is the dual to `IsEpsilonRegular`'s `¬`-form witness and is the
+piece that the algorithmic Szemerédi partition (Target C) iterates on
+to produce a refinement when irregularity is detected. -/
+theorem witnessOfIrregular (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) (h : ¬ IsWitnessRegular G eps A B) :
+    ∃ B' ∈ witnessFamilyB G A B,
+      (B'.card : ℚ) ≥ eps * B.card ∧
+      |edgeDensity G A B' - edgeDensity G A B| > eps := by
+  unfold IsWitnessRegular at h
+  push_neg at h
+  exact h
+
+/-- **Contrapositive**: if every `B'` in the ε-grid family that is at
+least `eps · |B|` large has density bias ≤ `eps`, then `(A, B)` is
+witness-regular. (The forward direction of the equivalence is just the
+definition; this corollary spells it out for readers.) -/
+theorem isWitnessRegular_of_no_witness (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V)
+    (h : ∀ B' ∈ witnessFamilyB G A B,
+      (B'.card : ℚ) ≥ eps * B.card →
+      |edgeDensity G A B' - edgeDensity G A B| ≤ eps) :
+    IsWitnessRegular G eps A B := h
+
 /-! ## Part 4: Mathlib-bridge stubs (S5 placeholders, not exported)
 
     These signatures are placeholders for the downstream S5 task —

--- a/research/problems/szemeredi-core-oq-04/knowledge.md
+++ b/research/problems/szemeredi-core-oq-04/knowledge.md
@@ -196,3 +196,63 @@ layer on top.
   project memory) implies callers *will* materialise, but until
   one does, the S5 deliverable is the only "uses witnessRegularity"
   consumer.
+
+### S3 (researcher-6, 2026-05-12) — ACT (alternate path)
+
+**Outcome**: progress — two sorry-free theorems added; 1 sorry retained.
+
+**What I added** (50 new lines in `proofs/Proofs/SzemerediCoreOQ04.lean`):
+
+1. **`witnessOfIrregular`** (the constructive witness extraction):
+   ```lean
+   theorem witnessOfIrregular (G : SimpleGraph V) [DecidableRel G.Adj]
+       (eps : ℚ) (A B : Finset V) (h : ¬ IsWitnessRegular G eps A B) :
+       ∃ B' ∈ witnessFamilyB G A B,
+         (B'.card : ℚ) ≥ eps * B.card ∧
+         |edgeDensity G A B' - edgeDensity G A B| > eps := by
+     unfold IsWitnessRegular at h
+     push_neg at h
+     exact h
+   ```
+   This is a one-step `push_neg` decomposition. The proof works
+   because `IsWitnessRegular` is a bounded universal `∀ B' ∈ family,
+   antecedent → conclusion`, and `push_neg` rewrites `¬ ∀ … → …` into
+   `∃ …, ∧ ¬ …`, with the inner `¬ |x| ≤ ε ↔ |x| > ε` simplification.
+
+2. **`isWitnessRegular_of_no_witness`** (the contrapositive, made
+   explicit as a corollary). The proof is `exact h` — just an
+   eta-contraction of the universal hypothesis to the definitional
+   form of `IsWitnessRegular`. Useful as a forward-direction reference.
+
+**Why this is the "alternate path"**: state.md's S3 next-action listed
+the main path (the slack-4 implication `witness_regular_implies_
+epsilon_regular`) AND an alternate easier path (the `witnessOfIrregular`
+extraction). I chose the alternate path because:
+- It is genuinely a one-session deliverable (~5-line proof).
+- It is sorry-free.
+- It completes the "Target B" surface (constructive witness
+  extraction), which Target C (constructive partition) depends on.
+
+The main ADLRY implication (slack-4) requires the per-vertex
+density transfer + averaging + restriction argument — 60-100 lines of
+careful real-number bound manipulation, not achievable in one session.
+
+**Build verified** via `./proofs/scripts/docker-build.sh
+Proofs.SzemerediCoreOQ04`. Build succeeded; the only sorry warning is
+the pre-existing one on `witness_regular_implies_epsilon_regular`.
+
+**Files modified (S3 narrow)**:
+- `proofs/Proofs/SzemerediCoreOQ04.lean` — added §3b (50 lines, 2 new
+  theorems, both sorry-free).
+- `src/data/research/problems/szemeredi-core-oq-04.json` — S3 entry,
+  phase OBSERVE→ACT, iter 2→3, builtItems +2, progressSummary.
+- `research/problems/szemeredi-core-oq-04/{knowledge.md, state.md}` —
+  this S3 entry.
+
+**Next steps**:
+- S4: prove `witness_regular_implies_epsilon_regular` (the slack-4
+  ε-grid ADLRY implication; per-vertex density transfer + averaging +
+  restriction). ~60-100 lines.
+- S5 (parallel): build Target C (constructive partition `findRegularPartition`)
+  using `witnessOfIrregular` as the iterate-on-failure step.
+- S6: Mathlib bridge to `SimpleGraph.IsUniform`.

--- a/research/problems/szemeredi-core-oq-04/state.md
+++ b/research/problems/szemeredi-core-oq-04/state.md
@@ -1,13 +1,69 @@
 # Current State
 
-**Phase**: ORIENT (S2 scaffold landed; one sorry on implication)
-**Since**: 2026-05-12T03:30:00Z
-**Last Updated**: 2026-05-12 (Iteration 2, researcher-9)
-**Iteration**: 2
+**Phase**: ACT (S3 alternate path: constructive witness extraction added, sorry-free; main slack-4 implication sorry retained)
+**Since**: 2026-05-12T06:30:00Z
+**Last Updated**: 2026-05-12 (Iteration 3, researcher-6)
+**Iteration**: 3
 
-## Current Focus
+## Iteration 3 (researcher-6, 2026-05-12) — S3 ACT (alternate path)
 
-Iteration 2 (researcher-9, 2026-05-12) — **S2 scaffold**: created
+**Outcome**: progress — added two sorry-free theorems (constructive witness extraction); 1 sorry retained on the main slack-4 implication.
+
+### What I added (50 lines)
+
+Two new sorry-free theorems in `proofs/Proofs/SzemerediCoreOQ04.lean`:
+
+1. **`witnessOfIrregular`** (Target B in S1's roadmap): constructive witness extraction.
+
+   ```lean
+   theorem witnessOfIrregular (G : SimpleGraph V) [DecidableRel G.Adj]
+       (eps : ℚ) (A B : Finset V) (h : ¬ IsWitnessRegular G eps A B) :
+       ∃ B' ∈ witnessFamilyB G A B,
+         (B'.card : ℚ) ≥ eps * B.card ∧
+         |edgeDensity G A B' - edgeDensity G A B| > eps := by
+     unfold IsWitnessRegular at h
+     push_neg at h
+     exact h
+   ```
+
+   The proof is a one-step `push_neg` decomposition. Given irregularity of the surrogate, the negation of the bounded universal `∀ B' ∈ family, antecedent → conclusion` is exactly the existential `∃ B' ∈ family, antecedent ∧ ¬ conclusion`. With `¬ |x| ≤ ε ↔ |x| > ε`, this is the constructive witness statement.
+
+2. **`isWitnessRegular_of_no_witness`** (the contrapositive form, made explicit). One-line proof: `exact h`.
+
+### Why this is the "alternate path"
+
+The Iteration-2 `Next Action` listed both:
+- **Main path** (recommended): `witness_regular_implies_epsilon_regular` — the slack-4 ε-grid ADLRY implication. ~60-100 lines, per-vertex density transfer + averaging + restriction.
+- **Alternate path** (easier): `witnessOfIrregular` extraction — a push_neg decomposition.
+
+I chose the alternate path because:
+- It is a one-session deliverable.
+- It is sorry-free.
+- It completes the **constructive surface of Target B** (witness extraction), which Target C (constructive `findRegularPartition`) depends on.
+
+### Build status (S3)
+
+**Verified** via `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04`:
+- 7744 jobs, only the pre-existing sorry warning on `witness_regular_implies_epsilon_regular`.
+- Linter warnings (unused `[Fintype V]` in section variables) appear for `witnessOfIrregular` and `isWitnessRegular_of_no_witness`; these are pre-existing patterns (also in `witnessFamilyB_subset` and the placeholder), not blocking.
+
+### Files modified (S3 narrow)
+
+- `proofs/Proofs/SzemerediCoreOQ04.lean` — +50 lines (Part 3b section with 2 new theorems).
+- `src/data/research/problems/szemeredi-core-oq-04.json` — phase ORIENT→ACT, iter 2→3, builtItems +2.
+- `research/problems/szemeredi-core-oq-04/{knowledge.md, state.md}` — S3 entry.
+
+### Next Action (S4)
+
+Prove `witness_regular_implies_epsilon_regular` (3-step density decomposition: per-vertex bound from grid → averaging over A → restriction A→A'). Aristotle-friendly. Estimated 60-100 lines.
+
+In parallel: build Target C (`findRegularPartition`) using `witnessOfIrregular` as the iterate-on-failure step.
+
+---
+
+## (Historic) Iteration 2 (researcher-9, 2026-05-12) — S2 scaffold
+
+Created
 `proofs/Proofs/SzemerediCoreOQ04.lean` (145 lines) with the three S1
 deliverables.
 

--- a/src/data/research/problems/szemeredi-core-oq-04.json
+++ b/src/data/research/problems/szemeredi-core-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "szemeredi-core-oq-04",
   "title": "Algorithmic Szemerédi: formalize the Alon-Duke-Lefmann-Rödl-Yuster 1994 constructive partition algorithm",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "constructive-refactor",
@@ -31,27 +31,29 @@
     "goal": "Replace `Classical.choice` at `SzemerediRegularity.lean:436` with a constructive `findRegularPartition` built on a decidable surrogate for `IsEpsilonRegular`."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-12T03:30:00.000Z",
-    "iteration": 2,
-    "focus": "S2 (researcher-9, 2026-05-12) — ORIENT scaffold. Created Proofs/SzemerediCoreOQ04.lean (145 lines) with the three S1 deliverables: (a) witnessFamilyB G A B := A.image (B.filter ∘ G.Adj) ∪ A.image (B.filter ∘ (¬G.Adj)) — polynomial-size family of size ≤ 2·|A|; (b) IsWitnessRegular G eps A B quantifying over witnessFamilyB; (c) noncomputable Decidable instance via Classical.dec (forced by Szemeredi.Core's open Classical → noncomputable edgeDensity). Two supporting lemmas sorry-free (witnessFamilyB_card_le and witnessFamilyB_subset). One sorry remaining on witness_regular_implies_epsilon_regular : IsWitnessRegular eps → IsEpsilonRegular (4*eps), with proof strategy documented inline (per-vertex density transfer → averaging → restriction slack).",
+    "phase": "ACT",
+    "since": "2026-05-12T06:30:00.000Z",
+    "iteration": 3,
+    "focus": "S3 ACT (researcher-6, 2026-05-12) — alternate path: constructive witness extraction. Added two sorry-free theorems to Proofs/SzemerediCoreOQ04.lean: (a) witnessOfIrregular : ¬ IsWitnessRegular → ∃ B' ∈ witnessFamilyB, |B'| ≥ eps·|B| ∧ |density bias| > eps (push_neg-style decomposition of the universally quantified definition); (b) isWitnessRegular_of_no_witness : the contrapositive form, spelling out the forward direction as a corollary. File now 238 lines (was 188), 1 sorry retained on the main witness_regular_implies_epsilon_regular ε-grid ADLRY implication.",
     "blockers": [],
-    "nextAction": "S3: prove witness_regular_implies_epsilon_regular (3-step density decomposition; ~30-60 lines, Aristotle-friendly via companion SzemerediCoreOQ04Aristotle.lean). Alternate easier S3: extract constructive witnessOfIrregular : ¬ IsWitnessRegular → ∃ B' ∈ witnessFamilyB, ... (push_neg-style decomposition).",
+    "nextAction": "S4: prove witness_regular_implies_epsilon_regular (3-step density decomposition: per-vertex bound from grid → averaging over A → restriction A→A'). Estimated ~60-100 lines, Aristotle-friendly. With witnessOfIrregular now in place, Target C (constructive findRegularPartition) can proceed in parallel.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 3,
+      "currentApproach": 2,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S2 (researcher-9, 2026-05-12): ORIENT scaffold. Created Proofs/SzemerediCoreOQ04.lean (145 lines) with the three S1 deliverables — Target A from the three-target hierarchy. Two definitions sorry-free (witnessFamilyB and IsWitnessRegular), two supporting lemmas sorry-free (witnessFamilyB_card_le proving |family| ≤ 2|A|, witnessFamilyB_subset proving every member ⊆ B), one noncomputable Decidable instance via Classical.dec (forced by parent file's open Classical), and one theorem with sorry (witness_regular_implies_epsilon_regular with slack constant 4). The sorry has a documented three-step proof strategy: per-vertex density transfer from B ∩ N(a) and B \\ N(a) members of the grid → averaging over a ∈ A → restriction slack from A → A'. Aristotle-friendly via planned SzemerediCoreOQ04Aristotle.lean once the scaffold is on origin/main. S1 honesty point retained: this is formalization (ADLRY 1994 is 30 years old), not research. // S1 (researcher-1, 2026-05-11): OBSERVE survey. Identified the algorithmic Szemerédi target — decoupling the partition construction in Proofs/SzemerediRegularity.lean:436 (regularity_lemma_strong) from Classical.choice using the ADLRY 1994 constructive witness.",
+    "progressSummary": "S3 ACT (researcher-6, 2026-05-12): added two sorry-free theorems on top of S2's scaffold — the alternate-path constructive witness extraction. `witnessOfIrregular` is a push_neg-style decomposition of `¬ IsWitnessRegular`: given irregularity of the surrogate, produce an explicit `B'` in the ε-grid family with both the cardinality lower bound and the density-bias upper bound that witnesses the failure. `isWitnessRegular_of_no_witness` is the contrapositive (the forward direction of the equivalence, made explicit). Together these complete the constructive surface of Target B (witness extraction) — the next iteration's task is the main ε-grid ADLRY implication (witness_regular_implies_epsilon_regular). // S2 (researcher-9, 2026-05-12): ORIENT scaffold. Created Proofs/SzemerediCoreOQ04.lean (145 lines) with the three S1 deliverables — Target A from the three-target hierarchy. Two definitions sorry-free (witnessFamilyB and IsWitnessRegular), two supporting lemmas sorry-free (witnessFamilyB_card_le proving |family| ≤ 2|A|, witnessFamilyB_subset proving every member ⊆ B), one noncomputable Decidable instance via Classical.dec, and one theorem with sorry (witness_regular_implies_epsilon_regular with slack constant 4). // S1 (researcher-1, 2026-05-11): OBSERVE survey. Identified the algorithmic Szemerédi target — decoupling the partition construction in Proofs/SzemerediRegularity.lean:436 (regularity_lemma_strong) from Classical.choice using the ADLRY 1994 constructive witness.",
     "builtItems": [
       "witnessFamilyB G A B — ε-grid family of size ≤ 2|A| (SzemerediCoreOQ04.lean:53)",
       "witnessFamilyB_card_le — polynomial-size bound proof (SzemerediCoreOQ04.lean:62)",
       "witnessFamilyB_subset — every member is ⊆ B (SzemerediCoreOQ04.lean:73)",
       "IsWitnessRegular G eps A B — decidable surrogate predicate (SzemerediCoreOQ04.lean:91)",
       "instDecidableIsWitnessRegular — Classical.dec instance (SzemerediCoreOQ04.lean:106)",
-      "witness_regular_implies_epsilon_regular — slack-4 implication theorem with sorry (SzemerediCoreOQ04.lean:140)"
+      "witness_regular_implies_epsilon_regular — slack-4 implication theorem with sorry (SzemerediCoreOQ04.lean:140)",
+      "**(S3 NEW)** witnessOfIrregular — constructive witness extraction for irregular pairs (push_neg-style decomposition of ¬ IsWitnessRegular; sorry-free; SzemerediCoreOQ04.lean:200)",
+      "**(S3 NEW)** isWitnessRegular_of_no_witness — contrapositive form (SzemerediCoreOQ04.lean:213)"
     ],
     "insights": [
       "IsEpsilonRegular at SzemerediCore.lean:39 quantifies over arbitrary Finset V — decidable in principle (Finset over Fintype is finite) but no explicit instance, and the naive Decidable would be O(2^|V|)-time. The ADLRY surrogate is the meaningful decidable replacement.",


### PR DESCRIPTION
## Summary

S3 ACT on `szemeredi-core-oq-04` (algorithmic Szemerédi / ADLRY 1994). Adds the **constructive witness extraction** — the easier of the two S3 paths in S2's Next Action.

## What this PR adds

Two new sorry-free theorems in `proofs/Proofs/SzemerediCoreOQ04.lean`:

**`witnessOfIrregular`** — Target B in S1's roadmap (constructive witness extraction):

```lean
theorem witnessOfIrregular (G : SimpleGraph V) [DecidableRel G.Adj]
    (eps : ℚ) (A B : Finset V) (h : ¬ IsWitnessRegular G eps A B) :
    ∃ B' ∈ witnessFamilyB G A B,
      (B'.card : ℚ) ≥ eps * B.card ∧
      |edgeDensity G A B' - edgeDensity G A B| > eps := by
  unfold IsWitnessRegular at h
  push_neg at h
  exact h
```

The proof is a one-step `push_neg` decomposition. Given irregularity of the surrogate, the negation of the bounded universal `∀ B' ∈ family, antecedent → conclusion` is the existential `∃ B' ∈ family, antecedent ∧ ¬ conclusion`. With `¬ |x| ≤ ε ↔ |x| > ε`, this is the constructive witness statement.

**`isWitnessRegular_of_no_witness`** — the contrapositive form, made explicit as a corollary. One-line proof: `exact h`.

## Why this is the "alternate path"

S2 (PR #17869, merged earlier today) shipped the ORIENT scaffold with one sorry on `witness_regular_implies_epsilon_regular` and listed two S3 directions in its Next Action:

* **Main path** (recommended, deferred to S4): prove the slack-4 ε-grid ADLRY implication `IsWitnessRegular → IsEpsilonRegular (4 · ε)`. Requires per-vertex density transfer + averaging + restriction; ~60-100 lines of careful real-number bound manipulation.
* **Alternate path** (easier, this PR): extract the constructive witness via `push_neg` on `¬ IsWitnessRegular`.

This PR delivers the alternate path because:

* It is a clean one-session deliverable (~5-line proof).
* It is sorry-free.
* It **completes the constructive surface of Target B** (witness extraction). Target C (constructive `findRegularPartition`) depends on this witness — having it means S4-on-Target-C can proceed in parallel with S4-on-Target-A's slack-4 implication.

## Counts

| Field | S2 (origin/main) | This PR |
|-------|--------|---------|
| `lineCount` | 188 | 238 |
| `theoremCount` | 4 | 6 (+2 new) |
| `definitionCount` | 2 | 2 |
| `axiomCount` | 0 | 0 |
| `sorries` | 1 (on `witness_regular_implies_epsilon_regular`) | 1 (same theorem) |

## Build status

**Verified locally** via `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04`:

```
warning: Proofs/SzemerediCoreOQ04.lean:161:8: declaration uses 'sorry'
[... linter warnings about unused [Fintype V] section variables ...]
Build completed successfully (7744 jobs).
```

Only one sorry warning (the pre-existing one on `witness_regular_implies_epsilon_regular`). The new theorems elaborate cleanly.

Linter warnings about unused `[Fintype V]` in section variables for the two new theorems are pre-existing patterns (already present in `witnessFamilyB_subset` and the placeholder); not blocking.

## Diff scope

| File | Net change |
|------|-----------|
| `proofs/Proofs/SzemerediCoreOQ04.lean` | +50 (Part 3b section, 2 new theorems with docstrings) |
| `src/data/research/problems/szemeredi-core-oq-04.json` | phase ORIENT→ACT, iter 2→3, builtItems +2, progressSummary |
| `research/problems/szemeredi-core-oq-04/knowledge.md` | S3 entry |
| `research/problems/szemeredi-core-oq-04/state.md` | S3 entry |

Total: 4 files, +185/-17 lines.

## Test plan

- [x] Lean build verifies (Docker, 7744 jobs, only pre-existing sorry warning).
- [x] JSON files valid.
- [x] Scope is narrow: only the slug's 4 files modified.
- [x] No open PR for this slug at push time.

🤖 Generated by researcher-6