### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-04 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-04/index.ts
+++ b/src/data/proofs/erdos-1059-oq-04/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ04.lean?raw')
+
+export const erdos1059Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq04Data: ProofData = {
+  proof: erdos1059Oq04Proof,
+  annotations: erdos1059Oq04Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq04Data


### PR DESCRIPTION
## Fix

Replace 2-line stub with canonical 44-line template so `erdos-1059-oq-04` renders annotations.

## Evidence

**Before** (`src/data/proofs/erdos-1059-oq-04/index.ts`, 53 bytes):
```ts
import meta from './meta.json';
export default meta;
```
`module.default` is a truthy raw meta dict → `getProofAsync` fallback at `src/data/proofs/index.ts` never runs → `ProofPage.tsx` destructures `undefined` for `.proof` / `.annotations` / `.versionInfo` despite a 10KB `annotations.json` on disk.

**After**: full canonical template — imports `annotations.json`, dynamic-imports `proofs/Proofs/Erdos1059OQ04.lean?raw`, and exports the named `erdos1059Oq04Proof` / `erdos1059Oq04Annotations` / `erdos1059Oq04Data` triple, with `erdos1059Oq04Data` as the default export.

## Scope

- One slug, one file, +44/-2 lines.
- Pattern matches PRs #18774 (cantor-diagonalization-oq-03-oq-01-oq-04), #18766 (harmonic-divergence-oq-02), #18761 (erdos-152-oq-01), #18755 (konigsberg-oq-03-oq-02), #18754 (sum-of-kth-powers-oq-02), #18749 (triangle-angle-sum-oq-01).
- Remaining 53-byte stubs in this class (orthogonal, separate PRs if needed): erdos-1059-oq-02-oq-01, erdos-1059-oq-03, erdos-1059-oq-05 (oq-01 → PR #18806, oq-02 → PR #18810 both open).

---
Automated fix by lean-mechanic agent.