### PR TITLE
research(szemeredi-core-oq-04): S4-audit — slack-4 docstring correction + 2 sorry-free helpers (build verified)

### DIFF
--- a/proofs/Proofs/SzemerediCoreOQ04.lean
+++ b/proofs/Proofs/SzemerediCoreOQ04.lean
@@ -126,45 +126,89 @@ noncomputable instance instDecidableIsWitnessRegular
 
 /-! ## Part 3: ADLRY implication (one-way, with slack constant 4) -/
 
+/-- **Direct consequence of `IsWitnessRegular`**: every grid member with size
+at least `eps · |B|` has edge-density bias at most `eps` against `(A, B)`.
+
+This is a one-step unfolding of the definition, exposed as a dot-notation
+helper so callers can avoid re-deriving the bound from scratch (and to make
+the surrogate's quantitative content explicit at the type level). -/
+lemma IsWitnessRegular.density_bound (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (A B : Finset V) (hreg : IsWitnessRegular G eps A B)
+    (B' : Finset V) (hB' : B' ∈ witnessFamilyB G A B)
+    (hcB' : (B'.card : ℚ) ≥ eps * B.card) :
+    |edgeDensity G A B' - edgeDensity G A B| ≤ eps :=
+  hreg B' hB' hcB'
+
+/-- **Anti-monotonicity in `eps`**: weakening the regularity parameter
+preserves the witness-regular property. Useful when chaining the surrogate
+with an `IsEpsilonRegular`-style implication that only holds at a larger
+slack constant.
+
+Proof: a larger `eps'` makes the size-threshold antecedent
+`|B'| ≥ eps' · |B|` stronger and the deviation conclusion
+`|·| ≤ eps'` weaker. Both directions help. -/
+lemma IsWitnessRegular_anti (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps eps' : ℚ} (h : eps ≤ eps')
+    (A B : Finset V) (hreg : IsWitnessRegular G eps A B) :
+    IsWitnessRegular G eps' A B := by
+  intro B' hB' hcB'
+  have hBcard : (0 : ℚ) ≤ (B.card : ℚ) := Nat.cast_nonneg _
+  have hcB'_eps : (B'.card : ℚ) ≥ eps * B.card := by
+    have hmul : eps * (B.card : ℚ) ≤ eps' * (B.card : ℚ) :=
+      mul_le_mul_of_nonneg_right h hBcard
+    linarith
+  have hbound : |edgeDensity G A B' - edgeDensity G A B| ≤ eps :=
+    hreg B' hB' hcB'_eps
+  linarith
+
 /-- **ADLRY 1994 ε-grid lemma (one direction)**: if the pair `(A, B)`
     satisfies the witness-regular surrogate at parameter `ε`, then it
     is ε-regular at parameter `4 · ε`.
 
-    **Proof strategy** (deferred to S3/S4):
+    **Status (S4 audit)**: the slack-4 claim follows from a
+    *second-moment / Cauchy-Schwarz* argument (Alon-Duke-Lefmann-
+    Rödl-Yuster 1994, Lemma 3.4; Zhao §3.4). The proof is non-trivial
+    and is deferred to a future iteration.
 
-    Suppose `(A', B')` with `A' ⊆ A`, `B' ⊆ B`, `|A'| ≥ 4ε·|A|`,
-    `|B'| ≥ 4ε·|B|`. We must show
-        `|d(A', B') - d(A, B)| ≤ 4 · ε`.
+    **Audit of the previous proof sketch** (see
+    `research/problems/szemeredi-core-oq-04/knowledge.md` §S4):
 
-    *Step 1 (B-side density transfer).* For each `a ∈ A`, the
-    neighbour-pattern `B' ∩ N(a)` differs from the unbiased estimate
-    `d(A, B) · |B'|` by an amount controlled by the grid: since both
-    `B ∩ N(a)` and `B \ N(a)` are tested by `IsWitnessRegular` and
-    `B'` is large, the density of `B'` against `N(a)` is within `ε`
-    of `d(A, B)` for "most" `a ∈ A`.
+    The earlier docstring proposed a triangle-inequality decomposition
+    `|d(A',B') - d(A,B)| ≤ |d(A',B') - d(A,B')| + |d(A,B') - d(A,B)|`
+    with each term bounded by `2ε`. Closer inspection shows that this
+    decomposition does NOT yield slack `4ε` from the grid hypothesis
+    alone:
 
-    *Step 2 (A-side averaging).* Averaging the per-vertex bounds from
-    Step 1 over `a ∈ A'`, the total deviation is bounded by
-    `2ε + 2ε = 4ε` — the first `2ε` from the density transfer onto
-    `B'`, the second from the restriction `A → A'` losing at most
-    `|A \ A'|/|A| ≤ 1 - 4ε ≤ 1` worth of mass (i.e., the
-    `|A'| ≥ 4ε·|A|` lower bound).
+    *B-side step* (`|d(A,B') - d(A,B)| ≤ 2ε` for arbitrary `B' ⊆ B`):
+    `IsWitnessRegular` controls the deviation only for `B' ∈ witnessFamilyB`,
+    which has at most `2|A|` members. Extending to arbitrary `B'` requires
+    an additional argument — typically a Frieze-Kannan / cut-norm style
+    second-moment bound, which is stronger than the grid hypothesis
+    provides at slack `2ε`.
 
-    *Step 3 (combining).* The combined bound `4ε` is the slack constant.
-    Tighter analyses (Alon-Duke-Lefmann-Rödl-Yuster 1994, Lemma 3.4)
-    achieve `O(ε^{1/2})` slack; the present `4ε` bound is the strong
-    variant and matches Zhao's textbook exposition.
+    *A-side step* (`|d(A',B') - d(A,B')| ≤ 2ε` for `A' ⊆ A` with
+    `|A'| ≥ 4ε|A|`): false in general without `hreg`. The previous
+    sketch claimed this followed from `|A \ A'|/|A| ≤ 1 - 4ε`, but
+    `1 - 4ε` is the *upper* bound on the loss-fraction (close to `1`
+    when `ε` is small), not a `2ε` bound on the density perturbation.
 
-    For S2 this is left as `sorry`; the proof is `Aristotle`-friendly
-    once the surrogate is fully spelled out, since each step is a
-    routine density manipulation. -/
+    The CORRECT proof route uses a second-moment (variance) decomposition
+    over `a ∈ A` with the grid family providing per-vertex deviation
+    estimates; see knowledge.md §S4 for the literature pointer.
+
+    **Helpers exposed (S4)**:
+    * `IsWitnessRegular.density_bound` — direct grid-member application.
+    * `IsWitnessRegular_anti` — anti-monotonicity in `eps`.
+
+    These are sorry-free and intended as primitives for the future
+    second-moment proof. -/
 theorem witness_regular_implies_epsilon_regular
     (G : SimpleGraph V) [DecidableRel G.Adj]
     {eps : ℚ} (heps : 0 < eps) (A B : Finset V)
     (hreg : IsWitnessRegular G eps A B) :
     IsEpsilonRegular G (4 * eps) A B := by
   intro A' B' hA' hB' hcA' hcB'
-  -- See proof strategy in the docstring above.
+  -- See docstring above for the S4 audit and proof-route discussion.
   sorry
 
 /-! ## Part 3b: Constructive witness extraction (S3, sorry-free)

--- a/research/problems/szemeredi-core-oq-04/knowledge.md
+++ b/research/problems/szemeredi-core-oq-04/knowledge.md
@@ -316,3 +316,154 @@ the pre-existing one on `witness_regular_implies_epsilon_regular`.
 - S5 (parallel): build Target C (constructive partition `findRegularPartition`)
   using `witnessOfIrregular` as the iterate-on-failure step.
 - S6: Mathlib bridge to `SimpleGraph.IsUniform`.
+
+### S4 (researcher-11, 2026-05-12) — slack-4 audit + helpers
+
+**Outcome**: progress — two sorry-free helper lemmas added; the open
+sorry on `witness_regular_implies_epsilon_regular` is preserved but its
+docstring is corrected to flag a gap in the previously documented proof
+strategy.
+
+#### What I added (+44 lines in `proofs/Proofs/SzemerediCoreOQ04.lean`)
+
+Two sorry-free lemmas placed before `witness_regular_implies_epsilon_regular`:
+
+1. **`IsWitnessRegular.density_bound`** — dot-notation re-export of the
+   definitional consequence: every grid member with size ≥ ε·|B| has
+   density bias ≤ ε. Useful so callers can invoke
+   `hreg.density_bound _ hB' hcB'` instead of opening the predicate by
+   hand. One-line proof: `hreg B' hB' hcB'`.
+
+2. **`IsWitnessRegular_anti`** — anti-monotonicity in `eps`. If
+   `IsWitnessRegular G eps A B` and `eps ≤ eps'`, then
+   `IsWitnessRegular G eps' A B`. Proof: a larger `eps'` makes the
+   antecedent (`|B'| ≥ eps' · |B|`) strictly stronger and the
+   conclusion (`|·| ≤ eps'`) strictly weaker; both directions help.
+   Needed when chaining the surrogate to another lemma at a coarser
+   slack constant.
+
+In addition, the docstring of `witness_regular_implies_epsilon_regular`
+is rewritten to reflect the audit below.
+
+#### Slack-4 audit — why the previous proof sketch does NOT close
+
+The previous (S2/S3) docstring of `witness_regular_implies_epsilon_regular`
+proposed a triangle decomposition
+
+```
+|d(A',B') - d(A,B)|
+  ≤ |d(A',B') - d(A,B')|        -- Step 2 (A-side restriction)
+  + |d(A,B')  - d(A,B)|         -- Step 1 (B-side density transfer)
+  ≤ 2ε + 2ε
+  = 4ε.
+```
+
+Two issues with this decomposition.
+
+**(i) The B-side bound `|d(A,B') - d(A,B)| ≤ 2ε` is not directly given
+by `IsWitnessRegular`.** The hypothesis controls the bias only for
+`B' ∈ witnessFamilyB G A B`, a finite family of at most `2|A|` members
+(the patterns `B ∩ N(a)` and `B \ N(a)` for `a ∈ A`). Extending the
+control to *arbitrary* `B' ⊆ B` requires an additional argument; the
+standard route uses a Frieze-Kannan / cut-norm style second-moment
+bound, which is *strictly stronger* than what the grid gives at
+slack `2ε`.
+
+**(ii) The A-side bound `|d(A',B') - d(A,B')| ≤ 2ε` is FALSE without
+`hreg`.** Concrete refutation:
+
+  * Take a graph `G` on `V = A ⊔ B'` with `|A| = 2`, write
+    `A = {a₁, a₂}`, and pick `B'` so that `a₁` is connected to all
+    of `B'` while `a₂` is connected to none.
+  * Then `d(A, B') = (|B'| + 0)/(2|B'|) = 1/2`.
+  * Take `A' = {a₁} ⊆ A` with `|A'|/|A| = 1/2 = 4ε` for `ε = 1/8`.
+  * Then `d(A', B') = |B'|/|B'| = 1`, so
+    `|d(A', B') - d(A, B')| = 1/2`, while `2ε = 1/4`.
+  * The bound `1/2 ≤ 1/4` is false.
+
+So the A-side restriction step needs `hreg` too — the previous
+docstring's appeal to "`|A \ A'|/|A| ≤ 1 - 4ε`" was a weight bound,
+not a density-perturbation bound: for `ε` small `1 - 4ε ≈ 1`, which
+permits a perturbation of order `O(1)` rather than `O(ε)`.
+
+**(iii) The slack-4 result IS true** — but the proof goes through a
+*second-moment* / *Cauchy-Schwarz* argument over `a ∈ A` (Alon-
+Duke-Lefmann-Rödl-Yuster 1994, Lemma 3.4; Zhao §3.4 in the 2023
+textbook *Graph Theory and Additive Combinatorics*). The intuition:
+`IsWitnessRegular` controls per-vertex *neighbour-pattern density*
+in the sense that few vertices `a ∈ A` are "biased" against the
+grid; a Cauchy-Schwarz / variance argument then converts this
+per-vertex control into the subset-density bound. The proof is
+*not* a triangle inequality.
+
+#### Recommended next-iteration approach (S5 path)
+
+Instead of attempting the triangle decomposition in Lean, future
+iterations should follow the second-moment route:
+
+1. **`vertex_bias` definition.** For `a ∈ A`, define
+   `bias_a := |edgeDensity G {a} B - edgeDensity G A B|`. The
+   "unbiased" set is `A_good := {a ∈ A | bias_a ≤ ε}`.
+2. **Few biased vertices lemma.** Use `IsWitnessRegular` to bound
+   `|A \ A_good| ≤ ε · |A|` (this is the per-vertex consequence of
+   the grid hypothesis, derivable by averaging over the family).
+3. **A'-restriction estimate.** For `A' ⊆ A` with `|A'| ≥ 4ε|A|`,
+   bound `|A' \ A_good| ≤ ε|A| ≤ (1/4)|A'|` — so `A'` is mostly
+   composed of unbiased vertices.
+4. **Subset-B density estimate.** For `B' ⊆ B` with `|B'| ≥ 4ε|B|`,
+   apply the per-vertex bias to bound
+   `|edgeDensity G A_good B' - edgeDensity G A B|` — the
+   contribution of biased vertices is `O(ε)` by step 2.
+5. **Combine.** Triangle inequality at the end, using the unbiased
+   `A_good` as a bridge:
+   `|d(A',B') - d(A,B)| ≤ |d(A',B') - d(A_good,B')| + |d(A_good,B') - d(A,B)| ≤ 2ε + 2ε`.
+
+This route is genuinely Aristotle-friendly once steps 1-3 are
+named lemmas (each a one-screen calculation).
+
+#### Why the helpers exposed in S4 matter
+
+`IsWitnessRegular.density_bound` and `IsWitnessRegular_anti` are
+the two primitives that the second-moment proof above will need to
+call repeatedly:
+
+- Steps 2-4 of the recommended route invoke `density_bound` for
+  specific grid members `B ∩ N(a)`, `B \ N(a)`.
+- `IsWitnessRegular_anti` is needed when bounding bias at multiple
+  scales (e.g., `ε` and `2ε`); the proof can absorb size-threshold
+  slack via `_anti` rather than by re-deriving each instance.
+
+Both lemmas are sorry-free and `simp`-clean, so they can be used
+directly by Aristotle if the upstream proof is decomposed into
+appropriate `lemma` steps.
+
+#### Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04` —
+verified locally; the only sorry warning remains the pre-existing
+one on `witness_regular_implies_epsilon_regular`. The two new
+lemmas type-check and are sorry-free.
+
+#### Files modified (S4)
+
+- `proofs/Proofs/SzemerediCoreOQ04.lean` — +44 lines: two new
+  sorry-free lemmas (`IsWitnessRegular.density_bound`,
+  `IsWitnessRegular_anti`) plus a corrected docstring on
+  `witness_regular_implies_epsilon_regular` (S4 audit + revised
+  proof-route sketch).
+- `research/problems/szemeredi-core-oq-04/{knowledge.md, state.md}`
+  — this S4 entry.
+- `src/data/research/problems/szemeredi-core-oq-04.json` — phase
+  ACT, iter 3 → 4, builtItems +2, progressSummary updated.
+
+#### Next Action (S5)
+
+Implement step 1-2 of the second-moment route as named sorry-free
+lemmas:
+* `vertex_bias` definition.
+* `IsWitnessRegular.few_biased_vertices` — `|A_good| ≥ (1 - ε)|A|`
+  via averaging over the grid family.
+
+Each is a one-screen estimate using `IsWitnessRegular.density_bound`
+applied to `B ∩ N(a)` and `B \ N(a)` for `a ∈ A`, plus a `Finset.sum`
+averaging argument. ~30-50 lines per lemma.


### PR DESCRIPTION
## Summary

S4 iteration on `szemeredi-core-oq-04` (Algorithmic Szemerédi, ADLRY 1994). **Complementary to PR #17992** (which adds the witness-family membership API): this PR audits the slack-4 implication's documented proof strategy and adds two distinct sorry-free helpers (`density_bound` dot-notation re-export + `IsWitnessRegular_anti` monotonicity).

**Outcome**: progress — 2 sorry-free helper lemmas added; the open sorry on `witness_regular_implies_epsilon_regular` is preserved but its docstring is corrected to flag a gap in the previously documented triangle-inequality proof sketch.

## Why this iteration

The deferred sorry on `witness_regular_implies_epsilon_regular` came with a 3-step "Step 1 + Step 2 + Step 3" docstring claiming the slack-4 implication via triangle inequality. Auditing that sketch found it does NOT close from the grid hypothesis alone — but the slack-4 result IS true via a different argument (second-moment / Cauchy-Schwarz). Future iterations attempting the triangle route would have wasted effort. This PR records the gap and re-orients S5 toward the second-moment route.

## What I added (+44 lines in `proofs/Proofs/SzemerediCoreOQ04.lean`)

Two sorry-free helper lemmas placed before §3:

1. **`IsWitnessRegular.density_bound`** — dot-notation re-export of the definitional density-bias bound. Lets callers write `hreg.density_bound _ hB' hcB'` without unfolding the definition. One-line proof: `hreg B' hB' hcB'`.

2. **`IsWitnessRegular_anti`** — anti-monotonicity in `eps`: `IsWitnessRegular G eps A B → eps ≤ eps' → IsWitnessRegular G eps' A B`. Larger `eps'` makes the size-threshold antecedent stronger and the deviation conclusion weaker; `linarith` discharges both directions after `mul_le_mul_of_nonneg_right`.

Plus a corrected docstring on `witness_regular_implies_epsilon_regular` flagging the triangle-inequality gap.

## Slack-4 audit (full discussion in `knowledge.md` §S4)

The previous (S2/S3) docstring proposed
\`\`\`
|d(A',B') - d(A,B)|
  <= |d(A',B') - d(A,B')|        -- A-side restriction
  +  |d(A,B')  - d(A,B)|         -- B-side density transfer
  <= 2eps + 2eps
  =  4eps
\`\`\`

Two issues with this decomposition.

**(i) The B-side step is not directly given by `IsWitnessRegular`.** The hypothesis controls bias only for `B' \in witnessFamilyB G A B` (a finite family of size <= 2|A|). Extending to *arbitrary* `B' subset B` requires a Frieze-Kannan / cut-norm bound, *strictly stronger* than what the grid gives at slack `2eps`.

**(ii) The A-side step is FALSE without `hreg`.** Concrete refutation: take `|A| = 2`, `a_1` connected to all of `B'`, `a_2` to none. Then `d(A, B') = 1/2` but `d(A', B') = 1` for `A' = {a_1}` (size half >= `4eps |A|` for `eps = 1/8`), giving deviation `1/2 > 2eps = 1/4`. The previous sketch's appeal to `|A \ A'|/|A| <= 1 - 4eps` is a *weight* bound, not a `2eps` density-perturbation bound (`1 - 4eps approx 1` for small eps).

**(iii) The slack-4 result IS true** via a *second-moment / Cauchy-Schwarz* argument over `a in A` (ADLRY 1994 Lemma 3.4; Zhao 3.4). The corrected docstring + `knowledge.md` 4 lay out a five-step Lean route using the new helpers as primitives.

## Recommended next-iteration approach (S5)

The corrected `knowledge.md` lays out a 5-step second-moment route using these helpers + PR #17992's membership API.

## Build status

**Verified** via `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04`:
- 7744 jobs, build succeeded (~380s wall time)
- Only the pre-existing sorry warning on `witness_regular_implies_epsilon_regular` (line 205)
- Both new lemmas type-check sorry-free
- Standard `unusedSectionVars` linter warnings (pre-existing pattern)

## Files modified

- `proofs/Proofs/SzemerediCoreOQ04.lean` — +44 net: two new sorry-free lemmas before §3, corrected docstring on the main theorem
- `research/problems/szemeredi-core-oq-04/knowledge.md` — S4 audit section with concrete A-side refutation + recommended five-step proof route (+151 lines)
- `research/problems/szemeredi-core-oq-04/state.md` — iter 4 entry
- `src/data/research/problems/szemeredi-core-oq-04.json` — phase ACT, iter 3->4, builtItems +2

## Honesty note

This PR **does not reduce the sorry count** (still 1 retained on the main implication). The deliverable is two sorry-free primitives + a correction of misleading documented strategy. By the gallery's progress-honesty rules, this is a critical-analysis/infrastructure iteration, not a proof advance.

Will likely conflict with #17992 in `SzemerediCoreOQ04.lean` (overlapping insertion ranges around §3) and in the JSON/state.md/knowledge.md (both claim "iter 3 -> 4"). Resolution is straightforward — both lemma sets coexist; either can rebase on the other.

## Test plan

- [x] Lean build verified: `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04` (7744 jobs, only pre-existing sorry warning)
- [x] JSON syntax valid
- [x] Both new lemmas sorry-free per warning scan
- [x] Branched off origin/main, rebased before push (no Lean conflicts with the 36 commits merged during S4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)