### PR TITLE
fix(mechanic): wire annotations into shannon-entropy-oq-03 index.ts

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03/index.ts
+++ b/src/data/proofs/shannon-entropy-oq-03/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/ShannonEntropySSA.lean?raw')
+
+export const shannonEntropyOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const shannonEntropyOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const shannonEntropyOq03Data: ProofData = {
+  proof: shannonEntropyOq03Proof,
+  annotations: shannonEntropyOq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default shannonEntropyOq03Data


### PR DESCRIPTION
## Fix

Replace 5-line `import meta; export { meta, annotations };` stub in `src/data/proofs/shannon-entropy-oq-03/index.ts` with the canonical 44-line template so `getProofAsync` produces a structured `ProofData` (proof + annotations) instead of treating the raw `meta` dict as the proof payload.

## Evidence

**Before** (109 bytes, 5 lines):
- `module.default` was the raw `metaJson` dict (truthy → `getProofAsync` fallback at `src/data/proofs/index.ts:60-79` never ran)
- `ProofPage.tsx:111` destructured `undefined` for `proof.proof` / `proof.annotations` / `proof.versionInfo`
- 11,454 bytes of authored `annotations.json` (`ann-ssa-context`, …) never rendered on the gallery page

**After** (1.2 KB, 44 lines, canonical template):
- Imports `annotationsJson` alongside `metaJson`
- Dynamic `leanSource = () => import('../../../../proofs/Proofs/ShannonEntropySSA.lean?raw')` matches `meta.proofRepoPath = \"Proofs/ShannonEntropySSA.lean\"`
- Exports `shannonEntropyOq03Proof`, `shannonEntropyOq03Annotations`, `shannonEntropyOq03Data` and a default `ProofData`
- Shape matches `src/data/proofs/triangle-angle-sum-oq-01/index.ts` (PR #18749, merged 2026-05-13)

## Scope

- One slug only; one-file diff (+43 / −3)
- No edits to `meta.json`, `annotations.json`, or the Lean source
- Out of scope: ≥20 other 2-line-stub slugs (`erdos-1153`, `partition-theorem-oq-03`, `cauchy-schwarz-oq-03-oq-02`, …) — separate PR per slug per memory `[Mechanic — 2-line index.ts stub gallery-wide 23-slug class]`

---
Automated fix by lean-mechanic agent.