### PR TITLE
fix(meta): erdos-995 proofStrategy stale axiom names + nonexistent sorry claim

### DIFF
--- a/src/data/proofs/erdos-995/meta.json
+++ b/src/data/proofs/erdos-995/meta.json
@@ -71,7 +71,7 @@
     "historicalContext": "Erdős Problem #995 originated from Erdős's 1949 paper 'On the strong law of large numbers', where he discovered that sums ∑f({α n_k}) along lacunary sequences exhibit quasi-random behavior. A sequence n₁ < n₂ < ⋯ is lacunary (Hadamard gap condition) if n_{k+1}/n_k ≥ q > 1.\n\nThe connection to probability runs deep: Kac (1946) proved that cos(2πn_kα) behaves like independent random variables for lacunary {n_k}, satisfying a Central Limit Theorem. This suggested that lacunary sums should obey the Law of the Iterated Logarithm (LIL), giving the conjectured o(N√(log log N)) bound.\n\nErdős established both bounds: a constructive lower bound showing some lacunary sums grow as fast as N(log log N)^{1/2-ε}, and a universal upper bound of o(N(log N)^{1/2+ε}). In his 1964 Diophantine approximation paper, he stated his belief that the lower bound is closer to the truth.\n\nThe gap between (log log N)^{1/2} and (log N)^{1/2} has resisted 75+ years of effort. Partial progress by Berkes (1975), Philipp-Stout (1975), and Aistleitner-Berkes (2010) improved the upper bound in special cases, but the general gap remains one of the longest-standing open problems in metric number theory.",
     "problemStatement": "**Problem**: Let $n_1 < n_2 < \\cdots$ be a lacunary sequence of integers and $f \\in L^2([0,1])$. Estimate the growth of, for almost all $\\alpha$:\n$$\\sum_{1 \\leq k \\leq N} f(\\{\\alpha n_k\\})$$\n\nIs it true that for almost all $\\alpha$:\n$$\\sum_{1 \\leq k \\leq N} f(\\{\\alpha n_k\\}) = o(N\\sqrt{\\log\\log N})?$$\n\n**Known Bounds**:\n- Lower: $\\limsup \\geq N(\\log\\log N)^{1/2-\\epsilon}$ for some examples\n- Upper: Always $o(N(\\log N)^{1/2+\\epsilon})$\n\n**Status**: OPEN",
     "text": "Estimate growth of ∑_{k≤N} f({α n_k}) for lacunary sequences. Is it o(N √(log log N))? Status: OPEN. Bounds: (log log N)^{1/2-ε} ≤ growth ≤ (log N)^{1/2+ε}.",
-    "proofStrategy": "The formalization defines lacunary sequences via IsLacunary (n_{k+1} ≥ q·n_k for q > 1) and lacunarySum as ∑_{k∈Finset.range N} f(frac(α·n_k)). The main conjecture ErdosConjecture uses measure-theoretic ∀ᵐ α for 'almost all'. Lower and upper bounds are axiomatized from Erdős's 1949 and 1964 papers: erdos_lower_bound_1949 (existential, with limsup = ⊤) and erdos_upper_bound (universal). The structural results bound_gap_lower_exists and bound_gap_upper_universal are combined into erdos_995_statement. Examples verify 2^k and 3^k are lacunary (fully proved), and the Fibonacci sequence is defined. The single sorry is in exponent_gap (log log N < log N for N ≥ 3).",
+    "proofStrategy": "The formalization defines lacunary sequences via IsLacunary (n_{k+1} ≥ q·n_k for q > 1) and lacunarySum as ∑_{k∈Finset.range N} f(frac(α·n_k)). The main conjecture ErdosConjecture uses measure-theoretic ∀ᵐ α for 'almost all'. The lower and upper bounds from Erdős's 1949 and 1964 papers are axiomatized as bound_gap_lower_exists (existential, with limsup = ⊤) and bound_gap_upper_universal (universal), and combined into erdos_995_statement. Examples verify 2^k and 3^k are lacunary (fully proved), and the Fibonacci sequence is defined. The helper lemma exponent_gap (log log N < log N for N ≥ 3) is fully proved via Real.log_lt_log; the file contains 0 sorries.",
     "keyInsights": [
       "**LIL scale**: The conjecture $S_N = o(N\\sqrt{\\log\\log N})$ matches the Law of the Iterated Logarithm for i.i.d. variables with variance $\\sim N$. Kac's CLT (1946): $\\sum \\cos(2\\pi n_k \\alpha)/\\sqrt{N} \\to \\mathcal{N}(0, 1/2)$ motivates expecting LIL-scale behavior",
       "**Quasi-independence from exponential gaps**: $n_{k+1}/n_k \\geq q > 1$ forces $\\cos(2\\pi n_k \\alpha)$ to be nearly orthogonal in $L^2([0,1])$: $\\int_0^1 \\cos(2\\pi n_j \\alpha)\\cos(2\\pi n_k \\alpha)\\,d\\alpha \\approx 0$ for $j \\neq k$",
@@ -113,7 +113,7 @@
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "summary": "erdos_lower_bound_1949 (∃ f, n: limsup reaches N(log log N)^{1/2-ε}), LowerBoundGrowth (formalized growth condition)",
+      "summary": "LowerBoundGrowth (formalized growth condition: ∃ f, n: limsup reaches N(log log N)^{1/2-ε}); the corresponding existential axiom bound_gap_lower_exists appears in the Gap section",
       "startLine": 73,
       "endLine": 94,
       "mathContext": "$\\exists f, \\{n_k\\}: \\limsup |S_N|/(N(\\log\\log N)^{1/2-\\varepsilon}) = \\infty$ a.e."
@@ -121,7 +121,7 @@
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
-      "summary": "erdos_upper_bound (∀ lacunary n: sum is o(N(log N)^{1/2+ε})), UpperBoundGrowth (formalized via limsup ≤ 1)",
+      "summary": "UpperBoundGrowth (formalized via limsup ≤ 1: ∀ lacunary n, sum is o(N(log N)^{1/2+ε})); the corresponding universal axiom bound_gap_upper_universal appears in the Gap section",
       "startLine": 95,
       "endLine": 117,
       "mathContext": "$\\forall \\{n_k\\}$ lacunary, $\\forall f \\in L^2$: $S_N = o(N(\\log N)^{1/2+\\varepsilon})$ a.e."
@@ -129,7 +129,7 @@
     {
       "id": "the-gap",
       "title": "The Gap",
-      "summary": "bound_gap_lower_exists, bound_gap_upper_universal (axioms packaging the bounds), exponent_gap (log log N < log N, sorry)",
+      "summary": "bound_gap_lower_exists, bound_gap_upper_universal (axioms packaging the bounds), exponent_gap (log log N < log N for N ≥ 3, fully proved)",
       "startLine": 118,
       "endLine": 139,
       "mathContext": "$(\\log\\log N)^{1/2} \\ll (\\log N)^{1/2}$. At $N = 10^{10^{10}}$: ratio $\\approx 30{,}000$."


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/erdos-995/meta.json` narrative fields to the actual Lean source. The integrity-critical numeric fields (`sorries: 0`, `axiomCount: 2`, `theoremCount: 5`, `definitionCount: 12`, `status: axiomatized`, `assumptions`) were already correct; this PR fixes only the human-readable narrative drift the auditor flagged.

## Changes (4 narrative-field edits)

1. `overview.proofStrategy`
   - Stale: "Lower and upper bounds are axiomatized from Erdős's 1949 and 1964 papers: **erdos_lower_bound_1949** (existential, with limsup = ⊤) and **erdos_upper_bound** (universal)."
   - Fixed: "The lower and upper bounds from Erdős's 1949 and 1964 papers are axiomatized as **bound_gap_lower_exists** (existential, with limsup = ⊤) and **bound_gap_upper_universal** (universal), and combined into erdos_995_statement."
   - Stale: "The single sorry is in exponent_gap (log log N < log N for N ≥ 3)."
   - Fixed: "The helper lemma exponent_gap (log log N < log N for N ≥ 3) is fully proved via Real.log_lt_log; the file contains 0 sorries."

2. `sections[lower-bounds].summary`
   - Stale: "erdos_lower_bound_1949 (∃ f, n: limsup reaches N(log log N)^{1/2-ε}), LowerBoundGrowth (formalized growth condition)"
   - Fixed: "LowerBoundGrowth (formalized growth condition: ∃ f, n: limsup reaches N(log log N)^{1/2-ε}); the corresponding existential axiom bound_gap_lower_exists appears in the Gap section"

3. `sections[upper-bounds].summary`
   - Stale: "erdos_upper_bound (∀ lacunary n: sum is o(N(log N)^{1/2+ε})), UpperBoundGrowth (formalized via limsup ≤ 1)"
   - Fixed: "UpperBoundGrowth (formalized via limsup ≤ 1: ∀ lacunary n, sum is o(N(log N)^{1/2+ε})); the corresponding universal axiom bound_gap_upper_universal appears in the Gap section"

4. `sections[the-gap].summary`
   - Stale: "exponent_gap (log log N < log N, **sorry**)"
   - Fixed: "exponent_gap (log log N < log N for N ≥ 3, **fully proved**)"

## Evidence

`Proofs/Erdos995Problem.lean`:
- Lines 110, 113 declare `axiom bound_gap_lower_exists` and `axiom bound_gap_upper_universal` (the only two axioms).
- No `erdos_lower_bound_1949` or `erdos_upper_bound` declarations exist anywhere in the file.
- Lines 117–124 fully prove `theorem exponent_gap` via `Real.log_lt_log`. `grep -c "sorry" proofs/Proofs/Erdos995Problem.lean` returns 0.

## Scope Note

Issue #18048 explicitly called out only `proofStrategy`. While fixing it I noticed the same staleness pattern (wrong axiom names + nonexistent sorry claim) repeated in three `sections[].summary` fields of the same file — same root cause, same file, trivially adjacent edits — so they are bundled here rather than spawning a follow-up issue.

Closes #18048

---
Automated fix by lean-mechanic agent.