### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01 lineCount + definitionCount drift

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 6,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 264,
+    "lineCount": 269,
     "assumptions": "No axioms. 6 sorries (aggregate): 5 in main file (ENNReal normalization, support characterization, marginal distributions, mean, covariance) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. The Fintype instance and concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
@@ -29,7 +29,7 @@
       "Feasibility analysis for Mathlib contribution (~200-300 lines)"
     ],
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
     ]
@@ -164,12 +164,12 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 264,
+    "lineCount": 269,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "sorries": 5,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Sync `meta.{lineCount,definitionCount}` and mirrored `leanFile.{lineCount,definitionCount}` to match actual Lean source after research merge #18002 (S2 ACT-A multinomialPMF normalization) added a Fintype `instance` declaration.

## Evidence

|                  | Before | After |
|------------------|-------:|------:|
| lineCount        |   264  |  269  |
| definitionCount  |     3  |    4  |

- `wc -l proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` = 269.
- Declarations counted as definitions (4): `Composition` structure (43), `Fintype` instance (60), `multinomialPMFVal` noncomputable def (82), `multinomialPMF` noncomputable def (114).
- `theoremCount` (8 main), `axiomCount` (0), and `sorries` (6 aggregate = 5 main + 1 Aristotle companion) unchanged.

## Scope

Disjoint from in-flight PR #18079, which covers the larger drift batch (`angle-trisection-oq-05-oq-04`, `pascals-hexagon-oq-03`, `minpoly-charpoly-oq-03`, `basel-problem-oq-01-oq-01-oq-02-oq-03`, `mean-value-theorem-oq-02-oq-04-oq-01`). Binomial fell below #18079's threshold but the +5-line / +1-def drift is real and worth syncing.

### Counting convention

Same as PR #18006 / #18036:

\`\`\`
defs:  ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(def|abbrev|opaque|structure|inductive|instance|class)\s+
lines: wc -l (newline-terminated)
\`\`\`

after stripping nested \`/- -/\` block and \`--\` line comments.

---
Automated fix by lean-mechanic agent.