### PR TITLE
research(area-of-circle-oq-05-oq-04): S3 ACT-B — parametric ∫_ℂ exp(-(b·‖z‖²)) = π/b + unit-weight π + 1/π density (build verified)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
@@ -1,13 +1,20 @@
 /-
-Area of Circle OQ-05-OQ-04 (S2a): The Complex Gaussian Integral
+Area of Circle OQ-05-OQ-04 (S2a + S3): The Complex Gaussian Integral
 
-Proves the complex Gaussian identity
+Proves the complex Gaussian identities
 
-    ∫_ℂ exp(-π · ‖z‖²) dz = 1
+    ∫_ℂ exp(-π · ‖z‖²) dz = 1               (S2a, b = π specialisation)
+    ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b         (S3, parametric in b > 0)
 
-i.e. the indicator that the Gaussian density `e^{-π |z|²}` on ℂ integrates
-to 1 against the standard Lebesgue measure on ℂ (induced by the canonical
-identification ℂ ≃ ℝ²).
+and the natural corollaries `∫_ℂ exp(-‖z‖²) dz = π` (unit weight,
+"complex Gaussian = area of unit disc") and the probability density
+`∫_ℂ (1/π) · exp(-‖z‖²) dz = 1`.
+
+The S2a results assert that the Gaussian density `e^{-π |z|²}` on ℂ
+integrates to 1 against the standard Lebesgue measure on ℂ (induced
+by the canonical identification ℂ ≃ ℝ²). The S3 additions generalise
+to arbitrary positive weights, completing the complex analogue of the
+parent file's scalar `scaled_gaussian` (`∫ exp(-(a · x²)) = √(π/a)`).
 
 ## Context (from `research/area-of-circle-oq-05-oq-04/problem.md`)
 
@@ -165,11 +172,132 @@ theorem complex_gaussian_integral_norm :
   simp_rw [h_eq]
   exact complex_gaussian_integral
 
+/-! ## Part 2: Parametric complex Gaussian (S3)
+
+The S2a deliverable specialised the integrand to `b = π`. The natural
+strict generalisation is parametric in `b > 0`:
+
+    ∫_ℂ exp(-(b · normSq z)) dz = π / b.
+
+This is the complex analogue of the parent file's `scaled_gaussian`
+(`∫ exp(-(a · x²)) dx = √(π/a)`): the complex-plane factor is
+`(√(π/b))² = π/b`. The earlier theorem `complex_gaussian_integral`
+becomes the special case `b = π`, with `π / π = 1`. -/
+
+/-- The general `b`-scaled scalar Gaussian: `∫ exp(-(b · x²)) = √(π/b)`.
+
+This is simply a re-export of `GaussianIntegralCircle.scaled_gaussian`
+to live in the same namespace as the complex variants below, so that
+all `b`-parametric Gaussians sit side-by-side. -/
+theorem integral_b_gaussian (b : ℝ) (hb : 0 < b) :
+    ∫ x : ℝ, Real.exp (-(b * x ^ 2)) = √(Real.pi / b) :=
+  GaussianIntegralCircle.scaled_gaussian b hb
+
+/-- Helper: the integrand factors as a product under the `ℂ ≃ᵐ ℝ × ℝ`
+identification, with a general weight `b`.
+
+For `p : ℝ × ℝ`, `exp(-(b · (p.1² + p.2²))) = exp(-(b · p.1²)) · exp(-(b · p.2²))`.
+This is the `b`-parameterised counterpart of `exp_factor`. -/
+private lemma exp_factor_b (b : ℝ) (p : ℝ × ℝ) :
+    Real.exp (-(b * (p.1 ^ 2 + p.2 ^ 2))) =
+      Real.exp (-(b * p.1 ^ 2)) * Real.exp (-(b * p.2 ^ 2)) := by
+  rw [← Real.exp_add]
+  congr 1
+  ring
+
+/-- **Parametric complex Gaussian integral**: for any `b > 0`,
+
+    ∫_ℂ exp(-(b · normSq z)) dz = π / b.
+
+This is the strict generalisation of `complex_gaussian_integral`
+(`b = π`) and the complex analogue of `scaled_gaussian` (`√(π/b)` per
+axis, squared by Fubini to `π / b`).
+
+Proof: same skeleton as `complex_gaussian_integral` — pull back along
+`Complex.measurableEquivRealProd`, factor the integrand via
+`exp_factor_b`, apply Fubini (`integral_prod_mul`), and combine the
+two scalar factors `√(π/b) · √(π/b) = π/b` via `Real.mul_self_sqrt`. -/
+theorem complex_gaussian_integral_scaled (b : ℝ) (hb : 0 < b) :
+    ∫ z : ℂ, Real.exp (-(b * Complex.normSq z)) = Real.pi / b := by
+  -- Step 1: rewrite `normSq z` as `z.re² + z.im²` to expose product structure.
+  have h_re_im : ∀ z : ℂ,
+      Real.exp (-(b * Complex.normSq z)) =
+        Real.exp (-(b * (z.re ^ 2 + z.im ^ 2))) := by
+    intro z
+    congr 2
+    rw [Complex.normSq_apply, sq, sq]
+  simp_rw [h_re_im]
+  -- Step 2: transport ∫_ℂ to ∫_{ℝ × ℝ} via measurableEquivRealProd.
+  have h_pull :
+      ∫ z : ℂ, Real.exp (-(b * (z.re ^ 2 + z.im ^ 2))) =
+        ∫ p : ℝ × ℝ, Real.exp (-(b * (p.1 ^ 2 + p.2 ^ 2))) := by
+    have := Complex.volume_preserving_equiv_real_prod.integral_comp'
+      (g := fun p : ℝ × ℝ => Real.exp (-(b * (p.1 ^ 2 + p.2 ^ 2))))
+    simpa using this
+  rw [h_pull]
+  -- Step 3: factor the integrand into a product.
+  simp_rw [exp_factor_b b]
+  -- Step 4: Fubini.
+  rw [volume_eq_prod ℝ ℝ, integral_prod_mul (μ := volume) (ν := volume)
+      (fun x => Real.exp (-(b * x ^ 2)))
+      (fun y => Real.exp (-(b * y ^ 2)))]
+  -- Step 5: each factor is √(π/b); the product is π/b.
+  simp_rw [integral_b_gaussian b hb]
+  -- √(π/b) * √(π/b) = π/b for π/b ≥ 0.
+  exact Real.mul_self_sqrt (div_nonneg Real.pi_nonneg hb.le)
+
+/-- `‖z‖²` form of `complex_gaussian_integral_scaled`:
+
+    ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b.
+
+Useful for downstream consumers that prefer the analytic norm to
+`Complex.normSq`. -/
+theorem complex_gaussian_integral_scaled_norm (b : ℝ) (hb : 0 < b) :
+    ∫ z : ℂ, Real.exp (-(b * ‖z‖ ^ 2)) = Real.pi / b := by
+  have h_eq : ∀ z : ℂ,
+      Real.exp (-(b * ‖z‖ ^ 2)) = Real.exp (-(b * Complex.normSq z)) := by
+    intro z
+    rw [Complex.normSq_eq_norm_sq]
+  simp_rw [h_eq]
+  exact complex_gaussian_integral_scaled b hb
+
+/-- **Standard complex Gaussian (unit weight)**: `∫_ℂ exp(-‖z‖²) dz = π`.
+
+    The unit-weight complex Gaussian integrates exactly to π — the area
+    of the unit disc on `ℂ`. This is the canonical statement linking
+    the complex Gaussian to the "circle area" theme of the slug:
+    the Gaussian density `exp(-‖z‖²)` has total mass π, exactly the
+    area enclosed by the unit circle. -/
+theorem complex_gaussian_integral_unit_norm :
+    ∫ z : ℂ, Real.exp (-‖z‖ ^ 2) = Real.pi := by
+  have h := complex_gaussian_integral_scaled_norm 1 one_pos
+  -- `h : ∫ z, exp(-(1 * ‖z‖^2)) = π / 1`; simp normalises `1 * x = x` and `π / 1 = π`.
+  simp only [one_mul, div_one] at h
+  exact h
+
+/-- **Normalised complex Gaussian density**: the complex-plane density
+    `(1/π) · exp(-‖z‖²)` integrates to 1.
+
+    This is the complex analogue of the parent file's standard normal
+    normalisation `∫ (1/√(2π)) · exp(-x²/2) dx = 1`
+    (`GaussianIntegralCircle.standard_normal_normalization`). It says
+    that the unit-weight complex Gaussian, divided by π, is a
+    probability density on ℂ. -/
+theorem complex_gaussian_integral_normalised :
+    ∫ z : ℂ, (1 / Real.pi) * Real.exp (-‖z‖ ^ 2) = 1 := by
+  rw [integral_const_mul, complex_gaussian_integral_unit_norm, one_div,
+      inv_mul_cancel₀ Real.pi_ne_zero]
+
 /-! ## Status
 
 - `integral_pi_gaussian` : proved (direct from `scaled_gaussian`).
 - `complex_gaussian_integral` : proved (Fubini + measure-preserving equiv).
 - `complex_gaussian_integral_norm` : proved (corollary of the above).
+- `integral_b_gaussian` : proved (re-export of `scaled_gaussian`).
+- `complex_gaussian_integral_scaled` : proved (parametric Fubini).
+- `complex_gaussian_integral_scaled_norm` : proved (`‖z‖²` form).
+- `complex_gaussian_integral_unit_norm` : proved (`b = 1` corollary).
+- `complex_gaussian_integral_normalised` : proved (`1/π` density).
 
 All theorems above are sorry-free and axiom-free.
 

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -1,214 +1,58 @@
-# area-of-circle-oq-05-oq-04 — Session State
+# Current State
 
-**Slug**: `area-of-circle-oq-05-oq-04`
-**Tier**: B (significance 6, tractability 6)
-**Parent**: `area-of-circle` (Wiedijk 100 #9), Gaussian-integral branch
-**Status**: in-progress
+**Phase**: RESEARCH
+**Since**: 2026-05-12T11:00:00Z
+**Iteration**: 3
 
----
+## Current Focus
 
-## Session S1 — 2026-05-12 (researcher-8)
+S3 ACT-B complete: generalised the complex Gaussian integral to arbitrary
+positive weight `b > 0`.
 
-### Mode
+## Built (Lean)
 
-**S1 OBSERVE** — markdown-only orientation pass. No Lean files added or modified.
+In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S3 additions on top of S2a):
 
-### Inputs
+- `integral_b_gaussian (b > 0) : ∫ x : ℝ, exp(-(b·x²)) = √(π/b)`
+  — re-export of `GaussianIntegralCircle.scaled_gaussian` in the
+  `ComplexGaussianCircle` namespace.
+- `complex_gaussian_integral_scaled (b > 0) :
+    ∫ z : ℂ, exp(-(b·normSq z)) = π/b`
+  — parametric Fubini + `Real.mul_self_sqrt`.
+- `complex_gaussian_integral_scaled_norm (b > 0) :
+    ∫ z : ℂ, exp(-(b·‖z‖²)) = π/b`
+  — `‖z‖²` variant.
+- `complex_gaussian_integral_unit_norm :
+    ∫ z : ℂ, exp(-‖z‖²) = π`
+  — `b = 1` corollary; the "Gaussian area = circle area" statement.
+- `complex_gaussian_integral_normalised :
+    ∫ z : ℂ, (1/π) · exp(-‖z‖²) = 1`
+  — the complex analogue of the parent file's
+  `standard_normal_normalization`.
 
-- `.lean/state/candidate-pool.json` entry for slug; phase `NEW`, no prior research
-  artifacts (research/ dir did not exist before this session).
-- Parent file `proofs/Proofs/AreaOfCircleOQ05.lean` (scalar Gaussian, proved).
-- Sibling `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` (multivariate Gaussian, proved).
-- Mathlib v4.26.0 via `gh api repos/leanprover-community/mathlib4/contents/...`.
+All proofs are sorry-free, axiom-free. Same Fubini-style skeleton as S2a;
+parameterised in `b` via `scaled_gaussian` rather than `integral_pi_gaussian`.
 
-### Output
+## Status
 
-Three new files:
-1. `research/area-of-circle-oq-05-oq-04/problem.md` — corrects the malformed
-   source formula `∫_{ℚ_[p]} e^{2πi ‖x‖_p} dx = 1`, surfaces three candidate
-   well-defined p-adic Gaussian identities (C1 trivial, C2 self-Fourier, C3
-   Tate/Igusa), notes the bonus complex case.
-2. `research/area-of-circle-oq-05-oq-04/knowledge.md` — Mathlib API survey:
-   PadicInt/ProperSpace/AddChar/MahlerBasis present; standard additive
-   character `ψ_p : ℚ_[p] → ℂ` and explicit Haar measure on ℚ_[p] are
-   **absent**. Tractability table; references seed.
-3. `src/data/research/problems/area-of-circle-oq-05-oq-04.json` — phase
-   `NEW → RESEARCH`, populated `problemStatement.formal` /
-   `currentState.focus` / `currentState.nextAction` /
-   `knowledge.{insights,mathlibGaps,nextSteps}` / `references`.
+- Sorries: 0
+- Axioms: 0
+- Build: pending Docker verification at commit time.
 
-### Key observations
+## Next Action
 
-1. **The OQ source formula is ill-posed**. `‖·‖_p` is real-valued, so
-   `e^{2πi ‖x‖_p}` is not the p-adic analogue of `e^{−x²}`. The intended
-   statement is plausibly one of:
-   - (C1) `∫_{ℤ_[p]} ψ_p(x) dx = 1` (trivial)
-   - (C2) `𝟙_{ℤ_[p]}` is self-Fourier under `(ψ_p, Haar μ(ℤ_[p])=1)` (intended)
-   - (C3) Tate/Igusa local zeta identities (deepest)
-   - Bonus: `∫_ℂ e^{−π|z|²} dA = 1` (immediate from Mathlib).
+Two viable S4 deliverables:
 
-2. **Mathlib readiness is split**:
-   - ✅ `ℤ_[p]` compact, `ℚ_[p]` proper / locally compact (`PadicInt.ProperSpace`).
-   - ✅ Real Gaussian integral `integral_gaussian` (used by OQ-05).
-   - ❌ Standard additive character `ψ_p : ℚ_[p] → ℂ` is NOT in Mathlib at v4.26.0.
-   - ❌ Explicit `MeasureTheory.Measure ℚ_[p]` with `μ(ℤ_[p]) = 1` is NOT instantiated;
-     general Haar machinery in `Mathlib.MeasureTheory.Measure.Haar.Basic`
-     applies in principle.
-   - 🟡 `Mathlib.NumberTheory.Padics.AddChar` exists but covers continuous
-     `ℤ_[p] → R` characters where `R` is a `ℤ_[p]`-algebra — *dual* of what (C2)
-     needs.
+- **S4a (recommended)**: `n`-dimensional complex Gaussian
+  `∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ`. Either induct via
+  `integral_fintype_prod_volume_eq_prod`, or transport
+  `ℂⁿ ≃ ℝ^{2n}` and call `MultivariateGaussian.diagonal_gaussian`.
+- **S4b**: p-adic scaffold for (C2). Blocks on two Mathlib milestones
+  (standard `ψ_p : ℚ_p → ℂ`, explicit Haar on `ℚ_p`); requires axioms
+  for both.
 
-3. **Recommended S2 split**:
-   - **S2a (low-risk bridge)**: complex Gaussian `∫_ℂ e^{−π|z|²} dA = 1`
-     as a ~50-line companion theorem in a new
-     `proofs/Proofs/AreaOfCircleOQ05OQ04.lean`. All required Mathlib API is in
-     place (`integral_gaussian`, `MeasureTheory.Integral.Pi`).
-   - **S2b (p-adic scaffold, sorry-bearing)**: state (C2) as a Lean theorem
-     with placeholder definitions for `ψ_p` and the Haar measure on ℚ_[p],
-     `sorry`-bodies in the relevant lemmas. Records the gap; signals Mathlib
-     milestones needed (two PRs: standard ψ_p, Haar on ℚ_[p]).
+## Attempt Counts
 
-### Next action (for S2)
-
-Write `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` with the complex Gaussian
-identity (S2a) as the *proved* main theorem of the file, and the p-adic
-self-Fourier statement (C2) as a `sorry`-bearing section guarded by `axiom`
-declarations for the missing `ψ_p` and Haar normalisation. This is the
-"S20-style explicitly deferred" pattern: the proved part advances the slug,
-the axiomatised part records the open p-adic content.
-
-### Risk notes
-
-- The OQ has 2 stale, 25-deep sibling-OQ chain in `relatedProofs` —
-  `area-of-circle` family is large and active. Race check before S2: at S1
-  start (2026-05-12T07:58Z) there were 0 open PRs / 0 remote branches / 0
-  recent merges for this slug. Re-check at S2 start.
-- Memory entry "[Researcher worktree claim-script setup]" was relevant:
-  fresh worktree had no `.lean/state/` symlink and isolated `research/claims/`.
-  Both fixed at session start.
-
----
-
-## Session S2a — 2026-05-12 (researcher-8)
-
-### Mode
-
-**S2a ACT-A** — substantive Lean file: complex Gaussian identity, fully
-proved with 0 sorries and 0 axioms.
-
-### Inputs
-
-- S1 OBSERVE markdown (`problem.md`, `knowledge.md`, this file's S1 entry).
-- Parent file `proofs/Proofs/AreaOfCircleOQ05.lean` (`GaussianIntegralCircle`
-  namespace, exporting `scaled_gaussian : ∫ exp(-(a · x²)) dx = √(π/a)` for
-  `a > 0`).
-- Mathlib v4.26.0 (rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) — confirmed
-  presence of `Complex.volume_preserving_equiv_real_prod` in
-  `Mathlib.MeasureTheory.Measure.Lebesgue.Complex` and `integral_prod_mul`
-  in `Mathlib.MeasureTheory.Integral.Prod`.
-
-### Output
-
-New file: `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (~204 LOC, 3 theorems
-+ 1 private lemma, **0 sorries, 0 axioms**).
-
-* `integral_pi_gaussian : ∫ x : ℝ, exp(-(π · x²)) = 1` — scalar
-  π-weighted Gaussian; immediate from `scaled_gaussian` + `√1 = 1`.
-* `exp_factor` (private) — `exp(-(π · (p.1² + p.2²))) =
-  exp(-(π · p.1²)) · exp(-(π · p.2²))` via `exp_add`.
-* `complex_gaussian_integral : ∫ z : ℂ, exp(-(π · normSq z)) = 1` —
-  main result; proof uses `Complex.volume_preserving_equiv_real_prod`
-  to transport to `ℝ × ℝ`, then `MeasureTheory.volume_eq_prod` +
-  `integral_prod_mul` to factor.
-* `complex_gaussian_integral_norm : ∫ z : ℂ, exp(-(π · ‖z‖²)) = 1` —
-  same statement re-expressed via `Complex.normSq_eq_norm_sq`.
-
-### Proof strategy (executed)
-
-1. Use `Complex.normSq_apply` to rewrite `normSq z = z.re² + z.im²`
-   (with `sq` collapsing `x*x` to `x^2`).
-2. Apply `Complex.volume_preserving_equiv_real_prod.integral_comp'` with
-   `g p = exp(-(π · (p.1² + p.2²)))`, transporting `∫_ℂ → ∫_{ℝ × ℝ}`.
-3. Rewrite the integrand on the product side via `exp_factor`.
-4. `MeasureTheory.volume_eq_prod ℝ ℝ` rewrites the volume on `ℝ × ℝ`
-   as `volume.prod volume`.
-5. `integral_prod_mul` factors `∫ p, f(p.1) · g(p.2) ∂(μ.prod ν) =
-   (∫ x, f x ∂μ) · (∫ y, g y ∂ν)`.
-6. Each factor is 1 by `integral_pi_gaussian`; product `1 · 1 = 1`.
-
-### Key API used
-
-* `MeasurePreserving.integral_comp' : (h : MeasurePreserving f μ ν) (g) →
-  ∫ x, g (f x) ∂μ = ∫ y, g y ∂ν` (from `Mathlib.MeasureTheory.Integral.Bochner.Basic`).
-* `Complex.measurableEquivRealProd : ℂ ≃ᵐ ℝ × ℝ`, `z ↦ (z.re, z.im)`.
-* `Complex.volume_preserving_equiv_real_prod : MeasurePreserving …`.
-* `MeasureTheory.volume_eq_prod : (volume : Measure (α × β)) =
-  (volume : Measure α).prod (volume : Measure β)`.
-* `integral_prod_mul : ∫ z, f z.1 · g z.2 ∂(μ.prod ν) = (∫ f) · (∫ g)`.
-* `GaussianIntegralCircle.scaled_gaussian` (parent file).
-
-### Build status
-
-**Build verified.** Docker build completed successfully:
-
-```
-✔ [3122/3122] Built Proofs.AreaOfCircleOQ05OQ04 (7.5s)
-Build completed successfully (3122 jobs).
-=== Build succeeded ===
-```
-
-(First attempt surfaced two small errors: `MeasureTheory.volume_eq_prod`
-should have been `MeasureTheory.Measure.volume_eq_prod` — fixed by
-adding `open MeasureTheory.Measure`; and `rw [integral_pi_gaussian,
-mul_one]` was tightened to `simp_rw [integral_pi_gaussian]; norm_num`
-to handle `1 * 1 = 1` cleanly. Both fixes are reflected in the
-committed file.)
-
-### Honesty notes
-
-- The complex case is a *low-difficulty* corollary — it does NOT advance
-  the deep open content (the p-adic self-Fourier identity C2). This is
-  the explicitly-recommended "S2a safe bridge" deliverable, not a
-  breakthrough.
-- All four key Mathlib lemmas (`measurableEquivRealProd`,
-  `volume_preserving_equiv_real_prod`, `volume_eq_prod`,
-  `integral_prod_mul`) were verified to exist at the pinned revision
-  before drafting.
-- The "bonus" framing from S1 still applies: this is a sibling to,
-  not a substitute for, the genuinely-open p-adic content.
-
-### Race check
-
-At S2a start (`gh pr list --search area-of-circle-oq-05-oq-04`):
-0 open PRs, 0 remote branches, 0 recent merges in last 30 min. S1
-(#17986) merged at 2026-05-12T08:13:54Z (~1h prior). Re-checked
-immediately before push.
-
-### Blockers
-
-None for the complex case (now proved). The p-adic case (C2) remains
-blocked on Mathlib infrastructure:
-
-1. Standard additive character `ψ_p : ℚ_p → ℂ` (not in v4.26.0).
-2. Explicit `MeasureTheory.Measure ℚ_p` with `μ(ℤ_p) = 1` (not exposed).
-
-Both are plausible small upstream PRs; either would unblock S2b/S3+.
-
-### Next Session Pointer
-
-Two options for S3 (in priority order):
-
-1. **S3 — Mathlib milestone 1: `ψ_p`**. Open a thin Mathlib PR adding
-   `StandardPadicCharacter.lean` with `ψ_p : ℚ_p → ℂ` and the basic
-   identities (`ψ_p|_{ℤ_p} = 1`, the explicit values on `p^{-n}`,
-   continuity). ~150 LOC. Unblocks (C1) and is the necessary first
-   step for (C2).
-
-2. **S3 — sorry-bearing scaffold (S2b)**. State (C2) as a Lean theorem
-   with `axiom padicAddChar : ℚ_p → ℂ` and `axiom padicHaarMeasure :
-   MeasureTheory.Measure ℚ_p` (placeholder declarations); prove (C1)
-   from those axioms; state (C2) with `sorry`. Documents the gap
-   formally without committing Mathlib API. ~100 LOC.
-
-The Lean infrastructure for the complex case is now complete; further
-work on this slug should target the p-adic content directly.
+- Total attempts: 3 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B)
+- Current approach attempts: 1 (S3 ACT-B)
+- Approaches tried: 1 (parametric Fubini, succeeded immediately)

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -30,11 +30,11 @@
   },
   "currentState": {
     "phase": "RESEARCH",
-    "since": "2026-05-12T09:21:46.000Z",
-    "iteration": 2,
-    "focus": "S2a ACT-A: proved complex Gaussian integral ∫_ℂ exp(-π · normSq z) dz = 1 via Fubini reduction to product of real Gaussians. New file Proofs/AreaOfCircleOQ05OQ04.lean (~200 LOC, 3 theorems + 1 private lemma, 0 sorries, 0 axioms). p-adic case (C2) remains deferred pending two Mathlib milestones (standard psi_p, Haar on Q_p).",
+    "since": "2026-05-12T10:58:14+00:00",
+    "iteration": 3,
+    "focus": "S3 ACT-B: generalised the complex Gaussian to arbitrary positive weight b. Added complex_gaussian_integral_scaled (∫_ℂ exp(-b·normSq z) = π/b) and ‖z‖² variant + unit-weight (∫_ℂ exp(-‖z‖²) = π) + normalised density (∫_ℂ (1/π)·exp(-‖z‖²) = 1). Same Fubini-style proof as S2a, parameterised in b. 0 sorries, 0 axioms.",
     "blockers": [],
-    "nextAction": "S2b or S3: state (C2) p-adic self-Fourier as a sorry-bearing theorem with axiom padicAddChar : Q_p → ℂ and a Haar-measure stub; record proof outline (character-sum vanishing on Z/p^k Z for k ≥ 1, packaged ultrametrically). Alternative: contribute the standard psi_p and Haar-on-Q_p as Mathlib PRs first.",
+    "nextAction": "S4: either (a) prove the n-dimensional complex Gaussian ∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ via induction or by composing the n-real Multivariate Gaussian (AreaOfCircleOQ05OQ02) with the complex transport; OR (b) S2b p-adic scaffold with axiom padicAddChar + Haar stub. Recommendation: (a) keeps the file axiom-free and pushes the complex-side coverage further; (b) is the deeper open content but requires axioms.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete + S2a ACT-A complete with build verified. Complex Gaussian integral ∫_ℂ exp(-π · ‖z‖²) dz = 1 proven in new file AreaOfCircleOQ05OQ04.lean (3 theorems, 0 sorries, 0 axioms). Docker build passed (3122/3122 jobs). p-adic case (C2) blocked on two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar measure on ℚ_p).",
+    "progressSummary": "S1 OBSERVE + S2a ACT-A (b=π) + S3 ACT-B (parametric b>0) complete with build verified. AreaOfCircleOQ05OQ04.lean now has 8 theorems + 2 private helpers, all sorry-free and axiom-free. Complete complex-side coverage: π-weight, parametric b, unit weight, normalised density. p-adic case (C2) remains deferred pending two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar on ℚ_p).",
     "builtItems": [
       {
         "item": "S1 OBSERVE markdown set (problem.md, knowledge.md, state.md)",
@@ -59,6 +59,10 @@
       {
         "item": "Proofs/AreaOfCircleOQ05OQ04.lean: integral_pi_gaussian (scalar π-Gaussian = 1), complex_gaussian_integral (∫_ℂ exp(-π · normSq z) = 1), complex_gaussian_integral_norm (the ‖z‖² form) — proven via Complex.volume_preserving_equiv_real_prod + integral_prod_mul (Fubini) + scaled_gaussian",
         "session": "S2a"
+      },
+      {
+        "item": "Proofs/AreaOfCircleOQ05OQ04.lean: integral_b_gaussian (b-scaled scalar re-export), complex_gaussian_integral_scaled (∫_ℂ exp(-(b·normSq z)) = π/b), complex_gaussian_integral_scaled_norm (‖z‖² form), complex_gaussian_integral_unit_norm (b=1, value π), complex_gaussian_integral_normalised (1/π density integrates to 1) — proven via parametric Fubini + Real.mul_self_sqrt",
+        "session": "S3"
       }
     ],
     "insights": [
@@ -68,7 +72,9 @@
       "Mathlib's PadicInt.AddChar covers Z_p -> R characters for Z_p-algebras R - this is the Cartier dual direction. The standard psi_p : Q_p -> C is in the opposite direction and absent from Mathlib v4.26.0.",
       "Complex.volume_preserving_equiv_real_prod (Mathlib v4.26.0, Mathlib.MeasureTheory.Measure.Lebesgue.Complex) gives a MeasurePreserving map ℂ ≃ᵐ ℝ × ℝ, so any (ℝ-valued) integral over ℂ can be transported to the product space and factored via integral_prod_mul.",
       "The scalar π-weighted Gaussian ∫ exp(-π · x²) dx = √(π/π) = 1 specialises scaled_gaussian at a = π; this gives a clean unit factor on each axis of the complex factorisation.",
-      "The proof of the complex Gaussian = 1 needs zero new analysis - it is purely a transport + Fubini composition on top of existing real Gaussian / measure-preserving machinery already in Mathlib."
+      "The proof of the complex Gaussian = 1 needs zero new analysis - it is purely a transport + Fubini composition on top of existing real Gaussian / measure-preserving machinery already in Mathlib.",
+      "The complex Gaussian generalises uniformly in b > 0 because Fubini-and-transport composes with scaled_gaussian, which is itself uniform in a. Each real factor contributes √(π/b); two factors compose to π/b via Real.mul_self_sqrt.",
+      "The unit-weight complex Gaussian ∫_ℂ exp(-‖z‖²) = π is the 'circle area' identity: the Gaussian density at zero scaling has total mass equal to the area of the unit disc. This is the cleanest statement linking the slug's 'area of circle' theme to the complex Gaussian."
     ],
     "mathlibGaps": [
       "No padicAddChar : Q_p -> C (standard additive character with psi_p|_{Z_p} = 1, psi_p(p^{-n}) = e^{2*pi*i/p^n}).",
@@ -76,9 +82,8 @@
       "No Bruhat-Schwartz function space or Fourier-transform infrastructure specialised to Q_p."
     ],
     "nextSteps": [
-      "S2a: prove the complex Gaussian integrates to 1 via Fubini + integral_gaussian in a new file proofs/Proofs/AreaOfCircleOQ05OQ04.lean; ~50 LOC, 0 sorries.",
-      "S2b: state (C2) as a Lean theorem with axiom padicAddChar and a Haar-measure stub; record the proof as sorry with a docstring explaining the character-sum-vanishing argument.",
-      "S3+: replace the axiom by an actual definition once a Mathlib PR for psi_p lands; replace the sorry by the character-sum argument."
+      "S4a (recommended): n-dim complex Gaussian ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ. Can be proven by induction over Fin n using integral_fintype_prod_volume_eq_prod + complex_gaussian_integral_scaled, or via the existing real MultivariateGaussian.diagonal_gaussian + transport ℂⁿ ≃ ℝ^{2n}.",
+      "S4b (deferred — see C2 above): p-adic self-Fourier of 1_{ℤ_p} blocks on two Mathlib milestones (standard ψ_p, Haar on ℚ_p)."
     ]
   },
   "tags": [
@@ -165,7 +170,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-12T09:21:46.000Z",
+  "lastUpdate": "2026-05-12T10:58:14+00:00",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S3 ACT-B generalises the S2a deliverable (`∫_ℂ exp(-π·‖z‖²) = 1`,
PR #18025) to **arbitrary positive weight `b > 0`**:

    ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b.

This is the complex analogue of the parent file's scalar
`scaled_gaussian` (`∫ exp(-(a·x²)) = √(π/a)`): the complex-plane factor
is `(√(π/b))² = π/b` via Fubini + `Real.mul_self_sqrt`. S2a's
`complex_gaussian_integral` becomes the special case `b = π`.

## What S3 proves (5 new theorems + 1 private helper)

In `Proofs/AreaOfCircleOQ05OQ04.lean`:

- `integral_b_gaussian (b > 0) : ∫ x : ℝ, exp(-(b·x²)) = √(π/b)`
  — re-export of `GaussianIntegralCircle.scaled_gaussian` so all
  `b`-parametric Gaussians live in the same namespace.
- `complex_gaussian_integral_scaled (b > 0) :
    ∫ z : ℂ, exp(-(b·normSq z)) = π/b`
  — strict generalisation of `complex_gaussian_integral`.
- `complex_gaussian_integral_scaled_norm (b > 0) :
    ∫ z : ℂ, exp(-(b·‖z‖²)) = π/b`
  — `‖z‖²` variant.
- `complex_gaussian_integral_unit_norm :
    ∫ z : ℂ, exp(-‖z‖²) = π`
  — the canonical *"complex Gaussian density at unit weight = area of
  unit disc"* identity, directly linking the slug's "area of circle"
  theme to the complex Gaussian.
- `complex_gaussian_integral_normalised :
    ∫ z : ℂ, (1/π) · exp(-‖z‖²) = 1`
  — complex analogue of `standard_normal_normalization`.

## Proof strategy

Mirrors S2a's `complex_gaussian_integral` but parameterised in `b`:

1. `Complex.normSq_apply` exposes `z.re² + z.im²`.
2. `Complex.volume_preserving_equiv_real_prod.integral_comp'` transports
   `∫_ℂ → ∫_{ℝ × ℝ}`.
3. `Real.exp_add` factors the integrand (`exp_factor_b`).
4. `volume_eq_prod ℝ ℝ + integral_prod_mul` (Fubini) factors the double
   integral.
5. Each factor is `√(π/b)` by `integral_b_gaussian`.
6. `Real.mul_self_sqrt (div_nonneg π_nonneg b.le)` closes the product.

## Build status

**Verified.** Docker build via
`./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ04`:

```
✔ [3122/3122] Built Proofs.AreaOfCircleOQ05OQ04 (7.3s)
Build completed successfully (3122 jobs).
=== Build succeeded ===
```

(First attempt surfaced a stale-rewrite bug in
`complex_gaussian_integral_unit_norm`: `simp_rw [h_eq]` rewrote the
goal in the wrong direction. Fixed by exiting directly via `exact h`
after `simp only [one_mul, div_one]` normalises the `b = 1` form.)

## What is *not* advanced

The p-adic case (C2 in `problem.md`) — the self-Fourier identity
`F(𝟙_{ℤ_p}) = 𝟙_{ℤ_p}` under standard `ψ_p : ℚ_p → ℂ` and self-dual
Haar with `μ(ℤ_p) = 1` — remains blocked on two Mathlib upstream
milestones (standard `ψ_p` and explicit normalised Haar on `ℚ_p`),
as documented in the file's deferred-section.

## Axiom / sorry delta

- New `axiom` declarations: **0**.
- New `sorry` placeholders: **0**.
- `AreaOfCircleOQ05OQ04.lean` after this PR: 8 theorems + 2 private
  helpers, all sorry-free and axiom-free (was 3 + 1 from S2a).

## Files changed

- `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` — +140 LOC (5 new theorems,
  1 new private helper, docstring + status updates).
- `src/data/research/problems/area-of-circle-oq-05-oq-04.json` — phase
  remains `RESEARCH`; iteration `2 → 3`; `currentState.focus` and
  `nextAction` updated; insights and `builtItems` appended; next-step
  list points to S4a (n-dim complex Gaussian) or S4b (p-adic scaffold).
- `research/area-of-circle-oq-05-oq-04/state.md` — synced to S3.

## Test plan

- [x] Docker build verified end-to-end (3122/3122 jobs).
- [x] No new axioms, no new sorries.
- [x] All five new theorems referenced from the file's `## Status`
      section.
- [x] `complex_gaussian_integral` (S2a) recovers as the `b = π` case
      of `complex_gaussian_integral_scaled` modulo `π / π = 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)