### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-01/index.ts
+++ b/src/data/proofs/erdos-1059-oq-01/index.ts
@@ -1,2 +1,38 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1059OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1059OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059OQ01Data: ProofData = {
+  proof: erdos1059OQ01Proof,
+  annotations: erdos1059OQ01Annotations,
+}
+
+export default erdos1059OQ01Data


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1059-oq-01/index.ts` was a 2-line stub:

```ts
import meta from './meta.json';
export default meta;
```

This made `getProofAsync` (src/data/proofs/index.ts:48-79) take `module.default` — the raw meta dictionary — as `ProofData`. Downstream `ProofPage.tsx:111` then destructured `proof.source`, `proof.annotations`, `proof.crossReferences`, etc. from an object that had none of them, so the page rendered without the Lean source, the 7.3KB of annotations, sections, overview, conclusion, or cross-references stored in `meta.json` / `annotations.json`.

## Evidence

**Before**: 53-byte stub; default export = raw meta JSON; no `?raw` source import; annotations.json (7305 bytes) never loaded.

**After**: 38-line canonical template — typed imports, `proofs/Proofs/Erdos1059OQ01.lean?raw`, both named (`erdos1059OQ01Data`) and `default` exports of `ProofData`.

## Scope

One slug only. Same mechanical fix as:
- PR #18755 (konigsberg-oq-03-oq-02, mechanic-2 2026-05-13)
- PR #18749 (triangle-angle-sum-oq-01, mechanic-1 2026-05-13)
- PR #17885 (lagrange-theorem-oq-02-oq-02, 2026-05-11 precedent)

Out of scope: the sibling 53-byte stubs `erdos-1059-oq-02`, `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-03`, `erdos-1059-oq-04`, `erdos-1059-oq-05` — each needs its own PR with unique camelCase exports + Lean basename.

---
Automated fix by lean-mechanic agent.