### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01): S2 ACT-A — multinomialPMF normalization (proven, sorry-free) + parent ENNReal/PMF drift fix (build verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -236,6 +236,7 @@ import Proofs.BinomialTheoremOQ02OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01Aristotle
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01
+import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ03
 import Proofs.BinomialTheoremOQ02OQ01OQ02

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
@@ -1,6 +1,7 @@
 import Mathlib.Probability.ProbabilityMassFunction.Basic
 import Mathlib.Data.Nat.Choose.Multinomial
 import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.ENNReal.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Tactic
 
@@ -31,6 +32,7 @@ The multinomial theorem provides the normalization proof directly.
 namespace BinomialTheoremOQ02OQ01OQ01
 
 open Finset BigOperators MeasureTheory
+open scoped ENNReal
 
 -- ============================================================
 -- PART 1: The Composition Type (Support of Multinomial)
@@ -112,8 +114,11 @@ theorem multinomialPMF_sum_eq_one {α : Type*} [DecidableEq α]
 noncomputable def multinomialPMF {α : Type*} [DecidableEq α]
     (s : Finset α) (p : α → ℝ≥0∞) (n : ℕ)
     (hp : ∑ i ∈ s, p i = 1) : PMF (Composition α s n) :=
-  ⟨fun k => multinomialPMFVal s p n k,
-   multinomialPMF_sum_eq_one s p n hp⟩
+  ⟨fun k => multinomialPMFVal s p n k, by
+    -- Convert the Finset.sum normalization into a HasSum statement.
+    -- For Fintype α, HasSum f c ↔ ∑ a, f a = c via hasSum_fintype.
+    have h := hasSum_fintype (fun k : Composition α s n => multinomialPMFVal s p n k)
+    rwa [multinomialPMF_sum_eq_one s p n hp] at h⟩
 
 -- ============================================================
 -- PART 5: Properties of the PMF

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,123 @@
+/-
+# Multinomial PMF Normalization (Proven)
+
+## Open Question (slug: binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01)
+
+The parent file `BinomialTheoremOQ02OQ01OQ01.lean` defines a `Composition`
+structure (the support type for the multinomial PMF) and the value
+`multinomialPMFVal s p n k`, then defers the normalization
+
+  `∑ k : Composition α s n, multinomialPMFVal s p n k = 1`
+
+to a `sorry` (line 102). This file proves the normalization by routing
+through Mathlib's `Finset.sum_pow_eq_sum_piAntidiag` and the sibling
+file's `CompositionFintype.sum_composition_eq_piAntidiag_sum` bridge.
+
+## Strategy (S2 ACT-A)
+
+The two `Composition` types — `BinomialTheoremOQ02OQ01OQ01.Composition`
+in the parent and `CompositionFintype.Composition` in the sibling — are
+structurally identical. We define a one-line `compositionTypeEquiv`
+between them, transfer the sum, then apply two stable Mathlib lemmas:
+
+  `sum_composition_eq_piAntidiag_sum` (sibling, line 145 of
+  `BinomialTheoremOQ02OQ01OQ01OQ01.lean`):
+    `∑ c : Composition α s n, f c.counts = ∑ k ∈ s.piAntidiag n, f k`
+
+  `Finset.sum_pow_eq_sum_piAntidiag` (Mathlib v4.26.0,
+  `Mathlib/Data/Nat/Choose/Multinomial.lean` line 301):
+    `(∑ i ∈ s, f i) ^ n = ∑ k ∈ s.piAntidiag n, multinomial s k * ∏ i ∈ s, f i ^ k i`
+
+The chain is: transfer the parent sum into the sibling sum via
+`Fintype.sum_equiv compositionTypeEquiv`; apply
+`sum_composition_eq_piAntidiag_sum` to land on a `piAntidiag` sum;
+recognize this as the RHS of `sum_pow_eq_sum_piAntidiag` (in reverse);
+fold via the hypothesis `∑ p i = 1` and `1 ^ n = 1`.
+
+## Output
+
+This file does NOT redefine `multinomialPMF` or `multinomialPMFVal`; it
+exports a single named theorem `multinomialPMF_sum_eq_one_proved` that
+discharges the parent's deferred normalization. Downstream consumers
+can either (a) replace the parent's `sorry` by importing this file and
+applying the proved theorem, or (b) keep using the parent's existential
+`multinomialPMF` definition while citing this file as the proof witness.
+-/
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Data.ENNReal.Basic
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Probability.ProbabilityMassFunction.Basic
+import Mathlib.Tactic
+import Proofs.BinomialTheoremOQ02OQ01OQ01
+import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01
+
+namespace BinomialTheoremOQ02OQ01OQ01
+
+open Finset BigOperators
+open scoped ENNReal
+
+/-! ## Namespace bridge
+
+The parent file's `Composition α s n` and the sibling file's
+`CompositionFintype.Composition α s n` have identical fields
+(`counts : α → ℕ`, `sum_eq : ∑ i ∈ s, counts i = n`, `counts_outside`).
+Their distinct namespacing is purely a layering artefact — the sibling
+keeps the bridge-to-`piAntidiag` machinery isolated from the gallery
+PMF construction. We expose the trivial type equivalence here so the
+two namespaces can share sums via `Fintype.sum_equiv`. -/
+
+/-- Bridge: the parent's `Composition α s n` is canonically equivalent
+to the sibling's `CompositionFintype.Composition α s n`. The forward
+and inverse maps are the identity on the underlying record. -/
+def compositionTypeEquiv (α : Type*) [DecidableEq α] (s : Finset α) (n : ℕ) :
+    Composition α s n ≃ CompositionFintype.Composition α s n where
+  toFun c := ⟨c.counts, c.sum_eq, c.counts_outside⟩
+  invFun c := ⟨c.counts, c.sum_eq, c.counts_outside⟩
+  left_inv c := by cases c; rfl
+  right_inv c := by cases c; rfl
+
+/-! ## Main theorem -/
+
+/-- **Normalization of the multinomial PMF (proven)**.
+
+The sum `∑ k : Composition α s n, multinomialPMFVal s p n k` equals `1`
+whenever `∑ i ∈ s, p i = 1`. This discharges the deferred sorry on
+`BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one`.
+
+Proof outline:
+
+  1. Transfer the sum via `compositionTypeEquiv` from
+     `BinomialTheoremOQ02OQ01OQ01.Composition` to
+     `CompositionFintype.Composition` (record-wise identity, hence
+     the summand `multinomialPMFVal s p n` is preserved unchanged on
+     the underlying `counts`).
+  2. Apply `CompositionFintype.sum_composition_eq_piAntidiag_sum` to
+     rewrite the `Composition`-indexed sum as a `piAntidiag`-indexed
+     sum on the `counts`-shaped function.
+  3. Apply `Finset.sum_pow_eq_sum_piAntidiag` in reverse to fold the
+     `piAntidiag` sum into a power.
+  4. Substitute `∑ i ∈ s, p i = 1` (hypothesis `hp`) and `(1 : ℝ≥0∞)^n
+     = 1` to conclude. -/
+theorem multinomialPMF_sum_eq_one_proved {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ≥0∞) (n : ℕ)
+    (hp : ∑ i ∈ s, p i = 1) :
+    ∑ k : Composition α s n, multinomialPMFVal s p n k = 1 := by
+  -- Step 1: transfer the Composition-indexed sum via compositionTypeEquiv.
+  -- The summand on the RHS spells out `multinomialPMFVal` on the
+  -- transported composition's `counts` field, which is `c.counts`
+  -- (componentwise identity) — `rfl` matches because both sides
+  -- reduce to the same product.
+  rw [Fintype.sum_equiv (compositionTypeEquiv α s n)
+        (fun c => multinomialPMFVal s p n c)
+        (fun c => (Nat.multinomial s c.counts : ℝ≥0∞)
+                    * ∏ i ∈ s, p i ^ c.counts i)
+        (fun _ => rfl)]
+  -- Step 2: use the sibling's bridge to land on a piAntidiag sum.
+  rw [CompositionFintype.sum_composition_eq_piAntidiag_sum (M := ℝ≥0∞) s n
+        (fun k => (Nat.multinomial s k : ℝ≥0∞) * ∏ i ∈ s, p i ^ k i)]
+  -- Step 3: fold the piAntidiag sum into a power via Mathlib.
+  rw [← Finset.sum_pow_eq_sum_piAntidiag s p n]
+  -- Step 4: use the normalization hypothesis and 1^n = 1.
+  rw [hp, one_pow]
+
+end BinomialTheoremOQ02OQ01OQ01

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
@@ -1,8 +1,81 @@
 # Current State
 
-**Phase**: OBSERVE → ORIENT (S1 scaffold; no Lean changes yet)
-**Since**: 2026-05-12 (S1 OBSERVE, researcher-10)
-**Iteration**: 1
+**Phase**: ACT (S2 ACT-A complete: namespace bridge + normalization theorem; sorry-free)
+**Since**: 2026-05-12T08:50:00Z (S2 ACT-A, researcher-11)
+**Iteration**: 2
+
+## Iteration 2 (researcher-11, 2026-05-12) — S2 ACT-A namespace bridge + normalization
+
+**Outcome**: progress — `multinomialPMF_sum_eq_one_proved` landed sorry-free in
+the new file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` (~110
+lines). The proof discharges the deferred parent-file sorry on
+`multinomialPMF_sum_eq_one` (line 102 of `BinomialTheoremOQ02OQ01OQ01.lean`)
+along the route documented in S1's `knowledge.md` §8.
+
+### What I added (~110 lines)
+
+New file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean`:
+
+* `compositionTypeEquiv` — namespace bridge between
+  `BinomialTheoremOQ02OQ01OQ01.Composition` and
+  `CompositionFintype.Composition`. The structure fields agree
+  (`counts`, `sum_eq`, `counts_outside`); both maps are the identity
+  on the underlying record. Sorry-free, ~6 lines of body.
+
+* `multinomialPMF_sum_eq_one_proved` — the main result, sorry-free,
+  ~6 lines of `rw` chain:
+  1. `Fintype.sum_equiv compositionTypeEquiv` — transfer to
+     `CompositionFintype.Composition`.
+  2. `CompositionFintype.sum_composition_eq_piAntidiag_sum` — bridge
+     to `piAntidiag` sum.
+  3. `← Finset.sum_pow_eq_sum_piAntidiag` — fold to the `n`-th power.
+  4. `hp` + `one_pow` — close.
+
+Plus `import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01` added to
+`proofs/Proofs.lean` (alphabetical position between
+`...OQ01OQ01OQ01.lean` and `...OQ01OQ01OQ02.lean` per S1's plan).
+
+### Build status (S2)
+
+**Verified** via `./proofs/scripts/docker-build.sh
+Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01`. Build succeeded; no
+new sorries introduced. The parent's `multinomialPMF_sum_eq_one`
+sorry remains in `BinomialTheoremOQ02OQ01OQ01.lean:102` because
+this iteration deliberately keeps the file as a *proof-of-existence*
+(per S1's Q1 recommendation) — downstream consumers can use the
+proven `multinomialPMF_sum_eq_one_proved` directly without
+back-porting.
+
+### Files modified (S2 narrow)
+
+- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` — new file
+  (~110 lines).
+- `proofs/Proofs.lean` — +1 import (alphabetical position).
+- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`
+  — phase OBSERVE→ACT, iter 1→2, builtItems +2.
+- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/{knowledge.md, state.md}`
+  — S2 entry.
+
+### Next Action (S3, optional)
+
+Either:
+
+* **S3a (back-port).** Replace the parent's `sorry` at
+  `BinomialTheoremOQ02OQ01OQ01.lean:102` with a one-line wrapper
+  calling `BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved`.
+  Trivial follow-up; would close the parent file's open sorry as well.
+* **S3b (out-of-scope cleanup).** Discharge the four downstream
+  sorries in the parent (`multinomialPMF_support`,
+  `multinomial_marginal_binomial`, `multinomial_mean`,
+  `multinomial_covariance`) — explicitly marked OUT OF SCOPE in S1
+  knowledge.md §10. Defer to a sibling slug.
+
+If neither S3 fires, the slug flips to `completed` after S2 merges.
+
+---
+
+## (Historic) Iteration 1 (researcher-10, 2026-05-12) — S1 OBSERVE
+
 
 ## Current Focus
 

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01",
   "title": "Discharge multinomialPMF_sum_eq_one by combining the gallery's piAntidiag bridge with Mathlib's multinomial theorem",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -27,21 +27,23 @@
     "goal": "Produce a Lean 4 file proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~50-60 lines, 0 axioms, 0 sorries) containing (i) a 10-line compositionTypeEquiv bridge between BinomialTheoremOQ02OQ01OQ01.Composition and CompositionFintype.Composition, and (ii) a theorem multinomialPMF_sum_eq_one_proved that closes the parent's sorry by sum_equiv + the two existing lemmas. Add an import line to proofs/Proofs.lean in alphabetical position. Target: build verified inside Docker; ≤ 60 lines."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T08:12:00.000Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE — scaffold problem.md, knowledge.md, state.md, and enrich this JSON. No Lean changes. Audit confirms Finset.sum_pow_eq_sum_piAntidiag is present at pinned Mathlib rev 2df2f015 and ENNReal is a CommSemiring; the namespace-bridge between the two structurally-identical Composition types is the only nontrivial S2 ACT-A subtask.",
+    "phase": "ACT",
+    "since": "2026-05-12T08:50:00.000Z",
+    "iteration": 2,
+    "focus": "S2 ACT-A (researcher-11, 2026-05-12) — created proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~110 lines, sorry-free) with the namespace-bridge compositionTypeEquiv between BinomialTheoremOQ02OQ01OQ01.Composition and CompositionFintype.Composition, plus the main theorem multinomialPMF_sum_eq_one_proved discharging the parent's deferred sorry on multinomialPMF_sum_eq_one (BinomialTheoremOQ02OQ01OQ01.lean:102). The proof is the 4-step rw chain documented in S1's knowledge.md §8: (1) Fintype.sum_equiv compositionTypeEquiv to transfer to the sibling Composition type, (2) CompositionFintype.sum_composition_eq_piAntidiag_sum to land on a piAntidiag sum, (3) ← Finset.sum_pow_eq_sum_piAntidiag to fold into a power, (4) hp + one_pow to close. Added import to proofs/Proofs.lean (alphabetical position between OQ01OQ01OQ01.lean and OQ01OQ01OQ02.lean). The parent's sorry remains; S3 back-port is optional follow-up.",
     "blockers": [],
-    "nextAction": "S2 ACT-A — create proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean with the compositionTypeEquiv bridge and the multinomialPMF_sum_eq_one_proved theorem; add import line to proofs/Proofs.lean; build inside Docker; commit build-pending if Docker times out per project memory.",
+    "nextAction": "S3 (optional): back-port the proven theorem into BinomialTheoremOQ02OQ01OQ01.lean by replacing the line-102 sorry with `exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp` (one-line wrapper). Trivial follow-up; would close the parent file's open sorry as well. Alternative: defer to a sibling slug for the four downstream sorries (multinomialPMF_support, multinomial_marginal_binomial, multinomial_mean, multinomial_covariance) — explicitly OUT OF SCOPE for this slug per S1 knowledge.md §10.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (2026-05-12, researcher-10): scaffolded the four artifact files for a previously empty (knowledge-score 0) tier-B slug. Mathlib v4.26.0 API audit at pin 2df2f015 confirms Finset.sum_pow_eq_sum_piAntidiag exists at Mathlib/Data/Nat/Choose/Multinomial.lean line 301-304, requires [CommSemiring R], and is stable across recent Mathlib releases. The gallery's BinomialTheoremOQ02OQ01OQ01OQ01.lean already provides sum_composition_eq_piAntidiag_sum. The remaining nontrivial subtask is the namespace bridge: the parent file's Composition and the child file's CompositionFintype.Composition are structurally identical but distinct Lean types, requiring a ~10-line compositionTypeEquiv. Total estimated S2 ACT-A: 50-60 lines of Lean.",
+    "progressSummary": "S2 ACT-A (researcher-11, 2026-05-12): the deferred multinomialPMF_sum_eq_one is now proved sorry-free in a new sibling file BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~110 lines). The proof closes the route documented in S1: namespace bridge via compositionTypeEquiv (record-wise identity equivalence between the parent and sibling Composition types), Fintype.sum_equiv to transfer summation, CompositionFintype.sum_composition_eq_piAntidiag_sum to land on piAntidiag, ← Finset.sum_pow_eq_sum_piAntidiag to fold into the n-th power, then hp + one_pow. Added the import to proofs/Proofs.lean. The parent's sorry remains for the moment; S3 back-port is a one-line wrapper away. // S1 OBSERVE (2026-05-12, researcher-10): scaffolded the four artifact files for a previously empty (knowledge-score 0) tier-B slug. Mathlib v4.26.0 API audit at pin 2df2f015 confirms Finset.sum_pow_eq_sum_piAntidiag exists at Mathlib/Data/Nat/Choose/Multinomial.lean line 301-304, requires [CommSemiring R], and is stable across recent Mathlib releases. The gallery's BinomialTheoremOQ02OQ01OQ01OQ01.lean already provides sum_composition_eq_piAntidiag_sum. The remaining nontrivial subtask is the namespace bridge: the parent file's Composition and the child file's CompositionFintype.Composition are structurally identical but distinct Lean types, requiring a ~10-line compositionTypeEquiv. Total estimated S2 ACT-A: 50-60 lines of Lean.",
     "builtItems": [
+      "**(S2 NEW)** proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean — namespace-bridge file with compositionTypeEquiv (record-wise identity Equiv between parent and sibling Composition types) and multinomialPMF_sum_eq_one_proved (the proven normalization theorem); ~110 lines, sorry-free, build verified (BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean)",
+      "**(S2 NEW)** proofs/Proofs.lean — added import in alphabetical position between OQ01OQ01OQ01.lean and OQ01OQ01OQ02.lean",
       "problem.md (formal statement + Lean target signature + non-claims)",
       "knowledge.md (Mathlib API audit + parent/sibling-child audit + namespace-bridge analysis + candidate proof skeleton)",
       "state.md (S1 phase + S2 plan + risks)",


### PR DESCRIPTION
## Summary

S2 ACT-A on `binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01`. Proves the deferred `multinomialPMF_sum_eq_one` (parent file `BinomialTheoremOQ02OQ01OQ01.lean:102` sorry) sorry-free in a new sibling file, AND fixes two pre-existing Mathlib-drift bugs in the parent that were silently breaking compilation on origin/main.

**Outcome**: progress — main result `multinomialPMF_sum_eq_one_proved` discharged sorry-free; parent file restored to a buildable state.

## Main contribution: `multinomialPMF_sum_eq_one_proved` (sorry-free)

New file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` (~110 lines) provides:

* `compositionTypeEquiv` — namespace bridge between `BinomialTheoremOQ02OQ01OQ01.Composition` and `CompositionFintype.Composition` (record-wise identity Equiv on the three structurally-equal fields `counts`, `sum_eq`, `counts_outside`).

* `multinomialPMF_sum_eq_one_proved` — the proven normalization, via the 4-step rewrite chain documented in S1's `knowledge.md` 8:

  1. `Fintype.sum_equiv compositionTypeEquiv` — transfer the `Composition`-indexed sum to the sibling type.
  2. `CompositionFintype.sum_composition_eq_piAntidiag_sum` — bridge to a `piAntidiag`-indexed sum on the `counts`-shaped function.
  3. `← Finset.sum_pow_eq_sum_piAntidiag` — fold to the n-th power.
  4. `hp` + `one_pow` — close.

Plus an import line added to `proofs/Proofs.lean` in alphabetical position between `OQ01OQ01OQ01.lean` and `OQ01OQ01OQ02.lean`.

Per S1 Q1 recommendation, this file is a *proof-of-existence* — it does NOT redefine `multinomialPMFVal`, `multinomialPMF`, or any other parent identifier. Downstream consumers can either back-port the proof (S3) or keep using the parent's existential definition.

## Parent drift fixes (necessary for the new file to build)

The parent `BinomialTheoremOQ02OQ01OQ01.lean` no longer compiled on origin/main due to two Mathlib drift issues:

**(i) `R>=0inf` notation became scoped.** Formerly available via transitive imports (e.g., `Mathlib.Probability.ProbabilityMassFunction.Basic`), now requires `open scoped ENNReal`. Fix: add `open scoped ENNReal` after the existing `open` block, plus an explicit `import Mathlib.Data.ENNReal.Basic`. (5 parse errors on lines 81/99/113/124/132 resolved.)

**(ii) `PMF.mk` no longer accepts `Finset.sum = 1`.** Mathlib's `PMF` wants `HasSum f 1`, not the Fintype-finite-support `Finset.sum = 1`. The parent's `multinomialPMF` definition at line 117-118 passed `multinomialPMF_sum_eq_one` (a Finset.sum equality) directly into the PMF subtype constructor; this used to coerce automatically but no longer does. Fix: convert via `hasSum_fintype` (the standard Fintype-finite-support → HasSum bridge in Mathlib v4.26.0):

\`\`\`lean
  ⟨fun k => multinomialPMFVal s p n k, by
    have h := hasSum_fintype (fun k : Composition α s n => multinomialPMFVal s p n k)
    rwa [multinomialPMF_sum_eq_one s p n hp] at h⟩
\`\`\`

These two fixes are the minimum needed to restore the parent's build; no behavior changes, no axiom additions, no sorry count delta on the parent.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01` — **build succeeded** (3063 jobs).

Warnings: only the parent's pre-existing `sorry` warnings on lines 100/136/155/170/182. The new file `BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` produces zero warnings and zero sorries.

## Files modified

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` — NEW (~110 lines, sorry-free)
- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` — minimal Mathlib drift fixes (1 line `open scoped ENNReal`, 1 line `import Mathlib.Data.ENNReal.Basic`, 4-line `multinomialPMF` body change to insert `hasSum_fintype` bridge)
- `proofs/Proofs.lean` — +1 import line (alphabetical)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md` — iter 2 entry
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json` — phase OBSERVE→ACT, iter 1→2, builtItems +2

## Honesty note

This PR introduces zero new sorries. It proves a previously-deferred normalization theorem (closing it sorry-free in a sibling file) and fixes two pre-existing Mathlib-drift bugs in the parent that were blocking compilation. The parent's *original* sorry on `multinomialPMF_sum_eq_one` remains unchanged (so an immediate S3 back-port replacing it with `exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp` is the natural follow-up).

The two drift fixes were forced by build necessity, not chosen as scope creep — without them the new file's `import Proofs.BinomialTheoremOQ02OQ01OQ01` cascades into compilation failure. They are minimal, additive, behavior-preserving.

## Test plan

- [x] Lean build verified: `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01` (3063 jobs)
- [x] New file `BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` is sorry-free with zero warnings
- [x] Parent file's pre-existing sorries (lines 100/136/155/170/182) preserved unchanged
- [x] JSON syntax validated
- [x] Branched off origin/main, rebased before push (post-rebase diff scoped to the 5 expected files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)