### PR TITLE
fix(mechanic): add missing review-tracker entries for euler-polyhedral-formula + fermats-last-theorem

### DIFF
--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -480,6 +480,22 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "euler-polyhedral-formula": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-24T21:00:00Z",
+      "overallGrade": "B",
+      "qualityScore": 7.0,
+      "actionItems": 6,
+      "resolvedItems": 5
+    },
+    "fermats-last-theorem": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-23T14:00:00Z",
+      "overallGrade": "B-",
+      "qualityScore": 6.0,
+      "actionItems": 3,
+      "resolvedItems": 2
     }
   }
 }


### PR DESCRIPTION
## Fix

Two gallery proofs have peer-reviewer review.json files but no entry in `src/data/proofs/review-tracker.json`, causing `scripts/peer-reviewer/find-targets.ts` to treat them as never-reviewed.

## Evidence

**Before**: scan over `src/data/proofs/*/review.json` finds 2 entries with `reviewer == 'peer-reviewer'` missing from tracker:

| Slug | reviewDate | grade | overall | actionItems | resolved |
|------|-----------|-------|---------|-------------|----------|
| euler-polyhedral-formula | 2026-03-24T21:00:00Z | B | 7.0 | 6 | 5 |
| fermats-last-theorem | 2026-03-23T14:00:00Z | B- | 6.0 | 3 | 2 |

Values from each slug's `review.json`: `overallAssessment.grade`, `qualityScores.overall`, `len(actionItems)`, `sum(a.status == 'resolved')`.

**After**: both entries present with `reviewCount: 1`. find-targets.ts will now correctly classify them as reviewed.

## Scope

Orthogonal to the three in-flight mechanic PRs:
- #18684 modifies counts in 60 existing entries (no overlap with appended new entries)
- #18708 schema rename in `src/data/proofs/angle-trisection/review.json` (different file)
- #18716 grade flip on `hilbert-15` entry (different slug)

Other review.json files without tracker entries (`ballot-problem-oq-01-oq-04` empty `{}`, `erdos-36`/`erdos-444` legacy enricher schema) are intentionally left for separate triage — only peer-reviewer reviews are tracked here.

---
Automated fix by lean-mechanic agent.