### PR TITLE
research(sperner-simplicial-bridge-oq-01): S4 GALLERY — mixed-pseudomanifold gallery entry (status: formalized, build pending)

### DIFF
--- a/research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s4-gallery-mixed-pseudomanifold-entry.md
+++ b/research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s4-gallery-mixed-pseudomanifold-entry.md
@@ -1,0 +1,133 @@
+# S4 GALLERY — `sperner-simplicial-bridge-oq-01` gallery entry
+
+**Researcher**: researcher-3
+**Date**: 2026-05-13
+**Phase**: ACT (GALLERY)
+**Iteration**: 5
+**Predecessors**: PR #18234 (S1 OBSERVE), #18363 (S2 SCAFFOLD), #18434 (S2b OBSERVE), #18451 (S2c PREP), #18537 (S3 ACT — `sperner_mixed_panchromatic_at_dim` lands, build pending), #18564 (S3b PREP — cross-stratum design + S4 GALLERY pre-flight recipe).
+**Build status**: not applicable — gallery files only, no Lean changes.
+
+## Scope
+
+Executes the S4 GALLERY recipe pre-flighted in PR #18564 (S3b PREP, Component C). Creates the three gallery files for the OQ-01 closure:
+
+- `src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json`
+- `src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json`
+- `src/data/proofs/sperner-simplicial-bridge-oq-01/index.ts`
+
+No edits to existing files. No edits to the Lean source `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` (post-S3-ACT state on origin/main; 184 LOC, 7 theorems, 3 defs, 0 sorries, 0 axioms). No edits to `state.md` / `knowledge.md` / `problem.md` / `src/data/research/problems/sperner-simplicial-bridge-oq-01.json` (drift sync remains auditor/mechanic).
+
+## Honest status — build-pending caveat
+
+S3 ACT (PR #18537) merged 2026-05-13T03:32:39Z with a `build pending` qualifier in its title. No subsequent Doctor/Mechanic PR has confirmed `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialBridgeOQ01` succeeds, and the local worktree's `proofs/.lake` symlink is in the self-referential loop documented in memory `feedback_researcher_lake_symlink_loop_and_wipe.md`, so a local build is not feasible from this session.
+
+The gallery entry therefore ships with:
+
+- `status: "formalized"`
+- `badge: "wip"`
+- `axiomCount: 0`
+- `sorries: 0`
+- `theoremCount: 7`
+- `definitionCount: 3`
+- `lineCount: 184`
+
+The `assumptions` field carries an explicit note that the formalisation is mathematically complete (0 sorries, 0 axioms) but build verification is pending. Once Doctor/Mechanic confirms the build, the entry can be promoted to `status: "verified"` / `badge: "verified"`.
+
+This conservative posture follows the CLAUDE.md "Axiom Integrity Policy" rule *"When in doubt, use 'axiomatized' — overclaiming 'verified' damages credibility"*, here weakened from `axiomatized` (which would falsely imply assumption-bearing axioms) to `formalized` with a `wip` badge, which is the precedent set by `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` (also 0 sorries, 0 axioms, `formalized`+`wip`).
+
+## Field values vs. S3b PREP recipe
+
+The S3b PREP (PR #18564 §C) pre-computed:
+
+| Field | S3b PREP value | This PR's value | Match |
+|---|---|---|---|
+| `lineCount` | 184 | 184 | ✓ |
+| `theoremCount` | 7 | 7 | ✓ |
+| `definitionCount` | 3 | 3 | ✓ |
+| `axiomCount` | 0 | 0 | ✓ |
+| `sorries` | 0 | 0 | ✓ |
+| `status` (if build passes) | `verified` | `formalized` (build unverified) | downgraded |
+| `badge` (if build passes) | `verified` | `wip` (build unverified) | downgraded |
+| `imports` | `["Proofs.SpernerSimplicialBridge"]` | same | ✓ |
+| `mathlib_version` | `4.26.0` | `4.26.0` | ✓ |
+
+The only deltas vs. the recipe are `status` and `badge`, downgraded to reflect the unverified build state. Recipe Component A (cross-stratum existential wrapper) was *not* bundled — Option α from the recipe would have required a Lean-file edit and a fresh build, both blocked by the symlink trap.
+
+## Three sections (matches S3b PREP Component C)
+
+| Section | Line range | Headline declaration | Annotation type |
+|---|---|---|---|
+| Stratification | 54-68 | `MixedPseudomanifold` | definition |
+| Pure → Mixed Coercion | 70-109 | `MixedPseudomanifold.of_pure` | theorem |
+| Per-Stratum Sperner | 111-180 | `sperner_mixed_panchromatic_at_dim` | theorem |
+
+Each section gets one annotation in `annotations.json` (3 total — keeping the entry well-sized for a derived extension; the parent's 7 sections / 7 annotations is unnecessary for a 184-LOC file).
+
+## Cross-references
+
+Three entries in `meta.crossReferences`:
+
+1. `generalisation-of` → `sperner-simplicial-bridge` (the parent OQ-01 strictly generalises).
+2. `uses` → `sperner-simplicial-bridge` (the per-stratum proof is a single application of the parent's `exists_panchromatic`).
+3. `sibling-of` → `sperner-simplicial-instance` (both build on the parent; sibling tackles concrete Kuhn-style triangulations).
+
+The `sperner-simplicial-instance` cross-reference is documented even though both slugs are sibling derivations — this entry's `MixedPseudomanifold` framework and the sibling's `findPanchromaticBrute` algorithm are complementary, not overlapping.
+
+## Three open questions in `meta.conclusion.openQuestions`
+
+Per the research methodology's "follow-up question generation" guidance (CLAUDE.md §researcher.md), three strong follow-ups:
+
+1. **Cross-stratum existential wrapper** — a 3-line `obtain`-then-`exact` convenience corollary. Pre-designed in S3b PREP Component A (PR #18564). Low priority (convenience, not new mathematical content).
+2. **`Mathlib.Geometry.SimplicialComplex.facets` bridge** — the natural Mathlib entry point for non-pure simplicial complexes. The translation layer between Mathlib's affine-set encoding and this file's `Finset (Finset E)` encoding is the open work. This is the parent's OQ-02, advanced by the mixed-pseudomanifold framework now in place.
+3. **Global boundary-door count** — replace the cross-stratum disjunction with a sum `globalBoundaryDoors K c := Σ d, boundaryDoorCount (d := d) K c`. Parity reasoning over a sum requires exactly one stratum has odd boundary count, non-trivial in multi-dimensional settings.
+
+## Orthogonality
+
+| Touched file | Status | Conflict |
+|---|---|---|
+| `src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json` | new | none (path does not exist on origin/main) |
+| `src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json` | new | none |
+| `src/data/proofs/sperner-simplicial-bridge-oq-01/index.ts` | new | none |
+| `research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s4-gallery-mixed-pseudomanifold-entry.md` | new | none (this file) |
+| `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` | unchanged | n/a |
+| `proofs/Proofs.lean` | unchanged | n/a |
+| `src/data/listings.json` | regenerated at deploy via `scripts/annotations/build.ts` | n/a |
+
+Per the gallery-clean-task memory `feedback_researcher_s3_gallery_clean_task_pattern.md`, this is a clean S4 GALLERY task: build-verified or build-pending Lean already on main, gallery dir missing, ship 3 files + 1 session note. No race risk (no open PR on this slug, none in flight on the parent or sibling slugs as of claim time).
+
+## Pre-flight checklist
+
+| Item | Verified by |
+|---|---|
+| Lean source on origin/main at 184 LOC, 7 theorems, 3 defs, 0 sorries, 0 axioms | direct `grep -nE "^(noncomputable )?(def|theorem|lemma)"` |
+| Lean source imported in `proofs/Proofs.lean` | direct grep |
+| No `sperner-simplicial-bridge-oq-01` gallery dir on disk | `ls src/data/proofs/sperner-simplicial-bridge-oq-01/` → not found |
+| Parent slug `sperner-simplicial-bridge` exists and is `verified` | direct meta.json read |
+| No open same-slug PR | `gh pr list --repo rjwalters/lean-genius --search "sperner-simplicial-bridge-oq-01 in:title is:open"` → empty |
+| Parent's `index.ts` shape | direct file read; standard `proof + annotations + getProofSource` pattern |
+| Parent's annotations.json schema (10 keys per entry) | direct file read |
+| JSON validates | `jq .` on both meta.json and annotations.json |
+| Worktree-local file paths (no Write-tool main-repo trap) | `ls -la` on both worktree and main-repo paths |
+
+## Post-merge follow-ups (deferred)
+
+1. **Build verification**. Doctor or Mechanic should run `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialBridgeOQ01` from a clean worktree (no `.lake` symlink loop) and, if successful, promote this gallery entry to `status: "verified"` / `badge: "verified"`.
+2. **Cross-stratum existential wrapper** (S3b PREP Option α). Add `sperner_mixed_panchromatic_exists` (~8-12 LOC) to the Lean file post-build-verify. Promote the `theoremCount` to 8 and `lineCount` to ~192-196.
+3. **Drift-sync** of `state.md` / `knowledge.md` / `problem.md` / `src/data/research/problems/sperner-simplicial-bridge-oq-01.json` to reflect Phase: GALLERY landed. Auditor/Mechanic's domain.
+4. **Parent slug's `openQuestions` list** in `src/data/proofs/sperner-simplicial-bridge/meta.json` — the OQ-01 entry can be marked closed/answered. Enricher/Mechanic's domain.
+
+## Honesty
+
+- **This entry does not prove the build is correct.** The Lean source is on origin/main but unverified by docker-build. Promotion to `verified` is deferred to Doctor/Mechanic.
+- **The mathematical content is unchanged from PR #18537.** This PR is *gallery integration only* — no new theorems, no new sorries, no new mathematical work. The gallery entry exposes the per-stratum theorem and the three supporting helpers in human-readable form.
+- **The annotations are derived from the file's docstrings and the S3b PREP recipe.** No new insights; the keyInsights and overview fields are distilled from the merged session notes.
+- **The cross-stratum existential wrapper (S3b PREP Option α) is *not* shipped here.** It would require a Lean-file edit, an additional theorem, and a fresh build, all blocked by the symlink trap. It is pre-designed and listed as a deferred follow-up.
+
+## References
+
+- **S3b PREP (recipe)**: `research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s3b-prep-cross-stratum-and-post-s3-build-risk-audit.md`, Component C (PR #18564).
+- **S3 ACT (Lean source)**: `research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s3-act-stratum-d-implementation.md` (PR #18537).
+- **Parent gallery slug**: `src/data/proofs/sperner-simplicial-bridge/{meta.json, annotations.json, index.ts}`.
+- **Formalised/wip precedent**: `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` (status `formalized`, badge `wip`, 0 sorries, 0 axioms).
+- **Build trap**: memory `feedback_researcher_lake_symlink_loop_and_wipe.md`.
+- **Gallery-clean-task pattern**: memory `feedback_researcher_s3_gallery_clean_task_pattern.md`.

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "ann-spc-oq01-stratification",
+    "proofId": "sperner-simplicial-bridge-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 68
+    },
+    "type": "definition",
+    "title": "Stratification: `topCellsOfDim` and `MixedPseudomanifold`",
+    "content": "Two definitions establish the framework for non-pure complexes.\n\n* `topCellsOfDim K d : Finset (Finset E)` (line 60-61) is `K.filter (fun s => s.card = d + 1)` — the dimension-`d` stratum of `K`, i.e. the cells with exactly `d + 1` vertices. As a `Finset`, it inherits all decidability machinery from `K` without new instance arguments.\n* `MixedPseudomanifold K : Prop` (line 66-68) is `∀ d : Nat, ∀ f : Finset E, f.card = d → ((topCellsOfDim K d).filter (fun s => f ⊆ s)).card ≤ 2`. Read: for every dimension `d` and every `d`-element face `f`, at most 2 dimension-`d` cells contain `f`. The dimension-stratification is essential — pseudomanifold conditions across different strata do not couple, because doors at different dimensions cannot pair.\n\nNote that the predicate quantifies over *all* `d`, including dimensions for which `K` has no cells. At an empty stratum the predicate is vacuously true (`Finset.filter ∅ p = ∅`, `card ∅ = 0 ≤ 2`). This is what makes `MixedPseudomanifold.of_pure` (next section) come out cleanly.",
+    "mathContext": "A *mixed-dimension* simplicial complex is one whose facets do not all have the same cardinality. The mathematical observation underpinning OQ-01 is that doors are dimension-graded: a codimension-1 face of a `(d+1)`-simplex has cardinality exactly `d`, so faces of cardinality `d` come from `(d+1)`-cells only. Two cells of different dimensions cannot share a door, so the door-pairing argument that drives Sperner's lemma runs *independently* on each dimensional stratum. The right pseudomanifold condition in the mixed setting is therefore *per-stratum*: every `d`-element face is contained in at most 2 dimension-`d` cells.",
+    "significance": "core",
+    "relatedConcepts": [
+      "dimension stratification",
+      "mixed pseudomanifold",
+      "Finset.filter",
+      "door-counting parity",
+      "graded simplicial complex"
+    ],
+    "prerequisites": [
+      "Finset.filter basics",
+      "pure pseudomanifold (parent slug)",
+      "Sperner's lemma door-counting"
+    ]
+  },
+  {
+    "id": "ann-spc-oq01-pure-to-mixed-coercion",
+    "proofId": "sperner-simplicial-bridge-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "Pure → Mixed Coercion (`topCellsOfDim_eq_of_pure`, `topCellsOfDim_eq_empty_of_pure`, `MixedPseudomanifold.of_pure`)",
+    "content": "Three theorems witness that the mixed framework strictly generalises the parent's pure setting.\n\n* `topCellsOfDim_eq_of_pure` (lines 74-79): given `hcard : ∀ s ∈ K, s.card = d + 1`, the dimension-`d` stratum *is* `K`. Proof: `unfold topCellsOfDim`, then apply `Finset.filter_eq_self.mpr hcard`.\n* `topCellsOfDim_eq_empty_of_pure` (lines 83-91): under the same uniform-cardinality hypothesis, strata at other dimensions are empty. Proof: rewrite via `Finset.filter_eq_empty_iff`, then any `s` in the stratum would have cardinality both `d + 1` and `d' + 1`, contradicting `omega`.\n* `MixedPseudomanifold.of_pure` (lines 97-109): a pure pseudomanifold lifts to a mixed pseudomanifold. Proof: `by_cases hd : d' = d`. For `d' = d`, rewrite the stratum to `K` via `topCellsOfDim_eq_of_pure` and apply the parent's `hpseudo`. For `d' ≠ d`, rewrite the stratum to `∅` via `topCellsOfDim_eq_empty_of_pure`, simplify the filter, and conclude `0 ≤ 2` via `Nat.zero_le _`.\n\nThe lift is vacuous at strata of other dimensions — the predicate's universal quantification over `d` is precisely what makes the generalisation a faithful extension rather than a parallel framework.",
+    "mathContext": "A *pure* pseudomanifold is a `MixedPseudomanifold` in which exactly one stratum is non-empty. The coercion `MixedPseudomanifold.of_pure` shows the predicate inclusion `Pure ⊆ Mixed`, which together with the per-stratum main theorem implies that any result derivable from `MixedPseudomanifold` is at least as strong as the parent's. The vacuous behaviour at off-stratum dimensions is essential: without the universal quantification, one would need an explicit disjunction `(∀ d, pseudomanifold on stratum d) ∨ (only stratum d non-empty)`, which is structurally less clean.",
+    "significance": "core",
+    "relatedConcepts": [
+      "predicate lift",
+      "Finset.filter_eq_self",
+      "Finset.filter_eq_empty_iff",
+      "vacuous quantification",
+      "subsumption"
+    ],
+    "prerequisites": [
+      "stratification (previous section)",
+      "Finset.filter_eq_self",
+      "Finset.filter_eq_empty_iff",
+      "by_cases tactic"
+    ]
+  },
+  {
+    "id": "ann-spc-oq01-per-stratum-sperner",
+    "proofId": "sperner-simplicial-bridge-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 180
+    },
+    "type": "theorem",
+    "title": "Per-Stratum Sperner (`sperner_mixed_panchromatic_at_dim`)",
+    "content": "The headline theorem and three supporting helpers, gated behind a `[LinearOrder E]` instance (the parent's `vertexEnum` uses `Finset.sort (· ≤ ·)`).\n\n* `card_of_mem_topCellsOfDim` (lines 128-131) projects `s.card = d + 1` from `s ∈ topCellsOfDim K d` via `(Finset.mem_filter.mp hs).2`.\n* `hpseudo_of_mixed` (lines 134-138) specialises `MixedPseudomanifold K` at a chosen dimension `d`, yielding the parent's pseudomanifold hypothesis `∀ f, f.card = d → ((topCellsOfDim K d).filter (fun s => f ⊆ s)).card ≤ 2`.\n* `boundaryDoorCount` (lines 148-156) is a `noncomputable def` packaging the parent's `hbdry` filter expression for dimension `d`, structurally a copy with `topCellsOfDim K d` substituted for the parent's `topCells` and `card_of_mem_topCellsOfDim` for the per-cell cardinality projection.\n* `sperner_mixed_panchromatic_at_dim` (lines 170-180) is the headline. Hypothesis: `MixedPseudomanifold K` and `Odd (boundaryDoorCount (d := d) K c)`. Conclusion: there exists a panchromatic top cell in `topCellsOfDim K d`. Proof body is a single term-mode application of the parent's `exists_panchromatic` with `topCellsOfDim K d` as `topCells`, `(fun _ hs => card_of_mem_topCellsOfDim hs)` as `hcard`, `hpseudo_of_mixed hmixed` as `hpseudo`, the supplied `c`, and `hbdry`. The `boundaryDoorCount` definition unfolds (via Lean's standard `def`-reducibility) to match the parent's expected `hbdry` shape.",
+    "mathContext": "Sperner's lemma in the mixed-pseudomanifold setting decomposes stratum by stratum. Fixing a target dimension `d`: the dimension-`d` stratum of a `MixedPseudomanifold` is itself a pure pseudomanifold (witnessed by `hpseudo_of_mixed`), the per-cell cardinality is uniform `d + 1` (witnessed by `card_of_mem_topCellsOfDim`), and the parent's `hbdry` filter is recoverable as `boundaryDoorCount K c` after definitional unfolding. The parent's `exists_panchromatic` then produces a panchromatic cell in the stratum. No new combinatorial reasoning is required — all the mathematical content sits in the predicate definitions of the previous two sections. This is the *bridge payoff* for the stratification framework: the proof of the main theorem is mechanical bookkeeping.",
+    "significance": "core",
+    "relatedConcepts": [
+      "exists_panchromatic (parent)",
+      "boundary-door count",
+      "term-mode proof",
+      "LinearOrder instance",
+      "subtype packaging"
+    ],
+    "prerequisites": [
+      "parent slug exists_panchromatic",
+      "stratification + coercion (previous sections)",
+      "Finset.mem_filter",
+      "definitional unfolding"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/index.ts
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/SpernerSimplicialBridgeOQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "sperner-simplicial-bridge-oq-01",
+  "slug": "sperner-simplicial-bridge-oq-01",
+  "title": "Sperner's Lemma for Mixed-Dimension Simplicial Complexes (OQ-01)",
+  "description": "A strict generalisation of `sperner-simplicial-bridge` to mixed-dimension (stratified) simplicial complexes, where top simplices may have different dimensions. The key structural observation is that *doors are dimension-graded*: a codimension-1 face of a `(d+1)`-simplex has cardinality `d`, and faces in different dimensions cannot be doors of each other. So the pseudomanifold condition decomposes stratum by stratum, and Sperner's lemma applies independently per stratum. The `MixedPseudomanifold` predicate captures the per-dimension pseudomanifold condition; `sperner_mixed_panchromatic_at_dim` packages the per-stratum hypotheses and applies the parent's `exists_panchromatic` to the chosen stratum.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
+    "date": "2026",
+    "dateAdded": "2026-05-13",
+    "mathlib_version": "4.26.0",
+    "status": "formalized",
+    "badge": "wip",
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "lineCount": 184,
+    "sorries": 0,
+    "imports": ["Proofs.SpernerSimplicialBridge"],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner",
+      "simplicial-complex",
+      "mixed-pseudomanifold",
+      "stratified",
+      "open-question"
+    ],
+    "assumptions": "0 sorries, 0 axioms — the formalisation is mathematically complete. Status is `formalized` (badge `wip`) rather than `verified` only because automated build verification is pending: the supporting Lean file `Proofs/SpernerSimplicialBridgeOQ01.lean` landed on origin/main via PR #18537 (S3 ACT) with a `build pending` qualifier in its title, and no subsequent Doctor/Mechanic PR has confirmed `docker-build.sh Proofs.SpernerSimplicialBridgeOQ01` succeeds. Once the build is verified, this entry can be promoted to `status: verified` / `badge: verified`. No mathematical assumptions beyond what the parent `sperner-simplicial-bridge` already carries (`LinearOrder E` for the per-stratum stratum; `DecidableEq E` for `Finset.filter`). The `MixedPseudomanifold.of_pure` sanity check verifies that pure pseudomanifolds lift to the mixed predicate (vacuously at strata of other dimensions), so the new framework genuinely subsumes the parent.",
+    "proofRepoPath": "Proofs/SpernerSimplicialBridgeOQ01.lean",
+    "originalContributions": [
+      "`topCellsOfDim K d`: dimension-graded stratification of a finite simplicial complex `K : Finset (Finset E)` — the cells with exactly `d + 1` vertices, defined via `Finset.filter`.",
+      "`MixedPseudomanifold K`: stratum-wise pseudomanifold predicate — for every dimension `d` and every `d`-element face `f`, at most 2 cells of dimension `d` contain `f`. Strictly generalises the parent's pure pseudomanifold condition.",
+      "`MixedPseudomanifold.of_pure`: a pure pseudomanifold lifts to the mixed predicate — the dimension-`d` stratum equals `K`, and strata at other dimensions are empty (so the bound `card ≤ 2` is vacuous). Sanity check that the generalisation subsumes the parent.",
+      "`boundaryDoorCount K c`: a `noncomputable def` packaging the parent's `hbdry` filter expression for a chosen dimension `d`, structurally a one-for-one copy with `topCellsOfDim K d` substituted for the parent's `topCells`.",
+      "`sperner_mixed_panchromatic_at_dim`: per-stratum main theorem — for each dimension `d` such that `boundaryDoorCount K c` is odd, the dimension-`d` stratum of a mixed pseudomanifold `K` contains a panchromatic top cell. Proof body is a single application of the parent's `exists_panchromatic` after packaging `hcard`, `hpseudo`, and `hbdry` per stratum."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/SpernerSimplicialBridgeOQ01.lean",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "imports": ["import Proofs.SpernerSimplicialBridge"],
+    "opens": ["Finset"],
+    "namespace": "Sperner.SimplicialComplex"
+  },
+  "sections": [
+    {
+      "id": "stratification",
+      "title": "Stratification by Dimension",
+      "startLine": 54,
+      "endLine": 68,
+      "summary": "Two core definitions. `topCellsOfDim K d := K.filter (fun s => s.card = d + 1)` extracts the dimension-`d` stratum of a (possibly mixed-dimension) complex via `Finset.filter`. `MixedPseudomanifold K` then asserts the pseudomanifold property *stratum by stratum*: for every dimension `d` and every `d`-element face `f`, at most 2 dimension-`d` cells contain `f`. The dimensional grading is essential because doors are dimension-graded — a codim-1 face of a `(d+1)`-simplex has cardinality `d`, so doors at different dimensions cannot pair with each other and the door-counting parity argument decomposes per stratum."
+    },
+    {
+      "id": "pure-to-mixed-coercion",
+      "title": "Pure → Mixed Coercion",
+      "startLine": 70,
+      "endLine": 109,
+      "summary": "Three theorems showing that pure pseudomanifolds lift to the mixed predicate. `topCellsOfDim_eq_of_pure`: when `∀ s ∈ K, s.card = d + 1`, the stratum at `d` is all of `K`. Proof: unfold `topCellsOfDim` and apply `Finset.filter_eq_self.mpr`. `topCellsOfDim_eq_empty_of_pure`: under the same hypothesis, every other stratum `d' ≠ d` is empty (any cell would have cardinality both `d+1` and `d'+1`, contradicting `omega`). `MixedPseudomanifold.of_pure`: combines both — for the target dimension `d` the bound follows from the parent's `hpseudo`; for other dimensions the filter is over an empty stratum and the cardinality is 0. The lift is vacuous at strata of other dimensions, witnessing that the generalisation genuinely subsumes the parent."
+    },
+    {
+      "id": "per-stratum-sperner",
+      "title": "Per-Stratum Sperner via the Parent's `exists_panchromatic`",
+      "startLine": 111,
+      "endLine": 180,
+      "summary": "Three helpers and the main theorem. `card_of_mem_topCellsOfDim` projects `s.card = d + 1` from membership in the stratum via `Finset.mem_filter.mp`. `hpseudo_of_mixed` specialises `MixedPseudomanifold K` at a chosen dimension `d`, yielding the parent's `hpseudo` hypothesis. `boundaryDoorCount` is a `noncomputable def` that, by construction, copies the parent's `hbdry` filter expression with `topCellsOfDim K d` substituted for the parent's `topCells` — so `Odd (boundaryDoorCount K c)` unfolds to the parent's `hbdry` predicate. `sperner_mixed_panchromatic_at_dim` then applies `exists_panchromatic` directly: pass `topCellsOfDim K d` as `topCells`, `(fun _ hs => card_of_mem_topCellsOfDim hs)` as `hcard`, `hpseudo_of_mixed hmixed` as `hpseudo`, and the unfolded `hbdry`. The proof body is a single term-mode application — no new mathematics is introduced, only the per-stratum bookkeeping."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sperner_mixed_panchromatic_at_dim",
+      "type": "core",
+      "statement": "$\\forall K\\, (\\text{hmixed} : \\mathrm{MixedPseudomanifold}\\,K)\\, (c : E \\to \\mathrm{Fin}(d+1)),\\ \\mathrm{Odd}\\,(\\mathrm{boundaryDoorCount}\\,K\\,c) \\Rightarrow \\exists s \\in \\mathrm{topCellsOfDim}\\,K\\,d,\\ s\\ \\text{is panchromatic}.$",
+      "significance": "**Stratification payoff.** For mixed-dimension complexes, Sperner's lemma applies independently per stratum. Fixing a dimension `d` with an odd boundary-door count, the dimension-`d` stratum of a `MixedPseudomanifold` contains a panchromatic top cell. This is a strict generalisation of the parent's `Sperner.SimplicialComplex.exists_panchromatic`, recovered by restricting to a pure (single-dimension) complex.",
+      "description": "Per-stratum Sperner's lemma for mixed-dimension simplicial complexes (the file's headline theorem)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "type": "generalisation-of",
+      "slug": "sperner-simplicial-bridge",
+      "rationale": "OQ-01 strictly generalises the pure pseudomanifold case to mixed-dimension complexes. `MixedPseudomanifold.of_pure` proves the embedding of pure data into the mixed framework."
+    },
+    {
+      "type": "uses",
+      "slug": "sperner-simplicial-bridge",
+      "rationale": "The per-stratum proof is a single application of the parent's `exists_panchromatic` on the chosen stratum after packaging per-stratum `hcard`, `hpseudo`, and `hbdry`."
+    },
+    {
+      "type": "sibling-of",
+      "slug": "sperner-simplicial-instance",
+      "rationale": "Both slugs build on `sperner-simplicial-bridge`. `sperner-simplicial-instance` provides concrete Kuhn-style triangulation instances of the parent; this slug extends the parent's framework to non-pure (mixed-dimension) complexes."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Sperner's lemma in its classical form (Emanuel Sperner, 1928) assumes a pure simplicial complex — every top simplex has the same dimension. The pure hypothesis is geometrically restrictive: most simplicial complexes arising in algebraic topology (cell complexes of CW-pairs, triangulated manifolds with boundary, polytopal decompositions of non-equidimensional spaces) are non-pure. De Longueville (2013, *A Course in Topological Combinatorics*, Springer, Ch. 2) develops Sperner's lemma for stratified (non-pure) complexes by exploiting the dimensional grading of doors: a codimension-1 face of a `(d+1)`-simplex has cardinality `d`, so doors at different dimensions cannot pair, and the door-counting parity argument runs independently per stratum.",
+    "problemStatement": "**Open Question 1 of `sperner-simplicial-bridge`**: can the pseudomanifold condition be weakened to allow non-pure complexes (cells of different dimensions) by stratifying the door-counting argument? This entry answers: **yes, via dimension-graded strata**. Inputs: a complex `K : Finset (Finset E)` (no uniform-cardinality hypothesis); a stratum-wise pseudomanifold predicate `MixedPseudomanifold K`; a chosen target dimension `d`; a coloring `c : E → Fin (d + 1)`; an odd boundary-door count at dimension `d`. Output: a panchromatic top cell in the dimension-`d` stratum `topCellsOfDim K d`.",
+    "proofStrategy": "Three orthogonal layers, no new mathematics:\n\n1. **Stratify**. `topCellsOfDim K d := K.filter (fun s => s.card = d + 1)` extracts the dimension-`d` stratum. `MixedPseudomanifold K` asserts the parent's pseudomanifold bound on each stratum independently.\n\n2. **Subsume**. `MixedPseudomanifold.of_pure` shows that pure pseudomanifolds lift to the mixed predicate, vacuously at strata of other dimensions (the filter is over an empty stratum, so the cardinality bound is trivial).\n\n3. **Per-stratum apply**. `sperner_mixed_panchromatic_at_dim` packages the three per-stratum hypotheses (`card_of_mem_topCellsOfDim`, `hpseudo_of_mixed`, `boundaryDoorCount` matching the parent's `hbdry` shape) and applies the parent's `exists_panchromatic` to the dimension-`d` stratum.\n\nNo new axioms, no new sorries — the mathematical content is entirely in the *predicate-level* observation that doors are dimension-graded.",
+    "keyInsights": [
+      "**Doors are dimension-graded.** A codim-1 face of a `(d+1)`-simplex has cardinality exactly `d`. Faces of cardinality `d` from a `(d'+1)`-simplex (with `d' ≠ d`) have cardinality `d'`, which differs. Two cells of different dimensions therefore cannot share a door — the door-pairing argument that drives Sperner's lemma decomposes by stratum.",
+      "**`MixedPseudomanifold` is the right predicate.** Quantifying `∀ d, ∀ f : Finset E, f.card = d → ((topCellsOfDim K d).filter (fun s => f ⊆ s)).card ≤ 2` captures exactly the per-stratum pseudomanifold condition without coupling strata. The lift `MixedPseudomanifold.of_pure` proves the predicate subsumes the parent (with the universally-quantified `d` vacuous off the unique stratum).",
+      "**The cross-stratum form is a trivial corollary.** Once `sperner_mixed_panchromatic_at_dim` is established, the disjunctive form (`∃ d, ∃ c, odd boundary count` ⇒ `∃ d, ∃ s, panchromatic`) is a 3-line wrapper: `obtain ⟨d, c, hbdry⟩` from the hypothesis, then apply the per-stratum theorem. The per-stratum form is the mathematical content; the cross-stratum form is convenience packaging.",
+      "**No new Mathlib dependencies.** The whole file sits on top of `Proofs.SpernerSimplicialBridge` — no imports beyond what the parent already brings. The only Mathlib API exercised is `Finset.filter`, `Finset.mem_filter`, and `Finset.filter_eq_self` / `Finset.filter_eq_empty_iff`, all stock.",
+      "**The parent's `verified` status is preserved.** Adding the mixed predicate and the per-stratum theorem does not touch the parent file's definitions or theorems; OQ-01 is a strict extension that subsumes (not replaces) the parent's `exists_panchromatic`."
+    ]
+  },
+  "conclusion": {
+    "summary": "Sperner's lemma generalises to mixed-dimension simplicial complexes via dimension-graded stratification. The file adds 184 lines, 7 theorems, and 3 definitions on top of `sperner-simplicial-bridge`, with 0 sorries and 0 axioms (subject to build verification of S3 ACT PR #18537). The mathematical content is entirely in the predicate-level observation that doors are dimension-graded; the proof of the main theorem is a single term-mode application of the parent's `exists_panchromatic` after packaging per-stratum hypotheses.",
+    "implications": "Closes one of the four open questions on the parent `sperner-simplicial-bridge`, lifting the open-question count from 4 to 3. The mixed-pseudomanifold framework is a direct precursor to OQ-02 (the `Mathlib.Geometry.SimplicialComplex.facets` bridge — Mathlib's notion of facets is dimension-graded) and OQ-04 (the `Mathlib.AlgebraicTopology.SimplicialSet` instance — simplicial sets naturally carry cells of all dimensions). Combined with the `sperner-simplicial-instance` line of work (Kuhn-style triangulation instances of the parent), this completes the framework side of the three-layer Sperner architecture in the gallery: abstract door-counting (`SpernerMathlib`) → mixed-pseudomanifold bridge (this file + parent) → concrete instances.",
+    "openQuestions": [
+      "Can the per-stratum form be packaged into a *cross-stratum existential* (`∃ d, ∃ c, odd boundary count` ⇒ `∃ d, ∃ s, panchromatic in stratum d`) as a 3-line wrapper? The per-stratum form is strictly stronger; this is convenience packaging only.",
+      "Does the mixed framework extend to `Mathlib.Geometry.SimplicialComplex.facets` (the Mathlib type that carries non-pure data natively)? The `topCellsOfDim` stratification of a `Finset (Finset E)` corresponds directly to dimension-grading of `K.facets` — but the affine-set encoding of Mathlib's `SimplicialComplex` requires a translation layer.",
+      "Can the cross-stratum disjunctive form `∃ d, stratum d has odd boundary count` be replaced by a *global* boundary-door count `globalBoundaryDoors K c := Σ d, boundaryDoorCount (d := d) K c`, with the hypothesis `Odd globalBoundaryDoors`? The parity reasoning over a sum requires that exactly one stratum has odd boundary count, which is non-trivial in the multi-dimensional setting."
+    ]
+  },
+  "references": [
+    {
+      "authors": ["De Longueville, Mark"],
+      "year": 2013,
+      "title": "A Course in Topological Combinatorics",
+      "venue": "Springer Universitext",
+      "note": "Chapter 2 develops Sperner's lemma for non-pure simplicial complexes via dimension-graded stratification — the canonical reference for the mixed-pseudomanifold framework formalised here."
+    },
+    {
+      "authors": ["Sperner, Emanuel"],
+      "year": 1928,
+      "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg, vol. 6, pp. 265-272",
+      "note": "The classical Sperner paper; works in the pure (uniform-dimension) setting that this entry generalises."
+    },
+    {
+      "authors": ["Henle, Michael"],
+      "year": 1979,
+      "title": "A Combinatorial Introduction to Topology",
+      "venue": "W. H. Freeman, San Francisco",
+      "note": "Classical reference for the barycentric subdivision framework on triangulated manifolds with boundary; the boundary cells form a non-pure complex, motivating the mixed-pseudomanifold generalisation."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes OQ-01 on the parent `sperner-simplicial-bridge` gallery proof by adding the gallery entry for `sperner-simplicial-bridge-oq-01` — the mixed-pseudomanifold (stratified) generalisation of Sperner's lemma. The underlying Lean source (`proofs/Proofs/SpernerSimplicialBridgeOQ01.lean`, 184 LOC, 7 theorems, 3 defs, 0 sorries, 0 axioms) landed via S3 ACT (#18537).

Follows the S3b PREP recipe (#18564 Component C) almost verbatim, with one explicit downgrade documented below.

## Files

| File | Action | Size |
|---|---|---|
| `src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json` | new | 16.5 KB |
| `src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json` | new | 7.7 KB |
| `src/data/proofs/sperner-simplicial-bridge-oq-01/index.ts` | new | 1.1 KB |
| `research/problems/sperner-simplicial-bridge-oq-01/sessions/2026-05-13-s4-gallery-mixed-pseudomanifold-entry.md` | new | session note |

No Lean changes. No edits to existing files. No edits to `state.md` / `knowledge.md` / `problem.md` / `src/data/research/problems/sperner-simplicial-bridge-oq-01.json` (drift sync is auditor/mechanic's domain). `src/data/proofs/listings.json` regenerates at deploy via `scripts/annotations/build.ts`.

## Mathematical content

The OQ-01 closure formalises the observation that *doors are dimension-graded*: a codimension-1 face of a `(d+1)`-simplex has cardinality `d`, so doors at different dimensions cannot pair, and the door-counting parity argument that drives Sperner's lemma decomposes per stratum. Three layers:

1. **Stratify**. `topCellsOfDim K d := K.filter (fun s => s.card = d + 1)` and `MixedPseudomanifold K` (per-stratum pseudomanifold predicate).
2. **Subsume**. `MixedPseudomanifold.of_pure` lifts pure pseudomanifolds, vacuously at other dimensions.
3. **Per-stratum apply**. `sperner_mixed_panchromatic_at_dim` packages per-stratum `hcard`/`hpseudo`/`hbdry` and applies the parent's `exists_panchromatic`.

The proof of the main theorem is a single term-mode application — no new mathematics, the content sits in the predicate definitions.

## Honest status — build-pending downgrade

S3 ACT (#18537) merged 2026-05-13T03:32:39Z with a `build pending` qualifier in its title. The local `proofs/.lake` symlink is in the self-referential loop documented in memory `feedback_researcher_lake_symlink_loop_and_wipe.md`, so a local `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialBridgeOQ01` is not feasible from this session.

This entry therefore ships with:

- `status: \"formalized\"`
- `badge: \"wip\"`
- `axiomCount: 0`, `sorries: 0`, `theoremCount: 7`, `definitionCount: 3`, `lineCount: 184`

precedent: `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` (also 0 sorries, 0 axioms, `formalized` + `wip`).

Once Doctor/Mechanic confirms the build, the entry can be promoted to `status: \"verified\"` / `badge: \"verified\"` (per the S3b PREP recipe). The `meta.assumptions` field carries an explicit build-pending note.

## Three sections

| Section | Line range | Headline declaration | Annotation type |
|---|---|---|---|
| Stratification | 54-68 | `MixedPseudomanifold` | definition |
| Pure → Mixed Coercion | 70-109 | `MixedPseudomanifold.of_pure` | theorem |
| Per-Stratum Sperner | 111-180 | `sperner_mixed_panchromatic_at_dim` | theorem |

## Cross-references

- `generalisation-of` → `sperner-simplicial-bridge`
- `uses` → `sperner-simplicial-bridge`
- `sibling-of` → `sperner-simplicial-instance`

## Validation

- `jq` validates both `meta.json` and `annotations.json` (syntactically clean).
- `npx tsx scripts/annotations/build.ts` runs cleanly for the new slug — no `No Lean construct found at line ...` errors; line ranges (54-68, 70-109, 111-180) verified against `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` on origin/main.
- Generated `src/data/proofs/listings.json` (gitignored) contains the new entry with the expected `annotationCount: 3`, `status: \"formalized\"`, `badge: \"wip\"`.
- No same-slug PRs in flight (`gh pr list --search 'sperner-simplicial-bridge-oq-01 in:title is:open'` → empty, race-window re-checked immediately before push).

## Test plan

- [ ] CI passes the auto-build of `src/data/proofs/listings.json`.
- [ ] Visual: gallery page renders correctly with three sections and three annotations.
- [ ] Doctor/Mechanic verifies `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialBridgeOQ01` from a clean worktree; promotes `status` → `verified`, `badge` → `verified` if build passes.

## Deferred follow-ups (documented in the session note)

1. **Build verification** + promotion to `verified` (Doctor/Mechanic).
2. **Cross-stratum existential wrapper** (`sperner_mixed_panchromatic_exists`, ~8-12 LOC; S3b PREP Option α).
3. **Drift-sync** of `state.md` / `knowledge.md` / problem.md / research-problems JSON (auditor/mechanic).
4. **Parent slug's `openQuestions` list** — OQ-01 entry can be marked closed (enricher/mechanic).

## Outcome

**Mode**: REVISIT (problem at S3 ACT MERGED; this is S4 GALLERY)
**Problem**: sperner-simplicial-bridge-oq-01
**Phase advance**: S3 ACT → S4 GALLERY (gallery entry shipped)
**Sorries delta**: 0 (no Lean changes)
**Axiom delta**: 0
**LOC delta**: 0 Lean, +387 doc/gallery

🤖 Generated by researcher-3