### PR TITLE
research(area-of-circle-oq-05-oq-04): S1 OBSERVE — p-adic Gaussian (source formula malformed; three corrected statements + Mathlib audit)

### DIFF
--- a/research/area-of-circle-oq-05-oq-04/knowledge.md
+++ b/research/area-of-circle-oq-05-oq-04/knowledge.md
@@ -1,0 +1,122 @@
+# area-of-circle-oq-05-oq-04 — Knowledge / Mathlib API survey
+
+S1 audit of what Mathlib v4.26.0 provides, against the three candidate
+formal statements in `problem.md`. All paths below are verified by direct
+`gh api repos/leanprover-community/mathlib4/contents/...` fetch on
+2026-05-12; no `tsx`/`pnpm` involved.
+
+## Available Mathlib infrastructure
+
+### `Mathlib.NumberTheory.Padics.*`
+
+- `Mathlib/NumberTheory/Padics/PadicNumbers.lean` — `ℚ_[p]` as completion of ℚ
+  under the p-adic norm; field structure, ring norm, completeness.
+- `Mathlib/NumberTheory/Padics/PadicIntegers.lean` — `ℤ_[p]` as subring of ℚ_[p]
+  with norm ≤ 1; local ring, DVR, nonarchimedean normed ring.
+- `Mathlib/NumberTheory/Padics/PadicNorm.lean` — `padicNorm : ℚ → ℚ`,
+  `padicValRat`, `padicValNat`. Real-valued norm via `Padic.norm`.
+- `Mathlib/NumberTheory/Padics/ProperSpace.lean` — `ℤ_[p]` is `CompactSpace`,
+  `ℚ_[p]` is `ProperSpace`. (Crucially: `ℚ_[p]` is locally compact.)
+- `Mathlib/NumberTheory/Padics/AddChar.lean` — continuous additive characters
+  `ℤ_[p] → R` for ultrametric normed `ℤ_[p]`-algebras `R`. Provides
+  `addChar_of_value_at_one`, `continuousAddCharEquiv`, Mahler-transform bridge.
+  NOTE: this is for *characters into* a `ℤ_[p]`-algebra, NOT the standard
+  C-valued character `ψ_p : ℚ_[p] → ℂ`. The latter does not appear to be in
+  Mathlib at v4.26.0.
+- `Mathlib/NumberTheory/Padics/MahlerBasis.lean` — Mahler's theorem; bridge to
+  Fourier analysis on `ℤ_[p]`.
+- `Mathlib/NumberTheory/Padics/RingHoms.lean`, `Hensel.lean`, `WithVal.lean`,
+  `ValuativeRel.lean`, `HeightOneSpectrum.lean`, `Complex.lean` — additional
+  algebraic structure (not directly relevant to S1).
+
+### `Mathlib.MeasureTheory.Measure.Haar.*`
+
+- `Mathlib/MeasureTheory/Measure/Haar/Basic.lean` — Haar measure on locally
+  compact topological groups (general construction; the existence theorem).
+- `Mathlib/MeasureTheory/Measure/Haar/Unique.lean` — Haar measure uniqueness up
+  to scaling.
+- `Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean`,
+  `OfBasis.lean`, `Extension.lean`, `Disintegration.lean` — variants;
+  the OfBasis file is what we'd use to *normalise* on ℤ_[p].
+- `Mathlib/MeasureTheory/Measure/Haar/DistribChar.lean` — Haar mod-character;
+  relevant for `‖·‖_p^s` integrals (C3) eventually.
+
+### Existing real Gaussian infrastructure (already used in OQ-05)
+
+- `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` —
+  `integral_gaussian : ∀ b : ℝ, ∫ x, exp(-b * x^2) = √(π/b)` for `b > 0`.
+- `Mathlib.MeasureTheory.Integral.Pi` — Fubini-style ℝⁿ integration
+  (used by `AreaOfCircleOQ05OQ02` for the multivariate case).
+
+## What's MISSING from Mathlib (gaps to surface)
+
+1. **Standard p-adic additive character `ψ_p : ℚ_[p] → ℂ`** with
+   `ψ_p|_{ℤ_[p]} = 1` and `ψ_p(p^{-n}) = e^{2πi · a_n}` where `a_n ∈ ℚ ∩ [0,1)`
+   is the "fractional part" component. Mathlib has only `ℤ_[p]`-algebra-valued
+   characters (`Mathlib.NumberTheory.Padics.AddChar`), which is the *dual*
+   direction (characters *of* ℤ_[p] into a Banach algebra). The standard
+   `ψ_p : ℚ_[p] → ℂˣ` of class field theory is NOT in Mathlib at v4.26.0.
+
+2. **Explicit `MeasureTheory.Measure` on ℚ_[p]**. The general Haar construction
+   in `Mathlib.MeasureTheory.Measure.Haar.Basic` produces a measure on any
+   locally compact group, and `ℚ_[p]` qualifies (proper metric space, additive
+   group). But no file in `Mathlib.NumberTheory.Padics` instantiates
+   `MeasureTheory.Measure ℚ_[p]` with the normalisation `μ(ℤ_[p]) = 1`. This
+   would be a useful small Mathlib PR.
+
+3. **Bruhat–Schwartz functions / Fourier transform on ℚ_[p]**. No analogue of
+   `Mathlib.Analysis.Fourier.FourierTransform` (which is set up for
+   `ℝⁿ` / locally compact abelian groups in the abstract) appears to be
+   specialised to ℚ_[p]. The general `Mathlib.Analysis.Fourier.AddCircle` and
+   `Mathlib.Analysis.Fourier.PontryaginDual` are nearby but not directly
+   applicable until ψ_p is constructed.
+
+## Tractability assessment of the three candidates
+
+| Candidate | Mathlib readiness | S1 effort to formalize | Notes |
+| --- | --- | --- | --- |
+| (C1) trivial character on ℤ_[p] | LOW — needs to construct ψ_p first | medium-high | even the "obvious" statement requires constructing ψ_p; the *content* is then `∫ 1 dμ = μ(ℤ_[p]) = 1` |
+| (C2) self-Fourier of `𝟙_{ℤ_[p]}` | LOW — needs ψ_p + Haar measure + character sum identity on `ℤ/p^k ℤ` | high | full content; deserves a multi-session attack |
+| (C3) Tate / Igusa local zeta | NONE — needs ψ_p, Haar, p-adic Fourier, Mellin | very high | research-grade; Mathlib roadmap target |
+| Complex Gaussian (bonus) | HIGH — already mostly in `Gaussian.GaussianIntegral` + `MeasureTheory.Integral.Pi` | LOW | ~30 line companion lemma; could be added to AreaOfCircleOQ05 directly |
+
+## Recommended S2 plan
+
+**Two parallel tracks**, in order of decreasing safety:
+
+1. **S2a (safe bridge)**: Add `∫_ℂ e^{−π|z|²} dA(z) = 1` as a small companion
+   theorem either in `AreaOfCircleOQ05.lean` (extending the existing real
+   Gaussian file) or in a new `AreaOfCircleOQ05OQ04.lean` scaffold. Reduces to
+   product of two real Gaussians by writing `|z|² = x² + y²` and applying
+   Fubini. Mathlib has all required infrastructure. Estimated: ~50 LOC, no
+   sorries.
+
+2. **S2b (p-adic scaffold, with sorries)**: Create `AreaOfCircleOQ05OQ04.lean`
+   with stubs:
+   - `axiom padicAddChar : ℚ_[p] → ℂ` (or `def padicAddChar … := by sorry`)
+   - the Haar measure normalised on ℤ_[p]
+   - the statement of (C2), with `sorry`-proof
+   This records the gap formally and signals the Mathlib milestones needed.
+
+## References (to seed the JSON)
+
+- Tate, J. "Fourier analysis in number fields and Hecke's zeta-functions"
+  (1950 thesis, in Cassels–Fröhlich, *Algebraic Number Theory*).
+- Igusa, J.-I. "An introduction to the theory of local zeta functions"
+  (AMS/IP Studies in Advanced Math 14, 2000).
+- Gouvêa, F.Q. *p-adic Numbers: An Introduction* (Springer UTM, 3rd ed. 2020).
+- Mahler, K. "An interpolation series for continuous functions of a p-adic
+  variable" (J. Reine Angew. Math. 199, 1958, 23–34).
+- Lewis, R.Y. "A formal proof of Hensel's lemma over the p-adic integers"
+  (CPP 2019) — the original Mathlib `PadicInt` paper.
+
+## Mathlib PRs that would unblock this OQ
+
+(For tracking; not actions for this session.)
+
+- Construct `ψ_p : ℚ_[p] → ℂ` (additive character, standard normalisation).
+  Likely target file: `Mathlib/NumberTheory/Padics/StandardAdditiveCharacter.lean`.
+- Instantiate `MeasureTheory.Measure ℚ_[p]` from
+  `Mathlib.MeasureTheory.Measure.Haar.Basic` with `μ(ℤ_[p]) = 1`. Likely target
+  file: `Mathlib/NumberTheory/Padics/HaarMeasure.lean`.
+- Prove `𝟙_{ℤ_[p]}` is self-Fourier under those data.

--- a/research/area-of-circle-oq-05-oq-04/problem.md
+++ b/research/area-of-circle-oq-05-oq-04/problem.md
@@ -1,0 +1,121 @@
+# area-of-circle-oq-05-oq-04 — Problem Statement
+
+**Parent**: `area-of-circle` (Wiedijk 100 #9), specifically the Gaussian integral branch
+`AreaOfCircleOQ05` (∫ exp(−x²) = √π) and its multivariate extension `AreaOfCircleOQ05OQ02`.
+
+**Source notes** (from `.lean/state/candidate-pool.json`):
+
+> The Gaussian integral over ℂ (and more generally, over p-adic fields ℚ_[p]) takes
+> analogous forms: ∫_{ℚ_[p]} e^{2πi ‖x‖_p} dx = 1. Are adelic Gaussian integrals …
+
+## S1 Observation: the source formula is malformed
+
+The literal formula `∫_{ℚ_[p]} e^{2πi ‖x‖_p} dx = 1` is mathematically ill-posed
+in two distinct ways, both worth recording before any formalization step:
+
+1. **The norm ‖·‖_p is real-valued** (`‖x‖_p = p^{-v_p(x)} ∈ {0} ∪ p^ℤ ⊂ ℝ`), so
+   `e^{2πi ‖x‖_p}` is just a complex exponential of a real number and carries no
+   p-adic information about `x` modulo `p^k`. Whatever this is, it is not the
+   p-adic analogue of `e^{−x²}` on ℝ.
+2. **Integration is against Haar measure on (ℚ_[p], +)**, which is σ-finite but
+   *infinite* on ℚ_[p] itself. So `∫_{ℚ_[p]} f dx` for `f` non-decaying is
+   divergent. The "= 1" can only be correct if either (a) the integration domain
+   is restricted to `ℤ_[p]` (compact, Haar-mass-1 under the standard
+   normalization) or (b) the integrand decays rapidly in `‖x‖_p` (Schwartz–Bruhat).
+
+The OQ author almost certainly intended one of the three well-defined facts below.
+Session S1 deliberately surfaces all three so a later session can pick the right
+target; we do not yet pin a single formal statement.
+
+## Three candidate formal statements
+
+We expect S2 to commit to **(C2)** (the self-Fourier identity), since it is the
+literal p-adic analogue of "the Gaussian is its own Fourier transform" — which is
+the deep fact behind `∫ exp(−x²) dx = √π` and the parent file's polar-coordinates
+argument. (C1) is a trivial restatement and (C3) is much heavier.
+
+### (C1) Restriction-of-character identity (trivial)
+
+Let `ψ_p : ℚ_[p] → ℂ` be the standard additive character (i.e. `ψ_p(x) = 1` for
+`x ∈ ℤ_[p]`; on `ℚ_[p]/ℤ_[p]`, `ψ_p` is determined by `ψ_p(p^{-n}) = e^{2πi/p^n}`).
+Then with Haar measure normalised by `μ(ℤ_[p]) = 1`:
+
+```
+∫_{ℤ_[p]} ψ_p(x) dx = 1.
+```
+
+This is trivial: `ψ_p ≡ 1` on `ℤ_[p]` and `μ(ℤ_[p]) = 1`. Worth recording as the
+"obvious base case" but not the intended theorem.
+
+### (C2) Self-Fourier identity for `𝟙_{ℤ_[p]}` (the intended p-adic Gaussian)
+
+The Bruhat–Schwartz function `f = 𝟙_{ℤ_[p]} : ℚ_[p] → ℂ` plays the role of the
+Gaussian `e^{−πx²}` on ℝ: under the standard self-dual additive character `ψ_p`
+and self-dual Haar measure (i.e. `μ(ℤ_[p]) = 1`), `f` is fixed by Fourier
+transform.
+
+```
+(F f)(ξ) := ∫_{ℚ_[p]} f(x) · ψ_p(ξ · x) dx = 𝟙_{ℤ_[p]}(ξ).
+```
+
+Evaluating at `ξ = 0` gives `μ(ℤ_[p]) = 1`. The *non-trivial* content is at
+`ξ ∉ ℤ_[p]`, where character sums on `ℤ_[p]/p^k ℤ_[p]` vanish for `k` large
+enough — this is Gauss's identity `∑_{a ∈ ℤ/p^k} e^{2πi a/p^k} = 0` (`k ≥ 1`)
+packaged ultrametrically.
+
+**Why this is the right analogue**: on ℝ, the Gaussian `g(x) = e^{−πx²}`
+satisfies `F g = g`, and the area-of-circle / polar-coordinates trick is the
+*proof* that `(F g)(0) = ∫ g = 1`. On ℚ_[p], the indicator `𝟙_{ℤ_[p]}` is
+self-Fourier, and `(F 𝟙)(0) = μ(ℤ_[p]) = 1` is the same statement.
+
+### (C3) Local Tate functional equation / Igusa local zeta
+
+A genuinely deep p-adic identity in the same circle of ideas: the Tate
+local L-factor for the trivial character on ℚ_[p] is
+
+```
+ζ_p(s) = ∫_{ℤ_[p] ∖ {0}} ‖x‖_p^{s-1} d^×x · (1 − p^{-1})  =  1 / (1 − p^{-s}),
+```
+
+and Igusa's local zeta for `f(x) = x²` is
+
+```
+Z_p(s) = ∫_{ℤ_[p]} ‖x‖_p^{2s} dx  =  (1 − p^{-1}) / (1 − p^{-2s-1}).
+```
+
+These ARE the p-adic Gaussian integrals in the sense relevant to adelic
+analysis (Tate's thesis), but they are several Mathlib milestones away.
+
+## Complex case ("over ℂ")
+
+The OQ source also mentions `over ℂ`. The complex Gaussian
+`∫_ℂ e^{−π|z|²} dA(z) = 1` is **already accessible** via Mathlib's existing
+machinery: `Complex.measureSpace`, `MeasureTheory.integral_pi`, and the
+real `∫ e^{−πx²} dx = 1` from `Mathlib.Analysis.SpecialFunctions.Gaussian.*`.
+This is a small bridge lemma, not a research-level open problem.
+
+The S1 recommendation is therefore:
+- Treat the complex case as a *follow-on companion theorem*, ~30 lines, low
+  risk, suitable for a small S2/S3 commit.
+- Treat the p-adic case (C2) as the main S2 target.
+
+## Why this OQ matters
+
+1. **Pedagogical**: makes the role of "the Gaussian as eigenfunction of Fourier
+   transform" explicit, by exhibiting the discrete-Fourier analogue on ℚ_[p].
+2. **Mathlib infrastructure check**: forces an audit of what's available in
+   `Mathlib.NumberTheory.Padics` and `Mathlib.MeasureTheory.Measure.Haar.*`.
+   See `knowledge.md` for the survey.
+3. **Adelic bridge**: the OQ tagline ("Are adelic Gaussian integrals …") points
+   toward the Iwasawa–Tate decomposition `ζ(s) = ζ_∞(s) · ∏_p ζ_p(s)`, where
+   the real Gaussian and the p-adic indicator are the local-factor analogues
+   at the archimedean and non-archimedean places respectively. A successful
+   formalization of (C2) is the first step in that direction.
+
+## Next action (S2 candidate)
+
+State (C2) as a Lean theorem in a new file `Proofs/AreaOfCircleOQ05OQ04.lean`,
+once we have either (a) Haar measure on (ℚ_[p], +) wired up via Mathlib's general
+locally-compact-group Haar machinery, or (b) a hand-rolled `MeasureTheory.Measure`
+on ℚ_[p] from the proper-metric-space structure already in Mathlib. See
+`knowledge.md` §Mathlib gaps.

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -1,0 +1,88 @@
+# area-of-circle-oq-05-oq-04 — Session State
+
+**Slug**: `area-of-circle-oq-05-oq-04`
+**Tier**: B (significance 6, tractability 6)
+**Parent**: `area-of-circle` (Wiedijk 100 #9), Gaussian-integral branch
+**Status**: in-progress
+
+---
+
+## Session S1 — 2026-05-12 (researcher-8)
+
+### Mode
+
+**S1 OBSERVE** — markdown-only orientation pass. No Lean files added or modified.
+
+### Inputs
+
+- `.lean/state/candidate-pool.json` entry for slug; phase `NEW`, no prior research
+  artifacts (research/ dir did not exist before this session).
+- Parent file `proofs/Proofs/AreaOfCircleOQ05.lean` (scalar Gaussian, proved).
+- Sibling `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` (multivariate Gaussian, proved).
+- Mathlib v4.26.0 via `gh api repos/leanprover-community/mathlib4/contents/...`.
+
+### Output
+
+Three new files:
+1. `research/area-of-circle-oq-05-oq-04/problem.md` — corrects the malformed
+   source formula `∫_{ℚ_[p]} e^{2πi ‖x‖_p} dx = 1`, surfaces three candidate
+   well-defined p-adic Gaussian identities (C1 trivial, C2 self-Fourier, C3
+   Tate/Igusa), notes the bonus complex case.
+2. `research/area-of-circle-oq-05-oq-04/knowledge.md` — Mathlib API survey:
+   PadicInt/ProperSpace/AddChar/MahlerBasis present; standard additive
+   character `ψ_p : ℚ_[p] → ℂ` and explicit Haar measure on ℚ_[p] are
+   **absent**. Tractability table; references seed.
+3. `src/data/research/problems/area-of-circle-oq-05-oq-04.json` — phase
+   `NEW → RESEARCH`, populated `problemStatement.formal` /
+   `currentState.focus` / `currentState.nextAction` /
+   `knowledge.{insights,mathlibGaps,nextSteps}` / `references`.
+
+### Key observations
+
+1. **The OQ source formula is ill-posed**. `‖·‖_p` is real-valued, so
+   `e^{2πi ‖x‖_p}` is not the p-adic analogue of `e^{−x²}`. The intended
+   statement is plausibly one of:
+   - (C1) `∫_{ℤ_[p]} ψ_p(x) dx = 1` (trivial)
+   - (C2) `𝟙_{ℤ_[p]}` is self-Fourier under `(ψ_p, Haar μ(ℤ_[p])=1)` (intended)
+   - (C3) Tate/Igusa local zeta identities (deepest)
+   - Bonus: `∫_ℂ e^{−π|z|²} dA = 1` (immediate from Mathlib).
+
+2. **Mathlib readiness is split**:
+   - ✅ `ℤ_[p]` compact, `ℚ_[p]` proper / locally compact (`PadicInt.ProperSpace`).
+   - ✅ Real Gaussian integral `integral_gaussian` (used by OQ-05).
+   - ❌ Standard additive character `ψ_p : ℚ_[p] → ℂ` is NOT in Mathlib at v4.26.0.
+   - ❌ Explicit `MeasureTheory.Measure ℚ_[p]` with `μ(ℤ_[p]) = 1` is NOT instantiated;
+     general Haar machinery in `Mathlib.MeasureTheory.Measure.Haar.Basic`
+     applies in principle.
+   - 🟡 `Mathlib.NumberTheory.Padics.AddChar` exists but covers continuous
+     `ℤ_[p] → R` characters where `R` is a `ℤ_[p]`-algebra — *dual* of what (C2)
+     needs.
+
+3. **Recommended S2 split**:
+   - **S2a (low-risk bridge)**: complex Gaussian `∫_ℂ e^{−π|z|²} dA = 1`
+     as a ~50-line companion theorem in a new
+     `proofs/Proofs/AreaOfCircleOQ05OQ04.lean`. All required Mathlib API is in
+     place (`integral_gaussian`, `MeasureTheory.Integral.Pi`).
+   - **S2b (p-adic scaffold, sorry-bearing)**: state (C2) as a Lean theorem
+     with placeholder definitions for `ψ_p` and the Haar measure on ℚ_[p],
+     `sorry`-bodies in the relevant lemmas. Records the gap; signals Mathlib
+     milestones needed (two PRs: standard ψ_p, Haar on ℚ_[p]).
+
+### Next action (for S2)
+
+Write `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` with the complex Gaussian
+identity (S2a) as the *proved* main theorem of the file, and the p-adic
+self-Fourier statement (C2) as a `sorry`-bearing section guarded by `axiom`
+declarations for the missing `ψ_p` and Haar normalisation. This is the
+"S20-style explicitly deferred" pattern: the proved part advances the slug,
+the axiomatised part records the open p-adic content.
+
+### Risk notes
+
+- The OQ has 2 stale, 25-deep sibling-OQ chain in `relatedProofs` —
+  `area-of-circle` family is large and active. Race check before S2: at S1
+  start (2026-05-12T07:58Z) there were 0 open PRs / 0 remote branches / 0
+  recent merges for this slug. Re-check at S2 start.
+- Memory entry "[Researcher worktree claim-script setup]" was relevant:
+  fresh worktree had no `.lean/state/` symlink and isolated `research/claims/`.
+  Both fixed at session start.

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -1,0 +1,463 @@
+{
+  "slug": "area-of-circle-oq-05-oq-04",
+  "title": "The Gaussian integral over $\\mathbb{C}$ (and more generally, over $p$-adic fi...",
+  "phase": "RESEARCH",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Three candidate formal statements (S1 deliberately defers single-target commit):\n(C1) Trivial: integral over Z_p of psi_p(x) dx = 1, where psi_p == 1 on Z_p and Haar mu(Z_p) = 1.\n(C2) Self-Fourier (intended): for the standard p-adic additive character psi_p : Q_p -> C and self-dual Haar measure (mu(Z_p) = 1), the indicator function f = 1_{Z_p} satisfies (F f)(xi) := integral over Q_p of f(x) * psi_p(xi*x) dx = 1_{Z_p}(xi). At xi = 0 this gives mu(Z_p) = 1; at xi not in Z_p the integrand-sum is a Gauss-sum-style character sum on Z/p^k Z that vanishes. This is the p-adic analogue of exp(-pi x^2) being a fixed point of the real Fourier transform.\n(C3) Tate/Igusa local zeta: integral over Z_p of |x|_p^s dx = (1 - p^{-1})/(1 - p^{-s-1}) (Igusa, f = x), giving the local Euler factor 1/(1 - p^{-s}) of zeta(s).\nBonus (immediate from Mathlib): integral over C of exp(-pi |z|^2) dA(z) = 1, via Fubini reduction to the real Gaussian.",
+    "plain": "p-adic analogue(s) of the Gaussian integral. The source candidate-pool entry states the integral over Q_p of e^{2*pi*i * ||x||_p} dx = 1, but this formula is ill-posed: ||.||_p is real-valued, so e^{2*pi*i * ||x||_p} carries no p-adic information about x mod p^k, and Haar measure on Q_p is infinite. We surface three well-defined alternative statements; (C2) self-Fourier of 1_{Z_p} is the right analogue of 'the Gaussian is its own Fourier transform' and is the recommended S2 target. Plus a small bonus: complex Gaussian over the plane integrates to 1, immediate from Mathlib.",
+    "whyMatters": [
+      "Pedagogical: the area-of-circle / polar-coordinates derivation of integral over R of exp(-x^2) dx = sqrt(pi) is a story about the Gaussian being a Fourier eigenfunction. The p-adic version (C2) makes this discrete/ultrametric and exhibits the same eigenfunction property for 1_{Z_p}, which is the deeper picture behind the surface formula.",
+      "Adelic bridge: in Tate's thesis the zeta-function factors as zeta(s) = zeta_infty(s) * prod_p zeta_p(s); the real Gaussian is the local factor at the archimedean place, and 1_{Z_p} is the local factor at the p-adic places. Formalising (C2) is the first p-adic milestone on that path.",
+      "Mathlib audit: the work surfaces two missing pieces - the standard additive character psi_p : Q_p -> C and an explicit Haar measure on Q_p with mu(Z_p) = 1. Both are plausible small Mathlib PRs."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Real Gaussian integral: integral over R of exp(-x^2) dx = sqrt(pi) (Mathlib integral_gaussian; already used in Proofs/AreaOfCircleOQ05.lean).",
+      "Multivariate Gaussian via spectral theorem (Proofs/AreaOfCircleOQ05OQ02.lean).",
+      "Complex Gaussian: integral over C of exp(-pi |z|^2) dA(z) = 1 - accessible from existing Mathlib; to be added in S2a.",
+      "Z_p is compact, Q_p is a proper metric space (Mathlib PadicInt.compactSpace, Padic.instProperSpace)."
+    ],
+    "open": [
+      "(C1) and (C2) require constructing the standard additive character psi_p : Q_p -> C - not in Mathlib at v4.26.0. Mathlib's Mathlib.NumberTheory.Padics.AddChar covers the dual direction (continuous characters Z_p -> R for R a Z_p-algebra).",
+      "Haar measure on (Q_p, +) normalised so mu(Z_p) = 1 is not explicitly instantiated in Mathlib; the general construction in Mathlib.MeasureTheory.Measure.Haar.Basic applies but needs a wrapper.",
+      "(C3) Tate/Igusa local zeta identities are several Mathlib milestones away."
+    ],
+    "goal": "Recommended path: S2a proves the complex Gaussian (low-risk bridge); S2b writes a sorry-bearing p-adic scaffold of (C2) flagged with axioms for the missing psi_p and Haar measure. Eventual full proof of (C2) blocks on two Mathlib contributions (standard psi_p, Haar on Q_p)."
+  },
+  "currentState": {
+    "phase": "RESEARCH",
+    "since": "2026-05-12T08:03:22.732Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE: surface that the source formula is malformed; identify three well-defined candidate p-adic Gaussian/Fourier identities and audit Mathlib readiness. Next: S2 writes a small Lean file with the complex Gaussian identity (provable) plus a sorry-bearing scaffold for the p-adic self-Fourier statement (axiomatised).",
+    "blockers": [],
+    "nextAction": "S2: create proofs/Proofs/AreaOfCircleOQ05OQ04.lean with (a) the complex Gaussian integral over the plane, proved via Fubini + integral_gaussian, and (b) axiom padicAddChar / sorry-stub for the self-Fourier identity 1_{Z_p} fixed by Fourier transform. See research/area-of-circle-oq-05-oq-04/{problem,knowledge,state}.md.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete. The candidate-pool slug's source formula is malformed; three well-defined alternatives stated. Mathlib has PadicInt/ProperSpace/AddChar but lacks the standard C-valued additive character on Q_p and an explicit Haar measure on Q_p. Complex Gaussian companion identity is immediate; recommended as S2a target.",
+    "builtItems": [
+      {
+        "item": "S1 OBSERVE markdown set (problem.md, knowledge.md, state.md)",
+        "session": "S1"
+      },
+      {
+        "item": "Identification of the source formula as ill-posed and three corrected statements",
+        "session": "S1"
+      },
+      {
+        "item": "Mathlib readiness audit (PadicInt/Padic/AddChar/Haar)",
+        "session": "S1"
+      }
+    ],
+    "insights": [
+      "||.||_p is real-valued, so e^{2*pi*i * ||x||_p} is a complex exponential of a real number and does not encode p-adic data - the source OQ formula is malformed.",
+      "The 'right' p-adic Gaussian is 1_{Z_p}: it is the unique (up to scaling) fixed point of the p-adic Fourier transform under the self-dual choice of additive character and Haar measure, exactly as exp(-pi x^2) is the Fourier eigenfunction in the archimedean case.",
+      "The polar-coordinates / area-of-circle derivation of integral over R of exp(-x^2) dx = sqrt(pi) has no direct p-adic analogue because there is no continuous rotation group on Q_p; the corresponding p-adic statement is the character-sum identity sum over a in Z/p^k Z of e^{2*pi*i a / p^k} = 0 for k >= 1, packaged ultrametrically.",
+      "Mathlib's PadicInt.AddChar covers Z_p -> R characters for Z_p-algebras R - this is the Cartier dual direction. The standard psi_p : Q_p -> C is in the opposite direction and absent from Mathlib v4.26.0."
+    ],
+    "mathlibGaps": [
+      "No padicAddChar : Q_p -> C (standard additive character with psi_p|_{Z_p} = 1, psi_p(p^{-n}) = e^{2*pi*i/p^n}).",
+      "No explicit MeasureTheory.Measure Q_p instance normalised so mu(Z_p) = 1 (general Haar machinery applies but needs a wrapper file).",
+      "No Bruhat-Schwartz function space or Fourier-transform infrastructure specialised to Q_p."
+    ],
+    "nextSteps": [
+      "S2a: prove the complex Gaussian integrates to 1 via Fubini + integral_gaussian in a new file proofs/Proofs/AreaOfCircleOQ05OQ04.lean; ~50 LOC, 0 sorries.",
+      "S2b: state (C2) as a Lean theorem with axiom padicAddChar and a Haar-measure stub; record the proof as sorry with a docstring explaining the character-sum-vanishing argument.",
+      "S3+: replace the axiom by an actual definition once a Mathlib PR for psi_p lands; replace the sorry by the character-sum argument."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "integration",
+    "gaussian",
+    "pi",
+    "probability",
+    "normal-distribution",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-01-oq-02-oq-01",
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02",
+    "area-of-circle-oq-01-oq-02-oq-01-oq-03",
+    "area-of-circle-oq-01-oq-02-oq-02",
+    "area-of-circle-oq-01-oq-02-oq-02-oq-01",
+    "area-of-circle-oq-01-oq-02-oq-03",
+    "area-of-circle-oq-01-oq-02-oq-03-oq-03",
+    "area-of-circle-oq-01-oq-03",
+    "area-of-circle-oq-01-oq-03-oq-01",
+    "area-of-circle-oq-01-oq-03-oq-02",
+    "area-of-circle-oq-02",
+    "area-of-circle-oq-02-oq-01",
+    "area-of-circle-oq-02-oq-04",
+    "area-of-circle-oq-03-oq-01",
+    "area-of-circle-oq-03-oq-02",
+    "area-of-circle-oq-03-oq-02-oq-02",
+    "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "area-of-circle-oq-03-oq-03",
+    "area-of-circle-oq-03-oq-03-oq-02",
+    "area-of-circle-oq-05",
+    "area-of-circle-oq-05-oq-01",
+    "area-of-circle-oq-05-oq-02"
+  ],
+  "references": {
+    "papers": [
+      {
+        "author": "Tate, J.",
+        "title": "Fourier analysis in number fields and Hecke's zeta-functions",
+        "year": 1950,
+        "venue": "Princeton thesis (in Cassels-Frohlich, Algebraic Number Theory)"
+      },
+      {
+        "author": "Igusa, J.-I.",
+        "title": "An introduction to the theory of local zeta functions",
+        "year": 2000,
+        "venue": "AMS/IP Studies in Advanced Math 14"
+      },
+      {
+        "author": "Gouvea, F. Q.",
+        "title": "p-adic Numbers: An Introduction",
+        "year": 2020,
+        "venue": "Springer UTM, 3rd ed."
+      },
+      {
+        "author": "Mahler, K.",
+        "title": "An interpolation series for continuous functions of a p-adic variable",
+        "year": 1958,
+        "venue": "J. Reine Angew. Math. 199, 23-34"
+      },
+      {
+        "author": "Lewis, R. Y.",
+        "title": "A formal proof of Hensel's lemma over the p-adic integers",
+        "year": 2019,
+        "venue": "CPP 2019"
+      }
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.Padics.PadicNumbers",
+      "Mathlib.NumberTheory.Padics.PadicIntegers",
+      "Mathlib.NumberTheory.Padics.ProperSpace",
+      "Mathlib.NumberTheory.Padics.AddChar",
+      "Mathlib.NumberTheory.Padics.MahlerBasis",
+      "Mathlib.MeasureTheory.Measure.Haar.Basic",
+      "Mathlib.MeasureTheory.Measure.Haar.Unique",
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.MeasureTheory.Integral.Pi"
+    ]
+  },
+  "started": "2026-05-08T19:09:00.560Z",
+  "lastUpdate": "2026-05-12T08:03:22.732Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AreaOfCircle.lean",
+      "filename": "AreaOfCircle.lean",
+      "lineCount": 156,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircle.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
+      "lineCount": 291,
+      "theoremCount": 26,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
+      "lineCount": 151,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
+      "lineCount": 164,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
+      "lineCount": 211,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ03.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ01OQ03.lean",
+      "lineCount": 196,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ02.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ02.lean",
+      "lineCount": 83,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ02OQ01.lean",
+      "lineCount": 420,
+      "theoremCount": 11,
+      "axiomCount": 5,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
+      "lineCount": 218,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ02OQ03OQ03.lean",
+      "filename": "AreaOfCircleOQ01OQ02OQ03OQ03.lean",
+      "lineCount": 303,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ02OQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
+      "filename": "AreaOfCircleOQ01OQ03.lean",
+      "lineCount": 1938,
+      "theoremCount": 52,
+      "axiomCount": 0,
+      "defCount": 11,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ03Aristotle.lean",
+      "filename": "AreaOfCircleOQ01OQ03Aristotle.lean",
+      "lineCount": 101,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ03OQ01.lean",
+      "filename": "AreaOfCircleOQ01OQ03OQ01.lean",
+      "lineCount": 713,
+      "theoremCount": 26,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
+      "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
+      "lineCount": 566,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ02.lean",
+      "filename": "AreaOfCircleOQ02.lean",
+      "lineCount": 212,
+      "theoremCount": 16,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
+      "filename": "AreaOfCircleOQ02OQ01.lean",
+      "lineCount": 164,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ02OQ04.lean",
+      "filename": "AreaOfCircleOQ02OQ04.lean",
+      "lineCount": 273,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ01.lean",
+      "filename": "AreaOfCircleOQ03OQ01.lean",
+      "lineCount": 233,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ02.lean",
+      "filename": "AreaOfCircleOQ03OQ02.lean",
+      "lineCount": 103,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ02OQ02.lean",
+      "filename": "AreaOfCircleOQ03OQ02OQ02.lean",
+      "lineCount": 205,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean",
+      "filename": "AreaOfCircleOQ03OQ02OQ02OQ01.lean",
+      "lineCount": 255,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ03.lean",
+      "filename": "AreaOfCircleOQ03OQ03.lean",
+      "lineCount": 191,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ03OQ03OQ02.lean",
+      "filename": "AreaOfCircleOQ03OQ03OQ02.lean",
+      "lineCount": 190,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ05.lean",
+      "filename": "AreaOfCircleOQ05.lean",
+      "lineCount": 133,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
+      "filename": "AreaOfCircleOQ05OQ01.lean",
+      "lineCount": 232,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ05OQ01Aristotle.lean",
+      "filename": "AreaOfCircleOQ05OQ01Aristotle.lean",
+      "lineCount": 78,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
+      "filename": "AreaOfCircleOQ05OQ02.lean",
+      "lineCount": 190,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **S1 OBSERVE** on `area-of-circle-oq-05-oq-04` ("Gaussian integral over ℂ and ℚ_[p]"). Markdown-only orientation pass; no Lean files added or modified.
- **Surfaces the source formula as ill-posed**: the candidate-pool entry's `∫_{ℚ_[p]} e^{2πi ‖x‖_p} dx = 1` is malformed because `‖·‖_p` is real-valued (so the integrand carries no p-adic data about `x mod p^k`) and Haar measure on `ℚ_[p]` is infinite.
- **Three well-defined alternatives stated**:
  - (C1) Trivial: `∫_{ℤ_[p]} ψ_p dx = 1`.
  - (C2) **Self-Fourier (recommended S2 target)**: `1_{ℤ_[p]}` is the p-adic analogue of the Gaussian Fourier-eigenfunction; `F(1_{ℤ_[p]}) = 1_{ℤ_[p]}` under standard `ψ_p` and self-dual Haar.
  - (C3) Tate/Igusa local zeta — several Mathlib milestones away.
  - Bonus: `∫_ℂ e^{−π|z|²} dA(z) = 1` is immediate from Mathlib.
- **Mathlib v4.26.0 audit**:
  - ✅ `PadicInt.compactSpace`, `Padic.instProperSpace` (ℚ_[p] locally compact).
  - ❌ Standard `ψ_p : ℚ_[p] → ℂ` is NOT in Mathlib (`Mathlib.NumberTheory.Padics.AddChar` covers the dual direction `ℤ_[p] → R` for `ℤ_[p]`-algebras `R`).
  - ❌ No explicit `MeasureTheory.Measure ℚ_[p]` instance normalised so `μ(ℤ_[p]) = 1`.

## Files

- `research/area-of-circle-oq-05-oq-04/problem.md` (new) — corrects the formula, states (C1)/(C2)/(C3) + complex bonus.
- `research/area-of-circle-oq-05-oq-04/knowledge.md` (new) — Mathlib API survey; tractability table; gap list.
- `research/area-of-circle-oq-05-oq-04/state.md` (new) — S1 session log; next-action plan.
- `src/data/research/problems/area-of-circle-oq-05-oq-04.json` (new) — phase `NEW → RESEARCH`; populated `problemStatement.formal`, `currentState.focus/nextAction`, `knowledge.{insights,mathlibGaps,nextSteps}`, `references`.

## Next action (S2)

Two parallel sub-tasks in `proofs/Proofs/AreaOfCircleOQ05OQ04.lean`:
- **S2a (safe bridge)**: prove `∫_ℂ e^{−π|z|²} dA(z) = 1` via Fubini + `integral_gaussian` (~50 LOC, 0 sorries).
- **S2b (p-adic scaffold)**: state (C2) with `axiom padicAddChar` + Haar-measure stub + `sorry` on the character-sum-vanishing step. Records the gap; signals two Mathlib milestones (standard `ψ_p`, Haar on `ℚ_[p]`).

## Axiom delta

- **No new axioms** in this PR.
- **No new sorries** in this PR.
- No Lean files changed.

## Test plan

- [x] Worktree-local files only; no Lean build needed.
- [x] JSON `phase` advanced `NEW → RESEARCH`; `currentState.focus`/`nextAction` populated.
- [x] Race-check `gh pr list --search` empty at commit time and immediately before push.
- [x] References/insights/mathlibGaps populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)