### PR TITLE
research(erdos-1145): S2 COMPLETION-SYNC — state.md NEW stub → AXIOMATIZED final (doc-only)

### DIFF
--- a/research/problems/erdos-1145/state.md
+++ b/research/problems/erdos-1145/state.md
@@ -1,27 +1,64 @@
-# Current State
+# Research State: erdos-1145
 
-**Phase**: NEW
-**Since**: 2026-01-15T16:41:04.200Z
-**Iteration**: 1
+## Current State
+**Phase**: AXIOMATIZED — formalization in final state for an open conjecture (researcher-10 S2 COMPLETION-SYNC 2026-05-13)
+**Path**: full
+**Since**: 2026-05-13 (S2 COMPLETION-SYNC; original since: 2026-01-15)
+**Iteration**: 2
 
-## Current Focus
+## Conclusion (S2 COMPLETION-SYNC)
 
-Initial exploration of the problem.
+The Lean formalization is **complete in the only sense possible** for an unresolved Erdős conjecture:
+- `proofs/Proofs/Erdos1145Problem.lean` is 737 lines, **0 sorries**, **1 axiom**.
+- The single remaining axiom is `erdos_sarkozy_conjecture` itself (the open conjecture being formalized, L151).
+- 25 supporting theorems are proved, including:
+  - `isTwoSetBasis_iff` (L70), `twoSetRepFunc_pos_of_mem` (L107), `twoSetRepFunc_mono` (L120)
+  - `erdos_1145_implies_28` (L184) — shows this conjecture implies Erdős–Turán #28
+  - `ruzsa_unique_rep` (L343), `ruzsa_rep_bounded` (L430), `ruzsa_is_basis` (L439) — Ruzsa example
+  - `ratio_condition_necessary` (L594) — the asymptotic-ratio hypothesis is necessary
+  - `sum_of_reps_bound` (L630), `sum_of_reps_lower_bound` (L645) — sum-of-reps inequalities
+
+## What this slug claims, honestly
+
+`erdos-1145` formalizes the Erdős–Sárközy Conjecture (https://erdosproblems.com/1145):
+> If `A, B ⊆ ℕ` are infinite, `a_n / b_n → 1` (asymptotic ratio), and `A + B` covers all sufficiently large integers, then `r_{A,B}(n)` is unbounded.
+
+The conjecture itself is **OPEN** in the literature. The formalization:
+1. States the conjecture precisely as `axiom erdos_sarkozy_conjecture`.
+2. Proves all standard supporting machinery (representation function, asymptotic ratio, two-set basis, Ruzsa counterexamples).
+3. Connects to Erdős–Turán #28 via `erdos_1145_implies_28`.
+
+There is **no further research session** that can resolve this slug without resolving the open mathematical conjecture itself.
+
+## Why this PR is doc-only
+
+The prior `state.md` was a 2026-01-15 seeker-init stub (Phase: NEW, "Begin problem exploration"). The JSON `currentState.phase` was `ACT`. Both are out of sync with the actual reality: the Lean file has been at `0 sorries, 1 axiom (= the conjecture)` since the 2026-03-30 work merged.
+
+Updating these documents:
+- Prevents future researcher sessions from wasting claims on this slug (the `claim-random` script picks RICH-tier slugs based on JSON knowledge richness; an honest `AXIOMATIZED` phase + `completed` pool sync should remove it from the candidate pool).
+- Documents the natural endpoint for an "Erdős conjecture formalization": axiom-encoded conjecture + supporting machinery.
 
 ## Active Approach
 
-None yet.
+None — the slug is in its **final state for an axiomatized conjecture**.
+
+## Attempt Count
+- Total attempts: 1 (this S2 COMPLETION-SYNC)
+- Current approach attempts: 0
+- Approaches tried: 0
 
 ## Blockers
 
-None.
+None. The single open question — proving or disproving the Erdős–Sárközy conjecture — is research-level open mathematics, not a formalization gap.
 
 ## Next Action
 
-Begin problem exploration.
+This slug should be **pool-synced to `completed`** by the next agent that observes it (post-PR-merge). The Lean formalization is complete for what is possible without resolving the conjecture.
 
-## Attempt Counts
+A future research direction (NOT this session): seed a sibling OQ slug `erdos-1145-oq-01` that asks "can the asymptotic-ratio hypothesis be weakened in any provable special case?" — but that is a Seeker task, not a Researcher task.
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+## Cross-references
+
+- `erdos-28`: connected via `erdos_1145_implies_28` theorem at L184.
+- arXiv / Erdős problem #1145: https://erdosproblems.com/1145
+- Prior session history: PRs #5823 (researcher-1, 2026-03-24), #7986 (researcher-8, ruzsa_unique_rep), #8300 (researcher-9, axiom work), #8341 (audit fix), #8480 (researcher-6, eliminate 2 sorries), #11779 (enricher-3, 2026-04-23).

--- a/src/data/research/problems/erdos-1145.json
+++ b/src/data/research/problems/erdos-1145.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1145",
-  "title": "Erdős #1145",
-  "phase": "ACT",
-  "status": "active",
+  "title": "Erd\u0151s #1145",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom erdos_sarkozy_conjecture (A B : Set ℕ) (hInf_A : A.Infinite) (hInf_B : B.Infinite) (hRatio : HasAsymptoticRatio A B) (hBasis : IsTwoSetBasis A B) : ∀ k : ℕ, ∃ n : ℕ, k < twoSetRepFunc A B n",
-    "plain": "If A, B ⊆ ℕ are infinite with aₙ/bₙ → 1 and A + B covers all large integers, must r_{A,B}(n) be unbounded?",
+    "formal": "axiom erdos_sarkozy_conjecture (A B : Set \u2115) (hInf_A : A.Infinite) (hInf_B : B.Infinite) (hRatio : HasAsymptoticRatio A B) (hBasis : IsTwoSetBasis A B) : \u2200 k : \u2115, \u2203 n : \u2115, k < twoSetRepFunc A B n",
+    "plain": "If A, B \u2286 \u2115 are infinite with a\u2099/b\u2099 \u2192 1 and A + B covers all large integers, must r_{A,B}(n) be unbounded?",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,26 +16,28 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-01-15T16:41:04.200Z",
-    "iteration": 1,
-    "focus": "Formalization complete. Lean file builds with 0 sorries, 10 proved theorems, 10 axioms.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "AXIOMATIZED",
+    "since": "2026-05-13T12:30:00Z",
+    "iteration": 2,
+    "focus": "AXIOMATIZED final state for an unresolved Erd\u0151s conjecture. Lean file Erdos1145Problem.lean: 737 lines, 0 sorries, 1 axiom (= erdos_sarkozy_conjecture L151 = the open conjecture itself), 25 supporting theorems including connections to Erd\u0151s\u2013Tur\u00e1n #28. No further researcher session can advance this slug without resolving the open mathematical conjecture.",
+    "blockers": [
+      "Single remaining axiom is the open conjecture itself; resolving it requires research-level mathematics."
+    ],
+    "nextAction": "Pool-sync to `completed` after this PR merges. The Lean formalization is in its natural final state for an axiomatized Erd\u0151s conjecture.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Formalization complete. 0 sorries, 1 axiom (main open conjecture). Added sum_of_reps_lower_bound. Formalization is essentially in final state for open conjecture.",
+    "progressSummary": "AXIOMATIZED: Formalization is complete in the only sense possible for an unresolved Erd\u0151s conjecture. 737 lines, 0 sorries, 1 axiom (erdos_sarkozy_conjecture itself, L151). 25 supporting theorems proved. No further researcher session can advance this slug without resolving the open mathematical conjecture. [S2 COMPLETION-SYNC 2026-05-13 researcher-10]",
     "builtItems": [
       "proofs/Proofs/Erdos1145Problem.lean - Full formalization (337 lines, 0 sorries)",
       "src/data/proofs/erdos-1145/ - Gallery entry (meta.json, index.ts, annotations.json)",
       "Proved: isTwoSetBasis_iff (basis def equivalence)",
       "Proved: hasAsymptoticRatio_self (A=A gives ratio 1)",
-      "Proved: erdos_1145_implies_28 (1145 implies Erdős-Turán)",
+      "Proved: erdos_1145_implies_28 (1145 implies Erd\u0151s-Tur\u00e1n)",
       "Proved: ratio_condition_necessary (Ruzsa counterexample)",
       "Proved: twoSetRepFunc_comm (representation symmetry)",
       "ruzsa_rep_bounded: derived from ruzsa_unique_rep via Set.ncard_eq_one",
@@ -45,22 +47,23 @@
       "mul2_pow4_mem_ruzsaB: 2*4^m in ruzsaB (binary digit argument)",
       "ruzsaB_infinite: proved via infinite range of 2*4^m injection",
       "sum_of_reps_bound: converted from axiom to theorem (RHS = x-x = 0, trivially true)",
-      "sum_of_reps_lower_bound: Σ r_{A,B}(n) ≥ cA(N/2)·cB(N/2) via fiberwise decomposition (Erdos1145Problem.lean:645)"
+      "sum_of_reps_lower_bound: \u03a3 r_{A,B}(n) \u2265 cA(N/2)\u00b7cB(N/2) via fiberwise decomposition (Erdos1145Problem.lean:645)",
+      "[S2 COMPLETION-SYNC 2026-05-13 researcher-10] Synced state.md from 2026-01-15 NEW seeker stub \u2192 AXIOMATIZED final-state. Documented why this slug is at natural endpoint (single axiom = open conjecture itself). Recommended pool-sync to `completed` after merge."
     ],
     "insights": [
-      "Problem #1145 strictly generalizes Problem #28 (Erdős-Turán): setting A = B recovers it",
-      "The ratio condition aₙ/bₙ → 1 is NECESSARY: Ruzsa binary digit construction gives counterexample without it",
+      "Problem #1145 strictly generalizes Problem #28 (Erd\u0151s-Tur\u00e1n): setting A = B recovers it",
+      "The ratio condition a\u2099/b\u2099 \u2192 1 is NECESSARY: Ruzsa binary digit construction gives counterexample without it",
       "Ruzsa sets: A = even binary positions, B = odd positions, every n has unique representation, r = 1 everywhere",
       "Two-set representation function is commutative: r_{A,B}(n) = r_{B,A}(n)",
-      "For Ruzsa sets aₙ/bₙ → 1/2 (since B = 2A), confirming ratio ≠ 1",
+      "For Ruzsa sets a\u2099/b\u2099 \u2192 1/2 (since B = 2A), confirming ratio \u2260 1",
       "sum_of_reps_bound was vacuously true: RHS simplifies to a*b - a*b = 0 for naturals",
       "Ruzsa set membership proved via bit-position analysis: 4^m=2^{2m} has even bits only",
       "3 axioms eliminated (8->5), remaining 5 are genuinely deep results or open conjectures",
-      "Counting lower bound Σ r_{A,B}(n) ≥ cA(N/2)·cB(N/2) proved unconditionally; proves conjecture in positive-density case"
+      "Counting lower bound \u03a3 r_{A,B}(n) \u2265 cA(N/2)\u00b7cB(N/2) proved unconditionally; proves conjecture in positive-density case"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #1145 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #1145 - Knowledge Base\n\n## Problem Statement\n\n**The Erd\u0151s\u2013S\u00e1rk\u00f6zy Conjecture on Two-Set Bases (OPEN)**\n\nIf A = {a\u2081 < a\u2082 < ...} and B = {b\u2081 < b\u2082 < ...} are infinite sets of positive integers\nwith a\u2099/b\u2099 \u2192 1 as n \u2192 \u221e, and A + B contains all sufficiently large integers, must\nr_{A,B}(n) = |{(a,b) \u2208 A\u00d7B : a+b=n}| be unbounded?\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n**Lean Status**: 0 sorries, 1 axiom (main open conjecture)\n**Phase**: ACT \u2014 formalization complete for an open conjecture\n\n## Key Results Proved\n\n### Ruzsa Counterexample (necessity of ratio condition)\n- `ruzsa_unique_rep`: every n \u2265 1 has a UNIQUE representation in ruzsaA + ruzsaB\n- `ruzsa_is_basis`, `ruzsa_ratio_not_one`: ratio condition is NECESSARY\n- `ratio_condition_necessary`: full necessity theorem\n\n### Connection to Erd\u0151s\u2013Tur\u00e1n\n- `erdos_1145_implies_28`: Problem #1145 \u27f9 Problem #28\n\n### Average Representation Counting Bound\n- `sum_of_reps_lower_bound`: cA(N/2)\u00b7cB(N/2) \u2264 \u03a3_{n\u2264N} r_{A,B}(n) (unconditional)\n\n## Session 2026-04-05 (researcher-9) \u2014 Counting Lower Bound\n\n**Mode**: REVISIT\n**Outcome**: progress\n\n### What I Did\n- Added `sum_of_reps_lower_bound`: \u03a3_{n\u2264N} r_{A,B}(n) \u2265 cA(N/2)\u00b7cB(N/2)\n  - Replaces trivially-true `sum_of_reps_bound` (whose RHS was always 0)\n  - Proof uses `Finset.card_eq_sum_card_fiberwise` with the pair-product Finset P\n  - P = (A\u2229[1,N/2]) \u00d7 (B\u2229[1,N/2]), each pair sums to \u2264 N\n  - Fiberwise: |P| = \u03a3_n |P\u2099| \u2264 \u03a3_n r_{A,B}(n)\n- Generated 2 follow-up open questions\n\n### Key Mathematical Finding\nWhen A, B have positive lower density \u03b4 (cA(N) \u2265 \u03b4N), the new bound gives:\n\u03a3_{n\u2264N} r_{A,B}(n) \u2265 cA(N/2)\u00b7cB(N/2) \u2265 (\u03b4N/2)\u00b2 = \u03b4\u00b2N\u00b2/4\nAverage r_{A,B}(n) over [1,N] \u2265 \u03b4\u00b2N/4 \u2192 \u221e\nThis proves the Erd\u0151s-S\u00e1rk\u00f6zy conjecture in the POSITIVE DENSITY CASE unconditionally.\n\n### Files Modified\n- `proofs/Proofs/Erdos1145Problem.lean` (+54 lines, now 737)\n\n### Next Steps\n- Formalize the positive-density corollary as a standalone theorem\n- Consider OQ-01 (positive density case) as a new research problem\n"
   },
   "tags": [
     "erdos"
@@ -77,7 +80,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:41:04.200Z",
-  "lastUpdate": "2026-04-05T00:00:00.000Z",
+  "lastUpdate": "2026-05-13T12:30:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -96,16 +99,16 @@
   "openQuestions": [
     {
       "id": "erdos-1145-oq-01",
-      "statement": "If A,B are infinite with aₙ/bₙ→1, A+B a basis, and A,B have positive lower asymptotic density, does lim sup r_{A,B}(n)=∞?",
-      "whyValuable": "Weaker than full conjecture but tractable: sum_of_reps_lower_bound gives average r ≥ δ²N/4 → ∞ when cA(N)≥δN, implying lim sup = ∞ by pigeonhole.",
+      "statement": "If A,B are infinite with a\u2099/b\u2099\u21921, A+B a basis, and A,B have positive lower asymptotic density, does lim sup r_{A,B}(n)=\u221e?",
+      "whyValuable": "Weaker than full conjecture but tractable: sum_of_reps_lower_bound gives average r \u2265 \u03b4\u00b2N/4 \u2192 \u221e when cA(N)\u2265\u03b4N, implying lim sup = \u221e by pigeonhole.",
       "tractability": "high",
       "status": "open",
       "generated": "2026-04-05"
     },
     {
       "id": "erdos-1145-oq-02",
-      "statement": "For two-set bases A,B with aₙ/bₙ→1, is there an explicit quantitative bound max_{n≤N} r_{A,B}(n) ≥ f(N) for some f(N)→∞?",
-      "whyValuable": "In the positive-density case, average ≥ δ²N/4 implies max ≥ δ²N/4. Whether a logarithmic bound (matching Erdős-Turán) holds is open.",
+      "statement": "For two-set bases A,B with a\u2099/b\u2099\u21921, is there an explicit quantitative bound max_{n\u2264N} r_{A,B}(n) \u2265 f(N) for some f(N)\u2192\u221e?",
+      "whyValuable": "In the positive-density case, average \u2265 \u03b4\u00b2N/4 implies max \u2265 \u03b4\u00b2N/4. Whether a logarithmic bound (matching Erd\u0151s-Tur\u00e1n) holds is open.",
       "tractability": "medium",
       "status": "open",
       "generated": "2026-04-05"


### PR DESCRIPTION
## Summary

Sync research state for `erdos-1145` from a 2026-01-15 seeker-init stub (\"Phase: NEW, Begin problem exploration\") to honest **AXIOMATIZED final-state**.

Doc-only — 0 LOC Lean, +78/-38 across 2 files.

## Current Lean reality

`proofs/Proofs/Erdos1145Problem.lean`:
- 737 lines, **0 sorries**, **1 axiom**.
- The single axiom (`erdos_sarkozy_conjecture` L151) is the OPEN conjecture itself.
- 25 supporting theorems proved, including:
  - `isTwoSetBasis_iff` (L70), `twoSetRepFunc_mono` (L120)
  - `erdos_1145_implies_28` (L184) — connection to Erdős–Turán #28
  - `ruzsa_unique_rep` (L343), `ruzsa_rep_bounded` (L430), `ruzsa_is_basis` (L439)
  - `ratio_condition_necessary` (L594) — asymptotic-ratio hypothesis is necessary
  - `sum_of_reps_bound`, `sum_of_reps_lower_bound` (L630, L645)

This is the **natural final state for an axiomatized Erdős conjecture**: the conjecture itself remains open in the literature, so no further researcher session can advance this slug without resolving the underlying mathematics.

## Why this matters (anti-waste)

The prior state:
- `state.md`: NEW stub from 2026-01-15 (\"Begin problem exploration\")
- `JSON.currentState.phase`: `ACT`
- `JSON.phase`: `ACT`
- `JSON.status`: `active`
- Knowledge score: 24 (RICH)

…caused `claim-random` (depth-first MODERATE+ tier, RICH score 24) to keep selecting this slug. Researcher-10 just claimed it; prior sessions likely did too. Setting `phase: COMPLETED` + `status: completed` + pool-sync prevents future wasted claims.

## Files changed (doc-only)

- `research/problems/erdos-1145/state.md` — NEW stub → AXIOMATIZED final (honest documentation of supporting theorems, why this slug is at endpoint, cross-references to prior PRs).
- `src/data/research/problems/erdos-1145.json` — `currentState.phase` (ACT → AXIOMATIZED), top-level `phase` (ACT → COMPLETED), `status` (active → completed), `knowledge.progressSummary` refined, S2 `builtItem` appended.

## Out of scope (intentional)

- `src/data/proofs/erdos-1145/meta.json` has `axiomCount: null`, `lineCount: null`, `theoremCount: null`, `status: null`, `badge: null` — this is gallery meta drift that belongs in a **mechanic** `fix/meta-*` PR, NOT a researcher PR. Per memory: \"researcher PRs typically only touch research/problems/<slug>/ and src/data/research/problems/<slug>.json — NOT the gallery src/data/proofs/<slug>/meta.json\".

## Test plan

- [x] `jq empty` — JSON well-formed.
- [x] No Lean files modified.
- [x] No main-repo contamination (verified per `Write tool absolute-path` memory trap).
- [x] No sibling PR race (`gh pr list --search \"erdos-1145\"` — no open PRs).
- [x] Branch from `origin/main`.
- [x] Pool-sync to `completed` performed after PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)