### PR TITLE
fix(mechanic): wire annotations into erdos-1179-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/index.ts
+++ b/src/data/proofs/erdos-1179-oq-01/index.ts
@@ -1,5 +1,6 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
 const meta = metaJson as unknown as {
@@ -30,7 +31,7 @@ export const proof: Proof = {
   crossReferences: meta.crossReferences,
 }
 
-export const annotations: Annotation[] = []
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,


### PR DESCRIPTION
## Fix

Replace the hardcoded `export const annotations: Annotation[] = []` at `src/data/proofs/erdos-1179-oq-01/index.ts:33` with an import of `./annotations.json`, exposing the **12 annotations (17.7 KB)** that were sitting dormant in the JSON file.

## Evidence

**Bug mechanism**: The proof object was already correctly wired (`Proof`, `ProofData`, `leanSource`, `default export` are all canonical). But `annotations` was hardcoded to `[]`, so the gallery page rendered the proof shell with **zero annotations** even though `annotations.json` contains 12 substantive entries.

```bash
$ wc -c src/data/proofs/erdos-1179-oq-01/annotations.json
17751
$ jq 'length' src/data/proofs/erdos-1179-oq-01/annotations.json
12
$ jq '.[0] | keys' src/data/proofs/erdos-1179-oq-01/annotations.json
["content","id","mathContext","prerequisites","proofId","range","relatedConcepts","significance","title","type"]
```

**Affected slug**: `erdos-1179-oq-01`
- `annotations.json`: 12 annotations, 17,751 bytes (rich content with `mathContext`, `prerequisites`, `relatedConcepts`)
- `index.ts` was already converted to the canonical Proof shape, but the `annotations` line was a `[]` stub left over from that conversion

**Before**: 12 annotations dormant in `annotations.json`; gallery page shows proof + no annotation overlays.
**After**: All 12 annotations rendered. 2-line diff (+1 import, 1-line swap).

## Validation

```
$ npx tsc --noEmit -p tsconfig.app.json
# Only pre-existing unrelated errors about auto-generated
# listings.json / research-listings.json (not in worktree).
# Zero errors on src/data/proofs/erdos-1179-oq-01/index.ts.
```

The `annotationsJson as unknown as Annotation[]` cast matches the same pattern used by `triangle-angle-sum-oq-01/index.ts` (PR #18749) and the open `erdos-848-oq-01` fix (PR #18837).

## Scope

- **Touched**: `src/data/proofs/erdos-1179-oq-01/index.ts` only (1 file, +2 / -1 lines).
- **Not touched**: `meta.json`, `annotations.json`, `tacticStates.json`, Lean source.
- **Orthogonal**: same sub-variant as PR #18837 (proof wired correctly, `annotations` was `[]` placeholder). Grep `export const annotations: Annotation\[\] = \[\]` across `src/data/proofs/**/index.ts` shows only **erdos-848-oq-01 (PR #18837)** and **erdos-1179-oq-01 (this PR)** match this pattern. Class fully covered after this merges.

---
Automated fix by lean-mechanic agent.