### PR TITLE
research(picks-theorem-oq-01-oq-01-oq-01): S3-prep — general primitive base case via partition-sum identity (build verified)

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
@@ -423,4 +423,80 @@ theorem triangle_3_3_pick_agrees :
     contributing `pickInterior = 0`, and the boundary/area accounting
     aggregates correctly via the additivity lemma. -/
 
+-- ════════════════════════════════════════════════════════════════
+-- SECTION VIII (S3-prep): Primitive Case `twiceArea = 1` ⇒ `I = 0`
+-- ════════════════════════════════════════════════════════════════
+
+/-! ### The partition-sum identity
+
+For any test point `p`, the three edge cross-products of `T` against
+`p` sum to the signed determinant `T.det`.  Geometrically: the three
+sub-triangles `(v_i, v_{i+1}, p)` tile `T` (with signs), so twice
+their signed areas sum to twice the signed area of `T`. -/
+
+/-- **Partition-sum identity**: the three edge cross-products of `T`
+    against any lattice point `p` sum to `T.det` (= twice the signed
+    area of `T`).  Discrete analogue of the additivity of signed
+    area under triangulation: the three sub-triangles `(vᵢ, vᵢ₊₁, p)`
+    tile `T` with appropriate signs. -/
+theorem cross2_partition_sum (T : LatticeTriangle) (p : ℤ × ℤ) :
+    cross2 T.v1 T.v2 p + cross2 T.v2 T.v3 p + cross2 T.v3 T.v1 p = T.det := by
+  unfold cross2 LatticeTriangle.det
+  ring
+
+/-! ### No strict-interior lattice points in a primitive triangle
+
+If `T.twiceArea = 1`, the `StrictInterior` predicate fails at every
+lattice point.  This is the general primitive base case of the
+Pick induction. -/
+
+/-- **Primitive case — no strict interior points**: for a primitive
+    lattice triangle (`twiceArea = 1`), no lattice point is strictly
+    interior.
+
+    *Proof idea.* The three cross-products `cross2 vᵢ vᵢ₊₁ p` sum to
+    `T.det` (`cross2_partition_sum`), whose absolute value is
+    `T.twiceArea = 1`.  If all three were of the same strict sign
+    (the `StrictInterior` condition), each would have absolute value
+    `≥ 1`, so the sum would have absolute value `≥ 3`, contradicting
+    `|sum| = 1`.  `omega` discharges the integer-arithmetic
+    contradiction in both orientations. -/
+theorem primitive_no_strict_interior (T : LatticeTriangle)
+    (h : T.twiceArea = 1) (p : ℤ × ℤ) : ¬ T.StrictInterior p := by
+  intro hsi
+  have hsum := cross2_partition_sum T p
+  unfold LatticeTriangle.twiceArea at h
+  unfold LatticeTriangle.StrictInterior at hsi
+  rcases hsi with ⟨h1, h2, h3⟩ | ⟨h1, h2, h3⟩ <;> omega
+
+/-- **Primitive case (S3-prep): `twiceArea = 1` ⇒ `realInteriorCount = 0`**.
+
+    For every lattice triangle `T` with `|det T| = 1`, the strictly-
+    interior lattice-point count is zero.  This is the **general
+    primitive base case** of the Pick induction.
+
+    The lemma strictly generalises `unitTriangle_realInteriorCount`
+    (which handled the specific triangle `{(0,0), (1,0), (0,1)}` via
+    `native_decide`) to *every* primitive triangle in `ℤ²`,
+    independent of orientation, vertex labelling, or position.
+
+    The proof is purely algebraic: combining `cross2_partition_sum`
+    with `|T.det| = T.twiceArea = 1` forces the three cross-products
+    not to all share the same strict sign, which is exactly the
+    failure of `StrictInterior p`.  No bounding-box enumeration is
+    required; the conclusion holds at every lattice point. -/
+theorem primitive_realInteriorCount_zero (T : LatticeTriangle)
+    (h : T.twiceArea = 1) : T.realInteriorCount = 0 := by
+  unfold LatticeTriangle.realInteriorCount LatticeTriangle.realInterior
+  rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  exact fun p _ => primitive_no_strict_interior T h p
+
+/-- **Sanity check**: the unit-triangle base case `unitTriangle_realInteriorCount`
+    is now recovered as a *uniform* corollary of the general primitive
+    lemma — not relying on `native_decide` on the specific vertex
+    coordinates.  This proves that the S3-prep generalisation is
+    consistent with the S2 base-case computation. -/
+example : unitTriangle.realInteriorCount = 0 :=
+  primitive_realInteriorCount_zero unitTriangle unitTriangle_twiceArea
+
 end PicksTheoremOQ01OQ01OQ01

--- a/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
@@ -2,9 +2,9 @@
 
 **Phase**: PLAN
 **Since**: 2026-05-12T11:30:00Z
-**Iteration**: 3
-**Last researcher**: researcher-4 (S2 OBSERVE — real interior count + base-case agreement)
-**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S2 OBSERVE — realInteriorCount via Finset + base-case agreement with pickInterior
+**Iteration**: 4
+**Last researcher**: researcher-4 (S3-prep — primitive case `twiceArea = 1 ⇒ I = 0`)
+**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S3-prep — general primitive base case via partition-sum identity
 
 ## Current Focus
 
@@ -15,7 +15,30 @@ constructive Pick's theorem for lattice triangles.
 ## Active Approach
 
 **S1 OBSERVE — bridge scaffold (prior session).**
-**S2 OBSERVE — real strictly-interior lattice-point count (this session).**
+**S2 OBSERVE — real strictly-interior lattice-point count (prior session).**
+**S3-prep — primitive case `twiceArea = 1 ⇒ realInteriorCount = 0` (this session).**
+
+`Proofs/PicksTheoremOQ01OQ01OQ01.lean` adds three new theorems (502 lines
+total, 0 sorries, 0 axioms):
+
+12. `cross2_partition_sum (T : LatticeTriangle) (p : ℤ × ℤ) :
+    cross2 T.v1 T.v2 p + cross2 T.v2 T.v3 p + cross2 T.v3 T.v1 p = T.det`
+    — the partition-sum identity, proved by `unfold; ring`.
+13. `primitive_no_strict_interior (T : LatticeTriangle)
+    (h : T.twiceArea = 1) (p : ℤ × ℤ) : ¬ T.StrictInterior p` — the core
+    impossibility lemma, proved by `omega` after combining the
+    partition-sum identity with the constraint `|T.det| = T.twiceArea = 1`.
+14. `primitive_realInteriorCount_zero (T : LatticeTriangle)
+    (h : T.twiceArea = 1) : T.realInteriorCount = 0` — the **general
+    primitive base case** of Pick's induction, holding for *every*
+    primitive lattice triangle (not just the unit instance verified
+    by `native_decide` in S2).
+
+The proof avoids bounding-box enumeration: the three cross-products
+sum to `T.det = ±1`, so if all three had the same strict sign each
+would be `≥ 1` in absolute value, forcing the sum to have absolute
+value `≥ 3` — a contradiction. The `StrictInterior` predicate fails
+*everywhere*, not just inside the bounding box.
 
 `Proofs/PicksTheoremOQ01OQ01OQ01.lean` now (425+ lines, 0 sorries, 0 axioms)
 contains, in addition to the S1 scaffold:
@@ -57,23 +80,36 @@ None at the S2 stage. Future work:
 
 ## Next Action
 
-**S3 — Additivity for primitive gluing.**
+**S3-full — Additivity for primitive gluing.**
 
-Formalize the union `T₁ ∪ T₂` of two lattice triangles sharing an edge
-(as a `Finset` of strictly-interior lattice points or, more cleanly, as
-a multiset of two triangles whose `realInteriorCount` sums consistently
-once the shared edge's gcd = 1 condition is invoked).  Prove the
-`realInteriorCount` and `pickInterior` additivity statements separately,
-then combine them.
+With the primitive base case now closed in full generality
+(`primitive_realInteriorCount_zero`), the remaining S3 work is the
+additivity step: when two lattice triangles `T₁`, `T₂` share an edge
+`e` with `gcd(e) = 1` (no interior boundary lattice points), the real
+interior counts satisfy
 
-A lighter alternative S3-prep step: prove the *primitive* case directly
-— for every `LatticeTriangle T` with `T.twiceArea = 1`,
-`T.realInteriorCount = 0`.  This generalizes `unitTriangle_realInteriorCount`
-by an SL₂(ℤ) symmetry / case analysis on the determinant sign.  This
-would close the "base case" of the eventual induction in full generality.
+  `realInteriorCount (T₁ ∪ T₂) = realInteriorCount T₁
+                                   + realInteriorCount T₂
+                                   + (boundary points strictly on e)`.
+
+The same identity holds for `pickInterior` by `pick_formula_cleared`.
+Combining with `primitive_realInteriorCount_zero` and
+`PicksTheoremOQ01OQ01.exists_primitive_triangulation` (S4) then closes
+the full Pick induction.
+
+Estimated effort for S3-full: 200–400 lines.  Possible decomposition:
+
+1. Define `LatticeTriangle.union (T₁ T₂ : LatticeTriangle) : LatticeTriangle`
+   (or work with the multiset of two triangles, depending on the
+   convexity setup).
+2. Prove `realInteriorCount_union_of_shared_edge_gcd_one`.
+3. Prove the matching `pickInterior_union` identity using
+   `pick_formula_cleared` and `boundaryCount_union_of_shared_edge_gcd_one`.
+
+Each step is self-contained and could be pursued in a separate iteration.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: 1 (bridge-via-cleared-form)
+- Total attempts: 3
+- Current approach attempts: 3
+- Approaches tried: 1 (bridge-via-cleared-form + primitive-base-case)

--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 24,
+    "theoremCount": 27,
     "definitionCount": 21,
-    "lineCount": 426,
+    "lineCount": 502,
     "tags": [
       "number-theory",
       "geometry",


### PR DESCRIPTION
## Summary

S3-prep iteration closing the **general primitive base case** of the Pick induction: for *every* lattice triangle with `twiceArea = 1`, `realInteriorCount = 0`. Strictly generalises `unitTriangle_realInteriorCount` (S2, `native_decide` on a single triangle) to all primitive triangles regardless of orientation, vertex labelling, or position in `ℤ²`.

## Deliverables (3 new theorems, 0 sorries, 0 axioms)

1. `cross2_partition_sum (T) (p) : cross2 T.v1 T.v2 p + cross2 T.v2 T.v3 p + cross2 T.v3 T.v1 p = T.det` — the discrete partition-sum identity (three sub-triangles tile `T` with signs), proved by `unfold; ring`.
2. `primitive_no_strict_interior (T) (h : T.twiceArea = 1) (p) : ¬ T.StrictInterior p` — for primitive `T`, no lattice point is strictly interior. Proof: the three cross-products sum to `T.det = ±1`; if all three had the same strict sign each would have absolute value `≥ 1`, contradicting `|sum| = 1`. `omega` discharges both orientations.
3. `primitive_realInteriorCount_zero (T) (h : T.twiceArea = 1) : T.realInteriorCount = 0` — the general primitive base case.

Plus a sanity-check `example` showing `unitTriangle.realInteriorCount = 0` is now a uniform corollary of the general lemma — not relying on `native_decide` on specific vertex coordinates.

## Strategic effect

The S3-prep closes the base case of Pick's induction in **full generality**. With this lemma in hand, the remaining S3-full work is the *additivity step*: when two lattice triangles share an edge with `gcd = 1`, their `realInteriorCount`s combine linearly (plus the boundary contribution). Combining additivity with this S3-prep base case + `PicksTheoremOQ01OQ01.exists_primitive_triangulation` closes the full Pick induction in S4.

Notably the proof **avoids bounding-box enumeration**: `StrictInterior p` fails *everywhere* in `ℤ²` for a primitive triangle, not just at points inside `T.boundingBox`. This is the right algebraic abstraction for the eventual induction.

## Counts

- Sorry count: 0 (unchanged).
- Axiom count: 0 (unchanged).
- Theorem count: 24 → 27 (+3 new no-sorry lemmas + 1 example).
- Definition count: 21 (unchanged).
- Line count: 426 → 502 (+76, mostly proofs + docstrings).

## Build status

`./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01` reports `Build completed successfully (3058 jobs)` with no `sorry` warnings.

## Scope choices

- **No bounding-box enumeration**: the proof works at the cross-product level, generalising cleanly beyond `T.boundingBox`.
- **No SL₂(ℤ) machinery**: avoided in favour of a one-line `omega` step after combining `cross2_partition_sum` with `|T.det| = 1`. Net diff stays under 80 lines.
- **No new infrastructure for S3-full**: this PR is strictly a *base-case lemma*; the additivity step (S3-full) is sketched in `state.md` as a separate iteration.

## Next action (S3-full)

Additivity: when two lattice triangles `T₁`, `T₂` share an edge `e` with `gcd(e) = 1`, prove `realInteriorCount (T₁ ∪ T₂) = realInteriorCount T₁ + realInteriorCount T₂ + (boundary points strictly on e)`. Combined with this PR's `primitive_realInteriorCount_zero` and `PicksTheoremOQ01OQ01.exists_primitive_triangulation`, closes the full Pick induction. Estimate: 200–400 lines.

## Test plan

- [x] Docker build passes (3058 jobs, no sorry warnings)
- [x] 0 sorries / 0 axioms maintained
- [x] No drift errors on origin/main
- [x] Pre-push `gh pr list --search` clean (no race)
- [x] `example : unitTriangle.realInteriorCount = 0` verified via the general lemma

🤖 Generated with [Claude Code](https://claude.com/claude-code)