### PR TITLE
Enrich newton-inductive-step-oq-02: split Layer 3 into k=1 + k≥2 sub-annotations

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/annotations.json
@@ -140,5 +140,56 @@
       "import-driven proof decomposition"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-newton-binomial-k1-quadratic",
+    "proofId": "newton-inductive-step-oq-02",
+    "range": { "startLine": 275, "endLine": 391 },
+    "type": "technique",
+    "title": "k = 1 Base Case: Discriminant Reduction via Pascal Identity",
+    "content": "The k = 1 sub-proof inside `newton_inequality_binomial` is a complete quadratic-nonneg argument hand-built from two Pascal-rule identities and the inductive hypothesis at k = 1 on the tail. After unfolding `esymm_cons_succ`, the goal becomes $\\binom{n+1}{2}(E_1 + x)^2 \\geq (n+1)^2 (E_2 + x \\cdot E_1)$, a quadratic in $x$ with $\\alpha = \\binom{n+1}{2}$, $\\beta = -(n+1) E_1$, $\\gamma = \\binom{n+1}{2} E_1^2 - (n+1)^2 E_2$. The classical condition $4 \\alpha \\gamma \\geq \\beta^2$ closes the goal via `quadratic_nonneg`.\n\nThe nontrivial work is showing $4 \\alpha \\gamma \\geq \\beta^2$ — i.e., $(n+1)^2 \\cdot ((n^2 - 1) E_1^2 - 2n(n+1) E_2) \\geq 0$, which factors as $(n+1)^3 \\cdot ((n-1) E_1^2 - 2n E_2) \\geq 0$. This reduces to $E_1^2 \\geq 2 E_2 \\cdot (n / (n-1))$ in the relevant range, recovered from the IH at k = 1 for `xs` (giving $\\binom{n}{2} E_1^2 \\geq n^2 E_2$) plus the Pascal-rule identity $2 \\binom{n}{2} = n(n-1)$.\n\nThe identity $2 \\binom{n}{2} = n(n-1)$ is proved inline by induction on $n$ rather than imported from Mathlib, since the cast to ℝ and the specific shape needed for `linear_combination` make a direct proof more transparent than searching for the right Mathlib lemma. The `linear_combination` invocations at `h4C3` (showing $4(\\binom{n}{2} + n)^2 = (n(n+1))^2$) and `hd_key` (the full discriminant identity) collapse what would otherwise be 50-line `ring` expansions into 1-line cofactor specifications.",
+    "mathContext": "**Quadratic-nonneg form**: for $\\alpha \\geq 0$, $\\gamma \\geq 0$, $4 \\alpha \\gamma \\geq \\beta^2$ $\\Rightarrow$ $\\alpha x^2 + \\beta x + \\gamma \\geq 0$. In Mathlib: `quadratic_nonneg`.\n\n**Pascal identity used twice**:\n- $\\binom{n+1}{2} = \\binom{n}{2} + \\binom{n}{1} = \\binom{n}{2} + n$ (composition step `hPascal2`).\n- $2 \\binom{n}{2} = n(n-1)$ (algebraic identity `h2C2`).\n\nCombining: $2(\\binom{n}{2} + n) = n(n-1) + 2n = n(n+1)$, so $4(\\binom{n}{2} + n)^2 = (n(n+1))^2$.\n\n**Discriminant computation**:\n- $4 \\alpha \\gamma - \\beta^2 = 4(\\binom{n}{2} + n)((\\binom{n}{2} + n) E_1^2 - (n+1)^2 E_2) - (n+1)^2 E_1^2$\n- $= (n+1)^2 \\cdot ((n^2 - 1) E_1^2 - 2 n(n+1) E_2)$  (via `linear_combination` on `h4C3`, `h2C2`)\n- $= (n+1)^3 \\cdot ((n-1) E_1^2 - 2 n E_2) \\geq 0$ from IH.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic_nonneg tactic",
+      "linear_combination tactic",
+      "Pascal's identity 2C(n,2)=n(n-1)",
+      "discriminant condition",
+      "quadratic inequality",
+      "case split on list length"
+    ],
+    "prerequisites": [
+      "esymm_cons_succ recurrence",
+      "Nat.choose_succ_succ (Pascal's rule)",
+      "quadratic_nonneg from Mathlib",
+      "linear_combination tactic semantics"
+    ]
+  },
+  {
+    "id": "ann-newton-binomial-induction-overflow",
+    "proofId": "newton-inductive-step-oq-02",
+    "range": { "startLine": 392, "endLine": 611 },
+    "type": "technique",
+    "title": "k ≥ 2 Inductive Step: Overflow-Aware Case Analysis",
+    "content": "The k ≥ 2 sub-proof starts with `obtain ⟨p, rfl⟩ : ∃ p, k = p + 2`, replacing $k$ with $p + 2$ uniformly to eliminate $k - 1$ and $k + 1$ obstructions. Three recurrence equations `rec_k`, `rec_km1`, `rec_kp1` expand $e_{p+2}, e_{p+1}, e_{p+3}$ on the head-cons list via `esymm_cons_succ`. Four abbreviations `ek := esymm xs (p+2)`, `ekm1, ekp1, ekm2` make the algebra readable; their nonnegativity is dispatched once at the top via `esymm_nonneg`.\n\nThree pieces of input data are assembled:\n1. **Unnormalized Newton on `xs` at $p + 2$** and at $p + 1$ — `h_unn_k`, `h_unn_km1` — both with overflow guards (when $p + 3 > n$ or $p + 2 > n$, the relevant $e_j$ is zero by `esymm_eq_zero_of_gt`).\n2. **Cross condition** `h_cross : ek · ekm1 ≥ ekm2 · ekp1` — obtained from `NewtonLogConcavity.cross_product_of_log_concave` plus a zero-tail fallback for the edge case `ekm1 = 0`.\n3. **Two normalized-Newton IHs** `h_ih_k`, `h_ih_km1` — applied at $p + 2$ and $p + 1$ respectively on `xs`, again with overflow guards (when $\\binom{n}{p+3}$ or $\\binom{n}{p+2}$ vanishes, the inequality is trivial).\n\nThe heavy lifting is then delegated to `NewtonLogConcavity.newton_cleared_denom_inductive_step` from `AmgmInequalityOQ02OQ02.lean`, which packages the algebraic combinatorial identity that drives the descent. Finally, a case split on $p + 3 \\leq n$ vs $p + 3 > n$ handles the boundary: when the new variable $x$ pushes $k + 1$ past the list length on `x :: xs`, $\\binom{n+1}{p+3} = 1$ (via $n = p + 2$) but $e_{p+3}(\\mathtt{xs}) = 0$, so the RHS collapses entirely.\n\nThis pattern — destruct via `obtain ⟨p, rfl⟩`, set abbreviations, gather all IH instances upfront with overflow guards, delegate the algebraic core to a packaged lemma — is reusable for any inequality whose induction needs to handle multiple `Nat.choose` overflow patterns simultaneously.",
+    "mathContext": "**Index management**: After `obtain ⟨p, rfl⟩ : ∃ p, k = p + 2`, indices become $\\{p, p+1, p+2, p+3\\}$. Overflow regions:\n- $p + 3 > n$ ⟹ $e_{p+3}(\\mathtt{xs}) = 0$\n- $p + 2 > n$ ⟹ $e_{p+2}(\\mathtt{xs}) = 0$ (only triggers when $n \\leq p + 1$, impossible given $k + 1 \\leq n + 1$).\n\n**Boundary at $n + 1 = p + 3$** (i.e., $n = p + 2$, $k = n - 1$ from the outer goal):\n- $\\binom{n}{p+3} = 0$, $e_{p+3}(\\mathtt{xs}) = 0$.\n- LHS: $\\binom{n+1}{p+1} \\binom{n+1}{p+3} \\cdot (e_{p+2}(x::\\mathtt{xs}))^2 = \\binom{n+1}{p+1} \\cdot 1 \\cdot e_{p+2}^2$.\n- RHS: $\\binom{n+1}{p+2}^2 \\cdot e_{p+1} \\cdot e_{p+3}(x::\\mathtt{xs}) = \\binom{n+1}{p+2}^2 \\cdot e_{p+1} \\cdot (0 + x \\cdot e_{p+2}(\\mathtt{xs}))$.\n\n**Inductive step (interior)**: `newton_cleared_denom_inductive_step n (p+2)` takes the cross-condition + two unnormalized + two normalized IHs and produces the binomial-weighted inequality on the cons list. Its internal proof is the algebraic combinatorial identity at the heart of the inductive descent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "obtain ⟨p, rfl⟩ destructuring",
+      "set abbreviation tactic",
+      "induction hypothesis gathering",
+      "Nat.choose_eq_zero_of_lt overflow",
+      "esymm_eq_zero_of_gt overflow",
+      "cross_product_of_log_concave",
+      "newton_cleared_denom_inductive_step",
+      "case split on boundary vs interior"
+    ],
+    "prerequisites": [
+      "NewtonLogConcavity.cross_product_of_log_concave",
+      "NewtonLogConcavity.newton_cleared_denom_inductive_step",
+      "Nat.choose_eq_zero_of_lt",
+      "esymm_cons_succ recurrence",
+      "esymm_eq_zero_of_gt zero-overflow lemma"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

The Layer 3 proof (`newton_inequality_binomial`, lines 254-611) had a single 357-line annotation. Splits it into two technique-focused sub-annotations:

### New annotations

1. **`ann-newton-binomial-k1-quadratic`** (lines 275-391, k = 1 base case)
   - Reduces to quadratic-nonneg form $\alpha x^2 + \beta x + \gamma \geq 0$ with $\alpha = \binom{n+1}{2}$, $\beta = -(n+1) E_1$, $\gamma = \binom{n+1}{2} E_1^2 - (n+1)^2 E_2$.
   - Discriminant computation via two Pascal identities: $\binom{n+1}{2} = \binom{n}{2} + n$ (composition) and $2 \binom{n}{2} = n(n-1)$ (proved inline by induction on $n$).
   - Shows how `linear_combination` collapses 50-line `ring` expansions to one-line cofactor specs (`h4C3`, `hd_key`).

2. **`ann-newton-binomial-induction-overflow`** (lines 392-611, k ≥ 2 inductive step)
   - Pattern: `obtain ⟨p, rfl⟩ : ∃ p, k = p + 2` → `set` abbreviations → gather all IH instances upfront with overflow guards → delegate algebraic core to `newton_cleared_denom_inductive_step` from `AmgmInequalityOQ02OQ02.lean`.
   - Documents the boundary case $n = p + 2$ where $\binom{n+1}{p+3} = 1$ but $e_{p+3}(\mathtt{xs}) = 0$, collapsing the RHS.
   - Reusable pattern for any inequality with multiple `Nat.choose` overflow regions.

### Quality impact

The 357-line monolithic annotation now has two specialised sub-annotations at technique level. Annotation count: 7 → 9. Both new annotations have full schema (`mathContext` with LaTeX discriminant + boundary algebra, `significance: key`, `relatedConcepts`, `prerequisites`).

The original `ann-newton-inequality-binomial` (lines 254-611) is preserved as a higher-level overview; the new annotations zoom into the k=1 quadratic mechanics and the k≥2 induction structure respectively.

## Verification

- [x] `annotations.json` parses (9 items).
- [x] `tsc --noEmit -p tsconfig.json` clean.
- [x] `tsx scripts/annotations/build.ts` exits 0, no target-specific warnings.
- [x] Single-file diff, 51 lines added.
- [x] Math content verified against Lean source (lines 275-391 quadratic discriminant chain, lines 392-611 destructure + delegate pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)