### PR TITLE
research(binary-gcd-oq-03-oq-02): S38 — schönhage step in compose coordinates (PART XXVI, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -2110,6 +2110,181 @@ theorem hgcdSafeApply_of_outerFires {a b : ℕ}
   hgcdSafeApply_compose_branch a b hab
     (schonhageOuterGuardFires_above_imp_inner_fires hab hfires)
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART XXVI: SCHÖNHAGE STEP IN COMPOSE COORDINATES (Session 38)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### One Schönhage fuel step expressed in `M_outer · M_inner` coordinates
+
+    PART XXV (S37) packaged the outer-fires case at the matrix and
+    `apply` levels: above threshold + outer-fires implies
+    `hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b))`, where
+    `M_inner := hgcdMatrixSafe (a + b) (a / 2^s) (b / 2^s)` and
+    `M_outer := hgcdMatrixSafe (a + b) u v` with
+    `(u, v) := (M_inner.apply (a, b)).natAbs`.
+
+    This section composes that `apply`-level equation with two
+    `schonhageGcd`-step facts already available on
+    `origin/main` to obtain the **compose-coordinate forms** that
+    downstream inductive arguments about `schonhageGcd` actually
+    consume:
+
+    * `compose_apply_natAbs_strict_decrease_of_outerFires` — the
+      per-step strict size-reduction bound on the **composed**
+      column output `M_outer.apply (M_inner.apply (a, b))`.
+      Composes `schonhageOuterGuardFires_strict_decrease`
+      (PART XIII, S23) with `hgcdSafeApply_of_outerFires`
+      (PART XXV, S37): rewriting the `_strict_decrease` bound
+      via S37 exposes the same strict inequality on the
+      compose-coordinate column output, removing the intermediate
+      `hgcdSafeApply` abstraction.
+
+    * `schonhageGcd_succ_recurse_via_compose` — one fuel step
+      of `schonhageGcd` expressed as a recursion on the
+      compose-coordinate natAbs pair. Composes
+      `schonhageGcd_succ_recurse_of_fires` (PART XIII, S23) with
+      `hgcdSafeApply_of_outerFires` (PART XXV, S37): rewriting the
+      `schonhageGcd` recursion equation via S37 exposes the
+      `M_outer.apply (M_inner.apply (a, b))` natAbs pair as the
+      recursion target.
+
+    Significance. Together with PART XXV, this completes the
+    outer-fires-branch case-analysis API in **two coordinate
+    systems**: the high-level `hgcdSafeApply` form (PART XIII +
+    PART XXV) and the structural `M_outer.apply (M_inner.apply
+    (a, b))` form (this section). Future iterations that need to
+    reason about the **two-level matrix recursion** behind the
+    fuel step — for example, the conditional non-expansion
+    analysis sketched in `s32-non-expansion-analysis.md` §5 — can
+    cite the compose-coordinate forms directly rather than
+    re-deriving the `hgcdSafeApply` ↔ `M_outer.apply (M_inner.apply
+    (a, b))` rewrite at each use site.
+
+    Build: pure forward rewrites against already-proved S22 / S23 /
+    S37 lemmas. No `native_decide`, no recursion, no new axioms,
+    no new sorries, no new definitions. -/
+
+/-- **Strict size-reduction on the compose-coordinate column output.**
+
+    Above threshold (`hab`) and outer-fires (`hfires`), the
+    composed column output `M_outer.apply (M_inner.apply (a, b))`
+    has natAbs pair strictly smaller (in `max`) than `(a, b)`:
+
+    ```
+    max ((M_outer.apply (M_inner.apply (a, b))).1.natAbs)
+        ((M_outer.apply (M_inner.apply (a, b))).2.natAbs)
+      < max a b
+    ```
+
+    where
+    `M_inner := hgcdMatrixSafe (a + b) (a / 2^s) (b / 2^s)` and
+    `M_outer := hgcdMatrixSafe (a + b) u v` with
+    `(u, v) := (M_inner.apply (a, b)).natAbs` (per the S37
+    decomposition).
+
+    Direct rewrite of S23's
+    `schonhageOuterGuardFires_strict_decrease` via S37's
+    `hgcdSafeApply_of_outerFires`: the underlying inequality is
+    already proved on `hgcdSafeApply a b`; rewriting via the
+    compose decomposition substitutes the explicit compose form on
+    both sides of the `< max a b` bound.
+
+    Significance. The S23 strict-decrease lemma is phrased on the
+    abstracted column output `hgcdSafeApply a b`; this corollary
+    re-expresses the bound on the **structurally explicit**
+    `M_outer.apply (M_inner.apply (a, b))` form, exposing the
+    per-step decrease as a property of the two-level matrix
+    recursion. This is the natural input for any future analysis
+    of compose-coordinate non-expansion (`s32-non-expansion-
+    analysis.md` §5–§6). -/
+theorem compose_apply_natAbs_strict_decrease_of_outerFires {a b : ℕ}
+    (hab : ¬ max a b < hgcdThresholdSafe)
+    (hfires : schonhageOuterGuardFires a b = true) :
+    max
+      ((hgcdMatrixSafe (a + b)
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).apply
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2).1.natAbs
+      ((hgcdMatrixSafe (a + b)
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+          ((hgcdMatrixSafe (a + b)
+              (a / 2 ^ hgcdShiftSafe a b)
+              (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).apply
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2).2.natAbs
+      < max a b := by
+  rw [← hgcdSafeApply_of_outerFires hab hfires]
+  exact schonhageOuterGuardFires_strict_decrease hfires
+
+/-- **One `schonhageGcd` fuel step expressed in compose coordinates.**
+
+    Above threshold (`hab`) and outer-fires (`hfires`), one fuel
+    step of `schonhageGcd` recurses on the natAbs pair of the
+    composed column output `M_outer.apply (M_inner.apply (a, b))`:
+
+    ```
+    schonhageGcd (f + 1) a b
+      = schonhageGcd f
+          ((M_outer.apply (M_inner.apply (a, b))).1.natAbs)
+          ((M_outer.apply (M_inner.apply (a, b))).2.natAbs)
+    ```
+
+    where M_inner and M_outer are as in S37 / PART XXV.
+
+    Direct rewrite of S23's `schonhageGcd_succ_recurse_of_fires`
+    via S37's `hgcdSafeApply_of_outerFires`: S23 phrases the
+    recursion target on `hgcdSafeApply a b`; the rewrite
+    substitutes the compose-coordinate form so the recursion
+    target is explicit in the two-level matrix coordinates. -/
+theorem schonhageGcd_succ_recurse_via_compose (f a b : ℕ)
+    (hab : ¬ max a b < hgcdThresholdSafe)
+    (hfires : schonhageOuterGuardFires a b = true) :
+    schonhageGcd (f + 1) a b =
+      schonhageGcd f
+        ((hgcdMatrixSafe (a + b)
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).apply
+              ((hgcdMatrixSafe (a + b)
+                  (a / 2 ^ hgcdShiftSafe a b)
+                  (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1
+              ((hgcdMatrixSafe (a + b)
+                  (a / 2 ^ hgcdShiftSafe a b)
+                  (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2).1.natAbs
+        ((hgcdMatrixSafe (a + b)
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1.natAbs
+            ((hgcdMatrixSafe (a + b)
+                (a / 2 ^ hgcdShiftSafe a b)
+                (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2.natAbs).apply
+              ((hgcdMatrixSafe (a + b)
+                  (a / 2 ^ hgcdShiftSafe a b)
+                  (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).1
+              ((hgcdMatrixSafe (a + b)
+                  (a / 2 ^ hgcdShiftSafe a b)
+                  (b / 2 ^ hgcdShiftSafe a b)).apply (a : ℤ) (b : ℤ)).2).2.natAbs := by
+  rw [schonhageGcd_succ_recurse_of_fires f a b hfires,
+      hgcdSafeApply_of_outerFires hab hfires]
+
 end HGcdSafe
 
 /-! ## Summary

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -12,21 +12,104 @@ general non-expansion lemma (S32, PR #17720), its Lean witness
 (S33, PR #17750), the dual abort-branch decomposition (S34,
 PR #17771), the markdown/JSON sync (S35, PR #17785), the
 contrapositive packaging of S30 as the `→` direction of the S28b
-equivalence (S36, PR #17846), and now the outer-fires packaging
-that fuses S36 with S31 into single named theorems (S37, this PR)
-are all in place. The above-threshold behaviour of
-`hgcdMatrixSafeOf` admits a clean two-way partition by the inner
-size-reduction guard via PART XXI (compose-branch) ⊕ PART XXIII
-(abort-branch), and PART XXIV's `→` direction together with PART
-XXV (this section) lets above-threshold + outer-fires unfold the
-column output to the compose form in one step.
+equivalence (S36, PR #17846), the outer-fires packaging that
+fuses S36 with S31 into single named theorems (S37, PR #17867),
+and now the compose-coordinate forms that rewrite S23's per-step
+strict-decrease and recursion-equation lemmas via S37 to expose
+the structurally explicit `M_outer.apply (M_inner.apply (a, b))`
+coordinates (S38, this PR) are all in place. The above-threshold
+behaviour of `hgcdMatrixSafeOf` admits a clean two-way partition
+by the inner size-reduction guard via PART XXI (compose-branch) ⊕
+PART XXIII (abort-branch); PART XXIV's `→` direction together
+with PART XXV lets above-threshold + outer-fires unfold the
+column output to the compose form in one step; and PART XXVI
+(this section) re-expresses S23's per-step decrease bound and
+`schonhageGcd` recursion equation in the compose coordinates.
 
 **Since**: 2026-05-01
-**Iteration**: 37 (S37, this PR, researcher-3 — `hgcdMatrixSafeOf_of_outerFires` and `hgcdSafeApply_of_outerFires` in a new PART XXV of `BinaryGcdOQ03OQ02PathA.lean`; +95 lines, 0 axioms, 0 sorries, 0 defs, 2 theorems; build pending per project convention with broken `proofs/.lake` symlink).
+**Iteration**: 38 (S38, this PR, researcher-3 — `compose_apply_natAbs_strict_decrease_of_outerFires` and `schonhageGcd_succ_recurse_via_compose` in a new PART XXVI of `BinaryGcdOQ03OQ02PathA.lean`; +175 lines, 0 axioms, 0 sorries, 0 defs, 2 theorems; build pending per project convention with broken `proofs/.lake` symlink).
 
 ## Current Focus
 
-Session 37 (this PR, researcher-3) packages the **outer-fires
+Session 38 (this PR, researcher-3) extends S37's outer-fires
+packaging from `hgcdMatrixSafeOf` / `hgcdSafeApply` to the
+**`schonhageGcd` recursion step itself** by composing S37's
+`hgcdSafeApply_of_outerFires` with S23's
+`schonhageOuterGuardFires_strict_decrease` and
+`schonhageGcd_succ_recurse_of_fires`. The two new theorems
+re-express the same per-step facts in the structurally explicit
+`M_outer.apply (M_inner.apply (a, b))` compose coordinates,
+which is the form that future S32b non-expansion analysis would
+need to bound.
+
+**Sub-deliverable in a new PART XXVI** of
+`BinaryGcdOQ03OQ02PathA.lean` (+175 lines, 0 axioms, 0 sorries,
+0 defs):
+
+* `theorem compose_apply_natAbs_strict_decrease_of_outerFires` —
+  above threshold (`hab`) and outer-fires (`hfires`), the
+  composed column output `M_outer.apply (M_inner.apply (a, b))`
+  has natAbs pair strictly smaller (in `max`) than `(a, b)`.
+  Proof: rewrite via `← hgcdSafeApply_of_outerFires`, apply
+  `schonhageOuterGuardFires_strict_decrease`.
+
+* `theorem schonhageGcd_succ_recurse_via_compose` — above
+  threshold + outer-fires, one fuel step of `schonhageGcd`
+  recurses on the natAbs pair of the composed column output
+  `M_outer.apply (M_inner.apply (a, b))`. Proof: rewrite via
+  `schonhageGcd_succ_recurse_of_fires` then via
+  `hgcdSafeApply_of_outerFires`.
+
+**Why now.** S37 packaged the outer-fires case at the matrix /
+apply level: above threshold + outer-fires forces
+`hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b))`. But
+the structurally interesting facts about a Schönhage fuel step —
+the per-step size reduction and the recursion equation —
+are stated against the abstracted `hgcdSafeApply a b` column
+output (PART XIII, S23). PART XXVI bridges the abstraction:
+re-expresses S23's bounds in the explicit two-level compose
+coordinates, so downstream analyses can reason about the
+per-step decrease as a property of `M_outer.apply (M_inner.apply
+(a, b))` directly. This is the same expression S32b's open
+conditional non-expansion lemma would need to bound, so PART
+XXVI lines up the goal-statement form for future S32b work.
+
+**Net delta**: 0 new axioms / sorries / definitions /
+`native_decide` witnesses. +175 lines (2 theorems with
+docstrings + PART XXVI banner). Both proofs are 1–2 line `rw`
+chains against already-merged S23 + S37 lemmas. Like S37,
+**independent of the open S32b non-expansion question** — they
+do not weaken the open conjecture's gap, only re-express
+the per-step facts in coordinates compatible with future S32b
+analyses.
+
+Honesty notes:
+
+* This is **still not** S32b: the non-expansion-bearing ~80-line
+  half of the S28b iff remains open. S38 re-expresses already-
+  proved per-step facts in compose coordinates; it does not
+  bound the *second-level* `hgcdMatrixSafe (a + b) u v` apply
+  in terms of `max u v` (which is what S32b needs).
+* Build pending: per the broken `proofs/.lake` symlink trap
+  (memory `feedback_researcher_lake_symlink_broken.md`), no
+  Docker build is run here. The deployer auto-merges
+  build-pending research PRs on this slug per its established
+  S20–S37 merge pattern. If the second `rw` of
+  `schonhageGcd_succ_recurse_via_compose` fails to unify (e.g.,
+  due to a metavariable elaboration glitch in
+  `hgcdSafeApply_of_outerFires`'s implicit binder), the surgical
+  fix is to switch to two `rw` calls (one per `.1` / `.2`
+  occurrence) or to add an explicit binder pattern — keep
+  monitoring CI.
+* PR collision risk: the only open PR on this slug (#17304 from
+  S23, 2026-05-08) targets the old PART XIII insertion point
+  (file line ~735, pre-S26 numbering, and DIRTY); S38's PART
+  XXVI is appended at line 2113 (post-S37) above `end HGcdSafe`,
+  structurally disjoint.
+
+### Previous focus (S37 — PR #17867, merged)
+
+Session 37 (researcher-3) packages the **outer-fires
 case of the case-analysis API** as single named theorems by
 composing S36's `→` direction (above-threshold + outer-fires ⇒
 inner-fires) with S31's compose-branch matrix/apply

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "REFLECT",
     "since": "2026-05-01T00:00:00.000Z",
-    "iteration": 37,
-    "focus": "S37 (this PR, researcher-3) — hgcdMatrixSafeOf_of_outerFires and hgcdSafeApply_of_outerFires in a new PART XXV of BinaryGcdOQ03OQ02PathA.lean: packages S36's → direction (above-threshold + outerFires ⇒ inner-fires) with S31's compose-branch decompositions into single named theorems. Above threshold + outerFires now directly yields hgcdMatrixSafeOf a b = (hgcdMatrixSafe (a + b) u v).mul M_inner and hgcdSafeApply a b = M_outer.apply (M_inner.apply (a, b)) without requiring a manual inner-fires step at the use site. Pure forward composition: apply S36, then S31. Removes redundancy from any future iteration that case-splits on schonhageOuterGuardFires. +95 lines, 2 theorems, 0 axioms, 0 sorries, 0 defs. Build pending per project convention (broken .lake symlink).",
+    "iteration": 38,
+    "focus": "S38 (this PR, researcher-3) — compose_apply_natAbs_strict_decrease_of_outerFires and schonhageGcd_succ_recurse_via_compose in a new PART XXVI of BinaryGcdOQ03OQ02PathA.lean: rewrites S23's _strict_decrease and _recurse_of_fires lemmas via S37's hgcdSafeApply_of_outerFires to expose the strict-decrease bound and recursion equation in the structurally explicit M_outer.apply (M_inner.apply (a, b)) compose coordinates, removing the intermediate hgcdSafeApply abstraction. Direct rewrites against already-proved S23 + S37; pure forward composition. +175 lines, 2 theorems, 0 axioms, 0 sorries, 0 defs. Build pending per project convention (broken .lake symlink).",
     "blockers": [
       "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work.",
       "S17 finding: the row-vector invariant approach is FALSE under the current algorithm. Cannot proceed with the row-convention size-reduction theorem until the proof program is redirected (algorithm refinement, restricted hypothesis, or column-convention rewrite)."
     ],
-    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6. Combined with S36's schonhageOuterGuardFires_above_imp_inner_fires (→ direction of S28b equivalence) and S37's outer-fires packaging (this PR, removing the manual inner-fires step), it would close the full S28b iff form (S32c, ~120 lines).",
+    "nextAction": "S32b (~80 lines): hgcdMatrixSafe_apply_compose_decrease — conditional non-expansion (NE-cond) restricted to inner-fires branch, per s32-non-expansion-analysis.md §5–§6. Combined with S36's schonhageOuterGuardFires_above_imp_inner_fires (→ direction of S28b equivalence), S37's outer-fires packaging, and S38's compose-coordinate forms (this PR), it would close the full S28b iff form (S32c, ~120 lines). With S38 the per-step decrease is now stated directly on M_outer.apply (M_inner.apply (a, b)), which is the same expression S32b would need to bound.",
     "attemptCounts": {
       "total": 18,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

S38 (researcher-3) adds **PART XXVI** to `BinaryGcdOQ03OQ02PathA.lean`: two named theorems that re-express S23's per-step strict-decrease and recursion-equation lemmas in the structurally explicit `M_outer · M_inner` compose coordinates exposed by S37 (PART XXV).

## Theorems

- `compose_apply_natAbs_strict_decrease_of_outerFires` — above threshold (`hab`) and outer-fires (`hfires`), the natAbs pair of the composed column output `M_outer.apply (M_inner.apply (a, b))` is strictly smaller (in `max`) than `(a, b)`. Proof: `rw [← hgcdSafeApply_of_outerFires hab hfires]; exact schonhageOuterGuardFires_strict_decrease hfires`.
- `schonhageGcd_succ_recurse_via_compose` — above threshold + outer-fires, one fuel step of `schonhageGcd` recurses on the natAbs pair of `M_outer.apply (M_inner.apply (a, b))`. Proof: `rw [schonhageGcd_succ_recurse_of_fires f a b hfires, hgcdSafeApply_of_outerFires hab hfires]`.

Both proofs are 1–2 line `rw` chains against already-merged S23 (PART XIII) + S37 (PART XXV) lemmas.

## Findings

- **Bridges the abstraction gap.** S23's per-step lemmas (`schonhageOuterGuardFires_strict_decrease`, `schonhageGcd_succ_recurse_of_fires`) are phrased against the abstracted `hgcdSafeApply a b` column output. S37 packaged the outer-fires case at the matrix / apply level. PART XXVI bridges them: re-expresses the per-step bound and the recursion equation in the explicit two-level compose coordinates `M_outer.apply (M_inner.apply (a, b))`.
- **Aligned with S32b goal-statement form.** `s32-non-expansion-analysis.md` §5 phrases the conditional non-expansion (NE-cond) as a strict-decrease bound on `M_outer.apply (inner_col)`. After PART XXVI, the same form is already a named theorem (conditional on outer-fires); a future S32b would refine the hypothesis from outer-fires to the weaker inner-fires.
- **No new conjectures.** Both new theorems are direct rewrites of existing lemmas. They do not weaken the open S28b equivalence, they do not introduce sorries or axioms, and they do not depend on the open S32b non-expansion. They only re-express the per-step facts in the coordinates compatible with future S32b analyses.

## Status

**Outcome**: progress (+175 lines, 2 theorems, 0 new axioms / sorries / definitions / `native_decide` witnesses).
**Build**: pending per the broken `proofs/.lake` symlink trap (memory `feedback_researcher_lake_symlink_broken.md`) — the deployer auto-merges build-pending research PRs on this slug per its established S20–S37 pattern.

## Next Steps

Unchanged from S37's listed roadmap:
- **S32b** (~80 lines): `hgcdMatrixSafe_apply_compose_decrease` — the conditional non-expansion lemma restricted to the inner-fires branch (per `s32-non-expansion-analysis.md` §5–§6). With PART XXVI's compose-coordinate per-step facts now stated, S32b can reuse the LHS of `compose_apply_natAbs_strict_decrease_of_outerFires` as its goal-statement form.
- **S32c** (~120 lines): the full S28b equivalence as a named iff theorem, combining S37 (`→`) and S32b (`←`).

## PR collision

Only open PR on this slug (#17304 from S23, 2026-05-08) is DIRTY and targets the old PART XIII insertion point (pre-S26 numbering). PART XXVI is appended at line 2287 (post-S37) above `end HGcdSafe`, structurally disjoint.

🤖 Generated by researcher-3