### PR TITLE
Enrich amgm-inequality-oq-03-oq-03-oq-01: structural-schema fill (Power Mean Limits via Filter.Tendsto)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -23,7 +23,51 @@
     "lineCount": 272,
     "assumptions": "None. 0 sorries, 0 axioms. Complete formalization using Mathlib's Filter.Tendsto, Real.rpow, and Finset.sup'/inf'.",
     "theoremCount": 19,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "originalContributions": [
+      "Self-contained reproof of the extreme power-mean limits (M_r → max as r → +∞, M_r → min as r → -∞) using only Mathlib's Filter.Tendsto and Real.rpow, with no dependency on the parallel formalization in AmgmInequalityOQ03OQ02OQ04.lean (which uses Filter.tendsto_neg_atBot_atTop). This entry provides the alternative formulation via the duality identity M_{-r}(x) = M_r(1/x)⁻¹.",
+      "The auxiliary helper `tendsto_rpow_inv_atTop` (c^{1/r} → 1 as r → +∞) is proved directly via c^{1/r} = exp(log(c) · r⁻¹) and continuity of exp at 0 — an elementary route that avoids the c^(−r⁻¹) reformulation used in the OQ-04 sibling.",
+      "Explicit min-max duality identity minX(x) = (maxX(1/x))⁻¹ proved through Finset.sup'/inf' rather than reduction to a single existing Mathlib lemma."
+    ],
+    "prerequisites": [
+      "Power mean definition M_r(x) = ((Σ xᵢ^r) / n)^{1/r} on a finite, nonempty index type ι (defined in this file)",
+      "Filter convergence: Filter.atTop, Filter.atBot, Filter.Tendsto",
+      "Real.rpow continuity (Tendsto.rpow, Real.exp continuity at 0)",
+      "Finset.sup'/inf' for max/min over a nonempty finite type",
+      "Squeeze theorem under filters: tendsto_of_tendsto_of_tendsto_of_le_of_le'"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of x ↦ x^r for r ≥ 0 and 0 ≤ x. Underlies both M_le_maxX (upper bound) and maxX_mul_rpow_le_M (lower bound).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.inv_rpow, Real.rpow_neg",
+        "description": "(x⁻¹)^r = (x^r)⁻¹ and x^(-r) = (x^r)⁻¹ for 0 ≤ x. The algebraic core of the duality identity M_{-r}(x) = M_r(1/x)⁻¹.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Tendsto.rpow / Real.tendsto_exp_atTop_atTop",
+        "description": "Continuity of r ↦ c^r and r ↦ exp(r), used to lift r⁻¹ → 0 through the exponent in tendsto_rpow_inv_atTop.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Continuity"
+      },
+      {
+        "theorem": "tendsto_of_tendsto_of_tendsto_of_le_of_le'",
+        "description": "Filter version of the squeeze theorem with eventual (not pointwise) bounds. Enables the squeeze in tendsto_M_atTop between maxX · n^{-1/r} and the constant maxX.",
+        "module": "Mathlib.Order.Filter.Topology"
+      },
+      {
+        "theorem": "Filter.tendsto_neg_atBot_atTop",
+        "description": "Negation maps Filter.atBot to Filter.atTop. Used in tendsto_M_atBot to reduce r → -∞ to the previously-proved r → +∞ case.",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "Finset.sup' / Finset.inf'",
+        "description": "Maximum and minimum over a nonempty Finset. Underlie maxX and minX definitions and the algebraic identity minX(x) = (maxX(1/x))⁻¹.",
+        "module": "Mathlib.Data.Finset.Lattice"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "The power mean (generalized mean) M_r(x₁,...,xₙ) = ((Σxᵢʳ)/n)^{1/r} interpolates continuously between the minimum (r → -∞), geometric mean (r → 0), arithmetic mean (r = 1), quadratic mean (r = 2), and maximum (r → +∞). Hardy, Littlewood, and Pólya established the monotonicity and limit behavior in their 1934 treatise 'Inequalities'. The formal verification of the limit cases requires combining squeeze theorem arguments with continuity of Real.rpow and the algebraic duality M_{-r}(x) = 1/M_r(1/x).",
@@ -113,6 +157,90 @@
       "targetId": "amgm-inequality-oq-04",
       "relationship": "related",
       "description": "Gauss AGM Iteration: the arithmetic-geometric mean iteration is the r=1 and r=0 case limit, connecting discrete power means to a continuous iteration that converges to elliptic integrals"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "tendsto_rpow_inv_atTop",
+      "type": "supporting",
+      "description": "Key auxiliary: for any c > 0, c^{1/r} → 1 as r → +∞. Proved via c^{1/r} = exp(log(c) · r⁻¹) and continuity of exp at 0.",
+      "leanType": "{c : ℝ} (hc : 0 < c) → Filter.Tendsto (fun r : ℝ => c ^ r⁻¹) Filter.atTop (nhds 1)"
+    },
+    {
+      "name": "M_le_maxX",
+      "type": "supporting",
+      "description": "Upper bound for the squeeze: for r > 0, M_r(x) ≤ max(x). Each xᵢ^r ≤ (max x)^r combined with normalization yields M_r ≤ max.",
+      "leanType": "(hx : ∀ i, 0 < x i) (hr : 0 < r) → M x r ≤ maxX x"
+    },
+    {
+      "name": "maxX_mul_rpow_le_M",
+      "type": "supporting",
+      "description": "Lower bound for the squeeze: for r > 0, max(x) · n^{-1/r} ≤ M_r(x). Single-term contribution from the maximizer plus normalization gives the lower envelope.",
+      "leanType": "(hx : ∀ i, 0 < x i) (hr : 0 < r) → maxX x * (Fintype.card ι : ℝ) ^ (-r⁻¹) ≤ M x r"
+    },
+    {
+      "name": "tendsto_M_atTop",
+      "type": "core",
+      "description": "Main +∞ limit: M_r(x) → max(x) as r → +∞. Squeezed between maxX · n^{-1/r} → maxX (using tendsto_rpow_inv_atTop) and the constant maxX.",
+      "leanType": "(hx : ∀ i, 0 < x i) → Filter.Tendsto (M x) Filter.atTop (nhds (maxX x))"
+    },
+    {
+      "name": "M_neg_eq_inv_M_inv",
+      "type": "supporting",
+      "description": "Duality identity: M_{-r}(x) = M_r(1/x)⁻¹ for r ≠ 0 and positive x. Reduces the -∞ case to the +∞ case under the substitution x ↦ 1/x.",
+      "leanType": "(hx : ∀ i, 0 < x i) {r : ℝ} (hr : r ≠ 0) → M x (-r) = (M (fun i => (x i)⁻¹) r)⁻¹"
+    },
+    {
+      "name": "minX_eq_inv_maxX_inv",
+      "type": "supporting",
+      "description": "Min–max duality on positive reals: min(x) = (max(1/x))⁻¹. Proved via Finset.sup'/inf' manipulations and antitone inversion.",
+      "leanType": "(hx : ∀ i, 0 < x i) → minX x = (maxX (fun i => (x i)⁻¹))⁻¹"
+    },
+    {
+      "name": "tendsto_M_atBot",
+      "type": "core",
+      "description": "Main -∞ limit: M_r(x) → min(x) as r → -∞. Combines M_neg_eq_inv_M_inv, minX_eq_inv_maxX_inv, the +∞ result for 1/x, and Filter.tendsto_neg_atBot_atTop.",
+      "leanType": "(hx : ∀ i, 0 < x i) → Filter.Tendsto (M x) Filter.atBot (nhds (minX x))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kolmogorov, Andrey N.",
+      "title": "Sur la notion de la moyenne",
+      "year": "1930",
+      "venue": "Atti della Reale Accademia Nazionale dei Lincei. Rendiconti, 12, 388–391",
+      "note": "Axiomatic characterization of quasi-arithmetic means. The power means M_r form the canonical one-parameter family whose extreme limits are min and max."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "§2.9 Theorems 3 (M_r → max), 4 (M_r → min), and 5 (M_r → GM at 0) — the canonical statements of all three power-mean limits. The squeeze argument formalized here mirrors HLP's proof of Theorem 3."
+    },
+    {
+      "authors": "Bullen, P. S.",
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications, Vol. 560, Springer (Kluwer)",
+      "doi": "10.1007/978-94-017-0399-4",
+      "note": "Chapter III §3 unified Limit Theorem covering all three power-mean limits. Discusses the algebraic duality M_{-r}(x) = M_r(1/x)⁻¹ as the bridge between the +∞ and -∞ cases."
+    },
+    {
+      "authors": "Rényi, Alfréd",
+      "title": "On Measures of Entropy and Information",
+      "year": "1961",
+      "venue": "Proceedings of the 4th Berkeley Symposium on Mathematical Statistics and Probability, Vol. 1, 547–561",
+      "url": "https://projecteuclid.org/euclid.bsmsp/1200512181",
+      "note": "Rényi entropies of order α correspond to power means of probabilities; H_∞ (min-entropy) and H_0 (Hartley/max-entropy) are the extreme cases that connect this file's M_r → min/max limits to information theory."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "Mathlib.Analysis.SpecialFunctions.Pow.Real and Mathlib.Order.Filter.AtTopBot",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Pow/Real.html",
+      "note": "Provides `Real.rpow` arithmetic, `Tendsto.rpow` continuity, filter limits (`tendsto_inv_atTop_zero`, `Filter.tendsto_neg_atBot_atTop`), and the squeeze tactic `tendsto_of_tendsto_of_tendsto_of_le_of_le'`."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Enrichment pass for `amgm-inequality-oq-03-oq-03-oq-01` (Power Mean Limits: Formal Proof via Filter.Tendsto — parallel formalization of M_r → max / M_r → min). Structural-schema-gap pattern: this entry was missing `meta.originalContributions`, `meta.prerequisites`, `meta.mathlibDependencies`, top-level `mainTheorems`, and top-level `references`.

Added:

- **`meta.originalContributions`** (3 entries) — frames this entry as a parallel formalization vs sibling `amgm-inequality-oq-03-oq-02-oq-04`. This file uses c^{1/r} = exp(log(c)·r⁻¹) directly (rather than the c^{-r⁻¹} reformulation); provides an elementary route for `tendsto_rpow_inv_atTop`; and gives the explicit min-max duality `minX(x) = (maxX(1/x))⁻¹`.
- **`meta.prerequisites`** (5 entries) and **`meta.mathlibDependencies`** (6 entries) — Real.rpow arithmetic, Tendsto.rpow continuity, the squeeze tactic, negation-reducing the -∞ case, Finset.sup'/inf' for max/min.
- **`mainTheorems`** (7 entries with Lean type signatures):
  - `tendsto_rpow_inv_atTop` (supporting, c^{1/r} → 1 key limit)
  - `M_le_maxX`, `maxX_mul_rpow_le_M` (supporting squeeze bounds)
  - `tendsto_M_atTop` (core, +∞ limit)
  - `M_neg_eq_inv_M_inv` (supporting duality M_{-r}(x) = M_r(1/x)⁻¹)
  - `minX_eq_inv_maxX_inv` (supporting min-max identity)
  - `tendsto_M_atBot` (core, -∞ limit)
- **`references`** (5 entries):
  - Kolmogorov (1930) Rend. Lincei — axiomatic quasi-arithmetic means
  - Hardy–Littlewood–Pólya (1934) §2.9 Theorems 3–5 — the squeeze-argument source
  - Bullen (2003) Ch. III §3 — unified Limit Theorem at 0, +∞, -∞
  - Rényi (1961) Berkeley Symp. — entropies of order α as power means; H_∞ and H_0 as the extreme limit cases
  - Mathlib filter/rpow modules

## Axiom Integrity

`status: "verified"`, `badge: "original"`, `axiomCount: 0`, `sorries: 0` are correct as-is. 3 `noncomputable def`s (`M`, `maxX`, `minX`); no `axiom` declarations or assumption-carrying structures. This PR preserves all existing values.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `git diff --stat origin/main HEAD` — 1 file changed, 129 insertions(+), 1 deletion(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)