### PR TITLE
audit: sync brouwer-oq0102 meta counts (axiomCount 2→3, lineCount 375→462)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -54,8 +54,8 @@
       "13 total theorems separating algebraic core (0 axioms), ball-zero scaffold + substantive form (theorems), and the two residual axioms (B1 surrogate + B2 sphere-nonzero)"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 375,
-    "assumptions": "2 axioms. (1) H_n_minus_1_sphere_nonzero (n ≥ 1, r : Retraction n, φ : ℤ →+ Unit) ⇒ ∃ ψ : Unit →+ ℤ, ψ.comp φ = id ℤ — encoding the deep singular-homology facts H_{n-1}(S^{n-1}) ≅ ℤ (Mathlib gap B2: no Mayer–Vietoris, no excision, no sphere homology) combined with retraction-functoriality. (2) contractible_singularHomology_zero (n ≥ 1, X : Type, [TopologicalSpace X] [ContractibleSpace X]) ⇒ singularHomology n X is zero — a thin classical-fact surrogate for Mathlib gap B1 (the prism operator bridging topological homotopy and chain homotopy). The mock-form lemma H_n_minus_1_ball_zero is preserved as a trivial theorem (existential witness ⟨0, trivial⟩) so downstream consumers continue working; alongside it H_n_minus_1_ball_zero_substantive is proved using contractible_singularHomology_zero. The composite singular_homology_retraction_split is preserved as a derived theorem combining the mock form with sphere-nonzero. no_retraction_axiom appears only in a block-comment example, not as an actual axiom. The algebraic argument (Part II) is fully proved with 0 axioms.",
+    "lineCount": 462,
+    "assumptions": "3 axioms. (1) H_n_minus_1_sphere_nonzero (n ≥ 1, r : Retraction n, φ : ℤ →+ Unit) ⇒ ∃ ψ : Unit →+ ℤ, ψ.comp φ = id ℤ — mock-form B2 surrogate composing the deep singular-homology facts H_{n-1}(S^{n-1}) ≅ ℤ (Mathlib gap B2: no Mayer–Vietoris, no excision, no sphere homology) with retraction-functoriality. (2) contractible_singularHomology_zero (n ≥ 1, X : Type, [TopologicalSpace X] [ContractibleSpace X]) ⇒ singularHomology n X is zero — a thin classical-fact surrogate for Mathlib gap B1 (the prism operator bridging topological homotopy and chain homotopy). (3) sphere_singularHomology_nonzero (n ≥ 1) ⇒ singularHomology n (UnitSphere (n+1)) is non-zero — strictly weaker substantive B2 surrogate landed in S7 ACT-D-1 (only asserts non-vanishing, not the full H_n(𝕊 n) ≅ ℤ), driving H_n_minus_1_sphere_nonzero_substantive while leaving the algebraic Section G7 bridge for S8. The mock-form lemma H_n_minus_1_ball_zero is preserved as a trivial theorem (existential witness ⟨0, trivial⟩); alongside it H_n_minus_1_ball_zero_substantive is proved using contractible_singularHomology_zero. The composite singular_homology_retraction_split is preserved as a derived theorem combining the mock form with sphere-nonzero. no_retraction_axiom appears only in a block-comment example, not as an actual axiom. The algebraic argument (Part II) is fully proved with 0 axioms.",
     "theoremCount": 13,
     "definitionCount": 3
   },
@@ -147,9 +147,9 @@
     }
   ],
   "leanFile": {
-    "lineCount": 375,
+    "lineCount": 462,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "sorries": 0,
     "definitionCount": 3,
     "theoremCount": 13


### PR DESCRIPTION
## Summary

Drift-sync for `brouwer-fixed-point-oq-01-oq-02`:
- `meta.axiomCount`: 2 → 3
- `meta.lineCount`: 375 → 462
- `meta.assumptions`: rewritten to describe the 3-axiom architecture
- `leanFile.axiomCount`: 2 → 3
- `leanFile.lineCount`: 375 → 462

## Why

`npx tsx scripts/auditor/find-targets.ts --issues` reports:

```
brouwer-fixed-point-oq-01-oq-02 (4x, last 2026-05-12) [axiomatized/axiom] ❌ axiom undercount: claims 2, actual declarations 3
```

The three real `axiom` declarations in `proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean` are:
- `H_n_minus_1_sphere_nonzero` (line 261, mock-form B2 surrogate)
- `contractible_singularHomology_zero` (line 287, thin B1 surrogate)
- `sphere_singularHomology_nonzero` (line 351, substantive B2 surrogate landed in S7 ACT-D-1)

Line 44's `axiom no_retraction_axiom` lives inside a markdown code-block in a docstring (the comparison block with `BrouwerFixedPoint.lean`) — not a real declaration. find-targets's regex correctly excludes it.

## Supersedes #18374

PR #18374 (`audit/sync-cramers-brouwer-1778628616`, opened 2026-05-12 23:35 UTC) is stuck on a DIRTY merge conflict in `audit-tracker.json`. Since auditor owns drift-sync and the conflict is purely from the always-moving tracker stream, this PR re-issues the brouwer half off current `origin/main` with no tracker churn.

The cramers-rule half of #18374 (sorries 0→1) is already synced on main — no edit needed.

## Test plan

- [x] `wc -l proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean` → 462
- [x] `grep -cE "^(?:(?:private|noncomputable)\s+)*axiom " proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean` → 4 (one of which is inside a docstring code-fence, so find-targets's stricter parser counts 3)
- [x] After merge, `npx tsx scripts/auditor/find-targets.ts --issues` should return zero issues.

Per Axiom Integrity Policy: status remains `axiomatized`, badge remains `axiom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)