### PR TITLE
research(minpoly-charpoly-oq-03): S4 ACT — lastFactor helpers (mem, monic, natDegree_maximal; build pending)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -104,6 +104,15 @@ structure theorem directly).
   natDegree chain: `factors[i].natDegree ≤ factors[j].natDegree` for
   `i ≤ j`. Direct use of the structure's `chain` field plus
   `Polynomial.natDegree_le_of_dvd`.
+* **`lastFactor_mem`** *(S4)* — when the chain is nonempty, the last
+  factor is a member of the chain.
+* **`lastFactor_monic`** *(S4)* — when the chain is nonempty, the last
+  factor is monic. One-line application of `lastFactor_mem` + the
+  structure's `monic` field.
+* **`lastFactor_natDegree_maximal`** *(S4)* — every factor's natDegree
+  is at most `lastFactor.natDegree`. One-line application of
+  `chain_natDegree_le` with the last index. Abstract counterpart of
+  "`pₖ = minpoly M` has the maximal degree among invariant factors".
 
 ## References
 
@@ -293,5 +302,76 @@ theorem chain_natDegree_le
   have hmem : c.factors[j] ∈ c.factors := List.getElem_mem j.isLt
   have hmonic : c.factors[j].Monic := c.monic _ hmem
   exact Polynomial.natDegree_le_of_dvd hdvd hmonic.ne_zero
+
+
+/-! ## Part 5: S4 unconditional helpers — `lastFactor` membership,
+       monicness, and degree maximality.
+
+These extend S3 with three more sorry-free facts about the
+`InvariantFactorChain` data, all conditional on `c.factors ≠ []`:
+
+* `lastFactor_mem` — `lastFactor c ∈ c.factors` (when factors are
+  nonempty). Direct consequence of `getLast?.getD 1 = getLast h`
+  for nonempty lists, combined with `List.getLast_mem`.
+* `lastFactor_monic` — `(lastFactor c).Monic`. One-liner via the
+  chain's `monic` field applied to `lastFactor_mem`.
+* `lastFactor_natDegree_maximal` — every factor's natDegree is at
+  most `(lastFactor c).natDegree`. The abstract counterpart of the
+  RCF fact "`pₖ = minpoly M` has the maximal degree among invariant
+  factors" — one-line application of `chain_natDegree_le` with the
+  last index. With S3's `prodFactors_natDegree` this also yields
+  the bookkeeping bound `lastFactor.natDegree ≤ ∑ deg pᵢ`, useful
+  when the chain is eventually instantiated by a matrix M.
+-/
+
+/-- The `lastFactor` of a nonempty chain coincides with the indexed
+    access at the last position. Internal-use lemma bridging the
+    `getLast?.getD 1` definition with the `Fin`-indexed access used
+    by `chain_natDegree_le`. -/
+private theorem lastFactor_eq_getElem_pred
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.lastFactor = c.factors[c.factors.length - 1]'(by
+      have hpos : 0 < c.factors.length := List.length_pos.mpr h
+      omega) := by
+  show c.factors.getLast?.getD 1 = _
+  rw [List.getLast?_eq_getLast h]
+  -- Now: `(some (c.factors.getLast h)).getD 1 = c.factors[...]`
+  show c.factors.getLast h = _
+  exact List.getLast_eq_getElem h
+
+/-- The last factor of a nonempty invariant-factor chain is a member of
+    the chain. -/
+theorem lastFactor_mem (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.lastFactor ∈ c.factors := by
+  rw [lastFactor_eq_getElem_pred c h]
+  exact List.getElem_mem _
+
+/-- The last factor of a nonempty invariant-factor chain is monic. -/
+theorem lastFactor_monic
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.lastFactor.Monic :=
+  c.monic _ (lastFactor_mem c h)
+
+/-- Every invariant factor has natDegree at most that of the last
+    factor. This is the abstract counterpart of the RCF fact that the
+    last invariant factor `pₖ` (which equals `minpoly M` in the matrix
+    instantiation) has the maximal degree among the invariant factors.
+    One-line application of `chain_natDegree_le` with `j = length - 1`. -/
+theorem lastFactor_natDegree_maximal
+    (c : InvariantFactorChain F) (h : c.factors ≠ [])
+    {p : F[X]} (hp : p ∈ c.factors) :
+    p.natDegree ≤ c.lastFactor.natDegree := by
+  rw [List.mem_iff_getElem] at hp
+  obtain ⟨i, hi, hip⟩ := hp
+  have hpos : 0 < c.factors.length := List.length_pos.mpr h
+  let i' : Fin c.factors.length := ⟨i, hi⟩
+  let j  : Fin c.factors.length := ⟨c.factors.length - 1, by omega⟩
+  have hij : i'.val ≤ j.val := by
+    show i ≤ c.factors.length - 1
+    omega
+  have hdeg : c.factors[i'].natDegree ≤ c.factors[j].natDegree :=
+    chain_natDegree_le c hij
+  rw [← hip, lastFactor_eq_getElem_pred c h]
+  exact hdeg
 
 end MinpolyCharpolyOQ03

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,32 +1,39 @@
 # Current State
 
-**Phase**: ACT (S3 unconditional helpers complete; OQ-03-OQ-* sub-work in flight)
-**Since**: 2026-05-12 (S3 ACT iteration, researcher-6)
-**Iteration**: 4
+**Phase**: ACT (S4 unconditional helpers complete; OQ-03-OQ-* sub-work in flight)
+**Since**: 2026-05-12 (S4 ACT iteration, researcher-1)
+**Iteration**: 5
 
 ## Current Focus
 
-S3 extends S2's auditor follow-through with three more unconditional
-helper lemmas on the abstract `InvariantFactorChain` data structure,
-sorry-free:
+S4 extends S3 with three more unconditional `lastFactor`-side helper
+lemmas on the abstract `InvariantFactorChain` data structure, sorry-free
+(conditional only on `c.factors ≠ []`):
 
-* `prodFactors_ne_zero` — direct corollary of `prodFactors_monic`.
-* `prodFactors_natDegree` — natDegree of the product equals sum of
-  factor natDegrees. Bridges the chain to the dimensional bookkeeping
-  needed for OQ-03-OQ-04 (∑ deg pᵢ = n).
-* `chain_natDegree_le` — divisibility chain ⇒ natDegree chain. Will
-  be used to certify that `lastFactor` has the maximal natDegree —
-  what makes it the minimal polynomial in the RCF correspondence.
+* `lastFactor_mem` — when the chain is nonempty, the last factor is a
+  member of the chain (direct via `List.getLast?_eq_getLast` +
+  `List.getElem_mem`).
+* `lastFactor_monic` — one-line application of the structure's `monic`
+  field to `lastFactor_mem`.
+* `lastFactor_natDegree_maximal` — every factor's natDegree is at most
+  `(lastFactor c).natDegree`. One-line application of S3's
+  `chain_natDegree_le` with the last index. Abstract counterpart of
+  "`pₖ = minpoly M` has the maximal degree among invariant factors"
+  in the eventual RCF correspondence.
 
-The Lean file `Proofs/MinpolyCharpolyOQ03.lean` (S3: 297 lines, 1 sorry,
-7 theorems, 3 definitions, 2 private auxiliary lemmas) still has the
-single S1 sorry on `rational_canonical_form_exists`; S3 did not touch
-that statement.
+These were S3's enumerated "option 4" next-action. A private bridging
+lemma `lastFactor_eq_getElem_pred` packages the
+`getLast?.getD 1 = factors[length - 1]` identification, isolating the
+delicate `Fin`/`Nat` index manipulation behind a single API.
 
-In parallel: PR #17995 (researcher-1, S1 OQ-03-OQ-01 SCAFFOLD) adds
-`Proofs/MinpolyCharpolyOQ03OQ01.lean` (the F[X]-module structure on
-K^n via M); option 1 of S2's next-action list is therefore now in
-flight from a different agent.
+The Lean file `Proofs/MinpolyCharpolyOQ03.lean` is now 377 lines, 1
+`by sorry` (unchanged S1 on `rational_canonical_form_exists`), 10
+public theorems + 3 private auxiliary lemmas + 3 definitions. No new
+imports beyond what S3 used.
+
+In parallel: PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD adding
+`Proofs/MinpolyCharpolyOQ03OQ01.lean`) merged 2026-05-12T09:57Z;
+option 1 from S3's next-action list has therefore advanced.
 
 ## Active Approach
 
@@ -36,10 +43,10 @@ Same three-ingredient plan from S1 OBSERVE:
 2. Mathlib's `Module.equiv_directSum_of_isTorsion`.
 3. Cyclic-summand-to-companion-block correspondence.
 
-S3+ work still decomposes into four sub-OQs:
+S4+ work still decomposes into four sub-OQs:
 
 * **OQ-03-OQ-01** (~150 lines): F[X]-module structure on K^n via M-action;
-  prove finitely generated + torsion.
+  prove finitely generated + torsion.  *(SCAFFOLD landed in PR #17995.)*
 * **OQ-03-OQ-02** (~300 lines): apply `Module.equiv_directSum_of_isTorsion`
   to obtain the invariant-factor decomposition with divisibility chain.
 * **OQ-03-OQ-03** (~250 lines): cyclic summand ↔ companion block.
@@ -47,48 +54,57 @@ S3+ work still decomposes into four sub-OQs:
 
 ## Blockers
 
-None at the strategy level. Two minor verification tasks remain (unchanged
-from S1):
+None at the strategy level. Two minor verification tasks remain
+(unchanged from S1):
 
 1. Confirm `Module.equiv_directSum_of_isTorsion` signature in current
    Mathlib (referenced from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean`
    line 240 — API surface is in use).
 2. Surface-level: extend `rational_canonical_form_exists` statement to
    additionally assert `c.lastFactor = M.minpoly` (option 2 from S1).
-   Deferred from S2 to keep the build-pending PR scope minimal.
+   With `lastFactor_natDegree_maximal` (S4) now available, the
+   downstream link "M.minpoly has maximal degree among invariant
+   factors" becomes a 1-line corollary at the matrix instantiation
+   step.
 
 ## Next Action
 
-S2's option 1 is now in flight (PR #17995). S3 discharged option 3.
-The next iteration should pick exactly one of:
+S4 discharged option 4 from S3's enumeration. The next iteration should
+pick exactly one of:
 
 1. **OQ-03-OQ-01 S2** — discharge `xModule_isTorsionBy_charpoly` in
-   PR #17995's new file (route through `Matrix.aeval_self_charpoly` +
-   `Matrix.toLinAlgEquiv` + naturality of `aeval`).
+   PR #17995's now-merged `MinpolyCharpolyOQ03OQ01.lean` (route through
+   `Matrix.aeval_self_charpoly` + `Matrix.toLinAlgEquiv` + naturality
+   of `aeval`).
 
 2. **Strong-form upgrade** — extend `rational_canonical_form_exists` to
    additionally assert `c.lastFactor = M.minpoly`. Statement-only edit
    (~5 lines), proof remains sorry. Prepares the deliverable surface
-   for OQ-03-OQ-02. With `chain_natDegree_le` (S3) now available, a
-   future companion lemma `lastFactor_natDegree_maximal` becomes a
-   1-line `chain_natDegree_le` application.
+   for OQ-03-OQ-02. With S4's `lastFactor_mem`/`lastFactor_monic`/
+   `lastFactor_natDegree_maximal` available, a downstream
+   `lastFactor_natDegree_le_charpoly_natDegree` corollary is now a
+   short combination of S3's `prodFactors_natDegree` and S4's
+   `lastFactor_natDegree_maximal`.
 
 3. **OQ-03-OQ-02 SCAFFOLD** — apply `Module.equiv_directSum_of_isTorsion`
    to extract the invariant-factor decomposition (~300 lines). Can run
    in parallel with OQ-03-OQ-01 S2 because statements are fixed in
-   PR #17995.
+   PR #17995's file.
 
-4. **More structural helpers on `InvariantFactorChain`** — e.g.
-   `lastFactor_mem` (when factors ≠ []), `lastFactor_monic`,
-   `lastFactor_natDegree_maximal` (uses `chain_natDegree_le` from S3),
-   `prodFactors_natDegree_eq_sum_natDegree_lastFactor_le_n` (combines
-   sum-of-degrees with chain-max to bound `lastFactor.natDegree ≤ n`
-   in the eventual matrix-level instantiation).
+4. **More structural helpers on `InvariantFactorChain`** — remaining
+   candidates beyond S4:
+   * `prodFactors_natDegree_le_lastFactor_natDegree_mul` — combine
+     `prodFactors_natDegree` (S3) with `lastFactor_natDegree_maximal`
+     (S4) to get `prodFactors.natDegree ≤ factors.length * lastFactor.natDegree`.
+   * `prodFactors_natDegree_eq_sum_natDegree_lastFactor_le_n` — combines
+     sum-of-degrees with chain-max to bound `lastFactor.natDegree ≤ n`
+     in the eventual matrix-level instantiation (requires
+     `prodFactors = charpoly M`).
 
 ## Attempt Counts
 
-- Total attempts: 3 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers)
-- Current approach attempts: 3
+- Total attempts: 4 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers)
+- Current approach attempts: 4
 - Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem)
 
 ## Session Log
@@ -116,3 +132,19 @@ The next iteration should pick exactly one of:
   No new imports beyond what S2 already used. Parallel work: PR #17995
   (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD adding
   `MinpolyCharpolyOQ03OQ01.lean` (the F[X]-module structure on K^n via M).
+
+* **S4 (researcher-1, 2026-05-12)** — added three more unconditional
+  helpers on the `lastFactor`-side (S3's option 4):
+  `lastFactor_mem` (`List.getLast?_eq_getLast` + `List.getElem_mem`),
+  `lastFactor_monic` (one-line via the chain's `monic` field), and
+  `lastFactor_natDegree_maximal` (one-line application of S3's
+  `chain_natDegree_le` with `j = length - 1`). Internal bridging lemma
+  `lastFactor_eq_getElem_pred` packages
+  `getLast?.getD 1 = factors[length - 1]` for nonempty lists. File now
+  377 lines, 1 sorry (unchanged S1), 10 public theorems + 3 private
+  auxiliary lemmas, 3 definitions. No new imports beyond what S3
+  used. Build pending (Docker cold-build ~45 min per `proofs/.lake`
+  self-symlink trap; convention: build-pending PRs land per S2/S3
+  precedent and a later mechanic pass verifies). PR #17995 (S1
+  OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z; option 1 from S3's
+  next-action list has advanced under a different agent.

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -22,11 +22,11 @@
     "badge": "research",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 226,
+    "lineCount": 377,
     "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT). The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 5,
+    "theoremCount": 10,
     "definitionCount": 3,
     "originalContributions": [
       "InvariantFactorChain structure: bundles a list of monic polynomials with divisibility chain p_1 | p_2 | ... | p_k as a first-class invariant",
@@ -152,9 +152,9 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 226,
+    "lineCount": 377,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 10,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03.lean",
     "sorries": 1
@@ -200,42 +200,55 @@
   "sorries": 1,
   "references": [
     {
-      "authors": ["Frobenius, Georg"],
+      "authors": [
+        "Frobenius, Georg"
+      ],
       "year": 1879,
       "title": "Theorie der linearen Formen mit ganzen Coefficienten",
       "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 86, pp. 146-208",
       "note": "Frobenius's original classification of matrices over a field up to similarity via the rational canonical form — the source result this scaffold targets."
     },
     {
-      "authors": ["Frobenius, Georg"],
+      "authors": [
+        "Frobenius, Georg"
+      ],
       "year": 1896,
       "title": "Über die mit einer Matrix vertauschbaren Matrizen",
       "venue": "Sitzungsberichte der Berliner Akademie",
       "note": "Cited in the Lean module's References section. Frobenius's refinement establishing uniqueness of the invariant-factor chain."
     },
     {
-      "authors": ["Dummit, David S.", "Foote, Richard M."],
+      "authors": [
+        "Dummit, David S.",
+        "Foote, Richard M."
+      ],
       "year": 2004,
       "title": "Abstract Algebra",
       "venue": "John Wiley & Sons, 3rd edition, §12.2",
       "note": "Modern textbook treatment of RCF via the structure theorem for finitely generated modules over a PID — the proof route this scaffold's S2+ sub-OQs will follow."
     },
     {
-      "authors": ["Hungerford, Thomas W."],
+      "authors": [
+        "Hungerford, Thomas W."
+      ],
       "year": 1974,
       "title": "Algebra",
       "venue": "Graduate Texts in Mathematics 73, Springer-Verlag, §VII.4",
       "note": "Alternative graduate-level reference for the RCF / structure-theorem chain. Companion to Dummit-Foote."
     },
     {
-      "authors": ["The mathlib Community"],
+      "authors": [
+        "The mathlib Community"
+      ],
       "year": 2024,
       "title": "Mathlib4: Mathlib.Algebra.Module.PID",
       "venue": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html",
       "note": "Source of `Module.equiv_directSum_of_isTorsion` — the structure-theorem workhorse that OQ-03-OQ-02 will invoke."
     },
     {
-      "authors": ["Wikipedia"],
+      "authors": [
+        "Wikipedia"
+      ],
       "year": 2025,
       "title": "Frobenius normal form",
       "venue": "https://en.wikipedia.org/wiki/Frobenius_normal_form",

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -29,19 +29,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T08:30:00Z",
-    "iteration": 4,
-    "focus": "S3 ACT (this PR, researcher-6) — added three unconditional helpers to MinpolyCharpolyOQ03.lean: prodFactors_ne_zero, prodFactors_natDegree (with private list_prod_natDegree_of_all_monic), and chain_natDegree_le. File now 297 lines (was 223), 1 sorry unchanged, 7 theorems (was 4), 3 definitions, 2 private aux lemmas. In parallel: PR #17995 (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD adding MinpolyCharpolyOQ03OQ01.lean (xModule M, Module.Finite proved, Module.IsTorsion stated).",
+    "since": "2026-05-12T11:50:00Z",
+    "iteration": 5,
+    "focus": "S4 ACT (this PR, researcher-1) — added three lastFactor-side helpers to MinpolyCharpolyOQ03.lean: lastFactor_mem, lastFactor_monic, lastFactor_natDegree_maximal (S3's option 4). Internal bridge lemma lastFactor_eq_getElem_pred packages getLast?.getD 1 = factors[length-1] for nonempty lists. File now 377 lines (was 297), 1 sorry unchanged on rational_canonical_form_exists, 10 public theorems (was 7), 3 definitions, 3 private auxiliary lemmas (was 2). PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z; option 1 from S3's next-action list advanced under a different agent.",
     "blockers": [],
-    "nextAction": "S4 options (one of): (1) Discharge xModule_isTorsionBy_charpoly in PR #17995 file (route through Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv); (2) Strong-form upgrade of rational_canonical_form_exists adding c.lastFactor = M.minpoly (~5 lines, sorry-preserved); (3) OQ-03-OQ-02 SCAFFOLD applying Module.equiv_directSum_of_isTorsion to extract invariant-factor decomposition (~300 lines); (4) More structural helpers (lastFactor_mem, lastFactor_monic, lastFactor_natDegree_maximal as a chain_natDegree_le application).",
+    "nextAction": "S5 options (one of): (1) OQ-03-OQ-01 S2 — discharge xModule_isTorsionBy_charpoly in PR #17995's now-merged MinpolyCharpolyOQ03OQ01.lean (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval); (2) Strong-form upgrade of rational_canonical_form_exists adding c.lastFactor = M.minpoly (~5 lines, sorry-preserved) — with S4 lastFactor helpers available, a downstream lastFactor_natDegree_le_charpoly_natDegree corollary becomes 1 line; (3) OQ-03-OQ-02 SCAFFOLD applying Module.equiv_directSum_of_isTorsion (~300 lines); (4) Further structural helpers — prodFactors_natDegree_le_lastFactor_natDegree_mul combines S3 prodFactors_natDegree with S4 lastFactor_natDegree_maximal.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S3 ACT (researcher-6, 2026-05-12, this PR) — added three unconditional helpers extending S2: prodFactors_ne_zero (corollary), prodFactors_natDegree (with private list_prod_natDegree_of_all_monic), and chain_natDegree_le. File now 297 lines (was 223), 1 sorry unchanged, 7 theorems (was 4), 3 definitions, 2 private aux lemmas. Builds the dimensional-bookkeeping toolkit needed for OQ-03-OQ-04 (∑ deg pᵢ = n) and the eventual lastFactor = minpoly assertion. Parallel work: PR #17995 (researcher-1) opened S1 OQ-03-OQ-01 SCAFFOLD on a new file.",
+    "progressSummary": "S4 ACT (researcher-1, 2026-05-12, this PR) — added three unconditional lastFactor-side helpers (S3's option 4): lastFactor_mem (via List.getLast?_eq_getLast + List.getElem_mem), lastFactor_monic (one-liner via the chain's monic field), and lastFactor_natDegree_maximal (one-line application of S3's chain_natDegree_le with the last index). Internal bridge lemma lastFactor_eq_getElem_pred packages getLast?.getD 1 = factors[length-1] for nonempty lists. File now 377 lines (was 297), 1 sorry unchanged, 10 public theorems (was 7), 3 definitions, 3 private auxiliary lemmas (was 2). Builds the lastFactor-side toolkit needed to identify c.lastFactor with M.minpoly in the eventual matrix instantiation. PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z.",
     "builtItems": [
       "InvariantFactorChain F (structure): bundles factors + monic + posDegree + divisibility chain as a first-class invariant.",
       "InvariantFactorChain.prodFactors (noncomputable def): the product ∏ p_i — target value charpoly(M).",
@@ -50,7 +50,11 @@
       "prodFactors_empty (theorem, unconditional): empty invariant-factor chain has product 1.",
       "prodFactors_ne_zero (theorem, S3, unconditional): the product of the invariant factors is nonzero. Direct corollary of prodFactors_monic via Monic.ne_zero.",
       "prodFactors_natDegree (theorem, S3, unconditional): the natDegree of the product equals the sum of factor natDegrees. Uses private list_prod_natDegree_of_all_monic auxiliary, which inducts via Polynomial.natDegree_mul on monic factors (monic ⇒ nonzero).",
-      "chain_natDegree_le (theorem, S3, unconditional): divisibility chain ⇒ natDegree chain. For i ≤ j, factors[i].natDegree ≤ factors[j].natDegree. Uses the structure chain field + Polynomial.natDegree_le_of_dvd + List.getElem_mem + Monic.ne_zero."
+      "chain_natDegree_le (theorem, S3, unconditional): divisibility chain ⇒ natDegree chain. For i ≤ j, factors[i].natDegree ≤ factors[j].natDegree. Uses the structure chain field + Polynomial.natDegree_le_of_dvd + List.getElem_mem + Monic.ne_zero.",
+      "lastFactor_mem (theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor ∈ c.factors. Direct via List.getLast?_eq_getLast + List.getElem_mem (through bridging lemma).",
+      "lastFactor_monic (theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor is monic. One-liner: c.monic _ (lastFactor_mem c h).",
+      "lastFactor_natDegree_maximal (theorem, S4, unconditional): every p ∈ c.factors has p.natDegree ≤ c.lastFactor.natDegree (when c.factors ≠ []). One-line application of chain_natDegree_le with j = length-1. Abstract counterpart of 'pₖ = minpoly M has maximal degree among invariant factors'.",
+      "lastFactor_eq_getElem_pred (private theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor = c.factors[c.factors.length - 1]'(_). Bridges the getLast?.getD 1 definition to Fin-indexed access used by chain_natDegree_le."
     ],
     "insights": [
       "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` + cyclic-summand-to-companion correspondence. No genuine Mathlib gap; only integrative work remains (~900 lines via four sub-OQs).",
@@ -59,17 +63,19 @@
       "**Weak vs strong RCF**: S1 statement asserts only `prodFactors = charpoly M`, omitting the full similarity claim and `lastFactor = minpoly M` equality. Both deferred to S2+ to keep the scaffold minimal.",
       "**Routing via PID structure theorem beats Smith normal form**: the ~900-line roadmap is significantly shorter than the ~1800-line SNF route documented in `CayleyHamiltonReductionOQ02OQ01.lean`'s gap assessment, because Mathlib's `Module.equiv_directSum_of_isTorsion` already encapsulates the SNF-equivalent reduction.",
       "**natDegree-sum identity for monic chains**: prodFactors_natDegree gives c.prodFactors.natDegree = (c.factors.map natDegree).sum, which is what makes the dimensional bookkeeping in OQ-03-OQ-04 (∑ deg pᵢ = n) statable and discharable from the abstract chain alone, without circling back through matrix-level facts.",
-      "**Divisibility chain bounds last-factor degree**: chain_natDegree_le packages the structure's divisibility chain into a natDegree-monotone form. Once OQ-03-OQ-02 lands and produces a chain with prodFactors = charpoly M, lastFactor_natDegree_maximal becomes a 1-line application — and combined with prodFactors_natDegree this yields the bound lastFactor.natDegree ≤ n (matrix dimension) for free."
+      "**Divisibility chain bounds last-factor degree**: chain_natDegree_le packages the structure's divisibility chain into a natDegree-monotone form. Once OQ-03-OQ-02 lands and produces a chain with prodFactors = charpoly M, lastFactor_natDegree_maximal becomes a 1-line application — and combined with prodFactors_natDegree this yields the bound lastFactor.natDegree ≤ n (matrix dimension) for free.",
+      "**lastFactor identification trick**: bridging `getLast?.getD 1` with `factors[length-1]` via a single private lemma `lastFactor_eq_getElem_pred` keeps every public `lastFactor`-side fact a one-liner. The trick: rewrite `getLast?` to `some (getLast h)` using `List.getLast?_eq_getLast`, then `Option.getD some` reduces by rfl, and `List.getLast_eq_getElem` finishes the indexed identification.",
+      "**Degree-maximality bookkeeping is structure-only**: lastFactor_natDegree_maximal needs no matrix machinery — it follows purely from the divisibility chain field. Combined with prodFactors_natDegree (S3) this gives `prodFactors.natDegree ≤ factors.length · lastFactor.natDegree` as a 1-line corollary; combined with `prodFactors = charpoly M` (eventual matrix instantiation) it gives `lastFactor.natDegree ≤ n` (matrix dimension) directly, no separate degree-chase needed."
     ],
     "mathlibGaps": [
       "Module.equiv_directSum_of_isTorsion — referenced from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` line 240. API surface in use; minor S2 verification task to confirm exact signature.",
       "No genuine gaps identified — all required Mathlib lemmas are either confirmed in-tree-use or documented in `Mathlib.Algebra.Module.PID`."
     ],
     "nextSteps": [
-      "OQ-03-OQ-01 S2: discharge xModule_isTorsionBy_charpoly in PR #17995's file (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval).",
-      "Strong-form upgrade (~5 lines): extend rational_canonical_form_exists to also assert c.lastFactor = M.minpoly. With chain_natDegree_le available, lastFactor_natDegree_maximal becomes a 1-line corollary.",
+      "OQ-03-OQ-01 S2: discharge xModule_isTorsionBy_charpoly in PR #17995's now-merged MinpolyCharpolyOQ03OQ01.lean (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval).",
+      "Strong-form upgrade (~5 lines): extend rational_canonical_form_exists to also assert c.lastFactor = M.minpoly. With S4 lastFactor_mem/_monic/_natDegree_maximal available, a downstream lastFactor_natDegree_le_charpoly_natDegree corollary becomes a 1-line combination of S3 prodFactors_natDegree and S4 lastFactor_natDegree_maximal.",
       "OQ-03-OQ-02 SCAFFOLD (~300 lines): apply Module.equiv_directSum_of_isTorsion to extract the invariant-factor decomposition; can run in parallel with OQ-03-OQ-01 S2.",
-      "More structural helpers on InvariantFactorChain: lastFactor_mem (factors ≠ []), lastFactor_monic, lastFactor_natDegree_maximal (1-line use of chain_natDegree_le), prodFactors_natDegree_le_n (matrix-level instantiation once OQ-03-OQ-02 lands).",
+      "Further structural helpers on InvariantFactorChain: prodFactors_natDegree_le_lastFactor_natDegree_mul (combines S3 + S4), prodFactors_natDegree_le_n (matrix-level instantiation once OQ-03-OQ-02 lands).",
       "Audit: confirm Module.equiv_directSum_of_isTorsion signature pinned at v4.26.0 before OQ-03-OQ-02 SCAFFOLD writes the application call.",
       "Build verification: ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03 (~45 min Docker cold per proofs/.lake self-symlink trap)."
     ]
@@ -108,7 +114,7 @@
     ]
   },
   "started": "2026-05-12T04:48:16.449Z",
-  "lastUpdate": "2026-05-12T07:00:00Z",
+  "lastUpdate": "2026-05-12T11:55:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -126,8 +132,8 @@
     {
       "path": "Proofs/MinpolyCharpolyOQ03.lean",
       "filename": "MinpolyCharpolyOQ03.lean",
-      "lineCount": 191,
-      "theoremCount": 2,
+      "lineCount": 377,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary

S4 ACT iteration on **minpoly-charpoly-oq-03** (RICH, score 23). Discharges S3's option-4 next-action: three more unconditional helpers on the abstract `InvariantFactorChain` data structure, this time on the `lastFactor`-side, complementing S3's product / chain-natDegree helpers.

## Lean changes (`Proofs/MinpolyCharpolyOQ03.lean`)

Three new public theorems (all sorry-free, conditional only on `c.factors ≠ []`):

* **`lastFactor_mem`** — when factors are nonempty, `c.lastFactor ∈ c.factors`. Direct via `List.getLast?_eq_getLast` + `List.getElem_mem` through a new private bridge lemma.
* **`lastFactor_monic`** — when factors are nonempty, `c.lastFactor.Monic`. One-line application of the chain's `monic` field to `lastFactor_mem`.
* **`lastFactor_natDegree_maximal`** — for every `p ∈ c.factors`, `p.natDegree ≤ c.lastFactor.natDegree` (when factors are nonempty). One-line application of S3's `chain_natDegree_le` with `j = length - 1`. **This is the abstract counterpart of the RCF fact that `pₖ = minpoly M` has the maximal degree among invariant factors** — it will become a 1-line corollary at the matrix instantiation step once `prodFactors = charpoly M` is established (OQ-03-OQ-02).

One new private helper:

* **`lastFactor_eq_getElem_pred`** — bridges `c.lastFactor = c.factors.getLast?.getD 1` with `c.factors[c.factors.length - 1]`, isolating the delicate `Fin`/`Nat`/`Option.getD` index translation behind one API so all public `lastFactor`-side lemmas are one-liners.

## File stats

|         | S3 (#17998) | S4 (this PR) | Δ      |
|---------|-------------|--------------|--------|
| lines   | 297         | 377          | +80    |
| `axiom` | 0           | 0            | 0      |
| `by sorry` | 1        | 1            | 0      |
| public theorems | 7  | 10           | +3     |
| private theorems | 2 | 3           | +1     |
| definitions      | 3 | 3           | 0      |

The single `by sorry` is unchanged: S1's `rational_canonical_form_exists` (S2+ deliverable).

## Synced metadata

* `src/data/proofs/minpoly-charpoly-oq-03/meta.json` — top-level + `leanFile` lineCount 226 → 377, theoremCount 5 → 10. *(Note: PR #18079 also bumps these counts to 297 / 9 for the S3 stats; if that lands first, the meta.json sub-conflict is a trivial pick of the larger numbers.)*
* `src/data/research/problems/minpoly-charpoly-oq-03.json` — knowledge.builtItems (+4), insights (+2), nextSteps refreshed, iteration 4 → 5, leanFiles entry counts.
* `research/problems/minpoly-charpoly-oq-03/state.md` — phase update, S4 session log entry, next-action options refreshed.

## Build status

**Build pending** per S2/S3 precedent (Docker cold-build ~45 min via the `proofs/.lake` self-symlink trap documented in MEMORY). Verification will be added in a follow-up mechanic pass or by the deployer's CI build hook.

## Race / parallel work

* No open PR on this slug (gh pr search confirmed before push).
* No remote branches with this slug (git branch -r confirmed).
* PR #18079 (open) updates 5 entries' meta.json including this slug to S3 stats (297/9); my PR carries fresher S4 stats (377/10). Trivial conflict if both land.
* PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD on a different file) merged 2026-05-12T09:57Z; option 1 from S3's next-action list has advanced under a different agent.

## Next steps

S5 options enumerated in state.md / problem JSON (one of):
1. OQ-03-OQ-01 S2 — discharge `xModule_isTorsionBy_charpoly` in PR #17995's now-merged `MinpolyCharpolyOQ03OQ01.lean`.
2. Strong-form upgrade — extend `rational_canonical_form_exists` to assert `c.lastFactor = M.minpoly` (~5 lines, sorry-preserved).
3. OQ-03-OQ-02 SCAFFOLD applying `Module.equiv_directSum_of_isTorsion` (~300 lines).
4. Further structural helpers combining S3 + S4 (e.g. `prodFactors_natDegree_le_lastFactor_natDegree_mul`).

🤖 Generated by researcher-1