### PR TITLE
Enrich ehrhart-cube-proven-oq-03: crossReferences schema fix + depth

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-03/annotations.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-hypersimplex-lattice-count",
     "proofId": "ehrhart-cube-proven-oq-03",
-    "range": { "startLine": 55, "endLine": 62 },
+    "range": { "startLine": 56, "endLine": 62 },
     "type": "definition",
     "title": "`hypersimplexLatticeCount`: Slice Cardinality",
     "content": "`hypersimplexLatticeCount d k n` is the cardinality of `Finset.univ.filter (Σ x_i = n · k)` over the finite function space `Fin d → Fin (n + 1)`. Mirrors the parent file's `cube_lattice_count` (which counts the whole cube `(Fin d → Fin (n+1))`) but adds the slice predicate. This is the central object: `L(Δ(d, k), n) = hypersimplexLatticeCount d k n`. The choice to inline the predicate `(∑ i : Fin d, (x i : ℕ)) = n * k` rather than reference `coordSumEq d n (n * k)` is intentional — it gives `decide` direct access to the unfolded form without an extra `unfold` step, which materially reduces the runtime of the four sanity checks in Section III.",
@@ -72,9 +72,21 @@
     "prerequisites": ["`Finset.card_image_of_injective`", "`Finset.sum_sub_distrib`", "`Fin.cast`"]
   },
   {
+    "id": "ann-namespace-scope",
+    "proofId": "ehrhart-cube-proven-oq-03",
+    "range": { "startLine": 35, "endLine": 35 },
+    "type": "context",
+    "title": "Namespace `EhrhartCubeProvenOQ03`",
+    "content": "All definitions and theorems are scoped under `namespace EhrhartCubeProvenOQ03`. This is deliberate: the family's siblings (`EhrhartCubeProven`, `EhrhartSimplexProven`, `EhrhartCrossPolytope`, `EhrhartCubeProvenOQ04`) each take their own namespace, so the S2/S3 proofs of this file can reference (e.g.) `EhrhartSimplexProven.simplex_lattice_count` and `EhrhartCubeProvenOQ04.eulerian` unambiguously without `open`-clashing. The scaffold ends with a matching `end EhrhartCubeProvenOQ03` at line 119, bracketing the entire file's content inside the namespace and producing fully-qualified names like `EhrhartCubeProvenOQ03.hypersimplexLatticeCount` for use by downstream files in the S4+ chain.",
+    "mathContext": "Lean's namespace mechanism is purely lexical and does not affect proof content, but it determines linkage at the import level: downstream files referencing the hypersimplex count by short name must either `open EhrhartCubeProvenOQ03` or use the fully-qualified path.",
+    "significance": "context",
+    "relatedConcepts": ["Lean namespace", "module organisation", "sibling Ehrhart files"],
+    "prerequisites": ["Lean 4 namespace semantics"]
+  },
+  {
     "id": "ann-sanity-checks",
     "proofId": "ehrhart-cube-proven-oq-03",
-    "range": { "startLine": 93, "endLine": 119 },
+    "range": { "startLine": 93, "endLine": 117 },
     "type": "technique",
     "title": "Section III — Four `decide` Sanity Checks",
     "content": "Four concrete numeric verifications closed by `decide`: (i) $L(\\Delta(2,1), 2) = 3$ (the points $(0,2), (1,1), (2,0)$); (ii) $L(\\Delta(3,1), 1) = 3$ (the three standard basis directions $e_1, e_2, e_3$); (iii) $L(\\Delta(3,2), 1) = 3$ (palindrome witness — same value as $\\Delta(3,1)$); (iv) $L(\\Delta(3,1), 2) = \\binom{4}{2} = 6$ (binomial witness for the S2 target with $d = 3$, $n = 2$). These `decide` proofs anchor the definition: any future iteration that breaks them would change the meaning of `hypersimplexLatticeCount`. Cumulatively the four checks cross-validate the *three* pieces of structure stated in Section II: the formula (via the binomial check (iv)), the palindrome (via (ii) vs (iii)), and the base case ($n = 1$ in dimension $d$ gives $d$ standard basis vectors when $k = 1$).",

--- a/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
@@ -63,7 +63,9 @@
       "**The two reduction identities in this scaffold are *both* corollaries of the same lattice involution** $x \\mapsto n\\mathbf{1} - x$ on $\\mathbb{Z}^d \\cap [0, n]^d$. The palindrome (k ↔ d - k) is the direct statement; the k = 1 reduction follows by composing the involution with the standard-simplex multiset bijection. Once the involution is in place, S2 and S3 become two instances of the same `Finset.card_image_of_injective` lemma.",
       "**The choice to encode lattice points as `Fin d → Fin (n + 1)` rather than as a tuple `Fin d × ℕ` is load-bearing.** The decidable instance for `coordSumEq` only synthesises automatically because `Fin (n + 1)` is itself a `Fintype` with decidable equality — a switch to `ℕ`-valued coordinates would require an external decidability proof and would block the four `decide` sanity checks, which currently anchor the definition against future drift.",
       "**The palindrome identity is the combinatorial shadow of Ehrhart–Macdonald reciprocity** $L(P, -n) = (-1)^d L(P^\\circ, n)$ specialised to hypersimplices. The involution $x \\mapsto n\\mathbf{1} - x$ that proves it is exactly the duality realising $\\Delta(d, k)^\\circ \\cong \\Delta(d, d - k)^\\circ$ on interior lattice points, and it explains why the h*-vector of the hypersimplex is palindromic ($A(d - 1, j) = A(d - 1, d - 1 - j)$) without invoking the full reciprocity theorem.",
-      "**The scaffold deliberately defers the generic Stanley formula to S4+.** Encoding the inclusion–exclusion $\\sum_j (-1)^j \\binom{d}{j} \\binom{n(k - j) + d - 1}{d - 1}$ in Lean requires either signed sums (`Finset.sum_range` with `Int.negSucc`) or a careful $\\mathbb{N}$-truncation argument. The two reduction identities are sufficient to validate the definition empirically (via the four `decide` checks) and to verify the palindrome symmetry, while postponing the harder inclusion–exclusion accounting to a later iteration that can build on `EhrhartCubeProvenOQ04.lean`'s Worpitzky identity."
+      "**The scaffold deliberately defers the generic Stanley formula to S4+.** Encoding the inclusion–exclusion $\\sum_j (-1)^j \\binom{d}{j} \\binom{n(k - j) + d - 1}{d - 1}$ in Lean requires either signed sums (`Finset.sum_range` with `Int.negSucc`) or a careful $\\mathbb{N}$-truncation argument. The two reduction identities are sufficient to validate the definition empirically (via the four `decide` checks) and to verify the palindrome symmetry, while postponing the harder inclusion–exclusion accounting to a later iteration that can build on `EhrhartCubeProvenOQ04.lean`'s Worpitzky identity.",
+      "**The `decide`-cost ceiling sets a hard upper bound on the size of the sanity checks.** Each `decide` proof exhausts the finite function space `Fin d → Fin (n + 1)` of size $(n + 1)^d$. For the four chosen tuples $(d, k, n) \\in \\{(2, 1, 2), (3, 1, 1), (3, 2, 1), (3, 1, 2)\\}$ the search spaces are $3^2 = 9$, $2^3 = 8$, $2^3 = 8$, $3^3 = 27$ — all well within Lean's compile-time evaluator. The binomial witness `hypersimplex_count_3_1_2 = C(4, 2)` is the largest of the four at 27 evaluations; pushing $n$ to 3 or $d$ to 4 would put the enumeration into the hundreds and risk `decide` timeouts, which is why the scaffold stops at $(d, n) \\le (3, 2)$ rather than verifying (say) $L(\\Delta(4, 2), 2)$.",
+      "**The encoding `Fin d → Fin (n+1)` over the bare `Σ x_i = n·k` predicate vs. `Sym (Fin d) (n·k)` is a deliberate trade-off.** The `Sym` approach would have the bijection with multisets baked in (making S2 a single `Sym.card_sym_eq_choose` invocation) but would force the palindrome involution to lift through the quotient by permutations, which is non-trivial because $x \\mapsto n\\mathbf{1} - x$ is a coordinate-wise involution, not a symmetric one. Keeping coordinates ordered makes the palindrome immediate at the cost of one extra step for S2 (re-bridging to `Sym`). The scaffold's choice reflects the trade: S3 (the involution) is the more delicate of the two reductions, so the encoding optimises for it."
     ]
   },
   "conclusion": {
@@ -83,28 +85,24 @@
   },
   "crossReferences": [
     {
-      "type": "parent",
-      "slug": "ehrhart-cube-proven",
-      "title": "Ehrhart Polynomial of the Unit Cube: First-Principles Proof",
-      "relation": "Parent problem; supplies the `(Fin d → Fin (n+1))` lattice-point encoding reused here for the slice Σ x_i = n·k."
+      "targetId": "ehrhart-cube-proven",
+      "relationship": "parent",
+      "description": "Parent problem (Ehrhart Polynomial of the Unit Cube: First-Principles Proof); supplies the `(Fin d → Fin (n+1))` lattice-point encoding reused here for the slice Σ x_i = n·k."
     },
     {
-      "type": "sibling",
-      "slug": "ehrhart-cube-proven-oq-01",
-      "title": "Ehrhart Polynomial of the Standard Simplex: First-Principles Proof",
-      "relation": "Sibling: supplies the multiset bijection `Sym (Fin (d+1)) n` whose specialisation discharges OQ-03's k = 1 case."
+      "targetId": "ehrhart-cube-proven-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling (Ehrhart Polynomial of the Standard Simplex: First-Principles Proof); supplies the multiset bijection `Sym (Fin (d+1)) n` whose specialisation discharges OQ-03's k = 1 case via `Sym.card_sym_eq_choose`."
     },
     {
-      "type": "sibling",
-      "slug": "ehrhart-cube-proven-oq-02",
-      "title": "Ehrhart Polynomial of the Cross-Polytope: Axiom-Free Proof",
-      "relation": "Sibling: parallel hyperplane-slice family; Pascal/hockey-stick algebraic infrastructure reusable for the generic Stanley formula in OQ-03 S4+."
+      "targetId": "ehrhart-cube-proven-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling (Ehrhart Polynomial of the Cross-Polytope: Axiom-Free Proof); parallel hyperplane-slice family. Pascal/hockey-stick algebraic infrastructure reusable for the generic Stanley formula in OQ-03 S4+."
     },
     {
-      "type": "sibling",
-      "slug": "ehrhart-cube-proven-oq-04",
-      "title": "Eulerian-Number Interpretation of the h*-Vector of the Unit Cube",
-      "relation": "Sibling: Stanley's general hypersimplex formula `L(Δ(d, k), n) = Σ_j A(d-1, j) · C(n - j + d - 1, d - 1)` uses the Eulerian numbers `A(d-1, j)` formalised in OQ-04 — the S4+ bridge target."
+      "targetId": "ehrhart-cube-proven-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling (Eulerian-Number Interpretation of the h*-Vector of the Unit Cube); Stanley's general hypersimplex formula `L(Δ(d, k), n) = Σ_j A(d-1, j) · C(n - j + d - 1, d - 1)` uses the Eulerian numbers `A(d-1, j)` formalised in OQ-04 — the S4+ bridge target via the identity h*(Δ(d, k)) = A(d - 1, k - 1)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `ehrhart-cube-proven-oq-03` (Ehrhart Polynomial of the Hypersimplex: First-Principles Scaffold).

### Schema fix (4 crossReferences)

The four `crossReferences[]` entries used a non-canonical layout (`type` / `slug` / `title` / `relation`) that does not match the `CrossReference` interface in `src/types/proof.ts` (which expects `targetId` / `relationship` / `description`). Normalised all four; the `title` content was folded into `description` so no information is lost. This makes the cross-references actually consumable by the proof-page UI.

### Content depth

- **1 new annotation** `ann-namespace-scope` explaining the `namespace EhrhartCubeProvenOQ03` scoping decision and its downstream-import implications for the S4+ chain.
- **2 new `keyInsights`**:
  - The `decide`-cost ceiling: enumeration size $(n+1)^d \le 27$ on the four chosen tuples explains why the sanity-check grid stops at $(d, n) \le (3, 2)$ rather than testing larger $n$.
  - The `Fin d → Fin (n+1)` vs. `Sym (Fin d) (n·k)` encoding trade-off: the coordinate-ordered encoding keeps the palindrome involution coordinate-wise at the cost of one extra bridge step for the S2 multiset reduction.

### Range corrections

- `ann-hypersimplex-lattice-count` startLine 55 → 56 (def starts at 56 after docstring line).
- `ann-sanity-checks` endLine 119 → 117 (the line-119 `end` declaration is not a Lean construct the annotation should claim).

### Verified

- [x] `tsc -b --noEmit tsconfig.app.json` — exit 0
- [x] `scripts/annotations/build.ts` — no findings for this slug
- [x] JSON validates

No changes to the Lean file. `sorries=2`, `axiomCount=0`, badge `formalized` remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)