### PR TITLE
research(central-limit-theorem-oq-02-oq-04): S4 partial — indicator-pair covariance identity (build pending)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -48,6 +48,7 @@ Per the S1/S2 plan, this file builds on the parent
 -/
 
 import Mathlib.MeasureTheory.Function.LpSpace.Basic
+import Mathlib.MeasureTheory.Integral.Bochner.Set
 import Mathlib.Probability.IdentDistrib
 import Mathlib.Probability.Variance
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
@@ -173,6 +174,48 @@ theorem ibragimov_threshold_summable (δ r : ℝ)
   linarith
 
 /-! ## Part III: Davydov's covariance inequality (S4 target, stated as sorry) -/
+
+/-- **Indicator-pair covariance identity** (S4 stepping-stone helper).
+
+For 0-1 indicators of measurable sets `A` and `B` in a probability space, the
+covariance simplifies to a difference of joint and product measures:
+$$
+\int \mathbf 1_A \cdot \mathbf 1_B \, d\mu
+   - \Bigl(\int \mathbf 1_A \, d\mu\Bigr) \cdot \Bigl(\int \mathbf 1_B \, d\mu\Bigr)
+ = \mu(A \cap B) - \mu(A) \cdot \mu(B).
+$$
+
+This is the algebraic identity that the indicator base case of Davydov's
+covariance inequality reduces to. The RHS is precisely the form bounded by
+the α-mixing coefficient `alphaMixingCoeff` (defined as the supremum of `|RHS|`
+over measurable pairs in the two σ-algebras), so combined with `le_ciSup`-type
+reasoning, it yields the constant-1 indicator-pair Davydov bound. The
+truncation + Hölder amplification step then promotes this base case to the
+sharp-constant general L^p inequality with constant 12 (the S4 deliverable).
+
+The proof is purely measure-theoretic: case analysis on `Set.indicator_apply`
+identifies the pointwise product `1_A · 1_B = 1_{A ∩ B}`, then
+`MeasureTheory.integral_indicator_one` evaluates each indicator integral as
+`μ.real`. No supremum machinery is invoked at this layer. -/
+theorem indicator_pair_covariance_eq
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {A B : Set Ω} (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    ∫ ω, A.indicator (1 : Ω → ℝ) ω * B.indicator (1 : Ω → ℝ) ω ∂μ
+      - (∫ ω, A.indicator (1 : Ω → ℝ) ω ∂μ)
+        * (∫ ω, B.indicator (1 : Ω → ℝ) ω ∂μ)
+    = μ.real (A ∩ B) - μ.real A * μ.real B := by
+  have hAB : MeasurableSet (A ∩ B) := hA.inter hB
+  -- Pointwise: `1_A(ω) · 1_B(ω) = 1_{A ∩ B}(ω)`, by case analysis on
+  -- `Set.indicator_apply` (no nested-supremum machinery is invoked).
+  have hprod :
+      (fun ω : Ω => A.indicator (1 : Ω → ℝ) ω * B.indicator (1 : Ω → ℝ) ω)
+        = (A ∩ B).indicator (1 : Ω → ℝ) := by
+    funext ω
+    simp only [Set.indicator_apply, Pi.one_apply, Set.mem_inter_iff]
+    by_cases hωA : ω ∈ A <;> by_cases hωB : ω ∈ B <;>
+      simp [hωA, hωB]
+  rw [hprod, integral_indicator_one hAB, integral_indicator_one hA,
+      integral_indicator_one hB]
 
 /-- **Davydov's covariance inequality** (Davydov 1968).
 

--- a/research/problems/central-limit-theorem-oq-02-oq-04/state.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/state.md
@@ -1,10 +1,130 @@
 # Current State
 
-**Phase**: ACT (S3 — Davydov reduction + longrun_variance proof shipped)
-**Since**: 2026-05-12T04:00:00Z
-**Iteration**: 3
+**Phase**: ACT (S4 partial — indicator-pair covariance identity proven; full Davydov deferred)
+**Since**: 2026-05-12T06:50:00Z
+**Iteration**: 4 (partial)
+**Last Updated**: 2026-05-12 (researcher-6)
 
-## Current Focus
+## S4 partial (researcher-6, 2026-05-12, this PR)
+
+**Indicator-pair covariance identity** — one new fully-proven private theorem,
+positioned in Part III immediately before `davydov_covariance_inequality`:
+
+```lean
+theorem indicator_pair_covariance_eq
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {A B : Set Ω} (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    ∫ ω, A.indicator (1 : Ω → ℝ) ω * B.indicator (1 : Ω → ℝ) ω ∂μ
+      - (∫ ω, A.indicator (1 : Ω → ℝ) ω ∂μ)
+        * (∫ ω, B.indicator (1 : Ω → ℝ) ω ∂μ)
+    = μ.real (A ∩ B) - μ.real A * μ.real B
+```
+
+This is the **algebraic identity** that the indicator base case of Davydov's
+covariance inequality reduces to. The RHS `μ(A ∩ B) − μ(A) · μ(B)` is precisely
+the expression appearing inside the supremum that defines `alphaMixingCoeff`
+in the parent file `CentralLimitTheoremOQ02.lean` (line 416–424). Combined
+with a `le_ciSup`-flavored bound (the next sub-step in the S4 path; deferred
+since the parent file flagged the nested-`ciSup` elaboration complexity in
+`alphaMixingCoeff_nonneg`), this yields the constant-1 Davydov bound on
+indicator pairs `|Cov(1_A, 1_B)| ≤ α(ℱ, 𝒢)`. The truncation + Hölder
+amplification step then promotes this base case to the sharp-constant
+general L^p inequality with constant 12 (the full S4 deliverable).
+
+**No supremum machinery is invoked at this layer.** The proof uses only:
+
+* `Set.indicator_apply` and `Set.mem_inter_iff` for pointwise identification
+  `1_A · 1_B = 1_{A ∩ B}`.
+* `MeasureTheory.integral_indicator_one` to evaluate each indicator integral
+  as `μ.real`.
+
+### Why this is a productive narrow step
+
+The full S4 Davydov proof is ~150 lines and decomposes as:
+
+1. **Indicator-pair algebraic identity** — *this PR*. ~20 lines of measure-theoretic
+   bookkeeping, fully proven, no Mathlib gaps.
+2. **Indicator-pair α-mixing bound** — `|Cov(1_A, 1_B)| ≤ α(ℱ, 𝒢)` via
+   `le_ciSup` on the nested-`ciSup` definition of `alphaMixingCoeff`. ~30 lines,
+   deferred pending the parent's nested-`ciSup` complexity workaround.
+3. **Simple-function extension** — linear combination of indicators by linearity
+   of integrals. ~30 lines.
+4. **Truncation step** — for L^p X, Y, bound the truncation tail via Markov's
+   inequality + Hölder. ~50 lines.
+5. **Hölder amplification** — Hölder on the bounded part yields the
+   `(p-2)/p` exponent. ~30 lines.
+
+This PR closes step 1 without touching the open S3 PRs (#17810, #17826), which
+target the already-merged stationarity / Davydov-reduction work. The open PRs
+are conflict-frozen against the post-S3 main; this S4 PR sits cleanly downstream
+without overlap.
+
+### Counts
+
+* `lineCount`: 402 → 443 (+41, including ~25 lines of docstring + 16 lines
+  of proof body + import line)
+* `theoremCount`: 7 → 8 (+1 fully-proven theorem)
+* `definitionCount`: 4 (unchanged)
+* `sorries`: 2 (unchanged — `davydov_covariance_inequality` and
+  `mixing_clt_ibragimov` remain the deferred targets; this PR adds a proven
+  helper but does not close either sorry)
+* `axiomCount`: 0 (unchanged)
+
+### Strategic positioning
+
+**Non-overlap with open PRs**:
+* #17810 (researcher-1, conflicting): 5 stationarity/moment-bound bridge
+  lemmas (Stationary.integrable_of_zero, etc.) — predates the merged S3 ACT
+  (#17820) and its content is now superseded by `stationary_eLpNorm_eq`
+  proven in S3. Conflict-frozen.
+* #17826 (researcher-1, mergeable): duplicate of merged S3 ACT (#17820);
+  same Davydov reduction + bridge lemmas. Content already in main.
+
+This PR is **strictly downstream** of S3: it adds a new helper proven against
+the post-S3 file, building on the now-merged `IbragimovHypotheses` /
+`davydov_covariance_inequality` API surface. No overlap with the two open S3
+PRs at the file-level (this PR adds a new theorem, doesn't touch existing
+ones). No overlap at the API level (this helper is positioned to be consumed
+by future S4 sub-steps, not by the S3 deliverables).
+
+### Build status
+
+**[BUILD UNVERIFIED]** — Same caveat as S2/S3/S22: worktree's
+`proofs/.lake` is a recursive self-symlink, so local Docker builds
+re-fresh-clone Mathlib (~30–45 min cold). The new helper uses only Mathlib
+API verified against `/Users/rwalters/GitHub/mathlib4`:
+
+* `MeasureTheory.integral_indicator_one`
+  (`Mathlib.MeasureTheory.Integral.Bochner.Set` line 519):
+  `∫ x, s.indicator 1 x ∂μ = μ.real s` for measurable `s`. Added as an
+  explicit import to ensure transitive availability.
+* `Set.indicator_apply`, `Pi.one_apply`, `Set.mem_inter_iff` — core Set/Pi
+  API, transitively available via `MeasureTheory.Function.LpSpace.Basic`.
+* `IsProbabilityMeasure` and `Measure.real` — transitively available.
+
+No new axioms.
+
+### Next iteration (S4 cont'd)
+
+After this PR lands, the remaining steps for closing
+`davydov_covariance_inequality`:
+
+1. **Indicator-pair α-mixing bound** (next ~30 lines): apply `le_ciSup` to
+   the nested `ciSup` definition of `alphaMixingCoeff` to derive
+   `|μ(A ∩ B) − μ(A)·μ(B)| ≤ alphaMixingCoeff μ ℱ 𝒢` for any measurable
+   `A ∈ ℱ`, `B ∈ 𝒢`. The proof composes with this PR's
+   `indicator_pair_covariance_eq` to give the constant-1 indicator-pair
+   Davydov bound on covariance. The parent's `alphaMixingCoeff_nonneg`
+   nested-`ciSup` complexity note (line 444) applies; the workaround is
+   to apply `le_ciSup` iteratively at each ⨆ layer.
+2. **Simple-function extension** (~30 lines).
+3. **Truncation + Hölder amplification** (~80 lines).
+
+Total ~140 lines once the nested-`ciSup` bound is settled.
+
+---
+
+## S3 (researcher-1, 2026-05-12, merged via #17820)
 
 S3 ACT — Discharge `longrun_variance_absolutely_convergent` by reducing it
 to a single named Davydov sorry. The S2 sorry on long-run variance has been

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -20,12 +20,12 @@
     "badge": "axiom",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 402,
+    "lineCount": 443,
     "assumptions": "2 sorries: (1) `davydov_covariance_inequality` — Davydov's covariance bound |Cov(X,Y)| ≤ 12·α₀^{(p-2)/p}·‖X‖_{L^p}·‖Y‖_{L^p}, stated in S3 as the bridge from α-mixing to summable covariances; S4 deliverable (~150 lines, indicator decomposition + Hölder); (2) `mixing_clt_ibragimov` — the main CLT statement via characteristic-function convergence, deferred to S6+ pending Bernstein block decomposition (S6), large-block independence (S7), and Lindeberg condition (S8). 0 axioms in this file; parent file CentralLimitTheoremOQ02.lean carries 1 axiom (`martingale_clt`; the Ibragimov mixing CLT is described in the parent's docstring but not declared as an `axiom`) and 3 sorries via its tail comment — those are reused by reference, not re-stated. Sharp-threshold computation `r > (2+δ)/δ ⇒ rδ/(2+δ) > 1` is fully proven (ibragimov_threshold_summable). The S3 bridge `longrun_variance_absolutely_convergent` is now proved modulo the stated Davydov lemma, with the polynomial summability `polynomial_mixing_summable` and stationarity equality `stationary_eLpNorm_eq` discharged unconditionally.",
     "mathlib_version": "4.26.0",
     "historicalContext": "Ibragimov's 1962 paper *Some limit theorems for stationary processes* (Theory Probab. Appl. 7, 349-382) is the foundational result for CLT under strong mixing. Building on Rosenblatt's 1956 introduction of α-mixing, Ibragimov showed that for stationary sequences with E[X₁²+δ] < ∞ and ∑_n α(n)^{δ/(2+δ)} < ∞, the partial sums S_n/√n converge weakly to a centered Gaussian with the long-run variance σ² = Var(X₁) + 2∑_{k=1}^∞ Cov(X₁, X_{1+k}). The polynomial-rate specialization α(n) ≤ C·n^{-r} translates Ibragimov's covariance summability condition to the algebraic threshold r > (2+δ)/δ — a sharpness statement first made explicit in the survey literature (Doukhan 1994, *Mixing: Properties and Examples*, Springer LNS 85, and Rio 2017, *Asymptotic Theory of Weakly Dependent Random Variables*). The threshold rate δ/(2+δ) is the Davydov exponent from his 1968 covariance inequality |Cov(X,Y)| ≤ C·α^{δ/(2+δ)}·‖X‖_{2+δ}·‖Y‖_{2+δ}.",
     "proofStrategy": "S2 ORIENT (done): define the necessary predicates and structure; state the main CLT theorem with a sorry; prove polynomial summability of n^{-s} for s > 1 and the sharp-threshold corollary `ibragimov_threshold_summable` (rδ/(2+δ) > 1 ⇒ Summable n^{-rδ/(2+δ)}). S3 ACT (done): add three bridge lemmas — `stationary_eLpNorm_eq` (L^p norms invariant under shift via IdentDistrib), `polynomial_mixing_summable` (summable mixing coefficients from the polynomial rate), and `davydov_covariance_inequality` (stated as the S4 deliverable) — then discharge `longrun_variance_absolutely_convergent` modulo Davydov by chaining the bridge lemmas. S4 ACT (next): prove Davydov's covariance inequality |Cov(X,Y)| ≤ 12·α^{(p-2)/p}·‖X‖_{L^p}·‖Y‖_{L^p} via truncation + Hölder + indicator decomposition (~150 lines). S5: no longer needed — folded into S3. S6+ ACT: Bernstein block decomposition + Lindeberg condition + invoke parent's martingale/Lindeberg-Feller CLT to close `mixing_clt_ibragimov`.",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 4,
     "originalContributions": [
       "Sharp-threshold formulation: IbragimovHypotheses structure encoding the r > (2+δ)/δ constraint as a top-level field",
@@ -35,6 +35,7 @@
       "polynomial_mixing_summable (S3): proven summability of the α-mixing coefficients under polynomial decay rate r > (2+δ)/δ",
       "longrun_variance_absolutely_convergent (S3, modulo Davydov): conditional proof of long-run variance summability via the stated davydov_covariance_inequality plus the S3 bridge lemmas",
       "davydov_covariance_inequality (S3, stated as S4 target): standalone statement of the Davydov–Ibragimov covariance bound at arbitrary mixing-coefficient upper bound α₀",
+      "indicator_pair_covariance_eq (S4 partial): proven algebraic identity ∫ 1_A · 1_B dμ − (∫ 1_A dμ)·(∫ 1_B dμ) = μ.real(A ∩ B) − μ.real A · μ.real B for measurable A, B — the stepping-stone for the indicator base case of Davydov's covariance inequality. Sidesteps the parent file's nested-ciSup elaboration concern by isolating the supremum-free algebraic step.",
       "Stationary predicate via marginal IdentDistrib (slice version; full joint stationarity deferred to S3+)",
       "PolynomialMixingRate predicate for α(n) ≤ C·n^{-r}",
       "MomentBound2δ predicate compatible with Mathlib's MemLp for p = 2+δ"
@@ -70,6 +71,11 @@
         "theorem": "CentralLimitTheoremOQ02.longRunVariance",
         "description": "σ² = Var(X₁) + 2∑_{k≥1} Cov(X₁, X_{k+1}) (in parent file)",
         "module": "Proofs.CentralLimitTheoremOQ02"
+      },
+      {
+        "theorem": "MeasureTheory.integral_indicator_one",
+        "description": "∫ x, s.indicator 1 x ∂μ = μ.real s for measurable s — used to evaluate each indicator integral in indicator_pair_covariance_eq",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
       }
     ]
   },


### PR DESCRIPTION
## Summary

S4 partial deliverable for the Ibragimov polynomial-α-mixing CLT. One fully-proven helper theorem positioned in Part III, immediately before the `davydov_covariance_inequality` sorry:

```lean
theorem indicator_pair_covariance_eq
    {μ : Measure Ω} [IsProbabilityMeasure μ]
    {A B : Set Ω} (hA : MeasurableSet A) (hB : MeasurableSet B) :
    ∫ ω, A.indicator (1 : Ω → ℝ) ω * B.indicator (1 : Ω → ℝ) ω ∂μ
      - (∫ ω, A.indicator (1 : Ω → ℝ) ω ∂μ)
        * (∫ ω, B.indicator (1 : Ω → ℝ) ω ∂μ)
    = μ.real (A ∩ B) - μ.real A * μ.real B
```

This is the **algebraic identity** that the indicator base case of Davydov's covariance inequality reduces to. The RHS `μ(A ∩ B) − μ(A) · μ(B)` is precisely the expression appearing inside the supremum that defines `alphaMixingCoeff` in the parent file `CentralLimitTheoremOQ02.lean` (line 416–424). Combined with a `le_ciSup`-style bound (the next sub-step in the S4 path; deferred since the parent file flagged nested-`ciSup` elaboration complexity in `alphaMixingCoeff_nonneg`), it yields the constant-1 indicator-pair Davydov bound, which the truncation + Hölder amplification step then promotes to the sharp-constant general L^p inequality.

## Proof

Pure measure theory, no supremum machinery at this layer:
- Case analysis on `Set.indicator_apply` identifies `1_A · 1_B = 1_{A ∩ B}` pointwise.
- `MeasureTheory.integral_indicator_one` evaluates each indicator integral as `μ.real`.

## Strategic positioning

**Strictly downstream of merged S3 (#17820).** Non-overlap with the two open S3 PRs on this slug:
- #17810 (CONFLICTING) — 5 stationarity/moment-bound bridge lemmas; conflict-frozen against the post-S3 main since the merged `stationary_eLpNorm_eq` and `IbragimovHypotheses` extension superseded its content.
- #17826 (mergeable) — duplicate of merged #17820; same Davydov reduction + bridge lemmas now in main.

This PR adds a *new* proven theorem and an explicit Mathlib import; it does not touch any existing theorem or definition. No content overlap with the open PRs at the file or API level.

## Counts

- `lineCount`: 402 → 443 (+41, including ~25-line docstring + 16-line proof body + 1 import line)
- `theoremCount`: 7 → 8 (+1 fully-proven theorem `indicator_pair_covariance_eq`)
- `definitionCount`: 4 (unchanged)
- `sorries`: 2 (unchanged — `davydov_covariance_inequality` and `mixing_clt_ibragimov` remain S4-cont'd and S6+ targets)
- `axiomCount`: 0 (unchanged)

## Files modified

- `proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean` — new helper theorem (+41 lines, +1 import line for `MeasureTheory.Integral.Bochner.Set`)
- `research/problems/central-limit-theorem-oq-02-oq-04/state.md` — S4 partial entry at top, S3 entry preserved
- `src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json` — lineCount 402→443, theoremCount 7→8, new `originalContributions` entry, new `mathlibDependencies` entry

## Build status

**[BUILD UNVERIFIED]** — Same caveat as S2/S3/S22: worktree's `proofs/.lake` is a recursive self-symlink so local Docker builds re-fresh-clone Mathlib (~30–45 min cold). The new helper uses only Mathlib API verified against `/Users/rwalters/GitHub/mathlib4` master:

- `MeasureTheory.integral_indicator_one` (`Mathlib/MeasureTheory/Integral/Bochner/Set.lean:519`): `∫ x, s.indicator 1 x ∂μ = μ.real s` for measurable `s`. Added explicit import.
- `Set.indicator_apply`, `Pi.one_apply`, `Set.mem_inter_iff` — core Set/Pi API.
- `IsProbabilityMeasure`, `Measure.real` — transitively available.

No new axioms. CI is the ground truth.

## Next iteration (S4 cont'd)

After this PR lands, the remaining steps for closing `davydov_covariance_inequality`:

1. **Indicator-pair α-mixing bound** (next ~30 lines): apply `le_ciSup` iteratively to derive `|μ(A ∩ B) − μ(A)·μ(B)| ≤ alphaMixingCoeff μ ℱ 𝒢` for measurable `A ∈ ℱ`, `B ∈ 𝒢`. Composes with this PR to give the constant-1 indicator-pair Davydov bound.
2. **Simple-function extension** (~30 lines).
3. **Truncation + Hölder amplification** (~80 lines).

Total ~140 lines once the nested-`ciSup` bound is settled.

## Test plan

- [ ] CI lake build verifies `indicator_pair_covariance_eq` typechecks.
- [ ] Next S4 PR (indicator-pair α-mixing bound) directly consumes this identity as the algebraic core.

Generated by researcher-6