### PR TITLE
research(knights-tour-oblique-oq-02): S2 ORIENT/ACT — Fintype + distribution + support lemma (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2417,6 +2417,7 @@ import Proofs.IsoscelesTriangleOQ01
 import Proofs.KeplerConjecture
 import Proofs.KnightsTourOblique
 import Proofs.KnightsTourObliqueOQ01
+import Proofs.KnightsTourObliqueOQ02
 import Proofs.Konigsberg
 import Proofs.KonigsbergOQ01
 import Proofs.KonigsbergOQ01OQ02

--- a/proofs/Proofs/KnightsTourObliqueOQ02.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02.lean
@@ -1,0 +1,139 @@
+/-
+  Knight's Tour Oblique Angles: Distribution Structural Skeleton (OQ-02)
+
+  Open question OQ-02: distribution of oblique counts across all closed
+  knight's tours on the 8×8 chessboard. Knuth (2025 Christmas Lecture)
+  proved every tour has ≥ 4 oblique turns and the minimum is achieved by
+  a unique tour up to D4 symmetry. The histogram values
+  `obliqueDistribution 5, 6, …` are unreachable in Lean (would require
+  enumerating ~1.3 × 10^13 tours), but the **structural skeleton** of the
+  distribution — support, D4-orbit divisibility, reversal symmetry — is
+  reachable using only the parent file's existing infrastructure.
+
+  ## What this file provides (S2 ORIENT)
+
+  - A `Fintype` instance for `ClosedTour` (Target A1, prerequisite for the
+    histogram definition; the parent file uses `Classical.choice` and does
+    not expose this).
+  - `obliqueDistribution : ℕ → ℕ` (Target A2): the histogram function
+    defined as a `Finset.filter` over `Finset.univ : Finset ClosedTour`.
+  - `obliqueDistribution_zero_below_four` (Target B): the support lower
+    bound — a direct lift of the parent's `oblique_lower_bound`.
+
+  ## What is deferred to S3+
+
+  - D4 group action on `ClosedTour` and `obliqueCount`-invariance (Target C).
+  - Reversal symmetry `obliqueCount (reverse t) = obliqueCount t` (Target D).
+  - Winding-parity joint constraint on `#turnAngle = 3` and `#turnAngle = 5`
+    sub-distributions (Target E).
+
+  ## Status
+
+  - [x] Fintype instance via injection into `Fin 64 → Square`
+  - [x] Distribution definition
+  - [x] Support lower bound (k < 4)
+  - [ ] D4 invariance (S3)
+  - [ ] Reversal symmetry (S3)
+  - [ ] Winding-parity constraint (S4)
+
+  Parent proof: `KnightsTourOblique.lean` (8×8 minimum + uniqueness).
+  Sibling: `KnightsTourObliqueOQ01.lean` (n×n minimum, n ≥ 5).
+
+  References
+  - Knuth, D. E. (2025). *29th Annual Christmas Lecture: Knight's Tours
+    and Oblique Turns*. Stanford University.
+  - Knuth, D. E. *TAOCP Volume 4, Fascicle 8a: Knight's Tours* (forthcoming).
+-/
+
+import Mathlib
+import Proofs.KnightsTourOblique
+
+namespace KnightsTourOblique
+
+/-!
+## Fintype instance for ClosedTour
+
+`ClosedTour` is a structure with one data field (`squares : List Square`)
+of length 64, plus several propositional fields. To get a `Fintype`
+instance we inject `ClosedTour ↪ (Fin 64 → Square)` by sending a tour to
+its indexing function and use `Fintype.ofInjective`. Two tours with the
+same indexing function have the same `squares` list (by `List.ext_get`),
+and structure-equality of `ClosedTour` is determined by `squares` since
+all other fields are propositions.
+-/
+
+/-- The indexing function of a closed tour: `toFn t i = t.squares[i]`. -/
+def toFn (t : ClosedTour) : Fin 64 → Square := fun i =>
+  t.squares.get ⟨i.val, by rw [t.length_eq]; exact i.isLt⟩
+
+theorem toFn_injective : Function.Injective toFn := by
+  rintro ⟨s1, h1, n1, p1, ne1, c1⟩ ⟨s2, h2, n2, p2, ne2, c2⟩ heq
+  -- First, show the underlying lists are equal.
+  have hsq : s1 = s2 := by
+    apply List.ext_get
+    · exact h1.trans h2.symm
+    · intro i hi1 hi2
+      have hi64 : i < 64 := by rw [h1] at hi1; exact hi1
+      have := congrFun heq ⟨i, hi64⟩
+      simpa [toFn] using this
+  -- Then the propositional fields collapse by proof irrelevance.
+  subst hsq
+  rfl
+
+/-- The set of closed knight's tours on the 8×8 board is finite.
+    `Fintype.ofInjective` is `noncomputable` (uses `Classical.choice`),
+    which is acceptable here because the distribution is studied
+    abstractly — we never reduce `Finset.univ : Finset ClosedTour`
+    computationally. -/
+noncomputable instance : Fintype ClosedTour :=
+  Fintype.ofInjective toFn toFn_injective
+
+/-!
+## The oblique-count distribution
+
+`obliqueDistribution k` counts the closed tours with exactly `k` oblique
+turns. The full histogram is determined by external enumeration (Knuth
+2025, McKay 1997); this file does not commit to those values and instead
+exposes the structural lemmas.
+-/
+
+/-- Number of closed knight's tours with exactly `k` oblique turns.
+    `noncomputable` because it depends on the `Fintype ClosedTour`
+    instance, which uses `Classical.choice`. -/
+noncomputable def obliqueDistribution (k : ℕ) : ℕ :=
+  (Finset.univ.filter (fun t : ClosedTour => obliqueCount t = k)).card
+
+/-!
+## Support lower bound
+
+The first structural fact: the distribution is supported on `k ≥ 4`.
+This is a one-line lift of `oblique_lower_bound : obliqueCount t ≥ 4`
+from the parent file.
+-/
+
+/-- Support lower bound: no tour has fewer than 4 oblique turns. -/
+theorem obliqueDistribution_zero_below_four (k : ℕ) (hk : k < 4) :
+    obliqueDistribution k = 0 := by
+  unfold obliqueDistribution
+  rw [Finset.card_eq_zero]
+  apply Finset.eq_empty_of_forall_not_mem
+  intro t ht
+  rw [Finset.mem_filter] at ht
+  obtain ⟨_, hcount⟩ := ht
+  have hbound : obliqueCount t ≥ 4 := oblique_lower_bound t
+  rw [hcount] at hbound
+  omega
+
+/-- Equivalent statement: the distribution vanishes on `{0, 1, 2, 3}`. -/
+theorem obliqueDistribution_support_le_three :
+    ∀ k, k ≤ 3 → obliqueDistribution k = 0 := fun k hk =>
+  obliqueDistribution_zero_below_four k (Nat.lt_succ_of_le hk)
+
+/-- The unique minimum tour from Knuth's classification (combined with
+    `oblique_lower_bound`) shows the support is non-empty at `k = 4`. The
+    concrete value `obliqueDistribution 4` is determined by the D4-orbit
+    of `minimalObliqueTour` (the parent's canonical witness) and is at
+    most 8 — but the exact value depends on Knuth's classification of
+    self-symmetric tours, which is deferred to S3. -/
+
+end KnightsTourOblique

--- a/research/problems/knights-tour-oblique-oq-02/knowledge.md
+++ b/research/problems/knights-tour-oblique-oq-02/knowledge.md
@@ -89,3 +89,76 @@ and the trivial support lemma; defer the harder D4 invariance to S3.
 - Zero axioms anticipated for the structural lemmas (support, D4-mod-8,
   reversal-mod-2, winding-parity). All are derivable from parent's
   existing infrastructure.
+
+## Iteration 2 (researcher-8, 2026-05-12) — S2 ORIENT/ACT
+
+**Outcome**: Lean changes shipped — built the `Fintype` instance, the
+distribution definition, and the support lower bound. 0 sorries, 0 new
+axioms.
+
+### What got built (concrete file deltas)
+
+`proofs/Proofs/KnightsTourObliqueOQ02.lean` (new, ~130 lines):
+
+- `def toFn (t : ClosedTour) : Fin 64 → Square` — indexing function
+  `fun i => t.squares.get ⟨i.val, by rw [t.length_eq]; exact i.isLt⟩`.
+- `theorem toFn_injective` — destructure both tours, extract
+  `s1 = s2` via `List.ext_get` from the pointwise function equality,
+  then collapse the propositional fields via `subst` + `rfl` (proof
+  irrelevance).
+- `instance : Fintype ClosedTour := Fintype.ofInjective toFn
+  toFn_injective` — the prerequisite for the histogram definition.
+- `def obliqueDistribution (k : ℕ) : ℕ` —
+  `(Finset.univ.filter (fun t => obliqueCount t = k)).card`.
+- `theorem obliqueDistribution_zero_below_four` — `k < 4` →
+  `obliqueDistribution k = 0`. Proof: `Finset.card_eq_zero` +
+  `Finset.eq_empty_of_forall_not_mem` + the parent's
+  `oblique_lower_bound`.
+- `theorem obliqueDistribution_support_le_three` — restatement in the
+  `k ≤ 3` form.
+
+`proofs/Proofs.lean` — registered the new module.
+
+### Why this matches the S1 plan
+
+S1 flagged the `Fintype ClosedTour` gap and identified
+`Fin 64 → Square` as the natural injection target. The S2 deliverable
+does exactly that — no surprises, no rework of S1's framing. The S1
+sorries / axioms anticipated table holds: 0 new axioms, the histogram
+is defined parametrically without committing to a concrete total.
+
+### What did NOT need to change in the parent
+
+The parent file `Proofs/KnightsTourOblique.lean` is untouched. The
+injection `ClosedTour ↪ (Fin 64 → Square)` is built externally without
+adding new fields to the structure or changing the `obliqueCount`
+definition. This isolates the OQ02 work from any risk of breaking the
+parent's existing proof of `oblique_lower_bound`.
+
+### Honest contribution assessment
+
+The Fintype instance is straightforward Lean engineering (an
+`ofInjective` + a `List.ext_get` argument), not deep mathematics. The
+support lower bound is a one-line lift. The substantive mathematical
+content (D4 invariance, reversal symmetry, winding-parity) is **all
+deferred to S3+**. That said, without the Fintype instance, the
+distribution cannot be defined at all in Lean — so this S2 is the
+necessary prerequisite work, not a stopping point.
+
+### Anticipated S3 work
+
+The D4 action requires lifting the 8 generators of D4 from `Square` to
+`ClosedTour`. The key technical step is showing that each generator
+preserves the closed-tour structure (path / closure / nodup). Once we
+have the action, `obliqueCount`-invariance is a one-step calculation
+because `isOblique` is symmetric and rotation-invariant on
+`MoveVector × MoveVector`. The orbit-stabilizer mod-8 divisibility is a
+direct corollary, with the self-symmetric exceptions deferred to S4.
+
+### Build verification
+
+Build pending — Docker build is queued. The file uses only the parent's
+public API (`ClosedTour`, `obliqueCount`, `oblique_lower_bound`) plus
+standard Mathlib (`Finset.filter`, `Fintype.ofInjective`,
+`List.ext_get`, `Finset.card_eq_zero`,
+`Finset.eq_empty_of_forall_not_mem`, `Finset.mem_filter`). No new axioms.

--- a/research/problems/knights-tour-oblique-oq-02/state.md
+++ b/research/problems/knights-tour-oblique-oq-02/state.md
@@ -1,71 +1,83 @@
 # Current State
 
-**Phase**: OBSERVE (S1 scaffold complete; no Lean changes yet)
-**Since**: 2026-05-12T10:10:00Z
-**Last Updated**: 2026-05-12 (Iteration 1, researcher-1)
-**Iteration**: 1
+**Phase**: ORIENT (S2 ACT — Fintype + distribution + support lemma)
+**Since**: 2026-05-12T11:35:00Z
+**Last Updated**: 2026-05-12 (Iteration 2, researcher-8)
+**Iteration**: 2
 
-## Iteration 1 (researcher-1, 2026-05-12) — S1 OBSERVE
+## Iteration 2 (researcher-8, 2026-05-12) — S2 ORIENT / ACT
 
-**Outcome**: scaffold — created `problem.md`, `knowledge.md`, `state.md`,
-and `src/data/research/problems/knights-tour-oblique-oq-02.json`. No Lean
-changes.
+**Outcome**: built — created `proofs/Proofs/KnightsTourObliqueOQ02.lean`
+with the `Fintype ClosedTour` instance, the histogram definition
+`obliqueDistribution : ℕ → ℕ`, and the support lower bound
+(`obliqueDistribution k = 0` for `k < 4`). 0 sorries. Defers D4
+invariance and reversal symmetry to S3 as planned in S1.
 
 ### What I added
 
-Doc-only scaffolding for a fresh tier-B slug. The deliverable is:
+- `proofs/Proofs/KnightsTourObliqueOQ02.lean` (~130 lines, 0 sorries)
+  - `def toFn : ClosedTour → (Fin 64 → Square)` — indexing function
+  - `theorem toFn_injective` — by `List.ext_get` on the underlying
+    `squares` list + proof irrelevance for the propositional fields
+  - `instance : Fintype ClosedTour` — `Fintype.ofInjective toFn`
+  - `def obliqueDistribution (k : ℕ) : ℕ` —
+    `(Finset.univ.filter (obliqueCount · = k)).card`
+  - `theorem obliqueDistribution_zero_below_four` — lifts parent's
+    `oblique_lower_bound` to the histogram
+  - `theorem obliqueDistribution_support_le_three` — restatement
+- Registered the module in `proofs/Proofs.lean`.
 
-- A precise framing of "what is the distribution of oblique counts" as a
-  function `obliqueDistribution : ℕ → ℕ` that maps `k` to the number of
-  closed knight's tours with exactly `k` oblique turns.
-- A tractability triage that distinguishes the **histogram values** (not
-  feasible in Lean — requires enumerating ~1.3 × 10^13 tours) from the
-  **structural symmetries** (feasible — D4 invariance, reversal symmetry,
-  winding-parity, support bounds).
-- A survey of the parent infrastructure (`Proofs/KnightsTourOblique.lean`,
-  2469 lines, 1 axiom) that the OQ-02 work can directly re-use:
-  `obliqueCount`, `tourMoves`, `turnAngle`, `tour_winding_zero`,
-  `no_turn_angle_4_all`.
-- A concrete S2 plan: build a new `Proofs/KnightsTourObliqueOQ02.lean`,
-  define `obliqueDistribution`, re-export the minimum theorem as a
-  support lemma, defer D4 invariance to S3.
+### Why these pieces, in this order
 
-### Why not S2 in this session
+S1's plan flagged the `Fintype ClosedTour` gap as the prerequisite
+blocker for defining the distribution. With `ClosedTour` constructed via
+a `Classical.choice`-style structure (proof-irrelevant fields after
+`squares : List Square`), the cleanest injection is into
+`Fin 64 → Square` via the indexing function: this target is a `Fintype`
+since `Square = Fin 8 × Fin 8` is, and the injection is straightforward
+to verify (`List.ext_get` on the data, proof irrelevance on the props).
 
-S2 ORIENT requires resolving the `Fintype ClosedTour` instance question
-(the parent file uses `Classical.choice` to express tours; an explicit
-`Fintype` instance needs `ClosedTour` recast as a subtype of `Vector
-Square 64`). That refactor touches the parent file and is best done as a
-focused S2 PR rather than bundled with the OBSERVE scaffold.
+The support lower bound is a one-line lift of the parent's
+`oblique_lower_bound : obliqueCount t ≥ 4`. Combining the two gives the
+first non-trivial structural fact about the distribution.
 
-### Files added (S1)
+### What this does NOT do (deferred to S3+)
 
-- `research/problems/knights-tour-oblique-oq-02/problem.md` — problem
-  description with tractability triage, references, parent linkage
-- `research/problems/knights-tour-oblique-oq-02/knowledge.md` — parent
-  infrastructure survey, feasibility table, S2 plan
-- `research/problems/knights-tour-oblique-oq-02/state.md` — this file
-- `src/data/research/problems/knights-tour-oblique-oq-02.json` — phase
-  OBSERVE, iter 1, references, knowledge surface
+- **D4 group action on `ClosedTour`** (Target C) — the 8-element
+  dihedral group acts by board symmetries, and `obliqueCount` is
+  invariant. This is the main S3 deliverable (~80-line lemma).
+- **Reversal symmetry** (Target D) — `obliqueCount (reverse t) =
+  obliqueCount t`. Roughly 30 lines once we have a `reverse : ClosedTour
+  → ClosedTour` definition.
+- **Winding-parity joint constraint** (Target E) — uses
+  `tour_winding_zero` + `no_turn_angle_4_all` to constrain `#turnAngle =
+  3` and `#turnAngle = 5` modulo 8.
 
-### Next action (S2 ORIENT)
+### Next action (S3 ORIENT)
 
-Create `proofs/Proofs/KnightsTourObliqueOQ02.lean` with:
+Define the D4 group action on `ClosedTour`:
 
-1. A `Fintype` instance for `ClosedTour` (either as a `decEq` subtype of
-   `Vector Square 64`, or via a separate definition aligning with the
-   parent's structure).
-2. `def obliqueDistribution : ℕ → ℕ`.
-3. `theorem obliqueDistribution_zero_below_four : ∀ k < 4,
-   obliqueDistribution k = 0` (one-line lift from parent's minimum
-   theorem).
-4. Stubs for the D4 invariance and reversal-symmetry theorems to be
-   filled in S3.
+1. Implement the 8-element generator set on `Square` (horizontal
+   reflection, vertical reflection, 90° rotation, and compositions).
+2. Lift each generator to a map `ClosedTour → ClosedTour` by mapping the
+   `squares` list pointwise. Verify path/closure/nodup preservation.
+3. Prove `obliqueCount`-invariance: the dot products of consecutive move
+   vectors are preserved by each symmetry generator.
+4. State the D4-mod-8 divisibility consequence, leaving the
+   self-symmetric-tour exception set as a sorried lemma for S4.
 
-Estimated S2 ACT size: ~100-150 lines, 0 sorries on the support lemma,
-1-2 sorries on the D4 / reversal stubs (deferred to S3).
+Estimated S3 size: ~150-200 lines, with possibly 1 sorry for the
+self-symmetric-tour exception (which Knuth's classification needs).
+
+### Build status
+
+Build pending. The parent `Proofs/KnightsTourOblique.lean` builds clean
+on origin/main, and the OQ02 file uses only its public surface
+(`ClosedTour`, `obliqueCount`, `oblique_lower_bound`) plus standard
+Mathlib (`Finset.filter`, `Fintype.ofInjective`, `List.ext_get`). No new
+axioms.
 
 ### Blockers
 
-None for the structural-skeleton portion. The histogram values are
-out-of-scope (require external enumeration).
+None. The D4 action and reversal symmetry are next-iteration work, not
+blockers.

--- a/src/data/research/problems/knights-tour-oblique-oq-02.json
+++ b/src/data/research/problems/knights-tour-oblique-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "knights-tour-oblique-oq-02",
   "title": "Distribution of oblique counts across all 13+ trillion closed knight's tours (8×8)",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "structural-skeleton",
@@ -34,32 +34,43 @@
     "goal": "Build the structural skeleton of the oblique-count distribution — support, D4-mod-8, reversal-mod-2, winding-parity — derivable from the existing infrastructure in `KnightsTourOblique.lean` without enumeration."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T10:10:00.000Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE (researcher-1, 2026-05-12) — doc-only scaffold. Created problem.md, knowledge.md, state.md, this JSON. No Lean changes. Identified what is and is not Lean-tractable: structural symmetries (support bounds, D4 invariance, reversal symmetry, winding-parity) are reachable; histogram values are not (require enumerating ~1.3 × 10^13 tours). Surveyed parent infrastructure in `KnightsTourOblique.lean` — the existing `obliqueCount`, `tour_winding_zero`, `no_turn_angle_4_all` give exactly the primitives needed.",
+    "phase": "ORIENT",
+    "since": "2026-05-12T11:35:00.000Z",
+    "iteration": 2,
+    "focus": "S2 ORIENT/ACT (researcher-8, 2026-05-12) — built proofs/Proofs/KnightsTourObliqueOQ02.lean (~130 lines, 0 sorries, 0 new axioms): Fintype ClosedTour via injection into Fin 64 → Square, def obliqueDistribution : ℕ → ℕ as Finset.filter over the new Fintype.univ, theorem obliqueDistribution_zero_below_four lifting parent oblique_lower_bound, plus the k ≤ 3 restatement. Registered in Proofs.lean. Parent file untouched.",
     "blockers": [],
-    "nextAction": "S2 ORIENT: create `proofs/Proofs/KnightsTourObliqueOQ02.lean`. Add a `Fintype ClosedTour` instance (the parent uses `Classical.choice`; we need an explicit instance to define the distribution as a `Finset.filter` count). Define `obliqueDistribution : ℕ → ℕ`. Prove `obliqueDistribution k = 0` for `k < 4` by lifting parent's minimum theorem. Estimated 100-150 lines, 0 sorries on the support lemma. Defer D4 invariance to S3.",
+    "nextAction": "S3 ORIENT: define the D4 group action on ClosedTour (8 generators on Square lifted pointwise via squares-list map, preserving path/closure/nodup). Prove obliqueCount is D4-invariant (dot product of consecutive moves is rotation/reflection-symmetric). State the orbit-size-divides-8 corollary and the resulting mod-8 divisibility of obliqueDistribution k generically. Defer self-symmetric tour exceptions to S4. Estimated 150-200 lines, possibly 1 sorry on the self-symmetric set classification.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (researcher-1, 2026-05-12): fresh tier-B slug. Doc-only scaffolding establishing the formal target `obliqueDistribution : ℕ → ℕ`, the tractability triage (structural symmetries are Lean-feasible; histogram values are not), and the S2 plan (introduce `Fintype ClosedTour` + define the distribution + lift the minimum theorem). Identified the parent's `obliqueCount`, `tour_winding_zero`, `no_turn_angle_4_all`, and `oblique_iff_large_turn` as the primitives that the OQ-02 work will compose. No Lean changes this session.",
+    "progressSummary": "S2 ORIENT/ACT (researcher-8, 2026-05-12): shipped the prerequisite Lean infrastructure. Created Proofs/KnightsTourObliqueOQ02.lean with the Fintype ClosedTour instance (via Fintype.ofInjective into Fin 64 → Square, using List.ext_get for injection proof), the histogram definition obliqueDistribution : ℕ → ℕ, and the support lower bound obliqueDistribution k = 0 for k < 4 (lifted from parent oblique_lower_bound). 0 sorries on the file, 0 new axioms. Parent KnightsTourOblique.lean untouched. Next: D4 group action (S3).",
     "builtItems": [
       "research/problems/knights-tour-oblique-oq-02/problem.md — problem description, tractability triage, parent linkage, references (Knuth 2025, Loebbing-Wegener 1996, McKay 1997)",
       "research/problems/knights-tour-oblique-oq-02/knowledge.md — parent infrastructure survey (`obliqueCount`, `tourMoves`, `turnAngle`, `tour_winding_zero`, `no_turn_angle_4_all`), feasibility table, sorries/axioms anticipated",
       "research/problems/knights-tour-oblique-oq-02/state.md — phase OBSERVE, S2 plan",
-      "src/data/research/problems/knights-tour-oblique-oq-02.json — this file"
+      "src/data/research/problems/knights-tour-oblique-oq-02.json — this file",
+      "proofs/Proofs/KnightsTourObliqueOQ02.lean — new file, ~130 lines",
+      "def toFn (t : ClosedTour) : Fin 64 → Square — indexing function",
+      "theorem toFn_injective : Function.Injective toFn — by List.ext_get + proof irrelevance",
+      "noncomputable instance : Fintype ClosedTour — via Fintype.ofInjective",
+      "noncomputable def obliqueDistribution (k : ℕ) : ℕ — Finset.univ.filter (· = k) |>.card",
+      "theorem obliqueDistribution_zero_below_four (k : ℕ) (hk : k < 4) : obliqueDistribution k = 0",
+      "theorem obliqueDistribution_support_le_three : ∀ k ≤ 3, obliqueDistribution k = 0",
+      "proofs/Proofs.lean — registered the new module"
     ],
     "insights": [
       "The full histogram is unreachable in Lean (1.3 × 10^13 tours), but the *structural skeleton* of the distribution — support, D4 invariance, reversal symmetry, winding-parity — is reachable using only the parent's existing infrastructure.",
       "D4 invariance + orbit-stabilizer gives `obliqueDistribution k ≡ 0 mod 8` generically; the only exceptions are tours fixed by a non-identity D4 element (symmetric tours). For the minimum k=4, Knuth's uniqueness theorem implies the orbit has size 8 (or a divisor, with the divisor case meaning the unique tour is itself D4-symmetric — a sharp question Knuth answered negatively).",
       "Reversal symmetry pairs every tour with its reverse, both having the same `obliqueCount`. Generically forces `obliqueDistribution k ≡ 0 mod 2`. Palindromic tours are the exceptions.",
       "The winding constraint `tour_winding_zero` + `no_turn_angle_4_all` (no 180° turn) restricts oblique turn angles to `{3, 5}` (both odd, equivalent to `±3 mod 8`). This gives a joint constraint on `#turnAngle = 3` and `#turnAngle = 5` that is more refined than a simple parity statement on `obliqueCount = #{turnAngle = 3} + #{turnAngle = 5}`.",
-      "The parent file uses `Classical.choice` to express closed tours; defining `obliqueDistribution` as a `Finset.filter` count requires either a separate `Fintype ClosedTour` derivation (e.g., as a subtype of `Vector Square 64` plus the closure and bijection constraints) or a parametric statement that never instantiates the cardinality. The parametric route is cleaner."
+      "The parent file uses `Classical.choice` to express closed tours; defining `obliqueDistribution` as a `Finset.filter` count requires either a separate `Fintype ClosedTour` derivation (e.g., as a subtype of `Vector Square 64` plus the closure and bijection constraints) or a parametric statement that never instantiates the cardinality. The parametric route is cleaner.",
+      "Fintype ClosedTour is achievable by injection into Fin 64 → Square (Square = Fin 8 × Fin 8 is a Fintype). The injection proof reduces to two parts: (1) List.ext_get gives s1 = s2 from pointwise function equality, (2) propositional fields of the ClosedTour structure collapse via proof irrelevance after subst.",
+      "The Fintype instance must be noncomputable because Fintype.ofInjective relies on Classical.choice. This propagates: obliqueDistribution is also noncomputable. This is acceptable for the structural-skeleton scope (we never reduce the histogram values computationally; concrete values come from external enumeration).",
+      "The support lower bound is a one-line lift: obliqueDistribution k = 0 iff the filtered set is empty, and the filtered set is empty when oblique_lower_bound rules out obliqueCount t = k for k < 4."
     ],
     "mathlibGaps": [
       "No `Fintype` instance for `ClosedTour` in the parent file. The parent uses `Classical.choice` for existential extraction; OQ-02 needs an explicit `Fintype` (or a parametric workaround).",


### PR DESCRIPTION
## Summary

S2 ORIENT/ACT for `knights-tour-oblique-oq-02` — the distribution of oblique counts across all closed knight's tours on the 8×8 chessboard (Knuth 2025, TAOCP Vol 4 Fascicle 8a).

Builds the prerequisite Lean infrastructure called for by S1 (#18046, researcher-1): a `Fintype` instance for `ClosedTour`, the histogram definition, and the support lower bound.

## What this adds

New file `proofs/Proofs/KnightsTourObliqueOQ02.lean` (~130 lines, 0 sorries, 0 new axioms):

- `def toFn (t : ClosedTour) : Fin 64 → Square` — the indexing function `fun i => t.squares.get ⟨i.val, ...⟩`.
- `theorem toFn_injective : Function.Injective toFn` — destructures both tours, extracts `s1 = s2` via `List.ext_get` from the pointwise function equality, then collapses the propositional fields by `subst` + `rfl` (definitional proof irrelevance).
- `noncomputable instance : Fintype ClosedTour := Fintype.ofInjective toFn toFn_injective` — the prerequisite for defining the histogram. `noncomputable` because `Fintype.ofInjective` relies on `Classical.choice`; acceptable here because we never reduce the distribution computationally (concrete histogram values come from external enumeration, not from Lean).
- `noncomputable def obliqueDistribution (k : ℕ) : ℕ := (Finset.univ.filter (fun t : ClosedTour => obliqueCount t = k)).card` — the histogram function.
- `theorem obliqueDistribution_zero_below_four (k : ℕ) (hk : k < 4) : obliqueDistribution k = 0` — the support lower bound. Proof: `Finset.card_eq_zero` + `Finset.eq_empty_of_forall_not_mem` + the parent's `oblique_lower_bound : obliqueCount t ≥ 4` (which forces a contradiction with `obliqueCount t = k < 4`).
- `theorem obliqueDistribution_support_le_three : ∀ k ≤ 3, obliqueDistribution k = 0` — restatement.

Module registered in `proofs/Proofs.lean`.

## Why this is the right S2 deliverable

S1 (#18046) identified the `Fintype ClosedTour` gap as the prerequisite blocker for defining the distribution at all: the parent file uses `Classical.choice`-style reasoning and does not expose a Fintype instance. The S2 plan was explicit:

> Create `proofs/Proofs/KnightsTourObliqueOQ02.lean` with:
> 1. A `Fintype` instance for `ClosedTour`
> 2. `def obliqueDistribution : ℕ → ℕ`
> 3. `theorem obliqueDistribution_zero_below_four`
> 4. Defer D4 invariance to S3.

This PR delivers exactly that — the file is the structural-skeleton infrastructure, with mathematical content (D4 invariance, reversal symmetry, winding-parity) explicitly deferred to S3+.

## What this does NOT do (deferred)

- **D4 group action** (S3): lift the 8 generators of the dihedral group from `Square` to `ClosedTour`, prove `obliqueCount`-invariance, conclude mod-8 divisibility (modulo self-symmetric exceptions).
- **Reversal symmetry** (S3): show `obliqueCount (reverse t) = obliqueCount t` and conclude generic mod-2 divisibility.
- **Winding-parity joint constraint** (S4): use `tour_winding_zero` + `no_turn_angle_4_all` to constrain the joint distribution of `#turnAngle = 3` and `#turnAngle = 5`.

## Honest contribution assessment

The Fintype instance is straightforward Lean engineering — `Fintype.ofInjective` + a `List.ext_get` injection argument — not deep mathematics. The support lower bound is a one-line lift of the parent's `oblique_lower_bound`. The substantive mathematical content (D4 invariance, reversal symmetry, winding-parity) is all deferred to S3+. But without the Fintype instance, the distribution cannot be defined at all in Lean, so this is the necessary prerequisite work.

## Parent file impact

`proofs/Proofs/KnightsTourOblique.lean` is **untouched**. The injection `ClosedTour ↪ (Fin 64 → Square)` is built externally without adding fields to the structure or modifying `obliqueCount`. This isolates the OQ02 work from any risk of breaking the parent's existing proof of `oblique_lower_bound` / `unique_minimum_oblique_tour`.

## Test plan

- [ ] Build verifies (docker build kicked off in background; will report status in follow-up if it completes within the PR review window)
- [ ] `proofs/Proofs/KnightsTourObliqueOQ02.lean` uses only public parent API + standard Mathlib
- [ ] 0 sorries on the file
- [ ] 0 new axioms (parent axiom `knuth_unique_four_oblique` is not used by S2)
- [ ] No `loom:review-requested` label (math agents per CLAUDE.md)

## Status

**Outcome**: progress (S2 → S3 next)
**Next Steps**: S3 ORIENT — define the D4 group action, prove `obliqueCount`-invariance, conclude mod-8 divisibility.

🤖 Generated by researcher-8