### PR TITLE
fix(meta): sync leanFile lineCount/theoremCount drift in 3 entries

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/meta.json
@@ -156,9 +156,9 @@
       "Polynomial"
     ],
     "namespace": "InverseGaloisD4OQ03",
-    "lineCount": 153,
+    "lineCount": 235,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/InverseGaloisD4OQ03.lean",
     "sorries": 1

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 157,
+    "lineCount": 163,
     "theoremCount": 4,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
@@ -175,7 +175,7 @@
       "ProbabilityTheory",
       "Set"
     ],
-    "lineCount": 157,
+    "lineCount": 163,
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 4,

--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -157,10 +157,10 @@
   ],
   "leanFile": {
     "path": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "lineCount": 426,
+    "lineCount": 502,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 24,
+    "theoremCount": 27,
     "definitionCount": 21,
     "imports": [
       "import Mathlib.Data.Int.GCD",


### PR DESCRIPTION
## Fix

Sync stale `leanFile.{lineCount,theoremCount}` (and `meta.lineCount` where applicable) to match actual `proofs/Proofs/*.lean` source after recent research merges.

## Evidence

Drift table (origin/main @ `6457155f73e`):

| slug                                  | field       | before → after | source merge |
|---------------------------------------|-------------|----------------|--------------|
| `inverse-galois-d4-oq-03`             | `leanFile.lineCount`     | 153 → 235 | #18063 S3a + #18154 S3b |
| `inverse-galois-d4-oq-03`             | `leanFile.theoremCount`  | 4 → 11    | (same) |
| `picks-theorem-oq-01-oq-01-oq-01`     | `leanFile.lineCount`     | 426 → 502 | #18069 S2 + #18158 S3-prep |
| `picks-theorem-oq-01-oq-01-oq-01`     | `leanFile.theoremCount`  | 24 → 27   | (same) |
| `laws-of-large-numbers-oq-04-oq-03`   | `meta.lineCount`         | 157 → 163 | #18146 S7 docstring update |
| `laws-of-large-numbers-oq-04-oq-03`   | `leanFile.lineCount`     | 157 → 163 | (same) |

### Counting convention

Same as PR #18079 / #18120 / #18133 (mechanic baseline):

```
theorems: ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(theorem|lemma)\s+
defs:     ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(def|abbrev|opaque|structure|inductive|class)\s+
lines:    splitlines()  (== wc -l for newline-terminated files)
```

after stripping nested `/- -/` block comments and `--` line comments.

## Notes

- In `inverse-galois-d4-oq-03` and `picks-theorem-oq-01-oq-01-oq-01`, the `meta.*` sub-objects already had the current values; only the mirrored `leanFile.*` block was stale.
- In `laws-of-large-numbers-oq-04-oq-03`, both blocks shared the same stale lineCount (S7 PR docstring-updated this file +6 lines but didn't sync meta).
- `axiomCount`, `definitionCount`, `sorries`, `status`, `badge` unchanged — this PR avoids touching the open #18137 sorry/axiom-asymmetry conventions.
- No code changes, no schema changes, surgical number-only edits.

## Validation

- 3 JSON files validated via `python3 -c 'json.load(...)'`.
- Counts reproduced against current `proofs/Proofs/*.lean` source.

---
Automated fix by lean-mechanic agent.