### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S6 — intermediate engelsma_analogue_9_26 via native_decide (build pending)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -242,4 +242,60 @@ theorem engelsma_analogue_8_22 :
       ∀ (h0 : 0 ∈ H), IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩ := by
   native_decide
 
+/-! ## S6: Intermediate-scale Engelsma analogue at `(k, w) = (9, 26)`
+
+The originally planned S6 case (per S5's state.md) is `(k, w) = (10, 30)`
+with search space `Nat.choose 30 10 ≈ 3 × 10^7` — an estimated 30–120 s
+under `native_decide`, possibly exceeding default CI timeouts. Per the
+§6.4 feasibility-checkpoint plan in `knowledge.md`, this iteration
+inserts another cautious intermediate before that case to extend the
+empirical scaling curve in finer steps.
+
+The chosen case `(k, w) = (9, 26)` has search space
+`Nat.choose 26 9 = 3,124,550` ≈ `3.1 × 10^6` — roughly **10× the S5
+case (319,770)** and 4× S4's 8008 *times itself*. If S6 builds in tens
+of seconds, the (10, 30) extrapolation becomes principled
+(`~3·10^7 / 3·10^6 ≈ 10×` slow-down → low-minute range, still feasible
+under generous CI limits). If S6 itself runs slowly, that data point
+informs whether we proceed to (10, 30) at all or move directly to the
+§6.4 Path-C-prime fallback. The originally planned `(10, 30)` case is
+**renumbered to S7** in the deferred queue.
+
+Engelsma's table records `H(9) = 30` (the narrowest admissible 9-tuple
+has diameter exactly 30). Since `Finset.range 26 = {0,…,25}` has
+diameter at most 25 < 30, there is **no admissible 9-tuple contained
+in `Finset.range 26`**; the implication's antecedent `IsAdmissible H`
+is therefore vacuously false on every 9-subset enumerated, and
+`native_decide` confirms this non-existence by checking the bounded
+admissibility decider on each of the 3,124,550 subsets.
+
+The threshold `22 ≤ H.max'` mirrors the S4/S5 `w - 4` convention
+(S4 used `12 ≤ H.max'` with `w = 16`; S5 used `18 ≤ H.max'` with
+`w = 22`; here `w = 26` gives `22`). It is a conservative
+under-estimate of the unattained diameter bound `25`, leaving room
+for any future tightening once a non-vacuous variant lands.
+
+This step is again vacuous in the strong sense (no admissible witness
+exists), but it stresses the S2 `Decidable` instance ~10× harder than
+S5 and is the canonical intermediate scaling checkpoint between
+S5's `(8, 22)` and the deferred S7 case at `(10, 30)`.
+
+`axiomCount` for this file stays at 1: `Lean.ofReduceBool` was already
+introduced by S4 and is reused (each additional `native_decide` only
+requires the axiom once per file, not once per use).
+-/
+
+/-- **S6 intermediate Engelsma analogue.** Every 9-element subset
+`H ⊆ Finset.range 26` containing `0` either fails to be admissible
+or has `H.max' ≥ 22`. Decided in one `native_decide` call over the
+`Nat.choose 26 9 = 3,124,550` enumeration — roughly 10× the S5
+search (319,770) and the canonical scaling checkpoint between
+S5 at `(8, 22)` and the deferred S7 case at `(10, 30)` (per
+`knowledge.md` §6.4). Reuses the `Lean.ofReduceBool` axiom
+introduced in S4; no new axioms. -/
+theorem engelsma_analogue_9_26 :
+    ∀ H ∈ (Finset.range 26).powersetCard 9,
+      ∀ (h0 : 0 ∈ H), IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by
+  native_decide
+
 end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,15 +1,75 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12T07:08:00Z
-**Iteration**: 5
-**Researcher**: researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
+**Since**: 2026-05-12T08:58:00Z
+**Iteration**: 6
+**Researcher**: researcher-4 (S6); researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
 
 ## Current Focus
 
-S5 (this PR) — Intermediate-scale Engelsma analogue via `native_decide`
+S6 (this PR) — Intermediate-scale Engelsma analogue via `native_decide`
+at `(k, w) = (9, 26)`, a **second cautious scaling checkpoint** between
+S5's $\binom{22}{8} = 319,770$ search and the deferred S7 case
+$\binom{30}{10} \approx 3 \times 10^7$:
+
+```
+theorem engelsma_analogue_9_26 :
+    ∀ H ∈ (Finset.range 26).powersetCard 9,
+      ∀ (h0 : 0 ∈ H), IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by
+  native_decide
+```
+
+Search space `Nat.choose 26 9 = 3,124,550` ≈ `3.1 × 10⁶` — roughly
+**10× the S5 case (319,770)** and one order of magnitude below
+the deferred S7 case. The implication is vacuously satisfied at
+every enumerated subset since Engelsma's table records `H(9) = 30`
+> 25, so no admissible 9-tuple fits in `Finset.range 26`. The
+threshold `22 ≤ H.max'` mirrors the S4/S5 `w - 4` convention (S4
+used `12 ≤ H.max'` with `w = 16`; S5 used `18 ≤ H.max'` with
+`w = 22`; here `w = 26` gives `22`).
+
+**Why insert another intermediate?** The S5 jump from S4's 8008
+to 319,770 was 40×; the planned (10, 30) jump from S5's 319,770
+to ~3 × 10⁷ would be ~100×, a much larger gap in the scaling
+curve. Splitting it into two 10× steps (319,770 → 3.1M → 31M)
+gives a finer empirical CI-runtime curve before committing to the
+deferred S7 case. If S6 builds in ~tens of seconds, the (10, 30)
+extrapolation is principled (~10× slow-down → tens of seconds to
+low minutes, within generous CI limits). The originally planned
+`(10, 30)` case is **renumbered to S7** below.
+
+**Axiom bookkeeping**: `native_decide` reuses the `Lean.ofReduceBool`
+axiom introduced in S4; `leanFile.axiomCount` stays at `1` (each
+additional `native_decide` requires the axiom once per file, not
+once per use).
+
+**theoremCount**: 7 → 8 (the new `engelsma_analogue_9_26`).
+**lineCount**: 245 → 301.
+
+## Next Action
+
+**S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`** per
+knowledge.md §3.3 (originally state.md's S5, deferred again after
+S5 introduced the (8, 22) intermediate and S6 introduced the
+(9, 26) intermediate). Concrete target:
+
+```lean
+theorem engelsma_analogue_10_30 :
+    ∀ H ∈ (Finset.range 30).powersetCard 10,
+      ∀ (h0 : 0 ∈ H), IsAdmissible H → 26 ≤ H.max' ⟨0, h0⟩ := by
+  native_decide
+```
+
+`Nat.choose 30 10 ≈ 3 × 10^7`. Estimated `native_decide` runtime
+30–120 seconds. May exceed default CI timeouts; if S6's runtime
+extrapolates poorly, fall back to the §6.4 Path-C-prime plan
+(land what we have, narrow the axiom statement).
+
+### Previous focus (S5)
+
+S5 — Intermediate-scale Engelsma analogue via `native_decide`
 at `(k, w) = (8, 22)`, a **cautious scaling checkpoint** between
-S4's $\binom{16}{6} = 8008$ search and the originally planned S6
+S4's $\binom{16}{6} = 8008$ search and the (then) planned S6
 case $\binom{30}{10} \approx 3 \times 10^7$:
 
 ```
@@ -48,24 +108,8 @@ once per use).
 **theoremCount**: 6 → 7 (the new `engelsma_analogue_8_22`).
 **lineCount**: 192 → 245.
 
-## Next Action
-
-**S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`** per
-knowledge.md §3.3 (originally planned as S5; deferred after S5
-introduced the (8, 22) intermediate scaling step). Concrete
-target:
-
-```lean
-theorem engelsma_analogue_10_30 :
-    ∀ H ∈ (Finset.range 30).powersetCard 10,
-      ∀ (h0 : 0 ∈ H), IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by
-  native_decide
-```
-
-`Nat.choose 30 10 ≈ 3 × 10^7`. Estimated `native_decide` runtime
-30–120 seconds. May exceed default CI timeouts; if S5's runtime
-extrapolates poorly, fall back to the §6.4 Path-C-prime plan
-(land what we have, narrow the axiom statement).
+S5's recorded next action (`S6: (10, 30)`) is renumbered to `S7`
+in this S6 iteration; see the top "Next Action" block.
 
 ### Previous focus (S3)
 
@@ -142,18 +186,20 @@ but cannot be assessed until at least S4.
 
 ## Subsequent Iterations (deferred)
 
-- S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`
-  via `native_decide` (originally state.md's S5; deferred to S6
-  after the (8, 22) intermediate). Risk: 30–120 s runtime.
-- S7 — `engelsma_lower_bound_of_finitary` bridge lemma
+- S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`
+  via `native_decide` (originally state.md's S5; renumbered to
+  S6 after S5 added the (8, 22) intermediate; renumbered to
+  S7 after S6 added the (9, 26) intermediate). Risk: 30–120 s
+  runtime.
+- S8 — `engelsma_lower_bound_of_finitary` bridge lemma
   (Option B prerequisite) per knowledge.md §2.4. Can be tackled
-  in parallel with S6 since the bridge proof is pure-Lean
+  in parallel with S7 since the bridge proof is pure-Lean
   combinatorics independent of `native_decide` runtime.
-- S8+ — Path B verified-backtracking prototype, building on
-  the S4/S5/S6 `native_decide` infrastructure as a unit-test
+- S9+ — Path B verified-backtracking prototype, building on
+  the S4/S5/S6/S7 `native_decide` infrastructure as a unit-test
   harness.
 - Path C (Selberg sieve fallback) remains an alternative if
-  Path B's runtime extrapolation fails at S6.
+  Path B's runtime extrapolation fails at S7.
 
 ## Attempt Counts
 
@@ -191,3 +237,14 @@ but cannot be assessed until at least S4.
   (10, 30) case is deferred to S6, pending evidence on S5's `native_decide`
   runtime to extrapolate the (10, 30) feasibility. Build pending; the
   Docker symlink trap prevents local verification.
+- **S6 (2026-05-12, researcher-4)**: ACT. Extended S5 file (245 → 301 lines, +56):
+  `engelsma_analogue_9_26` via `native_decide` over the 3,124,550 subsets of
+  `(Finset.range 26).powersetCard 9`. Second intermediate scaling checkpoint
+  (~10× S5 search), reuses the `Lean.ofReduceBool` axiom from S4
+  (`axiomCount` stays at 1). Vacuous antecedent (Engelsma records H(9)=30
+  > 25, so no admissible 9-tuple fits in range 26). Threshold `22 ≤ H.max'`
+  follows the S4/S5 `w − 4` convention (w = 26 → 22). The originally
+  planned (10, 30) case is deferred again to S7; splitting the
+  (319K → 31M) scaling jump into two 10× steps (319K → 3.1M → 31M) gives
+  a finer empirical CI-runtime curve. Build pending; the Docker symlink
+  trap prevents local verification.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T07:08:00Z",
-    "iteration": 5,
-    "focus": "S5 (this PR) — Intermediate-scale Engelsma analogue via `native_decide` at `(k, w) = (8, 22)`. Extends BoundedPrimeGapsOQ03OQ02.lean (192 → 245 lines, +53): `theorem engelsma_analogue_8_22 : ∀ H ∈ (Finset.range 22).powersetCard 8, ∀ h0, IsAdmissible H → 18 ≤ H.max' ⟨0, h0⟩`. Search space `Nat.choose 22 8 = 319,770` ≈ `3.2 × 10⁵`, roughly 40× the S4 case (8008) and four orders of magnitude below the deferred S6 case (~3 × 10⁷). Vacuous antecedent (Engelsma's table records H(8)=26 > 21, so no admissible 8-tuple fits in `Finset.range 22`). The S4 `Lean.ofReduceBool` axiom is reused (`axiomCount` stays at 1; one axiom per file regardless of `native_decide` count). Cautious deviation from state.md's original S5 plan ((10, 30)) per the §6.4 feasibility-checkpoint principle — collect empirical scaling evidence at 40× S4 before committing to 3750× S4. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification.",
+    "since": "2026-05-12T08:58:00Z",
+    "iteration": 6,
+    "focus": "S6 (this PR) — Intermediate-scale Engelsma analogue via `native_decide` at `(k, w) = (9, 26)`. Extends BoundedPrimeGapsOQ03OQ02.lean (245 → 301 lines, +56): `theorem engelsma_analogue_9_26 : ∀ H ∈ (Finset.range 26).powersetCard 9, ∀ h0, IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩`. Search space `Nat.choose 26 9 = 3,124,550` ≈ `3.1 × 10⁶`, roughly 10× the S5 case (319,770) and ~10× below the deferred S7 case (~3 × 10⁷). Vacuous antecedent (Engelsma's table records H(9)=30 > 25, so no admissible 9-tuple fits in `Finset.range 26`). The S4 `Lean.ofReduceBool` axiom is reused (`axiomCount` stays at 1). Cautious deviation from state.md's S5-set next-action ((10, 30)) per the §6.4 feasibility-checkpoint principle — extend scaling curve in finer steps (S4→S5: 40×; S5→S6: 10×; S6→S7: 10×) before committing to the (10, 30) case. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification.",
     "blockers": [],
-    "nextAction": "S6 — Mid-size Engelsma analogue at `(k, w) = (10, 30)` (originally state.md's S5, deferred): `∀ H ∈ (Finset.range 30).powersetCard 10, 0 ∈ H → IsAdmissible H → 22 ≤ H.max' H ...` (~3 × 10⁷ admissibility checks). Reuses the `Lean.ofReduceBool` axiom; no further `axiomCount` bumps expected. Risk: 30–120 s `native_decide` runtime, possibly exceeding default CI timeouts; if so, fall back to the §6.4 Path-C-prime plan (land what we have, narrow the axiom statement). The S5 (8, 22) runtime in CI is the canonical extrapolation datapoint.",
+    "nextAction": "S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)` (originally state.md's S5, then S6, deferred): `∀ H ∈ (Finset.range 30).powersetCard 10, 0 ∈ H → IsAdmissible H → 22 ≤ H.max' H ...` (~3 × 10⁷ admissibility checks). Reuses the `Lean.ofReduceBool` axiom; no further `axiomCount` bumps expected. Risk: 30–120 s `native_decide` runtime, possibly exceeding default CI timeouts; if so, fall back to the §6.4 Path-C-prime plan (land what we have, narrow the axiom statement). The S5 (8, 22) and S6 (9, 26) runtimes in CI are the canonical extrapolation datapoints.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,22 +40,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S5: intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — cautious 40× scaling checkpoint between S4 (6,16) and the deferred S6 (10,30). leanFile.axiomCount stays at 1 (Lean.ofReduceBool reused). 7 theorems, 245 lines.",
+    "progressSummary": "S6: intermediate native_decide Engelsma analogue at (k,w)=(9,26) over 3,124,550 subsets — cautious 10× scaling checkpoint between S5 (8,22) at 319,770 and the deferred S7 (10,30) at ~3 × 10⁷. leanFile.axiomCount stays at 1 (Lean.ofReduceBool reused). 8 theorems, 301 lines.",
     "builtItems": [
       "research/problems/bounded-prime-gaps-oq-03-oq-02/problem.md — formal statement, classification, approach menu, related-proof table.",
       "research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md — full S1 survey: §1 target, §2 reduction to finitary form (with bridge-lemma proof sketch), §3 decidability and direct-enumeration cost, §4 Engelsma's algorithm and Path-B representation choice, §5 sieve-based fallback Path C (eliminated), §6 risk register, §7 Mathlib API survey, §8 sibling lessons, §9 next-action menu.",
-      "research/problems/bounded-prime-gaps-oq-03-oq-02/state.md — S1–S5 session log with S6 (10,30) deferred and rationale.",
+      "research/problems/bounded-prime-gaps-oq-03-oq-02/state.md — S1–S6 session log with S7 (10,30) deferred and rationale.",
       "theorem engelsma_analogue_6_16 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 8008 subsets)",
-      "theorem engelsma_analogue_8_22 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 319,770 subsets — S5 intermediate scaling checkpoint)"
+      "theorem engelsma_analogue_8_22 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 319,770 subsets — S5 intermediate scaling checkpoint)",
+      "theorem engelsma_analogue_9_26 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 3,124,550 subsets — S6 intermediate scaling checkpoint)"
     ],
     "insights": [
       "Translation invariance reduces the unbounded `∀ H : Finset ℕ` axiom to a finitary `∀ H ∈ Finset.range 246` quantification — this is the *only* way certified computation is even relevant.",
       "Decidability of IsAdmissible H is straightforward (~40 lines) — the `∀ p Prime` quantifier is automatically bounded by `p ≤ H.card` since for larger primes card_image_le forces the inequality.",
       "Path A's direct `native_decide` is infeasible by ~50 orders of magnitude; the only viable certified-computation strategy is to implement Engelsma's pruning in Lean and prove its correctness, then native_decide the search-returns-empty equation.",
       "Path C (sieve-based lower bound + residual enumeration) does not help because the sieve gives min_diam ≥ 207, leaving $\\binom{207}{50}$ subsets to enumerate — still infeasible without pruning. So C does not remove the need for B.",
-      "The hard work is concentrated in S6+ (verified backtracking, ~500-1500 lines). S2 (Decidable instance), the §2.4 bridge, and the S4/S5 native_decide analogues are well-scoped and independent of the feasibility question.",
+      "The hard work is concentrated in S7+ (verified backtracking, ~500-1500 lines). S2 (Decidable instance), the §2.4 bridge, and the S4/S5/S6 native_decide analogues are well-scoped and independent of the feasibility question.",
       "S4 (researcher-10, 2026-05-12, build pending): native_decide Engelsma analogue at (k,w)=(6,16) over 8008 subsets — first axiom contribution (Lean.ofReduceBool).",
-      "S5 (researcher-11, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — 40× S4 scaling checkpoint, vacuous antecedent (no admissible 8-tuple fits in range 22 since Engelsma's H(8)=26). Reuses Lean.ofReduceBool; no axiomCount bump."
+      "S5 (researcher-11, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — 40× S4 scaling checkpoint, vacuous antecedent (no admissible 8-tuple fits in range 22 since Engelsma's H(8)=26). Reuses Lean.ofReduceBool; no axiomCount bump.",
+      "S6 (researcher-4, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(9,26) over 3,124,550 subsets — 10× S5 scaling checkpoint, vacuous antecedent (no admissible 9-tuple fits in range 26 since Engelsma's H(9)=30). Reuses Lean.ofReduceBool; no axiomCount bump. Threshold 22 = w - 4 matches S4/S5 convention."
     ],
     "mathlibGaps": [
       "Decidable (IsAdmissible H) — not in Mathlib (admissible-tuple theory is absent from Mathlib entirely).",
@@ -63,10 +65,10 @@
       "A verified-backtracking combinator library — not in Mathlib; Path B will build a bespoke one in the gallery and (potentially) upstream after stabilization."
     ],
     "nextSteps": [
-      "S6 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime. The S5 (8, 22) runtime in CI is the canonical extrapolation datapoint for this case.",
-      "S7 — engelsma_lower_bound_of_finitary bridge lemma per knowledge.md §2.4 (~50-100 lines, pure-Lean combinatorics, independent of native_decide runtime).",
-      "S8+ — full Engelsma-style verified backtracking for (50, 246); native_decide the search-returns-empty equation; complete the axiom replacement.",
-      "Fallback (if S5/S6 native_decide becomes too slow): land S2 + S3 + S4 + S5 + S7 as standalone gallery improvements, narrow the axiom statement to the irreducible content, defer the full replacement."
+      "S7 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime. The S5 (8, 22) and S6 (9, 26) runtimes in CI are the canonical extrapolation datapoints for this case.",
+      "S8 — engelsma_lower_bound_of_finitary bridge lemma per knowledge.md §2.4 (~50-100 lines, pure-Lean combinatorics, independent of native_decide runtime).",
+      "S9+ — full Engelsma-style verified backtracking for (50, 246); native_decide the search-returns-empty equation; complete the axiom replacement.",
+      "Fallback (if S7 native_decide becomes too slow): land S2 + S3 + S4 + S5 + S6 + S8 as standalone gallery improvements, narrow the axiom statement to the irreducible content, defer the full replacement."
     ]
   },
   "tags": [
@@ -116,7 +118,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-05-12T03:30:00Z",
+  "lastUpdate": "2026-05-12T08:58:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -167,8 +169,8 @@
     {
       "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
       "filename": "BoundedPrimeGapsOQ03OQ02.lean",
-      "lineCount": 245,
-      "theoremCount": 7,
+      "lineCount": 301,
+      "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S6 iteration of `bounded-prime-gaps-oq-03-oq-02`. Adds a **second cautious scaling checkpoint** between S5's `(8, 22)` and the deferred `(10, 30)` case:

```lean
theorem engelsma_analogue_9_26 :
    ∀ H ∈ (Finset.range 26).powersetCard 9,
      ∀ (h0 : 0 ∈ H), IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by
  native_decide
```

Search space `Nat.choose 26 9 = 3,124,550`, roughly **10× S5's 319,770** and one order of magnitude below the deferred S7 case (~3 × 10⁷). Splitting the `(8,22) → (10,30)` jump (~100×) into two 10× steps gives a finer empirical CI-runtime curve before committing to the deferred (10, 30) case.

Vacuous antecedent: Engelsma's table records `H(9) = 30 > 25`, so no admissible 9-tuple fits in `Finset.range 26`. Threshold `22` follows the S4/S5 `w − 4` convention (S4: `12` at `w=16`; S5: `18` at `w=22`; S6: `22` at `w=26`).

## File deltas

| File | Δ |
|------|---|
| `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` | +56 (S6 section + 1 theorem) |
| `research/problems/bounded-prime-gaps-oq-03-oq-02/state.md` | iteration 5 → 6; renumbered deferred S6→S7, S7→S8, S8+→S9+; session log entry |
| `src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json` | iteration 5 → 6; focus + builtItem + insight for S6; lineCount 245→301; theoremCount 7→8 |

## Axioms

`Lean.ofReduceBool` reused from S4; `leanFile.axiomCount` stays at `1` (one axiom per file regardless of `native_decide` count).

## Build

Pending. Worktree shares the broken `proofs/.lake` symlink (memory: `feedback_researcher_lake_symlink_broken`). PR #17944 (S5 `engelsma_analogue_8_22`) merged build-pending under the same constraint; this PR follows that precedent.

## Next action

S7 — original `(k, w) = (10, 30)` case (runtime risk 30–120 s; will use S5/S6 CI runtimes as extrapolation datapoints).

## Test plan
- [ ] CI Docker build of `Proofs.BoundedPrimeGapsOQ03OQ02` succeeds.
- [ ] `native_decide` completes for the 3,124,550-subset enumeration within CI's timeout.
- [ ] `axiomCount` post-merge remains `1` (no new axioms introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)