### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S66 ANALYSIS — refute S65's pointwise S57.7 plan via (3,2)-shape counter-example (doc-only)

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s05.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s05.md
@@ -1,0 +1,301 @@
+# Session 66 — S57.7 plan refutation: pointwise equality fails on non-vanishing crossing cells
+
+**Researcher.** researcher-8, 2026-05-12.
+
+**Mode.** ANALYSIS-ONLY (no `.lean` edits).
+
+**Outcome.** Concrete `(3,2)`-shape counter-example refuting the
+S65 session note's planned formulation of S57.7
+(`gnwProb μ c K y = gnwProb (μ\c') c K y` pointwise on the
+non-vanishing crossing cells of PR #17747's
+`strictHookCells_off_spine_class_at_c'` partition).  Realigns the
+"Next Action" with state.md line 537–539's earlier prediction that
+S57.7 "likely needs a `δ_arm` correction term".
+
+## Context
+
+PR #17865 (S57.6 prep 3, researcher-4) closes with a "Next step
+(S57.7 — non-vanishing crossing pointwise comparison)" plan
+proposing to prove, by induction on `K`,
+
+```lean
+gnwProb μ c K y = gnwProb (removeCorner μ c' hc') c K y
+```
+
+where `y = (x.1, c'.2)` is the unique non-vanishing arm-class
+crossing cell (case 1: `c.1 < c'.1`) of an off-spine `x` ∈ μ.
+S65 outlines a K-induction whose K-step would use S65's own
+`hookLength_at_arm_class_case1` to "align the K-step
+hookLength-divisor on both sides" and then apply IH on the strict
+hook of `y`.
+
+This session's deliverable: **a small-diagram counter-example**
+showing that this pointwise equality is **false** for the smallest
+non-degenerate case, plus a structural diagnosis of why.
+
+## Counter-example
+
+**Diagram.** μ = (3, 2) (i.e., the partition with row lengths 3, 2;
+five cells `(0,0), (0,1), (0,2), (1,0), (1,1)`).
+
+**Corners of μ.** `{(0,2), (1,1)}`.
+
+**Choose** `c = (0, 2)`, `c' = (1, 1)`.  Then
+`distinct_corners_dichotomy` gives **case 1**: `c.1 = 0 < 1 = c'.1`.
+
+**Off-spine cells of μ relative to c'.**
+`{x : x.1 ≠ 1 ∧ x.2 ≠ 1}` = `{(0,0), (0,2)}`.
+
+**Choose** `x = (0, 0)`.  Compute strict hook of `x` in μ:
+arm = `{(0,1), (0,2)}`, leg = `{(1,0)}`, so
+`strictHookCells μ 0 0 = {(0,1), (0,2), (1,0)}`.
+
+**Non-vanishing arm-class crossing cell.**
+`y = (x.1, c'.2) = (0, 1) ∈ strictHookCells μ 0 0` ✓.
+`y.1 = 0 ≠ 1 = c'.1`, `y.2 = 1 = c'.2`.  Confirms y is the unique
+arm-on-`c'`-column class member of S57.6 prep's partition.
+
+**Hook lengths in μ.**
+| cell  | armLen | legLen | hookLength |
+|-------|--------|--------|------------|
+| (0,0) | 2      | 1      | 4          |
+| (0,1) | 1      | 1      | 3          |
+| (0,2) | 0      | 0      | 1          |
+| (1,0) | 1      | 0      | 2          |
+| (1,1) | 0      | 0      | 1          |
+
+**Compute** `gnwProb μ c K y` for `K = hookLength μ 0 1 = 3`
+(stable value once `K ≥ hookLength`):
+
+* `K = 0`: `gnwProb μ c 0 (0,1) = 0` (def line 14385).
+* `K = 1`: `(0,1)` is not a corner of μ.
+  `gnwProb μ c 1 (0,1) = (1/2) · (gnwProb μ c 0 (0,2) + gnwProb μ c 0 (1,1))`
+  `= (1/2)(0 + 0) = 0`.
+* `K = 2`: `gnwProb μ c 2 (0,1) = (1/2) · (gnwProb μ c 1 (0,2) + gnwProb μ c 1 (1,1))`.
+  Both `(0,2)` and `(1,1)` are corners of μ; `(0,2) = c`, so
+  `gnwProb μ c 1 (0,2) = 1` and `gnwProb μ c 1 (1,1) = 0`.
+  Thus `gnwProb μ c 2 (0,1) = 1/2`.
+* `K = 3`: same recursion at K=3; corners stabilize at K=2 onward,
+  so `gnwProb μ c 3 (0,1) = 1/2`.
+
+**Hook lengths in `μ \ c' = (3, 1)`** (cells `{(0,0), (0,1), (0,2), (1,0)}`).
+| cell  | armLen' | legLen' | hookLength' |
+|-------|---------|---------|-------------|
+| (0,0) | 2       | 1       | 4           |
+| (0,1) | 1       | 0       | 2           |
+| (0,2) | 0       | 0       | 1           |
+| (1,0) | 0       | 0       | 1           |
+
+**Compute** `gnwProb (μ\c') c K (0,1)` for `K = hookLength (μ\c') 0 1 + 1 = 3`
+(or any `K ≥ 2`):
+
+* `K = 1`: `(0,1)` not a corner of `(3,1)` (since `(0,2) ∈ (3,1)`).
+  `strictHookCells (3,1) 0 1 = {(0,2)}` (leg empty: `(1,1) ∉ (3,1)`).
+  `gnwProb (3,1) c 1 (0,1) = (1/1) · gnwProb (3,1) c 0 (0,2) = 0`.
+* `K = 2`: `(0,2)` is a corner of `(3,1)` and equals `c`, so
+  `gnwProb (3,1) c 1 (0,2) = 1`.  Thus
+  `gnwProb (3,1) c 2 (0,1) = (1/1) · 1 = 1`.
+* `K ≥ 2`: stable at 1.
+
+**Result.**
+```
+gnwProb μ      c K (0,1) = 1/2     (K ≥ 2)
+gnwProb (μ\c') c K (0,1) = 1       (K ≥ 2)
+```
+**These are unequal.**  The S65 next-step claim is false.
+
+## Why the K-induction fails
+
+The S65 plan envisions using `hookLength_at_arm_class_case1` to
+align the K+1 step's `hookLength`-divisor.  But the divisor mismatch
+is intrinsic and the IH equality on `strictHookCells` cannot
+recover it.  Concretely, at `y = (0,1)`:
+
+* `|strictHookCells μ y.1 y.2| = hookLength μ 0 1 - 1 = 2`.
+* `|strictHookCells (μ\c') y.1 y.2| = hookLength (μ\c') 0 1 - 1 = 1`.
+
+The `μ`-side strict hook contains `c' = (1,1)` (in the leg of `y`);
+the `(μ\c')`-side strict hook does not.  The K+1 step recurrences:
+
+```
+gnwProb μ      c (K+1) y = (1/2) · (gnwProb μ      c K (0,2) + gnwProb μ      c K (1,1))
+gnwProb (μ\c') c (K+1) y = (1/1) · (gnwProb (μ\c') c K (0,2))
+```
+
+For `K ≥ 1`:
+
+* `gnwProb μ c K (1,1) = 0` (since `(1,1) = c'` is a corner ≠ `c`,
+  by S57.3a's `gnwProb_at_other_corner` family).
+* `gnwProb μ c K (0,2) = gnwProb (μ\c') c K (0,2) = 1`
+  (corner `(0,2) = c` on both sides).
+
+So:
+
+```
+gnwProb μ      c (K+1) y = (1/2) · (1 + 0) = 1/2
+gnwProb (μ\c') c (K+1) y = (1/1) · 1       = 1
+```
+
+The IH equality on the strict hook *holds* — both
+`gnwProb μ c K (0,2) = gnwProb (μ\c') c K (0,2)` — yet the
+divisor mismatch (`1/2` vs `1/1`) flips a 1 into a 1/2.  No K-shift
+or hook-length bookkeeping repairs this: the strict-hook walk
+*genuinely loses* the option of stepping to `c'` when `c'` is
+removed, and the missing mass redistributes onto the remaining
+arm/leg cells.
+
+## What state.md already predicted
+
+State.md line 537–539:
+
+> "the doubly-affected cell `d` plus `c.1` / `c.2` below-`c` cells
+> where genuine arm/leg pointwise comparison between `gnwProb μ`
+> and `gnwProb (μ\c')` is required (S57.7, **likely needs a `δ_arm`
+> correction term**)."
+
+State.md line 558–563 (case 2 analysis):
+
+> "(S2) case 2 (arm-of-c' with `c'.1 < c.1`): NOT covered.  Cells
+> `x = (c'.1, s)` with `s < c'.2` and `c'.1 < c.1` give
+> `x.1 = c'.1 < c.1`, no unreachability.  These cells need genuine
+> pointwise comparison — the **`δ_arm` story still applies** for
+> this sub-branch."
+
+The S65 session note's "Next step (S57.7)" plan **regressed** to
+naive pointwise equality, contradicting state.md's earlier wisdom.
+This session re-anchors the plan to state.md's `δ_arm` correction
+path.
+
+## Sum-level identity still holds
+
+To confirm the *aligned-K* sum identity `F_side_identity_aligned`
+remains plausible, compute both sides at the same (3,2) data:
+
+`d = (min c.1 c'.1, min c.2 c'.2) = (0, 1)`, `h_d = hookLength μ 0 1 = 3`,
+`(h_d - 1)² = 4`, `h_d · (h_d - 2) = 3`.
+
+`(μ\c').cells = {(0,0), (0,1), (0,2), (1,0)}`.
+
+LHS sum of `gnwProb μ c (hookLength μ x.1 x.2) x` over these cells:
+
+* `(0,0)`: `K = hookLength μ 0 0 = 4`.  By recursion,
+  `gnwProb μ c 4 (0,0) = (1/3)(1/2 + 1 + 0) = 1/2`.
+* `(0,1)`: `K = 3`, value = `1/2` (above).
+* `(0,2)`: `K = 1`, value = `1` (corner = c).
+* `(1,0)`: `K = 2`, value = `0` (`(1,0)` not corner; goes to corner
+  `(1,1) ≠ c`).
+
+LHS sum = `1/2 + 1/2 + 1 + 0 = 2`.  LHS = `2 · 4 = 8`.
+
+RHS sum of `gnwProb (μ\c') c (hookLength (μ\c') x.1 x.2) x`:
+
+* `(0,0)`: `K = 4`.  `H*'((0,0)) = {(0,1),(0,2),(1,0)}` in `(3,1)`.
+  `= (1/3)(1 + 1 + 0) = 2/3`.
+* `(0,1)`: `K = 2`, value = `1` (above).
+* `(0,2)`: `K = 1`, value = `1`.
+* `(1,0)`: `K = 1`, value = `0` (corner of `(3,1)` but ≠ `c`).
+
+RHS sum = `2/3 + 1 + 1 + 0 = 8/3`.  RHS = `(8/3) · 3 = 8`.
+
+**LHS = RHS = 8** ✓.  The aligned-K sum identity holds, even though
+the per-`x` integrands are pointwise unequal at three of the four
+cells:
+
+| x     | μ-side `gnwProb μ c (h_μ x) x` | (μ\c')-side `gnwProb (μ\c') c (h_{μ\c'} x) x` | equal? |
+|-------|--------------------------------|------------------------------------------------|--------|
+| (0,0) | 1/2                            | 2/3                                            | ✗      |
+| (0,1) | 1/2                            | 1                                              | ✗      |
+| (0,2) | 1                              | 1                                              | ✓      |
+| (1,0) | 0                              | 0                                              | ✓      |
+
+The cancellation is **global** across the `(μ\c')` cell sum, not
+pointwise.  Any K-induction-style attempt to prove S57.7 by
+*per-cell* `gnwProb` equality is structurally doomed; the proof
+must instead operate at the **summed** level, with a `δ_arm`-style
+correction term redistributing the missing `c'`-step mass across
+the arm/leg cells of the doubly-affected `d`-row/column.
+
+## Implication for S57.7's design
+
+The S57.7 lemma should target one of:
+
+1. **Sum-form aligned identity** (preferred): prove
+   `∑ y ∈ S, gnwProb μ c K y · w₁(y) = ∑ y ∈ S', gnwProb (μ\c') c K y · w₂(y)`
+   where `S` and `S'` are matched arm/leg subsets and `w₁`/`w₂` are
+   weight factors derived from the `(h_d - 1)²` vs `h_d · (h_d - 2)`
+   ratio.  Requires identifying the right `S, S', w₁, w₂` quartet.
+
+2. **Pointwise with explicit correction term `δ_arm(y)`**: prove
+   `gnwProb μ c K y = gnwProb (μ\c') c K y · α(y) + β(y)` for
+   per-cell rational corrections `α, β` chosen to cancel in the
+   `F_side_identity_aligned` sum.  More concrete but requires
+   guessing `α, β` upfront.
+
+State.md's "S57.7 likely needs a `δ_arm` correction term" wording
+suggests path (2).  This session does not commit to either — only
+flags that path (0) "naive pointwise equality" is not viable and
+should be removed from S65's "Next step" pointer.
+
+## Suggested replacement Next Action (S57.7 reformulated)
+
+**S57.7 — F-side aligned residual identity for arm/leg crossings.**
+Prove the *summed* identity
+
+```
+∑ x ∈ (μ\c').cells.filter (off-spine of c'),
+  gnwProb μ c (hookLength μ x.1 x.2) x · (h_d - 1)²
+=
+∑ x ∈ (μ\c').cells.filter (off-spine of c'),
+  gnwProb (μ\c') c (hookLength (μ\c') x.1 x.2) x · h_d · (h_d - 2)
+```
+
+restricted to off-spine `x` where the K-induction step uses
+S57.4's `gnwProb_succ_eq_off_spine_of_c'`, the S57.6 prep partition
+to split strict-hook contributions, and **a sum-level reweighting**
+to convert pointwise mass loss at `c'` into an arm/leg
+redistribution.
+
+This `δ_arm` correction is the geometric content of the
+"`(h_d - 1)² = h_d · (h_d - 2) + 1` sub-balance" — the `+1`
+absorbs the missing `c'`-step mass.
+
+Concretely, on the `(3,2)` data of this session:
+`(h_d - 1)² - h_d · (h_d - 2) = 4 - 3 = 1`, and the
+LHS-vs-RHS pointwise differences at the off-spine cells are
+`(0,0): 1/2 - 2/3 = -1/6`, `(0,1): 1/2 - 1 = -1/2`,
+`(0,2): 1 - 1 = 0`.  Weighted by `(h_d - 1)² = 4` and
+`h_d · (h_d - 2) = 3`:
+`4 · 1/2 + 4 · 1/2 + 4 · 1 + 0 - (3 · 2/3 + 3 · 1 + 3 · 1 + 0) = 8 - 8 = 0` ✓.
+
+The `+1` discrepancy `4 - 3 = 1` exactly absorbs the case-1
+arm-class mass loss `(0,1): 1/2 - 1 = -1/2`, weighted by something
+on the order of `2`.  The full `δ_arm` formula needs the leg/arm
+sum analysis from S57.5 + S57.3a to be derived.
+
+## Files Modified
+
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  — Session 65 acknowledgment, Session 66 entry, "Next Action"
+  refactored to sum-level S57.7.
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s05.md`
+  — this file.
+* `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`
+  — iteration nudge (64 → 66).
+
+**No `.lean` changes.**  No build attempted.  Build remains pending
+on parent `BallotProblemOQ03OQ02.lean` break (per memory note
+`feedback_researcher_ballot_oq03oq02_parent_break.md`).
+
+## Trap notes
+
+* Pre-claim: `gh pr list --search ballot-problem-oq-03-oq-01-oq-02 --state open`
+  returns `[]`.  Recent merges to this slug on `origin/main`:
+  `b3004f983da` (S57.6 prep 2, #17817), `e0fbafbbeff` (S57.6 prep 3,
+  #17865), `dff4802e329` (S57.6 prep 1, #17747), all 2026-05-12.
+  No race detected for an analysis-only S57 advance.
+* `.lean/state` symlink and `research/claims/` were already
+  populated in the worktree at session start (per
+  `feedback_researcher_worktree_claim_setup.md`); no setup needed.
+* Counter-example was hand-verified twice using the `gnwProb`
+  definition at line 14384 and the `strictHookCells` definition
+  at line 14274 — values consistent across both passes.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,91 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (S57.6 prep 2 done — crossing-class IH discharge lemmas package the S57.6 prep partition with S57.3a vanishings; only non-vanishing crossing cell remains per case)
+**Phase**: ACT (S57.6 prep 1/2/3 done — partition + vanishing-class IH discharge + non-vanishing-class K-shift facts in place; **S65's planned naive pointwise S57.7 refuted by Session 66 (3,2)-shape counter-example**, replanned to sum-level δ_arm-correction identity)
 **Path**: full
 **Since**: 2026-05-08T17:36:50+03:00
-**Last Updated**: 2026-05-12 (Session 64 / S57.6 prep 2 researcher-4)
-**Iteration**: 64
+**Last Updated**: 2026-05-12 (Session 66 / S57.7 plan refutation researcher-8)
+**Iteration**: 66
+
+## Session 66 — S57.7 plan refutation: pointwise equality fails (researcher-8, 2026-05-12)
+
+**Mode.** ANALYSIS-ONLY (no `.lean` edits).
+
+**Outcome.** Concrete `(3,2)`-shape counter-example refuting S65's
+"Next step (S57.7)" plan that proposed proving
+`gnwProb μ c K y = gnwProb (μ\c') c K y` pointwise on the
+non-vanishing crossing cells (case-1 arm-class
+`y = (x.1, c'.2)`, case-2 leg-class `y = (c'.1, x.2)`).  The
+divisor mismatch `|H*(y)| = |H*'(y)| + 1` (since `c' ∈ H*(y)`,
+`c' ∉ H*'(y)`) genuinely breaks pointwise equality even though IH
+on the strict-hook cells holds.  Realigns S57.7's "Next Action"
+with state.md's earlier `δ_arm` correction-term plan
+(line 537–539, line 558–563).
+
+**Counter-example summary.** `μ = (3,2)`, `c = (0,2)`, `c' = (1,1)`
+(case 1: `0 < 1`).  Off-spine `x = (0,0)`, non-vanishing arm-class
+`y = (0,1)`.  Direct computation from the `gnwProb` def (line
+14384):
+
+```
+gnwProb μ      c K (0,1) = 1/2  (K ≥ 2)
+gnwProb (μ\c') c K (0,1) = 1    (K ≥ 2)
+```
+
+The `μ`-side strict hook `H*(y) = {(0,2), (1,1)}` includes
+`c' = (1,1)`; the `(μ\c')`-side `H*'(y) = {(0,2)}` does not.
+At K+1: `(1/2)(1 + 0) = 1/2` vs `(1/1)(1) = 1`.  Hook-length shift
+`hookLength_at_arm_class_case1` does not bridge the missing-mass
+gap; mass redistributes globally, not locally.
+
+**Sum-level identity verified.** `F_side_identity_aligned`
+sum at the same `(3,2)` data: LHS sum of
+`gnwProb μ c (h_μ x) x` over `(μ\c').cells` weighted by
+`(h_d - 1)² = 4` equals 8; RHS sum of
+`gnwProb (μ\c') c (h_{μ\c'} x) x` weighted by
+`h_d · (h_d - 2) = 3` also equals 8.  The aligned identity holds
+**globally** despite per-cell pointwise inequality at three of
+four `(μ\c')` cells.  See `sessions/2026-05-12-s05.md` for the
+full table and arithmetic.
+
+**Implication.**  Any K-induction targeting *per-cell* equality on
+non-vanishing crossing cells is structurally doomed.  S57.7 must
+operate at the **summed** level with a sum-level reweighting
+(equivalently, a per-cell `δ_arm` correction term) that
+redistributes the missing `c'`-step mass across the arm/leg cells
+of the doubly-affected `d`-row/column.  The discrepancy
+`(h_d - 1)² - h_d · (h_d - 2) = +1` is the geometric content of
+this reweighting.
+
+**Files modified.**
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` — this entry, Session 65 acknowledgment, "Next Action" rewritten.
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s05.md` — counter-example, structural diagnosis, suggested S57.7 reformulation.
+* `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` — iteration 64 → 66.
+
+**Build status.** No `.lean` changes; no build attempted.  Parent
+`BallotProblemOQ03OQ02.lean` remains broken on `origin/main`.
+
+## Session 65 — S57.6 prep 3 non-vanishing crossing K-shifts (researcher-4, 2026-05-12)
+
+PR #17865 added two sorry-free single-removal hook-length shift
+lemmas in `BallotProblemOQ03OQ01OQ02Helpers.lean`:
+
+* `hookLength_at_arm_class_case1` (line ~5005) — for off-row cell
+  `(r, c'.2) ∈ μ` with `r ≠ c'.1`,
+  `hookLength (μ\c') r c'.2 + 1 = hookLength μ r c'.2`.
+
+* `hookLength_at_leg_class_case2` — mirror for off-column cell
+  `(c'.1, s) ∈ μ` with `s ≠ c'.2`.
+
+Pre-positioned for S57.7 K-bookkeeping at the non-vanishing
+crossing cells.  Helpers.lean: 15920 → 15995 lines (after S57.6
+prep 2 + prep 3 both merged).
+
+**S65's "Next step (S57.7)" plan refuted by Session 66** — see above.
+The shift lemmas remain valid as algebraic facts; only the proposed
+*use* of them in a naive pointwise K-induction is invalid.  They
+will instead serve as ingredients in the sum-level `δ_arm`
+correction once S57.7's correct formulation crystallizes.
 
 ## Session 64 — S57.6 prep 2 crossing-class IH discharge (researcher-4, 2026-05-12)
 
@@ -520,23 +600,80 @@ in place:
   memory ceiling estimate (~15500).  CI will verify the PR.
 
 ## Next Action
-**S57.6 — derive unconditional pointwise off-spine integrand identity**
-via well-founded recursion on `hookLength μ x.1 x.2`, using S57.4's
-`gnwProb_succ_eq_off_spine_of_c'` as the inductive step.  The strict
-hook of an off-spine cell `x` may contain "crossing" cells `y` with
-`y.1 = c'.1` or `y.2 = c'.2`; these are discharged by S57.3a's per-cell
-helpers (`gnwProb_zero_of_row_eq_c'_case1` /
-`gnwProb_zero_of_col_eq_c'_case2`) on whichever side of the
-case-1/case-2 dichotomy applies.  Estimated ~80–150 lines.  This
-closes the (S6) off-spine branch of S57.0.
 
-After S57.6, the (S2)/(S3) live arm/leg residuals — `range (c.1 + 1)`
-in case 1, `range (c.2 + 1)` in case 2 (S57.5 reductions) — remain the
-only piece of `F_side_identity_aligned`.  Each residual contains the
-doubly-affected cell `d` plus `c.1` / `c.2` below-`c` cells where
-genuine arm/leg pointwise comparison between `gnwProb μ` and
-`gnwProb (μ\c')` is required (S57.7, likely needs a `δ_arm`
-correction term).
+**S57.7 — sum-level F-side aligned residual identity for non-vanishing
+crossings** (replaces S65's refuted naive pointwise plan; see Session 66
+above + `sessions/2026-05-12-s05.md`).
+
+The S57.6 prep 1/2/3 chain (PRs #17747 / #17817 / #17865) reduces
+`F_side_identity_aligned` modulo two remaining contributions: the
+non-vanishing arm-class summands (case 1, `y = (x.1, c'.2)`) and the
+non-vanishing leg-class summands (case 2, `y = (c'.1, x.2)`).
+*Per-cell* equality `gnwProb μ c K y = gnwProb (μ\c') c K y` is
+**false** on these cells (Session 66 counter-example), because
+`c' ∈ H*(y) \ H*'(y)` causes the K+1 step's divisor and summands to
+mismatch by mass that is not recoverable from the IH.
+
+The correct target is at the **summed** level:
+
+```
+∑ x ∈ (μ\c').cells.filter (off-spine of c'),
+    [ gnwProb μ      c (hookLength μ      x.1 x.2) x · (h_d - 1)²
+    − gnwProb (μ\c') c (hookLength (μ\c') x.1 x.2) x · h_d · (h_d - 2) ]
+= 0
+```
+
+with the discrepancy `(h_d − 1)² − h_d · (h_d − 2) = +1` absorbing the
+missing `c'`-step mass uniformly across the off-spine arm/leg cells.
+Equivalently, S57.7 introduces a `δ_arm`-style per-cell correction
+term that integrates to zero against the off-spine sum.
+
+**Approach.**
+
+1. **Sub-lemma S57.7a — partial sums on the case-1 arm class.**  For
+   the non-vanishing arm-class strict-hook contributions of off-spine
+   cells `x = (r, c) ∈ (μ\c').cells` with `r ≠ c'.1`, write the
+   K-step residual `gnwProb μ c (K+1) x − gnwProb (μ\c') c (K+1) x`
+   as `(1/(K+1)) · gnwProb μ c K c'` plus a divisor-mismatch term
+   that recombines as a *fraction* of `gnwProb (μ\c') c K x` with
+   coefficient `+1/(|H*'(x)| · (|H*'(x)| + 1))`.
+   (S65's `hookLength_at_arm_class_case1` gives `|H*(x)| = |H*'(x)| + 1`.)
+
+2. **Sub-lemma S57.7b — case-2 leg-class mirror.**  Reduce to S57.7a
+   via S58 (PR #17650, transpose-equivariance of `strictHookCells`
+   and `gnwProb`).
+
+3. **Sub-lemma S57.7c — `δ_arm` integration to zero.**  Sum the
+   per-cell `δ_arm` correction over the off-spine arm/leg sub-domain
+   and show it cancels the `+1` discrepancy weighted by the
+   off-spine cell count.
+
+   Tools: S57.5's `sum_gnwProb_arm_of_c'_reduce_*` /
+   `sum_gnwProb_leg_of_c'_reduce_*` (PR #17734) for the sum reductions;
+   `sum_gnwProb_strictHookCells_eq_removeCorner` (line 15405) for the
+   strict-hook domain bridge.
+
+**Estimated.**  150–250 lines (sub-lemmas) + 40–80 lines for the
+final `F_side_identity_aligned` assembly.  Total likely exceeds the
+~15500-line Helpers.lean ceiling, forcing the Option E3 extraction
+into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` to land first.
+
+**Risk.**  Medium-high.  S57.7a's algebraic restatement is the
+crux; the `+1` discrepancy must factor cleanly through the
+divisor-mismatch.  Recommend an **analysis-only S57.7 spec session**
+next (Session 67) to derive S57.7a's exact algebraic form on the
+`(3,2)` and `(3,2,1)` test diagrams before any `.lean` edit.
+
+## Historical Next Action (S57.6, replanned by Session 66)
+
+The pre-S65 plan called for S57.6 to be a single ~80–150-line
+well-founded-recursion lemma deriving the unconditional pointwise
+off-spine integrand identity.  The S57.6 prep 1/2/3 chain (PRs
+#17747 / #17817 / #17865) decomposed S57.6 into bookkeeping
+sub-lemmas; Session 66 then refuted the implicit assumption that
+the non-vanishing crossing classes admit pointwise equality.
+S57.6 *proper* (the well-founded recursion) is now subsumed by
+S57.7's sum-level identity above.
 
 ## Historical Next Action (S57.3, now superseded by S57.5)
 **S57.3 — apply `gnwProb_unreachable_zero` to discharge (S2) and (S3)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -33,20 +33,20 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-21T13:45:00Z",
-    "iteration": 52,
-    "focus": "S52 (this session) — proved `hookProd_doubleRemove_factor` (BallotProblemOQ03OQ01OQ02Helpers.lean:5297, ~133 lines including 38-line docstring). This is the algebraic 'easy half' of the GNW exchange identity: H(μ)·H((μ\\c)\\c')·(h_d-1)² = H(μ\\c)·H(μ\\c')·h_d·(h_d-2) where h_d = hookLength μ c.1 c'.2. Proof applies hookProd_ratio_formula twice (to corner c on μ and on μ\\c'), uses S50 single-removal bridges to show pointwise equality off the doubly-affected cell d, uses Finset.mul_prod_erase to extract the differing d-factors (h_d/(h_d-1) in R₁ vs (h_d-1)/(h_d-2) in R₂), then closes by `rw [hR1, hR2]; field_simp; ring` after applying h_swap. S51 `hookLength_at_d_ge_3` provides the ℚ-cast safety. This closes step 1 of 3 in the s05 recipe; remaining: S53 F-side joint K-induction (~100-200 lines), S54+ combine. Sorry count unchanged (1).",
+    "iteration": 66,
+    "focus": "S66 (this session, researcher-8, ANALYSIS-ONLY) — refuted S65's planned naive pointwise S57.7 (`gnwProb μ c K y = gnwProb (μ\\c') c K y` on non-vanishing crossing cells of the S57.6 prep partition) with a (3,2)-shape counter-example: c=(0,2), c'=(1,1), x=(0,0), y=(0,1). Direct computation from the gnwProb def yields gnwProb μ c K y = 1/2 vs gnwProb (μ\\c') c K y = 1 (K ≥ 2). The mismatch is structural: c' ∈ H*(y) \\ H*'(y) so the K+1 step's divisor differs by 1 (1/2 vs 1/1), and IH on the strict-hook cells does not bridge the missing-mass gap. Sum-level F_side_identity_aligned identity verified to still hold at (3,2): both sides equal 8 despite per-cell pointwise inequality at three of four (μ\\c').cells. Realigns S57.7 with state.md's earlier `δ_arm` correction-term plan (line 537–539, 558–563). No `.lean` edits.",
     "blockers": [
       "gnwProb_exchange: GNW 1979 hook-weight shift identity in product form. S52 (this session) closed the algebraic easy half (`hookProd_doubleRemove_factor`, sorry-free). Remaining: F-side joint K-induction (S53, ~100-200 lines) using `gnwProb_step` for K-stability and the S43 sum-bridges, then S54+ combines via gnwProb bookkeeping. File-size approaches Docker 32GB ceiling at 14852 lines; extraction into a `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` sub-file should be a blocking prerequisite for S53."
     ],
-    "nextAction": "S53: prove the F-side joint K-induction on the sum-level invariant `(∑ gnwProb μ c K) · h_d (h_d−2) = (∑ gnwProb (μ\\c') c K) · (h_d − 1)²` using `gnwProb_step` for K-stability and the S43 sum-bridges (`sum_gnwProb_eq_removeCorner_cells`, `sum_gnwProb_strictHookCells_eq_removeCorner`). Likely needs file extraction first (Helpers.lean is at 14852 lines, Docker ceiling ~15500). Confidence: medium — joint K-induction may bifurcate at K=0 base case requiring a separate lemma. Then S54+ combines with S52's hookProd_doubleRemove_factor to close gnwProb_exchange.",
+    "nextAction": "S57.7 (REPLANNED, post-S66 refutation) — sum-level F-side aligned residual identity for non-vanishing crossings. The S57.6 prep 1/2/3 chain (PRs #17747/#17817/#17865) covers the vanishing crossing classes; remaining contribution is the case-1 arm-class y=(x.1,c'.2) and case-2 leg-class y=(c'.1,x.2). Per-cell equality `gnwProb μ c K y = gnwProb (μ\\c') c K y` is FALSE (Session 66 (3,2)-shape counter-example). Correct target: ∑ x ∈ off-spine (μ\\c').cells, [gnwProb μ ⋅ (h_d-1)² − gnwProb (μ\\c') ⋅ h_d(h_d-2)] = 0, with (h_d-1)² − h_d(h_d-2) = +1 absorbing the missing c'-step mass. Sub-lemmas S57.7a (case-1 arm partial sums), S57.7b (case-2 leg via S58 transpose), S57.7c (δ_arm integration to zero). Estimated 150–250 lines + 40–80 for assembly; Option E3 file-extraction must land first (Helpers.lean at 15995 lines). Recommend Session 67 = analysis-only S57.7 spec on (3,2)/(3,2,1) test diagrams to derive S57.7a's algebraic form before any .lean edit.",
     "attemptCounts": {
-      "total": 52,
-      "currentApproach": 16,
+      "total": 66,
+      "currentApproach": 30,
       "approachesTried": 12
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS session 62 / S57.5 (researcher-10, 2026-05-12): Added two sorry-free private lemmas in BallotProblemOQ03OQ01OQ02Helpers.lean (after S57.4 gnwProb_succ_eq_off_spine_of_c'): sum_gnwProb_leg_of_c'_reduce_case1 (case 1 c.1<c'.1 leg-of-c' sum reduces to range (c.1+1)) and sum_gnwProb_arm_of_c'_reduce_case2 (case 2 c.2<c'.2 arm-of-c' sum reduces to range (c.2+1)). Together with S57.3 PR #17719 sum-form vanishings, the four sub-branches of S57.0's cell partition are now tightly bounded: two vanish (S57.3), two reduce to small residuals containing the doubly-affected cell d plus c.1/c.2 below-c cells. Proofs use Finset.sum_Ico_consecutive + Finset.range_eq_Ico + Finset.sum_eq_zero + S57.2 gnwProb_unreachable_zero. +116 Helpers.lean lines (15600 → 15716, crossing the ~15500 Docker memory ceiling estimate by ~216 lines; S57.0 Option E3 file-extraction may be needed for S57.6+). Build pending due to ongoing BallotProblemOQ03OQ02.lean LGV-route sibling break on origin/main. Sole open sorry on GNW route remains F_side_identity_aligned. Next: S57.6 derives unconditional pointwise off-spine identity via WF recursion on hookLength using S57.4 + S57.3a crossing-cell helpers.",
+    "progressSummary": "PROGRESS session 66 / S66 (researcher-8, 2026-05-12, ANALYSIS-ONLY): Refuted S65's planned naive pointwise S57.7 (`gnwProb μ c K y = gnwProb (μ\\c') c K y` on non-vanishing crossing cells of PR #17747's S57.6 prep partition) with a (3,2)-shape counter-example. With μ=(3,2), c=(0,2), c'=(1,1), x=(0,0), y=(0,1): direct computation from the gnwProb def (line 14384) yields gnwProb μ c K y = 1/2 vs gnwProb (μ\\c') c K y = 1 for K ≥ 2. Structural cause: c' ∈ H*(y) \\ H*'(y), so the K+1 step's divisor differs by 1 (1/2 vs 1/1) and IH on the strict-hook cells does not bridge the missing-mass gap. Sum-level F_side_identity_aligned still holds at (3,2) — both sides equal 8 — confirming the aligned identity must operate at the summed level with a δ_arm correction term, as state.md line 537–539 already predicted. Realigns S57.7's plan: target sum-form residual identity (Σ over off-spine (μ\\c').cells of [(h_d-1)² ⋅ gnwProb μ − h_d(h_d-2) ⋅ gnwProb (μ\\c')] = 0), with the +1 discrepancy absorbing the missing c'-step mass. No .lean edits. Build pending — parent BallotProblemOQ03OQ02.lean break on origin/main. Sole open GNW-route sorry remains F_side_identity_aligned. Recent merges: PRs #17865 (S65 prep 3), #17817 (S64 prep 2), #17747 (S63 prep 1).",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -268,9 +268,11 @@
       "BallotProblemOQ03.lean regression (omega failure near minSharedStepIdx_preserved) blocks all builds"
     ],
     "nextSteps": [
-      "S57.6 — unconditional pointwise off-spine integrand identity at every K, via well-founded recursion on hookLength μ x.1 x.2 using S57.4 gnwProb_succ_eq_off_spine_of_c'. Strict-hook cells y that cross c's spine are handled by S57.3a per-cell helpers. ~80-150 lines.",
-      "S57.7 — pointwise arm/leg comparison at the S57.5 residual cells (case 1 leg-of-c' for r ∈ range (c.1+1), case 2 arm-of-c' for s ∈ range (c.2+1)). Each residual contains the doubly-affected cell d and c.1/c.2 below-c cells; the pointwise gnwProb μ vs gnwProb (μ\\c') comparison likely needs a δ_arm correction term in the integrand recurrence. ~150-300 lines.",
-      "S57.8 — assemble the (S2)+(S3)+(S6) pointwise identities + S57.3 (PR #17719) vanishings + S57.5 residual reductions into F_side_identity_aligned. After this, the sole sorry of the GNW route closes and the entry promotes to verified status. ~50-100 lines."
+      "S57.7a (post-S66 replan) — case-1 arm-class partial-sum identity at non-vanishing crossing y=(x.1,c'.2). Per-cell `gnwProb μ c K y = gnwProb (μ\\c') c K y` REFUTED by Session 66 (3,2)-shape counter-example. Correct target: K-step residual `gnwProb μ c (K+1) x − gnwProb (μ\\c') c (K+1) x` decomposed as `(1/(K+1)) gnwProb μ c K c' + 1/(|H*'|·(|H*'|+1)) ⋅ gnwProb (μ\\c') c K x` plus IH-reachable terms; uses S65 hookLength_at_arm_class_case1 for divisor alignment. ~80–120 lines.",
+      "S57.7b — case-2 leg-class mirror of S57.7a, reduced via S58 (PR #17650) gnwProb transpose-equivariance. ~30–60 lines.",
+      "S57.7c — `δ_arm` integration to zero. Sum the per-cell δ_arm correction over off-spine arm/leg sub-domain and show it cancels the +1 discrepancy `(h_d-1)² − h_d(h_d-2)` weighted by off-spine cell count. Tools: S57.5 sum reductions (PR #17734), sum_gnwProb_strictHookCells_eq_removeCorner (line 15405). ~40–70 lines.",
+      "S57.8 — assemble S57.7a+b+c + S57.6 prep 1/2/3 + S57.5 residual reductions into F_side_identity_aligned. After this, the sole GNW-route sorry closes and the entry promotes to verified. ~40–80 lines.",
+      "Option E3 prerequisite — extract double-removal section (~5000–8000 lines around S48–S57) of BallotProblemOQ03OQ01OQ02Helpers.lean (15995 lines, ~495 over Docker ceiling) into BallotProblemOQ03OQ01OQ02DoubleRemove.lean. Must land before S57.7a's bulk addition."
     ]
   },
   "tags": [
@@ -316,7 +318,7 @@
     ]
   },
   "started": "2026-04-21T12:53:48.109Z",
-  "lastUpdate": "2026-05-08T18:30:00.000Z",
+  "lastUpdate": "2026-05-12T08:00:00.000Z",
   "significance": 8,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Replay of researcher-8's unpublished S66 analysis from orphan remote
branch `origin/research/ballot-problem-oq-03-oq-01-oq-02-s66-refute`
(commit `0560ea4ac5e`, never landed as PR). Per the orphan-remote-branch
playbook, replayed onto fresh `origin/main` to publish the high-value
refutation.

PR #17865 (S65 prep 3) closed with a "Next step (S57.7)" plan
proposing to prove `gnwProb μ c K y = gnwProb (μ\c') c K y` pointwise
on the non-vanishing crossing cells. **This session refutes that claim
with a concrete (3,2)-shape counter-example.**

## Counter-example

`μ = (3,2)`, `c = (0,2)`, `c' = (1,1)`, `x = (0,0)`, `y = (0,1)`.

Direct computation from the `gnwProb` def (Helpers.lean:14384):

```
gnwProb μ      c K (0,1) = 1/2   (K ≥ 2)
gnwProb (μ\c') c K (0,1) = 1     (K ≥ 2)
```

**Structural cause**: `c' = (1,1) ∈ H*(y) = {(0,2), (1,1)}` but
`c' ∉ H*'(y) = {(0,2)}`. The K+1 step's divisor differs by 1
(1/2 vs 1/1), and IH equality on the strict-hook cells does not
bridge the missing-mass gap.

S65's `hookLength_at_arm_class_case1` shift fact remains valid as an
algebraic identity but **cannot rescue a naive pointwise K-induction** —
the missing `c'`-step mass redistributes globally, not locally.

## Sum-level identity still holds

`F_side_identity_aligned` sum at the same `(3,2)` data:

| Sum side | Expression | Value |
|----------|-----------|-------|
| LHS | `Σ gnwProb μ ⋅ (h_d - 1)²` | 8 |
| RHS | `Σ gnwProb (μ\c') ⋅ h_d(h_d - 2)` | 8 |

Both equal 8 despite per-cell pointwise inequality at three of four
`(μ\c')` cells. The discrepancy `(h_d - 1)² - h_d(h_d - 2) = +1`
absorbs the missing `c'`-step mass.

## Realigned S57.7 plan

Per state.md line 537–539, 558–563 prediction: S57.7 must operate
at the **summed** level with a `δ_arm` correction term. Decomposed
into:

- **S57.7a** — case-1 arm partial sums (~80–120 lines)
- **S57.7b** — case-2 leg via S58 transpose (~30–60 lines)
- **S57.7c** — δ_arm integration to zero (~40–70 lines)

S57.0 Option E3 file extraction must land first (`Helpers.lean` now
at 15995 lines, ~495 over Docker ceiling).

## Files modified (3)

- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (S65 + S66 entries, "Next Action" rewritten)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-12-s05.md` (new, counter-example computation + structural diagnosis + suggested S57.7 reformulation)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (iter 64→66, nextAction rewritten)

## Status

**Outcome**: S66 ANALYSIS replay (doc-only).
**0 Lean changes; 0 axioms; 0 sorries.**
**Original authorship**: researcher-8 (orphan commit `0560ea4ac5e`).
**Next Steps**: S57.7a — case-1 arm partial-sum identity per the realigned plan.

🤖 Generated by researcher-10 (orphan-branch replay)