### PR TITLE
fix(mechanic): wire annotations into erdos-848-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-848-oq-01/index.ts
+++ b/src/data/proofs/erdos-848-oq-01/index.ts
@@ -1,5 +1,6 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
 const meta = metaJson as unknown as {
   id: string; title: string; slug: string; description: string
@@ -18,7 +19,7 @@ export const proof: Proof = {
   crossReferences: meta.crossReferences,
 }
 
-export const annotations: Annotation[] = []
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const proofData: ProofData = { proof, annotations }
 
 export async function getProofSource(): Promise<string> {


### PR DESCRIPTION
## Fix

Replace the hardcoded `export const annotations: Annotation[] = []` at `src/data/proofs/erdos-848-oq-01/index.ts:21` with an import of `./annotations.json`, exposing the 5 rich annotations (7.4 KB) that were sitting dormant in the JSON file.

## Evidence

**Bug mechanism**: The proof object was already correctly wired (Proof, ProofData, leanSource, default export are all canonical). But `annotations` was hardcoded to `[]`, so the gallery page rendered the proof shell with **zero annotations** even though `annotations.json` contains 5 substantive entries about quadratic residues mod 25, the {7, 18} extremal set, and the docstring's analysis structure.

Sampled first annotation:

```json
{
  "id": "ann-e848-context",
  "title": "Why {7, 18} mod 25? The Quadratic Residue Answer",
  "content": "The docstring frames the core insight: the extremal sets for Erdős #848 are exactly the mod-25 classes of the square roots of -1 in ℤ/25ℤ...",
  "mathContext": "$ab + 1 \\equiv x^2 + 1 \\pmod{25}$..."
}
```

**Affected slug**: `erdos-848-oq-01` (Erdős #848 OQ-01: Why Exactly {7, 18} mod 25?)
- `annotations.json`: 5 annotations, 7,401 bytes (well-developed content)
- Lean source: `proofs/Proofs/Erdos848ProblemOQ01.lean` (exists, builds clean, 0 sorries, 0 axioms)
- Currently gallery-visible (in `listings.json`)
- `index.ts` was already converted to the canonical Proof shape, but the `annotations` line was a `[]` stub left over from that conversion

**Before**: 5 annotations dormant in `annotations.json`, gallery page shows proof + no annotation overlays.
**After**: All 5 annotations rendered. 2-line diff (+1 import, 1-line swap).

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
$ echo $?
0
```

No new type errors. The `annotationsJson as unknown as Annotation[]` cast matches the same pattern used by the 44-line canonical template (e.g. `triangle-angle-sum-oq-01/index.ts:32`, my PR #18830 cantor-diagonalization-oq-03-oq-01).

## Scope

- **Touched**: `src/data/proofs/erdos-848-oq-01/index.ts` only (1 file, +2 / -1 lines).
- **Not touched**: `meta.json`, `annotations.json`, `tacticStates.json`, Lean source.
- **Orthogonal to in-flight mechanic PRs**: #18810/#18813/#18817/#18820/#18823/#18824/#18806 (erdos-1059-oq-0{1..5}, different slug), #18805 (divisibility-truncation), #18815 (amgm), #18822 (bezout), #18827 (shannon-entropy), #18830 (cantor-diagonalization-oq-03-oq-01).

This is a different sub-variant of the gallery-wide "stub index.ts" class: the **proof was wired correctly but `annotations` was a `[]` placeholder**. I plan to scan for other slugs with the same pattern in subsequent cycles, one PR per slug per the lagrange precedent (PR #17885).

---
Automated fix by lean-mechanic agent.