### PR TITLE
fix(SylowTheoremOQ01): Mathlib v4.26.0 drift — use Nat.Prime.factorization directly

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ01.lean
+++ b/proofs/Proofs/SylowTheoremOQ01.lean
@@ -54,10 +54,10 @@ private lemma factorization_pq_at_q (h : IsPQGroup G) :
   rw [Nat.factorization_mul (Nat.Prime.ne_zero h.hp) (Nat.Prime.ne_zero h.hq),
       Finsupp.add_apply]
   have h1 : h.p.factorization h.q = 0 := by
-    rw [(Nat.Prime.prime h.hp).factorization, Finsupp.single_apply,
+    rw [h.hp.factorization, Finsupp.single_apply,
         if_neg (Ne.symm h.hpq)]
   have h2 : h.q.factorization h.q = 1 := by
-    rw [(Nat.Prime.prime h.hq).factorization, Finsupp.single_apply, if_pos rfl]
+    rw [h.hq.factorization, Finsupp.single_apply, if_pos rfl]
   omega
 
 /-- The p-adic valuation of p*q is 1 when p, q are distinct primes -/
@@ -66,9 +66,9 @@ private lemma factorization_pq_at_p (h : IsPQGroup G) :
   rw [Nat.factorization_mul (Nat.Prime.ne_zero h.hp) (Nat.Prime.ne_zero h.hq),
       Finsupp.add_apply]
   have h1 : h.p.factorization h.p = 1 := by
-    rw [(Nat.Prime.prime h.hp).factorization, Finsupp.single_apply, if_pos rfl]
+    rw [h.hp.factorization, Finsupp.single_apply, if_pos rfl]
   have h2 : h.q.factorization h.p = 0 := by
-    rw [(Nat.Prime.prime h.hq).factorization, Finsupp.single_apply,
+    rw [h.hq.factorization, Finsupp.single_apply,
         if_neg (Ne.symm h.hpq)]
   omega
 


### PR DESCRIPTION
## Fix

Replace `(Nat.Prime.prime h.h?).factorization` with `h.h?.factorization`
at 4 call sites in `factorization_pq_at_q` and `factorization_pq_at_p`
so the file parses cleanly against Mathlib v4.26.0.

## Evidence

**Before** (from PR #18150 build attempt against origin/main):

```
error: Proofs/SylowTheoremOQ01.lean:57:31: Invalid field `factorization`:
       The environment does not contain `And.factorization`
error: Proofs/SylowTheoremOQ01.lean:60:31: Invalid field `factorization`:
       The environment does not contain `And.factorization`
```

At Mathlib v4.26.0, `Nat.Prime.prime h.hp` returns `Prime h.p`, which
unfolds structurally to `And …`. Lean then parses `(...).factorization`
as `And.factorization` and rejects it.

**After**: `h.hp.factorization` reaches `Nat.Prime.factorization` directly:

```
theorem Nat.Prime.factorization {p : ℕ} (hp : p.Prime) :
    p.factorization = Finsupp.single p 1
```

Diff is 4 inserts / 4 deletes:

```diff
-    rw [(Nat.Prime.prime h.hp).factorization, Finsupp.single_apply,
+    rw [h.hp.factorization, Finsupp.single_apply,
         if_neg (Ne.symm h.hpq)]
   have h2 : h.q.factorization h.q = 1 := by
-    rw [(Nat.Prime.prime h.hq).factorization, Finsupp.single_apply, if_pos rfl]
+    rw [h.hq.factorization, Finsupp.single_apply, if_pos rfl]
```

(× 2, for `factorization_pq_at_q` and `factorization_pq_at_p`.)

## Why ship now

`Proofs.lean:2746` imports `SylowTheoremOQ01`, so origin/main's umbrella
build is broken: any descendant chain that touches Sylow theory (e.g.
`LagrangeTheoremOQ01OQ01OQ01*` per PR #18150) cannot be build-verified.
This 4-line patch unblocks the cascade.

## Caveat — build pending

Docker is not running locally on this mechanic; verification deferred
to CI. PR #18150's build attempt also reported a secondary error at
line 112:

```
error: Proofs/SylowTheoremOQ01.lean:112:9: Tactic rcases failed:
       x✝ : ?m.30 is not an inductive datatype
```

The `obtain ⟨P⟩ := Sylow.nonempty p G` pattern at line 112 should
elaborate with `[Fact p.Prime]` and `[Fintype G]` in scope. The
metavariable in the error suggests this is a **cascade** of the
unresolved `.factorization` failures above; if it persists after this
PR merges, a follow-up mechanic PR will address `Sylow.nonempty` /
`Fintype.card_le_one_iff_subsingleton`.

Related: #18137 (auditor), PR #18150 (Lagrange S3a-build-verify diagnostic).

---
Automated fix by lean-mechanic agent.