### PR TITLE
fix(meta): declare FeuerbachsTheoremDefs in additionalFiles (2 entries)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-04-22",
     "status": "verified",
     "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ04.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
     "tags": [
       "geometry",
       "feuerbach",
@@ -130,7 +133,10 @@
     "theoremCount": 12,
     "definitionCount": 1,
     "path": "Proofs/FeuerbachsTheoremDefsOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
@@ -64,6 +64,7 @@
     "theoremCount": 103,
     "definitionCount": 2,
     "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean",
       "Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     ]
   },
@@ -235,6 +236,7 @@
     "path": "Proofs/FeuerbachsTheoremOQ01.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean",
       "Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Declare `Proofs.FeuerbachsTheoremDefs` in `additionalFiles` for two
entries that import it. Per memory
`feedback_mechanic_core_helpers_additionalfiles`, non-Aristotle
single-level imports (Core/Helpers/Defs/ancestor) must be declared in
`meta.additionalFiles` to be picked up by `find-targets.ts:151` —
the auditor's auto-follow only handles Aristotle siblings.

## Evidence

| Slug | Imports | Already declared | Added |
|------|---------|-----------------|-------|
| feuerbachs-theorem-defs-oq-04 | `Proofs.FeuerbachsTheoremDefs` | (none) | `Proofs/FeuerbachsTheoremDefs.lean` |
| feuerbachs-theorem-oq-01 | `Proofs.FeuerbachsTheoremDefs` | `Proofs/FeuerbachsTheoremOQ01Aristotle.lean` | `Proofs/FeuerbachsTheoremDefs.lean` |

**No count drift**: `Proofs/FeuerbachsTheoremDefs.lean` has 0 sorries
and 0 axiom declarations, so adding it to `additionalFiles` is pure
plumbing. Both entries remain `status: verified`, `axiomCount: 0`,
`sorries: 0` (unchanged).

Mirrored in both `meta.additionalFiles` (the path read by find-targets)
and `leanFile.additionalFiles` (the dominant convention, ~143 entries).

## Scan results

Scanned all ~2200 gallery entries for single-level
`import Proofs.<X>(Core|Helpers|Defs)` not declared in either
`additionalFiles` path. Found exactly 3 cases:

- `feuerbachs-theorem-defs-oq-04` (this PR)
- `feuerbachs-theorem-oq-01` (this PR)
- `amgm-inequality-oq-02-oq-03` — **intentionally skipped**: its
  ancestor `AmgmInequalityOQ02.lean` has 2 axioms that would surface
  as latent count drift if added (current meta `axiomCount: 1`).

## Scope

- Only `meta.json` changes — no Lean source touched
- Two slugs only; both confirmed no open PRs touching their meta.json
- Both files pass JSON re-parse

---
Automated fix by lean-mechanic agent.