### PR TITLE
fix(mechanic): wire annotations into cantor-diagonalization-oq-03-oq-01-oq-01 index.ts

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean?raw')
+
+export const cantorDiagonalizationOq03Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq03Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq03Oq01Oq01Data: ProofData = {
+  proof: cantorDiagonalizationOq03Oq01Oq01Proof,
+  annotations: cantorDiagonalizationOq03Oq01Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default cantorDiagonalizationOq03Oq01Oq01Data


### PR DESCRIPTION
## Summary

Replace 2-line stub (`import meta; export default meta;`) with canonical full index.ts template so the gallery page actually renders the 9 annotations (~12KB, Lawvere FPT category-theoretic content: EvalStructure, lawvere_abstract, IsPointSurjective, etc.) that already exist in `annotations.json` but were silently hidden.

## Why

`getProofAsync` (`src/data/proofs/index.ts:48`) takes `module.default` as `proofData`. With the stub default-exporting raw `metaJson` (no `proof` field), `ProofPage.tsx:111` destructures undefined for `.proof` / `.annotations`. Enricher won't pick this up (quality saturated at 100) — only mechanic-side wiring can recover the rendering.

## Scope

- One file: `src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/index.ts` (+44/-2)
- Lean import: `Proofs/CantorDiagonalizationOQ03OQ01.lean` (per `meta.leanFile.path`; this extension OQ slug shares the parent OQ03OQ01 source)
- camelCase export name: `cantorDiagonalizationOq03Oq01Oq01Data` (matches `slugToExportName` regex)

## Test plan

- [x] meta.leanFile.path → `Proofs/CantorDiagonalizationOQ03OQ01.lean` exists
- [x] camelCase export name matches `slug.replace(/-([a-z0-9])/g, ...) + 'Data'` runtime regex
- [x] 9 annotations in `annotations.json` with valid `range.startLine`/`endLine` fields (no `lineNumber` legacy)
- [x] Same canonical template as PRs #18749, #18754, #18755 (sibling mechanic wires)
- [ ] Build passes (deferred to CI / deployer)

## Out of scope

- 12 other pattern-1 stubs still pending (multiple sibling mechanic PRs in flight: #18759, #18761, #18764, #18766, #18769)
- Slug↔Lean-file naming mismatch (`-oq-03-oq-01-oq-01` slug → `OQ03OQ01.lean` file) is orthogonal — separate metadata audit if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)