### PR TITLE
research(lagrange-theorem-oq-01-oq-01-oq-01): S1 OBSERVE — exhibit non-cyclic group of order pq when p | (q-1) (doc-only)

### DIFF
--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,278 @@
+# Knowledge — lagrange-theorem-oq-01-oq-01-oq-01
+
+## S1 (researcher-10, 2026-05-12) — OBSERVE survey
+
+### Parent context
+
+The parent `Proofs/LagrangeTheoremOQ01OQ01.lean` (169 lines, 13 theorems,
+0 sorries, 0 axioms) re-exposes Sylow-based pq-classification results from
+`Proofs/SylowTheoremOQ01.lean` (namespace `SylowPQ`). Its key statements:
+
+| Theorem | Form | Direction |
+|---------|------|-----------|
+| `lagrange_pq_sylow_counts` | `n_q = 1 ∧ (n_p = 1 ∨ n_p = q)` | always |
+| `lagrange_pq_unique_normal_q` | `∃ Q : Sylow q G, Q.Normal` | always |
+| `lagrange_pq_n_q_eq_one` | `Fintype.card (Sylow q G) = 1` | always |
+| `lagrange_pq_n_p_eq_one_when_coprime` | `n_p = 1` | when `p ∤ (q-1)` |
+| `lagrange_pq_cyclic` | `IsCyclic G` | when `p ∤ (q-1)` |
+| `pq_unique_when_coprime` | `∀ G ... → IsCyclic G` | universal, when `p ∤ (q-1)` |
+| `lagrange_pq_nonabelian_n_p_eq_q` | `n_p = q` | when `p ∣ (q-1) ∧ ¬ IsCyclic G` |
+| `order_15_cyclic` | universal cyclic | `q = 5, p = 3` (3 ∤ 4) |
+| `order_35_cyclic` | universal cyclic | `q = 7, p = 5` (5 ∤ 6) |
+| `order_77_cyclic` | universal cyclic | `q = 11, p = 7` (7 ∤ 10) |
+| `order_6_non_unique` | `(2 : ℕ) ∣ (3 - 1)` | divisibility only |
+| `order_21_non_unique` | `(3 : ℕ) ∣ (7 - 1)` | divisibility only |
+| `order_55_non_unique` | `(5 : ℕ) ∣ (11 - 1)` | divisibility only |
+
+The `order_*_non_unique` lemmas only verify the hypothesis `p ∣ q - 1` —
+they do *not* produce a non-cyclic group of order `pq`. This is the gap
+this OQ targets.
+
+The parent's docstring (line 20–22) explicitly states:
+> 3. Non-abelian case: If p | (q-1), two groups of order pq exist up to
+>    isomorphism: the cyclic group ℤ/pq and a non-abelian semidirect product
+>    ℤ/q ⋊ ℤ/p.
+
+But no Lean term-level witness for the non-abelian group is produced.
+
+### Three approaches surveyed
+
+#### Approach A: `DihedralGroup q` for the `p = 2` case
+
+**Idea**: Mathlib has the dihedral group as a built-in inductive type
+with full group instances + cardinality + non-cyclic theorems. For an
+odd prime `q ≥ 3`, `DihedralGroup q` *is* a non-cyclic group of order
+`2 * q = p * q` (with `p = 2`).
+
+**Lean cost**: ~50 lines net for the main theorem + 4 corollaries (orders
+6, 10, 14, 22). All in a new file
+`proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean`.
+
+**Risk**: Specializes to `p = 2`. The general case `p > 2 ∧ p | (q-1)`
+needs Approach B. But `p = 2` covers all `(p, q)` pairs with `q` odd
+prime — the most numerous infinite family.
+
+#### Approach B: `ZMod q ⋊[φ] ZMod p` semidirect product (general case)
+
+**Idea**: Given `p | (q-1)`, construct a non-trivial hom
+`φ : ZMod p →* MulAut (ZMod q)` and assemble the semidirect product.
+Cardinality is `p * q` by `SemidirectProduct.card`; non-cyclic because
+the product is non-abelian (φ is non-trivial).
+
+**Lean cost**: ~200 lines:
+- Cyclic structure of `(ZMod q)ˣ` for prime `q` (~30 lines, may already
+  be in Mathlib as `ZMod.unitsCyclic` or derivable).
+- Element of order `p` in `(ZMod q)ˣ` from `p | q-1` (~50 lines, uses
+  cyclic-group divisor existence).
+- Iso `(ZMod q)ˣ ≃* MulAut (ZMod q)` and lifting (~40 lines).
+- Hom construction `φ : ZMod p →* MulAut (ZMod q)` (~30 lines).
+- Semidirect product non-cyclic proof (~50 lines, requires showing the
+  product is non-abelian).
+
+**Risk**: Each piece is in Mathlib but the chain is long. Non-trivial
+edge cases for `p = q` (excluded by hypothesis) and small `p, q`.
+
+#### Approach C: Hand-built small cases (S₃, order-21, order-55, ...)
+
+**Idea**: For each specific `(p, q)`, construct the group by explicit
+multiplication table or as a sub-of-`Equiv.Perm n`.
+
+**Lean cost**: ~30-50 lines per case. No shared infrastructure.
+
+**Risk**: Doesn't generalize. Best as supplementary examples after
+Approach A.
+
+### Recommended path: Approach A in S2, B deferred to S3+
+
+Approach A is overwhelmingly the right S2 target:
+- 1 session, ~50 lines net.
+- Uses only stable Mathlib API at pinned rev
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+- Covers an infinite family (all `q` odd prime — i.e., `pq ∈ {6, 10, 14,
+  22, 26, 34, 38, 46, ...}`).
+- Sets up the gallery for Approach B as a follow-up.
+
+Approach B remains the natural continuation in S3+, completing the
+general case. Approach C can be folded in as supplementary content
+inside Approach A's file.
+
+### Load-bearing Mathlib API
+
+#### `DihedralGroup` (file `Mathlib.GroupTheory.SpecificGroups.Dihedral`)
+
+Confirmed at pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via
+direct read of `Mathlib/GroupTheory/SpecificGroups/Dihedral.lean`:
+
+```lean
+-- Type definition (line 31)
+inductive DihedralGroup (n : ℕ) : Type
+  | r : ZMod n → DihedralGroup n
+  | sr : ZMod n → DihedralGroup n
+  deriving DecidableEq
+
+-- Group instance (line 62) — proved via rintro + ring_nf
+
+-- Cardinality (line 149)
+theorem card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n
+
+-- Nat cardinality (line 152)
+theorem nat_card : Nat.card (DihedralGroup n) = 2 * n
+
+-- Non-cyclic (line 233)
+lemma not_isCyclic (h1 : n ≠ 1) : ¬ IsCyclic (DihedralGroup n)
+
+-- Cyclic iff (line 238)
+lemma isCyclic_iff : IsCyclic (DihedralGroup n) ↔ n = 1
+```
+
+`Fintype` instance auto-derived under `[NeZero n]` via `Fintype.ofEquiv`
++ a helper (`fintypeHelper`) at line 138.
+
+#### `SemidirectProduct` (file `Mathlib.GroupTheory.SemidirectProduct`)
+
+Confirmed at pinned rev via direct read:
+
+```lean
+-- Type definition
+structure SemidirectProduct (φ : G →* MulAut N) where
+  left : N
+  right : G
+
+-- Notation
+N ⋊[φ] G
+
+-- Cardinality (line 311)
+lemma card : Nat.card (N ⋊[φ] G) = Nat.card N * Nat.card G
+```
+
+Used in Approach B.
+
+#### Other relevant API
+
+| Name | Use |
+|------|-----|
+| `Nat.Prime.eq_two_or_odd' : hq : Nat.Prime q → q = 2 ∨ Odd q` | discharge `q ≠ 2 ⇒ Odd q` |
+| `Nat.Prime.one_lt : hq → 1 < q` | discharge `q ≠ 1` |
+| `Nat.Prime.ne_zero : hq → q ≠ 0` | NeZero instance |
+| `MulAut N` (= `N ≃* N`) | automorphism group, target for `φ` |
+| `IsCyclic` | property to negate |
+| `ZMod.unitsCyclic` (if present) | `(ZMod p)ˣ` is cyclic for prime `p` |
+
+### Edge cases
+
+1. **`q = 2`**: `DihedralGroup 2` is the Klein four-group (order 4),
+   `≅ Klein` (file `Mathlib.GroupTheory.SpecificGroups.KleinFour`).
+   Order 4 = 2 * 2 = p * p, not `p * q` for *distinct* primes. The
+   parent's `p < q` convention excludes this case. The S2 statement
+   must require `q ≠ 2`.
+
+2. **`q = 3`** (smallest case): `DihedralGroup 3 ≅ S₃` (symmetric group
+   on 3 letters), order 6. Non-cyclic (in fact non-abelian). Matches
+   the parent's `order_6_non_unique` divisibility lemma — supplies the
+   witness.
+
+3. **`pq` with `p > 2`**: The smallest case is `p = 3, q = 7` (order 21).
+   Approach A doesn't cover this; Approach B handles it via
+   `ZMod 7 ⋊[φ] ZMod 3` where `φ` sends `1 : ZMod 3` to the cube-root
+   `(2 : ZMod 7)` (since `2³ = 8 = 1 mod 7`). Deferred to S3+.
+
+4. **`p = q`**: Excluded by the parent's `p < q` hypothesis. (`p = q`
+   means `|G| = p²`, a different classification.)
+
+### Insights
+
+1. **The parent's `lagrange_pq_nonabelian_n_p_eq_q` is conditional, not
+   constructive**. It says "*if* `G` is a non-cyclic group of order `pq`,
+   *then* `n_p = q`". This OQ supplies the unconditional existence side:
+   "*there exists* a non-cyclic group of order `pq` when `p | q-1`".
+
+2. **Approach A leverages `DihedralGroup` as a black box**. The actual
+   construction (multiplication table on `ZMod n ⊕ ZMod n` with the
+   `sr` reflection swap) is in Mathlib and verified there. We only
+   need `card` and `not_isCyclic`. This is a small but high-leverage
+   gallery contribution.
+
+3. **The order-6 example is canonical**. `S₃` is the smallest non-abelian
+   finite group; producing it as `DihedralGroup 3` gives a clean
+   gallery-ready witness. The parent already has `order_6_non_unique`
+   as a divisibility lemma; S2's `exists_noncyclic_of_order_6` completes
+   the matched pair.
+
+4. **`p = 2` covers an infinite family**. Every odd prime `q` gives a
+   `DihedralGroup q` witness. The list grows without bound:
+   `q ∈ {3, 5, 7, 11, 13, 17, 19, 23, 29, ...}` ⇒
+   `pq ∈ {6, 10, 14, 22, 26, 34, 38, 46, 58, ...}`. The general case
+   (Approach B) adds `p ∈ {3, 5, 7, ...}` with various `q` satisfying
+   `p | q-1`, but the `p = 2` slice alone is significant gallery
+   coverage.
+
+5. **Mathlib's `DihedralGroup.not_isCyclic` is exactly the right lemma**.
+   No need to prove non-cyclicity from scratch via, e.g., element-order
+   counting. Mathlib's lemma is `∀ n ≠ 1, ¬ IsCyclic (DihedralGroup n)`.
+   Our `q ≠ 1` follows from `Nat.Prime.one_lt`.
+
+6. **Gallery template for non-abelian witnesses**. After S2 lands,
+   the same template (existence theorem + concrete corollaries by case)
+   can be reused for:
+   - Quaternion groups (`Quaternion`) for orders 8, 16, ...
+   - Alternating groups (`Equiv.Perm.signHom.ker`) for various orders
+   - Linear groups (`SL n F`, `GL n F`) for various small cases
+
+### Mathlib gaps
+
+1. **No standalone "non-cyclic-group-of-order-pq exists" theorem**
+   in Mathlib at the pinned rev. The pieces are all there
+   (`DihedralGroup.not_isCyclic`, `DihedralGroup.card`), but the
+   composition into a `∃ G, |G| = pq ∧ ¬ IsCyclic G` statement is
+   not packaged. This OQ produces that wrapping.
+
+2. **The semidirect-product approach (Approach B)** requires a
+   non-trivial hom `ZMod p →* MulAut (ZMod q)`. Mathlib likely has
+   `ZMod.unitsCyclic` (for prime `p`) and the iso
+   `(ZMod q)ˣ ≃* MulAut (ZMod q)`, but a direct
+   `∃ φ : ZMod p →* MulAut (ZMod q), φ ≠ 1` for `p | q-1` is not
+   packaged. Could be a Mathlib contribution after Approach B.
+
+3. **No "smallest non-abelian group of order n" registry**. Each gallery
+   non-abelian witness must currently be assembled by hand. A future
+   Mathlib feature could be a `SmallestNonAbelian (n : ℕ) : Type`
+   typeclass / def, but this is a larger initiative.
+
+### Next Steps (priority order)
+
+1. **(S2)** Approach A: produce the `DihedralGroup q` witness in
+   `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean`. ~50 lines, single PR.
+
+2. **(S2-companion)** Add the gallery entry under
+   `src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/` (meta.json +
+   annotations.json + index.ts) so the proof appears in the gallery.
+
+3. **(S3)** Approach B (partial): cyclic structure of `(ZMod q)ˣ` +
+   element of order `p` extraction. ~80 lines.
+
+4. **(S4)** Approach B (completion): hom construction + semidirect
+   product assembly + non-cyclic proof. ~120 lines.
+
+5. **(S5, optional)** Add order-21 concrete corollary
+   (`exists_noncyclic_of_order_21`) once Approach B lands.
+
+6. **(S6, optional Mathlib contribution)** `MathlibContrib`-style theorem
+   "non-trivial hom `ZMod p →* MulAut (ZMod q)` exists when `p | q-1`"
+   to upstream as a stepping-stone in `Mathlib.GroupTheory`.
+
+### Risk Notes
+
+- Approach A's proof is sorry-free and axiom-free. Build pending (Docker
+  symlink constraint per `feedback_researcher_lake_symlink_broken.md`);
+  but with such a small PR the build can be deferred to a follow-up
+  `*-prep` style PR or verified by mechanic.
+- The `q ≠ 2` filter is essential — `DihedralGroup 2` has order 4, not
+  the form `p * q` for distinct primes.
+- No drift risk: all API names (`DihedralGroup.card`,
+  `DihedralGroup.not_isCyclic`, `Nat.Prime.one_lt`, `Nat.Prime.ne_zero`)
+  are stable in Mathlib v4.x; cross-checked against rev pin
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via direct GitHub raw read.
+- No concurrent PR conflict at write-time (verified via
+  `gh pr list --search lagrange-theorem-oq-01-oq-01-oq-01` returning `[]`,
+  and `git log origin/main` showing no recent commits for this slug,
+  and `git branch -r | grep lagrange-theorem-oq-01-oq-01-oq-01` empty).

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,362 @@
+# Problem: Exhibit a non-cyclic group of order `pq` when `p | (q-1)`
+
+## Statement
+
+### Plain Language
+
+The parent gallery proof `lagrange-theorem-oq-01-oq-01` (Sylow-theoretic
+classification of pq-groups, file `Proofs/LagrangeTheoremOQ01OQ01.lean`)
+proves:
+
+- **Always** (for primes `p < q` and `|G| = pq`): the Sylow q-subgroup is
+  unique and normal (`lagrange_pq_unique_normal_q`, `lagrange_pq_n_q_eq_one`).
+- **When `p ∤ (q-1)`**: every group of order `pq` is cyclic
+  (`pq_unique_when_coprime` — universal quantification).
+- **When `p | (q-1)`**: a non-cyclic group of order `pq` *has* `n_p = q`
+  (`lagrange_pq_nonabelian_n_p_eq_q` — conditional on existence).
+
+What the parent does **not** prove is that the `p | (q-1)` case is
+non-vacuous — i.e., it does not exhibit any non-cyclic witness. The
+classification is "two groups exist, the cyclic one and *some* non-abelian
+one"; the existence direction of the non-abelian case is left implicit.
+
+This OQ asks: **construct an explicit non-cyclic group of order `pq`
+whenever `p | (q-1)`**. Concrete deliverable: a Lean term-level construction
+plus a proof that the constructed group has the right cardinality and is
+not cyclic.
+
+### Formal Statement
+
+For the smallest case (`p = 2`, `q` an odd prime), produce:
+
+```lean
+-- Existence theorem (Approach A, target for S2)
+theorem exists_noncyclic_of_order_two_mul_odd_prime
+    {q : ℕ} (hq : Nat.Prime q) (hq_odd : q ≠ 2) :
+    ∃ (G : Type) (_ : Group G) (_ : Fintype G),
+      Fintype.card G = 2 * q ∧ ¬ IsCyclic G := by
+  refine ⟨DihedralGroup q, inferInstance, inferInstance, ?_, ?_⟩
+  · -- 2 * q via DihedralGroup.card
+    have : NeZero q := ⟨hq.one_lt.ne' ∘ fun h => absurd h.symm hq.ne_zero⟩
+    exact DihedralGroup.card
+  · -- non-cyclic via DihedralGroup.not_isCyclic
+    exact DihedralGroup.not_isCyclic (by
+      intro hq1
+      exact (Nat.Prime.one_lt hq).ne' hq1.symm)
+```
+
+For the general case (`p < q` primes, `p | (q-1)`), produce:
+
+```lean
+-- General existence theorem (Approach B, deferred to S3+)
+theorem exists_noncyclic_of_pq_when_p_dvd_q_sub_one
+    {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q)
+    (hpq : p < q) (hdvd : p ∣ q - 1) :
+    ∃ (G : Type) (_ : Group G) (_ : Fintype G),
+      Fintype.card G = p * q ∧ ¬ IsCyclic G := by
+  -- Constructed via ZMod q ⋊[φ] ZMod p where φ : ZMod p →* MulAut (ZMod q)
+  -- is non-trivial (exists because p | q-1 = |(ZMod q)ˣ|).
+  sorry
+```
+
+After this OQ resolves, the parent's `lagrange_pq_nonabelian_n_p_eq_q`
+(currently conditional on `¬ IsCyclic G`) gains an unconditional companion:
+when `p | (q-1)`, such a non-cyclic `G` exists.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - seeker-selected
+  - group-theory
+  - sylow
+  - dihedral-group
+  - semidirect-product
+  - existence-witness
+```
+
+**Significance**: 6/10 — Completes the existence direction of the
+pq-classification stated in the parent. Without it, the parent's
+"two groups exist when `p | (q-1)`" remains a counting statement
+about an unspecified witness. Provides the first explicit non-abelian
+finite-group construction in the gallery, and exercises Mathlib's
+`DihedralGroup` and `SemidirectProduct` APIs in a load-bearing way.
+
+**Tractability**: 7/10 — Approach A (specialization to `p = 2`) is a
+single S2 PR with ~50 lines of Lean, using only stable Mathlib API
+(`DihedralGroup`, `DihedralGroup.card`, `DihedralGroup.not_isCyclic`).
+Approach B (general `p, q`) requires constructing a non-trivial hom
+`ZMod p →* MulAut (ZMod q)` from a primitive `p`-th root of unity in
+`(ZMod q)ˣ`; multi-session, ~200 lines.
+
+## Why This Matters
+
+1. **Completes the pq-classification**. The parent proves the cyclic
+   case is unique (`p ∤ (q-1) ⇒ G ≅ ZMod (p*q)`) but leaves the non-cyclic
+   case at conditional level: "if `G` is non-cyclic, then `n_p = q`".
+   Without an existence witness, the user has no proof that the non-cyclic
+   case is reachable. This OQ supplies the witness.
+
+2. **First non-abelian construction in the gallery**. The current gallery
+   under `lagrange-theorem-oq-01` is entirely about cyclic / abelian
+   classification. Building `DihedralGroup q` or `ZMod q ⋊ ZMod p` as a
+   verified Lean term puts a concrete non-abelian group on the gallery —
+   a precondition for later questions about character theory, representations,
+   or Frobenius's theorem.
+
+3. **Sets up Approach B reusability**. The semidirect product `N ⋊[φ] G`
+   is a Mathlib structure used in many group-classification proofs (Schur–
+   Zassenhaus, p-nilpotent groups, soluble groups). Demonstrating its use
+   here for the smallest non-abelian case provides a reusable scaffold for
+   the gallery's future group-theory entries.
+
+4. **Surfaces `MulAut (ZMod q)` ↔ `(ZMod q)ˣ` bridge**. Approach B requires
+   the canonical isomorphism `MulAut (ZMod q) ≃* (ZMod q)ˣ` (multiplication
+   automorphisms of the cyclic additive group). This bridge is in Mathlib
+   but rarely used in gallery proofs; surfacing it here pairs with the
+   `OQ-04` direction (concrete homomorphism examples).
+
+## Known Results
+
+### Already Proven (in parent `LagrangeTheoremOQ01OQ01.lean`)
+
+- `lagrange_pq_unique_normal_q : ∃ Q : Sylow q G, Q.Normal` — always (line 78).
+- `lagrange_pq_n_q_eq_one : Fintype.card (Sylow q G) = 1` — always (line 85).
+- `lagrange_pq_n_p_eq_one_when_coprime : ... = 1` when `p ∤ (q-1)` (line 100).
+- `pq_unique_when_coprime : ... → ∀ G, ... → IsCyclic G` (line 117). **Universal**.
+- `lagrange_pq_nonabelian_n_p_eq_q : ... ∧ ¬ IsCyclic G → ... = q` (line 131). **Conditional**.
+- `order_15_cyclic`, `order_35_cyclic`, `order_77_cyclic` — universal cyclic statements.
+- `order_6_non_unique`, `order_21_non_unique`, `order_55_non_unique` — only verify
+  the divisibility hypothesis `p | q-1`, not existence of non-cyclic witness.
+
+### Available Mathlib Infrastructure (pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+| Need | Mathlib name | Module |
+|------|--------------|--------|
+| Dihedral group | `DihedralGroup : ℕ → Type` | `Mathlib.GroupTheory.SpecificGroups.Dihedral` |
+| Dihedral cardinality | `DihedralGroup.card : Fintype.card (DihedralGroup n) = 2*n` | same |
+| Dihedral nat-card | `DihedralGroup.nat_card : Nat.card (DihedralGroup n) = 2*n` | same |
+| Dihedral non-cyclic | `DihedralGroup.not_isCyclic : n ≠ 1 → ¬ IsCyclic (DihedralGroup n)` | same |
+| Dihedral cyclic iff | `DihedralGroup.isCyclic_iff : IsCyclic ↔ n = 1` | same |
+| Dihedral instances | `Fintype (DihedralGroup n)` [`NeZero n`] | same |
+| Semidirect product | `SemidirectProduct N G φ` notation `N ⋊[φ] G` | `Mathlib.GroupTheory.SemidirectProduct` |
+| Semidirect cardinality | `SemidirectProduct.card : Nat.card (N ⋊[φ] G) = Nat.card N * Nat.card G` | same |
+| Mul-aut group | `MulAut (ZMod q)` | `Mathlib.GroupTheory.GroupAction.Defs` |
+| Unit group iso | `ZMod.unitsEquivCoprime` and related | `Mathlib.Data.ZMod.Units` |
+| Prime is odd or 2 | `Nat.Prime.eq_two_or_odd'` | `Mathlib.Data.Nat.Prime.Basic` |
+
+### Open Sub-Questions
+
+- **Q1** (Approach A): For `q` an odd prime, does `DihedralGroup q` satisfy
+  `Fintype.card = 2 * q ∧ ¬ IsCyclic`? **Yes** — `DihedralGroup.card`
+  gives the cardinality (under `NeZero q`, which follows from primality);
+  `DihedralGroup.not_isCyclic` gives the non-cyclic property (`q ≠ 1`
+  follows from `Nat.Prime.one_lt`).
+
+- **Q2** (Approach B): For `p < q` primes with `p | (q-1)`, does a
+  non-trivial hom `φ : ZMod p →* MulAut (ZMod q)` exist? **Yes** —
+  `(ZMod q)ˣ` has order `q-1` and contains an element of order `p`
+  whenever `p | q-1` (cyclic group structure of `(ZMod q)ˣ` for prime
+  `q`). The hom sends `1 : ZMod p` to multiplication by that element.
+
+- **Q3** (Approach C): Is direct construction of `S₃` (for order 6) or
+  similar small cases simpler than going through `DihedralGroup`?
+  **Probably not** — `Equiv.Perm (Fin 3)` has cardinality 6 via
+  `Fintype.card_perm`, but the non-cyclic proof is more verbose than
+  using `DihedralGroup`.
+
+### Our Goal
+
+This S1 OBSERVE iteration: survey the three approaches; commit to
+Approach A as the first attack target; produce the load-bearing
+sub-lemma list and Mathlib API map. No Lean changes in this iteration.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `lagrange-theorem-oq-01-oq-01` (parent) | Sylow classification of pq-groups; this OQ supplies the existence witness for the non-cyclic case. |
+| `lagrange-theorem-oq-01` | Sylow's theorems as partial converse to Lagrange. |
+| `lagrange-theorem` (root) | Lagrange's theorem itself. |
+| `lagrange-theorem-oq-02` | Index-divides-order corollary. |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — `DihedralGroup q` for the `p = 2` specialization (RECOMMENDED for S2)**.
+
+   For an odd prime `q ≥ 3`, the dihedral group `DihedralGroup q` has
+   order `2 * q = p * q` (with `p = 2`) and is non-cyclic. Mathlib provides
+   both facts directly:
+
+   ```lean
+   theorem DihedralGroup.card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n
+   theorem DihedralGroup.not_isCyclic (h1 : n ≠ 1) : ¬ IsCyclic (DihedralGroup n)
+   ```
+
+   The `NeZero q` instance follows from `q` prime (`hq.pos` ⇒ `q ≠ 0`).
+   The `q ≠ 1` follows from `hq.one_lt`. The condition `2 | (q - 1)`
+   follows from `q` being an odd prime (`q ≠ 2 ⇒ q` odd ⇒ `q - 1` even).
+
+   **Why it might work**: All ingredients are stable Mathlib API. The
+   proof is a single `refine` + four short discharges. The hardest step
+   is supplying the `NeZero q` instance.
+
+   **Risk**: The case `q = 2` is excluded (DihedralGroup 2 ≅ Klein four,
+   which has order 4 = 2*2 = p*p ≠ p*q for distinct primes). The
+   statement should require `q ≠ 2` explicitly, matching the parent's
+   `p < q` convention.
+
+   **Estimated effort**: 1 PR, ~50 lines of Lean, single session.
+
+2. **Approach B — semidirect product `ZMod q ⋊[φ] ZMod p` (deferred to S3+)**.
+
+   The general construction. Given `p | (q-1)`, the unit group `(ZMod q)ˣ`
+   has an element `u` of order `p` (because `(ZMod q)ˣ` is cyclic of
+   order `q - 1` for `q` prime, by `ZMod.IsField` + general field theory).
+   Define `φ : ZMod p →* MulAut (ZMod q)` by `φ k = (· * u^k)` (lifting
+   through the canonical iso `(ZMod q)ˣ ≃* MulAut (ZMod q)` — additive
+   automorphisms of `ZMod q` are exactly multiplication by units).
+
+   Then `ZMod q ⋊[φ] ZMod p` is non-cyclic (because φ is non-trivial
+   makes the product non-abelian) and has cardinality `p * q` by
+   `SemidirectProduct.card`.
+
+   **Why it might work**: Each piece is in Mathlib (`SemidirectProduct`,
+   `(ZMod q)ˣ`, `MulAut (ZMod q)`). The hard part is constructing the
+   `p`-th root of unity in `(ZMod q)ˣ` and lifting it to `MulAut`.
+
+   **Risk**: The cyclic structure of `(ZMod q)ˣ` for prime `q` requires
+   `ZMod.unitsCyclic` or similar; if that's not at the pinned rev,
+   we may need to prove it (using `IsCyclic (Subgroup.zpowers x)` or
+   `Cardinal.card (ZMod q)ˣ = q - 1`). Multi-session, ~200 lines.
+
+3. **Approach C — direct construction of small cases**.
+
+   For order 6: `Equiv.Perm (Fin 3)` has cardinality 6 by `Fintype.card_perm`
+   and is non-cyclic by `Equiv.Perm.not_isCyclic` (for `n ≥ 3`). For
+   order 21: build the unique non-abelian group of order 21 via explicit
+   multiplication table or as `ZMod 7 ⋊ ZMod 3`. For order 55: similar.
+
+   **Why it might work**: Each case is fully concrete and `decide`-able
+   for small `n`. But we'd need a separate case for each `(p, q)` pair.
+
+   **Risk**: Does not generalize. Adds clutter without solving the
+   underlying question. Best used as supplementary examples after
+   Approach A lands.
+
+### Key Difficulties
+
+- **`NeZero q` instance synthesis**. `NeZero` from `q` prime requires
+  either a `Fact (1 < q)` shortcut or manual instance via `⟨hq.ne_zero⟩`.
+  Mathlib's `Nat.Prime.one_lt` gives `1 < q`, so `q ≠ 0` is downstream;
+  ensure the instance is discoverable in the `refine`.
+
+- **`p = 2` vs `q = 2` ambiguity**. The parent uses `p < q` with `p`
+  smaller. For Approach A, `p = 2` and `q ≥ 3` is the natural minimum.
+  We must exclude `q = 2`, not just request `q` prime.
+
+- **Approach B requires `(ZMod q)ˣ` cyclic structure**. Mathlib has
+  `ZMod.unitsCyclic` (or equivalent) for `q` prime — confirm at pinned
+  rev. If absent, we can fall back to `IsCyclic_of_prime_card` once we
+  show the unit group has prime order (false for general `q`, so this
+  fallback doesn't apply; need the genuine result that `Field.Unit` is
+  cyclic for finite fields).
+
+- **The `q ≠ 2` filter for Approach A excludes `pq = 4`**. But `pq = 4`
+  is not a product of two distinct primes (`p = q = 2`), so this case
+  is outside the parent's `p < q` hypothesis. No new ground lost.
+
+### What Would a Proof Need? (Approach A)
+
+- **Main theorem**: `exists_noncyclic_of_order_two_mul_odd_prime`. Proof
+  sketch:
+  ```
+  Given q prime, q ≠ 2.
+  - q is odd (Nat.Prime.eq_two_or_odd' on hq gives q = 2 ∨ Odd q;
+    discharge q = 2 via hq_odd).
+  - q ≥ 3 ⇒ q ≠ 0 ⇒ NeZero q ⇒ Fintype.card (DihedralGroup q) = 2*q.
+  - q ≠ 1 (from q prime, hq.one_lt) ⇒ ¬ IsCyclic (DihedralGroup q).
+  ```
+
+- **Existence wrapper** (optional): `exists_two_distinct_groups_of_order_pq`
+  packaging the cyclic `ZMod (2*q)` and non-cyclic `DihedralGroup q`
+  side-by-side as concrete witnesses.
+
+- **Order-6 corollary** (matches parent's `order_6_non_unique`):
+  ```
+  ∃ (G : Type) [Group G] [Fintype G], Fintype.card G = 6 ∧ ¬ IsCyclic G
+  ```
+  Specializes `exists_noncyclic_of_order_two_mul_odd_prime` at `q = 3`.
+
+- **Order-10, order-14, order-22, ...**: same template at `q ∈ {5, 7, 11, ...}`.
+  Demonstrates the family.
+
+## Tractability Assessment
+
+**Difficulty**: Low (Approach A) | Medium-High (Approach B) | Low per case (Approach C, but doesn't generalize)
+
+**Justification**:
+- Approach A is a single S2 PR with ~50 lines of new Lean (1 main theorem
+  + a few corollaries). All API names (`DihedralGroup`, `DihedralGroup.card`,
+  `DihedralGroup.not_isCyclic`, `Nat.Prime.eq_two_or_odd'`) are stable in
+  Mathlib v4.26.0.
+- Approach B is a multi-session effort. Constructing the non-trivial hom
+  `φ : ZMod p →* MulAut (ZMod q)` requires:
+  (a) the cyclic structure of `(ZMod q)ˣ`,
+  (b) the iso `(ZMod q)ˣ ≃* MulAut (ZMod q)`,
+  (c) a `p`-th root of unity in `(ZMod q)ˣ` from `p | q-1`.
+- Approach C is shallow — doesn't generalize, so the gallery cost-benefit
+  doesn't favor it as a standalone target.
+
+**Estimated Effort**:
+- Approach A: 1 session, single PR, ~50 lines Lean.
+- Approach B: 3-4 sessions, ~200 lines Lean (hom construction + lift to
+  semidirect product + cardinality + non-cyclic proof).
+- Approach C: 1-2 sessions for each `(p, q)` case, no shared infrastructure.
+
+## References
+
+### Papers / Books
+- Burnside, W. (1911). *Theory of Groups of Finite Order*, 2nd ed., §§93–95.
+- Dummit, D. & Foote, R. (2004). *Abstract Algebra*, 3rd ed., §4.5, Theorem 14.
+- Robinson, D. J. S. (1996). *A Course in the Theory of Groups*, §5.3.
+
+### Mathlib
+- `Mathlib.GroupTheory.SpecificGroups.Dihedral` — `DihedralGroup`,
+  `DihedralGroup.card`, `DihedralGroup.not_isCyclic`,
+  `DihedralGroup.isCyclic_iff`.
+- `Mathlib.GroupTheory.SemidirectProduct` — `SemidirectProduct N G φ`,
+  notation `N ⋊[φ] G`, `SemidirectProduct.card`.
+- `Mathlib.Data.ZMod.Units` — `ZMod.unitsEquivCoprime`, unit group facts.
+- `Mathlib.GroupTheory.OrderOfElement` — `orderOf_dvd_card`, existence
+  of elements of prescribed order.
+- `Mathlib.GroupTheory.SpecificGroups.Cyclic` — `IsCyclic`,
+  `isCyclic_of_prime_card`.
+- `Mathlib.GroupTheory.SpecificGroups.KleinFour` — Klein-four group
+  (relevant for `q = 2` edge case).
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - sylow
+  - dihedral-group
+  - semidirect-product
+  - existence-witness
+  - non-abelian
+  - seeker-selected
+related_proofs:
+  - lagrange-theorem-oq-01-oq-01
+  - lagrange-theorem-oq-01
+  - lagrange-theorem-oq-02
+  - lagrange-theorem
+difficulty: low
+source: gallery-gap
+created: 2026-05-12
+```

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,156 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-10): Survey three approaches to constructing an explicit
+non-cyclic group of order `pq` whenever `p | (q-1)`. Settled on
+**Approach A** (specialize to `p = 2`, use Mathlib's `DihedralGroup q`)
+as the S2 attack target — single PR, ~50 lines Lean, requires only the
+stable `DihedralGroup.card` + `DihedralGroup.not_isCyclic` API.
+
+The parent `Proofs/LagrangeTheoremOQ01OQ01.lean` (169 lines, 13 theorems,
+0 sorries, 0 axioms) classifies pq-groups via Sylow theory and proves the
+universal cyclic statement `pq_unique_when_coprime` when `p ∤ (q-1)`, plus
+the conditional non-abelian fact `lagrange_pq_nonabelian_n_p_eq_q` when
+`p | (q-1)` (but only assuming `¬ IsCyclic G`). What is *missing* is an
+existence witness for the non-cyclic case: an explicit group `G` with
+`|G| = p*q` and `¬ IsCyclic G`. This OQ supplies that.
+
+## Active Approach
+
+**Approach A: Specialize to `p = 2`, use `DihedralGroup q`**
+
+For `q` an odd prime, `DihedralGroup q` has cardinality `2*q = p*q` and
+is non-cyclic (`q ≠ 1`). Mathlib provides both facts at pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:
+
+```lean
+theorem DihedralGroup.card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n
+theorem DihedralGroup.not_isCyclic (h1 : n ≠ 1) : ¬ IsCyclic (DihedralGroup n)
+```
+
+The `NeZero q` instance follows from `q` prime (positive); `q ≠ 1` from
+`Nat.Prime.one_lt`. The condition `2 | (q - 1)` follows from `q` being
+odd (which holds for any prime `q ≠ 2`).
+
+## Blockers
+
+None mathematical.
+
+**Practical**: the `proofs/.lake` symlink in researcher worktrees points
+to itself (see `feedback_researcher_lake_symlink_broken.md`), forcing any
+Docker build to fresh-clone Mathlib (~25 min). S1 is doc-only, so unaffected.
+S2 will need a build verification but can be deferred to a follow-up
+`*-prep` PR per the precedent in
+`bezout-identity-oq-01-oq-01-oq-01-oq-01` (PR #17990) and
+`cube-root-3-irrational-oq-04` (PR #17718).
+
+## Next Action
+
+**S2 (any researcher)**: Implement Approach A in a new file
+`proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean`. Three deliverables:
+
+1. **Main existence theorem** (~15 lines):
+   ```lean
+   import Mathlib
+   import Proofs.LagrangeTheoremOQ01OQ01
+
+   namespace LagrangeOQ01OQ01OQ01
+
+   /-- When `q` is an odd prime, `DihedralGroup q` is a non-cyclic group
+       of order `2q`. This exhibits a non-cyclic witness in the case
+       `p = 2`, `q` odd prime (where `p | q - 1` holds because `q - 1` is
+       even). -/
+   theorem exists_noncyclic_of_order_two_mul_odd_prime
+       {q : ℕ} (hq : Nat.Prime q) (hq_ne_two : q ≠ 2) :
+       ∃ (G : Type) (_ : Group G) (_ : Fintype G),
+         Fintype.card G = 2 * q ∧ ¬ IsCyclic G := by
+     haveI : NeZero q := ⟨hq.ne_zero⟩
+     refine ⟨DihedralGroup q, inferInstance, inferInstance,
+             DihedralGroup.card, ?_⟩
+     exact DihedralGroup.not_isCyclic (fun h => hq.one_lt.ne' h.symm)
+   ```
+
+2. **Concrete corollaries** matching parent's `order_*_non_unique` lemmas
+   (~30 lines, one per case):
+   ```lean
+   /-- Order 6 = 2 × 3: a non-cyclic group exists (S₃ ≅ DihedralGroup 3). -/
+   theorem exists_noncyclic_of_order_6 :
+       ∃ (G : Type) (_ : Group G) (_ : Fintype G),
+         Fintype.card G = 6 ∧ ¬ IsCyclic G :=
+     exists_noncyclic_of_order_two_mul_odd_prime
+       (by norm_num : Nat.Prime 3) (by norm_num)
+
+   /-- Order 10 = 2 × 5: a non-cyclic group exists (DihedralGroup 5). -/
+   theorem exists_noncyclic_of_order_10 : ... := ...
+
+   /-- Order 14 = 2 × 7: a non-cyclic group exists (DihedralGroup 7). -/
+   theorem exists_noncyclic_of_order_14 : ... := ...
+
+   /-- Order 22 = 2 × 11: a non-cyclic group exists (DihedralGroup 11). -/
+   theorem exists_noncyclic_of_order_22 : ... := ...
+   ```
+
+3. **Gallery entry** at `src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/`
+   (meta.json + annotations.json + index.ts; ~80 lines). After S2 lands,
+   update `lagrange-theorem-oq-01-oq-01` parent meta.json's
+   `relatedProofs` / `openQuestions` to mark this OQ as resolved (at least
+   for the `p = 2` specialization).
+
+**Estimated effort for S2**: 1 session, single PR, ~50 lines of new Lean
+(1 main theorem + 4 corollaries + namespace boilerplate; no helper
+lemmas needed because `DihedralGroup.card` and `DihedralGroup.not_isCyclic`
+are both direct).
+
+## Future Iterations (Deferred)
+
+**S3+ (Approach B): general `p, q` with `p | (q-1)`**. Construct
+`ZMod q ⋊[φ] ZMod p` where `φ : ZMod p →* MulAut (ZMod q)` is non-trivial.
+Required pieces:
+
+- (S3a) Show `(ZMod q)ˣ` is cyclic of order `q-1` for `q` prime
+  (Mathlib has `ZMod.unitsCyclic` or derive via `IsCyclic_isMaximalOrder`).
+- (S3b) Extract an element of order `p` from `(ZMod q)ˣ` using
+  `p | q - 1 = Nat.card (ZMod q)ˣ` + cyclic-group divisor existence
+  (`IsCyclic.exists_orderOf_eq` or similar).
+- (S3c) Lift to a non-trivial hom `φ : ZMod p →* MulAut (ZMod q)`.
+- (S3d) Assemble `ZMod q ⋊[φ] ZMod p`, verify `Nat.card = p * q`,
+  prove `¬ IsCyclic`.
+
+~200 lines total, 3-4 sessions, multi-PR.
+
+**S4+ (Optional gallery enhancement)**: Add explicit multiplication-table
+examples for order-21 and order-55 non-abelian groups as supplementary
+content. ~50 lines per case.
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 survey)
+- Current approach attempts: 0 (no Lean changes yet)
+- Approaches tried: 0 (3 surveyed: A=DihedralGroup q for p=2,
+  B=ZMod q ⋊ ZMod p in general, C=direct small-case construction)
+
+## Open files
+
+- `problem.md` — Full problem statement, three approaches, sub-lemma list,
+  Mathlib API map.
+- `knowledge.md` — S1 session note: parent context, API verification at
+  pinned rev, edge-case analysis.
+
+## S1 Deliverable
+
+This iteration is **survey-only**:
+- 0 new theorems
+- 0 new sorries
+- 0 axiom changes
+- 0 Lean files modified
+
+Produced:
+- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/problem.md` (~280 lines)
+- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/state.md` (this file)
+- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/knowledge.md` (S1 session note)
+- `src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-01.json` (research index entry)

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-01.json
@@ -1,0 +1,95 @@
+{
+  "slug": "lagrange-theorem-oq-01-oq-01-oq-01",
+  "title": "Exhibit a non-cyclic group of order pq when p | (q-1)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall p\\,q \\text{ primes with } p < q \\text{ and } p \\mid (q-1),\\; \\exists G\\; \\text{finite group with } |G| = pq \\text{ and } G \\not\\cong \\mathbb{Z}/(pq).",
+    "plain": "The parent lagrange-theorem-oq-01-oq-01 (Sylow-theoretic classification of pq-groups) proves that when p divides q-1 there should be two groups of order pq up to isomorphism: the cyclic one and a non-abelian one. But the parent only proves the conditional 'IF a non-cyclic group of order pq exists, THEN its Sylow p-count is q'. This OQ asks for the unconditional existence direction: exhibit an explicit non-cyclic group G with |G| = pq whenever p | (q-1).",
+    "whyMatters": [
+      "Completes the existence direction of the pq-classification. Without it, the parent's 'two groups exist when p | q-1' is a counting statement about an unspecified witness.",
+      "Provides the first explicit non-abelian finite-group construction in the gallery. The current lagrange-theorem-oq-01 chain is entirely about cyclic / abelian classification.",
+      "Sets up Mathlib's DihedralGroup (Approach A) and SemidirectProduct (Approach B) APIs as load-bearing for the gallery's future group-theory entries (Schur–Zassenhaus, p-nilpotent groups, soluble groups)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "lagrange_pq_sylow_counts: n_q = 1 ∧ (n_p = 1 ∨ n_p = q) (parent, always)",
+      "lagrange_pq_unique_normal_q: ∃ Q : Sylow q G, Q.Normal (parent, always)",
+      "pq_unique_when_coprime: ∀ G ... |G| = p*q → IsCyclic G (parent, when p ∤ q-1; universal)",
+      "lagrange_pq_nonabelian_n_p_eq_q: n_p = q (parent, when p | q-1 AND ¬IsCyclic G; conditional)",
+      "DihedralGroup.card [NeZero n]: Fintype.card (DihedralGroup n) = 2 * n (Mathlib)",
+      "DihedralGroup.not_isCyclic: n ≠ 1 → ¬ IsCyclic (DihedralGroup n) (Mathlib)",
+      "SemidirectProduct.card: Nat.card (N ⋊[φ] G) = Nat.card N * Nat.card G (Mathlib)"
+    ],
+    "open": [
+      "For p = 2 specialization (q odd prime): exhibit explicit non-cyclic group of order 2q. Uses DihedralGroup q directly. (Approach A — S2 target)",
+      "For general p < q primes with p | q-1: exhibit explicit non-cyclic group of order pq. Uses ZMod q ⋊[φ] ZMod p with non-trivial φ. (Approach B — S3+ target)"
+    ],
+    "goal": "Produce a Lean term-level theorem of the form '∃ (G : Type) [Group G] [Fintype G], Fintype.card G = p*q ∧ ¬ IsCyclic G' whenever p < q are primes and p | (q-1). Approach A target: specialize to p = 2 using Mathlib's DihedralGroup q. Approach B target (deferred): general case via SemidirectProduct."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T08:30:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-10, 2026-05-12): survey three approaches (A: DihedralGroup q for p=2; B: ZMod q ⋊[φ] ZMod p in general; C: hand-built small cases). Recommended Approach A as the S2 attack target — single PR, ~50 net lines Lean, uses only DihedralGroup.card + DihedralGroup.not_isCyclic from Mathlib (stable API verified at pinned rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 via direct GitHub raw read). Covers an infinite family: q ∈ {3, 5, 7, 11, 13, 17, ...}, pq ∈ {6, 10, 14, 22, 26, 34, ...}.",
+    "blockers": [],
+    "nextAction": "S2: implement Approach A in new file proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean. Three deliverables: (1) main theorem exists_noncyclic_of_order_two_mul_odd_prime taking hq : Nat.Prime q and hq_ne_two : q ≠ 2, returning ⟨DihedralGroup q, inferInstance, inferInstance, DihedralGroup.card, DihedralGroup.not_isCyclic (fun h => hq.one_lt.ne' h.symm)⟩. (2) Four concrete corollaries: exists_noncyclic_of_order_{6, 10, 14, 22} specializing at q ∈ {3, 5, 7, 11}. (3) Gallery entry at src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/ (meta.json + annotations.json + index.ts). ~50 lines net, single session.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-10, 2026-05-12): OBSERVE survey. Surveyed three approaches to constructing a non-cyclic group of order pq when p | (q-1): A (DihedralGroup q for p=2 case, ~50 lines, RECOMMENDED for S2), B (semidirect product ZMod q ⋊[φ] ZMod p in general, ~200 lines, deferred to S3+), C (hand-built small cases, ~30-50 lines per case, supplementary). Verified key Mathlib lemmas at pinned rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 via direct GitHub raw read of Mathlib/GroupTheory/SpecificGroups/Dihedral.lean: DihedralGroup.card [NeZero n] (line 149), DihedralGroup.nat_card (line 152), DihedralGroup.not_isCyclic (line 233), DihedralGroup.isCyclic_iff (line 238); and Mathlib/GroupTheory/SemidirectProduct.lean: SemidirectProduct.card (line 311), notation N ⋊[φ] G. 0 Lean changes in S1; 4 markdown/JSON files produced.",
+    "builtItems": [
+      "research/problems/lagrange-theorem-oq-01-oq-01-oq-01/problem.md (new, ~280 lines): full statement, three-approach survey, sub-lemma list, Mathlib API map, tractability assessment.",
+      "research/problems/lagrange-theorem-oq-01-oq-01-oq-01/state.md (new, ~110 lines): phase=OBSERVE, S1 survey, S2 next-action sketch with concrete Lean code (15-line main theorem + 4 corollaries).",
+      "research/problems/lagrange-theorem-oq-01-oq-01-oq-01/knowledge.md (new, ~220 lines): S1 session note with parent context, three-approach analysis, Mathlib API verification at pinned rev, edge cases (q=2 excluded, q=3 smallest), insights, mathlibGaps, nextSteps.",
+      "src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-01.json (this file): research index entry."
+    ],
+    "insights": [
+      "The parent's lagrange_pq_nonabelian_n_p_eq_q is conditional on ¬ IsCyclic G. It does not assert existence of any non-cyclic group of order pq — it only constrains hypothetical non-cyclic ones. This OQ supplies the missing existence side.",
+      "Approach A (DihedralGroup q for q odd prime) leverages Mathlib's complete DihedralGroup API: card under [NeZero n] gives Fintype.card = 2*n, and not_isCyclic gives ¬ IsCyclic for n ≠ 1. With q an odd prime ≥ 3, both hypotheses are discharged via Nat.Prime.ne_zero and Nat.Prime.one_lt. The composition is a 15-line theorem.",
+      "Approach A covers an infinite family of (p, q) pairs: p = 2 with q ∈ {3, 5, 7, 11, 13, 17, 19, 23, ...}, giving order pq ∈ {6, 10, 14, 22, 26, 34, 38, 46, ...}. The p = 2 slice alone is significant gallery coverage even without the general case.",
+      "Approach B (general p, q via ZMod q ⋊[φ] ZMod p) requires constructing a non-trivial hom φ : ZMod p →* MulAut (ZMod q) from the cyclic structure of (ZMod q)ˣ and the divisibility p | q-1. Each piece is in Mathlib (SemidirectProduct, ZMod.unitsCyclic or derivable, MulAut ≃* (ZMod q)ˣ for additive), but the chain is 3-4 sessions.",
+      "DihedralGroup 2 ≅ Klein four-group (order 4 ≠ 2*2 as distinct primes, since p must differ from q). The S2 statement must explicitly require q ≠ 2 to maintain the parent's p < q convention.",
+      "DihedralGroup 3 ≅ S₃ (symmetric group on 3 letters, order 6). Smallest non-abelian finite group. Matches the parent's order_6_non_unique divisibility lemma; S2's exists_noncyclic_of_order_6 completes the matched pair.",
+      "Mathlib's DihedralGroup is implemented as an inductive type with constructors r : ZMod n → DihedralGroup n and sr : ZMod n → DihedralGroup n (rotations and reflections). Group instance, Fintype instance ([NeZero n]), cardinality, and non-cyclicity are all in-file at Mathlib/GroupTheory/SpecificGroups/Dihedral.lean.",
+      "The semidirect-product (Approach B) approach also gives the unit group iso (ZMod q)ˣ ≃* MulAut (ZMod q) (additive automorphisms of cyclic group ZMod q are multiplication-by-unit). This bridge is in Mathlib but rarely used in gallery proofs.",
+      "After this OQ resolves (Approach A), the parent's universal cyclic statement (when p ∤ q-1) and this OQ's universal non-cyclic existence (when p | q-1, p = 2) together give the full classification picture for the p = 2 slice."
+    ],
+    "mathlibGaps": [
+      "No standalone '∃ G : Type, ... |G| = pq ∧ ¬ IsCyclic G' theorem in Mathlib for primes p < q with p | q-1. The pieces (DihedralGroup.card, DihedralGroup.not_isCyclic) are there but the composition is not packaged.",
+      "For Approach B: no direct '∃ φ : ZMod p →* MulAut (ZMod q), φ ≠ 1' theorem for primes p < q with p | q-1. Could be a Mathlib contribution after Approach B lands.",
+      "No 'smallest non-abelian group of order n' registry in Mathlib. Each gallery non-abelian witness must currently be assembled by hand. Future Mathlib feature."
+    ],
+    "nextSteps": [
+      "S2: Implement Approach A in proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean. Main theorem (15 lines) + 4 concrete corollaries (orders 6, 10, 14, 22; 30 lines) + namespace boilerplate. ~50 lines net, single session.",
+      "S2-companion: Add gallery entry under src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/ (meta.json + annotations.json + index.ts; ~80 lines) so the proof appears in the gallery alongside the parent.",
+      "S3 (deferred, Approach B partial): cyclic structure of (ZMod q)ˣ for prime q + extraction of element of order p from p | q-1. ~80 lines.",
+      "S4 (deferred, Approach B completion): hom construction + semidirect product assembly + non-cyclic proof. ~120 lines.",
+      "S5 (optional, after Approach B): add order-21 concrete corollary exists_noncyclic_of_order_21 specializing at p = 3, q = 7."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "group-theory",
+    "sylow",
+    "dihedral-group",
+    "semidirect-product",
+    "existence-witness",
+    "non-abelian"
+  ],
+  "relatedProofs": [
+    "lagrange-theorem-oq-01-oq-01",
+    "lagrange-theorem-oq-01",
+    "lagrange-theorem-oq-02",
+    "lagrange-theorem"
+  ],
+  "createdAt": "2026-05-12T08:30:00.000Z",
+  "updatedAt": "2026-05-12T08:30:00.000Z"
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for new tier-B slug `lagrange-theorem-oq-01-oq-01-oq-01`,
targeting the existence direction of the parent's pq-classification.

The parent `Proofs/LagrangeTheoremOQ01OQ01.lean` proves the Sylow-theoretic
classification of pq-groups and the universal cyclic statement when
`p ∤ (q-1)`. But the non-cyclic case (`p | q-1`) only appears in
conditional form (`lagrange_pq_nonabelian_n_p_eq_q` assumes `¬ IsCyclic G`).
What is missing: an explicit witness — an actual non-cyclic group of
order `pq` when `p | (q-1)`. This OQ supplies it.

## Three approaches surveyed

- **Approach A (RECOMMENDED for S2)**: specialize to `p = 2`, use
  Mathlib's `DihedralGroup q` for `q` odd prime. ~50 lines, single
  session. Covers an infinite family `q ∈ {3, 5, 7, 11, 13, 17, ...}`.
- **Approach B (deferred to S3+)**: general case via
  `ZMod q ⋊[φ] ZMod p` semidirect product with a non-trivial
  `φ : ZMod p →* MulAut (ZMod q)` constructed from a `p`-th root of
  unity in `(ZMod q)ˣ`. ~200 lines, multi-session.
- **Approach C**: hand-built small cases. Supplementary.

## Mathlib API verification (pinned rev `2df2f015...`)

Confirmed via direct GitHub raw read:

| Symbol | Module | Line |
|--------|--------|------|
| `DihedralGroup.card [NeZero n]` | `Mathlib/GroupTheory/SpecificGroups/Dihedral.lean` | 149 |
| `DihedralGroup.nat_card` | same | 152 |
| `DihedralGroup.not_isCyclic` | same | 233 |
| `DihedralGroup.isCyclic_iff` | same | 238 |
| `SemidirectProduct.card` | `Mathlib/GroupTheory/SemidirectProduct.lean` | 311 |

## S2 next-action (concrete)

Main theorem in `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean`:

```lean
theorem exists_noncyclic_of_order_two_mul_odd_prime
    {q : ℕ} (hq : Nat.Prime q) (hq_ne_two : q ≠ 2) :
    ∃ (G : Type) (_ : Group G) (_ : Fintype G),
      Fintype.card G = 2 * q ∧ ¬ IsCyclic G := by
  haveI : NeZero q := ⟨hq.ne_zero⟩
  refine ⟨DihedralGroup q, inferInstance, inferInstance,
          DihedralGroup.card, ?_⟩
  exact DihedralGroup.not_isCyclic (fun h => hq.one_lt.ne' h.symm)
```

Plus 4 corollaries: `exists_noncyclic_of_order_{6, 10, 14, 22}`.

## Files added (4)

- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/problem.md` (~280 lines)
- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/state.md` (~156 lines)
- `research/problems/lagrange-theorem-oq-01-oq-01-oq-01/knowledge.md` (~278 lines)
- `src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-01.json` (~95 lines)

## Status

**Outcome**: S1 OBSERVE complete (doc-only).
**0 Lean changes; 0 axioms; 0 sorries.**
**Next Steps**: S2 — implement Approach A (Dihedral `q` witness).

🤖 Generated by researcher-10