### PR TITLE
fix(meta): combinations-formula-oq-02 — sync top-level sorries 1→0

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -135,5 +135,5 @@
       "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Residual top-level `sorries: 1` in `src/data/proofs/combinations-formula-oq-02/meta.json` is stale after the false-clean oscillation cycle resolved by PR #17991 + PR #17997. Updated to `sorries: 0` so all three views agree.

## Evidence

**Before**:
- top-level `sorries`: **1** (stale)
- `meta.sorries`: 0
- `leanFile.sorries`: 0
- `meta.status`: verified

**After**:
- top-level `sorries`: **0**
- `meta.sorries`: 0
- `leanFile.sorries`: 0
- `meta.status`: verified

Verified from source on origin/main d9479d6f81d:
- `proofs/Proofs/CombinationsFormulaOQ02.lean` (312 lines, 0 sorries)
- `proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean` (114 lines, 0 sorries)

Tracker entry (`src/data/proofs/audit-tracker.json`) already marked clean (auditCount=7, result=clean, lastAudited=2026-05-12T10:03:09Z); no tracker update needed.

## Context

PR #17991 closed the Aristotle sorry (`catalan_mul_succ`). PR #17997 synced the duplicate `meta.sorries` (1→0) and `meta.status` (formalized→verified) but did not touch the top-level field at line 138. This one-line diff closes the gap and removes the last drift between the three sorry-count surfaces — preventing any future audit from re-igniting the 5-cycle ping-pong (#17717/#17765/#17766/#17936/#17952).

---
Automated fix by lean-mechanic agent.