### PR TITLE
Enrich 2D Carleson Spherical-Summation (fourier-series-oq-04-oq-01): annotations + conclusion

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-oq-01/index.ts
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/FourierSeriesOQ04OQ01.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string


### PR DESCRIPTION
## Summary

Enrichment pass for `fourier-series-oq-04-oq-01` — *2D Carleson Spherical-Summation Conjecture (axiomatized)*.

**Quality gap addressed:** `annotations.json` was empty (`[]`); `conclusion` schema was off (`text` instead of `summary`, no `implications`); `index.ts` cast was missing the `as unknown as` indirection so TypeScript flagged the `leanFile` field as incompatible with `ProofData`.

## Changes

- **9 new annotations** (`annotations.json`) covering every section of the Lean file:
  1. T² type construction (`Fin 2 → AddCircle 1` + `Fact (0 < 1)` instance)
  2. Product Haar measure (`Measure.pi` of `haarAddCircle`)
  3. Multi-index 2D Fourier coefficient (character factorisation)
  4. Lattice disc as a Finset (bounding-box + decidable filter pattern)
  5. Spherical partial Fourier sum (spherical vs rectangular at L² endpoint)
  6. The Carleson axiom (Axiom Integrity Policy, equivalent maximal estimate)
  7. L² norm companion (Plancherel route, Mathlib gap)
  8. & 9. Sanity-check lemmas (zero-function invariants)

  Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **`conclusion` schema fix:** renamed `text` → `summary` to match `ProofConclusion` interface; added 4-item `implications` array covering the axiom-integrity exemplar, Plancherel-on-Tⁿ as a high-leverage Mathlib gap, the structural (not technical) nature of the 1D/2D Carleson asymmetry, and the future-bifurcation implications of a resolution.
- **`index.ts` cast tightened:** `metaJson as unknown as { ... }` (matches enricher.md template; silences TS2352 about the `leanFile` field).

## Axiom integrity

No change to `status` (`axiomatized`), `badge` (`axiom`), `axiomCount` (`1`), or `sorries` (`1`). The Lean file genuinely has 1 `axiom` (`carleson_2d_sph`, the open conjecture) and 1 `sorry` (`sphPartialSum_L2_norm_converge`, Plancherel-on-T² Mathlib gap) — both accurately reported.

## Verification

- JSON parse OK for `meta.json` and `annotations.json` (`python3 -c "json.load(...)"`)
- `npx tsc -b` produces no new errors for this entry. (Pre-existing errors for `listings.json` / `research-listings.json` are unrelated.)

## Test plan
- [ ] Visit `/proofs/fourier-series-oq-04-oq-01` on preview deploy — verify annotations render with LaTeX, conclusion summary + implications + open questions all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)