### PR TITLE
fix(mechanic): wire annotations into divisibility-truncation-general index.ts

### DIFF
--- a/src/data/proofs/divisibility-truncation-general/index.ts
+++ b/src/data/proofs/divisibility-truncation-general/index.ts
@@ -1,2 +1,44 @@
-export { default as meta } from './meta.json'
-export { default as annotations } from './annotations.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/DivisibilityTruncationGeneral.lean?raw')
+
+export const divisibilityTruncationGeneralProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const divisibilityTruncationGeneralAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const divisibilityTruncationGeneralData: ProofData = {
+  proof: divisibilityTruncationGeneralProof,
+  annotations: divisibilityTruncationGeneralAnnotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default divisibilityTruncationGeneralData


### PR DESCRIPTION
## Fix

`src/data/proofs/divisibility-truncation-general/index.ts` was a 2-line stub:

```ts
export { default as meta } from './meta.json'
export { default as annotations } from './annotations.json'
```

That pattern exports the raw meta JSON as `module.default`, so `getProofAsync` at `src/data/proofs/index.ts:57` picks it up as `proofData`. The resulting object has top-level `id/title/slug/...` but no `.proof`, `.annotations`, or `getProofSource`, so `ProofPage.tsx:111` destructures `undefined` and the page renders without annotations, overview, conclusion, cross-references, or Lean source — despite 10.5KB of real annotations already present in `annotations.json`.

## Evidence

**Before**: `module.default = metaJson` (raw dict, missing `.proof`/`.annotations`/`getProofSource`) — gallery page silently broken.

**After**: `module.default = divisibilityTruncationGeneralData` (canonical `ProofData` shape), `getProofSource()` lazy-imports `proofs/Proofs/DivisibilityTruncationGeneral.lean?raw`. Mirrors PR #18749 (triangle-angle-sum-oq-01), PR #18755 (konigsberg-oq-03-oq-02), PR #18790 (bezout-identity-oq-03-oq-03), etc.

## Scope

One slug, one file. No edits to `meta.json`, `annotations.json`, or the Lean source. Lean file `proofs/Proofs/DivisibilityTruncationGeneral.lean` (10.2KB) already exists and is unaffected.

**Out of scope (separate PRs)**: ~9 other gallery slugs still ship the 2-line stub (`bezout-identity-oq-02-oq-01-oq-02-oq-02`, `erdos-1059-oq-01..05`, `divisibility-truncation-general-oq-01`, `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`). Each needs unique camelCase + Lean basename; bundling risks naming conflicts.

---
Automated fix by lean-mechanic agent.