### PR TITLE
research(ehrhart-cube-proven-oq-04): S6 PALINDROME-COROLLARY — dual Worpitzky form (build pending)

### DIFF
--- a/proofs/Proofs/EhrhartCubeProvenOQ04.lean
+++ b/proofs/Proofs/EhrhartCubeProvenOQ04.lean
@@ -49,6 +49,7 @@
   • `eulerian_row_sum_factorial`            — Σ_{k=0}^{d-1} A(d, k) = d!       (S3: PROVED)
   • `eulerian_palindrome`                   — A(d, k) = A(d, d-1-k) for k < d  (S5: PROVED)
   • `cube_lattice_count_eulerian`           — bridge to `EhrhartCubeProven`    (S2: PROVED)
+  • `worpitzky_identity_cube_palindrome`    — Σ A(d,k) C(n+d-k, d) = (n+1)^d   (S6: PROVED)
 
   Helper lemmas (S3):
   • `eulerian_zero_eq_one`                  — A(d, 0) = 1 for all d ≥ 0
@@ -673,5 +674,47 @@ theorem cube_lattice_count_eulerian (d : ℕ) (hd : 0 < d) (n : ℕ) :
   -- Lattice-point count of n · [0,1]^d equals (n + 1)^d via the canonical Fin bijection
   rw [Fintype.card_fun, Fintype.card_fin, Fintype.card_fin]
   exact worpitzky_identity_cube d hd n
+
+-- ============================================================
+-- SECTION VII: Palindrome-Reflected Worpitzky Identity (S6)
+-- ============================================================
+
+/--
+  **Palindrome-reflected Worpitzky identity** (S6: PROVED, build pending):
+  composing `worpitzky_identity_cube` with `eulerian_palindrome` and a
+  reindexing `k ↦ d - 1 - k` yields the *dual* (palindrome-reflected)
+  form of Worpitzky's identity for the cube:
+  $$ (n+1)^d \;=\; \sum_{k=0}^{d-1}\,A(d, k)\,\binom{n + d - k}{d}. $$
+  The shift `n + 1 + k ↦ n + d - k` is the standard alternative
+  parametrisation of the binomial-coefficient summand: the original form
+  is keyed by the *forward* exceedance index `k`, while this form keys
+  by the *descent* index `d - 1 - k`, exhibiting the palindromic
+  symmetry of the Eulerian numbers at the level of the entire sum.
+
+  Together with `worpitzky_identity_cube` this gives both equivalent
+  presentations of `(n+1)^d` in the Eulerian basis, useful for combinatorial
+  identities that prefer one parametrisation over the other (e.g. the dual
+  Worpitzky form is the natural shape when summing over *descent* statistics
+  in the symmetric group, whereas the forward form parametrises by *exceedance*).
+-/
+theorem worpitzky_identity_cube_palindrome (d : ℕ) (hd : 0 < d) (n : ℕ) :
+    (n + 1)^d = ∑ k ∈ Finset.range d,
+                eulerianNumber d k * Nat.choose (n + d - k) d := by
+  -- Start from worpitzky_identity_cube, then reindex the RHS via k ↦ d - 1 - k
+  -- and substitute the palindrome A(d, k) = A(d, d - 1 - k) pointwise.
+  rw [worpitzky_identity_cube d hd n]
+  -- Goal: ∑ k ∈ range d, A(d, k) * C(n+1+k, d) = ∑ k ∈ range d, A(d, k) * C(n+d-k, d)
+  conv_rhs => rw [← Finset.sum_range_reflect
+                    (fun k => eulerianNumber d k * Nat.choose (n + d - k) d) d]
+  -- Goal: ∑ k ∈ range d, A(d, k) * C(n+1+k, d) =
+  --       ∑ k ∈ range d, A(d, d-1-k) * C(n + d - (d-1-k), d)
+  refine Finset.sum_congr rfl fun k hk => ?_
+  have hk' : k < d := Finset.mem_range.mp hk
+  -- Goal: A(d, k) * C(n+1+k, d) = A(d, d-1-k) * C(n + d - (d-1-k), d)
+  rw [eulerian_palindrome d k hd hk']
+  -- Goal: A(d, d-1-k) * C(n+1+k, d) = A(d, d-1-k) * C(n + d - (d-1-k), d)
+  -- Show the binomial-coefficient arguments are equal via Nat-arithmetic.
+  have harith : n + 1 + k = n + d - (d - 1 - k) := by omega
+  rw [harith]
 
 end EhrhartCubeProvenOQ04

--- a/research/problems/ehrhart-cube-proven-oq-04/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-04/state.md
@@ -1,9 +1,9 @@
 # Current State
 
-**Phase**: PROVED (S5 complete — all combinatorial sorries closed)
-**Since**: 2026-05-12T05:00:00Z (S5 PR — palindrome)
-**Iteration**: 5
-**Researcher**: researcher-5
+**Phase**: PROVED (S6 palindrome-corollary added — all combinatorial sorries still closed + dual Worpitzky form)
+**Since**: 2026-05-13T11:40:00Z (S6 PR — palindrome-corollary, build pending)
+**Iteration**: 6
+**Researcher**: researcher-9
 
 ## Current Focus
 
@@ -55,25 +55,44 @@ All five combinatorial theorems are now formally proved.
 - `cube_lattice_count_eulerian : ∀ d n, 0 < d →
     |Fin d → Fin (n+1)| = ∑ A(d, k) C(n+1+k, d)`.
 
+### Palindrome-reflected Worpitzky form (S6, PROVED, build pending)
+- `worpitzky_identity_cube_palindrome : ∀ d n, 0 < d →
+    (n+1)^d = ∑ A(d, k) C(n+d-k, d)`.
+  Proved by composing `worpitzky_identity_cube` with `Finset.sum_range_reflect`
+  on the RHS (reindex `k ↦ d - 1 - k`) and substituting `eulerian_palindrome`
+  pointwise; the Nat-subtraction identity `n + 1 + k = n + d - (d - 1 - k)`
+  for `k < d` closes via `omega`. ~30 LOC including docstring; pure
+  composition of S4 + S5 outputs.
+
 ## Blockers
 
 None — all combinatorial sorries are closed.
 
 ## Next Action
 
-**S6 (optional)**:
-1. Verify the full-file build (worpitzky + palindrome both "build pending").
-2. Expose the palindrome corollary form `(n+1)^d = Σ A(d, k) C(n+d-k, d)` by
-   composing `worpitzky_identity_cube` with `eulerian_palindrome` (reindex
-   k ↦ d - 1 - k). Roughly 10–20 lines.
-3. Mathlib upstream PR: contribute `Mathlib.Combinatorics.Enumerative.Eulerian`
+**S6 (DONE, this PR — researcher-9 2026-05-13)**: Exposed the palindrome
+corollary form `(n+1)^d = Σ A(d, k) C(n+d-k, d)` via
+`worpitzky_identity_cube_palindrome` (Section VII, ~30 LOC including
+docstring). Proof composes `worpitzky_identity_cube` with
+`Finset.sum_range_reflect` and `eulerian_palindrome` pointwise, closing
+the Nat-subtraction arithmetic with `omega`. Build still pending per
+S4/S5 convention (Docker cold-build ~45 min, `.lake` symlink trap).
+
+**S7+ (optional)**:
+1. Verify the full-file build (worpitzky + palindrome + palindrome-corollary
+   all "build pending").
+2. Mathlib upstream PR: contribute `Mathlib.Combinatorics.Enumerative.Eulerian`
    with `eulerianNumber`, `eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`,
-   `eulerian_row_sum_factorial`, `eulerian_palindrome`, `worpitzky_identity`.
+   `eulerian_row_sum_factorial`, `eulerian_palindrome`, `worpitzky_identity`,
+   and the new `worpitzky_identity_cube_palindrome`.
+3. Polynomial-identity form: lift `worpitzky_identity_cube_palindrome` to
+   `Polynomial ℕ` (i.e. as an identity of generating functions rather than
+   pointwise on `n`). Roughly 30–50 LOC.
 
 ## Attempt Counts
 
-- Total attempts: 5 (S1 SCAFFOLD, S2 STRUCTURAL, S3 ROW-SUM, S4 WORPITZKY, S5 PALINDROME)
-- Current approach attempts: 0 (S6 optional)
+- Total attempts: 6 (S1 SCAFFOLD, S2 STRUCTURAL, S3 ROW-SUM, S4 WORPITZKY, S5 PALINDROME, S6 PALINDROME-COROLLARY)
+- Current approach attempts: 0 (S7 optional)
 - Approaches tried: 0
 
 ## Open Questions / Risks

--- a/src/data/research/problems/ehrhart-cube-proven-oq-04.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-04.json
@@ -39,18 +39,18 @@
   "currentState": {
     "phase": "PROVED",
     "since": "2026-05-12T05:00:00Z",
-    "iteration": 5,
-    "focus": "S5 PALINDROME (build pending): closed `eulerian_palindrome` by induction on d using only the recurrence and S3 helpers (no descent involution needed). The boundary `A(d+1, d) = 1` is derived from the recurrence + `eulerian_eq_zero_of_le (d, d)` + ih at j = d-1; the interior `1 ≤ k < d` case unfolds the recurrence on both sides and applies ih twice; the dual `k = d` boundary follows from `Nat.sub_self` and the k = 0 case. All five combinatorial theorems (cube_h_star_eulerian, eulerian_row_sum_factorial, worpitzky_identity_cube, eulerian_palindrome, cube_lattice_count_eulerian) are now closed.",
+    "iteration": 6,
+    "focus": "S6 PALINDROME-COROLLARY complete (build pending, researcher-9, 2026-05-13): composed worpitzky_identity_cube + Finset.sum_range_reflect + eulerian_palindrome into the dual Worpitzky form worpitzky_identity_cube_palindrome. ~30 LOC including docstring; one new section VII added; 1 new public theorem; file lineCount 677 → 720, theoremCount 27 → 28. No new imports; no axioms; no sorries.",
     "blockers": [],
-    "nextAction": "S6 (optional): verify build of the whole file. Optional follow-up: expose the palindrome corollary form `(n+1)^d = Σ A(d, k) C(n+d-k, d)` derived from worpitzky_identity_cube + eulerian_palindrome. Mathlib upstream PR for Eulerian numbers (longer-term).",
+    "nextAction": "S7 (optional): (1) verify the full-file Docker build (S4 worpitzky + S5 palindrome + S6 palindrome-corollary all build-pending; ~45 min cold per .lake symlink trap); (2) Mathlib upstream PR contributing Mathlib.Combinatorics.Enumerative.Eulerian with eulerianNumber, eulerian_zero_eq_one, eulerian_eq_zero_of_le, eulerian_row_sum_factorial, eulerian_palindrome, worpitzky_identity, worpitzky_identity_cube_palindrome; (3) Polynomial-identity form: lift worpitzky_identity_cube_palindrome to Polynomial ℕ as a generating-function identity rather than pointwise on n (~30-50 LOC).",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 6,
+      "currentApproach": 0,
+      "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "S1 SCAFFOLD + S2 STRUCTURAL + S3 ROW-SUM (researcher-3, 2026-05-12) + S4 WORPITZKY (researcher-5, 2026-05-12, build pending): S3 added two helper lemmas (`eulerian_zero_eq_one`, `eulerian_eq_zero_of_le`) and closed `eulerian_row_sum_factorial`. S4 adds the algebraic step identity `worpitzky_step : (k+1)·C(n+1+k, d+1) + (d-k)·C(n+2+k, d+1) = (n+1)·C(n+1+k, d)` (for k ≤ d) via Pascal + `Nat.choose_succ_right_eq`, and closes `worpitzky_identity_cube` by induction on d. The inductive step pulls (n+1) into the IH sum, applies `worpitzky_step` pointwise, splits via `Finset.sum_add_distrib`, then reindexes via `Finset.sum_range_succ'` and the Eulerian recurrence (using `eulerian_eq_zero_of_le` to discard the boundary term at the right end). 1 combinatorial sorry remains: eulerian_palindrome (descent involution).",
+    "progressSummary": "PROGRESS S6 (PALINDROME-COROLLARY, build pending): worpitzky_identity_cube_palindrome — (n+1)^d = Σ A(d, k) C(n+d-k, d) — the dual (palindrome-reflected) Worpitzky form. Pure composition of S4 worpitzky_identity_cube + S5 eulerian_palindrome via Finset.sum_range_reflect; ~30 LOC. File 677 → 720 lines, 27 → 28 public theorems, still 0 sorries / 0 axioms.",
     "builtItems": [
       "eulerianNumber : ℕ → ℕ → ℕ (def)",
       "cubeHStarPoly : ℕ → Polynomial ℕ (def)",
@@ -67,7 +67,8 @@
       "worpitzky_step (S4, proven — Pascal + Nat.choose_succ_right_eq, by_cases on d ≤ m for boundary)",
       "worpitzky_identity_cube (S4, proved modulo build verification — induction on d with worpitzky_step + Finset.sum_range_succ' reindex)",
       "eulerianNumber_recurrence (S5 helper, definitional rfl — A(d+1, k+1) recurrence equation as a named lemma)",
-      "eulerian_palindrome (S5, proved modulo build verification — induction on d with k = 0 / 1 ≤ k < d / k = d case-split)"
+      "eulerian_palindrome (S5, proved modulo build verification — induction on d with k = 0 / 1 ≤ k < d / k = d case-split)",
+      "worpitzky_identity_cube_palindrome (S6, proved modulo build verification — (n+1)^d = Σ_{k=0}^{d-1} A(d, k) C(n+d-k, d), the dual/palindrome-reflected Worpitzky form). Proof composes S4 worpitzky_identity_cube + S5 eulerian_palindrome via Finset.sum_range_reflect on the RHS (reindex k ↦ d-1-k), then substitutes A(d,k) = A(d,d-1-k) pointwise and closes the Nat-arithmetic identity n+1+k = n+d-(d-1-k) for k<d via omega. ~15 LOC of tactic + ~15 LOC docstring; new Section VII."
     ],
     "insights": [
       "Nat-subtraction in the eulerianNumber recurrence handles the boundary k ≥ d cleanly: both branches collapse to 0 automatically",
@@ -76,7 +77,8 @@
       "Mathlib does not have Eulerian numbers — first Lean formalization in this gallery; Mathlib contribution path opens",
       "cubeHStarPoly's k-th coefficient is definitional (Σ A(d,j) • X^j → coeff_smul + coeff_X_pow + Finset.sum_ite_eq') — the substantive content lives entirely in worpitzky_identity_cube",
       "S3 row-sum technique: extend both row sums to a common `range (d+1)` index set using `A(d, d) = 0`, then combine pointwise via `(k+1) + (d-k) = d+1` (for k < d) and direct A(d, d) = 0 cancellation (for k = d). Avoids `Finset.sum_Ico_eq_sum_range` reindexing.",
-      "Helper `eulerian_eq_zero_of_le` carries the recursion on the FIRST argument (d), with case-split on whether d = 0 or d ≥ 1 for the inner recursion call. Required to discharge `(d - k) * A(d, k) = 0` boundary contributions."
+      "Helper `eulerian_eq_zero_of_le` carries the recursion on the FIRST argument (d), with case-split on whether d = 0 or d ≥ 1 for the inner recursion call. Required to discharge `(d - k) * A(d, k) = 0` boundary contributions.",
+      "**Palindrome-reflected Worpitzky form composes from S4 + S5 directly**: once worpitzky_identity_cube (S4) and eulerian_palindrome (S5) are both in hand, the dual form (n+1)^d = Σ A(d,k) C(n+d-k, d) requires only Finset.sum_range_reflect + a Nat-arithmetic omega step — no new combinatorial content. The pedagogical takeaway: the palindromic symmetry of Eulerian numbers does not yield new identities at the level of (n+1)^d itself, but reindexes the existing identity from forward (exceedance) to descent parametrisation. Useful when downstream consumers prefer one parametrisation over the other (e.g. counting by descents vs. ascents in the symmetric group)."
     ],
     "mathlibGaps": [
       "No Eulerian numbers (`Nat.eulerianNumber` or similar)",
@@ -123,7 +125,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.563Z",
-  "lastUpdate": "2026-05-12T04:20:00Z",
+  "lastUpdate": "2026-05-13T11:45:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -141,8 +143,8 @@
     {
       "path": "Proofs/EhrhartCubeProvenOQ04.lean",
       "filename": "EhrhartCubeProvenOQ04.lean",
-      "lineCount": 677,
-      "theoremCount": 27,
+      "lineCount": 720,
+      "theoremCount": 28,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds `worpitzky_identity_cube_palindrome`: the palindrome-reflected form of the Worpitzky identity for the d-cube,

$$(n+1)^d \;=\; \sum_{k=0}^{d-1}\,A(d, k)\,\binom{n + d - k}{d}$$

where $A(d, k)$ is the Eulerian number and the binomial is keyed by the *descent* index $n + d - k$ rather than the *exceedance* index $n + 1 + k$ of the forward `worpitzky_identity_cube` (S4).

This was option 2 in the post-S5 `state.md` Next Action enumeration (\"Expose the palindrome corollary form `(n+1)^d = Σ A(d, k) C(n+d-k, d)` by composing `worpitzky_identity_cube` with `eulerian_palindrome` (reindex k ↦ d - 1 - k). Roughly 10–20 lines.\").

## Proof strategy

Pure composition of S4 + S5 outputs:

1. Start from `worpitzky_identity_cube` (S4).
2. Apply `← Finset.sum_range_reflect` to the RHS to reindex $k \mapsto d - 1 - k$.
3. Substitute `eulerian_palindrome` (S5) pointwise to convert $A(d, k) \mapsto A(d, d - 1 - k)$.
4. Close the Nat-arithmetic identity $n + 1 + k = n + d - (d - 1 - k)$ for $k < d$ via `omega`.

~15 LOC of tactic body + ~15 LOC of docstring; new Section VII in `EhrhartCubeProvenOQ04.lean`.

## File changes

| File | Change |
|--|--|
| `proofs/Proofs/EhrhartCubeProvenOQ04.lean` | lineCount 677 → 720 (+43); theoremCount 27 → 28 (+1 public); sorries 0 → 0 (unchanged); axioms 0 → 0 (unchanged); new Section VII; header docstring \"Main theorems\" entry added |
| `research/problems/ehrhart-cube-proven-oq-04/state.md` | Phase/Since/Iteration/Researcher bumped to S6; \"What's Built\" cumulative list gains an S6 section; \"Next Action\" enumerates S7 candidates |
| `src/data/research/problems/ehrhart-cube-proven-oq-04.json` | `currentState.{iteration,focus,nextAction,attemptCounts}`, `knowledge.{progressSummary,builtItems(+1),insights(+1)}`, `leanFiles[oq-04].{lineCount→720,theoremCount→28}`, `lastUpdate` |

## Build status

**Build pending** per slug convention (S4 worpitzky + S5 palindrome both shipped as build-pending; Docker cold-build ~45 min per `proofs/.lake` self-symlink trap; see `feedback_researcher_lake_symlink_loop_and_wipe`).

Proof uses only:

* `Finset.sum_range_reflect` (`Mathlib.Algebra.BigOperators.Intervals.lean`, confirmed at v4.26.0 HEAD: `(∑ j ∈ range n, f (n - 1 - j)) = ∑ j ∈ range n, f j`)
* `Finset.sum_congr` (Mathlib standard)
* `Finset.mem_range` (Mathlib standard)
* In-tree `worpitzky_identity_cube` + `eulerian_palindrome` (S4, S5; both in same file)
* `omega` (Mathlib standard)

No new Mathlib API beyond what S4 + S5 already use; build-failure risk is bounded to the `omega` arithmetic step (line 717). Fallback if `omega` fails: explicit `Nat.sub_sub_self` + `Nat.add_sub_cancel` rewrites.

## Race-context

`gh pr list --search \"ehrhart-cube-proven-oq-04 in:title\" --state open` returned 0 PRs at session start. Most recent merges:

| PR | UTC | Title (abbrev) |
|--|--|--|
| #17878 | 2026-05-12 05:36 | audit drift-sync after S5 palindrome |
| #17873 | 2026-05-12 05:25 | audit tracker → issues-fixed (CLOSED) |
| #17868 | 2026-05-12 05:23 | audit sync counts post-S5 |
| #17761 | 2026-05-12 02:32 | fix: remove True stub + sync counts |

All audit/fix work converged on the S5 sorry-discharge ~30h before this S6 session. No race window expected on a 30h-dormant slug.

## Honesty assessment

**Significance**: low-to-medium. This is a clean composition of two prior PROVED results (S4 worpitzky_identity_cube + S5 eulerian_palindrome) — no new combinatorial content, just a reindexing. The pedagogical value is that the palindromic symmetry of Eulerian numbers, when applied to the entire Worpitzky sum, does not yield new identities at the level of $(n+1)^d$ itself, but reindexes the existing identity from forward (exceedance) to descent parametrisation. Useful as a basis for the future Mathlib upstream PR (state.md S7 next-action) where having both forms strengthens the contribution.

**Not** a sorry discharge — sorry count remains 0. **Not** an axiom elimination — axiom count remains 0. Honest framing: \"useful corollary by composition,\" not \"new theorem.\"

🤖 Generated by researcher-9