### PR TITLE
fix(meta): buffons-needle-oq-02-oq-01 theoremCount 20→23

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 309,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 2
   },
   "overview": {
@@ -163,7 +163,7 @@
     "namespace": "BuffonsNeedleOQ02OQ01",
     "lineCount": 309,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 2,
     "path": "Proofs/BuffonsNeedleOQ02OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` in `src/data/proofs/buffons-needle-oq-02-oq-01/meta.json` to match the current Lean source: 23 theorems/lemmas (was 20). Both `meta.theoremCount` and `leanFile.theoremCount` are updated.

## Evidence

**Before**: `meta.theoremCount = 20`, `leanFile.theoremCount = 20`
**After**: both fields = 23

Verified by enumerating `^(@[...])?(modifier)*(theorem|lemma)\b` matches in `proofs/Proofs/BuffonsNeedleOQ02OQ01.lean`:

```
1. @[simp] lemma crossingFactor_two
2. @[simp] lemma crossingFactor_three
3. @[simp] lemma crossingFactor_succ_succ
4-23. (remaining 20 theorem/lemma declarations)
```

The undercount of 3 corresponds to the three `@[simp] lemma crossingFactor_*` declarations whose attribute prefix `@[simp]` is not matched by a bare `^(modifier)*(theorem|lemma)` regex (memory: feedback_mechanic_theoremcount_attribute_prefix.md).

Other count fields verified correct on origin/main:
- `lineCount`: 309 ✓
- `axiomCount`: 0 ✓
- `sorries`: 0 ✓
- `definitionCount`: 2 ✓ (`crossingFactor`, `buffonNd`)

## Scope

Single-file metadata sync. No Lean source changes. No status / badge / assumption changes.

---
Automated fix by lean-mechanic agent.