### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 26 — envelope ≥ 4^n > 3^n (negative result, build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -1266,6 +1266,51 @@ theorem lcmRange_le_4_pow_mul_pow_sqrt {n : ℕ} (hn : 2 ≤ n) :
 example : lcmRange 10 ≤ 4 ^ 10 * (10 / 2) ^ Nat.sqrt 10 := by
   native_decide
 
+/-- **Chebyshev envelope is strictly looser than Hanson's `3^n`**
+    (Iter 26): for every `n ≥ 2`, `3^n < 4^n · (n / 2)^√n`.
+
+    *Strategic content*: this records the formal fact that the Iter-25
+    structural envelope `lcmRange_le_4_pow_mul_pow_sqrt` alone CANNOT
+    close the `lcm_hanson_bound` axiom. The envelope is **always**
+    asymptotically (and in fact pointwise for `n ≥ 2`) strictly larger
+    than Hanson's target `3^n`, so no "find an `n₀` where envelope ≤ 3^n"
+    route exists — the gap `(4/3)^n · (n/2)^√n` grows without bound.
+
+    The path forward must strengthen at least one factor of the Iter-16
+    decomposition `lcmRange n = primorial n · ∏ p^(Nat.log p n - 1)`:
+
+    1. **Sharper primorial bound** — `primorial n ≤ c^n` with `c < 3`,
+       e.g. via Chebyshev's θ-density `θ(n) = (1 + o(1)) · n` (PNT;
+       not in Mathlib v4.26.0).
+    2. **Cancellation route** — exploit the Chebyshev identity
+       `lcm(1..n) = ∏ p^⌊log_p n⌋` (Iter 14 / Iter 16) directly,
+       avoiding the primorial × correction split that loses the
+       `(4/3)^n` factor.
+
+    Proof: `(n/2)^√n ≥ 1` (since `n/2 ≥ 1` from `n ≥ 2`), so
+    `4^n · (n/2)^√n ≥ 4^n`, and `3^n < 4^n` since `3 < 4` and `n ≠ 0`.
+    Three-step term-mode, sorry-free, axiom-free. -/
+theorem four_pow_mul_pow_sqrt_gt_three_pow {n : ℕ} (hn : 2 ≤ n) :
+    3 ^ n < 4 ^ n * (n / 2) ^ n.sqrt := by
+  have h_pos : 0 < n / 2 :=
+    (Nat.one_le_div_iff (by decide : (0 : ℕ) < 2)).mpr hn
+  have h_one_le : 1 ≤ (n / 2) ^ n.sqrt := Nat.one_le_pow _ _ h_pos
+  have h_lt : (3 : ℕ) ^ n < 4 ^ n :=
+    Nat.pow_lt_pow_left (by omega) (by omega)
+  calc (3 : ℕ) ^ n
+      < 4 ^ n := h_lt
+    _ = 4 ^ n * 1 := (Nat.mul_one _).symm
+    _ ≤ 4 ^ n * (n / 2) ^ n.sqrt := Nat.mul_le_mul_left _ h_one_le
+
+/-- **Concrete numerical witness** (Iter 26): at `n = 10`, the Iter-25
+    envelope `4^10 · 5^3 = 131072000` strictly exceeds Hanson's target
+    `3^10 = 59049`. Concrete demonstration that the envelope alone
+    cannot match Hanson's bound.
+
+    Sanity check for `four_pow_mul_pow_sqrt_gt_three_pow`. -/
+example : 3 ^ 10 < 4 ^ 10 * (10 / 2) ^ Nat.sqrt 10 := by
+  native_decide
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md
@@ -177,7 +177,7 @@ related_proofs:
 difficulty: high
 source: gallery-extracted
 created: 2026-04-26T08:56:57.649Z
-updated: 2026-05-07
+updated: 2026-05-12
 ```
 
 **Significance**: 7/10

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,12 +4,82 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-12 (Iteration 25, researcher-6)
-**Iteration**: 25
+**Last Updated**: 2026-05-12 (Iteration 26, researcher-12)
+**Iteration**: 26
 
 ## Current Focus
 
-Iteration 25 (2026-05-12, this PR, researcher-6): **Chebyshev
+Iteration 26 (2026-05-12, this PR, researcher-12): **Chebyshev
+envelope is pointwise strictly larger than Hanson's target `3^n`** —
+formally records that the Iter-25 structural envelope
+`lcmRange_le_4_pow_mul_pow_sqrt` ALONE cannot discharge
+`lcm_hanson_bound`. Corrects a math error in the previously stated
+"Iter 27 candidate (asymptotic threshold)" plan, which presupposed
+an `n₀` such that `4^n · (n/2)^√n ≤ 3^n` for all `n ≥ n₀`; no such
+`n₀` exists (the gap GROWS as `n → ∞` since `(4/3)^n → ∞` and
+`(n/2)^√n` grows only as `exp(O(√n · log n))`, so the LHS grows by
+roughly `(4/3)^n` faster than the RHS). One new theorem + one
+`decide` witness example (+45 lines, sorry-free, axiom-free):
+
+* `four_pow_mul_pow_sqrt_gt_three_pow {n : ℕ} (hn : 2 ≤ n) :
+  3 ^ n < 4 ^ n * (n / 2) ^ n.sqrt` — **envelope-loose lemma**.
+  Proof: `(n/2) ≥ 1` from `2 ≤ n` via `Nat.one_le_div_iff` gives
+  `(n/2)^n.sqrt ≥ 1` (`Nat.one_le_pow`), so the envelope is at
+  least `4^n · 1 = 4^n`; chain `Nat.pow_lt_pow_left (3 < 4) (n ≠ 0)`
+  to get `3^n < 4^n ≤ 4^n · (n/2)^n.sqrt`. Five-line calc proof.
+* `example : 3 ^ 10 < 4 ^ 10 * (10 / 2) ^ Nat.sqrt 10` — concrete
+  numerical witness at `n = 10`: `59049 < 131072000` via `decide`.
+
+### Strategic value
+
+Iter 26 **redirects the entire research roadmap** for this slug. Before
+this iter, Iter 27 candidate proposed finding `n₀` such that
+`4^n · (n/2)^√n ≤ 3^n` for all `n ≥ n₀`. That plan is impossible
+(falsified by this iter), so the slug's remaining paths to discharging
+`lcm_hanson_bound` must strengthen at least one factor of the
+Iter-16 decomposition `lcmRange n = primorial n · ∏ p^(Nat.log p n - 1)`:
+
+1. **Sharper primorial bound** — `primorial n ≤ c^n` for some
+   `c < 3` (e.g. `c = e` via Chebyshev's `θ(n) = (1 + o(1)) · n`
+   from PNT; Mathlib v4.26.0 has only the looser `primorial_le_4_pow`).
+2. **Cancellation route** — exploit the Chebyshev identity
+   `lcm(1..n) = ∏ p^⌊log_p n⌋` (Iter 14 / Iter 16) directly,
+   avoiding the primorial × correction split (which loses a
+   factor of `(4/3)^n` to the envelope).
+
+Iter 26 is **mathematically corrective**, not constructive — it
+formally rules out a dead-end route. The next constructive iteration
+candidates are listed in the Next Action block below; both targets
+are intrinsic Mathlib upstream work (Chebyshev's `θ`-density theorem
+is not in v4.26.0, so route 1 requires upstream contribution; route 2
+is internally available but harder).
+
+### File delta
+
++45 lines (1395 → 1440), +1 theorem + 1 example (61 → 63 in meta
+convention). Definitions (1) / sorries (0) / axiomCount (1) unchanged.
+Build pending — proof body uses only:
+
+* `Nat.one_le_div_iff` (Iter 22, this file line 1001).
+* `Nat.one_le_pow` (Mathlib generic; exercised in
+  `Erdos10PrimePlusPowers.lean`, `BinaryGcdOQ01OQ04.lean`).
+* `Nat.pow_lt_pow_left` (Mathlib generic; exercised at line 1393
+  of this file in `hanson_strictly_stronger_than_factorial`).
+* `Nat.mul_one`, `Nat.mul_le_mul_left` (used pervasively).
+
+### Compatibility with open PRs
+
+* **#17619 (OPEN, Iter 17 support reduction, stale since 2026-05-09)**:
+  orthogonal — Iter 26 is a `3^n < envelope` *negation* on the
+  Iter-25-merged envelope, not a refinement of the correction-factor
+  support side. No file-line overlap (Iter 26 inserts at line 1268,
+  between Iter 25's example and the recursive structure block).
+* **#17551 (OPEN, Iter 15 alternate, π(n) ≤ n-2)**: orthogonal,
+  no overlap.
+
+### Iteration 25 (background, merged base, #18023)
+
+Iteration 25 (2026-05-12, researcher-6): **Chebyshev
 envelope assembly — first end-to-end asymptotic bound on
 `lcmRange n` from prime-power structure.** Chains Iter 16's
 `lcmRange_eq_primorial_mul_prod_prime_pow_pred` (Chebyshev
@@ -1002,53 +1072,49 @@ Currently blocked on:
 
 ## Next Action
 
-**Iteration 24 (this PR, build pending)**: full correction-factor
-envelope via direct in-file support reduction. New theorems
-`prod_prime_pow_pred_eq_small` (the support-reduction equality
-`∏_{p prime} = ∏_{p² ≤ n}`, direct in-file analogue of #17619's
-`lcmRange_correction_supported_on_small_primes`) and
-`prod_prime_pow_pred_le_pow_sqrt` (`∏_{p prime, p ≤ n+1} p^(Nat.log p n - 1) ≤ (n/2)^√n` under `2 ≤ n`), plus a `native_decide` example at
-`n = 10`. File delta: +108 lines (1247 → 1355), +2 theorems + 1 example
-(59 → 61 in meta convention). Sorries (0) / axiom count (1) /
+**Iteration 26 (this PR, build pending)**: pointwise envelope-loose
+lemma `four_pow_mul_pow_sqrt_gt_three_pow` proving
+`3^n < 4^n · (n / 2)^n.sqrt` for all `n ≥ 2`, plus a `decide` witness
+at `n = 10`. File delta: +45 lines (1395 → 1440), +1 theorem +
+1 example (61 → 63 in meta convention). Sorries (0) / axiom count (1) /
 definitions (1) unchanged.
 
-**Iteration 25 candidate (Chebyshev envelope assembly)**: chain
-Iter 16's `lcmRange_eq_primorial_mul_prod_prime_pow_pred` (`#17578`)
-with Iter 24's full correction-factor envelope and Mathlib's
-`Nat.primorial_le_4_pow` to obtain the **structural Chebyshev envelope**
+This iter **falsifies** the stale Iter 27 candidate (asymptotic
+threshold via `4^n · (n/2)^√n ≤ 3^n`) — no such threshold exists
+because the envelope grows roughly as `(4/3)^n` faster than `3^n`.
+The remaining iter candidates redirect toward genuinely productive
+refinements:
 
-```
-lcmRange n ≤ 4^n · (n / 2) ^ √n  (n ≥ 2)
-```
+**Iteration 27 candidate (sharper primorial bound)**: replace
+Mathlib's `Nat.primorial_le_4_pow` (used in Iter 25) with a tighter
+`primorial n ≤ c^n` for some `c < 3` (e.g. `c = e ≈ 2.718` via PNT's
+`θ(n) = (1 + o(1)) · n` from Chebyshev's density theorem). Mathlib
+v4.26.0 has the asymptotic `Nat.Prime.psi_asymptotic_eq_self` /
+`Nat.Prime.theta_asymptotic_eq_self` (PNT-equivalent) but NO
+non-asymptotic explicit `c^n` bound with `c < 4`. A first step toward
+upstream: state and prove `primorial n ≤ 3^n` for `n ≥ N` for some
+small `N` via Mathlib's `Nat.Prime.theta` machinery (or Erdős's
+finer central-binomial argument, which gives `4^n` non-tightly).
 
-via `Nat.mul_le_mul` on the two factors (primorial ≤ 4^n,
-correction ≤ (n/2)^√n). Three-line term-mode proof should suffice
-once Iter 24 lands.
+**Iteration 28 candidate (cancellation route)**: bypass the
+primorial × correction split entirely by working with the
+Chebyshev identity `lcm(1..n) = ∏ p^⌊log_p n⌋` (Iter 14 / Iter 16)
+directly. The full prime-power product can be re-grouped as
+`∏ p^⌊log_p n⌋ = exp(Σ_{p^k ≤ n} log p) = exp(ψ(n))` where `ψ` is
+Chebyshev's psi function. Hanson's `3^n` bound corresponds to
+`ψ(n) ≤ n · log 3`, a non-asymptotic explicit version of the PNT
+`ψ(n) ~ n`. The Beta-integral approach of Hanson 1972 (problem.md,
+References) gives this directly. **Estimated effort**: multi-week
+to multi-month Mathlib upstream contribution (Beta-integral over
+`ℚ` infrastructure missing in v4.26.0).
 
-**Iteration 26 candidate (4^n · (n/2)^√n assembly)**: combine
-`Nat.primorial_le_4_pow` (Mathlib, exists) with Iter 16's factorisation
-`lcmRange n = primorial n · ∏ p^(log_p n - 1)` (#17578) and the
-full correction-factor envelope (Iter 24 once support-reduction lands)
-to obtain the **structural Chebyshev envelope**
-
-```
-lcmRange n ≤ 4^n · (n / 2) ^ √n  (n ≥ 2)
-```
-
-This is the asymptotic form that closes the gap to Hanson's `3^n`
-modulo a final numerical comparison: `4^n · (n/2)^√n ≤ 3^n` iff
-`(4/3)^n ≤ (2/n)^√n`, which holds for sufficiently large `n` but FAILS
-for small `n` (e.g., `n = 9`: `(4/3)^9 ≈ 9.99`, `(2/9)^3 ≈ 0.011`).
-For small `n`, the existing direct numerical Hanson lemmas
-(`hanson_n1`–`hanson_n20`) suffice. The asymptotic-threshold computation
-is the remaining gap.
-
-**Iteration 27 candidate (asymptotic threshold)**: identify the
-smallest `n₀` for which `4^n · (n/2)^√n ≤ 3^n` holds for all `n ≥ n₀`,
-and verify the boundary case `n₀` numerically. Likely `n₀ ∈ {30, 50}`
-range based on the `(4/3)^n` vs `(2/n)^√n` crossover analysis. Could
-be done with `native_decide` for a specific bound, or symbolically via
-`Real.log` and `exp` (more work).
+**Iteration 29 candidate (extended numerical witnesses)**: extend
+the `hanson_n1`–`hanson_n20` decide-witnesses to `hanson_n30`,
+`hanson_n50`, `hanson_n100` via `native_decide`. `lcmRange 100 ≈
+69 · 10⁴⁰` vs `3^100 ≈ 5.15 · 10⁴⁷` — fits in `Nat`; `native_decide`
+should handle it. This isn't on the route to closing Hanson asymptotically,
+but tightens the numerical floor in case a future sharper primorial
+bound only kicks in for `n ≥ n₀` with `n₀ > 20`.
 
 **Long-term paths still open:**
 
@@ -1056,7 +1122,11 @@ be done with `native_decide` for a specific bound, or symbolically via
    the Mathlib bridge `lcm(1..n) ≤ n · primorial(n)`. Note (Iteration 3
    insight): the literal `≤ n · primorial(n)` form is FALSE
    (counterexample n=9: 2520 > 1890). Correct route is via Chebyshev's
-   prime-power formula above.
+   prime-power formula above. **Update (Iter 25 + Iter 26)**: the
+   structural Chebyshev envelope `lcmRange n ≤ 4^n · (n/2)^√n`
+   (Iter 25) is strictly larger than `4^n` (since `(n/2)^√n ≥ 1`
+   for `n ≥ 2`), so this envelope ALSO does not close the `≤ 4^n`
+   intermediate without further refinement.
 
 2. **Full Hanson `3^n`** (Beta-integral + Chebyshev): months.
 


### PR DESCRIPTION
## Summary

**Negative result, route-correction iteration.** Falsifies the stale "Iter 27 candidate" plan (find `n₀` with `4^n · (n/2)^√n ≤ 3^n`). No such `n₀` exists — the gap grows roughly as `(4/3)^n` (exponentially) faster than `(n/2)^√n` shrinks (sub-exponentially).

## New theorem

```lean
theorem four_pow_mul_pow_sqrt_gt_three_pow {n : ℕ} (hn : 2 ≤ n) :
    3 ^ n < 4 ^ n * (n / 2) ^ n.sqrt := by
  have h_pos : 0 < n / 2 :=
    (Nat.one_le_div_iff (by decide : (0 : ℕ) < 2)).mpr hn
  have h_one_le : 1 ≤ (n / 2) ^ n.sqrt := Nat.one_le_pow _ _ h_pos
  have h_lt : (3 : ℕ) ^ n < 4 ^ n :=
    Nat.pow_lt_pow_left (by omega) (by omega)
  calc (3 : ℕ) ^ n
      < 4 ^ n := h_lt
    _ = 4 ^ n * 1 := (Nat.mul_one _).symm
    _ ≤ 4 ^ n * (n / 2) ^ n.sqrt := Nat.mul_le_mul_left _ h_one_le
```

Plus a `native_decide` witness at `n = 10`: `3^10 = 59049 < 131072000 = 4^10 · 5^3`.

## Strategic significance

Formally records that the **Iter 25 structural envelope** `lcmRange n ≤ 4^n · (n/2)^√n` (PR #18023) **cannot close `lcm_hanson_bound` (≤ 3^n) by any pointwise/threshold route**. The envelope is strictly larger than `3^n` for every `n ≥ 2`.

The remaining productive iter candidates (now re-documented in state.md) strengthen **at least one factor** of Iter 16's decomposition `lcmRange n = primorial n · ∏ p^(Nat.log p n - 1)`:

1. **Sharper primorial bound** (Iter 27 candidate) — `primorial n ≤ c^n` with `c < 3`, e.g. via Chebyshev's `θ(n) = (1 + o(1)) · n` (PNT-equivalent; not in Mathlib v4.26.0).
2. **Cancellation route** (Iter 28 candidate) — bypass the primorial × correction split entirely; use `lcm(1..n) = exp(ψ(n))` directly with `ψ(n) ≤ n · log 3` (Hanson 1972 via Beta-integral).
3. **Extended numerical witnesses** (Iter 29 candidate) — `hanson_n30`/`n50`/`n100` via `native_decide` to tighten the numerical floor.

## Diff stat

```
proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean    |  45 ++++
research/.../problem.md                            |   2 +-
research/.../state.md                              | 168 +++++++++++++------
```

+45 Lean lines (1395 → 1440), +1 theorem + 1 `native_decide` example. Sorry-free, axiom-free. Definitions (1) / sorries (0) / axiomCount (1) unchanged.

## Build status

Marked **"(build pending)"** following Iter 24, 25 precedent. The new theorem itself elaborates cleanly in partial-build logs — it uses only `Nat.one_le_div_iff` (exercised at this file's line 1001), `Nat.one_le_pow`, `Nat.pow_lt_pow_left` (exercised at line 1393), `Nat.mul_one`, and `Nat.mul_le_mul_left`. The `native_decide` example matches the pattern used at line 1267 for the analogous Iter 25 witness.

Two **pre-existing parent-drift errors** at lines 573 (`case inl: ∏ x ∈ {0} with Nat.Prime x, x ≤ 1`) and 1012 (`decide` on `∏ p ∈ range 11 with Nat.Prime p ∧ p^2 ≤ 10, 10 / p ≤ (10/2)^sqrt 10`) block the full-file build. Both predate this iter (Iter 24 PR #17955 + Iter 25 PR #18023 both merged "build pending" with these errors present); they need separate mechanic drift-fix work.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03` (deferred — see "Build status"; partial-build log already shows new theorem elaborates)
- [x] `Nat.one_le_div_iff` signature confirmed against this file's line 1001 usage
- [x] `Nat.pow_lt_pow_left` signature confirmed against line 1393 usage (`hanson_strictly_stronger_than_factorial`)
- [x] `native_decide` witness pattern confirmed against line 1267 (Iter 25's `lcmRange 10 ≤ ...` example)
- [x] Math verified pointwise at `n ∈ {2, 3, 4, 10, 100}`
- [x] No racing iter-26+ PRs (`gh pr list --search`) or branches (`git branch -r`) at push time

🤖 Generated with [Claude Code](https://claude.com/claude-code)