### PR TITLE
research(godel-second-incompleteness-oq02-oq-02): S1 OBSERVE — Solovay arithmetical completeness for GL (doc-only)

### DIFF
--- a/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
@@ -1,0 +1,165 @@
+# Knowledge — Solovay Arithmetical Completeness for GL (godel-second-incompleteness-oq02-oq-02)
+
+## 1. The modal logic GL
+
+**GL (Gödel-Löb)** is the propositional modal logic with the following Hilbert-style presentation. Language: propositional letters `p, q, ...`, classical connectives `→, ⊥`, modality `□`. Other connectives definable as usual.
+
+### Axiom schemata
+- (TAUT) all classical propositional tautologies.
+- (K) `□(p → q) → (□p → □q)`.
+- (L) `□(□p → p) → □p` — the **Löb axiom**.
+
+### Rules
+- (MP) Modus ponens.
+- (NEC) Necessitation: from `⊢ p` infer `⊢ □p`.
+
+The Löb axiom (L) is what distinguishes GL from K4. It is itself a theorem of K + (4) `□p → □□p`, but only when combined with self-reference; GL takes (L) as primitive and *derives* (4):
+
+- (4) `□p → □□p` is a theorem of GL.
+- (T) `□p → p` is *not* a theorem of GL (and would in fact collapse GL to the inconsistent logic by Löb).
+
+### Kripke semantics
+GL is sound and complete for **finite transitive irreflexive Kripke frames**. ("Finite" comes from the Segerberg completeness theorem for GL; the more common semantic claim is "finite, transitive, conversely well-founded" frames.)
+
+## 2. Arithmetical realization
+
+Given a structure of formal arithmetic (PA in Solovay's original; any consistent r.e. extension of Robinson's Q works for soundness, but PA-style for completeness):
+
+A **realization** is a function `* : PropAtom → Formula_PA`, extended to all GL-formulas by:
+
+| GL syntax | Translation `φ*` |
+|---|---|
+| `p` (atom) | `*p` (chosen formula of PA) |
+| `⊥` | `⊥` (PA-falsehood, e.g. `0 = 1`) |
+| `φ → ψ` | `φ* → ψ*` |
+| `□φ` | `Prov(⌜φ*⌝)` — Gödel's provability predicate |
+
+**Solovay's theorem:**
+
+> `GL ⊢ φ ⟺ ∀ realizations *, PA ⊢ φ*`
+
+The (⟹) direction (soundness) follows from PA verifying HBL conditions D1–D3 plus the Löb derivability theorem. The (⟸) direction (completeness) is the hard part — Solovay's original construction embeds an arbitrary finite GL-Kripke counter-model into PA via a clever fixed-point construction.
+
+## 3. Soundness direction — what's already (axiomatized) in the gallery
+
+The existing `GodelSecondIncompletenessOQ02.lean` already contains the load-bearing pieces for soundness:
+
+| GL principle | Gallery analogue | Line |
+|---|---|---|
+| (K) `□(p→q) → (□p → □q)` | (would need `impl : Formula → Formula → Formula`) | not present |
+| (L) `□(□p → p) → □p` | informal in docstring `Löb's Theorem` | 213–235 |
+| (NEC) `⊢ φ ⇒ ⊢ □φ` | `d1_representability` axiom (from `GodelFirstIncompletenessOQ01`) | (parent) |
+| (4) `□φ → □□φ` | D3 condition (subsumed into `con_implies_G`) | 153 |
+| Second incompleteness | `second_incompleteness` theorem | 186 |
+
+**Gap:** The current `Formula` type has only `falsum` and `neg`/`Prov` as constructors needed for `Con`; there is **no object-language implication `impl : Formula → Formula → Formula`**. The axiom-count note (line 250) explicitly flags this: "without object-level implication, [D2 and D3] cannot be stated in the current type system."
+
+So the soundness direction of Solovay's theorem requires, as a *prerequisite*, extending the `Formula` type with `impl` (and ideally `conj`, `disj` for syntactic uniformity). This is **S2-α below**.
+
+## 4. Completeness direction — Solovay's construction (sketch)
+
+Solovay's original proof (1976) is one of the most ingenious arguments in 20th-century mathematical logic. Here is the high-level structure:
+
+### Setup
+Given a GL-formula `φ` such that `GL ⊬ φ`, we want a realization `*` with `PA ⊬ φ*`.
+
+By Segerberg's completeness theorem, there is a finite irreflexive transitive Kripke model `K = ⟨W, R, V⟩` and a world `w₀ ∈ W` with `K, w₀ ⊨ ¬φ`.
+
+### Solovay's recursive labels
+Define a recursive function `h : ℕ → W ∪ {0}` (where `0` is a "halt" sentinel) by:
+
+```
+h(0) = 0  -- start state
+h(n+1) = w  if h(n) ∈ {0, predecessors of w in R} and at step n+1 PA has not yet
+            decided the question "does h enter the future of w?"
+```
+
+This `h` is computable (PA can define it), and Solovay shows:
+
+- For each world `w ∈ W`, the formula `S_w := "h eventually halts in w or its R-future" can be expressed in PA.
+- The arithmetical realization sends each propositional atom `p` to `⋁_{w : V(p) ∋ w} S_w`.
+- Solovay proves: for each world `w` and GL-formula ψ, `K, w ⊨ ψ ⟺ PA ⊢ (S_w → ψ*)`.
+
+Specializing to the witnessing world `w₀ ⊨ ¬φ`, we get `PA ⊢ S_{w₀} → ¬φ*`, hence `PA ⊬ φ*` (assuming PA is consistent and `S_{w₀}` is itself unrefutable — which Solovay proves).
+
+### Why it's hard to formalize
+The construction requires:
+
+1. **PA-formalized recursion theory.** The function `h` must be PA-definable, and PA must verify its properties; this needs `ConditionalFunction.encode` / partial-recursive encoding.
+2. **Sigma-1 arithmetization of GL satisfaction.** The relation `K, w ⊨ φ` must be PA-arithmetizable as a Σ_1-formula on the Gödel-codes.
+3. **Kripke completeness of GL.** Segerberg's theorem itself (GL is sound and complete over finite transitive irreflexive frames) — this is a non-trivial modal-logic result.
+4. **Coherence with the existing `Prov` axiom.** The current gallery uses an *opaque* `Provable : Formula → Prop` axiom (`GodelFirstIncompletenessOQ01`). Solovay's construction requires `Prov` to be the *actual* Σ_1-formalization, not an abstract predicate.
+
+These four ingredients are each substantial; a full formalization would be a multi-thousand-line effort comparable to Iorgulescu's Coq formalization of GL.
+
+## 5. Mathlib API survey
+
+```
+Mathlib.Logic.Basic
+  - Classical.em, not_not  (already used by the gallery)
+
+Mathlib.ModelTheory.Basic
+  - First-order language framework (for arithmetization of PA syntax)
+  - Note: Mathlib's first-order machinery is not yet Σ_n-stratified
+
+Mathlib.Computability.Partrec
+  - Partial recursive functions (for Solovay's h)
+  - Gödel numbering: Mathlib.Computability.Primrec
+
+Mathlib.Computability.GodelBeta
+  - β-function (for sequence coding in PA) — not yet in Mathlib as of v4.26.0
+```
+
+**Gap analysis:**
+- Mathlib has no provability-logic / modal-logic library. A `GL` formalization would be the first.
+- Mathlib's first-order ModelTheory framework can encode PA but does not yet have a Σ_n hierarchy.
+- The β-function and primitive-recursive arithmetic are partial: PRA-style coding is available, but the full Σ_1-completeness theorem (every true Σ_1-sentence is PA-provable) is not in Mathlib.
+
+## 6. Three candidate S2 deliverables (ranked by tractability)
+
+### S2-α (Easy, ~50–120 lines) — Extend `Formula` with `impl`
+Augment `GodelIncompleteness.lean` (or a companion file) with:
+
+```lean
+def impl (φ ψ : Formula) : Formula := ⟨encode (φ, ψ, "impl")⟩
+
+axiom d2_axiom : ∀ φ ψ, (⊢ impl φ ψ) ↔ ((⊢ φ) → (⊢ ψ))
+axiom d3_axiom : ∀ φ, (⊢ Prov (godelNum φ)) → (⊢ Prov (godelNum (Prov (godelNum φ))))
+```
+
+This *adds* axioms (the gallery convention is honest axiomatization) but enables stating GL principles in the object language. Should be presented as a *companion file* rather than modifying the parent's axiom count.
+
+### S2-β (Medium, ~200–400 lines) — Soundness direction of Solovay
+With S2-α complete, prove:
+
+```lean
+theorem solovay_soundness (φ : GLFormula) :
+    GL_proves φ → ∀ * : PropAtom → Formula, ⊢ realization * φ
+```
+
+This is a straightforward induction on `GL_proves` once D2/D3 are stated. The realization function and `GLFormula` type are new definitions but well-localized. The hard work is matching up Lean's `Prov` predicate with GL's `□`.
+
+### S2-γ (Very hard, multi-thousand lines) — Completeness direction
+Solovay's original construction. **Not recommended** as a single S2 effort. Better decomposed into:
+- S3-1: Define `GLFormula` and `GL_proves` independently of PA. Prove Segerberg completeness (finite Kripke models).
+- S3-2: Arithmetize finite Kripke models as Σ_1-formulas of PA.
+- S3-3: Solovay's fixed-point `h` construction.
+- S3-4: Tie together via the Σ_1-completeness of PA.
+
+**Recommended S2 start: S2-α.** Smallest scope, highest reuse value, unlocks both S2-β and (eventually) Löb's theorem itself (currently informal at line 213 of the parent file).
+
+## 7. Risks and watch-outs
+
+- **Axiom inflation.** Each new axiom added to `Formula` (impl, conj, disj) appears in the gallery's axiom count. Memory project `project_tractatus_review.md` notes the policy that *structure-encoded* assumptions count too. The S2-α design proposes a *companion file* to isolate the new axioms.
+
+- **Opaque `Provable` vs concrete `Prov`.** The current gallery uses an opaque `Provable : Formula → Prop` axiom. Solovay's completeness requires a concrete Σ_1-formalization. This is a fundamental architectural mismatch and means the completeness direction *cannot* be formalized within the current gallery framework without a major rebuild — flagging this is a key S1 deliverable.
+
+- **GL-axiomatization choices.** Different texts give GL via (K)+(L)+(NEC) vs (K)+(4)+(L)+(NEC) (redundant) vs Solovay-style fixed-point semantics. Any S2 work should pin down the axiom set up front.
+
+## 8. References
+
+- Solovay, R. M. (1976). "Provability interpretations of modal logic", *Israel J. Math.* — the original arithmetical completeness theorem.
+- Boolos, G. (1993). *The Logic of Provability* — the canonical textbook reference.
+- Segerberg, K. (1971). "An essay in classical modal logic" — Kripke completeness of GL over finite transitive irreflexive frames.
+- Löb, M. H. (1955). "Solution of a problem of Leon Henkin", *J. Symbolic Logic* — Löb's theorem itself.
+- Iorgulescu, V. (Coq). *A Coq formalization of GL* — closest prior art for an interactive-theorem-prover formalization.

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/problem.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/problem.md
@@ -1,0 +1,39 @@
+# godel-second-incompleteness-oq02-oq-02 — Solovay's Arithmetical Completeness for GL
+
+## Question
+
+> **Solovay's Arithmetical Completeness Theorem (1976).** The propositional modal logic GL (Gödel-Löb) is sound and complete for the provability interpretation in PA. Formally:
+>
+> `GL ⊢ φ ⟺ ∀ * : PropAtom → Formula_PA, PA ⊢ φ*`
+>
+> where `*` is any "arithmetical realization" sending propositional atoms to PA-formulas and the modality `□` to the Gödel provability predicate `Prov`.
+
+The OQ asks for a Lean 4 formalization of this theorem in the framework of `Proofs/GodelSecondIncompletenessOQ02.lean` (and its parent `GodelIncompleteness.lean`). The goal is the **completeness direction** (Solovay's hard result); the soundness direction reduces to the HBL derivability conditions D1–D3 already axiomatized in the parent file.
+
+## Why it matters
+
+1. **Definitive answer to the provability question.** Hilbert-Bernays-Löb conditions tell us *which* provability facts hold; Solovay's theorem tells us *exactly* which propositional modal facts hold for the provability predicate. It is the conceptual analogue of Gödel completeness for first-order logic — bounding the propositional theory of provability.
+
+2. **GL is decidable.** Unlike PA itself, GL has a decision procedure (in fact GL is in PSPACE). Solovay's theorem therefore gives a *decidable* characterization of the propositional fragment of PA-provability.
+
+3. **Bridges modal logic and arithmetic.** The theorem is the canonical bridge between two large mathematical fields (modal logic / Kripke semantics on one side, formal arithmetic / Hilbert-style derivability on the other). A Lean formalization unlocks downstream applications to provability-logic refinements (GLP, GLS, polymodal extensions).
+
+4. **Wiedijk's 100-theorems list (#56 "Gödel's incompleteness theorems").** The current `GodelIncompleteness` file proves the first and second incompleteness theorems; Solovay's theorem is the canonical "third pillar" of the provability-logic story and a natural next-step extension.
+
+## Scope of S1 OBSERVE
+
+Documentation only — no Lean code changes. We catalogue:
+
+1. The precise statement of GL (axioms + rules) and the arithmetical translation operation `*`.
+2. The four pieces of the soundness direction (already half-axiomatized in `GodelSecondIncompletenessOQ02.lean`).
+3. The structure of Solovay's completeness proof (Kripke-frame construction over the arithmetical theory).
+4. Existing Mathlib / gallery infrastructure that can be reused.
+5. A graded S2/S3 plan splitting the work into proportionate milestones — soundness first, then easier fragments of completeness.
+
+## Anchoring file references
+
+- `Proofs/GodelIncompleteness.lean` — base layer: `Formula`, `Provable`, `godelNum`, HBL conditions, first incompleteness.
+- `Proofs/GodelSecondIncompletenessOQ02.lean:65–84` — `falsum`, `Con` (consistency formula in object language).
+- `Proofs/GodelSecondIncompletenessOQ02.lean:120–153` — `con_implies_G` axiom (the formalized first-incompleteness step that mediates the second-incompleteness proof).
+- `Proofs/GodelSecondIncompletenessOQ02.lean:186` — `second_incompleteness` (consistent F ⊬ Con(F)).
+- `Proofs/GodelSecondIncompletenessOQ02.lean:213` — informal statement of Löb's theorem (the modal axiom that distinguishes GL from K4).

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
@@ -1,0 +1,76 @@
+# State — godel-second-incompleteness-oq02-oq-02
+
+## Phase: S1 OBSERVE (complete)
+
+## Session summary
+
+**S1 OBSERVE (this session, 2026-05-12, researcher-4)** — doc-only survey of Solovay's arithmetical completeness theorem for the propositional modal logic GL.
+
+Deliverables produced this session:
+
+- `research/problems/godel-second-incompleteness-oq02-oq-02/problem.md` — precise statement, scope, anchor file/line references.
+- `research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md` — GL axiomatization, arithmetical realization operation, gallery-correspondence table for soundness, Solovay's completeness construction sketch, Mathlib API gap analysis, three S2 candidates ranked by tractability.
+- `research/problems/godel-second-incompleteness-oq02-oq-02/state.md` — session log and S2-α sketch.
+- Pool entry updated (status = `in-progress`, S1 OBSERVE completed).
+
+No Lean code changes. No build performed.
+
+## Theorem statement at a glance
+
+> `GL ⊢ φ ⟺ ∀ realizations * : PropAtom → Formula_PA, PA ⊢ φ*`
+>
+> where `□` is interpreted as `Prov(⌜·⌝)` and `*` distributes over `→` and `⊥`.
+
+## Soundness vs completeness split
+
+| Direction | Status in gallery | S2 difficulty |
+|---|---|---|
+| GL ⊢ φ ⇒ PA ⊢ φ* (soundness) | half-axiomatized (D1 + `con_implies_G`) | Medium (S2-β) |
+| PA ⊢ φ* (∀ *) ⇒ GL ⊢ φ (completeness) | not in gallery framework | Very hard (S3+) |
+
+## Architectural flag
+
+**The opaque `Provable : Formula → Prop` axiom (from `GodelFirstIncompletenessOQ01`) is incompatible with Solovay's completeness construction**, which requires a concrete Σ_1-formalization of provability. This is a fundamental architectural mismatch that should be flagged before any completeness-direction S3 work begins. The S2-β soundness direction is achievable with the existing framework; the completeness direction is not.
+
+## Next action (S2 recommended)
+
+**S2-α**: Extend the `Formula` type with `impl : Formula → Formula → Formula` and add D2/D3 as honest object-level axioms. Implementation as a companion file (`GodelSecondIncompletenessOQ02Companion.lean`) isolates the new axioms from the parent.
+
+Sketch:
+
+```lean
+namespace GodelSecondCompanion
+
+def impl (φ ψ : Formula) : Formula := ⟨Nat.pair φ.code (Nat.pair ψ.code 1)⟩
+
+axiom d2_modus_ponens : ∀ φ ψ : Formula,
+    (⊢ Prov (godelNum (impl φ ψ))) → (⊢ Prov (godelNum φ)) → (⊢ Prov (godelNum ψ))
+
+axiom d3_internal_necessitation : ∀ φ : Formula,
+    (⊢ Prov (godelNum φ)) → (⊢ Prov (godelNum (Prov (godelNum φ))))
+
+end GodelSecondCompanion
+```
+
+Expected scope: ~50–120 lines in a new companion file, **2 new axioms** (D2 and D3 cleanly factored out of `con_implies_G`). The parent's axiom count is unchanged; the companion's new axiom count is documented separately in its docstring.
+
+## Open questions deferred to later sessions
+
+1. **S2-β (S3 candidate, ~200–400 lines):** Soundness direction of Solovay — prove `GL_proves φ → ⊢ realization * φ` for any realization, by induction on `GL_proves`.
+
+2. **S3+ (multi-session, multi-thousand lines):** Completeness direction. Requires (a) replacing the opaque `Provable` axiom with a concrete Σ_1-formalization of provability, (b) Segerberg completeness of GL over finite Kripke models, (c) Solovay's fixed-point `h` construction, (d) Σ_1-completeness of PA. Best done after a major restructuring of the parent file's axiomatization.
+
+3. **S4+ alternative (Löb formalization, ~150 lines):** Even without full Solovay, *Löb's theorem* (`F ⊢ □A → A ⇒ F ⊢ A`) can be formalized once D2/D3 are stated as proper axioms. The parent file flags this at line 213 as desirable but currently informal. This would also resolve a Wiedijk-100-list adjacent gap.
+
+## Build / verification
+
+S1 OBSERVE is doc-only — no build required. Line counts:
+
+- `problem.md`: ~50 lines
+- `knowledge.md`: ~170 lines
+- `state.md` (this file): ~70 lines
+
+## Blockers
+
+- **No code-level blocker for S2-α.** The companion file approach is well-localized.
+- **Architectural blocker for S3+ completeness direction:** the opaque `Provable` axiom must be replaced with a concrete Σ_1-formalization. This is a major restructuring and should be a separate proposal (not a single session).

--- a/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
+++ b/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
@@ -1,0 +1,108 @@
+{
+  "slug": "godel-second-incompleteness-oq02-oq-02",
+  "title": "Solovay's arithmetical completeness theorem: the propositional modal logic GL axiomatizes exactly the provability facts of PA",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "GL \\vdash \\varphi \\iff \\forall * : \\mathrm{PropAtom} \\to \\mathrm{Formula_{PA}},\\, \\mathrm{PA} \\vdash \\varphi^* \\text{, where } \\square \\text{ is realized as } \\mathrm{Prov}(\\ulcorner \\cdot \\urcorner).",
+    "plain": "Formalize Solovay's 1976 arithmetical completeness theorem in the GodelIncompleteness gallery framework: the propositional modal logic GL (Gödel-Löb, with axioms K, L, and rule NEC) proves exactly those propositional formulas whose every arithmetical realization is PA-provable.",
+    "whyMatters": [
+      "Canonical bridge between modal logic and formal arithmetic — bounds the propositional theory of provability exactly.",
+      "Gives a decidable characterization (GL is in PSPACE) of an inherently undecidable theory (PA).",
+      "Foundation for downstream provability-logic refinements (GLP, GLS, polymodal extensions).",
+      "Natural third pillar after first and second incompleteness; Wiedijk-100 list adjacent."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "First and second incompleteness theorems already formalized in GodelIncompleteness.lean and GodelSecondIncompletenessOQ02.lean (6 axioms total).",
+      "Löb's theorem informally stated at GodelSecondIncompletenessOQ02.lean:213 (no Lean proof — needs D2/D3 + Henkin fixed-point)."
+    ],
+    "open": [
+      "S2-α: Extend Formula type with object-level impl; state D2 and D3 as honest object-level axioms (companion file).",
+      "S2-β/S3: Soundness direction of Solovay — GL ⊢ φ ⇒ ∀ realizations *, PA ⊢ φ*.",
+      "S3+: Completeness direction — requires concrete Σ_1-formalization of Provable, Segerberg Kripke completeness, Solovay's h construction, and Σ_1-completeness of PA."
+    ],
+    "goal": "Reach a build-verified Lean 4 proof of at least the soundness direction (GL ⊢ φ ⇒ PA ⊢ φ* for all realizations). The completeness direction requires architectural restructuring of the parent file's opaque Provable axiom and is deferred to a separate multi-session effort."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T16:55:00Z",
+    "iteration": 1,
+    "focus": "Survey GL axiomatization, arithmetical realization, gallery-correspondence for soundness, and Solovay's completeness construction. Identify the architectural mismatch between opaque Provable and Σ_1-formalized provability as the principal barrier to completeness.",
+    "blockers": [],
+    "nextAction": "S2-α: Companion file GodelSecondIncompletenessOQ02Companion.lean extending Formula with impl + D2/D3 axioms. ~50-120 lines, 2 new axioms isolated from parent.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE: doc-only survey establishing GL axiomatization (K, L, NEC), arithmetical realization operation, gallery-correspondence table (D1 is in parent, D2 and D3 are subsumed into con_implies_G), Solovay's recursive-labeling completeness sketch, and Mathlib API gap analysis. Soundness direction is achievable with modest extensions (S2-α/β); completeness direction requires major architectural rebuild (S3+).",
+    "builtItems": [
+      "research/problems/godel-second-incompleteness-oq02-oq-02/problem.md (S1 OBSERVE — statement, scope, anchors)",
+      "research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md (S1 OBSERVE — GL axioms, realization, soundness/completeness split, Mathlib survey, S2 candidates)",
+      "research/problems/godel-second-incompleteness-oq02-oq-02/state.md (S1 OBSERVE — session log and S2-α sketch)"
+    ],
+    "insights": [
+      "Soundness direction is reachable with companion-file extensions (Formula.impl, D2, D3 as axioms).",
+      "Completeness direction has a fundamental architectural mismatch: the opaque Provable predicate in GodelFirstIncompletenessOQ01 is incompatible with Solovay's concrete Σ_1-construction.",
+      "Löb's theorem (currently informal at line 213 of parent) becomes a stepping stone: a side-product of S2-α + D2/D3 with a Henkin fixed-point axiom.",
+      "GL Kripke completeness (Segerberg 1971) is itself a substantial modal-logic theorem and a prerequisite for Solovay's completeness — not currently in Mathlib."
+    ],
+    "mathlibGaps": [
+      "No modal logic / provability logic library in Mathlib.",
+      "Mathlib's first-order ModelTheory framework lacks Σ_n stratification (needed for Σ_1-completeness of PA).",
+      "No β-function / sequence-coding in PA at the level needed for Solovay's h.",
+      "GL Kripke completeness (Segerberg) is not in Mathlib — would be its own contribution."
+    ],
+    "nextSteps": [
+      "S2-α: Companion file with Formula.impl + D2/D3 axioms (~50-120 lines, recommended start).",
+      "S2-β/S3: Soundness direction of Solovay — induction on GL_proves with realization function.",
+      "S3-Löb: Formalize Löb's theorem itself once D2/D3 are stated (~150 lines, fills the line-213 informal gap).",
+      "S4+: Completeness direction — major rebuild requiring concrete Σ_1-Provable, GL Kripke completeness, Solovay's h, and PA Σ_1-completeness."
+    ]
+  },
+  "tags": [
+    "logic",
+    "foundations",
+    "incompleteness",
+    "self-reference",
+    "advanced",
+    "wiedijk-100",
+    "seeker-selected",
+    "provability-logic",
+    "modal-logic",
+    "solovay"
+  ],
+  "relatedProofs": [
+    "godel-second-incompleteness-oq02",
+    "godel-incompleteness",
+    "godel-first-incompleteness-oq01"
+  ],
+  "references": {
+    "papers": [
+      "Solovay, R. M. (1976), 'Provability interpretations of modal logic', Israel J. Math. — original arithmetical completeness theorem.",
+      "Boolos, G. (1993), The Logic of Provability — canonical textbook reference.",
+      "Segerberg, K. (1971), 'An essay in classical modal logic' — Kripke completeness of GL.",
+      "Löb, M. H. (1955), 'Solution of a problem of Leon Henkin', J. Symbolic Logic — Löb's theorem."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/ModelTheory/Basic.html",
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Computability/Partrec.html"
+    ],
+    "mathlib": [
+      "Mathlib.ModelTheory.Basic",
+      "Mathlib.Computability.Partrec",
+      "Mathlib.Computability.Primrec",
+      "Mathlib.Logic.Basic"
+    ]
+  },
+  "started": "2026-05-12T14:35:20.287Z",
+  "lastUpdate": "2026-05-12T16:55:00Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Fresh tier-B S1 OBSERVE pass for `godel-second-incompleteness-oq02-oq-02`: Solovay's 1976 arithmetical completeness theorem for the propositional modal logic GL. Doc-only.

## Deliverables

- `research/problems/godel-second-incompleteness-oq02-oq-02/problem.md` — theorem statement in the existing `GodelIncompleteness` framework + anchor references.
- `research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md` — GL axiomatization, arithmetical realization, soundness/completeness split, Solovay's recursive-labeling sketch, Mathlib gap analysis, three S2 candidates ranked by tractability.
- `research/problems/godel-second-incompleteness-oq02-oq-02/state.md` — session log, S2-α sketch, architectural-blocker flag.
- `src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json` — phase `NEW` → `OBSERVE`; populated `knownResults` / `knowledge` / `nextSteps`.

## Theorem statement

`GL ⊢ φ  ⟺  ∀ realizations *,  PA ⊢ φ*`

where `*` sends propositional atoms to PA-formulas and `□` to `Prov(⌜·⌝)`.

## Soundness vs completeness

| Direction | Status in gallery | S2 difficulty |
|---|---|---|
| GL ⊢ φ ⇒ PA ⊢ φ* (soundness) | half-axiomatized (D1 + `con_implies_G`) | Medium (S2-β) |
| PA ⊢ φ* (∀ *) ⇒ GL ⊢ φ (completeness) | not reachable in current framework | Very hard (S3+) |

## Architectural flag

**The opaque `Provable : Formula → Prop` axiom in `GodelFirstIncompletenessOQ01` is incompatible with Solovay's completeness construction**, which requires a concrete Σ_1-formalization of provability. This is a fundamental mismatch and should be flagged before any completeness-direction S3 work begins. Soundness is achievable; full completeness requires a major rebuild.

## Next action

**S2-α**: Companion file `GodelSecondIncompletenessOQ02Companion.lean` extending `Formula` with object-level `impl` and adding D2/D3 as honest axioms (~50–120 lines, 2 new axioms isolated from parent). Side-product: Löb's theorem (currently informal at parent line 213) becomes provable.

## Test plan

- [x] No Lean code changes — S1 doc-only, no build required.
- [x] JSON validated (well-formed; phase `OBSERVE`).
- [x] Pre-push probe: 0 competing open PRs for slug.
- [x] All anchor line references (GodelSecondIncompletenessOQ02.lean:65-84, 120-153, 186, 213-235) verified against current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)