### PR TITLE
Enrich kepler-conjecture-oq-04: docstring annotation + 3 new cross-refs

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/annotations.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-docstring",
+    "proofId": "kepler-conjecture-oq-04",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Module docstring: three-flagship OQ-04 survey + S2 SCAFFOLD plan",
+    "content": "The module docstring is the narrative spine of OQ-04. It cites three flagship sub-questions of non-spherical packing in ℝ³ — (i) tetrahedra (Chen–Engel–Glotzer 2010), (ii) ellipsoids (Donev–Stillinger–Chaikin–Torquato 2004 and Bezdek–Kuperberg 2007), (iii) Ulam's 1972 conjecture — and then commits to a single concrete S2 deliverable: instantiate the parent file's `PackingDensity` type with the Chen–Engel–Glotzer rational constant `4000/4671` and prove three axiom-free `norm_num`-discharged bounds. The docstring also pre-records the entire S3 reduction chain — `4000/4671 > π/(3√2)` ⇔ `12000·√2 > 4671·π` ⇔ (squaring) `288 000 000 > 21 818 241·π²` ⇔ `π² < 13.2002` — so future agents can pick up exactly where S2 stops. The literary structure (parent-axiomatization recap → three-flagship survey → S2 goal → S3 deferred algebra) is a template worth replicating for other OQ entries that scaffold open problems.",
+    "mathContext": "Three density landmarks established: $\\delta_{\\text{FCC}} = \\frac{\\pi}{3\\sqrt{2}} \\approx 0.7405$ (parent, Hales–Flyspeck), $\\delta_{\\text{tet,CEG}} = \\frac{4000}{4671} \\approx 0.8564$ (this file's witness), and Ulam's conjectured ball-extremal lower bound $\\delta_K \\geq \\pi/(3\\sqrt{2})$ for centrally symmetric $K \\subset \\mathbb{R}^3$ (deferred). The S3 plan reduces a transcendental real-number comparison to a single rational $\\pi^2$ bound via squaring.",
+    "significance": "context",
+    "relatedConcepts": ["packing density landscape", "shape-specific bounds", "Chen-Engel-Glotzer 2010", "Donev-Stillinger-Chaikin-Torquato 2004", "Bezdek-Kuperberg 2007", "Ulam 1972 conjecture", "squaring reduction"],
+    "prerequisites": ["sphere packing intuition (FCC density)", "convex bodies in ℝ³", "abstract PackingDensity type from parent file"]
+  },
+  {
     "id": "ann-imports",
     "proofId": "kepler-conjecture-oq-04",
     "range": { "startLine": 53, "endLine": 58 },

--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -114,6 +114,21 @@
       "id": "kepler-conjecture",
       "title": "Kepler Conjecture: Sphere Packing (parent)",
       "relationship": "Parent gallery entry. Provides `fccDensity = π/(3√2)`, the `PackingDensity` structure, and the Kepler-Hales theorem axiomatization. OQ-04 instantiates `PackingDensity` with a concrete value strictly above `fccDensity`, formally demonstrating shape-specificity."
+    },
+    {
+      "id": "minkowski-fundamental-theorem",
+      "title": "Minkowski's Fundamental Theorem (lattice / convex body)",
+      "relationship": "Cousin result in lattice convex geometry. Minkowski's theorem gives a sufficient *volume* condition for a centrally symmetric convex body to contain a non-zero lattice point — a foundational tool for *lattice* packings. Bezdek–Kuperberg (2007), cited in this file's docstring, prove that the optimal *lattice* ellipsoid density in ℝ³ equals π/(3√2) exactly, leveraging the same lattice-symmetry framework. OQ-04 highlights the gap between lattice-constrained density (which preserves the FCC bound for ellipsoids) and unconstrained density (where Donev et al. achieve 0.7707 and Chen-Engel-Glotzer achieve 4000/4671 with dimer crystals)."
+    },
+    {
+      "id": "minkowski-theorem",
+      "title": "Minkowski's Theorem on Successive Minima",
+      "relationship": "Provides the asymptotic counting tool for *lattice* point estimates on convex bodies — the prerequisite framework for any density argument in the lattice-packing literature (Bezdek–Kuperberg 2007 belongs to this tradition). The strict separation between Minkowski-type lattice bounds and Chen–Engel–Glotzer's non-lattice 4000/4671 record motivates OQ-04's central observation: the FCC bound is rigid under lattice symmetry but breaks under non-lattice crystalline arrangements."
+    },
+    {
+      "id": "ehrhart-cube-proven",
+      "title": "Ehrhart Theory: Lattice-Point Counting in the Cube",
+      "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
     }
   ],
   "theoremCount": 3,


### PR DESCRIPTION
## Summary

First enrichment pass for `kepler-conjecture-oq-04` (passes=0, quality=0).

The entry already had deep meta.json content from researcher-11's S2 SCAFFOLD merge, so this pass focused on the two remaining quality gaps:

1. **Docstring section uncovered.** Added `ann-module-docstring` covering lines 1–51 — the entire three-flagship survey (tetrahedra, ellipsoids, Ulam) plus the pre-recorded S3 algebra (`4000/4671 > π/(3√2)` ⇔ `π² < 13.2002`). The Lean file's docstring is the narrative spine of OQ-04, and without an annotation it was invisible on the proof page.

2. **Cross-references thin.** Expanded `crossReferences` from 1 (parent `kepler-conjecture`) to 4 by adding:
   - `minkowski-fundamental-theorem` — the lattice-convex-body framework underpinning Bezdek-Kuperberg (2007)
   - `minkowski-theorem` — successive minima, foundational for lattice density bounds
   - `ehrhart-cube-proven` — Ehrhart counting as adjacent discrete-geometric machinery

Each new cross-reference is framed around the *lattice vs non-lattice density dichotomy* that motivates OQ-04 (Chen-Engel-Glotzer's 4000/4671 dimer breaks the FCC bound only because it is non-lattice).

## Verification

- `pnpm exec tsx scripts/annotations/build.ts` exits 0; no warnings for `kepler-conjecture-oq-04`
- JSON validated with `python3 -c "json.load(...)"` for both files
- Diff is clean against `origin/main` (only the two intended files, +27 lines)

## Axiom integrity

No changes to `axiomCount` (0), `status` (`axiomatized`), or `badge` (`axiom`). The file remains axiom-free; parent `Proofs/KeplerConjecture.lean` carries the Kepler-Hales / Thue / `fccDensity_lt_one` axiomatization, as already documented in `meta.assumptions`.