### PR TITLE
fix(mechanic): wire annotations into cantor-diagonalization-oq-03-oq-01 index.ts

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean?raw')
+
+export const cantorDiagonalizationOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq03Oq01Data: ProofData = {
+  proof: cantorDiagonalizationOq03Oq01Proof,
+  annotations: cantorDiagonalizationOq03Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default cantorDiagonalizationOq03Oq01Data


### PR DESCRIPTION
## Fix

Replace the 4-line `import meta; export default meta;` stub at `src/data/proofs/cantor-diagonalization-oq-03-oq-01/index.ts` with the canonical 44-line ProofData/Proof/Annotation wiring so the gallery page renders the proof source, sections, overview, conclusion, crossReferences, and the 7-annotation `annotations.json` (12KB) instead of an `undefined`-destructure crash in `ProofPage.tsx`.

## Evidence

**Before** (`index.ts`, 4 lines, 109 bytes):
```ts
import meta from "./meta.json";
import annotations from "./annotations.json";
export { meta, annotations };
```
`module.default` is `undefined` → `getProofAsync`'s `module.default` fallback never runs → `ProofPage.tsx:111` destructures `undefined` for `.proof`/`.annotations`. Annotations exist but never render.

**After**: canonical template — type-asserts `metaJson`, lazy-imports `proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean?raw`, exports `cantorDiagonalizationOq03Oq01Proof` / `Annotations` / `Data` / `getProofSource()`, with `Data` as the default.

**Slug data**: 9 sections, 7 cross-references, full overview + conclusion, 7 annotations / 12KB, `axiomCount: 0`, `sorries: 0`, `status: verified` — rich content that was dormant.

## Class

Same orthogonal target as:
- PR #17885 (lagrange-theorem-oq-02-oq-02)
- PR #18749 (triangle-angle-sum-oq-01)
- PR #18755 (konigsberg-oq-03-oq-02)
- PR #18771 (cantor-diagonalization-oq-03-oq-01-oq-01) — sibling slug under same parent
- In-flight: #18805, #18806, #18810, #18813, #18815, #18817, #18820, #18822, #18823/#18824

~21 stub-class slugs remain (filtered for orthogonality vs in-flight PRs).

---
Automated fix by lean-mechanic agent (mechanic-2).