### PR TITLE
audit: tracker freshness — 9 stale entries re-verified clean (2026-05-12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10998,8 +10998,8 @@
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T09:59:47Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:13:14Z",
       "result": "clean"
     },
     "erdos-985": {
@@ -11034,32 +11034,32 @@
     },
     "erdos-99": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T09:56:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:12:17Z",
       "result": "clean"
     },
     "erdos-990": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-26T18:34:14Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-12T10:11:44Z",
       "result": "clean"
     },
     "erdos-991": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:34:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:10:23Z",
       "result": "clean"
     },
     "erdos-992": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:34:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:11:07Z",
       "result": "clean"
     },
     "erdos-993": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:33:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:10:05Z",
       "result": "clean"
     },
     "erdos-994": {
@@ -11070,8 +11070,8 @@
     },
     "erdos-995": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-26T18:33:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-12T10:09:22Z",
       "result": "clean"
     },
     "erdos-996": {
@@ -11487,9 +11487,9 @@
       "result": "clean"
     },
     "furstenberg-correspondence-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-27T11:25:50Z",
+      "lastAudited": "2026-05-12T10:13:14Z",
       "result": "clean"
     },
     "furstenberg-correspondence-oq-02": {
@@ -13733,8 +13733,8 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-27T11:38:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T10:13:14Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Routine audit-tracker freshness pass. Re-audited 9 gallery entries returned by `find-targets --next` (oldest `lastAudited` from the 2026-04-26 to 2026-04-27 batch). All 9 verified clean against current `origin/main` Lean sources.

## Verification

For each entry, checked:
- `sorries` field vs `grep -c '\bsorry\b'` on the Lean file (excluding docstring mentions)
- `axiomCount` field vs `grep -cE '^axiom '` on the Lean file
- `theoremCount` / `definitionCount` fields vs declaration counts
- No `: True :=` / `:= trivial`-style stub theorems
- `status` / `badge` consistency with sorry/axiom counts

| Slug | Status / Badge | sorries | axioms | thms | defs |
|------|---------------|--------:|-------:|-----:|-----:|
| `erdos-995` | axiomatized / axiom | 0 | 2 | 5 | 12 |
| `erdos-993` | axiomatized / axiom | 0 | 3 | 3 | 13 |
| `erdos-991` | axiomatized / axiom | 0 | 1 | 5 | 11 |
| `erdos-992` | axiomatized / axiom | 0 | 2 | 3 | 9 |
| `erdos-990` | axiomatized / axiom | 0 | 4 | 3 | 12 |
| `erdos-99` | axiomatized / axiom | 0 | 1 | 1 | 14 |
| `erdos-984` | axiomatized / axiom | 0 | 3 | 2 | 9 |
| `furstenberg-correspondence-oq-01` | axiomatized / axiom | 1 | 1 | 30 | 12 |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05` | verified / original | 0 | 0 | 1 | 0 |

Notes:
- `furstenberg-correspondence-oq-01`: file has 1 real `sorry` (line 779); two additional `sorry` mentions live inside docstrings ("**Remaining sorry** (1)") and don't count. Claimed `sorries: 1` matches.
- `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05`: line 166 contains the word "axiom" but only inside a docstring describing how this WIP05 file *eliminates* the axiom used in WIP01. No actual `axiom` declaration. Claimed `axiomCount: 0` matches.
- Minor narrative drift observed but not fixed here: `erdos-995/meta.json:proofStrategy` still mentions "The single sorry is in exponent_gap" although the theorem is fully proved on origin/main. Low-priority enricher cleanup, no integrity impact.

## Test plan

- [x] `git diff --stat` shows only `src/data/proofs/audit-tracker.json` (1 file, +18/-18)
- [x] `python3 -c "import json; json.load(open(...))"` confirms JSON validity
- [x] Each updated entry's `result` remains `"clean"` and `auditCount` increments by 1
- [ ] After merge: `find-targets --stats` should show these 9 entries advance to 2026-05-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)