### PR TITLE
audit(general-quartic): sync meta.json counts to Lean source

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.eval",
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 6,
-    "lineCount": 360,
+    "lineCount": 428,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
@@ -49,7 +49,7 @@
     ],
     "assumptions": "6 axioms: ferrari_factorization_forward, ferrari_factorization_backward, quartic_has_four_roots, biquadratic_forward, biquadratic_backward, ferrari_roots_verify. 3 axioms proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 5
   },
   "overview": {


### PR DESCRIPTION
## Summary

Gallery integrity audit detected three count mismatches in `src/data/proofs/general-quartic/meta.json` versus `proofs/Proofs/GeneralQuartic.lean`:

| Field | Was | Actual |
|-------|-----|--------|
| `meta.sorries` | 0 | **1** (sorry at line 383 in `ferrari_biquad_limit`) |
| `meta.lineCount` | 360 | 428 |
| `meta.theoremCount` | 9 | 12 |

The HIGH-severity issue is `sorries: 0` claiming the proof is sorry-free when it has a deferred sorry. The top-level `sorries` and `leanFile.sorries` fields were already correct at `1`, so only the nested `meta.sorries` was stale.

Status `"axiomatized"` + badge `"axiom"` remain correct (6 axioms + 1 sorry).

## Verification

- sorry at line 383 in `ferrari_biquad_limit` (deferred per docstring; OQ-02 S3+)
- file is 428 lines
- 12 theorems by grep

## Test plan

- [x] meta.sorries matches actual sorry count (1)
- [x] meta.lineCount matches wc -l (428)
- [x] meta.theoremCount matches grep count (12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)