### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S8 ACT — engelsma_lower_bound_of_finitary bridge lemma (build pending)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -354,4 +354,264 @@ theorem engelsma_analogue_nonvacuous_6_17 :
       ∀ (h0 : 0 ∈ H), IsAdmissible H → 16 ≤ H.max' ⟨0, h0⟩ := by
   native_decide
 
+/-! ## S8: Translation invariance + bridge lemma `engelsma_lower_bound_of_finitary`
+
+This section discharges `knowledge.md` §2.4. The goal is to reduce the
+unbounded form of `engelsma_lower_bound` to its finitary form
+
+```
+∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H
+```
+
+via the three-step plan recorded in `state.md`:
+
+* **(a) Translation invariance**: if `m ≤ a` for every `a ∈ H`, then
+  `IsAdmissible (H.image (· - m)) ↔ IsAdmissible H`. The proof reduces
+  per-prime residue cardinalities through the Z/pZ-translate
+  `r ↦ (r + m) % p`.
+* **(b) 50-subset extraction**: any `H'` with `H'.card ≥ 50` and
+  `0 ∈ H'` contains a 50-element subset `H₀ ⊆ H'` with `0 ∈ H₀`.
+* **(c) Wiring**: combine (a) and (b) to derive the contradiction.
+
+The deliverable is the standalone bridge lemma
+`engelsma_lower_bound_of_finitary`, which (together with a future
+`(50, 246)` `native_decide` or verified-backtracking proof of the
+finitary form) replaces the `engelsma_lower_bound` axiom in
+`BoundedPrimeGapsOQ03.lean`.
+
+All proofs in this section are pure-Lean combinatorics —
+`native_decide` is not used. The §S4 `Lean.ofReduceBool` axiom is
+unaffected; `axiomCount` stays at `1`. -/
+
+/-- The key modular identity: if `m ≤ a` and `0 < p`, then the
+residue of `a - m` mod `p` equals the residue of `a % p + (p - m % p)`
+mod `p`. This lets us realize the per-prime translate
+`r ↦ (r + (p - m % p)) % p` as a bijection on residues, which is the
+core of the `IsAdmissible` translation invariance.
+
+Proof strategy: equivalent to `(a - m) ≡ a % p + (p - m % p) [MOD p]`
+(the goal IS this congruence, by `Nat.ModEq`'s definitional unfolding
+to mod equality). We add `m % p` to both sides:
+
+* `(a - m) + m % p ≡ (a - m) + m = a [MOD p]`
+* `(a % p + (p - m % p)) + m % p = a % p + p ≡ a % p ≡ a [MOD p]`
+
+then cancel `m % p` via `Nat.ModEq.add_right_cancel'`. -/
+private lemma sub_mod_eq_mod_add_sub_mod {a m p : ℕ} (hp : 0 < p) (hma : m ≤ a) :
+    (a - m) % p = ((a % p) + (p - m % p)) % p := by
+  have hmp_lt : m % p < p := Nat.mod_lt _ hp
+  have h_a_modeq : a ≡ a % p [MOD p] := (Nat.mod_mod a p).symm
+  have h_m_modeq : m ≡ m % p [MOD p] := (Nat.mod_mod m p).symm
+  -- (a) (a - m) + m % p ≡ a [MOD p]
+  have ha : (a - m) + m % p ≡ a [MOD p] := by
+    have hstep : (a - m) + m % p ≡ (a - m) + m [MOD p] :=
+      Nat.ModEq.add_left _ h_m_modeq.symm
+    rwa [Nat.sub_add_cancel hma] at hstep
+  -- (b) (a % p + (p - m % p)) + m % p ≡ a [MOD p]
+  have hb : (a % p + (p - m % p)) + m % p ≡ a [MOD p] := by
+    have h_arith : a % p + (p - m % p) + m % p = a % p + p := by
+      have h_pmp_add : (p - m % p) + m % p = p :=
+        Nat.sub_add_cancel (le_of_lt hmp_lt)
+      omega
+    rw [h_arith]
+    have h_p_zero : p ≡ 0 [MOD p] := Nat.modEq_zero_iff_dvd.mpr (dvd_refl p)
+    have hadd : a % p + p ≡ a % p + 0 [MOD p] :=
+      Nat.ModEq.add_left _ h_p_zero
+    rw [Nat.add_zero] at hadd
+    exact hadd.trans h_a_modeq.symm
+  -- Combine and cancel m % p.
+  have h_combine : (a - m) + m % p ≡ (a % p + (p - m % p)) + m % p [MOD p] :=
+    ha.trans hb.symm
+  exact Nat.ModEq.add_right_cancel' (m % p) h_combine
+
+/-- For each prime `p`, the residue-image of `H.image (· - m)` mod `p`
+has the same cardinality as `H.image (· % p)`, provided `m ≤ a` for
+every `a ∈ H`. The proof exhibits the bijection
+`r ↦ (r + m) % p` between the two residue-images and applies
+`Finset.card_image_of_injOn`.
+
+This is the per-prime building block of
+`isAdmissible_image_sub_iff` below. The hypothesis `hp : 0 < p` is
+needed for `Nat.mod_lt`; we will only apply this lemma at prime
+moduli, where `0 < p` follows from `Nat.Prime.pos`. -/
+private lemma card_image_image_sub_mod_eq
+    {H : Finset ℕ} {m p : ℕ} (hp : 0 < p) (hm : ∀ a ∈ H, m ≤ a) :
+    ((H.image (· - m)).image (· % p)).card = (H.image (· % p)).card := by
+  -- Step 1: rewrite the LHS image-of-image into a single image
+  -- under the shift `r ↦ (r + (p - m % p)) % p` of `H.image (· % p)`.
+  have heq : (H.image (· - m)).image (· % p) =
+      (H.image (· % p)).image (fun r => (r + (p - m % p)) % p) := by
+    ext k
+    simp only [Finset.mem_image]
+    constructor
+    · rintro ⟨b, ⟨a, ha, rfl⟩, rfl⟩
+      exact ⟨a % p, ⟨a, ha, rfl⟩,
+        (sub_mod_eq_mod_add_sub_mod hp (hm a ha)).symm⟩
+    · rintro ⟨r, ⟨a, ha, rfl⟩, rfl⟩
+      exact ⟨a - m, ⟨a, ha, rfl⟩,
+        (sub_mod_eq_mod_add_sub_mod hp (hm a ha))⟩
+  rw [heq]
+  -- Step 2: the addition-shift is injective on `H.image (· % p)`.
+  apply Finset.card_image_of_injOn
+  intro r hr r' hr' hrr'
+  -- `hr, hr' : r, r' ∈ ↑(H.image (· % p))`. Unfold:
+  rw [Finset.mem_coe, Finset.mem_image] at hr hr'
+  obtain ⟨a, _, rfl⟩ := hr
+  obtain ⟨a', _, rfl⟩ := hr'
+  -- hrr' : (a % p + (p - m % p)) % p = (a' % p + (p - m % p)) % p
+  -- Add `m % p` to both sides and use that `(p - m % p) + m % p = p`.
+  have h_amod : a % p < p := Nat.mod_lt _ hp
+  have h_a'mod : a' % p < p := Nat.mod_lt _ hp
+  have h_mmod : m % p < p := Nat.mod_lt _ hp
+  have h1 : (a % p + (p - m % p) + m % p) % p = a % p := by
+    have heq1 : a % p + (p - m % p) + m % p = a % p + p := by omega
+    rw [heq1, Nat.add_mod_right, Nat.mod_eq_of_lt h_amod]
+  have h2 : (a' % p + (p - m % p) + m % p) % p = a' % p := by
+    have heq2 : a' % p + (p - m % p) + m % p = a' % p + p := by omega
+    rw [heq2, Nat.add_mod_right, Nat.mod_eq_of_lt h_a'mod]
+  have h3 : (a % p + (p - m % p) + m % p) % p =
+      (a' % p + (p - m % p) + m % p) % p := by
+    rw [Nat.add_mod (a % p + (p - m % p)) (m % p) p,
+        Nat.add_mod (a' % p + (p - m % p)) (m % p) p, hrr']
+  rw [h1, h2] at h3
+  exact h3
+
+/-- Cardinality is preserved by translation `(· - m)` when `m ≤ a` for
+every `a ∈ H`. The map is injective on `H` because subtraction by a
+common shift is injective on `[m, ∞)`. -/
+lemma card_image_sub_eq {H : Finset ℕ} {m : ℕ} (hm : ∀ a ∈ H, m ≤ a) :
+    (H.image (· - m)).card = H.card := by
+  apply Finset.card_image_of_injOn
+  intro a ha b hb hab
+  have hma := hm a ha
+  have hmb := hm b hb
+  omega
+
+/-- `H.image (· - m)` is nonempty iff `H` is. The translation lemma. -/
+lemma image_sub_nonempty {H : Finset ℕ} {m : ℕ} :
+    (H.image (· - m)).Nonempty ↔ H.Nonempty :=
+  Finset.image_nonempty
+
+/-- The translated set has maximum `H.max' - m` when `m ≤` everything in `H`.
+Both directions: `H.max' - m ∈ image` (witnessed by `H.max'` itself), and
+every image element is `≤ H.max' - m` (since each `a ≤ H.max'`). -/
+lemma image_sub_max'_eq {H : Finset ℕ} {m : ℕ} (hne : H.Nonempty)
+    (hm : ∀ a ∈ H, m ≤ a) :
+    (H.image (· - m)).max' (image_sub_nonempty.mpr hne) = H.max' hne - m := by
+  apply le_antisymm
+  · apply Finset.max'_le
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    have hma := hm a ha
+    have hamax : a ≤ H.max' hne := Finset.le_max' _ _ ha
+    omega
+  · have h_max_mem : H.max' hne ∈ H := Finset.max'_mem _ _
+    have h_image_mem : H.max' hne - m ∈ H.image (· - m) :=
+      Finset.mem_image.mpr ⟨H.max' hne, h_max_mem, rfl⟩
+    exact Finset.le_max' _ _ h_image_mem
+
+/-- The translated set has minimum `0` when `m = H.min'`. -/
+lemma image_sub_min'_eq_zero {H : Finset ℕ} (hne : H.Nonempty) :
+    (H.image (· - H.min' hne)).min' (image_sub_nonempty.mpr hne) = 0 := by
+  apply le_antisymm
+  · have h_min_mem : H.min' hne ∈ H := Finset.min'_mem _ _
+    have h_image_mem : 0 ∈ H.image (· - H.min' hne) :=
+      Finset.mem_image.mpr ⟨H.min' hne, h_min_mem, Nat.sub_self _⟩
+    exact Finset.min'_le _ _ h_image_mem
+  · exact Nat.zero_le _
+
+/-- **(a) Translation invariance**: `IsAdmissible (H.image (· - m))` iff
+`IsAdmissible H`, provided `m ≤ a` for every `a ∈ H`. Both directions
+reduce to `card_image_image_sub_mod_eq` (per-prime residue
+cardinality preservation under the translate). -/
+theorem isAdmissible_image_sub_iff {H : Finset ℕ} {m : ℕ}
+    (hm : ∀ a ∈ H, m ≤ a) :
+    IsAdmissible (H.image (· - m)) ↔ IsAdmissible H := by
+  unfold IsAdmissible
+  constructor
+  · intro h p hp
+    rw [← card_image_image_sub_mod_eq hp.pos hm]
+    exact h p hp
+  · intro h p hp
+    rw [card_image_image_sub_mod_eq hp.pos hm]
+    exact h p hp
+
+/-- **(b) 50-subset extraction**: if `H'` has at least 50 elements and
+contains `0`, we can extract a 50-element subset `H₀ ⊆ H'` with `0 ∈ H₀`
+and `H₀ ⊆ Finset.range w` whenever `H' ⊆ Finset.range w`. Construction:
+take a 49-element subset of `H'.erase 0`, then re-insert `0`. -/
+private lemma exists_subset_card_50_containing_zero
+    {H' : Finset ℕ} (h0 : 0 ∈ H') (hcard : 50 ≤ H'.card) :
+    ∃ H₀ ⊆ H', H₀.card = 50 ∧ 0 ∈ H₀ := by
+  have h_erase_card : 49 ≤ (H'.erase 0).card := by
+    have : (H'.erase 0).card = H'.card - 1 := Finset.card_erase_of_mem h0
+    omega
+  obtain ⟨S, hS_sub, hS_card⟩ := Finset.exists_subset_card_eq h_erase_card
+  refine ⟨insert 0 S, ?_, ?_, Finset.mem_insert_self _ _⟩
+  · intro x hx
+    rcases Finset.mem_insert.mp hx with rfl | hxS
+    · exact h0
+    · exact Finset.mem_of_mem_erase (hS_sub hxS)
+  · have h0_notin : 0 ∉ S := fun h =>
+      (Finset.not_mem_erase 0 H') (hS_sub h)
+    rw [Finset.card_insert_of_not_mem h0_notin, hS_card]
+
+/-- **(c) The bridge lemma**: the finitary form of the Engelsma lower
+bound implies the unbounded form. Given any admissible `H : Finset ℕ`
+with `H.card ≥ 50`, we translate `H` to start at `0` (preserving
+admissibility and cardinality by (a)), extract a 50-subset `H₀`
+containing `0` (by (b)), observe `H₀ ⊆ Finset.range 246` since the
+translated max is `< 246` under the contradictory hypothesis, then
+invoke `hfin` to derive a contradiction.
+
+This is the §2.4 reduction promised in `knowledge.md` and the S8
+deliverable per `state.md`. Combined with a future `(50, 246)`
+verified-backtracking or `native_decide` proof of `hfin`, this
+replaces the `engelsma_lower_bound` axiom in
+`BoundedPrimeGapsOQ03.lean`. -/
+theorem engelsma_lower_bound_of_finitary
+    (hfin : ∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H →
+      ¬ IsAdmissible H) :
+    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
+    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne := by
+  intro H hadm hcard hne
+  by_contra hlt
+  push_neg at hlt
+  -- hlt : H.max' hne - H.min' hne < 246
+  set m := H.min' hne with hm_def
+  have hm_le : ∀ a ∈ H, m ≤ a := fun a ha => Finset.min'_le _ a ha
+  set H' := H.image (· - m) with hH'_def
+  have hH'_ne : H'.Nonempty := image_sub_nonempty.mpr hne
+  have hH'_adm : IsAdmissible H' := (isAdmissible_image_sub_iff hm_le).mpr hadm
+  have hH'_card : H'.card = H.card := card_image_sub_eq hm_le
+  have h0_mem : 0 ∈ H' := by
+    rw [hH'_def, Finset.mem_image]
+    exact ⟨m, Finset.min'_mem _ _, Nat.sub_self _⟩
+  -- The translated maximum equals `H.max' - m < 246`.
+  have hH'_max : H'.max' hH'_ne = H.max' hne - m := by
+    rw [hH'_def]
+    exact image_sub_max'_eq hne hm_le
+  have hH'_max_lt : H'.max' hH'_ne < 246 := by
+    rw [hH'_max]; exact hlt
+  -- Cardinality lifts.
+  have hH'_card_ge : 50 ≤ H'.card := by rw [hH'_card]; exact hcard
+  -- Extract a 50-subset H₀ ⊆ H' containing 0.
+  obtain ⟨H₀, hH₀_sub, hH₀_card, hH₀_zero⟩ :=
+    exists_subset_card_50_containing_zero h0_mem hH'_card_ge
+  -- H₀ is admissible (as a subset of an admissible set).
+  have hH₀_adm : IsAdmissible H₀ :=
+    BoundedPrimeGaps.admissible_subset hH₀_sub hH'_adm
+  -- H₀ ⊆ Finset.range 246: each element of H₀ is ≤ H'.max' < 246.
+  have hH₀_in_range : H₀ ⊆ Finset.range 246 := by
+    intro x hx
+    have hxH' : x ∈ H' := hH₀_sub hx
+    have hx_le : x ≤ H'.max' hH'_ne := Finset.le_max' _ _ hxH'
+    exact Finset.mem_range.mpr (lt_of_le_of_lt hx_le hH'_max_lt)
+  -- H₀ ∈ powersetCard 50 of Finset.range 246.
+  have hH₀_in_powersetCard : H₀ ∈ (Finset.range 246).powersetCard 50 :=
+    Finset.mem_powersetCard.mpr ⟨hH₀_in_range, hH₀_card⟩
+  -- Apply hfin to derive ¬ IsAdmissible H₀ — contradiction.
+  exact hfin H₀ hH₀_in_powersetCard hH₀_zero hH₀_adm
+
 end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,13 +1,85 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12T08:30:00Z
-**Iteration**: 6
-**Researcher**: researcher-5 (S6); researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
+**Since**: 2026-05-12T11:30:00Z
+**Iteration**: 8
+**Researcher**: researcher-3 (S8); researcher-5 (S6); researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
 
 ## Current Focus
 
-S6 (this PR) — **Non-vacuous Engelsma analogues at the boundary
+S8 (this PR) — **`engelsma_lower_bound_of_finitary` bridge lemma**
+per `knowledge.md` §2.4. Pure-Lean combinatorics, parallel to S7's
+deferred `(10, 30)` `native_decide` (still risky on CI). Extends
+`BoundedPrimeGapsOQ03OQ02.lean` (357 → 617 lines, +260) with three
+sub-pieces.
+
+```lean
+theorem engelsma_lower_bound_of_finitary
+    (hfin : ∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H →
+      ¬ IsAdmissible H) :
+    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
+    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne
+```
+
+### Sub-piece (a) — Translation invariance toolkit
+
+* `sub_mod_eq_mod_add_sub_mod` (private) — the modular identity
+  `(a - m) % p = ((a % p) + (p - m % p)) % p` for `m ≤ a`, proven via
+  a `Nat.ModEq` chain (add `m % p` to both sides, cancel after both
+  reduce to `a` modulo `p`).
+* `card_image_image_sub_mod_eq` (private) — per-prime residue
+  cardinality preservation: `((H.image (· - m)).image (· % p)).card =
+  (H.image (· % p)).card`, via the bijection
+  `r ↦ (r + (p - m % p)) % p`.
+* `card_image_sub_eq` — translation preserves overall cardinality.
+* `image_sub_nonempty` — translation preserves nonemptyness.
+* `image_sub_max'_eq` — `(H.image (· - m)).max' = H.max' - m`.
+* `image_sub_min'_eq_zero` — `(H.image (· - H.min')).min' = 0`.
+* `isAdmissible_image_sub_iff` — the headline:
+  `IsAdmissible (H.image (· - m)) ↔ IsAdmissible H` when `m ≤ ∀ a ∈ H`.
+
+### Sub-piece (b) — 50-subset extraction
+
+* `exists_subset_card_50_containing_zero` (private) — for any `H'`
+  with `0 ∈ H'` and `H'.card ≥ 50`, produces `H₀ ⊆ H'` with
+  `H₀.card = 50` and `0 ∈ H₀`. Construction: 49-subset of
+  `H'.erase 0`, re-insert `0`.
+
+### Sub-piece (c) — Wiring
+
+The headline `engelsma_lower_bound_of_finitary` runs the §2.4 proof
+sketch: by contradiction, set `m := H.min'`, translate to
+`H' := H.image (· - m)`, observe `0 ∈ H'` (witnessed by `m - m`),
+`H'.max' = H.max' - m < 246` (the contradictory hypothesis),
+`H'.card ≥ 50` (by (a)), `IsAdmissible H'` (by (a)). Apply (b) to get
+`H₀ ⊆ H'` with `0 ∈ H₀`, `H₀.card = 50`. By
+`BoundedPrimeGaps.admissible_subset`, `IsAdmissible H₀`. Each
+element of `H₀` is `≤ H'.max' < 246`, so `H₀ ⊆ Finset.range 246`.
+Hence `H₀ ∈ (Finset.range 246).powersetCard 50`. Apply `hfin` to
+derive `¬ IsAdmissible H₀` — contradiction.
+
+### Why now (instead of S7)?
+
+`state.md`'s prior `Next Action` was S7 = `(10, 30)` `native_decide`
+(deferred via S6). S7 still carries the documented 30-120 s runtime
+risk; S8 is **pure-Lean combinatorics** with no `native_decide` cost
+and is explicitly marked "tackleable in parallel with S7" in the
+prior state.md. Landing S8 unblocks Path B (S9+): once we have a
+verified search procedure returning `false` for `(50, 246)`, S8's
+bridge lemma immediately discharges the original `engelsma_lower_bound`
+axiom — no further wiring is needed.
+
+### Axiom bookkeeping
+
+`axiomCount` stays at `1` (the `Lean.ofReduceBool` axiom introduced
+in S4 by `native_decide` is preserved). All S8 proofs are pure
+combinatorics — no `native_decide`, no new axioms. `theoremCount`:
+11 → 20 (9 new lemmas/theorems; the helpers + headline split as
+described above).
+
+### Previous focus (S6)
+
+S6 — **Non-vacuous Engelsma analogues at the boundary
 `w = H(k)+1`** for `k = 3, 4, 5, 6`. S4 (6,16) and S5 (8,22) verified
 the bound *vacuously* (Engelsma's table has `H(k) > w−1` in both
 cases, so no admissible tuple fits); S6 closes that gap by enumerating
@@ -67,27 +139,42 @@ stays at `1`.
 
 ## Next Action
 
-**S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`** per
-knowledge.md §3.3 (originally state.md's S5, deferred to S6, now
-S7 after S6 collected non-vacuous boundary evidence). Concrete
-target:
+**S9 — Begin Path-B verified-backtracking infrastructure** for the
+finitary form per `knowledge.md` §4. With S8's bridge lemma in
+place, the path from `engelsmaSearch 246 50 = false` to the
+discharge of `engelsma_lower_bound` is now mechanical:
 
 ```lean
-theorem engelsma_analogue_10_30 :
-    ∀ H ∈ (Finset.range 30).powersetCard 10,
-      ∀ (h0 : 0 ∈ H), IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by
+-- (i) Define the search procedure (write this as a `def`)
+def engelsmaSearch (w k : ℕ) : Bool := ...
+
+-- (ii) Prove correctness (Option-3 hybrid pattern, §4.3)
+theorem engelsmaSearch_correct (w k : ℕ) :
+    engelsmaSearch w k = false ↔
+      ∀ H ∈ (Finset.range w).powersetCard k, 0 ∈ H → ¬ IsAdmissible H
+  := ...
+
+-- (iii) Eval at (50, 246) — completes the axiom replacement.
+theorem engelsmaSearch_50_246 : engelsmaSearch 246 50 = false := by
   native_decide
+
+-- Apply S8's bridge to conclude `engelsma_lower_bound`:
+theorem engelsma_lower_bound' :
+    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
+    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne :=
+  engelsma_lower_bound_of_finitary
+    ((engelsmaSearch_correct 246 50).mp engelsmaSearch_50_246)
 ```
 
-`Nat.choose 30 10 ≈ 3 × 10^7`. Estimated `native_decide` runtime
-30–120 seconds. Vacuous antecedent (Engelsma records H(10) ≥ 32).
-May exceed default CI timeouts; if so, fall back to the §6.4
-Path-C-prime plan (land S2–S6, narrow the axiom statement). S6's
-non-vacuous (5,13) and (6,17) results give the qualitative
-confidence that S2's `Decidable` instance is correct on actually
-admissible inputs — orthogonal to the (10, 30) runtime question
-but a useful prerequisite for the Path-B verified-backtracking
-work in S8+.
+S9 is the start of (i)+(ii); concretely, encode an admissibility
+pruner that enumerates k-tuples in `Finset.range w` and short-circuits
+on the first failed residue cover. Estimate: 50-150 lines for the
+`def` alone; another 100-300 lines for the structural-induction
+correctness proof. Total Path-B effort: 5-10 sessions per §6.1.
+
+**Alternative deferred S7** — `(10, 30)` `native_decide` analogue.
+Lower priority than S9 Path-B work; useful only as another empirical
+runtime datapoint for the eventual `engelsmaSearch_50_246` call.
 
 ### Previous focus (S5)
 
@@ -207,23 +294,28 @@ but cannot be assessed until at least S4.
 
 ## Subsequent Iterations (deferred)
 
-- S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)`
-  via `native_decide` (originally state.md's S5; renumbered after
-  S5's (8,22) intermediate and S6's non-vacuous boundary suite).
-  Risk: 30–120 s runtime. Vacuous antecedent (H(10) ≥ 32 > 29).
-- S8 — `engelsma_lower_bound_of_finitary` bridge lemma
-  (Option B prerequisite) per knowledge.md §2.4. Can be tackled
-  in parallel with S7 since the bridge proof is pure-Lean
-  combinatorics independent of `native_decide` runtime.
-  Sub-pieces: (a) `IsAdmissible (H.image (· - m))` translation
-  invariance when `m ≤ min H`; (b) 50-subset extraction from a
-  card-≥50 set containing 0; (c) wiring the contradiction.
-- S9+ — Path B verified-backtracking prototype, building on
-  the S4/S5/S6/S7 `native_decide` infrastructure as a unit-test
-  harness. S6's non-vacuous boundary witnesses double as the
-  expected-output cases that any backtracker must agree with.
-- Path C (Selberg sieve fallback) remains an alternative if
-  Path B's runtime extrapolation fails at S7.
+- S9 — Begin Path-B verified backtracking infrastructure: the
+  `engelsmaSearch (w k : ℕ) : Bool` `def` per knowledge.md §4
+  (Option-3 hybrid pattern in §4.3). ~50-150 lines for the
+  pruning logic alone. S8's translation + bridge lemmas are
+  the prerequisite that S9 now no longer has to worry about.
+- S10 — Correctness lemma `engelsmaSearch_correct`: equivalence
+  between `engelsmaSearch w k = false` and the absence of any
+  admissible witness in `(Finset.range w).powersetCard k`. ~100-300
+  lines via structural induction over the search tree. Pre-checked
+  on the S6 non-vacuous boundary witnesses (which any correct
+  search must agree with).
+- S11 — `engelsmaSearch 246 50 = false` via `native_decide`. With
+  S8 + S9 + S10 in place, this is the final step that discharges
+  `engelsma_lower_bound`. Runtime depends on the S9 pruner; per
+  knowledge.md §4.5 (~10-60 s after compilation).
+- Alternative deferred S7 — `(10, 30)` `native_decide` analogue.
+  Lower priority than the Path-B work above. Useful only as another
+  empirical scaling datapoint for the eventual S11 call.
+- Path C (Selberg sieve fallback) remains an alternative if Path-B
+  runtime turns out to be infeasible at (50, 246) — knowledge.md §5
+  notes it doesn't reduce to a tractable enumeration on its own,
+  but it would let us narrow the residual `native_decide` claim.
 
 ## Attempt Counts
 
@@ -274,4 +366,23 @@ but cannot be assessed until at least S4.
   Originally planned S6 = (10, 30) renumbered to S7 (still vacuous, higher
   runtime risk, lower mathematical value than the boundary non-vacuous
   cases here). Build pending; the Docker symlink trap prevents local
-  verification.
+  verification. PR #18027 merged.
+- **S8 (2026-05-12, researcher-3)**: ACT. Extended S6 file (357 → 617 lines, +260):
+  the `engelsma_lower_bound_of_finitary` bridge lemma per knowledge.md §2.4.
+  Pure-Lean combinatorics — no `native_decide`, no new axioms (`axiomCount`
+  stays at 1). Three sub-pieces: (a) translation invariance toolkit
+  (`isAdmissible_image_sub_iff` + the per-prime modular bijection lemma
+  `card_image_image_sub_mod_eq` + 4 helpers `card_image_sub_eq` /
+  `image_sub_nonempty` / `image_sub_max'_eq` / `image_sub_min'_eq_zero`,
+  with the foundational modular identity `sub_mod_eq_mod_add_sub_mod` proven
+  via a `Nat.ModEq` chain); (b) 50-subset extraction
+  `exists_subset_card_50_containing_zero`; (c) wiring in the headline
+  `engelsma_lower_bound_of_finitary` theorem. theoremCount 11 → 20 (9 new
+  lemmas/theorems). Reduces the unbounded `engelsma_lower_bound` axiom in
+  `BoundedPrimeGapsOQ03.lean` (line 134) to its finitary form
+  `∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H` —
+  Path-B (S9+) verified-backtracking work then needs only to discharge
+  the latter to close the axiom. Build pending; the Docker symlink trap
+  blocks local verification (memory: feedback_researcher_lake_symlink_broken).
+  Skipped S7 (vacuous (10, 30) `native_decide`) per state.md's note that
+  S8 is "tackleable in parallel with S7" with higher mathematical value.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T08:30:00Z",
-    "iteration": 6,
-    "focus": "S6 (this PR) — Non-vacuous Engelsma analogues at the boundary `w = H(k)+1` for k = 3, 4, 5, 6. Extends BoundedPrimeGapsOQ03OQ02.lean (245 → 357 lines, +112) with four theorems `engelsma_analogue_nonvacuous_(3,7) / (4,9) / (5,13) / (6,17)` via `native_decide`. Closes the vacuous-bound gap left by S4 (6,16) and S5 (8,22) — both vacuous because Engelsma records H(k) > w-1 in those cases. Search spaces: C(7,3)=35, C(9,4)=126, C(13,5)=1287, C(17,6)=12376 (cumulative ~1.4 × 10⁴ subsets — well below the S5 cost). Each bound is tight, witnessed by classical Hardy–Littlewood admissible k-tuples ({0,2}, {0,2,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12,16}). Reuses the `Lean.ofReduceBool` axiom from S4 (`axiomCount` stays at 1); theoremCount 7 → 11. Deviates from state.md's originally planned S6 = (10,30) because that case is still vacuous (H(10) ≥ 32) and carries 30–120 s runtime risk, while the non-vacuous boundary cases test the diameter bound for ~14k subsets total. The (10, 30) step is renumbered to S7. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification.",
+    "since": "2026-05-12T11:30:00Z",
+    "iteration": 8,
+    "focus": "S8 (this PR) — `engelsma_lower_bound_of_finitary` bridge lemma per knowledge.md §2.4. Pure-Lean combinatorics, parallel to S7's deferred (10, 30) `native_decide`. Extends BoundedPrimeGapsOQ03OQ02.lean (357 → 617 lines, +260) with three sub-pieces: (a) translation invariance (`isAdmissible_image_sub_iff` for `H.image (· - m)` when `m ≤ ∀ a ∈ H`) backed by a per-prime modular bijection lemma `card_image_image_sub_mod_eq` and supporting helpers `card_image_sub_eq` / `image_sub_max'_eq` / `image_sub_min'_eq_zero` / `image_sub_nonempty`; (b) 50-subset extraction (`exists_subset_card_50_containing_zero`); (c) wiring the contradiction in the headline `engelsma_lower_bound_of_finitary` theorem. Reduces the unbounded `engelsma_lower_bound` axiom in BoundedPrimeGapsOQ03.lean (line 134) to its finitary form `∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H` — i.e., a future `native_decide` or verified-backtracking proof of `hfin` will discharge the axiom directly. theoremCount 11 → 20 (9 new declarations). axiomCount stays at 1 (`Lean.ofReduceBool` reused from S4; no new axioms). 0 sorries. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification (memory: feedback_researcher_lake_symlink_broken). All proofs are pure-Lean combinatorics — no `native_decide` introduced this iteration.",
     "blockers": [],
-    "nextAction": "S7 — Mid-size Engelsma analogue at `(k, w) = (10, 30)` (originally state.md's S5, renumbered through S6, S7 after intermediate steps): `∀ H ∈ (Finset.range 30).powersetCard 10, ∀ h0, IsAdmissible H → 22 ≤ H.max' ⟨0, h0⟩ := by native_decide` (~3 × 10⁷ admissibility checks). Reuses the `Lean.ofReduceBool` axiom; no further `axiomCount` bumps expected. Risk: 30–120 s `native_decide` runtime, possibly exceeding default CI timeouts; if so, fall back to the §6.4 Path-C-prime plan (land S2-S6, narrow the axiom statement). Vacuous antecedent (Engelsma records H(10) ≥ 32 > 29). The S6 non-vacuous (5,13) and (6,17) results supply qualitative correctness evidence for the S2 instance — orthogonal to the (10, 30) runtime question but a useful prerequisite for the Path-B verified-backtracking work in S8+.",
+    "nextAction": "S9 — Begin Path-B verified-backtracking infrastructure for the finitary form per knowledge.md §4 (~500-1500 lines across multiple sessions). Concrete sub-targets: (i) `engelsmaSearch (w k : ℕ) : Bool` — Engelsma's pruned backtracking over admissible k-tuples in `Finset.range w`, written as a `def` returning whether any admissible witness exists; (ii) `engelsmaSearch_correct` — equivalence between the search returning `false` and the absence of admissible witnesses (knowledge.md §4.3 Option 3 hybrid pattern); (iii) `engelsmaSearch_50_246_returns_false` via `native_decide` once (i)+(ii) compile. Alternative S9: still tackle S7 — Mid-size Engelsma analogue at (10, 30) — risk is 30-120 s `native_decide` runtime; lower mathematical priority than Path B but provides another empirical scaling datapoint. Choice between S7 and S9 (Path B) depends on which CI-runtime appetite is higher.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,14 +40,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S6: non-vacuous Engelsma analogues at the boundary w=H(k)+1 for k=3..6 — closes the gap left by the vacuous S4/S5 cases. Four native_decide theorems over ~1.4 × 10⁴ subsets total, each tight (witnessed by classical admissible k-tuples). leanFile.axiomCount stays at 1 (Lean.ofReduceBool reused). 11 theorems, 357 lines.",
+    "progressSummary": "S8: `engelsma_lower_bound_of_finitary` bridge lemma per knowledge.md §2.4 — pure-Lean combinatorics that reduces the unbounded `engelsma_lower_bound` axiom to its finitary `∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H` form. Three sub-pieces: (a) translation invariance `isAdmissible_image_sub_iff` (backed by per-prime modular bijection `card_image_image_sub_mod_eq` + helpers); (b) 50-subset extraction `exists_subset_card_50_containing_zero`; (c) wiring in the headline theorem. theoremCount 11 → 20 (9 new declarations). axiomCount stays at 1 (Lean.ofReduceBool reused; no new axioms). 0 sorries; 617 lines. S6's non-vacuous boundary witnesses + S2 Decidable instance + S8 bridge form the complete reduction toolkit.",
     "builtItems": [
       "research/problems/bounded-prime-gaps-oq-03-oq-02/problem.md — formal statement, classification, approach menu, related-proof table.",
       "research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md — full S1 survey: §1 target, §2 reduction to finitary form (with bridge-lemma proof sketch), §3 decidability and direct-enumeration cost, §4 Engelsma's algorithm and Path-B representation choice, §5 sieve-based fallback Path C (eliminated), §6 risk register, §7 Mathlib API survey, §8 sibling lessons, §9 next-action menu.",
       "research/problems/bounded-prime-gaps-oq-03-oq-02/state.md — S1–S6 session log with S7 (10,30) deferred and rationale.",
       "theorem engelsma_analogue_6_16 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 8008 subsets, S4, vacuous)",
       "theorem engelsma_analogue_8_22 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 319,770 subsets, S5 intermediate scaling checkpoint, vacuous)",
-      "theorems engelsma_analogue_nonvacuous_3_7 / _4_9 / _5_13 / _6_17 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 35 / 126 / 1287 / 12376 subsets, S6 boundary non-vacuous cases, tight bounds witnessed by {0,2,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12,16})"
+      "theorems engelsma_analogue_nonvacuous_3_7 / _4_9 / _5_13 / _6_17 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 35 / 126 / 1287 / 12376 subsets, S6 boundary non-vacuous cases, tight bounds witnessed by {0,2,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12,16})",
+      "theorem isAdmissible_image_sub_iff in BoundedPrimeGapsOQ03OQ02.lean — IsAdmissible is invariant under translation `(· - m)` when `m ≤ ∀ a ∈ H`. Proven via per-prime residue-image cardinality preservation (S8, sub-piece a).",
+      "theorem engelsma_lower_bound_of_finitary in BoundedPrimeGapsOQ03OQ02.lean — the §2.4 bridge: the finitary form `∀ H ∈ powersetCard 50 (Finset.range 246), 0 ∈ H → ¬ IsAdmissible H` implies the unbounded `engelsma_lower_bound` axiom statement. Pure-Lean combinatorics, no `native_decide` (S8, sub-piece c)."
     ],
     "insights": [
       "Translation invariance reduces the unbounded `∀ H : Finset ℕ` axiom to a finitary `∀ H ∈ Finset.range 246` quantification — this is the *only* way certified computation is even relevant.",
@@ -57,7 +59,8 @@
       "The hard work is concentrated in S8+ (verified backtracking, ~500-1500 lines). S2 (Decidable instance), the §2.4 bridge, and the S4/S5/S6 native_decide analogues are well-scoped and independent of the feasibility question.",
       "S4 (researcher-10, 2026-05-12, build pending): native_decide Engelsma analogue at (k,w)=(6,16) over 8008 subsets — first axiom contribution (Lean.ofReduceBool). Vacuous (H(6)=16 > 15).",
       "S5 (researcher-11, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — 40× S4 scaling checkpoint, vacuous antecedent (no admissible 8-tuple fits in range 22 since Engelsma's H(8)=26). Reuses Lean.ofReduceBool; no axiomCount bump.",
-      "S6 (researcher-5, 2026-05-12, build pending): four non-vacuous Engelsma analogues at boundary (k, H(k)+1) for k=3..6 — closes the vacuous-bound gap by enumerating tight cases where admissible witnesses DO exist. Cumulative ~1.4 × 10⁴ subsets across the four. Reuses Lean.ofReduceBool; theoremCount 7 → 11. Doubles as a unit-test harness for future Path-B backtracking work."
+      "S6 (researcher-5, 2026-05-12, build pending): four non-vacuous Engelsma analogues at boundary (k, H(k)+1) for k=3..6 — closes the vacuous-bound gap by enumerating tight cases where admissible witnesses DO exist. Cumulative ~1.4 × 10⁴ subsets across the four. Reuses Lean.ofReduceBool; theoremCount 7 → 11. Doubles as a unit-test harness for future Path-B backtracking work.",
+      "S8 (researcher-3, 2026-05-12, build pending): `engelsma_lower_bound_of_finitary` bridge lemma — pure-Lean combinatorics, no native_decide, no new axioms. 9 new declarations: 6 lemmas/helpers (translation invariance toolkit: `card_image_sub_eq`, `image_sub_nonempty`, `image_sub_max'_eq`, `image_sub_min'_eq_zero`, plus the per-prime modular bijection `card_image_image_sub_mod_eq` and its `sub_mod_eq_mod_add_sub_mod` core identity); the headline `isAdmissible_image_sub_iff` and `engelsma_lower_bound_of_finitary` theorems; the 50-subset extraction helper `exists_subset_card_50_containing_zero`. theoremCount 11 → 20; axiomCount stays at 1. Reduces the unbounded `engelsma_lower_bound` axiom to its finitary form — future Path-B (S9+) work needs only to discharge the latter."
     ],
     "mathlibGaps": [
       "Decidable (IsAdmissible H) — not in Mathlib (admissible-tuple theory is absent from Mathlib entirely).",
@@ -65,10 +68,9 @@
       "A verified-backtracking combinator library — not in Mathlib; Path B will build a bespoke one in the gallery and (potentially) upstream after stabilization."
     ],
     "nextSteps": [
-      "S7 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime; vacuous antecedent (H(10) ≥ 32 > 29). The S5 (8, 22) CI runtime is the canonical extrapolation datapoint.",
-      "S8 — engelsma_lower_bound_of_finitary bridge lemma per knowledge.md §2.4 (~50-100 lines, pure-Lean combinatorics, independent of native_decide runtime). Sub-pieces: (a) translation invariance for `H.image (· - m)`, (b) 50-subset extraction containing 0, (c) wiring the contradiction. Parallelizable with S7.",
-      "S9+ — full Engelsma-style verified backtracking for (50, 246); native_decide the search-returns-empty equation; complete the axiom replacement. S6's non-vacuous boundary witnesses serve as the unit-test cases the backtracker must match.",
-      "Fallback (if S7 native_decide becomes too slow): land S2 + S3 + S4 + S5 + S6 + S8 as standalone gallery improvements, narrow the axiom statement to the irreducible content, defer the full replacement."
+      "S9+ — Path-B verified-backtracking infrastructure for the finitary form per knowledge.md §4. Concretely: (i) `engelsmaSearch (w k : ℕ) : Bool` — Engelsma's pruned backtracking written as a `def` returning whether any admissible witness fits; (ii) `engelsmaSearch_correct` — equivalence with the absence of admissible witnesses (Option 3 hybrid pattern in §4.3); (iii) `engelsmaSearch 246 50 = false` via `native_decide` once (i)+(ii) compile. With S8 in place, (iii) discharges the original `engelsma_lower_bound` axiom directly through `engelsma_lower_bound_of_finitary`.",
+      "Alternative deferred S7 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime; vacuous antecedent (H(10) ≥ 32 > 29). Lower mathematical priority than S9 Path-B work; useful only as another empirical scaling datapoint.",
+      "Fallback (if S9 Path-B becomes too slow to extrapolate to (50, 246) `native_decide` budget): land S2 + S3 + S4 + S5 + S6 + S8 as standalone gallery improvements; the bridge lemma already cleanly narrows the axiom statement to its irreducible finitary content."
     ]
   },
   "tags": [
@@ -118,7 +120,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-05-12T08:30:00Z",
+  "lastUpdate": "2026-05-12T11:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -169,8 +171,8 @@
     {
       "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
       "filename": "BoundedPrimeGapsOQ03OQ02.lean",
-      "lineCount": 357,
-      "theoremCount": 11,
+      "lineCount": 617,
+      "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S8 ACT iteration on `bounded-prime-gaps-oq-03-oq-02`: discharges
[knowledge.md §2.4](../blob/main/research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md)
by reducing the unbounded `engelsma_lower_bound` axiom in
`BoundedPrimeGapsOQ03.lean` (line 134) to its finitary form

```lean
∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H
```

via the headline lemma:

```lean
theorem engelsma_lower_bound_of_finitary
    (hfin : ∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H →
      ¬ IsAdmissible H) :
    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne
```

A future Path-B (S9+) verified-backtracking proof of `hfin`
discharges the original axiom *directly* through this bridge.

## Three sub-pieces

### (a) Translation invariance

`isAdmissible_image_sub_iff`: when `m ≤ a` for every `a ∈ H`,
`IsAdmissible (H.image (· - m)) ↔ IsAdmissible H`. Backed by
`card_image_image_sub_mod_eq` — per-prime residue-image cardinality
preservation via the bijection `r ↦ (r + m) % p`. The foundational
modular identity

```
(a - m) % p = ((a % p) + (p - m % p)) % p   (when m ≤ a, 0 < p)
```

is established as `sub_mod_eq_mod_add_sub_mod` via a `Nat.ModEq`
chain: add `m % p` to both sides; both reduce to `a` modulo `p`;
cancel.

Supporting helpers: `card_image_sub_eq` (cardinality preserved),
`image_sub_nonempty`, `image_sub_max'_eq` (max' = `H.max' - m`),
`image_sub_min'_eq_zero` (min' of the `(· - H.min')` translate is 0).

### (b) 50-subset extraction

`exists_subset_card_50_containing_zero`: given `H'` with
`H'.card ≥ 50` and `0 ∈ H'`, produces `H₀ ⊆ H'` with `H₀.card = 50`
and `0 ∈ H₀`. Construction: 49-subset of `H'.erase 0`, re-insert `0`.

### (c) Wiring

The headline `engelsma_lower_bound_of_finitary` runs the §2.4
contradiction proof: by_contra, set `m := H.min'`, translate to
`H' := H.image (· - m)`, observe `0 ∈ H'`, `H'.max' < 246`,
`H'.card ≥ 50`, `IsAdmissible H'` (by (a)). Apply (b) to extract
`H₀ ⊆ H'` with `0 ∈ H₀`, `H₀.card = 50`, then
`BoundedPrimeGaps.admissible_subset` gives `IsAdmissible H₀`. Each
element of `H₀` is `≤ H'.max' < 246`, so
`H₀ ∈ (Finset.range 246).powersetCard 50`. Apply `hfin` to derive
`¬ IsAdmissible H₀` — contradiction.

## Why S8 instead of S7?

`state.md`'s prior `Next Action` was S7 = `(10, 30)` `native_decide`
(deferred via S6). S7 still carries the documented 30-120 s runtime
risk; the prior state.md explicitly notes S8 is "tackleable in
parallel with S7 since the bridge proof is pure-Lean combinatorics
independent of `native_decide` runtime." S8 has higher mathematical
value (it's the actual *bridge* to closing the axiom), no
`native_decide` cost, no new axioms.

## File metrics

- `BoundedPrimeGapsOQ03OQ02.lean`: 357 → 617 lines (+260)
- theoremCount: 11 → 20 (+9 new declarations: 6 lemmas/helpers,
  2 theorems, 1 private extraction helper)
- axiomCount: 1 (unchanged — `Lean.ofReduceBool` from S4 reused;
  no `native_decide` added in S8)
- sorryCount: 0
- Pure-Lean combinatorics throughout

## Next-action menu (post-S8)

- **S9 (recommended)** — Begin Path-B verified-backtracking
  infrastructure (`engelsmaSearch` def + correctness lemma).
  Combined with S8, the path from `engelsmaSearch 246 50 = false`
  to discharging `engelsma_lower_bound` is now mechanical.
- **Alternative deferred S7** — `(10, 30)` `native_decide` analogue.
  Lower priority than S9; useful only as another empirical scaling
  datapoint.
- **Path-C-prime fallback** — if S9 Path-B is infeasible at
  `(50, 246)`, S8 already cleanly narrows the axiom statement to its
  irreducible finitary content.

## Test plan

- [x] All proofs are pure-Lean combinatorics (no `native_decide`)
- [x] Used standard Mathlib API: `Finset.image_*`, `Nat.ModEq.*`,
      `Nat.div_add_mod`, `Nat.sub_add_cancel`, `Finset.exists_subset_card_eq`
- [x] Updated `lineCount`, `theoremCount` in problem JSON; updated
      `state.md` session log with S8 entry; advanced `currentState.iteration`
      to 8 and `nextAction` to S9 Path-B.
- [ ] Build verification deferred per `proofs/.lake` symlink trap
      (memory: `feedback_researcher_lake_symlink_broken`); follows the
      build-pending precedent of S2 / S4 / S5 / S6 PRs (#17790, #17847,
      #17944, #18027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)