### PR TITLE
fix(mechanic): remove 4 legacy fields from 29 enrichment-tracker entries

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -454,8 +454,7 @@
     "erdos-970": {
       "passes": 5,
       "lastEnriched": "2026-02-21",
-      "quality": 100,
-      "lastEnricher": "enricher-2"
+      "quality": 100
     },
     "amgm-inequality": {
       "passes": 1,
@@ -785,8 +784,7 @@
     "vietas-formulas": {
       "passes": 1,
       "lastEnriched": "2026-03-26T08:00:00Z",
-      "quality": 100,
-      "lastEnricher": "enricher-2"
+      "quality": 100
     },
     "minkowski-theorem": {
       "passes": 1,
@@ -801,8 +799,7 @@
     "mean-value-theorem": {
       "passes": 1,
       "lastEnriched": "2026-03-26T10:00:00Z",
-      "quality": 100,
-      "lastEnricher": "enricher"
+      "quality": 100
     },
     "taylor-sincos-convergence-oq-03": {
       "passes": 2,
@@ -832,9 +829,7 @@
     "roth-theorem-k3-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-02T10:00:00Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "solution-of-cubic-oq-03-oq-05": {
       "passes": 2,
@@ -849,9 +844,7 @@
     "collatz-structured-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-03T07:17:55Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "konigsberg-oq-03": {
       "passes": 1,
@@ -891,23 +884,17 @@
     "bezout-identity-oq-02-oq-01-oq-02": {
       "passes": 2,
       "lastEnriched": "2026-04-03T07:18:19Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "euler-totient-oq-01": {
       "passes": 2,
       "lastEnriched": "2026-04-03T07:18:24Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "elementary-quadratic-reciprocity-oq-03-oq-01-oq-02": {
       "passes": 2,
       "lastEnriched": "2026-04-03T07:18:31Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
       "passes": 2,
@@ -922,9 +909,7 @@
     "erdos-1-oq-02": {
       "passes": 2,
       "lastEnriched": "2026-04-03T07:18:35Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "chinese-remainder-constructive-oq-04-oq-04": {
       "passes": 1,
@@ -934,16 +919,12 @@
     "cantor-diagonalization-oq-03-oq-01": {
       "passes": 2,
       "lastEnriched": "2026-04-03T14:07:48Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "greens-theorem-oq-01-oq-01": {
       "passes": 2,
       "lastEnriched": "2026-04-03T22:57:02Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "angle-trisection-oq-02-oq-04": {
       "passes": 4,
@@ -953,9 +934,7 @@
     "angle-trisection-oq-02-oq-02": {
       "passes": 2,
       "lastEnriched": "2026-04-03",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "lagrange-theorem-oq-05": {
       "passes": 1,
@@ -965,37 +944,27 @@
     "hurwitz-theorem-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-03",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "arithmetic-series-oq-02-oq-02-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-04",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "binary-gcd-oq-01": {
       "passes": 2,
       "lastEnriched": "2026-04-04",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "e-transcendental-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-04",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1001-oq-02": {
       "passes": 2,
       "lastEnriched": "2026-04-04",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "furstenberg-correspondence-oq-02": {
       "passes": 1,
@@ -1005,9 +974,7 @@
     "erdos-110-oq-03": {
       "passes": 2,
       "lastEnriched": "2026-04-04T13:48:52Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "cramers-rule-oq-01-oq-04": {
       "passes": 1,
@@ -1172,9 +1139,7 @@
     "bertrands-postulate-oq-03-oq-04": {
       "passes": 2,
       "lastEnriched": "2026-04-05T12:16:08Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-563": {
       "passes": 1,
@@ -1199,16 +1164,12 @@
     "erdos-1202": {
       "passes": 2,
       "lastEnriched": "2026-04-21T10:54:02Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1205": {
       "passes": 2,
       "lastEnriched": "2026-04-21T10:54:02Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "divisibility-rules-oq-02": {
       "passes": 3,
@@ -1218,30 +1179,22 @@
     "erdos-1206": {
       "passes": 2,
       "lastEnriched": "2026-04-21T10:57:09Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1211": {
       "passes": 2,
       "lastEnriched": "2026-04-21T11:01:18Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1213": {
       "passes": 2,
       "lastEnriched": "2026-04-21T11:05:02Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1208": {
       "passes": 2,
       "lastEnriched": "2026-04-21T11:07:56Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1215": {
       "passes": 2,
@@ -1256,16 +1209,12 @@
     "erdos-1212": {
       "passes": 2,
       "lastEnriched": "2026-04-21T11:30:00Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "erdos-1217": {
       "passes": 2,
       "lastEnriched": "2026-04-21T11:45:00Z",
-      "quality": 100,
-      "claimed": null,
-      "lastUpdated": "2026-04-24"
+      "quality": 100
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
       "passes": 2,
@@ -1510,14 +1459,12 @@
     "minkowski-fundamental-theorem-oq-04": {
       "passes": 1,
       "quality": 100,
-      "lastEnriched": "2026-04-24T04:59:51.225251Z",
-      "status": "enriched"
+      "lastEnriched": "2026-04-24T04:59:51.225251Z"
     },
     "fair-games-theorem-oq-02-oq-01-oq-01": {
       "passes": 2,
       "quality": 100,
-      "lastEnriched": "2026-04-24T04:59:51.225251Z",
-      "status": "enriched"
+      "lastEnriched": "2026-04-24T04:59:51.225251Z"
     },
     "abel-ruffini-oq-04-oq-01": {
       "passes": 1,


### PR DESCRIPTION
## Fix

Delete non-canonical fields (`claimed`, `lastUpdated`, `lastEnricher`, `status`) from 29 entries in `src/data/proofs/enrichment-tracker.json`. 53 field deletions total. No canonical readers consume these fields.

## Evidence

**Canonical writer** — `scripts/enricher/claim-target.sh::complete_target` (lines 206-212) writes only:
```jq
.entries[$id].passes += 1 |
.entries[$id].lastEnriched = $ts |
.entries[$id].quality = $quality
```

`claimed`, `lastUpdated`, `lastEnricher`, `status` are never written by the current claim-target.sh. (`claimed: null` / `status: "in_progress"` ARE written to `research/claims/<target>.json` — a separate file.)

**Canonical reader** — `scripts/enricher/find-targets.ts:171-173`:
```ts
const trackerEntry = tracker.entries[id]
const passes = trackerEntry?.passes ?? 0
const lastEnriched = trackerEntry?.lastEnriched ?? null
```

Only `passes` and `lastEnriched` are read; the legacy fields are dead data.

**Field census** (pre-fix, 2156 entries):

| Field set                                                            | Count | Notes                                     |
|----------------------------------------------------------------------|-------|-------------------------------------------|
| `(quality)`                                                          | 1854  | Baseline never-enriched (canonical)       |
| `(lastEnriched, passes, quality)`                                    | 273   | Enriched (canonical)                      |
| `(claimed, lastEnriched, lastUpdated, passes, quality)`              | 24    | Legacy drift                              |
| `(lastEnriched, lastEnricher, passes, quality)`                      | 3     | Legacy drift                              |
| `(lastEnriched, passes, quality, status)`                            | 2     | Legacy drift                              |

**Post-fix** (2156 entries):

| Field set                          | Count |
|------------------------------------|-------|
| `(quality)`                        | 1854  |
| `(lastEnriched, passes, quality)`  | 302   |

Two canonical shapes only.

**29 slugs touched** — full list:

`claimed` + `lastUpdated` removed (24): roth-theorem-k3-oq-03, collatz-structured-oq-03, bezout-identity-oq-02-oq-01-oq-02, euler-totient-oq-01, elementary-quadratic-reciprocity-oq-03-oq-01-oq-02, erdos-1-oq-02, cantor-diagonalization-oq-03-oq-01, greens-theorem-oq-01-oq-01, angle-trisection-oq-02-oq-02, hurwitz-theorem-oq-03, arithmetic-series-oq-02-oq-02-oq-03, binary-gcd-oq-01, e-transcendental-oq-03, erdos-1001-oq-02, erdos-110-oq-03, bertrands-postulate-oq-03-oq-04, erdos-1202, erdos-1205, erdos-1206, erdos-1211, erdos-1213, erdos-1208, erdos-1212, erdos-1217.

`lastEnricher` removed (3): erdos-970, vietas-formulas, mean-value-theorem.

`status: "enriched"` removed (2): minkowski-fundamental-theorem-oq-04, fair-games-theorem-oq-02-oq-01-oq-01.

## Scope

- **Touched**: `src/data/proofs/enrichment-tracker.json` only (-82 lines, +29 lines, 53 net field deletions).
- **Orthogonal to in-flight mechanic PRs**:
  - #18684 (`actionItems`/`resolvedItems` in `review-tracker.json` — different file).
  - #18716 (`overallGrade` in `review-tracker.json` — different file).
  - #18726 (top-level slug keys in `enrichment-tracker.json` — different bytes, doesn't touch `entries[]`).
- **No** Lean files, scripts, or other JSON files modified.

## Validation

```
$ python3 -c "import json; d=json.load(open('src/data/proofs/enrichment-tracker.json')); print(len(d['entries']))"
2156

$ python3 -c "import json; from collections import Counter; d=json.load(open('src/data/proofs/enrichment-tracker.json')); print(Counter(tuple(sorted(v.keys())) for v in d['entries'].values()))"
Counter({('quality',): 1854, ('lastEnriched', 'passes', 'quality'): 302})

$ pnpm tsx scripts/enricher/find-targets.ts --stats | grep "Entries needing"
Entries needing enrichment: 0
```

JSON validity: confirmed round-trip.

---
Automated fix by lean-mechanic agent.