### PR TITLE
research(roth-theorem-oq-02): S2 ACT-A — Bloom–Sisask axiom-form companion file (build verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2637,6 +2637,7 @@ import Proofs.RiemannHypothesis
 import Proofs.RiemannHypothesisConsequences
 import Proofs.RothTheorem
 import Proofs.RothTheoremAristotle
+import Proofs.RothTheoremOQ02
 import Proofs.RothTheoremOQ03
 import Proofs.RothTheoremQuantitative
 import Proofs.RothTheoremQuantitativeAristotle

--- a/proofs/Proofs/RothTheoremOQ02.lean
+++ b/proofs/Proofs/RothTheoremOQ02.lean
@@ -1,0 +1,118 @@
+import Mathlib.Combinatorics.Additive.Corner.Roth
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Roth's Theorem — Bloom–Sisask Logarithmic Bound (OQ-02, S2 ACT-A)
+
+## What This Provides
+
+A typed Lean target for the Bloom–Sisask 2020 quantitative refinement of
+Roth's theorem on three-term arithmetic progressions:
+
+  ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N / (log N)^(1+c)
+
+The bound is named `rothNumberNat_bloom_sisask` and asserted as a Lean
+`axiom`. Supporting names — `blasiConst` (a choice of constant `c`),
+`blasiConst_pos` (its positivity), and `rothNumberNat_le_blasi` (the
+bound at the chosen constant) — give downstream consumers a stable API
+without having to call `Exists.choose` manually.
+
+The file is *intentionally minimal*: it provides the typed landmark and
+the trivial consequence that the axiom is consistent with Mathlib's
+existing qualitative result `rothNumberNat_isLittleO_id`. The Lean
+formalization of Bloom–Sisask itself (≥ several thousand lines through
+Bohr sets, density increment, and Fourier analysis) is deferred.
+
+## Scope (S2 ACT-A, researcher-12, 2026-05-12)
+
+- File status: **axiomatized** (1 axiom, 0 sorries).
+- Imports: `Mathlib.Combinatorics.Additive.Corner.Roth` (for
+  `rothNumberNat` and `rothNumberNat_isLittleO_id`) and
+  `Mathlib.Analysis.SpecialFunctions.Log.Basic` (for `Real.log`).
+- The axiom matches the wording in the docstring of
+  `Mathlib.Combinatorics.Additive.AP.Three.Defs`, which explicitly names
+  Bloom–Sisask as the expected upper bound on `rothNumberNat`.
+
+## Why This Companion File (Path vs Editing the Gallery `bloom_sisask_bound`)
+
+The existing gallery file `proofs/Proofs/RothTheoremQuantitative.lean`
+already states a closely-related bound (`bloom_sisask_bound`) with `sorry`
+and uses a project-local `rothNumber` from
+`namespace Szemeredi.Roth.Quantitative`. This OQ-02 companion file
+deliberately works at the **Mathlib `rothNumberNat`** level, leaving the
+gallery file untouched. Downstream Mathlib-style consumers can refer to
+`RothTheoremOQ02.rothNumberNat_bloom_sisask` directly; gallery consumers
+continue to refer to `Szemeredi.Roth.Quantitative.bloom_sisask_bound`.
+Future work can unify the two presentations once Mathlib gains the
+prerequisite Bohr-set / density-increment / Fourier infrastructure.
+
+## References
+
+- Bloom, T. F., Sisask, O. (2020). *Breaking the logarithmic barrier in
+  Roth's theorem on arithmetic progressions.* arXiv:2007.03528.
+- Mathlib v4.26.0 module docstring of
+  `Mathlib.Combinatorics.Additive.AP.Three.Defs`.
+- Parent quantitative Roth file:
+  `proofs/Proofs/RothTheoremQuantitative.lean`.
+-/
+
+namespace RothTheoremOQ02
+
+open Asymptotics Filter Topology
+
+/-- **Bloom–Sisask 2020 logarithmic-barrier-breaking bound on the Roth
+number.** Axiomatic statement:
+
+  ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N / (log N)^(1+c)
+
+Proved analytically in Bloom–Sisask, arXiv:2007.03528 (2020), via
+density increment on Bohr sets with refined Fourier analysis; the full
+proof requires Bohr-set infrastructure not yet in Mathlib at v4.26.0
+(pin `2df2f0150c275ad`). Asserted here axiomatically so downstream
+gallery files can refer to the bound by name.
+
+The lower bound `N ≥ 3` matches the convention in the gallery file
+`Szemeredi.Roth.Quantitative.bloom_sisask_bound` and ensures
+`Real.log N > Real.log 3 > 1`, so the right-hand side is positive and
+the bound is non-vacuous. -/
+axiom rothNumberNat_bloom_sisask :
+    ∃ c : ℝ, 0 < c ∧ ∀ N : ℕ, 3 ≤ N →
+      (rothNumberNat N : ℝ) ≤ (N : ℝ) / Real.log N ^ (1 + c)
+
+/-- A canonical choice of the Bloom–Sisask constant `c > 0` extracted from
+the axiom via `Exists.choose`. Marked `noncomputable` because
+`Exists.choose` is. -/
+noncomputable def blasiConst : ℝ :=
+  rothNumberNat_bloom_sisask.choose
+
+/-- The Bloom–Sisask constant is positive. -/
+theorem blasiConst_pos : 0 < blasiConst :=
+  rothNumberNat_bloom_sisask.choose_spec.1
+
+/-- **Bloom–Sisask bound at the canonical constant.** For every `N ≥ 3`,
+`rothNumberNat N ≤ N / (log N)^(1 + blasiConst)`. Stable downstream API
+that hides the `Exists.choose`. -/
+theorem rothNumberNat_le_blasi (N : ℕ) (hN : 3 ≤ N) :
+    (rothNumberNat N : ℝ) ≤ (N : ℝ) / Real.log N ^ (1 + blasiConst) :=
+  rothNumberNat_bloom_sisask.choose_spec.2 N hN
+
+/-- **Consistency with Mathlib's qualitative result.** Mathlib v4.26.0
+records `rothNumberNat_isLittleO_id : (rothNumberNat N : ℝ) =o[atTop] (N : ℝ)`
+unconditionally in `Mathlib.Combinatorics.Additive.Corner.Roth`. The
+Bloom–Sisask axiom strengthens this with an *explicit* decay rate
+`O(N / (log N)^(1+c))`, and is consistent with the qualitative form
+in the sense that both assert `rothNumberNat N = o(N)`. We record the
+qualitative form as a one-line export so OQ-02 consumers can pull it
+in via this namespace without re-deriving it from the axiom. -/
+theorem bloom_sisask_consistent_with_isLittleO :
+    IsLittleO atTop (fun N : ℕ => (rothNumberNat N : ℝ))
+      (fun N : ℕ => (N : ℝ)) :=
+  rothNumberNat_isLittleO_id
+
+#check rothNumberNat_bloom_sisask
+#check blasiConst
+#check blasiConst_pos
+#check rothNumberNat_le_blasi
+#check bloom_sisask_consistent_with_isLittleO
+
+end RothTheoremOQ02

--- a/research/problems/roth-theorem-oq-02/state.md
+++ b/research/problems/roth-theorem-oq-02/state.md
@@ -1,12 +1,40 @@
 # Current State — roth-theorem-oq-02
 
-**Phase**: OBSERVE
-**Since**: 2026-05-12T09:30:00.000Z
-**Iteration**: 1
-**Researcher**: researcher-11
-**Mode**: FRESH (S1 OBSERVE, no Lean changes)
+**Phase**: ACT (S2 ACT-A — companion-file axiom-form)
+**Since**: 2026-05-12T11:55:00.000Z (S2 ACT-A, researcher-12)
+**Iteration**: 2
+**Researcher**: researcher-12 (S2); researcher-11 (S1)
+**Mode**: ACT (S2 ACT-A companion file)
 
-## Current Focus
+## Current Focus (S2 ACT-A)
+
+Session 2 (S2 ACT-A, researcher-12, 2026-05-12) follows S1's
+recommended path **S2-A** verbatim: create the companion file
+`proofs/Proofs/RothTheoremOQ02.lean` with a single `axiom` capturing
+the Bloom–Sisask 2020 bound on `rothNumberNat`, plus stable downstream
+API names (`blasiConst`, `blasiConst_pos`, `rothNumberNat_le_blasi`)
+and a one-line consistency-with-Mathlib export
+(`bloom_sisask_consistent_with_isLittleO`, equal to
+`rothNumberNat_isLittleO_id` from `Mathlib.Combinatorics.Additive.Corner.Roth`).
+
+The file is ~95 lines (docstring + 5 declarations). The axiom statement
+matches the conventions used in the parent gallery file
+`Proofs/RothTheoremQuantitative.lean` (`bloom_sisask_bound`) modulo the
+project-local `rothNumber` vs Mathlib's `rothNumberNat` — see the
+companion-file docstring §"Why This Companion File (Path vs Editing the
+Gallery)" for the design rationale.
+
+Deliverables:
+* `proofs/Proofs/RothTheoremOQ02.lean` — new file, 1 axiom, 4 supporting
+  theorems / defs, 0 sorries.
+* `proofs/Proofs.lean` — alphabetical insertion of
+  `import Proofs.RothTheoremOQ02` between `RothTheoremAristotle` and
+  `RothTheoremOQ03`.
+* `src/data/research/problems/roth-theorem-oq-02.json` — iteration 1 → 2,
+  status reflects axiomatized companion file.
+* `research/problems/roth-theorem-oq-02/state.md` — this update.
+
+## Prior Focus (S1 OBSERVE)
 
 Establish a clean, fact-checked OBSERVE-phase scaffold for the
 **Bloom–Sisask bound** `r₃(N) = O(N / (log N)^{1+c})` (arXiv:2007.03528,
@@ -93,11 +121,40 @@ Recommended: **start with S2-A**. It is shippable in one session, matches
 the Mathlib docstring goal verbatim, and unblocks the next-iteration
 plug-in (B → A → core).
 
+## Next Action (S3)
+
+S2 ACT-A shipped the typed axiom-form landmark. The remaining work is
+ranked (smallest first):
+
+- **S3-B (consistency check, suggested)** — Add a `bloom_sisask_consistent_with_Behrend`
+  theorem stating the axiomatic upper bound is consistent with Behrend's
+  lower bound on `rothNumberNat` (i.e. for sufficiently large N, the upper
+  and lower bounds do not cross). ~60 lines, requires Behrend infrastructure
+  in Mathlib (`Behrend.box / sphere / map` exist, but no explicit
+  `rothNumberNat ≥ N · exp(-c · √log N)` theorem is yet packaged in
+  Mathlib; would require either an axiom on Behrend or a partial
+  derivation from `Behrend.map` injectivity).
+- **S3-C (Bohr-set scaffold)** — Define `BohrSet T ρ` over `ZMod N` and
+  prove basic structure (0 ∈ B, symmetry, B(T, 1) = univ). About +200
+  lines. Higher risk; first step of the multi-quarter infrastructure
+  build toward a non-axiomatic Bloom–Sisask.
+- **S3-A (qualitative consequence, redundant)** — Derive
+  `Tendsto (rothNumberNat N / N) atTop (𝓝 0)` from the S2 axiom.
+  Redundant with Mathlib's existing `rothNumberNat_isLittleO_id` (which
+  S2's `bloom_sisask_consistent_with_isLittleO` already exposes); not
+  recommended.
+
+Recommended: **S3-B**. The Behrend lower bound is already implicit in
+Mathlib (`Mathlib.Combinatorics.Additive.AP.Three.Behrend`); making the
+non-crossing check explicit is a useful sanity test and motivates the
+gap-closing program (Kelley–Meka 2023's `N exp(-c (log N)^{1/12})`
+brings the upper bound much closer to Behrend's `N exp(-c sqrt(log N))`).
+
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2 (S1 OBSERVE markdown survey, S2 ACT-A companion file)
+- Current approach attempts: 1 (companion file with axiom)
+- Approaches tried: 1 (axiomatized companion file)
 
 ## Notes for Future Sessions
 

--- a/src/data/research/problems/roth-theorem-oq-02.json
+++ b/src/data/research/problems/roth-theorem-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "roth-theorem-oq-02",
   "title": "Formalize the Bloom-Sisask bound r_3(N) = O(N / (log N)^{1+c})",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "in-progress",
   "tier": "B",
   "path": "full",
@@ -32,21 +32,21 @@
     "goal": "Provide a Lean statement of the Bloom-Sisask bound matching the Mathlib `rothNumberNat` docstring goal, and establish a roadmap for the Bohr-set / quantitative Bogolyubov / density-increment infrastructure required for a full proof."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T09:30:00.000Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE scaffold: literature survey, Mathlib API snapshot, ranked infrastructure gap list, three S2 candidates.",
+    "phase": "ACT",
+    "since": "2026-05-12T11:55:00.000Z",
+    "iteration": 2,
+    "focus": "S2 ACT-A (researcher-12, 2026-05-12): Shipped the recommended S2-A companion file `proofs/Proofs/RothTheoremOQ02.lean` (1 axiom, 4 supporting declarations, 0 sorries, ~95 lines). The file declares `axiom rothNumberNat_bloom_sisask` matching the Mathlib `Mathlib.Combinatorics.Additive.AP.Three.Defs` docstring goal verbatim, provides stable downstream API (`blasiConst`, `blasiConst_pos`, `rothNumberNat_le_blasi`), and exposes the existing Mathlib qualitative form via `bloom_sisask_consistent_with_isLittleO := rothNumberNat_isLittleO_id`. The companion file operates at the Mathlib `rothNumberNat` level (not the project-local `Szemeredi.Roth.Quantitative.rothNumber` used by the gallery's `bloom_sisask_bound` sorry); the two are deliberately kept separate per the file's docstring §'Why This Companion File'. Imports: `Mathlib.Combinatorics.Additive.Corner.Roth` (for `rothNumberNat` and `rothNumberNat_isLittleO_id`) + `Mathlib.Analysis.SpecialFunctions.Log.Basic` (for `Real.log`). S1 OBSERVE (researcher-11, 2026-05-12, PR #18031 + #18033 complementary): literature survey, Mathlib API snapshot, ranked infrastructure gap list, three S2 candidates (markdown-only, no Lean).",
     "blockers": [
       "No Mathlib Bohr-set library (BohrSet T rho not defined).",
       "No quantitative Bogolyubov on Bohr sets in Mathlib.",
       "No density-increment iteration framework in Mathlib.",
       "No AP3-specific Fourier level-set / energy lemmas in Mathlib."
     ],
-    "nextAction": "S2-A (recommended): create `proofs/Proofs/RothTheoremOQ02.lean` with the Bloom-Sisask statement as a single `axiom rothNumberNat_bloom_sisask` matching the Mathlib docstring goal, plus a proven `bloom_sisask_implies_qualitative` consequence. Status `axiomatized`, badge `axiom`, sorries 0, axioms 1.",
+    "nextAction": "S3-B (recommended): bloom_sisask_consistent_with_Behrend — verify the S2 axiom's upper bound and Mathlib's existing Behrend lower bound do not cross for sufficiently large N. ~60 lines. S3-C: open the multi-quarter Bohr-set scaffold (BohrSet T rho over ZMod N + basic structure lemmas, ~200 lines). S3-A: derive Tendsto (rothNumberNat N / N) atTop (𝓝 0) from the axiom (redundant with `bloom_sisask_consistent_with_isLittleO`; not recommended).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {


### PR DESCRIPTION
## Summary

S2 ACT-A for `roth-theorem-oq-02`. Follows S1 OBSERVE's recommended path **S2-A** verbatim: ships a typed Lean landmark for the Bloom–Sisask 2020 bound on the Roth number, as an `axiom` in a new companion file. Provides stable downstream API names without committing to the multi-quarter Bohr-set / Bogolyubov / density-increment infrastructure build needed for a full non-axiomatic proof.

The axiom matches verbatim the goal explicitly named in the Mathlib v4.26.0 module docstring of `Mathlib.Combinatorics.Additive.AP.Three.Defs`.

## What's New

**`proofs/Proofs/RothTheoremOQ02.lean`** (new file, 117 lines including docstring, 1 axiom, 4 supporting declarations, 0 sorries):

- `axiom rothNumberNat_bloom_sisask : ∃ c > 0, ∀ N ≥ 3, (rothNumberNat N : ℝ) ≤ N / Real.log N ^ (1 + c)` — the Bloom–Sisask 2020 logarithmic-barrier-breaking upper bound (arXiv:2007.03528).
- `noncomputable def blasiConst : ℝ` — canonical choice of constant via `Exists.choose`.
- `theorem blasiConst_pos : 0 < blasiConst`.
- `theorem rothNumberNat_le_blasi (N : ℕ) (hN : 3 ≤ N) : (rothNumberNat N : ℝ) ≤ N / Real.log N ^ (1 + blasiConst)` — stable downstream API hiding the `Exists.choose`.
- `theorem bloom_sisask_consistent_with_isLittleO` — re-exports Mathlib's existing `rothNumberNat_isLittleO_id`.

**`proofs/Proofs.lean`**: alphabetical insertion of `import Proofs.RothTheoremOQ02`.

## Design rationale

The existing gallery file `proofs/Proofs/RothTheoremQuantitative.lean` already states a closely-related `bloom_sisask_bound` with `sorry`, but uses a project-local `rothNumber` from `namespace Szemeredi.Roth.Quantitative`. This OQ-02 companion file deliberately works at the **Mathlib `rothNumberNat`** level, leaving the gallery file untouched. The two presentations can be unified in a future iteration once Mathlib gains the prerequisite Bohr-set / density-increment / Fourier infrastructure. See the file's docstring §"Why This Companion File" for the full rationale.

## Build status (verified)

`./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ02` completed successfully (1997 jobs). All 5 `#check` outputs match the stated signatures.

## Deltas

- 1 new file (`proofs/Proofs/RothTheoremOQ02.lean`, 117 lines).
- 1 line added to `proofs/Proofs.lean` (the import).
- 0 new sorries (was 0), 1 new axiom (was 0; now 1).
- 2 new imports: `Mathlib.Combinatorics.Additive.Corner.Roth` and `Mathlib.Analysis.SpecialFunctions.Log.Basic`.

## Test plan

- [x] Source builds via `docker-build.sh Proofs.RothTheoremOQ02` (1997 jobs OK).
- [x] All 5 `#check` outputs match stated signatures.
- [x] 1 new axiom declared (`rothNumberNat_bloom_sisask`); 0 sorries; 0 hidden assumptions.
- [x] Pre-push check: 0 open PRs for `roth-theorem-oq-02`; rebased onto current `origin/main` (`41d3084340e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)