### PR TITLE
fix(mechanic): sync review-tracker qualityScore drift (43 entries)

### DIFF
--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -5,7 +5,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T00:30:06Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -37,7 +37,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T01:34:04Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -45,7 +45,7 @@
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T03:31:21Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -53,7 +53,7 @@
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T04:32:36Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 8.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -69,7 +69,7 @@
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T05:31:54Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 6.2,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -77,7 +77,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T05:39:33Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.8,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -85,7 +85,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:31:41Z",
       "overallGrade": "C",
-      "qualityScore": null,
+      "qualityScore": 5.5,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -93,7 +93,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:38:47Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.8,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -101,7 +101,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T07:31:13Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 5.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -109,7 +109,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T08:32:27Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -117,7 +117,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T09:32:17Z",
       "overallGrade": "B",
-      "qualityScore": null,
+      "qualityScore": 7.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -125,7 +125,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T10:31:52Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -133,7 +133,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T11:31:59Z",
       "overallGrade": "D+",
-      "qualityScore": null,
+      "qualityScore": 4.2,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -141,7 +141,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T14:35:25Z",
       "overallGrade": "C",
-      "qualityScore": null,
+      "qualityScore": 6.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -149,7 +149,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:33:11Z",
       "overallGrade": "C",
-      "qualityScore": null,
+      "qualityScore": 5.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -157,7 +157,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:41:27Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 6.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -165,7 +165,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:38:16Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -189,7 +189,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T16:40:33Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 5.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -285,7 +285,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T17:32:42Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.8,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -293,7 +293,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T18:37:05Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.5,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -301,7 +301,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T19:32:53Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -309,7 +309,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T20:32:37Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 8.2,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -317,7 +317,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T21:37:33Z",
       "overallGrade": "A-",
-      "qualityScore": null,
+      "qualityScore": 8.5,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -325,7 +325,7 @@
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T23:32:03Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 5.8,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -333,7 +333,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:38:18Z",
       "overallGrade": "A-",
-      "qualityScore": null,
+      "qualityScore": 8.2,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -341,7 +341,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:33:41Z",
       "overallGrade": "B",
-      "qualityScore": null,
+      "qualityScore": 7.2,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -349,7 +349,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:34:20Z",
       "overallGrade": "A-",
-      "qualityScore": null,
+      "qualityScore": 8.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -357,7 +357,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:38:33Z",
       "overallGrade": "B",
-      "qualityScore": null,
+      "qualityScore": 7.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -365,7 +365,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:33:12Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 8.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -373,7 +373,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:37:03Z",
       "overallGrade": "B",
-      "qualityScore": null,
+      "qualityScore": 7.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -381,7 +381,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T03:38:16Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -389,7 +389,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T04:34:12Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.8,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -397,7 +397,7 @@
       "reviewCount": 2,
       "lastReviewed": "2026-03-25T06:32:34Z",
       "overallGrade": "B",
-      "qualityScore": null,
+      "qualityScore": 7.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -405,7 +405,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T05:38:48Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.4,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -413,7 +413,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T06:43:08Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 7.0,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -421,7 +421,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T07:32:47Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 8.3,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -429,7 +429,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T08:33:48Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -437,7 +437,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T09:32:56Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 8.1,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -445,7 +445,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T10:32:33Z",
       "overallGrade": "B-",
-      "qualityScore": null,
+      "qualityScore": 6.9,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -453,7 +453,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T11:42:52Z",
       "overallGrade": "A-",
-      "qualityScore": null,
+      "qualityScore": 8.4,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -461,7 +461,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T12:44:41Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.6,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -469,7 +469,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T13:44:16Z",
       "overallGrade": "B+",
-      "qualityScore": null,
+      "qualityScore": 7.7,
       "actionItems": 0,
       "resolvedItems": 0
     },
@@ -477,7 +477,7 @@
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T14:44:32Z",
       "overallGrade": "C+",
-      "qualityScore": null,
+      "qualityScore": 6.1,
       "actionItems": 0,
       "resolvedItems": 0
     }


### PR DESCRIPTION
## Fix

Populate `qualityScore` in `src/data/proofs/review-tracker.json` for 43 entries where the tracker held `null` but the source-of-truth `<slug>/review.json::qualityScores.overall` was populated.

## Evidence

**Drift census** (script-scan over all 60 `entries` keys):

```
qs_drift_null (tracker null, review populated, need fix): 43
qs_drift_diff (both populated, differ):                    0
both null (no fix):                                        0
both match (no fix):                                      17
```

**Sample sync** (full list of 43 in the diff):

| Slug                                  | tracker | review.json.qualityScores.overall |
|---------------------------------------|---------|-----------------------------------|
| `abel-ruffini-oq-04`                  | `null`  | `6.0`                             |
| `abel-ruffini`                        | `null`  | `7.7`                             |
| `amgm-inequality`                     | `null`  | `7.7`                             |
| `area-of-circle-oq-01-oq-02-oq-01`    | `null`  | `8.0`                             |
| `hilbert-15`                          | `null`  | `6.7`                             |
| ... (38 more)                          |         |                                   |

## Scope

- **Touched**: 43 single-line value changes in `src/data/proofs/review-tracker.json` (`qualityScore: null` → `qualityScore: <float>`).
- **Orthogonal to PR #18684** (`actionItems`/`resolvedItems` sync, 60 entries) — leaves those fields untouched.
- **Orthogonal to PR #18716** (`hilbert-15.overallGrade` C → B-) — only touches `qualityScore`, not `overallGrade`. PR #18716's body explicitly flagged this exact drift as out-of-scope.
- **No** Lean files, scripts, or other JSON files touched.

## Validation

```
$ git diff --stat src/data/proofs/review-tracker.json
 src/data/proofs/review-tracker.json | 86 ++++++++++++++++++-------------------
 1 file changed, 43 insertions(+), 43 deletions(-)

$ git diff src/data/proofs/review-tracker.json | grep -c '^+.*qualityScore'
43
$ git diff src/data/proofs/review-tracker.json | grep -c '^-.*qualityScore'
43
$ git diff src/data/proofs/review-tracker.json | grep -E '^[+-]' | grep -v qualityScore | head
--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
# (only file-path headers; every changed line is a qualityScore field)

$ python3 -c "import json; json.load(open('src/data/proofs/review-tracker.json')); print('JSON valid')"
JSON valid
```

---
Automated fix by lean-mechanic agent.