### PR TITLE
audit: sync tracker for 5 stale-detected entries (all clean on origin/main)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1000,10 +1000,10 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-12T14:42:35Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-12T15:32:16Z",
+      "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-01-oq-01": {
       "auditCount": 2,
@@ -1289,9 +1289,9 @@
       "result": "clean"
     },
     "brouwer-fixed-point-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:43Z",
+      "lastAudited": "2026-05-12T15:32:04Z",
       "result": "clean"
     },
     "brouwer-fixed-point-oq-01-oq-03": {
@@ -11536,9 +11536,9 @@
     },
     "general-quartic": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-12T14:42:43Z",
-      "result": "issues-found",
+      "auditCount": 5,
+      "lastAudited": "2026-05-12T15:32:17Z",
+      "result": "clean",
       "issues": []
     },
     "geometric-series": {
@@ -12976,10 +12976,10 @@
       "result": "clean"
     },
     "shannon-channel-coding-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-12T14:41:01Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-12T15:32:16Z",
+      "result": "clean"
     },
     "shannon-channel-coding-oq-02-oq-04": {
       "auditCount": 2,
@@ -12988,10 +12988,10 @@
       "result": "clean"
     },
     "shannon-channel-coding-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-12T14:42:13Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-12T15:32:17Z",
+      "result": "clean"
     },
     "shannon-channel-coding-oq-04": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

The `find-targets.ts` queue flagged 5 entries as having sorry/axiom mismatches, but all are stale-local-main false positives. Verified against `origin/main`:

| slug | meta.sorries (actual) | axiomCount (actual) | status |
|------|---|---|---|
| brouwer-fixed-point-oq-01-oq-02 | 0 / 0 | 2 / 2 | clean |
| shannon-channel-coding-oq-02-oq-01 | 4 / 4 (companion) | 0 / 0 | clean |
| binomial-theorem-oq-02-oq-01-oq-01 | 5 / 5 (4 main + 1 Aristotle) | 0 / 0 | clean |
| shannon-channel-coding-oq-03 | 4 / 4 (companions) | 0 / 0 | clean |
| general-quartic | 1 / 1 | 6 / 6 | clean |

All five were addressed by concurrent merges (#18132, #18133, #18136, #18148, etc.). This PR only updates `audit-tracker.json` — `result` flips from `issues-found` → `clean` and `auditCount` bumps, with fresh `lastAudited` timestamps.

## Test plan

- [x] Verified each meta.json on `origin/main` matches its Lean source (sorry + axiom counts)
- [x] Only `src/data/proofs/audit-tracker.json` is touched