### PR TITLE
Enrich infinitude-primes-4k3-oq-03: Gaussian integers + boundary of elementary methods

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
@@ -201,6 +201,62 @@
     ]
   },
   {
+    "id": "gaussian-integers-splitting",
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": {
+      "startLine": 55,
+      "endLine": 66
+    },
+    "type": "insight",
+    "title": "Gaussian Integers: The Algebraic Shadow of the mod-4 Split",
+    "content": "The same mod-4 dichotomy proved elementarily here is, in algebraic number theory, the splitting behaviour of rational primes in the **Gaussian integers** $\\mathbb{Z}[i] = \\{a + bi : a, b \\in \\mathbb{Z}\\}$. Three exclusive cases govern every rational prime $p$:\n\n- **Split** ($p \\equiv 1 \\pmod 4$): $p = (a+bi)(a-bi)$ for unique $a, b$. Examples: $5 = (2+i)(2-i)$, $13 = (3+2i)(3-2i)$, $17 = (4+i)(4-i)$, $29 = (5+2i)(5-2i)$. The two Gaussian primes $a \\pm bi$ are conjugate and non-associate; $\\mathbb{Z}[i]/(p)$ is *not* a field, it decomposes as $\\mathbb{F}_p \\times \\mathbb{F}_p$.\n- **Inert** ($p \\equiv 3 \\pmod 4$): $p$ remains a Gaussian prime. Examples: $3, 7, 11, 19, 23, 31$. The quotient $\\mathbb{Z}[i]/(p) \\cong \\mathbb{F}_{p^2}$ is a degree-2 field extension.\n- **Ramified** ($p = 2$): $2 = -i(1+i)^2$ — the prime $1+i$ appears with multiplicity 2; $\\mathbb{Z}[i]/(2) \\cong \\mathbb{F}_2[\\epsilon]/\\epsilon^2$ is a non-reduced ring.\n\nThe link to the elementary proof: $p$ splits in $\\mathbb{Z}[i]$ ⟺ $X^2 + 1$ factors mod $p$ ⟺ $-1$ is a quadratic residue mod $p$ ⟺ $p \\equiv 1 \\pmod 4$ (Euler's criterion). The construction $N = (2(n+1)!)^2 + 1$ is exactly choosing $X = 2(n+1)!$ in $X^2 + 1$ and demanding a *split* prime factor. This is the simplest non-trivial example of the **Dedekind splitting principle**: in $\\mathcal{O}_K = \\mathbb{Z}[\\alpha]$ with $\\alpha$ root of minimal polynomial $f$, a rational prime $p \\nmid \\mathrm{disc}(f)$ splits according to the factorisation of $f$ mod $p$.",
+    "mathContext": "**Trichotomy in $\\mathbb{Z}[i]$**:\n- Split: $p \\equiv 1 \\pmod 4 \\Leftrightarrow p = \\pi \\bar{\\pi}$ with $\\pi, \\bar{\\pi}$ non-associate Gaussian primes.\n- Inert: $p \\equiv 3 \\pmod 4 \\Leftrightarrow p$ stays prime in $\\mathbb{Z}[i]$.\n- Ramified: $p = 2 = -i(1+i)^2$.\n\n**Dedekind-Kummer**: For $K = \\mathbb{Q}(i)$, $\\mathcal{O}_K = \\mathbb{Z}[i]$, minimal polynomial $f(X) = X^2 + 1$. Factor $f \\bmod p$:\n- $p \\equiv 1 \\pmod 4$: $X^2 + 1 \\equiv (X-k)(X+k) \\pmod p$ where $k^2 \\equiv -1$. ⟹ $p$ splits.\n- $p \\equiv 3 \\pmod 4$: $X^2 + 1$ stays irreducible mod $p$. ⟹ $p$ inert.\n- $p = 2$: $X^2 + 1 \\equiv (X+1)^2 \\pmod 2$. ⟹ ramified, $\\mathrm{disc} = -4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian integers ℤ[i]",
+      "splitting of primes in number fields",
+      "Dedekind-Kummer theorem",
+      "ramification and discriminant",
+      "Fermat's two-squares theorem",
+      "norm form a²+b²",
+      "Frobenius element"
+    ],
+    "prerequisites": [
+      "unique factorisation in ℤ[i]",
+      "splitting/inert/ramified terminology",
+      "minimal polynomial mod p",
+      "Euler's criterion for −1 as QR"
+    ]
+  },
+  {
+    "id": "boundary-of-elementary",
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": {
+      "startLine": 84,
+      "endLine": 103
+    },
+    "type": "context",
+    "title": "Boundary of Elementary Methods: Why mod 5 Is Already Hard",
+    "content": "The constructions_cover_all_odd_primes theorem encodes a remarkable fact: **the two infinite families in this file exhaust every odd prime**. This kind of complete covering is possible at modulus 4 but breaks down already at modulus 5. Of the four invertible classes $\\{1, 2, 3, 4\\} \\pmod 5$, only $a = 1$ and $a = 4$ satisfy Murty's criterion $a^2 \\equiv 1 \\pmod 5$ — these admit Euclid-style elementary proofs (using $\\Phi_5$ and $\\Phi_{10}$ respectively). For $a = 2, 3 \\pmod 5$, no Euclid-style polynomial construction is known. Selberg's 1949 elementary proof of Dirichlet's general theorem covers them but is technically as deep as the elementary proof of the prime number theorem (Selberg–Erdős 1949), not the textbook Euclid argument seen here. The same pattern persists for every modulus $d \\geq 5$: the classes with $a^2 \\equiv 1 \\pmod d$ — namely the elements of $(\\mathbb{Z}/d\\mathbb{Z})^\\times$ of order $\\leq 2$ — admit elementary proofs; the rest require either Dirichlet L-functions or Selberg's deep elementary methods.\n\nThe rcases-on-classification proof pattern used here (split on residue, supply witness in each branch) is therefore not a generic technique — it is specific to moduli with a small invertible group of involutions. For $d = 4$, $(\\mathbb{Z}/4\\mathbb{Z})^\\times = \\{1, 3\\}$ consists entirely of involutions ($1^2 = 1$, $3^2 = 9 \\equiv 1$), so both classes qualify. For $d = 8$, $(\\mathbb{Z}/8\\mathbb{Z})^\\times = \\{1, 3, 5, 7\\}$ — all four square to 1, so all four classes have elementary infinitude proofs. For $d = 12$ similarly. For $d = p$ an odd prime, only $\\{1, p-1\\}$ are involutions, so only two of $p - 1$ classes admit elementary proofs.",
+    "mathContext": "**Murty's criterion (1988)**: A class $a \\pmod d$ admits a Euclid-style elementary infinitude proof iff $a^2 \\equiv 1 \\pmod d$. Equivalently, $a$ is an involution in $(\\mathbb{Z}/d\\mathbb{Z})^\\times$. The number of qualifying classes is $|\\{x \\in (\\mathbb{Z}/d\\mathbb{Z})^\\times : x^2 = 1\\}|$, computable via CRT from the 2-torsion of each $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ factor (size $2$ for odd prime power, sizes $1, 2, 4$ for $2^1, 2^2, 2^{k \\geq 3}$).\n\n**Examples**:\n- $d = 4$: 2 of 2 invertible classes elementary ($a = 1, 3$). Coverage: **complete**.\n- $d = 5$: 2 of 4 elementary ($a = 1, 4$). Coverage: half.\n- $d = 8$: 4 of 4 elementary ($a = 1, 3, 5, 7$). Coverage: **complete**.\n- $d = 12$: 4 of 4 elementary. Coverage: **complete**.\n- $d = 7$: 2 of 6 elementary ($a = 1, 6$). Coverage: 1/3.\n- $d = 11$: 2 of 10 elementary ($a = 1, 10$). Coverage: 1/5.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Murty's criterion",
+      "Dirichlet's theorem",
+      "Selberg-Erdős elementary methods",
+      "Bang–Zsygmondy theorem",
+      "cyclotomic polynomial Φ_n",
+      "involutions in (ℤ/dℤ)×",
+      "boundary of elementary number theory"
+    ],
+    "prerequisites": [
+      "structure of (ℤ/dℤ)× as abelian group",
+      "involutions and order-2 elements",
+      "cyclotomic polynomial framework",
+      "Dirichlet's theorem statement"
+    ]
+  },
+  {
     "id": "set-infinite-api",
     "proofId": "infinitude-primes-4k3-oq-03",
     "range": {


### PR DESCRIPTION
## Summary

Adds two new high-value annotations to `infinitude-primes-4k3-oq-03` (quality 98, 0 passes), anchoring previously-prose-only material to specific code regions with concrete examples.

### New annotations

1. **`gaussian-integers-splitting`** (lines 55-66, main theorem)
   - Frames the mod-4 dichotomy as the splitting/inert/ramified trichotomy of rational primes in $\mathbb{Z}[i]$.
   - Concrete factorizations: $5 = (2+i)(2-i)$, $13 = (3+2i)(3-2i)$, $17 = (4+i)(4-i)$, $29 = (5+2i)(5-2i)$, $2 = -i(1+i)^2$.
   - Dedekind-Kummer derivation: factoring $X^2 + 1 \bmod p$ controls the splitting type, matching Euler's criterion.
   - Quotient ring structure for each case (field, field extension, non-reduced).

2. **`boundary-of-elementary`** (lines 84-103, `constructions_cover_all_odd_primes`)
   - Explains *why* the disjunctive classification works at mod 4 but not elsewhere.
   - Murty's criterion $a^2 \equiv 1 \pmod d$ counted via 2-torsion of $(\mathbb{Z}/d\mathbb{Z})^\times$.
   - Coverage table for $d = 4, 5, 7, 8, 11, 12$ showing complete vs partial elementary coverage.
   - Selberg-Erdős 1949 contrast: elementary but graduate-level deep.

### Quality impact

These annotations move keyInsight #7-#8 (Gaussian primes / cyclotomic generalization) and openQuestion #4 (Murty's criterion meta-theorem) from prose narrative into code-anchored pedagogy. Annotation count: 9 → 11. All schema fields populated (`mathContext`, `significance: key`, `relatedConcepts`, `prerequisites`).

## Verification

- [x] `annotations.json` parses as JSON (11 items, all valid).
- [x] `tsc --noEmit -p tsconfig.json` clean.
- [x] `tsx scripts/annotations/build.ts` exits 0, no warnings for this target.
- [x] Diff is single-file, 56 lines added.
- [x] Math content reviewed: factorizations correct, Dedekind-Kummer/2-torsion counts verified for $d \in \{4, 5, 7, 8, 11, 12\}$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)