### PR TITLE
fix(mechanic): wire annotations into angle-trisection-oq-05-oq-01 index.ts

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-01/index.ts
+++ b/src/data/proofs/angle-trisection-oq-05-oq-01/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/AngleTrisectionOQ05OQ01.lean?raw')
+
+export const angleTrisectionOq05Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOq05Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOq05Oq01Data: ProofData = {
+  proof: angleTrisectionOq05Oq01Proof,
+  annotations: angleTrisectionOq05Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default angleTrisectionOq05Oq01Data


### PR DESCRIPTION
## Fix

Replaces the 4-line legacy stub `index.ts` for `angle-trisection-oq-05-oq-01` with the canonical full template so the gallery page renders annotations and Lean source correctly.

## Evidence

**Before**:
```ts
import meta from "./meta.json";
import annotations from "./annotations.json";

export { meta, annotations };
```

`module.default` is undefined here, so `getProofAsync` (src/data/proofs/index.ts:60-79) falls through to the legacy `{ meta, annotations }` reconstruction path — but with `source: ''`, so the Lean source pane never renders. Worse, when the default-export path is hit for similar variants (the gallery has both 2-line and 4-line broken stubs), the raw meta JSON is returned as `ProofData`, and `ProofPage.tsx` destructures undefined for `proof.annotations`.

**After**: canonical full template — imports `annotationsJson` (9KB / matches schema), exports `angleTrisectionOq05Oq01Proof`/`Annotations`/`Data`, dynamically loads `proofs/Proofs/AngleTrisectionOQ05OQ01.lean?raw`, and provides a `default` export so `getProofAsync` returns well-formed `ProofData`.

## Scope

- **Files**: `src/data/proofs/angle-trisection-oq-05-oq-01/index.ts` only (+43 / -3).
- **No meta.json, annotations.json, or Lean changes.**

## Template provenance

Matches the canonical template established by recently-merged mechanic PRs in this class:
- #18794 erdos-1150
- #18787 erdos-1149
- #18766 harmonic-divergence-oq-02
- #18749 triangle-angle-sum-oq-01

## Out of scope (separate PRs)

There are ~20 remaining 3–4-line legacy-stub `index.ts` files in the gallery (each needs unique camelCase + Lean basename; one slug per PR per the established mechanic convention).

---
Automated fix by lean-mechanic agent.