### PR TITLE
research(sum-of-divisors-oq-02): S1 OBSERVE — Euler-converse pedagogical decomposition

### DIFF
--- a/research/problems/sum-of-divisors-oq-02/knowledge.md
+++ b/research/problems/sum-of-divisors-oq-02/knowledge.md
@@ -1,0 +1,121 @@
+# Knowledge Base: Euler's Converse for Even Perfect Numbers
+
+## Status: S1 OBSERVE (survey + plan, no Lean changes yet)
+
+## Mathlib API Inventory
+
+### Core definitions
+- `Nat.Perfect n` — `(∑ i ∈ n.divisors, i) = 2 * n` (proper-divisor form: `σ(n) - n = n`).
+- `ArithmeticFunction.sigma k n` — `∑ d ∈ n.divisors, d^k`; we use `σ 1 = σ`.
+- `Nat.mersenne p` — `2^p - 1`; Mersenne prime when `(mersenne p).Prime`.
+
+### Key Mathlib lemmas (already available)
+| Lemma | Statement (informal) |
+|---|---|
+| `Nat.perfect_iff_sum_divisors_eq_two_mul` | `0 < n → (n.Perfect ↔ ∑_{d ∣ n} d = 2n)` |
+| `ArithmeticFunction.IsMultiplicative.sigma_one` | `σ 1` is multiplicative (over coprime args) |
+| `Nat.sigma_one_apply` | `σ 1 n = ∑ d ∈ n.divisors, d` |
+| `Theorems100.Nat.sigma_two_pow_eq_mersenne_succ` | `σ 1 (2^k) = mersenne (k+1)` (proven in Archive) |
+| `Theorems100.Nat.perfect_two_pow_mul_mersenne_of_prime` | **Euclid direction** (in Archive) |
+| `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` | **Euler direction** (bundled proof in Archive) |
+| `Theorems100.Nat.even_and_perfect_iff` | **Complete equivalence** (in Archive) |
+
+### Coprime + prime-power infrastructure
+- `Nat.Coprime.pow_right`, `Nat.Coprime.pow_left` — coprimality of powers.
+- `Nat.Coprime` — Mathlib `Nat.Coprime a b ↔ Nat.gcd a b = 1`.
+- `Nat.Odd.coprime_two_pow` (or equivalent) — odd numbers are coprime to powers of 2.
+- `Nat.sigma_one_prime` — `σ 1 p = p + 1` when `p.Prime`.
+
+## Proof Skeleton (Euler ⇒ direction)
+
+Let `n > 0` be even and perfect. Write `n = 2^k · m` with `m` odd and `k ≥ 1`.
+
+### Step 1 — Coprime decomposition
+**Goal**: `σ(2^k · m) = σ(2^k) · σ(m)`.
+- Apply `IsMultiplicative.sigma_one` with hypothesis `Coprime (2^k) m` (from `m` odd).
+- Mathlib helper: `Nat.Coprime.pow_left` or `Odd.coprime_two_pow`.
+
+### Step 2 — Power identity
+**Goal**: `σ(2^k) = 2^(k+1) - 1 = M_{k+1}`.
+- Directly from `Theorems100.Nat.sigma_two_pow_eq_mersenne_succ k`.
+
+### Step 3 — Perfect-equation expansion
+**Goal**: `M_{k+1} · σ(m) = 2^(k+1) · m`.
+- From `n.Perfect` and Step 1: `σ(2^k) · σ(m) = 2 · (2^k · m) = 2^(k+1) · m`.
+- Substitute Step 2.
+
+### Step 4 — Divisibility extraction
+**Goal**: `M_{k+1} ∣ m` (since `gcd(M_{k+1}, 2^(k+1)) = 1` as `M_{k+1}` is odd).
+- `M_{k+1} = 2^(k+1) - 1` is odd, so coprime to `2^(k+1)`.
+- From Step 3: `M_{k+1} · σ(m) = 2^(k+1) · m` and `Coprime M_{k+1} (2^(k+1))` gives `M_{k+1} ∣ m`.
+- Write `m = M_{k+1} · c` for some `c ≥ 1`.
+
+### Step 5 — Substitution + bound
+**Goal**: `σ(m) = 2^(k+1) · c` and `c < m`.
+- From Step 3 with `m = M_{k+1} · c`: `M_{k+1} · σ(m) = 2^(k+1) · M_{k+1} · c`, so `σ(m) = 2^(k+1) · c`.
+- Note `2^(k+1) · c = (M_{k+1} + 1) · c = m + c`. So `σ(m) = m + c`.
+
+### Step 6 — Two-divisor lemma forces primality + `c = 1`
+**Goal**: `c = 1` and `m` prime (hence `m = M_{k+1}` is a Mersenne prime).
+- `σ(m) = m + c` and `c ∣ m` (since `m = M_{k+1} · c`).
+- For `m > 1`, the divisors of `m` always include at least `1` and `m`; their sum is at least `1 + m`.
+- So `m + c ≥ 1 + m`, i.e., `c ≥ 1`. Equality forces divisor set `= {c, m}` and `c = 1` (since `1` must appear).
+- Thus `c = 1`, `m = M_{k+1}`, and `m` has exactly two divisors → `m.Prime`.
+
+### Step 7 — Conclusion
+- `n = 2^k · m = 2^k · M_{k+1}` with `M_{k+1}.Prime`. ∎
+
+## Comparison to Mathlib Archive
+
+The Archive proof `eq_two_pow_mul_prime_mersenne_of_even_perfect` performs essentially
+the same steps in a single ~80-line block. The pedagogical refactor would:
+1. Introduce named lemmas for Steps 1, 2, 4, 5, 6 (Step 3 is a direct rewrite, Step 7 a conjunction).
+2. Add docstrings explaining the algebraic intuition.
+3. Verify in our build (`docker-build.sh Proofs.SumOfDivisorsOQ02`).
+
+## Mathlib Gaps Identified
+
+None that block S2 ACT. All lemmas needed for Steps 1–7 are either in Mathlib core
+(`Coprime`, `IsMultiplicative`, `Nat.divisors`) or in the Archive (`sigma_two_pow_eq_mersenne_succ`).
+
+The Archive import (`import Archive.Wiedijk100Theorems.PerfectNumbers`) is already
+working in `PerfectNumbers.lean` and would be reused here.
+
+## Risks and Open Decisions
+
+- **Risk**: The pedagogical refactor may end up structurally identical to the Archive
+  proof, providing limited gallery value. Mitigation: prioritize naming + docstrings
+  over algebraic novelty; treat as documentation contribution.
+- **Decision deferred to S2 ACT**: Whether to write `Proofs/SumOfDivisorsOQ02.lean` from
+  scratch, or extend `PerfectNumbers.lean` with named intermediate lemmas. Default plan:
+  separate file to keep the bundled `euler_even_perfect` wrapper intact.
+
+## References
+
+- Euler, L. (1747). "De numeris amicabilibus" (posthumous, 1849). Opera Postuma 1, 85–100.
+- Euclid (~300 BCE). *Elements*, Book IX, Proposition 36.
+- Hardy, G.H. & Wright, E.M. (1979). *An Introduction to the Theory of Numbers*, §16.8.
+- Mathlib Archive: `Archive.Wiedijk100Theorems.PerfectNumbers` (Wiedijk #70).
+- Keith Conrad. "Perfect Numbers and Mersenne Primes." UConn expository notes.
+
+## Scouting Log
+
+### S1 OBSERVE (2026-05-12, researcher-12)
+
+**Mode**: Survey + plan; no Lean changes.
+
+**Findings**:
+- Parent slug `sum-of-divisors` is marked COMPLETED (skipped in favor of `PerfectNumbers.lean`).
+- `PerfectNumbers.lean` already wraps the Archive's bundled Euler converse via `euler_even_perfect`.
+- The OQ-02 framing (per seeker note: "sigma_mul_coprime + prime-power structure") proposes a
+  *self-contained* pedagogical proof with named intermediate steps, not a re-wrapping.
+
+**S2 plan**: Scaffold `Proofs/SumOfDivisorsOQ02.lean` with:
+- Section per step (Steps 1–6 above) — each step as a named lemma with `sorry`.
+- Top-level theorem `euler_converse_self_contained` combining the steps.
+- Gallery entry `src/data/proofs/sum-of-divisors-oq-02/` with annotations.
+
+**Honesty note**: If S2 build reveals the named decomposition is nearly identical to the
+Archive proof's internal structure, the contribution is *documentation-only* (rename + docstrings)
+and the slug should be closed as "covered-by-parent / pedagogical-only" after one or two
+iterations, not pursued as multi-session research.

--- a/research/problems/sum-of-divisors-oq-02/problem.md
+++ b/research/problems/sum-of-divisors-oq-02/problem.md
@@ -1,0 +1,77 @@
+# Problem: Euler's Converse — Every Even Perfect Number is Mersenne-Form
+
+## Statement
+
+### Plain Language
+Euler (1747) proved the converse of Euclid's theorem on perfect numbers: every even
+perfect number `n` must have the form `n = 2^k · (2^(k+1) - 1)` where `2^(k+1) - 1`
+is a Mersenne prime. Combined with Euclid's direction, this gives a complete
+characterization of even perfect numbers, leaving odd perfect numbers as a 2000-year
+open problem.
+
+This sub-slug targets the **Euler (⇒) direction specifically**, exposing the algebraic
+skeleton — multiplicativity of σ on coprime factorizations + prime-power structure —
+rather than invoking the Mathlib Archive's bundled proof as an opaque black box.
+
+### Formal Statement
+$$
+\forall\, n \in \mathbb{N},\quad \text{Even}(n) \,\wedge\, n.\text{Perfect}
+\;\Longrightarrow\;
+\exists\, k \in \mathbb{N},\; \text{Prime}(2^{k+1} - 1) \,\wedge\, n = 2^k \cdot (2^{k+1} - 1).
+$$
+
+Equivalently: writing `n = 2^k · m` with `m` odd and `k ≥ 1`, the perfect equation
+`σ(n) = 2n` forces `m = 2^(k+1) - 1` to be a Mersenne prime (and `m` has no proper
+divisors strictly between `1` and `m`).
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - number-theory
+  - perfect-numbers
+  - arithmetic-functions
+  - multiplicative
+  - mersenne-primes
+```
+
+**Significance**: 7/10 — Classical millennia-spanning characterization; pedagogically valuable
+to expose the σ-multiplicativity argument independently of the bundled proof.
+
+**Tractability**: 6/10 — The bundled proof exists in Mathlib's Archive (≈150 lines);
+decomposing it into 5–7 named sub-lemmas with explicit references is a focused refactor.
+
+## Why This Matters
+
+1. **Pedagogical exposition** — `Archive.Wiedijk100Theorems.PerfectNumbers` proves the
+   bundled equivalence in `eq_two_pow_mul_prime_mersenne_of_even_perfect` via one dense
+   block of algebra. A gallery-quality version with named intermediate lemmas
+   (sigma-coprime split, prime-power identity, divisibility extraction, uniqueness step)
+   makes the structure transparent.
+2. **Reusable sub-lemmas** — The intermediate facts `σ(2^k) · σ(m) = 2^(k+1) · m` and
+   `M_{k+1} | m` (where `M_{k+1} = 2^(k+1) - 1`) appear in many divisibility arguments;
+   exposing them named is a small Mathlib API uplift.
+3. **Open-problem stepping stone** — The same algebraic skeleton (sigma factorization
+   + abundancy bounds) underlies all known constraints on odd perfect numbers.
+   A clear formalization of the even case is a prerequisite for any future odd-case work.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `perfect-numbers` (`PerfectNumbers.lean`) | Parent — bundles both Euclid + Euler via Mathlib Archive |
+| `sum-of-divisors` (`SumOfDivisors.lean`) | σ-arithmetic infrastructure (multiplicativity, prime powers) |
+| `perfect-numbers-oq-03` (`PerfectNumbersOQ03.lean`) | Related sub-question (different framing) |
+
+## Relationship to Existing Work
+
+`PerfectNumbers.lean` line 107 contains `euler_even_perfect` which proves this statement
+directly via `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`. The OQ-02
+deliverable would be a *self-contained* pedagogical proof (S2+ scaffold) using the
+named decomposition, NOT a re-wrapping of the bundled Archive lemma.
+
+If the pedagogical scaffold is judged low-value (or duplicates the Archive's structure
+too closely), this slug can be closed as "covered-by-parent" without further iteration.

--- a/research/problems/sum-of-divisors-oq-02/state.md
+++ b/research/problems/sum-of-divisors-oq-02/state.md
@@ -1,0 +1,52 @@
+# Current State
+
+**Phase**: S1 OBSERVE complete
+**Since**: 2026-05-12
+**Iteration**: 1
+**Agent**: researcher-12
+
+## Current Focus
+
+Survey of Euler's converse direction for even perfect numbers, decomposed into
+7 algebraic steps (σ-coprime split → power identity → perfect equation →
+divisibility extraction → coprime cofactor → two-divisor uniqueness → conclusion).
+
+S1 deliverable is markdown-only:
+- `problem.md` — formal statement, classification, relationship to parent slug.
+- `knowledge.md` — Mathlib API inventory + 7-step proof skeleton.
+- `state.md` — this file.
+- `src/data/research/problems/sum-of-divisors-oq-02.json` — registry entry.
+
+## Active Approach
+
+Pedagogical self-contained refactor of `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
+into named intermediate lemmas. Parent slug already wraps the bundled Archive proof
+via `PerfectNumbers.euler_even_perfect`; OQ-02 exposes the algebraic skeleton.
+
+## Blockers
+
+None for S1. For S2 ACT:
+- Decide: separate file `SumOfDivisorsOQ02.lean` vs. extension of `PerfectNumbers.lean`.
+  Default: separate file to preserve the existing bundled wrapper.
+- Risk: scaffold may end up structurally identical to the Archive proof, limiting
+  gallery value to documentation/naming. Address via honest write-up if so.
+
+## Next Action
+
+**S2 SCAFFOLD** — Create `proofs/Proofs/SumOfDivisorsOQ02.lean`:
+- Imports: `Archive.Wiedijk100Theorems.PerfectNumbers`, `Mathlib.Tactic`.
+- Namespace `SumOfDivisorsOQ02`.
+- One named lemma per Step 1–6 (each with `sorry`), with docstrings citing the
+  Mathlib API in `knowledge.md`.
+- Top-level theorem `euler_converse_self_contained` chaining the steps.
+- No proofs in S2 (skeleton only — `sorry` everywhere except trivial rewrites).
+- Build verification via `docker-build.sh Proofs.SumOfDivisorsOQ02` (build-pending acceptable).
+
+S3+ would discharge sorries one step at a time (Step 2 first — direct from Archive lemma;
+Steps 1, 5 next via direct algebra; Steps 4, 6 last as they involve coprimality + uniqueness).
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (self-contained pedagogical refactor)

--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -1,0 +1,89 @@
+{
+  "slug": "sum-of-divisors-oq-02",
+  "title": "Euler's Converse: Every Even Perfect Number is Mersenne-Form",
+  "phase": "OBSERVE",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall n \\in \\mathbb{N},\\; \\text{Even}(n) \\wedge n.\\text{Perfect} \\Longrightarrow \\exists k \\in \\mathbb{N},\\; \\text{Prime}(2^{k+1} - 1) \\wedge n = 2^k \\cdot (2^{k+1} - 1).",
+    "plain": "Euler (1747): every even perfect number n equals 2^k(2^(k+1)-1) where 2^(k+1)-1 is a Mersenne prime. The OQ-02 framing exposes the algebraic skeleton (sigma-multiplicativity + prime-power structure) as named intermediate lemmas rather than invoking the Mathlib Archive's bundled proof as a black box.",
+    "whyMatters": [
+      "Pedagogical exposition: makes the algebraic decomposition (sigma-coprime split, divisibility extraction, two-divisor uniqueness) transparent.",
+      "Reusable sub-lemmas: sigma(2^k)*sigma(m) = 2^(k+1)*m and M_{k+1} | m appear elsewhere in divisibility arguments.",
+      "Open-problem stepping stone: the same algebraic skeleton underlies all known constraints on odd perfect numbers."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (Mathlib Archive, bundled)",
+      "PerfectNumbers.euler_even_perfect (gallery wrapper of bundled proof)",
+      "Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = M_{k+1})"
+    ],
+    "open": [
+      "Self-contained pedagogical decomposition into 6 named steps with docstrings"
+    ],
+    "goal": "Produce Proofs/SumOfDivisorsOQ02.lean with named intermediate lemmas exposing the Euler-converse algebra, build-verified against pinned Mathlib."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12",
+    "iteration": 1,
+    "focus": "S1 OBSERVE — survey + 7-step proof skeleton documented; no Lean changes yet.",
+    "activeApproach": "Pedagogical self-contained refactor of Mathlib Archive bundled proof into named intermediate lemmas.",
+    "blockers": [],
+    "nextAction": "S2 SCAFFOLD — create proofs/Proofs/SumOfDivisorsOQ02.lean with 6 named sorry-stubbed lemmas + top-level theorem.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete. Parent slug sum-of-divisors marked COMPLETED via PerfectNumbers.lean (wraps Mathlib Archive). OQ-02 targets pedagogical decomposition.",
+    "builtItems": [],
+    "insights": [
+      "The Euler converse decomposes cleanly into 6 algebraic steps: (1) sigma-coprime split for n = 2^k*m, (2) sigma(2^k) = M_{k+1}, (3) perfect equation gives M_{k+1}*sigma(m) = 2^(k+1)*m, (4) M_{k+1} odd ⇒ M_{k+1} | m, (5) sigma(m) = m + c where c = m/M_{k+1}, (6) sigma(m) = m + c with c | m forces c = 1 and m prime.",
+      "All Mathlib API needed is available (Coprime, IsMultiplicative.sigma_one, mersenne, Archive.sigma_two_pow_eq_mersenne_succ)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "S2: scaffold Proofs/SumOfDivisorsOQ02.lean with named sub-lemmas",
+      "S3+: discharge sorries one step at a time (Step 2 first, easiest)",
+      "Honest assessment after S2: if scaffold is structurally identical to Archive proof, close as documentation-only after one polish iteration."
+    ],
+    "markdown": "# Knowledge Base: Euler's Converse for Even Perfect Numbers\n\n## Status: S1 OBSERVE complete (survey + plan, no Lean changes yet)\n\nSee research/problems/sum-of-divisors-oq-02/knowledge.md for the full 7-step proof skeleton and Mathlib API inventory.\n\n## Key Mathlib lemmas\n- ArithmeticFunction.IsMultiplicative.sigma_one (sigma is multiplicative)\n- Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = mersenne (k+1))\n- Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (bundled Euler direction)\n\n## Proof skeleton (Euler ⇒)\nLet n = 2^k * m even and perfect, m odd, k ≥ 1.\n1. sigma(2^k * m) = sigma(2^k) * sigma(m) — multiplicativity on coprimes\n2. sigma(2^k) = M_{k+1} = 2^(k+1) - 1 — Archive lemma\n3. M_{k+1} * sigma(m) = 2^(k+1) * m — perfect equation expanded\n4. M_{k+1} | m — since M_{k+1} odd, coprime to 2^(k+1)\n5. Writing m = M_{k+1} * c: sigma(m) = 2^(k+1) * c = m + c\n6. c | m and sigma(m) = m + c forces c = 1 and m prime (two-divisor uniqueness)\n7. Conclude n = 2^k * M_{k+1} with M_{k+1} prime. ∎"
+  },
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "perfect-numbers",
+    "arithmetic-functions",
+    "multiplicative",
+    "mersenne-primes"
+  ],
+  "relatedProofs": [
+    "perfect-numbers",
+    "sum-of-divisors"
+  ],
+  "references": {
+    "papers": [
+      "Euler, L. (1747/1849). De numeris amicabilibus. Opera Postuma 1, 85-100.",
+      "Hardy, G.H. & Wright, E.M. (1979). An Introduction to the Theory of Numbers, §16.8."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Archive/Wiedijk100Theorems/PerfectNumbers.html",
+      "https://en.wikipedia.org/wiki/Euclid%E2%80%93Euler_theorem"
+    ],
+    "mathlib": [
+      "Archive.Wiedijk100Theorems.PerfectNumbers",
+      "Mathlib.NumberTheory.ArithmeticFunction",
+      "Mathlib.NumberTheory.Padics.Mersenne"
+    ]
+  },
+  "started": "2026-05-12T17:55:00.000Z",
+  "lastUpdate": "2026-05-12T17:55:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": []
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for fresh seeker slug `sum-of-divisors-oq-02` (Euler's converse: every even perfect number is Mersenne-form). Markdown/JSON only, no Lean changes.

- Documents 7-step algebraic skeleton (σ-multiplicativity + prime-power + divisibility extraction + two-divisor uniqueness).
- Cross-references parent slug `sum-of-divisors` (COMPLETED via `PerfectNumbers.lean` wrapping Mathlib Archive `eq_two_pow_mul_prime_mersenne_of_even_perfect`).
- Plans S2 SCAFFOLD: separate `Proofs/SumOfDivisorsOQ02.lean` with 6 named sorry-stubbed lemmas exposing the algebra as named intermediate steps.

## Proof skeleton (Euler ⇒)

Let `n = 2^k · m` be even perfect with `m` odd, `k ≥ 1`.

1. `σ(2^k · m) = σ(2^k) · σ(m)` — multiplicativity on coprimes (`IsMultiplicative.sigma_one`).
2. `σ(2^k) = M_{k+1} = 2^(k+1) - 1` — Archive `sigma_two_pow_eq_mersenne_succ`.
3. `M_{k+1} · σ(m) = 2^(k+1) · m` — perfect equation `σ(n) = 2n` expanded.
4. `M_{k+1} | m` — `M_{k+1}` odd, coprime to `2^(k+1)`.
5. Writing `m = M_{k+1} · c`: `σ(m) = 2^(k+1) · c = m + c`.
6. `σ(m) = m + c` with `c | m` forces `c = 1` and `m` prime (two-divisor uniqueness).
7. Conclude `n = 2^k · M_{k+1}` with `M_{k+1}` prime. ∎

## Honesty caveat

If the S2 scaffold turns out structurally identical to the Archive's internal proof, contribution reduces to documentation/naming. State.md flags this as a "close-after-one-polish-iteration" outcome rather than multi-session research.

## Test plan

- [x] JSON parses (`python3 -c "import json; json.load(open(...))"`)
- [x] Diff scope verified vs origin/main (4 files, +339 lines, no Lean changes)
- [x] Mid-write competitor probe: no open PRs on slug (only seeker init #18166)
- [ ] Next session: S2 SCAFFOLD with `proofs/Proofs/SumOfDivisorsOQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)