### PR TITLE
fix(mechanic): wire annotations into laws-of-large-numbers-oq-03 index.ts

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-03/index.ts
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/LawsOfLargeNumbersOQ03.lean?raw')
+
+export const lawsOfLargeNumbersOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lawsOfLargeNumbersOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lawsOfLargeNumbersOq03Data: ProofData = {
+  proof: lawsOfLargeNumbersOq03Proof,
+  annotations: lawsOfLargeNumbersOq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default lawsOfLargeNumbersOq03Data


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub at `src/data/proofs/laws-of-large-numbers-oq-03/index.ts` with the canonical full TypeScript template (44 LOC). Without this fix, the proof page renders empty/broken even though 10.6KB of real annotation content exists in `annotations.json`.

## Evidence

**Bug mechanism**: For stub slugs whose `index.ts` is just
```ts
import meta from './meta.json';
export default meta;
```
the module's `default` export is the raw meta JSON dict (top-level `id, title, slug, description, meta, sections, ...`). In `src/data/proofs/index.ts:57`, `getProofAsync` picks this up as `proofData`:
```ts
let proofData: ProofData | undefined = module.default || module[exportName] || ...
```
Because `module.default` is truthy, the `{meta, annotations}` fallback never runs. `proofData` ends up being a plain meta JSON dict with no `.proof` or `.annotations` keys, so `ProofPage.tsx:111`'s destructure `const { proof, annotations, versionInfo } = proofData` yields `undefined` for all three.

**Affected slug**: `laws-of-large-numbers-oq-03` ("Law of Large Numbers for Dependent Random Variables (Ergodic Theory)")
- `annotations.json`: 10 annotations, 10,625 bytes — Birkhoff sums, measure-preserving iterates, invariant σ-algebra, Wiener tauberian, Hopf-Halmos σ-finite extension, etc.
- Lean source: `proofs/Proofs/LawsOfLargeNumbersOQ03.lean` (14,195 bytes; meta.json `proofRepoPath` matches)
- Currently gallery-visible but renders broken
- Stub never converted to canonical template

**Precedent**: PR #17885 (lagrange-theorem-oq-02-oq-02) and in-flight PR #18749 (triangle-angle-sum-oq-01) apply the same fix to other instances.

**Before**: 2-line stub, gallery page renders empty/broken.
**After**: 44-line canonical template (matches `abel-ruffini-galois-extensions-oq-05-oq-01/index.ts` shape), exports `lawsOfLargeNumbersOq03Proof`, `lawsOfLargeNumbersOq03Annotations`, `lawsOfLargeNumbersOq03Data` (default), `getProofSource()`.

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
src/data/proofs/index.ts(10,26): error TS2307: Cannot find module './listings.json' or its corresponding type declarations.
src/data/research/index.ts(16,26): error TS2307: Cannot find module './research-listings.json' or its corresponding type declarations.
```

Both errors are pre-existing and unrelated (missing generated listings JSONs not committed in this branch). No new type errors introduced.

## Scope

- **Touched**: `src/data/proofs/laws-of-large-numbers-oq-03/index.ts` only (1 file, +44 / -2 lines).
- **Not touched**: `meta.json`, `annotations.json`, `tacticStates.json` — already canonical.
- **Orthogonal to in-flight mechanic PRs**:
  - #18749 (triangle-angle-sum-oq-01 — different slug, same bug pattern)
  - #18754 (sum-of-kth-powers-oq-02 — different slug, same bug pattern)
  - #18755 (konigsberg-oq-03-oq-02 — different slug, same bug pattern)
- **Out of scope**: remaining ~19 slugs with the same 2-line stub pattern, listed in #18749's body — one PR per slug minimizes risk and matches the lagrange precedent.

---
Automated fix by lean-mechanic agent.