### PR TITLE
research(szemeredi-core-oq-04): S4 ACT — witness-family API for ADLRY ε-grid proof (sorry-free, build verified)

### DIFF
--- a/proofs/Proofs/SzemerediCoreOQ04.lean
+++ b/proofs/Proofs/SzemerediCoreOQ04.lean
@@ -86,6 +86,79 @@ lemma witnessFamilyB_subset (G : SimpleGraph V) [DecidableRel G.Adj]
     rw [← ha]
     exact Finset.filter_subset _ _
 
+/-! ### Membership API for the ε-grid
+
+These lemmas are the building blocks for the S5 ADLRY implication proof.
+The slack-4 implication needs to instantiate `IsWitnessRegular` at the two
+members of the witness family produced by each `a ∈ A` (the neighbour
+pattern and its complement), and then average the bounds. The lemmas in
+this subsection expose the witness family as a clean union of two
+neighbourhood-indexed images and prove the standard disjoint-decomposition
+identities. -/
+
+/-- For any `a ∈ A`, the neighbour-pattern `B ∩ N(a)` is in the witness
+    family. Used by the S5 ADLRY proof to apply `IsWitnessRegular` at the
+    relevant per-vertex test set. -/
+lemma mem_witnessFamilyB_nhd (G : SimpleGraph V) [DecidableRel G.Adj]
+    {A B : Finset V} {a : V} (ha : a ∈ A) :
+    B.filter (fun b => G.Adj a b) ∈ witnessFamilyB G A B := by
+  unfold witnessFamilyB
+  exact Finset.mem_union_left _ (Finset.mem_image.mpr ⟨a, ha, rfl⟩)
+
+/-- For any `a ∈ A`, the complement `B \ N(a)` is in the witness family.
+    The companion of `mem_witnessFamilyB_nhd`. -/
+lemma mem_witnessFamilyB_compl (G : SimpleGraph V) [DecidableRel G.Adj]
+    {A B : Finset V} {a : V} (ha : a ∈ A) :
+    B.filter (fun b => ¬ G.Adj a b) ∈ witnessFamilyB G A B := by
+  unfold witnessFamilyB
+  exact Finset.mem_union_right _ (Finset.mem_image.mpr ⟨a, ha, rfl⟩)
+
+/-- Characterization of membership in the witness family. -/
+lemma mem_witnessFamilyB_iff (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B B' : Finset V) :
+    B' ∈ witnessFamilyB G A B ↔
+      (∃ a ∈ A, B' = B.filter (fun b => G.Adj a b)) ∨
+      (∃ a ∈ A, B' = B.filter (fun b => ¬ G.Adj a b)) := by
+  unfold witnessFamilyB
+  constructor
+  · intro h
+    rcases Finset.mem_union.mp h with h | h
+    · obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp h
+      exact Or.inl ⟨a, ha, rfl⟩
+    · obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp h
+      exact Or.inr ⟨a, ha, rfl⟩
+  · intro h
+    rcases h with ⟨a, ha, rfl⟩ | ⟨a, ha, rfl⟩
+    · exact Finset.mem_union_left _ (Finset.mem_image.mpr ⟨a, ha, rfl⟩)
+    · exact Finset.mem_union_right _ (Finset.mem_image.mpr ⟨a, ha, rfl⟩)
+
+/-- The two ε-grid members for a single `a ∈ A` partition `B` disjointly.
+    This is the classical "neighbour-pattern / non-neighbour-pattern"
+    decomposition used in the ADLRY proof: applying `IsWitnessRegular`
+    to BOTH members yields a per-vertex density estimate, and the
+    cardinalities sum to `|B|`. -/
+lemma witnessFamilyB_card_split (G : SimpleGraph V) [DecidableRel G.Adj]
+    (B : Finset V) (a : V) :
+    (B.filter (fun b => G.Adj a b)).card +
+      (B.filter (fun b => ¬ G.Adj a b)).card = B.card :=
+  Finset.filter_card_add_filter_neg_card_eq_card (fun b => G.Adj a b)
+
+/-- For each `a ∈ A`, at least one of `B ∩ N(a)` and `B \ N(a)` has size
+    at least `|B| / 2`. This is the pigeonhole step used by the ADLRY
+    slack-4 implication: it guarantees that at least one ε-grid witness
+    is "large" (≥ eps · |B|) whenever `eps ≤ 1/2`. -/
+lemma witnessFamilyB_card_half (G : SimpleGraph V) [DecidableRel G.Adj]
+    (B : Finset V) (a : V) :
+    2 * (B.filter (fun b => G.Adj a b)).card ≥ B.card ∨
+    2 * (B.filter (fun b => ¬ G.Adj a b)).card ≥ B.card := by
+  have hsum : (B.filter (fun b => G.Adj a b)).card +
+      (B.filter (fun b => ¬ G.Adj a b)).card = B.card :=
+    witnessFamilyB_card_split (G := G) B a
+  by_contra hlt
+  push_neg at hlt
+  obtain ⟨h1, h2⟩ := hlt
+  omega
+
 /-! ## Part 2: The decidable surrogate -/
 
 /-- `IsWitnessRegular G eps A B` is the ADLRY surrogate for ε-regularity:


### PR DESCRIPTION
## Summary

S4 iteration on `szemeredi-core-oq-04` (Algorithmic Szemerédi, ADLRY 1994). Closes the witness-family API gap that blocks the S5 ADLRY slack-4 implication proof.

**Outcome**: progress — added 5 sorry-free supporting lemmas. No change in sorry count (still 1, on the main implication).

## What I added (73 lines)

New "Membership API for the ε-grid" subsection of `proofs/Proofs/SzemerediCoreOQ04.lean` (lines 89–160):

1. **`mem_witnessFamilyB_nhd`** — for `a ∈ A`, the neighbour pattern `B.filter (G.Adj a)` is in `witnessFamilyB G A B`. Used by the S5 proof to apply `IsWitnessRegular` per-vertex.
2. **`mem_witnessFamilyB_compl`** — dual for the non-neighbour pattern.
3. **`mem_witnessFamilyB_iff`** — membership characterization as a disjunction over the two image families. Pattern-matching primitive for S5's case analysis.
4. **`witnessFamilyB_card_split`** — `|B ∩ N(a)| + |B \ N(a)| = |B|` via Mathlib's `Finset.filter_card_add_filter_neg_card_eq_card`.
5. **`witnessFamilyB_card_half`** — pigeonhole: `2|B ∩ N(a)| ≥ |B| ∨ 2|B \ N(a)| ≥ |B|`. Handles the slack-4 proof's "one ε-grid member may be small" edge case.

## Why this is the right S4 deliverable

Iteration-3's plan asked for the full `witness_regular_implies_epsilon_regular` proof (60-100 lines). Inspection showed step 2 (per-vertex application of `IsWitnessRegular` to both ε-grid members for each `a ∈ A`) was sitting on an **API gap**: the file had `witnessFamilyB_subset` (member → ⊆ B) but no membership-direction lemmas. Closing this gap turns the S5 attempt into a focused arithmetic proof rather than an API-derivation exercise.

## Build status

**Verified** via `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04`:
- 7744 jobs, build succeeded
- Only the pre-existing `sorry` warning on `witness_regular_implies_epsilon_regular` at line 234
- All 5 new lemmas compile sorry-free
- Standard `unusedSectionVars` linter warnings on `[Fintype V]` / `[DecidableEq V]` (pre-existing pattern from S2/S3)

## Files modified

- `proofs/Proofs/SzemerediCoreOQ04.lean` — +73 lines (file 238 → 311)
- `src/data/research/problems/szemeredi-core-oq-04.json` — iter 3 → 4, builtItems +5
- `research/problems/szemeredi-core-oq-04/{knowledge.md, state.md}` — S4 entry

## Status

**Outcome**: progress (infrastructure)
**Next Steps (S5)**: prove `witness_regular_implies_epsilon_regular` using the new API. Sketch:
1. Prove `edgeDensity_eq_sum_neighborhood` via Mathlib's `Finset.sum_product` + `Finset.card_eq_sum_ones`.
2. Decompose `edgeDensity G A B − edgeDensity G A' B'` into per-vertex contributions.
3. Bound each contribution via `mem_witnessFamilyB_{nhd,compl} ha` + `hreg`.
4. Average using `witnessFamilyB_card_half`. Estimated 60-80 lines.

## Honesty Note

This iteration **does not reduce the sorry count** (still 1 sorry retained on the main implication). It adds API surface that makes the main implication tractable. By the gallery's progress-honesty rules, this is "infrastructure" rather than a proof advance.

🤖 Generated by researcher-3