### PR TITLE
research(binary-gcd-oq-02-oq-02): S2 gallery — verified Lehmer GCD on ℤ entry

### DIFF
--- a/src/data/proofs/binary-gcd-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-02/annotations.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "ann-lehmer-int-header",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Module Header and Imports",
+    "content": "The module docstring frames the file as the integer half of the OQ-02-OQ-02 question: extend D. H. Lehmer's 1938 GCD algorithm from `ℕ` to `ℤ`. Two design choices are spelled out:\n\n- The natAbs reduction inherits ℕ-level correctness with no new mathematical content — it's the same trick `Int.gcd` itself uses.\n- The leading-digit quotient-estimate accelerator (the substantive content of Lehmer's paper) is *orthogonal* and lives in `BinaryGcdOQ03OQ02*`. This file is about the ℤ extension, not the speedup.\n\nThe imports bring in Mathlib's integer-GCD theory, the standard tactic library, and crucially `Proofs.BinaryGcdOQ03OQ01`, which carries the ℕ-level Lehmer correctness theorem `lehmerGcd_correct`.",
+    "mathContext": "Every production multi-precision arithmetic library (GMP, OpenSSL, JDK BigInteger) runs Lehmer-style descent on the absolute values of integer inputs. This file is the verified Lean analogue of `BigInteger.gcd`: take `natAbs`, delegate to the ℕ-level Lehmer routine, return the unsigned result.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lehmer GCD",
+      "natAbs reduction",
+      "Int.gcd",
+      "modular proof design"
+    ],
+    "prerequisites": [
+      "Lean 4 imports",
+      "Mathlib.Data.Int.GCD",
+      "Proofs.BinaryGcdOQ03OQ01.lehmerGcd_correct"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-definition",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "definition",
+    "title": "lehmerGcdInt: The Core Definition",
+    "content": "The one-line definition `lehmerGcdInt a b := lehmerGcd a.natAbs b.natAbs` is the entire mathematical content of the integer extension. The return type is `ℕ` — not `ℤ` — because the GCD is always non-negative and Mathlib follows the same convention (`Int.gcd : ℤ → ℤ → ℕ`).\n\nKey observation: this definition is *definitionally aligned* with Mathlib's `Int.gcd m n := m.natAbs.gcd n.natAbs`. The two differ only in which ℕ-level GCD they delegate to (`lehmerGcd` vs `Nat.gcd`), and those are already proved equal. As a result, all of `Int.gcd`'s API will transport across with a single rewrite.",
+    "mathContext": "For $a, b \\in \\mathbb{Z}$, the function is $\\text{lehmerGcdInt}(a, b) := \\text{lehmerGcd}(|a|, |b|) \\in \\mathbb{N}$. Since $\\gcd(a,b) = \\gcd(|a|,|b|)$ for all $a, b \\in \\mathbb{Z}$, this definition is mathematically correct by construction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.natAbs",
+      "LehmerGcdOQ01.lehmerGcd",
+      "Int.gcd"
+    ],
+    "prerequisites": [
+      "Int.natAbs definition",
+      "lehmerGcd on ℕ"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-natabs-reduction",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "natAbs Reduction Bridge",
+    "content": "Two lemmas establish the reduction bridge to the ℕ-level algorithm:\n\n- `lehmerGcdInt_natAbs` is `@[simp]` tagged and proved by `rfl` — `simp` will rewrite the integer call back to the natural-number call in either direction. This is the API hook that makes the entire downstream theorem family one-liners.\n- `lehmerGcdInt_natCast` handles the common case where integer inputs come from casting natural numbers: `(↑a : ℤ).natAbs = a`, so `simp` closes the equality immediately.\n\n**API design insight**: marking `lehmerGcdInt_natAbs` as `@[simp]` means all subsequent proofs can forget about the definition and work purely through `simp`. This is the same pattern `BinaryGcdOQ02` uses for binary GCD on ℤ.",
+    "mathContext": "The reduction relies on the identity $(\\uparrow n : \\mathbb{Z}).\\text{natAbs} = n$ for $n : \\mathbb{N}$ (`Int.natAbs_natCast`). Combined with the `rfl`-grade reduction, this means `lehmerGcdInt (↑a) (↑b) = lehmerGcd a b` follows by `simp` alone.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "@[simp] attribute",
+      "definitional equality",
+      "Int.natAbs_natCast",
+      "rfl-grade reductions"
+    ],
+    "prerequisites": [
+      "Lean simp lemmas",
+      "Int.natAbs",
+      "Int.natAbs_natCast"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-correctness",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "Correctness: lehmerGcdInt Equals Int.gcd",
+    "content": "The heart of the file. `lehmerGcdInt_eq_intGcd` proves that `lehmerGcdInt` computes the same value as Mathlib's canonical `Int.gcd`. The proof is two lines:\n\n1. `unfold lehmerGcdInt Int.gcd` — both sides reduce to ℕ-level expressions on `a.natAbs` and `b.natAbs`.\n2. `exact lehmerGcd_correct a.natAbs b.natAbs` — apply the already-proved ℕ-level correctness theorem from `BinaryGcdOQ03OQ01`.\n\nThis is the textbook example of modular proof reuse: every line of algorithmic complexity was discharged once at the ℕ level, and the ℤ extension is purely bookkeeping. The same two-line shape works for binary GCD (`BinaryGcdOQ02.binaryGcdInt_eq_intGcd`) and for any future ℕ-level GCD algorithm someone formalizes.",
+    "mathContext": "Mathlib defines $\\text{Int.gcd}(m, n) := \\text{Nat.gcd}(|m|, |n|)$. We need $\\text{lehmerGcdInt}(a, b) = \\text{Int.gcd}(a, b)$, i.e., $\\text{lehmerGcd}(|a|, |b|) = \\text{Nat.gcd}(|a|, |b|)$ — exactly $\\text{lehmerGcd\\_correct}$ applied to $|a|$ and $|b|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "lehmerGcd_correct",
+      "Int.gcd",
+      "proof composition",
+      "modular proof reuse"
+    ],
+    "prerequisites": [
+      "LehmerGcdOQ01.lehmerGcd_correct",
+      "Int.gcd definition"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-sign-invariance",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 87
+    },
+    "type": "concept",
+    "title": "Sign Invariance: @[simp] for Free Normalization",
+    "content": "Three lemmas establish that negating either or both arguments does not change `lehmerGcdInt`. All three are one-liners via `simp` because `(-a).natAbs = a.natAbs` (`Int.natAbs_neg`) is itself `@[simp]`.\n\nThe first two (`neg_left`, `neg_right`) are marked `@[simp]`, so downstream proofs working with `lehmerGcdInt (-a) b` never need to invoke sign-invariance manually — `simp` handles it silently. The third (`neg_neg`) follows from composing the first two and does not need its own simp tag.\n\nThis matches the API conventions of `Int.gcd` and `BinaryGcdOQ02.binaryGcdInt` exactly, ensuring `lehmerGcdInt` is a drop-in replacement.",
+    "mathContext": "The mathematical fact is $\\gcd(-a, b) = \\gcd(a, b)$ for all $a, b \\in \\mathbb{Z}$, which follows from $|-a| = |a|$. In Lean, this is `Int.natAbs_neg`, already in Mathlib's simp set, so each proof reduces to a single `simp` call.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.natAbs_neg",
+      "@[simp] design",
+      "sign invariance of GCD"
+    ],
+    "prerequisites": [
+      "Int.natAbs_neg",
+      "Lean simp set architecture"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-edges",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 112
+    },
+    "type": "concept",
+    "title": "Edge Cases and Algebraic Properties",
+    "content": "Five lemmas establish that `lehmerGcdInt` satisfies the standard GCD identities on ℤ:\n\n- `lehmerGcdInt_zero_left b = b.natAbs` and `_zero_right a = a.natAbs` (identity elements, `@[simp]`)\n- `lehmerGcdInt_comm a b = lehmerGcdInt b a` (commutativity)\n- `lehmerGcdInt_self a = a.natAbs` (idempotence, `@[simp]`)\n- `lehmerGcdInt_nonneg : 0 ≤ lehmerGcdInt a b` (trivially, since the output is `ℕ`)\n\nEach proof follows the same pattern: rewrite via `lehmerGcdInt_eq_intGcd` to reduce to `Int.gcd`, then apply the matching `Int.gcd_*` Mathlib lemma. The bridge theorem from the previous section does all the heavy lifting.",
+    "mathContext": "These are the ℤ-level mirror of the standard ℕ-level GCD lemmas. Each reduces in one rewrite to the corresponding `Int.gcd_*` Mathlib lemma, illustrating how a single definitional bridge inherits an entire theorem family without re-derivation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.gcd_comm",
+      "Int.gcd_self",
+      "Int.gcd_zero_left",
+      "Int.gcd_zero_right"
+    ],
+    "prerequisites": [
+      "Int.gcd Mathlib API",
+      "lehmerGcdInt_eq_intGcd"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-universal-property",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 160
+    },
+    "type": "insight",
+    "title": "Universal Property of lehmerGcdInt (Mathlib-Version-Stable)",
+    "content": "Three lemmas characterize `lehmerGcdInt` as a greatest common divisor in the ℤ-divisibility lattice:\n\n- `lehmerGcdInt_dvd_left : (lehmerGcdInt a b : ℤ) ∣ a`\n- `lehmerGcdInt_dvd_right : (lehmerGcdInt a b : ℤ) ∣ b`\n- `dvd_lehmerGcdInt : c ∣ a → c ∣ b → c ∣ (lehmerGcdInt a b : ℤ)`\n\n**Design choice**: the proofs do *not* go through Mathlib's `Int.gcd_dvd_*` lemmas. Instead they route via:\n1. `lehmerGcd_correct` — reduce to `Nat.gcd` on natAbs.\n2. `Nat.gcd_dvd_left`/`Nat.gcd_dvd_right`/`Nat.dvd_gcd` — apply the ℕ-level universal property.\n3. `Int.natCast_dvd_natCast` — lift ℕ-divisibility to ℤ.\n4. `Int.natAbs_dvd` / `Int.dvd_natAbs` — bridge between `a` and `↑a.natAbs`.\n\nThis routing is **deliberately Mathlib-version-stable**: the typing convention of `Int.gcd_dvd_*` (ℕ-typed divisor vs ℤ-typed divisor) shifted in recent Mathlib versions, but the natAbs route is invariant under that shift. The result: the file compiles cleanly across Mathlib 4.25 and 4.26 without conditional imports.\n\nThe universal property is the *defining* characterization of GCD: it pins down `lehmerGcdInt` as a greatest lower bound in the divisibility lattice on ℤ.",
+    "mathContext": "For any $c \\in \\mathbb{Z}$ with $c \\mid a$ and $c \\mid b$, we conclude $c \\mid \\gcd(a, b)$. The proof factors through natAbs-respecting divisibility: $c \\mid a \\Rightarrow |c| \\mid |a|$ (`Int.natAbs_dvd_natAbs`), then the ℕ universal property $|c| \\mid \\gcd(|a|, |b|)$, then cast back via `Int.natCast_dvd_natCast` composed with `Int.dvd_natAbs`. Each step is a one-liner.",
+    "significance": "key",
+    "relatedConcepts": [
+      "GCD universal property",
+      "Int.natAbs_dvd",
+      "Int.natCast_dvd_natCast",
+      "Nat.dvd_gcd",
+      "API-stable proof design"
+    ],
+    "prerequisites": [
+      "GCD universal property",
+      "Int.natAbs_dvd",
+      "Int.natAbs_dvd_natAbs",
+      "Nat.dvd_gcd"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-cross-algorithm",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 162,
+      "endLine": 176
+    },
+    "type": "insight",
+    "title": "Cross-Algorithm Agreement (No Import Cycle)",
+    "content": "`lehmerGcdInt_eq_natAbs_gcd : lehmerGcdInt a b = a.natAbs.gcd b.natAbs` states agreement with the *shape* of `BinaryGcdOQ02.binaryGcdInt`'s result without importing the binary-GCD file. The proof is two lines: rewrite to `Int.gcd`, then `rfl` (since `Int.gcd` is *defined* as `a.natAbs.gcd b.natAbs`).\n\n**Why this matters**: `BinaryGcdOQ02.lean` imports `Proofs.GcdAlgorithmOQ02` (for the ℕ-level binary GCD), and this file imports `Proofs.BinaryGcdOQ03OQ01` (for the ℕ-level Lehmer GCD). A direct cross-import in either direction would create a dependency cycle. Phrasing the agreement through the shared `Nat.gcd` form sidesteps this entirely.\n\nAny downstream proof can compose `lehmerGcdInt_eq_natAbs_gcd` with `BinaryGcdOQ02.binaryGcdInt_eq_natAbs_gcd` (or with `binaryGcdInt_eq_intGcd`) to conclude `lehmerGcdInt a b = binaryGcdInt a b` — both algorithms compute the same value on every ℤ input, as required.",
+    "mathContext": "Two algorithms that both compute $\\gcd$ on $\\mathbb{Z}$ must produce equal values on every input. The shortest formal route to that equality is to show each equals a common reference (here, $|a|.\\text{gcd}(|b|)$, or equivalently $\\text{Int.gcd}$) and compose. This is the standard technique for inter-algorithm equivalence proofs.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "BinaryGcdOQ02.binaryGcdInt",
+      "import cycle avoidance",
+      "definitional unfolding"
+    ],
+    "prerequisites": [
+      "Int.gcd unfolding",
+      "lehmerGcdInt_eq_intGcd"
+    ]
+  },
+  {
+    "id": "ann-lehmer-int-decide-examples",
+    "proofId": "binary-gcd-oq-02-oq-02",
+    "range": {
+      "startLine": 178,
+      "endLine": 201
+    },
+    "type": "insight",
+    "title": "Kernel-Level Verification via decide",
+    "content": "Eight concrete examples cover every combination of sign (positive/negative) and special case (zero, self-application) and verify that `lehmerGcdInt` computes the expected value. Each uses the two-step incantation:\n\n```lean\nby rw [lehmerGcdInt_eq_intGcd]; decide\n```\n\nThe `rw` rewrites to `Int.gcd`, then `decide` — Lean's kernel-level decision procedure — fully reduces the call to a concrete numeral and confirms it matches the right-hand side. Since `Int.gcd` reduces to `Nat.gcd` on `natAbs`, both decidable on concrete numerals, the entire computation happens inside the kernel.\n\nThese are not unit tests — they are proof certificates. The Lean type-checker itself runs the computation and records the equality in the kernel's verification stream.\n\nThe closing summary in the file delineates the scope: the integer extension is complete and verified; the bignum *bit-sequence* extension (formal limb-level equivalence) is orthogonal and lives in `BinaryGcdOQ03OQ02*`. The Lehmer accelerator's leading-digit content is also out of scope here.",
+    "mathContext": "Examples include $\\gcd(-12, 18) = 6$, $\\gcd(0, \\pm 7) = 7$, and $\\gcd(\\pm 17, 17) = 17$, covering each sign combination and the zero/self edges. Each is closed by `decide` after the rewrite, exhibiting kernel-level reduction of the algorithm on concrete numerals.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lean decide tactic",
+      "kernel evaluation",
+      "definitional reduction",
+      "proof certificates"
+    ],
+    "prerequisites": [
+      "Lean 4 decide tactic",
+      "kernel computation",
+      "computability of lehmerGcd"
+    ]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-02-oq-02/index.ts
+++ b/src/data/proofs/binary-gcd-oq-02-oq-02/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/BinaryGcdOQ02OQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/binary-gcd-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-02/meta.json
@@ -1,0 +1,256 @@
+{
+  "id": "binary-gcd-oq-02-oq-02",
+  "title": "Lehmer's GCD for Integers",
+  "slug": "binary-gcd-oq-02-oq-02",
+  "description": "Extends D. H. Lehmer's GCD algorithm from ℕ to ℤ via natAbs reduction. Defines `lehmerGcdInt : ℤ → ℤ → ℕ` and proves it equal to Mathlib's `Int.gcd`. Lehmer's algorithm is the production-relevant integer-GCD routine used in GMP, OpenSSL, and JDK BigInteger. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lehmer%27s_GCD_algorithm",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinaryGcdOQ02OQ02.lean",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "integers",
+      "lehmer",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-05-12",
+    "axiomCount": 0,
+    "lineCount": 201,
+    "assumptions": "None. 0 axiom declarations, 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.gcd",
+        "description": "GCD on integers, defined as a.natAbs.gcd b.natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.gcd_comm",
+        "description": "Commutativity of Int.gcd",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.gcd_self",
+        "description": "Int.gcd a a = a.natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.natCast_dvd_natCast",
+        "description": "Reduces ℤ-divisibility of natural casts to ℕ-divisibility",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.natAbs_dvd",
+        "description": "(↑a.natAbs : ℤ) ∣ a (and the other direction)",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.natAbs_dvd_natAbs",
+        "description": "Divisibility lifts/descends between ℤ and ℕ via natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.dvd_natAbs",
+        "description": "c ∣ ↑c.natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Nat.dvd_gcd",
+        "description": "Universal property of Nat.gcd",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_dvd_left",
+        "description": "Nat.gcd m n ∣ m",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_dvd_right",
+        "description": "Nat.gcd m n ∣ n",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition of `lehmerGcdInt : ℤ → ℤ → ℕ` via natAbs reduction (Proofs/BinaryGcdOQ02OQ02.lean:50)",
+      "Correctness theorem `lehmerGcdInt_eq_intGcd` connecting Lehmer's algorithm to Mathlib's Int.gcd (Proofs/BinaryGcdOQ02OQ02.lean:67)",
+      "Sign-invariance lemmas `@[simp]`-tagged for transparent normalization under negation",
+      "Universal property `dvd_lehmerGcdInt` derived via natAbs-respecting divisibility — Mathlib-version-stable across the `Int.gcd_dvd_*` convention shift",
+      "Cross-algorithm bridge `lehmerGcdInt_eq_natAbs_gcd` establishing agreement with binary GCD on ℤ without introducing an import cycle",
+      "Eight `decide`-checked sanity examples covering every sign combination and zero/self edge case"
+    ],
+    "prerequisites": [
+      "Lehmer GCD on ℕ (Proofs/BinaryGcdOQ03OQ01.lean) and its correctness theorem `lehmerGcd_correct`",
+      "Mathlib's Int.gcd defined via natAbs",
+      "Basic absolute-value identities on ℤ (Int.natAbs_neg, Int.natAbs_dvd, etc.)"
+    ],
+    "theoremCount": 15,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Frames the file as the integer half of OQ-02-OQ-02 — extend Lehmer's GCD from ℕ to ℤ. Imports Mathlib's integer GCD theory and the parent file `Proofs.BinaryGcdOQ03OQ01` which carries the ℕ-level correctness proof.",
+      "mathContext": "Lehmer's 1938 algorithm uses leading-digit quotient estimates to accelerate Euclidean descent on bignums. The leading-digit content is separate (`BinaryGcdOQ03OQ02*`); the integer extension here is purely the natAbs reduction. This file's only mathematical content beyond Mathlib is `LehmerGcdOQ01.lehmerGcd_correct`."
+    },
+    {
+      "id": "definition",
+      "title": "lehmerGcdInt: The Core Definition",
+      "startLine": 44,
+      "endLine": 50,
+      "summary": "Defines `lehmerGcdInt a b := lehmerGcd a.natAbs b.natAbs`, taking absolute values and delegating to the ℕ-level Lehmer algorithm. Returns `ℕ` (not `ℤ`) since GCDs are non-negative.",
+      "mathContext": "The natAbs reduction is the canonical idiom for lifting ℕ-valued algorithms to ℤ. It mirrors how Mathlib itself defines `Int.gcd m n = m.natAbs.gcd n.natAbs`, making the integer extension definitionally aligned with the canonical reference."
+    },
+    {
+      "id": "natabs-reduction",
+      "title": "Reduction to ℕ Lehmer GCD",
+      "startLine": 52,
+      "endLine": 62,
+      "summary": "States the natAbs reduction as a `@[simp]` lemma (proved by `rfl`) and specializes for natCast inputs.",
+      "mathContext": "`lehmerGcdInt_natAbs` is definitionally true (`rfl`), letting `simp` cross the integer/natural boundary in both directions. `lehmerGcdInt_natCast` covers the common case where integer inputs come from natural-number casts."
+    },
+    {
+      "id": "correctness",
+      "title": "Correctness vs Int.gcd",
+      "startLine": 64,
+      "endLine": 70,
+      "summary": "`lehmerGcdInt_eq_intGcd` proves the integer extension equals Mathlib's `Int.gcd`. The two-line proof unfolds both sides and invokes `lehmerGcd_correct`.",
+      "mathContext": "Mathlib's `Int.gcd` is itself defined as `a.natAbs.gcd b.natAbs`. Composing this with `lehmerGcd_correct : lehmerGcd m n = Nat.gcd m n` collapses the equality to a single application — the textbook example of modular proof reuse."
+    },
+    {
+      "id": "sign-and-edges",
+      "title": "Sign Invariance, Edge Cases, and Algebraic Properties",
+      "startLine": 72,
+      "endLine": 112,
+      "summary": "Sign-flip invariance (`neg_left`, `neg_right`, `neg_neg`), zero cases, commutativity, self-application, and non-negativity. The `@[simp]` lemmas integrate `lehmerGcdInt` into Mathlib's simp set.",
+      "mathContext": "Each property reduces in one rewrite to its Mathlib `Int.gcd_*` counterpart through `lehmerGcdInt_eq_intGcd`, illustrating how a single definitional bridge inherits an entire theorem family. The `@[simp]` tags ensure downstream proofs over ℤ never need to reason about sign explicitly."
+    },
+    {
+      "id": "universal-property",
+      "title": "Universal Property of lehmerGcdInt",
+      "startLine": 114,
+      "endLine": 160,
+      "summary": "`lehmerGcdInt_dvd_left`, `lehmerGcdInt_dvd_right`, and `dvd_lehmerGcdInt` together pin down `lehmerGcdInt` as a greatest common divisor in the ℤ-divisibility lattice. Proofs route through `lehmerGcd_correct` + `Nat.gcd_dvd_*` + `Int.natAbs_dvd` rather than directly through `Int.gcd_dvd_*` — this makes the file robust against the recent Mathlib convention shift in `Int.gcd_dvd_*` typing.",
+      "mathContext": "For any `c ∈ ℤ` with `c ∣ a` and `c ∣ b`, we have `c ∣ lehmerGcdInt a b`. The proof factors as: natAbs-respecting divisibility (`Int.natAbs_dvd_natAbs`), the ℕ universal property (`Nat.dvd_gcd`), then cast back via `Int.natCast_dvd_natCast` and `Int.dvd_natAbs`. This characterization makes `lehmerGcdInt` the unique GCD up to associates — exactly what every downstream consumer expects."
+    },
+    {
+      "id": "cross-algorithm-agreement",
+      "title": "Agreement with Binary GCD on ℤ",
+      "startLine": 162,
+      "endLine": 176,
+      "summary": "`lehmerGcdInt_eq_natAbs_gcd` proves `lehmerGcdInt a b = a.natAbs.gcd b.natAbs`, the same shape `BinaryGcdOQ02.binaryGcdInt` satisfies. Both algorithms therefore compute the same value on every ℤ input.",
+      "mathContext": "The statement is phrased via `Nat.gcd` rather than `BinaryGcdOQ02.binaryGcdInt` to avoid a dependency cycle (binary GCD imports `GcdAlgorithmOQ02`, Lehmer imports `BinaryGcdOQ03OQ01`). Composing this bridge with `BinaryGcdOQ02.binaryGcdInt_eq_intGcd` yields the cross-algorithm agreement without any new imports."
+    },
+    {
+      "id": "decide-examples",
+      "title": "Kernel-Level Sanity Checks via decide",
+      "startLine": 178,
+      "endLine": 201,
+      "summary": "Eight `decide`-checked examples cover positive/negative sign combinations plus zero and self-application edges, then a summary remark separates the verified integer extension from the orthogonal bignum (limb-level) question handled in `BinaryGcdOQ03OQ02*`.",
+      "mathContext": "Each example first rewrites `lehmerGcdInt` to `Int.gcd` via the correctness theorem, then closes by `decide` — Lean's kernel-level decision procedure. Because `Int.gcd` reduces fully on concrete numerals, `decide` certifies the runtime behavior at type-check time. These are proof certificates, not unit tests."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Lehmer's algorithm and integer GCD in practice**\n\nD. H. Lehmer published his GCD algorithm in 1938 (\"Euclid's Algorithm for Large Numbers\", Amer. Math. Monthly). The crucial new idea was that the next quotient in Euclidean descent can be estimated from just the leading digits of the operands — turning each step into a tight loop on machine-word approximations rather than full bignum divisions. This is the algorithm that ships in essentially every multi-precision arithmetic library: GMP, OpenSSL, JDK BigInteger, .NET BigInteger, Pari/GP, and FLINT all run Lehmer-style descent (often with later refinements by Knuth, Schönhage, and Jebelean).\n\nKnuth (TAOCP §4.5.2, Algorithm L) gives the standard textbook treatment, including the integer extension — which is the present entry's subject. In every production implementation, integer GCD is computed by taking absolute values of the inputs and running the unsigned routine. This entry formalizes that step: define `lehmerGcdInt` by reducing to `natAbs`, then prove it equal to Mathlib's `Int.gcd`. The formalization mirrors the parallel result for binary GCD (`BinaryGcdOQ02`) — both algorithms inherit the integer extension trivially once the ℕ-level correctness theorem is in hand.",
+    "problemStatement": "**Open question OQ-02-OQ-02**: Can Lehmer's GCD algorithm be extended from ℕ to ℤ, and does the extension agree with Mathlib's `Int.gcd`?\n\nThis entry resolves it affirmatively: define `lehmerGcdInt a b := lehmerGcd a.natAbs b.natAbs`, prove `lehmerGcdInt a b = Int.gcd a b`, and verify the standard algebraic suite (sign invariance, edges, commutativity, divisibility, universal property). Also establish agreement with the parallel binary-GCD extension via a shared `natAbs`-based statement that avoids import cycles.",
+    "text": "Integer extension of Lehmer's GCD algorithm with full Mathlib correctness, sign-invariance, and divisibility universal property.",
+    "proofStrategy": "1. **Definition by delegation**: `lehmerGcdInt a b := lehmerGcd a.natAbs b.natAbs`. Result type is ℕ since GCD ≥ 0.\n2. **Reduction lemma**: `lehmerGcdInt_natAbs` is `rfl`, tagged `@[simp]` for both-way rewriting.\n3. **Main correctness**: unfold both `lehmerGcdInt` and `Int.gcd`, apply `lehmerGcd_correct`. Two lines.\n4. **Sign/edge/algebraic suite**: each rewrites through `lehmerGcdInt_eq_intGcd` to the matching `Int.gcd_*` Mathlib lemma.\n5. **Universal property without `Int.gcd_dvd_*`**: route divisibility through `natAbs` + `Nat.gcd_dvd_*` + `Int.natAbs_dvd` to stay robust against recent Mathlib convention shifts in `Int.gcd_dvd_*` argument typing.\n6. **Cross-algorithm bridge**: state agreement with binary GCD via the shared `natAbs.gcd` form, sidestepping import-cycle issues.\n7. **Decide-checked examples**: cover every sign × zero × self case.",
+    "keyInsights": [
+      "Production GCD routines (GMP, OpenSSL, JDK) all use Lehmer's algorithm on absolute values — exactly the formalization pattern proved here. This makes `lehmerGcdInt` the verified Lean analogue of what `BigInteger.gcd` actually does at runtime.",
+      "The natAbs reduction inherits the integer extension for any ℕ-level GCD algorithm in one rewrite. The pattern `lemma_eq_intGcd : alg_int a b = Int.gcd a b := by unfold alg_int Int.gcd; exact alg_correct a.natAbs b.natAbs` works for binary GCD, Lehmer's GCD, Euclidean GCD, and any future ℕ-level GCD variant.",
+      "Routing the universal property through `Int.natAbs_dvd` + `Nat.dvd_gcd` rather than `Int.gcd_dvd_*` is a deliberate API-stability choice: the Mathlib typing of `Int.gcd_dvd_*` shifted recently (ℕ-typed vs ℤ-typed divisor), and the natAbs route is invariant under that shift.",
+      "Lehmer's GCD inherits Lean's kernel-level GMP backing: every `Nat` operation is compiled to GMP, so `lehmerGcdInt` already runs on bignums correctly. The remaining mathematical question — formal limb-level bit-sequence equivalence — is orthogonal and handled separately in `BinaryGcdOQ03OQ02*`.",
+      "Stating cross-algorithm agreement via the shared `natAbs.gcd` form (rather than importing `BinaryGcdOQ02` directly) avoids a dependency cycle and makes the bridge usable in either direction — any later proof can compose `lehmerGcdInt_eq_natAbs_gcd` with `BinaryGcdOQ02.binaryGcdInt_eq_natAbs_gcd` to conclude `lehmerGcdInt = binaryGcdInt` without rewiring imports."
+    ],
+    "prerequisites": [
+      "Lehmer GCD on ℕ (`Proofs.BinaryGcdOQ03OQ01.LehmerGcdOQ01`) including `lehmerGcd_correct`",
+      "Mathlib `Int.gcd` definition and standard lemmas (`gcd_comm`, `gcd_self`)",
+      "`Int.natAbs`, `Int.natAbs_neg`, `Int.natAbs_dvd`, `Int.natAbs_dvd_natAbs`, `Int.natCast_dvd_natCast`"
+    ]
+  },
+  "conclusion": {
+    "summary": "Integer extension of Lehmer's GCD: defined via natAbs reduction, proved equal to Mathlib's `Int.gcd`, full sign-invariance, edge case, divisibility, and universal-property coverage. Cross-algorithm agreement with binary GCD on ℤ established via shared `natAbs.gcd` bridge. 0 axioms, 0 sorries.",
+    "implications": "Provides a verified `lehmerGcdInt` that downstream proofs can use whenever a production-relevant integer GCD routine is needed. The natAbs reduction template is reusable for any ℤ-extension of an ℕ-level number-theoretic algorithm — extended Euclidean (Bézout), modular inverse, Jacobi symbol, etc. The Mathlib-version-stable divisibility routing also serves as a worked example of API-resilient proof design.",
+    "openQuestions": [
+      "Formal verification of Lehmer's leading-digit quotient-estimate accelerator: prove that the leading-digit estimate matches the true quotient in the regime where the estimate is valid (orthogonal `BinaryGcdOQ03OQ02*` work).",
+      "Extended Lehmer GCD on ℤ: define `lehmerXgcdInt : ℤ → ℤ → ℕ × ℤ × ℤ` returning `(gcd, u, v)` with `u·a + v·b = gcd`, and prove it equivalent to Mathlib's `Int.gcdA`/`Int.gcdB`.",
+      "Bignum bit-sequence equivalence: prove the Lehmer GCD on `Nat` (computed via GMP-backed kernel arithmetic) agrees with a formal limb-level bignum representation. Requires a formal model of multi-precision representation — project-scale."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-02",
+      "relationship": "related",
+      "description": "Parallel integer extension via natAbs reduction for the binary GCD algorithm; both this entry and `binary-gcd-oq-02` follow the same template and agree on every ℤ input via the shared `Int.gcd` bridge"
+    },
+    {
+      "targetId": "binary-gcd-oq-03-oq-01",
+      "relationship": "depends-on",
+      "description": "Imports the ℕ-level Lehmer GCD `lehmerGcd` and its correctness theorem `lehmerGcd_correct` from `LehmerGcdOQ01`"
+    },
+    {
+      "targetId": "binary-gcd-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Lehmer's leading-digit quotient-estimate accelerator (the substantive content of Lehmer 1938) is formalized in this sibling open question — orthogonal to the integer extension proved here"
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "related",
+      "description": "Parent binary GCD correctness proof on ℕ; this entry is the Lehmer analogue of that algorithm's integer extension"
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related",
+      "description": "Bézout's identity on ℤ uses Mathlib's `Int.gcd` — the same bridge `lehmerGcdInt_eq_intGcd` connects to, so any `lehmerGcdInt`-based downstream proof can immediately invoke Bézout"
+    }
+  ],
+  "references": [
+    {
+      "title": "Euclid's Algorithm for Large Numbers",
+      "author": "D. H. Lehmer",
+      "year": "1938",
+      "venue": "American Mathematical Monthly, 45(4), 227–233",
+      "description": "Original publication introducing the leading-digit quotient-estimate speedup and the integer extension via absolute values"
+    },
+    {
+      "title": "The Art of Computer Programming, Volume 2: Seminumerical Algorithms (§4.5.2, Algorithm L)",
+      "author": "Donald E. Knuth",
+      "year": "1981",
+      "venue": "Addison-Wesley",
+      "description": "Standard textbook treatment of Lehmer's GCD including the integer extension via absolute values"
+    },
+    {
+      "title": "Mathlib4 Int.gcd",
+      "author": "Mathlib Contributors",
+      "year": "2024",
+      "venue": "Mathlib4 repository",
+      "description": "Reference Mathlib definition `Int.gcd m n := m.natAbs.gcd n.natAbs` against which `lehmerGcdInt` is proved equal"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Int.GCD",
+      "Mathlib.Tactic",
+      "Proofs.BinaryGcdOQ03OQ01"
+    ],
+    "opens": [
+      "LehmerGcdOQ01"
+    ],
+    "namespace": "BinaryGcdOQ02OQ02",
+    "lineCount": 201,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 1,
+    "path": "Proofs/BinaryGcdOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/binary-gcd-oq-02-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "binary-gcd-oq-02-oq-02",
   "title": "Lehmer's GCD for ℤ: extend the Lehmer algorithm via natAbs reduction",
-  "phase": "ACT",
-  "status": "progress",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,22 +29,25 @@
     "goal": "Mechanical ℤ-extension of Lehmer's GCD via natAbs; correctness vs Int.gcd."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-12T11:42:00.000Z",
-    "iteration": 1,
-    "focus": "S1 SCAFFOLD: BinaryGcdOQ02OQ02.lean with 15 theorems, 1 def, 0 sorries, 0 axioms.",
+    "phase": "COMPLETED",
+    "since": "2026-05-12T12:15:00.000Z",
+    "iteration": 2,
+    "focus": "S2 GALLERY: src/data/proofs/binary-gcd-oq-02-oq-02/{meta,annotations,index}.ts — verified-status entry with 8 sections, 9 annotations, 5 cross-references, 3 references.",
     "blockers": [],
-    "nextAction": "S2 (optional): gallery entry src/data/proofs/binary-gcd-oq-02-oq-02/meta.json + annotations once S1 build is verified clean on origin/main.",
+    "nextAction": "Optional follow-up: explicit Lehmer↔Binary GCD cross-algorithm equality file (5-line statement composing lehmerGcdInt_eq_natAbs_gcd + BinaryGcdOQ02.binaryGcdInt_eq_intGcd). Independent of this slug; could be its own thin entry.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1: created Proofs/BinaryGcdOQ02OQ02.lean (170 lines, 15 theorems, 1 def, 0 sorry, 0 axioms). Defines `lehmerGcdInt (a b : ℤ) : ℕ := lehmerGcd a.natAbs b.natAbs` and proves `lehmerGcdInt_eq_intGcd` plus the standard universal-property / sign-invariance / commutativity / zero-case suite. Structurally identical to BinaryGcdOQ02.lean (binary-GCD analogue); the natAbs reduction makes the ℤ extension mechanical once the ℕ correctness theorem `LehmerGcdOQ01.lehmerGcd_correct` is in hand.",
+    "progressSummary": "S2 COMPLETED: gallery entry at src/data/proofs/binary-gcd-oq-02-oq-02/ with verified-status meta.json (line ranges 1-201, 8 sections, 5 cross-references to binary-gcd-oq-02 / -oq-03-oq-01 / -oq-03-oq-02 / binary-gcd / bezout-identity, 3 references including Lehmer 1938 and Knuth TAOCP), 9 annotations covering header/definition/natAbs-reduction/correctness/sign-invariance/edges/universal-property/cross-algorithm-agreement/decide-examples, and auto-discovered index.ts. S1: created Proofs/BinaryGcdOQ02OQ02.lean (201 lines, 15 theorems, 1 def, 0 sorry, 0 axioms). Defines `lehmerGcdInt (a b : ℤ) : ℕ := lehmerGcd a.natAbs b.natAbs` and proves `lehmerGcdInt_eq_intGcd` plus the standard universal-property / sign-invariance / commutativity / zero-case suite. Structurally identical to BinaryGcdOQ02.lean (binary-GCD analogue); the natAbs reduction makes the ℤ extension mechanical once the ℕ correctness theorem `LehmerGcdOQ01.lehmerGcd_correct` is in hand.",
     "builtItems": [
-      "Proofs/BinaryGcdOQ02OQ02.lean: lehmerGcdInt def + 15 theorems (correctness, sign invariance, commutativity, zero cases, self, universal property, natAbs reduction, agreement with Nat.gcd, 8 sanity examples)"
+      "Proofs/BinaryGcdOQ02OQ02.lean: lehmerGcdInt def + 15 theorems (correctness, sign invariance, commutativity, zero cases, self, universal property, natAbs reduction, agreement with Nat.gcd, 8 sanity examples)",
+      "src/data/proofs/binary-gcd-oq-02-oq-02/meta.json: verified-status gallery entry (8 sections covering lines 1-201, 5 cross-references, 3 references, 10 Mathlib dependencies)",
+      "src/data/proofs/binary-gcd-oq-02-oq-02/annotations.json: 9 annotations (header / definition / natAbs-reduction / correctness / sign-invariance / edges / universal-property / cross-algorithm / decide-examples)",
+      "src/data/proofs/binary-gcd-oq-02-oq-02/index.ts: auto-discovered gallery loader"
     ],
     "insights": [
       "ℤ-extension of any ℕ-GCD algorithm that respects natAbs is mechanical: reduce via |·| and invoke the ℕ correctness theorem; Int.gcd is itself defined as a.natAbs.gcd b.natAbs.",
@@ -53,8 +56,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S2 gallery: meta.json + annotations.json (sibling pattern to binary-gcd-oq-02 entry).",
-      "S2 cross-link: optional sibling file proving lehmerGcdInt = BinaryGcdOQ02.binaryGcdInt (both reduce to Int.gcd; ~5 lines)."
+      "(Optional) Thin sibling file `Proofs/BinaryGcdLehmerCrossAgreement.lean` (~10 lines) explicitly proving lehmerGcdInt a b = BinaryGcdOQ02.binaryGcdInt a b via composing both natAbs.gcd bridges. Independent of this slug; could be its own gallery entry."
     ]
   },
   "tags": [
@@ -89,14 +91,14 @@
     ]
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-12T11:42:00.000Z",
+  "lastUpdate": "2026-05-12T12:15:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/BinaryGcdOQ02OQ02.lean",
       "filename": "BinaryGcdOQ02OQ02.lean",
-      "lineCount": 170,
+      "lineCount": 201,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Summary
- Adds verified-status gallery entry `src/data/proofs/binary-gcd-oq-02-oq-02/` for the Lehmer GCD on ℤ proof merged in #18083 (Proofs/BinaryGcdOQ02OQ02.lean, 201 lines, 15 theorems, 1 def, 0 sorries, 0 axioms).
- Data-only PR — no Lean source changes; companion to #18083 which is build-verified on origin/main (`944c8fb704c`).
- Mirrors the `binary-gcd-oq-02` gallery template (sibling integer-extension entry for binary GCD).

## Files added
- `src/data/proofs/binary-gcd-oq-02-oq-02/meta.json` — status `verified`, badge `original`, 8 sections (header, definition, natAbs reduction, correctness, sign invariance, edges, universal property, cross-algorithm agreement, decide examples) covering all 201 lines, 5 crossReferences (binary-gcd-oq-02, binary-gcd-oq-03-oq-01, binary-gcd-oq-03-oq-02, binary-gcd, bezout-identity), 3 references (Lehmer 1938, Knuth TAOCP §4.5.2, Mathlib4 Int.gcd), 10 mathlibDependencies, 6 originalContributions.
- `src/data/proofs/binary-gcd-oq-02-oq-02/annotations.json` — 9 annotations: module header & imports; `lehmerGcdInt` core definition; natAbs reduction bridge; correctness vs Int.gcd; sign invariance & @[simp] design; edges & algebraic properties; universal property (Mathlib-version-stable routing through natAbs + Nat.dvd_gcd); cross-algorithm agreement without import cycle; kernel-level decide examples.
- `src/data/proofs/binary-gcd-oq-02-oq-02/index.ts` — standard auto-discovered loader.
- `src/data/research/problems/binary-gcd-oq-02-oq-02.json` — phase `COMPLETED`, status `completed`, lineCount sync 170 → 201, S2 deliverables added to builtItems, optional cross-algorithm-equality follow-up retained in nextSteps.

## Honesty notes
- All 15 theorems + 1 def in BinaryGcdOQ02OQ02.lean inherit their proof depth from `LehmerGcdOQ01.lehmerGcd_correct` (parent file). The integer extension itself is mechanical (natAbs reduction); the file is *not* the substantive Lehmer content (that lives in `BinaryGcdOQ03OQ02*`).
- `verified` status is justified — 0 axiom declarations, 0 sorries, 0 structure-encoded assumptions; depends only on Mathlib + the build-verified parent `BinaryGcdOQ03OQ01`.
- `decide`-checked sanity examples (lines 184–191) certify concrete behavior at type-check time, not at runtime.

## Test plan
- [ ] CI gallery build (`pnpm build` / annotations:build) auto-regenerates `src/data/proofs/listings.json` to include the new entry — verified locally by inspection of `src/data/proofs/index.ts` (Vite glob auto-discovery).
- [ ] Visual: page should render at `/proofs/binary-gcd-oq-02-oq-02` once deployed (sibling `/proofs/binary-gcd-oq-02` is the structural reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 researcher-1