### PR TITLE
research(laws-of-large-numbers-oq-02): S2 ACT — discharge variance_sampleMean axiom to theorem (build-pending)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ02.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ02.lean
@@ -72,11 +72,11 @@ noncomputable def sampleMean (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) : ℝ 
 
 This requires:
 - Variance of a sum of independent RVs = sum of variances (Mathlib: IndepFun.variance_sum)
-- Variance scales as c²·Var (Mathlib: variance_smul)
+- Variance scales as c²·Var (Mathlib: variance_const_mul)
 - sampleMean is in L² (follows from X being in L²)
 
-The measure-theoretic bookkeeping for these steps is substantial in Lean,
-so we axiomatize the result and its prerequisites.
+Both bearers are present in Mathlib v4.26
+(`Mathlib.Probability.Moments.Variance`), so we discharge the result as a theorem.
 -/
 
 /-- The sample mean of L² random variables is in L².
@@ -108,16 +108,33 @@ theorem integral_sampleMean
 
 /-- **Variance of the sample mean**: Var(X̄ₙ) = σ²/n.
 
-    Proof sketch:
-    1. Var(∑ᵢ Xᵢ) = ∑ᵢ Var(Xᵢ) = nσ²  (independence)
-    2. Var(X̄ₙ) = Var((1/n)·∑ Xᵢ) = (1/n²)·nσ² = σ²/n  (scaling) -/
-axiom variance_sampleMean
+    Proof:
+    1. Var(∑ᵢ Xᵢ) = ∑ᵢ Var(Xᵢ) = nσ²  (independence, via `IndepFun.variance_sum`)
+    2. Var(X̄ₙ) = Var((1/n)·∑ Xᵢ) = (1/n²)·nσ² = σ²/n  (scaling, via `variance_const_mul`)
+
+    Previously axiomatized. S2 ACT 2026-05-13 discharges via Mathlib v4.26 bearers
+    `variance_const_mul` + `IndepFun.variance_sum`. -/
+theorem variance_sampleMean
     (X : ℕ → Ω → ℝ) (n : ℕ) (hn : 0 < n)
     (σ_sq : ℝ) (hσ : σ_sq ≥ 0)
     (h_var : ∀ i, variance (X i) volume = σ_sq)
     (hℒp : ∀ i, MemLp (X i) 2 volume)
     (h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume) :
-    variance (sampleMean X n) volume = σ_sq / n
+    variance (sampleMean X n) volume = σ_sq / n := by
+  have hpair : Set.Pairwise ↑(Finset.range n) fun i j => IndepFun (X i) (X j) volume :=
+    fun i _ j _ hij => h_indep hij
+  have hLp_set : ∀ i ∈ Finset.range n, MemLp (X i) 2 volume := fun i _ => hℒp i
+  have hvar_sum :
+      variance (fun ω => ∑ i ∈ Finset.range n, X i ω) volume
+        = ∑ i ∈ Finset.range n, variance (X i) volume := by
+    simpa [Finset.sum_apply] using IndepFun.variance_sum hLp_set hpair
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  unfold sampleMean
+  rw [variance_const_mul, hvar_sum]
+  simp_rw [h_var]
+  rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+  field_simp
+  ring
 
 -- ============================================================
 -- SECTION 3: The Chebyshev Convergence Rate
@@ -315,22 +332,23 @@ theorem chebyshev_rate_implies_convergence
 -- SECTION 9: Summary Statistics
 -- ============================================================
 
-/-- Axiom count summary:
-    - 1 technical axiom (variance_sampleMean — independence of variance sum)
-    - 1 axiom for standardNormalCDF (CLT statement scaffolding)
-    - 1 axiom for CLT statement (genuinely beyond Mathlib v4.26)
-    - 1 axiom for berryEsseenConstant (Berry-Esseen scaffolding)
-    Total: 3 axioms, 0 sorries
+/-- Axiom count summary (post-S2 ACT 2026-05-13):
+    - 1 axiom for standardNormalCDF (CLT statement scaffolding; genuinely beyond Mathlib v4.26)
+    - 1 axiom for berryEsseenConstant (Berry-Esseen scaffolding; genuinely beyond Mathlib v4.26)
+    Total: 2 axioms, 0 sorries
 
-    The remaining technical axiom (variance_sampleMean) encodes
-    Var(∑Xᵢ) = ∑Var(Xᵢ) under independence + scaling. Provable from Mathlib's
-    `IndepFun.variance_sum` + `variance_smul` but requires further L²
-    bookkeeping (variance of a sum + variance under linear scaling).
+    The `variance_sampleMean` axiom was discharged to a theorem via Mathlib's
+    `variance_const_mul` + `IndepFun.variance_sum` (S2 ACT 2026-05-13). The remaining
+    axioms (`standardNormalCDF`, `berryEsseenConstant`) encode the CLT and Berry-Esseen
+    constants — these are genuinely beyond Mathlib v4.26 (no `standardNormalCDF : ℝ → ℝ`
+    map and no Berry-Esseen theorem statement exist; Mathlib has Gaussian density and
+    characteristic functions but not the CLT itself).
 
     Proved in this file:
     - integral_sampleMean: linearity of expectation (integral_mul_left + integral_finset_sum)
     - sampleMean_memLp: L² closure via memLp_finset_sum + MemLp.const_mul
-    - chebyshev_convergence_rate: from Chebyshev inequality + variance/integral axioms
+    - variance_sampleMean: Var(X̄ₙ) = σ²/n (S2 ACT 2026-05-13; was axiom)
+    - chebyshev_convergence_rate: from Chebyshev inequality + variance_sampleMean
     - chebyshev_rate_implies_convergence: limit argument (tendsto_const_div + ofReal continuity)
     - chebyshevBound_nonneg, chebyshevBound_antitone: bound properties
     - chebyshev_rate_is_O_inv_n, berry_esseen_rate_involves_sqrt_n: rate computations -/

--- a/research/problems/laws-of-large-numbers-oq-02/state.md
+++ b/research/problems/laws-of-large-numbers-oq-02/state.md
@@ -1,0 +1,83 @@
+# Research State: laws-of-large-numbers-oq-02
+
+## Current State
+**Phase**: S2 ACT — discharge `variance_sampleMean` axiom to theorem
+**Path**: full
+**Since**: 2026-05-13 (S2 ACT by researcher-5; S1 OBSERVE by researcher-5 PR #18789; prior PRs #13382, #13415 2026-04-27)
+**Iteration**: 2
+**Build status**: build-pending (Docker `.lake` symlink loop in worktree, see Blockers).
+  Expected: 2 axioms (`standardNormalCDF`, `berryEsseenConstant`), 0 sorries, after S2 ACT lands.
+
+## What Has Been Proved
+
+Per `proofs/Proofs/LawsOfLargeNumbersOQ02.lean` (now ~355 LOC, was 338):
+
+- `sampleMean_memLp` — sample mean is in L² (theorem, discharged in #13382).
+- `integral_sampleMean` — `𝔼[X̄ₙ] = μ` when each `Xᵢ` has mean μ.
+- **`variance_sampleMean`** — `Var(X̄ₙ) = σ²/n` (**S2 ACT 2026-05-13**: was axiom, now
+  theorem; proved from `variance_const_mul` + `IndepFun.variance_sum`).
+- `chebyshev_convergence_rate` — `P(|X̄ₙ − μ| ≥ ε) ≤ σ² / (n ε²)` (derived from
+  Mathlib's Chebyshev inequality + (now proven) `variance_sampleMean`).
+- `chebyshevBound_nonneg`, `chebyshevBound_antitone` — basic monotonicity of the bound.
+- `chebyshev_rate_is_O_inv_n`, `berry_esseen_rate_involves_sqrt_n` — rate-ordering facts.
+- `chebyshev_rate_implies_convergence` — bridge to the WLLN convergence statement.
+
+## Remaining Axioms (post-S2 ACT)
+
+1. `standardNormalCDF : ℝ → ℝ` (was line 217): genuinely beyond Mathlib v4.26 — Mathlib
+   has Gaussian density and characteristic functions but no `Φ` function exposed as a
+   named scalar map from ℝ to ℝ with the standard normal interpretation.
+2. `berryEsseenConstant : ℝ` (was line 240): genuinely beyond Mathlib v4.26 — no
+   Berry–Esseen theorem statement exists in Mathlib. Mathlib does have characteristic
+   functions (`Mathlib.MeasureTheory.Measure.CharacteristicFunction`), but the CLT itself
+   has not been formalized.
+
+## Active Approach (S2 ACT)
+
+Per the S1 OBSERVE audit (`s1-observe-variance-sampleMean-bearer-audit.md`), the
+discharge of `variance_sampleMean` uses:
+
+- `variance_const_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) : variance (fun ω => c * X ω) μ = c ^ 2 * variance X μ`
+  (line 183 of `Mathlib/Probability/Moments/Variance.lean` at pinned SHA
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+- `IndepFun.variance_sum {X : ι → Ω → ℝ} {s : Finset ι} (hs : ∀ i ∈ s, MemLp (X i) 2 μ)
+  (h : Set.Pairwise ↑s fun i j => X i ⟂ᵢ[μ] X j) : variance (∑ i ∈ s, X i) μ =
+  ∑ i ∈ s, variance (X i) μ`
+  (line 403)
+
+The S2 ACT proof is ~22 LOC (5 `have`-lemmas + 5 rewrite/simp lines + `field_simp` +
+`ring`). Net diff: +37/−19 LOC including docstring updates and the SECTION 9 summary.
+
+## Attempt Count
+
+- Total attempts (S0 + #13382 + #13415 + S1 OBSERVE + S2 ACT): 5
+- Current approach attempts: 1 (S2 ACT, build pending)
+- Approaches tried: initial axiomatization (S0), `sampleMean_memLp` discharge (#13382),
+  axiom-count sync (#13415), Mathlib bearer audit (S1 PR #18789), `variance_sampleMean`
+  discharge (S2 ACT, this PR).
+
+## Blockers
+
+- Worktree `.lake` symlink loop confirmed: both
+  `proofs/.lake → /Users/rwalters/GitHub/lean-genius/proofs/.lake` (self-referential).
+  Direct Docker build from worktree CWD fails. Mitigation per memory trap
+  `feedback_researcher_lake_symlink_loop_and_wipe.md`: commit + push first, ship
+  build-pending PR, let doctor verify from clean worktree.
+- Two remaining axioms (CLT and Berry–Esseen) are upstream-blocked and out of scope.
+
+## Next Action
+
+- **Doctor or auditor**: verify the S2 ACT build from a clean worktree (no symlink
+  loop). Expected ~5–10 min for `Proofs.LawsOfLargeNumbersOQ02` (probabilistic deps).
+- **If build fails**: most-likely failure points (in order of likelihood) are:
+  1. `rw [variance_const_mul]` may need `simp only [variance_const_mul]` or
+     `simpa [variance_const_mul]` if `unfold sampleMean` exposes a slightly different
+     form (`1 / ↑n` vs `(1 : ℝ) / ↑n`).
+  2. The `simpa [Finset.sum_apply]` rewrite of `IndepFun.variance_sum` to the
+     pointwise-lambda form may need additional simp hints.
+  3. The final `field_simp` + `ring` may need `hn0` passed explicitly.
+- **Out of scope for the researcher role**: create the gallery entry
+  `src/data/proofs/laws-of-large-numbers-oq-02/{meta,annotations,index}.{json,ts}` —
+  this is the enricher's domain. Note this in handoff to enrichment-tracker if/when
+  claimed.
+- Long-term: track upstream Mathlib for `centralLimitTheorem` / `berryEsseen` statements.


### PR DESCRIPTION
## Summary

S2 ACT following [S1 OBSERVE PR #18789](https://github.com/rjwalters/lean-genius/pull/18789). Replaces the `variance_sampleMean` axiom in `proofs/Proofs/LawsOfLargeNumbersOQ02.lean` with a theorem proved from Mathlib v4.26 bearers `variance_const_mul` + `IndepFun.variance_sum`.

- **Axiom delta**: 3 → 2 (drops `variance_sampleMean`; `standardNormalCDF` + `berryEsseenConstant` remain — genuinely beyond Mathlib v4.26 per S1 audit)
- **Sorries delta**: 0 → 0
- **Diff**: -19 / +37 LOC in `LawsOfLargeNumbersOQ02.lean` + new `research/problems/laws-of-large-numbers-oq-02/state.md`

## Proof shape

```lean
theorem variance_sampleMean
    (X : ℕ → Ω → ℝ) (n : ℕ) (hn : 0 < n)
    (σ_sq : ℝ) (hσ : σ_sq ≥ 0)
    (h_var : ∀ i, variance (X i) volume = σ_sq)
    (hℒp : ∀ i, MemLp (X i) 2 volume)
    (h_indep : Pairwise fun i j => IndepFun (X i) (X j) volume) :
    variance (sampleMean X n) volume = σ_sq / n := by
  have hpair : Set.Pairwise ↑(Finset.range n) fun i j => IndepFun (X i) (X j) volume :=
    fun i _ j _ hij => h_indep hij
  have hLp_set : ∀ i ∈ Finset.range n, MemLp (X i) 2 volume := fun i _ => hℒp i
  have hvar_sum :
      variance (fun ω => ∑ i ∈ Finset.range n, X i ω) volume
        = ∑ i ∈ Finset.range n, variance (X i) volume := by
    simpa [Finset.sum_apply] using IndepFun.variance_sum hLp_set hpair
  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
  unfold sampleMean
  rw [variance_const_mul, hvar_sum]
  simp_rw [h_var]
  rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
  field_simp
  ring
```

## Mathlib bearer audit

Both bearers verified at **lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`** (per memory trap `feedback_researcher_mathlib_head_vs_lockfile_sha_drift.md` — not Mathlib HEAD):

- `variance_const_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) : variance (fun ω => c * X ω) μ = c ^ 2 * variance X μ` — line 183 of `Mathlib/Probability/Moments/Variance.lean`
- `IndepFun.variance_sum {X : ι → Ω → ℝ} {s : Finset ι} (hs : ∀ i ∈ s, MemLp (X i) 2 μ) (h : Set.Pairwise ↑s (X i ⟂ᵢ[μ] X j)) : variance (∑ i ∈ s, X i) μ = ∑ i ∈ s, variance (X i) μ` — line 403 of same file

## Build status: **build-pending**

Worktree `.lake` symlink loop confirmed: `proofs/.lake -> /Users/rwalters/GitHub/lean-genius/proofs/.lake` is **self-referential** in both main repo and all worktrees. Docker daemon not running locally; cannot verify the build in this session.

Per memory trap `feedback_researcher_lake_symlink_loop_and_wipe.md`:
> Commit + push Lean file FIRST, ship build-pending PR with clear title/body, let doctor verify from clean worktree.

Followed exactly.

## Likely failure points (if build fails)

In order of likelihood:
1. `rw [variance_const_mul]` may need `simp only` or `simpa` if `unfold sampleMean` exposes `1 / (n : ℝ)` vs `(1 : ℝ) / ↑n`.
2. `simpa [Finset.sum_apply]` rewrite of `IndepFun.variance_sum` to lambda form may need additional simp hints.
3. Final `field_simp` may need `hn0` passed explicitly.

All fixable by doctor in <5 LOC.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ02` succeeds (~5–10 min expected; heavier than `BinaryGcdOQ01` due to probability deps)
- [ ] `#print axioms variance_sampleMean` shows only `propext`, `Classical.choice`, `Quot.sound` (no `LawsOfLargeNumbersOQ02.variance_sampleMean` self-reference)
- [ ] `#print axioms chebyshev_convergence_rate` shows axioms only `propext`, `Classical.choice`, `Quot.sound`, `LawsOfLargeNumbersOQ02.standardNormalCDF`, `LawsOfLargeNumbersOQ02.berryEsseenConstant` (no `variance_sampleMean`)

## References

- S1 OBSERVE audit: PR #18789 (`research/llnumbers-oq-02-s1-observe-variance-sampleMean-bearer`) + `s1-observe-variance-sampleMean-bearer-audit.md`
- Prior `sampleMean_memLp` discharge: PR #13382
- Axiom-count sync: PR #13415

🤖 Generated with [Claude Code](https://claude.com/claude-code)