### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-02): S5 OBSERVE — Mathlib already ships ℤ[ω] + Jacobi-sum API (doc-only)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
@@ -452,8 +452,18 @@ theorem quarticChar_kernel_card (h4 : p % 4 = 1) :
 -- PART 8: Cubic Reciprocity (Axiomatized with Strategy)
 -- ============================================================
 
-/- The Eisenstein integers ℤ[ω] are not yet in Mathlib v4.26.0.
-   We describe them and their key properties as axioms. -/
+/- Note (researcher-5, 2026-05-13, S5 OBSERVE bearer audit):
+   Mathlib v4.26.0 (pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67) DOES ship the
+   Eisenstein integers ℤ[ω] — as the ring of integers `𝓞 K` of any number field K with
+   `IsCyclotomicExtension {3} ℚ K` (see Mathlib.NumberTheory.NumberField.Cyclotomic.Three
+   and Mathlib.NumberTheory.NumberField.Cyclotomic.PID.three_pid). The full Jacobi-sum
+   API used in the cubic-reciprocity proof strategy below is also already in Mathlib
+   (Mathlib.NumberTheory.JacobiSum.Basic). The two axioms below are predicated on the
+   local `structure EisensteinPrime` placeholder, and discharging them requires rebasing
+   that structure onto `IsCyclotomicExtension`/`𝓞 K` rather than waiting on an upstream
+   Mathlib feature. See
+   research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md
+   for the full bearer catalog and refactor plan. -/
 
 /-- A type representing Eisenstein primes (rational prime p ≡ 1 mod 3, written π ∈ ℤ[ω]). -/
 structure EisensteinPrime where
@@ -486,8 +496,14 @@ axiom cubicResidueSymbol (π : EisensteinPrime) (a : ℤ) : ZMod 3
     Compare with quadratic case: QR needs sign of Gauss sum; CR needs Jacobi sum.
     The Jacobi sum J(χ₃, χ₃) plays the role of the Gauss sum τ in QR.
 
-    Mathlib gap: Eisenstein integer ring ℤ[ω] is not in Mathlib v4.26.0.
-    The proof would require ~300 additional lines of Eisenstein infrastructure. -/
+    Mathlib status (audited by researcher-5, 2026-05-13, pinned SHA 2df2f01...):
+    Eisenstein integer ring ℤ[ω] IS in Mathlib v4.26.0 as `𝓞 K` for
+    `IsCyclotomicExtension {3} ℚ K` (see Mathlib.NumberTheory.NumberField.Cyclotomic.Three
+    and .PID). The Jacobi-sum API (jacobiSum, jacobiSum_mul_nontrivial,
+    gaussSum_pow_eq_prod_jacobiSum, jacobiSum_mem_algebraAdjoin_of_pow_eq_one, …) is in
+    Mathlib.NumberTheory.JacobiSum.Basic. Discharging this axiom requires rebasing the
+    local `structure EisensteinPrime` onto Mathlib's `𝓞 K` and porting Ireland–Rosen
+    Theorem 1 of Chapter 9 (~250 LOC), not waiting on upstream Mathlib. -/
 axiom cubic_reciprocity (π ρ : EisensteinPrime)
     (h_distinct : π.rational_prime ≠ ρ.rational_prime)
     (hπ : π.is_primary = true) (hρ : ρ.is_primary = true) :

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md
@@ -2,8 +2,8 @@
 
 **Title**: Can the character uniqueness argument be generalized to prove cubic or quartic reciprocity?
 
-**Status**: in-progress  
-**Phase**: ACT
+**Status**: axiomatized (build state; 0 sorries, 2 axioms)
+**Phase**: S5 OBSERVE — Mathlib bearer audit (post-S4)
 
 ## Problem Summary
 
@@ -42,16 +42,74 @@ For primes p ≡ 1 (mod 3), the group (ZMod p)ˣ is cyclic of order p-1 with 3 |
 - `proofs/Proofs.lean` (added import)
 - `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` (NEW)
 
-### Current State
+### Current State (S1 snapshot; subsequently updated — see Session 5 below)
 
 - 3 axioms: cubicEuler_hard, cubicResidueSymbol, cubic_reciprocity
 - 1 sorry: cubicChar_kernel_card (cyclic group kernel cardinality)
 - 24 theorems proved, 6 defs
 - Docker build submitted; awaiting result
 
-### Next Steps
+### Next Steps (S1 plan; superseded by S5 audit below)
 
 1. If Docker build passes: commit, push, PR with `research` label
 2. Future: prove cubicChar_kernel_card using `Subgroup.card_eq_iff_eq_top` or similar
 3. Future: when Mathlib gains Eisenstein integers, prove cubic_reciprocity
 4. Future: submit cubicEuler_hard to Aristotle (needs cyclic group theory)
+
+## Session 2026-05-13 (Session 5) — Mathlib Bearer Audit (OBSERVE)
+
+**Mode**: OBSERVE (doc-only / docstring + JSON-prose corrections; no Lean tactic changes)
+**Outcome**: progress — corrected misleading bearer claims; recorded refactor plan
+
+### What I Did
+
+- Audited pinned Mathlib v4.26.0 (SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) for
+  Eisenstein-integer and Jacobi-sum bearers cited by the file's two remaining axioms.
+- Confirmed Mathlib v4.26.0 ships:
+  - `Mathlib.NumberTheory.NumberField.Cyclotomic.Three` — Eisenstein integers as `𝓞 K`
+    for `IsCyclotomicExtension {3} ℚ K` (including unit classification, `λ^2 = -3η`,
+    `η^2 = -η - 1`, Kummer's lemma for `λ^2`).
+  - `Mathlib.NumberTheory.NumberField.Cyclotomic.PID` —
+    `three_pid : IsPrincipalIdealRing (𝓞 K)` for `IsCyclotomicExtension {3} ℚ K`.
+  - `Mathlib.NumberTheory.JacobiSum.Basic` — full Jacobi-sum API
+    (`jacobiSum`, `jacobiSum_mul_nontrivial`,
+    `jacobiSum_eq_gaussSum_mul_gaussSum_div_gaussSum`, `jacobiSum_mul_jacobiSum_inv`,
+    `gaussSum_pow_eq_prod_jacobiSum`,
+    `jacobiSum_mem_algebraAdjoin_of_pow_eq_one`).
+- Corrected file docstring comments at L455–L456 and L489 of
+  `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` (no code change).
+- Corrected `meta.json` text fields: `description`, `assumptions`, `keyInsights[4]`,
+  `openQuestions[0]`.
+- Synced this knowledge.md header (Status / Phase) and appended this Session-5 entry.
+- Wrote full audit trail at `s5-observe-eisenstein-bearer.md` (this directory).
+
+### Key Findings
+
+- The file's two remaining `axiom` declarations (`cubicResidueSymbol`,
+  `cubic_reciprocity`) are **not Mathlib-blocked**. They are predicated on the file's
+  local `structure EisensteinPrime`, which is decoupled from Mathlib's richer
+  `IsCyclotomicExtension {3} ℚ K` / `𝓞 K` formalization.
+- Sessions 2–4 (between S1 and now) already retired one axiom and the sole sorry:
+  - `cubicEuler_hard` was promoted from axiom to theorem in #15322 (2026-05-03) via
+    discrete log in the cyclic group `(ZMod p)ˣ`.
+  - `cubicChar_kernel_card` was promoted from sorry to theorem in #15356/#15357
+    (2026-05-03) via `IsCyclic.card_pow_eq_one_le` + injectivity.
+- Current build state: **2 axioms, 0 sorries, 27 theorems, 6 defs, 562 lines** (per
+  `meta.json` synced in #16691, 2026-05-07).
+- Future ACT to discharge the two remaining axioms is an **engineering refactor**
+  (rebase local `EisensteinPrime` onto Mathlib's `𝓞 K`), not a wait-on-upstream-Mathlib
+  task. Estimated ~250 LOC port of Ireland–Rosen Theorem 1 of Chapter 9 using the
+  existing Jacobi-sum API.
+
+### Files Modified
+
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md` (NEW)
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md` (this file)
+- `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` (text prose only)
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` (docstring comment text only)
+
+### Build Risk
+
+Zero — no tactic, import, or signature changes. All edits are within comment/doc text
+or JSON prose fields. Sorries unchanged (0). Axiom count unchanged (2). Theorem count
+unchanged (27).

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md
@@ -1,0 +1,116 @@
+# S5 OBSERVE — Mathlib Eisenstein-integer bearer audit (researcher-5, 2026-05-13)
+
+**Slug**: `elementary-quadratic-reciprocity-oq-01-oq-02`
+**Phase**: S5 OBSERVE (doc-only audit; no Lean changes other than docstring correction)
+**Mathlib SHA (pinned)**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0)
+**File audited**: `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean`
+
+## Motivation
+
+The Session-1 (2026-05-03) artifacts and the file's own docstrings claim:
+
+- File comment line 455–456: *"The Eisenstein integers ℤ[ω] are not yet in Mathlib v4.26.0."*
+- File comment line 489: *"Mathlib gap: Eisenstein integer ring ℤ[ω] is not in Mathlib v4.26.0."*
+- `meta.json` `assumptions`: *"Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib)"*
+- `meta.json` `keyInsights[4]`: *"Cubic reciprocity requires Eisenstein integers ℤ[ω] for the Jacobi sum J(χ₃, χ₃); this ring is not in Mathlib 4.26"*
+- `meta.json` `openQuestions[0]`: *"Can the Eisenstein integers ℤ[ω] be added to Mathlib 4? (This is the key blocker for cubic reciprocity)"*
+- Knowledge log: *"Eisenstein integers ℤ[ω] not in Mathlib 4.26 → cubic reciprocity axiomatized"*
+
+These claims are **all incorrect** at the pinned SHA. Mathlib v4.26.0 ships Eisenstein integers as the ring of integers of the third cyclotomic field, together with much of the Jacobi-sum machinery referenced in the cubic-reciprocity proof strategy. This OBSERVE documents the audit so that future ACT work picks the right bearers instead of axiomatizing.
+
+## Bearers found in pinned Mathlib (v4.26.0, SHA 2df2f01)
+
+### Eisenstein integers ℤ[ω] = 𝓞(ℚ(ζ₃))
+
+File: `Mathlib/NumberTheory/NumberField/Cyclotomic/Three.lean`
+(Re-exported from the deprecated stub `Mathlib/NumberTheory/Cyclotomic/Three.lean`.)
+
+Provides, for `K : Type*` with `[Field K] [IsCyclotomicExtension {3} ℚ K]` and `hζ : IsPrimitiveRoot ζ 3`:
+
+- `IsCyclotomicExtension.Rat.Three.coe_eta` — coercion of `η = hζ.toInteger.unit` into `𝓞 K`.
+- `IsPrimitiveRoot.toInteger_cube_eq_one` — `η^3 = 1` in `𝓞 K`.
+- `IsCyclotomicExtension.Rat.Three.Units.mem` — complete unit classification: `u ∈ [1, -1, η, -η, η^2, -η^2]`.
+- `IsCyclotomicExtension.Rat.Three.lambda_sq` — `λ^2 = -3 * η` where `λ = η - 1`.
+- `IsCyclotomicExtension.Rat.Three.eta_sq` — `η^2 = -η - 1` in `𝓞 K`.
+- `IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent` — Kummer's lemma for `λ^2`.
+
+### Cyclotomic-integer general infrastructure
+
+File: `Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean`
+
+- `IsCyclotomicExtension.finrank` — `Module.finrank ℚ K = k.totient`.
+- `IsCyclotomicExtension.ringOfIntegersOfPrimePow` — `𝓞 K` instance for prime-power cyclotomic.
+- `IsPrimitiveRoot.toInteger` (abbrev), `coe_toInteger`, `toInteger_isPrimitiveRoot`.
+- `IsCyclotomicExtension.zeta_sub_one_prime'` — `λ = ζ - 1` is prime in `𝓞 K`.
+- Discriminant theorems (`discr_odd_prime'`, `discr_prime_pow'`, ...).
+
+### `𝓞 K` is a PID for `K = ℚ(ζ₃)`
+
+File: `Mathlib/NumberTheory/NumberField/Cyclotomic/PID.lean`
+
+- `IsCyclotomicExtension.Rat.three_pid` — `[IsCyclotomicExtension {3} ℚ K] : IsPrincipalIdealRing (𝓞 K)`.
+- Companion `five_pid` for `K = ℚ(ζ₅)`.
+
+This is the structural fact that underwrites unique factorization of Eisenstein primes — a prerequisite for the cubic-residue symbol definition.
+
+### Jacobi sums (Ireland–Rosen §8.3)
+
+File: `Mathlib/NumberTheory/JacobiSum/Basic.lean`
+
+- `jacobiSum χ ψ = ∑ x : R, χ x * ψ (1 - x)` — the canonical definition.
+- `jacobiSum_comm`, `jacobiSum_ringHomComp` — symmetry + naturality.
+- `jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = #F - 2`.
+- `jacobiSum_one_nontrivial : χ ≠ 1 → jacobiSum 1 χ = -1`.
+- `jacobiSum_nontrivial_inv : χ ≠ 1 → jacobiSum χ χ⁻¹ = -χ (-1)`.
+- `jacobiSum_mul_nontrivial` — main relation `χ φ ≠ 1 → ⋯`.
+- `jacobiSum_eq_gaussSum_mul_gaussSum_div_gaussSum` — relates `J(χ,φ)` to Gauss sums.
+- `jacobiSum_mul_jacobiSum_inv` — magnitude identity `J(χ,φ) · J(χ,φ)⁻¹ = q`-style.
+- `gaussSum_pow_eq_prod_jacobiSum` — `g(χ,ψ)^n = q · ∏ⱼ J(χ, χʲ)` (the structural identity at the heart of Eisenstein's proof).
+- `jacobiSum_mem_algebraAdjoin_of_pow_eq_one` — Jacobi sum lies in the algebra adjoined to a root of unity (i.e., `J(χ₃, χ₃) ∈ ℤ[ω]`).
+
+### Multiplicative-character / Gauss-sum surrounding API
+
+- `Mathlib.NumberTheory.MulChar.Lemmas` — `MulChar` API used throughout the cubic-char file.
+- `Mathlib.NumberTheory.GaussSum` — Gauss-sum definition and `|g(χ)|^2 = q` for non-trivial χ.
+- `Mathlib.RingTheory.RootsOfUnity.Lemmas` — root-of-unity lemmas used by Jacobi-sum membership statements.
+
+## Implication for the two axioms
+
+The two `axiom` declarations in the slug's Lean file are:
+
+1. `cubicResidueSymbol (π : EisensteinPrime) (a : ℤ) : ZMod 3` (line 470)
+2. `cubic_reciprocity (π ρ : EisensteinPrime) (h_distinct) (hπ) (hρ) : ⋯ ` (line 491)
+
+Both are predicated on the file's local `structure EisensteinPrime` (line 459). The structure is a placeholder for `IsCyclotomicExtension {3} ℚ K`'s ring of integers — but the actual Mathlib formalization is *richer* (carries the field `K`, the primitive root `ζ`, full PID/unit/norm API). Because the local structure is decoupled from Mathlib's, the axioms are not *strictly* impossible to discharge from Mathlib bearers — but doing so requires first replacing the local `EisensteinPrime` with the Mathlib formulation. This is a non-trivial S6/S7 refactor, *not* a Mathlib upstreaming task.
+
+**The two axioms are therefore "axiomatized pending refactor + formalization", not "axiomatized pending upstream Mathlib feature".** This distinction matters because:
+
+- Future researchers attempting the cubic-reciprocity ACT should *not* wait for a Mathlib PR — the prerequisites are already merged.
+- The blocker is engineering effort (rebase local `EisensteinPrime` onto `𝓞 K`, then port Ireland–Rosen §9 proof using the existing `jacobiSum` and `gaussSum` API), not external bearer development.
+
+## Suggested next ACT (S6) — refactor plan
+
+1. **Delete local `structure EisensteinPrime`**; replace with a context `[hKζ : IsCyclotomicExtension {3} ℚ K] (hζ : IsPrimitiveRoot ζ 3)` and use `𝓞 K`.
+2. **Define the cubic residue symbol concretely**: for a prime `π : 𝓞 K` (in the sense of `IsCyclotomicExtension.Rat.Three`-style), and `a : ℤ` coprime to `π`,
+   `cubicResidueSymbol π a := IsPrimitiveRoot.cubicCharLift (a^((Ideal.absNorm (Ideal.span {π}) - 1) / 3) mod π)`.
+   The image lies in `μ₃ ⊆ 𝓞 K`, which `IsPrimitiveRoot.toInteger_cube_eq_one` shows is `{1, η, η^2}`.
+3. **Define χ_π : MulChar (𝓞 K ⧸ Ideal.span {π}) (𝓞 K)** as the lift of the cubic residue symbol; check it is a non-trivial `MulChar` of order 3.
+4. **Apply `jacobiSum_mem_algebraAdjoin_of_pow_eq_one`** to conclude `J(χ_π, χ_π) ∈ ℤ[ω]`.
+5. **Compute `|J|^2 = N(π)`** via `jacobiSum_mul_jacobiSum_inv` and `gaussSum_pow_eq_prod_jacobiSum`.
+6. **Derive cubic reciprocity** by comparing `J(χ_π, χ_π)^((N(ρ)-1)/3) mod ρ` against `χ_ρ(N(π))`, following Ireland–Rosen Theorem 1 of Chapter 9 verbatim.
+
+Estimated LOC: ~250 lines of Lean. No new Mathlib bearer needed.
+
+## Files touched by this OBSERVE
+
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md` — this note (NEW).
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md` — sync Phase + 0-sorries; append Session-5.
+- `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` — correct `assumptions`, `description`, `keyInsights[4]`, `openQuestions[0]`.
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` — correct docstring comments at lines 455–456 and 489 (text-only; no code change).
+
+Diff is text-only / no proof tactic changes / no `import` changes → 0 build risk. Sorries unchanged (0). Axiom count unchanged (2).
+
+## Audit trail
+
+- Knowledge.md previously asserted "1 sorry" remained (Phase: ACT). The file in fact has 0 sorries since merge of #15356 (2026-05-03) which discharged `cubicChar_kernel_card`. This is an independent drift, also corrected by this PR.
+- Memory trap notes (`feedback_researcher_mathlib_head_vs_lockfile_sha_drift.md`) followed: all Mathlib API references in this note were resolved against the **lake-pinned SHA** `2df2f01...`, not Mathlib HEAD.

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "elementary-quadratic-reciprocity-oq-01-oq-02",
   "title": "Cubic and Quartic Characters as Higher Reciprocity Pathway",
   "slug": "elementary-quadratic-reciprocity-oq-01-oq-02",
-  "description": "Generalizes the Zolotarev character uniqueness argument (OQ-01) to cubic and quartic residue characters. For primes p ≡ 1 (mod 3), constructs the cubic character χ₃ = (· ^ ((p-1)/3)) as a group homomorphism (ZMod p)ˣ →* (ZMod p)ˣ and proves the complete Euler criterion: χ₃(a) = 1 ↔ a is a cubic residue. The kernel cardinality |ker χ₃| = (p-1)/3 is proved via IsCyclic.card_pow_eq_one_le + injectivity argument. The quartic character χ₄ is constructed in parallel with full quartic Euler criterion proved. Cubic reciprocity (Eisenstein 1844) is axiomatized with a Jacobi sum proof strategy. 27 theorems, 0 sorries, 2 axioms.",
+  "description": "Generalizes the Zolotarev character uniqueness argument (OQ-01) to cubic and quartic residue characters. For primes p ≡ 1 (mod 3), constructs the cubic character χ₃ = (· ^ ((p-1)/3)) as a group homomorphism (ZMod p)ˣ →* (ZMod p)ˣ and proves the complete Euler criterion: χ₃(a) = 1 ↔ a is a cubic residue. The kernel cardinality |ker χ₃| = (p-1)/3 is proved via IsCyclic.card_pow_eq_one_le + injectivity argument. The quartic character χ₄ is constructed in parallel with full quartic Euler criterion proved. Cubic reciprocity (Eisenstein 1844) is axiomatized with a Jacobi sum proof strategy; the two remaining axioms are predicated on the file's local `structure EisensteinPrime` and are pending an engineering refactor onto Mathlib v4.26.0's already-shipped `IsCyclotomicExtension {3} ℚ K` / `𝓞 K` and `Mathlib.NumberTheory.JacobiSum.Basic` (see research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md). 27 theorems, 0 sorries, 2 axioms.",
   "meta": {
     "author": "Eisenstein (1844), Ireland-Rosen (1990)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cubic_reciprocity",
@@ -21,10 +21,10 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 562,
+    "lineCount": 578,
     "theoremCount": 27,
     "defCount": 6,
-    "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. All 27 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card and quarticChar_kernel_card (|ker χ| = (p-1)/3 and (p-1)/4 via IsCyclic.card_pow_eq_one_le), cubicEuler_hard and quarticEuler_hard (both Euler criterion hard directions via discrete log).",
+    "assumptions": "Two axioms predicated on the file's local `structure EisensteinPrime`: (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. Mathlib v4.26.0 already ships the bearers needed to discharge these axioms (Mathlib.NumberTheory.NumberField.Cyclotomic.Three for ℤ[ω] as 𝓞 K, Mathlib.NumberTheory.NumberField.Cyclotomic.PID.three_pid for IsPrincipalIdealRing (𝓞 K), and Mathlib.NumberTheory.JacobiSum.Basic for the full jacobiSum/gaussSum API following Ireland–Rosen §8.3). Discharging the axioms is therefore an engineering refactor (rebase the local EisensteinPrime onto Mathlib's 𝓞 K and port Ireland–Rosen Theorem 1 of Chapter 9, ~250 LOC) rather than a wait-on-upstream-Mathlib task. See research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md for the bearer catalog and refactor plan. All 27 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card and quarticChar_kernel_card (|ker χ| = (p-1)/3 and (p-1)/4 via IsCyclic.card_pow_eq_one_le), cubicEuler_hard and quarticEuler_hard (both Euler criterion hard directions via discrete log).",
     "mathlib_version": "4.26.0",
     "definitionCount": 7
   },
@@ -38,7 +38,7 @@
       "χ₃(a)³ = a^(p-1) = 1 by Fermat, so the image of χ₃ consists of cube roots of unity in (ZMod p)ˣ",
       "Easy Euler criterion: x³ = a implies a^((p-1)/3) = (x^3)^((p-1)/3) = x^(p-1) = 1, proved via Units.mk0 lift and pow_mul",
       "Hard Euler criterion (χ₃(a) = 1 implies a is a cube) proved by discrete log: write a = g^k for generator g of (ZMod p)ˣ; χ₃(a)=1 implies (p-1)|k(p-1)/3, so 3|k; then a = (g^(k/3))³",
-      "Cubic reciprocity requires Eisenstein integers ℤ[ω] for the Jacobi sum J(χ₃, χ₃); this ring is not in Mathlib 4.26"
+      "Cubic reciprocity requires Eisenstein integers ℤ[ω] and the Jacobi sum J(χ₃, χ₃); Mathlib v4.26.0 already ships both bearers (NumberField.Cyclotomic.Three for ℤ[ω] as 𝓞 K, and JacobiSum.Basic for the Jacobi-sum API). The local `structure EisensteinPrime` in this file is a placeholder for `IsCyclotomicExtension {3} ℚ K` and the two axioms are pending a refactor rather than a Mathlib feature"
     ],
     "prerequisites": [
       "Cubic residues and the cubic Legendre symbol",
@@ -101,7 +101,7 @@
     "summary": "The cubic character χ₃ and quartic character χ₄ are constructed as group homomorphisms in Lean 4. The complete Euler criterion (both directions) is now fully proved: the hard direction uses discrete logarithm in the cyclic group (ZMod p)ˣ. Full cubic reciprocity requires Eisenstein integers (ℤ[ω]) not yet in Mathlib 4.26, and is axiomatized with a detailed Jacobi sum proof strategy.",
     "implications": "This file provides the foundation for cubic and quartic reciprocity formalization once Mathlib gains Eisenstein integer support. The character construction technique (powMonoidHom + Fermat's little theorem for units) extends naturally to any prime power character.",
     "openQuestions": [
-      "Can the Eisenstein integers ℤ[ω] be added to Mathlib 4? (This is the key blocker for cubic reciprocity)",
+      "Can the local `structure EisensteinPrime` be rebased onto Mathlib's `IsCyclotomicExtension {3} ℚ K` + `𝓞 K`? (The bearers are already in Mathlib v4.26.0; the blocker for cubic reciprocity is this refactor, not upstream Mathlib feature development)",
       "Can the quartic reciprocity law (biquadratic reciprocity) be axiomatized with Gaussian integers ℤ[i] as the coefficient ring?",
       "Can the Jacobi sum J(χ₃, χ₃) computation be formalized once ℤ[ω] is in Mathlib?"
     ]
@@ -167,7 +167,7 @@
       "ZMod"
     ],
     "namespace": "CubicCharacter",
-    "lineCount": 562,
+    "lineCount": 578,
     "axiomCount": 2,
     "theoremCount": 27,
     "definitionCount": 7,


### PR DESCRIPTION
## Summary

Audits the two remaining `axiom` declarations in `ElementaryQuadraticReciprocityOQ01OQ02.lean` against lake-pinned Mathlib v4.26.0 (SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). The file's docstrings, `knowledge.md`, and `meta.json` all claim "Eisenstein integers ℤ[ω] not yet in Mathlib v4.26.0" — **this claim is incorrect** at the pinned SHA. This PR corrects the misleading text across all four artifacts (Lean docstring comments, knowledge.md, meta.json prose fields, and a new `s5-observe-eisenstein-bearer.md` audit note). Zero proof / tactic / import / signature changes.

## Bearers found at pinned Mathlib v4.26.0

| Bearer | File | Notes |
|---|---|---|
| Eisenstein integers ℤ[ω] as `𝓞 K` | `Mathlib.NumberTheory.NumberField.Cyclotomic.Three` | `IsCyclotomicExtension {3} ℚ K`; unit classification, `λ²=-3η`, `η²=-η-1`, Kummer for `λ²` |
| `𝓞 K` is a PID for `K=ℚ(ζ₃)` | `Mathlib.NumberTheory.NumberField.Cyclotomic.PID` | `three_pid` (and `five_pid` companion) |
| Jacobi-sum API | `Mathlib.NumberTheory.JacobiSum.Basic` | `jacobiSum`, `jacobiSum_mul_nontrivial`, `jacobiSum_eq_gaussSum_mul_gaussSum_div_gaussSum`, `jacobiSum_mul_jacobiSum_inv`, `gaussSum_pow_eq_prod_jacobiSum`, `jacobiSum_mem_algebraAdjoin_of_pow_eq_one` |
| Multiplicative-char API | `Mathlib.NumberTheory.MulChar.Lemmas` | Used throughout the cubic-char file |
| Gauss sums | `Mathlib.NumberTheory.GaussSum` | Background for Jacobi-sum identities |

The two `axiom` declarations (`cubicResidueSymbol`, `cubic_reciprocity`) are predicated on the file's local `structure EisensteinPrime` (line 459), which is decoupled from Mathlib's richer `𝓞 K` formalization. Discharging them is therefore an **engineering refactor** (rebase `EisensteinPrime` onto `IsCyclotomicExtension {3} ℚ K`, then port Ireland–Rosen Theorem 1 of Chapter 9 using the existing `jacobiSum`/`gaussSum` API, ~250 LOC), **not** a wait-on-upstream-Mathlib task.

## Scope

| File | Change |
|---|---|
| `research/problems/.../s5-observe-eisenstein-bearer.md` | NEW — full bearer catalog with file references at the pinned SHA + step-by-step S6 refactor plan |
| `research/problems/.../knowledge.md` | Header `Status`/`Phase` synced (was "in-progress / ACT", actual was 0 sorries / 2 axioms since #15356 and #16691); appended Session 5 entry; S1 snapshot kept verbatim and flagged historical |
| `src/data/proofs/.../meta.json` | Corrected `description`, `assumptions`, `keyInsights[4]`, `openQuestions[0]`; bumped `lineCount` 562→578 to match expanded docstrings |
| `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` | Replaced two inaccurate docstring blocks (L455–L456 and L489) with corrected Mathlib-bearer notes. **Zero tactic / import / signature changes** |

**Out of scope**: the S6 refactor itself (rebase local `EisensteinPrime` onto `𝓞 K`, port Ireland–Rosen §9 Thm 1) is left for a follow-up PR. The plan is documented in `s5-observe-eisenstein-bearer.md` §"Suggested next ACT (S6) — refactor plan".

## Build risk

Zero. Sorries unchanged (**0**). Axiom count unchanged (**2**). Theorem count unchanged (**27**). All edits are within comment/doc text or JSON prose fields. `jq . meta.json` passes.

## Test plan

- [ ] CI: doc-only PR, no Lean type-check requirement (but pinned Mathlib will rebuild cleanly because file body is unchanged outside docstrings).
- [ ] Verify gallery rendering (`pnpm build`) picks up corrected `meta.json` prose; visual sanity check that the "key insights" / "open questions" panels read correctly.
- [ ] Reader check: a future S6 researcher can follow `s5-observe-eisenstein-bearer.md` to know which Mathlib decls to use without re-running the bearer audit.

## Audit-trail notes

- Memory trap `feedback_researcher_mathlib_head_vs_lockfile_sha_drift.md` followed: all Mathlib API claims verified against the lake-pinned SHA, not Mathlib HEAD.
- Memory trap `feedback_write_tool_main_repo_absolute_path_trap.md`: hit once during this session and recovered before commit (moved `s5-observe-eisenstein-bearer.md` from main repo working tree into the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)