### PR TITLE
fix(meta): sync drift minpoly-charpoly-oq-03-oq-01 (sorries 3→2, lineCount 187→198)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15163,9 +15163,9 @@
       "issues": []
     },
     "minpoly-charpoly-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-12T10:41:05Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-05-13T03:15:00Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "russell-1-plus-1-oq-04": {

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -22,10 +22,10 @@
       "research"
     ],
     "badge": "research",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 187,
-    "assumptions": "0 axioms; 3 sorries — `xModule_isTorsionBy_charpoly` (Cayley-Hamilton transported across the standard-basis algebra equivalence), `xModule_isTorsion` (follows from IsTorsionBy + charpoly_monic ≠ 0), and `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
+    "lineCount": 198,
+    "assumptions": "0 axioms; 2 sorries — `xModule_isTorsion` (follows from IsTorsionBy + charpoly_monic ≠ 0) and `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). `xModule_isTorsionBy_charpoly` was discharged in S8 ACT (PR #18507) via `charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`. The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "theoremCount": 3,
@@ -166,12 +166,12 @@
       "Module"
     ],
     "namespace": "MinpolyCharpolyOQ03OQ01",
-    "lineCount": 187,
+    "lineCount": 198,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -225,7 +225,7 @@
       "significance": "API bridge between this sub-OQ and the parent's rational_canonical_form_exists."
     }
   ],
-  "sorries": 3,
+  "sorries": 2,
   "references": {
     "papers": [
       "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2 — K^n as an F[X]-module via M.",


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json` to actual Lean
source after PR #18507 (S8 ACT) discharged `xModule_isTorsionBy_charpoly`.

## Evidence

**Auditor flag** (`npx tsx scripts/auditor/find-targets.ts --issues`, pre-fix):
```
minpoly-charpoly-oq-03-oq-01 (1x, last 2026-05-12) [formalized/research]
  ❌ sorry mismatch: claims 3, actual 2
```

**Before** (meta.json): `sorries: 3`, `lineCount: 187`, `assumptions` listed three sorries (`xModule_isTorsionBy_charpoly`, `xModule_isTorsion`, `xModule_has_invariantFactorChain`).

**After** (matches `proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean`):
- `sorries: 2` — file has sorries at lines 173 (`xModule_isTorsion`) and 196 (`xModule_has_invariantFactorChain`); `xModule_isTorsionBy_charpoly` now has a real proof (lines 155–161).
- `lineCount: 198` — actual `wc -l` of the Lean file.
- `assumptions` field rewritten: drop `xModule_isTorsionBy_charpoly` from sorry list; note PR #18507 discharge with proof recipe (`charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`).
- `leanFile` mirrors + top-level `sorries` field synced to `2` / `198`.
- `audit-tracker.json`: `auditCount` 1→2, `lastAudited` bumped, `result` clean→`issues-fixed`.

**Validation** (post-fix):
```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

Both JSON files revalidate cleanly (`python3 -c "import json; json.load(open('…'))"`).

---
Automated fix by lean-mechanic agent.