### PR TITLE
Enrich minpoly-charpoly-oq-03: canonicalize references schema (papers/urls → structured array) + namespace-setup annotation

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/annotations.json
@@ -42,6 +42,18 @@
     ]
   },
   {
+    "id": "ann-mcpoq03-namespace-setup",
+    "proofId": "minpoly-charpoly-oq-03",
+    "range": { "startLine": 108, "endLine": 118 },
+    "type": "context",
+    "title": "Namespace, Opens, Variables, and Part 1 Header",
+    "content": "Three single-line declarations bind the scope of the rest of the file:\n\n* `namespace MinpolyCharpolyOQ03` (L108): all subsequent declarations are scoped under this namespace; downstream files import as `MinpolyCharpolyOQ03.InvariantFactorChain`, `MinpolyCharpolyOQ03.rational_canonical_form_exists`, etc.\n* `open Matrix Polynomial BigOperators` (L110): exposes unqualified `Matrix.charpoly` as `charpoly`, polynomial-ring notation (e.g. `F[X]`), and `BigOperators` for `∏` / `∑` syntax used in `prodFactors`.\n* `variable {F : Type*} [Field F]` (L112): the field parameter applied implicitly to every declaration in the file. Choosing `Field F` (rather than `[CommRing F]` or `[IntegralDomain F]`) reflects that the structure theorem `Module.equiv_directSum_of_isTorsion` requires `F[X]` to be a PID — which holds iff `F` is a field.\n\nLines 114-118 begin Part 1 with a sectional comment block setting up the invariant-factor data definitions.",
+    "mathContext": "The `Field F` typeclass is the *minimal* base for RCF: weaker hypotheses (e.g. `CommRing F`) would not give a PID structure on `F[X]`, breaking the route via `Module.equiv_directSum_of_isTorsion`. Stronger hypotheses (e.g. `IsAlgClosed F`) are not needed — that's precisely the field-independence virtue of RCF over JNF.",
+    "significance": "supporting",
+    "relatedConcepts": ["namespace scoping", "open directive", "variable declarations", "Field typeclass", "F[X] is a PID iff F is a field"],
+    "prerequisites": ["Lean 4 namespace mechanics", "typeclass binding"]
+  },
+  {
     "id": "ann-mcpoq03-invariantchain",
     "proofId": "minpoly-charpoly-oq-03",
     "range": { "startLine": 113, "endLine": 137 },

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -190,14 +190,48 @@
     }
   ],
   "sorries": 1,
-  "references": {
-    "papers": [
-      "Frobenius, G. (1879). 'Theorie der linearen Formen mit ganzen Coefficienten.' Crelle's Journal, 86, 146-208.",
-      "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html",
-      "https://en.wikipedia.org/wiki/Frobenius_normal_form"
-    ]
-  }
+  "references": [
+    {
+      "authors": ["Frobenius, Georg"],
+      "year": 1879,
+      "title": "Theorie der linearen Formen mit ganzen Coefficienten",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 86, pp. 146-208",
+      "note": "Frobenius's original classification of matrices over a field up to similarity via the rational canonical form — the source result this scaffold targets."
+    },
+    {
+      "authors": ["Frobenius, Georg"],
+      "year": 1896,
+      "title": "Über die mit einer Matrix vertauschbaren Matrizen",
+      "venue": "Sitzungsberichte der Berliner Akademie",
+      "note": "Cited in the Lean module's References section. Frobenius's refinement establishing uniqueness of the invariant-factor chain."
+    },
+    {
+      "authors": ["Dummit, David S.", "Foote, Richard M."],
+      "year": 2004,
+      "title": "Abstract Algebra",
+      "venue": "John Wiley & Sons, 3rd edition, §12.2",
+      "note": "Modern textbook treatment of RCF via the structure theorem for finitely generated modules over a PID — the proof route this scaffold's S2+ sub-OQs will follow."
+    },
+    {
+      "authors": ["Hungerford, Thomas W."],
+      "year": 1974,
+      "title": "Algebra",
+      "venue": "Graduate Texts in Mathematics 73, Springer-Verlag, §VII.4",
+      "note": "Alternative graduate-level reference for the RCF / structure-theorem chain. Companion to Dummit-Foote."
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "year": 2024,
+      "title": "Mathlib4: Mathlib.Algebra.Module.PID",
+      "venue": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html",
+      "note": "Source of `Module.equiv_directSum_of_isTorsion` — the structure-theorem workhorse that OQ-03-OQ-02 will invoke."
+    },
+    {
+      "authors": ["Wikipedia"],
+      "year": 2025,
+      "title": "Frobenius normal form",
+      "venue": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
+      "note": "General-audience overview of the rational canonical form (a.k.a. Frobenius normal form), including the relationship to Jordan normal form over algebraically closed fields."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass on `minpoly-charpoly-oq-03` (quality 98, passes 0). Two focused fixes — one schema canonicalization, one coverage-gap annotation.

### Schema fix: `references`

The entry's `references` field used a non-canonical `{papers: string[], urls: string[]}` shape (one of only 5 entries gallery-wide doing this). Converted to the standard array-of-objects with `{authors, year, title, venue, note}`. The previous shape stored Frobenius 1879 and Dummit-Foote 2004 as prose strings rather than structured citations, making them invisible to any future reference-aggregation tooling.

Grew from 4 string entries (2 papers + 2 urls) to 6 structured entries:
- Frobenius 1879 (the source RCF result)
- Frobenius 1896 (cited in the Lean module's References section)
- Dummit-Foote 2004 §12.2 (modern textbook treatment via PID structure theorem)
- Hungerford 1974 §VII.4 (alternative graduate-level reference)
- Mathlib `Module.equiv_directSum_of_isTorsion` documentation
- Wikipedia overview of Frobenius normal form

### Coverage gap fix

`ann-mcpoq03-namespace-setup` (lines 108-118): annotates the `namespace MinpolyCharpolyOQ03`, `open Matrix Polynomial BigOperators`, `variable {F : Type*} [Field F]`, and the Part 1 section header — previously the gap between the docstring annotation (ending at line 80) and the InvariantFactorChain definition (starting at line 113). Notes why `Field F` is the *minimal-correct* typeclass: `F[X]` is a PID iff `F` is a field, so weaker hypotheses (e.g. `CommRing`) would break the route through `Module.equiv_directSum_of_isTorsion`, while stronger hypotheses (`IsAlgClosed`) are unnecessary thanks to RCF's field-independence.

## Scope

Documentation/schema only — no Lean source changes. JSON validates. `pnpm build` skipped per known Node v26 / `better-sqlite3` gyp issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)