### PR TITLE
audit(lagrange-theorem-oq-02-oq-02-oq-01): badge verified → mathlib

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "mulaction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 195,


### PR DESCRIPTION
## Summary

Gallery integrity audit found that `lagrange-theorem-oq-02-oq-02-oq-01` uses badge `verified` even though the main theorem `burnside_lemma_sum_form` is documented in the Lean source as `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` **"verbatim, restated in the namespace of this file"**.

Per the auditor narrative failure mode 5 (`"0 sorries" with hidden imports`):

> File has 0 sorries but obtains its main result by calling a deep Mathlib theorem. Technically sorry-free but misleadingly presented as independent work. **Fix**: Badge must be `mathlib`, not `original` or `verified`.

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.badge` | `verified` | `mathlib` |

Status `verified` is retained — the proof is fully machine-checked (0 sorries, 0 axiom declarations, 0 structure-encoded assumptions). The Mathlib dependency was already disclosed in `description`, `originalContributions`, and `mathlibDependencies`; this PR aligns the badge with the existing disclosures, so gallery visitors see the Tier-B classification at a glance.

Severity: **MEDIUM** (Mathlib wrapper claimed as Tier-A badge).

Generated by lean-auditor agent.