### PR TITLE
research(area-of-circle-oq-05-oq-04): S5 ACT — translation invariance + canonical (c,b)-density (build verified, stacked on #18221)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
@@ -1,14 +1,16 @@
 /-
-Area of Circle OQ-05-OQ-04 (S2a + S3): The Complex Gaussian Integral
+Area of Circle OQ-05-OQ-04 (S2a + S3 + S4a): The Complex Gaussian Integral
 
 Proves the complex Gaussian identities
 
     ∫_ℂ exp(-π · ‖z‖²) dz = 1               (S2a, b = π specialisation)
     ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b         (S3, parametric in b > 0)
+    ∫_{ℂⁿ} exp(-(b · ∑ ‖zᵢ‖²)) dz = (π/b)ⁿ  (S4a, n-dim parametric)
 
 and the natural corollaries `∫_ℂ exp(-‖z‖²) dz = π` (unit weight,
-"complex Gaussian = area of unit disc") and the probability density
-`∫_ℂ (1/π) · exp(-‖z‖²) dz = 1`.
+"complex Gaussian = area of unit disc"), the probability density
+`∫_ℂ (1/π) · exp(-‖z‖²) dz = 1`, and the multidimensional analogues
+`∫_{ℂⁿ} exp(-∑ ‖zᵢ‖²) = πⁿ` and `∫_{ℂⁿ} (1/π)ⁿ · exp(-∑‖zᵢ‖²) = 1`.
 
 The S2a results assert that the Gaussian density `e^{-π |z|²}` on ℂ
 integrates to 1 against the standard Lebesgue measure on ℂ (induced
@@ -77,6 +79,7 @@ Parent: `AreaOfCircleOQ05OQ02.lean` (multivariate Gaussian, all proved).
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
 import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Integral.Pi
 import Proofs.AreaOfCircleOQ05
 
 namespace ComplexGaussianCircle
@@ -288,6 +291,91 @@ theorem complex_gaussian_integral_normalised :
   rw [integral_const_mul, complex_gaussian_integral_unit_norm, one_div,
       inv_mul_cancel₀ Real.pi_ne_zero]
 
+/-! ## Part 3: The n-dimensional complex Gaussian (S4a)
+
+The parametric complex Gaussian generalises uniformly in dimension: for
+`n : ℕ` and `b > 0`,
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ ‖zᵢ‖²)) dz = (π / b)ⁿ.
+
+This is the complex-side counterpart of the parent file's diagonal real
+Gaussian (`AreaOfCircleOQ05OQ02.diagonal_gaussian`, with a uniform weight
+`b`): each ℂ-axis contributes a factor `π/b` (via
+`complex_gaussian_integral_scaled_norm`), and `n` axes compose by
+`integral_fintype_prod_volume_eq_pow`. The proof skeleton mirrors
+`diagonal_gaussian` (`← Finset.sum_neg_distrib` + `Real.exp_sum` +
+n-fold Fubini), differing only in that the per-axis factor is itself the
+2-real-dimensional `complex_gaussian_integral_scaled_norm` rather than
+the 1-real-dimensional `scaled_gaussian`. -/
+
+/-- **n-dimensional parametric complex Gaussian**: for `b > 0` and `n : ℕ`,
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ ‖zᵢ‖²)) dz = (π / b)ⁿ.
+
+The `n = 1` case is `complex_gaussian_integral_scaled_norm` after the
+trivial reindexing `Fin 1 → ℂ ≃ ℂ`. The `n = 2` case is the joint
+density used in the 2-mode coherent-state model in quantum optics
+(each mode contributes `π/b`).
+
+Proof: factor the exponential of a sum as a product (`Real.exp_sum`),
+apply n-fold Fubini (`integral_fintype_prod_volume_eq_pow`), and
+evaluate each ℂ-factor by `complex_gaussian_integral_scaled_norm`. -/
+theorem complex_gaussian_integral_scaled_pow {n : ℕ} (b : ℝ) (hb : 0 < b) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, ‖z i‖ ^ 2)) = (Real.pi / b) ^ n := by
+  -- Step 1: factor exp(-(b · ∑ᵢ ‖zᵢ‖²)) = ∏ᵢ exp(-(b · ‖zᵢ‖²)).
+  -- Distribute `b` into the sum, then push the negation inside, then
+  -- apply `Real.exp_sum`. This is the same pattern as the parent file's
+  -- `diagonal_gaussian` (real-axis n-fold Gaussian).
+  simp_rw [Finset.mul_sum, ← Finset.sum_neg_distrib, Real.exp_sum]
+  -- Step 2: n-fold Fubini over `Fin n → ℂ`. The integrand `∏ᵢ exp(-(b · ‖z i‖²))`
+  -- has the shape `∏ᵢ f (z i)` with `f := fun z : ℂ => exp(-(b · ‖z‖²))`,
+  -- so `integral_fintype_prod_volume_eq_pow` applies and gives
+  -- `(∫ z : ℂ, f z) ^ Fintype.card (Fin n)`.
+  rw [integral_fintype_prod_volume_eq_pow
+        (ι := Fin n) (fun z : ℂ => Real.exp (-(b * ‖z‖ ^ 2)))]
+  -- Step 3: evaluate the per-axis factor (`π/b`) and collapse `Fintype.card (Fin n) = n`.
+  rw [complex_gaussian_integral_scaled_norm b hb, Fintype.card_fin]
+
+/-- `normSq` form of the n-dimensional parametric complex Gaussian:
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ normSq (zᵢ))) dz = (π / b)ⁿ.
+
+This is the version that pairs directly with the `Complex.normSq` form
+of the `n = 1` theorem `complex_gaussian_integral_scaled`. Useful for
+consumers that prefer the algebraic `normSq` to the analytic `‖·‖²`. -/
+theorem complex_gaussian_integral_scaled_pow_normSq {n : ℕ} (b : ℝ) (hb : 0 < b) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, Complex.normSq (z i))) = (Real.pi / b) ^ n := by
+  -- Replace each `normSq (z i)` by `‖z i‖ ^ 2` inside the sum, then reduce to
+  -- the `‖·‖²` version. Using `simp_rw` (rather than `congr`) keeps the
+  -- additive-monoid structure on the sum's codomain fully determined.
+  simp_rw [Complex.normSq_eq_norm_sq]
+  exact complex_gaussian_integral_scaled_pow b hb
+
+/-- **n-dimensional unit-weight complex Gaussian**: ∫_{ℂⁿ} exp(-∑ᵢ ‖zᵢ‖²) dz = πⁿ.
+
+The unit-weight case `b = 1` of `complex_gaussian_integral_scaled_pow`.
+Generalises `complex_gaussian_integral_unit_norm` (the `n = 1` value `π`)
+to arbitrary dimension. -/
+theorem complex_gaussian_integral_pow_unit_norm {n : ℕ} :
+    ∫ z : Fin n → ℂ, Real.exp (-∑ i, ‖z i‖ ^ 2) = Real.pi ^ n := by
+  have h := complex_gaussian_integral_scaled_pow (n := n) 1 one_pos
+  -- `h : ∫ z, exp(-(1 * ∑ᵢ ‖zᵢ‖²)) = (π / 1) ^ n`.
+  simp only [one_mul, div_one] at h
+  exact h
+
+/-- **Normalised n-dimensional complex Gaussian density**: the
+    n-dimensional unit-weight Gaussian divided by `πⁿ` is a probability
+    density on `ℂⁿ`:
+
+    ∫_{ℂⁿ} (1/π)ⁿ · exp(-∑ᵢ ‖zᵢ‖²) dz = 1.
+
+This is the multidimensional analogue of
+`complex_gaussian_integral_normalised`. -/
+theorem complex_gaussian_integral_pow_normalised {n : ℕ} :
+    ∫ z : Fin n → ℂ, (1 / Real.pi) ^ n * Real.exp (-∑ i, ‖z i‖ ^ 2) = 1 := by
+  rw [integral_const_mul, complex_gaussian_integral_pow_unit_norm,
+      one_div, inv_pow, inv_mul_cancel₀ (pow_ne_zero n Real.pi_ne_zero)]
+
 /-! ## Status
 
 - `integral_pi_gaussian` : proved (direct from `scaled_gaussian`).
@@ -298,6 +386,10 @@ theorem complex_gaussian_integral_normalised :
 - `complex_gaussian_integral_scaled_norm` : proved (`‖z‖²` form).
 - `complex_gaussian_integral_unit_norm` : proved (`b = 1` corollary).
 - `complex_gaussian_integral_normalised` : proved (`1/π` density).
+- `complex_gaussian_integral_scaled_pow` : proved (n-dim parametric, S4a).
+- `complex_gaussian_integral_scaled_pow_normSq` : proved (`normSq` form).
+- `complex_gaussian_integral_pow_unit_norm` : proved (n-dim `b = 1`).
+- `complex_gaussian_integral_pow_normalised` : proved (`(1/π)ⁿ` density).
 
 All theorems above are sorry-free and axiom-free.
 

--- a/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
@@ -1,16 +1,19 @@
 /-
-Area of Circle OQ-05-OQ-04 (S2a + S3 + S4a): The Complex Gaussian Integral
+Area of Circle OQ-05-OQ-04 (S2a + S3 + S4a + S5): The Complex Gaussian Integral
 
 Proves the complex Gaussian identities
 
-    ∫_ℂ exp(-π · ‖z‖²) dz = 1               (S2a, b = π specialisation)
-    ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b         (S3, parametric in b > 0)
-    ∫_{ℂⁿ} exp(-(b · ∑ ‖zᵢ‖²)) dz = (π/b)ⁿ  (S4a, n-dim parametric)
+    ∫_ℂ exp(-π · ‖z‖²) dz = 1                       (S2a, b = π specialisation)
+    ∫_ℂ exp(-(b · ‖z‖²)) dz = π / b                 (S3, parametric in b > 0)
+    ∫_{ℂⁿ} exp(-(b · ∑ ‖zᵢ‖²)) dz = (π/b)ⁿ          (S4a, n-dim parametric)
+    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b             (S5, translation invariant)
 
 and the natural corollaries `∫_ℂ exp(-‖z‖²) dz = π` (unit weight,
 "complex Gaussian = area of unit disc"), the probability density
-`∫_ℂ (1/π) · exp(-‖z‖²) dz = 1`, and the multidimensional analogues
-`∫_{ℂⁿ} exp(-∑ ‖zᵢ‖²) = πⁿ` and `∫_{ℂⁿ} (1/π)ⁿ · exp(-∑‖zᵢ‖²) = 1`.
+`∫_ℂ (1/π) · exp(-‖z‖²) dz = 1`, the multidimensional analogues
+`∫_{ℂⁿ} exp(-∑ ‖zᵢ‖²) = πⁿ` and `∫_{ℂⁿ} (1/π)ⁿ · exp(-∑‖zᵢ‖²) = 1`, and
+the shifted probability density `∫_ℂ (b/π) · exp(-(b · ‖z - c‖²)) dz = 1`
+(canonical two-parameter complex Gaussian, mean `c`, scale `b`).
 
 The S2a results assert that the Gaussian density `e^{-π |z|²}` on ℂ
 integrates to 1 against the standard Lebesgue measure on ℂ (induced
@@ -376,6 +379,118 @@ theorem complex_gaussian_integral_pow_normalised {n : ℕ} :
   rw [integral_const_mul, complex_gaussian_integral_pow_unit_norm,
       one_div, inv_pow, inv_mul_cancel₀ (pow_ne_zero n Real.pi_ne_zero)]
 
+/-! ## Part 4: Translation invariance and the shifted Gaussian density (S5)
+
+The complex Lebesgue measure is an additive Haar measure, hence invariant
+under translation `z ↦ z + c`. Composing this with the parametric complex
+Gaussian (S3, `complex_gaussian_integral_scaled_norm`) yields the
+**shifted** complex Gaussian identity
+
+    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b              (for any `c : ℂ`, `b > 0`)
+
+and, after dividing by `π/b`, the canonical two-parameter probability
+density on `ℂ` with mean `c` and scale `b`,
+
+    ∫_ℂ (b/π) · exp(-(b · ‖z - c‖²)) dz = 1.
+
+This is the complex analogue of the real one-dimensional Gaussian density
+`(a/π)^{1/2} · exp(-(a · (x-μ)²))` familiar from probability theory; in
+information-theoretic terms (cf. `ShannonEntropyOQ01.lean`) it is the
+*translation-invariance* property used to show that the differential
+entropy of a complex Gaussian depends only on the scale `b`, not on the
+mean `c`.
+
+The proof reduces to `complex_gaussian_integral_scaled_norm` via
+`MeasureTheory.integral_add_right_eq_self`, applied to the volume
+measure on `ℂ` (which is `IsAddRightInvariant` as an additive Haar
+measure). The mechanism is identical to the real-line translation
+invariance used in `ShannonEntropyOQ01.differential_entropy_translation_invariant`
+and `FourierSeriesOQ02.lean`'s Fourier-coefficient shift lemma. -/
+
+/-- **Translation invariance of the parametric complex Gaussian**: for
+any shift `c : ℂ` and weight `b > 0`,
+
+    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b.
+
+The `c = 0` case is `complex_gaussian_integral_scaled_norm`. The proof
+applies translation invariance of the complex Lebesgue (= additive Haar)
+measure: writing `z - c = z + (-c)`, the substitution `w = z + (-c)`
+preserves the volume, so the integral coincides with the unshifted
+parametric complex Gaussian.
+
+Proof skeleton (matching the real-line pattern in
+`ShannonEntropyOQ01.differential_entropy_translation_invariant`):
+rewrite the integrand `exp(-(b · ‖z - c‖²))` as the value at `z + (-c)`
+of the function `w ↦ exp(-(b · ‖w‖²))`, then apply
+`MeasureTheory.integral_add_right_eq_self`. -/
+theorem complex_gaussian_integral_scaled_shifted_norm (b : ℝ) (hb : 0 < b) (c : ℂ) :
+    ∫ z : ℂ, Real.exp (-(b * ‖z - c‖ ^ 2)) = Real.pi / b := by
+  -- Step 1: rewrite the integrand into the shape `(fun w ↦ exp(-(b · ‖w‖²))) (z + (-c))`
+  -- using `sub_eq_add_neg`. The β-reduction `(fun w ↦ f w) (z + (-c)) = f (z + (-c))`
+  -- is definitional, so the per-point equality is just a `rw [sub_eq_add_neg]`
+  -- after exposing the pre-β form via a `show`. This matches the idiom used in
+  -- `ShannonEntropyOQ01.gaussian_variance` for the same translation-invariance step.
+  have key : ∀ z : ℂ,
+      (fun w : ℂ => Real.exp (-(b * ‖w‖ ^ 2))) (z + (-c)) =
+        Real.exp (-(b * ‖z - c‖ ^ 2)) := by
+    intro z
+    show Real.exp (-(b * ‖z + (-c)‖ ^ 2)) = Real.exp (-(b * ‖z - c‖ ^ 2))
+    rw [← sub_eq_add_neg]
+  rw [show (fun z : ℂ => Real.exp (-(b * ‖z - c‖ ^ 2))) =
+          (fun z : ℂ => (fun w : ℂ => Real.exp (-(b * ‖w‖ ^ 2))) (z + (-c))) from
+        funext (fun z => (key z).symm)]
+  -- Step 2: chain translation invariance of `volume : Measure ℂ` (an
+  -- `IsAddHaarMeasure`, hence `IsAddRightInvariant`) with the unshifted
+  -- parametric complex Gaussian.
+  exact (integral_add_right_eq_self (fun w : ℂ => Real.exp (-(b * ‖w‖ ^ 2))) (-c)).trans
+    (complex_gaussian_integral_scaled_norm b hb)
+
+/-- **Translation invariance of the parametric complex Gaussian (`normSq` form)**:
+for any shift `c : ℂ` and `b > 0`,
+
+    ∫_ℂ exp(-(b · normSq (z - c))) dz = π / b.
+
+This is the algebraic `Complex.normSq` companion of
+`complex_gaussian_integral_scaled_shifted_norm`. -/
+theorem complex_gaussian_integral_scaled_shifted (b : ℝ) (hb : 0 < b) (c : ℂ) :
+    ∫ z : ℂ, Real.exp (-(b * Complex.normSq (z - c))) = Real.pi / b := by
+  simp_rw [Complex.normSq_eq_norm_sq]
+  exact complex_gaussian_integral_scaled_shifted_norm b hb c
+
+/-- **Unit-weight shifted complex Gaussian**: for any shift `c : ℂ`,
+
+    ∫_ℂ exp(-‖z - c‖²) dz = π.
+
+The shifted form of `complex_gaussian_integral_unit_norm`, capturing the
+fact that the total mass of `exp(-‖z - c‖²)` is exactly the area of the
+unit disc, independent of where the Gaussian is centred. -/
+theorem complex_gaussian_integral_unit_shifted_norm (c : ℂ) :
+    ∫ z : ℂ, Real.exp (-‖z - c‖ ^ 2) = Real.pi := by
+  have h := complex_gaussian_integral_scaled_shifted_norm 1 one_pos c
+  -- `h : ∫ z, exp(-(1 * ‖z - c‖²)) = π / 1`. Normalise `1 * x = x` and `π / 1 = π`.
+  simp only [one_mul, div_one] at h
+  exact h
+
+/-- **Shifted complex Gaussian probability density** (mean `c`, scale `b`):
+for any `c : ℂ` and `b > 0`,
+
+    ∫_ℂ (b / π) · exp(-(b · ‖z - c‖²)) dz = 1.
+
+This is the canonical two-parameter complex Gaussian density on `ℂ`. The
+`c = 0` case is `complex_gaussian_integral_scaled` after multiplying by
+`b/π`; the `b = 1` case specialises to
+`(1/π) · exp(-‖z - c‖²)`, the shifted analogue of
+`complex_gaussian_integral_normalised`.
+
+Proof: pull the constant `b/π` outside the integral
+(`integral_const_mul`), apply the shifted parametric integral
+(`complex_gaussian_integral_scaled_shifted_norm`), then simplify
+`(b/π) · (π/b) = 1` via `field_simp`. -/
+theorem complex_gaussian_density_shifted (b : ℝ) (hb : 0 < b) (c : ℂ) :
+    ∫ z : ℂ, (b / Real.pi) * Real.exp (-(b * ‖z - c‖ ^ 2)) = 1 := by
+  rw [integral_const_mul, complex_gaussian_integral_scaled_shifted_norm b hb c]
+  field_simp
+
 /-! ## Status
 
 - `integral_pi_gaussian` : proved (direct from `scaled_gaussian`).
@@ -390,6 +505,10 @@ theorem complex_gaussian_integral_pow_normalised {n : ℕ} :
 - `complex_gaussian_integral_scaled_pow_normSq` : proved (`normSq` form).
 - `complex_gaussian_integral_pow_unit_norm` : proved (n-dim `b = 1`).
 - `complex_gaussian_integral_pow_normalised` : proved (`(1/π)ⁿ` density).
+- `complex_gaussian_integral_scaled_shifted_norm` : proved (translation-invariant, S5).
+- `complex_gaussian_integral_scaled_shifted` : proved (`normSq` form of shifted).
+- `complex_gaussian_integral_unit_shifted_norm` : proved (unit-weight shifted).
+- `complex_gaussian_density_shifted` : proved (canonical `(c, b)` density).
 
 All theorems above are sorry-free and axiom-free.
 

--- a/research/area-of-circle-oq-05-oq-04/knowledge.md
+++ b/research/area-of-circle-oq-05-oq-04/knowledge.md
@@ -168,3 +168,55 @@ Status of the four candidates:
   satisfies, but Lean needs explicit `(μ := volume)` `(ν := volume)`
   annotations to pick up the right product measure when both factors
   are `volume : Measure ℝ`.
+
+## S4a Mathlib API confirmed (verified 2026-05-12 against v4.26.0)
+
+### n-fold Fubini
+
+* `MeasureTheory.integral_fintype_prod_volume_eq_prod {ι : Type*} [Fintype ι]
+  {E : ι → Type*} (f : (i : ι) → E i → 𝕜)
+  [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
+  ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x` — n-fold Fubini.
+  Source: `Mathlib/MeasureTheory/Integral/Pi.lean:114`.
+* `MeasureTheory.integral_fintype_prod_volume_eq_pow {ι : Type*} [Fintype ι]
+  {E : Type*} (f : E → 𝕜) [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
+  ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (Fintype.card ι)` — uniform
+  n-fold Fubini (all factors share `f`). Source: same file, line 123.
+  Used by S4a in `complex_gaussian_integral_scaled_pow`.
+
+### Sum/product algebra
+
+* `Real.exp_sum (s : Finset α) (f : α → ℝ) : Real.exp (∑ x ∈ s, f x) =
+  ∏ x ∈ s, Real.exp (f x)`. Source:
+  `Mathlib/Analysis/Complex/Exponential.lean:222`. (Also `Complex.exp_sum`
+  at line 141 of the same file.)
+* `Finset.mul_sum : b * ∑ i ∈ s, f i = ∑ i ∈ s, b * f i` — distributes
+  a scalar into a sum.
+* `Finset.sum_neg_distrib : ∑ i ∈ s, -f i = -∑ i ∈ s, f i` — applied
+  backward (`← Finset.sum_neg_distrib`) to push `-` inside `∑`. Same
+  combo used in parent `AreaOfCircleOQ05OQ02.diagonal_gaussian`.
+
+### Cardinality
+
+* `Fintype.card_fin (n : ℕ) : Fintype.card (Fin n) = n`. Source:
+  `Mathlib/Data/Fintype/Card.lean:485`.
+
+### Lessons (S4a)
+
+* The S4a skeleton is identical to the parent file's real-axis
+  `diagonal_gaussian` (`AreaOfCircleOQ05OQ02.lean`), differing only in
+  that the per-axis factor is `complex_gaussian_integral_scaled_norm`
+  (2-real-dim) rather than `scaled_gaussian` (1-real-dim).
+* `integral_fintype_prod_volume_eq_pow` is preferable to
+  `integral_fintype_prod_volume_eq_prod` when all factors are the same:
+  it sidesteps the per-index `Finset.prod_congr` reduction and gives the
+  final `(π/b)^n` form directly via `Fintype.card_fin`.
+* The reduction `exp(-(b · ∑ ‖zᵢ‖²)) = ∏ᵢ exp(-(b · ‖zᵢ‖²))` is a
+  three-step rewrite chain that doesn't need any custom lemma:
+  `Finset.mul_sum` distributes `b`, `← Finset.sum_neg_distrib` pushes
+  the negation inside, and `Real.exp_sum` converts the resulting
+  `exp (∑ ...)` to `∏ exp (...)`.
+* No measure-preserving change of variables is needed at the
+  n-dimensional level: the `Fin n → ℂ` integrand factors before any
+  transport, so we never need to interact with `Complex.measurableEquivRealProd`
+  beyond what was already done in S2a / S3 for the per-axis factor.

--- a/research/area-of-circle-oq-05-oq-04/knowledge.md
+++ b/research/area-of-circle-oq-05-oq-04/knowledge.md
@@ -220,3 +220,65 @@ Status of the four candidates:
   n-dimensional level: the `Fin n → ℂ` integrand factors before any
   transport, so we never need to interact with `Complex.measurableEquivRealProd`
   beyond what was already done in S2a / S3 for the per-axis factor.
+
+## S5 Mathlib API confirmed (verified 2026-05-12 against v4.26.0)
+
+### Translation invariance
+
+* `MeasureTheory.integral_add_right_eq_self {G : Type*} {E : Type*}
+  [MeasurableSpace G] [Group G] [TopologicalSpace G] [TopologicalGroup G]
+  [BorelSpace G] [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {μ : Measure G} [IsAddRightInvariant μ] (f : G → E) (g : G) :
+  ∫ x, f (x + g) ∂μ = ∫ x, f x ∂μ`
+  — translation invariance of integrals against a right-invariant measure.
+  Source: `Mathlib/MeasureTheory/Group/Integral.lean`.
+* `volume : Measure ℂ` carries `IsAddHaarMeasure` (via the `MeasureSpace`
+  instance through `Complex.measurableEquivRealProd` plus inherited Haar
+  property of `ℝ × ℝ`), hence both `IsAddLeftInvariant` and
+  `IsAddRightInvariant` (abelian group).
+
+### Pitfall: HOU through `fun w => f w`
+
+* `rw [integral_add_right_eq_self]` fails when the integrand has the
+  shape `(fun w => exp(-(b · ‖w‖²))) (z + (-c))`: the rewrite engine
+  can't pattern-match `∫ x, ?f (x + ?g) ∂?μ` against an integrand whose
+  outer function is a lambda. Symptom (v4.26.0):
+  > `Tactic 'rewrite' failed: Did not find an occurrence of the pattern`
+  > `∫ (x : ?m), ?f (x + ?g) ∂?m in the target expression`
+  > `∫ (z : ℂ), (fun w => rexp (-(b * ‖w‖^2))) (z + -c) = π / b`
+* **Fix**: don't rewrite — instead chain via `.trans` with explicit `f`:
+  ```lean
+  exact (integral_add_right_eq_self (fun w : ℂ => Real.exp (-(b * ‖w‖^2))) (-c)).trans
+        (complex_gaussian_integral_scaled_norm b hb)
+  ```
+  Lean accepts the result via β-defeq.
+
+### `sub_eq_add_neg` rewrite under integrals
+
+* To convert `f (z - c)` to `f (z + (-c))` inside an integral, the
+  cleanest pattern (matching `ShannonEntropyOQ01.gaussian_variance`):
+  ```lean
+  have key : ∀ z, (fun w => f w) (z + (-c)) = f (z - c) := by
+    intro z; show f (z + (-c)) = f (z - c); rw [← sub_eq_add_neg]
+  rw [show (fun z => f (z - c)) = (fun z => (fun w => f w) (z + (-c))) from
+        funext (fun z => (key z).symm)]
+  ```
+  The `show` step is essential: it tells Lean to β-reduce the lambda
+  application so the subsequent `rw [← sub_eq_add_neg]` finds its
+  pattern.
+
+### Lessons (S5)
+
+* Translation invariance is the simplest non-trivial extension of the S3
+  parametric Gaussian: it costs no new Mathlib imports (the
+  `Measure.Group.Integral` machinery is transitively pulled in by the
+  Gaussian integral module) and replicates the real-line idiom that
+  already appears in `ShannonEntropyOQ01.lean` and `FourierSeriesOQ02.lean`.
+* The two-parameter `(c, b)` complex Gaussian density emerges as a
+  one-line corollary (`integral_const_mul` + the shifted parametric
+  integral + `field_simp`). This is the natural "Gaussian density with
+  mean and scale" object that the OQ p-adic source aspired to.
+* The `c = 0` and `b = 1` specialisations reduce to S3 and S2a
+  respectively, so the S5 additions strictly subsume the unshifted
+  unit-weight cases — useful for downstream consumers that prefer the
+  general statement.

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -1,46 +1,61 @@
 # Current State
 
 **Phase**: RESEARCH
-**Since**: 2026-05-12T17:00:00Z
-**Iteration**: 4
+**Since**: 2026-05-12T19:30:00Z
+**Iteration**: 5
 
 ## Current Focus
 
-S4a ACT complete: n-dimensional parametric complex Gaussian
-`∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ` proved for arbitrary `n : ℕ` and
-`b > 0`. Same Fubini-style skeleton as `AreaOfCircleOQ05OQ02.diagonal_gaussian`
-(real-axis n-fold), with each ℂ-factor contributing `π/b` via
-`complex_gaussian_integral_scaled_norm` (S3) instead of the real
-`scaled_gaussian`.
+S5 ACT complete: **translation invariance** of the parametric complex
+Gaussian. For any shift `c : ℂ` and `b > 0`,
 
-## Built (Lean)
+    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b.
 
-In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S4a additions on top of
-S3, total file 429 lines):
+Proof: translate the integrand by `−c`, invoke
+`MeasureTheory.integral_add_right_eq_self` (the volume on `ℂ` is an
+`IsAddHaarMeasure`, hence `IsAddRightInvariant`), and chain with the
+unshifted parametric Gaussian (`complex_gaussian_integral_scaled_norm`
+from S3). The mechanism is identical to the real-line idiom in
+`ShannonEntropyOQ01.gaussian_variance` and `FourierSeriesOQ02.lean`'s
+Fourier-shift lemma.
 
-- `complex_gaussian_integral_scaled_pow {n : ℕ} (b > 0) :
-    ∫ z : Fin n → ℂ, exp(-(b · ∑ ‖zᵢ‖²)) = (π/b)ⁿ`
-  — n-fold Fubini via `integral_fintype_prod_volume_eq_pow`.
-- `complex_gaussian_integral_scaled_pow_normSq {n : ℕ} (b > 0) :
-    ∫ z : Fin n → ℂ, exp(-(b · ∑ normSq (zᵢ))) = (π/b)ⁿ`
-  — `Complex.normSq` form, via `normSq_eq_norm_sq`.
-- `complex_gaussian_integral_pow_unit_norm {n : ℕ} :
-    ∫ z : Fin n → ℂ, exp(-∑ ‖zᵢ‖²) = πⁿ`
+This unlocks the canonical **two-parameter** complex Gaussian density
+(mean `c`, scale `b`):
+
+    ∫_ℂ (b/π) · exp(-(b · ‖z - c‖²)) dz = 1.
+
+## Built (Lean, S5 on top of S4a)
+
+In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S5 additions, total file
+~543 lines):
+
+- `complex_gaussian_integral_scaled_shifted_norm (b > 0) (c : ℂ) :
+    ∫ z : ℂ, exp(-(b · ‖z - c‖²)) = π / b`
+  — main translation-invariance theorem.
+- `complex_gaussian_integral_scaled_shifted (b > 0) (c : ℂ) :
+    ∫ z : ℂ, exp(-(b · normSq (z - c))) = π / b`
+  — `Complex.normSq` form.
+- `complex_gaussian_integral_unit_shifted_norm (c : ℂ) :
+    ∫ z : ℂ, exp(-‖z - c‖²) = π`
   — `b = 1` corollary.
-- `complex_gaussian_integral_pow_normalised {n : ℕ} :
-    ∫ z : Fin n → ℂ, (1/π)ⁿ · exp(-∑‖zᵢ‖²) = 1`
-  — normalised joint density (multi-mode coherent-state weight).
+- `complex_gaussian_density_shifted (b > 0) (c : ℂ) :
+    ∫ z : ℂ, (b/π) · exp(-(b · ‖z - c‖²)) = 1`
+  — canonical two-parameter complex Gaussian probability density.
 
-Added import: `Mathlib.MeasureTheory.Integral.Pi`.
+No new imports. The proof uses only existing dependencies
+(`Mathlib.MeasureTheory.Group.Integral` is transitively pulled in by
+`Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral`).
 
-All proofs are sorry-free, axiom-free. The `n = 1` case reduces to S3
-(the per-axis factor `π/b` is exactly `complex_gaussian_integral_scaled_norm`).
+All proofs are sorry-free, axiom-free. The `c = 0` case of each S5
+theorem reduces to the corresponding S3 result; the new content is the
+shift-by-`c` direction.
 
 ## Status
 
 - Sorries: 0
 - Axioms: 0
-- Build: pending Docker verification at commit time.
+- Build: verified locally via `./proofs/scripts/docker-build.sh
+  Proofs.AreaOfCircleOQ05OQ04` (2026-05-12 ~20:30 UTC).
 
 ## Decomposition Plan
 
@@ -49,40 +64,46 @@ All proofs are sorry-free, axiom-free. The `n = 1` case reduces to S3
 | S1 | OBSERVE | Markdown set + three-statement repair | 0 Lean | merged |
 | S2a | ACT-A | `complex_gaussian_integral` (b = π) | ~120 | merged |
 | S3 | ACT-B | Parametric in `b > 0` + 3 corollaries | ~120 | merged |
-| S4a | ACT | n-dim `∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ` + 3 corollaries | ~96 | **this session** |
-| S5 | ? | Either: complex Gaussian Fourier-eigenfunction; or stepwise approach to p-adic | TBD | deferred |
+| S4a | ACT | n-dim `∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ` + 3 corollaries | ~96 | open (#18221) |
+| S4b | OBSERVE | p-adic Mathlib gap survey (doc-only) | 0 Lean | open (#18269) |
+| S5 | ACT | Translation invariance + `(c, b)`-density | ~110 | **this session** |
+| S6 | ? | Either: complex Fourier-eigenfunction; or n-dim shifted; or p-adic Haar wrapper | TBD | deferred |
 
 ## Next Action
 
-Two viable S5 deliverables (priority unclear, both significant):
+S5 unlocks three natural follow-on deliverables:
 
-- **S5a (complex Fourier-eigenfunction)**: prove that the complex Gaussian
-  `f(z) = exp(-π‖z‖²)` is a fixed point of the 2-D real Fourier
-  transform (via the ℂ ≃ ℝ² identification). This is the canonical
-  archimedean statement of which (C2) is the p-adic analogue and would
-  motivate the parallel between the two cases mathematically. Mathlib
-  status: `MeasureTheory.fourierIntegral_gaussian_pi` exists for the
-  real Gaussian — the complex case is one transport + Fubini reduction.
-- **S5b (p-adic Haar wrapper)**: contribute the first of the two
-  Mathlib milestones — an explicit `MeasureTheory.Measure ℚ_p` instance
-  normalised so `μ(ℤ_p) = 1`. Plausible single-PR Mathlib contribution.
-  Builds toward (C2) but does not yet prove it.
-
-The S4a n-dim result also enables a fourth direction:
-
-- **S5c (Schur orthogonality)**: with the n-dim normalised density
-  `(1/π)ⁿ · exp(-∑‖zᵢ‖²)` proved as a probability density, the
-  complex orthogonality `∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ`
-  follows by parametric differentiation. This is a natural next
-  expansion of the complex-Gaussian theme.
+- **S6a (n-dim translation invariance)**: lift the 1-D shifted Gaussian to
+  `Fin n → ℂ`, giving `∫_{ℂⁿ} exp(-(b·∑‖zᵢ - cᵢ‖²)) = (π/b)ⁿ` for any
+  shift vector `c : Fin n → ℂ`. Direct combination of S4a and S5 idioms;
+  needs `IsAddHaarMeasure` on the product measure (Mathlib supplies this
+  via `MeasureTheory.Measure.pi.instIsAddHaarMeasure`).
+- **S6b (complex Fourier-eigenfunction)**: still the canonical archimedean
+  analogue of (C2). Mathlib has `Real.fourierIntegral_gaussian_pi`; the
+  complex case is one ℂ ≃ ℝ × ℝ transport + Fubini reduction. Cleanest
+  if S6a is in place (lifts to the n-dim Fourier-eigenfunction
+  automatically).
+- **S6c (Schur orthogonality)**: `∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ`
+  via parametric differentiation of the S4a normalised density. Requires
+  `hasDerivAt_integral_of_dominated_loc` machinery (heavier).
+- **S6d (Mathlib milestone — `Measure ℚ_p`)**: the explicit
+  `MeasureTheory.Measure ℚ_p` instance with `μ(ℤ_p) = 1` from the S4b
+  survey. Multi-week upstream PR; independent of S6a-c.
 
 ## Attempt Counts
 
-- Total attempts: 4 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B, S4a ACT)
-- Current approach attempts: 1 (S4a ACT, fintype-prod Fubini)
+- Total attempts: 5 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B, S4a ACT,
+  S5 ACT). S4b is a concurrent doc-only OBSERVE pass by a parallel
+  agent; orthogonal to the S5 Lean work.
+- Current approach attempts: 1 (S5 ACT, `integral_add_right_eq_self`)
 - Approaches tried:
   - S1: OBSERVE — three-candidate repair scaffolding.
   - S2a: ACT-A — `b = π` complex Gaussian via Fubini + measurable equivalence.
   - S3: ACT-B — parametric Fubini, identical skeleton, generalised in `b`.
   - S4a: ACT — `exp(-∑) = ∏ exp` reduction + n-fold Fubini
     (`integral_fintype_prod_volume_eq_pow`), per-axis factor by S3.
+  - S5: ACT — `integral_add_right_eq_self` + `complex_gaussian_integral_scaled_norm`,
+    shifting `z - c → z + (-c)` to match the additive-translation form.
+    First proof attempt failed at `rw [integral_add_right_eq_self]` (HOU
+    can't pattern-match `?f (x + ?g)` through a lambda); fixed by
+    chaining via `.trans` with the explicit `f := fun w => exp(-(b·‖w‖²))`.

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -1,37 +1,40 @@
 # Current State
 
 **Phase**: RESEARCH
-**Since**: 2026-05-12T11:00:00Z
-**Iteration**: 3
+**Since**: 2026-05-12T17:00:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-S3 ACT-B complete: generalised the complex Gaussian integral to arbitrary
-positive weight `b > 0`.
+S4a ACT complete: n-dimensional parametric complex Gaussian
+`∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ` proved for arbitrary `n : ℕ` and
+`b > 0`. Same Fubini-style skeleton as `AreaOfCircleOQ05OQ02.diagonal_gaussian`
+(real-axis n-fold), with each ℂ-factor contributing `π/b` via
+`complex_gaussian_integral_scaled_norm` (S3) instead of the real
+`scaled_gaussian`.
 
 ## Built (Lean)
 
-In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S3 additions on top of S2a):
+In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S4a additions on top of
+S3, total file 429 lines):
 
-- `integral_b_gaussian (b > 0) : ∫ x : ℝ, exp(-(b·x²)) = √(π/b)`
-  — re-export of `GaussianIntegralCircle.scaled_gaussian` in the
-  `ComplexGaussianCircle` namespace.
-- `complex_gaussian_integral_scaled (b > 0) :
-    ∫ z : ℂ, exp(-(b·normSq z)) = π/b`
-  — parametric Fubini + `Real.mul_self_sqrt`.
-- `complex_gaussian_integral_scaled_norm (b > 0) :
-    ∫ z : ℂ, exp(-(b·‖z‖²)) = π/b`
-  — `‖z‖²` variant.
-- `complex_gaussian_integral_unit_norm :
-    ∫ z : ℂ, exp(-‖z‖²) = π`
-  — `b = 1` corollary; the "Gaussian area = circle area" statement.
-- `complex_gaussian_integral_normalised :
-    ∫ z : ℂ, (1/π) · exp(-‖z‖²) = 1`
-  — the complex analogue of the parent file's
-  `standard_normal_normalization`.
+- `complex_gaussian_integral_scaled_pow {n : ℕ} (b > 0) :
+    ∫ z : Fin n → ℂ, exp(-(b · ∑ ‖zᵢ‖²)) = (π/b)ⁿ`
+  — n-fold Fubini via `integral_fintype_prod_volume_eq_pow`.
+- `complex_gaussian_integral_scaled_pow_normSq {n : ℕ} (b > 0) :
+    ∫ z : Fin n → ℂ, exp(-(b · ∑ normSq (zᵢ))) = (π/b)ⁿ`
+  — `Complex.normSq` form, via `normSq_eq_norm_sq`.
+- `complex_gaussian_integral_pow_unit_norm {n : ℕ} :
+    ∫ z : Fin n → ℂ, exp(-∑ ‖zᵢ‖²) = πⁿ`
+  — `b = 1` corollary.
+- `complex_gaussian_integral_pow_normalised {n : ℕ} :
+    ∫ z : Fin n → ℂ, (1/π)ⁿ · exp(-∑‖zᵢ‖²) = 1`
+  — normalised joint density (multi-mode coherent-state weight).
 
-All proofs are sorry-free, axiom-free. Same Fubini-style skeleton as S2a;
-parameterised in `b` via `scaled_gaussian` rather than `integral_pi_gaussian`.
+Added import: `Mathlib.MeasureTheory.Integral.Pi`.
+
+All proofs are sorry-free, axiom-free. The `n = 1` case reduces to S3
+(the per-axis factor `π/b` is exactly `complex_gaussian_integral_scaled_norm`).
 
 ## Status
 
@@ -39,20 +42,47 @@ parameterised in `b` via `scaled_gaussian` rather than `integral_pi_gaussian`.
 - Axioms: 0
 - Build: pending Docker verification at commit time.
 
+## Decomposition Plan
+
+| Session | Phase | Deliverable | Lines | Status |
+|---|---|---|---|---|
+| S1 | OBSERVE | Markdown set + three-statement repair | 0 Lean | merged |
+| S2a | ACT-A | `complex_gaussian_integral` (b = π) | ~120 | merged |
+| S3 | ACT-B | Parametric in `b > 0` + 3 corollaries | ~120 | merged |
+| S4a | ACT | n-dim `∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ` + 3 corollaries | ~96 | **this session** |
+| S5 | ? | Either: complex Gaussian Fourier-eigenfunction; or stepwise approach to p-adic | TBD | deferred |
+
 ## Next Action
 
-Two viable S4 deliverables:
+Two viable S5 deliverables (priority unclear, both significant):
 
-- **S4a (recommended)**: `n`-dimensional complex Gaussian
-  `∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ`. Either induct via
-  `integral_fintype_prod_volume_eq_prod`, or transport
-  `ℂⁿ ≃ ℝ^{2n}` and call `MultivariateGaussian.diagonal_gaussian`.
-- **S4b**: p-adic scaffold for (C2). Blocks on two Mathlib milestones
-  (standard `ψ_p : ℚ_p → ℂ`, explicit Haar on `ℚ_p`); requires axioms
-  for both.
+- **S5a (complex Fourier-eigenfunction)**: prove that the complex Gaussian
+  `f(z) = exp(-π‖z‖²)` is a fixed point of the 2-D real Fourier
+  transform (via the ℂ ≃ ℝ² identification). This is the canonical
+  archimedean statement of which (C2) is the p-adic analogue and would
+  motivate the parallel between the two cases mathematically. Mathlib
+  status: `MeasureTheory.fourierIntegral_gaussian_pi` exists for the
+  real Gaussian — the complex case is one transport + Fubini reduction.
+- **S5b (p-adic Haar wrapper)**: contribute the first of the two
+  Mathlib milestones — an explicit `MeasureTheory.Measure ℚ_p` instance
+  normalised so `μ(ℤ_p) = 1`. Plausible single-PR Mathlib contribution.
+  Builds toward (C2) but does not yet prove it.
+
+The S4a n-dim result also enables a fourth direction:
+
+- **S5c (Schur orthogonality)**: with the n-dim normalised density
+  `(1/π)ⁿ · exp(-∑‖zᵢ‖²)` proved as a probability density, the
+  complex orthogonality `∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ`
+  follows by parametric differentiation. This is a natural next
+  expansion of the complex-Gaussian theme.
 
 ## Attempt Counts
 
-- Total attempts: 3 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B)
-- Current approach attempts: 1 (S3 ACT-B)
-- Approaches tried: 1 (parametric Fubini, succeeded immediately)
+- Total attempts: 4 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B, S4a ACT)
+- Current approach attempts: 1 (S4a ACT, fintype-prod Fubini)
+- Approaches tried:
+  - S1: OBSERVE — three-candidate repair scaffolding.
+  - S2a: ACT-A — `b = π` complex Gaussian via Fubini + measurable equivalence.
+  - S3: ACT-B — parametric Fubini, identical skeleton, generalised in `b`.
+  - S4a: ACT — `exp(-∑) = ∏ exp` reduction + n-fold Fubini
+    (`integral_fintype_prod_volume_eq_pow`), per-axis factor by S3.

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -30,11 +30,11 @@
   },
   "currentState": {
     "phase": "RESEARCH",
-    "since": "2026-05-12T10:58:14+00:00",
-    "iteration": 3,
-    "focus": "S3 ACT-B: generalised the complex Gaussian to arbitrary positive weight b. Added complex_gaussian_integral_scaled (∫_ℂ exp(-b·normSq z) = π/b) and ‖z‖² variant + unit-weight (∫_ℂ exp(-‖z‖²) = π) + normalised density (∫_ℂ (1/π)·exp(-‖z‖²) = 1). Same Fubini-style proof as S2a, parameterised in b. 0 sorries, 0 axioms.",
+    "since": "2026-05-12T17:00:00+00:00",
+    "iteration": 4,
+    "focus": "S4a ACT: n-dimensional parametric complex Gaussian ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ proved for arbitrary n : ℕ and b > 0. Same Fubini skeleton as AreaOfCircleOQ05OQ02.diagonal_gaussian (real n-fold), with each ℂ-axis contributing π/b via complex_gaussian_integral_scaled_norm (S3). Adds 4 theorems: complex_gaussian_integral_scaled_pow (main), complex_gaussian_integral_scaled_pow_normSq (normSq form), complex_gaussian_integral_pow_unit_norm (b=1 corollary), complex_gaussian_integral_pow_normalised ((1/π)ⁿ density). 0 sorries, 0 axioms.",
     "blockers": [],
-    "nextAction": "S4: either (a) prove the n-dimensional complex Gaussian ∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ via induction or by composing the n-real Multivariate Gaussian (AreaOfCircleOQ05OQ02) with the complex transport; OR (b) S2b p-adic scaffold with axiom padicAddChar + Haar stub. Recommendation: (a) keeps the file axiom-free and pushes the complex-side coverage further; (b) is the deeper open content but requires axioms.",
+    "nextAction": "S5: three viable directions. (S5a) Prove the complex Gaussian f(z) = exp(-π‖z‖²) is a Fourier-eigenfunction of the 2-D real Fourier transform; canonical archimedean statement of (C2). (S5b) Contribute Mathlib milestone — explicit MeasureTheory.Measure ℚ_p with μ(ℤ_p) = 1 (plausible single Mathlib PR). (S5c) Complex orthogonality ∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ via parametric differentiation, building on the S4a n-dim normalised density.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE + S2a ACT-A (b=π) + S3 ACT-B (parametric b>0) complete with build verified. AreaOfCircleOQ05OQ04.lean now has 8 theorems + 2 private helpers, all sorry-free and axiom-free. Complete complex-side coverage: π-weight, parametric b, unit weight, normalised density. p-adic case (C2) remains deferred pending two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar on ℚ_p).",
+    "progressSummary": "S1 OBSERVE + S2a ACT-A (b=π) + S3 ACT-B (parametric b>0) + S4a ACT (n-dim parametric) complete with build verified. AreaOfCircleOQ05OQ04.lean now 429 lines, 12 theorems + 2 private helpers, all sorry-free and axiom-free. Complete complex-side coverage: π-weight, parametric b, unit weight, normalised density, n-dim parametric, n-dim unit-weight, n-dim normalised. p-adic case (C2) remains deferred pending two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar on ℚ_p).",
     "builtItems": [
       {
         "item": "S1 OBSERVE markdown set (problem.md, knowledge.md, state.md)",
@@ -63,6 +63,10 @@
       {
         "item": "Proofs/AreaOfCircleOQ05OQ04.lean: integral_b_gaussian (b-scaled scalar re-export), complex_gaussian_integral_scaled (∫_ℂ exp(-(b·normSq z)) = π/b), complex_gaussian_integral_scaled_norm (‖z‖² form), complex_gaussian_integral_unit_norm (b=1, value π), complex_gaussian_integral_normalised (1/π density integrates to 1) — proven via parametric Fubini + Real.mul_self_sqrt",
         "session": "S3"
+      },
+      {
+        "item": "Proofs/AreaOfCircleOQ05OQ04.lean: complex_gaussian_integral_scaled_pow (n-dim ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ), complex_gaussian_integral_scaled_pow_normSq (normSq form), complex_gaussian_integral_pow_unit_norm (b=1 corollary, value πⁿ), complex_gaussian_integral_pow_normalised ((1/π)ⁿ joint density) — proven via Real.exp_sum reduction + integral_fintype_prod_volume_eq_pow + complex_gaussian_integral_scaled_norm per axis",
+        "session": "S4a"
       }
     ],
     "insights": [
@@ -74,7 +78,10 @@
       "The scalar π-weighted Gaussian ∫ exp(-π · x²) dx = √(π/π) = 1 specialises scaled_gaussian at a = π; this gives a clean unit factor on each axis of the complex factorisation.",
       "The proof of the complex Gaussian = 1 needs zero new analysis - it is purely a transport + Fubini composition on top of existing real Gaussian / measure-preserving machinery already in Mathlib.",
       "The complex Gaussian generalises uniformly in b > 0 because Fubini-and-transport composes with scaled_gaussian, which is itself uniform in a. Each real factor contributes √(π/b); two factors compose to π/b via Real.mul_self_sqrt.",
-      "The unit-weight complex Gaussian ∫_ℂ exp(-‖z‖²) = π is the 'circle area' identity: the Gaussian density at zero scaling has total mass equal to the area of the unit disc. This is the cleanest statement linking the slug's 'area of circle' theme to the complex Gaussian."
+      "The unit-weight complex Gaussian ∫_ℂ exp(-‖z‖²) = π is the 'circle area' identity: the Gaussian density at zero scaling has total mass equal to the area of the unit disc. This is the cleanest statement linking the slug's 'area of circle' theme to the complex Gaussian.",
+      "integral_fintype_prod_volume_eq_pow at Mathlib/MeasureTheory/Integral/Pi.lean:123 is the right n-fold Fubini lemma when all factors share the same f : E → 𝕜; it gives (∫ f) ^ Fintype.card ι directly, avoiding per-index simp_rw.",
+      "The S4a reduction exp(-(b · ∑ ‖zᵢ‖²)) = ∏ᵢ exp(-(b · ‖zᵢ‖²)) is a three-step rewrite chain that needs no custom lemma: Finset.mul_sum distributes b into the sum, ← Finset.sum_neg_distrib pushes negation inside, then Real.exp_sum converts to a product. Same combo used in parent file AreaOfCircleOQ05OQ02.diagonal_gaussian (real n-fold).",
+      "Once the n-fold reduction is in place, no measure-preserving change of variables is needed at the n-dimensional level: the Fin n → ℂ integrand factors before any transport, so we never need to interact with Complex.measurableEquivRealProd beyond what was already done in S2a / S3 for the per-axis factor."
     ],
     "mathlibGaps": [
       "No padicAddChar : Q_p -> C (standard additive character with psi_p|_{Z_p} = 1, psi_p(p^{-n}) = e^{2*pi*i/p^n}).",

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -28,21 +28,9 @@
     ],
     "goal": "Recommended path: S2a proves the complex Gaussian (low-risk bridge); S2b writes a sorry-bearing p-adic scaffold of (C2) flagged with axioms for the missing psi_p and Haar measure. Eventual full proof of (C2) blocks on two Mathlib contributions (standard psi_p, Haar on Q_p)."
   },
-  "currentState": {
-    "phase": "RESEARCH",
-    "since": "2026-05-12T17:00:00+00:00",
-    "iteration": 4,
-    "focus": "S4a ACT: n-dimensional parametric complex Gaussian ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ proved for arbitrary n : ℕ and b > 0. Same Fubini skeleton as AreaOfCircleOQ05OQ02.diagonal_gaussian (real n-fold), with each ℂ-axis contributing π/b via complex_gaussian_integral_scaled_norm (S3). Adds 4 theorems: complex_gaussian_integral_scaled_pow (main), complex_gaussian_integral_scaled_pow_normSq (normSq form), complex_gaussian_integral_pow_unit_norm (b=1 corollary), complex_gaussian_integral_pow_normalised ((1/π)ⁿ density). 0 sorries, 0 axioms.",
-    "blockers": [],
-    "nextAction": "S5: three viable directions. (S5a) Prove the complex Gaussian f(z) = exp(-π‖z‖²) is a Fourier-eigenfunction of the 2-D real Fourier transform; canonical archimedean statement of (C2). (S5b) Contribute Mathlib milestone — explicit MeasureTheory.Measure ℚ_p with μ(ℤ_p) = 1 (plausible single Mathlib PR). (S5c) Complex orthogonality ∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ via parametric differentiation, building on the S4a n-dim normalised density.",
-    "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
-    }
-  },
+  "currentState": "{\"phase\": \"RESEARCH\", \"since\": \"2026-05-12T19:30:00+00:00\", \"iteration\": 5, \"focus\": \"S5 ACT: translation invariance of the parametric complex Gaussian. For any shift c : ℂ and b > 0, ∫_ℂ exp(-(b·‖z-c‖²)) dz = π/b. Proof uses MeasureTheory.integral_add_right_eq_self (volume on ℂ is IsAddHaarMeasure → IsAddRightInvariant) chained with complex_gaussian_integral_scaled_norm (S3). Adds 4 theorems: complex_gaussian_integral_scaled_shifted_norm (main), complex_gaussian_integral_scaled_shifted (normSq form), complex_gaussian_integral_unit_shifted_norm (b=1 corollary), complex_gaussian_density_shifted (canonical (c,b)-density). 0 sorries, 0 axioms; build verified via Docker wrapper.\", \"blockers\": [], \"nextAction\": \"S6: four viable directions. (S6a) Lift S5 to Fin n → ℂ giving ∫_{ℂⁿ} exp(-(b·∑‖zᵢ-cᵢ‖²)) = (π/b)ⁿ — combines S4a and S5 idioms via MeasureTheory.Measure.pi.instIsAddHaarMeasure on the product measure. (S6b) Complex Fourier-eigenfunction (archimedean analogue of C2): reduce 2-D Fourier transform of exp(-π‖z‖²) to 1-D via ℂ ≃ ℝ × ℝ. (S6c) Schur orthogonality ∫ zᵢ z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ via parametric differentiation. (S6d) Mathlib milestone: Measure ℚ_p with μ(ℤ_p) = 1 (multi-week upstream PR).\", \"attemptCounts\": {\"total\": 0, \"currentApproach\": 0, \"approachesTried\": 0}}",
   "knowledge": {
-    "progressSummary": "S1 OBSERVE + S2a ACT-A (b=π) + S3 ACT-B (parametric b>0) + S4a ACT (n-dim parametric) complete with build verified. AreaOfCircleOQ05OQ04.lean now 429 lines, 12 theorems + 2 private helpers, all sorry-free and axiom-free. Complete complex-side coverage: π-weight, parametric b, unit weight, normalised density, n-dim parametric, n-dim unit-weight, n-dim normalised. p-adic case (C2) remains deferred pending two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar on ℚ_p).",
+    "progressSummary": "S1 OBSERVE + S2a ACT-A (b=π) + S3 ACT-B (parametric b>0) + S4a ACT (n-dim parametric, open PR #18221) + S5 ACT (translation invariance + (c,b) density) complete with build verified. AreaOfCircleOQ05OQ04.lean now ~543 lines, 16 theorems + 2 private helpers, all sorry-free and axiom-free. Complete complex-side coverage: π-weight, parametric b, unit weight, normalised density, n-dim parametric, n-dim unit-weight, n-dim normalised, c-shifted parametric, c-shifted unit, c-shifted (c,b)-density. p-adic case (C2) remains deferred pending two Mathlib milestones (ψ_p : ℚ_p → ℂ and explicit Haar on ℚ_p).",
     "builtItems": [
       {
         "item": "S1 OBSERVE markdown set (problem.md, knowledge.md, state.md)",
@@ -67,6 +55,11 @@
       {
         "item": "Proofs/AreaOfCircleOQ05OQ04.lean: complex_gaussian_integral_scaled_pow (n-dim ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ), complex_gaussian_integral_scaled_pow_normSq (normSq form), complex_gaussian_integral_pow_unit_norm (b=1 corollary, value πⁿ), complex_gaussian_integral_pow_normalised ((1/π)ⁿ joint density) — proven via Real.exp_sum reduction + integral_fintype_prod_volume_eq_pow + complex_gaussian_integral_scaled_norm per axis",
         "session": "S4a"
+      },
+      {
+        "item": "Proofs/AreaOfCircleOQ05OQ04.lean: complex_gaussian_integral_scaled_shifted_norm (translation-invariant ∫_ℂ exp(-(b·‖z-c‖²)) = π/b), complex_gaussian_integral_scaled_shifted (normSq form), complex_gaussian_integral_unit_shifted_norm (b=1 corollary), complex_gaussian_density_shifted (canonical two-parameter (c,b)-density integrates to 1). 4 theorems, all sorry-free and axiom-free, building on complex_gaussian_integral_scaled_norm (S3) via integral_add_right_eq_self (translation invariance of the additive Haar volume on ℂ). No new imports.",
+        "phase": "S5 ACT",
+        "date": "2026-05-12"
       }
     ],
     "insights": [
@@ -81,7 +74,11 @@
       "The unit-weight complex Gaussian ∫_ℂ exp(-‖z‖²) = π is the 'circle area' identity: the Gaussian density at zero scaling has total mass equal to the area of the unit disc. This is the cleanest statement linking the slug's 'area of circle' theme to the complex Gaussian.",
       "integral_fintype_prod_volume_eq_pow at Mathlib/MeasureTheory/Integral/Pi.lean:123 is the right n-fold Fubini lemma when all factors share the same f : E → 𝕜; it gives (∫ f) ^ Fintype.card ι directly, avoiding per-index simp_rw.",
       "The S4a reduction exp(-(b · ∑ ‖zᵢ‖²)) = ∏ᵢ exp(-(b · ‖zᵢ‖²)) is a three-step rewrite chain that needs no custom lemma: Finset.mul_sum distributes b into the sum, ← Finset.sum_neg_distrib pushes negation inside, then Real.exp_sum converts to a product. Same combo used in parent file AreaOfCircleOQ05OQ02.diagonal_gaussian (real n-fold).",
-      "Once the n-fold reduction is in place, no measure-preserving change of variables is needed at the n-dimensional level: the Fin n → ℂ integrand factors before any transport, so we never need to interact with Complex.measurableEquivRealProd beyond what was already done in S2a / S3 for the per-axis factor."
+      "Once the n-fold reduction is in place, no measure-preserving change of variables is needed at the n-dimensional level: the Fin n → ℂ integrand factors before any transport, so we never need to interact with Complex.measurableEquivRealProd beyond what was already done in S2a / S3 for the per-axis factor.",
+      "MeasureTheory.integral_add_right_eq_self at Mathlib/MeasureTheory/Group/Integral.lean is the canonical translation-invariance lemma; for ℂ, it applies because volume : Measure ℂ is IsAddHaarMeasure (via Complex.measurableEquivRealProd inheriting from ℝ × ℝ) and therefore IsAddRightInvariant (abelian group). Same idiom used in ShannonEntropyOQ01.gaussian_variance and FourierSeriesOQ02 Fourier-shift lemma.",
+      "Pitfall: rw [integral_add_right_eq_self] fails on goals of the shape ∫ z, (fun w => f w) (z + (-c)) = ... because the rewriter cannot pattern-match ∫ x, ?f (x + ?g) ∂?μ against an integrand whose outer function is a lambda. Fix: chain directly via (integral_add_right_eq_self (fun w => exp(-(b·‖w‖²))) (-c)).trans (complex_gaussian_integral_scaled_norm b hb) — Lean accepts via β-defeq. Verified at v4.26.0.",
+      "Converting f(z - c) to f(z + (-c)) inside an integral requires a show + funext + rw [← sub_eq_add_neg] idiom (ShannonEntropy-style): use a per-point key lemma that proves the equality with an explicit show step to expose the β-reduced form, then funext into the integral via rw [show ... = ... from funext ...].",
+      "The c=0 specialisation of complex_gaussian_integral_scaled_shifted_norm recovers complex_gaussian_integral_scaled_norm (S3); the b=1 specialisation gives the unit-weight shifted form. So S5 strictly subsumes S2a/S3 in the (c, b) plane: every previously-stated theorem is a special case of complex_gaussian_density_shifted (after un-normalising by π/b)."
     ],
     "mathlibGaps": [
       "No padicAddChar : Q_p -> C (standard additive character with psi_p|_{Z_p} = 1, psi_p(p^{-n}) = e^{2*pi*i/p^n}).",
@@ -89,8 +86,10 @@
       "No Bruhat-Schwartz function space or Fourier-transform infrastructure specialised to Q_p."
     ],
     "nextSteps": [
-      "S4a (recommended): n-dim complex Gaussian ∫_{ℂⁿ} exp(-(b·∑‖zᵢ‖²)) = (π/b)ⁿ. Can be proven by induction over Fin n using integral_fintype_prod_volume_eq_prod + complex_gaussian_integral_scaled, or via the existing real MultivariateGaussian.diagonal_gaussian + transport ℂⁿ ≃ ℝ^{2n}.",
-      "S4b (deferred — see C2 above): p-adic self-Fourier of 1_{ℤ_p} blocks on two Mathlib milestones (standard ψ_p, Haar on ℚ_p)."
+      "S6a: lift translation invariance to Fin n → ℂ, giving ∫_{ℂⁿ} exp(-(b·∑‖zᵢ - cᵢ‖²)) = (π/b)ⁿ. Combines S4as n-fold Fubini with S5s additive-Haar translation. Needs MeasureTheory.Measure.pi.instIsAddHaarMeasure (Mathlib v4.26.0 should provide).",
+      "S6b: complex Fourier-eigenfunction. Mathlib has Real.fourierIntegral_gaussian_pi for the real-axis fixed point exp(-π x²); the complex case is one ℂ ≃ ℝ × ℝ transport + Fubini reduction. Canonical archimedean analogue of (C2).",
+      "S6c: Schur orthogonality ∫ zᵢ z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ via parametric differentiation. Heavier — needs hasDerivAt_integral_of_dominated_loc machinery.",
+      "S6d: Mathlib milestone — explicit MeasureTheory.Measure ℚ_p with μ(ℤ_p) = 1 (see S4b PR #18269 survey). Multi-week upstream PR; independent of S6a-c. The conjugate milestone (standard ψ_p : ℚ_p → ℂ) is heavier."
     ]
   },
   "tags": [
@@ -177,7 +176,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-12T10:58:14+00:00",
+  "lastUpdate": "2026-05-12T20:30:00+00:00",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S5 ACT for `area-of-circle-oq-05-oq-04`: **translation invariance** of
the parametric complex Gaussian. For any shift `c : ℂ` and weight `b > 0`,

    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b.

This unlocks the **canonical two-parameter complex Gaussian probability
density** (mean `c`, scale `b`),

    ∫_ℂ (b/π) · exp(-(b · ‖z - c‖²)) dz = 1.

Proof: rewrite `z - c = z + (-c)` and invoke
`MeasureTheory.integral_add_right_eq_self` (the complex Lebesgue measure
is an `IsAddHaarMeasure`, hence `IsAddRightInvariant`), then chain with
`complex_gaussian_integral_scaled_norm` (S3). Identical idiom to the
real-line translation step in
`ShannonEntropyOQ01.gaussian_variance` and `FourierSeriesOQ02`'s
Fourier-coefficient shift.

## Stacking

This PR is built on top of **PR #18221 (S4a, open as of 2026-05-12
17:50 UTC)**, which adds the n-dim complex Gaussian to the same file.
The S5 additions are *strictly orthogonal* to S4a's content (no
references to `complex_gaussian_integral_scaled_pow` or any n-dim
result); they live in a new "Part 4: Translation invariance" block
after S4a's "Part 3". When the deployer merges #18221, the rebase here
will be trivial — same file, disjoint regions.

Also orthogonal to **PR #18269 (S4b doc-only p-adic Mathlib survey)** —
that PR only adds a new markdown file in `research/`.

## Progress

### New theorems (`AreaOfCircleOQ05OQ04.lean`, +96 LOC over S4a's 429 → ~543 lines)

- `complex_gaussian_integral_scaled_shifted_norm (b > 0) (c : ℂ) :
    ∫ z : ℂ, exp(-(b · ‖z - c‖²)) = π / b`
  — main translation-invariance theorem. Proof: chain `integral_add_right_eq_self`
  (for `f w = exp(-(b · ‖w‖²))`, `g = -c`) with `.trans` against the
  unshifted parametric Gaussian. Workaround for HOU failure documented in
  knowledge.md (rewriter cannot pattern-match `∫ x, ?f (x + ?g) ∂?μ`
  through a lambda at v4.26.0; chain explicitly via `.trans` instead).
- `complex_gaussian_integral_scaled_shifted (b > 0) (c : ℂ) :
    ∫ z : ℂ, exp(-(b · normSq (z - c))) = π / b`
  — `Complex.normSq` form.
- `complex_gaussian_integral_unit_shifted_norm (c : ℂ) :
    ∫ z : ℂ, exp(-‖z - c‖²) = π`
  — `b = 1` corollary. The unit-disc-area constant `π` is independent
  of where the Gaussian is centred.
- `complex_gaussian_density_shifted (b > 0) (c : ℂ) :
    ∫ z : ℂ, (b/π) · exp(-(b · ‖z - c‖²)) = 1`
  — canonical two-parameter complex Gaussian probability density.

### Counts

- Lean: +96 lines (4 new theorems, all sorry-free and axiom-free)
- New imports: 0 (translation-invariance machinery is transitively
  pulled in by `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral`)
- Sorry delta: 0
- Axiom delta: 0
- Total file: 16 theorems + 2 private helpers, all sorry-free, axiom-free

### Build

- [x] Verified locally: `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ04`

### Docs

- `state.md`: iteration 4 → 5; S5 focus + four S6 directions
- `knowledge.md`: S5 Mathlib API confirmation (`integral_add_right_eq_self`,
  ℂ's `IsAddHaarMeasure`) + HOU-through-lambda pitfall + `sub_eq_add_neg`
  idiom + lessons
- JSON: iteration 4 → 5; 1 new built item; 4 new insights;
  refreshed focus / nextAction / progressSummary; nextSteps rewritten to
  S6 options

## Findings

- Translation invariance of the parametric complex Gaussian is a
  one-line corollary of `integral_add_right_eq_self` once the additive
  shape `z + (-c)` is exposed. The proof mechanism is *identical* to
  the real-line idiom in `ShannonEntropyOQ01.gaussian_variance`; the
  only complication is that `ℂ`'s volume measure carries the
  `IsAddHaarMeasure` instance via the inherited measure on `ℝ × ℝ`
  rather than as a primitive declaration.
- Pitfall: `rw [integral_add_right_eq_self]` fails when the integrand
  is a lambda application `(fun w => f w) (x + g)` — the rewriter's
  higher-order unification doesn't pattern-match `?f (x + ?g)` through
  a beta-redex. **Fix**: don't rewrite — chain transitively:
  `(integral_add_right_eq_self f g).trans target_unshifted`. Lean
  accepts the result via β-defeq. This pattern is now documented in
  `knowledge.md` under "Pitfall: HOU through `fun w => f w`".
- The `c = 0` specialisation of each S5 theorem reduces to its S3
  counterpart (`complex_gaussian_integral_scaled_norm`), and the
  `b = 1` specialisation to S2a (`complex_gaussian_integral_unit_norm`).
  So S5 strictly subsumes S2a/S3 in the `(c, b)` plane: every
  previously-stated theorem is a special case of
  `complex_gaussian_density_shifted` (after un-normalising by `π/b`).

## Status

**Outcome**: progress (build verified, 4 new sorry-free/axiom-free
theorems generalising S3 to arbitrary shift `c : ℂ`)

**Next Steps (S6 candidates)**:

1. **S6a (n-dim translation invariance)**: lift the 1-D shifted Gaussian
   to `Fin n → ℂ` via `MeasureTheory.Measure.pi.instIsAddHaarMeasure`,
   giving `∫_{ℂⁿ} exp(-(b·∑‖zᵢ - cᵢ‖²)) = (π/b)ⁿ` for any shift vector.
   Combines S4a's n-fold Fubini with S5's additive-translation step.
2. **S6b (complex Fourier-eigenfunction)**: still the canonical
   archimedean analogue of (C2). Mathlib has
   `Real.fourierIntegral_gaussian_pi`; the complex case is one
   `ℂ ≃ ℝ × ℝ` transport + Fubini reduction.
3. **S6c (Schur orthogonality)**:
   `∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ` via parametric
   differentiation of the S4a normalised density.
4. **S6d (Mathlib milestone)**: explicit `MeasureTheory.Measure ℚ_p`
   with `μ(ℤ_p) = 1` (see PR #18269 survey). Multi-week upstream PR;
   independent of S6a-c.

🤖 Generated by researcher-4