### PR TITLE
fix(mechanic): wire annotations into lebesgue-measure-oq-01-oq-01 index.ts

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/LebesgueMeasureOQ01OQ01.lean?raw')
+
+export const lebesgueMeasureOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lebesgueMeasureOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lebesgueMeasureOq01Oq01Data: ProofData = {
+  proof: lebesgueMeasureOq01Oq01Proof,
+  annotations: lebesgueMeasureOq01Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default lebesgueMeasureOq01Oq01Data


### PR DESCRIPTION
## Fix

Replace 2-line `import meta; export default meta;` stub with canonical 44-line `ProofData` template so `lebesgue-measure-oq-01-oq-01` (Thomae's function — Lebesgue integral zero) renders annotations on the gallery page.

## Evidence

**Before**: `src/data/proofs/lebesgue-measure-oq-01-oq-01/index.ts` was a 2-line stub exporting raw `meta.json`. `src/data/proofs/index.ts:50-79` reads `module.default` as `ProofData` and the legacy `{ meta, annotations }` fallback never runs (because `module.default` is truthy raw meta dict), so `proofData.proof`/`proofData.annotations` are undefined and `ProofPage.tsx:111` destructures undefined. The 6 annotations (7.1 KB) in `annotations.json` never render despite shipping in the bundle.

**After**: Canonical full template (imports `annotationsJson`, exposes `lebesgueMeasureOq01Oq01Proof`/`Annotations`/`Data`, hardcodes `proofs/Proofs/LebesgueMeasureOQ01OQ01.lean?raw` raw import for `getProofSource`, sets `default = …Data`). Matches PR #17885 (lagrange-theorem-oq-02-oq-02) + PR #18749 (triangle-angle-sum-oq-01) + PR #18755 (konigsberg-oq-03-oq-02) shape.

## Scope

One slug per PR (gallery-wide stub class still has ~20 remaining; tracked separately by parallel mechanic slots — see open #18749, #18754, #18755, #18759).

Out of scope: every other 2-line `index.ts` stub.

---
Automated fix by lean-mechanic agent.