### PR TITLE
enrich(lagrange-theorem-oq-02-oq-02): add module-header section for lines 1-47

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
@@ -201,6 +201,14 @@
   ],
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: Class-Equation Blueprint and Tags",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Lines 1–2 import Mathlib and the parent file Proofs.LagrangeTheoremOQ02. Lines 4–37 are a 34-line block comment that introduces the class equation $|G| = |Z(G)| + \\sum [G:C_G(x)]$, the four-step proof chain (conjugacy partition → orbit-stabilizer → singletons-are-central → split), the three key applications (p-group center, order-$p^2$ abelian, Sylow $pq$), the prerequisite hierarchy Lagrange → Orbit-Stabilizer → Burnside → Class Equation → p-Groups, and references to Dummit & Foote §4.3 and Rotman §2.5. Lines 39–47 set `maxHeartbeats 800000`, open the namespace, open Subgroup/ConjClasses/MulAction, and lead into the Part I banner.",
+      "mathContext": "Class equation: $|G| = |Z(G)| + \\sum_{[x] \\text{ non-central}} [G : C_G(x)]$. The center $Z(G) = \\{x \\in G : \\forall g, gx = xg\\}$ contributes singleton classes; each non-central conjugacy class $[x]$ has size $[G : C_G(x)]$ by orbit-stabilizer applied to the conjugation action."
+    },
+    {
       "id": "class-equation-main",
       "title": "The Class Equation",
       "startLine": 55,


### PR DESCRIPTION
## Summary

Adds a ``module-header`` section covering lines 1–47 (imports + 34-line block comment + namespace/maxHeartbeats setup). The four existing sections covered the Lean code starting at line 55 but left the opening prose and prelude uncovered.

The new section's summary captures the class-equation statement, the four-step proof chain, the three key applications, the prerequisite hierarchy, and the references (Dummit & Foote §4.3, Rotman §2.5).

## Quality

Quality breakdown 98 → 100 (sections 8 → 10). All other facets already at max.

## Test plan

- [x] meta.json parses as JSON
- [x] sections array now has 5 entries; new entry precedes class-equation-main
- [x] find-targets.ts quality breakdown reports sections: 10, total: 100