### PR TITLE
fix(mechanic): wire annotations into konigsberg-oq-03-oq-02 index.ts

### DIFF
--- a/src/data/proofs/konigsberg-oq-03-oq-02/index.ts
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/KonigsbergOQ03OQ02.lean?raw')
+
+export const konigsbergOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const konigsbergOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const konigsbergOq03Oq02Data: ProofData = {
+  proof: konigsbergOq03Oq02Proof,
+  annotations: konigsbergOq03Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default konigsbergOq03Oq02Data


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub at `src/data/proofs/konigsberg-oq-03-oq-02/index.ts` with the canonical full TypeScript template. Without this fix, the proof page renders broken (proof / annotations / versionInfo all undefined) even though `annotations.json` ships 9 annotations / 12,130 bytes of real content (e.g. "Module Header: Infinite Paths Formalization for Erdős-Grünwald-Weiszfeld").

## Evidence

**Bug mechanism**: For stub slugs whose `index.ts` is just
```ts
import meta from './meta.json';
export default meta;
```
the module's `default` export is the raw meta JSON dict (top-level `id, title, slug, description, meta, sections, ...`). In `src/data/proofs/index.ts:57`, `getProofAsync` picks this up as `proofData`:
```ts
let proofData: ProofData | undefined = module.default || module[exportName] || ...
```
Because `module.default` is truthy, the `{meta, annotations}` fallback at lines 60–79 never runs. `proofData` ends up as a plain meta JSON dict with no `.proof` or `.annotations` keys, so `ProofPage.tsx:111`'s destructure `const { proof, annotations, versionInfo } = proofData` yields `undefined` for all three.

**Affected slug**: `konigsberg-oq-03-oq-02` (Infinite Paths in Graphs: ℕ-Indexed Formalization)
- `annotations.json`: 9 annotations, 12,130 bytes (well-developed Erdős-Grünwald-Weiszfeld content)
- Lean source: `proofs/Proofs/KonigsbergOQ03OQ02.lean` (184 lines, 0 sorries — confirmed present, builds clean)
- Currently gallery-visible but renders broken

**Precedent**:
- PR #17885 (lagrange-theorem-oq-02-oq-02, merged 2026-05-11) — original fix for this schema bug.
- PR #18749 (triangle-angle-sum-oq-01, opened 2026-05-13 by sibling mechanic) — picked first instance of the 23 known stub slugs; explicitly listed `konigsberg-oq-03-oq-02` under "Out of scope: each is a separate-PR-if-needed target."

This PR applies the same fix to one of those 22 remaining slugs.

**Before**: 2-line stub, gallery page renders empty/broken.
**After**: 44-line canonical template (matches `triangle-angle-sum-oq-01/index.ts` shape from PR #18749), exports `konigsbergOq03Oq02Proof`, `konigsbergOq03Oq02Annotations`, `konigsbergOq03Oq02Data` (default), `getProofSource()`.

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
$ echo $?
0
```

No new type errors. The Lean import path `proofs/Proofs/KonigsbergOQ03OQ02.lean` is confirmed present (note: `meta.leanFile.path` is null in meta.json — a separate metadata drift, out of scope for this fix; the canonical template hardcodes the path as PR #18749 does for triangle-angle-sum-oq-01).

## Scope

- **Touched**: `src/data/proofs/konigsberg-oq-03-oq-02/index.ts` only (1 file, +44 / -2 lines).
- **Not touched**: `meta.json`, `annotations.json`, `tacticStates.json` — left as-is.
- **Orthogonal to in-flight mechanic PR**: #18749 (triangle-angle-sum-oq-01 — different slug, same bug class). No overlap.
- **Out of scope** (21 remaining slugs in the same 2-line-stub bug class, each picked up as a separate PR):
  - `bezout-identity-oq-02-oq-01-oq-02-oq-02`, `bezout-identity-oq-03-oq-03`, `bezout-identity-oq-03-oq-04-oq-01`
  - `binary-gcd`
  - `cantor-diagonalization-oq-03-oq-01-oq-01`
  - `erdos-1059-oq-01`, `erdos-1059-oq-02`, `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-03`, `erdos-1059-oq-04`, `erdos-1059-oq-05`
  - `erdos-152-oq-01`
  - `harmonic-divergence-oq-02`, `laws-of-large-numbers-oq-03`, `lebesgue-measure-oq-01-oq-01`
  - `subset-count-multiset`, `triangle-angle-sum-oq-03`

Picked `konigsberg-oq-03-oq-02` from this set because: (a) it has 9 annotations (joint-richest with cantor-diagonalization-oq-03-oq-01-oq-01 among the remaining 21), (b) famous problem (Königsberg / Euler), and (c) Lean file is confirmed sorry-free, so the proof source viewer will render real content.

---
Automated fix by lean-mechanic agent (mechanic-2 slot).