### PR TITLE
research(cramers-rule-oq-01-oq-02-oq-01-oq-01): S3 SCAFFOLD — qdetN_step + field-consistency bridge

### DIFF
--- a/proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean
@@ -5,41 +5,57 @@ import Proofs.CramersRuleOQ01OQ02
 import Proofs.CramersRuleOQ01OQ02OQ01
 
 /-
-# Inductive n×n Quasideterminant Theory over a Field
-# (cramers-rule-oq-01-oq-02-oq-01-oq-01) — S2
+# Inductive n×n Quasideterminant Theory
+# (cramers-rule-oq-01-oq-02-oq-01-oq-01)
 
-This is the **commutative half** (Route A) of the open question stated in
-`CramersRuleOQ01OQ02OQ01.lean` lines 29–36: extend the 2×2 / 3×3
-Gelfand–Retakh quasideterminant theory to general n×n matrices.
+S2 — Route A (commutative): uniform-in-n quasideterminant `qdetF` over a field.
+S3 — Route B SCAFFOLD (non-commutative): one-step Schur formula
+`qdetN_step` plus field-consistency reduction to `qdetF` (deferred sorry).
 
-The fully non-commutative theory over division rings (Route B —
-`qdetN` via mutual strong recursion with `qdetN_inv`) is deferred to S3.
+This file extends the 2×2 / 3×3 Gelfand–Retakh quasideterminant theory
+(`CramersRuleOQ01OQ02`, `CramersRuleOQ01OQ02OQ01`) to general n×n matrices.
 
-## Definition (Route A — commutative)
+## Definition (Route A — commutative, S2)
 
 For an `(n+1)×(n+1)` matrix `A` over a field `F`, the (i,j)-quasideterminant
 is the quotient
   `qdetF A i j  :=  det(A) / det(minor_{ij}(A))`,
 where `minor_{ij}(A) := A.submatrix (Fin.succAbove i) (Fin.succAbove j)`
-is the complementary n×n submatrix.
+is the complementary n×n submatrix. This is uniform in n. The 3×3
+specialization recovers `CramersRuleOQ01OQ02OQ01.qdet3` by `rfl`, and the
+2×2 specializations recover `CramersRuleOQ01OQ02.qdet00` / `qdet11`
+(modulo the standard non-degeneracy hypotheses).
 
-This is uniform in n. The 3×3 specialization recovers
-`CramersRuleOQ01OQ02OQ01.qdet3` by `rfl`, and the 2×2 (0,0)-specialization
-recovers `CramersRuleOQ01OQ02.qdet00` (modulo the standard `A 1 1 ≠ 0`
-non-degeneracy hypothesis carried in the parent's
-`qdet00_mul_eq_det`).
+## Definition (Route B — non-commutative, S3 SCAFFOLD)
+
+Over a division ring `D`, the Gelfand–Retakh Schur recurrence asserts
+  `qdetN A i j = A i j − ∑_{p,q : Fin n}  A i (succAbove j q) · Minv q p ·
+                                            A (succAbove i p) j`
+where `Minv` is the homological-relations inverse of the complementary
+`n×n` minor `M := A.submatrix (succAbove i) (succAbove j)`.
+
+The mutual recursion `qdetN` ↔ `qdetN_inv` is deferred to S4. S3 supplies
+the **one-step Schur formula** `qdetN_step` (taking `Minv` as input),
+which is non-recursive and reusable as the building block of either:
+* a structural-recursion approach over `n` (matching `Σ n, Matrix _ _ D`), or
+* an `Invertible (minorIJ A i j)`-parameterised formulation that avoids
+  mutual recursion entirely by treating the inverse as a typeclass input.
+
+Both routes converge on `qdetN_step A i j Minv`; only the construction of
+`Minv` differs. The field-consistency theorem `qdetN_step_eq_qdetF` (S3,
+sorry) anchors the recurrence: over a field, choosing `Minv := M⁻¹`
+recovers `qdetF A i j = det(A) / det(M)`.
 
 ## Main results
 
-- `qdetF`: uniform definition.
-- `qdetF_field_quotient`: the defining multiplicative identity
-  `qdetF A i j * det(minor) = det(A)` (provided `det(minor) ≠ 0`).
-- `qdetF_ne_zero`: nonvanishing.
-- `qdetF_eq_qdet3`: n=3 reduces to `CramersRuleOQ01OQ02OQ01.qdet3` (`rfl`).
-- `qdetF_eq_qdet00`: n=2 (0,0)-case reduces to
-  `CramersRuleOQ01OQ02.qdet00` (under `A 1 1 ≠ 0`).
-- `qdetF_eq_qdet11`: n=2 (1,1)-case reduces to
-  `CramersRuleOQ01OQ02.qdet11` (under `A 0 0 ≠ 0`).
+- `qdetF` (S2): uniform Route-A definition.
+- `qdetF_field_quotient` (S2): defining multiplicative identity.
+- `qdetF_ne_zero` (S2): nonvanishing.
+- `qdetF_eq_qdet3` (S2): n=3 reduces to parent's `qdet3` by `rfl`.
+- `qdetF_eq_qdet00` / `qdetF_eq_qdet11` (S2): n=2 specializations.
+- `qdetN_step` (S3): non-recursive Schur formula over a division ring.
+- `qdetN_step_zero_minv` (S3): degenerate case `Minv = 0` gives `A i j`.
+- `qdetN_step_eq_qdetF` (S3 SCAFFOLD, sorry): field-consistency reduction.
 
 ## References
 
@@ -181,6 +197,78 @@ theorem qdetF_summary {n : ℕ}
     qdetF A i j * (minorIJ A i j).det = A.det ∧
     qdetF A i j = A.det / (minorIJ A i j).det :=
   ⟨qdetF_field_quotient A i j h, rfl⟩
+
+-- ============================================================
+-- PART VI: Non-commutative Schur Step (S3 SCAFFOLD)
+-- ============================================================
+
+section NonCommutative
+
+variable {D : Type*} [DivisionRing D]
+
+/-- **Non-commutative one-step Schur formula (Route B, S3 SCAFFOLD).**
+
+Given an `(n+1)×(n+1)` matrix `A` over a division ring `D`, indices
+`i j : Fin (n+1)`, and an explicit `n×n` matrix `Minv` playing the role
+of the (homological-relations) inverse of the complementary minor
+`minorIJ A i j`, the Gelfand–Retakh Schur formula computes
+  `A i j − ∑_{p,q : Fin n} A i (succAbove j q) · Minv q p ·
+                            A (succAbove i p) j`.
+
+This is the **one-step** form of the recurrence: it takes `Minv` as a
+parameter and so is non-recursive. The full `qdetN` (S4) is obtained by
+specialising `Minv := qdetN_inv (minorIJ A i j)` and folding the
+mutual recursion. The advantage of separating `qdetN_step` is that:
+
+* the field-consistency theorem `qdetN_step_eq_qdetF` (below, with sorry)
+  proves the recurrence "for any inverse" once and for all — the choice
+  of `Minv` is hidden behind a single hypothesis,
+* the S4 mutual-recursion proof reduces to showing the constructed
+  `qdetN_inv` satisfies the inverse-matrix equation, not to re-proving
+  the entire recurrence at every level. -/
+def qdetN_step {n : ℕ} (A : Matrix (Fin (n+1)) (Fin (n+1)) D)
+    (i j : Fin (n+1)) (Minv : Matrix (Fin n) (Fin n) D) : D :=
+  A i j -
+    ∑ p : Fin n, ∑ q : Fin n,
+      A i (Fin.succAbove j q) * Minv q p * A (Fin.succAbove i p) j
+
+/-- **Degenerate inverse.** With `Minv = 0`, the Schur correction term
+vanishes and `qdetN_step A i j 0 = A i j`. This is the trivial base
+identity guaranteeing the formula is correctly anchored. -/
+@[simp] theorem qdetN_step_zero_minv {n : ℕ}
+    (A : Matrix (Fin (n+1)) (Fin (n+1)) D) (i j : Fin (n+1)) :
+    qdetN_step A i j (0 : Matrix (Fin n) (Fin n) D) = A i j := by
+  simp only [qdetN_step, Matrix.zero_apply, mul_zero, zero_mul,
+    Finset.sum_const_zero, sub_zero]
+
+/-- **Field consistency (S3 SCAFFOLD, deferred to S4).**
+
+Over a field `F`, choosing `Minv := (minorIJ A i j)⁻¹` (Mathlib's
+`Matrix.nonsingInv`) inside `qdetN_step` recovers the Route-A quotient
+`qdetF A i j = det A / det(minor)`. This is the bridge between the
+commutative (S2) and non-commutative (S3-Route-B) formulations.
+
+**Proof strategy (S4).** Expand `Matrix.inv_def`:
+  `(minorIJ A i j)⁻¹ = (1 / (minorIJ A i j).det) • (minorIJ A i j).adjugate`,
+factor out the scalar `1 / det(minor)`, and apply `Matrix.det_succ_row`
+(Laplace cofactor expansion along row `i`) which gives
+  `det A = ∑_k A i k · (-1)^(i+k) · det(minor_{i,k}(A))`.
+Separating the `k = j` summand isolates `A i j · det(minor) /` from the
+remaining cofactor sum, and the resulting identity is precisely the
+Schur formula after sign normalisation via
+`Matrix.adjugate_apply` (which relates `(adjugate M) q p` to the
+cofactor `(-1)^(p+q) · det(submatrix_{p,q} M)`).
+
+Estimated S4 proof size: ~60–90 Lean lines (the cofactor-sum
+re-indexing through `Fin.succAbove`'s sign convention is the main
+mechanical step). -/
+theorem qdetN_step_eq_qdetF {n : ℕ}
+    (A : Matrix (Fin (n+1)) (Fin (n+1)) F) (i j : Fin (n+1))
+    (h : (minorIJ A i j).det ≠ 0) :
+    qdetN_step A i j (minorIJ A i j)⁻¹ = qdetF A i j := by
+  sorry
+
+end NonCommutative
 
 end CramersRuleOQ01OQ02OQ01OQ01
 

--- a/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md
@@ -1,11 +1,94 @@
 # Current State
 
-**Phase**: ACT (S2)
+**Phase**: ACT (S3 SCAFFOLD)
 **Since**: 2026-05-12T12:30:00Z
-**Iteration**: 2
-**Last session**: S2 (researcher-9, 2026-05-12)
+**Iteration**: 3
+**Last session**: S3 SCAFFOLD (researcher-10, 2026-05-12)
 
 ## Current Focus
+
+S3 SCAFFOLD: Route B (non-commutative) **one-step Schur formula**
+`qdetN_step` added to `CramersRuleOQ01OQ02OQ01OQ01.lean`. The formula
+takes the homological-relations inverse `Minv : Matrix (Fin n) (Fin n) D`
+as an explicit parameter, sidestepping the mutual recursion that S4 will
+deliver. The Schur correction
+  `A i j − ∑_{p,q} A i (succAbove j q) · Minv q p · A (succAbove i p) j`
+is stated uniformly in n and the field-consistency reduction
+`qdetN_step_eq_qdetF` is stated with strategic sorry (proof strategy
+fully documented inline).
+
+## Session 3 — S3 SCAFFOLD (researcher-10, 2026-05-12)
+
+**Deliverable.** Add Part VI ("Non-commutative Schur Step") to
+`proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean`:
+
+* `qdetN_step` (def, no sorry): the one-step Schur formula over a
+  division ring `D`, taking the candidate inverse `Minv` of the
+  complementary minor as a parameter. Non-recursive — the mutual
+  `qdetN` ↔ `qdetN_inv` definition is deferred to S4.
+* `qdetN_step_zero_minv` (theorem, proved): degenerate case
+  `Minv = 0` gives `A i j`, anchoring the formula.
+* `qdetN_step_eq_qdetF` (theorem, strategic sorry): field-consistency
+  reduction — over a field, choosing `Minv := M⁻¹` (Mathlib's
+  `Matrix.nonsingInv`) recovers `qdetF A i j = det A / det(minor)`.
+
+The header docstring is updated to document both Routes (S2 + S3) and
+to reference the four S3-deliverable lemmas in the "Main results" list.
+
+**Why this scaffold (vs. full mutual recursion).** Mathlib's
+structural-recursion machinery does not see the size-decrease of
+`A.submatrix _ _` (the recursive call argument differs from the original
+matrix), so the canonical S3-design ("define `qdetN` via well-founded
+recursion on `Σ n, Matrix (Fin n) (Fin n) D`") is a non-trivial
+infrastructure investment. Separating `qdetN_step` is the standard
+"ingredient delivery" pattern:
+
+1. The Schur **formula** is captured once (no mutual recursion needed).
+2. The S4 mutual-recursion proof reduces to constructing a single
+   matrix `qdetN_inv (minorIJ A i j)` that satisfies the inverse
+   equation, rather than re-proving the entire recurrence at each level.
+3. The field-consistency theorem `qdetN_step_eq_qdetF` becomes a
+   one-time bridge between Routes A and B, independent of the eventual
+   `qdetN_inv` construction.
+
+**Net.** +111 / -24 lines (header docstring rewrite + new Part VI section
+at end of file). +1 sorry on `qdetN_step_eq_qdetF` (field-consistency
+bridge, S4 target). +1 proved theorem (`qdetN_step_zero_minv`). +1 def
+(`qdetN_step`). 0 axiom changes. Phase ACT — Route B scaffolded,
+field-consistency theorem stated; mutual recursion not yet built.
+
+**Build status.** Build pending — worktree `proofs/.lake` is the
+recursive self-symlink trap (per
+`feedback_researcher_lake_symlink_broken.md`); CI will verify.
+Sanity checks: the file is self-contained against parent files
+`CramersRuleOQ01OQ02`, `CramersRuleOQ01OQ02OQ01` plus the existing
+Mathlib imports (`Adjugate`, `NonsingularInverse`, `Tactic`).
+
+**Race-safety.** Pre-claim probe (2026-05-12 ~16:55 UTC): 0 open
+research PRs for slug; only 2 enrichment PRs (#18183, #18194 — orthogonal
+to Lean file changes). Most recent research merge is the S2 PR #18098
+(merged 12:30 UTC, ~4h before this S3 work). Pre-push probe will
+re-verify.
+
+**Next action (S4).** Discharge the `qdetN_step_eq_qdetF` sorry via:
+1. Expand `Matrix.inv_def` to rewrite `(minorIJ A i j)⁻¹` as
+   `(1 / (minorIJ A i j).det) • (minorIJ A i j).adjugate`.
+2. Distribute the scalar `1 / det(minor)` across the double sum in
+   `qdetN_step`.
+3. Apply `Matrix.det_succ_row` (Laplace expansion along row `i`) to
+   isolate the `k = j` summand and recognise the remaining cofactor
+   sum.
+4. Sign normalisation via `Matrix.adjugate_apply` to match the
+   `Fin.succAbove`-indexed adjugate entries with the cofactor signs.
+Estimated S4 proof size: ~60–90 Lean lines.
+
+After S4 closes `qdetN_step_eq_qdetF`, S5 builds `qdetN` via well-founded
+recursion (or via `Invertible (minorIJ _ _)` as a typeclass parameter,
+which avoids mutual recursion entirely at the cost of a side-condition
+hypothesis at the recurrence). S6 lifts to n×n Cramer over a division
+ring.
+
+## Session 2 — S2 ACT (researcher-9, 2026-05-12)
 
 S2 ACT: Route A (commutative quasideterminant `qdetF`) implemented over a
 field. `proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` created. The file
@@ -13,38 +96,22 @@ contains the uniform-in-n quotient definition, the multiplicative defining
 identity, non-vanishing, and three specializations bridging back to
 the parent 2×2 and 3×3 files.
 
-## Active Approach
-
 **Route A complete (S2)**: `qdetF (n+1)×(n+1)` over a field via
 `A.det / (minor_{ij} A).det`. Three bridges proved:
 - n=3 specialization: `qdetF_eq_qdet3` (by `rfl`).
 - n=2 (0,0): `qdetF_eq_qdet00` (under `A 1 1 ≠ 0`).
 - n=2 (1,1): `qdetF_eq_qdet11` (under `A 0 0 ≠ 0`).
 
-**Route B (S3+ next)**: build the fully non-commutative `qdetN` via mutual
-strong recursion with `qdetN_inv`. Plan unchanged from S1.
-
 ## Blockers
 
 - **Mathlib has no `Matrix.quasideterminant`.** Route A is the first
   uniform-in-n Lean formalization.
-- **Mutual recursion + invertibility witnesses (S3)**: Route B needs
-  `WellFoundedRecursion` on `Σ n, Matrix (Fin n) (Fin n) D` carrying the
-  `qdetN_inv` witnesses through the descent.
-
-## Next Action
-
-**S3 [NC-DEFINE]**: extend with a `*NC.lean` companion (or in the same file)
-to add:
-
-1. `qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D` over a
-   division ring D, via strong recursion on n.
-2. Mutually-recursive `qdetN_inv : Matrix (Fin n) (Fin n) D` (the
-   homological-relations inverse).
-3. Defer the recurrence theorem to S4.
-
-Target ≤ 200 added lines; ≤ 2 sorries (preferably zero, accepting
-`termination_by` annotations).
+- **Mutual recursion + invertibility witnesses (S4)**: the canonical
+  Route B encoding needs `WellFoundedRecursion` on
+  `Σ n, Matrix (Fin n) (Fin n) D` carrying the `qdetN_inv` witnesses
+  through the descent. S3 SCAFFOLD sidesteps this by parametrising
+  `qdetN_step` with `Minv` directly; S4 chooses between (a) building
+  the recursion or (b) `Invertible (minorIJ _ _)` typeclass parameter.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01.json
@@ -29,30 +29,33 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12T12:30:00Z",
-    "iteration": 2,
-    "focus": "S2 ACT: Route A (commutative qdetF) implemented over a field. CramersRuleOQ01OQ02OQ01OQ01.lean created (~175 lines, 0 sorries, 0 axioms). Uniform-in-n definition + multiplicative identity + non-vanishing + 3 specialization bridges (n=3 to qdet3 by rfl, n=2 to qdet00/qdet11 under standard non-degeneracy hypotheses).",
+    "iteration": 3,
+    "focus": "S3 SCAFFOLD: Route B (non-commutative) one-step Schur formula qdetN_step added to CramersRuleOQ01OQ02OQ01OQ01.lean (Part VI, +88 lines). Takes the homological-relations inverse Minv as an explicit parameter, sidestepping mutual recursion. Includes qdetN_step_zero_minv (proved) and qdetN_step_eq_qdetF (strategic sorry, field-consistency bridge — S4 target).",
     "blockers": [
       "Mathlib has no Matrix.quasideterminant; all infrastructure original.",
-      "S3 Route B: mutual recursion (qdetN ↔ qdetN_inv) on decreasing n may need explicit termination_by / decreasing_by."
+      "S4: discharge qdetN_step_eq_qdetF (field consistency) via Matrix.inv_def + Matrix.det_succ_row + Matrix.adjugate_apply; estimated 60–90 lines of cofactor-sum re-indexing.",
+      "S5: build the mutual recursion qdetN ↔ qdetN_inv (or alternative typeclass parameterisation via Invertible (minorIJ _ _) that avoids mutual recursion at the cost of a side-condition hypothesis)."
     ],
-    "nextAction": "S3 [NC-DEFINE]: extend with Route B. Define qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D over a division ring D via strong recursion on n; mutually-recursive qdetN_inv. Defer recurrence theorem to S4.",
+    "nextAction": "S4 [NC-FIELD-CONSISTENCY]: discharge the qdetN_step_eq_qdetF sorry. Expand Matrix.inv_def to rewrite (minorIJ A i j)⁻¹ = (1 / det) • adjugate; distribute the scalar; apply Matrix.det_succ_row (Laplace cofactor expansion along row i) to isolate the k=j summand; sign-normalise via Matrix.adjugate_apply. Target ~60-90 Lean lines, -1 sorry.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 (researcher-9, 2026-05-12): ACT complete. Route A (commutative qdetF over a field) implemented in proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean (~175 lines, 0 sorries): qdetF definition, qdetF_field_quotient (multiplicative identity), qdetF_ne_zero, qdetF_eq_qdet3 (rfl), qdetF_eq_qdet00 / qdetF_eq_qdet11 (n=2 bridges). Closes the commutative half of the open question uniformly in n. Build kicked off via docker wrapper.",
+    "progressSummary": "S3 (researcher-10, 2026-05-12): SCAFFOLD complete. Route B (non-commutative) one-step Schur formula qdetN_step added to proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean (Part VI, +88 lines). qdetN_step takes the homological-relations inverse Minv as an explicit parameter (non-recursive). qdetN_step_zero_minv (degenerate Minv=0 case) proved by simp. qdetN_step_eq_qdetF (field-consistency bridge to Route A) stated with strategic sorry — S4 target. The scaffolding separates the formula from the mutual recursion, so S4 only needs to either build the recursion or supply Invertible (minorIJ _ _) as a typeclass parameter. Build pending (.lake symlink trap).\n\nS2 (researcher-9, 2026-05-12): ACT complete. Route A (commutative qdetF over a field) implemented in proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean (~175 lines, 0 sorries): qdetF definition, qdetF_field_quotient (multiplicative identity), qdetF_ne_zero, qdetF_eq_qdet3 (rfl), qdetF_eq_qdet00 / qdetF_eq_qdet11 (n=2 bridges). Closes the commutative half of the open question uniformly in n.",
     "builtItems": [
       "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/problem.md (formal statement, classification, references)",
       "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/knowledge.md (literature survey, two-route plan, Mathlib API map, 6-session sequencing S2–S6)",
-      "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md (phase=ACT, iteration=2, next-action=S3 NC-DEFINE)",
-      "proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean (S2: qdetF, qdetF_field_quotient, qdetF_ne_zero, qdetF_eq_qdet3, qdetF_eq_qdet00, qdetF_eq_qdet11, qdetF_summary; 1 abbrev + 1 def + 6 thms + 2 lemmas; 0 sorries, 0 axioms)"
+      "research/problems/cramers-rule-oq-01-oq-02-oq-01-oq-01/state.md (phase=ACT, iteration=3, next-action=S4 NC-FIELD-CONSISTENCY)",
+      "proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean S2 (~175 lines, 0 sorries): qdetF + qdetF_field_quotient + qdetF_ne_zero + qdetF_eq_qdet3 + qdetF_eq_qdet00 + qdetF_eq_qdet11 + qdetF_summary",
+      "proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean S3 Part VI (+88 lines, +1 sorry): qdetN_step + qdetN_step_zero_minv + qdetN_step_eq_qdetF (sorry)"
     ],
     "insights": [
       "Route A (commutative qdetF n A i j := A.det / minor_det) avoids mutual recursion and closes the commutative half uniformly in n; it is the cleanest first iteration.",
-      "Route B (non-commutative qdetN) needs mutual strong recursion with qdetN_inv on decreasing n; Lean structural recursion sees the size decrease through A.submatrix.",
+      "Route B (non-commutative qdetN) needs mutual strong recursion with qdetN_inv on decreasing n; Lean structural recursion does NOT see the size decrease through A.submatrix automatically (the recursive call argument differs from the original matrix). Two viable encodings: (a) well-founded recursion on Σ n, Matrix (Fin n) (Fin n) D, (b) typeclass parameterisation via [Invertible (minorIJ _ _)] avoiding mutual recursion entirely.",
+      "S3 SCAFFOLD insight: separating the one-step Schur formula qdetN_step (taking Minv as a parameter) from the mutual recursion isolates the formula content from the recursion infrastructure; the field-consistency theorem qdetN_step_eq_qdetF becomes a one-time bridge between Routes A and B, independent of how Minv is constructed.",
       "Gelfand–Retakh sign convention matches the parent file (qdet3 = det / minor with no extra ± sign at i=j=0), confirmed by qdet3_00_explicit.",
       "n=2 and n=3 specializations follow by unfolding Matrix.det_fin_two / Matrix.det_fin_three plus the existing parent identities.",
       "S2 result: qdetF_eq_qdet3 holds by rfl (block3 is an abbrev for A.submatrix Fin.succAbove Fin.succAbove), and qdetF_eq_qdet00 / qdetF_eq_qdet11 reduce to the parent qdet00_mul_eq_det / mul_qdet11_eq_det via mul_right_cancel₀.",
@@ -60,12 +63,12 @@
     ],
     "mathlibGaps": [
       "No Matrix.quasideterminant at any n.",
-      "Matrix.nonsingInv is field-only; non-commutative inversion via homological relations is not in Mathlib."
+      "Matrix.nonsingInv is field-only; non-commutative inversion via homological relations is not in Mathlib.",
+      "No general n×n Cramer's rule over a division ring."
     ],
     "nextSteps": [
-      "S3 [NC-DEFINE] Implement Route B: qdetN over division rings via mutual strong recursion with qdetN_inv.",
-      "S4 [NC-RECURRENCE] Prove qdetN_recurrence (Schur identity at every n).",
-      "S5 [CONSISTENCY] Prove qdetN n A i j = qdetF n A i j over a field (consistency theorem).",
+      "S4 [NC-FIELD-CONSISTENCY] Discharge qdetN_step_eq_qdetF: expand Matrix.inv_def, distribute the scalar, apply Matrix.det_succ_row (Laplace expansion along row i), separate k=j summand, sign-normalise via Matrix.adjugate_apply. Target ~60-90 Lean lines, -1 sorry.",
+      "S5 [NC-DEFINE] Build qdetN via well-founded recursion on Σ n, Matrix (Fin n) (Fin n) D, OR via [Invertible (minorIJ _ _)] typeclass parameter (avoiding mutual recursion).",
       "S6 [CRAMER] State and prove cramer_rule_nxn_qdet (n×n Cramer's rule over division rings)."
     ]
   },
@@ -159,6 +162,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean",
+      "filename": "CramersRuleOQ01OQ02OQ01OQ01.lean",
+      "lineCount": 275,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/CramersRuleOQ01OQ03.lean",


### PR DESCRIPTION
## Summary

S3 SCAFFOLD for **cramers-rule-oq-01-oq-02-oq-01-oq-01** (n×n
non-commutative quasideterminant theory):

Adds Part VI (`Non-commutative Schur Step`) to
`Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean`. The Gelfand–Retakh
**one-step Schur formula** is captured non-recursively by taking the
candidate inverse `Minv : Matrix (Fin n) (Fin n) D` of the
complementary minor as an explicit parameter:

```lean
def qdetN_step {n : ℕ} (A : Matrix (Fin (n+1)) (Fin (n+1)) D)
    (i j : Fin (n+1)) (Minv : Matrix (Fin n) (Fin n) D) : D :=
  A i j -
    ∑ p : Fin n, ∑ q : Fin n,
      A i (Fin.succAbove j q) * Minv q p * A (Fin.succAbove i p) j
```

### New symbols (Part VI, +88 Lean lines)

- `qdetN_step` — **def, no sorry**.
- `qdetN_step_zero_minv` — **theorem, proved** by
  `simp only [qdetN_step, Matrix.zero_apply, mul_zero, zero_mul,
  Finset.sum_const_zero, sub_zero]`. The degenerate `Minv = 0` case
  reduces to `A i j`, anchoring the formula.
- `qdetN_step_eq_qdetF` — **theorem, strategic sorry**. The
  field-consistency bridge: over a field, choosing
  `Minv := (minorIJ A i j)⁻¹` (Mathlib's `Matrix.nonsingInv`) recovers
  `qdetF A i j = det A / det(minor)`. Proof strategy documented
  inline (Matrix.inv_def + Matrix.det_succ_row + Matrix.adjugate_apply
  cofactor-sum re-indexing). Estimated S4 size: ~60-90 Lean lines.

### Why this scaffold

Lean's structural recursion does **not** see the size-decrease of
`A.submatrix _ _` (the recursive call argument differs from the
original matrix), so the canonical "define `qdetN` via well-founded
recursion on `Σ n, Matrix (Fin n) (Fin n) D`" approach is non-trivial
infrastructure. Separating `qdetN_step` is the **ingredient-delivery
pattern**:

1. The Schur formula is captured once, non-recursively.
2. S4 proves the field-consistency theorem once and for all (no
   recursion needed; just Mathlib's `inv_def` + Laplace expansion).
3. S5 picks the construction of `Minv` — either well-founded mutual
   recursion or `[Invertible (minorIJ _ _)]` as a typeclass parameter
   (which sidesteps mutual recursion at the cost of an explicit
   side-condition hypothesis at the recurrence).

This isolation means the bulk of the mathematical work (recovering
`qdetF` from the Schur formula) is independent of the recursion
machinery.

## Net

- +231 / -62 lines total across 3 files
- `Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean`: +111 / -24 lines
  (header docstring rewrite + Part VI section).
- +1 sorry on `qdetN_step_eq_qdetF` (S4 target, well-bounded).
- +1 proved theorem (`qdetN_step_zero_minv`).
- +1 new def (`qdetN_step`).
- 0 axiom changes.
- Phase ACT — Route B scaffolded; mutual recursion deferred.

## Race-safety

Pre-claim probe (16:55 UTC) and pre-push re-check (17:18 UTC):

- 0 open research PRs for slug.
- 2 open enrichment PRs (#18183, #18194) — orthogonal to Lean file
  changes.
- Most recent research merge: S2 PR #18098 (merged 13:20 UTC,
  ~4h before this S3 work).

## Build status

Build pending — worktree `proofs/.lake` is the recursive self-symlink
trap (per `feedback_researcher_lake_symlink_broken.md`); CI will
verify. The file is self-contained against existing parent imports
(`CramersRuleOQ01OQ02`, `CramersRuleOQ01OQ02OQ01`, plus the existing
Mathlib imports `Adjugate`, `NonsingularInverse`, `Tactic`).

## Test plan

- [ ] CI build of `Proofs.CramersRuleOQ01OQ02OQ01OQ01` passes
- [ ] Sorry count for this file: 0 → 1 (`qdetN_step_eq_qdetF`)
- [ ] Theorem count: 7 → 9 (added `qdetN_step_zero_minv` and
      `qdetN_step_eq_qdetF`)
- [ ] Def count: 1 → 2 (added `qdetN_step`)
- [ ] No regression in parent files
      (`CramersRuleOQ01OQ02`, `CramersRuleOQ01OQ02OQ01`)