### PR TITLE
fix(meta): sync minpoly-charpoly-oq-03-oq-01 sorry count 3→2

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -22,10 +22,10 @@
       "research"
     ],
     "badge": "research",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 187,
-    "assumptions": "0 axioms; 3 sorries — `xModule_isTorsionBy_charpoly` (Cayley-Hamilton transported across the standard-basis algebra equivalence), `xModule_isTorsion` (follows from IsTorsionBy + charpoly_monic ≠ 0), and `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
+    "assumptions": "0 axioms; 2 sorries — `xModule_isTorsion` (follows from IsTorsionBy + charpoly_monic ≠ 0) and `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). `xModule_isTorsionBy_charpoly` is now fully discharged (via #18507) using `charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`. The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "theoremCount": 3,
@@ -171,7 +171,7 @@
     "theoremCount": 3,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -207,7 +207,7 @@
       "name": "xModule_isTorsionBy_charpoly",
       "type": "supporting",
       "statement": "∀ (M : Matrix n n F), Module.IsTorsionBy F[X] (xModule M) M.charpoly",
-      "description": "Cayley-Hamilton restated on the F[X]-module synonym: charpoly M annihilates every element of xModule M. Sorry-guarded in this scaffold; deferred proof routes through Matrix.aeval_self_charpoly + the standard-basis algebra equivalence.",
+      "description": "Cayley-Hamilton restated on the F[X]-module synonym: charpoly M annihilates every element of xModule M. Fully discharged (via #18507) using charpoly_mulVecLin + LinearMap.aeval_self_charpoly + Module.AEval.of_symm_smul.",
       "significance": "Cayley-Hamilton contribution to the torsion proof; converts a matrix-level identity into a module-level annihilation."
     },
     {
@@ -225,7 +225,7 @@
       "significance": "API bridge between this sub-OQ and the parent's rational_canonical_form_exists."
     }
   ],
-  "sorries": 3,
+  "sorries": 2,
   "references": {
     "papers": [
       "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2 — K^n as an F[X]-module via M.",


### PR DESCRIPTION
## Fix

Sync `minpoly-charpoly-oq-03-oq-01` meta drift: `sorries` 3 → 2.

## Evidence

**Auditor finding** (`scripts/auditor/find-targets.ts --issues`):
```
minpoly-charpoly-oq-03-oq-01 (1x, last 2026-05-12) [formalized/research] ❌ sorry mismatch: claims 3, actual 2
```

**Before**: `meta.sorries = 3`, `leanFile.sorries = 3`, top-level `sorries = 3`.
**After**: all three = 2.

**Cause**: PR #18507 discharged `xModule_isTorsionBy_charpoly` (Cayley–Hamilton via `charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`), removing one of the three S1 scaffold sorries. `proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean` now has 2 sorries (`xModule_isTorsion`, `xModule_has_invariantFactorChain`) — confirmed via `grep -nE "^\s+sorry\s*$"` (lines 173, 196).

**Collateral updates** (one-shot, scoped to this drift):
- `meta.assumptions` rewritten: drop `xModule_isTorsionBy_charpoly` from the sorry enumeration; note discharge via #18507.
- `mainTheorems[xModule_isTorsionBy_charpoly].description` changed from "Sorry-guarded in this scaffold; deferred proof routes through Matrix.aeval_self_charpoly…" to a one-line discharge note.

No Lean source changes; meta-only.

---
Automated fix by lean-mechanic agent.