### PR TITLE
fix(meta): sync count drift in 8 entries (theoremCount/definitionCount/lineCount)

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries. All 3 previously sorry'd theorems proved: cyclic_when_coprime via commutator argument + order calculation, nonabelian_sylow_p_count by contradiction, pq_cyclic_classification by universal instantiation.",
     "lineCount": 387,
-    "theoremCount": 21,
+    "theoremCount": 13,
     "definitionCount": 3
   },
   "overview": {
@@ -118,7 +118,7 @@
     "namespace": "SylowPQ",
     "lineCount": 387,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 13,
     "sorryTheorems": 0,
     "definitionCount": 3,
     "path": "Proofs/SylowTheoremOQ01.lean",


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount,definitionCount}` and mirrored `leanFile.{lineCount,theoremCount,definitionCount}` to match actual `proofs/Proofs/*.lean` source after recent research merges.

## Evidence

Drift table (origin/main @ `6457155f73e`):

| slug                                  | field            | before → after |
|---------------------------------------|------------------|----------------|
| `sylow-theorems-oq-01`                | `theoremCount`     | 21 → 13        |
| `hilbert-10-oq-01-oq-02`              | `theoremCount`     | 83 → 77        |
| `hilbert-10-oq-01-oq-02`              | `definitionCount`  | 15 → 8         |
| `schauder-fixed-point-oq-03-oq-01`    | `theoremCount`     | 11 → 6         |
| `weak-goldbach`                       | `theoremCount`     | 26 → 25        |
| `weak-goldbach`                       | `definitionCount`  | 15 → 14        |
| `minpoly-charpoly-oq-03`              | `definitionCount`  | 3 → 1          |
| `fourier-series-oq-04-oq-01`          | `definitionCount`  | 5 → 1          |
| `angle-trisection-oq-05-oq-04`        | `definitionCount`  | 9 → 6          |
| `russell-1-plus-1-oq-04`              | `lineCount`        | 194 → 251      |
| `russell-1-plus-1-oq-04`              | `theoremCount`     | 5 → 6          |

Each slug updates **both** `meta.<field>` (the inner mathematical-metadata block) and the mirrored `leanFile.<field>` block consistently. Total: 22 line changes across 8 files.

### Counting convention

Same as PR #18133 / #18079 / #18170 mechanic baseline:

```
theorems: ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(theorem|lemma)\s+
defs:     ^\s*(@\[...]\s+)*(private|protected|noncomputable|partial|unsafe|scoped\s+)*(def|abbrev|opaque|structure|inductive|class)\s+
lines:    splitlines()  (== wc -l for newline-terminated files)
```

after stripping nested `/- -/` block comments and `--` line comments.

## Scope

- `sorries`, `axiomCount`, `status`, `badge` unchanged — no Axiom Integrity Policy impact, no contact with the #18137 sorry-counting conventions (already resolved by #18156/#18159).
- **No overlap** with open mechanic PRs:
  - #18170 (inverse-galois-d4, picks-theorem, laws-of-large-numbers-oq-04-oq-03)
  - #18171 (angle-trisection-cos-20-gal, cramers-rule, four-square, laws-of-large-numbers-oq-04)
  - #18142 / #18145 (binomial, shannon-OQ02OQ01, shannon-OQ03)
  - #18079 (basel, pascals-hexagon-oq-03)
- No code changes, no schema changes, surgical number-only edits.

## Validation

- 8 JSON files validated via `python3 -c 'json.load(...)'`
- Counts reproduced by scanning current `proofs/Proofs/*.lean` sources with the convention regex above

---
Automated fix by lean-mechanic agent.