### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-05 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-05/index.ts
+++ b/src/data/proofs/erdos-1059-oq-05/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ05.lean?raw')
+
+export const erdos1059Oq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq05Data: ProofData = {
+  proof: erdos1059Oq05Proof,
+  annotations: erdos1059Oq05Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq05Data


### PR DESCRIPTION
## Fix

Replaces 2-line `index.ts` stub (`import meta; export default meta;`) with the canonical template that imports `annotations.json` (6.1KB, rich) and exposes `getProofSource()` for the Lean file `proofs/Proofs/Erdos1059OQ05.lean`.

## Evidence

**Before**: `index.ts` was 2 lines:
```ts
import meta from './meta.json';
export default meta;
```
`module.default` evaluated to the raw meta dict — truthy, so the `getProofAsync` fallback at `src/data/proofs/index.ts:60-79` never ran, and `ProofPage.tsx:111` destructured `undefined` for `.proof` and `.annotations`. Page rendered broken despite a 6.1KB annotations.json being present.

**After**: 44-line canonical template — imports `annotationsJson`, dynamically loads `proofs/Proofs/Erdos1059OQ05.lean?raw`, exports `erdos1059Oq05Data: ProofData` as default. Page now renders the proof source and annotations.

## Scope

- One file changed: `src/data/proofs/erdos-1059-oq-05/index.ts`
- Sibling of fixes shipped in #18806 (oq-01), #18810 (oq-02), #18817 (oq-02-oq-01), #18813 (oq-04), and #18820 (oq-03).

---
Automated fix by lean-mechanic agent.