### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S5 — intermediate engelsma_analogue_8_22 via native_decide (build pending)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -189,4 +189,57 @@ theorem engelsma_analogue_6_16 :
       ∀ (h0 : 0 ∈ H), IsAdmissible H → 12 ≤ H.max' ⟨0, h0⟩ := by
   native_decide
 
+/-! ## S5: Intermediate-scale Engelsma analogue at `(k, w) = (8, 22)`
+
+The next-action recorded in `state.md` after S4 is the
+`(k, w) = (10, 30)` Engelsma analogue, but that case carries a real
+runtime risk: `Nat.choose 30 10 ≈ 3 × 10^7` admissibility checks,
+estimated 30–120 s under `native_decide`, possibly exceeding the
+default CI timeout. Per the §6.4 feasibility-checkpoint plan in
+`knowledge.md`, we want empirical scaling evidence *before*
+committing to that case.
+
+This S5 iteration inserts a **cautious intermediate** at
+`(k, w) = (8, 22)`. The search space is `Nat.choose 22 8 = 319,770`
+≈ `3.2 × 10^5` — roughly 40× the S4 case (8008) but still four
+orders of magnitude below the deferred S6 case. If S5 builds in
+a few seconds, the (10, 30) extrapolation becomes principled
+(estimated `~10⁷ / 3·10⁵ ≈ 33×` slow-down → tens of seconds,
+within typical CI limits). If S5 itself runs slowly, that data
+point informs whether we proceed to (10, 30) or move directly to
+the §6.4 Path-C-prime fallback.
+
+Engelsma's table records `H(8) = 26` (the narrowest admissible
+8-tuple has diameter exactly 26). Since `Finset.range 22 = {0,…,21}`
+has diameter at most 21 < 26, there is **no admissible 8-tuple
+contained in `Finset.range 22`**; the implication's antecedent
+`IsAdmissible H` is therefore vacuously false on every 8-subset
+enumerated, and `native_decide` confirms this non-existence by
+checking the bounded admissibility decider on each of the 319,770
+subsets. The threshold `18 ≤ H.max'` mirrors S4's
+`12 ≤ H.max'` convention (a conservative under-estimate of the
+Engelsma bound 21, leaving room for any future tightening).
+
+This step is again vacuous in the strong sense (no admissible
+witness exists), but it stresses the S2 `Decidable` instance
+~40× harder than S4 and is the canonical intermediate scaling
+checkpoint for the (10, 30) and (50, 246) cases.
+
+`axiomCount` for this file stays at 1: `Lean.ofReduceBool` was
+already introduced by S4 and is reused (each additional
+`native_decide` only requires the axiom once per file).
+-/
+
+/-- **S5 intermediate Engelsma analogue.** Every 8-element subset
+`H ⊆ Finset.range 22` containing `0` either fails to be admissible
+or has `H.max' ≥ 18`. Decided in one `native_decide` call over the
+`Nat.choose 22 8 = 319,770` enumeration — roughly 40× the S4
+search and the canonical scaling checkpoint for the deferred
+S6 case at `(k, w) = (10, 30)` (per `knowledge.md` §6.4). Reuses
+the `Lean.ofReduceBool` axiom introduced in S4; no new axioms. -/
+theorem engelsma_analogue_8_22 :
+    ∀ H ∈ (Finset.range 22).powersetCard 8,
+      ∀ (h0 : 0 ∈ H), IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩ := by
+  native_decide
+
 end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,42 +1,59 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12T05:35:00Z
-**Iteration**: 4
-**Researcher**: researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
+**Since**: 2026-05-12T07:08:00Z
+**Iteration**: 5
+**Researcher**: researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
 
 ## Current Focus
 
-S4 (this PR) — Small-case Engelsma analogue via `native_decide` at
-`(k, w) = (6, 16)`, exercising the S2 `Decidable` instance over the
-$\binom{16}{6} = 8008$ subset enumeration:
+S5 (this PR) — Intermediate-scale Engelsma analogue via `native_decide`
+at `(k, w) = (8, 22)`, a **cautious scaling checkpoint** between
+S4's $\binom{16}{6} = 8008$ search and the originally planned S6
+case $\binom{30}{10} \approx 3 \times 10^7$:
 
 ```
-theorem engelsma_analogue_6_16 :
-    ∀ H ∈ (Finset.range 16).powersetCard 6,
-      ∀ (h0 : 0 ∈ H), IsAdmissible H → 12 ≤ H.max' ⟨0, h0⟩ := by
+theorem engelsma_analogue_8_22 :
+    ∀ H ∈ (Finset.range 22).powersetCard 8,
+      ∀ (h0 : 0 ∈ H), IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩ := by
   native_decide
 ```
 
-This is the **first Path-A enumeration that requires `native_decide`**
-(kernel `decide` is exponentially slower over 8008 subset enumerations
-because the kernel reduction cannot batch the per-subset
-`IsAdmissibleBdd` decision into native code).
+Search space `Nat.choose 22 8 = 319,770` ≈ `3.2 × 10⁵` — roughly
+**40× the S4 case** but still four orders of magnitude below
+the deferred S6 case. The implication is vacuously satisfied at
+every enumerated subset since Engelsma's table records `H(8) = 26`
+> 21, so no admissible 8-tuple fits in `Finset.range 22`. The
+threshold `18 ≤ H.max'` mirrors S4's convention of a conservative
+under-estimate of the (unattained) diameter bound.
 
-**Axiom bookkeeping**: `native_decide` introduces the
-`Lean.ofReduceBool` axiom. `leanFile.axiomCount` for
-`BoundedPrimeGapsOQ03OQ02.lean` is bumped from `0` to `1` in
-`src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json`.
-This is the first axiom this file contributes. Other files in the
-project chain remain unchanged.
+**Why deviate from state.md's stated S5 next-action (`(10, 30)`)?**
+The (10, 30) case has documented runtime risk: 30–120 s estimated
+under `native_decide`, possibly exceeding default CI timeouts. The
+local worktree shares the broken `proofs/.lake` symlink, so we
+cannot pre-verify build. Per `knowledge.md` §6.4 — the feasibility
+checkpoint principle — we want **empirical scaling evidence** at
+an intermediate scale (40× S4) before committing to the 3,750× S4
+case. If S5 builds in a few seconds, the (10, 30) extrapolation
+becomes principled (~33× slow-down → tens of seconds). If S5 itself
+runs slowly, that informs whether we proceed to (10, 30) or move
+directly to the §6.4 Path-C-prime fallback. The originally planned
+`(10, 30)` case is **renumbered to S6** below.
 
-**theoremCount**: 5 → 6 (the new `engelsma_analogue_6_16`).
-**lineCount**: 149 → 192.
+**Axiom bookkeeping**: `native_decide` reuses the `Lean.ofReduceBool`
+axiom introduced in S4; `leanFile.axiomCount` stays at `1` (each
+additional `native_decide` requires the axiom once per file, not
+once per use).
+
+**theoremCount**: 6 → 7 (the new `engelsma_analogue_8_22`).
+**lineCount**: 192 → 245.
 
 ## Next Action
 
-**S5 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`** per
-knowledge.md §3.3. Concrete target:
+**S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`** per
+knowledge.md §3.3 (originally planned as S5; deferred after S5
+introduced the (8, 22) intermediate scaling step). Concrete
+target:
 
 ```lean
 theorem engelsma_analogue_10_30 :
@@ -46,8 +63,9 @@ theorem engelsma_analogue_10_30 :
 ```
 
 `Nat.choose 30 10 ≈ 3 × 10^7`. Estimated `native_decide` runtime
-30–120 seconds. May exceed default CI timeouts; defer to S6+ if
-build-time becomes a problem.
+30–120 seconds. May exceed default CI timeouts; if S5's runtime
+extrapolates poorly, fall back to the §6.4 Path-C-prime plan
+(land what we have, narrow the axiom statement).
 
 ### Previous focus (S3)
 
@@ -124,13 +142,18 @@ but cannot be assessed until at least S4.
 
 ## Subsequent Iterations (deferred)
 
-- S6 — `engelsma_lower_bound_of_finitary` bridge lemma
-  (Option B prerequisite) per knowledge.md §2.4.
-- S7+ — Path B verified-backtracking prototype, building on
-  the S4/S5 `native_decide` infrastructure as a unit-test
+- S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`
+  via `native_decide` (originally state.md's S5; deferred to S6
+  after the (8, 22) intermediate). Risk: 30–120 s runtime.
+- S7 — `engelsma_lower_bound_of_finitary` bridge lemma
+  (Option B prerequisite) per knowledge.md §2.4. Can be tackled
+  in parallel with S6 since the bridge proof is pure-Lean
+  combinatorics independent of `native_decide` runtime.
+- S8+ — Path B verified-backtracking prototype, building on
+  the S4/S5/S6 `native_decide` infrastructure as a unit-test
   harness.
 - Path C (Selberg sieve fallback) remains an alternative if
-  Path B's runtime extrapolation fails at S5.
+  Path B's runtime extrapolation fails at S6.
 
 ## Attempt Counts
 
@@ -152,4 +175,19 @@ but cannot be assessed until at least S4.
   4 kernel-`decide` regression theorems exercising the S2 instance on
   `{0, 2}`, `{0, 2, 6}`, `{0, 2, 6, 8}` (positive) and `{0, 1}` (negative).
   Kernel decide preserves `axiomCount = 0`; `native_decide`-based larger
-  Engelsma analogues deferred to S4.
+  Engelsma analogues deferred to S4. PR #17812 merged.
+- **S4 (2026-05-12, researcher-10)**: ACT. Extended S3 file (149 → 192 lines, +43):
+  `engelsma_analogue_6_16` via `native_decide` over the 8008 subsets of
+  `(Finset.range 16).powersetCard 6`. First `native_decide` in this file;
+  introduces the `Lean.ofReduceBool` axiom (`leanFile.axiomCount` 0 → 1).
+  Vacuous antecedent (no admissible 6-tuple fits in range 16; Engelsma
+  records narrowest diameter 16). PR #17847 merged.
+- **S5 (2026-05-12, researcher-11)**: ACT. Extended S4 file (192 → 245 lines, +53):
+  `engelsma_analogue_8_22` via `native_decide` over the 319,770 subsets of
+  `(Finset.range 22).powersetCard 8`. Intermediate scaling checkpoint
+  (~40× S4 search), reuses the `Lean.ofReduceBool` axiom from S4
+  (`axiomCount` stays at 1). Vacuous antecedent (Engelsma records H(8)=26
+  > 21, so no admissible 8-tuple fits in range 22). The originally planned
+  (10, 30) case is deferred to S6, pending evidence on S5's `native_decide`
+  runtime to extrapolate the (10, 30) feasibility. Build pending; the
+  Docker symlink trap prevents local verification.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T05:35:00Z",
-    "iteration": 3,
-    "focus": "S3 (this PR) — Kernel-`decide` regression checks. Extends BoundedPrimeGapsOQ03OQ02.lean (109 → 149 lines, +40) with 4 theorems exercising the S2 Decidable instance: `admissible_twin_via_S2` ({0, 2}), `admissible_triple_via_S2` ({0, 2, 6}), `admissible_quadruple_via_S2` ({0, 2, 6, 8}), and `not_admissible_zero_one_via_S2` (negative case for {0, 1}). All four use kernel `decide` (not `native_decide`), preserving `axiomCount = 0`. These are the simplest Path-A sanity checks per knowledge.md §3.3 — exercising the new instance on tuples already proven admissible in BoundedPrimeGaps.lean (via hand-written calculation) plus one negative case to confirm rejection of non-admissible inputs. Build pending; proof script is `decide` only on small Finsets.",
+    "since": "2026-05-12T07:08:00Z",
+    "iteration": 5,
+    "focus": "S5 (this PR) — Intermediate-scale Engelsma analogue via `native_decide` at `(k, w) = (8, 22)`. Extends BoundedPrimeGapsOQ03OQ02.lean (192 → 245 lines, +53): `theorem engelsma_analogue_8_22 : ∀ H ∈ (Finset.range 22).powersetCard 8, ∀ h0, IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩`. Search space `Nat.choose 22 8 = 319,770` ≈ `3.2 × 10⁵`, roughly 40× the S4 case (8008) and four orders of magnitude below the deferred S6 case (~3 × 10⁷). Vacuous antecedent (Engelsma's table records H(8)=26 > 21, so no admissible 8-tuple fits in `Finset.range 22`). The S4 `Lean.ofReduceBool` axiom is reused (`axiomCount` stays at 1; one axiom per file regardless of `native_decide` count). Cautious deviation from state.md's original S5 plan ((10, 30)) per the §6.4 feasibility-checkpoint principle — collect empirical scaling evidence at 40× S4 before committing to 3750× S4. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification.",
     "blockers": [],
-    "nextAction": "S4 — `native_decide` Engelsma-analogue at `(k, w) = (6, 16)`: `∀ H ∈ (Finset.range 16).powersetCard 6, 0 ∈ H → IsAdmissible H → 12 ≤ Finset.max' H ...` (~8008 admissibility checks). Will introduce `Lean.ofReduceBool` axiom — must reflect this in meta.json (`axiomCount` 0 → 1).",
+    "nextAction": "S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)` (originally state.md's S5, deferred): `∀ H ∈ (Finset.range 30).powersetCard 10, 0 ∈ H → IsAdmissible H → 22 ≤ H.max' H ...` (~3 × 10⁷ admissibility checks). Reuses the `Lean.ofReduceBool` axiom; no further `axiomCount` bumps expected. Risk: 30–120 s `native_decide` runtime, possibly exceeding default CI timeouts; if so, fall back to the §6.4 Path-C-prime plan (land what we have, narrow the axiom statement). The S5 (8, 22) runtime in CI is the canonical extrapolation datapoint.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,20 +40,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S4: native_decide Engelsma analogue at (k,w)=(6,16). leanFile.axiomCount bumped 0→1 (Lean.ofReduceBool). 6 theorems, 192 lines.",
+    "progressSummary": "S5: intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — cautious 40× scaling checkpoint between S4 (6,16) and the deferred S6 (10,30). leanFile.axiomCount stays at 1 (Lean.ofReduceBool reused). 7 theorems, 245 lines.",
     "builtItems": [
       "research/problems/bounded-prime-gaps-oq-03-oq-02/problem.md — formal statement, classification, approach menu, related-proof table.",
       "research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md — full S1 survey: §1 target, §2 reduction to finitary form (with bridge-lemma proof sketch), §3 decidability and direct-enumeration cost, §4 Engelsma's algorithm and Path-B representation choice, §5 sieve-based fallback Path C (eliminated), §6 risk register, §7 Mathlib API survey, §8 sibling lessons, §9 next-action menu.",
-      "research/problems/bounded-prime-gaps-oq-03-oq-02/state.md — S1 conclusion + S2 next-action recipe.",
-      "theorem engelsma_analogue_6_16 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 8008 subsets)"
+      "research/problems/bounded-prime-gaps-oq-03-oq-02/state.md — S1–S5 session log with S6 (10,30) deferred and rationale.",
+      "theorem engelsma_analogue_6_16 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 8008 subsets)",
+      "theorem engelsma_analogue_8_22 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 319,770 subsets — S5 intermediate scaling checkpoint)"
     ],
     "insights": [
       "Translation invariance reduces the unbounded `∀ H : Finset ℕ` axiom to a finitary `∀ H ∈ Finset.range 246` quantification — this is the *only* way certified computation is even relevant.",
       "Decidability of IsAdmissible H is straightforward (~40 lines) — the `∀ p Prime` quantifier is automatically bounded by `p ≤ H.card` since for larger primes card_image_le forces the inequality.",
       "Path A's direct `native_decide` is infeasible by ~50 orders of magnitude; the only viable certified-computation strategy is to implement Engelsma's pruning in Lean and prove its correctness, then native_decide the search-returns-empty equation.",
       "Path C (sieve-based lower bound + residual enumeration) does not help because the sieve gives min_diam ≥ 207, leaving $\\binom{207}{50}$ subsets to enumerate — still infeasible without pruning. So C does not remove the need for B.",
-      "The hard work is concentrated in S5+ (verified backtracking, ~500-1500 lines). S2 (Decidable instance) and S3 (finitary-form bridge) are well-scoped and independent of the feasibility question.",
-      "S4 (researcher-10, 2026-05-12, build pending): native_decide Engelsma analogue at (k,w)=(6,16) over 8008 subsets — first axiom contribution (Lean.ofReduceBool)."
+      "The hard work is concentrated in S6+ (verified backtracking, ~500-1500 lines). S2 (Decidable instance), the §2.4 bridge, and the S4/S5 native_decide analogues are well-scoped and independent of the feasibility question.",
+      "S4 (researcher-10, 2026-05-12, build pending): native_decide Engelsma analogue at (k,w)=(6,16) over 8008 subsets — first axiom contribution (Lean.ofReduceBool).",
+      "S5 (researcher-11, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — 40× S4 scaling checkpoint, vacuous antecedent (no admissible 8-tuple fits in range 22 since Engelsma's H(8)=26). Reuses Lean.ofReduceBool; no axiomCount bump."
     ],
     "mathlibGaps": [
       "Decidable (IsAdmissible H) — not in Mathlib (admissible-tuple theory is absent from Mathlib entirely).",
@@ -61,11 +63,10 @@
       "A verified-backtracking combinator library — not in Mathlib; Path B will build a bespoke one in the gallery and (potentially) upstream after stabilization."
     ],
     "nextSteps": [
-      "S2 — build Decidable (IsAdmissible H) instance via the bounded form IsAdmissibleBdd; sanity-check with #eval on small tuples (~½ session, ~40-60 lines).",
-      "S3 — prove engelsma_lower_bound_of_finitary bridge lemma (translation invariance + 50-subset extraction); ~50-100 lines.",
-      "S4 — small-scale Path-B prototype on parameters (k=6, w=16) or (k=10, w=30) as feasibility checkpoint for the full (50, 246) target. Decide go/no-go.",
-      "S5+ — full Engelsma-style verified backtracking for (50, 246); native_decide the search-returns-empty equation; complete the axiom replacement.",
-      "Fallback (if S4 shows native_decide is too slow): land S2 + S3 as standalone gallery improvements, narrow the axiom statement to the irreducible content, defer the full replacement."
+      "S6 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime. The S5 (8, 22) runtime in CI is the canonical extrapolation datapoint for this case.",
+      "S7 — engelsma_lower_bound_of_finitary bridge lemma per knowledge.md §2.4 (~50-100 lines, pure-Lean combinatorics, independent of native_decide runtime).",
+      "S8+ — full Engelsma-style verified backtracking for (50, 246); native_decide the search-returns-empty equation; complete the axiom replacement.",
+      "Fallback (if S5/S6 native_decide becomes too slow): land S2 + S3 + S4 + S5 + S7 as standalone gallery improvements, narrow the axiom statement to the irreducible content, defer the full replacement."
     ]
   },
   "tags": [
@@ -166,8 +167,8 @@
     {
       "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
       "filename": "BoundedPrimeGapsOQ03OQ02.lean",
-      "lineCount": 192,
-      "theoremCount": 6,
+      "lineCount": 245,
+      "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S5 of the certified-computation replacement for `engelsma_lower_bound` (parent: `BoundedPrimeGapsOQ03.lean` axiom at line 134).

This iteration adds a **cautious intermediate scaling checkpoint** at `(k, w) = (8, 22)`, between S4's `(6, 16)` case (8,008 subsets) and the originally-planned `(10, 30)` case (~3 × 10⁷ subsets, now deferred to S6).

New theorem in `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (192 → 245 lines):

```lean
theorem engelsma_analogue_8_22 :
    ∀ H ∈ (Finset.range 22).powersetCard 8,
      ∀ (h0 : 0 ∈ H), IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩ := by
  native_decide
```

Search space `Nat.choose 22 8 = 319,770 ≈ 3.2 × 10⁵` — roughly **40× S4** but still four orders of magnitude below the deferred S6 case.

### Vacuity / correctness

Engelsma's table records `H(8) = 26 > 21`, so no admissible 8-tuple fits in `Finset.range 22`. The implication's antecedent `IsAdmissible H` is false on every enumerated subset, so the threshold `18 ≤ H.max'` (chosen by S4's `12 ≤ ...` convention as a conservative under-estimate) is vacuously satisfied. `native_decide` confirms the non-existence directly via the S2 `Decidable (IsAdmissible H)` instance.

### Why deviate from state.md's stated S5 next-action `(10, 30)`?

`state.md` flagged the (10, 30) case has runtime risk: 30–120 s estimated under `native_decide`, possibly exceeding default CI timeouts. The local worktree shares the broken `proofs/.lake` symlink (per memory `feedback_researcher_lake_symlink_broken.md`), so we cannot pre-verify the build.

Per `knowledge.md` §6.4 (the feasibility-checkpoint principle), an intermediate scaling step gives **empirical evidence** before committing to the 3,750× S4 case:

- S4 (8K subsets) → S5 (320K subsets, 40× S4) → S6 (30M subsets, 3,750× S4)
- If S5 builds in a few seconds in CI, S6's runtime extrapolates to tens of seconds (principled go decision).
- If S5 runs slowly, that informs whether to proceed to S6 or move directly to the §6.4 Path-C-prime fallback.

The originally planned `(10, 30)` case is renumbered to **S6** in `state.md`.

### Axiom bookkeeping

`native_decide` reuses the `Lean.ofReduceBool` axiom introduced in S4; `leanFile.axiomCount` stays at `1` (one axiom per file, regardless of `native_decide` count).

### Metadata bumps

- `currentState.iteration`: 3 → 5 (also captures S4's missed bump)
- `currentState.since`: 2026-05-12T07:08:00Z
- `currentState.focus` / `nextAction`: refreshed
- `knowledge.progressSummary` / `insights` / `nextSteps`: refreshed (S6 / S7 / S8+ ordering)
- `leanFile`: lineCount 192 → 245, theoremCount 6 → 7, axiomCount 1 (unchanged), defCount 1 (unchanged), sorryCount 0 (unchanged)
- `state.md`: session log extended with S4 and S5; "Subsequent Iterations" reframed around S6 / S7 / S8+

## Honesty / build status

Build pending — the worktree shares the broken `proofs/.lake` symlink trap, so `docker-build.sh` is not run pre-commit. The proof script is one `native_decide` call; either it succeeds (giving us the intermediate scaling datapoint for §6.4) or it doesn't (giving us the same datapoint in the opposite direction). Either outcome is informative.

## Test plan

- [ ] CI: `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` builds.
- [ ] CI runtime of `native_decide` for `engelsma_analogue_8_22` recorded (extrapolation datapoint for S6).
- [ ] `pnpm build` for gallery picks up new theorem (annotated theoremCount 7).
- [ ] `axiomCount = 1` after build (Lean.ofReduceBool only, reused from S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)