### PR TITLE
audit(tracker): sync 7 entries — clean batch (2026-05-12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2162,9 +2162,9 @@
       "result": "clean"
     },
     "combinations-formula-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-12T05:52:27Z",
+      "lastAudited": "2026-05-12T07:38:17Z",
       "result": "clean"
     },
     "continuum-hypothesis": {
@@ -15116,6 +15116,42 @@
     "angle-trisection-oq-05-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-05-12T06:48:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-01-oq-03-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:40:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:40:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-02-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:42:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minpoly-charpoly-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:42:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pascals-hexagon-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:43:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spherical-law-of-cosines-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T07:43:51Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Tracker sync for 7 audit completions on 2026-05-12.

- **combinations-formula-oq-02** (re-audit, clean) — Aristotle companion file has 1 `sorry` on `catalan_mul_succ` which the main file proves cleanly at `CombinationsFormulaOQ02.lean:112`. The companion sorry is a proof-search target, not a dependency. 6th consecutive "clean" audit for the same false-positive flag.
- **cantors-theorem-oq-01-oq-03-oq-04** (fresh, clean) — 0 sorries, 0 axioms, 6 theorems; one-line generalisation of parent's `cf_powerSet_real_gt_continuum`. Badge `mathlib`, status `verified` consistent.
- **lagrange-theorem-oq-02-oq-02-oq-01** (fresh, clean) — Burnside's Lemma from conjugation-action class equation; 0/0, badge `mathlib`. Honest title.
- **mean-value-theorem-oq-02-oq-04-oq-01** (fresh, clean) — Refutes parent OQ-04 axiom via Runge counterexample; 1 sorry on corrected complex-disk version (deferred to S2). Status `axiomatized` properly reflects this.
- **minpoly-charpoly-oq-03** (fresh, clean) — Rational canonical form S1 scaffold; 1 sorry on main existence theorem, status `formalized`. Title labels it `(S1 Scaffold)`.
- **pascals-hexagon-oq-03** (fresh, clean) — Hexagrammum Mysticum S1 scaffold; 5 sorries listed explicitly in `assumptions`; status `formalized`. Title labels it `(S1 Scaffold)`. Minor: definitionCount drift (meta 5 vs actual 7, missing 2 `structure` declarations) — non-integrity hygiene only.
- **spherical-law-of-cosines-oq-05** (fresh, clean) — Haversine formula; 0/0/15. Description text slightly stale (still mentions an S1 sorry that S2 closed) — minor enrichment drift.

Gallery status after this PR: **2417/2417 audited**, 1 remaining flag (the combinations-formula-oq-02 Aristotle-companion false positive — known recurring issue).

## Test plan

- [x] All 7 completions verified against on-disk Lean: sorry counts, axiom counts, theorem counts match (using documented `@[simp]`-aware convention) for the integrity-critical fields.
- [x] No status claims overstate reality; scaffold/axiomatized entries clearly labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)