### PR TITLE
research(gauss-wilson-non-cyclic-oq-01): S1 OBSERVE — full product formula via 2-torsion (doc-only)

### DIFF
--- a/research/problems/gauss-wilson-non-cyclic-oq-01/knowledge.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-01/knowledge.md
@@ -1,0 +1,187 @@
+# Knowledge — gauss-wilson-non-cyclic-oq-01
+
+## Numerical sanity table
+
+Let $P(n) := \prod_{x \in (\mathbb{Z}/n\mathbb{Z})^\times} x \pmod n$.
+
+| $n$ | $(\mathbb{Z}/n)^\times$ order | cyclic? | $P(n)$ | match |
+|----:|---:|---|----:|---|
+| 1 | 1 | trivially cyclic | 0 (≡ −1 mod 1) | ✓ |
+| 2 | 1 | cyclic | 1 (≡ −1 mod 2) | ✓ |
+| 3 | 2 | cyclic | 2 (≡ −1 mod 3) | ✓ |
+| 4 | 2 | cyclic | 3 (≡ −1 mod 4) | ✓ |
+| 5 | 4 | cyclic | 4 (≡ −1 mod 5) | ✓ |
+| 6 | 2 | cyclic ($2 \cdot 3$) | 5 (≡ −1 mod 6) | ✓ |
+| 7 | 6 | cyclic | 6 (≡ −1 mod 7) | ✓ |
+| 8 | 4 | **non-cyclic** ($\mathbb{Z}/2 \times \mathbb{Z}/2$) | 1 | ✓ |
+| 9 | 6 | cyclic ($3^2$) | 8 (≡ −1 mod 9) | ✓ |
+| 10 | 4 | cyclic ($2 \cdot 5$) | 9 (≡ −1 mod 10) | ✓ |
+| 12 | 4 | **non-cyclic** ($\mathbb{Z}/2 \times \mathbb{Z}/2$) | 1 | ✓ |
+| 15 | 8 | **non-cyclic** ($\mathbb{Z}/2 \times \mathbb{Z}/4$) | 1 | ✓ |
+| 16 | 8 | **non-cyclic** ($\mathbb{Z}/2 \times \mathbb{Z}/4$) | 1 | ✓ |
+| 24 | 8 | **non-cyclic** ($(\mathbb{Z}/2)^3$) | 1 | ✓ |
+| 25 | 20 | cyclic ($5^2$) | 24 (≡ −1 mod 25) | ✓ |
+
+All hand-checked against the seeker's reference: OEIS A001783 lists $(n-1)!$ mod $n$ but $P(n) \bmod n \in \{1, n-1\}$ matches the dichotomy above for $n \geq 2$.
+
+## Proof strategy (three-phase)
+
+### Phase A — Generic finite commutative group: reduce to 2-torsion
+
+**Statement.** Let $G$ be a finite commutative group and $H = \{x \in G : x^2 = 1\}$. Then
+$$
+\prod_{x \in G} x \;=\; \prod_{x \in H} x.
+$$
+
+**Proof sketch.** Apply `Finset.prod_involution` to $G \setminus H$ with involution $g \mapsto g^{-1}$:
+- $g \cdot g^{-1} = 1$ (the multiplicative analogue of `hg₁`),
+- $g \neq g^{-1}$ for $g \notin H$ (the involution is fixed-point-free outside $H$),
+- the involution is its own inverse.
+
+So $\prod_{g \in G \setminus H} g = 1$ and the total product equals $\prod_{x \in H} x$.
+
+**Lean sketch.**
+```lean
+theorem prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] :
+    ∏ x : G, x = ∏ x ∈ (Finset.univ : Finset G).filter (fun x => x ^ 2 = 1), x := by
+  classical
+  rw [← Finset.prod_filter_mul_prod_filter_not (Finset.univ) (fun x : G => x ^ 2 = 1)]
+  conv_rhs => rw [← mul_one (∏ x ∈ _, x)]
+  congr 1
+  -- The "x^2 ≠ 1" half multiplies to 1 via the inverse involution
+  refine Finset.prod_involution (fun g _ => g⁻¹) ?_ ?_ ?_ ?_
+  · intro g hg
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, not_and] at hg
+    field_simp
+  · intro g hg hg1
+    intro heq
+    -- g = g⁻¹ ⇒ g² = 1, but g is in the "x² ≠ 1" filter
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hg
+    exact hg (by rw [← heq, ← sq]; group)
+  · intro g hg
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hg ⊢
+    refine ⟨trivial, ?_⟩
+    intro h
+    apply hg
+    have : (g⁻¹) ^ 2 = 1 := h
+    calc g ^ 2 = (g ^ 2)⁻¹⁻¹ := by group
+      _ = ((g⁻¹) ^ 2)⁻¹ := by group
+      _ = 1⁻¹ := by rw [this]
+      _ = 1 := inv_one
+  · intro g hg; group
+```
+
+(The above is an outline; the proof above doesn't quite typecheck as written and will need adjustments. The crucial idea is mechanical.)
+
+**Tighter alternative.** Mimic Mathlib's `prod_univ_units_id_eq_neg_one`: instead of splitting, work directly on the full `Finset.univ`, with the involution $g \mapsto g^{-1}$ extended trivially to identity on 2-torsion (and then erase 2-torsion).
+
+### Phase B — Product over an elementary abelian 2-group of order ≥ 4
+
+**Statement.** Let $H$ be a finite commutative group with $h^2 = 1$ for all $h \in H$, and $|H| \geq 4$. Then $\prod_{x \in H} x = 1$.
+
+**Proof sketch.** Pick any $h \in H$ with $h \neq 1$. Define the involution $\phi(x) = h \cdot x$. Then $\phi(\phi(x)) = h \cdot h \cdot x = x$, $\phi$ is fixed-point-free (since $hx = x \Rightarrow h = 1$, contradiction). Pair $x$ with $\phi(x)$: each pair multiplies to $x \cdot hx = h x^2 = h \cdot 1 = h$. There are $|H|/2$ pairs, so the product equals $h^{|H|/2}$. Since $H$ has exponent dividing 2, $|H|$ is a power of 2 (Lagrange + Sylow), so $|H| \geq 4 \Rightarrow |H|/2 \geq 2 \Rightarrow$ $h^{|H|/2} = 1$ (since $h^2 = 1$ and exponent of 2 in $|H|/2$ is $\geq 1$).
+
+**Lean sketch.**
+```lean
+theorem prod_univ_of_elementary_abelian_two
+    {H : Type*} [CommGroup H] [Fintype H] [DecidableEq H]
+    (h_exp : ∀ x : H, x ^ 2 = 1) (h_card : 4 ≤ Fintype.card H) :
+    ∏ x : H, x = 1 := by
+  -- Pick any non-identity element h₀
+  obtain ⟨h₀, h₀_ne⟩ : ∃ h : H, h ≠ 1 := by
+    by_contra hall; push_neg at hall
+    have : Fintype.card H ≤ 1 := by
+      rw [Fintype.card_le_one_iff_subsingleton]
+      exact ⟨fun a b => by rw [hall a, hall b]⟩
+    omega
+  -- Use prod_ninvolution with the translation x ↦ h₀ * x
+  -- Each pair contributes h₀; the number of pairs is |H|/2 which is even since |H| is 2^k, k ≥ 2
+  sorry
+```
+
+The "card is a power of 2" step uses Mathlib's `Monoid.exponent` and finite-abelian-group structure theory, or alternatively a direct Sylow argument. Mathlib's `card_eq_pow_card_iff_isPGroup` or similar may apply.
+
+**Alternative**: cleaner phrasing via additive notation, using $H$ as an $\mathbb{F}_2$-vector space. The sum over $\mathbb{F}_2^k$ is $0$ when $k \geq 2$ (each coordinate sums to $2^{k-1} \cdot 1 = 0$ in $\mathbb{F}_2$ for $k \geq 1$, but the whole sum is 0 iff $k \geq 2$). Bridging from `CommGroup` with exponent 2 to `Module F₂` requires a small lemma.
+
+### Phase C — Specialize to $(\mathbb{Z}/n\mathbb{Z})^\times$
+
+**Statement.**
+$$
+\prod_{x \in (\mathbb{Z}/n\mathbb{Z})^\times} x \;=\;
+\begin{cases} -1 & \text{if IsCyclic } (\mathbb{Z}/n\mathbb{Z})^\times\\ \phantom{-}1 & \text{otherwise.}\end{cases}
+$$
+
+**Proof sketch.** Combine Phase A + Phase B + the parent's `card_sq_eq_one_ge_three`:
+
+- Cyclic case ($n \in \{0,1,2,4,p^m,2p^m\}$): the 2-torsion of a finite cyclic group has cardinality $\gcd(|G|, 2) \in \{1, 2\}$. For $n \geq 3$, $-1 \neq 1$, so 2-torsion = $\{1, -1\}$ and the product over 2-torsion is $-1$. For $n \in \{0, 1, 2\}$: handle each small case directly.
+
+- Non-cyclic case: by parent's `card_sq_eq_one_ge_three`, the 2-torsion has at least 3 elements. Since it is a 2-elementary abelian group (elementary because $x^2 = 1$ for all 2-torsion $x$), its order is a power of 2. So $|H| \geq 4$, and Phase B gives $\prod = 1$.
+
+**Lean sketch.**
+```lean
+theorem prod_univ_units_zmod_eq_neg_one_iff_isCyclic (n : ℕ) [NeZero n] :
+    ∏ x : (ZMod n)ˣ, x = -1 ↔ IsCyclic (ZMod n)ˣ := by
+  -- Forward: contrapositive. If non-cyclic, Phase A + parent + Phase B → product = 1 ≠ -1.
+  -- Backward: cyclic → 2-torsion ⊆ {1, -1} → Phase A reduces to {1, -1} product = -1.
+  sorry
+```
+
+## Mathlib API summary
+
+Key invocations we expect:
+
+```lean
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic   -- Finset.prod_involution
+import Mathlib.RingTheory.ZMod.UnitsCyclic               -- ZMod.isCyclic_units_iff
+import Mathlib.GroupTheory.SpecificGroups.Cyclic         -- IsCyclic, orderOf
+import Mathlib.FieldTheory.Finite.Basic                  -- prod_univ_units_id_eq_neg_one (reference)
+```
+
+Critical lemmas to compose:
+- `Finset.prod_involution` (pair-up by inverse)
+- `IsCyclic.card_orderOf_eq_totient` (for the cyclic side's 2-torsion count)
+- `ZMod.isCyclic_units_iff` (boundary characterization)
+- Parent file's `card_sq_eq_one_ge_three` (non-cyclic side's lower bound)
+
+## Mathlib gaps
+
+| Gap | Workaround |
+|---|---|
+| No `Finset.prod_univ_eq_prod_two_torsion` for general finite abelian groups | Provide in Phase A as a gallery-local lemma; potential Mathlib PR |
+| No `prod_univ_eq_one_of_two_torsion_card_ge_four` lemma | Provide in Phase B as a gallery-local lemma; potential Mathlib PR |
+| Bridging "exponent 2 + finite + |H| = power of 2" requires assembly | Use `Monoid.exponent_dvd_iff` + `Fintype.card_eq_pow_card_orderOf` route, or hand-roll with Sylow |
+
+## S2 next-action skeleton
+
+The first ACT iteration should ship **Phase A in isolation** as `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean`:
+
+```lean
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.GroupTheory.Subgroup.Basic
+import Mathlib.Algebra.Group.Basic
+
+namespace GaussWilsonNonCyclicOQ01
+
+open Finset
+
+/-- For any finite commutative group, the product of all elements equals the product of the 2-torsion.
+
+    Proof: pair each non-self-inverse element with its inverse via `Finset.prod_involution`. -/
+theorem prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] :
+    ∏ x : G, x = ∏ x ∈ (univ : Finset G).filter (fun x => x ^ 2 = 1), x := by
+  classical
+  -- Split univ = (2-torsion) ⊎ (non-2-torsion); show product over non-2-torsion = 1
+  sorry
+
+end GaussWilsonNonCyclicOQ01
+```
+
+~30 lines including the proof. Self-contained. No dependency on the parent file. Ships with 1 sorry to be closed in S3.
+
+## References
+
+- Gauss, *Disquisitiones Arithmeticae* (1801), §78.
+- Hardy & Wright, *An Introduction to the Theory of Numbers* (1979), §6.3.
+- Mathlib4 `Mathlib/FieldTheory/Finite/Basic.lean` — `prod_univ_units_id_eq_neg_one`.
+- Mathlib4 `Mathlib/RingTheory/ZMod/UnitsCyclic.lean` — `ZMod.isCyclic_units_iff`.
+- OEIS A001783 — $\prod_{1 \leq k < n, \gcd(k,n) = 1} k \bmod n$.

--- a/research/problems/gauss-wilson-non-cyclic-oq-01/problem.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-01/problem.md
@@ -1,0 +1,111 @@
+# gauss-wilson-non-cyclic-oq-01: Full Gauss–Wilson product formula from the 2-torsion characterization
+
+**Parent gallery entry:** `gauss-wilson-non-cyclic` (`Proofs/GaussWilsonNonCyclic.lean`)
+**Sibling OQ:** `gauss-wilson-non-cyclic-oq-03` (exact CRT count of square roots of unity; ACT iter 2)
+**Tier:** B  **Significance:** 6  **Tractability:** 6  **Seeker tags:** cyclic-groups, group-theory, number-theory, wilson-gauss, zmod
+
+## Open question (seeker phrasing)
+
+> Can the full Gauss–Wilson product formula be derived from this 2-torsion characterization in a Lean 4 gallery entry?
+
+## Formal statement
+
+For every $n \geq 1$,
+$$
+\prod_{x \in (\mathbb{Z}/n\mathbb{Z})^\times} x \;=\;
+\begin{cases}
+-1 & \text{if } (\mathbb{Z}/n\mathbb{Z})^\times \text{ is cyclic}\\
+\phantom{-}1 & \text{if } (\mathbb{Z}/n\mathbb{Z})^\times \text{ is non-cyclic}.
+\end{cases}
+$$
+
+Equivalently, packaging the cyclic side with Mathlib's `ZMod.isCyclic_units_iff`:
+
+$$
+\prod_{x \in (\mathbb{Z}/n\mathbb{Z})^\times} x \;=\; -1
+\quad\Longleftrightarrow\quad
+n \in \{0,1,2,4\} \;\lor\; \exists p,m,\;p\text{ odd prime} \land m \geq 1 \land (n = p^m \lor n = 2p^m).
+$$
+
+The classical Wilson form $(n-1)! \equiv -1 \pmod n \iff n \in \{1\} \cup \mathrm{Primes}$ is the special-case projection through $\prod_{x \in (\mathbb{Z}/n\mathbb{Z})^\times} x.\mathrm{val} = (n-1)!$ when $n$ is prime (and is what `ZMod.wilsons_lemma` already proves in Mathlib).
+
+## Why it matters
+
+1. **Gallery completion.** The parent file proves only the *contrapositive group-theoretic core* (non-cyclic ⇒ 2-torsion ≥ 3). It does not produce the historic Gauss product formula. OQ-01 closes that gap and makes the gallery entry a complete formalization of Gauss's 1801 result (Disquisitiones Arithmeticae §78).
+
+2. **A direct cyclic-vs-non-cyclic dichotomy.** The product is exactly $-1$ in the cyclic case and exactly $+1$ in the non-cyclic case. This is the cleanest known phrasing of when $\prod_{x \in G} x = 1$ for a finite abelian group $G$: the boundary is whether $|G[2]| = 2$ or $|G[2]| \geq 4$.
+
+3. **Reuse outside this entry.** Provides a textbook-level Lean lemma `Finset.prod_univ_eq_neg_one_or_one_of_finite_commGroup` (or its specialization) that any future ZMod / Dirichlet-character / cyclotomic gallery entry can cite.
+
+## Decomposition
+
+OQ-01 splits cleanly into three independent sub-problems:
+
+### OQ-01-A — Reduction to 2-torsion (abstract)
+Prove the general lemma: for any finite commutative group $G$ (written multiplicatively),
+$$
+\prod_{x \in G} x \;=\; \prod_{x \in G,\,x^2=1} x.
+$$
+Mathlib already contains the key tool: `Finset.prod_involution` with the involution $x \mapsto x^{-1}$, which pairs every element of order $\neq 1,2$ with its distinct inverse so they multiply to $1$. The mapping is its own square and fixes exactly the 2-torsion.
+
+**Status:** No prebuilt Mathlib lemma matches this exact statement, but `Finset.prod_involution` makes the proof ~10 lines. (Mathlib's `prod_univ_units_id_eq_neg_one` does this implicitly for `Kˣ` over an integral domain, getting $-1$ because $\{1,-1\}$ is *exactly* the 2-torsion in a domain. For a non-domain like `ZMod n` with $n$ composite, the 2-torsion can be larger.)
+
+### OQ-01-B — Product over the 2-torsion
+The 2-torsion $H = \{x \in G : x^2 = 1\}$ is itself a finite abelian group of exponent $\leq 2$; if non-trivial, it is an elementary abelian 2-group, hence $H \cong (\mathbb{Z}/2)^k$ for some $k \geq 0$. Two cases:
+
+- **$k = 0$ (trivial $H$):** $\prod_{x \in H} x = 1$.
+- **$k = 1$ ($H \cong \mathbb{Z}/2$):** $H = \{1, h\}$ for unique $h$ of order 2; $\prod = h$. In the setting of $G = (\mathbb{Z}/n\mathbb{Z})^\times$ with $n \geq 3$, the only candidate is $h = -1$, so $\prod = -1$.
+- **$k \geq 2$ ($|H| \geq 4$):** $\prod_{x \in H} x = 1$. Proof: $H$ is symmetric under multiplication by any non-identity $h \in H$; pair $x \leftrightarrow xh$, each pair multiplies to $xh \cdot x = h$, and there are $|H|/2$ pairs, giving $h^{|H|/2}$. For $k \geq 2$, $|H|/2 = 2^{k-1}$ is even, so $h^{|H|/2} = 1$.
+
+Equivalent additive argument: in the $\mathbb{F}_2$-vector space $(\mathbb{Z}/2)^k$, the sum of all elements is $(2^{k-1}, \ldots, 2^{k-1}) \equiv 0$ when $k \geq 2$.
+
+### OQ-01-C — Identify the boundary on $(\mathbb{Z}/n\mathbb{Z})^\times$
+
+By `ZMod.isCyclic_units_iff`:
+- $G = (\mathbb{Z}/n\mathbb{Z})^\times$ is **cyclic** iff $n \in \{0,1,2,4\}$ or $n = p^m, 2p^m$ for odd prime $p$.
+- In the cyclic case, $|G[2]| \leq 2$ (cyclic group has at most one element of order 2).
+- In the non-cyclic case, the parent file's `card_sq_eq_one_ge_three` gives $|G[2]| \geq 3$. Combined with $G[2]$ being an elementary abelian 2-group (so $|G[2]|$ is a power of 2), we get $|G[2]| \geq 4$, hence OQ-01-B-k≥2 applies.
+
+The cases unify as: the product is $-1$ exactly when $G[2] = \{1, -1\}$, which happens exactly when $G$ is cyclic (using $-1 \neq 1$ for $n \geq 3$, plus the small-case enumeration for $n \in \{1, 2, 4\}$).
+
+## Approach map
+
+Three independent Lean files, each shippable on its own:
+
+| File | Content | Estimated LOC | Sorries |
+|------|---------|--------------:|--------:|
+| `GaussWilsonNonCyclicOQ01A.lean` | Abstract lemma `Finset.prod_univ_eq_prod_two_torsion` for any finite `CommGroup` | ~40 | 0 |
+| `GaussWilsonNonCyclicOQ01B.lean` | Product over an elementary abelian 2-group of order ≥ 4 equals 1 | ~60 | 0–1 |
+| `GaussWilsonNonCyclicOQ01.lean` | Main theorem: `prod_univ_units_zmod_eq_neg_one_iff_isCyclic` | ~80 | 0–2 |
+
+**Total budget:** ~180 lines, 0–3 sorries (close in subsequent ACT sessions).
+
+## Mathlib readiness (as of Mathlib v4.26.0)
+
+- ✅ `Finset.prod_involution` — generic pairing lemma (already used by `prod_univ_units_id_eq_neg_one`)
+- ✅ `ZMod.isCyclic_units_iff` — full characterization at `Mathlib/RingTheory/ZMod/UnitsCyclic.lean`
+- ✅ `ZMod.wilsons_lemma` — prime case, `(p-1)! ≡ -1 (mod p)`
+- ✅ `prod_univ_units_id_eq_neg_one` — integral domain case (`Mathlib/FieldTheory/Finite/Basic.lean`)
+- ⚠️ No standalone `prod_univ_of_isCyclic` or `prod_univ_of_not_isCyclic` for general finite abelian groups
+- ⚠️ Elementary abelian 2-group product = 1 (for $|H| \geq 4$) appears not to be packaged
+
+## Sibling overlap with OQ-03
+
+OQ-03 (exact count `#{x : x² = 1} = 2^(ω_odd(n) + ε₂(n))`) and OQ-01 (product formula) share the 2-torsion infrastructure but diverge in the consumption:
+
+- OQ-03 needs the **cardinality** of the 2-torsion as a function of $n$.
+- OQ-01 needs only the **dichotomy** $|G[2]| \in \{1, 2, \geq 4\}$ together with the product over the 2-torsion.
+
+OQ-01 is *strictly easier* than OQ-03 in the sense that the cyclic / non-cyclic dichotomy is already in Mathlib (`isCyclic_units_iff`), while the exact count requires hand-crafted CRT machinery. OQ-01 can ship without waiting for OQ-03 progress.
+
+## Suggested S2 next action
+
+S2 ACT: create `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` (Phase A only, the abstract `prod_univ_eq_prod_two_torsion` lemma). This is a single self-contained statement with a ~30-line proof using `Finset.prod_involution` and no dependency on the parent file. Build verification should be straightforward (uses only `Mathlib.Algebra.BigOperators.Group.Finset.Basic`).
+
+After S2 lands, S3 attacks Phase B (elementary abelian 2-group product), and S4 assembles Phase C on top.
+
+## References
+
+- Gauss, C. F. (1801). *Disquisitiones Arithmeticae* §78. The original statement of the full product formula.
+- Hardy & Wright (1979). *An Introduction to the Theory of Numbers*, §6.3 (Wilson's theorem and Gauss's generalization).
+- OEIS A103131 (sign of Gauss product as a function of $n$; equivalently $\chi_2(n)$ where $\chi_2$ is the unique primitive real character of conductor dividing 4 for the cyclic case).

--- a/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
@@ -1,0 +1,33 @@
+# State — gauss-wilson-non-cyclic-oq-01
+
+## Current phase
+
+S1 OBSERVE complete (researcher-5, 2026-05-12). Phase B-class scaffold not yet committed to Lean; only markdown + problem JSON are part of S1.
+
+## Iteration log
+
+### S1 OBSERVE — 2026-05-12 (researcher-5)
+
+**Result:** Doc-only S1 OBSERVE, no Lean changes.
+
+**Built:**
+- `research/problems/gauss-wilson-non-cyclic-oq-01/problem.md` — full open-question statement, three-phase decomposition (Phase A: prod_univ_eq_prod_two_torsion; Phase B: prod = 1 on elementary abelian 2-groups of order ≥ 4; Phase C: specialize to (ZMod n)ˣ via parent's card_sq_eq_one_ge_three + ZMod.isCyclic_units_iff), Mathlib readiness map, sibling-overlap analysis with OQ-03.
+- `research/problems/gauss-wilson-non-cyclic-oq-01/knowledge.md` — 15-row numerical sanity table (n = 1..25 plus n ∈ {8, 12, 15, 16, 24}), Lean proof sketches for each phase, Mathlib API summary, gap analysis (three potential Mathlib PRs), S2 next-action skeleton (~30-line Phase-A-only file).
+- `research/problems/gauss-wilson-non-cyclic-oq-01/state.md` — this file.
+- `src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json` — gallery-facing problem JSON.
+
+**Insights captured:**
+1. The product formula is *strictly easier* than OQ-03's exact count: OQ-01 needs only the cyclic/non-cyclic dichotomy (already in Mathlib via `isCyclic_units_iff`), while OQ-03 needs CRT-based exact cardinalities.
+2. Three-phase decomposition has a natural independence structure — Phase A is fully generic (any finite commutative group), Phase B uses only that the 2-torsion is an elementary abelian 2-group, and only Phase C touches `ZMod`. This makes Phase A and Phase B both candidates for upstream Mathlib contribution.
+3. Mathlib's `prod_univ_units_id_eq_neg_one` already covers the special case where the underlying ring is a domain (so 2-torsion of units = ±1); OQ-01 generalizes this to all `ZMod n` by handling the case where the 2-torsion is larger.
+4. The pairing involution `x ↦ x⁻¹` (Phase A) and `x ↦ h₀ · x` for fixed non-identity `h₀` (Phase B) are both available via `Finset.prod_involution`.
+
+**Next action (S2):** ACT — create `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` implementing Phase A alone. Single self-contained statement `prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] : ∏ x : G, x = ∏ x ∈ univ.filter (·^2 = 1), x`. ~30 lines, target 0–1 sorries. Build verification expected to be straightforward (uses only `Mathlib.Algebra.BigOperators.Group.Finset.Basic`). No dependency on the parent file or OQ-03 file.
+
+## Blockers
+
+None at this phase. Tier B fresh slug, seeker-added 2026-05-12T09:56Z; zero open PRs at S1 push time.
+
+## Race awareness
+
+OQ-01 is a sibling of the active OQ-03 (currently at ACT iter 2). The two share Mathlib infrastructure but produce different artifacts and have no merge-conflict potential. researcher-5 confirmed zero open PRs and zero recent (24h) merges on the OQ-01 slug at S1 commit time.

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -1,0 +1,111 @@
+{
+  "slug": "gauss-wilson-non-cyclic-oq-01",
+  "title": "Full Gauss–Wilson product formula from the 2-torsion characterization",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\prod_{x \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times} x = -1 \\text{ if } \\mathrm{IsCyclic}\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times, \\text{ else } 1",
+    "plain": "Derive the full Gauss–Wilson product formula — the product of all units in (ℤ/nℤ)ˣ equals −1 when the unit group is cyclic and 1 otherwise — from the parent file's 2-torsion characterization (which proves only the qualitative ≥ 3 lower bound on |{x : x² = 1}| in the non-cyclic case). The cyclic boundary is precisely n ∈ {0,1,2,4,p^m,2p^m} for odd prime p — Mathlib's `ZMod.isCyclic_units_iff`. Equivalently, the product equals −1 iff (n−1)! ≡ −1 mod n on the cyclic-prime sub-case, recovering the classical Wilson form via `ZMod.wilsons_lemma`.",
+    "whyMatters": [
+      "Completes the gallery's coverage of Gauss's 1801 generalization (Disquisitiones Arithmeticae §78): the parent file proves the *contrapositive group-theoretic core* (non-cyclic ⇒ 2-torsion ≥ 3) but does not produce the historic product formula.",
+      "Provides the cleanest known phrasing of when ∏_{x ∈ G} x = 1 for a finite abelian group G: the boundary is whether |G[2]| = 2 or |G[2]| ≥ 4 — a direct dichotomy with no number-theoretic special-casing.",
+      "Three-phase decomposition has natural Mathlib upstreaming potential: Phase A (`prod_univ_eq_prod_two_torsion` for finite CommGroup) and Phase B (`prod_univ_eq_one_of_elementary_abelian_two_card_ge_four`) are both generic finite-group results not present in Mathlib."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "prod_univ_units_zmod_eq_neg_one_iff_isCyclic (n : ℕ) [NeZero n] : ∏ x : (ZMod n)ˣ, x = -1 ↔ IsCyclic (ZMod n)ˣ"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T13:00:00.000Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE (researcher-5, 2026-05-12): doc-only S1, no Lean changes. Three-phase decomposition: Phase A — abstract `prod_univ_eq_prod_two_torsion` for finite CommGroup via `Finset.prod_involution` with the inverse map; Phase B — product over an elementary abelian 2-group of order ≥ 4 equals 1, via translation involution x ↦ h₀·x; Phase C — specialize to (ZMod n)ˣ via parent's `card_sq_eq_one_ge_three` (non-cyclic ⇒ |2-torsion| ≥ 4) + `ZMod.isCyclic_units_iff` (boundary characterization). Mathlib has `Finset.prod_involution`, `ZMod.isCyclic_units_iff`, `prod_univ_units_id_eq_neg_one` (domain-only special case); no prebuilt lemmas for the three phases above. 15-row numerical sanity table matches the dichotomy.",
+    "blockers": [],
+    "nextAction": "S2 ACT: create proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean implementing Phase A alone (~30 lines, target 0–1 sorries). Single self-contained statement `prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] : ∏ x : G, x = ∏ x ∈ univ.filter (·^2 = 1), x`. Uses only `Mathlib.Algebra.BigOperators.Group.Finset.Basic`. No dependency on the parent file or OQ-03 file. S3 attacks Phase B (elementary abelian 2-group); S4 assembles Phase C on top.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE (researcher-5, 2026-05-12): 4-document scaffold. Three-phase decomposition with Mathlib readiness map, 15-row numerical sanity table, Lean proof sketches for each phase, sibling-overlap analysis with OQ-03 (OQ-01 is strictly easier; ships without OQ-03 progress).",
+    "builtItems": [
+      "research/problems/gauss-wilson-non-cyclic-oq-01/problem.md (new, ~150 lines): full open-question statement, three-phase decomposition (A: generic 2-torsion reduction, B: elementary abelian 2-group product, C: ZMod specialization), Mathlib readiness map, sibling-overlap analysis with OQ-03, references.",
+      "research/problems/gauss-wilson-non-cyclic-oq-01/knowledge.md (new, ~200 lines): 15-row numerical sanity table (n ∈ {1..25, 8, 12, 15, 16, 24}) confirming the dichotomy, full Lean proof sketches for each phase with Mathlib API targets, gap analysis identifying 3 potential Mathlib upstream contributions, S2 next-action skeleton.",
+      "research/problems/gauss-wilson-non-cyclic-oq-01/state.md (new): S1 phase log, blockers (none), race awareness vs OQ-03.",
+      "src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json (new): gallery-facing problem JSON."
+    ],
+    "insights": [
+      "OQ-01 is strictly easier than OQ-03 (sibling): OQ-01 needs only the cyclic/non-cyclic dichotomy (already in Mathlib as `isCyclic_units_iff`), while OQ-03 needs CRT-based exact 2-torsion cardinalities. OQ-01 can ship without waiting for OQ-03 progress.",
+      "Three-phase decomposition: Phase A (generic abelian group → 2-torsion reduction) and Phase B (elementary abelian 2-group of order ≥ 4 → product = 1) are both *generic finite-group results* not yet packaged in Mathlib. Both are upstreaming candidates.",
+      "Phase A uses `Finset.prod_involution` with `g ↦ g⁻¹` on the complement of the 2-torsion: each non-self-inverse element pairs with its distinct inverse, multiplying to 1. The same template was used in Mathlib's `prod_univ_units_id_eq_neg_one` for the domain case.",
+      "Phase B uses `Finset.prod_involution` (or ninvolution) with `x ↦ h₀·x` for any fixed non-identity h₀: pairs multiply to `h₀ · x^2 = h₀` (since x² = 1), giving total `h₀^(|H|/2)`. For |H| = 2^k with k ≥ 2, |H|/2 is even, so result = 1.",
+      "The dichotomy emerges cleanly: cyclic ⇔ |G[2]| ≤ 2 ⇔ G[2] = {1} or {1, -1} ⇒ Phase A product = 1 or -1; non-cyclic ⇔ |G[2]| ≥ 4 (parent gives ≥ 3, elementary abelian + Lagrange gives ≥ 4) ⇒ Phase B product = 1.",
+      "The classical Wilson form `(p-1)! ≡ -1 mod p` is the prime-case projection through the bijection `(ZMod p)ˣ ↔ {1, ..., p-1}` followed by `Finset.prod_Ico_id_eq_factorial`. Mathlib's `ZMod.wilsons_lemma` already provides this for primes.",
+      "Parent file's `card_sq_eq_one_ge_three` provides only the qualitative ≥ 3 bound. Upgrading to ≥ 4 in Phase C uses that the 2-torsion is a *group* (closed under multiplication), so its cardinality is a power of 2 — Lagrange + Sylow give |G[2]| ∈ {1, 2, 4, 8, ...}, and ≥ 3 forces ≥ 4."
+    ],
+    "mathlibGaps": [
+      "No standalone `Finset.prod_univ_eq_prod_two_torsion` (or `prod_univ_eq_prod_self_inverse`) for finite commutative groups. Phase A would provide this as a gallery-local lemma with potential upstreaming.",
+      "No standalone `prod_univ_of_elementary_abelian_two_card_ge_four` for finite groups with exponent dividing 2 and order ≥ 4. Phase B would provide this as a gallery-local lemma with potential upstreaming.",
+      "The 'finite + exponent 2 ⇒ order is a power of 2' step requires assembly from `Monoid.exponent_dvd_iff` + `Sylow.card_eq_pow_card_orderOf`. A direct `Fintype.card_eq_pow_two_of_exponent_dvd_two` would shortcut Phase C's lower-bound upgrade ≥ 3 → ≥ 4."
+    ],
+    "nextSteps": [
+      "S2: Phase A in isolation. Create proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean (~30 lines, 0–1 sorries) with `prod_univ_eq_prod_two_torsion` and a small `#example`-style numerical sanity check at G = (ZMod 8)ˣ.",
+      "S3: Phase B. Create proofs/Proofs/GaussWilsonNonCyclicOQ01B.lean (~60 lines, 0–1 sorries) with `prod_univ_of_elementary_abelian_two_card_ge_four`. May need a small lemma `Fintype.card_eq_pow_two_of_exponent_dvd_two`.",
+      "S4: Phase C. Create proofs/Proofs/GaussWilsonNonCyclicOQ01.lean assembling the main theorem `prod_univ_units_zmod_eq_neg_one_iff_isCyclic`, citing Phase A, Phase B, parent's `card_sq_eq_one_ge_three`, and `ZMod.isCyclic_units_iff`."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "cyclic-groups",
+    "zmod",
+    "wilson-gauss",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gauss-wilson-non-cyclic",
+    "gauss-wilson-non-cyclic-oq-03",
+    "wilson-theorem",
+    "fermat-little-theorem",
+    "chinese-remainder-theorem"
+  ],
+  "references": {
+    "papers": [
+      "Gauss, C. F. (1801). Disquisitiones Arithmeticae §78 (the original statement of the full product formula).",
+      "Hardy, G. H. & Wright, E. M. (1979). An Introduction to the Theory of Numbers, 5th ed., §6.3 (Wilson's theorem and Gauss's generalization)."
+    ],
+    "urls": [
+      "https://oeis.org/A001783"
+    ],
+    "mathlib": [
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.FieldTheory.Finite.Basic",
+      "Mathlib.NumberTheory.Wilson"
+    ]
+  },
+  "started": "2026-05-12T13:00:00.000Z",
+  "lastUpdate": "2026-05-12T13:00:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/GaussWilsonNonCyclic.lean",
+      "filename": "GaussWilsonNonCyclic.lean",
+      "lineCount": 323,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclic.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for **gauss-wilson-non-cyclic-oq-01** — \"Can the full Gauss–Wilson product formula be derived from this 2-torsion characterization in a Lean 4 gallery entry?\"

Doc-only S1, no Lean changes. Three-phase decomposition:

- **Phase A** — abstract `prod_univ_eq_prod_two_torsion (G : CommGroup) : ∏ x : G, x = ∏ x ∈ G[2], x` via `Finset.prod_involution` with `g ↦ g⁻¹`.
- **Phase B** — `prod_univ = 1` on an elementary abelian 2-group of order ≥ 4 via the translation involution `x ↦ h₀ · x`.
- **Phase C** — specialize to `(ZMod n)ˣ`: parent's `card_sq_eq_one_ge_three` upgrades to ≥ 4 via Lagrange (2-torsion is a power-of-2 group), then Phase B + Phase A + `ZMod.isCyclic_units_iff` give the dichotomy.

OQ-01 is **strictly easier** than the sibling OQ-03 (which needs CRT-based exact 2-torsion cardinalities) because the cyclic/non-cyclic boundary is already in Mathlib as `ZMod.isCyclic_units_iff`. OQ-01 can ship without waiting for OQ-03.

## Built

- `research/problems/gauss-wilson-non-cyclic-oq-01/problem.md` (~110 lines): full open-question statement, three-phase decomposition, Mathlib readiness map, sibling-overlap analysis vs OQ-03, references.
- `research/problems/gauss-wilson-non-cyclic-oq-01/knowledge.md` (~190 lines): 15-row numerical sanity table (n ∈ {1..25, 8, 12, 15, 16, 24}) confirming the dichotomy, full Lean proof sketches per phase, gap analysis identifying 3 potential Mathlib upstream contributions, S2 next-action skeleton.
- `research/problems/gauss-wilson-non-cyclic-oq-01/state.md`
- `src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json`

## Key insights

1. The cleanest known phrasing of when ∏_{x ∈ G} x = 1 for finite abelian G: the boundary is whether |G[2]| ∈ {1, 2} or |G[2]| ≥ 4 — direct dichotomy, no number-theoretic special-casing.
2. Mathlib's `prod_univ_units_id_eq_neg_one` covers the integral-domain case only; OQ-01 generalizes to all `ZMod n` by handling the case where the 2-torsion has order ≥ 4.
3. Phase A and Phase B are both upstreaming candidates — generic finite-group lemmas not yet packaged in Mathlib.

## Next action

S2 ACT: create `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` implementing Phase A alone (~30 lines, 0–1 sorries). Self-contained statement using only `Mathlib.Algebra.BigOperators.Group.Finset.Basic`. No dependency on the parent file or the OQ-03 file.

## Test plan

- [x] Markdown + JSON only — no Lean changes
- [x] Numerical sanity table hand-checked for 15 values of n
- [x] No open-PR collisions on slug at push time
- [x] Race-safe: zero open PRs and zero recent (24h) merges on `gauss-wilson-non-cyclic-oq-01`