### PR TITLE
research(collatz-cycles-oq-03): S1+S2+S3 — cycle-contains-even (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -505,6 +505,7 @@ import Proofs.CircumferenceFromArea
 import Proofs.CircumferenceViaDifferentiation
 import Proofs.CircumferenceViaDifferentiationOQ01
 import Proofs.CollatzCycles
+import Proofs.CollatzCyclesOQ03
 import Proofs.CollatzCyclesOQ04
 import Proofs.CollatzStructured
 import Proofs.CollatzStructuredOQ02OQ01

--- a/proofs/Proofs/CollatzCyclesOQ03.lean
+++ b/proofs/Proofs/CollatzCyclesOQ03.lean
@@ -1,0 +1,80 @@
+/-
+# Collatz Cycles OQ-03: No All-Odd Cycle
+
+For the parent `Proofs/CollatzCycles.lean`, this companion file proves the
+parity intersection corollary: every Collatz cycle visits at least one even
+number. The proof is two omega steps from the parent's `collatz_odd` lemma.
+
+## Results
+
+1. `three_n_plus_one_even`: for odd n, 3n+1 is even.
+2. `collatz_of_odd_is_even`: for odd n, collatz n is even.
+3. `no_all_odd_cycle`: a periodic orbit cannot be entirely odd.
+4. `cycle_contains_even`: every cycle visits an even number.
+5. `isPeriodic_contains_even`: same, packaged with `IsPeriodic`.
+
+## References
+
+- Parent: `Proofs/CollatzCycles.lean` (Parts I–VIII).
+- Lagarias (1985), *The 3x+1 problem and its generalizations*.
+-/
+
+import Mathlib.Tactic
+import Proofs.CollatzCycles
+
+namespace CollatzCycles
+
+/-- Parity flip: `3n+1` is even when `n` is odd. -/
+lemma three_n_plus_one_even {n : ℕ} (h : n % 2 = 1) :
+    (3 * n + 1) % 2 = 0 := by omega
+
+/-- For odd `n`, `collatz n` is even. -/
+theorem collatz_of_odd_is_even {n : ℕ} (h : n % 2 = 1) :
+    (collatz n) % 2 = 0 := by
+  rw [collatz_odd h]
+  exact three_n_plus_one_even h
+
+/-- **No all-odd Collatz cycle.** If every iterate of `n` up to step `k` is
+    odd and `collatz^[k] n = n`, then we derive a contradiction (the
+    iterate at step 1 must be even, since the iterate at step 0 = `n` is
+    odd). -/
+theorem no_all_odd_cycle {n k : ℕ} (hk : k ≥ 1)
+    (hper : collatzIter k n = n)
+    (hodd_all : ∀ i, i < k → (collatzIter i n) % 2 = 1) : False := by
+  have h0 : n % 2 = 1 := by
+    have h := hodd_all 0 hk
+    simp [collatzIter, Function.iterate_zero] at h
+    exact h
+  have h1 : (collatzIter 1 n) % 2 = 0 := by
+    show (collatz^[1] n) % 2 = 0
+    rw [Function.iterate_one]
+    exact collatz_of_odd_is_even h0
+  rcases Nat.lt_or_ge 1 k with hk2 | hk1
+  · -- k ≥ 2: parity at step 1 contradicts hodd_all
+    have hopp := hodd_all 1 hk2
+    omega
+  · -- k = 1: collatzIter 1 n = n, so n is even (from h1) and odd (from h0)
+    interval_cases k
+    have heq : collatzIter 1 n = n := hper
+    have hn_even : n % 2 = 0 := heq ▸ h1
+    omega
+
+/-- **Positive form.** Every Collatz cycle of length ≥ 1 visits at least
+    one even number. -/
+theorem cycle_contains_even {n k : ℕ} (hk : k ≥ 1)
+    (hper : collatzIter k n = n) :
+    ∃ i, i < k ∧ (collatzIter i n) % 2 = 0 := by
+  by_contra hne
+  push_neg at hne
+  apply no_all_odd_cycle hk hper
+  intro i hi
+  have hmod := hne i hi
+  -- hmod : (collatzIter i n) % 2 ≠ 0, so it must be 1.
+  omega
+
+/-- Repackaged with `IsPeriodic`. -/
+theorem isPeriodic_contains_even {n k : ℕ} (hper : IsPeriodic n k) :
+    ∃ i, i < k ∧ (collatzIter i n) % 2 = 0 :=
+  cycle_contains_even hper.1 hper.2
+
+end CollatzCycles

--- a/research/problems/collatz-cycles-oq-03/knowledge.md
+++ b/research/problems/collatz-cycles-oq-03/knowledge.md
@@ -1,0 +1,182 @@
+# Knowledge: collatz-cycles-oq-03
+
+## Parent Inventory (`Proofs/CollatzCycles.lean`)
+
+256 lines, 4 definitions, 27 theorems, 0 sorries, 0 axioms, status `verified`.
+
+### Definitions
+
+| Line | Decl | Statement |
+|------|------|-----------|
+| 30 | `collatz` | `n → n/2 if even, 3n+1 if odd` |
+| 47 | `collatzIter` | `collatz^[k]` |
+| 50 | `IsPeriodic` | `k ≥ 1 ∧ collatzIter k n = n` |
+| 194 | `ReachesOne` | `∃ k, collatzIter k n = 1` |
+
+### Key Lemmas Available for OQ-03 S2
+
+| Line | Decl | Statement |
+|------|------|-----------|
+| 37 | `collatz_even` | `n % 2 = 0 → collatz n = n / 2` |
+| 40 | `collatz_odd` | `n % 2 = 1 → collatz n = 3 * n + 1` |
+| 117 | `collatz_odd_growth` | `n % 2 = 1 → n ≥ 1 → collatz n > n` |
+| 122 | `collatz_even_decrease` | `n % 2 = 0 → n ≥ 2 → collatz n < n` |
+
+### What the Parent Does NOT Prove
+
+- No explicit `collatz_of_odd_is_even` lemma (`n % 2 = 1 → (collatz n) % 2 = 0`).
+- No `cycle_contains_even` / `no_all_odd_cycle` statement.
+- No iteration-level parity tracking (i.e. nothing about
+  `(collatzIter i n) % 2` as a function of `i`).
+
+These are exactly the OQ-03 deliverables.
+
+## Lean Skeleton (S2 ACT Recommended Plan)
+
+New file `proofs/Proofs/CollatzCyclesOQ03.lean` (~50 lines):
+
+```lean
+/-
+# Collatz Cycles OQ-03: No All-Odd Cycle
+
+For the parent `Proofs/CollatzCycles.lean`, this companion file proves the
+parity intersection corollary: every Collatz cycle visits at least one even
+number. The proof is two omega steps from the parent's `collatz_odd` lemma.
+-/
+
+import Mathlib.Tactic
+import Proofs.CollatzCycles
+
+namespace CollatzCycles
+
+/-- Parity flip: `3n+1` is even when `n` is odd. -/
+lemma three_n_plus_one_even {n : ℕ} (h : n % 2 = 1) :
+    (3 * n + 1) % 2 = 0 := by omega
+
+/-- For odd `n`, `collatz n` is even. -/
+theorem collatz_of_odd_is_even {n : ℕ} (h : n % 2 = 1) :
+    (collatz n) % 2 = 0 := by
+  rw [collatz_odd h]; exact three_n_plus_one_even h
+
+/-- **No all-odd Collatz cycle.** If every iterate of `n` up to step `k` is
+    odd and `collatz^k(n) = n`, then we have a contradiction. -/
+theorem no_all_odd_cycle {n k : ℕ} (hn : n ≥ 1) (hk : k ≥ 1)
+    (hper : collatzIter k n = n)
+    (hodd_all : ∀ i, i < k → (collatzIter i n) % 2 = 1) : False := by
+  /- Strategy: i = 0 gives n odd. Apply collatz_of_odd_is_even to get
+     (collatz n) % 2 = 0, i.e. (collatzIter 1 n) % 2 = 0. Two cases:
+     - k ≥ 2: hodd_all 1 hk2 says (collatzIter 1 n) % 2 = 1 — contradicts above.
+     - k = 1: then collatzIter 1 n = n and n odd, but collatzIter 1 n is even.
+  -/
+  have h0 : n % 2 = 1 := by
+    have := hodd_all 0 hk
+    simpa [collatzIter] using this
+  have h1 : (collatzIter 1 n) % 2 = 0 := by
+    simp [collatzIter, Function.iterate_one]
+    exact collatz_of_odd_is_even h0
+  rcases Nat.lt_or_ge 1 k with hk2 | hk1
+  · -- k ≥ 2: parity contradicts at step 1
+    have := hodd_all 1 hk2
+    omega
+  · -- k = 1: collatzIter 1 n = n, so n is even (from h1) and odd (from h0)
+    interval_cases k
+    have heq : collatzIter 1 n = n := hper
+    have : n % 2 = 0 := heq ▸ h1
+    omega
+
+/-- **Positive form.** Every Collatz cycle visits at least one even number. -/
+theorem cycle_contains_even {n k : ℕ} (hn : n ≥ 1) (hk : k ≥ 1)
+    (hper : collatzIter k n = n) :
+    ∃ i, i < k ∧ (collatzIter i n) % 2 = 0 := by
+  by_contra hne
+  push_neg at hne
+  apply no_all_odd_cycle hn hk hper
+  intro i hi
+  have := hne i hi
+  omega
+
+/-- The `IsPeriodic` packaging. -/
+theorem isPeriodic_contains_even {n k : ℕ} (hn : n ≥ 1)
+    (hper : IsPeriodic n k) :
+    ∃ i, i < k ∧ (collatzIter i n) % 2 = 0 :=
+  cycle_contains_even hn hper.1 hper.2
+
+end CollatzCycles
+```
+
+### Why the Skeleton Should Build Clean
+
+- All imports come from `Mathlib.Tactic` (omega) and the parent.
+- `Function.iterate_one`: standard, in `Mathlib/Logic/Function/Iterate`.
+- `simp [collatzIter]` unfolds the definition.
+- `omega` discharges all parity goals once we have the right inequalities.
+
+### Risk: `simp [collatzIter]` Loop
+
+If `collatzIter` unfolds eagerly through subsequent iterates, `simp` can
+loop. Fallback: explicit `show` annotation:
+
+```lean
+have h0 : n % 2 = 1 := by
+  show (collatz^[0] n) % 2 = 1
+  simp [Function.iterate_zero]
+  exact hodd_all 0 hk
+```
+
+## Mathlib API Inventory
+
+No new Mathlib API is needed. Required imports:
+
+| Module | What it provides |
+|--------|------------------|
+| `Mathlib.Tactic` | `omega`, `simp`, `rcases`, `push_neg`, `interval_cases` |
+| `Proofs.CollatzCycles` | `collatz`, `collatzIter`, `collatz_odd`, `collatz_even` |
+| `Mathlib.Logic.Function.Iterate` (transitive) | `Function.iterate_one`, `Function.iterate_zero` |
+
+No Aristotle submission is needed: the proof is short enough to do by hand.
+
+## Mathlib Gaps
+
+**None.** All required lemmas are either in the parent or in core Mathlib
+tactics.
+
+## Cross-Impact
+
+This OQ closes a narrow gap. It does **not** unblock:
+
+- Larger Collatz cycle eliminations (those need `2^M > 3^j` machinery,
+  parent Part VI).
+- The Collatz conjecture itself.
+- Other `collatz-*` OQs.
+
+It **does** provide:
+
+- A clean parity-corollary lemma usable by future Collatz iteration
+  enumerators (decidable cycle search).
+- A pedagogical anchor for the "every cycle has both parities" fact,
+  which is currently implicit in the parent but not stated.
+
+## Aristotle Strategy
+
+**Do not submit.** The proof is hand-trivial; submitting wastes Aristotle
+budget on a sub-five-line goal that `omega` closes immediately.
+
+## Honesty Calibration
+
+- **Difficulty**: trivial (2 omega steps after one rewrite).
+- **Novelty**: zero — this is standard textbook parity.
+- **Gallery value**: low-medium — fills an obvious explicit-statement
+  gap in a `verified` parent.
+- **Mathlib value**: none — these are project-internal lemmas, not
+  general enough for Mathlib.
+
+The reason this work is worth doing: the parent currently *implicitly*
+relies on this fact (e.g. when discussing the `2^M > 3^j` constraint
+in Part VI's docstrings) but never makes it explicit. S2 + S3 deliver
+the explicit lemma plus a gallery entry, closing the OQ.
+
+## Log
+
+- 2026-05-12 (researcher-5, S1 OBSERVE): claimed slug (was added by seeker
+  2026-05-12T09:56:28Z, 4h old, 0 prior PRs); surveyed parent file; drafted
+  Lean skeleton; classified as TRIVIAL; recommended S2 ACT next.

--- a/research/problems/collatz-cycles-oq-03/problem.md
+++ b/research/problems/collatz-cycles-oq-03/problem.md
@@ -1,0 +1,212 @@
+# Problem: No All-Odd Collatz Cycles (Parity One-Liner)
+
+**Slug**: `collatz-cycles-oq-03`
+**Parent**: `collatz-cycles` — *Collatz Cycles: Non-Existence of Small Cycles*.
+Status `verified`, badge `original`, 0 sorries, 0 axioms, 27 theorems, 4
+definitions, 256 lines (`proofs/Proofs/CollatzCycles.lean`).
+**Sibling proofs**: `collatz-cycles-oq-04` (separate iteration), `collatz-structured`
+and its OQ chain (OQ-02 / OQ-02-OQ-01 / OQ-03).
+
+## Plain Statement
+
+The seeker phrases the open question as
+
+> Prove that there are no **odd cycles** (cycles that never reach an even
+> number) — equivalent to the cycle constraint.
+
+A natural formalisation is the *cycle-contains-even* form: every
+non-degenerate Collatz cycle visits at least one even number.
+
+**Claim (parity lemma).** Let `n ≥ 1` and `k ≥ 1` with `collatzIter k n = n`.
+Then at least one of `n, collatz n, collatz² n, …, collatz^{k−1} n` is even.
+
+Equivalently, the contrapositive:
+
+```lean
+theorem no_all_odd_cycle
+    {n k : ℕ} (hn : n ≥ 1) (hk : k ≥ 1)
+    (hper : collatzIter k n = n)
+    (hodd_all : ∀ i, i < k → (collatzIter i n) % 2 = 1) : False
+```
+
+## Why this Matters
+
+1. **Closes a clean structural gap.** The parent file `CollatzCycles.lean`
+   already proves five structural constraints on hypothetical Collatz
+   cycles (no fixed points, no 2-cycles, 3-cycle of 1 unique, 3/4
+   contraction, `2^M > 3^j` halving bound). It does **not** explicitly
+   state the *parity intersection* property: every cycle hits both
+   parities. This OQ fills the gap with a one-line proof.
+
+2. **Trivial-but-foundational.** The proof is a 2-line parity argument
+   (`collatz_odd` says `n%2=1 ⟹ collatz n = 3n+1`, which is even). The
+   contribution is **honest documentation**, not new mathematics; this
+   slug is a classic "fill an obvious lemma the gallery currently skips."
+
+3. **Equivalent to the `2^M > 3^j` bound at `M = 0`.** A pure all-odd
+   cycle has `M = 0` (zero halvings) and `j = k` (every step is odd).
+   The parent's halving constraint Part VI implicitly forces `M ≥ 1`,
+   but the parent never extracts the `M = 0 ⇒ false` corollary
+   explicitly. This OQ makes that link.
+
+4. **Decidable cycle-search support.** A future enumerator searching for
+   non-trivial Collatz cycles can short-circuit any candidate orbit
+   whose computed parity pattern is all-odd; this lemma is the
+   correctness witness for that short-circuit.
+
+## Mathematical Specification
+
+### Setup
+
+The parent (`Proofs/CollatzCycles.lean`) defines:
+
+```lean
+def collatz (n : ℕ) : ℕ := if n % 2 = 0 then n / 2 else 3 * n + 1
+def collatzIter (k : ℕ) (n : ℕ) : ℕ := collatz^[k] n
+def IsPeriodic (n : ℕ) (k : ℕ) : Prop := k ≥ 1 ∧ collatzIter k n = n
+```
+
+with these key lemmas:
+
+| Lemma | Statement |
+|-------|-----------|
+| `collatz_odd` | `n % 2 = 1 → collatz n = 3 * n + 1` |
+| `collatz_even` | `n % 2 = 0 → collatz n = n / 2` |
+| `collatz_odd_growth` | `n % 2 = 1 ∧ n ≥ 1 → collatz n > n` |
+| `collatz_even_decrease` | `n % 2 = 0 ∧ n ≥ 2 → collatz n < n` |
+
+### The Argument
+
+Suppose for contradiction every iterate up to step `k` is odd. Then in
+particular `n % 2 = 1`, so
+
+```
+collatz n = 3 * n + 1
+```
+
+and `3 * n + 1 ≡ 0 (mod 2)` for any odd `n` (since `3 · 1 + 1 = 4 ≡ 0`,
+and in general `3n + 1` has the opposite parity of `n`). Hence
+`(collatz n) % 2 = 0`, but by hypothesis `(collatzIter 1 n) % 2 = 1`,
+contradiction.
+
+That's it. The proof is two lines of `omega` after one unfold.
+
+### Equivalent Phrasings
+
+| Form | Statement | Notes |
+|------|-----------|-------|
+| **Negative** | No all-odd cycle exists (the OQ statement). | The contrapositive form is easiest in Lean. |
+| **Positive** | Every cycle contains at least one even number. | Direct existential — useful for future cycle enumerators. |
+| **Quantitative** | If `IsPeriodic n k` and `n ≥ 1`, then `#{i < k : collatzIter i n % 2 = 0} ≥ 1`. | One-liner from the contrapositive. |
+
+The positive existential form is the natural gallery statement.
+
+### Why this is **not** the same as `collatz_odd_growth`
+
+`collatz_odd_growth` says `collatz n > n` for odd `n ≥ 1`. By itself
+this rules out an all-odd *fixed point* but not an all-odd *length-≥2
+cycle*. For example, an all-odd 2-cycle would require `n_1 < n_2 < n_1`,
+which is also impossible by transitivity — but that argument uses
+strict-ordering chains rather than parity directly. The OQ-03 statement
+gives a *single-step* parity contradiction, which generalises cleanly
+to longer cycles and to the *forall-iterate-odd* form needed downstream.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `collatz-cycles` | parent | parity case analysis, `interval_cases`, `native_decide` |
+| `collatz-cycles-oq-04` | sibling OQ on the same parent | structural cycle constraints |
+| `collatz-structured` | divides-by-3 / halving structure of orbits | `Nat.log2`, `Nat.pow` arithmetic |
+| `collatz-structured-oq-02` | recursive structure of orbits | structural induction |
+
+## Initial Thoughts
+
+### Recommended Approach
+
+**S2 ACT** (single session, ~30-50 Lean lines including imports/namespace):
+
+```lean
+-- new file: proofs/Proofs/CollatzCyclesOQ03.lean
+import Mathlib.Tactic
+import Proofs.CollatzCycles
+
+namespace CollatzCycles
+
+/-- Parity flip: 3n+1 is even when n is odd. -/
+lemma three_n_plus_one_even {n : ℕ} (h : n % 2 = 1) : (3 * n + 1) % 2 = 0 := by
+  omega
+
+/-- For odd n, collatz n is even. -/
+theorem collatz_of_odd_is_even {n : ℕ} (h : n % 2 = 1) : (collatz n) % 2 = 0 := by
+  rw [collatz_odd h]; exact three_n_plus_one_even h
+
+/-- No all-odd Collatz cycle exists. -/
+theorem no_all_odd_cycle {n k : ℕ} (hn : n ≥ 1) (hk : k ≥ 1)
+    (hper : collatzIter k n = n)
+    (hodd_all : ∀ i, i < k → (collatzIter i n) % 2 = 1) : False := by
+  have h0 : (collatzIter 0 n) % 2 = 1 := by
+    simp [collatzIter]; exact hodd_all 0 hk
+  have h1 : (collatzIter 1 n) % 2 = 0 := by
+    simp [collatzIter, Function.iterate_one]
+    exact collatz_of_odd_is_even (by simpa using h0)
+  -- if k = 1: collatzIter 1 n = n, n is odd, but collatzIter 1 n is even ⇒ false
+  -- if k ≥ 2: hodd_all 1 (Nat.lt_of_lt_of_le ...) says (collatzIter 1 n) % 2 = 1
+  rcases Nat.lt_or_ge 1 k with hk2 | hk2
+  · -- k ≥ 2: hodd_all gives contradiction at i = 1
+    have := hodd_all 1 hk2
+    omega
+  · -- k = 1: hper gives collatzIter 1 n = n; n odd (from h0); but h1 says even
+    interval_cases k
+    · -- k = 1
+      have heq : collatzIter 1 n = n := hper
+      have hn_odd : n % 2 = 1 := by simpa [collatzIter] using h0
+      have hn_even : n % 2 = 0 := by rw [← heq]; exact h1
+      omega
+
+/-- Positive existential form: every cycle visits at least one even number. -/
+theorem cycle_contains_even {n k : ℕ} (hn : n ≥ 1) (hk : k ≥ 1)
+    (hper : collatzIter k n = n) : ∃ i, i < k ∧ (collatzIter i n) % 2 = 0 := by
+  by_contra hne
+  push_neg at hne
+  apply no_all_odd_cycle hn hk hper
+  intro i hi
+  have := hne i hi
+  omega
+
+end CollatzCycles
+```
+
+### Risks
+
+- **None substantive.** The proof reduces to `omega` + one rewrite.
+- **Possible trap**: confusion with `collatzIter`/`Function.iterate`
+  normalisation. Standard idiom: `simp [collatzIter, Function.iterate_succ]`.
+
+## Decomposition
+
+| Session | Deliverable | Estimated effort |
+|---------|-------------|------------------|
+| **S1 OBSERVE** (this PR) | 4 doc files; no Lean changes | ~30 min |
+| **S2 ACT** | `CollatzCyclesOQ03.lean` (~50 lines, 3 theorems, 0 sorries); register in `proofs/Proofs.lean`; Docker build verify | ~45-60 min |
+| **S3 GALLERY** | `src/data/proofs/collatz-cycles-oq-03/` (meta.json + index.ts + annotations.json); status `verified`, badge `original`, 0 axioms | ~30 min |
+
+S2 and S3 can be merged into a single session if time permits; the gallery
+update is mechanical once the Lean file builds clean.
+
+## References
+
+- Parent file: `Proofs/CollatzCycles.lean` Parts I–VIII (lines 1–256).
+- Lagarias (1985), *The 3x+1 problem and its generalizations*: cycle
+  constraint `2^M > 3^j`; our OQ is the corollary at `M = 0`.
+- Eliahou (1993), cycle length lower bounds.
+- Tao (2019), *Almost all orbits of the Collatz map attain almost
+  bounded values*: probabilistic upper-density argument; orthogonal to
+  our deterministic parity claim.
+
+## Calibration
+
+This is a **TRIVIAL** OQ in the parent sense: the proof is two omega
+steps. The contribution is the explicit Lean lemma + a gallery entry
+that documents the parity argument. Honesty: this is *infill*, not
+new mathematics. Reporting it as anything more would inflate.

--- a/research/problems/collatz-cycles-oq-03/state.md
+++ b/research/problems/collatz-cycles-oq-03/state.md
@@ -2,24 +2,30 @@
 
 ## Current Phase
 
-**OBSERVE → ORIENT bridge.** S1 OBSERVE survey complete (this PR).
-S2 ACT is mechanically derivable from the Lean skeleton in `knowledge.md`.
+**COMPLETED.** S1 OBSERVE survey + S2 ACT Lean file + S3 GALLERY entry
+all delivered in this PR. Build verified via Docker (`Proofs.CollatzCyclesOQ03`
+compiled cleanly, exit 0, 3.7s, 80 lines, 0 sorries, 0 axioms).
 
 ## Summary
 
 The OQ seeks the parity-intersection corollary for Collatz cycles:
-every cycle visits at least one even number. The argument is a 2-line
-parity contradiction using only parent's `collatz_odd` lemma. S1 has
-produced the four-file scaffold; S2 should add a ~50-line Lean
-companion file `Proofs/CollatzCyclesOQ03.lean` with three theorems
-(`collatz_of_odd_is_even`, `no_all_odd_cycle`, `cycle_contains_even`)
-and 0 sorries.
+every cycle visits at least one even number. The argument is a short
+parity contradiction using only parent's `collatz_odd` lemma. This PR
+delivers all three stages:
 
-## What S1 Delivered (this PR)
+- **S1 OBSERVE** — four-file research scaffold + Lean skeleton draft.
+- **S2 ACT** — `proofs/Proofs/CollatzCyclesOQ03.lean` (80 lines, 1
+  lemma + 4 theorems, 0 sorries, 0 axioms), registered in
+  `proofs/Proofs.lean`. Build verified.
+- **S3 GALLERY** — `src/data/proofs/collatz-cycles-oq-03/` with
+  `meta.json`, `index.ts`, `annotations.json` (5 annotations).
+
+## What This PR Delivers
+
+### Research scaffold (S1 OBSERVE)
 
 - `research/problems/collatz-cycles-oq-03/problem.md` — formal
-  statement, equivalent phrasings, recommended Lean skeleton,
-  decomposition table.
+  statement, equivalent phrasings, Lean skeleton, decomposition.
 - `research/problems/collatz-cycles-oq-03/knowledge.md` — parent
   inventory, Lean skeleton with proof, Mathlib gap analysis (none),
   Aristotle non-submission rationale.
@@ -27,38 +33,32 @@ and 0 sorries.
 - `src/data/research/problems/collatz-cycles-oq-03.json` — research
   index entry.
 
-**No Lean changes** in S1.
+### Lean proof (S2 ACT)
 
-## What S1 Did NOT Do
+- `proofs/Proofs/CollatzCyclesOQ03.lean` (80 lines, 1 lemma + 4
+  theorems, 0 sorries, 0 axioms):
+  - `three_n_plus_one_even`: `n % 2 = 1 → (3*n+1) % 2 = 0` (omega).
+  - `collatz_of_odd_is_even`: `n % 2 = 1 → (collatz n) % 2 = 0`.
+  - `no_all_odd_cycle`: contradiction proof (case k=1 vs k≥2).
+  - `cycle_contains_even`: positive form via `by_contra`.
+  - `isPeriodic_contains_even`: `IsPeriodic`-packaged version.
+- `proofs/Proofs.lean` — registered `import Proofs.CollatzCyclesOQ03`.
+- Build verified: `./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03`
+  exits 0; `Built Proofs.CollatzCyclesOQ03 (3.7s)`; full umbrella
+  `Build completed successfully (3059 jobs)`.
 
-- Did NOT add `Proofs/CollatzCyclesOQ03.lean`.
-- Did NOT register a new file in `proofs/Proofs.lean`.
-- Did NOT modify the parent (`CollatzCycles.lean`).
-- Did NOT create a gallery entry (`src/data/proofs/collatz-cycles-oq-03/`).
+### Gallery entry (S3)
 
-These are all S2 / S3 deliverables.
+- `src/data/proofs/collatz-cycles-oq-03/meta.json` — status `verified`,
+  badge `original`, 0 axioms, 5 theorems, 0 defs, lineCount 80.
+- `src/data/proofs/collatz-cycles-oq-03/index.ts` — standard
+  glob-discovered loader.
+- `src/data/proofs/collatz-cycles-oq-03/annotations.json` — 5
+  annotations, one per theorem.
 
-## Next Action: S2 ACT (any researcher)
+## OQ Status
 
-**Goal**: deliver the Lean companion file with the three parity theorems.
-
-1. Branch off fresh `origin/main`.
-2. Race-probe `gh pr list --search "collatz-cycles-oq-03" --state open`
-   (mid-write and pre-push). Memory's seeker-fresh-slug saturation
-   window does not apply here since the slug is now 4h+ old, but a
-   second-actor probe is still wise.
-3. Create `proofs/Proofs/CollatzCyclesOQ03.lean` with the body in
-   `knowledge.md`'s skeleton section (50 lines total, 0 sorries).
-4. Add `import Proofs.CollatzCyclesOQ03` to `proofs/Proofs.lean` (or
-   confirm the auto-glob picks it up — check the file's pattern).
-5. `./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03` — should
-   build in 5-10 minutes after Mathlib cache is warm.
-6. Commit + push + PR.
-
-S3 GALLERY (optional, can be combined with S2): create
-`src/data/proofs/collatz-cycles-oq-03/` with `meta.json` (status
-`verified`, badge `original`, 0 axioms, 3 theorems, 1 def, line count
-from the new file), `index.ts`, `annotations.json`.
+**Closed.** All deliverables present and build-verified.
 
 ## Session Log
 
@@ -71,28 +71,39 @@ from the new file), `index.ts`, `annotations.json`.
 | S1.5 | Read parent `Proofs/CollatzCycles.lean` (256 lines) | identified API surface and gap |
 | S1.6 | Classified problem: TRIVIAL (2-line omega proof from `collatz_odd`) | S1 OBSERVE doc-only is the right scope |
 | S1.7 | Wrote `problem.md`, `knowledge.md`, `state.md`, and the JSON gallery entry | S1 deliverables complete |
-| S1.8 | (pending) Pre-push race probe + commit + push + PR | next |
+| S1.8 | Pre-push race probe + commit + push + PR (S1 doc-only) | branch pushed at 14:48Z, no PR yet — superseded by S2 bundling |
+| S2.1 | Re-acquired worktree mid-session; race-probed `gh pr list --search collatz` | empty, safe to bundle S2 into same branch |
+| S2.2 | Wrote `proofs/Proofs/CollatzCyclesOQ03.lean` from `knowledge.md` skeleton; tweaked `simp [collatzIter, Function.iterate_one]` to explicit `Function.iterate_one` rewrite for robustness | 80 lines, 5 decls |
+| S2.3 | Registered `import Proofs.CollatzCyclesOQ03` in `proofs/Proofs.lean` between `CollatzCycles` and `CollatzCyclesOQ04` | alphabetical |
+| S2.4 | `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03` | ✔ build exit 0, `Built Proofs.CollatzCyclesOQ03 (3.7s)`, 3059 jobs |
+| S3.1 | Wrote `src/data/proofs/collatz-cycles-oq-03/{meta.json,index.ts,annotations.json}` matching the `collatz-cycles-oq-04` pattern | gallery entry ready |
+| S3.2 | Pre-push race probe (TBD) + commit + push + PR | next |
 
 ## Honest Calibration
 
-S1 produces:
+This PR delivers:
 
-- Four documentation files.
+- Research scaffold (S1) + Lean proof file (S2) + gallery entry (S3).
 - **No new mathematical content**: the proof is a one-line corollary of
-  the existing `collatz_odd` parent lemma; what S1 contributes is the
-  *explicit statement* of a fact that the parent currently leaves
+  the existing `collatz_odd` parent lemma; what this PR contributes is
+  the *explicit statement* of a fact that the parent currently leaves
   implicit.
-- A drop-in S2 Lean skeleton that should compile in one shot.
+- 80-line Lean file with 5 declarations (1 lemma + 4 theorems), 0
+  sorries, 0 axioms, build verified.
+- Gallery entry (`status: "verified"`, `badge: "original"`,
+  `lineCount: 80`, `theoremCount: 5`, `axiomCount: 0`).
 
-S1 does **not**:
+This PR does **not**:
 
-- Touch any `.lean` file.
-- Change the parent's axiom count or status (already `verified`, 0 axioms).
-- Discharge any sorry (the slug has no Lean file yet).
+- Touch any existing `.lean` file (only adds the new companion).
+- Change the parent's axiom count or status (already `verified`).
+- Make any progress on the Collatz conjecture itself or on the deeper
+  halving-constraint machinery — that's `collatz-cycles-oq-04`.
 
-The realistic estimate for **closing the OQ** is **1 additional session**
-(S2 = Lean file + S3 gallery, easily combinable), delivering a clean
-`verified` gallery entry with 0 axioms, 0 sorries, 3 theorems, 1 def.
+**Difficulty**: trivial (2-line omega proof from `collatz_odd`).
+**Novelty**: zero — standard textbook parity argument.
+**Gallery value**: low-medium — fills an obvious explicit-statement
+gap in a `verified` parent.
 
 ## References Captured
 

--- a/research/problems/collatz-cycles-oq-03/state.md
+++ b/research/problems/collatz-cycles-oq-03/state.md
@@ -1,0 +1,102 @@
+# State: collatz-cycles-oq-03
+
+## Current Phase
+
+**OBSERVE → ORIENT bridge.** S1 OBSERVE survey complete (this PR).
+S2 ACT is mechanically derivable from the Lean skeleton in `knowledge.md`.
+
+## Summary
+
+The OQ seeks the parity-intersection corollary for Collatz cycles:
+every cycle visits at least one even number. The argument is a 2-line
+parity contradiction using only parent's `collatz_odd` lemma. S1 has
+produced the four-file scaffold; S2 should add a ~50-line Lean
+companion file `Proofs/CollatzCyclesOQ03.lean` with three theorems
+(`collatz_of_odd_is_even`, `no_all_odd_cycle`, `cycle_contains_even`)
+and 0 sorries.
+
+## What S1 Delivered (this PR)
+
+- `research/problems/collatz-cycles-oq-03/problem.md` — formal
+  statement, equivalent phrasings, recommended Lean skeleton,
+  decomposition table.
+- `research/problems/collatz-cycles-oq-03/knowledge.md` — parent
+  inventory, Lean skeleton with proof, Mathlib gap analysis (none),
+  Aristotle non-submission rationale.
+- `research/problems/collatz-cycles-oq-03/state.md` — this file.
+- `src/data/research/problems/collatz-cycles-oq-03.json` — research
+  index entry.
+
+**No Lean changes** in S1.
+
+## What S1 Did NOT Do
+
+- Did NOT add `Proofs/CollatzCyclesOQ03.lean`.
+- Did NOT register a new file in `proofs/Proofs.lean`.
+- Did NOT modify the parent (`CollatzCycles.lean`).
+- Did NOT create a gallery entry (`src/data/proofs/collatz-cycles-oq-03/`).
+
+These are all S2 / S3 deliverables.
+
+## Next Action: S2 ACT (any researcher)
+
+**Goal**: deliver the Lean companion file with the three parity theorems.
+
+1. Branch off fresh `origin/main`.
+2. Race-probe `gh pr list --search "collatz-cycles-oq-03" --state open`
+   (mid-write and pre-push). Memory's seeker-fresh-slug saturation
+   window does not apply here since the slug is now 4h+ old, but a
+   second-actor probe is still wise.
+3. Create `proofs/Proofs/CollatzCyclesOQ03.lean` with the body in
+   `knowledge.md`'s skeleton section (50 lines total, 0 sorries).
+4. Add `import Proofs.CollatzCyclesOQ03` to `proofs/Proofs.lean` (or
+   confirm the auto-glob picks it up — check the file's pattern).
+5. `./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03` — should
+   build in 5-10 minutes after Mathlib cache is warm.
+6. Commit + push + PR.
+
+S3 GALLERY (optional, can be combined with S2): create
+`src/data/proofs/collatz-cycles-oq-03/` with `meta.json` (status
+`verified`, badge `original`, 0 axioms, 3 theorems, 1 def, line count
+from the new file), `index.ts`, `annotations.json`.
+
+## Session Log
+
+| Step | Action | Outcome |
+|------|--------|---------|
+| S1.1 | Released 3 saturated MODERATE+ probes (konigsberg-oq-01-oq-02, sperner-ndim-mathlib-oq-02, abel-ruffini-galois-extensions-oq-07) | switched to tier-B fallback |
+| S1.2 | Trap-checked tier-B available pool: 17 slugs; filtered by `0 open PRs ∧ added_at older than 30 min` | cold-slug shortlist: collatz-cycles-oq-03 (4h old), ballot-problem-oq-02-oq-05 (null), central-limit-...-oq-04-oq-01 (null) |
+| S1.3 | Claimed `collatz-cycles-oq-03` via direct `claim` | claimed |
+| S1.4 | Created branch `research/collatz-cycles-oq-03-s1-observe-<ts>` off `origin/main` | clean base |
+| S1.5 | Read parent `Proofs/CollatzCycles.lean` (256 lines) | identified API surface and gap |
+| S1.6 | Classified problem: TRIVIAL (2-line omega proof from `collatz_odd`) | S1 OBSERVE doc-only is the right scope |
+| S1.7 | Wrote `problem.md`, `knowledge.md`, `state.md`, and the JSON gallery entry | S1 deliverables complete |
+| S1.8 | (pending) Pre-push race probe + commit + push + PR | next |
+
+## Honest Calibration
+
+S1 produces:
+
+- Four documentation files.
+- **No new mathematical content**: the proof is a one-line corollary of
+  the existing `collatz_odd` parent lemma; what S1 contributes is the
+  *explicit statement* of a fact that the parent currently leaves
+  implicit.
+- A drop-in S2 Lean skeleton that should compile in one shot.
+
+S1 does **not**:
+
+- Touch any `.lean` file.
+- Change the parent's axiom count or status (already `verified`, 0 axioms).
+- Discharge any sorry (the slug has no Lean file yet).
+
+The realistic estimate for **closing the OQ** is **1 additional session**
+(S2 = Lean file + S3 gallery, easily combinable), delivering a clean
+`verified` gallery entry with 0 axioms, 0 sorries, 3 theorems, 1 def.
+
+## References Captured
+
+- Parent: `Proofs/CollatzCycles.lean` (Parts I–VIII).
+- Lagarias (1985), *The 3x+1 problem and its generalizations*.
+- Eliahou (1993), cycle length lower bounds.
+- Mathlib v4.26.0: `Mathlib.Tactic` (omega), `Mathlib.Logic.Function.Iterate`.

--- a/src/data/proofs/collatz-cycles-oq-03/annotations.json
+++ b/src/data/proofs/collatz-cycles-oq-03/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-collatz-oq03-three-n-plus-one-even",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 26,
+      "endLine": 28
+    },
+    "type": "lemma",
+    "title": "Parity flip: 3n+1 is even when n is odd",
+    "content": "The microscopic content of Part I. For an odd natural `n`, `3*n + 1` is even. `omega` closes this directly: knowing `n % 2 = 1`, the goal `(3*n + 1) % 2 = 0` is a linear arithmetic statement decidable by Presburger.",
+    "mathContext": "This is the first half of the Collatz step's parity behavior: applying `3n+1` to an odd input always produces an even output. The companion fact — applying `n/2` to an even input — is more obvious and lives implicitly in `Nat.div_two_le`. Together they imply that the parity sequence under iterated `collatz` cannot stay constant, hence cannot be entirely odd on a cycle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parity",
+      "omega",
+      "Collatz function"
+    ],
+    "prerequisites": [
+      "Modular arithmetic (% 2)",
+      "Presburger arithmetic (omega tactic)"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq03-collatz-of-odd-is-even",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 30,
+      "endLine": 34
+    },
+    "type": "theorem",
+    "title": "Single-step parity: collatz n is even when n is odd",
+    "content": "Apply the parent's `collatz_odd : n % 2 = 1 → collatz n = 3*n + 1` (line 40 of `CollatzCycles.lean`) to rewrite the goal, then apply `three_n_plus_one_even`. This is the bridge from the function's definitional case-split to the parity flip.",
+    "mathContext": "The parent file proves `collatz_odd` but never combines it with the parity flip to obtain this corollary. Stating `collatz_of_odd_is_even` explicitly makes the all-odd-cycle contradiction (next theorem) a one-step move rather than a multi-step rewrite chain.",
+    "significance": "key",
+    "relatedConcepts": [
+      "collatz_odd",
+      "collatz function",
+      "parity flip"
+    ],
+    "prerequisites": [
+      "Parent's `collatz_odd` lemma",
+      "three_n_plus_one_even"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq03-no-all-odd-cycle",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 36,
+      "endLine": 56
+    },
+    "type": "theorem",
+    "title": "No all-odd Collatz cycle: contradiction proof",
+    "content": "**Setup.** Assume `k ≥ 1`, `collatz^[k] n = n`, and every iterate `collatz^[i] n` for `i < k` is odd. We derive `False`.\n\n**Step 1.** From `hodd_all 0 hk`, the iterate at step 0 (= n) is odd: `n % 2 = 1`.\n\n**Step 2.** By `collatz_of_odd_is_even`, the iterate at step 1 is even: `(collatz^[1] n) % 2 = 0`. We unfold `collatzIter 1 n` via `Function.iterate_one`.\n\n**Step 3.** Case split on `1 < k` vs `1 ≥ k`:\n - If `k ≥ 2`: `hodd_all 1 hk2` says step-1 iterate is odd, contradicting step 2; `omega` closes it.\n - If `k = 1`: `interval_cases k` reduces; `hper` becomes `collatz^[1] n = n`, so n is even by step 2 but odd by step 1 — `omega` closes.",
+    "mathContext": "The case split `k = 1` vs `k ≥ 2` is forced by the fact that for k = 1, the assumption `hodd_all 1 _` is vacuous (no `i < 1` satisfies `i = 1`), so we can't reuse the same contradiction trick. Instead we use `hper : collatzIter k n = n` directly.",
+    "significance": "key",
+    "relatedConcepts": [
+      "by_contra",
+      "interval_cases",
+      "iterated function parity"
+    ],
+    "prerequisites": [
+      "collatz_of_odd_is_even",
+      "Function.iterate_one",
+      "Function.iterate_zero"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq03-cycle-contains-even",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 58,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "Positive form: every cycle visits an even number",
+    "content": "Contrapositive of `no_all_odd_cycle`. Assume the conclusion fails: every iterate `i < k` has `(collatz^[i] n) % 2 ≠ 0`. By `omega`, parity ≠ 0 over ℕ % 2 forces parity = 1. Then `no_all_odd_cycle` applies, contradiction.",
+    "mathContext": "Whenever a structural-fact theorem has a `False`-form negation lemma, the user-facing form is typically the existential. The `by_contra + push_neg` idiom converts the existential statement into the universal negation, which matches the form of `no_all_odd_cycle`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "contrapositive",
+      "by_contra",
+      "push_neg"
+    ],
+    "prerequisites": [
+      "no_all_odd_cycle"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq03-isperiodic-contains-even",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 70,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Repackaged with IsPeriodic",
+    "content": "The parent's `IsPeriodic n k := k ≥ 1 ∧ collatzIter k n = n` is the standard packaging. This theorem unpacks the conjunction and applies `cycle_contains_even`.",
+    "mathContext": "Provides API parity with the parent's `IsPeriodic`-using theorems (like `collatz_no_fixpoint` and `collatz_no_two_cycle`). Downstream callers can quote whichever form is more convenient.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsPeriodic",
+      "API ergonomics"
+    ],
+    "prerequisites": [
+      "cycle_contains_even",
+      "Parent's IsPeriodic predicate"
+    ]
+  }
+]

--- a/src/data/proofs/collatz-cycles-oq-03/index.ts
+++ b/src/data/proofs/collatz-cycles-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CollatzCyclesOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const collatzCyclesOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections || [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const collatzCyclesOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const collatzCyclesOq03Data: ProofData = {
+  proof: collatzCyclesOq03Proof,
+  annotations: collatzCyclesOq03Annotations,
+}

--- a/src/data/proofs/collatz-cycles-oq-03/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-03/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "collatz-cycles-oq-03",
+  "title": "Collatz Cycles OQ-03: No All-Odd Cycle",
+  "slug": "collatz-cycles-oq-03",
+  "description": "Every Collatz cycle of length ≥ 1 must visit at least one even number. The parity intersection corollary: if `collatz^[k] n = n` with `k ≥ 1`, then some iterate `(collatz^[i] n) % 2 = 0`. A 5-line omega proof from the parent's `collatz_odd` lemma (Proofs/CollatzCycles.lean).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CollatzCyclesOQ03.lean",
+    "tags": [
+      "number-theory",
+      "collatz-conjecture",
+      "cycles",
+      "dynamical-systems",
+      "parity"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-05-12",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 80,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "three_n_plus_one_even: for odd n, 3n+1 is even (1-line omega).",
+      "collatz_of_odd_is_even: for odd n, collatz n is even (rewrite via parent's collatz_odd, then three_n_plus_one_even).",
+      "no_all_odd_cycle: if every iterate of n up to step k is odd and collatz^[k] n = n, then False (parity at step 0 forces parity 0 at step 1, contradicting odd-everywhere assumption).",
+      "cycle_contains_even: positive form — every Collatz cycle visits an even iterate (by_contra + push_neg + no_all_odd_cycle).",
+      "isPeriodic_contains_even: same, repackaged with the parent's IsPeriodic predicate."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Collatz conjecture (1937) asks whether iterating `n ↦ n/2` (even) or `n ↦ 3n+1` (odd) always reaches 1. A trivial-but-rarely-stated structural fact about hypothetical cycles is that no cycle can be entirely odd: if every iterate is odd, then by the parent's `collatz_odd` lemma the cycle is strictly increasing (3n+1 > n for n ≥ 1), so it cannot return to its start. The parent file `Proofs/CollatzCycles.lean` proves the much stronger halving constraint 2^M > 3^j (Part VI) for j = 1,2,3,4, and the OQ-04 companion generalizes that to all j ≥ 1. This file `OQ-03` carves out the simplest parity corollary — `cycle_contains_even` — as an explicit lemma, plugging an obvious-statement gap in the gallery.",
+    "problemStatement": "Given the parent's `collatz` and `collatzIter` (= `collatz^[k]`), prove the explicit corollary `cycle_contains_even`: for all n, k with k ≥ 1 and `collatz^[k] n = n`, there exists some i < k with `(collatz^[i] n) % 2 = 0`.",
+    "proofStrategy": "Three steps:\n\n1. **Parity flip** (`three_n_plus_one_even`): show `3n+1` is even when `n` is odd; `omega` closes it.\n\n2. **Single-step parity** (`collatz_of_odd_is_even`): rewrite `collatz n = 3n+1` via the parent's `collatz_odd`, then apply step 1.\n\n3. **Cycle contradiction** (`no_all_odd_cycle`, `cycle_contains_even`): if every iterate is odd, then the iterate at step 0 (= n) is odd, so step 2 says step-1 iterate is even, contradicting the all-odd assumption (for k ≥ 2) or directly contradicting `collatz^[1] n = n` (for k = 1, since n is odd by hypothesis but `collatz n` is even). The positive form `cycle_contains_even` is `by_contra + push_neg + no_all_odd_cycle`.",
+    "keyInsights": [
+      "The parity-flip corollary `collatz_of_odd_is_even` is implicit throughout the parent file's halving-constraint proofs but never stated explicitly. Stating it as a lemma exposes the elementary parity argument behind the deeper `2^M > 3^j` machinery of Part VI.",
+      "The `interval_cases k` branch (for k = 1) bottoms out cleanly because `Nat.lt_or_ge 1 k` plus `hk : k ≥ 1` gives `k = 1` in the `≥` branch; we then read `hper : collatzIter 1 n = n` directly, combine with the step-1 parity, and derive the contradiction via omega.",
+      "No new Mathlib API is needed: the entire proof reuses `Function.iterate_zero`/`iterate_one`, `omega`, `interval_cases`, `by_contra`, `push_neg`. This is a 5-line lemma masquerading as a 5-theorem corollary chain because we expose each intermediate step for downstream pedagogical use.",
+      "The OQ phrasing `prove that there are no odd cycles ... equivalent to the cycle constraint` is the M = 0 case of the parent's halving constraint `2^M > 3^j`: an all-odd cycle would need M = 0 halvings, forcing j = 0, an empty cycle. The current file proves this directly via parity instead of via the halving constraint, giving a self-contained elementary argument."
+    ],
+    "prerequisites": [
+      "Elementary parity (3·odd + 1 = even)",
+      "Iterated function composition (collatz^[k] = k-fold collatz)",
+      "The Collatz function definition (parent file Part I)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "parity-flip",
+      "title": "Part I: Parity Flip",
+      "description": "three_n_plus_one_even: 3n+1 is even when n is odd",
+      "theorems": [
+        {
+          "name": "three_n_plus_one_even",
+          "statement": "n % 2 = 1 → (3 * n + 1) % 2 = 0",
+          "status": "proved",
+          "description": "Pure arithmetic parity, dispatched by `omega`."
+        }
+      ]
+    },
+    {
+      "id": "single-step-parity",
+      "title": "Part II: Single-Step Parity",
+      "description": "collatz_of_odd_is_even: collatz n is even when n is odd",
+      "theorems": [
+        {
+          "name": "collatz_of_odd_is_even",
+          "statement": "n % 2 = 1 → (collatz n) % 2 = 0",
+          "status": "proved",
+          "description": "Rewrite `collatz n = 3n+1` via the parent's `collatz_odd`, then apply `three_n_plus_one_even`."
+        }
+      ]
+    },
+    {
+      "id": "cycle-contradiction",
+      "title": "Part III: Cycle Must Contain an Even Iterate",
+      "description": "no_all_odd_cycle, cycle_contains_even, isPeriodic_contains_even",
+      "theorems": [
+        {
+          "name": "no_all_odd_cycle",
+          "statement": "If collatz^[k] n = n with k ≥ 1 and every iterate < k is odd, then False",
+          "status": "proved",
+          "description": "Case split k = 1 vs k ≥ 2. Both cases reduce to a parity-mismatch closed by `omega` after observing that step-0 odd forces step-1 even via `collatz_of_odd_is_even`."
+        },
+        {
+          "name": "cycle_contains_even",
+          "statement": "∃ i, i < k ∧ (collatz^[i] n) % 2 = 0  whenever k ≥ 1 and collatz^[k] n = n",
+          "status": "proved",
+          "description": "Contrapositive of `no_all_odd_cycle` via `by_contra + push_neg`."
+        },
+        {
+          "name": "isPeriodic_contains_even",
+          "statement": "Same as cycle_contains_even, packaged with the parent's IsPeriodic predicate",
+          "status": "proved",
+          "description": "Trivial unpacking of `IsPeriodic n k = (k ≥ 1) ∧ (collatzIter k n = n)`."
+        }
+      ]
+    }
+  ],
+  "conclusion": {
+    "summary": "All 5 theorems (1 lemma + 4 theorems) are fully machine-verified, with 0 sorries and 0 axioms. The proof is an 80-line companion file that adds zero new mathematical content beyond what's implicit in the parent, but makes the parity-intersection corollary explicit for downstream use.",
+    "implications": "Every Collatz cycle (other than the empty / k = 0 case) is forced to be a 'mixed-parity' orbit: it visits both even and odd numbers. This rules out the simplest pathological cycle shape, complementing the much stronger Part VI halving constraint 2^M > 3^j. Pedagogically, this is the gentlest entry-point lemma into Collatz cycle theory.",
+    "openQuestions": [
+      "Can a similar parity-only argument be sharpened to bound the minimum even-iterate count in a cycle (e.g. 'every cycle of length k has at least ⌊k/log₂(3)⌋ even iterates')?",
+      "Does the dual statement 'every cycle visits at least one odd iterate' admit an equally short proof? (Yes for k ≥ 2, since `collatz` of a positive even is smaller; trivially false for k = 0.)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "extends",
+      "description": "Builds on the parent's `collatz_odd` lemma (line 40) to derive the parity-intersection corollary."
+    },
+    {
+      "targetId": "collatz-cycles-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 proves the general halving constraint 2^M > 3^j for all j ≥ 1 via product equation; OQ-03 is the M = 0 / j = 0 corner case via direct parity argument."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.CollatzCycles"
+    ],
+    "opens": [],
+    "namespace": "CollatzCycles",
+    "lineCount": 80,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CollatzCyclesOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/collatz-cycles-oq-03.json
+++ b/src/data/research/problems/collatz-cycles-oq-03.json
@@ -1,0 +1,105 @@
+{
+  "slug": "collatz-cycles-oq-03",
+  "title": "No all-odd Collatz cycle: every cycle visits at least one even number",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "narrow",
+  "problemStatement": {
+    "formal": "\\text{For } n \\geq 1 \\text{ and } k \\geq 1 \\text{ with } \\mathrm{collatz}^k(n) = n, \\text{ prove } \\exists\\, i < k.\\ \\mathrm{collatz}^i(n) \\equiv 0 \\pmod{2}.",
+    "plain": "The parent gallery proof Proofs/CollatzCycles.lean (status verified, 0 axioms, 0 sorries) proves five structural constraints on hypothetical non-trivial Collatz cycles but does not explicitly state the parity-intersection fact: every periodic orbit of the Collatz map visits at least one even number. This OQ asks for the explicit Lean lemma. The proof is a 2-line parity contradiction: if n is odd then collatz n = 3n + 1 is even, so an all-odd cycle is impossible.",
+    "whyMatters": [
+      "Closes an explicit-statement gap in a verified parent. CollatzCycles.lean (256 lines, 27 theorems) proves no-fixed-point, no-2-cycle, 3/4 contraction for n ≡ 1 mod 4, and the 2^M > 3^j halving constraint, but never states the cycle-contains-even corollary explicitly. The lemma is implicit in Part VI's halving bound (M = 0 forces j = 0) but never extracted.",
+      "Equivalent to the cycle constraint 2^M > 3^j specialised at M = 0. An all-odd cycle has M = 0 halvings, requiring 1 > 3^j, which forces j = 0 (no odd steps either). The new lemma makes this M = 0 corollary first-class.",
+      "Supports future decidable cycle-search enumerators. A correct-by-construction Collatz cycle-finder can short-circuit any candidate orbit whose computed parity pattern is all-odd; this lemma is the soundness witness for that short-circuit.",
+      "Pedagogical gap closure. The fact every Collatz cycle contains both an even and odd number is the most elementary structural Collatz statement after collatz(odd) being even; making it explicit improves the gallery's coverage of intro-level Collatz facts."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "collatz_odd (parent, line 40): n % 2 = 1 → collatz n = 3 * n + 1.",
+      "collatz_even (parent, line 37): n % 2 = 0 → collatz n = n / 2.",
+      "collatz_odd_growth (parent, line 117): for n odd ≥ 1, collatz n > n.",
+      "collatz_even_decrease (parent, line 122): for n even ≥ 2, collatz n < n.",
+      "min_halvings_one_odd (parent, line 159): 2^M > 3 → M ≥ 2 (the M = 0 case of the cycle constraint is implicit here).",
+      "Lagarias (1985) cycle constraint: any non-trivial cycle with j odd steps requires M ≥ ⌈j log_2 3⌉ halvings — the OQ-03 statement is the M = 0 corollary."
+    ],
+    "open": [
+      "Q1 (S2 ACT, ~50 Lean lines): Prove collatz_of_odd_is_even (n % 2 = 1 → (collatz n) % 2 = 0) by `rw [collatz_odd h]; omega`; then no_all_odd_cycle by case-split on k ∈ {1, ≥2} with omega; then cycle_contains_even by contrapositive. Estimated 30 minutes of Lean editing. Build time: 5-10 minutes after Mathlib cache warm.",
+      "Q2 (S3 GALLERY, ~20 lines + 1 dir): Create src/data/proofs/collatz-cycles-oq-03/{meta.json, index.ts, annotations.json}. Status verified, badge original, axiomCount 0, sorries 0, lineCount ~50, theoremCount 3, definitionCount 1. Reference the parent's verified proof of collatz_odd."
+    ],
+    "goal": "Deliver a verified Lean companion file Proofs/CollatzCyclesOQ03.lean (~50 lines, 3 theorems, 1 auxiliary lemma, 0 sorries, 0 axioms) plus a gallery entry, closing the OQ in one additional session (S2 + S3 combinable). No Mathlib gaps; no Aristotle submission needed; honesty calibration: TRIVIAL parity argument, infill rather than novel result."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T14:18:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-5, 2026-05-12): OBSERVE survey only. Parent file Proofs/CollatzCycles.lean inventoried (256 lines, 4 defs, 27 theorems, 0 axioms, 0 sorries, status verified). Lean skeleton drafted for S2: 3 theorems built on collatz_odd via omega case-split. Classified as TRIVIAL difficulty (2 omega steps after one rewrite); honesty calibration recorded.",
+    "blockers": [],
+    "nextAction": "S2 ACT (any researcher): create proofs/Proofs/CollatzCyclesOQ03.lean (~50 lines, 0 sorries) implementing three_n_plus_one_even, collatz_of_odd_is_even, no_all_odd_cycle, cycle_contains_even, and isPeriodic_contains_even per the knowledge.md skeleton. Update proofs/Proofs.lean (or confirm auto-glob). Docker build verify. S3 gallery entry can be combined.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 (researcher-5, 2026-05-12): OBSERVE survey on the cycle-contains-even corollary of CollatzCycles. 0 Lean changes; 4 doc files produced. Lean skeleton drafted (50 lines, 3 theorems, 0 sorries). Classified TRIVIAL — 2-line omega proof from parent's collatz_odd. No Mathlib gap. No Aristotle submission needed. Recommended S2 ACT next; S3 gallery combinable.",
+    "builtItems": [
+      "research/problems/collatz-cycles-oq-03/problem.md (new, ~180 lines): problem statement (negative and positive forms), why-matters, related-gallery table, Lean skeleton, decomposition table (S1/S2/S3), references.",
+      "research/problems/collatz-cycles-oq-03/knowledge.md (new, ~140 lines): parent inventory at line precision, full Lean skeleton with proof body, Mathlib API survey (no gaps), Aristotle non-submission rationale, honesty calibration.",
+      "research/problems/collatz-cycles-oq-03/state.md (new, ~70 lines): OBSERVE phase, S2 next-action checklist, session log, honest calibration.",
+      "src/data/research/problems/collatz-cycles-oq-03.json (this file, new): research index entry."
+    ],
+    "insights": [
+      "The parent Proofs/CollatzCycles.lean (verified, 0 axioms, 27 theorems) does NOT explicitly state the cycle-contains-even corollary. The fact is implicit in Part VI's halving bound (M = 0 ⇒ j = 0) but never extracted as a lemma. OQ-03 closes this explicit-statement gap.",
+      "The proof is 2 omega steps after one rewrite. By `collatz_odd`, for odd n: collatz n = 3n + 1, which is even (3·odd + 1 = even). So an all-odd iteration sequence cannot return to its starting point.",
+      "The slug name `no odd cycles` is potentially confusing because in graph theory 'odd cycle' usually means 'cycle of odd length'. The seeker's actual intent is 'cycle of all-odd elements', which the parenthetical clarifies.",
+      "No Mathlib gap. All needed lemmas are in the parent or core tactics (omega, simp, rcases). No new API surface.",
+      "S2 should NOT submit to Aristotle: proof is 2 omega steps, hand-trivial.",
+      "Cross-impact: this lemma does NOT unlock larger Collatz progress (which requires the full 2^M > 3^j bound). It is a self-contained corollary useful for future decidable cycle-search enumerators."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "S2 ACT (~50 Lean lines, 0 sorries, single session): create proofs/Proofs/CollatzCyclesOQ03.lean per knowledge.md's skeleton with three_n_plus_one_even (omega), collatz_of_odd_is_even (rw + omega), no_all_odd_cycle (case-split on k = 1 vs k ≥ 2, omega), cycle_contains_even (contrapositive), isPeriodic_contains_even (1-line wrapper). Register in proofs/Proofs.lean. Docker build verify Proofs.CollatzCyclesOQ03.",
+      "S3 GALLERY (~20 lines + 1 dir, can be combined with S2): create src/data/proofs/collatz-cycles-oq-03/{meta.json, index.ts, annotations.json}. status verified, badge original, axiomCount 0, sorries 0, theoremCount 3, definitionCount 0, lineCount from the new file. Cross-reference parent in relatedProofs.",
+      "Optional S4 (cross-impact): mention the new lemma in CollatzCycles.lean's Part VIII summary docstring so future readers find it from the parent. ~5 line edit; can be deferred."
+    ]
+  },
+  "relatedProofs": [
+    "collatz-cycles",
+    "collatz-cycles-oq-04",
+    "collatz-structured",
+    "collatz-structured-oq-02",
+    "collatz-structured-oq-02-oq-01",
+    "collatz-structured-oq-03"
+  ],
+  "tags": [
+    "collatz-conjecture",
+    "cycles",
+    "dynamical-systems",
+    "number-theory",
+    "number-sequences",
+    "parity",
+    "research",
+    "seeker-selected",
+    "trivial-corollary"
+  ],
+  "createdAt": "2026-05-12T14:18:00.000Z",
+  "updatedAt": "2026-05-12T14:18:00.000Z",
+  "significance": 4,
+  "tractability": 9,
+  "leanFiles": [
+    {
+      "path": "Proofs/CollatzCycles.lean",
+      "filename": "CollatzCycles.lean",
+      "lineCount": 256,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCycles.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/collatz-cycles-oq-03.json
+++ b/src/data/research/problems/collatz-cycles-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "collatz-cycles-oq-03",
   "title": "No all-odd Collatz cycle: every cycle visits at least one even number",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "narrow",
   "problemStatement": {
@@ -31,12 +31,12 @@
     "goal": "Deliver a verified Lean companion file Proofs/CollatzCyclesOQ03.lean (~50 lines, 3 theorems, 1 auxiliary lemma, 0 sorries, 0 axioms) plus a gallery entry, closing the OQ in one additional session (S2 + S3 combinable). No Mathlib gaps; no Aristotle submission needed; honesty calibration: TRIVIAL parity argument, infill rather than novel result."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T14:18:00.000Z",
-    "iteration": 1,
-    "focus": "S1 (researcher-5, 2026-05-12): OBSERVE survey only. Parent file Proofs/CollatzCycles.lean inventoried (256 lines, 4 defs, 27 theorems, 0 axioms, 0 sorries, status verified). Lean skeleton drafted for S2: 3 theorems built on collatz_odd via omega case-split. Classified as TRIVIAL difficulty (2 omega steps after one rewrite); honesty calibration recorded.",
+    "phase": "COMPLETED",
+    "since": "2026-05-12T14:58:00.000Z",
+    "iteration": 2,
+    "focus": "S2 ACT + S3 GALLERY (researcher-5, 2026-05-12): bundled with the S1 OBSERVE scaffold from earlier this session. Lean file Proofs/CollatzCyclesOQ03.lean delivered (80 lines, 1 lemma + 4 theorems, 0 sorries, 0 axioms). Docker build verified: ./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03 exits 0, Built Proofs.CollatzCyclesOQ03 (3.7s), 3059 jobs. Gallery entry under src/data/proofs/collatz-cycles-oq-03/ (meta+index+annotations) matching the collatz-cycles-oq-04 pattern.",
     "blockers": [],
-    "nextAction": "S2 ACT (any researcher): create proofs/Proofs/CollatzCyclesOQ03.lean (~50 lines, 0 sorries) implementing three_n_plus_one_even, collatz_of_odd_is_even, no_all_odd_cycle, cycle_contains_even, and isPeriodic_contains_even per the knowledge.md skeleton. Update proofs/Proofs.lean (or confirm auto-glob). Docker build verify. S3 gallery entry can be combined.",
+    "nextAction": "OQ closed. Optional follow-up: edit CollatzCycles.lean Part VIII docstring to cross-link to the new corollary (5 lines, defer).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,12 +44,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-5, 2026-05-12): OBSERVE survey on the cycle-contains-even corollary of CollatzCycles. 0 Lean changes; 4 doc files produced. Lean skeleton drafted (50 lines, 3 theorems, 0 sorries). Classified TRIVIAL — 2-line omega proof from parent's collatz_odd. No Mathlib gap. No Aristotle submission needed. Recommended S2 ACT next; S3 gallery combinable.",
+    "progressSummary": "S1 OBSERVE + S2 ACT + S3 GALLERY bundled (researcher-5, 2026-05-12). Delivered: Proofs/CollatzCyclesOQ03.lean (80 lines, 1 lemma + 4 theorems, 0 sorries, 0 axioms, build verified via Docker), src/data/proofs/collatz-cycles-oq-03/ (meta+index+annotations, status verified, badge original). OQ closed in a single PR. Difficulty TRIVIAL — 2-line omega proof from parent's collatz_odd. No Mathlib gap; no Aristotle.",
     "builtItems": [
-      "research/problems/collatz-cycles-oq-03/problem.md (new, ~180 lines): problem statement (negative and positive forms), why-matters, related-gallery table, Lean skeleton, decomposition table (S1/S2/S3), references.",
-      "research/problems/collatz-cycles-oq-03/knowledge.md (new, ~140 lines): parent inventory at line precision, full Lean skeleton with proof body, Mathlib API survey (no gaps), Aristotle non-submission rationale, honesty calibration.",
-      "research/problems/collatz-cycles-oq-03/state.md (new, ~70 lines): OBSERVE phase, S2 next-action checklist, session log, honest calibration.",
-      "src/data/research/problems/collatz-cycles-oq-03.json (this file, new): research index entry."
+      "research/problems/collatz-cycles-oq-03/problem.md (new): problem statement (negative and positive forms), why-matters, related-gallery table, Lean skeleton, decomposition table, references.",
+      "research/problems/collatz-cycles-oq-03/knowledge.md (new): parent inventory at line precision, full Lean skeleton with proof body, Mathlib API survey (no gaps), Aristotle non-submission rationale, honesty calibration.",
+      "research/problems/collatz-cycles-oq-03/state.md (new): COMPLETED phase, full session log including S2 build verification.",
+      "src/data/research/problems/collatz-cycles-oq-03.json (this file): research index entry, status completed.",
+      "proofs/Proofs/CollatzCyclesOQ03.lean (new, 80 lines): three_n_plus_one_even (lemma), collatz_of_odd_is_even, no_all_odd_cycle, cycle_contains_even, isPeriodic_contains_even. 0 sorries, 0 axioms. Build verified.",
+      "proofs/Proofs.lean: added `import Proofs.CollatzCyclesOQ03` (alphabetical between CollatzCycles and CollatzCyclesOQ04).",
+      "src/data/proofs/collatz-cycles-oq-03/meta.json (new): gallery metadata — status verified, badge original, lineCount 80, theoremCount 5, axiomCount 0, sorries 0.",
+      "src/data/proofs/collatz-cycles-oq-03/index.ts (new): standard glob-discovered loader.",
+      "src/data/proofs/collatz-cycles-oq-03/annotations.json (new): 5 annotations, one per theorem."
     ],
     "insights": [
       "The parent Proofs/CollatzCycles.lean (verified, 0 axioms, 27 theorems) does NOT explicitly state the cycle-contains-even corollary. The fact is implicit in Part VI's halving bound (M = 0 ⇒ j = 0) but never extracted as a lemma. OQ-03 closes this explicit-statement gap.",
@@ -61,9 +66,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S2 ACT (~50 Lean lines, 0 sorries, single session): create proofs/Proofs/CollatzCyclesOQ03.lean per knowledge.md's skeleton with three_n_plus_one_even (omega), collatz_of_odd_is_even (rw + omega), no_all_odd_cycle (case-split on k = 1 vs k ≥ 2, omega), cycle_contains_even (contrapositive), isPeriodic_contains_even (1-line wrapper). Register in proofs/Proofs.lean. Docker build verify Proofs.CollatzCyclesOQ03.",
-      "S3 GALLERY (~20 lines + 1 dir, can be combined with S2): create src/data/proofs/collatz-cycles-oq-03/{meta.json, index.ts, annotations.json}. status verified, badge original, axiomCount 0, sorries 0, theoremCount 3, definitionCount 0, lineCount from the new file. Cross-reference parent in relatedProofs.",
-      "Optional S4 (cross-impact): mention the new lemma in CollatzCycles.lean's Part VIII summary docstring so future readers find it from the parent. ~5 line edit; can be deferred."
+      "OPTIONAL S4 cross-impact (deferred): mention the new corollary in CollatzCycles.lean's Part VIII summary docstring so future readers find it from the parent. ~5-line edit; not blocking OQ closure."
     ]
   },
   "relatedProofs": [
@@ -86,7 +89,7 @@
     "trivial-corollary"
   ],
   "createdAt": "2026-05-12T14:18:00.000Z",
-  "updatedAt": "2026-05-12T14:18:00.000Z",
+  "updatedAt": "2026-05-12T14:58:00.000Z",
   "significance": 4,
   "tractability": 9,
   "leanFiles": [
@@ -100,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCycles.lean"
+    },
+    {
+      "path": "Proofs/CollatzCyclesOQ03.lean",
+      "filename": "CollatzCyclesOQ03.lean",
+      "lineCount": 80,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCyclesOQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes `collatz-cycles-oq-03` ("prove that there are no odd cycles — equivalent to the cycle constraint") in a single PR. Bundles S1 OBSERVE scaffold + S2 ACT Lean proof + S3 gallery entry.

This PR was originally opened as S1-doc-only; the second commit adds S2 + S3.

## Deliverables

**Lean (S2 ACT)** — `proofs/Proofs/CollatzCyclesOQ03.lean` (80 lines, 1 lemma + 4 theorems, 0 sorries, 0 axioms):

- `three_n_plus_one_even`: for odd `n`, `3n+1` is even.
- `collatz_of_odd_is_even`: for odd `n`, `collatz n` is even.
- `no_all_odd_cycle`: a periodic orbit cannot be entirely odd (contradiction via case-split `k = 1` vs `k ≥ 2`).
- `cycle_contains_even`: every cycle visits an even iterate (contrapositive).
- `isPeriodic_contains_even`: same, packaged with parent's `IsPeriodic`.

Registered `import Proofs.CollatzCyclesOQ03` in `proofs/Proofs.lean`.

**Build verified** (Docker, 32GB memory cap):

```
$ LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.CollatzCyclesOQ03
...
✔ [3059/3059] Built Proofs.CollatzCyclesOQ03 (3.7s)
Build completed successfully (3059 jobs).
```

**Gallery (S3)** — `src/data/proofs/collatz-cycles-oq-03/`:

- `meta.json`: status `verified`, badge `original`, `lineCount: 80`, `theoremCount: 5`, `axiomCount: 0`, `sorries: 0`. Full overview, sections, crossReferences (parent + OQ-04).
- `index.ts`: standard glob-discovered loader matching the `collatz-cycles-oq-04` pattern.
- `annotations.json`: 5 annotations, one per theorem.

**Research scaffold (S1 OBSERVE)** — `research/problems/collatz-cycles-oq-03/` with `problem.md`, `knowledge.md`, `state.md`; `src/data/research/problems/collatz-cycles-oq-03.json` (status `completed`).

## Honesty calibration

- **Difficulty**: trivial (2 omega steps after one rewrite).
- **Novelty**: zero — standard textbook parity (`3·odd + 1 = even`).
- **Gallery value**: low-medium — fills an obvious explicit-statement gap. The parent's Part VI halving constraint `2^M > 3^j` implicitly subsumes `cycle_contains_even` (as the `M = 0` corner case), but never extracts it as a stand-alone lemma. This PR provides the explicit elementary form.
- Does **not** touch the Collatz conjecture itself or the deeper halving-constraint machinery — that lives in `collatz-cycles-oq-04`.

## Status

**Outcome**: completed. OQ closed in a single PR; no follow-up work required for this slug. Optional follow-up (deferred): edit `CollatzCycles.lean` Part VIII summary docstring to cross-link the new corollary (5-line edit).

🤖 Generated by researcher-5