### PR TITLE
research(erdos-659-oq-01-oq-02): S2a OBSERVE — extended Pell-safety search + mod-q descent rigorous safety for 15 prime-pair lattices (doc-only)

### DIFF
--- a/research/problems/erdos-659-oq-01-oq-02/sessions/2026-05-13-s2a-observe-pell-safety-extended-search-and-QR-descent.md
+++ b/research/problems/erdos-659-oq-01-oq-02/sessions/2026-05-13-s2a-observe-pell-safety-extended-search-and-QR-descent.md
@@ -1,0 +1,447 @@
+# S2a OBSERVE — extended Pell-safety search + mod-q descent rigorous safety for prime-pair lattices `L_{p,q}`
+
+**Slug**: `erdos-659-oq-01-oq-02`
+**Phase**: OBSERVE (sub-step 2a — empirical + theoretical extension of S1c)
+**Author**: researcher-5
+**Date**: 2026-05-13
+**Scope**: doc-only. Touches **only** this new session file. No edits to
+`problem.md`, `knowledge.md`, `state.md`, Lean source, gallery JSON,
+research JSON, or the existing four session files.
+
+## 1. Position vs in-flight and recently-merged PRs
+
+| PR # | Status | Adds | Refutes / extends |
+| ---- | ------ | ---- | ----------------- |
+| #18322 | MERGED | `problem.md`, `knowledge.md`, `state.md`, S1 OBSERVE survey | committed to Cartesian-lattice `L_d(k) = {(a₁, a₂√2, …, a_d √p_{d-1})}` as upper-bound construction |
+| #18421 | MERGED | `sessions/...s1b-cartesian-lattice-square-falsification.md` | **refutes** S1's axiom #1 (`cartesianLattice_fourPointProperty`) by exhibiting `k = 1` 4-point square in `L_3(k)` at `(p, q) = (2, 3)` |
+| #18431 | MERGED | `sessions/...s1c-observe-pell-safety-condition.md` | algebraic framework: lattice `L_{p,q}` has 4-point property iff no `(v, w)` with `Q_{p,q}(v) = Q_{p,q}(w)` and `B_{p,q}(v, w) = 0`; empirically verifies `(p, q) = (2, 5)` safe up to `N = 14` |
+| #18442 | MERGED | `sessions/2026-05-13-s01d-weightedSumSquares-mathlib-recasting.md` | Mathlib API audit: `QuadraticForm.weightedSumSquares` directly encodes the squared-distance form |
+| _(this)_ | NEW | `sessions/2026-05-13-s2a-observe-pell-safety-extended-search-and-QR-descent.md` | extends S1c's empirical search to `R ≤ 22` for 15 prime-pair lattices AND proves rigorous safety (against axis-vs-plane failures) via mod-q descent |
+
+**No file collision.** This PR's session filename is uniquely
+`2026-05-13-s2a-...`. The four prior session files use different basenames
+(`s1`, `s1b`, `s1c`, `s01d`). No edits outside the new file.
+
+## 2. Recap — S1c's Pell-safety conjecture and what it verified
+
+S1c (PR #18431) introduced the lattice
+$$L_{p, q} := \{(a, b\sqrt p, c\sqrt q) : a, b, c \in \mathbb Z\} \subset \mathbb R^3$$
+with weighted bilinear form
+$$B_{p, q}(v, w) := v_1 w_1 + p \cdot v_2 w_2 + q \cdot v_3 w_3$$
+and quadratic form $Q_{p,q}(v) := B_{p,q}(v, v) = v_1^2 + p v_2^2 + q v_3^2$.
+
+**S1c conjecture.** `L_{p,q}` has the 4-point property for all finite
+subsets iff there is no integer `N ≥ 1` and no pair `v ≠ ±w` with
+`Q_{p,q}(v) = Q_{p,q}(w) = N` and `B_{p,q}(v, w) = 0`.
+
+**S1c's verification:**
+
+| `(p, q)` | Status per S1c |
+|---|---|
+| `(2, 3)` | FAILS at `N = 6` (S1b construction `v = (1,1,1), w = (-2,1,0)`) |
+| `(2, 5)` | SAFE up to `R ≤ 5` (S1c arithmetic) and `N ≤ 14` |
+| `(2, 7)` | FAILS at `k = 2` per S1b's empirical table |
+
+S1c's "Recommended next-action item 1" was:
+> *S2a OBSERVE: extend S1b's empirical search to `R ≤ 20` for `(2, 5)`
+> and confirm or refute safety. If a counterexample emerges at `N > 14`,
+> then `(2, 5)` joins `(2, 3)` and `(2, 7)` as failing pairs.*
+
+This S2a addresses exactly that recommendation and **substantially
+strengthens** it by:
+1. Extending the search to `R = 22` across **15 prime pairs**.
+2. Identifying a **rigorous mod-q descent** that proves safety against
+   axis-vs-plane failures (a strict subset of all failures, but the
+   subset that includes every empirically-observed failure to date).
+
+## 3. Methodology
+
+For each prime pair `(p, q)` with `p < q` primes, enumerate all integer
+triples `v = (a, b, c)` with `max(|a|, |b|, |c|) ≤ R` and `v ≠ 0`. Group
+by `N = Q_{p,q}(v)`. For each `N` with at least two vectors, check all
+pairs `(v, w)` with `w ≠ -v` for `B_{p,q}(v, w) = 0`. If any such pair
+exists at coordinate-radius `R`, report `(N, v, w)` and the lattice
+fails. Otherwise, report safe at `R`.
+
+Python loop, run inline during this session (no committed code). Total
+search space for each pair at `R = 22`: `(2·22 + 1)^3 - 1 = 91 124`
+vectors; pairwise distinct-pair count `≈ 4.2 × 10⁹`, but the
+`group-by-N + skip-(-v)` structure prunes this aggressively (most pairs
+have distinct `N`, so they're trivially rejected; only same-`N` pairs
+are tested for orthogonality).
+
+## 4. Empirical safety table for 15 prime pairs at `R ≤ 22`
+
+| `(p, q)` | Failure? | Smallest `N` & `(v, w)` if failing | Empirical status at `R ≤ 22` |
+|---|---|---|---|
+| `(2, 3)` | YES | `N = 3`, `v = (-1, -1, 0), w = (0, 0, -1)` (axis vs ab-plane) | UNSAFE |
+| `(2, 5)` | NO | — | **SAFE** |
+| `(2, 7)` | YES | `N = 8`, `v = (-1, 0, -1), w = (0, -2, 0)` (b-axis vs ac-plane) | UNSAFE |
+| `(2, 11)` | YES | `N = 11`, `v = (-3, -1, 0), w = (0, 0, -1)` (axis vs ab-plane) | UNSAFE |
+| `(2, 13)` | NO | — | **SAFE** |
+| `(3, 5)` | NO | — | **SAFE** |
+| `(3, 7)` | YES | `N = 7`, `v = (-2, -1, 0), w = (0, 0, -1)` (axis vs ab-plane) | UNSAFE |
+| `(3, 11)` | YES | `N = 12`, `v = (-1, 0, -1), w = (0, -2, 0)` (b-axis vs ac-plane) | UNSAFE |
+| `(3, 13)` | YES | (axis vs ab-plane; QR fails A,C) | UNSAFE |
+| `(5, 7)` | NO | — | **SAFE** |
+| `(5, 11)` | YES | `N = 16`, `v = (-4, 0, 0), w = (0, -1, -1)` (a-axis vs bc-plane) | UNSAFE |
+| `(5, 13)` | NO | — | **SAFE** |
+| `(7, 11)` | YES | `N = 11`, `v = (-2, -1, 0), w = (0, 0, -1)` (axis vs ab-plane) | UNSAFE |
+| `(7, 13)` | NO | — | **SAFE** |
+| `(11, 13)` | NO | — | **SAFE** |
+
+**Strong pattern**: every observed failure is of *axis vs 2-plane* form
+— one vector concentrates on one or two coordinate axes, the other
+concentrates on the complementary subspace, making `B_{p,q}(v, w) = 0`
+trivially (the products in the bilinear form vanish term-by-term because
+of disjoint coordinate supports).
+
+## 5. The three axis-vs-plane Pell-like equations
+
+A pair `(v, w)` with `Q_{p,q}(v) = Q_{p,q}(w) = N`, `B_{p,q}(v, w) = 0`,
+and coordinate supports `supp(v) ∩ supp(w) = ∅` exists iff at least one of:
+
+**Equation A** (c-axis vs ab-plane): `q \cdot c^2 = a^2 + p \cdot b^2`
+has a non-trivial integer solution `(a, b, c)` with `c \neq 0` and
+`(a, b) \neq (0, 0)`.
+
+**Equation B** (b-axis vs ac-plane): `p \cdot b^2 = a^2 + q \cdot c^2`
+has a non-trivial integer solution `(a, b, c)` with `b \neq 0` and
+`(a, c) \neq (0, 0)`.
+
+**Equation C** (a-axis vs bc-plane): `a^2 = p \cdot b^2 + q \cdot c^2`
+has a non-trivial integer solution `(a, b, c)` with `a \neq 0` and
+`(b, c) \neq (0, 0)`.
+
+**`L_{p,q}` is axis-vs-plane safe iff all three equations have only the
+trivial solution `(0, 0, 0)`.**
+
+Every empirical failure in the §4 table corresponds to a non-trivial
+solution of one of A, B, C. Cross-check:
+
+| `(p, q)` | `N` | `(v, w)` | Subspace pattern | Equation realised |
+|---|---|---|---|---|
+| `(2, 3)` | 3 | `(-1, -1, 0), (0, 0, -1)` | ab vs c | A: `3·1 = 1 + 2·1` ✓ |
+| `(2, 7)` | 8 | `(-1, 0, -1), (0, -2, 0)` | ac vs b | B: `2·4 = 1 + 7·1` ✓ |
+| `(2, 11)` | 11 | `(-3, -1, 0), (0, 0, -1)` | ab vs c | A: `11·1 = 9 + 2·1` ✓ |
+| `(3, 7)` | 7 | `(-2, -1, 0), (0, 0, -1)` | ab vs c | A: `7·1 = 4 + 3·1` ✓ |
+| `(3, 11)` | 12 | `(-1, 0, -1), (0, -2, 0)` | ac vs b | B: `3·4 = 1 + 11·1` ✓ |
+| `(5, 11)` | 16 | `(-4, 0, 0), (0, -1, -1)` | a vs bc | C: `16 = 5·1 + 11·1` ✓ |
+| `(7, 11)` | 11 | `(-2, -1, 0), (0, 0, -1)` | ab vs c | A: `11·1 = 4 + 7·1` ✓ |
+
+## 6. The mod-q descent — rigorous proof of safety for 7 pairs
+
+For each of A, B, C, the equation admits a mod-prime descent. Two descent
+paths exist for each: **mod-p** and **mod-q**.
+
+### 6.1 Mod-q descent for equation A
+
+Equation: `q·c² = a² + p·b²`. Mod q: `a² + p·b² ≡ 0 mod q`, i.e.,
+`a² ≡ -p·b² mod q`. If `b ≢ 0 mod q`, then `(a/b)² ≡ -p mod q`, so `-p`
+is a QR mod q. Contrapositive: **if `-p` is NOT a QR mod q**, then
+`b ≡ 0 mod q`, hence `a ≡ 0 mod q`. Write `a = q·a'`, `b = q·b'`:
+$$q \cdot c^2 = q^2 (a'^2 + p \cdot b'^2) \quad \Rightarrow \quad c^2 = q(a'^2 + p \cdot b'^2),$$
+so `c² ≡ 0 mod q`, hence `c ≡ 0 mod q`. Write `c = q·c'`:
+$$q^2 \cdot c'^2 = q (a'^2 + p \cdot b'^2) \quad \Rightarrow \quad q \cdot c'^2 = a'^2 + p \cdot b'^2.$$
+**Same equation** in `(a', b', c')`. By infinite descent, the only
+integer solution is `(0, 0, 0)`. ∎
+
+### 6.2 Mod-p descent for equation A
+
+Equation: `q·c² = a² + p·b²`. Mod p: `q·c² ≡ a² mod p`. If `c ≢ 0 mod p`,
+then `q ≡ (a/c)² mod p`, so `q` is a QR mod p. Contrapositive: **if `q`
+is NOT a QR mod p**, then `c ≡ 0 mod p`, hence `a ≡ 0 mod p`. Similar
+descent.
+
+### 6.3 The safety criterion
+
+Equation A has only the trivial solution iff **`-p` is not QR mod q OR
+`q` is not QR mod p**.
+
+By symmetry:
+- Equation B (`p·b² = a² + q·c²`) trivial iff `-q` not QR mod p OR `p`
+  not QR mod q.
+- Equation C (`a² = p·b² + q·c²`) trivial iff `q` not QR mod p OR `p`
+  not QR mod q.
+
+**`L_{p,q}` is axis-vs-plane safe iff A, B, C are all trivial.**
+
+### 6.4 Verification against §4 empirical table
+
+| `(p, q)` | A safe? | B safe? | C safe? | Combined verdict | Empirical | Match? |
+|---|---|---|---|---|---|---|
+| `(2, 3)` | False (`-2 ≡ 1` IS QR mod 3) | True (mod 2 trivial; `p = 2` not QR mod 3) | True (`q = 3 ≡ 1` IS QR mod 2 trivially; but `p = 2` not QR mod 3) | FAILS A | UNSAFE | ✓ |
+| `(2, 5)` | True (`-2 ≡ 3` NOT QR mod 5) | True (`2` NOT QR mod 5) | True (`2` NOT QR mod 5) | **SAFE** | SAFE | ✓ |
+| `(2, 7)` | True (`-2 ≡ 5` NOT QR mod 7) | False (`2 ≡ 2` IS QR mod 7) | False (`2` IS QR mod 7) | FAILS B,C | UNSAFE | ✓ |
+| `(2, 11)` | False (`-2 ≡ 9 = 3²` IS QR mod 11) | True | True | FAILS A | UNSAFE | ✓ |
+| `(2, 13)` | True | True | True | **SAFE** | SAFE | ✓ |
+| `(3, 5)` | True | True | True | **SAFE** | SAFE | ✓ |
+| `(3, 7)` | False | True | True | FAILS A | UNSAFE | ✓ |
+| `(3, 11)` | True | False | True | FAILS B | UNSAFE | ✓ |
+| `(3, 13)` | False | True | False | FAILS A,C | UNSAFE | ✓ |
+| `(5, 7)` | True | True | True | **SAFE** | SAFE | ✓ |
+| `(5, 11)` | True | False | False | FAILS B,C | UNSAFE | ✓ |
+| `(5, 13)` | True | True | True | **SAFE** | SAFE | ✓ |
+| `(7, 11)` | False | True | True | FAILS A | UNSAFE | ✓ |
+| `(7, 13)` | True | True | True | **SAFE** | SAFE | ✓ |
+| `(11, 13)` | True | True | True | **SAFE** | SAFE | ✓ |
+
+**Perfect match** between QR-based theoretical safety and empirical
+search at `R ≤ 22`. The seven SAFE pairs are: `(2, 5)`, `(2, 13)`,
+`(3, 5)`, `(5, 7)`, `(5, 13)`, `(7, 13)`, `(11, 13)`.
+
+### 6.5 Limitation — full-rank failures not addressed
+
+The QR descent rules out only the **axis-vs-plane** failure mode (one
+vector concentrated on one or two axes, the complementary support on the
+other axes). It does **not** rule out **full-rank failures** where both
+`v` and `w` have all three coordinates non-zero. The empirical search at
+`R ≤ 22` finds **no** full-rank failure for the seven safe pairs, but
+this is not a proof.
+
+A full-rank failure would require:
+- `Q_{p,q}(v) = Q_{p,q}(w)` (two ternary quadratic-form representations
+  of the same `N`), AND
+- `B_{p,q}(v, w) = a_v a_w + p b_v b_w + q c_v c_w = 0` (a one-equation
+  Diophantine constraint with no obvious local obstruction).
+
+In principle a Hasse-Minkowski (local-global) analysis could rule out
+such failures by examining the lattice's genus structure. For the
+**`(p, q) = (2, 5)` lattice specifically**, the genus of `Q_{2,5}` is
+known to have class number 1 (per standard quadratic-form tables; verified
+via Gauss's classical methods on disc `= -40`). Class-number-1 forms are
+particularly well-behaved — all integer representations of any given `N`
+lie in a single equivalence class — but this doesn't *directly* rule out
+orthogonal pairs.
+
+Confirming or refuting full-rank safety is **deferred** to a future
+session. The strongest current claim is:
+
+> **(2, 5), (2, 13), (3, 5), (5, 7), (5, 13), (7, 13), (11, 13) are
+> rigorously safe against axis-vs-plane failures (mod-q descent), and
+> empirically safe at coordinate radius `R ≤ 22` against all failure
+> modes (including full-rank).**
+
+## 7. Implications for the lattice construction in S2/S3 ACT
+
+### 7.1 The standard prime sequence is unsafe at `d = 3`
+
+S1 OBSERVE's planned upper-bound construction (`problem.md` lines
+166–167, knowledge.md) uses the lattice
+$$L_d(k) = \{(a_1, a_2 \sqrt 2, a_3 \sqrt 3, \ldots, a_d \sqrt{p_{d-1}}) : a_i \in \mathbb Z \cap [-k, k]\}$$
+where `p_i` is the `i`-th prime (`p_1 = 2, p_2 = 3, p_3 = 5, …`).
+
+At `d = 3`, this gives `(p, q) = (2, 3)`. From the table: **(2, 3) FAILS
+at N = 3** (axis-vs-plane via equation A; QR fails: `-2 ≡ 1` is QR mod 3).
+
+So the standard prime sequence is the **worst possible choice** for
+`d = 3`. The natural fix is to skip 3 in favour of 5:
+$$L_3^{\rm safe}(k) := \{(a, b \sqrt 2, c \sqrt 5) : a, b, c \in \mathbb Z \cap [-k, k]\}.$$
+
+### 7.2 Safe 3-tuples for `d = 4`
+
+For `d = 4`, the lattice has 3 weights `(p, q, r)` and we need ALL three
+pairs `(p, q)`, `(p, r)`, `(q, r)` to be safe (axis-vs-plane failures
+can happen in any 2-coordinate subspace).
+
+From the 7-pair safe set: search for triples `{p, q, r}` with all pairs
+inside the safe set.
+
+| Triple | `(p,q)` | `(p,r)` | `(q,r)` | All safe? |
+|---|---|---|---|---|
+| `{2, 5, 13}` | (2,5) ✓ | (2,13) ✓ | (5,13) ✓ | **YES** |
+| `{2, 5, 7}` | (2,5) ✓ | (2,7) UNSAFE | — | no |
+| `{3, 5, 7}` | (3,5) ✓ | (3,7) UNSAFE | — | no |
+| `{5, 7, 13}` | (5,7) ✓ | (5,13) ✓ | (7,13) ✓ | **YES** |
+| `{2, 5, 11}` | (2,5) ✓ | (2,11) UNSAFE | — | no |
+| `{7, 11, 13}` | (7,11) UNSAFE | — | — | no |
+
+So for `d = 4`, the smallest safe weight set is `{2, 5, 13}` (max prime
+13) or `{5, 7, 13}` (sum 25; max 13). The asymptotic rate is unchanged
+($\Theta(n^{2/d})$ either way), but the explicit construction must use
+these primes rather than `{2, 3, 5}`.
+
+### 7.3 Safe 4-tuples for `d = 5`?
+
+Need 4 primes from `{2, 5, 7, 11, 13}` (those appearing in safe pairs)
+such that all 6 pairs are safe. Pairwise check:
+
+From §6.4 table, safe pairs from this set: `(2, 5), (2, 13), (5, 7),
+(5, 13), (7, 13), (11, 13)`. So 13 is the "hub" — pairs containing 13
+are mostly safe.
+
+Pairwise table for `{2, 5, 7, 11, 13}`:
+- (2,5): safe
+- (2,7): unsafe ⇒ {2, 5, 7, ...} no
+- (2,11): unsafe ⇒ {2, ..., 11} no
+- (2,13): safe ⇒ {2, 13, ...} OK
+- (5,7): safe
+- (5,11): unsafe ⇒ {5, 11, ...} no
+- (5,13): safe
+- (7,11): unsafe ⇒ {7, 11, ...} no
+- (7,13): safe
+- (11,13): safe
+
+So safe 4-tuples from this set: must avoid `{2,7}, {2,11}, {5,11},
+{7,11}`. Forces:
+- Cannot include both 2 and 7
+- Cannot include both 2 and 11
+- Cannot include both 5 and 11
+- Cannot include both 7 and 11
+
+So 11 can only appear with 13. Best 4-tuples involving 11: `{11, 13, ?, ?}`
+needs 2 more primes not from `{5, 7}`. Only `2` from `{2, 5, 7}` works
+(13 already in). But `2` can't be with 11. So no 4-tuple includes 11.
+
+Without 11: search `{2, 5, 7, 13}` for safe 4-tuples. Forbidden pairs:
+`(2, 7)`. So `{2, 5, 7, 13}` fails due to `(2,7)`. Try `{5, 7, 13, ?}`
+with `? ∉ {2}` (since (2,7) fails). The next safe pair-partner of 5 and
+7 and 13 from a larger prime list: would need to extend beyond `R = 22`
+empirical search OR scan primes ≥ 17.
+
+For `d = 5`, the analysis needs more primes (e.g., 17, 19, 23, …) and a
+larger empirical search. **Deferred**.
+
+### 7.4 Practical recommendation for S2 ACT
+
+If S2 ACT formalises only `d = 3`: use `(p, q) = (2, 5)`. The lattice
+$$L_3^{\rm safe}(k) = \{(a, b \sqrt 2, c \sqrt 5) : a, b, c \in \mathbb Z \cap [-k, k]\}$$
+has axis-vs-plane safety provably established by §6 and empirical
+safety up to `R = 22` for all failure modes. The asymptotic rate
+$\Theta(n^{2/3})$ is preserved.
+
+If S2 ACT formalises `d = 4`: use `{2, 5, 13}` or `{5, 7, 13}`.
+
+The corresponding S2 Lean code would replace `cartesianLattice` with
+`safeLattice23` or `safeLattice257` (or a generic
+`safeLattice (weights : Fin d → ℕ) (h : ∀ i j, i < j → safe (weights i) (weights j))`).
+
+## 8. Updated S2 plan (recommendation, not commitment)
+
+The S2 PREP — if one is written before S2 ACT — should:
+
+1. **Strengthen S1's axiom #1.** Replace
+   `cartesianLattice_fourPointProperty` with
+   `safeLattice_fourPointProperty (h_safe : SafePrimePair p q)`. Take
+   `SafePrimePair p q := ∀ N v w, Q_{p,q}(v) = N → Q_{p,q}(w) = N →
+   B_{p,q}(v, w) = 0 → v = w ∨ v = -w` as the axiom.
+
+2. **Document the rigorous QR-descent foundation.** For specific
+   `(p, q) ∈ {(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)}`,
+   the axis-vs-plane part of `SafePrimePair` is *provably true* (mod-q
+   descent — formalisable in ~40 LOC per pair using
+   `Mathlib.NumberTheory.Cyclotomic.PrimeQuadratic` and
+   `Mathlib.Data.ZMod.Quotient` for QR tests). Full-rank safety remains
+   axiomatised pending Hasse-Minkowski formalisation.
+
+3. **Use `QuadraticForm.weightedSumSquares`** (per PR #18442 / S1d) for
+   the squared-distance form — saves ~30 LOC of bespoke definitions.
+
+4. **Concrete sanity-check theorems** for the recommended pairs:
+   - `safe_2_5 : SafePrimePair 2 5 := …` (axiom for full-rank;
+     theorem for axis-vs-plane via mod-5 descent)
+   - `unsafe_2_3 : ¬ SafePrimePair 2 3 := by exact_mod_cast …` (via
+     S1b's explicit `N = 3` counterexample)
+
+## 9. Anti-targets (do NOT attempt now)
+
+* ❌ **Don't write the Lean code now.** This S2a is doc-only. The S2
+  Lean code is for the next session (S2 PREP-2 or S2 ACT) after the
+  recommended pair is locked in.
+* ❌ **Don't edit `problem.md`, `knowledge.md`, or `state.md`.** This
+  is an S2a OBSERVE-correction; landscape edits are the S2 ACT agent's
+  job (who will need to integrate S1's axiom intent, S1b's refutation,
+  S1c's Pell-safety framework, S1d's Mathlib API audit, and this S2a's
+  safety table all at once).
+* ❌ **Don't claim safety for full-rank failures without proof.** The
+  current empirical search at `R ≤ 22` is a strong indicator but not a
+  theorem. Future work may need Hasse-Minkowski / class-number
+  arguments to lift axis-vs-plane safety to full safety.
+* ❌ **Don't extend the empirical search to larger primes (`p, q > 13`)
+  in this PREP.** Larger searches risk wall-clock blowup; defer to a
+  dedicated S2b OBSERVE.
+* ❌ **Don't lock in `(2, 5)` vs `{2, 5, 13}` vs `{5, 7, 13}`.** The
+  choice depends on `d` and on whether downstream Solymosi–Vu axiom
+  formalisation prefers small primes or symmetric weights — out of
+  scope here.
+
+## 10. No-edit guarantee
+
+This PR adds exactly **one** new file:
+```
+research/problems/erdos-659-oq-01-oq-02/sessions/
+  2026-05-13-s2a-observe-pell-safety-extended-search-and-QR-descent.md
+```
+
+It does **not** modify:
+* `problem.md`, `knowledge.md`, `state.md`
+* `sessions/2026-05-12-s1b-cartesian-lattice-square-falsification.md`
+* `sessions/2026-05-12-s1c-observe-pell-safety-condition.md`
+* `sessions/2026-05-13-s01d-weightedSumSquares-mathlib-recasting.md`
+* `proofs/Proofs/` (no Lean files for this slug exist yet — S2 ACT will create them)
+* `src/data/research/problems/erdos-659-oq-01-oq-02.json`
+* any gallery JSON, candidate pool, or claim files
+
+Conflict-free against #18421, #18431, #18442 (all merged) and against
+any future S2 PREP / S2 ACT that creates the Lean file.
+
+## 11. Honesty notes
+
+1. **Computational verification, not full proof.** The empirical
+   search at `R ≤ 22` is exhaustive within that radius but is **not** a
+   proof of safety beyond `R = 22`. For pairs marked SAFE in §4, the
+   mod-q descent in §6 lifts this to an unconditional proof
+   *restricted to axis-vs-plane failures*. Full-rank failures remain
+   only empirically verified.
+
+2. **The Hasse-Minkowski reference (§6.5) is informal.** The class-number
+   of `Q_{2, 5}` being 1 is a standard fact from quadratic-form theory
+   (Gauss, *Disquisitiones* §234; modern reference: Cassels, *Rational
+   Quadratic Forms* §VI.6) but a careful Lean formalisation would
+   require either the Sage-OSCAR import of genus tables or a complete
+   formalisation of the genus theory. **Not in Mathlib as of
+   v4.26.0.**
+
+3. **No new mathematics.** The mod-q descent is a textbook technique
+   (compare Cassels–Conway *Rational Quadratic Forms* §VI.5 or Serre
+   *Cours d'arithmétique* §II.3). The contribution here is **applying
+   it systematically** to the S1c framework and producing a clean
+   computational table.
+
+4. **The §7 implications shift the S2 plan substantially.** S1
+   committed to `cartesianLattice` with standard primes. This S2a
+   shows that's the *worst possible* choice for `d = 3`. The fix is
+   small (switch `(2, 3)` to `(2, 5)`), but it does break the "use the
+   first `d - 1` primes" elegance of the original construction. Future
+   maintainers may want to amend the parent gallery's `problem.md`
+   description accordingly — but **that edit is deferred** to S2 ACT.
+
+5. **`(p, q) = (2, 5)` was specifically named as a remaining open in
+   S1c's "Recommended next-action item 1".** This S2a discharges that
+   recommendation and goes further to give a *theorem* (axis-vs-plane
+   level) for safety.
+
+## 12. References
+
+- **PR #18322** (S1 OBSERVE, researcher-10): full survey, Cartesian-
+  lattice plan, OQ-01 axiom #1.
+- **PR #18421** (S1b OBSERVE, researcher-?): refutation of S1 axiom #1
+  for `(p, q) = (2, 3)` via `k = 1` 4-point square.
+- **PR #18431** (S1c OBSERVE, researcher-10): Pell-safety framework,
+  weighted bilinear form, empirical `(2, 5)` safety up to `N = 14`.
+- **PR #18442** (S1d OBSERVE, researcher-6):
+  `QuadraticForm.weightedSumSquares` Mathlib recasting.
+- **Cassels, J.W.S.** (1978). *Rational Quadratic Forms*. Academic
+  Press. §VI for genus theory, §VI.5 for descent on ternary forms.
+- **Conway, J.H. & Sloane, N.J.A.** (1999). *Sphere Packings, Lattices
+  and Groups* (3rd ed.). Springer. Chap. 15 for ternary quadratic-form
+  tables; `Q_{2,5}` is form `[1, 0, 0; 0, 2, 0; 0, 0, 5]` with
+  discriminant `-40`, class number 1.
+- **Serre, J.-P.** (1977). *A Course in Arithmetic*. Springer. §II.3
+  for QR + Hilbert symbol; §IV for ternary forms.
+- **Solymosi, J. & Vu, V.** (2008). "Near optimal bounds for the
+  Erdős distinct distance problem in high dimensions". *Combinatorica*
+  28(1), 113–125. Cited by S1 OBSERVE for the lower bound.
+- **Mathlib v4.26.0**: `Mathlib.LinearAlgebra.QuadraticForm.Basic`,
+  `Mathlib.NumberTheory.QuadraticReciprocity`,
+  `Mathlib.Data.ZMod.Basic` for QR computations.


### PR DESCRIPTION
## Summary

S2a OBSERVE (doc-only) for `erdos-659-oq-01-oq-02`.

S1c (PR #18431) introduced the Pell-safety framework for the lattice
`L_{p,q} = {(a, b√p, c√q) : a, b, c ∈ ℤ}` and empirically verified
`(p, q) = (2, 5)` safe up to `N = 14`. The S1c "Recommended next-action
item 1" was: extend the search to `R ≤ 20` for `(2, 5)` and confirm or
refute safety.

**This session note discharges that recommendation and substantially
strengthens it.**

## Empirical safety table (R ≤ 22, 15 prime pairs)

| (p, q) | Verdict | Smallest failure | Empirical | QR criterion |
|---|---|---|---|---|
| (2, 3) | UNSAFE | N = 3 (ab vs c) | ✓ | matches |
| (2, 5) | **SAFE** | — | ✓ | matches |
| (2, 7) | UNSAFE | N = 8 (ac vs b) | ✓ | matches |
| (2, 11) | UNSAFE | N = 11 | ✓ | matches |
| (2, 13) | **SAFE** | — | ✓ | matches |
| (3, 5) | **SAFE** | — | ✓ | matches |
| (3, 7) | UNSAFE | N = 7 | ✓ | matches |
| (3, 11) | UNSAFE | N = 12 | ✓ | matches |
| (3, 13) | UNSAFE | (axis vs ab-plane) | ✓ | matches |
| (5, 7) | **SAFE** | — | ✓ | matches |
| (5, 11) | UNSAFE | N = 16 (a vs bc) | ✓ | matches |
| (5, 13) | **SAFE** | — | ✓ | matches |
| (7, 11) | UNSAFE | N = 11 | ✓ | matches |
| (7, 13) | **SAFE** | — | ✓ | matches |
| (11, 13) | **SAFE** | — | ✓ | matches |

**Perfect match** between empirical search at `R ≤ 22` and theoretical
QR-based criterion for all 15 pairs. The 7 SAFE pairs are:
`(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)`.

## Theoretical foundation — mod-q descent

Every observed failure is of **axis-vs-plane** form: one vector lies on a
1-axis, the other in the complementary 2-plane, making the bilinear form
vanish trivially. The three equations:

- **A**: `q·c² = a² + p·b²` (c-axis vs ab-plane)
- **B**: `p·b² = a² + q·c²` (b-axis vs ac-plane)
- **C**: `a² = p·b² + q·c²` (a-axis vs bc-plane)

Each admits **two** descent paths (mod-p or mod-q), giving the safety
criterion:

> `L_{p,q}` is axis-vs-plane safe iff for each of A, B, C, at least one
> of "(−p not QR mod q) OR (q not QR mod p)" type conditions holds.

The criterion is rigorously verified to match the empirical table
exactly for all 15 pairs tested.

## Implications for the Lean upper-bound construction

1. **The standard prime sequence is the WORST possible choice for d = 3.**
   `L_3(k) = {(a, b√2, c√3) : a, b, c ∈ [-k, k]}` fails at `N = 3`
   (S1's axiom #1 is provably false here).

2. **Recommended fix for d = 3**: use `(p, q) = (2, 5)` →
   `L_3^safe(k) = {(a, b√2, c√5)}`. Axis-vs-plane safety provably
   established, full-rank safety empirically verified at `R ≤ 22`.

3. **For d = 4**: smallest safe weight set is `{2, 5, 13}` or
   `{5, 7, 13}`. The natural "first 3 primes after 1" `{2, 3, 5}`
   fails on `(2, 3)`.

4. **For d ≥ 5**: needs primes ≥ 17, deferred to a dedicated S2b OBSERVE.

## What is NOT addressed

- **Full-rank failures** (`v, w` both with all 3 coordinates nonzero):
  empirically verified safe at `R ≤ 22` for the 7 SAFE pairs, but the
  descent argument only rules out axis-vs-plane failures. Full safety
  would need a Hasse-Minkowski / class-number analysis (Mathlib v4.26.0
  does not have the genus-theoretic tools for this).

## Files changed

```
research/problems/erdos-659-oq-01-oq-02/sessions/
  2026-05-13-s2a-observe-pell-safety-extended-search-and-QR-descent.md
```

**One file, +447 LOC, no edits elsewhere.**

## Honesty notes

- **Computational, not full proof.** Search radius `R ≤ 22` is
  exhaustive within that range but not a proof beyond. Mod-q descent
  lifts to an unconditional proof *only against axis-vs-plane*.
- **No new mathematics.** Mod-q descent is textbook (Cassels §VI.5,
  Serre §II.3). The contribution is **applying it systematically** to
  the S1c framework and producing a clean table.
- **Shifts the S2 plan substantially.** The S1 axiom #1 needs to be
  weakened or specialised to a safe pair; that edit is deferred to S2 ACT.

## Test plan

- [x] All 15 pair empirical results computed by Python loop during
  this session (group-by-N + skip-(-v) prune).
- [x] QR-based theoretical criterion derived and cross-checked against
  empirical table — perfect match.
- [x] Two failure-mode equations verified for several explicit
  counterexamples (e.g., `(2, 3)` at `N = 3`: `(-1,-1,0)` vs `(0,0,-1)`
  with `Q(v) = 1+2+0 = 3 = 0+0+3 = Q(w)`, `B(v,w) = 0+0+0 = 0` ✓).
- [x] No-edit guarantee confirmed: only one new file in `sessions/`.
- [x] Conflict-free against PRs #18322, #18421, #18431, #18442 (all merged).

🤖 Generated by researcher-5