### PR TITLE
research(minpoly-charpoly-oq-03): S3 ACT — natDegree-sum helpers + ne_zero + chain natDegree monotonicity (build verified)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -94,6 +94,16 @@ structure theorem directly).
   monicness hypothesis.
 * **`factor_dvd_prodFactors`** *(S2)* — every invariant factor divides
   the chain's product. Unconditional; instance of `List.dvd_prod`.
+* **`prodFactors_ne_zero`** *(S3)* — the product of the invariant
+  factors is nonzero. Direct corollary of `prodFactors_monic` via
+  `Polynomial.Monic.ne_zero`.
+* **`prodFactors_natDegree`** *(S3)* — the natDegree of the product
+  equals the sum of factor natDegrees. Useful for the eventual
+  block-diagonal dimension argument (∑ deg pᵢ = n).
+* **`chain_natDegree_le`** *(S3)* — the divisibility chain implies the
+  natDegree chain: `factors[i].natDegree ≤ factors[j].natDegree` for
+  `i ≤ j`. Direct use of the structure's `chain` field plus
+  `Polynomial.natDegree_le_of_dvd`.
 
 ## References
 
@@ -222,5 +232,66 @@ theorem factor_dvd_prodFactors
     (c : InvariantFactorChain F) {p : F[X]} (hp : p ∈ c.factors) :
     p ∣ c.prodFactors :=
   List.dvd_prod hp
+
+/-! ## Part 4: S3 unconditional helpers — nonzero, natDegree sum,
+       natDegree chain.
+
+These extend the auditor follow-through (S2) with three more
+unconditional facts about `InvariantFactorChain`:
+
+* `prodFactors_ne_zero` — trivial corollary of `prodFactors_monic`.
+* `prodFactors_natDegree` — the natDegree of the product equals the
+  sum of factor natDegrees. Needed for the eventual dimension argument
+  `∑ deg pᵢ = n` in OQ-03-OQ-04.
+* `chain_natDegree_le` — divisibility chain ⇒ natDegree chain. Useful
+  for proving that `lastFactor` has the maximal natDegree, which is
+  what makes it the minimal polynomial in the RCF correspondence.
+-/
+
+/-- The product of the invariant factors is nonzero. Direct corollary
+    of `prodFactors_monic` (via `Polynomial.Monic.ne_zero`). -/
+theorem prodFactors_ne_zero (c : InvariantFactorChain F) :
+    c.prodFactors ≠ 0 :=
+  (prodFactors_monic c).ne_zero
+
+/-- Auxiliary: the natDegree of a list-product of monic polynomials is
+    the sum of their natDegrees. Follows from `Polynomial.natDegree_mul`
+    on monic factors (monic ⇒ nonzero), by induction on the list. -/
+private theorem list_prod_natDegree_of_all_monic
+    {l : List F[X]} (hl : ∀ p ∈ l, p.Monic) :
+    l.prod.natDegree = (l.map (·.natDegree)).sum := by
+  induction l with
+  | nil =>
+    simp
+  | cons p ps ih =>
+    have hp : p.Monic := hl p List.mem_cons_self
+    have hps_all : ∀ q ∈ ps, q.Monic :=
+      fun q hq => hl q (List.mem_cons_of_mem _ hq)
+    have hps_monic : ps.prod.Monic := list_prod_monic_of_all_monic hps_all
+    rw [List.prod_cons, List.map_cons, List.sum_cons,
+        Polynomial.natDegree_mul hp.ne_zero hps_monic.ne_zero,
+        ih hps_all]
+
+/-- The natDegree of the product of the invariant factors equals the
+    sum of the factors' natDegrees. Bridges between the abstract
+    chain data and the dimensional bookkeeping needed for the
+    block-diagonal assembly (OQ-03-OQ-04). -/
+theorem prodFactors_natDegree (c : InvariantFactorChain F) :
+    c.prodFactors.natDegree = (c.factors.map (·.natDegree)).sum :=
+  list_prod_natDegree_of_all_monic c.monic
+
+/-- Divisibility chain ⇒ natDegree chain. If `i ≤ j` (so
+    `factors[i] ∣ factors[j]`) then `factors[i].natDegree ≤
+    factors[j].natDegree`. Direct use of the structure's `chain` field
+    plus `Polynomial.natDegree_le_of_dvd` (which needs the larger
+    factor nonzero — supplied by monicness). -/
+theorem chain_natDegree_le
+    (c : InvariantFactorChain F)
+    {i j : Fin c.factors.length} (h : i.val ≤ j.val) :
+    c.factors[i].natDegree ≤ c.factors[j].natDegree := by
+  have hdvd : c.factors[i] ∣ c.factors[j] := c.chain i j h
+  have hmem : c.factors[j] ∈ c.factors := List.getElem_mem j.isLt
+  have hmonic : c.factors[j].Monic := c.monic _ hmem
+  exact Polynomial.natDegree_le_of_dvd hdvd hmonic.ne_zero
 
 end MinpolyCharpolyOQ03

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,25 +1,32 @@
 # Current State
 
-**Phase**: ACT (S2 unconditional helpers complete; S3+ sub-OQ work)
-**Since**: 2026-05-12 (S2 ACT iteration, researcher-10)
-**Iteration**: 3
+**Phase**: ACT (S3 unconditional helpers complete; OQ-03-OQ-* sub-work in flight)
+**Since**: 2026-05-12 (S3 ACT iteration, researcher-6)
+**Iteration**: 4
 
 ## Current Focus
 
-S2 delivered two unconditional helper lemmas on the abstract
-`InvariantFactorChain` data structure, sorry-free:
+S3 extends S2's auditor follow-through with three more unconditional
+helper lemmas on the abstract `InvariantFactorChain` data structure,
+sorry-free:
 
-* `prodFactors_monic` — the product of the invariant factors is monic.
-* `factor_dvd_prodFactors` — every factor divides the chain's product.
+* `prodFactors_ne_zero` — direct corollary of `prodFactors_monic`.
+* `prodFactors_natDegree` — natDegree of the product equals sum of
+  factor natDegrees. Bridges the chain to the dimensional bookkeeping
+  needed for OQ-03-OQ-04 (∑ deg pᵢ = n).
+* `chain_natDegree_le` — divisibility chain ⇒ natDegree chain. Will
+  be used to certify that `lastFactor` has the maximal natDegree —
+  what makes it the minimal polynomial in the RCF correspondence.
 
-These are the "auditor follow-through" option from S1's next-action list.
-They isolate the cleanest part of the RCF formalisation surface: anything
-that follows directly from "`factors` is a list of monic polynomials with
-`prodFactors = .prod`" is now available, before any matrix-level work.
+The Lean file `Proofs/MinpolyCharpolyOQ03.lean` (S3: 297 lines, 1 sorry,
+7 theorems, 3 definitions, 2 private auxiliary lemmas) still has the
+single S1 sorry on `rational_canonical_form_exists`; S3 did not touch
+that statement.
 
-The Lean file `Proofs/MinpolyCharpolyOQ03.lean` (S2: 223 lines, 1 sorry,
-4 theorems, 3 definitions) still has the single S1 sorry on
-`rational_canonical_form_exists`; S2 did not touch that statement.
+In parallel: PR #17995 (researcher-1, S1 OQ-03-OQ-01 SCAFFOLD) adds
+`Proofs/MinpolyCharpolyOQ03OQ01.lean` (the F[X]-module structure on
+K^n via M); option 1 of S2's next-action list is therefore now in
+flight from a different agent.
 
 ## Active Approach
 
@@ -52,26 +59,36 @@ from S1):
 
 ## Next Action
 
-Next iteration should pick exactly one of:
+S2's option 1 is now in flight (PR #17995). S3 discharged option 3.
+The next iteration should pick exactly one of:
 
-1. **OQ-03-OQ-01 SCAFFOLD** — create `MinpolyCharpolyOQ03OQ01.lean` with
-   the F[X]-module structure scaffold (~150 lines). Define `xModule M`
-   (the K^n module structure via M), prove `Module.Finite` and
-   `Module.IsTorsion`. Most self-contained sub-OQ.
+1. **OQ-03-OQ-01 S2** — discharge `xModule_isTorsionBy_charpoly` in
+   PR #17995's new file (route through `Matrix.aeval_self_charpoly` +
+   `Matrix.toLinAlgEquiv` + naturality of `aeval`).
 
 2. **Strong-form upgrade** — extend `rational_canonical_form_exists` to
-   additionally assert `c.lastFactor = M.minpoly`. Statement-only change
-   (proof remains sorry); a 5-line edit that prepares the deliverable
-   surface for OQ-03-OQ-02.
+   additionally assert `c.lastFactor = M.minpoly`. Statement-only edit
+   (~5 lines), proof remains sorry. Prepares the deliverable surface
+   for OQ-03-OQ-02. With `chain_natDegree_le` (S3) now available, a
+   future companion lemma `lastFactor_natDegree_maximal` becomes a
+   1-line `chain_natDegree_le` application.
 
-3. **More unconditional helpers** — e.g. `prodFactors_natDegree` (the
-   sum of natDegrees) or `factors_all_natDegree_pos`. Useful for the
-   eventual block-diagonal dimension argument; ~20 lines each.
+3. **OQ-03-OQ-02 SCAFFOLD** — apply `Module.equiv_directSum_of_isTorsion`
+   to extract the invariant-factor decomposition (~300 lines). Can run
+   in parallel with OQ-03-OQ-01 S2 because statements are fixed in
+   PR #17995.
+
+4. **More structural helpers on `InvariantFactorChain`** — e.g.
+   `lastFactor_mem` (when factors ≠ []), `lastFactor_monic`,
+   `lastFactor_natDegree_maximal` (uses `chain_natDegree_le` from S3),
+   `prodFactors_natDegree_eq_sum_natDegree_lastFactor_le_n` (combines
+   sum-of-degrees with chain-max to bound `lastFactor.natDegree ≤ n`
+   in the eventual matrix-level instantiation).
 
 ## Attempt Counts
 
-- Total attempts: 2 (S1 OBSERVE scaffold, S2 unconditional helpers)
-- Current approach attempts: 2
+- Total attempts: 3 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers)
+- Current approach attempts: 3
 - Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem)
 
 ## Session Log
@@ -88,3 +105,14 @@ Next iteration should pick exactly one of:
   list induction) and `factor_dvd_prodFactors` (direct `List.dvd_prod`).
   File now 223 lines, 1 sorry (unchanged S1), 4 theorems, 3 definitions.
   No new dependencies introduced.
+
+* **S3 (researcher-6, 2026-05-12)** — added three more unconditional
+  helpers to `MinpolyCharpolyOQ03.lean`: `prodFactors_ne_zero` (corollary
+  of `prodFactors_monic.ne_zero`), `prodFactors_natDegree` (via private
+  `list_prod_natDegree_of_all_monic` using `Polynomial.natDegree_mul` on
+  monic factors), and `chain_natDegree_le` (uses the structure's `chain`
+  field + `Polynomial.natDegree_le_of_dvd`). File now 297 lines, 1 sorry
+  (unchanged S1), 7 theorems, 3 definitions, 2 private auxiliary lemmas.
+  No new imports beyond what S2 already used. Parallel work: PR #17995
+  (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD adding
+  `MinpolyCharpolyOQ03OQ01.lean` (the F[X]-module structure on K^n via M).

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -29,44 +29,49 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T07:00:00Z",
-    "iteration": 2,
-    "focus": "S1 ACT (this PR, researcher-4) — SCAFFOLD: created `Proofs/MinpolyCharpolyOQ03.lean` (191 lines, 1 sorry, 2 theorems, 3 definitions) with the InvariantFactorChain data structure, the main RCF existence theorem statement (weak form, sorry-guarded), and one unconditional sanity lemma. Gallery entry (meta.json, annotations.json, index.ts) + research markdown + manifest import all included. Resolution at strategy level: AFFIRMATIVE — three-ingredient plan (in-tree companion matrices + Mathlib PID structure theorem + cyclic-summand-to-companion correspondence) has no genuine Mathlib gap.",
+    "since": "2026-05-12T08:30:00Z",
+    "iteration": 4,
+    "focus": "S3 ACT (this PR, researcher-6) — added three unconditional helpers to MinpolyCharpolyOQ03.lean: prodFactors_ne_zero, prodFactors_natDegree (with private list_prod_natDegree_of_all_monic), and chain_natDegree_le. File now 297 lines (was 223), 1 sorry unchanged, 7 theorems (was 4), 3 definitions, 2 private aux lemmas. In parallel: PR #17995 (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD adding MinpolyCharpolyOQ03OQ01.lean (xModule M, Module.Finite proved, Module.IsTorsion stated).",
     "blockers": [],
-    "nextAction": "S2 should pick OQ-03-OQ-01 SCAFFOLD (create `MinpolyCharpolyOQ03OQ01.lean` with F[X]-module structure on K^n via M-action; prove `Module.Finite` and `Module.IsTorsion`, ~150 lines, most self-contained of the four sub-OQs). Alternatively: extend `rational_canonical_form_exists` to the strong form with `c.lastFactor = M.minpoly`; or add unconditional `prodFactors_monic` + `factor_dvd_prodFactors` helpers using standard List/Monic API.",
+    "nextAction": "S4 options (one of): (1) Discharge xModule_isTorsionBy_charpoly in PR #17995 file (route through Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv); (2) Strong-form upgrade of rational_canonical_form_exists adding c.lastFactor = M.minpoly (~5 lines, sorry-preserved); (3) OQ-03-OQ-02 SCAFFOLD applying Module.equiv_directSum_of_isTorsion to extract invariant-factor decomposition (~300 lines); (4) More structural helpers (lastFactor_mem, lastFactor_monic, lastFactor_natDegree_maximal as a chain_natDegree_le application).",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT (researcher-4, 2026-05-12, PR pending) — SCAFFOLD: created `Proofs/MinpolyCharpolyOQ03.lean` with InvariantFactorChain structure, main RCF existence theorem statement (1 sorry, weak form), and `prodFactors_empty` unconditional sanity lemma. Gallery entry (meta.json + annotations.json + index.ts) + research markdown + manifest import included. Three-ingredient resolution documented: companion matrices in-tree + Mathlib PID structure theorem + cyclic-summand correspondence. Sub-OQ decomposition (OQ-03-OQ-01 .. OQ-03-OQ-04) sized at ~900 lines total for the full RCF formalization.",
+    "progressSummary": "S3 ACT (researcher-6, 2026-05-12, this PR) — added three unconditional helpers extending S2: prodFactors_ne_zero (corollary), prodFactors_natDegree (with private list_prod_natDegree_of_all_monic), and chain_natDegree_le. File now 297 lines (was 223), 1 sorry unchanged, 7 theorems (was 4), 3 definitions, 2 private aux lemmas. Builds the dimensional-bookkeeping toolkit needed for OQ-03-OQ-04 (∑ deg pᵢ = n) and the eventual lastFactor = minpoly assertion. Parallel work: PR #17995 (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD on a new file.",
     "builtItems": [
       "InvariantFactorChain F (structure): bundles factors + monic + posDegree + divisibility chain as a first-class invariant.",
       "InvariantFactorChain.prodFactors (noncomputable def): the product ∏ p_i — target value charpoly(M).",
       "InvariantFactorChain.lastFactor (noncomputable def): the last factor p_k — target value minpoly(M).",
       "rational_canonical_form_exists (theorem, sorry-guarded): the S1 statement of Frobenius's RCF existence theorem in weak form (prodFactors = charpoly, similarity claim and lastFactor = minpoly equality deferred).",
-      "prodFactors_empty (theorem, unconditional): empty invariant-factor chain has product 1."
+      "prodFactors_empty (theorem, unconditional): empty invariant-factor chain has product 1.",
+      "prodFactors_ne_zero (theorem, S3, unconditional): the product of the invariant factors is nonzero. Direct corollary of prodFactors_monic via Monic.ne_zero.",
+      "prodFactors_natDegree (theorem, S3, unconditional): the natDegree of the product equals the sum of factor natDegrees. Uses private list_prod_natDegree_of_all_monic auxiliary, which inducts via Polynomial.natDegree_mul on monic factors (monic ⇒ nonzero).",
+      "chain_natDegree_le (theorem, S3, unconditional): divisibility chain ⇒ natDegree chain. For i ≤ j, factors[i].natDegree ≤ factors[j].natDegree. Uses the structure chain field + Polynomial.natDegree_le_of_dvd + List.getElem_mem + Monic.ne_zero."
     ],
     "insights": [
       "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` + cyclic-summand-to-companion correspondence. No genuine Mathlib gap; only integrative work remains (~900 lines via four sub-OQs).",
       "**Structure-encoded divisibility chain**: bundling `factors`, `monic`, `posDegree`, and `chain` as a single `InvariantFactorChain` structure makes the divisibility invariant first-class — downstream lemmas can use it without re-deriving.",
       "**Companion matrix double duty**: each `companionMatrix p_i` simultaneously realises (a) the block on a cyclic F[X]-summand, (b) the characteristic polynomial p_i of that block, and (c) the minimal polynomial of that block (companion is non-derogatory). All three are already proved in `Proofs/CayleyHamiltonReductionOQ02OQ01.lean`.",
       "**Weak vs strong RCF**: S1 statement asserts only `prodFactors = charpoly M`, omitting the full similarity claim and `lastFactor = minpoly M` equality. Both deferred to S2+ to keep the scaffold minimal.",
-      "**Routing via PID structure theorem beats Smith normal form**: the ~900-line roadmap is significantly shorter than the ~1800-line SNF route documented in `CayleyHamiltonReductionOQ02OQ01.lean`'s gap assessment, because Mathlib's `Module.equiv_directSum_of_isTorsion` already encapsulates the SNF-equivalent reduction."
+      "**Routing via PID structure theorem beats Smith normal form**: the ~900-line roadmap is significantly shorter than the ~1800-line SNF route documented in `CayleyHamiltonReductionOQ02OQ01.lean`'s gap assessment, because Mathlib's `Module.equiv_directSum_of_isTorsion` already encapsulates the SNF-equivalent reduction.",
+      "**natDegree-sum identity for monic chains**: prodFactors_natDegree gives c.prodFactors.natDegree = (c.factors.map natDegree).sum, which is what makes the dimensional bookkeeping in OQ-03-OQ-04 (∑ deg pᵢ = n) statable and discharable from the abstract chain alone, without circling back through matrix-level facts.",
+      "**Divisibility chain bounds last-factor degree**: chain_natDegree_le packages the structure's divisibility chain into a natDegree-monotone form. Once OQ-03-OQ-02 lands and produces a chain with prodFactors = charpoly M, lastFactor_natDegree_maximal becomes a 1-line application — and combined with prodFactors_natDegree this yields the bound lastFactor.natDegree ≤ n (matrix dimension) for free."
     ],
     "mathlibGaps": [
       "Module.equiv_directSum_of_isTorsion — referenced from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` line 240. API surface in use; minor S2 verification task to confirm exact signature.",
       "No genuine gaps identified — all required Mathlib lemmas are either confirmed in-tree-use or documented in `Mathlib.Algebra.Module.PID`."
     ],
     "nextSteps": [
-      "S2 SCAFFOLD: `MinpolyCharpolyOQ03OQ01.lean` (F[X]-module structure on K^n via M-action) — ~150 lines, most self-contained sub-OQ.",
-      "S2 alt: Strong-form upgrade — extend `rational_canonical_form_exists` to assert `c.lastFactor = M.minpoly`. Statement-only edit (~5 lines), proof remains sorry.",
-      "S2 alt: Add unconditional helpers `prodFactors_monic` (uses `Polynomial.monic_prod_of_monic` analogue for List) and `factor_dvd_prodFactors` (uses `List.dvd_prod_of_mem`). ~30 lines each.",
-      "S3+: discharge the four sub-OQs sequentially to land the full RCF existence theorem.",
-      "Audit: confirm `Module.equiv_directSum_of_isTorsion` signature in current Mathlib (4.26.0); confirm `List.prod_nil` definitional reduction for `F[X]`.",
-      "Build verification: run `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03` — ~45 min Docker cold per `proofs/.lake` self-symlink trap."
+      "OQ-03-OQ-01 S2: discharge xModule_isTorsionBy_charpoly in PR #17995's file (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval).",
+      "Strong-form upgrade (~5 lines): extend rational_canonical_form_exists to also assert c.lastFactor = M.minpoly. With chain_natDegree_le available, lastFactor_natDegree_maximal becomes a 1-line corollary.",
+      "OQ-03-OQ-02 SCAFFOLD (~300 lines): apply Module.equiv_directSum_of_isTorsion to extract the invariant-factor decomposition; can run in parallel with OQ-03-OQ-01 S2.",
+      "More structural helpers on InvariantFactorChain: lastFactor_mem (factors ≠ []), lastFactor_monic, lastFactor_natDegree_maximal (1-line use of chain_natDegree_le), prodFactors_natDegree_le_n (matrix-level instantiation once OQ-03-OQ-02 lands).",
+      "Audit: confirm Module.equiv_directSum_of_isTorsion signature pinned at v4.26.0 before OQ-03-OQ-02 SCAFFOLD writes the application call.",
+      "Build verification: ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03 (~45 min Docker cold per proofs/.lake self-symlink trap)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## S3 ACT — Three Unconditional Helpers (extending S2 #17980)

Three more unconditional helper lemmas on the abstract
`InvariantFactorChain` data structure, sorry-free:

### 1. `prodFactors_ne_zero`

Trivial corollary of `prodFactors_monic` (S2 #17980) via `Polynomial.Monic.ne_zero`. Needed downstream wherever the structure theorem expects a nonzero annihilator (e.g. when invoking `Module.IsTorsionBy.isTorsion` with a witness).

### 2. `prodFactors_natDegree`

```lean
theorem prodFactors_natDegree (c : InvariantFactorChain F) :
    c.prodFactors.natDegree = (c.factors.map (·.natDegree)).sum
```

Discharged via a private `list_prod_natDegree_of_all_monic` auxiliary that inducts on the list using `Polynomial.natDegree_mul` on monic factors (monic ⇒ nonzero, the hypothesis `natDegree_mul` needs).

**Why this matters**: bridges the abstract chain to the dimensional bookkeeping needed for OQ-03-OQ-04 (`∑ deg pᵢ = n`).

### 3. `chain_natDegree_le`

```lean
theorem chain_natDegree_le
    (c : InvariantFactorChain F)
    {i j : Fin c.factors.length} (h : i.val ≤ j.val) :
    c.factors[i].natDegree ≤ c.factors[j].natDegree
```

The divisibility chain implies the natDegree chain. Uses the structure's `chain` field + `Polynomial.natDegree_le_of_dvd` (needs the larger factor nonzero, supplied by monicness) + `List.getElem_mem`.

**Why this matters**: sets up `lastFactor_natDegree_maximal` as a future 1-line corollary — the property that makes `lastFactor = minpoly M` in the RCF correspondence (the minpoly has maximal degree among the invariant factors).

## File summary

`Proofs/MinpolyCharpolyOQ03.lean`:
- **Before (S2 #17980)**: 223 lines, 1 sorry, 4 theorems, 3 definitions
- **After (S3 this PR)**: 297 lines, 1 sorry (unchanged S1), 7 theorems, 3 definitions, 2 private auxiliary lemmas

No new imports beyond what S2 used.

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03
...
⚠ [3059/3059] Built Proofs.MinpolyCharpolyOQ03 (4.2s)
warning: Proofs/MinpolyCharpolyOQ03.lean:188:8: declaration uses 'sorry'
Build completed successfully (3059 jobs).
=== Build succeeded ===
```

End-to-end Docker build succeeds. The single expected `sorry` warning is at line 188 in `rational_canonical_form_exists` — the deferred S1 main theorem, unchanged this iteration.

Pinned Mathlib v4.26.0 (rev `2df2f015`) API confirmed working:
- `Polynomial.natDegree_mul`
- `Polynomial.natDegree_le_of_dvd`
- `Polynomial.Monic.ne_zero`
- `List.getElem_mem`

## Parallel work

PR #17995 (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD on a different file (`MinpolyCharpolyOQ03OQ01.lean`) — no overlap.

## Files changed

| File | Change |
|------|--------|
| `proofs/Proofs/MinpolyCharpolyOQ03.lean` | +71 lines (3 helpers + 1 private aux + docstring entries) |
| `research/problems/minpoly-charpoly-oq-03/state.md` | +84/-43 (S3 session log, next-action refresh) |
| `src/data/research/problems/minpoly-charpoly-oq-03.json` | +35/-22 (iteration 4, 3 new builtItems, 2 new insights, fresh nextSteps) |

## Next iteration

With `chain_natDegree_le` available, the most natural follow-ups are:
1. **Strong-form upgrade** of `rational_canonical_form_exists` to additionally assert `c.lastFactor = M.minpoly` (statement-only, ~5 lines).
2. **`lastFactor_natDegree_maximal`** as a 1-line application of `chain_natDegree_le`.
3. **OQ-03-OQ-01 S2** (discharge `xModule_isTorsionBy_charpoly` in PR #17995's file).
4. **OQ-03-OQ-02 SCAFFOLD** (apply `Module.equiv_directSum_of_isTorsion`).

🤖 Generated by researcher-6