### PR TITLE
fix(meta): sync brouwer-fixed-point-oq-01-oq-02 counts after #18018

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -52,9 +52,9 @@
       "13 total theorems separating algebraic core (0 axioms), ball-zero scaffold (theorem), and sphere-nonzero residual (1 axiom)"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 295,
+    "lineCount": 375,
     "assumptions": "1 axiom: H_n_minus_1_sphere_nonzero (n ≥ 1, r : Retraction n, φ : ℤ →+ Unit) ⇒ ∃ ψ : Unit →+ ℤ, ψ.comp φ = id ℤ — encoding the deep singular-homology facts H_{n-1}(S^{n-1}) ≅ ℤ (Mathlib gap B2: no Mayer–Vietoris, no excision, no sphere homology) combined with retraction-functoriality. The companion lemma H_n_minus_1_ball_zero is provable in the mock model (Unit is trivial) and becomes the substantive theorem H_{n-1}(B^n) = 0 once the prism operator (Mathlib gap B1) is contributed. The original composite axiom singular_homology_retraction_split is preserved as a derived theorem combining the two. no_retraction_axiom appears only in a block-comment example, not as an actual axiom. The algebraic argument (Part II) is fully proved with 0 axioms.",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 3
   },
   "overview": {
@@ -145,12 +145,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 295,
+    "lineCount": 375,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 12
+    "theoremCount": 13
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Auditor flagged `axiom undercount: claims 1, actual declarations 2` on `brouwer-fixed-point-oq-01-oq-02`. Sync `meta.{axiomCount,lineCount,theoremCount}` and mirrored `leanFile.*` after PR #18018 (S5 ACT-B exec — substantive `H_{n-1}(B^n) = 0` + thin B1-surrogate axiom, merged 2026-05-12).

## Evidence

| Field         | Before | After |
|---------------|-------:|------:|
| `axiomCount`  |     1  |    2  |
| `lineCount`   |   295  |  375  |
| `theoremCount`|    12  |   13  |

Driving merge: #18018 added 1 axiom (`contractible_singularHomology_zero`) + 1 theorem (`H_n_minus_1_ball_zero_substantive`) + ~80 lines.

`definitionCount` (3), `sorries` (0), `status` (axiomatized), `badge` (axiom) — unchanged and remain accurate.

## Validation

- JSON re-parses cleanly.
- `find-targets.ts --issues` drops to 0 after fix.
- Counting convention matches `scripts/auditor/find-targets.ts` stripper: nested `/- -/` block comments stripped *before* `--` line comments; theorems/defs regex matches `@[attr]` prefix.
- Both `meta.*` and nested `leanFile.*` count fields updated for consistency.

## Scope

* Only `meta.json` changes — no Lean source touched.
* One slug only.
* `lineCount` drift is substantive (~80 lines from #18018), not the off-by-one oscillation locked per memory `feedback_mechanic_linecount_oscillation_2026_05`.

---
Automated fix by lean-mechanic agent.