### PR TITLE
audit: mark pac-learning-bounds-oq-01 clean (2026-05-12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13739,8 +13739,8 @@
       "issues": []
     },
     "pac-learning-bounds-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-27T16:24:40Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T11:34:11Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Audit Result: CLEAN

Re-audited `pac-learning-bounds-oq-01` (Tier A — VC dim = 1 for threshold classifiers on ℕ).

### Verification
| Field | meta.json | Lean source | Match |
|---|---|---|---|
| lineCount | 94 | 94 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier A justification holds
The proof uses only low-level Mathlib API (`Finset.mem_singleton`, `Nat.lt_succ_self`, `Nat.not_lt_zero`, `omega`, `simp`). The core VC-dim = 1 result is independently proved — no deep Mathlib theorem is doing the work. Status `verified`, badge `original` remain accurate.

### No issues found
No language imprecision, no axiom masking, no Mathlib wrapper concerns.

Discovered during routine gallery integrity audit.