### PR TITLE
audit(erdos-943,950,942,94-oq-02): tracker bump — clean re-audit batch

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10699,10 +10699,10 @@
       "result": "clean"
     },
     "erdos-94-oq-02": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-28T03:38:49Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:34:03Z",
+      "result": "clean",
+      "agentId": "auditor-2026-05-13-batch"
     },
     "erdos-940": {
       "agentId": "auditor-cycle-20-batch",
@@ -10717,16 +10717,16 @@
       "result": "issues-fixed"
     },
     "erdos-942": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T03:44:36Z",
+      "agentId": "auditor-2026-05-13-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:34:03Z",
       "result": "clean"
     },
     "erdos-943": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T03:05:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-13-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:34:03Z",
+      "result": "clean"
     },
     "erdos-944": {
       "agentId": "auditor-cycle-20-batch",
@@ -10771,9 +10771,9 @@
       "result": "clean"
     },
     "erdos-950": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T03:36:11Z",
+      "agentId": "auditor-2026-05-13-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T08:34:03Z",
       "result": "clean"
     },
     "erdos-951": {


### PR DESCRIPTION
## Summary

Re-audit and tracker bump for 4 next-tier gallery entries last audited 2026-04-28 (~15 days ago). All four verified clean against their Lean sources.

## Verification

| slug              | status      | axioms | sorries | lines | thm | def    | check |
|-------------------|-------------|--------|---------|-------|-----|--------|-------|
| erdos-943         | axiomatized | 1 ✓    | 0 ✓     | 132 ✓ | 6 ✓ | 3 ✓    | clean |
| erdos-950         | axiomatized | 2 ✓    | 0 ✓     | 225 ✓ | 8 ✓ | 10 ✓   | clean |
| erdos-942         | axiomatized | 3 ✓    | 0 ✓     | 144 ✓ | 1 ✓ | 2 ✓    | clean |
| erdos-94-oq-02    | axiomatized | 3 ✓    | 2 ✓     | 212 ✓ | 8 ✓ | 13 ✓ † | clean |

† 12 `def` + 1 `abbrev Point`, consistent with `definitionCount: 13` (file `proofs/Proofs/Erdos94OQ02.lean`).

## Checks Run

- True-stub detection: 0 stubs in all four files
- Sorry count match: ✓ (incl. erdos-94-oq-02's 2 sorries correctly disclosed in `assumptions`)
- Axiom count match: ✓
- Badge tier appropriateness: all `axiomatized/axiom` — correct, since each declares ≥1 `axiom`
- Mathlib-wrapper overclaim: none detected

## Tracker Change

For each slug: `agentId` → `auditor-2026-05-13-batch`, `auditCount` 3→4, `lastAudited` → today, `result` → `clean`. erdos-94-oq-02 + erdos-943 had been `issues-fixed`; both confirmed fixed and now clean.

## Companion to

- #18681 audit(erdos-964,966,968): tracker bump — clean re-audit batch
- #18692 audit(erdos-956): tracker bump — clean re-audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)