### PR TITLE
audit(combinations-formula-oq-02): correct sorry count & status (1→0, formalized→verified)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -94,7 +94,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. The main file has 0 sorries and 0 axioms; the *Aristotle.lean companion exposes a duplicate `catalan_mul_succ` statement as an Aristotle proof-search target (1 sorry).",
+    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. Both the main file and the *Aristotle.lean companion are now fully proved (0 sorries, 0 axioms across both files).",
     "implications": "This formalization connects the gallery's binomial coefficient work (CombinationsFormula) to the ballot problem proofs (BallotProblemOQ03). The central binomial bound C(2n,n) <= 4^n is independently useful (e.g., for the Ap\u00e9ry irrationality proof).",
     "openQuestions": [
       "Prove the generating function C(x) = (1 - sqrt(1-4x))/(2x)",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Gallery integrity audit found a stale metadata claim for `combinations-formula-oq-02`:

- meta.json claimed `sorries: 1` and `status: "formalized"`
- Conclusion text described the Aristotle companion file as having a sorry-bearing `catalan_mul_succ` target
- Inspection shows both `CombinationsFormulaOQ02.lean` and `CombinationsFormulaOQ02Aristotle.lean` have **0 sorry declarations** and 0 axioms — Aristotle apparently completed the target since meta.json was last written

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `formalized` | `verified` |
| `meta.sorries` | 1 | 0 |
| top-level `sorries` | 1 | 0 |
| `conclusion.summary` | "Aristotle companion ... (1 sorry)" | "Both the main file and the *Aristotle.lean companion are now fully proved (0 sorries, 0 axioms across both files)" |

## Verification

After stripping block & line comments, `\bsorry\b` count is 0 in both `CombinationsFormulaOQ02.lean` and `CombinationsFormulaOQ02Aristotle.lean`.

Per CLAUDE.md axiom-integrity policy: `verified` status requires 0 sorries, 0 `axiom` declarations, and 0 structure-encoded assumptions — all satisfied here. Badge stays `original`.

Severity: **HIGH** (sorry-count mismatch — would underclaim verification status to gallery visitors).

Generated by lean-auditor agent.