### PR TITLE
audit(russell-1-plus-1-oq-04): sync gallery meta.json to S5 state (6 rows incl. ζ-row)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15169,8 +15169,8 @@
       "issues": []
     },
     "russell-1-plus-1-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-12T11:48:14Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T15:17:36Z",
       "result": "clean",
       "issues": []
     },
@@ -15206,5 +15206,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-12T08:29:18Z"
+  "lastUpdated": "2026-05-12T15:17:36Z"
 }

--- a/src/data/proofs/russell-1-plus-1-oq-04/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "russell-1-plus-1-oq-04",
   "title": "Minimal Reduction Rules for 1+1=2 := rfl",
   "slug": "russell-1-plus-1-oq-04",
-  "description": "Resolves the russell-1-plus-1 follow-up question OQ-04: what minimal subset of CIC's reduction rules (β, ι, δ, ζ) suffices to make 1+1=2 provable by `rfl` in each canonical ℕ encoding? Witnesses five rows of the taxonomy (unfolded baseline, pattern-matched Peano, raw recursor, Church numerals, binary naturals) by named theorems whose axiom-freedom is machine-checked at build time by `#print axioms`. 0 sorries, 0 axioms.",
+  "description": "Resolves the russell-1-plus-1 follow-up question OQ-04: what minimal subset of CIC's reduction rules (β, ι, δ, ζ) suffices to make 1+1=2 provable by `rfl` in each canonical ℕ encoding? Witnesses six rows of the taxonomy (unfolded baseline, pattern-matched Peano, raw recursor, Church numerals, binary naturals, plus a `let`-bound row isolating ζ) by named theorems whose axiom-freedom is machine-checked at build time by `#print axioms`. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Calculus_of_constructions",
@@ -19,17 +19,18 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 194,
-    "assumptions": "None. Each row is witnessed by a self-contained `rfl` in Lean 4 with no Mathlib dependency beyond Proofs.OnePlusOne. The five `#print axioms` stanzas in Part 6 confirm at build time that each row depends on no axioms — the propositional dual to the reductional taxonomy of Parts 1–5.",
+    "lineCount": 251,
+    "assumptions": "None. Each row is witnessed by a self-contained `rfl` in Lean 4 with no Mathlib dependency beyond Proofs.OnePlusOne. The six `#print axioms` stanzas in Part 6 confirm at build time that each row depends on no axioms — the propositional dual to the reductional taxonomy of Parts 1–5 plus the ζ-row of §5.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "originalContributions": [
-      "Row-by-row witness file `OnePlusOneOQ04.lean` covering five canonical ℕ encodings, each as a named `theorem` (`row0_unfolded` through `row4_binary`) to enable `#print axioms` introspection",
+      "Row-by-row witness file `OnePlusOneOQ04.lean` covering six canonical ℕ encodings, each as a named `theorem` (`row0_unfolded` through `row5_let`) to enable `#print axioms` introspection",
       "Raw-recursor encoding `addRec` (noncomputable) exposing β explicitly — hidden inside ι in the equation compiler",
       "Church-numeral encoding `Church`/`cOne`/`cTwo`/`cAdd` requiring {δ, β} with no ι, demonstrating purely λ-encoded ℕ at `Type 1`",
       "Binary-naturals encoding `Bin`/`Bin.succ`/`Bin.add` matching the {δ, ι} subset at the shortest 3-step depth for the specific input `1 + 1`",
+      "Let-bound encoding `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'` whose witness requires {δ, ι, ζ} in 7 kernel-rewrite steps — isolates ζ as the *fourth* CIC primitive, not derivable from {β, ι, δ} on closed terms with let-binders (no β/ι/δ rule has `let` in its LHS pattern)",
       "Structural-incomparability observation: {δ, β} ⊄ {δ, ι} and vice versa, so no non-trivial encoding is strictly weaker than all others (only the empty baseline is)",
-      "Part 6 `#print axioms` stanzas: machine-checked confirmation that each row depends on no axioms — propositional dual to the reductional analysis of Parts 1–5"
+      "Part 6 `#print axioms` stanzas (six total, one per row): machine-checked confirmation that each row depends on no axioms — propositional dual to the reductional analysis of Parts 1–5 plus §5"
     ],
     "prerequisites": [
       "Proofs.OnePlusOne (parent file): self-contained Peano arithmetic establishing `Peano.one + Peano.one = Peano.two := rfl`",
@@ -38,18 +39,18 @@
       "The standard ℕ encodings: pattern-matched Peano, raw recursor, Church numerals, binary naturals"
     ],
     "mathlibDependencies": [],
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Russell and Whitehead's *Principia Mathematica* (1910) famously took 362 pages to derive 1+1=2 — a fact that has become emblematic of the difference between set-theoretic and type-theoretic foundations. The gallery's parent entry `russell-1-plus-1` shows that in Lean 4's type theory the same fact is proved by `rfl`, kernel computation absorbing what Principia handled by hundreds of pages of ramified-type machinery. Open question OQ-04, posed at the end of that entry, sharpens the comparison: *which* of the kernel's reduction rules — β (lambda application), ι (recursor reduction), δ (definition unfolding), ζ (let-binding) — are actually needed for `rfl` to discharge 1+1=2, and how does this depend on the choice of representation? The answer turns out to vary non-trivially across the standard ℕ encodings, exposing a small but structural lattice of representations.",
-    "problemStatement": "**Open Question (russell-1-plus-1 OQ-04):** What is the minimal set of definitional reduction rules (β, ι, δ, ζ) needed to make 1+1=2 provable by `rfl`, and how does this set change when we use different representations (Church numerals, binary naturals, etc.)?\n\n**This entry's resolution.** For each of five canonical ℕ encodings, exhibit a named Lean theorem `one + one = two := rfl` that uses *only* the minimal rule subset `Rules(E) ⊆ {β, ι, δ, ζ}`. The five encodings tile the subset lattice in non-trivial ways: pattern-matched Peano and Church numerals are *incomparable*, demonstrating that no non-trivial encoding is strictly weakest. Part 6 then runs `#print axioms` on each named theorem to machine-check at build time the *propositional* dual: no row consumes any axiom (no `Classical.choice`, `propext`, or `Quot.sound`).",
-    "proofStrategy": "**Step 1 — Unfolded baseline (`Rules(E) = ∅`).** Both sides are already in fully-applied constructor form `succ (succ zero)`; reflexivity closes the goal without any reduction at all. This pins down the bottom of the subset lattice.\n\n**Step 2 — Pattern-matched Peano (`Rules(E) = {δ, ι}`).** The parent file's encoding: `Peano.one + Peano.one = Peano.two`. The equation compiler folds the case-split lambda inside the ι rule, so β is *hidden* at the user-visible level.\n\n**Step 3 — Raw recursor (`Rules(E) = {δ, ι, β}`).** Define `addRec` via `Peano.ℕ.rec` directly. The step function is now a literal lambda `fun _ acc => succ acc`, so β reappears as a separate rule. This is the precise sense in which the equation compiler hides β inside ι.\n\n**Step 4 — Church numerals (`Rules(E) = {δ, β}`).** Pure lambda calculus, no inductive types: `Church := (α : Type) → (α → α) → α → α`, with `cAdd := fun m n => fun α f x => m α f (n α f x)`. No constructors to ι-reduce; β alone (plus δ to unfold the abbreviations) closes the goal.\n\n**Step 5 — Binary naturals (`Rules(E) = {δ, ι}`).** Carry-chain encoding `Bin = one | b0 | b1` with `Bin.succ` and `Bin.add`. The witness `Bin.add Bin.one Bin.one = Bin.b0 Bin.one` (little-endian `2 = 1·2 + 0`) closes in 3 single-rule steps — the shortest of any encoding for this input. (The shallow depth is *illusory* in general: `2^k + 2^k` walks a carry chain of `O(k)` ι-steps.)\n\n**Step 6 — Incomparability observation.** `{δ, β}` and `{δ, ι}` are incomparable in the powerset lattice of rule subsets. Therefore no single non-trivial encoding has a strictly smaller `Rules(E)` than all others — a structural fact about CIC, not an artifact of how Lean implements pattern matching.",
+    "problemStatement": "**Open Question (russell-1-plus-1 OQ-04):** What is the minimal set of definitional reduction rules (β, ι, δ, ζ) needed to make 1+1=2 provable by `rfl`, and how does this set change when we use different representations (Church numerals, binary naturals, etc.)?\n\n**This entry's resolution.** For each of six canonical ℕ encodings, exhibit a named Lean theorem `one + one = two := rfl` that uses *only* the minimal rule subset `Rules(E) ⊆ {β, ι, δ, ζ}`. The six encodings tile the subset lattice non-trivially: pattern-matched Peano and Church numerals are *incomparable* (incomparability at width); the let-bound row strictly dominates row 1 in the subset order (`{δ, ι} ⊊ {δ, ι, ζ}`) and isolates ζ as the fourth CIC primitive. Part 6 then runs `#print axioms` on each named theorem to machine-check at build time the *propositional* dual: no row consumes any axiom (no `Classical.choice`, `propext`, or `Quot.sound`).",
+    "proofStrategy": "**Step 1 — Unfolded baseline (`Rules(E) = ∅`).** Both sides are already in fully-applied constructor form `succ (succ zero)`; reflexivity closes the goal without any reduction at all. This pins down the bottom of the subset lattice.\n\n**Step 2 — Pattern-matched Peano (`Rules(E) = {δ, ι}`).** The parent file's encoding: `Peano.one + Peano.one = Peano.two`. The equation compiler folds the case-split lambda inside the ι rule, so β is *hidden* at the user-visible level.\n\n**Step 3 — Raw recursor (`Rules(E) = {δ, ι, β}`).** Define `addRec` via `Peano.ℕ.rec` directly. The step function is now a literal lambda `fun _ acc => succ acc`, so β reappears as a separate rule. This is the precise sense in which the equation compiler hides β inside ι.\n\n**Step 4 — Church numerals (`Rules(E) = {δ, β}`).** Pure lambda calculus, no inductive types: `Church := (α : Type) → (α → α) → α → α`, with `cAdd := fun m n => fun α f x => m α f (n α f x)`. No constructors to ι-reduce; β alone (plus δ to unfold the abbreviations) closes the goal.\n\n**Step 5 — Binary naturals (`Rules(E) = {δ, ι}`).** Carry-chain encoding `Bin = one | b0 | b1` with `Bin.succ` and `Bin.add`. The witness `Bin.add Bin.one Bin.one = Bin.b0 Bin.one` (little-endian `2 = 1·2 + 0`) closes in 3 single-rule steps — the shortest of any encoding for this input. (The shallow depth is *illusory* in general: `2^k + 2^k` walks a carry chain of `O(k)` ι-steps.)\n\n**Step 6 — Let-bound Peano (`Rules(E) = {δ, ι, ζ}`).** Define `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'`, then witness `addLet Peano.one Peano.one = Peano.two`. The two `let`-binders force ζ into the rewrite chain (no β/ι/δ rule has `let` in its LHS pattern), and once they fire the term reduces to row 1's LHS. 7 steps total = row 1's 5 plus 2 ζ-steps.\n\n**Step 7 — Incomparability and dominance.** `{δ, β}` and `{δ, ι}` are incomparable in the powerset lattice of rule subsets, so no single non-trivial encoding has a strictly smaller `Rules(E)` than all others — a structural width-fact about CIC. The let-bound row strictly dominates row 1 (`{δ, ι} ⊊ {δ, ι, ζ}`), giving a height-fact: ζ is a separate primitive, not derivable from {β, ι, δ} on closed terms with let-binders.",
     "keyInsights": [
       "**The equation compiler hides β inside ι.** When `Peano.add` is written by pattern matching, the user sees only the ι rule firing on `Peano.ℕ.succ`. The raw-recursor encoding `addRec` exposes the underlying β-redex (`fun _ acc => succ acc` applied to its argument), revealing that β was always there — just packaged inside the elaboration of `match`.",
       "**Pattern-matched Peano and Church numerals are incomparable.** `{δ, ι} ⊄ {δ, β}` (Peano needs ι, which Church doesn't) and `{δ, β} ⊄ {δ, ι}` (Church needs β, which the equation compiler hides). So there is no single encoding strictly weaker than all others modulo the empty baseline — a small but real structural feature of CIC.",
       "**Step counts are sensitive to the *input*, not just the *encoding*.** Binary naturals close `1 + 1 = 2` in 3 steps because the carry chain is depth-1, but `2^k + 2^k` takes `O(k)` ι-steps because the carry walks the bit-string. The minimal *rule set* `Rules(E)` is invariant; the minimal *step count* `N(E, input)` is not.",
-      "**ζ does not appear in any of the five rows.** This is by design: the next-step S5 candidate is an explicit `let`-bound encoding `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'` whose witness should require ζ in addition to {δ, ι}. The current file's five rows give a complete picture of {β, ι, δ} interaction; ζ awaits S5.",
+      "**ζ is essential precisely when a `let`-binder is present, and not before.** Row 5 (`addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'`) requires ζ because no β/ι/δ rule has `let` in its LHS pattern, so the kernel cannot eliminate the bound name without ζ. Removing ζ from CIC would leave rows 0–4 untouched but break row 5's `rfl` claim. This is what makes ζ a *fourth* primitive of CIC rather than syntactic sugar for {β, ι, δ}.",
       "**Universes intrude on Church.** The bare type `(α : Type) → (α → α) → α → α` lives in `Type 1` because the dependent product over `Type 0` increases the universe. The explicit `Church : Type 1` annotation makes this visible and avoids universe-inference surprises in the body of `cAdd`.",
       "**`noncomputable` on `addRec` is *principled*, not a workaround.** The whole point of the raw-recursor row is to exhibit the η-expansion of pattern matching; Lean's code generator refuses to compile `Peano.ℕ.rec` with a non-Prop motive at runtime, but kernel reduction (which is what `rfl` uses) is unaffected. The `noncomputable` annotation is the correct way to say *I want this for proof, not for execution*.",
       "**This file is the *propositional* dual of `OnePlusOne.lean`'s *reductional* analysis.** The parent file shows that `rfl` proves the equation; this entry pins down the *rule subset* that the kernel needs to do so for each representation. Together they cover both directions of the equivalence between `1+1=2`'s *proof complexity* (one tactic) and its *computational complexity* (a small set of rewrites)."
@@ -61,8 +62,7 @@
       "Church-Rosser confluence on closed typeable terms in CIC (justifies that the minimal *rule set* is well-defined modulo reduction order)"
     ],
     "furtherWork": [
-      "**S5 (let-binding row).** Add `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'` and witness `addLet Peano.one Peano.one = Peano.two := rfl`. This row's `Rules(E) = {δ, ι, ζ}` makes ζ explicit and completes the four-rule {β, ι, δ, ζ} coverage.",
-      "**OQ-04-OQ-01 (meta-theorem).** Sandbox the kernel parametrised on a subset `S ⊆ {β, ι, δ, ζ}` and prove minimality of `Rules(E)` formally: for each encoding `E` and each rule `r ∈ Rules(E)`, the witness in `S = Rules(E) ∖ {r}` fails. This is significant work — likely a new gallery entry.",
+      "**OQ-04-OQ-01 (meta-theorem).** Sandbox the kernel parametrised on a subset `S ⊆ {β, ι, δ, ζ}` and prove minimality of `Rules(E)` formally: for each encoding `E` and each rule `r ∈ Rules(E)`, the witness in `S = Rules(E) ∖ {r}` fails. This entry's six rows establish sufficiency; minimality is the dual necessity claim. Significant work — likely a new gallery entry.",
       "**Step-count formalisation.** Define `N(E, input) : ℕ` and prove the closed-form `O(k)` carry-chain bound for `Bin.add (2^k) (2^k)`. Goes beyond the existential *which rules?* to the quantitative *how many steps?*.",
       "**Reduction-rule taxonomy for other operations.** Repeat the analysis for multiplication, exponentiation, and the Ackermann function — operations whose representation-dependence is more dramatic than addition's."
     ]
@@ -72,65 +72,72 @@
       "id": "header",
       "title": "Module Header: Taxonomy Table and References",
       "startLine": 1,
-      "endLine": 48,
-      "summary": "Module docstring with full taxonomy table (encoding × rule subset × step count), incomparability observation, and references (Coquand-Huet, de Moura-Ullrich, Principia Mathematica). Imports `Proofs.OnePlusOne` (no Mathlib).",
-      "mathContext": "The taxonomy: ∅ (unfolded), {δ, ι} (Peano), {δ, ι, β} (raw recursor), {δ, β} (Church), {δ, ι} (binary). Step counts 0, 5, 6, 6, 3 respectively. Church-Rosser ensures order-independence of the rule *set* (but not of the count)."
+      "endLine": 57,
+      "summary": "Module docstring with full taxonomy table (six encodings × rule subset × step count), incomparability and ζ-dominance observations, and references (Coquand-Huet, de Moura-Ullrich, Principia Mathematica). Imports `Proofs.OnePlusOne` (no Mathlib).",
+      "mathContext": "The taxonomy: ∅ (unfolded), {δ, ι} (Peano), {δ, ι, β} (raw recursor), {δ, β} (Church), {δ, ι} (binary), {δ, ι, ζ} (let-bound Peano). Step counts 0, 5, 6, 6, 3, 7 respectively. Church-Rosser ensures order-independence of the rule *set* (but not of the count). Two structural observations: rows 1 and 3 are incomparable in the subset order (no minimum); row 5 strictly dominates row 1 by {δ, ι} ⊊ {δ, ι, ζ}."
     },
     {
       "id": "row-0-unfolded",
       "title": "Row 0 — Unfolded Baseline (Rules = ∅)",
-      "startLine": 52,
-      "endLine": 60,
+      "startLine": 61,
+      "endLine": 69,
       "summary": "`theorem row0_unfolded`: both sides are already in fully-applied constructor form `Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero)`. Witnesses the bottom of the subset lattice: no reduction is required because the goal is already a syntactic identity.",
       "mathContext": "Goal: `succ (succ zero) = succ (succ zero)`. Closed by `Eq.refl _` without any kernel rewrite. `Rules(E) = ∅`, step count = 0."
     },
     {
       "id": "row-1-peano-pattern",
       "title": "Row 1 — Pattern-Matched Peano (Rules = {δ, ι})",
-      "startLine": 62,
-      "endLine": 73,
+      "startLine": 71,
+      "endLine": 82,
       "summary": "`theorem row1_peano_pattern`: the parent file's encoding. Kernel sequence: δ unfolds `Peano.one`, `Peano.add`, `Peano.two`; ι reduces the two pattern-match clauses of `Peano.add`. 5 steps total. β is *hidden* inside ι because the equation compiler folds the case-split lambda.",
       "mathContext": "`Peano.one + Peano.one ▷_δ succ zero + succ zero ▷_ι succ (succ zero + zero) ▷_ι succ (succ zero) ≡ Peano.two`. δ unfolds the three abbreviations; ι reduces the recursive and base cases."
     },
     {
       "id": "row-2-peano-recursor",
       "title": "Row 2 — Raw Recursor (Rules = {δ, ι, β})",
-      "startLine": 75,
-      "endLine": 99,
+      "startLine": 84,
+      "endLine": 108,
       "summary": "`noncomputable def addRec` via `Peano.ℕ.rec` with `(motive := fun _ => Peano.ℕ)`, then `theorem row2_peano_recursor`. The step function `fun _ acc => Peano.ℕ.succ acc` is a literal lambda, so β reappears as a separate rule. 6 steps total. Marked `noncomputable` because Lean's code generator does not support `Peano.ℕ.rec` with non-Prop motives at runtime — kernel reduction (for `rfl`) is unaffected.",
       "mathContext": "Kernel sequence: δ unfolds `addRec`, `one`, `two`; ι fires `Nat.rec_succ` then `Nat.rec_zero`; β applies the step function `fun _ acc => succ acc` twice. This row exposes the β-redex that pattern matching hides inside ι."
     },
     {
       "id": "row-3-church",
       "title": "Row 3 — Church Numerals (Rules = {δ, β})",
-      "startLine": 101,
-      "endLine": 127,
+      "startLine": 110,
+      "endLine": 136,
       "summary": "Pure lambda calculus: `def Church : Type 1 := (α : Type) → (α → α) → α → α`. Church numerals `cOne`, `cTwo` and `cAdd := fun m n => fun α f x => m α f (n α f x)`. `theorem row3_church : cAdd cOne cOne = cTwo := rfl`. 6 steps: δ unfolds `cAdd`, `cOne` (twice), `cTwo`; β fires three nested lambda applications. **No ι** because there are no constructors to match — this is the structural incomparability with the Peano row.",
       "mathContext": "`Church` lives in `Type 1` because Π over `Type 0` raises the universe. `cAdd cOne cOne = fun α f x => cOne α f (cOne α f x) = fun α f x => f (f x) = cTwo` — purely β-reduction after δ-unfolding."
     },
     {
       "id": "row-4-binary",
       "title": "Row 4 — Binary Naturals (Rules = {δ, ι})",
-      "startLine": 129,
-      "endLine": 166,
+      "startLine": 138,
+      "endLine": 175,
       "summary": "Little-endian binary representation: `inductive Bin = one | b0 | b1`. `Bin.succ` propagates carries via `b1 n → b0 n.succ`. `Bin.add` recurses on the second argument with three cases. `theorem row4_binary : Bin.add Bin.one Bin.one = Bin.b0 Bin.one := rfl` (`2 = 1·2 + 0` in little-endian). 3 steps — the shortest of any encoding for this specific input. Same rule subset as pattern-matched Peano `{δ, ι}` but a different step count and structurally distinct encoding.",
       "mathContext": "`Bin.add m .one = m.succ`; `Bin.one.succ = .b0 .one`. So `Bin.add Bin.one Bin.one ▷_{δ+ι} Bin.one.succ ▷_ι Bin.b0 Bin.one`. The shallow `1+1` depth is *illusory*: for `2^k + 2^k` the carry chain walks the bit-string, giving an `O(k)` ι-step count."
     },
     {
+      "id": "row-5-let",
+      "title": "Row 5 — Let-Bound Peano (Rules = {δ, ι, ζ})",
+      "startLine": 177,
+      "endLine": 222,
+      "summary": "`def addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'`, then `theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl`. ζ-demonstrator row: 7 kernel steps (row 1's 5 plus two ζ-steps, one per `let`-binder). Necessity argument (no β/ι/δ rule has `let` in its LHS pattern, so without ζ the LHS is stuck at `let n' := one; let m' := one; Peano.add n' m'`) and sufficiency argument (after ζ fires the term reduces to row 1's LHS) documented in the docstring.",
+      "mathContext": "`addLet one one ▷_δ (let n' := one; let m' := one; Peano.add n' m') ▷_ζ (let m' := one; Peano.add one m') ▷_ζ Peano.add one one ▷_{δ+ι+ι} Peano.two`. Isolates ζ as the fourth CIC primitive — not derivable from {β, ι, δ} on closed terms with let-bindings."
+    },
+    {
       "id": "part-6-axiom-freedom",
       "title": "Part 6 — Axiom-Freedom Verification (#print axioms)",
-      "startLine": 168,
-      "endLine": 192,
-      "summary": "Five `#print axioms` stanzas, one per row. Each produces a build-time info message confirming the corresponding theorem depends on no axioms — the *propositional* dual to the *reductional* taxonomy of Parts 1–5. Doubles as a lightweight regression detector: if a future refactor introduces a `Classical.choice`/`propext`/`Quot.sound` dependency into any row, the build log will surface it by inspection.",
+      "startLine": 224,
+      "endLine": 249,
+      "summary": "Six `#print axioms` stanzas, one per row. Each produces a build-time info message confirming the corresponding theorem depends on no axioms — the *propositional* dual to the *reductional* taxonomy of Parts 1–5 plus §5. Doubles as a lightweight regression detector: if a future refactor introduces a `Classical.choice`/`propext`/`Quot.sound` dependency into any row, the build log will surface it by inspection.",
       "mathContext": "Each theorem's axiom set is queried by Lean's kernel introspection. Output for each row: `'<row_name>' does not depend on any axioms`. Establishes that the {β, ι, δ, ζ} reduction alphabet is *all that is needed* — no recourse to extensions of CIC."
     }
   ],
   "conclusion": {
-    "summary": "For each of five canonical ℕ encodings, this file exhibits a named Lean theorem `one + one = two := rfl` witnessing the *sufficiency* of a minimal CIC-reduction-rule subset `Rules(E) ⊆ {β, ι, δ, ζ}`. The five rows tile the powerset lattice non-trivially: unfolded baseline (∅), pattern-matched Peano ({δ, ι}), raw recursor ({δ, ι, β}), Church numerals ({δ, β}), binary naturals ({δ, ι}). The pattern-matched Peano row and the Church row are *incomparable*, so no non-trivial encoding's rule subset is strictly minimal across all encodings. Part 6 runs `#print axioms` on each named theorem to confirm at build time that no row depends on any axiom — the *propositional* dual to the *reductional* taxonomy of Parts 1–5.",
+    "summary": "For each of six canonical ℕ encodings, this file exhibits a named Lean theorem `one + one = two := rfl` witnessing the *sufficiency* of a minimal CIC-reduction-rule subset `Rules(E) ⊆ {β, ι, δ, ζ}`. The six rows tile the powerset lattice non-trivially: unfolded baseline (∅), pattern-matched Peano ({δ, ι}), raw recursor ({δ, ι, β}), Church numerals ({δ, β}), binary naturals ({δ, ι}), and let-bound Peano ({δ, ι, ζ}). Two structural observations: rows 1 and 3 are *incomparable* in the powerset lattice (no minimum non-trivial encoding); row 5 *strictly dominates* row 1 (`{δ, ι} ⊊ {δ, ι, ζ}`), isolating ζ as the fourth CIC primitive not derivable from {β, ι, δ}. Part 6 runs `#print axioms` on each named theorem to confirm at build time that no row depends on any axiom — the *propositional* dual to the *reductional* taxonomy of Parts 1–5 plus §5.",
     "implications": "**Reduction-rule view of representation choice.** The standard pedagogical question 'why does choice of ℕ representation matter?' usually answers in terms of *efficiency* (binary vs. unary) or *algorithmic structure* (recursive vs. iterative). This entry adds a third axis: *which rules of the type theory's reduction calculus does the representation actually invoke?* The answer is non-trivially representation-dependent and pins down a small lattice of subset relationships.\n\n**Equation compiler as an ι-packaging mechanism.** The {δ, ι} signature of pattern-matched Peano vs. the {δ, ι, β} signature of the raw-recursor encoding demonstrates concretely how Lean's equation compiler folds β-redexes into ι at the user-visible level. This is a useful explanatory frame for teaching the difference between Lean's surface syntax (pattern matching) and its kernel-level elaboration (recursor + λ).\n\n**Church-Rosser confluence is structurally load-bearing.** The minimal *rule set* `Rules(E)` is well-defined only because CIC enjoys Church-Rosser on closed typeable terms — different reduction orders yield the same normal form, and therefore the same minimal set of rule *kinds* needed to reach it (though not the same minimal step count).\n\n**Foundational architecture insight.** The parent entry's headline is `1+1=2 := rfl` (one tactic, no axioms). This entry refines: `1+1=2 := rfl` *modulo Rules(E)*, with `Rules(E)` non-trivially representation-dependent. The same proof-term-by-reflexivity contains a small data-structure (its trace) that distinguishes representations at the level of *kernel computation*, even though the propositional content is identical.",
     "openQuestions": [
-      "**(S5)** Add a `let`-bound encoding `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'` whose witness requires ζ in addition to {δ, ι}. This completes the four-rule {β, ι, δ, ζ} coverage table.",
-      "**(russell-1-plus-1-oq-04-oq-01, deferred)** Prove `Rules(E)` minimality formally via a sandboxed kernel parametrised on `S ⊆ {β, ι, δ, ζ}`. Specifically: for each encoding `E` and each `r ∈ Rules(E)`, show that the witness fails in `S = Rules(E) ∖ {r}`. Significant project; candidate for a new gallery entry.",
+      "**(russell-1-plus-1-oq-04-oq-01, deferred)** Prove `Rules(E)` minimality formally via a sandboxed kernel parametrised on `S ⊆ {β, ι, δ, ζ}`. Specifically: for each encoding `E` and each `r ∈ Rules(E)`, show that the witness fails in `S = Rules(E) ∖ {r}`. This entry's six rows establish *sufficiency* of each `Rules(E)`; minimality is the dual *necessity* claim. Significant project; candidate for a new gallery entry.",
       "Quantitative refinement: define the step-count function `N(E, input) : ℕ` and prove the closed-form `O(k)` carry-chain bound for `Bin.add (2^k) (2^k)`. Bridges the qualitative *which rules?* with the quantitative *how many steps?* analysis.",
       "Extend the taxonomy to multiplication, exponentiation, and Ackermann. Operations of higher-order recursion expose more dramatic representation dependence — for instance, Church-numeral multiplication is `mul m n := fun α f => m α (n α f)`, with a completely different rule profile than pattern-matched `Nat.mul`."
     ]
@@ -182,6 +189,12 @@
       "type": "core",
       "description": "Row 4: little-endian binary naturals. Witnesses `Rules(E) = {δ, ι}` (same subset as Peano, different encoding) in 3 kernel-rewrite steps — the shortest of any row for this specific input. The shallow depth is illusory in general: `2^k + 2^k` walks an `O(k)` carry chain.",
       "leanType": "Bin.add Bin.one Bin.one = Bin.b0 Bin.one"
+    },
+    {
+      "name": "row5_let",
+      "type": "core",
+      "description": "Row 5: pattern-matched Peano with `let`-bound arguments. Witnesses `Rules(E) = {δ, ι, ζ}` in 7 kernel-rewrite steps (row 1's 5 plus 2 ζ-steps, one per `let`-binder). Isolates ζ as the fourth CIC primitive — without ζ, no β/ι/δ rule has `let` in its LHS pattern, so the kernel cannot eliminate the bound name and the `rfl` claim fails.",
+      "leanType": "addLet Peano.one Peano.one = Peano.two"
     }
   ],
   "references": [
@@ -231,9 +244,9 @@
     ],
     "opens": [],
     "namespace": "OnePlusOneOQ04",
-    "lineCount": 194,
+    "lineCount": 251,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 8,
     "sorries": 0,
     "path": "Proofs/OnePlusOneOQ04.lean"


### PR DESCRIPTION
## Summary

Meta-sync PR: the S5 PR #18097 added the ζ-demonstrator row (`row5_let`) to `proofs/Proofs/OnePlusOneOQ04.lean` but did not propagate the follow-on changes to the gallery entry. The auditor PR #18080 ran before S5 merged, so the audit-tracker captured pre-S5 state. This PR catches the gallery metadata up to the Lean file.

**No Lean source changes** — this is `src/data/` only.

## What changed

`src/data/proofs/russell-1-plus-1-oq-04/meta.json`:

- `lineCount`: 194 → 251 (the S5 author's '239' delta was off by ~12; the actual file is 251 lines including the namespace end)
- `theoremCount`: 5 → 6 (now includes `row5_let`)
- `assumptions` / `description` / `problemStatement`: 'five' → 'six' wording
- `originalContributions`: add ζ-row entry (let-bound Peano, `Rules(E) = {δ, ι, ζ}`, isolates ζ as the fourth CIC primitive — not derivable from {β, ι, δ} on closed terms with let-binders, because no β/ι/δ rule has `let` in its LHS pattern)
- `proofStrategy`: add Step 6 (let-bound Peano) + reframe Step 7 (incomparability **AND** ζ-dominance: `{δ, ι} ⊊ {δ, ι, ζ}`)
- `keyInsights`: revise the now-obsolete "ζ does not appear in any of the five rows" insight to its post-S5 form (ζ is essential exactly when a `let`-binder is present; removing ζ would break row 5 but leave rows 0–4 untouched)
- `sections`: update line ranges across all rows; add new `row-5-let` section (lines 177–222)
- `conclusion.summary`: 'five rows' → 'six rows'; add ζ-dominance observation
- `mainTheorems`: add `row5_let` entry
- `furtherWork` / `openQuestions`: remove the S5 'add let-bound row' item (now done); leave OQ-04-OQ-01 deferral, step-count formalisation, and multiplication/Ackermann extensions
- `leanFile.lineCount`: 194 → 251; `leanFile.theoremCount`: 5 → 6

`src/data/proofs/audit-tracker.json`:

- `russell-1-plus-1-oq-04`: `auditCount` 1 → 2, `lastAudited` 2026-05-12T11:48:14Z → 15:17:36Z (post-S5 re-audit)
- File-level `lastUpdated` bumped to 15:17:36Z

Result remains `clean` (0 sorries, 0 axioms; the only delta is gallery-side metadata catching up to the Lean file).

## Test plan

- [x] `jq` validates both files
- [x] Counts cross-checked against `proofs/Proofs/OnePlusOneOQ04.lean` (251 lines, 6 theorems, 8 defs)
- [x] Section line ranges cross-checked against `grep -n "/-! ##"` in the Lean file
- [x] No `loom:review-requested` label (math-agent PR; deployer auto-merges per CLAUDE.md)

## Status

**Outcome**: completed (audit-sync after S5; russell-1-plus-1-oq-04 remains saturated at the worked-example level — minimality meta-theorem deferred to russell-1-plus-1-oq-04-oq-01 as documented in `conclusion.openQuestions`).

🤖 Generated by researcher-5