### PR TITLE
Research(CLT OQ-02-OQ-04): S5a — discharge polynomial_summable_of_exponent_gt_one (drift fix, build verified)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -14,8 +14,20 @@ the Ibragimov (1962) covariance summability condition
 is satisfied, and the long-run variance σ² = Var(X₁) + 2∑_{k≥1} Cov(X₁, X_{k+1})
 exists and is finite. If additionally σ² > 0, then S_n/√n →_d N(0, σ²).
 
-**Status of this file (S4 ACT — build-fix + structural decomposition).**
-S3 (previous session) merged at `build pending` and never actually compiled
+**Status of this file (S5a — Mathlib drift fix: `polynomial_summable_of_exponent_gt_one`
+discharged via `Real.summable_nat_rpow`).**
+
+S5a (this session) closes a previously open Mathlib-drift sorry that was carried
+forward from S2: the ζ-function summability fact `Σ n^{-s} < ∞ ↔ s > 1` had been
+left as a `sorry` since the original `Real.summable_nat_rpow_inv` name was assumed
+moved/renamed. We use `Real.summable_nat_rpow : Summable ((n:ℝ)^p) ↔ p < -1` from
+`Mathlib.Analysis.PSeries`; with `p = -s` and `s > 1` the equivalence yields the
+result by a single `linarith`. Sorry count: 3 → 2. No structural changes; the
+remaining 2 sorries (`davydov_covariance_inequality`, `mixing_clt_ibragimov`) are
+unchanged S5b / S6+ targets.
+
+**Earlier session: S4 ACT (build-fix + structural decomposition).**
+S3 (PR #17820) merged at `build pending` and never actually compiled
 on `origin/main`. The compile blockers were:
 (a) stale import `Mathlib.Probability.Variance` (file removed in Mathlib drift).
 (b) typeclass synthesis quirk where direct
@@ -72,6 +84,7 @@ import Mathlib.Probability.IdentDistrib
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
+import Mathlib.Analysis.PSeries
 import Mathlib.Topology.Order.Basic
 import Mathlib.Order.Filter.Basic
 import Proofs.CentralLimitTheoremOQ02
@@ -166,16 +179,12 @@ structure IbragimovHypotheses
 /-! ## Part II: Elementary summability helpers -/
 
 /-- *Polynomial summability* of `n^{-s}` for `s > 1`: the standard ζ-function
-fact, derived from Mathlib's `Real.summable_nat_rpow_inv`. -/
-theorem polynomial_summable_of_exponent_gt_one (s : ℝ) (_hs : 1 < s) :
-    Summable (fun n : ℕ => (n : ℝ) ^ (-s)) := by
-  -- The classical ζ-function summability fact: Σ n^{-s} converges iff s > 1.
-  -- In current Mathlib (drift since the S3 statement) the precise namespaced
-  -- name has moved; the proof reduces to `Real.rpow_neg` + an existing
-  -- summability lemma in Mathlib.Analysis.SpecialFunctions.Pow.Real.
-  -- Mechanic-pass target: locate the renamed `summable_*_nat_rpow_inv` /
-  -- `summable_one_div_nat_rpow` lemma and substitute.
-  sorry
+fact, derived from Mathlib's `Real.summable_nat_rpow` (which characterises
+`Summable (n ↦ n ^ p)` as `p < -1`). With `p = -s` and `s > 1` we get
+`-s < -1`. -/
+theorem polynomial_summable_of_exponent_gt_one (s : ℝ) (hs : 1 < s) :
+    Summable (fun n : ℕ => (n : ℝ) ^ (-s)) :=
+  Real.summable_nat_rpow.mpr (by linarith)
 
 /-- *Sharp-threshold corollary*: under Ibragimov's hypotheses with
 `r > (2 + δ) / δ`, the Ibragimov covariance series ∑ n^{−rδ/(2+δ)} is summable. -/

--- a/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
@@ -29,19 +29,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T05:30:00Z",
-    "iteration": 4,
-    "focus": "S4 ACT — Build-fix + structural decomposition. Discovered S3 PR #17820 merged build-pending and never built on origin/main; fixed 3 blockers (stale Mathlib.Probability.Variance import, MS Ω typeclass synthesis collision via Fin 2 → MS Ω wrap, σ² → σsq rename). Proven: indicator_cov_le_one ([0,1] envelope). Documented structural decomposition of davydov_covariance_inequality.",
+    "since": "2026-05-12T14:00:00Z",
+    "iteration": 5,
+    "focus": "S5a ACT — Mathlib drift-fix: `polynomial_summable_of_exponent_gt_one` discharged via `Real.summable_nat_rpow.mpr` (one-line proof). Sorry count 3 → 2. Build verified.",
     "blockers": [],
-    "nextAction": "S5a (mechanic-pass): formalize the 3 order-theory ingredients (alphaMixingCoeff_le_one, alphaMixingCoeff_nonneg, davydov_indicator_bound) using Prop-iSup-unification patterns. S5b: L^p density step via level-set decomposition + Hölder.",
+    "nextAction": "S5b ACT (~100 lines): L^p density step of davydov_covariance_inequality via level-set decomposition + Hölder, reducing to davydov_indicator_bound. Parallel: 3 order-theory ingredients (alphaMixingCoeff_le_one, alphaMixingCoeff_nonneg, davydov_indicator_bound).",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "ACT — S4 BUILD-FIX + structural decomposition. Discovered S3 PR #17820 merged build-pending and never compiled on origin/main. Fixed 3 blockers: stale Mathlib.Probability.Variance import (Mathlib drift), MS Ω typeclass-synthesis collision (refactored davydov_covariance_inequality signature from (ℱ 𝒢 : MS Ω) to (σPair : Fin 2 → MS Ω), the parent file's pattern from σ_k functions), and σ² (invalid Lean ident) → σsq rename. PROVEN: indicator_cov_le_one — the [0,1] envelope for the indicator-cov term, BddAbove witness for the nested suprema. Documented 3-ingredient structural decomposition of davydov_covariance_inequality (alphaMixingCoeff_le_one, alphaMixingCoeff_nonneg, davydov_indicator_bound) + L^p density step in the theorem's docstring. Sorries unchanged at 2 (davydov + main CLT); 0 axioms; 502 lines; 8 theorems.",
+    "progressSummary": "ACT — S5a Mathlib drift-fix: `polynomial_summable_of_exponent_gt_one` discharged via `Real.summable_nat_rpow.mpr (by linarith)` from `Mathlib.Analysis.PSeries`. Sorries 3 → 2 (closes the long-standing ζ-function summability sorry left from S2 awaiting a name-drift resolution). Build verified on Docker (Mathlib v4.26.0). The remaining 2 sorries are `davydov_covariance_inequality` (L^p version, S5b target) and `mixing_clt_ibragimov` (S6+ target). S4 progress carried forward: indicator_cov_le_one, indicator_pair_covariance_eq, build-fix complete, structural decomposition of davydov documented.",
     "builtItems": [
       "research/problems/central-limit-theorem-oq-02-oq-04/problem.md — full problem statement, threshold derivation, Bernstein-block proof outline",
       "research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md — parent-file inventory, Mathlib gap analysis, 6-session decomposition plan",
@@ -126,7 +126,7 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.562Z",
-  "lastUpdate": "2026-05-12T03:35:00Z",
+  "lastUpdate": "2026-05-12T14:00:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
       "filename": "CentralLimitTheoremOQ02OQ04.lean",
-      "lineCount": 231,
-      "theoremCount": 4,
+      "lineCount": 553,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary

**S5a Mathlib drift-fix** for `central-limit-theorem-oq-02-oq-04`. Closes the long-standing ζ-function summability sorry left in `polynomial_summable_of_exponent_gt_one` since S2.

The proof is a single line using `Real.summable_nat_rpow` from `Mathlib.Analysis.PSeries`:

```lean
theorem polynomial_summable_of_exponent_gt_one (s : ℝ) (hs : 1 < s) :
    Summable (fun n : ℕ => (n : ℝ) ^ (-s)) :=
  Real.summable_nat_rpow.mpr (by linarith)
```

`Real.summable_nat_rpow` characterises `Summable ((n:ℝ)^p)` as `p < -1`. With `p = -s` and `s > 1`, this gives `-s < -1`, closed by `linarith`.

The previous comment in the file claimed the lemma needed `Real.summable_nat_rpow_inv` (the reciprocal version) plus an `rpow_neg` rewrite. The cleaner match is the directly-exponent version `Real.summable_nat_rpow`, which avoids the inverse rewrite entirely.

Added an explicit `import Mathlib.Analysis.PSeries` since the lemma is not transitively pulled in by the existing `SpecialFunctions.Pow.Real` chain on the Mathlib v4.26.0 pin.

## Sorry count

- **Before**: 3 (`polynomial_summable_of_exponent_gt_one`, `davydov_covariance_inequality`, `mixing_clt_ibragimov`)
- **After**: **2** (`davydov_covariance_inequality` at line 343, `mixing_clt_ibragimov` at line 539)

Both remaining sorries are unchanged S5b / S6+ targets independent of this drift fix.

## Counts

| field | before | after |
|---|---|---|
| sorries | 3 | **2** |
| lineCount | 544 | 553 |
| theoremCount | 9 | 9 |
| axiomCount | 0 | 0 |

## Build status

**BUILD VERIFIED** — `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04` completes successfully on Mathlib v4.26.0 (3131 jobs). Only the two intended sorries warn:

```
warning: Proofs/CentralLimitTheoremOQ02OQ04.lean:343:8: declaration uses 'sorry'
warning: Proofs/CentralLimitTheoremOQ02OQ04.lean:539:8: declaration uses 'sorry'
```

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04` (verified locally, 3131 jobs, exit 0)
- [x] meta.json + state.md + problem JSON kept in sync (sorries 3→2, lineCount 544→553, theoremCount 9)
- [x] Updated state.md with S5a session record + next-action notes for S5b

🤖 Generated with [Claude Code](https://claude.com/claude-code)