### PR TITLE
fix(auditor): accept either sorry-count convention for Aristotle-companion entries

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -60,6 +60,7 @@ interface AuditTarget {
   }
   actual: {
     sorryCount: number
+    mainSorryCount: number
     axiomCount: number
     trueStubCount: number
     hasMajorMathlibDep: boolean
@@ -211,9 +212,20 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`CRITICAL: ${target.actual.trueStubCount} True stubs but status is "verified"`)
   }
 
-  // Sorry count mismatch
-  if (target.meta.claimedSorries !== target.actual.sorryCount) {
-    issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
+  // Sorry count mismatch.
+  // Two coexisting meta.sorries conventions for entries with companion/additional files:
+  //   - chain-aggregate (PR #18120, axiom-symmetric): counts main + additionalFiles + companion
+  //   - main-file-only (PR #18127): counts only the main proofRepoPath
+  // Accept either to break the false-clean oscillation cycle on Aristotle-companion entries
+  // (Issue #18137). When no companion/additional files are followed, both counts are equal,
+  // so single-file entries are unaffected.
+  const claimed = target.meta.claimedSorries
+  if (claimed !== target.actual.sorryCount && claimed !== target.actual.mainSorryCount) {
+    issues.push(
+      target.actual.mainSorryCount === target.actual.sorryCount
+        ? `sorry mismatch: claims ${claimed}, actual ${target.actual.sorryCount}`
+        : `sorry mismatch: claims ${claimed}, actual main ${target.actual.mainSorryCount} / chain ${target.actual.sorryCount}`
+    )
   }
 
   // Axiom count mismatch -- only flag undercounts (meta claims fewer than detected).
@@ -259,17 +271,24 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
 
   // Actual counts from Lean file(s) — includes submodules and additionalFiles
   let sorryCount = 0
+  let mainSorryCount = 0
   let axiomCount = 0
   let trueStubCount = 0
   let hasMajorMathlibDep = false
 
   const allLeanFiles = leanPath ? resolveAllLeanFiles(leanPath, proofMeta) : []
-  for (const filePath of allLeanFiles) {
+  for (let i = 0; i < allLeanFiles.length; i++) {
+    const filePath = allLeanFiles[i]
     const rawContent = fs.readFileSync(filePath, 'utf-8')
     // Strip comments to avoid counting sorry/True in comments (Issue #6130)
     const content = stripLeanComments(rawContent)
 
-    sorryCount += (content.match(/\bsorry\b/g) || []).length
+    const fileSorryCount = (content.match(/\bsorry\b/g) || []).length
+    sorryCount += fileSorryCount
+    // resolveAllLeanFiles puts the main proofRepoPath first; track its sorries
+    // separately so meta.sorries claims using the main-file-only convention
+    // (PR #18127) can validate alongside chain-aggregate claims (PR #18120).
+    if (i === 0) mainSorryCount = fileSorryCount
     axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
@@ -309,6 +328,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     },
     actual: {
       sorryCount,
+      mainSorryCount,
       axiomCount,
       trueStubCount,
       hasMajorMathlibDep,


### PR DESCRIPTION
## Fix

`scripts/auditor/find-targets.ts` now accepts **either** the main-file-only sorry count or the chain-aggregate sorry count when validating `meta.sorries`. Two mechanic conventions have coexisted in the gallery for entries with Aristotle companion files:

- **chain-aggregate** (PR #18120, axiom-symmetric): `meta.sorries` counts main + `additionalFiles` + Aristotle companions
- **main-file-only** (PR #18127): `meta.sorries` counts only the main `proofRepoPath`

The previous script required chain-aggregate, so mechanic PRs alternated between the two conventions on the same entries (Issue #18137 evidence: `shannon-channel-coding-oq-03` flipped 5 times across PRs #17295, #18127, etc.).

This PR mirrors the existing **smart-axiom logic** on the sorry side: track `mainSorryCount` alongside `sorryCount`, and accept a claim that matches either. Single-file entries are unaffected (both counts are equal). When the claim matches neither, the message reports both values so mechanics can triage.

## Evidence

Before (4 flagged):

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 4 audit targets (of 4 total):

  general-quartic (3x, last 2026-05-03)              ❌ sorry mismatch: claims 0, actual 1
  shannon-channel-coding-oq-02-oq-01 (2x)            ❌ sorry mismatch: claims 0, actual 4
  binomial-theorem-oq-02-oq-01-oq-01 (3x)            ❌ sorry mismatch: claims 6, actual 5
  shannon-channel-coding-oq-03 (5x)                  ❌ sorry mismatch: claims 0, actual 4
```

After (2 flagged, genuine drift only):

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 2 audit targets (of 2 total):

  general-quartic (3x)                               ❌ sorry mismatch: claims 0, actual 1
  binomial-theorem-oq-02-oq-01-oq-01 (3x)            ❌ sorry mismatch: claims 6, actual main 4 / chain 5
```

The two `shannon-channel-coding-*` entries auto-clear because `meta.sorries = 0` already matches the main-file-only convention (main = 0, chain = 4). The remaining two are genuine count drift, addressed by existing meta-only PRs #18133 / #18136 / #18142 / #18145.

## Why this over a meta-only fix

Per Issue #18137's own analysis, a meta-only re-sync continues the oscillation cycle: the next time a mechanic re-counts using the other convention, the entries flip back. The script fix breaks the cycle structurally by making the validator accept either convention — exactly mirroring the smart-axiom behavior at lines 304-308 of the same file.

This is Option A from the issue body. It is the smallest code-side change (25 insertions / 5 deletions) that closes the issue durably.

## Scope

Script-only PR; no meta.json or Lean source touched. Side-by-side compatible with the meta-only PRs in flight (#18133, #18142, #18145) — those resolve genuine count drift; this PR resolves the convention asymmetry that produced the false-clean oscillation.

Closes #18137.

---
Automated fix by lean-mechanic agent.