### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S3 — ring ↔ unit bridge + native_decide build fix (build verified)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -28,19 +28,24 @@ where `ω_odd(n)` is the number of distinct odd prime factors of `n`, and
 The formula has been verified numerically for `n = 1..120` (see
 `research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md`).
 
-## This file (S2)
+## This file (S3)
 
 * Defines the closed-form count `numSqrtsOne` (computable, via
   `Nat.primeFactors` — note the contrast with `Nat.factorization`, which is
   `noncomputable` in Mathlib because of `multiplicity`).
 * Verifies the formula at a handful of small `n` via `decide`.
 * States the main theorem `card_sqrts_one_eq_numSqrtsOne` with `sorry`.
+* **S3 NEW**: ring↔unit bridge `card_sqrts_one_eq_card_units_sqrts_one`
+  reducing the ZMod-side count to a unit-group count, so that subsequent
+  sessions can work entirely inside `(ZMod n)ˣ` where the cyclic-group
+  structure (`ZMod.isCyclic_units_of_prime_pow` etc.) applies.
 
 ## Subsequent sessions
 
-* **S3**: prime-power cases via `ZMod.unitsCyclic` (~100 lines).
-* **S4**: CRT multiplicativity (~50 lines).
-* **S5**: assembly by induction on `n.primeFactors.card` (~40 lines).
+* **S4**: prime-power count `card_sqrts_one_unit_prime_pow_odd`
+  via `IsCyclic.card_orderOf_eq_totient` (~70 lines).
+* **S5**: CRT multiplicativity (~50 lines).
+* **S6**: assembly by induction on `n.primeFactors.card` (~40 lines).
 
 ## Status
 
@@ -86,22 +91,22 @@ theorem numSqrtsOne_pos (n : ℕ) : 0 < numSqrtsOne n := by
 -- ============================================================================
 
 -- Powers of 2: should give epsTwo correction only.
-example : numSqrtsOne 1 = 1 := by decide
-example : numSqrtsOne 2 = 1 := by decide
-example : numSqrtsOne 4 = 2 := by decide
-example : numSqrtsOne 8 = 4 := by decide
-example : numSqrtsOne 16 = 4 := by decide
+example : numSqrtsOne 1 = 1 := by native_decide
+example : numSqrtsOne 2 = 1 := by native_decide
+example : numSqrtsOne 4 = 2 := by native_decide
+example : numSqrtsOne 8 = 4 := by native_decide
+example : numSqrtsOne 16 = 4 := by native_decide
 
 -- Odd: pure ω_odd contribution.
-example : numSqrtsOne 3 = 2 := by decide
-example : numSqrtsOne 15 = 4 := by decide
-example : numSqrtsOne 105 = 8 := by decide
+example : numSqrtsOne 3 = 2 := by native_decide
+example : numSqrtsOne 15 = 4 := by native_decide
+example : numSqrtsOne 105 = 8 := by native_decide
 
 -- Mixed: both factors contribute.
-example : numSqrtsOne 12 = 4 := by decide      -- 2² · 3:  ω_odd=1, ε₂=1
-example : numSqrtsOne 24 = 8 := by decide      -- 2³ · 3:  ω_odd=1, ε₂=2
-example : numSqrtsOne 60 = 8 := by decide      -- 2² · 15: ω_odd=2, ε₂=1
-example : numSqrtsOne 120 = 16 := by decide    -- 2³ · 15: ω_odd=2, ε₂=2
+example : numSqrtsOne 12 = 4 := by native_decide      -- 2² · 3:  ω_odd=1, ε₂=1
+example : numSqrtsOne 24 = 8 := by native_decide      -- 2³ · 3:  ω_odd=1, ε₂=2
+example : numSqrtsOne 60 = 8 := by native_decide      -- 2² · 15: ω_odd=2, ε₂=1
+example : numSqrtsOne 120 = 16 := by native_decide    -- 2³ · 15: ω_odd=2, ε₂=2
 
 -- ============================================================================
 -- Section 3: Main theorem (target of S3..S5)
@@ -124,5 +129,53 @@ This is the quantitative upgrade of the parent's qualitative `≥ 3` bound
 theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) [NeZero n] :
     (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n := by
   sorry
+
+-- ============================================================================
+-- Section 4: Ring ↔ unit bridge (S3)
+-- ============================================================================
+
+/-- **Ring ↔ unit bridge for square roots of unity.**
+
+Every `x : ZMod n` satisfying `x² = 1` is automatically a unit (its inverse is
+itself), so counting solutions inside `ZMod n` is the same as counting
+solutions inside `(ZMod n)ˣ`.
+
+This is the key reduction that lets subsequent sessions (S4 onward) work
+entirely inside the unit group `(ZMod n)ˣ`, where the cyclic-group structure
+(`ZMod.isCyclic_units_of_prime_pow`, the order-`p^{k-1}(p-1)` totient
+formula, etc.) applies cleanly. The ring `ZMod n` itself is not even an
+integral domain when `n` is composite, so polynomial-roots arguments do
+not directly count `x² = 1`; the bridge sidesteps this by lifting to units.
+
+The bijection is the parent file's `unitOfSqEqOne` in one direction and
+`Units.val` in the other. We prove the equality of cardinalities by showing
+the image of the unit-side filter under `Units.val` is exactly the
+ring-side filter, then applying `Finset.card_image_of_injective` to the
+injection `Units.val_injective`. -/
+theorem card_sqrts_one_eq_card_units_sqrts_one (n : ℕ) [NeZero n] :
+    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card =
+    (Finset.univ.filter (fun u : (ZMod n)ˣ => u ^ 2 = 1)).card := by
+  classical
+  -- Image of the unit-side filter under `Units.val` is the ring-side filter.
+  have himg :
+      (Finset.univ.filter (fun u : (ZMod n)ˣ => u ^ 2 = 1)).image
+          (Units.val : (ZMod n)ˣ → ZMod n) =
+      Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1) := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and]
+    refine ⟨?_, ?_⟩
+    · rintro ⟨u, hu_sq, rfl⟩
+      -- `u² = 1` in the unit group transports to `(u : ZMod n)² = 1` in the ring.
+      have h : ((u ^ 2 : (ZMod n)ˣ) : ZMod n) = ((1 : (ZMod n)ˣ) : ZMod n) := by
+        rw [hu_sq]
+      rw [Units.val_pow_eq_pow_val, Units.val_one] at h
+      exact h
+    · intro hx_sq
+      -- Conversely, `unitOfSqEqOne x` lifts `x² = 1` to the unit group.
+      exact ⟨GaussWilsonNonCyclic.unitOfSqEqOne x hx_sq,
+             GaussWilsonNonCyclic.unitOfSqEqOne_sq x hx_sq,
+             GaussWilsonNonCyclic.unitOfSqEqOne_val x hx_sq⟩
+  -- Cardinality of the image equals cardinality of the original (val is injective).
+  rw [← himg, Finset.card_image_of_injective _ Units.val_injective]
 
 end GaussWilsonNonCyclicOQ03

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,10 +1,25 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S2)
-**Iteration**: 2
+**Since**: 2026-05-12 (S3)
+**Iteration**: 3
 
 ## Current Focus
+
+S3 (researcher-5, 2026-05-12): ACT — added the **ring ↔ unit bridge**
+`card_sqrts_one_eq_card_units_sqrts_one` to
+`proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`. Reduces the ZMod-side
+count of solutions `x² = 1` to a unit-group count, so subsequent
+sessions can work entirely inside `(ZMod n)ˣ`, where cyclic-group
+structure (`ZMod.isCyclic_units_of_prime_pow`, the order-`p^{k-1}(p-1)`
+totient formula, etc.) applies cleanly. The proof: image of the
+unit-side filter under `Units.val` equals the ring-side filter, then
+apply `Finset.card_image_of_injective` to `Units.val_injective`.
+
+The bridge sidesteps the fact that `ZMod n` is not an integral domain
+when `n` is composite (so polynomial-roots arguments do not directly
+count `x² = 1`); lifting to units recovers a clean count, since every
+solution is automatically a unit (`x · x = 1`).
 
 S2 (researcher-1, 2026-05-12): ACT — created
 `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` (~120 lines, 1 sorry,
@@ -74,17 +89,24 @@ Practical:
 
 ## Next Action
 
-**S3 (any researcher)**: prove the prime-power cases of
-`card_sqrts_one_eq_numSqrtsOne`.
+**S4 (any researcher)**: prove the **odd-prime-power case** at the
+unit level, using S3's bridge.
 
 For odd prime `p` and `k ≥ 1`:
 
-- Use cyclicity of `(ZMod p^k)ˣ` (`ZMod.unitsCyclic` family in
-  Mathlib) and the standard 2-torsion-count-in-cyclic-of-even-order
-  lemma to derive
-  `#{u : (ZMod p^k)ˣ // u² = 1} = 2`.
-- Combine with the parent's `unitOfSqEqOne` bridge to lift to
-  the ring level: `#{x : ZMod p^k // x² = 1} = 2`.
+- Use `ZMod.isCyclic_units_of_prime_pow p hp (hp2 : p ≠ 2) k` to
+  obtain `IsCyclic (ZMod (p^k))ˣ`.
+- `Fintype.card (ZMod (p^k))ˣ = p^{k-1}(p-1)`, which is **even** for
+  odd `p` (since `p - 1` is even).
+- Apply `IsCyclic.card_orderOf_eq_totient` at `d = 1` and `d = 2`
+  to get `#{u | orderOf u = 1} = φ(1) = 1` and
+  `#{u | orderOf u = 2} = φ(2) = 1`.
+- Partition `{u | u² = 1} = {orderOf u = 1} ⊔ {orderOf u = 2}`
+  (using `orderOf_dvd_iff_pow_eq_one` and the fact that
+  `Nat.divisors 2 = {1, 2}`).
+- Total: `#{u : (ZMod p^k)ˣ | u² = 1} = 2`.
+- Combine with S3's `card_sqrts_one_eq_card_units_sqrts_one`
+  to lift to the ring level: `#{x : ZMod p^k | x² = 1} = 2`.
 
 For `p = 2` (powers of 2):
 


### PR DESCRIPTION
## Summary

S3 of `gauss-wilson-non-cyclic-oq-03`:

- Adds the **ring ↔ unit bridge** `card_sqrts_one_eq_card_units_sqrts_one`, reducing the ZMod-side count of `x² = 1` to a unit-group count. Lets S4+ work entirely inside `(ZMod n)ˣ`, where the cyclic-group structure (`ZMod.isCyclic_units_of_prime_pow`, the totient formula at `d=1, 2`, etc.) applies cleanly.
- Sidesteps the fact that `ZMod n` is not an integral domain when `n` is composite (so polynomial-roots arguments do not directly count `x² = 1`).
- **Build fix**: 13 `example : numSqrtsOne k = ...` checks in S2 used `by decide`, which got stuck because `Nat.primeFactors` doesn't reduce in the kernel. Switched to `by native_decide` (compiled, runs in ms).
- **Build verified** locally: `./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ03` succeeds (3062 jobs, only warning is the pre-existing main-theorem sorry).

## Proof

The image of `{u ∈ (ZMod n)ˣ | u² = 1}` under `Units.val` equals `{x ∈ ZMod n | x² = 1}`:

- Forward (⊆): `u² = 1` transports to `(u : ZMod n)² = 1` via `Units.val_pow_eq_pow_val` + `Units.val_one`.
- Backward (⊇): `x² = 1` lifts to a unit via the parent's `GaussWilsonNonCyclic.unitOfSqEqOne` (already in main).

Cardinality preserved by `Finset.card_image_of_injective` applied to `Units.val_injective`.

## Status

| Metric | Before | After |
|--------|--------|-------|
| sorries | 1 | 1 (unchanged) |
| axioms | 0 | 0 |
| theorems | 1 + 13 examples | 2 + 13 examples |
| build | failing (S2 decide bug) | passing |

## Test plan

- [x] Build verified: 3062 jobs, only `sorry` warning at line 129 (pre-existing main theorem).
- [x] No race: `gh pr list --search` empty at push.
- [ ] Next: S4 odd-prime-power count via `IsCyclic.card_orderOf_eq_totient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)