### PR TITLE
gallery(sqrt2-plus-sqrt3-plus-sqrt5-irrational): S3 GALLERY — meta + annotations + index.ts (verified)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "ann-sqrt235-setup",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "Setting: Two-Squaring Strategy and Parent-Identity Reuse",
+    "content": "The module docstring sketches the proof at a high level. Let α = √2+√3+√5. We aim to show α is irrational by deriving a contradiction from α ∈ ℚ — specifically, that √30 ∈ ℚ, which fails by Mathlib's irrational_sqrt_natCast_iff applied to ¬IsSquare 30 (discharged via native_decide). The strategy isolates √30 via two squarings: the first reuses the parent gallery proof's exported (√2+√3)² = 5 + 2√6 identity (no need to re-prove it), the second collapses the cross term via the bridge √5·√6 = √30. The file imports Mathlib's irrationality and sqrt API and the parent proof Proofs.Sqrt2PlusSqrt3Irrational as a black-box dependency.",
+    "mathContext": "For squarefree positive integers $a, b, c$ with distinct prime factor sets, the linear combination $\\sqrt{a}+\\sqrt{b}+\\sqrt{c}$ is irrational over $\\mathbb{Q}$ (a unit case of Besicovitch 1940). The elementary route uses iterated squaring: $\\alpha = \\sqrt{a}+\\sqrt{b}+\\sqrt{c}$ satisfies a degree-4 algebraic relation over $\\mathbb{Q}[\\sqrt{ac}]$ (or any squarefree double-product), and one more squaring eliminates the residual surd. For $(a,b,c)=(2,3,5)$ the residual surd is $\\sqrt{30}$ after the second squaring.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sqrt",
+      "Irrational",
+      "irrational_sqrt_natCast_iff",
+      "sqrt2_plus_sqrt3_sq (parent identity)"
+    ],
+    "prerequisites": [
+      "real-valued square roots",
+      "irrationality of √n for non-square n",
+      "composing previously verified gallery proofs"
+    ]
+  },
+  {
+    "id": "ann-sqrt235-irrational-sqrt-thirty",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 53,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Auxiliary Lemma: √30 is Irrational",
+    "content": "irrational_sqrt_thirty discharges the irrationality of √30 in one line: native_decide computes that 30 is not a perfect square (¬IsSquare (30 : ℕ)), and irrational_sqrt_natCast_iff.mpr concludes Irrational (sqrt 30). native_decide reduces the proposition ¬∃ k : ℕ, k * k = 30 to a Lean kernel-evaluable decidable instance, which finishes in microseconds. The IsSquare instance comes from Mathlib's decidable_isSquare. This pattern — irrationality of √n via discharge of ¬IsSquare n — is the standard Mathlib idiom for elementary irrationality results.",
+    "mathContext": "$\\sqrt{n} \\notin \\mathbb{Q}$ if and only if $n$ is not a perfect square (when $n \\in \\mathbb{N}$). The forward direction is classical: if $\\sqrt{n} = p/q$ in lowest terms then $n q^2 = p^2$, and a prime power count modulo 2 forces $n$ to be a square. Mathlib formalises this as `irrational_sqrt_natCast_iff`. For $n = 30 = 2 \\cdot 3 \\cdot 5$, the prime factorisation has three odd-multiplicity primes, so 30 is squarefree (and a fortiori not a perfect square).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Irrational",
+      "irrational_sqrt_natCast_iff",
+      "IsSquare",
+      "native_decide"
+    ],
+    "prerequisites": [
+      "Mathlib's irrational_sqrt_natCast_iff",
+      "decidable arithmetic of IsSquare"
+    ]
+  },
+  {
+    "id": "ann-sqrt235-alpha-pos",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 58,
+      "endLine": 64
+    },
+    "type": "concept",
+    "title": "Positivity: 0 < α = √2 + √3 + √5",
+    "content": "alpha_pos establishes 0 < √2 + √3 + √5 by combining two non-negativity facts (sqrt_nonneg for √2 and √3) with one strict positivity (sqrt_pos.mpr applied to 0 < 5), then closing with linarith. The positivity is non-trivial machinery in the main theorem: it lets us deduce α ≠ 0, hence 8·α ≠ 0, which is exactly the hypothesis of `eq_div_iff` used to invert the quartic identity and exhibit a rational expression for √30. Without alpha_pos we could not divide.",
+    "mathContext": "$\\sqrt{2} + \\sqrt{3} + \\sqrt{5} > 0$ is trivial real-analysis (sum of non-negative reals with at least one positive). Within Lean 4's Mathlib, sqrt_nonneg : 0 ≤ Real.sqrt x is unconditional (Real.sqrt returns 0 for negative inputs), while sqrt_pos.mpr requires the strict hypothesis 0 < x.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sqrt_nonneg",
+      "Real.sqrt_pos",
+      "linarith"
+    ],
+    "prerequisites": [
+      "non-negativity of √x",
+      "strict positivity of √x for x > 0"
+    ]
+  },
+  {
+    "id": "ann-sqrt235-cross-bridge",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 66,
+      "endLine": 69
+    },
+    "type": "technique",
+    "title": "Cross-Radical Bridge: √5 · √6 = √30",
+    "content": "The private theorem sqrt5_mul_sqrt6 is the structural keystone of the second squaring. Real.sqrt_mul requires a non-negativity hypothesis (here 0 ≤ 5, discharged by norm_num); the rewrite ← Real.sqrt_mul then transforms sqrt 5 * sqrt 6 to sqrt (5 * 6), and norm_num evaluates 5 * 6 = 30 to finish. This bridge is what makes 2·√5 · 2·√6 collapse to 8·√30 in the alpha_quartic_identity proof — without it, the second squaring would leave a residual product of two distinct surds rather than a single √30, and the proof would not close.",
+    "mathContext": "For non-negative reals $a, b$: $\\sqrt{a} \\cdot \\sqrt{b} = \\sqrt{ab}$. This identity, while elementary, is sensitive to sign: it fails for negative reals (e.g. $\\sqrt{-1} \\cdot \\sqrt{-1} = -1 \\neq \\sqrt{1} = 1$ in the principal-branch convention). Mathlib's Real.sqrt is non-negative on non-negative inputs and zero on negatives, so the identity holds unconditionally when at least one factor is non-negative.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sqrt_mul",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "multiplicativity of √ on non-negative reals"
+    ]
+  },
+  {
+    "id": "ann-sqrt235-quartic-identity",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 71,
+      "endLine": 113
+    },
+    "type": "concept",
+    "title": "Key Algebraic Identity: α⁴ − 20·α² − 24 = 8·α·√30",
+    "content": "The substantive algebraic content of the proof, ~25 lines. Step 1 (lines 86-98): from the parent identity (√2+√3)² = 5 + 2√6 and (α − √5) = √2 + √3, expand (α − √5)² = α² − 2α√5 + (√5)² and apply Real.sq_sqrt to substitute (√5)² → 5. Rearrange via linarith to α² = 2α√5 + 2√6. Step 2 (lines 99-112): square the rearranged identity. The expansion (2α√5 + 2√6)² = 4α²·(√5)² + 8α·(√5·√6) + 4·(√6)² is established by ring, then three rewrites collapse the squared radicals and cross product: (√5)² → 5, (√6)² → 6 (both via sq_sqrt), and √5·√6 → √30 (via the private cross-radical bridge). Final assembly: (α²)² = α⁴ (by ring) and linarith chains the pieces. The two-substitution + linarith chain — established by the S2 PREP iteration (merged PR #18353) — was necessary because nlinarith cannot reason about cross-radical products like √5·√6 versus √30 directly.",
+    "mathContext": "The algebraic identity $\\alpha^4 - 20\\alpha^2 - 24 = 8\\alpha\\sqrt{30}$ for $\\alpha = \\sqrt{2}+\\sqrt{3}+\\sqrt{5}$ is the analogue of $\\alpha^2 - 5 = 2\\sqrt{6}$ from the parent ($\\alpha = \\sqrt{2}+\\sqrt{3}$). Each added summand doubles the polynomial degree relating $\\alpha$ to the residual surd: $\\sqrt{2}$ alone is its own minimal polynomial (degree 2), $\\sqrt{2}+\\sqrt{3}$ satisfies a degree-2 equation over $\\mathbb{Q}[\\sqrt{6}]$, and $\\sqrt{2}+\\sqrt{3}+\\sqrt{5}$ satisfies a degree-4 equation over $\\mathbb{Q}[\\sqrt{30}]$. The minimal polynomial of $\\alpha$ over $\\mathbb{Q}$ itself has degree 8 (the product over all sign choices $\\epsilon \\in \\{\\pm 1\\}^3$ of $(X - \\epsilon_1\\sqrt{2} - \\epsilon_2\\sqrt{3} - \\epsilon_3\\sqrt{5})$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "Real.sqrt_mul",
+      "linarith",
+      "ring",
+      "sqrt2_plus_sqrt3_sq (parent identity)"
+    ],
+    "prerequisites": [
+      "polynomial expansion of (a + b)²",
+      "(√x)² = x for x ≥ 0",
+      "linear arithmetic over the reals"
+    ]
+  },
+  {
+    "id": "ann-sqrt235-main",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+    "range": {
+      "startLine": 115,
+      "endLine": 142
+    },
+    "type": "concept",
+    "title": "Main Theorem: √2 + √3 + √5 is Irrational",
+    "content": "irrational_sqrt2_plus_sqrt3_plus_sqrt5 closes the slug. We unpack the assumed equality (r : ℝ) = √2 + √3 + √5 with intro ⟨r, hr⟩, derive positivity α > 0 from alpha_pos, then hαne : √2+√3+√5 ≠ 0 by ne_of_gt and h8r_ne : 8·(r:ℝ) ≠ 0 by mul_ne_zero. Substituting r for α in the quartic identity and applying eq_div_iff h8r_ne gives sqrt 30 = ((r:ℝ)⁴ − 20(r:ℝ)² − 24) / (8(r:ℝ)). We then exhibit the rational witness (r⁴ − 20r² − 24)/(8r) and apply irrational_sqrt_thirty to the rational-witness construction, contradicting our assumption. push_cast reconciles the ℚ → ℝ coercion for the final exact step.",
+    "mathContext": "The contradiction works because every step except $\\sqrt{30} \\in \\mathbb{Q}$ is a known fact: $\\alpha > 0$ (positivity), $r \\neq 0$ (consequence), the quartic identity (alpha_quartic_identity), and the algebraic manipulation (division). Only the conclusion $\\sqrt{30} \\in \\mathbb{Q}$ is wrong, which fails by irrational_sqrt_thirty. This isolates the entire contradiction in a single inequality: $\\sqrt{30}$ is not rational.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Irrational",
+      "eq_div_iff",
+      "mul_ne_zero",
+      "push_cast",
+      "alpha_quartic_identity",
+      "irrational_sqrt_thirty"
+    ],
+    "prerequisites": [
+      "field axioms for ℝ and ℚ",
+      "coercion ℚ → ℝ",
+      "destructuring Irrational hypotheses"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/index.ts
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalData: ProofData = { proof: sqrt2PlusSqrt3PlusSqrt5IrrationalProof, annotations: sqrt2PlusSqrt3PlusSqrt5IrrationalAnnotations, tacticStates: [] }

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+  "title": "Irrationality of √2 + √3 + √5",
+  "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+  "description": "Proves that √2 + √3 + √5 is irrational by isolating √30 via two squarings. Letting α = √2+√3+√5: reuse the parent identity (√2+√3)² = 5+2√6 to get α² = 2α√5 + 2√6, then square again to derive α⁴ − 20α² − 24 = 8α·√30. Dividing by 8α (positive) gives √30 ∈ ℚ if α ∈ ℚ, contradicting irrationality of √30 (proved via Mathlib's irrational_sqrt_natCast_iff + native_decide on ¬IsSquare 30). 4 public theorems + 1 private cross-radical bridge (√5·√6 = √30), 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-05-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean",
+    "tags": [
+      "irrationality",
+      "real-analysis",
+      "square-roots",
+      "number-theory",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-05-12",
+    "axiomCount": 0,
+    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff with native_decide on ¬IsSquare 30, Real.sq_sqrt, Real.sqrt_mul, sqrt_pos, sqrt_nonneg, plus the parent gallery proof's exported identity sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6.",
+    "lineCount": 144,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "irrational_sqrt2_plus_sqrt3_plus_sqrt5: √2 + √3 + √5 is irrational, proved via the isolate-√30-by-squaring-twice strategy (∼25-line proof body, parent-identity reuse + Real.sq_sqrt × 2)",
+      "alpha_quartic_identity: (√2+√3+√5)⁴ − 20·(√2+√3+√5)² − 24 = 8·(√2+√3+√5)·√30 — the key algebraic identity, proved by step-by-step substitution with linarith chains avoiding nlinarith on cross-radical products",
+      "sqrt5_mul_sqrt6: √5·√6 = √30 — private cross-radical bridge via ← Real.sqrt_mul + norm_num",
+      "alpha_pos: 0 < √2 + √3 + √5 — positivity established by sqrt_nonneg × 2 + sqrt_pos.mpr, needed to divide by 8α in the main theorem",
+      "irrational_sqrt_thirty: √30 is irrational — one-liner via irrational_sqrt_natCast_iff.mpr + native_decide on ¬IsSquare 30"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The irrationality of $\\sqrt{2}+\\sqrt{3}+\\sqrt{5}$ is the natural three-summand generalisation of the classical $\\sqrt{2}+\\sqrt{3} \\notin \\mathbb{Q}$ result (parent gallery entry). For two summands, one squaring reduces the problem to irrationality of $\\sqrt{6}$. For three squarefree summands, two squarings reduce it to irrationality of $\\sqrt{30}$. The general statement that $\\{\\sqrt{a_1}, \\ldots, \\sqrt{a_n}\\}$ are linearly independent over $\\mathbb{Q}$ when the $a_i$ are distinct squarefree positive integers was established by Besicovitch (1940) via a structured induction; this gallery entry handles the unit case n=3, $\\{a_1,a_2,a_3\\} = \\{2,3,5\\}$, with explicit elementary algebra rather than the general induction. The proof composes the parent gallery proof as a black box (re-using its exported `sqrt2_plus_sqrt3_sq` identity verbatim), demonstrating compositional theorem reuse across the gallery.",
+    "problemStatement": "Prove that $\\sqrt{2} + \\sqrt{3} + \\sqrt{5} \\notin \\mathbb{Q}$ (the third open question of the parent `sqrt2-plus-sqrt3-irrational` gallery proof, listed as OQ-01).",
+    "text": "Set $\\alpha := \\sqrt{2}+\\sqrt{3}+\\sqrt{5}$. The proof shows $\\sqrt{30} \\in \\mathbb{Q}$ whenever $\\alpha \\in \\mathbb{Q}$, which contradicts the irrationality of $\\sqrt{30}$ (a one-line consequence of Mathlib's `irrational_sqrt_natCast_iff` + `native_decide` on $\\neg\\mathrm{IsSquare}\\, 30$). Step 1 subtracts $\\sqrt{5}$ and squares: $(\\alpha - \\sqrt{5})^2 = (\\sqrt{2}+\\sqrt{3})^2 = 5 + 2\\sqrt{6}$ (parent identity), so $\\alpha^2 - 2\\alpha\\sqrt{5} + 5 = 5 + 2\\sqrt{6}$, i.e. $\\alpha^2 = 2\\alpha\\sqrt{5} + 2\\sqrt{6}$. Step 2 squares this: $\\alpha^4 = (2\\alpha\\sqrt{5} + 2\\sqrt{6})^2 = 4\\alpha^2 \\cdot 5 + 8\\alpha\\cdot\\sqrt{5}\\sqrt{6} + 4 \\cdot 6 = 20\\alpha^2 + 8\\alpha\\sqrt{30} + 24$, giving the key quartic identity $\\alpha^4 - 20\\alpha^2 - 24 = 8\\alpha\\sqrt{30}$. Step 3 observes $\\alpha > 0$ and concludes $\\sqrt{30} = (\\alpha^4 - 20\\alpha^2 - 24)/(8\\alpha)$ is rational when $\\alpha$ is, contradiction.",
+    "proofStrategy": "Isolate $\\sqrt{30}$ by squaring twice. The first squaring re-uses the parent gallery proof's exported $\\mathrm{sqrt2\\_plus\\_sqrt3\\_sq}$ identity verbatim. The second squaring expands a binomial whose cross term contains $\\sqrt{5}\\cdot\\sqrt{6} = \\sqrt{30}$. The substantive proof component is `alpha_quartic_identity`, which avoids `nlinarith` (fails on cross-radical products) by establishing a two-step `linarith` chain using `Real.sq_sqrt` and a private cross-radical bridge lemma `sqrt5_mul_sqrt6 : sqrt 5 * sqrt 6 = sqrt 30` (proved by `← Real.sqrt_mul` + `norm_num`). The main theorem then exhibits the explicit rational witness $(r^4 - 20r^2 - 24)/(8r)$ for $\\sqrt{30}$ and contradicts `irrational_sqrt_thirty` via `push_cast`.",
+    "keyInsights": [
+      "Two squarings collapse three nested surds into one. With one squaring, the parent reduces $\\sqrt{2}+\\sqrt{3} \\in \\mathbb{Q}$ to $\\sqrt{6} \\in \\mathbb{Q}$; with two squarings, this proof reduces $\\sqrt{2}+\\sqrt{3}+\\sqrt{5} \\in \\mathbb{Q}$ to $\\sqrt{30} \\in \\mathbb{Q}$. The cross-radical bridge $\\sqrt{5}\\cdot\\sqrt{6} = \\sqrt{30}$ is what makes the second squaring collapse to a single surd.",
+      "Compositional theorem reuse: the proof re-imports the parent's `sqrt2_plus_sqrt3_sq` identity as a black-box lemma, rather than re-proving it. This is a deliberate gallery-architecture choice — the parent proof is the right unit of reuse, not the underlying squaring trick.",
+      "`nlinarith` does not handle cross-radical products (e.g., $\\sqrt{5}\\cdot\\sqrt{6}$ vs $\\sqrt{30}$). The S2 PREP iteration (merged PR #18353) established a two-substitution + `linarith` chain that sidesteps `nlinarith`: first rewrite $\\sqrt{5}^2 \\to 5$ and $\\sqrt{6}^2 \\to 6$, then apply the bridge lemma $\\sqrt{5}\\cdot\\sqrt{6} \\to \\sqrt{30}$ as a separate `rw`. This proof technique transfers to any irrationality result requiring isolated radical manipulation.",
+      "Generalisation horizon — Besicovitch (1940): for distinct squarefree positive integers $a_1, \\ldots, a_n$, the $\\sqrt{a_i}$ are $\\mathbb{Q}$-linearly independent. The case $n=3, \\{a_1,a_2,a_3\\}=\\{2,3,5\\}$ handled here is the unit case for any future Besicovitch formalisation, currently not in Mathlib v4.26.0."
+    ],
+    "prerequisites": [
+      "Real.sq_sqrt : 0 ≤ r → sqrt r ^ 2 = r",
+      "Real.sqrt_mul : 0 ≤ a → sqrt (a * b) = sqrt a * sqrt b",
+      "Real.sqrt_pos / sqrt_nonneg (positivity of square root)",
+      "irrational_sqrt_natCast_iff : Irrational (sqrt n) ↔ ¬ IsSquare n",
+      "Parent gallery proof's exported sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms): irrational_sqrt2_plus_sqrt3_plus_sqrt5 : Irrational (sqrt 2 + sqrt 3 + sqrt 5). The proof composes the parent gallery proof's sqrt2_plus_sqrt3_sq identity with a second squaring step and the cross-radical bridge √5·√6 = √30. Build verified at Mathlib v4.26.0 (PR #18369, 3060 jobs, ~4 min Docker). 4 public theorems + 1 private bridge, 144 lines.",
+    "implications": "Closes OQ-01 of the parent `sqrt2-plus-sqrt3-irrational` gallery entry. Provides the unit-case (n=3) instance for any future formalisation of Besicovitch's general theorem on linear independence of square roots of distinct squarefree positive integers. The two-squaring + cross-radical-bridge technique generalises by induction to n ≥ 4 summands at quadratic blow-up per added summand (n=4 would require three squarings yielding an octic identity).",
+    "openQuestions": [
+      "Generalise to four summands: prove √2 + √3 + √5 + √7 ∉ ℚ via three squarings, yielding an octic identity (degree 8 in α).",
+      "Formalise Besicovitch's (1940) general theorem: for distinct squarefree positive integers a_1,...,a_n the {√a_i} are ℚ-linearly independent. Not in Mathlib v4.26.0; would require structured induction on n.",
+      "Compute the minimal polynomial of √2+√3+√5 over ℚ: expected degree 8, polynomial coefficients via Galois-conjugate product ∏_{ε ∈ {±1}³}(X − ε₁√2 − ε₂√3 − ε₃√5). Generalises the sister entry sqrt2-plus-sqrt3-irrational-oq-03 (which handles the n=2 case with degree 4)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational",
+      "relationship": "extends",
+      "description": "Parent gallery entry: irrationality of √2 + √3 via one squaring reducing to irrationality of √6. This proof extends to three summands via two squarings reducing to irrationality of √30, and composes the parent's exported sqrt2_plus_sqrt3_sq identity as a black-box lemma."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "relationship": "related",
+      "description": "Sister open question on the same parent: minimal polynomial of √2+√3 is X⁴−10X²+1 (degree 4). The corresponding minimal polynomial for √2+√3+√5 has expected degree 8 — a natural follow-up open question (see this entry's openQuestions). Both entries combine parent-identity reuse with explicit polynomial-coefficient analysis."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Two-step ancestor: irrationality of √2 alone (n=1 case). The proof family scales as (n=1 → no squaring → √2 base case; n=2 → one squaring → √6; n=3 → two squarings → √30), each step doubling the polynomial degree relating α to the residual surd."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-strategy",
+      "title": "Strategy: Isolate √30 by Squaring Twice",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring sketches the three-step strategy: (Step 1) subtract √5 then square, re-using the parent identity (√2+√3)² = 5+2√6 to derive α² = 2α√5 + 2√6; (Step 2) square again, using (√5)² = 5, (√6)² = 6, and √5·√6 = √30 to derive α⁴ − 20α² − 24 = 8α·√30; (Step 3) divide by 8α (positive) and conclude √30 ∈ ℚ if α ∈ ℚ, contradiction. Imports Mathlib.Data.Real.Irrational, Mathlib.Data.Real.Sqrt, Mathlib.Tactic, and the parent gallery proof Proofs.Sqrt2PlusSqrt3Irrational."
+    },
+    {
+      "id": "sec-irrational-sqrt-thirty",
+      "title": "Auxiliary: √30 is Irrational",
+      "startLine": 53,
+      "endLine": 56,
+      "summary": "irrational_sqrt_thirty: Irrational (sqrt 30). One-liner via Mathlib's irrational_sqrt_natCast_iff.mpr applied to ¬IsSquare (30 : ℕ), which native_decide discharges in milliseconds. Sets up the final contradiction in the main theorem."
+    },
+    {
+      "id": "sec-alpha-pos",
+      "title": "Positivity: 0 < √2 + √3 + √5",
+      "startLine": 58,
+      "endLine": 64,
+      "summary": "alpha_pos: 0 < sqrt 2 + sqrt 3 + sqrt 5. Establishes positivity by combining two sqrt_nonneg facts (for √2, √3) with sqrt_pos.mpr (for √5) via linarith. Needed in the main theorem so that 8·α ≠ 0 and we can divide both sides of the quartic identity by 8α."
+    },
+    {
+      "id": "sec-cross-radical-bridge",
+      "title": "Cross-Radical Bridge: √5 · √6 = √30",
+      "startLine": 66,
+      "endLine": 69,
+      "summary": "sqrt5_mul_sqrt6 (private): sqrt 5 * sqrt 6 = sqrt 30. The proof rewrites via ← Real.sqrt_mul (using 0 ≤ 5) to obtain sqrt (5 * 6), then norm_num closes 5 * 6 = 30. This private bridge is the keystone of the alpha_quartic_identity proof — it lets the cross term 2·√5 · 2·√6 collapse to 8·√30 in the second squaring."
+    },
+    {
+      "id": "sec-quartic-identity",
+      "title": "Key Identity: α⁴ − 20·α² − 24 = 8·α·√30",
+      "startLine": 71,
+      "endLine": 113,
+      "summary": "alpha_quartic_identity: the algebraic backbone. Step 1 establishes (α − √5)² = 5 + 2√6 via the parent identity sqrt2_plus_sqrt3_sq, then expands (α − √5)² = α² − 2α√5 + 5 (using sq_sqrt for (√5)² = 5) and rearranges to α² = 2α√5 + 2√6. Step 2 squares this and expands the binomial: (2α√5 + 2√6)² = 4α²·5 + 8α·√5·√6 + 4·6 = 20α² + 8α·√30 + 24 (using sq_sqrt twice plus the cross-radical bridge). Linarith closes the final assembly. The two-substitution + linarith chain was locked in by the S2 PREP iteration (merged PR #18353) to sidestep nlinarith failure on cross-radical products."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorem: √2 + √3 + √5 is Irrational",
+      "startLine": 115,
+      "endLine": 142,
+      "summary": "irrational_sqrt2_plus_sqrt3_plus_sqrt5 (main). Assume α = (r : ℝ) for some r : ℚ. By alpha_pos we have α > 0, so r ≠ 0 and 8 · (r : ℝ) ≠ 0. Substituting r for α in the quartic identity and dividing by 8(r:ℝ) gives sqrt 30 = ((r:ℝ)⁴ − 20(r:ℝ)² − 24) / (8(r:ℝ)). The rational witness (r⁴ − 20r² − 24) / (8r) ∈ ℚ then contradicts irrational_sqrt_thirty via push_cast. Closely modelled on the parent's irrational_sqrt2_plus_sqrt3 proof structure."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Ships the gallery integration for the build-verified Lean proof
`Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean`, completing the S3
GALLERY stage of the iteration roadmap. The Lean file already shipped
in main via PR #18369 (S2 ACT, build verified, 0 sorries, 0 axioms).

This is the third open question of the parent gallery proof
`sqrt2-plus-sqrt3-irrational` (OQ-01 in its `openQuestions`):

> Prove √2 + √3 + √5 is irrational.

The strategy isolates √30 by squaring twice: first reuse the parent's
`sqrt2_plus_sqrt3_sq` identity to derive α² = 2α√5 + 2√6, then square
again to get α⁴ − 20α² − 24 = 8α·√30. Since α > 0 and √30 is irrational
(via `irrational_sqrt_natCast_iff` + `native_decide` on ¬IsSquare 30),
no rational α can satisfy this. The crux is a cross-radical bridge
lemma `sqrt5_mul_sqrt6 : √5·√6 = √30` proved via `← Real.sqrt_mul +
norm_num`.

## Files added

- `src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json`
  — status `verified`, badge `original`, 5 theorems, 144 lines,
  0 sorries, 0 axioms. 6 sections matching the 4 public + 1 private
  + 1 docstring breakdown. 3 cross-references (parent, sister
  -oq-03, ancestor sqrt2-irrational).
- `src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/annotations.json`
  — 6 annotations matching the meta sections. Each carries
  mathContext (LaTeX), significance, relatedConcepts, prerequisites
  per the gallery schema.
- `src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/index.ts`
  — standard Vite-glob-discoverable module exporting
  `sqrt2PlusSqrt3PlusSqrt5IrrationalData`.

## Axiom Integrity audit

- 0 `axiom` declarations in `Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean`
  (verified via `grep -c '^axiom ' proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean` = 0).
- 0 assumption-carrying structure fields (the file declares no
  structures; only theorems against existing Mathlib + parent-gallery
  API).
- `axiomCount` set to 0; `assumptions` field documents the Mathlib +
  parent-gallery dependencies (none are assumption-bearing — all are
  proved or definitional).
- Status `verified`, badge `original` per the Axiom Integrity Policy
  status table.

## Race awareness

- `gh pr list --search "sqrt2-plus-sqrt3-plus-sqrt5 in:title"` at push
  time: empty (this is the first gallery-integration PR for the slug).
- No edits to any existing file. Only 3 new files in a new directory.
- `listings.json` is **not** modified here — it is auto-regenerated
  at deploy time by `scripts/annotations/build.ts` from the new
  `meta.json`. (The auto-regen step also picks up the
  `annotationCount = 6` from `annotations.json`.)

## Test plan

- [x] `python3 -c "json.load(open(...))"` succeeds for both JSON files
- [x] `src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/`
      directory has all 3 expected files
- [x] `index.ts` export name follows the kebab-to-camelCase convention
      consumed by `src/data/proofs/index.ts`'s `slugToExportName`
- [x] Lean source path `Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean`
      exists in main with the expected 144 lines, 5 theorems, 0 sorries,
      0 axioms (verified via `git show origin/main:...` + `wc -l` +
      `grep -c '^theorem'`)
- [x] Section line ranges in `meta.json` match the actual theorem
      positions in the Lean source (verified against `Read` output of
      the file at HEAD)
- [x] Cross-reference target IDs (`sqrt2-plus-sqrt3-irrational`,
      `sqrt2-plus-sqrt3-irrational-oq-03`, `sqrt2-irrational`)
      all exist as `src/data/proofs/<slug>/` directories in main

## Why this is a clean PR

1. **Doc-and-JSON only** — no Lean code changes, no build needed,
   no runtime risk.
2. **No edits to existing files** — only new files in a new
   directory. Zero merge-conflict risk with concurrent PRs.
3. **No phase advance in the research JSON** — the
   `src/data/research/problems/sqrt2-plus-sqrt3-irrational-oq-01.json`
   `phase` field stays `ACT`. Updating it (to `GALLERY-DONE` or
   similar) is a separate concern that can be handled by the next
   researcher or by the auditor.
4. **`state.md` left unchanged** — the next researcher can add an
   S3 session note documenting this gallery merge.

## Iteration history

| Stage | Date | PR | Outcome |
|------|------|-----|---------|
| S1 OBSERVE | 2026-05-12 | #18222 | Survey + 4 scaffold files |
| S2 PREP | 2026-05-12 | #18353 | Quartic-identity tactic chain |
| S2 ACT | 2026-05-12 | #18369 | Lean proof + build verified |
| S4 PREP | 2026-05-13 | #18402 | Besicovitch sibling memo (doc-only) |
| **S3 GALLERY** | 2026-05-12 | **this PR** | **Gallery integration (this)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)