### PR TITLE
fix(mechanic): wire annotations into triangle-angle-sum-oq-03 index.ts

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-03/index.ts
+++ b/src/data/proofs/triangle-angle-sum-oq-03/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/TriangleAngleSumOQ03.lean?raw')
+
+export const triangleAngleSumOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleAngleSumOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleAngleSumOq03Data: ProofData = {
+  proof: triangleAngleSumOq03Proof,
+  annotations: triangleAngleSumOq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default triangleAngleSumOq03Data


### PR DESCRIPTION
## Fix

Replace 2-line stub with canonical 44-line template so the page renders proof, annotations, and Lean source for `triangle-angle-sum-oq-03` (Triangle Angle Sum: Degenerate Cases and the Redundant Hypothesis).

## Evidence

**Before**:
```ts
import meta from './meta.json';
export default meta;
```
`module.default` was the raw meta dict, so `getProofAsync`'s legacy fallback at `src/data/proofs/index.ts:60-79` never ran — `ProofPage.tsx:111` destructured `undefined` for `.proof` / `.annotations`. The 6.1KB / 6-annotation `annotations.json` and 6-section meta existed but were never loaded.

**After**:
- imports `annotationsJson` + meta with full `ProofData` typing
- hardcodes `proofs/Proofs/TriangleAngleSumOQ03.lean?raw` for the Lean source
- exports camelCase `triangleAngleSumOq03{Proof,Annotations,Data}` plus `default` and `getProofSource()`

## Scope

Sibling of the in-flight PRs in this orthogonal target class (e.g. #18749 `triangle-angle-sum-oq-01`, #18755 `konigsberg-oq-03-oq-02`, #18773 `amgm-inequality-oq-02-oq-01-oq-02-oq-01`). One slug per PR.

Out of scope: the remaining ~13 unclaimed 2-line stub slugs (`bezout-identity-oq-02-oq-01-oq-02-oq-02`, `binary-gcd`, `divisibility-truncation-general{,-oq-01}`, `erdos-1059-oq-{01..05}`, `subset-count-multiset`, plus the `export { default as meta }` variant `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`). Each needs its own canonical template with unique camelCase exports + Lean basename.

---
Automated fix by lean-mechanic agent.