### PR TITLE
audit(sqrt2-plus-sqrt3-plus-sqrt5-irrational): clean — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15227,6 +15227,12 @@
       "lastAudited": "2026-05-13T02:15:07Z",
       "result": "clean",
       "issues": []
+    },
+    "sqrt2-plus-sqrt3-plus-sqrt5-irrational": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-13T04:26:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

Gallery integrity audit of `sqrt2-plus-sqrt3-plus-sqrt5-irrational` (PR #18538 GALLERY entry, S2 ACT PR #18369). **Result: clean.** All meta.json claims match the Lean source at `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean`.

## What was checked

| Field | meta.json | Lean source | ✓ |
|---|---|---|---|
| lineCount | 144 | 144 | ✓ |
| theoremCount | 5 | 5 (4 public + 1 private bridge) | ✓ |
| axiomCount | 0 | 0 `^axiom ` declarations | ✓ |
| sorries | 0 | 0 sorry occurrences | ✓ |
| True stubs | — | 0 `:= trivial` / `: True` | ✓ |
| status | `verified` | justified | ✓ |
| badge | `original` | justified (see Tier analysis) | ✓ |

## Tier classification

**Tier A** (Fully formalized theorem) is appropriate. The main theorem `irrational_sqrt2_plus_sqrt3_plus_sqrt5` is established by independent algebraic squaring (`alpha_quartic_identity` → divide-by-8α). Mathlib reliance is confined to:

- the auxiliary sub-lemma `irrational_sqrt_thirty` via `irrational_sqrt_natCast_iff` + `native_decide` on `¬ IsSquare 30` (one-liner, correctly described as auxiliary);
- standard `Real.sq_sqrt` / `Real.sqrt_mul` / `sqrt_pos` / `sqrt_nonneg`.

Both are explicitly disclosed in the `assumptions` field.

The parent import `Proofs.Sqrt2PlusSqrt3Irrational.sqrt2_plus_sqrt3_sq` exists at `Sqrt2PlusSqrt3Irrational.lean:25` and is honestly credited as a black-box re-use (key insight #2 in `keyInsights`).

## Failure modes checked

1. **Delegation opacity** — none. The `assumptions` and `originalContributions` fields make the Mathlib dependency explicit, and `keyInsights` calls out the compositional re-use of the parent.
2. **Axiom masking** — N/A (0 axioms, structure-encoded or otherwise).
3. **Inequality != theorem** — N/A. The result is the existential `Irrational (sqrt 2 + sqrt 3 + sqrt 5)`, fully formalized.
4. **Pipeline inflation** — N/A (single-file proof).
5. **"0 sorries" with hidden imports** — checked. The Mathlib call `irrational_sqrt_natCast_iff` is in an auxiliary lemma, not the main theorem; the algebraic backbone (`alpha_quartic_identity`) is independent.

## Action

Bump `src/data/proofs/audit-tracker.json` to record the clean audit (auditCount: 1, result: `clean`, lastAudited 2026-05-13T04:26:50Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)