### PR TITLE
fix(mechanic): wire annotations into erdos-1150 index.ts

### DIFF
--- a/src/data/proofs/erdos-1150/index.ts
+++ b/src/data/proofs/erdos-1150/index.ts
@@ -1,4 +1,38 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1150Problem.lean?raw'
 
-export default { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1150Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1150Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const erdos1150TacticStates: TacticState[] = []
+
+export const erdos1150Data: ProofData = {
+  proof: erdos1150Proof,
+  annotations: erdos1150Annotations,
+  tacticStates: erdos1150TacticStates,
+}


### PR DESCRIPTION
## Fix

The `src/data/proofs/erdos-1150/index.ts` stub `import meta; import annotations; export default { meta, annotations };` leaves `module.default` truthy-but-malformed. `getProofAsync` at `src/data/proofs/index.ts:48-99` picks the malformed default and never reaches the legacy `{ meta, annotations }` fallback (lines 60-79). Result: `proofData?.proof` is undefined on the gallery page despite a 14,733-byte `annotations.json` (13 theorems, axiomCount 3, 0 sorries) sitting next to it.

## Evidence

**Before** (3 LOC, malformed default):
```ts
import meta from "./meta.json";
import annotations from "./annotations.json";

export default { meta, annotations };
```

**After** (38 LOC, canonical loader template — matches the erdos-1149, konigsberg-oq-03-oq-02, triangle-angle-sum-oq-01 mechanic fixes):
- Typed `metaJson as unknown as { id, title, slug, description, meta, sections, overview?, conclusion?, crossReferences? }` cast
- `sourceRaw` import from `proofs/Proofs/Erdos1150Problem.lean?raw` (17,127-byte Lean source rendered in the source viewer)
- camelCase `erdos1150Proof`, `erdos1150Annotations: Annotation[]`, `erdos1150TacticStates: TacticState[] = []`, `erdos1150Data: ProofData` exports (matches `slugToExportName('erdos-1150')` at `index.ts:38-42`)

Single-file diff, no other gallery slugs touched. One PR per stub (one of ~52 remaining in this class).

## Scope

In scope: rewire `erdos-1150` loader so existing annotations.json + Lean source render.

Out of scope: re-enriching the Lean proof (already at axiomCount 3 with 0 sorries — PRs #5555, #5699, #7389, #11855, #14748 reconciled axioms and metadata); other stub slugs (each in its own PR).

---
Automated fix by lean-mechanic agent.