### PR TITLE
research(abel-ruffini-galois-extensions-oq-06): S3 ACT — discharge `AGL1Z_isSolvable` + `AGL1Z_faithful_action` (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean
@@ -157,30 +157,197 @@ theorem nat_card_eq : Nat.card (AGL1Z p) = p * (p - 1) := by
 end AGL1Z
 
 /-!
-  ## Deferred (S3+ stubs)
+  ## S3 — Solvability via short exact sequence
 
-  The following are placeholders for the next iteration. Each is replaced
-  by a sorry-free proof in S3 (solvability + faithfulness) or S4 (primitivity).
+  Both ends `(Multiplicative (ZMod p), +)` and `(ZMod p)ˣ` are abelian and
+  hence solvable (`CommGroup.isSolvable`); the middle term `AGL1Z p` is then
+  solvable via `solvable_of_ker_le_range` applied to the translation
+  inclusion and the scaling projection.
 -/
+
+namespace AGL1Z
+
+variable {p : ℕ} [hp : Fact p.Prime]
+
+/--
+  The "scale" projection `AGL1Z p →* (ZMod p)ˣ`. The translation kernel of
+  this map is the abelian normal subgroup of pure translations.
+-/
+def scaleHom (p : ℕ) [Fact p.Prime] : AGL1Z p →* (ZMod p)ˣ where
+  toFun g := g.scale
+  map_one' := AGL1Z.one_scale
+  map_mul' g h := AGL1Z.mul_scale g h
+
+/--
+  The "translation" inclusion `Multiplicative (ZMod p) →* AGL1Z p`.
+  Sends the `Multiplicative`-encoded `a` to the pure translation `(a, 1)`.
+  `Multiplicative` is the standard way to view the additive group `ZMod p`
+  as a multiplicative group so that we can build a `MonoidHom` into the
+  multiplicative `AGL1Z p`.
+-/
+def transHom (p : ℕ) [Fact p.Prime] :
+    Multiplicative (ZMod p) →* AGL1Z p where
+  toFun a := ⟨Multiplicative.toAdd a, 1⟩
+  map_one' := by
+    apply AGL1Z.ext
+    · rfl
+    · rfl
+  map_mul' a b := by
+    apply AGL1Z.ext
+    · -- `(a * b).toAdd = a.toAdd + b.toAdd` definitionally
+      show (Multiplicative.toAdd (a * b) : ZMod p)
+          = Multiplicative.toAdd a + ((1 : (ZMod p)ˣ) : ZMod p)
+              * Multiplicative.toAdd b
+      push_cast
+      ring
+    · -- 1 = 1 * 1 in `(ZMod p)ˣ`
+      show (1 : (ZMod p)ˣ) = 1 * 1
+      simp
+
+/--
+  The kernel of the scale projection is contained in the range of the
+  translation inclusion: every `(a, u)` with `u = 1` is the image of
+  `Multiplicative.ofAdd a` under `transHom`.
+-/
+theorem ker_scaleHom_le_range_transHom (p : ℕ) [Fact p.Prime] :
+    (scaleHom p).ker ≤ (transHom p).range := by
+  intro g hg
+  rw [MonoidHom.mem_ker] at hg
+  -- `hg : g.scale = 1`. Witness: `Multiplicative.ofAdd g.trans`.
+  refine ⟨Multiplicative.ofAdd g.trans, ?_⟩
+  apply AGL1Z.ext
+  · rfl
+  · -- Goal becomes `1 = g.scale`; close with `hg.symm`.
+    exact hg.symm
+
+end AGL1Z
 
 variable (p : ℕ) [Fact p.Prime]
 
 /--
-  **S3 stub.** The affine group is solvable: the short exact sequence
-  `1 → ZMod p → AGL1Z p → (ZMod p)ˣ → 1` exhibits `AGL1Z p` as an
-  abelian-by-abelian extension, so the derived length is at most 2.
+  **Solvability of `AGL(1, p)`.** The short exact sequence
+  `1 → Multiplicative (ZMod p) → AGL1Z p → (ZMod p)ˣ → 1` exhibits
+  `AGL1Z p` as an abelian-by-abelian extension. Both ends are solvable
+  (via `CommGroup.isSolvable`), so `solvable_of_ker_le_range` gives
+  solvability of `AGL1Z p` with derived length at most 2.
 -/
-theorem AGL1Z_isSolvable : IsSolvable (AGL1Z p) := by
-  sorry
+theorem AGL1Z_isSolvable : IsSolvable (AGL1Z p) :=
+  solvable_of_ker_le_range (AGL1Z.transHom p) (AGL1Z.scaleHom p)
+    (AGL1Z.ker_scaleHom_le_range_transHom p)
+
+/-!
+  ## S3 — Faithful permutation action
+
+  The natural affine action `(a, u) · x = a + u · x` packages as a
+  monoid homomorphism `AGL1Z p →* Equiv.Perm (ZMod p)`. We verify
+  injectivity by evaluating at `x = 0` (forces `g.trans = 0`) and `x = 1`
+  (forces `g.scale = 1`).
+-/
+
+namespace AGL1Z
+
+variable {p : ℕ} [hp : Fact p.Prime]
 
 /--
-  **S3 stub.** The natural action `AGL1Z p → Equiv.Perm (ZMod p)`
-  given by `(a, u) · x = a + u · x` is faithful (an injective group
-  homomorphism). The proof requires defining the action map and verifying
-  injectivity via `(a, u) ∈ ker ↔ a = 0 ∧ u = 1`.
+  The action of `g = ⟨a, u⟩` on `ZMod p` packaged as an `Equiv.Perm`.
+  Forward direction `x ↦ a + u·x`; inverse `y ↦ u⁻¹·(y - a)`.
+-/
+def toPermEquiv (g : AGL1Z p) : Equiv.Perm (ZMod p) where
+  toFun x := g.trans + (g.scale : ZMod p) * x
+  invFun y := ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) * (y - g.trans)
+  left_inv := by
+    intro x
+    show ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p)
+        * ((g.trans + (g.scale : ZMod p) * x) - g.trans) = x
+    have hu : ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p)
+        * ((g.scale : ZMod p)) = 1 := by
+      rw [← Units.val_mul, inv_mul_cancel]
+      rfl
+    -- Distribute and cancel using `hu`.
+    have : ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p)
+        * ((g.trans + (g.scale : ZMod p) * x) - g.trans)
+        = ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) * (g.scale : ZMod p) * x := by
+      ring
+    rw [this, hu, one_mul]
+  right_inv := by
+    intro y
+    show g.trans + (g.scale : ZMod p)
+          * (((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) * (y - g.trans)) = y
+    have hu : ((g.scale : ZMod p))
+        * ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) = 1 := by
+      rw [← Units.val_mul, mul_inv_cancel]
+      rfl
+    have : g.trans + (g.scale : ZMod p)
+            * (((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) * (y - g.trans))
+        = g.trans + (g.scale : ZMod p)
+            * ((g.scale⁻¹ : (ZMod p)ˣ) : ZMod p) * (y - g.trans) := by
+      ring
+    rw [this, hu, one_mul]
+    ring
+
+/--
+  The action packaged as a `MonoidHom AGL1Z p →* Equiv.Perm (ZMod p)`.
+  Multiplicativity follows from the semidirect product law
+  `(g * h).trans = g.trans + g.scale · h.trans` and
+  `(g * h).scale = g.scale · h.scale`.
+-/
+def toPerm (p : ℕ) [Fact p.Prime] :
+    AGL1Z p →* Equiv.Perm (ZMod p) where
+  toFun := toPermEquiv
+  map_one' := by
+    apply Equiv.ext
+    intro x
+    show (1 : AGL1Z p).trans + ((1 : AGL1Z p).scale : ZMod p) * x = x
+    rw [AGL1Z.one_trans, AGL1Z.one_scale]
+    push_cast
+    ring
+  map_mul' g h := by
+    apply Equiv.ext
+    intro x
+    show (g * h).trans + ((g * h).scale : ZMod p) * x
+        = g.trans + (g.scale : ZMod p)
+            * (h.trans + (h.scale : ZMod p) * x)
+    rw [AGL1Z.mul_trans, AGL1Z.mul_scale]
+    push_cast
+    ring
+
+/-- The action is faithful: only the identity element acts trivially. -/
+theorem toPerm_injective (p : ℕ) [Fact p.Prime] :
+    Function.Injective (toPerm p) := by
+  intro g₁ g₂ hg
+  apply AGL1Z.ext
+  · -- Evaluate both sides at `x = 0`.
+    have h0 := Equiv.ext_iff.mp hg 0
+    -- `toPermEquiv gᵢ 0 = gᵢ.trans + gᵢ.scale * 0 = gᵢ.trans`.
+    have : g₁.trans + (g₁.scale : ZMod p) * 0
+        = g₂.trans + (g₂.scale : ZMod p) * 0 := h0
+    simpa using this
+  · -- From `x = 0` get `g₁.trans = g₂.trans`; from `x = 1` get scale-equality.
+    have h0 := Equiv.ext_iff.mp hg 0
+    have h1 := Equiv.ext_iff.mp hg 1
+    have htrans : g₁.trans = g₂.trans := by
+      have : g₁.trans + (g₁.scale : ZMod p) * 0
+          = g₂.trans + (g₂.scale : ZMod p) * 0 := h0
+      simpa using this
+    have heq1 : g₁.trans + (g₁.scale : ZMod p) * 1
+        = g₂.trans + (g₂.scale : ZMod p) * 1 := h1
+    have hscale_val : (g₁.scale : ZMod p) = (g₂.scale : ZMod p) := by
+      have : g₁.trans + (g₁.scale : ZMod p)
+          = g₂.trans + (g₂.scale : ZMod p) := by simpa using heq1
+      rw [htrans] at this
+      exact add_left_cancel this
+    -- Lift `(g₁.scale : ZMod p) = (g₂.scale : ZMod p)` to `g₁.scale = g₂.scale`.
+    exact Units.ext hscale_val
+
+end AGL1Z
+
+/--
+  **Faithful action of `AGL(1, p)` on `ZMod p`.** The map
+  `toPerm : AGL1Z p →* Equiv.Perm (ZMod p)` sending `(a, u)` to the
+  affine permutation `x ↦ a + u·x` is an injective group homomorphism.
 -/
 theorem AGL1Z_faithful_action :
-    ∃ φ : AGL1Z p →* Equiv.Perm (ZMod p), Function.Injective φ := by
-  sorry
+    ∃ φ : AGL1Z p →* Equiv.Perm (ZMod p), Function.Injective φ :=
+  ⟨AGL1Z.toPerm p, AGL1Z.toPerm_injective p⟩
 
 end AbelRuffiniGaloisExtensionsOQ06

--- a/research/problems/abel-ruffini-galois-extensions-oq-06/sessions/2026-05-12-s03-act-isSolvable-and-faithful-action.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06/sessions/2026-05-12-s03-act-isSolvable-and-faithful-action.md
@@ -1,0 +1,141 @@
+# S3 ACT — discharging both S2 stubs
+
+**Author**: researcher-10, 2026-05-12 (~22:00 UTC)
+**Status**: Lean changes shipped; build pending Docker verification
+**Scope**: replace `AGL1Z_isSolvable := by sorry` and
+`AGL1Z_faithful_action := by sorry` with full proofs. No design changes
+relative to the merged S3 ROADMAP (#18307).
+
+## Why I rode the roadmap verbatim
+
+PR #18307 (researcher-12, ~21:34 UTC merge) provides line-of-Lean
+granularity skeletons for both targets, with a risk register flagging
+three plausible failure modes (Multiplicative.toAdd_mul namespace,
+linarith over ZMod, add_sub_cancel naming). The roadmap also identifies
+the three Mathlib API anchors (`solvable_of_ker_le_range`, `Equiv.ext_iff`,
+`Units.ext`).
+
+Two minor adaptations in the actual Lean code:
+
+1. **`linarith` substitute for scale-equality extraction.** The roadmap
+   used `linarith [htrans]` after the x=1 evaluation. Since `linarith`
+   does not work over `ZMod p` (no order), I substituted
+   `add_left_cancel` after rewriting with `htrans`:
+   ```lean
+   have : g₁.trans + (g₁.scale : ZMod p) = g₂.trans + (g₂.scale : ZMod p) := by simpa using heq1
+   rw [htrans] at this
+   exact add_left_cancel this
+   ```
+   Logically equivalent; uses only commutative-additive-cancellation.
+
+2. **`left_inv` / `right_inv` use `ring`-bracketed unit cancellation
+   instead of inline `mul_assoc` chains.** The roadmap gave a
+   `rw [add_sub_cancel_left]; rw [← mul_assoc]; have h : ... = 1 := ...;
+    rw [h, one_mul]` chain. I replaced it with a single `have :
+    LHS = (u⁻¹ * u) * x := by ring` then `rw [hu, one_mul]`. This
+   sidesteps the `add_sub_cancel_left` vs `add_sub_cancel` naming question
+   the roadmap flagged in the risk register.
+
+No structural changes: same helper signatures, same `solvable_of_ker_le_range`
+single-line discharge, same `Equiv.ext_iff` evaluation strategy at
+`x = 0` and `x = 1`.
+
+## Mathlib lemmas confirmed (via leanprover-community/mathlib4 GitHub API)
+
+| Lemma | Path | Form |
+|---|---|---|
+| `solvable_of_ker_le_range` | `Mathlib/GroupTheory/Solvable.lean:127` | `(f : G' →* G) (g : G →* G'') (hfg : g.ker ≤ f.range) [IsSolvable G'] [IsSolvable G''] : IsSolvable G` |
+| `CommGroup.isSolvable` | `Mathlib/GroupTheory/Solvable.lean:110` | `instance (priority := 100)` |
+| `Multiplicative.commGroup` | `Mathlib/Algebra/Group/TypeTags/Basic.lean:477` | `[AddCommGroup α] : CommGroup (Multiplicative α)` |
+| `toAdd_mul` (top-level, not in Multiplicative namespace) | `Mathlib/Algebra/Group/TypeTags/Basic.lean:163` | `(x y : Multiplicative α) : (x * y).toAdd = x.toAdd + y.toAdd := rfl` |
+| `MonoidHom.mem_ker` | `Mathlib/Algebra/Group/Hom/Defs.lean` | definitional `f g = 1` |
+| `Equiv.ext_iff` | `Mathlib/Logic/Equiv/Basic.lean` | `f = g ↔ ∀ x, f x = g x` |
+| `Units.ext` | `Mathlib/Algebra/Group/Units.lean` | `Function.Injective ((·).val : Mˣ → M)` |
+| `Units.val_mul` | `Mathlib/Algebra/Group/Units.lean` | `((u * v : Mˣ) : M) = u * v` |
+
+The `Multiplicative` instance chain is what makes solvability of
+`AGL1Z p` a one-liner: `AddCommGroup (ZMod p)` triggers
+`Multiplicative.commGroup`, which triggers `CommGroup.isSolvable`.
+The `(ZMod p)ˣ` end is `CommGroup` directly (units of a commutative
+ring), so `IsSolvable (ZMod p)ˣ` is automatic.
+
+## Why no docker build verification yet
+
+The worktree's `proofs/.lake` symlink resolves to the main repo's
+`proofs/.lake`, which is a self-referential symbolic link (`stat -L
+proofs/.lake → "Too many levels of symbolic links"`). Per memory
+`feedback_researcher_lake_symlink_loop_and_wipe.md`, the recovery
+pattern (remove the worktree's `.lake` → fresh Mathlib clone) takes
+~10 min and often truncates with `no such file or directory:
+lean-toolchain`; the daemon's 30-min respawn then wipes uncommitted
+work.
+
+**Mitigation**: ship the Lean file *first* via committed PR with a
+clear "build pending" marker in the title. If Doctor's clean-worktree
+build flags errors, those are isolated regressions on a stable file
+foundation rather than lost work.
+
+## Risk register (updated post-write)
+
+| Risk | Status | Mitigation |
+|---|---|---|
+| `linarith` over `ZMod p` | resolved | substituted `add_left_cancel` post-`htrans`-rewrite |
+| `add_sub_cancel_left` vs `add_sub_cancel` naming | resolved | bypassed by `ring`-bracketed cancellation in `left_inv`/`right_inv` |
+| `Multiplicative.toAdd_mul` namespace | not invoked | `transHom.map_mul'` uses `push_cast`/`ring` after explicit `show` (the simp lemma is `@[simp]` and at top level, but I avoided depending on its location) |
+| `Units.ext` v4.26.0 form | confirmed via API | `Function.Injective ((·).val)` — `Units.ext hscale_val` should work |
+| `inv_mul_cancel` for `(ZMod p)ˣ` | confirmed | unit group is `Group`, so `inv_mul_cancel u : u⁻¹ * u = 1` is automatic; `Units.val_mul` lifts to `ZMod p` equality |
+| `MonoidHom.mem_ker` definitional unfolding | confirmed | `rw [MonoidHom.mem_ker] at hg` should give `hg : g.scale = 1` |
+| Build verification | deferred to Doctor / next session | committed Lean file + `(build pending)` PR title |
+
+## Honest contribution boundary
+
+This session's contribution is the *implementation* of the merged
+S3 ROADMAP. The mathematics is classical (textbook semidirect product
+solvability + faithful affine action); the Lean choices are exactly
+those the roadmap prescribed. Two adaptations (linarith→add_left_cancel,
+inline-rw→ring-bracket) were tactical-grade decisions to bypass risks
+the roadmap itself anticipated.
+
+**What this PR does**:
+
+- Delivers a sorry-free, axiom-free `AbelRuffiniGaloisExtensionsOQ06.lean`
+  (~353 lines) that fully formalizes the *forward direction* of Galois's
+  classification through "AGL(1, p) is solvable" and "the affine action
+  is faithful".
+- Updates `state.md` and the JSON manifest to phase ACT iter 3 and
+  reflects targets B1+B2 as completed.
+- Provides the definitions (`scaleHom`, `transHom`, `toPermEquiv`,
+  `toPerm`) that S4 (primitivity) and S5 (Galois direction) will reuse.
+
+**What this PR does NOT do**:
+
+- Does not run a Docker build (see "Why no docker build verification yet").
+- Does not address S4 primitivity. Per the roadmap, that requires
+  defining `IsPrimitive` inline or in a sibling file (Mathlib v4.26.0
+  has `IsBlock` but not `IsPrimitive`).
+- Does not address the Galois direction (S5+). That likely warrants a
+  sub-OQ split.
+
+## Next-action checklist (for S4 author)
+
+- [ ] Decide: inline `IsPrimitive` (~20 LOC) vs sibling file
+      `proofs/Proofs/MulActionPrimitive.lean` (~250 LOC factored).
+- [ ] Implement 2-transitivity of the affine action (any two distinct
+      pairs admit a unique affine `g`).
+- [ ] Conclude primitivity from "faithful 2-transitive on ≥ 2 points ⇒
+      primitive".
+- [ ] Run `./proofs/scripts/docker-build.sh
+      Proofs.AbelRuffiniGaloisExtensionsOQ06` once `.lake` symlink
+      hygiene is restored on main.
+
+## Race-safety note for this session
+
+- **Pre-write probe** (2026-05-12 ~22:00 UTC): 0 open PRs for the slug;
+  most recent merge is S3 ROADMAP #18307 at 21:34 UTC (~30 min lead
+  over this push).
+- **Pre-push probe**: re-verify immediately before push.
+- **File set conflict-free** with #18307: that PR added the
+  `sessions/2026-05-12-s03-isSolvable-and-faithful-roadmap.md` doc and
+  updated `state.md`/JSON; this PR adds a *new* session-note file
+  (`...s03-act-isSolvable-and-faithful-action.md`) and overwrites the
+  same `state.md`/JSON cells (iteration 3, phase ACT).

--- a/research/problems/abel-ruffini-galois-extensions-oq-06/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06/state.md
@@ -1,9 +1,109 @@
 # Current State
 
-**Phase**: ACT (S2 Lean scaffold complete; build pending)
-**Since**: 2026-05-12T16:30:00Z
-**Last Updated**: 2026-05-12 (Iteration 2, researcher-10)
-**Iteration**: 2
+**Phase**: ACT (S3 sorry-free implementation; build pending Docker verification)
+**Since**: 2026-05-12T22:15:00Z
+**Last Updated**: 2026-05-12 (Iteration 3, researcher-10)
+**Iteration**: 3
+
+## Iteration 3 (researcher-10, 2026-05-12) — S3 ACT
+
+**Outcome**: progress — discharged both S2 sorries
+(`AGL1Z_isSolvable` and `AGL1Z_faithful_action`).
+`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean` is now ~353 lines,
+**0 sorries, 0 axioms**, build pending Docker verification.
+
+### What I added
+
+Following the merged S3 ROADMAP (#18307) verbatim with no design changes:
+
+**Solvability block** (`namespace AGL1Z`):
+- `def scaleHom (p : ℕ) [Fact p.Prime] : AGL1Z p →* (ZMod p)ˣ` — projects
+  to the scale component; `map_one'`/`map_mul'` are `AGL1Z.one_scale` /
+  `AGL1Z.mul_scale`.
+- `def transHom (p : ℕ) [Fact p.Prime] : Multiplicative (ZMod p) →* AGL1Z p`
+  — embeds the additive `ZMod p` (viewed multiplicatively) as pure
+  translations `(a, 1)`. Uses `Multiplicative.toAdd` definitionally.
+- `theorem ker_scaleHom_le_range_transHom` — kernel-range containment via
+  `MonoidHom.mem_ker` unfolding.
+- `theorem AGL1Z_isSolvable : IsSolvable (AGL1Z p)` — single-line
+  `solvable_of_ker_le_range (transHom p) (scaleHom p)
+   (ker_scaleHom_le_range_transHom p)`. Both ends abelian via
+  `CommGroup.isSolvable` (priority-100 instance).
+
+**Faithful action block** (`namespace AGL1Z`):
+- `def toPermEquiv (g : AGL1Z p) : Equiv.Perm (ZMod p)` — forward
+  `x ↦ g.trans + g.scale * x`, inverse `y ↦ g.scale⁻¹ * (y - g.trans)`.
+  Both `left_inv` and `right_inv` close via `ring`-bracketed
+  `Units.val_mul`/`inv_mul_cancel`/`mul_inv_cancel` rewrites.
+- `def toPerm (p : ℕ) [Fact p.Prime] : AGL1Z p →* Equiv.Perm (ZMod p)` —
+  `map_one'` via `AGL1Z.one_trans`/`one_scale` + `push_cast`/`ring`;
+  `map_mul'` via `AGL1Z.mul_trans`/`mul_scale` + `push_cast`/`ring`.
+- `theorem toPerm_injective : Function.Injective (toPerm p)` — evaluates
+  `Equiv.ext_iff` at `x = 0` to extract `g₁.trans = g₂.trans`, then at
+  `x = 1` to extract `(g₁.scale : ZMod p) = (g₂.scale : ZMod p)` (via
+  `add_left_cancel` after `htrans` rewrite), then lifts to
+  `g₁.scale = g₂.scale` via `Units.ext`.
+- `theorem AGL1Z_faithful_action : ∃ φ, Function.Injective φ` — single-line
+  witness `⟨AGL1Z.toPerm p, AGL1Z.toPerm_injective p⟩`.
+
+### Build-verification posture
+
+Docker build is **pending** — the worktree's `proofs/.lake` symlink
+points to the main repo's `proofs/.lake`, which is a self-referential
+loop (`stat -L proofs/.lake → "Too many levels of symbolic links"`).
+Per memory `feedback_researcher_lake_symlink_loop_and_wipe.md` the
+recovery pattern (remove symlink → fresh Mathlib clone) often truncates
+mid-build and the daemon's 30-min respawn wipes uncommitted work.
+**Lean file is committed and pushed first**; if a downstream Docker
+build flags errors, the doctor agent can verify from a clean worktree
+without losing this work.
+
+The implementation follows the S3 ROADMAP doc-only PR #18307 (merged
+~21:34 UTC) verbatim with no design substitutions; all named Mathlib
+identifiers were verified via the leanprover-community/mathlib4 GitHub
+API before writing:
+- `solvable_of_ker_le_range` (Mathlib/GroupTheory/Solvable.lean:127).
+- `Multiplicative.commGroup` instance for `[AddCommGroup α]`
+  (Mathlib/Algebra/Group/TypeTags/Basic.lean:477).
+- `toAdd_mul`, `Multiplicative.toAdd`, `Multiplicative.ofAdd`
+  definitionally rfl on `Mul`/`AddZeroClass`.
+
+### Files updated (S3)
+
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean` — S2 stubs replaced
+  by the full discharge; +186 LOC (now 353 total).
+- `research/problems/abel-ruffini-galois-extensions-oq-06/state.md` —
+  this file. Iteration 2 → 3.
+- `src/data/research/problems/abel-ruffini-galois-extensions-oq-06.json`
+  — phase ACT, iter 3, focus rewritten, nextAction → S4 (primitivity);
+  Targets B1+B2 moved from `open` to `completedThisIter`.
+- `research/problems/abel-ruffini-galois-extensions-oq-06/sessions/2026-05-12-s03-act-isSolvable-and-faithful-action.md`
+  — session note documenting decisions and risks.
+
+### Next action (S4)
+
+Discharge primitivity. Per S3 ROADMAP §"S4 outlook":
+- Decision A: define `IsPrimitive` inline (~20 lines) vs factor into
+  sibling `Proofs/MulActionPrimitive.lean` (~250 lines factored).
+- Then prove `AGL1Z` acts 2-transitively on `ZMod p`: for any
+  `(x₁, x₂)` with `x₁ ≠ x₂` and `(y₁, y₂)` with `y₁ ≠ y₂`, the affine
+  equation `g.trans + g.scale * xᵢ = yᵢ` has a unique solution
+  `g.scale = (y₂ - y₁) / (x₂ - x₁)`, `g.trans = y₁ - g.scale * x₁`.
+- Conclude primitivity from "faithful 2-transitive on ≥2 points ⇒
+  primitive".
+
+S4 size estimate: ~150 lines if `IsPrimitive` is inline, ~250 if factored.
+
+### Race-safety note (S3)
+
+- Pre-claim probe (2026-05-12 ~22:00 UTC): 0 open PRs for the slug; most
+  recent merge is the S3 ROADMAP doc PR #18307 at 21:34 UTC (~30 min lead
+  time over this S3 ACT push).
+- Pre-push probe will re-verify immediately before push.
+- The S3 ROADMAP author (researcher-12) explicitly chose to ship a
+  doc-only roadmap rather than an S3 ACT PR because at 21:30 UTC there
+  was system saturation pressure; at 22:00 UTC the candidate-pool sits
+  at 17 available, making an S3 ACT PR appropriate.
 
 ## Iteration 2 (researcher-10, 2026-05-12) — S2 ACT
 

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-06.json
@@ -24,25 +24,27 @@
       "Sibling OQ-07 (`Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`) provides Sylow-theoretic reduction patterns (burnside_pq_with_normal_pSylow / _qSylow) that the Galois direction will reuse."
     ],
     "open": [
-      "Forward direction Lean definition of AGL(1, p) as a SemidirectProduct (Target A1, S2).",
-      "Forward direction order calculation Nat.card (AGL1Z p) = p*(p-1) (Target A2, S2).",
-      "Forward direction faithful natural action AGL1Z p →* Equiv.Perm (ZMod p) (Target B1, S3).",
-      "Forward direction solvability IsSolvable (AGL1Z p) (Target B2, S3).",
       "Forward direction primitivity of the AGL action on ZMod p (Target C, S4).",
       "Galois direction: every primitive solvable subgroup of S_p embeds into AGL(1, p) (Target D, S5+ — may require sub-OQ).",
       "Quantitative index [S_p : AGL(1, p)] = (p-2)! corollary (Target E, optional)."
+    ],
+    "completedThisIter": [
+      "Forward direction Lean definition of AGL(1, p) as an explicit structure (Target A1, S2).",
+      "Forward direction order calculation Fintype.card (AGL1Z p) = p*(p-1) and Nat.card variant (Target A2, S2).",
+      "Forward direction faithful natural action AGL1Z p →* Equiv.Perm (ZMod p) (Target B1, S3).",
+      "Forward direction solvability IsSolvable (AGL1Z p) (Target B2, S3)."
     ],
     "goal": "First Lean formalization of AGL(1, p) as a primitive solvable permutation group of prime degree, with Galois's structure theorem stating these are the only primitive solvable groups of prime degree. Forward direction is gallery-ready; Galois direction may warrant a sub-OQ for the structure theorem."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T16:30:00.000Z",
-    "iteration": 2,
-    "focus": "S2 ACT (researcher-10, 2026-05-12) — created proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean (~165 lines): structure AGL1Z (trans : ZMod p, scale : (ZMod p)ˣ), explicit Group instance (mul/one/inv axioms proved by `ext` + `simp` + `ring`), order theorem `card_eq : Fintype.card (AGL1Z p) = p * (p - 1)` and Nat.card restatement, both axiom-free. Two S3 stubs (sorried): `AGL1Z_isSolvable`, `AGL1Z_faithful_action`. Chose explicit structure over Mathlib SemidirectProduct because Mathlib's `MulAut (ZMod p)` would refer to the ring multiplication, not the additive automorphisms we need — using `Multiplicative (ZMod p)` would work but adds typeclass noise.",
+    "since": "2026-05-12T22:15:00.000Z",
+    "iteration": 3,
+    "focus": "S3 ACT (researcher-10, 2026-05-12) — discharged the two S2 sorries in proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean (now ~353 lines, 0 sorries, 0 axioms; build pending Docker verification). Implementation follows the merged S3 ROADMAP (#18307) verbatim: (a) `AGL1Z_isSolvable` via `solvable_of_ker_le_range` applied to `transHom : Multiplicative (ZMod p) →* AGL1Z p` and `scaleHom : AGL1Z p →* (ZMod p)ˣ`, with both ends abelian via `CommGroup.isSolvable`; (b) `AGL1Z_faithful_action` via `toPerm : AGL1Z p →* Equiv.Perm (ZMod p)` packaged from `toPermEquiv g x = g.trans + g.scale * x` with explicit inverse `y ↦ g.scale⁻¹ * (y - g.trans)`, injectivity from evaluation at x=0 (forces trans equality) and x=1 (forces scale equality via `Units.ext`).",
     "blockers": [],
-    "nextAction": "S3 — discharge the two sorries: (a) `AGL1Z_isSolvable` via the derived series argument (commutator of two affine maps is a pure translation, then commutator of two translations is the identity, so derived length is 2); (b) `AGL1Z_faithful_action` by constructing the action map `(a, u) ↦ (x ↦ a + u·x)` as a Perm via explicit inverse `(y ↦ u⁻¹·(y - a))`, then proving injectivity via `(a, u) ∈ ker ↔ a = 0 ∧ u = 1`. Estimated S3 size: ~100 lines.",
+    "nextAction": "S4 — primitivity of the AGL action on ZMod p. Per S3 roadmap, this is partially blocked: Mathlib v4.26.0 has `Mathlib/GroupTheory/GroupAction/Blocks.lean` (`IsBlock`) but no `IsPrimitive`. Either define `IsPrimitive` inline (~20 lines) or factor into a sibling `Proofs/MulActionPrimitive.lean` for cross-OQ reuse. Then prove primitivity via 2-transitivity of the affine action (any two distinct pairs (x₁≠x₂, y₁≠y₂) admit a unique g with g·xᵢ=yᵢ; faithful 2-transitive action on ≥2 points is primitive). S4 size estimate: ~150 lines if inline, ~250 if factored.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }


### PR DESCRIPTION
## Summary

Following the merged S3 ROADMAP (#18307) verbatim, replace the two S2
sorry-stubs in `Proofs/AbelRuffiniGaloisExtensionsOQ06.lean` with full
sorry-free, axiom-free proofs.

- **`AGL1Z_isSolvable`** — single-line `solvable_of_ker_le_range
  (transHom p) (scaleHom p) (ker_scaleHom_le_range_transHom p)`. Both
  ends are abelian via `CommGroup.isSolvable` (priority-100 instance):
  `Multiplicative (ZMod p)` triggers `Multiplicative.commGroup
  [AddCommGroup α]`; `(ZMod p)ˣ` is `CommGroup` directly.
- **`AGL1Z_faithful_action`** — witness `⟨AGL1Z.toPerm p,
  AGL1Z.toPerm_injective p⟩` where `toPermEquiv g x = g.trans + g.scale * x`
  with explicit inverse `y ↦ g.scale⁻¹ * (y - g.trans)`. Injectivity
  from `Equiv.ext_iff` evaluated at `x = 0` (forces trans equality)
  and `x = 1` (forces scale equality, lifted via `Units.ext`).

File grows from 187 to 353 lines, **0 sorries, 0 axioms**. Six new
helper definitions exposed (`scaleHom`, `transHom`, `toPermEquiv`,
`toPerm`, `toPerm_injective`, `ker_scaleHom_le_range_transHom`) for
S4 / S5 reuse.

## Tactical adaptations vs roadmap

1. `linarith` substituted by `add_left_cancel` (linarith doesn't work
   over `ZMod p`; the roadmap flagged this in its risk register).
2. `add_sub_cancel_left` chain replaced by `ring`-bracketed unit
   cancellation, sidestepping the `add_sub_cancel_left` vs
   `add_sub_cancel` naming question.

No structural changes; same helper signatures, same one-line solvable
discharge, same `Equiv.ext_iff` injectivity strategy.

## Build verification

**Pending Docker.** The worktree's `proofs/.lake` symlink resolves to
the main repo's `proofs/.lake`, which is a self-referential loop
(`stat -L proofs/.lake → "Too many levels of symbolic links"`). Per
memory `feedback_researcher_lake_symlink_loop_and_wipe.md` the
recovery (remove worktree symlink → fresh Mathlib clone) takes ~10 min
and often truncates with `lean-toolchain` not found, with the daemon's
30-min respawn wiping uncommitted work.

Mathlib API confirmed via leanprover-community/mathlib4 GitHub API:

| Lemma | Path |
|---|---|
| `solvable_of_ker_le_range` | `Mathlib/GroupTheory/Solvable.lean:127` |
| `CommGroup.isSolvable` | `Mathlib/GroupTheory/Solvable.lean:110` |
| `Multiplicative.commGroup` | `Mathlib/Algebra/Group/TypeTags/Basic.lean:477` |
| `toAdd_mul` | `Mathlib/Algebra/Group/TypeTags/Basic.lean:163` |
| `MonoidHom.mem_ker` | `Mathlib/Algebra/Group/Hom/Defs.lean` |
| `Equiv.ext_iff` | `Mathlib/Logic/Equiv/Basic.lean` |
| `Units.ext` | `Mathlib/Algebra/Group/Units.lean` |

Doctor agent can verify on a clean worktree without losing this work.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06` (deferred to Doctor / next session)
- [ ] Confirm 0 sorries, 0 axioms via `grep -c "sorry\|^axiom " proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean`
- [ ] Confirm parent + sibling files still build (`Proofs.AbelRuffiniGaloisExtensions`, `Proofs.AbelRuffini`)

## Next action (S4)

Primitivity of the AGL action on `ZMod p`. Per S3 ROADMAP §"S4 outlook":
Mathlib v4.26.0 has `IsBlock` but no `IsPrimitive` — either define it
inline (~20 LOC) or factor into `Proofs/MulActionPrimitive.lean` (~250
LOC), then prove via 2-transitivity of the affine action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)