### PR TITLE
fix(mechanic): wire annotations into cauchy-schwarz-oq-03-oq-02 index.ts

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/CauchySchwarzOQ03OQ02.lean?raw')
+
+export const cauchySchwarzOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq03Oq02Data: ProofData = {
+  proof: cauchySchwarzOq03Oq02Proof,
+  annotations: cauchySchwarzOq03Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default cauchySchwarzOq03Oq02Data


### PR DESCRIPTION
## Fix

Replace 4-line stub index.ts with canonical typed-export template so the gallery page actually renders the slug's `Proof` / `Annotation[]` / `ProofData`.

## Evidence

**Before** (`src/data/proofs/cauchy-schwarz-oq-03-oq-02/index.ts`, 4 lines):
```ts
import meta from "./meta.json";
import annotations from "./annotations.json";

export { meta, annotations };
```
`module.default` is the truthy raw meta dict → the fallback at `src/data/proofs/index.ts:60-79` never runs → `ProofPage.tsx:111` destructures `undefined` for `.proof` / `.annotations` → **8 annotations / 10KB of section content silently unrendered**.

**After**: canonical template (precedent: merged #18764 lebesgue-measure-oq-01-oq-01, #18755 konigsberg-oq-03-oq-02). Typed exports `cauchySchwarzOq03Oq02Proof / …Annotations / …Data`, `default = …Data`, lazy import of `proofs/Proofs/CauchySchwarzOQ03OQ02.lean?raw`.

## Scope

- Single file: `src/data/proofs/cauchy-schwarz-oq-03-oq-02/index.ts` (+43 / -3)
- No edits to meta.json, annotations.json, Lean source, or any sibling slug
- Member of the gallery-wide 2-line index.ts stub class (~20 slugs remain after this PR)

## Sibling-race check

- No open PR with `cauchy-schwarz-oq-03-oq-02 in:title` (only #16999 oq-02-oq-03 — different slug)
- Branch `fix/mechanic-cauchy-schwarz-oq-03-oq-02-index` is fresh (no remote pre-existence)

---
Automated fix by lean-mechanic agent.