### PR TITLE
research(gauss-wilson-non-cyclic-oq-01): S2 ACT — Phase A prod_univ_eq_prod_two_torsion (build verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2295,6 +2295,7 @@ import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GCDAlgorithmOQ01OQ03
 import Proofs.GaussWilsonNonCyclic
+import Proofs.GaussWilsonNonCyclicOQ01A
 import Proofs.GcdAlgorithmOQ02
 import Proofs.GcdAlgorithmOQ04
 import Proofs.GelfondSchneider

--- a/proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean
@@ -1,0 +1,66 @@
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Tactic
+
+/-!
+# Gauss–Wilson Non-Cyclic OQ-01 — Phase A: Product Reduces to 2-Torsion
+
+This file delivers **Phase A** of the three-phase decomposition of
+`gauss-wilson-non-cyclic-oq-01`, in isolation from the parent
+`GaussWilsonNonCyclic.lean`.
+
+**Main theorem.** In any finite commutative group `G`, the product over
+`Finset.univ` equals the product over the 2-torsion subset
+`{x : G | x ^ 2 = 1}`:
+
+  ∏ x : G, x = ∏ x ∈ univ.filter (·^2 = 1), x
+
+**Proof.** Split `univ` into 2-torsion and non-2-torsion; the latter
+product is 1 via `Finset.prod_involution` with involution `x ↦ x⁻¹`.
+
+A copy of this lemma already exists in `WilsonsTheoremOQ04OQ02.lean`
+under the name `prod_eq_prod_involutions`; we re-state it here in the
+OQ-01 namespace so the S3 (Phase B + Phase C) workflow can depend on
+it without pulling in the entire Wilson development.
+-/
+
+namespace GaussWilsonNonCyclicOQ01
+
+open Finset
+
+/-- For any finite commutative group, the product of all elements equals
+    the product of the 2-torsion subset `{x : G | x^2 = 1}`.
+
+    Proof: pair each non-self-inverse element with its inverse via
+    `Finset.prod_involution`. The pairing is fixed-point-free outside
+    the 2-torsion, so the non-2-torsion product collapses to `1`. -/
+theorem prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] :
+    ∏ x : G, x = ∏ x ∈ (univ : Finset G).filter (fun x => x ^ 2 = 1), x := by
+  -- Split univ = (2-torsion) ⊎ (non-2-torsion)
+  have hsplit : ∏ x : G, x =
+      (∏ x ∈ univ.filter (fun x : G => x ^ 2 = 1), x) *
+      (∏ x ∈ univ.filter (fun x : G => ¬x ^ 2 = 1), x) :=
+    (prod_filter_mul_prod_filter_not univ (fun x : G => x ^ 2 = 1) id).symm
+  -- Non-2-torsion product collapses to 1 via the inverse involution
+  have hrest : ∏ x ∈ univ.filter (fun x : G => ¬x ^ 2 = 1), x = 1 := by
+    apply Finset.prod_involution (fun x _ => x⁻¹)
+    · -- pairing: x * x⁻¹ = 1
+      intros a _; exact mul_inv_cancel a
+    · -- fixed-point-free: x = x⁻¹ would force x^2 = 1
+      intro a ha _
+      simp only [mem_filter, mem_univ, true_and] at ha
+      intro heq
+      exact ha (by
+        have h := mul_inv_cancel a
+        rw [heq] at h
+        rwa [← sq] at h)
+    · -- involution: (x⁻¹)⁻¹ = x
+      intros a _; exact inv_inv a
+    · -- closure: x⁻¹ also has (x⁻¹)^2 ≠ 1 when x^2 ≠ 1
+      intro a ha
+      simp only [mem_filter, mem_univ, true_and] at ha
+      simp only [mem_filter, mem_univ, true_and]
+      rwa [inv_pow, inv_eq_one]
+  rw [hsplit, hrest, mul_one]
+
+end GaussWilsonNonCyclicOQ01

--- a/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
@@ -2,9 +2,45 @@
 
 ## Current phase
 
-S1 OBSERVE complete (researcher-5, 2026-05-12). Phase B-class scaffold not yet committed to Lean; only markdown + problem JSON are part of S1.
+S2 ACT complete (researcher-9, 2026-05-12). Phase A theorem
+`prod_univ_eq_prod_two_torsion` shipped in
+`proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` (≈35 lines, 0 sorries).
 
 ## Iteration log
+
+### S2 ACT — 2026-05-12 (researcher-9)
+
+**Result:** Phase A delivered as a standalone Lean file with 0 sorries.
+
+**Built:**
+- `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` — ~35 lines.
+  Single theorem `prod_univ_eq_prod_two_torsion : ∀ G [CommGroup G]
+  [Fintype G] [DecidableEq G], ∏ x : G, x = ∏ x ∈ univ.filter (·^2 = 1), x`.
+  Proof via `Finset.prod_involution` with `x ↦ x⁻¹` on the non-2-torsion
+  half, mirroring the existing `WilsonsTheoremOQ04OQ02.prod_eq_prod_involutions`
+  (same statement, distinct namespace).
+- `proofs/Proofs.lean` — alphabetically inserted import line.
+
+**Reuse note:** The same lemma already lives in
+`WilsonsTheoremOQ04OQ02.lean` under the name `prod_eq_prod_involutions`.
+The OQ-01 namespace re-statement is intentional so S3 (Phase B + Phase C)
+does not have to pull in the Wilson development; OQ-01 is built up
+phase-by-phase to maximize independence and Mathlib-PR-readiness of each
+phase (Phase A and Phase B are both candidates for upstream contribution,
+per S1 knowledge.md).
+
+**Next action (S3):** ACT — create
+`proofs/Proofs/GaussWilsonNonCyclicOQ01B.lean` implementing Phase B
+(product over an elementary abelian 2-group of order ≥ 4 equals 1).
+The Lean sketch in `knowledge.md` flags a `sorry` for the "card is a
+power of 2" step; the right approach is either
+(a) hand-roll a bijection with `Module F₂` and use the sum-over-vector-
+    space-of-dim ≥ 2 result, or
+(b) Sylow-style argument that `Monoid.exponent ∣ 2 ∧ Fintype.card H ≥ 4
+    ⇒ Fintype.card H ≥ 4 ∧ Fintype.card H = 2^k for some k ≥ 2`, then
+    pair-by-translation `x ↦ h₀ · x` and observe `h₀^(|H|/2) = 1` since
+    `|H|/2` is even.
+Target: ~80–120 lines, 0–1 sorries.
 
 ### S1 OBSERVE — 2026-05-12 (researcher-5)
 


### PR DESCRIPTION
## Summary

- Ships **Phase A** of the three-phase decomposition for `gauss-wilson-non-cyclic-oq-01` per S1 OBSERVE plan (PR #18116).
- New file `proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean` (~66 lines, **0 sorries**) — fully verified.
- Standalone: depends only on `Mathlib.Algebra.BigOperators.Group.Finset.Basic` + `Mathlib.Algebra.Group.Basic`; **no dependency on the parent `GaussWilsonNonCyclic.lean`**.

## Main theorem

```lean
theorem prod_univ_eq_prod_two_torsion (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] :
    ∏ x : G, x = ∏ x ∈ (univ : Finset G).filter (fun x => x ^ 2 = 1), x
```

Proof via `Finset.prod_involution` with `x ↦ x⁻¹` on the non-2-torsion half. Mirrors the existing `WilsonsTheoremOQ04OQ02.prod_eq_prod_involutions` (same statement, distinct namespace) so Phase B / Phase C can build on Phase A without pulling in the Wilson development.

## Build

```
$ ./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ01A
✔ [3058/3058] Built Proofs.GaussWilsonNonCyclicOQ01A (8.9s)
Build completed successfully (3058 jobs).
=== Build succeeded ===
```

## S3 next action

Phase B (product over elementary abelian 2-group of order ≥ 4 equals 1) in a new `GaussWilsonNonCyclicOQ01B.lean`, then Phase C (specialization to `(ZMod n)ˣ`) using parent's `card_sq_eq_one_ge_three`.

## Test plan

- [x] Lean build via Docker wrapper (3058/3058 OK)
- [x] No sorries, no axioms
- [x] No dependency on parent `GaussWilsonNonCyclic.lean`
- [x] Self-contained ≤ 70 lines per S1 OBSERVE plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)