### PR TITLE
Enrich Newton-Girard k=1,2,3 (amgm-...-oq-02-oq-01-oq-02-oq-01): generating-function origin + 4 refs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/annotations.json
@@ -149,5 +149,52 @@
       "omega tactic",
       "ring tactic"
     ]
+  },
+  {
+    "id": "ann-ng-generating-function",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 22
+    },
+    "type": "context",
+    "title": "Generating-Function Origin of the Recurrence",
+    "content": "The Newton-Girard recurrence proved in this file admits a clean derivation via the logarithmic derivative of the generating function for elementary symmetric polynomials. Setting $E(t) = \\prod_i (1 + x_i t) = \\sum_k e_k t^k$ and $P(t) = \\sum_{k \\ge 1} p_k t^{k-1}$, one computes\n$$\\frac{E'(t)}{E(t)} = \\sum_i \\frac{x_i}{1 + x_i t} = \\sum_i \\sum_{k \\ge 1} (-1)^{k-1} x_i^k t^{k-1} = P(-t).$$\nRearranging gives $E'(t) = E(t) \\cdot P(-t)$. Extracting coefficients of $t^{k-1}$ on both sides yields exactly the recurrence `MvPolynomial.psum_eq_mul_esymm_sub_sum` uses. This is the reason the identities hold over any commutative ring: the generating-function manipulation lives at the level of formal power series in `R[[t]]` and uses no analytic structure. Mathlib's combinatorial proof (Zeilberger 1984) is the bijective analog of this analytic argument.",
+    "mathContext": "$E(t) = \\prod_i (1 + x_i t) = \\sum_k e_k t^k$ (generating function for $e_k$); $P(t) = \\sum_{k \\ge 1} p_k t^{k-1}$ (generating function for $p_k$, shifted by 1). The identity $E'(t) = E(t) \\cdot P(-t)$ in $R[[t]]$ produces Newton-Girard upon equating coefficients.",
+    "significance": "context",
+    "relatedConcepts": [
+      "generating functions",
+      "logarithmic derivative",
+      "formal power series",
+      "Zeilberger combinatorial proof"
+    ],
+    "prerequisites": [
+      "formal power series",
+      "logarithmic derivative",
+      "MvPolynomial"
+    ]
+  },
+  {
+    "id": "ann-ng-aristotle-companion",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 22
+    },
+    "type": "context",
+    "title": "Aristotle Companion: Pre-Mathlib Proof-Search Targets",
+    "content": "The file `Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean` (listed in `additionalFiles`) is a companion artifact for the Aristotle automated proof-search tool. It contains the same three theorem statements with `sorry`-stubs and detailed natural-language proof strategies in docstrings — including the specific tactic chains (`simp [Finset.antidiagonal, Set.Ioo] at h`, `ring_nf at h ⊢; exact h`) that would discharge each target. The companion file was retained as a historical record of the Aristotle pre-submission strategy; the main file in this entry is the human-completed formalization that supersedes it. This pattern (paired main + Aristotle-companion files) appears throughout the gallery and lets the proof-search tool work on a clean target without seeing the human-found solution.",
+    "mathContext": "Companion-file pattern: Aristotle expects `theorem ... := by sorry` with provable supporting lemmas exposed, no `axiom` declarations, and no `/-!` docstring sections (parser incompatibility). Both files share the same three statement bodies; the main file's `:= by ...` proofs are the canonical version.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Aristotle proof search",
+      "companion-file pattern",
+      "automated theorem proving",
+      "proof-search target file"
+    ],
+    "prerequisites": [
+      "research/SORRY-CLASSIFICATION.md",
+      "Aristotle external proof search"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -57,7 +57,9 @@
       "psum_one_eq_esymm_one bridges two Mathlib lemmas (psum_one and esymm_one) that each separately state p\u2081 = \u03a3 X i = e\u2081",
       "All three corollaries work over any CommRing, not just \u211d \u2014 the algebraic structure is the only requirement",
       "The ring tactic closes each corollary after the antidiagonal is fully expanded, separating the combinatorial filtering from the algebraic simplification",
-      "The three-tactic pipeline \u2014 omega for antidiagonal arithmetic, sum_insert/sum_singleton for finite sum expansion, ring for polynomial identity \u2014 is a separable and composable proof strategy: each tactic handles exactly one layer of the proof (number theory \u2192 combinatorics \u2192 algebra)"
+      "The three-tactic pipeline \u2014 omega for antidiagonal arithmetic, sum_insert/sum_singleton for finite sum expansion, ring for polynomial identity \u2014 is a separable and composable proof strategy: each tactic handles exactly one layer of the proof (number theory \u2192 combinatorics \u2192 algebra)",
+      "**Generating-function perspective**: Newton-Girard is the logarithmic-derivative relation between two generating functions. Let $E(t) = \\prod_i (1 + x_i t) = \\sum_k e_k t^k$ and $P(t) = \\sum_{k\\ge 1} p_k t^{k-1}$. Then $\\frac{E'(t)}{E(t)} = \\sum_i \\frac{x_i}{1+x_i t} = P(-t)$, i.e. $E'(t) = E(t) \\cdot P(-t)$. Equating coefficients of $t^{k-1}$ yields exactly the Newton-Girard recurrence proved here. This is why the recurrence can be derived from a single formula in any commutative ring \u2014 it lives at the level of formal power series and has nothing to do with $\\mathbb{R}$ or analytic convergence.",
+      "**Schur-positivity bridge**: The Newton-Girard recurrence is the change-of-basis from power-sum symmetric functions $\\{p_\\lambda\\}$ to elementary symmetric functions $\\{e_\\lambda\\}$ at the level of one-row partitions. The full change-of-basis matrices (Schur in $p_\\lambda$, Schur in $e_\\lambda$ via Jacobi-Trudi) sit on top of this and explain why Schur polynomials are simultaneously polynomial in both bases. Mathlib's `MvPolynomial.Symmetric.NewtonIdentities` thus underlies any future Schur-polynomial formalization."
     ],
     "prerequisites": [
       "MvPolynomial.psum_eq_mul_esymm_sub_sum \u2014 general Newton-Girard recurrence (Mathlib)",
@@ -112,9 +114,11 @@
     "summary": "Derives three Newton-Girard corollaries (k=1,2,3) from Mathlib's general recurrence. All theorems are machine-verified with 0 sorries and 0 axiom declarations. The core results rely on Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum; original contributions are the explicit antidiagonal instantiations at k=2,3 and the bridging lemma psum_one_eq_esymm_one.",
     "implications": "**For Newton-Girard**: The three corollaries (p\u2081=e\u2081, p\u2082=e\u2081\u00b2\u22122e\u2082, p\u2083=e\u2081p\u2082\u2212e\u2082p\u2081+3e\u2083) are the foundational cases used in symmetric function theory and algebraic combinatorics.\n\n**For Symmetric Functions**: Combined with the parent's diagonal/off-diagonal decomposition, the k=2 corollary completes the Newton-Girard identity: (\u03a3x\u1d62)\u00b2 = \u03a3x\u1d62\u00b2 + 2\u00b7e\u2082.\n\n**For Mathlib Integration**: Demonstrates the pattern for instantiating the general psum_eq_mul_esymm_sub_sum recurrence at specific degrees using antidiagonal filters and omega, usable as a template for higher k.",
     "openQuestions": [
-      "Extend to k=4,5,... using the same antidiagonal template",
-      "Formalize the relationship between Newton-Girard and Schur positivity",
-      "Prove the general recurrence inductively without Mathlib, as an independent verification"
+      "Extend to k=4,5,... using the same antidiagonal template. Concretely: $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4 e_4$, requiring two `sum_insert` calls; $p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5 e_5$, requiring three. Can the pattern be turned into a `macro`/`elab` that auto-generates the proof for any user-supplied $k$?",
+      "Formalize the inverse direction (`MvPolynomial.mul_esymm_eq_sum`) at k=2,3 as named corollaries: $2 e_2 = e_1 p_1 - p_2$ and $3 e_3 = e_2 p_1 - e_1 p_2 + p_3$. Mathlib already has the general statement; the explicit corollaries would complete the symmetry with this file.",
+      "Connect to complete homogeneous symmetric polynomials $h_k = \\sum_{i_1 \\le \\ldots \\le i_k} x_{i_1} \\cdots x_{i_k}$ via the dual Newton-Girard identities $k h_k = \\sum_{j=1}^k h_{k-j} p_j$ (note the *positive* signs, in contrast to the $e_k$ version). Is `MvPolynomial.psum_eq_mul_hsymm_sub_sum` in Mathlib, or does it need to be added?",
+      "Formalize the relationship between Newton-Girard and Schur positivity. The Jacobi-Trudi formula expresses Schur polynomials $s_\\lambda = \\det(h_{\\lambda_i - i + j})$ and dually $s_\\lambda = \\det(e_{\\lambda'_i - i + j})$; combined with this file's recurrence on $e_k \\leftrightarrow p_k$, one obtains an explicit basis change between $\\{p_\\lambda\\}$ and $\\{s_\\lambda\\}$.",
+      "Prove the general recurrence inductively without Mathlib, as an independent verification — exercising the generating-function approach (`E'(t) = E(t) P(-t)`) in formal power series via `PowerSeries` in Mathlib."
     ]
   },
   "crossReferences": [
@@ -151,10 +155,39 @@
   ],
   "references": [
     {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'alg\u00e8bre",
+      "year": "1629",
+      "venue": "Amsterdam: Guillaume Iansson Blaeuw",
+      "note": "The earliest known statement of the identities relating power sums of polynomial roots to elementary symmetric polynomials \u2014 predates Newton by ~40 years. The historical attribution to Newton alone is incorrect; the modern name 'Newton-Girard identities' reflects the double discovery."
+    },
+    {
       "authors": "Newton, Isaac",
       "title": "Arithmetica Universalis",
       "year": "1707",
-      "note": "Newton's identities relating power sums to elementary symmetric polynomials. The n=2 case p\u2082 = e\u2081\u00b2 - 2e\u2082 and n=3 case p\u2083 = e\u2081p\u2082 - e\u2082p\u2081 + 3e\u2083 are proved explicitly here."
+      "venue": "Cambridge (manuscript ~1666)",
+      "note": "Newton's independent rediscovery and systematic treatment of the identities relating power sums to elementary symmetric polynomials. The k=2 case p\u2082 = e\u2081\u00b2 \u2212 2e\u2082 and k=3 case p\u2083 = e\u2081p\u2082 \u2212 e\u2082p\u2081 + 3e\u2083 are proved explicitly here."
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition, Chapter I \u00a72",
+      "note": "Canonical modern reference for symmetric function theory. The Newton-Girard identities appear as formulas (2.11\u2032) and (2.11\u2033); the generating-function derivation (E'(t)/E(t) = P(-t)) is in \u00a72.10. The Mathlib `MvPolynomial.Symmetric.NewtonIdentities` formalization follows the combinatorial approach in \u00a72."
+    },
+    {
+      "authors": "Mead, D. G.",
+      "title": "Newton's Identities",
+      "year": "1992",
+      "venue": "American Mathematical Monthly 99(8), pp. 749\u2013751",
+      "note": "Modern elementary proof of Newton's identities using only the relations between elementary symmetric polynomials and roots of a polynomial, accessible without symmetric function theory machinery."
+    },
+    {
+      "authors": "Zeilberger, Doron",
+      "title": "A Combinatorial Proof of Newton's Identities",
+      "year": "1984",
+      "venue": "Discrete Mathematics 49(3), p. 319",
+      "note": "Bijective combinatorial proof underpinning the Mathlib formalization `MvPolynomial.psum_eq_mul_esymm_sub_sum` \u2014 interprets the recurrence as an involution-based double-counting argument on sequences."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Summary

Targeted enrichment pass on the full-Newton-Girard-recurrence entry. The entry
was already well-developed (6 annotations with `mathContext`, 6 `keyInsights`,
5 sections covering the 91-line file). This pass adds depth in three directions:

- **Generating-function origin** (new keyInsight + new annotation): the proved
  recurrence is exactly the coefficient relation in $E'(t) = E(t) \cdot P(-t)$
  for the elementary-symmetric / power-sum generating functions. This explains
  why the identity holds over *any* commutative ring (formal power series, no
  analytic structure needed) and contextualizes Mathlib's combinatorial proof
  (Zeilberger 1984) as the bijective analog of the analytic argument.
- **Schur-positivity bridge** (new keyInsight): the proved recurrence is the
  one-row case of the $\{p_\lambda\} \to \{e_\lambda\}$ change-of-basis,
  underpinning Jacobi-Trudi and any future Schur-polynomial formalization on
  top of `MvPolynomial.Symmetric.NewtonIdentities`.
- **Aristotle companion documentation** (new annotation): documents the paired
  `AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean` file listed in `additionalFiles`,
  explaining the companion-file pattern for the proof-search workflow.

- **4 new references**: Girard 1629 (original, predates Newton by 40 years),
  Macdonald 1995 (canonical modern), Mead 1992 (modern elementary proof),
  Zeilberger 1984 (combinatorial proof underpinning Mathlib's API).

- **2 new openQuestions** with concrete k=4/k=5 templates, a request for the
  dual `mul_esymm_eq_sum` corollaries, the complete-homogeneous $h_k$ analog,
  and a generating-function-based independent verification using `PowerSeries`.

## What did NOT change

- Lean source untouched, schema unchanged.
- All existing annotations / sections / keyInsights / cross-references preserved.
- `lineCount`, `theoremCount`, `axiomCount`, `sorries` unchanged (91/3/0/0).

## Counts

| Field | Before | After |
|---|---|---|
| annotations | 6 | 8 |
| keyInsights | 6 | 8 |
| openQuestions | 3 | 5 |
| references | 1 | 5 |
| sections | 5 | 5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)