### PR TITLE
audit(abel-ruffini): clean — tracker bump after PR #18577 enrichment

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1,9 +1,9 @@
 {
   "entries": {
     "abel-ruffini": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-05-13T07:07:50Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {


### PR DESCRIPTION
## Summary

Re-audit of `abel-ruffini` (Wiedijk #16 — Abel-Ruffini theorem) after PR #18577 (Enrich abel-ruffini: 5 sister cross-refs + degree-5 dichotomy keyInsight) merged 2026-05-13T05:06Z and added 46 lines to `meta.json`. Last audit was 2026-05-03 (10 days ago, auditCount=5).

**Result: clean.** Tracker bumped: `auditCount` 5→6, `lastAudited` 2026-05-03 → 2026-05-13.

## Integrity checks

| Check | Expected | Actual | Status |
|-------|----------|--------|--------|
| Lean lineCount | 187 | 187 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | 0 | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| substantiveTheoremCount | 3 | 3 | ✓ |
| Tier (badge mathlib) | composes Mathlib | imports `Mathlib.FieldTheory.AbelRuffini`, wraps `solvableByRad.isSolvable'` + `Equiv.Perm.not_solvable` | ✓ |

Tier B language is correct: description says "*composed from Mathlib's Galois theory infrastructure*"; conclusion enumerates the three Mathlib wrappers (`galois_bridge`, `symmetric_group_not_solvable`, `not_solvable_by_rad_of_not_solvable_gal`). No delegation opacity / axiom masking / inequality-vs-theorem / pipeline inflation / hidden-import drift.

## Sister cross-ref verification (PR #18577's 5 new entries)

All five `meta.relatedProblems` additions point to existing gallery slugs with matching claim numbers:

| Slug | Claim in cross-ref | Actual `meta` | Status |
|------|-------------------|---------------|--------|
| `inverse-galois-a5` | "single Dedekind-derived axiom (`three_dvd_gal_card`)" | `status: axiomatized`, `axiomCount: 1`, `badge: axiom` | ✓ |
| `inverse-galois-d4` | "27 theorems, 0 sorries, 0 axioms" | `theoremCount: 27`, `sorries: 0`, `axiomCount: 0` | ✓ |
| `inverse-galois-f20` | "27 theorems, 0 sorries, 0 axioms" | `theoremCount: 27`, `sorries: 0`, `axiomCount: 0` | ✓ |
| `sylow-theorem` | "10 theorems, 0 sorries, 0 axioms" | `theoremCount: 10`, `sorries: 0`, `axiomCount: 0` | ✓ |
| `sylow-theorem-oq-01` | "classification of groups of order pq" | `status: verified`, `theoremCount: 21` | ✓ |

## Dichotomy keyInsight (overview.keyInsights[6])

The new "*Degree 5 is Necessary but Not Sufficient — The $X^5 - 2$ vs $x^5 - 4x + 2$ Dichotomy*" insight references three sibling slugs:

- `inverse-galois-f20` ↔ Gal(X⁵−2/ℚ) ≅ F₂₀ (solvable, |Gal|=20) — verified gallery entry
- `abel-ruffini-oq-04-oq-01` ↔ Gal(x⁵−4x+2/ℚ) ≅ S₅ (non-solvable) — verified gallery entry
- `inverse-galois-d4` ↔ Gal(X⁴−2/ℚ) ≅ D₄ (solvable, one degree down) — verified gallery entry

All three exist; group-theoretic claims (derived series, solvability) match standard references.

## Test plan

- [x] No open `audit/abel-ruffini-*` PR (checked `gh pr list --search "abel-ruffini in:title"`)
- [x] Lean source counts verified via direct `wc -l` / `grep` against `proofs/Proofs/AbelRuffini.lean`
- [x] Tracker diff is exactly 2 lines (`auditCount` + `lastAudited`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)