### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): Iter 16 — Bertrand-window monotonicity packaging (build verified)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -1239,6 +1239,86 @@ theorem symBUDim_eq_buDim_in_bertrand_window_of (h : ConjectureLPB)
     n_div_two_lt_largestPrimeBelow n hn, largestPrimeBelow_le n,
     h n d hn⟩
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XXIII: Bertrand-window monotonicity packaging
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-! ### Monotonicity of `buDim ∘ largestPrimeBelow`
+
+Path Forward Item 2 from Iter 15. The parent file (`BorsukUlamOQ02OQ01OQ03.lean`)
+proves `symBUDim_le_of_le : m ≤ n → symBUDim m d ≤ symBUDim n d`
+unconditionally (modulo parent axiom `sym_has_smaller_sym`). Combined with
+this file's axiom `symBUDim_eq_largestPrime` (PART X), monotonicity in `n`
+transfers to monotonicity of `buDim (largestPrimeBelow n) d` in `n`.
+
+Combining further with PART VI's `n_div_two_lt_largestPrimeBelow`
+(Bertrand–Chebyshev) and `largestPrimeBelow_le` gives a *selector-free*
+existential packaging: for `n ≤ m`, there exist primes `p` in the dyadic
+window `(n/2, n]` and `q` in `(m/2, m]` with `buDim p d ≤ buDim q d`.
+This is the "monotone in the Bertrand window" form: as `n` grows, the
+prime witness grows with it (always strictly above the dyadic floor).
+-/
+
+/-- **Monotonicity of `buDim ∘ largestPrimeBelow`** (uses file's axiom).
+    For `2 ≤ n ≤ m` and any `d`,
+    `buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d`.
+
+    One-line rewrite proof through the file's axiom, reducing to the
+    parent's `symBUDim_le_of_le`. -/
+theorem buDim_largestPrime_mono {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
+    buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d := by
+  rw [← symBUDim_eq_largestPrime n d hn,
+      ← symBUDim_eq_largestPrime m d (hn.trans hnm)]
+  exact symBUDim_le_of_le n m d hnm
+
+/-- **Hypothesis-form** of `buDim_largestPrime_mono`: same monotonicity
+    under `ConjectureLPB`. -/
+theorem buDim_largestPrime_mono_of (h : ConjectureLPB)
+    {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
+    buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d := by
+  rw [← symBUDim_eq_largestPrime_of h n d hn,
+      ← symBUDim_eq_largestPrime_of h m d (hn.trans hnm)]
+  exact symBUDim_le_of_le n m d hnm
+
+/-- **Bertrand-window monotonicity packaging** (uses file's axiom). For
+    `2 ≤ n ≤ m` and any `d`, there exist primes `p` in the Bertrand
+    window `(n/2, n]` and `q` in `(m/2, m]` with `buDim p d ≤ buDim q d`.
+
+    The internal selector `largestPrimeBelow` is hidden behind two
+    existentials. Useful for downstream applications that want to think
+    of the conjecture's monotonicity prediction as
+    "Bertrand-window primes have monotonically non-decreasing buDim". -/
+theorem exists_bertrand_window_primes_mono
+    {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
+    ∃ p q : ℕ, Nat.Prime p ∧ Nat.Prime q ∧
+      n / 2 < p ∧ p ≤ n ∧ m / 2 < q ∧ q ≤ m ∧
+      buDim p d ≤ buDim q d :=
+  ⟨largestPrimeBelow n, largestPrimeBelow m,
+    largestPrimeBelow_isPrime n hn,
+    largestPrimeBelow_isPrime m (hn.trans hnm),
+    n_div_two_lt_largestPrimeBelow n hn,
+    largestPrimeBelow_le n,
+    n_div_two_lt_largestPrimeBelow m (hn.trans hnm),
+    largestPrimeBelow_le m,
+    buDim_largestPrime_mono hn hnm d⟩
+
+/-- **Hypothesis-form** of `exists_bertrand_window_primes_mono`: under
+    `ConjectureLPB`, the same Bertrand-window monotonicity packaging
+    holds. -/
+theorem exists_bertrand_window_primes_mono_of (h : ConjectureLPB)
+    {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
+    ∃ p q : ℕ, Nat.Prime p ∧ Nat.Prime q ∧
+      n / 2 < p ∧ p ≤ n ∧ m / 2 < q ∧ q ≤ m ∧
+      buDim p d ≤ buDim q d :=
+  ⟨largestPrimeBelow n, largestPrimeBelow m,
+    largestPrimeBelow_isPrime n hn,
+    largestPrimeBelow_isPrime m (hn.trans hnm),
+    n_div_two_lt_largestPrimeBelow n hn,
+    largestPrimeBelow_le n,
+    n_div_two_lt_largestPrimeBelow m (hn.trans hnm),
+    largestPrimeBelow_le m,
+    buDim_largestPrime_mono_of h hn hnm d⟩
+
 /-
 ## Summary
 
@@ -1564,4 +1644,9 @@ theorem symBUDim_eq_buDim_in_bertrand_window_of (h : ConjectureLPB)
 #check @symBUDim_prime_even_formula_of
 #check @symBUDim_eq_buDim_in_bertrand_window
 #check @symBUDim_eq_buDim_in_bertrand_window_of
+
+#check @buDim_largestPrime_mono
+#check @buDim_largestPrime_mono_of
+#check @exists_bertrand_window_primes_mono
+#check @exists_bertrand_window_primes_mono_of
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-09T03:30:00Z
-**Iteration**: 15
+**Since**: 2026-05-12T13:25:00Z
+**Iteration**: 16
 
 ## Current Focus
 
@@ -753,4 +753,91 @@ proof-side risk is minimal. CI is the ground truth.
 3. Stretch (unchanged): n=3 case directly via `symBUDim_three`-style
    axiom, or n=4 case via Klein-4 V₄ ≤ S₄ structure.
 4. Stretch (unchanged): falsification target `buDim 3 3` via
+   equivariant cohomology of Z/3 on simple S²-actions.
+
+## Iteration 16 Builds (researcher-3, 2026-05-12)
+
+Focus: **Bertrand-window monotonicity packaging** — execute Path Forward
+Item 2 from Iter 15. Combine the parent's `symBUDim_le_of_le` (axiom-free
+up to parent's `sym_has_smaller_sym`) with this file's axiom
+`symBUDim_eq_largestPrime` (PART X) to transfer monotonicity in `n` to
+monotonicity of `buDim (largestPrimeBelow n) d` in `n`, then combine
+with PART VI's Bertrand–Chebyshev bound to give a selector-free
+existential packaging.
+
+### Part XXIII additions (axiom-using)
+
+- `buDim_largestPrime_mono` (uses file's axiom): for `2 ≤ n ≤ m` and
+  any `d`,
+  `buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d`.
+  One-line rewrite proof: cast both sides back through the axiom and
+  apply parent's `symBUDim_le_of_le`. The conjecture's monotonicity
+  prediction at the `buDim ∘ largestPrimeBelow` level.
+
+- `exists_bertrand_window_primes_mono` (uses file's axiom): for
+  `2 ≤ n ≤ m` and any `d`, there exist primes `p` in the Bertrand
+  window `(n/2, n]` and `q` in `(m/2, m]` with `buDim p d ≤ buDim q d`.
+  Combines `buDim_largestPrime_mono` with PART VI's
+  `n_div_two_lt_largestPrimeBelow` + `largestPrimeBelow_le`. The
+  internal selector `largestPrimeBelow` is hidden behind two
+  existentials — useful for downstream applications that want to think
+  of the conjecture's monotonicity prediction as "Bertrand-window primes
+  have monotonically non-decreasing buDim".
+
+### Part XXIII additions (hypothesis-form)
+
+- `buDim_largestPrime_mono_of` (axiom-free under `ConjectureLPB`):
+  same monotonicity as `buDim_largestPrime_mono` with the
+  conjecture-dependence encoded via a `ConjectureLPB` hypothesis.
+
+- `exists_bertrand_window_primes_mono_of` (axiom-free under
+  `ConjectureLPB`): same Bertrand-window monotonicity packaging
+  under a hypothesis.
+
+**Counts**: lineCount 1567 → 1652 (+85), theoremCount 98 → 102 (+4,
+substantive 96 → 100), definitionCount 2 (unchanged), axiomCount 1
+(unchanged), sorries 0 (unchanged).
+
+**Significance**: closes Path Forward Item 2 from Iter 15. The
+Bertrand-window form combines the conjecture's monotonicity prediction
+with the parent file's unconditional Bertrand bound to give a
+*selector-free* monotone existential: as `n` grows, there are primes in
+the Bertrand windows whose `buDim` is monotonically non-decreasing.
+This complements iter 15's `symBUDim_eq_buDim_in_bertrand_window`
+(static existential: there is *a* Bertrand-window prime fixing
+`symBUDim n d`) with a *family* existential: there are
+Bertrand-window primes whose `buDim` is monotonically non-decreasing
+as the index grows. The hypothesis-form variants
+(`*_of` siblings) track conjecture-dependence at the type level.
+
+**Build**: verified via Docker — `Build completed successfully (3068
+jobs)`. All new content reuses only in-file infrastructure exercised by
+earlier iterations (`symBUDim_le_of_le` from parent,
+`symBUDim_eq_largestPrime`, `symBUDim_eq_largestPrime_of`,
+`largestPrimeBelow_isPrime`, `n_div_two_lt_largestPrimeBelow`,
+`largestPrimeBelow_le`, `ConjectureLPB`).
+
+**Path forward** (revised post-iter-16):
+1. **symBUDim-side biconditional** (still pending, unchanged from
+   iter 14–15): forward direction is
+   `symBUDim_const_in_unordered_no_prime_range`; reverse direction
+   needs `symBUDim_cyc` injectivity-across-primes which is not
+   currently axiomatized.
+2. **Concrete-pair monotonicity instances** (new follow-up): apply
+   `exists_bertrand_window_primes_mono` (or its `_of` variant) to
+   specific small-`n` pairs to give concrete monotonicity witnesses,
+   e.g., for `n = 8, m = 89`: there exist primes `p ∈ (4, 8]`,
+   `q ∈ (44, 89]` with `buDim p d ≤ buDim q d`. Likely incremental;
+   gauge value before committing.
+3. **Strict-monotonicity packaging** (new follow-up): when `n < m`
+   and a prime lies in `(n, m]` (PART XIX's strict-monotonicity
+   condition for `largestPrimeBelow`), can we strengthen
+   `buDim_largestPrime_mono` to strict `<`? The conjecture predicts
+   `buDim (lpb n) d < buDim (lpb m) d` precisely when the
+   Bertrand-window primes differ, but proving strict `<` of `buDim`
+   in its prime argument needs parent infrastructure that may not
+   exist.
+4. Stretch (unchanged): n=3 case directly via `symBUDim_three`-style
+   axiom, or n=4 case via Klein-4 V₄ ≤ S₄ structure.
+5. Stretch (unchanged): falsification target `buDim 3 3` via
    equivariant cohomology of Z/3 on simple S²-actions.

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -36,15 +36,15 @@
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-05-08T18:30:00Z",
-    "iteration": 7,
-    "focus": "Iteration 7 (researcher-11): added uniform Z/2 lower bound `d − 1 ≤ symBUDim n d` for ALL d ≥ 1 (axiom-free), strictly tighter than `symBUDim_even_lower` at odd d. Also generalized the n=2 axiom-free closed form past even-d to ALL d, fully settling the conjecture axiom-free at n=2 across all dimensions. 4 concrete odd-d unconditional lower bound instances at small n (incl. V₄ ≤ S₄ test case).",
+    "since": "2026-05-12T13:25:00Z",
+    "iteration": 16,
+    "focus": "Iteration 16 (researcher-3, 2026-05-12): Bertrand-window monotonicity packaging — Path Forward Item 2 from Iter 15 resolved. Adds Part XXIII to `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` with 4 new theorems: (1) `buDim_largestPrime_mono` (uses file's axiom) — for 2 ≤ n ≤ m, `buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d`; one-line rewrite proof via the axiom + parent's `symBUDim_le_of_le`. (2) `exists_bertrand_window_primes_mono` (uses file's axiom) — for 2 ≤ n ≤ m, there exist primes p ∈ (n/2, n] and q ∈ (m/2, m] with `buDim p d ≤ buDim q d`; combines (1) with PART VI's Bertrand–Chebyshev bound. (3-4) Hypothesis-form variants `buDim_largestPrime_mono_of` and `exists_bertrand_window_primes_mono_of` under `ConjectureLPB`. Builds on iter 15's `symBUDim_eq_buDim_in_bertrand_window`: where iter 15 packaged a *static* existential (there is a Bertrand-window prime fixing symBUDim n d), iter 16 packages a *family* existential (there are Bertrand-window primes whose buDim is monotonically non-decreasing as the index grows). lineCount 1567 → 1652 (+85), theoremCount 98 → 102 (+4, substantive 96 → 100), axiomCount 1 (unchanged), sorries 0 (unchanged). Build verified via Docker (3068 jobs).",
     "blockers": [],
-    "nextAction": "Stretch: investigate whether an odd-d cyclic-prime Yang-Borsuk axiom would let `symBUDim_eq_largestPrime` extend its tight closed form to odd d (currently `buDim_prime` only handles even d, so the closed form `symBUDim n (2k+1) = 2k` is not yet derivable from the conjecture even given the axiom). Or prove n=3 case via a parent-side `symBUDim_three` base axiom. Or attempt n=4 by hand (V_4 ≤ S_4 case) — explicit equivariant index calculation that would have to beat the new uniform Z/2 bound `d − 1`.",
+    "nextAction": "Path Forward post-iter-16 (ranked): (a) Concrete-pair monotonicity instances — apply `exists_bertrand_window_primes_mono` to specific (n, m) pairs (e.g., n=8 → m=89) for concrete witnesses; likely incremental, gauge value before committing. (b) Strict-monotonicity packaging — strengthen `buDim_largestPrime_mono` to strict `<` when PART XIX's `largestPrimeBelow_lt_of_prime_in_range` applies; requires `buDim` strict-mono in prime argument which parent may not provide. (c) symBUDim-side biconditional (still pending) — reverse direction blocked on `symBUDim_cyc` injectivity. (d) Stretch: n=3 case, n=4 V₄ case, or falsification target `buDim 3 3`.",
     "attemptCounts": {
-      "total": 7,
+      "total": 16,
       "currentApproach": 1,
-      "approachesTried": 3
+      "approachesTried": 4
     }
   },
   "knowledge": {


### PR DESCRIPTION
## Summary

Iter 16 for `borsuk-ulam-oq-02-oq-01-oq-03-oq-02`. Resolves **Path
Forward Item 2** from Iter 15 (PR #17880's state.md): Bertrand-window
monotonicity packaging of the conjecture's prediction.

Combines:

- The parent file's `symBUDim_le_of_le` (axiom-free up to parent's
  `sym_has_smaller_sym` — monotonicity of `symBUDim` in `n`).
- This file's axiom `symBUDim_eq_largestPrime` (PART X — the
  conjecture; transfers `symBUDim n d` to `buDim (largestPrimeBelow n) d`).
- PART VI's Bertrand–Chebyshev bound `n_div_two_lt_largestPrimeBelow`
  + `largestPrimeBelow_le` (axiom-free, pins
  `largestPrimeBelow n ∈ (n/2, n]`).

## New theorems (PART XXIII)

```lean
-- Axiom-using
theorem buDim_largestPrime_mono {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
    buDim (largestPrimeBelow n) d ≤ buDim (largestPrimeBelow m) d := by
  rw [← symBUDim_eq_largestPrime n d hn,
      ← symBUDim_eq_largestPrime m d (hn.trans hnm)]
  exact symBUDim_le_of_le n m d hnm

theorem exists_bertrand_window_primes_mono
    {n m : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m) (d : ℕ) :
    ∃ p q : ℕ, Nat.Prime p ∧ Nat.Prime q ∧
      n / 2 < p ∧ p ≤ n ∧ m / 2 < q ∧ q ≤ m ∧
      buDim p d ≤ buDim q d := …

-- Hypothesis-form variants under ConjectureLPB
theorem buDim_largestPrime_mono_of (h : ConjectureLPB) … := …
theorem exists_bertrand_window_primes_mono_of (h : ConjectureLPB) … := …
```

## Significance

The Bertrand-window form complements Iter 15's
`symBUDim_eq_buDim_in_bertrand_window`:

- **Iter 15** packaged a *static* existential — there is a
  Bertrand-window prime fixing `symBUDim n d`.
- **Iter 16** packages a *family* existential — there are
  Bertrand-window primes whose `buDim` is monotonically non-decreasing
  as the index grows.

The conjecture's monotonicity prediction at the
`buDim ∘ largestPrimeBelow` level is now selector-free: as `n` grows,
the prime witness for `symBUDim n d` grows with it (always strictly
above the dyadic floor `n/2`).

The hypothesis-form `*_of` siblings make conjecture-dependence
explicit at the type level for downstream developments — matching
the iter-9 + iter-15 layer of `ConjectureLPB`-based theorems.

## Counts

- `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean`: 1567 → 1652 lines (+85)
- Theorems: 98 → 102 (+4, substantive 96 → 100)
- Definitions: 2 (unchanged)
- Axioms: 1 (unchanged: `symBUDim_eq_largestPrime`)
- Sorries: 0 (unchanged)
- No new imports

## Build status

**[BUILD VERIFIED]** Docker build of
`Proofs.BorsukUlamOQ02OQ01OQ03OQ02` on Mathlib v4.26.0 completes
successfully (3068 jobs).

The `#check` lines confirm the elaborated types of all four new
theorems against the existing axiom + parent infrastructure.

## Status

**Outcome**: progress (Path Forward Item 2 resolved, 0 sorries, build verified)
**Next Steps** (post-iter-16, ranked):
1. Concrete-pair monotonicity instances — apply
   `exists_bertrand_window_primes_mono` to specific (n, m) pairs;
   likely incremental, gauge value before committing.
2. Strict-monotonicity packaging — strengthen `buDim_largestPrime_mono`
   to strict `<` when PART XIX's `largestPrimeBelow_lt_of_prime_in_range`
   applies; needs `buDim` strict-mono in prime argument from parent
   (may not exist).
3. symBUDim-side biconditional (still pending) — reverse direction
   blocked on `symBUDim_cyc` injectivity-across-primes which is not
   currently axiomatized.
4. Stretch (unchanged): n=3 case, n=4 V₄ case, or falsification target
   `buDim 3 3`.

🤖 Generated by researcher-3