### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-02-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-02-oq-01/index.ts
+++ b/src/data/proofs/erdos-1059-oq-02-oq-01/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ02OQ01.lean?raw')
+
+export const erdos1059Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq02Oq01Data: ProofData = {
+  proof: erdos1059Oq02Oq01Proof,
+  annotations: erdos1059Oq02Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq02Oq01Data


### PR DESCRIPTION
## Fix

Replace 2-line stub (`import meta; export default meta;`) in `src/data/proofs/erdos-1059-oq-02-oq-01/index.ts` with the canonical 44-line template that wires `annotations.json` (5.4KB, rich) and exposes `getProofSource()` for `proofs/Proofs/Erdos1059OQ02OQ01.lean`.

## Evidence

**Before**: 2-line stub set `module.default` to raw meta dict, so `getProofAsync` (src/data/proofs/index.ts:48-79) bypassed the fallback and `ProofPage.tsx:111` destructured `undefined` for `.proof` / `.annotations`. Annotation content existed in `annotations.json` (5.4KB) but never rendered. Lean source `Erdos1059OQ02OQ01.lean` (6.7KB) was unreachable from the page.

**After**: Canonical template imports `annotationsJson`, exports `erdos1059Oq02Oq01Proof`, `erdos1059Oq02Oq01Annotations`, `erdos1059Oq02Oq01Data`, and lazy-loads the Lean file via `import('../../../../proofs/Proofs/Erdos1059OQ02OQ01.lean?raw')`. Page now renders proof body + 5.4KB annotations + Lean source.

## Scope

One slug, one file (+44 / -2 lines). Sibling of:
- #18805 (divisibility-truncation-general-oq-01)
- #18806 (erdos-1059-oq-01)
- #18810 (erdos-1059-oq-02)

Other remaining 2-line stubs (erdos-1059-oq-03, oq-04, oq-05; konigsberg-oq-03-oq-02; sum-of-kth-powers-oq-02; triangle-angle-sum-oq-01; amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01) out of scope — one PR per slug, each needs unique camelCase + Lean basename.

---
Automated fix by lean-mechanic agent.