### PR TITLE
fix(minpoly-charpoly-oq-03): replace fragile List.length_pos.mpr with explicit length_pos_of_ne_nil helper (build verified)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -324,6 +324,16 @@ These extend S3 with three more sorry-free facts about the
   when the chain is eventually instantiated by a matrix M.
 -/
 
+/-- Internal robust witness for `0 < l.length` from `l ≠ []`. Replaces
+    the post-merge fragile `List.length_pos.mpr` invocation in S4
+    (PR #18086) whose `List.length_pos` reference no longer exists at
+    the pinned Mathlib v4.26.0 rev (see "Build status" in PR header). -/
+private lemma length_pos_of_ne_nil {α : Type*} {l : List α} (h : l ≠ []) :
+    0 < l.length := by
+  rcases l with _ | _
+  · exact absurd rfl h
+  · exact Nat.succ_pos _
+
 /-- The `lastFactor` of a nonempty chain coincides with the indexed
     access at the last position. Internal-use lemma bridging the
     `getLast?.getD 1` definition with the `Fin`-indexed access used
@@ -331,7 +341,7 @@ These extend S3 with three more sorry-free facts about the
 private theorem lastFactor_eq_getElem_pred
     (c : InvariantFactorChain F) (h : c.factors ≠ []) :
     c.lastFactor = c.factors[c.factors.length - 1]'(by
-      have hpos : 0 < c.factors.length := List.length_pos.mpr h
+      have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
       omega) := by
   show c.factors.getLast?.getD 1 = _
   rw [List.getLast?_eq_getLast h]
@@ -363,7 +373,7 @@ theorem lastFactor_natDegree_maximal
     p.natDegree ≤ c.lastFactor.natDegree := by
   rw [List.mem_iff_getElem] at hp
   obtain ⟨i, hi, hip⟩ := hp
-  have hpos : 0 < c.factors.length := List.length_pos.mpr h
+  have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
   let i' : Fin c.factors.length := ⟨i, hi⟩
   let j  : Fin c.factors.length := ⟨c.factors.length - 1, by omega⟩
   have hij : i'.val ≤ j.val := by


### PR DESCRIPTION
## Summary

S4 (PR #18086, build-pending merge) introduced two invocations of `List.length_pos.mpr h` in `Proofs/MinpolyCharpolyOQ03.lean` (lines 334 and 366). Subsequent build attempts at the pinned Mathlib v4.26.0 rev fail with `Unknown constant List.length_pos.mpr` — the `List.length_pos` lemma has been renamed/restructured upstream so the `.mpr` field access no longer resolves.

This PR replaces both invocations with a small private helper that uses only stable v4.x primitives:

```lean
private lemma length_pos_of_ne_nil {α : Type*} {l : List α}
    (h : l ≠ []) : 0 < l.length := by
  rcases l with _ | _
  · exact absurd rfl h
  · exact Nat.succ_pos _
```

## Files modified

- `proofs/Proofs/MinpolyCharpolyOQ03.lean` (+12 / −2): adds the private helper; swaps both `List.length_pos.mpr h` sites to `length_pos_of_ne_nil h`. No net change to public theorem count or sorry count; +1 private lemma.

## Build status

**Build verified** via `proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03` — `[3059/3059] Built Proofs.MinpolyCharpolyOQ03 (89s)` / `Build completed successfully`. The pre-existing S1 sorry warning on `rational_canonical_form_exists` (line 197) and the unrelated `List.getLast?_eq_getLast` deprecation warning (line 347, S4 code) persist — neither blocks the build, and neither is in scope for this drift-fix PR.

## Why this is real progress

Unblocks build verification of S4 (PR #18086) and the queued S5 (PR #18182, also "build pending" pending this fix). Without this drift-fix, every iteration on this file ships "build pending" with a known but unfixed parent break. After this fix, the file builds clean on origin/main; S5 (#18182) will build clean once rebased post-merge.

## Findings

- The `List.length_pos.mpr` drift is a Mathlib v4.26.0 API change; the underlying lemma was likely renamed to `List.length_pos_iff` or similar. The defensive helper sidesteps the version drift entirely.
- The `List.getLast?_eq_getLast` deprecation warning on line 347 (S4 code) is a separate drift-fix opportunity — `List.getLast?_eq_getLast` → `List.getLast?_eq_some_getLast` per the deprecation message. Out of scope for this PR; a separate mechanic pass could address it.

🤖 Generated by researcher-10