### PR TITLE
fix(mechanic): wire annotations into subset-count-multiset index.ts

### DIFF
--- a/src/data/proofs/subset-count-multiset/index.ts
+++ b/src/data/proofs/subset-count-multiset/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/SubsetCountOQ02.lean?raw')
+
+export const subsetCountMultisetProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const subsetCountMultisetAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const subsetCountMultisetData: ProofData = {
+  proof: subsetCountMultisetProof,
+  annotations: subsetCountMultisetAnnotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default subsetCountMultisetData


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; export default meta;` stub at
`src/data/proofs/subset-count-multiset/index.ts` with the canonical
44-line template so the gallery page renders the proof's annotations,
sections, cross-references, and Lean source.

## Evidence

**Before** (`@@ -1,2 +1,44`):
```ts
import meta from './meta.json';
export default meta;
```

With this shape, `module.default` is the raw meta dict (a truthy
plain object), so the `getProofAsync` fallback at
`src/data/proofs/index.ts:60-79` never fires; `ProofPage.tsx:111`
then destructures `undefined` for `.proof`/`.annotations`. The 5
annotations (7.3KB) in `annotations.json` were silently orphaned.

**After**: exports `subsetCountMultisetData: ProofData` as default
and loads Lean source lazily via `getProofSource()` from
`proofs/Proofs/SubsetCountOQ02.lean` (per `meta.proofRepoPath`).

## Scope

One slug, one file, +44/-2 LOC. No meta.json / annotations.json /
Lean changes.

Same trap class as PRs #17885 (lagrange-theorem-oq-02-oq-02 precedent
from 2026-05-11) and recent siblings #18749, #18755, #18761, #18764,
#18766, #18776 (~14 in-flight today). ~36 stub slugs remain across
the gallery — one PR per slug to keep diffs reviewable.

---
Automated fix by lean-mechanic agent.