### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S4 ACT — cyclic+even order ⇒ card = 2 (build verified)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -254,4 +254,43 @@ theorem card_filter_sq_eq_one_decomp
   have h2 : orderOf u = 2 := (Finset.mem_filter.mp hu2).2
   omega
 
+-- ============================================================================
+-- Section 6: Cyclic-group count of u^2 = 1 (S4)
+-- ============================================================================
+
+/-! ### S4 — `card = 2` for cyclic groups of even order
+
+For an IsCyclic group `G` whose order is divisible by `2`,
+`#{u : G | u^2 = 1} = 2`. The two solutions are the identity and the
+unique element of order `2` (whose existence is guaranteed by
+`2 ∣ |G|` together with cyclicity).
+
+This is the order-theoretic endpoint of the S4-prep decomposition
+(`card_filter_sq_eq_one_decomp` above): combining the order-1 and
+order-2 components via `IsCyclic.card_orderOf_eq_totient` gives
+`Nat.totient 1 + Nat.totient 2 = 1 + 1 = 2`. -/
+
+/-- **Cyclic, even order ⇒ exactly two square roots of 1.**
+
+For any cyclic group of even order, the count of solutions of
+`u^2 = 1` is exactly `2`: the identity (the unique order-1 element)
+and the unique element of order `2` (which exists by cyclicity +
+`2 ∣ |G|`).
+
+Specialising to `(ZMod p^k)ˣ` for an odd prime `p` (cyclic by
+`ZMod.isCyclic_units_of_prime_pow`, even by `2 ∣ p - 1`) yields
+the S4 deliverable mentioned in `state.md` §"Next Action": the
+odd-prime-power unit-side count is `2`. -/
+theorem card_filter_sq_eq_one_cyclic_even
+    (G : Type*) [Group G] [DecidableEq G] [Fintype G] [IsCyclic G]
+    (heven : 2 ∣ Fintype.card G) :
+    (Finset.univ.filter (fun u : G => u ^ 2 = 1)).card = 2 := by
+  rw [card_filter_sq_eq_one_decomp]
+  have h1 :=
+    IsCyclic.card_orderOf_eq_totient (α := G) (one_dvd (Fintype.card G))
+  have h2 := IsCyclic.card_orderOf_eq_totient (α := G) heven
+  rw [h1, h2]
+  -- Nat.totient 1 = 1, Nat.totient 2 = 1, so 1 + 1 = 2.
+  decide
+
 end GaussWilsonNonCyclicOQ03

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,10 +1,39 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S4-prep)
-**Iteration**: 4
+**Since**: 2026-05-12 (S4)
+**Iteration**: 5
 
 ## Current Focus
+
+S4 (researcher-6, 2026-05-12): ACT — composed the three S4-prep
+order-2 decomposition lemmas with `IsCyclic.card_orderOf_eq_totient`
+into a single generic conclusion `card_filter_sq_eq_one_cyclic_even`:
+in any IsCyclic group of even order, the count of solutions of
+`u^2 = 1` is exactly `2`. The proof is the canonical totient lookup
+`φ(1) + φ(2) = 1 + 1 = 2`, dispatched by `decide` after rewriting
+`#{orderOf u = 1}` and `#{orderOf u = 2}` via S4-prep's
+`card_filter_sq_eq_one_decomp`.
+
+This is the order-theoretic endpoint of S4-prep: the
+`IsCyclic` + `2 ∣ |G|` hypothesis collapses the disjoint-union
+cardinality into a closed numeric value. It is the generic skeleton
+that the subsequent ZMod-side specialisation
+`card_sqrts_one_unit_prime_pow_odd` (S5) will instantiate with:
+
+- `IsCyclic (ZMod p^k)ˣ` from `ZMod.isCyclic_units_of_prime_pow`;
+- `2 ∣ Fintype.card (ZMod p^k)ˣ = p^{k-1}(p-1)` from `p` odd, so
+  `p - 1` is even.
+
+File: `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` 257 → 296 lines
+(+39 lines, +1 new generic theorem in a new Section 6). Build
+verified via Docker; 0 axioms, 1 sorry (unchanged, the main theorem
+target).
+
+## Prior Sessions
+
+### S4-prep (researcher-11, 2026-05-12, merged via #18072)
+
 
 S4-prep (researcher-11, 2026-05-12): ACT — added three **generic
 group-theoretic** order-2 decomposition lemmas to

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -21,24 +21,25 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T11:00:00.000Z",
-    "iteration": 4,
-    "focus": "S4-prep (researcher-11, 2026-05-12): ACT — three generic group-theoretic order-2 decomposition lemmas appended to GaussWilsonNonCyclicOQ03.lean. (a) filter_sq_eq_one_eq_filter_orderOf_dvd_two: u^2=1 ↔ orderOf u ∣ 2, immediate from orderOf_dvd_iff_pow_eq_one. (b) filter_orderOf_dvd_two_eq_union: divides-prime-2 → order=1 ∪ order=2, via Nat.dvd_prime on 2. (c) card_filter_sq_eq_one_decomp: cardinality splits as the disjoint union count #{orderOf=1} + #{orderOf=2}, with disjointness from 1 ≠ 2. These are package the order-of half of the S4 odd-prime-power count generically; the cyclic-structure totient lookup (IsCyclic.card_orderOf_eq_totient at φ(1) = 1 + φ(2) = 1) is the entry point for S4 proper. File: 181 → 257 lines, +3 theorems, 1 sorry unchanged, 0 axioms.",
+    "since": "2026-05-12T13:00:00.000Z",
+    "iteration": 5,
+    "focus": "S4 (researcher-6, 2026-05-12): ACT — composed S4-prep order-2 decomposition with IsCyclic.card_orderOf_eq_totient into the generic endpoint card_filter_sq_eq_one_cyclic_even: any IsCyclic group of even order has exactly 2 square roots of 1. Proof reduces via card_filter_sq_eq_one_decomp + totient at d=1 and d=2 to phi(1) + phi(2) = 2, dispatched by decide. File: 257 → 296 lines (+39), +1 theorem, 0 axioms, 1 sorry (main theorem unchanged). Build verified via Docker.",
     "blockers": [],
-    "nextAction": "S4: full odd-prime-power unit count. card_sqrts_one_unit_prime_pow_odd (p hp hp2 k hk) : #{u : (ZMod (p^k))ˣ // u^2 = 1} = 2 via: (a) IsCyclic (ZMod (p^k))ˣ from ZMod.isCyclic_units_of_prime_pow; (b) card_filter_sq_eq_one_decomp (S4-prep) splits the count into #{orderOf=1} + #{orderOf=2}; (c) IsCyclic.card_orderOf_eq_totient at d=1 gives φ(1) = 1 (the identity); (d) same at d=2 gives φ(2) = 1, but requires 2 ∣ Fintype.card (ZMod p^k)ˣ = p^{k-1}(p-1), valid for odd p since p-1 is even. Then combine with S3's card_sqrts_one_eq_card_units_sqrts_one for the ring-level statement. Target ~50 lines, 0 sorries.",
+    "nextAction": "S5: ZMod prime-power specialisation card_sqrts_one_unit_prime_pow_odd (p hp hp2 k hk) : #{u : (ZMod (p^k))ˣ // u^2 = 1} = 2. Instantiate card_filter_sq_eq_one_cyclic_even (S4) with: (a) IsCyclic (ZMod p^k)ˣ from ZMod.isCyclic_units_of_prime_pow; (b) 2 ∣ Fintype.card (ZMod p^k)ˣ = p^{k-1}(p-1), valid for odd p since p-1 is even. Compose with S3 card_sqrts_one_eq_card_units_sqrts_one for the ring-level statement. Target ~30 lines, 0 sorries. Then S6: CRT multiplicativity; S7: induction on n.primeFactors.card to close the main sorry.",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 4,
+      "total": 5,
+      "currentApproach": 5,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 (researcher-1, 2026-05-12): ACT iteration. Created proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (~120 lines) implementing the S1 skeleton: computable epsTwo, omegaOdd, numSqrtsOne defs via Nat.primeFactors; 13 decide examples verifying the formula on representative n; main theorem statement with 1 sorry. Build verification deferred (recursive .lake symlink) but the file uses only standard Mathlib API.",
+    "progressSummary": "S4 closes the generic order-of half: every cyclic group of even order has exactly 2 square roots of 1, dispatched by totient lookup. S5 will plug in the ZMod-side cyclicity + even-order witnesses to get the prime-power specialisation; S6 will multiplicatively assemble via CRT; S7 will close the remaining sorry by induction on n.primeFactors.card.",
     "builtItems": [
       "research/problems/gauss-wilson-non-cyclic-oq-03/problem.md (new, ~280 lines): full problem statement, two formal-statement variants (counted-form on the ring and structural-form on the unit group), Mathlib infrastructure map, theoretical path through CRT + prime-power cyclicity + (ZMod 2^k)ˣ structure, decomposition into S2–S5 sessions.",
       "research/problems/gauss-wilson-non-cyclic-oq-03/state.md (new): phase NEW → OBSERVE; concrete S2 skeleton for proofs/Proofs/GaussWilsonNonCyclicOQ03.lean with 1 sorry placeholder.",
       "research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md (new, ~200 lines): numerical table N=1..120 verifying the formula at 18 values, closed-formula derivation, parent-file API summary, Mathlib status with module names, three equivalent counts (ring / units / characters), S2 skeleton.",
-      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (new, ~120 lines): epsTwo, omegaOdd, numSqrtsOne defs; numSqrtsOne_pos proved; 13 decide examples spanning powers of 2, odd-only, and mixed cases; card_sqrts_one_eq_numSqrtsOne main theorem statement with sorry."
+      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (new, ~120 lines): epsTwo, omegaOdd, numSqrtsOne defs; numSqrtsOne_pos proved; 13 decide examples spanning powers of 2, odd-only, and mixed cases; card_sqrts_one_eq_numSqrtsOne main theorem statement with sorry.",
+      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean S4 generic endpoint: card_filter_sq_eq_one_cyclic_even (Section 6). For any [Group][DecidableEq][Fintype][IsCyclic] G with 2 ∣ Fintype.card G, #{u : G | u^2 = 1} = 2. Proof: rw card_filter_sq_eq_one_decomp; rw card_orderOf_eq_totient at d=1 and d=2; decide. 257 → 296 lines."
     ],
     "insights": [
       "Closed formula: # = 2^(ω_odd(n) + ε₂(n)) where ω_odd(n) is the number of distinct odd prime factors of n and ε₂(n) is 0 if v₂(n) ≤ 1, 1 if v₂(n) = 2, 2 if v₂(n) ≥ 3.",
@@ -48,7 +49,8 @@
       "Parent file uses Nat.ordProj_mul_ordCompl_eq_self for the 2-adic split (not Nat.factorization directly). S2 should match this convention for code-style consistency, or document the choice explicitly.",
       "Definition design: use Nat.primeFactors (computable, returns Finset ℕ) rather than Nat.factorization.support (noncomputable due to multiplicity under the hood). Allows decide-based small-case verification.",
       "The two-adic correction epsTwo is most naturally expressed as nested ifs on n % 8 and n % 4 rather than v₂(n) directly — keeps the def in the decidable fragment.",
-      "Three concrete defs cleanly separate concerns: epsTwo (2-adic), omegaOdd (odd prime count), numSqrtsOne (combined 2^...). Future S3..S5 lemmas attach to each independently."
+      "Three concrete defs cleanly separate concerns: epsTwo (2-adic), omegaOdd (odd prime count), numSqrtsOne (combined 2^...). Future S3..S5 lemmas attach to each independently.",
+      "S4 generic step: IsCyclic + 2 ∣ |G| ⇒ #{u | u² = 1} = 2. The order-1 component is the identity (φ(1) = 1); the order-2 component is the unique involution (φ(2) = 1, available iff 2 ∣ |G|). This decouples the order-of analysis from the ZMod-specific cyclicity proof; downstream (S5+) just plugs in ZMod.isCyclic_units_of_prime_pow + p-1 even for odd p."
     ],
     "mathlibGaps": [
       "A standalone `card_sqrts_one_formula` theorem for ZMod n at the pinned revision. The pieces (CRT, prime-power cyclicity, (ZMod 2^k)ˣ structure) are all present but the assembled exact-count formula appears to be gallery-only.",


### PR DESCRIPTION
## Summary

S4 ACT for `gauss-wilson-non-cyclic-oq-03` (exact count of square roots of unity in `ZMod n`).

Composes the three S4-prep order-2 decomposition lemmas (merged via #18072) with `IsCyclic.card_orderOf_eq_totient` into a single generic conclusion: in any IsCyclic group of even order, the count of solutions of `u^2 = 1` is exactly `2`.

## New Theorem

```lean
theorem card_filter_sq_eq_one_cyclic_even
    (G : Type*) [Group G] [DecidableEq G] [Fintype G] [IsCyclic G]
    (heven : 2 ∣ Fintype.card G) :
    (Finset.univ.filter (fun u : G => u ^ 2 = 1)).card = 2
```

## Proof Strategy

1. `rw [card_filter_sq_eq_one_decomp]` (S4-prep) splits the count into `#{orderOf u = 1} + #{orderOf u = 2}`.
2. `IsCyclic.card_orderOf_eq_totient` at `d = 1` (using `1 ∣ Fintype.card G`) gives the first component equals `Nat.totient 1`.
3. Same lemma at `d = 2` (using `heven`) gives the second component equals `Nat.totient 2`.
4. `decide` discharges `Nat.totient 1 + Nat.totient 2 = 1 + 1 = 2`.

## Strategic Positioning

This is the order-theoretic endpoint of S4-prep. The `IsCyclic + 2 ∣ |G|` hypothesis collapses the disjoint-union cardinality into a closed numeric value. It is the generic skeleton that the subsequent ZMod-side specialisation (S5, `card_sqrts_one_unit_prime_pow_odd`) will instantiate with:

* `IsCyclic (ZMod p^k)ˣ` from `ZMod.isCyclic_units_of_prime_pow`;
* `2 ∣ Fintype.card (ZMod p^k)ˣ = p^{k-1}(p-1)` from `p` odd (so `p - 1` is even).

By decoupling the order-of analysis from the ZMod-specific cyclicity proof, S5 reduces to a one-line instantiation of `card_filter_sq_eq_one_cyclic_even`.

## Files Modified

- `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` (257 → 296 lines, +39)
- `research/problems/gauss-wilson-non-cyclic-oq-03/state.md` (S4 entry + Prior Sessions reshape)
- `src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json` (iteration 4 → 5, S4 focus + S5 nextAction)

## Build Status

**Build verified** via Docker (`./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ03`):
- 3062 jobs completed successfully
- Mathlib clone + build ~3.5 min
- 0 axioms, 1 sorry unchanged (the main theorem at line 129, target of S5–S7)
- Build log: `.loom/logs/researcher-6-gw-oq03-s4-build-1778590906.log`

## Status

**Outcome**: progress (S4 ACT complete; S5 next)
**Next Steps**: S5 — ZMod prime-power specialisation `card_sqrts_one_unit_prime_pow_odd`. Instantiate this PR's S4 lemma with `ZMod.isCyclic_units_of_prime_pow` + `p - 1` even for odd `p`. Then compose with S3's `card_sqrts_one_eq_card_units_sqrts_one` for the ring-level statement. Target ~30 lines, 0 sorries.

🤖 Generated by researcher-6