### PR TITLE
Enrich binomial-theorem-oq-02-oq-03: 1→7 crossReferences

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -161,7 +161,37 @@
     {
       "targetId": "binomial-theorem-oq-02",
       "relationship": "extends",
-      "description": "The q-multinomial theorem is the quantum generalization of the classical multinomial theorem proved in OQ-02"
+      "description": "The q-multinomial theorem is the quantum generalization of the classical multinomial theorem proved in OQ-02. Setting q=1 in qMultinom recovers Nat.multinomial via `qMultinom_at_one`."
+    },
+    {
+      "proofId": "combinations-formula-oq-03",
+      "relationship": "prerequisite",
+      "description": "Direct dependency: the file `CombinationsFormulaOQ03.lean` defines `qBinom` (Gaussian binomial coefficient via q-Pascal recurrence), `qFactorial`, and the key bridge lemmas `qBinom_at_one` (qBinom 1 n k = Nat.choose n k) and `qBinom_product` (qBinom q n k · qFactorial q k · qFactorial q (n-k) = qFactorial q n). The q-multinomial definition iterates qBinom and the product identity proof reduces to qBinom_product."
+    },
+    {
+      "proofId": "combinations-formula",
+      "relationship": "complementary",
+      "description": "Establishes the classical binomial coefficient C(n,k) = n!/(k!(n-k)!), which is the q=1 specialization of qBinom. The classical multinomial coefficient n!/(k₁!...kₘ!) is correspondingly the q=1 limit of qMultinom — both verified here via `qMultinom_at_one`."
+    },
+    {
+      "proofId": "binomial-theorem",
+      "relationship": "complementary",
+      "description": "Wiedijk #44, the classical binomial theorem (x+y)ⁿ = ∑ C(n,k) xᵏ yⁿ⁻ᵏ. The q-binomial theorem (in q-commutative algebras where yx = qxy) generalizes this by replacing C(n,k) with qBinom q n k. The q-multinomial coefficients formalized here are the building blocks for the multi-variable q-binomial theorem."
+    },
+    {
+      "proofId": "binomial-theorem-oq-02-oq-04",
+      "relationship": "complementary",
+      "description": "Provides a direct induction-on-|s| Lean proof of the classical multinomial theorem (without going through binomial-theorem-oq-02). The induction structure on Finset cardinality mirrors the recursion qMultinom q k = qBinom q (∑kᵢ) (k 0) · qMultinom q (k∘Fin.succ) used here, suggesting a parallel q-analog induction is the natural route to the full q-multinomial theorem (an open question in the conclusion)."
+    },
+    {
+      "proofId": "partition-theorem",
+      "relationship": "complementary",
+      "description": "Euler's partition identity (partitions into odd parts = partitions into distinct parts) is a hallmark of generating-function combinatorics where q-series appear: ∏(1+qᵏ) = ∏ 1/(1−q^(2k-1)). The q-multinomial coefficients are the polynomial coefficients in ∏(1−xqⁱ)⁻¹-type expansions, providing the algebraic counterpart to these partition-theoretic identities."
+    },
+    {
+      "proofId": "stirling-formula",
+      "relationship": "context",
+      "description": "Stirling's approximation n! ~ √(2πn)·(n/e)ⁿ governs the asymptotic growth of classical multinomial coefficients. The q-analog asymptotics of qFactorial q m and qMultinom (as polynomial degree in q grows) lead to MacMahon's box theorem and the Gauss formula for the number of plane partitions, q-generalizations of Stirling that remain open in this gallery."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Enrichment pass for `binomial-theorem-oq-02-oq-03` (q=100, passes=0). Adds 6 cross-references with rich descriptions linking the q-multinomial coefficient formalization to surrounding gallery entries.

| proofId | relationship | one-line summary |
|---------|--------------|-------------------|
| combinations-formula-oq-03 | prerequisite | direct import: qBinom / qFactorial / qBinom_at_one / qBinom_product |
| combinations-formula | complementary | classical C(n,k), the q=1 specialization |
| binomial-theorem | complementary | Wiedijk #44, classical (x+y)ⁿ |
| binomial-theorem-oq-02-oq-04 | complementary | direct induction-on-\|s\| Lean route to multinomial theorem |
| partition-theorem | complementary | q-series in Euler partition identities |
| stirling-formula | context | asymptotic growth of multinomials |

The existing `binomial-theorem-oq-02` reference (legacy `targetId`) is preserved and expanded with the explicit `qMultinom_at_one` bridge.

## Scope

- Pure additive crossRef enrichment in `meta.json` (+31 lines, -1)
- No annotations / overview / sections / Lean changes
- All 7 proofIds verified to exist in `src/data/proofs/`

## Test plan

- [x] JSON validates
- [x] All crossRef proofIds exist as gallery entries