### PR TITLE
audit(combinations-formula-oq-02): demote verified→formalized, sorries 0→1

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",


### PR DESCRIPTION
## Summary

- Demote `status` from `verified` → `formalized` for `combinations-formula-oq-02`
- Bump `sorries` from `0` → `1` to reflect the Aristotle companion sorry stub
- Resolves the final entry from the 9-entry follow-up batch in issue #17291 (closed); the other 8 were migrated previously

## Why

The Aristotle companion file `CombinationsFormulaOQ02Aristotle.lean` contains 1 `sorry` stub for `catalan_mul_succ` (line 89). The main file `CombinationsFormulaOQ02.lean` proves `catalan_mul_succ` in full (lines 112-120), but the companion has its own independent stub for proof-search purposes.

Per the precedent from PR #17295 and PR #17300 (Option C in #17291), entries with verified main files but Aristotle-companion sorries should be downgraded to `status: formalized` with `sorries` reflecting the aggregate companion count.

This is a doc/meta-only change — no Lean code is modified.

## Verification

```
$ npx tsx scripts/auditor/find-targets.ts --issues
combinations-formula-oq-02 (5x, last 2026-05-12) [verified/original] ❌ sorry mismatch: claims 0, actual 1; status "verified" but has 1 sorries
```

After this PR, `find-targets.ts --issues` should return empty.

## Test plan

- [x] meta.json `status` and `sorries` updated
- [x] No Lean code changes
- [ ] Auditor confirms `--issues` is empty after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)