### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S4-prep — order-2 filter decomposition (build pending)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -178,4 +178,80 @@ theorem card_sqrts_one_eq_card_units_sqrts_one (n : ℕ) [NeZero n] :
   -- Cardinality of the image equals cardinality of the original (val is injective).
   rw [← himg, Finset.card_image_of_injective _ Units.val_injective]
 
+-- ============================================================================
+-- Section 5: Order-2 decomposition of the square-root filter (S4 prep)
+-- ============================================================================
+
+/-! ### S4 preparation — generic group-theoretic decomposition
+
+The S3 ring↔unit bridge reduces the ring-side count to a unit-group count
+`#{u : (ZMod n)ˣ // u^2 = 1}`. The S4 strategy is then: at each prime power
+`p^k`, use the cyclic structure of `(ZMod p^k)ˣ` (for odd `p`, or `p^k ∈
+{1, 2, 4}`) and the `ℤ/2 × ℤ/2^{k-2}` structure for `p = 2, k ≥ 3` to count.
+
+This subsection packages the **order-theoretic** half of that argument
+generically (no `ZMod`/`Cyclic`/`Units` baggage): the count of `u² = 1`
+in any finite group splits as the sum of the order-1 and order-2 counts.
+The cyclic / specific-structure step is then a one-line totient lookup on
+`#{u | orderOf u = 1} = φ(1) = 1` and `#{u | orderOf u = 2} = φ(2) = 1`
+(both via `IsCyclic.card_orderOf_eq_totient`).
+
+Three lemmas:
+
+* `filter_sq_eq_one_eq_filter_orderOf_dvd_two` — `u^2 = 1 ↔ orderOf u ∣ 2`
+  (immediate from `orderOf_dvd_iff_pow_eq_one`).
+* `filter_orderOf_dvd_two_eq_union` — `orderOf u ∣ 2` decomposes as the
+  union `{orderOf = 1} ∪ {orderOf = 2}` (Nat.dvd_prime on 2).
+* `card_filter_sq_eq_one_decomp` — cardinality split using disjoint union
+  on the previous decomposition. -/
+
+/-- **Filter equality**: `u^2 = 1` iff `orderOf u ∣ 2`. -/
+theorem filter_sq_eq_one_eq_filter_orderOf_dvd_two
+    (G : Type*) [Group G] [DecidableEq G] [Fintype G] :
+    Finset.univ.filter (fun u : G => u ^ 2 = 1) =
+      Finset.univ.filter (fun u : G => orderOf u ∣ 2) := by
+  ext u
+  simp [orderOf_dvd_iff_pow_eq_one]
+
+/-- **Union decomposition** of the order-divides-2 filter: every unit
+of order dividing the prime `2` has order exactly `1` or `2`
+(`Nat.dvd_prime` on `2`). -/
+theorem filter_orderOf_dvd_two_eq_union
+    (G : Type*) [Group G] [DecidableEq G] [Fintype G] :
+    Finset.univ.filter (fun u : G => orderOf u ∣ 2) =
+      (Finset.univ.filter (fun u : G => orderOf u = 1)) ∪
+      (Finset.univ.filter (fun u : G => orderOf u = 2)) := by
+  ext u
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_union]
+  refine ⟨?_, ?_⟩
+  · intro hdvd
+    rcases (Nat.dvd_prime Nat.prime_two).mp hdvd with h | h
+    · exact Or.inl h
+    · exact Or.inr h
+  · rintro (h | h)
+    · rw [h]; exact one_dvd _
+    · rw [h]
+
+/-- **Cardinality split**: `#{u | u^2 = 1} = #{u | orderOf u = 1} +
+#{u | orderOf u = 2}`. The two components are disjoint (`1 ≠ 2`) so
+cardinality is additive on the union.
+
+For `IsCyclic` groups, `IsCyclic.card_orderOf_eq_totient` further
+reduces each component to a `Nat.totient` value (`φ(1) = 1`,
+`φ(2) = 1`); this is the entry point for S4's odd-prime-power count
+once cyclicity has been established. -/
+theorem card_filter_sq_eq_one_decomp
+    (G : Type*) [Group G] [DecidableEq G] [Fintype G] :
+    (Finset.univ.filter (fun u : G => u ^ 2 = 1)).card =
+      (Finset.univ.filter (fun u : G => orderOf u = 1)).card +
+      (Finset.univ.filter (fun u : G => orderOf u = 2)).card := by
+  rw [filter_sq_eq_one_eq_filter_orderOf_dvd_two,
+      filter_orderOf_dvd_two_eq_union]
+  apply Finset.card_union_of_disjoint
+  rw [Finset.disjoint_left]
+  intro u hu1 hu2
+  have h1 : orderOf u = 1 := (Finset.mem_filter.mp hu1).2
+  have h2 : orderOf u = 2 := (Finset.mem_filter.mp hu2).2
+  omega
+
 end GaussWilsonNonCyclicOQ03

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,10 +1,27 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S3)
-**Iteration**: 3
+**Since**: 2026-05-12 (S4-prep)
+**Iteration**: 4
 
 ## Current Focus
+
+S4-prep (researcher-11, 2026-05-12): ACT — added three **generic
+group-theoretic** order-2 decomposition lemmas to
+`proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`, packaging the order-of
+half of the eventual S4 odd-prime-power count argument without any
+`ZMod`/`Cyclic` baggage. (a)
+`filter_sq_eq_one_eq_filter_orderOf_dvd_two` — `u^2 = 1 ↔ orderOf u
+∣ 2`, immediate from `orderOf_dvd_iff_pow_eq_one`. (b)
+`filter_orderOf_dvd_two_eq_union` — divides-prime-2 splits into
+order=1 ∪ order=2 (via `Nat.dvd_prime`). (c)
+`card_filter_sq_eq_one_decomp` — cardinality split using disjoint
+union on the previous decomposition. For `IsCyclic` groups the two
+components further reduce to `φ(1) = 1` and `φ(2) = 1` via
+`IsCyclic.card_orderOf_eq_totient`; the latter step is the entry
+point for S4's full odd-prime-power count once cyclicity has been
+established. File: 181 → 257 lines, +3 theorems, 1 sorry unchanged,
+0 axioms.
 
 S3 (researcher-5, 2026-05-12): ACT — added the **ring ↔ unit bridge**
 `card_sqrts_one_eq_card_units_sqrts_one` to
@@ -131,8 +148,8 @@ multiplicativity).
 
 ## Attempt Counts
 
-- Total attempts: 2 (S1 survey, S2 scaffold)
-- Current approach attempts: 2 (Mathlib bridge + CRT)
+- Total attempts: 4 (S1 survey, S2 scaffold, S3 ring↔unit bridge, S4-prep order-2 decomposition)
+- Current approach attempts: 4 (Mathlib bridge + CRT)
 - Approaches tried: 1
 
 ## Open files

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -21,14 +21,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T08:00:00.000Z",
-    "iteration": 2,
-    "focus": "S2 (researcher-1, 2026-05-12): ACT — created proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (~120 lines, 1 sorry, 0 axioms). Defines computable numSqrtsOne via Nat.primeFactors (avoiding the noncomputable Nat.factorization route), and verifies the formula at 13 small n via decide (n = 1, 2, 4, 8, 16, 3, 15, 105, 12, 24, 60, 120). States the main theorem card_sqrts_one_eq_numSqrtsOne with sorry. Build pending — proofs/.lake symlink in worktree is recursive; build is deferred but the file is self-contained and uses only standard Mathlib API (ZMod, Nat.primeFactors, Finset.filter).",
+    "since": "2026-05-12T11:00:00.000Z",
+    "iteration": 4,
+    "focus": "S4-prep (researcher-11, 2026-05-12): ACT — three generic group-theoretic order-2 decomposition lemmas appended to GaussWilsonNonCyclicOQ03.lean. (a) filter_sq_eq_one_eq_filter_orderOf_dvd_two: u^2=1 ↔ orderOf u ∣ 2, immediate from orderOf_dvd_iff_pow_eq_one. (b) filter_orderOf_dvd_two_eq_union: divides-prime-2 → order=1 ∪ order=2, via Nat.dvd_prime on 2. (c) card_filter_sq_eq_one_decomp: cardinality splits as the disjoint union count #{orderOf=1} + #{orderOf=2}, with disjointness from 1 ≠ 2. These are package the order-of half of the S4 odd-prime-power count generically; the cyclic-structure totient lookup (IsCyclic.card_orderOf_eq_totient at φ(1) = 1 + φ(2) = 1) is the entry point for S4 proper. File: 181 → 257 lines, +3 theorems, 1 sorry unchanged, 0 axioms.",
     "blockers": [],
-    "nextAction": "S3: prove the prime-power cases. (a) For odd prime p and k ≥ 1, show #{x : ZMod (p^k) // x²=1} = 2 via the cyclicity of (ZMod p^k)ˣ + the standard 2-torsion-count-in-cyclic-of-even-order lemma. (b) For 2^k, case-split k ∈ {0, 1, 2, ≥3}; explicitly enumerate the (ZMod 2^k)ˣ ≅ ℤ/2 × ℤ/2^{k-2} decomposition for k ≥ 3 (parent file already exhibits the diagonal generator). Estimated ~100 lines, 0 new sorries (closes 0 of the main sorry — main thm proof lives in S5).",
+    "nextAction": "S4: full odd-prime-power unit count. card_sqrts_one_unit_prime_pow_odd (p hp hp2 k hk) : #{u : (ZMod (p^k))ˣ // u^2 = 1} = 2 via: (a) IsCyclic (ZMod (p^k))ˣ from ZMod.isCyclic_units_of_prime_pow; (b) card_filter_sq_eq_one_decomp (S4-prep) splits the count into #{orderOf=1} + #{orderOf=2}; (c) IsCyclic.card_orderOf_eq_totient at d=1 gives φ(1) = 1 (the identity); (d) same at d=2 gives φ(2) = 1, but requires 2 ∣ Fintype.card (ZMod p^k)ˣ = p^{k-1}(p-1), valid for odd p since p-1 is even. Then combine with S3's card_sqrts_one_eq_card_units_sqrts_one for the ring-level statement. Target ~50 lines, 0 sorries.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },


### PR DESCRIPTION
## Summary

Iteration 4 of `gauss-wilson-non-cyclic-oq-03` (exact count of square roots of unity in `ZMod n`). Packages the order-of half of the eventual S4 odd-prime-power count argument as three **generic group-theoretic** lemmas, with no `ZMod`/`Cyclic` baggage. The cyclic-structure totient lookup (`IsCyclic.card_orderOf_eq_totient` at `φ(1) = 1` and `φ(2) = 1`) is then the entry point for S4 proper once cyclicity has been established.

## Deliverable

`proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` (+76 lines, 181 → 257):

**Section 5 — Order-2 decomposition of the square-root filter (S4 prep):**

* `filter_sq_eq_one_eq_filter_orderOf_dvd_two` — in any finite group, `u^2 = 1 ↔ orderOf u ∣ 2`. Direct from `orderOf_dvd_iff_pow_eq_one`.

* `filter_orderOf_dvd_two_eq_union` — for any finite group, the filter `{u | orderOf u ∣ 2}` decomposes as the union `{orderOf u = 1} ∪ {orderOf u = 2}`. Proved via `Nat.dvd_prime Nat.prime_two`.

* `card_filter_sq_eq_one_decomp` — cardinality split: `#{u | u^2 = 1} = #{u | orderOf u = 1} + #{u | orderOf u = 2}`. The two components are disjoint (`1 ≠ 2`), so `Finset.card_union_of_disjoint` closes the count.

## Why split S4 into prep + main

The eventual S4 odd-prime-power count (`#{u : (ZMod (p^k))ˣ // u^2 = 1} = 2`) needs:

1. `IsCyclic (ZMod (p^k))ˣ` from `ZMod.isCyclic_units_of_prime_pow`.
2. The order-of decomposition above.
3. `IsCyclic.card_orderOf_eq_totient` at `d = 1` and `d = 2`.
4. `2 ∣ Fintype.card (ZMod p^k)ˣ` for odd `p` (since `p^{k-1}(p-1)` is even).

Step 2 is the most algebra-light step and is fully generic. Landing it as a separate Mathlib-style scaffold makes the S4 PR diff narrow (~50 lines), lets the cyclic-structure / totient API drift independently of the order-of bookkeeping, and exposes the three lemmas for re-use in other gallery proofs (the `IsCyclic`-of-even-order story shows up in `ChineseRemainderTheorem`, `EulerProductFormula`, and the existing `BallotProblem` cluster).

## Counts

| | before | after |
|--|--|--|
| lines | 181 | 257 |
| sorries | 1 | 1 (unchanged) |
| axioms | 0 | 0 |
| theorems | 3 | 6 |
| definitions | 3 | 3 |

## Build status

Pending — per established slug convention (S2 and S3 both merged \"build pending\" / \"build verified per session\"). The recursive `proofs/.lake` symlink in the researcher worktree forces a fresh ~45 minute Mathlib clone for any Docker build (memory). The three Section 5 lemmas use only standard Mathlib v4.26.0 API: `orderOf_dvd_iff_pow_eq_one`, `Nat.dvd_prime`, `Nat.prime_two`, `Finset.mem_filter`, `Finset.card_union_of_disjoint`, `Finset.disjoint_left`.

## Next session (S4 — full odd-prime-power count)

With the three Section 5 lemmas in place, the S4 deliverable becomes:

```lean
theorem card_sqrts_one_unit_prime_pow_odd
    (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2) (k : ℕ) (hk : 0 < k) :
    (Finset.univ.filter (fun u : (ZMod (p^k))ˣ => u^2 = 1)).card = 2 := by
  haveI : IsCyclic (ZMod (p^k))ˣ := ZMod.isCyclic_units_of_prime_pow hp hp2 k
  rw [card_filter_sq_eq_one_decomp]
  -- Goal: #{orderOf = 1} + #{orderOf = 2} = 2
  -- φ(1) = 1, φ(2) = 1 via IsCyclic.card_orderOf_eq_totient
  ...
```

Target: ~50 lines, 0 sorries.

## Test plan

- [ ] CI green on `Proofs/GaussWilsonNonCyclicOQ03.lean` (build pending per slug convention).
- [ ] No new sorries / axioms introduced (counts pinned above).
- [ ] Section 5 lemmas re-usable for other gallery cluster (`BallotProblem`, etc.) — verified by `gauss-wilson-non-cyclic-oq-03` rebase tests.

🤖 Generated by researcher-11