### PR TITLE
fix(meta): sync navier-stokes counts (theoremCount 611→845, definitionCount 362→366)

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -65,8 +65,8 @@
     "relatedProblems": [],
     "lineCount": 21110,
     "mathlib_version": "4.26.0",
-    "theoremCount": 611,
-    "definitionCount": 362
+    "theoremCount": 845,
+    "definitionCount": 366
   },
   "overview": {
     "historicalContext": "**Navier-Stokes Existence and Smoothness (Millennium Prize Problem)**\n\nThe Navier-Stokes equations describe fluid motion: $\\partial_t u + (u \\cdot \\nabla)u = \\nu\\Delta u - \\nabla p + f$ with $\\nabla \\cdot u = 0$. The Millennium Prize asks whether smooth solutions exist globally in 3D. Leray (1934) proved weak solutions exist; Ladyzhenskaya (1962/1969) solved the 2D case; Caffarelli-Kohn-Nirenberg (1982) showed the 3D singular set has Hausdorff dimension at most 1. The 3D problem remains open after 90+ years.\n\nThis formalization is the largest single proof file in the gallery at 20,000+ lines across 110 parts, containing 1200+ definitions/theorems with 0 sorries. The 3D conditional result uses the NSAxioms structure (5 structure-encoded assumptions).",
@@ -268,8 +268,8 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21110,
     "axiomCount": 0,
-    "theoremCount": 611,
-    "definitionCount": 362,
+    "theoremCount": 845,
+    "definitionCount": 366,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -69,8 +69,8 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 611,
-    "definitionCount": 362
+    "theoremCount": 845,
+    "definitionCount": 366
   },
   "overview": {
     "historicalContext": "The two-dimensional Navier-Stokes equations have been known to have global smooth solutions since Ladyzhenskaya's work in 1969. The key is that vortex stretching — the primary mechanism that might cause blowup in 3D — is absent in 2D. In 2D, the vorticity ω satisfies a transport-diffusion equation without the dangerous (ω·∇)u stretching term.\n\nThe enstrophy E(t) = ∫|ω(x,t)|² dx is the squared L² norm of vorticity. In 2D, enstrophy satisfies the ODE dE/dt = -2νP where P = ∫|∇ω|² is the palinstrophy. Under a Poincaré inequality P ≥ μ₁E (where μ₁ is the first eigenvalue of -Δ on the domain), this becomes dE/dt ≤ -2νμ₁E, giving exponential decay.\n\nThis formalization extends the existing NavierStokes.lean (which already proved the asymptotic bound E(t) ≤ E(0)·exp(-2νμ₁t)) with new quantitative results: decay between arbitrary times, exact FTC integration of the enstrophy ODE, and total dissipation bounds.",
@@ -185,8 +185,8 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21110,
     "axiomCount": 0,
-    "theoremCount": 611,
-    "definitionCount": 362,
+    "theoremCount": 845,
+    "definitionCount": 366,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -62,8 +62,8 @@
     "lineCount": 21110,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 611,
-    "definitionCount": 362
+    "theoremCount": 845,
+    "definitionCount": 366
   },
   "overview": {
     "historicalContext": "The theory of well-posedness for 2D Navier-Stokes equations has a rich history beginning with Jean Leray's pioneering 1934 paper, which established the existence of weak solutions in both 2D and 3D. For 2D, Leray showed that solutions remain regular for all time — a result that fails (or at least remains unproven) in 3D.\n\nThe concept of well-posedness itself was formalized by Jacques Hadamard in his 1902 lectures: a problem is well-posed if it has (1) existence, (2) uniqueness, and (3) continuous dependence on data. Hadamard argued that physically meaningful problems should satisfy all three criteria.\n\nOlga Ladyzhenskaya's landmark 1969 monograph 'The Mathematical Theory of Viscous Incompressible Flow' provided the definitive treatment of 2D well-posedness. Her key contribution was the Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4(\\mathbb{R}^2)} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$, which gives the stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ for the difference energy $W(t) = \\|u_1 - u_2\\|_{L^2}^2$. The critical feature of 2D: enstrophy $E(t) = \\|\\nabla u\\|_{L^2}^2$ is bounded by its initial value $E(0)$, making the Gronwall growth rate $K = C \\cdot E(0)$ finite.\n\nThomas Gronwall's 1919 inequality — if $u'(t) \\leq \\beta(t) u(t)$ then $u(t) \\leq u(0) \\exp(\\int_0^t \\beta)$ — is the analytic engine of the proof. Combined with bounded enstrophy, it yields exponential stability $W(t) \\leq W(0) e^{CE(0)t}$ and hence uniqueness.\n\nIn 3D, enstrophy could potentially blow up ($E(t) \\to \\infty$), making $K(t) = C \\cdot E(t)$ unbounded and the Gronwall argument ineffective. This is precisely the obstruction at the heart of the Clay Millennium Prize Problem: proving or disproving 3D global regularity. The 2D well-posedness result formalized here serves as a template showing exactly where the 3D argument breaks down.\n\nThis formalization in Lean 4 is novel: the `NSSolutionPair2D` structure encodes the Ladyzhenskaya stability estimate as a structural hypothesis, abstracting away the PDE-specific Sobolev space analysis (not yet available in Mathlib) and focusing on the Gronwall argument itself.",
@@ -206,8 +206,8 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21110,
     "axiomCount": 0,
-    "theoremCount": 611,
-    "definitionCount": 362,
+    "theoremCount": 845,
+    "definitionCount": 366,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0
   },

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -74,8 +74,8 @@
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 21110,
-    "theoremCount": 611,
-    "definitionCount": 362
+    "theoremCount": 845,
+    "definitionCount": 366
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -368,7 +368,7 @@
     "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
-    "theoremCount": 611,
+    "theoremCount": 845,
     "lemmaCount": 14,
     "imports": [
       "Mathlib.Analysis.Calculus.Deriv.Basic",
@@ -408,7 +408,7 @@
     ],
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0,
-    "definitionCount": 362
+    "definitionCount": 366
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Sync `leanFile.{theoremCount,definitionCount}` and mirrored `meta.{theoremCount,definitionCount}` for the 4 entries that all reference `proofs/Proofs/NavierStokes.lean`.

## Evidence

| Slug                    | theoremCount | definitionCount |
|-------------------------|--------------|-----------------|
| navier-stokes           | 611 → 845    | 362 → 366       |
| navier-stokes-existence | 611 → 845    | 362 → 366       |
| navier-stokes-oq-01     | 611 → 845    | 362 → 366       |
| navier-stokes-oq-02     | 611 → 845    | 362 → 366       |

### Counting convention (matches PR #18006 / #17917)

```
theorems: ^(@[...] )*(private|protected|noncomputable)? (theorem|lemma)
defs:     ^(@[...] )*(private|protected|noncomputable)? (def|abbrev|structure|inductive|class|instance)
lines:    raw newline count (unchanged)
```

After stripping nested `/- -/` block comments and `--` line comments.

### Breakdown for `NavierStokes.lean`

- theorem-only: 831, lemma-only: 14 → combined `theoremCount` = **845**
- def: 104, structure: 249 (matches existing `structureCount`), inductive: 13 → `definitionCount` = **366**
- `axiomCount`: 0 (unchanged), `sorries`: 0 (unchanged), `lineCount`: 21110 (unchanged)

### Validation

- Surgical regex replacement (preserves Unicode + original JSON formatting); only the four targeted numeric values change per file.
- All 4 meta.json files remain valid JSON.
- `meta.lemmaCount = 14` left unchanged (correctly tracks lemma-only count).
- `structureCount = 249` left unchanged (already accurate).

---

Automated fix by lean-mechanic agent.