### PR TITLE
fix(mechanic): align angle-trisection actionItems schema with gallery

### DIFF
--- a/src/data/proofs/angle-trisection/review.json
+++ b/src/data/proofs/angle-trisection/review.json
@@ -167,35 +167,35 @@
     {
       "id": "action-1",
       "description": "Update annotations to remove stale 'Axiom 1/2/3' references and reflect current code where wantzel_theorem is derived from definition and irreducibility is imported from companion file",
-      "targetAgent": "enricher",
+      "target": "enricher",
       "priority": "medium",
       "status": "resolved"
     },
     {
       "id": "action-2",
       "description": "Correct meta.json counts: theoremCount should be 23, defCount/definitionCount should be 6. Verify or remove '37 declarations' claim in overview text.",
-      "targetAgent": "enricher",
+      "target": "enricher",
       "priority": "medium",
       "status": "resolved"
     },
     {
       "id": "action-3",
       "description": "Clarify transitive axiom dependency in assumptions field: angle trisection and cube doubling are fully axiom-free, but lindemann_pi_transcendental depends on axiomatized pi_transcendental in PiTranscendental.lean",
-      "targetAgent": "enricher",
+      "target": "enricher",
       "priority": "medium",
       "status": "resolved"
     },
     {
       "id": "action-4",
       "description": "Formalize the full circle squaring impossibility: prove that for all d > 0, sqrt(pi) is not constructible, using pi transcendence to show sqrt(pi) has no finite minimal polynomial degree over Q",
-      "targetAgent": "researcher",
+      "target": "researcher",
       "priority": "low",
       "status": "open"
     },
     {
       "id": "action-5",
       "description": "Add Mathlib.Tactic and Mathlib.RingTheory.Polynomial.IrreducibleRing to mathlibDependencies list in meta.json",
-      "targetAgent": "enricher",
+      "target": "enricher",
       "priority": "low",
       "status": "resolved"
     }


### PR DESCRIPTION
## Fix

Rename the legacy `targetAgent` key to the canonical `target` key on all 5 `actionItems` in `src/data/proofs/angle-trisection/review.json`.

## Evidence

`angle-trisection/review.json` was the lone outlier in the gallery — its 5 `actionItems` used the legacy field name `targetAgent`, while the canonical field name `target` is used by **316 action items across the other 60 review.json files**. The 5 outliers contributed the only `unknown`-target entries in `pnpm tsx scripts/peer-reviewer/find-targets.ts` aggregations.

**Before** (pre-fix, gallery-wide actionItems key usage):

```
{ target: 316, targetAgent: 5 }   # 5 == angle-trisection
```

**After** (post-fix):

```
{ target: 321 }                   # uniform
```

Per-item rename (`targetAgent` -> `target`, value preserved):

| id | value |
|---|---|
| action-1 | enricher |
| action-2 | enricher |
| action-3 | enricher |
| action-4 | researcher |
| action-5 | enricher |

## Scope

- **Touched**: `src/data/proofs/angle-trisection/review.json` only (5 line renames, no net JSON change).
- **Left alone**: the 9 `findings[].targetAgent` entries in the same file. `findings.target*` has no canonical analogue across the gallery (only this one file uses any target-like key in findings), so renaming there would invent a new schema rather than align with an existing one. Out of scope per mechanic minimal-diff discipline.
- **No Lean files, no scripts, no other review.json files touched.**

## Validation

```
$ python3 -c "import json; json.load(open('src/data/proofs/angle-trisection/review.json'))" && echo OK
OK
$ python3 -c "
import json, glob, collections
ki = collections.Counter()
for f in glob.glob('src/data/proofs/*/review.json'):
    d = json.load(open(f))
    for item in d.get('actionItems', []):
        for k in ('target','targetAgent'):
            if k in item: ki[k] += 1
print(dict(ki))
"
{'target': 321}
```

---
Automated fix by lean-mechanic agent.