### PR TITLE
fix(meta): schauder-fp-oq03-oq01 sync meta sub-block to lf values

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -50,7 +50,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 907,
+    "lineCount": 957,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -59,7 +59,7 @@
     ],
     "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free, but it transitively depends on the sorry-stubbed `exists_continuous_proj_convex` helper pending S11.B — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 4
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale `meta.sub.lineCount` (907 → 957) and `meta.sub.theoremCount` (8 → 9) for `schauder-fixed-point-oq-03-oq-01` after recent S18a/b/c PRs added theorems and lines but only updated the `leanFile` block.

## Evidence

| Field         | meta.sub (before) | meta.sub (after) | leanFile (correct) |
|---------------|-------------------|------------------|--------------------|
| lineCount     | 907               | 957              | 957                |
| theoremCount  | 8                 | 9                | 9                  |

**Verification**
- `wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` → 957
- Comment-stripped regex count of `theorem|lemma` declarations → 9
  (uhc_local_thickening, exists_continuous_proj_convex, brouwer_fpt, convex_combination_of_partition_in_S, typeclass_witnesses_compact_subset, exists_finite_subcover_for_uhc, seq_compact_of_compact, approx_fixedpoint_implies_fixedpoint, kakutani_from_brouwer)

## Origin of drift

- #17716 (2026-05-11) synced lineCount 766 → 779 in the `leanFile` block only
- #17755 / #17802 / #17910 (S18a/b/c) added theorems and lines, again leanFile-only
- The `meta.*` sub-block (`meta.lineCount`, `meta.theoremCount`) hasn't been touched since #17716, so it still reflects pre-S18 state

No code changes; metadata-only fix.

---
Automated fix by lean-mechanic agent.