### PR TITLE
research(roth-theorem-oq-02): S3 OBSERVE — Mathlib API audit corrects S2 S3-B plan (doc-only)

### DIFF
--- a/research/problems/roth-theorem-oq-02/knowledge.md
+++ b/research/problems/roth-theorem-oq-02/knowledge.md
@@ -53,6 +53,15 @@ Created: 2026-05-12. Phase: OBSERVE. Iteration: 1. Researcher: researcher-11.
   - Construction of large AP-free sets via lattice points on a sphere
   - `Behrend.box`, `Behrend.sphere`, `Behrend.map` injectivity
   - Lower bound `rothNumberNat n ≥ n · exp(-c · √log n)`
+  - **Explicit theorem (verified at pin `2df2f0150c275ad`)**:
+    `Behrend.roth_lower_bound : (N : ℝ) * exp (-4 * √(log N)) ≤ rothNumberNat N`
+    (unconditional, file line 482; constant `c = 4` hardcoded; small-`N`
+    case handled by `rothNumberNat.monotone` from `rothNumberNat 1 ≥ 1`).
+    The `4096 ≤ N` case is the substantive content via
+    `Behrend.roth_lower_bound_explicit` at line 420. **Note**: the prior
+    S2 state.md erroneously claimed "no explicit `rothNumberNat ≥ N · exp(-c · √log N)`
+    theorem is yet packaged in Mathlib"; this is corrected in the S3
+    state.md (audit verified by direct `git show 2df2f0150c275ad:…`).
 
 - `Mathlib/Combinatorics/Additive/Energy.lean`
   - `mulEnergy : Finset α → Finset α → ℕ` (additive/multiplicative energy)


### PR DESCRIPTION
## Summary

Doc-only correction iteration. The S2 ACT-A state.md (researcher-12, 2026-05-12) claimed Mathlib at the worktree's pin (`2df2f0150c275ad`) lacks an explicit `rothNumberNat ≥ N · exp(-c · √log N)` theorem, and proposed deriving it from `Behrend.map` injectivity. **This is incorrect.**

Audit at the pinned commit:

> `Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean` line 482:
> ```
> theorem roth_lower_bound :
>     (N : ℝ) * exp (-4 * √(log N)) ≤ rothNumberNat N
> ```

Unconditional on `N`. Constant `c = 4` hardcoded. Proof case-splits at `4096 ≤ N` (substantive via `roth_lower_bound_explicit`) and small `N` (monotonicity from trivial `rothNumberNat 1 ≥ 1`).

With the audit corrected, the S4-B consistency-check proof reduces to a pure asymptotic comparison:

  `exp (-4 √(log N)) ≤ 1 / (log N)^(1 + blasiConst)`

i.e. `(1 + blasiConst) · log(log N) ≤ 4 · √(log N)`, provable from Mathlib's `Real.isLittleO_log_rpow_atTop` family. No new infrastructure; ~60 lines Lean estimate stands.

## Changes

- `research/problems/roth-theorem-oq-02/state.md` — new **S3 OBSERVE** section + corrected **Next Action (S4)** with concrete proof recipe + new **Mathlib API audit** table; iteration 2 → 3.
- `research/problems/roth-theorem-oq-02/knowledge.md` — explicit theorem name, signature, file/line citation, audit-verification note.
- `src/data/research/problems/roth-theorem-oq-02.json` — iteration 2 → 3; refreshed `currentState.focus`, `nextAction` (S3-B → S4-B), `insights`, `nextSteps`.

## Test plan

- [x] No Lean source touched (`git diff origin/main --stat` shows only 3 doc/JSON files)
- [x] JSON validates (`python3 -c 'import json; json.load(...)'`)
- [x] Mathlib API verified by `git show 2df2f0150c275ad:Mathlib/.../Behrend.lean | grep -n "^theorem roth_lower_bound"` → line 482
- [ ] No build required (doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)