### PR TITLE
audit(combinations-formula-oq-02): close Aristotle sorry in catalan_mul_succ

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
@@ -83,10 +83,24 @@ theorem succ_dvd_centralBinom (n : ℕ) : (n + 1) ∣ centralBinom n := by
       rw [Nat.coprime_comm]; exact Nat.coprime_succ_self (m + 1)
     exact hcop.dvd_of_dvd_mul_right hdvd
 
-/-- **Fundamental Catalan identity**: C_n * (n+1) = C(2n, n). -/
+/-- **Fundamental Catalan identity**: C_n * (n+1) = C(2n, n).
+    Proof: catalan n = C(2n,n) - C(2n,n+1), so catalan n * (n+1) =
+    C(2n,n)*(n+1) - C(2n,n+1)*(n+1) = C(2n,n)*(n+1) - C(2n,n)*n = C(2n,n).
+    The auxiliary identity C(2n,n+1)*(n+1) = C(2n,n)*n is proved inline via
+    `Nat.choose_succ_right_eq` to avoid a forward reference to `choose_2n_succ`. -/
 theorem catalan_mul_succ (n : ℕ) :
     catalan n * (n + 1) = centralBinom n := by
-  sorry
+  show catalan n * (n + 1) = Nat.choose (2 * n) n
+  simp only [catalan]
+  rw [Nat.sub_mul]
+  have hcs : Nat.choose (2 * n) (n + 1) * (n + 1) = Nat.choose (2 * n) n * n := by
+    have h := Nat.choose_succ_right_eq (2 * n) n
+    simp only [show 2 * n - n = n from by omega] at h
+    linarith [mul_comm (Nat.choose (2 * n) n) n]
+  rw [hcs]
+  have hbound : Nat.choose (2 * n) n * n ≤ Nat.choose (2 * n) n * (n + 1) :=
+    Nat.mul_le_mul_left _ (Nat.le_succ n)
+  omega
 
 /-- C(2n, n+1) * (n+1) = C(2n, n) * n (divisibility relationship). -/
 theorem choose_2n_succ (n : ℕ) :


### PR DESCRIPTION
## Summary

Replaces the `sorry` stub at line 89 of `CombinationsFormulaOQ02Aristotle.lean` with a self-contained proof of `catalan_mul_succ : catalan n * (n+1) = centralBinom n`.

The same theorem is proved in the main file `CombinationsFormulaOQ02.lean` (lines 112-120) using `choose_2n_succ` as a prerequisite. Here we inline the auxiliary identity `C(2n,n+1)*(n+1) = C(2n,n)*n` (via `Nat.choose_succ_right_eq`) to avoid a forward reference to the file-local `choose_2n_succ` defined at line 92.

## Why this PR (and not another meta-only revert)

This entry has been bouncing between `verified/0` and `formalized/1` for weeks because the Aristotle file's sorry was never closed:

- PR #17717 (MERGED): meta `sorries: 1 → 0` (incorrect — Aristotle file still had sorry)
- PR #17765 (MERGED): meta `sorries: 0 → 1` (corrective revert)
- PR #17936 (MERGED): meta `sorries: 1 → 0` (incorrect again — same false reading: "Aristotle apparently completed the target")
- PR #17951 / PR #17987 (OPEN): proposed `sorries: 0 → 1` reverts (correct, but only re-tag, not durable)

With this PR, both files genuinely have **0 sorries**, so the merged-PR-#17936 state (`status: verified`, `sorries: 0`) becomes **accurate**. The two open revert PRs (#17951, #17987) can be closed without re-merging once this is in.

## Verification

```
$ grep -n "sorry\|^axiom\b" proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
(no matches)
```

The new proof mirrors the main file's strategy but inlines the auxiliary `choose_2n_succ`-style step to keep the theorem self-contained at its position in the file.

## Test plan

- [x] No more `sorry` in `CombinationsFormulaOQ02Aristotle.lean`
- [x] No more `sorry` in `CombinationsFormulaOQ02.lean` (unchanged)
- [x] meta.json already says `status: verified, sorries: 0` — now genuinely accurate
- [ ] CI / docker build verifies the Lean proof typechecks
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` returns empty after merge

Severity: **HIGH** — durable fix for an oscillation that has consumed at least 5 audit cycles.

Generated by lean-auditor agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)