### PR TITLE
Fix: sync 4 audit-flagged entries to aggregate-sorries convention (#18137)

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.eval",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -37,7 +37,7 @@
       "Root cause analysis of ShannonEntropy.lean line 811 failure (sum order mismatch in strong_subadditivity)",
       "Proposed fix: normalize ∑ y ∑ z ∑ x sum order before linarith using Finset.sum_comm"
     ],
-    "assumptions": "0 axioms in this file. Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file).",
+    "assumptions": "0 axioms in this file. 4 sorries (aggregate): 0 in the main bridge file ShannonChannelCodingOQ02OQ01.lean + 4 in the Aristotle companion ShannonChannelCodingOQ02OQ01Aristotle.lean (workbench targets for automated proof search). Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file).",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 312,


### PR DESCRIPTION
## Fix

Resolves persistently-flagged audit issue #18137 by aligning `meta.sorries` with the prevailing **aggregate** convention used across the gallery (consistent with `meta.axiomCount` per [Axiom Integrity Policy](https://github.com/rjwalters/lean-genius/blob/main/CLAUDE.md#axiom-integrity-policy) / PR #18120). No code changes — this is a meta-only sync.

| Slug | Field | Before | After | Why |
|---|---|---:|---:|---|
| `general-quartic` | `meta.sorries` + top `sorries` | 0 | **1** | Genuine main-file count (already reflected in `leanFile.sorries`); single-file proof so aggregate = main. |
| `binomial-theorem-oq-02-oq-01-oq-01` | `meta.sorries` + top `sorries` | 6 | **5** | Chain count = 4 (main) + 1 (`*Aristotle.lean`) = 5; previous 6 was stale post-#18089. |
| `binomial-theorem-oq-02-oq-01-oq-01` | `leanFile.sorries` | 5 | **4** | `leanFile.X` fields are main-file-only by convention (mirrors `leanFile.axiomCount` semantics). |
| `shannon-channel-coding-oq-02-oq-01` | `meta.sorries` + top `sorries` | 0 | **4** | Chain count = 0 (main) + 4 (`*Aristotle.lean`). |
| `shannon-channel-coding-oq-03` | `meta.sorries` + top `sorries` | 0 | **4** | Chain count = 0 (main) + 4 (`*Aristotle.lean`). |

The `assumptions` text on each updated entry was rewritten to enumerate the aggregate breakdown (main vs. companion).

## Convention Note (re: #18137)

The audit issue framed PR #18127 as having established a main-file-only `meta.sorries` convention. Inspecting the gallery shows the opposite: the prevailing pattern (71+ entries) keeps `meta.sorries` as the aggregate count across `main + additionalFiles + Aristotle companions`, while `meta.leanFile.sorries` carries the main-file-only count — exactly mirroring the axiom field split (`meta.axiomCount` aggregate vs. `meta.leanFile.axiomCount` main-only).

`find-targets.ts` already reads `meta.sorries` as aggregate (lines 260–282, 299). It was PR #18127's main-file-only edits to 2 entries (`shannon-channel-coding-oq-02-oq-01`, `shannon-channel-coding-oq-03`) that deviated from the prevailing pattern. Re-aligning those 2 entries — plus correcting the genuine count drift in `general-quartic` and `binomial-theorem-oq-02-oq-01-oq-01` — restores symmetry without touching code.

Alternative options A (mirror axiom logic for sorries) and C (skip Aristotle companions in `find-targets.ts`) were considered. Both require either a code change with wide blast radius (Option A flips 71 entries from passing to flagged because their `meta.sorries` is already aggregate) or split-counting across two metadata fields. Option B (this PR) is the smallest, most targeted fix that closes the issue and breaks the oscillation cycle.

## Evidence

```bash
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

Per-file sorry counts (comment-stripped):

```
proofs/Proofs/GeneralQuartic.lean                            : 1 (main)
proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean               : 4 (main)
proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean       : 1 (companion)
proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean               : 0 (main)
proofs/Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean       : 4 (companion)
proofs/Proofs/ShannonChannelCodingOQ03.lean                   : 0 (main)
proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean           : 4 (companion)
```

## Scope

Meta-only PR; no Lean source touched. JSON revalidates for all 4 files.

Closes #18137

---
Automated fix by lean-mechanic agent.