### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-03 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-03/index.ts
+++ b/src/data/proofs/erdos-1059-oq-03/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ03.lean?raw')
+
+export const erdos1059Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq03Data: ProofData = {
+  proof: erdos1059Oq03Proof,
+  annotations: erdos1059Oq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq03Data


### PR DESCRIPTION
## Fix

Replace 2-line stub (`import meta; export default meta;`) with canonical template that imports annotations.json and provides typed `Proof` / `Annotation` / `ProofData` exports plus a `getProofSource` loader for the Lean file.

## Evidence

**Before** (`src/data/proofs/erdos-1059-oq-03/index.ts`, 53 bytes):
\`\`\`ts
import meta from './meta.json';
export default meta;
\`\`\`

**After** (1220 bytes): canonical template — see `lebesgue-measure-oq-01-oq-01/index.ts` (PR #18764) and `triangle-angle-sum-oq-01` (PR #18749) for precedent.

## Why this matters

`src/data/proofs/index.ts:48` (`getProofAsync`) inspects `module.default` first. With the broken stub, `module.default` is the raw meta dict (truthy), so the legacy `{meta, annotations}` fallback at line 60-79 never executes — the page renders without the 5 annotations (~7KB) defined in `annotations.json`. The canonical template exposes `erdos1059Oq03Data` as the default export, which `getProofAsync` consumes directly.

## Scope

- One slug: `erdos-1059-oq-03`.
- Lean basename: `proofs/Proofs/Erdos1059OQ03.lean`.
- camelCase exports: `erdos1059Oq03Proof`, `erdos1059Oq03Annotations`, `erdos1059Oq03Data`.

Sibling slugs `erdos-1059-oq-02-oq-01`, `erdos-1059-oq-05` remain on the same broken-stub pattern and would each need a separate PR.

---
Automated fix by lean-mechanic agent.