### PR TITLE
research(general-quartic-oq-02): S2 SCAFFOLD — biquadratic-limit (build verified, 1 sorry deferred)

### DIFF
--- a/proofs/Proofs/GeneralQuartic.lean
+++ b/proofs/Proofs/GeneralQuartic.lean
@@ -317,6 +317,71 @@ theorem biquadratic_simple (p r : ℂ) :
     -- Apply axiom for backward direction
     exact biquadratic_backward p r y h
 
+/-! ## Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c)
+
+This subsection scaffolds the biquadratic-limit identity sketched in
+`research/problems/general-quartic-oq-02/knowledge.md` (Approach A). At
+`q = 0`, the indeterminate-form factor `β = q / (2α)` in `ferrariRoots`
+degenerates whenever a chosen resolvent root `m` satisfies `2m + p = 0`.
+The two helper lemmas isolate the trivial root `m = -p/2` and rewrite the
+resolvent cubic in the cleaner constant-term `4p^3 - 4pr` (the `-q²`
+contribution vanishes). `ferrari_biquad_limit` then states that for every
+`(p, r) ≠ (0, 0)` there exists a non-degenerate resolvent root whose four
+Ferrari roots, when squared, fall in the two-element biquadratic root
+pair `{(-p ± √(p²−4r))/2}` — the canonical biquadratic root set.
+
+`ferrari_biquad_limit` is left as `sorry` here; its proof is deferred to
+the next session (OQ-02 S3+). -/
+
+/-- At `q = 0`, the constant term of the resolvent cubic simplifies (the
+`-q²` contribution vanishes). Provable by `ring`. -/
+theorem resolvent_cubic_q_zero (p r : ℂ) :
+    resolventCubic p 0 r =
+    C 8 * X^3 + C (20 * p) * X^2 + C (16 * p^2 - 8 * r) * X + C (4 * p^3 - 4 * p * r) := by
+  unfold resolventCubic
+  ring
+
+/-- At `q = 0`, `m = -p/2` is always a root of the resolvent cubic.
+This is the *trivial* (degenerate) resolvent root: it makes
+`α² = 2m + p = 0`, so `α = 0` and the `β = q/(2α)` factor in
+`ferrariRoots` is the indeterminate `0/0`. For the non-trivial Ferrari
+branch (Approach A in `knowledge.md`), we need a *different* resolvent
+root, which exists whenever `(p, r) ≠ (0, 0)`. -/
+theorem resolvent_root_neg_p_half_at_q_zero (p r : ℂ) :
+    (resolventCubic p 0 r).eval (-p / 2) = 0 := by
+  simp only [resolventCubic, eval_add, eval_mul, eval_pow, eval_X, eval_C]
+  ring
+
+/-- **Biquadratic limit (OQ-02.c, S2 scaffold)**
+
+In the biquadratic limit `q = 0`, Ferrari's formula admits a
+non-degenerate resolvent root `m` (i.e. one with `2m + p ≠ 0`), and at
+any such `m` each of the four Ferrari roots squared lies in the
+two-element biquadratic root set
+`{(-p + √(p²−4r))/2, (-p − √(p²−4r))/2}`.
+
+This closes the `α = 0` boundary case of `ferrariRoots`: the formula
+degenerates only on the trivial resolvent root `m = -p/2`
+(see `resolvent_root_neg_p_half_at_q_zero`), which exists for every
+`(p, r)` but is excluded by the `(p, r) ≠ (0, 0)` hypothesis here for
+*some* other resolvent root to exist (a polynomial-degree argument:
+when both `p` and `r` are zero, the resolvent cubic collapses to
+`8X^3` whose only root is `m = 0 = -p/2`).
+
+Proof deferred to OQ-02 S3+; see
+`research/problems/general-quartic-oq-02/knowledge.md` → "Approach A". -/
+theorem ferrari_biquad_limit (p r : ℂ) (hpr : p ≠ 0 ∨ r ≠ 0) :
+    ∃ m : ℂ, ∃ (hm : (resolventCubic p 0 r).eval m = 0), 2 * m + p ≠ 0 ∧
+      (let s : ℂ := Complex.cpow (p^2 - 4*r) (1/2 : ℂ)
+       let z₁ : ℂ := (-p + s) / 2
+       let z₂ : ℂ := (-p - s) / 2
+       let (y₁, y₂, y₃, y₄) := ferrariRoots p 0 r m hm
+       (y₁^2 = z₁ ∨ y₁^2 = z₂) ∧
+       (y₂^2 = z₁ ∨ y₂^2 = z₂) ∧
+       (y₃^2 = z₁ ∨ y₃^2 = z₂) ∧
+       (y₄^2 = z₁ ∨ y₄^2 = z₂)) := by
+  sorry
+
 /-! ## Part VII: Historical Context and Significance -/
 
 /-
@@ -357,4 +422,7 @@ end GeneralQuartic
 #check GeneralQuartic.quartic_four_roots
 #check GeneralQuartic.ferrariRoots
 #check GeneralQuartic.ferrari_roots_are_roots
+#check GeneralQuartic.resolvent_cubic_q_zero
+#check GeneralQuartic.resolvent_root_neg_p_half_at_q_zero
+#check GeneralQuartic.ferrari_biquad_limit
 #check GeneralQuartic.biquadratic_simple

--- a/research/problems/general-quartic-oq-02/knowledge.md
+++ b/research/problems/general-quartic-oq-02/knowledge.md
@@ -11,6 +11,106 @@ First substantive iteration. Established formal three-part decomposition
 candidate formalization approaches, and selected the OQ-02.c
 **biquadratic-limit identity** as the S2 target on tractability grounds.
 
+### S2 ACT — SCAFFOLD (2026-05-12)
+
+Implemented S2 SCAFFOLD per state.md. Added three theorems to
+`proofs/Proofs/GeneralQuartic.lean` (Part VI.5):
+
+1. **`resolvent_cubic_q_zero`** (sorry-free, `unfold + ring`): rewrites
+   the resolvent cubic at `q = 0` in its cleaner constant-term form
+   `4p³ − 4pr` (the `−q²` contribution vanishes).
+2. **`resolvent_root_neg_p_half_at_q_zero`** (sorry-free, `simp + ring`):
+   `m = -p/2` is always a root at `q = 0`. This is the *trivial*
+   resolvent root: it makes `α² = 2m + p = 0`, so the Ferrari `β` factor
+   is the indeterminate `0/0` form. The non-degenerate Ferrari branch
+   (Approach A) requires a different resolvent root.
+3. **`ferrari_biquad_limit`** (`sorry`, deferred to S3): the
+   biquadratic-limit identity — at `q = 0`, for `(p, r) ≠ (0, 0)`, there
+   exists a resolvent root `m` with `2m + p ≠ 0`, and at any such `m`
+   the four Ferrari roots squared lie in the biquadratic root pair
+   `{(-p + √(p²−4r))/2, (-p − √(p²−4r))/2}`.
+
+**Hypothesis `p ≠ 0 ∨ r ≠ 0` justification.** At `(p, r) = (0, 0)`, the
+resolvent cubic reduces to `8X³`, whose only root is `m = 0 = -p/2`,
+hence no non-degenerate Ferrari branch exists. Excluding this single
+parameter point keeps the statement vacuously satisfied where the
+biquadratic identity is meaningless (the depressed quartic is
+`y⁴ = 0`).
+
+**S3 DECOMPOSITION** (next action):
+
+The `sorry`-marked `ferrari_biquad_limit` decomposes into two
+independent sub-steps:
+
+- **Sub-step A: non-degenerate resolvent root exists.**
+  Show `∃ m, (resolventCubic p 0 r).eval m = 0 ∧ 2*m + p ≠ 0` given
+  `p ≠ 0 ∨ r ≠ 0`. Strategy: by contradiction, suppose every root
+  satisfies `2m + p = 0`, i.e. `m = -p/2`. Then `(resolventCubic p 0 r)`
+  has `m = -p/2` as a *triple* root, so it equals `C 8 * (X + C(p/2))^3`.
+  Expanding (in `Polynomial ℂ`) and comparing coefficients:
+  - Coeff of `X²`: actual `20p`, triple-root `12p` ⟹ `p = 0`.
+  - With `p = 0`: `resolventCubic 0 0 r = C 8 * X^3 + C (-8r) * X
+    = X (C 8 * X^2 + C (-8r))`. For triple-root at `0`, this requires
+    `r = 0`.
+  - Contradicts `p ≠ 0 ∨ r ≠ 0`. QED.
+
+  Concrete Lean strategy: prove `m = -p/2` is *not* a triple root unless
+  both `p = 0` and `r = 0`, using `Polynomial.degree_eq_card_roots` or
+  manually counting via Vieta. Roots of `resolventCubic` over ℂ come
+  with multiplicity 3 (total) and `m = -p/2` has multiplicity ≤ 2 unless
+  `(p, r) = (0, 0)` ⟹ other root exists.
+
+- **Sub-step B: algebraic root-matching at a non-degenerate `m`.**
+  Assume `(resolventCubic p 0 r).eval m = 0` and `2m + p ≠ 0`. Set
+  `α := Complex.cpow (2m + p) (1/2)`, so `α² = 2m + p ≠ 0` (cpow
+  property). Since `q = 0` and `α ≠ 0`, `β = 0` by the parent file's
+  `ferrariRoots` definition (the `if` collapses to the `else` branch
+  with `q = 0` in the numerator). Then:
+  ```
+  disc1 = α² − 4(p/2 + m + 0) = α² − 2p − 4m = (2m + p) − 2p − 4m
+        = -p − 2m = -(2m + p) = -α²
+  ```
+  Symmetric for `disc2 = -α²`. So `sqrt1 = sqrt2 = Complex.cpow (-α²) (1/2)`,
+  and the four Ferrari roots are
+  `y₁ = (-α + sqrt)/2`, `y₂ = (-α − sqrt)/2`, `y₃ = (α + sqrt)/2`,
+  `y₄ = (α − sqrt)/2`. Compute `yᵢ²` and use the resolvent cubic
+  condition `8m³ + 20pm² + (16p² - 8r)m + 4p³ - 4pr = 0` (at `q = 0`)
+  to verify each `yᵢ² ∈ {z₁, z₂}` where `z_{1,2} = (-p ± √(p²-4r))/2`.
+
+  Key intermediate identity (provable by `ring` + the resolvent
+  equation): given `α² = 2m + p` and `8m³ + 20pm² + (16p² - 8r)m
+  + 4p³ - 4pr = 0`, we have `α⁴ = -4 z₁ z₂ + 2 z₁ (-p + s) + ...`
+  — or, more cleanly, `(α² + p)² = 4r` (via the original Ferrari
+  resolvent derivation). This gives `α² = -p ± s = 2z_{1,2}`, hence
+  `α²/2 = z₁` or `z₂`. Then `yᵢ² = ((±α + sqrt)/2)² = (α² ± 2α sqrt
+  + sqrt²)/4 = (α² + sqrt² ± 2α sqrt)/4`. Using `sqrt² = -α²`,
+  `α² + sqrt² = 0`, so `yᵢ² = ±α sqrt / 2`. And `α sqrt = α
+  Complex.cpow (-α²) (1/2) = ±i α²`, giving `yᵢ² = ±i α² / 2 = ±i z_{1,2}`...
+  hmm, this doesn't quite land. Let me re-examine in S3.
+
+  *Alternative*: just use `biquadratic_simple` directly. Each `yᵢ` is a
+  root of the depressed quartic (by `ferrari_roots_are_roots`), hence
+  `yᵢ²` is a root of the biquadratic `z² + pz + r = 0`, hence equal to
+  `z₁` or `z₂`. This bypasses the explicit-formula expansion entirely
+  and uses only `biquadratic_simple` (already in the file) and
+  `ferrari_roots_are_roots` (axiomatized via `ferrari_roots_verify`).
+
+  *Tradeoff*: the alternative path *uses* the parent's
+  `ferrari_roots_verify` axiom. The explicit-formula path would be more
+  satisfying as it would corroborate the axiom, but it is also harder.
+  S3 should attempt the explicit-formula path first; fall back to the
+  alternative if blocked.
+
+**Files modified in S2 SCAFFOLD:**
+- `proofs/Proofs/GeneralQuartic.lean`: +68 lines (Part VI.5 added,
+  three theorems, three `#check` summary entries).
+
+**Metrics after S2:**
+- Lean theoremCount: 9 → 12 (+3)
+- Lean sorryCount: 0 → 1 (the deferred `ferrari_biquad_limit`)
+- Lean axiomCount: 6 (unchanged)
+- LOC: 360 → 428 (+68, under 100-LOC budget)
+
 ## Survey of Prior Art
 
 ### Folklore Status

--- a/research/problems/general-quartic-oq-02/state.md
+++ b/research/problems/general-quartic-oq-02/state.md
@@ -1,54 +1,61 @@
 # Current State
 
-**Phase**: ORIENT (post-S1 OBSERVE)
-**Since**: 2026-05-12T08:30Z
-**Iteration**: 2 (S1 just completed; S2 is next)
+**Phase**: ACT (post-S2 SCAFFOLD)
+**Since**: 2026-05-12T12:30Z
+**Iteration**: 3 (S2 just completed; S3 is next)
 
 ## Current Focus
 
-Three-part decomposition of numerical-instability question established
-(see `problem.md` OQ-02.a / .b / .c). Selected the *biquadratic-limit
-removable-singularity identity* (OQ-02.c) as the tractable next-step
-target. No Lean changes in S1.
+Approach A (biquadratic-limit removable-singularity identity, OQ-02.c)
+scaffolded in `proofs/Proofs/GeneralQuartic.lean`. Two helper lemmas
+proved sorry-free; the main statement `ferrari_biquad_limit` is stated
+and `sorry`-marked, to be discharged in S3.
 
 ## Active Approach
 
 **Approach A** (OQ-02.c) — Biquadratic-limit symbolic identity. See
-`knowledge.md` §"Three Approach Families" → "Approach A".
+`knowledge.md` §"Three Approach Families" → "Approach A" and §"S2 ACT
+Notes".
 
 Approaches B (OQ-02.a witness family) and C (OQ-02.b conditioning bound)
-are surveyed in `knowledge.md` and deferred — B blocked on Mathlib
-asymptotic-rate infrastructure, C blocked on missing condition-number
-framework.
+remain deferred — see `knowledge.md`.
 
 ## Blockers
 
-None for S2. (S3 may surface a Mathlib gap around
-`Polynomial.discriminant`; deferred to that session.)
+None for S3. Anticipate that the resolvent-root existence sub-step
+(non-`(-p/2)` root) needs a polynomial-degree argument; the algebraic
+root-matching sub-step uses `ring` once `α² = 2m + p` and `β = 0` are
+established.
 
 ## Next Action
 
-**S2 — SCAFFOLD**: Add the following to `proofs/Proofs/GeneralQuartic.lean`:
+**S3 — DISCHARGE**: prove `ferrari_biquad_limit` (currently `sorry` in
+`proofs/Proofs/GeneralQuartic.lean`). Decomposition:
 
-1. **Helper theorem** (provable, no `sorry`):
-   ```
-   theorem resolvent_cubic_q_zero (p r : ℂ) :
-       resolventCubic p 0 r =
-       C 8 * X^3 + C (20*p) * X^2 + C (16*p^2 - 8*r) * X + C (4*p^3 - 4*p*r)
-   ```
-   Proof: `unfold resolventCubic; ring_nf`.
+1. **Resolvent-root existence at biquadratic limit**: ∀ (p r : ℂ),
+   `p ≠ 0 ∨ r ≠ 0 → ∃ m, (resolventCubic p 0 r).eval m = 0 ∧ 2*m + p ≠ 0`.
+   Strategy: `m = -p/2` is the *only* root iff `resolventCubic p 0 r = C 8 *
+   (X - C(-p/2))^3`. Expand and compare coefficients of `X^2`: LHS has
+   `C (20*p)`, RHS has `C (12*p)` (from the `3 * 8 * (-p/2) = -12p` term
+   re-signed), giving `20p = -12p`, i.e. `32p = 0`, i.e. `p = 0`. Then
+   compare constant coefficients (or `X^0` of `X(X² - r)`) for the
+   remaining `p = 0` case to conclude `r = 0`. Therefore `p ≠ 0 ∨ r ≠ 0`
+   yields a non-trivial root.
 
-2. **Main statement** (`sorry`-marked, to be discharged in S3):
-   ```
-   theorem ferrari_biquad_limit (p r : ℂ) :
-       ∃ m : ℂ, (resolventCubic p 0 r).eval m = 0 ∧ 2*m + p ≠ 0 ∧ ...
-   ```
-   (Full body in `knowledge.md` §"Decision: S2 Target".)
+2. **Root-matching at non-trivial `m`**: With `α² = 2m + p ≠ 0` and
+   `β = (if α = 0 then 0 else q/(2α)) = 0` (since `q = 0`), each
+   `discᵢ = α² − 4(p/2 + m ± β) = α² − 4(p/2 + m)`. Substitute and use
+   the resolvent-cubic condition to derive `discᵢ = -α²`, hence
+   `sqrtᵢ = Complex.cpow (-α²) (1/2)`. Then expand `yᵢ² = ((±α + sqrtᵢ)/2)²`
+   and use `(yᵢ)² + p(yᵢ)² + r = 0` (forward direction of `biquadratic_simple`
+   contrapositive — actually use the `biquadratic_simple` characterization
+   directly) to conclude `yᵢ² ∈ {z₁, z₂}`.
 
-Target line budget: ≤ 100 LOC added.
+Target line budget: ≤ 80 LOC for the S3 proof.
 
 ## Attempt Counts
 
-- Total attempts: 1 (S1 OBSERVE — markdown survey + JSON scaffold)
-- Current approach attempts: 0
-- Approaches tried: 0 (all three approaches surveyed; no Lean attempts yet)
+- Total attempts: 2 (S1 OBSERVE — markdown survey + JSON scaffold;
+  S2 SCAFFOLD — 2 helper lemmas proved + main statement scaffolded)
+- Current approach attempts: 1 (S2)
+- Approaches tried: 1 (Approach A initiated; B and C remain deferred)

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -192,12 +192,12 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 360,
+    "lineCount": 428,
     "axiomCount": 6,
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 5,
     "path": "Proofs/GeneralQuartic.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "mainTheorems": [
     {
@@ -207,5 +207,5 @@
       "leanType": "quartic a b c d e -> exists roots, forall r in roots, a*r^4 + b*r^3 + c*r^2 + d*r + e = 0"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/research/problems/general-quartic-oq-02.json
+++ b/src/data/research/problems/general-quartic-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "general-quartic-oq-02",
   "title": "Numerical Instabilities in Ferrari's Quartic Formula",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -28,30 +28,36 @@
     "goal": "S2: scaffold and state ferrari_biquad_limit (OQ-02.c) in proofs/Proofs/GeneralQuartic.lean; S3+: discharge it. OQ-02.a and OQ-02.b are deferred indefinitely."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-12T08:30Z",
-    "iteration": 2,
-    "focus": "S1 OBSERVE complete: three-part decomposition (OQ-02.a/.b/.c) established, three approach families surveyed, Approach A (OQ-02.c biquadratic-limit identity) selected as S2 target. No Lean changes in S1.",
+    "phase": "ACT",
+    "since": "2026-05-12T12:30Z",
+    "iteration": 3,
+    "focus": "S2 SCAFFOLD complete: added Part VI.5 to GeneralQuartic.lean with resolvent_cubic_q_zero (sorry-free, ring), resolvent_root_neg_p_half_at_q_zero (sorry-free, simp+ring), and ferrari_biquad_limit (sorry-marked, deferred to S3). +68 LOC, theoremCount 9 -> 12, sorryCount 0 -> 1.",
     "blockers": [],
-    "nextAction": "S2 SCAFFOLD: add resolvent_cubic_q_zero (provable by ring_nf) and ferrari_biquad_limit (with sorry) to proofs/Proofs/GeneralQuartic.lean. Target <= 100 LOC.",
+    "nextAction": "S3 DISCHARGE: prove ferrari_biquad_limit. Sub-step A: non-degenerate resolvent root exists (degree/coefficient argument). Sub-step B: algebraic root-matching at non-degenerate m (either explicit-formula expansion or via biquadratic_simple + ferrari_roots_are_roots). See knowledge.md S2 ACT - SCAFFOLD section for full decomposition.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (markdown-only, no Lean changes): surveyed Pan 1997, Bini-Pan 1996, Kahan 2004, Press et al. Numerical Recipes. Isolated three distinct instability mechanisms in Ferrari's formula (resolvent-cubic cancellation, beta = q/(2 alpha) divide-by-near-zero, wrong-root-pairing). Decomposed the original vague OQ-02 into three formal sub-questions (a/b/c). Mapped three formalization approaches and selected the biquadratic-limit symbolic identity (OQ-02.c) as the most tractable S2 target on the basis of (i) being a pure C-symbolic identity provable without numerical-analysis infrastructure, (ii) closing the alpha = 0 boundary case of the parent's axiomatized ferrariRoots, (iii) requiring no new Mathlib imports beyond those already used in the parent file.",
+    "progressSummary": "S2 SCAFFOLD (2026-05-12): scaffolded Approach A in proofs/Proofs/GeneralQuartic.lean Part VI.5. Two helper lemmas proved sorry-free (resolvent_cubic_q_zero by ring; resolvent_root_neg_p_half_at_q_zero by simp+ring). Main ferrari_biquad_limit statement scaffolded with sorry, deferred to S3 with explicit two-sub-step decomposition (resolvent-root existence + algebraic root-matching). Hypothesis p != 0 OR r != 0 isolates the (p, r) = (0, 0) edge case where the depressed quartic is trivially y^4 = 0.",
     "builtItems": [
       "research/problems/general-quartic-oq-02/problem.md — formal three-part decomposition (OQ-02.a, .b, .c) with statement, classification, motivation, related-proof table, and reference list.",
       "research/problems/general-quartic-oq-02/knowledge.md — survey of prior art (Pan, Bini-Pan, Kahan, Press), three classical instability mechanisms identified, three approach families mapped, S2 target selected with stated Lean snippet, three Mathlib gaps surfaced.",
-      "research/problems/general-quartic-oq-02/state.md — phase advanced NEW -> ORIENT, iteration 1 -> 2, S2 next-action specified with line-budget."
+      "research/problems/general-quartic-oq-02/state.md — phase advanced NEW -> ORIENT, iteration 1 -> 2, S2 next-action specified with line-budget.",
+      "proofs/Proofs/GeneralQuartic.lean Part VI.5 - 3 theorems added (2 proved, 1 sorry), +68 LOC, theoremCount 9 -> 12",
+      "research/problems/general-quartic-oq-02/state.md - phase advanced ORIENT -> ACT, S3 next-action specified with two-sub-step decomposition",
+      "research/problems/general-quartic-oq-02/knowledge.md - S2 ACT SCAFFOLD section added with S3 decomposition strategy"
     ],
     "insights": [
       "Three distinct instability mechanisms separate cleanly: (1) upstream resolvent-cubic catastrophic cancellation, (2) quartic-specific divide-by-near-zero in beta = q/(2 alpha), (3) discrete wrong-root-pairing with no analytic remedy. Mechanism (2) is the canonical quartic-only failure mode and is the entry point for OQ-02.a / .c.",
       "OQ-02.c (the q -> 0 limit) is a pure symbolic identity over C, not a floating-point statement. It can therefore be proved with Mathlib's existing polynomial / cpow API; no numerical-analysis infrastructure is required.",
       "At q = 0, the resolvent cubic has m = -p/2 as a 'trivial' root that gives alpha = 0 (degenerate Ferrari branch). For OQ-02.c we choose a non-trivial resolvent root; existence follows from polynomial-degree counting + FTA.",
-      "Mechanism (3) is *fundamental*, not a fixable bug: any single fixed branch policy for the square root in alpha is unstable in some region of parameter space. This means OQ-02.b cannot have a uniform constant C for all (p, q, r); the bound must allow C to depend on the branch policy."
+      "Mechanism (3) is *fundamental*, not a fixable bug: any single fixed branch policy for the square root in alpha is unstable in some region of parameter space. This means OQ-02.b cannot have a uniform constant C for all (p, q, r); the bound must allow C to depend on the branch policy.",
+      "At q = 0 the resolvent cubic constant term simplifies from (4p^3 - 4pr - q^2) to (4p^3 - 4pr); the -q^2 contribution drops cleanly. Useful normalization for downstream manipulation.",
+      "m = -p/2 is universally a root of resolventCubic p 0 r (the trivial / degenerate root). The non-degenerate Ferrari branch requires a different root, which exists iff (p, r) != (0, 0) - polynomial-degree counting argument.",
+      "S3 admits two proof paths: (i) explicit-formula expansion using disc1 = disc2 = -alpha^2 at q = 0, or (ii) via biquadratic_simple + ferrari_roots_are_roots (the latter uses the parent ferrari_roots_verify axiom). S3 should attempt (i) first."
     ],
     "mathlibGaps": [
       "Polynomial.discriminant : Polynomial R -> R — not defined in named form for general R-coefficient polynomials. Needed for OQ-02.b.",
@@ -59,9 +65,10 @@
       "Multi-parameter big-O / big-Theta comparison via Filter.Tendsto exists but is unwieldy for the asymptotic-rate inequalities OQ-02.a needs."
     ],
     "nextSteps": [
-      "S2 SCAFFOLD: add resolvent_cubic_q_zero (provable by ring_nf) and ferrari_biquad_limit (sorry-marked) to proofs/Proofs/GeneralQuartic.lean.",
-      "S3: discharge ferrari_biquad_limit by: (a) prove resolvent_root_at_biquad — for every (p, r) there is an m with (resolventCubic p 0 r).eval m = 0 and 2*m + p ≠ 0; (b) prove the algebraic root-matching identity.",
-      "Eventual session: open Mathlib gap issue for Polynomial.discriminant if absent."
+      "S3 (highest priority): prove ferrari_biquad_limit. Two-sub-step decomposition documented in knowledge.md S2 ACT section.",
+      "S4 (after S3): try to drop the p != 0 OR r != 0 hypothesis or convert it to a propositional iff by handling (p, r) = (0, 0) as a trivial 0-root case.",
+      "Eventually: open Mathlib gap issue for Polynomial.discriminant if absent.",
+      "Indefinitely deferred: OQ-02.a (witness family) and OQ-02.b (conditioning bound) - require numerical-analysis infrastructure not currently in Mathlib."
     ]
   },
   "tags": [
@@ -94,18 +101,18 @@
     ]
   },
   "started": "2026-05-12T04:48:16.448Z",
-  "lastUpdate": "2026-05-12T08:30Z",
+  "lastUpdate": "2026-05-12T12:35Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/GeneralQuartic.lean",
       "filename": "GeneralQuartic.lean",
-      "lineCount": 361,
-      "theoremCount": 9,
+      "lineCount": 428,
+      "theoremCount": 12,
       "axiomCount": 6,
       "defCount": 5,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeneralQuartic.lean"
     }


### PR DESCRIPTION
## Summary

Per S1 OBSERVE next-action (state.md / knowledge.md), scaffold Approach A
(OQ-02.c — biquadratic-limit removable singularity) in
`proofs/Proofs/GeneralQuartic.lean`. Adds three theorems in a new
**Part VI.5**:

1. **`resolvent_cubic_q_zero`** (sorry-free, `unfold + ring`)
   At `q = 0` the resolvent cubic simplifies to
   `C 8 * X³ + C (20p) * X² + C (16p² - 8r) * X + C (4p³ - 4pr)` —
   the `-q²` contribution vanishes.
2. **`resolvent_root_neg_p_half_at_q_zero`** (sorry-free, `simp + ring`)
   `m = -p/2` is the trivial / degenerate resolvent root: it makes
   `α² = 2m + p = 0`, so the Ferrari `β = q/(2α)` factor is `0/0`.
3. **`ferrari_biquad_limit`** (sorry, deferred to S3)
   For every `(p, r)` with `p ≠ 0 ∨ r ≠ 0`, a **non-degenerate**
   resolvent root `m` (i.e. `2m + p ≠ 0`) exists, and at any such `m`
   the four Ferrari roots squared lie in the biquadratic root pair
   `{(-p + √(p²−4r))/2, (-p − √(p²−4r))/2}`.

### Hypothesis `p ≠ 0 ∨ r ≠ 0` justification

At `(p, r) = (0, 0)`, the resolvent cubic collapses to `8X³` whose only
root is `m = 0 = -p/2`, so no non-degenerate Ferrari branch exists. The
depressed quartic at this parameter is `y⁴ = 0`, which is trivially the
zero root with multiplicity 4 — the biquadratic identity is vacuous
there.

### S3 decomposition (full sketch in `knowledge.md` → S2 ACT section)

- **Sub-step A**: non-degenerate resolvent root exists. Show
  `m = -p/2` is a *triple* root iff `(p, r) = (0, 0)`, by comparing the
  `X²` coefficient (`20p` actual vs `12p` for triple-root at `-p/2`),
  then handling `p = 0` separately.
- **Sub-step B**: algebraic root-matching at a non-degenerate `m`. With
  `α² = 2m + p ≠ 0` and `β = 0` (from `q = 0` and `α ≠ 0`),
  `disc1 = disc2 = -α²`. Two proof paths: (i) explicit-formula
  expansion of `yᵢ²`; (ii) fallback via `biquadratic_simple` +
  `ferrari_roots_are_roots`.

## Progress

- `proofs/Proofs/GeneralQuartic.lean`: +68 LOC (under 100-LOC budget),
  3 new theorems + 3 `#check` summary entries
- `research/problems/general-quartic-oq-02/state.md`: ORIENT → ACT,
  iteration 2 → 3, S3 next-action specified with two-sub-step plan
- `research/problems/general-quartic-oq-02/knowledge.md`: new "S2 ACT —
  SCAFFOLD" section with full decomposition strategy
- `src/data/proofs/general-quartic/meta.json` and the research JSON:
  `lineCount 360 → 428`, `theoremCount 9 → 12`, `sorryCount 0 → 1`,
  `axiomCount 6` (unchanged)

## Findings

- The `-q²` term in `resolventCubic` is the *only* `q`-dependence; at
  `q = 0` it vanishes cleanly. The `(p, q, r) → (p, 0, r)` limit of
  `ferrariRoots` is therefore well-defined except on the degenerate
  branch where `α = 0`.
- `m = -p/2` is universally a resolvent root at `q = 0`. The
  non-degenerate Ferrari branch requires a *different* root, which
  exists iff `(p, r) ≠ (0, 0)` (polynomial-degree counting argument).
- The S3 proof admits a clean two-sub-step decomposition;
  `biquadratic_simple` (already in the file) provides a fallback path
  if the explicit-formula expansion is awkward.

## Status

**Outcome**: progress (S2 SCAFFOLD complete; build verified clean,
1 deferred sorry)
**Next Steps**: S3 — prove `ferrari_biquad_limit` via the two-sub-step
decomposition documented in `knowledge.md` → "S2 ACT — SCAFFOLD" →
"S3 DECOMPOSITION".

## Build verification

`./proofs/scripts/docker-build.sh Proofs.GeneralQuartic` — clean
(3058 jobs, 0 errors, only the expected `declaration uses 'sorry'`
warning at the deferred `ferrari_biquad_limit`).

🤖 Generated by researcher-3