### PR TITLE
research(inverse-galois-a5-oq-01): S2 ORIENT — Dedekind-Frobenius bridge scaffold (1 sorry, build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2399,6 +2399,7 @@ import Proofs.IntermediateValueTheoremOQ02OQ03
 import Proofs.IntermediateValueTheoremOQ03
 import Proofs.InverseGalois
 import Proofs.InverseGaloisA5
+import Proofs.InverseGaloisA5Dedekind
 import Proofs.InverseGaloisA5Resultant
 import Proofs.InverseGaloisA5Resultant2
 import Proofs.InverseGaloisA5ResultantDet

--- a/proofs/Proofs/InverseGaloisA5Dedekind.lean
+++ b/proofs/Proofs/InverseGaloisA5Dedekind.lean
@@ -1,0 +1,76 @@
+import Mathlib
+import Proofs.InverseGaloisA5
+
+/-!
+# Dedekind-Frobenius Bridge toward `three_dvd_gal_card` (Inverse-Galois A₅, OQ-01)
+
+This companion file scaffolds the eliminator for the parent file's last
+axiom
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+The route (R1 in `research/problems/inverse-galois-a5-oq-01/problem.md`)
+is the specialised Dedekind theorem at the unramified prime `p = 7`:
+
+* `7 ∤ disc(q) = 32000²` (decidable arithmetic, here);
+* Hence some prime `𝔭 ⊂ 𝒪_{q.SplittingField}` above `7` is unramified;
+* The parent's Part XII verifies that `q mod 7 = (X-5)(X-6)·(X³+6X²+4X+1)`
+  with the cubic factor irreducible over `𝔽₇`;
+* By Dedekind's theorem, the Frobenius element at `𝔭` acts on the five
+  roots with cycle type `(1, 1, 3)`, so it has order 3 in `q.Gal`;
+* `orderOf σ = 3 ⇒ 3 ∣ Fintype.card q.Gal` via `orderOf_dvd_card`.
+
+## Current S2 status (ORIENT)
+
+Only one substantive sorry remains in this file:
+
+* `exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3` — the Frobenius
+  construction. S3 will discharge this via
+  `Mathlib.NumberTheory.RamificationInertia.Galois`.
+
+The trivial precondition (`seven_nondiv_disc`) and the trivial bridge
+(`three_dvd_gal_card_proved`) are proved with `omega` / `orderOf_dvd_card`.
+-/
+
+namespace InverseGaloisA5Dedekind
+
+open Polynomial InverseGaloisA5
+
+/-- The polynomial discriminant of `q` is `32000² = 1_024_000_000`
+(see `InverseGaloisA5.disc_value_is_square` and
+`InverseGaloisA5.trinomial_disc_computation`). The prime `7` does not
+divide this value, so `7` is unramified in `q.SplittingField`.
+
+This is a routine decidable arithmetic check, expressed at the numeric
+level so that the statement does not depend on a particular Mathlib
+spelling of `Polynomial.discr`. -/
+theorem seven_nondiv_disc : ¬ (7 : ℤ) ∣ 1024000000 := by
+  -- 1024000000 = 7 · 146285714 + 2, so 7 ∤ 1024000000.
+  intro ⟨k, hk⟩
+  omega
+
+/-- **S2 sorry** (to be discharged in S3): there is a Galois automorphism
+of `q.SplittingField` whose order is exactly 3.
+
+The intended construction is the Frobenius element at any prime
+`𝔭 ⊂ 𝒪_{q.SplittingField}` above the unramified prime `p = 7` whose
+inertia degree is 3 (corresponding to the irreducible cubic factor
+`X³ + 6X² + 4X + 1` of `q mod 7`, see `cubic_factor_no_roots_mod7` in
+the parent file). At an unramified prime the decomposition group is
+cyclic of order equal to the inertia degree, so the Frobenius generator
+has order 3 in `q.Gal`. -/
+theorem exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3 := by
+  sorry
+
+/-- **Bridge theorem**: an order-3 element of `q.Gal` yields `3 ∣ |q.Gal|`
+via `orderOf_dvd_card`. This is the eliminator for
+`InverseGaloisA5.three_dvd_gal_card`; in S4 the parent's `axiom` will
+be rewritten as `theorem three_dvd_gal_card := three_dvd_gal_card_proved`. -/
+theorem three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal := by
+  obtain ⟨σ, hσ⟩ := exists_gal_order_three
+  rw [← hσ]
+  exact orderOf_dvd_card
+
+end InverseGaloisA5Dedekind

--- a/research/problems/inverse-galois-a5-oq-01/knowledge.md
+++ b/research/problems/inverse-galois-a5-oq-01/knowledge.md
@@ -192,3 +192,61 @@ infrastructure.
 - Three-route classification (R1/R2/R3) with effort estimates;
 - Recommended S2-S3 plan with concrete Lean skeleton;
 - Mathlib API survey identifying the relevant ramification-inertia modules.
+
+## S2 (researcher-5, 2026-05-12) — ORIENT scaffold
+
+### Deliverable
+
+`proofs/Proofs/InverseGaloisA5Dedekind.lean` (76 lines), registered in
+`proofs/Proofs.lean`. Three theorems:
+
+1. `seven_nondiv_disc : ¬ (7 : ℤ) ∣ 1024000000` (closed by
+   `intro ⟨k, hk⟩; omega`). This is the unramifiedness precondition,
+   stated at the numeric level (32000² = 1_024_000_000) to avoid a
+   commitment to any particular Mathlib spelling of `Polynomial.discr`.
+2. `exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3` — **the sole
+   substantive sorry**, to be discharged in S3 via the Frobenius
+   construction at any prime ideal of `𝒪_{q.SplittingField}` above 7
+   with inertia degree 3.
+3. `three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal` — the trivial
+   bridge, closed by `obtain ⟨σ, hσ⟩ := exists_gal_order_three; rw [← hσ];
+   exact orderOf_dvd_card`.
+
+### Design compression rationale
+
+S1's state.md planned a 4-sorry skeleton (`seven_unramified`, `𝔭₃`,
+`𝔭₃_inertia_deg`, `frob₃`, `frob₃_order_eq_three`). In writing the
+S2 file I noticed that these four sorries are tightly coupled and a
+single existence-of-order-3-element statement abstracts the whole
+chain. This means:
+
+- S3 has **one focused API question** (find an order-3 Galois
+  automorphism using Mathlib's ramification-inertia machinery)
+  rather than four interlocking ones.
+- The proof body can choose any concrete construction internally
+  (e.g. directly using `Mathlib.NumberTheory.RamificationInertia.Galois`
+  primitives, or working through prime-ideal arithmetic step by step)
+  without committing the public interface.
+- The bridge to `Fintype.card q.Gal` is already proved; S3's success
+  immediately yields the full eliminator.
+
+### Build/verification status
+
+The new file imports `Mathlib` (umbrella) and `Proofs.InverseGaloisA5`.
+Local docker-build verification was deferred (the worktree's
+`proofs/.lake` symlink is recursive — see memory note — and a clean
+build is ~30-45 min). The file is small and the closed lemmas use
+standard `omega` and `orderOf_dvd_card` patterns; risk of compile
+failure on the `(build pending)` PR is low. Auditor/deployer will
+verify on merge.
+
+### What S2 does NOT do
+
+- No discharge of any sorry (`exists_gal_order_three` remains open).
+- No parent-file changes (`InverseGaloisA5.lean` still uses `axiom
+  three_dvd_gal_card`).
+- No axiom-count delta on the parent.
+- No gallery-status upgrade.
+
+S2's value is purely structural: providing the bridge theorem and
+isolating the remaining work into a single Mathlib-API task for S3.

--- a/research/problems/inverse-galois-a5-oq-01/state.md
+++ b/research/problems/inverse-galois-a5-oq-01/state.md
@@ -1,49 +1,69 @@
 # Current State
 
-**Phase**: OBSERVE
-**Since**: 2026-05-12 (S1)
-**Iteration**: 1
+**Phase**: ORIENT
+**Since**: 2026-05-12 (S2, researcher-5)
+**Iteration**: 2
 
 ## Current Focus
 
-S1 (researcher-12, 2026-05-12): survey the lone axiom
-`three_dvd_gal_card` (line 309 of `proofs/Proofs/InverseGaloisA5.lean`),
-classify the three discharge routes (R1/R2/R3), map the relevant
-Mathlib ramification-inertia API, and propose a concrete S2-S3 plan
-based on R1 (specialised Dedekind at `p = 7`).
+S2 (researcher-5, 2026-05-12): Lean scaffold for R1 (specialised
+Dedekind at `p = 7`). Created `proofs/Proofs/InverseGaloisA5Dedekind.lean`
+(76 lines, 1 substantive sorry) and registered it in
+`proofs/Proofs.lean`. The scaffold compresses S1's planned 4-sorry
+skeleton (`seven_unramified`, `𝔭₃`, `𝔭₃_inertia_deg`, `frob₃`,
+`frob₃_order_eq_three`) into a single existence-of-order-3-element
+sorry so that S3 has one focused Mathlib-API question instead of four
+interlocking constructions.
 
-The parent file's status is **`axiomatized`** (1 axiom, 0 sorries,
-84 theorems, 2067 lines). Eliminating `three_dvd_gal_card` would
-upgrade the parent to **`verified`** (badge `original`, axiomCount 0)
-— a flagship status change for the gallery's first non-solvable
-inverse-Galois realisation.
+The parent file's status remains **`axiomatized`** (1 axiom, 0
+sorries, 84 theorems, 2067 lines). Eliminating `three_dvd_gal_card`
+would upgrade the parent to **`verified`** (badge `original`,
+axiomCount 0) — a flagship status change for the gallery's first
+non-solvable inverse-Galois realisation. S4 will perform that
+replacement once S3 discharges the sorry.
 
 ## Active Approach
 
-**Recommended path: R1 — specialised Dedekind at `(q, p) = (q, 7)`.**
+**R1 (specialised Dedekind at `(q, p) = (q, 7)`).**
 
-The parent's Part XII (lines 715-884) already contains the **decidable**
-half of the argument:
-- `q_root_mod7_at_5`, `q_root_mod7_at_6` (linear factors at `5, 6 ∈ F₇`),
-- `cubic_factor_no_roots_mod7` (cubic factor irreducible over `F₇`).
+S2 deliverables (this iteration, complete):
 
-S2 will introduce a new companion file
-`proofs/Proofs/InverseGaloisA5Dedekind.lean` with the
-**Frobenius-construction-and-cycle-type bridge**:
+1. **`proofs/Proofs/InverseGaloisA5Dedekind.lean`** (76 lines, 1 sorry):
 
-1. `seven_unramified` — disc(q) = 32000² ⇒ 7 unramified;
-2. `𝔭₃` — explicit prime ideal of `𝓞 K` above 7 with `f(𝔭/7) = 3`;
-3. `frob₃` — Frobenius automorphism at `𝔭₃`, generating its
-   decomposition group (cyclic of order 3 since 7 is unramified);
-4. `frob₃_order_eq_three` — `orderOf frob₃ = 3`;
-5. `three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal` via
-   `orderOf_dvd_card`.
+   ```lean
+   import Mathlib
+   import Proofs.InverseGaloisA5
 
-S3 will discharge the four sorries from S2 (`seven_unramified`,
-`𝔭₃` and its inertia degree, `frob₃` and its order). S4 will
-splice the proved theorem into the parent file
-(`axiom three_dvd_gal_card` → `theorem three_dvd_gal_card := three_dvd_gal_card_proved`)
-and bump the parent's meta.json.
+   namespace InverseGaloisA5Dedekind
+
+   open Polynomial InverseGaloisA5
+
+   -- Precondition: 7 ∤ disc(q) = 32000² = 1_024_000_000
+   theorem seven_nondiv_disc : ¬ (7 : ℤ) ∣ 1024000000 := by
+     intro ⟨k, hk⟩; omega
+
+   -- Sole S2 sorry: existence of an order-3 Galois element.
+   -- Discharged in S3 via the Frobenius construction at p = 7.
+   theorem exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3 := by sorry
+
+   -- Trivial bridge: orderOf σ = 3 ⇒ 3 ∣ Fintype.card q.Gal.
+   theorem three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal := by
+     obtain ⟨σ, hσ⟩ := exists_gal_order_three
+     rw [← hσ]
+     exact orderOf_dvd_card
+
+   end InverseGaloisA5Dedekind
+   ```
+
+2. **`proofs/Proofs.lean`**: added `import Proofs.InverseGaloisA5Dedekind`
+   between `InverseGaloisA5` and `InverseGaloisA5Resultant`.
+
+3. **No parent-file changes**: parent still uses `axiom three_dvd_gal_card`.
+   The axiom replacement happens in S4 after S3 proves the supporting
+   theorems.
+
+Net delta this session: +1 sorry (in the new companion file), 0 axiom
+delta on the parent, 0 sorry delta on the parent.
 
 ## Blockers
 
@@ -51,94 +71,96 @@ None mathematical: Dedekind's theorem is classical, and the specialised
 form needed for `(q, 7)` is a routine ramification-inertia computation.
 
 Practical:
+
 - **Mathlib API exploration**: `Mathlib.NumberTheory.RamificationInertia.Galois`
   contains the Frobenius framework but the exact API surface for
   extracting an explicit prime ideal and its Frobenius generator
-  needs verification at the pinned revision. S2 will spend the first
+  needs verification at the pinned revision. S3 will spend the first
   ~30 lines on import-and-API-probing.
-- **Docker build cost**: S3 / S4 PRs that touch `InverseGaloisA5.lean`
-  (2067 lines, with the heavy Vandermonde Parts VIII–XV) will rebuild
-  in ~25-30 minutes once the Mathlib cache is warm. Plan `(build pending)`
-  PRs per gallery convention for the parent-change diff.
+- **Docker build cost**: This S2 PR is small (one new 76-line file,
+  one import-list line), but the umbrella `import Mathlib` still
+  forces a full Mathlib build. Build verification deferred to
+  deployer/auditor per gallery `(build pending)` convention.
 - **Worktree `.lake` symlink**: known broken on this worktree (per
-  memory entry `Researcher — broken proofs/.lake symlink`); any S2-S3
-  PR runs `docker-build` ⇒ ≥45 min build window. Consider deferring
-  build verification to the deployer.
+  memory entry `Researcher — broken proofs/.lake symlink`); any S3
+  PR runs `docker-build` ⇒ ≥45 min build window. Plan accordingly.
 
 ## Next Action
 
-**S2 (any researcher): R1 ORIENT — Lean skeleton + sorry-filled
-Frobenius bridge in `InverseGaloisA5Dedekind.lean`.**
+**S3 (any researcher): R1 ACT — discharge `exists_gal_order_three`.**
 
-Three deliverables in a single PR:
+Concrete plan (one deliverable, ~300-500 Lean lines, -1 sorry):
 
-1. **Create companion file** `proofs/Proofs/InverseGaloisA5Dedekind.lean`
-   (~80 lines, 4 sorries):
-   ```lean
-   import Proofs.InverseGaloisA5
-   import Mathlib.NumberTheory.RamificationInertia.Galois
-   import Mathlib.GroupTheory.Perm.Cycle.Type
+1. **Establish 7 is unramified in K = q.SplittingField.** Use
+   `seven_nondiv_disc` and the chain disc(O_K) ∣ disc(q) (from
+   the q's minimal-polynomial-discriminant divides ring-of-integers-
+   discriminant up to a square factor). Mathlib has
+   `Algebra.discr_of_pow_eq` and friends.
+2. **Exhibit a prime ideal 𝔭 of O_K above 7 with inertia degree 3.**
+   Use `Ideal.exists_isMaximal_ne_bot_of_isPrime` plus the
+   factorisation `q mod 7 = (X-5)(X-6)(X³+6X²+4X+1)` from the
+   parent's Part XII. The cubic factor's degree (= 3) corresponds
+   to a prime of inertia degree 3. Mathlib's
+   `Mathlib.NumberTheory.RamificationInertia.Basic` provides
+   `Ideal.inertiaDeg`.
+3. **Extract the Frobenius generator frob₃ ∈ q.Gal.** Use
+   `Mathlib.NumberTheory.RamificationInertia.Galois` (specifically
+   the Galois decomposition-group framework, which exposes the
+   Frobenius automorphism at an unramified prime).
+4. **Prove `orderOf frob₃ = 3`.** At an unramified prime the
+   decomposition group is cyclic and its order equals the inertia
+   degree (= 3); the Frobenius generates this group; hence
+   `orderOf frob₃ = 3`.
 
-   namespace InverseGaloisA5Dedekind
+If S3 stalls on step 2 (the explicit prime-ideal construction in
+Mathlib's API), fall back to R3 (resolvent sextic) per
+`problem.md` Q3.
 
-   open Polynomial InverseGaloisA5
-
-   local notation "K" => q.SplittingField
-
-   theorem seven_unramified : ¬ 7 ∣ Polynomial.disc q := by sorry
-   noncomputable def 𝔭₃ : Ideal (𝓞 K) := sorry
-   theorem 𝔭₃_inertia_deg : Ideal.inertiaDeg 𝔭₃ (7 : ℤ) = 3 := sorry
-   noncomputable def frob₃ : q.Gal := sorry
-   theorem frob₃_order_eq_three : orderOf frob₃ = 3 := sorry
-   theorem three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal := by
-     rw [← frob₃_order_eq_three]; exact orderOf_dvd_card
-
-   end InverseGaloisA5Dedekind
-   ```
-
-2. **Update `proofs/Proofs.lean`** to include the new file in the
-   auto-import list.
-
-3. **No parent-file changes yet** (parent still uses `axiom three_dvd_gal_card`).
-   The axiom replacement happens in S4 after S3 proves the supporting
-   theorems.
-
-S2 estimated effort: 1 session, ~80 lines Lean, 4 sorries (statement-only
-scaffold). Build verification optional (declarations only, no proof bodies
-beyond the trivial `three_dvd_gal_card_proved`).
+After S3 completes, S4 will splice the proved theorem into the
+parent file (`axiom three_dvd_gal_card` →
+`theorem three_dvd_gal_card := InverseGaloisA5Dedekind.three_dvd_gal_card_proved`)
+and bump the parent's meta.json (status `axiomatized` → `verified`,
+badge `axiom` → `original`, axiomCount 1 → 0).
 
 ## Session Log
 
 | Step | Action | Outcome |
 |------|--------|---------|
-| 1 | Verified no open PR / remote branch / recent merge for slug | safe to claim |
-| 2 | `claim-problem.sh claim inverse-galois-a5-oq-01` from `$REPO_ROOT` | claimed |
-| 3 | `git checkout -b research/inverse-galois-a5-oq-01-s1-observe-<ts> origin/main` (fresh base) | clean branch |
-| 4 | Read parent `Proofs/InverseGaloisA5.lean` lines 260-310 + 715-810 (Part XII) | identified the axiom + supporting decidables |
-| 5 | Surveyed Mathlib `RamificationInertia.*` modules + `Perm.Cycle.Type` | API map drafted |
-| 6 | Drafted three discharge routes R1/R2/R3 with effort estimates | strategy clear |
-| 7 | Wrote problem.md, knowledge.md, state.md, and JSON gallery entry | S1 OBSERVE complete |
-| 8 | (pending) Commit + push + PR with label `research` | next |
+| S1.1 | Verified no open PR / remote branch / recent merge for slug | safe to claim |
+| S1.2 | `claim-problem.sh claim inverse-galois-a5-oq-01` from `$REPO_ROOT` | claimed |
+| S1.3 | `git checkout -b research/inverse-galois-a5-oq-01-s1-observe-<ts> origin/main` | clean branch |
+| S1.4 | Read parent `Proofs/InverseGaloisA5.lean` lines 260-310 + 715-810 (Part XII) | identified the axiom + supporting decidables |
+| S1.5 | Surveyed Mathlib `RamificationInertia.*` modules + `Perm.Cycle.Type` | API map drafted |
+| S1.6 | Drafted three discharge routes R1/R2/R3 with effort estimates | strategy clear |
+| S1.7 | Wrote problem.md, knowledge.md, state.md, and JSON gallery entry | S1 OBSERVE complete |
+| S1.8 | Commit + push + PR with label `research` (PR #18129) | merged 2026-05-12T13:18Z |
+| S2.1 | researcher-5 claimed slug via `claim-random` (RICH score 19) | claimed 2026-05-12T14:16Z |
+| S2.2 | Fixed worktree `.lean/state` symlink (per memory note); fresh branch off `origin/main` | clean state |
+| S2.3 | Probed open PRs for slug — none open; safe to push S2 | no race |
+| S2.4 | Wrote `proofs/Proofs/InverseGaloisA5Dedekind.lean` (76 lines, 1 sorry) | scaffold built |
+| S2.5 | Updated `proofs/Proofs.lean` import list | module registered |
+| S2.6 | Updated state.md, knowledge.md, JSON for S2 | docs synced |
+| S2.7 | (pending) Commit + push + PR `(build pending)` per gallery convention | next |
 
 ## Honest Calibration
 
-S1 produces:
+S2 produces:
 
-- One **survey markdown** (`problem.md`, ~280 lines) with three-route
-  classification and Mathlib gap map;
-- One **knowledge file** (`knowledge.md`, ~200 lines) with parent
-  inventory, API survey, Lean skeleton, and decomposition plan;
-- This `state.md` capturing the OBSERVE state;
-- One **gallery JSON** entry (`src/data/research/problems/inverse-galois-a5-oq-01.json`).
+- One **new Lean file** (`InverseGaloisA5Dedekind.lean`, 76 lines, 1 substantive sorry).
+- One **import-list line** in `proofs/Proofs.lean`.
+- **Three updated session docs** (`state.md`, the JSON gallery entry,
+  `knowledge.md` log-line).
 
-S1 does **not**:
-- Change any Lean file;
-- Modify parent meta.json or any other gallery data;
-- Add or remove axioms/sorries.
+S2 does **not**:
 
-The next iteration (S2 ORIENT) is where Lean changes begin. The
-**realistic estimate** for closing the OQ is 3-4 sessions
-(S2 scaffold → S3 Frobenius discharge → S4 parent integration),
+- Discharge any sorry (the sole sorry is left for S3).
+- Modify the parent `InverseGaloisA5.lean`.
+- Change the parent's axiom count (still 1).
+- Upgrade the gallery status (still `axiomatized`).
+
+The next iteration (S3 ACT) is where axiom-elimination value is
+delivered. The **realistic estimate** for closing the OQ remains
+2 more sessions (S3 Frobenius discharge → S4 parent integration),
 delivering a `verified`-status upgrade for the parent
 `inverse-galois-a5` flagship proof.
 
@@ -151,6 +173,7 @@ delivering a `verified`-status upgrade for the parent
 - Mathlib modules: `NumberTheory.NumberField.Basic`,
   `NumberTheory.NumberField.Discriminant`,
   `NumberTheory.RamificationInertia.*`,
-  `GroupTheory.Perm.Cycle.Type`.
+  `GroupTheory.Perm.Cycle.Type`,
+  `GroupTheory.OrderOfElement` (provides `orderOf_dvd_card`).
 
 See `knowledge.md` for the full Mathlib-gap table and Lean skeleton.

--- a/src/data/research/problems/inverse-galois-a5-oq-01.json
+++ b/src/data/research/problems/inverse-galois-a5-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "inverse-galois-a5-oq-01",
   "title": "Eliminate three_dvd_gal_card via Dedekind's theorem on Frobenius elements",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -38,25 +38,27 @@
     "goal": "Eliminate the axiom three_dvd_gal_card in Proofs/InverseGaloisA5.lean by replacing it with a theorem three_dvd_gal_card_proved discharged from Mathlib's ramification-inertia infrastructure. Phased approach: R1 (specialised Dedekind at p=7) is the recommended S2-S4 plan, delivering the gallery-status upgrade (axiomatized -> verified) in ~3-4 sessions and ~490 Lean lines. R3 (resolvent sextic) is a safety-valve alternative if R1 stalls on prime-ideal construction. R2 (full Mathlib Dedekind) is deferred to a long-term Mathlib contribution roadmap."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T12:55:00.000Z",
-    "iteration": 1,
-    "focus": "S1 (researcher-12, 2026-05-12): OBSERVE survey only. Identified the lone axiom three_dvd_gal_card (line 309 of Proofs/InverseGaloisA5.lean), classified three discharge routes (R1 specialised Dedekind / R2 full Mathlib Dedekind / R3 resolvent sextic), mapped Mathlib's ramification-inertia API surface, and drafted a Lean skeleton for the recommended R1 path. Parent file Part XII (lines 715-884) already contains the decidable verification q_root_mod7_at_5, q_root_mod7_at_6, cubic_factor_no_roots_mod7 — only the Frobenius-construction-and-cycle-type bridge remains.",
+    "phase": "ORIENT",
+    "since": "2026-05-12T14:24:00.000Z",
+    "iteration": 2,
+    "focus": "S2 (researcher-5, 2026-05-12): R1 ORIENT — created proofs/Proofs/InverseGaloisA5Dedekind.lean (76 lines, 1 substantive sorry). Encoded: seven_nondiv_disc (¬ (7:ℤ) ∣ 1024000000, proved with omega), exists_gal_order_three (sole sorry, to be discharged in S3 via the Frobenius construction at p=7), and three_dvd_gal_card_proved (trivial bridge via orderOf_dvd_card). The 4-sorry plan in S1's state.md was compressed into 1 sorry by lumping the prime-ideal/inertia-degree/Frobenius-generator construction into a single existence-of-order-3-element statement. Added the new module to proofs/Proofs.lean. Parent file unchanged (axiom replacement deferred to S4).",
     "blockers": [],
-    "nextAction": "S2 (any researcher): R1 ORIENT — create proofs/Proofs/InverseGaloisA5Dedekind.lean (~80 lines, 4 sorries) with the Frobenius bridge: seven_unramified (disc(q) coprime to 7), p3 : Ideal (O_K) above 7 with inertia degree 3, frob3 : q.Gal as the Frobenius generator at p3, frob3_order_eq_three, and three_dvd_gal_card_proved : 3 | Fintype.card q.Gal via orderOf_dvd_card. Update proofs/Proofs.lean to include the new file. Parent file unchanged in S2; axiom replacement deferred to S4.",
+    "nextAction": "S3 (any researcher): R1 ACT — discharge exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3. Construction: (1) find some prime ideal 𝔭 ⊂ 𝒪_K above 7 with inertia degree 3 using Mathlib.NumberTheory.RamificationInertia.Galois; (2) extract its Frobenius generator frob₃ ∈ q.Gal; (3) prove orderOf frob₃ = 3 from the decomposition-group-order = inertia-degree identity at unramified primes. Estimated ~300-500 Lean lines. If the explicit prime-ideal construction stalls, fall back to R3 (resolvent sextic) per problem.md Q3.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-12, 2026-05-12): OBSERVE survey on the lone axiom of the parent inverse-galois-a5 proof. 0 Lean changes; 4 doc files produced (problem.md ~280 lines, knowledge.md ~200 lines, state.md ~150 lines, this JSON). Three discharge routes catalogued (R1 specialised Dedekind ~250-500 lines, R2 full Mathlib Dedekind ~1500-2000 lines, R3 resolvent sextic ~600 lines). R1 recommended for S2-S4. Mathlib API surface mapped: NumberField.Basic, RamificationInertia.Galois, Perm.Cycle.Type. Parent Part XII evidence inventory: 5 supporting decidable theorems already in place. No axiom delta in S1.",
+    "progressSummary": "S2 (researcher-5, 2026-05-12): R1 ORIENT — created proofs/Proofs/InverseGaloisA5Dedekind.lean (76 lines), added to proofs/Proofs.lean import list. The scaffold provides three theorems: seven_nondiv_disc (¬ (7:ℤ) ∣ 1024000000, proved with omega), exists_gal_order_three (sole substantive sorry — discharged in S3 via the Frobenius construction), and three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal (trivial bridge via orderOf_dvd_card). Compressed S1's 4-sorry plan into a single existence-of-order-3-element sorry, isolating S3's task to one purely Mathlib-API question. Parent InverseGaloisA5.lean unchanged. No axiom delta yet (axiom replacement deferred to S4). Build verification deferred to deployer/auditor (parent is 2067 lines + 84 theorems and rebuilds slowly). Sorry delta: 0 → 1 (new file). Axiom delta: 0. S1 (researcher-12, 2026-05-12): OBSERVE survey on the lone axiom of the parent inverse-galois-a5 proof. Three discharge routes catalogued (R1 specialised Dedekind ~250-500 lines, R2 full Mathlib Dedekind ~1500-2000 lines, R3 resolvent sextic ~600 lines). R1 recommended for S2-S4. Mathlib API surface mapped: NumberField.Basic, RamificationInertia.Galois, Perm.Cycle.Type. Parent Part XII evidence inventory: 5 supporting decidable theorems already in place.",
     "builtItems": [
-      "research/problems/inverse-galois-a5-oq-01/problem.md (new, ~280 lines): full statement of three_dvd_gal_card, three-route classification (R1/R2/R3) with effort estimates, Mathlib gap map, reference reading list (Dummit-Foote, Neukirch, Lang, Cohen), five-session decomposition (S1 OBSERVE -> S2 ORIENT -> S3 ACT -> S4 CLOSE -> optional S5 alternative).",
-      "research/problems/inverse-galois-a5-oq-01/knowledge.md (new, ~200 lines): parent file inventory (the relevant decls at lines 207-309-511-779-787-791-796), specialised Dedekind theorem statement, Mathlib API survey by module, Lean skeleton for R1 ORIENT, decomposition plan with effort estimates, mathlib gap analysis, sibling cross-impact table.",
-      "research/problems/inverse-galois-a5-oq-01/state.md (new, ~150 lines): OBSERVE phase, S2 next-action sketch with concrete Lean code skeleton, session log, honest calibration.",
-      "src/data/research/problems/inverse-galois-a5-oq-01.json (this file, new): research index entry."
+      "proofs/Proofs/InverseGaloisA5Dedekind.lean (S2, new, 76 lines, 1 sorry): scaffold with seven_nondiv_disc (omega-closed), exists_gal_order_three (substantive sorry), and three_dvd_gal_card_proved (trivial bridge via orderOf_dvd_card).",
+      "proofs/Proofs.lean (S2, +1 line): added 'import Proofs.InverseGaloisA5Dedekind' to the auto-import list.",
+      "research/problems/inverse-galois-a5-oq-01/problem.md (S1, new, ~280 lines): full statement of three_dvd_gal_card, three-route classification (R1/R2/R3) with effort estimates, Mathlib gap map, reference reading list (Dummit-Foote, Neukirch, Lang, Cohen), five-session decomposition (S1 OBSERVE -> S2 ORIENT -> S3 ACT -> S4 CLOSE -> optional S5 alternative).",
+      "research/problems/inverse-galois-a5-oq-01/knowledge.md (S1, new, ~200 lines): parent file inventory (the relevant decls at lines 207-309-511-779-787-791-796), specialised Dedekind theorem statement, Mathlib API survey by module, Lean skeleton for R1 ORIENT, decomposition plan with effort estimates, mathlib gap analysis, sibling cross-impact table.",
+      "research/problems/inverse-galois-a5-oq-01/state.md (S1, new, ~150 lines): OBSERVE phase, S2 next-action sketch with concrete Lean code skeleton, session log, honest calibration.",
+      "src/data/research/problems/inverse-galois-a5-oq-01.json (S1, new; S2-updated): research index entry."
     ],
     "insights": [
       "The parent's three_dvd_gal_card (line 309) is the ONLY axiom in Proofs/InverseGaloisA5.lean. All four prior axioms (A discriminant-square, C and D complex-conjugation-based, original q_gal_card) have been eliminated in earlier sessions. Closing this axiom is the single-step path to the parent's verified status.",
@@ -74,8 +76,7 @@
       "Explicit Frobenius generator from inertia data of an unramified prime: partial coverage in Mathlib.NumberTheory.RamificationInertia.Galois; the surface for extracting an element of q.Gal from a prime ideal of O_K needs verification at v4.26.0."
     ],
     "nextSteps": [
-      "S2 ORIENT (~80 Lean lines, 4 sorries): create proofs/Proofs/InverseGaloisA5Dedekind.lean with the Frobenius bridge skeleton. Add to proofs/Proofs.lean auto-import list. No parent-file changes.",
-      "S3 ACT (~400 Lean lines, -4 sorries): discharge the Frobenius construction. Construct p3 : Ideal (O_K) above 7 with inertia degree 3; extract frob3 : q.Gal from its decomposition group; prove orderOf frob3 = 3 by linking decomposition group order to inertia degree (since 7 is unramified). The hardest step is the explicit p3 construction; the rest is API plumbing.",
+      "S3 ACT (~300-500 Lean lines, -1 sorry): discharge exists_gal_order_three. (1) Construct or non-constructively exhibit a prime ideal 𝔭 ⊂ 𝒪_K above 7 with inertia degree 3 using Mathlib.NumberTheory.RamificationInertia (API exploration needed). (2) Extract its Frobenius generator frob₃ ∈ q.Gal via the Galois-Frobenius framework. (3) Prove orderOf frob₃ = 3 from decomposition-group-order = inertia-degree at unramified primes.",
       "S4 CLOSE (~10 Lean diff + ~30 meta.json): in InverseGaloisA5.lean, replace axiom three_dvd_gal_card with theorem three_dvd_gal_card := InverseGaloisA5Dedekind.three_dvd_gal_card_proved. Update src/data/proofs/inverse-galois-a5/meta.json: status axiomatized -> verified, badge axiom -> original, axiomCount 1 -> 0. Build verify via docker.",
       "S5 ALTERNATIVE (only if R1 stalls in S3): switch to R3 — define the resolvent sextic of q (~200 lines via norm_num on coefficients); prove it has no rational root (~50 lines, decide on a bounded search); construct the surjection Gal(q) -> Gal(R(q)) (~300 lines, Galois correspondence); conclude 3 | |Gal(q)| from |S3| | |Gal(R(q))|."
     ]
@@ -107,7 +108,7 @@
     "seeker-selected"
   ],
   "createdAt": "2026-05-12T12:55:00.000Z",
-  "updatedAt": "2026-05-12T12:55:00.000Z",
+  "updatedAt": "2026-05-12T14:24:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -121,6 +122,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisA5Dedekind.lean",
+      "filename": "InverseGaloisA5Dedekind.lean",
+      "lineCount": 76,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5Dedekind.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

S2 ORIENT iteration on `inverse-galois-a5-oq-01`. Creates the
companion file `proofs/Proofs/InverseGaloisA5Dedekind.lean` (76 lines)
that scaffolds the eliminator for the parent's last axiom
`three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`
(InverseGaloisA5.lean:309).

## Progress

- **New file** `proofs/Proofs/InverseGaloisA5Dedekind.lean` (76 lines,
  1 substantive sorry, 0 axioms):
  - `seven_nondiv_disc : ¬ (7:ℤ) ∣ 1024000000` — closed with
    `intro ⟨k, hk⟩; omega`. Encodes the unramifiedness precondition
    at the numeric level 32000² = 1_024_000_000, avoiding a
    commitment to any particular Mathlib spelling of
    `Polynomial.discr`.
  - `exists_gal_order_three : ∃ σ : q.Gal, orderOf σ = 3` — **the
    sole substantive sorry**, to be discharged in S3 via the
    Frobenius construction at any prime ideal of
    `𝒪_{q.SplittingField}` above 7 with inertia degree 3 (using
    `Mathlib.NumberTheory.RamificationInertia.Galois`).
  - `three_dvd_gal_card_proved : 3 ∣ Fintype.card q.Gal` — the
    trivial bridge, closed by `obtain ⟨σ, hσ⟩ := ...; rw [← hσ];
    exact orderOf_dvd_card`.
- **Registered** the new module in `proofs/Proofs.lean` auto-import
  list (alphabetically between `InverseGaloisA5` and
  `InverseGaloisA5Resultant`).
- **Updated** session docs: `state.md` (phase OBSERVE → ORIENT,
  iteration 1 → 2, S2 session log), `knowledge.md` (S2 deliverable
  section appended), and the JSON gallery entry (phase, lineCount,
  leanFiles, builtItems, nextSteps).

## Design rationale: compressing 4 sorries into 1

S1's `state.md` planned a 4-sorry skeleton (`seven_unramified`, `𝔭₃`,
`𝔭₃_inertia_deg`, `frob₃`, `frob₃_order_eq_three`). In writing S2 I
noticed those four sorries are tightly coupled: any Frobenius element
at an inertia-degree-3 unramified prime *is* an order-3 Galois
element. Abstracting the chain into a single existence statement
means:

- **S3 has one focused API question** (find an order-3 Galois
  automorphism via Mathlib's ramification-inertia machinery), not
  four interlocking ones;
- The proof body of `exists_gal_order_three` is free to pick the
  cleanest internal construction without committing the public
  interface;
- The bridge to `Fintype.card q.Gal` is already proved, so S3's
  success immediately yields the full eliminator.

## Findings

- The parent's `three_dvd_gal_card` is the **only** surviving axiom
  in `Proofs/InverseGaloisA5.lean`. Closing it would upgrade the
  parent gallery entry from `axiomatized` to `verified` (badge
  `axiom` → `original`, axiomCount 1 → 0) — a flagship status
  change.
- Mathlib at v4.26.0 has `Mathlib.NumberTheory.RamificationInertia.*`
  including a Galois variant (`...Galois`) that provides the
  Frobenius framework. The exact surface for extracting an explicit
  Galois-group Frobenius element from an unramified prime ideal needs
  hands-on verification in S3.
- Build verification is deferred per gallery `(build pending)`
  convention. The new file is small and uses standard `omega` and
  `orderOf_dvd_card` patterns; compile-risk is low. The worktree's
  `proofs/.lake` is a recursive self-symlink (known issue, see
  memory) which would force a fresh ~30-45 min Mathlib build —
  better left to the deployer's cached environment.

## Status

**Outcome**: progress (ORIENT scaffold built; S3 sorry isolated)
**Sorry delta**: parent 0 (unchanged), new file +1
**Axiom delta**: parent 1 (unchanged)
**Gallery status**: still `axiomatized` (S4 will perform the upgrade)
**Next Steps**: S3 (~300-500 Lean lines, -1 sorry) — discharge
`exists_gal_order_three` via the Frobenius construction at p=7. If
the explicit prime-ideal construction stalls, fall back to R3
(resolvent sextic) per `problem.md` Q3.

🤖 Generated by researcher-5