### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01): S3 — back-port multinomialPMF_sum_eq_one into parent (sorry-free, build verified)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.ENNReal.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Tactic
+import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01
 
 /-
 # Multinomial PMF Integration with Mathlib's PMF Framework
@@ -101,7 +102,29 @@ theorem multinomialPMF_sum_eq_one {α : Type*} [DecidableEq α]
     (s : Finset α) (p : α → ℝ≥0∞) (n : ℕ)
     (hp : ∑ i ∈ s, p i = 1) :
     ∑ k : Composition α s n, multinomialPMFVal s p n k = 1 := by
-  sorry -- Follows from multinomial theorem in ENNReal and the sum constraint
+  -- Anonymous record-wise equivalence to the sibling file's Composition type.
+  -- Both Composition structures have identical fields (counts, sum_eq,
+  -- counts_outside); the only reason for the bridge is namespace separation.
+  let e : Composition α s n ≃ CompositionFintype.Composition α s n :=
+    { toFun := fun c => ⟨c.counts, c.sum_eq, c.counts_outside⟩
+      invFun := fun c => ⟨c.counts, c.sum_eq, c.counts_outside⟩
+      left_inv := fun c => by cases c; rfl
+      right_inv := fun c => by cases c; rfl }
+  -- Step 1: transfer the Composition-indexed sum via the equivalence; the
+  -- summand is preserved pointwise because the bridge is the identity on
+  -- the underlying `counts` field, and `multinomialPMFVal` only reads `counts`.
+  rw [Fintype.sum_equiv e
+        (fun c => multinomialPMFVal s p n c)
+        (fun c => (Nat.multinomial s c.counts : ℝ≥0∞)
+                    * ∏ i ∈ s, p i ^ c.counts i)
+        (fun _ => rfl)]
+  -- Step 2: use the sibling's bridge to land on a piAntidiag sum.
+  rw [CompositionFintype.sum_composition_eq_piAntidiag_sum (M := ℝ≥0∞) s n
+        (fun k => (Nat.multinomial s k : ℝ≥0∞) * ∏ i ∈ s, p i ^ k i)]
+  -- Step 3: fold the piAntidiag sum into a power via Mathlib's multinomial theorem.
+  rw [← Finset.sum_pow_eq_sum_piAntidiag s p n]
+  -- Step 4: substitute ∑ p = 1 and 1^n = 1.
+  rw [hp, one_pow]
 
 -- ============================================================
 -- PART 4: The PMF Instance

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
@@ -1,10 +1,77 @@
 # Current State
 
-**Phase**: ACT (S2 ACT-A complete: namespace bridge + normalization theorem; sorry-free)
-**Since**: 2026-05-12T08:50:00Z (S2 ACT-A, researcher-11)
-**Iteration**: 2
+**Phase**: ACT (S3 back-port complete: parent sorry closed inline)
+**Since**: 2026-05-12T12:05:00Z (S3, researcher-6)
+**Iteration**: 3
 
-## Iteration 2 (researcher-11, 2026-05-12) — S2 ACT-A namespace bridge + normalization
+## Iteration 3 (researcher-6, 2026-05-12) — S3 back-port: close parent sorry
+
+**Outcome**: progress — `BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one`
+(line 100) is now proved sorry-free directly in the parent file. The proof
+inlines the 4-step `rw` chain from S2's `multinomialPMF_sum_eq_one_proved`
+together with an anonymous record-wise `Equiv` (the bridge cannot be the
+sibling's `compositionTypeEquiv` because the sibling file imports the parent,
+so a one-line `exact ...` wrapper would cycle).
+
+### What I added (~24 lines net)
+
+In `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean`:
+
+* `import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01` — new top-level import so
+  the parent can use `CompositionFintype.sum_composition_eq_piAntidiag_sum`
+  (sibling has no parent-file deps, so no cycle).
+
+* Body of `multinomialPMF_sum_eq_one` (was `sorry`): an inline
+  `let e : Composition α s n ≃ CompositionFintype.Composition α s n` (record-
+  wise identity Equiv on `counts`/`sum_eq`/`counts_outside`), then the same
+  4-step chain S2 used:
+  1. `Fintype.sum_equiv e` — transfer to the sibling Composition type.
+  2. `CompositionFintype.sum_composition_eq_piAntidiag_sum` — bridge to
+     `piAntidiag` sum.
+  3. `← Finset.sum_pow_eq_sum_piAntidiag` — fold to the `n`-th power.
+  4. `hp` + `one_pow` — close.
+
+### Why inline (not one-line wrapper)
+
+State.md S2's "Next Action" suggested
+`exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp`.
+This would create a circular import: the new file
+`BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` (where the `_proved` theorem
+lives) imports the parent. So the back-port has to be a duplicate inline
+proof body. The new file remains useful as a publicly-named witness
+(consumers can still cite `multinomialPMF_sum_eq_one_proved` if they want
+the named-on-purpose entry point).
+
+### Build status (S3)
+
+**Verified** via `./proofs/scripts/docker-build.sh
+Proofs.BinomialTheoremOQ02OQ01OQ01` (worktree-local script per project
+memory on `docker-build.sh REPO_ROOT` trap). The parent's
+`multinomialPMF_sum_eq_one` is now proven sorry-free; downstream parent
+sorries (`multinomialPMF_support`, `multinomial_marginal_binomial`,
+`multinomial_mean`, `multinomial_covariance`) remain — they are explicitly
+OUT OF SCOPE per S1's knowledge.md §10 and would belong to sibling slugs.
+
+### Files modified (S3 narrow)
+
+- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` — +1 import,
+  proof body replaces the line-104 `sorry` (~24 lines net).
+- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`
+  — iteration 2→3, status active→completed.
+- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/{knowledge.md,
+  state.md}` — S3 entry.
+
+### Slug status after S3
+
+Status flips to `completed`. The slug's stated goal —
+"discharge `multinomialPMF_sum_eq_one`" — is achieved in two places: the
+new sibling file (S2 ACT-A's `multinomialPMF_sum_eq_one_proved`) and the
+parent file directly (S3's back-ported proof). The four remaining
+downstream sorries are explicit non-goals.
+
+---
+
+## (Historic) Iteration 2 (researcher-11, 2026-05-12) — S2 ACT-A namespace bridge + normalization
 
 **Outcome**: progress — `multinomialPMF_sum_eq_one_proved` landed sorry-free in
 the new file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean` (~110

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01",
   "title": "Discharge multinomialPMF_sum_eq_one by combining the gallery's piAntidiag bridge with Mathlib's multinomial theorem",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,20 +28,21 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T08:50:00.000Z",
-    "iteration": 2,
-    "focus": "S2 ACT-A (researcher-11, 2026-05-12) — created proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~110 lines, sorry-free) with the namespace-bridge compositionTypeEquiv between BinomialTheoremOQ02OQ01OQ01.Composition and CompositionFintype.Composition, plus the main theorem multinomialPMF_sum_eq_one_proved discharging the parent's deferred sorry on multinomialPMF_sum_eq_one (BinomialTheoremOQ02OQ01OQ01.lean:102). The proof is the 4-step rw chain documented in S1's knowledge.md §8: (1) Fintype.sum_equiv compositionTypeEquiv to transfer to the sibling Composition type, (2) CompositionFintype.sum_composition_eq_piAntidiag_sum to land on a piAntidiag sum, (3) ← Finset.sum_pow_eq_sum_piAntidiag to fold into a power, (4) hp + one_pow to close. Added import to proofs/Proofs.lean (alphabetical position between OQ01OQ01OQ01.lean and OQ01OQ01OQ02.lean). The parent's sorry remains; S3 back-port is optional follow-up.",
+    "since": "2026-05-12T12:05:00.000Z",
+    "iteration": 3,
+    "focus": "S3 back-port (researcher-6, 2026-05-12) — closed the parent's BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one sorry directly by inlining a record-wise anonymous Equiv plus the same 4-step rw chain used in S2's multinomialPMF_sum_eq_one_proved. The state.md S2 next-action suggestion of `exact ...` (one-line wrapper) could not be used because the new sibling file (where _proved lives) imports the parent — a wrapper would cycle. Instead the parent imports Proofs.BinomialTheoremOQ02OQ01OQ01OQ01 (no cycle: the sibling has no parent-file deps) and inlines the proof body. The slug's stated goal — discharge multinomialPMF_sum_eq_one — is now achieved in both places (sibling file from S2 and parent file from S3). The four remaining downstream sorries (multinomialPMF_support, multinomial_marginal_binomial, multinomial_mean, multinomial_covariance) are explicit non-goals per S1 knowledge.md §10.",
     "blockers": [],
-    "nextAction": "S3 (optional): back-port the proven theorem into BinomialTheoremOQ02OQ01OQ01.lean by replacing the line-102 sorry with `exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp` (one-line wrapper). Trivial follow-up; would close the parent file's open sorry as well. Alternative: defer to a sibling slug for the four downstream sorries (multinomialPMF_support, multinomial_marginal_binomial, multinomial_mean, multinomial_covariance) — explicitly OUT OF SCOPE for this slug per S1 knowledge.md §10.",
+    "nextAction": "None. Slug status → completed. Sibling slugs would carry the downstream sorries (multinomialPMF_support, multinomial_marginal_binomial, multinomial_mean, multinomial_covariance) if/when those are added to the pool.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ACT-A (researcher-11, 2026-05-12): the deferred multinomialPMF_sum_eq_one is now proved sorry-free in a new sibling file BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~110 lines). The proof closes the route documented in S1: namespace bridge via compositionTypeEquiv (record-wise identity equivalence between the parent and sibling Composition types), Fintype.sum_equiv to transfer summation, CompositionFintype.sum_composition_eq_piAntidiag_sum to land on piAntidiag, ← Finset.sum_pow_eq_sum_piAntidiag to fold into the n-th power, then hp + one_pow. Added the import to proofs/Proofs.lean. The parent's sorry remains for the moment; S3 back-port is a one-line wrapper away. // S1 OBSERVE (2026-05-12, researcher-10): scaffolded the four artifact files for a previously empty (knowledge-score 0) tier-B slug. Mathlib v4.26.0 API audit at pin 2df2f015 confirms Finset.sum_pow_eq_sum_piAntidiag exists at Mathlib/Data/Nat/Choose/Multinomial.lean line 301-304, requires [CommSemiring R], and is stable across recent Mathlib releases. The gallery's BinomialTheoremOQ02OQ01OQ01OQ01.lean already provides sum_composition_eq_piAntidiag_sum. The remaining nontrivial subtask is the namespace bridge: the parent file's Composition and the child file's CompositionFintype.Composition are structurally identical but distinct Lean types, requiring a ~10-line compositionTypeEquiv. Total estimated S2 ACT-A: 50-60 lines of Lean.",
+    "progressSummary": "S3 back-port (researcher-6, 2026-05-12): closed the parent's multinomialPMF_sum_eq_one sorry directly by adding `import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01` to the parent and inlining the same 4-step rw chain S2 used (anonymous record-wise Equiv → Fintype.sum_equiv → sum_composition_eq_piAntidiag_sum → ← sum_pow_eq_sum_piAntidiag → hp + one_pow). The state.md S2 next-action's `exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp` (one-line wrapper) is not possible because the new sibling file (where _proved lives) imports the parent — so the back-port is a duplicate inline proof body. The new file remains useful as a publicly-named witness. // S2 ACT-A (researcher-11, 2026-05-12): the deferred multinomialPMF_sum_eq_one was proved sorry-free in a new sibling file BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~110 lines). The proof closes the route documented in S1: namespace bridge via compositionTypeEquiv, Fintype.sum_equiv, CompositionFintype.sum_composition_eq_piAntidiag_sum, ← Finset.sum_pow_eq_sum_piAntidiag, hp + one_pow. Added the import to proofs/Proofs.lean. // S1 OBSERVE (2026-05-12, researcher-10): scaffolded the four artifact files for a previously empty (knowledge-score 0) tier-B slug. Mathlib v4.26.0 API audit at pin 2df2f015 confirms Finset.sum_pow_eq_sum_piAntidiag exists at Mathlib/Data/Nat/Choose/Multinomial.lean line 301-304, requires [CommSemiring R], and is stable across recent Mathlib releases.",
     "builtItems": [
+      "**(S3 NEW)** proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean — closed line-104 sorry on multinomialPMF_sum_eq_one via inline anonymous Equiv plus the same 4-step rw chain; added top-level `import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01` (no cycle: sibling does not import parent); ~24 lines net.",
       "**(S2 NEW)** proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean — namespace-bridge file with compositionTypeEquiv (record-wise identity Equiv between parent and sibling Composition types) and multinomialPMF_sum_eq_one_proved (the proven normalization theorem); ~110 lines, sorry-free, build verified (BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean)",
       "**(S2 NEW)** proofs/Proofs.lean — added import in alphabetical position between OQ01OQ01OQ01.lean and OQ01OQ01OQ02.lean",
       "problem.md (formal statement + Lean target signature + non-claims)",


### PR DESCRIPTION
## Summary

- Closes the parent's deferred sorry on `BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one` (was line 104 of `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean`).
- Inlines the same 4-step `rw` chain S2 (#18002) used in the sibling-file's `multinomialPMF_sum_eq_one_proved`, together with an anonymous record-wise `Equiv` between the parent's `Composition` and the sibling's `CompositionFintype.Composition`.
- Parent now imports `Proofs.BinomialTheoremOQ02OQ01OQ01OQ01` for the sibling's `sum_composition_eq_piAntidiag_sum` bridge (no cycle — the sibling has no parent-file deps).
- Slug status flips to `completed`. The four remaining downstream sorries (`multinomialPMF_support`, `multinomial_marginal_binomial`, `multinomial_mean`, `multinomial_covariance`) are explicit non-goals per S1 knowledge.md §10.

### Why inline (not the one-line wrapper state.md S2 suggested)

State.md S2's "Next Action" suggested `exact BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one_proved s p n hp`. This is not possible: the new sibling file (where `_proved` lives) imports the parent, so a wrapper in the parent would create a circular import. Inlining duplicates ~10 lines of proof body but keeps the dependency graph acyclic. The named `multinomialPMF_sum_eq_one_proved` remains useful as a publicly-named witness for downstream callers who want the explicit-name entry point.

### Build verification

```
./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01
…
⚠ [3062/3062] Built Proofs.BinomialTheoremOQ02OQ01OQ01 (23s)
Build completed successfully (3062 jobs).
=== Build succeeded ===
```

Remaining build warnings on `BinomialTheoremOQ02OQ01OQ01.lean` are the four OUT-OF-SCOPE downstream sorries (lines 159/178/193/205 after the +24-line shift) plus two pre-existing `unused variable` warnings on the Fintype instance — not introduced by this PR.

## Test plan

- [x] Docker build of `Proofs.BinomialTheoremOQ02OQ01OQ01` clean (3062 jobs).
- [x] Net diff: +103 / -12 across three files; no `proofs/Proofs.lean` change (the S2 import already covers downstream visibility).
- [x] Rebased onto `origin/main` immediately before push.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)