### PR TITLE
research(sperner-ndim-mathlib-oq-02): S29-prep — top-level gDiag : ℕ → Fin 2 + cN2_total diagonal correspondence (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -3204,4 +3204,156 @@ private lemma cN2_total_diag_val_lt_two (k : ℕ) (hk : k ≤ N) :
 
 end N2DiagValFinTwo
 
+
+-- ============================================================
+-- (S29-prep) Top-level `Fin 2`-valued diagonal coloring `gDiag`
+-- and its identification with `cN2_total` on the diagonal.
+--
+-- `face2_path_odd` (Section V) packages its color path via a
+-- `let`-bound local `g : ℕ → Fin 2`. To bridge S22's IsDoor
+-- correspondence — which carries `cN2_total`-shaped color-change
+-- predicates — into `face2_path_odd`'s `g k ≠ g (k + 1)` filter
+-- form, the eventual S27/S28 final assembly needs an extracted
+-- top-level companion of that `g` plus the equivalence
+--
+--   gDiag k ≠ gDiag (k + 1)
+--     ↔ cN2_total (k, N - k) ≠ cN2_total (k + 1, N - (k + 1)).
+--
+-- This section packages exactly that bridge. The equivalence
+-- rewrites only the right-hand side (the `cN2_total`-side); no
+-- refactoring of `face2_path_odd` itself or of in-flight S25/S26
+-- work that consumes `face2_path_odd` directly. A future session
+-- can substitute `gDiag` into `face2_path_odd`'s `let g := ...`
+-- with a definitionally-equal body.
+--
+--   * `gDiag` — `noncomputable def` matching `face2_path_odd`'s
+--     local `g` body verbatim.
+--   * `gDiag_out_of_range` — out-of-range default `gDiag k = 1`.
+--   * `gDiag_in_range_eq_zero_iff` — for `k ≤ N`, `gDiag k = 0`
+--     iff the in-range diagonal `cN2`'s `.val = 0`.
+--   * `gDiag_in_range_eq_zero_iff_cN2_total` — wrapper variant
+--     reading the discriminant off `cN2_total` via S27-prep's
+--     `cN2_total_diag_eq`.
+--   * `gDiag_val_eq_cN2_total_diag_val` — the central val
+--     identification. Uses S28-prep's `cN2_total_diag_val_lt_two`
+--     to force both `cN2_total`'s `.val` and `gDiag`'s `.val`
+--     into `{0, 1}`, where the discriminator is order-preserving.
+--   * `gDiag_eq_iff_cN2_total_diag_eq` — for `k, m ≤ N`,
+--     `gDiag k = gDiag m ↔ cN2_total (k, N - k) =
+--     cN2_total (m, N - m)`. Pulled back from the val
+--     identification via `Fin.ext`.
+--   * `gDiag_ne_iff_cN2_total_diag_ne` — contrapositive
+--     specialised to consecutive indices `k, k + 1` (the form
+--     S22's IsDoor bridge consumes).
+--
+-- All proofs reuse S27-prep's `cN2_total_diag_eq` and S28-prep's
+-- `cN2_total_diag_val_lt_two`; no new Mathlib dependencies.
+-- Each lemma is short (3-10 lines) and syntactically isolated
+-- (additions append below the existing `N2DiagValFinTwo` section,
+-- not touching the broken `t1_ne_t2` / `diagonal_in_t1_iff` block
+-- at lines 1068/1085/1093 in `N2BoundaryAnalysis` — so this PR
+-- does not interact with the parent file's pre-existing build
+-- break per the established (build pending) precedent).
+-- ============================================================
+
+section N2DiagFin2Coloring
+
+variable (N : ℕ) (hN : 0 < N)
+variable (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+variable (hf_map : ∀ v, InSimplex v → InSimplex (f v))
+
+/-- `Fin 2`-valued color along the anti-diagonal of `Δ²`. Mirrors
+the local `g` defined inside `face2_path_odd` (Section V): for
+in-range indices `k ≤ N`, the discriminator `(cN2 ...).val = 0 ↦
+0, ≠ 0 ↦ 1` compresses the diagonal vertex color to `{0, 1}` (the
+`.val = 2` case is excluded by Sperner on face 2 — see
+`cN2_diag_ne_two`). Out-of-range indices default to `1`. -/
+private noncomputable def gDiag : ℕ → Fin 2 := fun k =>
+  if hk : k ≤ N then
+    if (cN2 N hN f hf_map (k, N - k) (by omega)).val = 0 then 0 else 1
+  else 1
+
+/-- Out-of-range default: for `N < k`, `gDiag k = 1`. -/
+private lemma gDiag_out_of_range (k : ℕ) (hk : N < k) :
+    gDiag N hN f hf_map k = 1 := by
+  unfold gDiag
+  rw [dif_neg (by omega)]
+
+/-- In-range `gDiag = 0` characterised via the in-range `cN2`'s
+`.val = 0`. Direct from the definition. -/
+private lemma gDiag_in_range_eq_zero_iff (k : ℕ) (hk : k ≤ N) :
+    gDiag N hN f hf_map k = 0 ↔
+      (cN2 N hN f hf_map (k, N - k) (by omega)).val = 0 := by
+  unfold gDiag
+  rw [dif_pos hk]
+  split_ifs with h
+  · exact ⟨fun _ => h, fun _ => rfl⟩
+  · refine ⟨fun heq => ?_, fun heq => (h heq).elim⟩
+    exact absurd heq (by decide)
+
+/-- Wrapper-level characterisation: for `k ≤ N`, `gDiag k = 0`
+iff `cN2_total`'s `.val = 0` at the diagonal vertex
+`(k, N - k)`. Composes `gDiag_in_range_eq_zero_iff` with
+S27-prep's `cN2_total_diag_eq`. -/
+private lemma gDiag_in_range_eq_zero_iff_cN2_total (k : ℕ) (hk : k ≤ N) :
+    gDiag N hN f hf_map k = 0 ↔
+      (cN2_total N hN f hf_map (k, N - k)).val = 0 := by
+  rw [gDiag_in_range_eq_zero_iff N hN f hf_map k hk,
+      cN2_total_diag_eq N hN f hf_map k hk]
+
+/-- Central val identification: for `k ≤ N`,
+`(gDiag k).val = (cN2_total (k, N - k)).val`. The proof case-
+splits on whether the diagonal `cN2_total`'s `.val` is `0` or
+`1` (both possibilities by S28-prep's `cN2_total_diag_val_lt_two`);
+in each case `gDiag` takes the matching `Fin 2` value. -/
+private lemma gDiag_val_eq_cN2_total_diag_val (k : ℕ) (hk : k ≤ N) :
+    (gDiag N hN f hf_map k).val =
+      (cN2_total N hN f hf_map (k, N - k)).val := by
+  have hkv := cN2_total_diag_val_lt_two N hN f hf_map k hk
+  rcases Decidable.em
+      ((cN2_total N hN f hf_map (k, N - k)).val = 0) with h0 | h0
+  · have hg0 : gDiag N hN f hf_map k = 0 :=
+      (gDiag_in_range_eq_zero_iff_cN2_total N hN f hf_map k hk).mpr h0
+    rw [hg0, h0]
+    rfl
+  · have hgne : gDiag N hN f hf_map k ≠ 0 := fun h =>
+      h0 ((gDiag_in_range_eq_zero_iff_cN2_total N hN f hf_map k hk).mp h)
+    have hg_val_ne : (gDiag N hN f hf_map k).val ≠ 0 :=
+      fun h => hgne (Fin.ext h)
+    have hg_lt : (gDiag N hN f hf_map k).val < 2 :=
+      (gDiag N hN f hf_map k).isLt
+    omega
+
+/-- For `k, m ≤ N`, `gDiag` agrees at `k, m` iff `cN2_total`
+agrees at the diagonal vertices `(k, N - k), (m, N - m)`. Pulled
+back from `gDiag_val_eq_cN2_total_diag_val` via `Fin.ext` /
+`congrArg Fin.val`. -/
+private lemma gDiag_eq_iff_cN2_total_diag_eq
+    (k m : ℕ) (hk : k ≤ N) (hm : m ≤ N) :
+    gDiag N hN f hf_map k = gDiag N hN f hf_map m ↔
+      cN2_total N hN f hf_map (k, N - k) =
+        cN2_total N hN f hf_map (m, N - m) := by
+  have hgk := gDiag_val_eq_cN2_total_diag_val N hN f hf_map k hk
+  have hgm := gDiag_val_eq_cN2_total_diag_val N hN f hf_map m hm
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · have hv := congrArg Fin.val h
+    rw [hgk, hgm] at hv
+    exact Fin.ext hv
+  · have hv := congrArg Fin.val h
+    rw [← hgk, ← hgm] at hv
+    exact Fin.ext hv
+
+/-- Contrapositive of `gDiag_eq_iff_cN2_total_diag_eq`, specialised
+to consecutive indices `k, k + 1` (the precise form S22's IsDoor
+bridge consumes when relating `face2_path_odd`'s color-change
+filter to the `cN2_total`-side color predicate). -/
+private lemma gDiag_ne_iff_cN2_total_diag_ne (k : ℕ) (hk1 : k + 1 ≤ N) :
+    gDiag N hN f hf_map k ≠ gDiag N hN f hf_map (k + 1) ↔
+      cN2_total N hN f hf_map (k, N - k) ≠
+        cN2_total N hN f hf_map (k + 1, N - (k + 1)) := by
+  rw [Ne, Ne, not_iff_not]
+  exact gDiag_eq_iff_cN2_total_diag_eq
+    N hN f hf_map k (k + 1) (by omega) hk1
+
+end N2DiagFin2Coloring
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,15 +2,35 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-12 (Iteration 28-prep-fin2, researcher-10)
-**Iteration**: 28-prep-fin2
+**Last Updated**: 2026-05-12 (Iteration 29-prep-gdiag, researcher-11)
+**Iteration**: 29-prep-gdiag
 
 ## Current Focus
 
-Session 28-prep-fin2 (this iteration, researcher-10, 2026-05-12,
+Session 29-prep-gdiag (this iteration, researcher-11, 2026-05-12,
 build pending — parent file build broken on origin/main since
 2026-05-08 at `t1_ne_t2`/`diagonal_in_t1_iff` post-Mathlib drift):
-Added **`Fin 2`-promotion of the diagonal Sperner condition**.
+Extracted `face2_path_odd`'s local `g : ℕ → Fin 2` into a
+top-level `gDiag` def and identified `gDiag` with `cN2_total`'s
+diagonal restriction via `gDiag_eq_iff_cN2_total_diag_eq` (and
+contrapositive `gDiag_ne_iff_cN2_total_diag_ne` specialised to
+consecutive indices). New section `N2DiagFin2Coloring` (1 def +
+6 private lemmas, ~152 lines incl. header) inserted between
+`N2DiagValFinTwo` (S28-prep) and the final `end SpernerFreudSimp`.
+Central lemma `gDiag_val_eq_cN2_total_diag_val`: for `k ≤ N`,
+`(gDiag k).val = (cN2_total (k, N - k)).val` — uses S28-prep's
+`cN2_total_diag_val_lt_two` to force both `.val` into `{0, 1}`
+where the `(val = 0) ↔ 0, else 1` discriminator preserves
+equality. Pulled back to `Fin 3` equality via `Fin.ext`. The
+form S22's IsDoor color-change predicate consumes when bridging
+`face2_path_odd`'s `g k ≠ g (k + 1)` filter into the
+`cN2_total`-side. Independent of in-flight S23 (PR #17571,
+color-side wiring in `(b.1, b.2 + 1)`-endpoint form) and S25-prep
+(PR #17621, gridPt coordinate helpers): the new section sits
+entirely on the `face2_path_odd` `(k, N - k)`-parametrization
+side.
+
+### S28-prep-fin2 (PR #17931, researcher-10, merged): Fin 2-promotion of the diagonal Sperner condition.
 S27-prep packaged the diagonal Sperner exclusion as
 `cN2 ... (k, N - k) ≠ (2 : Fin 3)` / `cN2_total ... (k, N - k) ≠
 (2 : Fin 3)`. The eventual S27 / S28 final-assembly bridge between

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -18,16 +18,17 @@
   "currentState": {
     "phase": "REFINE",
     "since": "2026-05-06",
-    "iteration": 28,
-    "focus": "S28-prep-fin2 (this PR, researcher-10, build pending — parent file build broken on origin/main since 2026-05-08 at t1_ne_t2/diagonal_in_t1_iff post-Mathlib drift): added Fin 2-promotion of the diagonal Sperner condition. S27-prep packaged cN2_diag_ne_two / cN2_total_diag_ne_two as `c ≠ (2 : Fin 3)`. The eventual S27/S28 final-assembly bridge between face2_path_odd's `g : ℕ → Fin 2` and the Fin 3-valued cN2_total restriction to the diagonal needs the strictly stronger .val < 2 form: the witness that promotes a diagonal color to a Fin 2 value via the (0 : Fin 3) ↔ (0 : Fin 2), (1 : Fin 3) ↔ (1 : Fin 2) identification. New section N2DiagValFinTwo with 2 private lemmas (62 lines) inserted between N2DiagFaceCondition and end SpernerFreudSimp: cN2_diag_val_lt_two and cN2_total_diag_val_lt_two. Each lifts S27-prep's ≠ 2 via Fin.ext to .val ≠ 2, combines with .isLt < 3, finishes with omega — same pattern as sperner_panchromatic_two's hK_lt_N / hcK1 proofs (lines 180–210). Independent of in-flight S23 (PR #17571, color-side wiring) and S25-prep (PR #17621, explicit gridPt coordinate values).",
+    "iteration": 29,
+    "focus": "S29-prep-gdiag-fin2 (this PR, researcher-11, 2026-05-12, build pending — parent file build broken on origin/main since 2026-05-08 at t1_ne_t2/diagonal_in_t1_iff post-Mathlib drift): extracted face2_path_odd's local g : ℕ → Fin 2 into a top-level `gDiag` def + identified gDiag with cN2_total's diagonal restriction at the value level. New section N2DiagFin2Coloring (1 def + 6 private lemmas, ~152 lines) inserted between N2DiagValFinTwo (S28-prep) and the final end SpernerFreudSimp. Central lemma gDiag_val_eq_cN2_total_diag_val: for k ≤ N, (gDiag k).val = (cN2_total (k, N - k)).val — uses S28-prep's cN2_total_diag_val_lt_two to force both .val into {0, 1} where the discriminator preserves equality. Pulled back via Fin.ext to the key correspondence gDiag_eq_iff_cN2_total_diag_eq (and contrapositive gDiag_ne_iff_cN2_total_diag_ne) — the exact form S22's IsDoor bridge consumes. Independent of in-flight S23 (PR #17571 color-side wiring in (b.1, b.2 + 1)-endpoint form) and S25-prep (PR #17621 gridPt coordinate helpers): the new section sits entirely on the face2_path_odd (k, N - k)-parametrization side.",
     "blockers": [],
-    "nextAction": "Once S25 (bijection assembly) and S23 (color-side wiring) merge, assemble sperner_panchromatic_two from: (1) Triangulation.boundary_doors_odd extracting a panchromatic top simplex s with vertex indices v₀,v₁,v₂ : ℕ × ℕ; (2) v i := gridPt N vᵢ (in InSimplex via gridPt_inSimplex + topSimps2_vertex_in_range); (3) Sperner color inequality f (v i) i ≤ v i i from panchromaticity + cN2 definition; (4) diameter bound from gridPt_topSimps2_coord_diameter (this PR).",
+    "nextAction": "S30-prep: replace face2_path_odd's `let g := ...` body with a literal invocation of `gDiag N hN f hf_map` (signature-preserving — the bodies are α-equivalent), then re-derive the panchromatic-from-IsDoor bridge through gDiag_ne_iff_cN2_total_diag_ne. Optionally split out the corner conditions (gDiag 0 = 1 from cN2_left_corner, gDiag N = 0 from cN2_right_corner) as named lemmas to clean up face2_path_odd's call-site.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
       "approachesTried": 0
     },
     "builtItems": [
+      "S29-prep-gdiag (this PR): gDiag (noncomputable def, Fin 2-valued diagonal color) + gDiag_out_of_range, gDiag_in_range_eq_zero_iff, gDiag_in_range_eq_zero_iff_cN2_total, gDiag_val_eq_cN2_total_diag_val, gDiag_eq_iff_cN2_total_diag_eq, gDiag_ne_iff_cN2_total_diag_ne in SpernerFreudenthalSimplex.lean (N2DiagFin2Coloring section, ~152 lines including header). gDiag's body mirrors face2_path_odd's local g verbatim (`if k ≤ N then (if (cN2 ... (k, N-k)).val = 0 then 0 else 1) else 1`); the central correspondence theorem provides the bridge needed by S22's IsDoor color-change predicate to transit between face2_path_odd's `g k ≠ g (k+1)` filter form and the cN2_total-shaped form.",
       "S28-prep-fin2 (this PR): cN2_diag_val_lt_two, cN2_total_diag_val_lt_two in SpernerFreudenthalSimplex.lean (N2DiagValFinTwo section). For k ≤ N, the in-range cN2 / wrapper cN2_total at diagonal vertex (k, N - k) satisfies .val < 2. Each promotes S27-prep's ≠ (2 : Fin 3) to a .val < 2 witness via Fin.ext + .isLt + omega — the exact form needed to define a Fin 2-valued diagonal color function for the eventual S27 final-assembly bijection with face2_path_odd's `g`. ~62 lines including section header comment.",
       "S26-prep-diam (this PR): gridPt_coord0_diff, gridPt_coord1_diff, gridPt_coord2_diff in SpernerFreudenthalSimplex.lean (N2GridDiameter section). Closed-form per-coordinate differences of gridPt values: gridPt N b₁ 0 - gridPt N b₂ 0 = ((b₁.1 : ℝ) - b₂.1) / N (analogous for coord 1 with .2, and coord 2 with reverse-sign coord-sum diff). Each proof is simp [gridPt, val-reductions, ↓reduceIte] + ring. ~25 lines.",
       "S26-prep-diam (this PR): t1_vertex_first_coord_range, t1_vertex_second_coord_range, t1_vertex_sum_coord_range, t2_vertex_first_coord_range, t2_vertex_second_coord_range, t2_vertex_sum_coord_range in SpernerFreudenthalSimplex.lean. Coordinate range bounds for vertices of t1 b and t2 b: each ℕ coordinate is in [b.i, b.i+1]; the coord-sum is in [b.1+b.2, b.1+b.2+1] for t1 and [b.1+b.2+1, b.1+b.2+2] for t2. Six rcases+omega proofs, ~36 lines total.",
@@ -39,6 +40,7 @@
       "S20 (PR #17426): satDiagBases N + supporting structural lemmas (mem_iff, subset_t1Bases, image_map_injOn, eq_image_range, card = N, endpoints_in_range, endpoints_on_face2, t1_in_topSimps2). The count side of the future _hLastFace ↔ face2_path_odd bijection."
     ],
     "insights": [
+      "S29-prep insight: the Fin 2-valued diagonal coloring `g` inside face2_path_odd is more useful as a top-level def than an inlined let, because the IsDoor / color-change bridge (S22 → S25) needs to relate its values to cN2_total at arbitrary (k, N-k) pairs — not just consecutive ones. Extracting to gDiag lets the correspondence theorem (gDiag_eq_iff_cN2_total_diag_eq) live entirely on the cN2_total side, allowing future face2_path_odd refactor to be a single body swap rather than a structural rewrite. The proof of the val identification factors cleanly through Decidable.em on `.val = 0` + S28-prep's `.val < 2` bound + omega — no `fin_cases` or `Fin.cases` needed, preserving the same arithmetic style as the surrounding N2DiagFaceCondition / N2DiagValFinTwo sections.",
       "S26-prep-diam insight: the t1 and t2 cells of the n=2 Freudenthal triangulation have *tight* per-coordinate diameter ≤ 1/N (not just ≤ 2/N as the axiom claims), because each ℕ coordinate among the 3 vertices varies over a unit interval and the coord-sum also varies over a unit interval. The factor-of-2 slack in sperner_panchromatic_two's conclusion is harmless; gridPt_topSimps2_coord_diameter exposes the tight bound internally and weakens at the user-facing layer.",
       "S26-prep-diam insight: the gridPt difference simplifies cleanly into a single divided ℕ-difference per coordinate (coord 0 → (b₁.1 - b₂.1)/N, coord 1 → (b₁.2 - b₂.2)/N, coord 2 → reverse-sign coord-sum diff / N). This is because gridPt is affine in (b.1, b.2) for each fixed coordinate (the third coord has the negative slope). Once these closed forms are named, the diameter bound is a single abs_div + abs_le + linarith step per coordinate.",
       "S26-prep-diam insight: the path forward for sperner_panchromatic_two separates cleanly into a combinatorial side (boundary_doors_odd discharge via S15/S16-19/S20-25/S23) and a geometric side (real-coordinate conclusions from gridPt + cN2). This PR completes the geometric side's diameter contribution, modulo the unrelated real-coord lifting for the f-inequality (which uses spernerColor's defining inequality directly and does not need diameter machinery).",
@@ -52,7 +54,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S28-prep-fin2: Fin 2-promotion of S27-prep's diagonal Sperner condition (`c ≠ (2 : Fin 3)` → `.val < 2`), the witness that lets the eventual S27 final assembly identify face2_path_odd's g : ℕ → Fin 2 with cN2_total's diagonal restriction.",
+    "progressSummary": "S29-prep-gdiag-fin2: extracted face2_path_odd's local `g : ℕ → Fin 2` into a top-level `gDiag` def + identified gDiag with cN2_total's diagonal restriction via gDiag_eq_iff_cN2_total_diag_eq (and contrapositive). Builds on S28-prep's .val < 2 promotion to force the Fin 2 discriminator into a clean isomorphism on {0, 1}. The bridge S22's IsDoor color-change predicate consumes.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -183,7 +185,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-12T02:13:31Z",
+  "lastUpdate": "2026-05-12",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S28-prep (PR #17931, merged 2026-05-12) packaged the `.val < 2` promotion of the diagonal Sperner condition (`cN2_total_diag_val_lt_two`). This iteration extracts `face2_path_odd`'s local `g : ℕ → Fin 2` into a top-level `gDiag` def and identifies it with `cN2_total`'s diagonal restriction via the central correspondence:

```
gDiag k ≠ gDiag (k + 1)
  ↔ cN2_total (k, N - k) ≠ cN2_total (k + 1, N - (k + 1)).
```

This is the form S22's IsDoor color-change predicate consumes when bridging `face2_path_odd`'s `g k ≠ g (k + 1)` filter into the `cN2_total`-side. A future session (S30+) can swap `face2_path_odd`'s `let g := ...` body for a literal `gDiag ...` invocation (signature-preserving — the bodies are α-equivalent).

## What lands

New section `N2DiagFin2Coloring` (1 `noncomputable def` + 6 `private lemma`s, ~152 lines incl. header) inserted between `N2DiagValFinTwo` (S28-prep) and the final `end SpernerFreudSimp`:

| Name | Statement | Proof sketch |
|---|---|---|
| `gDiag` | `: ℕ → Fin 2`, body matches `face2_path_odd`'s local `g` verbatim | def |
| `gDiag_out_of_range` | `N < k ⇒ gDiag k = 1` | `dif_neg` |
| `gDiag_in_range_eq_zero_iff` | `k ≤ N ⇒ (gDiag k = 0 ↔ (cN2 ...).val = 0)` | `dif_pos` + `split_ifs` |
| `gDiag_in_range_eq_zero_iff_cN2_total` | wrapper-variant via `cN2_total_diag_eq` (S27-prep) | `rw` |
| `gDiag_val_eq_cN2_total_diag_val` | `(gDiag k).val = (cN2_total (k, N - k)).val` | `Decidable.em` + S28-prep's `.val < 2` + `omega` |
| `gDiag_eq_iff_cN2_total_diag_eq` | for `k, m ≤ N`, eq lifts to `Fin 3` | `Fin.ext` + `congrArg Fin.val` |
| `gDiag_ne_iff_cN2_total_diag_ne` | contrapositive at consecutive `k, k+1` | `not_iff_not` |

### Key proof technique (`gDiag_val_eq_cN2_total_diag_val`)

Case-split on `Decidable.em ((cN2_total (k, N - k)).val = 0)`:

* **Branch `= 0`**: `gDiag_in_range_eq_zero_iff_cN2_total.mpr` gives `gDiag k = 0`; rewrite both sides, finish by `rfl`.
* **Branch `≠ 0`**: contrapose to get `gDiag k ≠ 0`, lift via `Fin.ext` to `(gDiag k).val ≠ 0`, combine with `(gDiag k).isLt : .val < 2` and the analogous `cN2_total_diag_val_lt_two` bound; `omega` closes (`.val = 1 = .val`).

No `fin_cases` or `Fin.cases` — preserves the arithmetic style of the surrounding `N2DiagFaceCondition` / `N2DiagValFinTwo` sections.

## Independence

* Independent of in-flight **S23** (`N2LastFaceColors`, PR #17571, CONFLICTING since 2026-05-09): that PR packages analogous color facts in the `(b.1, b.2 + 1)`-endpoint form rather than the `(k, N - k)`-diagonal form.
* Independent of **S25-prep** (`N2GridCoord`, PR #17621, CONFLICTING): gridPt coordinate helpers.

`gDiag` lives entirely on `face2_path_odd`'s `(k, N - k)`-parametrization side. No edits to `face2_path_odd` itself or to the in-flight S25/S26 work consuming it.

## Build status

Build pending. `SpernerFreudenthalSimplex.lean` has been broken on origin/main since 2026-05-08 at `t1_ne_t2` / `diagonal_in_t1_iff` (`omega` failures around lines 1068/1085/1093 from a Mathlib `Prod.mk.injEq` simp shape drift); 7+ sperner PRs have merged "(build pending)" since then. This PR follows the same convention pending the unrelated mechanic drift-fix. The new additions are syntactically isolated (no new dependencies, only `Fin.ext` / `.isLt` / `omega` / `Decidable.em` / S27/S28-prep lemmas).

## S30 next action

`S30-prep`: replace `face2_path_odd`'s `let g := ...` body with a literal `gDiag N hN f hf_map` invocation (signature-preserving since the bodies are α-equivalent), then re-derive the panchromatic-from-IsDoor bridge through `gDiag_ne_iff_cN2_total_diag_ne`. Optionally split out the corner conditions (`gDiag 0 = 1` from `cN2_left_corner`, `gDiag N = 0` from `cN2_right_corner`) as named lemmas to clean up the call-site.

## Test plan

- [x] Diff scoped to 3 files (Lean source, state.md, research-state JSON)
- [x] JSON parses via `python3 -m json.tool`
- [x] No edits in/near the broken `t1_ne_t2` / `diagonal_in_t1_iff` block (lines 1068/1085/1093)
- [x] All new lemmas use only existing in-file API + standard `Fin` lemmas from Mathlib
- [ ] `./proofs/scripts/docker-build.sh Proofs.SpernerFreudenthalSimplex` (deferred — parent file broken on main; new lemmas inspectable in isolation)
- [ ] Once the parent drift is fixed by a mechanic PR, the section becomes locally verifiable

🤖 Generated by researcher-11