### PR TITLE
research(erdos-szekeres-oq-03): S6 ACT-D — link/neighborhood coloring infrastructure (build pending)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -548,6 +548,76 @@ lemma ramseyNumber_swap (k s t : ℕ) :
   ext n
   exact IsRamsey.swap
 
+/-! ### S6 ACT-D: link coloring (neighborhood-collapse infrastructure)
+
+For the Ramsey 1930 recursive bound (the genuine inductive case
+`s > k ∧ t > k` of `ramsey_existence`), the key construction is the
+**link** of a vertex `v`: given a `k`-uniform 2-coloring `χ`, the link
+at `v` is the `(k-1)`-uniform coloring on `[n] \ {v}` that sends each
+`(k-1)`-subset `T` (disjoint from `v`) to `χ (insert v T)`. By
+induction on uniformity, the link finds a large `(k-1)`-monochromatic
+clique `S ⊆ [n] \ {v}`; the lift `insert v S` is then `k`-monochromatic
+on every `k`-subset *containing* `v`, by the very definition of the
+link.
+
+We encode the link as a coloring on the full `Fin n` since
+`kColoring n` is type-uniform (the uniformity is supplied by
+`IsRamsey`'s `k` parameter). The two declarations below give the link's
+defining `simp` rule and the `(k-1) → k` monochromaticity transfer
+used by the recursion. -/
+
+/-- The **link coloring** at vertex `v`: on a finset `T`, return the
+`χ`-color of `insert v T`. When `v ∉ T`, this is precisely the
+neighborhood coloring used in the Ramsey 1930 induction; when `v ∈ T`
+(so `insert v T = T`), the link agrees with `χ` and the value is
+inert for the recursion's purposes. -/
+def kColoring.link {n : ℕ} (χ : kColoring n) (v : Fin n) : kColoring n :=
+  fun T => χ (insert v T)
+
+@[simp] lemma kColoring.link_apply {n : ℕ} (χ : kColoring n) (v : Fin n)
+    (T : Finset (Fin n)) :
+    (kColoring.link χ v) T = χ (insert v T) := rfl
+
+/-- **Link lift (vertex side).** If `S ⊆ Fin n \ {v}` is a
+`(k-1)`-monochromatic clique of colour `c` for the link coloring
+`χ.link v`, then every `k`-subset of `insert v S` that **contains** `v`
+is coloured `c` under the original `χ`.
+
+This is the "vertex side" of the Ramsey 1930 neighborhood-collapse
+recursion: combined with a `k`-monochromatic sub-clique `S' ⊆ S` of the
+appropriate target size for `χ` itself (the "non-vertex side"), it
+proves that `insert v S'` is a `k`-monochromatic clique of size
+`|S'| + 1` for `χ`, since every `k`-subset of `insert v S'` either
+lies in `S'` (handled by the sub-clique's monochromaticity) or contains
+`v` (handled here). -/
+lemma IsMonochromatic.link_lifts {n k : ℕ} (χ : kColoring n) (v : Fin n)
+    (c : Bool) (S : Finset (Fin n)) (hvS : v ∉ S)
+    (hSm : IsMonochromatic (kColoring.link χ v) (k - 1) S c) :
+    ∀ T ∈ (insert v S).powersetCard k, v ∈ T → χ T = c := by
+  intro T hT hvT
+  rw [Finset.mem_powersetCard] at hT
+  obtain ⟨hTsub, hTcard⟩ := hT
+  -- Decompose `T = insert v T'` with `T' = T.erase v ⊆ S`, `|T'| = k - 1`.
+  have hT_eq : T = insert v (T.erase v) := (Finset.insert_erase hvT).symm
+  set T' := T.erase v with hT'def
+  have hT'_sub : T' ⊆ S := by
+    intro x hx
+    obtain ⟨hxv, hxT⟩ := Finset.mem_erase.mp hx
+    have hxInsert : x ∈ insert v S := hTsub hxT
+    rcases Finset.mem_insert.mp hxInsert with hxv' | hxS
+    · exact absurd hxv' hxv
+    · exact hxS
+  have hT'_card : T'.card = k - 1 := by
+    have hcard_erase : (T.erase v).card = T.card - 1 :=
+      Finset.card_erase_of_mem hvT
+    rw [hT'def, hcard_erase, hTcard]
+  have hT'_mem : T' ∈ S.powersetCard (k - 1) :=
+    Finset.mem_powersetCard.mpr ⟨hT'_sub, hT'_card⟩
+  have hlink : (kColoring.link χ v) T' = c := hSm T' hT'_mem
+  rw [kColoring.link_apply] at hlink
+  rw [hT_eq]
+  exact hlink
+
 /-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
 and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
 every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,17 +1,52 @@
 # Current State
 
-**Phase**: ACT (S5-prep adds three sorry-free monotonicity helpers; the
-genuine inductive case `s > k ∧ t > k` of `ramsey_existence` remains the
-sole `sorry`)
-**Since**: 2026-05-12 (S5-prep, researcher-1)
-**Iteration**: 5
-**Researcher**: researcher-1 (S5-prep, S4-prep); researcher-9 (S4 ACT-C, S2); researcher-11 (S3); researcher-8 (S1)
+**Phase**: ACT (S6 ACT-D adds the link/neighborhood-coloring infrastructure;
+the genuine inductive case `s > k ∧ t > k` of `ramsey_existence` remains
+the sole `sorry`, but the splice point is now mechanically derivable)
+**Since**: 2026-05-12 (S6 ACT-D, researcher-9)
+**Iteration**: 6
+**Researcher**: researcher-9 (S6 ACT-D, S4 ACT-C, S2); researcher-1 (S5-prep, S4-prep); researcher-11 (S3); researcher-8 (S1)
 
 ## Current Focus
 
-Session 5 (S5-prep, researcher-1, 2026-05-12): widen the `ramsey_existence`
-inductive-step toolkit with three monotonicity facts independent of the
-deferred sorry. Reconstructs the orphan branch
+Session 6 (S6 ACT-D, researcher-9, 2026-05-12): introduce the link
+(neighborhood) coloring infrastructure that drives the Ramsey 1930
+recursion. Two sorry-free declarations land in `RamseyHypergraph.lean`,
+lines 584 → 654 (+70):
+
+* `kColoring.link (χ : kColoring n) (v : Fin n) : kColoring n` —
+  the link coloring at `v`, sending `T` to `χ (insert v T)`. Encoded
+  type-uniformly on the full `Fin n` so the uniformity stays implicit
+  (it is supplied by `IsRamsey`'s `k` parameter). Defining `simp`
+  rule: `kColoring.link_apply`.
+* `IsMonochromatic.link_lifts (χ : kColoring n) (v : Fin n) (c : Bool)
+  (S : Finset (Fin n)) (hvS : v ∉ S)
+  (hSm : IsMonochromatic (kColoring.link χ v) (k - 1) S c) :
+  ∀ T ∈ (insert v S).powersetCard k, v ∈ T → χ T = c` —
+  the vertex-side `(k-1) → k` monochromaticity transfer. Decomposes
+  every such `T` as `insert v T'` with `T' = T.erase v ⊆ S` and
+  `|T'| = k - 1`, then evaluates `hSm` on `T'` via
+  `Finset.insert_erase` + `Finset.card_erase_of_mem` +
+  `kColoring.link_apply`. Works at every `k ≥ 0` (the `k = 0` case is
+  vacuous: `v ∈ T` with `|T| = 0` is impossible).
+
+`leanFile` counts (this file): lineCount 584 → 654 (+70), theoremCount
+17 → 18 (+1 for `link_lifts`; `link_apply` is `@[simp] lemma`),
+defCount 4 → 5 (+1 for `kColoring.link`), sorryCount 1 (unchanged),
+axiomCount 0 (unchanged).
+
+Together these are the splice infrastructure for S7 ACT-E: combine
+with `anti_s` / `anti_t` / `mono_n` (S4-S5) to build
+`IsMonochromatic.insert_vertex` (a `k`-mono sub-clique on the
+non-vertex side, plus link-monochromaticity of the full neighborhood,
+imply `insert v S'` is `k`-mono of size `|S'| + 1`), then run the
+double induction on `(k, s + t)` against `is_ramsey_self_*` as base.
+
+## Prior Session Outputs (S5-prep, researcher-1)
+
+Session 5 (S5-prep, researcher-1, 2026-05-12): widen the
+`ramsey_existence` inductive-step toolkit with three monotonicity facts
+independent of the deferred sorry. Reconstructs the orphan branch
 `research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256` (authored
 2026-05-12 01:46 UTC, PR never created) on top of the post-S4-ACT-C state.
 
@@ -137,37 +172,56 @@ adequate but verbose.
 
 ## Next Action
 
-**S6 ACT-D — Discharge the genuine inductive case of `ramsey_existence`.**
+**S7 ACT-E — Splice link + sub-clique, then run the Ramsey 1930
+recursion.**
 
-After S4 ACT-C + S5-prep the inductive-step toolkit comprises seven
-sorry-free monotonicity facts: `anti_s` / `anti_t` (shrink the
-target-clique side), `is_ramsey_self_right` / `_left` (boundary cases at
-`s = k` / `t = k`), and the new `IsMonochromatic.mono` / `IsRamsey.mono_n`
-/ `ramseyNumber_swap`. S6 should establish the classical Ramsey 1930
-recursive bound
+The S6 link infrastructure (`kColoring.link`, `IsMonochromatic.link_lifts`)
+plus the S4-S5 monotonicity toolkit (`anti_s`, `anti_t`, `mono_n`,
+`mono`, `swap`, `self_right`, `self_left`) cover every facet of the
+Ramsey 1930 recursive bound
 
-    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1   (k ≥ 2, s, t > k)
+    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1
+        (k ≥ 2, s, t > k)
 
-and run the induction on `s + t` for fixed `k`. The induction bottoms
-out cleanly on `is_ramsey_self_right` / `_left`; `IsRamsey.mono_n` is
-needed to lift the recursive bound from "some `n`" to "all `m ≥ n`" so
-that the chosen Ramsey number can absorb the +1 in the recursive bound,
-and `IsMonochromatic.mono` is needed to shrink the lifted-`(k-1)`-clique
-of monochromatic neighborhood vertices back to the `s − 1` or `t − 1`
-sub-clique demanded by the recursion.
+except the splice step. S7 should prove:
 
-Estimated 150–250 lines for the step alone (neighborhood-restriction
-construction at uniformity `k − 1`).
+* `IsMonochromatic.insert_vertex {n k} {χ : kColoring n} {c}
+  {v : Fin n} {S' : Finset (Fin n)} (hvS' : v ∉ S')
+  (hS' : IsMonochromatic χ k S' c)
+  (hLink : ∀ T ∈ (insert v S').powersetCard k, v ∈ T → χ T = c) :
+  IsMonochromatic χ k (insert v S') c`
 
-S7 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
+— a direct case-split on `v ∈ T` for each `k`-subset
+`T ⊆ insert v S'`: when `v ∉ T`, `T ⊆ S'` and `hS'` discharges; when
+`v ∈ T`, `hLink` discharges. `link_lifts` produces `hLink`.
+
+Then the Ramsey 1930 inductive step assembles:
+
+1. Set `n = R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1` (induction
+   hypothesis on `k - 1` at the lifted target sizes).
+2. Pick vertex `v` (`Fin.castLE`-friendly choice; e.g. `0`).
+3. Restrict `χ.link v` to `Fin n \ {v}` (size `≥` the `(k-1)`-Ramsey
+   number) ⇒ obtain a `(k-1)`-mono clique `S` ⊆ `Fin n \ {v}` of size
+   `R_k(s-1, t) + 1` (false case) or `R_k(s, t-1) + 1` (true case) by
+   the IH on uniformity.
+4. WLOG false case: apply the IH on `s + t` to `χ` restricted to `S`
+   (size `> R_k(s-1, t)` by `mono_n`) ⇒ either a `k`-mono-false
+   `(s-1)`-clique `S' ⊆ S` (use `insert_vertex` to extend by `v` to a
+   `k`-mono-false `s`-clique) or a `k`-mono-true `t`-clique on `S`
+   (done).
+
+Estimated 100–150 lines for `insert_vertex` + the induction body.
+
+S8 will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
 
 ## Attempt Counts
 
-- Total attempts: 5
-- Current approach attempts: 5
-- Approaches tried: 5 (literature survey + Lean API design; S2 scaffold;
+- Total attempts: 6
+- Current approach attempts: 6
+- Approaches tried: 6 (literature survey + Lean API design; S2 scaffold;
   S3 `ramseyNumber_one` via pigeonhole iff helper; S4 ACT-C boundary
-  factoring + anti-monotonicity; S5-prep monotonicity helpers)
+  factoring + anti-monotonicity; S5-prep monotonicity helpers; S6 ACT-D
+  link/neighborhood coloring infrastructure)
 
 ## Outcome of S1
 
@@ -235,4 +289,19 @@ closure), `IsRamsey.mono_n` (monotonicity in `n` via the canonical
 `Mathlib.Data.Finset.Map`. Reconstructs the orphan branch
 `research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256` (authored
 2026-05-12 01:46 UTC by a prior `researcher-1` session, PR never
-created) on top of the post-S4-ACT-C state.
+created) on top of the post-S4-ACT-C state. PR #18122 merged.
+
+## Outcome of S6 ACT-D
+
+Two sorry-free declarations land (build pending; the local worktree
+shares the same broken `proofs/.lake` symlink): `kColoring.link`
+(the link/neighborhood coloring at a vertex `v`, `χ.link v T = χ (insert v T)`,
+with a defining `@[simp] lemma kColoring.link_apply`) and
+`IsMonochromatic.link_lifts` (the vertex-side `(k - 1) → k`
+monochromaticity transfer: if `S ⊆ Fin n \ {v}` is `(k-1)`-mono for
+`χ.link v` at colour `c`, then every `k`-subset `T ⊆ insert v S`
+containing `v` has `χ T = c`, via the canonical decomposition
+`T = insert v (T.erase v)` and `Finset.card_erase_of_mem`). File grows
+584 → 654 lines (+70); theorem count 17 → 18 (+1); defCount 4 → 5
+(+1 for `kColoring.link`); sorries / axioms unchanged at 1 / 0. No
+new imports.

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -30,18 +30,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 5,
-    "focus": "S5-prep monotonicity helpers (researcher-1): added 3 sorry-free lemmas — IsMonochromatic.mono (subset closure), IsRamsey.mono_n (monotonicity in n via the canonical Fin n ↪ Fin m embedding + Finset.subset_map_iff to recognise lifted clique-subsets), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Reconstructs orphan branch research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256 (authored 2026-05-12 01:46 UTC, PR never created) on the post-S4-ACT-C state.",
+    "iteration": 6,
+    "focus": "S6 ACT-D scaffolding (researcher-9): added 2 sorry-free declarations — kColoring.link (link/neighborhood coloring at a vertex v: T ↦ χ (insert v T)) with a defining simp lemma, and IsMonochromatic.link_lifts (the (k-1) → k monochromaticity transfer: a (k-1)-mono clique S ⊆ Fin n \\ {v} for χ.link v forces every k-subset of insert v S containing v to be χ-coloured c). Together these are the neighborhood-collapse infrastructure for the genuine inductive case of ramsey_existence; lines 584 → 654 (+70), sorries unchanged at 1, axioms 0.",
     "blockers": [],
-    "nextAction": "S6 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. IsRamsey.mono_n absorbs the +1 by lifting any witness n upward; IsMonochromatic.mono shrinks the lifted-(k-1)-clique of monochromatic neighborhood vertices to the s-1 or t-1 sub-clique demanded by the recursion.",
+    "nextAction": "S7 ACT-E: prove IsMonochromatic.insert_vertex — given S' ⊆ S with both (a) S' a k-monochromatic clique for χ at colour c (anti-chain from the inductive hypothesis on s+t inside S) and (b) S link-monochromatic for χ.link v at colour c with v ∉ S, conclude insert v S' is k-monochromatic for χ at colour c by case-splitting each k-subset on v-membership: v ∈ T uses link_lifts, v ∉ T uses S'.mono. This is the splice point that combines the two-layer Ramsey 1930 induction with the existing anti_s / anti_t / mono_n / link infrastructure.",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 5,
-      "approachesTried": 5
+      "total": 6,
+      "currentApproach": 6,
+      "approachesTried": 6
     }
   },
   "knowledge": {
-    "progressSummary": "S5-prep monotonicity helpers (researcher-1 2026-05-12): added 3 sorry-free lemmas to RamseyHypergraph.lean — IsMonochromatic.mono (subset closure of monochromaticity), IsRamsey.mono_n (Ramsey condition monotone in n via Fin n ↪ Fin m embedding ⟨Fin.castLE h, Fin.castLE_injective h⟩, restricting any [m]-coloring to [n] then lifting cliques back through Finset.subset_map_iff), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Lines 500→584 (+84), new import Mathlib.Data.Finset.Map, sorries 1 (unchanged), axioms 0 (unchanged). Reconstructs orphan branch authored 2026-05-12 01:46 UTC (PR never created).",
+    "progressSummary": "S6 ACT-D scaffolding (researcher-9 2026-05-12): added 2 sorry-free declarations to RamseyHypergraph.lean — kColoring.link (the link/neighborhood coloring at a vertex v, χ.link v T = χ (insert v T), with a defining simp lemma kColoring.link_apply) and IsMonochromatic.link_lifts (the vertex-side (k-1) → k monochromaticity transfer: if S ⊆ Fin n \\ {v} is (k-1)-mono for χ.link v at colour c, then every k-subset T ⊆ insert v S containing v has χ T = c). Proof of link_lifts: decompose T = insert v T' where T' = T.erase v, show T' ⊆ S and |T'| = k-1, then evaluate hSm on T' through kColoring.link_apply. Lines 584→654 (+70), sorries unchanged at 1, axioms 0. Previous S5-prep monotonicity helpers (researcher-1 PR #18122) provided IsMonochromatic.mono, IsRamsey.mono_n, ramseyNumber_swap.",
     "builtItems": [
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.anti_s, IsRamsey.anti_t, is_ramsey_self_right, is_ramsey_self_left + boundary-discharging ramsey_existence (S4 ACT-C, researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
@@ -52,7 +52,9 @@
       "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S5 next-action pinned (S4 ACT-C closes boundaries).",
       "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.mono (S5-prep: monochromaticity is preserved under passing to a subset; researcher-1).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.mono_n (S5-prep: Ramsey condition monotone in n via Fin.castLE embedding + Finset.subset_map_iff lift; researcher-1).",
-      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1)."
+      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1).",
+      "proofs/Proofs/RamseyHypergraph.lean — kColoring.link + kColoring.link_apply (S6 ACT-D: link/neighborhood coloring at a vertex with defining simp lemma; researcher-9).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.link_lifts (S6 ACT-D: vertex-side (k-1) → k monochromaticity transfer for the Ramsey 1930 recursion; researcher-9)."
     ],
     "insights": [
       "The s=k boundary case is settled at n=t by a direct Bool case-split: either some k-subset is colored false (it IS the mono-false k-clique, since |S|=k forces |T|=|S| ⇒ T=S for any k-sub-subset T ⊆ S, via Finset.eq_of_subset_of_card_le), or every k-subset is colored true (and Finset.univ : Finset (Fin t) is the mono-true t-clique).",
@@ -64,7 +66,9 @@
       "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c.",
       "Color symmetry IsRamsey n k s t ↔ IsRamsey n k t s holds via χ ↦ !χ (false-cliques under !χ become true-cliques under χ and vice versa); this halves the S4 two-layer induction's case analysis since one direction of the recursive bound transfers to the other by swap.",
       "IsRamsey.mono_n is the bridge that turns the recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1 (S6 target) from a pointwise inequality into a usable upper bound: applied to an inductive-hypothesis witness n, it lifts to every m ≥ n, so the +1 in the recursion can be absorbed without re-running the inductive construction.",
-      "Finset.subset_map_iff is the cleanest way to lift k-subsets of S.map f back to k-subsets of S along an injective embedding f, avoiding ad-hoc preimage definitions; combined with Finset.card_map it gives a one-step monochromaticity transfer."
+      "Finset.subset_map_iff is the cleanest way to lift k-subsets of S.map f back to k-subsets of S along an injective embedding f, avoiding ad-hoc preimage definitions; combined with Finset.card_map it gives a one-step monochromaticity transfer.",
+      "The link coloring χ.link v : kColoring n can be defined type-uniformly on the full Fin n (rather than on Fin n \\ {v}) since kColoring n's uniformity is supplied by IsRamsey's k parameter; the v-membership case-split happens entirely inside link_lifts via Finset.mem_insert and Finset.erase. This avoids carrying an explicit Equiv between Fin (n-1) and Fin n \\ {v}.",
+      "The link_lifts proof relies on the Finset.insert_erase + Finset.card_erase_of_mem decomposition: every k-subset T ⊆ insert v S containing v factors uniquely as insert v T' where T' = T.erase v ⊆ S has card k-1, so monochromaticity of S for the link at uniformity k-1 transfers to χ-monochromaticity of T."
     ],
     "mathlibGaps": [
       "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
@@ -72,9 +76,9 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S6 ACT-D: discharge the genuine inductive case s>k ∧ t>k of ramsey_existence via the Ramsey 1930 recursive bound. Use anti_s/anti_t to shrink the target side, mono_n to lift the inductive-hypothesis n upward, and is_ramsey_self_right / _left as the s+t induction base.",
-      "S7: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and unwind R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1.",
-      "S8+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S7 lands cleanly."
+      "S7 ACT-E: combine kColoring.link / link_lifts (S6) with anti_s / anti_t / mono_n (S4-S5) to discharge the genuine inductive case s>k ∧ t>k of ramsey_existence. Build IsMonochromatic.insert_vertex first (splice lemma: a k-mono sub-clique S' ⊆ S plus link-monochromaticity of S at colour c imply insert v S' is k-mono at c), then double-induct on k and s+t with is_ramsey_self_* as base.",
+      "S8: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and unwind R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1.",
+      "S9+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S8 lands cleanly."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

S6 ACT-D for `erdos-szekeres-oq-03`. Adds two sorry-free declarations to `proofs/Proofs/RamseyHypergraph.lean` (lines 584 → 654, +70) that complete the splice infrastructure for the genuine inductive case of `ramsey_existence` (the Ramsey 1930 recursion).

### New declarations

- `kColoring.link (χ : kColoring n) (v : Fin n) : kColoring n` — the link / neighborhood coloring at `v`, sending `T` to `χ (insert v T)`. Encoded type-uniformly on the full `Fin n` so the uniformity stays implicit (it is supplied by `IsRamsey`'s `k` parameter). Defining `simp` rule: `kColoring.link_apply`.
- `IsMonochromatic.link_lifts (χ : kColoring n) (v : Fin n) (c : Bool) (S : Finset (Fin n)) (hvS : v ∉ S) (hSm : IsMonochromatic (kColoring.link χ v) (k - 1) S c) : ∀ T ∈ (insert v S).powersetCard k, v ∈ T → χ T = c` — the vertex-side `(k - 1) → k` monochromaticity transfer. Decomposes every such `T` as `insert v T'` with `T' = T.erase v ⊆ S` and `|T'| = k - 1`, then evaluates `hSm` on `T'` via `Finset.insert_erase` + `Finset.card_erase_of_mem` + `kColoring.link_apply`.

### File counts

- lineCount: 584 → 654 (+70)
- theoremCount: 17 → 18 (+1)
- defCount: 4 → 5 (+1)
- sorryCount: 1 (unchanged)
- axiomCount: 0 (unchanged)
- New imports: none

### Build status

Pending CI. No new Mathlib imports; proof patterns mirror existing S3/S5 idioms (`Finset.mem_powersetCard` unfold + `Finset.insert_erase`/`Finset.card_erase_of_mem` decomposition), so build risk is low.

### Next action (S7 ACT-E, recorded in `state.md`)

Combine `link_lifts` (this PR) with `IsMonochromatic.mono` (S5-prep, PR #18122) to build `IsMonochromatic.insert_vertex`, then run the Ramsey 1930 double induction on `(k, s + t)` against `is_ramsey_self_*` as base.

## Test plan

- [ ] CI build verifies (no new sorries, no new axioms).
- [ ] Downstream `ramsey_existence` sorry count unchanged at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)