### PR TITLE
audit(tracker): mark zsqrtd-neg-two-oq-03 clean (S2 ACT Eisenstein infra)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15221,6 +15221,12 @@
       "lastAudited": "2026-05-12T22:35:19Z",
       "result": "clean",
       "issues": []
+    },
+    "zsqrtd-neg-two-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-13T02:15:07Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

- Final unaudited proof in the gallery (2428/2429 → 2429/2429).
- `zsqrtd-neg-two-oq-03` landed yesterday via PR #18436 (S2 ACT Eisenstein integer ring + norm) but the audit tracker was never bumped.

## Audit pass

Source: `proofs/Proofs/ZsqrtdNegTwoOQ03.lean` (207 lines, S2 ACT infrastructure).

| Check | Claim | Actual | OK |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| `axiom` declarations | 0 | 0 | ✓ |
| `True`-stub theorems | — | 0 | ✓ |
| Status / badge | `verified` / `original` | Tier A infrastructure | ✓ |

The file builds a fresh concrete `CommRing Eisenstein` and proves the four norm properties (`norm_nonneg`, `norm_mul`, `norm_eq_zero_iff`, `norm_pos_of_ne_zero`) from first principles. Mathlib reuse (`nsmulRec`, `zsmulRec`, `npowRec`, `sq_nonneg`, `pow_eq_zero_iff`) is scalar-mul scaffolding and one inequality lemma — not a Mathlib wrapper of the main result.

All four auditor-tracked fields consistent. Marking `clean`.

## Housekeeping (out of scope, not blocking)

`meta.lineCount = 175` and `meta.theoremCount = 13` lag the actual file (207 lines, 20 `theorem` declarations). These fields are not auditor-tracked; they're swept in batch by the next `fix(meta): sync count drift` pass (cf. #18184 which synced 8 such drifts last week). Leaving for that sweep.

## Test plan

- [x] Tracker JSON validates
- [x] Audit-fields check passes (`npx tsx scripts/auditor/find-targets.ts --next` now returns brouwer-fixed-point-oq-01-oq-02 as the sole residual, covered by in-flight #18374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)