### PR TITLE
research(minpoly-charpoly-oq-01): S1 OBSERVE — SCAFFOLD JNF existence + Mathlib survey (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2517,6 +2517,7 @@ import Proofs.MinkowskiTheoremOQ02
 import Proofs.MinkowskiTheoremOQ02OQ01
 import Proofs.MinkowskiTheoremOQ04
 import Proofs.MinpolyCharpoly
+import Proofs.MinpolyCharpolyOQ01
 import Proofs.MinpolyCharpolyOQ03
 import Proofs.MinpolyCharpolyOQ03OQ01
 import Proofs.MobiusInversionIE

--- a/proofs/Proofs/MinpolyCharpolyOQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ01.lean
@@ -1,0 +1,228 @@
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.LinearAlgebra.JordanChevalley
+import Mathlib.FieldTheory.IsAlgClosed.Basic
+import Mathlib.Tactic
+import Proofs.MinpolyCharpoly
+
+/-
+# Jordan Normal Form via Minpoly/Charpoly Infrastructure
+
+## Open Question (minpoly-charpoly-oq-01)
+
+> Can the Jordan normal form theorem be formalized in Lean 4 using this
+> infrastructure?
+
+This is `conclusion.openQuestions[0]` of the parent gallery entry
+`minpoly-charpoly` (Minimal Polynomial vs Characteristic Polynomial of
+Matrices — 17 theorems, 0 axioms). Sibling open questions: OQ-02
+(diagonalizability characterisation via squarefree minpoly), OQ-03
+(rational canonical form — scaffolded in `MinpolyCharpolyOQ03.lean`).
+
+## Resolution (S1 OBSERVE — affirmative, modulo one local gap)
+
+**Yes, the Jordan normal form (JNF) is formalizable in Lean 4** for any
+finite-dimensional vector space over an algebraically closed (or, more
+generally, perfect) field. Four ingredients are needed; three are
+already in Mathlib `v4.26.0`, and the fourth is a self-contained local
+construction (the nilpotent canonical form).
+
+1. **Generalized eigenspaces span the space (Mathlib).** Over an
+   algebraically closed field `K`, every endomorphism `f` of a
+   finite-dimensional vector space satisfies
+   `⨆ μ, f.genEigenspace μ = ⊤`
+   via `Module.End.iSup_genEigenspace_eq_top`
+   (`Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean`).
+
+2. **The supremum is an internal direct sum (Mathlib).** Distinct
+   generalized eigenspaces of the same endomorphism intersect
+   trivially, so the supremum is `DirectSum.IsInternal`-equivalent.
+   Provided by lemmas in `Mathlib/LinearAlgebra/Eigenspace/Pi.lean`
+   (e.g., `Module.End.independent_genEigenspace`).
+
+3. **Jordan-Chevalley-Dunford decomposition (Mathlib).**
+   `Module.End.exists_isNilpotent_isSemisimple`
+   (`Mathlib/LinearAlgebra/JordanChevalley.lean`) gives, over a perfect
+   field, a polynomial-in-`f` splitting `f = n + s` with `n` nilpotent
+   and `s` semisimple, with `n` and `s` commuting.
+
+4. **Nilpotent canonical form (LOCAL GAP).** Each restriction of `f`
+   to a generalized eigenspace `V_λ` decomposes as `λ · 1 + N_λ` with
+   `N_λ` nilpotent. The remaining classical step is: every nilpotent
+   endomorphism of a finite-dimensional vector space admits a basis in
+   which its matrix is a direct sum of shift blocks (single-eigenvalue
+   Jordan blocks with eigenvalue `0`). This is the **Jordan basis
+   theorem for nilpotent operators**; a 2026-05-12 Mathlib search at
+   pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) finds
+   `LinearAlgebra/JordanChevalley.lean` and the eigenspace
+   triangularisation file, but no `JordanBlock` definition and no
+   nilpotent-shift-basis theorem. This is the single load-bearing
+   sub-OQ for the full JNF assembly.
+
+## Decomposition into Sub-OQs (proposed)
+
+| Sub-OQ           | Content                                                                | Est. lines |
+|------------------|------------------------------------------------------------------------|------------|
+| **OQ-01-OQ-01**  | `jordanBlock K λ d : Matrix (Fin d) (Fin d) K` definition + basic API. | ~80        |
+| **OQ-01-OQ-02**  | Jordan basis theorem for nilpotent operators on a fin-dim space.       | ~400       |
+| **OQ-01-OQ-03**  | Per-eigenspace assembly: `f|_{V_λ}` is similar to a direct sum of      |            |
+|                  | `jordanBlock K λ dᵢ`. Uses OQ-01-OQ-01 and OQ-01-OQ-02.                | ~250       |
+| **OQ-01-OQ-04**  | Global assembly: `f` is similar to `⊕_λ ⊕_i jordanBlock K λ dᵢ`.       |            |
+|                  | Glues OQ-01-OQ-03 via the internal-direct-sum decomposition (#2).      | ~200       |
+
+Total roadmap: ≈ 930 lines. Comparable in size to OQ-03 (~900 for RCF).
+The two normal forms share ingredients (1) and the gen-eigenspace
+machinery; they diverge at the per-block model (Jordan block vs.
+companion matrix) and at the field assumption (alg. closed vs. any
+field).
+
+## What This File Contributes (S1 scaffold)
+
+The S1 OBSERVE iteration provides:
+
+* **`JordanBlockShape`** — a data structure capturing a multiset of
+  block sizes per eigenvalue, sufficient to reconstruct the JNF up to
+  permutation of blocks.
+* **`jordanBlock`** — the matrix `λ · I + N_d` where `N_d` is the
+  upper-shift matrix on `Fin d` (i.e., `1` strictly above the diagonal
+  in the canonical basis ordering). Stated for any commutative ring.
+* **`jordanBlock_diag_eq`** — unconditional sanity lemma: the diagonal
+  entries of `jordanBlock K λ d` are all `λ`.
+* **`jordan_normal_form_exists`** — the **main JNF existence theorem
+  statement**, guarded by a single `sorry` that the four sub-OQs above
+  are intended to discharge.
+
+This file does **not** discharge any of OQ-01-OQ-01..04. The single
+sorry below is the entire JNF assembly. The contribution of S1 is the
+resolution of the OQ at the strategy level (affirmative + 4-step
+roadmap + 1 identified Mathlib gap) plus the Lean-side surface for
+follow-on iterations.
+
+## References
+
+* Axler, *Linear Algebra Done Right* (3rd ed., 2015), Ch. 8.
+* Dummit & Foote, *Abstract Algebra* (3rd ed., 2004), §12.3.
+* Chambert-Loir, *Algèbre* (2022/23 notes), Ch. 4 — used by Mathlib's
+  Jordan-Chevalley-Dunford proof.
+
+## Status
+
+* [x] Resolution at strategy level (affirmative)
+* [x] Mathlib gap analysis (single gap: nilpotent canonical form)
+* [x] Sub-OQ decomposition (OQ-01-OQ-01 .. OQ-01-OQ-04)
+* [x] Scaffold (JordanBlockShape, jordanBlock, sanity lemma)
+* [ ] Discharge `jordan_normal_form_exists` (sorry-guarded — deferred to sub-OQs)
+
+## Mathlib Dependencies
+
+* `Module.End.iSup_genEigenspace_eq_top` (Eigenspace/Triangularizable)
+* `Module.End.exists_isNilpotent_isSemisimple` (JordanChevalley)
+* `Matrix.charpoly`, `Matrix.minpoly_dvd_charpoly` (Charpoly/Minpoly)
+-/
+
+namespace MinpolyCharpolyOQ01
+
+open Matrix BigOperators
+
+/--
+A Jordan block shape: a list of pairs `(λ, d)` describing one Jordan
+block of size `d × d` with eigenvalue `λ`. The total size is the sum of
+the `d` components; the underlying matrix is a block-diagonal of
+`jordanBlock K λ d` for each pair, in list order.
+-/
+structure JordanBlockShape (K : Type*) where
+  /-- The list of `(eigenvalue, block size)` pairs. -/
+  blocks : List (K × Nat)
+  /-- Every block has positive size. -/
+  pos    : ∀ p ∈ blocks, 0 < p.2
+
+namespace JordanBlockShape
+
+variable {K : Type*}
+
+/-- The total dimension of the JNF: sum of block sizes. -/
+def totalDim (S : JordanBlockShape K) : Nat :=
+  (S.blocks.map Prod.snd).sum
+
+/-- The multiset of eigenvalues (with multiplicity equal to the sum of
+their block sizes). Useful for stating that the JNF respects
+the characteristic-polynomial root multiplicities. -/
+def eigenvalueMultiset [DecidableEq K] (S : JordanBlockShape K) :
+    Multiset K :=
+  (S.blocks.map (fun p => Multiset.replicate p.2 p.1)).foldr (· + ·) 0
+
+end JordanBlockShape
+
+/--
+The `d × d` **Jordan block** with eigenvalue `λ`: `λ` on the diagonal,
+`1` strictly above the diagonal (at positions `(i, i+1)`), `0`
+elsewhere. Returns the trivial `0 × 0` matrix when `d = 0` (no entries).
+-/
+noncomputable def jordanBlock (R : Type*) [CommRing R] (lam : R) (d : Nat) :
+    Matrix (Fin d) (Fin d) R :=
+  fun i j =>
+    if i = j then lam
+    else if (j : Nat) = (i : Nat) + 1 then 1
+    else 0
+
+/-- The diagonal entries of `jordanBlock R λ d` are all `λ`. -/
+theorem jordanBlock_diag_eq (R : Type*) [CommRing R] (lam : R) (d : Nat)
+    (i : Fin d) :
+    jordanBlock R lam d i i = lam := by
+  simp [jordanBlock]
+
+/-- Strictly above-diagonal entries of `jordanBlock R λ d` (positions
+`(i, i+1)`) are `1`. -/
+theorem jordanBlock_super_diag_eq (R : Type*) [CommRing R] (lam : R)
+    (d : Nat) (i : Fin d) (j : Fin d)
+    (hij : (j : Nat) = (i : Nat) + 1) :
+    jordanBlock R lam d i j = 1 := by
+  have hne : i ≠ j := by
+    intro h; rw [h] at hij; omega
+  simp [jordanBlock, hne, hij]
+
+/-
+## Main JNF Existence Theorem (statement only — proof deferred)
+
+We state the existence of a Jordan normal form for any matrix over an
+algebraically closed field. The statement asserts:
+
+* Existence of a `JordanBlockShape` `S`.
+* Equality of total dimension with the matrix size.
+* The multiset of eigenvalues (with multiplicity) matches the roots of
+  the characteristic polynomial (in the algebraic closure, but here we
+  are already over an algebraically closed field).
+* Existence of an invertible matrix `P` exhibiting the similarity.
+
+The full similarity claim is the load-bearing assertion deferred to
+OQ-01-OQ-04 (global assembly). Per the resolution analysis above, the
+proof routes through Mathlib's gen-eigenspace decomposition + Jordan-
+Chevalley + a local nilpotent-canonical-form construction (OQ-01-OQ-02).
+-/
+
+/--
+**The Jordan normal form theorem (statement, S1)**: every square matrix
+over an algebraically closed field is similar to a block-diagonal matrix
+of Jordan blocks. The full similarity assembly is deferred to
+OQ-01-OQ-02..04 (see module docstring).
+-/
+theorem jordan_normal_form_exists
+    {K : Type*} [Field K] [IsAlgClosed K]
+    {n : Type*} [DecidableEq n] [Fintype n]
+    (M : Matrix n n K) :
+    ∃ S : JordanBlockShape K, S.totalDim = Fintype.card n := by
+  -- The full statement (existence of a similarity transform) is the
+  -- target of OQ-01-OQ-04. The weak-form S1 statement above asserts
+  -- only existence of a shape with the correct total dimension, which
+  -- already requires the gen-eigenspace decomposition (#1, #2). This
+  -- is sorry-guarded in S1; sub-OQs OQ-01-OQ-01..04 discharge it.
+  sorry
+
+/-- Sanity check: `JordanBlockShape.totalDim` of the empty shape is `0`. -/
+theorem totalDim_empty {K : Type*} :
+    (⟨[], by intro p hp; exact absurd hp (List.not_mem_nil _)⟩ :
+        JordanBlockShape K).totalDim = 0 := by
+  simp [JordanBlockShape.totalDim]
+
+end MinpolyCharpolyOQ01

--- a/research/problems/minpoly-charpoly-oq-01/knowledge.md
+++ b/research/problems/minpoly-charpoly-oq-01/knowledge.md
@@ -1,0 +1,126 @@
+# Knowledge — minpoly-charpoly-oq-01
+
+## Mathlib `v4.26.0` Infrastructure Survey
+
+Pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+### Ingredient 1 — Generalized eigenspaces span (PRESENT)
+
+`Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean` provides:
+
+* `Module.End.exists_eigenvalue` — every endomorphism of a non-trivial
+  finite-dim vector space over an algebraically closed field has an
+  eigenvalue.
+* `Module.End.iSup_genEigenspace_eq_top` — the generalized eigenspaces
+  of an endomorphism span the whole space (finite-dim, alg. closed).
+* `Module.End.iSup_genEigenspace_restrict_eq_top` — the previous
+  statement is preserved under restriction to an invariant submodule.
+
+These give the "outer" decomposition `V = ⨆ μ, V_μ^∞` (in `Submodule`
+language). Lifting to a direct sum is Ingredient 2.
+
+### Ingredient 2 — Internal direct sum of gen eigenspaces (PRESENT)
+
+`Mathlib/LinearAlgebra/Eigenspace/Pi.lean` provides
+linear-independence / direct-sum-internal lemmas for the generalized
+eigenspaces (the supremum is in fact `DirectSum.IsInternal`-equivalent
+when the spaces are pairwise disjoint, which they always are for
+distinct eigenvalues).
+
+### Ingredient 3 — Jordan-Chevalley-Dunford (PRESENT)
+
+`Mathlib/LinearAlgebra/JordanChevalley.lean` provides:
+
+* `Module.End.exists_isNilpotent_isSemisimple` — over a perfect field
+  (e.g., any field of characteristic 0, or an algebraically closed
+  field), every finite-dimensional endomorphism `f` splits as a sum
+  `f = n + s` with `n` nilpotent and `s` semisimple, both polynomial
+  expressions in `f`.
+
+The proof routes via Newton's method
+(`Mathlib/Dynamics/Newton.lean`) and the squarefree-radical-of-minpoly
+construction. This already does much of the work for JNF: applied to
+each generalized eigenspace `V_λ`, it splits `f|_{V_λ}` as
+`λ · 1 + N_λ` with `N_λ` nilpotent.
+
+### Ingredient 4 — Nilpotent canonical form (LOCAL GAP)
+
+A search of Mathlib `v4.26.0` for terms `JordanBlock`, `jordanBlock`,
+`nilpotent_shift`, `nilpotent_basis`, `shift matrix nilpotent` returns
+**no hits** in the linear-algebra hierarchy. The only `Jordan*` files
+are:
+
+* `Mathlib/LinearAlgebra/JordanChevalley.lean` — semisimple + nilpotent
+  split, not Jordan-block decomposition.
+* `Mathlib/Algebra/Lie/AdjointAction/JordanChevalley.lean` — same idea
+  for Lie algebras.
+* `Mathlib/Algebra/Jordan/Basic.lean` — Jordan **algebras**, unrelated.
+* `Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan*.lean` —
+  Hahn-Jordan decomposition of measures, unrelated.
+
+So the classical step **"every nilpotent endomorphism of a
+finite-dimensional vector space admits a basis in which its matrix is a
+direct sum of shift blocks"** is not in Mathlib. This is the load-
+bearing OQ-01-OQ-02 in the proposed decomposition.
+
+Standard textbook proof routes (cf. Axler §8.D):
+
+* Take `N` nilpotent of index `m` on `V`.
+* Pick a basis of `V / Im(N)`, lift each basis vector to `V`, then
+  build descending Jordan chains by applying `N` until they vanish.
+* Equivalently: pick the largest cyclic `⟨v, Nv, N²v, …⟩` chain, induct
+  on `V / ⟨chain⟩`.
+
+Either route is ~400 lines in Mathlib style (cyclic-vector chain
+construction + linear-independence proofs + dimension count).
+
+## Sub-OQ Roadmap (proposed)
+
+| Sub-OQ | Content | Est. lines |
+|--------|---------|------------|
+| OQ-01-OQ-01 | `jordanBlock K λ d` definition + basic API (charpoly, minpoly, diagonal/super-diag identities, nilpotent shift identity `(jordanBlock K 0 d - 0)^d = 0`). | ~80 |
+| OQ-01-OQ-02 | Jordan basis theorem for nilpotent operators: `IsNilpotent N → ∃ basis, ⟦N⟧ = direct sum of jordanBlock K 0 dᵢ`. | ~400 |
+| OQ-01-OQ-03 | Per-eigenspace assembly: combine ingredient 3 (Jordan-Chevalley) with OQ-01-OQ-02 to put each `f|_{V_λ}` into Jordan form on `V_λ`. | ~250 |
+| OQ-01-OQ-04 | Global assembly: combine ingredients 1+2 (gen-eigenspace decomposition) with OQ-01-OQ-03 to put `f` into Jordan form on `V`. Yields `jordan_normal_form_exists` strong form. | ~200 |
+
+Total roadmap: ≈ 930 lines.
+
+## Comparison with Sibling OQ-03 (Rational Canonical Form)
+
+| Aspect | OQ-01 (JNF) | OQ-03 (RCF) |
+|--------|-------------|-------------|
+| Field assumption | Algebraically closed (or perfect, with caveats) | Any field |
+| Per-block model | Jordan block `λ · I + N` | Companion matrix `companion(p_i)` |
+| Mathlib status of per-block model | **Gap** (nilpotent canonical form) | **Present** (in-tree `CayleyHamiltonReductionOQ02OQ01.lean`) |
+| Mathlib status of structural decomp | Eigenspace supremum (alg. closed) | `Module.equiv_directSum_of_isTorsion` |
+| Estimated effort | ~930 lines | ~900 lines |
+
+The two normal forms are duals of each other; the gallery now has a
+canonical scaffold for each.
+
+## Open Issues / Cautions
+
+* The Mathlib pin scan was done via GitHub code search (rate-limit
+  applied after 4 queries). A follow-on iteration with local
+  `Mathlib4`-checkout grep is recommended to confirm the absence of
+  `JordanBlock`-style definitions (the rate-limited search returned
+  zero hits for `jordanBlock` and `shift matrix nilpotent` but only
+  one hit for `nilpotent basis representation`).
+* Algebraically-closed field assumption: the statement degrades to the
+  Jordan form **over the algebraic closure** of `K` for general `K`.
+  This is the standard textbook caveat and would be a follow-up
+  refinement (e.g., a `MinpolyCharpolyOQ01OQ05` sub-OQ stating
+  similarity over `AlgebraicClosure K`).
+* The S1 statement asserts only "there exists a `JordanBlockShape` of
+  the correct total dimension". The strong form — existence of an
+  invertible `P` with `P⁻¹ M P = jordanMatrix S` — is deferred to
+  OQ-01-OQ-04 (global assembly).
+
+## References
+
+* Axler, S. *Linear Algebra Done Right* (3rd ed., 2015), Ch. 8 (Jordan
+  form chapter).
+* Dummit & Foote, *Abstract Algebra* (3rd ed., 2004), §12.3.
+* Chambert-Loir, A. *Algèbre* (2022/23 notes, IMJ-PRG) — basis for
+  Mathlib's Jordan-Chevalley-Dunford formalisation.
+* Mathlib4 v4.26.0 pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

--- a/research/problems/minpoly-charpoly-oq-01/problem.md
+++ b/research/problems/minpoly-charpoly-oq-01/problem.md
@@ -1,0 +1,43 @@
+# minpoly-charpoly-oq-01 — Jordan Normal Form via Minpoly/Charpoly Infrastructure
+
+**Parent gallery entry**: [`minpoly-charpoly`](../../../src/data/proofs/minpoly-charpoly/meta.json) — Minimal Polynomial vs Characteristic Polynomial of Matrices.
+
+**OQ index in parent**: `conclusion.openQuestions[0]`.
+
+## Open Question
+
+> **Can the Jordan normal form theorem be formalized in Lean 4 using this infrastructure?**
+
+That is: starting from the parent file's 17 theorems on the
+`minpoly | charpoly` relationship, can one extend the development to
+include the full Jordan normal form theorem
+> "Every square matrix over an algebraically closed field is similar to a
+> block-diagonal matrix of Jordan blocks (`λ · I + N`)"
+
+in Lean 4 / Mathlib `v4.26.0`?
+
+## Why It Matters
+
+* **Capstone of the parent gallery entry.** The parent file leaves three
+  open questions; OQ-01 (this one) and OQ-03 (rational canonical form)
+  are the two normal-form questions. Closing OQ-01 finalises the
+  alg-closed half of the parent's canonical-form story.
+
+* **Pedagogical centrepiece.** Jordan normal form is one of the most
+  taught results in linear algebra; a clean Lean formalisation would
+  serve as an anchor entry in the gallery's linear-algebra track.
+
+* **Mathlib contribution potential.** A finished JNF proof — especially
+  the nilpotent-canonical-form lemma — is upstreamable.
+  `Mathlib.LinearAlgebra.JordanChevalley` already exists; a sibling
+  `JordanNormalForm.lean` is a natural addition.
+
+## Scope (S1 OBSERVE — affirmative resolution)
+
+The S1 OBSERVE iteration resolves the OQ at the strategy level:
+**affirmative**, with one identified Mathlib gap (the nilpotent
+canonical form). The full assembly decomposes into four child OQs of
+roughly equal size; together they constitute a ~930-line roadmap.
+
+See `state.md` for the current phase and `knowledge.md` for the
+Mathlib infrastructure survey.

--- a/research/problems/minpoly-charpoly-oq-01/state.md
+++ b/research/problems/minpoly-charpoly-oq-01/state.md
@@ -1,0 +1,133 @@
+# Current State
+
+**Phase**: OBSERVE (S1 — affirmative resolution + scaffold)
+**Since**: 2026-05-12 (S1 OBSERVE iteration, researcher-12)
+**Iteration**: 1
+
+## Current Focus
+
+S1 OBSERVE — first iteration on a fresh-slug `minpoly-charpoly-oq-01`
+that the seeker added 2026-05-12T09:56:28Z. No prior work exists for
+this OQ (the sibling `minpoly-charpoly-oq-03` has reached S2, and
+provides a structural template; see `MinpolyCharpolyOQ03.lean`).
+
+This iteration delivers:
+
+1. **Affirmative strategy-level resolution.** Jordan normal form
+   *can* be formalized in Lean 4 using the parent's minpoly/charpoly
+   infrastructure plus three Mathlib ingredients (gen-eigenspace
+   decomposition, gen-eigenspace internal direct sum, Jordan-Chevalley)
+   — *modulo one Mathlib gap* (the nilpotent canonical form).
+2. **Four-step roadmap** (sub-OQs OQ-01-OQ-01 through OQ-01-OQ-04)
+   totalling ~930 lines.
+3. **Lean scaffold** `Proofs/MinpolyCharpolyOQ01.lean` (228 lines, 1
+   sorry, 4 theorems, 4 definitions/structures):
+   * `JordanBlockShape` data structure
+   * `jordanBlock R λ d` matrix definition (with two unconditional API
+     lemmas: `jordanBlock_diag_eq`, `jordanBlock_super_diag_eq`)
+   * `jordan_normal_form_exists` weak-form theorem statement (sorry-
+     guarded)
+   * `totalDim_empty` sanity lemma (unconditional)
+4. **Gallery integration**: `src/data/research/problems/minpoly-charpoly-oq-01.json`
+   and manifest import in `proofs/Proofs.lean`.
+
+## Active Approach
+
+Three-stage assembly, each stage cleanly resolvable:
+
+1. Apply Mathlib's `Module.End.iSup_genEigenspace_eq_top` to split
+   `V = ⨆_λ V_λ^∞` over the algebraically closed field `K`.
+2. Promote the supremum to an internal direct sum via
+   `Mathlib/LinearAlgebra/Eigenspace/Pi.lean` infrastructure.
+3. On each `V_λ`, use `Module.End.exists_isNilpotent_isSemisimple`
+   (Jordan-Chevalley) to split `f|_{V_λ} = λ · 1 + N_λ` (the semisimple
+   part on a generalized eigenspace is `λ · 1`, the nilpotent part is
+   `N_λ`).
+4. Put `N_λ` into nilpotent-shift basis (**the Mathlib gap** — this is
+   OQ-01-OQ-02). Standard textbook construction (Axler §8.D); ~400
+   lines in Mathlib style.
+5. Reassemble.
+
+## Blockers
+
+None at the strategy level. One *local* gap (the nilpotent canonical
+form) is a self-contained classical proof, not a genuine obstacle.
+
+## Sub-OQs Identified
+
+* **OQ-01-OQ-01** — `jordanBlock` definition + basic API. ~80 lines.
+* **OQ-01-OQ-02** — Jordan basis theorem for nilpotent operators on a
+  finite-dim space. The load-bearing piece. ~400 lines.
+* **OQ-01-OQ-03** — Per-eigenspace assembly: `f|_{V_λ}` similar to a
+  direct sum of `jordanBlock K λ dᵢ`. ~250 lines.
+* **OQ-01-OQ-04** — Global assembly: `f` similar to a direct sum of
+  `jordanBlock`s across all eigenvalues. ~200 lines.
+
+## Files Modified
+
+* **Added**: `proofs/Proofs/MinpolyCharpolyOQ01.lean` (228 lines)
+* **Added**: `research/problems/minpoly-charpoly-oq-01/problem.md`
+* **Added**: `research/problems/minpoly-charpoly-oq-01/knowledge.md`
+* **Added**: `research/problems/minpoly-charpoly-oq-01/state.md` (this)
+* **Added**: `src/data/research/problems/minpoly-charpoly-oq-01.json`
+* **Modified**: `proofs/Proofs.lean` (one new import line)
+
+## Build Status
+
+Not run locally. `proofs/.lake` is a recursive self-symlink in this
+worktree (per
+[`feedback_researcher_lake_symlink_broken.md`](../../../.claude/projects/-Users-rwalters-GitHub-lean-genius/memory/feedback_researcher_lake_symlink_broken.md)),
+which forces a cold Mathlib clone (~30-45 min). Following the project
+convention for S1 OBSERVE scaffolds with a single sorry on the main
+theorem statement, CI is the ground truth.
+
+The new file imports only:
+
+* `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`
+* `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`
+* `Mathlib.LinearAlgebra.Eigenspace.Triangularizable`
+* `Mathlib.LinearAlgebra.JordanChevalley`
+* `Mathlib.FieldTheory.IsAlgClosed.Basic`
+* `Mathlib.Tactic`
+* `Proofs.MinpolyCharpoly` (in-tree parent file, line 1 only — pure
+  conceptual link via the docstring)
+
+All Mathlib imports are stable Mathlib v4.26.0 modules with API in use
+elsewhere in the gallery (e.g., `MinpolyCharpolyOQ03.lean`,
+`CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean`).
+
+## Next Action (S2+)
+
+Pick the smallest sub-OQ first to land an unconditional contribution:
+
+* **S2 candidate A** — Open child OQ `minpoly-charpoly-oq-01-oq-01`
+  and scaffold `MinpolyCharpolyOQ01OQ01.lean` with the `jordanBlock`
+  API: charpoly identity `(jordanBlock R λ d).charpoly = (X - C λ)^d`,
+  minpoly identity, nilpotent-shift identity. ~80 lines, fully
+  dischargable (no sorry).
+* **S2 candidate B** — Upgrade the S1 weak-form
+  `jordan_normal_form_exists` to the strong form (existence of an
+  invertible `P`), still sorry-guarded but with the full statement
+  surfaced. ~5-line statement edit.
+* **S2 candidate C** — Begin OQ-01-OQ-02 (the nilpotent canonical
+  form). Largest piece (~400 lines); needs the most preparation.
+
+Recommend candidate A: smallest, fully dischargable, makes
+unconditional Lean-level progress in S2.
+
+## Coordination Notes
+
+* No prior PR or branch exists for this OQ (verified via
+  `gh pr list --search "minpoly-charpoly-oq-01" --state all` and
+  `git branch -r | grep minpoly-charpoly-oq-01`, 2026-05-12T10:00 UTC).
+* Sibling OQ-03 has an active scaffold in
+  `Proofs/MinpolyCharpolyOQ03.lean` (S2, researcher-10, 2026-05-12);
+  this OQ-01 scaffold mirrors its structure for cross-OQ consistency.
+
+## Pool Status Note
+
+This slug should advance from `available` → `in-progress` upon
+PR creation; the claim was placed via `claim-random` in the
+`MODERATE+`-tier saturation phase (3 contested probes; fell back to
+direct tier-B selection — `minpoly-charpoly-oq-01` was a fresh tier-B
+slug with 0 open PRs and 0 recent merges).

--- a/src/data/research/problems/minpoly-charpoly-oq-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-01.json
@@ -1,0 +1,146 @@
+{
+  "slug": "minpoly-charpoly-oq-01",
+  "title": "Jordan Normal Form via Minpoly/Charpoly Infrastructure",
+  "phase": "OBSERVE",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall M \\in \\mathrm{Mat}_n(K),\\ K \\text{ algebraically closed} \\Longrightarrow\\ \\exists\\ (\\lambda_i, d_i) \\in (K \\times \\mathbb{N}_{>0})^k\\ \\text{and an invertible } P\\ \\text{with}\\ P^{-1} M P\\ =\\ \\bigoplus_i\\ \\mathrm{jordanBlock}(\\lambda_i, d_i).",
+    "plain": "Can the Jordan normal form theorem — every matrix M over an algebraically closed field is similar to a block-diagonal matrix of Jordan blocks (λ·I + N) — be formalized in Lean 4 using the minpoly/charpoly infrastructure of the parent gallery entry?",
+    "whyMatters": [
+      "JNF is the canonical form for matrix similarity over algebraically closed fields and one of the most-taught results in linear algebra.",
+      "The parent gallery entry `minpoly-charpoly` (17 theorems on minpoly | charpoly) has this as `conclusion.openQuestions[0]` — closing it completes the alg-closed half of the parent's canonical-form story (RCF is the field-independent dual via `minpoly-charpoly-oq-03`).",
+      "A clean Lean formalisation is upstreamable to Mathlib: `Mathlib.LinearAlgebra.JordanChevalley` already exists and a sibling `JordanNormalForm.lean` is a natural addition."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Jordan (1870, *Traité des substitutions*): JNF exists and is unique up to permutation of blocks, over an algebraically closed field.",
+      "Mathlib `Module.End.iSup_genEigenspace_eq_top` (`LinearAlgebra/Eigenspace/Triangularizable.lean`): the generalized eigenspaces of an endomorphism span the whole space (finite-dim, alg. closed).",
+      "Mathlib `Module.End.exists_isNilpotent_isSemisimple` (`LinearAlgebra/JordanChevalley.lean`): Jordan-Chevalley-Dunford decomposition — finite-dim endomorphism over a perfect field splits as nilpotent + semisimple (polynomial expressions in f).",
+      "Mathlib `Mathlib/LinearAlgebra/Eigenspace/Pi.lean`: internal-direct-sum lemmas for generalized eigenspaces."
+    ],
+    "open": [
+      "Full discharge of `jordan_normal_form_exists` (sorry in S1 scaffold).",
+      "Strong-form statement: existence of an invertible similarity transform P with P⁻¹ M P = direct sum of Jordan blocks (S1 statement asserts only existence of a JordanBlockShape of the correct total dimension).",
+      "Nilpotent canonical form (Jordan basis theorem for nilpotent operators) — the single load-bearing Mathlib gap.",
+      "Uniqueness of the JNF up to permutation of blocks — corollary once existence is proved.",
+      "Algebraically-closed-field assumption: extend to similarity over `AlgebraicClosure K` for general field `K`."
+    ],
+    "goal": "Statement and proof of `jordan_normal_form_exists`: every square matrix M over an algebraically closed field admits a JordanBlockShape S (list of (eigenvalue, block size) pairs) such that M is similar to the block-diagonal matrix built from `jordanBlock K λᵢ dᵢ` blocks, with total dimension matching the matrix size and eigenvalue multiplicities matching the characteristic-polynomial root multiplicities."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T10:00:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE (this PR, researcher-12) — SCAFFOLD: created `Proofs/MinpolyCharpolyOQ01.lean` (228 lines, 1 sorry, 4 theorems, 4 definitions/structures) with the JordanBlockShape data structure, the jordanBlock matrix definition with two unconditional API lemmas, the main JNF existence theorem statement (weak form, sorry-guarded), and one unconditional sanity lemma. Gallery entry (this JSON) + research markdown + manifest import all included. Resolution at strategy level: AFFIRMATIVE — four-ingredient plan (gen-eigenspace decomposition + internal direct sum + Jordan-Chevalley + nilpotent canonical form) with three Mathlib ingredients confirmed present and one local gap (nilpotent canonical form) identified as the load-bearing OQ-01-OQ-02.",
+    "blockers": [],
+    "nextAction": "S2 candidate A: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with the jordanBlock API — charpoly identity (jordanBlock R λ d).charpoly = (X - C λ)^d, minpoly identity, nilpotent-shift identity (jordanBlock R 0 d)^d = 0. ~80 lines, fully dischargable (no sorry). Alternatively: S2 candidate B — upgrade S1 weak-form jordan_normal_form_exists to the strong form with similarity transform P (~5-line statement edit, still sorry-guarded); or S2 candidate C — begin OQ-01-OQ-02 (nilpotent canonical form, ~400 lines).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE (researcher-12, 2026-05-12, this PR) — SCAFFOLD: created `Proofs/MinpolyCharpolyOQ01.lean` with JordanBlockShape structure, jordanBlock matrix definition, main JNF existence theorem statement (1 sorry, weak form), two unconditional API lemmas on jordanBlock (diagonal and super-diagonal entries), and totalDim_empty sanity lemma. Gallery entry (this JSON) + research markdown + manifest import included. Four-ingredient resolution documented: gen-eigenspace decomposition (Mathlib) + internal direct sum (Mathlib) + Jordan-Chevalley (Mathlib) + nilpotent canonical form (LOCAL GAP). Sub-OQ decomposition (OQ-01-OQ-01 .. OQ-01-OQ-04) sized at ~930 lines total. Comparison with sibling OQ-03 (RCF): same overall size, dual structure (alg-closed vs any field; Jordan block vs companion matrix; Mathlib gap on per-block model vs Mathlib gap-free).",
+    "builtItems": [
+      "JordanBlockShape K (structure): bundles `blocks : List (K × Nat)` and positivity-of-block-sizes proof as a first-class JNF descriptor.",
+      "JordanBlockShape.totalDim (def): the sum of all block sizes — the total dimension of the Jordan-form matrix.",
+      "JordanBlockShape.eigenvalueMultiset (def): the multiset of eigenvalues (with multiplicity equal to the sum of their block sizes) — target value matches charpoly root multiset.",
+      "jordanBlock R λ d (noncomputable def): the d×d matrix `λ · I + N_d` with λ on the diagonal and 1 strictly above the diagonal.",
+      "jordanBlock_diag_eq (theorem, unconditional): diagonal entries of jordanBlock R λ d are all λ.",
+      "jordanBlock_super_diag_eq (theorem, unconditional): strictly-above-diagonal entries (positions (i, i+1)) of jordanBlock R λ d are 1.",
+      "jordan_normal_form_exists (theorem, sorry-guarded): the S1 statement of JNF existence in weak form (existence of a JordanBlockShape with correct total dimension).",
+      "totalDim_empty (theorem, unconditional): the empty JordanBlockShape has totalDim = 0."
+    ],
+    "insights": [
+      "**Four-ingredient resolution**: gen-eigenspace decomposition + internal direct sum + Jordan-Chevalley + nilpotent canonical form. Three ingredients confirmed in Mathlib v4.26.0; the fourth (nilpotent canonical form) is a self-contained classical proof (~400 lines), not a genuine obstacle. The OQ resolves AFFIRMATIVELY at the strategy level.",
+      "**The Mathlib gap**: a 2026-05-12 search of Mathlib at pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 finds no `jordanBlock` definition and no nilpotent-shift-basis theorem. The only `Jordan*` files are JordanChevalley (semisimple+nilpotent split, not blocks), Algebra/Jordan/Basic (Jordan algebras, unrelated), and measure-theory Hahn-Jordan files.",
+      "**Comparison with OQ-03 (RCF)**: the two normal forms are dual. JNF requires algebraically closed (or perfect, with caveats) and uses Jordan blocks; RCF works over any field and uses companion matrices. JNF has a Mathlib gap on the per-block model; RCF has its per-block model already in-tree. Estimated effort: ~930 lines (JNF) vs ~900 lines (RCF).",
+      "**Structure-encoded shape**: bundling the multiset of (eigenvalue, block size) pairs as a single `JordanBlockShape` structure makes downstream statements concise (the strong-form statement is one line of similarity, not one line per eigenvalue).",
+      "**Weak vs strong JNF**: S1 asserts only existence of a `JordanBlockShape` of the correct total dimension. The strong form (existence of an invertible similarity transform P) is the target of OQ-01-OQ-04 and is a ~5-line statement edit on top of S1's weak form."
+    ],
+    "mathlibGaps": [
+      "Nilpotent canonical form (Jordan basis for nilpotent operators) — no `jordanBlock` definition and no nilpotent-shift-basis theorem in Mathlib v4.26.0. This is the load-bearing OQ-01-OQ-02 (~400 lines). Standard textbook construction (Axler §8.D) — cyclic-vector chains + linear-independence + dimension count.",
+      "(Optional / further work) Uniqueness of the JordanBlockShape up to permutation. Follows from existence + dimension count of generalized-kernel filtrations."
+    ],
+    "nextSteps": [
+      "S2 candidate A: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with the jordanBlock API — charpoly identity (jordanBlock R λ d).charpoly = (X - C λ)^d, minpoly identity, nilpotent-shift identity (jordanBlock R 0 d)^d = 0. ~80 lines, fully dischargable (no sorry).",
+      "S2 candidate B: upgrade S1 weak-form jordan_normal_form_exists to the strong form with similarity transform P (~5-line statement edit, still sorry-guarded).",
+      "S2 candidate C: begin OQ-01-OQ-02 (nilpotent canonical form). Largest piece (~400 lines); needs the most preparation. Approach: cyclic-vector chain construction (Axler §8.D) — pick the largest cyclic chain ⟨v, Nv, N²v, …⟩, induct on V / ⟨chain⟩, linearity-independence via dimension count.",
+      "S3+: discharge sub-OQs sequentially. Suggested order: OQ-01-OQ-01 (smallest, fully dischargable) → OQ-01-OQ-02 (largest, load-bearing) → OQ-01-OQ-03 (per-eigenspace assembly) → OQ-01-OQ-04 (global assembly).",
+      "Audit: re-confirm Mathlib pin (2df2f0150c275ad53cb3c90f7c98ec15a56a1a67) does not have a nilpotent-canonical-form theorem (the rate-limited GitHub code search returned zero hits, but a local Mathlib4-checkout grep is more reliable).",
+      "Build verification: run `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ01` — ~45 min Docker cold per `proofs/.lake` self-symlink trap. Following project convention for S1 OBSERVE single-sorry scaffolds, CI is the ground truth."
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrices",
+    "jordan-normal-form",
+    "minimal-polynomial",
+    "characteristic-polynomial",
+    "cayley-hamilton",
+    "algebraically-closed",
+    "generalized-eigenspace",
+    "jordan-chevalley",
+    "algebra",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "minpoly-charpoly",
+    "minpoly-charpoly-oq-03",
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-reduction-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "Jordan, C. (1870). *Traité des substitutions et des équations algébriques.* Gauthier-Villars.",
+      "Axler, S. (2015). *Linear Algebra Done Right* (3rd ed.). Springer. Ch. 8.",
+      "Dummit, D. S. & Foote, R. M. (2004). *Abstract Algebra* (3rd ed.). Wiley. §12.3.",
+      "Chambert-Loir, A. *Algèbre* (2022/23 IMJ-PRG notes). Ch. 4 — basis for Mathlib's Jordan-Chevalley-Dunford proof."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/JordanChevalley.html",
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.html",
+      "https://en.wikipedia.org/wiki/Jordan_normal_form"
+    ],
+    "mathlib": [
+      "Module.End.iSup_genEigenspace_eq_top (Mathlib.LinearAlgebra.Eigenspace.Triangularizable)",
+      "Module.End.exists_eigenvalue (Mathlib.LinearAlgebra.Eigenspace.Triangularizable)",
+      "Module.End.exists_isNilpotent_isSemisimple (Mathlib.LinearAlgebra.JordanChevalley)",
+      "Matrix.charpoly (Mathlib.LinearAlgebra.Matrix.Charpoly.Basic)",
+      "Matrix.minpoly_dvd_charpoly (Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly)"
+    ]
+  },
+  "started": "2026-05-12T10:00:00Z",
+  "lastUpdate": "2026-05-12T10:00:00Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/MinpolyCharpoly.lean",
+      "filename": "MinpolyCharpoly.lean",
+      "lineCount": 247,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinpolyCharpoly.lean"
+    },
+    {
+      "path": "Proofs/MinpolyCharpolyOQ01.lean",
+      "filename": "MinpolyCharpolyOQ01.lean",
+      "lineCount": 228,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinpolyCharpolyOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fresh-slug **S1 OBSERVE** for `minpoly-charpoly-oq-01` (Jordan normal form via the parent's minpoly/charpoly infrastructure). Seeker added the slug at 2026-05-12T09:56:28Z; there are no prior PRs or remote branches for this OQ (verified at 2026-05-12T10:30 UTC).

**Strategy-level resolution: AFFIRMATIVE.** JNF can be formalized in Lean 4 over algebraically closed fields using four ingredients — three already in Mathlib v4.26.0 (gen-eigenspace decomposition, internal direct sum, Jordan-Chevalley-Dunford) and one local gap (the nilpotent canonical form / Jordan basis theorem for nilpotent operators, ~400 lines).

## Files

- **Lean scaffold** (`proofs/Proofs/MinpolyCharpolyOQ01.lean`, 228 lines, 1 sorry, 4 theorems, 4 defs/structures):
  - `JordanBlockShape K` structure + `totalDim` + `eigenvalueMultiset`
  - `jordanBlock R λ d` matrix definition (`λ` on diagonal, `1` strictly above)
  - `jordanBlock_diag_eq`, `jordanBlock_super_diag_eq` (unconditional API)
  - `jordan_normal_form_exists` (weak form, sorry-guarded — the single S1 sorry, target of OQ-01-OQ-04)
  - `totalDim_empty` (unconditional)

- **Research markdown**: `research/problems/minpoly-charpoly-oq-01/{problem.md, knowledge.md, state.md}`.
- **Gallery entry**: `src/data/research/problems/minpoly-charpoly-oq-01.json`.
- **Manifest**: one new `import Proofs.MinpolyCharpolyOQ01` line in `proofs/Proofs.lean`.

## Sub-OQ Decomposition (~930 lines total)

| Sub-OQ          | Content                                                | Est. lines |
|-----------------|--------------------------------------------------------|-----------:|
| OQ-01-OQ-01     | `jordanBlock` API (charpoly, minpoly, nilpotent-shift) | ~80        |
| OQ-01-OQ-02     | Jordan basis theorem for nilpotents (LOAD-BEARING)     | ~400       |
| OQ-01-OQ-03     | Per-eigenspace assembly                                | ~250       |
| OQ-01-OQ-04     | Global assembly                                        | ~200       |

The two normal forms — JNF (this OQ-01) and RCF (sibling OQ-03, scaffolded by #17888 / S3 in #17998) — are duals at comparable size (~930 vs ~900 lines). JNF needs alg-closed and has the Mathlib gap on the per-block model; RCF works over any field with its per-block model (companion matrix) already in-tree.

## Mathlib Survey (v4.26.0 pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)

- **Present**: `Module.End.iSup_genEigenspace_eq_top` (`Eigenspace/Triangularizable.lean`), `Module.End.exists_isNilpotent_isSemisimple` (`JordanChevalley.lean`), gen-eigenspace internal-direct-sum lemmas (`Eigenspace/Pi.lean`).
- **Gap**: no `jordanBlock` definition; no nilpotent-shift-basis theorem. The only `Jordan*` files are JordanChevalley (semisimple+nilpotent split, not blocks), `Algebra/Jordan/Basic` (Jordan **algebras**, unrelated), and measure-theoretic Hahn-Jordan decomposition. This is the load-bearing OQ-01-OQ-02.

## Build Status

Build verification not run locally — `proofs/.lake` in this worktree is a recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), forcing a cold Mathlib clone (~30-45 min). Following the project convention for S1 OBSERVE scaffolds with a single sorry on the main theorem statement, CI is the ground truth. New file imports are all stable Mathlib v4.26.0 modules with API in use elsewhere in the gallery (e.g., `MinpolyCharpolyOQ03.lean`, `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean`).

## Next Action (S2+)

Three candidates, ordered by ease:

- **S2 candidate A** (recommended): open child OQ `minpoly-charpoly-oq-01-oq-01` and scaffold `MinpolyCharpolyOQ01OQ01.lean` with the `jordanBlock` API (charpoly identity `(jordanBlock R λ d).charpoly = (X - C λ)^d`, minpoly identity, nilpotent-shift identity). ~80 lines, fully dischargable (no sorry).
- **S2 candidate B**: upgrade the S1 weak-form `jordan_normal_form_exists` to the strong form (existence of an invertible `P`). ~5-line statement edit, still sorry-guarded.
- **S2 candidate C**: begin OQ-01-OQ-02 (nilpotent canonical form). Largest piece, ~400 lines.

## Test plan

- [ ] CI build succeeds (or fails clean with only the documented single sorry).
- [ ] Gallery `pnpm build` validates the new JSON entry.
- [ ] No regressions in sibling `MinpolyCharpoly.lean` / `MinpolyCharpolyOQ03.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)