### PR TITLE
fix(meta): combinations-formula-oq-02 revert false-clean (sorry still present)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
@@ -94,7 +94,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. Both the main file and the *Aristotle.lean companion are now fully proved (0 sorries, 0 axioms across both files).",
+    "summary": "Catalan numbers fully formalized in the main file: C_n*(n+1) = C(2n,n) proved via absorption identity, positivity, monotonicity, 2^n/4^n bounds proved, and the convolution C_{n+1} = sum C_k*C_{n-k} proved via Mathlib's catalan_succ'. The main file has 0 sorries and 0 axioms; the *Aristotle.lean companion exposes a duplicate `catalan_mul_succ` statement as an Aristotle proof-search target (1 sorry).",
     "implications": "This formalization connects the gallery's binomial coefficient work (CombinationsFormula) to the ballot problem proofs (BallotProblemOQ03). The central binomial bound C(2n,n) <= 4^n is independently useful (e.g., for the Ap\u00e9ry irrationality proof).",
     "openQuestions": [
       "Prove the generating function C(x) = (1 - sqrt(1-4x))/(2x)",
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Audit PR #17936 set `meta.json` to `sorries: 0` / `status: verified` based on an inspection that missed the surviving `sorry` at `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean:89` (`catalan_mul_succ`). The mechanic's `find-targets --issues` correctly flags the resulting drift:

```
❌ sorry mismatch: claims 0, actual 1; status "verified" but has 1 sorries
```

## Evidence

```
$ git show origin/main:proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean \
    | grep -nE '\\bsorry\\b'
89:  sorry

$ git show origin/main:proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean | sed -n '86,90p'
/-- **Fundamental Catalan identity**: C_n * (n+1) = C(2n, n). -/
theorem catalan_mul_succ (n : ℕ) :
    catalan n * (n + 1) = centralBinom n := by
  sorry
```

The audit's claim of "0 sorries across both files" was incorrect: the `catalan_mul_succ` theorem in the Aristotle companion file is still sorry-bearing (the matching theorem is proved in the main file, so this companion entry is the duplicate Aristotle target, not yet discharged).

## Changes (`src/data/proofs/combinations-formula-oq-02/meta.json` only)

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `verified` | `formalized` |
| `meta.sorries` | 0 | 1 |
| top-level `sorries` | 0 | 1 |
| `conclusion.summary` | "Both ... fully proved (0 sorries...)" | "main file 0 sorries ... companion exposes ... (1 sorry)" |

`leanFile.sorries` stays 0 (main-file convention).

## Validation

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

Closes the drift identified by find-targets. The underlying `catalan_mul_succ` proof in the companion file is left for a future mechanic / Aristotle cycle.

---
Automated fix by lean-mechanic agent.