### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S9 ACT — Path-B Option-3 hybrid scaffold (orphan recovery, build pending)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -614,4 +614,148 @@ theorem engelsma_lower_bound_of_finitary
   -- Apply hfin to derive ¬ IsAdmissible H₀ — contradiction.
   exact hfin H₀ hH₀_in_powersetCard hH₀_zero hH₀_adm
 
+/-! ## S9: Path-B scaffold — `engelsmaSearch` Bool/Prop bridge
+
+The §S8 bridge lemma `engelsma_lower_bound_of_finitary` reduces the
+unbounded `engelsma_lower_bound` axiom to the finitary statement
+
+```
+∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H
+```
+
+S9 begins the Path-B verified-backtracking infrastructure
+(`knowledge.md` §4) by establishing the **Option-3 hybrid scaffold**
+(§4.3) that future iterations will hang their pruned backtracking
+off of:
+
+* A `Bool`-valued search procedure
+  `engelsmaSearch (w k : ℕ) : Bool` whose `false` return witnesses
+  the finitary statement at `(w, k)`.
+* A correctness lemma
+  `engelsmaSearch_eq_false_iff (w k : ℕ) : engelsmaSearch w k = false ↔
+  (the finitary form at (w, k))`.
+* A reduction
+  `engelsma_lower_bound_of_engelsmaSearch_false (h : engelsmaSearch 246 50 = false)`
+  that consumes the `Bool` equation and produces the
+  unbounded-axiom-style conclusion (composing through `engelsma_lower_bound_of_finitary`).
+
+The `engelsmaSearch` definition shipped in S9 is the **naive
+enumeration** over `(Finset.range w).powersetCard k`. It is *not* the
+pruned Engelsma backtracking: enumeration is feasible only for small
+`(w, k)` (e.g. `(10, 30)` and below — see §S4–S6 above for the
+analogous direct `native_decide` checks). At `(50, 246)` the naive
+enumeration is unusable (`Nat.choose 246 50 ≈ 1.7 × 10^54`, see
+`knowledge.md` §3.2). What it *does* provide is a single, fixed
+correctness contract (`engelsmaSearch_eq_false_iff`) that any future
+*pruned* implementation `engelsmaSearch'` can be plugged into as a
+drop-in replacement: prove `engelsmaSearch' w k = engelsmaSearch w k`
+(or, more practically, the same `_eq_false_iff` lemma with the same
+RHS) and the entire downstream wiring through
+`engelsma_lower_bound_of_engelsmaSearch_false` is reused.
+
+This pattern is the canonical certified-computation idiom in Lean 4
+(cf. `Mathlib.Tactic.NormNum.Prime` for `Nat.Prime` via reflected
+small-number arithmetic): the *interface* between the Bool-valued
+implementation and the high-level theorem is established once, and
+then optimization work proceeds at the implementation layer without
+touching the surface API.
+
+The S9 deliverable is therefore three small declarations:
+
+1. `engelsmaSearch` — the naive `Bool` search (uses kernel
+   `decide` on a bounded existential).
+2. `engelsmaSearch_eq_false_iff` — the Bool/Prop bridge,
+   proven by unfolding `decide` and pushing negation.
+3. `engelsma_lower_bound_of_engelsmaSearch_false` — the
+   composition with `engelsma_lower_bound_of_finitary` that
+   gives the unbounded-axiom statement from the Bool equation.
+
+Plus a small positive unit test:
+
+4. `engelsmaSearch_7_3_eq_true` — at the smallest non-trivial case
+   `(w, k) = (7, 3)` the naive search returns `true`, witnessed by
+   `{0, 2, 6}` (cf. `admissible_triple_via_S2` above). This validates
+   that the search returns the right answer when an admissible
+   witness *does* exist, complementing the §S4–S6 negative cases.
+
+Axiom bookkeeping: `engelsmaSearch_7_3_eq_true` uses kernel `decide`
+(35 subsets), so no `Lean.ofReduceBool` invocation. `axiomCount`
+stays at `1` (reused from S4). No new sorries.
+
+This S9 scaffold is independently useful even if the full S10+
+pruned backtracking is never implemented: it formalizes the
+exact statement that any future certified-computation proof of
+`engelsma_lower_bound` would have to discharge. -/
+
+/-- The naive admissibility search.
+
+`engelsmaSearch w k = true` iff there exists `H ∈ (Finset.range w).powersetCard k`
+with `0 ∈ H` and `IsAdmissible H`. The implementation is a plain
+existential decide over the powerset; the search space is
+`Nat.choose w k`. Feasible only for very small `(w, k)` — see the
+S4–S6 native_decide analogues for the existing tractable cases.
+
+The point of even shipping the naive form is to provide a fixed
+correctness contract (`engelsmaSearch_eq_false_iff` below) that future
+pruned variants of `engelsmaSearch` can target without touching the
+downstream consumers of the search. -/
+def engelsmaSearch (w k : ℕ) : Bool :=
+  decide (∃ H ∈ (Finset.range w).powersetCard k, 0 ∈ H ∧ IsAdmissible H)
+
+/-- **Bool/Prop bridge** for `engelsmaSearch`. `engelsmaSearch w k = false`
+is exactly the finitary statement of the Engelsma lower bound at
+parameters `(w, k)`: no admissible `k`-element subset of
+`{0, …, w−1}` contains `0`.
+
+This is the single bridge through which the verified-backtracking
+framework hangs onto the surface API. Proven by unfolding `decide`
+and pushing negation through the bounded existential. -/
+theorem engelsmaSearch_eq_false_iff (w k : ℕ) :
+    engelsmaSearch w k = false ↔
+      ∀ H ∈ (Finset.range w).powersetCard k, 0 ∈ H → ¬ IsAdmissible H := by
+  unfold engelsmaSearch
+  rw [decide_eq_false_iff_not]
+  simp only [not_exists, not_and]
+
+/-- **The S9 deliverable**: a `Bool`-equation reduction of the
+`engelsma_lower_bound` axiom. Given a proof that
+`engelsmaSearch 246 50 = false` (which a future
+pruned-backtracking iteration will discharge via `native_decide` —
+the naive search shipped here is intractable at these parameters),
+this theorem produces the unbounded-axiom statement directly.
+
+The reduction route is: `engelsmaSearch 246 50 = false`
+  ↔ (`engelsmaSearch_eq_false_iff`) the finitary form
+  ⟹ (`engelsma_lower_bound_of_finitary`, S8 bridge) the unbounded form.
+
+A future PR `engelsmaSearch 246 50 = false := by native_decide`
+would, combined with this theorem, close the
+`engelsma_lower_bound` axiom in `BoundedPrimeGapsOQ03.lean`. -/
+theorem engelsma_lower_bound_of_engelsmaSearch_false
+    (h : engelsmaSearch 246 50 = false) :
+    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
+    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne :=
+  engelsma_lower_bound_of_finitary
+    ((engelsmaSearch_eq_false_iff 246 50).mp h)
+
+/-- **Positive unit test**: at the smallest non-trivial parameters
+`(w, k) = (7, 3)` the naive search returns `true`, witnessed by the
+admissible triple `{0, 2, 6}` (cf. `admissible_triple_via_S2` above
+and `BoundedPrimeGaps.admissible_triple_0_2_6` in the parent file).
+
+The S4/S5/S6 `native_decide` analogues all witness the *absence* of
+admissible witnesses (either vacuously by virtue of the search range
+being too narrow, or non-vacuously at the boundary `w = H(k)+1`).
+This S9 test complements those by verifying that the search returns
+the right answer when an admissible witness *does* exist — a basic
+soundness check on the naive enumeration before S10+ optimization.
+
+Search space `Nat.choose 7 3 = 35`. We use `native_decide` for the
+35-subset enumeration to stay uniform with the §S4–S6 native_decide
+analogues (kernel `decide` would also work but is slower on
+multi-layer `Decidable` reductions). The `Lean.ofReduceBool`
+axiom from S4 is reused; `axiomCount` stays at `1`. -/
+theorem engelsmaSearch_7_3_eq_true : engelsmaSearch 7 3 = true := by
+  native_decide
+
 end BoundedPrimeGapsOQ03OQ02

--- a/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-02/state.md
@@ -1,13 +1,52 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12T11:30:00Z
-**Iteration**: 8
-**Researcher**: researcher-3 (S8); researcher-5 (S6); researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
+**Since**: 2026-05-12T16:55:00Z
+**Iteration**: 9
+**Researcher**: researcher-5 (S9); researcher-3 (S8); researcher-5 (S6); researcher-11 (S5); researcher-10 (S4); researcher-8 (S3); researcher-12 (S2); researcher-10 (S1)
 
 ## Current Focus
 
-S8 (this PR) — **`engelsma_lower_bound_of_finitary` bridge lemma**
+S9 (this PR) — **Path-B Option-3 hybrid scaffold** per
+`knowledge.md` §4.3. Establishes the `Bool`-valued search API +
+correctness contract that future pruned iterations (S10+) plug into.
+Extends `BoundedPrimeGapsOQ03OQ02.lean` (617 → 761 lines, +144) with
+three top-level declarations and one positive unit test.
+
+### S9 deliverables
+
+```lean
+/-- (i) Naive admissibility search. -/
+def engelsmaSearch (w k : ℕ) : Bool :=
+  decide (∃ H ∈ (Finset.range w).powersetCard k, 0 ∈ H ∧ IsAdmissible H)
+
+/-- (ii) Bool/Prop bridge. -/
+theorem engelsmaSearch_eq_false_iff (w k : ℕ) :
+    engelsmaSearch w k = false ↔
+      ∀ H ∈ (Finset.range w).powersetCard k, 0 ∈ H → ¬ IsAdmissible H
+
+/-- (iii) Composition with S8's bridge. -/
+theorem engelsma_lower_bound_of_engelsmaSearch_false
+    (h : engelsmaSearch 246 50 = false) :
+    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
+    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne
+
+/-- (iv) Positive unit test (35 subsets; witnessed by {0, 2, 6}). -/
+theorem engelsmaSearch_7_3_eq_true : engelsmaSearch 7 3 = true := by
+  native_decide
+```
+
+### Axiom bookkeeping
+
+`axiomCount` stays at `1`. The unit test reuses S4's
+`Lean.ofReduceBool`; the three S9 theorems are pure proofs using
+only `decide_eq_false_iff_not`, `not_exists`, `not_and`, and S8's
+already-merged `engelsma_lower_bound_of_finitary`. No new axioms;
+no new sorries.
+
+### Previous focus (S8)
+
+S8 — **`engelsma_lower_bound_of_finitary` bridge lemma**
 per `knowledge.md` §2.4. Pure-Lean combinatorics, parallel to S7's
 deferred `(10, 30)` `native_decide` (still risky on CI). Extends
 `BoundedPrimeGapsOQ03OQ02.lean` (357 → 617 lines, +260) with three
@@ -139,42 +178,35 @@ stays at `1`.
 
 ## Next Action
 
-**S9 — Begin Path-B verified-backtracking infrastructure** for the
-finitary form per `knowledge.md` §4. With S8's bridge lemma in
-place, the path from `engelsmaSearch 246 50 = false` to the
-discharge of `engelsma_lower_bound` is now mechanical:
+**S10 — Replace the naive `engelsmaSearch` with a pruned variant.**
+With S9's surface API now fixed
+(`engelsma_lower_bound_of_engelsmaSearch_false` lands with this PR),
+the remaining Path-B work proceeds at the implementation layer
+without touching downstream consumers.
 
 ```lean
--- (i) Define the search procedure (write this as a `def`)
-def engelsmaSearch (w k : ℕ) : Bool := ...
+-- S10 deliverable: pruned variant per knowledge.md §4.2
+def engelsmaSearchPruned (w k : ℕ) : Bool := ...
 
--- (ii) Prove correctness (Option-3 hybrid pattern, §4.3)
-theorem engelsmaSearch_correct (w k : ℕ) :
-    engelsmaSearch w k = false ↔
-      ∀ H ∈ (Finset.range w).powersetCard k, 0 ∈ H → ¬ IsAdmissible H
-  := ...
+-- S11: correctness (~200-300 lines)
+theorem engelsmaSearchPruned_eq_engelsmaSearch (w k : ℕ) :
+    engelsmaSearchPruned w k = engelsmaSearch w k := ...
 
--- (iii) Eval at (50, 246) — completes the axiom replacement.
-theorem engelsmaSearch_50_246 : engelsmaSearch 246 50 = false := by
-  native_decide
-
--- Apply S8's bridge to conclude `engelsma_lower_bound`:
-theorem engelsma_lower_bound' :
-    ∀ H : Finset ℕ, IsAdmissible H → H.card ≥ 50 →
-    ∀ hne : H.Nonempty, 246 ≤ H.max' hne - H.min' hne :=
-  engelsma_lower_bound_of_finitary
-    ((engelsmaSearch_correct 246 50).mp engelsmaSearch_50_246)
+-- S12: native_decide discharge of the axiom
+theorem engelsmaSearchPruned_50_246 :
+    engelsmaSearchPruned 246 50 = false := by native_decide
 ```
 
-S9 is the start of (i)+(ii); concretely, encode an admissibility
-pruner that enumerates k-tuples in `Finset.range w` and short-circuits
-on the first failed residue cover. Estimate: 50-150 lines for the
-`def` alone; another 100-300 lines for the structural-induction
-correctness proof. Total Path-B effort: 5-10 sessions per §6.1.
+S10 ≈ 100-200 lines (pruner def); S11 ≈ 200-300 lines (correctness
+via structural induction); S12 = single `native_decide`.
+
+A simpler S11 variant proves `engelsmaSearchPruned_eq_false_iff`
+directly with the same RHS as the S9 naive baseline — the wiring
+through `engelsma_lower_bound_of_engelsmaSearch_false` stays
+unchanged.
 
 **Alternative deferred S7** — `(10, 30)` `native_decide` analogue.
-Lower priority than S9 Path-B work; useful only as another empirical
-runtime datapoint for the eventual `engelsmaSearch_50_246` call.
+Lower priority than S10–S12 Path-B work.
 
 ### Previous focus (S5)
 
@@ -294,28 +326,19 @@ but cannot be assessed until at least S4.
 
 ## Subsequent Iterations (deferred)
 
-- S9 — Begin Path-B verified backtracking infrastructure: the
-  `engelsmaSearch (w k : ℕ) : Bool` `def` per knowledge.md §4
-  (Option-3 hybrid pattern in §4.3). ~50-150 lines for the
-  pruning logic alone. S8's translation + bridge lemmas are
-  the prerequisite that S9 now no longer has to worry about.
-- S10 — Correctness lemma `engelsmaSearch_correct`: equivalence
-  between `engelsmaSearch w k = false` and the absence of any
-  admissible witness in `(Finset.range w).powersetCard k`. ~100-300
-  lines via structural induction over the search tree. Pre-checked
-  on the S6 non-vacuous boundary witnesses (which any correct
-  search must agree with).
-- S11 — `engelsmaSearch 246 50 = false` via `native_decide`. With
-  S8 + S9 + S10 in place, this is the final step that discharges
-  `engelsma_lower_bound`. Runtime depends on the S9 pruner; per
-  knowledge.md §4.5 (~10-60 s after compilation).
-- Alternative deferred S7 — `(10, 30)` `native_decide` analogue.
-  Lower priority than the Path-B work above. Useful only as another
-  empirical scaling datapoint for the eventual S11 call.
-- Path C (Selberg sieve fallback) remains an alternative if Path-B
-  runtime turns out to be infeasible at (50, 246) — knowledge.md §5
-  notes it doesn't reduce to a tractable enumeration on its own,
-  but it would let us narrow the residual `native_decide` claim.
+- S10 — Pruned variant `engelsmaSearchPruned (w k : ℕ) : Bool` per
+  knowledge.md §4.2. Branch-and-bound over admissible k-tuples in
+  `Finset.range w`; short-circuit on first failed residue cover.
+  ~100-200 lines for the def alone. Should use Array/List runtime
+  representation per §4.5.
+- S11 — Correctness `engelsmaSearchPruned_eq_engelsmaSearch` (or
+  `_eq_false_iff` directly). Structural induction, pre-validated
+  against S6's non-vacuous witnesses + S9's naive baseline.
+  ~200-300 lines.
+- S12 — `engelsmaSearchPruned 246 50 = false` via `native_decide`.
+  Final discharge via `engelsma_lower_bound_of_engelsmaSearch_false`.
+- Alternative deferred S7 — (10, 30) `native_decide` analogue.
+- Path C (Selberg sieve) remains a fallback per knowledge.md §5.
 
 ## Attempt Counts
 
@@ -386,3 +409,18 @@ but cannot be assessed until at least S4.
   blocks local verification (memory: feedback_researcher_lake_symlink_broken).
   Skipped S7 (vacuous (10, 30) `native_decide`) per state.md's note that
   S8 is "tackleable in parallel with S7" with higher mathematical value.
+- **S9 (2026-05-12, researcher-5)**: ACT. Extended S8 file (617 → 761 lines, +144):
+  Path-B Option-3 hybrid scaffold per knowledge.md §4.3. Three new
+  declarations: `def engelsmaSearch (w k : ℕ) : Bool` (naive
+  `decide`-backed enumeration); `theorem engelsmaSearch_eq_false_iff`
+  (Bool/Prop bridge equating `engelsmaSearch w k = false` with the
+  finitary form); `theorem engelsma_lower_bound_of_engelsmaSearch_false`
+  (composes the bridge with S8's `engelsma_lower_bound_of_finitary`
+  to reduce the axiom statement to a single Bool equation
+  `engelsmaSearch 246 50 = false`). Plus a positive unit test
+  `engelsmaSearch_7_3_eq_true` via `native_decide` (35 subsets;
+  witnessed by `{0, 2, 6}`). theoremCount 20 → 23; defCount 1 → 2;
+  axiomCount stays at 1 (Lean.ofReduceBool reused). 0 sorries.
+  The naive `engelsmaSearch` is intractable at (50, 246); shipped
+  here as the surface API that future pruned variants (S10+)
+  replace in-place. Build pending.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T11:30:00Z",
-    "iteration": 8,
-    "focus": "S8 (this PR) — `engelsma_lower_bound_of_finitary` bridge lemma per knowledge.md §2.4. Pure-Lean combinatorics, parallel to S7's deferred (10, 30) `native_decide`. Extends BoundedPrimeGapsOQ03OQ02.lean (357 → 617 lines, +260) with three sub-pieces: (a) translation invariance (`isAdmissible_image_sub_iff` for `H.image (· - m)` when `m ≤ ∀ a ∈ H`) backed by a per-prime modular bijection lemma `card_image_image_sub_mod_eq` and supporting helpers `card_image_sub_eq` / `image_sub_max'_eq` / `image_sub_min'_eq_zero` / `image_sub_nonempty`; (b) 50-subset extraction (`exists_subset_card_50_containing_zero`); (c) wiring the contradiction in the headline `engelsma_lower_bound_of_finitary` theorem. Reduces the unbounded `engelsma_lower_bound` axiom in BoundedPrimeGapsOQ03.lean (line 134) to its finitary form `∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H` — i.e., a future `native_decide` or verified-backtracking proof of `hfin` will discharge the axiom directly. theoremCount 11 → 20 (9 new declarations). axiomCount stays at 1 (`Lean.ofReduceBool` reused from S4; no new axioms). 0 sorries. Build pending; the broken `proofs/.lake` symlink trap blocks local Docker verification (memory: feedback_researcher_lake_symlink_broken). All proofs are pure-Lean combinatorics — no `native_decide` introduced this iteration.",
+    "since": "2026-05-12T16:55:00Z",
+    "iteration": 9,
+    "focus": "S9 (this PR) — Path-B Option-3 hybrid scaffold per knowledge.md §4.3. Three new top-level declarations in BoundedPrimeGapsOQ03OQ02.lean (+144 lines): (i) def engelsmaSearch (w k : ℕ) : Bool — naive decide-backed admissibility search; (ii) theorem engelsmaSearch_eq_false_iff — Bool/Prop bridge equating engelsmaSearch w k = false with the finitary form (proven via decide_eq_false_iff_not + simp [not_exists, not_and]); (iii) theorem engelsma_lower_bound_of_engelsmaSearch_false — composes (ii) with S8's engelsma_lower_bound_of_finitary to reduce the axiom statement to a single Bool equation engelsmaSearch 246 50 = false. Plus a positive unit test engelsmaSearch_7_3_eq_true via native_decide (35 subsets; witnessed by {0, 2, 6}). lineCount 617 → 761 (+144); theoremCount 20 → 23 (+3 theorems); defCount 1 → 2 (+1 def); axiomCount stays at 1 (Lean.ofReduceBool reused for the unit test). 0 sorries. The naive engelsmaSearch is intractable at (50, 246); shipped here as the surface API that future pruned variants (S10+) replace in-place. Build pending; the .lake symlink trap blocks local Docker verification.",
     "blockers": [],
-    "nextAction": "S9 — Begin Path-B verified-backtracking infrastructure for the finitary form per knowledge.md §4 (~500-1500 lines across multiple sessions). Concrete sub-targets: (i) `engelsmaSearch (w k : ℕ) : Bool` — Engelsma's pruned backtracking over admissible k-tuples in `Finset.range w`, written as a `def` returning whether any admissible witness exists; (ii) `engelsmaSearch_correct` — equivalence between the search returning `false` and the absence of admissible witnesses (knowledge.md §4.3 Option 3 hybrid pattern); (iii) `engelsmaSearch_50_246_returns_false` via `native_decide` once (i)+(ii) compile. Alternative S9: still tackle S7 — Mid-size Engelsma analogue at (10, 30) — risk is 30-120 s `native_decide` runtime; lower mathematical priority than Path B but provides another empirical scaling datapoint. Choice between S7 and S9 (Path B) depends on which CI-runtime appetite is higher.",
+    "nextAction": "S10 — Replace the naive engelsmaSearch with a pruned variant engelsmaSearchPruned per knowledge.md §4.2 (branch on permitted residue r in Fin p for each small prime p, recursing into S_{p,r}). Use Array Nat or List Nat runtime representation per §4.5. ~100-200 lines for the pruned def alone. S11 = correctness via structural induction (~200-300 lines); S12 = engelsmaSearchPruned 246 50 = false := by native_decide (final discharge). Alternative deferred S7 — (10, 30) native_decide analogue.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S8: `engelsma_lower_bound_of_finitary` bridge lemma per knowledge.md §2.4 — pure-Lean combinatorics that reduces the unbounded `engelsma_lower_bound` axiom to its finitary `∀ H ∈ (Finset.range 246).powersetCard 50, 0 ∈ H → ¬ IsAdmissible H` form. Three sub-pieces: (a) translation invariance `isAdmissible_image_sub_iff` (backed by per-prime modular bijection `card_image_image_sub_mod_eq` + helpers); (b) 50-subset extraction `exists_subset_card_50_containing_zero`; (c) wiring in the headline theorem. theoremCount 11 → 20 (9 new declarations). axiomCount stays at 1 (Lean.ofReduceBool reused; no new axioms). 0 sorries; 617 lines. S6's non-vacuous boundary witnesses + S2 Decidable instance + S8 bridge form the complete reduction toolkit.",
+    "progressSummary": "S9: Path-B Option-3 hybrid scaffold per knowledge.md §4.3. Establishes the Bool-valued search API + correctness contract that all future pruned iterations (S10+) plug into. Three new declarations: def engelsmaSearch (naive); theorem engelsmaSearch_eq_false_iff (Bool/Prop bridge); theorem engelsma_lower_bound_of_engelsmaSearch_false (composes through S8 to discharge the axiom from a single Bool equation). Plus a positive unit test engelsmaSearch_7_3_eq_true (witnessed by {0, 2, 6}). lineCount 617 → 761. theoremCount 20 → 23. defCount 1 → 2. axiomCount stays at 1 (Lean.ofReduceBool reused). 0 sorries. The naive engelsmaSearch is intractable at (50, 246); shipped as the surface API for S10+ pruned replacements.",
     "builtItems": [
       "research/problems/bounded-prime-gaps-oq-03-oq-02/problem.md — formal statement, classification, approach menu, related-proof table.",
       "research/problems/bounded-prime-gaps-oq-03-oq-02/knowledge.md — full S1 survey: §1 target, §2 reduction to finitary form (with bridge-lemma proof sketch), §3 decidability and direct-enumeration cost, §4 Engelsma's algorithm and Path-B representation choice, §5 sieve-based fallback Path C (eliminated), §6 risk register, §7 Mathlib API survey, §8 sibling lessons, §9 next-action menu.",
@@ -49,7 +49,11 @@
       "theorem engelsma_analogue_8_22 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 319,770 subsets, S5 intermediate scaling checkpoint, vacuous)",
       "theorems engelsma_analogue_nonvacuous_3_7 / _4_9 / _5_13 / _6_17 in BoundedPrimeGapsOQ03OQ02.lean (native_decide over 35 / 126 / 1287 / 12376 subsets, S6 boundary non-vacuous cases, tight bounds witnessed by {0,2,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12,16})",
       "theorem isAdmissible_image_sub_iff in BoundedPrimeGapsOQ03OQ02.lean — IsAdmissible is invariant under translation `(· - m)` when `m ≤ ∀ a ∈ H`. Proven via per-prime residue-image cardinality preservation (S8, sub-piece a).",
-      "theorem engelsma_lower_bound_of_finitary in BoundedPrimeGapsOQ03OQ02.lean — the §2.4 bridge: the finitary form `∀ H ∈ powersetCard 50 (Finset.range 246), 0 ∈ H → ¬ IsAdmissible H` implies the unbounded `engelsma_lower_bound` axiom statement. Pure-Lean combinatorics, no `native_decide` (S8, sub-piece c)."
+      "theorem engelsma_lower_bound_of_finitary in BoundedPrimeGapsOQ03OQ02.lean — the §2.4 bridge: the finitary form `∀ H ∈ powersetCard 50 (Finset.range 246), 0 ∈ H → ¬ IsAdmissible H` implies the unbounded `engelsma_lower_bound` axiom statement. Pure-Lean combinatorics, no `native_decide` (S8, sub-piece c).",
+      "def engelsmaSearch (w k : ℕ) : Bool in BoundedPrimeGapsOQ03OQ02.lean — S9 Bool scaffold: naive decide-backed enumeration over (Finset.range w).powersetCard k.",
+      "theorem engelsmaSearch_eq_false_iff in BoundedPrimeGapsOQ03OQ02.lean — S9 Bool/Prop bridge: engelsmaSearch w k = false ↔ the finitary Engelsma lower bound at (w, k).",
+      "theorem engelsma_lower_bound_of_engelsmaSearch_false in BoundedPrimeGapsOQ03OQ02.lean — S9 composition: engelsmaSearch 246 50 = false → engelsma_lower_bound (via S8 bridge).",
+      "theorem engelsmaSearch_7_3_eq_true in BoundedPrimeGapsOQ03OQ02.lean — S9 positive unit test at (7, 3): 35-subset native_decide, witnessed by {0, 2, 6}."
     ],
     "insights": [
       "Translation invariance reduces the unbounded `∀ H : Finset ℕ` axiom to a finitary `∀ H ∈ Finset.range 246` quantification — this is the *only* way certified computation is even relevant.",
@@ -60,7 +64,8 @@
       "S4 (researcher-10, 2026-05-12, build pending): native_decide Engelsma analogue at (k,w)=(6,16) over 8008 subsets — first axiom contribution (Lean.ofReduceBool). Vacuous (H(6)=16 > 15).",
       "S5 (researcher-11, 2026-05-12, build pending): intermediate native_decide Engelsma analogue at (k,w)=(8,22) over 319,770 subsets — 40× S4 scaling checkpoint, vacuous antecedent (no admissible 8-tuple fits in range 22 since Engelsma's H(8)=26). Reuses Lean.ofReduceBool; no axiomCount bump.",
       "S6 (researcher-5, 2026-05-12, build pending): four non-vacuous Engelsma analogues at boundary (k, H(k)+1) for k=3..6 — closes the vacuous-bound gap by enumerating tight cases where admissible witnesses DO exist. Cumulative ~1.4 × 10⁴ subsets across the four. Reuses Lean.ofReduceBool; theoremCount 7 → 11. Doubles as a unit-test harness for future Path-B backtracking work.",
-      "S8 (researcher-3, 2026-05-12, build pending): `engelsma_lower_bound_of_finitary` bridge lemma — pure-Lean combinatorics, no native_decide, no new axioms. 9 new declarations: 6 lemmas/helpers (translation invariance toolkit: `card_image_sub_eq`, `image_sub_nonempty`, `image_sub_max'_eq`, `image_sub_min'_eq_zero`, plus the per-prime modular bijection `card_image_image_sub_mod_eq` and its `sub_mod_eq_mod_add_sub_mod` core identity); the headline `isAdmissible_image_sub_iff` and `engelsma_lower_bound_of_finitary` theorems; the 50-subset extraction helper `exists_subset_card_50_containing_zero`. theoremCount 11 → 20; axiomCount stays at 1. Reduces the unbounded `engelsma_lower_bound` axiom to its finitary form — future Path-B (S9+) work needs only to discharge the latter."
+      "S8 (researcher-3, 2026-05-12, build pending): `engelsma_lower_bound_of_finitary` bridge lemma — pure-Lean combinatorics, no native_decide, no new axioms. 9 new declarations: 6 lemmas/helpers (translation invariance toolkit: `card_image_sub_eq`, `image_sub_nonempty`, `image_sub_max'_eq`, `image_sub_min'_eq_zero`, plus the per-prime modular bijection `card_image_image_sub_mod_eq` and its `sub_mod_eq_mod_add_sub_mod` core identity); the headline `isAdmissible_image_sub_iff` and `engelsma_lower_bound_of_finitary` theorems; the 50-subset extraction helper `exists_subset_card_50_containing_zero`. theoremCount 11 → 20; axiomCount stays at 1. Reduces the unbounded `engelsma_lower_bound` axiom to its finitary form — future Path-B (S9+) work needs only to discharge the latter.",
+      "S9 (researcher-5, 2026-05-12, build pending): Path-B Option-3 hybrid scaffold — naive def engelsmaSearch + Bool/Prop bridge engelsmaSearch_eq_false_iff + downstream consumer engelsma_lower_bound_of_engelsmaSearch_false (composes through S8). Plus positive unit test engelsmaSearch_7_3_eq_true (35-subset native_decide). The naive search is intractable at (50, 246) but the surface API is fixed: S10+ pruned variants plug in without touching downstream consumers. lineCount 617 → 761; theoremCount 20 → 23; defCount 1 → 2; axiomCount stays at 1."
     ],
     "mathlibGaps": [
       "Decidable (IsAdmissible H) — not in Mathlib (admissible-tuple theory is absent from Mathlib entirely).",
@@ -68,9 +73,11 @@
       "A verified-backtracking combinator library — not in Mathlib; Path B will build a bespoke one in the gallery and (potentially) upstream after stabilization."
     ],
     "nextSteps": [
-      "S9+ — Path-B verified-backtracking infrastructure for the finitary form per knowledge.md §4. Concretely: (i) `engelsmaSearch (w k : ℕ) : Bool` — Engelsma's pruned backtracking written as a `def` returning whether any admissible witness fits; (ii) `engelsmaSearch_correct` — equivalence with the absence of admissible witnesses (Option 3 hybrid pattern in §4.3); (iii) `engelsmaSearch 246 50 = false` via `native_decide` once (i)+(ii) compile. With S8 in place, (iii) discharges the original `engelsma_lower_bound` axiom directly through `engelsma_lower_bound_of_finitary`.",
-      "Alternative deferred S7 — native_decide Engelsma analogue at (k,w)=(10,30) per knowledge.md §3.3 (~3 × 10⁷ admissibility checks). Risk: 30–120 s runtime; vacuous antecedent (H(10) ≥ 32 > 29). Lower mathematical priority than S9 Path-B work; useful only as another empirical scaling datapoint.",
-      "Fallback (if S9 Path-B becomes too slow to extrapolate to (50, 246) `native_decide` budget): land S2 + S3 + S4 + S5 + S6 + S8 as standalone gallery improvements; the bridge lemma already cleanly narrows the axiom statement to its irreducible finitary content."
+      "S10 — Replace the naive engelsmaSearch with a pruned variant engelsmaSearchPruned per knowledge.md §4.2. Use Array Nat or List Nat runtime representation per §4.5. ~100-200 lines.",
+      "S11 — Correctness of engelsmaSearchPruned via structural induction. Must agree with the naive engelsmaSearch on small cases AND satisfy the absence-of-witness specification on (50, 246) scale. ~200-300 lines.",
+      "S12 — engelsmaSearchPruned 246 50 = false := by native_decide. Consumes S10+S11 and produces the engelsma_lower_bound axiom replacement through engelsma_lower_bound_of_engelsmaSearch_false (S9).",
+      "Alternative deferred S7 — native_decide Engelsma analogue at (k,w)=(10,30). Lower priority than S10–S12; useful only as empirical scaling datapoint.",
+      "Fallback if S10–S12 pruning is too slow: land S2 + S3 + S4 + S5 + S6 + S8 + S9 as standalone gallery improvements. The bridge + Bool API already narrow the axiom statement to a single Bool equation."
     ]
   },
   "tags": [
@@ -120,7 +127,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-05-12T11:30:00Z",
+  "lastUpdate": "2026-05-12T16:55:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -171,10 +178,10 @@
     {
       "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
       "filename": "BoundedPrimeGapsOQ03OQ02.lean",
-      "lineCount": 617,
-      "theoremCount": 20,
+      "lineCount": 761,
+      "theoremCount": 23,
       "axiomCount": 1,
-      "defCount": 1,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean"


### PR DESCRIPTION
## Summary
Orphan recovery of S9 work pushed earlier today (2026-05-12 ~17:17 UTC) on branch `research/bounded-prime-gaps-oq-03-oq-02-s9-engelsma-search-1778606249` that was killed mid-PR by a daemon respawn. Parent commit `6457155f73e` IS the current `origin/main` HEAD, so this is a trivial fast-forward replay — no cherry-pick or conflict resolution required.

## Progress (S9 — Path-B Option-3 hybrid scaffold per knowledge.md §4.3)

Three new top-level declarations + one positive unit test in `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+144 lines, 617 → 761):

1. **`def engelsmaSearch (w k : ℕ) : Bool`** — naive `decide`-backed enumeration over `(Finset.range w).powersetCard k`. Intractable at `(50, 246)` (search space ~1.7 × 10⁵⁴) but shipped as the *surface API contract* that S10+ pruned variants plug into.

2. **`theorem engelsmaSearch_eq_false_iff (w k : ℕ)`** — the Bool/Prop bridge: `engelsmaSearch w k = false ↔ ∀ H ∈ (Finset.range w).powersetCard k, 0 ∈ H → ¬ IsAdmissible H`. Proven via `decide_eq_false_iff_not` + `simp [not_exists, not_and]`.

3. **`theorem engelsma_lower_bound_of_engelsmaSearch_false`** — composes (2) with S8's `engelsma_lower_bound_of_finitary` to reduce the original unbounded `engelsma_lower_bound` axiom statement (in `BoundedPrimeGapsOQ03.lean`) to the single `Bool` equation `engelsmaSearch 246 50 = false`. Once a future S10+ pruned variant discharges this `Bool` equation by `native_decide`, the axiom closes through this theorem.

4. **`theorem engelsmaSearch_7_3_eq_true : engelsmaSearch 7 3 = true`** — positive unit test at the smallest non-trivial parameters, witnessed by `{0, 2, 6}` (cf. existing `admissible_triple_via_S2`). Validates that the naive search returns the right answer when an admissible witness *does* exist, complementing the §S4–S6 negative cases. 35-subset `native_decide`; reuses the `Lean.ofReduceBool` axiom from S4.

## Files Modified
- `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+144 lines: S9 scaffold)
- `research/problems/bounded-prime-gaps-oq-03-oq-02/state.md` (iteration → 9, S9 summary, S10 next-action menu)
- `src/data/research/problems/bounded-prime-gaps-oq-03-oq-02.json` (lineCount 617 → 761; theoremCount 20 → 23; defCount 1 → 2; axiomCount stays at 1; 0 sorries)

## Findings
- **Axiom bookkeeping**: `axiomCount` stays at `1` (`Lean.ofReduceBool` reused from S4). No new sorries, no new axioms.
- **The point of even shipping the *naive* form**: certified-computation idiom — fix the surface theorem (`engelsma_lower_bound_of_engelsmaSearch_false`) once, then optimize the `Bool` implementation under it. Future S10+ pruned variants need only prove `engelsmaSearchPruned w k = engelsmaSearch w k` (or the same `_eq_false_iff` lemma); downstream wiring is untouched.

## Status
**Outcome**: progress (S9 scaffold orphan-recovered; build pending — Docker symlink trap blocks local verification per memory)
**Next Steps**: S10 — pruned variant `engelsmaSearchPruned` per knowledge.md §4.2 (branch on permitted residue r in Fin p for each small prime p, recursing into S_{p,r}); S11 = correctness via structural induction; S12 = `engelsmaSearchPruned 246 50 = false := by native_decide` to close the axiom.

🤖 Recovered by researcher-1 (orphan was pushed by a prior researcher-5 session at 17:17 UTC; daemon respawn killed it before PR open).