### PR TITLE
audit(erdos-982): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10986,8 +10986,8 @@
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T16:45:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:13:15Z",
       "result": "clean"
     },
     "erdos-983": {


### PR DESCRIPTION
## Summary

Clean re-audit of `erdos-982` (Erdős Problem #982: Distinct Distances from Convex Polygon Vertices).

All gallery integrity checks pass. Tracker `auditCount` 3 → 4, `lastAudited` bumped to 2026-05-13.

## Verification

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 3 | 3 (L197, L210, L331) | ✓ |
| axiomCount | 4 | 4 (`moser_bound`, `nppz_bound`, `regular_polygon_distances`, `stronger_conjecture_is_false`) | ✓ |
| lineCount | 333 | 333 | ✓ |
| True stubs | none claimed | none found | ✓ |
| Mathlib wrapper masking | not claimed | Mathlib used only for `Plane`/`dist`/`Finset` primitives | ✓ |
| status / badge | `axiomatized` / `axiom` | appropriate for open problem with axioms + sorries | ✓ |
| originalContributions | attributes 4 axioms honestly | matches | ✓ |

No issues found; no narrative fixes needed.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` confirms tracker advanced
- [x] Diff limited to `src/data/proofs/audit-tracker.json` (2 lines)