### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-02-oq-02): S1 OBSERVE — `LocallyIntegrable` wrapper reframing (docs only)

### DIFF
--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/knowledge.md
@@ -1,0 +1,160 @@
+# Knowledge — greens-theorem-oq-01-oq-01-oq-02-oq-02
+
+## S1 (researcher-8, 2026-05-12) — OBSERVE survey
+
+### Question
+
+Can the integrability hypothesis of the parent's
+`intervalIntegral_swap` (currently a product-of-restricted
+volumes on `uIcc a b × uIcc c d`) be replaced with the
+canonical global condition `LocallyIntegrable f volume`?
+
+### Short answer
+
+**Yes — as a user-interface wrapper, not as a strict
+weakening.**
+
+`LocallyIntegrable f volume` on ℝ² implies integrability on any
+compact set, including `uIcc a b × uIcc c d`, so it is *stronger*
+than the parent's hypothesis (which asserts integrability on
+only that one rectangle). However, it is the canonical Mathlib
+idiom that users already have in hand for, e.g., continuous
+functions, L¹_loc densities, Sobolev representatives. A wrapper
+that takes `LocallyIntegrable` and discharges the awkward
+`(restrict A).prod (restrict B)` form internally is a strict
+usability win — the same kind of "free" wrapper sibling OQ-03
+produces for the Bochner codomain.
+
+### Comparison of hypotheses
+
+Let `K := uIcc a b ×ˢ uIcc c d : Set (ℝ × ℝ)` (compact).
+Write `μ := volume` on ℝ × ℝ (= product Lebesgue).
+
+| Hypothesis | What it says | Relation to parent |
+|---|---|---|
+| Parent: `Integrable f ((volume.restrict (uIcc a b)).prod (volume.restrict (uIcc c d)))` | f is L¹ against the product of one-dim restricted volumes | baseline |
+| Equivalent form: `IntegrableOn f K μ` | f is L¹ on the rectangle K | ↔ parent (via `restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc`) |
+| `LocallyIntegrable f μ` | every point of ℝ² has an open neighborhood on which f is L¹ | strictly stronger than parent (gives IntegrableOn on **every** compact, not just K) |
+| `LocallyIntegrable f μ` ∧ `Measurable f` | (joint condition the wrapper takes) | strictly stronger, but the canonical Mathlib idiom |
+
+The seeker phrasing "weakened from `uIcc a b × uIcc c d` to
+`LocallyIntegrable`" inverts the implication direction. Future
+iterations should treat this as an **alternative interface
+wrapper**, not a strict weakening; the deliverable claim must
+not say "we weakened the hypothesis".
+
+### Mathlib API audit (parent's pin: mathlib4 rev 2df2f015)
+
+The parent file imports
+```lean
+import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Measure.Prod
+```
+
+For the proposed S2 wrapper we additionally need:
+
+| Mathlib lemma | Where | Signature (Bochner-generic) |
+|---|---|---|
+| `MeasureTheory.LocallyIntegrable` | `Mathlib.MeasureTheory.Function.LocallyIntegrable` | `def LocallyIntegrable (f : X → E) (μ : Measure X) : Prop` |
+| `LocallyIntegrable.integrableOn_isCompact` | same file | `LocallyIntegrable f μ → IsCompact K → IntegrableOn f K μ` |
+| `IsCompact.prod` / `isCompact_uIcc` | `Mathlib.Topology.Order.Bounded` / `Mathlib.MeasureTheory.Integral.IntervalIntegral` | `IsCompact A → IsCompact B → IsCompact (A ×ˢ B)`; `IsCompact (uIcc a b)` |
+| `restrict_prod_eq_prod_restrict` | `Mathlib.MeasureTheory.Measure.Prod` | `MeasurableSet s → MeasurableSet t → (μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s ×ˢ t)` |
+| `measurableSet_uIcc` | `Mathlib.MeasureTheory.Integral.IntervalIntegral` | `MeasurableSet (uIcc a b)` |
+
+All five entries are already imported (transitively) by the
+parent file. **No new imports needed.** The parent's
+continuous-case proof already uses `restrict_prod_eq_prod_restrict
+measurableSet_uIcc measurableSet_uIcc` and the `IsCompact`
+ingredients (`isCompact_uIcc.prod isCompact_uIcc`); the only new
+ingredient is `LocallyIntegrable.integrableOn_isCompact`.
+
+### Proof sketch (S2)
+
+```lean
+theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  apply intervalIntegral_swap a b c d hf_meas
+  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
+    isCompact_uIcc.prod isCompact_uIcc
+  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
+      (uIcc a b ×ˢ uIcc c d) volume :=
+    hf_loc.integrableOn_isCompact hcpt
+  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
+```
+
+This is a **5-line modification** of the parent's
+`intervalIntegral_swap_of_continuous` proof. The only change is
+
+```
+-- Parent (continuous case):
+have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2) (uIcc a b ×ˢ uIcc c d) volume :=
+  hf.continuousOn.integrableOn_compact hcpt
+-- This file (locally integrable case):
+have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2) (uIcc a b ×ˢ uIcc c d) volume :=
+  hf_loc.integrableOn_isCompact hcpt
+```
+
+Everything else is verbatim.
+
+### Why not eliminate `Measurable` too?
+
+`LocallyIntegrable` already includes `AEStronglyMeasurable` (the
+Mathlib def is `LocallyIntegrable f μ ↔ AEStronglyMeasurable f μ
+∧ ∀ x, ∃ U ∈ 𝓝 x, IntegrableOn f U μ`). For the inner
+`intervalIntegral_swap`, however, we need `Measurable f` (not
+`AEStronglyMeasurable`) because of the `mono_measure` chain in
+the parent's ordered-case proof.
+
+**Practical resolution.** Most users have `Continuous f` (which
+gives both `Measurable` and `LocallyIntegrable` immediately).
+Keeping `hf_meas` as a separate hypothesis in the wrapper is
+cheap and preserves the parent's measurability assumption
+verbatim. A future refinement could try to drop it to
+`AEStronglyMeasurable`, but that is a separate question (depends
+on whether `MeasureTheory.integral_integral_swap` accepts
+`AEStronglyMeasurable` — sibling OQ-03 audit suggests yes, but
+not verified for this specific path).
+
+### Composition with sibling OQ-03 (Bochner generalization)
+
+OQ-03 produces a Bochner-codomain version of the parent's three
+theorems. The same `LocallyIntegrable` wrapper composes
+verbatim with that file: replace `f : ℝ → ℝ → ℝ` by `f : ℝ → ℝ
+→ E` (Banach), invoke the Bochner-generic
+`intervalIntegral_swap` from OQ-03, and use
+`MeasureTheory.LocallyIntegrable` (which is already
+codomain-generic in Mathlib). The composed wrapper is not part
+of this OQ's deliverable; seeker may extract it as its own
+sub-OQ.
+
+### Mathlib gaps
+
+None identified. All required API is in Mathlib at the parent's
+pin.
+
+### Risks for S2
+
+1. **`LocallyIntegrable.integrableOn_isCompact` name drift.**
+   The Mathlib lemma may also be known as
+   `LocallyIntegrable.integrableOn_compact` or
+   `LocallyIntegrable.integrableOn_of_isCompact`. If the exact
+   name has drifted, search with `#check
+   @MeasureTheory.LocallyIntegrable.integrableOn_isCompact` and
+   `#check @LocallyIntegrable` in the Lean infoview.
+2. **Build pressure.** Per project memory, direct `lake build`
+   crashes the host; S2 must use `./proofs/scripts/docker-build.sh
+   Proofs.GreensTheoremOQ01OQ01OQ02OQ02` from the worktree (not
+   the main-repo absolute path, which mounts the wrong root).
+
+### Next iteration
+
+S2 SCAFFOLD: write `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean`
+(~30 lines: imports + namespace + the single wrapper theorem +
+docstring). Build-verify locally via Docker wrapper. Update the
+gallery entry with the new file and propose Mathlib
+contribution path. Anticipated PR size: ~30 Lean lines + ~50
+gallery JSON/MD lines = small.

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/problem.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/problem.md
@@ -1,0 +1,144 @@
+# Problem: `LocallyIntegrable` interface for `intervalIntegral_swap`
+
+## Statement
+
+### Plain Language
+
+The parent gallery entry `greens-theorem-oq-01-oq-01-oq-02`
+(`Proofs/GreensTheoremOQ01OQ01OQ02.lean`, verified, 0 sorries,
+0 axioms) proves three real-valued versions of an iterated
+interval-integral Fubini lemma:
+
+```
+intervalIntegral_swap_of_le        -- a ≤ b, c ≤ d
+intervalIntegral_swap              -- any orderings, sign-flip reduction
+intervalIntegral_swap_of_continuous -- continuous integrand (no integrability hyp.)
+```
+
+The general `intervalIntegral_swap` requires a somewhat awkward
+integrability hypothesis:
+
+```lean
+(hf_int : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+  ((volume.restrict (uIcc a b)).prod (volume.restrict (uIcc c d))))
+```
+
+i.e. integrability against the *product of restricted* one-dim
+volumes on the unordered intervals `uIcc a b` and `uIcc c d`.
+
+The seeker-extracted open question asks:
+
+> Can the integrability hypothesis be weakened from
+> `uIcc a b × uIcc c d` to local integrability
+> (`LocallyIntegrable`), similar to how Fubini-Tonelli handles
+> σ-finite measures?
+
+### Reframing the question
+
+As literally stated this is **mathematically backwards**:
+
+- `LocallyIntegrable f volume` (on ℝ²) means: every point has an
+  open neighborhood on which `f` is integrable. Equivalently
+  (Mathlib): `IntegrableOn f K volume` for **every** compact
+  `K ⊆ ℝ²`.
+- The parent's hypothesis asserts integrability on **one**
+  particular compact rectangle `uIcc a b × uIcc c d`.
+
+Therefore `LocallyIntegrable f volume → parent hypothesis` (just
+specialize to the rectangle), but **not** conversely.
+`LocallyIntegrable` is strictly **stronger**, not weaker, than
+the parent's compact-rectangle hypothesis.
+
+The intent behind the seeker question, however, is clear and
+useful: provide a **user-interface wrapper** that takes the
+natural global condition `LocallyIntegrable f volume` and
+discharges the awkward `(volume.restrict A).prod
+(volume.restrict B)` form internally. This is analogous to
+sibling OQ-03 (Bochner generalization), which produces a "free"
+codomain-generic wrapper around the parent.
+
+### Formal Statement (S2 target)
+
+We seek a Lean wrapper of the form:
+
+```lean
+theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  apply intervalIntegral_swap a b c d hf_meas
+  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
+    isCompact_uIcc.prod isCompact_uIcc
+  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
+      (uIcc a b ×ˢ uIcc c d) volume :=
+    hf_loc.integrableOn_isCompact hcpt
+  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
+```
+
+This is **the same proof script** as the parent's continuous
+case, with `hf.continuousOn.integrableOn_compact hcpt` replaced
+by `hf_loc.integrableOn_isCompact hcpt`. See `knowledge.md`
+§ "Mathlib API audit" for the precise lemma names and pin.
+
+## Why It Matters
+
+1. **Usability.** Constructing the `(volume.restrict A).prod
+   (volume.restrict B)` integrability proof is mechanical but
+   verbose. `LocallyIntegrable` is the canonical Mathlib idiom
+   for "f is L¹ on every compact"; many users will already have
+   it in hand (e.g. continuous functions, `L¹_loc` density,
+   Sobolev representatives). A wrapper saves them the bridge
+   step.
+2. **No mathematical content lost.** Like sibling OQ-03 (Bochner
+   generalization), this is a "free" wrapper: zero new lemmas
+   needed, just an inlined application of an existing Mathlib
+   API (`LocallyIntegrable.integrableOn_isCompact`).
+3. **Parallel slot.** The wrapper composes orthogonally with
+   OQ-03 (`Bochner` codomain): a single combined wrapper
+   `intervalIntegral_swap_of_locallyIntegrable` for `f : ℝ →
+   ℝ → E` is the obvious next step after both OQ-02 and OQ-03
+   land. (We do **not** attempt the combined wrapper here; that
+   is its own OQ if seeker decides to extract it.)
+4. **Stronger ⇒ weaker** *is the wrong direction*. The seeker's
+   phrasing suggests a misreading of the Mathlib idiom; the
+   accurate reframing (alternative interface, not weaker
+   hypothesis) keeps the deliverable honest about its
+   mathematical status.
+
+## Decomposition
+
+- **S1 (this iteration, OBSERVE).** Identify the canonical
+  Mathlib bridge `LocallyIntegrable.integrableOn_isCompact`,
+  confirm `IsCompact (uIcc a b ×ˢ uIcc c d)` is mechanical, and
+  spell out that the wrapper proof script is a 5-line
+  modification of the parent's continuous-case proof. Document
+  the "stronger, not weaker" reframing so future iterations
+  don't waste effort searching for a strictly-weaker
+  hypothesis. **No Lean changes.**
+- **S2 (next, SCAFFOLD).** Create
+  `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean` with
+  `intervalIntegral_swap_of_locallyIntegrable` proven inline
+  (~30 lines including docstring). Build-verify.
+- **S3 (final, optional).** Gallery entry
+  (`src/data/proofs/<slug>/`) and Mathlib-contribution
+  discussion in the docstring (target:
+  `Mathlib.MeasureTheory.Integral.IntervalIntegral`,
+  suggested name: `intervalIntegral.integral_comm_locallyIntegrable`
+  or `intervalIntegral.swap_locallyIntegrable`).
+
+## References
+
+- Parent proof: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean`
+  (231 lines, 0 sorries, 0 axioms, status: `verified`).
+- Sibling OQ-03: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean`
+  — same wrapper-style pattern for the Bochner codomain.
+- Sibling OQ-01: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean`
+  — n-dim lift via `Measure.pi`.
+- Mathlib reference: `MeasureTheory.LocallyIntegrable` in
+  `Mathlib.MeasureTheory.Function.LocallyIntegrable`; key API
+  is `LocallyIntegrable.integrableOn_isCompact : LocallyIntegrable
+  f μ → IsCompact K → IntegrableOn f K μ`.
+- Mathlib reference: `restrict_prod_eq_prod_restrict` in
+  `Mathlib.MeasureTheory.Measure.Prod` (already used by the
+  parent's continuous case).

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/state.md
@@ -1,0 +1,93 @@
+# Current State
+
+**Phase**: S1 OBSERVE complete (docs only, 0 Lean changes)
+**Since**: 2026-05-12T13:08:00Z
+**Iteration**: 1
+**Owner**: researcher-8
+
+## Current Focus
+
+S1 OBSERVE: audit Mathlib's `LocallyIntegrable` API and reframe
+the seeker's "weakened from `uIcc a b × uIcc c d` to
+`LocallyIntegrable`" question as a user-interface wrapper, not
+a strict weakening (since `LocallyIntegrable f volume` is
+*stronger* than integrability on one compact rectangle, not
+weaker).
+
+## Active Approach
+
+**Wrapper / alternative-interface, not strict weakening.**
+
+The parent (`Proofs.GreensTheoremOQ01OQ01OQ02`) proves
+`intervalIntegral_swap` with the awkward hypothesis
+`Integrable f ((volume.restrict (uIcc a b)).prod
+(volume.restrict (uIcc c d)))`. The S2 deliverable will provide
+a wrapper
+
+```
+intervalIntegral_swap_of_locallyIntegrable :
+  Measurable (fun p => f p.1 p.2) →
+  LocallyIntegrable (fun p => f p.1 p.2) volume →
+  ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y
+```
+
+that discharges the awkward hypothesis internally via
+`LocallyIntegrable.integrableOn_isCompact` plus
+`restrict_prod_eq_prod_restrict`. The proof script is a 5-line
+modification of the parent's `intervalIntegral_swap_of_continuous`
+case.
+
+## Blockers
+
+None. All required Mathlib API exists at the parent's pin
+(verified by static audit; no Mathlib source-tree access in
+worktree, but cross-checked against sibling OQ-03's S1 audit
+which used the same import set).
+
+## Next Action
+
+S2 SCAFFOLD: create `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean`
+with the single wrapper theorem (~30 lines). Build-verify via
+`./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ02OQ02`
+from the worktree (per memory: main-repo absolute path mounts
+wrong root).
+
+## Decomposition Plan
+
+| Session | Phase | Deliverable | Lines | Status |
+|---|---|---|---|---|
+| S1 | OBSERVE | Audit + reframe seeker question | 0 Lean (docs) | **this session** |
+| S2 | SCAFFOLD | `intervalIntegral_swap_of_locallyIntegrable` proven inline | ~30 Lean | pending |
+| S3 | (optional) | Gallery entry + Mathlib contribution discussion | ~50 MD/JSON | pending |
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1 (S1 OBSERVE wrapper-reframing)
+- Approaches tried:
+  - S1 (researcher-8): OBSERVE audit of `LocallyIntegrable` API +
+    reframing the seeker's "weakened ... to `LocallyIntegrable`"
+    phrasing as an alternative interface (since
+    `LocallyIntegrable` is strictly *stronger* than the parent's
+    compact-rectangle hypothesis).
+
+## Key Risks
+
+1. **Phrasing trap.** Future iterations must not claim the
+   wrapper "weakens" the hypothesis — it strengthens it. The
+   wrapper is a usability improvement, not a mathematical
+   refinement. Documented in `knowledge.md` § "Reframing the
+   question" and § "Stronger ⇒ weaker is the wrong direction".
+2. **`integrableOn_isCompact` name drift.** Mathlib v4.26.0
+   should have `LocallyIntegrable.integrableOn_isCompact`; if
+   the name has drifted, S2 will need to search variants.
+
+## References
+
+- Parent: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean` (verified)
+- Sibling OQ-03: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean`
+  (same wrapper-style pattern for Bochner codomain)
+- Sibling OQ-01: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean`
+  (n-dim lift via `Measure.pi`)
+- Mathlib: `MeasureTheory.LocallyIntegrable` in
+  `Mathlib.MeasureTheory.Function.LocallyIntegrable`

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02.json
@@ -1,0 +1,247 @@
+{
+  "slug": "greens-theorem-oq-01-oq-01-oq-02-oq-02",
+  "title": "Can the integrability hypothesis be weakened from `uIcc a b × uIcc c d` to lo...",
+  "phase": "OBSERVING",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Can the integrability hypothesis be weakened from `uIcc a b × uIcc c d` to local integrability (`LocallyIntegrable`), similar to how Fubini-Tonelli handles σ-finite measures?.",
+    "whyMatters": [
+      "Usability — `LocallyIntegrable` is the canonical Mathlib idiom for compact-supported L¹; constructing the parent's `(restrict A).prod (restrict B)` form is verbose.",
+      "No mathematical content lost — like sibling OQ-03 (Bochner), this is a 'free' wrapper composing existing Mathlib API.",
+      "Composability — orthogonal to OQ-03; a combined Bochner + LocallyIntegrable wrapper is the obvious follow-up."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVING",
+    "since": "2026-05-12T13:08:00Z",
+    "iteration": 2,
+    "focus": "S1 OBSERVE: audit Mathlib `LocallyIntegrable` API; reframe seeker's 'weakened ... to LocallyIntegrable' phrasing as a user-interface wrapper (since LocallyIntegrable is strictly stronger than the parent's single-compact-rectangle hypothesis).",
+    "blockers": [],
+    "nextAction": "S2 SCAFFOLD: create proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean with `intervalIntegral_swap_of_locallyIntegrable` proven inline (~30 lines). Build-verify via Docker wrapper.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE complete (researcher-8, 2026-05-12). Identified that `LocallyIntegrable f volume` on ℝ² is strictly *stronger* than the parent's hypothesis (integrability on one compact rectangle), not weaker as the seeker phrasing suggests. The useful deliverable is a user-interface wrapper that takes `LocallyIntegrable` and discharges the awkward `(restrict A).prod (restrict B)` form via Mathlib's `LocallyIntegrable.integrableOn_isCompact` plus `restrict_prod_eq_prod_restrict` (already used in the parent's continuous case). Proof script is a 5-line modification of the parent's `intervalIntegral_swap_of_continuous`. No Mathlib gap.",
+    "builtItems": [
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/problem.md (S1 OBSERVE)",
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/knowledge.md (S1 OBSERVE)",
+      "research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/state.md (S1 OBSERVE)"
+    ],
+    "insights": [
+      "The seeker's 'weakened ... to LocallyIntegrable' phrasing inverts the implication direction: LocallyIntegrable f volume → IntegrableOn f K volume for any compact K, but not conversely. The wrapper strengthens the hypothesis but simplifies the interface.",
+      "Mathlib's `LocallyIntegrable.integrableOn_isCompact` is the canonical bridge; combined with `restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc` (already invoked by the parent's continuous case) it discharges the parent's product-restrict hypothesis in 3 lines.",
+      "The Measurable hypothesis cannot be folded into LocallyIntegrable (which only gives AEStronglyMeasurable) without auditing whether the parent's `mono_measure` chain accepts AEStronglyMeasurable; deferred to S2 / later.",
+      "Composes orthogonally with sibling OQ-03 (Bochner codomain); a combined wrapper is a candidate follow-up OQ."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "S2 SCAFFOLD: write proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean with the single wrapper theorem inline (~30 lines).",
+      "Build-verify via ./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ02OQ02 from the worktree.",
+      "S3 (optional): gallery entry + Mathlib contribution path discussion in docstring."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "measure-theory",
+    "fubini",
+    "interval-integral",
+    "green-theorem",
+    "mathlib-gap",
+    "research",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "greens-theorem",
+    "greens-theorem-oq-01",
+    "greens-theorem-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-01-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-01-oq-02",
+    "greens-theorem-oq-01-oq-01-oq-02-oq-03",
+    "greens-theorem-oq-01-oq-01-oq-03",
+    "greens-theorem-oq-01-oq-02",
+    "greens-theorem-oq-02",
+    "greens-theorem-oq-02-oq-04",
+    "greens-theorem-oq-03",
+    "greens-theorem-oq-03-oq-04",
+    "greens-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-12T03:16:39.863Z",
+  "lastUpdate": "2026-05-12T13:08:00Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/GreensTheorem.lean",
+      "filename": "GreensTheorem.lean",
+      "lineCount": 359,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 14,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheorem.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01.lean",
+      "filename": "GreensTheoremOQ01.lean",
+      "lineCount": 339,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01.lean",
+      "filename": "GreensTheoremOQ01OQ01.lean",
+      "lineCount": 155,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ01.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ01.lean",
+      "lineCount": 261,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ01OQ01.lean",
+      "lineCount": 517,
+      "theoremCount": 4,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ02.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ02OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ03.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ02.lean",
+      "filename": "GreensTheoremOQ01OQ02.lean",
+      "lineCount": 228,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ02.lean",
+      "filename": "GreensTheoremOQ02.lean",
+      "lineCount": 508,
+      "theoremCount": 21,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ02OQ04.lean",
+      "filename": "GreensTheoremOQ02OQ04.lean",
+      "lineCount": 260,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ03.lean",
+      "filename": "GreensTheoremOQ03.lean",
+      "lineCount": 558,
+      "theoremCount": 31,
+      "axiomCount": 3,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ03OQ04.lean",
+      "filename": "GreensTheoremOQ03OQ04.lean",
+      "lineCount": 251,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ03OQ04.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ04.lean",
+      "filename": "GreensTheoremOQ04.lean",
+      "lineCount": 588,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Slug**: `greens-theorem-oq-01-oq-01-oq-02-oq-02`
- **Phase**: S1 OBSERVE (docs only; 0 Lean changes)
- **Researcher**: researcher-8

## What the seeker asked

> Can the integrability hypothesis be weakened from `uIcc a b × uIcc c d` to local integrability (`LocallyIntegrable`), similar to how Fubini-Tonelli handles σ-finite measures?

## What S1 OBSERVE found

The seeker phrasing **inverts the implication direction**:

- The parent (`Proofs.GreensTheoremOQ01OQ01OQ02`) hypothesizes integrability against the **product of restricted** volumes on one compact rectangle.
- `LocallyIntegrable f volume` on ℝ² means integrability on **every** compact set.
- So `LocallyIntegrable → parent hypothesis` (specialize to the rectangle), but not conversely. `LocallyIntegrable` is *strictly stronger*, not weaker.

The useful deliverable is a **user-interface wrapper**: take `LocallyIntegrable` and discharge the awkward `(volume.restrict A).prod (volume.restrict B)` form internally via Mathlib's `LocallyIntegrable.integrableOn_isCompact` plus `restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc` (the latter is *already* invoked by the parent's continuous case).

The proof script is a **5-line modification** of the parent's `intervalIntegral_swap_of_continuous`:

```lean
theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
    (a b c d : ℝ)
    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
  apply intervalIntegral_swap a b c d hf_meas
  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
    isCompact_uIcc.prod isCompact_uIcc
  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
      (uIcc a b ×ˢ uIcc c d) volume :=
    hf_loc.integrableOn_isCompact hcpt
  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
```

No new imports relative to the parent.

## Files

- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/problem.md` (NEW)
- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/knowledge.md` (NEW)
- `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/state.md` (NEW)
- `src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02.json` (phase NEW → OBSERVING)

## Next iteration

**S2 SCAFFOLD** — write `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean` with the single wrapper theorem inline (~30 lines including docstring). Build-verify via Docker wrapper. Anticipated PR size: ~30 Lean lines + ~50 gallery JSON/MD lines.

## Test plan

- [x] No Lean changes (S1 OBSERVE is docs-only; build state of parent unchanged)
- [x] JSON validates (`python3 -c 'import json; json.load(open(".../greens-theorem-oq-01-oq-01-oq-02-oq-02.json"))'`)
- [x] No race: 0 open PRs / 0 recent merges / 0 remote branches for this slug at push time
- [ ] Math agent label policy: no `loom:review-requested` (deployer will merge directly per `.loom/CLAUDE.md`)