### PR TITLE
fix(mechanic): wire annotations into amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 index.ts

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,2 +1,44 @@
-export { default as meta } from './meta.json';
-export { default as annotations } from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean?raw')
+
+export const amgmInequalityOq02Oq01Oq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq02Oq01Oq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq02Oq01Oq02Oq01Oq01Data: ProofData = {
+  proof: amgmInequalityOq02Oq01Oq02Oq01Oq01Proof,
+  annotations: amgmInequalityOq02Oq01Oq02Oq01Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default amgmInequalityOq02Oq01Oq02Oq01Oq01Data


### PR DESCRIPTION
## Fix

Replace 2-line `export { default as meta }` stub at `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/index.ts` with the canonical 44-line template (Proof / Annotation / ProofData exports + lazy Lean source factory).

## Evidence

**Before**: 2-line file exported only `meta` / `annotations` named JSON re-exports — no `Proof`, no `ProofData`, no Lean source wiring. The 14KB `annotations.json` and 17KB `meta.json` exist but the page falls into the legacy `{ meta, annotations }` fallback at `src/data/proofs/index.ts:60-79` which hardcodes `source: ''`, so the Lean source pane stays empty and the `*Data` named export downstream consumers expect is absent.

**After**: Canonical template (same shape as merged PR #18755 / #18749 / #18773) wires:
- `amgmInequalityOq02Oq01Oq02Oq01Oq01Proof` (named export, full `Proof`)
- `amgmInequalityOq02Oq01Oq02Oq01Oq01Annotations` (named export, `Annotation[]`)
- `amgmInequalityOq02Oq01Oq02Oq01Oq01Data` (named + default export, `ProofData`)
- `getProofSource()` async accessor — lazy-loads `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean?raw`

`Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean` exists (5979 bytes, status `verified`, 0 sorries, 0 axioms per meta.json) — wiring is straightforward.

## Scope

One slug. +44 / -2 LOC on a single `index.ts`. Same fix class as PR #18755 (konigsberg-oq-03-oq-02), PR #18749 (triangle-angle-sum-oq-01), PR #18773 (amgm-inequality-oq-02-oq-01-oq-02-oq-01).

Sibling 2-line stubs still on main (out of scope for this PR): `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-03`, `erdos-1059-oq-04`, `erdos-1059-oq-05`.

---
Automated fix by lean-mechanic agent.