### PR TITLE
research(sperner-ndim-mathlib-oq-02): S28-prep — Fin 2-promotion of diagonal Sperner condition (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -3142,4 +3142,66 @@ private lemma cN2_total_diag_ne_two (k : ℕ) (hk : k ≤ N) :
 
 end N2DiagFaceCondition
 
+-- ============================================================
+-- (S28-prep) `Fin 2`-promotion of the diagonal Sperner condition.
+--
+-- S27-prep's `cN2_diag_ne_two` / `cN2_total_diag_ne_two` package
+-- the diagonal Sperner exclusion as `c ≠ (2 : Fin 3)`. The
+-- eventual S27/S28 final-assembly bridge between
+-- `face2_path_odd`'s `g : ℕ → Fin 2` and `cN2_total`'s
+-- `Fin 3`-valued diagonal restriction needs the strictly
+-- stronger `.val < 2` form: the witness that promotes a
+-- diagonal color to a `Fin 2` value via the
+-- `(0 : Fin 3) ↔ (0 : Fin 2)`, `(1 : Fin 3) ↔ (1 : Fin 2)`
+-- identification. This section packages that promotion, mirroring
+-- the `Fin.val_ne ⇒ val < bound` pattern already used in
+-- `sperner_panchromatic_two`'s `hK_lt_N` / `hcK1` proofs.
+--
+--   * `cN2_diag_val_lt_two` — `.val < 2` form for in-range `cN2`.
+--   * `cN2_total_diag_val_lt_two` — wrapper-level `.val < 2`.
+--
+-- Each proof reuses S27-prep's `≠ 2` lemma + the `.isLt` bound
+-- + `omega`. Independent of in-flight #17571 (S23 color wiring
+-- in `(b.1, b.2 + 1)`-endpoint form) and #17621 (S25-prep gridPt
+-- coordinate helpers): these consume the wrapper at non-diagonal
+-- form and the geometric simplex respectively. The promotion
+-- here lives entirely on the `face2_path_odd` `(k, N - k)`-
+-- parametrization side and unblocks the eventual `g k ≠ g (k+1)
+-- ↔ cN2_total (k, N-k) ≠ cN2_total (k+1, N-(k+1))` color-change
+-- correspondence S22's IsDoor bridge will consume.
+-- ============================================================
+
+section N2DiagValFinTwo
+
+variable (N : ℕ) (hN : 0 < N)
+variable (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+variable (hf_map : ∀ v, InSimplex v → InSimplex (f v))
+
+/-- Strengthening of `cN2_diag_ne_two` (S27-prep) to a `.val < 2`
+form: for `k ≤ N`, the in-range diagonal color's `.val` lies in
+`{0, 1}`. The pattern matches `sperner_panchromatic_two`'s
+`hK_lt_N`/`hcK1` proofs: combine `Fin.ext` to lift `.val ≠ n`
+from `c ≠ n`, then `.isLt` + `omega`. -/
+private lemma cN2_diag_val_lt_two (k : ℕ) (hk : k ≤ N) :
+    (cN2 N hN f hf_map (k, N - k) (by omega)).val < 2 := by
+  have hne : cN2 N hN f hf_map (k, N - k) (by omega) ≠ (2 : Fin 3) :=
+    cN2_diag_ne_two N hN f hf_map k hk
+  have hval_ne : (cN2 N hN f hf_map (k, N - k) (by omega)).val ≠ 2 :=
+    fun h => hne (Fin.ext h)
+  have hlt := (cN2 N hN f hf_map (k, N - k) (by omega)).isLt
+  omega
+
+/-- Wrapper-level companion of `cN2_diag_val_lt_two`: for `k ≤ N`,
+`cN2_total`'s `.val` at the diagonal vertex `(k, N - k)` lies in
+`{0, 1}`. Composes `cN2_total_diag_eq` (S27-prep) with
+`cN2_diag_val_lt_two`. This is the exact form consumed when
+defining the `Fin 2`-valued diagonal color function the S27
+final-assembly bijection with `face2_path_odd`'s `g` will use. -/
+private lemma cN2_total_diag_val_lt_two (k : ℕ) (hk : k ≤ N) :
+    (cN2_total N hN f hf_map (k, N - k)).val < 2 := by
+  rw [cN2_total_diag_eq N hN f hf_map k hk]
+  exact cN2_diag_val_lt_two N hN f hf_map k hk
+
+end N2DiagValFinTwo
+
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,13 +2,58 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-12 (Iteration 27-prep-diag-face, researcher-10)
-**Iteration**: 27-prep-diag-face
+**Last Updated**: 2026-05-12 (Iteration 28-prep-fin2, researcher-10)
+**Iteration**: 28-prep-fin2
 
 ## Current Focus
 
-Session 27-prep-diag-face (this iteration, researcher-10, 2026-05-12,
-build pending): Added **face-2 and color characterizations at the
+Session 28-prep-fin2 (this iteration, researcher-10, 2026-05-12,
+build pending — parent file build broken on origin/main since
+2026-05-08 at `t1_ne_t2`/`diagonal_in_t1_iff` post-Mathlib drift):
+Added **`Fin 2`-promotion of the diagonal Sperner condition**.
+S27-prep packaged the diagonal Sperner exclusion as
+`cN2 ... (k, N - k) ≠ (2 : Fin 3)` / `cN2_total ... (k, N - k) ≠
+(2 : Fin 3)`. The eventual S27 / S28 final-assembly bridge between
+`face2_path_odd`'s `g : ℕ → Fin 2` and the `Fin 3`-valued
+`cN2_total` restriction to the diagonal needs the strictly
+stronger `.val < 2` form: the witness that promotes a diagonal
+color to a `Fin 2` value via the
+`(0 : Fin 3) ↔ (0 : Fin 2)`, `(1 : Fin 3) ↔ (1 : Fin 2)`
+identification. This session packages that promotion, mirroring
+the `Fin.val_ne ⇒ val < bound` pattern already in
+`sperner_panchromatic_two`'s `hK_lt_N` / `hcK1` proofs (lines
+180–210).
+
+New section `N2DiagValFinTwo` (2 private lemmas, 62 lines added to
+`SpernerFreudenthalSimplex.lean`, inserted between
+`N2DiagFaceCondition` and the final `end SpernerFreudSimp`):
+
+* **`.val < 2` promotion** (2 lemmas):
+  - `cN2_diag_val_lt_two (k : ℕ) (hk : k ≤ N) :
+    (cN2 N hN f hf_map (k, N - k) (by omega)).val < 2`.
+    Proof: lift S27-prep's `cN2_diag_ne_two` to `.val ≠ 2` via
+    `Fin.ext`, combine with the `.isLt` bound `< 3`, finish with
+    `omega`.
+  - `cN2_total_diag_val_lt_two (k : ℕ) (hk : k ≤ N) :
+    (cN2_total N hN f hf_map (k, N - k)).val < 2`.
+    Proof: rewrite via S27-prep's `cN2_total_diag_eq` then apply
+    `cN2_diag_val_lt_two`.
+
+Independent of the still-stale in-flight S23 (`N2LastFaceColors`,
+PR #17571, CONFLICTING since 2026-05-09) which packages the
+analogous color facts in the `(b.1, b.2 + 1)`-endpoint form
+rather than the `(k, N - k)`-diagonal form, and of S25-prep
+(`N2GridCoord`, PR #17621, CONFLICTING) gridPt coordinate
+helpers. The promotion here lives entirely on the
+`face2_path_odd` `(k, N - k)`-parametrization side and unblocks
+the eventual `g k ≠ g (k+1) ↔ cN2_total (k, N - k) ≠ cN2_total
+(k+1, N - (k+1))` color-change correspondence S22's IsDoor
+bridge will consume.
+
+## Prior Sessions (Recent)
+
+Session 27-prep-diag-face (researcher-10, 2026-05-12, build
+pending): Added **face-2 and color characterizations at the
 `(k, N - k)` diagonal vertices** of `face2_path_odd`. The S26-prep
 `N2DiagonalEndpointForm` lemmas translated `satDiagBases` endpoint
 expressions into the `(k, N - k)` parametrization; this session
@@ -19,7 +64,7 @@ hypothesis.
 
 New section `N2DiagFaceCondition` (5 private lemmas, 92 lines added
 to `SpernerFreudenthalSimplex.lean`, inserted between
-`N2DiagonalEndpointForm` and the final `end SpernerFreudSimp`):
+`N2DiagonalEndpointForm` and `N2DiagValFinTwo`):
 
 * **Face-2 membership at the diagonal** (2 lemmas):
   - `onFaceΔ2_diag (k : ℕ) (hk : k ≤ N) : onFaceΔ2 N (k, N - k) 2`.

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "REFINE",
     "since": "2026-05-06",
-    "iteration": 23,
-    "focus": "S26-prep-diam (this PR, researcher-5, build pending): added the per-coordinate gridPt diameter bounds that the eventual sperner_panchromatic_two real-coordinate conclusion |v i l - v j l| ≤ 2/N will consume. New section N2GridDiameter with 10 private lemmas (187 lines) inserted between N2VertexRange and end SpernerFreudSimp: three closed-form coord-diff lemmas (gridPt_coord0_diff, gridPt_coord1_diff, gridPt_coord2_diff), six vertex-coord range bounds for t1/t2 (first/second/sum), and three diameter bounds (gridPt_t1_coord_diameter and gridPt_t2_coord_diameter at the tight ≤ 1/N, plus gridPt_topSimps2_coord_diameter wrapping at the ≤ 2/N form matching the abstract sperner_panchromatic axiom). Independent of in-flight S23 (PR #17571, color-side wiring) and S25-prep (PR #17621, explicit gridPt coordinate values) — diameter is the geometric side of the eventual glue, orthogonal to the _hLastFace/IsDoor combinatorial side.",
+    "iteration": 28,
+    "focus": "S28-prep-fin2 (this PR, researcher-10, build pending — parent file build broken on origin/main since 2026-05-08 at t1_ne_t2/diagonal_in_t1_iff post-Mathlib drift): added Fin 2-promotion of the diagonal Sperner condition. S27-prep packaged cN2_diag_ne_two / cN2_total_diag_ne_two as `c ≠ (2 : Fin 3)`. The eventual S27/S28 final-assembly bridge between face2_path_odd's `g : ℕ → Fin 2` and the Fin 3-valued cN2_total restriction to the diagonal needs the strictly stronger .val < 2 form: the witness that promotes a diagonal color to a Fin 2 value via the (0 : Fin 3) ↔ (0 : Fin 2), (1 : Fin 3) ↔ (1 : Fin 2) identification. New section N2DiagValFinTwo with 2 private lemmas (62 lines) inserted between N2DiagFaceCondition and end SpernerFreudSimp: cN2_diag_val_lt_two and cN2_total_diag_val_lt_two. Each lifts S27-prep's ≠ 2 via Fin.ext to .val ≠ 2, combines with .isLt < 3, finishes with omega — same pattern as sperner_panchromatic_two's hK_lt_N / hcK1 proofs (lines 180–210). Independent of in-flight S23 (PR #17571, color-side wiring) and S25-prep (PR #17621, explicit gridPt coordinate values).",
     "blockers": [],
     "nextAction": "Once S25 (bijection assembly) and S23 (color-side wiring) merge, assemble sperner_panchromatic_two from: (1) Triangulation.boundary_doors_odd extracting a panchromatic top simplex s with vertex indices v₀,v₁,v₂ : ℕ × ℕ; (2) v i := gridPt N vᵢ (in InSimplex via gridPt_inSimplex + topSimps2_vertex_in_range); (3) Sperner color inequality f (v i) i ≤ v i i from panchromaticity + cN2 definition; (4) diameter bound from gridPt_topSimps2_coord_diameter (this PR).",
     "attemptCounts": {
@@ -28,6 +28,7 @@
       "approachesTried": 0
     },
     "builtItems": [
+      "S28-prep-fin2 (this PR): cN2_diag_val_lt_two, cN2_total_diag_val_lt_two in SpernerFreudenthalSimplex.lean (N2DiagValFinTwo section). For k ≤ N, the in-range cN2 / wrapper cN2_total at diagonal vertex (k, N - k) satisfies .val < 2. Each promotes S27-prep's ≠ (2 : Fin 3) to a .val < 2 witness via Fin.ext + .isLt + omega — the exact form needed to define a Fin 2-valued diagonal color function for the eventual S27 final-assembly bijection with face2_path_odd's `g`. ~62 lines including section header comment.",
       "S26-prep-diam (this PR): gridPt_coord0_diff, gridPt_coord1_diff, gridPt_coord2_diff in SpernerFreudenthalSimplex.lean (N2GridDiameter section). Closed-form per-coordinate differences of gridPt values: gridPt N b₁ 0 - gridPt N b₂ 0 = ((b₁.1 : ℝ) - b₂.1) / N (analogous for coord 1 with .2, and coord 2 with reverse-sign coord-sum diff). Each proof is simp [gridPt, val-reductions, ↓reduceIte] + ring. ~25 lines.",
       "S26-prep-diam (this PR): t1_vertex_first_coord_range, t1_vertex_second_coord_range, t1_vertex_sum_coord_range, t2_vertex_first_coord_range, t2_vertex_second_coord_range, t2_vertex_sum_coord_range in SpernerFreudenthalSimplex.lean. Coordinate range bounds for vertices of t1 b and t2 b: each ℕ coordinate is in [b.i, b.i+1]; the coord-sum is in [b.1+b.2, b.1+b.2+1] for t1 and [b.1+b.2+1, b.1+b.2+2] for t2. Six rcases+omega proofs, ~36 lines total.",
       "S26-prep-diam (this PR): gridPt_t1_coord_diameter and gridPt_t2_coord_diameter in SpernerFreudenthalSimplex.lean. For any two vertices b₁, b₂ ∈ t1 b (resp. t2 b) and any l : Fin 3, |gridPt N b₁ l - gridPt N b₂ l| ≤ 1/N. Three-case fin_cases l proof; each case rewrites via the coord-diff lemma, applies abs_div + abs_of_pos, extracts ℕ-range bounds in ℝ via exact_mod_cast, concludes via linarith + div_le_div_of_nonneg_right. ~80 lines.",
@@ -51,7 +52,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S27-prep-diag-face: face-2 / Sperner-condition glue at (k, N-k) diagonal vertices of face2_path_odd, packaging shape consumed by S22 h_no2 hypotheses; supporting infra for S27 final assembly.",
+    "progressSummary": "S28-prep-fin2: Fin 2-promotion of S27-prep's diagonal Sperner condition (`c ≠ (2 : Fin 3)` → `.val < 2`), the witness that lets the eventual S27 final assembly identify face2_path_odd's g : ℕ → Fin 2 with cN2_total's diagonal restriction.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",


### PR DESCRIPTION
## Summary

S27-prep (PR #17841, merged 2026-05-12) packaged the diagonal Sperner exclusion as `cN2 ... (k, N - k) ≠ (2 : Fin 3)` and its wrapper companion. The eventual S27 final-assembly bridge between `face2_path_odd`'s `g : ℕ → Fin 2` and the `Fin 3`-valued `cN2_total` restriction to the diagonal needs the strictly stronger `.val < 2` form — the witness that promotes a diagonal color to a `Fin 2` value via the `(0 : Fin 3) ↔ (0 : Fin 2)`, `(1 : Fin 3) ↔ (1 : Fin 2)` identification.

This iteration adds the `Fin 2`-promotion as a small standalone section, mirroring the `Fin.val_ne ⇒ val < bound` pattern already established in `sperner_panchromatic_two`'s `hK_lt_N` / `hcK1` proofs (lines 180–210 of the same file).

## What lands

New section `N2DiagValFinTwo` (2 private lemmas, 62 lines added to `SpernerFreudenthalSimplex.lean`, inserted between `N2DiagFaceCondition` and the final `end SpernerFreudSimp`):

* `cN2_diag_val_lt_two (k : ℕ) (hk : k ≤ N) : (cN2 N hN f hf_map (k, N - k) (by omega)).val < 2`. Proof: lift S27-prep's `cN2_diag_ne_two` to `.val ≠ 2` via `Fin.ext`, combine with the `.isLt` bound `< 3`, finish with `omega`.
* `cN2_total_diag_val_lt_two (k : ℕ) (hk : k ≤ N) : (cN2_total N hN f hf_map (k, N - k)).val < 2`. Proof: rewrite via S27-prep's `cN2_total_diag_eq` then apply `cN2_diag_val_lt_two`.

State.md + research JSON updated to reflect S28-prep (iteration counter bumped 23 → 28 to match merged session sequence).

## Independence

* Independent of the still-stale in-flight S23 (`N2LastFaceColors`, PR #17571, CONFLICTING since 2026-05-09) which packages the analogous color facts in the `(b.1, b.2 + 1)`-endpoint form rather than the `(k, N - k)`-diagonal form.
* Independent of S25-prep (`N2GridCoord`, PR #17621, CONFLICTING) gridPt coordinate helpers.

The promotion here lives entirely on the `face2_path_odd` `(k, N - k)`-parametrization side and unblocks the eventual `g k ≠ g (k+1) ↔ cN2_total (k, N - k) ≠ cN2_total (k+1, N - (k+1))` color-change correspondence S22's IsDoor bridge will consume.

## Build status

Build pending: `SpernerFreudenthalSimplex.lean` has been broken on origin/main since 2026-05-08 at `t1_ne_t2` / `diagonal_in_t1_iff` (`omega` failures around lines 1068/1085/1093 from a Mathlib `Prod.mk.injEq` simp shape drift); 6+ sperner PRs have merged "(build pending)" since then. This PR follows the same convention pending the unrelated mechanic drift-fix. The new additions are syntactically isolated (no new dependencies, only `Fin.ext` / `.isLt` / `omega`).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.SpernerFreudenthalSimplex` (deferred — parent file broken on main; new lemmas inspectable in isolation).
- [ ] Once the parent drift is fixed by a mechanic PR, this section becomes locally verifiable as 2 short omega+Fin.ext chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)