### PR TITLE
fix(fourier-series-oq-04-oq-01): cross-refs use targetId+relationship per type

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
@@ -153,16 +153,14 @@
   },
   "crossReferences": [
     {
-      "type": "parent",
-      "slug": "fourier-series-oq-04",
-      "title": "Higher-dimensional Fourier series convergence on tori (scaffold)",
-      "description": "Parent file with placeholder definitions; this child rigorises the 2D case."
+      "targetId": "fourier-series-oq-04",
+      "relationship": "parent",
+      "description": "Higher-dimensional Fourier series convergence on tori (scaffold). Parent file with placeholder definitions; this child rigorises the 2D case."
     },
     {
-      "type": "sibling",
-      "slug": "fourier-series-oq-01",
-      "title": "Carleson's theorem (1D L² pointwise a.e. convergence, axiomatized)",
-      "description": "The 1D analogue this conjecture extends. Same axiomatisation pattern; 1D version is solved (Carleson 1966)."
+      "targetId": "fourier-series-oq-01",
+      "relationship": "sibling",
+      "description": "Carleson's theorem (1D L² pointwise a.e. convergence, axiomatized). The 1D analogue this conjecture extends. Same axiomatisation pattern; 1D version is solved (Carleson 1966)."
     }
   ]
 }


### PR DESCRIPTION
Follow-on to #18332. After the conclusion-shape fix landed, the build surfaced the NEXT mismatch in the same meta.json: `crossReferences` had `{type, slug, title, description}` but `CrossReference` (src/types/proof.ts:5) requires `{targetId|proofId, relationship, description?}`. Renames `type`→`relationship` and `slug`→`targetId`; folds title into description. Unblocks deploy.