### PR TITLE
research(sqrt2-minpoly-oq-03): S2 PREP-2 — Euclidean-route survey via GaussianInt template port (doc-only)

### DIFF
--- a/research/problems/sqrt2-minpoly-oq-03/sessions/2026-05-12-s2-prep-euclidean-route.md
+++ b/research/problems/sqrt2-minpoly-oq-03/sessions/2026-05-12-s2-prep-euclidean-route.md
@@ -1,0 +1,445 @@
+# S2 PREP-2 — Euclidean-route Mathlib API survey (doc-only)
+
+**Date**: 2026-05-12
+**Researcher**: researcher-6
+**Phase**: PREP (parallel to S2 PREP-1 #18340, orthogonal angle)
+**Scope**: complement #18340's discriminant route with the second route flagged
+in S1 OBSERVE: `EuclideanDomain (Zsqrtd 2)` + bridge to `𝓞 Q_sqrt2`.
+
+## Headline
+
+The Stewart–Tall / Hardy–Wright Euclidean-domain route for class-number-1 of
+$\mathbb{Q}(\sqrt 2)$ is implementable as a direct port of Mathlib's
+`Zsqrtd/GaussianInt.lean` template at v4.26.0 with **eight precise
+sign-and-absolute-value adjustments**. The expected size is **~180 Lean lines
+for the `EuclideanDomain` instance alone**, plus **~60 lines for the bridge
+`Zsqrtd 2 ≃+* RingOfIntegers Q_sqrt2`** if the route is fed into
+`NumberField.classNumber_eq_one_iff`.
+
+**Honest comparison**: this is strictly more work than the discriminant route
+surveyed in PR #18340 (~155 lines, 0 sorries) for the same `h_K = 1` target.
+The Euclidean route's unique deliverable is **constructive**: explicit `Div` /
+`Mod` operations on `Zsqrtd 2` and a working extended-Bezout algorithm. The
+discriminant route gives only the existence of principal generators.
+
+Recommendation: S2 ACT pursues the discriminant route (per #18340). The
+Euclidean route is a candidate **optional S5 corollary** as the S1 plan
+originally proposed.
+
+## Why this doc is non-overlapping with #18340
+
+PR #18340 surveys:
+
+- `RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt` (one-shot via
+  Minkowski-bound discharge: $|d_K| = 8 < (2 \cdot 1 \cdot (4/2))^2 = 16$)
+- `Algebra.discr_powerBasis_eq_norm` for the discriminant computation
+- `AdjoinRoot` vs. `IntermediateField ℚ ℝ` setup choice
+- Explicit absence of `Zsqrtd 2 ≃+* 𝓞 Q_sqrt2` bridge at v4.26.0
+- Estimate: ~155 LOC, 0 sorries
+
+This doc adds the **complementary** survey of the Euclidean-domain route:
+
+- `Mathlib.NumberTheory.Zsqrtd.GaussianInt` line-by-line porting analysis
+- Real-quadratic-specific adjustments (signed norm, absolute-value
+  reformulation, `√2`-based `Div` via `Real.sqrt`)
+- The bridge construction (needed to feed Euclidean → `classNumber`)
+- Risk register specific to the real-quadratic setting
+
+Disjointness: same `sessions/` directory but a separate file; no
+state.md / knowledge.md / JSON / Lean changes.
+
+## Mathlib infrastructure at v4.26.0 (Mathlib rev `2df2f0150c275ad`)
+
+Files inspected:
+
+| File | Role |
+|---|---|
+| `Mathlib/NumberTheory/Zsqrtd/Basic.lean` (~970 lines) | `Zsqrtd d` for any `d : ℤ`: `CommRing`, `IsDomain`, signed `norm`, `star`, `lift` universal property |
+| `Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean` (~310 lines) | `EuclideanDomain (Zsqrtd (-1))` via `Complex.normSq` rounding |
+| `Mathlib/NumberTheory/Zsqrtd/ToReal.lean` (~35 lines) | `Zsqrtd.toReal : ℤ√d →+* ℝ` for `0 ≤ d` via `Real.sqrt` |
+| `Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean` | (unrelated; quadratic reciprocity via `Z[i]`) |
+
+Key Basic.lean facts used:
+
+- `Zsqrtd.norm (n : ℤ√d) : ℤ := n.re * n.re - d * n.im * n.im` (Basic.lean:477)
+- `Zsqrtd.norm_mul : norm (n * m) = norm n * norm m` (Basic.lean:497)
+- `Zsqrtd.norm_eq_one_iff : x.norm.natAbs = 1 ↔ IsUnit x` (Basic.lean:528)
+- `Zsqrtd.norm_nonneg : d ≤ 0 → 0 ≤ n.norm` (Basic.lean:518) — **does not apply for d = 2**
+- `Zsqrtd.norm_eq_of_associated : d ≤ 0 → ...` — same restriction
+- `instance : IsDomain (ℤ√d)` (Basic.lean:882; for all `d` such that `d` is not a square, or for the negative case; verify exact hypotheses)
+
+Key GaussianInt.lean structure (template for porting):
+
+```
+line 168:  instance : Div ℤ[i]                            -- via Complex round
+line 174:  theorem div_def                                -- explicit re/im formula
+line 178:  theorem toComplex_re_div                       -- Complex compat
+line 184:  theorem toComplex_im_div                       -- Complex compat
+line 190:  theorem normSq_le_normSq_of_re_le_of_im_le    -- norm monotonicity
+line 197:  theorem normSq_div_sub_div_lt_one             -- KEY: |fraction error|² < 1
+line 212:  instance : Mod ℤ[i]
+line 215:  theorem mod_def
+line 218:  theorem norm_mod_lt                            -- |x % y|.norm < y.norm
+line 229:  theorem natAbs_norm_mod_lt                     -- ℕ version
+line 233:  theorem norm_le_norm_mul_left
+line 240:  instance instNontrivial
+line 243:  instance : EuclideanDomain ℤ[i]                -- assembles the above
+```
+
+## Porting analysis: GaussianInt → Zsqrtd 2
+
+The Gaussian template runs over `ℂ` via `Zsqrtd.toComplex : ℤ[i] → ℂ`. For
+`Zsqrtd 2`, the analogous embedding is `Zsqrtd.toReal h : ℤ√2 → ℝ` (with
+`h : (0 : ℤ) ≤ 2 := by decide`). Each Gaussian helper has a real-quadratic
+counterpart, listed below with line counts and adjustments.
+
+### Adjustment 1: `toComplex` → `toReal` (line 64-141 of GaussianInt)
+
+**Gaussian**: 8 lemmas about `((x : ℤ[i]) : ℂ).re/im`, `toComplex_add/mul/neg/sub/star/zero/one/inj`.
+
+**Zsqrtd 2**: replace with 8 lemmas about `Zsqrtd.toReal h`. Most are
+auto-generated by the ring-hom universal property `Zsqrtd.lift` (Basic.lean:925).
+The `toComplex_inj` injectivity proof — line 128, 6 lines — ports to
+`Zsqrtd.toReal_injective` (already in ToReal.lean:30).
+
+**LOC**: ~20 (vs Gaussian's 80).
+
+### Adjustment 2: `norm_nonneg` → `abs_norm` (line 146 of GaussianInt)
+
+**Gaussian**: `norm_nonneg (x : ℤ[i]) : 0 ≤ norm x` — direct from `re² + im²`.
+
+**Zsqrtd 2**: norm is `re² - 2·im²` which can be negative. The required
+analog is the **absolute value**: `(x.norm : ℝ) = (toReal h x) * (toReal h (star x))`
+where `star (⟨a, b⟩) = ⟨a, -b⟩` (Basic.lean's `star` instance). So
+`toReal h x * toReal h (star x) = (a + b√2)(a - b√2) = a² - 2b²`.
+
+But for the Euclidean-domain norm we use **`Int.natAbs ∘ norm`**, which sidesteps
+the sign issue at the cost of one extra `Int.natAbs_lt_natAbs` step.
+
+**LOC**: ~6.
+
+### Adjustment 3: `Div` instance (line 168 of GaussianInt)
+
+**Gaussian** (5 lines):
+```
+instance : Div ℤ[i] :=
+  ⟨fun x y =>
+    let n := (norm y : ℚ)⁻¹
+    let c := star y
+    ⟨round ((x * c).re * n : ℚ), round ((x * c).im * n : ℚ)⟩⟩
+```
+
+This works because `x / y = (x · star y) / (y · star y) = (x · star y) / N(y)`,
+and rounding each component to the nearest integer gives the nearest Gaussian
+integer.
+
+**Zsqrtd 2**: identical formula! The norm `N(y) = re² - 2·im² : ℤ` may be
+**negative**, but the rounding `round (q : ℚ)` is sign-agnostic. So the
+`Div` instance ports verbatim:
+
+```
+instance : Div (ℤ√2) :=
+  ⟨fun x y =>
+    let n := (norm y : ℚ)⁻¹
+    let c := star y
+    ⟨round ((x * c).re * n : ℚ), round ((x * c).im * n : ℚ)⟩⟩
+```
+
+**Caveat**: when `N(y) = 0`, `n` is `0⁻¹ = 0` and `x / y = ⟨0, 0⟩`. This matches
+the EuclideanDomain requirement `quotient_zero` (Gaussian's proof at line 247
+ports verbatim).
+
+**LOC**: ~5.
+
+### Adjustment 4: KEY — `normSq_div_sub_div_lt_one` → `abs_norm_div_sub_div_lt_one`
+
+This is the **heart of the porting effort**.
+
+**Gaussian** (line 197, ~13 lines):
+
+```
+theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :
+    Complex.normSq ((x / y : ℂ) - ((x / y : ℤ[i]) : ℂ)) < 1 := ...
+```
+
+Bound: `normSq (p + q·i) = p² + q²` with `p, q ∈ [-1/2, 1/2]` (round error).
+Max is `(1/2)² + (1/2)² = 1/2 < 1`.
+
+**Zsqrtd 2**: the analog is
+
+```
+theorem abs_norm_div_sub_div_lt_one (x y : ℤ√2) :
+    |((x : ℝ) / (y : ℝ) - ((x / y : ℤ√2) : ℝ))| · ... < 1
+```
+
+But the **right** Zsqrtd-2 formulation uses the algebraic norm, not the
+real-distance norm. Let `r := x - y · (x / y) : ℤ√2`. The claim
+`|N(r)| < |N(y)|` follows from:
+
+```
+|N(r)| = |N(y · ((x : ℝ) / y - (x / y : ℤ√2)))|
+       = |N(y)| · |((x : ℝ) / y).re - (x / y : ℤ√2).re|
+                · |((x : ℝ) / y).re + (x / y : ℤ√2).re - 2 · ...|
+```
+
+Wait — the issue is that `Real.sqrt 2`-based "complex conjugate" is the
+**field-theoretic conjugate** `a + b√2 ↦ a - b√2`, not the complex conjugate
+`a + bi ↦ a - bi`. The map factors through `Zsqrtd.toReal h ∘ star`, sending
+`a + b√2 ∈ ℤ√2` to `a - b√2 ∈ ℝ`.
+
+The bound becomes:
+
+For `p, q ∈ [-1/2, 1/2]`, `|p² - 2q²| ≤ max(1/4, 1/2) = 1/2 < 1`. ✓
+
+Concrete algebraic skeleton (target ~25 LOC, vs Gaussian's 13):
+
+```
+theorem abs_norm_re_sub_round_le (x : ℚ) : |x - round x| ≤ 1/2 := abs_sub_round x
+
+theorem abs_norm_quad_lt_one (p q : ℝ) (hp : |p| ≤ 1/2) (hq : |q| ≤ 1/2) :
+    |p^2 - 2 * q^2| ≤ 1/2 := by
+  have hp2 : p^2 ≤ 1/4 := by nlinarith [sq_nonneg p]
+  have hq2 : q^2 ≤ 1/4 := by nlinarith [sq_nonneg q]
+  have h2q2 : 2 * q^2 ≤ 1/2 := by linarith
+  -- abs split
+  rcases abs_le.mp (show |p^2 - 2*q^2| ≤ 1/2 by ...) with ...
+  sorry  -- ~10 lines of nlinarith/positivity
+
+theorem abs_norm_div_sub_div_lt (x y : ℤ√2) (hy : y ≠ 0) :
+    |Zsqrtd.norm (x - y * (x / y : ℤ√2))| < |Zsqrtd.norm y| := ...
+```
+
+**LOC**: ~25.
+
+**Risk**: the `nlinarith` + `abs_le` algebraic juggle is more brittle than
+the Gaussian `Complex.normSq` calc. May need `polyrith` or explicit
+case-split on `sign (p² - 2q²)`.
+
+### Adjustment 5: `Mod` instance + `mod_def` + `norm_mod_lt`
+
+**Gaussian** (5 lines):
+```
+instance : Mod ℤ[i] := ⟨fun x y => x - y * (x / y)⟩
+theorem mod_def (x y : ℤ[i]) : x % y = x - y * (x / y) := rfl
+```
+
+**Zsqrtd 2**: ports verbatim.
+
+The accompanying `norm_mod_lt` proof (line 218 of GaussianInt, ~10 lines) is
+where Adjustment 4 lands. Restating:
+
+```
+theorem norm_mod_lt (x : ℤ√2) {y : ℤ√2} (hy : y ≠ 0) :
+    (x % y).norm.natAbs < y.norm.natAbs := ...
+```
+
+The Gaussian version chains via `Complex.normSq` and `(@Int.cast_lt ℝ _ _ _ _).1`.
+The Zsqrtd-2 version chains via `Int.natAbs_lt_natAbs_of_nonneg` (no,
+norm here can be negative, so use `Int.natAbs_lt_iff_abs_lt`) and
+`Adjustment 4`. Expected ~15 LOC.
+
+**LOC**: ~20.
+
+### Adjustment 6: `norm_le_norm_mul_left`
+
+**Gaussian** (line 233, ~5 lines):
+
+```
+theorem norm_le_norm_mul_left (x : ℤ[i]) {y : ℤ[i]} (hy : y ≠ 0) :
+    (norm x).natAbs ≤ (norm (x * y)).natAbs := by
+  rw [Zsqrtd.norm_mul, Int.natAbs_mul]
+  exact le_mul_of_one_le_right (Nat.zero_le _) (Int.ofNat_le.1 (by
+    rw [abs_natCast_norm]
+    exact Int.add_one_le_of_lt (norm_pos.2 hy)))
+```
+
+**Zsqrtd 2**: the proof structure ports verbatim — `Zsqrtd.norm_mul` is general
+in `d`. The Gaussian-specific `norm_pos.2 hy : 0 < norm y` does NOT hold for
+`Zsqrtd 2` (norm can be negative). Replace with `(norm y).natAbs ≠ 0`, which
+follows from `norm_eq_zero_iff` (Basic.lean:902, requires `d` non-square):
+
+```
+theorem norm_natAbs_pos {y : ℤ√2} (hy : y ≠ 0) : 0 < y.norm.natAbs := by
+  rw [Int.natAbs_pos]
+  intro h
+  have : (2 : ℤ) ≠ n * n := fun n => by nlinarith [sq_nonneg n, sq_nonneg (n+1)]
+  -- 2 is not a perfect square
+  exact hy ((Zsqrtd.norm_eq_zero (fun n hn => ...) y).mp h)
+```
+
+**LOC**: ~10 (5 for the analog + 5 for the perfect-square-of-2 lemma).
+
+### Adjustment 7: `Nontrivial`
+
+**Gaussian** (line 240): `instance instNontrivial : Nontrivial ℤ[i] := ⟨⟨0, 1, by decide⟩⟩`
+
+**Zsqrtd 2**: identical pattern.
+
+```
+instance instNontrivial : Nontrivial (ℤ√2) := ⟨⟨0, 1, by decide⟩⟩
+```
+
+**LOC**: 1.
+
+### Adjustment 8: `EuclideanDomain` assembly
+
+**Gaussian** (line 243, ~13 lines):
+
+```
+instance : EuclideanDomain ℤ[i] :=
+  { GaussianInt.instCommRing, GaussianInt.instNontrivial with
+    quotient := (· / ·)
+    remainder := (· % ·)
+    quotient_zero := by simp [div_def]; rfl
+    quotient_mul_add_remainder_eq := fun _ _ => by simp [mod_def]
+    r := _
+    r_wellFounded := (measure (Int.natAbs ∘ norm)).wf
+    remainder_lt := natAbs_norm_mod_lt
+    mul_left_not_lt := fun a _ hb0 => not_lt_of_ge <| norm_le_norm_mul_left a hb0 }
+```
+
+**Zsqrtd 2**: assembles Adjustments 3, 5, 6, 7 identically. **LOC**: ~13.
+
+## Total LOC estimate
+
+| Adjustment | Description | LOC |
+|---:|---|---:|
+| 1 | `toComplex` → `toReal` lemmas | 20 |
+| 2 | `norm_nonneg` → `abs_norm` (via `natAbs`) | 6 |
+| 3 | `Div` instance | 5 |
+| 4 | `abs_norm_div_sub_div_lt` (key proof) | 25 |
+| 5 | `Mod` + `mod_def` + `norm_mod_lt` | 20 |
+| 6 | `norm_le_norm_mul_left` + non-square-2 | 10 |
+| 7 | `Nontrivial` | 1 |
+| 8 | `EuclideanDomain` assembly | 13 |
+| - | imports + namespace + header docstring | 25 |
+| - | misc. lemma plumbing (`Int.natAbs_lt_iff_abs_lt` shims) | 15 |
+| - | safety buffer (sorry-fallbacks for sign-juggle in Adj 4) | 40 |
+| **Total** | | **~180** |
+
+This is **before** the bridge to `RingOfIntegers Q_sqrt2`.
+
+## Bridge to `RingOfIntegers Q_sqrt2`
+
+To feed `EuclideanDomain (Zsqrtd 2)` into `NumberField.classNumber Q_sqrt2 = 1`,
+we need a ring isomorphism:
+
+```
+def zsqrtd2_to_RingOfIntegers : (ℤ√2) ≃+* RingOfIntegers Q_sqrt2 := ...
+```
+
+The forward direction is clear: send `(⟨a, b⟩ : ℤ√2)` to `a + b · sqrt2_root`
+where `sqrt2_root` is the canonical generator of `Q_sqrt2 = AdjoinRoot (X² - 2)`.
+
+The inverse requires showing every algebraic integer in `Q_sqrt2` is of the
+form `a + b√2` with `a, b ∈ ℤ`. This is a number-theoretic fact: the ring of
+integers of $\mathbb{Q}(\sqrt 2)$ is exactly $\mathbb{Z}[\sqrt 2]$ since
+$2 \not\equiv 1 \pmod 4$. (Contrast $\mathbb{Q}(\sqrt 5)$, where the ring
+of integers is $\mathbb{Z}[(1 + \sqrt 5)/2]$, strictly bigger than
+$\mathbb{Z}[\sqrt 5]$.)
+
+The Mathlib-shaped proof needs:
+
+1. `IsIntegralClosure (ℤ√2) ℤ Q_sqrt2` — exhibits `ℤ√2` as the integral
+   closure of `ℤ` in `Q_sqrt2`.
+2. Apply `IsIntegralClosure.equiv` (Mathlib's
+   `RingTheory.IntegralClosure.Basic`) to get the iso to
+   `RingOfIntegers Q_sqrt2` (which by definition is the integral closure).
+
+**LOC estimate**: ~60 for the bridge, with ~3 strategic sorries on the
+integral-closure proof (requires Gauss-Lemma-style trace/norm argument for
+`2 ≢ 1 (mod 4)`).
+
+## Comparison table: discriminant route vs Euclidean route
+
+| Aspect | Discriminant (#18340) | Euclidean (this doc) |
+|---|---|---|
+| Target | `h_K = 1` | `EuclideanDomain (ℤ√2)`, then optional bridge to `h_K = 1` |
+| LOC for `h_K = 1` | ~155 | ~180 + 60 = 240 |
+| LOC for `EuclideanDomain (ℤ√2)` | not produced | ~180 |
+| Sorries | 0 expected | 0–3 in bridge |
+| Key Mathlib lemma | `RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt` (`NumberField/ClassNumber.lean:198`) | `EuclideanDomain` constructor (`Algebra/EuclideanDomain/Defs.lean`) |
+| Key compute | `\|disc\| = 8 < 16` (norm_num) | `\|p² - 2q²\| ≤ 1/2 < 1` (nlinarith) |
+| Setup choice | `AdjoinRoot (X² - 2)` recommended | `Zsqrtd 2` (Mathlib-given) |
+| Constructive output | non-constructive (existence of generators) | constructive (`Div`, `Mod`, extended-Bezout) |
+| Pedagogical match | Marcus 1977 §5.3 | Stewart-Tall §9.3, Hardy-Wright §14.6 |
+| Sister-field scaling | scales to all `√d`, `d` small | scales to `d ∈ {-1, -2, -3, -7, -11, 2, 3, 6, 7, 11, 14, 19, 21, 22, 23, 29, ...}` (Heegner-Stark + Chatland-Davenport list) |
+| Risk | sign-of-discriminant API drift | sign-juggle in Adjustment 4 |
+
+## Recommendation
+
+Per S1's plan:
+
+- **S2 ACT (primary)**: follow #18340's discriminant route. Cheaper for the
+  literal OQ-03 target.
+- **S3 ACT**: bridge `ℤ√2 ≃+* 𝓞 Q_sqrt2` is useful **regardless of route**
+  (lets the gallery present both narrative and algorithm).
+- **S5 ACT (optional)**: instantiate `EuclideanDomain (ℤ√2)` per this doc
+  for the constructive corollary. Gives the **algorithm** that the
+  discriminant route only proves exists.
+
+The Euclidean route is not the recommended primary path, but is a documented
+secondary deliverable with a precise LOC budget and risk register.
+
+## Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Sign-juggle in `abs_norm_div_sub_div_lt` (Adjustment 4) brittler than Gaussian's `normSq` calc | medium | fallback to explicit case-split on `sign (p² − 2q²)`; or extract two unsigned lemmas (`p² + 2q² ≤ ...` and `|p² − 2q²| ≤ p² + 2q²`) and chain |
+| `Zsqrtd.norm_eq_zero` (Basic.lean:902) requires `∀ n, d ≠ n * n` hypothesis | low | provide `(fun n : ℤ => by decide)` for `d = 2` — but `decide` may blow up; use `nlinarith [sq_nonneg n, sq_nonneg (n+1)]` instead, ~3 lines |
+| Bridge `IsIntegralClosure (ℤ√2) ℤ Q_sqrt2` requires Gauss-Lemma-style trace/norm reasoning | medium | defer to S3 PREP doc-only survey; not blocking for #18340's primary route |
+| `Real.sqrt 2`-based `Div` triggers noncomputability when chained with `Decidable` instances | low | `Zsqrtd.toReal` is `noncomputable` already in ToReal.lean; this only affects `#eval`, not proofs. The `Div` formula uses `ℚ`-rounding and stays computable |
+| Mathlib pin v4.26.0 may have `Algebra.discr_powerBasis_eq_norm` sign convention different from textbook | low | discriminant of $\mathbb{Q}(\sqrt 2)$ over $\mathbb{Q}$ is +8 (Marcus 1977 p. 90), but Mathlib's `Algebra.discr` may use $\det(\text{Tr}(b_i \cdot b_j))$ vs $\det^2$; verify in S2 ORIENT |
+| `Adjustment 4`'s `nlinarith` step may time out at `maxHeartbeats 200000` | low | extract to a `private` lemma with explicit `(p : ℝ) (hp : |p| ≤ 1/2) → ...` hypothesis, isolating the algebraic step. Used `set_option maxHeartbeats 800000` in the parent file already |
+
+## Cross-references
+
+- Parent file: `proofs/Proofs/Sqrt2Minpoly.lean` (140 lines, 0 sorries, 0 axioms).
+  Reusable: `irred_X_sq_sub_two : Irreducible (X^2 - C 2 : ℚ[X])` (line 72).
+- Sibling slugs: `sqrt2-minpoly-oq-01`, `sqrt2-minpoly-oq-02` (open question
+  children of the parent).
+- Mathlib precedent: `Mathlib/NumberTheory/Cyclotomic/PID.lean` — Q(ζ₃)'s
+  class-number-1 via a similar pattern (PR #18340 surveys this).
+- Hardy & Wright, *An Introduction to the Theory of Numbers* (6th ed.), §14.6
+  "Quadratic fields of class-number one".
+- Stewart & Tall, *Algebraic Number Theory and Fermat's Last Theorem*, §9.3
+  "Euclidean quadratic fields".
+- Chatland-Davenport (1950) "Euclid's algorithm in real quadratic fields"
+  — the canonical list of `d > 0` for which $\mathbb{Z}[\sqrt d]$ (or its
+  ring of integers) is Euclidean. $d = 2$ is on the list; $d = 23$ is the
+  largest real-quadratic Euclidean field.
+
+## Honest assessment
+
+This document does **not** introduce new mathematical content. The Stewart-Tall
+Euclidean argument for $\mathbb{Z}[\sqrt 2]$ is textbook (Hardy-Wright §14.6,
+Stewart-Tall §9.3, Marcus §5 Exercise 12). The contribution is engineering:
+
+1. **A precise LOC budget** for porting `GaussianInt.lean` to `Zsqrtd 2`:
+   8 adjustments, ~180 lines for the instance, ~60 for the bridge.
+2. **A risk register** specific to the sign-and-absolute-value pivot from
+   the negative-discriminant case to the positive-discriminant case.
+3. **A reasoned recommendation** that the Euclidean route is a strictly
+   harder path to the same `h_K = 1` target than the discriminant route
+   surveyed in #18340, and should be pursued (if at all) as an optional S5
+   corollary providing constructive output.
+
+This is consistent with S1 OBSERVE's framing, which listed the Minkowski
+route as the primary and the Euclidean route as "S5 optional".
+
+## Disjointness probe (pre-push)
+
+Re-run at S2 PREP-2 push start (2026-05-12 ~23:25 UTC):
+
+- `gh pr list -R rjwalters/lean-genius --state open --search "sqrt2-minpoly-oq-03"` →
+  0 open research PRs (#18340 merged into `origin/main` since this doc was drafted)
+- `git log origin/main --oneline -- research/problems/sqrt2-minpoly-oq-03/sessions/` →
+  1 commit: `31dd3bdfb92` (PR #18340, the discriminant-route survey)
+  — sessions directory now exists on `origin/main` with the discriminant-route file
+- This file's name: `2026-05-12-s2-prep-euclidean-route.md` — distinct from
+  `2026-05-12-s2-prep-mathlib-api-survey.md` (already in `origin/main` from #18340)
+
+Pristine doc-only deliverable: 0 Lean changes, 0 state.md changes, 0
+knowledge.md changes, 0 problem.md changes, 0 JSON changes, 0 meta.json
+changes. Only adds the new sessions file alongside the merged discriminant
+survey.


### PR DESCRIPTION
## Summary

S2 PREP-2 doc-only complement to merged #18340's discriminant-route survey for `sqrt2-minpoly-oq-03` (class number 1 for $\mathbb{Q}(\sqrt 2)$).

This PR surveys the **second route** flagged in S1 OBSERVE: `EuclideanDomain (Zsqrtd 2)` ported from Mathlib's `Zsqrtd/GaussianInt.lean` template via 8 sign-and-absolute-value adjustments.

## Headline

- **~180 Lean lines** for the `EuclideanDomain` instance alone
- **~60 lines** for the bridge `Zsqrtd 2 ≃+* RingOfIntegers Q_sqrt2` if fed into `NumberField.classNumber`
- Strictly **more work** than the discriminant route (~155 LOC, 0 sorries) for the same `h_K = 1` target
- **Unique deliverable**: constructive `Div`/`Mod` operations, explicit Bezout/extended-GCD algorithm

## Adjustments analyzed (line-by-line vs. `Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean` at v4.26.0)

| # | Adjustment | LOC |
|---:|---|---:|
| 1 | toComplex → toReal h lemmas | 20 |
| 2 | norm_nonneg → Int.natAbs ∘ norm | 6 |
| 3 | Div instance — formula ports verbatim | 5 |
| 4 | KEY: abs_norm_div_sub_div_lt sign-juggle | 25 |
| 5 | Mod + mod_def + norm_mod_lt | 20 |
| 6 | norm_le_norm_mul_left + non-square-2 | 10 |
| 7 | Nontrivial | 1 |
| 8 | EuclideanDomain assembly | 13 |
| - | imports, namespace, plumbing, safety buffer | 80 |
| Total | | ~180 |

## Recommendation

- **S2 ACT (primary)**: pursue #18340's discriminant route (cheaper for h_K = 1)
- **S5 ACT (optional)**: instantiate EuclideanDomain (ℤ√2) for the algorithmic corollary

Consistent with S1 OBSERVE's framing.

## Files

- `research/problems/sqrt2-minpoly-oq-03/sessions/2026-05-12-s2-prep-euclidean-route.md` (+445 LOC, pristine new file)

## Disjointness

Pristine doc-only. No Lean / state.md / knowledge.md / problem.md / JSON / meta.json changes. Sits alongside #18340's `2026-05-12-s2-prep-mathlib-api-survey.md` in `sessions/`.

## Build status

N/A (doc-only).

## Test plan

- [ ] Verify GaussianInt.lean line numbers (168, 197, 218, 233, 240, 243) at v4.26.0
- [ ] LOC estimates calibrated against actual GaussianInt template (~310 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)