### PR TITLE
audit(erdos-2-oq-01): fix sorry count drift (1 → 0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5189,10 +5189,10 @@
       "result": "clean"
     },
     "erdos-2-oq-01": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-28T03:43:36Z",
-      "result": "clean"
+      "lastAudited": "2026-05-13T08:40:00Z",
+      "result": "issues-fixed"
     },
     "erdos-20": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -18,7 +18,7 @@
       "extension"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 2,
     "erdosUrl": "https://erdosproblems.com/2",
     "erdosProblemStatus": "open-question",


### PR DESCRIPTION
## Gallery Integrity Issue (HIGH severity)

**Proof**: `erdos-2-oq-01` (Exact Maximum Minimum Modulus for Covering Systems)

**Mismatch**: meta.json `sorries: 1` but `proofs/Proofs/Erdos2OQ01.lean` has **0 sorries**.

The `assumptions` field in the same meta.json already read \"0 sorry(s)\" — the top-level `sorries: 1` was internally inconsistent on its face.

## Evidence

```
$ grep -c "sorry" proofs/Proofs/Erdos2OQ01.lean
0
$ grep -cE "^theorem |^lemma " proofs/Proofs/Erdos2OQ01.lean
18           # matches theoremCount: 18 ✓
$ grep -cE "^def |^noncomputable def " proofs/Proofs/Erdos2OQ01.lean
2            # matches definitionCount: 2 ✓
$ wc -l proofs/Proofs/Erdos2OQ01.lean
232          # matches lineCount: 232 ✓
```

Axioms (3) are inherited from parent `Proofs/Erdos2Problem.lean`:
- `balister_bound`
- `owens_construction`
- `reciprocal_sum_ge_one`

matching `axiomCount: 3`. No structures declare assumption-bearing fields, so the count is complete.

## Changes

- `src/data/proofs/erdos-2-oq-01/meta.json`: `sorries: 1` → `sorries: 0`
- `src/data/proofs/audit-tracker.json`: bump `erdos-2-oq-01` (auditCount 8 → 9, lastAudited → 2026-05-13T08:40Z, result → issues-fixed)

`status: \"axiomatized\"` and `badge: \"axiom\"` remain accurate — the 3 inherited axioms keep this Tier C / axiomatized.

---
Discovered during gallery integrity audit (2026-05-13).