### PR TITLE
research(russell-1-plus-1-oq-04): S3 — named row theorems + #print axioms + noncomputable fix (build verified)

### DIFF
--- a/proofs/Proofs/OnePlusOneOQ04.lean
+++ b/proofs/Proofs/OnePlusOneOQ04.lean
@@ -55,7 +55,7 @@ namespace OnePlusOneOQ04
     no reduction is required: `Rules(E) = ∅`. This witnesses that
     `∅ ⊆ Rules(E)` is strict whenever `add`, `one`, or `two` is
     a `def`. -/
-example :
+theorem row0_unfolded :
     Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero) =
       Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero) := rfl
 
@@ -70,13 +70,20 @@ example :
 
     `δ` is required because `one`, `add`, `two` are `def`s; `ι`
     is required because `add` pattern-matches on a constructor. -/
-example : Peano.one + Peano.one = Peano.two := rfl
+theorem row1_peano_pattern : Peano.one + Peano.one = Peano.two := rfl
 
 /-! ## Row 2: Peano with Raw Recursor — `Rules(E) = {δ, ι, β}` -/
 
 /-- Same `Peano.ℕ`, but `add` written via the auto-generated
-    eliminator `Peano.ℕ.rec` rather than the equation compiler. -/
-def addRec (n m : Peano.ℕ) : Peano.ℕ :=
+    eliminator `Peano.ℕ.rec` rather than the equation compiler.
+
+    Marked `noncomputable` because Lean 4's code generator declines
+    `Peano.ℕ.rec` with a non-Prop motive. (Equivalent definitions via
+    `match` *do* compile; `Peano.add` itself in the parent file is
+    such a `match` form. The raw-recursor form here is for kernel
+    reduction at the type-checking level only — exactly what `rfl`
+    needs — not for runtime execution.) -/
+noncomputable def addRec (n m : Peano.ℕ) : Peano.ℕ :=
   Peano.ℕ.rec (motive := fun _ => Peano.ℕ) n
     (fun _ acc => Peano.ℕ.succ acc) m
 
@@ -89,7 +96,7 @@ def addRec (n m : Peano.ℕ) : Peano.ℕ :=
     λ. This is the precise sense in which the equation compiler
     "hides" the β inside `ι` at the user-visible level — the raw
     recursor exposes it. -/
-example : addRec Peano.one Peano.one = Peano.two := rfl
+theorem row2_peano_recursor : addRec Peano.one Peano.one = Peano.two := rfl
 
 /-! ## Row 3: Church Numerals — `Rules(E) = {δ, β}` -/
 
@@ -117,7 +124,7 @@ def cAdd : Church → Church → Church :=
     Church numerals are purely λ-encoded. This is the structural
     incomparability with the Peano row — `{δ, β} ⊄ {δ, ι}` and
     vice versa. -/
-example : cAdd cOne cOne = cTwo := rfl
+theorem row3_church : cAdd cOne cOne = cTwo := rfl
 
 /-! ## Row 4: Binary Naturals — `Rules(E) = {δ, ι}` -/
 
@@ -156,6 +163,32 @@ def Bin.add : Bin → Bin → Bin
     The shallow `1+1` depth is illusory in general: for
     `2^k + 2^k` the depth is `O(k)` `ι`-steps as the carry chain
     walks the bit-string. -/
-example : Bin.add Bin.one Bin.one = Bin.b0 Bin.one := rfl
+theorem row4_binary : Bin.add Bin.one Bin.one = Bin.b0 Bin.one := rfl
+
+/-! ## Part 6: Axiom-Freedom Verification
+
+Each of the five row witnesses is `:= rfl`, so the proof is by
+kernel reduction with no extra axioms. The `#print axioms` stanzas
+below produce a machine-checked confirmation of this claim
+(expected output for each: `'<name>' depends on no axioms`),
+serving as the *propositional* dual to the *reductional* taxonomy
+of `Rules(E)` documented in Parts 1–5.
+
+This dual is the substance of the OQ-04 contribution: the
+`{β, ι, δ, ζ}` rule alphabet is *all that is needed* in the sense
+that every row is closed by reflexivity alone, with no recourse to
+`Classical.choice`, `propext`, `Quot.sound`, or any further
+extension to CIC.
+
+If any of these stanzas prints additional axioms (e.g. after a
+future refactor introduces a `Classical`-dependent helper into one
+of the encodings), the file will still compile but the dual claim
+will fail by inspection — a lightweight regression detector. -/
+
+#print axioms row0_unfolded
+#print axioms row1_peano_pattern
+#print axioms row2_peano_recursor
+#print axioms row3_church
+#print axioms row4_binary
 
 end OnePlusOneOQ04

--- a/research/problems/russell-1-plus-1-oq-04/knowledge.md
+++ b/research/problems/russell-1-plus-1-oq-04/knowledge.md
@@ -1,5 +1,87 @@
 # Knowledge — russell-1-plus-1-oq-04
 
+## S3 (researcher-1, 2026-05-12) — ACT (axiom-freedom verification)
+
+**Outcome**: progress — five `example := rfl` row witnesses promoted to
+named `theorem`s, and a new "Part 6: Axiom-Freedom Verification"
+section with five `#print axioms` stanzas added at the end of
+`proofs/Proofs/OnePlusOneOQ04.lean` (161 → 187 lines, 0 sorries, 0
+axioms).
+
+**What changed**:
+
+1. Each row witness is now a named `theorem`:
+   - `row0_unfolded` (Rules = ∅)
+   - `row1_peano_pattern` (Rules = {δ, ι})
+   - `row2_peano_recursor` (Rules = {δ, ι, β})
+   - `row3_church` (Rules = {δ, β})
+   - `row4_binary` (Rules = {δ, ι})
+
+2. New `Part 6: Axiom-Freedom Verification` with five `#print axioms`
+   stanzas. Each emits the info message
+   `'<row_name>' depends on no axioms` at compile time.
+
+**Why this is the right S3 deliverable**:
+
+The S1 insight #6 noted that `#print axioms` is the *propositional*
+dual of the *reductional* question OQ-04 asks. This iteration
+spells out that duality in Lean:
+
+- Parts 1–5: each row's `Rules(E) ⊆ {β, ι, δ, ζ}` is *sufficient*
+  for `:= rfl` to succeed (reductional content).
+- Part 6: each row's `:= rfl` proof uses *no extra axioms* —
+  not `Classical.choice`, `propext`, `Quot.sound`, or anything beyond
+  CIC's primitive reductions (propositional content).
+
+Together these establish that the file's contribution — exhibiting
+five canonical encodings of `1+1=2` — is rigorously axiom-free and
+purely kernel-reductional, matching the S1 honesty notes.
+
+**Why `theorem` instead of `example`**:
+
+`example` cannot be referenced by `#print axioms`, which requires a
+named declaration. Renaming is a no-op semantically (both produce
+checked-but-discarded proof terms with the same definitional
+behaviour); the rename is purely for the `#print axioms` query
+surface.
+
+**Why no `#reduce` stanzas** (deviating from the S2 next-action):
+
+`#reduce` emits the fully-normalised term, which for the recursor and
+Church rows produces multi-page kernel output that bloats the build
+log without adding logical content. The propositional axiom-freedom
+claim is the load-bearing verification for OQ-04; `#reduce` can be
+re-introduced in S5 if the let-binding example needs step-by-step
+trace output.
+
+**Files modified (S3 narrow)**:
+
+- `proofs/Proofs/OnePlusOneOQ04.lean` — +26 lines (5 `theorem`
+  renames + Part 6 docstring + 5 `#print axioms`).
+- `src/data/research/problems/russell-1-plus-1-oq-04.json` — iter 2 →
+  3, builtItems += 6.
+- `research/problems/russell-1-plus-1-oq-04/{knowledge.md, state.md}`
+  — this S3 entry.
+
+**Next steps**:
+
+- S4 (recommended next): Add gallery entry
+  `src/data/proofs/russell-1-plus-1-oq-04/` with `meta.json` +
+  `index.ts` so the file is browsable on the live site.
+- S5 (optional): Let-binding example demonstrating ζ's role.
+- Deferred → OQ-04-OQ-01: meta-theorem stating `Rules(E)` formally
+  via a sandboxed kernel parametrised on a subset of {β, ι, δ, ζ}.
+
+**Honesty note**
+
+The contribution is *infrastructure* — converting anonymous
+`example`s to named theorems so that the axiom-freedom claim becomes
+machine-checked. No new proof content; sorry count unchanged (still
+0). The dual claim was implicit in S2 (since `rfl` proofs cannot
+introduce axioms); S3 makes it *explicit and queryable*.
+
+---
+
 ## S1 (researcher-11, 2026-05-12) — OBSERVE survey
 
 ### The taxonomy in one table

--- a/research/problems/russell-1-plus-1-oq-04/state.md
+++ b/research/problems/russell-1-plus-1-oq-04/state.md
@@ -1,10 +1,95 @@
 # Current State
 
-**Phase**: ACT (S2 file written; advancing to S3 gallery + `#print axioms`)
+**Phase**: ACT (S3 augmentation complete — named theorems + #print axioms; advancing to S4 gallery)
 **Since**: 2026-05-12T05:00:00Z (S1)
-**Last Updated**: 2026-05-12 (S2 ACT by researcher-3)
-**Iteration**: 2
-**Last researcher**: researcher-3
+**Last Updated**: 2026-05-12 (S3 ACT by researcher-1)
+**Iteration**: 3
+**Last researcher**: researcher-1
+
+## S3 Summary (2026-05-12, researcher-1)
+
+**Mode**: ACT (augment the S2 file with `#print axioms` machine-checked
+axiom-freedom verification).
+
+### Deliverable
+
+Augmented `proofs/Proofs/OnePlusOneOQ04.lean` (161 → 187 lines):
+
+1. **Converted each `example` to a named `theorem`** so it can be
+   referenced by `#print axioms`:
+
+   - `row0_unfolded` — Rules(E) = ∅, the trivial baseline.
+   - `row1_peano_pattern` — Rules(E) = {δ, ι}, the parent file's encoding.
+   - `row2_peano_recursor` — Rules(E) = {δ, ι, β}, raw `Peano.ℕ.rec`.
+   - `row3_church` — Rules(E) = {δ, β}, Church numerals.
+   - `row4_binary` — Rules(E) = {δ, ι}, binary little-endian naturals.
+
+2. **Added Part 6: Axiom-Freedom Verification** with five `#print axioms`
+   stanzas (one per row witness). Each emits the info message
+   `'<name>' depends on no axioms` at compile time, providing a
+   *machine-checked* dual to the *human-checked* reductional taxonomy
+   of Parts 1–5.
+
+### Design choices
+
+- **`theorem` rather than `example`** to make the row witnesses
+  referenceable from `#print axioms`. No semantic change — `theorem`
+  vs `example` is purely a binding choice (named ↔ anonymous).
+- **`#print axioms` placed at the end** (Part 6) rather than inline
+  per row. Keeps the per-row docstrings focused on the reduction-rule
+  story; the propositional dual is its own logical section.
+- **No `#reduce` stanzas** despite the S2 next-action mentioning
+  them. `#reduce` produces verbose kernel output that bloats the
+  build log without adding propositional content; the more
+  conservative `#print axioms` does the load-bearing verification
+  work for the OQ-04 question. `#reduce` can be added in S5 if
+  needed for the let-binding example.
+
+### File deltas
+
+- `proofs/Proofs/OnePlusOneOQ04.lean`: +26 lines (5 `theorem` renames + Part 6 docstring + 5 `#print axioms`).
+- Sorry count: 0 (unchanged).
+- Axiom count: 0 (unchanged; now machine-verified at compile time).
+- Theorem count: 0 → 5 (five row witnesses promoted from `example` to `theorem`).
+- Definition count: 7 (unchanged — `addRec`, `Church`, `cOne`, `cTwo`, `cAdd`, `Bin.succ`, `Bin.add` plus the `inductive Bin`).
+
+### Build status
+
+**Verified** via `./proofs/scripts/docker-build.sh Proofs.OnePlusOneOQ04`.
+Three jobs (incremental, cache hit on Mathlib). Five info messages confirm
+the propositional dual:
+
+```
+info: 'OnePlusOneOQ04.row0_unfolded'        does not depend on any axioms
+info: 'OnePlusOneOQ04.row1_peano_pattern'   does not depend on any axioms
+info: 'OnePlusOneOQ04.row2_peano_recursor'  does not depend on any axioms
+info: 'OnePlusOneOQ04.row3_church'          does not depend on any axioms
+info: 'OnePlusOneOQ04.row4_binary'          does not depend on any axioms
+```
+
+### S3 build-fix: latent S2 issue
+
+Bringing the file under build verification uncovered a latent code-generator
+error in S2's `addRec` (S2 was merged "(build pending)" — see PR #17971
+title — and never actually built). The code generator declines
+`Peano.ℕ.rec` with a non-Prop motive:
+
+```
+error: code generator does not support recursor `Peano.ℕ.rec` yet,
+       consider using 'match ... with' and/or structural recursion
+```
+
+**Fix**: marked `addRec` as `noncomputable def`. The kernel reduction
+for `:= rfl` (which is what the row witnesses need) is unaffected;
+only runtime code-generation is skipped. Equivalent `match`-style
+definitions *do* compile (see `Peano.add` in the parent file), but
+the whole point of `addRec` is to exhibit the *raw recursor*
+encoding, so the `noncomputable` annotation is the principled fix.
+
+Sorry count: still 0. Axiom count: still 0 (now machine-checked at
+build time by Part 6's `#print axioms` stanzas).
+
+---
 
 ## S2 Summary (2026-05-12, researcher-3)
 

--- a/src/data/research/problems/russell-1-plus-1-oq-04.json
+++ b/src/data/research/problems/russell-1-plus-1-oq-04.json
@@ -28,14 +28,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T05:00:00Z",
-    "iteration": 2,
-    "focus": "S2 (researcher-3, 2026-05-12) ACT complete: new file proofs/Proofs/OnePlusOneOQ04.lean (161 lines, 0 axioms, 0 sorries) with five `example := rfl` theorems witnessing each row of the S1 taxonomy table: (0) unfolded baseline `Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero) = Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero)`; (1) Peano pattern-match `Peano.one + Peano.one = Peano.two`; (2) Peano raw-recursor via new `addRec` (`{δ,ι,β}`); (3) Church numerals via new `Church/cOne/cTwo/cAdd` (`{δ,β}`); (4) binary naturals via new `inductive Bin` + `Bin.succ`/`Bin.add` (`{δ,ι}`, `Bin.add Bin.one Bin.one = Bin.b0 Bin.one`). Imported into proofs/Proofs.lean alphabetically between Proofs.OnePlusOne and Proofs.PACLearning.",
+    "since": "2026-05-12T08:30:00Z",
+    "iteration": 3,
+    "focus": "S3 (researcher-1, 2026-05-12) ACT complete: augmented proofs/Proofs/OnePlusOneOQ04.lean — converted each of the five `example := rfl` row witnesses into a named `theorem` (row0_unfolded, row1_peano_pattern, row2_peano_recursor, row3_church, row4_binary) and added a `Part 6: Axiom-Freedom Verification` section with `#print axioms` stanzas for each row witness. The `#print axioms` block is the *propositional* dual of the *reductional* taxonomy of Parts 1–5 (per S1 knowledge.md insight #6): each row's reduction-rule subset `Rules(E) ⊆ {β,ι,δ,ζ}` is *sufficient* (witnessed by `:= rfl`) AND no Classical/extensional axiom is silently consumed (verified by `#print axioms`). File 161 → 187 lines, 0 sorries, 0 axioms, no Mathlib import added.",
     "blockers": [],
-    "nextAction": "S3: Augment OnePlusOneOQ04.lean with `#print axioms` + `#reduce` stanzas per example (confirms axiom-freeness as the propositional dual of the reduction-rule taxonomy). S4: Add gallery entry src/data/proofs/russell-1-plus-1-oq-04/ (status=verified, badge=original, axiomCount=0, sorries=0).",
+    "nextAction": "S4: Add gallery entry src/data/proofs/russell-1-plus-1-oq-04/ (status=verified, badge=original, axiomCount=0, sorries=0, leanFile pointing to proofs/Proofs/OnePlusOneOQ04.lean). Cross-reference parent entry russell-1-plus-1. S5 (optional): A let-binding example demonstrating ζ's role.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
@@ -44,9 +44,15 @@
     "builtItems": [
       "research/problems/russell-1-plus-1-oq-04/problem.md (~210 lines) — expanded problem statement, theoretical framework, representation catalogue, summary table, Principia comparison, Mathlib infrastructure map, next-action decomposition, risk notes.",
       "research/problems/russell-1-plus-1-oq-04/knowledge.md (~200 lines) — S1 entry with taxonomy table, five hand-traces, lower-bound arguments, 6 insights, 3 Mathlib gaps, 5 next steps, risk notes, references.",
-      "research/problems/russell-1-plus-1-oq-04/state.md — updated phase to OBSERVE→ACT, next action specified as S2 worked Lean file.",
-      "proofs/Proofs/OnePlusOneOQ04.lean (161 lines, 0 axioms, 0 sorries) — S2 ACT worked Lean file. Five `example := rfl` theorems, one per row of the S1 taxonomy table. New defs `addRec` (raw recursor for Peano), `Church : Type 1`/`cOne`/`cTwo`/`cAdd` (Church numerals), `inductive Bin`/`Bin.succ` (carry chain)/`Bin.add` (struct-rec on 2nd arg). Imported into proofs/Proofs.lean.",
-      "proofs/Proofs.lean — +1 import for Proofs.OnePlusOneOQ04 (alphabetic between OnePlusOne and PACLearning)."
+      "research/problems/russell-1-plus-1-oq-04/state.md — updated phase to OBSERVE→ACT→ACT(S3).",
+      "proofs/Proofs/OnePlusOneOQ04.lean (S3: 187 lines, was 161; 0 axioms, 0 sorries) — five named row theorems (row0_unfolded, row1_peano_pattern, row2_peano_recursor, row3_church, row4_binary) with `#print axioms` stanzas in a new Part 6: Axiom-Freedom Verification section. Defs from S2 (addRec, Church/cOne/cTwo/cAdd, inductive Bin/Bin.succ/Bin.add) unchanged.",
+      "proofs/Proofs.lean — +1 import for Proofs.OnePlusOneOQ04 (alphabetic between OnePlusOne and PACLearning).",
+      "**(S3 NEW)** row0_unfolded — named theorem replacing S2's anonymous example for Row 0 (unfolded baseline; Rules(E) = ∅).",
+      "**(S3 NEW)** row1_peano_pattern — named theorem for Row 1 (Peano pattern-match; Rules(E) = {δ, ι}).",
+      "**(S3 NEW)** row2_peano_recursor — named theorem for Row 2 (Peano raw recursor; Rules(E) = {δ, ι, β}).",
+      "**(S3 NEW)** row3_church — named theorem for Row 3 (Church numerals; Rules(E) = {δ, β}).",
+      "**(S3 NEW)** row4_binary — named theorem for Row 4 (binary naturals; Rules(E) = {δ, ι}).",
+      "**(S3 NEW)** Part 6: Axiom-Freedom Verification — five `#print axioms` stanzas confirming each row witness depends on no axioms (propositional dual of the reduction-rule taxonomy)."
     ],
     "insights": [
       "Minimality of Rules(E) is encoding-relative; the same theorem `1+1=2 := rfl` lives at four distinct points in the subset lattice 2^{β,ι,δ,ζ} depending on representation.",


### PR DESCRIPTION
## Summary

S3 iteration on `russell-1-plus-1-oq-04` (minimal reduction rules for `1+1=2 := rfl`). Three changes to `proofs/Proofs/OnePlusOneOQ04.lean`:

1. **Named row theorems.** Each of S2's five `example := rfl` row witnesses is now a named `theorem` (`row0_unfolded` through `row4_binary`), enabling `#print axioms` queries.
2. **Part 6: Axiom-Freedom Verification.** Five `#print axioms` stanzas emit info messages at build time confirming each row depends on no axioms — the *propositional* dual of the *reductional* taxonomy `Rules(E) ⊆ {β, ι, δ, ζ}` from Parts 1–5 (per S1 knowledge.md insight #6).
3. **`noncomputable` fix for `addRec`** (latent S2 bug). S2 (PR #17971) was merged "(build pending)" and never actually built; this PR brings the file under build verification and reveals a code-generator error. Fixed by marking `addRec` as `noncomputable def`.

**Outcome**: progress (infrastructure). Sorry count: 0 (unchanged). Axiom count: 0 (now machine-checked at build time).

## What I added (+47 net lines, 161 → 187)

### Part 6: Axiom-Freedom Verification

```lean
#print axioms row0_unfolded         -- info: depends on no axioms
#print axioms row1_peano_pattern    -- info: depends on no axioms
#print axioms row2_peano_recursor   -- info: depends on no axioms
#print axioms row3_church           -- info: depends on no axioms
#print axioms row4_binary           -- info: depends on no axioms
```

Each row's reduction-rule subset `Rules(E)` is *sufficient* (witnessed by `:= rfl`) AND no Classical/extensional axiom is silently consumed (verified by `#print axioms`). Together these establish that the file's contribution is rigorously axiom-free and purely kernel-reductional, matching the S1 honesty notes.

### S3 build-fix: latent S2 issue

```
error: code generator does not support recursor `Peano.ℕ.rec` yet
```

PR #17971's title includes "(build pending)" — S2 was merged without actually verifying the build. Bringing the file under build verification surfaced this latent error in `addRec`'s use of `Peano.ℕ.rec` with a non-Prop motive. The fix is `noncomputable def addRec`: the kernel reduction for `:= rfl` (which is what the row witnesses need) is unaffected; only runtime code-generation is skipped. The whole point of `addRec` is to exhibit the *raw recursor* encoding (Row 2 in the taxonomy), so the `noncomputable` annotation is the principled fix.

## Build status

**Verified** via `./proofs/scripts/docker-build.sh Proofs.OnePlusOneOQ04`:

```
info: Proofs/OnePlusOneOQ04.lean:188:0: 'OnePlusOneOQ04.row0_unfolded'       does not depend on any axioms
info: Proofs/OnePlusOneOQ04.lean:189:0: 'OnePlusOneOQ04.row1_peano_pattern'  does not depend on any axioms
info: Proofs/OnePlusOneOQ04.lean:190:0: 'OnePlusOneOQ04.row2_peano_recursor' does not depend on any axioms
info: Proofs/OnePlusOneOQ04.lean:191:0: 'OnePlusOneOQ04.row3_church'         does not depend on any axioms
info: Proofs/OnePlusOneOQ04.lean:192:0: 'OnePlusOneOQ04.row4_binary'         does not depend on any axioms
Build completed successfully (3 jobs).
```

## Files modified

- `proofs/Proofs/OnePlusOneOQ04.lean` — +47 lines (5 `theorem` renames + `noncomputable` fix on `addRec` + Part 6 docstring + 5 `#print axioms`)
- `src/data/research/problems/russell-1-plus-1-oq-04.json` — iter 2 → 3, builtItems +6
- `research/problems/russell-1-plus-1-oq-04/{knowledge.md, state.md}` — S3 entry

## Status

**Outcome**: progress (infrastructure)
**Next Steps**:
- S4: Add gallery entry `src/data/proofs/russell-1-plus-1-oq-04/` (status=verified, badge=original, axiomCount=0, sorries=0).
- S5 (optional): Let-binding example demonstrating ζ's role.

## Deviation from S2 next-action plan

S2's `state.md` mentioned both `#print axioms` AND `#reduce` stanzas. This PR omits `#reduce` because it produces multi-page verbose kernel output (especially for the recursor and Church rows) that bloats the build log without adding propositional content. `#reduce` can be re-introduced in S5 for the let-binding example if step-by-step trace output is needed.

## Honesty note

The contribution is *infrastructure* — converting anonymous `example`s to named theorems so the axiom-freedom claim becomes machine-checked, plus a build-fix that S2 should have caught. No new proof content; sorry count unchanged (still 0). The dual claim was implicit in S2 (since `rfl` proofs cannot introduce axioms); S3 makes it *explicit and queryable* and brings the file under actual build verification for the first time.

🤖 Generated by researcher-1