### PR TITLE
fix(mechanic): wire annotations into bezout-identity-oq-02-oq-01-oq-02-oq-02 index.ts

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean?raw')
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOq02Oq01Oq02Oq02Data: ProofData = {
+  proof: bezoutIdentityOq02Oq01Oq02Oq02Proof,
+  annotations: bezoutIdentityOq02Oq01Oq02Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default bezoutIdentityOq02Oq01Oq02Oq02Data


### PR DESCRIPTION
## Fix

Replace 2-line `import meta; export default meta;` stub at
`src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/index.ts` with the
canonical 44-line template so the slug's 6 annotations and 13 theorems
render in the gallery.

## Evidence

**Before** (current main, 2 lines):
```ts
import meta from './meta.json';
export default meta;
```
`getProofAsync` (src/data/proofs/index.ts:48-79) reads `module.default` as
the raw meta-json dict — has `.id`, `.title`, `.sections`, but NO `.proof`
or `.annotations` keys. The legacy fallback at line 61 (`!proofData &&
module.meta`) never fires because `proofData` was already truthy. The
`ProofPage` component then destructures `proofData.proof` as undefined and
renders blank.

**After** (44 lines): typed `metaJson` cast + dynamic Lean source loader
from `proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean?raw` + camelCase
`bezoutIdentityOq02Oq01Oq02Oq02{Proof,Annotations,Data}` exports +
`getProofSource()` async hook. `module.default = bezoutIdentityOq02Oq01Oq02Oq02Data`
which is a real `ProofData` with `.proof` and `.annotations`.

## Annotation content this unhides

- 6 annotations, 9.7 KB (Gaussian Integers: Euclidean Domain and Prime Classification)
- 14 theorems in `proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean` (193 LOC, 0 sorries, 0 axioms — status `verified`)
- 5 sections (norm definition, Euclidean domain structure, prime classification)

## Scope

One-file edit on a single gallery slug. Orthogonal to in-flight sibling
mechanic PRs (#18790 bezout-identity-oq-03-oq-03, #18769 bezout-identity-oq-03-oq-04-oq-01).

Matches canonical template established by PR #18749 (triangle-angle-sum-oq-01)
and #17885 (lagrange-theorem-oq-02-oq-02).

## Out of scope (separate PR per slug)

Remaining 2-line stubs that still ship the same bug: `erdos-1059-oq-{01..05,02-oq-01}`,
`amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`. `divisibility-truncation-general*`
is currently held by mechanic-3.

---
Automated fix by lean-mechanic agent (mechanic-1).