### PR TITLE
research(weak-goldbach-oq-03): S1 OBSERVE — 4-approach survey for axiom elimination (doc-only)

### DIFF
--- a/research/problems/weak-goldbach-oq-03/knowledge.md
+++ b/research/problems/weak-goldbach-oq-03/knowledge.md
@@ -1,0 +1,281 @@
+# Knowledge — weak-goldbach-oq-03
+
+## S1 (researcher-5, 2026-05-12) — OBSERVE survey
+
+### Parent context
+
+The parent gallery proof `weak-goldbach` (Weak Goldbach Conjecture, Helfgott
+2013) is formalized in `proofs/Proofs/WeakGoldbach.lean` (480 lines, 24
+theorems, 15 definitions, 0 sorries). Despite the 0-sorry count, the file
+carries **9 axioms** plus **2 theorem-level `True`-stub placeholders** plus
+**1 placeholder definition** (`schnirelmannDensity := 0`), so the
+sorry-free claim is misleading without the axiom audit.
+
+### Full axiom + stub audit
+
+| # | Declaration | Line | Form | Feasibility |
+|---|-------------|------|------|-------------|
+| 1 | `vinogradov_ternary_goldbach` | 236 | axiom | HEROIC |
+| 2 | `helfgott_weak_goldbach` | 240 | axiom | HEROIC |
+| 3 | `circle_method_asymptotic` | 301 | axiom | HEROIC |
+| 4 | `schnirelmann_basis_theorem` | 340 | axiom | INTERMEDIATE (Mathlib gap) |
+| 5 | `ramare_six_primes` | 350 | axiom | HEROIC |
+| 6 | `tao_five_primes` | 355 | axiom | HEROIC |
+| 7 | `chen_theorem` | 389 | axiom | HEROIC |
+| 8 | `binary_goldbach_verified` | 395 | axiom | TRACTABLE (small range) / HEROIC (full) |
+| 9 | `helfgott_explicit_bound` | 425 | axiom | HEROIC |
+| 10 | `singular_series_positive` | 286 | theorem returning trivial `⟨1, one_pos⟩` | TRACTABLE (give real content) |
+| 11 | `vinogradov_minor_arc_bound` | 292 | theorem with `True` conclusion | TRACTABLE (give real content) |
+| 12 | `linnik_goldbach_representations` | 406 | theorem with `True` conclusion | TRACTABLE (give real content) |
+| 13 | `schnirelmannDensity` | 330 | placeholder def := 0 | TRACTABLE (use Mathlib) |
+
+Counting: **9 axioms** in the technical sense, but 4 additional declarations
+(items 10-13) carry placeholder/trivial content that should be upgraded
+before any "axiom-free" claim is honest.
+
+### Three feasibility tiers
+
+#### TRACTABLE (1-3 sessions each, S2-S5 candidates)
+
+- **(A) Mathlib `schnirelmannDensity` integration**: Replace the placeholder
+  `def schnirelmannDensity ... := 0` with `import Mathlib.Combinatorics.Schnirelmann`
+  and use Mathlib's real definition. Update `schnirelmann_basis_theorem`
+  statement accordingly. Add 1-3 small lemmas (e.g., density of primes is 0,
+  density of {0} is 0). **~80 lines Lean, single S2 session.**
+
+- **(B) Upgrade `True`-stub theorems**: Replace
+  - `vinogradov_minor_arc_bound : ... → True` with
+    `‖exponentialSumOverPrimes N α‖ ≤ Nat.primeCounting N` (triangle inequality + `‖exp‖ = 1`).
+  - `linnik_goldbach_representations : ... → True` with
+    `representationCount n ≤ (Nat.primeCounting n)^3` (cardinality of the
+    triple-product underlying `representationCount`).
+  - `singular_series_positive`: replace the trivial `⟨1, one_pos⟩` with an
+    actual constant tied to `n`, or fold this into a real `S(n)` definition.
+
+  **~40-60 lines Lean, single S2/S3 session.**
+
+- **(C) Small-range `binary_goldbach_verified` via `native_decide`**:
+  Split the axiom at `B = 10³` or `10⁴`:
+  - `theorem binary_goldbach_verified_small : ∀ n ≤ B, ...` by `native_decide`.
+  - `axiom binary_goldbach_verified_large : ∀ n with B < n ≤ 4·10¹⁸, ...`
+    (remains axiomatic; the actual Oliveira e Silva computation is 8 CPU-
+    months out of scope).
+  **~50 lines Lean + native_decide compile time, single S2/S3 session.**
+
+#### INTERMEDIATE (multi-session, weeks to months)
+
+- **(D) Schnirelmann's theorem proper**. Classical proof via:
+  1. **Schnirelmann inequality**: `σ(A + B) ≥ α + β − αβ` where `α := σ(A)`,
+     `β := σ(B)`. Provable from the elementary bound
+     `(A + B)(n) ≥ A(n) + B(n) − min(A(n), B(n))`.
+  2. **Iteration**: `σ(2A) ≥ 2α − α² = 1 − (1 − α)²`; inductively
+     `σ(2^k A) ≥ 1 − (1 − α)^(2^k)`, so for some `k₀`,
+     `σ(2^{k₀} A) > 1/2`.
+  3. **Density-half basis**: If `σ(A) > 1/2` then `A + A ⊇ ℕ⁺`. Proof:
+     for any `n ≥ 1`, `A(n) > n/2`, so by pigeonhole `A(n) + (n − A(n))`-
+     style cardinality argument, the sumset covers.
+  4. **Conclusion**: `A` is an additive basis of order `2^{k₀ + 1}`.
+
+  Reference: Nathanson, *Additive Number Theory* (Springer GTM 164),
+  Chapter 7 (Schnirelmann's theorem).
+
+  **~600-1000 lines Lean, 3-6 sessions, 2-4 months wall-clock.**
+
+#### HEROIC (multi-year, not S2-Sn candidates)
+
+- (E) `vinogradov_ternary_goldbach`, `helfgott_weak_goldbach`,
+  `circle_method_asymptotic`, `ramare_six_primes`, `tao_five_primes`,
+  `chen_theorem`, `helfgott_explicit_bound`: All require the **circle
+  method machinery** (major/minor arcs, Vinogradov's exponential-sum
+  bound on minor arcs, the Hardy-Littlewood singular series) plus
+  specific paper-length analytic arguments. Each is a 6-12 month
+  formalization project at the level of full Mathlib contributions.
+
+  None of these are S2-Sn candidates under OQ-03; the OQ should be
+  understood as "make progress on the TRACTABLE/INTERMEDIATE axioms;
+  HEROIC ones are aspirational."
+
+### Recommended path: Approach A in S2
+
+Approach A is the right S2 target:
+- Single PR, ~80 lines Lean.
+- Uses only stable Mathlib API at v4.26.0.
+- Removes the file's only placeholder *definition* (item 13), upgrading
+  one of the file's hidden flaws.
+- Exposes `Mathlib.Combinatorics.Schnirelmann` as the first gallery
+  consumer of that module — a Mathlib-coverage win.
+- Sets up Approach D (Schnirelmann's theorem proper) as the natural S3+
+  followup once Mathlib's TODO list closes that gap (either via this
+  OQ contributing back to Mathlib, or independently).
+
+### Load-bearing Mathlib API
+
+#### Mathlib.Combinatorics.Schnirelmann (v4.26.0)
+
+```lean
+-- The Schnirelmann density of a set A ⊆ ℕ
+noncomputable def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ
+
+lemma schnirelmannDensity_nonneg : 0 ≤ schnirelmannDensity A
+lemma schnirelmannDensity_le_one : schnirelmannDensity A ≤ 1
+lemma schnirelmannDensity_le_div {n : ℕ} (hn : n ≠ 0) :
+    schnirelmannDensity A ≤ #{a ∈ Ioc 0 n | a ∈ A} / n
+lemma schnirelmannDensity_mul_le_card_filter {n : ℕ} :
+    schnirelmannDensity A * n ≤ #{a ∈ Ioc 0 n | a ∈ A}
+lemma schnirelmannDensity_le_of_le {x : ℝ} (n : ℕ) (hn : n ≠ 0)
+    (hx : #{a ∈ Ioc 0 n | a ∈ A} / n ≤ x) :
+    schnirelmannDensity A ≤ x
+lemma schnirelmannDensity_le_of_notMem {k : ℕ} (hk : k ∉ A) :
+    schnirelmannDensity A ≤ 1 - (k⁻¹ : ℝ)
+lemma schnirelmannDensity_eq_zero_of_one_notMem (h : 1 ∉ A) :
+    schnirelmannDensity A = 0
+lemma schnirelmannDensity_le_of_subset {B : Set ℕ} [DecidablePred (· ∈ B)]
+    (h : A ⊆ B) : schnirelmannDensity A ≤ schnirelmannDensity B
+```
+
+**Mathlib TODO** (from the module docstring): "Prove Schnirelmann's
+theorem and Mann's theorem on the subadditivity of this density." —
+This OQ's Approach D contribution lines up directly with this TODO.
+
+#### Mathlib.NumberTheory.PrimeCounting
+
+```lean
+def Nat.primeCounting (n : ℕ) : ℕ  -- π(n) = |{p prime : p ≤ n}|
+```
+
+#### Mathlib.Data.Nat.Prime.Defs
+
+```lean
+def Nat.Prime (n : ℕ) : Prop
+instance Nat.decidablePrime : DecidablePred Nat.Prime
+```
+
+### Key insights
+
+1. **"0 sorries" ≠ "0 assumptions"**. The parent file's 0-sorry count is
+   misleading: 9 axioms + 2 `True`-stub theorems + 1 placeholder definition
+   sum to 12 unverified pieces of content. Any "axiom-free" claim must
+   address all 12.
+
+2. **The Mathlib gap on Schnirelmann's theorem is explicit**. The
+   `Mathlib.Combinatorics.Schnirelmann` module docstring lists this as
+   TODO. The OQ's Approach D doubles as a Mathlib contribution opportunity.
+
+3. **The placeholder definition `schnirelmannDensity := 0` is fixable
+   immediately**. Mathlib has the real definition; the parent file just
+   needs to import it. This is item 13 and dovetails with Approach A.
+
+4. **The 2 `True`-stub theorems are not "lies", they are placeholders**.
+   `vinogradov_minor_arc_bound` and `linnik_goldbach_representations`
+   currently prove nothing useful, but each can be upgraded to a *real*
+   (modest) bound via Mathlib API in 10-20 lines. The full Vinogradov
+   minor-arc bound is HEROIC, but a trivial-but-real bound is TRACTABLE.
+
+5. **Computational verification has a tractable lower tier**. Oliveira e
+   Silva verified binary Goldbach up to 4·10¹⁸ (8 CPU-months). We can't
+   reach that bound in Lean, but `native_decide` can comfortably handle
+   `n ≤ 10³` or `10⁴`, splitting the axiom into a TRACTABLE-small
+   theorem + a HEROIC-large residual axiom.
+
+6. **The Schnirelmann proof is well-documented**. Nathanson's *Additive
+   Number Theory* GTM 164 gives a complete combinatorial proof in
+   Chapter 7. The proof uses no analytic number theory beyond
+   elementary inequalities and the Cauchy-Schwarz-style density
+   manipulation. Estimated ~600-1000 Lean lines, all combinatorial.
+
+7. **No gallery proof currently imports `Mathlib.Combinatorics.Schnirelmann`**.
+   This OQ would be the first. The lack of consumers may explain why
+   Schnirelmann's theorem itself has been on Mathlib's TODO list for
+   years — no downstream pressure.
+
+8. **The OQ scope is asymmetric across axioms**. Of the 9 axioms,
+   ~80% (7/9) are HEROIC (multi-year), ~10% (1/9) is INTERMEDIATE
+   (months), and ~10% (1/9 — `binary_goldbach_verified`) is partly
+   TRACTABLE (small range) but HEROIC for full elimination. The S2-Sn
+   path must focus on the TRACTABLE items and the INTERMEDIATE
+   `schnirelmann_basis_theorem` (Approach D); the HEROIC tier is
+   long-term aspiration only.
+
+### Mathlib gaps identified
+
+1. **Schnirelmann's theorem** (`σ(A) > 0 → ∃ h, IsAdditiveBasis A h`):
+   On Mathlib TODO list (`Mathlib/Combinatorics/Schnirelmann.lean`
+   module docstring). Estimated ~600-1000 Lean lines. Approach D target.
+
+2. **Schnirelmann inequality** (`σ(A + B) ≥ α + β − αβ`): On the same
+   Mathlib TODO list (Mann's theorem is a sharpening). Approach D
+   sub-lemma.
+
+3. **Density-half basis** (`σ(A) > 1/2 → A + A ⊇ ℕ⁺`): Not in Mathlib;
+   sub-lemma of Approach D.
+
+4. **Vinogradov's exponential-sum bound** (the minor-arc inequality
+   `sup |S(α)| ≤ N / (log N)^A`): Not in Mathlib. HEROIC tier; would
+   require the Mathlib analytic-number-theory infrastructure (singular
+   series, Gauss sums, etc.) to be built first.
+
+5. **Hardy-Littlewood singular series**: Not in Mathlib. HEROIC tier;
+   parent file's `singular_series_positive` is a `⟨1, one_pos⟩`
+   placeholder, so even the trivial Mathlib statement is missing.
+
+### Edge cases / potential pitfalls
+
+- **Namespace clash**: Parent's `def schnirelmannDensity` (line 330) and
+  Mathlib's `schnirelmannDensity` will clash on `import Mathlib.Combinatorics.Schnirelmann`.
+  Approach A must remove the local def OR rename it. Removing is cleaner;
+  renaming risks confusion.
+
+- **`schnirelmann_basis_theorem` statement now refers to a different `σ`**:
+  After Approach A's import, the axiom's `schnirelmannDensity` resolves
+  to Mathlib's, not the placeholder's. The statement still typechecks
+  (both have type `Set ℕ → ℝ`), but the *content* is now meaningful (the
+  axiom asserts something real, not vacuously about a constant-0 function).
+
+- **`IsAdditiveBasis` is also parent-file-local**. If a future Mathlib
+  contribution defines `Mathlib.Combinatorics.IsAdditiveBasis`, we'd
+  prefer to use that. Currently the parent's definition is fine.
+
+- **`decide` vs `native_decide` for `binary_goldbach_verified_small`**:
+  Plain `decide` may stack-overflow at `B = 10⁴`; `native_decide` is the
+  safe choice. Need to verify `B = 10³` first as a baseline.
+
+- **`representationCount` is a triple product over `Finset.range (n + 1)`**:
+  For Approach B's `linnik_goldbach_representations` upgrade, the bound
+  `representationCount n ≤ (Nat.primeCounting n)^3` uses
+  `Finset.card_le_card` on `(primesUpTo n)^3 ⊇ {(p,q,r) : p+q+r=n, primes}`.
+  Should be straightforward.
+
+### Next session expectations (S2 candidate)
+
+**S2 (any researcher): Approach A** — Mathlib `schnirelmannDensity` integration.
+Three changes to `proofs/Proofs/WeakGoldbach.lean`:
+
+1. Add `import Mathlib.Combinatorics.Schnirelmann` at the top.
+
+2. Remove the placeholder
+   ```lean
+   def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ := 0
+   ```
+   (lines ~329-332).
+
+3. Add 1-3 small lemmas using the Mathlib API:
+   ```lean
+   /-- The Schnirelmann density of the set of primes is 0
+       (since 1 ∉ {primes}). -/
+   lemma schnirelmannDensity_primes_eq_zero :
+       schnirelmannDensity {n : ℕ | Nat.Prime n} = 0 :=
+     schnirelmannDensity_eq_zero_of_one_notMem (by decide : ¬ Nat.Prime 1)
+   ```
+
+4. (Optional, defer to S3) Re-verify that `schnirelmann_basis_theorem`
+   axiom statement still parses and that downstream lemmas using it (if
+   any) still typecheck.
+
+**S2 deliverable**: 1 PR, ~80 lines net (1 import + 1 removal + 1-3 lemmas),
+single session, build-verified via `./proofs/scripts/docker-build.sh
+Proofs.WeakGoldbach` (Mathlib import requires fresh build given the new
+module dependency).
+
+**S3+ candidates**: Approach B (True-stub upgrades), Approach C
+(`native_decide` for small range), then Approach D (Schnirelmann's
+theorem proper, multi-session).

--- a/research/problems/weak-goldbach-oq-03/problem.md
+++ b/research/problems/weak-goldbach-oq-03/problem.md
@@ -1,0 +1,475 @@
+# Problem: Formalize Helfgott's proof of weak Goldbach without axioms
+
+## Statement
+
+### Plain Language
+
+The parent gallery proof `weak-goldbach` (Weak Goldbach Conjecture, Helfgott
+2013: every odd integer `n > 5` is a sum of three primes) is formalized in
+`Proofs/WeakGoldbach.lean` (480 lines, 24 theorems, 0 sorries) but carries
+**9 axioms** encoding the deep analytic ingredients of the proof.
+
+This OQ asks whether — and how — these axioms can be progressively discharged
+so that the gallery's `weak-goldbach` entry moves from `axiomatized` toward
+`verified`. Full elimination is a multi-year effort; this OQ identifies the
+tractable entry points and proposes a phased plan.
+
+### Formal Statement
+
+Eliminate the following 9 axioms in `Proofs/WeakGoldbach.lean` by replacing
+each with a Lean-level proof or a stronger Lean-level construction:
+
+```lean
+axiom vinogradov_ternary_goldbach :
+    ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Odd n → IsSumOfThreePrimes n
+axiom helfgott_weak_goldbach : WeakGoldbachConjecture
+axiom circle_method_asymptotic :
+    ∀ ε > 0, ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Odd n →
+      (representationCount n : ℝ) > (n : ℝ) ^ 2 / ((Real.log n) ^ 3 * 2) * (1 - ε)
+axiom schnirelmann_basis_theorem (A : Set ℕ) [DecidablePred (· ∈ A)] :
+    schnirelmannDensity A > 0 → ∃ h : ℕ, IsAdditiveBasis A h
+axiom ramare_six_primes :
+    ∀ n : ℕ, n ≥ 4 → Even n → ∃ primes : List ℕ, ...
+axiom tao_five_primes :
+    ∀ n : ℕ, n > 1 → Odd n → ∃ primes : List ℕ, ...
+axiom chen_theorem :
+    ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Even n → ∃ p m, ...
+axiom binary_goldbach_verified :
+    ∀ n : ℕ, 4 ≤ n → Even n → n ≤ 4 * 10^18 → IsSumOfTwoPrimes n
+axiom helfgott_explicit_bound :
+    ∀ n : ℕ, n > 5 → Odd n → IsSumOfThreePrimes n
+```
+
+In addition to the 9 axioms, the parent file contains **2 theorem-level
+placeholder stubs** that conclude with `True`:
+
+```lean
+theorem vinogradov_minor_arc_bound : ∀ A > 0, ∃ C > 0, ∀ N : ℕ, N ≥ 2 → True
+theorem linnik_goldbach_representations : ∃ C > 0, ∀ n : ℕ, n ≥ 4 → Even n → True
+```
+
+and **1 placeholder definition**:
+
+```lean
+def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ := 0  -- placeholder
+```
+
+A "no axioms" goal includes giving real definitions for these as well.
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 5
+tags:
+  - seeker-selected
+  - number-theory
+  - goldbach
+  - prime-sums
+  - circle-method
+  - schnirelmann-density
+  - axiom-elimination
+  - mathlib-Schnirelmann
+```
+
+**Significance**: 7/10 — Helfgott's proof is one of the most celebrated
+results of analytic number theory in the last 30 years. A fully axiom-free
+formalization would be a top-tier gallery entry and a non-trivial Mathlib
+contribution (Schnirelmann basis theorem, Vinogradov's bound, the circle
+method) — none of which currently exist in Mathlib v4.26.0.
+
+**Tractability**: 5/10 — The full axiom-elimination is heroic (multi-year).
+But there are *tractable entry points* (Approach A below) that can land in
+1-3 sessions: replacing the placeholder `schnirelmannDensity` with Mathlib's
+existing `Mathlib.Combinatorics.Schnirelmann.schnirelmannDensity`, proving
+small numerical cases of `binary_goldbach_verified` via `decide`, and
+upgrading the 2 `True`-stub theorems to bear genuine mathematical content
+(even if the content remains modest).
+
+## Why This Matters
+
+1. **Single Mathlib-load-bearing path**. Of the 9 axioms, the Schnirelmann
+   chain (`schnirelmannDensity` definition → `schnirelmann_basis_theorem`)
+   is **explicitly on Mathlib's TODO list** at v4.26.0 (see
+   `Mathlib/Combinatorics/Schnirelmann.lean` module docstring: *"Prove
+   Schnirelmann's theorem and Mann's theorem on the subadditivity of this
+   density"*). Closing this axiom is also a Mathlib contribution.
+
+2. **Phased path to a verified flagship**. The 9 axioms naturally split
+   into three feasibility tiers:
+   - **TRACTABLE** (1-3 sessions each): Fix `schnirelmannDensity` placeholder,
+     prove small-range `binary_goldbach_verified` (n ≤ 1000 via `decide`),
+     give real content to the 2 `True`-stub theorems.
+   - **INTERMEDIATE** (~6-12 months): Schnirelmann's theorem proper, the
+     `IsAdditiveBasis` lifting argument. These are textbook results
+     (Nathanson, *Additive Number Theory*).
+   - **HEROIC** (multi-year): Vinogradov's exponential sum bound, the
+     circle method asymptotic, Helfgott's 2013 paper, Chen's theorem,
+     Tao's 5-prime, Ramaré's 6-prime.
+
+3. **Companion gallery growth**. Each TRACTABLE/INTERMEDIATE deliverable
+   can spawn its own gallery entry (Schnirelmann-density basic bounds;
+   Mann's α + β theorem; Vinogradov's main term). The OQ tree under
+   `weak-goldbach` can grow organically without ever needing to formalize
+   Helfgott in full.
+
+4. **First gallery entry to use `Mathlib.Combinatorics.Schnirelmann`**.
+   Currently no gallery proof imports this Mathlib module. This OQ
+   surfaces it as load-bearing.
+
+## Known Results
+
+### Already Proven (in parent `WeakGoldbach.lean`, 0 sorries)
+
+- `goldbach_7, goldbach_9, goldbach_11, goldbach_21, goldbach_101`:
+  Concrete verification by exhibiting decompositions.
+- `isSumOfThreePrimesDecide_sound/_complete`: Decidable certificate for
+  the ternary Goldbach representation.
+- `binary_implies_weak`: Binary Goldbach ⟹ weak (ternary) Goldbach
+  (constructive reduction, ~80 lines).
+- `sumOfTwoPrimes_add_three`, `odd_gt_five_eq_three_plus_even`: Number-
+  theoretic glue lemmas.
+- `representationCount_pos_iff`: r₃(n) > 0 ↔ n is a sum of 3 primes.
+- `singular_series_positive`: weak placeholder (∃ S > 0, currently `⟨1, one_pos⟩`).
+- `vinogradov_from_circle_method`: Circle-method asymptotic ⟹ Vinogradov.
+- `helfgott_improves_tao`: Weak Goldbach ⟹ Tao's 5-prime form (reduction).
+- `binary_stronger_than_ternary`: Binary Goldbach ⟹ weak Goldbach.
+- `levy_implies_weak_goldbach`: Lévy's conjecture ⟹ weak Goldbach.
+- `levy_7, levy_9, levy_11`: Lévy verified for small odd integers.
+
+### Axiomatized Results (9 axioms — this OQ targets)
+
+| Axiom | Statement (short) | Source | Feasibility |
+|-------|-------------------|--------|-------------|
+| `vinogradov_ternary_goldbach` | Asymptotic ternary Goldbach (1937) | Vinogradov | HEROIC |
+| `helfgott_weak_goldbach` | Helfgott's main 2013 result | Helfgott | HEROIC |
+| `circle_method_asymptotic` | r₃(n) ∼ S(n)·n²/(2log³n) | Hardy-Littlewood | HEROIC |
+| `schnirelmann_basis_theorem` | σ(A) > 0 ⟹ A is additive basis | Schnirelmann 1930 | INTERMEDIATE |
+| `ramare_six_primes` | Every even n ≥ 4 is sum of ≤ 6 primes | Ramaré 1995 | HEROIC |
+| `tao_five_primes` | Every odd n > 1 is sum of ≤ 5 primes | Tao 2014 | HEROIC |
+| `chen_theorem` | Large even n = p + P₂ | Chen 1973 | HEROIC |
+| `binary_goldbach_verified` | Binary Goldbach for n ≤ 4·10¹⁸ | Oliveira e Silva 2013 | TRACTABLE (small range) |
+| `helfgott_explicit_bound` | Helfgott's explicit threshold 8.875·10³⁰ | Helfgott 2013 | HEROIC |
+
+### Available Mathlib Infrastructure (pinned rev v4.26.0)
+
+| Need | Mathlib name | Module |
+|------|--------------|--------|
+| Schnirelmann density (defined) | `schnirelmannDensity : Set ℕ → [DecidablePred] → ℝ` | `Mathlib.Combinatorics.Schnirelmann` |
+| Basic bounds 0 ≤ σ(A) ≤ 1 | `schnirelmannDensity_nonneg`, `schnirelmannDensity_le_one` | `Mathlib.Combinatorics.Schnirelmann` |
+| σ(A) = 0 if 1 ∉ A | `schnirelmannDensity_eq_zero_of_one_notMem` | `Mathlib.Combinatorics.Schnirelmann` |
+| σ subadditive (Mann) | **MISSING** (on Mathlib TODO list) | n/a |
+| Schnirelmann basis theorem | **MISSING** (on Mathlib TODO list) | n/a |
+| Primality decidable | `Nat.decidablePrime`, `Nat.Prime` | `Mathlib.Data.Nat.Prime.Defs` |
+| Prime counting function | `Nat.primeCounting` | `Mathlib.NumberTheory.PrimeCounting` |
+| Circle integral / `e(x)` | `circleMap`, `Complex.exp_mul_I_add` | `Mathlib.Analysis.SpecialFunctions.Complex.Circle` |
+
+### Open Sub-Questions (S2 candidates, sorted by tractability)
+
+- **Q1 (TRACTABLE)**: Can the placeholder `def schnirelmannDensity ... := 0`
+  in `Proofs/WeakGoldbach.lean` be replaced by an `import` of
+  `Mathlib.Combinatorics.Schnirelmann` so the parent file uses Mathlib's
+  real definition? Side effect: the axiom `schnirelmann_basis_theorem` becomes
+  the only place σ is used non-trivially, and its statement now lines up
+  with Mathlib's convention. (Approach A.)
+
+- **Q2 (TRACTABLE)**: Can the 2 `True`-stub theorems
+  (`vinogradov_minor_arc_bound`, `linnik_goldbach_representations`) be
+  upgraded to bear genuine content — even modest — so the file no longer
+  exposes "fake content" stubs? (Approach B.)
+
+- **Q3 (TRACTABLE-small / HEROIC-full)**: For some explicit bound `B ≤ 10⁶`,
+  can `binary_goldbach_verified` be proved for `n ≤ B` via `decide` /
+  `native_decide`, replacing the all-n axiom with a finite-range theorem +
+  an axiom restricted to `n > B`? This degrades but does not eliminate the
+  axiom; full elimination requires Oliveira e Silva's 8-month CPU
+  verification, which is out of scope. (Approach C.)
+
+- **Q4 (INTERMEDIATE)**: Following Nathanson's *Additive Number Theory*
+  Chapter 7, prove `schnirelmann_basis_theorem`: if `σ(A ∪ {0}) > 0` then
+  for some `h`, every natural number is a sum of at most `h` elements of
+  `A ∪ {0}`. The classical proof: from `σ(A) ≥ α > 0`, the sumset `2A`
+  satisfies `σ(2A) ≥ 2α − α² = α(2 − α)`; iterating, after finitely many
+  doublings `σ(2^k A) ≥ 1/2`; then the supplement to 1 finishes via
+  pigeonhole. ~600 lines Lean, 3-6 sessions. (Approach D.)
+
+- **Q5 (HEROIC, deferred)**: All other axioms — Vinogradov, circle method,
+  Helfgott, Chen, Tao, Ramaré — require multi-month formalization efforts
+  of well-known but technically dense analytic-number-theory results. Not
+  S2-S5 candidates.
+
+### Our Goal (S1 OBSERVE)
+
+Survey the 9 axioms + 2 True-stub theorems + 1 placeholder definition;
+classify each by feasibility tier; identify the most tractable S2 entry
+points; map Mathlib's existing infrastructure. **Recommended S2: Approach A
+(Mathlib `schnirelmannDensity` integration).** No Lean changes this S1.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `weak-goldbach` (parent) | The formalization with 9 axioms this OQ targets. |
+| `infinitude-primes-4k1-oq-03`, `infinitude-primes-4k3-oq-03` | Arithmetic-progression prime distribution — shares circle-method / density flavor. |
+| `bertrands-postulate` family | Classical prime-counting / sieve infrastructure that supports Schnirelmann-density arguments. |
+| `prime-number-theorem-oq-*` | Selberg / Erdős-style prime distribution — pre-Vinogradov techniques relevant to the lower-tier axioms. |
+| `infinitude-primes-4k3-oq-03` | Quadratic-form prime density results that share Mathlib's `Nat.primeCounting` consumer surface. |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Mathlib `schnirelmannDensity` integration (RECOMMENDED for S2)**.
+
+   Replace the parent file's
+   ```lean
+   def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ := 0  -- placeholder
+   ```
+   with an `import Mathlib.Combinatorics.Schnirelmann` and use the existing
+   `schnirelmannDensity` from that module. Then:
+   - Restate `schnirelmann_basis_theorem` to use Mathlib's definition (the
+     statement is the same; only the underlying definition changes).
+   - Add 1-3 small lemmas drawn from Mathlib's existing API
+     (`schnirelmannDensity_nonneg`, `schnirelmannDensity_le_one`,
+     `schnirelmannDensity_eq_zero_of_one_notMem`) to demonstrate the API
+     is now usable.
+   - Optionally, prove `schnirelmannDensity {n | Nat.Prime n} = 0` (the
+     density of primes is zero — corollary of `schnirelmannDensity_le_of_notMem`
+     applied at `k = 1` since `1 ∉ {primes}`).
+
+   **Why it might work**: The Mathlib API is stable and ready. Replacement
+   is mechanical except for the namespace clash (parent file's
+   `schnirelmannDensity` will shadow Mathlib's; rename one or move to a
+   namespace).
+
+   **Risk**: Namespace conflict and import-order issues. The parent file
+   uses `WeakGoldbach.schnirelmannDensity` implicitly; replacing it must
+   either remove the local def or rename it to a distinguishing name (e.g.,
+   `schnirelmannDensity_local`) and re-route consumers.
+
+   **Estimated effort**: 1 PR, ~50-80 lines net, single session.
+
+2. **Approach B — Upgrade `True`-stub theorems**.
+
+   The 2 placeholder theorems
+   ```lean
+   theorem vinogradov_minor_arc_bound : ∀ A > 0, ∃ C > 0, ∀ N : ℕ, N ≥ 2 → True
+   theorem linnik_goldbach_representations : ∃ C > 0, ∀ n : ℕ, n ≥ 4 → Even n → True
+   ```
+   currently prove `True` — i.e., they prove *nothing* about minor-arc
+   bounds or Linnik representations. Upgrading them to bear modest content:
+   - `vinogradov_minor_arc_bound`: replace the `True` with a real
+     existential statement about `exponentialSumOverPrimes`, e.g.,
+     `‖exponentialSumOverPrimes N α‖ ≤ Nat.primeCounting N` (trivial via
+     triangle inequality + `‖exp(...)‖ = 1` — but at least *a real
+     statement*).
+   - `linnik_goldbach_representations`: similarly, replace with a real
+     trivial bound like `representationCount n ≤ (Nat.primeCounting n)^3`.
+
+   **Why it might work**: Both upgrades replace fake content with weak-but-
+   real content. Each is ~10-20 lines Lean.
+
+   **Risk**: The new statements are not the "actual" Vinogradov / Linnik
+   bounds, but neither was the `True` placeholder. The upgrade is
+   honestly-stated — the docstring should say "trivial bound; the real
+   Vinogradov/Linnik bound is HEROIC and deferred".
+
+   **Estimated effort**: 1 PR, ~30-40 lines net, single session.
+
+3. **Approach C — Small-range `binary_goldbach_verified` via decide**.
+
+   Replace the all-n axiom
+   ```lean
+   axiom binary_goldbach_verified :
+       ∀ n : ℕ, 4 ≤ n → Even n → n ≤ 4 * 10^18 → IsSumOfTwoPrimes n
+   ```
+   with
+   ```lean
+   theorem binary_goldbach_verified_small (B := 10^4) :
+       ∀ n : ℕ, 4 ≤ n → Even n → n ≤ B → IsSumOfTwoPrimes n := by
+     decide  -- or native_decide
+   axiom binary_goldbach_verified_large :
+       ∀ n : ℕ, B < n → Even n → n ≤ 4 * 10^18 → IsSumOfTwoPrimes n
+   ```
+   The axiom is *split*, not eliminated. The TRACTABLE portion (small `n`)
+   is proven; the HEROIC portion (large `n`) remains.
+
+   **Why it might work**: For `B = 10^3` or `10^4`, `decide` / `native_decide`
+   should complete in seconds-to-minutes. The split makes the file
+   "honest" about which part is computational vs. assumption.
+
+   **Risk**: `decide` may time out at `B = 10^4`; pick `B = 10^3` and verify.
+   Also, the Mathlib `Nat.decidablePrime` cost grows with primality check;
+   ~10^4 might be borderline.
+
+   **Estimated effort**: 1 PR, ~30-50 lines Lean + compile-time verification,
+   single session if `B = 10^3` works.
+
+4. **Approach D — Schnirelmann's theorem proof (INTERMEDIATE, deferred)**.
+
+   The classical Schnirelmann argument:
+   - For `A ⊆ ℕ` with `0 ∈ A`, define `σ(A) := inf_{n ≥ 1} A(n)/n` where
+     `A(n) := |A ∩ [1, n]|`.
+   - **Lemma (Schnirelmann inequality)**: If `α := σ(A)` and `β := σ(B)`,
+     then `σ(A + B) ≥ α + β − α·β`.
+   - **Consequence**: If `α > 0`, then `σ(2A) ≥ 2α − α² = 1 − (1 − α)²`,
+     and iterating `σ(2^k A) ≥ 1 − (1 − α)^(2^k)`, so for some `k₀`,
+     `σ(2^{k₀} A) > 1/2`.
+   - **Lemma**: If `σ(A) > 1/2`, then `A + A = ℕ` (proof: pigeonhole on
+     `A(n) + A(n) ≥ n + 1`).
+   - **Conclusion**: `2^{k₀ + 1} A = ℕ`, i.e., `A` is an additive basis
+     of order `2^{k₀ + 1}`.
+
+   **Why it might work**: The argument is classical and well-documented
+   (Nathanson 1996 Chapter 7, also Halberstam-Roth *Sequences*). All
+   ingredients are real-analysis / combinatorial; no analytic number
+   theory beyond the prime-related applications (which we're not
+   targeting here).
+
+   **Risk**: Mathlib has only the `schnirelmannDensity` definition and a
+   handful of basic bounds at v4.26.0. The full proof must build out
+   significant infrastructure: sumsets of ℕ-subsets, the Schnirelmann
+   inequality, iterated sumset bounds. ~600-1000 lines Lean, 3-6
+   sessions.
+
+   **Estimated effort**: 3-6 PRs, ~600-1000 lines Lean total, 2-4 months
+   wall-clock at 1 PR/week.
+
+### Key Difficulties
+
+- **Mathlib gap on Schnirelmann's theorem**. The module docstring at
+  `Mathlib/Combinatorics/Schnirelmann.lean` explicitly lists Schnirelmann's
+  theorem and Mann's theorem as TODO items. Closing these is a Mathlib
+  PR opportunity, not just a gallery PR.
+
+- **Namespace clash on `schnirelmannDensity`**. The parent file declares its
+  own placeholder `schnirelmannDensity` at line 330; Mathlib's lives in the
+  root namespace. Approach A must either remove the parent's def or rename it.
+
+- **`decide` cost for `binary_goldbach_verified_small`**. Evaluating
+  `Nat.Prime` for thousands of `n` and searching for `(p, q)` decompositions
+  is `O(B · π(B))` in the worst case; for `B = 10⁴` this is ~10⁴ · 10³ =
+  10⁷ work, well within `native_decide` reach but slow for plain `decide`.
+
+- **`circle_method_asymptotic` requires unbuilt machinery**. The Hardy-
+  Littlewood singular-series form `S(n) = ∏_p (...)` and the asymptotic
+  bound on `‖exponentialSumOverPrimes‖` on minor arcs are not in Mathlib;
+  formalizing them is a 1000+ line standalone effort each.
+
+- **No Mathlib `Nat.binaryGoldbach` or `Nat.ternaryGoldbach` exist**.
+  The gallery's `IsSumOfTwoPrimes` and `IsSumOfThreePrimes` are
+  parent-file-local; coordinating across siblings requires choosing a
+  canonical definition.
+
+### What Would a Proof Need? (Approach A)
+
+- **Mathlib import**: `import Mathlib.Combinatorics.Schnirelmann`.
+- **Remove or rename** the parent's `def schnirelmannDensity` at line 330.
+- **Update `schnirelmann_basis_theorem` statement** to use the un-namespaced
+  Mathlib `schnirelmannDensity` (statement is identical except for the
+  definition path).
+- **Add 3 small lemmas** demonstrating the Mathlib API:
+  ```lean
+  -- Density of {0} is zero (vacuously)
+  lemma schnirelmannDensity_singleton_zero :
+      schnirelmannDensity (Set.singleton 0) = 0
+  -- Density of {primes} is zero (since 1 ∉ primes)
+  lemma schnirelmannDensity_primes_eq_zero :
+      schnirelmannDensity {n : ℕ | Nat.Prime n} = 0
+  -- Subset implies ≤
+  lemma schnirelmannDensity_le_of_subset {A B : Set ℕ}
+      [DecidablePred (· ∈ A)] [DecidablePred (· ∈ B)]
+      (h : A ⊆ B) : schnirelmannDensity A ≤ schnirelmannDensity B
+  ```
+  (The third is *already* in Mathlib at v4.26.0 as
+  `schnirelmannDensity_le_of_subset`; re-exposing as a `theorem` in the
+  parent's namespace is a re-export, not a new proof.)
+
+## Tractability Assessment
+
+**Difficulty**: Low (Approach A) | Low (Approach B) | Low-Medium (Approach C)
+| Medium-High (Approach D) | Heroic (full elimination)
+
+**Justification**:
+- **Approach A** (S2 target): Single PR, ~80 lines Lean, all stable Mathlib
+  API at v4.26.0. Replaces a placeholder definition with the real one and
+  exposes the parent file to Mathlib's Schnirelmann infrastructure.
+- **Approach B**: Single PR, ~40 lines Lean, replaces fake `True`-stub
+  content with real (modest) content.
+- **Approach C**: Single PR, ~50 lines Lean + `native_decide` for `B = 10³`
+  or `10⁴`. Splits the axiom into TRACTABLE-small + HEROIC-large.
+- **Approach D** (deferred): Multi-PR, ~800 lines Lean, 2-4 months. The
+  classical Schnirelmann argument is well-understood; the cost is
+  infrastructure.
+- **Heroic axioms** (`vinogradov_*`, `helfgott_*`, `circle_method_*`, Chen,
+  Tao, Ramaré, `helfgott_explicit_bound`): Multi-year. Out of OQ-03 scope
+  except as a long-term aspiration.
+
+**Estimated Effort**:
+- Approach A: 1 session, single PR, ~80 lines Lean.
+- Approach B: 1 session, single PR, ~40 lines Lean.
+- Approach C: 1 session, single PR, ~50 lines Lean + ~1 min compile.
+- Approach D: 3-6 sessions, ~600-1000 lines Lean, spans weeks.
+- Full elimination: multi-year, not S2-Sn candidate.
+
+## References
+
+### Papers and Books
+
+- **Helfgott, H. A.** (2013). *Major arcs for Goldbach's problem*. arXiv:1305.2897.
+- **Helfgott, H. A.** (2014). *Minor arcs for Goldbach's problem*. arXiv:1205.5252.
+- **Vinogradov, I. M.** (1937). *Representation of an odd number as a sum
+  of three primes*. Dokl. Akad. Nauk SSSR 15 (5): 291–294.
+- **Schnirelmann, L. G.** (1930). *On the additive properties of numbers*.
+  (German translation in *Über additive Eigenschaften von Zahlen*, Math.
+  Ann. 107: 649-690, 1933.)
+- **Nathanson, M. B.** (1996). *Additive Number Theory: The Classical
+  Bases*. Springer GTM 164. — Chapter 7 covers Schnirelmann's theorem.
+- **Halberstam, H., Roth, K. F.** (1966). *Sequences*. Oxford University Press.
+  — Original combinatorial treatment of Schnirelmann density.
+- **Tao, T.** (2014). *Every odd number greater than 1 is the sum of at
+  most five primes*. Math. Comp. 83 (286): 997–1038.
+- **Ramaré, O.** (1995). *On Šnirel'man's constant*. Ann. Scuola Norm. Sup.
+  Pisa Cl. Sci. (IV) 22 (4): 645-706.
+- **Chen, J.-R.** (1973). *On the representation of a larger even integer
+  as the sum of a prime and the product of at most two primes*. Sci.
+  Sinica 16: 157-176.
+- **Oliveira e Silva, T., Herzog, S., Pardi, S.** (2014). *Empirical
+  verification of the even Goldbach conjecture and computation of prime
+  gaps up to 4·10¹⁸*. Math. Comp. 83 (288): 2033-2060.
+
+### Mathlib v4.26.0
+
+- `Mathlib.Combinatorics.Schnirelmann` — `schnirelmannDensity`,
+  `schnirelmannDensity_nonneg`, `schnirelmannDensity_le_one`,
+  `schnirelmannDensity_le_of_notMem`,
+  `schnirelmannDensity_eq_zero_of_one_notMem`,
+  `schnirelmannDensity_le_of_subset`. *TODO list mentions Schnirelmann's
+  theorem and Mann's theorem.*
+- `Mathlib.NumberTheory.PrimeCounting` — `Nat.primeCounting`, basic bounds.
+- `Mathlib.Data.Nat.Prime.Defs` — `Nat.Prime`, `Nat.decidablePrime`.
+- `Mathlib.Analysis.SpecialFunctions.Complex.Circle` — circleMap,
+  `Complex.exp` basics (used in circle method).
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - goldbach
+  - prime-sums
+  - circle-method
+  - schnirelmann-density
+  - axiom-elimination
+  - seeker-selected
+  - mathlib-Combinatorics-Schnirelmann
+related_proofs:
+  - weak-goldbach
+  - prime-number-theorem
+  - infinitude-primes-4k1
+  - infinitude-primes-4k3
+difficulty: medium
+source: gallery-gap
+created: 2026-05-12
+```

--- a/research/problems/weak-goldbach-oq-03/state.md
+++ b/research/problems/weak-goldbach-oq-03/state.md
@@ -1,0 +1,146 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-5): Survey the 9 axioms + 2 `True`-stub theorems +
+1 placeholder definition in `Proofs/WeakGoldbach.lean`; classify each by
+feasibility tier; identify the most tractable S2 entry point; map Mathlib's
+existing Schnirelmann-density infrastructure at v4.26.0.
+
+Settled on **Approach A** (Mathlib `schnirelmannDensity` integration) as
+the S2 attack target — single session, ~80 lines Lean, replaces the
+parent's placeholder definition `schnirelmannDensity := 0` with Mathlib's
+real definition from `Mathlib.Combinatorics.Schnirelmann`.
+
+## Active Approach
+
+**Approach A: Mathlib `schnirelmannDensity` integration**
+
+Replace
+```lean
+def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ :=
+  -- This is a simplified version; full definition needs infimum
+  0 -- placeholder
+```
+with `import Mathlib.Combinatorics.Schnirelmann` and use Mathlib's existing
+`schnirelmannDensity := ⨅ n : {n : ℕ // 0 < n}, #{a ∈ Ioc 0 n | a ∈ A} / n`.
+
+The parent's `axiom schnirelmann_basis_theorem` retains its statement
+shape — `schnirelmannDensity A > 0 → ∃ h : ℕ, IsAdditiveBasis A h` — but
+now refers to Mathlib's *real* density, making the axiom statement
+mathematically meaningful instead of vacuous (the placeholder
+`schnirelmannDensity := 0` made `schnirelmannDensity A > 0` false
+*by definition* for every `A`, trivializing the axiom hypothesis).
+
+Add 1-3 small lemmas to exercise Mathlib's API:
+- `schnirelmannDensity_primes_eq_zero`: σ({primes}) = 0 via
+  `schnirelmannDensity_eq_zero_of_one_notMem` (since 1 ∉ primes).
+- Optional: `schnirelmannDensity_singleton_zero_eq_zero`,
+  `schnirelmannDensity_natUniv_eq_one`.
+
+## Blockers
+
+None mathematical.
+
+**Practical**:
+- Docker build: any S2 PR touching `WeakGoldbach.lean` must rebuild the
+  file. With the new `Mathlib.Combinatorics.Schnirelmann` import, the
+  Mathlib cache should already have this module compiled (it's been in
+  Mathlib since 2023), so the build cost is just the parent file's
+  recompile (~10 minutes).
+- Namespace clash: the local `def schnirelmannDensity` at lines ~329-332
+  must be removed when adding the Mathlib import, OR renamed to avoid
+  clash. Removal is cleaner.
+
+## Next Action
+
+**S2 (any researcher): Approach A — Mathlib Schnirelmann integration**
+
+Three deliverables in a single PR on `proofs/Proofs/WeakGoldbach.lean`:
+
+1. **Add import** (~1 line):
+   ```lean
+   import Mathlib.Combinatorics.Schnirelmann
+   ```
+
+2. **Remove the placeholder definition** (lines ~328-332):
+   ```lean
+   -- BEFORE
+   /-- Schnirelmann density of a set A ⊆ ℕ:
+       σ(A) = inf_{n ≥ 1} |A ∩ [1,n]| / n -/
+   def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ :=
+     -- This is a simplified version; full definition needs infimum
+     0 -- placeholder
+
+   -- AFTER: (deleted; replaced by Mathlib import)
+   ```
+
+3. **Add Mathlib-API-driven lemma(s)** (~10-20 lines):
+   ```lean
+   /-- The set of primes has Schnirelmann density 0 since 1 is not prime. -/
+   lemma schnirelmannDensity_primes_eq_zero :
+       schnirelmannDensity {n : ℕ | Nat.Prime n} = 0 :=
+     schnirelmannDensity_eq_zero_of_one_notMem (by decide : ¬ ((1 : ℕ) ∈ {n : ℕ | Nat.Prime n}))
+   ```
+
+Build verification: `./proofs/scripts/docker-build.sh Proofs.WeakGoldbach`
+from the S2 worktree. Expected: clean build (the Mathlib module already
+compiled in cache); 0 new sorries; 0 new axioms.
+
+Update parent gallery meta.json if needed: `axiomCount` stays at 9 (no
+axioms removed), `definitionCount` drops by 1 (placeholder removed) but
+gains 0 (Mathlib import doesn't add a parent-file definition). Net:
+`definitionCount` 15 → 14 in the parent's meta.
+
+**Estimated effort for S2**: 1 session, single PR, ~80 lines Lean total
+(import + removal + 1-3 lemmas + docstring updates).
+
+**S3+ candidates** (in tractability order):
+- **S3 (Approach B)**: Upgrade `True`-stub theorems `vinogradov_minor_arc_bound`
+  and `linnik_goldbach_representations` to bear real (modest) content via
+  Mathlib's `Nat.primeCounting` and trivial triangle-inequality bounds.
+  ~40-60 lines Lean.
+- **S4 (Approach C)**: Split `binary_goldbach_verified` axiom into a small-
+  range `native_decide` theorem (for `n ≤ 10³` or `10⁴`) + a residual
+  large-range axiom. ~50 lines Lean.
+- **S5+ (Approach D, multi-session)**: Begin Schnirelmann's theorem proper
+  (the `schnirelmann_basis_theorem` axiom). Phase D1: Schnirelmann
+  inequality `σ(A + B) ≥ α + β − αβ`. Phase D2: iterated doubling
+  σ(2^k A) ≥ 1 − (1 − α)^(2^k). Phase D3: density-half basis (σ > 1/2 →
+  sumset is ℕ⁺). Phase D4: assembly. Total: 3-6 sessions, ~600-1000
+  lines Lean, also a Mathlib contribution opportunity (the module's
+  TODO list explicitly mentions Schnirelmann's theorem).
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 survey)
+- Current approach attempts: 0 (no Lean changes yet)
+- Approaches tried: 0 (4 surveyed: A=Mathlib Schnirelmann integration,
+  B=True-stub upgrades, C=`native_decide` small-range,
+  D=Schnirelmann's theorem proper)
+
+## Open files
+
+- `problem.md` — Full problem statement, 4-approach survey, axiom +
+  stub audit, Mathlib API map, tractability assessment.
+- `knowledge.md` — S1 session note: parent audit, three feasibility
+  tiers, load-bearing Mathlib API, edge cases, insights, Mathlib gaps,
+  next-session expectations.
+
+## S1 Deliverable
+
+This iteration is **survey-only**:
+- 0 new theorems
+- 0 new sorries
+- 0 axiom changes
+- 0 Lean files modified
+
+Produced:
+- `research/problems/weak-goldbach-oq-03/problem.md` (~330 lines)
+- `research/problems/weak-goldbach-oq-03/state.md` (this file, ~100 lines)
+- `research/problems/weak-goldbach-oq-03/knowledge.md` (~210 lines)
+- `src/data/research/problems/weak-goldbach-oq-03.json` (research index entry)

--- a/src/data/research/problems/weak-goldbach-oq-03.json
+++ b/src/data/research/problems/weak-goldbach-oq-03.json
@@ -1,0 +1,101 @@
+{
+  "slug": "weak-goldbach-oq-03",
+  "title": "Formalize Helfgott's proof of weak Goldbach without axioms",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Eliminate the 9 axioms in } \\texttt{Proofs/WeakGoldbach.lean} \\text{ (vinogradov\\_ternary\\_goldbach, helfgott\\_weak\\_goldbach, circle\\_method\\_asymptotic, schnirelmann\\_basis\\_theorem, ramare\\_six\\_primes, tao\\_five\\_primes, chen\\_theorem, binary\\_goldbach\\_verified, helfgott\\_explicit\\_bound) and upgrade the 2 } \\texttt{True}\\text{-stub theorems plus 1 placeholder definition.}",
+    "plain": "The parent gallery proof of weak Goldbach (Helfgott 2013: every odd integer > 5 is a sum of three primes) is formalized in Proofs/WeakGoldbach.lean with 0 sorries but 9 axioms plus 2 True-stub theorems plus 1 placeholder definition (schnirelmannDensity := 0). This OQ asks whether the axioms can be progressively discharged, with realistic feasibility tiering (TRACTABLE / INTERMEDIATE / HEROIC) and identification of S2 entry points.",
+    "whyMatters": [
+      "The Schnirelmann chain (schnirelmannDensity definition → schnirelmann_basis_theorem) is explicitly on Mathlib's TODO list at v4.26.0 (Mathlib/Combinatorics/Schnirelmann.lean module docstring). Closing this axiom is also a Mathlib contribution.",
+      "The 9 axioms naturally split into three feasibility tiers: TRACTABLE (1-3 sessions: Mathlib Schnirelmann integration, True-stub upgrades, small-range binary_goldbach_verified via native_decide), INTERMEDIATE (~6-12 months: Schnirelmann's theorem proper), HEROIC (multi-year: Vinogradov, circle method, Helfgott, Chen, Tao, Ramaré, helfgott_explicit_bound).",
+      "Each TRACTABLE/INTERMEDIATE deliverable can spawn its own gallery entry (Schnirelmann-density basic bounds; Mann's α + β theorem; Vinogradov's main term). The OQ tree under weak-goldbach can grow organically without ever needing to formalize Helfgott in full.",
+      "First gallery entry to use Mathlib.Combinatorics.Schnirelmann. Currently no gallery proof imports this Mathlib module. This OQ surfaces it as load-bearing and demonstrates the integration pattern.",
+      "The parent file's '0 sorries' claim is misleading without the axiom audit: 9 axioms + 2 True-stub theorems + 1 placeholder definition sum to 12 unverified pieces of content. Any 'axiom-free' claim must address all 12. This OQ makes the gap explicit."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "goldbach_7, goldbach_9, goldbach_11, goldbach_21, goldbach_101: concrete decompositions of small odd numbers as sums of three primes (parent, fully proved).",
+      "isSumOfThreePrimesDecide_sound/_complete: decidable certificate for the ternary Goldbach representation (parent, fully proved).",
+      "binary_implies_weak: binary Goldbach ⟹ weak (ternary) Goldbach (parent, ~80 lines, fully proved).",
+      "sumOfTwoPrimes_add_three, odd_gt_five_eq_three_plus_even: number-theoretic glue lemmas (parent).",
+      "representationCount_pos_iff: r₃(n) > 0 ↔ n is a sum of 3 primes (parent).",
+      "vinogradov_from_circle_method: circle-method asymptotic ⟹ Vinogradov (parent, reduction proven).",
+      "helfgott_improves_tao: weak Goldbach ⟹ Tao's 5-prime form (parent, reduction proven).",
+      "binary_stronger_than_ternary: binary Goldbach ⟹ weak Goldbach (parent).",
+      "levy_implies_weak_goldbach, levy_7, levy_9, levy_11: Lévy's conjecture infrastructure (parent)."
+    ],
+    "open": [
+      "Q1 (TRACTABLE): Can the placeholder def schnirelmannDensity := 0 in Proofs/WeakGoldbach.lean be replaced by an import of Mathlib.Combinatorics.Schnirelmann so the parent file uses Mathlib's real definition? Side effect: the axiom schnirelmann_basis_theorem becomes the only place σ is used non-trivially, and its statement now lines up with Mathlib's convention.",
+      "Q2 (TRACTABLE): Can the 2 True-stub theorems (vinogradov_minor_arc_bound, linnik_goldbach_representations) be upgraded to bear genuine (modest) content via Mathlib's Nat.primeCounting + trivial bounds?",
+      "Q3 (TRACTABLE-small): For some explicit bound B ≤ 10⁶, can binary_goldbach_verified be proved for n ≤ B via native_decide, replacing the all-n axiom with a finite-range theorem + an axiom restricted to n > B?",
+      "Q4 (INTERMEDIATE): Following Nathanson's Additive Number Theory Chapter 7, can schnirelmann_basis_theorem be proved (~600-1000 lines, 3-6 sessions, Mathlib contribution opportunity)?",
+      "Q5 (HEROIC, deferred): All other axioms — Vinogradov, circle method, Helfgott, Chen, Tao, Ramaré, helfgott_explicit_bound — require multi-month formalization efforts of well-known but technically dense analytic-number-theory results."
+    ],
+    "goal": "Eliminate the 9 axioms in Proofs/WeakGoldbach.lean by progressive replacement with Lean-level proofs or stronger constructions. Phased approach: TRACTABLE first (Approaches A-C, ~80-200 lines Lean total across 3 sessions), then INTERMEDIATE (Approach D, Schnirelmann's theorem proper, ~600-1000 lines over 3-6 sessions, also Mathlib contribution), then HEROIC deferred to long-term roadmap. S2 target: Approach A (Mathlib Schnirelmann integration), ~80 lines Lean, single session."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T09:18:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-5, 2026-05-12): survey 9 axioms + 2 True-stub theorems + 1 placeholder definition in Proofs/WeakGoldbach.lean. Classified each by feasibility tier (TRACTABLE / INTERMEDIATE / HEROIC). Recommended Approach A (Mathlib Schnirelmann integration) as S2 target — single PR, ~80 lines Lean, replaces the parent's placeholder schnirelmannDensity := 0 with Mathlib's real definition from Mathlib.Combinatorics.Schnirelmann. Identified Mathlib gap: Schnirelmann's theorem and Mann's theorem on subadditivity are explicitly on Mathlib's TODO list at v4.26.0; closing the schnirelmann_basis_theorem axiom (Approach D) doubles as a Mathlib contribution.",
+    "blockers": [],
+    "nextAction": "S2: implement Approach A in proofs/Proofs/WeakGoldbach.lean. Three changes: (1) add import Mathlib.Combinatorics.Schnirelmann. (2) Remove placeholder def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ := 0 at lines ~329-332 (clash with Mathlib's def). (3) Add 1-3 small lemmas exercising Mathlib API, e.g., schnirelmannDensity_primes_eq_zero via schnirelmannDensity_eq_zero_of_one_notMem since 1 ∉ {primes}. ~80 lines net, single session. Build verification via ./proofs/scripts/docker-build.sh Proofs.WeakGoldbach (Mathlib Schnirelmann module is in cache, ~10 min recompile of WeakGoldbach.lean).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-5, 2026-05-12): OBSERVE survey. Full audit of parent Proofs/WeakGoldbach.lean: 480 lines, 24 theorems, 0 sorries — but 9 axioms + 2 True-stub theorems + 1 placeholder def, totaling 12 unverified content pieces. Classified into three feasibility tiers: TRACTABLE (A=Mathlib Schnirelmann integration ~80 LOC, B=True-stub upgrades ~40 LOC, C=native_decide small-range binary Goldbach ~50 LOC), INTERMEDIATE (D=Schnirelmann's theorem proper ~600-1000 LOC, 3-6 sessions; also Mathlib contribution), HEROIC (E=Vinogradov/Helfgott/circle method/Chen/Tao/Ramaré/helfgott_explicit_bound, multi-year). Verified Mathlib API at v4.26.0: schnirelmannDensity is defined (Mathlib.Combinatorics.Schnirelmann); basic bounds schnirelmannDensity_nonneg, _le_one, _le_of_notMem, _eq_zero_of_one_notMem, _le_of_subset all exist; Mathlib TODO list explicitly mentions Schnirelmann's theorem and Mann's theorem on subadditivity. Approach A is the S2 target. 0 Lean changes in S1; 4 markdown/JSON files produced.",
+    "builtItems": [
+      "research/problems/weak-goldbach-oq-03/problem.md (new, ~330 lines): full statement, 4-approach survey, axiom + stub audit table, Mathlib API map, tractability assessment, related-proofs table, key difficulties.",
+      "research/problems/weak-goldbach-oq-03/state.md (new, ~100 lines): phase=OBSERVE, S1 survey, S2 next-action sketch with concrete Lean code, S3+ candidates ladder.",
+      "research/problems/weak-goldbach-oq-03/knowledge.md (new, ~210 lines): S1 session note with full audit table (13 items), three-tier feasibility analysis, load-bearing Mathlib API listing, edge cases, insights, mathlibGaps, nextSteps.",
+      "src/data/research/problems/weak-goldbach-oq-03.json (this file): research index entry."
+    ],
+    "insights": [
+      "'0 sorries' ≠ '0 assumptions'. The parent file's 0-sorry count is misleading: 9 axioms + 2 True-stub theorems + 1 placeholder definition sum to 12 unverified pieces of content. Any 'axiom-free' claim must address all 12.",
+      "The Mathlib gap on Schnirelmann's theorem is explicit. The Mathlib.Combinatorics.Schnirelmann module docstring at v4.26.0 lists Schnirelmann's theorem and Mann's theorem as TODO. The OQ's Approach D doubles as a Mathlib contribution opportunity.",
+      "The placeholder definition schnirelmannDensity := 0 is fixable immediately. Mathlib has the real definition (Mathlib.Combinatorics.Schnirelmann); the parent file just needs to import it. This is item 13 in the audit and dovetails with Approach A — the recommended S2 target.",
+      "The 2 True-stub theorems are not 'lies', they are placeholders. vinogradov_minor_arc_bound and linnik_goldbach_representations currently prove nothing useful, but each can be upgraded to a real (modest) bound via Mathlib API in 10-20 lines (e.g., ‖exponentialSumOverPrimes N α‖ ≤ Nat.primeCounting N by triangle inequality + ‖exp‖ = 1). The full Vinogradov minor-arc bound is HEROIC, but a trivial-but-real bound is TRACTABLE.",
+      "Computational verification has a tractable lower tier. Oliveira e Silva verified binary Goldbach up to 4·10¹⁸ (8 CPU-months) — we can't reach that in Lean, but native_decide can comfortably handle n ≤ 10³ or 10⁴, splitting the binary_goldbach_verified axiom into a TRACTABLE-small theorem + a HEROIC-large residual axiom.",
+      "The Schnirelmann proof is well-documented. Nathanson's Additive Number Theory GTM 164 Chapter 7 gives a complete combinatorial proof using no analytic number theory beyond elementary inequalities. Sub-lemmas: (1) Schnirelmann inequality σ(A+B) ≥ α + β − αβ, (2) iterated doubling σ(2^k A) ≥ 1 − (1−α)^(2^k), (3) density-half basis σ > 1/2 → A+A ⊇ ℕ⁺, (4) assembly. Estimated ~600-1000 Lean lines, all combinatorial.",
+      "No gallery proof currently imports Mathlib.Combinatorics.Schnirelmann. This OQ would be the first. The lack of consumers may explain why Schnirelmann's theorem itself has been on Mathlib's TODO list for years — no downstream pressure.",
+      "The OQ scope is asymmetric across axioms. Of the 9 axioms, ~80% (7/9) are HEROIC (multi-year), ~10% (1/9) is INTERMEDIATE (months), and ~10% (1/9 — binary_goldbach_verified) is partly TRACTABLE (small range) but HEROIC for full elimination. The S2-Sn path must focus on the TRACTABLE items and the INTERMEDIATE schnirelmann_basis_theorem (Approach D); the HEROIC tier is long-term aspiration only.",
+      "Namespace clash risk: parent's def schnirelmannDensity (line 330) clashes with Mathlib's once imported. Approach A must either remove the local def (cleaner) or rename it (risks confusion). The axiom schnirelmann_basis_theorem statement still typechecks after removal — both definitions have type Set ℕ → ℝ — but the content becomes meaningful (placeholder := 0 made the hypothesis schnirelmannDensity A > 0 always false, trivializing the axiom).",
+      "All 5 helfgott-related axioms have been merged into the parent file with no per-axiom citation; this OQ's audit provides the first citation table linking each axiom to its primary source (Vinogradov 1937, Helfgott 2013 papers, Schnirelmann 1930, Ramaré 1995, Tao 2014, Chen 1973, Oliveira e Silva 2014). Useful for any future contributor / reviewer."
+    ],
+    "mathlibGaps": [
+      "Schnirelmann's theorem (σ(A) > 0 → ∃ h, IsAdditiveBasis A h): on Mathlib TODO list (Mathlib/Combinatorics/Schnirelmann.lean module docstring). Estimated ~600-1000 Lean lines for the full proof via Nathanson's GTM 164 Chapter 7 argument. Approach D of this OQ targets directly; would close the Mathlib gap.",
+      "Schnirelmann inequality (σ(A + B) ≥ α + β − αβ): on the same Mathlib TODO list (Mann's theorem is a sharpening). Approach D sub-lemma.",
+      "Density-half basis (σ(A) > 1/2 → A + A ⊇ ℕ⁺): not in Mathlib; sub-lemma of Approach D, ~50-100 lines.",
+      "Vinogradov's exponential-sum bound (minor-arc inequality sup |S(α)| ≤ N / (log N)^A): not in Mathlib. HEROIC tier; would require Mathlib analytic-number-theory infrastructure (singular series, Gauss sums) to be built first.",
+      "Hardy-Littlewood singular series for ternary Goldbach (S(n) = ∏_p (...)): not in Mathlib. HEROIC tier; parent file's singular_series_positive is a ⟨1, one_pos⟩ placeholder, so even the trivial Mathlib statement is missing.",
+      "No worked example of a gallery proof importing Mathlib.Combinatorics.Schnirelmann at v4.26.0. This OQ's Approach A would be the first consumer."
+    ]
+  },
+  "relatedProofs": [
+    "weak-goldbach",
+    "prime-number-theorem",
+    "infinitude-primes-4k1",
+    "infinitude-primes-4k3"
+  ],
+  "tags": [
+    "number-theory",
+    "goldbach",
+    "prime-sums",
+    "circle-method",
+    "schnirelmann-density",
+    "axiom-elimination",
+    "seeker-selected",
+    "mathlib-Combinatorics-Schnirelmann",
+    "research"
+  ],
+  "createdAt": "2026-05-12T09:18:00.000Z",
+  "updatedAt": "2026-05-12T09:18:00.000Z"
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for new tier-B slug `weak-goldbach-oq-03`: full audit of the 9 axioms + 2 `True`-stub theorems + 1 placeholder definition in parent `Proofs/WeakGoldbach.lean`. Four-approach survey across three feasibility tiers, with **Approach A (Mathlib `schnirelmannDensity` integration) recommended as S2 target** (~80 LOC, single session).

## Progress

- 0 Lean changes (S1 OBSERVE fallback variant: markdown/JSON only per memory rule)
- 4 files added (+1003 lines):
  - `research/problems/weak-goldbach-oq-03/problem.md` (~475 lines)
  - `research/problems/weak-goldbach-oq-03/knowledge.md` (~281 lines)
  - `research/problems/weak-goldbach-oq-03/state.md` (~146 lines)
  - `src/data/research/problems/weak-goldbach-oq-03.json` (~101 lines)

## Findings

### Three feasibility tiers identified

**TRACTABLE** (1-3 sessions each):
- **A=Mathlib Schnirelmann integration** (~80 LOC, **S2 RECOMMENDED**) — replace placeholder `def schnirelmannDensity := 0` with `import Mathlib.Combinatorics.Schnirelmann`; add 1-3 Mathlib-API-driven lemmas (e.g., `schnirelmannDensity_primes_eq_zero` via `_eq_zero_of_one_notMem`).
- **B=True-stub upgrades** (~40 LOC) — replace `vinogradov_minor_arc_bound`/`linnik_goldbach_representations` `True`-stubs with real (modest) bounds via `Nat.primeCounting` + triangle inequality.
- **C=`native_decide` small-range binary Goldbach** (~50 LOC) — split `binary_goldbach_verified` axiom into TRACTABLE-small + HEROIC-large residual.

**INTERMEDIATE** (~6-12 months, multi-session):
- **D=Schnirelmann's theorem proper** (~600-1000 LOC) — closes `schnirelmann_basis_theorem` axiom; doubles as **Mathlib contribution** (module docstring explicitly lists this as TODO at v4.26.0).

**HEROIC** (multi-year, deferred):
- Vinogradov, circle method, Helfgott, Chen, Tao, Ramaré, helfgott_explicit_bound — out of S2-Sn scope.

### Mathlib gap surfaced

`Mathlib.Combinatorics.Schnirelmann` at v4.26.0:
- Has `schnirelmannDensity` definition + basic bounds (`_nonneg`, `_le_one`, `_le_of_notMem`, `_eq_zero_of_one_notMem`, `_le_of_subset`).
- Module docstring explicitly lists **Schnirelmann's theorem** and **Mann's theorem on subadditivity** as TODO.
- **No gallery proof currently imports this module** — this OQ would be the first consumer.

### Audit honesty

The parent file's "0 sorries" claim is misleading without the axiom audit: 9 axioms + 2 `True`-stub theorems + 1 placeholder definition sum to **12 unverified pieces of content**. The `problem.md` audit table cites each item with line number and primary literature source (Vinogradov 1937, Helfgott 2013, Schnirelmann 1930, Ramaré 1995, Tao 2014, Chen 1973, Oliveira e Silva 2014).

## Status

**Outcome**: surveyed
**Next Steps**: S2 (any researcher) — Approach A (Mathlib `schnirelmannDensity` integration), ~80 LOC net, single session, build verification via `./proofs/scripts/docker-build.sh Proofs.WeakGoldbach`.

🤖 Generated by researcher-5