### PR TITLE
research(erdos-szekeres-oq-03): S4 ACT-C — anti-monotonicity + boundary cases (build pending)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -20,13 +20,14 @@ diagonal hypergraph Ramsey number `R_k(s,t)` as the least `n` such that every
 monochromatic `s`-clique of one color or a monochromatic `t`-clique of the
 other.
 
-After **S3** (this revision) the `k = 1` pigeonhole sanity check
-`ramseyNumber_one s t = s + t - 1` is proved — the simplest instance of the
-hypergraph Ramsey theorem and a unit test for the API introduced in S2.
-The general existence theorem `ramsey_existence` (OQ-03a, two-layer Ramsey
-1930 induction) and the Erdős–Rado tower upper bound (OQ-03b) remain
-`sorry`-marked, deferred to S4+ per
-`research/problems/erdos-szekeres-oq-03/state.md`.
+After **S4 ACT-C** (this revision) the structural foundations of
+`ramsey_existence` are in place: anti-monotonicity of the Ramsey condition
+in both target sizes, and the `s = k` / `t = k` boundary cases proved at
+`n = t` / `n = s` via a direct case-split on whether some `k`-subset is
+colored `false`. `ramsey_existence` itself is rewritten to discharge both
+boundaries; only the genuine inductive case `s > k ∧ t > k` (the Ramsey 1930
+recursive bound through uniformity `k-1`) remains `sorry`-marked, deferred to
+S5+ per `research/problems/erdos-szekeres-oq-03/state.md`.
 
 ## Status
 
@@ -37,8 +38,14 @@ The general existence theorem `ramsey_existence` (OQ-03a, two-layer Ramsey
   `t = 0` base cases (the empty set witnesses both).
 - [x] **`isRamsey_one_iff` and `ramseyNumber_one` (S3)**: the `k = 1` case
   is the pigeonhole `s + t - 1` bound, by partitioning singletons.
-- [ ] `ramsey_existence` (OQ-03a): the general result, stated as `sorry`.
-  Proof strategy in `state.md`.
+- [x] **`IsRamsey.swap` and `ramseyNumber_zero_*` (S4-prep)**: color symmetry
+  and degenerate-`ramseyNumber` collapses.
+- [x] **`IsRamsey.anti_s` / `IsRamsey.anti_t` (S4 ACT-C)**: anti-monotonicity
+  in the target sizes, by extracting a sub-clique of the desired smaller size.
+- [x] **`is_ramsey_self_right` / `is_ramsey_self_left` (S4 ACT-C)**: the
+  `s = k` and `t = k` boundary cases at `n = t` and `n = s`, respectively.
+- [ ] `ramsey_existence` (OQ-03a): boundaries closed; the genuine inductive
+  case `s > k ∧ t > k` is `sorry`. Proof strategy in `state.md` (S5+).
 
 ## Approach
 
@@ -102,18 +109,6 @@ lemma isMonochromatic_of_card_lt {n k : ℕ} (χ : kColoring n)
   have hTle : T.card ≤ S.card := Finset.card_le_card hTsub
   exfalso
   omega
-
-/-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
-and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
-every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.
-
-This is the main result of the OQ-03 entry. The proof (Ramsey 1930) is by
-two-layer induction on `k` and `s + t`; see `state.md` for the strategy.
-Deferred to S4+ (S3 closed the `k = 1` sanity check; the `k ≥ 2` induction
-needs the additional neighborhood-collapse machinery). -/
-theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
-    ∃ n, IsRamsey n k s t := by
-  sorry
 
 /-- The empty set is a `0`-clique, monochromatic of every color. -/
 lemma isMonochromatic_empty_zero {n k : ℕ} (χ : kColoring n) (c : Bool)
@@ -369,5 +364,137 @@ lemma ramseyNumber_zero_true (k s : ℕ) (hk : 1 ≤ k) :
   unfold ramseyNumber
   have h0 : (0 : ℕ) ∈ {n | IsRamsey n k s 0} := is_ramsey_zero_true 0 k s hk
   exact Nat.le_zero.mp (Nat.sInf_le h0)
+
+/-! ### S4 ACT-C: structural lemmas and boundary cases of `ramsey_existence`
+
+The four lemmas below are the structural foundation for the S5 two-layer
+Ramsey-1930 induction:
+
+* `IsRamsey.anti_s`, `IsRamsey.anti_t` — anti-monotonicity in the target sizes.
+  A larger `s`-target is strictly harder to satisfy, so shrinking it preserves
+  the Ramsey condition. Needed in S5 to lift the recursive bound (which only
+  produces an `(s-1)`- or `(t-1)`-clique on a sub-coloring) up to the
+  outer `s`- or `t`-clique.
+* `is_ramsey_self_right`, `is_ramsey_self_left` — the `s = k` (resp. `t = k`)
+  boundary case: at uniformity `k`, target sizes `(k, t)` are settled by
+  `n = t`. Either some `k`-subset is colored `false` (giving a `k`-clique
+  monochromatic-`false`) or every `k`-subset is colored `true` (giving the
+  full `t`-vertex set as a monochromatic-`true` `t`-clique).
+
+With these in hand, `ramsey_existence` (below) is reduced to its
+genuinely-inductive case `s > k ∧ t > k` (the S5 target).
+-/
+
+/-- **Anti-monotonicity of `IsRamsey` in the `s`-target.** A larger `s` is
+strictly harder to satisfy — shrinking it preserves the Ramsey condition. The
+proof: any `s`-clique contains an `s'`-sub-clique (via
+`Finset.exists_subset_card_eq`), and monochromaticity descends to subsets. -/
+lemma IsRamsey.anti_s {n k s s' t : ℕ} (hss' : s' ≤ s)
+    (h : IsRamsey n k s t) : IsRamsey n k s' t := by
+  intro χ
+  rcases h χ with ⟨S, hSc, hSm⟩ | ⟨S, hSc, hSm⟩
+  · -- false-clique S of size s; extract an s'-sized sub-clique.
+    have hs'S : s' ≤ S.card := hSc ▸ hss'
+    obtain ⟨S', hS'sub, hS'card⟩ := Finset.exists_subset_card_eq hs'S
+    refine Or.inl ⟨S', hS'card, ?_⟩
+    intro T hT
+    rw [Finset.mem_powersetCard] at hT
+    obtain ⟨hTsub, hTcard⟩ := hT
+    exact hSm T (Finset.mem_powersetCard.mpr ⟨hTsub.trans hS'sub, hTcard⟩)
+  · -- t-clique branch: pass through unchanged.
+    exact Or.inr ⟨S, hSc, hSm⟩
+
+/-- **Anti-monotonicity of `IsRamsey` in the `t`-target.** Symmetric to
+`IsRamsey.anti_s`. -/
+lemma IsRamsey.anti_t {n k s t t' : ℕ} (htt' : t' ≤ t)
+    (h : IsRamsey n k s t) : IsRamsey n k s t' := by
+  intro χ
+  rcases h χ with ⟨S, hSc, hSm⟩ | ⟨S, hSc, hSm⟩
+  · exact Or.inl ⟨S, hSc, hSm⟩
+  · have ht'S : t' ≤ S.card := hSc ▸ htt'
+    obtain ⟨S', hS'sub, hS'card⟩ := Finset.exists_subset_card_eq ht'S
+    refine Or.inr ⟨S', hS'card, ?_⟩
+    intro T hT
+    rw [Finset.mem_powersetCard] at hT
+    obtain ⟨hTsub, hTcard⟩ := hT
+    exact hSm T (Finset.mem_powersetCard.mpr ⟨hTsub.trans hS'sub, hTcard⟩)
+
+/-- **Boundary case `s = k`.** At uniformity `k` and target sizes `(k, t)` with
+`k ≤ t`, the Ramsey condition holds at `n = t`.
+
+Proof: case-split on whether some `k`-subset is colored `false`.
+
+* **Case A.** If some `S` with `|S| = k` has `χ S = false`, then `S` itself is
+  a `k`-clique with monochromatic-`false` `k`-subsets — its only `k`-subset is
+  `S`, by `Finset.eq_of_subset_of_card_le` applied to the inclusion.
+* **Case B.** If no `k`-subset is colored `false`, then every `k`-subset of
+  `Finset.univ : Finset (Fin t)` is colored `true`, and `Finset.univ` is a
+  `t`-clique with `card = t` (by `Fintype.card_fin`). -/
+lemma is_ramsey_self_right (k t : ℕ) (hk : 1 ≤ k) (hkt : k ≤ t) :
+    IsRamsey t k k t := by
+  classical
+  intro χ
+  by_cases h : ∃ S : Finset (Fin t), S.card = k ∧ χ S = false
+  · -- Case A: a false-colored k-subset is itself the mono-false k-clique.
+    obtain ⟨S, hScard, hSχ⟩ := h
+    refine Or.inl ⟨S, hScard, ?_⟩
+    intro T hT
+    rw [Finset.mem_powersetCard] at hT
+    obtain ⟨hTsub, hTcard⟩ := hT
+    -- |T| = k = |S| with T ⊆ S ⇒ T = S.
+    have hT_eq : T = S := Finset.eq_of_subset_of_card_le hTsub (by omega)
+    rw [hT_eq]
+    exact hSχ
+  · -- Case B: every k-subset is colored true; Finset.univ is the mono-true t-clique.
+    push_neg at h
+    refine Or.inr ⟨Finset.univ, ?_, ?_⟩
+    · rw [Finset.card_univ, Fintype.card_fin]
+    · intro T hT
+      rw [Finset.mem_powersetCard] at hT
+      obtain ⟨_, hTcard⟩ := hT
+      -- From `h`, χ T ≠ false; in `Bool`, this forces χ T = true.
+      have hχ_ne : χ T ≠ false := fun hχ => h T hTcard hχ
+      cases hT_color : χ T with
+      | false => exact absurd hT_color hχ_ne
+      | true => exact hT_color
+
+/-- **Boundary case `t = k`.** Symmetric to `is_ramsey_self_right` via
+`IsRamsey.swap`. -/
+lemma is_ramsey_self_left (k s : ℕ) (hk : 1 ≤ k) (hks : k ≤ s) :
+    IsRamsey s k s k :=
+  IsRamsey.swap.mpr (is_ramsey_self_right k s hk hks)
+
+/-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
+and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
+every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.
+
+This is the main result of the OQ-03 entry. The proof is the classical Ramsey
+1930 two-layer induction on `k` (uniformity) and `s + t` (target sizes), with
+the two boundary cases `s = k` and `t = k` discharged by `is_ramsey_self_right`
+and `is_ramsey_self_left`, respectively. The genuine inductive case
+`s > k ∧ t > k` (which requires the neighborhood-collapse construction of
+Ramsey 1930) is deferred to S5+.
+
+Status after S4 ACT-C:
+* `s = k`: closed via `is_ramsey_self_right`, take `n = t`.
+* `t = k`: closed via `is_ramsey_self_left`, take `n = s`.
+* `s > k ∧ t > k`: `sorry` (S5 target — the recursive Ramsey bound). -/
+theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
+    ∃ n, IsRamsey n k s t := by
+  rcases eq_or_lt_of_le hs with hs_eq | hs_lt
+  · -- s = k boundary: n = t suffices by `is_ramsey_self_right`.
+    refine ⟨t, ?_⟩
+    rw [← hs_eq]
+    exact is_ramsey_self_right k t (by omega) ht
+  · rcases eq_or_lt_of_le ht with ht_eq | ht_lt
+    · -- t = k boundary: n = s suffices by `is_ramsey_self_left`.
+      refine ⟨s, ?_⟩
+      rw [← ht_eq]
+      exact is_ramsey_self_left k s (by omega) hs
+    · -- s > k ∧ t > k: the genuine inductive case (Ramsey 1930 recursive
+      -- bound). Deferred to S5+: the neighborhood-collapse construction
+      -- reduces uniformity `k` to `k-1` on a `(k-1)`-uniform induced
+      -- coloring, then recurses on `s + t`.
+      sorry
 
 end RamseyK

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,38 +1,61 @@
 # Current State
 
-**Phase**: ACT (S3 closes the `k = 1` sanity check; `ramsey_existence` remains)
-**Since**: 2026-05-12 (S3 ACT-B, researcher-11)
-**Iteration**: 3
-**Researcher**: researcher-11 (S3); researcher-9 (S2); researcher-8 (S1)
+**Phase**: ACT (S4 ACT-C closes the `s = k` / `t = k` boundary cases; the
+genuine inductive case `s > k ∧ t > k` remains the sole `ramsey_existence`
+sorry)
+**Since**: 2026-05-12 (S4 ACT-C, researcher-9)
+**Iteration**: 4
+**Researcher**: researcher-9 (S4 ACT-C, S2); researcher-1 (S4-prep); researcher-11 (S3); researcher-8 (S1)
 
 ## Current Focus
 
-Session 3 (S3 ACT-B, researcher-11, 2026-05-12): discharge the `k = 1`
-pigeonhole sanity check `ramseyNumber 1 s t = s + t - 1`.
+Session 4 (S4 ACT-C, researcher-9, 2026-05-12): factor `ramsey_existence`
+through the two boundary cases (`s = k` and `t = k`) and the
+anti-monotonicity of `IsRamsey` in both target sizes. The remaining sorry
+is now restricted to the genuine inductive content `s > k ∧ t > k`.
 
 Output of this session (build pending; the local worktree shares the broken
 `proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`):
 
-* `proofs/Proofs/RamseyHypergraph.lean` — 147 → 304 lines, +157.
-  New helper `isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
-  IsRamsey n 1 s t ↔ s + t - 1 ≤ n` cleanly factors the result.
-  - **Forward (⇐): `s + t - 1 ≤ n → IsRamsey n 1 s t`.** Pigeonhole. Let
-    `F := univ.filter (χ {·} = false)`, `G := univ.filter (χ {·} = true)`.
-    `Finset.filter_card_add_filter_neg_card_eq_card` gives
-    `|F| + |G| = n`. Case `|F| ≥ s` extracts an `s`-clique via
-    `Finset.exists_subset_card_eq`; otherwise `|G| ≥ t` extracts a
-    `t`-clique.
-  - **Reverse (⇒): `IsRamsey n 1 s t → s + t - 1 ≤ n`.** Contrapositive
-    on `n ≤ s + t - 2`. Build the worst-case coloring with
-    `a := min (s-1) n` `false`-singletons and the rest `true`. Two card
-    bounds via the globally-injective `Fin.val : Fin n → ℕ`:
-      - false-clique image ⊆ `Finset.range a` so `|S| ≤ a ≤ s - 1`.
-      - true-clique image ⊆ `Finset.Ico a n` (card `n - a` via
-        `Nat.card_Ico`) and case-split on `min` gives `n - a ≤ t - 1`.
-* `ramseyNumber_one`: closed by `isRamsey_one_iff` plus
-  `Nat.sInf` on the upward-closed set `{n | s + t - 1 ≤ n}`.
-* `leanFile` counts (this file): lineCount 147 → 304, theoremCount 6 → 7,
-  defCount 4 (unchanged), sorryCount 2 → 1, axiomCount 0 (unchanged).
+* `proofs/Proofs/RamseyHypergraph.lean` — 373 → 500 lines, +127.
+  New sorry-free lemmas:
+  - `IsRamsey.anti_s {n k s s' t} : s' ≤ s → IsRamsey n k s t → IsRamsey n k s' t`
+    — anti-monotonicity in the `false`-target. Extract an `s'`-sub-clique of
+    the `s`-clique via `Finset.exists_subset_card_eq`; monochromaticity
+    descends to subsets through `Finset.subset.trans` on `mem_powersetCard`.
+  - `IsRamsey.anti_t` — symmetric in `t`.
+  - `is_ramsey_self_right (k t : ℕ) (hk : 1 ≤ k) (hkt : k ≤ t) :
+    IsRamsey t k k t` — the `s = k` boundary case at `n = t`. Case-split on
+    `∃ S, |S| = k ∧ χ S = false`:
+      - **Case A.** Some `k`-subset `S` is colored `false` ⇒ `S` itself is the
+        mono-`false` `k`-clique. Sole `k`-sub-subset `T ⊆ S` satisfies
+        `|T| = k = |S|`, so `T = S` by `Finset.eq_of_subset_of_card_le`.
+      - **Case B.** No `k`-subset is `false` ⇒ every `k`-subset is `true`,
+        and `Finset.univ` (card `t` by `Fintype.card_fin`) is the mono-`true`
+        `t`-clique.
+  - `is_ramsey_self_left (k s : ℕ) (hk : 1 ≤ k) (hks : k ≤ s) :
+    IsRamsey s k s k` — `t = k` boundary, via `IsRamsey.swap.mpr` of
+    `is_ramsey_self_right k s hk hks`.
+* `ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t)`:
+  refactored to discharge both boundaries:
+  - `s = k`: take `n = t`, apply `is_ramsey_self_right`.
+  - `t = k`: take `n = s`, apply `is_ramsey_self_left`.
+  - `s > k ∧ t > k`: the genuine inductive case; deferred to S5.
+* `leanFile` counts (this file): lineCount 373 → 500 (+127), theoremCount
+  10 → 14 (+4), defCount 4 (unchanged), sorryCount 1 (unchanged),
+  axiomCount 0 (unchanged).
+
+## Prior Session Outputs (S3, researcher-11)
+
+* `proofs/Proofs/RamseyHypergraph.lean`: `isRamsey_one_iff` and
+  `ramseyNumber_one s t = s + t - 1`. PR #17960 merged (build verified).
+
+S3 introduced `isRamsey_one_iff (n s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) :
+IsRamsey n 1 s t ↔ s + t - 1 ≤ n` (forward via `Finset.filter_card_add_filter_neg_card_eq_card`
+pigeonhole + `Finset.exists_subset_card_eq`; backward via the
+`min (s-1) n`-prefix bad coloring with two `Fin.val_injective` card bounds)
+and derived `ramseyNumber_one` by `Nat.sInf` on the upward-closed set
+`{n | s + t - 1 ≤ n}`.
 
 ## Prior Session Outputs (S2, researcher-9)
 
@@ -80,29 +103,34 @@ adequate but verbose.
 
 ## Next Action
 
-**S4 ACT-C — Existence theorem `ramsey_existence` (OQ-03a).**
+**S5 ACT-D — Discharge the genuine inductive case of `ramsey_existence`.**
 
-The standard Ramsey 1930 two-layer induction. Induct on `s + t` for fixed
-`k`; the inductive step is the "neighborhood-tree" argument: fix any
-vertex `v`, the `(k-1)`-restrictions of `k`-subsets through `v` give a
-`(k-1)`-coloring on `[n] \ {v}`, then apply induction at uniformity `k-1`.
+After S4 ACT-C the boundaries `s = k` and `t = k` are sorry-free via
+`is_ramsey_self_right` / `is_ramsey_self_left`; the surviving sorry sits
+inside `ramsey_existence` under `s > k ∧ t > k`. S5 should establish the
+classical Ramsey 1930 recursive bound
 
-* Base case `k = 2`: reuse `SimpleGraph.ramseyNumber`-style proof (or
-  re-prove inline using the `k = 1` pigeonhole now available as
-  `ramseyNumber_one`).
-* Inductive step `k ≥ 3`: the harder half; ~150–300 lines depending on
-  how much Mathlib API is built up. Concretely, prove the recursive
-  bound `IsRamsey (R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1) k s t` and
-  derive `∃ n, IsRamsey n k s t` from there.
+    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1   (k ≥ 2, s, t > k)
 
-S5 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
+and run the induction on `s + t` for fixed `k`. The induction bottoms out
+cleanly on `is_ramsey_self_right` (`s = k+1` step ultimately calls back to
+`s' = k`) and `is_ramsey_self_left` (symmetric) — the four S4-ACT-C
+helpers (`anti_s`, `anti_t`, plus the two boundary lemmas) are precisely
+the API needed to "shrink" cliques produced at lower `s + t` back to the
+target size.
+
+Estimated 150–250 lines for the step alone (neighborhood-restriction
+construction at uniformity `k − 1`).
+
+S6 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
 
 ## Attempt Counts
 
-- Total attempts: 3
-- Current approach attempts: 3
-- Approaches tried: 3 (literature survey + Lean API design; S2 scaffold;
-  S3 `ramseyNumber_one` via pigeonhole iff helper)
+- Total attempts: 4
+- Current approach attempts: 4
+- Approaches tried: 4 (literature survey + Lean API design; S2 scaffold;
+  S3 `ramseyNumber_one` via pigeonhole iff helper; S4 ACT-C boundary
+  factoring + anti-monotonicity)
 
 ## Outcome of S1
 
@@ -128,5 +156,30 @@ s + t - 1 ≤ n` that factors the result cleanly. Forward direction uses
 constructs the bad coloring with `min (s-1) n` `false`-singletons and
 bounds the clique cards via `Finset.range`/`Finset.Ico` images of the
 globally-injective `Fin.val`. `ramseyNumber 1 s t = s + t - 1` then
-follows from the iff via `Nat.sInf` on the upward-closed set. Build
-pending (worktree shares the broken `proofs/.lake` symlink).
+follows from the iff via `Nat.sInf` on the upward-closed set. PR #17960
+merged.
+
+## Outcome of S4-prep
+
+S4-prep landed three sorry-free lemmas extending the API surface for the
+S4 inductive proof: `IsRamsey.swap` (color symmetry via `χ ↦ !χ`, halving
+the case analysis of any recursive bound) and `ramseyNumber_zero_false`/
+`ramseyNumber_zero_true` (degenerate-side `ramseyNumber` collapses to 0
+when one target size is 0). PR #17977 merged.
+
+## Outcome of S4 ACT-C
+
+S4 ACT-C delivered a structural factoring of `ramsey_existence`. Four new
+sorry-free lemmas land: `IsRamsey.anti_s` and `IsRamsey.anti_t`
+(anti-monotonicity in the target sizes via `Finset.exists_subset_card_eq`
+sub-clique extraction), `is_ramsey_self_right` (the `s = k` boundary at
+`n = t` via a direct Bool case-split on `∃ S, |S| = k ∧ χ S = false` —
+either the false `k`-subset is the mono-`false` `k`-clique via
+`Finset.eq_of_subset_of_card_le`, or `Finset.univ` is the mono-`true`
+`t`-clique), and `is_ramsey_self_left` (the `t = k` boundary, via
+`IsRamsey.swap.mpr`). `ramsey_existence` is then refactored to discharge
+both boundaries via these helpers, with the lone surviving sorry confined
+to the genuine inductive case `s > k ∧ t > k` (the S5 target). Build
+pending (worktree shares the broken `proofs/.lake` symlink); proof
+patterns mirror the S3 idioms (`cases hχ : χ T with`, `Finset.mem_powersetCard`
+membership unfold) so build risk is low.

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -30,27 +30,31 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 3,
-    "focus": "S4-prep API expansion (researcher-1, parallel to PR #17960's S3 ramseyNumber_one): added color-symmetry lemma IsRamsey.swap (s↔t via χ↦!χ) and degenerate-side base cases ramseyNumber_zero_false / ramseyNumber_zero_true (= 0 when one target size is 0).",
+    "iteration": 4,
+    "focus": "S4 ACT-C structural factoring (researcher-9): added 4 sorry-free helpers — IsRamsey.anti_s, IsRamsey.anti_t (anti-monotonicity in target sizes), is_ramsey_self_right (s=k boundary at n=t via Bool case-split), is_ramsey_self_left (t=k symmetric via IsRamsey.swap). ramsey_existence rewritten to discharge both boundaries; only the genuine inductive case s>k ∧ t>k remains sorry.",
     "blockers": [],
-    "nextAction": "S4 ACT-C: discharge ramsey_existence (OQ-03a) via the two-layer neighborhood induction. Base case k=2 reuses Mathlib's SimpleGraph.ramseyNumber; the k≥3 step uses fix-a-vertex neighborhood-restriction. IsRamsey.swap halves the case analysis. Estimated 150–300 lines.",
+    "nextAction": "S5 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. With the boundary cases now sorry-free, the induction on s+t for fixed k bottoms out cleanly on is_ramsey_self_right / is_ramsey_self_left, leaving only the inductive step's neighborhood-restriction construction to prove. Estimated 150–250 lines for the step alone.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
-      "approachesTried": 3
+      "total": 4,
+      "currentApproach": 4,
+      "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "S4-prep API (researcher-1 2026-05-12, parallel to PR #17960): added 3 sorry-free lemmas to RamseyHypergraph.lean — IsRamsey.swap (color symmetry under χ↦!χ, halves S4 case analysis), ramseyNumber_zero_false, ramseyNumber_zero_true (= 0 when either target size is 0; complement ramseyNumber_one on the s=0/t=0 end of the parameter range). Lines 147→209 (+62), sorries unchanged at 2. S3 ACT-B (researcher-11, PR #17960 open, build pending): discharged ramseyNumber_one s t = s+t-1 via isRamsey_one_iff (pigeonhole forward + min-singleton bad coloring backward) and standard sInf computation. S2 ACT-A scaffold (researcher-9 2026-05-12): created RamseyK API surface with 4 sorry-free supporting lemmas + 2 sorry-bearing main theorems. S1 ORIENT (researcher-8 2026-05-12): Decomposed OQ-03 into three sub-goals.",
+    "progressSummary": "S4 ACT-C structural factoring (researcher-9 2026-05-12): added 4 sorry-free lemmas — IsRamsey.anti_s, IsRamsey.anti_t (anti-monotonicity in target sizes via Finset.exists_subset_card_eq sub-clique extraction), is_ramsey_self_right (s=k boundary case, IsRamsey t k k t at n=t via Bool case-split on existence of a false k-subset), is_ramsey_self_left (t=k via IsRamsey.swap). ramsey_existence rewritten: boundary cases s=k / t=k discharged via the two self-Ramsey lemmas; only the genuine inductive case s>k ∧ t>k remains sorry. Lines 373→500 (+127), theorems 10→14 (+4), sorries unchanged at 1. S4-prep API (researcher-1, PR #17977): added 3 sorry-free lemmas — IsRamsey.swap (color symmetry under χ↦!χ), ramseyNumber_zero_false, ramseyNumber_zero_true. S3 ACT-B (researcher-11, PR #17960 build verified): discharged ramseyNumber_one s t = s+t-1 via isRamsey_one_iff (pigeonhole forward + min-singleton bad coloring backward). S2 ACT-A scaffold (researcher-9 2026-05-12): RamseyK API surface. S1 ORIENT (researcher-8 2026-05-12): decomposed OQ-03 into three sub-goals.",
     "builtItems": [
+      "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.anti_s, IsRamsey.anti_t, is_ramsey_self_right, is_ramsey_self_left + boundary-discharging ramsey_existence (S4 ACT-C, researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
       "proofs/Proofs/RamseyHypergraph.lean — isRamsey_one_iff and proved ramseyNumber_one = s+t-1 (S3, researcher-11, PR #17960 build pending).",
       "proofs/Proofs/RamseyHypergraph.lean — RamseyK API + 4 sorry-free degenerate-case lemmas + 2 sorry-bearing theorems (S2, researcher-9).",
       "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals (S1).",
       "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey + Mathlib API audit + suggested API surface (S1).",
-      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S3 next-action pinned."
+      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S5 next-action pinned (S4 ACT-C closes boundaries)."
     ],
     "insights": [
+      "The s=k boundary case is settled at n=t by a direct Bool case-split: either some k-subset is colored false (it IS the mono-false k-clique, since |S|=k forces |T|=|S| ⇒ T=S for any k-sub-subset T ⊆ S, via Finset.eq_of_subset_of_card_le), or every k-subset is colored true (and Finset.univ : Finset (Fin t) is the mono-true t-clique).",
+      "Anti-monotonicity of IsRamsey in s/t falls out of Finset.exists_subset_card_eq: shrink an s-clique to an s'-clique by extracting any s'-sized subset; monochromaticity descends to subsets since powersetCard k is closed under taking subsets through Finset.subset.trans.",
+      "After S4 ACT-C, ramsey_existence has exactly one sorry — the s>k ∧ t>k case — which is the genuine inductive content of Ramsey 1930. The induction on s+t now bottoms out cleanly on is_ramsey_self_right / is_ramsey_self_left rather than requiring separate ad-hoc base cases.",
       "OQ-03 cleanly factors into existence + upper + lower bounds; the existence and upper bound share the same two-layer neighborhood induction.",
       "The k=1 case ramseyNumber 1 s t = s + t - 1 is direct pigeonhole and serves as a clean sanity-check theorem for the new API (~30 lines).",
       "The lower-bound half (OQ-03c) is the harder direction and likely warrants its own sub-OQ once OQ-03a/b land.",
@@ -63,9 +67,9 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S4 ACT-C: discharge ramsey_existence (OQ-03a). Two-layer Ramsey 1930 induction; base case k=2 from Mathlib SimpleGraph.ramseyNumber; inductive step (k≥3) by fix-a-vertex neighborhood restriction (~150–300 lines).",
-      "S5: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and prove by unwinding the recursive R_k ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1 inequality.",
-      "S6+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S5 lands cleanly."
+      "S5 ACT-D: discharge the s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1, with induction on s+t for fixed k. The boundary base cases (s=k or t=k) are sorry-free as of S4 ACT-C; only the neighborhood-restriction construction at the inductive step needs proof (~150–250 lines).",
+      "S6: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and prove by unwinding the recursive inequality above.",
+      "S7+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S6 lands cleanly."
     ]
   },
   "tags": [
@@ -98,18 +102,18 @@
     ]
   },
   "started": "2026-05-12T04:48:16.447Z",
-  "lastUpdate": "2026-05-12T08:00:00.000Z",
+  "lastUpdate": "2026-05-12T11:35:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/RamseyHypergraph.lean",
       "filename": "RamseyHypergraph.lean",
-      "lineCount": 209,
-      "theoremCount": 9,
+      "lineCount": 500,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RamseyHypergraph.lean"
     },


### PR DESCRIPTION
## Summary

S4 ACT-C structural factoring of `ramsey_existence` (OQ-03a) in
`proofs/Proofs/RamseyHypergraph.lean`. Four new sorry-free lemmas land;
the remaining `ramsey_existence` sorry is narrowed to the genuine
inductive case `s > k ∧ t > k`. Total file sorries unchanged at 1.

## What lands

* `IsRamsey.anti_s {n k s s' t} : s' ≤ s → IsRamsey n k s t → IsRamsey n k s' t`
  Anti-monotonicity in the false-target. Sub-clique extraction via
  `Finset.exists_subset_card_eq`; monochromaticity descends via
  `Finset.subset.trans` on `mem_powersetCard`.
* `IsRamsey.anti_t` — symmetric in `t`.
* `is_ramsey_self_right (k t : ℕ) (hk : 1 ≤ k) (hkt : k ≤ t) :
   IsRamsey t k k t`
  The `s = k` boundary at `n = t`. Bool case-split on
  `∃ S, |S| = k ∧ χ S = false`:
    - Case A: that S is itself the mono-false k-clique (its only k-sub-subset
      is itself by `Finset.eq_of_subset_of_card_le`).
    - Case B: every k-subset is true ⇒ `Finset.univ` (card t via
      `Fintype.card_fin`) is the mono-true t-clique.
* `is_ramsey_self_left (k s : ℕ) (hk : 1 ≤ k) (hks : k ≤ s) :
   IsRamsey s k s k`
  The `t = k` boundary, by `IsRamsey.swap.mpr (is_ramsey_self_right k s hk hks)`.

`ramsey_existence` rewritten to discharge both boundaries; only the
`s > k ∧ t > k` case (the Ramsey-1930 recursive bound through uniformity
`k - 1`) remains sorry.

## File counts

`Proofs/RamseyHypergraph.lean`: lineCount 373 → 500 (+127), theoremCount
10 → 14 (+4), defCount 4 (unchanged), sorryCount 1 (unchanged),
axiomCount 0 (unchanged).

## Build status

Pending — the worktree shares the known-broken `proofs/.lake` symlink
(memory `feedback_researcher_lake_symlink_broken.md`), so docker-build
would fresh-clone Mathlib + cache fetch (~45 min). Proof patterns mirror
the S3 idioms (`cases hχ : χ T with`, `Finset.mem_powersetCard`
membership unfold, `Finset.exists_subset_card_eq`) that built cleanly in
PR #17960; build risk is correspondingly low.

## Follow-on (S5)

After S4 ACT-C the surviving sorry is exactly the Ramsey-1930 recursive
bound

    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1
    (for k ≥ 2, s > k, t > k)

with induction on `s + t` for fixed `k`. The four S4-ACT-C helpers
(`anti_s`, `anti_t`, plus the two boundary lemmas) form the precise API
the induction needs to "shrink" cliques produced at intermediate `s + t`
back to target size and to terminate cleanly on the `s = k` / `t = k` axes.

## Test plan

- [ ] Build verification deferred to a later batch (broken `.lake` symlink).
- [x] Diff inspected: proofs follow S3 / S4-prep style; `cases hχ : χ T with`
      matches the established Bool-elimination idiom at lines 340/347.
- [x] Pre-push race probe: no contesting open PRs for slug
      `erdos-szekeres-oq-03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)