### PR TITLE
Enrich pascals-hexagon-oq-03: add mathContext/significance/relatedConcepts/prerequisites to 9 annotations

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03/annotations.json
+++ b/src/data/proofs/pascals-hexagon-oq-03/annotations.json
@@ -8,7 +8,22 @@
     },
     "type": "context",
     "title": "Import Stack: Group Theory + Fintype + Parent File",
-    "content": "Nine imports stage the four ingredients of the Hexagrammum Mysticum scaffold:\n\n* **Fintype.Card / Fintype.Perm**: for `card_sym6 = 720` via `native_decide`. Mathlib's `Fintype.card_perm` gives `|Equiv.Perm α| = (Fintype.card α)!`.\n* **Fin.Basic**: for `Fin.rev` and `Fin.rev_rev` — the involutive reversal used to construct `hexRev`.\n* **QuotientGroup.Basic**: for the `Sym(6) ⧸ hexagonalGroup` quotient and Lagrange's theorem `Subgroup.card_eq_card_quotient_mul_card_subgroup`.\n* **SpecificGroups.Dihedral**: for `DihedralGroup 6` — reference target for the OQ-03-OQ-01 isomorphism strategy.\n* **Subgroup.Basic**: for `Subgroup.closure` and the generator-membership lemmas.\n* **Logic.Equiv.Fin**: for `finRotate 6` — the canonical cyclic-rotation `Equiv.Perm (Fin 6)`.\n* **Proofs.PascalsHexagon**: the parent file providing `Conic`, `InscribedHexagon`, `ProjPoint`, `ProjLine`, `pointOnLine`, `lineThrough`, `lineIntersection`, `pascalP/Q/R`, and `pascal_hexagon_theorem`."
+    "content": "Nine imports stage the four ingredients of the Hexagrammum Mysticum scaffold:\n\n* **Fintype.Card / Fintype.Perm**: for `card_sym6 = 720` via `native_decide`. Mathlib's `Fintype.card_perm` gives `|Equiv.Perm α| = (Fintype.card α)!`.\n* **Fin.Basic**: for `Fin.rev` and `Fin.rev_rev` — the involutive reversal used to construct `hexRev`.\n* **QuotientGroup.Basic**: for the `Sym(6) ⧸ hexagonalGroup` quotient and Lagrange's theorem `Subgroup.card_eq_card_quotient_mul_card_subgroup`.\n* **SpecificGroups.Dihedral**: for `DihedralGroup 6` — reference target for the OQ-03-OQ-01 isomorphism strategy.\n* **Subgroup.Basic**: for `Subgroup.closure` and the generator-membership lemmas.\n* **Logic.Equiv.Fin**: for `finRotate 6` — the canonical cyclic-rotation `Equiv.Perm (Fin 6)`.\n* **Proofs.PascalsHexagon**: the parent file providing `Conic`, `InscribedHexagon`, `ProjPoint`, `ProjLine`, `pointOnLine`, `lineThrough`, `lineIntersection`, `pascalP/Q/R`, and `pascal_hexagon_theorem`.",
+    "mathContext": "Backbone identity: $\\mathrm{Sym}(6) \\cong S_6$ with $|S_6| = 6! = 720$, $D_6 \\le S_6$ with $|D_6| = 12$, and $|S_6 / D_6| = 720 / 12 = 60$ by Lagrange's theorem $|G| = |G/H| \\cdot |H|$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "symmetric group",
+      "dihedral group",
+      "subgroup closure",
+      "quotient group",
+      "Lagrange's theorem",
+      "Pascal's theorem"
+    ],
+    "prerequisites": [
+      "finite group theory",
+      "Mathlib group-theory hierarchy",
+      "Pascal's theorem (parent file)"
+    ]
   },
   {
     "id": "ann-phex-oq03-hexRot",
@@ -19,7 +34,20 @@
     },
     "type": "definition",
     "title": "hexRot: Cyclic Rotation of Fin 6",
-    "content": "`hexRot := finRotate 6 : Equiv.Perm (Fin 6)` realises the cyclic-rotation generator of the dihedral group D_6 ↪ Sym(6). Mathlib's `finRotate n` is the permutation `i ↦ i + 1 (mod n)`, fully constructive, with all involutive/cyclic properties already proved (`finRotate_zero`, `finRotate_succ_apply`, etc.). Choosing `finRotate` over an ad-hoc definition means the OQ-03-OQ-01 cardinality proof can rely on Mathlib's existing API for cyclic rotations rather than re-deriving rotation lemmas."
+    "content": "`hexRot := finRotate 6 : Equiv.Perm (Fin 6)` realises the cyclic-rotation generator of the dihedral group D_6 ↪ Sym(6). Mathlib's `finRotate n` is the permutation `i ↦ i + 1 (mod n)`, fully constructive, with all involutive/cyclic properties already proved (`finRotate_zero`, `finRotate_succ_apply`, etc.). Choosing `finRotate` over an ad-hoc definition means the OQ-03-OQ-01 cardinality proof can rely on Mathlib's existing API for cyclic rotations rather than re-deriving rotation lemmas.",
+    "mathContext": "The rotation generator $\\rho \\in S_6$ with $\\rho(i) = i + 1 \\pmod 6$. As an element of $D_6$ it has order 6: $\\rho^6 = 1$ and $\\rho^k \\ne 1$ for $1 \\le k \\le 5$. Cycle notation: $\\rho = (0\\,1\\,2\\,3\\,4\\,5)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclic group $\\mathbb{Z}/6\\mathbb{Z}$",
+      "permutation cycle structure",
+      "rotation symmetry of the hexagon",
+      "Mathlib finRotate API"
+    ],
+    "prerequisites": [
+      "Equiv.Perm",
+      "modular arithmetic on Fin n",
+      "Mathlib Logic.Equiv.Fin"
+    ]
   },
   {
     "id": "ann-phex-oq03-hexRev",
@@ -30,7 +58,21 @@
     },
     "type": "definition",
     "title": "hexRev: Reversal i ↦ 5 - i",
-    "content": "`hexRev` is built directly as an `Equiv.Perm (Fin 6)` structure literal with `toFun := Fin.rev`, `invFun := Fin.rev`, and both `left_inv` and `right_inv` discharged by `Fin.rev_rev` (a single Mathlib lemma asserting `i.rev.rev = i`). On `Fin 6`, `Fin.rev i = ⟨5 - i.val, ...⟩`, so `hexRev` swaps `(0, 5)`, `(1, 4)`, and `(2, 3)`. This is the reflection generator of `D_6 ↪ Sym(6)`. The choice of `Fin.rev` over a hand-rolled `omega`-proof is deliberate: the involutive proof reduces to a single named Mathlib lemma rather than an `ext`+`omega` chain."
+    "content": "`hexRev` is built directly as an `Equiv.Perm (Fin 6)` structure literal with `toFun := Fin.rev`, `invFun := Fin.rev`, and both `left_inv` and `right_inv` discharged by `Fin.rev_rev` (a single Mathlib lemma asserting `i.rev.rev = i`). On `Fin 6`, `Fin.rev i = ⟨5 - i.val, ...⟩`, so `hexRev` swaps `(0, 5)`, `(1, 4)`, and `(2, 3)`. This is the reflection generator of `D_6 ↪ Sym(6)`. The choice of `Fin.rev` over a hand-rolled `omega`-proof is deliberate: the involutive proof reduces to a single named Mathlib lemma rather than an `ext`+`omega` chain.",
+    "mathContext": "The reflection generator $\\sigma \\in S_6$ with $\\sigma(i) = 5 - i$. As an involution: $\\sigma^2 = 1$. Cycle notation: $\\sigma = (0\\,5)(1\\,4)(2\\,3)$. With $\\rho$ it satisfies the dihedral relation $\\sigma \\rho \\sigma = \\rho^{-1}$, so $\\langle \\rho, \\sigma \\rangle \\cong D_6$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "involution",
+      "reflection symmetry",
+      "dihedral group generator",
+      "Mathlib Fin.rev",
+      "structure literal vs ext+omega"
+    ],
+    "prerequisites": [
+      "Equiv.Perm",
+      "Fin.rev / Fin.rev_rev",
+      "involution definition"
+    ]
   },
   {
     "id": "ann-phex-oq03-hexagonalGroup",
@@ -41,7 +83,21 @@
     },
     "type": "definition",
     "title": "hexagonalGroup: The Dihedral Subgroup of Sym(6)",
-    "content": "`hexagonalGroup := Subgroup.closure {hexRot, hexRev}` is the smallest subgroup of `Sym(6) = Equiv.Perm (Fin 6)` containing the cyclic-rotation and reversal generators. It is isomorphic to Mathlib's `DihedralGroup 6` of order 12. The OQ-03-OQ-01 sorry establishes `Nat.card hexagonalGroup = 12` by exhibiting a `MonoidHom` from `DihedralGroup 6` to this closure (using the universal property of `DihedralGroup` via its dihedral relations) and proving the homomorphism is injective. Alternative S2 strategy: directly enumerate the 12 elements as `{ρ^k σ^ε : k ∈ Fin 6, ε ∈ Fin 2}` and verify each lies in the closure via `Subgroup.subset_closure` + `Subgroup.mul_mem`."
+    "content": "`hexagonalGroup := Subgroup.closure {hexRot, hexRev}` is the smallest subgroup of `Sym(6) = Equiv.Perm (Fin 6)` containing the cyclic-rotation and reversal generators. It is isomorphic to Mathlib's `DihedralGroup 6` of order 12. The OQ-03-OQ-01 sorry establishes `Nat.card hexagonalGroup = 12` by exhibiting a `MonoidHom` from `DihedralGroup 6` to this closure (using the universal property of `DihedralGroup` via its dihedral relations) and proving the homomorphism is injective. Alternative S2 strategy: directly enumerate the 12 elements as `{ρ^k σ^ε : k ∈ Fin 6, ε ∈ Fin 2}` and verify each lies in the closure via `Subgroup.subset_closure` + `Subgroup.mul_mem`.",
+    "mathContext": "Presentation: $D_6 = \\langle \\rho, \\sigma \\mid \\rho^6 = \\sigma^2 = 1,\\ \\sigma \\rho \\sigma = \\rho^{-1} \\rangle$, order 12. As a subgroup of $S_6$: $\\langle \\rho, \\sigma \\rangle = \\{\\rho^k, \\rho^k \\sigma : 0 \\le k \\le 5\\}$. Index $[S_6 : D_6] = 60$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dihedral group of order 12",
+      "subgroup closure",
+      "group presentation by generators and relations",
+      "DihedralGroup 6 in Mathlib",
+      "MonoidHom injectivity"
+    ],
+    "prerequisites": [
+      "subgroup closure",
+      "dihedral group presentation",
+      "Subgroup.mul_mem / Subgroup.subset_closure"
+    ]
   },
   {
     "id": "ann-phex-oq03-hexagonLabeling",
@@ -52,7 +108,21 @@
     },
     "type": "definition",
     "title": "HexagonLabeling: Sym(6) ⧸ D_6",
-    "content": "`HexagonLabeling := Equiv.Perm (Fin 6) ⧸ hexagonalGroup` packages the 60 distinct hexagonal labelings as cosets of the dihedral subgroup. The `abbrev` declaration means downstream definitions can use `HexagonLabeling` directly without unfolding. The cardinality `Nat.card HexagonLabeling = 60` follows from `card_sym6 = 720` (Fintype, proved unconditionally) and `card_hexagonalGroup = 12` (OQ-03-OQ-01 sorry) via Lagrange's theorem `Subgroup.card_eq_card_quotient_mul_card_subgroup`."
+    "content": "`HexagonLabeling := Equiv.Perm (Fin 6) ⧸ hexagonalGroup` packages the 60 distinct hexagonal labelings as cosets of the dihedral subgroup. The `abbrev` declaration means downstream definitions can use `HexagonLabeling` directly without unfolding. The cardinality `Nat.card HexagonLabeling = 60` follows from `card_sym6 = 720` (Fintype, proved unconditionally) and `card_hexagonalGroup = 12` (OQ-03-OQ-01 sorry) via Lagrange's theorem `Subgroup.card_eq_card_quotient_mul_card_subgroup`.",
+    "mathContext": "Quotient $S_6 / D_6$ of left cosets, with $|S_6 / D_6| = |S_6| / |D_6| = 720 / 12 = 60$ by Lagrange. Each coset is a $D_6$-orbit under left multiplication, i.e. a class of hexagonal labelings agreeing modulo cyclic rotation and reversal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quotient group",
+      "left coset space",
+      "Lagrange's theorem",
+      "group action",
+      "orbit-stabilizer relation"
+    ],
+    "prerequisites": [
+      "quotient groups (Mathlib QuotientGroup)",
+      "Lagrange's theorem",
+      "Subgroup.card_eq_card_quotient_mul_card_subgroup"
+    ]
   },
   {
     "id": "ann-phex-oq03-card-sym6",
@@ -63,7 +133,21 @@
     },
     "type": "theorem",
     "title": "card_sym6: |Sym(6)| = 720 (Unconditional)",
-    "content": "Single-line `native_decide` proof using `Fintype.card_perm` + `Fintype.card_fin` + factorial reduction. The same pattern appears in `Proofs/AbelRuffiniGaloisExtensions.lean` line 314 (`card_s6 : Fintype.card (Equiv.Perm (Fin 6)) = 720`), confirming this idiom is established in the gallery."
+    "content": "Single-line `native_decide` proof using `Fintype.card_perm` + `Fintype.card_fin` + factorial reduction. The same pattern appears in `Proofs/AbelRuffiniGaloisExtensions.lean` line 314 (`card_s6 : Fintype.card (Equiv.Perm (Fin 6)) = 720`), confirming this idiom is established in the gallery.",
+    "mathContext": "$|S_6| = 6! = 720$. General formula: $|\\mathrm{Sym}(\\alpha)| = (|\\alpha|)!$ for any finite type $\\alpha$, applied here with $\\alpha = \\mathrm{Fin}\\ 6$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factorial function",
+      "permutation count",
+      "Fintype.card",
+      "native_decide tactic",
+      "Mathlib Fintype.card_perm"
+    ],
+    "prerequisites": [
+      "Fintype instance on Equiv.Perm",
+      "factorial of 6",
+      "native_decide / kernel computation"
+    ]
   },
   {
     "id": "ann-phex-oq03-pascal-line",
@@ -74,7 +158,22 @@
     },
     "type": "theorem",
     "title": "pascalLine: Pascal-Line Map from HexagonLabeling (OQ-03-OQ-02)",
-    "content": "`pascalLine : Conic → InscribedHexagon → HexagonLabeling → ProjLine` is the central scaffold-stage operation: given a labeling, the Pascal line of the permuted hexagon. Its full definition + well-definedness on the `Sym(6) ⧸ D_6` quotient is deferred to OQ-03-OQ-02. The well-definedness argument: cyclic rotation of `(A, B, C, D, E, F)` cyclically permutes `(pascalP, pascalQ, pascalR)`, preserving the line they span; reversal swaps two of the three Pascal points, again preserving collinearity. Both `hexRot` and `hexRev` therefore act trivially on the Pascal line, so the quotient by `⟨hexRot, hexRev⟩` is well-defined.\n\nThe trivial existence statement `hexagrammum_mysticum_pascal_lines` (line 215) packages this as `∃ lines, lines = pascalLine C hex` — the meaningful content is in the sorry-guarded `pascalLine` definition itself."
+    "content": "`pascalLine : Conic → InscribedHexagon → HexagonLabeling → ProjLine` is the central scaffold-stage operation: given a labeling, the Pascal line of the permuted hexagon. Its full definition + well-definedness on the `Sym(6) ⧸ D_6` quotient is deferred to OQ-03-OQ-02. The well-definedness argument: cyclic rotation of `(A, B, C, D, E, F)` cyclically permutes `(pascalP, pascalQ, pascalR)`, preserving the line they span; reversal swaps two of the three Pascal points, again preserving collinearity. Both `hexRot` and `hexRev` therefore act trivially on the Pascal line, so the quotient by `⟨hexRot, hexRev⟩` is well-defined.\n\nThe trivial existence statement `hexagrammum_mysticum_pascal_lines` (line 215) packages this as `∃ lines, lines = pascalLine C hex` — the meaningful content is in the sorry-guarded `pascalLine` definition itself.",
+    "mathContext": "$\\mathrm{pascalLine} : \\mathcal{C} \\to \\mathrm{InscribedHexagon}(\\mathcal{C}) \\to (S_6 / D_6) \\to \\mathbb{P}^1$. Quotient well-definedness: for all $g \\in D_6$, $\\mathrm{pascalLine}(C, h, g \\cdot \\pi) = \\mathrm{pascalLine}(C, h, \\pi)$. The Pascal triple $(P, Q, R)$ is the multiset $\\{AB \\cap DE,\\ BC \\cap EF,\\ CD \\cap FA\\}$; $\\rho$ permutes it cyclically and $\\sigma$ swaps two members, both preserving the line they span.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's theorem",
+      "projective line in $\\mathbb{P}^2$",
+      "quotient lift via Quotient.liftOn",
+      "well-defined function on cosets",
+      "D_6 action on Pascal triples"
+    ],
+    "prerequisites": [
+      "Pascal's theorem (parent file)",
+      "Quotient.liftOn / QuotientGroup.lift",
+      "projective incidence geometry",
+      "group action on a function's domain"
+    ]
   },
   {
     "id": "ann-phex-oq03-steiner",
@@ -85,7 +184,23 @@
     },
     "type": "theorem",
     "title": "SteinerPoint Structure and 20-Count (OQ-03-OQ-03)",
-    "content": "`SteinerPoint C hex` packages four pieces of data: the concurrence `point : ProjPoint`, the 3-element `triple : Finset HexagonLabeling`, the `card_triple : triple.card = 3` proof, and the `on_lines : ∀ lbl ∈ triple, pointOnLine point (pascalLine C hex lbl)` concurrence proof. This structure forces S2+ to produce concrete Steiner points rather than abstract existence claims.\n\n`steiner_count_eq_20`: six points on a non-degenerate conic determine exactly 20 Steiner points. The OQ-03-OQ-03 sorry proof strategy enumerates the 20 Steiner triples as a `Finset (Finset HexagonLabeling)`, proves concurrence for one representative triple via the Cayley-Bacharach axiom (a pair of degenerate cubics meeting in 9 points, 6 on the conic, 3 forming the Steiner point), and deduces the remaining 19 by `S_6`-symmetry."
+    "content": "`SteinerPoint C hex` packages four pieces of data: the concurrence `point : ProjPoint`, the 3-element `triple : Finset HexagonLabeling`, the `card_triple : triple.card = 3` proof, and the `on_lines : ∀ lbl ∈ triple, pointOnLine point (pascalLine C hex lbl)` concurrence proof. This structure forces S2+ to produce concrete Steiner points rather than abstract existence claims.\n\n`steiner_count_eq_20`: six points on a non-degenerate conic determine exactly 20 Steiner points. The OQ-03-OQ-03 sorry proof strategy enumerates the 20 Steiner triples as a `Finset (Finset HexagonLabeling)`, proves concurrence for one representative triple via the Cayley-Bacharach axiom (a pair of degenerate cubics meeting in 9 points, 6 on the conic, 3 forming the Steiner point), and deduces the remaining 19 by `S_6`-symmetry.",
+    "mathContext": "$|\\{\\text{Steiner points of an inscribed hexagon}\\}| = 20$. Each Steiner point $S$ lies on exactly 3 of the 60 Pascal lines and corresponds to a 3-element subset $\\{\\ell_1, \\ell_2, \\ell_3\\} \\subset \\mathbb{P}^1$ of Pascal lines that are concurrent at $S$. Cayley-Bacharach setup: two cubics $C_1, C_2$ through 9 points; if 6 lie on a conic, the other 3 are collinear — and conversely, for the Steiner case, concurrent at a single Steiner point.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Steiner point (Steiner 1827)",
+      "Cayley-Bacharach theorem (Cayley 1849)",
+      "concurrent line bundle",
+      "cubic curve degeneration",
+      "incidence geometry of $\\mathbb{P}^2$",
+      "structure-encoded data + proof packaging"
+    ],
+    "prerequisites": [
+      "Pascal's theorem",
+      "Cayley-Bacharach theorem (or coordinate computation in $\\mathbb{P}^2$)",
+      "Finset enumeration of 3-subsets",
+      "projective concurrence pointOnLine"
+    ]
   },
   {
     "id": "ann-phex-oq03-kirkman",
@@ -96,6 +211,22 @@
     },
     "type": "theorem",
     "title": "KirkmanPoint Structure and 60-Count (OQ-03-OQ-04)",
-    "content": "`KirkmanPoint C hex` mirrors `SteinerPoint` in shape but encodes a combinatorially distinct family of concurrence triples. The 60 Kirkman points correspond to a different orbit structure on the 60 Pascal lines than the 20 Steiner points. Conway-Ryba 2012 documents the explicit Kirkman-triple enumeration via the outer automorphism of S_6: each Kirkman triple is parameterized by a 'syntheme' (a partition of 6 into three pairs) together with a 'duad' (an unordered pair), giving 15 × 4 = 60 Kirkman triples in total. The OQ-03-OQ-04 sorry follows the same Cayley-Bacharach concurrence pattern as OQ-03-OQ-03 with different triple combinatorics."
+    "content": "`KirkmanPoint C hex` mirrors `SteinerPoint` in shape but encodes a combinatorially distinct family of concurrence triples. The 60 Kirkman points correspond to a different orbit structure on the 60 Pascal lines than the 20 Steiner points. Conway-Ryba 2012 documents the explicit Kirkman-triple enumeration via the outer automorphism of S_6: each Kirkman triple is parameterized by a 'syntheme' (a partition of 6 into three pairs) together with a 'duad' (an unordered pair), giving 15 × 4 = 60 Kirkman triples in total. The OQ-03-OQ-04 sorry follows the same Cayley-Bacharach concurrence pattern as OQ-03-OQ-03 with different triple combinatorics.",
+    "mathContext": "$|\\{\\text{Kirkman points}\\}| = 60$. A syntheme is a partition of $\\{1,\\ldots,6\\}$ into three unordered pairs (a perfect matching of $K_6$); there are $\\frac{1}{3!} \\binom{6}{2}\\binom{4}{2}\\binom{2}{2} = 15$ synthemes. A duad is an unordered pair of $\\{1,\\ldots,6\\}$; each syntheme is compatible with exactly 4 duads. Total: $15 \\times 4 = 60$ Kirkman triples, in bijection with the 60 Kirkman points.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kirkman point (Kirkman 1849)",
+      "outer automorphism of $S_6$",
+      "syntheme",
+      "duad",
+      "Conway-Ryba 2012 enumeration",
+      "$K_6$ perfect matchings"
+    ],
+    "prerequisites": [
+      "Pascal's theorem",
+      "Cayley-Bacharach theorem",
+      "$S_6$ exceptional outer automorphism (or direct enumeration)",
+      "combinatorial design theory"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds the four enrichment fields (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`) — called out in the enricher role spec as the standard quality target — to every one of the 9 existing annotations in the Hexagrammum Mysticum S1 scaffold (`pascals-hexagon-oq-03`).

### What changed

| Annotation | mathContext highlight | significance |
|---|---|---|
| Imports | $\|S_6\| = 720$, $\|D_6\| = 12$, $\|S_6/D_6\| = 60$ | context |
| hexRot | $\rho(i) = i + 1 \pmod 6$, $\rho = (0\,1\,2\,3\,4\,5)$, $\rho^6 = 1$ | key |
| hexRev | $\sigma(i) = 5 - i$, $\sigma = (0\,5)(1\,4)(2\,3)$, $\sigma\rho\sigma = \rho^{-1}$ | key |
| hexagonalGroup | $D_6$ presentation, $\{\rho^k, \rho^k\sigma : 0 \le k \le 5\}$, $[S_6:D_6]=60$ | key |
| HexagonLabeling | Lagrange: $\|S_6/D_6\| = 720/12 = 60$ | key |
| card_sym6 | $\|S_6\| = 6! = 720$ from $\|\text{Sym}(\alpha)\| = (\|\alpha\|)!$ | supporting |
| pascalLine | Quotient lift, $D_6$-action on Pascal triple $(P,Q,R)$ | key |
| SteinerPoint | Cayley-Bacharach: two cubics, 9 points, 6 on conic | key |
| KirkmanPoint | Conway-Ryba syntheme-duad: $15 \times 4 = 60$ | key |

`relatedConcepts` arrays cross-link to: $S_6$ outer automorphism, $K_6$ perfect matchings, cubic curve degeneration, MonoidHom injectivity, Quotient.liftOn, orbit-stabilizer, etc. `prerequisites` arrays list the Mathlib/math background needed for each annotation.

### Scope

Single-file change to `annotations.json` only — no Lean source changes, no meta.json schema changes, no new annotations added.

### Complementary to PR #17953

PR #17953 (open) adds 4 **new** annotations covering gap line ranges (docstring 12-109, card_hexagonalGroup 172-180, card_hexagon_labelings 182-190, sanity lemmas 278-289). This PR **modifies existing 9 annotations** on different ranges — the two are on intersecting JSON but conceptually orthogonal: one adds coverage, this one deepens quality. Whichever merges second will need a trivial rebase.

### Validation

- `python3 json.load` passes; all 9 annotations have the 4 new fields.
- Full `pnpm build` skipped per memory `enricher_pnpm_build_bypass` (Node v26 / better-sqlite3 gyp hang); CI will run the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)