### PR TITLE
fix(mechanic): wire annotations into divisibility-truncation-general-oq-01 index.ts

### DIFF
--- a/src/data/proofs/divisibility-truncation-general-oq-01/index.ts
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/index.ts
@@ -1,2 +1,38 @@
-export { default as meta } from './meta.json'
-export { default as annotations } from './annotations.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const divisibilityTruncationGeneralOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const divisibilityTruncationGeneralOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const divisibilityTruncationGeneralOQ01TacticStates: TacticState[] = []
+
+export const divisibilityTruncationGeneralOQ01Data: ProofData = {
+  proof: divisibilityTruncationGeneralOQ01Proof,
+  annotations: divisibilityTruncationGeneralOQ01Annotations,
+  tacticStates: divisibilityTruncationGeneralOQ01TacticStates,
+}


### PR DESCRIPTION
## Fix

Replace 2-line `export { default as meta }; export { default as annotations };` stub at
`src/data/proofs/divisibility-truncation-general-oq-01/index.ts` with the canonical
template (matches recently-merged `lagrange-theorem-oq-02-oq-02` PR #17885 +
`ballot-problem-oq-01-oq-02-oq-01`).

## Evidence

**Before** (2 lines): `getProofAsync` (src/data/proofs/index.ts:50-79) falls through to
the legacy `module.meta` branch which CAN construct a `ProofData`, but loses the Lean
source (`?raw` not imported) and `tacticStates: []`. Gallery page can render but is
incomplete.

**After** (37 lines): synchronous `import sourceRaw from
'../../../../proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean?raw'`, camelCase
`divisibilityTruncationGeneralOQ01{Proof,Annotations,TacticStates,Data}` exports, full
ProofData object — `getProofAsync` resolves on `module[exportName]` first try.

## Scope

- Single file: `src/data/proofs/divisibility-truncation-general-oq-01/index.ts`.
- Annotations content (5KB, 7 annotations) was unreachable before, now wired.
- Sibling to mechanic PR #18799 on parent slug `divisibility-truncation-general`.
- 7 stub slugs total remain unclaimed across the gallery: `erdos-1059-oq-01`,
  `erdos-1059-oq-02`, `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-03`,
  `erdos-1059-oq-04`, `erdos-1059-oq-05`, and (now claimed by this PR)
  `divisibility-truncation-general-oq-01`. One fix per PR; out of scope here.

---
Automated fix by lean-mechanic agent.