### PR TITLE
fix(mechanic): wire annotations into chinese-remainder-constructive-oq-03 index.ts

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03/index.ts
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/index.ts
@@ -1,4 +1,30 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/ChineseRemainderConstructiveOQ03.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Fix

Replace the 2-line `import meta; import annotations; export { meta, annotations }` stub with the canonical 30-line template so `chinese-remainder-constructive-oq-03` renders annotations + Lean source like the rest of the gallery.

## Evidence

**Before** — `src/data/proofs/chinese-remainder-constructive-oq-03/index.ts`:
```ts
import meta from './meta.json';
import annotations from './annotations.json';

export { meta, annotations };
```
`getProofAsync` (`src/data/proofs/index.ts:50-79`) sees no `module.default`, no `module[exportName]`, and no `*Data` export, so it falls into the legacy-fallback path. That path sets `proof.source = ''` (no Lean source) and never calls `getProofSource`, so the proof page shows annotations but the Lean source viewer is empty.

**After** — canonical template (same shape as PR #18837 erdos-848-oq-01, PR #18755 konigsberg-oq-03-oq-02, PR #18749 triangle-angle-sum-oq-01, PR #17885 lagrange-theorem-oq-02-oq-02):
- Imports `annotationsJson` (11 annotations, 15KB) directly from `./annotations.json` and casts to `Annotation[]`.
- Builds a proper `Proof` with `sections`/`overview`/`conclusion`/`crossReferences` from `meta.json`.
- Exposes `getProofSource()` that lazy-imports `proofs/Proofs/ChineseRemainderConstructiveOQ03.lean?raw`.
- `export default proofData` so `getProofAsync` takes the fast path (line 57) instead of the legacy fallback.

## Scope

Single file: `src/data/proofs/chinese-remainder-constructive-oq-03/index.ts` (+29 / −3).

No changes to `meta.json`, `annotations.json`, the Lean source, or any other slug. Annotations content was already authored — only the index wiring was missing.

## Out of scope (orthogonal targets, separate PRs if needed)

7 other unclaimed 2-line `index.ts` stubs across the gallery: `erdos-1036-oq-01`, `erdos-1153`, `erdos-1021-oq-01`, `triangular-reciprocals-oq-01`, `elementary-quadratic-reciprocity-oq-03-oq-01-oq-02`, `partition-theorem-oq-03`, `ramseys-theorem-oq-04` — each needs its own PR (unique camelCase + Lean basename).

---
Automated fix by lean-mechanic agent.