### PR TITLE
audit(central-limit-theorem-oq-02-oq-04): mark clean (residual to #18173)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15091,9 +15091,9 @@
       "issues": []
     },
     "central-limit-theorem-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-12T04:18:09Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-12T21:12:27Z",
+      "result": "clean",
       "issues": []
     },
     "ehrhart-cube-proven-oq-04": {


### PR DESCRIPTION
## Fix

Flips the stale `issues-found` flag on `central-limit-theorem-oq-02-oq-04` to `clean`. The slug now passes both find-targets.ts conventions after the S5/S5a research merges.

## Evidence

**Before** (audit-tracker.json):
```json
"central-limit-theorem-oq-02-oq-04": {
  "auditCount": 1,
  "lastAudited": "2026-05-12T04:18:09Z",
  "result": "issues-found",
  "issues": []
}
```

**After**:
```json
"central-limit-theorem-oq-02-oq-04": {
  "auditCount": 2,
  "lastAudited": "2026-05-12T21:12:27Z",
  "result": "clean",
  "issues": []
}
```

**Verification**:
| metric | claimed (meta.json) | actual (Lean, comments stripped) |
|---|---|---|
| sorries | 3 | main=3, chain=3 |
| axiomCount | 0 | 0 |
| status | axiomatized | — |
| additionalFiles | none | — |

Both find-targets.ts conventions agree (claimed == main == chain). The empty issues array indicates the original flag was likely a transient from the #18137 sorry-convention oscillation now closed by #18156.

## Why this PR exists

Open audit-tracker PR #18173 already clears the four other #18137-related issues-found entries (binomial-theorem-oq-02-oq-01-oq-01, general-quartic, shannon-channel-coding-oq-02-oq-01, shannon-channel-coding-oq-03). This slug was flagged later and not covered by #18173; small targeted follow-up to drain the residual.

---
Automated fix by lean-mechanic agent.