### PR TITLE
fix(mechanic): remove 9 stale top-level slug keys from enrichment-tracker.json

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7126,56 +7126,5 @@
       "lastEnriched": "2026-05-04T08:09:35Z",
       "quality": 98
     }
-  },
-  "elementary-quadratic-reciprocity-oq-03-oq-03": {
-    "passes": 1,
-    "quality": 90,
-    "lastEnriched": "2026-04-02",
-    "status": "enriched"
-  },
-  "roth-theorem-k3-oq-03": {
-    "passes": 1,
-    "quality": 90,
-    "lastEnriched": "2026-04-02",
-    "status": "enriched"
-  },
-  "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
-    "passes": 1,
-    "quality": 88,
-    "lastEnriched": "2026-04-21",
-    "status": "enriched"
-  },
-  "szemeredi-hypergraph-core-oq-01-incomplete-01": {
-    "passes": 1,
-    "quality": 93,
-    "lastEnriched": "2026-04-21",
-    "status": "enriched"
-  },
-  "ballot-problem-oq-03-oq-01-oq-02": {
-    "passes": 1,
-    "quality": 85,
-    "lastEnriched": "2026-04-21",
-    "status": "enriched"
-  },
-  "binomial-theorem-oq-02-oq-01-oq-01": {
-    "passes": 1,
-    "quality": 80,
-    "lastEnriched": "2026-04-21",
-    "status": "enriched"
-  },
-  "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
-    "passes": 1,
-    "lastEnriched": "2026-04-26T12:10:19Z",
-    "quality": 100
-  },
-  "de-moivre-oq-02-oq-02": {
-    "passes": 1,
-    "lastEnriched": "2026-05-03T22:01:18.789Z",
-    "quality": 100
-  },
-  "desargues-theorem-oq-01-oq-01": {
-    "passes": 1,
-    "lastEnriched": "2026-05-03T22:01:46.445Z",
-    "quality": 100
   }
 }


### PR DESCRIPTION
## Fix

Delete 9 legacy slug-named keys at the **top level** of
\`src/data/proofs/enrichment-tracker.json\`. The canonical schema is
\`{version: 1, entries: { <slug>: {...}, ... } }\` — every script reads
\`tracker.entries[<slug>]\` and never the top level, so these keys were
data drift invisible to all consumers.

## Evidence

**Drift census** (top-level keys other than \`version\` and \`entries\`):

| Slug | top-level value | also in \`entries[]\`? |
|---|---|---|
| \`elementary-quadratic-reciprocity-oq-03-oq-03\` | \`{passes:1, quality:90, lastEnriched:"2026-04-02"}\` | yes — \`{passes:2, quality:100, lastEnriched:2026-04-22}\` (fresher) |
| \`roth-theorem-k3-oq-03\` | \`{passes:1, quality:90}\` | yes — \`{passes:2, quality:100}\` |
| \`arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02\` | \`{passes:1, quality:88}\` | yes — \`{quality:100}\` |
| \`szemeredi-hypergraph-core-oq-01-incomplete-01\` | \`{passes:1, quality:93}\` | yes — \`{quality:100}\` |
| \`ballot-problem-oq-03-oq-01-oq-02\` | \`{passes:1, quality:85}\` | yes — \`{quality:100}\` |
| \`binomial-theorem-oq-02-oq-01-oq-01\` | \`{passes:1, quality:80}\` | yes — \`{quality:100}\` |
| \`desargues-theorem-oq-01-oq-01\` | \`{passes:1, quality:100}\` | yes — \`{passes:4, quality:26, lastEnriched:2026-05-03}\` |
| \`angle-trisection-oq-02-oq-01-oq-02-incomplete-01\` | \`{passes:1, quality:100}\` | **no** (orphan record) |
| \`de-moivre-oq-02-oq-02\` | \`{passes:1, quality:100}\` | **no** (orphan record) |

For 7 of 9 slugs the entries-dict version was already present and held
fresher data (later \`lastEnriched\` and/or higher \`passes\`). For the 2
orphans, the data was never read by any script (\`find-targets.ts\` only
walks \`tracker.entries\`), so removing it does not change observable
gallery state.

**Script reads** (all hit \`entries[]\` exclusively):

\`\`\`
scripts/enricher/find-targets.ts:171   const trackerEntry = tracker.entries[id]
scripts/peer-reviewer/find-targets.ts:144  const enrichEntry = enrichmentTracker.entries[id]
scripts/enricher/claim-target.sh:202   jq -e ".entries[\"$target_id\"]"
scripts/enricher/claim-target.sh:237   jq -r ".entries[\"$target_id\"].passes"
scripts/enricher/claim-target.sh:281   jq '.entries | length'
\`\`\`

Current \`claim-target.sh\` cannot reproduce the drift — the legacy
write paths that emitted top-level keys are gone, so this is a one-shot
cleanup, not a patch over a recurring issue.

## Scope

- **Touched**: \`src/data/proofs/enrichment-tracker.json\` only
  (-51 lines, +0 lines, JSON re-validated round-trip).
- **Top-level keys post-fix**: \`["version", "entries"]\` (canonical).
- **\`entries\` count post-fix**: 2156 (unchanged).
- **\`pnpm tsx scripts/enricher/find-targets.ts --stats\`** post-fix:
  \`Entries needing enrichment: 0\` (gallery still saturated).
- **Orthogonal to in-flight mechanic PRs**: #18684 (\`actionItems\`),
  #18708 (\`targetAgent\` schema), #18713 (schauder meta drift),
  #18716 (\`overallGrade\`), #18718 (missing review-tracker entries),
  #18721 (\`qualityScore\`) — different file (\`review-tracker.json\` vs
  \`enrichment-tracker.json\`) or different field set; this PR touches
  no overlapping bytes.
- **No** Lean files, scripts, or other JSON files modified.

## Validation

\`\`\`
$ python3 -c "import json; d=json.load(open('src/data/proofs/enrichment-tracker.json')); print(list(d.keys()), len(d['entries']))"
['version', 'entries'] 2156

$ git diff --stat src/data/proofs/enrichment-tracker.json
 src/data/proofs/enrichment-tracker.json | 51 ---------------------------------
 1 file changed, 51 deletions(-)

$ pnpm tsx scripts/enricher/find-targets.ts --stats | tail -5
  ...
  Entries needing enrichment: 0
\`\`\`

---
Automated fix by lean-mechanic agent.