### PR TITLE
audit(binomial-theorem-oq-02-oq-01-oq-01): sync sorries 6 → 5 to actual

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,11 +16,11 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 5,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 269,
-    "assumptions": "No axioms. 6 sorries (aggregate): 5 in main file (ENNReal normalization, support characterization, marginal distributions, mean, covariance) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. The Fintype instance and concrete dice example are fully proved.",
+    "assumptions": "No axioms. 5 sorries (aggregate): 4 in main file (support characterization at line 164, marginal distribution at line 185, mean at line 200, covariance at line 213) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. ENNReal normalization (multinomialPMF_sum_eq_one), the Fintype instance, the PMF construction, and the concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
       "PMF construction via multinomialPMFVal in ENNReal",


### PR DESCRIPTION
## Summary

Gallery integrity audit detected a sorries count mismatch.

- `meta.sorries`: 6 → **5**
- `meta.assumptions`: corrected — ENNReal normalization (`multinomialPMF_sum_eq_one`) is actually fully proved at lines 101-127, not a sorry

Aggregate counts:
- Main file `BinomialTheoremOQ02OQ01OQ01.lean`: **4 sorries** at lines 164, 185, 200, 213 (support characterization, marginal binomial, mean, covariance)
- Aristotle companion: 1 sorry

The legacy `sorries: 6` was stale — it included ENNReal normalization, but that theorem was completed and the metadata never caught up.

Status `"formalized"` + badge `"wip"` remain correct.

## Test plan

- [x] aggregate sorry count matches meta.sorries (5)
- [x] assumptions text accurately lists remaining sorries
- [x] originalContributions list unchanged (no proof status regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)