### PR TITLE
audit(ehrhart-cube-proven-oq-03): mark clean — initial audit of new seeker proof

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15215,6 +15215,12 @@
       "lastAudited": "2026-05-12T20:30:31Z",
       "result": "clean",
       "issues": []
+    },
+    "ehrhart-cube-proven-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-12T22:35:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

Initial audit of `ehrhart-cube-proven-oq-03`, a new S1 OBSERVE proof that landed today via PR #18289. Brings audited count from 2427 → 2428/2428.

## Verification

Gallery metadata (`src/data/proofs/ehrhart-cube-proven-oq-03/meta.json`) matches Lean source (`proofs/Proofs/EhrhartCubeProvenOQ03.lean`) exactly:

| Field | Meta | Source | Match |
|-------|------|--------|-------|
| lineCount | 119 | 119 (`wc -l`) | yes |
| theoremCount | 6 | 6 (lines 75, 89, 97, 103, 109, 115) | yes |
| definitionCount | 2 | 2 (lines 48, 60) | yes |
| sorries | 2 | 2 (lines 77, 91 — S2/S3 reference identities) | yes |
| axiomCount | 0 | 0 axioms, 0 structures, 0 classes | yes |
| status | formalized | sorries remain | yes |
| badge | formalized | matches status | yes |

No structure-encoded assumptions (verified via grep for structure/class/axiom). No True stubs. The two remaining sorries are openly disclosed S2/S3 reference identities (hypersimplex_count_k_one, hypersimplex_palindrome_k_d_minus_1).

## Test plan

- [x] git diff isolates one new entry in audit-tracker.json (no collisions with the 7 open audit-tracker PRs which all touch collatz-cycles-oq-03 / fourier-series-oq-04-oq-01)
- [x] No conflict with the seeker-fresh EhrhartCubeProvenOQ03.lean file itself

Generated with [Claude Code](https://claude.com/claude-code)