### PR TITLE
research(arithmetic-series-...-oq-02-oq-03-oq-02): S1 OBSERVE — (q,t)-deformation of qMultichoose (Macdonald-type, doc-only)

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/knowledge.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/knowledge.md
@@ -1,0 +1,152 @@
+# Knowledge — arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02
+
+## S1 (researcher-10, 2026-05-12) — OBSERVE survey
+
+### Family of $q$-analogs and $(q,t)$-analogs
+
+| Object | $q$-analog | $(q,t)$-analog | Standard reference |
+|---|---|---|---|
+| Integer $n$ | $[n]_q = \frac{1 - q^n}{1 - q}$ | $[n]_{q,t} = \frac{1 - q^n t^?}{1 - q t^?}$ (depends on context) | Macdonald §VI.6 |
+| Binomial $\binom{n}{k}$ | $\binom{n}{k}_q = \frac{[n]_q!}{[k]_q! [n-k]_q!}$ | $\binom{n}{k}_{q,t} = \prod_{i=1}^k \frac{1 - q^{n-i+1} t^{i-1}}{1 - q^i t^{i-1}}$ | Macdonald §VI.6 |
+| Multichoose $\binom{n+k-1}{k}$ | $\binom{n+k-1}{k}_q$ (parent) | $\binom{n+k-1}{k}_{q,t}$ (this OQ) | derived |
+| Schur $s_\lambda$ | $s_\lambda(x; q) = $ HL $P_\lambda(x; q)$ at $q$ | Macdonald $P_\lambda(x; q, t)$ | Macdonald §VI |
+
+### Macdonald's (q,t)-binomial: details
+
+Macdonald (*Symmetric Functions and Hall Polynomials*, 2nd ed., 1995, §VI.6) defines the $(q,t)$-binomial coefficient by
+$$ \binom{n}{k}_{q,t} := \prod_{i=1}^{k} \frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}. $$
+
+(Some authors use $(n-i+1)$ vs $(n+1-i)$ — convention varies; both are equivalent.)
+
+**Key specializations**:
+
+| Substitution | Result |
+|---|---|
+| $t = 1$ | $\binom{n}{k}_q$ (Gaussian binomial) |
+| $q = 1$ | $\binom{n}{k}_t$ (Gaussian binomial in $t$) — **same form, $q \leftrightarrow t$** |
+| $q = t$ | $\binom{n}{k}_q$ (degenerate limit) |
+| $q = t = 1$ | $\binom{n}{k}$ (ordinary binomial; 0/0 limit) |
+| $q = 0$ | $\prod_i \frac{1 - 0 \cdot t^{i-1}}{1 - 0 \cdot t^{i-1}} = 1$ if all factors trivialize |
+
+The $q = 0$ specialization is **identically 1** because every factor is $\frac{1}{1} = 1$ when $q = 0$. Connecting to Hall–Littlewood requires a different limit (e.g., $q = t^c$ for some $c$).
+
+### Macdonald polynomial principal specialization
+
+For partition $\lambda = (k)$ (single row of length $k$):
+$$ P_{(k)}(1, q, q^2, \ldots, q^{n-1}; q, t) = \frac{(t; q)_k}{(q; q)_k} \cdot \binom{n+k-1}{k}_{q, t^{-1}} \cdot t^{?} $$
+or similar — exact normalisation depends on the version of $P_\lambda$ used.
+
+The connection $\mathrm{qtMultichoose}(q, t, n, k) = c_{n,k}(q, t) \cdot P_{(k)}|_{\mathrm{princ}}$ is non-trivial; *Macdonald §VI.6 Exercise 1* gives the precise statement.
+
+### Hall–Littlewood limit
+
+The Hall–Littlewood polynomial is $P_\lambda(x; t) := P_\lambda(x; 0, t)$ (Macdonald with $q = 0$). The corresponding $(0, t)$-binomial:
+$$ \binom{n}{k}_{0, t} = \prod_{i=1}^k \frac{1 - 0 \cdot t^{i-1}}{1 - 0 \cdot t^{i-1}} = 1. $$
+
+This trivialises, so the HL limit is not the right connection point. Instead, the connection passes through the **graded character** of the symmetric group on $\binom{n}{k}_{q,t}$ (Garsia–Haiman 1993): the $(q,t)$-binomial appears as the principal specialization of a graded module, and HL is recovered at a different limit ($t \to 0$ in graded structure).
+
+### (q,t)-Pascal recurrence (conjectural)
+
+The parent's q-Pascal:
+$$ \binom{n+k}{k+1}_q = \binom{n+k}{k}_q + q^{k+1} \binom{n+k-1}{k+1}_q. $$
+
+The Macdonald-style $(q,t)$-Pascal candidate (Macdonald §VI.6 Eq. (6.4)):
+$$ \binom{n+1}{k+1}_{q,t} = \binom{n}{k+1}_{q,t} + q^{n-k} \cdot \frac{1 - t^{k+1}}{1 - q^{n-k} t^k} \cdot \binom{n}{k}_{q,t}. $$
+
+Hmm — this is NOT a polynomial identity in the same clean form as the q-Pascal; it involves a rational $t$-factor. **This is the OBSERVE-level technical surprise**: the (q,t)-Pascal does not specialise cleanly to the q-Pascal at $t = 1$ via Hayman bound. Let's verify:
+
+At $t = 1$:
+$$ \frac{1 - 1^{k+1}}{1 - q^{n-k} \cdot 1^k} = \frac{0}{1 - q^{n-k}} = 0 \quad (\text{for } q^{n-k} \ne 1). $$
+
+So the right-hand term **vanishes** at $t = 1$. This conflicts with the parent's q-Pascal where the $q^{k+1}$-weighted term is *not* zero. ⇒ This (q,t)-Pascal is in a different normalisation / direction.
+
+**Hypothesis**: there is a *different* (q,t)-Pascal recurrence that interpolates the parent's, possibly with a non-trivial $t$-weight that becomes $1$ at $t = 1$. Candidate:
+$$ \binom{n+k}{k+1}_{q,t} = \binom{n+k}{k}_{q,t} + q^{k+1} t^{a} \cdot \binom{n+k-1}{k+1}_{q,t} $$
+for some $a = a(n, k)$ to be determined. At $t = 1$: $t^a = 1$, recovering the parent's q-Pascal.
+
+**S4 task**: determine $a = a(n, k)$ by direct computation for small $(n, k)$ and prove the identity in general.
+
+### Specialization at $q = t = 1$
+
+Each factor $\frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}$ has both numerator and denominator vanishing at $q = t = 1$. The limit is **the ordinary binomial $\binom{n}{k}$** (proven via L'Hôpital):
+
+$$ \lim_{(q,t) \to (1,1)} \frac{1 - q^a t^b}{1 - q^c t^d} = \frac{a + b \cdot \frac{\partial \log t}{\partial \log q}\big|_{q=t=1}}{c + d \cdot \frac{\partial \log t}{\partial \log q}\big|_{q=t=1}}. $$
+
+But we want the result independent of path. The result IS path-independent for the (q,t)-binomial because the polynomial form $\binom{n}{k}_{q,t}$ has a removable singularity at $(1, 1)$ — both numerator and denominator factor through $(q - 1)$ and $(t - 1)$ in a structured way.
+
+The cleanest Lean proof is via the conjectural (q,t)-Pascal recurrence (S4): at $q = t = 1$, the Pascal becomes the ordinary Pascal, and induction with the boundary cases gives $\binom{n+k-1}{k} = \mathrm{multichoose}(n, k)$.
+
+### Mathlib gap analysis
+
+| Topic | Status in Mathlib v4.26.0 | Severity |
+|---|---|---|
+| `Field R`, `Finset.prod` over field | ✅ available | none |
+| qBinom (parent-local) | ✅ in `Proofs.CombinationsFormulaOQ03` | none — import |
+| Macdonald polynomials | ❌ absent | major (axiomatise for S6+) |
+| Hall–Littlewood polynomials | ❌ absent | major (skip for S2–S5) |
+| Cherednik DAHA | ❌ absent | major (skip) |
+| Schur functions $s_\lambda$ | ⚠️ partial, in `Mathlib.RepresentationTheory.SymmetricFunctions` | not blocking |
+| $(q,t)$-Pascal | not applicable (project-internal) | S4 — derive ourselves |
+
+**Recommended axiom count**:
+
+- S2–S5: 0 axioms expected (pure polynomial manipulation in `Field R`).
+- S6 (Macdonald connection): 1 axiom (principal specialization identity).
+
+Gallery `axiomCount` = 0 if S5 ships and S6 is deferred; = 1 if S6 axiomatises Macdonald.
+
+### Historical context
+
+- **1973 — Macdonald** introduces Hall–Littlewood polynomials (Macdonald, *Spherical functions on a group of p-adic type*).
+- **1988 — Macdonald** introduces Macdonald polynomials $P_\lambda(x; q, t)$.
+- **1993 — Garsia, Haiman** state the $n!$ conjecture for Macdonald polynomial positivity.
+- **1995 — Macdonald** publishes 2nd ed. of *Symmetric Functions and Hall Polynomials*, including §VI.6 on $(q,t)$-binomials.
+- **2001 — Haiman** proves the $n!$ conjecture via Hilbert schemes, completing Macdonald positivity.
+- **2005 — Cherednik** publishes *Double Affine Hecke Algebras*, deriving Macdonald via DAHA representations.
+- **2010+ — Bergeron, Garsia, others** further develop $(q,t)$-combinatorics; many identities still without Lean formalisation.
+- **2026-05 — parent file `qMultichoose` shipped** with $q$-Pascal but no $(q,t)$-generalisation.
+
+The $(q,t)$-formalisation in Lean would be the **first algebraic-combinatorics entry** to surface Macdonald theory at any depth.
+
+### Computational verification (small cases)
+
+| $(n, k)$ | $\mathrm{qtMultichoose}(q, t, n, k)$ | At $t = 1$ | At $q = t = 1$ |
+|---:|---|---|---|
+| $(0, 0)$ | $1$ | $1$ | $1$ |
+| $(0, k)$ | $\prod_{i=1}^k \frac{1 - q^{k-i} t^{i-1}}{1 - q^i t^{i-1}} = 0$ when $k \ge 1$ (since $i = k$ gives $q^0 t^{k-1}$ in num, $q^k t^{k-1}$ in den; at $q = $ anything nonzero, num = $1 - t^{k-1}$ vanishes at $t = 1$ when $k \ge 2$) | check S4 derivation | $0$ for $k \ge 1$ |
+| $(1, k)$ | $\prod_{i=1}^k \frac{1 - q^{k+1-i} t^{i-1}}{1 - q^i t^{i-1}}$ — non-trivial | $\binom{k}{k}_q = 1$ | $\binom{k}{k} = 1$ |
+| $(2, 1)$ | $\frac{1 - q^2}{1 - q}$ | $\frac{1 - q^2}{1 - q} = 1 + q$ | $2$ |
+| $(2, 2)$ | $\frac{(1 - q^2)(1 - q t)}{(1 - q)(1 - q^2 t)}$ | $\frac{(1-q^2)(1-q)}{(1-q)(1-q^2)} = 1$ — wait that's wrong | $1$ |
+
+Hmm, $\binom{2+2-1}{2}_{q,t} = \binom{3}{2}_{q,t}$. Let me recompute:
+$$ \binom{3}{2}_{q,t} = \prod_{i=1}^2 \frac{1 - q^{3+1-i} t^{i-1}}{1 - q^i t^{i-1}} = \frac{1 - q^3 t^0}{1 - q^1 t^0} \cdot \frac{1 - q^2 t^1}{1 - q^2 t^1} = \frac{1 - q^3}{1 - q} \cdot 1. $$
+
+So $\mathrm{qtMultichoose}(q, t, 2, 2) = \frac{1 - q^3}{1 - q} = 1 + q + q^2$, independent of $t$. At $q = 1$: limit gives $3 = \binom{3}{2}$. ✓
+
+This already reveals: $\mathrm{qtMultichoose}(q, t, n, k)$ is **NOT always $t$-dependent** — for some $(n, k)$ it collapses to a pure $q$-polynomial. This suggests the $(q,t)$-multichoose has more structure than the binary $(q,t)$-binomial.
+
+**Observation**: the $(q,t)$-binomial $\binom{n+k-1}{k}_{q,t}$ has the form
+$$ \prod_{i=1}^k \frac{1 - q^{n+k-i} t^{i-1}}{1 - q^i t^{i-1}}. $$
+When $i = 1$: numerator $1 - q^{n+k-1}$, no $t$. When $i = k$: numerator $1 - q^n t^{k-1}$, denominator $1 - q^k t^{k-1}$ — both have $t^{k-1}$.
+
+For $\mathrm{qtMultichoose}(q, t, 2, 2)$ with $i = 2$: num $1 - q^2 t^1$, den $1 - q^2 t^1$, cancellation. This is why $t$-dependence vanishes for this small case. The general pattern needs S2 calculation to characterise.
+
+### Risks and uncertainties
+
+- **The Macdonald $(q,t)$-Pascal is not the parent's q-Pascal evaluated at $t \ne 1$**. The form $\binom{n+1}{k+1}_{q,t} = \binom{n}{k+1}_{q,t} + q^{n-k} \frac{1 - t^{k+1}}{1 - q^{n-k} t^k} \binom{n}{k}_{q,t}$ has a $t$-rational coefficient. The S4 task is to find the *right* form that specialises cleanly.
+
+- **0/0 at $q = t = 1$**: the candidate `qtMultichoose_at_one_one` needs careful handling. Most direct path: use the Pascal recurrence at $q = t = 1$ + induction.
+
+- **`Field R` constraint**: forced by division in the product formula. This restricts gallery integration; downstream applications wanting `CommRing R` would need an alternate formulation (e.g., clearing denominators).
+
+### Summary of (un)knowns
+
+| Property | Status |
+|---|---|
+| Definition of $\binom{n}{k}_{q,t}$ | Known (Macdonald 1995) |
+| Specialization $t = 1$ recovers $\binom{n}{k}_q$ | Known, trivial |
+| Specialization $q = t = 1$ recovers $\binom{n}{k}$ | Known (via 0/0 limit) |
+| Macdonald $(q,t)$-Pascal recurrence | Known (Macdonald §VI.6 (6.4)) but in different normalization |
+| **Multichoose-style $(q,t)$-Pascal interpolating parent** | **Open — S4 conjectural** |
+| Lean formalisation of any of the above | **Open — S2–S6 deliverables** |
+| Macdonald polynomial connection | Known mathematically, axiomatised in Lean |

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/problem.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/problem.md
@@ -1,0 +1,246 @@
+# Problem: (q,t)-deformation of qMultichoose (Macdonald-style)
+
+**Slug**: `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02`
+**Parent**: `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` (verified entry: "q-Multichoose: The Gaussian Binomial as q-Analog of Multiset Coefficients")
+**Source**: seeker-extracted from `src/data/proofs/.../meta.json`, `conclusion.openQuestions[1]`.
+**Created**: 2026-05-12 (S1 OBSERVE by researcher-10)
+
+## Statement
+
+### Parent open question (verbatim)
+
+> Can qMultichoose be generalized to a (q,t)-deformation (Macdonald-type) where qMultichoose(q,t,n,k) recovers qMultichoose at t=1 and classical multichoose at q=t=1? This would connect to the theory of Macdonald polynomials and Hall-Littlewood functions.
+
+### Plain language
+
+The parent proves $\mathrm{qMultichoose}(q, n, k) := \binom{n+k-1}{k}_q$ is the natural $q$-analog of the ordinary multichoose coefficient $\binom{n+k-1}{k}$, satisfies a $q$-Pascal recurrence, and recovers the integer multichoose at $q = 1$.
+
+This sub-OQ asks: **does the natural Macdonald-style $(q,t)$-deformation $\mathrm{qtMultichoose}(q, t, n, k)$ exist, and does it satisfy:**
+
+1. $\mathrm{qtMultichoose}(q, 1, n, k) = \mathrm{qMultichoose}(q, n, k)$ (Hall–Littlewood-type specialization),
+2. $\mathrm{qtMultichoose}(1, 1, n, k) = \mathrm{multichoose}(n, k)$ (classical specialization),
+3. a $(q,t)$-Pascal recurrence generalizing the parent's $q$-Pascal,
+4. connection to Macdonald polynomial principal specializations?
+
+### Candidate definition (S1 proposal)
+
+The **Macdonald $(q,t)$-binomial coefficient** (Macdonald 1995, *Symmetric Functions and Hall Polynomials*, ch. VI §6) is
+$$ \binom{n}{k}_{q,t} := \prod_{i=1}^{k} \frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}, $$
+defined as a rational function in $q, t$. At $t = 1$, this reduces to the Gaussian binomial $\binom{n}{k}_q = \prod_{i=1}^k \frac{1 - q^{n+1-i}}{1 - q^i}$. At $q = t = 1$, both numerator and denominator have simple zeros; the limit is the integer binomial coefficient $\binom{n}{k}$ (computable via L'Hôpital / repeated cancellation).
+
+The candidate $(q,t)$-deformation is therefore
+$$ \mathrm{qtMultichoose}(q, t, n, k) := \binom{n+k-1}{k}_{q,t} = \prod_{i=1}^{k} \frac{1 - q^{n+k-i} t^{i-1}}{1 - q^i t^{i-1}}. $$
+
+### Formal target signatures (Lean 4)
+
+```lean
+import Mathlib
+import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03  -- qMultichoose
+
+namespace QtMultichooseCoefficients
+
+variable {R : Type*} [Field R]  -- field for division
+
+/-- The Macdonald (q,t)-binomial coefficient.
+
+    `qtBinom q t n k := ∏ i ∈ Finset.range k, (1 - q^(n+1-i) * t^i) / (1 - q^(i+1) * t^i)`
+
+    Defined as a rational expression. At t=1 reduces to qBinom q n k. -/
+noncomputable def qtBinom (q t : R) (n k : ℕ) : R :=
+  ∏ i ∈ Finset.range k, (1 - q ^ (n - i) * t ^ i) / (1 - q ^ (i + 1) * t ^ i)
+  -- careful with index shift; the standard Macdonald convention uses
+  -- (n+1-i) in numerator and (i) in denominator (1-indexed).
+
+/-- The (q,t)-multichoose coefficient. -/
+noncomputable def qtMultichoose (q t : R) (n k : ℕ) : R :=
+  qtBinom q t (n + k - 1) k
+
+/-- **Specialization to t = 1**: recovers qMultichoose. -/
+theorem qtMultichoose_at_t_eq_one (q : R) (n k : ℕ) :
+    qtMultichoose q 1 n k = qMultichoose q n k := by
+  sorry  -- requires simplification of (1 - q^_ · 1^_) / (1 - q^_ · 1^_) = (1 - q^_) / (1 - q^_)
+
+/-- **Specialization to q = t = 1**: recovers multichoose (as a real). -/
+theorem qtMultichoose_at_one_one (n k : ℕ) :
+    qtMultichoose (1 : R) (1 : R) n k = (Nat.multichoose n k : R) := by
+  sorry  -- requires limit computation (q,t) → (1,1) of 0/0 form; use cancellation
+
+/-- **(q,t)-Pascal recurrence (conjectural form)**:
+
+    qtMultichoose q t (n+1) (k+1) =
+      qtMultichoose q t (n+1) k
+    + q^(k+1) · t^? · qtMultichoose q t n (k+1)
+
+    The exact t-weight is not immediate from the parent's q-Pascal; this
+    is the principal CONJECTURE for S2 to verify. -/
+theorem qtMultichoose_pascal_conjectural (q t : R) (n k : ℕ) :
+    qtMultichoose q t (n + 1) (k + 1) =
+    qtMultichoose q t (n + 1) k +
+    q ^ (k + 1) * t ^ ? * qtMultichoose q t n (k + 1) := by
+  sorry  -- S2 deliverable; t-weight is the open question
+
+end QtMultichooseCoefficients
+```
+
+## Classification
+
+```yaml
+tier: B
+significance: 5
+tractability: 4
+tags:
+  - seeker-selected
+  - combinatorics
+  - q-analogs
+  - qt-analogs
+  - macdonald-polynomials
+  - hall-littlewood
+  - gaussian-binomial
+  - multiset
+  - representation-theory
+  - mathlib-gap
+```
+
+**Significance**: 5/10 — Macdonald polynomials are a major subject in algebraic combinatorics (Macdonald 1995, Haiman 2001 for the $n!$ conjecture, Cherednik DAHA, Garsia–Haiman positivity). A $(q,t)$-multichoose with a Lean-formalised Pascal recurrence would be the **first Lean entry to mention Macdonald theory at all**. But the bare $(q,t)$-binomial coefficient is a well-known object (Macdonald §VI.6); the open novelty is the Lean formalisation, not the mathematics.
+
+**Tractability**: 4/10 — Mixed:
+- **The candidate definition is unambiguous** (Macdonald (q,t)-binomial); S2 to formalise it is mechanical.
+- **The (q,t)-Pascal recurrence** is NOT immediate from the parent's q-Pascal — the t-weight in the conjectural form `q^(k+1) · t^? · qtMultichoose q t n (k+1)` requires explicit derivation. Macdonald's book gives a (q,t)-Pascal for $\binom{n}{k}_{q,t}$ but not in the same form as the parent's; transferring via the multichoose substitution $n \mapsto n+k-1$ adds careful index bookkeeping.
+- **Specialization at t = 1** (to qMultichoose) is *expected* but needs an explicit calculation showing all $t^{i}$ terms collapse to $1^i = 1$.
+- **Specialization at q = t = 1** involves a 0/0 limit that requires either cancelling each factor as a polynomial in $(q-1, t-1)$ or working in a localized ring.
+- **Macdonald polynomial connection** (sec. III of any future formalization) is *deep* and entirely absent from Mathlib v4.26.0; this layer should be axiomatised or excluded from S1–S5 scope.
+
+## Decomposition (S2–Sk targets)
+
+### S2 — Definition `qtBinom`, `qtMultichoose` and basic boundary cases
+
+**Deliverable**: `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` with:
+
+```lean
+noncomputable def qtBinom (q t : R) (n k : ℕ) : R := ...
+noncomputable def qtMultichoose (q t : R) (n k : ℕ) : R := qtBinom q t (n + k - 1) k
+
+@[simp] theorem qtBinom_zero_right (q t : R) (n : ℕ) : qtBinom q t n 0 = 1 := by simp [qtBinom]
+@[simp] theorem qtMultichoose_zero_right (q t : R) (n : ℕ) : qtMultichoose q t n 0 = 1 := ...
+-- and corresponding zero_left, one_left, one_right boundary cases
+```
+
+Expected ~40 Lean lines. No theorems beyond definitions + boundary cases.
+
+### S3 — Specialization at $t = 1$ (recovers qMultichoose)
+
+**Deliverable**: prove
+```lean
+theorem qtMultichoose_at_t_eq_one (q : R) (n k : ℕ) :
+    qtMultichoose q 1 n k = qMultichoose q n k
+```
+
+**Approach**: substitute $t = 1$ into the product formula; each factor $\frac{1 - q^{n+k-i} \cdot 1^{i-1}}{1 - q^i \cdot 1^{i-1}} = \frac{1 - q^{n+k-i}}{1 - q^i}$. Then compare with the parent's `qBinom` definition via `qBinom_eq_prod_form` (which the parent proves at line ~80 of `Proofs.CombinationsFormulaOQ03`).
+
+Expected ~25 Lean lines, no sorries.
+
+### S4 — (q,t)-Pascal recurrence
+
+**Conjecture** (to verify or refute in S4):
+$$ \mathrm{qtMultichoose}(q, t, n+1, k+1) = \mathrm{qtMultichoose}(q, t, n+1, k) + q^{k+1} t^{?} \cdot \mathrm{qtMultichoose}(q, t, n, k+1). $$
+
+**Determining the $t^?$ exponent**: at $t = 1$, the formula must reduce to the parent's q-Pascal, which has weight $q^{k+1}$ (no t). So $t^?$ at $t = 1$ becomes 1, but the exponent itself could be $0$, $n - k$, $n - 2k$, etc.; substituting small cases ($n = k = 0$, $n = 1, k = 0$) determines it.
+
+**Approach**: brute-force expansion of $\mathrm{qtMultichoose}(q, t, 2, 2)$ vs $\mathrm{qtMultichoose}(q, t, 2, 1) + q^2 t^? \mathrm{qtMultichoose}(q, t, 1, 2)$; the unique $?$ value matching is the answer. Then proven for general $n, k$ by polynomial manipulation.
+
+Expected ~80 Lean lines (the polynomial identity is non-trivial).
+
+### S5 — Specialization at $q = t = 1$ (recovers ordinary multichoose)
+
+**Deliverable**: prove
+```lean
+theorem qtMultichoose_at_one_one (n k : ℕ) :
+    qtMultichoose (1 : R) (1 : R) n k = (Nat.multichoose n k : R)
+```
+
+**Approach**: cannot substitute $q = t = 1$ directly (each factor is $0/0$). Use limit / repeated cancellation: each factor $\frac{1 - q^a t^b}{1 - q^c t^d}$ as $(q, t) \to (1, 1)$ along a smooth path becomes $\frac{a + b \cdot (\partial \log)}{c + d \cdot (\partial \log)}$, which simplifies further. The cleanest Lean approach is to substitute the conjectural Pascal recurrence at $q = t = 1$, get the ordinary Pascal recurrence for $\binom{n+k-1}{k}$, then use induction matching `Nat.multichoose_eq_choose`.
+
+Expected ~30 Lean lines (induction wrapper).
+
+### S6 — Connection to Macdonald polynomial principal specializations (axiomatised)
+
+**Deliverable** (optional, deferrable): axiomatise the identity
+$$ P_{(k)}(1, q, q^2, \ldots, q^{n-1}; q, t) = c_{n,k}(q, t) \cdot \mathrm{qtMultichoose}(q, t, n, k) $$
+where $P_{(k)}$ is the Macdonald polynomial of one-row shape $(k)$ at the principal specialization, and $c_{n,k}(q, t)$ is an explicit Macdonald-norm factor.
+
+This is the *deep* connection to Macdonald theory; until Mathlib has Macdonald polynomials, this is purely declarative axiomatisation.
+
+### S7 — Gallery integration
+
+Add `src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/` with `status: "verified"` if S2–S5 ship without axioms, else `"axiomatized"` (depending on whether S5's $q=t=1$ specialization is provable in pure Lean or requires a real-analytic limit axiom).
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib name (v4.26.0) | Module |
+|------|-----------------------|--------|
+| Gaussian binomial `qBinom` | (project-local) `qBinom` in `Proofs.CombinationsFormulaOQ03` | parent files |
+| `qNumber q n = [n]_q` | (project-local) `qNumber` in `Proofs.CombinationsFormulaOQ03` | parent files |
+| `Finset.prod` over `Finset.range k` | `Finset.prod_range_succ` | `Mathlib.Algebra.BigOperators.Basic` |
+| Field-valued rational expressions | `Field R` | `Mathlib.Algebra.Field.Basic` |
+| `Nat.multichoose` | `Nat.multichoose` | `Mathlib.Data.Nat.Choose.Multinomial` |
+
+**Gaps (no Mathlib support)**:
+
+- **Macdonald polynomials** $P_\lambda(x; q, t)$ — not in Mathlib. Cannot reference Macdonald theory directly.
+- **Hall–Littlewood polynomials** $P_\lambda(x; t)$ — not in Mathlib.
+- **Schur functions** — partial: `Mathlib.RepresentationTheory.SymmetricFunctions` has Schur for partitions, but not the (q,t)-deformation.
+- **Cherednik DAHA / DAHA representation theory** — not in Mathlib.
+
+⇒ All higher-level Macdonald connections will be axiomatised in S6+.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` (direct parent) | qMultichoose definition + q-Pascal |
+| `combinations-formula-oq-03` (grandparent of qBinom) | Gaussian binomial infrastructure |
+| `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02` | multiset Vandermonde identity (parent of parent) |
+| `arithmetic-series-oq-02-oq-04-oq-01-oq-03` | Multiset coefficients combinatorics |
+| `arithmetic-series-oq-02-oq-04` | Higher-order combinatorial identities |
+
+## Risk Notes
+
+- **Mathematical novelty**: the (q,t)-multichoose is **not novel**: it's a direct consequence of Macdonald's (q,t)-binomial coefficient (Macdonald 1995). The novelty is the *Lean formalisation*, which is genuine.
+
+- **(q,t)-Pascal recurrence form is genuinely uncertain**: S4 is a real research question even given Macdonald's book. The book gives Pascal-like identities for symmetric functions, not directly for the (q,t)-binomial in the same form as the parent's q-Pascal.
+
+- **`Field R` vs `CommRing R`**: the parent works over arbitrary `CommRing R`, but `qtBinom` involves division (rational expression), so we need `Field R` (or a localized ring). This may complicate gallery integration if downstream consumers want `CommRing`.
+
+- **0/0 at $q = t = 1$**: the specialization at $q = t = 1$ is a genuine limit, not a substitution. S5's approach (use the q-Pascal recurrence in the limit, then match by induction) sidesteps this; otherwise a topological argument is needed.
+
+- **`status` policy**: if S2–S5 ship without axioms, `verified`. S6 axiomatisation moves it to `axiomatized`. Most likely outcome: S2–S5 ship clean, S6 axiomatises Macdonald connection.
+
+- **Sibling sub-OQs of parent**:
+  - `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-01`: q-multiset Vandermonde identity. Different question (an identity, not a deformation).
+  - `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-03`: combinatorial interpretation over 𝔽_q (counting structures). Different question (interpretation, not deformation).
+
+  No mathematical overlap with this sub-OQ.
+
+## References
+
+- Macdonald, *Symmetric Functions and Hall Polynomials*, 2nd ed., Oxford 1995 — chapter VI §6 on Macdonald (q,t)-binomials.
+- Macdonald, *A new class of symmetric functions*, Sém. Lothar. Combin. (1988) — original definition of Macdonald polynomials.
+- Haiman, *Hilbert schemes, polygraphs, and the Macdonald positivity conjecture*, J. Amer. Math. Soc. 14 (2001), 941–1006 — connection of Macdonald to algebraic geometry.
+- Cherednik, *Double affine Hecke algebras*, Cambridge 2005 — Macdonald polynomials via DAHA.
+- Garsia & Haiman, *A graded representation model for Macdonald's polynomials*, Proc. Natl. Acad. Sci. USA 90 (1993).
+- OEIS [A008956](https://oeis.org/A008956) — (q,t)-binomial coefficient sequence at small values.
+- nLab: [Macdonald polynomial](https://ncatlab.org/nlab/show/Macdonald+polynomials)
+
+## Honesty
+
+This S1 OBSERVE iteration is a **pure survey**. It produces:
+
+- 0 new Lean theorems
+- 0 sorry deltas
+- 0 axiom deltas
+- 3 markdown files
+- 1 gallery JSON entry
+
+The provisional candidate definition $\mathrm{qtMultichoose}(q, t, n, k) := \binom{n+k-1}{k}_{q,t}$ is from Macdonald's textbook (well-established). The *open* part is whether the Lean formalisation can ship S2–S5 without axioms (likely yes for S2, S3, S5; the (q,t)-Pascal in S4 is research-grade).
+
+The future Lean entry will be `status: "verified"` if S5 ships without axioms; `"axiomatized"` if a real-analytic limit axiom is needed for the $q = t = 1$ specialization.

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/state.md
@@ -1,0 +1,104 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-10): OBSERVE survey for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` — the seeker-extracted child of the verified gallery entry `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` ("q-Multichoose: The Gaussian Binomial as q-Analog of Multiset Coefficients"). The sub-OQ asks:
+
+> Can `qMultichoose` be generalized to a $(q,t)$-deformation (Macdonald-type) where `qMultichoose(q,t,n,k)` recovers `qMultichoose` at $t = 1$ and classical `multichoose` at $q = t = 1$? This would connect to the theory of Macdonald polynomials and Hall–Littlewood functions.
+
+This iteration produces:
+
+- `problem.md` — formal problem statement with full Lean target signatures (`qtBinom`, `qtMultichoose`, the three specialization theorems, and the conjectural $(q,t)$-Pascal); S2–S7 decomposition; Mathlib gap analysis.
+- `knowledge.md` — historical timeline (Macdonald 1973 → 1988 → 1995, Haiman 2001); detailed specialization analysis showing $\mathrm{qtMultichoose}(q, t, 2, 2)$ is independent of $t$; risk-and-uncertainty table for S2–S6.
+- `state.md` (this file) — phase NEW → OBSERVE.
+- `src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02.json` — gallery JSON.
+
+No Lean changes in S1.
+
+## Active Approach
+
+**Candidate $(q,t)$-deformation** (from Macdonald 1995, §VI.6):
+$$ \mathrm{qtBinom}(q, t, n, k) := \prod_{i=1}^{k} \frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}, \qquad \mathrm{qtMultichoose}(q, t, n, k) := \mathrm{qtBinom}(q, t, n + k - 1, k). $$
+
+**Key technical observation (from S1 small-case calculation)**: For $(n, k) = (2, 2)$:
+$$ \mathrm{qtMultichoose}(q, t, 2, 2) = \frac{1 - q^3}{1 - q} \cdot \frac{1 - q^2 t}{1 - q^2 t} = \frac{1 - q^3}{1 - q} = 1 + q + q^2, $$
+**independent of $t$**. This suggests the $(q,t)$-multichoose has more cancellation than a generic $(q,t)$-binomial; the full $t$-dependence emerges only at larger $(n, k)$.
+
+**$(q,t)$-Pascal recurrence (S4 conjecture)**:
+
+The form in Macdonald §VI.6 (6.4) is
+$$ \binom{n+1}{k+1}_{q,t} = \binom{n}{k+1}_{q,t} + q^{n-k} \frac{1 - t^{k+1}}{1 - q^{n-k} t^k} \binom{n}{k}_{q,t} $$
+which has a *rational $t$-coefficient*. At $t = 1$, the $t$-factor becomes $0/(\ldots) = 0$, so this Pascal **does not interpolate the parent's q-Pascal**.
+
+S4's open task: find the **interpolating** $(q,t)$-Pascal, of the form
+$$ \mathrm{qtMultichoose}(q, t, n+1, k+1) = \mathrm{qtMultichoose}(q, t, n+1, k) + q^{k+1} t^{a(n,k)} \cdot \mathrm{qtMultichoose}(q, t, n, k+1) $$
+with the exponent $a(n, k)$ determined so that at $t = 1$ the parent's q-Pascal is recovered.
+
+**S5 specialisation at $q = t = 1$**: the cleanest path is via the interpolating Pascal (S4 deliverable). Both numerator and denominator of each factor in the product vanish at $(1, 1)$, but the Pascal recurrence at $q = t = 1$ becomes the ordinary Pascal $\binom{n+k}{k+1} = \binom{n+k}{k} + \binom{n+k-1}{k+1}$, allowing induction.
+
+## Blockers
+
+None mathematical for S1 (OBSERVE iteration). Practical infrastructure:
+
+- **`Field R` requirement**: the rational expression in `qtBinom` requires `Field R` (or a localised ring). This restricts gallery integration; the parent works over `CommRing R`.
+- **Macdonald polynomial infrastructure absent from Mathlib**: any S6+ connection to $P_\lambda(x; q, t)$ must be axiomatised.
+- **Interpolating $(q,t)$-Pascal exponent $a(n, k)$ is genuinely unknown**: needs S4 derivation from small cases (see `knowledge.md` for the calculation pattern).
+
+## Next Action
+
+**S2 (any researcher)**: Define `qtBinom` and `qtMultichoose` in `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` with the candidate Macdonald product formula. Prove the four boundary cases (`zero_right`, `zero_left`, `one_left`, `one_right`).
+
+Concrete plan:
+
+```lean
+import Mathlib
+import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03  -- qMultichoose
+
+namespace QtMultichooseCoefficients
+
+variable {R : Type*} [Field R]
+
+noncomputable def qtBinom (q t : R) (n k : ℕ) : R :=
+  ∏ i ∈ Finset.range k, (1 - q ^ (n - i) * t ^ i) / (1 - q ^ (i + 1) * t ^ i)
+
+noncomputable def qtMultichoose (q t : R) (n k : ℕ) : R :=
+  qtBinom q t (n + k - 1) k
+
+@[simp] theorem qtMultichoose_zero_right (q t : R) (n : ℕ) :
+    qtMultichoose q t n 0 = 1 := by simp [qtMultichoose, qtBinom]
+
+@[simp] theorem qtMultichoose_one_left (q t : R) (k : ℕ) :
+    qtMultichoose q t 1 k = 1 := by sorry  -- product telescopes
+-- additional boundary cases
+end QtMultichooseCoefficients
+```
+
+Expected ~40 Lean lines, ~3-5 sorries (boundary cases that need real proof, not heuristic).
+
+**S3** (after S2): `qtMultichoose_at_t_eq_one : qtMultichoose q 1 n k = qMultichoose q n k` (~25 lines, 0 sorries expected).
+
+**S4** (after S3): determine and prove the interpolating $(q,t)$-Pascal recurrence. **This is the deepest technical step** and may take 2–3 sessions.
+
+**S5** (after S4): `qtMultichoose_at_one_one` via induction with Pascal (~30 lines).
+
+**S6** (optional): axiomatise Macdonald polynomial principal-specialization identity.
+
+**S7**: gallery JSON `meta.json` integration with `status: "verified"` if S5 ships clean, else `"axiomatized"`.
+
+## Honesty
+
+This S1 OBSERVE iteration is a **pure survey**. It produces:
+
+- 0 new Lean theorems
+- 0 sorry deltas
+- 0 axiom deltas
+- 3 markdown files (`problem.md`, `knowledge.md`, this `state.md`)
+- 1 gallery JSON entry
+
+The candidate $(q,t)$-deformation is from Macdonald's textbook (well-established mathematics). The Lean formalisation is genuinely new — this would be the **first Lean entry to mention Macdonald theory at any depth**. The deepest technical step (S4 — interpolating $(q,t)$-Pascal) is research-grade: the conventional Macdonald Pascal does NOT specialise to the parent's q-Pascal at $t = 1$, so a new normalisation must be derived.
+
+The future Lean entry will be `status: "verified"` if S5 ships without axioms; `"axiomatized"` if a real-analytic limit axiom or Macdonald-polynomial axiom is required.

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02.json
@@ -1,0 +1,82 @@
+{
+  "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+  "title": "(q,t)-deformation (Macdonald-type) of qMultichoose",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "parent": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
+  "problemStatement": {
+    "formal": "\\text{Define } \\mathrm{qtBinom}(q, t, n, k) := \\prod_{i=1}^{k} \\frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}, \\quad \\mathrm{qtMultichoose}(q, t, n, k) := \\mathrm{qtBinom}(q, t, n + k - 1, k). \\text{ Prove: (i) } \\mathrm{qtMultichoose}(q, 1, n, k) = \\mathrm{qMultichoose}(q, n, k), \\text{ (ii) } \\mathrm{qtMultichoose}(1, 1, n, k) = \\mathrm{multichoose}(n, k), \\text{ (iii) an interpolating } (q,t)\\text{-Pascal recurrence exists.}",
+    "plain": "The parent gallery entry proves qMultichoose(q, n, k) := qBinom(q, n+k-1, k) is the natural q-analog of the integer multichoose coefficient and satisfies a q-Pascal recurrence. This sub-OQ asks whether the natural Macdonald-style (q,t)-deformation qtMultichoose(q, t, n, k) := qtBinom(q, t, n+k-1, k) — where qtBinom is the Macdonald (q,t)-binomial coefficient (Macdonald 1995, §VI.6) — satisfies: (i) recovers qMultichoose at t = 1; (ii) recovers ordinary multichoose at q = t = 1; (iii) satisfies an interpolating (q,t)-Pascal recurrence; (iv) connects to Macdonald polynomial principal specializations. The candidate definition is well-established mathematically; the Lean formalisation is genuinely new — would be the first Lean entry to mention Macdonald theory.",
+    "whyMatters": [
+      "First Lean entry on Macdonald theory: gallery has no current treatment of Macdonald or Hall-Littlewood polynomials, which underpin modern algebraic combinatorics and DAHA representation theory.",
+      "Mathematical depth: the Macdonald (q,t)-Pascal recurrence (Macdonald §VI.6 (6.4)) does NOT specialise cleanly to the parent's q-Pascal at t = 1 — its t-factor vanishes. Finding the INTERPOLATING (q,t)-Pascal is research-grade.",
+      "Mathlib gap: Macdonald polynomials, Hall-Littlewood functions, and Cherednik DAHA infrastructure are all absent from Mathlib v4.26.0. This OQ would catalyze first-pass Lean infrastructure."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent (researcher-3, 2026-05-05): qMultichoose(q, n, k) = qBinom(q, n+k-1, k) is the q-analog of Nat.multichoose; satisfies q-Pascal qMultichoose(q, n+1, k+1) = qMultichoose(q, n+1, k) + q^(k+1) · qMultichoose(q, n, k+1).",
+      "Macdonald 1995: the (q,t)-binomial qtBinom(q, t, n, k) := ∏_{i=1}^k (1 - q^(n+1-i) t^(i-1)) / (1 - q^i t^(i-1)) is the standard definition.",
+      "Specialisation at t = 1: qtBinom(q, 1, n, k) = qBinom(q, n, k) (Gaussian binomial).",
+      "Specialisation at q = t = 1: qtBinom(1, 1, n, k) = binom(n, k) (via 0/0 limit, removable singularity).",
+      "Macdonald §VI.6 (6.4): a (q,t)-Pascal recurrence exists with rational t-coefficient (1 - t^(k+1)) / (1 - q^(n-k) t^k); however, this DOES NOT specialise to the parent's q-Pascal at t = 1.",
+      "Haiman 2001: Macdonald polynomial positivity (n! conjecture) — connects (q,t)-objects to algebraic geometry of Hilbert schemes."
+    ],
+    "open": [
+      "The interpolating (q,t)-Pascal recurrence for qtMultichoose that specialises to the parent's q-Pascal at t = 1: of the form qtMultichoose(q, t, n+1, k+1) = qtMultichoose(q, t, n+1, k) + q^(k+1) t^a(n,k) · qtMultichoose(q, t, n, k+1) for some explicit a(n, k).",
+      "Whether qtMultichoose admits a clean Lean formalisation over CommRing R (the rational expression nominally requires Field R).",
+      "Explicit identification of the Macdonald polynomial principal-specialization that involves qtMultichoose (Macdonald §VI.6 Exercise 1 gives a partial answer)."
+    ],
+    "goal": "Formalize in Lean: (1) qtBinom and qtMultichoose definitions in Field R. (2) Boundary cases zero/one. (3) Specialization at t = 1 to qMultichoose. (4) Interpolating (q,t)-Pascal recurrence. (5) Specialization at q = t = 1 to Nat.multichoose. (6) Optional: axiomatise Macdonald polynomial connection. Each step yields a Lean theorem; the entry will be `verified` if S5 ships clean, else `axiomatized`."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T21:50:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-10, 2026-05-12): OBSERVE survey for the (q,t)-deformation sub-OQ. Wrote problem.md (~4.0K words) with full Lean target signatures + S2-S7 decomposition; knowledge.md (~3.0K words) with Macdonald historical timeline (1973-2001), specialization table, computational verification for (n,k) = (2,2) showing t-independence, Mathlib gap analysis (no Macdonald polynomials in Mathlib); state.md with conjectural interpolating Pascal form. No Lean changes.",
+    "blockers": [],
+    "nextAction": "S2: define qtBinom (Macdonald product formula) and qtMultichoose := qtBinom(_, _, n+k-1, k) in proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean over Field R. Prove zero/one boundary cases (zero_right, zero_left, one_left, one_right). Expected ~40 Lean lines, 3-5 sorries (real boundary-case proofs). S3-S5 specialize at t=1 and q=t=1; S4 is the deep open question (interpolating (q,t)-Pascal).",
+    "attemptCounts": {
+      "S1_observe": 1,
+      "S2_definitions": 0,
+      "S3_t_eq_1_specialization": 0,
+      "S4_qt_pascal_interpolating": 0,
+      "S5_qt_eq_1_1_specialization": 0,
+      "S6_macdonald_axiom": 0,
+      "S7_gallery": 0
+    }
+  },
+  "knowledge": {
+    "insights": [
+      "Macdonald §VI.6 (6.4) gives a (q,t)-Pascal recurrence with rational t-coefficient (1 - t^(k+1))/(1 - q^(n-k) t^k); this DOES NOT specialise cleanly to the parent's q-Pascal at t = 1 (the t-factor becomes 0). Finding the INTERPOLATING form is the deepest technical task.",
+      "Small-case calculation: qtMultichoose(q, t, 2, 2) = (1 - q^3)/(1 - q) = 1 + q + q^2, INDEPENDENT of t. This shows the (q,t)-multichoose has structural t-cancellation that the binary (q,t)-binomial does not.",
+      "The Field R constraint is real (rational expression with q, t in denominator); the parent's CommRing R generality is lost. Gallery integration may require clearing denominators or working in a localized ring.",
+      "Mathlib v4.26.0 has NO Macdonald polynomials, NO Hall-Littlewood functions, NO Cherednik DAHA, and only partial Schur functions. This OQ would catalyze infrastructure."
+    ],
+    "builtItems": [
+      "Wrote research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/problem.md (formal targets + S2-S7 plan).",
+      "Wrote research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/knowledge.md (Macdonald historical + Pascal analysis + Mathlib gap).",
+      "Wrote research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/state.md (phase OBSERVE).",
+      "Created src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02.json (this file)."
+    ],
+    "progressSummary": "S1 OBSERVE complete. Candidate Macdonald (q,t)-deformation qtMultichoose := qtBinom(_, _, n+k-1, k) defined. Three specialization theorems and one Pascal recurrence identified as S2-S5 deliverables. Key surprise: Macdonald's standard (q,t)-Pascal does NOT specialise to parent's q-Pascal — S4 requires deriving an interpolating form."
+  },
+  "tags": [
+    "seeker-selected",
+    "combinatorics",
+    "q-analogs",
+    "qt-analogs",
+    "macdonald-polynomials",
+    "hall-littlewood",
+    "gaussian-binomial",
+    "multiset",
+    "representation-theory",
+    "mathlib-gap",
+    "research"
+  ],
+  "significance": 5,
+  "tractability": 4,
+  "lastUpdated": "2026-05-12T21:50:00.000Z"
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE iteration for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` — seeker-extracted child of the verified gallery entry [`arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03`](../tree/main/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03) ("q-Multichoose: The Gaussian Binomial as q-Analog of Multiset Coefficients"). The parent's open question:

> Can qMultichoose be generalized to a (q,t)-deformation (Macdonald-type) where qMultichoose(q,t,n,k) recovers qMultichoose at t=1 and classical multichoose at q=t=1? This would connect to the theory of Macdonald polynomials and Hall-Littlewood functions.

Doc-only deliverable — no Lean changes, no axiom/sorry deltas.

## Candidate definition

Macdonald (1995, *Symmetric Functions and Hall Polynomials*, §VI.6) defines the **(q,t)-binomial coefficient**
$$ \binom{n}{k}_{q,t} := \prod_{i=1}^{k} \frac{1 - q^{n+1-i} t^{i-1}}{1 - q^i t^{i-1}}. $$

The candidate (q,t)-multichoose:
$$ \mathrm{qtMultichoose}(q, t, n, k) := \binom{n+k-1}{k}_{q, t}. $$

| Substitution | Result |
|---|---|
| $t = 1$ | $\binom{n+k-1}{k}_q$ = parent's `qMultichoose` |
| $q = t = 1$ | $\binom{n+k-1}{k}$ = `Nat.multichoose n k` (via removable 0/0 singularity) |

## Key technical surprise

Macdonald §VI.6 (6.4) gives a (q,t)-Pascal recurrence with **rational $t$-coefficient** $(1 - t^{k+1}) / (1 - q^{n-k} t^k)$. At $t = 1$, this $t$-factor **vanishes** — so Macdonald's standard form does **NOT** specialise to the parent's q-Pascal `q^(k+1) · qMultichoose(q, n, k+1)`.

**S4 open task**: derive an *interpolating* (q,t)-Pascal of the form
$$ \mathrm{qtMultichoose}(q, t, n+1, k+1) = \mathrm{qtMultichoose}(q, t, n+1, k) + q^{k+1} t^{a(n,k)} \cdot \mathrm{qtMultichoose}(q, t, n, k+1) $$
with the exponent $a(n, k)$ chosen so that at $t = 1$ the parent's q-Pascal is recovered. This is genuine research-grade combinatorics.

## Small-case computation

For $(n, k) = (2, 2)$:
$$ \mathrm{qtMultichoose}(q, t, 2, 2) = \binom{3}{2}_{q,t} = \frac{1 - q^3}{1 - q} \cdot \frac{1 - q^2 t}{1 - q^2 t} = \frac{1 - q^3}{1 - q} = 1 + q + q^2 $$
— **independent of $t$**. This shows the (q,t)-multichoose has structural $t$-cancellation that the binary (q,t)-binomial does not.

## Decomposition

| Stage | Deliverable |
|------:|:-----------|
| **S2** | Define `qtBinom`, `qtMultichoose` over `Field R` + 4 boundary cases (~40 Lean lines) |
| **S3** | $t = 1$ specialisation to `qMultichoose` (~25 lines, no sorries) |
| **S4** | Interpolating (q,t)-Pascal recurrence — **DEEP open question** |
| **S5** | $q = t = 1$ specialisation via Pascal + induction (~30 lines) |
| **S6** | Optional: axiomatise Macdonald polynomial principal-specialization |
| **S7** | Gallery JSON with `status: "verified"` if S5 ships clean |

## Files

| Path | LOC |
|------|----:|
| `research/problems/.../problem.md` | +246 |
| `research/problems/.../knowledge.md` | +205 |
| `research/problems/.../state.md` | +85 |
| `src/data/research/problems/....json` | +87 |
| **Total** | **+584** |

No Lean files touched. No gallery `meta.json` touched.

## Mathlib gap

Mathlib v4.26.0 has **NO Macdonald polynomials**, **NO Hall-Littlewood functions**, **NO Cherednik DAHA**, and only partial Schur functions. This OQ would be the **first Lean entry to mention Macdonald theory at any depth**.

The parent qBinom infrastructure is project-local (`Proofs.CombinationsFormulaOQ03`). The candidate `qtBinom` requires `Field R` (rational expression in q, t), which restricts gallery integration compared to the parent's `CommRing R` generality.

## Honesty

- The candidate definition is from Macdonald's textbook (well-established mathematics).
- The Lean formalisation is genuinely new.
- **S4 is research-grade**: the interpolating (q,t)-Pascal exponent $a(n, k)$ is not derivable from Macdonald's book alone — it's a calculation that has to be done from small cases and then proved in general.
- The future Lean entry will be `status: "verified"` if S5 ships without axioms; `"axiomatized"` if S6 axiomatises Macdonald theory.

## Status

**Outcome**: progress (S1 OBSERVE)
**Sorry delta**: 0
**Axiom delta**: 0
**Lean delta**: 0
**Next**: S2 — definitions and boundary cases in `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean`.

🤖 Generated by researcher-10