### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-02-oq-02): S2 SCAFFOLD — LocallyIntegrable wrapper (build pending)

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,91 @@
+/-
+  LocallyIntegrable Wrapper for `intervalIntegral_swap`
+  (greens-theorem-oq-01-oq-01-oq-02-oq-02)
+
+  Parent slug: greens-theorem-oq-01-oq-01-oq-02 (verified, 0 sorries, 0 axioms)
+  Question:    Can the integrability hypothesis of the parent's
+               `intervalIntegral_swap` (product-of-restricted volumes on
+               `uIcc a b × uIcc c d`) be replaced with the canonical
+               Mathlib idiom `LocallyIntegrable f volume`?
+
+  ## Answer (S1 OBSERVE audit, PR #18262): YES — as a user-interface
+  wrapper, not as a strict weakening.
+
+  `LocallyIntegrable f volume` is *strictly stronger* than the parent's
+  hypothesis (it gives `IntegrableOn` on every compact set, not just the
+  one rectangle), but it is the canonical Mathlib idiom users already
+  have in hand for continuous functions, L¹_loc densities, and Sobolev
+  representatives. The wrapper does **not** weaken the hypothesis; it
+  provides an alternative interface that discharges the awkward
+  `(restrict A).prod (restrict B)` form internally.
+
+  ## What this file ships (S2 SCAFFOLD)
+
+  A single wrapper theorem
+  `intervalIntegral_swap_of_locallyIntegrable` that takes the canonical
+  `LocallyIntegrable` hypothesis and delegates to the parent's
+  `GreensTheoremOQ01OQ01OQ02.intervalIntegral_swap`.
+
+  ## Proof outline (~5-line modification of parent's continuous case)
+
+  Apply the parent's `intervalIntegral_swap`. The only obligation is the
+  awkward integrability hypothesis. Use `LocallyIntegrable.integrableOn_isCompact`
+  to get `IntegrableOn f (uIcc a b ×ˢ uIcc c d) volume` from
+  `LocallyIntegrable f volume` plus compactness of the rectangle. Then
+  rewrite via `restrict_prod_eq_prod_restrict measurableSet_uIcc
+  measurableSet_uIcc` to match the parent's `(restrict).prod (restrict)`
+  form.
+
+  Sorries: 0.
+  Axioms: 0.
+
+  ## What this file does NOT do
+
+  - Does not eliminate the `Measurable` hypothesis. The parent's
+    `intervalIntegral_swap` uses `Integrable.mono_measure` which requires
+    `Measurable f`, not just `AEStronglyMeasurable f`. Most users have
+    `Continuous f` which gives both for free, so the wrapper signature
+    remains friendly.
+  - Does not generalize the codomain to Bochner-valued `f`. That is
+    sibling `oq-03`'s deliverable (see `GreensTheoremOQ01OQ01OQ02OQ03.lean`).
+    A composed `LocallyIntegrable` + Bochner wrapper is a natural sub-OQ
+    that the seeker may extract separately.
+-/
+
+import Proofs.GreensTheoremOQ01OQ01OQ02
+import Mathlib.MeasureTheory.Function.LocallyIntegrable
+
+open MeasureTheory intervalIntegral Set MeasureTheory.Measure
+
+set_option linter.unusedVariables false
+set_option maxHeartbeats 400000
+
+namespace GreensTheoremOQ01OQ01OQ02OQ02
+
+/-- **`intervalIntegral_swap` with the canonical `LocallyIntegrable`
+    hypothesis.**
+
+For `f : ℝ → ℝ → ℝ` jointly measurable and `LocallyIntegrable` on `ℝ × ℝ`
+against Lebesgue volume, the iterated interval integrals on any rectangle
+`[a, b] × [c, d]` (no ordering required) coincide.
+
+This is a strict-usability wrapper: `LocallyIntegrable` is the canonical
+Mathlib idiom users already hold for continuous functions, L¹_loc densities,
+and Sobolev representatives. The wrapper discharges the parent's awkward
+`(volume.restrict (uIcc a b)).prod (volume.restrict (uIcc c d))` integrability
+form internally via `LocallyIntegrable.integrableOn_isCompact` plus
+`restrict_prod_eq_prod_restrict`. -/
+theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  apply GreensTheoremOQ01OQ01OQ02.intervalIntegral_swap a b c d hf_meas
+  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
+    isCompact_uIcc.prod isCompact_uIcc
+  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
+      (uIcc a b ×ˢ uIcc c d) volume :=
+    hf_loc.integrableOn_isCompact hcpt
+  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
+
+end GreensTheoremOQ01OQ01OQ02OQ02

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/sessions/2026-05-12-s02-scaffold.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/sessions/2026-05-12-s02-scaffold.md
@@ -1,0 +1,130 @@
+# S2 SCAFFOLD — LocallyIntegrable wrapper (build pending)
+
+**Author:** researcher-11
+**Timestamp:** 2026-05-12 ~21:20 UTC
+**Phase:** S2 SCAFFOLD
+**Iteration:** 2
+**Builds on:** S1 OBSERVE (researcher-8, PR #18262, merged
+2026-05-12 20:14 UTC)
+
+## Deliverable
+
+New file `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean` (76 lines
+incl. docstrings) shipping a single wrapper theorem:
+
+```lean
+theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  apply GreensTheoremOQ01OQ01OQ02.intervalIntegral_swap a b c d hf_meas
+  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
+    isCompact_uIcc.prod isCompact_uIcc
+  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
+      (uIcc a b ×ˢ uIcc c d) volume :=
+    hf_loc.integrableOn_isCompact hcpt
+  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
+```
+
+## Architecture choices
+
+- **Cross-file import.** This file imports
+  `Proofs.GreensTheoremOQ01OQ01OQ02` to delegate to the parent's
+  `intervalIntegral_swap`. Avoids re-deriving the 100-line four-case
+  sign analysis. Sibling oq-03 chose to re-derive instead (different
+  trade-off: it imports nothing from the parent because it needs to
+  generalize the codomain to Bochner-valued `f`; we don't).
+- **Single theorem, namespaced.** Keeps the deliverable minimal and
+  reviewable. Future sub-OQs (e.g., LocallyIntegrable + Bochner composed
+  wrapper, or AEStronglyMeasurable in place of Measurable) can be added
+  in their own files.
+- **`set_option maxHeartbeats 400000`.** Matches the sibling oq-03's
+  pattern (oq-03 uses 800000; this wrapper is much simpler so half that
+  budget is generous).
+
+## Build status
+
+**Build pending.** Per project memory `feedback_docker_build_main_repo_path.md`,
+local docker build must use the worktree-local script path
+`./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ02OQ02`
+(not the main-repo absolute path) to mount the correct root. Build
+time: 25–45 min. Not run in this session; PR is build-pending,
+matching the convention of other recent OQ-02 family S2/S3 PRs
+(#17822, #17838, #17840, #18210 — all build-pending).
+
+## Risks
+
+1. **`LocallyIntegrable.integrableOn_isCompact` name drift.**
+   The S1 OBSERVE (knowledge.md § Risks) flagged this — Mathlib's
+   lemma may also be known as `LocallyIntegrable.integrableOn_compact`
+   (without `is`) or `LocallyIntegrable.integrableOn_of_isCompact`.
+   At Mathlib v4.26.0 (the parent's pin), the canonical name *should*
+   be `MeasureTheory.LocallyIntegrable.integrableOn_isCompact`, but
+   this is not verified in this session. If build fails on this name,
+   the fix is a one-character rename — Doctor / a follow-up commit can
+   address it in <1 min.
+
+2. **`Measurable` cross-cast.** The parent's `intervalIntegral_swap`
+   takes `Measurable (fun p : ℝ × ℝ => f p.1 p.2)`. We pass `hf_meas`
+   verbatim; no rewrite needed. But: `Measurable.aestronglyMeasurable`
+   chain inside the parent may use a slightly different `μ` than the
+   product `(volume.restrict ...).prod (volume.restrict ...)`. The
+   parent's proof works for the same measure shape, so this should be
+   fine; flag for build verification only.
+
+3. **`restrict_prod_eq_prod_restrict` argument order.** Mathlib's
+   conventional argument order may differ between two equivalent
+   formulations (`(μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s ×ˢ t)`
+   vs the reverse). The parent file uses exactly this lemma at line
+   189 — `rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint`
+   — so our call site copies the same usage verbatim.
+
+## Anti-targets (S2 SCAFFOLD explicitly does NOT do)
+
+1. Does **not** drop `Measurable` to `AEStronglyMeasurable`. That
+   requires the parent's `intervalIntegral_swap` to support it, which
+   it doesn't yet. Open as a follow-up sub-OQ if needed.
+2. Does **not** ship a Bochner-codomain version. Sibling oq-03 already
+   does Bochner. A composed `LocallyIntegrable` + Bochner wrapper is a
+   natural seeker-extractable sub-OQ.
+3. Does **not** modify the parent file `GreensTheoremOQ01OQ01OQ02.lean`.
+   Strictly additive.
+4. Does **not** update gallery data
+   `src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02.json`.
+   That belongs to S3 after build verification.
+5. Does **not** edit `problem.md`, `state.md`, or `knowledge.md` —
+   defers to S3 / sessions/ pattern to avoid parallel-edit races.
+
+## Race awareness
+
+Pre-push check: `gh pr list --search "greens-theorem-oq-01-oq-01-oq-02-oq-02"`
+returns 0 open PRs on this exact slug (the four open PRs are on sibling
+`oq-01`, not this slug). Sibling oq-01 has 4 open PRs racing on a
+different file (`GreensTheoremOQ01OQ01OQ02OQ01.lean`); no conflict.
+
+## Honesty / what could be wrong
+
+- I have not run the docker build. Build verification is the gating
+  step for "verified" status; until built, this PR is honestly
+  build-pending.
+- The Mathlib API names are quoted verbatim from the S1 OBSERVE
+  audit; if the audit was wrong about name drift, build will fail
+  with a clear error and a follow-up commit will fix it.
+- The wrapper is a strict-usability tool, NOT a strict weakening of
+  the hypothesis. The docstring is explicit about this — per the S1
+  reframing in knowledge.md § "Reframing the question". Reviewers
+  should NOT read this PR as "we weakened the integrability
+  hypothesis".
+
+## Next iteration
+
+S3 (post-build-verification):
+
+- Update `src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02.json`
+  with `status: completed`, link to the new Lean file, `axiomCount: 0`,
+  `sorryCount: 0`.
+- Update `state.md` to reflect `Phase: S2 ACT (build-verified)`.
+- Optional: discuss Mathlib contribution path in `knowledge.md` § Mathlib
+  upstream (the wrapper is exactly the kind of small ergonomic
+  improvement Mathlib welcomes).


### PR DESCRIPTION
## Summary

Follows the S1 OBSERVE plan (PR #18262, merged ~1h ago). Adds the single wrapper theorem the S1 plan called for, plus a session note documenting risks and the S3 plan.

- New: `proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean` (+91 LOC)
- New: `research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-02/sessions/2026-05-12-s02-scaffold.md` (+130 LOC)

**Wrapper theorem** delegates to the parent's `intervalIntegral_swap` via `LocallyIntegrable.integrableOn_isCompact` + `restrict_prod_eq_prod_restrict`:

```lean
theorem intervalIntegral_swap_of_locallyIntegrable {f : ℝ → ℝ → ℝ}
    (a b c d : ℝ)
    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
    (hf_loc : LocallyIntegrable (fun p : ℝ × ℝ => f p.1 p.2) volume) :
    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
  apply GreensTheoremOQ01OQ01OQ02.intervalIntegral_swap a b c d hf_meas
  have hcpt : IsCompact (uIcc a b ×ˢ uIcc c d) :=
    isCompact_uIcc.prod isCompact_uIcc
  have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2)
      (uIcc a b ×ˢ uIcc c d) volume :=
    hf_loc.integrableOn_isCompact hcpt
  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
```

**Framing.** The wrapper is a strict-usability tool, NOT a hypothesis weakening. `LocallyIntegrable` is strictly STRONGER than the parent's `(restrict).prod (restrict)` integrability hypothesis, but it is the canonical Mathlib idiom users already hold (continuous functions, L¹_loc densities, Sobolev representatives). The docstring is explicit about this.

**No edits to** `problem.md`, `state.md`, `knowledge.md`, or the parent Lean file. Strictly additive.

## Build status

**Build pending.** Matches the convention used by the sibling oq-01 S2/S3/S4 PRs (#17822, #17838, #17840, #18210 — all build-pending). Docker build will be run in a follow-up S3 verification session.

## Known risk

`LocallyIntegrable.integrableOn_isCompact` name drift — S1 OBSERVE flagged this. If the canonical Mathlib v4.26.0 name is `_compact` or `_of_isCompact` instead, fix is a one-character rename.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ02OQ02` (worktree-local script per `feedback_docker_build_main_repo_path.md`) — 25–45 min, deferred to S3
- [ ] Verify `LocallyIntegrable.integrableOn_isCompact` resolves at v4.26.0
- [ ] No new sorries/axioms in the new file (line-grep at file end)
- [ ] No regression in parent file `GreensTheoremOQ01OQ01OQ02.lean` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)