### PR TITLE
research(mean-value-theorem-oq-02-oq-04-oq-01): S5 ACT — limit-extraction proof for `cauchy_diag_norm_bound` (build verified)

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
@@ -124,7 +124,7 @@ Lean-4 spelling thereof) — this is the precise S2 deliverable.
 noncomputable section
 
 open Real Set
-open scoped NNReal ENNReal
+open scoped NNReal ENNReal Topology Filter
 
 namespace MeanValueTheoremOQ02OQ04OQ01
 
@@ -414,35 +414,119 @@ theorem geometric_tail_identity (r R : ℝ) (hR : 0 < R) (hrR : r < R) (n : ℕ)
       = r ^ (n + 1) / R ^ n / (R - r) := by rw [key]
     _ = r ^ (n + 1) / (R ^ n * (R - r)) := by rw [div_div]
 
-/-- **Cauchy diagonal-norm bound** (S4 sub-lemma; one remaining `sorry`).
+/-- **Cauchy diagonal-norm bound at a strict intermediate radius**
+(S5 sub-lemma; one remaining `sorry`).
+
+For `f : ℂ → ℂ` holomorphic on `Metric.ball a R` with uniform sup bound
+`‖f z‖ ≤ M` on that disk, the *diagonal* multilinear evaluation
+`p k (fun _ ↦ w)` of the `k`-th formal-power-series coefficient is
+bounded by `M · (‖w‖ / r')^k` for every `r' ∈ (0, R)`.
+
+This is the **finite-radius** form of the textbook Cauchy coefficient
+estimate. It is the statement that directly matches Mathlib's
+Cauchy-integral chain on the closed sphere `sphere a r'`: the bound
+involves only the *strict* sub-disk radius `r'`, not the boundary `R`.
+The boundary form `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / R)^k` then follows
+by taking `r' → R⁻` (continuity of the upper bound — formalized in
+`cauchy_diag_norm_bound` below).
+
+The remaining proof chain (deferred to a future iteration; this is the
+only residual `sorry` in this file as of S5) routes through:
+
+1. **Sub-disk inclusion**: `closedBall a r' ⊂ Metric.ball a R` for
+   `r' < R`, so `f` is bounded by `M` on `sphere a r' ⊂ closedBall a r'`.
+2. `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
+   (Cauchy integral on `sphere a r'`):
+   `‖iteratedDeriv k f a‖ ≤ k! · M / (r')^k`.
+3. `HasFPowerSeriesOnBall.factorial_smul`: relates the formal-series
+   coefficient `p k` to `iteratedFDeriv k f a / k!`.
+4. `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` (in 1D the product
+   collapses to `w^k`):
+   `(iteratedFDeriv k f a) (fun _ ↦ w) = w^k * iteratedDeriv k f a`.
+5. Combine: `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k`.
+
+Why this decomposition is useful. The boundary form
+`cauchy_diag_norm_bound` requires two distinct mathematical ingredients:
+(a) the Cauchy estimate on a *closed* sphere of radius `r' < R`, and
+(b) the continuity-of-upper-bound limit `r' → R⁻`. The original
+`cauchy_diag_norm_bound` statement entangled both. This sub-lemma
+isolates ingredient (a) — the *finite-radius* Cauchy bound — so that
+the limit argument (ingredient b) can be discharged independently and
+the remaining gap is the precise statement Mathlib's Cauchy-integral
+infrastructure produces directly. -/
+theorem cauchy_diag_norm_bound_at_radius
+    (f : ℂ → ℂ) (a : ℂ) (R M : ℝ)
+    (_hR : 0 < R) (_hM : 0 ≤ M)
+    (p : FormalMultilinearSeries ℂ ℂ ℂ)
+    (_hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
+    (_hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
+    (k : ℕ) (w : ℂ) (r' : ℝ) (_hr' : 0 < r') (_hr'R : r' < R) :
+    ‖p k (fun _ ↦ w)‖ ≤ M * (‖w‖ / r') ^ k := by
+  -- Deferred to S6: see docstring for the Mathlib Cauchy-integral chain on
+  -- `sphere a r'` followed by the formal-series / iterated-derivative bridge.
+  sorry
+
+/-- **Cauchy diagonal-norm bound** (S4 statement; S5 limit-extraction proof).
 
 For `f : ℂ → ℂ` holomorphic on `Metric.ball a R` with uniform sup bound
 `‖f z‖ ≤ M` on that disk, the *diagonal* multilinear evaluation
 `p k (fun _ ↦ w)` of the `k`-th formal-power-series coefficient is
 bounded by `M · (‖w‖ / R)^k` for every `w` with `‖w‖ < R`.
 
-This is the textbook Cauchy coefficient estimate. The proof chain is
-sketched in the §3b umbrella docstring above; concretely it routes through
-`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (Cauchy
-integral on `sphere a r'` with `r' ∈ (max r ‖w‖, R)`), the formal-series /
-iterated-derivative bridge `HasFPowerSeriesOnBall.factorial_smul` plus
-`iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` (1D collapses to `w^k`),
-and finally a `r' → R⁻` continuity-of-upper-bound limit.
+**Proof (S5).** The bound for every strict intermediate radius
+`r' ∈ (0, R)` is supplied by `cauchy_diag_norm_bound_at_radius`:
+`‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k`. The function
+`r' ↦ M · (‖w‖ / r')^k` is continuous at `R` (since `R > 0`), so
+`Filter.Tendsto` along `𝓝[<] R` lands at `M · (‖w‖ / R)^k`.
+`le_of_tendsto` then transports the eventual pointwise bound to the
+limit value, yielding the boundary bound.
 
-This sub-lemma is the **only remaining `sorry`** in this file after S4. It
-isolates the residual formalization gap to a single named statement so that
-future iterations (or a Mathlib contribution) can close it without
-revisiting the surrounding combination scaffolding. -/
+This is the **only remaining `sorry`** in this file (it routes through
+`cauchy_diag_norm_bound_at_radius`'s deferred Mathlib Cauchy-integral
+chain). The limit-extraction step is **fully proven** below; what
+remains is the finite-radius Cauchy estimate, which is exactly what
+Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
+infrastructure provides. -/
 theorem cauchy_diag_norm_bound
     (f : ℂ → ℂ) (a : ℂ) (R M : ℝ)
-    (_hR : 0 < R) (_hM : 0 ≤ M)
+    (hR : 0 < R) (hM : 0 ≤ M)
     (p : FormalMultilinearSeries ℂ ℂ ℂ)
-    (_hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
-    (_hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
+    (hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
+    (hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
     (k : ℕ) (w : ℂ) (_hw : ‖w‖ < R) :
     ‖p k (fun _ ↦ w)‖ ≤ M * (‖w‖ / R) ^ k := by
-  -- Deferred to S5: see docstring for the Mathlib Cauchy-integral chain.
-  sorry
+  -- Setup.
+  have hR_ne : (R : ℝ) ≠ 0 := ne_of_gt hR
+  -- Pointwise bound on the open interval `(0, R)` of intermediate radii,
+  -- via the deferred finite-radius Cauchy estimate.
+  have h_at_r : ∀ r' ∈ Set.Ioo (0 : ℝ) R,
+      ‖p k (fun _ ↦ w)‖ ≤ M * (‖w‖ / r') ^ k := by
+    rintro r' ⟨hr'_pos, hr'_lt_R⟩
+    exact cauchy_diag_norm_bound_at_radius f a R M hR hM p hf hbound k w r'
+      hr'_pos hr'_lt_R
+  -- The function `r' ↦ M · (‖w‖ / r')^k` is continuous at `R`.
+  -- Composition: const ↦ `M` × ((const `‖w‖` / id) ^ k).
+  have hg_cont : ContinuousAt (fun r' : ℝ => M * (‖w‖ / r') ^ k) R := by
+    refine continuousAt_const.mul ?_
+    exact ((continuousAt_const.div continuousAt_id hR_ne).pow k)
+  -- Tendsto along `𝓝[<] R` lands at the boundary value.
+  have h_tendsto :
+      Filter.Tendsto (fun r' : ℝ => M * (‖w‖ / r') ^ k)
+        (𝓝[<] R) (𝓝 (M * (‖w‖ / R) ^ k)) :=
+    hg_cont.tendsto.mono_left nhdsWithin_le_nhds
+  -- The open interval `(0, R)` is eventually in `𝓝[<] R` (and nonempty since
+  -- `R > 0`), so the pointwise bound holds eventually along the filter.
+  have h_Ioo_mem : Set.Ioo (0 : ℝ) R ∈ 𝓝[<] R := by
+    rw [mem_nhdsWithin]
+    refine ⟨Set.Ioi 0, isOpen_Ioi, hR, ?_⟩
+    rintro x ⟨hx_pos, hx_lt_R⟩
+    exact ⟨hx_pos, hx_lt_R⟩
+  have h_event :
+      ∀ᶠ r' in 𝓝[<] R, ‖p k (fun _ ↦ w)‖ ≤ M * (‖w‖ / r') ^ k :=
+    Filter.eventually_of_mem h_Ioo_mem h_at_r
+  -- Transport the eventual lower bound through the limit (`ge_of_tendsto` lifts
+  -- a lower bound on `f c` to a lower bound on `lim f`).
+  exact ge_of_tendsto h_tendsto h_event
 
 /-- **Corrected Cauchy uniform bound** (complex hypothesis, fixed index).
 
@@ -614,6 +698,7 @@ theorem analytic_taylor_remainder_uniform_geometric_complex
 #check @OriginalRemainderForm
 #check @originalRemainderForm_is_false
 #check @geometric_tail_identity
+#check @cauchy_diag_norm_bound_at_radius
 #check @cauchy_diag_norm_bound
 #check @analytic_taylor_remainder_uniform_bound_complex
 #check @analytic_taylor_remainder_uniform_geometric_complex

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
@@ -163,3 +163,47 @@ To avoid duplication / merge collisions, **this S2 PR is narrowed to one unique 
 - **Alternative S5**: use `cauchyPowerSeries` + `Complex.norm_cauchyPowerSeries_le` + `DifferentiableOn.hasFPowerSeriesOnBall` + power-series uniqueness on the closed disk of radius `r' < R`. This routes through `cauchyPowerSeries` directly, potentially shorter than the iterated-derivative path.
 
 - **Audit sibling gallery files** that import `MeanValueTheoremOQ02OQ04` for similar OQ-04-axiom-dependence (still open from S2).
+
+## Session 2026-05-12 (Session 5, researcher-3) — Limit-extraction proof for `cauchy_diag_norm_bound`
+
+**Mode**: REVISIT (RICH knowledge, 4 prior sessions)
+**Outcome**: progress (cauchy_diag_norm_bound is now PROVEN by limit-extraction from a new finite-radius sub-lemma; the residual sorry shifts to the finite-radius form)
+
+### What I Did
+
+1. **Decomposed `cauchy_diag_norm_bound` into two natural sub-steps**:
+   - **(a)** the Cauchy estimate at a strict intermediate radius `r' ∈ (0, R)`: `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/r')^k` — captured in new sub-lemma `cauchy_diag_norm_bound_at_radius`, deferred to S6.
+   - **(b)** the limit-extraction step `r' → R⁻`: continuity of `r' ↦ M · (‖w‖/r')^k` at `R > 0` lets `Filter.Tendsto` along `𝓝[<] R` transport the pointwise bound from `Set.Ioo 0 R` to the boundary value `M · (‖w‖ / R)^k`. **Fully proved this iteration.**
+
+2. **Wrote ~50-line limit-extraction proof** for `cauchy_diag_norm_bound`. Key Mathlib API used:
+   - `ContinuousAt.mul`, `ContinuousAt.div` (with `R ≠ 0` from `0 < R` via `ne_of_gt`), `ContinuousAt.pow`, `continuousAt_const`, `continuousAt_id`
+   - `ContinuousAt.tendsto` + `Filter.Tendsto.mono_left` + `nhdsWithin_le_nhds` for `Tendsto … (𝓝[<] R) (𝓝 g R)`
+   - `mem_nhdsWithin` + `isOpen_Ioi.mem_nhds hR` for `Set.Ioo 0 R ∈ 𝓝[<] R`
+   - `Filter.eventually_of_mem` for `∀ᶠ r' in 𝓝[<] R, ‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/r')^k`
+   - `le_of_tendsto` to transport the eventual bound to the boundary limit
+
+3. **Build verification**: docker-build started this session. State.md updated to reflect the new sorry locality.
+
+### Mathematical Insight
+
+The limit-extraction is structurally orthogonal to the Cauchy-integral chain on `sphere a r'`. By isolating it, the residual gap (the finite-radius form `cauchy_diag_norm_bound_at_radius`) is now precisely the statement Mathlib's Cauchy estimate produces directly — no further "take limit" plumbing required of a future S6 iteration. This makes the remaining gap easier to discharge and the proof easier to audit.
+
+The function `g(r') := M · (‖w‖ / r')^k` is in fact *monotonically decreasing* on `(0, ∞)` (assuming `M ≥ 0` and `‖w‖ ≥ 0`), so the infimum over `r' ∈ (0, R)` is attained as `r' → R⁻` and equals `g(R) = M · (‖w‖ / R)^k`. The limit-extraction is "tight" — no slack is introduced by taking the limit.
+
+### Edge cases handled by the inner sub-lemma
+
+- `w = 0`, `k = 0`: bound at r' is `M · (0/r')^0 = M · 1 = M`. Limit gives `M · (0/R)^0 = M`. Both consistent with `‖p 0 (fun _ ↦ 0)‖ = ‖f a‖ ≤ M`.
+- `w = 0`, `k > 0`: bound at r' is `M · 0^k = 0`. Limit gives 0. Both consistent with multilinear annihilation `p k (fun _ ↦ 0) = 0`.
+- `w ≠ 0`: limit refinement is genuine — `(‖w‖/r')^k > (‖w‖/R)^k` strictly for `r' < R`.
+
+### Files Modified
+
+- **Modified**: `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — split `cauchy_diag_norm_bound` into `cauchy_diag_norm_bound_at_radius` (new sorry, S6 deferral) + `cauchy_diag_norm_bound` (now proven by limit-extraction). +91 lines.
+- **Modified**: `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/{knowledge.md, state.md}` — S5 entry.
+- **Modified**: `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json` — synced.
+
+### Next Steps (S6+)
+
+- **Discharge `cauchy_diag_norm_bound_at_radius`** via Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + the formal-series / iterated-derivative bridge (`HasFPowerSeriesOnBall.factorial_smul` and `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`). The limit-extraction step is now closed; S6 only needs the *finite-radius* Cauchy bound. Estimated 60-100 lines.
+
+- **Reference template**: `Proofs/TaylorTheoremOQ02.lean::fps_coeff_eq_taylor_coeff` already implements the ℝ-analogue of the formal-series / iterated-derivative bridge via `HasFPowerSeriesAt.iteratedFDeriv_eq_sum_of_completeSpace`. The ℂ-version should be parallel (ℂ is also a CompleteSpace).

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
@@ -1,10 +1,10 @@
 # State: mean-value-theorem-oq-02-oq-04-oq-01
 
-**Phase**: ACT (S4: §3b explicit-form `analytic_taylor_remainder_uniform_bound_complex` is now PROVEN modulo one named sub-lemma `cauchy_diag_norm_bound` — sorry count stays at 1 but the §3b combination scaffolding is fully formalized)
+**Phase**: ACT (S5: `cauchy_diag_norm_bound` is now PROVEN by limit-extraction from a new finite-radius sub-lemma `cauchy_diag_norm_bound_at_radius`. The sorry shifts from the boundary-form bound to a strict-intermediate-radius form that directly matches Mathlib's Cauchy-integral chain on `sphere a r'`. Sorry count stays at 1 but the limit-extraction step (`r' → R⁻` via `Filter.Tendsto.le_of_tendsto`) is fully formalized.)
 
 ## Lean File
 
-`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — 614 lines, 0 new axioms, 1 sorry (moved from main theorem to a single named Mathlib-bridge sub-lemma).
+`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — 705 lines, 0 new axioms, 1 sorry (now on the finite-radius sub-lemma `cauchy_diag_norm_bound_at_radius`).
 
 ## Theorems Proved (constructively)
 
@@ -18,11 +18,12 @@
 - `analytic_taylor_remainder_uniform_geometric_complex` (S2): existential Cauchy-style geometric approximation in `z`-centered coordinates, via Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'`.
 - `originalRemainderForm_is_false` (S3): refutation of the S1-S2 explicit-form RHS paired with `partialSum n`.
 - `geometric_tail_identity` (S3): `(r / R)^(n+1) * R / (R - r) = r^(n+1) / (R^n * (R - r))` under `0 < R`, `r < R`. Proven via `field_simp + ring`.
-- **NEW (S4)** `analytic_taylor_remainder_uniform_bound_complex`: §3b explicit form is now PROVEN modulo `cauchy_diag_norm_bound`. Proof chains `HasFPowerSeriesOnBall.hasSum_sub` (Mathlib), `cauchy_diag_norm_bound` (this file, sorry), `norm_sub_le_of_geometric_bound_of_hasSum` (Mathlib), `geometric_tail_identity`, and `norm_sub_rev` + `field_simp + ring` for the RHS normalization.
+- **(S4)** `analytic_taylor_remainder_uniform_bound_complex`: §3b explicit form is now PROVEN modulo `cauchy_diag_norm_bound`. Proof chains `HasFPowerSeriesOnBall.hasSum_sub` (Mathlib), `cauchy_diag_norm_bound`, `norm_sub_le_of_geometric_bound_of_hasSum` (Mathlib), `geometric_tail_identity`, and `norm_sub_rev` + `field_simp + ring` for the RHS normalization.
+- **NEW (S5)** `cauchy_diag_norm_bound` is now PROVEN by limit-extraction from a new sub-lemma `cauchy_diag_norm_bound_at_radius` (the finite-radius form with explicit `r' ∈ (0, R)`). The limit-extraction proof uses `ContinuousAt.mul`, `ContinuousAt.div`, `ContinuousAt.pow`, `Filter.Tendsto.mono_left` along `𝓝[<] R`, `Filter.eventually_of_mem` with `Set.Ioo 0 R ∈ 𝓝[<] R`, and `le_of_tendsto` to transport the eventual bound to the boundary limit. **The only remaining `sorry`** in the file is now the finite-radius `cauchy_diag_norm_bound_at_radius`, which directly matches Mathlib's Cauchy-integral chain on `sphere a r'`.
 
 ## Theorems With Sorry (deferred)
 
-- `cauchy_diag_norm_bound`: per-degree Cauchy coefficient bound `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / R)^k` for `‖w‖ < R`, given `‖f z‖ ≤ M` on `Metric.ball a R` and `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)`. **This is the only remaining sorry in the file** (deferred to S5).
+- `cauchy_diag_norm_bound_at_radius`: per-degree Cauchy coefficient bound at a strict intermediate radius `r' ∈ (0, R)` — `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k` — given `‖f z‖ ≤ M` on `Metric.ball a R` and `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)`. **This is the only remaining sorry in the file** (deferred to S6). The boundary form `cauchy_diag_norm_bound` is now PROVEN from this via limit-extraction.
 
 ## Definitions
 
@@ -32,9 +33,29 @@
 
 ## Build Status
 
-**Build verification pending** (S4 PR) via `./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01` (worktree-local script). Net new sorry-free content: the entire §3b combination/scaffolding proof of `analytic_taylor_remainder_uniform_bound_complex`. The one remaining `sorry` in the file is on the strictly smaller statement `cauchy_diag_norm_bound`.
+**Build verification IN PROGRESS** (S5 PR) via `./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01` (worktree-local script). Net new sorry-free content (S5): the entire limit-extraction proof of `cauchy_diag_norm_bound` (from the finite-radius sub-lemma). The one remaining `sorry` in the file is on the strict-intermediate-radius `cauchy_diag_norm_bound_at_radius`.
 
-## S4 Contribution (this session)
+## S5 Contribution (this session)
+
+1. **Refactored sorry locality**: introduced new sub-lemma `cauchy_diag_norm_bound_at_radius` with explicit intermediate radius `r' ∈ (0, R)`. Its conclusion is the *finite-radius* Cauchy bound `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k` — exactly the statement Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` infrastructure produces directly on `sphere a r'`. The single residual sorry of the file now lives on this strict-r' form.
+
+2. **Limit-extraction step, fully formalized** in `cauchy_diag_norm_bound`. The proof body now contains the actual chain:
+   - For every `r' ∈ Set.Ioo 0 R`, apply `cauchy_diag_norm_bound_at_radius` to get `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k`.
+   - Continuity of `r' ↦ M * (‖w‖ / r')^k` at `R > 0` via `ContinuousAt.mul`, `ContinuousAt.div` (with `R ≠ 0` from `0 < R`), and `ContinuousAt.pow`.
+   - `Filter.Tendsto.mono_left` from `ContinuousAt.tendsto` to `𝓝[<] R`.
+   - `Set.Ioo (0 : ℝ) R ∈ 𝓝[<] R` via `mem_nhdsWithin` with `Set.Ioi 0 ∈ 𝓝 R` witness (since `0 < R`).
+   - `Filter.eventually_of_mem` transports the pointwise bound on `Set.Ioo 0 R` to `∀ᶠ r' in 𝓝[<] R, …`.
+   - `le_of_tendsto` lifts the eventual bound to the boundary limit `M · (‖w‖ / R)^k`.
+
+3. **Sorry count unchanged** (1 → 1) but the residual gap is now isolated to a *strict-intermediate-radius* statement rather than the boundary form. The limit-extraction step is no longer a black-box; the entire continuity / `𝓝[<]` / `le_of_tendsto` chain is auditable.
+
+4. **Cleanly rebased against origin/main** (post-#18085, the S4 merge). The S5 changes are local to lines 417–490 (replacing the old `cauchy_diag_norm_bound` `sorry` with two theorems and a fully-proved limit reduction).
+
+## Coordination Note (S5)
+
+This builds on the merged S4 state (PR #18085). The S5 sub-lemma `cauchy_diag_norm_bound_at_radius` exposes the *exact* hypothesis pattern Mathlib's Cauchy-integral chain expects: a strict intermediate radius `r'`, a sup bound on the open ball of radius `R > r'`, and a HasFPowerSeriesOnBall hypothesis on the ball of radius `R`. A future S6 iteration can discharge it without re-litigating the limit-extraction logic.
+
+## S4 Contribution (previous session, for reference)
 
 1. **New sub-lemma `cauchy_diag_norm_bound`** (statement, sorry deferred): isolates the single Cauchy-coefficient gap, with full docstring sketch of the proof chain (`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` + `r' → R⁻` limit).
 
@@ -53,18 +74,18 @@
 
 PR #17904 (researcher-1, conflicting) had `cauchy_diag_norm_bound` as a separate `sorry` AND the main combination step as a separate `sorry` (net 2 sorries vs S3's 1). This S4 PR keeps the sorry count at 1 by completing the combination step, leaving only the Cauchy-coefficient gap deferred. The naming `cauchy_diag_norm_bound` is identical to #17904's; the signature differs (uses `_hR`, `_hM`, `_hf`, `_hbound`, `_hw` underscored since the body is `sorry`).
 
-## Next Action (S5+)
+## Next Action (S6+)
 
-Discharge `cauchy_diag_norm_bound` via the Mathlib Cauchy-integral chain:
+Discharge `cauchy_diag_norm_bound_at_radius` via the Mathlib Cauchy-integral chain (the limit-extraction step is **already done** in S5):
 
-1. Fix `r' ∈ (max(r, ‖w‖), R)`; then `closedBall a r' ⊂ Metric.ball a R` so `f` is bounded by `M` on `sphere a r'`.
-2. Apply `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` to get `‖iteratedDeriv k f a‖ ≤ k! · M / r'^k`.
-3. Use `HasFPowerSeriesOnBall.factorial_smul` to relate `p k` to `iteratedFDeriv k f a / k!`.
+1. Sub-disk inclusion: `closedBall a r' ⊂ Metric.ball a R` from `r' < R`, hence `f` is bounded by `M` on `sphere a r' ⊂ closedBall a r'` via `hbound`.
+2. Apply `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (or the closest Mathlib variant) to get `‖iteratedDeriv k f a‖ ≤ k! · M / r'^k`.
+3. Use `HasFPowerSeriesOnBall.factorial_smul` (or `HasFPowerSeriesAt.iteratedFDeriv_eq_sum_of_completeSpace` — cf. `TaylorTheoremOQ02.fps_coeff_eq_taylor_coeff` for the ℝ-analogue) to relate `p k` to `iteratedFDeriv k f a / k!`.
 4. `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` (in 1D the product collapses to `w^k`): `(iteratedFDeriv k f a) (fun _ ↦ w) = w^k * iteratedDeriv k f a`.
-5. Conclude `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/r')^k`. Take `r' → R⁻` (continuity of the upper bound) to get `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/R)^k`.
+5. Combine: `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/r')^k`.
 
-Estimated S5 proof length: 100-150 lines (Cauchy integral + iterated derivative bridge + limit).
+Estimated S6 proof length: 60-100 lines (no limit step required; just the Cauchy estimate on a closed sphere + the formal-series / iterated-derivative bridge).
 
 ## Pool Status Note
 
-This slug remains `progress` (one sorry remains on `cauchy_diag_norm_bound`). Set status to `progress` after S4 merge.
+This slug remains `progress` (one sorry remains on `cauchy_diag_norm_bound_at_radius`). Set status to `progress` after S5 merge.

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -23,8 +23,8 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 621,
-    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in §2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in §3a via constant-1 witness on ℂ, S3 contribution). One sorry remains in cauchy_diag_norm_bound (the per-degree Cauchy coefficient estimate ‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / R)^k); the surrounding §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo this single sub-lemma (S4 contribution).",
+    "lineCount": 705,
+    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S5, one sorry remains in cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R) — the form Mathlibs Cauchy-integral chain on sphere a r prime produces directly). The boundary form cauchy_diag_norm_bound (with norm of w over R) is now PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven modulo this single finite-radius sub-lemma.",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -96,7 +96,7 @@
       "Demonstration that the explicit R^n factor in the denominator (M·r^(n+1) / (R^n · (R-r))) is essential; the OQ-04 statement that absorbs R^n into M is too weak to be true under real-only hypotheses.",
       "S4 (Iter 4): the §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo a single named sub-lemma cauchy_diag_norm_bound. The combination scaffolding (HasFPowerSeriesOnBall.hasSum_sub → per-term geometric bound via cauchy_diag_norm_bound → norm_sub_le_of_geometric_bound_of_hasSum at index n+1 → norm_sub_rev + field_simp + ring rescaling using 1 − r/R = (R−r)/R) is now Lean code, not docstring. Sorry count stays at 1 (moved from main-theorem black-box to a single Cauchy-coefficient gap)."
     ],
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "mean-value-theorem-oq-02-oq-04-oq-01",
   "title": "Refutation of the OQ-04 axiom: Cauchy uniform bound fails on real-only hypotheses (Runge phenomenon)",
-  "phase": "ACT (S4: §3b main theorem fully proven modulo cauchy_diag_norm_bound sub-lemma; sorry count stays at 1 but residual gap isolated to a single Cauchy-coefficient bridge)",
+  "phase": "ACT (S5: cauchy_diag_norm_bound is now PROVEN by limit-extraction from a new finite-radius sub-lemma cauchy_diag_norm_bound_at_radius; sorry shifts to the strict-r form which directly matches Mathlibs Cauchy-integral chain on sphere a r)",
   "status": "progress",
   "tier": "B",
   "path": "full",
@@ -33,18 +33,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "S3 NARROW: off-by-one refutation as formal theorem (originalRemainderForm_is_false) + corrected statement on §3b (partialSum n → partialSum (n+1)) cleanly rebased against origin/main post-#17912; geometric_tail_identity proven. §3b proof body still deferred (S4).",
+    "iteration": 5,
+    "focus": "S5: refactor sorry locality from boundary form to strict-intermediate-radius form. Adds cauchy_diag_norm_bound_at_radius (new sorry, S6 deferral) and proves cauchy_diag_norm_bound by ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto. Sorry count stays at 1 but the limit-extraction step (r prime to R from below) is now fully formalized.",
     "blockers": [],
-    "nextAction": "S4: discharge analytic_taylor_remainder_uniform_bound_complex (corrected indices) via cauchy_diag_norm_bound (Cauchy coefficient bound) + HasFPowerSeriesOnBall.hasSum + norm_sub_le_of_geometric_bound_of_hasSum + geometric_tail_identity. Estimated 150-250 lines.",
+    "nextAction": "S6: discharge cauchy_diag_norm_bound_at_radius via Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le + HasFPowerSeriesOnBall.factorial_smul + iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod. Limit step already closed; only finite-radius Cauchy estimate remains. Estimated 60-100 lines.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S4 (2026-05-12) — §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo a single named sub-lemma cauchy_diag_norm_bound. Combination scaffolding (HasFPowerSeriesOnBall.hasSum_sub → per-term geometric bound → norm_sub_le_of_geometric_bound_of_hasSum at index n+1 → RHS rescaling via 1−r/R = (R−r)/R + geometric_tail_identity) is now Lean code, not docstring. Sorry count unchanged (1 → 1) but residual gap is isolated to the per-degree Cauchy coefficient estimate.",
+    "progressSummary": "S5 (2026-05-12, researcher-3) — cauchy_diag_norm_bound is now PROVEN by limit-extraction from a new finite-radius sub-lemma cauchy_diag_norm_bound_at_radius. The boundary form (with ‖w‖/R) follows from the strict-intermediate form (with ‖w‖/r prime) by ContinuousAt at R + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto. Sorry count unchanged (1 → 1) but the residual gap is now the finite-radius Cauchy estimate (directly matching Mathlibs sphere-based Cauchy-integral chain) rather than the boundary form. The S5 contribution is the ~50-line limit-extraction proof; S6 only needs the finite-radius Cauchy bound + iterated-derivative bridge (no further limit step required).",
     "builtItems": [
       "Definition runge in Proofs/MeanValueTheoremOQ02OQ04OQ01.lean (~137) — the Runge function 1/(1+x²)",
       "Theorem runge_one_add_sq_pos (~142) — 1 + x² > 0",
@@ -61,7 +61,8 @@
       "**(S3 NEW)** Theorem geometric_tail_identity — pure-algebra rewrite (r/R)^(n+1)·R/(R-r) = r^(n+1)/(R^n·(R-r)); field_simp + ring",
       "**(S3 RESTATEMENT)** Theorem analytic_taylor_remainder_uniform_bound_complex — corrected partialSum (n+1) indexing; RHS aligns with geometric tail from degree k=n+1; sorry retained",
       "S4: cauchy_diag_norm_bound (sorry, named sub-lemma) — isolates the residual gap to the Cauchy coefficient bound `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/R)^k` for `‖w‖ < R`, with proof chain sketched in the docstring",
-      "S4: analytic_taylor_remainder_uniform_bound_complex (PROVEN modulo cauchy_diag_norm_bound) — full combination chain: hasSum_sub + per-term bound + norm_sub_le_of_geometric_bound_of_hasSum + norm_sub_rev + algebraic rescaling"
+      "S4: analytic_taylor_remainder_uniform_bound_complex (PROVEN modulo cauchy_diag_norm_bound) — full combination chain: hasSum_sub + per-term bound + norm_sub_le_of_geometric_bound_of_hasSum + norm_sub_rev + algebraic rescaling",
+      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound_at_radius (NEW SORRY, deferred to S6) — finite-radius form, statement only. cauchy_diag_norm_bound (S4 statement, S5 PROVEN) — limit-extraction proof using ContinuousAt.mul + ContinuousAt.div + ContinuousAt.pow + ContinuousAt.tendsto.mono_left nhdsWithin_le_nhds + mem_nhdsWithin with Set.Ioi 0 in 𝓝 R witness + Filter.eventually_of_mem + le_of_tendsto. ~50 lines in proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean lines 417-490."
     ],
     "insights": [
       "The parent OQ-04 axiom is mathematically false: real-analyticity + real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk.",
@@ -78,7 +79,8 @@
       "S4: HasFPowerSeriesOnBall.hasSum_sub is the right Mathlib hook for the diagonal HasSum at a point `z` in the disk — no need for the ball-at-origin form.",
       "S4: partialSum n y = ∑ k ∈ Finset.range n, p k (fun _ => y) definitionally — rfl closes the unfolding step.",
       "S4: The RHS algebra (`M * (r/R)^(n+1) / (1 - r/R) = M * r^(n+1) / (R^n * (R-r))`) does NOT close by `field_simp + ring` alone — `ring` cannot combine stray `R⁻¹^n` factors. Use an explicit `calc` chain via `div_div_eq_mul_div + mul_assoc + mul_div_assoc + geometric_tail_identity + ← mul_div_assoc`.",
-      "S4: `pow_le_pow_left` is unknown in Mathlib v4.26.0 (renamed or removed). Use `gcongr` for monotonicity-of-pow + monotonicity-of-div together."
+      "S4: `pow_le_pow_left` is unknown in Mathlib v4.26.0 (renamed or removed). Use `gcongr` for monotonicity-of-pow + monotonicity-of-div together.",
+      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound decomposes naturally into (a) the finite-radius Cauchy bound at strict r prime in (0, R), and (b) the limit-extraction r prime to R from below via continuity of r prime to M * (‖w‖/r prime)^k. Isolating (b) into a fully-proven limit-reduction makes the residual sorry exactly the statement Mathlibs Cauchy-integral infrastructure produces directly on sphere a r prime; no further limit plumbing needed in a future S6 iteration."
     ],
     "mathlibGaps": [
       "Bridge from AnalyticOn ℝ (real-analytic on a real interval) to HasFPowerSeriesOnBall on Metric.ball (a:ℂ) R for some complex extension — not directly available; would need real-to-complex analytic continuation lemmas.",
@@ -88,7 +90,8 @@
     "nextSteps": [
       "S5: Discharge cauchy_diag_norm_bound via the Mathlib Cauchy-integral chain (Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le + HasFPowerSeriesOnBall.factorial_smul + iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod + r'→R⁻ limit). Estimated 100-150 lines.",
       "S5 alternative: cauchyPowerSeries + Complex.norm_cauchyPowerSeries_le + DifferentiableOn.hasFPowerSeriesOnBall + power-series uniqueness on closed disk of radius r' < R.",
-      "Audit sibling gallery files that import MeanValueTheoremOQ02OQ04 for similar OQ-04-axiom-dependence."
+      "Audit sibling gallery files that import MeanValueTheoremOQ02OQ04 for similar OQ-04-axiom-dependence.",
+      "S6: discharge cauchy_diag_norm_bound_at_radius via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le (finite-radius Cauchy estimate on sphere a r prime, where r prime < R so closedBall a r prime is a strict subset of ball a R) + HasFPowerSeriesOnBall.factorial_smul (formal-series / iterated-derivative bridge) + iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod (1D collapse). Reference template: TaylorTheoremOQ02.fps_coeff_eq_taylor_coeff for the ℝ-analogue of the bridge."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S5 ACT for `mean-value-theorem-oq-02-oq-04-oq-01`. Builds on S4 (PR #18085).

**Headline**: `cauchy_diag_norm_bound` (the §3b umbrella's last open sub-lemma) is now PROVEN by limit-extraction from a new finite-radius sub-lemma `cauchy_diag_norm_bound_at_radius`. The single residual `sorry` shifts from the boundary form to the strict-intermediate-radius form — the form Mathlib's Cauchy-integral chain on `sphere a r'` produces directly.

## Theorems (this PR)

- **NEW (sorry)** `cauchy_diag_norm_bound_at_radius`: finite-radius Cauchy coefficient bound at `r' ∈ (0, R)` — `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k`. Deferred to S6.
- **NEW (PROVEN, ~50 lines)** `cauchy_diag_norm_bound`: boundary form (`‖w‖ / R`) — proven by limit-extraction from the new sub-lemma.

## Limit-extraction proof chain

| Step | Tactic / Lemma |
|---|---|
| Pointwise bound on `Set.Ioo 0 R` | `cauchy_diag_norm_bound_at_radius` |
| Continuity of `r' ↦ M · (‖w‖ / r')^k` at `R > 0` | `ContinuousAt.mul`, `ContinuousAt.div` (with `R ≠ 0`), `ContinuousAt.pow` |
| `Tendsto … (𝓝[<] R) (𝓝 (M · (‖w‖ / R)^k))` | `ContinuousAt.tendsto` + `Filter.Tendsto.mono_left` + `nhdsWithin_le_nhds` |
| `Set.Ioo 0 R ∈ 𝓝[<] R` | `mem_nhdsWithin` with `(Set.Ioi 0, isOpen_Ioi, hR)` witness |
| Eventual bound | `Filter.eventually_of_mem` |
| Lift to limit | `ge_of_tendsto` |

## Why this decomposition

Before S5, the `cauchy_diag_norm_bound` sorry entangled two distinct mathematical ingredients: (a) the finite-radius Cauchy estimate on `sphere a r'`, and (b) the limit-extraction `r' → R⁻`. S5 isolates (a) into the new sub-lemma and proves (b) in full. A future S6 iteration only needs Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + the formal-series / iterated-derivative bridge — no further limit plumbing required.

## Net deltas

| Metric | Before S5 | After S5 |
|---|---|---|
| Sorries | 1 (`cauchy_diag_norm_bound`) | 1 (`cauchy_diag_norm_bound_at_radius`) |
| Axioms | 0 | 0 |
| Theorems | 12 | 13 |
| Lines | 614 | 705 |

## Files

| File | Δ | Notes |
|---|---|---|
| `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` | +91 | Split sorry + prove limit-extraction; add `open scoped Topology Filter` |
| `research/problems/.../knowledge.md` | +44 | S5 entry |
| `research/problems/.../state.md` | various | S5 update |
| `src/data/research/problems/.../<slug>.json` | various | iteration → 5 |
| `src/data/proofs/.../meta.json` | small | `lineCount` 621→705, `theoremCount` 12→13 |

## Build verification

`./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01` succeeded (`Build completed successfully (7745 jobs)` — log `.loom/logs/researcher-3-mvt-s5-build-v3.log`). Only one warning (the expected `declaration uses 'sorry'` on the new sub-lemma).

## Status

- **Outcome**: progress (S5 ACT)
- **Phase**: ACT
- **Next**: S6 — discharge `cauchy_diag_norm_bound_at_radius` via `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`. The limit step is closed; S6 only needs the finite-radius Cauchy estimate + the formal-series / iterated-derivative bridge. Estimated 60–100 lines.

🤖 Generated by researcher-3
