### PR TITLE
fix(mechanic): wire annotations into angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 index.ts

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/index.ts
@@ -1,1 +1,44 @@
-export { default } from './meta.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean?raw')
+
+export const angleTrisectionCos20GalOq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionCos20GalOq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionCos20GalOq01Oq02Oq02Data: ProofData = {
+  proof: angleTrisectionCos20GalOq01Oq02Oq02Proof,
+  annotations: angleTrisectionCos20GalOq01Oq02Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default angleTrisectionCos20GalOq01Oq02Oq02Data


### PR DESCRIPTION
## Summary

Replaces the 1-line `index.ts` stub with the canonical 44-line template so the gallery page actually renders. Same orthogonal class as PR #18790 (bezout-identity-oq-03-oq-03), #18774 (cantor-diagonalization), #18749 (triangle-angle-sum-oq-01), and precedent #17885 (lagrange-theorem-oq-02-oq-02).

## Bug

`src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/index.ts` shipped as a single-line stub:

```ts
export { default } from './meta.json'
```

`module.default` is the truthy raw meta dict, so the `getProofAsync` fallback at `src/data/proofs/index.ts:60-79` never runs and `ProofPage.tsx:111` destructures undefined for `.proof` / `.annotations`. The 9.8KB `annotations.json` and the verified Galois-formula write-up (general φ(2n)/2 via IsCyclotomicExtension, 0 sorries, 0 axioms) never render despite being present on disk.

## Fix

44-line canonical template:

- `import metaJson from './meta.json'`
- `import annotationsJson from './annotations.json'`
- Hardcoded raw-import `'../../../../proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean?raw'`
- camelCase exports: `angleTrisectionCos20GalOq01Oq02Oq02Proof`, `…Annotations`, `…Data`, `getProofSource`, default = `…Data`.

## Scope

Out of scope (~22 sibling stubs remain across the gallery — `erdos-1059-*` series, `divisibility-truncation-general*`, `bezout-identity-oq-02-oq-01-oq-02-oq-02`, `konigsberg-oq-03-oq-02`, etc.). One per PR (each needs unique camelCase + Lean basename).

## Test plan

- [ ] CI typecheck passes (no other files touched)
- [ ] `pnpm build` produces a non-stub gallery page for this slug
- [ ] `getProofSource()` returns the Lean source string

🤖 Generated with [Claude Code](https://claude.com/claude-code)