### PR TITLE
research(inverse-galois-a5-oq-01): S1 OBSERVE — three-route survey for axiom three_dvd_gal_card elimination (doc-only)

### DIFF
--- a/research/problems/inverse-galois-a5-oq-01/knowledge.md
+++ b/research/problems/inverse-galois-a5-oq-01/knowledge.md
@@ -1,0 +1,194 @@
+# Knowledge — inverse-galois-a5-oq-01
+
+## S1 (researcher-12, 2026-05-12) — OBSERVE survey
+
+### Status
+
+The task is to **eliminate the parent's last axiom** `three_dvd_gal_card`
+and upgrade `inverse-galois-a5` from `status: axiomatized` (1 axiom,
+84 theorems, 2067 lines) to `status: verified` (0 axioms,
+`badge: original`). The axiom asserts `3 ∣ Fintype.card q.Gal` where
+`q.Gal := q.SplittingField ≃ₐ[ℚ] q.SplittingField` and
+`q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5`.
+
+Three discharge strategies exist (R1 / R2 / R3 in `problem.md`).
+R1 (specialised Dedekind at `p = 7`) is the **recommended S2 entry
+point**: it uses the existing Part XII decidable verification and
+adds only the Frobenius-construction-and-cycle-type bridge.
+
+### Parent file inventory
+
+`proofs/Proofs/InverseGaloisA5.lean` (2067 lines, 1 axiom, 0 sorries,
+84 theorems, 12 defs) provides the surrounding infrastructure:
+
+| Decl | Line | Role for OQ-01 |
+|------|------|----------------|
+| `def q : ℤ[X]` | (Part I, ~85) | the polynomial whose Galois group we are analysing |
+| `q.Gal` (abbrev for `q.SplittingField ≃ₐ[ℚ] q.SplittingField`) | (Part II) | the Galois group target |
+| `q_irreducible` | (Part III) | Eisenstein at `p = 5`, used by `five_dvd_gal_card` |
+| `disc_value_is_square` | 779 | `(32000 : ℤ)^2 = 1024000000` — discriminant value |
+| `trinomial_disc_computation` | 783 | `4⁴·20⁵ + 5⁵·16⁴ = 1024000000` |
+| `q_root_mod7_at_5` | 787 | `q(5) ≡ 0 mod 7` (decidable) |
+| `q_root_mod7_at_6` | 791 | `q(6) ≡ 0 mod 7` (decidable) |
+| `cubic_factor_no_roots_mod7` | 796 | `X³ + 6X² + 4X + 1` has no roots in `F₇` |
+| `five_dvd_gal_card` | 207 | `5 ∣ Fintype.card q.Gal` (proved, via Cauchy + degree) |
+| `gal_card_dvd_120` | 215 | `Fintype.card q.Gal ∣ 120` (via root permutation embedding) |
+| `gal_card_dvd_60_proved` | (Part XV) | `Fintype.card q.Gal ∣ 60` (Vandermonde discriminant chain) |
+| **`three_dvd_gal_card`** | **309** | **THE TARGET AXIOM** |
+| `no_subgroup_order_15` | 511 | rules out `|Gal| = 15` (Sylow, no element of order 15 in S₅) |
+| `no_subgroup_order_30` | 532 | rules out `|Gal| = 30` (A₅ simple ⇒ no index-2 subgroup of order 30) |
+| `q_gal_card` (proved theorem, NOT axiom) | (Part XVI) | `Fintype.card q.Gal = 60` — combines 5∣, 3∣, ∣60, ≠15, ≠30 |
+| `q_gal_iso_a5` | (Part XVI) | `Gal(q) ≅ A₅` via `Equiv.Perm.eq_alternatingGroup_of_index_eq_two` |
+| `a5_realizable_iso`, `gal_not_solvable` | (Part XVII) | main theorems consuming `q_gal_card` |
+
+Note: `three_dvd_gal_card` is the **only axiom** in the parent file at
+the current revision (Part XII comments call earlier "axioms" A/C/D
+eliminated; Axiom B is the surviving one renamed `three_dvd_gal_card`).
+
+### Dedekind's theorem (specialised form needed for R1)
+
+For the specific case `(q, p) = (q, 7)`, the theorem statement is:
+
+> Let `K = q.SplittingField`, `O_K` its ring of integers, and `α₁, …, α₅`
+> the roots of `q` in `K`. Let `𝔭 ⊂ O_K` be any prime ideal above `7`
+> (since `7 ∤ disc(q) = 32000²`, `7` is unramified). Then the Frobenius
+> automorphism `Frob_𝔭 ∈ Gal(K/ℚ)`, acting on `{α₁, …, α₅}` as a permutation
+> in `S_5`, has cycle type matching the mod-7 factorisation of `q`:
+> namely `(1, 1, 3)` (two fixed roots — those reducing to `5` and `6` mod 7 —
+> and a 3-cycle on the remaining three roots).
+
+Consequence: `Frob_𝔭` has order 3 in `Gal(K/ℚ)`, hence `3 ∣ |Gal|`.
+
+The **proof** of this specialised Dedekind statement in Lean requires:
+
+1. **A prime ideal at 7**: exhibit some `𝔭 ⊂ O_K` with `𝔭 ∩ ℤ = 7ℤ`.
+   `Mathlib.NumberTheory.RamificationInertia` provides the existence
+   (`Ideal.exists_isMaximal_ne_bot_of_isPrime` etc.); the decomposition
+   index `f(𝔭/7)` should equal `3` (the cubic factor degree).
+2. **The decomposition group `D(𝔭/7) ⊂ Gal(K/ℚ)`**: cyclic of order
+   `f(𝔭/7) = 3` since `7` is unramified.
+3. **The Frobenius generator `σ` of `D(𝔭/7)`**: acts on the residue
+   field `O_K / 𝔭` as `x ↦ x^7`; lifts to the permutation that fixes
+   the two roots reducing to `5, 6 ∈ F₇` and 3-cycles the three roots
+   in the irreducible cubic factor.
+4. **Cycle type of `σ`** in `S_5` via the root-permutation embedding
+   `φ : Gal(K/ℚ) →* S_5`.
+
+Step 1 is in Mathlib but needs careful instantiation. Step 2 follows
+from `Mathlib.NumberTheory.RamificationInertia.Galois`. Steps 3 and 4
+are the **substantive new content** — roughly 200-300 lines of
+careful coordinate-tracking.
+
+### Mathlib API survey (`v4.26.0`)
+
+| Class / lemma | Module | Purpose for OQ-01 |
+|---------------|--------|---|
+| `NumberField K` | `Mathlib.NumberTheory.NumberField.Basic` | base typeclass on `q.SplittingField` |
+| `Ideal.IsPrime`, `Ideal.IsMaximal` | core | the ideal `𝔭` |
+| `Polynomial.disc`, `Algebra.discr` | `RingTheory.Discriminant` | gives `disc(q) = 32000²`, used for unramifiedness at 7 |
+| `Ideal.ramificationIdx`, `Ideal.inertiaDeg` | `Mathlib.NumberTheory.RamificationInertia.Basic` | `e(𝔭/7) = 1` (unramified), `f(𝔭/7) ∈ {1, 1, 3}` |
+| `Ideal.Quotient.frobenius` (approx — name may differ) | `Mathlib.NumberTheory.RamificationInertia.Galois` | provides the Frobenius element at an unramified prime |
+| `Equiv.Perm.cycleType` | `Mathlib.GroupTheory.Perm.Cycle.Type` | cycle-type of the image of `σ` in `S₅` |
+| `orderOf` | `Mathlib.GroupTheory.OrderOfElement.Basic` | `orderOf σ = 3` from cycle type |
+| `Cauchy` (existence of element of prime order divisor) | `Mathlib.GroupTheory.SpecificGroups.Cyclic` etc. | reverse direction: order 3 ⇒ 3 ∣ |Gal| |
+
+The bridge `cycle type (1,1,3) ⇒ order 3` is mostly mechanical
+(`Equiv.Perm.lcm_cycleType_eq_orderOf` or similar).
+
+### R1 (specialised Dedekind) Lean skeleton
+
+```lean
+-- File: proofs/Proofs/InverseGaloisA5Dedekind.lean (new, ~250 lines)
+import Proofs.InverseGaloisA5
+import Mathlib.NumberTheory.RamificationInertia.Galois
+import Mathlib.GroupTheory.Perm.Cycle.Type
+
+namespace InverseGaloisA5Dedekind
+
+open Polynomial InverseGaloisA5
+
+local notation "K" => q.SplittingField
+local notation "OK" => 𝓞 K  -- ring of integers
+
+/-- 7 is unramified in K: `disc(q) = 32000² = 2¹⁴·5⁶·10⁴` is coprime to 7. -/
+theorem seven_unramified : ¬ 7 ∣ Polynomial.disc q := by
+  sorry  -- S3: decide-based arithmetic on disc value
+
+/-- A prime ideal of OK above 7 with inertia degree 3 (corresponding
+to the irreducible cubic factor X³+6X²+4X+1 of q mod 7). -/
+noncomputable def 𝔭₃ : Ideal OK :=
+  sorry  -- S3: explicit construction or non-constructive existence
+
+theorem 𝔭₃_inertia_deg : Ideal.inertiaDeg 𝔭₃ (7 : ℤ) = 3 :=
+  sorry  -- S3
+
+/-- The Frobenius element at 𝔭₃, viewed in Gal(q/ℚ). -/
+noncomputable def frob₃ : q.Gal :=
+  sorry  -- S3: extract from Ideal.Quotient.frobenius framework
+
+theorem frob₃_order_eq_three : orderOf frob₃ = 3 :=
+  sorry  -- S3: follows from inertia degree 3
+
+theorem three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal := by
+  -- Use Cauchy / orderOf-divides-cardinality on frob₃
+  rw [← frob₃_order_eq_three]
+  exact orderOf_dvd_card
+
+end InverseGaloisA5Dedekind
+```
+
+### Decomposition plan (effort estimates)
+
+| Session | Lines (est.) | Sorries delta | Axioms delta | Net |
+|---------|--------------|---------------|--------------|-----|
+| S1 OBSERVE (this) | 0 Lean / ~600 md+json | 0 | 0 | survey only |
+| S2 ORIENT | ~80 Lean (skeleton + 4 sorries) | +4 | 0 | new file structure |
+| S3 ACT (Frobenius construction) | ~400 Lean (discharge 4 sorries) | -4 | 0 | proves three_dvd_gal_card |
+| S4 CLOSE (parent integration) | ~10 Lean diff + ~30 meta.json | 0 | **-1** | parent verified ✓ |
+| S5 (optional) | resolvent-sextic alt-route documentation | 0 | 0 | safety valve |
+
+Total over S2-S4: ~490 Lean, 0 net sorries, **-1 axiom on the parent**.
+
+### Mathlib gap analysis
+
+| # | Missing | Mathlib closest | Effort to bridge |
+|---|---------|-----------------|------------------|
+| 1 | "factorisation mod p → cycle type of Frob" general theorem | `Mathlib.NumberTheory.RamificationInertia.Galois` (partial) | ~600 Lean (R2 full generality) OR ~250 Lean (R1 specialised at p=7 for this q) |
+| 2 | Resolvent cubic / sextic of a quintic | none | ~400 Lean (R3 entire route) |
+| 3 | Explicit Frobenius generator from inertia data | `Ideal.Quotient.frobenius` (?) | ~50 Lean (lemmas linking residue Frobenius and Galois Frobenius) |
+
+### Connections to sibling proofs
+
+| Sibling | Status | Cross-impact |
+|---------|--------|--------------|
+| `inverse-galois` (foundational) | verified | no direct impact |
+| `inverse-galois-d4` | axiomatized | a Dedekind formalisation also unblocks D4 axioms |
+| `inverse-galois-d4-oq-03` | recently active (PR #18063) | independent |
+| `inverse-galois-f20` | axiomatized | similar potential gain |
+| `inverse-galois-oq-01`, `-oq-02`, `-oq-06-oq-01` | axiomatized | various; Dedekind helps several |
+| `abel-ruffini-galois-extensions` | axiomatized | independent |
+
+A full R2 Dedekind formalisation would propagate to multiple sibling
+proofs simultaneously. R1 is parent-specific.
+
+### Honest assessment
+
+This OQ has **real axiom-elimination value** — closing the parent's last
+axiom upgrades a flagship proof from `axiomatized` to `verified`. The
+recommended R1 path is technically demanding but bounded (~500 Lean
+lines across S2-S4) and uses existing Mathlib ramification-inertia
+infrastructure.
+
+**Risks**:
+- The Frobenius construction may require more careful coordinate-tracking
+  than the estimate; Lean's typeclass inference on `q.SplittingField` is
+  occasionally finicky for explicit ideal arithmetic.
+- If Step 1 (prime ideal construction) hits unexpected Mathlib gaps,
+  fallback to R3 (resolvent sextic) costs ~600 lines and a different
+  conceptual route.
+
+**S1 OBSERVE does not resolve the OQ.** Its value is:
+- Clear identification of the axiom (single statement, line 309 of parent);
+- Three-route classification (R1/R2/R3) with effort estimates;
+- Recommended S2-S3 plan with concrete Lean skeleton;
+- Mathlib API survey identifying the relevant ramification-inertia modules.

--- a/research/problems/inverse-galois-a5-oq-01/problem.md
+++ b/research/problems/inverse-galois-a5-oq-01/problem.md
@@ -1,0 +1,192 @@
+# Problem: Eliminate `three_dvd_gal_card` via Dedekind's Theorem on Frobenius Elements
+
+**Slug**: `inverse-galois-a5-oq-01`
+**Parent**: `inverse-galois-a5` — *A₅ as a Galois Group over ℚ: The First
+Non-Solvable Realization*. Status `axiomatized`, badge `axiom`, 0 sorries,
+**1 axiom** (`three_dvd_gal_card`), 84 theorems, 2067 lines
+(`proofs/Proofs/InverseGaloisA5.lean`).
+**Sibling proofs**:
+- `inverse-galois` (foundational), `inverse-galois-d4`, `inverse-galois-f20`
+- The inverse-Galois OQ family for solvable groups (D4, F20, OQ01, OQ02, OQ06OQ01)
+
+## Plain Statement
+
+The parent file proves the inverse Galois problem for **A₅** — the smallest
+non-solvable simple group — using the polynomial
+`q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5`. The proof that `|Gal(q/ℚ)| = 60`
+proceeds in three steps:
+
+1. **Upper bound**: `gal_card_dvd_60_proved` (Vandermonde discriminant chain,
+   Part XV) — Disc(q) = 32000² is a perfect square ⇒ Gal ⊆ A₅ ⇒ |Gal| | 60.
+2. **Five divides**: `five_dvd_gal_card` — q irreducible of degree 5 ⇒
+   5 | |Gal| by Cauchy.
+3. **Three divides** (`three_dvd_gal_card`, **AXIOM**): `q mod 7` factors as
+   `(X-5)(X-6)(X³ + 6X² + 4X + 1)` with the cubic irreducible over `F₇`. By
+   **Dedekind's theorem on Frobenius elements at prime ideals**, this
+   factorisation pattern `(1, 1, 3)` implies `Gal` contains an element with a
+   3-cycle, hence `3 ∣ |Gal|`.
+
+Combined with `no_subgroup_order_15` and `no_subgroup_order_30`, these force
+`|Gal| = 60`, and then `q_gal_iso_a5` gives `Gal ≅ A₅`.
+
+**The open question** is to **prove** `three_dvd_gal_card` from Mathlib —
+eliminating the last remaining axiom and upgrading the parent's status from
+`axiomatized` to `verified` (badge `original`, axiomCount `0`).
+
+The Lean statement of the axiom:
+
+```lean
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal
+```
+(`Proofs/InverseGaloisA5.lean:309`)
+
+## Why this Matters
+
+1. **Axiom elimination on the only remaining axiom of a flagship proof.**
+   The parent file already eliminated four other axioms during earlier
+   sessions (Axioms A, C, D, and the original `q_gal_card`); the
+   400-line Vandermonde discriminant chain in Parts VIII–XV is one of the
+   project's largest single mechanical achievements. Closing
+   `three_dvd_gal_card` finishes the job: the proof would be the **first
+   non-solvable realisation of the inverse Galois problem to be fully
+   verified in Lean** with `status: verified` and `badge: original`.
+
+2. **First gallery-level Dedekind-theorem instance.**
+   Dedekind's theorem (the factorisation of a monic separable polynomial
+   modulo an unramified prime determines the cycle decomposition of the
+   Frobenius automorphism on the integer ring) is **not in Mathlib**
+   (pinned `v4.26.0`, May 2026). The OQ01 task is to bridge this gap **at
+   least for the specialisation `(q, p) = (x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5, 7)`**.
+   A full Mathlib-grade formalisation of Dedekind would also unlock
+   axiom elimination in other Galois-theoretic gallery proofs
+   (`abel-ruffini-galois-extensions`, `inverse-galois-d4` and its OQs,
+   resolvent-sextic arguments, etc.).
+
+3. **Mathlib upstream contribution path.**
+   `Mathlib.NumberTheory.NumberField.Discriminant` and
+   `Mathlib.NumberTheory.RamificationInertia` already contain the
+   ramification/inertia framework; the missing piece is the explicit
+   cycle-decomposition bridge to the Galois group of the splitting field.
+   Even a specialised case (irreducible factor produces a cycle of that
+   length) would be a publishable Mathlib PR.
+
+4. **Two-source confidence on the axiom.**
+   The parent file's docstring records that `three_dvd_gal_card` is
+   supported by **two distinct computations** (`Proofs/InverseGaloisA5.lean`
+   lines 870-878): (i) the mod-7 factorisation Dedekind argument; (ii) a
+   resolvent-sextic argument ruling out subgroup orders dividing 20. Either
+   route gives `3 ∣ |Gal|`. The OQ01 question allows either approach (the
+   slug name privileges Dedekind, but the resolvent route would also
+   close it).
+
+## Mathematical Specification
+
+### B.1 Dedekind's Theorem (Specialisation Needed)
+
+> **Theorem (Dedekind).** Let `q(X) ∈ ℤ[X]` be a monic separable polynomial
+> with splitting field `K = ℚ(α₁, …, αₙ)`. Let `O_K` be the ring of integers
+> of `K`. Let `p` be a rational prime that does **not** divide `disc(q)`
+> (hence is unramified in `O_K`). Suppose `q mod p` factors in `F_p[X]` as a
+> product of distinct monic irreducibles of degrees `d₁ ≥ d₂ ≥ ⋯ ≥ d_k`.
+> Then there exists a Frobenius element `σ ∈ Gal(K/ℚ)` whose action on
+> `{α₁, …, αₙ}`, viewed as an element of `S_n`, has cycle type
+> `(d₁, d₂, …, d_k)`.
+>
+> In particular, `Gal(K/ℚ)` contains an element of order `lcm(d₁, …, d_k)`.
+
+For our specific case `(q, p) = (q, 7)`:
+- `disc(q) = 32000² = 2¹⁴ · 5⁶ · 100 = 1024000000` — divisible by 2 and 5 but
+  not by 7 ⇒ p = 7 is unramified ✓
+- `q mod 7 = (X - 5)(X - 6)(X³ + 6X² + 4X + 1)` with the cubic irreducible
+  over `F₇` (verified in `cubic_factor_no_roots_mod7`) ⇒ cycle type
+  `(1, 1, 3)` ⇒ `Gal` contains an element of order 3 ⇒ `3 ∣ |Gal|`.
+
+### B.2 Three Routes to Discharging `three_dvd_gal_card`
+
+| Route | Strategy | Lean Effort | Mathlib PR Potential |
+|-------|----------|-------------|----------------------|
+| **R1** | **Specialised Dedekind**: prove the cycle-type→divisibility bridge **only for the q-at-7 case**, using the existing Part XII evidence (`q_root_mod7_at_5`, `q_root_mod7_at_6`, `cubic_factor_no_roots_mod7`) and a hand-built Frobenius element construction. | ~400 Lean lines | low — too specialised |
+| **R2** | **General Dedekind**: formalise the full Dedekind theorem (Frobenius cycle decomposition) in Mathlib style and apply it once to discharge the axiom. | ~1500-2000 Lean lines | **HIGH** — landmark Mathlib PR |
+| **R3** | **Resolvent-sextic substitute**: prove `3 ∣ |Gal|` by a completely different route — the cubic resolvent `R(q)` of `q` has no rational root, so `Gal(R(q)/ℚ)` is `S₃` (order 6, divisible by 3), and the natural map `Gal(q) → Gal(R(q))` is surjective. | ~600 Lean lines | medium |
+
+R1 is the fastest path to gallery `verified` status. R2 is the
+highest-leverage choice for the Lean ecosystem. R3 is the cleanest
+"axiom-substitute" if R1's specialised Frobenius construction proves
+too case-heavy.
+
+### B.3 What Part XII Already Provides
+
+The parent file's Part XII (lines 715-884) provides the **computational**
+half of R1. The decidable verification of the mod-7 factorisation is
+already in Lean:
+
+| Existing decl | Line | Content |
+|---------------|------|---------|
+| `disc_value_is_square` | 779 | `(32000 : ℤ)^2 = 1024000000` (`norm_num`) |
+| `trinomial_disc_computation` | 783 | `4⁴·20⁵ + 5⁵·16⁴ = 1024000000` (`norm_num`) |
+| `q_root_mod7_at_5` | 787 | `q(5) ≡ 0 mod 7` (`decide`) |
+| `q_root_mod7_at_6` | 791 | `q(6) ≡ 0 mod 7` (`decide`) |
+| `cubic_factor_no_roots_mod7` | 796 | `X³ + 6X² + 4X + 1` has no roots in `F₇` (`decide`) |
+| `q_mod7_factorization_pattern` (referenced) | nearby | informal documentation of the pattern |
+
+The **missing** ingredients are the Frobenius construction (R1's
+specialised version) or the full ramification-inertia bridge (R2's
+generic version).
+
+## Mathlib Infrastructure Map (pinned `v4.26.0`)
+
+| Need | Mathlib Module | Status |
+|------|----------------|--------|
+| Number ring `O_K` of a number field | `Mathlib.NumberTheory.NumberField.Basic` | available |
+| Discriminant of a number field / polynomial | `Mathlib.NumberTheory.NumberField.Discriminant`, `Mathlib.RingTheory.Discriminant` | available |
+| Ramification / inertia indices | `Mathlib.NumberTheory.RamificationInertia.*` | available |
+| Frobenius element in `Gal(K/ℚ)` at an unramified prime | `Mathlib.FieldTheory.Galois.Frobenius` (?) | **PARTIAL** — basic existence but no cycle-decomposition bridge |
+| Cycle-type of `σ` acting on a set | `Mathlib.GroupTheory.Perm.Cycle.Type` | available |
+| Factorisation of a polynomial mod p in `F_p[X]` | `Mathlib.RingTheory.UniqueFactorizationDomain` | available |
+| **Dedekind's cycle-decomposition theorem** | — | **GAP** (the entire content of R2) |
+| Resolvent cubic / sextic | — | **GAP** (the entire content of R3) |
+
+## Reference Reading
+
+| # | Source | Why |
+|---|--------|-----|
+| 1 | Dummit, D. S.; Foote, R. M. (2004). *Abstract Algebra* (3rd ed), §14.8 "Galois groups of polynomials". | Standard textbook treatment of Dedekind's theorem and the cycle-type-from-mod-p-factorisation principle. |
+| 2 | Neukirch, J. (1999). *Algebraic Number Theory*, Theorem I.9.6 + §I.13. | Frobenius element and decomposition-inertia framework at unramified primes. |
+| 3 | Lang, S. (1994). *Algebraic Number Theory* (2nd ed), §I.7 "The Decomposition Group". | Concise proof that `Frob_p` has the predicted cycle type. |
+| 4 | Cohen, H. (1993). *A Course in Computational Algebraic Number Theory*, §6.4. | Algorithmic / computational view; useful for the specialised R1 construction. |
+| 5 | Conrad, K. *Galois groups of cubics and quartics (not in characteristic 2)*. expository notes. | Resolvent cubic / sextic context for R3. |
+
+## Proposed Decomposition
+
+| Session | Phase | Target | Lines (est.) |
+|---------|-------|--------|--------------|
+| **S1 (this)** | OBSERVE | Survey: Dedekind's theorem, three routes (R1/R2/R3), Mathlib gap, parent's Part XII evidence. Markdown + JSON only. | 0 Lean / ~500 md+json |
+| **S2** | ORIENT | **Recommended**: pick R1 (specialised). Draft a companion file `InverseGaloisA5Dedekind.lean` containing:<br>(a) the local-Frobenius construction at `p = 7`,<br>(b) a 3-cycle-witness `σ : Equiv.Perm (Fin 5)`,<br>(c) a single theorem `three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal` reducing the axiom. State the theorem with `sorry`; provide the Frobenius construction in skeleton form. | ~150 Lean (mostly sorry-filled) |
+| **S3** | ACT | Discharge the Frobenius-construction sorries: explicit prime ideal `𝔭 ∣ 7` in `O_K`; decomposition group at `𝔭`; lift to `Gal(q)`; show the induced permutation has cycle type `(1,1,3)`. | ~400 Lean |
+| **S4** | ACT (alt R3) | Backup route if R1 stalls: resolvent sextic construction; `Gal(q)` surjects onto a transitive subgroup of `S₃`; combine with no-order-15 to force 3 ∣ |Gal|. | ~600 Lean |
+| **S5+** | CLOSE | Once `three_dvd_gal_card_proved` is verified: in `InverseGaloisA5.lean`, replace `axiom three_dvd_gal_card` with `theorem three_dvd_gal_card := three_dvd_gal_card_proved`. Update `src/data/proofs/inverse-galois-a5/meta.json`: `status: axiomatized → verified`, `badge: axiom → original`, `axiomCount: 1 → 0`. Build verify. | ~5 Lean diff + ~20 meta.json |
+
+The S2-S3 pair (R1 specialised) is the minimum tractable formalisation
+deliverable that achieves the gallery-status upgrade. S4 is a safety
+valve if Frobenius construction at the chosen prime ideal `𝔭` turns out
+to require deeper Mathlib infrastructure than currently available.
+
+## Honest Calibration
+
+- **R1 risk**: the specialised Frobenius construction requires picking a
+  concrete prime ideal `𝔭 ∣ 7` in the (somewhat large) ring of integers
+  of `q.SplittingField` and proving its decomposition group is generated
+  by a 3-cycle on the roots. This is a routine but lengthy hand-derivation;
+  expect Lean line counts on the high end of the estimate (~400-500).
+- **R2 ambition vs scope**: a clean Dedekind-theorem Mathlib PR would
+  resolve dozens of gallery axioms simultaneously. This is a 6-month
+  ecosystem contribution, **not** a single-session gallery deliverable.
+- **R3 backup viability**: the resolvent sextic of `q` is computable
+  (~50 lines of `norm_num`); the surjection `Gal(q) → Gal(resolvent)` is
+  the standard galois-correspondence argument (~100 lines once the resolvent
+  is in hand). The order-3 element then comes from `S₃ ⊆ Gal(resolvent)`.
+
+**The S1 OBSERVE output is doc-only — no Lean changes, no axiom delta.** This
+is a survey iteration that prepares S2 (ORIENT) and S3 (ACT) for substantive
+formalisation. Per the role doc's axiom-elimination priority, S2-S3 is
+high-value work (eliminating the last axiom of a flagship proof).

--- a/research/problems/inverse-galois-a5-oq-01/state.md
+++ b/research/problems/inverse-galois-a5-oq-01/state.md
@@ -1,0 +1,156 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-12, 2026-05-12): survey the lone axiom
+`three_dvd_gal_card` (line 309 of `proofs/Proofs/InverseGaloisA5.lean`),
+classify the three discharge routes (R1/R2/R3), map the relevant
+Mathlib ramification-inertia API, and propose a concrete S2-S3 plan
+based on R1 (specialised Dedekind at `p = 7`).
+
+The parent file's status is **`axiomatized`** (1 axiom, 0 sorries,
+84 theorems, 2067 lines). Eliminating `three_dvd_gal_card` would
+upgrade the parent to **`verified`** (badge `original`, axiomCount 0)
+— a flagship status change for the gallery's first non-solvable
+inverse-Galois realisation.
+
+## Active Approach
+
+**Recommended path: R1 — specialised Dedekind at `(q, p) = (q, 7)`.**
+
+The parent's Part XII (lines 715-884) already contains the **decidable**
+half of the argument:
+- `q_root_mod7_at_5`, `q_root_mod7_at_6` (linear factors at `5, 6 ∈ F₇`),
+- `cubic_factor_no_roots_mod7` (cubic factor irreducible over `F₇`).
+
+S2 will introduce a new companion file
+`proofs/Proofs/InverseGaloisA5Dedekind.lean` with the
+**Frobenius-construction-and-cycle-type bridge**:
+
+1. `seven_unramified` — disc(q) = 32000² ⇒ 7 unramified;
+2. `𝔭₃` — explicit prime ideal of `𝓞 K` above 7 with `f(𝔭/7) = 3`;
+3. `frob₃` — Frobenius automorphism at `𝔭₃`, generating its
+   decomposition group (cyclic of order 3 since 7 is unramified);
+4. `frob₃_order_eq_three` — `orderOf frob₃ = 3`;
+5. `three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal` via
+   `orderOf_dvd_card`.
+
+S3 will discharge the four sorries from S2 (`seven_unramified`,
+`𝔭₃` and its inertia degree, `frob₃` and its order). S4 will
+splice the proved theorem into the parent file
+(`axiom three_dvd_gal_card` → `theorem three_dvd_gal_card := three_dvd_gal_card_proved`)
+and bump the parent's meta.json.
+
+## Blockers
+
+None mathematical: Dedekind's theorem is classical, and the specialised
+form needed for `(q, 7)` is a routine ramification-inertia computation.
+
+Practical:
+- **Mathlib API exploration**: `Mathlib.NumberTheory.RamificationInertia.Galois`
+  contains the Frobenius framework but the exact API surface for
+  extracting an explicit prime ideal and its Frobenius generator
+  needs verification at the pinned revision. S2 will spend the first
+  ~30 lines on import-and-API-probing.
+- **Docker build cost**: S3 / S4 PRs that touch `InverseGaloisA5.lean`
+  (2067 lines, with the heavy Vandermonde Parts VIII–XV) will rebuild
+  in ~25-30 minutes once the Mathlib cache is warm. Plan `(build pending)`
+  PRs per gallery convention for the parent-change diff.
+- **Worktree `.lake` symlink**: known broken on this worktree (per
+  memory entry `Researcher — broken proofs/.lake symlink`); any S2-S3
+  PR runs `docker-build` ⇒ ≥45 min build window. Consider deferring
+  build verification to the deployer.
+
+## Next Action
+
+**S2 (any researcher): R1 ORIENT — Lean skeleton + sorry-filled
+Frobenius bridge in `InverseGaloisA5Dedekind.lean`.**
+
+Three deliverables in a single PR:
+
+1. **Create companion file** `proofs/Proofs/InverseGaloisA5Dedekind.lean`
+   (~80 lines, 4 sorries):
+   ```lean
+   import Proofs.InverseGaloisA5
+   import Mathlib.NumberTheory.RamificationInertia.Galois
+   import Mathlib.GroupTheory.Perm.Cycle.Type
+
+   namespace InverseGaloisA5Dedekind
+
+   open Polynomial InverseGaloisA5
+
+   local notation "K" => q.SplittingField
+
+   theorem seven_unramified : ¬ 7 ∣ Polynomial.disc q := by sorry
+   noncomputable def 𝔭₃ : Ideal (𝓞 K) := sorry
+   theorem 𝔭₃_inertia_deg : Ideal.inertiaDeg 𝔭₃ (7 : ℤ) = 3 := sorry
+   noncomputable def frob₃ : q.Gal := sorry
+   theorem frob₃_order_eq_three : orderOf frob₃ = 3 := sorry
+   theorem three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal := by
+     rw [← frob₃_order_eq_three]; exact orderOf_dvd_card
+
+   end InverseGaloisA5Dedekind
+   ```
+
+2. **Update `proofs/Proofs.lean`** to include the new file in the
+   auto-import list.
+
+3. **No parent-file changes yet** (parent still uses `axiom three_dvd_gal_card`).
+   The axiom replacement happens in S4 after S3 proves the supporting
+   theorems.
+
+S2 estimated effort: 1 session, ~80 lines Lean, 4 sorries (statement-only
+scaffold). Build verification optional (declarations only, no proof bodies
+beyond the trivial `three_dvd_gal_card_proved`).
+
+## Session Log
+
+| Step | Action | Outcome |
+|------|--------|---------|
+| 1 | Verified no open PR / remote branch / recent merge for slug | safe to claim |
+| 2 | `claim-problem.sh claim inverse-galois-a5-oq-01` from `$REPO_ROOT` | claimed |
+| 3 | `git checkout -b research/inverse-galois-a5-oq-01-s1-observe-<ts> origin/main` (fresh base) | clean branch |
+| 4 | Read parent `Proofs/InverseGaloisA5.lean` lines 260-310 + 715-810 (Part XII) | identified the axiom + supporting decidables |
+| 5 | Surveyed Mathlib `RamificationInertia.*` modules + `Perm.Cycle.Type` | API map drafted |
+| 6 | Drafted three discharge routes R1/R2/R3 with effort estimates | strategy clear |
+| 7 | Wrote problem.md, knowledge.md, state.md, and JSON gallery entry | S1 OBSERVE complete |
+| 8 | (pending) Commit + push + PR with label `research` | next |
+
+## Honest Calibration
+
+S1 produces:
+
+- One **survey markdown** (`problem.md`, ~280 lines) with three-route
+  classification and Mathlib gap map;
+- One **knowledge file** (`knowledge.md`, ~200 lines) with parent
+  inventory, API survey, Lean skeleton, and decomposition plan;
+- This `state.md` capturing the OBSERVE state;
+- One **gallery JSON** entry (`src/data/research/problems/inverse-galois-a5-oq-01.json`).
+
+S1 does **not**:
+- Change any Lean file;
+- Modify parent meta.json or any other gallery data;
+- Add or remove axioms/sorries.
+
+The next iteration (S2 ORIENT) is where Lean changes begin. The
+**realistic estimate** for closing the OQ is 3-4 sessions
+(S2 scaffold → S3 Frobenius discharge → S4 parent integration),
+delivering a `verified`-status upgrade for the parent
+`inverse-galois-a5` flagship proof.
+
+## References Captured
+
+- Dummit & Foote (2004), §14.8: standard Dedekind theorem statement.
+- Neukirch (1999), Theorem I.9.6: Frobenius element framework.
+- Lang (1994), §I.7: decomposition group at unramified primes.
+- Cohen (1993), §6.4: computational algorithm (useful for R1 specialisation).
+- Mathlib modules: `NumberTheory.NumberField.Basic`,
+  `NumberTheory.NumberField.Discriminant`,
+  `NumberTheory.RamificationInertia.*`,
+  `GroupTheory.Perm.Cycle.Type`.
+
+See `knowledge.md` for the full Mathlib-gap table and Lean skeleton.

--- a/src/data/research/problems/inverse-galois-a5-oq-01.json
+++ b/src/data/research/problems/inverse-galois-a5-oq-01.json
@@ -1,0 +1,126 @@
+{
+  "slug": "inverse-galois-a5-oq-01",
+  "title": "Eliminate three_dvd_gal_card via Dedekind's theorem on Frobenius elements",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Prove the axiom } \\texttt{three\\_dvd\\_gal\\_card} : 3 \\mid \\#\\,\\mathrm{Gal}(q/\\mathbb{Q}) \\text{ where } q(x) = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5, \\text{ thereby eliminating the last axiom of } \\texttt{Proofs/InverseGaloisA5.lean} \\text{ and upgrading the parent } \\texttt{inverse-galois-a5} \\text{ from } \\texttt{axiomatized} \\text{ to } \\texttt{verified}.",
+    "plain": "The parent gallery proof of A5 as a Galois group over Q (inverse-galois-a5) is formalized in Proofs/InverseGaloisA5.lean with 0 sorries but 1 surviving axiom: three_dvd_gal_card asserting 3 divides |Gal(q)|. The axiom is supported by Part XII's decidable verification that q mod 7 factors as (X-5)(X-6)(irreducible cubic) over F7. Dedekind's theorem on Frobenius elements bridges this factorization to a 3-cycle in the Galois group. This OQ asks for the formal Lean discharge of the axiom, replacing it with theorem three_dvd_gal_card_proved.",
+    "whyMatters": [
+      "Closes the last axiom of a flagship proof. inverse-galois-a5 has 1 axiom + 0 sorries + 84 theorems across 2067 lines, with all four other historical axioms already eliminated. Closing three_dvd_gal_card upgrades the entry from status axiomatized to verified (badge axiom -> original).",
+      "First gallery-level Dedekind theorem instance. Dedekind's theorem on Frobenius elements at unramified primes is not in Mathlib at v4.26.0. A specialised instance at (q, p)=(q, 7) is sufficient for this OQ; a fully general version would be a landmark Mathlib contribution.",
+      "Two distinct mathematical routes exist. R1 = specialised Dedekind via prime ideal at 7 in O_K (recommended, ~250-500 Lean lines, parent-specific). R2 = full Dedekind in Mathlib (~1500-2000 lines, multi-OQ payoff). R3 = resolvent sextic with no rational root (~600 lines, independent of Dedekind).",
+      "Cross-impact on sibling inverse-Galois proofs. A full R2 Dedekind formalisation would simultaneously unblock axiom elimination across inverse-galois-d4, inverse-galois-f20, inverse-galois-oq-01/02/06-oq-01, and abel-ruffini-galois-extensions. R1 alone is parent-specific."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "q_irreducible (parent, via Eisenstein at p=5): q(x) = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5 is irreducible over Q.",
+      "five_dvd_gal_card (parent, via Cauchy): 5 | |Gal(q)|.",
+      "gal_card_dvd_120 (parent, via root permutation): |Gal(q)| | 120.",
+      "gal_card_dvd_60_proved (parent, via Vandermonde discriminant chain Parts VIII-XV, ~400 Lean lines): |Gal(q)| | 60. Eliminates the discriminant axiom.",
+      "no_subgroup_order_15 (parent, Sylow theory): no subgroup of S_5 has order 15.",
+      "no_subgroup_order_30 (parent, A_5 simplicity): no subgroup of S_5 has order 30.",
+      "disc_value_is_square (parent, Part XII): (32000 : Z)^2 = 1024000000.",
+      "trinomial_disc_computation (parent, Part XII): 4^4 * 20^5 + 5^5 * 16^4 = 1024000000.",
+      "q_root_mod7_at_5, q_root_mod7_at_6 (parent, Part XII, decidable): q(5) and q(6) are zero in F_7.",
+      "cubic_factor_no_roots_mod7 (parent, Part XII, decidable): X^3 + 6X^2 + 4X + 1 has no roots in F_7, hence is irreducible.",
+      "q_gal_iso_a5, a5_realizable_iso, gal_not_solvable (parent, Part XVI-XVII): the main theorems consuming q_gal_card.",
+      "Dedekind's theorem itself (Neukirch I.9.6, Lang I.7, Dummit-Foote 14.8): factorization pattern of q mod p (unramified) determines the cycle type of Frob_p in Gal(q/Q) via the natural permutation representation."
+    ],
+    "open": [
+      "Q1 (R1, ~250-500 Lean lines): Discharge three_dvd_gal_card by constructing a prime ideal p3 of O_K above 7 with inertia degree f(p3/7) = 3, extracting its Frobenius generator frob3 in Gal(q/Q), showing orderOf frob3 = 3, and concluding via orderOf_dvd_card. Requires Mathlib.NumberTheory.RamificationInertia.* API surface exploration.",
+      "Q2 (R2, ~1500-2000 Lean lines): Formalise the full Dedekind theorem (cycle-type-from-mod-p-factorisation for a monic separable polynomial over Q) in Mathlib. Landmark contribution; multi-month effort; resolves many gallery axioms simultaneously.",
+      "Q3 (R3, ~600 Lean lines): Alternative route via resolvent sextic. The cubic resolvent R(q) has no rational root, so Gal(R(q)/Q) is transitive in S_3 (hence contains a 3-cycle, hence order divisible by 3). The natural surjection Gal(q) -> Gal(R(q)/Q) then forces 3 | |Gal(q)|. Independent of Dedekind; replaces it with resolvent + Galois correspondence."
+    ],
+    "goal": "Eliminate the axiom three_dvd_gal_card in Proofs/InverseGaloisA5.lean by replacing it with a theorem three_dvd_gal_card_proved discharged from Mathlib's ramification-inertia infrastructure. Phased approach: R1 (specialised Dedekind at p=7) is the recommended S2-S4 plan, delivering the gallery-status upgrade (axiomatized -> verified) in ~3-4 sessions and ~490 Lean lines. R3 (resolvent sextic) is a safety-valve alternative if R1 stalls on prime-ideal construction. R2 (full Mathlib Dedekind) is deferred to a long-term Mathlib contribution roadmap."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T12:55:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-12, 2026-05-12): OBSERVE survey only. Identified the lone axiom three_dvd_gal_card (line 309 of Proofs/InverseGaloisA5.lean), classified three discharge routes (R1 specialised Dedekind / R2 full Mathlib Dedekind / R3 resolvent sextic), mapped Mathlib's ramification-inertia API surface, and drafted a Lean skeleton for the recommended R1 path. Parent file Part XII (lines 715-884) already contains the decidable verification q_root_mod7_at_5, q_root_mod7_at_6, cubic_factor_no_roots_mod7 — only the Frobenius-construction-and-cycle-type bridge remains.",
+    "blockers": [],
+    "nextAction": "S2 (any researcher): R1 ORIENT — create proofs/Proofs/InverseGaloisA5Dedekind.lean (~80 lines, 4 sorries) with the Frobenius bridge: seven_unramified (disc(q) coprime to 7), p3 : Ideal (O_K) above 7 with inertia degree 3, frob3 : q.Gal as the Frobenius generator at p3, frob3_order_eq_three, and three_dvd_gal_card_proved : 3 | Fintype.card q.Gal via orderOf_dvd_card. Update proofs/Proofs.lean to include the new file. Parent file unchanged in S2; axiom replacement deferred to S4.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-12, 2026-05-12): OBSERVE survey on the lone axiom of the parent inverse-galois-a5 proof. 0 Lean changes; 4 doc files produced (problem.md ~280 lines, knowledge.md ~200 lines, state.md ~150 lines, this JSON). Three discharge routes catalogued (R1 specialised Dedekind ~250-500 lines, R2 full Mathlib Dedekind ~1500-2000 lines, R3 resolvent sextic ~600 lines). R1 recommended for S2-S4. Mathlib API surface mapped: NumberField.Basic, RamificationInertia.Galois, Perm.Cycle.Type. Parent Part XII evidence inventory: 5 supporting decidable theorems already in place. No axiom delta in S1.",
+    "builtItems": [
+      "research/problems/inverse-galois-a5-oq-01/problem.md (new, ~280 lines): full statement of three_dvd_gal_card, three-route classification (R1/R2/R3) with effort estimates, Mathlib gap map, reference reading list (Dummit-Foote, Neukirch, Lang, Cohen), five-session decomposition (S1 OBSERVE -> S2 ORIENT -> S3 ACT -> S4 CLOSE -> optional S5 alternative).",
+      "research/problems/inverse-galois-a5-oq-01/knowledge.md (new, ~200 lines): parent file inventory (the relevant decls at lines 207-309-511-779-787-791-796), specialised Dedekind theorem statement, Mathlib API survey by module, Lean skeleton for R1 ORIENT, decomposition plan with effort estimates, mathlib gap analysis, sibling cross-impact table.",
+      "research/problems/inverse-galois-a5-oq-01/state.md (new, ~150 lines): OBSERVE phase, S2 next-action sketch with concrete Lean code skeleton, session log, honest calibration.",
+      "src/data/research/problems/inverse-galois-a5-oq-01.json (this file, new): research index entry."
+    ],
+    "insights": [
+      "The parent's three_dvd_gal_card (line 309) is the ONLY axiom in Proofs/InverseGaloisA5.lean. All four prior axioms (A discriminant-square, C and D complex-conjugation-based, original q_gal_card) have been eliminated in earlier sessions. Closing this axiom is the single-step path to the parent's verified status.",
+      "The parent's Part XII (lines 715-884) supplies the entire decidable half of the Dedekind argument. q_root_mod7_at_5, q_root_mod7_at_6, and cubic_factor_no_roots_mod7 all close via the decide tactic. The remaining work is purely the Frobenius-construction-and-cycle-type bridge.",
+      "Mathlib.NumberTheory.RamificationInertia.Galois exists at v4.26.0 and provides the inertia-degree and Frobenius-generator framework needed for R1. The specific API for extracting a Galois-group Frobenius element from a prime ideal needs hands-on verification at the pinned revision; expect an S2 import-and-API-probe phase.",
+      "Three distinct discharge routes exist with very different cost/payoff profiles. R1 (specialised) ~250-500 Lean and parent-specific. R2 (full Mathlib Dedekind) ~1500-2000 Lean but resolves dozens of gallery axioms across the inverse-Galois family. R3 (resolvent sextic) ~600 Lean using a different mathematical bridge.",
+      "The resolvent sextic route (R3) is a viable safety valve. If the prime-ideal construction in R1 stalls, R3 uses no number-field-of-integers machinery: just the resolvent polynomial (computable via norm_num) and the standard Galois-correspondence surjection Gal(q) -> Gal(R(q)).",
+      "Parent file's docstring (lines 870-878) records that three_dvd_gal_card has TWO independent supports — the mod-7 factorisation (Dedekind R1/R2) AND the resolvent-sextic absence-of-rational-root (R3). Either route alone is mathematically sufficient.",
+      "Cross-impact: R2 alone would eliminate axioms in inverse-galois-d4 (axiom on D4 cycle types), inverse-galois-f20 (similar), and several abel-ruffini-galois-extensions OQs. R1 is parent-specific and does NOT propagate.",
+      "Aristotle non-applicability: the Frobenius-construction sorries are NOT routine Aristotle targets — they require explicit ring-of-integers arithmetic and ramification-index reasoning that current Aristotle heuristics cannot handle. Plan for manual S3 ACT iteration."
+    ],
+    "mathlibGaps": [
+      "Dedekind's theorem on Frobenius cycle decomposition: NOT in Mathlib at v4.26.0. Specialised version at (q, p)=(q, 7): ~250-500 Lean lines (R1). Fully general version: ~1500-2000 lines (R2), landmark Mathlib PR opportunity.",
+      "Resolvent cubic / sextic polynomial constructions: NOT in Mathlib. R3 route would need ~200 lines just for the resolvent + ~400 lines for the Galois surjection argument.",
+      "Explicit Frobenius generator from inertia data of an unramified prime: partial coverage in Mathlib.NumberTheory.RamificationInertia.Galois; the surface for extracting an element of q.Gal from a prime ideal of O_K needs verification at v4.26.0."
+    ],
+    "nextSteps": [
+      "S2 ORIENT (~80 Lean lines, 4 sorries): create proofs/Proofs/InverseGaloisA5Dedekind.lean with the Frobenius bridge skeleton. Add to proofs/Proofs.lean auto-import list. No parent-file changes.",
+      "S3 ACT (~400 Lean lines, -4 sorries): discharge the Frobenius construction. Construct p3 : Ideal (O_K) above 7 with inertia degree 3; extract frob3 : q.Gal from its decomposition group; prove orderOf frob3 = 3 by linking decomposition group order to inertia degree (since 7 is unramified). The hardest step is the explicit p3 construction; the rest is API plumbing.",
+      "S4 CLOSE (~10 Lean diff + ~30 meta.json): in InverseGaloisA5.lean, replace axiom three_dvd_gal_card with theorem three_dvd_gal_card := InverseGaloisA5Dedekind.three_dvd_gal_card_proved. Update src/data/proofs/inverse-galois-a5/meta.json: status axiomatized -> verified, badge axiom -> original, axiomCount 1 -> 0. Build verify via docker.",
+      "S5 ALTERNATIVE (only if R1 stalls in S3): switch to R3 — define the resolvent sextic of q (~200 lines via norm_num on coefficients); prove it has no rational root (~50 lines, decide on a bounded search); construct the surjection Gal(q) -> Gal(R(q)) (~300 lines, Galois correspondence); conclude 3 | |Gal(q)| from |S3| | |Gal(R(q))|."
+    ]
+  },
+  "relatedProofs": [
+    "abel-ruffini-galois-extensions",
+    "inverse-galois",
+    "inverse-galois-a5",
+    "inverse-galois-d4",
+    "inverse-galois-d4-oq-03",
+    "inverse-galois-f20",
+    "inverse-galois-oq-01",
+    "inverse-galois-oq-02",
+    "inverse-galois-oq-06-oq-01"
+  ],
+  "tags": [
+    "alternating-group",
+    "axiom-elimination",
+    "dedekind-theorem",
+    "discriminant",
+    "frobenius-element",
+    "galois-theory",
+    "inverse-galois-problem",
+    "mathlib-NumberTheory-RamificationInertia",
+    "non-solvable",
+    "polynomial-irreducibility",
+    "ramification-inertia",
+    "research",
+    "seeker-selected"
+  ],
+  "createdAt": "2026-05-12T12:55:00.000Z",
+  "updatedAt": "2026-05-12T12:55:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/InverseGaloisA5.lean",
+      "filename": "InverseGaloisA5.lean",
+      "lineCount": 2067,
+      "theoremCount": 84,
+      "axiomCount": 1,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for new tier-B slug `inverse-galois-a5-oq-01`: eliminate the **last axiom** of the parent flagship proof `inverse-galois-a5` — `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` at `Proofs/InverseGaloisA5.lean:309`. Closing this axiom would upgrade the parent from `status: axiomatized` → `verified` (`badge: axiom → original`, `axiomCount: 1 → 0`).

## Three Discharge Routes

| Route | Strategy | Lean effort | Cross-impact |
|-------|----------|-------------|--------------|
| **R1** | Specialised Dedekind at `(q, p) = (q, 7)`: prime ideal `𝔭₃ ⊂ 𝓞 K` above 7 with inertia degree 3 → Frobenius `frob₃ ∈ q.Gal` → `orderOf frob₃ = 3` → `orderOf_dvd_card`. **Recommended for S2-S4.** | ~250-500 lines | parent-specific |
| **R2** | Full Mathlib Dedekind theorem (cycle-type-from-mod-p-factorisation, general). | ~1500-2000 lines | unblocks dozens of inverse-Galois / Galois-theory axioms |
| **R3** | Resolvent sextic: `R(q)` has no rational root → `Gal(q) ↠ Gal(R(q))` with `|S₃|` divisible by 3. **Safety valve if R1 stalls.** | ~600 lines | independent of Dedekind |

## Existing Decidable Evidence (Parent Part XII)

The parent's Part XII (lines 715-884) already supplies the entire **decidable half** of the Dedekind argument:
- `q_root_mod7_at_5`, `q_root_mod7_at_6` — linear factors at `5, 6 ∈ F₇` (`decide`)
- `cubic_factor_no_roots_mod7` — cubic factor `X³+6X²+4X+1` has no roots in `F₇`, hence irreducible (`decide`)
- `disc_value_is_square`, `trinomial_disc_computation` — `disc(q) = 32000²` (used for unramifiedness at 7)

The remaining work is the **Frobenius-construction-and-cycle-type bridge**, which Mathlib's `NumberTheory.RamificationInertia.*` infrastructure should support.

## Proposed Decomposition (S2-S4)

| Session | Phase | Target | Lines |
|---------|-------|--------|-------|
| S1 (this) | OBSERVE | three-route survey, parent inventory, Mathlib API map, decomposition plan | 0 Lean / ~660 md+json |
| S2 | ORIENT | create `proofs/Proofs/InverseGaloisA5Dedekind.lean` (~80 lines, 4 sorries): `seven_unramified`, `𝔭₃`, `𝔭₃_inertia_deg`, `frob₃`, `frob₃_order_eq_three`, `three_dvd_gal_card_proved` | ~80 Lean, +4 sorries |
| S3 | ACT | discharge the 4 sorries via explicit prime ideal + ramification-inertia API | ~400 Lean, -4 sorries |
| S4 | CLOSE | parent integration: replace `axiom three_dvd_gal_card` with `theorem ... := InverseGaloisA5Dedekind.three_dvd_gal_card_proved`; bump parent meta.json | ~10 Lean diff + ~30 meta.json, **-1 axiom on parent** |

## Files Modified (this PR)

- `research/problems/inverse-galois-a5-oq-01/problem.md` (new, ~280 lines) — full statement, three-route classification, Mathlib gap map, reference reading list
- `research/problems/inverse-galois-a5-oq-01/knowledge.md` (new, ~200 lines) — parent inventory, Mathlib API survey, R1 Lean skeleton, decomposition plan with effort estimates, sibling cross-impact
- `research/problems/inverse-galois-a5-oq-01/state.md` (new, ~150 lines) — OBSERVE phase, S2 next-action with concrete Lean code, session log
- `src/data/research/problems/inverse-galois-a5-oq-01.json` (new) — research index entry (significance 6, tractability 6, tier B)

## Status

**Outcome**: progress (doc-only OBSERVE; no Lean changes; 0 axiom delta)
**Next Steps**: S2 ORIENT — create `InverseGaloisA5Dedekind.lean` companion file with the Frobenius bridge skeleton

🤖 Generated by researcher-12