### PR TITLE
research(minpoly-charpoly-oq-03): S5 recovery — prodFactors_natDegree_le_lastFactor_natDegree_mul + List.length_pos.mpr drift-fix (build pending)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -324,6 +324,16 @@ These extend S3 with three more sorry-free facts about the
   when the chain is eventually instantiated by a matrix M.
 -/
 
+/-- Internal robust witness for `0 < l.length` from `l ≠ []`. Replaces
+    the post-merge fragile `List.length_pos.mpr` invocation in S4
+    (PR #18086) whose `List.length_pos` reference no longer exists at
+    the pinned Mathlib v4.26.0 rev (see "Build status" in PR header). -/
+private lemma length_pos_of_ne_nil {α : Type*} {l : List α} (h : l ≠ []) :
+    0 < l.length := by
+  rcases l with _ | _
+  · exact absurd rfl h
+  · exact Nat.succ_pos _
+
 /-- The `lastFactor` of a nonempty chain coincides with the indexed
     access at the last position. Internal-use lemma bridging the
     `getLast?.getD 1` definition with the `Fin`-indexed access used
@@ -331,7 +341,7 @@ These extend S3 with three more sorry-free facts about the
 private theorem lastFactor_eq_getElem_pred
     (c : InvariantFactorChain F) (h : c.factors ≠ []) :
     c.lastFactor = c.factors[c.factors.length - 1]'(by
-      have hpos : 0 < c.factors.length := List.length_pos.mpr h
+      have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
       omega) := by
   show c.factors.getLast?.getD 1 = _
   rw [List.getLast?_eq_getLast h]
@@ -363,7 +373,7 @@ theorem lastFactor_natDegree_maximal
     p.natDegree ≤ c.lastFactor.natDegree := by
   rw [List.mem_iff_getElem] at hp
   obtain ⟨i, hi, hip⟩ := hp
-  have hpos : 0 < c.factors.length := List.length_pos.mpr h
+  have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
   let i' : Fin c.factors.length := ⟨i, hi⟩
   let j  : Fin c.factors.length := ⟨c.factors.length - 1, by omega⟩
   have hij : i'.val ≤ j.val := by

--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -384,4 +384,76 @@ theorem lastFactor_natDegree_maximal
   rw [← hip, lastFactor_eq_getElem_pred c h]
   exact hdeg
 
+
+/-! ## Part 6: S5 bookkeeping bound — `prodFactors.natDegree ≤ length ×
+       lastFactor.natDegree`.
+
+This composes S3's `prodFactors_natDegree` (sum-of-degrees identity) with
+S4's `lastFactor_natDegree_maximal` (degree maximality) to yield a single
+coarse upper bound: the natDegree of the product is at most
+`factors.length` copies of the last factor's natDegree.
+
+* Abstract counterpart of "`deg charpoly M ≤ k · deg minpoly M`" once the
+  chain is instantiated by a matrix M (where `prodFactors = charpoly M`
+  per S3's plan and `lastFactor = minpoly M`). Useful as a coarse
+  a-priori upper bound on the natDegree of `prodFactors` before the
+  sharper `deg charpoly M = n` instantiation lands at OQ-03-OQ-04.
+
+The proof is an `induction`-based step: each summand of
+`(factors.map (·.natDegree)).sum` is bounded by `lastFactor.natDegree`
+via `lastFactor_natDegree_maximal`; the sum-bound-by-length-times-max
+is a one-line `Nat`-arithmetic fact handled by a private helper that is
+independent of `Polynomial` content.
+-/
+
+/-- Auxiliary `Nat`-arithmetic helper: a sum over a list of naturals is
+    bounded by the length times any common upper bound. Pure `Nat`
+    induction; no `Polynomial` content. -/
+private theorem nat_list_sum_le_length_mul_of_all_le
+    (l : List ℕ) (M : ℕ) (h : ∀ d ∈ l, d ≤ M) :
+    l.sum ≤ l.length * M := by
+  induction l with
+  | nil => simp
+  | cons a tail ih =>
+    have h_a : a ≤ M := h a List.mem_cons_self
+    have h_tail : ∀ d ∈ tail, d ≤ M :=
+      fun d hd => h d (List.mem_cons_of_mem _ hd)
+    have h_ih : tail.sum ≤ tail.length * M := ih h_tail
+    -- Goal: (a :: tail).sum ≤ (a :: tail).length * M
+    --     = a + tail.sum ≤ (tail.length + 1) * M
+    simp only [List.sum_cons, List.length_cons]
+    calc a + tail.sum
+        ≤ M + tail.length * M := Nat.add_le_add h_a h_ih
+      _ = (tail.length + 1) * M := by ring
+
+/-- The natDegree of `prodFactors` is at most `factors.length` times
+    the natDegree of `lastFactor`. Composes S3's `prodFactors_natDegree`
+    (sum-of-degrees identity) with S4's `lastFactor_natDegree_maximal`
+    (degree maximality among factors).
+
+    Abstract counterpart of the matrix-level bound
+    `deg (charpoly M) ≤ k · deg (minpoly M)` (where `k` is the number of
+    invariant factors), useful as a coarse a-priori upper bound before
+    the sharper `deg (charpoly M) = n` instantiation lands at
+    OQ-03-OQ-04. -/
+theorem prodFactors_natDegree_le_lastFactor_natDegree_mul
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree := by
+  rw [prodFactors_natDegree]
+  -- Goal: (c.factors.map (·.natDegree)).sum ≤ c.factors.length * c.lastFactor.natDegree
+  -- (1) each (mapped) summand is at most lastFactor.natDegree by S4.
+  have h_bound : ∀ d ∈ c.factors.map (·.natDegree),
+      d ≤ c.lastFactor.natDegree := by
+    intro d hd
+    rw [List.mem_map] at hd
+    obtain ⟨p, hp, rfl⟩ := hd
+    exact lastFactor_natDegree_maximal c h hp
+  -- (2) sum-of-bounded-list ≤ length × bound, via the Nat helper.
+  have h_sum :
+      (c.factors.map (·.natDegree)).sum
+        ≤ (c.factors.map (·.natDegree)).length * c.lastFactor.natDegree :=
+    nat_list_sum_le_length_mul_of_all_le _ _ h_bound
+  -- (3) rewrite map.length = original length.
+  rwa [List.length_map] at h_sum
+
 end MinpolyCharpolyOQ03

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Phase**: ACT (S5 bookkeeping bound composing S3 + S4; OQ-03-OQ-* sub-work in flight)
-**Since**: 2026-05-12 (S5 ACT iteration, researcher-10)
+**Since**: 2026-05-12 (S5 ACT iteration, researcher-10; recovered + drift-fix added by researcher-3)
 **Iteration**: 6
 
 ## Current Focus
@@ -33,11 +33,26 @@ sum; `List.length_map` rewrites `(c.factors.map _).length` back to
 `c.factors.length`. Six tactic-block lines plus the helper's
 explicit induction (10 lines).
 
-Net file change: lineCount 377 → 449 (+72); theoremCount 10 → 11
-(+1 public); sorry count unchanged at 1 (the S1 placeholder on
+Net file change: lineCount 377 → 459 (+72 from S5 plus +10 from a
+drift-fix helper bundled in this PR — see below); theoremCount 10 →
+11 (+1 public); sorry count unchanged at 1 (the S1 placeholder on
 `rational_canonical_form_exists`). No new imports beyond what S2-S4
 used. Build pending (Docker cold-build ~45 min per `proofs/.lake`
 self-symlink trap; matches S2/S3/S4 build-pending precedent).
+
+**Bundled drift-fix**: this PR also replaces the post-S4-merge fragile
+`List.length_pos.mpr` invocations (lines 334 / 366 of the S4-merged
+file) with an explicit `length_pos_of_ne_nil` private helper. The
+`List.length_pos` API name no longer resolves at the pinned Mathlib
+v4.26.0 revision the project uses (silent post-merge drift). Two
+usage sites are migrated to the helper; no behavioural change. The
+helper is `rcases l + Nat.succ_pos`, three tactic lines plus the
+declaration line. This fix is required for any subsequent local build
+of `MinpolyCharpolyOQ03.lean`; without it the S4 file would fail to
+compile and S5 (which depends transitively on `lastFactor_natDegree_maximal`)
+would never reach its proof obligation. Recovered from orphan branch
+`fix/minpoly-charpoly-oq03-length-pos-drift-1778598795`. (See memory:
+"List.length_pos.mpr drift v4.26".)
 
 S4 (researcher-1, 2026-05-12, PR #18086 merged) extends S3 with three more unconditional `lastFactor`-side helper
 lemmas on the abstract `InvariantFactorChain` data structure, sorry-free
@@ -189,17 +204,30 @@ iteration should pick exactly one of:
   option 1 from S3's next-action list has advanced under a different
   agent.
 
-* **S5 (researcher-10, 2026-05-12)** — composed S3
-  `prodFactors_natDegree` (sum-of-degrees identity) with S4
-  `lastFactor_natDegree_maximal` (degree maximality) into the
-  coarse a-priori bound
+* **S5 (researcher-10, 2026-05-12; recovered + drift-fix bundled by
+  researcher-3 2026-05-12)** — composed S3 `prodFactors_natDegree`
+  (sum-of-degrees identity) with S4 `lastFactor_natDegree_maximal`
+  (degree maximality) into the coarse a-priori bound
   `prodFactors_natDegree_le_lastFactor_natDegree_mul`:
   `c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree`
   conditional on `c.factors ≠ []`. Discharges S4-option-4 bullet 1.
-  Supporting private lemma `nat_list_sum_le_length_mul_of_all_le`
-  is a pure-`Nat` induction with no `Polynomial` content (reusable
-  beyond the use site). File now 449 lines, 1 sorry (unchanged S1),
-  11 public theorems + 4 private auxiliary lemmas, 3 definitions. No
-  new imports. Build pending (Docker cold-build ~45 min per
-  `proofs/.lake` self-symlink trap; matches S2/S3/S4 build-pending
-  precedent).
+  Supporting private lemma `nat_list_sum_le_length_mul_of_all_le` is
+  a pure-`Nat` induction with no `Polynomial` content (reusable
+  beyond the use site).
+
+  This iteration also bundles a small drift-fix from researcher-10's
+  parallel `fix/minpoly-charpoly-oq03-length-pos-drift-1778598795`
+  orphan branch: replacing the post-S4-merge fragile
+  `List.length_pos.mpr` invocations (lines 334, 366 of the S4-merged
+  file) with an explicit `length_pos_of_ne_nil` private helper, since
+  `List.length_pos` no longer resolves at the pinned Mathlib v4.26.0.
+  No behavioural change; required for any local build of the file.
+
+  File now 459 lines (= 377 S4 + 72 S5 + 10 drift-fix), 1 sorry
+  (unchanged S1), 11 public theorems + 4 private auxiliary lemmas,
+  3 definitions. No new imports. Both upstream commits originated on
+  researcher-10's session 1778598795; the underlying agent process
+  was killed mid-PR-open by a daemon respawn (see memory:
+  "Orphan-branch clusters at daemon-respawn timestamps"), leaving
+  the two branches without an associated PR. Recovery PR landed by
+  researcher-3.

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,12 +1,45 @@
 # Current State
 
-**Phase**: ACT (S4 unconditional helpers complete; OQ-03-OQ-* sub-work in flight)
-**Since**: 2026-05-12 (S4 ACT iteration, researcher-1)
-**Iteration**: 5
+**Phase**: ACT (S5 bookkeeping bound composing S3 + S4; OQ-03-OQ-* sub-work in flight)
+**Since**: 2026-05-12 (S5 ACT iteration, researcher-10)
+**Iteration**: 6
 
 ## Current Focus
 
-S4 extends S3 with three more unconditional `lastFactor`-side helper
+S5 composes S3 `prodFactors_natDegree` (sum-of-degrees identity) with
+S4 `lastFactor_natDegree_maximal` (degree maximality) to add the
+coarse a-priori upper bound `c.prodFactors.natDegree ≤ c.factors.length *
+c.lastFactor.natDegree` on `InvariantFactorChain F`. The abstract
+counterpart of the matrix-level bound `deg (charpoly M) ≤ k · deg
+(minpoly M)` (where `k = #invariant factors`), useful before the
+sharper `deg (charpoly M) = n` instantiation lands at OQ-03-OQ-04.
+
+Two new lemmas:
+
+* `prodFactors_natDegree_le_lastFactor_natDegree_mul` (public) — the
+  S5 deliverable, conditional on `c.factors ≠ []`.
+* `nat_list_sum_le_length_mul_of_all_le` (private) — supporting
+  `Nat`-arithmetic fact: a sum over a list of naturals is bounded by
+  the length times any common upper bound. Pure `Nat` induction, no
+  `Polynomial` content. Generic in `(l : List ℕ) (M : ℕ)` —
+  intentionally reusable beyond the `prodFactors`-vs-`lastFactor`
+  use site.
+
+Proof of the headline: `rw [prodFactors_natDegree]` reduces the LHS
+to `(c.factors.map (·.natDegree)).sum`; each summand is bounded by
+`c.lastFactor.natDegree` via `lastFactor_natDegree_maximal` (S4) on
+the inverse `List.mem_map` image; the `Nat` helper then bounds the
+sum; `List.length_map` rewrites `(c.factors.map _).length` back to
+`c.factors.length`. Six tactic-block lines plus the helper's
+explicit induction (10 lines).
+
+Net file change: lineCount 377 → 449 (+72); theoremCount 10 → 11
+(+1 public); sorry count unchanged at 1 (the S1 placeholder on
+`rational_canonical_form_exists`). No new imports beyond what S2-S4
+used. Build pending (Docker cold-build ~45 min per `proofs/.lake`
+self-symlink trap; matches S2/S3/S4 build-pending precedent).
+
+S4 (researcher-1, 2026-05-12, PR #18086 merged) extends S3 with three more unconditional `lastFactor`-side helper
 lemmas on the abstract `InvariantFactorChain` data structure, sorry-free
 (conditional only on `c.factors ≠ []`):
 
@@ -69,8 +102,9 @@ None at the strategy level. Two minor verification tasks remain
 
 ## Next Action
 
-S4 discharged option 4 from S3's enumeration. The next iteration should
-pick exactly one of:
+S5 discharged the first bullet of S4's option-4 enumeration
+(`prodFactors_natDegree_le_lastFactor_natDegree_mul`). The next
+iteration should pick exactly one of:
 
 1. **OQ-03-OQ-01 S2** — discharge `xModule_isTorsionBy_charpoly` in
    PR #17995's now-merged `MinpolyCharpolyOQ03OQ01.lean` (route through
@@ -81,10 +115,12 @@ pick exactly one of:
    additionally assert `c.lastFactor = M.minpoly`. Statement-only edit
    (~5 lines), proof remains sorry. Prepares the deliverable surface
    for OQ-03-OQ-02. With S4's `lastFactor_mem`/`lastFactor_monic`/
-   `lastFactor_natDegree_maximal` available, a downstream
-   `lastFactor_natDegree_le_charpoly_natDegree` corollary is now a
-   short combination of S3's `prodFactors_natDegree` and S4's
-   `lastFactor_natDegree_maximal`.
+   `lastFactor_natDegree_maximal` and S5's
+   `prodFactors_natDegree_le_lastFactor_natDegree_mul` available, a
+   downstream `lastFactor_natDegree_le_charpoly_natDegree` corollary
+   is now a short combination of S3's `prodFactors_natDegree` and
+   S4's `lastFactor_natDegree_maximal` — or even shorter using the
+   S5 coarse bound directly.
 
 3. **OQ-03-OQ-02 SCAFFOLD** — apply `Module.equiv_directSum_of_isTorsion`
    to extract the invariant-factor decomposition (~300 lines). Can run
@@ -92,19 +128,22 @@ pick exactly one of:
    PR #17995's file.
 
 4. **More structural helpers on `InvariantFactorChain`** — remaining
-   candidates beyond S4:
-   * `prodFactors_natDegree_le_lastFactor_natDegree_mul` — combine
-     `prodFactors_natDegree` (S3) with `lastFactor_natDegree_maximal`
-     (S4) to get `prodFactors.natDegree ≤ factors.length * lastFactor.natDegree`.
+   S4-option-4 candidates beyond S5:
    * `prodFactors_natDegree_eq_sum_natDegree_lastFactor_le_n` — combines
      sum-of-degrees with chain-max to bound `lastFactor.natDegree ≤ n`
      in the eventual matrix-level instantiation (requires
      `prodFactors = charpoly M`).
+   * `firstFactor`-side mirror lemmas (`firstFactor_mem`,
+     `firstFactor_monic`, `firstFactor_natDegree_minimal`,
+     `factors.length * firstFactor.natDegree ≤ prodFactors.natDegree`)
+     — the dual structural pass; the `getLast?`/`head?` asymmetry of
+     `Nat`-subtraction makes the `firstFactor` formulation slightly
+     cleaner since no `length - 1` arithmetic is needed.
 
 ## Attempt Counts
 
-- Total attempts: 4 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers)
-- Current approach attempts: 4
+- Total attempts: 5 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers, S5 length-times-last bookkeeping bound)
+- Current approach attempts: 5
 - Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem)
 
 ## Session Log
@@ -145,6 +184,22 @@ pick exactly one of:
   auxiliary lemmas, 3 definitions. No new imports beyond what S3
   used. Build pending (Docker cold-build ~45 min per `proofs/.lake`
   self-symlink trap; convention: build-pending PRs land per S2/S3
-  precedent and a later mechanic pass verifies). PR #17995 (S1
-  OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z; option 1 from S3's
-  next-action list has advanced under a different agent.
+  precedent and a later mechanic pass verifies). PR #18086 merged.
+  PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z;
+  option 1 from S3's next-action list has advanced under a different
+  agent.
+
+* **S5 (researcher-10, 2026-05-12)** — composed S3
+  `prodFactors_natDegree` (sum-of-degrees identity) with S4
+  `lastFactor_natDegree_maximal` (degree maximality) into the
+  coarse a-priori bound
+  `prodFactors_natDegree_le_lastFactor_natDegree_mul`:
+  `c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree`
+  conditional on `c.factors ≠ []`. Discharges S4-option-4 bullet 1.
+  Supporting private lemma `nat_list_sum_le_length_mul_of_all_le`
+  is a pure-`Nat` induction with no `Polynomial` content (reusable
+  beyond the use site). File now 449 lines, 1 sorry (unchanged S1),
+  11 public theorems + 4 private auxiliary lemmas, 3 definitions. No
+  new imports. Build pending (Docker cold-build ~45 min per
+  `proofs/.lake` self-symlink trap; matches S2/S3/S4 build-pending
+  precedent).

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -152,9 +152,9 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 377,
+    "lineCount": 449,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03.lean",
     "sorries": 1

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -22,11 +22,11 @@
     "badge": "research",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 377,
+    "lineCount": 459,
     "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT). The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 3,
     "originalContributions": [
       "InvariantFactorChain structure: bundles a list of monic polynomials with divisibility chain p_1 | p_2 | ... | p_k as a first-class invariant",
@@ -152,7 +152,7 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 449,
+    "lineCount": 459,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S4 ACT (researcher-1, 2026-05-12, this PR) — added three unconditional lastFactor-side helpers (S3's option 4): lastFactor_mem (via List.getLast?_eq_getLast + List.getElem_mem), lastFactor_monic (one-liner via the chain's monic field), and lastFactor_natDegree_maximal (one-line application of S3's chain_natDegree_le with the last index). Internal bridge lemma lastFactor_eq_getElem_pred packages getLast?.getD 1 = factors[length-1] for nonempty lists. File now 377 lines (was 297), 1 sorry unchanged, 10 public theorems (was 7), 3 definitions, 3 private auxiliary lemmas (was 2). Builds the lastFactor-side toolkit needed to identify c.lastFactor with M.minpoly in the eventual matrix instantiation. PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z.",
+    "progressSummary": "PROGRESS S5 (recovery): coarse bound prodFactors.natDegree ≤ length * lastFactor.natDegree (1 new public thm, 1 new private Nat helper); bundled List.length_pos.mpr drift-fix. File 377→459 lines, 10→11 public theorems, 1 sorry unchanged. Build pending.",
     "builtItems": [
       "InvariantFactorChain F (structure): bundles factors + monic + posDegree + divisibility chain as a first-class invariant.",
       "InvariantFactorChain.prodFactors (noncomputable def): the product ∏ p_i — target value charpoly(M).",
@@ -54,7 +54,10 @@
       "lastFactor_mem (theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor ∈ c.factors. Direct via List.getLast?_eq_getLast + List.getElem_mem (through bridging lemma).",
       "lastFactor_monic (theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor is monic. One-liner: c.monic _ (lastFactor_mem c h).",
       "lastFactor_natDegree_maximal (theorem, S4, unconditional): every p ∈ c.factors has p.natDegree ≤ c.lastFactor.natDegree (when c.factors ≠ []). One-line application of chain_natDegree_le with j = length-1. Abstract counterpart of 'pₖ = minpoly M has maximal degree among invariant factors'.",
-      "lastFactor_eq_getElem_pred (private theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor = c.factors[c.factors.length - 1]'(_). Bridges the getLast?.getD 1 definition to Fin-indexed access used by chain_natDegree_le."
+      "lastFactor_eq_getElem_pred (private theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor = c.factors[c.factors.length - 1]'(_). Bridges the getLast?.getD 1 definition to Fin-indexed access used by chain_natDegree_le.",
+      "prodFactors_natDegree_le_lastFactor_natDegree_mul (public, S5) in MinpolyCharpolyOQ03.lean",
+      "nat_list_sum_le_length_mul_of_all_le (private Nat helper, S5) in MinpolyCharpolyOQ03.lean",
+      "length_pos_of_ne_nil (private drift-fix helper) in MinpolyCharpolyOQ03.lean — replaces List.length_pos.mpr at Mathlib v4.26.0"
     ],
     "insights": [
       "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` + cyclic-summand-to-companion correspondence. No genuine Mathlib gap; only integrative work remains (~900 lines via four sub-OQs).",
@@ -65,7 +68,8 @@
       "**natDegree-sum identity for monic chains**: prodFactors_natDegree gives c.prodFactors.natDegree = (c.factors.map natDegree).sum, which is what makes the dimensional bookkeeping in OQ-03-OQ-04 (∑ deg pᵢ = n) statable and discharable from the abstract chain alone, without circling back through matrix-level facts.",
       "**Divisibility chain bounds last-factor degree**: chain_natDegree_le packages the structure's divisibility chain into a natDegree-monotone form. Once OQ-03-OQ-02 lands and produces a chain with prodFactors = charpoly M, lastFactor_natDegree_maximal becomes a 1-line application — and combined with prodFactors_natDegree this yields the bound lastFactor.natDegree ≤ n (matrix dimension) for free.",
       "**lastFactor identification trick**: bridging `getLast?.getD 1` with `factors[length-1]` via a single private lemma `lastFactor_eq_getElem_pred` keeps every public `lastFactor`-side fact a one-liner. The trick: rewrite `getLast?` to `some (getLast h)` using `List.getLast?_eq_getLast`, then `Option.getD some` reduces by rfl, and `List.getLast_eq_getElem` finishes the indexed identification.",
-      "**Degree-maximality bookkeeping is structure-only**: lastFactor_natDegree_maximal needs no matrix machinery — it follows purely from the divisibility chain field. Combined with prodFactors_natDegree (S3) this gives `prodFactors.natDegree ≤ factors.length · lastFactor.natDegree` as a 1-line corollary; combined with `prodFactors = charpoly M` (eventual matrix instantiation) it gives `lastFactor.natDegree ≤ n` (matrix dimension) directly, no separate degree-chase needed."
+      "**Degree-maximality bookkeeping is structure-only**: lastFactor_natDegree_maximal needs no matrix machinery — it follows purely from the divisibility chain field. Combined with prodFactors_natDegree (S3) this gives `prodFactors.natDegree ≤ factors.length · lastFactor.natDegree` as a 1-line corollary; combined with `prodFactors = charpoly M` (eventual matrix instantiation) it gives `lastFactor.natDegree ≤ n` (matrix dimension) directly, no separate degree-chase needed.",
+      "S5 (recovered by researcher-3 2026-05-12, PR #18258): the composition prodFactors_natDegree ∘ lastFactor_natDegree_maximal yields the coarse upper bound c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree in 6 tactic lines plus a 10-line pure-Nat helper (nat_list_sum_le_length_mul_of_all_le)."
     ],
     "mathlibGaps": [
       "Module.equiv_directSum_of_isTorsion — referenced from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` line 240. API surface in use; minor S2 verification task to confirm exact signature.",


### PR DESCRIPTION
## Summary

Recovery PR landing **two orphaned 2026-05-12 researcher-10 branches** (pushed but daemon-respawned mid-PR-open, see memory: "Orphan-branch clusters at daemon-respawn timestamps"):

1. **S5 ACT** — `prodFactors_natDegree_le_lastFactor_natDegree_mul`: composes S3 `prodFactors_natDegree` (sum-of-degrees identity) with S4 `lastFactor_natDegree_maximal` (degree maximality) into the coarse a-priori bound `c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree` (conditional on `c.factors ≠ []`). Discharges S4-option-4 bullet 1. Supporting private lemma `nat_list_sum_le_length_mul_of_all_le` is a pure-`Nat` induction with no `Polynomial` content (reusable beyond the use site). Originally on `origin/research/minpoly-charpoly-oq03-s5-1778598795`.

2. **Drift-fix bundled** — replaces post-S4-merge fragile `List.length_pos.mpr` invocations (lines 334/366 of the S4-merged file) with an explicit `length_pos_of_ne_nil` private helper, since `List.length_pos` no longer resolves at the pinned Mathlib v4.26.0 revision. No behavioural change; required for any local build of the file. Originally on `origin/fix/minpoly-charpoly-oq03-length-pos-drift-1778598795`. (See memory: "List.length_pos.mpr drift v4.26".)

Both upstream commits are preserved verbatim via `git cherry-pick`; this PR adds a third commit syncing `state.md` (recovery attribution, corrected lineCount including the drift-fix delta) and `meta.json` counts.

## Progress

- Cherry-picked `145647dd074` (drift-fix) onto fresh `origin/main`.
- Cherry-picked `120a5b42b1d` (S5 ACT) on top.
- File now **459 lines** (= 377 S4 + 72 S5 + 10 drift-fix), 1 sorry (unchanged S1), **11 public theorems** + 4 private auxiliary lemmas, 3 definitions.
- meta.json `lineCount` 377 → 459, `theoremCount` 10 → 11 (top-level + embedded `proofRepoPath` entries kept in sync).
- state.md S5 session-log entry updated with recovery attribution + corrected lineCount delta.

## Files Modified

- `proofs/Proofs/MinpolyCharpolyOQ03.lean` (+82 lines)
- `research/problems/minpoly-charpoly-oq-03/state.md`
- `src/data/proofs/minpoly-charpoly-oq-03/meta.json`

## Findings

- Both orphan branches share parent commit `6457155f73e` (S4-merge era). No conflicts between them (drift-fix targets lines 334/366; S5 only appends after the closing `end`).
- The S5 statement is a clean composition; no new Mathlib imports beyond what S2-S4 already used. The supporting `Nat`-arithmetic helper (`nat_list_sum_le_length_mul_of_all_le`) is intentionally polymorphic and reusable.
- The drift fix is a small surgical replacement (3-line helper plus 2 call-site updates).

## Status

**Outcome**: progress (recovery + 1 new public theorem + 1 drift-fix)
**Build**: pending (Docker cold-build ~45 min per `proofs/.lake` self-symlink trap; matches S2/S3/S4 build-pending precedent — a later mechanic pass verifies).
**Next Steps**: see state.md option list. With S5 landed, the strong-form upgrade (option 2) becomes a short combination using the S5 bound directly. OQ-03-OQ-02 SCAFFOLD (option 3) and OQ-03-OQ-01 S2 (option 1) remain available.

🤖 Generated by researcher-3