### PR TITLE
fix(meta): schauder-fp-oq03-oq01 sync meta sub-block lineCount 1119→1218, theoremCount 11→13

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1119,
+    "lineCount": 1218,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -63,7 +63,7 @@
     ],
     "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free, but it transitively depends on the sorry-stubbed `exists_continuous_proj_convex` helper pending S11.B — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 4
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` / `meta.theoremCount` to current `leanFile.*` after S18d/S18e/S18f/S19 ACT merges.

PR #18646 (S19 ACT step (a) — closed-image helper) explicitly handed off this drift:

> Top-level `.meta.lineCount` / `.meta.theoremCount` drift unchanged (auditor/mechanic's drift-sync domain).

## Evidence

| Field         | meta.sub (before) | meta.sub (after) | lf (correct) |
|---------------|-------------------|------------------|--------------|
| lineCount     | 1119              | 1218             | 1218         |
| theoremCount  | 11                | 13               | 13           |

Verified locally:

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1218 proofs/Proofs/SchauderFixedPointOQ03OQ01.lean

$ grep -cE "^(theorem|lemma|private theorem|private lemma) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
13
```

13 declarations: `uhc_local_thickening`, `uhc_local_thickening_with_input_diameter`, `exists_continuous_proj_convex`, `brouwer_fpt`, `convex_combination_of_partition_in_S`, `typeclass_witnesses_compact_subset`, `exists_finite_subcover_for_uhc`, `exists_partition_subordinate_to_uhc_cover`, `exists_continuous_selection_with_witnesses`, `image_subtype_isClosed_of_isClosed_of_compact`, `seq_compact_of_compact`, `approx_fixedpoint_implies_fixedpoint`, `kakutani_from_brouwer`.

`axiomCount` (2), `definitionCount` (4), `sorries` (0) match across both blocks — no other drift detected.

## Scope

Pure metadata sync. Touches only `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json`. No Lean files, no `audit-tracker.json`, no scripts. Diff is exactly two `-` / two `+` lines.

Continuation of #17950 (the previous meta-sub sync at 957/9 after S18a/b/c).

## Validation

```
$ python3 -c "import json; json.load(open('src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json'))" && echo "JSON valid"
JSON valid
```

---
Automated fix by lean-mechanic agent.