### PR TITLE
Enrich Derangements Nearest Integer (D(n) = round(n!/e)): add 8 cross-references

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -121,5 +121,47 @@
       "Quantify the total variation convergence rate TV(X_n, Pois(1)) ≤ C/n via Chen-Stein method"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-01",
+      "relationship": "parent",
+      "description": "Parent open question 'k Fixed Points: P(X_n = k) → e⁻¹/k! as n → ∞'. This OQ-01-OQ-01 specializes the k=0 case (no fixed points, i.e. derangements) to the quantitative rounding statement D(n) = round(n!/e), strengthening the qualitative limit P(X_n = 0) → 1/e to an exact integer identity for all n ≥ 1."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Grandparent file imported directly via `Proofs.DerangementsConvergence`. Provides the key input lemma `derangements_convergence_rate`: $|D(n)/n! - e^{-1}| \\leq 1/(n+1)!$, the alternating-series rate bound from the partial-sum truncation. This file scales that bound by $n!$ to obtain the absolute error $|D(n) - n!/e| \\leq 1/(n+1)$, then the nearest-integer rounding identity follows by $1/(n+1) < 1/2$ for $n \\geq 2$."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Base derangements gallery entry. Formalizes the inclusion-exclusion formula $D(n) = n! \\sum_{k=0}^{n} (-1)^k / k!$ (Montmort 1713), from which the asymptotic $D(n) \\sim n!/e$ follows immediately by recognizing the truncated alternating series for $e^{-1}$. The present nearest-integer theorem is the quantitative completion: the truncation error is so small that integer rounding recovers $D(n)$ exactly."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "alternative",
+      "description": "Sibling OQ-03 of the same parent, also titled 'Derangements = round(n!/e)' — an independent formalization of the same nearest-integer identity via a different proof route. Cross-validates the present OQ-01-OQ-01 derivation; convergent formalizations of the same theorem strengthen confidence in both."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Transcendence of $e$ (Hermite 1873). The constant $e$ appearing in $D(n) = \\text{round}(n!/e)$ is provably transcendental — meaning $n!/e$ is irrational for every $n \\geq 1$, so the equality $D(n) = n!/e$ never holds exactly; only the rounded identity $D(n) = \\text{round}(n!/e)$ does. This sharp integer-vs-transcendental dichotomy is the source of the 'curious' rounding phenomenon: an irrational expression whose rounded value coincides exactly with a combinatorial integer for every $n$."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "Principle of Inclusion/Exclusion — the combinatorial identity from which Montmort (1713) first derived $D(n) = n! \\sum_{k=0}^{n} (-1)^k / k!$ by summing $(-1)^{|S|} (n - |S|)!$ over subsets $S$ of positions to be fixed. The alternating series character of the resulting partial sums is precisely what enables the tight rate bound $|D(n)/n! - e^{-1}| \\leq 1/(n+1)!$ used in this file, and hence the nearest-integer rounding theorem."
+    },
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "analogue",
+      "description": "Leibniz's series $\\pi/4 = \\sum_{k=0}^{\\infty} (-1)^k/(2k+1)$ — another classical alternating-series identity for a transcendental constant. Like the present file's $e^{-1} = \\sum_k (-1)^k/k!$, the partial-sum error is bounded by the next term (the alternating series remainder lemma). The two results are stylistically parallel: both expand a transcendental constant as an alternating series of reciprocals, and both yield computable rate bounds for truncations."
+    },
+    {
+      "targetId": "taylor-sincos-convergence",
+      "relationship": "technique",
+      "description": "Taylor series convergence for $\\sin$ and $\\cos$ — uses the same alternating-series remainder technique as this file. Both prove that a truncated alternating series approximates its limit with error bounded by the absolute value of the next omitted term ($|R_N| \\leq |a_{N+1}|$). The present file applies this principle to $e^{-1} = \\sum (-1)^k/k!$ at truncation $n$; taylor-sincos-convergence applies the same lemma to $\\sin x = \\sum (-1)^k x^{2k+1}/(2k+1)!$ and $\\cos x = \\sum (-1)^k x^{2k}/(2k)!$."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds the missing `crossReferences` array to `derangements-convergence-oq-01-oq-01/meta.json`. The entry had a complete overview, sections, key insights, and conclusion, but `crossReferences` was entirely absent — leaving the gallery page with no navigation to mathematically related results.

## Cross-references added (8)

| Target | Relationship | Why |
|---|---|---|
| `derangements-convergence-oq-01` | parent | Specializes k=0 (derangements) case |
| `derangements-convergence` | foundational | Source of the alternating-series rate bound |
| `derangements` | foundational | Montmort inclusion-exclusion formula |
| `derangements-convergence-oq-03` | alternative | Same theorem, different derivation |
| `e-transcendental` | related | $e$ transcendence ⇒ $n!/e$ irrational ⇒ never exact, only rounded |
| `inclusion-exclusion` | foundational | Combinatorial source of $D(n)$ |
| `leibniz-pi` | analogue | Parallel alt. series for transcendental constant |
| `taylor-sincos-convergence` | technique | Same alt. series remainder lemma |

Each cross-reference includes a substantive description tying the slugs mathematically.

## Test plan

- [x] `jq` validates JSON
- [x] `npx tsx scripts/annotations/build.ts` exits 0 (no new warnings introduced)
- [x] All 8 target slugs exist in `src/data/proofs/`