### PR TITLE
audit(combinations-formula-oq-02): sync meta sorries 1→0 after PR #17991 closed sorry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2162,10 +2162,10 @@
       "result": "clean"
     },
     "combinations-formula-oq-02": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-12T07:38:17Z",
-      "result": "clean"
+      "lastAudited": "2026-05-12T08:29:18Z",
+      "result": "issues-fixed"
     },
     "continuum-hypothesis": {
       "agentId": "auditor-cycle-20-batch",
@@ -15157,5 +15157,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T21:15:00Z"
+  "lastUpdated": "2026-05-12T08:29:18Z"
 }

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
     "date": "2026-04-12",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",


### PR DESCRIPTION
## Summary

Meta-side completion of the false-clean oscillation cycle. PR #17991 closed the Aristotle `catalan_mul_succ` sorry; the two-step nature (sorry-close PR + meta-sync PR) caused #17952 to merge ~3 minutes after #17991 with a stale snapshot that re-asserted `sorries: 1`.

Both Lean source files now have 0 sorries on `origin/main` (HEAD `ccc79059a57`):

```
proofs/Proofs/CombinationsFormulaOQ02.lean              0 sorries (312 lines)
proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean     0 sorries (114 lines)
```

`catalan_mul_succ` is fully proved in the Aristotle companion at line 91 via `omega` (post-#17991).

## Changes

- `meta.json`: `sorries: 1 → 0`, `status: formalized → verified`. Badge stays `original` (0 axioms, mostly own infrastructure; Mathlib only cited for `catalan_succ'` in the convolution identity, which fits Tier A under the existing `originalContributions` list).
- `audit-tracker.json`: bump `auditCount 6→7`, `result clean → issues-fixed`, `lastAudited` to current.

## Cycle ledger

| PR | Direction | State |
|----|-----------|-------|
| #17717 | 1→0 | MERGED |
| #17765 | 0→1 | MERGED |
| #17936 | 1→0, formalized→verified | MERGED |
| #17951 | 0→1 revert | CLOSED |
| #17987 | 0→1 revert | CLOSED |
| #17991 | **close Aristotle sorry in catalan_mul_succ** | **MERGED (root fix)** |
| #17952 | 1 (stale) | MERGED (race) |
| **this PR** | **1→0, formalized→verified (post-#17991)** | — |

Also obsoletes still-open #17957 (which proposed marking issues-found based on the pre-#17991 sorry count).

## Test plan

- [x] `grep -c "sorry"` on both Lean files → 0
- [x] Diff scoped to two files
- [x] `find-targets.ts --issues` should drop to 0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)