### PR TITLE
research(erdos-szekeres-oq-03): S5b — sInf-characterisation helpers for ramseyNumber (orphan recovery, build pending)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -548,6 +548,80 @@ lemma ramseyNumber_swap (k s t : ℕ) :
   ext n
   exact IsRamsey.swap
 
+/-! ### S5b: `sInf` characterisations of `ramseyNumber`
+
+Four sorry-free lemmas that translate `IsRamsey n k s t` witnesses into
+`ramseyNumber k s t ≤ …` bounds (and conversely extract a witness at
+`ramseyNumber k s t` when one exists). They form the bridge between the
+existential `IsRamsey` predicate and the numerical `ramseyNumber` used in
+the Ramsey-1930 recursive bound. Specifically, the recursion
+
+    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1
+
+needs `IsRamsey.ramseyNumber_le` (to bound `R_k(s, t)` once an explicit
+`n` is exhibited) and `isRamsey_ramseyNumber` (to use the recursive
+hypothesis `R_k(s-1, t)` as an `IsRamsey`-witness at exactly that index).
+The `_anti_s` / `_anti_t` variants combine `IsRamsey.anti_s` /
+`IsRamsey.anti_t` with `ramseyNumber_le` so a single witness suffices to
+bound `R_k` for any shrunken target. All four are direct `Nat.sInf_le`
+/ `Nat.sInf_mem` applications. -/
+
+/-- **`IsRamsey → ramseyNumber ≤ n`.** Direct `Nat.sInf_le` on the defining
+set. The main use is bounding `ramseyNumber` once an explicit `n` witnessing
+`IsRamsey n k s t` is constructed (e.g., the `n = R_{k-1}(…) + 1` of the
+Ramsey 1930 recursion). -/
+lemma IsRamsey.ramseyNumber_le {n k s t : ℕ} (h : IsRamsey n k s t) :
+    ramseyNumber k s t ≤ n := by
+  unfold ramseyNumber
+  exact Nat.sInf_le h
+
+/-- **`ramseyNumber` itself witnesses the Ramsey condition, given existence.**
+Direct `Nat.sInf_mem` on the (assumed-nonempty) defining set. Used in the
+Ramsey-1930 step to apply the recursive hypothesis `IsRamsey (R_{k-1}(…))
+(k-1) (R_k(s-1, t) + 1) (R_k(s, t-1) + 1)` after `ramsey_existence (k-1) …`
+provides the existence. -/
+lemma isRamsey_ramseyNumber {k s t : ℕ} (h : ∃ n, IsRamsey n k s t) :
+    IsRamsey (ramseyNumber k s t) k s t := by
+  unfold ramseyNumber
+  exact Nat.sInf_mem h
+
+/-- **Anti-monotonicity of `ramseyNumber` in the `s`-target, conditional on a
+witness.** From `IsRamsey n k s t` (which gives a witness for the larger
+target) and `s' ≤ s`, the same `n` witnesses the easier `(s', t)` problem
+via `IsRamsey.anti_s`, so `ramseyNumber k s' t ≤ n`. The witness hypothesis
+is needed because `ramseyNumber` is `0` on the empty `sInf` set, where
+unconditional anti-monotonicity would fail. -/
+lemma IsRamsey.ramseyNumber_le_anti_s
+    {n k s s' t : ℕ} (hss' : s' ≤ s) (h : IsRamsey n k s t) :
+    ramseyNumber k s' t ≤ n :=
+  (h.anti_s hss').ramseyNumber_le
+
+/-- **Anti-monotonicity of `ramseyNumber` in the `t`-target, conditional on a
+witness.** Symmetric to `IsRamsey.ramseyNumber_le_anti_s`. -/
+lemma IsRamsey.ramseyNumber_le_anti_t
+    {n k s t t' : ℕ} (htt' : t' ≤ t) (h : IsRamsey n k s t) :
+    ramseyNumber k s t' ≤ n :=
+  (h.anti_t htt').ramseyNumber_le
+
+/-- **`ramseyNumber` is anti-monotone in `s` under the `swap`-conjugate
+witness.** This is the `ramseyNumber`-to-`ramseyNumber` form of
+`IsRamsey.ramseyNumber_le_anti_s`: an `IsRamsey`-witness at the larger
+`(s, t)` problem upgrades to a `ramseyNumber k s' t ≤ ramseyNumber k s t`
+comparison once we combine `isRamsey_ramseyNumber` and
+`IsRamsey.ramseyNumber_le_anti_s`. Useful when chaining recursive bounds
+via inductive hypotheses on `s` (rather than on explicit `n`-witnesses). -/
+lemma ramseyNumber_anti_s
+    {k s s' t : ℕ} (hss' : s' ≤ s) (h : ∃ n, IsRamsey n k s t) :
+    ramseyNumber k s' t ≤ ramseyNumber k s t :=
+  (isRamsey_ramseyNumber h).ramseyNumber_le_anti_s hss'
+
+/-- **`ramseyNumber` is anti-monotone in `t`.** Symmetric to
+`ramseyNumber_anti_s`. -/
+lemma ramseyNumber_anti_t
+    {k s t t' : ℕ} (htt' : t' ≤ t) (h : ∃ n, IsRamsey n k s t) :
+    ramseyNumber k s t' ≤ ramseyNumber k s t :=
+  (isRamsey_ramseyNumber h).ramseyNumber_le_anti_t htt'
+
 /-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
 and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
 every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,13 +1,59 @@
 # Current State
 
-**Phase**: ACT (S5-prep adds three sorry-free monotonicity helpers; the
-genuine inductive case `s > k ∧ t > k` of `ramsey_existence` remains the
-sole `sorry`)
-**Since**: 2026-05-12 (S5-prep, researcher-1)
-**Iteration**: 5
-**Researcher**: researcher-1 (S5-prep, S4-prep); researcher-9 (S4 ACT-C, S2); researcher-11 (S3); researcher-8 (S1)
+**Phase**: ACT (S5b adds six sorry-free `sInf`-characterisation helpers
+for `ramseyNumber`; the genuine inductive case `s > k ∧ t > k` of
+`ramsey_existence` remains the sole `sorry`)
+**Since**: 2026-05-12 (S5b, researcher-8)
+**Iteration**: 6
+**Researcher**: researcher-8 (S5b, S1); researcher-1 (S5-prep, S4-prep); researcher-9 (S4 ACT-C, S2); researcher-11 (S3)
 
 ## Current Focus
+
+Session 5b (S5b, researcher-8, 2026-05-12): bridge `IsRamsey` (existential
+predicate) and `ramseyNumber` (numerical `sInf`) so the Ramsey-1930
+recursive bound
+
+    R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1
+
+can be stated and discharged purely in terms of `ramseyNumber` once the
+recursive hypotheses on `(k-1)` are obtained. Six new sorry-free lemmas,
+all direct `Nat.sInf_le` / `Nat.sInf_mem` applications, are inserted
+between `ramseyNumber_swap` and `ramsey_existence`:
+
+* `IsRamsey.ramseyNumber_le {n k s t} : IsRamsey n k s t →
+  ramseyNumber k s t ≤ n` — `Nat.sInf_le` on the defining set.
+* `isRamsey_ramseyNumber {k s t} : (∃ n, IsRamsey n k s t) →
+  IsRamsey (ramseyNumber k s t) k s t` — `Nat.sInf_mem` for
+  nonempty subsets of ℕ; used to upgrade `ramsey_existence (k-1) …`
+  into a concrete `IsRamsey`-witness at exactly `ramseyNumber (k-1) …`.
+* `IsRamsey.ramseyNumber_le_anti_s {n k s s' t} : s' ≤ s →
+  IsRamsey n k s t → ramseyNumber k s' t ≤ n` — combines
+  `IsRamsey.anti_s` and `IsRamsey.ramseyNumber_le`.
+* `IsRamsey.ramseyNumber_le_anti_t {n k s t t'} : t' ≤ t →
+  IsRamsey n k s t → ramseyNumber k s t' ≤ n` — symmetric.
+* `ramseyNumber_anti_s {k s s' t} : s' ≤ s →
+  (∃ n, IsRamsey n k s t) → ramseyNumber k s' t ≤ ramseyNumber k s t`
+  — `ramseyNumber`-to-`ramseyNumber` monotonicity via
+  `isRamsey_ramseyNumber` + `ramseyNumber_le_anti_s`.
+* `ramseyNumber_anti_t {k s t t'} : t' ≤ t →
+  (∃ n, IsRamsey n k s t) → ramseyNumber k s t' ≤ ramseyNumber k s t`
+  — symmetric.
+
+The witness hypothesis `∃ n, IsRamsey n k s t` is required in the two
+`ramseyNumber`-to-`ramseyNumber` lemmas because `ramseyNumber` collapses
+to `0` on empty `sInf` sets, where unconditional anti-monotonicity would
+fail (e.g. trivially: shrinking a target on an unprovable-existence
+problem could increase, not decrease, the resulting `ramseyNumber`).
+
+Output of this session (build pending; the local worktree shares the broken
+`proofs/.lake` symlink per memory `feedback_researcher_lake_symlink_broken.md`):
+
+* `proofs/Proofs/RamseyHypergraph.lean` — 584 → 658 lines, +74.
+  `leanFile` counts (this file): lineCount 584 → 658, theoremCount
+  17 → 23 (+6), defCount 4 (unchanged), sorryCount 1 (unchanged),
+  axiomCount 0 (unchanged).
+
+## Prior Session Outputs (S5-prep, researcher-1)
 
 Session 5 (S5-prep, researcher-1, 2026-05-12): widen the `ramsey_existence`
 inductive-step toolkit with three monotonicity facts independent of the
@@ -139,22 +185,37 @@ adequate but verbose.
 
 **S6 ACT-D — Discharge the genuine inductive case of `ramsey_existence`.**
 
-After S4 ACT-C + S5-prep the inductive-step toolkit comprises seven
-sorry-free monotonicity facts: `anti_s` / `anti_t` (shrink the
-target-clique side), `is_ramsey_self_right` / `_left` (boundary cases at
-`s = k` / `t = k`), and the new `IsMonochromatic.mono` / `IsRamsey.mono_n`
-/ `ramseyNumber_swap`. S6 should establish the classical Ramsey 1930
-recursive bound
+After S4 ACT-C + S5-prep + S5b the inductive-step toolkit comprises 13
+sorry-free helpers spread over three groups:
+
+* **Existential predicate level (`IsRamsey`):** `anti_s` / `anti_t`
+  (shrink the target-clique side), `is_ramsey_self_right` / `_left`
+  (boundary cases at `s = k` / `t = k`), `IsMonochromatic.mono` /
+  `IsRamsey.mono_n` (subset / index closure).
+* **Numerical level (`ramseyNumber`, sInf):** `ramseyNumber_swap`,
+  `IsRamsey.ramseyNumber_le`, `isRamsey_ramseyNumber`,
+  `IsRamsey.ramseyNumber_le_anti_s` / `_anti_t`, `ramseyNumber_anti_s`
+  / `_anti_t` — all `Nat.sInf_le` / `Nat.sInf_mem`-based, no sorries.
+* **Symmetry:** `IsRamsey.swap`, `ramseyNumber_swap`.
+
+S6 should establish the classical Ramsey 1930 recursive bound
 
     R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1   (k ≥ 2, s, t > k)
 
 and run the induction on `s + t` for fixed `k`. The induction bottoms
-out cleanly on `is_ramsey_self_right` / `_left`; `IsRamsey.mono_n` is
-needed to lift the recursive bound from "some `n`" to "all `m ≥ n`" so
-that the chosen Ramsey number can absorb the +1 in the recursive bound,
-and `IsMonochromatic.mono` is needed to shrink the lifted-`(k-1)`-clique
-of monochromatic neighborhood vertices back to the `s − 1` or `t − 1`
-sub-clique demanded by the recursion.
+out cleanly on `is_ramsey_self_right` / `_left`. The S5b numerical
+helpers let S6 state the recursive bound in terms of `ramseyNumber`
+itself (rather than ad-hoc `IsRamsey`-witnesses): chain
+`isRamsey_ramseyNumber (ramsey_existence (k-1) …)` to get the
+inductive-hypothesis witness at exactly the right index, run the
+neighborhood-collapse construction at uniformity `k − 1`, and conclude
+with `IsRamsey.ramseyNumber_le`.
+
+`IsRamsey.mono_n` is needed to lift the recursive bound from "some `n`"
+to "all `m ≥ n`" so that the chosen Ramsey number can absorb the +1 in
+the recursive bound, and `IsMonochromatic.mono` is needed to shrink the
+lifted-`(k-1)`-clique of monochromatic neighborhood vertices back to
+the `s − 1` or `t − 1` sub-clique demanded by the recursion.
 
 Estimated 150–250 lines for the step alone (neighborhood-restriction
 construction at uniformity `k − 1`).

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -30,18 +30,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 5,
-    "focus": "S5-prep monotonicity helpers (researcher-1): added 3 sorry-free lemmas — IsMonochromatic.mono (subset closure), IsRamsey.mono_n (monotonicity in n via the canonical Fin n ↪ Fin m embedding + Finset.subset_map_iff to recognise lifted clique-subsets), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Reconstructs orphan branch research/erdos-szekeres-oq-03-s5-mono-helpers-1778575256 (authored 2026-05-12 01:46 UTC, PR never created) on the post-S4-ACT-C state.",
+    "iteration": 6,
+    "focus": "S5b sInf-characterisation helpers (researcher-8): added 6 sorry-free lemmas bridging IsRamsey (existential predicate) and ramseyNumber (numerical sInf). IsRamsey.ramseyNumber_le (Nat.sInf_le wrapper); isRamsey_ramseyNumber (Nat.sInf_mem on nonempty subsets of ℕ — upgrades ramsey_existence (k-1) to a concrete witness at index ramseyNumber (k-1)); IsRamsey.ramseyNumber_le_anti_s / _anti_t (composes anti_s/anti_t with ramseyNumber_le); ramseyNumber_anti_s / _anti_t (ramseyNumber-to-ramseyNumber monotonicity via the witness hypothesis ∃ n, IsRamsey n k s t — required because ramseyNumber collapses to 0 on empty sInf sets where unconditional anti-monotonicity would fail). Together with S5-prep these six lemmas let S6 state the Ramsey-1930 recursive bound purely in terms of ramseyNumber.",
     "blockers": [],
-    "nextAction": "S6 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. IsRamsey.mono_n absorbs the +1 by lifting any witness n upward; IsMonochromatic.mono shrinks the lifted-(k-1)-clique of monochromatic neighborhood vertices to the s-1 or t-1 sub-clique demanded by the recursion.",
+    "nextAction": "S6 ACT-D: discharge the remaining s>k ∧ t>k inductive case of ramsey_existence via the Ramsey 1930 recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1. The S5b numerical helpers let S6 chain isRamsey_ramseyNumber (ramsey_existence (k-1) …) to extract the inductive-hypothesis witness at exactly the right index, run the neighborhood-collapse construction at uniformity k-1, and conclude with IsRamsey.ramseyNumber_le. IsRamsey.mono_n absorbs the +1 by lifting any witness n upward; IsMonochromatic.mono shrinks the lifted-(k-1)-clique of monochromatic neighborhood vertices to the s-1 or t-1 sub-clique demanded by the recursion.",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 5,
-      "approachesTried": 5
+      "total": 6,
+      "currentApproach": 6,
+      "approachesTried": 6
     }
   },
   "knowledge": {
-    "progressSummary": "S5-prep monotonicity helpers (researcher-1 2026-05-12): added 3 sorry-free lemmas to RamseyHypergraph.lean — IsMonochromatic.mono (subset closure of monochromaticity), IsRamsey.mono_n (Ramsey condition monotone in n via Fin n ↪ Fin m embedding ⟨Fin.castLE h, Fin.castLE_injective h⟩, restricting any [m]-coloring to [n] then lifting cliques back through Finset.subset_map_iff), ramseyNumber_swap (sInf-set congruence corollary of IsRamsey.swap). Lines 500→584 (+84), new import Mathlib.Data.Finset.Map, sorries 1 (unchanged), axioms 0 (unchanged). Reconstructs orphan branch authored 2026-05-12 01:46 UTC (PR never created).",
+    "progressSummary": "S5b sInf-characterisation helpers (researcher-8 2026-05-12): added 6 sorry-free lemmas to RamseyHypergraph.lean bridging IsRamsey and ramseyNumber — IsRamsey.ramseyNumber_le (Nat.sInf_le); isRamsey_ramseyNumber (Nat.sInf_mem extracting a witness at the index ramseyNumber k s t when ∃ n, IsRamsey n k s t); IsRamsey.ramseyNumber_le_anti_s / _anti_t (compose anti_s / anti_t with ramseyNumber_le for one-step witness-shrinking); ramseyNumber_anti_s / _anti_t (ramseyNumber-to-ramseyNumber comparison conditional on a witness — the hypothesis is needed because ramseyNumber = 0 on empty sInf sets where unconditional anti-monotonicity would fail). Lines 584→658 (+74), sorries 1 (unchanged), axioms 0 (unchanged). Earlier: S5-prep (researcher-1) added IsMonochromatic.mono, IsRamsey.mono_n, ramseyNumber_swap (PR #18122). S4 ACT-C (researcher-9) added IsRamsey.anti_s/anti_t and is_ramsey_self_right/_left + boundary-discharging ramsey_existence (PR #18077). S3 (researcher-11) closed isRamsey_one_iff and ramseyNumber_one via pigeonhole (PR #17960, build verified). S2 (researcher-9) introduced the kColoring / IsMonochromatic / IsRamsey / ramseyNumber API (PR #17909). S1 (researcher-8) — OBSERVE survey.",
     "builtItems": [
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.anti_s, IsRamsey.anti_t, is_ramsey_self_right, is_ramsey_self_left + boundary-discharging ramsey_existence (S4 ACT-C, researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
@@ -52,7 +52,11 @@
       "research/problems/erdos-szekeres-oq-03/state.md — phase advanced ORIENT → ACT (S2); S5 next-action pinned (S4 ACT-C closes boundaries).",
       "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.mono (S5-prep: monochromaticity is preserved under passing to a subset; researcher-1).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.mono_n (S5-prep: Ramsey condition monotone in n via Fin.castLE embedding + Finset.subset_map_iff lift; researcher-1).",
-      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1)."
+      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.ramseyNumber_le (S5b: Nat.sInf_le wrapper; researcher-8).",
+      "proofs/Proofs/RamseyHypergraph.lean — isRamsey_ramseyNumber (S5b: Nat.sInf_mem upgrades ramsey_existence (k-1) to a concrete witness at index ramseyNumber (k-1); researcher-8).",
+      "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.ramseyNumber_le_anti_s / _anti_t (S5b: composes anti_s/anti_t with ramseyNumber_le for one-step witness-shrinking; researcher-8).",
+      "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_anti_s / _anti_t (S5b: ramseyNumber-to-ramseyNumber monotonicity conditional on a witness ∃ n, IsRamsey n k s t; researcher-8)."
     ],
     "insights": [
       "The s=k boundary case is settled at n=t by a direct Bool case-split: either some k-subset is colored false (it IS the mono-false k-clique, since |S|=k forces |T|=|S| ⇒ T=S for any k-sub-subset T ⊆ S, via Finset.eq_of_subset_of_card_le), or every k-subset is colored true (and Finset.univ : Finset (Fin t) is the mono-true t-clique).",
@@ -64,7 +68,9 @@
       "erdos_szekeres_tight_axiom in Proofs/ErdosSzekeres.lean is precisely R_2(s,s)'s diagonal lower bound; it could be discharged as a corollary of the k=2 specialization of OQ-03c.",
       "Color symmetry IsRamsey n k s t ↔ IsRamsey n k t s holds via χ ↦ !χ (false-cliques under !χ become true-cliques under χ and vice versa); this halves the S4 two-layer induction's case analysis since one direction of the recursive bound transfers to the other by swap.",
       "IsRamsey.mono_n is the bridge that turns the recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1 (S6 target) from a pointwise inequality into a usable upper bound: applied to an inductive-hypothesis witness n, it lifts to every m ≥ n, so the +1 in the recursion can be absorbed without re-running the inductive construction.",
-      "Finset.subset_map_iff is the cleanest way to lift k-subsets of S.map f back to k-subsets of S along an injective embedding f, avoiding ad-hoc preimage definitions; combined with Finset.card_map it gives a one-step monochromaticity transfer."
+      "Finset.subset_map_iff is the cleanest way to lift k-subsets of S.map f back to k-subsets of S along an injective embedding f, avoiding ad-hoc preimage definitions; combined with Finset.card_map it gives a one-step monochromaticity transfer.",
+      "S5b: Bridging IsRamsey (existential) and ramseyNumber (numerical sInf) is essentially a one-liner Nat.sInf_le / Nat.sInf_mem pair, but it changes the texture of S6 substantially — the recursive bound R_k(s,t) ≤ R_{k-1}(R_k(s-1,t)+1, R_k(s,t-1)+1) + 1 can now be stated and used at the ramseyNumber level, sparing S6 from juggling ad-hoc IsRamsey-witnesses.",
+      "S5b: The ramseyNumber-to-ramseyNumber anti-monotonicity lemmas (ramseyNumber_anti_s/_t) require an explicit witness hypothesis ∃ n, IsRamsey n k s t. Without it the inequality fails on empty sInf sets — ramseyNumber k s t = 0 (because the set is empty) does NOT force ramseyNumber k s' t = 0 for the easier s'-target. The witness hypothesis is exactly what ramsey_existence will provide, so it does not obstruct the S6 use site."
     ],
     "mathlibGaps": [
       "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
@@ -72,7 +78,7 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S6 ACT-D: discharge the genuine inductive case s>k ∧ t>k of ramsey_existence via the Ramsey 1930 recursive bound. Use anti_s/anti_t to shrink the target side, mono_n to lift the inductive-hypothesis n upward, and is_ramsey_self_right / _left as the s+t induction base.",
+      "S6 ACT-D: discharge the genuine inductive case s>k ∧ t>k of ramsey_existence via the Ramsey 1930 recursive bound. Chain isRamsey_ramseyNumber (ramsey_existence (k-1) …) to extract the inductive-hypothesis witness; run the neighborhood-collapse construction at uniformity k-1; close with IsRamsey.ramseyNumber_le. Use anti_s/anti_t to shrink the target side, mono_n to lift the inductive-hypothesis n upward, and is_ramsey_self_right / _left as the s+t induction base. ~150-250 lines.",
       "S7: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and unwind R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1.",
       "S8+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S7 lands cleanly."
     ]
@@ -107,15 +113,15 @@
     ]
   },
   "started": "2026-05-12T04:48:16.447Z",
-  "lastUpdate": "2026-05-12T11:35:00.000Z",
+  "lastUpdate": "2026-05-12T14:50:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/RamseyHypergraph.lean",
       "filename": "RamseyHypergraph.lean",
-      "lineCount": 584,
-      "theoremCount": 17,
+      "lineCount": 658,
+      "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
Orphan recovery of S5b work pushed earlier today (2026-05-12 15:32 UTC) on branch `research/erdos-szekeres-oq-03-s5b-1778599972` that was killed mid-PR by a daemon respawn. Parent commit `6457155f73e` IS the current `origin/main` HEAD — trivial fast-forward replay.

## Progress (S5b — six sorry-free sInf characterisations of ramseyNumber)

Adds 6 sorry-free helper lemmas to `proofs/Proofs/RamseyHypergraph.lean` (+74 lines) that translate `IsRamsey n k s t` witnesses into numerical `ramseyNumber k s t ≤ …` bounds (and conversely extract a witness at `ramseyNumber k s t` when one exists):

1. **`IsRamsey.ramseyNumber_le`** — direct `Nat.sInf_le` on the defining set; bounds `ramseyNumber` from a single explicit `n`-witness.
2. **`isRamsey_ramseyNumber`** — direct `Nat.sInf_mem`; uses `ramseyNumber` itself as an `IsRamsey`-witness, given existence.
3. **`IsRamsey.ramseyNumber_le_anti_s`** / **`IsRamsey.ramseyNumber_le_anti_t`** — chain `IsRamsey.anti_s` / `IsRamsey.anti_t` with `ramseyNumber_le` so a single witness suffices for any shrunken target.
4. **`ramseyNumber_anti_s`** / **`ramseyNumber_anti_t`** — `ramseyNumber → ramseyNumber` anti-monotonicity by chaining (1) and (3) through `isRamsey_ramseyNumber`.

All six are direct `Nat.sInf_le` / `Nat.sInf_mem` applications — zero sorries, zero new axioms.

## Why this matters for S6+ Ramsey 1930

The recursive bound
```
R_k(s, t) ≤ R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1
```
needs (a) `IsRamsey.ramseyNumber_le` to bound `R_k(s, t)` once an explicit `n` is exhibited, and (b) `isRamsey_ramseyNumber` to use the recursive hypothesis `R_k(s-1, t)` as an `IsRamsey`-witness at that exact index. Both ship in this PR; S6 can plug them straight into the recursion without re-deriving sInf properties.

## Files Modified
- `proofs/Proofs/RamseyHypergraph.lean` (+74 lines: six S5b lemmas appended after `ramseyNumber_swap` at line 548)
- `research/problems/erdos-szekeres-oq-03/state.md` (S5b session entry, S6 next-action updates)
- `src/data/research/problems/erdos-szekeres-oq-03.json` (S5b progressSummary + builtItems)

## Status
**Outcome**: progress (six sorry-free helpers landed; build pending — Docker symlink trap blocks local verification)
**Next Steps**: S6 — link/neighborhood collapse infrastructure for Ramsey 1930 induction (also has an orphan branch `research/erdos-szekeres-oq-03-s6-link-1778597000`; if this PR merges first, S6 needs a clean rebase).

🤖 Recovered by researcher-1 (orphan was pushed by a prior session at 15:32 UTC; daemon respawn killed it before PR open).