### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S6 — fano_converse_capacity composite (build pending)

### DIFF
--- a/proofs/Proofs/ShannonChannelCoding.lean
+++ b/proofs/Proofs/ShannonChannelCoding.lean
@@ -10,10 +10,11 @@
 
   Axioms: 3 (channel_coding_achievability, channel_coding_converse,
     bsc_capacity_eq)
-  Theorems: 12 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
+  Theorems: 13 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
     channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity,
     capacity_le_log_card, rate_of_code_pos, fano_inequality,
-    fano_converse_step, bsc_capacity_le_one, bsc_capacity_nonneg)
+    fano_converse_step, fano_converse_capacity,
+    bsc_capacity_le_one, bsc_capacity_nonneg)
   Sorries: 0
 -/
 import Mathlib
@@ -253,6 +254,75 @@ theorem fano_converse_step {α β : Type*} [Fintype α] [Fintype β]
   -- Fano: H(X|Y) ≤ h(P_e) + P_e · log(|α| - 1).
   have hfano := fano_inequality pXY hp hsum
   -- Combine algebraically.
+  linarith
+
+/-- **Fano-form converse single-letter bound with channel capacity.**
+
+    For a channel `ch : DMChannel α β` and a uniform input distribution
+    `inp : InputDist α` (i.e., `inp.p ≡ (Fintype.card α)⁻¹`),
+
+    `log |α| ≤ channelCapacity ch + h(P_e) + P_e · log(|α| - 1)`
+
+    where `P_e` is the Fano error term for the joint distribution
+    `jointDist ch inp`.
+
+    This is the canonical "uniform-input single-letter converse": for
+    the worst-case (uniform) codebook over `|α|` codewords, the
+    log-cardinality is bounded by `channelCapacity ch` plus the Fano
+    error penalty. Rearranges to `(1 - P_e) · log |α| ≤
+    channelCapacity ch + h(P_e)` once one absorbs the always-nonneg
+    correction `P_e · log(|α| / (|α| - 1)) ≥ 0` (for `|α| ≥ 2`); the
+    bare form stated here is the single-letter ingredient that block-
+    coding arguments invoke at each channel use of an `n`-block code.
+
+    The proof combines three ingredients:
+    * `fano_converse_step` (this file) — the abstract single-letter
+      identity under explicit uniform-entropy hypothesis;
+    * `entropy_of_uniform_eq_log_card` (`ShannonEntropy.lean`) —
+      discharges the uniform-entropy hypothesis;
+    * `channelMI_le_capacity` (this file, line 137) — replaces
+      `mutualInformation (jointDist ch inp)` with `channelCapacity ch`.
+
+    The X-marginal of `jointDist ch inp` is `inp.p`, since each row
+    `∑ y, ch.W x y = 1` (channel rows are probability distributions);
+    this is the bridge that lets `entropy_of_uniform_eq_log_card`
+    apply to the joint-distribution marginal. -/
+theorem fano_converse_capacity {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β] [Nonempty α]
+    (ch : DMChannel α β) (inp : InputDist α)
+    (h_inp_uniform : ∀ x : α, inp.p x = (Fintype.card α : ℝ)⁻¹) :
+    let P_e := 1 - ∑ y : β, ∑ x : α,
+                 jointDist ch inp (x, y) ^ 2 /
+                   (∑ x' : α, jointDist ch inp (x', y))
+    Real.log (Fintype.card α) ≤
+      channelCapacity ch +
+      InformationTheory.BinaryEntropy.h P_e +
+      P_e * Real.log ((Fintype.card α : ℝ) - 1) := by
+  intro P_e
+  -- The X-marginal of `jointDist ch inp` equals `inp.p`,
+  -- since `∑ y, ch.W x y = 1` (channel rows are probability distributions).
+  have h_marg : (fun x : α => ∑ y : β, jointDist ch inp (x, y)) = inp.p := by
+    funext x
+    show ∑ y : β, inp.p x * ch.W x y = inp.p x
+    rw [← Finset.mul_sum, ch.sum_one, mul_one]
+  -- The hypothesis `h_inp_uniform` says `inp.p` is the uniform constant.
+  have h_inp_eq : inp.p = fun _ : α => (Fintype.card α : ℝ)⁻¹ := funext h_inp_uniform
+  -- Discharge the `h_uniform` hypothesis of `fano_converse_step` using
+  -- `entropy_of_uniform_eq_log_card` (in `ShannonEntropy.lean`).
+  have h_uniform :
+      shannonEntropy (fun x : α => ∑ y : β, jointDist ch inp (x, y)) =
+        Real.log (Fintype.card α) := by
+    rw [h_marg, h_inp_eq]
+    exact entropy_of_uniform_eq_log_card
+  -- Apply `fano_converse_step` to the joint distribution.
+  have hfano_step :=
+    fano_converse_step (jointDist ch inp)
+      (jointDist_nonneg ch inp) (jointDist_sum_one ch inp) h_uniform
+  -- `mutualInformation (jointDist ch inp) = channelMI ch inp` by definition.
+  have hcap : mutualInformation (jointDist ch inp) ≤ channelCapacity ch := by
+    show channelMI ch inp ≤ channelCapacity ch
+    exact channelMI_le_capacity ch inp
+  -- Combine the two bounds.
   linarith
 
 /- ## Main theorems -/

--- a/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
@@ -1,94 +1,118 @@
 # Current State
 
 **Phase**: ACT-PROGRESS
-**Since**: 2026-05-12T05:30:00Z
-**Iteration**: 4
+**Since**: 2026-05-12T10:20:00Z
+**Iteration**: 6
 
 ## Current Focus
 
-Iteration 4 follows on from S3 (PR #17852, merged: `channelMI_le_capacity` +
-`capacity_le_log_card` named lemmas in `ShannonChannelCoding.lean`, with the
-parent meta.json `theoremCount` bumped 9 → 11). The next-action item from S3's
-state.md called for: *stand up `entropy_of_uniform_eq_log_card` (H(uniform) =
-log|α|) in `ShannonEntropy.lean`*, so that the Fano-step converse can write
-`(1 - P_e) log M ≤ channelMI ch inp + h P_e ≤ channelCapacity ch + h P_e`
-as a direct corollary of the existing infrastructure (Fano + chain rule +
-single-letter capacity bounds).
+S6 builds on S5 (PR #17887, merged: `fano_converse_step` — abstract
+single-letter identity under explicit uniform-entropy hypothesis) and
+S4 (PR #17879, merged: `entropy_of_uniform_eq_log_card` in
+`ShannonEntropy.lean`).
 
-This iteration delivers exactly that:
+This iteration assembles the **uniform-input single-letter converse
+with capacity bound** by combining the three already-merged
+ingredients:
 
-`entropy_of_uniform_eq_log_card` — for any finite nonempty alphabet `α`,
-`shannonEntropy (fun _ => (Fintype.card α : ℝ)⁻¹) = Real.log (Fintype.card α)`.
+`fano_converse_capacity` — for any DM channel `ch : DMChannel α β`
+and uniform input distribution `inp : InputDist α` (i.e.,
+`∀ x, inp.p x = (Fintype.card α)⁻¹`):
 
-The lemma sits in `ShannonEntropy.lean` (the foundational file) directly after
-`entropy_le_log_card`, providing the equality witness for the maximum-entropy
-bound. Statement is on the abstract constant function `fun _ => (card α)⁻¹`
-(not an `InputDist` structure), so it is reusable across every
-`Shannon*OQ*.lean` and `ShannonChannelCoding*.lean` file without forcing
-callers to import `ShannonChannelCodingOQ02OQ04`'s `uniformDist` wrapper.
+```
+log |α| ≤ channelCapacity ch + h(P_e) + P_e · log(|α| - 1)
+```
 
-Gallery counts on `shannon-entropy` are synced in this PR
-(theoremCount 23 → 24, lineCount 901 → 929).
+where `P_e := 1 - ∑ y, ∑ x, jointDist ch inp (x, y)² / (∑ x', jointDist ch inp (x', y))`
+is the Fano error term for the joint distribution `jointDist ch inp`.
+
+The lemma sits in `ShannonChannelCoding.lean` immediately after
+`fano_converse_step` (line 257 region), and is the natural composite
+that downstream block-coding converse arguments will invoke per
+channel use.
 
 ## Active Approach
 
-Proof strategy (direct calculation, 6 lines):
+Proof strategy (7 `have`s + a `linarith`):
 
-1. `hcard_pos : (0 : ℝ) < Fintype.card α` from `Fintype.card_pos`
-2. `hinv_ne : (Fintype.card α : ℝ)⁻¹ ≠ 0` from `inv_ne_zero`
-3. `unfold shannonEntropy` exposes the `-∑ x, if p x = 0 then 0 else ...` form
-4. `simp_rw [if_neg hinv_ne]` collapses the `if` (uniform value is nonzero)
-5. `Finset.sum_const + Finset.card_univ + nsmul_eq_mul` collapses the
-   constant sum to `|α| · ((|α|⁻¹) · log((|α|⁻¹)))`
-6. `Real.log_inv + ← mul_assoc + mul_inv_cancel₀ + one_mul + neg_neg`
-   simplifies to `Real.log (Fintype.card α)`
+1. **X-marginal of `jointDist ch inp` equals `inp.p`** — `funext` then
+   `show ∑ y, inp.p x * ch.W x y = inp.p x`; one `Finset.mul_sum`
+   pulls the constant out, then `ch.sum_one` and `mul_one` close it.
 
-The proof mirrors the tail of `entropy_le_log_card`'s proof (which already
-shows `-∑ p·log(1/|α|) = log|α|` for any distribution `p`) but specialises to
-the uniform case where `p ≡ (1/|α|)`, avoiding the Gibbs detour entirely.
+2. **Uniform-entropy discharge** — rewrite the X-marginal as `inp.p`,
+   then as the uniform constant `fun _ => (card α)⁻¹`, then quote
+   `entropy_of_uniform_eq_log_card` (S4, `ShannonEntropy.lean`).
 
-A sibling lemma `entropy_uniform_fintype` already exists in
-`ShannonChannelCodingOQ02OQ04.lean` (line 78), stated on
-`(uniformDist (α := α)).p`. Both lemmas are now available; the new general
-form is usable without importing OQ02OQ04.
+3. **Apply `fano_converse_step`** to `jointDist ch inp` with the
+   discharged uniform-entropy hypothesis. This gives
+   `log |α| ≤ mutualInformation (jointDist ch inp) + h(P_e) + P_e · log(|α|-1)`.
+
+4. **Apply `channelMI_le_capacity`** to replace
+   `mutualInformation (jointDist ch inp)` with `channelCapacity ch`.
+   The two are definitionally equal (`channelMI = mutualInformation ∘ jointDist`),
+   so a `show` redirect suffices to convert the type before applying
+   the inequality.
+
+5. **`linarith`** combines the two bounds.
+
+The proof is ~22 lines (theorem statement included) with 0 sorries
+and no new axioms. It is purely an algebraic composition of
+already-merged S3/S4/S5 ingredients.
 
 ## Blockers
 
-* `proofs/.lake` recursive self-symlink persists (per memory feedback) — S4
-  follows the "(build pending)" PR-title convention. The proof relies only on
-  standard Mathlib lemmas (`Real.log_inv`, `Finset.sum_const`,
-  `mul_inv_cancel₀`); the calling pattern is byte-identical to the tail of
-  the already-merged `entropy_le_log_card` proof. If a follow-up build flags
-  an issue, the fallback is to inline the explicit `field_simp [hcard.ne']`
-  step used in `entropy_uniform_fintype` (line 80–89 of OQ02OQ04).
+* `proofs/.lake` recursive self-symlink in this worktree persists
+  (per `feedback_researcher_lake_symlink_broken.md`); S6 follows the
+  established "(build pending)" PR-title convention for the
+  shannon-channel-coding-oq-02-oq-01-oq-01 series (S2/S3/S4/S5 all
+  merged build-pending).
+
+* The proof relies only on already-merged ingredients
+  (`channelMI_le_capacity` from S3 PR #17852, `entropy_of_uniform_eq_log_card`
+  from S4 PR #17879, `fano_converse_step` from S5 PR #17887). If the
+  Lean elaborator surfaces a let-binding mismatch on the abstract `P_e`,
+  the fallback is `dsimp only []` or `set P_e' := ... with hP_e` before
+  applying the two upstream lemmas.
 
 ## Next Action
 
-* S5 candidate: assemble the **Fano-form converse identity** in
-  `ShannonChannelCoding.lean`:
-  ```
-  log |α| ≤ mutualInformation pXY + h P_e + P_e * Real.log (|α| - 1)
-  ```
-  for any joint distribution `pXY` whose X-marginal is uniform
-  (`∀ x, ∑ y, pXY (x, y) = (Fintype.card α)⁻¹`).
+* **S7 candidate (asymptotic block-coding converse axiom discharge)**.
+  Combine `fano_converse_capacity` with the standard block-coding
+  observation that a length-`n` code with `M = |Fin code.M|`
+  codewords achieves rate `R = log M / n`. The converse axiom
+  `channel_coding_converse` in `ShannonChannelCoding.lean` (line 287)
+  asserts that if `R > capacity ch`, then error probability is bounded
+  below by some `δ > 0` for all sufficiently long codes. Discharging
+  this requires:
+  1. Per-letter joint distribution from a length-`n` code uniformly
+     distributed over `M` codewords (the encoder's induced input law
+     on `α^n`);
+  2. Memoryless-channel chain rule `I(X^n;Y^n) ≤ n · channelCapacity ch`
+     (data-processing on independent-channel-uses);
+  3. Apply S6's `fano_converse_capacity` to extract `R - capacity ch ≤
+     h(P_e)/n + P_e · log(|α|-1) + (1/n)·O(1)`;
+  4. Rearrange to bound `P_e` away from 0 for `R > capacity ch`.
 
-  This combines `chain_rule pXY` (MI = H(X) − H(X|Y)), the new
-  `entropy_of_uniform_eq_log_card` (H(X) = log|α| when X uniform), and the
-  `fano_inequality` theorem already in-file. The proof is a single
-  `linarith` step once the three ingredients are quoted as `have`s.
+  This is heavy work, likely requires a separate sub-slug for
+  step (2) (memoryless-channel chain rule).
 
-  Rearranges to the canonical `(1 − P_e) log |α| ≤ MI + h(P_e)`-style form
-  by adding `P_e · log(|α|/(|α|−1))` to both sides (always nonneg, so the
-  looser bound holds unconditionally).
+* **Alternative S7 (lighter)**: prove a clean rearrangement
+  `(1 - P_e) · log |α| ≤ channelCapacity ch + h(P_e)` for `|α| ≥ 2`
+  by absorbing the `P_e · log(|α| - 1) ≤ P_e · log |α|` slack. This
+  is the canonical "Shannon-form" converse bound stated in textbook
+  treatments and is a single algebraic manipulation downstream of S6.
 
-* Alternative S5: build the per-letter chain rule for the joint distribution
-  on the n-th product channel `(X^n, Y^n)`: `I(X^n;Y^n) = ∑_i I(X_i; Y_i)`
-  under memoryless channel. This is the second half of the converse and is
-  much heavier (likely needs its own `OQ-02-OQ-01-OQ-02` slug).
+* **Alternative S7 (sibling)**: prove `entropy_uniform_implies_uniform_marginal`
+  in `ShannonEntropy.lean` — the converse direction stating that if
+  `shannonEntropy p = Real.log (Fintype.card α)` then `p ≡ (card α)⁻¹`
+  (equality case of `entropy_le_log_card`). Useful for tightness
+  arguments in capacity-achieving inputs.
 
 ## Attempt Counts
 
-- Total attempts: 4
+- Total attempts: 6
 - Current approach attempts: 1
-- Approaches tried: 4 (S1 dispatcher; S2 axiom swap; S3 single-letter
-  capacity bounds; S4 uniform-entropy equality witness)
+- Approaches tried: 6 (S1 dispatcher; S2 axiom swap; S3 single-letter
+  capacity bounds; S4 uniform-entropy equality witness; S5 abstract
+  fano_converse_step; S6 uniform-input fano_converse_capacity with
+  channelCapacity bound).

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -39,10 +39,10 @@
       "Channel capacity definition (placeholder returning 0)",
       "Theorem statements for Fano inequality, achievability, converse, and BSC capacity (all placeholder stubs proving True)"
     ],
-    "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 11 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01). 0 sorries.",
+    "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 13 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01, single-letter Fano-form converse fano_converse_step + fano_converse_capacity). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 276,
+    "lineCount": 394,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",
@@ -51,7 +51,7 @@
       "Fano's inequality and the channel coding converse"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 8
   },
   "overview": {
@@ -172,9 +172,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 276,
+    "lineCount": 394,
     "axiomCount": 3,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 8,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -17,37 +17,43 @@
   },
   "currentState": {
     "phase": "ACT-PROGRESS",
-    "since": "2026-05-12T05:40:00Z",
-    "iteration": 5,
-    "focus": "S5: fano_converse_step named lemma in ShannonChannelCoding.lean — single-letter Fano-form converse log|α| ≤ I(X;Y) + h(P_e) + P_e·log(|α|-1) under abstract uniform-entropy hypothesis. Decoupled from S4 PR #17879.",
+    "since": "2026-05-12T10:20:00Z",
+    "iteration": 6,
+    "focus": "S6: fano_converse_capacity composite — uniform-input single-letter converse with channelCapacity bound. Combines S3 channelMI_le_capacity + S4 entropy_of_uniform_eq_log_card + S5 fano_converse_step into log|α| ≤ channelCapacity ch + h(P_e) + P_e·log(|α|-1).",
     "blockers": [],
-    "nextAction": "S6 candidate: discharge channel_coding_converse axiom (asymptotic regime) using fano_converse_step + channelMI_le_capacity + OQ02OQ03's converse_from_combined_bound algebra. Alt: prove entropy_uniform_implies_uniform_marginal converse.",
+    "nextAction": "S7 candidate: discharge channel_coding_converse axiom (asymptotic) via n-block extension; or lighter Shannon-form rearrangement (1-P_e)·log|α| ≤ C + h(P_e) by absorbing P_e·log(|α|-1) ≤ P_e·log|α| slack; or sibling entropy_uniform_implies_uniform_marginal converse in ShannonEntropy.lean.",
     "attemptCounts": {
-      "total": 5,
+      "total": 6,
       "currentApproach": 1,
-      "approachesTried": 5
+      "approachesTried": 6
     }
   },
   "knowledge": {
-    "progressSummary": "S5 (researcher-5, 2026-05-12): fano_converse_step lemma added to ShannonChannelCoding.lean (line 200 region, +47 lines). Proves log|\u03b1| \u2264 I(X;Y) + h(P_e) + P_e\u00b7log(|\u03b1|-1) under explicit uniform-entropy hypothesis, decoupled from S4 PR #17879. Parent gallery: theoremCount 11\u219212, lineCount 275\u2192324. Build pending.",
+    "progressSummary": "S6 (researcher-3, 2026-05-12): fano_converse_capacity composite lemma added to ShannonChannelCoding.lean after fano_converse_step. Combines S3 channelMI_le_capacity + S4 entropy_of_uniform_eq_log_card + S5 fano_converse_step into a single uniform-input bound log|\u03b1| \u2264 channelCapacity ch + h(P_e) + P_e\u00b7log(|\u03b1|-1) for a DM channel with uniform InputDist. Parent gallery: theoremCount 12\u219213. Build pending.",
     "builtItems": [
       "fano_from_oq03_std (ShannonChannelCodingOQ02OQ01.lean:201): bridge via InformationTheory.conditionalEntropy by definitional equality (rfl)",
       "fano_singleton_card_one (ShannonChannelCodingOQ02OQ01.lean:216): |\u03b1|=1 case via Subsingleton + h_nonneg",
       "fano_inequality_proved (ShannonChannelCodingOQ02OQ01.lean:288): dispatcher matching the fano_inequality axiom signature exactly",
-      "ShannonChannelCoding.lean: `theorem fano_inequality := FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum` (line 157) + `import Proofs.ShannonChannelCodingOQ02OQ01`"
+      "ShannonChannelCoding.lean: `theorem fano_inequality := FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum` (line 157) + `import Proofs.ShannonChannelCodingOQ02OQ01`",
+      "fano_converse_step (ShannonChannelCoding.lean:235 region): abstract single-letter identity log|\u03b1| \u2264 I(X;Y) + h(P_e) + P_e\u00b7log(|\u03b1|-1) under explicit h_uniform hypothesis (S5, PR #17887)",
+      "entropy_of_uniform_eq_log_card (ShannonEntropy.lean:233): H(uniform) = log|\u03b1| equality witness (S4, PR #17879)",
+      "fano_converse_capacity (ShannonChannelCoding.lean:290 region): uniform-input composite log|\u03b1| \u2264 channelCapacity ch + h(P_e) + P_e\u00b7log(|\u03b1|-1) for any DM channel with uniform InputDist (S6, this PR)"
     ],
     "insights": [
       "The two conditionalEntropy definitions are body-identical, hence rfl-equal; this lets the bridge use a term-mode `:=` instead of a tactic rewrite.",
       "For |\u03b1|=1, both sides of Fano simplify to 0: H(X|Y)=0 (degenerate ratio inside log), P_e=0 (singleton collapse), and (card \u03b1 : \u211d) - 1 = 0 annihilates the second RHS term.",
       "Empty \u03b1 is vacuous via Finset.univ_eq_empty + sum_empty contradicting hsum=1.",
       "fano_inequality_proved signature matches axiom byte-for-byte modulo the `(Fintype.card \u03b1 : \u211d)` cast (both files use the same cast form).",
-      "Term-mode reference `:= dispatcher pXY hp hsum` suffices for axiom->theorem swap when the dispatcher's body is defeq to the axiom's stated type (unused `let pX` in the axiom unfolds away; Real.log argument elaborates uniformly under expected type \u211d)."
+      "Term-mode reference `:= dispatcher pXY hp hsum` suffices for axiom->theorem swap when the dispatcher's body is defeq to the axiom's stated type (unused `let pX` in the axiom unfolds away; Real.log argument elaborates uniformly under expected type \u211d).",
+      "S6 bridge: the X-marginal of jointDist ch inp equals inp.p exactly, since each channel row \u2211 y, ch.W x y = 1 by the DMChannel structure axiom; one Finset.mul_sum factoring then closes the marginal identity by rfl on inp.p x.",
+      "channelMI ch inp = mutualInformation (jointDist ch inp) is a definitional equality (the `def channelMI`'s body), so a `show channelMI ch inp \u2264 channelCapacity ch` redirect on the goal of an inequality stated in terms of `mutualInformation (jointDist ch inp)` suffices to invoke `channelMI_le_capacity` without intermediate manipulation."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify Docker build of ShannonChannelCoding.lean and ShannonChannelCodingOQ02OQ01.lean; if term-mode proof fails for defeq reasons, switch to tactic-mode `:= by exact FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum` or `:= by simp only []; exact ...`.",
-      "Mechanic: re-sync any sibling meta.json entries that reference 4-axiom counts on shannon-channel-coding.",
-      "Follow-up question: can channel_coding_converse axiom be discharged similarly via fano_inequality + standard data-processing inequality?"
+      "Verify Docker build of ShannonChannelCoding.lean post-S6; the proof relies on already-merged S3/S4/S5 ingredients but final compilation lives with CI on this PR.",
+      "S7 candidate (heavy): discharge channel_coding_converse axiom (asymptotic block-coding regime) via S6 + memoryless-channel chain rule I(X^n;Y^n) ≤ n·channelCapacity ch.",
+      "S7 candidate (lighter): prove canonical Shannon-form rearrangement (1-P_e)·log|α| ≤ channelCapacity ch + h(P_e) by absorbing the always-nonneg slack P_e·(log|α| - log(|α|-1)) ≥ 0 for |α| ≥ 2.",
+      "S7 candidate (sibling): prove entropy_uniform_implies_uniform_marginal converse in ShannonEntropy.lean (equality case of entropy_le_log_card)."
     ]
   },
   "tags": [
@@ -70,15 +76,15 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.565Z",
-  "lastUpdate": "2026-05-12T05:40:00Z",
+  "lastUpdate": "2026-05-12T10:20:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 324,
-      "theoremCount": 12,
+      "lineCount": 394,
+      "theoremCount": 13,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds `fano_converse_capacity` to `ShannonChannelCoding.lean` after `fano_converse_step` (line 290 region): the **uniform-input single-letter converse with channelCapacity bound**.

For any DM channel `ch : DMChannel α β` and uniform input distribution `inp : InputDist α` (i.e., `∀ x, inp.p x = (Fintype.card α : ℝ)⁻¹`):

```
log |α| ≤ channelCapacity ch + h(P_e) + P_e · log(|α| - 1)
```

where `P_e := 1 - ∑ y, ∑ x, jointDist ch inp (x, y)² / pY(y)` is the Fano error term for the joint distribution `jointDist ch inp`. This is the canonical *single-letter Shannon-converse ingredient* that downstream block-coding arguments invoke per channel use.

## Proof (22 lines)

Composes three **already-merged** ingredients:

| Lemma | File | Source PR |
|---|---|---|
| `fano_converse_step` | `ShannonChannelCoding.lean:235` | S5 PR #17887 |
| `entropy_of_uniform_eq_log_card` | `ShannonEntropy.lean:233` | S4 PR #17879 |
| `channelMI_le_capacity` | `ShannonChannelCoding.lean:137` | S3 PR #17852 |

Two algebraic bridges:

1. **X-marginal of `jointDist ch inp` equals `inp.p`** — since each channel row `∑ y, ch.W x y = 1` by the `DMChannel` structure axiom; one `Finset.mul_sum` factoring closes this by `rfl` on `inp.p x`.
2. **`channelMI ch inp = mutualInformation (jointDist ch inp)`** by definition — a `show` redirect on the goal of the upstream inequality suffices to invoke `channelMI_le_capacity`.

Final `linarith` step combines the discharged uniform-entropy bound from `fano_converse_step` with the capacity-replacement bound from `channelMI_le_capacity`.

## Net change

| File | Change |
|------|--------|
| `proofs/Proofs/ShannonChannelCoding.lean` | +71 lines (1 docstring + 1 theorem; updated module header theorem-count) |
| `src/data/proofs/shannon-channel-coding/meta.json` | lineCount 324 → 394, theoremCount 12 → 13, assumptions string |
| `src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json` | phase/iteration/builtItems/insights/nextSteps/lineCount/theoremCount/lastUpdate |
| `research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md` | full S6 session entry |

- Sorries: 0 (unchanged)
- Axioms: 3 in `ShannonChannelCoding.lean` (unchanged: `channel_coding_achievability`, `channel_coding_converse`, `bsc_capacity_eq`)

## Status

**Outcome**: progress (single-letter uniform-input bound assembled; asymptotic block-coding converse axiom still open)

**Build status**: pending — `proofs/.lake` recursive self-symlink in this worktree persists (per `feedback_researcher_lake_symlink_broken.md`); CI will verify. The proof relies only on already-merged S3/S4/S5 ingredients in main + Mathlib's `Finset.mul_sum`/`mul_one`/`linarith`. Follows the established build-pending PR-title convention for the shannon-channel-coding-oq-02-oq-01-oq-01 series (S2/S3/S4/S5 all merged build-pending).

## Next steps (S7 candidates)

* **Heavy**: discharge `channel_coding_converse` axiom (asymptotic block-coding regime) via S6 + memoryless-channel chain rule `I(X^n;Y^n) ≤ n · channelCapacity ch`. Step (2) likely needs its own sub-slug.
* **Lighter**: prove canonical Shannon-form rearrangement `(1 - P_e) · log |α| ≤ channelCapacity ch + h(P_e)` by absorbing the always-nonneg slack `P_e · (log |α| - log(|α|-1)) ≥ 0` for `|α| ≥ 2`.
* **Sibling**: prove `entropy_uniform_implies_uniform_marginal` converse in `ShannonEntropy.lean` (equality case of `entropy_le_log_card`); useful for tightness arguments in capacity-achieving inputs.

🤖 Generated by researcher-3