### PR TITLE
Enrich Uniform n×n Quasideterminants (cramers-rule-oq-01-oq-02-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,34 +1,110 @@
 [
   {
-    "id": "qdetf-uniform-definition",
-    "title": "The uniform-in-n commutative quasideterminant",
-    "startLine": 79,
-    "endLine": 81,
-    "content": "qdetF is the canonical Gelfand–Retakh quasideterminant in its commutative (Schur-complement-as-quotient) form, uniform in n. For any (n+1)×(n+1) matrix A over a field F, qdetF A i j is just det(A) / det(minor_{ij}(A)). This single definition specializes to qdet00/qdet11 (n=2, in the non-degenerate regime where A 1 1 or A 0 0 is nonzero) and to qdet3 (n=3, by rfl, since block3 is an abbrev for the same A.submatrix Fin.succAbove Fin.succAbove). The fully non-commutative analogue qdetN over a division ring requires mutual strong recursion with qdetN_inv and is deferred to S3.",
-    "category": "definition"
+    "id": "ann-minor-ij",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 66 },
+    "type": "definition",
+    "title": "The complementary n×n submatrix (uniform-in-n)",
+    "content": "`minorIJ A i j` is the complementary `n×n` submatrix obtained by deleting row `i` and column `j` from an `(n+1)×(n+1)` matrix. The construction `A.submatrix (Fin.succAbove i) (Fin.succAbove j)` uses `Fin.succAbove i : Fin n → Fin (n+1)`, the canonical injection that skips index `i`. Crucially, `minorIJ` is declared `abbrev` rather than `def`: this makes it transparent to definitional equality, which is what enables the `qdetF_eq_qdet3` bridge to hold by `rfl` (since the parent's `block3` is itself an `abbrev` over the same body).",
+    "mathContext": "$\\mathrm{minor}_{ij}(A) := (A_{rs})_{r \\neq i,\\, s \\neq j}$, viewed as a matrix indexed by $\\mathrm{Fin}(n) \\times \\mathrm{Fin}(n)$ via $\\mathrm{Fin.succAbove}\\,i$ and $\\mathrm{Fin.succAbove}\\,j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["complementary minor", "Fin.succAbove", "Matrix.submatrix", "abbrev transparency"],
+    "prerequisites": ["Mathlib Matrix API", "Fin arithmetic"]
   },
   {
-    "id": "qdetf-multiplicative-identity",
+    "id": "ann-qdetf-definition",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 81 },
+    "type": "definition",
+    "title": "qdetF — the uniform-in-n commutative quasideterminant",
+    "content": "`qdetF` is the canonical Gelfand–Retakh quasideterminant in its commutative (Schur-complement-as-quotient) form, uniform in n. For any `(n+1)×(n+1)` matrix `A` over a field `F`, `qdetF A i j := A.det / (minorIJ A i j).det`. This single one-line definition is what makes Route A tractable: no induction, no mutual recursion, no Schur-complement bookkeeping. It specializes to `qdet00`/`qdet11` (n=2, in the non-degenerate regime) and to `qdet3` (n=3, by `rfl`). The fully non-commutative analogue `qdetN` over a division ring is genuinely harder — it requires mutual strong recursion with `qdetN_inv` on decreasing `n` — and is the S3 target.",
+    "mathContext": "$|A|_{ij} := \\dfrac{\\det A}{\\det \\mathrm{minor}_{ij}(A)} \\in F.$ For a non-commutative division ring $D$, the corresponding formula uses Schur complements: $|A|_{ij} = A_{ij} - A_{i,\\hat j} (A_{\\hat i, \\hat j})^{-1} A_{\\hat i, j}$, where hats denote the complementary block. Over a commutative field the two formulas coincide.",
+    "significance": "key",
+    "relatedConcepts": ["Gelfand-Retakh quasideterminant", "Schur complement", "Cramer's rule", "Route A vs Route B"],
+    "prerequisites": ["Matrix.det", "field division", "n=2 quasideterminant theory (parent file)"]
+  },
+  {
+    "id": "ann-qdetf-field-quotient",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 91 },
+    "type": "theorem",
     "title": "The multiplicative defining identity",
-    "startLine": 86,
-    "endLine": 91,
-    "content": "qdetF_field_quotient is the multiplicative form of the defining identity: qdetF · minor_det = det(A) (when minor_det ≠ 0). It is the n×n analogue of CramersRuleOQ01OQ02OQ01.qdet3_mul_minor_eq_det, with the same one-line proof via div_mul_cancel₀. This identity is the foundational tool for n×n Cramer's-rule arguments using quasideterminants: instead of dividing by det(A), one divides by the minor determinant to isolate a single column/row variable.",
-    "category": "theorem"
+    "content": "`qdetF_field_quotient` rewrites the quotient definition into the algebraically more useful multiplicative form: `qdetF A i j * (minorIJ A i j).det = A.det` (when the minor is invertible). This is the n×n analogue of `CramersRuleOQ01OQ02OQ01.qdet3_mul_minor_eq_det`, with the same one-line proof via `div_mul_cancel₀`. The multiplicative form is preferred in Cramer-style arguments because it lets us isolate a single column or row variable by clearing denominators rather than introducing them.",
+    "mathContext": "$|A|_{ij} \\cdot \\det \\mathrm{minor}_{ij}(A) = \\det A.$ Equivalently, $\\det A = |A|_{ij} \\cdot \\det \\mathrm{minor}_{ij}(A)$, the Cramer-style factorization of the full determinant through the (i,j)-quasideterminant.",
+    "significance": "key",
+    "relatedConcepts": ["div_mul_cancel₀", "Cramer's rule", "multiplicative form"],
+    "prerequisites": ["field algebra", "Mathlib's div_mul_cancel₀ API"]
   },
   {
-    "id": "qdetf-eq-qdet3-by-rfl",
-    "title": "n=3 bridge by rfl",
-    "startLine": 117,
-    "endLine": 121,
-    "content": "The equality qdetF A i j = CramersRuleOQ01OQ02OQ01.qdet3 A i j (for A : Matrix (Fin 3) (Fin 3) F) holds by rfl because block3 is an abbrev for A.submatrix (Fin.succAbove i) (Fin.succAbove j) — exactly the body of minorIJ. Lean's reducibility settings make abbrevs transparent to definitional equality, so the two definitions are judgmentally equal without any rewriting. This is the cleanest possible bridge: the 3×3 quasideterminant theory is literally a special case of qdetF.",
-    "category": "theorem"
+    "id": "ann-qdetf-ne-zero",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 100 },
+    "type": "theorem",
+    "title": "Non-vanishing of qdetF",
+    "content": "`qdetF_ne_zero` is the one-line consequence that, when both `det A` and the complementary-minor determinant are nonzero, the quasideterminant is nonzero. This is the natural non-degeneracy criterion for treating qdetF as an invertible quantity (e.g. when solving linear systems via the quasideterminant variant of Cramer's rule).",
+    "mathContext": "$\\det A \\neq 0 \\wedge \\det \\mathrm{minor}_{ij}(A) \\neq 0 \\implies |A|_{ij} \\neq 0.$ The converse implication is also true (since $|A|_{ij} = \\det A / \\det \\mathrm{minor}_{ij}(A)$, both numerator and denominator must be nonzero for the quotient to be defined and nonzero) but is not needed downstream.",
+    "significance": "supporting",
+    "relatedConcepts": ["div_ne_zero", "non-degenerate matrix", "invertibility"],
+    "prerequisites": ["field algebra"]
   },
   {
-    "id": "qdetf-eq-qdet00-bridge",
-    "title": "n=2 bridge via mul_right_cancel₀",
-    "startLine": 137,
-    "endLine": 151,
-    "content": "The 2×2 (0,0)-quasideterminant qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0 is non-commutative-friendly (uses inverses, not divisions). Over a field with A 1 1 ≠ 0, the parent file's qdet00_mul_eq_det gives qdet00 A * A 1 1 = A.det. Symmetrically, qdetF_field_quotient gives qdetF A 0 0 * A 1 1 = A.det (using minorIJ_22_00_det to identify the minor determinant as A 1 1). Both sides have the same product against the nonzero A 1 1, so mul_right_cancel₀ closes qdetF A 0 0 = qdet00 A. This bridge uses NONE of the non-degeneracy beyond the standard A 1 1 ≠ 0 hypothesis carried in the parent file's API.",
-    "category": "theorem"
+    "id": "ann-qdetf-eq-qdet3",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 111 },
+    "type": "theorem",
+    "title": "n=3 specialization by rfl",
+    "content": "The equality `qdetF A i j = CramersRuleOQ01OQ02OQ01.qdet3 A i j` (for `A : Matrix (Fin 3) (Fin 3) F`) holds by `rfl`. This is the cleanest possible bridge: the n=3 quasideterminant theory is *literally* (definitionally) a special case of `qdetF`. The reason is that `block3 i j A` in the parent file is an `abbrev` whose body is `A.submatrix (Fin.succAbove i) (Fin.succAbove j)` — the same body as `minorIJ`. Lean's reducibility settings unfold `abbrev` transparently, so the two definitions are *judgmentally* equal.",
+    "mathContext": "At $n+1 = 3$, both `qdetF` and `qdet3` reduce to $\\det(A) / \\det(\\text{2×2 block})$ via the same underlying `submatrix` construction. Definitional equality means no rewriting is needed — Lean recognises the proof as `rfl`.",
+    "significance": "key",
+    "relatedConcepts": ["definitional equality", "abbrev", "rfl", "reducibility"],
+    "prerequisites": ["Lean 4 reducibility semantics", "n=3 quasideterminant theory (parent file)"]
+  },
+  {
+    "id": "ann-minor-22-det-lemmas",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 117, "endLine": 135 },
+    "type": "technique",
+    "title": "Pinning the 2×2 minor determinants",
+    "content": "The (0,0)- and (1,1)-minors of a 2×2 matrix are 1×1 (singleton) matrices, so their determinants are just the single remaining entry. The two `@[simp]` lemmas pin these explicitly: `minorIJ A 0 0 . det = A 1 1` and `minorIJ A 1 1 . det = A 0 0`. The proofs use `Matrix.det_fin_one` to reduce the determinant to the single entry, then `Fin.succAbove (0 : Fin 2) (0 : Fin 1) = 1` by `rfl`. These lemmas are the bridge between the abstract `minorIJ` and the concrete entries used in the parent's `qdet00`/`qdet11` formulas.",
+    "mathContext": "$\\det \\mathrm{minor}_{00}([[a,b],[c,d]]) = d = A_{11}$ and $\\det \\mathrm{minor}_{11}([[a,b],[c,d]]) = a = A_{00}$. The signs of the cofactors are absorbed into the row/column-deletion convention.",
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.det_fin_one", "Fin.succAbove evaluation", "cofactor", "@[simp] lemmas"],
+    "prerequisites": ["2×2 determinant", "Fin arithmetic"]
+  },
+  {
+    "id": "ann-qdetf-eq-qdet00",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 152 },
+    "type": "theorem",
+    "title": "n=2 (0,0)-specialization via mul_right_cancel₀",
+    "content": "Bridges `qdetF A 0 0` (the uniform commutative form) to the parent's 2×2 (0,0)-quasideterminant `qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0`. The strategy is multiplicative cancellation: under `A 1 1 ≠ 0`, *both* sides multiply against `A 1 1` to give `A.det` — `qdetF` via `qdetF_field_quotient` (using `minorIJ_22_00_det` to identify the minor as `A 1 1`), and `qdet00` via the parent's `qdet00_mul_eq_det`. Two quantities with the same product against a nonzero `A 1 1` must be equal, so `mul_right_cancel₀` closes the goal. No further non-degeneracy is needed beyond the standard `A 1 1 ≠ 0` already carried in the parent's API.",
+    "mathContext": "For a 2×2 matrix $A$ with $A_{11} \\neq 0$: $|A|_{00}^{(F)} = \\dfrac{\\det A}{A_{11}}$ and $|A|_{00}^{(\\text{Schur})} = A_{00} - A_{01} A_{11}^{-1} A_{10}$. Both satisfy $|A|_{00} \\cdot A_{11} = \\det A$, so they coincide. The Schur form is the non-commutative-friendly version; the quotient form is the commutative one.",
+    "significance": "key",
+    "relatedConcepts": ["mul_right_cancel₀", "Schur complement", "qdet00_mul_eq_det", "n=2 quasideterminant"],
+    "prerequisites": ["2×2 quasideterminant theory (parent file)", "mul_right_cancel₀"]
+  },
+  {
+    "id": "ann-qdetf-eq-qdet11",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 154, "endLine": 167 },
+    "type": "theorem",
+    "title": "n=2 (1,1)-specialization (symmetric to (0,0))",
+    "content": "The (1,1)-twin of `qdetF_eq_qdet00`. The structure is identical except that the parent's identity comes in the form `A 0 0 * qdet11 A = A.det` rather than `qdet11 A * A 0 0 = A.det`, so an extra `mul_comm` rewrite is needed before `mul_right_cancel₀` applies. The hypothesis is the symmetric `A 0 0 ≠ 0`. Together, `qdetF_eq_qdet00` and `qdetF_eq_qdet11` exhaust the four (i,j) cases for n=2 (the off-diagonal cases (0,1) and (1,0) are handled by the parent's `qdet01`/`qdet10` via the same template, deferred here).",
+    "mathContext": "For a 2×2 matrix $A$ with $A_{00} \\neq 0$: $|A|_{11}^{(F)} = \\dfrac{\\det A}{A_{00}}$ and $|A|_{11}^{(\\text{Schur})} = A_{11} - A_{10} A_{00}^{-1} A_{01}$. Both multiply against $A_{00}$ to give $\\det A$ (modulo `mul_comm`).",
+    "significance": "supporting",
+    "relatedConcepts": ["mul_comm", "mul_right_cancel₀", "qdet11", "n=2 quasideterminant"],
+    "prerequisites": ["qdetF_eq_qdet00 pattern", "2×2 Schur form"]
+  },
+  {
+    "id": "ann-qdetf-summary",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 173, "endLine": 183 },
+    "type": "theorem",
+    "title": "Route-A summary: multiplicative identity + definitional quotient",
+    "content": "`qdetF_summary` packages the two faces of the Route A theory: the multiplicative form `qdetF · minor_det = det A` (from `qdetF_field_quotient`) and the quotient form `qdetF = det A / minor_det` (by `rfl` from the definition). Together, these are the complete commutative-half story: every n×n quasideterminant identity over a field can be derived by combining one of these two forms with standard field algebra. The non-commutative S3 target (`qdetN` over a division ring) will need a structurally analogous summary, but its proof will require mutual recursion rather than `rfl`.",
+    "mathContext": "$|A|_{ij} \\cdot \\det \\mathrm{minor}_{ij}(A) = \\det A \\quad \\wedge \\quad |A|_{ij} = \\dfrac{\\det A}{\\det \\mathrm{minor}_{ij}(A)}.$ The conjunction is the complete API of `qdetF` from which all commutative n×n Cramer-style identities follow.",
+    "significance": "key",
+    "relatedConcepts": ["Cramer's rule (n×n)", "non-commutative deferred (S3)", "qdetN", "summary theorem"],
+    "prerequisites": ["qdetF_field_quotient"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-01-oq-02-oq-01-oq-01` (Uniform n×n Quasideterminants — Route A).

## What changed

`annotations.json` previously had 4 entries using a non-standard schema (`startLine`/`endLine` at top level, `category` instead of `type`, no `proofId`, no `mathContext`/`significance`/`relatedConcepts`/`prerequisites`).

This PR:

1. **Migrates the 4 existing annotations** to the standard schema with full enrichment fields
2. **Adds 5 new annotations** covering previously uncovered constructs

Total: **4 → 9 annotations**; coverage extends from lines 79-151 to 62-183 of the Lean file.

## The 9 annotations

| # | Construct | Lines | Type | Significance |
|---|-----------|-------|------|--------------|
| 1 | `minorIJ` (complementary submatrix; abbrev-transparency role) | 62-66 | definition | supporting |
| 2 | `qdetF` (uniform-in-n commutative quasideterminant) | 72-81 | definition | key |
| 3 | `qdetF_field_quotient` (multiplicative defining identity) | 83-91 | theorem | key |
| 4 | `qdetF_ne_zero` (non-vanishing) | 93-100 | theorem | supporting |
| 5 | `qdetF_eq_qdet3` (n=3 bridge by rfl) | 106-111 | theorem | key |
| 6 | `minorIJ_22_{00,11}_det` (pinning 1×1 minors) | 117-135 | technique | supporting |
| 7 | `qdetF_eq_qdet00` (n=2 bridge via mul_right_cancel₀) | 137-152 | theorem | key |
| 8 | `qdetF_eq_qdet11` (symmetric (1,1) bridge with mul_comm) | 154-167 | theorem | supporting |
| 9 | `qdetF_summary` (Route A complete API) | 173-183 | theorem | key |

Every annotation now has LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

## Verification

Ran `npx tsx scripts/annotations/build.ts`: no errors specific to this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)