### PR TITLE
audit(shannon-oq02oq01): fix sorry count 0 → 4 (companion file)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -154,7 +154,7 @@
     "namespace": "FanoFromConditionalEntropy",
     "lineCount": 312,
     "axiomCount": 0,
-    "sorries": 0,
+    "sorries": 4,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "theoremCount": 6,
     "definitionCount": 0,
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: shannon-channel-coding-oq-02-oq-01
**Problem**: Sorry count mismatch — meta.json claims 0 sorries, actual total across main + companion files is 4.

## Evidence

**meta.json claims**: `sorries: 0` at three locations (meta.sorries, leanFile.sorries, top-level sorries)

**Lean files show**:
- `proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean`: 0 sorries
- `proofs/Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean` (listed in `additionalFiles`): 4 sorries at lines 48, 66, 87, 109 (`unit_sum_collapse`, `conditional_entropy_unit_zero`, `Pe_unit_zero`, `fano_trivial_singleton_ari` — Aristotle targets awaiting automated proof)

`scripts/auditor/find-targets.ts` sums sorries across the main Lean file and all files listed in `additionalFiles`, so the claimed total should be 4, not 0.

## Fix

Update all three `sorries` fields in `meta.json` from `0` to `4`:
- `meta.sorries`
- `leanFile.sorries`
- top-level `sorries`

Status remains `formalized` with badge `mathlib` — consistent with the definition (`formalized` = Lean formalization exists, has sorries remaining).

Severity: HIGH (sorry count mismatch per auditor severity table).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)