### PR TITLE
Enrich lagrange-theorem-oq-01-oq-01-oq-01: 5th annotation + section split

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -23,6 +23,30 @@
     ]
   },
   {
+    "id": "ann-pq-001-neZero-haveI",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 80
+    },
+    "type": "insight",
+    "title": "haveI : NeZero q — typeclass plumbing for DihedralGroup.card",
+    "content": "The single line `haveI : NeZero q := ⟨hq.ne_zero⟩` is structurally essential. `DihedralGroup.card` carries a typeclass hypothesis `[NeZero n]`, and Mathlib does not (and should not) export an instance `NeZero q` from `Nat.Prime q` because primality is logically stronger than nonzero and instance synthesis must converge. Hence the proof must locally construct the `NeZero` instance and inject it into the typeclass cache via `haveI` (the term-mode analogue of `letI` for instances). After this single line, `DihedralGroup.card` and `inferInstance` (for `Fintype (DihedralGroup q)`) both succeed without further hints. The same trick recurs throughout Mathlib whenever a `Fintype.card` lemma needs `NeZero`.",
+    "mathContext": "The `NeZero` typeclass packages the proposition $n \\ne 0$ as a class so that lemmas like $\\mathrm{Fintype.card}(\\mathrm{DihedralGroup}\\,n) = 2n$ (which would be wrong for $n = 0$ because $\\mathrm{DihedralGroup}\\,0$ is the infinite dihedral group) can be stated unconditionally on the proposition side while keeping the proof obligation in the typeclass-resolution machinery. The `haveI` tactic is preferred over `have` for instances because it makes the resulting fact available to type-class search; plain `have` would not.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "NeZero typeclass",
+      "haveI vs letI vs have",
+      "typeclass synthesis",
+      "DihedralGroup 0 (infinite dihedral)"
+    ],
+    "prerequisites": [
+      "Lean 4 typeclass system",
+      "Nat.Prime.ne_zero",
+      "haveI tactic"
+    ]
+  },
+  {
     "id": "ann-pq-001-main-theorem",
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
@@ -53,11 +53,18 @@
   },
   "sections": [
     {
-      "id": "header-imports",
-      "title": "Header and Imports",
+      "id": "module-docstring",
+      "title": "Module Docstring: OQ Statement and Approach A Strategy",
       "startLine": 1,
+      "endLine": 47,
+      "summary": "States the open question (OQ-01-OQ-01-OQ-01): exhibit an explicit non-cyclic group of order pq when distinct primes p, q satisfy p ∣ (q-1). Describes Approach A (this file) — specialize to p = 2 and use Mathlib's DihedralGroup q — and Approach B (deferred to S3+) — the general semidirect product ZMod q ⋊[φ] ZMod p. Pins the required Mathlib API at rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67, cites Dummit-Foote §4.5, and notes that the q ≠ 2 hypothesis is documentary rather than load-bearing."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and Namespace",
+      "startLine": 49,
       "endLine": 53,
-      "summary": "Module docstring stating the OQ-01-OQ-01-OQ-01 problem (explicit non-cyclic pq-witness), Approach A strategy (specialize to p = 2, use DihedralGroup q), and the pinned Mathlib API (DihedralGroup.card, DihedralGroup.not_isCyclic). Imports Mathlib and Proofs.LagrangeTheoremOQ01OQ01."
+      "summary": "Imports the full Mathlib bundle (for DihedralGroup, NeZero, Nat.Prime) and the parent file Proofs.LagrangeTheoremOQ01OQ01 (for the pq-classification context). Opens the LagrangeOQ01OQ01OQ01 namespace where all theorems live."
     },
     {
       "id": "main-existence",


### PR DESCRIPTION
## Summary

Enrichment pass for `lagrange-theorem-oq-01-oq-01-oq-01` (pq-Groups: Explicit Non-Cyclic Witness for p = 2 via DihedralGroup q).

Quality score 93 → 100 per `scripts/enricher/find-targets.ts`.

### annotations.json (4 → 5)
- Added `ann-pq-001-neZero-haveI` (insight type) covering the `haveI : NeZero q := ⟨hq.ne_zero⟩` typeclass-plumbing pattern at lines 73–80.
- This single line is structurally essential: `DihedralGroup.card` carries `[NeZero n]` and Mathlib does not auto-derive `NeZero` from `Nat.Prime` (instance synthesis must converge). The new annotation documents why, the term-mode `haveI` vs `letI` vs `have` distinction, and connects to the `DihedralGroup 0` infinite-dihedral degenerate case.

### meta.json (4 → 5 sections)
- Split `header-imports` (lines 1–53) into:
  - `module-docstring` (lines 1–47) — the OQ statement, Approach A strategy, pinned Mathlib API, Dummit-Foote citation.
  - `imports-namespace` (lines 49–53) — `import Mathlib`, parent import, namespace declaration.

### Axiom integrity
Verified `status: "verified"`, `axiomCount: 0`, `sorries: 0` reflect the Lean source: no `axiom` declarations, no structure-encoded assumptions. The hypothesis `q ≠ 2` in the main theorem is documentary (certifies the OQ's `p ∣ (q-1)` premise) and the underlying proof depends only on `Nat.Prime.one_lt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)