### PR TITLE
audit(tracker): sync 2 entries — szemeredi-hypergraph-gowers re-audit + russell-1-plus-1-oq-04

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13406,10 +13406,10 @@
       "result": "clean"
     },
     "szemeredi-hypergraph-core-oq-01-incomplete-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-27T15:43:55Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-12T11:53:27Z",
+      "result": "clean"
     },
     "szemeredi-regularity": {
       "agentId": "auditor-cycle-20-batch",
@@ -15164,6 +15164,12 @@
     "minpoly-charpoly-oq-03-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-05-12T10:41:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "russell-1-plus-1-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T11:48:14Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- **szemeredi-hypergraph-core-oq-01-incomplete-01**: re-audit clean. Lean file shows 322 lines, 0 sorries, 0 axioms, 14 theorems, 7 defs/structures — all match meta.json. Title and originalContributions are infrastructure-scoped; mathlibDependencies (only `Finset.inter_eq_left`) does not constitute a core-result import, so badge `original` is appropriate.
- **russell-1-plus-1-oq-04**: first-audit clean entry from prior auditor session (was uncommitted in working tree).

## Integrity checks

| Field | meta.json | Lean source |
|---|---|---|
| lineCount | 322 | 322 |
| sorries | 0 | 0 |
| axiomCount | 0 | 0 |
| theoremCount | 14 | 14 |
| definitionCount | 7 | 7 |
| True stubs | — | 0 |

No issues found.

## Test plan
- [x] Tracker JSON is valid
- [x] Counts match Lean source