### PR TITLE
fix(mechanic): wire annotations into erdos-1143 index.ts

### DIFF
--- a/src/data/proofs/erdos-1143/index.ts
+++ b/src/data/proofs/erdos-1143/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export default { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1143Problem.lean?raw')
+
+export const erdos1143Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1143Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1143Data: ProofData = {
+  proof: erdos1143Proof,
+  annotations: erdos1143Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1143Data


### PR DESCRIPTION
## Fix

Replace the 3-line `import meta; import annotations; export default { meta, annotations }` stub at `src/data/proofs/erdos-1143/index.ts` with the canonical 44-line template so the gallery page actually renders the proof and its 12 annotations.

## Evidence

**Before**: `module.default = { meta, annotations }` is truthy, so `getProofAsync` (`src/data/proofs/index.ts:48-79`) assigns it to `proofData`. The legacy fallback at line 61 only triggers when `proofData` is falsy, so the page receives a `ProofData`-shaped object whose `.proof` is undefined. `ProofPage` destructures undefined for `.id`, `.title`, sections, overview, conclusion, and crossReferences — page renders blank despite a 14 KB `annotations.json` (12 entries) and a fully-populated `meta.json` (status: `axiomatized`, 2 axioms, Erdős Problem #1143 — Covering Intervals with Multiples of Primes).

**After**: Canonical template matching `abel-ruffini-galois-extensions-oq-05-oq-01/index.ts` and `cantor-diagonalization-oq-03-oq-01-oq-04/index.ts` (PR #18774):

- Typed `Proof` object built from `metaJson` fields (id, title, slug, description, meta, sections, overview, conclusion, crossReferences)
- Eager-import `annotationsJson` as the `Annotation[]` export
- Lazy `?raw` import of `proofs/Proofs/Erdos1143Problem.lean` via `getProofSource()` for the source viewer
- Named exports `erdos1143Proof`, `erdos1143Annotations`, `erdos1143Data` (slug-camelCase per `slugToExportName`)
- `export default erdos1143Data` so glob-loader picks it up directly

## Scope

One slug, one file, +43/-3. No edits to `meta.json`, `annotations.json`, or the Lean source. Orthogonal to the other ~10 open mechanic PRs fixing sibling stub slugs (e.g. #18774, #18773, #18771, #18769, #18766, #18764, #18761, #18759, #18755, #18754, #18749).

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)