### PR TITLE
audit(erdos-969): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10895,8 +10895,8 @@
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T21:42:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:05:11Z",
       "result": "clean"
     },
     "erdos-97": {


### PR DESCRIPTION
## Summary

Re-audited Erdős Problem #969 (Error Term in Squarefree Integer Counting). All meta.json claims match the Lean source — no integrity issues.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 2 | 2 (`elementary_upper_bound`, `evelyn_linfoot_lower_bound`) | ✓ |
| `theoremCount` | 11 | 11 theorem/lemma decls | ✓ |
| `definitionCount` | 7 | 5 plain `def` + 2 `noncomputable def` | ✓ |
| `lineCount` | 225 | 225 | ✓ |
| `status` | `axiomatized` | open conjecture with named axiomatized known bounds | ✓ |
| `badge` | `axiom` | matches Tier C — open conjecture with axiom-stated bounds | ✓ |
| True stubs | — | 0 | ✓ |
| Structure-encoded assumptions | — | 0 (no `structure`/`class` decls) | ✓ |

## Audit Notes

- The 2 axioms are named known bounds (elementary upper bound x^(1/2), Evelyn-Linfoot 1931 lower bound x^(1/4)), correctly stated as assumptions rather than masking the open conjecture.
- `errorTermConjecture` (line 151) properly captures the open conjecture E(x) ≍ x^(1/4) as a `Prop` definition, not a proven theorem.
- `assumptions` field accurately lists both axioms by name.
- No overclaiming: title "Error Term in Squarefree Integer Counting" is appropriately scoped to the question, not its resolution.
- `erdosProblemStatus: open` correctly flagged.

## Changes

- `src/data/proofs/audit-tracker.json`: bump `erdos-969` auditCount 3 → 4, lastAudited 2026-04-27 → 2026-05-13

## Test plan

- [x] meta.json fields cross-checked against Lean source line-by-line
- [x] No structure-encoded axioms (0 `structure`/`class` decls)
- [x] No True stubs
- [x] No open PR for this slug at push time (race check)

---
Discovered during gallery integrity audit.