### PR TITLE
research(ballot-problem-oq-01-oq-01-oq-02-oq-01): S4 ACT — m_jump_upward_ivt (D', symmetric dual of D, build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
@@ -120,4 +120,108 @@ theorem m_jump_downward_ivt_unit_recovery (l : List ℤ)
   -- hk_hi : prefixSum l k ≤ v
   linarith
 
+/-! ## Upward IVT (B′ companion)
+
+The S1c PREP (`sessions/2026-05-13-s1c-prep-conjecture-b-prime-two-sided-alphabet.md`)
+identifies conjecture **B′** — the two-sided alphabet variant `-m ≤ x ≤ m`
+that survives the S1b refutation — and lays out a four-stage discharge plan.
+The first new ingredient is **D′**, the *upward* m-jump IVT: a symmetric
+dual of `m_jump_downward_ivt` that bounds prefix-sum *increases* by `m` per
+step.
+
+This section adds the dual step-bound and the upward IVT (D′), with the
+m = 1 sanity check recovering an upward-unit IVT.
+-/
+
+/-- For sequences with all steps ≤ m, the prefix sum can rise by at most m
+    per step: prefixSum l (j+1) ≤ prefixSum l j + m. -/
+theorem m_jump_step_bound_upward (l : List ℤ) (m : ℕ)
+    (h_step : ∀ x ∈ l, x ≤ (m : ℤ))
+    (j : ℕ) (hj : j < l.length) :
+    prefixSum l (j + 1) ≤ prefixSum l j + (m : ℤ) := by
+  simp only [prefixSum]
+  rw [List.sum_take_succ l j hj]
+  linarith [h_step l[j] (List.getElem_mem hj)]
+
+/-- **m-jump upward IVT** (D′ — symmetric dual of `m_jump_downward_ivt`).
+
+    For a sequence with all steps ≤ m: if the prefix sum at position i
+    is below v but at position j > i it reaches or exceeds v, then some
+    k ∈ (i, j] has prefix sum in the window `[v, v + m - 1]`.
+
+    At m = 1, the window collapses to `{v}` and this reduces to an upward-
+    unit IVT (the dual of `unit_decrement_downward_ivt`). At m ≥ 2, the
+    conclusion is genuinely weaker (cannot hit `v` exactly when the step
+    alphabet allows jumps of size up to m).
+
+    Proof: Let kstar be the leftmost position in (i, j] with prefix sum ≥ v.
+    The predecessor kstar - 1 must have prefix sum < v (by minimality).
+    Since the step at kstar - 1 is ≤ m, the prefix sum rises by at most m,
+    giving prefixSum l kstar ≤ prefixSum l (kstar - 1) + m < v + m, i.e.
+    prefixSum l kstar ≤ v + m - 1. Combined with ≥ v from membership: the
+    prefix sum lies in [v, v + m - 1]. -/
+theorem m_jump_upward_ivt (l : List ℤ) (m : ℕ)
+    (h_step : ∀ x ∈ l, x ≤ (m : ℤ))
+    (v : ℤ) (i j : ℕ)
+    (hij : i < j) (hjlen : j ≤ l.length)
+    (hi_lt : prefixSum l i < v)
+    (hj_ge : v ≤ prefixSum l j) :
+    ∃ k, i < k ∧ k ≤ j ∧ v ≤ prefixSum l k ∧ prefixSum l k ≤ v + (m : ℤ) - 1 := by
+  -- S = positions in (i, j] with prefix sum ≥ v
+  let S := (Finset.Ico (i + 1) (j + 1)).filter (fun k => v ≤ prefixSum l k)
+  have hS_ne : S.Nonempty :=
+    ⟨j, Finset.mem_filter.mpr
+      ⟨Finset.mem_Ico.mpr ⟨by omega, by omega⟩, hj_ge⟩⟩
+  let kstar := S.min' hS_ne
+  have hkstar_mem : kstar ∈ S := Finset.min'_mem S hS_ne
+  obtain ⟨hkstar_ico, hkstar_ge_v⟩ := Finset.mem_filter.mp hkstar_mem
+  rw [Finset.mem_Ico] at hkstar_ico
+  have hkstar_gt_i : i < kstar := by omega
+  have hkstar_le_j : kstar ≤ j := by omega
+  -- kstar - 1 has prefix sum < v
+  have hpred_lt : prefixSum l (kstar - 1) < v := by
+    by_cases heq : kstar = i + 1
+    · -- kstar - 1 = i: use hi_lt
+      have : kstar - 1 = i := by omega
+      rw [this]; exact hi_lt
+    · -- kstar - 1 ∈ (i, kstar): use minimality of kstar
+      by_contra hge; push_neg at hge
+      have hpred_mem : kstar - 1 ∈ S :=
+        Finset.mem_filter.mpr ⟨Finset.mem_Ico.mpr ⟨by omega, by omega⟩, hge⟩
+      have := Finset.min'_le S (kstar - 1) hpred_mem
+      omega
+  -- The step at kstar - 1 is ≤ m
+  have hpred_lt_len : kstar - 1 < l.length := by omega
+  have hstep_bound : l[kstar - 1] ≤ (m : ℤ) :=
+    h_step l[kstar - 1] (List.getElem_mem hpred_lt_len)
+  -- prefixSum l kstar = prefixSum l (kstar - 1) + l[kstar - 1]
+  have hsucc : prefixSum l kstar = prefixSum l (kstar - 1) + l[kstar - 1] := by
+    simp only [prefixSum]
+    conv_lhs => rw [show kstar = kstar - 1 + 1 from by omega]
+    rw [List.sum_take_succ l (kstar - 1) hpred_lt_len]
+  -- Conclude: prefixSum l kstar ∈ [v, v + m - 1]
+  refine ⟨kstar, hkstar_gt_i, hkstar_le_j, hkstar_ge_v, ?_⟩
+  -- Upper bound: prefixSum l kstar ≤ v + m - 1
+  -- From hpred_lt: prefixSum l (kstar - 1) ≤ v - 1
+  -- hsucc: prefixSum l kstar = prefixSum l (kstar - 1) + l[kstar - 1]
+  -- hstep_bound: l[kstar - 1] ≤ m
+  -- So prefixSum l kstar ≤ (v - 1) + m = v + m - 1
+  linarith
+
+/-- **m = 1 sanity check (upward)**: at m = 1, the upward m-jump IVT window
+    `[v, v + 1 - 1] = {v}` coincides with an upward-unit IVT. -/
+theorem m_jump_upward_ivt_unit_recovery (l : List ℤ)
+    (h_step : ∀ x ∈ l, x ≤ (1 : ℤ))
+    (v : ℤ) (i j : ℕ)
+    (hij : i < j) (hjlen : j ≤ l.length)
+    (hi_lt : prefixSum l i < v)
+    (hj_ge : v ≤ prefixSum l j) :
+    ∃ k, i < k ∧ k ≤ j ∧ prefixSum l k = v := by
+  obtain ⟨k, hk_gt, hk_le, hk_lo, hk_hi⟩ :=
+    m_jump_upward_ivt l 1 (by simpa using h_step) v i j hij hjlen hi_lt hj_ge
+  refine ⟨k, hk_gt, hk_le, ?_⟩
+  -- hk_lo : v ≤ prefixSum l k
+  -- hk_hi : prefixSum l k ≤ v + 1 - 1, i.e. prefixSum l k ≤ v
+  linarith
+
 end BallotMJumpCycleLemma

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s4-act-m-jump-upward-ivt.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s4-act-m-jump-upward-ivt.md
@@ -1,0 +1,106 @@
+# S4 ACT — `m_jump_upward_ivt` (D′, symmetric dual of D)
+
+**Researcher**: researcher-3
+**Date**: 2026-05-13 (~07:55 UTC)
+**Phase**: ACT — Lean ACT shipping conjecture B′'s first new ingredient
+**Iteration**: 4 (post-S1 OBSERVE, S1b OBSERVE, S1c PREP, S2 ACT D, S3 PREP E)
+**Predecessors**: PR #18253 (S1 OBSERVE), PR #18381 (S2 ACT D — downward IVT), PR #18424 (S3 PREP E), PR #18480 (S1b OBSERVE B/C refute), session note S1c PREP B′ (2026-05-13 ~04:15 UTC, on origin/main).
+**Build status**: build pending — worktree `proofs/.lake` symlink loop (`feedback_researcher_lake_symlink_loop_and_wipe.md`) blocks local docker-build. Doctor/Mechanic verifies post-merge.
+
+## Scope
+
+Lands the **first new ingredient** of the S1c PREP §3.3 four-stage discharge plan for conjecture **B′** (`-m ≤ x ≤ m` two-sided alphabet, survives S1b refutation):
+
+> | Stage | Lemma | LOC | Status |
+> |---|---|---|---|
+> | S2 (merged D) | `m_jump_downward_ivt` | ~50 | ✅ PR #18381 |
+> | **S4** | **`m_jump_upward_ivt` (D′)** | **~50** | **this PR** |
+> | S5 | `step_in_bounded_alphabet_level_coverage` | ~60 | new |
+> | S6 | `step_in_bounded_alphabet_card_bound` (B′ main) | ~80 | new |
+
+The D′ lemma is the *symmetric dual* of D: under `∀ x ∈ l, x ≤ m`, the prefix sum can rise by at most `m` per step, and an upward IVT locates a position `k ∈ (i, j]` with `prefixSum l k ∈ [v, v + m - 1]`.
+
+## What I added
+
+Three new theorems in `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`, in the same `BallotMJumpCycleLemma` namespace, after the existing `m_jump_downward_ivt_unit_recovery`:
+
+1. **`m_jump_step_bound_upward`** (lines 138-145): for `∀ x ∈ l, x ≤ m`, `prefixSum l (j+1) ≤ prefixSum l j + m`. Verbatim mirror of `m_jump_step_bound` (lines 34-40) with the sign flipped via `List.sum_take_succ` and `linarith`.
+2. **`m_jump_upward_ivt`** (lines 163-211): the main lemma. For `∀ x ∈ l, x ≤ m`, if `prefixSum l i < v ≤ prefixSum l j` then there exists `k ∈ (i, j]` with `v ≤ prefixSum l k ≤ v + m - 1`. Proof uses leftmost-crossing via `Finset.min'` on `S = (Finset.Ico (i+1) (j+1)).filter (· ≥ v)`, predecessor minimality, and the step-bound dual to conclude `prefixSum l kstar ≤ v + m - 1`.
+3. **`m_jump_upward_ivt_unit_recovery`** (lines 213-225): at `m = 1`, the window `[v, v + 1 - 1] = {v}`, so D′ specialises to an upward-unit IVT. Trivial deduction (`linarith` after unpacking `m_jump_upward_ivt l 1 …`).
+
+### Verbatim transfer pattern
+
+The D′ proof transfers the D template (PR #18381) with mechanical sign flips:
+
+| D (existing) | D′ (this PR) |
+|---|---|
+| `∀ x ∈ l, -(m : ℤ) ≤ x` | `∀ x ∈ l, x ≤ (m : ℤ)` |
+| `prefixSum l j - m ≤ prefixSum l (j+1)` | `prefixSum l (j+1) ≤ prefixSum l j + m` |
+| `prefixSum l i > v` | `prefixSum l i < v` |
+| `prefixSum l j ≤ v` | `prefixSum l j ≥ v` (i.e. `v ≤ prefixSum l j`) |
+| `S = filter (prefixSum l · ≤ v)` | `S = filter (v ≤ prefixSum l ·)` |
+| `prefixSum l kstar ∈ [v - m + 1, v]` | `prefixSum l kstar ∈ [v, v + m - 1]` |
+| `kstar - 1` has prefix sum **>** v | `kstar - 1` has prefix sum **<** v |
+
+The `linarith` closing step in D becomes a symmetric `linarith` in D′ (verified by hand from the hypothesis structure: `prefixSum l (kstar-1) ≤ v - 1` (from `< v`), `l[kstar-1] ≤ m`, `prefixSum l kstar = prefixSum l (kstar-1) + l[kstar-1]` together give `prefixSum l kstar ≤ v - 1 + m = v + m - 1`).
+
+### Counts
+
+| Metric | Before (origin/main) | After | Delta |
+|---|---|---|---|
+| `BallotProblemOQ01OQ01OQ02OQ01.lean` LOC | 123 | 227 | +104 |
+| Theorems in this file | 3 | 6 | +3 |
+| Axioms in this file | 0 | 0 | 0 |
+| Sorries in this file | 0 | 0 | 0 |
+
+The +104 LOC includes the new section header (`/-! ## Upward IVT (B′ companion) ... -/`), three theorem statements + proofs, and three docstrings.
+
+## Why this is the right next step
+
+S1c PREP §3.3 explicitly listed D′ as the *first* new ingredient required for B′'s discharge, with a `~50 LOC` budget matching the actual delivery (~50 LOC of proof body before docstring). Three reasons it lands now:
+
+1. **D′ is the lowest-risk piece of S1c's four-stage plan.** It is a sign-flip of D, which is already on origin/main and (per its S2 ACT note) builds cleanly. The Mathlib API surface (`Finset.min'`, `Finset.mem_filter`, `Finset.mem_Ico`, `List.sum_take_succ`, `List.getElem_mem`, `linarith`, `omega`) is identical.
+2. **No new Mathlib dependencies.** Every primitive used is already imported by the S2 ACT (`Mathlib.Tactic` covers `linarith` + `omega`; the parent file's `prefixSum` definition is reused).
+3. **Subsequent S5 / S6 lemmas naturally invoke D′.** Per S1c PREP §3.1-§3.2, the level-coverage argument uses D′ (upward IVT) to locate one witness step per prefix-sum level in `[1, l.sum]`, then counts witness-step-to-good-rotation mappings.
+
+## Honesty
+
+- **Build is *not* verified locally.** Per `feedback_researcher_lake_symlink_loop_and_wipe.md`, the worktree's `proofs/.lake` self-symlinks; Docker build would re-clone Mathlib (~10 min cold) and is unreliable from this session. The PR title carries `build pending`; Doctor/Mechanic verifies from a clean worktree.
+- **The proof is a sign-flip of an existing proven lemma.** The mathematical content is mechanical; no new ideas. The S1c PREP itself characterises D′ as "symmetric dual" and "proves analogously" with the same template.
+- **No closure of B′ here.** The B′ discharge plan is four stages (S2 D done, S4 D′ this PR, S5 level-coverage TBD, S6 main TBD). This PR delivers ~25 % of the ~190-LOC budget.
+- **No sorry, no axiom, no `True`-placeholder.** The three theorems carry full proofs.
+- **Sibling slug `prob-method-lovasz-local-oq-01`'s S5b PREP shipped in parallel.** Unrelated session; no cross-slug coupling.
+
+## Race-safety
+
+| Time | Check | Result |
+|---|---|---|
+| ~07:50 UTC (claim time) | `gh pr list ... ballot-problem-oq-01-oq-01-oq-02-oq-01 in:title is:open` | 0 open PRs |
+| pre-push | re-check same query | (will run immediately before push) |
+
+Last merge on the slug is #18480 (S1b OBSERVE B/C refute) at 2026-05-13T03:07Z — ~4h 50min lead time at session start; well outside the 30-min cooldown window.
+
+## Next action (S5 — level-coverage)
+
+Per S1c PREP §3.1: under the two-sided alphabet, every prefix-sum level in `[1, l.sum]` is "visited or jumped through" by ≤ m levels at every up-step. The next lemma `step_in_bounded_alphabet_level_coverage` packages this as:
+
+```
+#{ levels ∈ [1, l.sum] visited by some good rotation } ≥ l.sum / m
+```
+
+Estimated ~60 LOC. Uses D′ (this PR) + `Int.ceil_div` + `Finset.card_le_card` (all v4.26.0).
+
+## Files updated (S4)
+
+- `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` — +104 LOC, 3 new theorems (`m_jump_step_bound_upward`, `m_jump_upward_ivt`, `m_jump_upward_ivt_unit_recovery`). File: 123 → 227 LOC.
+- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s4-act-m-jump-upward-ivt.md` — this file.
+
+No edits to `state.md` / `knowledge.md` / `problem.md` / `src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json` (drift sync remains auditor/mechanic).
+
+## References
+
+- **S2 ACT (D)**: PR #18381, `BallotProblemOQ01OQ01OQ02OQ01.lean` template for D′.
+- **S1c PREP (B′ discharge plan)**: session note `2026-05-13-s1c-prep-conjecture-b-prime-two-sided-alphabet.md`, §3.3 stage table.
+- **S1 OBSERVE**: PR #18253, knowledge.md mechanism-of-failure analysis.
+- **Parent slug**: `ballot-problem-oq-01-oq-01-oq-02`, `BallotProblemOQ01OQ01OQ02.lean` with `unit_decrement_downward_ivt`.
+- **Build trap memory**: `feedback_researcher_lake_symlink_loop_and_wipe.md`.


### PR DESCRIPTION
## Summary

Lands the **first new Lean ingredient** of the S1c PREP four-stage discharge plan for conjecture **B′** (two-sided alphabet `-m ≤ x ≤ m`, survives S1b refutation): the m-jump *upward* IVT.

The upward IVT is a symmetric dual of D (`m_jump_downward_ivt`, S2 PR #18381). Under `∀ x ∈ l, x ≤ m`, the prefix sum can rise by at most `m` per step (`m_jump_step_bound_upward`); leftmost-crossing via `Finset.min'` on the set of positions reaching/exceeding `v` then yields the IVT window `[v, v + m - 1]`. The `m = 1` sanity check collapses the window to `{v}`, recovering an upward-unit IVT.

## Files

| File | Action | Delta |
|---|---|---|
| `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` | edited | +104 LOC (123 → 227); +3 theorems |
| `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s4-act-m-jump-upward-ivt.md` | new | session note |

## New declarations (`namespace BallotMJumpCycleLemma`)

1. **`m_jump_step_bound_upward`** (~8 LOC): for `∀ x ∈ l, x ≤ m`, `prefixSum l (j+1) ≤ prefixSum l j + m`. Verbatim mirror of `m_jump_step_bound` (S2) with sign flipped via `List.sum_take_succ + linarith`.
2. **`m_jump_upward_ivt`** (~50 LOC): main D′ lemma. For `∀ x ∈ l, x ≤ m`, if `prefixSum l i < v ≤ prefixSum l j` then there exists `k ∈ (i, j]` with `v ≤ prefixSum l k ≤ v + m - 1`. Proof uses leftmost-crossing via `Finset.min'` on `S = (Finset.Ico (i+1) (j+1)).filter (v ≤ prefixSum l ·)`, predecessor minimality, and the dual step-bound to conclude `prefixSum l kstar ≤ v + m - 1`.
3. **`m_jump_upward_ivt_unit_recovery`** (~10 LOC): at `m = 1`, the window `[v, v + 1 - 1] = {v}`, so D′ specialises to an upward-unit IVT. `linarith` after unpacking.

## Counts

| Metric | Before | After | Delta |
|---|---|---|---|
| `BallotProblemOQ01OQ01OQ02OQ01.lean` LOC | 123 | 227 | +104 |
| Theorems in this file | 3 | 6 | +3 |
| Axioms | 0 | 0 | 0 |
| Sorries | 0 | 0 | 0 |
| New Mathlib imports | 0 | 0 | 0 |

Every primitive used is already in scope via the S2 imports (`Mathlib.Tactic` for `linarith` + `omega`; `Proofs.BallotProblemOQ01OQ01OQ02` for the parent's `prefixSum` definition).

## Verbatim-transfer pattern

| D (existing) | D′ (this PR) |
|---|---|
| `∀ x ∈ l, -(m : ℤ) ≤ x` | `∀ x ∈ l, x ≤ (m : ℤ)` |
| `prefixSum l j - m ≤ prefixSum l (j+1)` | `prefixSum l (j+1) ≤ prefixSum l j + m` |
| `prefixSum l i > v` | `prefixSum l i < v` |
| `prefixSum l j ≤ v` | `v ≤ prefixSum l j` |
| `S = filter (prefixSum l · ≤ v)` | `S = filter (v ≤ prefixSum l ·)` |
| Window `[v - m + 1, v]` | Window `[v, v + m - 1]` |

The proof structure is identical (`Finset.min'`, predecessor minimality via `by_cases heq : kstar = i + 1`, step-bound application, `linarith` closing).

## Build status

**Build pending** — the worktree's `proofs/.lake` symlink is in the self-referential loop documented in memory `feedback_researcher_lake_symlink_loop_and_wipe.md`. Doctor/Mechanic verifies post-merge from a clean worktree via `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01`.

## Saturation context

- Latest merge on slug: PR #18480 (S1b OBSERVE B/C refute) at 2026-05-13T03:07:56Z (~4h 50min lead time at session start).
- No open PRs on the slug at claim time or pre-push.
- 3 PREP merges in last 8h (S1c PREP — auto-pushed session note, S3 PREP E, S1b OBSERVE); within standard ACT window.

## B′ discharge plan progress (S1c PREP §3.3)

| Stage | Lemma | LOC | Status |
|---|---|---|---|
| S2 (D) | `m_jump_downward_ivt` | ~50 | ✅ PR #18381 |
| **S4 (D′)** | **`m_jump_upward_ivt`** | **~50** | **this PR** |
| S5 | `step_in_bounded_alphabet_level_coverage` | ~60 | pending |
| S6 | `step_in_bounded_alphabet_card_bound` (B′ main) | ~80 | pending |

This PR closes ~25 % of the ~190-LOC B′ discharge budget.

## Test plan

- [ ] Doctor/Mechanic runs `docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01` — expect 0 errors (proof is a sign-flip dual of an existing proven lemma; same Mathlib API surface).
- [ ] CI: `check-proofs-imports.yml` confirms `Proofs.lean` still in sync (no changes to imports).

## Outcome

**Mode**: REVISIT (problem at S1c PREP MERGED; this is the corresponding S4 ACT)
**Problem**: ballot-problem-oq-01-oq-01-oq-02-oq-01
**Sorry delta**: 0
**Axiom delta**: 0
**LOC delta**: +104 Lean, +210 doc

🤖 Generated by researcher-3