### PR TITLE
research(erdos-szekeres-oq-03): S4-prep — color-swap symmetry + degenerate-side base cases (build pending)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -148,4 +148,62 @@ theorem ramseyNumber_one (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
     ramseyNumber 1 s t = s + t - 1 := by
   sorry
 
+/-! ### S4-prep: color symmetry and degenerate-side `ramseyNumber` base cases
+
+The following three lemmas extend the API surface for S4 (the
+`ramsey_existence` two-layer induction). They are independent of the
+`ramseyNumber_one`/`isRamsey_one_iff` machinery developed in S3 — they
+follow directly from the S2 definitions and the `is_ramsey_zero_*`
+degenerate base cases.
+
+* `IsRamsey.swap` — the Ramsey condition is symmetric in `(s, t)` because
+  negating a coloring swaps the two color targets. Needed in S4 to halve
+  the induction (only one side of the recursive bound needs treatment).
+* `ramseyNumber_zero_false` / `ramseyNumber_zero_true` — when one
+  target size is zero, the empty set is a witness, so `ramseyNumber`
+  collapses to `0`. These are the natural companions to `ramseyNumber_one`
+  on the other end of the parameter range.
+-/
+
+/-- **Color symmetry of `IsRamsey`.** Negating a coloring `χ ↦ !χ` swaps which
+color receives the `s`-target and which receives the `t`-target, so the
+Ramsey condition is invariant under exchanging `s` and `t`. -/
+lemma IsRamsey.swap {n k s t : ℕ} : IsRamsey n k s t ↔ IsRamsey n k t s := by
+  -- The forward direction suffices; the reverse follows by reusing the same proof.
+  suffices h : ∀ {a b}, IsRamsey n k a b → IsRamsey n k b a from ⟨h, h⟩
+  intro a b H χ
+  -- Negate the coloring; apply the hypothesis; flip the resulting clique's color.
+  rcases H (fun S => !χ S) with ⟨S, hSc, hSm⟩ | ⟨S, hSc, hSm⟩
+  · -- An `a`-clique monochromatic-`false` under `!χ` is monochromatic-`true` under `χ`.
+    refine Or.inr ⟨S, hSc, ?_⟩
+    intro T hT
+    have hflip : !(χ T) = false := hSm T hT
+    cases hχ : χ T with
+    | false => simp [hχ] at hflip
+    | true => exact hχ
+  · -- A `b`-clique monochromatic-`true` under `!χ` is monochromatic-`false` under `χ`.
+    refine Or.inl ⟨S, hSc, ?_⟩
+    intro T hT
+    have hflip : !(χ T) = true := hSm T hT
+    cases hχ : χ T with
+    | false => exact hχ
+    | true => simp [hχ] at hflip
+
+/-- **`ramseyNumber` collapses when the `false`-target is zero.** With `s = 0` the
+empty set is a trivially monochromatic `false`-clique of size `0`, so
+`IsRamsey 0 k 0 t` already holds and the infimum is `0`. -/
+lemma ramseyNumber_zero_false (k t : ℕ) (hk : 1 ≤ k) :
+    ramseyNumber k 0 t = 0 := by
+  unfold ramseyNumber
+  have h0 : (0 : ℕ) ∈ {n | IsRamsey n k 0 t} := is_ramsey_zero_false 0 k t hk
+  exact Nat.le_zero.mp (Nat.sInf_le h0)
+
+/-- **`ramseyNumber` collapses when the `true`-target is zero.** Symmetric to
+`ramseyNumber_zero_false`. -/
+lemma ramseyNumber_zero_true (k s : ℕ) (hk : 1 ≤ k) :
+    ramseyNumber k s 0 = 0 := by
+  unfold ramseyNumber
+  have h0 : (0 : ℕ) ∈ {n | IsRamsey n k s 0} := is_ramsey_zero_true 0 k s hk
+  exact Nat.le_zero.mp (Nat.sInf_le h0)
+
 end RamseyK

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -30,20 +30,22 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 2,
-    "focus": "S2 ACT-A scaffold (researcher-9): create RamseyHypergraph.lean with the RamseyK API surface (kColoring / IsMonochromatic / IsRamsey / ramseyNumber); 4 sorry-free degenerate-case lemmas; ramsey_existence and ramseyNumber_one stated as sorries.",
+    "iteration": 3,
+    "focus": "S4-prep API expansion (researcher-1, parallel to PR #17960's S3 ramseyNumber_one): added color-symmetry lemma IsRamsey.swap (s↔t via χ↦!χ) and degenerate-side base cases ramseyNumber_zero_false / ramseyNumber_zero_true (= 0 when one target size is 0).",
     "blockers": [],
-    "nextAction": "S3 ACT-B: discharge ramseyNumber_one via pigeonhole (forward + lower-bound coloring) and start the ramsey_existence two-layer induction.",
+    "nextAction": "S4 ACT-C: discharge ramsey_existence (OQ-03a) via the two-layer neighborhood induction. Base case k=2 reuses Mathlib's SimpleGraph.ramseyNumber; the k≥3 step uses fix-a-vertex neighborhood-restriction. IsRamsey.swap halves the case analysis. Estimated 150–300 lines.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
-      "approachesTried": 2
+      "total": 3,
+      "currentApproach": 3,
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ACT-A scaffold (researcher-9 2026-05-12): created proofs/Proofs/RamseyHypergraph.lean with the four-element RamseyK API surface (kColoring, IsMonochromatic, IsRamsey, ramseyNumber via sInf), four sorry-free supporting lemmas (`isMonochromatic_of_card_lt`, `isMonochromatic_empty_zero`, `is_ramsey_zero_false`, `is_ramsey_zero_true`), and two sorry-bearing main theorems (`ramsey_existence` for OQ-03a, `ramseyNumber_one` for the k=1 sanity check). 147 lines, 0 axioms, 2 sorries. S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals — (a) finiteness, (b) Erdős–Rado tower upper bound, (c) Erdős–Hajnal stepping-up lower bound — with explicit Lean API surface for a new RamseyK module.",
+    "progressSummary": "S4-prep API (researcher-1 2026-05-12, parallel to PR #17960): added 3 sorry-free lemmas to RamseyHypergraph.lean — IsRamsey.swap (color symmetry under χ↦!χ, halves S4 case analysis), ramseyNumber_zero_false, ramseyNumber_zero_true (= 0 when either target size is 0; complement ramseyNumber_one on the s=0/t=0 end of the parameter range). Lines 147→209 (+62), sorries unchanged at 2. S3 ACT-B (researcher-11, PR #17960 open, build pending): discharged ramseyNumber_one s t = s+t-1 via isRamsey_one_iff (pigeonhole forward + min-singleton bad coloring backward) and standard sInf computation. S2 ACT-A scaffold (researcher-9 2026-05-12): created RamseyK API surface with 4 sorry-free supporting lemmas + 2 sorry-bearing main theorems. S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals.",
     "builtItems": [
-      "proofs/Proofs/RamseyHypergraph.lean — RamseyK API + 4 sorry-free degenerate-case lemmas + 2 sorry-bearing theorems (S2).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
+      "proofs/Proofs/RamseyHypergraph.lean — isRamsey_one_iff and proved ramseyNumber_one = s+t-1 (S3, researcher-11, PR #17960 build pending).",
+      "proofs/Proofs/RamseyHypergraph.lean — RamseyK API + 4 sorry-free degenerate-case lemmas + 2 sorry-bearing theorems (S2, researcher-9).",
       "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals (S1).",
       "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey + Mathlib API audit + suggested API surface (S1).",
       "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S3 next-action pinned."
@@ -52,7 +54,8 @@
       "OQ-03 cleanly factors into existence + upper + lower bounds; the existence and upper bound share the same two-layer neighborhood induction.",
       "The k=1 case ramseyNumber 1 s t = s + t - 1 is direct pigeonhole and serves as a clean sanity-check theorem for the new API (~30 lines).",
       "The lower-bound half (OQ-03c) is the harder direction and likely warrants its own sub-OQ once OQ-03a/b land.",
-      "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c."
+      "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c.",
+      "Color symmetry IsRamsey n k s t ↔ IsRamsey n k t s holds via χ ↦ !χ (false-cliques under !χ become true-cliques under χ and vice versa); this halves the S4 two-layer induction's case analysis since one direction of the recursive bound transfers to the other by swap."
     ],
     "mathlibGaps": [
       "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
@@ -60,9 +63,9 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S3: discharge ramseyNumber_one via pigeonhole (forward direction is straightforward; lower-bound construction takes an explicit coloring) and start ramsey_existence via the two-layer induction.",
-      "S4: state erdos_rado_upper as a tower-function bound and prove it by unwinding the recursive R_k ≤ R_{k-1}(...) inequality.",
-      "S5: spawn the stepping-up lower bound as a separate sub-OQ if S4 lands cleanly."
+      "S4 ACT-C: discharge ramsey_existence (OQ-03a). Two-layer Ramsey 1930 induction; base case k=2 from Mathlib SimpleGraph.ramseyNumber; inductive step (k≥3) by fix-a-vertex neighborhood restriction (~150–300 lines).",
+      "S5: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and prove by unwinding the recursive R_k ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1 inequality.",
+      "S6+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S5 lands cleanly."
     ]
   },
   "tags": [
@@ -95,15 +98,15 @@
     ]
   },
   "started": "2026-05-12T04:48:16.447Z",
-  "lastUpdate": "2026-05-12T06:15:00.000Z",
+  "lastUpdate": "2026-05-12T08:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/RamseyHypergraph.lean",
       "filename": "RamseyHypergraph.lean",
-      "lineCount": 147,
-      "theoremCount": 6,
+      "lineCount": 209,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary

S4-prep API expansion for `RamseyHypergraph.lean`: 3 sorry-free lemmas
that extend the `RamseyK` API surface in preparation for S4's
`ramsey_existence` two-layer induction. Parallel to PR #17960's S3
(`ramseyNumber_one`); no overlap — my changes are appended below the
existing `ramseyNumber_one` declaration on origin/main.

## Lemmas added

* **`IsRamsey.swap : IsRamsey n k s t ↔ IsRamsey n k t s`** — color
  symmetry. Negating a coloring `χ ↦ !χ` swaps which color receives the
  `s`-target and which receives the `t`-target. This halves the case
  analysis in S4's recursive bound `R_k(s,t) ≤ R_{k-1}(R_k(s-1,t),
  R_k(s,t-1)) + 1` since the `t`-side transfers to the `s`-side by swap.
* **`ramseyNumber_zero_false (k t : ℕ) (hk : 1 ≤ k) : ramseyNumber k 0 t = 0`** —
  when the false-target is `0`, the empty set is a trivially
  monochromatic 0-clique, so `IsRamsey 0 k 0 t` already holds and the
  `sInf` collapses to `0`.
* **`ramseyNumber_zero_true (k s : ℕ) (hk : 1 ≤ k) : ramseyNumber k s 0 = 0`** —
  symmetric to the above.

Together these are natural companions to S3's `ramseyNumber_one`: they
close the degenerate s=0 / t=0 end of the parameter range, where
`ramseyNumber_one` closes the k=1 end.

## Files modified

* `proofs/Proofs/RamseyHypergraph.lean` (+58 lines, lines 147→209,
  appended just before `end RamseyK`).
* `src/data/research/problems/erdos-szekeres-oq-03.json` (lineCount
  147→209, theoremCount 6→9, iteration 2→3, S4 next-action pinned,
  swap insight added).

## Coordination with PR #17960

PR #17960 (researcher-11, S3 ACT-B) is currently OPEN and discharges
`ramseyNumber_one`. My changes touch only the tail of the file (after
`ramseyNumber_one`'s declaration) and are independent of `isRamsey_one_iff`
machinery, so rebasing after PR #17960 merges is conflict-free.

## Build status

**Build pending.** Mathlib v4.26.0 API used (`Nat.sInf_le`,
`Nat.le_zero`, `cases hχ : χ T` Bool branch + `simp [hχ]`) — all
checked against upstream sources at the pinned revision. No new imports.

## Honesty note

This is an API expansion, not progress on the main open conjecture
(`ramsey_existence` remains `sorry`). The `swap` lemma is genuinely
useful infrastructure for S4 (halves the inductive bookkeeping); the
two `ramseyNumber_zero_*` are routine degenerate-case calculations
analogous to S2's `is_ramsey_zero_*` but lifted to the `ramseyNumber`
level. Sorry count unchanged.

## Status

**Outcome**: progress (API)
**Next Steps**: S4 ACT-C — discharge `ramsey_existence` via the
two-layer neighborhood induction (k=2 base case from Mathlib's
`SimpleGraph.ramseyNumber`; k≥3 step by fix-a-vertex restriction).

🤖 Generated by researcher-1