### PR TITLE
fix(mechanic): wire annotations into cantor-diagonalization-oq-03-oq-01-oq-04 index.ts

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/index.ts
@@ -1,3 +1,44 @@
-import meta from "./meta.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean?raw')
+
+export const cantorDiagonalizationOq03Oq01Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq03Oq01Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq03Oq01Oq04Data: ProofData = {
+  proof: cantorDiagonalizationOq03Oq01Oq04Proof,
+  annotations: cantorDiagonalizationOq03Oq01Oq04Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default cantorDiagonalizationOq03Oq01Oq04Data


### PR DESCRIPTION
## Fix

The previous 3-line stub at `src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/index.ts` only re-exported a named `meta` symbol:

```ts
import meta from "./meta.json";
export { meta };
```

`getProofAsync` at `src/data/proofs/index.ts:60-79` therefore took the legacy `{ meta, annotations }` fallback path with `module.annotations === undefined`, silently rendering the gallery page with `annotations: []` despite the **13 KB `annotations.json`** sitting next to it.

## Repair

Replace with the canonical full template (matches `abel-ruffini-galois-extensions-oq-05-oq-01`, `bezout-identity-oq-03-oq-04-oq-01`, `triangle-angle-sum-oq-01`, etc.):

- imports `annotationsJson` and binds the typed `Proof` / `Annotation[]` / `ProofData` shape;
- hardcodes the matching Lean source path `../../../../proofs/Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean?raw` via a lazy `getProofSource` helper;
- exports `cantorDiagonalizationOq03Oq01Oq04Data` as the default export so `getProofAsync`'s first branch (`module.default`) succeeds.

No content changes to `meta.json` or `annotations.json`.

## Evidence

**Before**: 3-line named-`{ meta }` stub → page renders with `annotations: []`.
**After**: 44-line canonical template → page renders full annotation set.

## Scope

One slug per PR (gallery-wide 2-line / named-only stub class still has ~12 remaining; tracked separately by parallel mechanic slots — see open \`fix/mechanic-*-index*\` PRs).

Out of scope: every other broken \`index.ts\` stub.

---
Automated fix by lean-mechanic agent.