### PR TITLE
fix(meta): picks-theorem-oq-01-oq-01-oq-01 + shannon-channel-coding count drift

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 16,
-    "definitionCount": 9,
-    "lineCount": 278,
+    "theoremCount": 24,
+    "definitionCount": 21,
+    "lineCount": 426,
     "tags": [
       "number-theory",
       "geometry",
@@ -135,11 +135,11 @@
   ],
   "leanFile": {
     "path": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "lineCount": 278,
+    "lineCount": 426,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 16,
-    "definitionCount": 9,
+    "theoremCount": 24,
+    "definitionCount": 21,
     "imports": [
       "import Mathlib.Data.Int.GCD",
       "import Mathlib.Data.Nat.GCD.Basic",

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -42,7 +42,7 @@
     "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 13 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01, single-letter Fano-form converse fano_converse_step + fano_converse_capacity). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 394,
+    "lineCount": 442,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",
@@ -51,7 +51,7 @@
       "Fano's inequality and the channel coding converse"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 8
   },
   "overview": {
@@ -172,9 +172,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 394,
+    "lineCount": 442,
     "axiomCount": 3,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 8,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync mirrored `meta.{lineCount,theoremCount,definitionCount}` and `leanFile.{lineCount,theoremCount,definitionCount}` to match actual Lean sources after recent research merges.

## Evidence

| Slug | lineCount | theoremCount | definitionCount |
|------|-----------|--------------|-----------------|
| `picks-theorem-oq-01-oq-01-oq-01` | 278 → 426 | 16 → 24 | 9 → 21 |
| `shannon-channel-coding` | 394 → 442 | 13 → 14 | 8 (unchanged) |

### Driving merges

- **`picks-theorem-oq-01-oq-01-oq-01`**: PR #18069 (squash of `S1 OBSERVE` + `S2 OBSERVE` realInteriorCount via Finset). The meta.json was set to the S1 body counts; the S2 commit (squashed into the same merge) added 12 new definitions (`StrictInterior` + decidability instance for it, `xmin`/`xmax`/`ymin`/`ymax`, `boundingBox`, `realInterior`, `realInteriorCount`) and 8 base-case agreement theorems (`*_realInteriorCount`, `*_pick_agrees` × 3) before the squash-merge.
- **`shannon-channel-coding`**: PR #18078 (S7 `fano_converse_shannon_form`, "build pending"). Added one theorem (+48 lines) on top of the existing 13-theorem / 8-def baseline.

### Counting convention

Same as PR #18079 / PR #18087:

```
theorems: ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(theorem|lemma)\s+
defs:     ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(def|abbrev|opaque|structure|inductive|class)\s+
lines:    `wc -l`  (newline-terminated lines)
```

after stripping nested `/- -/` block comments and `--` line comments. `instance` is excluded from definitionCount (matching PR #18079).

`axiomCount` (0 picks / 3 shannon) and `sorries` (0 both) are unchanged.

### Disjoint from

- **PR #18079** (open): angle-trisection / pascals-hexagon / minpoly-charpoly-oq-03 / basel / mean-value
- **PR #18087** (open): binomial-theorem-oq-02-oq-01-oq-01

### Validation

- Both `meta.json` files revalidate as JSON.
- Per-file re-count after edits: every entry is **CLEAN** in `sorries` / `theoremCount` / `definitionCount` / `lineCount`.

Closes the residual drift surfaced by an `awk wc -l + grep` sweep across `src/data/proofs/*/meta.json` (top remaining drifts after #18079 / #18087).

---
Automated fix by lean-mechanic agent.