### PR TITLE
Enrich No-All-Odd Collatz Cycle (collatz-cycles-oq-03)

### DIFF
--- a/src/data/proofs/collatz-cycles-oq-03/annotations.json
+++ b/src/data/proofs/collatz-cycles-oq-03/annotations.json
@@ -1,15 +1,38 @@
 [
   {
+    "id": "ann-collatz-oq03-header",
+    "proofId": "collatz-cycles-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 20
+    },
+    "type": "context",
+    "title": "OQ Statement and Proof Outline",
+    "content": "The file's docstring states the OQ-03 claim — every Collatz cycle visits at least one even number — and lists the five-theorem chain that delivers it: `three_n_plus_one_even` → `collatz_of_odd_is_even` → `no_all_odd_cycle` → `cycle_contains_even` → `isPeriodic_contains_even`. The proof is two `omega` steps from the parent's `collatz_odd` lemma. The 80-line file is far longer than the mathematical content (≈5 lines of new logic) because each intermediate fact is stated as a named theorem, both for pedagogical clarity and so downstream callers can import the most convenient form.",
+    "mathContext": "The Collatz function $C : \\mathbb{N} \\to \\mathbb{N}$ is defined as $C(n) = n/2$ if $n$ is even and $C(n) = 3n+1$ if $n$ is odd. A cycle of length $k$ is an $n$ with $C^k(n) = n$ and $k \\geq 1$. The OQ-03 claim: for every cycle, some iterate $C^i(n)$ ($0 \\leq i < k$) is even.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Collatz conjecture (1937)",
+      "iterated function dynamics",
+      "Lagarias 1985 survey",
+      "parent file: Proofs/CollatzCycles.lean"
+    ],
+    "prerequisites": [
+      "Collatz function definition",
+      "iterated function composition (Function.iterate)"
+    ]
+  },
+  {
     "id": "ann-collatz-oq03-three-n-plus-one-even",
     "proofId": "collatz-cycles-oq-03",
     "range": {
-      "startLine": 26,
-      "endLine": 28
+      "startLine": 28,
+      "endLine": 29
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Parity flip: 3n+1 is even when n is odd",
-    "content": "The microscopic content of Part I. For an odd natural `n`, `3*n + 1` is even. `omega` closes this directly: knowing `n % 2 = 1`, the goal `(3*n + 1) % 2 = 0` is a linear arithmetic statement decidable by Presburger.",
-    "mathContext": "This is the first half of the Collatz step's parity behavior: applying `3n+1` to an odd input always produces an even output. The companion fact — applying `n/2` to an even input — is more obvious and lives implicitly in `Nat.div_two_le`. Together they imply that the parity sequence under iterated `collatz` cannot stay constant, hence cannot be entirely odd on a cycle.",
+    "content": "The microscopic content of Part I. For an odd natural `n`, `3*n + 1` is even. `omega` closes this directly: knowing `n % 2 = 1`, the goal `(3*n + 1) % 2 = 0` is a linear arithmetic statement decidable by Presburger. This is the entire mathematical kernel of the file — every subsequent theorem is a wrapper around this parity flip.",
+    "mathContext": "$n \\equiv 1 \\pmod 2 \\implies 3n + 1 \\equiv 3 + 1 \\equiv 0 \\pmod 2$. This is the first half of the Collatz step's parity behavior: applying $3n+1$ to an odd input always produces an even output. The companion fact — applying $n/2$ to an even input — is more obvious and lives implicitly in `Nat.div_two_le`. Together they imply that the parity sequence under iterated $C$ cannot stay constant odd, hence cannot be entirely odd on a cycle.",
     "significance": "supporting",
     "relatedConcepts": [
       "parity",
@@ -25,18 +48,19 @@
     "id": "ann-collatz-oq03-collatz-of-odd-is-even",
     "proofId": "collatz-cycles-oq-03",
     "range": {
-      "startLine": 30,
-      "endLine": 34
+      "startLine": 32,
+      "endLine": 35
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Single-step parity: collatz n is even when n is odd",
-    "content": "Apply the parent's `collatz_odd : n % 2 = 1 → collatz n = 3*n + 1` (line 40 of `CollatzCycles.lean`) to rewrite the goal, then apply `three_n_plus_one_even`. This is the bridge from the function's definitional case-split to the parity flip.",
-    "mathContext": "The parent file proves `collatz_odd` but never combines it with the parity flip to obtain this corollary. Stating `collatz_of_odd_is_even` explicitly makes the all-odd-cycle contradiction (next theorem) a one-step move rather than a multi-step rewrite chain.",
+    "content": "Apply the parent's `collatz_odd : n % 2 = 1 → collatz n = 3*n + 1` (line 40 of `CollatzCycles.lean`) to rewrite the goal, then apply `three_n_plus_one_even`. This is the bridge from the function's definitional case-split to the parity flip. The parent file proves `collatz_odd` but never combines it with the parity flip to obtain this corollary, so stating `collatz_of_odd_is_even` explicitly makes the all-odd-cycle contradiction (next theorem) a one-step move rather than a multi-step rewrite chain.",
+    "mathContext": "$n \\equiv 1 \\pmod 2 \\implies C(n) \\equiv 0 \\pmod 2$. The corollary chain: definitional `collatz_odd` (rewrite to $3n+1$) ∘ `three_n_plus_one_even` (parity flip) = `collatz_of_odd_is_even`. Stating the corollary explicitly is a *single-step lemma* design choice that pays dividends in `no_all_odd_cycle` (where it's used twice via `Function.iterate_one`).",
     "significance": "key",
     "relatedConcepts": [
       "collatz_odd",
       "collatz function",
-      "parity flip"
+      "parity flip",
+      "single-step lemma design"
     ],
     "prerequisites": [
       "Parent's `collatz_odd` lemma",
@@ -47,18 +71,20 @@
     "id": "ann-collatz-oq03-no-all-odd-cycle",
     "proofId": "collatz-cycles-oq-03",
     "range": {
-      "startLine": 36,
-      "endLine": 56
+      "startLine": 41,
+      "endLine": 60
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "No all-odd Collatz cycle: contradiction proof",
     "content": "**Setup.** Assume `k ≥ 1`, `collatz^[k] n = n`, and every iterate `collatz^[i] n` for `i < k` is odd. We derive `False`.\n\n**Step 1.** From `hodd_all 0 hk`, the iterate at step 0 (= n) is odd: `n % 2 = 1`.\n\n**Step 2.** By `collatz_of_odd_is_even`, the iterate at step 1 is even: `(collatz^[1] n) % 2 = 0`. We unfold `collatzIter 1 n` via `Function.iterate_one`.\n\n**Step 3.** Case split on `1 < k` vs `1 ≥ k`:\n - If `k ≥ 2`: `hodd_all 1 hk2` says step-1 iterate is odd, contradicting step 2; `omega` closes it.\n - If `k = 1`: `interval_cases k` reduces; `hper` becomes `collatz^[1] n = n`, so n is even by step 2 but odd by step 1 — `omega` closes.",
-    "mathContext": "The case split `k = 1` vs `k ≥ 2` is forced by the fact that for k = 1, the assumption `hodd_all 1 _` is vacuous (no `i < 1` satisfies `i = 1`), so we can't reuse the same contradiction trick. Instead we use `hper : collatzIter k n = n` directly.",
+    "mathContext": "The case split $k = 1$ vs $k \\geq 2$ is forced by the fact that for $k = 1$, the assumption `hodd_all 1 _` is vacuous (no $i < 1$ satisfies $i = 1$), so we can't reuse the same contradiction trick. Instead we use `hper : collatzIter k n = n` directly: $n$ is the only iterate, so step-0 odd and step-1 even both refer to $n$.",
     "significance": "key",
     "relatedConcepts": [
       "by_contra",
       "interval_cases",
-      "iterated function parity"
+      "iterated function parity",
+      "Function.iterate_zero",
+      "Function.iterate_one"
     ],
     "prerequisites": [
       "collatz_of_odd_is_even",
@@ -70,18 +96,19 @@
     "id": "ann-collatz-oq03-cycle-contains-even",
     "proofId": "collatz-cycles-oq-03",
     "range": {
-      "startLine": 58,
-      "endLine": 68
+      "startLine": 64,
+      "endLine": 73
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Positive form: every cycle visits an even number",
-    "content": "Contrapositive of `no_all_odd_cycle`. Assume the conclusion fails: every iterate `i < k` has `(collatz^[i] n) % 2 ≠ 0`. By `omega`, parity ≠ 0 over ℕ % 2 forces parity = 1. Then `no_all_odd_cycle` applies, contradiction.",
-    "mathContext": "Whenever a structural-fact theorem has a `False`-form negation lemma, the user-facing form is typically the existential. The `by_contra + push_neg` idiom converts the existential statement into the universal negation, which matches the form of `no_all_odd_cycle`.",
+    "content": "Contrapositive of `no_all_odd_cycle`. Assume the conclusion fails: every iterate `i < k` has `(collatz^[i] n) % 2 ≠ 0`. By `omega`, parity ≠ 0 over `ℕ % 2` forces parity = 1. Then `no_all_odd_cycle` applies, contradiction. The `by_contra + push_neg` idiom converts the existential `∃ i, i < k ∧ (collatzIter i n) % 2 = 0` into the universal negation `∀ i, i < k → (collatzIter i n) % 2 ≠ 0`, which matches the form of `no_all_odd_cycle`'s `hodd_all`.",
+    "mathContext": "$\\exists i < k:\\ C^i(n) \\equiv 0 \\pmod 2$ — the user-facing form. Whenever a structural-fact theorem has a `False`-form negation lemma, the user-facing form is typically the existential, and `by_contra + push_neg` is the canonical idiom for moving between forms.",
     "significance": "key",
     "relatedConcepts": [
       "contrapositive",
       "by_contra",
-      "push_neg"
+      "push_neg",
+      "negation of existential"
     ],
     "prerequisites": [
       "no_all_odd_cycle"
@@ -91,17 +118,18 @@
     "id": "ann-collatz-oq03-isperiodic-contains-even",
     "proofId": "collatz-cycles-oq-03",
     "range": {
-      "startLine": 70,
-      "endLine": 74
+      "startLine": 76,
+      "endLine": 78
     },
-    "type": "theorem",
+    "type": "context",
     "title": "Repackaged with IsPeriodic",
-    "content": "The parent's `IsPeriodic n k := k ≥ 1 ∧ collatzIter k n = n` is the standard packaging. This theorem unpacks the conjunction and applies `cycle_contains_even`.",
-    "mathContext": "Provides API parity with the parent's `IsPeriodic`-using theorems (like `collatz_no_fixpoint` and `collatz_no_two_cycle`). Downstream callers can quote whichever form is more convenient.",
+    "content": "The parent's `IsPeriodic n k := k ≥ 1 ∧ collatzIter k n = n` is the standard packaging. This theorem unpacks the conjunction and applies `cycle_contains_even`. Provides API parity with the parent's `IsPeriodic`-using theorems (like `collatz_no_fixpoint` and `collatz_no_two_cycle`); downstream callers can quote whichever form is more convenient.",
+    "mathContext": "$\\mathrm{IsPeriodic}(n, k) = (k \\geq 1) \\wedge (C^k(n) = n)$, the conjunctive packaging used throughout the parent file. The corollary `isPeriodic_contains_even` is the same fact stated in this convention, with the proof being a one-liner: `cycle_contains_even hper.1 hper.2`.",
     "significance": "supporting",
     "relatedConcepts": [
       "IsPeriodic",
-      "API ergonomics"
+      "API ergonomics",
+      "conjunctive packaging"
     ],
     "prerequisites": [
       "cycle_contains_even",


### PR DESCRIPTION
Enrichment pass for `collatz-cycles-oq-03` (Collatz Cycles OQ-03: No All-Odd Cycle).

## What changed

The existing 5 annotations were well-structured but had two issues:

1. **Non-canonical type values**: \`lemma\` and \`theorem\` are not in the schema enum (\`concept|definition|technique|insight|context\`)
2. **Off-by-one startLines**: pointed at the docstring line rather than the \`lemma\`/\`theorem\` keyword, causing build-script warnings (\"No Lean construct found at line N\")

This PR fixes both, deepens \`mathContext\` on the parity-flip annotations with explicit modular-arithmetic LaTeX, and adds a 6th annotation for the file header (OQ statement + 5-theorem outline).

## Changes

| Annotation | Before | After |
|---|---|---|
| three_n_plus_one_even | type=lemma, line 26 | type=technique, line 28 |
| collatz_of_odd_is_even | type=theorem, line 30 | type=technique, line 32 |
| no_all_odd_cycle | type=theorem, line 36 | type=insight, line 41 |
| cycle_contains_even | type=theorem, line 58 | type=insight, line 64 |
| isPeriodic_contains_even | type=theorem, line 70 | type=context, line 76 |
| (new) header docstring | — | type=context, lines 1-20 |

Total: 5 → 6 annotations.

## Verification

Tested by copying the new annotations.json into main repo's tree and running \`npx tsx scripts/annotations/build.ts\` — all 6 annotations now resolve to Lean constructs with no warnings. Restored main repo state before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)