### PR TITLE
fix(mechanic): wire annotations into erdos-1150 index.ts

### DIFF
--- a/src/data/proofs/erdos-1150/index.ts
+++ b/src/data/proofs/erdos-1150/index.ts
@@ -1,4 +1,38 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1150Problem.lean?raw'
 
-export default { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1150Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1150Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const erdos1150TacticStates: TacticState[] = []
+
+export const erdos1150Data: ProofData = {
+  proof: erdos1150Proof,
+  annotations: erdos1150Annotations,
+  tacticStates: erdos1150TacticStates,
+}


### PR DESCRIPTION
## Fix

Replace 2-line broken-default-export stub in `src/data/proofs/erdos-1150/index.ts` with the canonical index.ts shape so the gallery page renders the proof, annotations, and Lean source.

## Evidence

**Before** (2-line stub):

```ts
import meta from "./meta.json";
import annotations from "./annotations.json";

export default { meta, annotations };
```

The loader at `src/data/proofs/index.ts:57` picks `module.default` (= raw `{ meta, annotations }`) as `proofData`. Because it's truthy, the legacy fallback at lines 60-79 (which constructs proper `ProofData` from `module.meta` + `module.annotations`) is skipped. `ProofPage.tsx` then destructures `.proof`, `.annotations`, `.versionInfo` from a dict that has none of them.

**After** (canonical template):

- Imports `metaJson`, `annotationsJson`, and `sourceRaw` from `proofs/Proofs/Erdos1150Problem.lean?raw` (declared as `meta.proofRepoPath`)
- Exports `erdos1150Proof: Proof`, `erdos1150Annotations: Annotation[]`, `erdos1150TacticStates: TacticState[]`, and `erdos1150Data: ProofData`
- 13 annotations / 14.7KB and a 17KB Lean source now reach the page

## Scope

- One slug per PR (`erdos-1150`).
- Same defect class as PR #18749, #18754, #18755, #18759, #18761, #18764, #18766, #18769, #18771, #18773, #18774, #18776, #18777, #18780, #18787.
- ~22 broken-default-export stubs remain across the gallery (orthogonal future PRs).

## Out of scope

- Meta/axiom/sorry counts (unchanged; `axiomCount: 3`, `sorries: 0`, `status: axiomatized`).
- Aristotle companion file (none present).

---
Automated fix by lean-mechanic agent.