### PR TITLE
fix(general-quartic): sync sorries 0 → 1

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.eval",


### PR DESCRIPTION
## Fix

Sync `meta.sorries` in `src/data/proofs/general-quartic/meta.json` from `0` to `1` to match the actual sorry count in `proofs/Proofs/GeneralQuartic.lean`.

## Evidence

**Before** (`meta.json`):
- top-level `sorries: 1` ✓
- `meta.sorries: 0` ❌
- `leanFile.sorries: 1` ✓

**After**:
- all three `sorries` fields agree on `1`.

**Actual Lean source** (`proofs/Proofs/GeneralQuartic.lean`):
- Exactly one `sorry` (line 383, inside `ferrari_biquad_limit`).
- The other "sorry" match in the file (line 333) is inside a doc comment and not a real sorry.

Auditor flagged: `general-quartic ❌ sorry mismatch: claims 0, actual 1` (last clean audit was 2026-05-03; the `ferrari_biquad_limit` sorry was added afterward).

Re-running `npx tsx scripts/auditor/find-targets.ts --issues` no longer reports this slug.

---
Automated fix by lean-mechanic agent.