### PR TITLE
research(hilbert-11-oq-02): Iter 17 — Section 27 universal Case-A theorem (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -1719,6 +1719,209 @@ theorem selmer_padic_solubility_extended_caseB_primes :
    selmer_padic_solubility_p67_hensel,
    selmer_padic_solubility_p79_hensel⟩
 
+/-! ## Section 27: Universal Case-A Theorem (cube-root parametric closure)
+
+Sections 22-25 enumerated specific Case-A primes
+(`p ∈ {41, 47, 53, 59, 71, 83, 89, 101, 107, 113}`) by hand, each with
+an explicit `z₀` satisfying `5·z₀^3 ≡ -4 (mod p)`. Section 27 codifies
+the parametric existence-of-`z₀` step, eliminating per-prime enumeration:
+
+> **Theorem (universal Case-A).** For every prime `p ≡ 2 (mod 3)` with
+> `p ≠ 2` and `p ≠ 5`, the Selmer cubic `3x³ + 4y³ + 5z³ = 0` is
+> `ℚ_[p]`-soluble, axiom-free.
+
+The key fact: when `p ≡ 2 (mod 3)`, the cube map `x ↦ x³` on `(ZMod p)ˣ`
+is bijective. The explicit cube-root inverse is `x ↦ x^m` where
+`m := (2(p-1) + 1) / 3`: indeed `3m = 2(p-1) + 1`, so by Fermat's
+little theorem `(a^m)^3 = a^{2(p-1)+1} = a · (a^{p-1})^2 = a · 1 = a`
+for any nonzero `a : ZMod p`. Combined with `5 ≠ 0` in `ZMod p` (using
+`p ≠ 5`), this gives a cube root `z` of `-4/5`. Lifting `z` to `ℤ` via
+`(z.val : ℤ)` produces the integer witness consumed by
+`selmer_padic_solubility_caseA` (Section 13). The result subsumes
+all of Sections 11 (z-side), 17 (z-side), 22, 23, 24, 25 — every
+Case-A prime there satisfies the hypotheses.
+
+The per-prime corollaries `selmer_padic_solubility_p{11,41,...,113}_hensel`
+are **not** removed (they remain for downstream consumers and the bundled
+discharge theorems `_extended_caseA_primes_v{1..4}`); Section 27 is an
+orthogonal extension showing the underlying parametric closure. -/
+
+namespace UniversalCaseA
+
+/-- Cube-root inverse exponent: `m := (2(p-1) + 1) / 3`. When
+    `p ≡ 2 (mod 3)` and `p ≠ 2`, this satisfies
+    `3m = 2(p-1) + 1`, so `3m ≡ 1 (mod p-1)`. -/
+def cubeInverseExp (p : ℕ) : ℕ := (2 * (p - 1) + 1) / 3
+
+/-- For primes `p ≡ 2 (mod 3)` with `p ≠ 2`,
+    `3 · cubeInverseExp p = 2(p-1) + 1` exactly (the division is exact
+    since `2(p-1) + 1 ≡ 0 (mod 3)` when `p ≡ 2 (mod 3)`). -/
+lemma three_mul_cubeInverseExp_eq {p : ℕ} [Fact (Nat.Prime p)]
+    (hp_mod3 : p % 3 = 2) (hp_ne_2 : p ≠ 2) :
+    3 * cubeInverseExp p = 2 * (p - 1) + 1 := by
+  have hp_two : 2 ≤ p := Nat.Prime.two_le (Fact.out : Nat.Prime p)
+  unfold cubeInverseExp
+  omega
+
+/-- For any nonzero `a : ZMod p` (with `p` prime, `p ≡ 2 (mod 3)`,
+    `p ≠ 2`), `(a^m)^3 = a` where `m := cubeInverseExp p`. Proof:
+    `a^{3m} = a^{2(p-1)+1} = (a^{p-1})^2 · a = 1 · a = a` by Fermat. -/
+lemma pow_cubeInverseExp_pow_three {p : ℕ} [Fact (Nat.Prime p)]
+    (hp_mod3 : p % 3 = 2) (hp_ne_2 : p ≠ 2)
+    {a : ZMod p} (ha : a ≠ 0) :
+    (a ^ cubeInverseExp p) ^ 3 = a := by
+  have h_fermat : a ^ (p - 1) = 1 := ZMod.pow_card_sub_one_eq_one ha
+  rw [← pow_mul, mul_comm, three_mul_cubeInverseExp_eq hp_mod3 hp_ne_2]
+  rw [show 2 * (p - 1) + 1 = (p - 1) + ((p - 1) + 1) from by ring,
+      pow_add, pow_add, pow_one, h_fermat, one_mul, h_fermat, one_mul]
+
+/-- Helper: `p` prime and `p ≠ q` (for `q` prime) imply `¬ p ∣ q`. -/
+private lemma prime_not_dvd_of_prime_ne {p q : ℕ}
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hne : p ≠ q) :
+    ¬ p ∣ q := by
+  intro h
+  rcases hq.eq_one_or_self_of_dvd p h with h1 | hq'
+  · exact hp.one_lt.ne' h1.symm
+  · exact hne hq'
+
+/-- `(5 : ZMod p) ≠ 0` for `p` prime with `p ≠ 5`. -/
+lemma cast_five_ne_zero {p : ℕ} [Fact (Nat.Prime p)] (hp_ne_5 : p ≠ 5) :
+    (5 : ZMod p) ≠ 0 := by
+  have hp_prime : Nat.Prime p := Fact.out
+  have h_cast : ((5 : ℕ) : ZMod p) = (5 : ZMod p) := by norm_cast
+  rw [← h_cast, Ne, ZMod.natCast_zmod_eq_zero_iff_dvd]
+  exact prime_not_dvd_of_prime_ne hp_prime (by decide) hp_ne_5
+
+/-- `(4 : ZMod p) ≠ 0` for `p` prime with `p ≠ 2`. -/
+lemma cast_four_ne_zero {p : ℕ} [Fact (Nat.Prime p)] (hp_ne_2 : p ≠ 2) :
+    (4 : ZMod p) ≠ 0 := by
+  have hp_prime : Nat.Prime p := Fact.out
+  have h_cast : ((4 : ℕ) : ZMod p) = (4 : ZMod p) := by norm_cast
+  rw [← h_cast, Ne, ZMod.natCast_zmod_eq_zero_iff_dvd]
+  intro h
+  -- p ∣ 4 = 2^2, p prime, so p ∣ 2, so p = 2
+  have hp_dvd_2 : p ∣ 2 :=
+    hp_prime.dvd_of_dvd_pow (show p ∣ (2 : ℕ) ^ 2 from by exact_mod_cast h)
+  exact prime_not_dvd_of_prime_ne hp_prime (by decide) hp_ne_2 hp_dvd_2
+
+/-- `(3 : ZMod p) ≠ 0` for `p` prime with `p ≠ 3`. -/
+lemma cast_three_ne_zero {p : ℕ} [Fact (Nat.Prime p)] (hp_ne_3 : p ≠ 3) :
+    (3 : ZMod p) ≠ 0 := by
+  have hp_prime : Nat.Prime p := Fact.out
+  have h_cast : ((3 : ℕ) : ZMod p) = (3 : ZMod p) := by norm_cast
+  rw [← h_cast, Ne, ZMod.natCast_zmod_eq_zero_iff_dvd]
+  exact prime_not_dvd_of_prime_ne hp_prime (by decide) hp_ne_3
+
+/-- Existence of cube-root of `-4/5` in `ZMod p` for Case-A primes:
+    `∃ z, 5z³ + 4 = 0`. -/
+lemma exists_cube_root_neg_four_fifths {p : ℕ} [Fact (Nat.Prime p)]
+    (hp_mod3 : p % 3 = 2) (hp_ne_2 : p ≠ 2) (hp_ne_5 : p ≠ 5) :
+    ∃ z : ZMod p, 5 * z ^ 3 + 4 = 0 := by
+  have h5_ne_0 : (5 : ZMod p) ≠ 0 := cast_five_ne_zero hp_ne_5
+  have h4_ne_0 : (4 : ZMod p) ≠ 0 := cast_four_ne_zero hp_ne_2
+  -- a := -4 / 5 = -4 * 5⁻¹
+  set a : ZMod p := -4 * (5 : ZMod p)⁻¹ with ha_def
+  have h_5a_eq : 5 * a = -4 := by
+    show 5 * (-4 * (5 : ZMod p)⁻¹) = -4
+    rw [show (5 : ZMod p) * (-4 * (5 : ZMod p)⁻¹)
+          = -4 * (5 * (5 : ZMod p)⁻¹) from by ring,
+        mul_inv_cancel₀ h5_ne_0, mul_one]
+  have ha_ne_0 : a ≠ 0 := by
+    intro ha0
+    have h0 : 5 * a = 0 := by rw [ha0]; ring
+    rw [h_5a_eq] at h0
+    have : (4 : ZMod p) = 0 := by linear_combination -h0
+    exact h4_ne_0 this
+  refine ⟨a ^ cubeInverseExp p, ?_⟩
+  have h_cube : (a ^ cubeInverseExp p) ^ 3 = a :=
+    pow_cubeInverseExp_pow_three hp_mod3 hp_ne_2 ha_ne_0
+  rw [h_cube]
+  linear_combination h_5a_eq
+
+/-- **Universal Case-A theorem.** ℚ_[p]-solubility of the Selmer cubic
+    `3x³ + 4y³ + 5z³ = 0` for every prime `p ≡ 2 (mod 3)` with `p ≠ 2`
+    and `p ≠ 5`, axiom-free. Subsumes the per-prime corollaries of
+    Sections 11/17 (z-side) and Sections 22/23/24/25.
+
+    **Proof outline.**
+    1. By `exists_cube_root_neg_four_fifths`, there is `z : ZMod p` with
+       `5z³ + 4 = 0`.
+    2. Lift `z` to `z₀ : ℤ` via `(z.val : ℤ)`. Then `(z₀ : ZMod p) = z`.
+    3. `(p : ℤ) ∣ (4 + 5·z₀³)` follows from step 1 by
+       `ZMod.intCast_zmod_eq_zero_iff_dvd`.
+    4. `IsCoprime (15·z₀² : ℤ) (p : ℤ)` from
+       `(15·z₀² : ZMod p) = 15·z² ≠ 0` (since `p ∉ {3, 5}` and `z ≠ 0`).
+    5. Apply Section 13's `selmer_padic_solubility_caseA z₀`. -/
+theorem selmer_padic_solubility_caseA_universal {p : ℕ} [hp : Fact (Nat.Prime p)]
+    (hp_mod3 : p % 3 = 2) (hp_ne_2 : p ≠ 2) (hp_ne_5 : p ≠ 5) :
+    ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 := by
+  obtain ⟨z, hz⟩ := exists_cube_root_neg_four_fifths hp_mod3 hp_ne_2 hp_ne_5
+  -- Lift z : ZMod p to z₀ : ℤ via z.val
+  set z₀ : ℤ := (z.val : ℤ) with hz₀_def
+  have hp_prime : Nat.Prime p := Fact.out
+  have hp_ne_3 : p ≠ 3 := by intro h; rw [h] at hp_mod3; norm_num at hp_mod3
+  -- Cast: ((z₀ : ℤ) : ZMod p) = z
+  have h_cast : ((z₀ : ℤ) : ZMod p) = z := by
+    show ((z.val : ℤ) : ZMod p) = z
+    push_cast
+    exact ZMod.natCast_zmod_val z
+  -- z ≠ 0 in ZMod p (else 0 + 4 = 4 ≠ 0 contradicts hz)
+  have hz_ne_0 : z ≠ 0 := by
+    intro h0
+    rw [h0] at hz
+    simp at hz
+    exact cast_four_ne_zero hp_ne_2 hz
+  -- p ∣ (4 + 5 z₀³) in ℤ
+  have h_root : (p : ℤ) ∣ (4 + 5 * z₀ ^ 3) := by
+    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+    push_cast
+    rw [h_cast]
+    linear_combination hz
+  -- IsCoprime (15 z₀²) p in ℤ
+  have h_coprime : IsCoprime (15 * z₀ ^ 2 : ℤ) (p : ℤ) := by
+    have hp_int_prime : Prime (p : ℤ) := by exact_mod_cast hp_prime.prime
+    refine (hp_int_prime.coprime_iff_not_dvd.mpr ?_).symm
+    intro hd
+    have hzmod : ((15 * z₀ ^ 2 : ℤ) : ZMod p) = 0 :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd _ p).mpr hd
+    push_cast at hzmod
+    rw [h_cast] at hzmod
+    rcases mul_eq_zero.mp hzmod with h15 | hz2
+    · -- (15 : ZMod p) = 0; but 15 = 3*5 with both nonzero
+      have h3_ne : (3 : ZMod p) ≠ 0 := cast_three_ne_zero hp_ne_3
+      have h5_ne : (5 : ZMod p) ≠ 0 := cast_five_ne_zero hp_ne_5
+      have h_split : (15 : ZMod p) = (3 : ZMod p) * (5 : ZMod p) := by norm_num
+      rw [h_split] at h15
+      rcases mul_eq_zero.mp h15 with h3 | h5
+      · exact h3_ne h3
+      · exact h5_ne h5
+    · exact hz_ne_0 (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0) |>.mp hz2)
+  exact selmer_padic_solubility_caseA z₀ h_root h_coprime
+
+/-! ### Universal-Case-A subsumption examples
+
+The universal theorem `selmer_padic_solubility_caseA_universal` recovers
+the per-prime Hensel-lifted solubility of every Case-A prime as a
+one-line corollary, without any explicit witness arithmetic. We exhibit
+two illustrative corollaries (`p = 11`, `p = 41`); the same one-liner
+works for every prime `p ≡ 2 (mod 3)`, `p ∉ {2, 5}`. -/
+
+/-- Universal-Case-A corollary at `p = 11`: matches Section 11's
+    `selmer_padic_solubility_p11_hensel` without invoking the witness
+    `z₀ = 2`. -/
+theorem selmer_padic_solubility_p11_universal :
+    ∃ (x y z : ℚ_[11]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_caseA_universal (by decide) (by decide) (by decide)
+
+/-- Universal-Case-A corollary at `p = 41`: matches Section 22's
+    `selmer_padic_solubility_p41_hensel` without invoking the witness
+    `z₀ = 9`. -/
+theorem selmer_padic_solubility_p41_universal :
+    ∃ (x y z : ℚ_[41]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_caseA_universal (by decide) (by decide) (by decide)
+
+end UniversalCaseA
+
 #check @selmerCubic_real_solution
 #check @selmer_rat_implies_real
 #check @selmer_rat_implies_padic
@@ -1760,5 +1963,8 @@ theorem selmer_padic_solubility_extended_caseB_primes :
 #check @selmer_padic_solubility_p67_hensel
 #check @selmer_padic_solubility_p79_hensel
 #check @selmer_padic_solubility_extended_caseB_primes
+#check @UniversalCaseA.selmer_padic_solubility_caseA_universal
+#check @UniversalCaseA.selmer_padic_solubility_p11_universal
+#check @UniversalCaseA.selmer_padic_solubility_p41_universal
 
 end Hilbert11OQ02

--- a/research/problems/hilbert-11-oq-02/knowledge.md
+++ b/research/problems/hilbert-11-oq-02/knowledge.md
@@ -352,3 +352,104 @@ verifying the witness arithmetic.
    `selmer_witness_p3_mod27`. Mathlib has the strong-form lemma; the
    valuation arithmetic v₃(f) = 3 > 2·v₃(∂_z f) = 2 (Section 8) needs
    to be discharged in Lean.
+
+
+---
+
+## Session 2026-05-12 (Iteration 17, researcher-6) — Section 27 Universal Case-A
+
+### What was added
+
+**Section 27** (`Proofs/Hilbert11OQ02.lean`, namespace `UniversalCaseA`):
+the universal Case-A theorem closing the parametric enumeration of
+Sections 22-25.
+
+> For every prime `p ≡ 2 (mod 3)` with `p ≠ 2` and `p ≠ 5`, the Selmer
+> cubic `3x³ + 4y³ + 5z³ = 0` admits an axiom-free `ℚ_[p]`-solubility
+> proof.
+
+The new namespace exposes 11 sorry-free declarations:
+
+- `cubeInverseExp (p : ℕ) := (2 * (p - 1) + 1) / 3` — the cube-root
+  inverse exponent. When `p ≡ 2 (mod 3)`, `3 · cubeInverseExp p =
+  2(p-1) + 1`, so `(a^m)^3 = a^{3m} = a^{2(p-1) + 1} = (a^{p-1})^2 · a
+  = 1 · a = a` for any nonzero `a : ZMod p` by Fermat
+  (`ZMod.pow_card_sub_one_eq_one`).
+- Three small-natural casts `cast_{five,four,three}_ne_zero` for the
+  forbidden-residue exclusions (`p ∉ {2, 3, 5}`).
+- `exists_cube_root_neg_four_fifths` — existence of `z : ZMod p` with
+  `5 z³ + 4 = 0`, constructed as `(-4 / 5) ^ cubeInverseExp p`.
+- The headline `selmer_padic_solubility_caseA_universal`, which lifts
+  the cube root `z` to `z₀ := (z.val : ℤ)` and applies Section 13's
+  `selmer_padic_solubility_caseA`.
+
+### Why this closes the "enumeration theater"
+
+Sections 22-25 enumerated 10 specific Case-A primes
+(`p ∈ {41, 47, 53, 59, 71, 83, 89, 101, 107, 113}`) by computing
+individual witnesses `z₀` and verifying `(p, z₀)` Hensel hypotheses by
+`decide`. Each iteration added 4-8 lines per prime; the marginal value
+was decreasing rapidly. Section 27 replaces the enumeration with a
+single theorem covering **all** infinitely many Case-A primes,
+discharged by parametric `omega` and `linear_combination` calls plus
+the Fermat identity for `ZMod p`. Future Case-A primes need no
+additional Lean code; any user can invoke `caseA_universal _ _ _` with
+three `by decide`'s.
+
+### Why "Section 27" (not 25)
+
+The iter-15 attempt at this theorem (commit `fc4ed36fd89` on branch
+`research/hilbert-11-oq-02-iter15-universal-caseA-1778290900`) used
+"Section 25" as the section number. That attempt never merged
+(stale-branch reverts during the iter-15/16 window), and meanwhile
+"Section 25" became the iter-15 merged enumeration of primes 107/113
+(PR #17613) and "Section 26" became the Case-B primes 43/67/79
+(PR #17642). Section 27 is the natural next-available slot above the
+Case-B sections.
+
+### Mathlib API used
+
+All in `Mathlib.Data.ZMod.Basic` and adjacent files (already imported):
+
+- `ZMod.pow_card_sub_one_eq_one` — Fermat for nonzero `a : ZMod p`.
+- `ZMod.natCast_zmod_eq_zero_iff_dvd` — `(n : ZMod p) = 0 ↔ p ∣ n`.
+- `ZMod.intCast_zmod_eq_zero_iff_dvd` — integer version.
+- `ZMod.natCast_zmod_val` — `(z.val : ZMod p) = z`.
+- `Nat.Prime.dvd_of_dvd_pow`, `Nat.Prime.eq_one_or_self_of_dvd`.
+- `Prime.coprime_iff_not_dvd` — for `IsCoprime` discharge.
+- Standard `omega`, `linear_combination`, `push_cast`,
+  `mul_inv_cancel₀`, `mul_eq_zero`, `pow_eq_zero_iff`.
+
+No new imports required.
+
+### Counts
+
+- `lineCount`: 1764 → 1970 (+206)
+- `theoremCount`: 73 → 83 (+10: 7 lemmas + 3 theorems)
+- `defCount`: 8 → 9 (+1: `cubeInverseExp`)
+- `axiomCount`: 2 (unchanged)
+- `sorryCount`: 0 (unchanged)
+
+### Build status
+
+Pending — `./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02` running
+at session-start; broken `proofs/.lake` symlink forces full Mathlib
+clone (~30-45 min wall time per memory). Confidence high: same proof
+code was build-pending at iter-15 abandonment, and all tactic calls
+are standard Mathlib v4.26 API.
+
+### Next Steps
+
+1. **Universal Case-B theorem**: parametric Hensel-lift over `(x, y, 0)`
+   projection for primes `p ≡ 1 (mod 3)`, `p ≥ 7`. More intricate than
+   Case-A because the witness coordinate differs per prime; needs
+   sub-cases keyed on which coordinate is fixed.
+
+2. **Cleanup**: collapse the four near-identical `g(z) = 4 + 5z³`
+   private polynomial definitions (`Hensel3.Gint`, `Hensel11.Gint`,
+   `HenselCaseA.Gint`, and now implicit in Section 27) into a single
+   module-level `Selmer.GintZ`.
+
+3. **Far stretch**: discharge `selmer_no_rational_solution` via
+   3-descent infrastructure on `E : y² = x³ - 432·15²` — Mathlib gap;
+   multi-thousand-line contribution.

--- a/research/problems/hilbert-11-oq-02/state.md
+++ b/research/problems/hilbert-11-oq-02/state.md
@@ -1,13 +1,124 @@
 # Current State
 
-**Phase**: ITERATING (extending discharged sub-collection beyond Section-8 primes)
-**Since**: 2026-05-08T22:30:00Z
-**Last Updated**: 2026-05-09 (Iteration 14, researcher-13)
-**Iteration**: 14
+**Phase**: ITERATING (universal Case-A closure resolving the enumeration of Sections 22-25)
+**Since**: 2026-05-12T16:46:00Z
+**Last Updated**: 2026-05-12 (Iteration 17, researcher-6)
+**Iteration**: 17
 
-## Current Focus
+## Iteration 17 (researcher-6, 2026-05-12) — Section 27 universal Case-A theorem
 
-Iteration 14 (this session, researcher-13): added **Section 24** —
+**Outcome**: progress — closes the enumeration theater of Sections 22-25
+(per-prime Case-A primes 41/47/53/59/71/83/89/101/107/113) with a single
+parametric closure theorem. For *every* prime `p ≡ 2 (mod 3)` with
+`p ≠ 2` and `p ≠ 5`, the Selmer cubic `3x³ + 4y³ + 5z³ = 0` admits an
+axiom-free `ℚ_[p]`-solubility proof. Sorry count unchanged at 0; axiom
+count unchanged at 2; the universal Case-A axiom `selmer_padic_solubility`
+remains for the Case-B / special-prime fragments.
+
+### What I added (+206 lines, all sorry-free)
+
+A new "Section 27: Universal Case-A Theorem (cube-root parametric
+closure)" subsection inside `proofs/Proofs/Hilbert11OQ02.lean`,
+namespaced as `UniversalCaseA`:
+
+1. **`cubeInverseExp p := (2 * (p - 1) + 1) / 3`** (def). The cube-root
+   inverse exponent.
+2. **`three_mul_cubeInverseExp_eq`** — `3 · cubeInverseExp p = 2(p-1) + 1`
+   exactly when `p % 3 = 2` and `p ≠ 2`. (`omega`)
+3. **`pow_cubeInverseExp_pow_three`** — `(a^m)^3 = a` for any nonzero
+   `a : ZMod p`. Proof: `a^{3m} = a^{2(p-1)+1} = (a^{p-1})^2 · a = a` by
+   Fermat (`ZMod.pow_card_sub_one_eq_one`).
+4. **`prime_not_dvd_of_prime_ne`** — `p` prime and `p ≠ q` (with `q`
+   prime) ⇒ `¬ p ∣ q`. Private helper.
+5. **`cast_{five,four,three}_ne_zero`** — three small-natural casts
+   nonzero in `ZMod p` under the appropriate `p ≠ q` hypotheses.
+6. **`exists_cube_root_neg_four_fifths`** — `∃ z : ZMod p, 5z³ + 4 = 0`
+   when `p ≡ 2 (mod 3)`, `p ∉ {2, 5}`. Constructs `z := (-4/5)^m`.
+7. **`selmer_padic_solubility_caseA_universal`** (headline theorem) —
+   the universal Case-A closure. Lifts `z` to `z₀ := (z.val : ℤ)` and
+   applies Section 13's `selmer_padic_solubility_caseA z₀`.
+8. **`selmer_padic_solubility_p11_universal`** + **`_p41_universal`** —
+   two illustrative one-line corollaries at `p = 11` and `p = 41`,
+   matching the explicit Hensel-lifted versions but with NO explicit
+   witness arithmetic.
+
+Plus 3 new `#check` lines in the trailing block.
+
+### Why this is the right S(17) deliverable
+
+The slug had been in an "enumeration theater" pattern (Sections 22, 23,
+24, 25) of per-prime corollary additions, each `+5-10 lines`, with
+diminishing marginal value. The Section-24 docstring (and iter-14
+`nextAction`) explicitly flagged the universal Case-A theorem as the
+right escape:
+
+> "Iter 15 candidates: (1) Section 25 — universal Case-A theorem: prove
+> for every prime p ≡ 2 (mod 3), p ∉ {2, 5}, ∃ axiom-free
+> ℚ_[p]-solubility witness."
+
+An earlier attempt at this (iter-15 branch `research/hilbert-11-oq-02-iter15-universal-caseA-1778290900`, commit `fc4ed36fd89`, never merged) ran into stale-branch reverts and was overtaken by simpler per-prime additions. This iteration resurrects that work, adapts it to current main (Sections 25/26 having since landed: primes 107/113 + Case-B 43/67/79), renames to **Section 27**, and adjusts the docstring to credit all earlier Case-A sections (11/17/22/23/24/25) as subsumed.
+
+### Build status (S17)
+
+In progress — `./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02`
+kicked off at session-start (broken `proofs/.lake` symlink forces full
+Mathlib clone + cache fetch; ~30-45 min wall time per memory). Build log
+at `.loom/logs/researcher-6-hilbert11-iter17-build.log`. Will update once
+verified.
+
+All proof tactics are standard Mathlib v4.26 API: `omega`, `push_cast`,
+`linear_combination`, `mul_eq_zero`, `pow_eq_zero_iff`,
+`mul_inv_cancel₀`, plus `ZMod.pow_card_sub_one_eq_one`,
+`ZMod.natCast_zmod_eq_zero_iff_dvd`,
+`ZMod.intCast_zmod_eq_zero_iff_dvd`, `ZMod.natCast_zmod_val`,
+`Nat.Prime.dvd_of_dvd_pow`, `Nat.Prime.eq_one_or_self_of_dvd`,
+`Prime.coprime_iff_not_dvd`. The iter-15 attempt was build-pending at
+the time of its abandonment; same code structure suggests build will
+succeed.
+
+### Counts
+
+- `lineCount`: 1764 → 1970 (+206)
+- `theoremCount`: 73 → 83 (+10: 7 lemmas + 3 theorems)
+- `defCount`: 8 → 9 (+1: `cubeInverseExp`)
+- `axiomCount`: 2 (unchanged — `selmer_no_rational_solution`,
+  `selmer_padic_solubility`)
+- `sorryCount`: 0 (unchanged)
+
+### Files modified (S17 narrow)
+
+- `proofs/Proofs/Hilbert11OQ02.lean` — +206 lines (Section 27 +
+  trailing `#check`s).
+- `src/data/research/problems/hilbert-11-oq-02.json` — iter 14 → 17,
+  lineCount 1764 → 1970, theoremCount 73 → 83, defCount 8 → 9, focus
+  + nextAction updated.
+- `research/problems/hilbert-11-oq-02/{state.md, knowledge.md}` — this
+  iter-17 entry.
+
+### Next Action (S18)
+
+Iter 18 candidates, in order of value:
+
+1. **Section 28 — universal Case-B theorem**: parametric Hensel-lift over
+   the `(x, y, 0)` projection for primes `p ≡ 1 (mod 3)`, `p ≥ 7`. The
+   witness coordinate differs per prime (`(1, 1, 0)` at `p = 7` vs
+   `(0, 1, 5)` at `p = 37`), so the parametric setup needs multiple
+   sub-cases keyed on which coordinate is fixed. Substantially more
+   intricate than Case-A; uses `Hasse-Weil` + alternative projections.
+
+2. **Cleanup refactor**: collapse `Hensel3.Gint`, `Hensel11.Gint`,
+   `HenselCaseA.Gint` duplication (now four near-identical
+   `g(z) = 4 + 5z³` polynomial definitions at private scope). Promote
+   to a module-level `Selmer.GintZ` shared across sections.
+
+3. **Far stretch**: discharge `selmer_no_rational_solution` itself via
+   3-descent infrastructure (multi-thousand-line Mathlib contribution).
+
+---
+
+## (Historic) Iteration 14 (researcher-13, 2026-05-09) — S14 Section 24
+
+Iteration 14 (researcher-13): added **Section 24** —
 four further Case-A primes (`p ∈ {71, 83, 89, 101}`) as one-line
 corollaries of the Section-13 parametric `selmer_padic_solubility_caseA`.
 Continuing the Section-22/23 pattern (Iters 12/13), this extends the

--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -41,15 +41,15 @@
   },
   "currentState": {
     "phase": "ITERATING",
-    "since": "2026-05-09T01:00:00Z",
-    "iteration": 14,
-    "focus": "Iteration 14 (researcher-13, 2026-05-09): added Section 24 — four further Case-A primes (p ∈ {71, 83, 89, 101}) as one-line corollaries of selmer_padic_solubility_caseA. Continuing the Section-22/23 pattern from iters 12/13, this extends the discharged sub-collection from 16 to 20 primes total (12 Section-8 primes + Sections 22/23's {41, 47, 53, 59} + Section 24's {71, 83, 89, 101}). Witnesses: z₀ = 63 for p = 71 (4+5·63³ = 1250239 = 71·17609, gcd(15·63², 71) = 1); z₀ = 23 for p = 83 (4+5·23³ = 60839 = 83·733, gcd(15·23², 83) = 1); z₀ = 9 for p = 89 (4+5·9³ = 3649 = 89·41, gcd(15·9², 89) = 1); z₀ = 81 for p = 101 (4+5·81³ = 2657209 = 101·26309, gcd(15·81², 101) = 1). Plus selmer_padic_solubility_extended_caseA_primes_v3 8-fold conjunction bundle covering all extended Case-A primes (supersedes the v2 bundle from iter 13). File 1481 → 1592 lines (+111). Theorems 66 → 71 (+5: 4 per-prime corollaries + bundle). Definitions, axioms, sorries unchanged at 8/2/0. Build status: pending. Confidence high — new theorems are structurally identical to existing selmer_padic_solubility_p{17,23,29,41,47,53,59}_hensel; only the prime literal and witness z₀ differ; no new Mathlib API surface.",
+    "since": "2026-05-12T16:46:00Z",
+    "iteration": 17,
+    "focus": "Iteration 17 (researcher-6, 2026-05-12): added Section 27 — universal Case-A theorem (parametric Fermat-based cube-root closure). For every prime p ≡ 2 (mod 3) with p ≠ 2 and p ≠ 5, the Selmer cubic 3x³+4y³+5z³=0 admits an axiom-free ℚ_[p]-solubility proof, subsuming the per-prime enumeration of Sections 11/17/22/23/24/25. Key construction: cubeInverseExp p := (2(p-1)+1)/3, then (a^m)^3 = a for any nonzero a ∈ ZMod p (by Fermat). Combined with cast_five_ne_zero (p ≠ 5) yields existence of z ∈ ZMod p with 5z³ + 4 = 0; lifting via z.val to ℤ provides the integer witness for Section 13's selmer_padic_solubility_caseA. New namespace UniversalCaseA with 11 declarations: 1 def (cubeInverseExp), 7 lemmas (three_mul_cubeInverseExp_eq, pow_cubeInverseExp_pow_three, prime_not_dvd_of_prime_ne, cast_{five,four,three}_ne_zero, exists_cube_root_neg_four_fifths), 3 theorems (selmer_padic_solubility_caseA_universal, _p11_universal, _p41_universal). All sorry-free. File 1764 → 1970 lines (+206). Theorems 73 → 83 (+10). Defs 8 → 9 (+1). Axioms 2 unchanged. Sorries 0 unchanged. Build status: pending. Resurrects the iter-15-universal-caseA branch (commit fc4ed36fd89, never merged due to stale-branch reverts).",
     "blockers": [],
-    "nextAction": "Iter 15 candidates: (1) Section 25 — universal Case-A theorem: prove for every prime p ≡ 2 (mod 3), p ∉ {2, 5}, ∃ axiom-free ℚ_[p]-solubility witness. The proof combines selmer_padic_solubility_caseA with cube-bijectivity of (ZMod p)ˣ when gcd(3, p-1) = 1 (always true for p ≡ 2 mod 3, since p - 1 ≡ 1 mod 3). This eliminates the per-prime enumeration and resolves the universal axiom for the Case-A subset. Mathlib lemma needed: cube-power bijectivity in cyclic groups of coprime order — likely in Mathlib.GroupTheory.SpecificGroups.Cyclic or via ZMod.unitOfCoprime/Subgroup.zpowers machinery. (2) Iter 15 alternate — more incremental Case-A primes p ∈ {107, 113, 131, 137} (continuing the Section-22/23/24 pattern; +50 line PR, low risk, low marginal value). (3) Cleanup refactor: collapse Hensel3.Gint / Hensel11.Gint duplication. Far stretch: pivot to selmer_no_rational_solution via 3-descent infrastructure (multi-thousand-line Mathlib contribution).",
+    "nextAction": "Iter 18 candidates: (1) Section 28 — universal Case-B theorem: parametric Hensel-lift over (x, y, 0) projection for primes p ≡ 1 (mod 3), p ≥ 7. The witness coordinate differs per prime (e.g. (1, 1, 0) at p=7 vs (0, 1, 5) at p=37), so the parametric setup needs multiple sub-cases keyed on which coordinate is fixed. (2) Cleanup refactor: collapse Hensel3.Gint / Hensel11.Gint / HenselCaseA.Gint duplication (now four near-identical g(z) = 4 + 5z³ polynomials at private scope). (3) Far stretch: discharge selmer_no_rational_solution via 3-descent infrastructure (Mathlib gap; multi-thousand-line contribution).",
     "attemptCounts": {
-      "total": 14,
-      "currentApproach": 9,
-      "approachesTried": 7
+      "total": 17,
+      "currentApproach": 12,
+      "approachesTried": 8
     }
   },
   "knowledge": {
@@ -222,10 +222,10 @@
     {
       "path": "Proofs/Hilbert11OQ02.lean",
       "filename": "Hilbert11OQ02.lean",
-      "lineCount": 1764,
-      "theoremCount": 73,
+      "lineCount": 1970,
+      "theoremCount": 83,
       "axiomCount": 2,
-      "defCount": 8,
+      "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ02.lean"


### PR DESCRIPTION
## Summary

S17 for `hilbert-11-oq-02`: adds **Section 27** to `Proofs/Hilbert11OQ02.lean` — the **universal Case-A theorem** closing the parametric enumeration of Sections 22-25.

> **Theorem (universal Case-A).** For every prime `p ≡ 2 (mod 3)` with `p ≠ 2` and `p ≠ 5`, the Selmer cubic `3x³ + 4y³ + 5z³ = 0` admits an axiom-free `ℚ_[p]`-solubility proof.

This subsumes Sections 11/17 (z-side) and Sections 22/23/24/25 (per-prime enumeration of `p ∈ {41, 47, 53, 59, 71, 83, 89, 101, 107, 113}`) under a single parametric closure.

## Construction (Fermat-based cube-root)

When `p ≡ 2 (mod 3)`, the cube map `x ↦ x³` on `(ZMod p)ˣ` is bijective. The explicit cube-root inverse is `x ↦ x^m` where `m := cubeInverseExp p := (2(p-1)+1) / 3`: indeed `3m = 2(p-1) + 1`, so by Fermat
```
(a^m)^3 = a^{3m} = a^{2(p-1)+1} = (a^{p-1})^2 · a = 1 · a = a
```
for any nonzero `a : ZMod p`. Combined with `(5 : ZMod p) ≠ 0` (using `p ≠ 5`), this gives a cube root `z` of `-4/5`. Lifting `z` to `ℤ` via `(z.val : ℤ)` produces the integer witness consumed by Section 13's `selmer_padic_solubility_caseA`.

## Changes (`Proofs/Hilbert11OQ02.lean`)

A new "Section 27" subsection inside `namespace UniversalCaseA` (sorry-free, 206 lines):

- **`cubeInverseExp (p : ℕ) := (2 * (p - 1) + 1) / 3`** (def). Cube-root inverse exponent.
- **`three_mul_cubeInverseExp_eq`** — `3 · cubeInverseExp p = 2(p-1) + 1` exactly when `p % 3 = 2` and `p ≠ 2`. (`omega`)
- **`pow_cubeInverseExp_pow_three`** — Fermat-based cube identity.
- **`prime_not_dvd_of_prime_ne`** (private) — `p` prime and `p ≠ q` ⇒ `¬ p ∣ q`.
- **`cast_{five,four,three}_ne_zero`** — small-natural casts nonzero in `ZMod p`.
- **`exists_cube_root_neg_four_fifths`** — `∃ z : ZMod p, 5z³ + 4 = 0`.
- **`selmer_padic_solubility_caseA_universal`** (headline).
- **`selmer_padic_solubility_p11_universal`**, **`_p41_universal`** — illustrative one-line corollaries.

Plus 3 new `#check` lines in the trailing block.

## Why Section 27 (not 25)

An earlier attempt at this theorem (iter-15 branch, commit `fc4ed36fd89`, never merged) used "Section 25" as the section number. That branch was abandoned during the iter-15/16 window and the merged "Section 25" became the iter-15 enumeration of primes 107/113 (PR #17613); "Section 26" became the Case-B primes 43/67/79 (PR #17642). Section 27 is the next-available slot above the Case-B sections.

## Why this closes the enumeration theater

Sections 22-25 enumerated 10 specific Case-A primes by computing individual witnesses `z₀` and verifying `(p, z₀)` Hensel hypotheses by `decide`. Each iteration added 4-8 lines per prime with diminishing marginal value. Section 27 replaces the enumeration with a single theorem covering **all** infinitely many Case-A primes, discharged by parametric `omega` + `linear_combination` + the Fermat identity for `ZMod p`. Future Case-A primes need no additional Lean code; users invoke `caseA_universal _ _ _` with three `by decide`'s.

## Net delta

| Metric          | iter 16 (current main) | iter 17 | Δ |
|-----------------|------------------------|---------|---|
| `lineCount`     | 1764                   | 1970    | +206 |
| `theoremCount`  | 73                     | 83      | +10 (7 lemmas + 3 theorems) |
| `defCount`      | 8                      | 9       | +1 (`cubeInverseExp`) |
| `axiomCount`    | 2                      | 2       | 0 |
| `sorryCount`    | 0                      | 0       | 0 |

The two file-level axioms (`selmer_no_rational_solution`, `selmer_padic_solubility`) are unchanged. The universal Case-A theorem reduces the per-prime work needed to eventually discharge the `selmer_padic_solubility` axiom — Case-B (`p ≡ 1 mod 3`, `p ≥ 7`) and special primes `p ∈ {2, 3, 5}` remain.

## Build

Build pending — `./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02` running at session-start (broken `proofs/.lake` symlink forces full Mathlib clone + cache fetch, ~30-45 min wall time per memory). Will follow up if any build issue arises.

Confidence high — same proof structure as the iter-15 attempt (which was build-pending at abandonment, not build-broken). All tactics use standard Mathlib v4.26 API (`ZMod.pow_card_sub_one_eq_one`, `ZMod.{nat,int}Cast_zmod_eq_zero_iff_dvd`, `ZMod.natCast_zmod_val`, `Nat.Prime.{dvd_of_dvd_pow,eq_one_or_self_of_dvd}`, `Prime.coprime_iff_not_dvd`) plus `omega`, `linear_combination`, `push_cast`, `mul_inv_cancel₀`, `mul_eq_zero`, `pow_eq_zero_iff`. No new imports.

## Orthogonal to other open work

- No open PRs touch `Proofs/Hilbert11OQ02.lean` (verified via `gh pr list --state open --search`).
- All edits append after Section 26 (the trailing Case-B section); no edits to Sections 1-26.
- The iter-15/16 stale branches on origin are heavily out-of-sync with main (massive file deletions) and are superseded by this PR.

## Honest scope

This does **not** discharge the `selmer_padic_solubility` axiom in full. The axiom claims solubility for every prime `p`; this PR covers the Case-A subset (primes `p ≡ 2 mod 3`, `p ∉ {2, 5}` — infinitely many primes, but density ~1/2). The Case-B fragment (`p ≡ 1 mod 3`, `p ≥ 7`) and special primes (`p ∈ {2, 3, 5}`) remain; what this PR delivers is the **uniform** treatment of Case-A, replacing per-prime enumeration with a parametric closure.

## Status

- **Outcome**: structural progress (universal Case-A theorem closing Sections 22-25 enumeration; per-prime corollaries retained for backward compatibility)
- **Next**: S18 — universal Case-B theorem (parametric Hensel-lift over `(x, y, 0)` projection); cleanup refactor on Hensel*.Gint duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)