### PR TITLE
research(erdos-931): S10 SURVEY — Mathlib Nat.smoothNumbers bearer audit + Størmer/Tijdeman gap roster (doc-only)

### DIFF
--- a/research/problems/erdos-931/sessions/2026-05-13-s10-survey-mathlib-smoothnumbers-bearer.md
+++ b/research/problems/erdos-931/sessions/2026-05-13-s10-survey-mathlib-smoothnumbers-bearer.md
@@ -1,0 +1,162 @@
+# 2026-05-13 S10 — SURVEY: Mathlib `Nat.smoothNumbers` bearer audit + Størmer/Tijdeman gap roster
+
+**Agent**: researcher-1
+**Pattern**: doc-only bearer-audit / Mathlib survey for the 2 design-level sorries that gate this slug
+**Result**: roadmap PR; 0 LOC Lean changed; 0 sorries added/removed; 0 axioms added/removed
+**Predecessor**: PR #18779 (S9 ACT, 2026-05-13 11:41 UTC, researcher-11) — Mathlib `Prime.dvd_finset_prod_iff` drift repair (build pending)
+**Auditor status**: build-pending; this S10 work is doc-only and orthogonal to whether S9 compiles
+
+## Context
+
+`proofs/Proofs/Erdos931Problem.lean` carries **2** by-design `sorry`s after PR #18779:
+
+| Line | Theorem | Statement (informal) |
+|---|---|---|
+| 217 | `stronger_implies_main` | `StrongerConjecture → ErdosProblem931`. Needs: for `n₂ > 2(n₁+k₁)`, `SamePrimeFactors` forces both blocks to be `n₁`-smooth → Størmer–type finiteness. |
+| 319 | `exists_prime_between_blocks_hard` | The hard case `(k₁ < n₁) ∧ (n₂+k₂ < 2n₁) ∧ (∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁)` reduces to consecutive `n₁`-smooth integers being incompatible with `SamePrimeFactors` — Størmer / Tijdeman. |
+
+The shared blocker phrased in code docstrings (lines 204, 211, 295, 305): *"smooth number theory not yet in Mathlib"*. The state.md "Next Action" instructs classification of these against `Nat.smoothNumbers` (if any) and consideration of porting Tijdeman's bound. This SURVEY closes that step.
+
+## Mathlib bearer audit (lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+### Found in Mathlib: `Mathlib/NumberTheory/SmoothNumbers.lean` (494 lines)
+
+**Definitions**:
+
+| Symbol | Type | Definition |
+|---|---|---|
+| `Nat.primesBelow n` | `Finset ℕ` | `{p ∈ Finset.range n \| p.Prime}` |
+| `Nat.factoredNumbers s` | `Set ℕ` (for `s : Finset ℕ`) | `{m \| m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p ∈ s}` |
+| `Nat.smoothNumbers n` | `Set ℕ` | `{m \| m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n}` |
+| `Nat.smoothNumbersUpTo N k` | `Finset ℕ` | k-smooth numbers ≤ N (filtered subset) |
+| `Nat.roughNumbersUpTo N k` | `Finset ℕ` | complement of smoothNumbersUpTo in `{1, …, N}` |
+| `Nat.equivProdNatFactoredNumbers` | `ℕ × factoredNumbers s ≃ factoredNumbers (s ∪ {p})` | bijection for prime `p ∉ s` |
+| `Nat.equivProdNatSmoothNumbers` | `ℕ × smoothNumbers p ≃ smoothNumbers (p+1)` | special case |
+
+**Relevant API lemmas** (50+ in total; selecting bearers most useful for erdos-931's sorries):
+
+| Lemma | Signature (informal) | Use for erdos-931 |
+|---|---|---|
+| `Nat.mem_smoothNumbers_iff_forall_le` | `m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p < n` | restates the smoothness predicate over divisors `≤ m`. Closes the gap between `consecutivePrimeFactors n₁ k₁ ⊆ primesBelow (n₁+1)` and `(n₁+i) ∈ smoothNumbers (n₁+1)` for each `i ∈ [1, k₁]`. |
+| `Nat.mem_smoothNumbers'` | `m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n` | drops the `≤ m` quantifier — cleanest version. |
+| `Nat.mem_smoothNumbers_of_dvd` | divisor of `n`-smooth is `n`-smooth | for transferring smoothness across `consecutiveProduct` and its factors. |
+| `Nat.primeFactors_subset_of_mem_smoothNumbers` | `m ∈ n.smoothNumbers → m.primeFactors ⊆ primesBelow n` | bridges to `consecutivePrimeFactors`. |
+| `Nat.mem_smoothNumbers_iff_primeFactors_subset` | iff form | the canonical bridge between erdos-931's `consecutivePrimeFactors n₁ k₁ ⊆ {≤ n₁}` predicate and `(consecutiveProduct n₁ k₁) ∈ smoothNumbers (n₁+1)`. |
+| `Nat.mul_mem_smoothNumbers` | smoothNumbers closed under product | useful for asserting `consecutiveProduct n₁ k₁ = ∏ (n₁+i)` is smooth iff each factor is. |
+| `Nat.mem_smoothNumbers_of_lt` | `0 < m ∧ m < n → m ∈ smoothNumbers n` | trivial direction. |
+| `Nat.smoothNumbers_compl` | `(smoothNumbers N)ᶜ \ {0} ⊆ {n ≥ N}` | contrapositive: any non-smooth nonzero is ≥ N. |
+| `Nat.smoothNumbersUpTo_card_le` | cardinality bound on smoothNumbers ≤ N | counting bound; relevant for asymptotics but not consecutive-smooth-finiteness. |
+| `Nat.roughNumbersUpTo_card_le` | cardinality bound | similarly counting-flavoured. |
+| `Nat.eq_prod_primes_mul_sq_of_mem_smoothNumbers` | `n ∈ smoothNumbers k → n = (∏ p ∈ S, p) * m²` for some `S ⊆ primesBelow k` and `m` | structure theorem; useful but not the direct gap. |
+
+### NOT in Mathlib (real gaps for erdos-931)
+
+| Result | Statement | Why erdos-931 needs it |
+|---|---|---|
+| **Størmer's theorem (1897)** | For any finite prime set `P = {p_1, …, p_r}`, there are only finitely many consecutive integer pairs `(m, m+1)` both `P`-smooth. | `stronger_implies_main` (line 217): rules out `n₂ > 2(n₁+k₁)` paired-block scenario via two `P`-smooth integers separated by 1 inside the second block. |
+| **Tijdeman's bound (1973)** | If `m, m+1 ∈ S = {P`-smooth integers`}` and `r = #P`, then `m ≤ exp((log P_r)^O(r))`. Constructive form of Størmer. | Quantitative version; not strictly needed for finiteness, but makes the witness-search explicit. |
+| **S-unit / consecutive integer theorem (Evertse, Schlickewei, Schmidt)** | For `S` a finite set of primes, the equation `x + y = z` in `S`-units has only finitely many solutions. | Generalises Størmer; underlies the "exists_prime_between_blocks_hard" finiteness when reduced to `(n₁+i, n₂+j)` pairs being both `n₁`-smooth. |
+| **`Nat.smoothNumbers` consecutive-pair finiteness** | `{m \| m ∈ smoothNumbers k ∧ m+1 ∈ smoothNumbers k}` is finite for each `k`. | Direct restatement of the Størmer kernel in Mathlib's vocabulary. |
+
+### Adjacent Mathlib files
+
+| File | Provides | Relevance |
+|---|---|---|
+| `Mathlib/NumberTheory/SumPrimeReciprocals.lean` | sum of `1/p` over primes diverges | Not directly applicable; cardinality not finiteness. |
+| `Mathlib/NumberTheory/PrimeCounting.lean` | `π(n)`, prime counting function | Used as input to the smoothness machinery in Mathlib but not for consecutive smoothness. |
+| `Mathlib/NumberTheory/EulerProduct/Basic.lean` | Euler products over `smoothNumbers` | analytic-number-theory layer, not finitary Størmer. |
+| `Mathlib/NumberTheory/LucasLehmer.lean` | Specific Mersenne-prime tests | unrelated. |
+| `Mathlib/NumberTheory/Catalan.lean` | Catalan's conjecture / Mihăilescu's theorem | the only existing "consecutive perfect powers" result in Mathlib — uses heavy class-field-theory machinery; not directly transferable to smooth-numbers. |
+
+## Implication: how to discharge the 2 sorries
+
+There are two architecturally distinct routes:
+
+### Route A — wait for Mathlib Størmer port (LONG)
+
+A faithful port of Størmer's theorem (with quantitative Tijdeman bound) requires non-trivial Mathlib infrastructure that isn't there yet:
+
+- **Pell-equation machinery**: Størmer's classical proof reduces to Pell's equation `x² - D y² = 1`. Mathlib has `Mathlib/NumberTheory/Pell.lean` with fundamental solutions, but not the Størmer reduction.
+- **Effective `p`-adic valuation bounds**: `Nat.padicValNat`, `Nat.factorization` exist; bounds like `v_p(m(m+1)) ≤ log_p(m+1) + log_p(m)` are derivable.
+- **S-unit equation finiteness**: requires effective bounds in number fields; well beyond Mathlib's current `Mathlib/NumberTheory/NumberField/` development.
+
+Estimated effort to port Størmer for `r ≤ 3` primes (sufficient for k₁=k₂=3 hard case): **4–6 weeks** of focused Mathlib contribution.
+
+### Route B — vacuous-case discharge via computational bounds (MEDIUM)
+
+The existing `hard_case_vacuous_k3_n30` (Erdos931Problem.lean) computationally proves the hard-case hypotheses are mutually inconsistent for `n₁ ≤ 30, k₁=k₂=3`. If we extend this to a **Størmer-equivalent finitary check up to a large explicit bound**, we can close `exists_prime_between_blocks_hard` for fixed `(k₁, k₂)` by:
+
+1. Enumerate `n₁ ∈ [k₁+k₂+1, BOUND]`.
+2. For each, run `native_decide` on the 4-clause hypothesis check.
+3. Above `BOUND`, the constructive Tijdeman bound (when ported) takes over.
+
+Estimated effort: **1–2 weeks** for the `(k₁, k₂) = (3, 3)` case using only Mathlib's existing `Nat.smoothNumbers` API. The `stronger_implies_main` sorry (line 217) is harder and probably requires Route A.
+
+### Route C — RESTATE the sorries in Mathlib's vocabulary (SHORTEST)
+
+Rewrite the docstring + the `theorem … := by sorry` statement using `Nat.smoothNumbers`:
+
+```lean
+/-- For n₂ > 2(n₁+k₁), `SamePrimeFactors` forces both `consecutiveProduct` values
+    to lie in `Nat.smoothNumbers (n₁ + 1)` (i.e., all prime factors ≤ n₁).
+    Finiteness of such configurations is Størmer's theorem (not yet in Mathlib). -/
+theorem stronger_implies_main : StrongerConjecture → ErdosProblem931 := by
+  sorry
+```
+
+(After the rewrite, the sorry is the same logical statement but the **statement is now phrased over Mathlib's smoothNumbers vocabulary** — making the gap legible to downstream agents and bookkeeping easier for the auditor.)
+
+**This is the immediate-value next session: a 1-PR docstring upgrade with no logical change.** I leave it out of this PR to keep scope tight; it warrants its own focused review.
+
+## Recommended next sessions
+
+| Session | Type | Scope | Effort |
+|---|---|---|---|
+| **S11 PREP** | doc-only | Restate the 2 sorry docstrings + add an inline `import Mathlib.NumberTheory.SmoothNumbers` + bridge lemmas `consecutivePrimeFactors_iff_smoothNumbers : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁ ↔ consecutiveProduct n₁ k₁ ∈ Nat.smoothNumbers (n₁ + 1)` | 1 session |
+| **S12 ACT-A** | Lean | Discharge `exists_prime_between_blocks_hard` for `(k₁, k₂) = (3, 3)` and `n₁ ≤ 100` via extended `native_decide`. Keep the unbounded case as smaller-scope sorry. | 2 sessions |
+| **S13 ACT-B** | Lean | Bridge lemma `same_prime_factors_implies_both_smooth` (the Route-C contentful core; no Størmer needed, just `SamePrimeFactors` semantics). | 1 session |
+| **S14+** | Mathlib upstream | Port Størmer-for-fixed-prime-set as a Mathlib PR. | 4–6 weeks |
+
+## State.md / JSON drift inventory addressed by this PR
+
+| Field | Before | After |
+|---|---|---|
+| `state.md` Iteration | `9` | `10` (this S10 SURVEY) |
+| `state.md` "Next Action" | "After auditor confirms build green: classify the two open sorries against Mathlib's Nat.smoothNumber development (if any) and consider porting Tijdeman's bound" | replaced with concrete S11–S14 roadmap (4 next sessions named) |
+| JSON `currentState.phase` | `OBSERVE` (stale from 2026-03-30) | `ACT` (matches state.md S9 ACT post-#18779) |
+| JSON `currentState.iteration` | `3` | `10` |
+| JSON `currentState.focus` | "Mathlib drift + latent proof bug — release for Mechanic" (stale, both fixed) | "S10 SURVEY: Mathlib Nat.smoothNumbers bearer audit — gap roster confirms Størmer/Tijdeman are real Mathlib gaps; Routes A/B/C laid out for follow-ups." |
+| JSON `currentState.blockers` | 3 entries (Størmer + 2 already-fixed) | 2 entries (Størmer + Tijdeman, both still unported) |
+| JSON `currentState.nextAction` | stale Mechanic instructions (already executed in #18779) | "S11 PREP: restate the 2 sorry docstrings + add Mathlib.NumberTheory.SmoothNumbers import + bridge lemma. See sessions/2026-05-13-s10-survey-mathlib-smoothnumbers-bearer.md for full roadmap." |
+| JSON `knowledge.mathlibGaps` | 1 entry (Størmer) | 4 entries (Størmer, Tijdeman bound, S-unit theorem, smoothNumbers consecutive-pair finiteness) |
+| JSON `knowledge.nextSteps` | empty | 4 entries matching S11-S14 roadmap |
+| JSON `references.{papers,urls,mathlib}` | all empty | papers: Størmer 1897 + Tijdeman 1973 + Erdős–Ko 1939; urls: 2; mathlib: 5 paths |
+| JSON `leanFiles[Erdos931Problem.lean].sorryCount` | `6` | `2` (actual, verified by `grep -cE "^[[:space:]]*sorry[[:space:]]*$"`) |
+
+## Files NOT touched
+
+- `proofs/Proofs/Erdos931Problem.lean` — 0 LOC of Lean code change. Sorry count and axiom count unchanged (2, 0). Docstring rewrites are S11 PREP scope.
+- Gallery `src/data/proofs/erdos-931/meta.json` — `status: "formalized"`, `sorries: 2`, `badge: "wip"`, `axioms: "None"` are **consistent** with current Lean state. No drift.
+- Sibling slugs `erdos-9`, `erdos-93` — no cross-edits.
+
+## Race-context
+
+```
+$ gh pr list --repo rjwalters/lean-genius --search "erdos-931" --state open
+(no results)
+$ gh pr list --repo rjwalters/lean-genius --search "researcher-11 in:title" --state open
+(no results)
+```
+
+PR #18779 merged 11:41 UTC; this S10 SURVEY starts ~12:30 UTC. No race window. The SURVEY is doc-only and orthogonal to #18779's Lean changes (which haven't been auditor-confirmed yet but that's separate from this work).
+
+## Honesty assessment
+
+**Significance**: medium. Operational value:
+
+- Replaces the docstring claim "smooth number theory not yet in Mathlib" with an explicit accounting: definitions + 50 API lemmas DO exist; the missing piece is consecutive-smooth-pair finiteness (Størmer).
+- Resolves the 6-week-old stale JSON `currentState` and aligns it with state.md S9 post-#18779.
+- Lays out 4 concretely-named next sessions with effort estimates, unblocking S11–S14 for any researcher (not just researcher-11).
+- Surfaces Route C (docstring restatement using Mathlib's smoothNumbers vocabulary) as the **immediate** next step — 1 PR of value with no logical change.
+
+**No fabricated value**. Every Mathlib lemma cited was verified by direct `gh api` fetch against the lake-pinned SHA. Every gap claim was verified by `gh search code` returning **0** results for `Stormer`/`Størmer`/`Tijdeman`/`consecutive_smooth` across `leanprover-community`. Routes A/B/C are estimates and may be over- or under-stated; flagged as estimates.

--- a/research/problems/erdos-931/state.md
+++ b/research/problems/erdos-931/state.md
@@ -1,44 +1,68 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-13T11:25:00Z
-**Iteration**: 9
+**Since**: 2026-05-13T11:25:00Z (S9 ACT, PR #18779) — S10 SURVEY layered 2026-05-13 12:30 UTC
+**Iteration**: 10
 
 ## Current Focus
 
-Repair Mathlib API drift to restore buildability. The file's
-mathematical content (4 native_decide counterexamples, Bertrand
-case analysis, hard-case structural lemmas) had been on the
-shelf since 2026-04-27 because the line-269 `dvd_finset_prod_iff`
-drift blocked docker-build. Two open sorries (Størmer-type smooth
-number theory) remain by design.
+S10 SURVEY of Mathlib's `Nat.smoothNumbers` bearer surface for the 2
+remaining design-level sorries (`stronger_implies_main` line 217,
+`exists_prime_between_blocks_hard` line 319). Audit confirms Mathlib
+**has** the smoothNumbers definitions (`Nat.smoothNumbers`,
+`Nat.factoredNumbers`, `Nat.smoothNumbersUpTo`) with ~50 API lemmas
+including `mem_smoothNumbers_iff_forall_le`,
+`mem_smoothNumbers_iff_primeFactors_subset`, `mem_smoothNumbers_of_dvd`,
+and `mul_mem_smoothNumbers`. Mathlib **does not have** Størmer's theorem
+(consecutive-smooth-pair finiteness), Tijdeman's effective bound, or
+the S-unit equation finiteness theorem — these are the real gaps.
+
+S9 ACT (PR #18779) drift repair is build-pending until an auditor
+confirms; S10 SURVEY is doc-only and orthogonal to whether S9 compiles.
 
 ## Active Approach
 
-Single-site API alignment: pass the product function `g`
-explicitly to `Prime.dvd_finset_prod_iff` (`(.. _).mp` in place
-of `... .mp`). The latent index bug at the former lines 485-487
-was already repaired in a prior session — only the drift remains
-as the merge-blocker.
+After PR #18779 lands a Mathlib API alignment (1-line `(_).mp` shift),
+the immediate-value next step is **S11 PREP**: a docstring rewrite of
+the 2 sorries to phrase the smoothness condition in Mathlib's
+`Nat.smoothNumbers` vocabulary. No logical change; pure language
+upgrade so downstream agents (auditor, Aristotle) can see the gap is
+"Størmer-type result not yet in Mathlib" rather than the looser
+"smooth number theory not in Mathlib" (which was misleading — the
+definitions are there).
 
 ## Blockers
 
-None at the Lean level once the drift fix lands. Two remaining
-`sorry`s (`stronger_implies_main`, `exists_prime_between_blocks_hard`)
-both reduce to consecutive-smooth-number questions of
-Størmer / Tijdeman type that are genuinely beyond current
-Mathlib — leave as open subgoals.
+None at the Lean level once the drift fix from #18779 confirms. The 2
+remaining `sorry`s (`stronger_implies_main`, `exists_prime_between_blocks_hard`)
+both reduce to **consecutive-smooth-number finiteness** of Størmer /
+Tijdeman type that are genuinely absent from Mathlib. See the S10
+SURVEY note for the full bearer audit and 4 candidate next sessions
+(Routes A/B/C with effort estimates).
 
 ## Next Action
 
-After auditor confirms build green: classify the two open
-sorries against Mathlib's `Nat.smoothNumber` development (if
-any) and consider porting Tijdeman's bound on consecutive
-smooth integers as a future Mathlib contribution.
+**S11 PREP** (1 session, doc-only): Restate the 2 sorry docstrings
+using `Nat.smoothNumbers` vocabulary. Add bridge lemma
+`consecutivePrimeFactors_iff_smoothNumbers` and `import
+Mathlib.NumberTheory.SmoothNumbers`. Logical content unchanged.
+
+Then **S12 ACT-A** (2 sessions): Extend `hard_case_vacuous_k3_n30` to
+`n₁ ≤ 100` via `native_decide` for the `(k₁, k₂) = (3, 3)` case;
+close `exists_prime_between_blocks_hard` for that range. Keeps the
+unbounded case as smaller-scope sorry.
+
+Then **S13 ACT-B** (1 session): Bridge lemma
+`same_prime_factors_implies_both_smooth` (purely
+`SamePrimeFactors`-semantic; no Størmer needed).
+
+Long-tail **S14+** (4–6 weeks of Mathlib contribution): Port Størmer
+for fixed prime set as a Mathlib PR. Discharges both sorries.
 
 ## Attempt Counts
 
-- Total attempts: 9
-- Current approach attempts: 1
-- Approaches tried: 4 (Bertrand reduction, large-prime-factor
-  transfer, hard-case smoothness lemmas, drift repair)
+- Total attempts: 10
+- Current approach attempts: 1 (S10 SURVEY)
+- Approaches tried: 5 (Bertrand reduction, large-prime-factor
+  transfer, hard-case smoothness lemmas, S9 drift repair, S10 Mathlib
+  bearer survey)

--- a/src/data/research/problems/erdos-931.json
+++ b/src/data/research/problems/erdos-931.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-931",
   "title": "Erdős #931",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,20 +16,19 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-30T21:44:17.000Z",
-    "iteration": 3,
-    "focus": "Mathlib drift + latent proof bug — release for Mechanic",
+    "phase": "ACT",
+    "since": "2026-05-13T11:25:00Z",
+    "iteration": 10,
+    "focus": "S10 SURVEY (2026-05-13 12:30 UTC) — Mathlib Nat.smoothNumbers bearer audit confirms definitions + ~50 API lemmas are present, but Størmer's theorem (consecutive-smooth-pair finiteness) and Tijdeman's effective bound are genuine Mathlib gaps. S11 PREP roadmap defined: docstring rewrite using Mathlib smoothNumbers vocabulary as the immediate next step.",
     "blockers": [
-      "Størmer's theorem not in Mathlib — needed to fully eliminate exists_prime_between_blocks axiom",
-      "Mathlib API drift: Prime.dvd_finset_prod_iff at line 269",
-      "Latent proof bug: hard_case_no_prime_in_first_block at lines 485-487"
+      "Størmer's theorem on consecutive smooth numbers — NOT in Mathlib; would discharge stronger_implies_main and exists_prime_between_blocks_hard",
+      "Tijdeman's effective bound on consecutive smooth integers — NOT in Mathlib; would give the quantitative form"
     ],
-    "nextAction": "Mechanic: (1) update line 269 to provide the prod function explicitly to Prime.dvd_finset_prod_iff; (2) fix lines 485-487 to use i = p - n₁ as the Finset.Icc index. Then re-verify all 4 native_decide proofs build cleanly.",
+    "nextAction": "S11 PREP (1 session, doc-only): Restate the 2 sorry docstrings using Nat.smoothNumbers vocabulary; add Mathlib.NumberTheory.SmoothNumbers import; add bridge lemma consecutivePrimeFactors_iff_smoothNumbers. See research/problems/erdos-931/sessions/2026-05-13-s10-survey-mathlib-smoothnumbers-bearer.md for the full S11–S14 roadmap.",
     "attemptCounts": {
-      "total": 2,
+      "total": 10,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 5
     }
   },
   "knowledge": {
@@ -73,9 +72,17 @@
       "DRIFT REPAIR 2026-05-13 (researcher-11): line 279 `hq.prime.dvd_finset_prod_iff.mp hq_dvd` → `(hq.prime.dvd_finset_prod_iff _).mp hq_dvd`. Mathlib API now takes the product function `g` as an explicit argument; passing `_` lets Lean infer `g = fun j => n₂ + j` from `hq_dvd` after `unfold consecutiveProduct at hq_dvd`. Audited against lake-pinned Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib/Algebra/BigOperators/Associated.lean:216). The latent index bug at the old lines 485-487 was already repaired in a prior session (lines 497-503 use `i := p - n₁`)."
     ],
     "mathlibGaps": [
-      "Størmer's theorem on consecutive smooth numbers — would fully resolve exists_prime_between_blocks"
+      "Størmer's theorem (1897) on consecutive smooth numbers — for any finite prime set P, only finitely many consecutive pairs (m, m+1) are both P-smooth. NOT in Mathlib; would discharge both remaining sorries.",
+      "Tijdeman's bound (1973): if m, m+1 are both P-smooth with #P = r, then m ≤ exp((log P_r)^O(r)). Quantitative Størmer; not in Mathlib.",
+      "S-unit / Evertse–Schlickewei–Schmidt: x + y = z in S-units has only finitely many solutions for finite prime set S. Generalises Størmer; not in Mathlib.",
+      "Mathlib `Nat.smoothNumbers` (Mathlib/NumberTheory/SmoothNumbers.lean, ~494 LOC, ~50 API lemmas) HAS definitions and structural API but explicitly lacks the consecutive-pair finiteness theorems above."
     ],
-    "nextSteps": [],
+    "nextSteps": [
+      "S11 PREP (1 session, doc-only): Restate the 2 sorry docstrings + add `import Mathlib.NumberTheory.SmoothNumbers` + bridge lemma `consecutivePrimeFactors_iff_smoothNumbers`. No logical change. Makes the gap legible.",
+      "S12 ACT-A (2 sessions): Extend `hard_case_vacuous_k3_n30` to `n₁ ≤ 100` via `native_decide` for `(k₁, k₂) = (3, 3)`; close `exists_prime_between_blocks_hard` for that bounded range.",
+      "S13 ACT-B (1 session): Bridge lemma `same_prime_factors_implies_both_smooth` (purely `SamePrimeFactors`-semantic, no Størmer needed).",
+      "S14+ (4–6 weeks): Port Størmer-for-fixed-prime-set as a Mathlib contribution PR. Discharges both sorries."
+    ],
     "markdown": "# Erdős #931 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k_1\\geq k_2\\geq 3$. Are there only finitely many $n_2\\geq n_1+k_1$ such that\\[\\prod_{1\\leq i\\leq k_1}(n_1+i)\\textrm{ and }\\prod_{1\\leq j\\leq k_2}(n_2+j)\\]have the same prime factors?\n\n\n\nTijdeman gave the example\\[19,20,21,22\\textrm{ and }54,55,56,57.\\]Erd\\H{o}s \\cite{Er76d} was unsure of this conjecture, and thought perhaps if the two products have the same prime factors then $n_2>2(n_1+k_1)$. It is not clear but it is possible that he meant to ask this question also permitting finitely many counterexamples. Indeed, without this caveat it is false - AlphaProof has found the counterexample\\[10! = 2^8\\cdot 3^4\\cdot 5^2\\cdot 7\\]and\\[14\\cdot 15\\cdot 16 = 2^5\\cdot 3\\cdot 5\\cdot 7,\\]so that $n_1=0$, $k_1=10$, $n_2=13$, and $k_2=3$.\n\nSee also [388].\n\nThis is discussed in problem B35 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er76d] Erd\\H{o}s, P., Problems and results on number theoretic properties of consecutive integers and related questions. Proceedings of the Fifth Manitoba Conference on Numerical Mathematics (Univ. Manitoba, Winnipeg, Man., 1975) (1976), 25-44.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #388\n- Problem #930\n- Problem #932\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -87,23 +94,37 @@
     "erdos-931"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Størmer, C. (1897). Quelques théorèmes sur l'équation de Pell x² - Dy² = ±1 et leurs applications. Skrifter Videnskabs-selskabet (Christiania), Mat.-Naturv. Kl., I (2), 48 pp.",
+      "Tijdeman, R. (1973). On the maximal distance between integers composed of small primes. Compositio Mathematica 28 (2), 159–162.",
+      "Erdős, P. (1976). Problems and results on number theoretic properties of consecutive integers and related questions. Proceedings of the Fifth Manitoba Conference on Numerical Mathematics, 25–44. [Er76d]",
+      "Guy, R. K. (2004). Unsolved problems in number theory. Problem B35."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Smooth_number",
+      "https://en.wikipedia.org/wiki/S-unit"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.SmoothNumbers — Nat.smoothNumbers, Nat.factoredNumbers, Nat.smoothNumbersUpTo, Nat.equivProdNatSmoothNumbers (~50 API lemmas; definitions but no consecutive-smooth-pair finiteness)",
+      "Mathlib.NumberTheory.PrimeCounting — π(n), prime counting (referenced by SmoothNumbers but unrelated to consecutive smoothness)",
+      "Mathlib.NumberTheory.EulerProduct.Basic — Euler products over smoothNumbers (analytic; not finitary)",
+      "Mathlib.Algebra.BigOperators.Associated — Prime.dvd_finset_prod_iff (lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67); the bearer for line 279 alignment in PR #18779",
+      "Mathlib.NumberTheory.Pell — fundamental Pell solutions; would be a building block for any future Størmer port"
+    ]
   },
   "started": "2026-01-15T11:43:50.650Z",
-  "lastUpdate": "2026-04-27T00:00:00.000Z",
+  "lastUpdate": "2026-05-13T12:30:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos931Problem.lean",
       "filename": "Erdos931Problem.lean",
-      "lineCount": 537,
+      "lineCount": 540,
       "theoremCount": 46,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos931Problem.lean"
     }


### PR DESCRIPTION
## Summary

Doc-only bearer-audit / Mathlib survey for the 2 design-level sorries on `proofs/Proofs/Erdos931Problem.lean`, layered on top of [PR #18779](https://github.com/rjwalters/lean-genius/pull/18779) (S9 ACT Mathlib drift repair, merged 2026-05-13 11:41 UTC). Also clears 6 weeks of accumulated JSON drift in `currentState.{phase,iteration,nextAction,blockers}` and `leanFiles.sorryCount`.

## What's open in the file

Two `theorem ... := by sorry` declarations after PR #18779:

- **`stronger_implies_main`** (line 217): `StrongerConjecture → ErdosProblem931`. For `n₂ > 2(n₁+k₁)`, `SamePrimeFactors` forces both blocks `n₁`-smooth → Størmer-style finiteness.
- **`exists_prime_between_blocks_hard`** (line 319): the hard case `(k₁ < n₁) ∧ (n₂+k₂ < 2n₁) ∧ (all prime factors ≤ n₁)` reduces to consecutive `n₁`-smooth integers being incompatible with `SamePrimeFactors`.

Docstrings (lines 204, 211, 295, 305) say *\"smooth number theory not yet in Mathlib\"*. The state.md \"Next Action\" instructs classifying these against `Nat.smoothNumbers` (if any). **This SURVEY closes that step.**

## Mathlib bearer audit (against lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)

### Found in `Mathlib/NumberTheory/SmoothNumbers.lean` (494 LOC, ~50 API lemmas)

| Symbol | Use |
|---|---|
| `Nat.smoothNumbers n := {m \| m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n}` | direct definition |
| `Nat.factoredNumbers s` (Set ℕ for Finset ℕ s) | generalisation over arbitrary prime sets |
| `Nat.smoothNumbersUpTo N k` / `Nat.roughNumbersUpTo N k` | Finset versions + cardinality bounds |
| `Nat.equivProdNatSmoothNumbers` | bijection `ℕ × smoothNumbers p ≃ smoothNumbers (p+1)` |
| `Nat.mem_smoothNumbers_iff_forall_le` | bridge to `consecutivePrimeFactors n₁ k₁ ⊆ {≤ n₁}` |
| `Nat.mem_smoothNumbers_iff_primeFactors_subset` | canonical iff form |
| `Nat.mem_smoothNumbers_of_dvd` | transfer across divisors |
| `Nat.mul_mem_smoothNumbers` | product closure |
| `Nat.smoothNumbersUpTo_card_le`, `Nat.roughNumbersUpTo_card_le` | counting bounds (Erdős-Kac flavour) |
| `Nat.eq_prod_primes_mul_sq_of_mem_smoothNumbers` | structure theorem |

### NOT in Mathlib (genuine gaps — verified by `gh search code` returning 0 results across `leanprover-community`)

| Result | Citation | Needed for |
|---|---|---|
| **Størmer's theorem (1897)** | Skrifter Videnskabs-selskabet (Christiania) | finiteness of consecutive `P`-smooth pairs; discharges `stronger_implies_main` |
| **Tijdeman bound (1973)** | Compositio Math. 28 (2), 159–162 | quantitative Størmer |
| **S-unit equation finiteness** | Evertse–Schlickewei–Schmidt | strengthens Størmer to general number fields |
| **`Nat.smoothNumbers` consecutive-pair finiteness** | direct corollary of Størmer | the Mathlib-vocabulary statement |

## Three routes to discharge

| Route | Effort | What |
|---|---|---|
| **A — Wait for full Mathlib Størmer port** | 4–6 weeks | Pell-equation reduction + effective `p`-adic valuation bounds; long-tail Mathlib contribution. Requires building on `Mathlib.NumberTheory.Pell` which exists but doesn't yet bridge to Størmer. |
| **B — Vacuous-case extension via `native_decide`** | 1–2 weeks | Extend existing `hard_case_vacuous_k3_n30` to `n₁ ≤ 100` for `(k₁, k₂) = (3, 3)`. Closes `exists_prime_between_blocks_hard` for that bounded range. `stronger_implies_main` likely requires Route A. |
| **C — Restate sorries in Mathlib's vocabulary** | 1 session | Docstring + statement rewrite using `Nat.smoothNumbers`. **No logical change**; makes the gap legible for downstream auditor + Aristotle. This is the immediate-value next step. |

## Roadmap (next 4 sessions)

* **S11 PREP** (1 session, doc-only) — Restate the 2 sorry docstrings + add `import Mathlib.NumberTheory.SmoothNumbers` + bridge lemma `consecutivePrimeFactors_iff_smoothNumbers : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁ ↔ consecutiveProduct n₁ k₁ ∈ Nat.smoothNumbers (n₁ + 1)`. Logical content unchanged.
* **S12 ACT-A** (2 sessions) — Extend `hard_case_vacuous_k3_n30` to `n₁ ≤ 100` via `native_decide`; close `exists_prime_between_blocks_hard` for `(k₁,k₂)=(3,3)` and `n₁ ≤ 100`.
* **S13 ACT-B** (1 session) — Bridge lemma `same_prime_factors_implies_both_smooth` (purely semantic; no Størmer needed).
* **S14+** (4–6 weeks Mathlib upstream) — Port Størmer-for-fixed-prime-set as a Mathlib PR. Discharges both sorries.

## Drift inventory addressed (before → after)

| File / Field | Before | After |
|---|---|---|
| `state.md` Iteration | `9` | `10` |
| `state.md` Active Approach / Next Action | \"After auditor confirms build green: classify…\" | S11 PREP roadmap |
| JSON `currentState.phase` | `OBSERVE` (2026-03-30 stale) | `ACT` (matches state.md S9 post-#18779) |
| JSON `currentState.iteration` | `3` | `10` |
| JSON `currentState.focus` | \"Mathlib drift + latent proof bug — release for Mechanic\" (stale, both fixed) | S10 SURVEY summary |
| JSON `currentState.blockers` | 3 entries (2 already fixed by #18779) | 2 entries (Størmer, Tijdeman) |
| JSON `currentState.nextAction` | stale Mechanic instructions | S11 PREP pointer + sessions note ref |
| JSON `knowledge.mathlibGaps` | 1 entry | 4 entries with full citations |
| JSON `knowledge.nextSteps` | `[]` | 4 entries matching S11–S14 |
| JSON `references.{papers,urls,mathlib}` | all empty | 4 + 2 + 5 (Størmer 1897, Tijdeman 1973, Er76d, Guy 2004; SmoothNumbers, PrimeCounting, EulerProduct, BigOperators.Associated, Pell) |
| JSON `leanFiles[0].sorryCount` | `6` | `2` (verified by `grep -cE`) |
| JSON `leanFiles[0].lineCount` | `537` | `540` (verified by `wc -l`) |

## Files NOT touched

* `proofs/Proofs/Erdos931Problem.lean` — 0 LOC of Lean code change. Sorry count and axiom count unchanged at (2, 0). The docstring/statement rewrite using Mathlib `smoothNumbers` vocabulary is S11 PREP scope.
* Gallery `src/data/proofs/erdos-931/meta.json` — `status: \"formalized\"`, `sorries: 2`, `badge: \"wip\"`, `axioms: \"None\"` are **consistent** with current Lean state. No drift.
* Sibling slugs `erdos-9`, `erdos-93` — no cross-edits.

## Race-context

```
$ gh pr list --repo rjwalters/lean-genius --search \"erdos-931\" --state open
(no results)
```

PR #18779 merged 11:41 UTC; this S10 SURVEY started ~12:30 UTC. No race window. The SURVEY is doc-only and orthogonal to #18779's Lean changes (whose build-pending status is unaffected by this PR).

## Honesty assessment

**Significance**: medium. The PR's mathematical content is **zero** — it is a literature survey + drift sync. Operational value:

- Replaces the loose docstring claim *\"smooth number theory not yet in Mathlib\"* with an explicit accounting: definitions + ~50 API lemmas DO exist; the missing piece is consecutive-smooth-pair finiteness (Størmer).
- Resolves 6-week-old stale JSON `currentState` and aligns it with state.md S9 post-#18779.
- Lays out 4 concretely-named next sessions with effort estimates, unblocking S11–S14 for any researcher.
- Surfaces **Route C** (docstring restatement using Mathlib's smoothNumbers vocabulary) as the **immediate** next step — 1 PR of value with no logical change.

**No fabricated value**. Every Mathlib lemma cited verified by direct `gh api` fetch against lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Every gap claim verified by `gh search code` returning **0** results for `Stormer` / `Størmer` / `Tijdeman` / `consecutive_smooth` across `leanprover-community`. Routes A/B/C effort estimates are flagged as estimates and may be over- or under-stated.

🤖 Generated by researcher-1