### PR TITLE
research(four-square-distribution-oq-01): S18c-orbit-precursor-3 ACT — permStabilizer_card via Mathlib DomMulAct (build pending)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -1,5 +1,6 @@
 import Proofs.FourSquareDistribution
 import Mathlib.NumberTheory.Divisors
+import Mathlib.GroupTheory.Perm.DomMulAct
 import Mathlib.Tactic
 
 /-
@@ -2772,6 +2773,51 @@ lemma signFlipOrbit_card_ge_two (v : Fin 4 → ℤ) (i₀ : Fin 4) (hi₀ : v i�
     exact ⟨s₁, Finset.mem_univ _, rfl⟩
   exact Finset.one_lt_card.mpr
     ⟨applyFlip s₀ v, hmem0, applyFlip s₁ v, hmem1, hne⟩
+
+/-- **(S18c-orbit-precursor-3, Part 33)** Permutation-stabilizer
+    cardinality formula.
+
+    For any `v : Fin 4 → ℤ`,
+
+      `|Stab_(S₄) v| = ∏ i ∈ image v, (mult i)!`
+
+    where `mult i := |{ j : Fin 4 // v j = i }|` is the number of
+    coordinates of `v` taking the value `i`, and the action is
+    `applyPerm` (Part 30). The stabilizer subtype is
+    `{ σ : Equiv.Perm (Fin 4) // applyPerm σ v = v }`.
+
+    Proof: bridge to Mathlib's `DomMulAct.stabilizer_card'` (which uses
+    the convention `v ∘ g = v`) via the involution `σ ↔ σ.symm` on
+    `Equiv.Perm (Fin 4)`. Locally `applyPerm σ v := v ∘ σ.symm`, so
+    `applyPerm σ v = v ↔ v ∘ σ.symm = v` definitionally, and
+    `σ ↦ σ.symm` is a bijection.
+
+    Combined with Part 31's `signFlipStabilizer_card` (giving
+    `|Stab_(ℤ/2)⁴ v| = 2^(# zero coords v)`), this exhausts the two
+    side stabilizers of the `(ℤ/2)⁴ ⋊ S₄` action. The combined
+    semidirect-product stabilizer (Part 34, follow-up) is genuinely
+    a third lemma — see PREP `s18c-orbit-case-enumeration-prep.md` §2.
+
+    PREP: `s18c-orbit-precursor-perm-stab.md` (PR #18418). -/
+lemma permStabilizer_card (v : Fin 4 → ℤ) :
+    Fintype.card { σ : Equiv.Perm (Fin 4) // applyPerm σ v = v } =
+      ∏ i ∈ Finset.univ.image v, (Fintype.card { j : Fin 4 // v j = i })! := by
+  classical
+  -- Bridge to Mathlib's convention `v ∘ g = v` via the involution
+  -- `σ ↔ σ.symm` on `Equiv.Perm (Fin 4)`. The predicate `applyPerm σ v = v`
+  -- unfolds definitionally to `v ∘ σ.symm = v`.
+  have e :
+      { σ : Equiv.Perm (Fin 4) // applyPerm σ v = v } ≃
+      { g : Equiv.Perm (Fin 4) // v ∘ g = v } :=
+    { toFun := fun s => ⟨s.1.symm, s.2⟩
+      invFun := fun s => ⟨s.1.symm, by
+        show v ∘ s.1.symm.symm = v
+        rw [Equiv.symm_symm]
+        exact s.2⟩
+      left_inv := fun s => Subtype.ext s.1.symm_symm
+      right_inv := fun s => Subtype.ext s.1.symm_symm }
+  rw [Fintype.card_congr e]
+  exact DomMulAct.stabilizer_card' v
 
 /-- **(S18c-orbit, TARGET DECLARATION, deferred)** Every orbit of the
     (ℤ/2)⁴ ⋊ S₄ action on the four-square solution set has cardinality


### PR DESCRIPTION
## Summary

Implements **Part 33** of the (ℤ/2)⁴ ⋊ S₄ orbit-decomposition argument for `8 ∣ r4Count n`, designed by PR [#18418](https://github.com/rjwalters/lean-genius/pull/18418) (PREP, mine — doc-only). Adds the **permutation-side stabilizer cardinality lemma** `permStabilizer_card` inside `namespace S18c`, bridging local `applyPerm σ v := v ∘ σ.symm` to Mathlib's `DomMulAct.stabilizer_card'` (`Mathlib/GroupTheory/Perm/DomMulAct.lean:122`).

## Theorem

For any `v : Fin 4 → ℤ`,
$$|\{ \sigma : S_4 \mid \text{applyPerm}\ \sigma\ v = v \}| = \prod_{i \in \text{image}(v)} (\text{mult}_v(i))!$$

where $\text{mult}_v(i) = |\{ j : \text{Fin}\ 4 \mid v_j = i \}|$.

**Worked examples** (matching the multiplicity-pattern sanity table in PREP §4):

| `v` | image | mults | ∏ (mult)! | brute-force |
|---|---|---|---:|---:|
| `(a, b, c, d)` distinct | 4 | 1,1,1,1 | 1 | 1 |
| `(a, a, b, c)` | 3 | 2,1,1 | 2 | 2 |
| `(a, a, b, b)` | 2 | 2,2 | 4 | 4 |
| `(a, a, a, b)` | 2 | 3,1 | 6 | 6 |
| `(a, a, a, a)` | 1 | 4 | 24 | 24 |

## Proof sketch

The local action convention is `applyPerm σ v := v ∘ σ.symm`. Mathlib's `stabilizer_card'` uses the convention `v ∘ g = v` (no `.symm`). The bridge is the involution $\sigma \mapsto \sigma^{-1}$ on $S_4$:

```lean
have e : { σ // applyPerm σ v = v } ≃ { g // v ∘ g = v } :=
  { toFun := fun s => ⟨s.1.symm, s.2⟩
    invFun := fun s => ⟨s.1.symm, by
      show v ∘ s.1.symm.symm = v; rw [Equiv.symm_symm]; exact s.2⟩
    left_inv := fun s => Subtype.ext s.1.symm_symm
    right_inv := fun s => Subtype.ext s.1.symm_symm }
rw [Fintype.card_congr e]
exact DomMulAct.stabilizer_card' v
```

The `toFun` step uses `applyPerm σ v = v ↔ v ∘ σ.symm = v` (definitional unfold of `applyPerm`); `invFun` adds one `Equiv.symm_symm` rewrite for the reverse direction. Both inverse laws are `σ.symm_symm = σ`.

## Net delta

- `proofs/Proofs/FourSquareDistributionOQ01.lean`: +46 LOC, +1 import (`Mathlib.GroupTheory.Perm.DomMulAct`), +1 lemma (`permStabilizer_card`).
- 0 new axioms; 0 new sorries.

## Significance

Closes the **second of three** stabilizer counts needed for `orbitCard_dvd_eight_of_pos`:

| Lemma | Subgroup | Status |
|---|---|---|
| `signFlipStabilizer_card` (Part 31, #18139) | (ℤ/2)⁴ | ✓ merged |
| `permStabilizer_card` (Part 33, **this PR**) | S₄ | proposed |
| `combinedStabilizer_card` (Part 34, designed in #18549) | (ℤ/2)⁴ ⋊ S₄ | future |

**Subtle**: the combined stabilizer is *not* the product of the two side stabilizers — it counts pairs $(s, \sigma)$ that move equal-$|v_i|$ positions and compensate via sign flips. See PR #18549 §2.5 for an explicit example: $|\text{permStab}((1,-1,2,3))| = 1$ (signed) but $|\text{combinedStab}((1,-1,2,3))| = 2$ (absolute-value).

## Mathlib citation

`DomMulAct.stabilizer_card'` at `Mathlib/GroupTheory/Perm/DomMulAct.lean:122`, rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib v4.26.0). Verified via GitHub Contents API on 2026-05-12 in PREP #18418, re-verified at push time.

## Race awareness

- **Open PRs on slug** at push time: 2 (both build-pending, both stale, both target earlier file regions per PREP #18418 §5):
  - #17701 (S18 general bridge, 27 h stale)
  - #17388 (S11 atomic-axiom decomp, 4 d stale)
- **Recent merges last 4 h**: 1 (#18549 S18c-orbit case enum PREP, doc-only).
- **Insertion line**: ~2798, immediately after Part 32 (`signFlipOrbit_card_ge_two`). Both open PRs add at S11/S18 boundary (far earlier); rebase risk minimal.

## Build status

**Build pending** — per slug precedent: S17, S18, S18a, S18b, S18c-framework, S18c-orbit-precursor, S18c-orbit-precursor-2 all shipped build-pending. Local Docker build is blocked by the `.lake` symlink loop on worktree; auditor pipeline carries the build outcome.

## Test plan

- [x] `git diff --stat origin/main` shows exactly one file modified (`proofs/Proofs/FourSquareDistributionOQ01.lean`)
- [x] +1 import line; +1 lemma; 0 deletions; 0 edits to `state.md` / `meta.json` / `problem.md` / `knowledge.md`
- [x] Lemma signature matches PREP #18418 §1 verbatim
- [x] `permStabilizer_card` placed at line ~2798, between Part 32 and the deferred `orbitCard_dvd_eight_of_pos_target_decl`
- [x] Mathlib `DomMulAct.stabilizer_card'` confirmed at v4.26.0 (`Mathlib/GroupTheory/Perm/DomMulAct.lean:122`)
- [x] No conflict with open PRs #17701 / #17388 (verified file scope; both add at S11/S18 boundary)
- [ ] Docker build (auditor will verify)

## References

- PREP: PR [#18418](https://github.com/rjwalters/lean-genius/pull/18418) — `s18c-orbit-precursor-perm-stab.md` design memo (mine, 2026-05-12).
- Part 31 sibling: PR [#18139](https://github.com/rjwalters/lean-genius/pull/18139) — sign-flip stabilizer (researcher-11).
- Part 32 sibling: PR [#18216](https://github.com/rjwalters/lean-genius/pull/18216) — sign-flip orbit non-triviality (researcher-3).
- Follow-up Part 34/35 design: PR [#18549](https://github.com/rjwalters/lean-genius/pull/18549) — combined stabilizer + 11-case enumeration (researcher-10).
- Mathlib: `DomMulAct.stabilizer_card'` (`Mathlib/GroupTheory/Perm/DomMulAct.lean:122`).
- Spec: `research/problems/four-square-distribution-oq-01/s18-eight-divisibility-spec.md` §3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)