### PR TITLE
Enrich minpoly-charpoly-oq-03-oq-01: 7 annotations on F[X]-module scaffold

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-imports",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 8 },
+    "type": "context",
+    "title": "Imports: Cayley-Hamilton, AEval, Torsion, Finiteness",
+    "content": "Eight imports assemble the entire toolkit. `Matrix.Charpoly.{Basic,Minpoly}` provides `Matrix.charpoly`, `Matrix.aeval_self_charpoly` (matrix-level Cayley-Hamilton), and `charpoly_monic`. `Matrix.ToLin` supplies the algebra equivalence `Matrix n n F ≃ₐ[F] ((n→F) →ₗ[F] (n→F))` central to the deferred S2 torsion proof. `Polynomial.Module.AEval` gives the `Module.AEval'` synonym and the auto-firing `instFinitePolynomial`. `Module.Torsion.Basic` provides `IsTorsion`, `IsTorsionBy` and their bridge `isTorsionBy_iff_mem_annihilator`. `RingTheory.Finiteness.Defs` defines `Module.Finite` as `Submodule.FG ⊤`. The parent `MinpolyCharpolyOQ03` is imported for the `InvariantFactorChain` data structure used in §4.",
+    "mathContext": "Toolkit: $\\mathrm{aeval}_M(\\mathrm{charpoly}\\, M) = 0$, $\\mathrm{Module.AEval}'\\, \\varphi$, $\\mathrm{IsTorsion}$, $\\mathrm{InvariantFactorChain}$ from the parent.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib namespace conventions", "Module.AEval'", "Cayley-Hamilton", "InvariantFactorChain"],
+    "prerequisites": ["Lean 4 import system", "Mathlib module"]
+  },
+  {
+    "id": "ann-docstring-scope",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 10, "endLine": 78 },
+    "type": "context",
+    "title": "Top docstring: sub-OQ-01/4 position, 4-step decomposition table, S1 scope",
+    "content": "The 69-line docstring lays out the parent's four-sub-OQ decomposition of the rational canonical form (RCF): (01) F[X]-module structure (~150 LOC), (02) PID structure theorem application (~300 LOC), (03) cyclic-summand ↔ companion-block correspondence (~250 LOC), (04) global assembly of the similarity transform (~200 LOC). This file delivers (01). The S1 scope is deliberately heterogeneous: one **unconditional** instance (`xModule.instFinite`, no sorry) + three **statement-only** theorems whose proofs are deferred. The proof-route sketch for the deferred torsion proof is given in steps 1-4 of the docstring.",
+    "mathContext": "RCF existence: $\\forall M \\in \\mathrm{Mat}_n(F),\\ \\exists\\ P\\ \\mathrm{invertible},\\ P^{-1} M P = \\bigoplus_i C_{p_i}$ where $C_{p_i}$ is the companion matrix of an invariant factor $p_i$ and $p_1 \\mid p_2 \\mid \\cdots \\mid p_k$. Sub-OQ-01 supplies the input hypothesis to step 02's structure-theorem call.",
+    "significance": "context",
+    "relatedConcepts": ["rational canonical form", "invariant factors", "PID structure theorem", "scaffold-first formalization", "Frobenius/Weyr decomposition"],
+    "prerequisites": ["Dummit & Foote §12.2", "Hungerford §VII.4", "Module.equiv_directSum_of_isTorsion"]
+  },
+  {
+    "id": "ann-endo-def",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 94, "endLine": 97 },
+    "type": "definition",
+    "title": "endo: stable name for M.mulVecLin",
+    "content": "Renaming `M.mulVecLin` to `endo M` matters more than it looks: `Module.AEval'` is parameterized by an F-linear endomorphism, so every downstream reference must mention the same term. Using bare `M.mulVecLin` in successive `Module.AEval'` calls leaks the dot-notation through type ascription and produces goals like `aeval (M.mulVecLin) ...` mixed with `aeval (endo M) ...` that don't defeq-unify under `aeval` (a non-reducible algebra homomorphism). The named definition forces uniform spelling.",
+    "mathContext": "$\\mathrm{endo}\\, M : (n \\to F) \\to_{\\mathrm{lin}[F]} (n \\to F)$ defined by $v \\mapsto M v$ (the linear map of left multiplication by $M$).",
+    "significance": "supporting",
+    "relatedConcepts": ["mulVecLin", "endomorphism", "naming hygiene", "definitional unification"],
+    "prerequisites": ["Matrix.mulVecLin", "Lean 4 def vs abbrev"]
+  },
+  {
+    "id": "ann-xmodule-def",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 99, "endLine": 113 },
+    "type": "definition",
+    "title": "xModule M: F[X]-module synonym via AEval'",
+    "content": "`xModule M = Module.AEval' (endo M)` is the heart of this file. `Module.AEval'` is a Mathlib *type synonym* of `n → F` carrying a new F[X]-module structure: `p • v := aeval (endo M) p v`. Two design choices matter: (1) using `abbrev` (not `def`) keeps the synonym transparent so `Module.AEval.instFinitePolynomial` fires automatically via `inferInstance`; (2) `xModule.of` packages the F-linear equivalence between the underlying `n → F` and `xModule M` (definitionally equal types, but with different module structures over a larger ring). This equivalence is the entry point for transporting Cayley-Hamilton from the matrix side to the module side.",
+    "mathContext": "$\\mathrm{xModule}\\, M$ is $F^n$ with the polynomial action $p \\cdot v := p(M) v$. Equivalently, $M$ acts as $X$ and the $F[X]$-module structure restricts to the F-module structure on $F^n$ via the inclusion $F \\hookrightarrow F[X]$.",
+    "significance": "key",
+    "relatedConcepts": ["Module.AEval'", "type synonym", "transparent abbreviation", "polynomial action via aeval", "F[X]-module from endomorphism"],
+    "prerequisites": ["Mathlib `Polynomial.aeval`", "type synonyms in Lean 4", "module structures from algebra homomorphisms"]
+  },
+  {
+    "id": "ann-finite-instance",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 115, "endLine": 123 },
+    "type": "technique",
+    "title": "Module.Finite F[X] (no sorry) — Mathlib does all the work",
+    "content": "The one-line `inferInstance` is the substantive payoff of choosing `abbrev` over `def`. Instance synthesis chains: `Fintype n` + `Field F` ⇒ `Module.Finite F (n → F)` via `Pi.basisFun`; then `Module.AEval.instFinitePolynomial` lifts F-finiteness to F[X]-finiteness on the AEval' synonym. The mathematical content of the lift is: if {e₁, …, eₙ} spans `n → F` over F, the same vectors still span `xModule M` over F[X] because every F[X]-linear combination Σ pᵢ(M) eᵢ is also an F-linear combination of vectors of the form Mᵏ eᵢ — finite by Cayley-Hamilton (Mⁿ is an F-linear combination of M⁰, …, M^(n-1)). Mathlib has already done that argument once and for all in `instFinitePolynomial`.",
+    "mathContext": "$\\dim_F F^n = n < \\infty \\Rightarrow \\mathrm{Module.Finite}\\, F[X]\\, (\\mathrm{xModule}\\, M)$. Same generating set $\\{e_1, \\dots, e_n\\}$ works over both $F$ and $F[X]$ because $M$-iterates collapse via Cayley-Hamilton.",
+    "significance": "key",
+    "relatedConcepts": ["instance synthesis", "Pi.basisFun", "Module.AEval.instFinitePolynomial", "finite generation lifting", "Cayley-Hamilton (used implicitly by Mathlib)"],
+    "prerequisites": ["Module.Finite definition", "instance resolution chain", "module generated by a finite set"]
+  },
+  {
+    "id": "ann-torsion-statements",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 125, "endLine": 162 },
+    "type": "technique",
+    "title": "IsTorsionBy charpoly → IsTorsion: the deferred two-step",
+    "content": "Two sorry-guarded theorems separate the *Cayley-Hamilton transport* (step a) from the *nonZeroDivisor upgrade* (step b). Step a (`xModule_isTorsionBy_charpoly`): take `Matrix.aeval_self_charpoly` (matrix-level: aeval M charpoly = 0), apply naturality of `aeval` along the F-algebra equivalence `Matrix n n F ≃ₐ[F] ((n→F) →ₗ[F] (n→F))` (provided by `Matrix.toLin'`), land at `aeval (endo M) charpoly = 0` as a LinearMap, unfold the AEval' smul to get `charpoly • v = 0` for all `v`. Step b (`xModule_isTorsion`): `charpoly_monic` gives charpoly ≠ 0 in F[X]; F[X] is a domain (F is a field), so charpoly ∈ F[X]⁰. Apply the `isTorsionBy_nonZeroDivisor_implies_isTorsion` pattern. Step b is mechanical (~10 LOC); step a's technical core is the `aeval`-naturality lemma along an algebra-equivalence (~30-50 LOC).",
+    "mathContext": "**Step a**: $\\mathrm{charpoly}(M) \\cdot v = \\mathrm{aeval}(\\mathrm{endo}\\, M)(\\mathrm{charpoly}\\, M)(v) = (\\mathrm{aeval}_M\\, \\mathrm{charpoly}\\, M)\\cdot v = 0$ via Cayley-Hamilton + algebra-equivalence. **Step b**: $\\mathrm{charpoly}\\, M$ monic $\\Rightarrow \\mathrm{charpoly}\\, M \\neq 0 \\Rightarrow \\mathrm{charpoly}\\, M \\in F[X]^{\\times 0}$ (non-zero-divisors of an integral domain).",
+    "significance": "key",
+    "relatedConcepts": ["Cayley-Hamilton", "naturality of aeval", "Matrix.toLin'", "charpoly_monic", "non-zero-divisor", "integral domain"],
+    "prerequisites": ["Module.IsTorsionBy", "Module.IsTorsion", "F[X] is an integral domain when F is a field", "Polynomial.aeval as algebra homomorphism"]
+  },
+  {
+    "id": "ann-bridge-invariant-factor",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 164, "endLine": 187 },
+    "type": "insight",
+    "title": "API bridge: restate the parent's RCF target in this file's vocabulary",
+    "content": "`xModule_has_invariantFactorChain` restates the parent's `rational_canonical_form_exists` using *this file's* `xModule M`. The two formulations are mutually derivable (given the parent's `InvariantFactorChain` structure), so this isn't proof content — it's API fixedness. The benefit: OQ-03-OQ-02 can be written against `xModule_has_invariantFactorChain` without naming the parent's auxiliary structures directly, giving each sub-OQ a clean local API. This is the canonical 'bridge-statement' pattern: state the consumer's target in producer-local vocabulary, sorry-guard it, let the next iteration (or downstream sub-OQ) discharge.",
+    "mathContext": "$\\forall M \\in \\mathrm{Mat}_n(F),\\ \\exists\\ c : \\mathrm{InvariantFactorChain}\\, F,\\ c.\\mathrm{prodFactors} = \\mathrm{charpoly}(M)$. Same content as the parent's main theorem; reformulated against this file's $\\mathrm{xModule}\\, M$ to fix the bridging surface.",
+    "significance": "key",
+    "relatedConcepts": ["API surface design", "bridge statements", "sub-OQ decomposition", "InvariantFactorChain"],
+    "prerequisites": ["parent `MinpolyCharpolyOQ03.rational_canonical_form_exists`", "scaffold-first methodology"]
+  }
+]


### PR DESCRIPTION
## Summary

Enrichment pass for `minpoly-charpoly-oq-03-oq-01` (quality=43, passes=0).

- Filled empty `annotations.json` (was `[]`) with 7 substantive annotations
- All fields populated: `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`
- Annotations cover 5 sections: imports, top docstring (sub-OQ-01/4 decomposition table), `endo` definition, `xModule` abbrev (AEval' synonym), Module.Finite unconditional instance, IsTorsionBy/IsTorsion deferred two-step, OQ-03-OQ-02 bridge statement

## Highlights

- **Why abbrev not def**: explains the design choice that lets `Module.AEval.instFinitePolynomial` fire via `inferInstance` (the one unconditional result of the scaffold)
- **Cayley-Hamilton transport spelled out**: 4-step proof route (matrix-level aeval → algebra-equivalence naturality → LinearMap-level aeval → AEval' smul)
- **IsTorsionBy → IsTorsion upgrade**: ~10 LOC mechanical via `charpoly_monic` + integral-domain witness, separated from the technical 30-50 LOC step a
- **Bridge-statement pattern explained**: producer-local restatement of `rational_canonical_form_exists` to fix the OQ-03-OQ-02 API surface

## Verification

- `tsx scripts/annotations/build.ts` validates clean for this slug
- Vite step deferred to CI (Node v26 + better-sqlite3 gyp known trap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)