### PR TITLE
fix(meta): sync count drift in 4 entries (lineCount/theoremCount)

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
@@ -25,7 +25,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 228,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "defCount": 3,
     "assumptions": "1 axiom (now in companion LawsOfLargeNumbersOQ04OQ03Bracketing.lean): bracketingGrid_exists — existence of an ε-bracketing grid of continuity points for any CDF on a probability measure on ℝ. Purely real-analytic content (reduces to Monotone.exists_increasing_continuity_seq, the natural Mathlib upstream target). The parent's monolithic axiom glivenko_cantelli_uniform was retired in S7; the proved variant lives in the companion as theorem glivenko_cantelli_uniform. The two integration facts thresholdIndicator_integrable and integral_thresholdIndicator_eq_cdf are fully proved. Pointwise convergence theorem is fully proved via SLLN.",
     "mathlibDependencies": [
@@ -214,7 +214,7 @@
     "namespace": "GlivenkoCantelli",
     "lineCount": 228,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 3,
     "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount}` and (where present) `leanFile.theoremCount` to match actual `proofs/Proofs/*.lean` sources after recent research merges. Metadata-only PR; no Lean code touched.

## Evidence

Drift table (origin/main @ `6457155f73e`):

| slug                                       | field                    | before → after |
|--------------------------------------------|--------------------------|----------------|
| `four-square-distribution-oq-01`           | `meta.lineCount`         | 2723 → 2732    |
| `angle-trisection-cos-20-gal-oq-01-oq-03`  | `meta.lineCount`         | 962 → 1089     |
| `angle-trisection-cos-20-gal-oq-01-oq-03`  | `meta.theoremCount`      | 55 → 57        |
| `cramers-rule-oq-01-oq-02-oq-01-oq-01`     | `meta.theoremCount`      | 6 → 8          |
| `cramers-rule-oq-01-oq-02-oq-01-oq-01`     | `leanFile.theoremCount`  | 6 → 8          |
| `laws-of-large-numbers-oq-04`              | `meta.theoremCount`      | 13 → 14        |
| `laws-of-large-numbers-oq-04`              | `leanFile.theoremCount`  | 13 → 14        |

### Driving merges

- `four-square-distribution-oq-01`: S18c-orbit-precursor (#18139, +9 lines)
- `angle-trisection-cos-20-gal-oq-01-oq-03`: S5/S6/S7/S8/S9 ACT cluster (latest #18103, +127 lines, +2 theorems)
- `cramers-rule-oq-01-oq-02-oq-01-oq-01`: S2 ACT (#18098, +2 theorems exposed via `qdetF_eq_qdet00`/`qdetF_eq_qdet11`/`qdetF_summary` in the docstring changelog)
- `laws-of-large-numbers-oq-04`: S7 — retire `glivenko_cantelli_uniform` axiom (#18146, +1 theorem in main exposing the proved variant from companion)

### Counting convention

Same as PR #18079 / #18120 / #18133 / #18170 (mechanic baseline):

```
theorems: ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(theorem|lemma)\s+
lines:    splitlines()  (== wc -l for newline-terminated files)
```

after stripping nested `/- -/` block comments and `--` line comments.

### Validation

- All 4 meta.json files revalidate as JSON (`python3 -m json.tool`).
- Surgical numeric edits only; no narrative or schema changes.
- Diff: 4 files, +7 -7 lines.

### Scope notes

- No overlap with open mechanic PRs #18079 (basel/minpoly/pascals/angle-OQ05/MVT), #18142 (binomial+shannon), #18145 (general-quartic/binomial/shannon), or #18170 (inverse-galois/picks/laws-OQ04-OQ03).
- `russell-1-plus-1-oq-04` was a candidate but is already covered by audit PR #18169.

---
Automated fix by lean-mechanic agent.