### PR TITLE
research(hilbert-10-oq-01-oq-02): iter 24a — Π₂ ∩ Π₂ ⊆ Π₂ + Σ₂ ∪ Σ₂ ⊆ Σ₂ binary closures off current main (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -2362,6 +2362,127 @@ theorem koenigsmann_2016_universal_doubleNeg :
     koenigsmann_2016_universal
 
 -- ============================================================
+-- Part VIII.28 (iter 24a, Path B): the missing diagonal at level 2 —
+--                                   Π₂ ∩ Π₂ ⊆ Π₂ binary
+--                                   + Σ₂ ∪ Σ₂ ⊆ Σ₂ binary
+-- ============================================================
+
+/-- **Iter 24a (Π₂ binary intersection closure)**: the Π₂ class is
+    closed under binary intersection.
+
+    Direct level-2 analog of iter 12's
+    `intersection_isDiophantineDefinition`: the existential `x`-block is
+    packed via `evenProj`/`oddProj` while the universal `y`-block is
+    shared between the two Π₂ inputs. The polynomial witness is the
+    same sum-of-squares construction as iter 12, with one outer `∀ y`
+    added uniformly.
+
+    Polynomial witness:
+
+      Q(q, y, x) := P₁(q, y, evenProj x)² + P₂(q, y, oddProj x)²
+
+    Combined with iter 20's `pi2_union_isUniversalExistentialDefinition`,
+    this **completes the Π₂ binary closure grid** (∪ AND ∩). Neither
+    class is (known to be) closed under complement; that would collapse
+    Σ₂ = Π₂ over ℚ, equivalent to the OPEN question via
+    `existentialUniversal_iff_universalExistential_complement`.
+
+    Re-implementation off current `origin/main` of the stale stack
+    PR #17456 (CONFLICTING/DIRTY since 2026-05-08); see PREP
+    `2026-05-13-iter24-prep-iter16-stack-audit.md` for the audit
+    establishing tractability. ZERO new Mathlib imports; ZERO new
+    helper lemmas (uses only iter 12's packing helpers `evenProj`,
+    `oddProj`, `interleave`, `evenProj_interleave`,
+    `oddProj_interleave`; plus `mul_self_nonneg`, `linarith`,
+    `mul_eq_zero`). -/
+theorem pi2_intersection_isUniversalExistentialDefinition
+    {S₁ S₂ : RatSubset}
+    (h₁ : IsUniversalExistentialDefinition S₁)
+    (h₂ : IsUniversalExistentialDefinition S₂) :
+    IsUniversalExistentialDefinition (fun q => S₁ q ∧ S₂ q) := by
+  obtain ⟨P₁, hP₁⟩ := h₁
+  obtain ⟨P₂, hP₂⟩ := h₂
+  refine ⟨fun q y x =>
+    (P₁ q y (evenProj x)) * (P₁ q y (evenProj x)) +
+    (P₂ q y (oddProj x)) * (P₂ q y (oddProj x)), fun q => ?_⟩
+  constructor
+  · rintro ⟨hS₁, hS₂⟩ y
+    -- For each y, peel x_i from each Π₂ witness at SAME y, interleave.
+    obtain ⟨x₁, hx₁⟩ := (hP₁ q).mp hS₁ y
+    obtain ⟨x₂, hx₂⟩ := (hP₂ q).mp hS₂ y
+    refine ⟨interleave x₁ x₂, ?_⟩
+    rw [evenProj_interleave, oddProj_interleave, hx₁, hx₂]
+    ring
+  · intro hAll
+    -- For each y: sum-of-squares = 0 ⇒ each factor = 0 ⇒ S_i witness at that y.
+    have hSep : ∀ y : Nat → Rat,
+        (∃ x : Nat → Rat, P₁ q y x = 0) ∧ (∃ x : Nat → Rat, P₂ q y x = 0) := by
+      intro y
+      obtain ⟨x, hx⟩ := hAll y
+      set a := P₁ q y (evenProj x)
+      set b := P₂ q y (oddProj x)
+      have haa_nn : (0 : Rat) ≤ a * a := mul_self_nonneg a
+      have hbb_nn : (0 : Rat) ≤ b * b := mul_self_nonneg b
+      have haa_zero : a * a = 0 := by linarith
+      have hbb_zero : b * b = 0 := by linarith
+      have ha : a = 0 := (mul_eq_zero.mp haa_zero).elim id id
+      have hb : b = 0 := (mul_eq_zero.mp hbb_zero).elim id id
+      exact ⟨⟨evenProj x, ha⟩, ⟨oddProj x, hb⟩⟩
+    refine ⟨(hP₁ q).mpr fun y => (hSep y).1,
+            (hP₂ q).mpr fun y => (hSep y).2⟩
+
+/-- **Iter 24a (Σ₂ binary union closure)**: the Σ₂ class is closed
+    under binary union.
+
+    Direct level-2 analog of iter 13's `union_isCoDiophantineDefinition`:
+    chain through iter 5's Σ₂/Π₂ duality, iter 24a's Π₂ ∩ closure
+    (above), and iter 7's Π₂ class congruence helper.
+
+      Σ₂(S₁), Σ₂(S₂)
+        →[iter 5 existentialUniversal_iff_universalExistential_complement]  Π₂(¬S₁), Π₂(¬S₂)
+        →[iter 24a pi2_intersection_isUniversalExistentialDefinition]        Π₂(¬S₁ ∧ ¬S₂)
+        →[iter 7 universalExistentialDefinition_iff_of_pred_iff
+           via constructive de Morgan ¬S₁ ∧ ¬S₂ ↔ ¬(S₁ ∨ S₂)]              Π₂(¬(S₁ ∨ S₂))
+        →[iter 5 existentialUniversal_iff_universalExistential_complement]   Σ₂(S₁ ∨ S₂)
+
+    Combined with iter 20's
+    `sigma2_intersection_isExistentialUniversalDefinition`, this
+    **completes the Σ₂ binary closure grid** (∪ AND ∩). The underlying
+    polynomial witness (after unfolding the iter 5 duality, which is
+    identity on the polynomial family P) is the same sum-of-squares
+    construction as the Π₂ ∩ closure above.
+
+    Re-implementation off current `origin/main` of the stale stack
+    PR #17456 (CONFLICTING/DIRTY since 2026-05-08). -/
+theorem sigma2_union_isExistentialUniversalDefinition
+    {S₁ S₂ : RatSubset}
+    (h₁ : IsExistentialUniversalDefinition S₁)
+    (h₂ : IsExistentialUniversalDefinition S₂) :
+    IsExistentialUniversalDefinition (fun q => S₁ q ∨ S₂ q) := by
+  -- Step 1: dualize each Σ₂ to Π₂ on the complement (iter 5 duality).
+  have hd₁ : IsUniversalExistentialDefinition (fun q => ¬ S₁ q) :=
+    (existentialUniversal_iff_universalExistential_complement S₁).mp h₁
+  have hd₂ : IsUniversalExistentialDefinition (fun q => ¬ S₂ q) :=
+    (existentialUniversal_iff_universalExistential_complement S₂).mp h₂
+  -- Step 2: Π₂ closed under binary intersection (iter 24a, this section).
+  have hcap : IsUniversalExistentialDefinition (fun q => ¬ S₁ q ∧ ¬ S₂ q) :=
+    pi2_intersection_isUniversalExistentialDefinition hd₁ hd₂
+  -- Step 3: bridge via constructive de Morgan
+  --     `¬ S₁ q ∧ ¬ S₂ q ↔ ¬ (S₁ q ∨ S₂ q)`.
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ¬ S₁ q ∧ ¬ S₂ q) q ↔
+        (fun q : Rat => ¬ (S₁ q ∨ S₂ q)) q := by
+    intro q
+    refine ⟨fun ⟨hn₁, hn₂⟩ hor => hor.elim hn₁ hn₂,
+            fun hnor => ⟨fun h₁q => hnor (Or.inl h₁q),
+                          fun h₂q => hnor (Or.inr h₂q)⟩⟩
+  have hd : IsUniversalExistentialDefinition (fun q : Rat => ¬ (S₁ q ∨ S₂ q)) :=
+    (universalExistentialDefinition_iff_of_pred_iff hbridge).mp hcap
+  -- Step 4: Π₂(¬T) ↔ Σ₂(T) via iter 5 duality, with T = S₁ ∪ S₂.
+  exact (existentialUniversal_iff_universalExistential_complement
+    (fun q => S₁ q ∨ S₂ q)).mpr hd
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -2648,5 +2769,7 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @IntegersAreExistentialUniversalOverQ
 #check @integers_existentialUniversal_iff_complement_universalExistential
 #check @koenigsmann_2016_universal_doubleNeg
+#check @pi2_intersection_isUniversalExistentialDefinition
+#check @sigma2_union_isExistentialUniversalDefinition
 
 end Hilbert10Rationals


### PR DESCRIPTION
## Summary

Re-implementation of the **stale iter 16 stack** (PR [#17456](https://github.com/rjwalters/lean-genius/pull/17456), CONFLICTING/DIRTY since 2026-05-08) on current `origin/main`, delivering the two genuinely-open binary closure cells of the level-2 arithmetic hierarchy over ℚ.

Per PREP `2026-05-13-iter24-prep-iter16-stack-audit.md` (researcher-11, already on main), iter 16's named theorems are NOT on `origin/main` despite iter 20-22 docstrings referencing them as if landed. The stale stack is structurally blocked. This PR follows the PREP's **Option B recommendation** (clean re-open as iter 24, off current main), shipping the **binary** cells (iter 24a). List/Finset arity transports (iter 24b) deferred.

## Theorems shipped

**`pi2_intersection_isUniversalExistentialDefinition`** (~50 LOC) — Π₂ is closed under binary intersection. Polynomial witness:

$$Q(q, y, x) = P_1(q, y, \text{evenProj}\,x)^2 + P_2(q, y, \text{oddProj}\,x)^2$$

The existential $x$-block is packed via `evenProj`/`oddProj`; the universal $y$-block is shared. Direct level-2 analog of iter 12's `intersection_isDiophantineDefinition` (lines 1246-1273 on main) with one outer `∀ y` added uniformly.

**`sigma2_union_isExistentialUniversalDefinition`** (~30 LOC) — Σ₂ is closed under binary union. Direct level-2 analog of iter 13's `union_isCoDiophantineDefinition`, chaining:

```
Σ₂(S₁), Σ₂(S₂)
  →[iter 5 duality]                Π₂(¬S₁), Π₂(¬S₂)
  →[iter 24a Π₂ ∩, above]          Π₂(¬S₁ ∧ ¬S₂)
  →[iter 7 congruence + de Morgan] Π₂(¬(S₁ ∨ S₂))
  →[iter 5 duality, reverse]       Σ₂(S₁ ∨ S₂)
```

## Grid completion

Combined with iter 20's `sigma2_intersection_*` / `pi2_union_*` (already on main), this **fills the level-2 binary closure grid**:

| Class | binary ∪                              | binary ∩                              |
|-------|----------------------------------------|----------------------------------------|
| Σ₂    | **iter 24a (THIS PR)** sigma2_union_*  | iter 20 ✓ sigma2_intersection_*        |
| Π₂    | iter 20 ✓ pi2_union_*                  | **iter 24a (THIS PR)** pi2_intersection_* |

Neither class is (known to be) closed under complement — that would collapse Σ₂ = Π₂ over ℚ, equivalent to the OPEN question via `existentialUniversal_iff_universalExistential_complement`.

## Net delta

- `proofs/Proofs/Hilbert10OQ01OQ02.lean`: **+123 LOC** (2 new theorems in new Part VIII.28 section + 2 `#check` lines)
- **0 new axioms, 0 new sorries, 0 new Mathlib imports**
- Uses only existing helpers: `evenProj`, `oddProj`, `interleave`, `evenProj_interleave`, `oddProj_interleave` (iter 12); `existentialUniversal_iff_universalExistential_complement` (iter 5); `universalExistentialDefinition_iff_of_pred_iff` (iter 7); `mul_self_nonneg`, `linarith`, `mul_eq_zero` (Mathlib, already imported)
- 0 edits to other files (state.md, problem.md, meta.json, gallery JSON all untouched)

## Orthogonality to stale PRs

The stale stack #17456/#17552/#17602 was filed off a pre-iter-17 main (2026-05-08). Iter 20-23 landed on top since then; **this PR branches off current `origin/main`** (HEAD `a84a6c8757a`). The diff against current main is clean (zero rebase conflicts) because the stale PRs never landed.

This PR uses **identical names** to #17456's claimed theorems (`pi2_intersection_isUniversalExistentialDefinition`, `sigma2_union_isExistentialUniversalDefinition`). The math is identical; the implementation is fresh against current main. **Recommended follow-on**: close #17456/#17552/#17602 as superseded.

## Build status

**Build pending** — slug precedent: iter 14, 15, 16, 17, 18, 19, 20, 21, 22 all shipped build-pending. Worktree's `proofs/.lake` is the known recursive self-symlink (per memory `feedback_researcher_lake_symlink_broken.md`); auditor pipeline carries the build outcome.

## Race awareness

- **Open PRs on slug** at push time: 3 (all stale 4+ days, CONFLICTING/DIRTY: #17456, #17552, #17602)
- **Recent merges last 4h**: 0
- **Insertion**: new Part VIII.28 section at line 2363, between iter 23's `koenigsmann_2016_universal_doubleNeg` and Part IX commentary. No edits to existing sections.

## Test plan

- [x] `git diff --stat origin/main` shows exactly 1 file modified (+123 LOC)
- [x] 2 new theorems with signatures matching PREP §5 §6 verbatim
- [x] 0 sorries, 0 axioms, 0 new imports
- [x] All cited helpers (`evenProj_interleave`, `oddProj_interleave`, `mul_self_nonneg`, etc.) verified present on main via grep
- [x] iter 12 template (lines 1246-1273) byte-for-byte parallel except outer `∀ y`
- [x] iter 13 template (lines 1349-1374) byte-for-byte parallel for the Σ₂ ∪ duality chain
- [x] No conflicts with the 3 stale open PRs (none of their work is on main)
- [ ] Docker build (auditor will verify)

## References

- PREP: `research/problems/hilbert-10-oq-01-oq-02/sessions/2026-05-13-iter24-prep-iter16-stack-audit.md` — full audit, recommendation, and forward design (researcher-11, on main).
- Stale stack: PR [#17456](https://github.com/rjwalters/lean-genius/pull/17456) iter 16 (binary), PR [#17552](https://github.com/rjwalters/lean-genius/pull/17552) iter 18 (list), PR [#17602](https://github.com/rjwalters/lean-genius/pull/17602) iter 19 (Finset) — all CONFLICTING/DIRTY since 2026-05-08/09.
- Templates on main: iter 12 `intersection_isDiophantineDefinition` (Hilbert10OQ01OQ02.lean:1246), iter 13 `union_isCoDiophantineDefinition` (Hilbert10OQ01OQ02.lean:1349).
- Sibling grid cells: iter 20 `sigma2_intersection_isExistentialUniversalDefinition` (Hilbert10OQ01OQ02.lean:1911), `pi2_union_isUniversalExistentialDefinition` (Hilbert10OQ01OQ02.lean:1988).
- Mathlib helpers: `mul_self_nonneg`, `mul_eq_zero`, `linarith` — all on iter-12's import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)