### PR TITLE
research(erdos-szekeres-oq-03): S3 ACT-B — ramseyNumber_one via pigeonhole iff helper (build verified)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fin.Basic
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Tactic
 
@@ -19,10 +20,12 @@ diagonal hypergraph Ramsey number `R_k(s,t)` as the least `n` such that every
 monochromatic `s`-clique of one color or a monochromatic `t`-clique of the
 other.
 
-This file is the **S2 scaffold** — it sets up the API and states the main
-existence theorem (`ramsey_existence`, OQ-03a) as a `sorry`. The two-layer
-neighborhood induction (Ramsey 1930) and the Erdős–Rado tower upper bound
-(OQ-03b) are deferred to later sessions per
+After **S3** (this revision) the `k = 1` pigeonhole sanity check
+`ramseyNumber_one s t = s + t - 1` is proved — the simplest instance of the
+hypergraph Ramsey theorem and a unit test for the API introduced in S2.
+The general existence theorem `ramsey_existence` (OQ-03a, two-layer Ramsey
+1930 induction) and the Erdős–Rado tower upper bound (OQ-03b) remain
+`sorry`-marked, deferred to S4+ per
 `research/problems/erdos-szekeres-oq-03/state.md`.
 
 ## Status
@@ -30,12 +33,12 @@ neighborhood induction (Ramsey 1930) and the Erdős–Rado tower upper bound
 - [x] Definitions: `kColoring`, `IsMonochromatic`, `IsRamsey`, `ramseyNumber`.
 - [x] `IsMonochromatic_of_card_lt_k`: any subset smaller than `k` is trivially
   monochromatic of every color (the `powersetCard` is empty).
-- [x] `is_ramsey_zero_clique`: the degenerate `s = 0` case (every coloring has
-  a `0`-clique).
-- [ ] `ramsey_existence` (OQ-03a): the main result, stated as `sorry`. Proof
-  strategy in `state.md`.
-- [ ] `ramseyNumber_one` (k=1 pigeonhole sanity check): stated as `sorry` and
-  scheduled for S3 alongside the existence theorem.
+- [x] `is_ramsey_zero_false` / `is_ramsey_zero_true`: degenerate `s = 0` /
+  `t = 0` base cases (the empty set witnesses both).
+- [x] **`isRamsey_one_iff` and `ramseyNumber_one` (S3)**: the `k = 1` case
+  is the pigeonhole `s + t - 1` bound, by partitioning singletons.
+- [ ] `ramsey_existence` (OQ-03a): the general result, stated as `sorry`.
+  Proof strategy in `state.md`.
 
 ## Approach
 
@@ -106,7 +109,8 @@ every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.
 
 This is the main result of the OQ-03 entry. The proof (Ramsey 1930) is by
 two-layer induction on `k` and `s + t`; see `state.md` for the strategy.
-Deferred to S3. -/
+Deferred to S4+ (S3 closed the `k = 1` sanity check; the `k ≥ 2` induction
+needs the additional neighborhood-collapse machinery). -/
 theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
     ∃ n, IsRamsey n k s t := by
   sorry
@@ -135,18 +139,167 @@ lemma is_ramsey_zero_true (n k s : ℕ) (hk : 1 ≤ k) : IsRamsey n k s 0 := by
   · exact Finset.card_empty
   · exact isMonochromatic_empty_zero χ true hk
 
-/-- (k=1 sanity check, scheduled for S3.) The `k = 1` Ramsey number is the
-pigeonhole bound `s + t - 1`. Stated here for the API; proof deferred to S3
-(it needs both the pigeonhole-forward direction and an explicit bad coloring
-for the lower bound).
+/-- (S3 helper.) At uniformity `k = 1`, the Ramsey condition is equivalent to
+the pigeonhole bound `s + t - 1 ≤ n`.
 
-The forward direction (showing `IsRamsey (s+t-1) 1 s t` via `Finset.filter`
-counting) is straightforward; the reverse `¬ IsRamsey (s+t-2) 1 s t` requires
-constructing the coloring with `s-1` `false`-singletons and `t-1`
-`true`-singletons. -/
+* Forward (`s + t - 1 ≤ n → IsRamsey n 1 s t`): partition `Fin n` by
+  `χ {·}`; one of the two color classes has cardinality `≥ s` or `≥ t`.
+* Backward (`IsRamsey n 1 s t → s + t - 1 ≤ n`): contrapositive — if
+  `n ≤ s + t - 2` then the coloring with `min (s-1) n` `false`-singletons
+  and the rest `true` exhibits no monochromatic `s`- or `t`-clique. -/
+lemma isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
+    IsRamsey n 1 s t ↔ s + t - 1 ≤ n := by
+  classical
+  constructor
+  · -- (⇒) IsRamsey n 1 s t → s + t - 1 ≤ n.  Contrapositive: if n ≤ s+t-2 we
+    -- exhibit a coloring that defeats every monochromatic s/t-clique candidate.
+    intro hR
+    by_contra hlt
+    push_neg at hlt
+    -- hlt : n < s + t - 1, equivalently n ≤ s + t - 2.
+    -- Build the "bad" coloring: first `a = min (s-1) n` singletons are `false`,
+    -- rest `true`. (Definition only depends on each singleton's element.)
+    set a : ℕ := min (s - 1) n with ha_def
+    -- Decidability of `a ≤ i.val` for `i : Fin n` lets us define χ.
+    let χ : kColoring n := fun S => decide (∃ i ∈ S, a ≤ i.val)
+    -- Two helper facts about χ on singletons.
+    have hχ_false : ∀ i : Fin n, i.val < a → χ {i} = false := by
+      intro i hi
+      show decide (∃ j ∈ ({i} : Finset (Fin n)), a ≤ j.val) = false
+      simp only [Finset.mem_singleton, exists_eq_left]
+      exact decide_eq_false (Nat.not_le_of_lt hi)
+    have hχ_true : ∀ i : Fin n, a ≤ i.val → χ {i} = true := by
+      intro i hi
+      show decide (∃ j ∈ ({i} : Finset (Fin n)), a ≤ j.val) = true
+      simp only [Finset.mem_singleton, exists_eq_left]
+      exact decide_eq_true hi
+    -- Two card bounds via the globally-injective `Fin.val : Fin n → ℕ`.
+    -- (1) Any S with `∀ i ∈ S, i.val < a` has |S| ≤ a (image ⊆ Finset.range a).
+    -- (2) Any S with `∀ i ∈ S, a ≤ i.val` has |S| ≤ n - a (image ⊆ Finset.Ico a n).
+    have hcard_lo : ∀ (S : Finset (Fin n)), (∀ i ∈ S, i.val < a) → S.card ≤ a := by
+      intro S hS
+      have h_im : S.image (fun i : Fin n => i.val) ⊆ Finset.range a := by
+        intro x hx
+        rcases Finset.mem_image.mp hx with ⟨i, hiS, rfl⟩
+        exact Finset.mem_range.mpr (hS i hiS)
+      calc S.card
+          = (S.image (fun i : Fin n => i.val)).card :=
+              (Finset.card_image_of_injective S Fin.val_injective).symm
+        _ ≤ (Finset.range a).card := Finset.card_le_card h_im
+        _ = a := Finset.card_range a
+    have hcard_hi : ∀ (S : Finset (Fin n)), (∀ i ∈ S, a ≤ i.val) → S.card ≤ n - a := by
+      intro S hS
+      have h_im : S.image (fun i : Fin n => i.val) ⊆ Finset.Ico a n := by
+        intro x hx
+        rcases Finset.mem_image.mp hx with ⟨i, hiS, rfl⟩
+        exact Finset.mem_Ico.mpr ⟨hS i hiS, i.isLt⟩
+      calc S.card
+          = (S.image (fun i : Fin n => i.val)).card :=
+              (Finset.card_image_of_injective S Fin.val_injective).symm
+        _ ≤ (Finset.Ico a n).card := Finset.card_le_card h_im
+        _ = n - a := Nat.card_Ico a n
+    -- Helper: from monochromatic-`c` on S, every `i ∈ S` has `χ {i} = c`.
+    have hmono_singleton : ∀ {S : Finset (Fin n)} {c : Bool},
+        IsMonochromatic χ 1 S c → ∀ i ∈ S, χ {i} = c := by
+      intro S c hmono i hiS
+      apply hmono
+      rw [Finset.mem_powersetCard]
+      exact ⟨Finset.singleton_subset_iff.mpr hiS, Finset.card_singleton i⟩
+    rcases hR χ with ⟨S, hScard, hSmono⟩ | ⟨S, hScard, hSmono⟩
+    · -- false-clique S of size s: every i ∈ S has χ {i} = false ⇒ i.val < a.
+      have hSlt : ∀ i ∈ S, i.val < a := by
+        intro i hiS
+        have hχ : χ {i} = false := hmono_singleton hSmono i hiS
+        by_contra hge
+        push_neg at hge
+        have : χ {i} = true := hχ_true i hge
+        simp [this] at hχ
+      have hcard : S.card ≤ a := hcard_lo S hSlt
+      have ha_bound : a ≤ s - 1 := by simp [a]; omega
+      omega
+    · -- true-clique S of size t: every i ∈ S has a ≤ i.val.
+      have hSge : ∀ i ∈ S, a ≤ i.val := by
+        intro i hiS
+        have hχ : χ {i} = true := hmono_singleton hSmono i hiS
+        by_contra hlt'
+        push_neg at hlt'
+        have : χ {i} = false := hχ_false i hlt'
+        simp [this] at hχ
+      have hcard : S.card ≤ n - a := hcard_hi S hSge
+      -- Bound n - a ≤ t - 1, case-split on the `min`.
+      have ha_bound : n - a ≤ t - 1 := by
+        rcases le_or_lt (s - 1) n with hsa | hsa
+        · -- a = s - 1
+          have ha_eq : a = s - 1 := by simp [a]; omega
+          omega
+        · -- a = n
+          have ha_eq : a = n := by simp [a]; omega
+          omega
+      omega
+  · -- (⇐) s + t - 1 ≤ n → IsRamsey n 1 s t.  Pigeonhole partition of `Fin n`
+    -- by the color χ {·}; one color class has size ≥ s or ≥ t.
+    intro hge χ
+    -- F := false-singletons, G := true-singletons; they partition `Fin n`.
+    let F : Finset (Fin n) := Finset.univ.filter (fun i : Fin n => χ {i} = false)
+    let G : Finset (Fin n) := Finset.univ.filter (fun i : Fin n => χ {i} = true)
+    have hF_neg : (Finset.univ.filter (fun i : Fin n => ¬ (χ {i} = false))) = G := by
+      ext i
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, G]
+      cases hc : χ {i} <;> simp [hc]
+    have hsum : F.card + G.card = n := by
+      have h :
+          (Finset.univ.filter (fun i : Fin n => χ {i} = false)).card +
+            (Finset.univ.filter (fun i : Fin n => ¬ (χ {i} = false))).card =
+          (Finset.univ : Finset (Fin n)).card :=
+        Finset.filter_card_add_filter_neg_card_eq_card _
+      rw [hF_neg] at h
+      have hcard_univ : (Finset.univ : Finset (Fin n)).card = n := by
+        rw [Finset.card_univ, Fintype.card_fin]
+      simpa [F, hcard_univ] using h
+    by_cases hFs : s ≤ F.card
+    · -- |F| ≥ s: pick S ⊆ F with |S| = s; every singleton of S has χ {·} = false.
+      obtain ⟨S, hSsub, hScard⟩ := Finset.exists_subset_card_eq hFs
+      refine Or.inl ⟨S, hScard, ?_⟩
+      intro T hT
+      rw [Finset.mem_powersetCard] at hT
+      obtain ⟨hTsub, hTcard⟩ := hT
+      obtain ⟨i, rfl⟩ := Finset.card_eq_one.mp hTcard
+      have hi : i ∈ S := Finset.singleton_subset_iff.mp hTsub
+      have hiF : i ∈ F := hSsub hi
+      simpa [F, Finset.mem_filter] using hiF
+    · -- |F| < s ⇒ |G| > n - s ≥ (s+t-1) - s = t - 1, hence |G| ≥ t.
+      push_neg at hFs
+      have hGcard : t ≤ G.card := by omega
+      obtain ⟨S, hSsub, hScard⟩ := Finset.exists_subset_card_eq hGcard
+      refine Or.inr ⟨S, hScard, ?_⟩
+      intro U hU
+      rw [Finset.mem_powersetCard] at hU
+      obtain ⟨hUsub, hUcard⟩ := hU
+      obtain ⟨i, rfl⟩ := Finset.card_eq_one.mp hUcard
+      have hi : i ∈ S := Finset.singleton_subset_iff.mp hUsub
+      have hiG : i ∈ G := hSsub hi
+      simpa [G, Finset.mem_filter] using hiG
+
+/-- (S3, OQ-03 sanity check.) **The `k = 1` Ramsey number is the pigeonhole bound**
+`R_1(s, t) = s + t - 1`. This is the base case of the Erdős–Rado tower upper bound
+and the simplest instance of the hypergraph Ramsey theorem. It serves as a unit
+test for the `RamseyK.IsRamsey` / `RamseyK.ramseyNumber` API introduced in S2.
+
+The proof reduces to `isRamsey_one_iff` plus the standard `Nat.sInf` computation
+on the upward-closed set `{n | s + t - 1 ≤ n} = Set.Ici (s + t - 1)`. -/
 theorem ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
     ramseyNumber 1 s t = s + t - 1 := by
-  sorry
+  unfold ramseyNumber
+  have hset : {n | IsRamsey n 1 s t} = {n | s + t - 1 ≤ n} := by
+    ext n; rw [Set.mem_setOf_eq, Set.mem_setOf_eq]
+    exact isRamsey_one_iff n s t hs ht
+  rw [hset]
+  -- sInf {n | s+t-1 ≤ n} = s+t-1
+  apply le_antisymm
+  · exact Nat.sInf_le (le_refl _)
+  · refine le_csInf ⟨s + t - 1, le_refl _⟩ ?_
+    intro n hn
+    exact hn
 
 /-! ### S4-prep: color symmetry and degenerate-side `ramseyNumber` base cases
 

--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -215,7 +215,8 @@ lemma isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
         have : χ {i} = true := hχ_true i hge
         simp [this] at hχ
       have hcard : S.card ≤ a := hcard_lo S hSlt
-      have ha_bound : a ≤ s - 1 := by simp [a]; omega
+      -- a = min (s - 1) n ≤ s - 1, contradicting hcard + hScard : S.card = s.
+      have ha_bound : a ≤ s - 1 := min_le_left _ _
       omega
     · -- true-clique S of size t: every i ∈ S has a ≤ i.val.
       have hSge : ∀ i ∈ S, a ≤ i.val := by
@@ -228,12 +229,16 @@ lemma isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
       have hcard : S.card ≤ n - a := hcard_hi S hSge
       -- Bound n - a ≤ t - 1, case-split on the `min`.
       have ha_bound : n - a ≤ t - 1 := by
-        rcases le_or_lt (s - 1) n with hsa | hsa
+        rcases le_or_gt (s - 1) n with hsa | hsa
         · -- a = s - 1
-          have ha_eq : a = s - 1 := by simp [a]; omega
+          have ha_eq : a = s - 1 := by
+            show min (s - 1) n = s - 1
+            exact min_eq_left hsa
           omega
-        · -- a = n
-          have ha_eq : a = n := by simp [a]; omega
+        · -- a = n (when s - 1 > n)
+          have ha_eq : a = n := by
+            show min (s - 1) n = n
+            exact min_eq_right (le_of_lt hsa)
           omega
       omega
   · -- (⇐) s + t - 1 ≤ n → IsRamsey n 1 s t.  Pigeonhole partition of `Fin n`
@@ -245,7 +250,7 @@ lemma isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
     have hF_neg : (Finset.univ.filter (fun i : Fin n => ¬ (χ {i} = false))) = G := by
       ext i
       simp only [Finset.mem_filter, Finset.mem_univ, true_and, G]
-      cases hc : χ {i} <;> simp [hc]
+      cases hc : χ {i} <;> simp
     have hsum : F.card + G.card = n := by
       have h :
           (Finset.univ.filter (fun i : Fin n => χ {i} = false)).card +
@@ -294,12 +299,18 @@ theorem ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
     ext n; rw [Set.mem_setOf_eq, Set.mem_setOf_eq]
     exact isRamsey_one_iff n s t hs ht
   rw [hset]
-  -- sInf {n | s+t-1 ≤ n} = s+t-1
+  -- sInf {n | s+t-1 ≤ n} = s+t-1: `s+t-1` is the min of the upward-closed set.
   apply le_antisymm
-  · exact Nat.sInf_le (le_refl _)
-  · refine le_csInf ⟨s + t - 1, le_refl _⟩ ?_
-    intro n hn
-    exact hn
+  · -- sInf ≤ s+t-1: membership witness `s+t-1 ≤ s+t-1`.
+    apply Nat.sInf_le
+    rw [Set.mem_setOf_eq]
+  · -- s+t-1 ≤ sInf: every member of the set is ≥ s+t-1.
+    apply le_csInf
+    · refine ⟨s + t - 1, ?_⟩
+      rw [Set.mem_setOf_eq]
+    · intro n hn
+      rw [Set.mem_setOf_eq] at hn
+      exact hn
 
 /-! ### S4-prep: color symmetry and degenerate-side `ramseyNumber` base cases
 

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,31 +1,46 @@
 # Current State
 
-**Phase**: ACT (S2 scaffold landed; existence + k=1 sanity check remain `sorry`)
-**Since**: 2026-05-12 (S2 ACT-A scaffold, researcher-9)
-**Iteration**: 2
+**Phase**: ACT (S3 closes the `k = 1` sanity check; `ramsey_existence` remains)
+**Since**: 2026-05-12 (S3 ACT-B, researcher-11)
+**Iteration**: 3
+**Researcher**: researcher-11 (S3); researcher-9 (S2); researcher-8 (S1)
 
 ## Current Focus
 
-Session 2 (S2 ACT-A, researcher-9, 2026-05-12): create the
-`RamseyHypergraph.lean` API surface and state the main existence theorem
-(OQ-03a) as a `sorry`.
+Session 3 (S3 ACT-B, researcher-11, 2026-05-12): discharge the `k = 1`
+pigeonhole sanity check `ramseyNumber 1 s t = s + t - 1`.
 
-Output of this session:
+Output of this session (build pending; the local worktree shares the broken
+`proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`):
 
-* `proofs/Proofs/RamseyHypergraph.lean` (~147 lines, 2 sorries, 0 axioms).
-  Definitions: `kColoring`, `IsMonochromatic`, `IsRamsey`, `ramseyNumber`
-  (via `sInf`).
-  Proved API lemmas: `isMonochromatic_of_card_lt` (subsets smaller than
-  the uniformity have no `k`-subsets, hence are trivially monochromatic),
-  `isMonochromatic_empty_zero`, `is_ramsey_zero_false`, `is_ramsey_zero_true`
-  (degenerate `s=0` / `t=0` cases — the empty set is the witness).
-  Two sorries:
-  - `ramsey_existence` (the OQ-03a main theorem) — to be discharged in S3.
-  - `ramseyNumber_one` (k=1 pigeonhole sanity check) — postponed to S3
-    because the lower-bound construction (a coloring with `s-1`
-    `false`-singletons and `t-1` `true`-singletons) takes more space than
-    initially estimated.
-* `proofs/Proofs.lean` regenerated to include the new file.
+* `proofs/Proofs/RamseyHypergraph.lean` — 147 → 304 lines, +157.
+  New helper `isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
+  IsRamsey n 1 s t ↔ s + t - 1 ≤ n` cleanly factors the result.
+  - **Forward (⇐): `s + t - 1 ≤ n → IsRamsey n 1 s t`.** Pigeonhole. Let
+    `F := univ.filter (χ {·} = false)`, `G := univ.filter (χ {·} = true)`.
+    `Finset.filter_card_add_filter_neg_card_eq_card` gives
+    `|F| + |G| = n`. Case `|F| ≥ s` extracts an `s`-clique via
+    `Finset.exists_subset_card_eq`; otherwise `|G| ≥ t` extracts a
+    `t`-clique.
+  - **Reverse (⇒): `IsRamsey n 1 s t → s + t - 1 ≤ n`.** Contrapositive
+    on `n ≤ s + t - 2`. Build the worst-case coloring with
+    `a := min (s-1) n` `false`-singletons and the rest `true`. Two card
+    bounds via the globally-injective `Fin.val : Fin n → ℕ`:
+      - false-clique image ⊆ `Finset.range a` so `|S| ≤ a ≤ s - 1`.
+      - true-clique image ⊆ `Finset.Ico a n` (card `n - a` via
+        `Nat.card_Ico`) and case-split on `min` gives `n - a ≤ t - 1`.
+* `ramseyNumber_one`: closed by `isRamsey_one_iff` plus
+  `Nat.sInf` on the upward-closed set `{n | s + t - 1 ≤ n}`.
+* `leanFile` counts (this file): lineCount 147 → 304, theoremCount 6 → 7,
+  defCount 4 (unchanged), sorryCount 2 → 1, axiomCount 0 (unchanged).
+
+## Prior Session Outputs (S2, researcher-9)
+
+* `proofs/Proofs/RamseyHypergraph.lean` (147 lines): API surface
+  (`kColoring`, `IsMonochromatic`, `IsRamsey`, `ramseyNumber`) +
+  `isMonochromatic_of_card_lt`, `isMonochromatic_empty_zero`,
+  `is_ramsey_zero_false`, `is_ramsey_zero_true`; `ramsey_existence` and
+  `ramseyNumber_one` stated as sorries. PR #17909 merged.
 
 ## Prior Session Outputs (S1, researcher-8)
 
@@ -65,34 +80,29 @@ adequate but verbose.
 
 ## Next Action
 
-**S3 ACT-B.** Two parallel tasks (can be done in either order):
+**S4 ACT-C — Existence theorem `ramsey_existence` (OQ-03a).**
 
-1. **Pigeonhole base case `ramseyNumber_one s t = s + t - 1`.**
-   - Forward (`IsRamsey (s+t-1) 1 s t`): partition `Fin (s+t-1)` by
-     `i ↦ χ {i}`; if `|filter (χ{·}=false)| ≥ s` use that as the s-clique,
-     else (by pigeonhole) the complement gives a t-clique.
-   - Backward (`¬ IsRamsey (s+t-2) 1 s t`): explicit coloring with the
-     first `s-1` singletons `false` and the remaining `t-1` `true`.
-   - Combine via `sInf_eq_iff` (or by showing both `sInf ≤ s+t-1` and
-     `s+t-1 ≤ sInf`).
-2. **Existence theorem `ramsey_existence` (OQ-03a).**
-   The standard two-layer induction (Ramsey 1930). Induct on `s + t`
-   for fixed `k`; the inductive step is the "neighborhood-tree" argument:
-   fix any vertex `v`, the `(k-1)`-restrictions of `k`-subsets through
-   `v` give a `(k-1)`-coloring on `[n] \ {v}`, then apply induction at
-   uniformity `k-1`.
-   - Base case `k = 2`: reuse `SimpleGraph.ramseyNumber` from Mathlib
-     (or re-prove inline). 
-   - Inductive step (k ≥ 3): the harder half; ~150-300 lines depending on
-     how much Mathlib API is built up.
+The standard Ramsey 1930 two-layer induction. Induct on `s + t` for fixed
+`k`; the inductive step is the "neighborhood-tree" argument: fix any
+vertex `v`, the `(k-1)`-restrictions of `k`-subsets through `v` give a
+`(k-1)`-coloring on `[n] \ {v}`, then apply induction at uniformity `k-1`.
 
-S4 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
+* Base case `k = 2`: reuse `SimpleGraph.ramseyNumber`-style proof (or
+  re-prove inline using the `k = 1` pigeonhole now available as
+  `ramseyNumber_one`).
+* Inductive step `k ≥ 3`: the harder half; ~150–300 lines depending on
+  how much Mathlib API is built up. Concretely, prove the recursive
+  bound `IsRamsey (R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1) k s t` and
+  derive `∃ n, IsRamsey n k s t` from there.
+
+S5 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: 2 (literature survey + Lean API design; S2 scaffold)
+- Total attempts: 3
+- Current approach attempts: 3
+- Approaches tried: 3 (literature survey + Lean API design; S2 scaffold;
+  S3 `ramseyNumber_one` via pigeonhole iff helper)
 
 ## Outcome of S1
 
@@ -105,4 +115,18 @@ S2 SCAFFOLD landed (build pending). `RamseyHypergraph.lean` adds 4
 definitions and 4 sorry-free supporting lemmas alongside 2 sorries
 (`ramsey_existence`, `ramseyNumber_one`). The `IsMonochromatic`-of-too-small
 helper and the `s=0` / `t=0` degenerate Ramsey base cases form the
-foundation for S3's pigeonhole and inductive arguments.
+foundation for S3's pigeonhole and inductive arguments. PR #17909 merged.
+
+## Outcome of S3
+
+S3 closed `ramseyNumber_one s t = s + t - 1` (the `k = 1` pigeonhole
+sanity check), reducing the file's `sorryCount` 2 → 1. The proof
+introduces a new helper `isRamsey_one_iff : IsRamsey n 1 s t ↔
+s + t - 1 ≤ n` that factors the result cleanly. Forward direction uses
+`Finset.filter_card_add_filter_neg_card_eq_card` plus
+`Finset.exists_subset_card_eq` for the pigeonhole; reverse (contrapositive)
+constructs the bad coloring with `min (s-1) n` `false`-singletons and
+bounds the clique cards via `Finset.range`/`Finset.Ico` images of the
+globally-injective `Fin.val`. `ramseyNumber 1 s t = s + t - 1` then
+follows from the iff via `Nat.sInf` on the upward-closed set. Build
+pending (worktree shares the broken `proofs/.lake` symlink).


### PR DESCRIPTION
## Summary

S3 ACT-B for OQ-03 of erdos-szekeres (hypergraph Ramsey numbers): discharge the
`k = 1` pigeonhole sanity check `RamseyK.ramseyNumber 1 s t = s + t - 1` in
`Proofs/RamseyHypergraph.lean`.

The proof factors through a new helper
`isRamsey_one_iff : IsRamsey n 1 s t ↔ s + t - 1 ≤ n`:

* **Forward (⇐).** Partition \`Fin n\` into the false-singletons
  \`F := univ.filter (χ {·} = false)\` and the true-singletons \`G\`.
  \`Finset.filter_card_add_filter_neg_card_eq_card\` gives \`|F| + |G| = n\`;
  case \`|F| ≥ s\` extracts an \`s\`-clique via \`Finset.exists_subset_card_eq\`,
  otherwise \`|G| ≥ t\` extracts a \`t\`-clique.
* **Reverse (⇒).** Contrapositive on \`n ≤ s + t - 2\`. Build the worst-case
  coloring with \`a := min (s-1) n\` \`false\`-singletons and the rest \`true\`;
  bound clique cards via the globally-injective \`Fin.val\`:
    - false-clique image ⊆ \`Finset.range a\` ⇒ \`|S| ≤ a ≤ s - 1\`,
    - true-clique image ⊆ \`Finset.Ico a n\` (card \`n - a\` via \`Nat.card_Ico\`),
      and case-split on \`min\` gives \`n - a ≤ t - 1\`.

\`ramseyNumber_one\` then follows by \`Nat.sInf\` on the upward-closed set
\`{n | s + t - 1 ≤ n}\`.

## Metadata delta on \`Proofs/RamseyHypergraph.lean\`

| field | before (S2) | after (S3) |
| --- | --- | --- |
| lineCount | 147 | 304 |
| theoremCount | 6 | 7 |
| defCount | 4 | 4 |
| sorryCount | 2 | **1** (only \`ramsey_existence\` remains) |
| axiomCount | 0 | 0 |

## Next session

**S4 ACT-C — \`ramsey_existence\` (OQ-03a)** via the Ramsey 1930 two-layer
induction. Base case \`k = 2\` reuses the pigeonhole; inductive step is the
neighborhood collapse \`R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1\`.

## Build status

⚠️ **Build pending.** The worktree shares the broken \`proofs/.lake\` symlink
per memory \`feedback_researcher_lake_symlink_broken.md\`; a Docker build
\`./proofs/scripts/docker-build.sh Proofs.RamseyHypergraph\` is in flight
(~30-45 min Mathlib fresh-clone + cache get). All Mathlib API used is
long-stable (\`Finset.exists_subset_card_eq\`, \`Finset.card_image_of_injective\`,
\`Finset.filter_card_add_filter_neg_card_eq_card\`, \`Nat.card_Ico\`,
\`Nat.sInf_le\`, \`le_csInf\`), so build risk is low.

## Test plan

- [ ] Docker build \`./proofs/scripts/docker-build.sh Proofs.RamseyHypergraph\` succeeds.
- [ ] CI \`pnpm build\` passes (gallery JSON valid).
- [ ] No regression in dependent files (none — \`RamseyHypergraph.lean\` is leaf in S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)