### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-02): S2 COMPLETION-SYNC (doc-only)

### DIFF
--- a/research/problems/descartes-rule-of-signs-oq-01-oq-02/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-02/state.md
@@ -1,25 +1,64 @@
 # Research State: descartes-rule-of-signs-oq-01-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-03-30T11:35:19-07:00
-**Iteration**: 1
+**Since**: 2026-05-13T11:40:00Z
+**Iteration**: 2
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Completed Work
+
+**The OQ**: "What is the minimal infrastructure for Descartes parity — just complex
+conjugate pairing, or also exact sign variation change under each root type?"
+
+**The answer**: **Both are needed.** This is captured in `DescartesRuleOfSignsOQ01OQ02.lean`
+(317 LOC, 13 theorems, 1 axiom, 0 sorries, axiomatized):
+
+1. **Complex conjugate pairing** (proved in sibling `DescartesRuleOfSignsOQ01OQ01.lean`):
+   non-real roots pair, so `Even nonreal`. Gives `degree ≡ real_roots (mod 2)`.
+
+2. **Sign variation parity under root extraction** (axiomatized as
+   `sign_variation_parity_under_positive_root`): when `p = (X - C r) * q` with `r > 0`,
+   `¬Even (signVariations p + signVariations q)`. This is the *irreducible* combinatorial-
+   algebraic ingredient — Mathlib only proves the *inequality* version
+   (`succ_signVariations_le_X_sub_C_mul`), not the parity.
+
+3. **Parity chain** (`parity_chain`, `descartes_parity_witness`): given the four
+   structural ingredients, the existential witness `pos + 2k = sv` follows.
+
+Resolution at small degrees: linear, quadratic, cubic, quartic each instantiate the
+witness via `parity_witness` + bounded `omega`.
 
 ## Active Approach
-None yet.
+
+None — slug answered.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1 (structural infrastructure analysis)
 
 ## Blockers
+
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+None — slug answered. The remaining axiom is the genuine hard part (the parity version
+of Descartes' rule, beyond Mathlib's current inequality version), and stands as a
+documented open lemma rather than a research gap.
+
+If anyone wants to discharge the axiom: requires a coefficient-sign-sequence analysis of
+`(X - C r) * q` — see Mathlib's `Polynomial.RuleOfSigns` for the inequality version and
+extend the induction with a parity refinement. Estimated 200–500 LOC.
+
+## Follow-up Open Question Candidate
+
+`oq-01-oq-02-oq-01` (candidate): Can `sign_variation_parity_under_positive_root` be
+discharged by extending Mathlib's `succ_signVariations_le_X_sub_C_mul` induction with a
+parity refinement? Specifically, can `signVariations_eq_eraseLead_add_ite` be lifted to
+give exact `signVariations(p) = signVariations(q) + 2k + 1`?
+
+This is a concrete forward step rather than a vague generalization — and a natural one,
+since Mathlib's current proof gets `≥ signVariations(q) + 1` and the parity version
+would refine the inequality.

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
@@ -29,17 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formal infrastructure analysis. Both conjugate pairing and sign variation analysis needed.",
+    "progressSummary": "COMPLETED: OQ answered. Minimal infrastructure for Descartes parity requires BOTH complex conjugate pairing (degree ≡ real_roots mod 2) AND sign variation parity under root extraction (the hard combinatorial-algebraic ingredient, axiomatized as sign_variation_parity_under_positive_root). 317 LOC, 13 theorems, 1 axiom, 0 sorries. Mathlib provides the inequality version only (succ_signVariations_le_X_sub_C_mul); the parity version is the remaining axiom.",
     "builtItems": [
-      "proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean (271 lines, 1 axiom, 0 sorries, 10 theorems)",
-      "src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/ (gallery entry)"
+      "proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean (317 lines, 1 axiom, 0 sorries, 13 theorems)",
+      "src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/ (gallery entry, axiomatized)",
+      "Structural answer: minimal infrastructure = conjugate pairing + sign variation parity under root extraction"
     ],
     "insights": [
       "Conjugate pairing alone is NOT sufficient for Descartes parity",
       "Minimal infrastructure: conjugate pairs + sign variation parity under root extraction",
       "The gap: conjugate pairing gives degree=real_roots (mod 2), but parity needs sv=pos_roots (mod 2)",
       "The irreducible hard part: how multiplication by (X - C r) transforms coefficient sign sequences",
-      "Parity chain theorem composes all three ingredients"
+      "Parity chain theorem composes all three ingredients",
+      "Mathlib v4.26.0 has Polynomial.RuleOfSigns with succ_signVariations_le_X_sub_C_mul: multiplying by (X - C η) with η > 0 increases signVariations by at least 1. The PARITY refinement (exact = signVariations(q) + 2k + 1) is missing from Mathlib and would be the natural follow-up.",
+      "Forward path to discharge the axiom: extend Mathlib induction with parity tracking via signVariations_eq_eraseLead_add_ite. Estimated 200-500 LOC; would constitute the full Descartes Rule of Signs parity version, beyond Mathlib current inequality version."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Doc-only sync. The OQ (*"what is the minimal infrastructure for Descartes parity"*) was answered in the prior session: **both** complex conjugate pairing **and** sign variation parity under root extraction are needed. The Lean file (`DescartesRuleOfSignsOQ01OQ02.lean`, 317 LOC, 13 theorems, **1 axiom, 0 sorries**) captures the structural answer with the irreducible hard part isolated as a single named axiom.

However `state.md` was still the seeker-init stub (`Phase: OBSERVE`, `Iteration: 1`, dated 2026-03-30), and the knowledge JSON `progressSummary` — though prefixed `COMPLETED:` — didn't document the Mathlib-bearer audit.

## Changes (doc-only)

- **`state.md`**: `Phase: OBSERVE → COMPLETED`, document completed work, surface the remaining axiom as a *documented hard lemma* rather than a research gap.
- **`knowledge.progressSummary`**: clarified to reference Mathlib's inequality version (`succ_signVariations_le_X_sub_C_mul`) vs the missing parity refinement.
- **`knowledge.insights`** (+2): Mathlib bearer audit (`RuleOfSigns.lean` `succ_signVariations_le_X_sub_C_mul` + `signVariations_eq_eraseLead_add_ite`); concrete forward path to discharge the axiom (~200-500 LOC parity refinement of Mathlib's inequality induction).
- **`knowledge.builtItems`**: rewrote to 3 canonical entries reflecting actual file state (was: 2 outdated entries).

## What is **not** changed

- No Lean file edits.
- No `src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json` edits. Meta is already in sync: `status: axiomatized`, `badge: axiom`, `sorries: 0`, `axiomCount: 1`, `theoremCount: 13`, `lineCount: 317`.

## Mathematical note

The remaining axiom `sign_variation_parity_under_positive_root` is the genuine **parity** version of Descartes' Rule of Signs, beyond Mathlib's current **inequality** version (`Polynomial.roots_countP_pos_le_signVariations`). Discharging it would be substantial (~200-500 LOC: extending Mathlib's induction via `signVariations_eq_eraseLead_add_ite` with parity tracking) and is captured as a candidate follow-up OQ in `state.md`, not as a blocker for this slug's answer.

## Status

- **Outcome**: completion-sync (doc-only; slug now correctly reflects completed status across all three loci: meta.json, knowledge JSON, state.md)
- **Build**: not needed — no Lean changes
- **Next**: pool-sync (`update completed` + `release`) handled at session end

## Test Plan

- [ ] CI green (no build needed; data-only changes)
- [ ] Gallery page unchanged (no schema modifications)

🤖 Generated by researcher-8