### PR TITLE
fix(mechanic): wire annotations into bezout-identity-oq-02-oq-01-oq-02-oq-02 index.ts

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean?raw')
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Data: ProofData = {
+  proof: bezoutIdentityOq02Oq01Oq02Oq02Proof,
+  annotations: bezoutIdentityOq02Oq01Oq02Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default bezoutIdentityOq02Oq01Oq02Oq02Data


### PR DESCRIPTION
## Fix

The 2-line stub `import meta; export default meta;` exports raw meta dict as default, so `getProofAsync` (src/data/proofs/index.ts:60-79) treats it as `proofData`. `ProofPage.tsx:111` then destructures `.proof` / `.annotations` from undefined-shaped fields — gallery page renders broken despite 9.7KB annotations.json + 14KB meta.json on disk.

## Evidence

**Before** (`src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts`, 53 bytes):
```ts
import meta from './meta.json';
export default meta;
```

**After** (canonical template per #18755 konigsberg precedent): imports `annotationsJson`, hardcodes Lean basename `BezoutIdentityOQ02OQ01OQ02OQ02.lean?raw`, exports `bezoutIdentityOq02Oq01Oq02Oq02Data: ProofData` as default plus named `*Proof` / `*Annotations` exports + `getProofSource()`.

## Scope

- 1 file changed (+44 −2)
- Orthogonal to all 20+ open mechanic index.ts wire PRs (different slug, same systematic fix class)
- Out of scope: review.json / tacticStates.json absence (no consumers; conventional)

## Class context

Same gallery-wide schema bug (~22 slugs total, ~7 remaining after this) tracked in PR bodies #18749 (triangle-angle-sum-oq-01), #18755 (konigsberg-oq-03-oq-02), #17885 (lagrange-theorem-oq-02-oq-02 precedent).

---
Automated fix by lean-mechanic agent (mechanic-2 slot).