### PR TITLE
research(pascals-hexagon-oq-03): S3b-prep — powered semiconjugacy on (hexRot, hexRev) (build pending — parent broken)

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -221,6 +221,55 @@ theorem orderOf_hexRev : orderOf hexRev = 2 := by
     exact hexRev_ne_one
 
 -- ============================================================
+-- PART 2d: Semiconjugacy and Power-Inversion (S3b-prep)
+-- ============================================================
+-- The S2 dihedral relation `hexRev * hexRot * hexRev = hexRot⁻¹` extends
+-- to all powers via `SemiconjBy`. The four lemmas below give the form
+-- needed for the four cases of `map_mul'` in the S3c homomorphism
+-- `DihedralGroup 6 →* Equiv.Perm (Fin 6)` (built from `hexRot, hexRev`):
+--   • `r i * sr j` requires pushing `hexRot ^ i.val` past `hexRev`.
+--   • `sr i * r j` and `sr i * sr j` similarly need the powered form.
+-- All four are pure group-theory consequences of S2 + S3a; no new
+-- computation on `Equiv.Perm (Fin 6)` is required.
+
+/-- `hexRev` is self-inverse: `hexRev⁻¹ = hexRev`.
+    Immediate from `hexRev_mul_self : hexRev * hexRev = 1`. -/
+theorem hexRev_inv : hexRev⁻¹ = hexRev :=
+  inv_eq_of_mul_eq_one_right hexRev_mul_self
+
+/-- **Semiconjugacy form of the S2 relation**: `hexRev * hexRot = hexRot⁻¹ * hexRev`.
+    Equivalent to `hexRev_hexRot_hexRev` after right-multiplying by `hexRev`
+    and using `hexRev_mul_self`. Phrased via Mathlib's `SemiconjBy` so the
+    powered form follows by `SemiconjBy.pow_right`. -/
+theorem hexRev_semiconj_hexRot : SemiconjBy hexRev hexRot hexRot⁻¹ := by
+  unfold SemiconjBy
+  calc hexRev * hexRot
+      = hexRev * hexRot * 1 := by rw [mul_one]
+    _ = hexRev * hexRot * (hexRev * hexRev) := by rw [← hexRev_mul_self]
+    _ = (hexRev * hexRot * hexRev) * hexRev := by rw [← mul_assoc]
+    _ = hexRot⁻¹ * hexRev := by rw [hexRev_hexRot_hexRev]
+
+/-- **Powered semiconjugacy**: `hexRev * hexRot ^ n = (hexRot ^ n)⁻¹ * hexRev`.
+    Push form of the dihedral conjugation relation; obtained from
+    `hexRev_semiconj_hexRot` via `SemiconjBy.pow_right` plus `inv_pow`. -/
+theorem hexRev_semiconj_hexRot_pow (n : ℕ) :
+    hexRev * hexRot ^ n = (hexRot ^ n)⁻¹ * hexRev := by
+  have h : SemiconjBy hexRev (hexRot ^ n) (hexRot⁻¹ ^ n) :=
+    hexRev_semiconj_hexRot.pow_right n
+  -- `SemiconjBy.eq` extracts the equation `a * x = y * a`; rewrite `hexRot⁻¹ ^ n` to `(hexRot^n)⁻¹`.
+  rw [inv_pow] at h
+  exact h.eq
+
+/-- **Conjugation-by-`hexRev` powered form**:
+    `hexRev * hexRot ^ n * hexRev = (hexRot ^ n)⁻¹`.
+    Combines `hexRev_semiconj_hexRot_pow` with `hexRev_mul_self` to cancel
+    the trailing pair. This is the workhorse for the `sr * sr` and `r * sr`
+    cases of the S3c homomorphism's `map_mul'`. -/
+theorem hexRev_hexRot_pow_hexRev (n : ℕ) :
+    hexRev * hexRot ^ n * hexRev = (hexRot ^ n)⁻¹ := by
+  rw [hexRev_semiconj_hexRot_pow n, mul_assoc, hexRev_mul_self, mul_one]
+
+-- ============================================================
 -- PART 3: Hexagon Labelings as Sym(6) ⧸ D_6
 -- ============================================================
 
@@ -240,22 +289,31 @@ theorem card_sym6 : Fintype.card (Equiv.Perm (Fin 6)) = 720 := by
 
 /-- **OQ-03-OQ-01**: the dihedral subgroup `hexagonalGroup` has order 12.
 
-    Progress (S3a, this PR): the dihedral defining relations and the exact
-    orders of the two generators are now in hand —
-    `hexRot_pow_six`, `hexRev_mul_self`, `hexRev_hexRot_hexRev`,
-    `orderOf_hexRot` (= 6), and `orderOf_hexRev` (= 2). These pin the
-    twelve elements `{hexRot ^ i, hexRev * hexRot ^ i : i ∈ Fin 6}` to be
-    pairwise distinct (standard dihedral argument).
+    Progress so far (S2 + S3a + S3b-prep, this PR adds the third):
 
-    Remaining (S3b): (i) define a homomorphism
+    * S2 — dihedral defining relations on `(hexRot, hexRev)`:
+      `hexRot_pow_six`, `hexRev_mul_self`, `hexRev_hexRot_hexRev`.
+    * S3a — exact orders: `orderOf_hexRot` (= 6), `orderOf_hexRev` (= 2).
+    * S3b-prep — powered semiconjugacy (this PR):
+      `hexRev_inv`, `hexRev_semiconj_hexRot`, `hexRev_semiconj_hexRot_pow`,
+      `hexRev_hexRot_pow_hexRev`. These extend the S2 conjugation
+      relation from `n = 1` to all natural exponents.
+
+    Together S2 + S3a + S3b-prep give the standard dihedral toolkit:
+    the twelve elements `{hexRot ^ i, hexRev * hexRot ^ i : i ∈ Fin 6}`
+    are pairwise distinct and the four `map_mul'` cases of the
+    DihedralGroup-into-Sym(6) hom rewrite mechanically using these
+    lemmas.
+
+    Remaining (S3c): (i) define
     `φ : DihedralGroup 6 →* Equiv.Perm (Fin 6)` by
     `φ (r i) = hexRot ^ i.val`, `φ (sr i) = hexRev * hexRot ^ i.val`,
-    using the three relations for the `map_mul'` proof (the
-    modular-wraparound `i + j : ZMod 6` is discharged via
-    `hexRot_pow_six`); (ii) show `φ.range = hexagonalGroup`; (iii)
-    show `φ` is injective using `orderOf_hexRot` plus the conjugation
-    relation; then `Nat.card hexagonalGroup = Nat.card (DihedralGroup 6)
-    = 12` via `DihedralGroup.nat_card`. -/
+    using S3b-prep for the `r * sr`, `sr * r`, `sr * sr` cases and
+    `hexRot_pow_six` for the `ZMod 6` modular wraparound; (ii) show
+    `φ.range = hexagonalGroup`; (iii) show `φ` is injective using
+    `orderOf_hexRot` plus the conjugation relation; then
+    `Nat.card hexagonalGroup = Nat.card (DihedralGroup 6) = 12` via
+    `DihedralGroup.nat_card`. -/
 theorem card_hexagonalGroup : Nat.card hexagonalGroup = 12 := by
   sorry
 

--- a/research/problems/pascals-hexagon-oq-03/state.md
+++ b/research/problems/pascals-hexagon-oq-03/state.md
@@ -2,9 +2,32 @@
 
 ## Current phase
 
-**S3a ACT** — exact orders proved: `orderOf hexRot = 6`, `orderOf hexRev = 2`. Full `card_hexagonalGroup = 12` deferred to S3b (homomorphism construction).
+**S3b-prep ACT** — powered semiconjugacy lemmas (`hexRev_inv`, `hexRev_semiconj_hexRot`, `hexRev_semiconj_hexRot_pow`, `hexRev_hexRot_pow_hexRev`) added. The four `map_mul'` cases of the planned `DihedralGroup 6 →* Equiv.Perm (Fin 6)` homomorphism (S3c) now rewrite mechanically from S2 + S3a + S3b-prep.
 
 ## Latest iteration
+
+**Iteration 4** (2026-05-12, researcher-3)
+
+**Outcome**: S3b-prep complete — four new lemmas added to `proofs/Proofs/PascalsHexagonOQ03.lean` in a new PART 2d (~40 lines):
+
+| Lemma | Statement | Tactic |
+|---|---|---|
+| `hexRev_inv` | `hexRev⁻¹ = hexRev` | `inv_eq_of_mul_eq_one_right hexRev_mul_self` |
+| `hexRev_semiconj_hexRot` | `SemiconjBy hexRev hexRot hexRot⁻¹` (i.e. `hexRev * hexRot = hexRot⁻¹ * hexRev`) | `unfold SemiconjBy` + 4-step `calc` using S2's `hexRev_mul_self`, `hexRev_hexRot_hexRev`, plus `← mul_assoc` |
+| `hexRev_semiconj_hexRot_pow` | `∀ n, hexRev * hexRot ^ n = (hexRot ^ n)⁻¹ * hexRev` | `SemiconjBy.pow_right` + `rw [inv_pow]` + `.eq` projection |
+| `hexRev_hexRot_pow_hexRev` | `∀ n, hexRev * hexRot ^ n * hexRev = (hexRot ^ n)⁻¹` | `rw [hexRev_semiconj_hexRot_pow, mul_assoc, hexRev_mul_self, mul_one]` |
+
+These extend the S2 dihedral conjugation relation from `n = 1` to all natural exponents. Combined with S3a's `orderOf hexRot = 6`, they suffice to mechanically discharge the three non-trivial cases of `map_mul'` for the S3c homomorphism `φ : DihedralGroup 6 →* Equiv.Perm (Fin 6)`:
+
+- `φ (r i) * φ (sr j) = φ (sr (j - i))`: needs to push `hexRot^i.val` past `hexRev`, which `hexRev_semiconj_hexRot_pow` does (in the opposite direction; commute).
+- `φ (sr i) * φ (r j) = φ (sr (i + j))`: needs `(hexRev * hexRot^i.val) * hexRot^j.val = hexRev * hexRot^(i.val + j.val)`, a single `mul_assoc` + `pow_add`.
+- `φ (sr i) * φ (sr j) = φ (r (j - i))`: needs `(hexRev * hexRot^i.val) * (hexRev * hexRot^j.val) = hexRot^((j-i).val)`. Rewrite `hexRot^i.val * hexRev` via the semiconjugacy (push form), then collapse `hexRev * hexRev = 1`, leaving `(hexRot^i.val)⁻¹ * hexRot^j.val`. The modular wraparound `(i.val + j.val mod 6)` vs `(i + j : ZMod 6).val` is handled by `hexRot_pow_six`.
+
+**Sorry delta**: unchanged at 5 (4 new lemmas are fully proved; `card_hexagonalGroup` still sorry pending the homomorphism).
+
+**Build status**: pending. Parent `Proofs/PascalsHexagon.lean` is broken on origin/main (40 Mathlib drift errors). S1 PR #17916, S2 PR #17983, S3a PR #18026 all merged "(build pending)"; this PR follows the same precedent. No new dependencies; only uses `SemiconjBy.pow_right`, `inv_pow`, `inv_eq_of_mul_eq_one_right`, and basic associativity — all verified to exist in pinned Mathlib (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) at `Mathlib/Algebra/Group/Semiconj/Defs.lean:107` and `Mathlib/Algebra/Group/Basic.lean:409`.
+
+**Honest scope note**: S3b-prep does NOT discharge OQ-03-OQ-01. It supplies the powered-conjugation toolkit so that S3c (the homomorphism construction + range + injectivity) reduces to a mechanical case split. The hard mathematical content of S3c is the four `map_mul'` cases (especially the `ZMod 6` wraparound) and the injectivity argument; S3b-prep does not address these directly but makes the rewrite chains tractable.
 
 **Iteration 3** (2026-05-12, researcher-3)
 
@@ -93,7 +116,25 @@ Estimated S3 size: ~80–150 lines, mostly the `map_mul'` case-split and the ran
 - ACT: chose to ship `orderOf hexRot = 6` and `orderOf hexRev = 2` as S3a, decoupling the easy "exact orders" part from the substantial homomorphism construction (S3b). Rationale: the injectivity step of S3b reduces cleanly once these orders are pinned (standard dihedral argument), so S3a is a genuine prerequisite. New lemma `hexRot_pow_lt_six_ne_one` discharges the five non-trivial powers via `interval_cases m` + `congrArg (·.toFun 0)` + `native_decide` per case — avoids the fragile `simp [hexRot, finRotate]` approach used in the existing `hexRot_ne_one`/`hexRev_ne_one` sanity lemmas.
 - Verification: each `orderOf X = n` proof uses Mathlib's `orderOf_eq_iff` with positivity precondition. The 5-case `interval_cases` produces concrete goals `(hexRot ^ k) 0 = (1 : Equiv.Perm (Fin 6)) 0 → False` for k=1..5, each settled by `native_decide` after specializing the equality at 0 via `congrArg`. The `hexRev` case is one-line: `pow_one` + `hexRev_ne_one`.
 
-**Next action (S3b)**: same as listed above the S3a log — construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)` using the S2 dihedral relations and the S3a order facts for injectivity.
+### S3b-prep (2026-05-12, researcher-3)
+
+- ORIENT: claim-random selected pascals-hexagon-oq-03 again (knowledge score 28, RICH). Pre-claim checks: open PRs on slug are #17953 (enrichment), #18006/#18007 (meta drift) — same as S3a; no parallel S3b PR; `gh pr list --search "pascals-hexagon-oq-03"` returned 3 merged research PRs (S1 #17916, S2 #17983, S3a #18026 just merged 09:55 UTC) and zero open research PRs. Memory + state.md confirm parent broken; followed S1/S2/S3a "build pending" precedent.
+- ACT: chose to ship the four powered-semiconjugacy lemmas as S3b-prep, decoupling the powered-conjugation toolkit (pure group theory consequences of S2 + S3a) from the substantial homomorphism construction (S3c). Rationale: the three non-trivial `map_mul'` cases of `φ : DihedralGroup 6 →* Equiv.Perm (Fin 6)` reduce to mechanical rewrites once `hexRev * hexRot^n = (hexRot^n)⁻¹ * hexRev` and its conjugation cousin are in hand. New PART 2d (~40 lines, 4 lemmas). No new Mathlib dependencies — only `SemiconjBy.pow_right` (verified at `Mathlib/Algebra/Group/Semiconj/Defs.lean:107`), `inv_pow` (verified at `Mathlib/Algebra/Group/Basic.lean:409`), and `inv_eq_of_mul_eq_one_right`.
+- Verification: each proof uses standard Mathlib group-theory lemmas plus the S2 relations. The `hexRev_semiconj_hexRot` proof is a 4-step `calc` that inserts `hexRev * hexRev = 1` between `hexRot` and `hexRev` to expose the S2 conjugation pattern. The powered version follows by `SemiconjBy.pow_right n` + `rw [inv_pow]` + `.eq`. The conjugation form `hexRev_hexRot_pow_hexRev` is a 4-step `rw` chain. No `decide` / `native_decide` / `interval_cases` needed — pure group-theory algebra at this level.
+
+**Next action (S3c)**: construct `hexHom : DihedralGroup 6 →* Equiv.Perm (Fin 6)` using S2 + S3a + S3b-prep. Concrete plan:
+- `toFun (r i) := hexRot ^ i.val`, `toFun (sr i) := hexRev * hexRot ^ i.val` (i : ZMod 6).
+- `map_one' = rfl` (since `1 = r 0` in DihedralGroup; `hexRot^0 = 1`).
+- `map_mul'` four cases:
+  - **r-r**: `hexRot^i.val * hexRot^j.val = hexRot^((i+j).val)`. Use `pow_add` + `hexRot_pow_six` to discharge the `ZMod 6` modular wraparound.
+  - **r-sr**: `hexRot^i.val * (hexRev * hexRot^j.val) = hexRev * hexRot^((j-i).val)`. Use `hexRev_semiconj_hexRot_pow i.val` (in the form `hexRot^i.val * hexRev = hexRev * hexRot⁻¹^i.val = hexRev * (hexRot^i.val)⁻¹`) — actually need the opposite-direction push; can derive by inversion + S3b-prep.
+  - **sr-r**: `(hexRev * hexRot^i.val) * hexRot^j.val = hexRev * hexRot^((i+j).val)`. Single `mul_assoc` + `pow_add` + wraparound.
+  - **sr-sr**: `(hexRev * hexRot^i.val) * (hexRev * hexRot^j.val) = hexRot^((j-i).val)`. Use `hexRev_hexRot_pow_hexRev` to collapse `hexRev * hexRot^i.val * hexRev = (hexRot^i.val)⁻¹`, leaving `(hexRot^i.val)⁻¹ * hexRot^j.val`. Then `pow_neg` / `zpow` + wraparound.
+- Then `hexHom.range = hexagonalGroup` (≤ by induction; ≥ by `hexRot, hexRev ∈ range`).
+- Injectivity: 12 image elements pairwise distinct via S3a order facts.
+- Conclude `Nat.card hexagonalGroup = 12` via `DihedralGroup.nat_card`.
+
+Estimated S3c size: ~120–180 lines, mostly the `map_mul'` case split and the range/injectivity proofs.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Adds **PART 2d** to `proofs/Proofs/PascalsHexagonOQ03.lean` (~40 lines, 4 new lemmas) extending the S2 dihedral conjugation relation `hexRev * hexRot * hexRev = hexRot⁻¹` from `n = 1` to all natural exponents:

| Lemma | Statement |
|---|---|
| `hexRev_inv` | `hexRev⁻¹ = hexRev` |
| `hexRev_semiconj_hexRot` | `SemiconjBy hexRev hexRot hexRot⁻¹` |
| `hexRev_semiconj_hexRot_pow` | `∀ n, hexRev * hexRot ^ n = (hexRot ^ n)⁻¹ * hexRev` |
| `hexRev_hexRot_pow_hexRev` | `∀ n, hexRev * hexRot ^ n * hexRev = (hexRot ^ n)⁻¹` |

All four are pure group-theory consequences of S2 + S3a, derived via Mathlib's `SemiconjBy.pow_right` plus `inv_pow`. No new computation on `Equiv.Perm (Fin 6)`; no Mathlib drift.

## Why this matters

S3c will construct `φ : DihedralGroup 6 →* Equiv.Perm (Fin 6)` with `φ (r i) = hexRot ^ i.val` and `φ (sr i) = hexRev * hexRot ^ i.val`. The three non-trivial `map_mul'` cases — `r * sr`, `sr * r`, `sr * sr` — require pushing `hexRot ^ k` past `hexRev` or conjugating it. S3b-prep gives exactly those rewrites in their powered form.

In particular, the workhorse identity for the `sr * sr` case,
```
(hexRev * hexRot ^ i.val) * (hexRev * hexRot ^ j.val) = …
```
collapses immediately via `hexRev_hexRot_pow_hexRev` (turning the inner `hexRev * hexRot ^ i.val * hexRev` into `(hexRot ^ i.val)⁻¹`).

## Verification

API verified directly against pinned Mathlib rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:

- `SemiconjBy.pow_right` — `Mathlib/Algebra/Group/Semiconj/Defs.lean:107`
- `inv_pow` — `Mathlib/Algebra/Group/Basic.lean:409`
- `inv_eq_of_mul_eq_one_right` — `Mathlib/Algebra/Group/Basic.lean:358` (referenced)

All proofs use only standard Mathlib group-theory lemmas plus the S2 relations. No `decide` / `native_decide` / `interval_cases` — pure algebra at this level.

## Sorry delta

Unchanged at 5. The four new lemmas are fully proved; `card_hexagonalGroup` (OQ-03-OQ-01) still sorry pending the S3c homomorphism construction.

## Build status

**Pending.** Parent `Proofs/PascalsHexagon.lean` is broken on `origin/main` (~40 Mathlib drift errors, lines 360–1153). S1 PR #17916, S2 PR #17983, S3a PR #18026 all merged "(build pending)"; this PR follows the same precedent.

## Honest scope note

S3b-prep does **NOT** discharge OQ-03-OQ-01. It supplies the powered-conjugation toolkit so that S3c (the homomorphism construction + range + injectivity) reduces to a mechanical case split. The hard mathematical content of S3c — the four `map_mul'` cases (especially the `ZMod 6` wraparound via `hexRot_pow_six`) and the injectivity argument — is not addressed here, but the rewrite chains become tractable.

## Test plan

- [ ] Parent rebuild on `origin/main` (out of scope; tracked in memory's `pascals_hexagon_parent_break` note).
- [ ] S3c PR will validate `card_hexagonalGroup = 12` once the homomorphism is constructed.