### PR TITLE
fix(auditor): accept main-only or chain sorries to break #18137 oscillation

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -60,6 +60,7 @@ interface AuditTarget {
   }
   actual: {
     sorryCount: number
+    mainSorryCount: number
     axiomCount: number
     trueStubCount: number
     hasMajorMathlibDep: boolean
@@ -211,9 +212,20 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`CRITICAL: ${target.actual.trueStubCount} True stubs but status is "verified"`)
   }
 
-  // Sorry count mismatch
-  if (target.meta.claimedSorries !== target.actual.sorryCount) {
-    issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
+  // Sorry count mismatch.
+  // Two coexisting meta.sorries conventions for entries with companion/additional files:
+  //   - chain-aggregate (PR #18120, axiom-symmetric): counts main + additionalFiles + companion
+  //   - main-file-only (PR #18127): counts only the main proofRepoPath
+  // Accept either to break the false-clean oscillation cycle on Aristotle-companion entries
+  // (Issue #18137). When no companion/additional files are followed, both counts are equal,
+  // so single-file entries are unaffected.
+  const claimed = target.meta.claimedSorries
+  if (claimed !== target.actual.sorryCount && claimed !== target.actual.mainSorryCount) {
+    issues.push(
+      target.actual.mainSorryCount === target.actual.sorryCount
+        ? `sorry mismatch: claims ${claimed}, actual ${target.actual.sorryCount}`
+        : `sorry mismatch: claims ${claimed}, actual main ${target.actual.mainSorryCount} / chain ${target.actual.sorryCount}`
+    )
   }
 
   // Axiom count mismatch -- only flag undercounts (meta claims fewer than detected).
@@ -259,17 +271,24 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
 
   // Actual counts from Lean file(s) — includes submodules and additionalFiles
   let sorryCount = 0
+  let mainSorryCount = 0
   let axiomCount = 0
   let trueStubCount = 0
   let hasMajorMathlibDep = false
 
   const allLeanFiles = leanPath ? resolveAllLeanFiles(leanPath, proofMeta) : []
-  for (const filePath of allLeanFiles) {
+  for (let i = 0; i < allLeanFiles.length; i++) {
+    const filePath = allLeanFiles[i]
     const rawContent = fs.readFileSync(filePath, 'utf-8')
     // Strip comments to avoid counting sorry/True in comments (Issue #6130)
     const content = stripLeanComments(rawContent)
 
-    sorryCount += (content.match(/\bsorry\b/g) || []).length
+    const fileSorryCount = (content.match(/\bsorry\b/g) || []).length
+    sorryCount += fileSorryCount
+    // resolveAllLeanFiles puts the main proofRepoPath first; track its sorries
+    // separately so meta.sorries claims using the main-file-only convention
+    // (PR #18127) can validate alongside chain-aggregate claims (PR #18120).
+    if (i === 0) mainSorryCount = fileSorryCount
     axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
@@ -309,6 +328,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     },
     actual: {
       sorryCount,
+      mainSorryCount,
       axiomCount,
       trueStubCount,
       hasMajorMathlibDep,


### PR DESCRIPTION
## Fix

\`scripts/auditor/find-targets.ts\` now tracks main-file sorries separately during chain aggregation and accepts **either** the chain-aggregate convention or the main-file-only convention for \`meta.sorries\`. Single-file entries are unaffected.

## Why

Issue #18137 traced a false-clean oscillation cycle on Aristotle-companion entries to a structural conflict between two recently-established \`meta.sorries\` conventions, both landed on 2026-05-12:

- **PR #18120**: chain-aggregate (axiom-symmetric). \`meta.sorries\` counts main + \`additionalFiles\` + companion.
- **PR #18127**: main-file-only. \`meta.sorries\` counts only the main \`proofRepoPath\`.

The auditor compared chain-aggregate actual against \`meta.sorries\`, which validated #18120-style PRs but flagged #18127-style PRs as \`sorry mismatch\`. Each subsequent mechanic re-flipped the convention, perpetuating the cycle (shannon-channel-coding-oq-03 alone was audit-flagged 5 times, with #18142 / #18145 now competing meta-only flips).

This is **Option A** from the issue: mirror the smart axiom logic (\`find-targets.ts:304-308\`) by accepting either convention at the detection layer.

## Evidence

Before this change (origin/main):
\`\`\`
Top 4 audit targets:
  general-quartic                          ❌ sorry mismatch: claims 0, actual 1
  shannon-channel-coding-oq-02-oq-01       ❌ sorry mismatch: claims 0, actual 4
  shannon-channel-coding-oq-03             ❌ sorry mismatch: claims 0, actual 4
  binomial-theorem-oq-02-oq-01-oq-01       ❌ sorry mismatch: claims 6, actual 5
\`\`\`

After this change:
\`\`\`
Top 2 audit targets:
  general-quartic                          ❌ sorry mismatch: claims 0, actual 1
  binomial-theorem-oq-02-oq-01-oq-01       ❌ sorry mismatch: claims 6, actual main 4 / chain 5
\`\`\`

The two Shannon Aristotle-companion entries (\`claim=0\` matches \`mainSorryCount=0\`) drop off the issues list — they were the canonical asymmetry victims. The remaining two are genuine drifts unrelated to the convention conflict; meta-only fix PRs (#18142, #18145) handle those.

## Notes

- Diff is +25 / -5 lines in a single file.
- New \`mainSorryCount\` field on \`AuditTarget.actual\` is internal-only.
- Error message format is unchanged for single-file entries (\`mainSorryCount === sorryCount\`); multi-file mismatches now show both counts.
- Axiom mismatch check is untouched — its existing \"smart\" logic (lines 304-308) already handles the analogous main-vs-chain distinction for axiom counts.

Closes #18137

---
Automated fix by lean-mechanic agent (mechanic-3).