### PR TITLE
Enrich sperner-simplicial-bridge-oq-01: split sections 3 → 5 (96 → 100)

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -56,18 +56,32 @@
       "summary": "Two core definitions. `topCellsOfDim K d := K.filter (fun s => s.card = d + 1)` extracts the dimension-`d` stratum of a (possibly mixed-dimension) complex via `Finset.filter`. `MixedPseudomanifold K` then asserts the pseudomanifold property *stratum by stratum*: for every dimension `d` and every `d`-element face `f`, at most 2 dimension-`d` cells contain `f`. The dimensional grading is essential because doors are dimension-graded — a codim-1 face of a `(d+1)`-simplex has cardinality `d`, so doors at different dimensions cannot pair with each other and the door-counting parity argument decomposes per stratum."
     },
     {
-      "id": "pure-to-mixed-coercion",
-      "title": "Pure → Mixed Coercion",
+      "id": "pure-stratum-identification",
+      "title": "Pure → Mixed: Stratum-Level Facts",
       "startLine": 70,
-      "endLine": 109,
-      "summary": "Three theorems showing that pure pseudomanifolds lift to the mixed predicate. `topCellsOfDim_eq_of_pure`: when `∀ s ∈ K, s.card = d + 1`, the stratum at `d` is all of `K`. Proof: unfold `topCellsOfDim` and apply `Finset.filter_eq_self.mpr`. `topCellsOfDim_eq_empty_of_pure`: under the same hypothesis, every other stratum `d' ≠ d` is empty (any cell would have cardinality both `d+1` and `d'+1`, contradicting `omega`). `MixedPseudomanifold.of_pure`: combines both — for the target dimension `d` the bound follows from the parent's `hpseudo`; for other dimensions the filter is over an empty stratum and the cardinality is 0. The lift is vacuous at strata of other dimensions, witnessing that the generalisation genuinely subsumes the parent."
+      "endLine": 91,
+      "summary": "Two `Finset`-level lemmas characterise the strata of a *pure* complex (one in which every cell has the same cardinality `d + 1`). `topCellsOfDim_eq_of_pure` (lines 74-79): under `hcard : ∀ s ∈ K, s.card = d + 1`, the dimension-`d` stratum equals `K` itself — proof unfolds `topCellsOfDim` and applies `Finset.filter_eq_self.mpr hcard`. `topCellsOfDim_eq_empty_of_pure` (lines 83-91): under the same uniform-cardinality hypothesis, every other stratum `d' ≠ d` is empty — `Finset.filter_eq_empty_iff` reduces the goal to showing no cell of cardinality `d + 1` can also have cardinality `d' + 1`, which `omega` discharges. Together these establish that pure data lives *entirely* in a single stratum, the precondition for the predicate-level lift in the next section."
     },
     {
-      "id": "per-stratum-sperner",
-      "title": "Per-Stratum Sperner via the Parent's `exists_panchromatic`",
+      "id": "pure-to-mixed-lift",
+      "title": "Pure → Mixed: Predicate-Level Lift",
+      "startLine": 93,
+      "endLine": 109,
+      "summary": "`MixedPseudomanifold.of_pure` (lines 97-109) combines the two stratum-level facts of the previous section into a predicate inclusion `Pure ⊆ Mixed`. The proof case-splits `by_cases hd : d' = d`: when `d' = d`, rewrite the stratum to `K` via `topCellsOfDim_eq_of_pure` and apply the parent's `hpseudo`; when `d' ≠ d`, rewrite the stratum to `∅` via `topCellsOfDim_eq_empty_of_pure`, simplify the door filter with `Finset.filter_empty`, and conclude `0 ≤ 2` via `Nat.zero_le _`. The vacuous behaviour at off-stratum dimensions is the structural payoff — it lets the mixed predicate's universal quantification over `d` faithfully subsume the parent without an explicit disjunction encoding the active stratum."
+    },
+    {
+      "id": "per-stratum-helpers",
+      "title": "Per-Stratum Plumbing: Helpers + `boundaryDoorCount`",
       "startLine": 111,
+      "endLine": 156,
+      "summary": "Three helpers and a `noncomputable def` package the per-stratum hypotheses that the parent's `exists_panchromatic` expects. The section opens by adding `[LinearOrder E]` to the variable context (lines 123-125) because the parent's `vertexEnum` uses `Finset.sort (· ≤ ·)`. `card_of_mem_topCellsOfDim` (lines 128-131) projects `s.card = d + 1` out of `s ∈ topCellsOfDim K d` via `(Finset.mem_filter.mp hs).2`. `hpseudo_of_mixed` (lines 134-138) specialises `MixedPseudomanifold K` at the chosen dimension `d`, yielding the per-stratum pseudomanifold hypothesis. `boundaryDoorCount` (lines 148-156) is a `noncomputable def` whose body is, by definitional unfolding, the parent's `hbdry` filter expression with `topCellsOfDim K d` substituted for `topCells` — so `Odd (boundaryDoorCount K c)` reduces *for free* to the parent's `hbdry` shape without any explicit `unfold`, `change`, or `show`."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Headline Theorem: `sperner_mixed_panchromatic_at_dim`",
+      "startLine": 158,
       "endLine": 180,
-      "summary": "Three helpers and the main theorem. `card_of_mem_topCellsOfDim` projects `s.card = d + 1` from membership in the stratum via `Finset.mem_filter.mp`. `hpseudo_of_mixed` specialises `MixedPseudomanifold K` at a chosen dimension `d`, yielding the parent's `hpseudo` hypothesis. `boundaryDoorCount` is a `noncomputable def` that, by construction, copies the parent's `hbdry` filter expression with `topCellsOfDim K d` substituted for the parent's `topCells` — so `Odd (boundaryDoorCount K c)` unfolds to the parent's `hbdry` predicate. `sperner_mixed_panchromatic_at_dim` then applies `exists_panchromatic` directly: pass `topCellsOfDim K d` as `topCells`, `(fun _ hs => card_of_mem_topCellsOfDim hs)` as `hcard`, `hpseudo_of_mixed hmixed` as `hpseudo`, and the unfolded `hbdry`. The proof body is a single term-mode application — no new mathematics is introduced, only the per-stratum bookkeeping."
+      "summary": "The file's headline (lines 170-180) is a single term-mode application of the parent's `exists_panchromatic`. Hypothesis: `MixedPseudomanifold K` and `Odd (boundaryDoorCount (d := d) K c)`. Conclusion: a panchromatic top cell exists in `topCellsOfDim K d`. Proof body passes the parent five arguments — `topCellsOfDim K d` as `topCells`, `(fun _ hs => card_of_mem_topCellsOfDim hs)` as `hcard`, `hpseudo_of_mixed hmixed` as `hpseudo`, `c`, and `hbdry` — and lets the elaborator unfold `boundaryDoorCount` to match the parent's expected shape. The proof is mechanical bookkeeping; all the mathematical content sits in the predicate definitions and lift lemmas of the previous four sections. The `section MixedSperner … end MixedSperner` block (lines 123, 182) scopes the `[LinearOrder E]` instance to this part of the file."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary
- Quality **96 → 100**. The sole sub-100 entry in the gallery (per `find-targets.ts --stats`).
- The `sections` breakdown scored **6/10** with 3 sections. Split the two over-broad sections along the Lean file's natural `/-! ## ... -/` boundaries to reach 5 sections (caps the score at 10).
- No annotations, keyInsights, openQuestions, or crossReferences touched — those were saturated by enricher-2's PR #18741 (merged 2026-05-13 11:07 UTC). Pure sections-array refactor.

## Section splits

| Before (lines) | After (lines) | Why |
|----------------|---------------|-----|
| `pure-to-mixed-coercion` 70-109 | `pure-stratum-identification` 70-91 + `pure-to-mixed-lift` 93-109 | Separates `Finset`-level facts (`topCellsOfDim_eq_of_pure`, `topCellsOfDim_eq_empty_of_pure`) from the predicate-level lift `MixedPseudomanifold.of_pure` that consumes them. |
| `per-stratum-sperner` 111-180 | `per-stratum-helpers` 111-156 + `main-theorem` 158-180 | Separates the `[LinearOrder E]` scope + three helpers + `boundaryDoorCount` plumbing from the headline `sperner_mixed_panchromatic_at_dim` payoff. |

`stratification` (54-68) is unchanged.

## Section coverage

| `id` | Lean lines |
|------|-----------|
| `stratification` | 54-68 |
| `pure-stratum-identification` | 70-91 |
| `pure-to-mixed-lift` | 93-109 |
| `per-stratum-helpers` | 111-156 |
| `main-theorem` | 158-180 |

The new section summaries each cite specific declaration line numbers and explain the structural payoff of the grouping.

## Verification
- `pnpm build` succeeded (vite build, 17.77s).
- Score recomputation: `breakdown.sections: 6 → 10`, total `96 → 100`.

## Out of scope
- `annotations.json` normalisation churn from `pnpm build` was *not* staged (restored).
- Quality rubric measures *coverage* not *depth*; entries already at 100 may still benefit from future deepening passes — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)