### PR TITLE
research(randomized-maxcut-oq-03): S1 OBSERVE — bipartite tightness witness for 1/2 ratio (doc-only)

### DIFF
--- a/src/data/research/problems/randomized-maxcut-oq-03.json
+++ b/src/data/research/problems/randomized-maxcut-oq-03.json
@@ -1,0 +1,107 @@
+{
+  "slug": "randomized-maxcut-oq-03",
+  "title": "Randomized MaxCut 1/2-approximation tightness: bipartite family witness",
+  "phase": "OBSERVE",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{For the simple randomized MaxCut algorithm (assign each vertex to A/B uniformly), show that the 1/2 approximation ratio is tight by exhibiting a graph family where } E[|C|] / \\mathrm{MaxCut}(G) = 1/2 \\text{ exactly. The bipartite family suffices: every non-empty bipartite simple graph achieves } \\mathrm{MaxCut} = |E| \\text{ and } E[|C|] = |E|/2.",
+    "plain": "The parent file proofs/Proofs/RandomizedMaxCut.lean (324 lines, 0 sorries) proves E[|C|] >= MaxCut/2 (the approximation guarantee). OQ-03 asks for the *tightness* direction: a family where E[|C|] = MaxCut/2 exactly. Answer: bipartite graphs. For any non-empty bipartite simple graph, MaxCut = |E| (the canonical bipartition cuts every edge) and E[|C|] = |E|/2 (parent's expected_cut_size), so the ratio is exactly 1/2. Concrete witnesses: K_{m,n}, path graphs P_n, even cycles C_{2n}. S2 ACT ships ~65 LOC Lean in proofs/Proofs/RandomizedMaxCutOQ03.lean with universal `rand_approx_tight_on_bipartite` + concrete `rand_approx_tight_K_mn`.",
+    "whyMatters": [
+      "Completes the 1/2-approximation analysis: parent ships the lower bound, OQ-03 ships the tightness witness, so the gallery's randomized-MaxCut family has both directions.",
+      "Pedagogical clarity: tightness witnesses are standard for approximation algorithms; their presence in the gallery enables follow-up slugs (e.g., Goemans-Williamson 0.878-tightness on specific instances).",
+      "Reusable bipartite-tightness pattern: the completeBipartiteFamily construction unlocks tightness analyses for other algorithms whose worst case rests on bipartite structure."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent: E[|C|] = |E|/2 (expected_cut_size, line 251 of RandomizedMaxCut.lean).",
+      "Parent: MaxCut <= |E| (maxCut_le_edges, line 291).",
+      "Parent: E[|C|] >= MaxCut/2 (rand_approx_guarantee, line 309)."
+    ],
+    "open": [
+      "Tightness theorem `rand_approx_tight_on_bipartite`: for any bipartite SimpleGraph V (Fintype, DecidableEq), randomizedMaxCut G = (maxCutValue G : ℝ) / 2. ~65 Lean LOC.",
+      "Concrete witness `rand_approx_tight_K_mn`: complete bipartite K_{m,n} for positive m, n. ~15 LOC corollary."
+    ],
+    "goal": "Ship proofs/Proofs/RandomizedMaxCutOQ03.lean (~65 LOC, 0-1 sorries) with both universal and concrete tightness theorems; preserve the parent file unchanged."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T21:05:00Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE — bipartite-family tightness confirmation + Mathlib IsBipartite/completeBipartiteGraph API audit + S2 ACT skeleton.",
+    "blockers": [],
+    "nextAction": "S2 ACT — create proofs/Proofs/RandomizedMaxCutOQ03.lean with exists_full_cut_of_isBipartite + maxCut_eq_edges_of_bipartite + rand_approx_tight_on_bipartite + rand_approx_tight_K_mn (~65 LOC, 0-1 sorries). Skeleton in knowledge.md §4.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE doc-only: confirmed bipartite family is the tightness witness for the parent's 1/2-approximation guarantee. For any non-empty bipartite simple graph, MaxCut = |E| (canonical bipartition cuts every edge) and E[|C|] = |E|/2 (parent's expected_cut_size), giving ratio = 1/2 exactly. Audited Mathlib's SimpleGraph.IsBipartite and completeBipartiteGraph API; both exist in v4.26.0. Locked S2 ACT scope: ~65 LOC new file with two helpers (exists_full_cut_of_isBipartite, maxCut_eq_edges_of_bipartite) + main theorem (rand_approx_tight_on_bipartite) + concrete corollary (rand_approx_tight_K_mn). Out of scope: variance (oq-01), derandomisation (oq-02), Goemans-Williamson (sibling).",
+    "builtItems": [
+      "research/problems/randomized-maxcut-oq-03/problem.md (formal scope, bipartite tightness theorem, sub-OQ index)",
+      "research/problems/randomized-maxcut-oq-03/knowledge.md (parent recap, Mathlib alignment, Lean skeleton, concrete witness, risk register)",
+      "research/problems/randomized-maxcut-oq-03/state.md (phase OBSERVE, S2 scope lock, race awareness)"
+    ],
+    "insights": [
+      "Bipartite is the tight family because MaxCut = |E| exactly (every edge crossable) iff the graph is bipartite — non-bipartite forces MaxCut <= |E| - 1 by the odd-cycle constraint.",
+      "Parent's expected_cut_size already gives E[|C|] = |E|/2 in absolute terms; combining with MaxCut = |E| on bipartite gives the tightness for free.",
+      "Mathlib's SimpleGraph.IsBipartite + completeBipartiteGraph provide direct API; no scaffolding needed unless lemma names have drifted.",
+      "The construction generalises: any approximation algorithm whose worst-case rests on a structural class (bipartite, planar, etc.) has its tightness witness in that class."
+    ],
+    "mathlibGaps": [
+      "Mathlib's SimpleGraph.IsBipartite + completeBipartiteGraph are present but lemma names may have drifted from older Mathlib API. Verify before S2 ACT."
+    ],
+    "nextSteps": [
+      "S2 ACT — ship proofs/Proofs/RandomizedMaxCutOQ03.lean (~65 LOC) with both universal and concrete tightness theorems.",
+      "S3 (optional) — Mathlib upstreaming experiment.",
+      "Sister-slug coordination: oq-01 variance, oq-02 derandomisation, oq-04 are orthogonal; no concurrent S1 OBSERVE risk."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "graph-theory",
+    "approximation-algorithms",
+    "randomized-algorithms",
+    "max-cut",
+    "bipartite",
+    "tightness-witness",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "randomized-maxcut",
+    "randomized-maxcut-oq-01",
+    "randomized-maxcut-oq-02",
+    "randomized-maxcut-oq-04",
+    "goemans-williamson-max-cut"
+  ],
+  "references": {
+    "papers": [
+      {
+        "author": "Motwani, R., and Raghavan, P.",
+        "year": 1995,
+        "title": "Randomized Algorithms, §5.1 (MaxCut and approximation)",
+        "venue": "Cambridge University Press"
+      },
+      {
+        "author": "Williamson, D. P., and Shmoys, D. B.",
+        "year": 2011,
+        "title": "The Design of Approximation Algorithms, §5 (randomized rounding and MaxCut)",
+        "venue": "Cambridge University Press"
+      }
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Bipartite (IsBipartite class)",
+      "Mathlib.Combinatorics.SimpleGraph.Subgraph (used by parent's Cut structure)"
+    ]
+  },
+  "started": "2026-05-12T21:05:00Z",
+  "lastUpdate": "2026-05-12T21:05:00Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": []
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE for the seeker-fresh slug `randomized-maxcut-oq-03`
("Can we prove the 1/2 ratio is tight by exhibiting a graph family
where the algorithm achieves exactly 1/2?"). **Doc-only.**

## Mathematical answer

**The bipartite family** is the tightness witness. For any non-
empty bipartite simple graph G:

- `MaxCut(G) = |E|` (canonical bipartition cuts every edge).
- `E[|C|] = |E| / 2` (parent's `expected_cut_size`, line 251 of
  `RandomizedMaxCut.lean`).
- Hence `E[|C|] / MaxCut = 1/2` *exactly*.

Concrete witnesses: complete bipartite `K_{m,n}` (m, n positive),
path graphs `P_n` (n ≥ 2), even cycles `C_{2n}` (n ≥ 1).

## Parent file recap

`proofs/Proofs/RandomizedMaxCut.lean` (324 lines, 0 sorries) ships
the upper-bound side via `rand_approx_guarantee : E[|C|] ≥ MaxCut/2`.
OQ-03 ships the tightness (lower-bound) side. After S2, the family
has both directions and the 1/2-approximation analysis is complete.

## Mathlib alignment

- `SimpleGraph.IsBipartite` exists in v4.26.0.
- `SimpleGraph.completeBipartiteGraph m n : SimpleGraph (m ⊕ n)` exists.
- Exact lemma names (`exists_2coloring` vs `coloring`) need ~5 min
  audit at S2 time.

## S2 ACT scope (~65 LOC, 0–1 sorries)

Ship `proofs/Proofs/RandomizedMaxCutOQ03.lean`:

| Item | LOC | Role |
|------|-----|------|
| `exists_full_cut_of_isBipartite` | ~20 | helper: bipartite ⇒ cut covering every edge |
| `maxCut_eq_edges_of_bipartite` | ~8 | helper: bipartite ⇒ MaxCut = \|E\| |
| `rand_approx_tight_on_bipartite` | ~5 | **main** — universal tightness |
| `rand_approx_tight_K_mn` | ~5 | concrete K_{m,n} corollary |
| Docstring + namespace | ~25 | infrastructure |

## Files (S1 OBSERVE deliverable)

- **NEW** `research/problems/randomized-maxcut-oq-03/problem.md`
  (~150 lines): formal scope, bipartite tightness theorem, sub-OQ
  index (A: universal vs concrete; B: Mathlib API; C: variance —
  out of scope).
- **NEW** `research/problems/randomized-maxcut-oq-03/knowledge.md`
  (~250 lines): § 1 math content, § 2 parent file recap, § 3 Mathlib
  alignment, § 4 S2 Lean skeleton, § 5 K_{m,n} witness, § 6 S2 scope,
  § 8 risk register, § 10 cost.
- **NEW** `research/problems/randomized-maxcut-oq-03/state.md`
  (~115 lines): phase OBSERVE, S2 lock, race awareness.
- **NEW** `src/data/research/problems/randomized-maxcut-oq-03.json`
  (~95 lines): gallery entry, status `in-progress`.

## Race awareness

OQ-03 has zero open PRs and zero recent merges at push time
(verified twice via `gh pr list --search`). Siblings (`oq-01`,
`oq-02`, `oq-04`) target orthogonal aspects (variance,
derandomisation). `goemans-williamson-max-cut` is a strictly
different (stronger) algorithm.

## Status

**Outcome**: progress — bipartite tightness witness confirmed;
~65-LOC S2 ACT skeleton ready for mechanical adaptation.
**Next Steps**: S2 ACT — ship `RandomizedMaxCutOQ03.lean` with both
universal and concrete tightness theorems. Skeleton in
`knowledge.md` § 4.
**Axiom integrity**: 0 axioms added; no Lean changes in this PR.

🤖 Generated by researcher-1