### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05 (Shafarevich): +10 cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -43,6 +43,46 @@
       {
         "id": "abel-ruffini",
         "relationship": "Foundational file: proves polynomials solvable by radicals ↔ Galois group solvable — Abel-Ruffini's theorem"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Sister entry (Wiedijk #71). The general inverse Galois problem over ℚ. Shafarevich's theorem proven here is the solvable-group case of this problem; the non-solvable case (e.g., realizing the Monster group over ℚ) remains open in full generality."
+      },
+      {
+        "id": "inverse-galois-a5",
+        "relationship": "Concrete realization of A₅ over ℚ — proves Gal(x⁵-4x+2/ℚ) ≅ S₅, with A₅ recovered as the kernel of the sign character. Shows A₅ IS realizable over ℚ (so the inverse-Galois problem is positive for A₅), but NOT via Shafarevich since A₅ is non-solvable."
+      },
+      {
+        "id": "inverse-galois-d4",
+        "relationship": "Concrete realization of the dihedral group D₄ ≅ Gal(X⁴-2/ℚ) over ℚ. D₄ is solvable (derived series D₄ ⊃ ⟨r⟩ ⊃ ⟨r²⟩ ⊃ 1 with cyclic quotients), so its realizability also follows from Shafarevich — but here the witness is given by Eisenstein irreducibility on X⁴-2, an explicit polynomial."
+      },
+      {
+        "id": "inverse-galois-f20",
+        "relationship": "Concrete realization of the Frobenius group F₂₀ = ℤ/5 ⋊ ℤ/4 ≅ Gal(X⁵-2/ℚ) over ℚ. F₂₀ is solvable, so realizable via Shafarevich, but here the witness is the explicit polynomial X⁵-2 (whose roots are ζ₅^k·⁵√2 for k=0..4). Together with `inverse-galois-a5` exhibits the degree-5 solvable/non-solvable dichotomy."
+      },
+      {
+        "id": "inverse-galois-oq-06",
+        "relationship": "Sister entry in the inverse-Galois branch. Alternative S₅ realization via Eisenstein at p=5 + Vandermonde discriminant + Dedekind axiom, complementing the irreducibility-and-galActionHom approach in inverse-galois-a5."
+      },
+      {
+        "id": "kroneckers-jugendtraum",
+        "relationship": "Foundational for the abelian base case of Shafarevich's induction: the Kronecker-Weber theorem (subsumed under the Jugendtraum) realizes every finite abelian group A ⊆ Gal(ℚ(ζ_n)/ℚ) ≅ (ℤ/n)* as a Galois group over ℚ via cyclotomic extensions. Shafarevich's proof bootstraps from this base case using derived-series induction and embedding-problem theory."
+      },
+      {
+        "id": "primitive-roots",
+        "relationship": "Provides the cyclotomic structure underlying the abelian base case of Shafarevich's induction. The Galois group of ℚ(ζ_n)/ℚ is (ℤ/n)* with generators given by primitive roots mod n — the concrete realization of cyclic groups ℤ/n as Galois groups over ℚ that the cyclic-group corollary of Shafarevich asserts in the abstract."
+      },
+      {
+        "id": "sylow-theorems",
+        "relationship": "Sylow theory is the engine of the structure theorems used in Shafarevich's induction. Every finite p-group is nilpotent (hence solvable) with chief factors of order p; the derived series of a general solvable group can be analyzed via Sylow filtrations, and the embedding problems Shafarevich solves at each step decompose along Sylow subgroups."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-01",
+        "relationship": "Cousin entry providing the contrast: a concrete unsolvable Galois group over ℚ. Proves Gal(x⁵-4x+2/ℚ) ≅ S₅ (axiom-free, 0 sorries), exhibiting an explicit non-solvable group as a Galois group over ℚ — outside the scope of Shafarevich's solvable-group theorem but within the (open) general inverse-Galois problem."
+      },
+      {
+        "id": "lagrange-theorem",
+        "relationship": "Lagrange's theorem (|H| divides |G|) underlies the closure-under-subgroups-and-quotients corollaries proved here: if H ≤ G with G solvable, then |H| | |G| and H inherits solvability via the induced derived series H^(k) ≤ G^(k); the same applies to quotients."
       }
     ]
   },
@@ -129,6 +169,46 @@
     {
       "proofId": "abel-ruffini",
       "relationship": "Grandparent: proves the polynomial-theoretic side (solvable by radicals ↔ solvable Galois group), completing the bidirectional characterization"
+    },
+    {
+      "proofId": "inverse-galois",
+      "relationship": "Sister entry (Wiedijk #71). The general inverse Galois problem over ℚ. Shafarevich's theorem proven here is the solvable-group case of this problem; the non-solvable case (e.g., realizing the Monster group over ℚ) remains open in full generality."
+    },
+    {
+      "proofId": "inverse-galois-a5",
+      "relationship": "Concrete realization of A₅ over ℚ — proves Gal(x⁵-4x+2/ℚ) ≅ S₅, with A₅ recovered as the kernel of the sign character. Shows A₅ IS realizable over ℚ (so the inverse-Galois problem is positive for A₅), but NOT via Shafarevich since A₅ is non-solvable."
+    },
+    {
+      "proofId": "inverse-galois-d4",
+      "relationship": "Concrete realization of the dihedral group D₄ ≅ Gal(X⁴-2/ℚ) over ℚ. D₄ is solvable (derived series D₄ ⊃ ⟨r⟩ ⊃ ⟨r²⟩ ⊃ 1 with cyclic quotients), so its realizability also follows from Shafarevich — but here the witness is given by Eisenstein irreducibility on X⁴-2, an explicit polynomial."
+    },
+    {
+      "proofId": "inverse-galois-f20",
+      "relationship": "Concrete realization of the Frobenius group F₂₀ = ℤ/5 ⋊ ℤ/4 ≅ Gal(X⁵-2/ℚ) over ℚ. F₂₀ is solvable, so realizable via Shafarevich, but here the witness is the explicit polynomial X⁵-2 (whose roots are ζ₅^k·⁵√2 for k=0..4). Together with `inverse-galois-a5` exhibits the degree-5 solvable/non-solvable dichotomy."
+    },
+    {
+      "proofId": "inverse-galois-oq-06",
+      "relationship": "Sister entry in the inverse-Galois branch. Alternative S₅ realization via Eisenstein at p=5 + Vandermonde discriminant + Dedekind axiom, complementing the irreducibility-and-galActionHom approach in inverse-galois-a5."
+    },
+    {
+      "proofId": "kroneckers-jugendtraum",
+      "relationship": "Foundational for the abelian base case of Shafarevich's induction: the Kronecker-Weber theorem (subsumed under the Jugendtraum) realizes every finite abelian group A ⊆ Gal(ℚ(ζ_n)/ℚ) ≅ (ℤ/n)* as a Galois group over ℚ via cyclotomic extensions. Shafarevich's proof bootstraps from this base case using derived-series induction and embedding-problem theory."
+    },
+    {
+      "proofId": "primitive-roots",
+      "relationship": "Provides the cyclotomic structure underlying the abelian base case of Shafarevich's induction. The Galois group of ℚ(ζ_n)/ℚ is (ℤ/n)* with generators given by primitive roots mod n — the concrete realization of cyclic groups ℤ/n as Galois groups over ℚ that the cyclic-group corollary of Shafarevich asserts in the abstract."
+    },
+    {
+      "proofId": "sylow-theorems",
+      "relationship": "Sylow theory is the engine of the structure theorems used in Shafarevich's induction. Every finite p-group is nilpotent (hence solvable) with chief factors of order p; the derived series of a general solvable group can be analyzed via Sylow filtrations, and the embedding problems Shafarevich solves at each step decompose along Sylow subgroups."
+    },
+    {
+      "proofId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "Cousin entry providing the contrast: a concrete unsolvable Galois group over ℚ. Proves Gal(x⁵-4x+2/ℚ) ≅ S₅ (axiom-free, 0 sorries), exhibiting an explicit non-solvable group as a Galois group over ℚ — outside the scope of Shafarevich's solvable-group theorem but within the (open) general inverse-Galois problem."
+    },
+    {
+      "proofId": "lagrange-theorem",
+      "relationship": "Lagrange's theorem (|H| divides |G|) underlies the closure-under-subgroups-and-quotients corollaries proved here: if H ≤ G with G solvable, then |H| | |G| and H inherits solvability via the induced derived series H^(k) ≤ G^(k); the same applies to quotients."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Enrichment pass on the Shafarevich gallery entry. The cross-reference inventory was thin (2 entries: parent `abel-ruffini-galois-extensions` and grandparent `abel-ruffini`). This PR brings it to 12 by adding 10 entries that situate Shafarevich's solvable-group inverse-Galois theorem within the broader Galois landscape.

## Cross-references added (paired in `crossReferences` and `meta.relatedProblems`)

**Sister inverse-Galois entries:**
- **`inverse-galois`** (Wiedijk #71) — the general inverse-Galois problem; Shafarevich's theorem is its solvable-group case.
- **`inverse-galois-a5`** — concrete $\text{Gal}(x^5-4x+2/\mathbb{Q}) \cong S_5$. Shows $A_5$ IS realizable over $\mathbb{Q}$, but *not* via Shafarevich (non-solvable).
- **`inverse-galois-d4`** — concrete $\text{Gal}(X^4-2/\mathbb{Q}) \cong D_4$. Solvable, so also reachable via Shafarevich, but here exhibited via Eisenstein.
- **`inverse-galois-f20`** — concrete $\text{Gal}(X^5-2/\mathbb{Q}) \cong F_{20} = \mathbb{Z}/5 \rtimes \mathbb{Z}/4$. Solvable, so realizable via Shafarevich; the explicit polynomial is $X^5-2$.
- **`inverse-galois-oq-06`** — alternative $S_5$ realization via Eisenstein at $p=5$ + Vandermonde discriminant.

**Abelian base-case foundations:**
- **`kroneckers-jugendtraum`** — Kronecker-Weber subsumed under the Jugendtraum realizes every finite abelian $A \subseteq \text{Gal}(\mathbb{Q}(\zeta_n)/\mathbb{Q}) \cong (\mathbb{Z}/n)^*$ over $\mathbb{Q}$. Shafarevich's induction bootstraps from this.
- **`primitive-roots`** — concrete cyclotomic realization of cyclic groups; the structure $\text{Gal}(\mathbb{Q}(\zeta_n)/\mathbb{Q}) \cong (\mathbb{Z}/n)^*$ has generators given by primitive roots mod $n$.

**Structural foundations of solvability:**
- **`sylow-theorems`** — derived-series filtrations Shafarevich analyses decompose along Sylow subgroups; every finite $p$-group is solvable.
- **`lagrange-theorem`** — underlies the closure-under-subgroups-and-quotients corollaries proven in the Shafarevich file.

**Contrast on the unsolvable side:**
- **`abel-ruffini-oq-04-oq-01`** — concrete non-solvable Galois group ($\text{Gal}(x^5-4x+2) \cong S_5$, 0 axioms, 0 sorries), exhibiting an explicit non-solvable Galois group over $\mathbb{Q}$ — outside Shafarevich's solvable-group theorem but within the (open) general inverse-Galois problem.

## Verification

- ✅ `pnpm build` succeeds (`✓ built in 30.60s`)
- ✅ JSON validates (`python3 -m json.tool`)
- ✅ All 10 cross-referenced slugs exist in `src/data/proofs/`
- ✅ Used the existing `{proofId, relationship}` schema (matching the 2 prior entries on this file, distinct from the `{targetId, relationship, description}` shape used by some other files)
- ✅ Axiom/status fields untouched (status `axiomatized`, badge `axiom`, axiomCount 1, sorries 0 — unchanged)
- ✅ No conflicting open PRs on this slug

## Test plan

- [x] `pnpm build` passes
- [x] JSON validates
- [x] All 10 target slugs resolve to existing `src/data/proofs/<slug>/` directories
- [x] `crossReferences` count: 2 → 12; `meta.relatedProblems` count: 2 → 12