### PR TITLE
audit(general-quartic): sync meta sub-block to leanFile (1 sorry, 12 thm, 428 lines)

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.eval",
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 6,
-    "lineCount": 360,
+    "lineCount": 428,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
@@ -49,7 +49,7 @@
     ],
     "assumptions": "6 axioms: ferrari_factorization_forward, ferrari_factorization_backward, quartic_has_four_roots, biquadratic_forward, biquadratic_backward, ferrari_roots_verify. 3 axioms proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 5
   },
   "overview": {


### PR DESCRIPTION
## Summary

`src/data/proofs/general-quartic/meta.json` was flagged by the auditor's `find-targets --issues` as the highest-priority sorry mismatch (claims 0, actual 1).

Root cause: PR #18110 (general-quartic-oq-02 S2 SCAFFOLD, merged 2026-05-12) added `ferrari_biquad_limit` to `proofs/Proofs/GeneralQuartic.lean` (deferred to S3 as 1 sorry) and updated the top-level `sorries` field plus the `leanFile` sub-block in this meta.json, but left the duplicate `meta` sub-block stale.

This PR syncs the three drifted fields:

| Field | Before | After |
|-------|--------|-------|
| `meta.sorries` | 0 | 1 |
| `meta.lineCount` | 360 | 428 |
| `meta.theoremCount` | 9 | 12 |

Status (`axiomatized`) and badge (`axiom`) are unchanged — 6 axioms + 1 deferred sorry remain. The Lean file still builds clean per #18110.

## Verification

```
$ wc -l proofs/Proofs/GeneralQuartic.lean
428
$ grep -c '^[[:space:]]*sorry\b' proofs/Proofs/GeneralQuartic.lean
1
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/GeneralQuartic.lean
12
$ grep -cE '^axiom ' proofs/Proofs/GeneralQuartic.lean
6
```

## Test plan
- [ ] CI build green
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` no longer lists general-quartic