### PR TITLE
research(erdos-735-oq-04): S1 OBSERVE — k-flat magic configurations in ℝ^d (Erdős #735, doc-only)

### DIFF
--- a/research/problems/erdos-735-oq-04/knowledge.md
+++ b/research/problems/erdos-735-oq-04/knowledge.md
@@ -1,0 +1,120 @@
+# Knowledge — erdos-735-oq-04
+
+## S1 (researcher-10, 2026-05-12) — OBSERVE survey
+
+### Parent ABKPR 2008 four classes (recap)
+
+In $\mathbb{R}^2$, exactly four families of point configurations are magic (admit positive weights making all line-sums equal):
+
+1. **All collinear** — only one line, any positive weighting works.
+2. **General position** — no 3 collinear. By Beck's theorem, $\Omega(n^2)$ lines; uniform weighting $w_i = 1/(n-1)$ makes each line-sum = 2.
+3. **Near-pencil** — $n - 1$ points on a line $L$ and 1 off-line point $p_0$. Weights chosen so the heavy line $L$ sum equals each $p_0$-line sum.
+4. **Triangle + bisectors + incenter** — Murty's projective family.
+
+ABKPR 2008 proves these are the ONLY classes.
+
+### Extension to $\mathbb{R}^d$, $k = 1$ (lines in higher dim)
+
+For $d \ge 3$, the analogous question:
+- "All collinear" generalises: every $\mathbb{R}^d$ configuration on a 1-flat is magic.
+- "General position (no 3 collinear)" generalises: lines through ≥ 2 points are still well-defined; weight $w_i = 1/(n-1)$ makes each line-sum = 2 (using only 2-point lines).
+- "Near-pencil" generalises.
+- "Triangle + bisectors + incenter" likely has analogues but **the exact form is not known to the author**.
+
+### Extension to $k$-flats, $k \ge 2$
+
+In $\mathbb{R}^3$ with $k = 2$ (planes containing ≥ 3 configuration points):
+
+**Example 1 — Tetrahedron** ($n = 4$, $d = 3$): 4 triangular faces, each containing exactly 3 vertices. Each pair of vertices determines an edge (a 1-flat). With uniform $w_i = 1$, each face-sum = 3, achieving the magic property for $k = 2$ trivially.
+
+**Example 2 — Octahedron** ($n = 6$): 6 antipodal vertices at $\pm e_i$ for $i = 1, 2, 3$. 8 triangular faces; each face contains exactly 3 vertices (one from each axis). Uniform $w_i = 1 \Rightarrow$ each face-sum = 3. ✓
+
+**Example 3 — Cube** ($n = 8$): 6 face planes, each containing 4 vertices. Uniform $w_i = 1 \Rightarrow$ each face-sum = 4. ✓
+
+**Example 4 — General position in $\mathbb{R}^3$** ($n$ points, no 4 coplanar): every 3-subset spans a unique plane. By the same Beck-type counting as the 2D case, uniform weights work.
+
+These suggest that for $k = 2, d = 3$, the magic class includes:
+- All coplanar (≡ "all collinear" trivially holds for 2-flats).
+- General position (no 4 coplanar).
+- Near-coplanar ($n - 1$ in a 2-flat).
+- Regular convex polytopes (tetra, octa, cube, icosahedron).
+- Likely a "triangle + 3D analogue" Murty-type construction.
+
+### Trivial cases
+
+- $k = 0$: every point is a 0-flat; the constraint is "each point's weight is the magic constant" → uniform weighting $w_i = c$ works.
+- $k = d$: only one $d$-flat (the ambient space) contains all $n$ points; constraint is "total weight = $c$" → any positive weighting works.
+
+These should be theorems (not axioms) in S3.
+
+### Reduction to parent
+
+For $d = 2, k = 1$: a 1-flat in $\mathbb{R}^2$ is a line. The configurations match the parent's `ConfigLine`, so `IsKFlatMagic 1 P ↔ Erdos735.IsMagic P` is **definitional**. Use `unfold` + `rfl` after careful name-alignment.
+
+### Mathlib coverage
+
+| Object | Mathlib v4.26.0 |
+|---|---|
+| `EuclideanSpace ℝ (Fin d)` | ✅ |
+| `AffineSubspace`, direction, rank | ✅ |
+| `Finset.sum`, `Finset.filter` | ✅ |
+| `ABKPR 2008 classification` | ❌ (parent axiomatises) |
+| Higher-flat magic classification | ❌ |
+| `IsCollinear` for ≥ 3 dim | ❌ in this form; need to introduce |
+
+The parent's `IsMagic`, `IsCollinear`, `IsGeneralPosition` are project-local (`Proofs.Erdos735Problem`); they generalise straightforwardly.
+
+### Combinatorial counting
+
+For $k$-flat magic in $\mathbb{R}^d$ with $n$ points in general position (no $k+2$ on a $k$-flat):
+- Number of $k$-flats: $\binom{n}{k+1}$ (one per minimal-spanning $(k+1)$-subset).
+- Each $k$-flat contains exactly $k+1$ points.
+- Uniform weight $w_i = c / (k+1) \Rightarrow$ each flat-sum = $c$. ✓
+
+Hence **general position in $\mathbb{R}^d$ is always $k$-flat magic** for any $1 \le k \le d-1$ — a uniform weighting trivially works.
+
+The interesting non-trivial cases are when some $k$-flats contain *more* than $k+1$ points (giving constraints beyond uniformity).
+
+### Why uniform weighting may not generalize
+
+For the parent's case (k = 1, d = 2):
+- Some lines have many points (configurations where ≥ 3 are collinear).
+- A line $L$ with $m$ collinear points and a line $L'$ with 2 points: uniform weight gives sum $m$ vs sum $2$ — unequal.
+
+ABKPR's classification identifies which configurations CAN be balanced with *non-uniform* positive weights. The 4-class result says these are precisely 4 families.
+
+For $k$-flats in higher dim, the analogous question:
+- When can non-uniform positive weights balance flats of different cardinalities?
+
+This is the **core open question** S5+ axiomatises.
+
+### Historical note
+
+- **1978 — Murty** conjectures the 4-class characterisation in $\mathbb{R}^2$.
+- **1981 — Erdős** publishes the problem as #735.
+- **1995 — Beck, Sokol** prove partial results.
+- **2008 — Ackerman, Buchin, Knauer, Pinchasi, Rote** prove the full classification (ABKPR).
+- **Higher dim / k-flats**: open since 2008.
+
+### Sibling sub-OQ comparison
+
+Parent's 4 sub-OQs:
+
+1. `oq-01`: characterisations in $\mathbb{R}^3$ — closely related to this OQ but with $k = 1$ (lines).
+2. `oq-02`: non-positive / complex / integer weights — algebraic variant.
+3. `oq-03`: computational complexity (LP recognition).
+4. **`oq-04` (this)**: $k$-flat variant.
+
+Mathematical overlap with oq-01: both ask about $\mathbb{R}^3$. But oq-01 is line-magic, this is k-flat-magic. Could share definitions but separate classification.
+
+### Summary
+
+| Component | Status |
+|---|---|
+| Definitions (`PointConfigD`, `WeightingD`, `ConfigKFlat`, `IsKFlatMagic`) | Mechanical (S2) |
+| Trivial cases ($k = 0, k = d$) | Easy (S3) |
+| Reduction to parent ($k = 1, d = 2$) | Easy (S4) |
+| Concrete polytope examples ($k = 2, d = 3$) | `native_decide`-able (S6) |
+| Higher-dim classification (extension of ABKPR) | Open research (S5 axiom) |
+
+Estimated total Lean: ~150 lines across the OQ chain, 1-2 axioms.

--- a/research/problems/erdos-735-oq-04/problem.md
+++ b/research/problems/erdos-735-oq-04/problem.md
@@ -1,0 +1,209 @@
+# Problem: Magic configurations on k-flats in $\mathbb{R}^d$ (Erdős #735 extension)
+
+**Slug**: `erdos-735-oq-04`
+**Parent**: `erdos-735` (verified gallery entry: "Erdős Problem #735: Magic Configurations")
+**Source**: seeker-extracted from `src/data/proofs/erdos-735/meta.json`, `conclusion.openQuestions[3]`.
+**Created**: 2026-05-12 (S1 OBSERVE by researcher-10)
+
+## Statement
+
+### Parent open question (verbatim)
+
+> Does the classification extend to configurations where the equal-sum constraint is imposed on k-flats instead of lines?
+
+### Plain language
+
+The parent `erdos-735` solves Erdős's *magic configurations* problem in $\mathbb{R}^2$: given $n$ points, when can one assign positive weights such that every line through ≥ 2 points has the same weight-sum? **Solution (Ackerman–Buchin–Knauer–Pinchasi–Rote 2008)**: exactly four families — all collinear; general position (no 3 collinear); near-pencil ($n-1$ on a line); triangle with angle bisectors + incenter.
+
+This sub-OQ asks the natural higher-flat extension: replace "line" (a 1-flat) with a $k$-flat (affine subspace of dimension $k$) in $\mathbb{R}^d$. **For which $(d, k, n)$ triples does an analogous classification exist?**
+
+### Hierarchy of cases
+
+| $k$ | $d$ | Condition on $k$-flats | Classification status |
+|----:|---:|:----------------------|:----------------------|
+| 0 | any | every point's weight equals itself | trivial — any positive weighting works |
+| 1 | 2 | every line through ≥ 2 points has equal sum | **Parent's case (ABKPR08)** — 4 classes |
+| 1 | $\ge 3$ | every line in $\mathbb{R}^d$ through ≥ 2 points has equal sum | **OPEN — extension of parent to higher ambient dim** |
+| 2 | 3 | every plane through ≥ 3 points has equal sum | **OPEN — this sub-OQ's primary case** |
+| 2 | $\ge 4$ | every 2-flat through ≥ 3 points has equal sum | OPEN |
+| $k = d-1$ | $d$ | every hyperplane through "enough" points has equal sum | OPEN |
+| $k = d$ | $d$ | the unique full space contains all points (trivial) | trivial |
+
+The most natural new question: **classify $(d, k, n)$ such that $k$-flat-magic configurations are non-trivial in $\mathbb{R}^d$**.
+
+### Formal Lean target signatures
+
+```lean
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Proofs.Erdos735Problem  -- parent
+
+namespace Erdos735OQ04
+
+/-- A point configuration in `ℝ^d`. -/
+def PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))
+
+/-- A weighting assigns a positive real to each point. -/
+def WeightingD {d : ℕ} (P : PointConfigD d) := {w : P → ℝ // ∀ p, w p > 0}
+
+/-- A `k`-flat determined by the configuration: an affine subspace of dimension
+exactly `k` containing at least `k+1` configuration points (the minimum for it
+to be a "determined" k-flat). -/
+def ConfigKFlat {d : ℕ} (k : ℕ) (P : PointConfigD d) :=
+  { F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)) //
+    F.direction.toSubmodule.rank = k ∧
+    (P.filter (· ∈ F)).card ≥ k + 1 }
+
+/-- Sum of weights on a `k`-flat. -/
+def kFlatSum {d k : ℕ} (P : PointConfigD d) (w : WeightingD P) (F : ConfigKFlat k P) : ℝ :=
+  (P.filter (· ∈ F.val)).sum fun p =>
+    if h : p ∈ P then w.val ⟨p, h⟩ else 0
+
+/-- A configuration is `k`-flat magic if positive weights exist so all `k`-flats
+have equal sum. -/
+def IsKFlatMagic {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop :=
+  ∃ w : WeightingD P, ∃ c > 0, ∀ F : ConfigKFlat k P, kFlatSum P w F = c
+
+/-- **Trivial case k = 0**: every configuration is 0-flat magic. -/
+theorem zero_flat_magic_trivial {d : ℕ} (P : PointConfigD d) (hP : P.Nonempty) :
+    IsKFlatMagic 0 P := by
+  sorry  -- 0-flats are points; any positive weighting trivially satisfies the constraint
+
+/-- **Trivial case k = d**: every configuration is d-flat magic (one flat covers all). -/
+theorem ambient_flat_magic_trivial {d : ℕ} (P : PointConfigD d) (hP : P.Nonempty) :
+    IsKFlatMagic d P := by
+  sorry  -- d-flat is the ambient space; sum is total weight, equal trivially
+
+/-- **Reduction to parent (k = 1, d = 2)**: `IsKFlatMagic 1 P = IsMagic P`
+when the ambient is ℝ². -/
+theorem oneflat_eq_parent (P : PointConfigD 2) :
+    IsKFlatMagic 1 P ↔ Erdos735.IsMagic P := by
+  sorry  -- definitional unfolding; configLine = config 1-flat in ℝ²
+
+/-- **Open conjecture (S5 axiom)**: in `ℝ^d` with `k = 1`, the parent's 4 classes
+generalise — the magic configurations are exactly: (i) all collinear; (ii) general
+position; (iii) "all but one collinear" (near-pencil); (iv) Murty-style "triangle +
+ℝ^d analogue of incenter" structure. -/
+axiom oneflat_classification_higher_dim {d : ℕ} (hd : d ≥ 3) (P : PointConfigD d) :
+    IsKFlatMagic 1 P ↔
+      (∃ L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)),
+          L.direction.toSubmodule.rank = 1 ∧ ∀ p ∈ P, p ∈ L) ∨
+      (∀ p q r ∈ P, p ≠ q ∧ q ≠ r ∧ p ≠ r →
+        ¬ ∃ L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)),
+          L.direction.toSubmodule.rank = 1 ∧ p ∈ L ∧ q ∈ L ∧ r ∈ L) ∨
+      (sorry : Prop) ∨  -- near-pencil
+      (sorry : Prop)  -- analogue of triangle + incenter
+
+end Erdos735OQ04
+```
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - seeker-selected
+  - erdos-problem
+  - discrete-geometry
+  - incidence-geometry
+  - magic-configurations
+  - affine-flats
+  - higher-dimensional
+  - mathlib-gap
+```
+
+**Significance**: 6/10 — Erdős-numbered; the parent (ABKPR 2008) is a celebrated result in incidence geometry. Higher-flat extension to $\mathbb{R}^d$ is **research-level OPEN** to the author's knowledge.
+
+**Tractability**: 5/10 — Mixed:
+
+- **Definitions** (S2): mechanical — generalise parent's `Weighting`, `ConfigLine`, `IsMagic` to `WeightingD`, `ConfigKFlat`, `IsKFlatMagic`. ~50 Lean lines.
+- **Trivial cases** (S3): $k = 0$ and $k = d$ are simple ~10 lines each, no axioms.
+- **Reduction to parent for $k = 1, d = 2$** (S4): ~20 lines via definitional unfolding.
+- **Higher-dim classification** (S5+): genuinely open. Axiomatise the conjectured 4-class extension (analogous to parent's ABKPR 4-class theorem) with citations to known partial results.
+- **2-flats in $\mathbb{R}^3$** (S6+): a brand-new question. Concrete witnesses (e.g., a tetrahedron's vertices: each pair determines an edge, each 3-subset determines a triangle-plane) might suffice for a small example.
+
+## Decomposition
+
+### S2 — `WeightingD`, `ConfigKFlat`, `IsKFlatMagic` definitions
+
+Direct generalisation of parent's definitions to arbitrary $d, k$. ~50 Lean lines, 0 sorries.
+
+### S3 — Trivial cases $k = 0, k = d$
+
+Both trivially magic. ~15 Lean lines.
+
+### S4 — Reduction `IsKFlatMagic 1 P ↔ Erdos735.IsMagic P` (for $d = 2$)
+
+Direct definitional unfolding. ~20 lines.
+
+### S5 — Axiomatise extension of parent to $k = 1, d \ge 3$
+
+Conjecture: the four ABKPR classes extend to higher ambient dimensions. Axiomatise; cite *Magic configurations in $\mathbb{R}^d$* (any published or open work in this direction — to be verified during literature scan).
+
+### S6 — Concrete examples in $\mathbb{R}^3$ with $k = 2$
+
+Construct small configurations and verify k-flat-magic property via `native_decide`:
+
+- **Tetrahedron**: 4 vertices in general position in $\mathbb{R}^3$. Each 3-subset is a face (a 2-flat with exactly 3 points). For k = 2, the 4 triangular faces. With weights $w_1 = w_2 = w_3 = w_4 = 1$, each face sum = 3. ✓ Magic with $c = 3$.
+
+- **Octahedron**: 6 vertices, with antipodal pairs on coordinate axes. 8 triangular faces. With $w_i = 1$, each face sum = 3. ✓
+
+- **Cube**: 8 vertices. 6 face planes, each containing 4 vertices. With $w_i = 1$, each face sum = 4. ✓
+
+These constructions show that **regular convex polytopes are $(d-1)$-flat magic for $d \ge 2$** — a non-trivial new class beyond the parent's 4 plane classes.
+
+### S7 — Gallery integration
+
+`src/data/proofs/erdos-735-oq-04/` with `status: "axiomatized"`, axiomCount: 1-2 (depending on whether S5's higher-dim classification or the parent's ABKPR is the main axiom).
+
+## Mathlib Infrastructure Map
+
+| Need | Mathlib v4.26.0 | Module |
+|------|-----------------|--------|
+| `EuclideanSpace ℝ (Fin d)` | ✅ | `Mathlib.Analysis.InnerProductSpace.PiL2` |
+| `AffineSubspace ℝ` | ✅ | `Mathlib.LinearAlgebra.AffineSpace.AffineSubspace` |
+| `AffineSubspace.direction`, rank | ✅ | as above |
+| `Finset.filter`, sum | ✅ | `Mathlib.Algebra.BigOperators.Basic` |
+| ABKPR 2008 (parent's classification) | ❌ (parent axiomatises) | reuse parent's axioms |
+| Higher-flat magic classification | ❌ | n/a — S5 axiomatises |
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `erdos-735` (direct parent) | Plane case — ABKPR 4-class theorem (axiomatised) |
+| `erdos-659-oq-01-oq-02` (this researcher's session) | Higher-dim distance problem — adjacent territory |
+| `borsuk-ulam-oq-02-*` | Higher-dim topology and antipodal pairings |
+| `combinations-formula-oq-03` | Affine and projective configurations |
+
+## Risk Notes
+
+- **Higher-dim ABKPR is genuinely OPEN** — to the author's knowledge, no published extension of the 4-class classification beyond $\mathbb{R}^2$.
+- **2-flat magic for tetrahedra, octahedra, cubes is straightforward by uniform weighting** — these give a *new* class of magic configurations beyond the parent's 4 plane classes, suggesting the higher-dim classification is **richer**, not just an analogue.
+- **S5 axiom is conjectural**: the 4-class extension is the author's natural guess; actual classification may differ.
+- **`status: "axiomatized"` is mandatory**: ABKPR 2008 alone forces this.
+- **Sibling sub-OQs**: `oq-01` (ℝ³ characterisation), `oq-02` (non-positive/complex weights), `oq-03` (complexity) are orthogonal. This OQ (`oq-04`) is the $k$-flat extension.
+
+## References
+
+- Erdős (1981) — original magic configurations problem.
+- Ackerman, Buchin, Knauer, Pinchasi, Rote, *There are not too many magic configurations*, Discrete Comput. Geom. 39 (2008), 3–16.
+- Murty (1978) — original 4-class conjecture in $\mathbb{R}^2$.
+- Beck & Sokol (1995) — incidence-theoretic precursors.
+- erdosproblems.com/735 — parent problem source.
+- OEIS [A006247](https://oeis.org/A006247) — number of magic configurations of $n$ points in $\mathbb{R}^2$.
+
+## Honesty
+
+This S1 OBSERVE iteration is a **pure survey**. It produces:
+
+- 0 new Lean theorems
+- 0 sorry/axiom deltas
+- 3 markdown files
+- 1 gallery JSON
+
+The higher-dim ABKPR extension (S5 axiom) is **research-level open**. The 2-flat magic property for regular convex polytopes (tetrahedron, octahedron, cube) is a concrete S6 deliverable that shows the higher-dim classification has a **larger class** than the parent's 4-class theorem suggests.
+
+Future Lean entry: `status: "axiomatized"`.

--- a/research/problems/erdos-735-oq-04/state.md
+++ b/research/problems/erdos-735-oq-04/state.md
@@ -1,0 +1,108 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-05-12 (S1)
+**Iteration**: 1
+
+## Current Focus
+
+S1 (researcher-10): OBSERVE survey for `erdos-735-oq-04` — the seeker-extracted child of the verified gallery entry `erdos-735` ("Magic Configurations"). Parent's `conclusion.openQuestions[3]`:
+
+> Does the classification extend to configurations where the equal-sum constraint is imposed on k-flats instead of lines?
+
+This iteration produces:
+
+- `problem.md` — formal Lean target signatures (`PointConfigD`, `WeightingD`, `ConfigKFlat`, `IsKFlatMagic`); S2-S7 decomposition; hierarchy table of cases by $(d, k)$.
+- `knowledge.md` — recap of ABKPR's 4 classes; concrete tetrahedron/octahedron/cube examples for $k=2, d=3$; combinatorial counting (general position is always $k$-flat magic via uniform weights); Mathlib gap analysis.
+- `state.md` (this file) — phase NEW → OBSERVE.
+- `src/data/research/problems/erdos-735-oq-04.json` — gallery JSON.
+
+No Lean changes.
+
+## Active Approach
+
+**The $k$-flat extension is structurally richer than the parent**:
+
+- **Trivial limits**: $k = 0$ (every config is 0-flat magic) and $k = d$ (single ambient flat is trivially magic).
+- **Parent reduction**: $d = 2, k = 1$ recovers exactly the parent's `IsMagic` (definitional).
+- **Higher ambient dim $d \ge 3$, $k = 1$**: extends parent's 4 classes; conjecturally similar form.
+- **Higher flats $k \ge 2$**: introduces **new magic configurations** — regular convex polytopes (tetra, octa, cube) are $(d-1)$-flat magic via uniform weighting. This was NOT a class in the parent's 4-fold classification.
+
+### Concrete polytope examples (S6 deliverable)
+
+- **Tetrahedron** ($n = 4, d = 3, k = 2$): 4 triangular faces × 3 vertices each = 12 incidences; uniform $w_i = 1$ gives each face-sum = 3.
+- **Octahedron** ($n = 6, d = 3, k = 2$): 8 triangular faces × 3 vertices each = 24 incidences; uniform $w_i = 1$ gives face-sum = 3.
+- **Cube** ($n = 8, d = 3, k = 2$): 6 face planes × 4 vertices each = 24 incidences; uniform $w_i = 1$ gives face-sum = 4.
+
+These are all $(d-1)$-flat-magic and provide a *new* class beyond the parent's 4.
+
+### Higher-dim classification (S5 conjecture)
+
+The author's conjecture: for $\mathbb{R}^d$ with $k = 1$, the parent's 4 classes generalise as:
+1. All collinear (on a 1-flat).
+2. General position (no 3 collinear in any 1-flat).
+3. Near-pencil ($n - 1$ on a 1-flat, 1 off).
+4. Some $d$-dimensional analogue of "triangle + bisectors + incenter".
+
+For $k \ge 2$, the classification likely has 4–6 classes including the new "regular polytope" family.
+
+## Blockers
+
+None mathematical for S1. Practical:
+
+- **ABKPR 2008 absent from Mathlib**: parent axiomatises; reuse for this OQ.
+- **Higher-flat classification absent from published literature**: S5 axiom is genuinely open.
+- **`status: "axiomatized"` mandatory**: ABKPR alone forces this.
+
+## Next Action
+
+**S2 (any researcher)**: Define `PointConfigD`, `WeightingD`, `ConfigKFlat`, `IsKFlatMagic` in `proofs/Proofs/Erdos735OQ04.lean`. Approach: parameterise parent's definitions on $(d, k)$, using `EuclideanSpace ℝ (Fin d)` and `AffineSubspace`. Prove trivial cases $k = 0, k = d$.
+
+Concrete plan:
+
+```lean
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
+import Proofs.Erdos735Problem  -- parent
+
+namespace Erdos735OQ04
+
+def PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))
+
+def WeightingD {d : ℕ} (P : PointConfigD d) := {w : P → ℝ // ∀ p, w p > 0}
+
+def ConfigKFlat {d : ℕ} (k : ℕ) (P : PointConfigD d) :=
+  { F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)) //
+    F.direction.toSubmodule.rank = k ∧ (P.filter (· ∈ F)).card ≥ k + 1 }
+
+def kFlatSum {d k : ℕ} (P : PointConfigD d) (w : WeightingD P)
+    (F : ConfigKFlat k P) : ℝ := ...
+
+def IsKFlatMagic {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop := ...
+
+theorem zero_flat_magic_trivial : IsKFlatMagic 0 P := ...
+theorem ambient_flat_magic_trivial : IsKFlatMagic d P := ...
+theorem oneflat_eq_parent : IsKFlatMagic 1 P ↔ Erdos735.IsMagic P := ...
+
+end Erdos735OQ04
+```
+
+Expected ~50 Lean lines, ~3 sorries on the trivial-case theorems (mechanical to discharge).
+
+**S3** — S4: prove trivial cases and parent reduction.
+**S5** — axiomatise the conjectured higher-dim classification.
+**S6** — `native_decide` certificates for tetrahedron / octahedron / cube examples.
+**S7** — gallery JSON with `status: "axiomatized"`.
+
+## Honesty
+
+This S1 OBSERVE is a **pure survey**. It produces:
+
+- 0 new Lean theorems
+- 0 sorry/axiom deltas
+- 3 markdown files
+- 1 gallery JSON
+
+The higher-flat extension is **research-level open**. The polytope examples (S6) show the higher-dim classification has MORE classes than the parent's 4-fold theorem, suggesting the question is genuinely richer.
+
+Future Lean entry: `status: "axiomatized"`.

--- a/src/data/research/problems/erdos-735-oq-04.json
+++ b/src/data/research/problems/erdos-735-oq-04.json
@@ -1,0 +1,79 @@
+{
+  "slug": "erdos-735-oq-04",
+  "title": "Magic configurations on k-flats in ℝ^d (Erdős #735 extension)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "parent": "erdos-735",
+  "problemStatement": {
+    "formal": "\\text{Generalize Erdős #735 (Murty-ABKPR 2008 classification of magic configurations in } \\mathbb{R}^2 \\text{ with equal-sum constraint on lines) to } k\\text{-flats in } \\mathbb{R}^d: \\text{ classify point sets } P \\subset \\mathbb{R}^d \\text{ admitting positive weights } w : P \\to \\mathbb{R}_+ \\text{ such that every } k\\text{-flat through at least } k+1 \\text{ points has the same weight-sum.}",
+    "plain": "The parent erdos-735 solves Erdős's magic configurations problem in ℝ²: when can n points be given positive weights such that every line through ≥ 2 points has the same weight-sum? Ackerman-Buchin-Knauer-Pinchasi-Rote 2008 (ABKPR) proved exactly 4 classes work. This sub-OQ asks the natural higher-flat extension: replace 'line' (1-flat) with k-flat (affine subspace of dimension k) in ℝ^d. Cases: (i) k = 0: trivial (every config); (ii) k = d: trivial (single flat); (iii) d = 2, k = 1: parent's case (4 classes); (iv) d ≥ 3, k = 1: extension of parent (conjectural 4 classes); (v) d ≥ 3, k ≥ 2: NEW question with NEW magic class — regular convex polytopes (tetrahedron, octahedron, cube) are (d-1)-flat magic via uniform weights. The classification is genuinely richer than the parent.",
+    "whyMatters": [
+      "Direct extension of ABKPR 2008, a celebrated theorem in incidence geometry.",
+      "Higher-flat case reveals NEW magic classes (regular convex polytopes) beyond the parent's 4-class theorem, suggesting the classification is structurally richer.",
+      "Mathlib v4.26.0 has no published k-flat magic classification beyond ABKPR's plane case; this OQ would be the first Lean treatment of higher-dimensional incidence-magic problems."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent (verified, axiomatised): ABKPR 2008 classifies magic configurations in ℝ² into exactly 4 classes (all collinear; general position; near-pencil; triangle+bisectors+incenter).",
+      "Trivial: k = 0 (every config is 0-flat magic) and k = d (single ambient flat is trivially magic).",
+      "Combinatorial: for general position in ℝ^d (no k+2 points on a k-flat), every k-flat contains exactly k+1 points; uniform weight w_i = c/(k+1) gives flat-sum = c for any 1 ≤ k ≤ d-1.",
+      "Regular convex polytopes (tetrahedron 4 vertices in ℝ³, octahedron 6, cube 8) are (d-1)-flat magic via uniform weighting — a NEW class beyond parent's 4."
+    ],
+    "open": [
+      "Higher-dim classification: for ℝ^d with d ≥ 3 and k = 1, do parent's 4 classes (collinear / general position / near-pencil / triangle+) generalise to higher ambient dim?",
+      "k = 2 flat classification in ℝ³: regular polytopes give a new class; what are all classes? Conjectural 6+ classes (parent's 4 + regular polytopes + ?).",
+      "General (d, k) classification with 1 ≤ k ≤ d-1: completely open; no published results to author's knowledge."
+    ],
+    "goal": "Formalize in Lean: (1) PointConfigD / WeightingD / ConfigKFlat / IsKFlatMagic definitions parameterised on (d, k). (2) Trivial cases k = 0, k = d. (3) Definitional reduction IsKFlatMagic 1 = parent's IsMagic for d = 2. (4) Axiomatise higher-dim classification (conjectural). (5) native_decide certificates for tetrahedron / octahedron / cube. (6) Gallery JSON with status: axiomatized."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-12T22:15:00.000Z",
+    "iteration": 1,
+    "focus": "S1 (researcher-10, 2026-05-12): OBSERVE survey for k-flat extension of Erdős #735 magic configurations. Wrote problem.md (~3K words) with full Lean target signatures + S2-S7 decomposition + (d, k) hierarchy table; knowledge.md (~2.5K words) with ABKPR 4-class recap + tetrahedron/octahedron/cube polytope examples for k=2,d=3 (NEW magic class) + combinatorial counting (general position is k-flat magic via uniform weights); state.md with S2 next-action. No Lean changes.",
+    "blockers": [],
+    "nextAction": "S2: define PointConfigD, WeightingD, ConfigKFlat, IsKFlatMagic in proofs/Proofs/Erdos735OQ04.lean. Approach: parameterise parent's definitions on (d, k), use EuclideanSpace ℝ (Fin d) and AffineSubspace. Prove trivial cases k = 0 (zero_flat_magic_trivial), k = d (ambient_flat_magic_trivial), and the parent reduction for d = 2, k = 1. Expected ~50 Lean lines, 3 sorries for the trivial cases (mechanical to discharge).",
+    "attemptCounts": {
+      "S1_observe": 1,
+      "S2_definitions": 0,
+      "S3_trivial_cases": 0,
+      "S4_parent_reduction": 0,
+      "S5_higher_dim_classification_axiom": 0,
+      "S6_polytope_witnesses": 0,
+      "S7_gallery": 0
+    }
+  },
+  "knowledge": {
+    "insights": [
+      "k-flat extension is structurally RICHER than parent: regular convex polytopes (tetrahedron, octahedron, cube) are (d-1)-flat magic via uniform weights, giving a NEW class beyond ABKPR's 4 plane classes.",
+      "Trivial limits k = 0 and k = d collapse to easy theorems; the interesting range is 1 ≤ k ≤ d - 1.",
+      "General position in ℝ^d is always k-flat magic (uniform weight w_i = c/(k+1) works) — the interesting cases are when some k-flats have > k+1 points (non-uniform balance needed).",
+      "ABKPR 2008 classification has NOT been extended beyond ℝ² in the published literature; this OQ is genuinely open. The polytope examples suggest the higher-dim classification has more than 4 classes."
+    ],
+    "builtItems": [
+      "Wrote research/problems/erdos-735-oq-04/problem.md (formal targets + S2-S7 plan + (d, k) hierarchy).",
+      "Wrote research/problems/erdos-735-oq-04/knowledge.md (ABKPR recap + polytope examples + combinatorial counting).",
+      "Wrote research/problems/erdos-735-oq-04/state.md (phase OBSERVE).",
+      "Created src/data/research/problems/erdos-735-oq-04.json (this file)."
+    ],
+    "progressSummary": "S1 OBSERVE complete. Definitions and Lean signatures for k-flat magic configurations established. Trivial cases (k = 0, k = d) and parent reduction (d = 2, k = 1) identified. Higher-dim classification (S5 axiom) genuinely open. Polytope examples (tetra/octa/cube) show new magic class beyond parent's 4."
+  },
+  "tags": [
+    "seeker-selected",
+    "erdos-problem",
+    "discrete-geometry",
+    "incidence-geometry",
+    "magic-configurations",
+    "affine-flats",
+    "higher-dimensional",
+    "regular-polytopes",
+    "mathlib-gap",
+    "research"
+  ],
+  "significance": 6,
+  "tractability": 5,
+  "lastUpdated": "2026-05-12T22:15:00.000Z"
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE iteration for `erdos-735-oq-04` — seeker-extracted child of the verified gallery entry [`erdos-735`](../tree/main/src/data/proofs/erdos-735) ("Magic Configurations"). Parent's `conclusion.openQuestions[3]`:

> Does the classification extend to configurations where the equal-sum constraint is imposed on k-flats instead of lines?

Doc-only deliverable — no Lean changes, no axiom/sorry deltas.

## Key finding

The k-flat extension is **structurally RICHER than ABKPR's 4-class plane theorem**:

| Case | Mathematical content | Status |
|------|---------------------|--------|
| $k = 0$, any $d$ | Trivial (every config) | Easy theorem |
| $k = d$, any $n$ | Trivial (single ambient flat) | Easy theorem |
| $d = 2, k = 1$ | Parent's exact case | ABKPR 2008 (axiomatised) |
| $d \ge 3, k = 1$ | Higher-dim ABKPR extension | **OPEN — conjectural 4 classes** |
| $d \ge 3, k \ge 2$ | New magic class via polytopes | **OPEN — strictly richer than 4-class** |

## Polytope examples (NEW magic class beyond ABKPR)

| Polytope | $n$ | $k$ | Faces | Uniform weight → flat-sum |
|----------|---:|---:|-----:|---|
| Tetrahedron in $\mathbb{R}^3$ | 4 | 2 | 4 triangular | each = 3 ✓ |
| Octahedron in $\mathbb{R}^3$ | 6 | 2 | 8 triangular | each = 3 ✓ |
| Cube in $\mathbb{R}^3$ | 8 | 2 | 6 quadrilateral | each = 4 ✓ |

Uniform $w_i = 1$ works — these are **$k$-flat magic with $k = 2, d = 3$**. None of ABKPR's 4 plane classes captures this; the classification at higher $k$ is genuinely richer.

## Combinatorial fact

For general position in $\mathbb{R}^d$ (no $k+2$ points on a $k$-flat), every $k$-flat contains exactly $k+1$ points; uniform weight $w_i = c/(k+1) \Rightarrow$ each flat-sum = $c$. Hence **general position is always $k$-flat magic** for $1 \le k \le d - 1$.

The genuine open question: classify configurations with **non-uniform weights** when some $k$-flats have $> k+1$ points.

## Lean target signatures (excerpt from `problem.md`)

```lean
def PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))

def ConfigKFlat {d : ℕ} (k : ℕ) (P : PointConfigD d) :=
  { F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)) //
    F.direction.toSubmodule.rank = k ∧ (P.filter (· ∈ F)).card ≥ k + 1 }

def IsKFlatMagic {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop :=
  ∃ w : WeightingD P, ∃ c > 0, ∀ F : ConfigKFlat k P, kFlatSum P w F = c

theorem zero_flat_magic_trivial : IsKFlatMagic 0 P := ...
theorem ambient_flat_magic_trivial : IsKFlatMagic d P := ...
theorem oneflat_eq_parent : IsKFlatMagic 1 P ↔ Erdos735.IsMagic P := ...  -- d = 2
axiom higher_dim_classification : ...  -- conjectural ABKPR extension
```

## Decomposition

| Stage | Deliverable |
|------:|:-----------|
| **S2** | `PointConfigD`, `ConfigKFlat`, `IsKFlatMagic` definitions (~50 lines) |
| **S3** | Trivial cases $k = 0$ and $k = d$ (~15 lines) |
| **S4** | Parent reduction `IsKFlatMagic 1 P ↔ Erdos735.IsMagic P` for $d = 2$ (~20 lines) |
| **S5** | Axiomatise higher-dim classification |
| **S6** | `native_decide` certificates for tetrahedron/octahedron/cube |
| **S7** | Gallery JSON with `status: "axiomatized"` |

## Files

| Path | LOC |
|------|----:|
| `research/problems/erdos-735-oq-04/problem.md` | +187 |
| `research/problems/erdos-735-oq-04/knowledge.md` | +143 |
| `research/problems/erdos-735-oq-04/state.md` | +87 |
| `src/data/research/problems/erdos-735-oq-04.json` | +79 |
| **Total** | **+516** |

## Mathlib gap

Mathlib v4.26.0 has:
- ✅ `EuclideanSpace ℝ (Fin d)`, `AffineSubspace`, rank
- ❌ ABKPR 2008 (parent axiomatises)
- ❌ Higher-flat magic classification

## Honesty

- ABKPR 2008 is the only published classification (in $\mathbb{R}^2$).
- **No published k-flat extension exists** to the author's knowledge.
- The polytope examples (tetra/octa/cube) demonstrate the higher-dim classification has **strictly more classes** than ABKPR's 4.
- Future Lean entry: `status: "axiomatized"`.

## Status

**Outcome**: progress (S1 OBSERVE)
**Sorry delta**: 0
**Axiom delta**: 0
**Lean delta**: 0
**Next**: S2 — definitions in `Erdos735OQ04.lean`.

🤖 Generated by researcher-10