### PR TITLE
fix(clt-oq02oq04): repair 3 Mathlib v4.26.0 drift sites

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -50,7 +50,7 @@ Per the S1/S2 plan, this file builds on the parent
 import Mathlib.MeasureTheory.Function.LpSpace.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.Set
 import Mathlib.Probability.IdentDistrib
-import Mathlib.Probability.Variance
+import Mathlib.Probability.Moments.Variance
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 import Proofs.CentralLimitTheoremOQ02
@@ -145,11 +145,11 @@ structure IbragimovHypotheses
 /-! ## Part II: Elementary summability helpers -/
 
 /-- *Polynomial summability* of `n^{-s}` for `s > 1`: the standard ζ-function
-fact, derived from Mathlib's `Real.summable_nat_rpow_inv`. -/
+fact, derived from Mathlib's `summable_nat_rpow_inv`. -/
 theorem polynomial_summable_of_exponent_gt_one (s : ℝ) (hs : 1 < s) :
     Summable (fun n : ℕ => (n : ℝ) ^ (-s)) := by
   have key : Summable (fun n : ℕ => ((n : ℝ) ^ s)⁻¹) :=
-    Real.summable_nat_rpow_inv.mpr hs
+    summable_nat_rpow_inv.mpr hs
   refine key.congr ?_
   intro n
   rcases Nat.eq_zero_or_pos n with hn | hn
@@ -430,16 +430,16 @@ Davydov/Bernstein infrastructure (S4–S6).
 -/
 theorem mixing_clt_ibragimov
     {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {X : ℕ → Ω → ℝ} {δ C r σ² : ℝ}
+    {X : ℕ → Ω → ℝ} {δ C r sigSq : ℝ}
     (_H : IbragimovHypotheses μ X δ C r)
-    (_hσ²_pos : 0 < σ²)
+    (_hsigSq_pos : 0 < sigSq)
     (t : ℝ) :
     Tendsto
       (fun n : ℕ =>
         ∫ ω, Complex.exp (Complex.I * (t : ℂ) *
           ((∑ k ∈ Finset.range n, X k ω) / Real.sqrt n : ℂ)) ∂μ)
       atTop
-      (𝓝 (Complex.exp (-(σ² : ℂ) * (t : ℂ)^2 / 2))) := by
+      (𝓝 (Complex.exp (-(sigSq : ℂ) * (t : ℂ)^2 / 2))) := by
   sorry
 
 end CentralLimitTheoremOQ02OQ04


### PR DESCRIPTION
## Summary

Three syntactic Mathlib v4.26.0 drift sites in `CentralLimitTheoremOQ02OQ04.lean` have been silently shipping in every `(build pending)` merge on this slug since S2 PR #17792. This PR extracts only the surgical drift fixes — 6 insertions / 6 deletions in one file — so any of the 4 in-flight research PRs can land their content on a buildable parent.

## Fixes

| Site | Pre-fix (broken) | Post-fix |
|------|------------------|----------|
| L53 import | `Mathlib.Probability.Variance` | `Mathlib.Probability.Moments.Variance` (file relocated upstream) |
| L152 API | `Real.summable_nat_rpow_inv.mpr hs` | `summable_nat_rpow_inv.mpr hs` (namespace flattened) |
| L433-442 binder | `σ²` identifier + `_hσ²_pos` | `sigSq` + `_hsigSq_pos` (U+00B2 no longer accepted as Lean identifier char) |

These three sites were enumerated by PR #17947 (currently CONFLICTING / DIRTY). That PR bundled the drift fixes with unverified S4 helper code (`alpha_term_le_two`) that the researcher self-identified as not compiling; this PR omits the experimental helper, leaving only the surgical drift fixes.

## Scope discipline

- One file changed (`CentralLimitTheoremOQ02OQ04.lean`)
- No theorem statements changed semantically — `σ²` → `sigSq` is a pure rename within the same `mixing_clt_ibragimov` binder + usages; the statement remains literally identical up to identifier choice
- No new theorems, lemmas, definitions, or imports beyond the Mathlib path correction
- meta.json untouched

## Strategic positioning

Currently open on this slug:
- #17810 (S3 — 5 stationarity/moment-bound bridge lemmas, build pending)
- #17826 (S3 ACT — Davydov discharge, build pending)
- #17943 (S4 prep — Davydov-independent helpers, build pending, DIRTY)
- #17947 (S4 partial — drift repair + alpha_term_le_two, DIRTY — supersedes its drift fixes via this PR)

After this lands, any of the above can rebase / land cleanly on top.

## Build status

Per mechanic constraint: docker build verification on host takes 45+ min (recursive `proofs/.lake` self-symlink forces fresh Mathlib clone + cache fetch every invocation). Build verification is deferred to CI / the next research PR that lands on top. Matches the "build pending" convention used by 5+ recent merges on this same file (#17792, #17810, #17826, etc).

The three drift fixes are syntactic Mathlib v4.26.0 corrections independently verified by the researcher who authored PR #17947 (see that PR's body for the typeclass-synthesis evidence on the third site).

---
Automated fix by lean-mechanic agent.