### PR TITLE
fix(meta): sync sorry/axiom counts on cramers-rule-...-oq-01 + brouwer-fp-oq-01-oq-02

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -149,7 +149,7 @@
   "leanFile": {
     "lineCount": 375,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "sorries": 0,
     "definitionCount": 3,
     "theoremCount": 13

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "recursion"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 187,
     "assumptions": "None for the qdetF definition and the multiplicative identity. The n=2 specialization theorems require the non-degeneracy hypothesis carried in the parent file (A 1 1 ≠ 0 for the (0,0)-case, A 0 0 ≠ 0 for the (1,1)-case).",
@@ -134,7 +134,7 @@
     "theoremCount": 6,
     "definitionCount": 2,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {
@@ -146,5 +146,5 @@
       "url": "https://en.wikipedia.org/wiki/Quasideterminant"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Clears two auditor-flagged drifts surfaced by `scripts/auditor/find-targets.ts --issues`:

- `cramers-rule-oq-01-oq-02-oq-01-oq-01`: bumps `sorries` 0 → 1 (three sites: `meta.meta.sorries`, `meta.leanFile.sorries`, top-level `meta.sorries`). The Lean source has one `sorry` at line 269 (`qdetN_step_eq_qdetF`, the deferred S3 field-consistency reduction).
- `brouwer-fixed-point-oq-01-oq-02`: bumps `axiomCount` 2 → 3 (two sites: `meta.meta.axiomCount`, `meta.leanFile.axiomCount`). The Lean source declares three real axioms — `H_n_minus_1_sphere_nonzero`, `contractible_singularHomology_zero`, and `sphere_singularHomology_nonzero` (the last added by PR #18168 without a meta bump).

No theoremCount/lineCount edits — those conventions are still being reconciled across other open meta-drift PRs (#18170 #18171 #18184) and are not flagged by `find-targets`. Scope is narrowed to the script-flagged drift only.

## Verification

```
$ tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

(Before this PR: 2 targets — sorry mismatch on cramers-rule and axiom undercount on brouwer.)

## Test plan

- [x] JSON syntax validates
- [x] find-targets.ts --issues reports 0 targets after fix
- [x] No theoremCount/lineCount changes that could conflict with open PRs #18170/#18171/#18184

🤖 Generated with [Claude Code](https://claude.com/claude-code)