### PR TITLE
audit(shannon-channel-coding-oq-02-oq-01): sync sorries to aggregate (4)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",


### PR DESCRIPTION
## Summary

Gallery integrity audit detected a sorries count mismatch in `src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json`.

- `meta.sorries`: 0 → **4**

The auditor aggregates sorries across the main proof file and any `additionalFiles`. Here:
- `Proofs/ShannonChannelCodingOQ02OQ01.lean` — 0 sorries
- `Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean` (additionalFiles) — 4 sorries at lines 48, 66, 87, 109

The Aristotle companion sorries are intentional candidates for the Aristotle proof-search service.

Status `"formalized"` + badge `"mathlib"` remain correct.

## Test plan

- [x] aggregate sorry count matches meta.sorries (4)
- [x] main file unchanged (0 sorries, 0 axioms)
- [x] additionalFiles Aristotle companion unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)