### PR TITLE
Enrich F[X]-Module Structure on K^n via Matrix Action (minpoly-charpoly-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/annotations.json
@@ -24,6 +24,18 @@
     "prerequisites": ["Dummit & Foote §12.2", "Hungerford §VII.4", "Module.equiv_directSum_of_isTorsion"]
   },
   {
+    "id": "ann-namespace-and-typeclass-setup",
+    "proofId": "minpoly-charpoly-oq-03-oq-01",
+    "range": { "startLine": 80, "endLine": 86 },
+    "type": "context",
+    "title": "Namespace, opens, and typeclass variables",
+    "content": "The five-line preamble fixes the entire ambient context for the file. `namespace MinpolyCharpolyOQ03OQ01` walls every definition into a slug-matching scope so downstream sub-OQs reference `xModule` unambiguously (e.g., `MinpolyCharpolyOQ03OQ01.xModule M` from OQ-03-OQ-02). `open Matrix Polynomial Module` brings three namespaces into scope simultaneously — Matrix for `mulVecLin`/`charpoly`/`charpoly_monic`, Polynomial for `aeval` and the `F[X]` notation (`Polynomial F`), Module for `AEval'`/`IsTorsion`/`IsTorsionBy`/`Finite`. The two `variable` lines declare the standing typeclass context: `[Field F]` (needed so `F[X]` is an integral domain and `charpoly_monic` ⇒ `charpoly ≠ 0` ⇒ `charpoly ∈ F[X]⁰`), plus `[Fintype n] [DecidableEq n]` (needed to construct `Pi.basisFun`, which `Module.AEval.instFinitePolynomial` consumes when lifting F-finiteness to F[X]-finiteness). Dropping `[Field F]` to a `[CommRing F]` would block the IsTorsion upgrade in step b of §3 — this is a deliberate strength of hypothesis, not vestigial.",
+    "mathContext": "Standing context: $F$ a field, $n$ a finite type with decidable equality. These choices make $F[X]$ a PID, $F^n$ finite-dimensional with an explicit basis, and unlock instance synthesis for both Module.Finite and the eventual `Module.equiv_directSum_of_isTorsion` consumption.",
+    "significance": "supporting",
+    "relatedConcepts": ["typeclass resolution", "namespace hygiene", "Pi.basisFun", "F[X] as PID", "Field vs CommRing"],
+    "prerequisites": ["Lean 4 namespace/open/variable mechanics", "Mathlib typeclass conventions"]
+  },
+  {
     "id": "ann-endo-def",
     "proofId": "minpoly-charpoly-oq-03-oq-01",
     "range": { "startLine": 94, "endLine": 97 },

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -87,7 +87,8 @@
       "**Torsion is the substantive content**: the entire mathematical work of OQ-03-OQ-01 is concentrated in `xModule_isTorsion`. Once Cayley-Hamilton is transported across the standard-basis algebra equivalence, the IsTorsion conclusion follows mechanically from charpoly_monic.",
       "**Standard-basis algebra equivalence is the Cayley-Hamilton bridge**: `Matrix.toLin'` is an algebra equivalence, so `aeval` commutes with it. This single fact is the technical glue between `Matrix.aeval_self_charpoly` (the matrix Cayley-Hamilton) and `aeval (M.mulVecLin) M.charpoly = 0` (the LinearMap form needed by AEval').",
       "**Statement-only sorries fix the API surface early**: deferring the three proofs (isTorsionBy, isTorsion, hasInvariantFactorChain) but locking down their **statements** means OQ-03-OQ-02+ can be written against final API surfaces. This is the key value of the SCAFFOLD pattern at sub-OQ depth-one.",
-      "**Charpoly is the right torsion witness — not minpoly**: using `Matrix.charpoly M` (rather than `minpoly F M`) as the `IsTorsionBy` witness is a deliberate API choice. Charpoly is **monic of degree exactly `Fintype.card n`** (via `Matrix.charpoly_monic` + `Matrix.charpoly_natDegree`), so (i) charpoly ≠ 0 in F[X] is immediate, placing it in F[X]⁰; (ii) the invariant-factor chain produced downstream has $\\sum_i \\deg p_i = n$ for free, giving clean dimension control for OQ-03-OQ-02. The **minimal polynomial** generates xModule M's annihilator ideal and is mathematically sharper, but harder to control degree-wise and would require a separate `aeval M (minpoly F M) = 0` proof. Cayley-Hamilton (`Matrix.aeval_self_charpoly`) supplies the charpoly annihilation directly — the perfect input for this scaffold."
+      "**Charpoly is the right torsion witness — not minpoly**: using `Matrix.charpoly M` (rather than `minpoly F M`) as the `IsTorsionBy` witness is a deliberate API choice. Charpoly is **monic of degree exactly `Fintype.card n`** (via `Matrix.charpoly_monic` + `Matrix.charpoly_natDegree`), so (i) charpoly ≠ 0 in F[X] is immediate, placing it in F[X]⁰; (ii) the invariant-factor chain produced downstream has $\\sum_i \\deg p_i = n$ for free, giving clean dimension control for OQ-03-OQ-02. The **minimal polynomial** generates xModule M's annihilator ideal and is mathematically sharper, but harder to control degree-wise and would require a separate `aeval M (minpoly F M) = 0` proof. Cayley-Hamilton (`Matrix.aeval_self_charpoly`) supplies the charpoly annihilation directly — the perfect input for this scaffold.",
+      "**`abbrev` over `def` is load-bearing for instance synthesis**: `xModule M := Module.AEval' (endo M)` is declared as `abbrev`, not `def`, so the synonym stays *transparent* to typeclass resolution. The single-line `xModule.instFinite M := inferInstance` works only because Lean's instance synthesis can see through the abbreviation to `Module.AEval' (endo M)` and fire `Module.AEval.instFinitePolynomial` on it. Reformulating as `def xModule` would block the cascade and force a manual `Module.AEval.instFinitePolynomial (endo M)` invocation — and downstream consumers in OQ-03-OQ-02/03/04 would each need to unfold the def to make their own instance searches succeed. The `abbrev` choice is the difference between a one-line proof and a recurring API friction point."
     ],
     "prerequisites": [
       "Linear algebra: K^n as a module, matrices and linear maps, charpoly",
@@ -187,6 +188,11 @@
       "targetId": "cayley-hamilton",
       "relationship": "depends-on",
       "description": "Direct technical dependency: Matrix.aeval_self_charpoly is the key Mathlib input for the deferred proof of xModule_isTorsionBy_charpoly."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Parallel decomposition strand: when M is nonderogatory (minimal polynomial of degree n), xModule M is cyclic over F[X] — a single-summand special case of the invariant-factor chain produced by OQ-03-OQ-02. The Krylov / cyclic-vector machinery developed there is the constructive counterpart to the existential PID structure theorem invoked here."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Enrichment pass for `minpoly-charpoly-oq-03-oq-01` (S1 scaffold for the first sub-OQ of the rational canonical form decomposition).

- **New annotation** `ann-namespace-and-typeclass-setup` covering lines 80–86 of the Lean file (namespace/opens/variables block), filling the gap between the §0 docstring and the §1 definition. Explains the load-bearing role of `[Field F]` (makes `F[X]` an integral domain, needed for the `IsTorsionBy → IsTorsion` upgrade) and `[Fintype n] [DecidableEq n]` (unlocks `Pi.basisFun` feeding `Module.AEval.instFinitePolynomial`).
- **New keyInsight** explaining the `abbrev` vs `def` design choice for `xModule`: the abbreviation is transparent to typeclass resolution, which is what lets `xModule.instFinite M := inferInstance` fire automatically through `Module.AEval.instFinitePolynomial`. A `def` would force every downstream consumer in OQ-03-OQ-02/03/04 to manually invoke the instance, turning a one-line proof into recurring API friction.
- **New crossReference** to `cayley-hamilton-minpoly-oq-05-oq-01` (Krylov / nonderogatory cyclic vectors), framing it as the constructive counterpart to the existential PID structure-theorem path: when `M` is nonderogatory, the invariant-factor chain collapses to a single summand and Krylov gives an explicit cyclic vector.

## Verification

- Annotations build (`tsx scripts/annotations/build.ts`): clean for this slug
- Research build (`tsx scripts/research/build.ts`): clean
- TypeScript build (`node node_modules/typescript/bin/tsc -b`): clean

## Axiom integrity

Unchanged: `status: "formalized"`, `badge: "research"`, `sorries: 3`, `axiomCount: 0`. No structure-encoded assumptions introduced.