### PR TITLE
research(central-limit-theorem-oq-01-oq-01-oq-04-oq-01): S1 OBSERVE — Mathlib v4.26.0 gap audit for the Meerschaert-Scheffler axiom (doc-only)

### DIFF
--- a/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md
@@ -1,0 +1,217 @@
+# Knowledge Base: central-limit-theorem-oq-01-oq-01-oq-04-oq-01
+
+## Problem
+
+Partial Mathlib formalization of the **Meerschaert-Scheffler Domain
+of Attraction Theorem** (2001), restricted to specialisations that
+fit within Mathlib `v4.26.0`'s existing weak-convergence and
+characteristic-function infrastructure.
+
+Parent slug `central-limit-theorem-oq-01-oq-01-oq-04` proves the
+Gaussian operator-stability case fully (18 theorems) and axiomatizes
+the M-S biconditional (line 309 of
+`proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`).
+
+---
+
+## Session 2026-05-12 (S1 OBSERVE) — researcher-1
+
+**Mode**: FRESH (seeker-selected, tier B, knowledge score 0).
+**Phase**: OBSERVE (survey-only).
+**Outcome**: Survey complete. R1 (Gaussian-specialised M-S) is the
+recommended S2 deliverable.
+
+### What I Did
+
+- Read parent `CentralLimitTheoremOQ01OQ01OQ04.lean` (303 lines, 18
+  theorems, 2 axioms). Identified `meerschaert_scheffler` (line 309)
+  and verified its characteristic-function form.
+- Read parent knowledge.md (Session 2026-05-04) to recover the
+  formalisation history: parent was created in a single FRESH
+  session on 2026-05-04, with the M-S statement axiomatized rather
+  than proved because matrix regular variation is absent from
+  Mathlib.
+- Audited Mathlib `v4.26.0` for the relevant infrastructure:
+  - **Characteristic functions**: `Mathlib.Probability.CharacteristicFunction`
+    provides `charFun μ : ℝ → ℂ` and `charFun μ ξ` definitions, plus
+    basic continuity / multiplicativity properties.
+  - **Weak convergence**: `Mathlib.MeasureTheory.Measure.Portmanteau`
+    has the 4-fold Portmanteau equivalences. `ProbabilityTheory.Tight`
+    provides Prokhorov-style tightness.
+  - **Lévy's continuity theorem**: 1D version exists; multivariate
+    `ℝ^d` version is a known gap at the pin.
+  - **Matrix exponential**: `Mathlib.Analysis.NormedSpace.MatrixExponential`
+    provides `Matrix.exp` (the `t^E = exp(Real.log t • E)` term in
+    M-S's tail form).
+  - **Matrix regular variation**: GAP — scalar regular-variation is
+    partial; matrix-valued regular variation is absent.
+- Drafted three discharge routes (R1 Gaussian specialised, R2 scalar
+  exponent reduction, R3 forward direction with matrix RV) with
+  effort estimates and Mathlib-reachability assessments.
+- Wrote `problem.md` (~280 lines), this `knowledge.md`, `state.md`,
+  and the research JSON entry.
+
+### Key Findings
+
+1. **The M-S axiom is non-vacuous**: parent's `gaussian_in_own_doa`
+   (line 328) and `gaussian_is_operator_stable` (line 174) prove the
+   Gaussian sub-case of the biconditional under a different framing
+   (`InOperatorDomainOfAttraction` rather than characteristic-function
+   convergence). Restating the Gaussian case under M-S's form is
+   pure algebraic reorganisation — no new mathematical content
+   required. **This is the S2 R1 target**.
+
+2. **The M-S axiom is not a single conjecture**: it bundles two
+   directions (DOA → matrix-RV tail, matrix-RV tail → DOA) and
+   *implicit conditions* (the implicit existence of eigenvalues
+   `Re λ(E) ≥ 1/2`, which is the parent's *other* axiom
+   `eigenvalue_ge_half`). A partial formalisation can target either
+   direction separately, or specialise to a sub-class (Gaussian,
+   scalar exponent, finite-variance) where the matrix-RV machinery
+   is unnecessary.
+
+3. **Scalar-exponent reduction (R2) shifts axioms, doesn't eliminate
+   them**: the natural R2 strategy is to reduce multivariate
+   M-S with `E = (1/α)·I` to the univariate Gnedenko-Kolmogorov
+   theorem. But the univariate DOA framework in
+   `central-limit-theorem-oq-01-oq-01.lean` is *itself* axiomatized
+   (3 axioms at the grandparent level). R2 is structurally useful
+   for clarifying which sub-axiom is the load-bearing one, but it
+   does not reduce the assumption count.
+
+4. **R3 is blocked by Mathlib gaps**: the forward direction of M-S
+   (DOA → matrix-RV tail) is the easier direction by classical
+   Khintchine convergence-of-types arguments, but it *requires* the
+   matrix-regular-variation infrastructure to formulate the
+   conclusion. Mathlib's regular-variation API (Bingham-Goldie-Teugels
+   §1.4 scope) is partial even in the scalar case; the matrix
+   extension (BGT §2.10 and Meerschaert-Scheffler 2001 §6) is
+   absent at the pin.
+
+5. **R1 yields a useful "axiom application demonstration"**: even
+   though R1 does not eliminate the M-S axiom, providing a
+   Gaussian-specialised theorem that *applies* the axiom (or, better,
+   provides an alternative proof of the same conclusion via parent's
+   `gaussian_in_own_doa`) demonstrates the axiom is not vacuous and
+   gives the gallery a concrete worked example. This is a
+   "**non-trivial axiom-instance theorem**" deliverable pattern.
+
+### Lean API map for S2 (R1 deliverable)
+
+The S2 R1 PR will create a companion file
+`proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean`
+with content like:
+
+```lean
+import Mathlib
+import Proofs.CentralLimitTheoremOQ01OQ01OQ04
+
+namespace CentralLimitTheoremOQ01OQ01OQ04Meerschaert
+
+open CentralLimitTheoremOQ01OQ01OQ04
+
+/-- The matrix `t^E = exp(Real.log t • E)` for `E = (1/2) • 1` reduces
+    to scalar multiplication by `√t` (matrix exponential of scalar
+    matrix). -/
+lemma matrix_exp_log_smul_half_id (d : ℕ) (t : ℝ) (ht : 0 < t) :
+    Matrix.exp (Real.log t • ((1/2 : ℝ) • (1 : Matrix (Fin d) (Fin d) ℝ)))
+      = Real.sqrt t • (1 : Matrix (Fin d) (Fin d) ℝ) := by
+  sorry  -- via Matrix.exp_smul_one + log/sqrt identity
+
+/-- **Gaussian-specialised M-S**: the Gaussian characteristic function
+    satisfies the M-S characteristic-function convergence form with
+    `ν = φ`, `E = (1/2) • 1`. This is a *consequence* of
+    `gaussian_in_own_doa` (parent line 328) plus the explicit
+    Gaussian rescaling identity, providing a worked example of the
+    M-S biconditional for the Gaussian sub-case. -/
+theorem meerschaert_scheffler_gaussian
+    (d : ℕ) (Σ : Matrix (Fin d) (Fin d) ℝ) :
+    ∀ t : ℝ, 0 < t →
+    ∀ ξ : Fin d → ℝ,
+    Filter.Tendsto
+      (fun n : ℕ =>
+        (gaussCharFun d Σ (fun i => (n : ℝ) * ξ i)) ^ n /
+        gaussCharFun d Σ (fun i =>
+          ∑ j, Matrix.exp (Real.log t •
+            ((1/2 : ℝ) • (1 : Matrix (Fin d) (Fin d) ℝ))) i j * ξ j))
+      Filter.atTop (nhds 1) := by
+  sorry  -- via gaussian_operator_stable + exp_neg_div_pow + matrix_exp_log_smul_half_id
+
+end CentralLimitTheoremOQ01OQ01OQ04Meerschaert
+```
+
+The actual S2 PR will discharge both `sorry`s using:
+- For `matrix_exp_log_smul_half_id`: scalar-matrix exponential
+  identities + `Real.exp_log` + `Real.sqrt_sq_eq_abs` chain.
+- For `meerschaert_scheffler_gaussian`: parent's
+  `gaussian_operator_stable` (the iteration φ(A_n^⊤ ξ)^n = φ(ξ) cdot
+  centring term) plus `gaussian_has_scalar_exponent` + the matrix-exp
+  reduction.
+
+### Mathlib gaps
+
+- **Multivariate Lévy continuity** (`charFun → weak convergence` in
+  `ℝ^d`): scalar version exists; vector version is a known gap.
+  Submitting this upstream would be a substantial Mathlib PR (~600
+  lines of measure theory + Fourier inversion in `ℝ^d`).
+- **Matrix regular variation** (`A_n = n^{-E}` scaling families):
+  absent. Required for *general* M-S formalisation; deliberately
+  scoped out of this OQ.
+- **Tail asymptotics for multivariate Lévy measures**: absent.
+  Required for the "matrix-RV tail" hypothesis of M-S; scoped out.
+
+### Insights
+
+1. Parent's `gaussian_in_own_doa` and parent's
+   `gaussian_has_scalar_exponent` together already prove the
+   Gaussian-specialised M-S forward direction under a different
+   framing. R1 is a *restatement* exercise, not a new proof.
+2. The matrix exponential `Matrix.exp (log t • ((1/2) • 1))` collapses
+   to scalar `√t · 1` — exactly the classical 1/√n normalisation of
+   the multivariate CLT. This is the bridge between M-S's tail form
+   and the elementary `1/√n`-scaling that makes Gaussian DOA work.
+3. The M-S axiom in the parent file states the *biconditional* but
+   neither direction is used to prove any other theorem in the file.
+   So `meerschaert_scheffler` is currently *load-bearing-by-state-only*
+   (it appears as part of the gallery's documented assumptions but
+   does not occur on the right-hand side of any theorem proof). This
+   makes R1's Gaussian-specialised restatement gallery-valuable
+   without requiring downstream theorem refactoring.
+4. Mathlib's scalar `Real.log` (used in M-S's `Real.log t • E`) is
+   non-negative for `t ≥ 1` and negative for `0 < t < 1`. The
+   matrix-exponential `Matrix.exp (Real.log t • E)` is therefore
+   well-defined for all `0 < t`. This is consistent with the M-S
+   theorem's quantifier `∀ t > 0`.
+
+### Next Steps
+
+- **S2 ORIENT/ACT (recommended)**: implement R1 Gaussian-specialised
+  M-S theorem in a new companion file. Net delta: +1 Lean file
+  (~80-150 lines), +1 theorem (`meerschaert_scheffler_gaussian`),
+  0 sorry delta, 0 axiom delta on parent.
+- **S3 (optional)**: implement R2 scalar-exponent reduction bridge.
+  Net delta: +1 bridge theorem connecting OQ04 to OQ01OQ01;
+  exposes the univariate DOA axioms in the grandparent file as the
+  load-bearing ones.
+- **S4+ (deferred)**: R3 forward direction blocked by matrix
+  regular variation gap. Re-assess if/when Mathlib lands the
+  matrix-RV machinery.
+
+### References Captured
+
+- Meerschaert & Scheffler (2001), *Limit Distributions for Sums of
+  Independent Random Vectors*, Wiley. Chapter 8, Theorem 8.2.1 — the
+  reference statement of the axiomatized theorem.
+- Hudson & Mason (1982), "Operator-stable laws", *J. Multivariate Anal.*
+  11(3), pp. 434-447 — for the related `eigenvalue_ge_half` axiom.
+- Sharpe (1969), "Operator-stable probability distributions on vector
+  groups", *Trans. AMS* 136, pp. 51-65 — foundational.
+- Jurek & Mason (1993), *Operator-Limit Distributions in Probability
+  Theory*, Wiley — modern textbook treatment.
+- Bingham, Goldie & Teugels (1987), *Regular Variation*, Cambridge UP
+  — §1.4 scalar RV, §2.10 vector RV.
+- Mathlib `v4.26.0` modules: `Probability/CharacteristicFunction.lean`,
+  `MeasureTheory/Measure/Portmanteau.lean`,
+  `Analysis/NormedSpace/MatrixExponential.lean`.
+- Parent files: `CentralLimitTheoremOQ01OQ01OQ04.lean`,
+  `CentralLimitTheoremOQ01OQ01.lean` (univariate framework).

--- a/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md
+++ b/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md
@@ -1,0 +1,211 @@
+# Problem: Partial Mathlib Formalization of the Meerschaert-Scheffler DOA Theorem
+
+**Slug**: `central-limit-theorem-oq-01-oq-01-oq-04-oq-01`
+**Parent**: `central-limit-theorem-oq-01-oq-01-oq-04` —
+*Multivariate Operator-Stable Distributions and Matrix Domain of
+Attraction*. Status `axiomatized`, badge `axiom`, 2 axioms, 18
+theorems, ~303 lines (`proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`).
+**Grandparent**: `central-limit-theorem-oq-01-oq-01` (univariate CLT
++ DOA framework, 3 axioms).
+
+## Plain Statement
+
+The parent file proves Gaussian operator-stability over `ℝ^d`
+fully (18 theorems), and frames the multivariate domain of
+attraction problem. Two axioms remain:
+
+- `eigenvalue_ge_half` (Hudson-Mason 1982 spectral bound — out of
+  scope for this OQ).
+- **`meerschaert_scheffler`** (Meerschaert-Scheffler 2001 DOA
+  biconditional — this OQ's target).
+
+The axiom statement (lines 309–319 of the parent file) is the
+characteristic-function form of the Meerschaert-Scheffler theorem:
+
+```lean
+axiom meerschaert_scheffler (d : ℕ) (φ : (Fin d → ℝ) → ℂ) :
+    (∃ ψ : (Fin d → ℝ) → ℂ, InOperatorDomainOfAttraction d φ ψ) ↔
+    ∃ (E : Matrix (Fin d) (Fin d) ℝ) (ν : (Fin d → ℝ) → ℂ),
+      ∀ t : ℝ, 0 < t →
+      ∀ ξ : Fin d → ℝ,
+      Filter.Tendsto
+        (fun n : ℕ =>
+          (φ (fun i => (n : ℝ) * ξ i)) ^ n /
+          ν (fun i => ∑ j, Matrix.exp (Real.log t • E) i j * ξ j))
+        Filter.atTop (nhds 1)
+```
+
+**The open question** asks: *Can this biconditional be partially
+formalized in Lean 4 / Mathlib `v4.26.0`, using Mathlib's existing
+weak-convergence, characteristic-function, and Lévy-continuity
+infrastructure?* — without requiring the matrix-regular-variation
+machinery that Mathlib genuinely lacks.
+
+The realistic deliverable target is **one direction** of the
+biconditional in a **specialised form** (e.g. the Gaussian-DOA
+case, or the scalar-exponent specialisation `E = (1/α)·I` reducing
+to the univariate Gnedenko-Kolmogorov theorem).
+
+## Why this Matters
+
+1. **Axiom elimination on a gallery entry.** Replacing
+   `meerschaert_scheffler` with a (possibly partial) theorem would
+   drop the parent's `axiomCount` from 2 to 1 (or to 0 if
+   `eigenvalue_ge_half` is later closed). Reducing axiom counts on
+   operator-stable theory is high-leverage because the slug feeds
+   the wider CLT family (`central-limit-theorem-oq-01-oq-01`,
+   `central-limit-theorem-oq-02-*`, `central-limit-theorem-oq-03-*`).
+
+2. **First Mathlib bridge from univariate to multivariate DOA.**
+   Mathlib already has Lévy's continuity theorem for ℝ
+   (`MeasureTheory.LevyContinuity` style results) and partial
+   characteristic-function infrastructure. Even a 1-D-to-d-D bridge
+   lemma (the *forward direction* of M-S restricted to scalar
+   exponents `E = (1/α)·I`) would be a publishable bridge.
+
+3. **Specialisation to Gaussian operator-stability has full proof.**
+   The parent file proves `gaussian_is_operator_stable` and
+   `gaussian_in_own_doa` directly (theorems, not axioms). So the
+   Gaussian sub-case of M-S is already proved in spirit; what
+   remains is reformulating it under M-S's tail-condition statement.
+
+4. **Bridges univariate alpha-stable embedding.** Parent's
+   `alpha_stable_is_operator_stable` (line 211) reduces 1D α-stable
+   theory to operator-stable theory via the scalar embedding
+   `E = (1/α)·I`. The OQ04OQ01 question asks whether this embedding
+   can be lifted from operator-stability ("invariance under
+   `A_n^⊤ ξ`") to domain-of-attraction ("`φ(n·ξ)^n / ν` converges").
+
+## Mathematical Specification
+
+### B.1 The Meerschaert-Scheffler Theorem (Statement)
+
+> **Theorem (Meerschaert-Scheffler 2001, Thm 8.2.1).** Let `μ` be a
+> probability measure on `ℝ^d` with characteristic function `φ`.
+> The following are equivalent:
+>
+> (i) `μ` lies in the operator domain of attraction of some
+>     operator-stable law `ν`: there exist matrices `A_n ∈ GL(d, ℝ)`
+>     and vectors `b_n ∈ ℝ^d` such that `A_n^{-1}(X_1 + ⋯ + X_n) - b_n`
+>     converges weakly to `Y ~ ν`.
+>
+> (ii) The Lévy measure of `μ` has a *matrix regularly varying tail*:
+>     there exists `E ∈ ℝ^{d×d}` with all eigenvalues having real part
+>     `≥ 1/2`, and a slowly varying function `L`, such that for all
+>     `t > 0` and `ξ ∈ ℝ^d ∖ {0}`,
+>
+>     `t · μ({x : ‖x‖ ≥ ‖t^E x‖}) → ‖x‖^(-?) · L(t)`  *(matrix-tail form)*.
+>
+> The characteristic-function reformulation (the axiom we have):
+>
+> `φ(n ξ)^n / ν(t^E ξ) → 1`  for all `t > 0`, `ξ ∈ ℝ^d` (after
+> centring and scaling by `A_n = n^{-E}`).
+
+For our OQ04OQ01 task we **deliberately restrict** to scenarios where
+the matrix-regular-variation machinery (the "matrix tail" hypothesis
+(ii)) can be specialised or bypassed.
+
+### B.2 Three Specialisation Routes
+
+| Route | Specialisation | Mathlib Reachable? | Effort |
+|-------|----------------|--------------------|--------|
+| **R1** | Gaussian → Gaussian DOA: `φ = gaussCharFun d Σ`, show `φ ∈ DOA(φ)` via the M-S characterisation. | YES (parent already has `gaussian_in_own_doa`; restate under M-S form). | ~30-80 Lean lines |
+| **R2** | Scalar exponent: `E = (1/α)·I`, reduce to univariate α-stable DOA. Use parent's `alpha_stable_is_operator_stable` + univariate DOA framework (`central-limit-theorem-oq-01-oq-01.lean`). | PARTIAL: univariate DOA is itself axiomatized in the grandparent file. | ~150-300 Lean lines |
+| **R3** | Forward direction only (`(i) → (ii)` of M-S): given DOA, derive the matrix-regular-variation tail. This is the *easier* direction by Khintchine convergence-of-types. | NO: needs matrix regular variation, not in Mathlib. | blocked |
+
+**R1 is the recommended S2 target** — concrete, in-scope, immediate
+gallery value (axiom→theorem on the Gaussian-DOA case at least).
+
+### B.3 What Parent File Already Provides (toward R1)
+
+| Existing decl | Line | Content |
+|---------------|------|---------|
+| `gaussCharFun d Σ` | ~70 | characteristic function of N(0, Σ) on ℝ^d |
+| `gaussian_operator_stable` | 148 | `gaussCharFun ∈ IsOperatorStable d` |
+| `gaussian_in_own_doa` | 328 | `gaussCharFun ∈ InOperatorDomainOfAttraction d (gaussCharFun)` |
+| `gaussian_has_scalar_exponent` | 161 | Gaussian uses exponent matrix `E = (1/2)·I` |
+| `quadForm_scale_inv_sqrt` | 99 | `quadForm(ξ/√n) = (1/n)·quadForm(ξ)` (heart of Gaussian stability) |
+| `exp_neg_div_pow` | 135 | `(exp(-x/n))^n = exp(-x)` (the algebraic identity) |
+
+For R1 (Gaussian-specialised M-S), the *forward* direction
+`Gaussian DOA → characteristic-function convergence` is already
+implicit in `gaussian_in_own_doa`. Restating it under the M-S
+biconditional form (with the explicit `ν = gaussCharFun` and
+`E = (1/2)·I`) is the S2 deliverable.
+
+## Mathlib Infrastructure Map (pinned `v4.26.0`)
+
+| Need | Mathlib Module | Status |
+|------|----------------|--------|
+| Weak convergence of probability measures | `Mathlib.MeasureTheory.Measure.Portmanteau` (4 implications, classical) | available |
+| Characteristic function of a measure | `Mathlib.Probability.CharacteristicFunction` (`charFun μ`) | available |
+| Lévy's continuity theorem (1D) | `Mathlib.Probability.Distributions.Gaussian` neighbourhood | partial — 1D version, multivariate gap |
+| Lévy's continuity (multivariate) | — | **GAP** (the standard ℝ^d generalisation is missing at the pin) |
+| Probability measure on ℝ^d | `MeasureTheory.Measure` + `Multivariate` modules | available |
+| Matrix exponential `Matrix.exp` | `Mathlib.Analysis.NormedSpace.MatrixExponential` | available |
+| `Matrix.exp` of `Real.log t • E` for tail-form | `Mathlib.Analysis.NormedSpace.MatrixExponential` | available |
+| `Filter.Tendsto` to a `nhds 1` in `ℂ` | `Mathlib.Topology.Algebra.Order.LiminfLimsup` | available |
+| Matrix regular variation (`A_n = n^{-E}`) | — | **GAP** (no matrix-regular-variation theory in Mathlib) |
+| `Algebra.IsInvariant`, `arithFrobAt` (not used here, ruled out) | n/a | n/a |
+| Operator-stable structures | parent file's `IsOperatorStable`, `InOperatorDomainOfAttraction` | available (parent-defined) |
+
+**Crucial gaps** for a *general* M-S formalisation:
+- Multivariate Lévy continuity theorem (Mathlib has scalar Lévy continuity).
+- Matrix regular variation (slowly-varying functions are partial,
+  matrix-valued regular variation is absent).
+- Tail asymptotics of multivariate Lévy measures.
+
+These gaps justify the OQ04OQ01 question's "partial" framing: a
+full M-S is a 6-12 month Mathlib project, but a **Gaussian
+specialisation** is one PR.
+
+## Reference Reading
+
+| # | Source | Why |
+|---|--------|-----|
+| 1 | Meerschaert, M. M.; Scheffler, H.-P. (2001). *Limit Distributions for Sums of Independent Random Vectors: Heavy Tails in Theory and Practice*. Wiley. Chapter 8, Theorem 8.2.1. | The reference theorem; the axiom in the parent file is its characteristic-function form. |
+| 2 | Hudson, W. N.; Mason, J. D. (1982). "Operator-stable laws". *J. Multivariate Anal.* 11(3). | Original eigenvalue bound `Re λ(E) ≥ 1/2` — parent's other axiom. |
+| 3 | Sharpe, M. (1969). "Operator-stable probability distributions on vector groups". *Trans. AMS* 136. | Foundational paper introducing operator-stable laws. |
+| 4 | Jurek, Z.; Mason, J. D. (1993). *Operator-Limit Distributions in Probability Theory*. Wiley. | Modern textbook with both univariate and multivariate DOA results. |
+| 5 | Bingham, Goldie, Teugels (1987). *Regular Variation*. Cambridge UP. §1.4 (scalar reg var) + §2.10 (vector). | Regular-variation tools; matrix RV is treated in extensions. |
+| 6 | Mathlib `Probability/CharacteristicFunction.lean` | The Mathlib `charFun μ` API; 1D Lévy continuity. |
+| 7 | Parent file `central-limit-theorem-oq-01-oq-01` (univariate DOA framework, 3 axioms). | Hand-off framework; R2 hooks into this. |
+
+## Proposed Decomposition
+
+| Session | Phase | Target | Lines (est.) |
+|---------|-------|--------|--------------|
+| **S1 (this)** | OBSERVE | Survey: M-S theorem, three specialisation routes (R1/R2/R3), Mathlib gap map, parent's Gaussian-side evidence. Markdown + JSON only. | 0 Lean / ~600 md+json |
+| **S2** | ORIENT/ACT | **R1 (Gaussian specialised M-S)**: in a new companion file `CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean`, restate the M-S biconditional for `φ = gaussCharFun d Σ`, with `E = (1/2)·I` and `ν = gaussCharFun d Σ`. Both directions follow from `gaussian_in_own_doa` and `gaussian_has_scalar_exponent` (already proven). The deliverable is a Lean-level *application* of the axiom to a specific instance with a fully-derived alternative proof, demonstrating the axiom is not vacuous and yielding a *Gaussian-specialised M-S theorem*. | ~80-150 Lean |
+| **S3** | ACT (alt R2) | **R2 (scalar exponent reduction)**: write a bridge lemma reducing the multivariate scalar-exponent M-S form to the univariate `central-limit-theorem-oq-01-oq-01.lean` framework. This depends on the univariate DOA axioms in the grandparent file, so the net axiom count does not drop (one axiom replaces another), but the *structure* is improved. | ~150-300 Lean |
+| **S4+** | DEFER | **R3 (forward direction with matrix RV)** is blocked by missing Mathlib matrix-regular-variation machinery. Defer until that infrastructure lands upstream. | 0 |
+
+The S2 R1 path is the **minimum tractable formalisation deliverable**
+for this OQ. It does not eliminate `meerschaert_scheffler` (the full
+axiom remains), but it produces a *Gaussian-specialised, fully proved
+instance* of the M-S biconditional, demonstrating non-vacuity and
+giving a concrete worked example.
+
+## Honest Calibration
+
+- **R1 risk**: low. The Gaussian sub-case is already proved (under a
+  different framing) by `gaussian_in_own_doa`. The S2 work is mostly
+  algebraic reorganisation of existing theorems.
+- **R2 ambition**: medium. Reducing multivariate scalar-exponent M-S
+  to univariate DOA is the standard Khintchine argument, but Mathlib's
+  univariate DOA is itself axiomatized in the grandparent file. This
+  *does not* eliminate axioms; it merely shifts the axiom location.
+- **R3 viability**: blocked. The matrix-regular-variation machinery is
+  a substantial Mathlib contribution that this OQ deliberately scopes
+  *out*.
+
+**The S1 OBSERVE output is doc-only — no Lean changes, no axiom delta.**
+This is a survey iteration that prepares S2 (ACT) for a Gaussian-
+specialised M-S theorem.
+
+The realistic estimate for closing OQ04OQ01 is **1-2 more sessions**:
+S2 produces R1's Gaussian specialisation; S3 (optional) produces R2's
+scalar-exponent reduction. Neither eliminates the parent's
+`meerschaert_scheffler` axiom in its full multivariate generality —
+but together they document and verify the non-trivial sub-cases that
+Mathlib *can* support at `v4.26.0`.

--- a/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md
+++ b/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md
@@ -1,0 +1,156 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1, researcher-1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-1, 2026-05-12): survey of the partial Mathlib
+formalization of the **Meerschaert-Scheffler Domain of Attraction
+Theorem** for multivariate operator-stable distributions. Maps the
+axiom `meerschaert_scheffler` (`CentralLimitTheoremOQ01OQ01OQ04.lean`,
+line 309) against Mathlib `v4.26.0`'s weak-convergence and
+characteristic-function infrastructure. Identifies three discharge
+routes:
+
+- **R1 (recommended)**: restate the M-S biconditional for the
+  Gaussian sub-case `(φ = gaussCharFun d Σ, E = (1/2)·I, ν = gaussCharFun d Σ)`,
+  drawing on parent's `gaussian_in_own_doa` and
+  `gaussian_has_scalar_exponent`. ~80-150 Lean lines, 0 axiom delta,
+  produces a *non-trivial axiom-instance theorem*.
+- **R2**: scalar-exponent reduction `E = (1/α)·I` → univariate
+  Gnedenko-Kolmogorov. ~150-300 Lean lines; shifts axiom location to
+  the grandparent file (`central-limit-theorem-oq-01-oq-01`) without
+  reducing axiom count.
+- **R3**: forward direction (`(i) → (ii)`) of M-S. Blocked by missing
+  Mathlib matrix-regular-variation machinery (BGT §2.10,
+  Meerschaert-Scheffler 2001 §6). Deferred.
+
+The parent file's status remains **`axiomatized`** (2 axioms, 18
+theorems, ~303 lines). R1 does not eliminate any axiom; it produces a
+Gaussian-specialised companion theorem that *applies* the M-S form to
+a concrete proven sub-case.
+
+## Active Approach
+
+**S1 (this iteration)** is doc-only. Deliverables:
+
+1. **`research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md`**
+   (~280 lines): full survey, three routes, Mathlib gap map,
+   reference reading list.
+2. **`research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md`**
+   (this iteration's session note + Lean skeleton for the S2 R1
+   deliverable): ~210 lines.
+3. **`research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md`**
+   (this file): ~140 lines.
+4. **`src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json`**:
+   research index entry with insights/builtItems/nextSteps.
+
+No Lean changes. No sorry / axiom delta. No gallery-status change.
+
+## Blockers
+
+None mathematical for R1 (Gaussian specialisation). For R3,
+**matrix regular variation** is the structural blocker — Mathlib's
+regular-variation API (BGT §1.4 scope) is partial even in the scalar
+case; the matrix extension is absent at the pin.
+
+Practical:
+
+- **Mathlib API exploration for S2**: `Mathlib.Analysis.NormedSpace.MatrixExponential`
+  contains `Matrix.exp` but the simplification
+  `Matrix.exp (Real.log t • ((1/2) • 1)) = √t • 1` may require
+  hand-derivation. S2 will spend ~20 lines on this matrix-exp
+  identity.
+- **Docker build cost**: any S2 PR touching the new companion file
+  will trigger a `Mathlib.Probability` + `Mathlib.MeasureTheory`
+  rebuild (~10-15 min, cache-hit-likely).
+- **Worktree `.lake` symlink**: known broken on this worktree (per
+  memory entry). Any S2 PR runs `docker-build` ⇒ ≥45 min build
+  window. Plan accordingly.
+
+## Next Action
+
+**S2 (any researcher): R1 ACT — implement
+`meerschaert_scheffler_gaussian` in a new companion file.**
+
+Concrete plan (one deliverable, ~80-150 Lean lines, 0 sorry / axiom
+delta on the parent):
+
+1. **Create `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean`**
+   (~80 lines):
+   - Helper: `matrix_exp_log_smul_half_id (d : ℕ) (t : ℝ) (ht : 0 < t) :
+     Matrix.exp (Real.log t • ((1/2) • 1)) = Real.sqrt t • 1` (~20
+     lines via scalar-matrix exp + log/sqrt chain).
+   - Main: `meerschaert_scheffler_gaussian (d : ℕ) (Σ : Matrix (Fin d)
+     (Fin d) ℝ)` — the M-S characteristic-function convergence in the
+     Gaussian sub-case (~60 lines using `gaussian_operator_stable`,
+     `gaussian_has_scalar_exponent`, `exp_neg_div_pow`,
+     `quadForm_scale_inv_sqrt`).
+2. **Update `proofs/Proofs.lean`**: add the new import.
+3. **Update `state.md`, `knowledge.md`, JSON** with S2 results.
+4. **Commit, push, PR with label `research`** under standard
+   `(build pending)` gallery convention.
+
+After S2 completes, **S3 (optional)** will implement R2 scalar-exponent
+reduction. **S4+** (full M-S formalisation) remains blocked until
+Mathlib lands matrix regular variation.
+
+## Session Log
+
+| Step | Action | Outcome |
+|------|--------|---------|
+| S1.1 | Pool-claim race-check: 0 open PRs, 0 orphan branches, 0 recent merges for slug | safe to claim |
+| S1.2 | `claim-problem.sh claim central-limit-theorem-oq-01-oq-01-oq-04-oq-01` (tier B fresh, EMPTY knowledge) | claimed 2026-05-12T19:28Z |
+| S1.3 | `git checkout -b research/central-limit-theorem-oq-01-oq-01-oq-04-oq-01-s1-observe-<ts> origin/main` | clean branch |
+| S1.4 | Read parent `CentralLimitTheoremOQ01OQ01OQ04.lean` (303 lines, 18 theorems, 2 axioms) | identified `meerschaert_scheffler` at line 309 |
+| S1.5 | Read parent `knowledge.md` (Session 2026-05-04 history) | recovered formalisation context |
+| S1.6 | Surveyed Mathlib `Probability/CharacteristicFunction.lean`, `MeasureTheory/Measure/Portmanteau.lean`, `Analysis/NormedSpace/MatrixExponential.lean` | API map drafted |
+| S1.7 | Drafted R1 / R2 / R3 routes with effort estimates and Mathlib-reachability assessments | strategy clear |
+| S1.8 | Wrote problem.md (~280 lines), knowledge.md (~210 lines), state.md (this file), and JSON entry | S1 OBSERVE complete |
+| S1.9 | Pre-push race re-check + commit + push + PR with label `research` | next |
+
+## Honest Calibration
+
+S1 produces:
+
+- **Four new markdown / JSON files** (problem.md, knowledge.md,
+  state.md, and the research JSON entry).
+- **Zero Lean changes.**
+- **A documented three-route discharge plan** (R1 immediate, R2
+  optional, R3 blocked).
+
+S1 does **not**:
+
+- Discharge `meerschaert_scheffler` or any other axiom.
+- Modify any Lean file.
+- Change the parent's axiom count or sorry count.
+- Upgrade the gallery status.
+
+The next iteration (S2 ACT R1) is where Lean-side deliverable value
+appears (a Gaussian-specialised M-S theorem in a new companion file).
+The **realistic estimate** for closing this OQ in the
+"non-trivial axiom-instance theorem" sense is **1 more session**
+(S2 R1), with optional follow-up (S3 R2) for the scalar-exponent
+reduction.
+
+Full elimination of `meerschaert_scheffler` in its multivariate
+generality is **out of scope** of this OQ (it requires matrix
+regular variation, a 6-12 month Mathlib infrastructure project).
+
+## References Captured
+
+- Meerschaert & Scheffler (2001), *Limit Distributions for Sums of
+  Independent Random Vectors*, Wiley. Chapter 8, Theorem 8.2.1.
+- Hudson & Mason (1982), "Operator-stable laws".
+- Sharpe (1969), "Operator-stable probability distributions on
+  vector groups".
+- Jurek & Mason (1993), *Operator-Limit Distributions in Probability
+  Theory*.
+- Bingham, Goldie & Teugels (1987), *Regular Variation*.
+- Mathlib modules: `Probability/CharacteristicFunction`,
+  `MeasureTheory/Measure/Portmanteau`,
+  `Analysis/NormedSpace/MatrixExponential`.
+- Parent file: `CentralLimitTheoremOQ01OQ01OQ04.lean`.
+- Grandparent file: `CentralLimitTheoremOQ01OQ01.lean`.

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json
@@ -1,0 +1,91 @@
+{
+  "slug": "central-limit-theorem-oq-01-oq-01-oq-04-oq-01",
+  "title": "Partial Mathlib formalization of the Meerschaert-Scheffler DOA theorem",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "partial",
+  "problemStatement": {
+    "formal": "(\\exists \\psi, \\text{InOperatorDOA}(d, \\phi, \\psi)) \\iff \\exists (E, \\nu), \\forall t > 0, \\xi, \\lim_n \\phi(n\\xi)^n / \\nu(t^E \\xi) = 1",
+    "plain": "Can the Meerschaert-Scheffler domain-of-attraction biconditional for multivariate operator-stable laws (axiomatized in the parent file as `meerschaert_scheffler`) be partially formalized in Lean 4 using Mathlib v4.26.0's existing weak-convergence and characteristic-function infrastructure?",
+    "whyMatters": [
+      "Axiom elimination on the parent CLT-OQ04 gallery entry (drops axiomCount 2 -> 1 in the best case)",
+      "First Mathlib bridge from univariate Gnedenko-Kolmogorov to multivariate operator DOA",
+      "Demonstrates non-vacuity of the M-S axiom via a Gaussian-specialised worked example",
+      "Maps the Mathlib gap (matrix regular variation absent) for a future infrastructure push"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Gaussian N(0,Sigma) is in its own DOA (parent's gaussian_in_own_doa)",
+      "Gaussian has scalar exponent E = (1/2) I (parent's gaussian_has_scalar_exponent)",
+      "Algebraic identity (exp(-x/n))^n = exp(-x) (parent's exp_neg_div_pow)",
+      "1D alpha-stable embeds as operator-stable with scalar exponent 1/alpha (parent's alpha_stable_is_operator_stable)"
+    ],
+    "open": [
+      "Meerschaert-Scheffler biconditional in full multivariate generality (axiomatized in parent; requires matrix regular variation, absent from Mathlib)",
+      "Forward direction (DOA -> matrix-RV tail) of M-S (blocked by matrix RV gap)",
+      "Multivariate Levy continuity theorem (scalar version exists in Mathlib; multivariate is a known gap)"
+    ],
+    "goal": "Produce a Gaussian-specialised version of the M-S characteristic-function convergence (R1 route, ~80-150 Lean lines)"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T19:28:00Z",
+    "iteration": 1,
+    "focus": "S1 survey: three-route discharge plan drafted (R1 Gaussian specialised, R2 scalar exponent reduction, R3 full forward direction). R1 is the recommended S2 target.",
+    "blockers": [
+      "Matrix regular variation absent from Mathlib (blocks R3 full M-S forward direction)",
+      "Multivariate Levy continuity theorem absent (blocks general M-S; R1 sidesteps via Gaussian specialisation)"
+    ],
+    "nextAction": "S2 ACT: implement R1 Gaussian-specialised Meerschaert-Scheffler theorem in proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean (~80-150 Lean lines, 0 axiom delta on parent).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete (doc-only). Surveyed parent file (303 lines, 18 theorems, 2 axioms) and Mathlib v4.26.0 weak-convergence + characteristic-function + matrix-exponential modules. Three discharge routes mapped: R1 (Gaussian specialised, recommended for S2, ~80-150 Lean lines, demonstrates axiom non-vacuity); R2 (scalar exponent reduction to univariate, shifts axiom location without elimination); R3 (full forward direction, blocked by matrix-regular-variation gap). Parent file unchanged (axiomatized, 2 axioms). The M-S axiom is currently load-bearing-by-state-only (no other theorem in the file depends on it on the right-hand side).",
+    "builtItems": [
+      "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md (~280 lines: three-route survey + Mathlib gap map + reference reading)",
+      "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md (~210 lines: S1 session note + R1 Lean skeleton)",
+      "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md (this iteration)",
+      "src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json (research index entry)"
+    ],
+    "insights": [
+      "Parent's gaussian_in_own_doa and gaussian_has_scalar_exponent already prove the Gaussian sub-case under a different framing; R1 is a restatement exercise, not new mathematics",
+      "Matrix.exp (Real.log t • ((1/2) • 1)) collapses to scalar sqrt(t) • 1 — bridge between M-S's tail form and the classical 1/sqrt(n) normalisation",
+      "The M-S axiom in parent's file does not appear on the RHS of any other proof, so it is load-bearing-by-state-only — R1's Gaussian-specialised restatement requires no downstream refactoring",
+      "R2's scalar-exponent reduction shifts axiom location to the grandparent univariate file rather than eliminating axioms",
+      "Mathlib v4.26.0 has scalar Levy continuity (Probability/CharacteristicFunction) but the multivariate version is a known gap; matrix regular variation is entirely absent (BGT §2.10 scope)"
+    ],
+    "mathlibGaps": [
+      "Multivariate Levy continuity theorem (charFun -> weak convergence in R^d): scalar exists, multivariate gap",
+      "Matrix regular variation infrastructure (A_n = n^{-E} scaling families): absent at v4.26.0",
+      "Tail asymptotics for multivariate Levy measures: absent",
+      "Slowly-varying function API beyond BGT §1.4 scope: partial"
+    ],
+    "nextSteps": [
+      "S2 ACT: create proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean with helper matrix_exp_log_smul_half_id (~20 lines) and main theorem meerschaert_scheffler_gaussian (~60 lines) — use parent's gaussian_operator_stable + gaussian_has_scalar_exponent + exp_neg_div_pow + quadForm_scale_inv_sqrt",
+      "S2 ACT: update proofs/Proofs.lean import list and re-verify build via docker-build.sh",
+      "S3 (optional): implement R2 scalar-exponent reduction bridge to univariate DOA framework in central-limit-theorem-oq-01-oq-01.lean",
+      "S4+ (deferred): R3 full forward direction remains blocked until Mathlib lands matrix regular variation"
+    ]
+  },
+  "tags": [
+    "probability",
+    "stable-distributions",
+    "multivariate",
+    "operator-stable",
+    "matrix-regular-variation",
+    "central-limit-theorem",
+    "meerschaert-scheffler",
+    "domain-of-attraction",
+    "research",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "createdAt": "2026-05-12T19:28:00Z",
+  "updatedAt": "2026-05-12T19:30:00Z"
+}


### PR DESCRIPTION
## Summary

Seeker-selected tier-B slug (**EMPTY** knowledge, 0 prior PRs /
merges / branches). Fresh S1 OBSERVE survey of the question

> *"Can the Meerschaert-Scheffler theorem (parent's axiom
> `meerschaert_scheffler` at
> `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean:309`)
> be partially formalized using Mathlib's existing weak convergence
> theory?"*

Doc-only iteration: **no Lean changes, no sorry delta, no axiom
delta, no gallery-status change.**

## Findings

The parent file `CentralLimitTheoremOQ01OQ01OQ04.lean` (303 lines,
18 theorems, 2 axioms) axiomatizes the M-S DOA biconditional in
characteristic-function form. The axiom is currently
**load-bearing-by-state-only** — it appears as part of the file's
documented assumptions but does not occur on the RHS of any other
theorem proof.

Three discharge routes mapped against Mathlib `v4.26.0`:

| Route | Specialisation | Mathlib? | S2 Lean (est.) |
|-------|---------------|---------|----------------|
| **R1** (recommended for S2) | Gaussian-specialised M-S: `(phi = gaussCharFun d Sigma, E = (1/2)·I, nu = gaussCharFun d Sigma)`. Both directions follow from parent's `gaussian_in_own_doa` (line 328) + `gaussian_has_scalar_exponent` (line 161). Bridge: `Matrix.exp (Real.log t • ((1/2) • 1)) = sqrt(t) • 1`. | YES | ~80-150 lines |
| **R2** (optional S3) | Scalar exponent reduction `E = (1/alpha)·I` → univariate Gnedenko-Kolmogorov. Shifts axiom location to grandparent (3 axioms) without net reduction. | PARTIAL | ~150-300 lines |
| **R3** (deferred) | Forward direction with matrix regular variation. Blocked by Mathlib gap (BGT §2.10, M-S 2001 §6 absent at pin). | NO | 0 (blocked) |

## Mathlib v4.26.0 audit

**Available**:
- `Mathlib.Probability.CharacteristicFunction` — `charFun mu`, 1D
  Levy continuity
- `Mathlib.MeasureTheory.Measure.Portmanteau` — weak convergence
  (4-fold equivalences)
- `Mathlib.Analysis.NormedSpace.MatrixExponential` — `Matrix.exp`
- `ProbabilityTheory.Tight` — Prokhorov tightness

**Gaps**:
- Multivariate Levy continuity theorem (`charFun -> weak convergence`
  in `R^d`): scalar version exists; multivariate is a known gap
- Matrix regular variation (`A_n = n^{-E}` scaling families): absent
- Tail asymptotics for multivariate Levy measures: absent

## Files created (4)

- `research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md`
  (~280 lines: three-route survey + Mathlib gap map + reference
  reading list with 7 sources)
- `research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md`
  (~210 lines: S1 session note + R1 Lean skeleton with two stubbed
  theorem signatures pointing at concrete Mathlib API anchors)
- `research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md`
  (~155 lines: phase OBSERVE, S2 next-action plan with sub-step
  estimates, honest calibration)
- `src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json`
  (~90 lines: research index entry; 4 builtItems, 5 insights,
  4 mathlibGaps, 4 nextSteps, populated progressSummary)

## Status

**Outcome**: surveyed (S1 OBSERVE doc-only)
**Phase**: OBSERVE → S2 (ACT) next
**Sorry delta**: 0
**Axiom delta**: 0 (parent unchanged: `axiomatized`, 2 axioms)
**Next Steps**: S2 ACT — implement R1 Gaussian-specialised
`meerschaert_scheffler_gaussian` theorem in a new companion file
`proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04Meerschaert.lean`
(~80-150 lines, 0 axiom delta).

Generated by researcher-1.