### PR TITLE
fix(mechanic): wire annotations into erdos-1149 index.ts

### DIFF
--- a/src/data/proofs/erdos-1149/index.ts
+++ b/src/data/proofs/erdos-1149/index.ts
@@ -1,4 +1,38 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1149Problem.lean?raw'
 
-export default { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1149Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1149Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const erdos1149TacticStates: TacticState[] = []
+
+export const erdos1149Data: ProofData = {
+  proof: erdos1149Proof,
+  annotations: erdos1149Annotations,
+  tacticStates: erdos1149TacticStates,
+}


### PR DESCRIPTION
## Fix

Replace 2-line broken-default-export stub in `src/data/proofs/erdos-1149/index.ts` with the canonical index.ts shape so the gallery page renders the proof, annotations, and Lean source.

## Evidence

**Before** (2-line stub):

```ts
import meta from "./meta.json";
import annotations from "./annotations.json";

export default { meta, annotations };
```

The loader at `src/data/proofs/index.ts:57` picks `module.default` (= raw `{ meta, annotations }`) as `proofData`. Because it's truthy, the legacy fallback at lines 60-79 (which constructs proper `ProofData` from `module.meta` + `module.annotations`) is skipped. `ProofPage.tsx` then destructures `.proof`, `.annotations`, `.versionInfo` from a dict that has none of them.

**After** (canonical template):

- Imports `metaJson`, `annotationsJson`, and `sourceRaw` from `proofs/Proofs/Erdos1149Problem.lean?raw` (declared as `meta.proofRepoPath`)
- Exports `erdos1149Proof: Proof`, `erdos1149Annotations: Annotation[]`, `erdos1149TacticStates: TacticState[]`, and `erdos1149Data: ProofData`
- 11 annotations / 14.5KB and a 13.6KB Lean source now reach the page

## Scope

- One slug per PR (`erdos-1149`).
- Same defect class as PR #18749, #18754, #18755, #18759, #18761, #18764, #18766, #18769, #18771, #18773, #18774, #18776, #18777, #18780.
- ~22 broken-default-export stubs remain across the gallery (orthogonal future PRs).

## Out of scope

- Meta/axiom/sorry counts (unchanged; `axiomCount: 1`, `sorries: 0`, `status: axiomatized`).
- Aristotle companion file `Erdos1149Aristotle.lean` (unchanged).

---
Automated fix by lean-mechanic agent.