### PR TITLE
research(shannon-entropy-oq-01): S3 COMPLETION-SYNC — verified-complete slug state-drift sync (doc-only)

### DIFF
--- a/research/problems/shannon-entropy-oq-01/sessions/2026-05-13-s3-completion-sync.md
+++ b/research/problems/shannon-entropy-oq-01/sessions/2026-05-13-s3-completion-sync.md
@@ -1,0 +1,112 @@
+# 2026-05-13 S3 — COMPLETION-SYNC
+
+**Agent**: researcher-1
+**Pattern**: state-drift sync for verified-complete RICH-tier slug (~6 weeks stale)
+**Result**: doc-only PR; 0 LOC Lean changed; 0 sorries added/removed; 0 axioms added/removed
+**Trigger**: `claim-random` returned `shannon-entropy-oq-01` (knowledge score 38, RICH tier, depth-first preferred). Per the stale-completed RICH-tier trap (see memory), first-30-seconds triage:
+
+```bash
+$ cat src/data/research/problems/shannon-entropy-oq-01.json | jq -r .knowledge.progressSummary
+COMPLETE: All sorries eliminated. gaussian_second_moment and gaussian_quad_integrable proved ...
+
+$ head -5 research/problems/shannon-entropy-oq-01/state.md
+# Current State
+**Phase**: NEW
+**Since**: 2026-03-30T17:32:58.852Z
+**Iteration**: 1
+...
+
+$ grep -cE "^[[:space:]]*sorry[[:space:]]*$|:= sorry$|:= by sorry" proofs/Proofs/ShannonEntropyOQ01.lean
+0
+
+$ grep -cE "^[[:space:]]*sorry[[:space:]]*$|:= sorry$|:= by sorry" proofs/Proofs/ShannonEntropyOQ01Aristotle.lean
+2
+```
+
+Verdict: drift, not a real research opportunity. Sync to ground truth.
+
+## Drift inventory (before → after)
+
+| File | Field | Before | After | Notes |
+|---|---|---|---|---|
+| `research/problems/shannon-entropy-oq-01/state.md` | Phase | `NEW` (2026-03-30 seeker-init stub) | `COMPLETED` (PR #8805 2026-04-03) | 6-week stale |
+| `…/state.md` | Iteration | `1` | `3` | counts S1 setup, S2 closure, S3 sync |
+| `…/state.md` | Current Focus | `Initial exploration of the problem.` | full COMPLETED summary with 6 theorem names | from JSON `progressSummary` |
+| `src/data/research/problems/shannon-entropy-oq-01.json` | `status` | `active` | `completed` | drives `claim-random` pool filter |
+| `…json` | `title` | truncated `"...continuous dist..."` | full plain-English statement | |
+| `…json` | `problemStatement.formal` | `"\\text{(formal statement to be added)}"` | full formal statement with all 6 theorem signatures | |
+| `…json` | `problemStatement.plain` | one-sentence stub | full plain-English summary | |
+| `…json` | `problemStatement.whyMatters` | `[]` | 3 entries (foundational, pedagogical, cross-reference) | |
+| `…json` | `knownResults.proven` | `[]` | 7 entries (6 Mathlib + 1 in-tree) | |
+| `…json` | `knownResults.open` | `[]` | 3 forward-extension candidates | sub-OQ seeds |
+| `…json` | `knownResults.goal` | `""` | full goal statement | |
+| `…json` | `currentState.focus` | `"COMPLETE: All sorries eliminated. Build succeeds with 0 errors."` | S3 sync summary | the "Build succeeds with 0 errors" claim was true for `ShannonEntropyOQ01.lean` but the Aristotle companion still has 2 sorries; clarified |
+| `…json` | `currentState.nextAction` | `"Done. Gallery entry verified at src/data/proofs/shannon-entropy-oq-01/ (status: verified, 0 sorries, 0 axioms)."` | factually corrected | gallery is `formalized` not `verified`, with `sorries: 2` reflecting the Aristotle companion |
+| `…json` | `currentState.attemptCounts.currentApproach` | `2` | `0` | no active approach when status `completed` |
+| `…json` | `knowledge.progressSummary` | "COMPLETE: All sorries eliminated. …" | same intent + PR #8805 attribution and explicit theorem counts | |
+| `…json` | `knowledge.builtItems` | 17 entries, mixed concrete + abstract | 17 entries, all with file:line and proof-witness one-liner | line numbers verified by `grep -nE` at session start |
+| `…json` | `knowledge.nextSteps` | `[]` | 4 entries (3 sub-OQ + Aristotle drop) | seeker-actionable |
+| `…json` | `tags` | `["seeker-selected"]` | 8 tags (+`completed`, content tags) | |
+| `…json` | `relatedProofs` | 4 entries (incl. self) | 4 entries (no self) | |
+| `…json` | `references.{papers,urls,mathlib}` | all empty | 2 + 2 + 6 | |
+| `…json` | `lastUpdate` | `2026-04-27T00:00:00.000Z` | `2026-05-13T12:00:00.000Z` | |
+| `…json` | `leanFiles[ShannonEntropyOQ01.lean].sorryCount` | `1` | `0` | actual count verified |
+| `…json` | `leanFiles[ShannonEntropyOQ01.lean].lineCount` | `624` | `623` | actual count verified by `wc -l` |
+| `…json` | `leanFiles[ShannonEntropyOQ01Aristotle.lean].sorryCount` | `3` | `2` | actual count verified |
+
+## Files NOT touched (out of scope for this PR)
+
+* `proofs/Proofs/ShannonEntropyOQ01.lean` — verified-complete; **0 LOC of Lean code change**. Sorry count unchanged at 0; axiom count unchanged at 0.
+* `proofs/Proofs/ShannonEntropyOQ01Aristotle.lean` — obsolete companion still on disk; flagged for follow-up drop (see below).
+* `proofs/Proofs.lean` — auto-generated; not touched.
+* `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` — its `import Proofs.ShannonEntropyOQ01Aristotle` at line 2470 stays valid as long as the companion exists.
+* `src/data/proofs/shannon-entropy-oq-01/{meta,annotations,index}.{json,ts}` — gallery surface unchanged. `meta.json` `status: "formalized"`, `sorries: 2`, `badge: "original"` is **consistent** with current Lean state (per the [meta.sorries aggregates main + Aristotle companion](feedback_mechanic_meta_sorries_aggregates_aristotle_companion.md) rule, the 2 sorries are real and live in the companion).
+* Sibling slugs `shannon-entropy`, `-oq-02`, `-oq-03`, `-ssa` — no cross-edits.
+
+## Recommended follow-up: Aristotle companion drop
+
+`proofs/Proofs/ShannonEntropyOQ01Aristotle.lean` declares two `theorem … := by sorry` stubs (`gaussian_second_moment`, `gaussian_quad_integrable`) under namespace `ShannonEntropyOQ01Aristotle`. Both statements are **already proved** in `ShannonEntropyOQ01.lean` as `private lemma`s (lines 335 and 467 respectively), discharged via:
+
+- IBP using antiderivative `G(x) = -x/(2b) * exp(-b * x²)` plus `integral_Ioi_of_hasDerivAt_of_tendsto'` and the matching Iic FTC variant;
+- `integrable_rpow_mul_exp_neg_mul_sq` with `s = 2` plus `Integrable.comp_sub_right`.
+
+The companion was created as an Aristotle proof-search target while the main file was incomplete; after PR #8914 closed the file's last sorry, the companion became dead weight. **Dropping it** would let the gallery move from `formalized` → `verified`:
+
+1. `git rm proofs/Proofs/ShannonEntropyOQ01Aristotle.lean`
+2. `./.lean/scripts/generate-proofs-imports.sh` (regenerates `proofs/Proofs.lean`)
+3. Edit `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` line 2470 to drop `import Proofs.ShannonEntropyOQ01Aristotle`
+4. Edit `src/data/proofs/shannon-entropy-oq-01/meta.json`: remove `"Proofs/ShannonEntropyOQ01Aristotle.lean"` from `additionalFiles`, `sorries: 2` → `0`, `status: "formalized"` → `"verified"`. `badge: "original"` stays (this **is** an original contribution; `verified` is for not-original verified proofs per the badge rule in CLAUDE.md).
+
+Pure-deletion change; build risk is essentially zero (no new Lean code), but warrants a Docker build to confirm before merge. Mechanic or doctor domain. I am leaving it out of this PR to keep scope tight and matching the established researcher-9 doc-only COMPLETION-SYNC pattern (PR #18753, #18791).
+
+## Operational pool update (NOT in PR diff)
+
+After merge, the slug's pool entry transitions from `in-progress` → `completed` via:
+
+```bash
+cd /Users/rwalters/GitHub/lean-genius && \
+  RESEARCHER_ID=researcher-1 \
+  ./scripts/research/claim-problem.sh update shannon-entropy-oq-01 completed
+```
+
+This removes the slug from `claim-random`'s candidate set (`select(.status != "completed" and .status != "blocked" and .status != "graduated")`). RICH-tier pool currently shows 531 entries; this slug's knowledge_score 38 places it deep in the depth-first range, so removing it gives a small but real signal-density improvement.
+
+## Race-context
+
+```bash
+$ gh pr list --repo rjwalters/lean-genius --search "shannon-entropy-oq-01 in:title" --state open
+(no results)
+```
+
+No open PR for this slug. Last research-side activity: PR #8805 (2026-04-03, original proof) and #8931 (2026-04-03, knowledge update). Last enrichment: #12202 (2026-04-24). No race window expected.
+
+## Honesty assessment
+
+**Significance**: low. The PR's mathematical content is **zero** — it is audit-trail propagation. Operational value:
+
+- Removes 6 weeks of accumulated state-drift on a verified-complete slug.
+- Corrects `leanFiles` sorry counts that wrongly attributed 1 sorry to the (0-sorry) main file and over-counted the companion at 3 (actual 2).
+- Surfaces 3 concrete sub-OQ candidates with explicit suggested slug IDs (`-oq-01-oq-01` ℝⁿ extension, `-oq-01-oq-02` Entropy Power Inequality, `-oq-01-oq-03` Cramér–Rao bound) for seeker prioritisation.
+- Provides an explicit followable recipe for the Aristotle companion drop so a mechanic/doctor can ship the verified-promotion in a ~3-file orthogonal PR.
+
+No fabricated value. Every claim in the corrected `builtItems` was verified by reading the actual Lean file at session start (`grep -nE` for declaration lines, `wc -l` for line counts, `grep -cE` for sorry counts).

--- a/research/problems/shannon-entropy-oq-01/state.md
+++ b/research/problems/shannon-entropy-oq-01/state.md
@@ -1,27 +1,70 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T17:32:58.852Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-04-03 (PR #8805 verified)
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+State-drift sync for verified-complete slug. The Lean file
+`proofs/Proofs/ShannonEntropyOQ01.lean` has been complete (623 LOC, 6
+public theorems, 0 sorries, 0 axioms) since PR #8805 merged on
+2026-04-03. The research-side `state.md` and JSON were never advanced
+past the 2026-03-30 seeker-init NEW stub. This S3 doc-only pass syncs
+them to ground truth.
 
 ## Active Approach
 
-None yet.
+None — verified-complete. The OQ asked "Can differential entropy
+h(X) = -∫ f(x) ln f(x) dx for continuous distributions be formalized
+in Lean using Mathlib's measure theory?" The answer is YES,
+demonstrated by 6 fully-proved theorems in
+`proofs/Proofs/ShannonEntropyOQ01.lean`:
+
+- `kl_divergence_continuous_nonneg` — D(f||g) ≥ 0 (continuous KL divergence)
+- `gibbs_inequality_continuous` — h(f) ≤ -∫ f·ln g for reference density g
+- `differentialEntropy_translation_invariant` — h(f(·-c)) = h(f) via Lebesgue invariance
+- `differentialEntropy_scale_equivariant` — h(g) = h(f) + ln|a| via `Measure.integral_comp_div`
+- `gaussianDifferentialEntropy` — h(N(μ,σ²)) = ½ ln(2πeσ²)
+- `gaussian_max_entropy` — Gaussian maximizes h at fixed variance
+
+Supporting private lemmas: `kl_term_bound_cts`, `gaussianPDF_eq_gaussianPDFReal`,
+`gaussianPDF_integral_eq_one`, `gaussianPDF_integrable`, `gaussianPDF_log`,
+`mul_exp_tendsto_zero`, `gaussian_second_moment` (IBP via antiderivative
+G(x) = -x/(2b)·exp(-bx²)), `gaussian_quad_integrable`.
 
 ## Blockers
 
-None.
+None for the OQ itself. Note: the Aristotle companion
+`proofs/Proofs/ShannonEntropyOQ01Aristotle.lean` still carries 2 stub
+sorries (the same `gaussian_second_moment` and `gaussian_quad_integrable`
+statements that are already proved as `private lemma`s in the main file).
+The companion is obsolete; a follow-up PR can drop it (file deletion +
+import removal in `proofs/Proofs.lean` + `additionalFiles` edit in
+gallery `meta.json`) to allow the gallery to move from `formalized` to
+`verified`.
 
 ## Next Action
 
-Begin problem exploration.
+Done at the research-side. Follow-ups (out of scope for this PR):
+
+1. **Aristotle companion drop** — delete `ShannonEntropyOQ01Aristotle.lean`,
+   remove its import from `proofs/Proofs.lean` (auto-generated; rerun
+   `./.lean/scripts/generate-proofs-imports.sh`) and from
+   `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`
+   line 2470. Remove from `meta.json.additionalFiles`, drop `sorries`
+   2 → 0, promote status `formalized` → `verified`.
+
+2. **Forward extensions** — possible sub-OQs:
+   - `shannon-entropy-oq-01-oq-01`: extend differential entropy to ℝⁿ
+     (multivariate Gaussian; uses `Matrix.det`-based normalization)
+   - `shannon-entropy-oq-01-oq-02`: prove the Entropy Power Inequality
+     `e^(2h(X+Y)/n) ≥ e^(2h(X)/n) + e^(2h(Y)/n)` (Shannon 1948, Stam 1959)
+   - `shannon-entropy-oq-01-oq-03`: connect to the Cramér–Rao bound
+     (Fisher information ↔ score function ↔ differential entropy)
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3 (Session 1 setup, Session 2 closure, Session 3 sync)
+- Current approach attempts: N/A — completed
+- Approaches tried: 1 (Bochner integral + Mathlib `ProbabilityTheory.gaussianPDFReal` bridge)

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -1,97 +1,130 @@
 {
   "slug": "shannon-entropy-oq-01",
-  "title": "Can differential entropy $h(X) = -\\int f(x) \\ln f(x)\\,dx$ for continuous dist...",
+  "title": "Can differential entropy h(X) = -∫ f(x) ln f(x) dx for continuous distributions be formalized in Lean using Mathlib's measure theory?",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: Can differential entropy $h(X) = -\\int f(x) \\ln f(x)\\,dx$ for continuous dist....",
-    "whyMatters": []
+    "formal": "Formalize differential entropy `differentialEntropy f := -∫ x, f x * Real.log (f x)` for `f : ℝ → ℝ`, then prove: (i) continuous Gibbs inequality `kl_divergence_continuous_nonneg : 0 ≤ klDivergenceCts f g` and `gibbs_inequality_continuous : differentialEntropy f ≤ -∫ x, f x * Real.log (g x)`; (ii) Lebesgue-invariance properties `differentialEntropy_translation_invariant : differentialEntropy (fun x => f (x - c)) = differentialEntropy f` and `differentialEntropy_scale_equivariant : differentialEntropy (fun x => (1/|a|) * f (x/a)) = differentialEntropy f + Real.log |a|`; (iii) the Gaussian closed form `gaussianDifferentialEntropy : differentialEntropy (gaussianPDF μ σ) = (1/2) * Real.log (2 * π * exp 1 * σ^2)`; and (iv) the maximum-entropy theorem `gaussian_max_entropy : differentialEntropy f ≤ (1/2) * Real.log (2 * π * exp 1 * σ^2)` under variance bound `∫ x, x^2 * f x ≤ σ^2`.",
+    "plain": "Shannon's 1948 paper introduced differential entropy h(X) = -∫ f(x) ln f(x) dx as the continuous analogue of discrete entropy H(X) = -Σ p(x) log p(x). It is the cornerstone of continuous information theory: it underwrites channel capacity, maximum-entropy inference, and the Cramér–Rao bound. This open question asks whether the whole edifice — Gibbs inequality, translation/scale invariance, the Gaussian closed form, and the Gaussian maximum-entropy property — can be formalized in Lean 4 using Mathlib's Bochner integral and its `ProbabilityTheory.gaussianPDFReal` family.",
+    "whyMatters": [
+      "Foundational: differential entropy is the bridge between discrete information theory and continuous probability. A formal proof unlocks downstream formalization of channel capacity, rate-distortion theory, and the Asymptotic Equipartition Property for continuous sources.",
+      "Pedagogical: the proof exercises Mathlib's Bochner integral API (`integral_add_right_eq_self`, `Measure.integral_comp_div`, `integral_gaussian`, `integrable_rpow_mul_exp_neg_mul_sq`, `ProbabilityTheory.integral_gaussianPDFReal_eq_one`) more deeply than any other gallery entry.",
+      "Cross-reference: the maximum-entropy proof uses Gibbs's inequality with the Gaussian as reference density — a beautiful three-line reduction once the machinery is in place. This pattern (`gibbs_inequality_continuous` + log expansion + variance bound) generalises to other max-entropy distributions (exponential, Laplace, gamma) for follow-on OQs."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Mathlib `Real.log_le_sub_one_of_pos`: `0 < x → Real.log x ≤ x - 1` (the analytic inequality underpinning Gibbs).",
+      "Mathlib `MeasureTheory.integral_add_right_eq_self`: ∫ x, f(x + a) dx = ∫ x, f x dx (Lebesgue translation invariance).",
+      "Mathlib `MeasureTheory.Measure.integral_comp_div`: ∫ x, f(x/a) dx = |a| * ∫ x, f x dx (change of variables under division).",
+      "Mathlib `integral_gaussian`: ∫ x, exp(-b*x²) dx = √(π/b) for b > 0.",
+      "Mathlib `integrable_rpow_mul_exp_neg_mul_sq`: x^s * exp(-b*x²) is integrable for s > -1, b > 0.",
+      "Mathlib `ProbabilityTheory.integral_gaussianPDFReal_eq_one` and `integrable_gaussianPDFReal` for normalization and integrability of the NNReal-variance Gaussian PDF.",
+      "In-tree file `proofs/Proofs/ShannonEntropyOQ01.lean` (PR #8805, 2026-04-03, +PRs #8914, #8931 closure): 623 LOC, 6 public theorems, 0 sorries, 0 axioms. Builds against the lake-pinned Mathlib SHA."
+    ],
+    "open": [
+      "Multivariate extension to ℝⁿ (Gaussian with covariance matrix; uses `Matrix.det` normalization). Candidate sub-OQ `shannon-entropy-oq-01-oq-01`.",
+      "Entropy Power Inequality (Shannon 1948, Stam 1959): e^(2h(X+Y)/n) ≥ e^(2h(X)/n) + e^(2h(Y)/n) for independent X, Y. Candidate sub-OQ `shannon-entropy-oq-01-oq-02`. Open in Mathlib; classical proofs (Shannon, Stam, Lieb, Dembo–Cover–Thomas) use Fisher information and de Bruijn's identity.",
+      "Cramér–Rao bound via Fisher information / differential entropy connection (de Bruijn identity: d/dt h(X_t) = (1/2) J(X_t) where X_t = X + √t·Z). Candidate sub-OQ `shannon-entropy-oq-01-oq-03`."
+    ],
+    "goal": "YES, formalize differential entropy plus the four core theorems (Gibbs, invariance, Gaussian closed form, Gaussian max-entropy) in Lean 4. — ACHIEVED in `proofs/Proofs/ShannonEntropyOQ01.lean`."
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-03-30T17:32:58.852Z",
-    "iteration": 2,
-    "focus": "COMPLETE: All sorries eliminated. Build succeeds with 0 errors.",
+    "since": "2026-04-03T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 doc-only state-drift sync: research-side state.md + this JSON brought into alignment with verified-complete Lean file ShannonEntropyOQ01.lean (623 LOC, 6 thms, 0 sorries, 0 axioms since 2026-04-03).",
     "blockers": [],
-    "nextAction": "Done. Gallery entry verified at src/data/proofs/shannon-entropy-oq-01/ (status: verified, 0 sorries, 0 axioms).",
+    "nextAction": "Done at research-side. Gallery surface remains `formalized` until the obsolete Aristotle companion `ShannonEntropyOQ01Aristotle.lean` is dropped (its 2 stub sorries duplicate already-proved private lemmas in the main file). Companion drop is a separate ~3-file PR (delete file, regenerate `proofs/Proofs.lean`, remove from `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean:2470`, edit gallery `meta.json` additionalFiles + sorries + status).",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 0,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: All sorries eliminated. gaussian_second_moment and gaussian_quad_integrable proved using IBP via antiderivative G(x)=-x/(2b)*exp(-b*x^2) and integrable_rpow_mul_exp_neg_mul_sq.",
+    "progressSummary": "COMPLETE since PR #8805 (2026-04-03). 6 public theorems proved in proofs/Proofs/ShannonEntropyOQ01.lean (623 LOC, 0 sorries, 0 axioms): kl_divergence_continuous_nonneg, gibbs_inequality_continuous, differentialEntropy_translation_invariant, differentialEntropy_scale_equivariant, gaussianDifferentialEntropy, gaussian_max_entropy. Eight supporting private lemmas, including gaussian_second_moment proved by IBP via antiderivative G(x) = -x/(2b)·exp(-b·x²) and gaussian_quad_integrable proved via integrable_rpow_mul_exp_neg_mul_sq.",
     "builtItems": [
-      "ShannonEntropyOQ01.lean: differentialEntropy (def, line 43)",
-      "ShannonEntropyOQ01.lean: klDivergenceCts (def, line 47)",
-      "ShannonEntropyOQ01.lean: kl_term_bound_cts (lemma, line 59) — proved",
-      "ShannonEntropyOQ01.lean: kl_divergence_continuous_nonneg (theorem, line 90) — proved",
-      "ShannonEntropyOQ01.lean: gibbs_inequality_continuous (theorem, line 117) — proved",
-      "ShannonEntropyOQ01.lean: differentialEntropy_translation_invariant (theorem, line 167) — proved",
-      "ShannonEntropyOQ01.lean: gaussianPDF (def, line 210)",
-      "ShannonEntropyOQ01.lean: gaussian_max_entropy (theorem, line 239) — proved",
-      "differentialEntropy_scale_equivariant proved in ShannonEntropyOQ01.lean via integral_comp_div",
-      "gaussianPDF_eq_gaussianPDFReal helper lemma (bridges to Mathlib gaussianPDFReal)",
-      "gaussianPDF_integral_eq_one proved via ProbabilityTheory.integral_gaussianPDFReal_eq_one",
-      "gaussianPDF_integrable proved via ProbabilityTheory.integrable_gaussianPDFReal",
-      "gaussianPDF_log proved - expands log density into linear form",
-      "gaussianDifferentialEntropy proved modulo gaussian_second_moment + gaussian_quad_integrable",
-      "gaussian_second_moment proved: ∫(x-μ)²*gaussianPDF = σ² via IBP + integral_gaussian",
-      "gaussian_quad_integrable proved: via integrable_rpow_mul_exp_neg_mul_sq + comp_sub_right + const_mul",
-      "mul_exp_tendsto_zero proved: x*exp(-b*x²)→0 via elementary squeeze (no tendsto_pow_atTop needed)",
-      "gaussianDifferentialEntropy proved: h(N(μ,σ²)) = ½ln(2πeσ²) — complete with 0 sorries"
+      "ShannonEntropyOQ01.lean:43 — `differentialEntropy : (ℝ → ℝ) → ℝ` (def via Bochner integral)",
+      "ShannonEntropyOQ01.lean:47 — `klDivergenceCts : (ℝ → ℝ) → (ℝ → ℝ) → ℝ` (def)",
+      "ShannonEntropyOQ01.lean:59 — `kl_term_bound_cts : p * Real.log (p/q) ≥ p - q` (private lemma, proved)",
+      "ShannonEntropyOQ01.lean:90 — `kl_divergence_continuous_nonneg : 0 ≤ klDivergenceCts f g` (theorem, proved)",
+      "ShannonEntropyOQ01.lean:117 — `gibbs_inequality_continuous : differentialEntropy f ≤ -∫ x, f x * Real.log (g x)` (theorem, proved)",
+      "ShannonEntropyOQ01.lean:167 — `differentialEntropy_translation_invariant : differentialEntropy (fun x => f (x - c)) = differentialEntropy f` (theorem, proved via `integral_add_right_eq_self`)",
+      "ShannonEntropyOQ01.lean:197 — `differentialEntropy_scale_equivariant : differentialEntropy ((1/|a|) · f (·/a)) = differentialEntropy f + Real.log |a|` (theorem, proved via `Measure.integral_comp_div`)",
+      "ShannonEntropyOQ01.lean:257 — `gaussianPDF : ℝ → ℝ → ℝ → ℝ` (noncomputable def)",
+      "ShannonEntropyOQ01.lean:260 — `gaussianPDF_eq_gaussianPDFReal` (private bridge to `ProbabilityTheory.gaussianPDFReal`)",
+      "ShannonEntropyOQ01.lean:265 — `gaussianPDF_integral_eq_one` (private lemma, proved)",
+      "ShannonEntropyOQ01.lean:273 — `gaussianPDF_integrable` (private lemma, proved)",
+      "ShannonEntropyOQ01.lean:280 — `gaussianPDF_log : log (gaussianPDF μ σ x) = -(1/2)·log(2πσ²) - (x-μ)²/(2σ²)` (private lemma, proved)",
+      "ShannonEntropyOQ01.lean:290 — `mul_exp_tendsto_zero : Tendsto (fun x => x * exp(-b*x²)) atTop (𝓝 0)` (private lemma, proved by elementary squeeze)",
+      "ShannonEntropyOQ01.lean:335 — `gaussian_second_moment : ∫ x, (x - μ)² * gaussianPDF μ σ x = σ²` (private lemma, proved via IBP)",
+      "ShannonEntropyOQ01.lean:467 — `gaussian_quad_integrable : Integrable (fun x => (x - μ)² * gaussianPDF μ σ x)` (private lemma, proved)",
+      "ShannonEntropyOQ01.lean:489 — `gaussianDifferentialEntropy : differentialEntropy (gaussianPDF μ σ) = (1/2)·log(2πeσ²)` (theorem, proved)",
+      "ShannonEntropyOQ01.lean:532 — `gaussian_max_entropy : differentialEntropy f ≤ (1/2)·log(2πeσ²)` under `∫ x, x² f x ≤ σ²` (theorem, proved)"
     ],
     "insights": [
-      "gaussian_max_entropy follows from Gibbs inequality + log expansion: log(gaussianPDF) = -½log(2πσ²) - x²/(2σ²), then integrate and use variance bound",
-      "Gibbs inequality h(f) ≤ -∫f log g requires ∫g = 1 AND integrability of gaussianPDF",
-      "gaussianPDF 0 σ normalization: congr 1; congr 1; ring to equate -(x-0)²/(2σ²) with -(1/(2σ²))*x², since ring handles field division in Lean 4",
-      "integrability of gaussianPDF 0 σ follows from integrable_exp_neg_mul_sq with b = 1/(2σ²)",
-      "∫x, A - ∫x, B in Lean 4 parses as ∫x, (A - ∫x, B) — always use explicit parentheses (∫x, A) - (∫x, B)",
-      "differentialEntropy_scale_equivariant requires ∫f=1 hypothesis (without it the identity is false)",
-      "gaussianDifferentialEntropy requires Gaussian second moment: ∫x, x² * gaussianPDF 0 σ x = σ²",
-      "integral_comp_div is the key for scale equivariance: ∫f(x/a)dx = |a|*∫f, simp [smul_eq_mul] needed to convert • to *",
-      "Integrable.comp_div from Mathlib.MeasureTheory.Measure.Haar.NormedSpace handles integrability under scaling",
-      "gaussianPDFReal in ProbabilityTheory namespace uses NNReal variance ⟨σ²,sq_nonneg σ⟩ - bridge via NNReal.coe_mk",
-      "gaussianDifferentialEntropy proof architecture: expand log → split integral → normalization + second moment → algebra",
-      "IBP via antiderivative G(x)=-x/(2b)*exp(-b*x^2): G'(x)=x²exp(-bx²)-(1/2b)exp(-bx^2), FTC gives ∫G'=0 over ℝ → ∫x²exp = (1/2b)∫exp",
-      "Alpha-equiv issue in Eq.trans: use rw [integral_sub hint1 hint2] at h_full_zero to mutate hypothesis instead of .trans chain",
-      "pow_le_pow_left unavailable by that name in Lean4; use mul_le_mul + sq conversions instead",
-      "div_le_iff/le_div_iff may be unavailable; use field_simp + mul_le_mul_of_nonneg_right instead",
-      "tendsto_of_tendsto_of_tendsto_of_le_of_le (non-prime) expects Pi-order ≤; use prime version for Filter.Eventually",
-      "gaussianPDF_integrable: simp_rw cannot rewrite under point-free Integrable f; use funext + rw instead",
-      "squeeze_zero may be unreliable; tendsto_of_tendsto_of_tendsto_of_le_of_le' is the robust alternative"
+      "`Real.log 0 = 0` in Mathlib makes the `0 · log 0 = 0` convention automatic — no special casing needed.",
+      "Continuous Gibbs reduces to the pointwise inequality `Real.log (q/p) ≤ q/p - 1` (Mathlib `Real.log_le_sub_one_of_pos`); multiply by p, negate, integrate.",
+      "Translation invariance: rewrite `f(x-c) = (fun y => f y)((x + (-c)))` and apply `integral_add_right_eq_self` directly.",
+      "Scale equivariance requires `∫ f = 1` (without it the identity h(g) = h(f) + ln|a| is false). The key Mathlib lemma is `MeasureTheory.Measure.integral_comp_div`, with `simp only [smul_eq_mul]` to convert • to *.",
+      "Gaussian second moment `∫ x, x² exp(-bx²) = (1/(2b)) ∫ exp(-bx²)` is proved by integration by parts using the antiderivative G(x) = -x/(2b) · exp(-bx²); FTC over Ioi 0 and Iic 0 with `integral_Ioi_of_hasDerivAt_of_tendsto'` and the matching Iic lemma.",
+      "Alpha-equivalence in `Eq.trans` chains can break with `MeasureTheory.integral_sub`; rewrite the hypothesis in place: `rw [integral_sub hint1 hint2] at h_full_zero`.",
+      "`pow_le_pow_left` is renamed/moved in current Mathlib; use `mul_le_mul` plus `sq` rewrites instead.",
+      "`div_le_iff` / `le_div_iff` patterns sometimes do not match by `rw`; compute manually via `field_simp` + `mul_le_mul_of_nonneg_right`.",
+      "`tendsto_of_tendsto_of_tendsto_of_le_of_le'` (prime version) is the robust alternative to `squeeze_zero` for Filter.Eventually bounds.",
+      "Maximum-entropy proof architecture is elegant: apply Gibbs with g = `gaussianPDF 0 σ`, expand `log g = -½ log(2πσ²) - x²/(2σ²)`, use normalization + variance bound, algebra gives ½ log(2πeσ²)."
     ],
     "mathlibGaps": [
-      "pow_le_pow_left has been renamed or moved — use mul_le_mul + sq rewrites",
-      "div_le_iff pattern may not match in rw; compute manually with field_simp + mul_le_mul_of_nonneg_right"
+      "`pow_le_pow_left` renamed/moved — use `mul_le_mul` + `sq` rewrites.",
+      "`div_le_iff` rewrite-pattern coverage is incomplete; manual `field_simp` workaround documented in the file.",
+      "No Mathlib `differentialEntropy` namespace yet; this file is the natural seed for one."
     ],
-    "nextSteps": []
+    "nextSteps": [
+      "Sub-OQ candidate `-oq-01-oq-01`: multivariate differential entropy on ℝⁿ.",
+      "Sub-OQ candidate `-oq-01-oq-02`: Entropy Power Inequality (Shannon–Stam).",
+      "Sub-OQ candidate `-oq-01-oq-03`: Cramér–Rao bound via Fisher information + differential entropy (de Bruijn identity).",
+      "Aristotle companion drop (mechanic / clean-up domain): delete `ShannonEntropyOQ01Aristotle.lean` and regenerate the auto-generated `proofs/Proofs.lean`."
+    ]
   },
   "tags": [
-    "seeker-selected"
+    "seeker-selected",
+    "completed",
+    "information-theory",
+    "differential-entropy",
+    "measure-theory",
+    "gaussian",
+    "gibbs-inequality",
+    "max-entropy"
   ],
   "relatedProofs": [
     "shannon-entropy",
-    "shannon-entropy-oq-01",
     "shannon-entropy-oq-02",
-    "shannon-entropy-oq-03"
+    "shannon-entropy-oq-03",
+    "shannon-entropy-ssa"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Shannon, C. E. (1948). A Mathematical Theory of Communication. Bell System Technical Journal 27.",
+      "Cover, T. M. & Thomas, J. A. (2006). Elements of Information Theory, 2nd ed., Wiley — chapter 8 (differential entropy)."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Differential_entropy",
+      "https://en.wikipedia.org/wiki/Maximum_entropy_probability_distribution"
+    ],
+    "mathlib": [
+      "Mathlib.MeasureTheory.Integral.Bochner",
+      "Mathlib.MeasureTheory.Group.Integral (integral_add_right_eq_self)",
+      "Mathlib.MeasureTheory.Measure.Haar.NormedSpace (Measure.integral_comp_div, Integrable.comp_div)",
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral (integral_gaussian, integrable_rpow_mul_exp_neg_mul_sq, integrable_exp_neg_mul_sq)",
+      "Mathlib.Probability.Distributions.Gaussian.Real (gaussianPDFReal, integral_gaussianPDFReal_eq_one, integrable_gaussianPDFReal)",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic (Real.log_le_sub_one_of_pos)"
+    ]
   },
   "started": "2026-03-30T17:32:58.852Z",
-  "lastUpdate": "2026-04-27T00:00:00.000Z",
+  "lastUpdate": "2026-05-13T12:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -120,11 +153,11 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 624,
+      "lineCount": 623,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },
@@ -135,7 +168,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },


### PR DESCRIPTION
## Summary

Doc-only state-drift sync for `shannon-entropy-oq-01`. The Lean file `proofs/Proofs/ShannonEntropyOQ01.lean` has been **verified-complete since 2026-04-03** (6 public theorems, 0 sorries, 0 axioms, 623 LOC; closure landed in PR #8805 + #8914 + #8931), but the research-side `state.md` was never advanced past its 2026-03-30 seeker-init `NEW` stub, and the JSON's `leanFiles` sorry counts drifted away from reality (claimed 1 sorry on the OQ01.lean file that has 0; claimed 3 sorries on the companion that has 2).

This PR rewrites both research-side artifacts to match ground truth and adds a session note documenting the full drift inventory.

## Drift inventory (before → after)

| File | Field | Before | After |
|---|---|---|---|
| `research/problems/shannon-entropy-oq-01/state.md` | `Phase` | `NEW` (2026-03-30 stub) | `COMPLETED` (PR #8805 ref) |
| `…/state.md` | `Iteration` | `1` | `3` |
| `…/state.md` | `Current Focus` | "Initial exploration of the problem." | full COMPLETED summary with 6 theorem names |
| `src/data/research/problems/shannon-entropy-oq-01.json` | `status` | `"active"` | `"completed"` |
| `…json` | `title` | truncated `"...continuous dist..."` | full plain-English statement |
| `…json` | `problemStatement.formal` | `"\\text{(formal statement to be added)}"` | full formal statement with all 6 theorem signatures |
| `…json` | `problemStatement.plain` | one-sentence stub | full plain-English summary |
| `…json` | `problemStatement.whyMatters` | `[]` | 3 entries (foundational, pedagogical, cross-reference) |
| `…json` | `knownResults.proven` | `[]` | 7 entries (6 Mathlib bearers + in-tree PR #8805 file) |
| `…json` | `knownResults.open` | `[]` | 3 forward-extension candidates (ℝⁿ, EPI, Cramér–Rao) |
| `…json` | `knownResults.goal` | `""` | full goal statement |
| `…json` | `currentState.nextAction` | falsely claimed gallery is `verified, 0 sorries, 0 axioms` | corrected to acknowledge gallery is `formalized` with 2 Aristotle companion sorries pending follow-up drop |
| `…json` | `currentState.attemptCounts.currentApproach` | `2` | `0` |
| `…json` | `knowledge.builtItems` | 17 entries, no line numbers | 17 entries with file:line + proof-witness one-liner |
| `…json` | `knowledge.nextSteps` | `[]` | 4 entries (3 sub-OQ candidates + Aristotle drop) |
| `…json` | `tags` | `[\"seeker-selected\"]` | 8 tags (+`completed`, content) |
| `…json` | `references.{papers,urls,mathlib}` | all empty | 2 + 2 + 6 |
| `…json` | `lastUpdate` | `2026-04-27T00:00:00.000Z` | `2026-05-13T12:00:00.000Z` |
| `…json` | `leanFiles[ShannonEntropyOQ01.lean].sorryCount` | `1` | `0` (verified by `grep -cE`) |
| `…json` | `leanFiles[ShannonEntropyOQ01.lean].lineCount` | `624` | `623` (verified by `wc -l`) |
| `…json` | `leanFiles[ShannonEntropyOQ01Aristotle.lean].sorryCount` | `3` | `2` (verified by `grep -cE`) |

## Actual theorem inventory (`proofs/Proofs/ShannonEntropyOQ01.lean`)

| # | Theorem | Line | Proof witness |
|--|--|--|--|
| 1 | `kl_divergence_continuous_nonneg` | 90 | pointwise `kl_term_bound_cts` + `integral_mono` + ∫f=∫g=1 |
| 2 | `gibbs_inequality_continuous` | 117 | split `log(f/g) = log f - log g`, apply (1) |
| 3 | `differentialEntropy_translation_invariant` | 167 | `integral_add_right_eq_self` |
| 4 | `differentialEntropy_scale_equivariant` | 197 | `Measure.integral_comp_div` |
| 5 | `gaussianDifferentialEntropy` | 489 | expand `gaussianPDF_log` + normalization + `gaussian_second_moment` |
| 6 | `gaussian_max_entropy` | 532 | apply (2) with `g = gaussianPDF 0 σ` + variance bound |

All 6 verified at session start by reading the file in full and grepping. Eight supporting private lemmas (`kl_term_bound_cts`, `gaussianPDF_eq_gaussianPDFReal`, `gaussianPDF_integral_eq_one`, `gaussianPDF_integrable`, `gaussianPDF_log`, `mul_exp_tendsto_zero`, `gaussian_second_moment`, `gaussian_quad_integrable`) all proved.

## Files NOT touched

* `proofs/Proofs/ShannonEntropyOQ01.lean` — verified-complete; **0 LOC of Lean code change**. Sorry count unchanged at 0; axiom count unchanged at 0.
* `proofs/Proofs/ShannonEntropyOQ01Aristotle.lean` — obsolete companion (2 stub sorries duplicating proved `private lemma`s in the main file at lines 335 + 467). Drop is a separate ~3-file orthogonal PR; flagged in PR body below.
* `proofs/Proofs.lean` — auto-generated; left alone.
* `src/data/proofs/shannon-entropy-oq-01/{meta,annotations,index}.{json,ts}` — gallery surface unchanged. `meta.json` `status: \"formalized\"`, `sorries: 2`, `badge: \"original\"` are **consistent** with current Lean state (the 2 sorries live in the Aristotle companion per the `meta.sorries`-aggregates-main+companion rule).
* Sibling slugs `shannon-entropy`, `-oq-02`, `-oq-03`, `-ssa` — no cross-edits.

## Recommended follow-up: Aristotle companion drop (out of scope here)

`ShannonEntropyOQ01Aristotle.lean` declares 2 `theorem … := by sorry` stubs (`gaussian_second_moment`, `gaussian_quad_integrable`) under namespace `ShannonEntropyOQ01Aristotle`. Both statements are **already proved** in the main file as `private lemma`s. The companion was created as an Aristotle proof-search target while the main file was incomplete; after PR #8914 closed the file's last sorry, the companion became dead weight.

Dropping it would let the gallery move from `formalized` → `verified`:

1. `git rm proofs/Proofs/ShannonEntropyOQ01Aristotle.lean`
2. `./.lean/scripts/generate-proofs-imports.sh` (regenerates `proofs/Proofs.lean`)
3. Edit `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` line 2470 to drop `import Proofs.ShannonEntropyOQ01Aristotle`
4. Edit `src/data/proofs/shannon-entropy-oq-01/meta.json`: remove `\"Proofs/ShannonEntropyOQ01Aristotle.lean\"` from `additionalFiles`, `sorries: 2` → `0`, `status: \"formalized\"` → `\"verified\"`. `badge: \"original\"` stays (this **is** an original contribution; `verified` badge is for not-original verified proofs per the badge rule in CLAUDE.md).

Pure-deletion change with essentially zero build risk (no new Lean code), but warrants a Docker build to confirm before merge. Mechanic or doctor domain. Held out of this PR to keep scope tight and match the established researcher-9 doc-only COMPLETION-SYNC pattern (PRs #18753, #18791).

## Operational pool update (NOT in PR diff)

After merge, the slug's pool entry transitions from `in-progress` → `completed` via:

```bash
cd /Users/rwalters/GitHub/lean-genius && \\
  RESEARCHER_ID=researcher-1 \\
  ./scripts/research/claim-problem.sh update shannon-entropy-oq-01 completed
```

This removes the slug from `claim-random`'s candidate set. RICH-tier currently shows 531 entries; this slug's knowledge_score 38 places it deep in the depth-first range, so removing it gives a small but real signal-density improvement.

## Race-context

```
$ gh pr list --repo rjwalters/lean-genius --search \"shannon-entropy-oq-01 in:title\" --state open
(no results)
```

No open PR for this slug. Last research-side activity: PRs #8805 (2026-04-03, original proof), #8914 (2026-04-03, scale equivariance + Gaussian entropy), #8931 (2026-04-03, knowledge update). Last enrichment: #12202 (2026-04-24). No race window expected.

## Honesty assessment

**Significance**: low. The PR's mathematical content is **zero** — it is audit-trail propagation, not novel research. Operational value:

- Removes ~6 weeks of accumulated state-drift on a verified-complete slug.
- Corrects `leanFiles` sorry counts that wrongly attributed 1 sorry to the (0-sorry) main file and over-counted the companion at 3 (actual 2).
- Replaces the false `currentState.nextAction` claim of `verified, 0 sorries, 0 axioms` (gallery is actually `formalized` with `sorries: 2`).
- Surfaces 3 concrete sub-OQ candidates with explicit suggested slug IDs (`-oq-01-oq-01` ℝⁿ extension, `-oq-01-oq-02` Entropy Power Inequality, `-oq-01-oq-03` Cramér–Rao bound) for seeker prioritisation.
- Provides an explicit followable recipe for the Aristotle companion drop so a mechanic/doctor can ship the verified-promotion in a ~3-file orthogonal PR.

No fabricated value. Every claim in the corrected `builtItems` was verified by reading the actual Lean file at session start.

🤖 Generated by researcher-1