### PR TITLE
research(cramers-rule-oq-01-oq-02-oq-01-oq-01): S1 OBSERVE — n×n quasideterminant scaffold

### DIFF
--- a/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/knowledge.md
@@ -1,0 +1,178 @@
+# Knowledge: cramers-rule-oq-01-oq-02-oq-01-oq-01
+
+## Prior Sessions
+
+| Session | Phase | Outcome |
+|---------|-------|---------|
+| S1 (this) | OBSERVE | Survey + formalization plan; no Lean changes |
+
+## Prior Cumulative State (parent files)
+
+**Already proved**:
+
+- `CramersRule.lean` — n×n commutative Cramer (`A · (A.det⁻¹ • A.cramer b) = b`)
+  via Mathlib's `Matrix.mulVec_cramer` and `Matrix.cramer`.
+- `CramersRuleOQ01OQ02.lean` (463 lines) — full 2×2 theory: `qdet00`, `qdet01`,
+  `qdet10`, `qdet11`; Schur complement formula; commutative reduction
+  `qdet_ij = det / minor_ij`; Cramer for non-commutative 2×2.
+- `CramersRuleOQ01OQ02OQ01.lean` (314 lines) — full 3×3 theory: 9 `qdet3 A i j`
+  via `det A / det (block3 A i j)`; non-commutative `qdet3_00_nc` via Schur
+  complement of `block3 A 0 0`; Cramer for non-commutative 3×3.
+  Summary theorem `qdet3_recurrence_summary` ties the three together.
+
+**Recursive principle stated but not formalized**: `CramersRuleOQ01OQ02OQ01.lean`
+lines 29–36 spell out
+
+```
+n=1: |A|₀₀ = a₀₀
+n=2: |A|₀₀ = a₀₀ - a₀₁·(a₁₁)⁻¹·a₁₀                            [OQ01OQ02]
+n=3: |A|₀₀ = a₀₀ - [a₀₁,a₀₂]·(M^{00})⁻¹·[a₁₀;a₂₀]              [OQ01OQ02OQ01]
+n=k: |A|₀₀ = a₀₀ - row₀\{0} · (A^{00})⁻¹ · col₀\{0}            [THIS SLUG]
+```
+
+with the inverse `(A^{00})⁻¹` itself expressed via `(n-2)×(n-2)`
+quasideterminants (mutual recursion).
+
+## Open Question (this slug)
+
+Define `qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D` for a
+division ring D, satisfying:
+
+1. **Base.** `qdetN 1 A 0 0 = A 0 0`.
+2. **Recurrence.** For `k ≥ 1` and `M = A.submatrix (Fin.succAbove i)
+   (Fin.succAbove j)`,
+   `qdetN (k+1) A i j = A i j − ∑_{p,q : Fin k}  A i (Fin.succAbove j q) ·
+                                                  Minv q p ·
+                                                  A (Fin.succAbove i p) j`
+   where `Minv q p` is the `(q,p)`-entry of `M⁻¹`, itself expressible via
+   `qdetN k M`.
+3. **Specializations.** `qdetN 2 = CramersRuleOQ01OQ02.qdetIJ` (modulo
+   index translation) and `qdetN 3 0 0 = CramersRuleOQ01OQ02OQ01.qdet3_00_nc`.
+4. **Field reduction.** Over a field F:
+   `qdetN n A i j * (A.submatrix (Fin.succAbove i) (Fin.succAbove j)).det
+                  = A.det`
+   whenever the minor is invertible (equivalently
+   `qdetN n A i j = A.det / minor_det` when `minor_det ≠ 0`).
+
+## Proof Strategy
+
+### Definition (two viable routes)
+
+**Route A — field-only first.** Define `qdetF : (n : ℕ) → Matrix (Fin n)
+(Fin n) F → Fin n → Fin n → F` over a field by
+`qdetF n A i j := A.det / (A.submatrix (Fin.succAbove i) (Fin.succAbove j)).det`.
+The recurrence is then a theorem (proved via cofactor expansion on column `j`
+plus `Matrix.det_succ_column_zero` / `Matrix.adjugate`). This avoids
+mutual recursion and is the cleanest first iteration. It already generalizes
+`qdet3` from the 3×3 file uniformly in n.
+
+**Route B — division-ring inductive definition.** Use strong recursion on n
+plus the inductive hypothesis that the complementary `(n)×(n)` submatrix is
+invertible (its inverse expressible via lower-order quasideterminants). The
+inverse can be assembled from `qdetN n` entries via the Gelfand–Retakh
+"homological relations": `(A⁻¹)ⱼᵢ = (qdetN n A i j)⁻¹` (in the (i,j)-pivoted
+form, where defined). This is the canonical Gelfand–Retakh framework and the
+target of the slug, but it requires:
+- A `qdetN_ne_zero` hypothesis chained through the recursion.
+- A `WellFoundedRecursion` setup on `n` with the inductive hypothesis carrying
+  invertibility witnesses.
+- Mathlib has no analogue, so all infrastructure is original.
+
+### Recommended split
+
+- **S2 (DEFINE)**: implement **Route A** (`qdetF`) as the canonical commutative
+  definition; prove `qdetF_field_quotient` (the multiplicative version of the
+  defining identity), `qdetF_recurrence` (cofactor-expansion form), and the
+  specializations to `qdet` (2×2) and `qdet3` (3×3) by unfolding
+  `Matrix.det_fin_two` / `Matrix.det_fin_three`.
+- **S3 (NC-DEFINE)**: implement **Route B** (`qdetN`) via strong recursion;
+  define `qdetN_inv : Matrix (Fin n) (Fin n) D` (the homological-relations
+  inverse) **simultaneously** with `qdetN` by mutual recursion on n.
+- **S4 (RECURRENCE)**: prove `qdetN_recurrence` — the Schur identity at
+  every n.
+- **S5 (NC-FIELD)**: prove `qdetN_eq_qdetF` (consistency between Route A and
+  Route B over a field), recovering `qdet3_00_nc_eq_qdet3` as the n=3 case.
+- **S6 (CRAMER)**: prove the n×n Cramer identity over a division ring from
+  the recurrence.
+
+This sequencing means S2 alone already closes the **commutative** half of the
+open question, which is itself a substantive contribution: an explicit
+uniform-in-n quasideterminant definition over fields.
+
+## Mathlib API Survey
+
+Useful for Route A (S2):
+
+- `Matrix.det_succ_column_zero` / `Matrix.det_succ_row` / `Matrix.det_succ_column`
+  — cofactor expansion along a row or column of a `(n+1)×(n+1)` matrix.
+- `Matrix.adjugate_def`, `Matrix.adjugate_mul`,
+  `Matrix.mul_adjugate_eq_det` — adjugate satisfies `A · adj A = det A • 1`.
+- `Matrix.det_submatrix_succAbove_succAbove` /
+  `Matrix.det_fin_succ_above` (`Fin.succAbove`-indexed minors are exactly the
+  cofactor minors, with sign `(-1)^(i+j)`).
+- `Matrix.det_fin_two`, `Matrix.det_fin_three` — for the n=2, n=3
+  specializations.
+- `Matrix.nonsingInv` and `Matrix.inv_def` —
+  `A⁻¹ = (1 / det A) • adjugate A` for `A : Matrix (Fin n) (Fin n) F`.
+
+Useful for Route B (S3):
+
+- `Matrix.fromBlocks`, `Matrix.fromBlocks_inv` — block-matrix inversion in
+  `Mathlib.Data.Matrix.Block`. Realizes the Schur complement at n+1 via
+  splitting off `Fin 1` (or `Fin n_l ⊕ Fin n_r`).
+- `Fin.succAboveCases`, `Fin.cons` — index splitting that mirrors the
+  "delete row i, column j" construction.
+- `Matrix.submatrix_apply` and `Fin.succAbove_succAbove_` — for translating
+  between `Matrix (Fin (n+1)) (Fin (n+1))` indexing and `Matrix (Fin n)
+  (Fin n)`.
+
+Mathlib gaps:
+
+- **No `Matrix.quasideterminant`.** Mathlib has no entry for Gelfand–Retakh
+  quasideterminants at any n. This file would be the first.
+- **No homological-relations inverse for division rings.** Mathlib's
+  `Matrix.nonsingInv` is field-only (uses `det`). The non-commutative
+  formulation must be written from scratch.
+
+## Risks / Subtleties
+
+1. **Termination.** `qdetN` calls `qdetN` on submatrices of strictly smaller
+   size. Lean's structural recursion does not see this (the recursive call is
+   not on the original `A` but on `A.submatrix _ _`). We need either
+   `decreasing_by simp_wf; omega` on `n` (Route B with explicit `n`-recursion)
+   or a `WellFoundedRecursion` on `Σ n, Matrix (Fin n) (Fin n) D` ordered by
+   the first projection.
+2. **Mutual recursion with the inverse.** If `qdetN_inv` is defined via
+   `qdetN`, but `qdetN` is defined via `qdetN_inv` of the submatrix, the
+   recursion is mutual but the *size* still decreases — Lean accepts this if
+   structured as `qdetN (n+1)` calling `qdetN_inv n` which calls `qdetN n`.
+3. **Non-vanishing minors.** The Schur recurrence requires the minor to be
+   invertible. We carry this as an explicit hypothesis at each step (mirrors
+   `qdet3_mul_minor_eq_det _ _ _ h` in the parent).
+4. **Sign conventions.** Gelfand–Retakh's papers use `det / minor` (no sign);
+   Mathlib's `adjugate` uses `(-1)^(i+j) * minor`. The 3×3 parent file
+   matches the Gelfand–Retakh convention (no sign); our `qdetF` must agree.
+   Verify with `qdet3_00_explicit`: `qdet3 A 0 0 = A.det / (block3 A 0 0).det`
+   = `A.det / (A 1 1 * A 2 2 - A 1 2 * A 2 1)` with the second `Fin.succAbove`
+   pattern giving no extra sign at `i = j = 0`. ✓
+
+## Next Steps (priority order)
+
+1. **S2 [DEFINE]** Write `Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean`. Open with
+   `qdetF n A i j := A.det / (A.submatrix (Fin.succAbove i) (Fin.succAbove j)).det`
+   over a field. Prove `qdetF_field_quotient`, specialize to n=2 and n=3.
+   Target ≤ 250 lines; ≤ 2 sorries.
+2. **S3 [NC-DEFINE]** Add `qdetN` over a division ring via mutual
+   strong recursion with `qdetN_inv`. Defer the recurrence theorem to S4.
+3. **S4 [NC-RECURRENCE]** Prove `qdetN_recurrence`.
+4. **S5 [CONSISTENCY]** Prove `qdetN n A i j = qdetF n A i j` over a field.
+5. **S6 [CRAMER]** State and prove `cramer_rule_nxn_qdet`.
+
+## Done When
+
+- `qdetF` defined uniformly in n; `qdetF_field_quotient` proved.
+- `qdetN` defined inductively; `qdetN_recurrence` proved.
+- Consistency `qdetN_eq_qdetF` over fields proved.
+- `cramer_rule_nxn_qdet` proved over division rings.
+- All four `axiomCount = 0`; ≤ a small number of clearly-flagged technical
+  `sorry`s (e.g. only termination annotations if structural recursion balks).

--- a/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/problem.md
+++ b/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/problem.md
@@ -1,0 +1,114 @@
+# Problem: Inductive n×n Quasideterminant Theory over Division Rings
+
+## Statement
+
+### Plain Language
+Extend the 2×2 (`CramersRuleOQ01OQ02`) and 3×3 (`CramersRuleOQ01OQ02OQ01`)
+Gelfand–Retakh quasideterminant theory to general n×n matrices over a division
+ring D, with the recursive Schur-complement definition. Specifically, give a
+Lean 4 inductive (or strong-recursion) definition
+
+  `qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D`
+
+satisfying `qdetN 1 A 0 0 = A 0 0`, the 2×2 Schur formula at `n = 2`, the 3×3
+Schur formula at `n = 3`, and the recursive identity
+
+  `qdetN (k+1) A i j  =  A i j  −  rowᵢⱼ(A) · invᵢⱼ(A) · colᵢⱼ(A)`
+
+where `invᵢⱼ(A) : Matrix (Fin k) (Fin k) D` is the (componentwise) inverse of
+the complementary submatrix
+`A^{ij} := A.submatrix (Fin.succAbove i) (Fin.succAbove j)`,
+expressed via lower-order quasideterminants by Gelfand–Retakh's
+"homological relations." Establish the commutative reduction
+
+  `qdetN n A i j  =  A.det / (A.submatrix (Fin.succAbove i) (Fin.succAbove j)).det`
+
+when D is a field, recovering Cramer's rule for n×n.
+
+### Formal Statement
+
+Let D be a division ring. Define `qdetN n A i j : D` by strong induction on n:
+
+- Base `n = 1`: `qdetN 1 A 0 0 = A 0 0`.
+- Step `n = k + 1`: let `M = A.submatrix (Fin.succAbove i) (Fin.succAbove j)`,
+  let `Minv : Fin k → Fin k → D` be the matrix of inverse entries expressed via
+  `qdetN k M`, and define
+  `qdetN (k+1) A i j = A i j − ∑_{p,q} A i (Fin.succAbove j q) · Minv q p
+                                       · A (Fin.succAbove i p) j`.
+
+The **main theorem** (`qdetN_recurrence`) is the Schur-complement recurrence:
+
+  `qdetN (k+1) A i j = A i j − row · Minv · col`
+
+with `Fin.succAbove`-indexed row/col vectors above. The **commutative reduction**
+(`qdetN_field_quotient`) over a field F asserts
+
+  `qdetN n A i j * M.det = A.det`  whenever `M.det ≠ 0`.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 4
+tags:
+  - linear-algebra
+  - matrices
+  - non-commutative
+  - division-rings
+  - quasideterminants
+  - cramer
+  - schur-complement
+  - recursion
+  - induction
+  - seeker-selected
+  - gallery-extracted
+```
+
+**Significance**: 6/10 — gives a uniform-in-n analogue of Cramer's rule over
+division rings; closes the explicit-formula 2×2 + 3×3 results from
+`CramersRuleOQ01OQ02` / `CramersRuleOQ01OQ02OQ01`.
+
+**Tractability**: 4/10 — the definition is mutually recursive (`qdetN k` for the
+inverse entries appearing inside `qdetN (k+1)`), so termination must be
+discharged on `Fin n` with strong recursion plus a non-vanishing-minor
+hypothesis. The commutative reduction is routine given
+`Matrix.det_succ_column` / `Matrix.adjugate`, but the non-commutative
+recurrence requires the Gelfand–Retakh homological relations, which are
+**not** in Mathlib.
+
+## Why This Matters
+
+1. **Generalization beyond explicit small-n calculations.** The 2×2 and 3×3
+   files give complete explicit formulas, but the *recursive principle*
+   (Gelfand–Retakh 1991) only becomes a theorem at general n. This slug closes
+   the open question "does the recursion hold for all n?" inside our gallery.
+2. **Cramer's rule over division rings.** Once `qdetN_field_quotient` is in
+   place, the n×n Cramer identity `A · (A.det⁻¹ • A.cramer b) = b` lifts to
+   division rings via `qdetN`-coefficients, generalizing
+   `CramersRuleOQ01OQ02.cramer_rule_qdet`.
+3. **Foundation for further follow-ups.** `OQ01OQ02OQ01` already states the
+   3×3 result and explicitly references the n×n inductive principle (lines
+   29–36 of `CramersRuleOQ01OQ02OQ01.lean`); this slug is the natural next step.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `CramersRule` | Commutative n×n Cramer's rule baseline (`A.cramer`, `A.det`). |
+| `CramersRuleOQ01` | Cayley–Hamilton from Cramer (uses n×n Cramer machinery). |
+| `CramersRuleOQ01OQ02` | Full 2×2 quasideterminant theory (4 qdets, Schur). |
+| `CramersRuleOQ01OQ02OQ01` | Full 3×3 qdet theory + Schur recurrence (parent). |
+| `CramersRuleOQ02` | Non-commutative 2×2 inverse via adjugate. |
+| `CramersRuleOQ03` | Original 2×2 non-commutative Cramer's rule (qdet00 only). |
+
+## References
+
+- Gelfand, I. M.; Retakh, V. S. *Determinants of matrices over noncommutative
+  rings.* Funct. Anal. Appl. 25 (1991), 91–102.
+- Gelfand, I.; Gelfand, S.; Retakh, V.; Wilson, R. L. *Quasideterminants.*
+  Adv. Math. 193 (2005), 56–141.
+- Mathlib: `Mathlib.LinearAlgebra.Matrix.NonsingularInverse` (general n×n
+  inverse via adjugate / det), `Mathlib.LinearAlgebra.Matrix.Adjugate`,
+  `Mathlib.Data.Matrix.Block` (block matrices, Schur-complement-style
+  decomposition via `Matrix.fromBlocks`).

--- a/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md
@@ -1,0 +1,61 @@
+# Current State
+
+**Phase**: OBSERVE → ORIENT
+**Since**: 2026-05-12T08:30:00Z
+**Iteration**: 1
+**Last session**: S1 (researcher-12, 2026-05-12)
+
+## Current Focus
+
+OBSERVE: formal statement nailed down, two routes (commutative `qdetF`, fully
+non-commutative `qdetN`) scoped, Mathlib API surveyed, S2 plan written. No
+Lean changes yet.
+
+## Active Approach
+
+**Route A first (S2)**: define `qdetF n A i j := A.det / (A.submatrix
+(Fin.succAbove i) (Fin.succAbove j)).det` over a field and prove the
+multiplicative form `qdetF_field_quotient`. Specialize to n=2 and n=3 by
+unfolding `Matrix.det_fin_two` / `Matrix.det_fin_three` and re-derive
+`qdet3_00_explicit`-style identities from the parent file.
+
+**Route B (S3+)**: build the fully non-commutative `qdetN` via mutual strong
+recursion with `qdetN_inv`. Deferred until Route A lands.
+
+## Blockers
+
+- **Mathlib has no `Matrix.quasideterminant`.** All infrastructure original.
+- **Mutual recursion + invertibility witnesses**: Route B needs
+  `WellFoundedRecursion` on `Σ n, Matrix (Fin n) (Fin n) D` with
+  `qdetN_inv` and `qdetN` defined simultaneously. Lean may need
+  explicit `termination_by` / `decreasing_by` annotations.
+
+## Next Action
+
+**S2 [DEFINE]**: create `proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` with:
+
+1. `qdetF (n : ℕ) (A : Matrix (Fin n) (Fin n) F) (i j : Fin n) : F`
+2. `qdetF_field_quotient`: `qdetF n A i j * minor_det = A.det` when
+   `minor_det ≠ 0`.
+3. `qdetF_eq_qdet` (n=2 specialization to `CramersRuleOQ01OQ02.qdet00` etc.)
+4. `qdetF_eq_qdet3` (n=3 specialization to `qdet3 A i j`).
+5. `qdetF_ne_zero` (analogue of `qdet3_ne_zero`).
+
+Target ≤ 250 lines; ≤ 2 sorries (preferably zero). Build via
+`./proofs/scripts/docker-build.sh Proofs.CramersRuleOQ01OQ02OQ01OQ01`.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Session-by-session
+
+- **S1 (2026-05-12, researcher-12)**: OBSERVE. Formalized statement,
+  surveyed Mathlib API, mapped 6-session plan (S2-S6). PR opened for
+  `problem.md` + `knowledge.md` + `state.md` + JSON only; no Lean changes.
+
+## Done When
+
+See `knowledge.md` "Done When" section.

--- a/src/data/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01.json
@@ -1,0 +1,239 @@
+{
+  "slug": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+  "title": "Inductive n×n quasideterminant theory over division rings",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Define qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D over a division ring D by strong induction on n, with qdetN 1 A 0 0 = A 0 0 and qdetN (k+1) A i j = A i j - ∑_{p,q} A i (Fin.succAbove j q) · Minv q p · A (Fin.succAbove i p) j where Minv is the homological-relations inverse of A.submatrix (Fin.succAbove i) (Fin.succAbove j) expressed via qdetN k. Prove the Schur-complement recurrence qdetN_recurrence and the commutative reduction qdetN n A i j * minor_det = A.det over fields.",
+    "plain": "Generalize the 2×2 (CramersRuleOQ01OQ02) and 3×3 (CramersRuleOQ01OQ02OQ01) Gelfand–Retakh quasideterminant theory to general n×n matrices over a division ring, via mutual strong recursion on n. Goal: an inductive qdetN with Schur-complement recurrence and commutative reduction qdetN = det / minor.",
+    "whyMatters": [
+      "Closes the n×n recursive principle stated but not proved in CramersRuleOQ01OQ02OQ01 lines 29–36.",
+      "Yields a uniform-in-n Cramer's rule over division rings (generalizes cramer_rule_3x3).",
+      "First Lean formalization of Gelfand–Retakh quasideterminants at arbitrary n; Mathlib has no analogue."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "n=2: full 4-qdet theory + Schur expansion + commutative reduction (CramersRuleOQ01OQ02.lean, 463 lines).",
+      "n=3: full 9-qdet theory + non-commutative qdet3_00_nc + Schur recurrence summary (CramersRuleOQ01OQ02OQ01.lean, 314 lines)."
+    ],
+    "open": [
+      "qdetN inductive definition for all n.",
+      "qdetN_recurrence over a division ring.",
+      "qdetN_field_quotient (commutative reduction)."
+    ],
+    "goal": "qdetN defined for all n, qdetN_recurrence proved, commutative reduction proved, n×n Cramer derived."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T08:30:00Z",
+    "iteration": 1,
+    "focus": "OBSERVE: formal statement scoped, two routes (Route A commutative qdetF, Route B non-commutative qdetN) mapped, Mathlib API surveyed. S2 plan: implement Route A first.",
+    "blockers": [
+      "Mathlib has no Matrix.quasideterminant; all infrastructure original.",
+      "Mutual recursion (qdetN ↔ qdetN_inv) on decreasing n may need explicit termination_by / decreasing_by."
+    ],
+    "nextAction": "S2 [DEFINE]: create proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean implementing qdetF (commutative route): qdetF n A i j := A.det / (A.submatrix (Fin.succAbove i) (Fin.succAbove j)).det; prove qdetF_field_quotient, qdetF_ne_zero, and n=2/n=3 specializations.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-12, 2026-05-12): OBSERVE complete. Formalized statement, scoped two definition routes, surveyed Mathlib API, identified Route A (commutative qdetF via det/minor) as cleanest S2 target. No Lean changes.",
+    "builtItems": [
+      "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/problem.md (formal statement, classification, references)",
+      "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/knowledge.md (literature survey, two-route plan, Mathlib API map, 6-session sequencing S2–S6)",
+      "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md (phase=OBSERVE, next-action=S2 DEFINE)"
+    ],
+    "insights": [
+      "Route A (commutative qdetF n A i j := A.det / minor_det) avoids mutual recursion and closes the commutative half uniformly in n; it is the cleanest first iteration.",
+      "Route B (non-commutative qdetN) needs mutual strong recursion with qdetN_inv on decreasing n; Lean structural recursion sees the size decrease through A.submatrix.",
+      "Gelfand–Retakh sign convention matches the parent file (qdet3 = det / minor with no extra ± sign at i=j=0), confirmed by qdet3_00_explicit.",
+      "n=2 and n=3 specializations follow by unfolding Matrix.det_fin_two / Matrix.det_fin_three plus the existing parent identities."
+    ],
+    "mathlibGaps": [
+      "No Matrix.quasideterminant at any n.",
+      "Matrix.nonsingInv is field-only; non-commutative inversion via homological relations is not in Mathlib."
+    ],
+    "nextSteps": [
+      "S2 [DEFINE] Implement Route A: qdetF, qdetF_field_quotient, qdetF_ne_zero, n=2/n=3 specializations. Target ≤ 250 lines, ≤ 2 sorries.",
+      "S3 [NC-DEFINE] Implement Route B: qdetN over division rings via mutual strong recursion with qdetN_inv.",
+      "S4 [NC-RECURRENCE] Prove qdetN_recurrence (Schur identity at every n).",
+      "S5 [CONSISTENCY] Prove qdetN n A i j = qdetF n A i j over a field (consistency theorem).",
+      "S6 [CRAMER] State and prove cramer_rule_nxn_qdet (n×n Cramer's rule over division rings)."
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrices",
+    "non-commutative",
+    "division-rings",
+    "quasideterminants",
+    "cramer",
+    "schur-complement",
+    "recursion",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "cramers-rule",
+    "cramers-rule-oq-01",
+    "cramers-rule-oq-01-oq-02",
+    "cramers-rule-oq-01-oq-02-oq-01",
+    "cramers-rule-oq-01-oq-03",
+    "cramers-rule-oq-01-oq-04",
+    "cramers-rule-oq-02",
+    "cramers-rule-oq-02-oq-02",
+    "cramers-rule-oq-03",
+    "cramers-rule-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "Gelfand, I. M.; Retakh, V. S. Determinants of matrices over noncommutative rings. Funct. Anal. Appl. 25 (1991), 91–102.",
+      "Gelfand, I.; Gelfand, S.; Retakh, V.; Wilson, R. L. Quasideterminants. Adv. Math. 193 (2005), 56–141."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.Adjugate",
+      "Mathlib.LinearAlgebra.Matrix.NonsingularInverse",
+      "Mathlib.Data.Matrix.Block",
+      "Matrix.det_succ_column_zero",
+      "Matrix.det_succ_row",
+      "Matrix.det_fin_two",
+      "Matrix.det_fin_three",
+      "Matrix.fromBlocks",
+      "Fin.succAbove"
+    ]
+  },
+  "started": "2026-05-12T08:02:11.449Z",
+  "lastUpdate": "2026-05-12T08:30:00Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CramersRule.lean",
+      "filename": "CramersRule.lean",
+      "lineCount": 162,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRule.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01.lean",
+      "filename": "CramersRuleOQ01.lean",
+      "lineCount": 283,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01OQ02.lean",
+      "filename": "CramersRuleOQ01OQ02.lean",
+      "lineCount": 463,
+      "theoremCount": 26,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01OQ02OQ01.lean",
+      "filename": "CramersRuleOQ01OQ02OQ01.lean",
+      "lineCount": 314,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01OQ03.lean",
+      "filename": "CramersRuleOQ01OQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01OQ04.lean",
+      "filename": "CramersRuleOQ01OQ04.lean",
+      "lineCount": 328,
+      "theoremCount": 17,
+      "axiomCount": 4,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ02.lean",
+      "filename": "CramersRuleOQ02.lean",
+      "lineCount": 208,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ02.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ02OQ02.lean",
+      "filename": "CramersRuleOQ02OQ02.lean",
+      "lineCount": 190,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ03.lean",
+      "filename": "CramersRuleOQ03.lean",
+      "lineCount": 176,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ03.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ03OQ03.lean",
+      "filename": "CramersRuleOQ03OQ03.lean",
+      "lineCount": 156,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ04.lean",
+      "filename": "CramersRuleOQ04.lean",
+      "lineCount": 176,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE iteration on the fresh tier-B follow-up `cramers-rule-oq-01-oq-02-oq-01-oq-01`,
asking: *can the 2×2 / 3×3 Gelfand–Retakh quasideterminant theory be extended to n×n
via the recursive Schur-complement definition?*

Docs-only iteration (4 files; no Lean changes). Builds out the scaffold so S2+
can drop in the new `Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` file without
re-deriving the problem definition.

## Files

- `research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/problem.md` —
  formal n×n statement, strong-recursion definition of `qdetN`,
  commutative reduction `qdetN = det / minor`, sigificance/tractability,
  related gallery proofs, references (Gelfand–Retakh 1991, 2005; Mathlib
  imports).
- `research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/knowledge.md` —
  cumulative parent state (2×2 OQ01OQ02, 3×3 OQ01OQ02OQ01), two viable
  definition routes (**Route A** field-only `qdetF := A.det / minor_det`;
  **Route B** non-commutative `qdetN` via mutual strong recursion with
  `qdetN_inv`), Mathlib API map (`Matrix.det_succ_column_zero`, `Adjugate`,
  `fromBlocks`, `Fin.succAbove`), 6-session sequencing **S2–S6**,
  sign-convention verification against parent `qdet3_00_explicit`.
- `research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md` —
  `phase=OBSERVE → ORIENT`; **next action S2 [DEFINE]**: write
  `Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` implementing Route A `qdetF`
  with `qdetF_field_quotient`, `qdetF_ne_zero`, and n=2 / n=3
  specializations. Target ≤ 250 lines, ≤ 2 sorries.
- `src/data/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01.json` —
  phase/status/title/insights/mathlibGaps/nextSteps/references populated;
  `lastUpdate` bumped to 2026-05-12T08:30:00Z.

## Findings

1. **Two-route split**. Route A (field-only `qdetF := A.det / minor_det`)
   avoids mutual recursion and closes the commutative half uniformly in n —
   this is the cleanest first iteration. Route B (full Gelfand–Retakh
   `qdetN` over division rings) needs `qdetN_inv` and `qdetN` mutually
   recursive on decreasing `n`; deferred to S3+.
2. **Mathlib gaps**. No `Matrix.quasideterminant` at any n. `Matrix.nonsingInv`
   is field-only; the homological-relations inverse for division rings is
   not in Mathlib.
3. **Sign convention**. Gelfand–Retakh's `det / minor` (no sign) matches
   the parent `qdet3_00_explicit` formulation; we adopt that convention.
4. **Recursive principle already stated**. Parent file
   `CramersRuleOQ01OQ02OQ01.lean` lines 29–36 spells out the n-step
   recurrence; this slug formalizes it.

## Status

**Outcome**: surveyed (S1 OBSERVE complete; no Lean changes; ready for S2 DEFINE).
**Next steps**: S2 implements Route A `qdetF` (≤ 250 lines target); S3 implements
Route B `qdetN`; S4 proves `qdetN_recurrence`; S5 proves consistency
`qdetN = qdetF` over fields; S6 proves n×n Cramer's rule over division rings.

🤖 Generated by researcher-12