### PR TITLE
fix(mechanic): wire annotations into feuerbachs-theorem-oq-02 index.ts

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02/index.ts
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/FeuerbachsTheoremOQ02.lean?raw')
+
+export const feuerbachsTheoremOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const feuerbachsTheoremOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const feuerbachsTheoremOq02Data: ProofData = {
+  proof: feuerbachsTheoremOq02Proof,
+  annotations: feuerbachsTheoremOq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default feuerbachsTheoremOq02Data


### PR DESCRIPTION
## Fix

Replace `feuerbachs-theorem-oq-02/index.ts` stub (`import meta; export { meta, annotations };`) with the canonical full-template shape so the Lean source panel and typed exports work.

## Evidence

**Before** (5 lines, 109 bytes):
- No `default` export and no `getProofSource`.
- Falls through to the legacy fallback at `src/data/proofs/index.ts:60-79`, which constructs a `ProofData` but leaves `proof.source = ''`.
- `ProofViewer.tsx:20` reads `proof.source.split('\n')` — Lean source panel renders empty for this slug despite `proofs/Proofs/FeuerbachsTheoremOQ02.lean` containing 33,799 bytes.
- 9 annotations / ~18KB never bind to a typed export.

**After** (44 lines, canonical template):
- Named exports: `feuerbachsTheoremOq02Proof`, `feuerbachsTheoremOq02Annotations`, `feuerbachsTheoremOq02Data`.
- `default` export: `feuerbachsTheoremOq02Data` (hits the `module.default` path at `src/data/proofs/index.ts:57`).
- `getProofSource` lazy-imports `proofs/Proofs/FeuerbachsTheoremOQ02.lean?raw` (33,799 bytes), populating `proof.source` for `ProofViewer`.

## Scope

- Touches only `src/data/proofs/feuerbachs-theorem-oq-02/index.ts`.
- No changes to `meta.json`, `annotations.json`, or the Lean source.

Companion class to PRs #18820, #18810, #18813, #18817 (`export default meta;` variant). This is the **named-export** sub-variant of the same orthogonal target class — 18 such slugs remain unclaimed per local survey (`elementary-quadratic-reciprocity-oq-03-oq-01-oq-02`, `partition-theorem-oq-03`, `lagrange-theorem-oq-02-oq-01`, `triangular-reciprocals-oq-01`, `lagrange-theorem-oq-05`, `angle-trisection-oq-05-oq-04`, `erdos-1021-oq-01`, `ramseys-theorem-oq-04`, `harmonic-divergence-oq-04`, `erdos-1036-oq-01`, `chinese-remainder-constructive-oq-03`, `gcd-algorithm-oq-04`, `gcd-algorithm-oq-02`, `lagrange-theorem-oq-02-oq-02-oq-01`, `erdos-1153`, `birthday-problem-oq-03-oq-01`, `erdos-114-oq-04`).

---
Automated fix by lean-mechanic agent.