### PR TITLE
research(fourier-series-oq-04-oq-01): S1 OBSERVE — 2D Carleson spherical-summation conjecture survey (doc-only)

### DIFF
--- a/research/problems/fourier-series-oq-04-oq-01/knowledge.md
+++ b/research/problems/fourier-series-oq-04-oq-01/knowledge.md
@@ -1,0 +1,109 @@
+# Knowledge: fourier-series-oq-04-oq-01
+
+## S1 (researcher-6, 2026-05-12) — OBSERVE survey
+
+### Concrete problem statement (with all qualifiers)
+
+Let $\mathbb{T}^2 = (\mathbb{R}/\mathbb{Z})^2$ with normalised Haar measure $\mu$. For $f \in L^2(\mathbb{T}^2)$ and $k = (k_1, k_2) \in \mathbb{Z}^2$,
+
+$$
+\widehat f(k) = \int_{\mathbb{T}^2} f(x)\, e^{-2\pi i (k_1 x_1 + k_2 x_2)}\, d\mu(x).
+$$
+
+For $R > 0$, the **spherical partial sum** is
+
+$$
+S_R^{\text{sph}} f(x) = \sum_{|k| \le R} \widehat f(k)\, e^{2\pi i k \cdot x},
+$$
+
+with $|k| = \sqrt{k_1^2 + k_2^2}$ the Euclidean norm. The conjecture:
+
+$$
+\forall f \in L^2(\mathbb{T}^2) :\quad S_R^{\text{sph}} f(x) \xrightarrow{R \to \infty} f(x)\quad \text{for a.e. } x.
+$$
+
+**Status (as of 2024)**: Open. No improvement on Fefferman's 1971 ball-multiplier barrier; no conditional approach (Kakeya, restriction) has discharged the L² endpoint.
+
+### Why the 1D case is solved but 2D is not
+
+The 1D Carleson theorem (1966, $L^2$) and Hunt's $L^p$ extension (1968, $1 < p < \infty$) rely on:
+1. **Time-frequency localisation**: a single rectangle in phase space corresponds to an interval in frequency. The dyadic decomposition of $\{|k| \le R\}$ on $\mathbb{T}^1$ is a sequence of disjoint *intervals*.
+2. **Maximal operator boundedness**: $T^* f(x) = \sup_R |S_R f(x)|$ is bounded on $L^p$ via Carleson's tree decomposition.
+
+In 2D, the level set $\{|k| \le R\} \subset \mathbb{Z}^2$ is a **disc** whose boundary is curved. A dyadic decomposition produces annular regions whose multipliers are *not* products of 1D multipliers (rectangles aligned with axes do not tile a disc efficiently). Fefferman 1971's ball multiplier theorem shows that for $p \ne 2$, the operator does **not** extend; this rules out Hunt-style $L^p$-interpolation arguments.
+
+The L²-specific subtlety: Plancherel gives norm convergence, but a.e. convergence requires a *weak-type maximal estimate*
+$$
+\mu(\{x : \sup_R |S_R^{\text{sph}} f(x)| > \lambda\}) \le C \|f\|_{L^2}^2 / \lambda^2.
+$$
+No such estimate is known.
+
+### Bochner-Riesz means and the critical exponent
+
+For $\delta \ge 0$, define
+$$
+S_R^\delta f(x) = \sum_{|k| \le R} \left(1 - |k|^2 / R^2\right)^\delta \widehat f(k)\, e^{2\pi i k \cdot x}.
+$$
+- $\delta = 0$: spherical partial sum (the conjecture).
+- $\delta > (n-1)/2$ (i.e. $> 1/2$ in $n=2$): a.e. convergence in $L^p$ for $1 \le p \le \infty$. **Classical** (Stein 1958).
+- $0 < \delta \le (n-1)/2$: Bochner-Riesz conjecture, also open. For $\delta = 0$ (the spherical case) the conjecture reduces to the 2D Carleson conjecture in $L^2$.
+
+A modern statement of the **Bochner-Riesz conjecture in $\mathbb{R}^n$**: $S_R^\delta$ extends to a bounded operator $L^p \to L^p$ iff $\delta > \max(0, n(1/p - 1/2) - 1/2)$. The $L^2$-endpoint a.e. statement is the spherical Carleson conjecture.
+
+### Mathlib API survey (Lean 4, current pinned revision via Mathlib `import Mathlib`)
+
+**Available in Mathlib (1D, AddCircle)**:
+- `Mathlib.Analysis.Fourier.AddCircle`:
+  - `fourier (n : ℤ) : AddCircle T → ℂ` — the n-th character.
+  - `fourierCoeff f n` — the n-th Fourier coefficient (integral against `haarAddCircle`).
+  - `fourier_add`, `fourier_neg`, `fourier_zero` — character algebra.
+  - `fourierBasis`, `fourierBasis_apply` — Hilbert basis of $L^2(\text{AddCircle } T)$.
+  - `tsum_sq_fourierCoeff_eq_lp_norm_sq` — Parseval (1D).
+- `Mathlib.Analysis.Fourier.FourierTransform`:
+  - `Real.fourierIntegral` — Fourier transform on $\mathbb{R}$ (continuous version).
+- `Mathlib.MeasureTheory.Function.LpSpace.Basic` — `MemLp`, `Lp p μ`, `eLpNorm`.
+- `Mathlib.Analysis.InnerProductSpace.l2Space` — `lp 2` Hilbert structure.
+
+**Verified absent (Mathlib gaps; checked by `grep -r` and `loogle`)**:
+- No `MultiFourierCoeff` / `fourierCoeff` over `(Fin n → AddCircle T)`. The parent file `Proofs/FourierSeriesOQ04.lean` declares its own `def fourierCoeff … := 0` placeholder.
+- No `BochnerRiesz`, `sphericalPartialSum`, `ballMultiplier` definitions.
+- No multi-dimensional Plancherel / Parseval (as an explicit identity over $\mathbb{T}^n$).
+- No `Fefferman_ball_multiplier` or related counterexample.
+
+**Workable detour**: `Mathlib.Analysis.Fourier.PoissonSummation` covers Poisson summation in any $n$ via `EuclideanSpace`. The Schwartz-class L²-convergence claim for $n$-torus partial sums is *implicit* in Mathlib's general $L^2$ theory (orthonormal basis exists as a tensor product of 1D bases) but has not been spelled out as a named theorem.
+
+### Insights
+
+1. **The 2D Carleson conjecture is the "endpoint" of two flagship open problems** — Bochner-Riesz in $L^2$ AND the 1D Carleson theorem in higher dimensions. Either positive progress collapses one of these. No conditional result links it to Kakeya or restriction at the $L^2$ endpoint.
+2. **L² norm convergence is trivial** by Plancherel; the difficulty is the a.e. claim. This asymmetry guides the formalisation: Plancherel is in reach; the maximal-operator estimate is not.
+3. **Rectangular vs spherical asymmetry is genuinely $n$-dependent**: in 1D, rectangular = spherical. In $n \ge 2$, Fefferman (1971) showed *rectangular* $L^1$ may diverge a.e., yet *spherical* $L^2$ a.e. is open. Both facts can be stated separately in the gallery without conflict.
+4. **The `axiom` formalisation is the honest path**: this is a Millennium-Prize-class open problem in harmonic analysis (not a Clay problem but a long-standing flagship). The status should be `axiomatized` with a clear `axiom carleson_2d_sph` and a body of unconditional companion theorems.
+5. **Doc-only S1 is appropriate**: the parent `FourierSeriesOQ04.lean` is a 103-line stub with placeholder `:= 0` definitions. Until the parent's definitions are rigorised (S2 ACT-A), the child cannot prove anything substantive. Documenting the math first is the cleanest unblock.
+
+### Mathlib gaps (cumulative, for future contribution)
+
+1. `MultiFourierCoeff f k` over `(Fin n → AddCircle T) → ℂ` for `k : Fin n → ℤ` — natural API; would specialise to the existing 1D `fourierCoeff` when `n = 1`.
+2. `Plancherel_ntorus : ‖f‖_{L^2(T^n)}² = ∑ k, ‖MultiFourierCoeff f k‖²` — direct from `lp 2` over `Fin n → ℤ` (countable index).
+3. `BochnerRieszMultiplier (δ : ℝ) (R : ℝ) (k : Fin n → ℤ) : ℂ := max (1 - ‖k‖² / R²) 0 ^ δ` (with `:= 0` outside the disc).
+4. `sphericalPartialSum f R := ∑ k ∈ ballLattice R, MultiFourierCoeff f k • exp_basis k` — concrete `Finset.sum` over a finite index set per $R$.
+
+### Next Steps (priority order)
+
+1. **S2a (ACT — high value, tractable)**: In a new file `Proofs/FourierSeriesOQ04OQ01.lean`, define
+   - `MultiFourierCoeff` rigorously (real integral over `Fin n → AddCircle T`).
+   - `sphericalPartialSum f R x` as an explicit `Finset.sum` over `latticeDisc R : Finset (Fin n → ℤ)`.
+   - State `axiom carleson_2d_sph` and surround it with the *unconditional* L²-norm-convergence statement (provable from Plancherel via the `lp 2` Hilbert basis).
+   - Add the gallery entry `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` with status `axiomatized` and badge `axiom`.
+
+2. **S2b (ACT — slower)**: Formalise Bochner-Riesz convergence for $\delta > (n-1)/2$ (Stein 1958). This is a real theorem to formalise (1958-era classical), not a placeholder. Likely 2-3 iterations.
+
+3. **S3 (ACT — speculative)**: Fefferman 1971 ball-multiplier counterexample. The classical proof uses Besicovitch sets and a Kakeya-style construction — likely beyond a single Lean file without a major Mathlib detour. Postpone.
+
+4. **(skip)** Attempting to prove the conjecture itself. This is genuine open mathematics; no PR should claim to close it.
+
+### Risk Notes
+
+- **Risk 1 (parent drift)**: `FourierSeriesOQ04.lean` currently has placeholder `:= 0` definitions. If S2 replaces them with real integrals, downstream gallery entries that import the parent may break. Mitigation: S2a should keep the new definitions in a fresh file (`FourierSeriesOQ04OQ01.lean`) rather than editing the parent.
+- **Risk 2 (Bochner-Riesz scope)**: A faithful $\delta > 1/2$ a.e. convergence proof is 1958-era harmonic analysis — short in textbooks but each step in Lean expands considerably. Estimate 300-500 lines for S2b.
+- **Risk 3 (ball multiplier)**: Fefferman's counterexample requires a Besicovitch / Kakeya set construction, which Mathlib lacks. Defer to a dedicated entry.
+- **Risk 4 (gallery axiom integrity)**: Per CLAUDE.md "Axiom Integrity Policy", `status` MUST be `axiomatized` with `badge: axiom` for any entry with `axiom carleson_2d_sph`. Do not claim `verified` based on the unconditional partial results alone.

--- a/research/problems/fourier-series-oq-04-oq-01/problem.md
+++ b/research/problems/fourier-series-oq-04-oq-01/problem.md
@@ -1,0 +1,98 @@
+# Problem: 2D Carleson conjecture for spherical Fourier series on $\mathbb{T}^2$
+
+## Statement
+
+### Plain Language
+
+For $f \in L^2(\mathbb{T}^2)$ and $R > 0$, the **spherical partial sum** is
+
+$$
+S_R^{\text{sph}} f(x) \;=\; \sum_{k \in \mathbb{Z}^2,\; |k| \le R}\; \widehat f(k)\, e^{2\pi i\, k \cdot x},
+$$
+
+where the sum is over lattice points $k = (k_1, k_2) \in \mathbb{Z}^2$ inside the closed disc of radius $R$ in Euclidean norm.
+
+**Open question (2D Carleson, spherical).** Does $S_R^{\text{sph}} f(x) \to f(x)$ for almost every $x \in \mathbb{T}^2$, for every $f \in L^2(\mathbb{T}^2)$?
+
+### Formal Statement
+
+Let `T2 := Fin 2 → AddCircle (1 : ℝ)` (or any equivalent encoding of the 2-torus). For
+`f : T2 → ℂ` and `k : Fin 2 → ℤ` define the Fourier coefficient
+`fourierCoeff f k := ∫ x, f x * Complex.exp (-2 * π * I * (k.1 * x.1 + k.2 * x.2)) ∂μ`
+(haar measure on `T2`). The spherical partial sum is
+```lean
+noncomputable def sphPartialSum (f : T2 → ℂ) (R : ℝ) (x : T2) : ℂ :=
+  ∑ k in latticeDisc R, fourierCoeff f k * Complex.exp (2 * π * I * (k.1 * x.1 + k.2 * x.2))
+```
+where `latticeDisc R : Finset (Fin 2 → ℤ)` enumerates integer lattice points with `k.1^2 + k.2^2 ≤ R^2`.
+
+The conjecture, axiomatized:
+```lean
+axiom carleson_2d_sph : ∀ f : T2 → ℂ, MemLp f 2 μ →
+  ∀ᵐ x ∂μ, Tendsto (fun R : ℝ => sphPartialSum f R x) atTop (𝓝 (f x))
+```
+
+The formal goal of this entry is **not** to prove the conjecture (open in mathematics), but to (i) state it precisely, (ii) formalize the partial results known unconditionally, and (iii) populate the surrounding lemma library so the conjecture statement is correctly grounded.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - seeker-selected
+  - harmonic-analysis
+  - fourier-series
+  - convergence
+  - multi-dimensional
+  - bochner-riesz
+  - carleson-conjecture
+  - open-problem
+```
+
+**Significance**: 6/10 — Among the top open problems in modern harmonic analysis; connects to the Bochner-Riesz, restriction, and Kakeya conjectures. The 1D analogue (Carleson 1966, Hunt 1968) is one of the deepest theorems in 20th-century analysis.
+
+**Tractability**: 5/10 — The conjecture itself is open. But the surrounding library is tractable: Plancherel/Parseval for $\mathbb{T}^n$ (L² convergence in norm), Bochner-Riesz convergence above the critical exponent, and Fefferman's 1971 disproof for rectangular sums in $L^1$ are all in reach of a careful Mathlib build.
+
+## Why This Matters
+
+1. **Gallery scope**: The 1D parent (`FourierSeries.lean`, `FourierSeriesOQ01.lean`, `FourierSeriesOQ02.lean`) is rich; the 2D / $n$-D side is currently a 103-line stub with placeholder definitions (`fourierCoeff := 0`). A real $n$-torus formalization is the next natural extension.
+
+2. **Bochner-Riesz connection**: The spherical partial-sum problem is the limit case $\delta = 0$ of Bochner-Riesz means
+   $$ S_R^{\delta} f(x) = \sum_{|k| \le R} \left(1 - |k|^2/R^2\right)^\delta \widehat f(k)\, e^{2\pi i k \cdot x}. $$
+   For $\delta > (n-1)/2$ ($\delta > 1/2$ in $n=2$), $L^2$ a.e. convergence is classical. The conjecture asks how far this critical exponent can be lowered. The endpoint $\delta = 0$ (no smoothing) is the spherical conjecture.
+
+3. **Asymmetry with rectangular sums**: Fefferman's 1971 ball multiplier theorem implies $L^p$ unboundedness of $S_R^{\text{sph}}$ for $p \ne 2$ in $n \ge 2$. So the 2D conjecture is genuinely $L^2$-specific — strikingly different from 1D where Carleson works in $L^p$ for $1 < p < \infty$.
+
+4. **Companion to `FourierSeriesOQ04.lean`**: That file currently asserts the open status in a docstring (line 95: "The n=2 pointwise convergence for L² is one of the major open problems in harmonic analysis. Carleson's theorem (1966) only covers n=1."). This child fleshes that claim into a formal `axiom` + a body of partial results.
+
+## Theoretical Context
+
+### Known unconditional results
+
+- **L² norm convergence** (any summation method, all $n$): $\|S_R^{\text{sph}} f - f\|_{L^2} \to 0$ for $f \in L^2(\mathbb{T}^n)$. Direct from Plancherel: $\|S_R f - f\|_{L^2}^2 = \sum_{|k| > R} |\widehat f(k)|^2 \to 0$.
+- **Bochner-Riesz, $\delta > (n-1)/2$**: $S_R^\delta f \to f$ a.e. for $f \in L^p(\mathbb{T}^n)$, $1 \le p \le \infty$ (classical, Stein 1958).
+- **1D Carleson** (`n=1`): $S_R f \to f$ a.e. for $f \in L^p(\mathbb{T})$, $1 < p < \infty$. Hunt (1968) extended Carleson (1966) from $L^2$ to $L^p$.
+- **Lipschitz / smooth functions in any $n$**: Spherical partial sums converge uniformly for $C^1$ data via Riemann-Lebesgue + decay of $\widehat f$.
+
+### Known negative results
+
+- **Fefferman 1971 (rectangular)**: The rectangular partial sums of an $L^1(\mathbb{T}^2)$ function may diverge a.e. — the multi-dimensional analogue of Kolmogorov's 1923 1D counterexample.
+- **Fefferman 1971 (ball multiplier)**: The characteristic function $\chi_{B(0,1)}$ is **not** an $L^p(\mathbb{R}^n)$ Fourier multiplier for $p \ne 2$, $n \ge 2$. This shows the spherical-summation operator does not extend boundedly to $L^p$.
+- **Bochner-Riesz, $\delta < (n-1)(1/p - 1/2)$**: For $p < 2n/(n+1)$ or $p > 2n/(n-1)$ in $n \ge 2$, $S_R^\delta$ is unbounded on $L^p$ (Herz, Fefferman).
+
+### Open status
+
+The spherical $L^2$ a.e. conjecture in $n=2$ has been open since at least Stein's 1971 ICM address. Tao's "Some recent progress on the restriction conjecture" (2002) lists it as a flagship open problem of harmonic analysis. As of 2024, no improvement on Fefferman's barrier is known in either direction.
+
+## Path Forward (sketch — see `state.md` for the active iteration)
+
+S1 (this iteration): OBSERVE — document the problem, survey unconditional results, map the Mathlib API.
+
+S2 onward: ACT on tractable partial deliverables:
+- (S2a) Restate `FourierSeriesOQ04`'s definitions over a real $n$-torus model (replacing the `:= 0` stubs with the actual integral / sum); prove Plancherel in $n$ dimensions.
+- (S2b) Formalize the conjecture as `axiom carleson_2d_sph : …` in `Proofs/FourierSeriesOQ04OQ01.lean`; state Bochner-Riesz $\delta > 1/2$ as an unconditional companion theorem (axiomatized if Mathlib lacks the integral operator).
+- (S2c) Formalize Fefferman's ball-multiplier statement as `axiom fefferman_1971_ball : ¬ IsLp_multiplier (charFn (ball 0 1)) p (Fin 2 → ℝ)` for $p \ne 2$.
+
+The first iteration's deliverable is **doc-only**: no Lean changes. The Lean stub is the parent's responsibility; this child's S1 lays the math substrate.

--- a/research/problems/fourier-series-oq-04-oq-01/state.md
+++ b/research/problems/fourier-series-oq-04-oq-01/state.md
@@ -1,0 +1,105 @@
+# Research State: fourier-series-oq-04-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-6, 2026-05-12) — **OBSERVE** survey of the 2D Carleson
+spherical-summation conjecture for $L^2(\mathbb{T}^2)$. Doc-only,
+no Lean changes. Deliverables: this `state.md`, `problem.md` (formal
+statement + classification), `knowledge.md` (Mathlib API map +
+unconditional companion results + Bochner-Riesz context), and the
+discovery JSON `src/data/research/problems/fourier-series-oq-04-oq-01.json`.
+
+The parent file `Proofs/FourierSeriesOQ04.lean` (103 lines, 0 theorems,
+3 placeholder `:= 0` definitions) declares the open-problem status in
+its docstring (lines 95-96: "The n=2 pointwise convergence for L² is
+one of the major open problems in harmonic analysis. Carleson's
+theorem (1966) only covers n=1."). This child entry promotes that
+docstring claim into a formal problem definition with a clearly
+marked `axiom` and a body of unconditional partial results.
+
+## Active Approach
+
+**Axiomatize the open conjecture; formalize the partial results
+that are provable unconditionally.**
+
+The 2D spherical Carleson conjecture is open in mathematics (Stein
+1971 ICM; Tao 2002 restriction-conjecture survey; no progress on
+the L²-endpoint as of 2024). The honest formalisation is:
+
+1. State the conjecture as a single `axiom carleson_2d_sph` with
+   precise quantifiers over `f ∈ L^2(T^2)` and Lebesgue-a.e. `x`.
+2. Surround it with unconditional results:
+   - `L2_norm_convergence` — $\|S_R^{\text{sph}} f - f\|_{L^2} \to 0$
+     from Plancherel (provable in Lean from the `lp 2` Hilbert
+     basis of `(Fin 2 → AddCircle 1) → ℂ`).
+   - `bochner_riesz_critical` — $S_R^\delta f \to f$ a.e. for
+     $\delta > 1/2$ (classical, Stein 1958; multi-iteration target).
+3. Gallery entry: `status = "axiomatized"`, `badge = "axiom"`.
+
+This matches the gallery's standard treatment of open problems
+(per CLAUDE.md Axiom Integrity Policy). Compare e.g. `riemann-hypothesis`,
+`p-vs-np`: `axiomatized` with the conjecture as an `axiom`.
+
+## Blockers
+
+None mathematical for S1. S2 onward will need:
+- A real-integral definition of `MultiFourierCoeff` on `Fin n → AddCircle T` (Mathlib gap; ~30 lines of careful setup).
+- A real-`Finset`-based definition of `latticeDisc R : Finset (Fin n → ℤ)` (provable: integer lattice points in a closed disc are a finite set; need `Finset.filter` + bound on $|k_i|$ by $\lceil R \rceil$).
+
+Practical: this worktree's `proofs/.lake` symlink points to itself,
+so any Docker build would be a fresh ~25-minute clone. S1 is text-only
+and unaffected. S2 will need to budget build time.
+
+## Next Action
+
+**S2a (any researcher) — ACT, doc-light scaffold**:
+
+Create `proofs/Proofs/FourierSeriesOQ04OQ01.lean` (new file, ~150 lines) containing:
+
+1. Header / imports:
+   ```lean
+   import Mathlib.Analysis.Fourier.AddCircle
+   import Mathlib.MeasureTheory.Constructions.Pi
+   import Mathlib.Tactic
+   ```
+2. Rigorous definitions (replace parent's `:= 0` placeholders):
+   ```lean
+   abbrev T2 : Type := Fin 2 → AddCircle (1 : ℝ)
+   noncomputable def multiFourierCoeff (f : T2 → ℂ) (k : Fin 2 → ℤ) : ℂ := ...
+   def latticeDisc (R : ℝ) : Finset (Fin 2 → ℤ) := ...   -- non-trivial; see knowledge.md
+   noncomputable def sphPartialSum (f : T2 → ℂ) (R : ℝ) (x : T2) : ℂ :=
+     ∑ k ∈ latticeDisc R, multiFourierCoeff f k * exp (2 * π * I * (k 0 * x 0 + k 1 * x 1))
+   ```
+3. The conjecture (axiomatized):
+   ```lean
+   /-- 2D Carleson conjecture for spherical Fourier series on the torus.
+       Open in mathematics; stated as an axiom for gallery scope. -/
+   axiom carleson_2d_sph (f : T2 → ℂ) (hf : MemLp f 2 μ) :
+     ∀ᵐ x ∂μ, Tendsto (fun R : ℝ => sphPartialSum f R x) atTop (𝓝 (f x))
+   ```
+4. One unconditional companion theorem (proof skeleton, may have sorries):
+   ```lean
+   /-- L² norm convergence (Plancherel-direct, holds unconditionally). -/
+   theorem sphPartialSum_L2_norm_converge (f : T2 → ℂ) (hf : MemLp f 2 μ) :
+     Tendsto (fun R : ℝ => eLpNorm (sphPartialSum f R - f) 2 μ) atTop (𝓝 0) := by
+     sorry  -- Plancherel + bigger-and-bigger lattice exhausts the index
+   ```
+5. Gallery entry: create `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` with
+   `status: "axiomatized"`, `badge: "axiom"`, `sorries: 1`, `axiomCount: 1`,
+   `additionalFiles: ["Proofs/FourierSeriesOQ04.lean"]` (the parent).
+
+S2a budget: ~150 Lean lines + meta.json. The `latticeDisc R` Finset
+is the only non-routine definition (proof that integer pairs $(k_1, k_2)$
+with $k_1^2 + k_2^2 \le R^2$ form a finite set — bound by `|k_i| ≤ ⌈R⌉`
+and use `Finset.filter (· ∈ Icc (-⌈R⌉) ⌈R⌉ ×ˢ Icc (-⌈R⌉) ⌈R⌉)`).
+A clean S2a may need a build cycle; tracking as "build pending" PR is
+acceptable per gallery convention.
+
+## Earlier Focus
+
+(none — this is iteration 1)

--- a/src/data/research/problems/fourier-series-oq-04-oq-01.json
+++ b/src/data/research/problems/fourier-series-oq-04-oq-01.json
@@ -1,0 +1,130 @@
+{
+  "slug": "fourier-series-oq-04-oq-01",
+  "title": "2D Carleson conjecture for spherical Fourier series on T^2",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall f \\in L^2(\\mathbb{T}^2):\\quad S_R^{\\text{sph}} f(x) \\xrightarrow{R \\to \\infty} f(x) \\text{ for a.e. } x, \\text{ where } S_R^{\\text{sph}} f(x) = \\sum_{|k| \\le R} \\widehat f(k)\\, e^{2\\pi i k \\cdot x}, \\quad k \\in \\mathbb{Z}^2.",
+    "plain": "Does the spherical Fourier series of an arbitrary square-integrable function on the 2-torus converge pointwise almost everywhere? This is the 2D analogue of Carleson's 1966 theorem; it has been open since at least Stein's 1971 ICM address.",
+    "whyMatters": [
+      "Flagship open problem of harmonic analysis. Listed in Tao 2002 'Some recent progress on the restriction conjecture' as a central problem connecting Bochner-Riesz, restriction, and Kakeya.",
+      "The 1D version (Carleson 1966, Hunt 1968) is one of the deepest theorems of 20th-century analysis. The 2D analogue is genuinely different: Fefferman's 1971 ball-multiplier theorem rules out the 1D L^p-interpolation approach.",
+      "Gallery scope: parent file Proofs/FourierSeriesOQ04.lean (103 lines, 0 theorems, 3 placeholder := 0 definitions) declares the open status in its docstring. This child entry promotes that docstring claim into a formal axiom + a body of unconditional partial results."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "L^2 norm convergence (any summation method, all n): ||S_R^sph f - f||_{L^2} -> 0 for f in L^2(T^n). Direct from Plancherel.",
+      "Bochner-Riesz, delta > (n-1)/2 (Stein 1958): a.e. convergence in L^p for 1 <= p <= infinity.",
+      "1D Carleson (Carleson 1966, L^2) and Hunt 1968 (L^p, 1 < p < infinity) on T^1.",
+      "Lipschitz / C^1 data: spherical partial sums converge uniformly in any n via Fourier coefficient decay."
+    ],
+    "open": [
+      "The 2D spherical Carleson conjecture itself (this slug).",
+      "Bochner-Riesz conjecture in n >= 2 for 0 < delta <= (n-1)/2 (a strict superset of the spherical L^2 case)."
+    ],
+    "goal": "Lean-formalize the conjecture as an axiom; surround it with the unconditional partial results (Plancherel L^2-norm convergence, Bochner-Riesz delta > 1/2 a.e. convergence) and the asymmetry results (Fefferman 1971 rectangular divergence in L^1)."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T08:38:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-6, 2026-05-12): OBSERVE survey of the 2D Carleson spherical-summation conjecture for L^2(T^2). Doc-only, no Lean changes. Deliverables: state.md, problem.md (formal statement + classification), knowledge.md (Mathlib API map + unconditional companion results + Bochner-Riesz context), and this discovery JSON. The parent file Proofs/FourierSeriesOQ04.lean (103 lines, 0 theorems, 3 placeholder := 0 definitions) declares the open-problem status in its docstring (lines 95-96).",
+    "blockers": [],
+    "nextAction": "S2a (any researcher) — ACT, doc-light scaffold: create proofs/Proofs/FourierSeriesOQ04OQ01.lean (~150 lines) with rigorous multiFourierCoeff / latticeDisc / sphPartialSum definitions, the conjecture as `axiom carleson_2d_sph`, and one unconditional companion theorem (sphPartialSum_L2_norm_converge, may have sorry pending Plancherel-on-T^2). Gallery entry src/data/proofs/fourier-series-oq-04-oq-01/meta.json with status='axiomatized', badge='axiom', sorries=1, axiomCount=1, additionalFiles=['Proofs/FourierSeriesOQ04.lean'].",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-6, 2026-05-12) — OBSERVE survey. Established that the 2D Carleson spherical-summation conjecture is open in mathematics (Stein 1971 ICM; Tao 2002 survey; no progress as of 2024). Identified the precise formal statement (sum over integer lattice points in a closed Euclidean disc of radius R), the Mathlib API gap (no MultiFourierCoeff on Fin n -> AddCircle T), the unconditional companion results (Plancherel L^2-norm convergence trivially; Bochner-Riesz a.e. for delta > (n-1)/2 classically), and the asymmetry results (Fefferman 1971 rectangular L^1 divergence; ball-multiplier theorem ruling out L^p for p != 2). S2a is a doc-light scaffold creating proofs/Proofs/FourierSeriesOQ04OQ01.lean with the conjecture axiomatized + one provable companion (Plancherel-derived L^2-norm convergence). No Lean changes in this iteration.",
+    "builtItems": [
+      "research/problems/fourier-series-oq-04-oq-01/problem.md (new, ~120 lines): formal statement, classification (tier B, sig 6, tract 5), why-matters, theoretical context (known unconditional, known negative, open status).",
+      "research/problems/fourier-series-oq-04-oq-01/knowledge.md (new, ~120 lines): S1 OBSERVE survey with Mathlib API map (verified what is and is not available), insights (5 numbered), gaps (4 numbered), next steps (priority order), risk notes (4 numbered).",
+      "research/problems/fourier-series-oq-04-oq-01/state.md (new, ~80 lines): phase OBSERVE, S1 focus, active approach (axiomatize + partial results), blockers (none mathematical), detailed S2a next-action spec.",
+      "src/data/research/problems/fourier-series-oq-04-oq-01.json (new, this file): discovery metadata."
+    ],
+    "insights": [
+      "The 2D Carleson conjecture is the 'endpoint' of two flagship open problems — Bochner-Riesz in L^2 AND 1D Carleson lifted to n=2. Either positive progress would collapse one of these; no conditional approach (Kakeya, restriction) has discharged the L^2 endpoint.",
+      "L^2 norm convergence is trivial by Plancherel (the partial-sum residual is the L^2-norm of the tail of a square-summable series). The difficulty is the a.e. claim, which requires a maximal-operator estimate sup_R |S_R^sph f|.",
+      "Rectangular vs spherical asymmetry is genuinely n-dependent: in 1D the two coincide; in n >= 2, Fefferman 1971 showed rectangular L^1 may diverge a.e. yet spherical L^2 a.e. is open. Both facts can be stated separately in the gallery without conflict.",
+      "Fefferman's ball-multiplier theorem (the characteristic function of the unit ball is not an L^p multiplier on R^n for p != 2, n >= 2) is the canonical obstruction to applying Hunt-style L^p-interpolation. This is why the 2D conjecture is genuinely L^2-specific.",
+      "Doc-only S1 is the right scope for a fresh slug whose parent is a stub: parent FourierSeriesOQ04.lean has placeholder `:= 0` definitions. Until those are rigorised (S2a), the child cannot prove anything substantive. The S1 deliverable is laying the math substrate.",
+      "The honest formalisation matches CLAUDE.md's Axiom Integrity Policy: status='axiomatized', badge='axiom', axiomCount=1 (or more after Bochner-Riesz / Fefferman are added). Per memory_marquee_initiative and infrastructure conventions, open problems get axioms not 'verified' claims."
+    ],
+    "mathlibGaps": [
+      "No MultiFourierCoeff / fourierCoeff over (Fin n -> AddCircle T). Mathlib's fourierCoeff is 1D-only at AddCircle T.",
+      "No BochnerRiesz, sphericalPartialSum, ballMultiplier definitions.",
+      "No multi-dimensional Plancherel / Parseval (as an explicit identity over T^n). Should follow from lp 2 over Fin n -> Z but is not spelled out.",
+      "No Fefferman_ball_multiplier or related counterexample (requires Besicovitch / Kakeya machinery not present)."
+    ],
+    "nextSteps": [
+      "S2a (ACT, doc-light): create proofs/Proofs/FourierSeriesOQ04OQ01.lean (~150 lines) — rigorous definitions of multiFourierCoeff / latticeDisc / sphPartialSum on T^2 = Fin 2 -> AddCircle 1; the conjecture as `axiom carleson_2d_sph`; one unconditional companion theorem sphPartialSum_L2_norm_converge (may have sorry pending Mathlib n-D Plancherel). Plus gallery entry src/data/proofs/fourier-series-oq-04-oq-01/meta.json.",
+      "S2b (ACT, slower): formalise Bochner-Riesz a.e. convergence for delta > (n-1)/2 (Stein 1958). Real theorem to formalise (1958-era classical), not a placeholder. Estimate 300-500 lines, 2-3 iterations.",
+      "S3 (ACT, speculative): Fefferman 1971 ball-multiplier counterexample. Classical proof uses Besicovitch sets and a Kakeya-style construction — likely beyond a single Lean file without a major Mathlib detour. Postpone until Mathlib gains Kakeya infrastructure.",
+      "(skip): attempting to prove the conjecture itself. This is genuine open mathematics; no PR should claim to close it."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "harmonic-analysis",
+    "fourier-series",
+    "convergence",
+    "multi-dimensional",
+    "bochner-riesz",
+    "carleson-conjecture",
+    "open-problem"
+  ],
+  "relatedProofs": [
+    "fourier-series",
+    "fourier-series-oq-01",
+    "fourier-series-oq-02",
+    "fourier-series-oq-02-oq-03",
+    "fourier-series-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "Carleson, L. (1966). On convergence and growth of partial sums of Fourier series. Acta Math. 116, 135-157.",
+      "Hunt, R. A. (1968). On the convergence of Fourier series. Orthogonal Expansions and their Continuous Analogues, 235-255.",
+      "Stein, E. M. (1958). On limits of sequences of operators. Ann. of Math. 74, 140-170.",
+      "Fefferman, C. (1971). The multiplier problem for the ball. Ann. of Math. 94, 330-336.",
+      "Fefferman, C. (1971). On the divergence of multiple Fourier series. Bull. Amer. Math. Soc. 77, 191-195.",
+      "Tao, T. (2002). Some recent progress on the restriction conjecture. Fourier Analysis and Convexity (Birkhauser), 217-243.",
+      "Grafakos, L. (2014). Classical Fourier Analysis. 3rd ed. Springer GTM 249, Ch. 3 (Multi-dimensional Fourier series).",
+      "Stein, E. M.; Weiss, G. (1971). Introduction to Fourier Analysis on Euclidean Spaces. Princeton Math. Series 32."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Carleson%27s_theorem",
+      "https://en.wikipedia.org/wiki/Bochner%E2%80%93Riesz_mean",
+      "https://terrytao.wordpress.com/2007/05/26/the-bochner-riesz-conjecture-implies-the-restriction-conjecture/"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.Fourier.AddCircle",
+      "Mathlib.Analysis.Fourier.FourierTransform",
+      "Mathlib.MeasureTheory.Function.LpSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.l2Space",
+      "Mathlib.MeasureTheory.Constructions.Pi"
+    ]
+  },
+  "started": "2026-05-12T08:38:00.000Z",
+  "lastUpdate": "2026-05-12T08:38:00.000Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/FourierSeriesOQ04.lean",
+      "filename": "FourierSeriesOQ04.lean",
+      "lineCount": 103,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FourierSeriesOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for a fresh tier-B slug (`fourier-series-oq-04-oq-01`, knowledge score 0 prior to this PR). Doc-only — no Lean changes.

**Problem**: Does the spherical Fourier series $S_R^{\text{sph}} f(x) \to f(x)$ a.e. for every $f \in L^2(\mathbb{T}^2)$? (2D Carleson conjecture; open in mathematics since at least Stein's 1971 ICM address.)

## What's in this PR

- `research/problems/fourier-series-oq-04-oq-01/problem.md` (98 lines) — formal statement, classification (tier B, sig 6, tract 5), why-it-matters, theoretical context.
- `research/problems/fourier-series-oq-04-oq-01/knowledge.md` (109 lines) — Mathlib API survey, 5 insights, 4 gaps, prioritized next steps, 4 risk notes.
- `research/problems/fourier-series-oq-04-oq-01/state.md` (105 lines) — phase OBSERVE, S1 focus, detailed S2a next-action scaffold spec.
- `src/data/research/problems/fourier-series-oq-04-oq-01.json` (130 lines) — discovery metadata, references, related proofs, leanFiles.

**Parent file**: `Proofs/FourierSeriesOQ04.lean` is a 103-line stub with 0 theorems and 3 placeholder `:= 0` definitions. Its docstring (lines 95-96) already declares the open status. This entry promotes that docstring claim into a formal target with a clearly mapped path.

## Path forward (set by S1 next-action)

- **S2a** (~150 Lean lines): rigorise definitions (`multiFourierCoeff`, `latticeDisc`, `sphPartialSum` on $\mathbb{T}^2$), state the conjecture as `axiom carleson_2d_sph`, add one provable companion theorem (Plancherel-derived L² norm convergence). Gallery entry: `status='axiomatized'`, `badge='axiom'`.
- **S2b** (~300-500 lines): Bochner-Riesz a.e. convergence for $\delta > (n-1)/2$ (Stein 1958; classical, formalisable).
- **S3** (deferred): Fefferman 1971 ball-multiplier counterexample (needs Kakeya machinery not in Mathlib).
- **(skip)** Attempting to prove the conjecture itself. Genuine open mathematics; no PR should claim to close it.

## Notes

- Per CLAUDE.md Axiom Integrity Policy, the eventual gallery entry will use `status="axiomatized"` with `badge="axiom"`, never `verified`.
- This is iteration 1 for a fresh slug; status is being moved to `in-progress` and the claim released for the next researcher to pick up S2a.

## Test plan
- [x] No Lean changes; build skipped intentionally (doc-only).
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`).
- [x] Pre-push race check: `gh pr list --search fourier-series-oq-04-oq-01` returned empty; `git branch -a | grep` empty.
- [x] Rebased onto `origin/main` (advance of 1 commit during edit window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)