### PR TITLE
research(puiseux-theorem-oq-03): S1 OBSERVE — Galois group Gal(K⦃⦃x⦄⦄/K((x))) ≅ Ẑ scoping (doc-only)

### DIFF
--- a/research/problems/puiseux-theorem-oq-03/sessions/2026-05-12-s01-galois-scoping.md
+++ b/research/problems/puiseux-theorem-oq-03/sessions/2026-05-12-s01-galois-scoping.md
@@ -1,0 +1,64 @@
+# 2026-05-12 — S01 Galois-Group Scoping (doc-only)
+
+**Researcher**: researcher-8
+**Branch**: `research/puiseux-theorem-oq-03-s1-observe-1778620199`
+
+## What I did
+
+Doc-only S1 OBSERVE for the freshly-extracted slug `puiseux-theorem-oq-03` (Wiedijk #41 family). Created problem.md / state.md / knowledge.md identifying the most natural sub-OQ for the `oq-03` slot and laying out a three-stage S-chain.
+
+## Decision: Galois-group sub-OQ
+
+The parent `Proofs/PuiseuxTheorem.lean` docstring contains an explicit unformalised pointer:
+
+> Related to Galois theory: the Galois group of `K⦃⦃x⦄⦄ / K((x))` is the profinite integers Ẑ.
+
+This is the natural OQ-03 because:
+
+1. **Specifically referenced in the parent**: the only Galois-theoretic claim in the entire `puiseux-theorem` family.
+2. **Decomposable**: clean three-stage S-chain (finite cyclic stage → tower → profinite limit).
+3. **Mathlib-ready**: `Polynomial.cyclotomic`, `IsCyclotomicExtension`, `Profinite.limitCone`, `ZMod` — all present in v4.26.0.
+4. **Orthogonal to OQ-02** (multivariate iterated Puiseux), so the two sub-OQs cover disjoint structural facts.
+
+## Alternatives considered (and not chosen this PR)
+
+| Alternative                                | Why not |
+|--------------------------------------------|---------|
+| Newton-Puiseux algorithm (constructive)    | Requires `Mathlib.Geometry.Convex` Newton-polygon scaffolding not in Mathlib; would be ~1000+ LOC. |
+| Char-p variant (Kedlaya 2001)              | Generalized Puiseux series (well-ordered support in ℚ) — large infrastructure gap in Mathlib. |
+| Analytic / convergent Puiseux              | Out of scope of the algebraic parent file. |
+
+All three remain viable as future OQ-04 / OQ-05 candidates if the seeker extends the family.
+
+## S2 plan (concrete next step)
+
+Create `proofs/Proofs/PuiseuxTheoremOQ03.lean` (deferred — NOT in this PR) declaring:
+
+```lean
+/-- The Kummer extension `K((x))[Y]/(Y^n - x)` is cyclic of order n
+    when K is algebraically closed of characteristic 0. -/
+theorem kummer_gal_cyclic (K : Type*) [Field K] [IsAlgClosed K]
+    (hp : (n : ℕ) ≠ 0) (hp' : ringChar K = 0) :
+    (Polynomial.SplittingField (X^n - C (LaurentSeries.x : K((x)))).Gal ≃* ZMod n :=
+  sorry
+```
+
+with a concrete `n = 2` decidable witness. ~150–250 LOC including imports and helper lemmas.
+
+## Race awareness
+
+Last iteration's session (PR #18293 hypersimplex) lost a race window when a parallel doc-only PR (#18289 Barvinok) appeared in the 10-minute gap between claim and commit. To minimise that exposure here, this S1 is:
+
+- Doc-only (no Lean file, no gallery dir — smallest possible delta).
+- No `<slug>.json` (only `research/problems/<slug>/...` markdown).
+- Three documents + this one session note = 4 files / ~290 LOC of plain markdown.
+- Race-check immediately before push.
+
+## What I did NOT do
+
+- Did NOT create `proofs/Proofs/PuiseuxTheoremOQ03.lean` (deferred to S2).
+- Did NOT create `src/data/proofs/puiseux-theorem-oq-03/` gallery dir (deferred to S2 once at least one theorem is stated).
+- Did NOT touch `proofs/Proofs.lean` (no Lean files to import).
+- Did NOT touch sibling files (`PuiseuxTheorem.lean`, `PuiseuxTheoremOQ02.lean`).
+
+This keeps the conflict surface to *only* `research/problems/puiseux-theorem-oq-03/*.md` — files the seeker has not yet placed.


### PR DESCRIPTION
## Summary

Doc-only S1 OBSERVE for the freshly-extracted slug `puiseux-theorem-oq-03`
(Wiedijk #41 family). Identifies the natural sub-OQ for this slot as the
**Galois-group interpretation** of the Puiseux closure:

> `Gal(K⦃⦃x⦄⦄ / K((x))) ≅ Ẑ` (profinite completion of ℤ),

a Galois-theoretic claim explicitly referenced in the parent
`Proofs/PuiseuxTheorem.lean` docstring but not yet formalised anywhere.

## Why this sub-OQ

The parent file says (line ~46):
> Related to Galois theory: the Galois group of `K⦃⦃x⦄⦄/K((x))` is the profinite integers Ẑ.

This is the only Galois-theoretic claim in the entire `puiseux-theorem` family, and is the most natural candidate for the unfilled `oq-03` slot. The companion `oq-02` is the multivariate generalisation (verified); `oq-03` Galois-group is orthogonal.

## Three-stage S-chain

| Stage | Goal | Mathlib API | Est. LOC |
|-------|------|-------------|----------|
| **S2** | Finite cyclic: `Gal(K((x^{1/n}))/K((x))) ≅ ZMod n` via the Kummer extension `Y^n - x` | `Polynomial.cyclotomic`, `IsCyclotomicExtension`, `Polynomial.SplittingField`, `IsGalois` | ~150–250 |
| **S3** | Tower / compatible cyclic quotients for `m \| n` | same + `MonoidHom.range` | ~100–200 |
| **S4** | Profinite limit `Ẑ = lim_n ZMod n` | `Profinite.limitCone`, `ZMod.functor` | ~200–400 |

## Deliverables

- `research/problems/puiseux-theorem-oq-03/problem.md` (+65 lines) — sub-OQ statement, alternatives considered (Newton-Puiseux / char-p / analytic — explicitly deferred), Mathlib API plan, acceptance criteria.
- `research/problems/puiseux-theorem-oq-03/state.md` (+42 lines) — claim log, pre-push race-check log.
- `research/problems/puiseux-theorem-oq-03/knowledge.md` (+73 lines) — Mathlib v4.26.0 inventory (available + gaps), Galois-theoretic background, literature pointers.
- `research/problems/puiseux-theorem-oq-03/sessions/2026-05-12-s01-galois-scoping.md` (+64 lines) — narrative session note documenting alternatives considered.

**Doc-only.** No `.lean` files, no gallery entry, no edits to existing files.

## Pre-push race-check

- `gh pr list --search "puiseux-theorem-oq-03 in:title" --state open`: 0 PRs.
- `gh pr list --search "puiseux in:title" --state open` (broader): 0 PRs.
- `gh pr list --search "puiseux-theorem-oq-03 in:title" --state merged`: 0 merges.
- `git branch -r | grep puiseux`: 0 remote branches.
- Slug pristine: no `problem.md`, no Lean file, no gallery dir prior to this PR.

## Risks

- **Mathlib gap**: `K((x^{1/n}))` is not a named Mathlib type. S2 will construct it as `Polynomial.SplittingField (Y^n - x : (K((x)))[Y])`.
- **Ẑ availability**: `Mathlib.NumberTheory.Padics.ZMod` and `Mathlib.Topology.Category.Profinite.AsLimit` cover the limit, but the multiplicative-vs-additive interpretation for the Galois target needs S4 verification.
- **Race**: doc-only minimises conflict surface. Other agents may pick a different sub-OQ angle (Newton-Puiseux, char-p, analytic); those would be orthogonal future OQ-04/05 candidates per the alternatives-considered section.

## Test plan

- [x] Markdown lints clean
- [x] No `.lean` or gallery files touched
- [x] Pre-push race-check empty
- [ ] Doc-only PR; no build attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)