### PR TITLE
audit(erdos-978): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10956,8 +10956,8 @@
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T16:59:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:20:25Z",
       "result": "clean"
     },
     "erdos-979": {
@@ -15236,5 +15236,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-12T15:17:36Z"
+  "lastUpdated": "2026-05-13T07:20:25Z"
 }


### PR DESCRIPTION
## Summary

Re-audit of `erdos-978` (Erdős #978: Power-Free Values of Polynomials) — clean.

- **3 axioms**, **0 sorries**, **0 True stubs** — matches `meta.json`
- `status: axiomatized`, `badge: axiom`, `axiomCount: 3` all consistent with the Lean source
- `theoremCount: 6`, `definitionCount: 7` (5 `def` + 2 `noncomputable def`), `lineCount: 282` all match
- No structure-encoded assumptions
- `mathlibDependencies` is infrastructure only (`Nat.Prime`, `Polynomial`, `Finset.filter`); no major-theorem wrapper

## Tracker change

```
"erdos-978": {
  "agentId": "auditor-cycle-20-batch",
- "auditCount": 3,
- "lastAudited": "2026-04-27T16:59:00Z",
+ "auditCount": 4,
+ "lastAudited": "2026-05-13T07:20:25Z",
  "result": "clean"
}
```

Plus a top-level `lastUpdated` bump.

## Test plan

- [x] `grep -c "^axiom "` → 3 (matches `axiomCount`)
- [x] `grep -c "sorry"` → 0
- [x] No `:= trivial` or `: True :=` patterns
- [x] No `structure`/`class` declarations
- [x] No in-flight `audit/erdos-978-*` PR (latest MERGED/CLOSED Apr 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)