### PR TITLE
research(erdos-892): S3 PREP — state.md/JSON sync + uniform-in-k condensed-term bound (complement to #18763)

### DIFF
--- a/research/problems/erdos-892/knowledge.md
+++ b/research/problems/erdos-892/knowledge.md
@@ -71,7 +71,7 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+- **2026-05-13 (researcher-9, S3 PREP, complement to PR #18763)** — Doc-only state.md / knowledge.md / gallery JSON sync explicitly scoped out by the sibling skeleton PR #18763 (researcher-11). Pinned 10 Mathlib lemma names + line numbers against lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Replaced the prior `for k ≥ 1` condensed-term lower bound with the uniform-in-k bound `2^k + 2 ≤ 2^(k+2)` (valid for all k ∈ ℕ since `3·2^k ≥ 2`), yielding `2^k · f(2^k) ≥ 1/(4·(k+2)·log 2)` without a k=0 special case. Full Steps 1–6 recipe + LOC estimate in `state.md` S3 PREP section.
 
 ---
 

--- a/research/problems/erdos-892/state.md
+++ b/research/problems/erdos-892/state.md
@@ -1,12 +1,93 @@
 # Current State
 
-**Phase**: AXIOMATIZED (gallery formalization complete)
-**Since**: 2026-04-28
-**Iteration**: 2
+**Phase**: S3 PREP — Cauchy condensation recipe verified against pinned Mathlib SHA, with uniform-in-k condensed-term lower bound
+**Since**: 2026-05-13 (S3 PREP); 2026-04-28 (AXIOMATIZED baseline)
+**Iteration**: 3
+**Owner**: researcher-9 (S3 PREP, 2026-05-13)
 
 ## Current Focus
 
-Metadata reconciliation: meta.json `conclusion.summary` was stale (claimed 6 theorems / 2 sorries / 1 axiom). Actual Lean file `Proofs/Erdos892Problem.lean` has 6 definitions, 7 theorems, 0 sorries, and 2 axioms. Updated conclusion.summary to match.
+Pre-ACT audit + refinement of the existing recipe (knowledge.insights[6]–[7]) for eliminating `axiom harmonic_log_plus2_diverges` (Erdos892Problem.lean:172) via Mathlib's Cauchy condensation test. This session is **doc-only** — no Lean file changes. Goal: pin every Mathlib lemma to the lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, give file paths + line numbers, and replace the existing `for k ≥ 1` condensed-term bound with a uniform-in-k bound that avoids the k=0 edge case.
+
+**Complementary to in-flight PR #18763** (researcher-11, 2026-05-13 11:27 UTC) which adds a `~90-LOC ACT skeleton under research/problems/erdos-892/sessions/` and explicitly scopes out state.md / knowledge.md / gallery JSON edits. This PR fills exactly that scope gap (state.md / knowledge.md / `src/data/research/problems/erdos-892.json`) and refines the condensed-term bound used in their §3 from the `k ≥ 1` form `2^k · f(2^k) ≥ 1/(2 log 2 (k+2))` to the **uniform-in-k** form `2^k · f(2^k) ≥ 1/(4 log 2 (k+2))` (valid for all k ∈ ℕ via `2^k + 2 ≤ 2^(k+2)`), which lets the future ACT writer drop the k=0 special-case argument.
+
+## S3 PREP — Verified Mathlib API (pinned SHA 2df2f0150c…)
+
+All names + signatures cross-checked via `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<sha>` against the SHA in `proofs/lake-manifest.json`.
+
+| Mathlib lemma | File:line | Signature (abridged) |
+|---|---|---|
+| `summable_condensed_iff_of_nonneg` | `Mathlib/Analysis/PSeries.lean:228` | `(h_nonneg : ∀ n, 0 ≤ f n) (h_mono : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) → (Summable fun k => (2:ℝ)^k * f (2^k)) ↔ Summable f` |
+| `not_summable_iff_tendsto_nat_atTop_of_nonneg` | `Mathlib/Topology/Algebra/InfiniteSum/Real.lean:61` | `(hf : ∀ n, 0 ≤ f n) → ¬Summable f ↔ Tendsto (fun n => ∑ i ∈ range n, f i) atTop atTop` |
+| `summable_iff_not_tendsto_nat_atTop_of_nonneg` | `Mathlib/Topology/Algebra/InfiniteSum/Real.lean:66` | dual of the above |
+| `tendsto_sum_range_one_div_nat_succ_atTop` | `Mathlib/Analysis/PSeries.lean:337` | `Tendsto (fun n => ∑ i ∈ range n, (1:ℝ)/(i+1)) atTop atTop` |
+| `not_summable_natCast_inv` | `Mathlib/Analysis/PSeries.lean:327` | `¬Summable (fun n => n⁻¹ : ℕ → ℝ)` |
+| `not_summable_one_div_natCast` | `Mathlib/Analysis/PSeries.lean:333` | `¬Summable (fun n => 1 / n : ℕ → ℝ)` |
+| `Real.log_pos` | `Mathlib/Analysis/SpecialFunctions/Log/Basic.lean:173` | `1 < x → 0 < log x` |
+| `Real.log_le_log` | `Mathlib/Analysis/SpecialFunctions/Log/Basic.lean:148` | `0 < x → x ≤ y → log x ≤ log y` |
+| `Real.log_lt_log` | `Mathlib/Analysis/SpecialFunctions/Log/Basic.lean:152` | `0 < x → x < y → log x < log y` |
+| `Real.log_pow` | `Mathlib/Analysis/SpecialFunctions/Log/Basic.lean:273` | `log (x^n) = n * log x` |
+
+## S3 PREP — Refined Recipe (replacing knowledge.insights[7])
+
+Define `f : ℕ → ℝ` by `f n := 1 / ((↑n + 2) * Real.log (↑n + 2))`. Goal: prove
+`harmonic_log_plus2_diverges : ∀ S : ℝ, ∃ N : ℕ, S + 1 < ∑ n ∈ range N, f n`.
+
+### Step 1 — Non-negativity (`h_nonneg`)
+For all `n : ℕ`, `0 ≤ f n`. Both factors are positive:
+- `(↑n + 2 : ℝ) > 0` since `n + 2 ≥ 2 > 0` — `by positivity` or `Nat.cast_add_pos`.
+- `Real.log (↑n + 2) > 0` via `Real.log_pos` with hypothesis `1 < ↑n + 2` (which is `Nat.one_lt_succ_succ` cast to ℝ).
+- Reciprocal of a positive real is positive.
+
+### Step 2 — Antitone (`h_mono`)
+For `m n : ℕ`, `0 < m → m ≤ n → f n ≤ f m`. Equivalently (since denominators positive),
+`(↑m + 2) * Real.log (↑m + 2) ≤ (↑n + 2) * Real.log (↑n + 2)`.
+- `↑m + 2 ≤ ↑n + 2` from `m ≤ n` via `Nat.cast_le`.
+- `Real.log (↑m + 2) ≤ Real.log (↑n + 2)` via `Real.log_le_log` with positivity from Step 1.
+- Both factors are non-negative, so product is monotone — `mul_le_mul` with two `le` hypotheses + non-negativity.
+- (Note: the antitonicity hypothesis form `0 < m → m ≤ n → f n ≤ f m` is what `summable_condensed_iff_of_nonneg` expects. The `0 < m` hypothesis is not actually needed here since `f` is antitone on all of ℕ, but accepting and discarding the hypothesis is fine.)
+
+### Step 3 — Uniform-in-k condensed-term lower bound (replaces "for k ≥ 1")
+**Key improvement over knowledge.insights[7]**: the existing recipe uses `2^k + 2 ≤ 2 · 2^k` which fails at `k = 0` (`2^0 + 2 = 3 > 2 = 2·2^0`). Replace with the looser-but-uniform bound:
+- For all `k : ℕ`, `2^k + 2 ≤ 2^(k+2)`.
+  - Algebraic check: `2^(k+2) = 4 · 2^k ≥ 2^k + 2 ⟺ 3 · 2^k ≥ 2`, which holds for all `k ∈ ℕ` since `2^k ≥ 1`.
+  - In Lean: `Nat.lt_pow_self`-style induction or `by omega`-after-`pow_succ`-rewriting, or simply `Nat.add_le` + `Nat.one_le_two_pow`.
+- Consequently, for all `k : ℕ`:
+  - `Real.log (2^k + 2) ≤ Real.log (2^(k+2)) = (↑k + 2) * Real.log 2` (via `Real.log_le_log` + `Real.log_pow`).
+  - `(↑(2^k) + 2) * Real.log (↑(2^k) + 2) ≤ ↑(2^(k+2)) * (↑k + 2) * Real.log 2 = 4 * ↑(2^k) * (↑k + 2) * Real.log 2`.
+  - Therefore `(2:ℝ)^k * f (2^k) = (2:ℝ)^k / ((↑(2^k) + 2) * Real.log (↑(2^k) + 2)) ≥ (2:ℝ)^k / (4 * ↑(2^k) * (↑k + 2) * Real.log 2) = 1 / (4 * (↑k + 2) * Real.log 2)`.
+
+### Step 4 — Lower bound diverges
+`g k := 1 / (4 * (↑k + 2) * Real.log 2)` is `1 / (4 * Real.log 2)` times the harmonic-tail `1/(k+2)`.
+- ¬Summable `(fun k => 1/(↑k + 2))` — from `not_summable_natCast_inv` after the index-shift `k ↦ k + 2`, or directly from the divergence of `tendsto_sum_range_one_div_nat_succ_atTop` after a one-term shift.
+- ¬Summable `g` follows by scalar multiplication: `(1/(4*Real.log 2)) > 0` so summability is preserved by `Summable.const_smul_iff` (or contrapositive).
+
+### Step 5 — Lift to the condensed series, then to f
+- ¬Summable `(fun k => (2:ℝ)^k * f (2^k))` via comparison Step 3 + Step 4: if the condensed series were summable, comparison `g k ≤ 2^k * f(2^k)` gives `Summable g`, contradicting Step 4. Use `Summable.of_nonneg_of_le` contrapositively, or `Summable.mono` after non-negativity.
+- ¬Summable `f` via `summable_condensed_iff_of_nonneg` (Step 1 + Step 2).
+
+### Step 6 — Extract existential N
+- From ¬Summable `f` + non-negativity of `f` (Step 1), apply `not_summable_iff_tendsto_nat_atTop_of_nonneg.mp` to get
+  `Tendsto (fun N => ∑ n ∈ Finset.range N, f n) atTop atTop`.
+- `Tendsto.eventually_gt` (or its specialization for `atTop`) applied to the target `S + 1` then provides the desired `N`.
+
+### Estimated LOC
+- Step 1: ~3 lines (positivity)
+- Step 2: ~6 lines (antitone via `Real.log_le_log` + `mul_le_mul`)
+- Step 3: ~15 lines (uniform bound + algebraic manipulation; bulk of the proof)
+- Step 4: ~5 lines (harmonic divergence + scalar bridge)
+- Step 5: ~6 lines (comparison)
+- Step 6: ~3 lines (existential extraction)
+- Total: **~40 lines of tactic proof + ~10 lines of `have` scaffolding ≈ 50 lines**, matching the existing estimate (50-70 lines).
+
+## Active Approach (post-S3 PREP)
+
+Gallery entry uses an "axiomatized" formalization:
+- 6 definitions: `IsPrimitive`, `IsStrictlyIncreasing`, `IsDominatedBy`, `ErdosProblem892`, `IsGCDFree`, `ErdosProblem892GCDFree`.
+- 7 proved theorems: `primitive_elements_ge_two`, `strict_inc_lower_bound`, `strict_inc_eventually_ge`, `product_log_comparison`, `reciprocal_log_comparison`, `erdos_1935_necessary`, `linear_growth_no_primitive_dominator`.
+- 2 axioms: `primitive_reciprocal_log_convergent` (Erdős 1935 deep result), `harmonic_log_plus2_diverges` (now S3-PREP-ready for Mathlib-derived theorem replacement).
+
+The Erdős 1935 necessary condition is fully proved in Lean. The Erdős–Sárközy–Szemerédi 1968 problem itself remains open (no characterization of necessary AND sufficient conditions for primitive domination is known).
 
 ## Active Approach
 
@@ -34,6 +115,6 @@ to verify directly — this would not solve the open question but would strength
 
 ## Attempt Counts
 
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
-- Approaches tried: 1 (metadata reconciliation; underlying problem remains open)
+- Approaches tried: 2 (metadata reconciliation 2026-04-28; S3 PREP recipe refinement 2026-05-13 — Mathlib API pinned + uniform-in-k condensed-term bound)

--- a/src/data/research/problems/erdos-892.json
+++ b/src/data/research/problems/erdos-892.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-892",
   "title": "Erdős #892",
-  "phase": "OBSERVE",
+  "phase": "S3-PREP",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -42,11 +42,12 @@
       "Main file reciprocal_log_comparison is correctly stated and proved",
       "Main theorem erdos_1935_necessary is a substantive 70-line proof",
       "Mathlib has Cauchy condensation in `Mathlib.Analysis.PSeries`: `summable_condensed_iff_of_nonneg` says Summable f ↔ Summable (fun k => 2^k * f(2^k)) for f nonneg + antitone (for n ≥ 1). Combined with `not_summable_iff_tendsto_nat_atTop_of_nonneg` from `Mathlib.Topology.Algebra.InfiniteSum.Real`, the axiom `harmonic_log_plus2_diverges` is reducible to a Mathlib proof.",
-      "Concrete elimination recipe for harmonic_log_plus2_diverges: (1) Antitone proof: f(n)=1/((n+2)·log(n+2)) is decreasing because both (n+2) and log(n+2) are positive and increasing for n ≥ 0. (2) Condense: 2^k · f(2^k) = 2^k/((2^k+2)·log(2^k+2)) ≥ 1/(2(k+1) log 2) for k ≥ 1 (since 2^k+2 ≤ 2·2^k and log(2^k+2) ≤ (k+1) log 2). (3) Compare condensed series to (1/(2 log 2)) · Σ 1/(k+1), divergent by tendsto_sum_range_one_div_nat_succ_atTop. (4) Use not_summable_iff_tendsto_nat_atTop_of_nonneg to convert ¬Summable to atTop and extract the existential N for any S."
+      "Concrete elimination recipe for harmonic_log_plus2_diverges: (1) Antitone proof: f(n)=1/((n+2)·log(n+2)) is decreasing because both (n+2) and log(n+2) are positive and increasing for n ≥ 0. (2) Condense: 2^k · f(2^k) = 2^k/((2^k+2)·log(2^k+2)) ≥ 1/(2(k+1) log 2) for k ≥ 1 (since 2^k+2 ≤ 2·2^k and log(2^k+2) ≤ (k+1) log 2). (3) Compare condensed series to (1/(2 log 2)) · Σ 1/(k+1), divergent by tendsto_sum_range_one_div_nat_succ_atTop. (4) Use not_summable_iff_tendsto_nat_atTop_of_nonneg to convert ¬Summable to atTop and extract the existential N for any S.",
+      "S3 PREP (2026-05-13, researcher-9, complement to PR #18763) — Mathlib API pinned against lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`: `summable_condensed_iff_of_nonneg` (PSeries.lean:228), `not_summable_iff_tendsto_nat_atTop_of_nonneg` (InfiniteSum/Real.lean:61), `tendsto_sum_range_one_div_nat_succ_atTop` (PSeries.lean:337), `Real.log_pos` (Log/Basic.lean:173), `Real.log_le_log` (Log/Basic.lean:148), `Real.log_pow` (Log/Basic.lean:273). Recipe improvement over PR #18763 §3: replace the `for k ≥ 1` bound `2^k + 2 ≤ 2·2^k` (fails at k=0) with the uniform-in-k bound `2^k + 2 ≤ 2^(k+2)` (holds for all k ∈ ℕ since 3·2^k ≥ 2). This yields the uniform condensed-term lower bound `2^k · f(2^k) ≥ 1/(4·(k+2)·log 2)` valid for every k ≥ 0, letting the ACT writer drop the k=0 special-case argument."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Eliminate axiom harmonic_log_plus2_diverges (Erdos892Problem.lean:172) using Mathlib's summable_condensed_iff_of_nonneg + tendsto_sum_range_one_div_nat_succ_atTop. Estimated 50-70 lines: (a) recip_log_plus2_antitone (~10 lines), (b) not_summable_recip_log_plus2 via condensation (~30-50 lines), (c) Tendsto.eventually to extract the existential N (~5 lines)."
+      "ACT-READY: Eliminate `axiom harmonic_log_plus2_diverges` (Erdos892Problem.lean:172) following the S3 PREP recipe in `research/problems/erdos-892/state.md` (Steps 1–6, ~50 LOC) and the drop-in skeleton in PR #18763's sessions file (researcher-11, 2026-05-13). All Mathlib lemmas pinned to lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` with file:line references. Use the uniform-in-k condensed-term bound `2^k · f(2^k) ≥ 1/(4·(k+2)·log 2)` from this PR's S3 PREP refinement to avoid the k=0 edge case in the skeleton."
     ],
     "markdown": "# Erdős #892 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a necessary and sufficient condition for a sequence of integers $b_1<b_2<\\cdots$ that ensures there exists a primitive sequence $a_1<a_2<\\cdots$ (i.e. no element divides another) with $a_n \\ll b_n$ for all $n$?\n\nIn particular, is this always possible if there are no non-trivial solutions to $(b_i,b_j)=b_k$?\n\n\n\nA problem of Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS68}. It is known that\\[\\sum \\frac{1}{b_n\\log b_n}<\\infty\\]and\\[\\sum_{b_n<x}\\frac{1}{b_n} =o\\left(\\frac{\\log x}{\\sqrt{\\log\\log x}}\\right)\\]are both necessary. (The former is due to Erd\\H{o}s \\cite{Er35}, the latter to Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS67}.)\n\nOne can ask a similar question for sequences of real numbers, as in [143].\n\n\n\n\nReferences\n\n\n[ESS67] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozy, A. and Szemer\\'{e}di, E., On a theorem of Behrend. J. Austral. Math. Soc. (1967), 9--16.\n\n[ESS68] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozi, A. and Szemer\\'{e}di, E., On the solvability of certain equations in sequences of\npositive upper logarithmic density. J. London Math. Soc. (1968), 71--78.\n\n[Er35] Erd\\\"{o}s, Paul, Note on Sequences of Integers No One of Which is Divisible By Any Other. J. London Math. Soc. (1935), 126-128.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #143\n- Problem #891\n- Problem #893\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n- ESS68\n- Er35\n- ESS67\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -64,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:22:53.228Z",
-  "lastUpdate": "2026-04-27T00:00:00.000Z",
+  "lastUpdate": "2026-05-13T11:30:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Doc-only complement to in-flight PR #18763 (researcher-11, 2026-05-13 11:27 UTC) which adds a ~90-LOC ACT skeleton under `research/problems/erdos-892/sessions/` and **explicitly scopes out** state.md, knowledge.md, and gallery JSON edits ([PR #18763 Scope](https://github.com/rjwalters/lean-genius/pull/18763): "No edits to problem.md / state.md / knowledge.md / gallery JSON / .lean").

This PR fills exactly that scope gap (state.md / knowledge.md / `src/data/research/problems/erdos-892.json`) **and** refines the condensed-term bound used in PR #18763 §3 from `for k ≥ 1` to **uniform-in-k**.

## Scope (orthogonal to PR #18763)

- File overlap with PR #18763: **zero** (theirs touches only `sessions/2026-05-13-s3-prep-mathlib-bearer-harmonic-log-divergence.md`; mine touches only state.md / knowledge.md / gallery JSON).
- Doc-only. No Lean file changes. No new files. No edits to `proofs/` tree.

## Files

| File | Change |
|---|---|
| `research/problems/erdos-892/state.md` | Phase `AXIOMATIZED` → `S3 PREP`; new Mathlib API table (10 lemmas with file:line pinned to lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`); Steps 1–6 refined recipe with LOC estimate |
| `research/problems/erdos-892/knowledge.md` | New `Sessions` entry cross-referencing PR #18763 |
| `src/data/research/problems/erdos-892.json` | `phase` OBSERVE → S3-PREP; `lastUpdate` → 2026-05-13; new 9th `knowledge.insights` entry; `knowledge.nextSteps` rewritten to ACT-READY |

## Math refinement (over PR #18763 §3)

PR #18763's Step 2 uses `2^k + 2 ≤ 2 · 2^k`, which **fails at k = 0** (`3 ≰ 2`). The skeleton handles this with a `k ≥ 1` qualifier + special-case argument.

This PR replaces it with the uniform-in-k bound:

```
2^k + 2 ≤ 2^(k+2)            (holds for all k ∈ ℕ since 3·2^k ≥ 2)
log(2^k + 2) ≤ (k+2)·log 2   (Real.log_le_log + Real.log_pow)
⟹ 2^k · f(2^k) ≥ 1/(4·(k+2)·log 2)
```

Valid uniformly for k ≥ 0, letting the ACT writer drop the k = 0 special case. The bound is looser by a constant factor 2 (1/4 vs 1/2), which is irrelevant — both diverge at the same rate against the harmonic-tail comparison.

## Mathlib API verification (pinned)

All names + file:line cross-checked against `proofs/lake-manifest.json` SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<sha>`. Full table in state.md.

## Race check

- `gh pr list --search "erdos-892 in:title" --state open` at commit time: only PR #18763 (researcher-11).
- Re-checked immediately before push: same single open PR.
- This PR opened ~25 min after PR #18763 with deliberately orthogonal file scope.

## Test plan

- [x] State.md / knowledge.md / JSON edits committed in worktree, not main repo (verified via `git status` from worktree CWD).
- [x] JSON round-trip via Python `json.load`/`json.dump` — no syntax errors.
- [x] All 10 Mathlib lemma names re-fetched against pinned SHA.
- [x] Uniform bound `2^k + 2 ≤ 2^(k+2)` algebraically verified for k = 0, 1, 2 + general `3·2^k ≥ 2` argument.
- [x] Pre-push race re-check confirmed no other erdos-892 PRs landed during commit drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code) by researcher-9