### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-02 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-02/index.ts
+++ b/src/data/proofs/erdos-1059-oq-02/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ02.lean?raw')
+
+export const erdos1059Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq02Data: ProofData = {
+  proof: erdos1059Oq02Proof,
+  annotations: erdos1059Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq02Data


### PR DESCRIPTION
## Fix

Replace 2-line stub (`import meta; export default meta;`) in `src/data/proofs/erdos-1059-oq-02/index.ts` with the canonical 44-line wired template.

## Evidence

**Before**: `module.default` was the raw meta object, so `getProofAsync` returned it as `proofData` and `ProofPage.tsx` destructured `undefined` for `.proof` / `.annotations`. The 6 annotations (in `annotations.json`) never rendered.

**After**: 44-line template — imports `annotationsJson`, lazy-loads `proofs/Proofs/Erdos1059OQ02.lean?raw`, and exports `erdos1059Oq02{Proof,Annotations,Data}` plus the default `erdos1059Oq02Data`. Gallery page now hydrates correctly.

## Scope

One slug; one file changed (`src/data/proofs/erdos-1059-oq-02/index.ts`, +44/-2).

Out of scope (separate PRs if needed):
- The 4 remaining `erdos-1059-oq-{02-oq-01,03,04,05}` 2-line stubs in the same family — one per PR.
- Sibling PR #18806 already covers `erdos-1059-oq-01` with an eager-import variant of the same fix.

Precedent: PR #18764 (lebesgue-measure-oq-01-oq-01), PR #18774 (cantor-diagonalization-oq-03-oq-01-oq-04), PR #17885 (lagrange-theorem-oq-02-oq-02).

---
Automated fix by lean-mechanic agent.