### PR TITLE
audit(erdos-970,974,976): tracker bump — clean re-audit batch

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10907,8 +10907,8 @@
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T17:28:10Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:43:00Z",
       "result": "clean"
     },
     "erdos-971": {
@@ -10931,8 +10931,8 @@
     },
     "erdos-974": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T17:29:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:43:01Z",
       "result": "clean"
     },
     "erdos-975": {
@@ -10943,9 +10943,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T17:32:53Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:43:02Z",
+      "result": "clean"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited 3 Erdős axiomatized stubs (last audit 2026-04-27, PR #13334). All clean — meta.json counts match Lean source exactly.

| slug | lines | sorries | axioms | True stubs | meta status / badge |
|------|-------|---------|--------|-----------|---------------------|
| erdos-970 | 157 | 0 | 8 | 0 | axiomatized / axiom |
| erdos-974 | 196 | 0 | 3 | 0 | axiomatized / axiom |
| erdos-976 | 175 | 0 | 1 | 0 | axiomatized / axiom |

**Verified axioms:**
- erdos-970: `h`, `iwaniec_upper_bound`, `fgkmt_lower_bound`, `h_one`, `h_two`, `h_three`, `h_four`, `h_five`
- erdos-974: `power_sum_roots_of_unity`, `turan_conjecture`, `tijdeman_1966_odd`
- erdos-976: `tenenbaum_bound`

`assumptions` field names match axiom declarations in each file. erdos-976 transitions `issues-fixed` → `clean` (issue from prior cycle stayed fixed).

## Test plan

- [x] All 3 meta.json fields (status, badge, sorries, axiomCount, lineCount, assumptions) checked against current Lean source
- [x] No new sorries / True stubs introduced since last audit
- [x] No open `audit/erdos-97{0,4,6}-*` PR conflicts

Discovered during gallery integrity audit (auditor agent, 20-min cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)