### PR TITLE
audit: tracker queue drained (2427/2427) — final two clean audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15203,6 +15203,18 @@
       "issues": [],
       "lastAudited": "2026-05-12T14:50:30Z",
       "result": "clean"
+    },
+    "collatz-cycles-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T20:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T20:30:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

Marks the final two unaudited gallery entries `clean`:
- **collatz-cycles-oq-03**: 80 lines, 0 sorries, 0 axioms, 5 theorems/lemmas. `status: verified` + `badge: original` match Lean source. Companion file exposing `cycle_contains_even` (no all-odd Collatz cycle, by elementary parity).
- **fourier-series-oq-04-oq-01**: 179 lines, 1 axiom (`carleson_2d_sph`), 1 sorry (`sphPartialSum_L2_norm_converge`), 3 theorems, 5 defs. `status: axiomatized` + `badge: axiom` correct for the open 2D Carleson conjecture per Axiom Integrity Policy.

Gallery audit queue: **2427/2427 audited, 0 unaudited, 0 issues**.

## Audit checks performed

For each entry: lineCount, sorries, axiomCount, theoremCount, definitionCount cross-verified against Lean source; no True stubs; no structure-encoded assumptions; no Mathlib-wrapper delegation opacity; language precision (title/description) consistent with tier and badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)