### PR TITLE
audit(erdos-964,966,968): tracker bump — clean re-audit batch

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10865,8 +10865,8 @@
     },
     "erdos-964": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T23:57:59Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:15:00Z",
       "result": "clean"
     },
     "erdos-965": {
@@ -10877,9 +10877,9 @@
     },
     "erdos-966": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T23:56:03Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:15:01Z",
+      "result": "clean"
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
@@ -10889,8 +10889,8 @@
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T21:44:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:15:01Z",
       "result": "clean"
     },
     "erdos-969": {


### PR DESCRIPTION
## Summary

Clean re-audit batch for three Erdős problem entries that have been stale on `audit-tracker.json` since 2026-04-27. All three pass `find-targets.ts` automated integrity checks against the current Lean sources.

## Verification

| Slug      | Lean file                  | sorries | axioms | lineCount | status / badge          |
|-----------|----------------------------|---------|--------|-----------|-------------------------|
| erdos-964 | `Proofs/Erdos964Problem.lean` | 0 / 0 (meta vs actual) | 1 / 1 | 336 | `axiomatized` / `axiom` |
| erdos-966 | `Proofs/Erdos966Problem.lean` | 0 / 0 | 6 / 6 | 294 | `axiomatized` / `axiom` |
| erdos-968 | `Proofs/Erdos968Problem.lean` | 0 / 0 | 2 / 2 | 236 | `axiomatized` / `axiom` |

Per slug:
- 0 True stubs in any `theorem`/`lemma` declaration
- No structure-encoded assumption fields (only data structures, no `*Axioms` classes)
- meta.json counts match `grep` of the Lean source after comment stripping
- Tier C narrative appropriate for open Erdős problems

## Scope notes

Skipped sibling `erdos-967` (last audited 2026-05-13T07:57:44Z) and `erdos-969` (last 2026-05-13T08:05:11Z) — already re-audited today on `origin/main` (PRs #18669 and #18675). Avoiding duplicate tracker churn.

## Diff

`src/data/proofs/audit-tracker.json`: 3 entries, `auditCount` 3 → 4, `lastAudited` → 2026-05-13T08:15Z, `erdos-966` `result` `issues-fixed` → `clean` (issues from prior cycle have been fixed and never recurred).

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` reports no issues for any of the three
- [x] Diff limited to `src/data/proofs/audit-tracker.json` (7 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)