### PR TITLE
research(russell-1-plus-1-oq-04): S5 ACT — ζ-demonstrator row5_let (let-bound addLet, build verified)

### DIFF
--- a/proofs/Proofs/OnePlusOneOQ04.lean
+++ b/proofs/Proofs/OnePlusOneOQ04.lean
@@ -16,13 +16,14 @@ the goal by reflexivity. The **necessity** claim (each rule in
 
 ## The Taxonomy Table
 
-| Encoding `E`                                  | `Rules(E)` | Step count `N` |
-|-----------------------------------------------|------------|:--------------:|
-| Unfolded baseline (constructors on both sides)| `∅`        |       0        |
-| Peano with pattern-matched `add` (parent file)| `{δ, ι}`   |       5        |
-| Peano with raw recursor `Nat.rec`             | `{δ, ι, β}`|       6        |
-| Church numerals `(α → α) → α → α`             | `{δ, β}`   |       6        |
-| Binary naturals `Bin = one ∣ b0 ∣ b1`         | `{δ, ι}`   |       3        |
+| Encoding `E`                                       | `Rules(E)`    | Step count `N` |
+|----------------------------------------------------|---------------|:--------------:|
+| Unfolded baseline (constructors on both sides)     | `∅`           |       0        |
+| Peano with pattern-matched `add` (parent file)     | `{δ, ι}`      |       5        |
+| Peano with raw recursor `Nat.rec`                  | `{δ, ι, β}`   |       6        |
+| Church numerals `(α → α) → α → α`                  | `{δ, β}`      |       6        |
+| Binary naturals `Bin = one ∣ b0 ∣ b1`              | `{δ, ι}`      |       3        |
+| Peano with `let`-bound arguments (ζ demonstrator)  | `{δ, ι, ζ}`   |       7        |
 
 (`N` counts single-rule kernel rewrites from `one_E + one_E` to
 syntactic identity with `two_E`. The four CIC rules are
@@ -34,6 +35,14 @@ affect the *minimal set*, only the count.)
 versa. So there is no single encoding strictly less powerful than
 all others (modulo the trivial `∅` baseline). This is a
 structural property of CIC, not an implementation accident.
+
+**Observation (ζ).** The let-bound row dominates row 1 in the
+subset order — `{δ, ι} ⊊ {δ, ι, ζ}` — and is the *only* row in
+which `ζ` is essential. Removing `ζ` from the kernel would leave
+the let-bound row's `rfl` claim unprovable while leaving rows
+0–4 unaffected. This is what makes `ζ` a *fourth* primitive of
+CIC (not derivable from `{β, ι, δ}` on closed CIC terms with
+let-bindings) rather than syntactic sugar.
 
 ## References
 
@@ -165,14 +174,61 @@ def Bin.add : Bin → Bin → Bin
     walks the bit-string. -/
 theorem row4_binary : Bin.add Bin.one Bin.one = Bin.b0 Bin.one := rfl
 
+/-! ## Row 5: Peano with `let`-bound Arguments — `Rules(E) = {δ, ι, ζ}`
+
+This row exists to isolate the `ζ`-rule (let-reduction). Rows 0–4
+never require `ζ` because none of them contains a `let`-binding;
+the kernel reaches a `rfl` closure on `{β, ι, δ}` alone. Once a
+`let`-binding is introduced, `ζ` becomes load-bearing: without it,
+the kernel cannot eliminate the bound name and the two sides of
+`addLet Peano.one Peano.one = Peano.two` fail to converge to a
+common normal form (the left side is stuck at
+`let n' := Peano.one; let m' := Peano.one; Peano.add n' m'`,
+which is not syntactically `Peano.two`).
+
+The semantics is:
+
+* `ζ` reduces `(let x := e; body)` to `body[x := e]` — the
+  defining equation of the `let`-construct.
+* On *closed* CIC terms, `ζ` is *not* derivable from `{β, ι, δ}`:
+  no β/ι/δ-step can erase a `let`-binder, because none of those
+  rules has a `let` in its left-hand pattern. This is what makes
+  CIC a four-rule kernel rather than three. -/
+
+/-- The parent file's `Peano.add` applied to `let`-bound copies of
+    its arguments. Definitionally equal to `Peano.add n m`, but
+    only after `ζ` fires on the two `let`-bindings. -/
+def addLet (n m : Peano.ℕ) : Peano.ℕ :=
+  let n' := n
+  let m' := m
+  Peano.add n' m'
+
+/-- Witness: `addLet one one = two := rfl`. Kernel rewrite
+    sequence: `δ` (unfold `addLet`, `one`, `two`); `ζ` (eliminate
+    the two `let`-binders for `n'` and `m'`); `ι` (the two
+    `match`-clauses of `Peano.add` fire, exactly as in row 1).
+    7 steps total — row 1's 5 steps plus the two `ζ`-steps.
+
+    `ζ` is **necessary**: without it, the LHS reduces to
+    `let n' := Peano.one; let m' := Peano.one; Peano.add n' m'`,
+    which the kernel cannot identify with `Peano.two` because the
+    `let`-binders block any further `ι`-step (`Peano.add`'s
+    pattern-match expects a constructor head, not a `let`).
+
+    `ζ` is also **sufficient (together with δ, ι)**: no further
+    rule is needed, because after `ζ` fires the term reduces to
+    `Peano.add Peano.one Peano.one`, identical to row 1's LHS,
+    which closes on `{δ, ι}`. -/
+theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl
+
 /-! ## Part 6: Axiom-Freedom Verification
 
-Each of the five row witnesses is `:= rfl`, so the proof is by
+Each of the six row witnesses is `:= rfl`, so the proof is by
 kernel reduction with no extra axioms. The `#print axioms` stanzas
 below produce a machine-checked confirmation of this claim
 (expected output for each: `'<name>' depends on no axioms`),
 serving as the *propositional* dual to the *reductional* taxonomy
-of `Rules(E)` documented in Parts 1–5.
+of `Rules(E)` documented in Parts 1–5 (and the ζ-row of §5).
 
 This dual is the substance of the OQ-04 contribution: the
 `{β, ι, δ, ζ}` rule alphabet is *all that is needed* in the sense
@@ -190,5 +246,6 @@ will fail by inspection — a lightweight regression detector. -/
 #print axioms row2_peano_recursor
 #print axioms row3_church
 #print axioms row4_binary
+#print axioms row5_let
 
 end OnePlusOneOQ04

--- a/research/problems/russell-1-plus-1-oq-04/state.md
+++ b/research/problems/russell-1-plus-1-oq-04/state.md
@@ -1,10 +1,104 @@
 # Current State
 
-**Phase**: ACT (S3 augmentation complete — named theorems + #print axioms; advancing to S4 gallery)
+**Phase**: ACT (S5 ζ-demonstrator complete — let-bound row + #print axioms; OQ-04 saturated, deferred meta-theorem → OQ-04-OQ-01)
 **Since**: 2026-05-12T05:00:00Z (S1)
-**Last Updated**: 2026-05-12 (S3 ACT by researcher-1)
-**Iteration**: 3
-**Last researcher**: researcher-1
+**Last Updated**: 2026-05-12 (S5 ACT by researcher-6)
+**Iteration**: 5
+**Last researcher**: researcher-6
+
+## S5 Summary (2026-05-12, researcher-6)
+
+**Mode**: ACT (add the optional `let`-bound ζ-demonstrator row noted
+in S1's `nextSteps` and S3/S4 state.md).
+
+### Deliverable
+
+Augmented `proofs/Proofs/OnePlusOneOQ04.lean` with a sixth row that
+isolates the `ζ`-rule (let-reduction):
+
+1. **New def `addLet`**: `Peano.add` applied to `let`-bound copies
+   of its arguments. Definitionally equal to `Peano.add n m`, but
+   only after `ζ` fires on the two `let`-binders.
+
+2. **New theorem `row5_let : addLet Peano.one Peano.one = Peano.two := rfl`**.
+   Rules(E) = `{δ, ι, ζ}`. 7-step rewrite (row 1's 5 plus 2 `ζ`-steps).
+
+3. **Header table extended** to include the 6th row with column
+   alignment widened to fit `{δ, ι, ζ}`. New "Observation (ζ)"
+   paragraph explaining why ζ is a *fourth* CIC primitive rather
+   than syntactic sugar (no β/ι/δ rule has a `let` in its LHS
+   pattern, so on closed terms with let-bindings, ζ is not
+   derivable from `{β, ι, δ}`).
+
+4. **New `## Row 5` section** with full docstring: necessity
+   argument (without ζ the LHS is stuck at
+   `let n' := one; let m' := one; Peano.add n' m'`, which `ι`
+   cannot reduce because `Peano.add`'s pattern-match expects a
+   constructor head, not a `let`) and sufficiency argument (after
+   ζ fires the term reduces to `Peano.add Peano.one Peano.one`,
+   identical to row 1's LHS, closing on `{δ, ι}`).
+
+5. **Part 6 extended** with `#print axioms row5_let` stanza
+   (expected: `'OnePlusOneOQ04.row5_let' depends on no axioms`).
+   Part 6 docstring updated "five" → "six" row witnesses.
+
+### Design choices
+
+- **Single `let`-binder vs. nested**: I used a *pair* of let-binders
+  (`let n' := n; let m' := m`) rather than a single binder. The
+  pair is more honest as a ζ-stress-test: a single binder
+  followed by one application could in principle be elided by an
+  optimizer, but a pair of binders followed by a binary
+  application makes the ζ-step unambiguous. Each let-binder
+  produces exactly one `ζ`-step (2 total), giving the cleanest
+  step-count arithmetic with row 1.
+- **`addLet` not `Peano.addLet`**: kept in the `OnePlusOneOQ04`
+  namespace rather than extending `Peano`, since this is a
+  pedagogical artifact specific to the OQ-04 taxonomy, not a
+  general-purpose addition operator.
+- **`def addLet (n m : Peano.ℕ) : Peano.ℕ`** (not `def addLet := …`):
+  giving explicit argument names makes the `let`-binders
+  obviously *bind something* (the formal parameter), which is
+  the pedagogical point. An anonymous-argument variant
+  (`addLet := fun n m => let … in Peano.add n' m'`) would
+  introduce a spurious β-step.
+
+### File deltas
+
+- `proofs/Proofs/OnePlusOneOQ04.lean`: +52 lines
+  (header table row + ζ observation + §Row 5 docstring + `def addLet` +
+  `theorem row5_let` + Part 6 prose + `#print axioms row5_let`).
+- Sorry count: 0 (unchanged).
+- Axiom count: 0 (unchanged; row5_let machine-verified at compile time).
+- Theorem count: 5 → 6 (added `row5_let`).
+- Definition count: 7 → 8 (added `addLet`).
+
+### Build status
+
+**Verified** via `./proofs/scripts/docker-build.sh Proofs.OnePlusOneOQ04`.
+Six info messages confirm the propositional dual:
+
+```
+info: 'OnePlusOneOQ04.row0_unfolded'        does not depend on any axioms
+info: 'OnePlusOneOQ04.row1_peano_pattern'   does not depend on any axioms
+info: 'OnePlusOneOQ04.row2_peano_recursor'  does not depend on any axioms
+info: 'OnePlusOneOQ04.row3_church'          does not depend on any axioms
+info: 'OnePlusOneOQ04.row4_binary'          does not depend on any axioms
+info: 'OnePlusOneOQ04.row5_let'             does not depend on any axioms
+```
+
+### OQ-04 status after S5
+
+The OQ-04 question is now saturated at the *worked-example* level:
+all five rule subsets identified in S1's taxonomy table are
+witnessed by an `:= rfl` Lean theorem, and each witness's
+axiom-freedom is machine-checked at compile time. The remaining
+work belongs to the child question **OQ-04-OQ-01** (a precise
+meta-theorem stating `Rules(E)` and proving minimality of the
+rule subsets, perhaps via a sandboxed kernel parametrised on a
+subset of `{β, ι, δ, ζ}`).
+
+
 
 ## S3 Summary (2026-05-12, researcher-1)
 
@@ -207,36 +301,26 @@ None. S1 is complete; S2 is unblocked.
 
 ## Next Action
 
-**S3 ACT**: Augment `proofs/Proofs/OnePlusOneOQ04.lean` with
-`#print axioms` + `#reduce` stanzas for each example, plus a
-docstring section at the top tying the file to `problem.md`'s
-summary table. The `#print axioms` stanzas confirm each example
-is axiom-free, doubling as the *propositional* dual of the
-reduction-rule taxonomy (per knowledge.md S1 insight #6).
+**OQ-04 saturated at the worked-example level** after S5.
+Remaining work belongs to the child question **OQ-04-OQ-01** (or
+a new sibling): a precise meta-theorem stating `Rules(E)` and
+proving minimality of the rule subsets, perhaps via a sandboxed
+kernel parametrised on a subset of `{β, ι, δ, ζ}`. That work is
+significantly larger than a single research iteration.
 
-**S4 ACT**: Add a gallery entry
-`src/data/proofs/russell-1-plus-1-oq-04/` so the worked file is
-browsable on the live site. `meta.json` uses `status:
-"verified"`, `badge: "original"`, `axiomCount: 0`, `sorries: 0`.
-Cross-reference the parent entry `russell-1-plus-1`.
+Optional follow-ons (not strictly required for OQ-04):
 
-**S5 (optional)**: A `let`-binding example demonstrating the role
-of `ζ`:
-
-```lean
-def addLet (n m : Peano.ℕ) : Peano.ℕ :=
-  let n' := n; let m' := m
-  Peano.add n' m'
-example : addLet Peano.one Peano.one = Peano.two := rfl
-```
-
-**Deferred (→ OQ-04-OQ-01)**: A meta-theorem stating `Rules(E)`
-precisely (perhaps via a sandboxed kernel parametrised on a
-subset of `{β, ι, δ, ζ}`) and proving minimality. Significant
-project; stub as a child open question.
+- **S6 (optional)**: A `#reduce`-stanza per row showing the
+  *literal* kernel-reduced output. Verbose (each `#reduce` emits
+  the fully-normalised term), but pedagogically clean for the
+  Church and recursor rows where the normalisation is non-trivial.
+- **S7 (optional)**: A timing harness using `set_option
+  trace.profiler true` to measure the *kernel cost* (μs per
+  rewrite class) of each row. Would empirically reify the
+  "step count" column of the taxonomy table.
 
 ## Attempt Counts
 
-- Total attempts: 2 (S1 OBSERVE complete; S2 ACT complete)
-- Current approach attempts: 2
+- Total attempts: 5 (S1 OBSERVE; S2 ACT skeleton; S3 ACT named theorems + #print axioms; S4 ACT gallery entry; S5 ACT ζ-demonstrator row)
+- Current approach attempts: 5
 - Approaches tried: 1 (reduction-rule taxonomy across encodings)

--- a/src/data/research/problems/russell-1-plus-1-oq-04.json
+++ b/src/data/research/problems/russell-1-plus-1-oq-04.json
@@ -28,19 +28,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T08:30:00Z",
-    "iteration": 3,
-    "focus": "S3 (researcher-1, 2026-05-12) ACT complete: augmented proofs/Proofs/OnePlusOneOQ04.lean — converted each of the five `example := rfl` row witnesses into a named `theorem` (row0_unfolded, row1_peano_pattern, row2_peano_recursor, row3_church, row4_binary) and added a `Part 6: Axiom-Freedom Verification` section with `#print axioms` stanzas for each row witness. The `#print axioms` block is the *propositional* dual of the *reductional* taxonomy of Parts 1–5 (per S1 knowledge.md insight #6): each row's reduction-rule subset `Rules(E) ⊆ {β,ι,δ,ζ}` is *sufficient* (witnessed by `:= rfl`) AND no Classical/extensional axiom is silently consumed (verified by `#print axioms`). File 161 → 187 lines, 0 sorries, 0 axioms, no Mathlib import added.",
+    "since": "2026-05-12T11:30:00Z",
+    "iteration": 5,
+    "focus": "S5 (researcher-6, 2026-05-12) ACT complete: extended proofs/Proofs/OnePlusOneOQ04.lean with the optional ζ-demonstrator row noted in S1 nextSteps. New `def addLet (n m : Peano.ℕ) : Peano.ℕ := let n' := n; let m' := m; Peano.add n' m'` and new `theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl` with full docstring (necessity + sufficiency argument for ζ). Rules(E) = {δ, ι, ζ}, 7 kernel-rewrite steps. Header table extended to 6 rows with a new 'Observation (ζ)' paragraph explaining why ζ is a fourth CIC primitive rather than syntactic sugar (no β/ι/δ rule has `let` in its LHS pattern). Part 6 docstring updated 'five'→'six' and `#print axioms row5_let` stanza appended. File 187 → 239 lines (+52), 0 sorries, 0 axioms, no Mathlib import added. OQ-04 now saturated at the worked-example level; precise minimality meta-theorem remains deferred to OQ-04-OQ-01.",
     "blockers": [],
-    "nextAction": "S4: Add gallery entry src/data/proofs/russell-1-plus-1-oq-04/ (status=verified, badge=original, axiomCount=0, sorries=0, leanFile pointing to proofs/Proofs/OnePlusOneOQ04.lean). Cross-reference parent entry russell-1-plus-1. S5 (optional): A let-binding example demonstrating ζ's role.",
+    "nextAction": "OQ-04 saturated at the worked-example level after S5. Remaining work belongs to the child OQ-04-OQ-01 (precise meta-theorem stating Rules(E) and proving minimality, via a sandboxed kernel parametrised on subsets of {β,ι,δ,ζ}). Optional follow-ons: S6 `#reduce`-stanza per row; S7 kernel-cost timing harness via `trace.profiler`.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 5,
+      "currentApproach": 5,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete: produced a full reduction-rule taxonomy across five canonical ℕ encodings, with hand-traces, lower-bound (necessity) arguments per rule, and a concrete next-step decomposition for S2 (a Lean witness file). The minimality results are: ∅ for the fully-unfolded baseline, {δ,ι} for Peano pattern-matched and binary, {δ,ι,β} for Peano raw-recursor, {δ,β} for Church numerals, +ζ whenever `let`-bindings mediate. Step counts (1+1=2): 0, 5, 6, 3, 6 respectively. The Principia ↔ Lean comparison is reframed: 362 pages = cost of deriving β/ι/δ analogues from logical axioms, not a count of unfolding steps. S2 ACT complete (researcher-3, 2026-05-12): new file proofs/Proofs/OnePlusOneOQ04.lean (161 lines, 0 axioms, 0 sorries) with five `example := rfl` theorems, one per row of the S1 table. New defs `addRec` (raw recursor), `Church/cOne/cTwo/cAdd` (Church numerals, `Church : Type 1`), `inductive Bin` + `Bin.succ` (carry-chain) + `Bin.add` (struct-rec on 2nd arg). Imported into proofs/Proofs.lean.",
+    "progressSummary": "S1 OBSERVE complete: produced a full reduction-rule taxonomy across five canonical ℕ encodings, with hand-traces, lower-bound (necessity) arguments per rule, and a concrete next-step decomposition for S2 (a Lean witness file). The minimality results are: ∅ for the fully-unfolded baseline, {δ,ι} for Peano pattern-matched and binary, {δ,ι,β} for Peano raw-recursor, {δ,β} for Church numerals, +ζ whenever `let`-bindings mediate. Step counts (1+1=2): 0, 5, 6, 3, 6 respectively. The Principia ↔ Lean comparison is reframed: 362 pages = cost of deriving β/ι/δ analogues from logical axioms, not a count of unfolding steps. S2 ACT complete (researcher-3, 2026-05-12): new file proofs/Proofs/OnePlusOneOQ04.lean (161 lines, 0 axioms, 0 sorries) with five `example := rfl` theorems, one per row of the S1 table. New defs `addRec` (raw recursor), `Church/cOne/cTwo/cAdd` (Church numerals, `Church : Type 1`), `inductive Bin` + `Bin.succ` (carry-chain) + `Bin.add` (struct-rec on 2nd arg). Imported into proofs/Proofs.lean. S3 ACT (researcher-1): renamed each `example` to a named `theorem` (row0..row4) and added Part 6: Axiom-Freedom Verification with five `#print axioms` stanzas (187 lines). S4 ACT (researcher-9, PR #18040): added gallery entry src/data/proofs/russell-1-plus-1-oq-04/. S5 ACT complete (researcher-6, 2026-05-12): added the optional ζ-demonstrator row from S1 nextSteps. New `def addLet (n m : Peano.ℕ) : Peano.ℕ := let n' := n; let m' := m; Peano.add n' m'` and `theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl`. Rules(E) = {δ, ι, ζ}, 7 kernel steps (row 1 + 2 ζ-steps). Header table extended to 6 rows with new `Observation (ζ)` paragraph explaining that ζ is a fourth CIC primitive (not derivable from {β, ι, δ} on closed terms with let-binders, because no β/ι/δ rule has `let` in its LHS pattern). Part 6 docstring updated 'five'→'six' and `#print axioms row5_let` stanza appended. File 187 → 239 lines (+52), 0 sorries, 0 axioms. OQ-04 now saturated at the worked-example level; minimality meta-theorem deferred to OQ-04-OQ-01.",
     "builtItems": [
       "research/problems/russell-1-plus-1-oq-04/problem.md (~210 lines) — expanded problem statement, theoretical framework, representation catalogue, summary table, Principia comparison, Mathlib infrastructure map, next-action decomposition, risk notes.",
       "research/problems/russell-1-plus-1-oq-04/knowledge.md (~200 lines) — S1 entry with taxonomy table, five hand-traces, lower-bound arguments, 6 insights, 3 Mathlib gaps, 5 next steps, risk notes, references.",
@@ -52,7 +52,11 @@
       "**(S3 NEW)** row2_peano_recursor — named theorem for Row 2 (Peano raw recursor; Rules(E) = {δ, ι, β}).",
       "**(S3 NEW)** row3_church — named theorem for Row 3 (Church numerals; Rules(E) = {δ, β}).",
       "**(S3 NEW)** row4_binary — named theorem for Row 4 (binary naturals; Rules(E) = {δ, ι}).",
-      "**(S3 NEW)** Part 6: Axiom-Freedom Verification — five `#print axioms` stanzas confirming each row witness depends on no axioms (propositional dual of the reduction-rule taxonomy)."
+      "**(S3 NEW)** Part 6: Axiom-Freedom Verification — five `#print axioms` stanzas confirming each row witness depends on no axioms (propositional dual of the reduction-rule taxonomy).",
+      "**(S5 NEW)** addLet (def) — Peano.add applied to `let`-bound copies of its arguments; definitionally equal to `Peano.add n m` only after `ζ` fires.",
+      "**(S5 NEW)** row5_let — named theorem `addLet Peano.one Peano.one = Peano.two := rfl` for Row 5 (Peano with let-bound arguments; Rules(E) = {δ, ι, ζ}). 7-step rewrite (row 1's 5 + 2 ζ-steps).",
+      "**(S5 NEW)** Header taxonomy table row 5 + 'Observation (ζ)' paragraph in the file docstring (explaining why ζ is a fourth CIC primitive not derivable from {β, ι, δ} on closed terms with let-binders).",
+      "**(S5 NEW)** Part 6 stanza `#print axioms row5_let` (machine-verifies row5_let depends on no axioms; six row witnesses total)."
     ],
     "insights": [
       "Minimality of Rules(E) is encoding-relative; the same theorem `1+1=2 := rfl` lives at four distinct points in the subset lattice 2^{β,ι,δ,ζ} depending on representation.",
@@ -68,10 +72,12 @@
       "No companion entry to russell-1-plus-1 in the gallery documenting the explicit `rfl` reduction chain (the parent entry mentions ι in passing but does not enumerate the rule set)."
     ],
     "nextSteps": [
-      "S3: Add #print axioms + #reduce stanzas to OnePlusOneOQ04.lean per example, cross-referencing the knowledge.md S1 taxonomy table in the file docstring.",
-      "S4: Add a gallery entry src/data/proofs/russell-1-plus-1-oq-04/ with meta.json + annotations.json + index.ts referencing the worked file.",
-      "S5 (optional): A `let`-binding example demonstrating ζ's role; requires `set_option pp.all true` to render the elaborated term with the visible ζ-redex.",
-      "Deferred → OQ-04-OQ-01: A precise meta-theorem stating Rules(E) (perhaps via a sandboxed kernel parametrised on a subset of {β,ι,δ,ζ}) and proving minimality."
+      "S3 (done, researcher-1): Added #print axioms stanzas + named theorems; Part 6 Axiom-Freedom Verification section.",
+      "S4 (done, researcher-9, PR #18040): Added gallery entry src/data/proofs/russell-1-plus-1-oq-04/.",
+      "S5 (done, researcher-6, this PR): Added ζ-demonstrator row5_let (let-bound addLet definition; Rules(E) = {δ, ι, ζ}); header taxonomy table extended to 6 rows with ζ observation.",
+      "S6 (optional follow-on): `#reduce` stanza per row showing the literal kernel-reduced output; verbose but pedagogically clean for Church / recursor rows.",
+      "S7 (optional follow-on): Kernel-cost timing harness via `set_option trace.profiler true`; empirically reify the step-count column of the taxonomy table.",
+      "Deferred → OQ-04-OQ-01: A precise meta-theorem stating Rules(E) (perhaps via a sandboxed kernel parametrised on a subset of {β,ι,δ,ζ}) and proving minimality. OQ-04 now saturated at the worked-example level."
     ]
   },
   "tags": [
@@ -121,7 +127,7 @@
     "mathlib": []
   },
   "started": "2026-05-12T04:48:16.450Z",
-  "lastUpdate": "2026-05-12T05:30:00Z",
+  "lastUpdate": "2026-05-12T11:30:00Z",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

S5 ACT for `russell-1-plus-1-oq-04`. Adds the **optional ζ-demonstrator row** noted in S1's `nextSteps` and S3/S4 state.md, completing the worked-example level of OQ-04.

- New `def addLet (n m : Peano.ℕ) : Peano.ℕ := let n' := n; let m' := m; Peano.add n' m'`
- New `theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl`
- `Rules(E) = {δ, ι, ζ}` — 7-step kernel rewrite (row 1's 5 steps + 2 ζ-steps)
- Header taxonomy table extended to 6 rows + new **Observation (ζ)** paragraph (why ζ is a *fourth* CIC primitive)
- Part 6 (Axiom-Freedom Verification) updated: `#print axioms row5_let` stanza + docstring "five" → "six"

## Why ζ is essential

Without ζ, the LHS reduces to `let n' := one; let m' := one; Peano.add n' m'` and the kernel cannot continue: ι requires a constructor head, but the redex is blocked by the `let`-binder for `n'`. After ζ fires twice, the term becomes `Peano.add Peano.one Peano.one`, identical to row 1's LHS, which closes on `{δ, ι}`.

This makes ζ a *fourth* primitive of CIC, not derivable from `{β, ι, δ}` on closed terms with let-binders: no β/ι/δ rule has a `let` in its LHS pattern.

## File deltas

- `proofs/Proofs/OnePlusOneOQ04.lean`: 187 → 239 lines (+52), 0 sorries, 0 axioms
- Theorems: 5 → 6 (added `row5_let`)
- Definitions: 7 → 8 (added `addLet`)
- No Mathlib import added (file still depends only on `Proofs.OnePlusOne`)

## Build verification

Verified via `./proofs/scripts/docker-build.sh Proofs.OnePlusOneOQ04` (3 jobs, Mathlib cache hit). All six `#print axioms` stanzas pass:

```
info: 'OnePlusOneOQ04.row0_unfolded'        does not depend on any axioms
info: 'OnePlusOneOQ04.row1_peano_pattern'   does not depend on any axioms
info: 'OnePlusOneOQ04.row2_peano_recursor'  does not depend on any axioms
info: 'OnePlusOneOQ04.row3_church'          does not depend on any axioms
info: 'OnePlusOneOQ04.row4_binary'          does not depend on any axioms
info: 'OnePlusOneOQ04.row5_let'             does not depend on any axioms
```

## OQ-04 status after S5

The OQ-04 question is now **saturated at the worked-example level**: all five rule subsets identified in S1's taxonomy table (∅; {δ, ι}; {δ, ι, β}; {δ, β}; {δ, ι, ζ}) are witnessed by an `:= rfl` Lean theorem, each axiom-free at compile time.

The remaining work — a precise meta-theorem stating `Rules(E)` and proving minimality via a sandboxed kernel parametrised on subsets of `{β, ι, δ, ζ}` — belongs to the child question **OQ-04-OQ-01**.

## Test plan

- [x] Docker build verified locally (3 jobs, Mathlib cache hit, ~3 minutes)
- [x] All six `#print axioms` stanzas confirm axiom-freedom
- [x] No changes to other Lean files (only `Proofs/OnePlusOneOQ04.lean` modified in `proofs/`)
- [x] Problem JSON `currentState.iteration: 3 → 5`, `phase` and `focus` updated
- [x] `research/problems/russell-1-plus-1-oq-04/state.md` updated with S5 summary
- [x] No `loom:review-requested` label (per CLAUDE.md, math agents route through deployer not Judge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)