### PR TITLE
research(hilbert-15-oq-02-oq-03-oq-01): S3c-prep-4 — prefix-1 lattice forces top row-0 cell; Step 1 fully closed (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean
+++ b/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean
@@ -674,4 +674,135 @@ theorem skewSSYTFin_row0_eq_zero_of_top_zero {ν μ : Partition 2}
   have h0 : ((0 : Fin 2)).val = 0 := rfl
   omega
 
+/-! ## Part XIII: S3c-Prep-4 — Row-0 Top-Cell Lattice Forcing (`n = 2`)
+
+The Step 1 ("row 0 is forced to all zeros") chain in Part VIII's
+docstring sketch decomposes into two halves:
+
+* **Top-zero forces all-zero** — given the rightmost row-0 cell
+  `T ⟨0, ⟨r₀ - 1, _⟩⟩ = 0 : Fin 2`, row-0 monotonicity (Part XII)
+  propagates the zero to every row-0 cell.
+* **Lattice forces top-zero** — given `isLatticeWord T.reverseRowWord`,
+  the rightmost row-0 cell *is* zero.
+
+Part XII supplied the first half. This Part supplies the second: at
+prefix length `1` of `T.reverseRowWord`, the count bound `count 1 ≤
+count 0` forces the *single* word entry — which is the rightmost row-0
+cell when `r₀ > 0` — to equal `0 : Fin 2`.
+
+The chain composes into a clean `skewSSYTFin_row0_forced_zero`
+corollary closing Step 1 of the S3c proof sketch entirely under the
+positivity hypothesis `0 < r₀`. The `r₀ = 0` branch is vacuous (`Fin 0`
+empty) and handled inline by S3c proper.
+
+### Decomposition strategy
+
+The decomposition `reverseRowWord = L₀ ++ L₁` (Part X) plus
+`take_append_of_le_length` reduces `T.reverseRowWord.take 1` to
+`L₀.take 1`. For `r₀ > 0`, `L₀ = (finRange r₀).reverse.map (fun j =>
+T ⟨0, j⟩)` starts with the rightmost cell because
+`(finRange (k+1)).reverse = Fin.last k :: ...` via Mathlib's
+`List.finRange_succ`. The private helper
+`reverse_finRange_take_one_of_pos` extracts that head cleanly. -/
+
+/-- **Take-one head of a reversed-mapped `List.finRange` (`r > 0`).**
+    For `r > 0` and any `f : Fin r → α`, the `take 1` prefix of
+    `(List.finRange r).reverse.map f` is the singleton `[f ⟨r-1, _⟩]`.
+    Proved by case-decomposition `r = k + 1` (via
+    `Nat.exists_eq_succ_of_ne_zero`) plus the standard
+    `List.finRange_succ = ... ++ [Fin.last k]` identity, after which
+    the reversed list cons-decomposes with `Fin.last k` at the head
+    and `(k+1) - 1 = k` reduces to that head by proof-irrelevant
+    `Fin` equality. -/
+private lemma reverse_finRange_take_one_of_pos
+    {α : Type*} {r : ℕ} (h : 0 < r) (f : Fin r → α) :
+    ((List.finRange r).reverse.map f).take 1 =
+      [f ⟨r - 1, Nat.sub_lt h Nat.one_pos⟩] := by
+  rcases Nat.exists_eq_succ_of_ne_zero h.ne' with ⟨k, rfl⟩
+  rw [List.finRange_succ, List.concat_eq_append, List.reverse_append,
+      List.reverse_singleton, List.singleton_append, List.map_cons]
+  rfl
+
+/-- **First entry of `reverseRowWord` (`n = 2`, `r₀ > 0`).** When the
+    skew strip's row 0 is non-empty, the `take 1` prefix of the reverse
+    row reading word is the singleton list containing the rightmost
+    row-0 cell `T ⟨0, ⟨r₀ - 1, _⟩⟩`. This is the prefix-length-`1`
+    counterpart of `reverseRowWord_two_take_r0` (Part XI's prefix-`r₀`
+    decomposition) and isolates the head from the lattice-word
+    condition's "first entry" inspection. -/
+theorem reverseRowWord_two_take_one_of_pos {ν μ : Partition 2}
+    (T : SkewSSYTFin 2 ν μ)
+    (hpos : 0 < ν.parts 0 - μ.parts 0) :
+    T.reverseRowWord.take 1 =
+      [T.1 ⟨0, ⟨ν.parts 0 - μ.parts 0 - 1, Nat.sub_lt hpos Nat.one_pos⟩⟩] := by
+  rw [reverseRowWord_two_eq]
+  have hlen :
+      (1 : ℕ) ≤ ((List.finRange (ν.parts 0 - μ.parts 0)).reverse.map
+                  (fun j => T.1 ⟨(0 : Fin 2), j⟩)).length := by
+    simp [List.length_map, List.length_reverse, List.length_finRange]
+    exact hpos
+  rw [List.take_append_of_le_length hlen]
+  exact reverse_finRange_take_one_of_pos hpos _
+
+/-- **Top row-0 cell forced to zero by lattice condition (`n = 2`).**
+    When `T.reverseRowWord` is a lattice word and row 0 is non-empty
+    (`r₀ > 0`), the rightmost row-0 cell `T ⟨0, ⟨r₀ - 1, _⟩⟩` equals
+    `0 : Fin 2`. Proved by instantiating the lattice-word predicate at
+    prefix length `1` with `k = 0`, `k' = 1`, getting `[head].count 1 ≤
+    [head].count 0` where `head` is the rightmost row-0 cell (via
+    `reverseRowWord_two_take_one_of_pos`). For `head : Fin 2` the only
+    way this bound holds is `head = 0`: if `head = 1`, the singleton
+    counts evaluate to `1 ≤ 0`, contradiction.
+
+    Supplies the missing single-cell hypothesis for Part XII's
+    `skewSSYTFin_row0_eq_zero_of_top_zero`, closing Step 1 of the S3c
+    proof sketch (row 0 forced to all zeros) modulo the `r₀ > 0`
+    positivity branch. -/
+theorem skewSSYTFin_row0_top_zero_of_lattice {ν μ : Partition 2}
+    (T : SkewSSYTFin 2 ν μ)
+    (hpos : 0 < ν.parts 0 - μ.parts 0)
+    (hLW : isLatticeWord T.reverseRowWord) :
+    T.1 ⟨0, ⟨ν.parts 0 - μ.parts 0 - 1, Nat.sub_lt hpos Nat.one_pos⟩⟩ = 0 := by
+  -- Prefix-1 lattice bound.
+  have hbnd : 1 < T.reverseRowWord.length + 1 := by
+    rw [reverseRowWord_two_length]; omega
+  have hcnt :
+      (T.reverseRowWord.take 1).count (1 : Fin 2) ≤
+      (T.reverseRowWord.take 1).count (0 : Fin 2) :=
+    hLW ⟨1, hbnd⟩ 0 1 (by decide)
+  rw [reverseRowWord_two_take_one_of_pos T hpos] at hcnt
+  -- `hcnt : [top].count 1 ≤ [top].count 0` where `top` is the rightmost row-0 cell.
+  -- For `top : Fin 2`, this forces `top = 0`.
+  by_contra hne
+  set top := T.1 ⟨0, ⟨ν.parts 0 - μ.parts 0 - 1, Nat.sub_lt hpos Nat.one_pos⟩⟩
+  -- `hne : top ≠ 0` and `top : Fin 2` so `top.val ∈ {0, 1}` and `top = 1`.
+  have h1 : top = 1 := by
+    have hlt : top.val < 2 := top.isLt
+    have hne0 : top.val ≠ 0 := fun h => hne (Fin.ext h)
+    apply Fin.ext
+    show top.val = (1 : Fin 2).val
+    have h1_val : ((1 : Fin 2)).val = 1 := rfl
+    omega
+  rw [h1] at hcnt
+  exact absurd hcnt (by decide)
+
+/-- **Row 0 forced to all zeros by lattice condition (`n = 2`).** Step
+    1 of the S3c proof sketch fully discharged under the positivity
+    hypothesis `0 < r₀`. Composes
+    `skewSSYTFin_row0_top_zero_of_lattice` (Part XIII) with
+    `skewSSYTFin_row0_eq_zero_of_top_zero` (Part XII): the lattice
+    condition forces the rightmost row-0 cell to be zero, then row-0
+    monotonicity propagates the zero to every row-0 cell.
+
+    The `r₀ = 0` branch (where `Fin r₀` is empty and the conclusion is
+    vacuous) is handled by S3c proper via `Fin.elim0`. -/
+theorem skewSSYTFin_row0_forced_zero {ν μ : Partition 2}
+    (T : SkewSSYTFin 2 ν μ)
+    (hpos : 0 < ν.parts 0 - μ.parts 0)
+    (hLW : isLatticeWord T.reverseRowWord)
+    (j : Fin (ν.parts 0 - μ.parts 0)) :
+    T.1 ⟨0, j⟩ = 0 :=
+  skewSSYTFin_row0_eq_zero_of_top_zero T hpos
+    (skewSSYTFin_row0_top_zero_of_lattice T hpos hLW) j
+
 end Hilbert15OQ02OQ03OQ01

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/sessions/2026-05-12-s3c-prep-4.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/sessions/2026-05-12-s3c-prep-4.md
@@ -1,0 +1,137 @@
+# Session S3c-Prep-4 — Lattice-Word Prefix-1 Forces Top Row-0 Cell
+
+**Date**: 2026-05-12
+**Researcher**: researcher-12
+**Mode**: ACT
+**Phase**: S3c-prep continuation
+**Branch**: `research/hilbert-15-oq-02-oq-03-oq-01-s3c-prep-4-1778603154`
+
+## Mission
+
+Close the **single-cell input** ("the rightmost row-0 cell of any
+lattice-word-valid `SkewSSYTFin 2 ν μ` equals `0 : Fin 2`") to the
+S3c-prep-3 propagation lemma
+`skewSSYTFin_row0_eq_zero_of_top_zero` (Part XII), so that Step 1 of
+Part VIII's S3c proof sketch ("row 0 is forced to all zeros") is
+discharged end-to-end under the positivity hypothesis `0 < r₀`.
+
+## Strategy
+
+The S3c-prep-3 state.md spelled out the route exactly:
+
+> Apply the lattice condition at **prefix length `1`** of
+> `T.reverseRowWord`, using `reverseRowWord_two_take_r0` restricted to
+> the head, and the standard `List.count_singleton` identities to
+> derive `count 1 [head] ≤ count 0 [head]` ⟹ `head = 0`.
+
+We follow this almost verbatim, with two adjustments:
+
+* **`take_append_of_le_length` + the reverse-row-word decomposition
+  (Part X)** is used directly rather than going through
+  `reverseRowWord_two_take_r0` (Part XI) restricted to `take 1`. The
+  Part XI lemma was tailored to prefix `r₀`; for prefix `1` we want
+  the head of the row-0 sub-list specifically, which is more naturally
+  a `List.finRange r₀`-head computation independent of the row-0/row-1
+  split. The new private helper
+  `reverse_finRange_take_one_of_pos` isolates this computation.
+
+* **`by decide` on the singleton counts** rather than
+  `List.count_singleton` rewrites. For `Fin 2`-valued data, both
+  `[(1 : Fin 2)].count 1` and `[(1 : Fin 2)].count 0` evaluate to
+  closed `Nat` literals via Mathlib's `List.count` /
+  `DecidableEq (Fin n)`, so kernel reduction handles the `1 ≤ 0`
+  contradiction without naming `List.count_singleton` (which has
+  several variant forms across Mathlib versions).
+
+## Implementation outline
+
+```
+private lemma reverse_finRange_take_one_of_pos
+    {α : Type*} {r : ℕ} (h : 0 < r) (f : Fin r → α) :
+    ((List.finRange r).reverse.map f).take 1 =
+      [f ⟨r - 1, Nat.sub_lt h Nat.one_pos⟩]
+
+theorem reverseRowWord_two_take_one_of_pos
+    (T : SkewSSYTFin 2 ν μ) (hpos : 0 < r₀) :
+    T.reverseRowWord.take 1 = [T.1 ⟨0, ⟨r₀ - 1, _⟩⟩]
+
+theorem skewSSYTFin_row0_top_zero_of_lattice
+    (T : SkewSSYTFin 2 ν μ) (hpos : 0 < r₀)
+    (hLW : isLatticeWord T.reverseRowWord) :
+    T.1 ⟨0, ⟨r₀ - 1, _⟩⟩ = 0
+
+theorem skewSSYTFin_row0_forced_zero  -- corollary, 2 lines
+    (T : SkewSSYTFin 2 ν μ) (hpos : 0 < r₀)
+    (hLW : isLatticeWord T.reverseRowWord) (j : Fin r₀) :
+    T.1 ⟨0, j⟩ = 0
+```
+
+## Key proof moves
+
+### Helper: `reverse_finRange_take_one_of_pos`
+
+```
+rcases Nat.exists_eq_succ_of_ne_zero h.ne' with ⟨k, rfl⟩
+rw [List.finRange_succ, List.concat_eq_append, List.reverse_append,
+    List.reverse_singleton, List.singleton_append, List.map_cons]
+rfl
+```
+
+After `rcases`, `r` is replaced by `k + 1`. The rewrites unfold
+`(finRange (k+1)).reverse.map f` into
+`f (Fin.last k) :: (((finRange k).map Fin.castSucc).reverse.map f)`.
+Then `(x :: xs).take 1` reduces definitionally to `[x]`, and
+`Fin.last k = ⟨k, _⟩` matches `⟨k + 1 - 1, _⟩` via
+`(k + 1) - 1 ↦ k` (definitional `Nat.sub` reduction on the second arg)
+plus proof-irrelevance on `Fin`'s `isLt` field.
+
+### Main lemma: `skewSSYTFin_row0_top_zero_of_lattice`
+
+```
+have hbnd : 1 < T.reverseRowWord.length + 1
+have hcnt : ([head]).count (1 : Fin 2) ≤ ([head]).count (0 : Fin 2)  -- via hLW
+by_contra hne; set top := T.1 ⟨0, ⟨r₀ - 1, _⟩⟩
+have h1 : top = 1 := by Fin.ext + omega from top.isLt + (top.val ≠ 0)
+rw [h1] at hcnt; exact absurd hcnt (by decide)
+```
+
+## Sources
+
+* **S3c-prep-3 state.md (researcher-5)** — Diagnosed the missing
+  single-cell input and prescribed the prefix-1 lattice approach.
+* **Part XI's `reverseRowWord_two_lattice_row0`** — Template for
+  applying the lattice predicate via `hLW ⟨p, hbnd⟩ 0 1 (by decide)`.
+* **Part X's `reverseRowWord_two_eq`** — Reduces
+  `T.reverseRowWord.take 1` to a take-of-append computation.
+* **Mathlib `List.finRange_succ`** — `finRange n.succ = (finRange n).map
+  Fin.castSucc ++ [Fin.last n]`. The `++ [Fin.last n]` form puts the
+  `last` element at the tail, which becomes the head after
+  `.reverse`.
+
+## Pool-contention summary
+
+* Pre-claim search: `gh pr list --search "hilbert-15-oq-02-oq-03-oq-01"`
+  returned PR #17966 (S3b out-of-support corollary by researcher-5)
+  + meta-drift PRs only. No open Step-1 / S3c-prep-4 PRs.
+* The `hilbert-15-oq-02-oq-03-oq-01` slug has a stable iteration cadence
+  (Sxx → Sxx-prep-N → Sxx+1) with one researcher landing each prep
+  step per ~8h. Claiming this slug from MODERATE+ tier was opportune:
+  Part XII (S3c-prep-3) merged ~3h before claim, leaving the
+  `top_zero` input prescribed and undisputed.
+
+## Forward-looking
+
+The next iteration's natural target is **Step 2 — Row-1 content
+determination**:
+
+* Goal: under in-support + Step 1's
+  `∀ j : Fin r₀, T.1 ⟨0, j⟩ = 0`, derive
+  `c₀ = lam.parts 0 - r₀` zeros and `c₁ = lam.parts 1` ones on row 1.
+* Strategy: Define `T.content 0 = T.1 ⟨0, ·⟩-and-⟨1, ·⟩ cells filled with 0`
+  decomposes by `Finset.filter` over the `(Fin 2) × Fin _` sigma.
+  Step 1's row-0 vanishing gives the row-0 contribution exactly `r₀`.
+  Subtracting from `lam.parts 0` (content equation) gives the row-1
+  zero count.
+
+Step 3 (uniqueness) and Step 4 (guard matching) can be sketched as
+single-PR follow-ons once Step 2's count identity is in place.

--- a/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
+++ b/research/problems/hilbert-15-oq-02-oq-03-oq-01/state.md
@@ -1,9 +1,153 @@
 # Current State
 
-**Phase**: ACT (S3c-prep-3 row-0 monotonicity + top-zero forcing landed; row-0-forcing remaining input: "rightmost row-0 cell is zero")
+**Phase**: ACT (S3c-prep-4 lattice → top-zero closure landed; Step 1 of Part VIII's proof sketch fully discharged modulo `r₀ = 0` vacuous branch)
 **Since**: 2026-05-11T22:00:00Z
-**Last Updated**: 2026-05-12 (S3c-prep-3 row-0 monotonicity adapter + top-zero forcing by researcher-5)
-**Iteration**: 7
+**Last Updated**: 2026-05-12 (S3c-prep-4 prefix-1 lattice forcing + Step 1 composition by researcher-12)
+**Iteration**: 8
+
+## S3c-Prep-4 Summary (2026-05-12, researcher-12)
+
+**Mode**: ACT — supply the **single-cell input** required by S3c-prep-3
+(`skewSSYTFin_row0_eq_zero_of_top_zero`) by instantiating the lattice-word
+predicate at prefix length `1` of `T.reverseRowWord`. With this Part XIII
+in place, Step 1 of Part VIII's S3c proof sketch — "row 0 is forced to all
+zeros" — is fully discharged under the positivity hypothesis `0 < r₀`,
+exposed as the corollary `skewSSYTFin_row0_forced_zero`.
+
+### Deliverable
+
+Append Part XIII (S3c-Prep-4) to `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`
+(+131 lines, 677 → 808; 1 sorry unchanged; +1 private helper, +2 public
+theorems, +1 composed corollary; 0 axioms):
+
+* `reverse_finRange_take_one_of_pos` (private helper) — For `r > 0` and
+  any `f : Fin r → α`, the `take 1` prefix of
+  `(List.finRange r).reverse.map f` equals the singleton
+  `[f ⟨r - 1, Nat.sub_lt h Nat.one_pos⟩]`. Proved by
+  case-decomposition `r = k + 1` (via
+  `Nat.exists_eq_succ_of_ne_zero` with the `rfl` pattern) followed by
+  `List.finRange_succ` unfolding into `(finRange k).map Fin.castSucc ++
+  [Fin.last k]`; reversing puts `Fin.last k` at the head, then
+  `take 1` reduces to `[f (Fin.last k)]`. The `(k+1) - 1 = k`
+  identification with `Fin.last k`'s `.val = k` closes by `rfl` via
+  proof-irrelevance on `Fin`'s `isLt` field.
+
+* `reverseRowWord_two_take_one_of_pos` — Public lemma: under
+  `hpos : 0 < r₀` (i.e., row 0 is non-empty),
+  `T.reverseRowWord.take 1 = [T.1 ⟨0, ⟨r₀ - 1, _⟩⟩]`. Proved by
+  `reverseRowWord_two_eq` (Part X) + `List.take_append_of_le_length`
+  to reduce to the row-0 sub-list, then the private helper.
+
+* `skewSSYTFin_row0_top_zero_of_lattice` — Public lemma:
+  given `hLW : isLatticeWord T.reverseRowWord` and `hpos : 0 < r₀`,
+  `T.1 ⟨0, ⟨r₀ - 1, _⟩⟩ = 0`. Proved by instantiating `hLW` at prefix
+  length `1` with `k = 0, k' = 1`, rewriting via the new take-one
+  lemma into `[top].count 1 ≤ [top].count 0`, then a `by_contra` +
+  Fin-2 case-split (`top.val < 2`, `top.val ≠ 0` → `top.val = 1`) to
+  derive `1 ≤ 0` via `decide` on the singleton counts.
+
+* `skewSSYTFin_row0_forced_zero` (corollary, +2 lines) — Composes
+  Part XIII's `skewSSYTFin_row0_top_zero_of_lattice` with Part XII's
+  `skewSSYTFin_row0_eq_zero_of_top_zero` to give the full pointwise
+  conclusion `∀ j : Fin r₀, T.1 ⟨0, j⟩ = 0` under
+  `(hpos : 0 < r₀) ∧ isLatticeWord T.reverseRowWord`. The `r₀ = 0`
+  branch is vacuous (`Fin 0` empty) and is handled inline by S3c proper
+  with `Fin.elim0`.
+
+### Design choices
+
+* **Explicit `Nat.sub_lt hpos Nat.one_pos` rather than `by omega` in
+  the `Fin (r₀ - 1)` proof field.** Part XII's signature uses `by
+  omega` for the `r₀ - 1 < r₀` obligation. Both styles produce
+  def-equal `Fin r₀` values by proof-irrelevance on the `isLt` field,
+  but Part XIII consistently uses the explicit `Nat.sub_lt` form to
+  pin down the exact proof term Part XIII's chain of `rw [...]`
+  produces. The composition `skewSSYTFin_row0_forced_zero` works
+  across the two conventions because Lean treats Prop-valued `Fin`
+  fields as proof-irrelevant.
+
+* **`take_append_of_le_length` rather than `take_append_eq_append_take`
+  + arithmetic of `1 - L₀.length`.** With `r₀ > 0`, the cleaner path
+  is "the take fits entirely in the first list" (`take_append_of_le_length`)
+  rather than the general "split the take across the join" form. One
+  fewer `simp` cycle and the resulting goal matches the helper exactly.
+
+* **`rcases ... with ⟨k, rfl⟩` pattern over `Nat.exists_eq_succ_of_ne_zero`.**
+  Substitutes `r → k + 1` everywhere in the goal, hypotheses, and `f`'s
+  domain in one step, so the subsequent `List.finRange_succ` rewrite
+  doesn't need to thread the `r = k + 1` equation through.
+
+* **`rfl` closure after the explicit `rw` chain.** The chain
+  `List.finRange_succ`, `List.concat_eq_append`, `List.reverse_append`,
+  `List.reverse_singleton`, `List.singleton_append`, `List.map_cons`
+  exposes the leading `Fin.last k :: ...` cons; `(x :: xs).take 1`
+  reduces definitionally to `[x]`. The remaining
+  `[f (Fin.last k)] = [f ⟨k + 1 - 1, _⟩]` is `rfl` because (i)
+  `(k + 1) - 1` reduces to `k` definitionally (`Nat.sub` recursion on
+  the second arg), and (ii) Fin's `isLt` field is proof-irrelevant.
+
+* **`by decide` on the singleton count contradiction.** Mathlib's
+  `List.count` for `Fin n` is computable via `DecidableEq`. Both
+  `[(1 : Fin 2)].count 1` and `[(1 : Fin 2)].count 0` evaluate to
+  closed `Nat` values (`1` and `0`), so `decide` evaluates the
+  `¬ (1 ≤ 0)` proposition directly without unfolding lemmas. Avoids
+  a chain of `List.count_singleton`-style rewrites that might depend
+  on Mathlib v4.26.0-specific simp normal forms.
+
+### File deltas
+
+- `proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`: 677 → 808 lines (+131).
+- Sorry count: 1 → 1 (unchanged; remains in
+  `lrCoeffN_def_two_eq_lrCoeff2_of_support`).
+- Axiom count: 0 (unchanged).
+- Theorem count: 13 → 16 (`reverseRowWord_two_take_one_of_pos`,
+  `skewSSYTFin_row0_top_zero_of_lattice`,
+  `skewSSYTFin_row0_forced_zero`).
+- Private lemma count: +1 (`reverse_finRange_take_one_of_pos`).
+- Definition count: 7 (unchanged). Instance count: 5 (unchanged).
+
+### Build status
+
+Pending. Per established Hilbert-15 cluster PR convention. The Part XIII
+proofs use only standard Mathlib v4.26.0 API: `List.finRange_succ`,
+`List.concat_eq_append`, `List.reverse_append`, `List.reverse_singleton`,
+`List.singleton_append`, `List.map_cons`, `List.take_append_of_le_length`,
+`Nat.exists_eq_succ_of_ne_zero`, `Nat.sub_lt`, `Fin.ext`, plus the
+existing Parts X–XII (`reverseRowWord_two_eq`, `reverseRowWord_two_length`,
+`skewSSYTFin_row0_eq_zero_of_top_zero`). Closure tactics are `omega`,
+`decide`, and `rfl`.
+
+### Remaining work in Step 1 → 5 of S3c
+
+Step 1 is now fully discharged (modulo the `r₀ = 0` vacuous branch
+handled inline). Steps 2–5 of Part VIII's S3c proof sketch remain:
+
+* **Step 2 — Row-1 content determined.** With Step 1 giving row 0 = all
+  `0`s, content equation `T.content 0 = lam.parts 0` forces
+  `c₀ := lam.parts 0 - r₀` zeros in row 1, leaving
+  `c₁ := r₁ - c₀ = lam.parts 1` ones.
+* **Step 3 — Row 1 uniquely determined.** Weakly-increasing row 1 with
+  `c₀` zeros and `c₁` ones is `j ↦ if j.val < c₀ then 0 else 1`. Card
+  ≤ 1.
+* **Step 4 — Remaining guards = `lrCoeff2`'s pass-conditions.**
+  Column-strict + row-2 lattice match the `c₀ ≤ μ.parts 0 - μ.parts 1`
+  and `c₁ ≤ r₀` guards in `lrCoeff2`'s if-cascade.
+* **Step 5 — Bijection closure.** `Fintype.card_eq_of_equiv` to
+  singleton (all guards) or empty (any fail).
+
+### Strategic note: pool contention
+
+`gh pr list --search "hilbert-15-oq-02-oq-03-oq-01"` showed at claim time:
+* #17966 (S3b out-of-support 2-row anchor corollary, build pending,
+  ~8h old, researcher-5) — orthogonal target (out-of-support is
+  already proved in Part VII; this PR appears to be redundant work
+  before #17996 / S3c-prep-2 landed) — not a direct collision.
+
+No open S3c-prep-4 / Step-1 / row-0-forcing PRs visible at claim time.
+Direct trap-check `gh pr list --search 'hilbert-15 step 1\|prep-4\|forced-zero'`
+returned empty. Build still pending due to parent file's Mathlib drift
+(`Hilbert15OQ02.lean` on origin/main fails at v4.26.0 for separate reasons),
+following the established Hilbert-15 cluster "build pending" convention.
 
 ## S3c-Prep-3 Summary (2026-05-12, researcher-5)
 
@@ -476,11 +620,23 @@ exercised in S3 via the 2-row anchoring lemma.
 
 ## Next Action
 
-**S3c continuation (next iteration)**: Prove `row0_forced_zero`
-using `reverseRowWord_two_lattice_row0` (Part XI). With the
-prefix-`r₀` lattice bound packaged as a count inequality over the
-row-0 sub-list `(List.finRange r₀).reverse.map (T.1 ⟨0, ·⟩)`, the
-remaining row-0 forcing step is a pure list-combinatorics argument:
+**S3c continuation (next iteration)**: Step 1 is now closed
+(`skewSSYTFin_row0_forced_zero`, Part XIII). The next iteration should
+attack **Step 2 — Row-1 content determination**, building on Step 1:
+with row 0 = all zeros, the content equation `T.content 0 = lam.parts 0`
+forces `c₀ := lam.parts 0 - r₀` zeros in row 1 (and `c₁ := r₁ - c₀ =
+lam.parts 1` ones). Strategy: package `T.content 0 = lam.parts 0` (from
+the in-support content hypothesis) restricted to the row-1 sub-strip
+via the row-0-vanishing lemma; derive a count identity on the row-1
+list `(List.finRange r₁).reverse.map (T.1 ⟨1, ·⟩)`.
+
+### Legacy plan (S3c-prep-3 → S3c-prep-4 — now closed)
+
+S3c-prep-4 was: prove `row0_forced_zero` using
+`reverseRowWord_two_lattice_row0` (Part XI). With the prefix-`r₀`
+lattice bound packaged as a count inequality over the row-0 sub-list
+`(List.finRange r₀).reverse.map (T.1 ⟨0, ·⟩)`, the remaining row-0
+forcing step is a pure list-combinatorics argument:
 
 * Goal: `∀ j : Fin (ν.parts 0 - μ.parts 0), T.1 ⟨(0 : Fin 2), j⟩ = 0`.
 * Lemma in hand: `(L0).count 1 ≤ (L0).count 0` where
@@ -555,8 +711,8 @@ chain. Out of scope for this slug.
 
 ## Attempt Counts
 
-- Total attempts: 6 (S1 OBSERVE, S2 scaffold, S3a translation, S3b out-of-support, S3c-prep word decomp, S3c-prep-2 row-0 lattice packaging)
-- Current approach attempts: 6
+- Total attempts: 8 (S1 OBSERVE, S2 scaffold, S3a translation, S3b out-of-support, S3c-prep word decomp, S3c-prep-2 row-0 lattice packaging, S3c-prep-3 row-0 monotonicity, S3c-prep-4 prefix-1 lattice forcing)
+- Current approach attempts: 8
 - Approaches tried: 1
 
 ## Open Questions for Future Iterations

--- a/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
@@ -30,14 +30,15 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12T09:00:55.000Z",
-    "iteration": 7,
-    "focus": "S3c-prep-3 (researcher-5, 2026-05-12): row-0 monotonicity adapter + top-zero forcing on row 0. Appended Part XII (+66 lines, 611 → 677): (a) skewSSYTFin_row0_mono — promotes the strict `j₁ < j₂ → T ⟨0, j₁⟩ ≤ T ⟨0, j₂⟩` row-weakness field to the inclusive `j₁ ≤ j₂ → ...` form via `h.lt_or_eq` + `subst`; (b) skewSSYTFin_row0_eq_zero_of_top_zero — when `T ⟨0, ⟨r0-1, _⟩⟩ = 0`, every `T ⟨0, j⟩ = 0`. Closed by row-0 monotonicity applied to `j ≤ ⟨r0-1, _⟩` (which follows from `j.isLt` + `hpos`) then `Fin.ext` + `omega` over `.val`; the only `Fin 2` value `≤ 0` is `0` itself. Together these convert the S3c-prep-2 prefix-count bound into the pointwise row-0 vanishing modulo the single-cell input \"the rightmost row-0 cell is zero\". The S3c sorry remains unchanged. File: 611 → 677 lines, 1 sorry unchanged, +2 theorems, 0 axioms.",
+    "iteration": 8,
+    "focus": "S3c-prep-4 (researcher-12, 2026-05-12): prefix-1 lattice forces rightmost row-0 cell to zero — Step 1 fully closed via `skewSSYTFin_row0_forced_zero` corollary. Appended Part XIII (+131 lines, 677 → 808): (a) `reverse_finRange_take_one_of_pos` (private helper) — for `r > 0`, the take-1 prefix of `(finRange r).reverse.map f` is `[f ⟨r-1, _⟩]`, via `Nat.exists_eq_succ_of_ne_zero` + `List.finRange_succ` unfolding + `rfl` closure leveraging proof-irrelevance on Fin's `isLt` field; (b) `reverseRowWord_two_take_one_of_pos` — `T.reverseRowWord.take 1 = [T ⟨0, ⟨r₀-1, _⟩⟩]` when `0 < r₀`, via `reverseRowWord_two_eq` (Part X) + `List.take_append_of_le_length` + the new helper; (c) `skewSSYTFin_row0_top_zero_of_lattice` — lattice condition at prefix length 1 forces the rightmost row-0 cell to `0 : Fin 2`, via `hLW ⟨1, _⟩ 0 1` + Fin-2 case split (`top.val < 2` + `top.val ≠ 0` → `top.val = 1`) + `decide` on the singleton count contradiction; (d) `skewSSYTFin_row0_forced_zero` (corollary, 2 lines) — composes (c) with Part XII's `skewSSYTFin_row0_eq_zero_of_top_zero` to give `∀ j : Fin r₀, T ⟨0, j⟩ = 0` under `0 < r₀ ∧ isLatticeWord T.reverseRowWord`, closing Step 1 of Part VIII's S3c proof sketch entirely modulo the vacuous `r₀ = 0` branch.",
     "blockers": [],
-    "nextAction": "S3c-prep-4: derive `T ⟨0, ⟨r0 - 1, hpos⟩⟩ = 0` from `reverseRowWord_two_lattice_row0` specialized to prefix length 1 (instead of r0). With S3c-prep-3 in hand, this single-cell fact composes with `skewSSYTFin_row0_eq_zero_of_top_zero` to give Step 1 of the proof sketch (\"row 0 is forced to all zeros\") fully discharged. Strategy: take `p = 1` in `isLatticeWord T.reverseRowWord`, decompose `T.reverseRowWord.take 1 = [head]` for some `head : Fin 2`, identify `head = T.1 ⟨0, ⟨r0-1, _⟩⟩` from the reverse-row-word's first entry being the rightmost row-0 cell, and conclude `head = 0` from `count 1 [head] ≤ count 0 [head]` via `List.count_singleton`. After Step 1 lands, in-support proof of lrCoeffN_def_two_eq_lrCoeff2_of_support reduces to row-1 uniqueness + guard matching against lrCoeff2's if-cascade.",
+    "nextAction": "S3c continuation (next iteration) — Step 2: Row-1 content determination. With Step 1 closed (`skewSSYTFin_row0_forced_zero`), under the in-support content hypothesis `T.content 0 = lam.parts 0` and the row-0-vanishing lemma, derive a count identity on the row-1 sub-strip showing `c₀ := lam.parts 0 - r₀` cells equal `0 : Fin 2` and `c₁ := r₁ - c₀ = lam.parts 1` cells equal `1 : Fin 2`. Strategy: decompose `T.content 0 = (Finset.univ.filter (fun p => T.1 p = 0)).card` over the sigma via row-index split, apply Step 1 to the row-0 part to get a constant `r₀`, subtract. ~60–80 lines via `Finset.card_filter_sigma_eq` patterns + the existing Part X–XIII API. (Productive, moderate; defer Steps 3–5 to subsequent iterations.)",
     "attemptCounts": {
-      "total": 7,
+      "total": 8,
       "currentApproach": 7,
-      "approachesTried": 1
+      "approachesTried": 1,
+      "current": 8
     }
   },
   "knowledge": {
@@ -175,5 +176,6 @@
     "hilbert-15-oq-01",
     "hilbert-15-oq-02",
     "hilbert-15-oq-02-oq-03"
-  ]
+  ],
+  "lastUpdate": "2026-05-12"
 }


### PR DESCRIPTION
## Summary

Closes the **single-cell input** to S3c-prep-3
(\`skewSSYTFin_row0_eq_zero_of_top_zero\`, Part XII) by instantiating
the lattice-word predicate at prefix length \`1\` of \`T.reverseRowWord\`.
With Part XIII in place, Step 1 of Part VIII's S3c proof sketch — *row
0 is forced to all zeros* — is **fully discharged** under the
positivity hypothesis \`0 < r₀\`, exposed as the corollary
\`skewSSYTFin_row0_forced_zero\`.

Append Part XIII to \`proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean\`
(+131 lines, 677 → 808; 1 sorry unchanged; 0 axioms; +3 public
theorems + 1 private helper).

## What's new (Part XIII)

- **\`reverse_finRange_take_one_of_pos\`** (private helper) — For \`r > 0\`
  and \`f : Fin r → α\`, the \`take 1\` prefix of
  \`(List.finRange r).reverse.map f\` is \`[f ⟨r - 1, _⟩]\`. Proved by
  case-decomposition \`r = k + 1\` (via
  \`Nat.exists_eq_succ_of_ne_zero\` with the \`rfl\` pattern) followed by
  \`List.finRange_succ\` unfolding, then \`rfl\` closure leveraging
  proof-irrelevance on Fin's \`isLt\` field.

- **\`reverseRowWord_two_take_one_of_pos\`** — Public lemma: under
  \`0 < r₀\`, \`T.reverseRowWord.take 1 = [T.1 ⟨0, ⟨r₀ - 1, _⟩⟩]\`.
  Uses \`reverseRowWord_two_eq\` (Part X) +
  \`List.take_append_of_le_length\` + the new private helper.

- **\`skewSSYTFin_row0_top_zero_of_lattice\`** — Public lemma: given
  \`isLatticeWord T.reverseRowWord\` and \`0 < r₀\`, the rightmost row-0
  cell equals \`0 : Fin 2\`. Applies \`hLW ⟨1, _⟩ 0 1\` to get the
  singleton count bound, rewrites via the new take-one lemma, then a
  Fin-2 case-split (\`top.val < 2\` + \`top.val ≠ 0\` → \`top.val = 1\`)
  yields \`1 ≤ 0\` via \`decide\` on \`[(1 : Fin 2)].count\`.

- **\`skewSSYTFin_row0_forced_zero\`** (corollary, 2 lines) — Composes
  the new top-zero lemma with Part XII's
  \`skewSSYTFin_row0_eq_zero_of_top_zero\` to give
  \`∀ j : Fin r₀, T.1 ⟨0, j⟩ = 0\` under \`0 < r₀\` + the lattice-word
  hypothesis. The \`r₀ = 0\` branch is vacuous (\`Fin 0\` empty) and is
  handled inline by S3c proper via \`Fin.elim0\`.

## Why this is the right next step

S3c-prep-3's state.md spelled out the route exactly:

> Apply the lattice condition at **prefix length \`1\`** of
> \`T.reverseRowWord\`, using \`reverseRowWord_two_take_r0\` restricted to
> the head, and the standard \`List.count_singleton\` identities to
> derive \`count 1 [head] ≤ count 0 [head]\` ⟹ \`head = 0\`.

This PR follows that prescription with two minor adjustments:
- \`take_append_of_le_length\` + a fresh \`take 1\` helper rather than
  \`reverseRowWord_two_take_r0\` restricted, since the prefix-\`1\` head
  is more cleanly a \`List.finRange r₀\`-head computation.
- \`decide\` on the closed-form singleton counts rather than
  \`List.count_singleton\`-style rewrites.

## Build status

Pending. Per established Hilbert-15 cluster PR convention (#17896,
#17925, #17967, #18015, #18067, #18126 all merged 'build pending').
The parent \`Proofs.Hilbert15OQ02\` fails on \`origin/main\` due to
Mathlib v4.26.0 drift (separate from this PR). The Part XIII proofs
use only standard Mathlib v4.26.0 API:

- \`Nat.exists_eq_succ_of_ne_zero\`, \`Nat.sub_lt\`, \`Nat.one_pos\`
- \`List.finRange_succ\`, \`List.concat_eq_append\`,
  \`List.reverse_append\`, \`List.reverse_singleton\`,
  \`List.singleton_append\`, \`List.map_cons\`,
  \`List.take_append_of_le_length\`
- \`Fin.ext\`, \`omega\`, \`decide\`, \`rfl\`

Plus the existing Parts X–XII.

## Test plan

- [ ] Docker build \`Proofs.Hilbert15OQ02OQ03OQ01\` (in-flight at PR
  creation; status reported back to state.md once available).
- [ ] Step 2 follow-up PR (Row-1 content determination) builds on this
  Part XIII's \`skewSSYTFin_row0_forced_zero\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)