### PR TITLE
fix(mechanic): wire annotations into sum-of-kth-powers-oq-02 index.ts

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-02/index.ts
+++ b/src/data/proofs/sum-of-kth-powers-oq-02/index.ts
@@ -1,3 +1,44 @@
-import meta from './meta.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export default meta;
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/SumOfKthPowersOQ02.lean?raw')
+
+export const sumOfKthPowersOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sumOfKthPowersOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sumOfKthPowersOq02Data: ProofData = {
+  proof: sumOfKthPowersOq02Proof,
+  annotations: sumOfKthPowersOq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default sumOfKthPowersOq02Data


### PR DESCRIPTION
## Fix

Replace the 3-line `import meta; export default meta;` stub at `src/data/proofs/sum-of-kth-powers-oq-02/index.ts` with the canonical full TypeScript template. Without this fix the proof page renders with no annotations and no proof data even though 16KB / 13 annotations live in `annotations.json`.

## Evidence

**Bug mechanism**: For stub slugs whose `index.ts` is just

```ts
import meta from './meta.json';
export default meta;
```

the module's `default` export is the raw meta JSON dict (top-level `id, title, slug, description, meta, sections, ...`). In `src/data/proofs/index.ts`, `getProofAsync` picks this up as `proofData`:

```ts
let proofData: ProofData | undefined = module.default || module[exportName] || ...
```

Because `module.default` is truthy, the `{meta, annotations}` fallback never runs. `proofData` ends up being a plain meta JSON dict with no `.proof` or `.annotations` keys, so `ProofPage.tsx:111`'s destructure `const { proof, annotations, versionInfo } = proofData` yields `undefined` for all three.

**Affected slug**: `sum-of-kth-powers-oq-02` (Sum of Powers: Extension to Non-Integer Exponents)
- `annotations.json`: 13 annotations, ~16KB (well-developed content)
- Lean source: `proofs/Proofs/SumOfKthPowersOQ02.lean` (exists, status `verified`, 14 theorems, 0 sorries, 0 axioms)
- Currently gallery-visible (`badge: mathlib` in `listings.json`) but renders broken
- Stub never converted to canonical template

**Precedents**:
- PR #17885 (lagrange-theorem-oq-02-oq-02): same schema bug fix
- PR #18749 (triangle-angle-sum-oq-01, currently open): same fix on a sibling slug

**Before**: 3-line stub, gallery page renders empty/broken.
**After**: 45-line canonical template (matches `abel-ruffini-galois-extensions-oq-05-oq-01/index.ts` shape), exports `sumOfKthPowersOq02Proof`, `sumOfKthPowersOq02Annotations`, `sumOfKthPowersOq02Data` (default), `getProofSource()`.

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
$ echo $?
0
```

No new type errors. The Lean source path `proofs/Proofs/SumOfKthPowersOQ02.lean` matches `meta.leanFile.path` and is confirmed present.

## Scope

- **Touched**: `src/data/proofs/sum-of-kth-powers-oq-02/index.ts` only (1 file, +43 / -2 lines).
- **Not touched**: `meta.json`, `annotations.json` — already canonical.
- **Orthogonal to in-flight mechanic PR**:
  - #18749 (`triangle-angle-sum-oq-01` index.ts stub — same bug class, different slug)
- **Out of scope** (~22 other slugs with the same `index.ts` stub pattern; each needs a unique camelCase + verified Lean file path, so one PR per slug):
  - `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`, `amgm-inequality-oq-02-oq-01-oq-02-oq-01`
  - `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02`
  - `bezout-identity-oq-02-oq-01-oq-02-oq-02`, `bezout-identity-oq-03-oq-03`, `bezout-identity-oq-03-oq-04-oq-01`
  - `binary-gcd`
  - `cantor-diagonalization-oq-03-oq-01-oq-01`, `cantor-diagonalization-oq-03-oq-01-oq-04`
  - `divisibility-truncation-general`, `divisibility-truncation-general-oq-01`
  - `erdos-1059-oq-01..05`, `erdos-1059-oq-02-oq-01`
  - `erdos-152-oq-01`
  - `harmonic-divergence-oq-02`, `konigsberg-oq-03-oq-02`
  - `laws-of-large-numbers-oq-03`, `lebesgue-measure-oq-01-oq-01`
  - `subset-count-multiset`, `triangle-angle-sum-oq-03`

Picked `sum-of-kth-powers-oq-02` next because it has the richest annotation content (13 annotations, the highest among affected slugs) and is `verified` (no axioms / no sorries) so the underlying Lean is stable.

---
Automated fix by lean-mechanic agent.