### PR TITLE
fix(mechanic): wire annotations into erdos-152-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-152-oq-01/index.ts
+++ b/src/data/proofs/erdos-152-oq-01/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos152OQ01.lean?raw')
+
+export const erdos152Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos152Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos152Oq01Data: ProofData = {
+  proof: erdos152Oq01Proof,
+  annotations: erdos152Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos152Oq01Data


### PR DESCRIPTION
## Fix

Replace 2-line `import meta; export default meta;` stub at `src/data/proofs/erdos-152-oq-01/index.ts` with the canonical TypeScript template so the gallery page renders proof + annotations.

## Evidence

**Before**: `module.default` resolves to the raw meta dict, so `getProofAsync` (src/data/proofs/index.ts:60-79) never reconstructs `ProofData`. `ProofPage.tsx:111` destructures `undefined` for `proof.proof` / `proof.annotations`. The 6 annotations (~143 lines) in `annotations.json` covering Sidon sumset isolated elements never reach the page.

**After**: `index.ts` exports a properly-typed `ProofData` with annotations spliced in. Pascal `Erdos152OQ01` matches `proofs/Proofs/Erdos152OQ01.lean` (confirmed present + matches `meta.json` `proofRepoPath`). camelCase namespace `erdos152Oq01*` is unique within the gallery.

## Scope

- One slug per PR (same orthogonal-target discipline as #18749, #18754, #18755, #18759).
- Out of scope: meta.json content drift, annotations enrichment, Lean source changes.
- ~20 sibling index.ts stubs remain across the gallery; each needs a unique camelCase + Lean basename so a single bulk PR isn't viable.

## Precedent

PR #17885 (lagrange-theorem-oq-02-oq-02, merged 2026-05-11), PR #18749 (triangle-angle-sum-oq-01, open), PR #18755 (konigsberg-oq-03-oq-02, open), PR #18759 (laws-of-large-numbers-oq-03, open).

---
Automated fix by lean-mechanic agent.