### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S8 — continuity-point density infrastructure (build pending)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
@@ -52,6 +52,8 @@ build verification deferred to S4 alongside the §2.3–§2.5 theorem additions.
 -/
 
 import Proofs.LawsOfLargeNumbersOQ04OQ03
+import Mathlib.Topology.Algebra.Module.Cardinality
+import Mathlib.Topology.Order.Monotone
 
 namespace GlivenkoCantelli
 
@@ -117,6 +119,77 @@ axiom bracketingGrid_exists [IsProbabilityMeasure μ]
     {X : ℕ → Ω → ℝ} (hX_meas : ∀ i, Measurable (X i))
     {ε : ℝ} (hε : 0 < ε) :
     Nonempty (BracketingGrid (trueCDF X μ) ε)
+
+-- ============================================================================
+-- §2.2.5: Continuity-point density (foundation for `bracketingGrid_exists`)
+-- ============================================================================
+
+/-! ### Continuity-point density (S8)
+
+The mathematical content of `bracketingGrid_exists` reduces to three real-analytic
+facts about a CDF `F = trueCDF X μ`:
+
+  (i)   `F` is monotone non-decreasing (already in the parent as `trueCDF_mono`);
+  (ii)  the discontinuity set of a monotone function `ℝ → ℝ` is countable
+        (Mathlib's `Monotone.countable_not_continuousAt`);
+  (iii) the complement of a countable subset of ℝ is dense
+        (Mathlib's `Set.Countable.dense_compl`, applied with `𝕜 := ℝ`).
+
+S8 packages these three facts as named lemmas so the eventual greedy
+construction discharging `bracketingGrid_exists` (S9+) can quote them without
+re-deriving the typeclass plumbing each time. None of the three pieces is novel
+mathematics; the value is in pre-packaging the exact shape consumed by the
+boundary/interior cell selection (`ContinuousAt F (q j)` for each grid node). -/
+
+/-- `trueCDF X μ` packaged as a `Monotone` function `ℝ → ℝ`.
+    Bundle form of the parent's `trueCDF_mono`; consumed by
+    `Monotone.countable_not_continuousAt` below. -/
+theorem trueCDF_monotone [IsProbabilityMeasure μ] (X : ℕ → Ω → ℝ) :
+    Monotone (trueCDF X μ) :=
+  fun _ _ hxy => trueCDF_mono X hxy
+
+/-- The set of discontinuity points of `trueCDF X μ` is countable.
+    Direct application of `Monotone.countable_not_continuousAt` to
+    `trueCDF_monotone`. -/
+theorem trueCDF_countable_discontinuities [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) :
+    Set.Countable {x : ℝ | ¬ ContinuousAt (trueCDF X μ) x} :=
+  (trueCDF_monotone X).countable_not_continuousAt
+
+/-- The set of continuity points of `trueCDF X μ` is dense in `ℝ`.
+    Follows from `trueCDF_countable_discontinuities` via
+    `Set.Countable.dense_compl` (𝕜 := ℝ): any countable subset of a
+    non-trivial real topological vector space has dense complement.
+
+    This is the exact shape the eventual greedy construction will consume:
+    inside any open interval `(a, b)` containing a candidate grid node, a
+    continuity point of `F` exists, so the `cont` field of `BracketingGrid`
+    can always be discharged. -/
+theorem trueCDF_continuityPoints_dense [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) :
+    Dense {x : ℝ | ContinuousAt (trueCDF X μ) x} := by
+  -- Continuity-points = complement of discontinuity set.
+  have h_eq : {x : ℝ | ContinuousAt (trueCDF X μ) x} =
+      {x : ℝ | ¬ ContinuousAt (trueCDF X μ) x}ᶜ := by
+    ext x; simp
+  rw [h_eq]
+  -- Apply `Set.Countable.dense_compl` with 𝕜 = ℝ (the ambient field is ℝ
+  -- and the module is `ℝ` over itself; all topology / module typeclasses
+  -- are stdlib).
+  exact (trueCDF_countable_discontinuities X).dense_compl ℝ
+
+/-- Inside any open interval `(a, b)` with `a < b`, a continuity point of
+    `trueCDF X μ` exists. This is the form consumed in the greedy
+    selection step of the eventual `bracketingGrid_exists` proof. -/
+theorem trueCDF_continuityPoint_in_Ioo [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) {a b : ℝ} (hab : a < b) :
+    ∃ x ∈ Set.Ioo a b, ContinuousAt (trueCDF X μ) x := by
+  have h_dense := trueCDF_continuityPoints_dense X
+  -- `Dense` + nonempty open set ⇒ nonempty intersection.
+  have h_open : IsOpen (Set.Ioo a b) := isOpen_Ioo
+  have h_ne : (Set.Ioo a b).Nonempty := Set.nonempty_Ioo.mpr hab
+  obtain ⟨x, hx_cont, hx_in⟩ := h_dense.exists_mem_open h_open h_ne
+  exact ⟨x, hx_in, hx_cont⟩
 
 -- ============================================================================
 -- §2.3: Simultaneous pointwise convergence at all grid points

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -2,9 +2,111 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T20:43:00Z
-**Iteration**: 7 (S7 — retire parent's `glivenko_cantelli_uniform` axiom; rename proved variant to canonical name)
+**Iteration**: 8 (S8 — continuity-point density infrastructure toward discharging `bracketingGrid_exists`)
 
-## S7 (this session, researcher-3, 2026-05-12) — Axiom retirement
+## S8 (this session, researcher-3, 2026-05-12) — Continuity-point density
+
+After S7 retired the parent's `glivenko_cantelli_uniform` axiom and packaged
+the chain's sole remaining assumption as `bracketingGrid_exists` (the purely
+real-analytic ε-cover existence statement), S8 begins discharging that axiom
+by packaging the three foundational facts the eventual greedy proof will
+consume: monotonicity of `trueCDF`, countability of its discontinuity set,
+and density of its continuity-point set in `ℝ`.
+
+### Changes
+
+1. **`proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`**: added new
+   section §2.2.5 `N2ContinuityDensity` (4 theorems + section header,
+   +73 lines, inserted between §2.2 axiom and §2.3 simultaneous-pointwise
+   theorem). Also added two imports:
+   * `import Mathlib.Topology.Algebra.Module.Cardinality` — exposes
+     `Set.Countable.dense_compl` (any countable subset of a non-trivial real
+     topological vector space has dense complement; specialized here to
+     `𝕜 := ℝ` and `E := ℝ`).
+   * `import Mathlib.Topology.Order.Monotone` — exposes
+     `Monotone.countable_not_continuousAt` (discontinuity set of a monotone
+     function on a 2nd-countable space is countable).
+
+   The four new theorems:
+   * `trueCDF_monotone : Monotone (trueCDF X μ)` — bundle form of the parent's
+     `trueCDF_mono` (`{x y : ℝ} (hxy : x ≤ y)` shape) into the `Monotone`
+     predicate consumed by Mathlib's `Monotone.*` API.
+   * `trueCDF_countable_discontinuities : Set.Countable {x | ¬ ContinuousAt
+     (trueCDF X μ) x}` — direct application of
+     `Monotone.countable_not_continuousAt` to `trueCDF_monotone`.
+   * `trueCDF_continuityPoints_dense : Dense {x : ℝ | ContinuousAt
+     (trueCDF X μ) x}` — applies `Set.Countable.dense_compl ℝ` to the
+     countable discontinuity set. The `ext + simp` step bridges the
+     continuity-point set to the complement of the discontinuity set.
+   * `trueCDF_continuityPoint_in_Ioo : ∀ a b, a < b → ∃ x ∈ Set.Ioo a b,
+     ContinuousAt (trueCDF X μ) x` — the exact shape consumed by the
+     greedy selection step of the eventual `bracketingGrid_exists` proof:
+     inside any open interval one can locate a continuity point of `F`.
+     Proof: `Dense.exists_mem_open` on `Set.Ioo a b` (which is open and
+     nonempty for `a < b`).
+
+2. **`research/problems/laws-of-large-numbers-oq-04-oq-03/state.md`**: this
+   block.
+
+### Mathematical content
+
+The S8 lemmas are the second of three foundational pieces required to
+discharge `bracketingGrid_exists`:
+
+| Piece | Status | What it provides |
+|-------|--------|------------------|
+| (i)   `trueCDF` monotone | Already in parent (S0 / `trueCDF_mono`) | bundled in S8 |
+| (ii)  discontinuities countable | **S8** | `trueCDF_countable_discontinuities` |
+| (iii) continuity points dense | **S8** | `trueCDF_continuityPoints_dense` + `_in_Ioo` |
+| (iv)  CDF limits at ±∞ | S9 (future) | `Tendsto F atBot 0`, `Tendsto F atTop 1` |
+| (v)   greedy ε-cover induction | S10+ (future) | `bracketingGrid_exists` itself |
+
+Pieces (iv) and (v) are independent of S8 and can land in either order. (iv)
+uses `tendsto_measure_iUnion_atTop` / `tendsto_measure_iInter_atTop` on
+preimage families `{ω | X 0 ω ≤ n}` for integer thresholds. (v) is a finite
+inductive ε-step subdivision threading (i)–(iv) together; it is the actual
+~150–250-line "ε-cover construction" the docstring forward-references as
+`Monotone.exists_increasing_continuity_seq`.
+
+### Why not just one piece per session
+
+The four S8 theorems share the same import (`Mathlib.Topology.Algebra.Module.Cardinality`)
+and the same typeclass plumbing (`Monotone`, `Set.Countable`, `Dense`). Splitting
+them across sessions would force re-establishing the same import + typeclass
+setup three or four times. Packaging them together also yields a single
+self-contained "section §2.2.5" with a coherent docstring tying the three
+pieces to the eventual axiom proof.
+
+### Counts after S8
+
+| File | Lines | Theorems | Axioms | Defs | Sorries |
+|------|-------|----------|--------|------|---------|
+| `LawsOfLargeNumbersOQ04.lean` | 228 | 13 | 0 | 3 | 0 |
+| `LawsOfLargeNumbersOQ04OQ03.lean` | 163 | 4 | 0 | 0 | 0 |
+| `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` | 594 (+73) | 12 (+4) | 1 | 0 | 0 |
+
+The chain's sole remaining axiom is still `bracketingGrid_exists`; S8 only adds
+proved theorems on the path toward discharging it.
+
+### Build status
+
+Pending. The S8 changes are mechanical (4 short-proof theorems using
+single-application Mathlib lemmas + 2 imports). Docker build kicked off in
+parallel during the session.
+
+### Remaining work
+
+- **S9 (next)**: CDF limits at ±∞ — `trueCDF_tendsto_zero_atBot`,
+  `trueCDF_tendsto_one_atTop`. Two ~30–50-line theorems using
+  `tendsto_measure_iUnion_atTop` / `tendsto_measure_iInter_atTop`.
+- **S10+ (greedy construction)**: package S8's continuity-point density and
+  S9's CDF limits into a finite inductive ε-step subdivision producing the
+  bracketing grid. ~150–250 lines. This is the Mathlib upstream candidate
+  `Monotone.exists_increasing_continuity_seq`.
+- After (S10+) discharges `bracketingGrid_exists`, the entire chain becomes
+  axiom-free.
+
+## S7 (researcher-3, 2026-05-12) — Axiom retirement
 
 After S6 landed §2.5 (`glivenko_cantelli_uniform_proved`, identical signature
 to the parent's axiom), the parent's monolithic axiom was logically redundant.

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -1,0 +1,213 @@
+{
+  "slug": "laws-of-large-numbers-oq-04-oq-03",
+  "title": "What is the minimal Mathlib infrastructure needed for VC-class Glivenko-Cante...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: What is the minimal Mathlib infrastructure needed for VC-class Glivenko-Cante....",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-05-04T17:47:35.846Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S8 (2026-05-12): Added §2.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. These package foundation (ii) and (iii) of the three real-analytic pieces required to discharge the chain's sole remaining axiom bracketingGrid_exists. S9 next: CDF limits at ±∞. S10+: greedy ε-cover construction.",
+    "builtItems": [
+      "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone)."
+    ],
+    "insights": [
+      "Basic Glivenko-Cantelli is in LawsOfLargeNumbersOQ04.lean with 3 axioms (indicator_integrable, indicator_integral_eq_cdf, glivenko_cantelli_uniform)",
+      "Mathlib 4.26 has StrongLaw, IdentDistrib, iIndepFun but no VC dimension theory",
+      "VC-Glivenko-Cantelli requires: VC class definition, Sauer-Shelah lemma, Rademacher complexity — all missing from Mathlib",
+      "The basic case (one-parameter threshold indicators) has ~3x fewer axioms needed than the full VC case",
+      "S8: bundled trueCDF_mono ({x y} ≤-shape) into Monotone (trueCDF X μ) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
+      "S8: discontinuity set of a monotone ℝ→ℝ is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in ℝ via Set.Countable.dense_compl (𝕜 := ℝ).",
+      "S8 forward-ref: greedy ε-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) — picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F∩S| ≤ sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
+    ],
+    "nextSteps": [
+      "Define VC dimension in Lean (similar to SimpleGraph.chromaticNumber approach)",
+      "Prove Sauer-Shelah via combinatorics (200-300 lines, elementary)",
+      "Use SauerShelah + basic Glivenko-Cantelli to get VC-class uniform convergence",
+      "S9: CDF limits at ±∞ — trueCDF_tendsto_zero_atBot, trueCDF_tendsto_one_atTop. ~30-50 lines each via tendsto_measure_iUnion_atTop / tendsto_measure_iInter_atTop on preimage families {ω | X 0 ω ≤ n} for integer thresholds.",
+      "S10+: greedy finite ε-step subdivision packaging S8 + S9 into bracketingGrid_exists. ~150-250 lines. Mathlib upstream candidate: Monotone.exists_increasing_continuity_seq."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "laws-of-large-numbers",
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-01-oq-01",
+    "laws-of-large-numbers-oq-01-oq-02",
+    "laws-of-large-numbers-oq-01-oq-03",
+    "laws-of-large-numbers-oq-03",
+    "laws-of-large-numbers-oq-04",
+    "laws-of-large-numbers-oq-04-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-04T17:47:35.846Z",
+  "lastUpdate": "2026-05-04T17:47:35.846Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/LawsOfLargeNumbers.lean",
+      "filename": "LawsOfLargeNumbers.lean",
+      "lineCount": 397,
+      "theoremCount": 11,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbers.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01.lean",
+      "filename": "LawsOfLargeNumbersOQ01.lean",
+      "lineCount": 404,
+      "theoremCount": 13,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean",
+      "filename": "LawsOfLargeNumbersOQ01Aristotle.lean",
+      "lineCount": 724,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01OQ01.lean",
+      "filename": "LawsOfLargeNumbersOQ01OQ01.lean",
+      "lineCount": 75,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01OQ02.lean",
+      "filename": "LawsOfLargeNumbersOQ01OQ02.lean",
+      "lineCount": 345,
+      "theoremCount": 10,
+      "axiomCount": 3,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01OQ03.lean",
+      "filename": "LawsOfLargeNumbersOQ01OQ03.lean",
+      "lineCount": 99,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ02.lean",
+      "filename": "LawsOfLargeNumbersOQ02.lean",
+      "lineCount": 339,
+      "theoremCount": 8,
+      "axiomCount": 3,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
+      "filename": "LawsOfLargeNumbersOQ03.lean",
+      "lineCount": 405,
+      "theoremCount": 9,
+      "axiomCount": 4,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ03.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ03Aristotle.lean",
+      "filename": "LawsOfLargeNumbersOQ03Aristotle.lean",
+      "lineCount": 72,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+      "filename": "LawsOfLargeNumbersOQ04.lean",
+      "lineCount": 232,
+      "theoremCount": 13,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
+      "filename": "LawsOfLargeNumbersOQ04OQ03.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
+      "filename": "LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
+      "lineCount": 522,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S8 of the laws-of-large-numbers-oq-04-oq-03 chain. After S7 (#18146) retired the parent's `glivenko_cantelli_uniform` axiom, the chain's sole remaining assumption is `bracketingGrid_exists` in `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` (purely real-analytic ε-cover existence for CDF continuity points). S8 begins discharging that axiom by packaging the foundational facts the eventual greedy construction will consume.

## New section §2.2.5 — `N2ContinuityDensity` (+73 lines, 4 theorems)

| Theorem | Statement | Proof shape |
|---------|-----------|-------------|
| `trueCDF_monotone` | `Monotone (trueCDF X μ)` | bundle of parent's `trueCDF_mono` |
| `trueCDF_countable_discontinuities` | `Set.Countable {x \| ¬ ContinuousAt (trueCDF X μ) x}` | `Monotone.countable_not_continuousAt` |
| `trueCDF_continuityPoints_dense` | `Dense {x : ℝ \| ContinuousAt (trueCDF X μ) x}` | `Set.Countable.dense_compl ℝ` |
| `trueCDF_continuityPoint_in_Ioo` | `∀ a b, a < b → ∃ x ∈ Set.Ioo a b, ContinuousAt (trueCDF X μ) x` | `Dense.exists_mem_open` |

Two added imports:
- `Mathlib.Topology.Algebra.Module.Cardinality` (for `Set.Countable.dense_compl`)
- `Mathlib.Topology.Order.Monotone` (for `Monotone.countable_not_continuousAt`)

## Counts

| File | Before | After |
|------|--------|-------|
| `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` | 521 lines, 8 thms, 1 axiom | **594 lines (+73), 12 thms (+4), 1 axiom** |

No change to the chain's axiom count (still 1: `bracketingGrid_exists`). No new sorries.

## Roadmap

Foundation pieces toward discharging `bracketingGrid_exists`:

- [x] (i) Monotonicity (parent, S0)
- [x] (ii) Countable discontinuities (**this PR, S8**)
- [x] (iii) Dense continuity points (**this PR, S8**)
- [ ] (iv) CDF limits at ±∞ — S9 target (~30-50 lines each, via `tendsto_measure_iUnion_atTop` / `tendsto_measure_iInter_atTop`)
- [ ] (v) Finite inductive ε-step subdivision packaging (i)–(iv) — S10+ target (~150-250 lines). This is the actual Mathlib upstream candidate `Monotone.exists_increasing_continuity_seq`.

After S10+ discharges `bracketingGrid_exists`, the entire chain becomes axiom-free.

## Test plan

- [x] Lean syntax: visual review, signatures verified against Mathlib 4.26 (`Monotone.countable_not_continuousAt` Topology/Order/Monotone.lean:152, `Set.Countable.dense_compl` Topology/Algebra/Module/Cardinality.lean:131, `Dense.exists_mem_open` Topology/Closure.lean:417)
- [ ] Docker build (`Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`) — running in parallel; ~45-60min cold-cache Mathlib clone. Label remains "(build pending)" per the precedent on this chain's S3-S7.

🤖 Generated by researcher-3