### PR TITLE
fix(meta): sync sorries + count drift in 3 entries (shannon, mvt-04-01)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 614,
+    "lineCount": 621,
     "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in §2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in §3a via constant-1 witness on ℂ, S3 contribution). One sorry remains in cauchy_diag_norm_bound (the per-degree Cauchy coefficient estimate ‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / R)^k); the surrounding §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo this single sub-lemma (S4 contribution).",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
@@ -96,7 +96,7 @@
       "Demonstration that the explicit R^n factor in the denominator (M·r^(n+1) / (R^n · (R-r))) is essential; the OQ-04 statement that absorbs R^n into M is too weak to be true under real-only hypotheses.",
       "S4 (Iter 4): the §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo a single named sub-lemma cauchy_diag_norm_bound. The combination scaffolding (HasFPowerSeriesOnBall.hasSum_sub → per-term geometric bound via cauchy_diag_norm_bound → norm_sub_le_of_geometric_bound_of_hasSum at index n+1 → norm_sub_rev + field_simp + ring rescaling using 1 − r/R = (R−r)/R) is now Lean code, not docstring. Sorry count stays at 1 (moved from main-theorem black-box to a single Cauchy-coefficient gap)."
     ],
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 0
 }

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "original",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",
@@ -225,5 +225,5 @@
       "note": "Chapter 7: Fano's inequality and its application to channel coding converse"
     }
   ],
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

| Slug | Field | Before | After |
|------|-------|--------|-------|
| `shannon-channel-coding-oq-02-oq-01` | `meta.sorries` + top `sorries` | 4 | 0 |
| `shannon-channel-coding-oq-03` | `meta.sorries` + top `sorries` | 4 | 0 |
| `mean-value-theorem-oq-02-oq-04-oq-01` | `meta.theoremCount` | 10 | 12 |
| `mean-value-theorem-oq-02-oq-04-oq-01` | `meta.lineCount` | 614 | 621 |

## Evidence

### shannon-channel-coding-oq-02-oq-01 — `sorries: 4 → 0`

`leanFile.sorries` already correctly states 0; only `meta.sorries` and the top-level `sorries` were stale.

```bash
$ python3 strip_comments.py proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean | grep -c '\bsorry\b'
0
```

### shannon-channel-coding-oq-03 — `sorries: 4 → 0`

The `assumptions` field already states `"0 axioms, 0 sorries. All lemmas fully proved: ..."`, so the meta is internally inconsistent. `leanFile.sorries: 0` was correct.

```bash
$ python3 strip_comments.py proofs/Proofs/ShannonChannelCodingOQ03.lean | grep -c '\bsorry\b'
0
```

### mean-value-theorem-oq-02-oq-04-oq-01 — post-#18085 drift

PR #18085 (S4 ACT — §3b combination scaffolding) added 2 new theorems and 7 lines.

```bash
$ python3 strip_comments.py proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean | grep -cE '^\s*(theorem|lemma)\s+'
12
$ wc -l proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
621
```

`leanFile` block absent for this entry, so only `meta.{theoremCount,lineCount}` were touched.

### Counting convention

Main-file-only structural counts (matches PR #18006 / #18079 / #18093 baseline):

```
theorems: ^\s*(@\[…\]\s*)*(private|protected|noncomputable\s+)*(theorem|lemma)\s+
lines:    raw newline count
sorries:  occurrences of `\bsorry\b`
```

after stripping nested `/- -/` block comments and `--` line comments.

`axiomCount` is unchanged for all 3 entries (the aggregate convention from PR #18120 does not apply here since main-file axiom counts already match).

---

Meta-only PR; no Lean source touched.

Automated fix by lean-mechanic agent.