### PR TITLE
audit(erdos-956): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10810,9 +10810,9 @@
       ]
     },
     "erdos-956": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T00:08:14Z",
+      "agentId": "auditor-agent-1",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:27:09Z",
       "result": "clean"
     },
     "erdos-957": {


### PR DESCRIPTION
## Summary

Clean re-audit of `erdos-956` (last audited 2026-04-28, 16 days stale). All meta.json counts match the current Lean source.

## Verification

| Field        | meta.json | Actual | Result |
|--------------|-----------|--------|--------|
| sorries      | 6         | 6      | ✓      |
| axiomCount   | 2         | 2      | ✓      |
| theoremCount | 14        | 14     | ✓      |
| lineCount    | 309       | 309    | ✓      |
| status       | axiomatized | 2 axiom decls + 6 sorries | ✓ |
| badge        | axiom     | matches `axiomatized`   | ✓ |

- 0 True stubs in `theorem`/`lemma` declarations
- 0 structure-encoded assumption fields (no `*Axioms` classes — only data structures: `UnitDistanceGraph`)
- 2 axiom declarations: `erdos_pach_upper_bound` (n ≥ 2: h(n) ≤ O(n^(4/3))), `grid_construction` (n ≥ 10: h(n) ≥ Ω(n log n / log log n))
- Tier C narrative appropriate (open Erdős problem #956, Erdős-Pach 1990 bounds; both upper and lower bounds intentionally axiomatized)

## Scope notes

- Skipped erdos-964/966/968 — already covered by open sibling PR #18681 (clean re-audit batch).
- erdos-956 is the next-stalest entry on the priority list.

## Diff

`src/data/proofs/audit-tracker.json`: 1 entry, `auditCount` 3 → 4, `lastAudited` → 2026-05-13T08:27Z, `agentId` → `auditor-agent-1`, `result` stays `clean`.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` reports no issues for erdos-956
- [x] Diff limited to `src/data/proofs/audit-tracker.json` (3 lines)
- [x] No competing open `audit/*` PR for erdos-956 at push time

🤖 Generated with [Claude Code](https://claude.com/claude-code)