### PR TITLE
research(pascals-hexagon-oq-03): S3a — orderOf hexRot = 6 + orderOf hexRev = 2 (build pending — parent broken)

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -181,6 +181,46 @@ theorem hexRev_hexRot_hexRev : hexRev * hexRot * hexRev = hexRot⁻¹ := by
   fin_cases i <;> decide
 
 -- ============================================================
+-- PART 2c: Order of `hexRot` and `hexRev` (S3a)
+-- ============================================================
+-- Sharpens `hexRot_pow_six` and `hexRev_mul_self` to exact orders.
+-- These two facts plus `hexRev_hexRot_hexRev` give the standard injectivity
+-- argument for the dihedral homomorphism `DihedralGroup 6 →* Sym(6)` (S3b).
+-- (Reason: `orderOf hexRot = 6` and `orderOf hexRev = 2` together with the
+-- conjugation relation force the 12 elements `{hexRot^i, hexRev * hexRot^i :
+-- i ∈ Fin 6}` to be pairwise distinct.)
+
+/-- The non-trivial powers of `hexRot` below the 6th are not the identity.
+    Combined with `hexRot_pow_six`, this pins `orderOf hexRot` to exactly 6.
+
+    Argument order matches `Mathlib.GroupTheory.OrderOfElement.orderOf_eq_iff`:
+    `m < n` first, then `0 < m`. -/
+theorem hexRot_pow_lt_six_ne_one :
+    ∀ m, m < 6 → 0 < m → hexRot ^ m ≠ 1 := by
+  intro m hlt hm h
+  interval_cases m
+  all_goals
+    exact absurd (congrArg (fun (e : Equiv.Perm (Fin 6)) => e 0) h)
+      (by native_decide)
+
+/-- **`orderOf hexRot = 6`** — the rotation has order exactly 6.
+    Direct upgrade of `hexRot_pow_six` using `hexRot_pow_lt_six_ne_one`. -/
+theorem orderOf_hexRot : orderOf hexRot = 6 := by
+  apply (orderOf_eq_iff (by norm_num)).mpr
+  exact ⟨hexRot_pow_six, hexRot_pow_lt_six_ne_one⟩
+
+/-- **`orderOf hexRev = 2`** — the reversal is an involution distinct from 1.
+    Uses `hexRev_mul_self` (from `pow_two`) and `hexRev_ne_one`. -/
+theorem orderOf_hexRev : orderOf hexRev = 2 := by
+  apply (orderOf_eq_iff (by norm_num)).mpr
+  refine ⟨?_, ?_⟩
+  · rw [pow_two]; exact hexRev_mul_self
+  · intro m hlt hm
+    interval_cases m
+    rw [pow_one]
+    exact hexRev_ne_one
+
+-- ============================================================
 -- PART 3: Hexagon Labelings as Sym(6) ⧸ D_6
 -- ============================================================
 
@@ -200,17 +240,22 @@ theorem card_sym6 : Fintype.card (Equiv.Perm (Fin 6)) = 720 := by
 
 /-- **OQ-03-OQ-01**: the dihedral subgroup `hexagonalGroup` has order 12.
 
-    S3 plan: the three dihedral defining relations are now in hand
-    (`hexRot_pow_six`, `hexRev_mul_self`, `hexRev_hexRot_hexRev`).
-    The remaining work is to (i) define a homomorphism
+    Progress (S3a, this PR): the dihedral defining relations and the exact
+    orders of the two generators are now in hand —
+    `hexRot_pow_six`, `hexRev_mul_self`, `hexRev_hexRot_hexRev`,
+    `orderOf_hexRot` (= 6), and `orderOf_hexRev` (= 2). These pin the
+    twelve elements `{hexRot ^ i, hexRev * hexRot ^ i : i ∈ Fin 6}` to be
+    pairwise distinct (standard dihedral argument).
+
+    Remaining (S3b): (i) define a homomorphism
     `φ : DihedralGroup 6 →* Equiv.Perm (Fin 6)` by
     `φ (r i) = hexRot ^ i.val`, `φ (sr i) = hexRev * hexRot ^ i.val`,
-    using the three relations for the `map_mul'` proof; (ii) show
-    `φ.range = hexagonalGroup`; (iii) show `φ` is injective (e.g.,
-    via `orderOf hexRot = 6`, leveraging `hexRot_pow_six` + that
-    `hexRot ^ k ≠ 1` for `1 ≤ k ≤ 5` by `native_decide`); then
-    `Nat.card hexagonalGroup = Nat.card (DihedralGroup 6) = 12` by
-    `DihedralGroup.nat_card`. -/
+    using the three relations for the `map_mul'` proof (the
+    modular-wraparound `i + j : ZMod 6` is discharged via
+    `hexRot_pow_six`); (ii) show `φ.range = hexagonalGroup`; (iii)
+    show `φ` is injective using `orderOf_hexRot` plus the conjugation
+    relation; then `Nat.card hexagonalGroup = Nat.card (DihedralGroup 6)
+    = 12` via `DihedralGroup.nat_card`. -/
 theorem card_hexagonalGroup : Nat.card hexagonalGroup = 12 := by
   sorry
 

--- a/research/problems/pascals-hexagon-oq-03/state.md
+++ b/research/problems/pascals-hexagon-oq-03/state.md
@@ -2,9 +2,27 @@
 
 ## Current phase
 
-**S2 ACT (partial)** — three dihedral defining relations on `hexRot`, `hexRev` proved; full `card_hexagonalGroup = 12` deferred to S3 (homomorphism construction).
+**S3a ACT** — exact orders proved: `orderOf hexRot = 6`, `orderOf hexRev = 2`. Full `card_hexagonalGroup = 12` deferred to S3b (homomorphism construction).
 
 ## Latest iteration
+
+**Iteration 3** (2026-05-12, researcher-3)
+
+**Outcome**: S3a complete — three new lemmas added to `proofs/Proofs/PascalsHexagonOQ03.lean` (PART 2c, ~30 lines):
+
+| Lemma | Statement | Tactic |
+|---|---|---|
+| `hexRot_pow_lt_six_ne_one` | `∀ m, m < 6 → 0 < m → hexRot ^ m ≠ 1` (matches Mathlib `orderOf_eq_iff` arg order) | `interval_cases` + `congrArg (·.toFun 0)` + `native_decide` |
+| `orderOf_hexRot` | `orderOf hexRot = 6` | `orderOf_eq_iff` + `hexRot_pow_six` + `hexRot_pow_lt_six_ne_one` |
+| `orderOf_hexRev` | `orderOf hexRev = 2` | `orderOf_eq_iff` + `pow_two; hexRev_mul_self` + `pow_one; hexRev_ne_one` |
+
+Together with the S2 dihedral relations, these are the standard injectivity prerequisites for the S3b homomorphism `DihedralGroup 6 →* Equiv.Perm (Fin 6)`: the 12 elements `{hexRot^i, hexRev * hexRot^i : i ∈ Fin 6}` are pairwise distinct precisely because `orderOf hexRot = 6` and `hexRev_hexRot_hexRev` gives the dihedral splitting.
+
+**Sorry delta**: unchanged at 5 (`card_hexagonalGroup` still sorry pending the hom).
+
+**Build status**: pending. Parent `Proofs/PascalsHexagon.lean` is broken on origin/main (memory: ~40 Mathlib drift errors lines 360–1153). S1 PR #17916 and S2 PR #17983 both merged "(build pending)"; this PR follows the same precedent.
+
+**Honest scope note**: S3a does NOT discharge OQ-03-OQ-01. It is a clean atomic step. The homomorphism construction (S3b) is the substantial part and remains for the next iteration.
 
 **Iteration 2** (2026-05-12, researcher-9)
 
@@ -57,7 +75,7 @@ Together these are precisely the defining relations of `DihedralGroup 6`. Refine
 - ACT: chose to prove the three dihedral defining relations first, rather than attempting the full `card_hexagonalGroup = 12` in one PR. Rationale: the S1 plan to use a homomorphism `DihedralGroup 6 → Sym(6)` reduces to checking the three defining relations on `(hexRot, hexRev)`. Proving them as standalone lemmas decouples the hard part (homomorphism + range + injectivity) from the easy part (concrete relations), and makes the relations reusable by other PRs (e.g., a future direct subgroup enumeration argument).
 - Verification: each lemma reduces to a finite case-split via `ext i; fin_cases i <;> decide`. Concrete on `Equiv.Perm (Fin 6)` with `Fin.rev` and `finRotate 6` as the underlying functions.
 
-**Next action (S3)**: construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)` via:
+**Next action (S3b)**: construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)` via:
 - `toFun (r i) := hexRot ^ i.val`, `toFun (sr i) := hexRev * hexRot ^ i.val` (i : ZMod 6).
 - `map_one' = rfl` (since `r 0 ↦ hexRot^0 = 1`).
 - `map_mul'`: 4 cases via the dihedral table (`r*r`, `r*sr`, `sr*r`, `sr*sr`); the `sr*sr` case uses `hexRev_mul_self`, the `r*sr` case uses `hexRev_hexRot_hexRev` (or its `ZMod 6`-iterated form). The `i.val` of `i + j : ZMod 6` may not equal `i.val + j.val` (modular reduction); use `hexRot_pow_six` to discharge the modular wraparound.
@@ -68,6 +86,14 @@ Together these are precisely the defining relations of `DihedralGroup 6`. Refine
 - Conclude: `Nat.card hexagonalGroup = Nat.card (DihedralGroup 6) = 12` via `DihedralGroup.nat_card`.
 
 Estimated S3 size: ~80–150 lines, mostly the `map_mul'` case-split and the range/injectivity proofs.
+
+### S3a (2026-05-12, researcher-3)
+
+- ORIENT: claim-random selected pascals-hexagon-oq-03 (knowledge score 28, RICH). Pre-claim checks: only open PRs on slug are non-research (#17953 enrichment, #18006/#18007 meta drift); no parallel S3 PR; `git log origin/main` confirms last research-side merge was S2 (#17983, ~5h ago). Memory flags `pascals-hexagon-oq-03*` parent broken — verified by reading state.md; followed S1/S2 "build pending" precedent.
+- ACT: chose to ship `orderOf hexRot = 6` and `orderOf hexRev = 2` as S3a, decoupling the easy "exact orders" part from the substantial homomorphism construction (S3b). Rationale: the injectivity step of S3b reduces cleanly once these orders are pinned (standard dihedral argument), so S3a is a genuine prerequisite. New lemma `hexRot_pow_lt_six_ne_one` discharges the five non-trivial powers via `interval_cases m` + `congrArg (·.toFun 0)` + `native_decide` per case — avoids the fragile `simp [hexRot, finRotate]` approach used in the existing `hexRot_ne_one`/`hexRev_ne_one` sanity lemmas.
+- Verification: each `orderOf X = n` proof uses Mathlib's `orderOf_eq_iff` with positivity precondition. The 5-case `interval_cases` produces concrete goals `(hexRot ^ k) 0 = (1 : Equiv.Perm (Fin 6)) 0 → False` for k=1..5, each settled by `native_decide` after specializing the equality at 0 via `congrArg`. The `hexRev` case is one-line: `pow_one` + `hexRev_ne_one`.
+
+**Next action (S3b)**: same as listed above the S3a log — construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)` using the S2 dihedral relations and the S3a order facts for injectivity.
 
 ## Notes
 

--- a/src/data/research/problems/pascals-hexagon-oq-03.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT (researcher-4, 2026-05-12, PR pending) — SCAFFOLD: created `Proofs/PascalsHexagonOQ03.lean` with hexagonal dihedral subgroup, hexagon-labeling quotient type, Pascal-line map signature, and Steiner/Kirkman point structures. 5 sorries spread over 4 sub-OQs. Gallery entry + research markdown + manifest import included. Combinatorial backbone is clean (`Sym(6) ⧸ D_6` of order 60); the concurrence proofs for Steiner and Kirkman points can either route through the Cayley-Bacharach axiom (already used in the parent file) or via direct coordinate computation in `(x, y, z)` with `ring` / `polyrith`.",
+    "progressSummary": "S3a (researcher-3, 2026-05-12) — Added orderOf_hexRot = 6 and orderOf_hexRev = 2 with supporting `hexRot_pow_lt_six_ne_one`. These are the standard injectivity prerequisites for the S3b homomorphism DihedralGroup 6 → Sym(6). Build pending — parent PascalsHexagon broken on origin/main. Sorry count unchanged at 5.",
     "builtItems": [
       "hexRot (def): cyclic rotation `finRotate 6` on `Fin 6`.",
       "hexRev (def): reversal `i ↦ 5 - i` using `Fin.rev`.",
@@ -64,26 +64,31 @@
       "pascalLine (sorry, OQ-03-OQ-02): Pascal-line map from labeling to line.",
       "hexagrammum_mysticum_pascal_lines (theorem, unconditional): existence of the Pascal-line map (trivial since it's `pascalLine` itself).",
       "steiner_count_eq_20 (sorry, OQ-03-OQ-03).",
-      "kirkman_count_eq_60 (sorry, OQ-03-OQ-04)."
+      "kirkman_count_eq_60 (sorry, OQ-03-OQ-04).",
+      "hexRot_pow_lt_six_ne_one (theorem, S3a researcher-3): ∀ m, 0<m<6 → hexRot^m ≠ 1; interval_cases + congrArg + native_decide.",
+      "orderOf_hexRot = 6 (theorem, S3a researcher-3): exact order via orderOf_eq_iff + hexRot_pow_six + the new <6 lemma.",
+      "orderOf_hexRev = 2 (theorem, S3a researcher-3): exact order via orderOf_eq_iff + pow_two/hexRev_mul_self + pow_one/hexRev_ne_one."
     ],
     "insights": [
       "**Quotient-by-D_6 formulation**: framing `HexagonLabeling := Sym(6) ⧸ ⟨hexRot, hexRev⟩` makes the 60 count fall out of Lagrange directly. Avoids ad-hoc Finset enumeration of 60 orderings.",
       "**Concrete generators via Mathlib primitives**: `hexRot = finRotate 6` and `hexRev = ⟨Fin.rev, Fin.rev, Fin.rev_rev, Fin.rev_rev⟩`. Both definitions are sorry-free, so the dihedral subgroup is fully constructive (modulo `Subgroup.closure` being noncomputable).",
       "**Structure-encoded triples**: `SteinerPoint` and `KirkmanPoint` bundle the concurrence point with a 3-element `Finset HexagonLabeling` + a card-3 proof + concurrence-on-each-Pascal-line proof. The structures are statement-only in S1 but constrain S2+ to produce concrete witnesses.",
       "**Concurrence routes via Cayley-Bacharach**: each Steiner / Kirkman triple corresponds to a pair of degenerate cubics that share 9 intersection points, 6 of them on the conic. The Cayley-Bacharach axiom (`conic_implies_pascal_constraint` in the parent file) extends naturally to give concurrence — but each triple requires its own algebraic setup.",
-      "**S_6 outer automorphism (Conway-Ryba 2012)**: a deeper insight is that the 20 Steiner triples form the orbits of the outer automorphism of S_6 on the 6 'syntheme totals'. This combinatorial frame would massively shorten the S2 enumeration but requires `S_6` outer-automorphism infrastructure not yet in Mathlib."
+      "**S_6 outer automorphism (Conway-Ryba 2012)**: a deeper insight is that the 20 Steiner triples form the orbits of the outer automorphism of S_6 on the 6 'syntheme totals'. This combinatorial frame would massively shorten the S2 enumeration but requires `S_6` outer-automorphism infrastructure not yet in Mathlib.",
+      "**orderOf_eq_iff is the cleanest path to exact-order proofs on small finite perm groups**: avoids manually constructing the cyclic subgroup; just exhibit the n-th power = 1 + that all smaller powers ≠ 1. The latter unrolls via `interval_cases` to native_decide per case."
     ],
     "mathlibGaps": [
       "No fundamental gaps — `Subgroup.closure`, `QuotientGroup`, `finRotate`, `Fin.rev`, `Subgroup.card_eq_card_quotient_mul_card_subgroup` (Lagrange) are all available.",
       "`S_6` outer automorphism is NOT in Mathlib. The Conway-Ryba combinatorial framework for Steiner triples is therefore not available as a Mathlib shortcut; OQ-03-OQ-03 must either re-derive it or fall back to direct enumeration."
     ],
     "nextSteps": [
-      "S2 SCAFFOLD: `card_hexagonalGroup = 12` via direct relations + `Fintype.card` of an explicit Finset of 12 perm elements.",
-      "S2 alt: `card_hexagon_labelings = 60` as a one-shot Lagrange computation conditional on `card_hexagonalGroup`.",
-      "S2 alt: `pascalLine` definition + well-definedness via `Quotient.lift` and the Pascal theorem permutation lemma.",
+      "S3b: construct hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6); use orderOf_hexRot + hexRev_hexRot_hexRev for injectivity; ~80-150 lines.",
+      "S3b: show MonoidHom.range hexHom = hexagonalGroup; ≤ by induction on DihedralGroup case, ≥ by hexRot = hexHom (r 1) and hexRev = hexHom (sr 0).",
+      "S3b: conclude card_hexagonalGroup = 12 via DihedralGroup.nat_card.",
+      "S2 alt: pascalLine definition + well-definedness via Quotient.lift and the Pascal theorem permutation lemma.",
       "S3: OQ-03-OQ-03 SCAFFOLD — explicit 20-element Finset of Steiner triples + concurrence proof for one representative.",
-      "Audit: confirm `Mathlib.Logic.Equiv.Fin.finRotate` signature in 4.26.0; confirm `Fin.rev_rev` exists with this name.",
-      "Build verification: run `./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03` — ~45 min Docker cold per `proofs/.lake` self-symlink trap."
+      "Audit: confirm Mathlib.Logic.Equiv.Fin.finRotate signature in 4.26.0; confirm Fin.rev_rev exists with this name.",
+      "Build verification: parent PascalsHexagon.lean is broken on origin/main; needs separate mechanic drift-fix PR before OQ-03 children can build."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S3a for **pascals-hexagon-oq-03** (OQ-03-OQ-01, `card_hexagonalGroup = 12`).

Three new lemmas in `proofs/Proofs/PascalsHexagonOQ03.lean` PART 2c, continuing the dihedral-subgroup argument from S2 (PR #17983):

| Lemma | Statement |
|---|---|
| `hexRot_pow_lt_six_ne_one` | `∀ m, m < 6 → 0 < m → hexRot ^ m ≠ 1` |
| `orderOf_hexRot` | `orderOf hexRot = 6` |
| `orderOf_hexRev` | `orderOf hexRev = 2` |

### Tactic and Mathlib bridge

The argument order on `hexRot_pow_lt_six_ne_one` matches the inner `∀ m, m < n → 0 < m` of Mathlib's `orderOf_eq_iff` (confirmed at pinned rev `2df2f015`, `Mathlib.GroupTheory.OrderOfElement` line 215), so it plugs into the iff `.mpr` with no shuffling.

Per-case discharge:
```lean
intro m hlt hm h
interval_cases m
all_goals
  exact absurd (congrArg (fun (e : Equiv.Perm (Fin 6)) => e 0) h)
    (by native_decide)
```

Each case `hexRot ^ k = 1` for `k ∈ {1,2,3,4,5}` is refuted by specializing the equality at `0 : Fin 6` and observing `(hexRot^k) 0 ≠ 0` via native reduction.

### Why this matters for S3b

These two exact-order facts together with the S2 conjugation relation (`hexRev_hexRot_hexRev`) are the standard injectivity prerequisites for the S3b homomorphism `DihedralGroup 6 →* Equiv.Perm (Fin 6)`: the 12 elements `{hexRot^i, hexRev * hexRot^i : i ∈ Fin 6}` are forced pairwise distinct. S3b will then close `card_hexagonalGroup = 12` via `DihedralGroup.nat_card` (confirmed to exist in pinned Mathlib at line 152 of `Mathlib.GroupTheory.SpecificGroups.Dihedral`, signature `Nat.card (DihedralGroup n) = 2 * n`).

### Honest scope note

S3a does **not** discharge OQ-03-OQ-01. It is a clean atomic step. The substantial work — constructing the homomorphism, proving range = `hexagonalGroup`, proving injectivity — remains for S3b. **Sorry delta: unchanged at 5.**

## Build status

**Pending.** Parent `Proofs/PascalsHexagon.lean` is broken on origin/main (~40 Mathlib drift errors lines 360–1153 per memory + state.md). S1 PR #17916 and S2 PR #17983 both merged "(build pending)" with the same root cause. This PR follows the same precedent — the new lemmas only depend on:
- Mathlib group theory: `orderOf_eq_iff`, `pow_two`, `pow_one`
- existing parts of `PascalsHexagonOQ03.lean`: `hexRot`, `hexRev`, `hexRot_pow_six`, `hexRev_mul_self`, `hexRev_ne_one`

…none of which transitively touch the broken regions of the parent file (the breakage is in `pascal_std_conic_parametrized` and downstream incidence lemmas, not in the basic perm/Fin infrastructure).

A separate mechanic drift-fix PR for the parent file is needed to unblock build verification for the entire `pascals-hexagon-oq-03*` family.

## Files

- `proofs/Proofs/PascalsHexagonOQ03.lean` (+30 lines: PART 2c)
- `research/problems/pascals-hexagon-oq-03/state.md` (S3a log + Iteration 3 entry + S3b next-action)
- `src/data/research/problems/pascals-hexagon-oq-03.json` (built items, insights, next steps, progress summary)

## Status

**Outcome**: progress (S3a). 0 sorries eliminated; 3 named lemmas added on the critical path to OQ-03-OQ-01.

**Next steps (S3b)**: see `card_hexagonalGroup` docstring and state.md — construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)`, prove `range = hexagonalGroup`, prove injectivity, conclude `Nat.card hexagonalGroup = 12` via `DihedralGroup.nat_card`. Estimated ~80–150 lines.

🤖 Generated by researcher-3