### PR TITLE
fix(mechanic): wire annotations into triangle-angle-sum-oq-01 index.ts

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-01/index.ts
+++ b/src/data/proofs/triangle-angle-sum-oq-01/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/TriangleAngleSumOQ01.lean?raw')
+
+export const triangleAngleSumOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleAngleSumOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleAngleSumOq01Data: ProofData = {
+  proof: triangleAngleSumOq01Proof,
+  annotations: triangleAngleSumOq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default triangleAngleSumOq01Data


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub at `src/data/proofs/triangle-angle-sum-oq-01/index.ts` with the canonical full TypeScript template. Without this fix, the proof page renders with no annotations and no proof data even though 12KB of real annotation content exists in `annotations.json` (12 annotations since 2026-03-29).

## Evidence

**Bug mechanism**: For stub slugs whose `index.ts` is just
```ts
import meta from './meta.json';
export default meta;
```
the module's `default` export is the raw meta JSON dict (top-level `id, title, slug, description, meta, sections, ...`). In `src/data/proofs/index.ts:57`, `getProofAsync` picks this up as `proofData`:
```ts
let proofData: ProofData | undefined = module.default || module[exportName] || ...
```
Because `module.default` is truthy, the `{meta, annotations}` fallback at lines 60–79 never runs. `proofData` ends up being a plain meta JSON dict with no `.proof` or `.annotations` keys, so `ProofPage.tsx:111`'s destructure `const { proof, annotations, versionInfo } = proofData` yields `undefined` for all three.

**Affected slug**: `triangle-angle-sum-oq-01` (Converse Angle Sum: Triangle Angle Sum = π Implies Euclidean Geometry)
- annotations.json: 12 annotations, 12,050 bytes (well-developed content)
- Lean source: `proofs/Proofs/TriangleAngleSumOQ01.lean` (exists, builds clean)
- Currently gallery-visible (in `listings.json`) but renders broken
- Stub created 2026-03-29 (`fb112bf6682`); never converted to canonical template

**Precedent**: PR #17885 (lagrange-theorem-oq-02-oq-02, merged 2026-05-11) addressed the same schema bug:
> "Fix critical schema bug: replace minimal `{meta, annotations}` stub with full Proof/Annotation/ProofData index.ts template; without this, the gallery page showed 'proof not found' on the live site even though it appeared in the listing"

This PR applies the same fix to the next instance.

**Before**: 2-line stub, gallery page renders empty/broken.
**After**: 44-line canonical template (matches `abel-ruffini-galois-extensions-oq-05-oq-01/index.ts` shape), exports `triangleAngleSumOq01Proof`, `triangleAngleSumOq01Annotations`, `triangleAngleSumOq01Data` (default), `getProofSource()`.

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
$ echo $?
0
```

No new type errors. The Lean source path `proofs/Proofs/TriangleAngleSumOQ01.lean` is confirmed present and matches `meta.leanFile.path` ("Proofs/TriangleAngleSumOQ01.lean").

## Scope

- **Touched**: `src/data/proofs/triangle-angle-sum-oq-01/index.ts` only (1 file, +44 / -2 lines).
- **Not touched**: `meta.json`, `annotations.json`, `tacticStates.json` — already canonical, untouched.
- **Orthogonal to in-flight mechanic PR**:
  - #18740 (empty `review.json` stub for ballot-problem-oq-01-oq-04 — different file, different concern)
- **Out of scope** (23 other slugs with the same `index.ts` stub pattern; each needs a custom camelCase variable + verified Lean file path, so one PR per slug minimizes risk and matches the lagrange precedent):
  - `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02`
  - `bezout-identity-oq-02-oq-01-oq-02-oq-02`, `bezout-identity-oq-03-oq-03`, `bezout-identity-oq-03-oq-04-oq-01`
  - `binary-gcd`
  - `cantor-diagonalization-oq-03-oq-01-oq-01`, `cantor-diagonalization-oq-03-oq-01-oq-04`
  - `erdos-1059-oq-01`, `erdos-1059-oq-02`, `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-03`, `erdos-1059-oq-04`, `erdos-1059-oq-05`
  - `erdos-1179-oq-01`, `erdos-152-oq-01`, `erdos-848-oq-01`
  - `harmonic-divergence-oq-02`, `konigsberg-oq-03-oq-02`, `laws-of-large-numbers-oq-03`
  - `lebesgue-measure-oq-01-oq-01`, `subset-count-multiset`, `sum-of-kth-powers-oq-02`
  - `triangle-angle-sum-oq-03`

Each is a separate-PR-if-needed target. Picked `triangle-angle-sum-oq-01` first because it has the richest annotation content (12 annotations / 12KB) among the affected slugs and a well-known underlying theorem.

---
Automated fix by lean-mechanic agent.