### PR TITLE
Enrich ehrhart-cube-proven-oq-03: preamble + imports sections (q 96→100)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
@@ -33,6 +33,20 @@
   },
   "sections": [
     {
+      "id": "section-0-preamble",
+      "title": "Preamble — File header and S1 OBSERVE summary",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module-level docstring stating the S1 OBSERVE goal (axiom-free hypersimplex Ehrhart count), enumerating the three deliverables (the `hypersimplexLatticeCount` definition; the two `sorry`'d reference identities `hypersimplex_count_k_one` and `hypersimplex_palindrome_k_d_minus_1`; three `decide`-closed sanity checks), and locating the file within the four-sibling `ehrhart-cube-proven` family (cube / standard simplex OQ-01 / cross-polytope OQ-02 / Eulerian h*-vector OQ-04). The header declares Status: S1 SCAFFOLD with `Sorries: 2`, which the meta.json `sorries: 2` count mirrors verbatim."
+    },
+    {
+      "id": "section-0b-imports-setup",
+      "title": "Imports and namespace setup",
+      "startLine": 30,
+      "endLine": 35,
+      "summary": "`import Mathlib` brings in the full library (required for `Finset.filter`, `Fin (n+1)`, `Sym.card_sym_eq_choose`, and the decidability transfer used by `coordSumEq`'s instance). Two `set_option linter.unusedSimpArgs false` / `linter.unusedTactic false` directives silence the unused-tactic linter that fires on scaffolded `sorry` bodies. Opens `namespace EhrhartCubeProvenOQ03` to localise the four new identifiers (`coordSumEq`, `hypersimplexLatticeCount`, and the two theorem names) so siblings in the family can use the unqualified names without collision."
+    },
+    {
       "id": "section-1-definition",
       "title": "Section I — Hypersimplex Lattice-Point Definition",
       "startLine": 36,


### PR DESCRIPTION
## Summary

Final pass on `ehrhart-cube-proven-oq-03`, the only remaining sub-100-quality entry in the gallery: add the two missing prefix sections that cover the Lean file's docstring header and imports.

## Changes

- **`section-0-preamble`** (lines 1-29): documents the S1 OBSERVE goal, the three deliverables (definition / `sorry`'d reference identities / `decide` sanity checks), the four-sibling `ehrhart-cube-proven` family, and the `Sorries: 2` status that the meta.json `sorries: 2` count mirrors.
- **`section-0b-imports-setup`** (lines 30-35): documents `import Mathlib`, the two `linter.unusedSimpArgs` / `linter.unusedTactic` set_options that silence scaffold-`sorry` warnings, and the `namespace EhrhartCubeProvenOQ03` open.

## Coverage

TOC now covers the full 119-line file: `[1-29] + [30-35] + [36-62] + [64-92] + [93-119]`. Section count 3→5 → `sections` quality factor 6→10 → overall quality 96→100.

## Verification

- `find-targets --json` post-edit confirms `quality: 100, priority: 0` with all 8 sub-factors at max.
- `pnpm build` in the worktree fails on the well-known better-sqlite3 native-module install loop (unrelated to JSON). Both `meta.json` and `annotations.json` parse via `JSON.parse` and are read successfully by `find-targets`; sections are in ascending-start order and cover the full 119-line file with no gaps.

## No content rewrites

- Existing 3 sections, all 7 keyInsights, the 4 crossReferences, the historicalContext narrative, and the conclusion are preserved verbatim.
- Lean source untouched.