### PR TITLE
fix(meta): sync drift in cramers-rule + brouwer (sorries / axiomCount)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -149,7 +149,7 @@
   "leanFile": {
     "lineCount": 375,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "sorries": 0,
     "definitionCount": 3,
     "theoremCount": 13

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "recursion"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 187,
     "assumptions": "None for the qdetF definition and the multiplicative identity. The n=2 specialization theorems require the non-degeneracy hypothesis carried in the parent file (A 1 1 ≠ 0 for the (0,0)-case, A 0 0 ≠ 0 for the (1,1)-case).",
@@ -134,7 +134,7 @@
     "theoremCount": 6,
     "definitionCount": 2,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Two auditor-flagged drift issues cleared via single-field bumps. After this PR, `npx tsx scripts/auditor/find-targets.ts --stats` reports **0 unaudited / 0 issues across 2428 proofs**.

### cramers-rule-oq-01-oq-02-oq-01-oq-01 — sorry mismatch: claims 0, actual 1

PR #18214 (`S3 SCAFFOLD — qdetN_step one-step Schur formula + field-consistency bridge`) added the deferred `qdetN_step_eq_qdetF` sorry to `proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean:269`. It updated only `research/.../state.md` and the research JSON; the gallery `meta.json` was not synced.

Bumped both:
- `meta.sorries`: 0 → 1
- `leanFile.sorries`: 0 → 1

### brouwer-fixed-point-oq-01-oq-02 — axiom undercount: claims 2, actual declarations 3

PR #18168 (`S7 ACT-D-1 exec — thin B2 surrogate axiom + substantive sphere theorem`, merged 23:21 UTC) added the file-level axiom `sphere_singularHomology_nonzero` at line 351 of `proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean`. The merge updated only the parent slug's research JSON (brouwer-fixed-point-oq-01-oq-02-**oq-03-oq-02**); the sibling slug's gallery `meta.json` was not synced. (PR #18179's audit-tracker sweep that flagged this slug as clean predated #18168.)

Note: the `axiom no_retraction_axiom` reference at line 44 sits inside the file's `/- ... -/` docstring block (markdown-style code fence) and is correctly stripped by `find-targets`'s comment scanner. The 3 real axiom declarations are `H_n_minus_1_sphere_nonzero` (line 261), `contractible_singularHomology_zero` (line 287, added by PR #18018), and `sphere_singularHomology_nonzero` (line 351, added by PR #18168).

Bumped both:
- `meta.axiomCount`: 2 → 3
- `leanFile.axiomCount`: 2 → 3

Narrative descriptors (`originalContributions`, `assumptions`, `description`) that mention "2 axioms / 13 theorems" are intentionally left unchanged to minimize conflict surface with concurrent enrichment PRs touching brouwer slugs. A follow-up narrative-sync (mirroring PR #18060's pattern) can land once those settle.

## Test plan

- [x] `find-targets --issues` returns 0 results on this branch
- [x] `find-targets --stats` confirms 0 issues across 2428 proofs
- [x] No Lean code changes; pure metadata bump
- [x] Diff is exactly 4 lines (2 fields × 2 slugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)