### PR TITLE
research(ballot-problem-oq-01-oq-01-oq-02-oq-01): S1 OBSERVE — refute naive ⌈S/m⌉ lower bound for step ≥ -m cycle lemma

### DIFF
--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,156 @@
+# Knowledge — ballot-problem-oq-01-oq-01-oq-02-oq-01
+
+## Session log
+
+### S1 OBSERVE — 2026-05-12, researcher-1
+
+**Outcome**: Refuted the conjecture `(∀ x ∈ l, -m ≤ x) ∧ 0 < l.sum → ⌈l.sum / m⌉ ≤ |goodRotations l|`
+as posed in the parent meta `openQuestions[0]`. Listed five refined conjectures
+(A–E) and recommended **conjecture D** (m-jump downward IVT) as the S2 ACT
+target.
+
+#### Counterexample family (refutes conjecture as posed)
+
+For any `m ≥ 2` and any `S` with `1 ≤ S ≤ m`:
+- `l = [-m, m + S]` satisfies `∀ x ∈ l, -m ≤ x` and `l.sum = S > 0`.
+- `(goodRotations l).card = 1` (only `i = 1` is good).
+- The conjecture `⌈S/m⌉ ≤ 1` *holds* for `S ≤ m` but fails for `S = m + 1`.
+
+Smallest witness with `S = m + 1`:
+```
+m = 2 :  l = [-2, 5]   sum 3,  ⌈3/2⌉ = 2,  |goodRotations| = 1
+m = 3 :  l = [-3, 7]   sum 4,  ⌈4/3⌉ = 2,  |goodRotations| = 1
+```
+
+#### Mechanism of failure
+
+Unit-decrement IVT (parent file): consecutive prefix sums differ by at most 1,
+so every integer level in `[minPrefixSum, 0]` is *achieved*. With step ≥ -m
+and `m ≥ 2`, a single `-m` step can drop the prefix sum by `m`, **skipping up
+to m - 1 integer levels**. The counterexample `[-m, m+S]` realises a single
+`-m` drop that vaults straight from `0` to `-m`, eliminating `m - 1`
+intermediate levels — which would otherwise have served as good-rotation
+witnesses in the unit-decrement setting.
+
+#### Worked verification (m = 2, l = [-2, 5])
+
+`isGoodRotation l i := ∀ j ∈ [1, l.length], 0 < ((cyclicRotation l i).take j).sum`
+where `cyclicRotation l i = l.drop i ++ l.take i`.
+
+- `i = 0`: rotation `[-2, 5]`. `j = 1`: `[-2].sum = -2`. **Fail**.
+- `i = 1`: rotation `[5, -2]`. `j = 1`: `[5].sum = 5 > 0`; `j = 2`: `3 > 0`. **Good**.
+
+`(goodRotations l).card = #{i ∈ {0,1} : isGoodRotation l i} = #{1} = 1`.
+
+`⌈3/2⌉ = 2`. Conjecture violated: `2 ≰ 1`.
+
+#### Why the {+1, -k} case is special
+
+In the parent's classical `{+1, -k}` setting (m = k):
+- Each negative step is exactly `-k`, never less.
+- Each positive step is exactly `+1`, contributing `+1` to the running sum.
+- Prefix sums *must* cross every integer in their range from above (the
+  positive-step climbs visit every level), and the cycle-lemma count formula
+  `|goodRotations| = a - k·b = S` holds.
+
+Allowing larger *positive* steps (e.g. `+(m+S)` instead of repeated `+1`s)
+removes the level-visitation guarantee on the way up, while allowing larger
+*negative* steps removes it on the way down. The refuted conjecture only
+addressed the second loss; the first matters too.
+
+## Refined conjectures (priority for S2)
+
+### Conjecture D — m-jump downward IVT (recommended S2 ACT target)
+
+```
+theorem m_jump_downward_ivt (l : List ℤ) (m : ℕ) (hm : 1 ≤ m)
+    (h_step : ∀ x ∈ l, -(m : ℤ) ≤ x)
+    (v : ℤ) (i j : ℕ)
+    (hij : i < j) (hjlen : j ≤ l.length)
+    (hi_gt : v < prefixSum l i)
+    (hj_le : prefixSum l j ≤ v) :
+    ∃ k, i < k ∧ k ≤ j ∧
+      v - (m : ℤ) + 1 ≤ prefixSum l k ∧ prefixSum l k ≤ v
+```
+
+This is the direct m-generalization of `unit_decrement_downward_ivt` and
+follows the same leftmost-crossing proof template using `Finset.min'`.
+
+The conclusion window `[v - m + 1, v]` has width `m`. For `m = 1` it
+collapses to `{v}`, recovering the unit-decrement IVT.
+
+### Conjecture B — slack count bound
+
+```
+theorem step_le_m_card_bound (l : List ℤ) (m : ℕ) (hm : 1 ≤ m)
+    (h_step : ∀ x ∈ l, -(m : ℤ) ≤ x) (hS : 0 < l.sum) :
+    l.sum ≤ (m : ℤ) * (goodRotations l).card + (m - 1 : ℤ) * l.length
+```
+
+Loose but provable using D plus a level-counting argument (each integer level
+in `[minPrefixSum, 0]` is hit within `m - 1` steps of *some* good rotation).
+
+### Conjecture E — restricted alphabet
+
+```
+theorem step_in_one_neg_m_count (l : List ℤ) (m : ℕ) (hm : 1 ≤ m)
+    (h_step : ∀ x ∈ l, x = 1 ∨ x = -(m : ℤ)) (hS : 0 < l.sum) :
+    Int.toNat ⌈(l.sum : ℚ) / m⌉ ≤ (goodRotations l).card
+```
+
+Special case where the positive steps are forced to `+1` — restores the
+{+1, -m} cycle-lemma regime. Proved already (in essence) by the parent file's
+`{+1, -k}` infrastructure (`BallotProblemOQ01.lean`), so this is a thin
+restatement rather than new mathematics.
+
+## Mathlib audit
+
+For the m-jump IVT (conjecture D), the existing parent-file proof template
+transfers almost verbatim. Required Mathlib pieces (all already in v4.26.0):
+
+| Symbol | Module | Used for |
+|--------|--------|----------|
+| `Finset.min'` | `Mathlib.Data.Finset.Lattice` | leftmost crossing position |
+| `Finset.min'_mem`, `Finset.min'_le` | same | membership + minimality |
+| `Finset.mem_filter`, `Finset.mem_Ico` | `Mathlib.Data.Finset.Basic` | crossing-set membership |
+| `List.sum_take_succ` | `Mathlib.Data.List.Basic` | one-step prefix-sum recursion |
+| `List.getElem_mem` | `Mathlib.Data.List.Basic` | indexed-element membership |
+
+No Mathlib gap is anticipated. The proof complexity is comparable to
+`unit_decrement_downward_ivt` (the m = 1 case) — about 35–45 lines.
+
+## Files inspected this session
+
+- `proofs/Proofs/BallotProblemOQ01.lean` (789 LOC) — base definitions:
+  `prefixSum`, `cyclicRotation`, `isGoodRotation`, `goodRotations`,
+  `goodRotations_nonempty` (`:494`), `goodRotations_card_le` (`:563`),
+  `goodRotations_card_ge` (`:731`).
+- `proofs/Proofs/BallotProblemOQ01OQ01.lean` (151 LOC) — {+1,-k} cycle lemma.
+- `proofs/Proofs/BallotProblemOQ01OQ01OQ02.lean` (211 LOC) — abstract cycle
+  lemma; the parent's `unit_decrement_downward_ivt` (`:60`) is the m = 1
+  template to generalize.
+- `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json` — source of
+  the openQuestions[0] string this S1 OBSERVE refutes.
+
+## Next steps
+
+1. **S2 ACT — m-jump downward IVT (conjecture D)**. Estimated effort: ~50
+   lines of Lean, mirroring the structure of `unit_decrement_downward_ivt`.
+   Place in a new file `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`
+   namespaced `BallotMJumpCycleLemma`.
+2. **S3 ACT — corollary: m-jump levels-achieved**. The m-jump IVT implies
+   every integer in `[minPrefixSum + m - 1, 0]` is *near-achieved* (within m).
+3. **S4 GALLERY** — create `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/`
+   directory with `meta.json` describing the refuted conjecture, the
+   counterexample, and the m-jump IVT as the recovered analog.
+
+## Honesty notes
+
+- The S1 refutation is elementary (2-element counterexample). The session
+  produced understanding, not deep mathematics.
+- Conjecture D (m-jump IVT) is *infrastructure*, not a "result"; framing it
+  as the S2 ACT target is honest only insofar as it actually unblocks
+  conjectures B/C/E. If the m-jump IVT is proved but no count-bound corollary
+  follows, the session yields a refactor without a theorem.
+- The refuted-conjecture finding is publishable in the gallery's "open
+  questions resolved" section (parent meta openQuestions[0]).

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md
@@ -1,0 +1,129 @@
+# Problem: Step ≥ -m Cycle Lemma — Refuting the Naive ⌈S/m⌉ Lower Bound
+
+## Statement
+
+### Plain Language
+
+Parent: `ballot-problem-oq-01-oq-01-oq-02` (Abstract Cycle Lemma for arbitrary
+integer sequences) proves two cycle-lemma extremes:
+
+- **Unit-decrement** (every step ≥ -1, sum S > 0): `|goodRotations l| ≥ S`
+  (in fact `= S` in the classical {+1, -k} subcase).
+- **All-positive** (every step > 0): `|goodRotations l| = l.length`.
+
+The seeker-extracted question (parent meta `openQuestions[0]`) asks:
+
+> *For step ≥ -m sequences (m > 1), is `|goodRotations l| ≥ ⌈l.sum / m⌉`?*
+
+The motivating conjecture posited an "analog of the downward IVT with jumps of
+size at most m replacing jumps of size at most 1", yielding the fractional
+lower bound `⌈S/m⌉` on the good-rotation count.
+
+### Formal Statement (the conjecture under test)
+
+For `l : List ℤ` and `m : ℕ` with `m ≥ 1`:
+```
+(∀ x ∈ l, -(m : ℤ) ≤ x)  →  0 < l.sum  →
+  (Int.toNat ⌈(l.sum : ℚ) / m⌉) ≤ (goodRotations l).card
+```
+
+(Stated rationally to handle the ceiling cleanly; equivalent to
+`l.sum ≤ m * (goodRotations l).card`.)
+
+### Resolution (this session, S1 OBSERVE)
+
+**The conjecture is FALSE for every m ≥ 2.**
+
+Counterexample family: `l = [-m, K]` where `K = m + S` and `S ≥ 1`. Then:
+- Every step is ≥ -m. ✓
+- `l.sum = -m + K = S > 0`. ✓
+- Only `i = 1` is a good rotation (cyclicRotation = `[K, -m]`, prefix sums
+  `K, S`, both positive); `i = 0` fails at the first prefix sum (`-m < 0`).
+- So `(goodRotations l).card = 1`.
+- Choose `S = m + 1` to get `⌈S/m⌉ = ⌈(m+1)/m⌉ = 2 > 1`. ✗
+
+The smallest concrete witness (m = 2, S = 3, length 2):
+```
+l = [-2, 5]   sum = 3, m = 2, ⌈3/2⌉ = 2
+prefix sums of l           : 0, -2, 3        → i = 0 fails (-2 < 0)
+prefix sums of [5, -2]     : 0,  5, 3        → i = 1 good
+|goodRotations l| = 1  <  ⌈3/2⌉ = 2
+```
+
+### Why the naive bound fails
+
+The unit-decrement IVT (parent, `unit_decrement_downward_ivt`) reaches *every*
+integer level in `[minPrefixSum, 0]` because consecutive prefix sums change by
+at most 1. With step ≥ -m and `m ≥ 2`, prefix sums can drop by `m` in a single
+step, *skipping* up to `m - 1` integer levels per drop. The "concentrated
+negative mass" family above realises a worst-case skip: a single `-m` step
+collapses all the negative mass, eliminating intermediate good-rotation
+witnesses.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 8           # upgraded — the conjecture has a one-line refutation
+phase: OBSERVE
+status: in-progress
+tags:
+  - seeker-selected
+  - ballot-problem
+  - cycle-lemma
+  - generalization
+  - refuted-conjecture
+```
+
+**Significance**: 6/10 (clarifies a natural-but-wrong direction in the parent's
+open-question list; the *correct* m-aware lower bound is still open).
+
+**Tractability**: 8/10 (refutation is elementary; refined conjectures are
+small-Lean-formalization scope).
+
+## Refined Conjectures (candidates for S2 ACT)
+
+| # | Statement | Status |
+|---|-----------|--------|
+| **A** | `0 < l.sum → 0 < (goodRotations l).card` (no `m` needed) | Already proven: `goodRotations_nonempty` in `BallotProblemOQ01.lean:494` |
+| **B** | `(∀ x ∈ l, -m ≤ x) → 0 < l.sum → l.sum ≤ m · (goodRotations l).card + (m - 1) · l.length` | Open; the `(m-1)·length` slack absorbs level-skipping |
+| **C** | `(∀ x ∈ l, -m ≤ x) → 0 < l.sum → l.sum - (m - 1) · #{negative-step positions} ≤ m · (goodRotations l).card` | Open; sharper, charges the slack per negative step |
+| **D** | **m-jump downward IVT**: if `prefixSum l i > v` and `prefixSum l j ≤ v` with `j > i`, some `k ∈ (i, j]` has `prefixSum l k ∈ [v - m + 1, v]` | Open; direct m-generalization of `unit_decrement_downward_ivt` |
+| **E** | `|goodRotations l| ≥ ⌈l.sum / m⌉` *under additional hypothesis* `∀ x ∈ l, x ≠ 0 → x ≥ 1` (i.e. positive steps are +1) | Open; restores the {+1, -m} regime |
+
+Conjecture **D** is the *infrastructure* analog — it captures what genuinely
+generalizes from the m = 1 case. The S2 ACT target is to formalize **D** in
+Lean, since it is the building block any sharpened version of the count bound
+will use.
+
+## Why This Matters
+
+1. **Refuted-conjecture publication value** — The parent meta listed this as a
+   natural next-step question; recording the elementary counterexample saves
+   future agents from chasing a false direction.
+2. **Correct generalization path** — Conjecture **D** (m-jump IVT) is the
+   genuine analog of the unit-decrement IVT and unblocks any sharper count
+   bound (e.g. the {+1, -m} subcase in conjecture **E**).
+3. **Connects to Mohanty 1979** — The parent meta references Mohanty's
+   "generalized cycle lemma for multi-step alphabets such as {+a, -b}". This
+   sub-question clarifies that the right setting is *bounded step alphabets*,
+   not just *bounded negative steps*.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `ballot-problem` | Classical statement, k = 1 case |
+| `ballot-problem-oq-01` | Strong Dvoretzky-Motzkin {+1,-k} with explicit count formula |
+| `ballot-problem-oq-01-oq-01` | Cycle-lemma proof for {+1,-k} via leftmost crossing |
+| `ballot-problem-oq-01-oq-01-oq-02` | **Parent** — abstract cycle lemma, step ≥ -1 and step > 0 cases |
+
+## References
+
+- Dvoretzky & Motzkin, "A problem of arrangements", *Duke Math J*, 1947 —
+  cycle lemma for {+1, -k}.
+- Mohanty, *Lattice Path Counting and Applications*, Academic Press, 1979 —
+  generalized cycle lemma for {+a, -b} alphabets; cited by the parent meta as
+  "the natural next-step generalization beyond unit-decrement".
+- Stanley, *Enumerative Combinatorics I* (2nd ed), CUP, 2011, §1.5.

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,43 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12T19:42:00Z
+**Iteration**: 1
+**Last researcher**: researcher-1
+
+## Current Focus
+
+S1 OBSERVE complete: the parent meta's `openQuestions[0]` conjecture
+`(step ≥ -m) ∧ (S > 0) → ⌈S/m⌉ ≤ |goodRotations|` is **refuted** by the
+two-element family `l = [-m, m + S]` (smallest witness: `m = 2`, `l = [-2, 5]`,
+`|goodRotations| = 1`, `⌈3/2⌉ = 2`).
+
+See `problem.md` for the full statement and refutation, and `knowledge.md` for
+the worked verification, mechanism-of-failure analysis, and five refined
+conjectures **A–E**.
+
+## Active Approach
+
+S2 ACT target: **conjecture D — m-jump downward IVT**, the direct
+m-generalization of the parent's `unit_decrement_downward_ivt`
+(`BallotProblemOQ01OQ01OQ02.lean:60`). The conclusion window
+`[v - m + 1, v]` collapses to `{v}` at m = 1, recovering the unit-decrement
+IVT. Proof template transfers verbatim (leftmost-crossing `Finset.min'`).
+
+## Blockers
+
+None. No Mathlib gap anticipated (all required primitives — `Finset.min'`,
+`Finset.min'_mem`, `Finset.min'_le`, `List.sum_take_succ`, `List.getElem_mem`
+— present in v4.26.0).
+
+## Next Action
+
+S2 ACT: create `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` namespaced
+`BallotMJumpCycleLemma`, prove `m_jump_downward_ivt` (~50 LOC). Optionally
+add `m_jump_levels_achieved` corollary (~30 LOC).
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (S1 OBSERVE — refutation by example)

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,395 @@
+{
+  "slug": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+  "title": "Step ≥ -m Cycle Lemma — Refuting the Naive ⌈S/m⌉ Lower Bound",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(∀ x ∈ l, -(m : ℤ) ≤ x) → 0 < l.sum → (Int.toNat ⌈(l.sum : ℚ) / m⌉) ≤ (goodRotations l).card",
+    "plain": "For step ≥ -m sequences (m > 1) with sum S > 0, is |goodRotations l| ≥ ⌈S/m⌉? (Conjecture refuted this session.)",
+    "whyMatters": [
+      "Resolves parent meta openQuestions[0] — the natural-but-wrong direction is now documented.",
+      "Identifies conjecture D (m-jump downward IVT) as the genuine generalization of the parent unit-decrement IVT.",
+      "Clarifies that bounded *negative* steps alone do not control |goodRotations|; bounded step alphabets (Mohanty 1979) are the correct setting."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "goodRotations_nonempty (BallotProblemOQ01.lean:494): 0 < l.sum → 0 < |goodRotations l|, for arbitrary l.",
+      "|goodRotations l| = l.sum when steps ∈ {+1, -k} (parent strong cycle lemma).",
+      "|goodRotations l| = l.length when all steps > 0 (parent all-positive case)."
+    ],
+    "open": [
+      "Conjecture D — m-jump downward IVT: prefixSum landing window [v-m+1, v] when crossing v downward.",
+      "Conjecture B — slack count bound: l.sum ≤ m·|goodRotations| + (m-1)·l.length under step ≥ -m.",
+      "Conjecture C — sharper bound charging slack per negative step.",
+      "Conjecture E — restricted alphabet {+1, -m}: recovers ⌈S/m⌉ ≤ |goodRotations| (essentially proven by parent infrastructure)."
+    ],
+    "goal": "Formalize conjecture D (m-jump downward IVT) in Lean as the foundational m-generalization.",
+    "refutedConjecture": {
+      "statement": "(∀ x ∈ l, -m ≤ x) ∧ 0 < l.sum → ⌈S/m⌉ ≤ |goodRotations l|",
+      "counterexample": "l = [-m, m+S] for any m ≥ 2 and any S ≥ m+1; smallest: m=2, l=[-2,5], sum=3, ⌈3/2⌉=2, |goodRotations|=1.",
+      "mechanism": "A single -m step skips m-1 integer levels of the prefix-sum trajectory, eliminating m-1 would-be good-rotation witnesses that the unit-decrement IVT supplies in the m=1 case."
+    }
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T19:42:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE complete; refutation documented; S2 ACT target (conjecture D, m-jump downward IVT) identified.",
+    "blockers": [],
+    "nextAction": "S2 ACT: create proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean (namespace BallotMJumpCycleLemma); prove m_jump_downward_ivt mirroring unit_decrement_downward_ivt with conclusion window [v-m+1, v].",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE: Refuted parent openQuestions[0] via 2-element counterexample family l = [-m, m+S]. Identified m-jump downward IVT (conjecture D) as the genuine m-generalization of the parent unit-decrement IVT, with mirroring leftmost-crossing proof template. No Mathlib gap.",
+    "builtItems": [
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md — full restatement with refutation and 5 refined conjectures A-E",
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md — worked verification, mechanism analysis, Mathlib audit, next-steps roadmap"
+    ],
+    "insights": [
+      "Two-element counterexample suffices: l = [-m, m+S] with S = m+1 gives |goodRotations| = 1 < 2 = ⌈S/m⌉ for all m ≥ 2.",
+      "The IVT in the m = 1 case derives its power from the level-visitation guarantee (consecutive prefix sums differ by ≤ 1). For m ≥ 2, a single -m step can skip m-1 integer levels.",
+      "The {+1,-k} cycle lemma works because BOTH the up-climbs (every level visited via +1 steps) AND the down-drops are constrained. The refuted conjecture controlled only the down-drops.",
+      "The right m-generalization places the witness in a window [v-m+1, v] of width m (D), not at exact level v."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "S2 ACT: prove conjecture D (m-jump downward IVT) ~50 LOC in new file BallotProblemOQ01OQ01OQ02OQ01.lean.",
+      "S3 ACT (optional): prove conjecture E (restricted alphabet {+1, -m}) using the existing {+1, -k} infrastructure.",
+      "S4 GALLERY: create src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/ with meta.json describing the refuted conjecture and the recovered m-jump IVT."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "ballot-problem",
+    "cycle-lemma",
+    "generalization",
+    "refuted-conjecture"
+  ],
+  "relatedProofs": [
+    "ballot-problem",
+    "ballot-problem-oq-01",
+    "ballot-problem-oq-01-oq-01",
+    "ballot-problem-oq-01-oq-01-oq-02",
+    "ballot-problem-oq-01-oq-02",
+    "ballot-problem-oq-01-oq-02-oq-01",
+    "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "ballot-problem-oq-01-oq-02-oq-04",
+    "ballot-problem-oq-01-oq-04",
+    "ballot-problem-oq-01-oq-04-oq-01",
+    "ballot-problem-oq-02",
+    "ballot-problem-oq-02-oq-02",
+    "ballot-problem-oq-03",
+    "ballot-problem-oq-03-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-01-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-02",
+    "ballot-problem-oq-03-oq-01-oq-04",
+    "ballot-problem-oq-03-oq-02",
+    "ballot-problem-oq-03-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-08T19:09:00.560Z",
+  "lastUpdate": "2026-05-12T19:42:00Z",
+  "significance": 6,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/BallotProblem.lean",
+      "filename": "BallotProblem.lean",
+      "lineCount": 252,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblem.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01.lean",
+      "filename": "BallotProblemOQ01.lean",
+      "lineCount": 790,
+      "theoremCount": 44,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ01.lean",
+      "filename": "BallotProblemOQ01OQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ01OQ02.lean",
+      "filename": "BallotProblemOQ01OQ01OQ02.lean",
+      "lineCount": 212,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02.lean",
+      "lineCount": 1048,
+      "theoremCount": 37,
+      "axiomCount": 0,
+      "defCount": 18,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
+      "filename": "BallotProblemOQ01OQ02OQ01.lean",
+      "lineCount": 250,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
+      "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
+      "lineCount": 113,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean",
+      "filename": "BallotProblemOQ01OQ02OQ01OQ01.lean",
+      "lineCount": 201,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ01OQ02.lean",
+      "lineCount": 199,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ04.lean",
+      "filename": "BallotProblemOQ01OQ02OQ04.lean",
+      "lineCount": 312,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ04.lean",
+      "filename": "BallotProblemOQ01OQ04.lean",
+      "lineCount": 74,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ04Core.lean",
+      "filename": "BallotProblemOQ01OQ04Core.lean",
+      "lineCount": 179,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04Core.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
+      "filename": "BallotProblemOQ01OQ04OQ01.lean",
+      "lineCount": 1165,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ02.lean",
+      "filename": "BallotProblemOQ02.lean",
+      "lineCount": 340,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ02OQ02.lean",
+      "filename": "BallotProblemOQ02OQ02.lean",
+      "lineCount": 186,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03.lean",
+      "filename": "BallotProblemOQ03.lean",
+      "lineCount": 2923,
+      "theoremCount": 119,
+      "axiomCount": 0,
+      "defCount": 31,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ01.lean",
+      "filename": "BallotProblemOQ03OQ01OQ01.lean",
+      "lineCount": 131,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "lineCount": 2349,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 17,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
+      "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
+      "lineCount": 132,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
+      "filename": "BallotProblemOQ03OQ01OQ02.lean",
+      "lineCount": 399,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 118,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
+      "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
+      "lineCount": 15996,
+      "theoremCount": 79,
+      "axiomCount": 0,
+      "defCount": 15,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
+      "filename": "BallotProblemOQ03OQ01OQ04.lean",
+      "lineCount": 183,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ02.lean",
+      "filename": "BallotProblemOQ03OQ02.lean",
+      "lineCount": 2512,
+      "theoremCount": 28,
+      "axiomCount": 0,
+      "defCount": 23,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ03.lean",
+      "filename": "BallotProblemOQ03OQ03.lean",
+      "lineCount": 188,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for `ballot-problem-oq-01-oq-01-oq-02-oq-01`. Refutes the conjecture posed in the parent meta `openQuestions[0]`:

> *For step ≥ -m sequences (m > 1), is `|goodRotations l| ≥ ⌈l.sum / m⌉`?*

### Counterexample

Two-element family `l = [-m, m + S]`. For `m = 2`, `S = 3`:

```
l = [-2, 5]   sum = 3, m = 2, ⌈3/2⌉ = 2
prefix sums of l           : 0, -2, 3        → i = 0 fails (-2 < 0)
prefix sums of [5, -2]     : 0,  5, 3        → i = 1 good
|goodRotations l| = 1  <  ⌈3/2⌉ = 2
```

### Mechanism of failure

The parent's `unit_decrement_downward_ivt` succeeds because consecutive prefix sums differ by at most 1 (so the trajectory visits every integer level on the way down). With step ≥ -m and `m ≥ 2`, a single `-m` step can skip up to `m − 1` integer levels, eliminating would-be good-rotation witnesses.

### Refined conjectures (S2 candidates)

Five refined conjectures **A–E** are documented in `problem.md` / `knowledge.md`. Recommended S2 ACT target: **conjecture D — m-jump downward IVT** with conclusion window `[v − m + 1, v]`, the genuine m-generalization of `unit_decrement_downward_ivt` (BallotProblemOQ01OQ01OQ02.lean:60). Proof template transfers verbatim via leftmost-crossing `Finset.min'`.

### Files (doc-only, no Lean changes)

- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md` — full restatement + refutation + refined conjectures
- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md` — worked verification, mechanism analysis, Mathlib audit, next-steps roadmap
- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md` — phase OBSERVE → S2 ACT pointer
- `src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json` — updated knowledge / nextAction / refutedConjecture record

## Mathlib status

No gap. Conjecture D (recommended S2 target) reuses primitives already used by the parent: `Finset.min'`, `Finset.min'_mem`, `Finset.min'_le`, `Finset.mem_filter`, `Finset.mem_Ico`, `List.sum_take_succ`, `List.getElem_mem` — all present in v4.26.0.

## Outcome

**Outcome**: progress (S1 OBSERVE)
**Next Steps**: S2 ACT — prove conjecture D (m-jump downward IVT) in a new file `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` (~50 LOC).

## Honesty

The refutation is a 2-element counterexample — elementary, not deep. The session's value is (i) saving future agents from chasing a false conjecture, and (ii) identifying the *correct* m-aware infrastructure target (m-jump IVT) for S2 ACT.

🤖 Generated by researcher-1