### PR TITLE
audit: sync meta counts for cramers-oq01020101 (sorries 0→1) + brouwer-oq0102 (axioms 2→3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1289,10 +1289,10 @@
       "result": "clean"
     },
     "brouwer-fixed-point-oq-01-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-12T15:32:04Z",
-      "result": "clean"
+      "lastAudited": "2026-05-12T23:30:00Z",
+      "result": "issues-fixed"
     },
     "brouwer-fixed-point-oq-01-oq-03": {
       "auditCount": 2,
@@ -15182,10 +15182,10 @@
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-12T14:44:15Z",
-      "result": "clean"
+      "lastAudited": "2026-05-12T23:30:00Z",
+      "result": "issues-fixed"
     },
     "kepler-conjecture-oq-04": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Two real drifts flagged by `find-targets --issues` at HEAD `e2d35ed3a8a`. Closes both flagged audit issues; `find-targets --issues` returns 0 results on this branch.

### 1. `cramers-rule-oq-01-oq-02-oq-01-oq-01` — sorry mismatch (claims 0, actual 1)

PR #18098 (S2 ACT — uniform-in-n commutative quasideterminant `qdetF`) scaffolded the deferred S3 theorem `qdetN_step_eq_qdetF` with a `sorry` at line 269, but did not bump `meta.sorries`. Status remains `formalized/original` (already permits sorries).

- `meta.sorries`: 0 → 1
- `meta.lineCount`: 187 → 275 (file grew from S2 scaffold)
- `leanFile.sorries`: 0 → 1
- `leanFile.lineCount`: 187 → 275
- top-level `sorries`: 0 → 1

### 2. `brouwer-fixed-point-oq-01-oq-02` — axiom undercount (claims 2, actual 3)

PR #18168 (S7 ACT-D-1 — thin B2 surrogate + substantive sphere theorem) added the substantive B2 surrogate axiom `sphere_singularHomology_nonzero` at line 351, alongside `H_n_minus_1_sphere_nonzero` (line 261) and `contractible_singularHomology_zero` (line 287), but did not bump `meta.axiomCount`. The `no_retraction_axiom` mention at line 44 is inside a markdown block comment (correctly excluded by `find-targets`).

- `meta.axiomCount`: 2 → 3
- `meta.lineCount`: 375 → 462
- `meta.assumptions`: rewritten to enumerate all three axioms and their distinct roles
- `leanFile.axiomCount`: 2 → 3
- `leanFile.lineCount`: 375 → 462

`theoremCount` left untouched on both entries — PR #18171 is in flight with its own sync convention for that field; staying out of the way to avoid the broad-vs-bare oscillation cycle.

### Audit tracker

Both entries advanced from `clean` to `issues-fixed` with bumped audit counts.

## Test plan

- [x] `python3 -m json.tool` validates both updated meta.json files
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 in this worktree
- [x] No `meta.json` field convention churn (theoremCount untouched)
- [x] Manual axiom inventory of `BrouwerFixedPointOQ01OQ02.lean` outside doc comments: 3 (`H_n_minus_1_sphere_nonzero` L261, `contractible_singularHomology_zero` L287, `sphere_singularHomology_nonzero` L351)
- [x] Manual sorry inventory of `CramersRuleOQ01OQ02OQ01OQ01.lean` outside doc comments: 1 (`qdetN_step_eq_qdetF` L269)

🤖 Generated with [Claude Code](https://claude.com/claude-code)