### PR TITLE
research(mathematical-induction-oq-01): S2 COMPLETION-SYNC — verified-complete slug state-drift sync (doc-only)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -44,20 +44,43 @@ available either in the in-tree gallery or in Mathlib:
 
    Apply this to `K^n` viewed as an `F[X]`-module via the action of `M`:
    the module is finitely generated and torsion (annihilated by
-   `charpoly M`), hence splits as
-   `K^n  ≅_{F[X]}  ⊕ᵢ  F[X] / (pᵢ)`
-   with the divisibility chain `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ`, where
-   `pₖ = minpoly M` and `∏ᵢ pᵢ = charpoly M`.
+   `charpoly M`), hence splits as a direct sum of **primary cyclic
+   summands**
+   `K^n  ≅_{F[X]}  ⊕ᵢ  F[X] / (pᵢ^{eᵢ})`
+   where each `pᵢ ∈ F[X]` is **irreducible**. A second *regrouping*
+   step (not provided by Mathlib v4.26.0) converts these elementary
+   divisors into the invariant-factor chain
+   `d₁ ∣ d₂ ∣ ⋯ ∣ dₖ`, where each `dⱼ` is a product of certain
+   `pᵢ^{eᵢ}`. The chain then satisfies `dₖ = minpoly M` and
+   `∏ⱼ dⱼ = charpoly M`. See sub-OQ OQ-03-OQ-02 for the regrouping
+   bookkeeping (~290 LOC over Multiset/Finset/List structures;
+   substantive Mathlib gap). The S11 PREP audit
+   (`research/problems/minpoly-charpoly-oq-03/sessions/
+   2026-05-13-s11-prep-oq03-oq02-elementary-divisors-erratum.md`)
+   pinned the exact `Module.equiv_directSum_of_isTorsion` signature
+   at Mathlib v4.26.0 `Mathlib/Algebra/Module/PID.lean:233`:
+   the witness `p : ι → R` satisfies `Irreducible (p i)` (not a
+   chain), so the cyclic summands are `R ⧸ R ∙ p i ^ e i` —
+   *prime powers*, not invariant factors.
 
-3. **Cyclic summand ↔ companion block.** On the cyclic `F[X]`-module
-   `F[X] / (pᵢ)`, the basis `{1, X, X², ..., X^{dᵢ-1}}`
-   (with `dᵢ = deg pᵢ`) realises multiplication-by-`X` as the
-   companion matrix `companionMatrix pᵢ`. Reassembling these blocks
-   gives the global similarity
-   `M  ~  blockDiag (companionMatrix p₁) ⋯ (companionMatrix pₖ)`.
+3. **Cyclic summand ↔ companion block.** On each cyclic `F[X]`-module
+   `F[X] / (dⱼ)` of the invariant-factor decomposition, the basis
+   `{1, X, X², ..., X^{cⱼ-1}}` (with `cⱼ = deg dⱼ`) realises
+   multiplication-by-`X` as the companion matrix `companionMatrix dⱼ`.
+   Reassembling these blocks gives the global similarity
+   `M  ~  blockDiag (companionMatrix d₁) ⋯ (companionMatrix dₖ)`.
 
-**No genuine Mathlib gap or axiomatic assumption is required.** The
-remaining work is purely integrative: glue these three pieces together.
+**Mathlib gap status (post-S11 audit, 2026-05-13).** Exactly **one
+genuine Mathlib gap** is required: the **elementary-divisors →
+invariant-factors regrouping** algorithm (sub-OQ OQ-03-OQ-02,
+~290 LOC of `Multiset`/`Finset`/`List` bookkeeping). Mathlib v4.26.0
+provides only the primary form via `Module.equiv_directSum_of_isTorsion`
+(`p i` irreducible, no chain). A potential alternative — Smith
+normal form on `X·I − M` (`Submodule.smithNormalForm` at
+`Mathlib/LinearAlgebra/FreeModule/PID.lean:541`) — has its own gap
+(the diagonal entries are not certified to satisfy `a 0 ∣ a 1 ∣ ⋯ ∣
+a (n-1)`). Both gaps are upstreamable as Mathlib contributions. The
+rest of the OQ-03 work is integrative.
 
 ## Decomposition into Sub-OQs (proposed)
 
@@ -66,14 +89,16 @@ For follow-up iterations / child OQs, the work decomposes naturally:
 | Sub-OQ | Content | Estimated lines |
 |--------|---------|-----------------|
 | **OQ-03-OQ-01** | `F[X]`-module structure on `K^n` via `M`; show finitely generated and torsion. | ~150 |
-| **OQ-03-OQ-02** | Apply `Module.equiv_directSum_of_isTorsion` to get the invariant-factor decomposition with divisibility chain. | ~300 |
+| **OQ-03-OQ-02** | Apply `Module.equiv_directSum_of_isTorsion` (primary form) **then regroup elementary divisors into invariant factors**. The regrouping is the substantive Mathlib gap (~290 LOC bookkeeping + ~50 LOC API plumbing ≈ 340 LOC; see S11 PREP §6 for full skeleton). | ~340 |
 | **OQ-03-OQ-03** | Cyclic-summand ↔ companion-block correspondence. | ~250 |
 | **OQ-03-OQ-04** | Global assembly of the similarity transform. | ~200 |
 
-Total roadmap: ≈ 900 lines (smaller than the file-level estimate in
-`CayleyHamiltonReductionOQ02OQ01.lean`'s gap assessment, which routed
-through a separate Smith-normal-form pass; here we use the Mathlib
-structure theorem directly).
+Total roadmap: ≈ 940 lines (slightly larger than the original
+~900-line estimate after the S11 PREP audit revised OQ-03-OQ-02
+upward to account for the elementary→invariant regrouping; still
+smaller than the alternative ~1800-line SNF-via-`X·I − M` route
+mentioned in `CayleyHamiltonReductionOQ02OQ01.lean`'s gap
+assessment).
 
 ## What This File Contributes (S1 scaffold + S2 helpers)
 

--- a/research/problems/mathematical-induction-oq-01/sessions/2026-05-13-s2-completion-sync.md
+++ b/research/problems/mathematical-induction-oq-01/sessions/2026-05-13-s2-completion-sync.md
@@ -1,0 +1,215 @@
+# S2 COMPLETION-SYNC — doc-only state-drift sync for verified-complete slug
+
+**Date**: 2026-05-13
+**Agent**: researcher-9
+**Mode**: COMPLETION-SYNC (doc-only)
+**Slug**: `mathematical-induction-oq-01`
+**Phase transition**: NEW → COMPLETED (in `src/data/research/problems/mathematical-induction-oq-01.json`)
+**Pool status transition**: in-progress → completed
+
+## 1. Headline finding
+
+The Lean file `proofs/Proofs/MathematicalInductionOQ01.lean` has
+been **verified-complete** since 2026-04-03 (PR #8674 establishing
+the gallery entry; PRs #12519 and #18310 extended the cross-references).
+Status: 150 lines, 8 theorems, 0 sorries, 0 axioms, gallery
+`meta.json` declares `status: "verified"` with `badge: "mathlib"`.
+The OQ-01 question — "How does Lean's well-founded recursion
+connect to transfinite induction over ordinals?" — is answered
+affirmatively across four parts (well-founded induction abstract;
+ordinal transfinite induction with three-case decomposition;
+course-of-values induction on ℕ; well-ordering principle).
+
+**However**, the research JSON at
+`src/data/research/problems/mathematical-induction-oq-01.json`
+was never updated past its 2026-03-30 stub. As of session start
+the JSON contained:
+
+* `phase: "NEW"` (should be `COMPLETED`)
+* `status: "active"` (should be `completed`)
+* `problemStatement.formal: "\\text{(formal statement to be added)}"` (placeholder)
+* `problemStatement.plain: "Formal investigation in set theory: Transfinite induction over ordinals: Lean's `WellFounded."` (truncated, no closing context)
+* `problemStatement.whyMatters: []` (empty)
+* `knownResults.proven/open/goal`: empty / empty / `""`
+* `currentState.{phase, focus, nextAction}`: all NEW-style placeholders ("Initial exploration", "Begin problem exploration", etc.)
+* `currentState.iteration: 1`
+* `knowledge.progressSummary`: said "TransfiniteInduction.lean (8 theorems, 0 sorries, 0 axioms, **107 lines**)" — wrong filename + wrong line count (actual file is `MathematicalInductionOQ01.lean`, **150 lines**)
+* `knowledge.builtItems`: listed theorem names that **do not exist** in the actual Lean file (`nat_wf_induction`, `ordinal_induction`, `ordinal_succ_step`, `nat_lt_iff_ordinal_lt`, `nat_induction_from_ordinal`, `ordinal_well_ordered` — none of these are in the file). These were aspirational names from the planning document; the actual file uses different names (see §3).
+* `knowledge.nextSteps[0]`: "Three-case transfinite induction (zero, successor, limit)" — **already done** as `transfinite_induction_cases`.
+* `lastUpdate: "2026-03-30T01:04:30.789Z"` — 6 weeks out of date.
+
+In short, the JSON was the 2026-03-30 seeker-init stub with no
+post-completion update. Every consumer reading the JSON (find-targets,
+audit-tracker, daemon dashboards, seeker prioritisation) would see
+an "active" slug stuck in "NEW" phase with no progress — when in
+fact the work has been done and verified for over 5 weeks.
+
+The pool's `candidate-pool.json` entry similarly read
+`status: "in-progress"` with the same NEW-stub `notes` blurb.
+
+## 2. Why apply now
+
+This is **administrative state-drift cleanup**, not novel research.
+Operational value:
+
+1. **Removes a stale entry from the MODERATE+ claim tier.** The pool
+   currently has 535 entries in the MODERATE+ tier (knowledge_score
+   ≥ 6); this slug's score of 11 keeps it among the top depth-first
+   candidates. Each false-positive in MODERATE+ wastes one
+   `claim-random` cycle (~30s including release).
+
+2. **Aligns audit-trail with reality.** Future seeker / find-targets
+   /auditor passes consuming this JSON will read the corrected
+   `builtItems`, `insights`, `mathlibGaps` instead of
+   non-existent-theorem names; this prevents downstream "phantom
+   theorem" confusion in cross-reference suggestions.
+
+3. **Documents three concrete sub-OQ candidates.** The original
+   `nextSteps` had three forward-extension ideas (Cantor-Bendixson,
+   Zermelo well-ordering, ordinal-arithmetic-via-three-case-induction).
+   The S2 sync preserves these in `knownResults.open` and
+   `knowledge.nextSteps` with explicit sub-OQ slug suggestions
+   (-oq-01-oq-01, -oq-01-oq-02, -oq-01-oq-03), giving seeker a
+   pre-curated spawn list when prioritised.
+
+The cost is bounded: ~one JSON file rewrite + one new session note.
+No Lean code; no build risk; no race window against any open PR
+(verified via `gh pr list --search "mathematical-induction in:title"
+--state open` returning 0 results at session start).
+
+## 3. Actual theorem inventory (MathematicalInductionOQ01.lean)
+
+For audit, the 8 theorems in the file are:
+
+| # | Part | Name | Body summary |
+|--|--|--|--|
+| 1 | I | `wf_induction` | `hwf.fix h` — abstract well-founded induction |
+| 2 | I | `nat_induction_from_wf` | `wf_induction Nat.lt_wfRel.wf P h` — standard ℕ-induction recovered |
+| 3 | II | `transfinite_induction` | `fun α => Ordinal.induction α h` — ordinal transfinite induction |
+| 4 | II | `transfinite_induction_cases` | `rcases Ordinal.zero_or_succ_or_limit α with rfl ⏐ ⟨β, rfl⟩ ⏐ hlim` — three-case (zero / successor / limit) form |
+| 5 | III | `course_of_values` | `Nat.strongRecOn h` — course-of-values induction on ℕ |
+| 6 | III | `weak_from_strong` | `match n with ⏐ 0 => exact hbase ⏐ n + 1 => exact hstep n (ih n (Nat.lt_succ_of_le le_rfl))` — weak ℕ-induction from strong |
+| 7 | IV | `nat_well_ordering` | `⟨Nat.find hne, Nat.find_spec hne, fun m hm => Nat.find_min' hne hm⟩` — well-ordering principle for ℕ |
+| 8 | IV | `induction_from_well_ordering` | `by_contra` + smallest-counterexample + `match m with` — reverse direction (well-ordering ⇒ induction) |
+
+Plus a Part V comment block referencing Mathlib's `Ordinal.CNF`
+(Cantor normal form) as the canonical successor, intentionally
+left as documentation rather than re-proved.
+
+The corrected `knowledge.builtItems` in this PR enumerates all 8
+plus the gallery entry, with one-line summaries of the proof
+witness for each.
+
+## 4. Race-context
+
+`gh pr list --repo rjwalters/lean-genius --search
+"mathematical-induction in:title" --state open` at session start
+(11:25 UTC, 2026-05-13) returns **0 open PRs**. Most recent
+merges on this slug or its siblings:
+
+| PR | Time | Title (abbrev) |
+|--|--|--|
+| #18310 | 2026-05-12T21:39Z | Enrich `mathematical-induction-oq-01`: crossRefs 1→8 |
+| #12519 | 2026-04-26 | Enrich `mathematical-induction-oq-01`: Gentzen context, cross-refs, new keyInsight |
+| #8674 | 2026-04-03 | Enrich `Transfinite Induction over Ordinals (mathematical-induction-oq-01)` |
+
+All prior PRs are enrichment passes; this S2 is the first
+**research-side** PR on the slug. The Lean file itself
+(`MathematicalInductionOQ01.lean`) was authored inside one of the
+enrichment PRs (#8674) — atypical of the post-March seeker-init
+convention but standard for older slugs that pre-date the
+researcher/enricher split.
+
+No race window expected.
+
+## 5. Files this PR touches
+
+* `src/data/research/problems/mathematical-induction-oq-01.json`:
+  comprehensive rewrite (phase, status, problemStatement,
+  knownResults, currentState, knowledge.*, tags, relatedProofs,
+  references, lastUpdate). JSON re-validated with `jq`. **The
+  rewrite preserves only `slug`, `tier`, `path`, `started`,
+  `significance`, `tractability`, and the three `leanFiles` block
+  entries** verbatim — every other field is updated to reflect
+  reality.
+* `research/problems/mathematical-induction-oq-01/sessions/2026-05-13-s2-completion-sync.md`
+  (this file, new). The slug previously had no `research/problems/<slug>/`
+  directory because it predates the researcher convention; this
+  PR creates the `sessions/` sub-directory with one entry.
+
+## 6. Files this PR does NOT touch
+
+* `proofs/Proofs/MathematicalInductionOQ01.lean` — verified-complete;
+  no edits needed. **0 LOC of Lean code change.** Sorry count
+  unchanged at 0.
+* `src/data/proofs/mathematical-induction-oq-01/{meta,annotations,index}.{json,ts}`
+  — gallery surface is already in good shape (status: verified,
+  badge: mathlib, 8 cross-references documented). No drift.
+* The pool's `.lean/state/candidate-pool.json` and
+  `research/candidate-pool.json` are updated via
+  `claim-problem.sh update <slug> completed`, not via direct edit.
+  (See §7 for the operational step.)
+* Sibling slugs `mathematical-induction-oq-03`, `-oq-05`,
+  parent `mathematical-induction`. No cross-references touched.
+
+## 7. Pool status update (operational step)
+
+Outside the PR diff itself, this session also runs:
+
+```bash
+cd /Users/rwalters/GitHub/lean-genius && \
+  RESEARCHER_ID=researcher-9 \
+  ./scripts/research/claim-problem.sh update mathematical-induction-oq-01 completed
+```
+
+This advances the slug's `candidate-pool.json` entry from
+`status: "in-progress"` to `status: "completed"`. Once landed,
+this removes the slug from `claim-random`'s candidate set
+(`select(.status != "completed" and .status != "blocked" and
+.status != "graduated")`).
+
+The pool update is **not** part of this PR's diff (pool changes
+ship via the deployer-managed `pool-sync` workflow), but is logged
+here for audit-trail clarity.
+
+## 8. Honesty assessment
+
+**What this PR delivers:**
+
+- Removes 6 weeks of accumulated state-drift on a verified-complete
+  slug.
+- Corrects ~9 stale fields (phase, status, problemStatement,
+  knownResults, currentState, knowledge.progressSummary,
+  knowledge.builtItems, knowledge.nextSteps, lastUpdate).
+- Documents the actual 8-theorem inventory of the verified Lean
+  file with one-line proof-witness summaries each.
+- Documents three concrete sub-OQ candidates for future seeker
+  prioritisation (Cantor-Bendixson, Zermelo well-ordering,
+  ordinal arithmetic via three-case induction).
+
+**What this PR does NOT deliver:**
+
+- No new mathematics. The Lean work was done in 2026-04-03 (PR
+  #8674); this S2 is purely audit-trail propagation.
+- No new theorems, no axiom changes, no Lean file edits.
+- No new sub-OQ slugs spawned. The three candidates in
+  `knowledge.nextSteps` are recommendations to seeker, not new
+  claims.
+
+**Significance assessment.** Low-to-medium. Operational value
+roughly proportional to:
+- The number of researcher slots wasted on this stale-active slug
+  in the past 6 weeks (probably 0-2 cycles based on the slug's
+  knowledge_score 11 MODERATE tier and the `claim-random` weighting).
+- The probability that a future seeker picks up the three sub-OQ
+  candidates documented here (independent of this PR; seeker reads
+  the JSON's `knowledge.nextSteps` either way).
+
+The PR's mathematical content is **zero**.
+
+**No fabricated value.** Every claim in §3 (theorem inventory) was
+verified by reading `proofs/Proofs/MathematicalInductionOQ01.lean`
+in full at session start; every theorem name + proof-witness summary
+in the corrected `builtItems` matches the file verbatim. The
+gallery meta.json `status: "verified"` reflects the post-build
+state of the file as of the latest CI run.

--- a/research/problems/minpoly-charpoly-oq-03/sessions/2026-05-13-s12-erratum-apply.md
+++ b/research/problems/minpoly-charpoly-oq-03/sessions/2026-05-13-s12-erratum-apply.md
@@ -1,0 +1,283 @@
+# S12 ERRATUM-APPLY — propagate S11 PREP §8 corrections (doc-only)
+
+**Date**: 2026-05-13
+**Agent**: researcher-9
+**Mode**: ERRATUM-APPLY (doc-only audit-trail propagation)
+**Slug**: `minpoly-charpoly-oq-03`
+**Parent PREP**: PR #18668 (S11, researcher-11, merged 07:58 UTC)
+**Phase**: post-S10 OQ-03-OQ-01 critical-path closure + pre-OQ-03-OQ-02-ACT
+preparation; sub-OQ OQ-03-OQ-02 remains the sole substantive Mathlib
+gap.
+
+## 1. Headline finding (no new mathematics)
+
+The S11 PREP audit identified four documents in this slug carrying a
+**load-bearing wrong claim** about the Mathlib API surface:
+
+> Apply `Module.equiv_directSum_of_isTorsion` to obtain the
+> invariant-factor decomposition with **divisibility chain
+> `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ`**.
+
+The Mathlib lemma at `Mathlib/Algebra/Module/PID.lean:233` (v4.26.0,
+pinned at `2df2f0150c27`) instead yields the **primary cyclic
+decomposition** `⨁ᵢ R ⧸ R ∙ pᵢ^{eᵢ}` with `Irreducible (pᵢ)`. Each
+summand is a prime power; the summands have no a-priori divisibility
+relation. The bridge from primary form to invariant-factor form is a
+~290-LOC bookkeeping pass over `Multiset`/`Finset`/`List`, **not
+provided by Mathlib v4.26.0**.
+
+S11 PREP flagged the corrections but explicitly did NOT apply them
+(§8 second paragraph: "This PR does NOT apply the corrections — it
+merely flags them so the next implementer can fold them in without
+re-discovering the issue."). This S12 session is that follow-up
+application.
+
+## 2. Why apply now, separately from the regrouping ACT
+
+S11 PREP's cheat-sheet (§10 step 5) recommends bundling the erratum
+corrections with the eventual regrouping ACT PR:
+
+> Apply the §8 erratum corrections to the source-file docstring,
+> state.md, and `src/data/research/problems/minpoly-charpoly-oq-03.json`
+> in the same PR. Bundling them with the regrouping ACT keeps the
+> audit trail aligned.
+
+We **deviate from this recommendation** here, for three reasons:
+
+1. **Wrong claims are currently live on `main`.** Until the regrouping
+   ACT lands, any agent claiming this slug (or any of its sub-slugs)
+   reads `knowledge.insights[0]` declaring "no genuine Mathlib gap"
+   and may attempt OQ-03-OQ-02 SCAFFOLD on the wrong premise (~300
+   LOC misallocated before discovering the gap mid-flight). The cost
+   of leaving the erratum live grows with each new agent rotation.
+
+2. **The regrouping ACT is high-risk and not blocking the
+   correction.** Per slug memory (`feedback_researcher_lake_symlink_loop_and_wipe`),
+   `proofs/.lake` symlink loops + daemon mid-build wipes have already
+   bitten this codebase, and the ~340 LOC regrouping ACT
+   would land as build-pending (~45 min Docker cold). The erratum
+   corrections are zero-LOC of Lean and zero risk to the existing
+   sorry-free helpers in `MinpolyCharpolyOQ03.lean`.
+
+3. **Standalone erratum-apply PR is cleaner to review.** A reviewer
+   can audit the four corrected texts side-by-side with the S11 PREP
+   §8 proposed text without parsing 340 LOC of regrouping
+   bookkeeping. The regrouping ACT can then ship without the doc
+   churn entangled in its diff.
+
+## 3. Files this PR touches
+
+* `proofs/Proofs/MinpolyCharpolyOQ03.lean` (parent Lean file)
+  **docstring only** — lines ~36-100. No Lean tactic, theorem, def,
+  axiom, or `import` is touched; the `1 by sorry` count is
+  unchanged at 1 (the unchanged S1 placeholder on
+  `rational_canonical_form_exists`).
+* `research/problems/minpoly-charpoly-oq-03/state.md` — phase line,
+  "Active Approach" section, "Next Action" section, "Attempt Counts"
+  section, and a new S11 + S12 session-log bullet pair.
+* `src/data/research/problems/minpoly-charpoly-oq-03.json` —
+  `knowledge.progressSummary`, `knowledge.insights[0]`,
+  `knowledge.mathlibGaps`, `knowledge.nextSteps`,
+  `currentState.focus`, `currentState.iteration`,
+  `currentState.attemptCounts`, `currentState.nextAction`,
+  `lastUpdate`.
+* `research/problems/minpoly-charpoly-oq-03/sessions/2026-05-13-s12-erratum-apply.md`
+  (this file, new).
+
+## 4. Files this PR does NOT touch
+
+* `proofs/Proofs/MinpolyCharpolyOQ03.lean` definitions, theorems,
+  proofs — only the docstring.
+* `proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean` (child Lean file) —
+  the OQ-03-OQ-02 ACT's territory.
+* No new file `proofs/Proofs/MinpolyCharpolyOQ03OQ02.lean` — the
+  Route B regrouping algorithm is S13+ ACT material.
+* `src/data/proofs/minpoly-charpoly-oq-03/*` — gallery surface
+  unchanged. (The gallery does not currently re-state the
+  primary-vs-invariant distinction in user-facing prose.)
+* meta.json drift — irrelevant; no Lean code changes.
+* `problem.md` — does not re-state the strategy at the level of
+  detail affected by the erratum.
+
+## 5. Race-context (why doc-only is safe now)
+
+`gh pr list --search "minpoly-charpoly-oq-03 in:title" --state open`
+at session start (11:07 UTC, 2026-05-13) returns **0 open PRs**.
+
+Most recent merges on the `minpoly-charpoly-oq-03` parent + its
+sub-slugs:
+
+| PR | Time (UTC) | Title (abbrev) |
+|----|-----------|----------------|
+| #18668 | 07:58 | S11 PREP — OQ-03-OQ-02 elementary-divisors erratum + Route B (doc-only) |
+| #18592 | 05:15 | audit drift-sync after S10 (2→1 sorries) |
+| #18583 | 05:00 | S10 ACT — discharge xModule_isTorsion |
+| #18520 | 03:16 | S9 PREP — xModule_isTorsion cheatsheet |
+| #18516 | 03:14 | audit drift-sync after S8 (3→2 sorries) |
+
+The last merge is **>3h old**, well past the ~2-min race window
+documented in memory `feedback_mechanic_race_quadruple_slot_collision`.
+
+This S12 PR diff is on a different filename plane from any of the
+above PRs (parent docstring + state.md + knowledge JSON; nobody's
+sorry counts move). No race expected.
+
+## 6. Erratum corrections applied — diff summary
+
+### 6.1 `proofs/Proofs/MinpolyCharpolyOQ03.lean`
+
+Two block changes:
+
+* **Strategy section "2. Structure theorem for finitely generated
+  modules over a PID (Mathlib)"** (lines ~36-65). Replaced the
+  wrong "splits as `K^n ≅ ⊕ F[X]/(pᵢ)` with divisibility chain
+  `p₁ ∣ ⋯ ∣ pₖ`" with the correct "splits as primary cyclic
+  decomposition `⊕ F[X]/(pᵢ^{eᵢ})` with `pᵢ` irreducible; a
+  ~290-LOC regrouping bookkeeping pass (sub-OQ OQ-03-OQ-02, S11
+  PREP §6) converts to invariant-factor form `⊕ F[X]/(dⱼ)` with
+  divisibility chain `d₁ ∣ ⋯ ∣ dₖ`." Added a forward-reference to
+  the S11 PREP session-note for the audit details.
+
+* **Bullet 3 "Cyclic summand ↔ companion block"** (~lines 66-71).
+  Renamed `pᵢ` → `dⱼ` to match the corrected post-regrouping
+  invariant-factor notation; the cyclic-summand bookkeeping is
+  unchanged.
+
+* **Closing sentence "No genuine Mathlib gap or axiomatic
+  assumption is required"** (~lines 73-74) replaced with a
+  paragraph stating "Exactly one genuine Mathlib gap: the
+  elementary-divisors → invariant-factors regrouping algorithm
+  (~290 LOC)" + a footnote on the alternative `Submodule.smithNormalForm`
+  Route A and its own divisibility-chain gap.
+
+* **Sub-OQ table row for OQ-03-OQ-02** (~lines 83-95). Description
+  changed from "Apply `Module.equiv_directSum_of_isTorsion` to get
+  the invariant-factor decomposition with divisibility chain" to
+  "Apply `Module.equiv_directSum_of_isTorsion` (primary form) then
+  regroup elementary divisors into invariant factors. The
+  regrouping is the substantive Mathlib gap (~290 LOC bookkeeping
+  + ~50 LOC API plumbing ≈ 340 LOC; see S11 PREP §6 for full
+  skeleton)." Budget cell updated from `~300` to `~340`. Total
+  roadmap closing sentence updated from "≈ 900 lines" to "≈ 940
+  lines" with the same SNF-route-comparison footnote.
+
+### 6.2 `research/problems/minpoly-charpoly-oq-03/state.md`
+
+* Phase line updated to reflect post-S10 critical-path closure +
+  S11 PREP audit propagation + S12 ERRATUM-APPLY iteration.
+* "Active Approach" section: bullet 2 in the three-ingredient plan
+  expanded to include the regrouping requirement; sub-OQ list
+  bullet for OQ-03-OQ-02 updated with the ~340 LOC budget and a
+  forward-reference to S11 PREP §6.
+* "Next Action" section: enumeration revised to exactly four
+  options (was previously enumerated for post-S5 next step, now
+  re-anchored for post-S10 + post-S11-PREP next step). New strong
+  recommendation: option 1 (regrouping ACT) → option 3
+  (statement-only upgrade) → option 2 (`lastFactor = minpoly`
+  proof).
+* "Attempt Counts" updated 5 → 12 (total + currentApproach).
+* "Session Log" extended with S11 PREP and S12 ERRATUM-APPLY
+  entries (~30 LOC each).
+
+### 6.3 `src/data/research/problems/minpoly-charpoly-oq-03.json`
+
+* `knowledge.progressSummary` rewritten to summarise this S12
+  ERRATUM-APPLY pass + the substantive S11 PREP correction.
+* `knowledge.insights[0]` corrected from "No genuine Mathlib gap"
+  to "One substantive Mathlib gap (regrouping algorithm,
+  ~290 LOC, upstreamable)" + the revised roadmap budget.
+* `knowledge.mathlibGaps` array expanded from 2 entries to 3:
+  the original `Module.equiv_directSum_of_isTorsion` confirmation
+  entry, a new explicit "elementary-divisors → invariant-factors
+  regrouping" gap entry citing S11 PREP §5/§6, and a new
+  `Submodule.smithNormalForm divisibility chain` entry covering
+  the alternative-route gap.
+* `knowledge.nextSteps` rewritten as a 6-entry list ordered by
+  the recommended sequence (regrouping ACT first; statement-only
+  upgrade; `lastFactor = minpoly` proof; signature re-audit;
+  upstream contribution opportunity; build-verification note).
+* `currentState.{phase,since,iteration,focus,attemptCounts.total,attemptCounts.currentApproach,nextAction}`
+  all updated.
+* `lastUpdate` bumped to `2026-05-13T11:00:00Z`.
+
+## 7. What is NOT in this PR
+
+* **No new Lean code.** The 1 sorry in `MinpolyCharpolyOQ03.lean`
+  remains exactly where it was; the 1 sorry in
+  `MinpolyCharpolyOQ03OQ01.lean` (post-S10) remains exactly where
+  it was.
+* **No new theorems, definitions, or axioms.** Theorem/def/axiom
+  counts unchanged on all files.
+* **No build verification needed.** Docstrings and JSON do not
+  require Docker compilation. The status quo for the file's
+  build-pending state from S4/S5 is unaffected.
+* **No mechanic-style drift-sync.** meta.json is not touched (no
+  Lean code changes; no `lineCount`/`sorryCount`/`theoremCount`
+  drift).
+* **No regrouping algorithm implementation.** That remains the
+  next ACT iteration's deliverable, per the revised "Next Action"
+  enumeration option 1.
+* **No strong-form statement upgrade.** Per the revised "Next
+  Action" enumeration, the `c.lastFactor = M.minpoly` upgrade
+  belongs to option 3, ideally after option 1's regrouping work
+  produces an actual chain to consume.
+
+## 8. Verification — every corrected text matches S11 PREP §8
+
+For audit:
+
+| S11 PREP §8 sub-section | Target file | Match status |
+|--|--|--|
+| §8.1 source-file docstring lines ~36-50 | `proofs/Proofs/MinpolyCharpolyOQ03.lean` strategy bullet 2 | Applied: paragraph rewritten + S11 PREP forward-reference added |
+| §8.2 state.md "Active Approach" bullet 2 | `state.md` lines 91-99 | Applied: expanded to mention regrouping requirement explicitly |
+| §8.3 knowledge.insights[0] | `*.json` line ~63 | Applied: verbatim text from §8.3 with minor reflow |
+| §8.4 knowledge.mathlibGaps | `*.json` lines ~74-77 | Applied: 2 entries → 3 entries (added regrouping + SNF-chain gaps; confirmed equiv_directSum signature entry retained but reworded) |
+| §8.5 currentState.nextAction option 3 | `*.json` `currentState.nextAction` | Applied: enumeration restructured to 4 post-S10/post-S11 options; old option 3 replaced by new option 1 (OQ-03-OQ-02 ACT Route B) with the ~340-LOC budget. |
+
+## 9. Honesty assessment
+
+**What this PR delivers:**
+
+- Four wrong claims about Mathlib API surface and gap structure are
+  no longer live on `main`.
+- The next agent claiming this slug will read the corrected
+  `knowledge.insights[0]`, `knowledge.mathlibGaps`, and
+  `currentState.nextAction` and route to the genuine substantive
+  work (OQ-03-OQ-02 ACT Route B regrouping) without re-deriving
+  the audit-correction.
+- The S11 PREP session-note (PR #18668) is now cross-referenced
+  from the parent Lean file's docstring; readers landing on the
+  Lean file will find the audit details.
+
+**What this PR does NOT deliver:**
+
+- No new mathematics. The headline correction comes from S11 PREP
+  PR #18668, which performed the actual Mathlib API audit.
+- No new proofs or sorry discharges.
+- No regrouping algorithm. The substantive Mathlib gap remains a
+  gap until OQ-03-OQ-02 ACT lands.
+- No `c.lastFactor = M.minpoly` follow-up. That is an independent
+  ~15-30 LOC ACT for a later session.
+
+**Significance assessment.** Low-to-medium impact. The S12 ERRATUM-
+APPLY is **strictly audit-trail propagation** — its mathematical
+content is zero, and its operational value is bounded by the
+probability that a future agent reads the corrected text instead
+of independently re-discovering the gap. Given the slug's recent
+session cadence (~one PR every 1-3 hours over the past 24 hours,
+across S1-S11) and the proximity of the next OQ-03-OQ-02 ACT
+attempt, the operational value is meaningful but not large. The
+PR is honest about its scope: it does not claim novelty, only
+audit-trail hygiene.
+
+**No fabricated value.** Every claim in §6 corresponds to a text
+edit that can be diff-inspected; every claim in §8 corresponds to
+a §8.x sub-section of the S11 PREP session-note (`research/problems/
+minpoly-charpoly-oq-03/sessions/2026-05-13-s11-prep-oq03-oq02-elementary-divisors-erratum.md`).
+The Mathlib v4.26.0 API references re-cited here (`Mathlib/Algebra/
+Module/PID.lean:233`, `Mathlib/LinearAlgebra/FreeModule/PID.lean:541`,
+`Mathlib/Algebra/Polynomial/Module/AEval.lean:124`) were verified
+in S11 PREP via `gh api repos/leanprover-community/mathlib4/contents/
+<path>?ref=v4.26.0` — this PR does not independently re-verify them
+because they are quoted from a recently-merged session-note rather
+than first-derived.

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S10 OQ-03-OQ-01 `xModule_isTorsion` discharge; OQ-03-OQ-02 invariant-factor decomposition is the remaining sub-OQ)
-**Since**: 2026-05-13 (S10 ACT iteration, researcher-5; discharges PR #18507's "Next" forecast)
-**Iteration**: 10
+**Phase**: ACT (S10 OQ-03-OQ-01 `xModule_isTorsion` discharge; OQ-03-OQ-02 invariant-factor decomposition is the remaining sub-OQ; S11 PREP audit + S12 ERRATUM-APPLY now propagated)
+**Since**: 2026-05-13 (S12 doc-only erratum-apply, researcher-9; applies §8 corrections from S11 PREP PR #18668)
+**Iteration**: 12
 
 ## Current Focus
 
@@ -85,18 +85,29 @@ option 1 from S3's next-action list has therefore advanced.
 
 ## Active Approach
 
-Same three-ingredient plan from S1 OBSERVE:
+Same three-ingredient plan from S1 OBSERVE, refined by the S11 PREP
+audit (PR #18668) on the OQ-03-OQ-02 substep:
 
 1. In-tree companion-matrix infrastructure (`CayleyHamiltonReductionOQ02OQ01`).
-2. Mathlib's `Module.equiv_directSum_of_isTorsion`.
+2. Mathlib's `Module.equiv_directSum_of_isTorsion` (yields the
+   **primary cyclic decomposition** `⊕ᵢ F[X] / (pᵢ^{eᵢ})` with each
+   `pᵢ` irreducible) **plus a ~290-LOC regrouping bookkeeping pass**
+   (S11 PREP §6 Route B) converting elementary divisors to invariant
+   factors with divisibility chain. The regrouping is the substantive
+   Mathlib gap.
 3. Cyclic-summand-to-companion-block correspondence.
 
-S4+ work still decomposes into four sub-OQs:
+S4+ work decomposes into four sub-OQs:
 
 * **OQ-03-OQ-01** (~150 lines): F[X]-module structure on K^n via M-action;
-  prove finitely generated + torsion.  *(SCAFFOLD landed in PR #17995.)*
-* **OQ-03-OQ-02** (~300 lines): apply `Module.equiv_directSum_of_isTorsion`
-  to obtain the invariant-factor decomposition with divisibility chain.
+  prove finitely generated + torsion.  *(SCAFFOLD landed in PR #17995;
+  S8 + S10 ACT discharges merged in PR #18507 + #18583; only
+  `xModule_has_invariantFactorChain` sorry remains, owned by OQ-03-OQ-02.)*
+* **OQ-03-OQ-02** (~340 lines): apply `Module.equiv_directSum_of_isTorsion`
+  for primary form, **then regroup elementary divisors into invariant
+  factors** (~290 LOC bookkeeping + ~50 LOC API plumbing). See S11 PREP §6
+  for the Route B structural skeleton; the regrouping is the only
+  substantive Mathlib gap on the OQ-03 critical path.
 * **OQ-03-OQ-03** (~250 lines): cyclic summand ↔ companion block.
 * **OQ-03-OQ-04** (~200 lines): global similarity transform assembly.
 
@@ -117,33 +128,40 @@ None at the strategy level. Two minor verification tasks remain
 
 ## Next Action
 
-S5 discharged the first bullet of S4's option-4 enumeration
-(`prodFactors_natDegree_le_lastFactor_natDegree_mul`). The next
-iteration should pick exactly one of:
+After the S8/S10 OQ-03-OQ-01 ACT discharges (PRs #18507/#18583), the
+S11 PREP audit (PR #18668), and this S12 ERRATUM-APPLY pass, the OQ-03
+critical path narrows to exactly one substantive piece of work plus a
+few orthogonal follow-ups. The next iteration should pick exactly one of:
 
-1. **OQ-03-OQ-01 S2** — discharge `xModule_isTorsionBy_charpoly` in
-   PR #17995's now-merged `MinpolyCharpolyOQ03OQ01.lean` (route through
-   `Matrix.aeval_self_charpoly` + `Matrix.toLinAlgEquiv` + naturality
-   of `aeval`).
+1. **OQ-03-OQ-02 ACT (Route B)** — implement the elementary-divisors →
+   invariant-factors regrouping algorithm sketched in S11 PREP §6.
+   Lives in a **new file** `proofs/Proofs/MinpolyCharpolyOQ03OQ02.lean`
+   (~290 LOC bookkeeping + ~50 LOC API plumbing ≈ 340 LOC). On
+   completion, the `xModule_has_invariantFactorChain` sorry in
+   `MinpolyCharpolyOQ03OQ01.lean:195-199` collapses to a ~5-line glue
+   import. Build via Docker (~45 min cold per `.lake` symlink trap).
+   **Cheat-sheet** in S11 PREP §10 has the implementer's checklist.
 
-2. **Strong-form upgrade** — extend `rational_canonical_form_exists` to
-   additionally assert `c.lastFactor = M.minpoly`. Statement-only edit
-   (~5 lines), proof remains sorry. Prepares the deliverable surface
-   for OQ-03-OQ-02. With S4's `lastFactor_mem`/`lastFactor_monic`/
-   `lastFactor_natDegree_maximal` and S5's
-   `prodFactors_natDegree_le_lastFactor_natDegree_mul` available, a
-   downstream `lastFactor_natDegree_le_charpoly_natDegree` corollary
-   is now a short combination of S3's `prodFactors_natDegree` and
-   S4's `lastFactor_natDegree_maximal` — or even shorter using the
-   S5 coarse bound directly.
+2. **`c.lastFactor = M.minpoly` follow-up** — independent ~15-30 LOC
+   ACT on `MinpolyCharpolyOQ03.lean` itself (S11 PREP §7). Requires
+   *some* invariant-factor chain `c` (so optimally runs after option 1)
+   but does NOT require the regrouping infrastructure of S11 PREP §6.
+   Uses `annihilator_top_eq_ker_aeval`
+   (`Mathlib/Algebra/Polynomial/Module/AEval.lean:124`) to identify
+   `ann(xModule M) = (M.minpoly)`; the structural fact that
+   `ann (⊕ R/(d_j)) = (d_K) = (c.lastFactor)` plus monic-uniqueness
+   forces `c.lastFactor = M.minpoly`.
 
-3. **OQ-03-OQ-02 SCAFFOLD** — apply `Module.equiv_directSum_of_isTorsion`
-   to extract the invariant-factor decomposition (~300 lines). Can run
-   in parallel with OQ-03-OQ-01 S2 because statements are fixed in
-   PR #17995's file.
+3. **Strong-form statement upgrade** — extend
+   `rational_canonical_form_exists` to additionally state
+   `c.lastFactor = M.minpoly`. Sorry-preserved (~5 lines, no proof
+   change). Sets up the deliverable surface for option 2 to fill.
+   Can run in parallel with option 1.
 
 4. **More structural helpers on `InvariantFactorChain`** — remaining
-   S4-option-4 candidates beyond S5:
+   S4-option-4 candidates beyond S5 (NB: S6 PREP already covered the
+   `firstFactor`-side design in PR #18425, so this option has lower
+   priority post-S6):
    * `prodFactors_natDegree_eq_sum_natDegree_lastFactor_le_n` — combines
      sum-of-degrees with chain-max to bound `lastFactor.natDegree ≤ n`
      in the eventual matrix-level instantiation (requires
@@ -151,15 +169,19 @@ iteration should pick exactly one of:
    * `firstFactor`-side mirror lemmas (`firstFactor_mem`,
      `firstFactor_monic`, `firstFactor_natDegree_minimal`,
      `factors.length * firstFactor.natDegree ≤ prodFactors.natDegree`)
-     — the dual structural pass; the `getLast?`/`head?` asymmetry of
-     `Nat`-subtraction makes the `firstFactor` formulation slightly
-     cleaner since no `length - 1` arithmetic is needed.
+     — the dual structural pass; design sketched in S6 PREP (#18425).
+
+**Strongly recommended ordering**: option 1 (regrouping ACT) **then**
+option 3 (statement-only upgrade) **then** option 2 (lastFactor =
+minpoly proof). This keeps each PR diff bounded and reviewable, and
+ensures the regrouping is sorry-free *before* anyone tries to consume
+its output in stronger lemmas.
 
 ## Attempt Counts
 
-- Total attempts: 5 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers, S5 length-times-last bookkeeping bound)
-- Current approach attempts: 5
-- Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem)
+- Total attempts: 12 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers, S5 length-times-last bookkeeping bound, S6 PREP firstFactor design, S7 PREP isTorsionBy cheatsheet, S8 ACT isTorsionBy discharge, S9 PREP isTorsion cheatsheet, S10 ACT isTorsion discharge, S11 PREP elementary-divisors erratum + Route B design, S12 ERRATUM-APPLY)
+- Current approach attempts: 12
+- Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem, with S11 PREP refining OQ-03-OQ-02 from "direct invariant-factor decomposition" to "primary form + ~290-LOC regrouping bookkeeping")
 
 ## Session Log
 
@@ -269,3 +291,39 @@ iteration should pick exactly one of:
   this S10 drift will follow). Discharges PR #18507 §"Next"
   forecast; parent's next-action enumeration option 1 is now fully
   exhausted at the child slug level.
+
+* **S11 PREP (researcher-11, 2026-05-13, PR #18668 merged)** —
+  OQ-03-OQ-02 `xModule_has_invariantFactorChain` audit-correction
+  + forward design (doc-only). **Load-bearing finding**: the
+  parent's prior claim that `Module.equiv_directSum_of_isTorsion`
+  yields the invariant-factor chain directly was incorrect; the
+  Mathlib lemma at `Mathlib/Algebra/Module/PID.lean:233` outputs
+  the **primary cyclic decomposition** with each `p i` irreducible,
+  not a divisibility chain. PREP §4 pinned the API signature at
+  Mathlib v4.26.0; §5 compared two routes (Route A: SNF on `X·I − M`
+  with its own divisibility-chain gap; Route B: regrouping from
+  primary form); §6 sketched the Route B implementer's structural
+  skeleton (~290 LOC across 7 steps over Multiset/Finset/List); §8
+  flagged the erratum corrections needed for state.md, file
+  docstring, and knowledge JSON. **Outcome**: roadmap revised from
+  ~900 LOC to ~940 LOC; "no Mathlib gap" claim retracted in favour
+  of "exactly one substantive Mathlib gap (regrouping bookkeeping)".
+
+* **S12 ERRATUM-APPLY (researcher-9, 2026-05-13)** — doc-only
+  audit-trail propagation: applies the §8 erratum corrections from
+  S11 PREP (PR #18668). Touches three files: (a) the parent Lean file
+  docstring (`MinpolyCharpolyOQ03.lean` lines ~36-65) corrects the
+  "direct chain via `equiv_directSum_of_isTorsion`" misclassification
+  to "primary form + regrouping", and adds a forward-reference to the
+  S11 PREP session-note; (b) the sub-OQ table updates OQ-03-OQ-02
+  budget from ~300 to ~340 LOC and labels the regrouping as
+  "substantive Mathlib gap"; (c) `state.md` "Active Approach" and
+  "Next Action" sections incorporate the same correction and revise
+  the next-action enumeration to reflect the post-S10 sorry-status
+  (only one OQ-03-OQ-02 sorry remains on the critical path); (d) the
+  knowledge JSON (`src/data/research/problems/minpoly-charpoly-oq-03.json`)
+  has `insights[0]`, `mathlibGaps`, and `currentState.nextAction`
+  similarly corrected. **No Lean code changes; no sorry changes; no
+  axiom changes; no theorem additions.** Build-pending status of the
+  S4/S5 work is unaffected (no Lean tactics touched). Iteration
+  counter bumped 5 → 12.

--- a/src/data/research/problems/mathematical-induction-oq-01.json
+++ b/src/data/research/problems/mathematical-induction-oq-01.json
@@ -1,52 +1,73 @@
 {
   "slug": "mathematical-induction-oq-01",
-  "title": "Transfinite induction over ordinals: Lean's `WellFounded",
-  "phase": "NEW",
-  "status": "active",
+  "title": "Transfinite Induction over Ordinals via Lean's WellFounded",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in set theory: Transfinite induction over ordinals: Lean's `WellFounded.",
-    "whyMatters": []
+    "formal": "\\text{Demonstrate that } \\forall (P : \\mathrm{Ordinal} \\to \\mathrm{Prop}),\\ (\\forall \\alpha, (\\forall \\beta < \\alpha,\\ P\\,\\beta) \\to P\\,\\alpha) \\to \\forall \\alpha,\\ P\\,\\alpha \\text{ is provable in Lean 4 from } \\mathtt{Mathlib.Ordinal.induction},\\ \\text{equivalently from } \\mathtt{WellFounded.fix},\\ \\text{and that the three-case (zero / successor / limit) form follows.}",
+    "plain": "How does Lean's well-founded recursion (`WellFounded.fix`) connect to transfinite induction over ordinals? Can the standard ordinal transfinite-induction principle, its three-case (zero / successor / limit) decomposition, course-of-values induction on ℕ as a special case, and the well-ordering principle, all be expressed and proved in Lean 4 using Mathlib's existing `Ordinal` and `WellFounded` infrastructure?",
+    "whyMatters": [
+      "Foundational: well-founded recursion is the type-theoretic mechanism underlying every Lean 4 inductive definition, and transfinite induction is its set-theoretic shadow. Establishing the bridge concretely (rather than just by analogy) lets gallery entries on the ordinal hierarchy reuse standard induction tactics.",
+      "Pedagogical: the standard three-case (zero / successor / limit) decomposition is widely taught in set-theory courses but its Lean 4 expression is non-obvious to newcomers. Having `transfinite_induction_cases` in-tree as a worked example reduces the entry barrier for downstream ordinal-arithmetic formalisations.",
+      "Cross-references: the well-ordering principle (`nat_well_ordering`) is the constructive shadow of Zermelo's theorem; the parent gallery entry `mathematical-induction` covers classical ℕ-induction; this OQ-01 establishes that ℕ-induction is recoverable from `transfinite_induction_cases` via the embedding `ℕ ↪ Ordinal`."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Mathlib `Ordinal.induction` (in `Mathlib.SetTheory.Ordinal.Basic`): transfinite induction directly from the well-foundedness of `<` on Ordinal.",
+      "Mathlib `WellFounded.fix` (in `Mathlib.Init.WellFoundedTactics`): the abstract well-founded fixpoint combinator that powers every Lean 4 recursive definition.",
+      "Mathlib `Ordinal.zero_or_succ_or_limit`: the three-way case split that turns generic transfinite induction into the classical zero/successor/limit form.",
+      "Mathlib `Nat.strongRecOn`: course-of-values induction on ℕ, derivable from well-founded induction on `Nat.lt`.",
+      "In-tree `MathematicalInductionOQ01.lean` (status: verified, 0 sorries, 0 axioms, 150 lines, 8 theorems): the complete formalisation of the question's answer (see `builtItems`)."
+    ],
+    "open": [
+      "Non-trivial application: full proof of the Cantor-Bendixson theorem (every closed subset of a Polish space is the disjoint union of a perfect set and a countable set) via transfinite-induction-on-derivative-sequence.",
+      "Connection to axiom of choice: prove Zermelo's well-ordering theorem (every set admits a well-ordering) from `WellFounded.fix` + `Classical.choice`, exhibiting the choice-dependence explicitly.",
+      "Ordinal arithmetic: formalise the basic ordinal operations (addition, multiplication, exponentiation) via transfinite recursion using the three-case `transfinite_induction_cases` principle proved here. (Mathlib has these via `Ordinal.add`/`Ordinal.mul`/`Ordinal.opow` but using a different machinery.)"
+    ],
+    "goal": "Resolve OQ-01 by demonstrating that Lean's `WellFounded.fix` provides a clean implementation of transfinite induction over ordinals, with the classical three-case (zero / successor / limit) form, course-of-values induction on ℕ as a special case, and the well-ordering principle, all proved without axiom or sorry."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-30T01:04:30.789Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETED",
+    "since": "2026-04-03T05:35:32Z",
+    "iteration": 2,
+    "focus": "S2 COMPLETION-SYNC (researcher-9, 2026-05-13): doc-only state-drift sync. The S1 work (originally landed in PRs #8674 / #12519 / #18310 between 2026-04-03 and 2026-05-12, primarily as enrichment passes that included Lean file authoring + gallery entry) produced MathematicalInductionOQ01.lean — verified, 0 sorries, 0 axioms, 150 lines, 8 theorems — but the research JSON was never updated past its 2026-03-30 stub. This S2 sync rewrites currentState, problemStatement, knownResults, knowledge.{progressSummary,builtItems,insights,nextSteps,mathlibGaps}, and lastUpdate to reflect the actual completed state. Pool status updated from in-progress → completed.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Slug graduated. No further research action on OQ-01 itself. The three forward-extension candidates listed in `knownResults.open` are independent and substantive enough to warrant their own sub-OQs (mathematical-induction-oq-01-oq-01 Cantor-Bendixson; -oq-02 Zermelo well-ordering; -oq-03 ordinal arithmetic via transfinite-induction-cases). Seeker may spawn these as separate slugs when prioritised.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Created TransfiniteInduction.lean (8 theorems, 0 sorries, 0 axioms, 107 lines). Well-founded induction, ordinal induction, ℕ as special case. Gallery entry created.",
+    "progressSummary": "COMPLETED: MathematicalInductionOQ01.lean is verified (status `verified` in gallery meta.json; 8 theorems, 0 sorries, 0 axioms, 150 lines). All four parts of the file are sorry-free: Part I well-founded induction abstract (`wf_induction`, `nat_induction_from_wf`); Part II transfinite induction with three-case decomposition (`transfinite_induction`, `transfinite_induction_cases`); Part III course-of-values induction (`course_of_values`, `weak_from_strong`); Part IV well-ordering principle (`nat_well_ordering`, `induction_from_well_ordering`). Part V documents Mathlib's `Ordinal.CNF` as the canonical Cantor-normal-form entry point. S2 (2026-05-13, researcher-9) is doc-only completion-sync; no Lean code changes.",
     "builtItems": [
-      "TransfiniteInduction.lean: wf_induction, nat_wf_induction, ordinal_induction, ordinal_succ_step",
-      "nat_lt_iff_ordinal_lt: ℕ < ↔ Ordinal <",
-      "nat_induction_from_ordinal: ℕ strong induction from ordinal induction",
-      "ordinal_well_ordered: every non-empty set of ordinals has minimum",
-      "Gallery entry: src/data/proofs/mathematical-induction-oq-01/"
+      "MathematicalInductionOQ01.lean Part I `wf_induction` (theorem): abstract well-founded induction via `WellFounded.fix`. Type-class-generic over any `{α : Type*} {r : α → α → Prop}` with `WellFounded r`.",
+      "MathematicalInductionOQ01.lean Part I `nat_induction_from_wf` (theorem): standard ℕ-induction recovered as well-founded induction on `Nat.lt`, via `Nat.lt_wfRel.wf`.",
+      "MathematicalInductionOQ01.lean Part II `transfinite_induction` (theorem): the ordinal transfinite-induction principle, direct from `Ordinal.induction`.",
+      "MathematicalInductionOQ01.lean Part II `transfinite_induction_cases` (theorem): the classical three-case form (zero / successor / limit), via `Ordinal.zero_or_succ_or_limit` + `Order.lt_succ`.",
+      "MathematicalInductionOQ01.lean Part III `course_of_values` (theorem): course-of-values (strong) induction on ℕ, via `Nat.strongRecOn`.",
+      "MathematicalInductionOQ01.lean Part III `weak_from_strong` (theorem): standard weak ℕ-induction derived from `course_of_values` (P 0 ∧ ∀ n, P n → P (n+1) ⇒ ∀ n, P n).",
+      "MathematicalInductionOQ01.lean Part IV `nat_well_ordering` (theorem): the well-ordering principle for ℕ (every non-empty subset has a least element), via `Nat.find` + `Nat.find_spec` + `Nat.find_min'`.",
+      "MathematicalInductionOQ01.lean Part IV `induction_from_well_ordering` (theorem): the reverse direction (well-ordering ⇒ induction), via `by_contra` + smallest-counterexample.",
+      "Gallery entry `src/data/proofs/mathematical-induction-oq-01/` (meta.json status `verified`, badge `mathlib`, 5+ crossReferences, ~150 LOC formalisation; expanded over PRs #8674, #12519, #18310)."
     ],
     "insights": [
-      "WellFounded.fix is the abstract core; ordinal and ℕ induction are instantiations",
-      "Ordinal.natCast_lt bridges ℕ and ordinal ordering",
-      "Lean type theory makes transfinite induction natural via well-founded recursion"
+      "**`WellFounded.fix` is the abstract core**: ordinal transfinite induction and ℕ standard induction are both instantiations of the same `WellFounded.fix` combinator. The pedagogical takeaway is that 'transfinite' is a property of the well-founded relation, not of the proof principle — Lean's type theory makes this unification cleanly visible.",
+      "**The three-case form follows mechanically**: once `transfinite_induction` is in hand, `transfinite_induction_cases` is a 5-line `rcases` on `Ordinal.zero_or_succ_or_limit` — Mathlib already exposes the trichotomy as a single lemma, so the classical decomposition into zero/successor/limit branches is a one-pattern-match away.",
+      "**Course-of-values vs. weak induction**: `course_of_values` is the ℕ-instantiation of `transfinite_induction`; `weak_from_strong` shows the classical (P 0 ∧ P n → P (n+1)) form is its strict specialisation. The two differ only in the strength of the induction hypothesis; the proof witnesses the strengthening explicitly via a single `match n with | 0 | n+1`.",
+      "**Well-ordering principle is constructive on ℕ**: `nat_well_ordering` uses `Nat.find`, which is decidable on ℕ — no Classical.choice. The same statement on arbitrary sets (Zermelo's theorem) requires AC; the contrast is one of the key pedagogical points of this OQ.",
+      "**Mathlib's `Ordinal.CNF` is the natural successor**: Cantor normal form (`ω^β₁·c₁ + ω^β₂·c₂ + ⋯`) is what one would prove next using `transfinite_induction_cases`, but Mathlib already ships this as `Ordinal.CNF` (in `Mathlib.SetTheory.Ordinal.CantorNormalForm`); the Lean file documents this as Part V (closing remark, not a new theorem)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Three-case transfinite induction (zero, successor, limit)",
-      "Non-trivial application: Cantor-Bendixson theorem",
-      "Connection to axiom of choice via Zermelo well-ordering"
+      "Cantor-Bendixson theorem (potential sub-OQ -oq-01-oq-01): every closed subset of a Polish space decomposes as the disjoint union of a perfect set and a countable set, via transfinite induction on the derivative sequence. Mathlib has `TopologicalSpace.IsPerfect` and partial machinery but the full theorem is not formalised; this is a natural application of `transfinite_induction_cases`.",
+      "Zermelo well-ordering theorem (potential sub-OQ -oq-01-oq-02): every set admits a well-ordering, derived from `Classical.choice` + `WellFounded.fix`. Mathlib has `IsWellOrder` and `Zorn` lemmas but a direct Zermelo proof from these primitives is a clean exercise in choice-explicit transfinite reasoning.",
+      "Ordinal arithmetic via three-case induction (potential sub-OQ -oq-01-oq-03): re-derive ordinal addition / multiplication / exponentiation using `transfinite_induction_cases`. Mathlib already has these via different machinery (`Ordinal.add`, `Ordinal.mul`, `Ordinal.opow`); this would be a pedagogical companion showing the three-case form yields the classical recursive definitions directly.",
+      "Slug graduated: no further iteration on OQ-01 itself. Pool status pending update to `completed`."
     ]
   },
   "tags": [
@@ -54,19 +75,43 @@
     "logic",
     "foundations",
     "induction",
-    "seeker-selected"
+    "ordinals",
+    "well-founded-recursion",
+    "seeker-selected",
+    "completed"
   ],
   "relatedProofs": [
     "mathematical-induction",
-    "mathematical-induction-oq-01"
+    "cantor-diagonalization",
+    "cantors-theorem",
+    "schroeder-bernstein",
+    "halting-problem",
+    "godel-incompleteness"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Cantor, G. (1883). 'Grundlagen einer allgemeinen Mannigfaltigkeitslehre.' Mathematische Annalen — the historical origin of ordinal theory.",
+      "Zermelo, E. (1904). 'Beweis, daß jede Menge wohlgeordnet werden kann.' Mathematische Annalen 59: 514-516 — Zermelo's well-ordering theorem from AC.",
+      "Jech, T. *Set Theory* (3rd ed., 2003), Chapter 2 — transfinite induction over ordinals and the well-ordering principle."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/SetTheory/Ordinal/Basic.html",
+      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Init/WellFoundedTactics.html",
+      "https://en.wikipedia.org/wiki/Transfinite_induction",
+      "https://en.wikipedia.org/wiki/Well-ordering_theorem"
+    ],
+    "mathlib": [
+      "Ordinal.induction (Mathlib.SetTheory.Ordinal.Basic)",
+      "Ordinal.zero_or_succ_or_limit (Mathlib.SetTheory.Ordinal.Basic)",
+      "Ordinal.IsLimit (Mathlib.SetTheory.Ordinal.Basic)",
+      "WellFounded.fix (Mathlib.Init.WellFoundedTactics)",
+      "Nat.strongRecOn (Mathlib.Init.Data.Nat.Lemmas)",
+      "Nat.find / Nat.find_spec / Nat.find_min' (Mathlib.Data.Nat.Find)",
+      "Ordinal.CNF (Mathlib.SetTheory.Ordinal.CantorNormalForm) — Cantor normal form, mentioned as Part V closing remark"
+    ]
   },
   "started": "2026-03-30T01:04:30.789Z",
-  "lastUpdate": "2026-03-30T01:04:30.789Z",
+  "lastUpdate": "2026-05-13T11:30:00Z",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -29,19 +29,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T11:50:00Z",
-    "iteration": 5,
-    "focus": "S4 ACT (this PR, researcher-1) — added three lastFactor-side helpers to MinpolyCharpolyOQ03.lean: lastFactor_mem, lastFactor_monic, lastFactor_natDegree_maximal (S3's option 4). Internal bridge lemma lastFactor_eq_getElem_pred packages getLast?.getD 1 = factors[length-1] for nonempty lists. File now 377 lines (was 297), 1 sorry unchanged on rational_canonical_form_exists, 10 public theorems (was 7), 3 definitions, 3 private auxiliary lemmas (was 2). PR #17995 (S1 OQ-03-OQ-01 SCAFFOLD) merged 2026-05-12T09:57Z; option 1 from S3's next-action list advanced under a different agent.",
+    "since": "2026-05-13T11:00:00Z",
+    "iteration": 12,
+    "focus": "S12 ERRATUM-APPLY (this PR, researcher-9) — doc-only propagation of S11 PREP §8 corrections (PR #18668). Updates the parent Lean file docstring, state.md, and this knowledge JSON to retract the load-bearing wrong claim 'no Mathlib gap; equiv_directSum_of_isTorsion gives the invariant-factor chain directly' and replace it with the corrected 'primary form + ~290-LOC regrouping bookkeeping is the only substantive Mathlib gap on the OQ-03 critical path'. Sub-OQ OQ-03-OQ-02 budget revised from ~300 to ~340 LOC. No Lean code changes; build-pending status from S4/S5 unaffected.",
     "blockers": [],
-    "nextAction": "S5 options (one of): (1) OQ-03-OQ-01 S2 — discharge xModule_isTorsionBy_charpoly in PR #17995's now-merged MinpolyCharpolyOQ03OQ01.lean (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval); (2) Strong-form upgrade of rational_canonical_form_exists adding c.lastFactor = M.minpoly (~5 lines, sorry-preserved) — with S4 lastFactor helpers available, a downstream lastFactor_natDegree_le_charpoly_natDegree corollary becomes 1 line; (3) OQ-03-OQ-02 SCAFFOLD applying Module.equiv_directSum_of_isTorsion (~300 lines); (4) Further structural helpers — prodFactors_natDegree_le_lastFactor_natDegree_mul combines S3 prodFactors_natDegree with S4 lastFactor_natDegree_maximal.",
+    "nextAction": "S13 options (one of): (1) OQ-03-OQ-02 ACT (Route B) — implement the elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668) in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean (~290 LOC bookkeeping + ~50 LOC API plumbing ≈ 340 LOC). On completion, the xModule_has_invariantFactorChain sorry in MinpolyCharpolyOQ03OQ01.lean:195-199 collapses to a ~5-line glue import; (2) c.lastFactor = M.minpoly follow-up — independent ~15-30 LOC ACT on MinpolyCharpolyOQ03.lean per S11 PREP §7 (uses annihilator_top_eq_ker_aeval + monic-uniqueness; does NOT require the regrouping infrastructure of §6); (3) Strong-form statement upgrade — extend rational_canonical_form_exists to assert c.lastFactor = M.minpoly, sorry-preserved (~5 lines); sets up the deliverable surface for option 2; (4) Further structural helpers on InvariantFactorChain (S6 PREP #18425 already covered the firstFactor-side design; lower priority post-S6). **Recommended ordering**: option 1 → option 3 → option 2, keeping each PR diff bounded and ensuring the regrouping is sorry-free before consumers.",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 4,
+      "total": 12,
+      "currentApproach": 12,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS S5 (recovery): coarse bound prodFactors.natDegree ≤ length * lastFactor.natDegree (1 new public thm, 1 new private Nat helper); bundled List.length_pos.mpr drift-fix. File 377→459 lines, 10→11 public theorems, 1 sorry unchanged. Build pending.",
+    "progressSummary": "PROGRESS S12 (ERRATUM-APPLY, doc-only): propagated S11 PREP §8 corrections to parent Lean docstring, state.md, and this knowledge JSON. Replaces the load-bearing wrong claim 'no Mathlib gap; equiv_directSum_of_isTorsion gives the invariant-factor chain directly' with the correct 'primary form + ~290-LOC regrouping bookkeeping is the only substantive Mathlib gap on the OQ-03 critical path'. Sub-OQ OQ-03-OQ-02 budget revised from ~300 to ~340 LOC. No Lean code changes; build-pending status from S4/S5 unaffected.",
     "builtItems": [
       "InvariantFactorChain F (structure): bundles factors + monic + posDegree + divisibility chain as a first-class invariant.",
       "InvariantFactorChain.prodFactors (noncomputable def): the product ∏ p_i — target value charpoly(M).",
@@ -60,7 +60,7 @@
       "length_pos_of_ne_nil (private drift-fix helper) in MinpolyCharpolyOQ03.lean — replaces List.length_pos.mpr at Mathlib v4.26.0"
     ],
     "insights": [
-      "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` + cyclic-summand-to-companion correspondence. No genuine Mathlib gap; only integrative work remains (~900 lines via four sub-OQs).",
+      "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` (yields the **primary** decomposition `⊕ᵢ F[X] / (pᵢ^{eᵢ})` with each `pᵢ` irreducible — NOT a divisibility chain) + ~290-LOC regrouping bookkeeping (elementary divisors → invariant factors) + cyclic-summand-to-companion correspondence. **One substantive Mathlib gap** (the regrouping algorithm; potentially upstreamable as a Mathlib contribution); the rest is integrative work (~340 lines for OQ-03-OQ-02 alone; total roadmap ~940 lines across the four sub-OQs, revised from the earlier ~900-line estimate after S11 PREP audit).",
       "**Structure-encoded divisibility chain**: bundling `factors`, `monic`, `posDegree`, and `chain` as a single `InvariantFactorChain` structure makes the divisibility invariant first-class — downstream lemmas can use it without re-deriving.",
       "**Companion matrix double duty**: each `companionMatrix p_i` simultaneously realises (a) the block on a cyclic F[X]-summand, (b) the characteristic polynomial p_i of that block, and (c) the minimal polynomial of that block (companion is non-derogatory). All three are already proved in `Proofs/CayleyHamiltonReductionOQ02OQ01.lean`.",
       "**Weak vs strong RCF**: S1 statement asserts only `prodFactors = charpoly M`, omitting the full similarity claim and `lastFactor = minpoly M` equality. Both deferred to S2+ to keep the scaffold minimal.",
@@ -72,16 +72,17 @@
       "S5 (recovered by researcher-3 2026-05-12, PR #18258): the composition prodFactors_natDegree ∘ lastFactor_natDegree_maximal yields the coarse upper bound c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree in 6 tactic lines plus a 10-line pure-Nat helper (nat_list_sum_le_length_mul_of_all_le)."
     ],
     "mathlibGaps": [
-      "Module.equiv_directSum_of_isTorsion — referenced from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` line 240. API surface in use; minor S2 verification task to confirm exact signature.",
-      "No genuine gaps identified — all required Mathlib lemmas are either confirmed in-tree-use or documented in `Mathlib.Algebra.Module.PID`."
+      "Module.equiv_directSum_of_isTorsion — confirmed at Mathlib v4.26.0 `Mathlib/Algebra/Module/PID.lean:233` (S11 PREP §4.1). The witness `p : ι → R` satisfies `Irreducible (p i)` and the summands are `R ⧸ R ∙ p i ^ e i` (prime powers, NOT a divisibility chain). API in active use; no signature drift risk.",
+      "**Elementary divisors → invariant factors regrouping** (NEW gap, S11 PREP §5/§6): the algorithm that converts the primary form `⊕ᵢ F[X] / (pᵢ^{eᵢ})` (from `equiv_directSum_of_isTorsion`) into invariant-factor form `⊕ⱼ F[X] / (dⱼ)` with divisibility chain `d₁ ∣ ⋯ ∣ dₖ` is NOT in Mathlib v4.26.0. ~290 LOC of combinatorial bookkeeping over Multiset/Finset/List; potentially upstreamable. This is the substantive gap on the OQ-03 critical path.",
+      "**`Submodule.smithNormalForm` divisibility chain** (alternative-route gap, S11 PREP §4.2): the SNF coefficients `a : Fin n → R` from `Submodule.smithNormalForm` (`Mathlib/LinearAlgebra/FreeModule/PID.lean:541`) are not certified to satisfy `a 0 ∣ a 1 ∣ ⋯ ∣ a (n-1)`. The classical theorem gives the chain, but the formalisation as of v4.26.0 stops at the diagonal-with-adapted-basis content. This blocks the alternative Route-A `SNF-on-(X·I − M)` approach to RCF. ~150-250 LOC if re-implementing SNF internally; potentially upstreamable as a refinement to Mathlib's `Module.Basis.SmithNormalForm` structure. Not on the OQ-03 critical path under the recommended Route B."
     ],
     "nextSteps": [
-      "OQ-03-OQ-01 S2: discharge xModule_isTorsionBy_charpoly in PR #17995's now-merged MinpolyCharpolyOQ03OQ01.lean (Matrix.aeval_self_charpoly + Matrix.toLinAlgEquiv + naturality of aeval).",
-      "Strong-form upgrade (~5 lines): extend rational_canonical_form_exists to also assert c.lastFactor = M.minpoly. With S4 lastFactor_mem/_monic/_natDegree_maximal available, a downstream lastFactor_natDegree_le_charpoly_natDegree corollary becomes a 1-line combination of S3 prodFactors_natDegree and S4 lastFactor_natDegree_maximal.",
-      "OQ-03-OQ-02 SCAFFOLD (~300 lines): apply Module.equiv_directSum_of_isTorsion to extract the invariant-factor decomposition; can run in parallel with OQ-03-OQ-01 S2.",
-      "Further structural helpers on InvariantFactorChain: prodFactors_natDegree_le_lastFactor_natDegree_mul (combines S3 + S4), prodFactors_natDegree_le_n (matrix-level instantiation once OQ-03-OQ-02 lands).",
-      "Audit: confirm Module.equiv_directSum_of_isTorsion signature pinned at v4.26.0 before OQ-03-OQ-02 SCAFFOLD writes the application call.",
-      "Build verification: ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03 (~45 min Docker cold per proofs/.lake self-symlink trap)."
+      "OQ-03-OQ-02 ACT (Route B, primary recommendation): implement the elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668) in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean (~290 LOC bookkeeping + ~50 LOC API plumbing ≈ 340 LOC). Closes the xModule_has_invariantFactorChain sorry in MinpolyCharpolyOQ03OQ01.lean:195-199 via a ~5-line glue import.",
+      "Strong-form statement upgrade (~5 lines, sorry-preserved): extend rational_canonical_form_exists to also assert c.lastFactor = M.minpoly. Sets up the deliverable surface for the next step.",
+      "c.lastFactor = M.minpoly proof (~15-30 LOC ACT per S11 PREP §7): uses annihilator_top_eq_ker_aeval (Mathlib/Algebra/Polynomial/Module/AEval.lean:124) + monic-uniqueness. Independent of the regrouping infrastructure; runs cleanly after option 1 produces the chain.",
+      "Audit: re-confirm Module.equiv_directSum_of_isTorsion signature at the pinned Mathlib v4.26.0 before the OQ-03-OQ-02 ACT writes its application call (PREP §4.1 pinned it at Mathlib/Algebra/Module/PID.lean:233 with `Irreducible (p i)`).",
+      "Upstream contribution opportunity: the ~290-LOC regrouping bookkeeping is the standard elementary-divisors-to-invariant-factors bridge (Dummit & Foote §12.1 Thm 5; Lang §III.7 Thm 7.7); after landing in-tree it would be a clean Mathlib PR refactoring `Module.equiv_directSum_of_isTorsion` users.",
+      "Build verification: ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03OQ02 (~45 min Docker cold per proofs/.lake self-symlink trap). Build-pending PRs are acceptable per the slug's S2/S3/S4/S5 convention."
     ]
   },
   "tags": [
@@ -118,7 +119,7 @@
     ]
   },
   "started": "2026-05-12T04:48:16.449Z",
-  "lastUpdate": "2026-05-12T11:55:00Z",
+  "lastUpdate": "2026-05-13T11:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Doc-only state-drift sync for `mathematical-induction-oq-01`. The Lean file `proofs/Proofs/MathematicalInductionOQ01.lean` has been **verified-complete since 2026-04-03** (8 theorems, 0 sorries, 0 axioms, 150 lines, gallery `meta.json` status `verified`), but the research JSON at `src/data/research/problems/mathematical-induction-oq-01.json` was never updated past its 2026-03-30 seeker-init stub. This PR rewrites the JSON to match reality and creates a session-note documenting the drift inventory.

## Drift inventory (before → after)

| Field | Before (stub) | After (this PR) |
|--|--|--|
| `phase` | `"NEW"` | `"COMPLETED"` |
| `status` | `"active"` | `"completed"` |
| `problemStatement.formal` | placeholder | full formal statement |
| `problemStatement.plain` | truncated | full plain-English statement |
| `problemStatement.whyMatters` | `[]` | 3 entries (foundational, pedagogical, cross-reference) |
| `knownResults.proven` | `[]` | 5 entries (Mathlib `Ordinal.induction`, `WellFounded.fix`, `zero_or_succ_or_limit`, `Nat.strongRecOn`, in-tree file) |
| `knownResults.open` | `[]` | 3 forward-extension candidates (Cantor-Bendixson, Zermelo well-ordering, ordinal arithmetic) |
| `knownResults.goal` | `""` | full goal statement |
| `currentState.{phase,focus,nextAction}` | NEW-stub placeholders | COMPLETED + S2 sync log |
| `currentState.iteration` | `1` | `2` |
| `knowledge.progressSummary` | wrong filename (TransfiniteInduction.lean) + wrong LOC (107) | correct filename (MathematicalInductionOQ01.lean) + correct LOC (150) |
| `knowledge.builtItems` | listed 4-6 **non-existent** theorem names | actual 8 theorem names with proof-witness one-liners |
| `knowledge.nextSteps[0]` | "Three-case transfinite induction" — already done | removed; 3 sub-OQ candidates remain |
| `tags` | 5 entries | 8 entries (+`ordinals`, `well-founded-recursion`, `completed`) |
| `relatedProofs` | 2 entries | 6 entries (matching gallery crossRefs) |
| `references.{papers,urls,mathlib}` | all empty | 3 + 4 + 7 |
| `lastUpdate` | `2026-03-30T01:04:30.789Z` | `2026-05-13T11:30:00Z` |

## Actual theorem inventory (MathematicalInductionOQ01.lean)

| # | Part | Theorem name | Proof witness |
|--|--|--|--|
| 1 | I | `wf_induction` | `hwf.fix h` |
| 2 | I | `nat_induction_from_wf` | `wf_induction Nat.lt_wfRel.wf P h` |
| 3 | II | `transfinite_induction` | `fun α => Ordinal.induction α h` |
| 4 | II | `transfinite_induction_cases` | `rcases Ordinal.zero_or_succ_or_limit α with rfl ⏐ ⟨β, rfl⟩ ⏐ hlim` |
| 5 | III | `course_of_values` | `Nat.strongRecOn h` |
| 6 | III | `weak_from_strong` | `match n with ⏐ 0 ⏐ n+1` |
| 7 | IV | `nat_well_ordering` | `⟨Nat.find hne, Nat.find_spec hne, fun m hm => Nat.find_min' hne hm⟩` |
| 8 | IV | `induction_from_well_ordering` | `by_contra` + smallest-counterexample |

All 8 verified at session start by reading the file in full. None of the names in the prior JSON's `builtItems` (`nat_wf_induction`, `ordinal_induction`, `ordinal_succ_step`, `nat_lt_iff_ordinal_lt`, `nat_induction_from_ordinal`, `ordinal_well_ordered`) exist in the actual file — they were aspirational planning-document names.

## Files NOT touched

* `proofs/Proofs/MathematicalInductionOQ01.lean` — verified-complete; **0 LOC of Lean code change**. Sorry count unchanged at 0; axiom count unchanged at 0.
* `src/data/proofs/mathematical-induction-oq-01/{meta,annotations,index}.{json,ts}` — gallery surface unchanged.
* Sibling slugs `mathematical-induction-oq-03`, `-oq-05`, parent `mathematical-induction` — no cross-edits.

## Operational pool update (NOT in PR diff)

After merge, the slug's pool entry transitions from `status: "in-progress"` → `"completed"` via:

```bash
cd /Users/rwalters/GitHub/lean-genius && \
  RESEARCHER_ID=researcher-9 \
  ./scripts/research/claim-problem.sh update mathematical-induction-oq-01 completed
```

This removes the slug from `claim-random`'s candidate set (`select(.status != "completed" and .status != "blocked" and .status != "graduated")`), freeing one slot in the MODERATE+ tier (currently 535 entries; this slug's knowledge_score 11 places it in the depth-first preferred range).

## Race-context

`gh pr list --repo rjwalters/lean-genius --search "mathematical-induction in:title" --state open` returned 0 PRs at session start (11:25 UTC). All prior PRs on this slug (#8674, #12519, #18310) are enrichment passes; this is the first **research-side** PR. No race window expected.

## Honesty assessment

**Significance**: low-to-medium. The PR's mathematical content is **zero** — it is audit-trail propagation, not novel research.

Operational value comes from:
- Removing 6 weeks of accumulated state-drift on a verified-complete slug.
- Correcting 4-6 **non-existent** theorem names in `knowledge.builtItems` (would have caused phantom-cross-reference confusion for downstream consumers).
- Surfacing three concrete sub-OQ candidates (Cantor-Bendixson, Zermelo well-ordering, ordinal arithmetic via three-case induction) with explicit suggested slug IDs (`-oq-01-oq-01`, `-oq-01-oq-02`, `-oq-01-oq-03`) for seeker prioritisation.

No fabricated value. Every claim in the corrected `builtItems` was verified by reading the actual Lean file at session start.

🤖 Generated by researcher-9