### PR TITLE
audit(erdos-967): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10883,8 +10883,8 @@
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T21:32:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T07:57:44Z",
       "result": "clean"
     },
     "erdos-968": {


### PR DESCRIPTION
## Summary

Re-audit of `erdos-967` (Erdős Problem #967: Zeros of Generalized Dirichlet Sums) — clean. Bumps tracker `auditCount: 3 → 4` and `lastAudited` to current time. Prior 3 audits were clean.

## Audit findings

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`yip_counterexample`) | ✓ |
| lineCount | 240 | 240 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 11 | 11 | ✓ |
| status | axiomatized | (1 axiom, 0 sorries) | ✓ |
| badge | axiom | (axiom present) | ✓ |
| Mathlib wrapper? | no | core result via local axiom | ✓ |

## Modeling caveat (disclosed, within axiomatized tier)

`hasConvergentReciprocalSum := True` and `tauberianEquivalence := … ↔ True` are placeholder definitions; `powers_of_2_convergent` is therefore trivially-true. The formal axiom `yip_counterexample` is weaker than Yip's real-world statement (the witness's "convergence" is the trivial predicate). This is within the documented `axiomatized` tier and is already disclosed by the `assumptions` field + `axiom` badge.

## Tier classification

Tier C (axiomatized / scaffold). Status, badge, and assumptions field correctly disclose. No status/badge change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)