### PR TITLE
Enrich pascals-hexagon-oq-03: docstring + card_hexagonalGroup + card_labelings + sanity-lemmas annotations, Lagrange cross-ref

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03/meta.json
@@ -194,6 +194,11 @@
       "targetId": "abel-ruffini-galois-extensions",
       "relationship": "related",
       "description": "Shares the `Equiv.Perm (Fin 6)` cardinality pattern: `card_s6 = 720` by `native_decide` appears identically in `AbelRuffiniGaloisExtensions.lean` line 314."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "depends-on",
+      "description": "The 60-Pascal-line count is a direct Lagrange consequence: `card_hexagon_labelings = |Sym(6)| / |hexagonalGroup| = 720 / 12 = 60`. The OQ-03-OQ-01 (`card_hexagonalGroup = 12`) is the only nontrivial step; once that is in hand, the 60-count is a single application of `Subgroup.card_eq_card_quotient_mul_card_subgroup`. Lagrange's theorem itself is formalized as Wiedijk #71 in the gallery."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Enrichment pass on the Hexagrammum Mysticum S1 scaffold (`pascals-hexagon-oq-03`). Adds four new annotations to close gaps in coverage, plus one new cross-reference to `lagrange-theorem`.

### Coverage gap fixes (4 new annotations)

| Range | Title | Why |
|---|---|---|
| 12-109 | Module Docstring: Sub-OQ Roadmap | The 98-line docstring carrying the entire `OQ-03-OQ-01..05` plan was previously uncovered |
| 172-180 | `card_hexagonalGroup = 12` (OQ-03-OQ-01) | The headline sub-OQ sorry — explains the `DihedralGroup 6 →* hexagonalGroup` MonoidHom injectivity strategy |
| 182-190 | `card_hexagon_labelings = 60` (Lagrange) | The 60-count derivation `|Sym(6)| / |D_6| = 720/12 = 60`, the foundational combinatorial identity |
| 278-289 | Sanity Lemmas (`hexRot_ne_one`, `hexRev_ne_one`) | Non-triviality of generators, the minimal sanity check the OQ-03-OQ-01 MonoidHom injectivity builds on |

After this pass, every theorem in the file has a dedicated annotation.

### Cross-reference

- `lagrange-theorem` (depends-on): Wiedijk #71 in the gallery. The `card_hexagon_labelings = 60` derivation is a direct application of `Subgroup.card_eq_card_quotient_mul_card_subgroup`.

## Scope

Documentation only — no Lean source changes, no schema changes. JSON validates via `python3 json.load`. Full `pnpm build` skipped per the known Node v26 / `better-sqlite3` gyp-hang issue (memory: `enricher_pnpm_build_bypass`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)