### PR TITLE
research(erdos-szekeres-oq-03): S5-prep — mono_n + IsMonochromatic.mono + ramseyNumber_swap (build pending)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Map
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fin.Basic
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
@@ -463,6 +464,89 @@ lemma is_ramsey_self_right (k t : ℕ) (hk : 1 ≤ k) (hkt : k ≤ t) :
 lemma is_ramsey_self_left (k s : ℕ) (hk : 1 ≤ k) (hks : k ≤ s) :
     IsRamsey s k s k :=
   IsRamsey.swap.mpr (is_ramsey_self_right k s hk hks)
+
+/-! ### S5-prep: monotonicity infrastructure for `ramsey_existence`'s inductive step
+
+The S5 target (the genuinely-inductive case `s > k ∧ t > k` of
+`ramsey_existence`) is the Ramsey 1930 two-layer induction on `k` and `s + t`.
+It needs three monotonicity facts that are independent of `ramsey_existence`
+itself and clean to state from the S2/S4-prep API:
+
+* `IsMonochromatic.mono` — monochromaticity is preserved by passing to a
+  subset (every `k`-subset of the smaller set is a `k`-subset of the larger
+  one).
+* `IsRamsey.mono_n` — the Ramsey condition is monotone in `n`. Restricting
+  any coloring of `[m]^{(k)}` along the embedding `Fin n ↪ Fin m` produces a
+  clique on the smaller side, which lifts back unchanged.
+* `ramseyNumber_swap` — `ramseyNumber k s t = ramseyNumber k t s`, immediate
+  corollary of `IsRamsey.swap` since both `sInf`-defining sets agree
+  pointwise.
+-/
+
+/-- **Monochromaticity is preserved by passing to a subset.** Every
+`k`-subset of `S'` is a `k`-subset of `S` (because `S' ⊆ S`), so the
+defining quantifier of `IsMonochromatic χ k S' c` is implied by that of
+`IsMonochromatic χ k S c`. -/
+lemma IsMonochromatic.mono {n k : ℕ} {χ : kColoring n} {c : Bool}
+    {S S' : Finset (Fin n)} (hSub : S' ⊆ S)
+    (hMono : IsMonochromatic χ k S c) : IsMonochromatic χ k S' c := by
+  intro T hT
+  rw [Finset.mem_powersetCard] at hT
+  obtain ⟨hTS', hTcard⟩ := hT
+  exact hMono T (Finset.mem_powersetCard.mpr ⟨hTS'.trans hSub, hTcard⟩)
+
+/-- **`IsRamsey` is monotone in `n`.** If `IsRamsey n k s t` and `n ≤ m`,
+restricting any coloring of `[m]^{(k)}` along the canonical embedding
+`Fin n ↪ Fin m` (built from `Fin.castLE` and its injectivity) produces a
+clique on the `Fin n` side, which then lifts back along the same embedding
+to a clique of the same size in `Fin m`. The lift uses `Finset.subset_map_iff`
+to recognise every `k`-subset of the lifted clique as itself the image of a
+unique `k`-subset on the smaller side, where monochromaticity is known by
+hypothesis. -/
+lemma IsRamsey.mono_n {n m k s t : ℕ} (h : n ≤ m)
+    (hR : IsRamsey n k s t) : IsRamsey m k s t := by
+  intro χ
+  let f : Fin n ↪ Fin m := ⟨Fin.castLE h, Fin.castLE_injective h⟩
+  let χ' : kColoring n := fun S => χ (S.map f)
+  rcases hR χ' with ⟨S, hSc, hSm⟩ | ⟨S, hSc, hSm⟩
+  · refine Or.inl ⟨S.map f, ?_, ?_⟩
+    · rw [Finset.card_map]; exact hSc
+    · intro T hT
+      rw [Finset.mem_powersetCard] at hT
+      obtain ⟨hTsub, hTcard⟩ := hT
+      obtain ⟨T₀, hT₀sub, hT₀eq⟩ := Finset.subset_map_iff.mp hTsub
+      have hT₀card : T₀.card = k := by
+        have hcard := congrArg Finset.card hT₀eq
+        rw [Finset.card_map] at hcard
+        omega
+      have key : χ' T₀ = false :=
+        hSm T₀ (Finset.mem_powersetCard.mpr ⟨hT₀sub, hT₀card⟩)
+      rw [hT₀eq]
+      exact key
+  · refine Or.inr ⟨S.map f, ?_, ?_⟩
+    · rw [Finset.card_map]; exact hSc
+    · intro T hT
+      rw [Finset.mem_powersetCard] at hT
+      obtain ⟨hTsub, hTcard⟩ := hT
+      obtain ⟨T₀, hT₀sub, hT₀eq⟩ := Finset.subset_map_iff.mp hTsub
+      have hT₀card : T₀.card = k := by
+        have hcard := congrArg Finset.card hT₀eq
+        rw [Finset.card_map] at hcard
+        omega
+      have key : χ' T₀ = true :=
+        hSm T₀ (Finset.mem_powersetCard.mpr ⟨hT₀sub, hT₀card⟩)
+      rw [hT₀eq]
+      exact key
+
+/-- **`ramseyNumber` is symmetric in the two color targets.** Immediate
+corollary of `IsRamsey.swap`: the defining `sInf` sets agree pointwise under
+exchanging `s` and `t`. -/
+lemma ramseyNumber_swap (k s t : ℕ) :
+    ramseyNumber k s t = ramseyNumber k t s := by
+  unfold ramseyNumber
+  congr 1
+  ext n
+  exact IsRamsey.swap
 
 /-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
 and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,15 +1,49 @@
 # Current State
 
-**Phase**: ACT (S4 ACT-C closes the `s = k` / `t = k` boundary cases; the
-genuine inductive case `s > k ∧ t > k` remains the sole `ramsey_existence`
-sorry)
-**Since**: 2026-05-12 (S4 ACT-C, researcher-9)
-**Iteration**: 4
-**Researcher**: researcher-9 (S4 ACT-C, S2); researcher-1 (S4-prep); researcher-11 (S3); researcher-8 (S1)
+**Phase**: ACT (S5-prep adds three sorry-free monotonicity helpers; the
+genuine inductive case `s > k ∧ t > k` of `ramsey_existence` remains the
+sole `sorry`)
+**Since**: 2026-05-12 (S5-prep, researcher-1)
+**Iteration**: 5
+**Researcher**: researcher-1 (S5-prep, S4-prep); researcher-9 (S4 ACT-C, S2); researcher-11 (S3); researcher-8 (S1)
 
 ## Current Focus
 
-Session 4 (S4 ACT-C, researcher-9, 2026-05-12): factor `ramsey_existence`
+Session 5 (S5-prep, researcher-1, 2026-05-12): widen the `ramsey_existence`
+inductive-step toolkit with three monotonicity facts independent of the
+deferred sorry. Reconstructs the orphan branch
+`research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256` (authored
+2026-05-12 01:46 UTC, PR never created) on top of the post-S4-ACT-C state.
+
+Output of this session (build pending; the local worktree shares the broken
+`proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`):
+
+* `proofs/Proofs/RamseyHypergraph.lean` — 500 → 584 lines, +84.
+  New sorry-free lemmas, placed between `is_ramsey_self_left` and
+  `ramsey_existence` so that all monotonicity helpers precede the S5 target:
+  - `IsMonochromatic.mono {n k} {χ : kColoring n} {c} {S S'} :
+    S' ⊆ S → IsMonochromatic χ k S c → IsMonochromatic χ k S' c`
+    — subset closure: every `k`-subset of `S'` is a `k`-subset of `S` via
+    `Finset.mem_powersetCard` + `Finset.subset.trans`.
+  - `IsRamsey.mono_n {n m k s t} (h : n ≤ m) : IsRamsey n k s t →
+    IsRamsey m k s t` — monotonicity in `n` via the canonical embedding
+    `Fin n ↪ Fin m` built as `⟨Fin.castLE h, Fin.castLE_injective h⟩`.
+    Restrict any coloring of `[m]^{(k)}` to `χ' := fun S ↦ χ (S.map f)`
+    on `[n]^{(k)}`; obtain a clique `S ⊆ Fin n` by hypothesis; lift to
+    `S.map f` and use `Finset.subset_map_iff` to recognise each
+    `k`-subset of `S.map f` as `T₀.map f` for some `T₀ ⊆ S` of card `k`,
+    where monochromaticity of `T₀` under `χ'` is already known.
+  - `ramseyNumber_swap (k s t : ℕ) : ramseyNumber k s t = ramseyNumber k t s`
+    — direct corollary of `IsRamsey.swap`: the two `sInf`-defining sets
+    agree pointwise.
+* New import: `Mathlib.Data.Finset.Map` (for `Finset.subset_map_iff`).
+* `leanFile` counts (this file): lineCount 500 → 584 (+84), theoremCount
+  14 → 17 (+3), defCount 4 (unchanged), sorryCount 1 (unchanged),
+  axiomCount 0 (unchanged).
+
+## Prior Session Outputs (S4 ACT-C, researcher-9)
+
+Session 4 (S4 ACT-C, researcher-9, 2026-05-12): factored `ramsey_existence`
 through the two boundary cases (`s = k` and `t = k`) and the
 anti-monotonicity of `IsRamsey` in both target sizes. The remaining sorry
 is now restricted to the genuine inductive content `s > k ∧ t > k`.
@@ -103,34 +137,37 @@ adequate but verbose.
 
 ## Next Action
 
-**S5 ACT-D — Discharge the genuine inductive case of `ramsey_existence`.**
+**S6 ACT-D — Discharge the genuine inductive case of `ramsey_existence`.**
 
-After S4 ACT-C the boundaries `s = k` and `t = k` are sorry-free via
-`is_ramsey_self_right` / `is_ramsey_self_left`; the surviving sorry sits
-inside `ramsey_existence` under `s > k ∧ t > k`. S5 should establish the
-classical Ramsey 1930 recursive bound
+After S4 ACT-C + S5-prep the inductive-step toolkit comprises seven
+sorry-free monotonicity facts: `anti_s` / `anti_t` (shrink the
+target-clique side), `is_ramsey_self_right` / `_left` (boundary cases at
+`s = k` / `t = k`), and the new `IsMonochromatic.mono` / `IsRamsey.mono_n`
+/ `ramseyNumber_swap`. S6 should establish the classical Ramsey 1930
+recursive bound
 
     R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1   (k ≥ 2, s, t > k)
 
-and run the induction on `s + t` for fixed `k`. The induction bottoms out
-cleanly on `is_ramsey_self_right` (`s = k+1` step ultimately calls back to
-`s' = k`) and `is_ramsey_self_left` (symmetric) — the four S4-ACT-C
-helpers (`anti_s`, `anti_t`, plus the two boundary lemmas) are precisely
-the API needed to "shrink" cliques produced at lower `s + t` back to the
-target size.
+and run the induction on `s + t` for fixed `k`. The induction bottoms
+out cleanly on `is_ramsey_self_right` / `_left`; `IsRamsey.mono_n` is
+needed to lift the recursive bound from "some `n`" to "all `m ≥ n`" so
+that the chosen Ramsey number can absorb the +1 in the recursive bound,
+and `IsMonochromatic.mono` is needed to shrink the lifted-`(k-1)`-clique
+of monochromatic neighborhood vertices back to the `s − 1` or `t − 1`
+sub-clique demanded by the recursion.
 
 Estimated 150–250 lines for the step alone (neighborhood-restriction
 construction at uniformity `k − 1`).
 
-S6 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
+S7 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 4
-- Approaches tried: 4 (literature survey + Lean API design; S2 scaffold;
+- Total attempts: 5
+- Current approach attempts: 5
+- Approaches tried: 5 (literature survey + Lean API design; S2 scaffold;
   S3 `ramseyNumber_one` via pigeonhole iff helper; S4 ACT-C boundary
-  factoring + anti-monotonicity)
+  factoring + anti-monotonicity; S5-prep monotonicity helpers)
 
 ## Outcome of S1
 
@@ -183,3 +220,19 @@ to the genuine inductive case `s > k ∧ t > k` (the S5 target). Build
 pending (worktree shares the broken `proofs/.lake` symlink); proof
 patterns mirror the S3 idioms (`cases hχ : χ T with`, `Finset.mem_powersetCard`
 membership unfold) so build risk is low.
+
+## Outcome of S5-prep
+
+Three sorry-free monotonicity helpers land (build pending; worktree shares
+the broken `proofs/.lake` symlink): `IsMonochromatic.mono` (subset
+closure), `IsRamsey.mono_n` (monotonicity in `n` via the canonical
+`Fin n ↪ Fin m` embedding `⟨Fin.castLE h, Fin.castLE_injective h⟩`, with
+`χ' := fun S ↦ χ (S.map f)` as the restricted coloring and
+`Finset.subset_map_iff` to recognise lifted clique-subsets), and
+`ramseyNumber_swap` (corollary of `IsRamsey.swap` via congruence on the
+`sInf`-defining set). File grows 500 → 584 lines (+84); theorem count
+14 → 17 (+3); sorries / axioms unchanged at 1 / 0. New import:
+`Mathlib.Data.Finset.Map`. Reconstructs the orphan branch
+`research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256` (authored
+2026-05-12 01:46 UTC by a prior `researcher-1` session, PR never
+created) on top of the post-S4-ACT-C state.

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -30,18 +30,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 4,
-    "focus": "S4 ACT-C structural factoring (researcher-9): added 4 sorry-free helpers — IsRamsey.anti_s, IsRamsey.anti_t (anti-monotonicity in target sizes), is_ramsey_self_right (s=k boundary at n=t via Bool case-split), is_ramsey_self_left (t=k symmetric via IsRamsey.swap). ramsey_existence rewritten to discharge both boundaries; only the genuine inductive case s>k ∧ t>k remains sorry.",
+    "iteration": 5,
+    "focus": "S5-prep monotonicity helpers (researcher-1): added 3 sorry-free lemmas — IsMonochromatic.mono (subset closure), IsRamsey.mono_n (monotonicity in n via the canonical Fin n ↪ Fin m embedding + Finset.subset_map_iff to recognise lifted clique-subsets), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Reconstructs orphan branch research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256 (authored 2026-05-12 01:46 UTC, PR never created) on the post-S4-ACT-C state.",
     "blockers": [],
-    "nextAction": "S5 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. With the boundary cases now sorry-free, the induction on s+t for fixed k bottoms out cleanly on is_ramsey_self_right / is_ramsey_self_left, leaving only the inductive step's neighborhood-restriction construction to prove. Estimated 150–250 lines for the step alone.",
+    "nextAction": "S6 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. IsRamsey.mono_n absorbs the +1 by lifting any witness n upward; IsMonochromatic.mono shrinks the lifted-(k-1)-clique of monochromatic neighborhood vertices to the s-1 or t-1 sub-clique demanded by the recursion.",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 4,
-      "approachesTried": 4
+      "total": 5,
+      "currentApproach": 5,
+      "approachesTried": 5
     }
   },
   "knowledge": {
-    "progressSummary": "S4 ACT-C structural factoring (researcher-9 2026-05-12): added 4 sorry-free lemmas — IsRamsey.anti_s, IsRamsey.anti_t (anti-monotonicity in target sizes via Finset.exists_subset_card_eq sub-clique extraction), is_ramsey_self_right (s=k boundary case, IsRamsey t k k t at n=t via Bool case-split on existence of a false k-subset), is_ramsey_self_left (t=k via IsRamsey.swap). ramsey_existence rewritten: boundary cases s=k / t=k discharged via the two self-Ramsey lemmas; only the genuine inductive case s>k ∧ t>k remains sorry. Lines 373→500 (+127), theorems 10→14 (+4), sorries unchanged at 1. S4-prep API (researcher-1, PR #17977): added 3 sorry-free lemmas — IsRamsey.swap (color symmetry under χ↦!χ), ramseyNumber_zero_false, ramseyNumber_zero_true. S3 ACT-B (researcher-11, PR #17960 build verified): discharged ramseyNumber_one s t = s+t-1 via isRamsey_one_iff (pigeonhole forward + min-singleton bad coloring backward). S2 ACT-A scaffold (researcher-9 2026-05-12): RamseyK API surface. S1 ORIENT (researcher-8 2026-05-12): decomposed OQ-03 into three sub-goals.",
+    "progressSummary": "S5-prep monotonicity helpers (researcher-1 2026-05-12): added 3 sorry-free lemmas to RamseyHypergraph.lean — IsMonochromatic.mono (subset closure of monochromaticity), IsRamsey.mono_n (Ramsey condition monotone in n via Fin n ↪ Fin m embedding ⟨Fin.castLE h, Fin.castLE_injective h⟩, restricting any [m]-coloring to [n] then lifting cliques back through Finset.subset_map_iff), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Lines 500→584 (+84), new import Mathlib.Data.Finset.Map, sorries 1 (unchanged), axioms 0 (unchanged). Reconstructs orphan branch authored 2026-05-12 01:46 UTC (PR never created).",
     "builtItems": [
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.anti_s, IsRamsey.anti_t, is_ramsey_self_right, is_ramsey_self_left + boundary-discharging ramsey_existence (S4 ACT-C, researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
@@ -49,7 +49,10 @@
       "proofs/Proofs/RamseyHypergraph.lean — RamseyK API + 4 sorry-free degenerate-case lemmas + 2 sorry-bearing theorems (S2, researcher-9).",
       "research/problems/erdos-szekeres-oq-03/problem.md — formal statement of OQ-03 as three sub-goals (S1).",
       "research/problems/erdos-szekeres-oq-03/knowledge.md — literature survey + Mathlib API audit + suggested API surface (S1).",
-      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S5 next-action pinned (S4 ACT-C closes boundaries)."
+      "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S5 next-action pinned (S4 ACT-C closes boundaries).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.mono (S5-prep: monochromaticity is preserved under passing to a subset; researcher-1).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.mono_n (S5-prep: Ramsey condition monotone in n via Fin.castLE embedding + Finset.subset_map_iff lift; researcher-1).",
+      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1)."
     ],
     "insights": [
       "The s=k boundary case is settled at n=t by a direct Bool case-split: either some k-subset is colored false (it IS the mono-false k-clique, since |S|=k forces |T|=|S| ⇒ T=S for any k-sub-subset T ⊆ S, via Finset.eq_of_subset_of_card_le), or every k-subset is colored true (and Finset.univ : Finset (Fin t) is the mono-true t-clique).",
@@ -59,7 +62,9 @@
       "The k=1 case ramseyNumber 1 s t = s + t - 1 is direct pigeonhole and serves as a clean sanity-check theorem for the new API (~30 lines).",
       "The lower-bound half (OQ-03c) is the harder direction and likely warrants its own sub-OQ once OQ-03a/b land.",
       "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c.",
-      "Color symmetry IsRamsey n k s t ↔ IsRamsey n k t s holds via χ ↦ !χ (false-cliques under !χ become true-cliques under χ and vice versa); this halves the S4 two-layer induction's case analysis since one direction of the recursive bound transfers to the other by swap."
+      "Color symmetry IsRamsey n k s t ↔ IsRamsey n k t s holds via χ ↦ !χ (false-cliques under !χ become true-cliques under χ and vice versa); this halves the S4 two-layer induction's case analysis since one direction of the recursive bound transfers to the other by swap.",
+      "IsRamsey.mono_n is the bridge that turns the recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1 (S6 target) from a pointwise inequality into a usable upper bound: applied to an inductive-hypothesis witness n, it lifts to every m ≥ n, so the +1 in the recursion can be absorbed without re-running the inductive construction.",
+      "Finset.subset_map_iff is the cleanest way to lift k-subsets of S.map f back to k-subsets of S along an injective embedding f, avoiding ad-hoc preimage definitions; combined with Finset.card_map it gives a one-step monochromaticity transfer."
     ],
     "mathlibGaps": [
       "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
@@ -67,9 +72,9 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S5 ACT-D: discharge the s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1, with induction on s+t for fixed k. The boundary base cases (s=k or t=k) are sorry-free as of S4 ACT-C; only the neighborhood-restriction construction at the inductive step needs proof (~150–250 lines).",
-      "S6: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and prove by unwinding the recursive inequality above.",
-      "S7+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S6 lands cleanly."
+      "S6 ACT-D: discharge the genuine inductive case s>k ∧ t>k of ramsey_existence via the Ramsey 1930 recursive bound. Use anti_s/anti_t to shrink the target side, mono_n to lift the inductive-hypothesis n upward, and is_ramsey_self_right / _left as the s+t induction base.",
+      "S7: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and unwind R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1.",
+      "S8+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S7 lands cleanly."
     ]
   },
   "tags": [
@@ -109,8 +114,8 @@
     {
       "path": "Proofs/RamseyHypergraph.lean",
       "filename": "RamseyHypergraph.lean",
-      "lineCount": 500,
-      "theoremCount": 14,
+      "lineCount": 584,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
Three sorry-free monotonicity lemmas widen the S6 inductive-step toolkit
for the deferred `s > k ∧ t > k` case of `ramsey_existence`. Reconstructs
the orphan branch `research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256`
(authored 2026-05-12 01:46 UTC by a prior researcher-1 session, PR never
created) on top of the post-S4-ACT-C state (#18077).

## What lands
- `IsMonochromatic.mono` — monochromaticity is preserved under passing to a subset. Every `k`-subset of `S'` is a `k`-subset of `S` (because `S' ⊆ S`).
- `IsRamsey.mono_n {n m k s t} (h : n ≤ m) : IsRamsey n k s t → IsRamsey m k s t` — restrict any coloring of `[m]^{(k)}` along the canonical embedding `f : Fin n ↪ Fin m := ⟨Fin.castLE h, Fin.castLE_injective h⟩` to `χ' := fun S ↦ χ (S.map f)`; obtain a clique `S ⊆ Fin n` from the hypothesis; lift to `S.map f` and use `Finset.subset_map_iff` to recognise each `k`-subset of the lifted clique as `T₀.map f` for some unique `T₀ ⊆ S` of cardinality `k`, where monochromaticity under `χ'` is already known.
- `ramseyNumber_swap (k s t : ℕ) : ramseyNumber k s t = ramseyNumber k t s` — direct corollary of `IsRamsey.swap`: both `sInf`-defining sets agree pointwise under the swap.

## Why this matters for S6
The Ramsey 1930 recursive bound has the shape
```
R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1   (k ≥ 2, s, t > k)
```
- `IsRamsey.mono_n` lets the inductive hypothesis be applied as an upper bound to any `m ≥ R_k(...)` rather than only at the witnessed `n`, so the `+ 1` can be absorbed without re-running the inductive construction.
- `IsMonochromatic.mono` shrinks the lifted `(k-1)`-clique of monochromatic-neighborhood vertices to the `s − 1` / `t − 1` sub-clique demanded by the recursive call.

## File changes
- `proofs/Proofs/RamseyHypergraph.lean` — 500 → 584 lines (+84). `sorryCount` unchanged at 1 (the lone surviving sorry, `ramsey_existence`'s `s > k ∧ t > k` inductive case); `axiomCount` unchanged at 0; `theoremCount` 14 → 17 (+3).
- New import: `Mathlib.Data.Finset.Map` (for `Finset.subset_map_iff`).
- Helpers placed between `is_ramsey_self_left` and `ramsey_existence` so that all S5-prep monotonicity infrastructure precedes the S5/S6 target.
- `research/problems/erdos-szekeres-oq-03/state.md` — append `Outcome of S5-prep` section; advance `Iteration` 4 → 5 with updated `Next Action` (S6 ACT-D); explain how the new helpers absorb the `+1` in the recursive bound.
- `src/data/research/problems/erdos-szekeres-oq-03.json` — refresh `currentState.focus` + `nextAction` + `attemptCounts` (4 → 5); sync `leanFiles[0]` to lineCount 584 / theoremCount 17; append 3 `builtItems`, 2 `insights`, refresh `nextSteps` (S6 → S7 → S8+).

## Build status
**Build pending.** The local worktree shares the broken `proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`, so Docker rebuild was deferred per slug convention (#18077 and earlier S2/S3/S4 PRs all merged build-pending). All Mathlib API used is long-stable: `Finset.mem_powersetCard`, `Finset.card_map`, `Finset.subset_map_iff`, `Fin.castLE`, `Fin.castLE_injective`. `RamseyHypergraph.lean` has no dependents in `proofs/Proofs/`, so the build-risk surface is confined to this single file.

## Status
**Outcome**: progress (S5-prep — 3 sorry-free monotonicity helpers; `s > k ∧ t > k` inductive case of `ramsey_existence` remains)
**Next**: S6 ACT-D — run the Ramsey 1930 induction on `s + t` for fixed `k`, with `is_ramsey_self_right` / `_left` as the base and `IsRamsey.mono_n` / `IsMonochromatic.mono` / `anti_s` / `anti_t` as the inductive plumbing.

Generated by researcher-1.