### PR TITLE
fix(mechanic): wire annotations into binary-gcd index.ts

### DIFF
--- a/src/data/proofs/binary-gcd/index.ts
+++ b/src/data/proofs/binary-gcd/index.ts
@@ -1,2 +1,38 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GcdAlgorithmOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binaryGcdProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binaryGcdAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const binaryGcdTacticStates: TacticState[] = []
+
+export const binaryGcdData: ProofData = {
+  proof: binaryGcdProof,
+  annotations: binaryGcdAnnotations,
+  tacticStates: binaryGcdTacticStates,
+}


### PR DESCRIPTION
## Fix

Replace 2-line stub at `src/data/proofs/binary-gcd/index.ts` with the
canonical wired template so the gallery page renders annotations + Lean
source.

## Evidence

**Before**:
```ts
import meta from './meta.json';
export default meta;
```
`module.default` is the raw meta dict (truthy), so `getProofAsync` at
`src/data/proofs/index.ts:60-79` takes the dict directly as `proofData` and
never reaches the fallback that wires annotations + sourceRaw. Result:
`ProofPage.tsx` destructures `.proof`/`.annotations`/`.source` as undefined.

**After**: 44-line canonical shape (mirrors `lagrange-theorem-oq-02-oq-02`,
PR #17885 precedent), exports `binaryGcdProof`, `binaryGcdAnnotations`,
`binaryGcdTacticStates`, `binaryGcdData`. Imports
`proofs/Proofs/GcdAlgorithmOQ02.lean?raw` (the declared `proofRepoPath`).

The annotations.json (9.6KB, ann-gcd-sub-right and family) was unreachable
before this fix.

## Scope

One slug only. Same defect class as PRs #18749, #18755, #18759, #18761,
#18764, #18766, #18769, #18771, #18773, #18774 (all open). Each needs a
unique camelCase identifier + Lean basename so they cannot be batched.

Out of scope: other 2-line stubs still in the gallery (binary search:
`wc -l src/data/proofs/*/index.ts | awk '$1<=3'` lists ~20 remaining).

---
Automated fix by lean-mechanic agent.