### PR TITLE
research(laws-of-large-numbers-oq-02): S1 OBSERVE — scaffold + audit shows variance_sampleMean is derivable (doc-only)

### DIFF
--- a/research/problems/laws-of-large-numbers-oq-02/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-02/knowledge.md
@@ -1,0 +1,126 @@
+# Knowledge Base: laws-of-large-numbers-oq-02
+
+Insights accumulated during research on this problem.
+Last updated: 2026-05-13 (S1 OBSERVE scaffold + bearer audit by researcher-5).
+
+---
+
+## Problem Understanding
+
+The headline question is *quantitative* WLLN: how fast does `X̄ₙ → μ` happen in probability?
+Three escalating answers:
+
+| Tier | Rate | Cost | Bearer in Mathlib v4.26 |
+|---|---|---|---|
+| Chebyshev | O(1/n) | requires only Var(X) < ∞ | ✓ (already done in `chebyshev_convergence_rate`) |
+| CLT | O(1/√n) in distribution | requires i.i.d. + Var(X) < ∞ | ⚠ characteristic functions present, theorem absent |
+| Berry–Esseen | O(1/√n) uniform sup-norm | requires 𝔼\|X − μ\|³ < ∞ | ✗ no formalization |
+
+The Chebyshev tier is the only one currently provable in-repo end-to-end using Mathlib bearers
+alone (modulo the `variance_sampleMean` audit fix).
+
+---
+
+## What Is Proved (S0 + prior)
+
+Already in `proofs/Proofs/LawsOfLargeNumbersOQ02.lean`:
+
+- `sampleMean_memLp` — sample mean is L² when each summand is L². Uses
+  `MemLp.finset_sum` + `MemLp.const_mul`.
+- `integral_sampleMean` — `𝔼[X̄ₙ] = μ` from linearity of integral + `integral_finset_sum`.
+- `chebyshev_convergence_rate` — quantitative WLLN at rate O(1/n).
+- `chebyshev_rate_is_O_inv_n` — rate ordering.
+- `berry_esseen_rate_involves_sqrt_n` — rate ordering for the (axiomatized) Berry–Esseen
+  statement.
+- `chebyshev_rate_implies_convergence` — bridge to the WLLN convergence-in-probability
+  statement (uses `ProbabilityTheory.tendsto_measure_atTop_of_pos`).
+
+Note: as of #13382 (2026-04-27), the `sampleMean_memLp` axiom was discharged.
+
+---
+
+## Insights
+
+### `variance_sampleMean` is derivable, not bearer-blocked
+
+The axiom `variance_sampleMean` is stated as
+
+```lean
+axiom variance_sampleMean
+    (X : ℕ → Ω → ℝ) (n : ℕ) (hn : 0 < n)
+    (σ_sq : ℝ) (hσ : σ_sq ≥ 0)
+    (h_var : ∀ i, variance (X i) volume = σ_sq)
+    (hℒp : ∀ i, MemLp (X i) 2 volume)
+    (h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume) :
+    variance (sampleMean X n) volume = σ_sq / n
+```
+
+Mathlib v4.26.0 ships the two bearers that close the proof in ~25 LOC of Lean:
+
+- `Mathlib.Probability.Moments.Variance.IndepFun.variance_sum`
+  ```
+  theorem IndepFun.variance_sum {ι : Type*} {X : ι → Ω → ℝ} {s : Finset ι}
+      (hs : ∀ i ∈ s, MemLp (X i) 2 μ)
+      (h : Set.Pairwise ↑s fun i j => X i ⟂ᵢ[μ] X j) :
+      variance (∑ i ∈ s, X i) μ = ∑ i ∈ s, variance (X i) μ
+  ```
+- `Mathlib.Probability.Moments.Variance.variance_smul`
+  ```
+  theorem variance_smul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
+      Var[c • X; μ] = c^2 * Var[X; μ]
+  ```
+
+Combining: `Var(X̄ₙ) = Var((1/n) · ∑ᵢ Xᵢ) = (1/n)² · Var(∑ᵢ Xᵢ) = (1/n)² · n · σ² = σ² / n`.
+
+The only friction is converting the slug's `Pairwise (i j : ℕ)` hypothesis to the
+`Set.Pairwise (↑(Finset.range n))` form Mathlib expects. Recipe in
+`s1-observe-variance-sampleMean-bearer-audit.md`.
+
+### CLT / standardNormalCDF status in Mathlib v4.26
+
+Mathlib has the building blocks but not the assembled CLT:
+
+- `Mathlib.Probability.Distributions.Gaussian.{Basic, Real, Fernique}` — Gaussian measure and
+  density.
+- `Mathlib.MeasureTheory.Measure.CharacteristicFunction` — characteristic functions of
+  measures.
+- `Mathlib.Probability.Independence.CharacteristicFunction` — `IndepFun ↔ char-fn factors`.
+
+But there is **no theorem** of the form
+`tendsto (fun n ↦ μ (Set.Iic (sqrt n · (X̄ₙ − μ) / σ ≤ x))) atTop (𝓝 (Φ x))` in Mathlib v4.26.
+The slug's `standardNormalCDF` axiom is therefore genuinely beyond upstream.
+
+### Berry–Esseen status
+
+No Berry–Esseen theorem exists in Mathlib v4.26 (no constant `berryEsseenConstant`, no error-
+bound theorem). The slug's two axioms in this area are genuinely beyond upstream and require
+either:
+
+1. Smoothing-inequality approach (Esseen's original — requires the `|χ(t) − e^{-t²/2}| / t`
+   estimate); or
+2. Stein's method (more modern; would need new infrastructure for exchangeable pairs).
+
+Both are research-level Lean formalizations (≥1000 LOC estimate).
+
+### Gallery entry absent
+
+`src/data/proofs/laws-of-large-numbers-oq-02/` does not exist. The Lean file is part of the
+build (imported via `proofs/Proofs.lean`) but is not rendered in the gallery. This is an
+enrichment task; flagging here so the next enricher claim picks it up.
+
+---
+
+## Dead Ends
+
+None recorded yet (slug has not had failure-mode attempts).
+
+---
+
+## Cross-references
+
+- `Proofs/LawsOfLargeNumbersOQ01.lean` (and `OQ01OQ01.lean`, `OQ01OQ02.lean`, `OQ01OQ03.lean`)
+  — sibling OQ-01 development.
+- `Proofs/LawsOfLargeNumbers.lean` — parent (WLLN + SLLN baseline).
+- `Mathlib.Probability.StrongLaw` — Mathlib's SLLN.
+- `Mathlib.Probability.Independence.CharacteristicFunction` — likely starting point for a
+  future CLT formalization.

--- a/research/problems/laws-of-large-numbers-oq-02/literature/README.md
+++ b/research/problems/laws-of-large-numbers-oq-02/literature/README.md
@@ -1,0 +1,30 @@
+# Literature for laws-of-large-numbers-oq-02
+
+## Primary sources
+
+- Chebyshev, P.L. (1867). *Des valeurs moyennes.* Journal de mathématiques pures et appliquées (2) **12**, 177–184. — Quantitative WLLN at rate O(1/n).
+- Lindeberg, J.W. (1922). *Eine neue Herleitung des Exponentialgesetzes in der Wahrscheinlichkeitsrechnung.* Mathematische Zeitschrift **15**, 211–225. — Lindeberg's proof of CLT.
+- Berry, A.C. (1941). *The accuracy of the Gaussian approximation to the sum of independent variates.* Trans. AMS **49**, 122–136. — One half of Berry–Esseen.
+- Esseen, C.-G. (1942). *On the Liapunoff limit of error in the theory of probability.* Arkiv för matematik, astronomi och fysik **A28**, 1–19. — Other half.
+- Stein, C. (1972). *A bound for the error in the normal approximation to the distribution of a sum of dependent random variables.* Proc. Sixth Berkeley Symp., Vol. 2, 583–602. — Stein's method (modern Berry–Esseen alternative).
+
+## Mathlib references (pinned SHA `2df2f01...`)
+
+- `Mathlib.Probability.StrongLaw` — SLLN for i.i.d. integrable random variables.
+- `Mathlib.Probability.Moments.Variance` — `IndepFun.variance_sum`, `variance_smul`,
+  `variance_const_mul`. **Load-bearing for discharging `variance_sampleMean`** — see
+  `../s1-observe-variance-sampleMean-bearer-audit.md`.
+- `Mathlib.Probability.Distributions.Gaussian.{Basic,Real,Fernique}` — Gaussian measure.
+- `Mathlib.MeasureTheory.Measure.CharacteristicFunction` — characteristic functions of
+  measures.
+- `Mathlib.Probability.Independence.CharacteristicFunction` — `IndepFun ↔ χ factors`.
+- `Mathlib.Probability.Inequality.Chebyshev` (via `Mathlib.Probability.Moments.Basic`) —
+  Chebyshev's inequality, already used by `chebyshev_convergence_rate`.
+
+## Notes
+
+- A formalization of the CLT would likely follow Lindeberg's swap argument, which
+  matches Mathlib's expected style (it's elementary and avoids characteristic-function
+  inversion).
+- A Berry–Esseen formalization is research-level (no analogous Mathlib formalization
+  exists for any quantitative CLT).

--- a/research/problems/laws-of-large-numbers-oq-02/problem.md
+++ b/research/problems/laws-of-large-numbers-oq-02/problem.md
@@ -1,0 +1,54 @@
+# laws-of-large-numbers-oq-02
+
+## Problem Description
+
+How fast does convergence occur in the Law of Large Numbers?
+
+Three progressively sharper quantitative refinements of the Weak Law of Large Numbers
+(WLLN) are studied:
+
+1. **Chebyshev rate**: P(|X̄ₙ − μ| ≥ ε) ≤ σ² / (n ε²)  — rate O(1/n).
+2. **Central Limit Theorem (CLT)**: √n (X̄ₙ − μ) / σ →ᵈ N(0,1)  — fluctuations scale as 1/√n.
+3. **Berry–Esseen bound**: |P(Sₙ ≤ x) − Φ(x)| ≤ Cρ / (σ³ √n)  — explicit error bound for the
+   CLT approximation, where `ρ = 𝔼|X − μ|³`.
+
+## Metadata
+
+- **Category**: extension (quantitative refinement of the WLLN)
+- **Tractability**: mixed — Chebyshev rate is straightforward from Mathlib; CLT/Berry–Esseen
+  are research-level formalizations.
+- **Source Proof**: laws-of-large-numbers
+- **Selected By**: seeker (date in candidate-pool); scaffold added 2026-05-13 by researcher-5
+  after S1 OBSERVE.
+
+## Related Gallery Proofs
+
+- `laws-of-large-numbers` — parent (Weak/Strong LLN).
+- `laws-of-large-numbers-oq-01-oq-02` — Marcinkiewicz–Zygmund SLLN rate hierarchy (sibling).
+- `laws-of-large-numbers-oq-01-oq-03` — sibling.
+- `laws-of-large-numbers-oq-03`, `laws-of-large-numbers-oq-04` — other siblings.
+
+## Current Lean File
+
+`proofs/Proofs/LawsOfLargeNumbersOQ02.lean` — 338 LOC, 0 sorries, **3 axioms**
+(`variance_sampleMean`, `standardNormalCDF`, `berryEsseenConstant`). Prior PRs:
+
+- #13382 (2026-04-27): "eliminate `sampleMean_memLp` axiom + Mathlib v4.26 fix" — converted
+  one axiom into a theorem.
+- #13415 (2026-04-27): "refresh stale axiom count".
+
+## Gallery Status
+
+**No gallery entry exists**: `src/data/proofs/laws-of-large-numbers-oq-02/` is absent. The
+Lean file is built but ungalleried. Creating the gallery entry is the enricher's domain
+(out of scope for this researcher slug).
+
+## Suggested First Steps
+
+1. Audit Mathlib v4.26.0 for bearers that could discharge any of the three remaining axioms
+   (see `s1-observe-variance-sampleMean-bearer-audit.md` — the `variance_sampleMean` axiom
+   is derivable; CLT/Berry–Esseen are not).
+2. S2 ACT (the obvious next step): replace the `variance_sampleMean` axiom with a theorem
+   proved from `IndepFun.variance_sum` + `variance_smul` (~25 LOC, no new imports).
+3. Long-term: track upstream Mathlib for a CLT theorem statement once characteristic-
+   function infrastructure crystallizes into an applied lemma.

--- a/research/problems/laws-of-large-numbers-oq-02/s1-observe-variance-sampleMean-bearer-audit.md
+++ b/research/problems/laws-of-large-numbers-oq-02/s1-observe-variance-sampleMean-bearer-audit.md
@@ -1,0 +1,197 @@
+# S1 OBSERVE — Mathlib bearer audit for `variance_sampleMean` axiom (researcher-5, 2026-05-13)
+
+**Slug**: `laws-of-large-numbers-oq-02`
+**Phase**: S1 OBSERVE (doc-only audit + Lean recipe; no Lean changes in this PR)
+**Mathlib SHA (pinned)**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0)
+**Lean file**: `proofs/Proofs/LawsOfLargeNumbersOQ02.lean` (338 LOC, 0 sorries, 3 axioms)
+
+## Goal of this OBSERVE
+
+Document that the `variance_sampleMean` axiom at line 114 of
+`LawsOfLargeNumbersOQ02.lean` is **not Mathlib-blocked** and can be discharged in ~25 LOC
+using two existing Mathlib bearers. Distinguish this from the other two axioms in the same
+file (`standardNormalCDF`, `berryEsseenConstant`) which **are** genuinely beyond Mathlib
+v4.26.0 (the CLT and Berry–Esseen theorems have no Mathlib formalization).
+
+## Audit findings (per-axiom)
+
+| Axiom | Line | Status | Mathlib bearer |
+|---|---|---|---|
+| `variance_sampleMean` | 114 | **Derivable** | `IndepFun.variance_sum` + `variance_smul` |
+| `standardNormalCDF : ℝ → ℝ` | 217 | Genuinely beyond | Gaussian *density* exists; no named CDF map |
+| `berryEsseenConstant : ℝ` | 240 | Genuinely beyond | No Berry–Esseen statement in Mathlib |
+
+## The `variance_sampleMean` recipe
+
+### Mathlib bearers (verified at SHA `2df2f01...`)
+
+Both in `Mathlib/Probability/Moments/Variance.lean`:
+
+```lean
+-- Line ~403 of Variance.lean
+nonrec theorem IndepFun.variance_sum {ι : Type*} {X : ι → Ω → ℝ} {s : Finset ι}
+    (hs : ∀ i ∈ s, MemLp (X i) 2 μ)
+    (h : Set.Pairwise ↑s fun i j => X i ⟂ᵢ[μ] X j) :
+    variance (∑ i ∈ s, X i) μ = ∑ i ∈ s, variance (X i) μ
+
+-- Line ~194 of Variance.lean
+theorem variance_smul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
+    Var[c • X; μ] = c^2 * Var[X; μ]
+```
+
+`Var[·; μ]` is notation for `variance · μ`; `⟂ᵢ[μ]` is notation for `IndepFun · · μ`.
+
+### The slug's axiom (verbatim, line 114)
+
+```lean
+axiom variance_sampleMean
+    (X : ℕ → Ω → ℝ) (n : ℕ) (hn : 0 < n)
+    (σ_sq : ℝ) (hσ : σ_sq ≥ 0)
+    (h_var : ∀ i, variance (X i) volume = σ_sq)
+    (hℒp : ∀ i, MemLp (X i) 2 volume)
+    (h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume) :
+    variance (sampleMean X n) volume = σ_sq / n
+```
+
+And `sampleMean` is defined earlier as `sampleMean X n ω = (1 / (n : ℝ)) · ∑ i ∈ Finset.range n, X i ω`.
+
+### Derivation (informal)
+
+```
+Var(X̄ₙ)
+  = Var((1/n) · ∑ᵢ ∈ range n, Xᵢ)                     [defn of sampleMean]
+  = (1/n)² · Var(∑ᵢ ∈ range n, Xᵢ)                    [variance_smul]
+  = (1/n)² · ∑ᵢ ∈ range n, Var(Xᵢ)                     [IndepFun.variance_sum]
+  = (1/n)² · ∑ᵢ ∈ range n, σ²                          [h_var]
+  = (1/n)² · n · σ²                                    [Finset.sum_const + card_range]
+  = σ² / n                                             [arithmetic]
+```
+
+### Lean recipe (~25 LOC, target for S2 ACT)
+
+```lean
+/-- **Variance of the sample mean** (proved from Mathlib v4.26 bearers).
+    Was previously `variance_sampleMean : axiom`; discharged via
+    `IndepFun.variance_sum` + `variance_smul`. -/
+theorem variance_sampleMean
+    (X : ℕ → Ω → ℝ) (n : ℕ) (hn : 0 < n)
+    (σ_sq : ℝ) (hσ : σ_sq ≥ 0)
+    (h_var : ∀ i, variance (X i) volume = σ_sq)
+    (hℒp : ∀ i, MemLp (X i) 2 volume)
+    (h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume) :
+    variance (sampleMean X n) volume = σ_sq / n := by
+  -- 1. Unfold sampleMean = (1/n) · ∑
+  unfold sampleMean
+  -- 2. Pull (1/n) out via variance_smul; result has factor (1/n)²
+  have hsmul : variance (fun ω => (1 / (n : ℝ)) * ∑ i ∈ Finset.range n, X i ω) volume
+      = (1 / (n : ℝ))^2 * variance (fun ω => ∑ i ∈ Finset.range n, X i ω) volume := by
+    -- variance_smul, after rewriting `c * f` as `c • f`
+    simpa [smul_eq_mul] using variance_smul (1 / (n : ℝ))
+      (fun ω => ∑ i ∈ Finset.range n, X i ω) volume
+  -- 3. Apply IndepFun.variance_sum on Finset.range n
+  have hpair :
+      Set.Pairwise ↑(Finset.range n) fun i j => IndepFun (X i) (X j) volume := by
+    intro i hi j hj hij
+    exact h_indep hij
+  have hLp_set : ∀ i ∈ Finset.range n, MemLp (X i) 2 volume :=
+      fun i _ => hℒp i
+  have hvar_sum :
+      variance (fun ω => ∑ i ∈ Finset.range n, X i ω) volume
+      = ∑ i ∈ Finset.range n, variance (X i) volume := by
+    -- Note: ∑ᵢ X i = (∑ᵢ X i) as functions; Mathlib's variance_sum may need
+    -- a `Finset.sum_apply`-style rewrite first.
+    simpa [Finset.sum_apply] using IndepFun.variance_sum hLp_set hpair
+  -- 4. Substitute h_var to get ∑ σ_sq = n · σ_sq
+  rw [hsmul, hvar_sum]
+  simp_rw [h_var]
+  rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+  -- 5. Algebra: (1/n)² · n · σ² = σ² / n
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  field_simp
+  ring
+```
+
+### Subtleties for the S2 ACT author
+
+1. **`Pairwise` (ℕ-indexed) vs `Set.Pairwise` (on `Finset.range n`)**: the slug's
+   `h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume` is over all of `ℕ × ℕ`,
+   which is *strictly stronger* than `Set.Pairwise ↑(Finset.range n) …`. So the converson
+   `hpair` is one direction only: just unpack and apply. The `simpa` in `hvar_sum` will
+   take care of unwrapping `∑ᵢ X i ω` to `(∑ᵢ X i) ω` via `Finset.sum_apply`.
+
+2. **`smul_eq_mul` rewrite**: `variance_smul` is stated with `•`; the slug's `sampleMean`
+   uses `*`. A single `simpa [smul_eq_mul]` bridges them.
+
+3. **`field_simp` + `ring`** are sufficient for the final algebra given `hn0`.
+
+4. **No new imports**: `Mathlib.Probability.Moments.Variance` is already imported via
+   `Mathlib.Probability.Moments.Variance` (the slug already uses
+   `variance (X i) volume`, so the file is transitively in scope).
+
+### Build risk
+
+- **LOC**: ~25 lines.
+- **Tactics**: `unfold`, `simpa`, `simp_rw`, `rw`, `field_simp`, `ring`, `Nat.cast_ne_zero`,
+  `Finset.sum_const`, `Finset.card_range`, `nsmul_eq_mul`. All cheap.
+- **No new typeclasses, no new instances.**
+- **Sorries delta**: 0 → 0.
+- **Axiom delta**: 3 → 2 if S2 ACT succeeds (the axiom becomes a theorem).
+- **Worktree `.lake` symlink loop**: build from main repo cwd via
+  `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ02`. Expected ~5–10 min
+  (heavier dependency footprint than `BinaryGcdOQ01`).
+
+## CLT / Berry–Esseen status (confirmed beyond Mathlib v4.26)
+
+Mathlib's `Mathlib/Probability/` directory at SHA `2df2f01...` contains:
+
+```
+Probability/
+├── Decision/   Distributions/   Independence/   Kernel/
+├── Martingale/   Moments/   ProbabilityMassFunction/   Process/
+├── BorelCantelli.lean   CDF.lean   CondVar.lean   ConditionalExpectation.lean
+├── ConditionalProbability.lean   Density.lean   HasLaw.lean   HasLawExists.lean
+├── IdentDistrib.lean   IdentDistribIndep.lean   Integration.lean
+├── Notation.lean   ProductMeasure.lean   StrongLaw.lean   UniformOn.lean
+```
+
+Notably absent: any file named `CentralLimit*`, `Berry*`, `Esseen*`. The
+`Probability/Independence/CharacteristicFunction.lean` file proves the *equivalence*
+`IndepFun ↔ joint χ = product of χᵢ` but does not extend this to a CLT statement. The
+`Probability/Distributions/Gaussian/` directory exposes the Gaussian *measure* and density,
+not a `standardNormalCDF : ℝ → ℝ` function.
+
+**Conclusion**: the slug's `standardNormalCDF` and `berryEsseenConstant` axioms are
+genuinely beyond Mathlib v4.26 and would require new upstream infrastructure (or a local
+multi-hundred-LOC port) to discharge. They are *legitimately* axiomatized, in contrast to
+`variance_sampleMean`.
+
+## Files this OBSERVE adds
+
+- `research/problems/laws-of-large-numbers-oq-02/problem.md` (NEW; was missing)
+- `research/problems/laws-of-large-numbers-oq-02/state.md` (NEW; was missing)
+- `research/problems/laws-of-large-numbers-oq-02/knowledge.md` (NEW; was missing)
+- `research/problems/laws-of-large-numbers-oq-02/s1-observe-variance-sampleMean-bearer-audit.md`
+  (NEW; this note)
+- `research/problems/laws-of-large-numbers-oq-02/literature/` (NEW empty dir scaffold)
+
+The `research/problems/laws-of-large-numbers-oq-02/` directory **did not exist** before
+this PR — both the Lean file (`LawsOfLargeNumbersOQ02.lean`) and the gallery entry
+(`src/data/proofs/laws-of-large-numbers-oq-02/`, still missing) were managed without the
+usual seeker-init scaffold.
+
+## Out of scope for this OBSERVE
+
+- The actual S2 ACT (replacing the `variance_sampleMean` axiom with a theorem). Recipe
+  given but not implemented — would require Docker build verification.
+- Gallery entry creation (`src/data/proofs/laws-of-large-numbers-oq-02/meta.json` etc.).
+  This is the enricher's domain.
+- The CLT / Berry–Esseen axioms (genuinely beyond Mathlib v4.26).
+
+## Audit-trail notes
+
+- Memory trap `feedback_researcher_mathlib_head_vs_lockfile_sha_drift.md` followed:
+  Mathlib decls verified at lake-pinned SHA `2df2f01...`, not Mathlib HEAD.
+- `gh api search/code` rate limit (30/hr per memory trap
+  `feedback_researcher_4_2026_05_13_dual_prep_audit_and_forward_design_session.md`): NOT
+  invoked in this audit — file structure used `git/trees ?recursive=1` (one request,
+  navigates to all paths) and direct `contents/.../*.lean?ref=` (already known paths).


### PR DESCRIPTION
## Summary

This slug had **no** `research/problems/laws-of-large-numbers-oq-02/` directory at all before this PR, even though `proofs/Proofs/LawsOfLargeNumbersOQ02.lean` (338 LOC, 3 axioms, 0 sorries) has been in the build since 2026-04-27 (PRs #13382, #13415). This PR:

1. **Scaffolds the missing seeker-init directory** with `problem.md`, `state.md`, `knowledge.md`, `literature/README.md`.
2. **Audits the three remaining axioms** at lake-pinned Mathlib v4.26.0 (SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) and documents that one of them — `variance_sampleMean` — is **derivable** from existing Mathlib bearers (incorrectly axiomatized).

## Per-axiom audit findings

| Axiom | Line | Status | Mathlib bearer |
|---|---|---|---|
| `variance_sampleMean` | 114 | **Derivable** | `IndepFun.variance_sum` + `variance_smul` |
| `standardNormalCDF : ℝ → ℝ` | 217 | Genuinely beyond v4.26 | Gaussian *density* present, no named CDF |
| `berryEsseenConstant : ℝ` | 240 | Genuinely beyond v4.26 | No Berry–Esseen statement in Mathlib |

Both bearer-yielding theorems live in `Mathlib/Probability/Moments/Variance.lean`:

```lean
theorem IndepFun.variance_sum {ι : Type*} {X : ι → Ω → ℝ} {s : Finset ι}
    (hs : ∀ i ∈ s, MemLp (X i) 2 μ)
    (h : Set.Pairwise ↑s fun i j => X i ⟂ᵢ[μ] X j) :
    variance (∑ i ∈ s, X i) μ = ∑ i ∈ s, variance (X i) μ

theorem variance_smul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
    Var[c • X; μ] = c^2 * Var[X; μ]
```

## S2 ACT recipe (left as follow-up)

`s1-observe-variance-sampleMean-bearer-audit.md` includes a verbatim ~25 LOC Lean proof
sketch:

```
Var(X̄ₙ) = Var((1/n) · ∑ᵢ Xᵢ)
       = (1/n)² · Var(∑ᵢ Xᵢ)              [variance_smul]
       = (1/n)² · ∑ᵢ Var(Xᵢ)               [IndepFun.variance_sum]
       = (1/n)² · n · σ²                   [h_var, Finset.sum_const, card_range]
       = σ² / n                            [field_simp; ring]
```

A follow-up S2 ACT PR can replace the `axiom` declaration with this `theorem` block.
**Build verification** is required for that ACT and the worktree `.lake` symlink loop
(memory trap `feedback_researcher_lake_symlink_loop_and_wipe.md`) makes worktree Docker
builds unreliable, so the ACT should be run from main repo cwd:
`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ02`.

## CLT / Berry–Esseen status

Confirmed beyond Mathlib v4.26 by directory inspection at the pinned SHA: no
`CentralLimit*` / `Berry*` / `Esseen*` files exist. Mathlib has the building blocks
(`Mathlib.MeasureTheory.Measure.CharacteristicFunction`,
`Mathlib.Probability.Independence.CharacteristicFunction`,
`Mathlib.Probability.Distributions.Gaussian.*`) but no assembled CLT theorem. These two
axioms are *legitimately* axiomatized.

## Scope

**In scope**: `research/problems/laws-of-large-numbers-oq-02/` directory only (5 NEW files).

**Out of scope**:
- The S2 ACT itself (replacing `variance_sampleMean` axiom with theorem). Recipe provided but not implemented.
- Creating the gallery entry `src/data/proofs/laws-of-large-numbers-oq-02/` (still missing — this is the enricher's domain).
- CLT / Berry–Esseen formalization (research-level, multi-hundred-LOC).

## Build risk

Zero. No Lean files touched. Sorries unchanged (**0**). Axiom count unchanged (**3**).

## Test plan

- [ ] CI: doc-only PR, no Lean type-check required.
- [ ] Reader check: a future S2 ACT author can follow `s1-observe-variance-sampleMean-bearer-audit.md` to discharge the `variance_sampleMean` axiom in ~25 LOC without re-running the Mathlib bearer audit.

## Audit-trail notes

- Memory trap `feedback_researcher_mathlib_head_vs_lockfile_sha_drift.md` followed: Mathlib decls verified at lake-pinned SHA `2df2f01...`, not Mathlib HEAD.
- Memory trap `feedback_write_tool_main_repo_absolute_path_trap.md`: all writes via worktree-relative paths.
- `gh api search/code` rate limit (30/hr per memory trap `feedback_researcher_4_2026_05_13_dual_prep_audit_and_forward_design_session.md`): **not consumed** — bearer audit used `gh api git/trees?recursive=1` (one call) plus direct `contents/.../*.lean?ref=` fetches on known paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)