### PR TITLE
Enrich sperner-simplicial-bridge-oq-01: +2 annotations, +3 xrefs, +2 keyInsights, +2 openQuestions

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-spc-oq01-header",
+    "proofId": "sperner-simplicial-bridge-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "File Header: Mixed-Dimension Sperner",
+    "content": "The module docstring (lines 8-48) names the structural payoff explicitly: *door dimensions are graded*. A codimension-1 face of a `(d+1)`-simplex has cardinality `d`, so faces of different cardinalities cannot pair as doors. The classical pseudomanifold condition therefore decomposes stratum by stratum.\n\nThe single `import` (line 6, `Proofs.SpernerSimplicialBridge`) is the entirety of the dependency surface — no new Mathlib modules are imported beyond what the parent already brings. The `namespace Sperner.SimplicialComplex` opening (line 50) places every new declaration in the parent's namespace, so unqualified references to `vertexEnum`, `exists_panchromatic`, `IsDoor`, `IsPanchromatic`, and `adjFn` resolve against the parent without qualification.\n\nThe `open Finset` directive (line 52) is essential: every use of `filter`, `mem_filter`, `filter_eq_self`, `filter_eq_empty_iff`, and `filter_empty` resolves to the `Finset` namespace without explicit prefixes, keeping the proof bodies compact.",
+    "mathContext": "The mathematical content of the file is concentrated in three predicate-level observations, summarised in the *Main definitions* and *Main results* sections of the docstring: (i) the dimension-graded stratification `topCellsOfDim`; (ii) the per-stratum pseudomanifold predicate `MixedPseudomanifold`; (iii) the pure-to-mixed coercion `MixedPseudomanifold.of_pure` witnessing that the new framework subsumes the parent. The headline theorem `sperner_mixed_panchromatic_at_dim` is then a *bookkeeping* application of the parent's `exists_panchromatic` to the chosen stratum.",
+    "significance": "context",
+    "relatedConcepts": [
+      "module-level docstring conventions",
+      "namespace inheritance",
+      "open Finset",
+      "predicate-level vs proof-level content",
+      "De Longueville mixed-pseudomanifold reference"
+    ],
+    "prerequisites": [
+      "Lean 4 module/namespace basics",
+      "parent slug `sperner-simplicial-bridge` overview"
+    ]
+  },
+  {
     "id": "ann-spc-oq01-stratification",
     "proofId": "sperner-simplicial-bridge-oq-01",
     "range": {
@@ -48,6 +72,33 @@
       "Finset.filter_eq_self",
       "Finset.filter_eq_empty_iff",
       "by_cases tactic"
+    ]
+  },
+  {
+    "id": "ann-spc-oq01-boundary-door-count",
+    "proofId": "sperner-simplicial-bridge-oq-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 156
+    },
+    "type": "definition",
+    "title": "`boundaryDoorCount`: per-stratum boundary-door count",
+    "content": "`boundaryDoorCount K c : ℕ` (a `noncomputable def`) counts the number of *boundary doors* of `topCellsOfDim K d` under colouring `c`. The body is the cardinality of the `Finset.univ.filter (…)` over pairs `p : { s // s ∈ topCellsOfDim K d } × Fin (d + 1)` satisfying two conjuncts:\n\n1. **`Sperner.IsDoor (vertexEnum …) c p.1 p.2`** — the colours `{0, …, d−1}` are all present on `s \\ {vertex k}` (the lower-colour face is panchromatic in dimension `d`).\n2. **`adjFn (topCellsOfDim K d) (fun _ hs => card_of_mem_topCellsOfDim hs) p.1 p.2 = none`** — the face `s \\ {vertex k}` is *not* shared with any other cell of dimension `d`; it lies on the boundary of the stratum.\n\nThe `noncomputable` modifier is necessary because the parent's `adjFn` returns an `Option` via an existential choice that does not produce a decidable witness in general. The signature is parameterised by an implicit `{d : Nat}` and an explicit `c : E → Fin (d + 1)`; the dimension is determined by the codomain of the colouring, which keeps invocation sites concise (`boundaryDoorCount (d := d) K c` only when type inference cannot fix `d`).\n\nMost importantly: by Lean's standard `def`-reducibility, `boundaryDoorCount K c` *is* (syntactically, modulo unfolding) the parent's `hbdry` argument with `topCellsOfDim K d` substituted for `topCells`. So `sperner_mixed_panchromatic_at_dim` can pass `hbdry : Odd (boundaryDoorCount K c)` directly into the parent's `exists_panchromatic` without any explicit `unfold`, `change`, or `show` — the elaborator does the substitution for free.",
+    "mathContext": "The parity of the boundary-door count is the *input* to Sperner's lemma in its door-counting form. Classically, the count of boundary doors of a pseudomanifold is *odd* iff a panchromatic top cell exists (the Brouwer/Sperner reflection of the fact that the boundary of a triangulated disk has odd total panchromatic-face count when the disk is properly coloured). In the mixed-dimension setting, the count specialises to a chosen stratum: only `(d+1)`-cells and their `d`-element subfaces contribute. The cross-stratum *global* count (summed across `d`) would change parity by including faces of all sizes, which is precisely why the per-stratum form is the natural one — see also the third open question.",
+    "significance": "core",
+    "relatedConcepts": [
+      "noncomputable def",
+      "Sperner.IsDoor",
+      "adjFn (parent)",
+      "definitional unfolding",
+      "subtype `{ s // s ∈ topCellsOfDim K d }`",
+      "implicit dimension parameter"
+    ],
+    "prerequisites": [
+      "parent slug `Sperner.IsDoor` definition",
+      "parent slug `adjFn` definition",
+      "Finset.univ on subtype",
+      "Option.none semantics"
     ]
   },
   {

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -94,6 +94,21 @@
       "type": "sibling-of",
       "slug": "sperner-simplicial-instance",
       "rationale": "Both slugs build on `sperner-simplicial-bridge`. `sperner-simplicial-instance` provides concrete Kuhn-style triangulation instances of the parent; this slug extends the parent's framework to non-pure (mixed-dimension) complexes."
+    },
+    {
+      "type": "depends-on",
+      "slug": "sperner-mathlib",
+      "rationale": "The parent's `exists_panchromatic` (which this slug's headline theorem applies stratum-by-stratum) is built on the abstract door-counting parity machinery established in `sperner-mathlib`. Transitively, the mixed-dimension result inherits its combinatorial backbone from the `Sperner.IsDoor` / `Sperner.IsPanchromatic` predicates introduced there."
+    },
+    {
+      "type": "related-to",
+      "slug": "sperner-ndim-mathlib",
+      "rationale": "`sperner-ndim-mathlib` proves Sperner's lemma on the standard `n`-simplex in Mathlib's `CellComplex` setting. The mixed-pseudomanifold framework here is the abstract-`Finset (Finset E)`-of-cells counterpart, with the dimensional stratification playing the role of `CellComplex.facesOfDim`. The two lines of work converge in OQ-02 (`Mathlib.Geometry.SimplicialComplex.facets` bridge)."
+    },
+    {
+      "type": "related-to",
+      "slug": "sperner-ndim-mathlib-oq-01",
+      "rationale": "`sperner-ndim-mathlib-oq-01` lifts Sperner to the Freudenthal `CellComplex` framework — a parallel exercise in extending Sperner beyond its pure-simplicial origins. Both slugs address Open Question 1 of their respective parents; the mixed-dimension generalisation here is to abstract simplicial complexes what the Freudenthal lift is to cell complexes."
     }
   ],
   "overview": {
@@ -105,7 +120,9 @@
       "**`MixedPseudomanifold` is the right predicate.** Quantifying `∀ d, ∀ f : Finset E, f.card = d → ((topCellsOfDim K d).filter (fun s => f ⊆ s)).card ≤ 2` captures exactly the per-stratum pseudomanifold condition without coupling strata. The lift `MixedPseudomanifold.of_pure` proves the predicate subsumes the parent (with the universally-quantified `d` vacuous off the unique stratum).",
       "**The cross-stratum form is a trivial corollary.** Once `sperner_mixed_panchromatic_at_dim` is established, the disjunctive form (`∃ d, ∃ c, odd boundary count` ⇒ `∃ d, ∃ s, panchromatic`) is a 3-line wrapper: `obtain ⟨d, c, hbdry⟩` from the hypothesis, then apply the per-stratum theorem. The per-stratum form is the mathematical content; the cross-stratum form is convenience packaging.",
       "**No new Mathlib dependencies.** The whole file sits on top of `Proofs.SpernerSimplicialBridge` — no imports beyond what the parent already brings. The only Mathlib API exercised is `Finset.filter`, `Finset.mem_filter`, and `Finset.filter_eq_self` / `Finset.filter_eq_empty_iff`, all stock.",
-      "**The parent's `verified` status is preserved.** Adding the mixed predicate and the per-stratum theorem does not touch the parent file's definitions or theorems; OQ-01 is a strict extension that subsumes (not replaces) the parent's `exists_panchromatic`."
+      "**The parent's `verified` status is preserved.** Adding the mixed predicate and the per-stratum theorem does not touch the parent file's definitions or theorems; OQ-01 is a strict extension that subsumes (not replaces) the parent's `exists_panchromatic`.",
+      "**Definitional unfolding does the work.** `boundaryDoorCount` is engineered so that `Odd (boundaryDoorCount K c)` *is* (modulo `def`-reducibility) the parent's `hbdry` predicate after `topCells → topCellsOfDim K d` substitution. The proof of `sperner_mixed_panchromatic_at_dim` is therefore a *single term-mode* application of `exists_panchromatic` — no `unfold`, no `change`, no `show`. The right definition turns a multi-line tactic proof into a 4-line term.",
+      "**Stratification commutes with predicates on subtypes.** The headline theorem's conclusion `∃ s : { s : Finset E // s ∈ topCellsOfDim K d }, IsPanchromatic (fun σ => vertexEnum σ.1 (card_of_mem_topCellsOfDim σ.2)) c s` packages the per-cell cardinality witness as a *function of the membership proof*, not a separate hypothesis. This lets the parent's `IsPanchromatic` predicate (which depends on the `vertexEnum` of each cell) be reused unchanged on the stratum's subtype, with no `Sigma` or `PSigma` repackaging."
     ]
   },
   "conclusion": {
@@ -114,7 +131,9 @@
     "openQuestions": [
       "Can the per-stratum form be packaged into a *cross-stratum existential* (`∃ d, ∃ c, odd boundary count` ⇒ `∃ d, ∃ s, panchromatic in stratum d`) as a 3-line wrapper? The per-stratum form is strictly stronger; this is convenience packaging only.",
       "Does the mixed framework extend to `Mathlib.Geometry.SimplicialComplex.facets` (the Mathlib type that carries non-pure data natively)? The `topCellsOfDim` stratification of a `Finset (Finset E)` corresponds directly to dimension-grading of `K.facets` — but the affine-set encoding of Mathlib's `SimplicialComplex` requires a translation layer.",
-      "Can the cross-stratum disjunctive form `∃ d, stratum d has odd boundary count` be replaced by a *global* boundary-door count `globalBoundaryDoors K c := Σ d, boundaryDoorCount (d := d) K c`, with the hypothesis `Odd globalBoundaryDoors`? The parity reasoning over a sum requires that exactly one stratum has odd boundary count, which is non-trivial in the multi-dimensional setting."
+      "Can the cross-stratum disjunctive form `∃ d, stratum d has odd boundary count` be replaced by a *global* boundary-door count `globalBoundaryDoors K c := Σ d, boundaryDoorCount (d := d) K c`, with the hypothesis `Odd globalBoundaryDoors`? The parity reasoning over a sum requires that exactly one stratum has odd boundary count, which is non-trivial in the multi-dimensional setting.",
+      "Does the mixed framework integrate with `sperner-ndim-mathlib`'s `CellComplex`-based proof on the standard simplex? Mathlib's `CellComplex.facesOfDim` is the closest analogue of `topCellsOfDim`, but the encoding is via abstract `Finset` of face indices rather than `Finset (Finset E)`. A `MixedPseudomanifold`-equivalent predicate on `CellComplex` would unify the two formalisations and reduce one to the other.",
+      "Can the per-stratum theorem be iterated through *barycentric subdivision*? A barycentric subdivision of a mixed-dimension complex preserves the stratification (each dimension-`d` cell subdivides into dimension-`d` sub-cells) but multiplies cell counts and rebases the colouring. Stating the iteration as a fixed-point of a colour-refinement operator would yield a quantitative refinement of OQ-01 — useful for KKM-type fixed-point applications that need fine-grained Sperner statements."
     ]
   },
   "references": [


### PR DESCRIPTION
First enrichment pass on the mixed-dimension Sperner gallery entry (quality 83 → targeted gaps closed).

## Annotations (+2, 3 → 5)
- **Header annotation** (lines 1–52): namespace/imports/docstring with the doors-are-dimension-graded structural claim spelled out; new `context` annotation closes the lines-1-53 coverage gap.
- **`boundaryDoorCount` annotation** (lines 140–156): split off from the per-stratum-sperner block. Spells out the two-conjunct filter body (`Sperner.IsDoor` ∧ `adjFn = none`), why `noncomputable` is required, and — crucially — that the def is engineered to match the parent's `hbdry` shape under Lean's `def`-reducibility so `sperner_mixed_panchromatic_at_dim` needs no `unfold`.

## crossReferences (+3, 3 → 6)
- `depends-on` → `sperner-mathlib` (abstract door-counting parity machinery the parent uses).
- `related-to` → `sperner-ndim-mathlib` (CellComplex counterpart of the mixed-pseudomanifold framework; converges on OQ-02).
- `related-to` → `sperner-ndim-mathlib-oq-01` (sister generalisation — Freudenthal CellComplex lift addresses parallel OQ-01).

## keyInsights (+2, 5 → 7)
- **Definitional unfolding does the work** — `boundaryDoorCount` *is* (modulo def-reducibility) the parent's `hbdry` predicate; the main theorem is a 4-line term-mode application.
- **Stratification commutes with subtype predicates** — `IsPanchromatic` on `{ s // s ∈ topCellsOfDim K d }` reuses the parent without `Sigma` repackaging because `vertexEnum σ.1 (card_of_mem_topCellsOfDim σ.2)` packages the cardinality as a function of the membership proof.

## openQuestions (+2, 3 → 5)
- Integration with `sperner-ndim-mathlib`'s `CellComplex.facesOfDim`-based proof on the standard simplex.
- Barycentric subdivision iteration of the per-stratum theorem (quantitative refinement for KKM-type applications).

## Verification
- `pnpm build` ✓ (after restoring 996 unrelated annotations.json normalization edits).
- JSON validates, all line ranges fit within the 184-line Lean file.
- No edits to the Lean source or the parent slug; orthogonal to any in-flight S-* PRs.