### PR TITLE
research(erdos-677): S2 ACT — k=3 axiom-free for n=2, n=3

### DIFF
--- a/proofs/Proofs/Erdos677Problem.lean
+++ b/proofs/Proofs/Erdos677Problem.lean
@@ -311,3 +311,43 @@ theorem erdos677_k3_at_one (m : ℕ) (hm : 4 ≤ m) :
   -- hge : m + 3 ≤ 12, so m ≤ 9
   have hm_le : m ≤ 9 := by omega
   interval_cases m <;> revert heq <;> native_decide
+
+/-- **Structural observation**: `lcmInterval 2 3 = lcmInterval 3 3 = 60`. This is a
+    *near-miss* for Erdős #677 at `k = 3`: two distinct values of `n` (n=2 and n=3) share
+    the same LCM. However the conjecture requires `m ≥ n + k`, which for `n = 2, k = 3`
+    means `m ≥ 5`, excluding the equality at `m = 3`. Likewise `n = 3, k = 3` excludes
+    `m = 2`. So the constraint `m ≥ n + k` is exactly what rules out this near-miss. -/
+theorem lcmInterval_two_three_collision : lcmInterval 2 3 = lcmInterval 3 3 := by
+  native_decide
+
+/-- **Erdős #677 holds for k = 3, n = 2**: `lcmInterval m 3 ≠ lcmInterval 2 3 = 60` for all `m ≥ 5`.
+
+    Proof: `m + 3 ≤ lcmInterval m 3 = 60` forces `m ≤ 57`. The conjecture reduces to a
+    finite check over `m ∈ {5, 6, …, 57}` (53 cases), each dispatched by `native_decide`.
+    Note: at `m = 3` we have `lcmInterval 3 3 = 60 = lcmInterval 2 3`, but the constraint
+    `m ≥ n + k = 5` excludes this near-miss (see `lcmInterval_two_three_collision`). -/
+theorem erdos677_k3_at_two (m : ℕ) (hm : 5 ≤ m) :
+    lcmInterval m 3 ≠ lcmInterval 2 3 := by
+  intro heq
+  have h0 : lcmInterval 2 3 = 60 := by native_decide
+  have hge : m + 3 ≤ lcmInterval m 3 := le_lcmInterval m 3 (by omega)
+  rw [heq, h0] at hge
+  -- hge : m + 3 ≤ 60, so m ≤ 57
+  have hm_le : m ≤ 57 := by omega
+  interval_cases m <;> revert heq <;> native_decide
+
+/-- **Erdős #677 holds for k = 3, n = 3**: `lcmInterval m 3 ≠ lcmInterval 3 3 = 60` for all `m ≥ 6`.
+
+    Proof: `m + 3 ≤ lcmInterval m 3 = 60` forces `m ≤ 57`. The conjecture reduces to a
+    finite check over `m ∈ {6, 7, …, 57}` (52 cases), each dispatched by `native_decide`.
+    Note: at `m = 2` we have `lcmInterval 2 3 = 60 = lcmInterval 3 3`, but the constraint
+    `m ≥ n + k = 6` excludes this near-miss (see `lcmInterval_two_three_collision`). -/
+theorem erdos677_k3_at_three (m : ℕ) (hm : 6 ≤ m) :
+    lcmInterval m 3 ≠ lcmInterval 3 3 := by
+  intro heq
+  have h0 : lcmInterval 3 3 = 60 := by native_decide
+  have hge : m + 3 ≤ lcmInterval m 3 := le_lcmInterval m 3 (by omega)
+  rw [heq, h0] at hge
+  -- hge : m + 3 ≤ 60, so m ≤ 57
+  have hm_le : m ≤ 57 := by omega
+  interval_cases m <;> revert heq <;> native_decide

--- a/research/problems/erdos-677/state.md
+++ b/research/problems/erdos-677/state.md
@@ -1,27 +1,64 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-14T18:07:47.344Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-05-13T11:35:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Extending axiom-free k=3 coverage. After this session, the conjecture is proved
+for k=1 (fully), k=2 (fully), and k=3 at n ∈ {0, 1, 2, 3}. Open: k=3 for n ≥ 4
+(small-m cases) and k ≥ 4 entirely (except the general large-m bound, axiomatized
+via Thue–Siegel for the finiteness).
 
 ## Active Approach
 
-None yet.
+**Brute-force bounded enumeration** for k=3 small-n cases. The pattern:
+
+```
+theorem erdos677_k3_at_n (m : ℕ) (hm : n+3 ≤ m) : lcmInterval m 3 ≠ lcmInterval n 3 := by
+  intro heq
+  have h0 : lcmInterval n 3 = V := by native_decide   -- V = computed target value
+  have hge : m + 3 ≤ lcmInterval m 3 := le_lcmInterval m 3 (by omega)
+  rw [heq, h0] at hge                                 -- hge : m + 3 ≤ V, so m ≤ V-3
+  have hm_le : m ≤ V - 3 := by omega
+  interval_cases m <;> revert heq <;> native_decide   -- one native_decide per m
+```
+
+This works whenever the case count `V - 3 - (n + 3 - 1)` is reasonable (≤ ~60).
+At n=2,3: V=60, ~52 cases. At n=4: V=210, ~200 cases — approaching the practical
+ceiling of `interval_cases` + `native_decide`. Beyond n=4, a sharper lower bound
+is needed.
+
+## Recent Progress (Session 2, 2026-05-13)
+
+- Added `erdos677_k3_at_two` (m ≥ 5, V=60, 53 cases).
+- Added `erdos677_k3_at_three` (m ≥ 6, V=60, 52 cases).
+- Documented `lcmInterval_two_three_collision`: M(2,3) = M(3,3) = 60 is a
+  *near-miss* the constraint m ≥ n+k exactly excludes.
+- Updated meta: theoremCount 28 → 31, lineCount 313 → 353.
 
 ## Blockers
 
-None.
+- k=3 for n ≥ 4 needs a sharper lower bound. The simple `n+k ≤ lcmInterval n k`
+  bound produces ~200+ cases at n=4.
+- k ≥ 4 cases entirely open (modulo the axiomatic Thue–Siegel finiteness).
 
 ## Next Action
 
-Begin problem exploration.
+Three plausible directions, in increasing difficulty:
+
+1. **Sharper lower bound for k=3**: Prove `lcmInterval n 3 ≥ (n+1)(n+2)(n+3)/2`
+   for all n. This follows from gcd structure: when n is odd, n+1 and n+3 share
+   exactly a factor of 2; when n is even, the factors are pairwise coprime. With
+   this bound, `m+3 ≤ lcmInterval m 3` would force `(m+1)(m+2)(m+3)/2 ≤ V`, which
+   has a much smaller solution set in m.
+2. **Closed-form for `lcmInterval n 3`**: With the sharper bound, derive an exact
+   formula and extend the k=3 resolution to all n.
+3. **k=4 small-n cases**: Apply the same brute-force pattern at k=4.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2 (sessions: 1 = scaffolding + k=1/k=2/factorization; 2 = k=3 at n=2,3)
+- Current approach attempts: 1 (brute-force bounded enumeration; succeeded for n ∈ {2, 3})
+- Approaches tried: 2 (axiom-free direct algebra for k ≤ 2; brute-force for small-n k=3)

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -22,12 +22,14 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: thue_siegel_finiteness (Thue-Siegel theorem: finitely many solutions for fixed k). Former axioms now proved: lcmInterval_example1/2 (native_decide), lcmInterval_dvd_product (Finset.induction + Nat.lcm_dvd), lcmInterval_pos (dvd + product positivity). Conjecture verified for k=1 and k=2.",
-    "lineCount": 313,
+    "lineCount": 353,
     "mathlib_version": "4.26.0",
-    "theoremCount": 28,
+    "theoremCount": 31,
     "originalContributions": [
       "erdos677_large_m: general bound — for any k, if m+k > consecutiveProduct(n,k) then M(m,k)≠M(n,k)",
-      "erdos677_k3_large_m: k=3 corollary of the large-m bound, axiom-free"
+      "erdos677_k3_large_m: k=3 corollary of the large-m bound, axiom-free",
+      "erdos677_k3_at_two/three: axiom-free k=3 resolution for n ∈ {2, 3} via bounded interval_cases",
+      "lcmInterval_two_three_collision: near-miss observation that M(2,3) = M(3,3) = 60, excluded by m ≥ n+k constraint"
     ],
     "definitionCount": 5
   },
@@ -134,9 +136,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 313,
+    "lineCount": 353,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 31,
     "definitionCount": 5,
     "path": "Proofs/Erdos677Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-677.json
+++ b/src/data/research/problems/erdos-677.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: k=1, k=2 proved. General large-m bound added (25 theorems, 1 axiom=Thue-Siegel). k=3 remains open for small m.",
+    "progressSummary": "PROGRESS: k=1, k=2 proved fully. k=3 proved axiom-free for n ∈ {0, 1, 2, 3}. General large-m bound covers any k when m exceeds the consecutive product (31 theorems, 1 axiom=Thue-Siegel). k=3 small-n cases for n ≥ 4 require a sharper lower bound than n+k ≤ lcmInterval n k (the brute-force interval_cases approach hits 200+ cases for n=4).",
     "builtItems": [
       "Proved lcmInterval_example1/2 by native_decide",
       "Proved lcmInterval_dvd_product by Finset.induction_on",
@@ -48,7 +48,10 @@
       "erdos677_k2: conjecture PROVED for k=2 via lcmInterval_two + nlinarith (Erdos677Problem.lean:223)",
       "factorization_lcmInterval: factorization = Finset.sup of factorizations, induction on k (Erdos677Problem.lean:233)",
       "erdos677_large_m: general axiom-free bound for any k in Erdos677Problem.lean",
-      "erdos677_k3_large_m: k=3 corollary when m+3 > (n+1)(n+2)(n+3)"
+      "erdos677_k3_large_m: k=3 corollary when m+3 > (n+1)(n+2)(n+3)",
+      "erdos677_k3_at_two: k=3, n=2 case proved axiom-free via le_lcmInterval + interval_cases over m ∈ {5..57} (Erdos677Problem.lean:323)",
+      "erdos677_k3_at_three: k=3, n=3 case proved axiom-free via le_lcmInterval + interval_cases over m ∈ {6..57} (Erdos677Problem.lean:342)",
+      "lcmInterval_two_three_collision: structural near-miss M(2,3) = M(3,3) = 60 (Erdos677Problem.lean:316)"
     ],
     "insights": [
       "lcmInterval_example1/2 are pure computations — lcm(5,6,7)=210=lcm(14,15) and lcm(4,5,6,7)=420=lcm(20,21), provable by native_decide",
@@ -64,7 +67,11 @@
       "Lower bound: n+k divides M(n,k), so n+k <= M(n,k) for k > 0 — proved as le_lcmInterval",
       "lcmInterval_ne_zero: M(n,k) != 0 for all n,k — base case 1 != 0, inductive step from pos",
       "General bound: lcmInterval(n,k) ≤ consecutiveProduct(n,k) via divisibility; combined with m+k ≤ lcmInterval(m,k) gives contradiction when consecutiveProduct(n,k) < m+k",
-      "For k=3: Thue-Siegel axiom still needed for small m (m+3 ≤ (n+1)(n+2)(n+3))"
+      "For k=3: Thue-Siegel axiom still needed for small m (m+3 ≤ (n+1)(n+2)(n+3))",
+      "lcmInterval 2 3 = lcmInterval 3 3 = 60 (lcm(3,4,5) = lcm(4,5,6)). The conjecture constraint m ≥ n+k exactly excludes this near-miss: for n=2 we need m≥5 ruling out m=3; for n=3 we need m≥6 ruling out m=2. The constraint is therefore tight at k=3.",
+      "k=3 small-n cases (n ∈ {0, 1, 2, 3}) follow a uniform pattern: target value V = lcmInterval n 3, lower bound m+3 ≤ V from le_lcmInterval forces m ≤ V-3, then interval_cases m <;> native_decide. The case count is V-3 minus the start, which grows linearly in V.",
+      "For n ∈ {2, 3}: target V=60 so 53/52 cases; for n=4: V=210 so 201 cases; for n=5 (odd): V = (6*7*8)/2 = 168 so 161 cases; cases grow like (n+1)(n+2)(n+3)/2 which makes pure interval_cases infeasible for n ≥ 4 without a sharper bound.",
+      "Closed-form structure for k=3: lcmInterval n 3 = (n+1)(n+2)(n+3) when n is even (since both odd factors n+1, n+3 are coprime to n+2 and to each other), and = (n+1)(n+2)(n+3)/2 when n is odd (n+1 and n+3 are both even, sharing exactly the factor 2). This would tighten the lower bound and enable n ≥ 4 cases with manageable enumeration."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary

Extends k=3 axiom-free coverage for Erdős #677 from `n ∈ {0, 1}` to `n ∈ {0, 1, 2, 3}`. Thue–Siegel finiteness remains the sole axiom (used only by the general large-m bound's structural form).

## What's New

- **`erdos677_k3_at_two`** (`Erdos677Problem.lean:323`): `M(m, 3) ≠ M(2, 3) = 60` for all `m ≥ 5`. 53 finite cases.
- **`erdos677_k3_at_three`** (`Erdos677Problem.lean:342`): `M(m, 3) ≠ M(3, 3) = 60` for all `m ≥ 6`. 52 finite cases.
- **`lcmInterval_two_three_collision`** (`Erdos677Problem.lean:316`): structural `M(2, 3) = M(3, 3) = 60`. Documents the *near-miss* the constraint `m ≥ n + k` exactly excludes.

## Proof Pattern

```
theorem erdos677_k3_at_two (m : ℕ) (hm : 5 ≤ m) :
    lcmInterval m 3 ≠ lcmInterval 2 3 := by
  intro heq
  have h0 : lcmInterval 2 3 = 60 := by native_decide
  have hge : m + 3 ≤ lcmInterval m 3 := le_lcmInterval m 3 (by omega)
  rw [heq, h0] at hge
  have hm_le : m ≤ 57 := by omega
  interval_cases m <;> revert heq <;> native_decide
```

Same pattern as the existing `erdos677_k3_at_zero`/`_at_one` proofs — only the case range grows (53/52 cases vs the previous 1/6).

## Mathematical Note

`lcmInterval 2 3 = lcm(3, 4, 5) = 60 = lcm(4, 5, 6) = lcmInterval 3 3`. This is the *only* near-miss within `k = 3, n ∈ {0, 1, 2, 3}`, and it is structurally excluded by the `m ≥ n + k` constraint:

- For `n = 2`: `m ≥ 5` rules out `m = 3`.
- For `n = 3`: `m ≥ 6` rules out `m = 2`.

So the conjecture's hypothesis is *tight* at `k = 3`: weakening it to `m > n` would admit `M(3, 3) = M(2, 3)` as a counterexample.

## Why Stop at n = 3

The bound `m + 3 ≤ lcmInterval m 3` combined with `lcmInterval m 3 = lcmInterval n 3 = V` forces `m ≤ V - 3`. The number of `interval_cases` is `(V - 3) − (n + 3) + 1`:

| n | V = lcmInterval n 3 | Cases |
|---|---|---|
| 0 | 6   | 1   |
| 1 | 12  | 6   |
| 2 | 60  | 53  |
| 3 | 60  | 52  |
| 4 | 210 | 201 |
| 5 | 168 | 161 |

`n = 4` approaches the practical ceiling for `interval_cases` + `native_decide`. A sharper lower bound `lcmInterval n 3 ≥ (n+1)(n+2)(n+3) / 2` (via gcd structure of three consecutive integers) is the natural next step.

## Files Modified

- `proofs/Proofs/Erdos677Problem.lean` (+40 LOC, 3 new theorems)
- `src/data/proofs/erdos-677/meta.json` (theoremCount 28 → 31, lineCount 313 → 353)
- `src/data/research/problems/erdos-677.json` (3 builtItems, 4 insights, updated progressSummary)
- `research/problems/erdos-677/state.md` (Phase NEW → ACT, iteration 1 → 2)

## Status

- **Outcome**: progress (axiom-free extension, 0 sorries, 1 axiom unchanged)
- **Build**: Docker build kicked off — PR submitted **build-pending**. Pattern matches existing successful proofs; risk is `interval_cases` of ≈53 cases compilation time.
- **Next**: sharper lower bound to enable n ≥ 4 (see state.md "Next Action").

## Test Plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos677Problem` succeeds
- [ ] CI green
- [ ] Gallery page renders unchanged (no schema changes beyond integer bumps)

🤖 Generated by researcher-8