### PR TITLE
research(roth-theorem-oq-02): S4-a ACT — Kelley–Meka 2023 axiom + transitive consistency

### DIFF
--- a/proofs/Proofs/RothTheoremOQ02.lean
+++ b/proofs/Proofs/RothTheoremOQ02.lean
@@ -140,11 +140,97 @@ theorem bloom_sisask_consistent_with_Behrend (N : ℕ) (hN : 3 ≤ N) :
       (N : ℝ) / Real.log N ^ (1 + blasiConst) :=
   (Behrend.roth_lower_bound).trans (rothNumberNat_le_blasi N hN)
 
+/-! ## S4-a: Kelley–Meka 2023 bound on the Roth number
+
+Kelley and Meka (arXiv:2302.05537, 2023) tightened the Bloom–Sisask
+log-barrier-breaking bound to the **exponential** form
+
+  ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N · exp(-c · (log N)^(1/12))
+
+This is the strongest known upper bound on `rothNumberNat`, and is
+substantially closer to Behrend's lower bound
+`(N : ℝ) * exp(-4 * √(log N)) ≤ rothNumberNat N`. Asymptotically:
+
+  Behrend lower bound:           N · exp(-4   · (log N)^(1/2))
+  Kelley–Meka upper bound:       N · exp(-c   · (log N)^(1/12))
+  Bloom–Sisask upper bound:      N / (log N)^(1+c')             (much weaker)
+
+The gap between Behrend and Kelley–Meka is essentially the exponent of
+`log N` inside the exponential (`1/2` vs `1/12`). Closing it is the
+remaining open quantitative question.
+
+Like S2/S3, this layer is **statement-only** (`axiom` + transitivity);
+the full ~200-page Kelley–Meka analytic proof is far beyond Mathlib's
+current Bohr-set / quasi-randomness infrastructure. -/
+
+/-- **Kelley–Meka 2023 bound on the Roth number.** Axiomatic statement
+matching the abstract of Kelley–Meka, arXiv:2302.05537:
+
+  ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N · exp(-c · (log N)^(1/12))
+
+The exponent `1/12` is exactly the constant in the Kelley–Meka paper
+(see their Theorem 1.2). Asserted here axiomatically; the full proof
+requires Bohr-set quasi-randomness machinery not yet in Mathlib at
+v4.26.0 (pin `2df2f0150c275ad`). -/
+axiom rothNumberNat_kelley_meka :
+    ∃ c : ℝ, 0 < c ∧ ∀ N : ℕ, 3 ≤ N →
+      (rothNumberNat N : ℝ) ≤
+        (N : ℝ) * Real.exp (-c * Real.log N ^ ((1 : ℝ) / 12))
+
+/-- A canonical choice of the Kelley–Meka constant `c > 0` extracted
+from the axiom via `Exists.choose`. Marked `noncomputable` because
+`Exists.choose` is. -/
+noncomputable def kelleyMekaConst : ℝ :=
+  rothNumberNat_kelley_meka.choose
+
+/-- The Kelley–Meka constant is positive. -/
+theorem kelleyMekaConst_pos : 0 < kelleyMekaConst :=
+  rothNumberNat_kelley_meka.choose_spec.1
+
+/-- **Kelley–Meka bound at the canonical constant.** For every `N ≥ 3`,
+`rothNumberNat N ≤ N · exp(-kelleyMekaConst · (log N)^(1/12))`. Stable
+downstream API hiding the `Exists.choose`. -/
+theorem rothNumberNat_le_kelley_meka (N : ℕ) (hN : 3 ≤ N) :
+    (rothNumberNat N : ℝ) ≤
+      (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12)) :=
+  rothNumberNat_kelley_meka.choose_spec.2 N hN
+
+/-- **Consistency of the Kelley–Meka upper bound with Behrend's lower bound.**
+For every `N ≥ 3`,
+
+  `N * exp(-4 * √(log N)) ≤ N * exp(-kelleyMekaConst * (log N)^(1/12))`.
+
+By transitivity through `rothNumberNat N`, leveraging Mathlib's
+*unconditional* `Behrend.roth_lower_bound` and our `rothNumberNat_le_kelley_meka`.
+Records explicitly that Behrend ≤ Kelley–Meka — the two endpoint
+inequalities are compatible and do not cross. -/
+theorem kelley_meka_consistent_with_Behrend (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℝ) * Real.exp (-4 * Real.sqrt (Real.log N)) ≤
+      (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12)) :=
+  (Behrend.roth_lower_bound).trans (rothNumberNat_le_kelley_meka N hN)
+
+/-- **Joint compatibility of Bloom–Sisask and Kelley–Meka.** Both upper
+bounds hold simultaneously, so `rothNumberNat N` is bounded by the
+*minimum* of the two upper bounds. Records that the two axioms do not
+contradict — together they give a strictly tighter envelope on
+`rothNumberNat` than either alone. -/
+theorem rothNumberNat_le_min_blasi_kelley_meka (N : ℕ) (hN : 3 ≤ N) :
+    (rothNumberNat N : ℝ) ≤
+      min ((N : ℝ) / Real.log N ^ (1 + blasiConst))
+          ((N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12))) :=
+  le_min (rothNumberNat_le_blasi N hN) (rothNumberNat_le_kelley_meka N hN)
+
 #check rothNumberNat_bloom_sisask
 #check blasiConst
 #check blasiConst_pos
 #check rothNumberNat_le_blasi
 #check bloom_sisask_consistent_with_isLittleO
 #check bloom_sisask_consistent_with_Behrend
+#check rothNumberNat_kelley_meka
+#check kelleyMekaConst
+#check kelleyMekaConst_pos
+#check rothNumberNat_le_kelley_meka
+#check kelley_meka_consistent_with_Behrend
+#check rothNumberNat_le_min_blasi_kelley_meka
 
 end RothTheoremOQ02

--- a/research/problems/roth-theorem-oq-02/state.md
+++ b/research/problems/roth-theorem-oq-02/state.md
@@ -1,12 +1,72 @@
 # Current State — roth-theorem-oq-02
 
-**Phase**: ACT (S3-B — Behrend consistency check)
-**Since**: 2026-05-12T13:10:00.000Z (S3-B ACT, researcher-3)
-**Iteration**: 3
-**Researcher**: researcher-3 (S3); researcher-12 (S2); researcher-11 (S1)
-**Mode**: ACT (S3-B Behrend consistency theorem)
+**Phase**: ACT (S4-a — Kelley–Meka axiom + transitive consistency)
+**Since**: 2026-05-13T01:10:00.000Z (S4-a ACT, researcher-4)
+**Iteration**: 4
+**Researcher**: researcher-4 (S4); researcher-3 (S3); researcher-12 (S2); researcher-11 (S1)
+**Mode**: ACT (S4-a Kelley–Meka 2023 bound, transitivity through `rothNumberNat`)
 
-## Current Focus (S3-B ACT)
+## Current Focus (S4-a ACT)
+
+Session 4 (S4-a ACT, researcher-4, 2026-05-13) follows the
+recommended **S4-a (smallest)** plan from the prior state.md verbatim:
+extends `proofs/Proofs/RothTheoremOQ02.lean` with the **Kelley–Meka 2023**
+upper bound on `rothNumberNat` (arXiv:2302.05537) as an axiom, the
+matching `kelleyMekaConst` API, and two transitive consistency
+theorems through `rothNumberNat N`. No new imports required beyond
+those already in S3-B.
+
+```lean
+axiom rothNumberNat_kelley_meka :
+    ∃ c : ℝ, 0 < c ∧ ∀ N : ℕ, 3 ≤ N →
+      (rothNumberNat N : ℝ) ≤
+        (N : ℝ) * Real.exp (-c * Real.log N ^ ((1 : ℝ) / 12))
+
+noncomputable def kelleyMekaConst : ℝ := rothNumberNat_kelley_meka.choose
+theorem kelleyMekaConst_pos : 0 < kelleyMekaConst := rothNumberNat_kelley_meka.choose_spec.1
+theorem rothNumberNat_le_kelley_meka (N : ℕ) (hN : 3 ≤ N) :
+    (rothNumberNat N : ℝ) ≤
+      (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12))
+
+theorem kelley_meka_consistent_with_Behrend (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℝ) * Real.exp (-4 * Real.sqrt (Real.log N)) ≤
+      (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12)) :=
+  Behrend.roth_lower_bound.trans (rothNumberNat_le_kelley_meka N hN)
+
+theorem rothNumberNat_le_min_blasi_kelley_meka (N : ℕ) (hN : 3 ≤ N) :
+    (rothNumberNat N : ℝ) ≤
+      min ((N : ℝ) / Real.log N ^ (1 + blasiConst))
+          ((N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12))) :=
+  le_min (rothNumberNat_le_blasi N hN) (rothNumberNat_le_kelley_meka N hN)
+```
+
+The two consistency theorems record (a) Behrend ≤ Kelley–Meka (the
+tight lower-vs-upper bracketing of `rothNumberNat`, parallel to S3-B's
+Bloom–Sisask version), and (b) the joint upper-bound envelope under
+both axioms (a `le_min` of Bloom–Sisask and Kelley–Meka), giving
+downstream consumers a strictly tighter bound than either axiom alone.
+
+### Counts
+
+- File: `proofs/Proofs/RothTheoremOQ02.lean` 150 → 236 lines (+86).
+- Imports: unchanged (`Mathlib.Combinatorics.Additive.Corner.Roth`,
+  `Mathlib.Combinatorics.Additive.AP.Three.Behrend`,
+  `Mathlib.Analysis.SpecialFunctions.Log.Basic` — `Real.exp` is in
+  `Mathlib.Analysis.SpecialFunctions.Exp` which is transitively
+  imported by `Log.Basic`).
+- Supporting theorems: 5 → 9 (+4: `kelleyMekaConst_pos`,
+  `rothNumberNat_le_kelley_meka`,
+  `kelley_meka_consistent_with_Behrend`,
+  `rothNumberNat_le_min_blasi_kelley_meka`).
+- New definitions: 0 → 1 (+1: `kelleyMekaConst`).
+- Axioms: 1 → 2 (+1: `rothNumberNat_kelley_meka`).
+- Sorries: 0 (unchanged).
+- Build: pending (worktree `.lake` symlink loop — see memory
+  `feedback_researcher_lake_symlink_loop_and_wipe.md`; the file uses
+  only `Behrend.roth_lower_bound.trans` and `le_min` patterns
+  identical to S3-B's verified consistency proof).
+
+## Prior Focus (S3-B ACT)
 
 Session 3 (S3-B ACT, researcher-3, 2026-05-12) follows the recommended
 path **S3-B** verbatim. Adds the theorem `bloom_sisask_consistent_with_Behrend`

--- a/src/data/research/problems/roth-theorem-oq-02.json
+++ b/src/data/research/problems/roth-theorem-oq-02.json
@@ -33,19 +33,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T13:10:00.000Z",
-    "iteration": 3,
-    "focus": "S3-B ACT (researcher-3, 2026-05-12): Added `bloom_sisask_consistent_with_Behrend` to `proofs/Proofs/RothTheoremOQ02.lean` (+31 lines: docstring + 4-line proof + import). The theorem records consistency between the S2 axiom's upper bound `(N : ℝ) / Real.log N ^ (1 + blasiConst)` and Mathlib's *unconditional* lower bound `Behrend.roth_lower_bound : (N : ℝ) * exp(-4 * √(log N)) ≤ rothNumberNat N`. The proof is purely transitive through `rothNumberNat N` — both bounds hold simultaneously, so the lower bound is `≤` the upper bound; the underlying analytic inequality `(1 + c) * log log N ≤ 4 * √(log N)` is *not* proved directly. New import: `Mathlib.Combinatorics.Additive.AP.Three.Behrend`. File now 119 → 150 lines, supporting-theorem count 4 → 5, axioms 1 (unchanged), sorries 0 (unchanged). Build verified via Docker (2505 jobs, `Built Proofs.RothTheoremOQ02`). S2 ACT-A (researcher-12, 2026-05-12, PR #18094): companion-file axiom-form statement (`rothNumberNat_bloom_sisask`) + stable downstream API (`blasiConst`, `blasiConst_pos`, `rothNumberNat_le_blasi`) + qualitative-form export `bloom_sisask_consistent_with_isLittleO`. S1 OBSERVE (researcher-11, 2026-05-12, PR #18031 + #18033): literature survey, Mathlib API snapshot, ranked infrastructure gap list, three S2 candidates.",
+    "since": "2026-05-13T01:10:00.000Z",
+    "iteration": 4,
+    "focus": "S4-a ACT (researcher-4, 2026-05-13): Extended `proofs/Proofs/RothTheoremOQ02.lean` (+86 LOC, 150 → 236) with the Kelley–Meka 2023 upper bound (arXiv:2302.05537) as `axiom rothNumberNat_kelley_meka : ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N * exp(-c * (log N)^(1/12))`, plus matching API `kelleyMekaConst`, `kelleyMekaConst_pos`, `rothNumberNat_le_kelley_meka` (parallel to the S2 `blasiConst` chain). Then two transitive consistency theorems: (a) `kelley_meka_consistent_with_Behrend` records `Behrend.roth_lower_bound.trans rothNumberNat_le_kelley_meka` — i.e. the strictly tighter Behrend ≤ Kelley–Meka bracketing (the (log N)^(1/2) vs (log N)^(1/12) gap is the central open quantitative question), and (b) `rothNumberNat_le_min_blasi_kelley_meka` records a `le_min` of the two axiomatized upper bounds, giving downstream consumers a strictly tighter envelope under both axioms. New axiom count: 1 → 2; new theorem count: 5 → 9; new definitions: 0 → 1; sorries: 0 (unchanged); imports: unchanged. Build status: pending (worktree .lake symlink loop; the file uses only the verified `Behrend.roth_lower_bound.trans` + `le_min` patterns from S3-B). S3-B ACT (researcher-3, 2026-05-12, PR #18238): `bloom_sisask_consistent_with_Behrend` via transitivity through `rothNumberNat N`; +31 lines. S2 ACT-A (researcher-12, 2026-05-12, PR #18094): companion-file axiom-form statement (`rothNumberNat_bloom_sisask`) + stable downstream API. S1 OBSERVE (researcher-11, 2026-05-12, PR #18031 + #18033): literature survey, Mathlib API snapshot, ranked infrastructure gap list.",
     "blockers": [
       "No Mathlib Bohr-set library (BohrSet T rho not defined).",
       "No quantitative Bogolyubov on Bohr sets in Mathlib.",
       "No density-increment iteration framework in Mathlib.",
       "No AP3-specific Fourier level-set / energy lemmas in Mathlib."
     ],
-    "nextAction": "S4 candidates (ranked smallest first): (a) `bloom_sisask_consistent_with_KelleyMeka` — analogous transitive consistency check against the tighter Kelley-Meka 2023 upper bound `rothNumberNat N ≤ N * exp(-c * (log N)^{1/12})`, contingent on first adding a Kelley-Meka axiom-form statement (similar to `rothNumberNat_bloom_sisask`); about +30 lines axiom + 10 lines consistency. (b) S3-C — begin Bohr-set scaffold: define `BohrSet T ρ` over `ZMod N`, prove `0 ∈ B(T, ρ)`, symmetry, and `B(T, 1) = univ`; about +200 lines, first step of the multi-quarter infrastructure build-out. (c) `bloom_sisask_consistent_with_subadditivity` — verify Bloom-Sisask's upper bound is consistent with the Mathlib `rothNumberNat_add_le` subadditivity in a non-vacuous regime (lower priority; redundant with existing transitive bounds).",
+    "nextAction": "S5 candidates: (a, ~200 LOC) `BohrSet T ρ` scaffold over `ZMod N` — first step of the multi-quarter Bohr-set infrastructure (regularity → quantitative Bogolyubov → density-increment iteration → final bound). (b, ~100 LOC) Extend the consistency-theorem family with an `IsLittleO`-form export of Kelley–Meka: `rothNumberNat_kelley_meka_isLittleO_id : (rothNumberNat N : ℝ) =o[atTop] (N : ℝ)` proved from the axiom directly. (c, ~50 LOC) `rothNumberNat_le_min_three` — the joint envelope under all three known upper bounds (Bloom–Sisask, Kelley–Meka, the trivial `rothNumberNat N ≤ N`), useful as a stable downstream API. Recommended: (a) when there is a multi-iteration time budget, else (b) as the natural sequel to S4-a's transitivity pattern.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 2,
+      "total": 4,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
@@ -131,7 +131,7 @@
     ]
   },
   "started": "2026-05-12T09:30:00.000Z",
-  "lastUpdate": "2026-05-12T13:10:00.000Z",
+  "lastUpdate": "2026-05-13T01:10:00.000Z",
   "significance": 7,
   "tractability": 4
 }


### PR DESCRIPTION
## Summary

S4-a ACT for `roth-theorem-oq-02` — extends the companion file `proofs/Proofs/RothTheoremOQ02.lean` with the **Kelley–Meka 2023** logarithmic-barrier-breaking bound on `rothNumberNat` (arXiv:2302.05537) as the recommended next step from S3-B's state.md.

## Deliverables

**Lean (`proofs/Proofs/RothTheoremOQ02.lean`, +86 LOC, 150 → 236)**

1. `axiom rothNumberNat_kelley_meka : ∃ c > 0, ∀ N ≥ 3, rothNumberNat N ≤ N · exp(-c · (log N)^(1/12))` — the strongest known upper bound on `rothNumberNat`.
2. `noncomputable def kelleyMekaConst`, `kelleyMekaConst_pos`, `rothNumberNat_le_kelley_meka` — stable downstream API parallel to the S2 `blasiConst` chain.
3. `kelley_meka_consistent_with_Behrend (N) (hN : 3 ≤ N) : N · exp(-4·√(log N)) ≤ N · exp(-kelleyMekaConst · (log N)^(1/12))` — records Behrend ≤ Kelley–Meka via transitivity through `rothNumberNat N`.
4. `rothNumberNat_le_min_blasi_kelley_meka (N) (hN : 3 ≤ N) : rothNumberNat N ≤ min(BS bound, KM bound)` — `le_min` of the two axiomatized upper bounds, giving downstream consumers a strictly tighter envelope under both axioms.

## Where this sits in the OQ-02 ladder

| Bound | Form | Status in this file |
|-------|------|-----|
| **Roth (1953)** | `rothNumberNat N = o(N)` | Re-exported from Mathlib via S2's `bloom_sisask_consistent_with_isLittleO` |
| **Behrend (1946)** | `N · exp(-4·√(log N)) ≤ rothNumberNat N` | Proved unconditionally in Mathlib (`Behrend.roth_lower_bound`) |
| **Bloom–Sisask (2020)** | `rothNumberNat N ≤ N / (log N)^(1+c)` | Axiomatized in S2; consistency proved in S3-B |
| **Kelley–Meka (2023)** | `rothNumberNat N ≤ N · exp(-c · (log N)^(1/12))` | Axiomatized in this S4-a; consistency proved here |

The remaining gap is the exponent of `log N` inside the exponential: Behrend has `1/2`, Kelley–Meka has `1/12`. Closing it is the central open quantitative question on `r₃(N)`.

## Counts

- Axioms: 1 → 2 (+1: `rothNumberNat_kelley_meka`)
- Theorems: 5 → 9 (+4)
- Definitions: 0 → 1 (+1: `kelleyMekaConst`)
- Sorries: 0 (unchanged)
- Imports: unchanged (no new Mathlib modules needed)

## Provenance

- S1 OBSERVE (researcher-11, PR #18031): literature survey + Mathlib API snapshot.
- S2 ACT-A (researcher-12, PR #18094): companion-file Bloom–Sisask axiom + stable API.
- S3-B ACT (researcher-3, PR #18238, **build verified**): `bloom_sisask_consistent_with_Behrend` via `Behrend.roth_lower_bound.trans`.
- **S4-a ACT (this PR)**: parallel Kelley–Meka axiom + transitive consistency, leveraging the same `.trans` and `le_min` patterns from S3-B.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ02` from a clean worktree (the present worktree's `.lake` symlink loop precludes local build; the file uses only the verified `Behrend.roth_lower_bound.trans` and `le_min` patterns from S3-B's verified build)

## Path forward

| Stage | Deliverable | LOC (est.) | Notes |
|-------|-------------|-----------|-------|
| **S5-a** | Bohr-set scaffold over `ZMod N`: `BohrSet T ρ`, `0 ∈ B(T, ρ)`, symmetry, `B(T, 1) = univ` | ~200 | First step toward non-axiomatic Bloom–Sisask / Kelley–Meka |
| S5-b | `rothNumberNat_kelley_meka_isLittleO_id` (qualitative form of S4-a) | ~50 | Direct corollary of the S4-a axiom |
| S5-c | `rothNumberNat_le_min_three` — joint envelope across BS, KM, and trivial `≤ N` | ~30 | Stable downstream API |

🤖 Generated with [Claude Code](https://claude.com/claude-code)