### PR TITLE
audit: tracker — 6 new-audits + combinations-formula-oq-02 revert

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2162,10 +2162,10 @@
       "result": "clean"
     },
     "combinations-formula-oq-02": {
-      "auditCount": 5,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-12T05:52:27Z",
-      "result": "clean"
+      "lastAudited": "2026-05-12T07:26:52Z",
+      "result": "issues-found"
     },
     "continuum-hypothesis": {
       "agentId": "auditor-cycle-20-batch",
@@ -15116,6 +15116,42 @@
     "angle-trisection-oq-05-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-05-12T06:48:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-01-oq-03-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:27:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:28:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-02-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:28:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minpoly-charpoly-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:28:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pascals-hexagon-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:29:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spherical-law-of-cosines-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:30:05Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Tracker update from one auditor loop iteration on 2026-05-12T07:26Z–07:30Z.

### 1. Six never-audited entries audited clean

All 5 declared counts (sorries, axioms, status, badge) match the corresponding Lean source on `origin/main`:

| Slug | Status / Badge | Sorries | Axioms | Notes |
|------|---------------|--------:|-------:|-------|
| `cantors-theorem-oq-01-oq-03-oq-04` | verified / mathlib | 0 | 0 | Tier B (König via Mathlib), `mathlibDependencies` + `assumptions` properly attributed |
| `lagrange-theorem-oq-02-oq-02-oq-01` | verified / mathlib | 0 | 0 | Tier B (Burnside via Mathlib), 4 theorems, clean |
| `mean-value-theorem-oq-02-oq-04-oq-01` | axiomatized / axiom | 1 | 0 | Refutes parent OQ-04 axiom + corrected complex-disk theorem with 1 deferred sorry |
| `minpoly-charpoly-oq-03` | formalized / research | 1 | 0 | S1 OBSERVE scaffold; 1 sorry on `rational_canonical_form_exists` |
| `pascals-hexagon-oq-03` | formalized / research | 5 | 0 | Four-sub-OQ scaffold; sorries map 1:1 to listed sub-OQs |
| `spherical-law-of-cosines-oq-05` | verified / original | 0 | 0 | 15 theorems, all proved; haversine formula derivation |

### 2. `combinations-formula-oq-02`: clean → issues-found

PR #17936 set `meta.status` to `verified` / `sorries: 0` based on an inspection that missed the surviving `sorry` at `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean:89` (`catalan_mul_succ`). `find-targets --issues` correctly re-flags it:

```
combinations-formula-oq-02 (6x) [verified/original]
  ❌ sorry mismatch: claims 0, actual 1; status "verified" but has 1 sorries
```

Two open meta-fix PRs already address the drift — this PR only updates the tracker's `result` field for transparency:

- #17951 — `audit(combinations-formula-oq-02): revert false-clean (Aristotle sorry still present)`
- #17952 — `fix(meta): combinations-formula-oq-02 revert false-clean (sorry still present)`

## Verification

```
$ npx tsx scripts/auditor/find-targets.ts --stats
Total proofs:     2417
Audited:          2417
Unaudited:        0
With issues:      1     # combinations-formula-oq-02, pending PR #17951/#17952
Critical issues:  0
```

## Test plan

- [x] Diff scoped to `src/data/proofs/audit-tracker.json` only (1 file, +39 / -3)
- [x] All 6 newly-audited slugs verified against their Lean source on `origin/main`
- [x] `combinations-formula-oq-02` Aristotle sorry confirmed at line 89
- [ ] After merge of #17951 or #17952, `--issues` count drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)