### PR TITLE
fix(mechanic): wire annotations into erdos-1059-oq-05 index.ts

### DIFF
--- a/src/data/proofs/erdos-1059-oq-05/index.ts
+++ b/src/data/proofs/erdos-1059-oq-05/index.ts
@@ -1,2 +1,44 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1059OQ05.lean?raw')
+
+export const erdos1059Oq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1059Oq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1059Oq05Data: ProofData = {
+  proof: erdos1059Oq05Proof,
+  annotations: erdos1059Oq05Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1059Oq05Data


### PR DESCRIPTION
## Fix

Replace `erdos-1059-oq-05/index.ts` 2-line stub with the canonical 44-line gallery template so the page renders proof + annotations + Lean source.

## Evidence

**Before** (2 lines, 53 bytes):
```ts
import meta from './meta.json';
export default meta;
```

`getProofAsync` (`src/data/proofs/index.ts:60-79`) sees `module.default` as a truthy raw meta dict and skips the `proof / annotations / versionInfo` fallback. `ProofPage.tsx:111` then destructures `undefined` for `.proof` and `.annotations`, so the existing **6.1KB annotations.json** (Decidable factorial compositeness content) never renders.

**After**: canonical template (same shape used by sibling slugs and PRs #17885 / #18749 / #18755) — imports `annotationsJson`, exports `erdos1059Oq05Proof / erdos1059Oq05Annotations / erdos1059Oq05Data`, wires `Erdos1059OQ05.lean?raw`.

## Scope

Single-file repair on `src/data/proofs/erdos-1059-oq-05/index.ts`. No metadata, no Lean, no annotations content changed.

Sibling mechanic PRs covering same class: #18805 (divisibility-truncation-general-oq-01), #18806 (erdos-1059-oq-01), #18810 (erdos-1059-oq-02), #18813 (erdos-1059-oq-04). Remote branch `fix/mechanic-erdos-1059-oq-03-index-stub` (mechanic-3) and PR #18815 (amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01) cover other slugs in the class.

---
Automated fix by lean-mechanic agent.