### PR TITLE
research(area-of-circle-oq-05-oq-04): S2a ACT-A — complex Gaussian integral ∫_ℂ exp(-π·‖z‖²) dz = 1 (build verified)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
@@ -1,0 +1,205 @@
+/-
+Area of Circle OQ-05-OQ-04 (S2a): The Complex Gaussian Integral
+
+Proves the complex Gaussian identity
+
+    ∫_ℂ exp(-π · ‖z‖²) dz = 1
+
+i.e. the indicator that the Gaussian density `e^{-π |z|²}` on ℂ integrates
+to 1 against the standard Lebesgue measure on ℂ (induced by the canonical
+identification ℂ ≃ ℝ²).
+
+## Context (from `research/area-of-circle-oq-05-oq-04/problem.md`)
+
+The OQ source formula
+
+    ∫_{ℚ_p} e^{2πi ‖x‖_p} dx = 1
+
+is malformed for genuine p-adic reasons (the norm `‖·‖_p` is real-valued;
+the integrand carries no p-adic information; and Haar measure on ℚ_p is
+infinite). The S1 OBSERVE pass identified three well-defined repair targets:
+
+  * (C1) `∫_{ℤ_p} ψ_p dμ = 1` — trivial.
+  * (C2) `𝟙_{ℤ_p}` is self-Fourier under `(ψ_p, Haar μ(ℤ_p)=1)` — the
+         intended p-adic Gaussian analogue; needs Mathlib infrastructure
+         not yet upstreamed (standard additive character `ψ_p : ℚ_p → ℂ`,
+         explicit `MeasureTheory.Measure ℚ_p`).
+  * (C3) Tate / Igusa local zeta — far heavier.
+
+The OQ source also references the case "over ℂ", which is the immediate
+follow-on this file delivers. This is the "S2a safe bridge" recommendation
+of `research/area-of-circle-oq-05-oq-04/state.md`: ~50 lines, 0 sorries,
+0 axioms, downstream of existing Mathlib + parent infrastructure.
+
+## Proof Strategy
+
+The complex Gaussian reduces to a product of two real Gaussians via the
+measure-preserving identification ℂ ≃ ℝ × ℝ:
+
+1. Mathlib's `Complex.volume_preserving_equiv_real_prod` exhibits the
+   `MeasurableEquiv` `ℂ ≃ᵐ ℝ × ℝ`, `z ↦ (z.re, z.im)`, as a
+   measure-preserving map between `(volume : Measure ℂ)` and the product
+   measure on `ℝ × ℝ`.
+
+2. Pulling the integrand back via `MeasurePreserving.integral_comp'`,
+   `∫_ℂ exp(-π · normSq z) dz = ∫_{ℝ × ℝ} exp(-π · (x² + y²)) d(x,y)`.
+
+3. Factor the integrand: `exp(-π · (x² + y²)) = exp(-π x²) · exp(-π y²)`
+   (`Real.exp_add` after `mul_add` and `neg_add`).
+
+4. `MeasureTheory.volume_eq_prod` rewrites the volume on `ℝ × ℝ` as
+   `volume.prod volume`, after which `integral_prod_mul` factors the
+   double integral into a product of single integrals.
+
+5. Each single-variable factor is `∫ exp(-π · x²) dx = √(π/π) = 1`
+   by the parent file's `scaled_gaussian` at `a = π`.
+
+The whole proof is sorry-free and axiom-free.
+
+## Why this case but not the p-adic case
+
+The p-adic case (C2) is a multi-session attack that requires *first*
+contributing the missing Mathlib infrastructure (standard ψ_p and Haar
+on ℚ_p, two distinct upstream PRs). The complex case is essentially a
+2-line corollary of `integral_gaussian` plus Fubini, which is the
+appropriate single-session deliverable for tier-B / S2a.
+
+Parent: `AreaOfCircleOQ05OQ02.lean` (multivariate Gaussian, all proved).
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
+import Mathlib.MeasureTheory.Integral.Prod
+import Proofs.AreaOfCircleOQ05
+
+namespace ComplexGaussianCircle
+
+open MeasureTheory MeasureTheory.Measure Real Complex
+
+/-- The scalar π-weighted Gaussian integral: ∫ exp(-(π · x²)) dx = 1.
+
+Direct consequence of the parent file's `scaled_gaussian` with `a = π`:
+`∫ exp(-(π · x²)) = √(π / π) = √1 = 1`. -/
+theorem integral_pi_gaussian :
+    ∫ x : ℝ, Real.exp (-(Real.pi * x ^ 2)) = 1 := by
+  have h := GaussianIntegralCircle.scaled_gaussian Real.pi Real.pi_pos
+  rw [div_self (ne_of_gt Real.pi_pos), Real.sqrt_one] at h
+  exact h
+
+/-- Helper: the integrand factors as a product under the `ℂ ≃ᵐ ℝ × ℝ`
+identification.
+
+For `p : ℝ × ℝ`, `exp(-(π · (p.1² + p.2²))) = exp(-(π · p.1²)) · exp(-(π · p.2²))`. -/
+private lemma exp_factor (p : ℝ × ℝ) :
+    Real.exp (-(Real.pi * (p.1 ^ 2 + p.2 ^ 2))) =
+      Real.exp (-(Real.pi * p.1 ^ 2)) * Real.exp (-(Real.pi * p.2 ^ 2)) := by
+  rw [← Real.exp_add]
+  congr 1
+  ring
+
+/-- The complex Gaussian integral over ℂ with `b = π`:
+
+    ∫_ℂ exp(-π · ‖z‖²) dz = 1.
+
+Equivalent formulation (via `normSq_eq_norm_sq`): the Gaussian density
+`exp(-π · normSq z)` integrates to 1 against the canonical Lebesgue
+measure on ℂ. This is the "bonus complex case" from
+`problem.md` §"Complex case (over ℂ)" — the well-defined sibling of
+the malformed p-adic source formula.
+
+Proof: pull back along `Complex.measurableEquivRealProd` (measure-preserving),
+factor the integrand via `exp_factor`, and apply Fubini
+(`integral_prod_mul`) to get a product of two scalar π-Gaussians, each
+equal to 1 by `integral_pi_gaussian`. -/
+theorem complex_gaussian_integral :
+    ∫ z : ℂ, Real.exp (-(Real.pi * Complex.normSq z)) = 1 := by
+  -- Step 1: rewrite the integrand to expose (z.re, z.im) on ℂ side, since
+  -- `normSq z = z.re * z.re + z.im * z.im` matches `p.1^2 + p.2^2` after
+  -- `mul_self = sq`.
+  have h_re_im : ∀ z : ℂ,
+      Real.exp (-(Real.pi * Complex.normSq z)) =
+        Real.exp (-(Real.pi * (z.re ^ 2 + z.im ^ 2))) := by
+    intro z
+    congr 2
+    rw [Complex.normSq_apply, sq, sq]
+  simp_rw [h_re_im]
+  -- Step 2: transport ∫_ℂ to ∫_{ℝ × ℝ} via measurableEquivRealProd.
+  -- The function `g : ℝ × ℝ → ℝ` is `fun p => exp(-(π * (p.1^2 + p.2^2)))`.
+  -- Under the equivalence, `(measurableEquivRealProd z).1 = z.re` and
+  -- `(measurableEquivRealProd z).2 = z.im`, so we can rewrite the LHS as
+  -- `∫ z, g(measurableEquivRealProd z)`.
+  have h_pull :
+      ∫ z : ℂ, Real.exp (-(Real.pi * (z.re ^ 2 + z.im ^ 2))) =
+        ∫ p : ℝ × ℝ, Real.exp (-(Real.pi * (p.1 ^ 2 + p.2 ^ 2))) := by
+    have := Complex.volume_preserving_equiv_real_prod.integral_comp'
+      (g := fun p : ℝ × ℝ => Real.exp (-(Real.pi * (p.1 ^ 2 + p.2 ^ 2))))
+    -- `this : ∫ z, g (measurableEquivRealProd z) = ∫ p, g p`
+    -- and `measurableEquivRealProd_apply z = (z.re, z.im)`.
+    simpa using this
+  rw [h_pull]
+  -- Step 3: factor the integrand into a product, then apply Fubini.
+  simp_rw [exp_factor]
+  -- Step 4: `(volume : Measure (ℝ × ℝ)) = (volume : Measure ℝ).prod (volume : Measure ℝ)`
+  -- is `rfl` (`MeasureTheory.Measure.volume_eq_prod`), so `integral_prod_mul`
+  -- applies after a `volume_eq_prod` rewrite.
+  rw [volume_eq_prod ℝ ℝ, integral_prod_mul (μ := volume) (ν := volume)
+      (fun x => Real.exp (-(Real.pi * x ^ 2)))
+      (fun y => Real.exp (-(Real.pi * y ^ 2)))]
+  -- Step 5: each factor is 1 by `integral_pi_gaussian`; product `1 * 1 = 1`.
+  simp_rw [integral_pi_gaussian]
+  norm_num
+
+/-- Restated in terms of `‖z‖²` (preferred for downstream use): the
+Gaussian density `exp(-π · ‖z‖²)` on ℂ integrates to 1.
+
+This is `complex_gaussian_integral` with the integrand expressed via
+the analytic norm `‖z‖` instead of `Complex.normSq z`. The two forms are
+equivalent by `Complex.normSq_eq_norm_sq : normSq z = ‖z‖²`. -/
+theorem complex_gaussian_integral_norm :
+    ∫ z : ℂ, Real.exp (-(Real.pi * ‖z‖ ^ 2)) = 1 := by
+  have h_eq : ∀ z : ℂ,
+      Real.exp (-(Real.pi * ‖z‖ ^ 2)) =
+        Real.exp (-(Real.pi * Complex.normSq z)) := by
+    intro z
+    rw [Complex.normSq_eq_norm_sq]
+  simp_rw [h_eq]
+  exact complex_gaussian_integral
+
+/-! ## Status
+
+- `integral_pi_gaussian` : proved (direct from `scaled_gaussian`).
+- `complex_gaussian_integral` : proved (Fubini + measure-preserving equiv).
+- `complex_gaussian_integral_norm` : proved (corollary of the above).
+
+All theorems above are sorry-free and axiom-free.
+
+## Deferred — p-adic case (C2 in problem.md)
+
+The p-adic self-Fourier identity
+
+    (F 𝟙_{ℤ_p})(ξ) = 𝟙_{ℤ_p}(ξ),
+    so in particular `∫_{ℚ_p} 𝟙_{ℤ_p}(x) ψ_p(0 · x) dx = μ(ℤ_p) = 1`
+
+is the intended p-adic analogue (cf. `problem.md` §C2). Formalizing
+this requires two Mathlib milestones currently absent at v4.26.0:
+
+1. **Standard p-adic additive character** `ψ_p : ℚ_p → ℂ` with
+   `ψ_p|_{ℤ_p} = 1` and `ψ_p(p^{-n}) = e^{2πi · a_n}`. Mathlib's
+   `Mathlib.NumberTheory.Padics.AddChar` only treats `ℤ_p → R` characters
+   into a `ℤ_p`-algebra `R` — the *dual* direction.
+
+2. **Explicit `MeasureTheory.Measure ℚ_p`** with `μ(ℤ_p) = 1`. The
+   general Haar machinery in `Mathlib.MeasureTheory.Measure.Haar.Basic`
+   applies (ℚ_p is locally compact via `PadicInt.ProperSpace`), but the
+   specific normalised instance is not exposed.
+
+Once those are upstream, the proof of (C2) follows the same Fubini-style
+factorisation as `complex_gaussian_integral`, replacing the Gaussian
+integral on each real factor with the character-sum identity
+`∑_{a ∈ ℤ/p^k ℤ} e^{2πi a / p^k} = 0` for `k ≥ 1`, packaged ultrametrically.
+
+The complex case in this file is the "scalar" companion to that
+non-trivial p-adic Fourier-fixed-point statement.
+-/
+
+end ComplexGaussianCircle

--- a/research/area-of-circle-oq-05-oq-04/knowledge.md
+++ b/research/area-of-circle-oq-05-oq-04/knowledge.md
@@ -120,3 +120,51 @@ formal statements in `problem.md`. All paths below are verified by direct
   `Mathlib.MeasureTheory.Measure.Haar.Basic` with `μ(ℤ_[p]) = 1`. Likely target
   file: `Mathlib/NumberTheory/Padics/HaarMeasure.lean`.
 - Prove `𝟙_{ℤ_[p]}` is self-Fourier under those data.
+
+---
+
+## S2a (2026-05-12) — Complex case proved
+
+Status of the four candidates:
+
+| Candidate | Status after S2a |
+| --- | --- |
+| (C1) trivial character on ℤ_[p] | Still blocked — needs `ψ_p` |
+| (C2) self-Fourier of `𝟙_{ℤ_[p]}` | Still blocked — needs `ψ_p` + Haar on ℚ_[p] |
+| (C3) Tate / Igusa local zeta | Still far |
+| Complex Gaussian (bonus) | **PROVED** in `Proofs/AreaOfCircleOQ05OQ04.lean` |
+
+### Mathlib API confirmed at v4.26.0 (rev `2df2f015`)
+
+* `Complex.measurableEquivRealProd : ℂ ≃ᵐ ℝ × ℝ` and its `_symm_apply`
+  simp lemma. Source: `Mathlib/MeasureTheory/Measure/Lebesgue/Complex.lean`.
+* `Complex.volume_preserving_equiv_real_prod : MeasurePreserving …` — the
+  push-forward of `volume : Measure ℂ` along the equiv is the product
+  measure on `ℝ × ℝ`. Same file.
+* `MeasureTheory.volume_eq_prod (α β) [MeasureSpace α] [MeasureSpace β] :
+  (volume : Measure (α × β)) = (volume : Measure α).prod (volume : Measure β)`.
+  Source: `Mathlib/MeasureTheory/Measure/Prod.lean`.
+* `integral_prod_mul {L : Type*} [RCLike L] (f : α → L) (g : β → L) :
+  ∫ z, f z.1 * g z.2 ∂(μ.prod ν) = (∫ x, f x ∂μ) * ∫ y, g y ∂ν`. Source:
+  `Mathlib/MeasureTheory/Integral/Prod.lean`. Works for `L = ℝ` (used here).
+* `MeasurePreserving.integral_comp' {β} {ν} {f : α ≃ᵐ β} (h : ...)
+  (g : β → G) : ∫ x, g (f x) ∂μ = ∫ y, g y ∂ν`. Source:
+  `Mathlib/MeasureTheory/Integral/Bochner/Basic.lean`.
+
+### Mathlib API still missing (unchanged from S1)
+
+1. `ψ_p : ℚ_[p] → ℂ` standard additive character — needed for (C1)/(C2).
+2. Explicit `MeasureTheory.Measure ℚ_[p]` with `μ(ℤ_[p]) = 1` — needed
+   for any integral identity on `ℚ_[p]` /`ℤ_[p]`.
+
+### Lessons recorded
+
+* The `Complex.normSq z = z.re² + z.im²` identity is via
+  `Complex.normSq_apply`, *not* `Complex.normSq_def`; `sq` simp-collapses
+  `x * x` to `x ^ 2`.
+* The integrand `exp(-(π · (p.1² + p.2²)))` factors cleanly via
+  `← Real.exp_add` + `ring` after the appropriate `congr 1` step.
+* `integral_prod_mul` requires the codomain to be `RCLike`, which `ℝ`
+  satisfies, but Lean needs explicit `(μ := volume)` `(ν := volume)`
+  annotations to pick up the right product measure when both factors
+  are `volume : Measure ℝ`.

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -86,3 +86,129 @@ the axiomatised part records the open p-adic content.
 - Memory entry "[Researcher worktree claim-script setup]" was relevant:
   fresh worktree had no `.lean/state/` symlink and isolated `research/claims/`.
   Both fixed at session start.
+
+---
+
+## Session S2a — 2026-05-12 (researcher-8)
+
+### Mode
+
+**S2a ACT-A** — substantive Lean file: complex Gaussian identity, fully
+proved with 0 sorries and 0 axioms.
+
+### Inputs
+
+- S1 OBSERVE markdown (`problem.md`, `knowledge.md`, this file's S1 entry).
+- Parent file `proofs/Proofs/AreaOfCircleOQ05.lean` (`GaussianIntegralCircle`
+  namespace, exporting `scaled_gaussian : ∫ exp(-(a · x²)) dx = √(π/a)` for
+  `a > 0`).
+- Mathlib v4.26.0 (rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) — confirmed
+  presence of `Complex.volume_preserving_equiv_real_prod` in
+  `Mathlib.MeasureTheory.Measure.Lebesgue.Complex` and `integral_prod_mul`
+  in `Mathlib.MeasureTheory.Integral.Prod`.
+
+### Output
+
+New file: `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (~204 LOC, 3 theorems
++ 1 private lemma, **0 sorries, 0 axioms**).
+
+* `integral_pi_gaussian : ∫ x : ℝ, exp(-(π · x²)) = 1` — scalar
+  π-weighted Gaussian; immediate from `scaled_gaussian` + `√1 = 1`.
+* `exp_factor` (private) — `exp(-(π · (p.1² + p.2²))) =
+  exp(-(π · p.1²)) · exp(-(π · p.2²))` via `exp_add`.
+* `complex_gaussian_integral : ∫ z : ℂ, exp(-(π · normSq z)) = 1` —
+  main result; proof uses `Complex.volume_preserving_equiv_real_prod`
+  to transport to `ℝ × ℝ`, then `MeasureTheory.volume_eq_prod` +
+  `integral_prod_mul` to factor.
+* `complex_gaussian_integral_norm : ∫ z : ℂ, exp(-(π · ‖z‖²)) = 1` —
+  same statement re-expressed via `Complex.normSq_eq_norm_sq`.
+
+### Proof strategy (executed)
+
+1. Use `Complex.normSq_apply` to rewrite `normSq z = z.re² + z.im²`
+   (with `sq` collapsing `x*x` to `x^2`).
+2. Apply `Complex.volume_preserving_equiv_real_prod.integral_comp'` with
+   `g p = exp(-(π · (p.1² + p.2²)))`, transporting `∫_ℂ → ∫_{ℝ × ℝ}`.
+3. Rewrite the integrand on the product side via `exp_factor`.
+4. `MeasureTheory.volume_eq_prod ℝ ℝ` rewrites the volume on `ℝ × ℝ`
+   as `volume.prod volume`.
+5. `integral_prod_mul` factors `∫ p, f(p.1) · g(p.2) ∂(μ.prod ν) =
+   (∫ x, f x ∂μ) · (∫ y, g y ∂ν)`.
+6. Each factor is 1 by `integral_pi_gaussian`; product `1 · 1 = 1`.
+
+### Key API used
+
+* `MeasurePreserving.integral_comp' : (h : MeasurePreserving f μ ν) (g) →
+  ∫ x, g (f x) ∂μ = ∫ y, g y ∂ν` (from `Mathlib.MeasureTheory.Integral.Bochner.Basic`).
+* `Complex.measurableEquivRealProd : ℂ ≃ᵐ ℝ × ℝ`, `z ↦ (z.re, z.im)`.
+* `Complex.volume_preserving_equiv_real_prod : MeasurePreserving …`.
+* `MeasureTheory.volume_eq_prod : (volume : Measure (α × β)) =
+  (volume : Measure α).prod (volume : Measure β)`.
+* `integral_prod_mul : ∫ z, f z.1 · g z.2 ∂(μ.prod ν) = (∫ f) · (∫ g)`.
+* `GaussianIntegralCircle.scaled_gaussian` (parent file).
+
+### Build status
+
+**Build verified.** Docker build completed successfully:
+
+```
+✔ [3122/3122] Built Proofs.AreaOfCircleOQ05OQ04 (7.5s)
+Build completed successfully (3122 jobs).
+=== Build succeeded ===
+```
+
+(First attempt surfaced two small errors: `MeasureTheory.volume_eq_prod`
+should have been `MeasureTheory.Measure.volume_eq_prod` — fixed by
+adding `open MeasureTheory.Measure`; and `rw [integral_pi_gaussian,
+mul_one]` was tightened to `simp_rw [integral_pi_gaussian]; norm_num`
+to handle `1 * 1 = 1` cleanly. Both fixes are reflected in the
+committed file.)
+
+### Honesty notes
+
+- The complex case is a *low-difficulty* corollary — it does NOT advance
+  the deep open content (the p-adic self-Fourier identity C2). This is
+  the explicitly-recommended "S2a safe bridge" deliverable, not a
+  breakthrough.
+- All four key Mathlib lemmas (`measurableEquivRealProd`,
+  `volume_preserving_equiv_real_prod`, `volume_eq_prod`,
+  `integral_prod_mul`) were verified to exist at the pinned revision
+  before drafting.
+- The "bonus" framing from S1 still applies: this is a sibling to,
+  not a substitute for, the genuinely-open p-adic content.
+
+### Race check
+
+At S2a start (`gh pr list --search area-of-circle-oq-05-oq-04`):
+0 open PRs, 0 remote branches, 0 recent merges in last 30 min. S1
+(#17986) merged at 2026-05-12T08:13:54Z (~1h prior). Re-checked
+immediately before push.
+
+### Blockers
+
+None for the complex case (now proved). The p-adic case (C2) remains
+blocked on Mathlib infrastructure:
+
+1. Standard additive character `ψ_p : ℚ_p → ℂ` (not in v4.26.0).
+2. Explicit `MeasureTheory.Measure ℚ_p` with `μ(ℤ_p) = 1` (not exposed).
+
+Both are plausible small upstream PRs; either would unblock S2b/S3+.
+
+### Next Session Pointer
+
+Two options for S3 (in priority order):
+
+1. **S3 — Mathlib milestone 1: `ψ_p`**. Open a thin Mathlib PR adding
+   `StandardPadicCharacter.lean` with `ψ_p : ℚ_p → ℂ` and the basic
+   identities (`ψ_p|_{ℤ_p} = 1`, the explicit values on `p^{-n}`,
+   continuity). ~150 LOC. Unblocks (C1) and is the necessary first
+   step for (C2).
+
+2. **S3 — sorry-bearing scaffold (S2b)**. State (C2) as a Lean theorem
+   with `axiom padicAddChar : ℚ_p → ℂ` and `axiom padicHaarMeasure :
+   MeasureTheory.Measure ℚ_p` (placeholder declarations); prove (C1)
+   from those axioms; state (C2) with `sorry`. Documents the gap
+   formally without committing Mathlib API. ~100 LOC.
+
+The Lean infrastructure for the complex case is now complete; further
+work on this slug should target the p-adic content directly.

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -18,7 +18,7 @@
     "proven": [
       "Real Gaussian integral: integral over R of exp(-x^2) dx = sqrt(pi) (Mathlib integral_gaussian; already used in Proofs/AreaOfCircleOQ05.lean).",
       "Multivariate Gaussian via spectral theorem (Proofs/AreaOfCircleOQ05OQ02.lean).",
-      "Complex Gaussian: integral over C of exp(-pi |z|^2) dA(z) = 1 - accessible from existing Mathlib; to be added in S2a.",
+      "Complex Gaussian: integral over C of exp(-pi · normSq z) dz = 1 — PROVED in Proofs/AreaOfCircleOQ05OQ04.lean (S2a).",
       "Z_p is compact, Q_p is a proper metric space (Mathlib PadicInt.compactSpace, Padic.instProperSpace)."
     ],
     "open": [
@@ -30,11 +30,11 @@
   },
   "currentState": {
     "phase": "RESEARCH",
-    "since": "2026-05-12T08:03:22.732Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE: surface that the source formula is malformed; identify three well-defined candidate p-adic Gaussian/Fourier identities and audit Mathlib readiness. Next: S2 writes a small Lean file with the complex Gaussian identity (provable) plus a sorry-bearing scaffold for the p-adic self-Fourier statement (axiomatised).",
+    "since": "2026-05-12T09:21:46.000Z",
+    "iteration": 2,
+    "focus": "S2a ACT-A: proved complex Gaussian integral ∫_ℂ exp(-π · normSq z) dz = 1 via Fubini reduction to product of real Gaussians. New file Proofs/AreaOfCircleOQ05OQ04.lean (~200 LOC, 3 theorems + 1 private lemma, 0 sorries, 0 axioms). p-adic case (C2) remains deferred pending two Mathlib milestones (standard psi_p, Haar on Q_p).",
     "blockers": [],
-    "nextAction": "S2: create proofs/Proofs/AreaOfCircleOQ05OQ04.lean with (a) the complex Gaussian integral over the plane, proved via Fubini + integral_gaussian, and (b) axiom padicAddChar / sorry-stub for the self-Fourier identity 1_{Z_p} fixed by Fourier transform. See research/area-of-circle-oq-05-oq-04/{problem,knowledge,state}.md.",
+    "nextAction": "S2b or S3: state (C2) p-adic self-Fourier as a sorry-bearing theorem with axiom padicAddChar : Q_p → ℂ and a Haar-measure stub; record proof outline (character-sum vanishing on Z/p^k Z for k ≥ 1, packaged ultrametrically). Alternative: contribute the standard psi_p and Haar-on-Q_p as Mathlib PRs first.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete. The candidate-pool slug's source formula is malformed; three well-defined alternatives stated. Mathlib has PadicInt/ProperSpace/AddChar but lacks the standard C-valued additive character on Q_p and an explicit Haar measure on Q_p. Complex Gaussian companion identity is immediate; recommended as S2a target.",
+    "progressSummary": "S1 OBSERVE complete + S2a ACT-A complete with build verified. Complex Gaussian integral ∫_ℂ exp(-π · ‖z‖²) dz = 1 proven in new file AreaOfCircleOQ05OQ04.lean (3 theorems, 0 sorries, 0 axioms). Docker build passed (3122/3122 jobs). p-adic case (C2) blocked on two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar measure on ℚ_p).",
     "builtItems": [
       {
         "item": "S1 OBSERVE markdown set (problem.md, knowledge.md, state.md)",
@@ -55,13 +55,20 @@
       {
         "item": "Mathlib readiness audit (PadicInt/Padic/AddChar/Haar)",
         "session": "S1"
+      },
+      {
+        "item": "Proofs/AreaOfCircleOQ05OQ04.lean: integral_pi_gaussian (scalar π-Gaussian = 1), complex_gaussian_integral (∫_ℂ exp(-π · normSq z) = 1), complex_gaussian_integral_norm (the ‖z‖² form) — proven via Complex.volume_preserving_equiv_real_prod + integral_prod_mul (Fubini) + scaled_gaussian",
+        "session": "S2a"
       }
     ],
     "insights": [
       "||.||_p is real-valued, so e^{2*pi*i * ||x||_p} is a complex exponential of a real number and does not encode p-adic data - the source OQ formula is malformed.",
       "The 'right' p-adic Gaussian is 1_{Z_p}: it is the unique (up to scaling) fixed point of the p-adic Fourier transform under the self-dual choice of additive character and Haar measure, exactly as exp(-pi x^2) is the Fourier eigenfunction in the archimedean case.",
       "The polar-coordinates / area-of-circle derivation of integral over R of exp(-x^2) dx = sqrt(pi) has no direct p-adic analogue because there is no continuous rotation group on Q_p; the corresponding p-adic statement is the character-sum identity sum over a in Z/p^k Z of e^{2*pi*i a / p^k} = 0 for k >= 1, packaged ultrametrically.",
-      "Mathlib's PadicInt.AddChar covers Z_p -> R characters for Z_p-algebras R - this is the Cartier dual direction. The standard psi_p : Q_p -> C is in the opposite direction and absent from Mathlib v4.26.0."
+      "Mathlib's PadicInt.AddChar covers Z_p -> R characters for Z_p-algebras R - this is the Cartier dual direction. The standard psi_p : Q_p -> C is in the opposite direction and absent from Mathlib v4.26.0.",
+      "Complex.volume_preserving_equiv_real_prod (Mathlib v4.26.0, Mathlib.MeasureTheory.Measure.Lebesgue.Complex) gives a MeasurePreserving map ℂ ≃ᵐ ℝ × ℝ, so any (ℝ-valued) integral over ℂ can be transported to the product space and factored via integral_prod_mul.",
+      "The scalar π-weighted Gaussian ∫ exp(-π · x²) dx = √(π/π) = 1 specialises scaled_gaussian at a = π; this gives a clean unit factor on each axis of the complex factorisation.",
+      "The proof of the complex Gaussian = 1 needs zero new analysis - it is purely a transport + Fubini composition on top of existing real Gaussian / measure-preserving machinery already in Mathlib."
     ],
     "mathlibGaps": [
       "No padicAddChar : Q_p -> C (standard additive character with psi_p|_{Z_p} = 1, psi_p(p^{-n}) = e^{2*pi*i/p^n}).",
@@ -158,7 +165,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-12T08:03:22.732Z",
+  "lastUpdate": "2026-05-12T09:21:46.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -458,6 +465,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/AreaOfCircleOQ05OQ04.lean",
+      "filename": "AreaOfCircleOQ05OQ04.lean",
+      "lineCount": 204,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ04.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

S2a executes the explicitly-recommended **"S2a safe bridge"** deliverable
from `research/area-of-circle-oq-05-oq-04/state.md` (S1 OBSERVE merged in
PR #17986 ~1h prior): the complex case `∫_ℂ exp(-π · ‖z‖²) dz = 1`.

New file `Proofs/AreaOfCircleOQ05OQ04.lean` (~205 LOC, 3 theorems +
1 private lemma, **0 sorries, 0 axioms, build verified**).

## What S2a proves

- `integral_pi_gaussian : ∫ x : ℝ, exp(-(π · x²)) = 1` — scalar π-weighted
  Gaussian, immediate from `GaussianIntegralCircle.scaled_gaussian` + `√1 = 1`.
- `complex_gaussian_integral : ∫ z : ℂ, exp(-(π · Complex.normSq z)) = 1`
  — main result.
- `complex_gaussian_integral_norm : ∫ z : ℂ, exp(-(π · ‖z‖²)) = 1` —
  norm-form restatement via `Complex.normSq_eq_norm_sq`.

## Proof strategy

1. `Complex.normSq_apply` rewrites `normSq z = z.re² + z.im²`.
2. `Complex.volume_preserving_equiv_real_prod.integral_comp'` transports
   `∫_ℂ → ∫_{ℝ × ℝ}` via the measurable equivalence `z ↦ (z.re, z.im)`.
3. `Real.exp_add` factors the integrand into a product of single-variable
   Gaussians (private lemma `exp_factor`).
4. `MeasureTheory.Measure.volume_eq_prod ℝ ℝ` exposes the volume on
   `ℝ × ℝ` as `volume.prod volume`.
5. `integral_prod_mul` (Fubini) factors the double integral.
6. Each factor is 1 by `integral_pi_gaussian`.

## What is *not* advanced

The deep open content — the p-adic self-Fourier identity (C2 in
`problem.md`) — remains blocked on two Mathlib upstream contributions:

1. **Standard additive character** `ψ_p : ℚ_p → ℂ` (Mathlib v4.26.0
   exposes only the *dual* `ℤ_p → R` characters in
   `Mathlib.NumberTheory.Padics.AddChar`).
2. **Explicit `MeasureTheory.Measure ℚ_p`** with `μ(ℤ_p) = 1` (general
   Haar machinery applies via `PadicInt.ProperSpace`, but no normalised
   instance is exposed).

This PR is the explicitly-flagged S2a *safe bridge*, not a substitute for
solving (C2). The p-adic content remains the slug's real research target.

## Build status

**Verified.** Docker build via `./proofs/scripts/docker-build.sh
Proofs.AreaOfCircleOQ05OQ04` completed successfully:

```
✔ [3122/3122] Built Proofs.AreaOfCircleOQ05OQ04 (7.5s)
Build completed successfully (3122 jobs).
=== Build succeeded ===
```

(First build attempt surfaced two small errors:
`MeasureTheory.volume_eq_prod` was incorrectly unqualified — fixed by
adding `open MeasureTheory.Measure`; and an `rw [..., mul_one]` step
was tightened to `simp_rw + norm_num` for `1 * 1 = 1`. Both fixes are
in the committed file.)

## Test plan

- [x] Docker build verified (3122/3122 jobs).
- [ ] `#check ComplexGaussianCircle.complex_gaussian_integral` and
      `#check ComplexGaussianCircle.complex_gaussian_integral_norm` in
      downstream consumer to confirm API is exposed.
- [ ] Verify `Real.normSq_eq_norm_sq` linkage if downstream uses
      `‖z‖²` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)