### PR TITLE
research(gauss-wilson-non-cyclic-oq-01): S6 ACT — Phase C iff theorem scaffold modulo 2 strategic sorries (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2302,6 +2302,7 @@ import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GCDAlgorithmOQ01OQ03
 import Proofs.GaussWilsonNonCyclic
+import Proofs.GaussWilsonNonCyclicOQ01
 import Proofs.GaussWilsonNonCyclicOQ01A
 import Proofs.GaussWilsonNonCyclicOQ01B
 import Proofs.GcdAlgorithmOQ02

--- a/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
@@ -1,0 +1,183 @@
+import Proofs.GaussWilsonNonCyclic
+import Proofs.GaussWilsonNonCyclicOQ01A
+import Proofs.GaussWilsonNonCyclicOQ01B
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Tactic
+
+/-!
+# Gauss–Wilson Non-Cyclic OQ-01 — Phase C: Main iff Theorem (scaffold)
+
+This file delivers the **scaffold** of `prod_univ_units_zmod_eq_neg_one_iff_isCyclic`
+for `gauss-wilson-non-cyclic-oq-01`, building on Phase A and Phase B.
+
+**Main theorem.** For `n ≥ 1`,
+
+  ∏ x : (ZMod n)ˣ, x = -1   ↔   IsCyclic (ZMod n)ˣ.
+
+This scaffold ships the **structural case-split** following S5b PREP's
+corrected proof skeleton (3 bugs in S5 PREP's design memo: `interval_cases`
+without upper bound, `all_goals` after `decide`, `absurd h_cyc h_cyc` type
+mismatch). The two implication-direction sub-lemmas
+`prod_eq_neg_one_of_isCyclic_aux` and `prod_eq_one_of_not_isCyclic_aux`
+remain strategic sorries — their discharge is the natural S7/S8 work.
+
+## Phase chain
+
+| Phase | File | Status |
+|---|---|---|
+| A | `GaussWilsonNonCyclicOQ01A.lean` | merged, build-verified (S2 PR #18147) |
+| B (partial) | `GaussWilsonNonCyclicOQ01B.lean` | merged, build-pending (S3 PR #18232), 1 strategic sorry |
+| C (scaffold, THIS FILE) | `GaussWilsonNonCyclicOQ01.lean` | proposed; 2 strategic sorries deferred to S7/S8 |
+
+## Mathlib citations consumed (verified at pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+- `IsCyclic.card_pow_eq_one_le` (`Mathlib/GroupTheory/SpecificGroups/Cyclic.lean:317`)
+- `ZMod.prod_univ_units_id_eq_neg_one`-style: see `Mathlib/NumberTheory/Wilson.lean`
+- `Finset.prod_filter`, `Finset.prod_mul_distrib` (umbrella `Mathlib.Tactic` pull-ins)
+
+## Why scaffold and not full Phase C?
+
+Per S5b PREP §3.3, the cyclic direction admits a 1-line shortcut via
+`prod_univ_units_id_eq_neg_one` only when `n` is **prime** (so `ZMod n` is
+a field). For composite cyclic `n ∈ {4, p^k≥2, 2p^k}`, the manual
+"`G[2] = {1, -1}`" argument via `IsCyclic.card_pow_eq_one_le` is required.
+That argument is ~30-40 LOC and orthogonal to the case-split scaffold
+here. The non-cyclic direction additionally consumes the Phase B
+strategic sorry chain (S4 in flight) so its discharge depends on S4 ACT.
+
+Strategic-sorry isolation gives the next researcher a clearly-stated
+pair of sub-lemmas to close, while shipping the *outer* iff structure
+build-pending. Companion to S3 ACT's strategic-sorry isolation in Phase B.
+
+## Spec
+
+- `problem.md` § "Approach map" sub-problem C: this file's main theorem.
+- S5b PREP `2026-05-13-s5b-prep-design-bugs-and-mathlib-audit.md` (PR #18607)
+  — corrected proof skeleton + Mathlib API erratum.
+-/
+
+namespace GaussWilsonNonCyclicOQ01
+
+open Finset GaussWilsonNonCyclicOQ01
+
+/-- Re-derivation of `GaussWilsonNonCyclic.neg_one_ne_one_units'`, which is
+    `private` in the parent file. For `n ≥ 3`, `(-1 : (ZMod n)ˣ) ≠ 1`. -/
+private lemma neg_one_ne_one_units_of_ge_three {n : ℕ} (hn : n ≥ 3) [NeZero n] :
+    (-1 : (ZMod n)ˣ) ≠ 1 := by
+  intro h
+  have hv := congr_arg (Units.val : (ZMod n)ˣ → ZMod n) h
+  simp only [Units.val_neg, Units.val_one] at hv
+  apply (show (-1 : ZMod n) ≠ 1 by
+    intro heq
+    have h11 : (1 : ZMod n) + 1 = 0 := by
+      have := neg_add_cancel (1 : ZMod n); rwa [heq] at this
+    have h2eq : (2 : ZMod n) = 1 + 1 := by norm_num
+    have hchar : (2 : ZMod n) = 0 := by rw [h2eq]; exact h11
+    have hdvd : n ∣ 2 := (ZMod.natCast_eq_zero_iff 2 n).mp (by exact_mod_cast hchar)
+    exact absurd (Nat.le_of_dvd (by norm_num) hdvd) (by omega))
+  exact hv
+
+/-- **(STRATEGIC SORRY — cyclic direction)** For `n ≥ 3` with
+    `(ZMod n)ˣ` cyclic, the product of units equals `-1`.
+
+    Mathematical content: in a finite cyclic group `G`, the 2-torsion
+    subset `{x : G | x^2 = 1}` has cardinality `≤ 2` (Mathlib's
+    `IsCyclic.card_pow_eq_one_le` at `n := 2`). For `(ZMod n)ˣ` with
+    `n ≥ 3`, both `1` and `-1` lie in the 2-torsion subset and are
+    distinct (`neg_one_ne_one_units_of_ge_three`), forcing exactly
+    `{1, -1}`. Then Phase A reduces `∏ univ` to `∏ {1, -1} = 1 · (-1) = -1`.
+
+    For `n = p` prime, this admits a 1-line shortcut via
+    `prod_univ_units_id_eq_neg_one` (`Mathlib/NumberTheory/Wilson.lean`,
+    via `IsDomain (ZMod p)`). For composite cyclic `n ∈ {4, p^k≥2, 2p^k}`,
+    the manual `G[2] = {1, -1}` argument via `IsCyclic.card_pow_eq_one_le`
+    is required (~30-40 LOC).
+
+    Deferred to S7 ACT. -/
+theorem prod_eq_neg_one_of_isCyclic_aux {n : ℕ} (hn : n ≥ 3) [NeZero n]
+    (_hcyc : IsCyclic (ZMod n)ˣ) :
+    (∏ x : (ZMod n)ˣ, x) = -1 := by
+  sorry
+
+/-- **(STRATEGIC SORRY — non-cyclic direction)** For `n ≥ 3` with
+    `(ZMod n)ˣ` non-cyclic, the product of units equals `1`.
+
+    Mathematical content: by the parent file's
+    `card_sq_eq_one_ge_three`, the 2-torsion subset of `(ZMod n)ˣ` has
+    cardinality `≥ 3`. Since the 2-torsion is a subgroup and elementary
+    2-abelian, its cardinality is a power of 2, so `≥ 4`. Phase A
+    reduces `∏ univ` to `∏ (2-torsion)`. Phase B
+    (`prod_univ_eq_one_of_elementary_card_ge_four`) gives `∏ (2-torsion) = 1`.
+
+    This direction consumes Phase B's strategic sorry chain transitively
+    (`prod_univ_eq_pow_card_div_two_of_elementary`, S4 in flight).
+    Deferred to S8 ACT (after S4 ACT closes the Phase B chain).
+
+    Subtleties for S8 implementer:
+    - The 2-torsion subset is `univ.filter (fun x => x ^ 2 = 1) : Finset (ZMod n)ˣ`.
+    - To apply Phase B, lift the filter to a subgroup `H ≤ (ZMod n)ˣ` and
+      invoke `Phase B.prod_univ_eq_one_of_elementary_card_ge_four` on
+      `H`. This requires either constructing the subgroup explicitly
+      or working in the subtype.
+    - Phase A is stated for `∏ x : G, x` where `G` is a finite commutative
+      group; the bridge is `Finset.prod_subtype_eq_prod_filter` or
+      `Finset.prod_attach`. -/
+theorem prod_eq_one_of_not_isCyclic_aux {n : ℕ} (hn : n ≥ 3) [NeZero n]
+    (_hncyc : ¬IsCyclic (ZMod n)ˣ) :
+    (∏ x : (ZMod n)ˣ, x) = 1 := by
+  sorry
+
+/-- **The main Gauss–Wilson product formula for `(ZMod n)ˣ`.**
+
+    For `n ≥ 1`,
+
+      `∏ x : (ZMod n)ˣ, x = -1 ↔ IsCyclic (ZMod n)ˣ`.
+
+    Proof structure (corrected from S5 PREP per S5b PREP §2):
+
+    1. **Small cases `n ∈ {1, 2}`**: dispatched by `decide`.
+       Both are trivially cyclic, and the product `(ZMod n)ˣ`-side
+       evaluates by computation. `interval_cases` here is sound because
+       both bounds `1 ≤ n < 3` are present (bug 1 fix).
+
+    2. **`n ≥ 3`**: case-split on `IsCyclic (ZMod n)ˣ` via `by_cases`.
+       - **`IsCyclic`** branch: apply `prod_eq_neg_one_of_isCyclic_aux`.
+       - **`¬IsCyclic`** branch: forward direction `prod = -1 ⟹ IsCyclic`
+         is contrapositively-vacuous via
+         `prod_eq_one_of_not_isCyclic_aux` (giving `prod = 1 ≠ -1`).
+         Backward direction `IsCyclic ⟹ prod = -1` is impossible by
+         hypothesis (bug 3 fix: rename `h_cyc` inside the `refine`-binder
+         to avoid shadowing).
+
+    The original S5 PREP design memo (PR #18465 ≈ #18502) contained
+    4 bugs in the proof skeleton flagged by S5b PREP (PR #18607); this
+    file ships the corrected version. -/
+theorem prod_univ_units_zmod_eq_neg_one_iff_isCyclic
+    {n : ℕ} (hn : 1 ≤ n) :
+    (∏ x : (ZMod n)ˣ, x) = -1 ↔ IsCyclic (ZMod n)ˣ := by
+  -- Dispatch small cases `n ∈ {1, 2}` separately, then handle `n ≥ 3` generically.
+  rcases Nat.lt_or_ge n 3 with hlt | hge
+  · -- n ∈ {1, 2}
+    interval_cases n
+    · -- n = 1: (ZMod 1)ˣ is trivial; both sides hold.
+      decide
+    · -- n = 2: (ZMod 2)ˣ has one element (1 = -1); both sides hold.
+      decide
+  · -- n ≥ 3
+    haveI : NeZero n := ⟨by omega⟩
+    by_cases h_cyc : IsCyclic (ZMod n)ˣ
+    · -- Cyclic case: both sides hold (via prod_eq_neg_one_of_isCyclic_aux).
+      refine ⟨fun _ => h_cyc, fun _ => ?_⟩
+      exact prod_eq_neg_one_of_isCyclic_aux hge h_cyc
+    · -- Non-cyclic case: both sides fail.
+      refine ⟨fun h_prod => ?_, fun h_cyc' => absurd h_cyc' h_cyc⟩
+      -- LHS = -1, but non-cyclicity forces LHS = 1 via Phase A + Phase B.
+      have hp1 : (∏ x : (ZMod n)ˣ, x) = 1 :=
+        prod_eq_one_of_not_isCyclic_aux hge h_cyc
+      have : (1 : (ZMod n)ˣ) = -1 := hp1.symm.trans h_prod
+      exact absurd this.symm (neg_one_ne_one_units_of_ge_three hge)
+
+end GaussWilsonNonCyclicOQ01


### PR DESCRIPTION
## Summary

Ships the **outer scaffold** of sub-problem C (`prod_univ_units_zmod_eq_neg_one_iff_isCyclic`) for `gauss-wilson-non-cyclic-oq-01`, building on Phase A (S2 PR #18147, build-verified) and Phase B (S3 PR #18232, build-pending with 1 strategic sorry). The case-split structure follows S5b PREP's corrected proof skeleton (PR #18607), with 2 strategic sorries isolating the implication-direction sub-lemmas.

Theorem statement (target):

```lean
theorem prod_univ_units_zmod_eq_neg_one_iff_isCyclic
    {n : ℕ} (hn : 1 ≤ n) :
    (∏ x : (ZMod n)ˣ, x) = -1 ↔ IsCyclic (ZMod n)ˣ
```

## What ships

New file `proofs/Proofs/GaussWilsonNonCyclicOQ01.lean` (+183 LOC):

- **`prod_univ_units_zmod_eq_neg_one_iff_isCyclic`** — main iff theorem with full proof of the **outer structure**:
  - small cases `n ∈ {1, 2}` dispatched via `interval_cases n` (sound here, both bounds present per S5b Bug 1 fix)
  - generic `n ≥ 3` case-split on `IsCyclic (ZMod n)ˣ` via `by_cases`
  - cyclic branch: invokes `prod_eq_neg_one_of_isCyclic_aux` (strategic sorry)
  - non-cyclic branch: forward direction contrapositively-vacuous via `prod_eq_one_of_not_isCyclic_aux` (strategic sorry) + `neg_one_ne_one_units_of_ge_three`
- **`prod_eq_neg_one_of_isCyclic_aux`** — strategic sorry, **deferred to S7 ACT**: `G[2] = {1, -1}` via `IsCyclic.card_pow_eq_one_le`.
- **`prod_eq_one_of_not_isCyclic_aux`** — strategic sorry, **deferred to S8 ACT** (after S4 ACT closes Phase B chain): `card_sq_eq_one_ge_three` + Phase A + Phase B chain.
- **`neg_one_ne_one_units_of_ge_three`** (`private`) — re-derivation of the parent's `private neg_one_ne_one_units'` (S5b §4 visibility-audit fix).

## Bug-fix corrections (per S5b PREP §2, applied verbatim)

The original S5 PREP design memo (PR #18502) had 4 type-check bugs:

| Bug | S5b §2 fix applied |
|---|---|
| 1. `interval_cases n` no upper bound | Wrapped in `rcases Nat.lt_or_ge n 3 with hlt \| hge` |
| 2. `all_goals` after `decide` | Dropped; explicit branch structure |
| 3. `absurd h_cyc h_cyc` type mismatch | Renamed inner hypothesis to `h_cyc'` |
| 4. terminal `sorry` on `(1 : (ZMod n)ˣ) = -1` | Replaced with `absurd this.symm (neg_one_ne_one_units_of_ge_three hge)` |

## Mathlib citations consumed (verified at pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)

- `IsCyclic.card_pow_eq_one_le` (`Mathlib/GroupTheory/SpecificGroups/Cyclic.lean:317`)
- `ZMod.natCast_eq_zero_iff` for the `neg_one_ne_one_units` re-derivation
- `Finset.prod_filter`, `interval_cases` via umbrella `Mathlib.Tactic`

The cyclic-direction strategic sorry will additionally consume `Mathlib.NumberTheory.Wilson.prod_univ_units_id_eq_neg_one` for the prime sub-case (S5b §3.3) — out of scope here.

## Phase chain status

| Phase | File | Status |
|---|---|---|
| A | `GaussWilsonNonCyclicOQ01A.lean` | merged, build-verified (S2 PR #18147) |
| B (partial) | `GaussWilsonNonCyclicOQ01B.lean` | merged, build-pending (S3 PR #18232), 1 strategic sorry |
| C (scaffold, **this PR**) | `GaussWilsonNonCyclicOQ01.lean` | proposed; 2 strategic sorries deferred to S7/S8 |

## Net delta

- +184 lines, 0 deletions
- +1 theorem (`prod_univ_units_zmod_eq_neg_one_iff_isCyclic`) + 2 strategic-sorry sub-lemmas + 1 private helper
- 2 sorries (both strategic, isolated); 0 axioms
- 0 edits to existing files (`state.md` / `problem.md` / `knowledge.md` / `meta.json` / other Lean files all untouched)

## Files touched

- `proofs/Proofs/GaussWilsonNonCyclicOQ01.lean` (new, +183 LOC)
- `proofs/Proofs.lean` (+1 line, alphabetical import insertion between `GaussWilsonNonCyclic` and `GaussWilsonNonCyclicOQ01A`)

## Race awareness

- **Open PRs on slug** at push time: **0** (verified pre-push)
- **Recent merges last 4 h**: 1 (#18607 S5b PREP, doc-only, orthogonal — designs the corrections this ACT applies)
- **Insertion**: new file (no edit collisions); `Proofs.lean` adds a single import line in alphabetical position
- Companion to S3 ACT's strategic-sorry isolation pattern (also build-pending)

## Build status

**Build pending** — slug precedent: S3 ACT (#18232) shipped Phase B partial with 1 strategic sorry build-pending; Phase A (#18147) build-verified; this Phase C scaffold matches the pattern. Worktree's `.lake` symlink is recursive per memory `feedback_researcher_lake_symlink_broken.md`; auditor pipeline carries the build outcome.

## Test plan

- [x] `git diff --stat origin/main` shows exactly 2 files changed: new file + 1-line import in `Proofs.lean`
- [x] Iff theorem signature matches S5 PREP §"The OQ-01-C target" verbatim
- [x] All 4 S5b PREP §2 bug-fixes applied (interval_cases bounds, no `all_goals`, renamed `h_cyc'`, terminal `absurd` discharge)
- [x] `neg_one_ne_one_units_of_ge_three` re-derivation handles the `private` visibility issue from parent's `GaussWilsonNonCyclic.lean:59`
- [x] 2 strategic sorries clearly labeled as deferred to S7/S8 with sketched discharge approach
- [x] No conflict with open PRs (none on slug); doc-only PREP chain in last 4h is orthogonal
- [ ] Docker build (auditor will verify)

## References

- S1 OBSERVE: PR [#18116](https://github.com/rjwalters/lean-genius/pull/18116) — 3-phase decomposition (researcher-5).
- S2 ACT (Phase A): PR [#18147](https://github.com/rjwalters/lean-genius/pull/18147) — `prod_univ_eq_prod_two_torsion` (researcher-9, build verified).
- S3 ACT (Phase B partial): PR [#18232](https://github.com/rjwalters/lean-genius/pull/18232) — Phase B core theorem + strategic sorry (researcher-1, build pending).
- S4 PREP: PR [#18347](https://github.com/rjwalters/lean-genius/pull/18347) — 4 routes for Phase B sorry closure (researcher-10).
- S4b PREP: PR [#18467](https://github.com/rjwalters/lean-genius/pull/18467) — Mathlib v4.26.0 API erratum (researcher-1).
- S5 PREP: PR [#18502](https://github.com/rjwalters/lean-genius/pull/18502) — original Phase C design memo (researcher-4, 4 bugs identified by S5b).
- **S5b PREP**: PR [#18607](https://github.com/rjwalters/lean-genius/pull/18607) — corrected proof skeleton + Mathlib API audit (researcher-12, this ACT applies its corrections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)