### PR TITLE
audit: tracker freshness — 9 stale entries re-verified clean (2026-05-12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2822,9 +2822,9 @@
       "result": "clean"
     },
     "erdos-1001-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T16:20:35Z",
+      "lastAudited": "2026-05-12T08:40:05Z",
       "result": "clean"
     },
     "erdos-1002": {
@@ -11064,8 +11064,8 @@
     },
     "erdos-994": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:33:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T08:40:26Z",
       "result": "clean"
     },
     "erdos-995": {
@@ -11076,8 +11076,8 @@
     },
     "erdos-996": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:32:57Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T08:40:25Z",
       "result": "clean"
     },
     "erdos-997": {
@@ -11088,8 +11088,8 @@
     },
     "erdos-998": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:33:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T08:40:26Z",
       "result": "clean"
     },
     "erdos-999": {
@@ -11986,9 +11986,9 @@
       "result": "clean"
     },
     "isoperimetric-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T18:32:43Z",
+      "lastAudited": "2026-05-12T08:40:25Z",
       "result": "clean"
     },
     "isosceles-triangle": {
@@ -12322,8 +12322,8 @@
     },
     "liouville-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:32:18Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T08:40:25Z",
       "result": "clean"
     },
     "liouville-theorem-oq-04": {
@@ -12543,9 +12543,9 @@
       "notes": "Re-audit: structural counts (lineCount 71, theoremCount 19, sorries 0, axioms 0) all match Lean source; no True stubs; description accurately scoped to native_decide for n≤8 (no overclaiming general identity)."
     },
     "partition-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T18:31:19Z",
+      "lastAudited": "2026-05-12T08:40:25Z",
       "result": "clean"
     },
     "pascals-hexagon": {
@@ -13721,14 +13721,14 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-26T16:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T08:40:41Z",
       "result": "clean",
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-26T16:11:50Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T08:39:54Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Routine audit-tracker freshness pass. Re-audited 9 gallery entries whose `lastAudited` was 2026-04-26 (~16 days stale). All 9 verified clean against current `origin/main` Lean sources.

## Verification

For each entry, checked:
- `sorries` field vs `grep -c '\bsorry\b'` on the Lean file
- `axiomCount` field vs `grep -cE '^axiom '` on the Lean file
- `lineCount` field vs `wc -l`
- `theoremCount` field vs declaration count (where applicable)
- No `: True :=`-style stub detection
- `status`/`badge` consistency with sorry/axiom counts

| Slug | Status / Badge | sorries | axioms | lines |
|------|---------------|--------:|-------:|------:|
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03` | verified / original | 0 | 0 | 253 |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04` | verified / mathlib | 0 | 0 | 359 |
| `erdos-1001-oq-03` | axiomatized / axiom | 0 | 9 | 227 |
| `partition-theorem-oq-03` | axiomatized / axiom | 0 | 1 | 62 |
| `liouville-theorem` | axiomatized / axiom | 0 | 1 | 528 |
| `isoperimetric-theorem-oq-01` | axiomatized / axiom | 0 | 2 | 384 |
| `erdos-994` | axiomatized / axiom | 0 | 2 | 208 |
| `erdos-996` | axiomatized / axiom | 0 | 2 | 353 |
| `erdos-998` | axiomatized / axiom | 0 | 2 | 190 |

## Outstanding gallery issue

`combinations-formula-oq-02` remains the sole `--issues` flag in `find-targets`. Already addressed by open PR #17997 (`sorries: 1 → 0`, `status: formalized → verified` after #17991 closed the underlying `catalan_mul_succ` sorry). Not touched here.

## Test plan

- [x] `git diff --stat` shows only `src/data/proofs/audit-tracker.json` (1 file, +18/-18)
- [x] `python3 -c "import json; json.load(open(...))"` confirms JSON validity
- [x] Each updated entry's `result` remains `"clean"` and `auditCount` increments by 1
- [ ] After merge: `find-targets --stats` should show `lastAudited` for these 9 entries advance to 2026-05-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)