### PR TITLE
audit(combinations-formula-oq-02): revert false-clean (Aristotle sorry still present)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -94,7 +94,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. Both the main file and the *Aristotle.lean companion are now fully proved (0 sorries, 0 axioms across both files).",
+    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. The main file has 0 sorries and 0 axioms; the *Aristotle.lean companion exposes a duplicate `catalan_mul_succ` statement as an Aristotle proof-search target (1 sorry).",
     "implications": "This formalization connects the gallery's binomial coefficient work (CombinationsFormula) to the ballot problem proofs (BallotProblemOQ03). The central binomial bound C(2n,n) <= 4^n is independently useful (e.g., for the Ap\u00e9ry irrationality proof).",
     "openQuestions": [
       "Prove the generating function C(x) = (1 - sqrt(1-4x))/(2x)",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Reverts the meta.json portion of [PR #17936](https://github.com/rjwalters/lean-genius/pull/17936), which claimed the Aristotle companion file was "fully proved (0 sorry declarations across both files)" — verification shows the `catalan_mul_succ` target sorry is still present on `origin/main`.

```
proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
  86:  /-- **Fundamental Catalan identity**: C_n * (n+1) = C(2n, n). -/
  87:  theorem catalan_mul_succ (n : ℕ) :
  88:      catalan n * (n + 1) = centralBinom n := by
  89:    sorry
```

## Changes

| Field | Before (#17936) | After (this PR) |
|-------|-----------------|-----------------|
| `meta.status` | `verified` | `formalized` |
| `meta.sorries` | 0 | 1 |
| top-level `sorries` | 0 | 1 |
| `conclusion.summary` | "Both ... fully proved (0 sorries)" | "main file has 0 sorries ... Aristotle companion exposes ... (1 sorry)" |

The main file `CombinationsFormulaOQ02.lean` is unchanged and remains fully proved (0 sorries, 0 axioms); only the entry's aggregate count reflects the persistent Aristotle target.

## Background

This entry was demoted `verified → formalized` in [PR #17295](https://github.com/rjwalters/lean-genius/pull/17295) (resolving [#17291](https://github.com/rjwalters/lean-genius/issues/17291)) precisely because of the Aristotle companion sorry. Since the Aristotle file remains unchanged (last touched in PR #15865), the same Option-C demotion still applies.

`scripts/auditor/find-targets.ts` aggregates sorries from `meta.additionalFiles`, so `verified + sorries:0` while the companion contains a sorry produces:
- `sorry mismatch: claims 0, actual 1`
- `status "verified" but has 1 sorries`

## Test plan

- [x] Verified `theorem catalan_mul_succ ... := by sorry` exists at line 87-89 of `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean` on `origin/main`
- [x] Confirmed `CombinationsFormulaOQ02Aristotle.lean` is listed in `meta.additionalFiles`
- [x] Confirmed comment-stripped scan: main file 0 sorries, Aristotle 1 sorry
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` should drop `combinations-formula-oq-02` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)