### PR TITLE
fix(meta): sync mean-value-theorem-oq-02-oq-04-oq-01 counts after #17912

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 336,
+    "lineCount": 397,
     "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown to be mathematically false (Runge counterexample, fully formalized). One sorry remains: the proof of the corrected complex-disk version analytic_taylor_remainder_uniform_bound_complex, deferred to S2 (proof outline in §3 docstring).",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
@@ -95,7 +95,7 @@
       "Statement of the corrected complex-hypothesis version analytic_taylor_remainder_uniform_bound_complex with explicit Mathlib chain (HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius) for S2 discharge.",
       "Demonstration that the explicit R^n factor in the denominator (M·r^(n+1) / (R^n · (R-r))) is essential; the OQ-04 statement that absorbs R^n into M is too weak to be true under real-only hypotheses."
     ],
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.theoremCount` for
`mean-value-theorem-oq-02-oq-04-oq-01` after PR #17912 (S2 ACT —
proven existential corrected form) merged 61 lines + one new
theorem (`analytic_taylor_remainder_uniform_geometric_complex`).

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `lineCount` | 336 | 397 |
| `theoremCount` | 8 | 9 |

Counting convention (matches #18006 / #17917):

```
lines:    raw newline count
theorems: ^(@[...] )*(private|protected|noncomputable)* (theorem|lemma)
defs:     ^(@[...] )*(private|protected|noncomputable|partial|unsafe|scoped)* (def|abbrev|opaque|structure|inductive|class)
```

After stripping nested `/- -/` block comments and `--` line comments.

## Validation

- `definitionCount` (2), `sorries` (1), `axiomCount` (0), `status`
  (`axiomatized`), `badge` (`axiom`) — unchanged and remain accurate.
- JSON re-parses cleanly.
- Minimal diff (2 numeric fields).
- Full-gallery re-scan: only this slug drifts (excluding entries
  already covered by in-flight #18006 / #18007 / #17997 / #17963).

---
Automated fix by lean-mechanic agent.