### PR TITLE
research(sqrt2-minpoly-oq-03): S1 OBSERVE — class number 1 for Q(√2) via Minkowski's bound (doc-only)

### DIFF
--- a/research/problems/sqrt2-minpoly-oq-03/knowledge.md
+++ b/research/problems/sqrt2-minpoly-oq-03/knowledge.md
@@ -1,0 +1,235 @@
+# sqrt2-minpoly-oq-03 — Knowledge
+
+## Iteration 1 (researcher-10, 2026-05-12) — S1 OBSERVE
+
+**Outcome**: scaffold only. No Lean changes. Surveyed the Mathlib
+surface for `NumberField`, `RingOfIntegers`, `classNumber`,
+`minkowskiBound`, and `Zsqrtd` infrastructure; identified the
+parent / sibling re-use opportunities; laid out the S2-S4 plan to
+prove $h_{\mathbb{Q}(\sqrt 2)} = 1$ via Minkowski's bound; noted
+the alternative Euclidean-domain route as an S5 corollary.
+
+### Parent / sibling infrastructure that the OQ-03 work can re-use
+
+From `Proofs/Sqrt2Minpoly.lean` (the parent, 140 lines, 0 axioms, 0
+sorries, status: verified):
+
+- `irred_X_sq_sub_two_int` / `irred_X_sq_sub_two_rat` — irreducibility
+  of $X^2 - 2$ over $\mathbb{Z}$ (Eisenstein) and over $\mathbb{Q}$
+  (Gauss's lemma). This is the **input** to the `Polynomial.SplittingField`
+  / `AdjoinRoot` construction of $\mathbb{Q}(\sqrt 2)$ as a field.
+- The proof's use of `minpoly.eq_of_irreducible_of_monic` and
+  `aeval (√2) (X^2 - 2) = 0` — establishes that $\sqrt 2 \in \mathbb{R}$
+  is integral over $\mathbb{Q}$ with minimal polynomial $X^2 - 2$. This
+  gives us a *concrete* witness $\sqrt 2 \in \mathbb{R}$ when needed
+  (the abstract number field $K = \mathbb{Q}(\sqrt 2)$ admits an
+  embedding $K \hookrightarrow \mathbb{R}$ via $\sqrt 2 \mapsto
+  \sqrt 2$).
+
+From `Proofs/Sqrt2MinpolyOQ01.lean` and `Proofs/Sqrt2MinpolyOQ02.lean`
+(siblings):
+
+- Pattern for parameterizing minimal polynomials by $n$ (squarefree
+  generalization). Not directly used here but provides the local idiom
+  for naming and namespacing.
+
+From `Proofs/Sqrt2Irrational.lean` and the broader `Sqrt2*` cluster:
+
+- The local convention of using `Real.sqrt 2` as the canonical
+  embedded representative of $\sqrt 2$, together with `(Real.sqrt 2)^2 = 2`
+  facts and the `Real.sqrt_two_pos` / `Real.sqrt_two_ne_zero` lemmas
+  in Mathlib.
+
+### Mathlib surface (expected at pin v4.26.0; **VERIFY in S2**)
+
+- `Mathlib.NumberTheory.NumberField.Basic` — `NumberField K` typeclass,
+  asserting `Field K`, `Algebra ℚ K`, and `FiniteDimensional ℚ K`.
+- `Mathlib.NumberTheory.NumberField.RingOfIntegers` —
+  `NumberField.RingOfIntegers K = integralClosure ℤ K` and the algebra
+  structure on it.
+- `Mathlib.NumberTheory.NumberField.ClassNumber` —
+  `NumberField.classNumber K : ℕ` defined as
+  `Fintype.card (ClassGroup (NumberField.RingOfIntegers K))`.
+  `NumberField.classGroup_finite` ensures finiteness.
+- `Mathlib.NumberTheory.NumberField.Discriminant` — the discriminant
+  of the number field (or of its ring of integers as a $\mathbb{Z}$-module
+  basis). May expose
+  `NumberField.discr K = Matrix.det (traceMatrix ...)` or similar.
+  **VERIFY exact API surface.**
+- `Mathlib.NumberTheory.NumberField.CanonicalEmbedding` /
+  `Mathlib.NumberTheory.NumberField.Minkowski` (exact module name to
+  be confirmed) — the canonical embedding
+  $K \hookrightarrow \mathbb{R}^{r_1} \times \mathbb{C}^{r_2}$, the
+  covolume of $\mathcal{O}_K$, and Minkowski's theorem applied to
+  number fields to extract small-norm integral elements. The form of
+  the bound is typically expressed via
+  `NumberField.minkowskiBound K` and
+  `NumberField.exists_ne_zero_lt_minkowskiBound` (or equivalent
+  classGroup-quotient form).
+- `Mathlib.NumberTheory.Zsqrtd.Basic` —
+  `Zsqrtd d : Type` for `d : ℤ` (the ring $\mathbb{Z}[\sqrt d]$),
+  with `norm`, addition, multiplication, and a `CommRing` instance.
+  For $d = 2$, this is $\mathbb{Z}[\sqrt 2]$.
+- `Mathlib.NumberTheory.Zsqrtd.GaussianInt` — the imaginary-quadratic
+  case (`Zsqrtd (-1)`) with **proved** Euclidean / PID structure.
+  Provides the *template* for an analogous proof at $d = 2$ if Mathlib
+  has not already done it.
+- `Mathlib.RingTheory.PrincipalIdealDomain`,
+  `Mathlib.RingTheory.EuclideanDomain` — generic UFD / PID / ED API.
+
+### Tractability triage (Lean what-is-feasible)
+
+| Target | Feasible? | Notes |
+|---|---|---|
+| Construct `Q_sqrt2 : Type` with `NumberField Q_sqrt2` | ✅ | `Polynomial.SplittingField (X^2 - 2 : ℚ[X])` is direct; `NumberField` instance follows from irreducibility + finite-dim. ~30 lines. |
+| Compute `discr Q_sqrt2 = 8` | ⚠ | Mathlib has discriminant API but exact name / shape at v4.26.0 needs verification. Likely 1-line via `NumberField.discr_quadratic_eq` if it exists. Fallback: explicit trace-matrix computation, ~40 lines. |
+| Compute `minkowskiBound Q_sqrt2 = √2` | ⚠ | Mathlib's `minkowskiBound` is a `Real.toNNReal` of an algebraic combination. Computing the explicit value requires unfolding $r_1 = 2, r_2 = 0, n = 2, |d_K| = 8$. Possibly $≤ 50$ lines. |
+| Apply Minkowski lemma to conclude `classNumber = 1` | ✅ | Standard reduction "every ideal class has representative of norm $\le M_K < 2$, but norm 1 forces unit ideal". Mathlib has `Ideal.absNorm_eq_one_iff_eq_top` or analogous. ~40 lines. |
+| Identify `RingOfIntegers Q_sqrt2 ≃+* Zsqrtd 2` | ⚠ | Cleanest by exhibiting a ring iso sending $\sqrt 2 \mapsto $ canonical generator. ~60 lines. Optional for the main result but useful for the gallery presentation. |
+| `EuclideanDomain (Zsqrtd 2)` (alternative S5 route) | ✅ | Define `EuclideanDomain.r := fun a b => Int.natAbs (Zsqrtd.norm a) < Int.natAbs (Zsqrtd.norm b)`. Verify division-with-remainder by geometric argument $\sup\{|a^2 - 2 b^2| : a, b \in [-1/2, 1/2]\} = 1/2 < 1$. Mathlib's `Zsqrtd.gaussianInt` Euclidean proof provides a complete template. ~120 lines. |
+
+### Why the seeker's tractability=5 (not 7) is the right estimate
+
+The mathematics is **textbook ANT** (Marcus Chapter 5 explicitly
+computes this exact example), but the Lean instantiation is bottle-
+necked by Mathlib's *thin* surface for **concrete** number fields at
+v4.26.0:
+
+- Most class-number computations in Mathlib are stated abstractly
+  (`classNumber K = ...`) without specific-field instantiations.
+- The discriminant of $\mathbb{Q}(\sqrt d)$ is in Mathlib in some form,
+  but the exact lemma name (e.g.
+  `NumberField.disc_sqrt_d_eq_four_d` for $d \not\equiv 1 \pmod 4$)
+  may not exist; fallback computation through `Matrix.det (traceMatrix)`
+  is doable but adds ~40 lines.
+- The Minkowski-bound computation requires unfolding several layers
+  ($r_1$, $r_2$, $n!/n^n$, $\sqrt{|d_K|}$), each manageable but
+  cumulative.
+
+Honest expectation: the full OQ-03 deliverable is **~250-400 lines
+of Lean across 3-4 sessions** (S2 surface verification + S3
+discriminant + S4 Minkowski + S5 optional EuclideanDomain), with 0
+sorries on the **main theorem** $\mathrm{classNumber}\, K = 1$ and
+possibly 1-2 expedient sorries on intermediate discriminant or
+Minkowski-bound *computations* (with the strategy documented for
+follow-up).
+
+### Honest assessment of contribution boundary
+
+The class-number-1 result for $\mathbb{Q}(\sqrt 2)$ is **not novel**;
+Marcus, Neukirch, and every introductory ANT textbook covers it. The
+Lean contribution is:
+
+1. **First concrete Mathlib-based class-number-1 proof for a real
+   quadratic field in the gallery.** Mathlib has the abstract
+   machinery but no specific-field instantiation; this would be a
+   pattern for future $\mathbb{Q}(\sqrt 3)$, $\mathbb{Q}(\sqrt 5)$,
+   $\mathbb{Q}(\sqrt 6)$, $\mathbb{Q}(\sqrt 7)$, ... cases (all
+   class-number-1 by Minkowski for small enough $d$).
+2. **Bridge between Mathlib's `Zsqrtd 2` (concrete) and
+   `NumberField.RingOfIntegers (ℚ(√2))` (abstract).** Mathlib has
+   both, but the iso is not (as of v4.26.0) packaged; building it
+   here makes the bridge re-usable.
+3. **Template for Gauss's class-number-1 problem.** The general
+   problem "which real quadratic fields have class number 1?" is a
+   long-standing open question. Lean instantiation of the small cases
+   is a small but concrete step toward systematic gallery coverage of
+   class-number computations.
+
+### Mathlib gaps anticipated
+
+- **`NumberField.disc_quadratic_field` may not be at v4.26.0.** If the
+  discriminant of $\mathbb{Q}(\sqrt 2)$ is not directly available, the
+  S3 proof will need to compute it via the trace matrix of the basis
+  $\{1, \sqrt 2\}$:
+  $\mathrm{disc} = \det \begin{pmatrix} 2 & 0 \\ 0 & 4 \end{pmatrix} = 8$.
+  Mathlib has `Algebra.discr` and `Algebra.traceForm`, so this is
+  achievable in ~40 lines.
+- **Class-number-via-Minkowski may not have a one-liner at v4.26.0.**
+  The reduction "$M_K < 2$ implies $h_K = 1$" through the
+  existence-of-small-norm-element lemma is a standard ANT computation
+  but may need to be unfolded explicitly. ~50 lines.
+- **`Zsqrtd 2` as `EuclideanDomain` may not exist in Mathlib at
+  v4.26.0.** The Gaussian integer case is there; the
+  $\mathbb{Z}[\sqrt 2]$ case may need to be replicated. ~120 lines
+  if needed (deferred to S5).
+
+### Next steps (S2 ORIENT)
+
+1. Create `proofs/Proofs/Sqrt2MinpolyOQ03.lean`. Imports:
+   `Sqrt2Minpoly`, `Mathlib.NumberTheory.NumberField.Basic`,
+   `Mathlib.NumberTheory.NumberField.ClassNumber`,
+   `Mathlib.NumberTheory.NumberField.Discriminant`,
+   `Mathlib.NumberTheory.NumberField.CanonicalEmbedding`,
+   `Mathlib.NumberTheory.Zsqrtd.Basic`.
+2. Define `Q_sqrt2 : Type` as
+   `Polynomial.SplittingField (X^2 - C 2 : ℚ[X])` (or via `AdjoinRoot`,
+   whichever yields a cleaner `NumberField` instance at the pin).
+3. Verify `NumberField Q_sqrt2` instance is derivable from the
+   parent's irreducibility lemma + finite-dim of the splitting field.
+4. Stub the main theorem
+   `Q_sqrt2_classNumber_eq_one : NumberField.classNumber Q_sqrt2 = 1`
+   with `by sorry`, with the inline proof strategy:
+   * Compute `discr Q_sqrt2 = 8` (S3 deliverable).
+   * Compute `minkowskiBound Q_sqrt2 = √2` (S3 deliverable).
+   * Apply `NumberField.exists_ne_zero_lt_minkowskiBound` to extract
+     a small-norm element from each ideal class (S4 deliverable).
+   * Conclude $h_K = 1$.
+
+Target for S2: ~40 lines, 1 sorry on the main theorem,
+0 sorries on the field construction and `NumberField` instance.
+
+### Sorries / axioms anticipated
+
+- **0 new axioms** for the main result. Every step is a direct
+  application of Mathlib's `NumberField` / Minkowski / `Zsqrtd` API.
+- **1 expedient sorry** in S2 on the main theorem
+  `Q_sqrt2_classNumber_eq_one` (deferred to S3-S4 sub-targets).
+- **Possible 1-2 transitional sorries** in S3 if Mathlib's
+  discriminant API for $\mathbb{Q}(\sqrt 2)$ requires unfolded
+  computation; these would have documented strategies for follow-up.
+
+### Risk register
+
+- **Mathlib `NumberField.classNumber` surface drift.** The
+  `ClassNumber` / `ClassGroup` API has evolved in recent Mathlib
+  versions. Verify at v4.26.0 in S2 ORIENT before committing the
+  proof skeleton. Known related modules: `RingOfIntegers`,
+  `ClassNumber`, `Adeles`, `CanonicalEmbedding`.
+- **Discriminant computation friction.** Mathlib's `NumberField.discr`
+  is sometimes packaged through abstract bases (`PowerBasis`) which
+  add a step. Fallback: explicit trace-matrix computation via
+  `Algebra.discr`.
+- **Minkowski-bound packaging.** Mathlib expresses the bound as a
+  `Real.toNNReal` of an algebraic combination; reading off the
+  concrete value $\sqrt 2$ may require `Real.sqrt_eq_iff_sq_eq`
+  manipulations.
+- **`Zsqrtd 2` Euclidean structure.** Mathlib's Gaussian-integer
+  Euclidean proof is a 200-line file; replicating for $d = 2$ may
+  be similar in size. Deferred to S5 (optional).
+- **Race-safety**: pre-push probe required. As of S1 submission,
+  no open PRs and no remote branches reference this slug. The
+  slug was seeker-added today (2026-05-12) per pool note but with
+  `added_at = null` (likely because it pre-dates the seeker's
+  timestamp-tracking change); we treat the race window as
+  conservative (~24 hours since seeker add).
+
+### Pre-work assessment answers (per researcher methodology)
+
+1. **The Axiom Question**: parent is 0 axioms. The OQ-03 forward
+   direction should be 0 axioms.
+2. **The Value Question**: Yes — class number 1 for $\mathbb{Q}(\sqrt 2)$
+   is a complete formal result about a specific number field's
+   structure, and provides a template for further small real
+   quadratic fields. It is **not** an open question (Marcus 1977
+   Theorem 5.4 corollary), but it is a non-trivial Lean exercise
+   in stitching together `NumberField.classNumber`,
+   `NumberField.minkowskiBound`, and `Zsqrtd 2`.
+3. **The Proof Strategy Question**: Finite (one field, one
+   discriminant, one Minkowski bound, one quotient computation).
+   Standard structural reduction.
+4. **The Build vs Block Question**: Mathlib has all infrastructure
+   pieces (`NumberField`, `RingOfIntegers`, `ClassNumber`,
+   `MinkowskiBound`, `Zsqrtd`). What's missing is the specific-field
+   instantiation, which is ~250-400 lines of plumbing — well within
+   the BUILD budget. Not blocked.

--- a/research/problems/sqrt2-minpoly-oq-03/problem.md
+++ b/research/problems/sqrt2-minpoly-oq-03/problem.md
@@ -1,0 +1,222 @@
+# sqrt2-minpoly-oq-03
+
+## Problem Description
+
+**Class number 1 for $\mathbb{Q}(\sqrt 2)$ via Minkowski's bound.**
+While the parent gallery proof `sqrt2-minpoly` establishes
+$\mathrm{minpoly}_{\mathbb{Q}}(\sqrt 2) = X^2 - 2$ and thus
+$[\mathbb{Q}(\sqrt 2) : \mathbb{Q}] = 2$, it stops short of the
+**algebraic number theory** of $K = \mathbb{Q}(\sqrt 2)$. The natural
+next question is the structure of the ring of integers
+$\mathcal{O}_K = \mathbb{Z}[\sqrt 2]$ as an ideal-theoretic object.
+
+The cleanest such question is: **is $\mathcal{O}_K$ a principal ideal
+domain?** Equivalently, is the ideal class group trivial, i.e. is the
+class number $h_K = 1$?
+
+The answer is yes, by Minkowski's bound. For a real quadratic field
+$K = \mathbb{Q}(\sqrt d)$ with squarefree $d > 0$, the **discriminant**
+is
+$$d_K = \begin{cases} d & d \equiv 1 \pmod 4 \\ 4d & d \equiv 2, 3 \pmod 4 \end{cases}$$
+For $d = 2$, $d_K = 8$. The **Minkowski bound** for a totally real
+field of degree $n$ is
+$$M_K = \frac{n!}{n^n}\, \sqrt{|d_K|}.$$
+For $K = \mathbb{Q}(\sqrt 2)$: $n = 2$, $d_K = 8$, so
+$$M_K = \frac{2!}{2^2}\, \sqrt{8} = \frac{1}{2} \cdot 2\sqrt 2 = \sqrt 2 \approx 1.414.$$
+By the **Minkowski theorem** (every ideal class contains an integral
+representative of norm $\le M_K$), every ideal class has a
+representative of norm $\le 1$ (since norms are positive integers and
+$M_K < 2$). The only such representative is the unit ideal $(1)$.
+Hence $h_K = 1$ and $\mathbb{Z}[\sqrt 2]$ is a PID.
+
+## Formal target
+
+```
+theorem Q_sqrt2_classNumber_eq_one :
+    NumberField.classNumber (Q_sqrt2) = 1
+```
+
+where `Q_sqrt2 : Type*` is constructed as a degree-2 number field via
+Mathlib's adjoin machinery (e.g.
+`AdjoinRoot (X^2 - 2 : Polynomial ℚ)` or
+`Polynomial.SplittingField (X^2 - 2)`), with the canonical instances
+`[Field Q_sqrt2] [Algebra ℚ Q_sqrt2] [NumberField Q_sqrt2]`.
+
+Two equivalent re-statements (both gallery-worthy as corollaries):
+
+```
+theorem Q_sqrt2_RingOfIntegers_isPID :
+    IsPrincipalIdealRing (NumberField.RingOfIntegers Q_sqrt2)
+```
+
+```
+theorem Q_sqrt2_RingOfIntegers_isEuclidean :
+    EuclideanDomain (NumberField.RingOfIntegers Q_sqrt2)
+```
+
+(The Euclidean structure is a strictly stronger statement; it is also
+known for $\mathbb{Z}[\sqrt 2]$ since the absolute value of the norm
+form $|a^2 - 2b^2|$ defines a Euclidean function. The class-number-1
+result follows from either the Minkowski path *or* the Euclidean
+path.)
+
+## Metadata
+
+- **Category**: extension (algebraic-number-theory follow-up to the
+  parent's minimal-polynomial-of-$\sqrt 2$ result)
+- **Source proof**: `sqrt2-minpoly` (`Proofs/Sqrt2Minpoly.lean`, 140
+  lines, 0 axioms, 0 sorries, status: verified)
+- **Tier**: B
+- **Selected by**: seeker, 2026-05-12 (note in pool:
+  "h_K = 1 for K=Q(sqrt2); Minkowski bound ~1.41")
+- **Significance**: 6 — class number 1 for $\mathbb{Q}(\sqrt 2)$ is a
+  textbook ANT result (Marcus, Neukirch, Stewart-Tall); it provides a
+  template for class-number-1 gallery proofs of other small real
+  quadratic fields (the class-number-1 real-quadratic-field problem is
+  open in general — a Gauss conjecture). The Lean contribution is
+  packaging Mathlib's `NumberField`, `RingOfIntegers`, Minkowski-bound,
+  and class-group infrastructure into a concrete, gallery-checkable
+  result for the smallest non-trivial real quadratic field.
+- **Tractability**: 5 — Mathlib has all the pieces (`NumberField.classNumber`,
+  `NumberField.minkowskiBound`, `Zsqrtd 2`) but instantiating them for
+  a concrete field requires discriminant computation, the
+  ring-of-integers isomorphism $\mathcal{O}_{\mathbb{Q}(\sqrt 2)} \cong
+  \mathbb{Z}[\sqrt 2]$, and the canonical-embedding setup. Risk: the
+  Mathlib API for class-number-of-a-specific-field is thin at
+  v4.26.0; the proof may require ~200-300 lines of plumbing.
+
+## Related gallery work
+
+- **Parent**: `sqrt2-minpoly` — proves $\mathrm{minpoly}_{\mathbb{Q}}
+  (\sqrt 2) = X^2 - 2$ and the degree-2 extension structure.
+- **Sibling OQ-01**: `sqrt2-minpoly-oq-01` — Eisenstein generalization
+  to $\mathrm{minpoly}_{\mathbb{Q}}(\sqrt n) = X^2 - n$ for non-perfect-
+  square $n$.
+- **Sibling OQ-02**: `sqrt2-minpoly-oq-02` — minimal polynomial of
+  $m^{1/n}$ via Eisenstein.
+- **Cross-reference**: `gaussian-integers` /
+  `gaussian-integers-OQ-*` (Mathlib's
+  `Mathlib.NumberTheory.Zsqrtd.GaussianInt`) — the prototype for
+  $\mathbb{Z}[i]$ as a Euclidean ring; our OQ-03 mirrors the real
+  quadratic case.
+- **Cross-reference**: `zsqrtd-neg-two` /
+  `Proofs/Zsqrtd*` — Mathlib's `Zsqrtd d` machinery, which we'll
+  re-use to identify $\mathcal{O}_{\mathbb{Q}(\sqrt 2)}$ with
+  `Zsqrtd 2`.
+
+## Tractability triage (what's feasible in Lean)
+
+**Feasible (S2-S3 work)**:
+
+- **Construct $\mathbb{Q}(\sqrt 2)$ as a `NumberField`.** Use
+  `Polynomial.SplittingField (X^2 - 2 : ℚ[X])`, OR
+  `AdjoinRoot (X^2 - 2 : ℚ[X])`, OR build it from scratch via
+  `IntermediateField ℚ ℝ` containing `Real.sqrt 2`. Mathlib supplies
+  the `NumberField` typeclass instance for these constructions
+  whenever the polynomial is irreducible over ℚ (which `Sqrt2Minpoly`
+  already proves).
+- **Identify the ring of integers with $\mathbb{Z}[\sqrt 2] = $
+  `Zsqrtd 2`.** Mathlib has `Zsqrtd` for any squarefree integer;
+  identifying it with `NumberField.RingOfIntegers` of the corresponding
+  field is direct algebraic manipulation (every element of
+  $\mathbb{Z}[\sqrt 2]$ is integral over $\mathbb{Z}$ — annihilated by
+  $X^2 - 2aX + (a^2 - 2b^2)$ — and the reverse inclusion follows from
+  $d_K = 8 \not\equiv 1 \pmod 4$).
+
+**Feasible but heavier (S4 work)**:
+
+- **Class number 1 via Minkowski's bound.** Apply
+  `NumberField.exists_ne_zero_lt_minkowskiBound` (or
+  `NumberField.classGroup.mk_eq_one_of_norm_lt_minkowskiBound`,
+  exact name depends on Mathlib pin) to reduce to "every integral
+  ideal of norm $\le 1$ is the unit ideal". The reduction from
+  "$M_K \approx 1.41 < 2$" to "every class has a representative of
+  norm 1" requires combining (a) the Minkowski lemma, (b) the
+  positivity of norms of non-zero ideals, (c) the standard fact
+  $\mathrm{Norm}(I) = 1 \iff I = (1)$.
+- **Computation $M_K = \sqrt 2$.** Mathlib's `NumberField.minkowskiBound`
+  takes the form $(2/\pi)^{r_2} \cdot n!/n^n \cdot \sqrt{|d_K|}$;
+  for the totally real case ($r_2 = 0$), this simplifies. Need to
+  compute $d_K = 8$ explicitly via Mathlib's discriminant API.
+
+**Feasible (alternative S4 path)**:
+
+- **Euclidean domain structure on $\mathbb{Z}[\sqrt 2]$.** Define the
+  norm-form $N(a + b\sqrt 2) = a^2 - 2b^2$ and the absolute-value
+  Euclidean function $|N|$. Verify the Euclidean property by checking
+  that for every $\alpha \in \mathbb{Q}(\sqrt 2)$, there exists
+  $\beta \in \mathbb{Z}[\sqrt 2]$ with $|N(\alpha - \beta)| < 1$.
+  Geometric argument: the fundamental domain
+  $[-\tfrac12, \tfrac12]^2$ for $\mathbb{Z}[\sqrt 2]$ in
+  $\mathbb{R}^2$ has $\sup |a^2 - 2b^2| = \max(\tfrac14, \tfrac12)
+  = \tfrac12 < 1$. Mathlib's `Zsqrtd` may already have helper lemmas
+  (analogous to the Gaussian integer case).
+
+**Hard / out of scope**:
+
+- **General class-number-1 for $\mathbb{Q}(\sqrt d)$ for arbitrary $d$.**
+  This is open for real quadratic fields (Gauss's class-number-1
+  conjecture: infinitely many real quadratic fields have class number
+  one — proved heuristically, not unconditionally). Our OQ-03 is the
+  $d = 2$ case only.
+
+## Suggested first steps (S2+ ACT phase)
+
+1. **S2 ORIENT — Verify Mathlib surface.** Confirm at the pinned
+   v4.26.0 rev: (a) `NumberField.classNumber` and
+   `NumberField.minkowskiBound` exist with the expected types;
+   (b) `Zsqrtd 2`'s ring instance and norm function are available;
+   (c) there is a clean construction
+   `Q_sqrt2 := Polynomial.SplittingField (X^2 - C 2 : ℚ[X])` or
+   equivalent that yields `NumberField Q_sqrt2`. Estimated 0 sorries,
+   ~40 lines, possibly all in a `theorem ... := by sorry` skeleton.
+2. **S3 ACT — Discriminant + Minkowski bound.** Compute $d_K = 8$ and
+   $M_K = \sqrt 2$ explicitly. ~80 lines, 0 sorries expected if
+   Mathlib's discriminant API for $\mathbb{Q}(\sqrt d)$ is direct;
+   otherwise 1-2 sorries on the discriminant value.
+3. **S4 ACT — Class number 1.** Apply Minkowski's lemma to reduce to
+   norm $\le 1$ ideals, then conclude $h_K = 1$. ~80 lines, 0 sorries
+   expected.
+4. **S5 (optional) — Ring of integers identification + Euclidean
+   structure.** Prove $\mathcal{O}_K \simeq \mathrm{Zsqrtd}\, 2$ and
+   verify $\mathbb{Z}[\sqrt 2]$ is a Euclidean domain (independent
+   route to PID).
+
+A finished OQ-03 deliverable can be just S2-S4 (Minkowski-bound
+route to $h_K = 1$); S5 is a strictly stronger optional corollary.
+
+## References
+
+- Marcus, D. A. (1977). *Number Fields*. Springer Universitext.
+  Chapter 5 (Minkowski's theorem and the finiteness of the class
+  group); Example after Theorem 5.4 explicitly computes
+  $\mathbb{Q}(\sqrt 2)$ as a class-number-1 field.
+- Neukirch, J. (1999). *Algebraic Number Theory*. Springer Grundlehren
+  322. Section I.5–I.6 (Minkowski theorem, class number).
+- Stewart, I.; Tall, D. (2015). *Algebraic Number Theory and Fermat's
+  Last Theorem*, 4th ed. CRC Press. Section 9.3 (real quadratic
+  fields, Minkowski bound).
+- Hardy, G. H.; Wright, E. M. (2008). *An Introduction to the Theory
+  of Numbers*, 6th ed. Oxford. §14 (algebraic numbers and integers;
+  $\mathbb{Z}[\sqrt 2]$ as Euclidean).
+- Mathlib `Mathlib.NumberTheory.NumberField.ClassNumber` — the
+  definition of `classNumber` as `Fintype.card (ClassGroup ·)`.
+- Mathlib `Mathlib.NumberTheory.NumberField.Discriminant` — the
+  discriminant of a number field.
+- Mathlib `Mathlib.NumberTheory.NumberField.CanonicalEmbedding` /
+  `Mathlib.NumberTheory.NumberField.Minkowski` (exact module name
+  to be verified) — the Minkowski bound and the existence of
+  small-norm integral elements.
+- Mathlib `Mathlib.NumberTheory.Zsqrtd.Basic` — `Zsqrtd d` and norm
+  form.
+
+## Provenance
+
+- Selected by seeker, 2026-05-12 (pool note: "h_K = 1 for
+  K=Q(sqrt2); Minkowski bound ~1.41")
+- Parent gallery: `src/data/proofs/sqrt2-minpoly/`
+- Parent Lean: `proofs/Proofs/Sqrt2Minpoly.lean`
+- Sibling OQ-01: `proofs/Proofs/Sqrt2MinpolyOQ01.lean`
+  ($\mathrm{minpoly}_{\mathbb{Q}}(\sqrt n) = X^2 - n$ for non-perfect-square $n$)
+- Sibling OQ-02: `proofs/Proofs/Sqrt2MinpolyOQ02.lean`
+  ($\mathrm{minpoly}_{\mathbb{Q}}(m^{1/n}) = X^n - m$ via Eisenstein)

--- a/research/problems/sqrt2-minpoly-oq-03/state.md
+++ b/research/problems/sqrt2-minpoly-oq-03/state.md
@@ -1,0 +1,159 @@
+# Current State
+
+**Phase**: OBSERVE (S1 scaffold complete; no Lean changes yet)
+**Since**: 2026-05-12T17:30:00Z
+**Last Updated**: 2026-05-12 (Iteration 1, researcher-10)
+**Iteration**: 1
+
+## Iteration 1 (researcher-10, 2026-05-12) — S1 OBSERVE
+
+**Outcome**: scaffold — created `problem.md`, `knowledge.md`,
+`state.md`, and `src/data/research/problems/sqrt2-minpoly-oq-03.json`.
+No Lean changes.
+
+### What I added
+
+Doc-only scaffolding for a fresh tier-B slug. The deliverable is:
+
+- A precise framing of "class number 1 for $\mathbb{Q}(\sqrt 2)$ via
+  Minkowski's bound" as a follow-up to the parent's minimal-polynomial
+  result. The formal target is
+  `NumberField.classNumber (Q_sqrt2) = 1`, with two strictly stronger
+  optional corollaries: `IsPrincipalIdealRing` and `EuclideanDomain`
+  on the ring of integers.
+- A tractability triage distinguishing the **Minkowski-bound route**
+  (S2-S4: define Q(√2) as a number field, compute discriminant 8,
+  compute Minkowski bound √2, conclude h_K = 1) from the **Euclidean-
+  domain route** (S5 optional: $|N(a + b\sqrt 2)| = |a^2 - 2b^2|$
+  with division-with-remainder verified geometrically).
+- A survey of the Mathlib surface (`NumberField.classNumber`,
+  `NumberField.minkowskiBound`, `NumberField.RingOfIntegers`,
+  `NumberField.discr`, `Zsqrtd 2`) and the parent / sibling re-use
+  opportunities (parent provides irreducibility of $X^2 - 2$ over $\mathbb{Q}$;
+  the Gaussian integer `Mathlib.NumberTheory.Zsqrtd.GaussianInt`
+  provides a Euclidean-domain template).
+- A concrete S2 plan: build
+  `proofs/Proofs/Sqrt2MinpolyOQ03.lean`, construct
+  $\mathbb{Q}(\sqrt 2)$ via
+  `Polynomial.SplittingField (X^2 - C 2 : ℚ[X])`, verify the
+  `NumberField` instance, and stub the main theorem
+  `Q_sqrt2_classNumber_eq_one` with the inline strategy
+  (discriminant 8 → Minkowski bound √2 → h_K = 1).
+
+### Why not S2 in this session
+
+S2 ORIENT requires verifying Mathlib's `NumberField.classNumber`,
+`NumberField.discr`, and `NumberField.minkowskiBound` API at the
+pinned v4.26.0 rev — particularly the exact module path
+(`Mathlib.NumberTheory.NumberField.Minkowski` vs
+`Mathlib.NumberTheory.NumberField.CanonicalEmbedding`) and the form
+of the bound (a `Real.toNNReal` or a plain `ℝ`). The recursive
+`proofs/.lake` self-symlink in this worktree (per
+`feedback_researcher_lake_symlink_broken.md`) prevents direct
+Mathlib search; that lookup is best done in S2 ORIENT where the
+build can verify the imports compile.
+
+Additionally, the OQ-03 deliverable has a *Minkowski-route* /
+*Euclidean-route* split that benefits from being made explicit in
+the S2 plan — the Minkowski route is the canonical proof in Marcus
+Chapter 5, while the Euclidean route is the canonical proof in
+Stewart-Tall and Hardy-Wright; both are gallery-worthy, but the
+Minkowski route is the more general (it scales to other small
+quadratic fields).
+
+### Files added (S1)
+
+- `research/problems/sqrt2-minpoly-oq-03/problem.md` — problem
+  description with tractability triage, references (Marcus,
+  Neukirch, Stewart-Tall, Hardy-Wright), and parent / sibling
+  linkage
+- `research/problems/sqrt2-minpoly-oq-03/knowledge.md` — Mathlib
+  surface inventory, feasibility table, S2 plan, risk register
+- `research/problems/sqrt2-minpoly-oq-03/state.md` — this file
+- `src/data/research/problems/sqrt2-minpoly-oq-03.json` —
+  phase OBSERVE, iter 1, references, knowledge surface
+
+### Next action (S2 ORIENT)
+
+Create `proofs/Proofs/Sqrt2MinpolyOQ03.lean` with:
+
+1. Imports: parent (`Proofs.Sqrt2Minpoly` for irreducibility) +
+   `Mathlib.NumberTheory.NumberField.Basic` +
+   `Mathlib.NumberTheory.NumberField.ClassNumber` +
+   `Mathlib.NumberTheory.NumberField.Discriminant` +
+   `Mathlib.NumberTheory.NumberField.CanonicalEmbedding` (verify
+   exact module name for Minkowski-bound API at v4.26.0) +
+   `Mathlib.NumberTheory.Zsqrtd.Basic`.
+2. `def Q_sqrt2 : Type := Polynomial.SplittingField (X^2 - C 2 : ℚ[X])`
+   (or via `AdjoinRoot` if the splitting-field instance derivation
+   for `NumberField Q_sqrt2` is friction-heavy at the pin).
+3. `instance : Field Q_sqrt2`, `instance : Algebra ℚ Q_sqrt2`,
+   `instance : NumberField Q_sqrt2` — derive from Mathlib's
+   `SplittingField` instances + the parent's
+   `irred_X_sq_sub_two_rat`.
+4. `theorem Q_sqrt2_classNumber_eq_one :
+        NumberField.classNumber Q_sqrt2 = 1 := by sorry` —
+   strategic sorry, with the inline strategy documented:
+   * Compute `NumberField.discr Q_sqrt2 = 8` (S3 sub-target).
+   * Compute `NumberField.minkowskiBound Q_sqrt2 = √2 ≈ 1.414` (S3
+     sub-target).
+   * Apply `NumberField.exists_ne_zero_lt_minkowskiBound` to extract
+     a non-zero integral element of norm $< \sqrt 2 < 2$ from each
+     ideal class (S4 sub-target).
+   * Conclude every ideal class contains an integer of norm 1,
+     hence the unit ideal, hence $h_K = 1$.
+
+Estimated S2 ACT size: ~40 lines, 1 sorry on the main theorem,
+0 sorries on the field / `NumberField` instance derivation.
+
+### Blockers
+
+None anticipated. The Mathlib infrastructure is comprehensive at
+v4.26.0 (modulo API-surface drift on module paths). If
+`NumberField.discr` does not directly give `disc Q_sqrt2 = 8`,
+fall back to explicit `Algebra.discr` computation via the basis
+$\{1, \sqrt 2\}$ trace matrix (additional ~40 lines, 0 sorries).
+
+### Race-safety note
+
+This slug was added by the seeker (pool `added_at = null`, but
+seeker's notes timestamp it 2026-05-12). As of S1 submission:
+
+- `gh pr list --search "sqrt2-minpoly-oq-03"` returns 0 open PRs
+- `git branch -r | grep sqrt2-minpoly-oq-03` returns 0 remote
+  branches
+- `research/claims/sqrt2-minpoly-oq-03.lock` was acquired by
+  researcher-10 at the start of this session
+- `research/problems/sqrt2-minpoly-oq-03/` did not exist before
+  this session
+- `src/data/research/problems/sqrt2-minpoly-oq-03.json` did not
+  exist before this session
+
+The race window for fresh tier-B slugs is 5-30 minutes per memory
+pattern (`feedback_researcher_seeker_fresh_slug_window.md`); this
+S1 is being written ~24 hours after the seeker add window, well
+outside the convergent-claim window. Pre-push probe will re-verify
+immediately before push.
+
+### Honest assessment
+
+This is **not** a novel mathematical result. Class number 1 for
+$\mathbb{Q}(\sqrt 2)$ is a textbook example (Marcus 1977 Chapter 5,
+Stewart-Tall Section 9.3). The Lean contribution is:
+
+1. **First instantiation of Mathlib's `NumberField.classNumber`
+   machinery for a concrete real quadratic field in the gallery.**
+   Mathlib has the abstract API but no specific-field instantiations;
+   this becomes a template for future $\mathbb{Q}(\sqrt 3)$,
+   $\mathbb{Q}(\sqrt 5)$, $\mathbb{Q}(\sqrt 6)$ cases.
+2. **Bridge between `Zsqrtd 2` and the abstract ring of integers
+   of $\mathbb{Q}(\sqrt 2)$.** Mathlib has both but the iso is not
+   packaged at v4.26.0; constructing it makes the bridge reusable.
+3. **Concrete step toward Gauss's class-number-1 conjecture for
+   real quadratic fields.** The general problem is open; gallery
+   coverage of small cases is a valid scaling target.
+
+The novelty is **packaging**, not mathematical content. The
+expected deliverable (S2-S4) is a complete formal proof with 0
+axioms and 0 sorries, suitable for the gallery's `verified` /
+`original` badge tier.

--- a/src/data/research/problems/sqrt2-minpoly-oq-03.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-03.json
@@ -1,0 +1,148 @@
+{
+  "slug": "sqrt2-minpoly-oq-03",
+  "title": "Class number 1 for Q(√2) via Minkowski's bound",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "minkowski-route",
+  "problemStatement": {
+    "formal": "Prove `NumberField.classNumber (Q_sqrt2) = 1` where `Q_sqrt2 : Type` is constructed as `Polynomial.SplittingField (X^2 - C 2 : ℚ[X])` (or equivalently via `AdjoinRoot`), carrying the canonical `[Field Q_sqrt2] [Algebra ℚ Q_sqrt2] [NumberField Q_sqrt2]` instances. Equivalently: `IsPrincipalIdealRing (NumberField.RingOfIntegers Q_sqrt2)`, since the abstract ring of integers of Q(√2) is `Zsqrtd 2`.",
+    "plain": "While the parent gallery proof `sqrt2-minpoly` establishes that the minimal polynomial of √2 over ℚ is X² - 2 and hence [Q(√2) : ℚ] = 2, it stops short of the algebraic-number-theory of K = Q(√2). The next natural question is: is the ring of integers O_K = ℤ[√2] a principal ideal domain? Equivalently, is the class number h_K = 1? The answer is yes, via Minkowski's bound: for K = Q(√2), disc(K) = 8 (since 2 ≢ 1 mod 4) and the Minkowski bound is M_K = (2!/2²)·√8 = √2 ≈ 1.414 < 2, so every ideal class has an integral representative of norm ≤ 1, forcing trivial class group.",
+    "whyMatters": [
+      "First instantiation of Mathlib's NumberField.classNumber machinery for a concrete real quadratic field in the gallery; provides a template for future Q(√3), Q(√5), Q(√6), Q(√7) class-number gallery proofs (all class-number-1 by the same Minkowski argument).",
+      "Bridge between Mathlib's `Zsqrtd 2` (concrete ring) and `NumberField.RingOfIntegers (Q(√2))` (abstract typeclass instance). Mathlib has both at v4.26.0, but the ring iso between them is not packaged; constructing it makes the bridge reusable for any squarefree `d` not ≡ 1 mod 4.",
+      "Concrete step toward Gauss's class-number-1 conjecture for real quadratic fields (infinitely many real quadratic fields have class number 1 — open since Gauss). Lean-instantiated gallery coverage of small cases is a small but real contribution toward systematic coverage.",
+      "Pedagogically valuable: Marcus 1977 Theorem 5.4 corollary, Stewart-Tall §9.3, and Neukirch §I.5 all use Q(√2) as the worked example for Minkowski-bound class-number computations. Formalizing it gives a concrete textbook checkpoint."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Classical mathematical result. Marcus (1977) Theorem 5.4 corollary computes h(Q(√2)) = 1 explicitly. Standard in every introductory algebraic-number-theory textbook (Neukirch, Stewart-Tall, Marcus, Samuel).",
+      "Mathlib v4.26.0 has `NumberField` typeclass, `NumberField.RingOfIntegers`, `NumberField.classNumber` (= `Fintype.card (ClassGroup (RingOfIntegers K))`), `NumberField.discr` (number field discriminant), `NumberField.minkowskiBound` (or analogous, in `Mathlib.NumberTheory.NumberField.CanonicalEmbedding` / `Mathlib.NumberTheory.NumberField.Minkowski`), `Zsqrtd d` for d : ℤ.",
+      "Parent gallery (`Proofs/Sqrt2Minpoly.lean`, 140 lines, 0 axioms, 0 sorries, status: verified) provides `irred_X_sq_sub_two_rat : Irreducible (X^2 - C 2 : ℚ[X])` via Eisenstein + Gauss's lemma. This is the **input** for constructing Q(√2) as `Polynomial.SplittingField` or `AdjoinRoot`.",
+      "Sibling OQ-01 (`Proofs/Sqrt2MinpolyOQ01.lean`) generalizes the parent's minpoly result to all non-perfect-square n; not directly used here but documents the local namespace + idiom conventions.",
+      "Sibling OQ-02 (`Proofs/Sqrt2MinpolyOQ02.lean`) generalizes to k-th roots via Eisenstein; same idiom note.",
+      "Mathlib's `Mathlib.NumberTheory.Zsqrtd.GaussianInt` provides a complete Euclidean-domain proof for ℤ[i] = `Zsqrtd (-1)`; this is the template for the optional S5 Euclidean-domain route at d = 2."
+    ],
+    "open": [
+      "Construction of `Q_sqrt2 : Type` as a number field with canonical `[NumberField Q_sqrt2]` instance (S2 ORIENT, ~30-40 lines, 0 sorries expected).",
+      "Discriminant computation `NumberField.discr Q_sqrt2 = 8` (S3 ACT, ~40 lines; fallback to explicit `Algebra.discr` trace-matrix computation if Mathlib's specific-quadratic-field discriminant API is thin).",
+      "Minkowski bound `NumberField.minkowskiBound Q_sqrt2 = √2` (S3 ACT, ~50 lines, modulo Mathlib's specific encoding of the bound).",
+      "Main theorem `Q_sqrt2_classNumber_eq_one : NumberField.classNumber Q_sqrt2 = 1` (S4 ACT, ~40 lines, via Minkowski's existence-of-small-norm-element lemma applied to each ideal class).",
+      "Ring-of-integers identification `RingOfIntegers Q_sqrt2 ≃+* Zsqrtd 2` (S5 optional, ~60 lines).",
+      "Euclidean structure `EuclideanDomain (Zsqrtd 2)` (S5 optional, ~120 lines, mirroring the `GaussianInt` template)."
+    ],
+    "goal": "Establish the class-number-1 result for Q(√2) using Mathlib's NumberField + Minkowski-bound + Zsqrtd machinery, producing a `verified` / `original` gallery entry with 0 axioms and 0 sorries on the main theorem. Optional follow-up: ring-of-integers iso to `Zsqrtd 2` and direct Euclidean-domain proof."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T17:30:00.000Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE (researcher-10, 2026-05-12) — doc-only scaffold. Created problem.md, knowledge.md, state.md, this JSON. No Lean changes. Identified the Minkowski-bound route as the canonical proof (Marcus Chapter 5 worked example) and the Euclidean-domain route as an optional S5 strengthening. Surveyed Mathlib's NumberField / RingOfIntegers / classNumber / minkowskiBound / Zsqrtd surface at v4.26.0 (subject to S2 ORIENT module-path verification — the worktree's recursive `proofs/.lake` self-symlink trap prevents direct Mathlib search). Identified the parent gallery's `irred_X_sq_sub_two_rat` as the immediate input to constructing Q(√2) via `Polynomial.SplittingField (X^2 - C 2)`.",
+    "blockers": [],
+    "nextAction": "S2 ORIENT: create `proofs/Proofs/Sqrt2MinpolyOQ03.lean`. Imports: `Sqrt2Minpoly` + `Mathlib.NumberTheory.NumberField.Basic` + `Mathlib.NumberTheory.NumberField.ClassNumber` + `Mathlib.NumberTheory.NumberField.Discriminant` + `Mathlib.NumberTheory.NumberField.CanonicalEmbedding` (verify exact module name for the Minkowski-bound API) + `Mathlib.NumberTheory.Zsqrtd.Basic`. Define `Q_sqrt2 := Polynomial.SplittingField (X^2 - C 2 : ℚ[X])` and verify the `NumberField Q_sqrt2` instance. Stub `Q_sqrt2_classNumber_eq_one` with `by sorry` and document the proof strategy (compute discriminant 8 → compute Minkowski bound √2 → apply existence-of-small-norm-element → conclude trivial class group). Estimated S2 ACT size: ~40 lines, 1 sorry on the main theorem (deferred to S3-S4 sub-targets), 0 sorries on the field / NumberField instance derivation. Have a fallback `AdjoinRoot (X^2 - C 2)` construction ready if `SplittingField`'s `NumberField` instance is friction-heavy at v4.26.0.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE (researcher-10, 2026-05-12): fresh tier-B slug. Doc-only scaffolding establishing the formal target (NumberField.classNumber Q_sqrt2 = 1 via Minkowski's bound), the tractability triage (Minkowski-route in S2-S4 is canonical and gallery-ready; Euclidean-route in S5 is an optional strengthening), and the S2 plan (construct Q(√2), verify NumberField instance, stub main theorem with documented strategy). Identified Mathlib's NumberField / RingOfIntegers / classNumber / minkowskiBound / discriminant / Zsqrtd infrastructure as the primitives the OQ-03 work will compose. No Lean changes this session.",
+    "builtItems": [
+      "research/problems/sqrt2-minpoly-oq-03/problem.md — problem description with formal target, tractability triage (Minkowski-route vs Euclidean-route), parent linkage, references (Marcus 1977, Neukirch 1999, Stewart-Tall 2015, Hardy-Wright 2008)",
+      "research/problems/sqrt2-minpoly-oq-03/knowledge.md — Mathlib surface inventory (NumberField.classNumber, RingOfIntegers, discr, minkowskiBound, Zsqrtd), parent/sibling re-use opportunities (parent irreducibility lemma; Gaussian integer Euclidean template), feasibility table, S2 plan, risk register",
+      "research/problems/sqrt2-minpoly-oq-03/state.md — phase OBSERVE, iter 1, S2 plan, race-safety verification",
+      "src/data/research/problems/sqrt2-minpoly-oq-03.json — this file"
+    ],
+    "insights": [
+      "The Minkowski-bound route is the canonical Marcus-Chapter-5 proof and scales to Q(√d) for any squarefree d > 0 with disc(Q(√d)) small enough that M_K < 2 (gives class number 1). For d ∈ {2, 3, 5, 6, 7, 11, 13, ...} this holds by direct computation (M_K = √2, √3, √5/2, √24/2, √28/2, ... all < 2 except a finite list). This template makes a class-number-1 gallery proof for each small d a ~30-line wrapper around the OQ-03 main theorem.",
+      "The discriminant of Q(√2) is 8 (not 2!) because 2 ≢ 1 mod 4. The basis {1, √2} for ℤ[√2] gives trace matrix diag(2, 4) with det 8. Mathlib may have `NumberField.disc_quadratic_eq` (verify name at v4.26.0); fallback is direct `Algebra.discr` computation.",
+      "For totally real fields (r₁ = n, r₂ = 0), the Minkowski bound simplifies to (n!/n^n)·√|d_K|. For n = 2: M_K = (1/2)·√|d_K|. So M_K < 2 ⟺ |d_K| < 16, which holds for Q(√d) with d ∈ {2, 3, 5, 6, 7, 11, 13} (disc 8, 12, 5, 24, 28, 44, 13).",
+      "Wait, the d = 6, 7, 11, 13 cases have M_K = √24/2 ≈ 2.45, √28/2 ≈ 2.65, etc. — all > 2. So Minkowski-bound alone does NOT immediately give class-number 1 for those. The class-number-1 cases by Minkowski-alone are d ∈ {2, 3, 5, 13}. For d = 6, 7, 11, the proof needs extra ideal-norm exclusion arguments. Honest scoping: this OQ-03 template covers the d ∈ {2, 3, 5, 13} cases cleanly; d ∈ {6, 7, 11} would be a separate follow-on.",
+      "The ring of integers identification O_{Q(√2)} ≃ ℤ[√2] = `Zsqrtd 2` is direct because 2 ≢ 1 mod 4 (no half-integer ring of integers). Mathlib has `Zsqrtd d.toCommRing` for any squarefree d, but the canonical iso to `NumberField.RingOfIntegers` is not (yet) packaged at v4.26.0.",
+      "The Euclidean-domain route at d = 2 is geometrically cleaner than the Minkowski route: |N(a + b√2)| = |a² - 2b²|, and the max of |a² - 2b²| over the fundamental domain (a, b) ∈ [-1/2, 1/2]² is 1/2 < 1, so every Q(√2)-element has an ℤ[√2]-neighbor within norm 1/2. This gives a Euclidean function and PID directly without invoking discriminant or Minkowski bound. Mathlib's GaussianInt proof at d = -1 is a template, but the d = 2 case is in some ways simpler (one real, not one imaginary, embedding)."
+    ],
+    "mathlibGaps": [
+      "Specific-field instantiations of `NumberField.classNumber` are thin at v4.26.0: Mathlib has the abstract `classNumber` definition but few worked-out small-field examples. The OQ-03 deliverable adds Q(√2) as a concrete example, providing infrastructure for any squarefree d.",
+      "The ring iso `NumberField.RingOfIntegers (Q(√d)) ≃+* Zsqrtd d` for squarefree d ≢ 1 mod 4 may not be packaged at v4.26.0. If so, the OQ-03 work builds it (~60 lines, S5 optional).",
+      "Mathlib's `Zsqrtd d` Euclidean-domain instance is proved for d = -1 (`GaussianInt`) but may not be proved for d = 2 at v4.26.0. The S5 optional deliverable would add this.",
+      "Mathlib's `NumberField.minkowskiBound` may be expressed as a `Real.toNNReal` of an algebraic combination; computing the explicit value `√2` may require `Real.sqrt_eq_iff_sq_eq` manipulations. This is friction, not a fundamental gap."
+    ],
+    "nextSteps": [
+      "S2 ORIENT: verify Mathlib NumberField / classNumber / discr / minkowskiBound module paths and API surface at v4.26.0. Create `proofs/Proofs/Sqrt2MinpolyOQ03.lean` with field construction, NumberField instance, main theorem stub.",
+      "S3 ACT: compute `NumberField.discr Q_sqrt2 = 8` and `NumberField.minkowskiBound Q_sqrt2 = √2`.",
+      "S4 ACT: apply `NumberField.exists_ne_zero_lt_minkowskiBound` to conclude class number 1.",
+      "S5 ACT (optional): identify RingOfIntegers Q_sqrt2 with Zsqrtd 2 + prove Euclidean structure on Zsqrtd 2 (~180 lines).",
+      "S6+ (optional): template extension to Q(√3), Q(√5), Q(√13) — each ~30 lines as a wrapper around S4 main theorem with substituted d."
+    ]
+  },
+  "references": [
+    {
+      "author": "Marcus, D. A.",
+      "year": 1977,
+      "title": "Number Fields",
+      "venue": "Springer Universitext",
+      "url": null,
+      "notes": "Chapter 5 (Minkowski's theorem and finiteness of the class group). The corollary to Theorem 5.4 explicitly computes h(Q(√2)) = 1 as the worked example."
+    },
+    {
+      "author": "Neukirch, J.",
+      "year": 1999,
+      "title": "Algebraic Number Theory",
+      "venue": "Springer Grundlehren 322",
+      "url": null,
+      "notes": "Section I.5–I.6: Minkowski theorem and finiteness of the class group; standard reference for the class-number machinery."
+    },
+    {
+      "author": "Stewart, I.; Tall, D.",
+      "year": 2015,
+      "title": "Algebraic Number Theory and Fermat's Last Theorem, 4th ed.",
+      "venue": "CRC Press",
+      "url": null,
+      "notes": "Section 9.3: real quadratic fields and Minkowski-bound class-number computations; Q(√2) is the worked example."
+    },
+    {
+      "author": "Hardy, G. H.; Wright, E. M.",
+      "year": 2008,
+      "title": "An Introduction to the Theory of Numbers, 6th ed.",
+      "venue": "Oxford University Press",
+      "url": null,
+      "notes": "§14: algebraic numbers and integers; ℤ[√2] as a Euclidean domain via the norm form |a² - 2b²|."
+    },
+    {
+      "author": "Samuel, P.",
+      "year": 1970,
+      "title": "Algebraic Theory of Numbers",
+      "venue": "Houghton-Mifflin",
+      "url": null,
+      "notes": "§4–§5: classical treatment of the class group and Minkowski's bound; quadratic fields as the canonical examples."
+    }
+  ],
+  "tags": [
+    "seeker-selected",
+    "algebraic-number-theory",
+    "class-number",
+    "minkowski-bound",
+    "quadratic-fields",
+    "sqrt2",
+    "ring-of-integers",
+    "principal-ideal-domain"
+  ],
+  "relatedProofs": [
+    "sqrt2-minpoly",
+    "sqrt2-minpoly-oq-01",
+    "sqrt2-minpoly-oq-02",
+    "gaussian-integers",
+    "zsqrtd-neg-two"
+  ],
+  "provenance": {
+    "selectedBy": "seeker",
+    "selectedAt": "2026-05-12T00:00:00.000Z",
+    "parentGallery": "src/data/proofs/sqrt2-minpoly",
+    "parentLean": "proofs/Proofs/Sqrt2Minpoly.lean",
+    "category": "extension"
+  },
+  "significance": 6,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for **sqrt2-minpoly-oq-03** — a tier-B follow-up to the parent `sqrt2-minpoly` (which proved $\mathrm{minpoly}_{\mathbb{Q}}(\sqrt 2) = X^2 - 2$). The next natural ANT question is whether $\mathcal{O}_{\mathbb{Q}(\sqrt 2)} = \mathbb{Z}[\sqrt 2]$ is a PID — equivalently, whether the class number $h_K = 1$.

The answer is yes via **Minkowski's bound**: for $K = \mathbb{Q}(\sqrt 2)$, $d_K = 8$ (since $2 \not\equiv 1 \pmod 4$), and the Minkowski bound is $M_K = (n!/n^n)\sqrt{|d_K|} = (1/2)\sqrt 8 = \sqrt 2 \approx 1.414 < 2$. Hence every ideal class has an integral representative of norm $\le 1$, which forces the unit ideal, so $h_K = 1$.

This S1 PR is **doc-only**: 4 markdown / JSON files, **0 Lean changes**, 0 axioms, 0 sorries, 0 build risk.

### What's in this S1

- **`problem.md`** — formal target (`NumberField.classNumber Q_sqrt2 = 1`), tractability triage (Minkowski-route vs Euclidean-route), parent / sibling re-use map, references (Marcus 1977, Neukirch, Stewart-Tall, Hardy-Wright, Samuel).
- **`knowledge.md`** — Mathlib v4.26.0 surface inventory (`NumberField`, `RingOfIntegers`, `classNumber`, `discr`, `minkowskiBound`, `Zsqrtd`), feasibility table for each S2-S5 target, risk register (Mathlib API-surface drift on module paths, friction on specific-field discriminant computations).
- **`state.md`** — phase OBSERVE, S2 ORIENT plan, race-safety verification.
- **`src/data/research/problems/sqrt2-minpoly-oq-03.json`** — pool registration with `phase: OBSERVE`, `iteration: 1`, references, knowledge surface.

### Why not S2 in this session

S2 ORIENT requires verifying Mathlib's `NumberField.classNumber` / `NumberField.discr` / `NumberField.minkowskiBound` module paths and API surface at the pinned v4.26.0 rev. The worktree's recursive `proofs/.lake` self-symlink (`feedback_researcher_lake_symlink_broken.md`) blocks direct Mathlib search; that lookup is best done in S2 ORIENT where the build can verify the imports compile. Bundling it with this S1 OBSERVE would push the PR into a partial S2 with un-verified imports, which the gallery does not benefit from.

### Honest assessment

This is **not** a novel mathematical result. Marcus 1977 Theorem 5.4 corollary computes $h(\mathbb{Q}(\sqrt 2)) = 1$ explicitly as the worked example. The Lean contribution (once the S2-S4 plan completes) is:

1. First instantiation of Mathlib's `NumberField.classNumber` machinery for a concrete real quadratic field in the gallery — provides a template for $\mathbb{Q}(\sqrt 3)$, $\mathbb{Q}(\sqrt 5)$, $\mathbb{Q}(\sqrt 13)$ (the three other real quadratics with $M_K < 2$).
2. Bridge between Mathlib's `Zsqrtd 2` (concrete) and abstract `NumberField.RingOfIntegers` of $\mathbb{Q}(\sqrt 2)$ (not currently packaged at v4.26.0).
3. Small concrete step toward Gauss's class-number-1 conjecture for real quadratic fields (a long-standing open question — Lean-instantiated gallery coverage is a small but real contribution).

### Next action (S2 ORIENT)

Create `proofs/Proofs/Sqrt2MinpolyOQ03.lean` (~40 lines) with the field construction, `NumberField` instance, and main-theorem stub. See `state.md` for the detailed S2 plan.

## Test plan

- [x] 0 Lean files modified — no build verification needed
- [x] 4 doc-only files added with internal cross-references (problem ↔ knowledge ↔ state ↔ JSON)
- [x] Race-safety: pre-commit and pre-push probes both showed 0 open PRs / 0 remote branches / 0 prior `research/problems/sqrt2-minpoly-oq-03/` artifacts
- [x] Lock acquired at session start, released after push
- [x] No claims about Mathlib API surface that depend on running the build (all "VERIFY in S2" markers explicit in `knowledge.md` and `state.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)