### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 25 — Chebyshev envelope lcmRange n ≤ 4^n · (n/2)^√n (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -1226,6 +1226,46 @@ example :
       ≤ (10 / 2) ^ Nat.sqrt 10 := by
   native_decide
 
+/-- **Chebyshev envelope assembly** (Iter 25): for `n ≥ 2`,
+    `lcmRange n ≤ 4^n · (n / 2)^√n`.
+
+    Combines Iter 16's primorial × correction-factor decomposition
+    (`lcmRange_eq_primorial_mul_prod_prime_pow_pred`) with Mathlib's
+    `primorial_le_4_pow` (the classical Erdős primorial bound) and
+    Iter 24's full correction-factor envelope
+    (`prod_prime_pow_pred_le_pow_sqrt`). The proof is a single
+    `Nat.mul_le_mul` after rewriting `lcmRange n` as the product of
+    the two factors.
+
+    Strategic significance: this is the FIRST end-to-end asymptotic
+    envelope on `lcmRange n` derived from prime-power structure
+    (rather than the trivial `≤ n^n` factorial route of Part 3). The
+    bound is asymptotically `4^n · 2^O(√n · log n)`, hence strictly
+    weaker than Hanson's target `3^n` but capturing the right `O(4^n)`
+    leading factor that any prime-power-based proof must produce.
+    Closing the remaining `(4/3)^n vs (n/2)^√n` gap requires a
+    sharper Chebyshev-style bound on the correction factor (or a
+    cancellation between primorial and correction that exploits the
+    Chebyshev `θ(n) ~ n` density — out of scope of this file).
+
+    Concrete numerics (sanity check):
+    * `n = 10`: LHS = `lcmRange 10 = 2520`, RHS = `4^10 · 5^3 =
+      1048576 · 125 ≈ 1.31 · 10⁸`. ✓ (2520 ≤ 131072000)
+    * `n = 20`: LHS = `232792560 ≈ 2.33 · 10⁸`,
+      RHS = `4^20 · 10^4 ≈ 1.10 · 10¹⁶`. ✓ -/
+theorem lcmRange_le_4_pow_mul_pow_sqrt {n : ℕ} (hn : 2 ≤ n) :
+    lcmRange n ≤ 4 ^ n * (n / 2) ^ n.sqrt := by
+  rw [lcmRange_eq_primorial_mul_prod_prime_pow_pred]
+  exact Nat.mul_le_mul (primorial_le_4_pow n)
+    (prod_prime_pow_pred_le_pow_sqrt hn)
+
+/-- **Concrete numerical witness** (Iter 25): at `n = 10`,
+    `lcmRange 10 = 2520 ≤ 4^10 · 5^3 = 131072000`.
+
+    Sanity check for `lcmRange_le_4_pow_mul_pow_sqrt`. -/
+example : lcmRange 10 ≤ 4 ^ 10 * (10 / 2) ^ Nat.sqrt 10 := by
+  native_decide
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,12 +4,78 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-12 (Iteration 24, researcher-1)
-**Iteration**: 24
+**Last Updated**: 2026-05-12 (Iteration 25, researcher-6)
+**Iteration**: 25
 
 ## Current Focus
 
-Iteration 24 (2026-05-12, this PR, researcher-1): **Full
+Iteration 25 (2026-05-12, this PR, researcher-6): **Chebyshev
+envelope assembly — first end-to-end asymptotic bound on
+`lcmRange n` from prime-power structure.** Chains Iter 16's
+`lcmRange_eq_primorial_mul_prod_prime_pow_pred` (Chebyshev
+decomposition factored through primorial), Mathlib's classical
+`primorial_le_4_pow` (Erdős primorial bound), and Iter 24's
+`prod_prime_pow_pred_le_pow_sqrt` (full correction-factor envelope)
+into a single multiplicative inequality. One new theorem + one
+`native_decide` witness example (+40 lines, sorry-free, axiom-free,
+single `Nat.mul_le_mul`):
+
+* `lcmRange_le_4_pow_mul_pow_sqrt {n : ℕ} (hn : 2 ≤ n) :
+  lcmRange n ≤ 4 ^ n * (n / 2) ^ n.sqrt` — the **Chebyshev
+  envelope** for `n ≥ 2`. Proof: rewrite via Iter 16 then chain
+  `primorial_le_4_pow n` and `prod_prime_pow_pred_le_pow_sqrt hn`
+  through `Nat.mul_le_mul`.
+* `example`: `lcmRange 10 ≤ 4^10 · 5^3 = 131072000` (`native_decide`
+  witness, the LHS is `2520`).
+
+### Strategic value
+
+Iter 25 is the **first asymptotic bound** on `lcmRange n` derived
+purely from prime-power structure (Parts 2–4 of the file). Until
+this iter, the only complete unconditional asymptotic envelope was
+`lcmRange n ≤ n^n` (Part 3, via factorials); Iter 16 supplied the
+multiplicative decomposition but stopped short of bounding both
+factors. The new bound is asymptotically `4^n · 2^O(√n · log n)`,
+which is:
+
+* **Strictly weaker than Hanson's target `3^n`** — `4^n` exceeds
+  `3^n` for all `n ≥ 1`, so this bound alone does NOT close the
+  axiomatized `hanson_bound`. It captures the right `O(4^n)` leading
+  factor that any prime-power-based proof must produce (the
+  primorial side), then loses ground on the small-prime correction.
+* **Strictly stronger than the factorial bound** — for `n ≥ ~14`,
+  `4^n · (n/2)^√n ≤ n^n` (the `4 ≤ n` margin compounds via
+  `4^n ≤ (n/2)^n / (n/8)^n`; the correction factor is sub-polynomial
+  in `n^n`). Concrete witness: at `n = 20`, our bound gives
+  `≈ 1.10 · 10¹⁶`, vs. `20! ≈ 2.43 · 10¹⁸` and `20^20 ≈ 1.05 · 10²⁶`.
+
+### Asymptotic gap analysis: `(4/3)^n vs (n/2)^√n`
+
+Hanson's `3^n` against our envelope reduces (taking logs) to:
+
+  `(n · log 2) vs (√n · log(n/2)) / log 3`
+
+The RHS grows as `√n · log n / log 3`, which is `o(n)` — so
+asymptotically, the correction factor is dwarfed by the `(4/3)^n`
+gap. Concretely, `(4/3)^n > (n/2)^√n` for all `n` large enough
+(around `n ≥ 320` per a continuous-extension calculation); for
+smaller `n`, the small-`n` numerical checks (`hanson_n1`–
+`hanson_n20`) close the gap. The route to closing `hanson_bound`
+via this envelope therefore requires:
+
+1. **Sharper correction-factor bound** — replace
+   `prod_prime_pow_pred_le_pow_sqrt` by a Chebyshev-density estimate
+   `≤ exp(O(√n))` (Chebyshev's `θ` lower bound), or
+2. **Cancellation between primorial and correction** — exploit the
+   fact that `primorial n ~ exp((1+o(1)) n)` is asymptotically
+   `e^n`, not `4^n`, leaving room to absorb the correction.
+
+Both routes are intrinsic Mathlib upstream work (Chebyshev's
+density theorem is not in v4.26.0).
+
+## Prior Iterations
+
+Iteration 24 (2026-05-12, researcher-1): **Full
 correction-factor envelope — direct in-file support reduction
 chained with Iter 23's small-prime envelope** — combines the
 support-reduction primitive `prime_pow_pred_eq_one_of_sq_lt`

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -31,21 +31,22 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T20:50:00Z",
-    "iteration": 23,
-    "focus": "Iter 23 (this PR, researcher-1): small-prime power-product envelope — LHS half of the Hanson bridge, without depending on PR #17619 (Iter 17 support-reduction, OPEN since 2026-05-09). Two new theorems: prod_prime_pow_pred_le_prod_div_prime_small (filtered Iter 19 — Finset.prod_le_prod of prime_pow_pred_le_div over the small-prime filter {p ≤ n+1 : p.Prime ∧ p² ≤ n}); and prod_prime_pow_pred_small_le_pow_sqrt (composition with Iter 22's (n/2)^√n envelope under 2 ≤ n). +107 lines (1140 → 1247), +2 theorems + 1 example (57 → 59). Sorries (0) / axiomCount (1) / definitions (1) unchanged.",
+    "iteration": 25,
+    "focus": "Iter 25 (this PR, researcher-6): Chebyshev envelope assembly — first end-to-end asymptotic bound on lcmRange n from prime-power structure. Chains Iter 16 (lcmRange = primorial × correction-factor), Mathlib's primorial_le_4_pow, and Iter 24's prod_prime_pow_pred_le_pow_sqrt into lcmRange_le_4_pow_mul_pow_sqrt: for n ≥ 2, lcmRange n ≤ 4^n · (n/2)^√n. One new theorem + one native_decide example, +40 lines, sorry-free, axiom-free, single Nat.mul_le_mul.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
-      "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
+      "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)",
+      "Iter 25 envelope (4^n · (n/2)^√n) is strictly weaker than Hanson's 3^n target; closing requires a sharper correction-factor bound (Chebyshev θ density, not in Mathlib v4.26.0) or primorial-vs-correction cancellation (PNT-equivalent)."
     ],
-    "nextAction": "Iter 24 candidate (direct in-file support-reduction lemma): replicate PR #17619's lcmRange_correction_supported_on_small_primes using Finset.prod_subset + Nat.log_lt_iff_lt_pow, collapsing the full-prime filter to the small-prime filter on Iter 19's LHS. Combined with Iter 23's envelope, gives the full correction-factor envelope ∏_{p ≤ n, p.Prime} p^(Nat.log p n - 1) ≤ (n/2)^√n. Iter 25+: assemble with Nat.primorial_le_4_pow for the structural Chebyshev envelope lcmRange n ≤ 4^n · (n/2)^√n. Iter 27 (asymptotic-threshold): find n₀ where 4^n · (n/2)^√n ≤ 3^n.",
+    "nextAction": "Iter 26: Sharper correction-factor bound replacing Iter 24's (n/2)^√n. Two routes: (a) Chebyshev θ density — bound the small-prime product by exp(O(√n)) via Mathlib's Chebyshev infrastructure (not yet in v4.26.0); (b) cancellation between primorial and correction — exploit primorial n ~ exp((1+o(1))n) ~ e^n (PNT-equivalent) rather than the loose 4^n. Iter 27 (asymptotic threshold): find n₀ where 4^n · (n/2)^√n ≤ 3^n, OR find n₀ where the sharper Iter 26 envelope drops below 3^n; combined with hanson_n1..n20 numerical witnesses, this would discharge hanson_bound for n ≥ n₀.",
     "attemptCounts": {
-      "total": 23,
-      "currentApproach": 5,
+      "total": 25,
+      "currentApproach": 7,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "ITERATING (iter 24). Iter 24 (researcher-1, this PR): added prod_prime_pow_pred_eq_small (support-reduction equality between full and small-prime correction-factor products) and prod_prime_pow_pred_le_pow_sqrt (FULL correction-factor envelope ∏_{p prime, p ≤ n+1} p^(Nat.log p n - 1) ≤ (n/2)^√n under 2 ≤ n) to BaselProblemOQ01OQ01OQ02OQ03.lean. Closes the small-vs-full filter gap left open by stalled PR #17619 (Iter 17). +108 lines, +2 theorems, sorry-free, axiom-free. Sorries (0), axiomCount (1), definitionCount (1) unchanged. Next: Iter 25 — Chebyshev envelope lcmRange n ≤ 4^n · (n/2)^√n via Iter 16 factorisation + Nat.primorial_le_4_pow.",
+    "progressSummary": "ITERATING (iter 25). Iter 25 (researcher-6, this PR): added lcmRange_le_4_pow_mul_pow_sqrt (Chebyshev envelope assembly: for n ≥ 2, lcmRange n ≤ 4^n · (n/2)^√n) to BaselProblemOQ01OQ01OQ02OQ03.lean. First end-to-end asymptotic bound on lcmRange n from prime-power structure (Parts 2–4). Chains Iter 16 (lcmRange = primorial · correction), Mathlib's primorial_le_4_pow, and Iter 24's prod_prime_pow_pred_le_pow_sqrt via Nat.mul_le_mul. +40 lines, +1 theorem + 1 native_decide example, sorry-free, axiom-free. The envelope is strictly weaker than Hanson's 3^n target (closing requires Chebyshev θ density or primorial-vs-correction cancellation; both await Mathlib upstream). Iter 24 (researcher-1, prior): added prod_prime_pow_pred_eq_small and prod_prime_pow_pred_le_pow_sqrt closing the small-vs-full filter gap. Next: Iter 26 — sharper correction-factor bound (Chebyshev θ density or primorial cancellation).",
     "builtItems": [
       "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:80",
       "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:87-98",


### PR DESCRIPTION
## Summary

**First end-to-end asymptotic envelope** on `lcmRange n` derived from prime-power structure.

Chains three previously-merged ingredients via a single `Nat.mul_le_mul`:
- **Iter 16** (`lcmRange_eq_primorial_mul_prod_prime_pow_pred`): the Chebyshev decomposition `lcmRange n = primorial n · ∏ p^(log_p n - 1)`
- **Mathlib** (`primorial_le_4_pow`): classical Erdős bound `primorial n ≤ 4^n`
- **Iter 24** (`prod_prime_pow_pred_le_pow_sqrt`, merged in #17955): full correction-factor envelope `∏ p^(log_p n - 1) ≤ (n/2)^√n` for `n ≥ 2`

## New theorem

```lean
theorem lcmRange_le_4_pow_mul_pow_sqrt {n : ℕ} (hn : 2 ≤ n) :
    lcmRange n ≤ 4 ^ n * (n / 2) ^ n.sqrt := by
  rw [lcmRange_eq_primorial_mul_prod_prime_pow_pred]
  exact Nat.mul_le_mul (primorial_le_4_pow n)
    (prod_prime_pow_pred_le_pow_sqrt hn)
```

Plus a `native_decide` witness at `n = 10`: `lcmRange 10 = 2520 ≤ 4^10 · 5^3 = 131072000`.

## Strategic significance

This is the **first asymptotic bound** on `lcmRange n` derived purely from prime-power structure (Parts 2–4 of the file). Until this iter, the only complete unconditional asymptotic envelope was the trivial `≤ n^n` factorial route (Part 3); Iter 16 supplied the multiplicative decomposition but stopped short of bounding both factors.

The envelope is asymptotically `4^n · 2^O(√n · log n)`:

- **Strictly weaker than Hanson's target `3^n`** — the `4^n` exceeds `3^n` for all `n ≥ 1`. Closing the axiomatized `hanson_bound` via this envelope requires either:
  - (i) a sharper correction-factor bound via Chebyshev's `θ` density (currently absent from Mathlib v4.26.0), or
  - (ii) cancellation between primorial and correction exploiting the PNT-equivalent `primorial(n) ~ e^n` (rather than the loose `4^n`).
- **Strictly stronger than the factorial bound** — for `n ≥ ~14`, `4^n · (n/2)^√n < n^n`. At `n = 20`, our envelope gives `≈ 1.10 · 10¹⁶`, vs. `20! ≈ 2.43 · 10¹⁸` and `20^20 ≈ 1.05 · 10²⁶`.

## Diff stat

```
proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean    | 40 ++++++++++++
research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md | 72 +++++++++++++++++++++-
src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json | 15 ++---
```

+40 Lean lines (1355 → 1395), +1 theorem, +1 `native_decide` example. Sorry-free, axiom-free. Single `Nat.mul_le_mul` proof.

## Build status

Marked **"build pending"** in the title following the precedent of Iter 24 (#17955) — the worktree's recursive `proofs/.lake` symlink forces Docker to fresh-clone Mathlib (~45 min, well beyond the standard timeout). The new theorem's proof is a single line invoking three theorems already verified on `origin/main`; no API drift, no novel tactics.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03` (deferred — see "Build status")
- [x] `Nat.mul_le_mul` signature verified against `lean4@master/src/Init/Data/Nat/Basic.lean:757`
- [x] `primorial_le_4_pow` signature verified against `mathlib4@2df2f0150c27/Mathlib/NumberTheory/Primorial.lean:66`
- [x] Predecessor theorems' types match the new theorem's RHS factors

🤖 Generated with [Claude Code](https://claude.com/claude-code)