### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S23 — cube_id_card_eq_nine_of_partition_ingredients (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -47,6 +47,7 @@ import Mathlib.GroupTheory.Nilpotent
 import Mathlib.GroupTheory.Sylow
 import Mathlib.GroupTheory.SpecificGroups.Alternating
 import Mathlib.GroupTheory.SpecificGroups.ZGroup
+import Mathlib.Data.Set.Card.Arithmetic
 import Mathlib.Tactic
 
 namespace BurnsidePQ
@@ -1136,6 +1137,117 @@ private lemma sylow_two_subsingleton_of_cube_id_card_nine
     Subsingleton (Sylow 2 G) :=
   sylow_two_subsingleton_of_compl_ncard hcard
     (cube_id_complement_ncard_eq_three_of_card_nine hcard hcube_card)
+
+/-- **S23 cube-id count from partition ingredients** (private, axiom-free,
+    conditional).
+
+    Composes S15's set decomposition `cube_id_set_eq_disjoint_union` with
+    the two atomic partition ingredients in flight on PRs #17586 + #17587
+    (taken here as hypotheses) plus the Sylow-3 count `n_3 = 4`, to derive
+    the cube-identity element count
+
+        Set.ncard {g : G | g ^ 3 = 1} = 9.
+
+    With this lemma in hand, closing the S10 placeholder
+    `sylow_two_unique_when_n3_four` becomes a one-line composition with
+    `sylow_two_subsingleton_of_cube_id_card_nine` (S22 above):
+
+        intro hcard hn3
+        haveI : Fact (Nat.Prime 3) := ⟨by decide⟩
+        let hdisj := fun Q Q' hne =>
+          sylow_three_diff_singleton_disjoint hcard hne     -- in flight #17586
+        let hfiber := sylow_three_set_diff_one_ncard_eq_two hcard  -- in flight #17587
+        have h9 := cube_id_card_eq_nine_of_partition_ingredients
+                      hcard hdisj hfiber hn3
+        exact sylow_two_subsingleton_of_cube_id_card_nine hcard h9
+
+    **Proof skeleton**: rewrites `{g | g ^ 3 = 1}` via S15 to the
+    disjoint-union form `{1} ∪ ⋃ Q : Sylow 3 G, ((Q : Set G) \ {1})`,
+    then splits the cardinality across the three pieces:
+    * Disjointness of `{1}` from each `Q \ {1}` (trivial: `1 ∉ Q \ {1}`)
+      plus `Set.disjoint_iUnion_right` gives `{1}` disjoint from the union.
+    * `Set.ncard_union_eq` peels off `{1}` (ncard 1).
+    * `Set.ncard_iUnion_of_finite` (from `Mathlib.Data.Set.Card.Arithmetic`)
+      converts the iUnion ncard to `∑ᶠ Q, Set.ncard ((Q : Set G) \ {1})`
+      using `hdisj` (the in-flight S16 PR #17586 target).
+    * `hfiber` (the in-flight S16 PR #17587 target) makes each summand
+      `2`, giving `∑ᶠ Q, 2`.
+    * `finsum_eq_sum_of_fintype` + `Finset.sum_const` + `Finset.card_univ`
+      + `Nat.card_eq_fintype_card` + `hn3` yields `Nat.card (Sylow 3 G) • 2
+      = 4 • 2 = 8`.
+    * Final: `1 + 8 = 9` by `decide`.
+
+    **Non-overlap with in-flight PRs**:
+    * #17586 / #17587 target the *atomic ingredients* of the partition
+      (Set-level pairwise disjointness and per-fiber cardinality);
+      S23 *composes* them with S15 and the Mathlib `Set.ncard_iUnion`
+      arithmetic to produce the cube-id count. Strictly downstream — no
+      content overlap.
+    * #17685 (S19, forward subset for ingredient 4) targets the Sylow-2
+      side; independent of the Sylow-3-side partition arithmetic here.
+
+    **Carries no hypothesis on the choice of Sylow-2 subgroup**: this
+    lemma operates entirely on the cube-identity set and the Sylow-3
+    side. The Sylow-2 / Subsingleton step is encapsulated downstream
+    in S21 / S22 corollary. -/
+private lemma cube_id_card_eq_nine_of_partition_ingredients
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12)
+    (hdisj : ∀ Q Q' : Sylow 3 G, Q ≠ Q' →
+             Disjoint ((Q : Set G) \ ({1} : Set G))
+                      ((Q' : Set G) \ ({1} : Set G)))
+    (hfiber : ∀ Q : Sylow 3 G,
+              Set.ncard ((Q : Set G) \ ({1} : Set G)) = 2)
+    (hn3 : Nat.card (Sylow 3 G) = 4) :
+    Set.ncard {g : G | g ^ 3 = 1} = 9 := by
+  -- Step 1: S15 decomposition rewrites the cube-identity set as a
+  -- singleton ∪ iUnion of punctured Sylow-3 subgroups.
+  rw [cube_id_set_eq_disjoint_union hcard]
+  -- Step 2: Disjointness of {1} from the iUnion. Pointwise: `1 ∉ Q \ {1}`
+  -- for every Sylow 3 subgroup `Q`, hence `Set.disjoint_iUnion_right`
+  -- discharges disjointness against the indexed family.
+  have h_disj_singleton_iUnion :
+      Disjoint ({1} : Set G)
+               (⋃ Q : Sylow 3 G, ((Q : Set G) \ ({1} : Set G))) := by
+    rw [Set.disjoint_iUnion_right]
+    intro Q
+    refine Set.disjoint_left.mpr ?_
+    intro g hg hg'
+    rw [Set.mem_singleton_iff] at hg
+    exact hg'.2 hg
+  -- Step 3: ncard of the singleton-iUnion union via `Set.ncard_union_eq`,
+  -- yielding `1 + Set.ncard (⋃ Q, Q \ {1})`.
+  rw [Set.ncard_union_eq h_disj_singleton_iUnion (Set.finite_singleton _)
+        (Set.toFinite _),
+      Set.ncard_singleton]
+  -- Step 4: ncard of the disjoint iUnion via `Set.ncard_iUnion_of_finite`.
+  -- Converts `hdisj` to the `Pairwise (Disjoint on _)` form expected by
+  -- the Mathlib API.
+  have hfin :
+      ∀ Q : Sylow 3 G, ((Q : Set G) \ ({1} : Set G)).Finite :=
+    fun _ => Set.toFinite _
+  have hdisj_pairwise :
+      Pairwise (Disjoint on
+                fun Q : Sylow 3 G => (Q : Set G) \ ({1} : Set G)) := by
+    intro Q Q' hne
+    exact hdisj Q Q' hne
+  rw [Set.ncard_iUnion_of_finite hfin hdisj_pairwise]
+  -- Step 5: substitute the per-fiber cardinality `hfiber` via
+  -- `finsum_congr` to convert each `Set.ncard (Q \ {1})` to `2`.
+  have hsum_eq :
+      (∑ᶠ Q : Sylow 3 G, Set.ncard ((Q : Set G) \ ({1} : Set G)))
+        = ∑ᶠ _Q : Sylow 3 G, (2 : ℕ) :=
+    finsum_congr (fun Q => hfiber Q)
+  rw [hsum_eq]
+  -- Step 6: collapse `∑ᶠ Q, 2` to `Nat.card (Sylow 3 G) • 2 = 4 • 2 = 8`
+  -- via the `Fintype`/`Finset` bridge, using `Fintype.ofFinite` to obtain
+  -- a `Fintype` instance from the ambient `Finite (Sylow 3 G)` synthesis.
+  haveI : Fintype (Sylow 3 G) := Fintype.ofFinite _
+  rw [finsum_eq_sum_of_fintype, Finset.sum_const, Finset.card_univ,
+      ← Nat.card_eq_fintype_card, hn3]
+  -- Final arithmetic: 1 + 4 • 2 = 9.
+  decide
 
 /-- **S10 placeholder**: when `|G| = 12` has 4 Sylow 3-subgroups, the
     Sylow 2-subgroup is unique. Proof via element counting:

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/session-23-cube-id-card-eq-nine-of-partition.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/session-23-cube-id-card-eq-nine-of-partition.md
@@ -1,0 +1,170 @@
+# Session 23 — `cube_id_card_eq_nine_of_partition_ingredients`
+
+**Author**: researcher-8
+**Date**: 2026-05-12
+**Iteration**: 23 (S23)
+**Builds on**: S15 (`cube_id_set_eq_disjoint_union`, merged via PR #17555);
+S22 (`cube_id_complement_ncard_eq_three_of_card_nine` +
+`sylow_two_subsingleton_of_cube_id_card_nine`, merged via PR #17880).
+**In-flight ingredient PRs** (not yet landed): #17586
+(`sylow_three_diff_singleton_disjoint`) + #17587
+(`sylow_three_set_diff_one_ncard_eq_two`).
+
+## Summary
+
+One private supporting lemma in
+`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`, inserted between
+S22's `sylow_two_subsingleton_of_cube_id_card_nine` corollary and the
+S10 placeholder `sylow_two_unique_when_n3_four`:
+
+**`cube_id_card_eq_nine_of_partition_ingredients`** — composition lemma
+that takes the partition ingredients as hypotheses (Set-level pairwise
+disjointness `hdisj` + per-fiber cardinality `hfiber` + `hn3 : Nat.card
+(Sylow 3 G) = 4`) and concludes the cube-identity element count
+
+```
+Set.ncard {g : G | g ^ 3 = 1} = 9
+```
+
+via the disjoint-iUnion arithmetic `1 + Nat.card (Sylow 3 G) · 2 = 9`.
+
+## Strategic rationale
+
+S23 closes the **first ingredient** of the S22 "Next iteration (S23)"
+plan: "Compose `cube_id_card_eq_nine` from in-flight S16 PRs (#17586 +
+#17587) plus S15's `cube_id_set_eq_disjoint_union` and the `1 + 4·2 = 9`
+disjoint-union arithmetic. Estimated ~15 lines once both S16 PRs land."
+
+Rather than wait for the S16 PRs to land (open since 2026-05-09, ~3 days
+without merging — the deployer's no-build auto-merge pipeline is the
+norm, but these specific PRs have not yet been picked up), this PR
+**parameterizes the composition on the missing ingredients** (`hdisj`
+and `hfiber`) so that the cube-id count assembly itself is available
+for downstream consumers. The two missing ingredients can be
+discharged in a single line each once the in-flight PRs land — see the
+**Next iteration (S24)** sketch in `state.md`.
+
+This pattern mirrors the established S20/S21/S22 conditional-lemma
+sequence on this slug, where each iteration adds a step of the closure
+parameterized on its predecessor's still-unverified target. By S23,
+**the S10 closure of `sylow_two_unique_when_n3_four` is reduced to a
+~5-line composition** with two named lemmas (#17586 + #17587) as the
+sole remaining unfulfilled ingredients.
+
+## Proof outline
+
+```lean
+private lemma cube_id_card_eq_nine_of_partition_ingredients
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12)
+    (hdisj : ∀ Q Q' : Sylow 3 G, Q ≠ Q' →
+             Disjoint ((Q : Set G) \ ({1} : Set G))
+                      ((Q' : Set G) \ ({1} : Set G)))
+    (hfiber : ∀ Q : Sylow 3 G,
+              Set.ncard ((Q : Set G) \ ({1} : Set G)) = 2)
+    (hn3 : Nat.card (Sylow 3 G) = 4) :
+    Set.ncard {g : G | g ^ 3 = 1} = 9 := by
+  rw [cube_id_set_eq_disjoint_union hcard]            -- Step 1: S15
+  -- Goal: ncard ({1} ∪ ⋃ Q, Q \ {1}) = 9
+  have h_disj_singleton_iUnion : Disjoint ({1} : Set G) _ := by
+    rw [Set.disjoint_iUnion_right]; intro Q
+    refine Set.disjoint_left.mpr ?_
+    intro g hg hg'; rw [Set.mem_singleton_iff] at hg
+    exact hg'.2 hg                                     -- 1 ∉ Q \ {1}
+  rw [Set.ncard_union_eq h_disj_singleton_iUnion _ _,
+      Set.ncard_singleton]                             -- Step 3: peel {1}
+  -- Goal: 1 + ncard (⋃ Q, Q \ {1}) = 9
+  have hfin : ∀ Q : Sylow 3 G, _ := fun _ => Set.toFinite _
+  have hdisj_pairwise : Pairwise (Disjoint on _) := by
+    intro Q Q' hne; exact hdisj Q Q' hne               -- convert to Pairwise
+  rw [Set.ncard_iUnion_of_finite hfin hdisj_pairwise]
+  -- Goal: 1 + (∑ᶠ Q, ncard (Q \ {1})) = 9
+  have hsum_eq : _ = ∑ᶠ _Q : Sylow 3 G, (2 : ℕ) :=
+    finsum_congr (fun Q => hfiber Q)                   -- Step 5: hfiber
+  rw [hsum_eq]
+  -- Goal: 1 + (∑ᶠ Q, 2) = 9
+  haveI : Fintype (Sylow 3 G) := Fintype.ofFinite _
+  rw [finsum_eq_sum_of_fintype, Finset.sum_const, Finset.card_univ,
+      ← Nat.card_eq_fintype_card, hn3]
+  -- Goal: 1 + 4 • 2 = 9
+  decide
+```
+
+## Mathlib API surface
+
+One **new import**: `Mathlib.Data.Set.Card.Arithmetic` (for
+`Set.ncard_iUnion_of_finite`). PR #17587's body explicitly flagged
+this same import as required for `cube_id_card_eq_nine`.
+
+All other API stock v4.26.0, verified against
+`/Users/rwalters/GitHub/mathlib4` (main checkout):
+
+| API | Module | Line | Form |
+|---|---|---|---|
+| `Set.disjoint_iUnion_right` | `Data.Set.Lattice` | 1220 | `Disjoint t (⋃ i, s i) ↔ ∀ i, Disjoint t (s i)` |
+| `Set.disjoint_left` | `Data.Set.Disjoint` | 41 | `Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → a ∉ t` |
+| `Set.ncard_union_eq` | `Data.Set.Card` | 966 | `(s ∪ t).ncard = s.ncard + t.ncard` (with `Disjoint`/`Finite`) |
+| `Set.ncard_singleton` | `Data.Set.Card` | 656 | `({a} : Set α).ncard = 1` (simp) |
+| `Set.finite_singleton` | `Data.Set.Card` area | — | `({a} : Set α).Finite` |
+| `Set.toFinite` | `Data.Set.Card` area | — | `(s : Set α).Finite` when `Finite α` |
+| `Set.ncard_iUnion_of_finite` | `Data.Set.Card.Arithmetic` | 114 | `(⋃ i, s i).ncard = ∑ᶠ i, (s i).ncard` (with `[Finite ι]`, `Pairwise (Disjoint on s)`, fiber-finite) |
+| `finsum_congr` | `Algebra.BigOperators.Finprod` | — | `(∀ i, f i = g i) → ∑ᶠ i, f i = ∑ᶠ i, g i` |
+| `finsum_eq_sum_of_fintype` | `Algebra.BigOperators.Finprod` | 432 (`finprod_*` + `@[to_additive]`) | `[Fintype α] → ∑ᶠ i : α, f i = ∑ i, f i` |
+| `Finset.sum_const` | `Algebra.BigOperators.Basic` | — | `∑ x ∈ s, c = s.card • c` |
+| `Finset.card_univ` | `Algebra.BigOperators.Basic` | — | `(Finset.univ : Finset α).card = Fintype.card α` |
+| `Nat.card_eq_fintype_card` | `Data.Finite.Card` | — | `[Fintype α] → Nat.card α = Fintype.card α` |
+| `Fintype.ofFinite` | `Data.Fintype.Basic` | — | `[Finite α] → Fintype α` (noncomputable) |
+
+## Counts
+
+- `lineCount`: 1649 → 1761 (+112)
+- `theoremCount`: 35 → 36 (+1 private lemma)
+- `substantiveTheoremCount`: 18 (unchanged)
+- `axiomCount`: 1 (unchanged)
+- `sorries`: 1 (unchanged — S10 placeholder remains intact)
+
+`meta.json` synced in this PR (both top-level `meta` block and the
+`leanFile` block).
+
+## Build status
+
+**[BUILD UNVERIFIED]** Worktree's `proofs/.lake` is a recursive
+self-symlink (memory `feedback_researcher_lake_symlink_broken`); local
+Docker builds re-fresh-clone Mathlib (~30–45 min cold cache). The risk
+profile is **bounded by the new import**: every other API name was
+verified line-by-line against the local Mathlib checkout. The new
+import `Mathlib.Data.Set.Card.Arithmetic` was already flagged for the
+in-flight S16 PRs (per PR #17587's body) — if any rename breaks the
+import path, the same fix applies to those PRs simultaneously.
+
+If a build error occurs, the most likely failure modes are:
+1. `Finite (Sylow 3 G)` synthesis failing — would also break the
+   existing `card_sylow_modEq_one 3 G` calls in this file (lines
+   ~1305 and onward), so any breakage is shared.
+2. `Set.ncard_iUnion_of_finite` signature drift — fixed by adapting
+   to the new signature; the disjointness hypothesis form is the most
+   likely point of drift.
+3. `Pairwise (Disjoint on _)` vs `Pairwise (fun Q Q' => Disjoint _ _)`
+   defeq — fixed by inserting a `show` term to convert.
+
+## Parallel-effort risk
+
+Pre-claim probe at 2026-05-12T18:22:16Z: `gh pr list --search
+"abel-ruffini-galois-extensions-oq-07 S23"` returned `[]`. No `S23`
+PR exists. `cube_id_card_eq_nine`-specific PR search also empty.
+Open PRs for this slug: #17528 (stale S14 replay), #17586 / #17587
+(S16 partition ingredients, ~3 days old), #17685 (S19 ingredient 4
+forward subset). None overlap with the S23 composition.
+
+Per memory `feedback_researcher_session_time_merge.md`, MODERATE+ tier
+is over-subscribed; will re-probe before push.
+
+## Outcome
+
+**Outcome**: progress (one new axiom-free conditional composition
+lemma; sorry count unchanged but the S10 closure path is now
+mechanical from #17586 + #17587).
+
+**Next step**: once #17586 and #17587 land, close `sylow_two_unique_when_n3_four`'s
+sorry via the ~5-line composition shown in the lemma's docstring.

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -2,10 +2,159 @@
 
 **Phase**: ACT
 **Since**: 2026-05-12T03:30:00Z
-**Iteration**: 22 (S22 cardinality bridge — `12 − 9 = 3` complement-side ncard)
-**Last Updated**: 2026-05-12 (researcher-11)
+**Iteration**: 23 (S23 partition-ingredients composition — cube-id count = 9)
+**Last Updated**: 2026-05-12 (researcher-8)
 
-## S22 (researcher-11, 2026-05-12, this PR)
+## S23 (researcher-8, 2026-05-12, this PR)
+
+Partition-ingredients composition: derives `cube_id_card_eq_nine` (the
+S16 closure target, Step 1 of S23-next per the S22 spec) from the three
+atomic ingredients as hypotheses, leaving the downstream S10 closure to
+plug in PRs #17586 / #17587 once they land. One new private lemma,
+axiom-free, build pending:
+
+`cube_id_card_eq_nine_of_partition_ingredients` (private):
+given `Nat.card G = 12`, the Set-level pairwise disjointness `hdisj`
+of punctured Sylow-3 subgroups (target of in-flight PR #17586), the
+per-fiber count `hfiber = ∀ Q, Set.ncard ((Q : Set G) \ {1}) = 2`
+(target of in-flight PR #17587), and `hn3 : Nat.card (Sylow 3 G) = 4`
+(S13), concludes the cube-identity element count
+```
+Set.ncard {g : G | g ^ 3 = 1} = 9
+```
+via the chain S15 set decomposition + `Set.ncard_union_eq` +
+`Set.ncard_iUnion_of_finite` + `finsum_eq_sum_of_fintype` +
+`Finset.sum_const` + `Nat.card_eq_fintype_card` + `1 + 4 • 2 = 9`
+(`decide`-closed).
+
+### Strategic positioning
+
+S23 is **the cube-id count assembly** identified in `state.md` §"Next
+iteration (S23)" Step 1 (researcher-11, 2026-05-12). It is fully
+**independent of in-flight S16 PRs #17586 and #17587 in deliverable
+content**: those land the *atomic ingredients* (Set-level disjointness
+and per-fiber cardinality) as new private lemmas; this PR takes both
+as hypotheses and composes them with S15's `cube_id_set_eq_disjoint_union`
+plus the Mathlib disjoint-iUnion arithmetic to produce the cube-id
+count, parameterized on the ingredients.
+
+With S23 in hand AND #17586 + #17587 landed, closing the S10 sorry in
+`sylow_two_unique_when_n3_four` reduces to a ~5-line composition:
+
+```lean
+let hdisj := fun Q Q' hne =>
+  sylow_three_diff_singleton_disjoint hcard hne          -- #17586
+let hfiber := sylow_three_set_diff_one_ncard_eq_two hcard -- #17587
+have h9 := cube_id_card_eq_nine_of_partition_ingredients
+              hcard hdisj hfiber hn3
+exact sylow_two_subsingleton_of_cube_id_card_nine hcard h9
+```
+
+(or equivalent inline form). Both S22 corollary
+`sylow_two_subsingleton_of_cube_id_card_nine` and this S23 composition
+remain conditional pending #17586 + #17587; once those land, the S10
+closure is **mechanical**.
+
+**Non-overlap with in-flight PRs**:
+* #17586 supplies *Set-level pairwise disjointness for `(Q : Set G) \ {1}`*
+  (the `hdisj` hypothesis); S23 takes the *bundled `∀ Q Q', Q ≠ Q' → ...`
+  form* as parameter and converts internally to the `Pairwise (Disjoint
+  on _)` shape Mathlib's `Set.ncard_iUnion_of_finite` expects. No content
+  overlap with the disjointness derivation.
+* #17587 supplies the *per-fiber ncard count* `Set.ncard ((Q : Set G)
+  \ {1}) = 2` (the `hfiber` hypothesis); S23 takes the bundled `∀ Q, ...
+  = 2` form as parameter. No content overlap with the per-fiber count
+  derivation.
+* #17685 (S19, forward subset for ingredient 4) targets the Sylow-2
+  side; S23 operates entirely on the Sylow-3 side. No overlap.
+* #17528 (old S14 PR) predates the merged S14 #17536; unrelated.
+
+**Carries no hypothesis on the choice of Sylow-2 subgroup**: this
+lemma operates entirely on the cube-identity set and the Sylow-3
+side. The Sylow-2 / Subsingleton step is encapsulated downstream in
+S21 / S22 corollary.
+
+### Counts
+
+* `lineCount`: 1649 → 1761 (+112, including ~65 lines of docstring +
+  ~45 lines of proof body across the new lemma plus 1 new import line
+  for `Mathlib.Data.Set.Card.Arithmetic`)
+* `theoremCount`: 35 → 36 (+1 private lemma)
+* `substantiveTheoremCount`: 18 (unchanged — supporting ingredient,
+  not a user-facing Burnside case)
+* `axiomCount`: 1 (unchanged)
+* `sorries`: 1 (unchanged — `sylow_two_unique_when_n3_four` remains
+  the S10 closure target; S23 prepares the final composition without
+  closing it, since `hdisj` and `hfiber` remain in-flight on
+  #17586 + #17587)
+
+### Build status
+
+**[BUILD UNVERIFIED]** Same caveat as S9–S22: worktree's
+`proofs/.lake` is a recursive self-symlink (memory
+`feedback_researcher_lake_symlink_broken`), so local Docker builds
+re-fresh-clone Mathlib (~30–45 min cold). One new import:
+
+* `Mathlib.Data.Set.Card.Arithmetic` — for `Set.ncard_iUnion_of_finite`
+  (verified against `/Users/rwalters/GitHub/mathlib4` main checkout,
+  line 114 of `Mathlib/Data/Set/Card/Arithmetic.lean`). PR #17587's
+  body explicitly notes this import is "not transitively imported via
+  Sylow chain"; verified locally that it transitively pulls
+  `Mathlib.Algebra.BigOperators.Finprod` (for `finsum_eq_sum_of_fintype`,
+  `finsum_congr`) and `Mathlib.Data.Set.Card` (for `Set.ncard_singleton`,
+  `Set.ncard_union_eq`).
+
+Other Mathlib API used (all stock v4.26.0, all verified against the
+local Mathlib checkout):
+
+* `Set.disjoint_iUnion_right` — `Mathlib.Data.Set.Lattice:1220`.
+* `Set.disjoint_left` — `Mathlib.Data.Set.Disjoint:41`.
+* `Set.ncard_union_eq` — `Mathlib.Data.Set.Card:966`.
+* `Set.ncard_singleton` — `Mathlib.Data.Set.Card:656`.
+* `Set.finite_singleton` / `Set.toFinite` — `Mathlib.Data.Set.Card`
+  area; transitively imported.
+* `Set.ncard_iUnion_of_finite` — `Mathlib.Data.Set.Card.Arithmetic:114`,
+  signature `[Finite ι] {s : ι → Set α} (hs : ∀ i, (s i).Finite)
+  (h : Pairwise (Disjoint on s)) : (⋃ i, s i).ncard = ∑ᶠ i, (s i).ncard`.
+* `finsum_congr` — `Mathlib.Algebra.BigOperators.Finprod`.
+* `finsum_eq_sum_of_fintype` — same module, line 432 (it is the additive
+  version of `finprod_eq_prod_of_fintype` via `@[to_additive]`).
+* `Finset.sum_const` — `Mathlib.Algebra.BigOperators.Basic`, transitively
+  imported.
+* `Finset.card_univ` — same, transitively imported.
+* `Nat.card_eq_fintype_card` — `Mathlib.Data.Finite.Card`, transitively
+  imported.
+* `Fintype.ofFinite` — `Mathlib.Data.Fintype.Basic`, transitively
+  imported; `noncomputable` upgrade from `Finite` to `Fintype`.
+
+The `Finite (Sylow 3 G)` instance is auto-derived by Lean's typeclass
+synthesis from `[Finite G]` (existing code at line ~1305 already uses
+`card_sylow_modEq_one 3 G` without explicit `[Finite (Sylow 3 G)]`,
+which requires the same instance — chain via
+`Sylow extends Subgroup G` + `Subtype.finite`-style synthesis).
+
+### Next iteration (S24)
+
+After this PR lands AND #17586 + #17587 land, the S10 closure of
+`sylow_two_unique_when_n3_four` becomes the mechanical ~5-line
+composition shown in the docstring above. Estimated total ~5 lines.
+
+If S24 occurs before #17586 + #17587 land, alternatives:
+1. **Strengthen S15** — refactor `cube_id_set_eq_disjoint_union`'s
+   docstring to record the partition's full content for downstream
+   readers; pure docs, no behavior change. Low-leverage.
+2. **`burnside_pq` dispatch update** — independent of the S10 closure:
+   refactor `burnside_pq_nontrivial` axiom's hypothesis from
+   `2 ≤ a ∨ 2 ≤ b` to `2 ≤ a ∧ 2 ≤ b` once S10 / S11 / S12 close
+   their respective sub-cases. This is the "S18" task per the
+   pre-S22 next-action plan; arguably should land *before* S10
+   closes (decoupling axiom-narrowing from the S10 ingredient
+   chain). High-leverage but requires careful coordination with
+   the dispatch path.
+
+---
+
+## S22 (researcher-11, 2026-05-12, merged via #17880)
 
 Cardinality bridge step (Step 2 of S22-next per the S21 spec), one
 new private lemma plus one composition corollary, both axiom-free,

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1649,
+    "lineCount": 1761,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -133,7 +133,7 @@
       "g_pow_three_iff_mem_some_sylow_three (Iteration 14, private, axiom-free): pointwise membership characterization for the S10 element-counting closure. For finite G with |G| = 12, an element satisfies g^3 = 1 iff it lies in some Sylow 3-subgroup. Forward via Subgroup.zpowers g being a 3-subgroup (Nat.card_zpowers + IsPGroup.of_card with n ∈ {0, 1}) and IsPGroup.exists_le_sylow. Backward via pow_card_eq_one' applied inside (Q : Subgroup G) with |Q| = 3 (S13's sylow_three_card_eq_three_of_card_twelve) plus Subgroup.coe_pow / Subgroup.coe_one to push ↑Q ↑1 = 1 back to G. FIRST of five named ingredients planned in session-13-s10-element-count-spec.md §1 for the S10 closure of sylow_two_unique_when_n3_four; the four-Sylow-3 hypothesis is not used here, only the cardinality |G| = 12 (which gives |Q| = 3 for any Q : Sylow 3 G)."
     ],
     "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7/9/11): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited. Iteration 7 (S7), 7.5, and 9 progressively cover the three sub-cases of the `(a, b) = (2, 1)` shape: S7 proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`; S7.5 covers `p < q` with `(p, q) ≠ (2, 3)`; S9 covers the exceptional `(p, q) = (2, 3), |G| = 12` (modulo a single isolated sorry deferred to S10 — the `sylow_two_unique_when_n3_four` element-counting lemma). Iteration 11 (S11) mirrors this trio for the symmetric `(a, b) = (1, 2)` shape: `burnside_p_q_squared_p_lt_q` (mirror of S7), `burnside_p_q_squared_q_lt_p` excluding `(p, q) = (3, 2)` (mirror of S7.5), and `burnside_p_q_squared_twelve_mirror` reusing S9 for `|G| = 12 = 3 · 2²`. After S10 closes the deferred sorry and S12 updates the `burnside_pq` dispatch, `burnside_pq_nontrivial` will be required only for shapes with `2 ≤ a ∧ 2 ≤ b` (orders divisible by `p²` AND `q²` for distinct primes); a full proof of that residual axiom would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route — character theory + algebraic integers à la Burnside 1904, or transfer + focal subgroup à la Goldschmidt-Matsuyama 1970s).",
-    "theoremCount": 35,
+    "theoremCount": 36,
     "definitionCount": 0
 },
   "overview": {
@@ -271,9 +271,9 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1649,
+    "lineCount": 1761,
     "axiomCount": 1,
-    "theoremCount": 35,
+    "theoremCount": 36,
     "substantiveTheoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -30,7 +30,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-09T03:00:00.000Z",
-    "iteration": 15,
+    "iteration": 23,
     "focus": "S9 (researcher-10, 2026-05-08): **|G| = 12 partial Lean implementation**. S7 (PR #17114), S7.5 (PR #17155), and S8 spec (PR #17180) merged. This iteration implements the bulk of the S8 spec axiom-free, with one isolated sorry deferred to S10. Added in proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean (738→876 lines, +1 main theorem, +2 private lemmas, sorries 0→1, axiomCount 1 unchanged): (1) sylow_count_dvd_four_modEq_one_three (private, axiom-free, ~12 lines): n ≥ 1 ∧ n ∣ 4 ∧ n ≡ 1 [MOD 3] → n ∈ {1, 4} via interval_cases. (2) sylow_two_unique_when_n3_four (private, sorry'd for S10, ~7 lines): the element-counting cardinality lemma, proof outline in docstring. (3) burnside_p_squared_q_twelve (axiom-free modulo above, ~55 lines): main theorem for the exceptional (p,q)=(2,3), |G|=12 case. The n_3 = 1 branch is fully discharged via burnside_pq_with_normal_qSylow; the n_3 = 4 branch reduces to Subsingleton (Sylow 2 G) via the S10 lemma, then discharges via burnside_pq_with_normal_pSylow. Code follows S7.5 idioms verbatim (factorization-of-cardinality, Sylow.card_eq_multiplicity, Subgroup.card_mul_index, Sylow.normal_of_subsingleton chain). Build status: not verified locally (proofs/.lake symlink trap; ~45-min cold-cache builds). Risk-equivalent to merged-but-build-pending S7.5. After S10 closes the sorry, burnside_pq dispatch can peel off (a,b)=(2,1) axiom-free; with symmetric (1,2) shape (S11), burnside_pq_nontrivial narrows to require 2 ≤ a ∧ 2 ≤ b.",
     "blockers": [
       "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama). Note: Mathlib has `Mathlib.GroupTheory.Focal` (focal subgroup definition + transfer to focal quotient), so partial scaffolding exists for the character-free route.",
@@ -38,7 +38,7 @@
     ],
     "nextAction": "S10: close `sylow_two_unique_when_n3_four`'s sorry via element counting (~80-120 lines). Pairwise trivial intersection of distinct prime-order Sylow 3-subgroups, partition `{g | g^3 = 1} = {e} ⊔ ⊔ᵢ (Q_i \\ {e})` of cardinality 9, residue 3 = `|P| − 1` for any Sylow 2-subgroup `P` pinning P uniquely. Mathlib API to verify: `Set.ncard_biUnion`/`Finset.card_disjUnion`, `Subgroup.disjoint_iff_inf_eq_bot`, `Subgroup.eq_bot_of_card_le_one`, `Sylow.ext`. Then post-S10: update `burnside_pq` dispatch to peel off `(a,b)=(2,1)` axiom-free. Then S11: symmetric `(1,2)` shape (~250 lines mirroring S7/S7.5/S9). Then S12: peel off `(1,2)` from dispatch. Then S13: |G|=p²q² Sylow analysis. Then S14+: Goldschmidt-Matsuyama via `Mathlib.GroupTheory.Focal`.",
     "attemptCounts": {
-      "total": 9,
+      "total": 10,
       "currentApproach": 1,
       "approachesTried": 1
     }


### PR DESCRIPTION
## Summary

One new private axiom-free lemma `cube_id_card_eq_nine_of_partition_ingredients` in `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`, closing **Step 1 of the S22 "Next iteration (S23)" plan** (per S22's docstring + state.md, researcher-11, PR #17880, merged this morning).

Composes the **partition ingredients** as hypotheses with S15's set decomposition (`cube_id_set_eq_disjoint_union`, merged via #17555) and the Mathlib disjoint-iUnion arithmetic to derive the cube-identity element count

```
Set.ncard {g : G | g ^ 3 = 1} = 9
```

— the S16 target that the in-flight PRs **#17586** (`sylow_three_diff_singleton_disjoint`) + **#17587** (`sylow_three_set_diff_one_ncard_eq_two`) build toward. Both ingredients are taken here as hypotheses, so the composition itself lands axiom-free **without waiting on the S16 PRs to merge** (those have been open ~3.7 days without merging).

## With S23 in hand, S10 closure is mechanical

Once #17586 + #17587 land (and the new ingredient-derivation lemmas are available on `origin/main`), closing `sylow_two_unique_when_n3_four`'s lone sorry reduces to the ~5-line composition shown in the lemma's docstring:

```lean
intro hcard hn3
haveI : Fact (Nat.Prime 3) := ⟨by decide⟩
let hdisj := fun Q Q' hne =>
  sylow_three_diff_singleton_disjoint hcard hne        -- in-flight #17586
let hfiber := sylow_three_set_diff_one_ncard_eq_two hcard  -- in-flight #17587
have h9 := cube_id_card_eq_nine_of_partition_ingredients
              hcard hdisj hfiber hn3
exact sylow_two_subsingleton_of_cube_id_card_nine hcard h9
```

Mirrors the established S20/S21/S22 conditional-lemma pattern on this slug.

## Proof shape

```lean
private lemma cube_id_card_eq_nine_of_partition_ingredients
    {G : Type*} [Group G] [Finite G] [Fact (Nat.Prime 3)]
    (hcard : Nat.card G = 12)
    (hdisj : ∀ Q Q' : Sylow 3 G, Q ≠ Q' →
             Disjoint ((Q : Set G) \ ({1} : Set G))
                      ((Q' : Set G) \ ({1} : Set G)))
    (hfiber : ∀ Q : Sylow 3 G,
              Set.ncard ((Q : Set G) \ ({1} : Set G)) = 2)
    (hn3 : Nat.card (Sylow 3 G) = 4) :
    Set.ncard {g : G | g ^ 3 = 1} = 9 := by
  rw [cube_id_set_eq_disjoint_union hcard]                       -- Step 1: S15
  -- ncard ({1} ∪ ⋃ Q, Q \ {1}) = 9
  have h_disj : Disjoint ({1} : Set G) _ := by                   -- Step 2
    rw [Set.disjoint_iUnion_right]; intro Q
    refine Set.disjoint_left.mpr ?_
    intro g hg hg'; rw [Set.mem_singleton_iff] at hg
    exact hg'.2 hg
  rw [Set.ncard_union_eq h_disj _ _, Set.ncard_singleton]        -- Step 3
  -- 1 + ncard (⋃ Q, Q \ {1}) = 9
  have hfin : ∀ Q : Sylow 3 G, _ := fun _ => Set.toFinite _
  have hdisj_pairwise : Pairwise (Disjoint on _) :=
    fun _ _ hne => hdisj _ _ hne
  rw [Set.ncard_iUnion_of_finite hfin hdisj_pairwise]            -- Step 4
  -- 1 + (∑ᶠ Q, ncard (Q \ {1})) = 9
  rw [finsum_congr (fun Q => hfiber Q)]                          -- Step 5
  -- 1 + (∑ᶠ Q, 2) = 9
  haveI : Fintype (Sylow 3 G) := Fintype.ofFinite _
  rw [finsum_eq_sum_of_fintype, Finset.sum_const, Finset.card_univ,
      ← Nat.card_eq_fintype_card, hn3]                            -- Step 6
  -- 1 + 4 • 2 = 9
  decide
```

## Counts

| Field | Before | After | Delta |
|---|---|---|---|
| `lineCount` | 1649 | 1761 | +112 (~65 docstring + ~45 proof body + 1 import + ~1 blank line) |
| `theoremCount` | 35 | 36 | +1 private lemma |
| `substantiveTheoremCount` | 18 | 18 | unchanged |
| `axiomCount` | 1 | 1 | unchanged |
| `sorries` | 1 | 1 | unchanged — S10 placeholder remains |

`meta.json` synced in both top-level `meta` block and the `leanFile` block. `state.md` prepended with S23 entry. New session note `session-23-cube-id-card-eq-nine-of-partition.md` documents the full Mathlib API surface + per-lemma module/line cross-reference. Problem JSON iteration 15 → 23, attemptCounts.total 9 → 10.

## Mathlib API surface

One **new import**: `Mathlib.Data.Set.Card.Arithmetic` (for `Set.ncard_iUnion_of_finite`). PR #17587's body explicitly flagged this same import for the in-flight S16 chain — not transitively imported via Sylow.

All other API stock v4.26.0, verified line-by-line against `/Users/rwalters/GitHub/mathlib4` (main checkout):

| API | Module | Line |
|---|---|---|
| `Set.disjoint_iUnion_right` | `Data.Set.Lattice` | 1220 |
| `Set.disjoint_left` | `Data.Set.Disjoint` | 41 |
| `Set.ncard_union_eq` | `Data.Set.Card` | 966 |
| `Set.ncard_singleton` | `Data.Set.Card` | 656 |
| `Set.ncard_iUnion_of_finite` | `Data.Set.Card.Arithmetic` | 114 |
| `finsum_congr` | `Algebra.BigOperators.Finprod` | — |
| `finsum_eq_sum_of_fintype` | `Algebra.BigOperators.Finprod` | 432 (`finprod_*` + `@[to_additive]`) |
| `Finset.sum_const` / `Finset.card_univ` | `Algebra.BigOperators.Basic` | — |
| `Nat.card_eq_fintype_card` | `Data.Finite.Card` | — |
| `Fintype.ofFinite` | `Data.Fintype.Basic` | — |

## Strategic non-overlap with in-flight PRs

* **#17586** (S16 Sylow-3 set-level pairwise disjointness, open since 2026-05-09): targets the *atomic disjointness* lemma `sylow_three_diff_singleton_disjoint`. S23 takes this as the `hdisj` hypothesis and converts internally to the `Pairwise (Disjoint on _)` form. No content overlap.
* **#17587** (S16 Sylow-3 per-fiber count, open since 2026-05-09): targets `sylow_three_set_diff_one_ncard_eq_two`. S23 takes this as the `hfiber` hypothesis. No content overlap.
* **#17685** (S19 Sylow-2-side ingredient 4 forward subset, open since 2026-05-12): operates on the Sylow-2 side; S23 operates entirely on the Sylow-3 side + cube-id set. Independent.
* **#17528** (stale S14 PR, predates merged S14 via #17536): unrelated.

Pre-claim probe at 2026-05-12T18:22:16Z and pre-push probe at 2026-05-12T18:29:17Z: no S23 PR exists. No parallel work for `cube_id_card_eq_nine` composition.

## Build status

**[BUILD UNVERIFIED]** Worktree's `proofs/.lake` is a recursive self-symlink (memory `feedback_researcher_lake_symlink_broken`). Local Docker builds re-fresh-clone Mathlib (~30–45 min cold).

Risk profile: bounded by the new import + the disjoint-iUnion arithmetic chain. Likely failure modes (and mitigations):

1. `Finite (Sylow 3 G)` synthesis failure — would also break existing `card_sylow_modEq_one 3 G` calls at lines ~1305+ of this file, so any breakage is shared with the rest of the |G|=12 chain (S9–S22).
2. `Set.ncard_iUnion_of_finite` signature drift — fixed by matching the new signature; the disjointness hypothesis form (`Pairwise (Disjoint on _)`) is the most likely point of drift.
3. `Pairwise` defeq mismatch — pre-mitigated via explicit `fun _ _ hne => hdisj _ _ hne` conversion (Step 4 above).

## Test plan

- [ ] CI Docker build reaches end without new errors
- [ ] No new `sorry`/`axiom` declarations introduced (sorries still 1, axiomCount still 1)
- [x] meta.json `lineCount`/`theoremCount` match the post-S23 file state (1761/36 in both top-level and `leanFile` blocks)
- [x] state.md updated: phase ACT, iteration 23, last-updated 2026-05-12 (researcher-8)
- [x] session-23 note tracks full proof outline + Mathlib API cross-reference + parallel-effort risk
- [x] no `loom:review-requested` label (per CLAUDE.md math-agent policy — deployer auto-merges build-pending math PRs)

🤖 Generated by researcher-8 (Claude Opus 4.7)