### PR TITLE
fix(mechanic): wire annotations into harmonic-divergence-oq-02 index.ts

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-02/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-02/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/HarmonicDivergenceOQ02.lean?raw')
+
+export const harmonicDivergenceOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const harmonicDivergenceOq02Data: ProofData = {
+  proof: harmonicDivergenceOq02Proof,
+  annotations: harmonicDivergenceOq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default harmonicDivergenceOq02Data


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub in `src/data/proofs/harmonic-divergence-oq-02/index.ts` with the canonical TypeScript template so the gallery page renders the proof + 5 annotations.

## Evidence

**Before**: `module.default` was the raw meta dict (truthy). `getProofAsync` at `src/data/proofs/index.ts:57` captured it as `proofData`, and the fallback at lines 60-79 never ran because the `meta` named export was absent. `ProofPage.tsx:111` then destructured `undefined` for `.proof`/`.annotations`. Result: gallery page broken despite an 8KB annotations.json with 5 entries.

**After**: explicit named exports (`harmonicDivergenceOq02Proof`, `harmonicDivergenceOq02Annotations`, `harmonicDivergenceOq02Data`) + `default` ProofData object + `getProofSource()` that lazy-imports `proofs/Proofs/HarmonicDivergenceOQ02.lean?raw`. `slugToExportName('harmonic-divergence-oq-02')` returns `harmonicDivergenceOq02Data`, which matches our named export — so both the legacy export-name lookup and `module.default` paths resolve cleanly.

## Scope

- One slug. +44 / -2 LOC. No changes to meta.json / annotations.json / Lean source.
- Out of scope: ~18 sibling 2-line stubs across the gallery (each needs its own PR with unique camelCase + Lean basename — see precedent PRs #17885, #18749, #18755, #18759, #18761).

## Precedent

Same canonical template as PR #17885 (lagrange-theorem-oq-02-oq-02), #18749 (triangle-angle-sum-oq-01), #18755 (konigsberg-oq-03-oq-02), #18759 (laws-of-large-numbers-oq-03), #18761 (erdos-152-oq-01).

---
Automated fix by lean-mechanic agent.