### PR TITLE
Enrich Uniform n×n Quasideterminants (S3 SCAFFOLD): drift-fix + Part VI coverage

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-minor-ij",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 62, "endLine": 66 },
+    "range": { "startLine": 78, "endLine": 82 },
     "type": "definition",
     "title": "The complementary n×n submatrix (uniform-in-n)",
     "content": "`minorIJ A i j` is the complementary `n×n` submatrix obtained by deleting row `i` and column `j` from an `(n+1)×(n+1)` matrix. The construction `A.submatrix (Fin.succAbove i) (Fin.succAbove j)` uses `Fin.succAbove i : Fin n → Fin (n+1)`, the canonical injection that skips index `i`. Crucially, `minorIJ` is declared `abbrev` rather than `def`: this makes it transparent to definitional equality, which is what enables the `qdetF_eq_qdet3` bridge to hold by `rfl` (since the parent's `block3` is itself an `abbrev` over the same body).",
@@ -14,7 +14,7 @@
   {
     "id": "ann-qdetf-definition",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 72, "endLine": 81 },
+    "range": { "startLine": 88, "endLine": 97 },
     "type": "definition",
     "title": "qdetF — the uniform-in-n commutative quasideterminant",
     "content": "`qdetF` is the canonical Gelfand–Retakh quasideterminant in its commutative (Schur-complement-as-quotient) form, uniform in n. For any `(n+1)×(n+1)` matrix `A` over a field `F`, `qdetF A i j := A.det / (minorIJ A i j).det`. This single one-line definition is what makes Route A tractable: no induction, no mutual recursion, no Schur-complement bookkeeping. It specializes to `qdet00`/`qdet11` (n=2, in the non-degenerate regime) and to `qdet3` (n=3, by `rfl`). The fully non-commutative analogue `qdetN` over a division ring is genuinely harder — it requires mutual strong recursion with `qdetN_inv` on decreasing `n` — and is the S3 target.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-qdetf-field-quotient",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 83, "endLine": 91 },
+    "range": { "startLine": 99, "endLine": 107 },
     "type": "theorem",
     "title": "The multiplicative defining identity",
     "content": "`qdetF_field_quotient` rewrites the quotient definition into the algebraically more useful multiplicative form: `qdetF A i j * (minorIJ A i j).det = A.det` (when the minor is invertible). This is the n×n analogue of `CramersRuleOQ01OQ02OQ01.qdet3_mul_minor_eq_det`, with the same one-line proof via `div_mul_cancel₀`. The multiplicative form is preferred in Cramer-style arguments because it lets us isolate a single column or row variable by clearing denominators rather than introducing them.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-qdetf-ne-zero",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 93, "endLine": 100 },
+    "range": { "startLine": 109, "endLine": 116 },
     "type": "theorem",
     "title": "Non-vanishing of qdetF",
     "content": "`qdetF_ne_zero` is the one-line consequence that, when both `det A` and the complementary-minor determinant are nonzero, the quasideterminant is nonzero. This is the natural non-degeneracy criterion for treating qdetF as an invertible quantity (e.g. when solving linear systems via the quasideterminant variant of Cramer's rule).",
@@ -50,7 +50,7 @@
   {
     "id": "ann-qdetf-eq-qdet3",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 106, "endLine": 111 },
+    "range": { "startLine": 122, "endLine": 127 },
     "type": "theorem",
     "title": "n=3 specialization by rfl",
     "content": "The equality `qdetF A i j = CramersRuleOQ01OQ02OQ01.qdet3 A i j` (for `A : Matrix (Fin 3) (Fin 3) F`) holds by `rfl`. This is the cleanest possible bridge: the n=3 quasideterminant theory is *literally* (definitionally) a special case of `qdetF`. The reason is that `block3 i j A` in the parent file is an `abbrev` whose body is `A.submatrix (Fin.succAbove i) (Fin.succAbove j)` — the same body as `minorIJ`. Lean's reducibility settings unfold `abbrev` transparently, so the two definitions are *judgmentally* equal.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-minor-22-det-lemmas",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 117, "endLine": 135 },
+    "range": { "startLine": 133, "endLine": 151 },
     "type": "technique",
     "title": "Pinning the 2×2 minor determinants",
     "content": "The (0,0)- and (1,1)-minors of a 2×2 matrix are 1×1 (singleton) matrices, so their determinants are just the single remaining entry. The two `@[simp]` lemmas pin these explicitly: `minorIJ A 0 0 . det = A 1 1` and `minorIJ A 1 1 . det = A 0 0`. The proofs use `Matrix.det_fin_one` to reduce the determinant to the single entry, then `Fin.succAbove (0 : Fin 2) (0 : Fin 1) = 1` by `rfl`. These lemmas are the bridge between the abstract `minorIJ` and the concrete entries used in the parent's `qdet00`/`qdet11` formulas.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-qdetf-eq-qdet00",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 137, "endLine": 152 },
+    "range": { "startLine": 153, "endLine": 168 },
     "type": "theorem",
     "title": "n=2 (0,0)-specialization via mul_right_cancel₀",
     "content": "Bridges `qdetF A 0 0` (the uniform commutative form) to the parent's 2×2 (0,0)-quasideterminant `qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0`. The strategy is multiplicative cancellation: under `A 1 1 ≠ 0`, *both* sides multiply against `A 1 1` to give `A.det` — `qdetF` via `qdetF_field_quotient` (using `minorIJ_22_00_det` to identify the minor as `A 1 1`), and `qdet00` via the parent's `qdet00_mul_eq_det`. Two quantities with the same product against a nonzero `A 1 1` must be equal, so `mul_right_cancel₀` closes the goal. No further non-degeneracy is needed beyond the standard `A 1 1 ≠ 0` already carried in the parent's API.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-qdetf-eq-qdet11",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 154, "endLine": 167 },
+    "range": { "startLine": 170, "endLine": 183 },
     "type": "theorem",
     "title": "n=2 (1,1)-specialization (symmetric to (0,0))",
     "content": "The (1,1)-twin of `qdetF_eq_qdet00`. The structure is identical except that the parent's identity comes in the form `A 0 0 * qdet11 A = A.det` rather than `qdet11 A * A 0 0 = A.det`, so an extra `mul_comm` rewrite is needed before `mul_right_cancel₀` applies. The hypothesis is the symmetric `A 0 0 ≠ 0`. Together, `qdetF_eq_qdet00` and `qdetF_eq_qdet11` exhaust the four (i,j) cases for n=2 (the off-diagonal cases (0,1) and (1,0) are handled by the parent's `qdet01`/`qdet10` via the same template, deferred here).",
@@ -98,13 +98,49 @@
   {
     "id": "ann-qdetf-summary",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 173, "endLine": 183 },
+    "range": { "startLine": 189, "endLine": 199 },
     "type": "theorem",
     "title": "Route-A summary: multiplicative identity + definitional quotient",
     "content": "`qdetF_summary` packages the two faces of the Route A theory: the multiplicative form `qdetF · minor_det = det A` (from `qdetF_field_quotient`) and the quotient form `qdetF = det A / minor_det` (by `rfl` from the definition). Together, these are the complete commutative-half story: every n×n quasideterminant identity over a field can be derived by combining one of these two forms with standard field algebra. The non-commutative S3 target (`qdetN` over a division ring) will need a structurally analogous summary, but its proof will require mutual recursion rather than `rfl`.",
     "mathContext": "$|A|_{ij} \\cdot \\det \\mathrm{minor}_{ij}(A) = \\det A \\quad \\wedge \\quad |A|_{ij} = \\dfrac{\\det A}{\\det \\mathrm{minor}_{ij}(A)}.$ The conjunction is the complete API of `qdetF` from which all commutative n×n Cramer-style identities follow.",
     "significance": "key",
-    "relatedConcepts": ["Cramer's rule (n×n)", "non-commutative deferred (S3)", "qdetN", "summary theorem"],
+    "relatedConcepts": ["Cramer's rule (n×n)", "non-commutative one-step formula (Part VI)", "qdetN_step", "summary theorem"],
     "prerequisites": ["qdetF_field_quotient"]
+  },
+  {
+    "id": "ann-qdetn-step",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 209, "endLine": 233 },
+    "type": "definition",
+    "title": "qdetN_step — the non-recursive one-step Schur formula (Route B, S3 SCAFFOLD)",
+    "content": "`qdetN_step` is the **non-commutative** counterpart to `qdetF` for an `(n+1)×(n+1)` matrix `A` over a division ring `D`. It computes the Gelfand–Retakh Schur correction `A i j − ∑_{p,q : Fin n} A i (succAbove j q) · Minv q p · A (succAbove i p) j`, where `Minv` plays the role of the (homological-relations) inverse of the complementary minor `minorIJ A i j`. Crucially, `Minv` is taken as an *explicit parameter* rather than constructed by mutual recursion — this is the structural innovation of the S3 SCAFFOLD: the recurrence is decoupled from its inverse-construction. The full inductive `qdetN` (S4+) will be obtained either (a) by structural recursion on `Σ n, Matrix _ _ D` with `qdetN_step` as the recurrence kernel, or (b) by parameterising on `Invertible (minorIJ A i j)` and treating the inverse as a typeclass input — avoiding mutual recursion altogether. Both routes converge on `qdetN_step A i j Minv`; only the source of `Minv` differs.",
+    "mathContext": "$|A|_{ij} = A_{ij} - \\sum_{p,q : \\mathrm{Fin}\\,n} A_{i,\\widehat{\\jmath}_q} \\cdot M^{-1}_{q,p} \\cdot A_{\\widehat{\\imath}_p, j}$, where $\\widehat{\\jmath}_q := \\mathrm{Fin.succAbove}\\,j\\,q$ and $M = \\mathrm{minor}_{ij}(A)$. Over a commutative field this collapses to $\\det(A)/\\det(M)$ via Laplace cofactor expansion; over a division ring it cannot be expressed as a quotient because multiplication is non-commutative.",
+    "significance": "key",
+    "relatedConcepts": ["Gelfand-Retakh recurrence", "Schur complement", "non-commutative quasideterminant", "decoupled recursion", "Route B vs Route A"],
+    "prerequisites": ["DivisionRing API", "Matrix.submatrix", "Fin.succAbove", "double Finset.sum"]
+  },
+  {
+    "id": "ann-qdetn-step-zero-minv",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 235, "endLine": 242 },
+    "type": "theorem",
+    "title": "Degenerate base case: qdetN_step A i j 0 = A i j",
+    "content": "When `Minv = 0`, the Schur correction term is identically zero (every product contains a `Minv q p = 0` factor), so `qdetN_step A i j 0 = A i j`. This is the trivial base identity guaranteeing the Schur formula is correctly anchored — at the bottom of the recursion (or with a zero pseudo-inverse), it returns the (i,j)-entry itself. The proof is a one-line `simp` using `Matrix.zero_apply`, `mul_zero`, `zero_mul`, `Finset.sum_const_zero`, and `sub_zero`. Tagged `@[simp]` so downstream proofs auto-reduce the degenerate case.",
+    "mathContext": "$\\mathrm{qdetN\\_step}(A, i, j, 0) = A_{ij} - \\sum_{p,q} A_{i,\\widehat{\\jmath}_q} \\cdot 0 \\cdot A_{\\widehat{\\imath}_p, j} = A_{ij} - 0 = A_{ij}.$ This is the minimum-information baseline: with no inverse data, the Schur formula collapses to the bare entry.",
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.zero_apply", "Finset.sum_const_zero", "@[simp] base case", "sanity check"],
+    "prerequisites": ["DivisionRing.zero_mul / mul_zero", "Finset.sum_const_zero"]
+  },
+  {
+    "id": "ann-qdetn-step-eq-qdetf",
+    "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 244, "endLine": 269 },
+    "type": "context",
+    "title": "Field-consistency bridge qdetN_step_eq_qdetF (S3 SCAFFOLD, deferred sorry)",
+    "content": "The strategic linchpin of the entire program: over a field `F`, choosing `Minv := (minorIJ A i j)⁻¹` (Mathlib's `Matrix.nonsingInv`) inside `qdetN_step` recovers `qdetF A i j = det A / det(minor)`. This identity bridges the commutative (S2) and non-commutative (S3) formulations and reduces the entire Route B construction to a *known* Mathlib identity — the Laplace cofactor expansion `Matrix.det_succ_row`. The proof carries a `sorry` deferred to S4. The detailed strategy in the docstring is: (1) expand `Matrix.inv_def` to rewrite `(minorIJ A i j)⁻¹` as `(1 / det(minor)) • adjugate(minor)`; (2) factor the scalar `1/det(minor)` out of the double sum; (3) apply `Matrix.det_succ_row` along row `i`, which gives `det A = ∑_k A i k · (-1)^(i+k) · det(minor_{i,k}(A))`; (4) separate the `k = j` summand from the remaining cofactor terms; (5) use `Matrix.adjugate_apply` (which relates `(adjugate M) q p` to `(-1)^(p+q) · det(submatrix_{p,q} M)`) to align signs. Estimated S4 proof size: ~60–90 Lean lines, dominated by `Fin.succAbove` re-indexing.",
+    "mathContext": "$\\mathrm{qdetN\\_step}(A, i, j, M^{-1}) = A_{ij} - \\sum_{p,q} A_{i,\\widehat{\\jmath}_q} \\cdot M^{-1}_{q,p} \\cdot A_{\\widehat{\\imath}_p, j} \\stackrel{?}{=} \\frac{\\det A}{\\det M} = |A|^{(F)}_{ij}.$ The equality follows from Laplace expansion of $\\det A$ along row $i$ combined with the adjugate's definition $(\\mathrm{adj}\\,M)_{q,p} = (-1)^{p+q} \\det(\\mathrm{submatrix}_{p,q}\\,M)$.",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.det_succ_row", "Matrix.adjugate", "Matrix.adjugate_apply", "Matrix.inv_def", "Laplace expansion", "field-consistency bridge"],
+    "prerequisites": ["Matrix.nonsingInv", "Matrix.det_succ_row", "Matrix.adjugate_apply", "Fin.succAbove sign-of-permutation conventions"]
   }
 ]

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
   "title": "Uniform n×n Quasideterminants over a Field (Route A)",
   "slug": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
-  "description": "S2 of the inductive n×n Gelfand–Retakh quasideterminant initiative. Introduces qdetF, the commutative quasideterminant defined uniformly in n over a field as det(A)/det(minor_{ij}(A)). Proves the multiplicative defining identity, non-vanishing, and three specialization bridges back to the parent 2×2 (CramersRuleOQ01OQ02.qdet00/qdet11) and 3×3 (CramersRuleOQ01OQ02OQ01.qdet3) theories. Closes the commutative half of the open question; the fully non-commutative qdetN over a division ring is deferred to S3.",
+  "description": "S2 + S3 SCAFFOLD of the inductive n×n Gelfand–Retakh quasideterminant initiative. S2 introduces qdetF, the commutative quasideterminant defined uniformly in n over a field as det(A)/det(minor_{ij}(A)), proves the multiplicative defining identity, non-vanishing, and three specialization bridges back to the parent 2×2 (CramersRuleOQ01OQ02.qdet00/qdet11) and 3×3 (CramersRuleOQ01OQ02OQ01.qdet3) theories. S3 SCAFFOLD adds the non-commutative one-step Schur formula qdetN_step over a division ring, proves its degenerate base case, and defers the field-consistency reduction qdetN_step_eq_qdetF (the cofactor-expansion bridge from the explicit inverse `(minorIJ A i j)⁻¹` to qdetF) as the sole remaining sorry to S4.",
   "meta": {
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Quasideterminant",
@@ -19,10 +19,10 @@
       "recursion"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 187,
-    "assumptions": "None for the qdetF definition and the multiplicative identity. The n=2 specialization theorems require the non-degeneracy hypothesis carried in the parent file (A 1 1 ≠ 0 for the (0,0)-case, A 0 0 ≠ 0 for the (1,1)-case).",
+    "lineCount": 276,
+    "assumptions": "None for the qdetF definition and the multiplicative identity. The n=2 specialization theorems require the non-degeneracy hypothesis carried in the parent file (A 1 1 ≠ 0 for the (0,0)-case, A 0 0 ≠ 0 for the (1,1)-case). The S3 SCAFFOLD theorem qdetN_step_eq_qdetF (Route B → Route A bridge over a field) requires (minorIJ A i j).det ≠ 0 and currently carries a sorry pending S4 cofactor-expansion expansion.",
     "originalContributions": [
       "Defined minorIJ: the complementary n×n submatrix of an (n+1)×(n+1) matrix via Fin.succAbove, uniformly in n (generalizes CramersRuleOQ01OQ02OQ01.block3)",
       "Defined qdetF: the (i,j)-quasideterminant of an (n+1)×(n+1) matrix over a field as det(A)/det(minor_{ij}(A)), the canonical Gelfand–Retakh commutative quotient form uniform in n",
@@ -32,72 +32,94 @@
       "Proved minorIJ_22_00_det and minorIJ_22_11_det: the (0,0)- and (1,1)-minors of a 2×2 matrix evaluate to A 1 1 and A 0 0 respectively, via det_fin_one + explicit Fin.succAbove evaluation",
       "Proved qdetF_eq_qdet00: under A 1 1 ≠ 0, qdetF A 0 0 = CramersRuleOQ01OQ02.qdet00 A (bridges the n=2 Schur-form quasideterminant to the uniform commutative form)",
       "Proved qdetF_eq_qdet11: under A 0 0 ≠ 0, qdetF A 1 1 = CramersRuleOQ01OQ02.qdet11 A",
-      "Proved qdetF_summary: packaged multiplicative identity + definitional equation in a single result"
+      "Proved qdetF_summary: packaged multiplicative identity + definitional equation in a single result",
+      "Defined qdetN_step (S3 SCAFFOLD): the non-recursive one-step Gelfand–Retakh Schur formula `A i j − ∑_{p,q} A i (succAbove j q) · Minv q p · A (succAbove i p) j` over a division ring, parameterised by an explicit complementary-minor inverse Minv",
+      "Proved qdetN_step_zero_minv: the degenerate base identity qdetN_step A i j 0 = A i j (the Schur correction term vanishes when Minv = 0)",
+      "Stated qdetN_step_eq_qdetF (S3 SCAFFOLD, deferred): the field-consistency bridge — choosing Minv := (minorIJ A i j)⁻¹ recovers qdetF A i j — together with a detailed S4 proof strategy via Matrix.det_succ_row cofactor expansion and Matrix.adjugate_apply"
     ],
-    "theoremCount": 6,
-    "definitionCount": 2
+    "theoremCount": 10,
+    "definitionCount": 3
   },
   "sections": [
     {
       "id": "complementary-submatrix",
-      "title": "The Complementary n×n Submatrix",
-      "startLine": 64,
-      "endLine": 72,
-      "summary": "Defines minorIJ : Matrix (Fin (n+1)) (Fin (n+1)) F → Fin (n+1) → Fin (n+1) → Matrix (Fin n) (Fin n) F as A.submatrix (Fin.succAbove i) (Fin.succAbove j). This is the uniform-in-n complementary minor — the (n-deleted-row, n-deleted-column) sub-matrix.",
-      "mathContext": "Fin.succAbove i : Fin n → Fin (n+1) maps an index in the smaller type to the corresponding index in the larger type, skipping i. The submatrix construction A.submatrix r c at indices (i,j) returns A (r i) (c j), giving the natural cofactor minor."
+      "title": "Part I — The Complementary n×n Submatrix",
+      "startLine": 74,
+      "endLine": 82,
+      "summary": "Defines `minorIJ : Matrix (Fin (n+1)) (Fin (n+1)) F → Fin (n+1) → Fin (n+1) → Matrix (Fin n) (Fin n) F` as `A.submatrix (Fin.succAbove i) (Fin.succAbove j)`. This is the uniform-in-n complementary minor — the (n-deleted-row, n-deleted-column) sub-matrix. Declared `abbrev` so the parent's 3×3 `block3` reduces to it definitionally.",
+      "mathContext": "`Fin.succAbove i : Fin n → Fin (n+1)` maps an index in the smaller type to the corresponding index in the larger type, skipping i. The submatrix construction `A.submatrix r c` at indices (i,j) returns `A (r i) (c j)`, giving the natural cofactor minor."
     },
     {
       "id": "uniform-quasideterminant",
-      "title": "The Uniform-in-n Quasideterminant",
-      "startLine": 78,
-      "endLine": 109,
-      "summary": "Defines qdetF A i j := A.det / (minorIJ A i j).det over a field, proves qdetF_field_quotient (the multiplicative defining identity) and qdetF_ne_zero (non-vanishing criterion). Both are one-line proofs via div_mul_cancel₀ and div_ne_zero.",
-      "mathContext": "Over a commutative field F, the Gelfand–Retakh (i,j)-quasideterminant of an (n+1)×(n+1) matrix is det(A) / minor(A,i,j). This is the canonical quotient form, uniform in n. The multiplicative form qdetF · minor_det = det(A) is the foundational identity from which all Cramer-type results derive."
+      "title": "Part II — The Uniform-in-n Quasideterminant",
+      "startLine": 84,
+      "endLine": 116,
+      "summary": "Defines `qdetF A i j := A.det / (minorIJ A i j).det` over a field, proves `qdetF_field_quotient` (the multiplicative defining identity) and `qdetF_ne_zero` (non-vanishing criterion). Both are one-line proofs via `div_mul_cancel₀` and `div_ne_zero`.",
+      "mathContext": "Over a commutative field F, the Gelfand–Retakh (i,j)-quasideterminant of an (n+1)×(n+1) matrix is `det(A) / minor(A,i,j)`. This is the canonical quotient form, uniform in n. The multiplicative form `qdetF · minor_det = det(A)` is the foundational identity from which all Cramer-type results derive."
     },
     {
       "id": "n-3-specialization",
-      "title": "n=3 Specialization (qdetF = qdet3 by rfl)",
-      "startLine": 112,
-      "endLine": 121,
-      "summary": "Proves qdetF_eq_qdet3: for A : Matrix (Fin 3) (Fin 3) F, qdetF A i j = CramersRuleOQ01OQ02OQ01.qdet3 A i j by rfl. The equality is definitional because block3 is an abbrev for A.submatrix Fin.succAbove Fin.succAbove.",
-      "mathContext": "The 3×3 quasideterminant theory of CramersRuleOQ01OQ02OQ01.lean uses the same definitional template as qdetF restricted to n+1 = 3. Because abbrev unfolds transparently, the equality holds at the level of definitional equality without any rewriting."
+      "title": "Part III — n=3 Specialization (qdetF = qdet3 by rfl)",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "Proves `qdetF_eq_qdet3`: for `A : Matrix (Fin 3) (Fin 3) F`, `qdetF A i j = CramersRuleOQ01OQ02OQ01.qdet3 A i j` by `rfl`. The equality is definitional because `block3` is an `abbrev` for `A.submatrix Fin.succAbove Fin.succAbove`.",
+      "mathContext": "The 3×3 quasideterminant theory of CramersRuleOQ01OQ02OQ01.lean uses the same definitional template as `qdetF` restricted to n+1 = 3. Because `abbrev` unfolds transparently, the equality holds at the level of definitional equality without any rewriting."
     },
     {
       "id": "n-2-specialization",
-      "title": "n=2 Specialization (Schur Form via qdet00/qdet11)",
-      "startLine": 125,
-      "endLine": 175,
-      "summary": "Bridges the uniform commutative form qdetF to the 2×2 Schur-form quasideterminants of CramersRuleOQ01OQ02. minorIJ_22_00_det evaluates the (0,0)-minor as A 1 1 (and dually for (1,1)). qdetF_eq_qdet00 and qdetF_eq_qdet11 use the parent identities qdet00_mul_eq_det / mul_qdet11_eq_det together with mul_right_cancel₀ to identify qdetF with qdet00 / qdet11 under the standard non-degeneracy hypothesis.",
-      "mathContext": "The 2×2 Schur-form qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0 is non-commutative-friendly (uses inverses, not divisions). Over a field with A 1 1 ≠ 0, it equals A.det / A 1 1 = qdetF A 0 0. The bridge isolates this purely commutative reduction."
+      "title": "Part IV — n=2 Specialization (Schur Form via qdet00/qdet11)",
+      "startLine": 129,
+      "endLine": 183,
+      "summary": "Bridges the uniform commutative form `qdetF` to the 2×2 Schur-form quasideterminants of CramersRuleOQ01OQ02. `minorIJ_22_00_det` evaluates the (0,0)-minor as `A 1 1` (and dually for (1,1)). `qdetF_eq_qdet00` and `qdetF_eq_qdet11` use the parent identities `qdet00_mul_eq_det` / `mul_qdet11_eq_det` together with `mul_right_cancel₀` to identify `qdetF` with `qdet00` / `qdet11` under the standard non-degeneracy hypothesis.",
+      "mathContext": "The 2×2 Schur-form `qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0` is non-commutative-friendly (uses inverses, not divisions). Over a field with `A 1 1 ≠ 0`, it equals `A.det / A 1 1 = qdetF A 0 0`. The bridge isolates this purely commutative reduction."
+    },
+    {
+      "id": "summary",
+      "title": "Part V — Route-A Summary",
+      "startLine": 185,
+      "endLine": 199,
+      "summary": "`qdetF_summary` packages the multiplicative form `qdetF · minor_det = det A` together with the definitional quotient `qdetF = det A / minor_det` into a single conjunction theorem. This is the complete commutative-half API.",
+      "mathContext": "Conjunction: $|A|_{ij} \\cdot \\det \\mathrm{minor}_{ij}(A) = \\det A$ and $|A|_{ij} = \\det A / \\det \\mathrm{minor}_{ij}(A)$. The non-commutative S3 analogue (over a division ring) cannot be stated as a quotient and must use the explicit Schur formula instead."
+    },
+    {
+      "id": "noncommutative-schur-step",
+      "title": "Part VI — Non-commutative Schur Step (S3 SCAFFOLD)",
+      "startLine": 201,
+      "endLine": 269,
+      "summary": "Introduces `qdetN_step` over a division ring `D`: the non-recursive one-step Schur formula `A i j − ∑_{p,q} A i (succAbove j q) · Minv q p · A (succAbove i p) j`, parameterised by an explicit `Minv` playing the role of the complementary-minor inverse. `qdetN_step_zero_minv` proves the degenerate `Minv = 0` case gives `A i j`. The field-consistency theorem `qdetN_step_eq_qdetF` (choosing `Minv := (minorIJ A i j)⁻¹` recovers `qdetF`) is stated with a detailed S4 proof strategy via `Matrix.det_succ_row` cofactor expansion + `Matrix.adjugate_apply` sign normalisation; the proof itself is the sole remaining sorry, deferred to S4.",
+      "mathContext": "Over a division ring D, the Gelfand–Retakh quasideterminant satisfies the Schur recurrence $|A|_{ij} = A_{ij} - \\sum_{p,q} A_{i,\\hat j_q} \\cdot M^{-1}_{q,p} \\cdot A_{\\hat i_p, j}$ where $M = \\mathrm{minor}_{ij}(A)$. By separating the recurrence into a non-recursive 'one-step' form `qdetN_step` (taking Minv as input), the mutual recursion `qdetN ↔ qdetN_inv` of S4 is reduced to proving `Minv` satisfies the inverse equation, not to re-proving the entire Schur identity at every level."
     }
   ],
   "overview": {
-    "historicalContext": "Gelfand and Retakh introduced quasideterminants in 1991 as the correct non-commutative analogue of the determinant: an n×n matrix over a division ring has n^2 quasideterminants, one per entry, each defined recursively via a Schur complement of the complementary (n-1)×(n-1) submatrix. Over a commutative field, $|A|_{ij} = \\det(A) / \\text{minor}(A,i,j)$. The recursive structure — inverse of the complementary submatrix, itself built from lower-order quasideterminants — has been formalized in Lean only at n=2 (CramersRuleOQ01OQ02.lean, 463 lines) and n=3 (CramersRuleOQ01OQ02OQ01.lean, 313 lines). This file (S2 of the open-question initiative for general n) introduces the commutative half uniformly in n, leaving the non-commutative inductive qdetN over a division ring (Route B) for S3.",
-    "problemStatement": "Define a uniform-in-n quasideterminant qdetF over a field that recovers CramersRuleOQ01OQ02.qdet00/qdet11 (n=2) and CramersRuleOQ01OQ02OQ01.qdet3 (n=3) by the canonical det/minor quotient.",
-    "text": "qdetF is defined uniformly in n via the commutative quotient formula. The defining identity qdetF · minor_det = det(A) is one line (div_mul_cancel₀). Non-vanishing follows from div_ne_zero. The n=3 specialization is rfl because the parent block3 is an abbrev. The n=2 specializations require slightly more work: the (0,0)- and (1,1)-minors of a 2×2 matrix are singleton matrices whose determinants reduce via det_fin_one + Fin.succAbove evaluation; the connection to qdet00/qdet11 then comes from mul_right_cancel₀ applied to the parent's qdet00_mul_eq_det / mul_qdet11_eq_det.",
-    "proofStrategy": "(1) Define minorIJ and qdetF uniformly. (2) Prove the multiplicative identity and non-vanishing in one line each. (3) Show n=3 specialization holds by rfl. (4) For the n=2 specializations: pin the minor determinants via det_fin_one, then use mul_right_cancel₀ with the parent file's existing qdet00_mul_eq_det / mul_qdet11_eq_det identities to identify qdetF with qdet00 / qdet11. (5) Package a one-line summary theorem combining the multiplicative identity with the definitional quotient.",
+    "historicalContext": "Gelfand and Retakh introduced quasideterminants in 1991 as the correct non-commutative analogue of the determinant: an n×n matrix over a division ring has n² quasideterminants, one per entry, each defined recursively via a Schur complement of the complementary (n-1)×(n-1) submatrix. Over a commutative field, $|A|_{ij} = \\det(A) / \\text{minor}(A,i,j)$. The recursive structure — inverse of the complementary submatrix, itself built from lower-order quasideterminants — was historically formalized in Lean only at n=2 (CramersRuleOQ01OQ02.lean, 463 lines) and n=3 (CramersRuleOQ01OQ02OQ01.lean, 313 lines). This file is the inductive lift to general n: S2 (Route A) introduces the commutative quotient form `qdetF` uniformly in n; S3 SCAFFOLD (Route B) supplies the non-commutative one-step Schur formula `qdetN_step` over a division ring, deferring only the field-consistency reduction `qdetN_step_eq_qdetF` (the bridge from the explicit `(minorIJ A i j)⁻¹` choice back to `qdetF`) to S4 via Mathlib's `Matrix.det_succ_row` cofactor expansion. The S3 separation — passing `Minv` as a parameter rather than tying it into mutual recursion — is a structural innovation that lets the recurrence be proven once and re-used at every level of the eventual inductive `qdetN`.",
+    "problemStatement": "(S2) Define a uniform-in-n quasideterminant `qdetF` over a field that recovers `CramersRuleOQ01OQ02.qdet00/qdet11` (n=2) and `CramersRuleOQ01OQ02OQ01.qdet3` (n=3) by the canonical det/minor quotient. (S3 SCAFFOLD) Lift the construction to a division ring by giving a non-recursive Schur-form predecessor `qdetN_step` parameterised by an explicit complementary-minor inverse, and prove the field-consistency reduction that `qdetN_step A i j (minorIJ A i j)⁻¹ = qdetF A i j`.",
+    "text": "`qdetF` is defined uniformly in n via the commutative quotient formula. The defining identity `qdetF · minor_det = det(A)` is one line (`div_mul_cancel₀`). Non-vanishing follows from `div_ne_zero`. The n=3 specialization is `rfl` because the parent `block3` is an `abbrev`. The n=2 specializations require slightly more work: the (0,0)- and (1,1)-minors of a 2×2 matrix are singleton matrices whose determinants reduce via `det_fin_one` + `Fin.succAbove` evaluation; the connection to `qdet00`/`qdet11` then comes from `mul_right_cancel₀` applied to the parent's `qdet00_mul_eq_det` / `mul_qdet11_eq_det`. The S3 SCAFFOLD `qdetN_step` is a `def` over a division ring with a double sum indexed by `Fin n × Fin n`; the degenerate case `Minv = 0` collapses by `simp`, and the field-consistency bridge `qdetN_step_eq_qdetF` is stated with a detailed S4 proof strategy but carries a sorry.",
+    "proofStrategy": "(1) Define `minorIJ` and `qdetF` uniformly. (2) Prove the multiplicative identity and non-vanishing in one line each. (3) Show n=3 specialization holds by `rfl`. (4) For the n=2 specializations: pin the minor determinants via `det_fin_one`, then use `mul_right_cancel₀` with the parent file's existing `qdet00_mul_eq_det` / `mul_qdet11_eq_det` identities to identify `qdetF` with `qdet00` / `qdet11`. (5) Package a summary theorem combining the multiplicative identity with the definitional quotient. (6, S3 SCAFFOLD) Define `qdetN_step A i j Minv` over a division ring as the Schur correction `A i j − ∑_{p,q} A i (succAbove j q) · Minv q p · A (succAbove i p) j`; prove the degenerate base case `qdetN_step A i j 0 = A i j` by `simp`. (7, S3 deferred) State `qdetN_step_eq_qdetF` with a detailed S4 strategy: expand `Matrix.inv_def`, factor `1 / det(minor)`, apply `Matrix.det_succ_row` along row `i` (Laplace cofactor expansion), separate the `k = j` summand, and use `Matrix.adjugate_apply` to relate `(adjugate M) q p` to the signed cofactor `(-1)^(p+q) · det(submatrix_{p,q} M)`.",
     "keyInsights": [
-      "The uniform-in-n commutative quasideterminant is a single quotient — no induction, no recursion, no mutual definition required",
-      "The n=3 bridge is rfl: the parent block3 is an abbrev, so the uniform minorIJ and the 3×3-specific block3 are definitionally equal",
-      "The n=2 bridge reduces to mul_right_cancel₀ once the parent's qdet00_mul_eq_det / mul_qdet11_eq_det are recognized as multiplicative-form variants of the same identity",
-      "The fully non-commutative theory (Route B: qdetN over a division ring) is genuinely harder — it needs mutual strong recursion with qdetN_inv on decreasing n — and is deferred to S3"
+      "The uniform-in-n commutative quasideterminant is a single quotient — no induction, no recursion, no mutual definition required — and Mathlib's existing field-division API discharges all three core identities in one line each",
+      "The n=3 bridge is `rfl`: the parent `block3` is an `abbrev`, so the uniform `minorIJ` and the 3×3-specific `block3` are definitionally equal (this is the cleanest possible reduction)",
+      "The n=2 bridge reduces to `mul_right_cancel₀` once the parent's `qdet00_mul_eq_det` / `mul_qdet11_eq_det` are recognised as multiplicative-form variants of the same identity — no new content over a field, just cancellation",
+      "The Route B (non-commutative) one-step Schur formula `qdetN_step` decouples 'the recurrence' from 'the inverse construction': by passing `Minv` as a parameter, the recurrence is proven once and re-used at every level of the eventual inductive `qdetN`, so S4's mutual recursion has only to verify the inverse equation, not to re-prove Schur each time",
+      "The deferred field-consistency theorem `qdetN_step_eq_qdetF` is the strategic linchpin: it reduces the entire Route B construction to a *known* identity (Mathlib's `Matrix.det_succ_row` Laplace expansion + `Matrix.adjugate_apply` sign normalisation), so the S4 proof is mechanical re-indexing rather than open-ended algebra"
     ],
     "prerequisites": [
       "2×2 quasideterminant theory (CramersRuleOQ01OQ02.lean)",
       "3×3 quasideterminant theory (CramersRuleOQ01OQ02OQ01.lean)",
-      "Matrix.det_fin_one, Matrix.det_fin_two",
+      "Matrix.det_fin_one, Matrix.det_fin_two, Matrix.det_succ_row",
+      "Matrix.adjugate, Matrix.adjugate_apply, Matrix.inv_def",
       "Fin.succAbove for submatrix selection",
-      "Matrix.submatrix_apply"
+      "Matrix.submatrix_apply",
+      "DivisionRing API for the Route B Schur formula"
     ]
   },
   "conclusion": {
-    "summary": "Route A of the inductive n×n quasideterminant program is implemented in 187 lines, 0 sorries, 0 axioms. The uniform-in-n commutative qdetF generalizes both qdet00/qdet11 (n=2) and qdet3 (n=3) in their non-degenerate regimes, with the n=3 bridge holding by rfl and the n=2 bridges by mul_right_cancel₀ + det_fin_one.",
-    "implications": "The commutative half of the open question (define a uniform-in-n quasideterminant matching the parent 2×2 and 3×3 theories) is closed. The remaining content is the fully non-commutative inductive qdetN over a division ring (S3), whose proof of consistency over a field is qdetF_summary's S5 analogue.",
+    "summary": "Route A (S2, commutative) of the inductive n×n quasideterminant program is fully implemented in 276 lines with 0 axioms. The uniform-in-n commutative `qdetF` generalises both `qdet00`/`qdet11` (n=2) and `qdet3` (n=3) in their non-degenerate regimes, with the n=3 bridge holding by `rfl` and the n=2 bridges by `mul_right_cancel₀` + `det_fin_one`. Route B (S3 SCAFFOLD, non-commutative) adds the one-step Schur formula `qdetN_step` over a division ring together with its degenerate `Minv = 0` base case; the field-consistency reduction `qdetN_step_eq_qdetF` carries the file's sole sorry, deferred to S4.",
+    "implications": "The commutative half of the open question is closed: every n×n commutative Cramer-style identity over a field can be derived from `qdetF_summary` plus standard field algebra. The structural innovation of S3 — passing the complementary-minor inverse `Minv` as a parameter rather than tying it into mutual recursion — is the key insight that will let S4 build the full inductive `qdetN` on a single Schur identity proven once and re-used at every level. The deferred sorry is anchored to a Mathlib-known identity (Laplace cofactor expansion via `Matrix.det_succ_row` + `Matrix.adjugate_apply`), so its discharge is mechanical re-indexing rather than open algebraic discovery.",
     "openQuestions": [
-      "Define qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D over a division ring D via mutual strong recursion with qdetN_inv (S3).",
-      "Prove qdetN_recurrence: the Schur identity at every n (S4).",
-      "Prove qdetN_eq_qdetF over a field — the consistency theorem connecting Route A and Route B (S5).",
-      "Derive cramer_rule_nxn_qdet: the n×n Cramer's rule over a division ring (S6)."
+      "Prove `qdetN_step_eq_qdetF` (S4): the field-consistency bridge `qdetN_step A i j (minorIJ A i j)⁻¹ = qdetF A i j`. Strategy: expand `Matrix.inv_def`, factor `1/det(minor)`, apply `Matrix.det_succ_row` (Laplace expansion along row i), separate the `k = j` summand, and use `Matrix.adjugate_apply` to relate `(adjugate M) q p` to the signed cofactor `(-1)^(p+q) · det(submatrix_{p,q} M)`. Estimated ~60–90 Lean lines.",
+      "Build the inductive `qdetN : (n : ℕ) → Matrix (Fin n) (Fin n) D → Fin n → Fin n → D` (S5) via either (a) structural recursion over `Σ n, Matrix _ _ D` with `qdetN_step` as the recurrence kernel, or (b) `Invertible (minorIJ A i j)`-parameterised formulation that avoids mutual recursion by treating the inverse as a typeclass input.",
+      "Prove `qdetN_eq_qdetF` over a field (S6): the consistency theorem connecting Route A (S2) and Route B (S5).",
+      "Derive `cramer_rule_nxn_qdet` (S7): the n×n Cramer's rule over a division ring, the headline application of the entire chain."
     ]
   },
   "crossReferences": [
@@ -129,12 +151,12 @@
       "Matrix"
     ],
     "namespace": "CramersRuleOQ01OQ02OQ01OQ01",
-    "lineCount": 187,
+    "lineCount": 276,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 2,
+    "theoremCount": 10,
+    "definitionCount": 3,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

The `cramers-rule-oq-01-oq-02-oq-01-oq-01` Lean file grew from 187 → 276 lines via PR #18214 (S3 SCAFFOLD — `qdetN_step` non-commutative one-step Schur formula + field-consistency bridge with sorry), but the gallery metadata was never updated. This enrichment pass closes the drift and adds substantive annotation coverage for the new Part VI content.

## Drift fixes (meta.json + leanFile)

| Field | Old | New |
|---|---|---|
| `lineCount` | 187 | **276** |
| `sorries` | 0 | **1** |
| `theoremCount` | 6 | **10** |
| `definitionCount` | 2 | **3** |
| `assumptions` | (no mention of S3) | flags the deferred sorry on `qdetN_step_eq_qdetF` |

All 9 existing annotation line ranges shifted (each off by ~12-16 lines from the S3 SCAFFOLD insertion). All 4 existing section line ranges shifted; new Part V (Summary) and Part VI (Non-commutative Schur Step) sections added.

## New content

**3 new annotations** covering the S3 SCAFFOLD additions:
- `ann-qdetn-step`: definition of the parameterised Schur formula over a division ring, with the structural-innovation rationale (decoupling recurrence from inverse-construction)
- `ann-qdetn-step-zero-minv`: degenerate `Minv = 0` base case
- `ann-qdetn-step-eq-qdetf`: detailed S4 proof strategy via `Matrix.det_succ_row` + `Matrix.adjugate_apply`

**3 new `originalContributions`** for the S3 SCAFFOLD theorems/definitions.

**2 new `keyInsights`**:
- The decoupled-recursion structural innovation: passing `Minv` as a parameter rather than via mutual recursion, so S4's mutual recursion only needs to verify the inverse equation
- The Mathlib-anchored deferred sorry: reducing the entire Route B construction to known Mathlib identities (`det_succ_row` + `adjugate_apply`), making the S4 discharge mechanical re-indexing

**Rewritten `conclusion.openQuestions`** to reflect actual progress: `qdetN_step` exists, `qdetN_step_eq_qdetF` is the sole remaining sorry, and S4 → S5 → S6 → S7 staging is clarified (Schur identity → inductive `qdetN` → consistency → `cramer_rule_nxn_qdet`).

Description and `overview.problemStatement` now cover both Route A and Route B SCAFFOLD; prerequisites extended with `Matrix.det_succ_row`, `adjugate`, `inv_def`, and DivisionRing API.

## Axiom integrity

0 axiom declarations, 0 structure-encoded assumptions; `badge: \"original\"` with `status: \"formalized\"` correctly reflects the 1 remaining sorry on `qdetN_step_eq_qdetF` (deferred to S4 with detailed proof strategy in-file).

## Test plan
- [x] JSON syntax validated (python json.load on both files)
- [x] tsc --noEmit passes cleanly
- [x] tsx scripts/annotations/build.ts --strict reports 0 errors on this slug
- [x] All annotation line ranges fall within actual Lean constructs in the 276-line file

🤖 Generated with [Claude Code](https://claude.com/claude-code)