### PR TITLE
Enrich perfect-numbers-oq-03: module-header annotation + Lucas-Lehmer context + schema fix

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-03/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-03/annotations.json
@@ -1,5 +1,33 @@
 [
   {
+    "id": "perfect-numbers-oq-03-module-header",
+    "proofId": "perfect-numbers-oq-03",
+    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "title": "Module Header: Historical Context and the Three Pillars",
+    "content": "The module docstring frames the proof's three pillars and their historical lineage:\n\n**(1) Necessity (18th century, Euler)**: $M(n)$ prime $\\Rightarrow n$ prime. The contrapositive ($n$ composite $\\Rightarrow M(n)$ composite) follows directly from the factoring identity. Euler used this to enumerate even perfect numbers up to $M(31)$ in his 1747 manuscript *De numeris amicabilibus*, and the same identity underlies modern Mersenne-prime searches.\n\n**(2) Lucas Congruence (Lucas 1876)**: If a prime $q$ divides $M(p) = 2^p - 1$ with $p$ prime, then $p \\mid q - 1$. This is the heart of the **Lucas–Lehmer primality test** (Lucas 1878, refined by Lehmer 1930), which has discovered *all* known Mersenne primes since the 1950s — including the current record $M(136279841)$ discovered by GIMPS in October 2024 (the 52nd known Mersenne prime). Without the Lucas congruence, one would need to trial-divide $M(p)$ by every prime up to $\\sqrt{M(p)} \\approx 2^{p/2}$, which is computationally infeasible for $p > 50$; the congruence restricts candidate divisors to those $\\equiv 1 \\pmod p$, slashing the search space by a factor of $\\sim p$.\n\n**(3) LPW Conjecture (Lenstra–Pomerance–Wagstaff, 1980s)**: The expected count of Mersenne primes with exponent $\\le N$ is $\\sim (e^\\gamma/\\log 2) \\cdot \\log \\log N$. The constant $e^\\gamma/\\log 2 \\approx 2.5695$ encodes both the prime number theorem (via the $\\log$) and the conditional probability that a random integer near $M(p)$ is prime (giving the $\\log \\log$ second factor). The conjecture is consistent with the 51 (now 52) known Mersenne primes but is currently far from provable.\n\nThe formalization deliberately states LPW as a `def : Prop` rather than an `axiom`, preserving `axiomCount = 0` while making the conjecture mechanically expressible. This is a reusable pattern for unproved conjectures in Lean: the proposition can be referenced in downstream lemmas (as a hypothesis) without committing to its truth.",
+    "mathContext": "Three nested results: (i) $M(n)\\text{ prime} \\Rightarrow n\\text{ prime}$ (necessary condition on exponent); (ii) $q\\text{ prime}, q \\mid M(p) \\Rightarrow p \\mid q - 1$ (Lucas 1876; underlies Lucas–Lehmer test); (iii) $|\\{p \\le N : M(p)\\text{ prime}\\}| \\sim (e^\\gamma/\\log 2)\\,\\log \\log N$ (LPW conjecture, open).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler 1747 — De numeris amicabilibus",
+      "Lucas–Lehmer primality test",
+      "GIMPS (Great Internet Mersenne Prime Search)",
+      "Lenstra–Pomerance–Wagstaff heuristic",
+      "Euler–Mascheroni constant γ",
+      "axiom-free encoding of open conjectures",
+      "M(136279841) (2024 record)"
+    ],
+    "prerequisites": [
+      "Mersenne primes and perfect numbers",
+      "Lucas–Lehmer test (historical context)",
+      "Filter.atTop asymptotics in Lean 4",
+      "axiom-free formalization conventions"
+    ]
+  },
+  {
     "id": "perfect-numbers-oq-03-mersenne-def",
     "proofId": "perfect-numbers-oq-03",
     "type": "definition",

--- a/src/data/proofs/perfect-numbers-oq-03/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-03/meta.json
@@ -46,17 +46,20 @@
       "**Sparsity Evidence**: M(11) = 2047 = 23 × 89 shows that even when p is prime, M(p) may be composite (the factor 23 ≡ 1 (mod 11) per the Lucas congruence)."
     ],
     "prerequisites": [
-      "Mersenne primes and perfect numbers",
-      "Multiplicative order in ZMod",
-      "Fermat's little theorem",
-      "Divisibility in natural numbers"
+      "Mersenne primes and the Euclid–Euler theorem (perfect numbers ↔ Mersenne primes)",
+      "Multiplicative order of an element in $(\\mathbb{Z}/q\\mathbb{Z})^\\times$",
+      "Fermat's little theorem: $a^{q-1} \\equiv 1 \\pmod q$ for $\\gcd(a, q) = 1$",
+      "Divisibility in $\\mathbb{N}$ and the factoring identity $x^a - 1 \\mid x^b - 1$ when $a \\mid b$",
+      "ZMod and `Nat.Prime` API in Mathlib (`ZMod.orderOf_dvd_of_pow_eq_one`)",
+      "`Filter.atTop` asymptotic notation in Lean 4 (used to state LPWConjecture)",
+      "Euler–Mascheroni constant $\\gamma \\approx 0.5772$ (appears in LPW constant $e^\\gamma/\\log 2$)"
     ]
   },
   "crossReferences": [
     {
-      "targetId": "perfect-numbers",
+      "proofId": "perfect-numbers",
       "relationship": "extends",
-      "description": "Parent formalization proving the Euclid-Euler theorem connecting perfect numbers and Mersenne primes"
+      "description": "Parent formalization proving the Euclid–Euler theorem: an even number is perfect iff it has the form $2^{p-1}(2^p - 1)$ with $2^p - 1$ prime. This file refines the parent's Mersenne-prime side by adding the two necessary conditions (exponent primality, Lucas factor congruence) and the LPW density conjecture."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Three targeted enrichments for **perfect-numbers-oq-03** (Mersenne primes — necessity, Lucas congruence, LPW conjecture).

### 1. NEW annotation `perfect-numbers-oq-03-module-header` (lines 1–43)

Module-level annotation framing the three historical pillars and *why each matters computationally*, none of which previously had a dedicated annotation:

- **Euler 1747** (*De numeris amicabilibus*) for the necessity direction
- **Lucas 1876 + Lehmer 1930** for the factor congruence — the heart of the Lucas–Lehmer primality test, which has discovered *every* known Mersenne prime since the 1950s, including the current record **M(136279841)** discovered by GIMPS in October 2024 (52nd known). The annotation explains *why* the congruence is computationally vital: it restricts trial divisors of $M(p)$ to those $\equiv 1 \pmod p$, slashing the search space by $\sim p$ — making primality testing for $p > 50$ feasible.
- **Lenstra–Pomerance–Wagstaff 1980s** for the asymptotic density $\sim (e^\gamma/\log 2)\,\log\log N \approx 2.5695\,\log\log N$
- The reusable `def : Prop` pattern for axiom-free encoding of open conjectures

### 2. `prerequisites` expansion (4 → 7 items)

Adds Euclid–Euler framing, the factoring identity $x^a - 1 \mid x^b - 1$, `ZMod.orderOf_dvd_of_pow_eq_one`, `Filter.atTop`, and Euler–Mascheroni γ.

### 3. `crossReferences[0]` schema normalization

`targetId` → `proofId` (preferred field name; `targetId` is a legacy alias per the Proof type — non-behavioral fix).

### Verification

- `JSON.parse` clean
- `tsx scripts/annotations/build.ts` exit 0; zero errors for this slug (7 anchors all resolve)
- `tsx scripts/research/build.ts` exit 0
- `tsc -b` exit 0
- Diff scope: 2 files, +37/-6 lines

## Test plan
- [x] JSON parse
- [x] annotations:build resolves all anchors for this slug
- [x] research:build OK
- [x] tsc -b OK