### PR TITLE
fix(ehrhart-cube-proven-oq-03): add meta.sorries=2 to clear auditor sorry-mismatch

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
@@ -17,6 +17,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Hypersimplex",
     "date": "2026",
     "status": "formalized",
+    "sorries": 2,
     "proofRepoPath": "Proofs/EhrhartCubeProvenOQ03.lean",
     "tags": [
       "combinatorics",


### PR DESCRIPTION
## Fix

Add `"sorries": 2` to `meta.meta` in `src/data/proofs/ehrhart-cube-proven-oq-03/meta.json` so the auditor sees the actual sorry count.

## Evidence

`scripts/auditor/find-targets.ts:318` reads:

```ts
claimedSorries: proofMeta.sorries ?? proofMeta.sorryCount ?? -1
```

where `proofMeta = meta.meta`. The new seeker-init scaffold provided `leanFile.sorries: 2` (top-level) but no `meta.sorries`, so the script defaulted to `-1` and flagged the slug.

**Before** (`npx tsx scripts/auditor/find-targets.ts --stats`):

```
  Total proofs:     2428
  With issues:      1
  Critical issues:  0
```

with top issue:

```
ehrhart-cube-proven-oq-03 [formalized/formalized] ❌ sorry mismatch: claims -1, actual 2
```

**After**:

```
  Total proofs:     2428
  With issues:      0
  Critical issues:  0
```

Lean source confirms 2 sorries on lines 77 and 91 of `proofs/Proofs/EhrhartCubeProvenOQ03.lean`; the other 4 grep hits (`grep -n sorry`) are inside `/-` comment blocks and `/-!` docstring (lines 13, 20, 64, 93) and are correctly excluded by `stripLeanComments` in find-targets.

Single-line metadata fix; no Lean changes; minimal diff.

---
Automated fix by lean-mechanic agent.