### PR TITLE
fix(mechanic): wire annotations into amgm-inequality-oq-02-oq-01-oq-02-oq-01 index.ts

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/index.ts
@@ -1,2 +1,44 @@
-export { default as meta } from './meta.json';
-export { default as annotations } from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean?raw')
+
+export const amgmInequalityOq02Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq02Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq02Oq01Oq02Oq01Data: ProofData = {
+  proof: amgmInequalityOq02Oq01Oq02Oq01Proof,
+  annotations: amgmInequalityOq02Oq01Oq02Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default amgmInequalityOq02Oq01Oq02Oq01Data


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub with the canonical 44-line TypeScript template so the gallery page renders the proof + 9 Newton-Girard annotations.

## Evidence

**Before**: `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/index.ts` was only:
```ts
export { default as meta } from './meta.json';
export { default as annotations } from './annotations.json';
```

`getProofAsync` at `src/data/proofs/index.ts:57` reads `module.default`, which here resolved to the raw `meta.json` object (truthy), so the fallback path at lines 60–79 never ran. `ProofPage.tsx:111` then destructures `proofData.proof.*` / `proofData.annotations` from `undefined`, breaking the page silently despite a fully populated 12.6 KB `annotations.json` (9 annotations: `psum_one_eq_esymm_one`, `psum_two_eq` antidiagonal computation, `psum_three_eq`, etc.) and the Lean source at `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` (91 LOC, 3 theorems, 0 sorries, 0 axioms).

**After**: Canonical template wires:
- `metaJson` + `annotationsJson` JSON imports
- Typed `Proof` / `Annotation[]` / `ProofData` exports
- Async `getProofSource()` via `import('../../../../proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean?raw')`
- `default export = amgmInequalityOq02Oq01Oq02Oq01Data` (camelCase lowercase `q` per `slugToExportName` regex `-([a-z0-9])` at `src/data/proofs/index.ts:39-42`)

## Scope

- Single file: `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/index.ts` (+44 −2 LOC).
- No edits to `meta.json`, `annotations.json`, or the Lean source.
- Out of scope: the ~16 sibling slugs still on 2-line stubs (`bezout-identity-oq-02-oq-01-oq-02-oq-02`, `binary-gcd`, `cantor-diagonalization-oq-03-oq-01-oq-01`, `divisibility-truncation-general`, `erdos-1059-oq-01..oq-05`, `subset-count-multiset`, `triangle-angle-sum-oq-03`, etc.) — separate PR each.

## Precedent

Same pattern as PR #17885 (lagrange-theorem-oq-02-oq-02), PR #18749 (triangle-angle-sum-oq-01), PR #18755 (konigsberg-oq-03-oq-02), PR #18759 (laws-of-large-numbers-oq-03), PR #18761 (erdos-152-oq-01), PR #18766 (harmonic-divergence-oq-02).

---
Automated fix by lean-mechanic agent.