### PR TITLE
Enrich Irrationality of ∛2: Delian-problem thread, references, cross-refs

### DIFF
--- a/src/data/proofs/cube-root-2-irrational/meta.json
+++ b/src/data/proofs/cube-root-2-irrational/meta.json
@@ -27,19 +27,35 @@
       "two_not_perfect_cube: ¬∃ n : ℤ, n³ = 2, proved by direct integer bounds",
       "cbrt2_cubed: (2^(1/3))^3 = 2 using rpow composition",
       "irrational_two_pow_one_third: alternative named form"
+    ],
+    "relatedProblems": [
+      {
+        "id": "cube-root-3-irrational",
+        "relationship": "Sibling proof using the identical Mathlib template applied to ∛3; only the integer bounds (1³ < 3 < 2³) and the constant change."
+      },
+      {
+        "id": "nth-root-irrational",
+        "relationship": "General theorem: ∛2 is the n=3, m=2 specialisation of 'nth root of a non-perfect-nth-power is irrational'."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "∛2 is a degree-3 algebraic number whose minimal polynomial X³ − 2 is Eisenstein-irreducible. Galois theory of such cubic radicals underlies the Abel–Ruffini impossibility of solving the general quintic by radicals."
+      }
     ]
   },
   "overview": {
-    "historicalContext": "The irrationality of ∛2 has roots stretching back to ancient Greece. The Pythagoreans' discovery of the irrationality of √2 (circa 5th century BC) was philosophically shocking, demonstrating that ratios of integers cannot capture all geometric magnitudes. The irrationality of ∛2 is less ancient in its explicit formulation but arises naturally in classical geometry: doubling the cube — the Delian problem of constructing a cube with twice the volume — requires a length of ∛2, and the impossibility of this construction by compass and straightedge (proved only in the 19th century using Galois theory) hinges on ∛2 being a degree-3 algebraic number. Medieval and Renaissance mathematicians worked with cube roots extensively in solving cubic equations, but a systematic theory of irrationals had to await Dedekind and Cantor in the 19th century. The modern proof via `irrational_nrt_of_notint_nrt` encapsulates the classical argument: any rational root $p/q$ of $X^3 - 2$ in lowest terms satisfies $q \\mid 1$ (rational root theorem), so the root would be an integer — but no integer cubes to 2.",
+    "historicalContext": "The irrationality of ∛2 has roots stretching back to ancient Greece. The Pythagoreans' discovery of the irrationality of √2 (circa 5th century BC, traditionally attributed to Hippasus of Metapontum) was philosophically shocking, demonstrating that ratios of integers cannot capture all geometric magnitudes. The irrationality of ∛2 is less ancient in its explicit formulation but arises naturally in classical geometry: **doubling the cube** — the **Delian problem** of constructing a cube with twice the volume of a given cube — requires a length of ∛2, and the impossibility of this construction by compass and straightedge (proved only in 1837 by Pierre Wantzel using field-extension degree arguments) hinges on ∛2 being a degree-3 algebraic number, while compass-and-straightedge constructions can only produce numbers of degree a power of 2.\n\nThe Delian legend (Eratosthenes, 3rd century BC) recounts that the oracle at Delos commanded the Greeks to double the volume of Apollo's cubical altar to end a plague. The Greek geometers — Hippocrates of Chios, Archytas of Tarentum, Menaechmus, Eudoxus — produced solutions using conic sections and mechanical devices, but a compass-and-straightedge solution eluded them. Plato is said to have rebuked the use of mechanical instruments as 'destroying the good of geometry', and the problem remained a touchstone of Greek mathematics.\n\nMedieval and Renaissance mathematicians worked with cube roots extensively in solving cubic equations (Cardano's *Ars Magna*, 1545), but a systematic theory of irrationals had to await Dedekind and Cantor in the 19th century. The modern proof via `irrational_nrt_of_notint_nrt` encapsulates the classical argument: any rational root $p/q$ of $X^3 - 2$ in lowest terms satisfies $q \\mid 1$ (rational root theorem), so the root would be an integer — but no integer cubes to 2. Equivalently, $X^3 - 2$ is Eisenstein-irreducible at $p = 2$, so it has no rational roots and $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3$.",
     "problemStatement": "Prove that 2^(1/3) : ℝ is irrational, i.e., ¬∃ r : ℚ, (r : ℝ) = 2^(1/3).",
     "text": "The proof proceeds in three steps. First, cbrt2_cubed: (2^(1/3))^3 = 2, proved using Real.rpow_natCast and Real.rpow_mul. Second, two_not_perfect_cube: no integer n satisfies n³ = 2 — if n ≤ 0 then n³ ≤ 0 < 2; if n ≥ 2 then n³ ≥ 8 > 2; so n = 1 but 1³ = 1 ≠ 2. Third, cbrt2_not_int: ∛2 is not an integer. Finally, irrational_cbrt2 applies irrational_nrt_of_notint_nrt 3 2 with these three facts.",
     "proofStrategy": "two_not_perfect_cube: case split n ≤ 0 (n³ ≤ 0 by nlinarith), n ≥ 2 (n³ ≥ 8 by nlinarith), then n = 1 by omega and norm_num for 1³ ≠ 2. cbrt2_cubed: rpow composition with Real.rpow_mul and the equation (1/3)*3 = 1.",
     "keyInsights": [
-      "irrational_nrt_of_notint_nrt is a general Mathlib lemma: x^n = m ∧ ¬IsInt(x) → Irrational(x)",
-      "The key number theory fact: integers are either ≤ 1 or ≥ 2 (no gap where n³ = 2)",
-      "rpow composition: (2^(1/3))^3 = 2^((1/3)*3) = 2^1 = 2",
-      "The argument is essentially the same as for ∛3 (see companion file)",
-      "The rational root theorem underpins the irrationality machine: a rational p/q root of x^n - m must have q dividing 1 and p dividing m, so it would be an integer — the reduction to 'is m a perfect n-th power?' is both necessary and sufficient"
+      "**Mathlib's irrationality machine**: `irrational_nrt_of_notint_nrt` is a general Mathlib lemma — $x^n = m \\wedge \\neg \\text{IsInt}(x) \\Rightarrow \\text{Irrational}(x)$ — so the entire proof reduces to showing $\\sqrt[3]{2}$ is not an integer.",
+      "**The key number-theoretic gap**: integers come in discrete steps, so $n^3$ jumps from $1$ (at $n=1$) to $8$ (at $n=2$). Since $1 < 2 < 8$, no integer cubes to 2 — the absence of perfect cubes in $(1, 8)$ is the crux.",
+      "**rpow composition**: $(2^{1/3})^3 = 2^{(1/3) \\cdot 3} = 2^1 = 2$ via `Real.rpow_mul` with the hypothesis $0 \\leq 2$. This is the only real-analytic step; everything else is integer combinatorics.",
+      "**Sibling pattern**: the argument is essentially identical for $\\sqrt[3]{3}$ (companion file `CubeRoot3Irrational`) — only the integer bound changes. The general $n$-th-root version is `nth-root-irrational`.",
+      "**Rational root theorem foundation**: the irrationality machine encapsulates a classical fact — a rational root $p/q$ (in lowest terms) of $X^n - m$ must satisfy $q \\mid 1$, so $q = 1$ and the root is an integer. The reduction to 'is $m$ a perfect $n$-th power?' is both necessary and sufficient for irrationality of $\\sqrt[n]{m}$.",
+      "**Eisenstein irreducibility**: $X^3 - 2$ is Eisenstein-irreducible at $p = 2$ (the prime 2 divides the constant term −2 but $2^2 = 4$ does not, and 2 does not divide the leading coefficient 1). Hence $X^3 - 2$ is the minimal polynomial of $\\sqrt[3]{2}$ over $\\mathbb{Q}$, and $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3$ — irrationality is the degree $> 1$ shadow of this stronger algebraic statement.",
+      "**Delian-problem connection**: doubling the cube is impossible by compass and straightedge because it requires constructing a length of $\\sqrt[3]{2}$, but constructible numbers form a tower of quadratic extensions $\\mathbb{Q} \\subset K_1 \\subset \\cdots$ with each $[K_{i+1} : K_i] = 2$, so the degree $[\\mathbb{Q}(\\alpha) : \\mathbb{Q}]$ of any constructible $\\alpha$ is a power of 2. Since $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3$, $\\sqrt[3]{2}$ is not constructible — the impossibility proof depends on the very irrationality result formalised here."
     ],
     "prerequisites": [
       "Real.rpow: Real.rpow_mul, Real.rpow_natCast",
@@ -49,11 +65,12 @@
   },
   "conclusion": {
     "summary": "∛2 is irrational, proved by showing 2 is not a perfect cube and applying Mathlib's irrational_nrt_of_notint_nrt. 5 theorems, 0 axioms, 91 lines.",
-    "implications": "This is the n=3 case of the general theorem: $\\sqrt[n]{m}$ is irrational whenever $m$ is not a perfect $n$-th power of an integer. Mathlib's `irrational_nrt_of_notint_nrt` encapsulates the rational root theorem and makes all such proofs one-line applications once the perfect-power check is done. The result also plays a role in the theory of algebraic numbers: $\\sqrt[3]{2}$ is a degree-3 algebraic integer, not a degree-1 one (i.e., not rational), which connects to the classical impossibility of doubling the cube by compass and straightedge. The companion file `CubeRoot3Irrational` follows the identical pattern for $\\sqrt[3]{3}$, and both results are used as lemmas in Gelfond-Schneider-related formalizations.",
+    "implications": "**General nth-root template**: this is the n=3, m=2 case of the general theorem that $\\sqrt[n]{m}$ is irrational whenever $m$ is not a perfect $n$-th power of an integer. Mathlib's `irrational_nrt_of_notint_nrt` encapsulates the rational root theorem and makes all such proofs one-line applications once the perfect-power check is done. The same template handles $\\sqrt[3]{3}$ (companion file), $\\sqrt[4]{5}$, etc.\n\n**Algebraic number theory**: $\\sqrt[3]{2}$ is a degree-3 algebraic integer — its minimal polynomial $X^3 - 2$ over $\\mathbb{Q}$ is Eisenstein-irreducible at $p = 2$. Hence $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3$ and $\\{1, \\sqrt[3]{2}, \\sqrt[3]{4}\\}$ is a $\\mathbb{Q}$-basis. The Galois closure $\\mathbb{Q}(\\sqrt[3]{2}, \\omega)$ (where $\\omega = e^{2\\pi i/3}$) has degree 6 and Galois group $S_3$ — the smallest non-abelian Galois group, and a foundational example in the theory of solvability by radicals.\n\n**Delian problem (doubling the cube)**: a compass-and-straightedge construction of a cube with twice a given volume requires a length of $\\sqrt[3]{2}$. Constructible numbers have degree a power of 2 over $\\mathbb{Q}$; since $\\sqrt[3]{2}$ has degree 3, the construction is impossible. Wantzel (1837) gave the first rigorous proof of this fact. The companion impossibility — trisection of a general angle — is formalised in `angle-trisection-cos-20-gal`. Squaring the circle, the third classical impossibility, requires transcendence of $\\pi$ (Lindemann 1882).\n\n**Consumer in the Lean library**: the alias `irrational_two_pow_one_third` is consumed by `GelfondSchneider.lean`, which formalises (under suitable axioms) the Gelfond–Schneider theorem: $2^{\\sqrt{2}}$ is transcendental — a vastly stronger statement about the same base.",
     "openQuestions": [
-      "Generalize: n√m is irrational iff m is not a perfect n-th power (general theorem)",
-      "Prove the Gelfond-Schneider theorem: 2^√2 is transcendental (much harder)",
-      "Formalize the degree bound: any n-th root of a non-perfect-power is a degree-n algebraic number, which would require Galois theory machinery in Mathlib"
+      "Generalize: $\\sqrt[n]{m}$ is irrational iff $m$ is not a perfect $n$-th power (the general theorem, partially formalised in `nth-root-irrational`).",
+      "Prove the Gelfond–Schneider theorem in full: $2^{\\sqrt{2}}$ (and more generally $a^b$ for algebraic $a \\notin \\{0, 1\\}$ and irrational algebraic $b$) is transcendental — much harder, requires non-trivial analysis.",
+      "Formalize the degree bound: any $n$-th root of a non-perfect-power is a degree-$n$ algebraic number, which would require Galois theory machinery and Eisenstein's irreducibility criterion in Mathlib.",
+      "Formalize the Delian problem impossibility: prove that no compass-and-straightedge construction yields $\\sqrt[3]{2}$, using the fact that constructible numbers have degree a power of 2 over $\\mathbb{Q}$. This would connect this proof to the classical-geometry impossibility trilogy alongside angle trisection (already formalised) and squaring the circle."
     ]
   },
   "leanFile": {
@@ -69,12 +86,47 @@
     {
       "targetId": "cube-root-3-irrational",
       "relationship": "related",
-      "description": "Identical proof strategy applied to ∛3"
+      "description": "Identical proof strategy applied to ∛3 — only the integer bounds change. Both use cbrtN_cubed → N_not_perfect_cube → cbrtN_not_int → irrational_cbrtN."
     },
     {
       "targetId": "sqrt2-plus-sqrt3-irrational",
       "relationship": "related",
-      "description": "Irrationality of √2+√3 uses a different technique (squaring and reducing to √6 irrational)"
+      "description": "Irrationality of √2+√3 uses a different technique (squaring and reducing to √6 irrational), illustrating that not every irrationality result fits the irrational_nrt_of_notint_nrt template."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "generalizes",
+      "description": "The general theorem: m^(1/n) is irrational whenever m is not a perfect n-th power. This entry is the n=3, m=2 specialisation; nth-root-irrational formalises the general statement."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The classical n=2 case (irrationality of √2 and other square roots). Same Mathlib template applied to the square-root level — the historical starting point of irrationality theory."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "∛2 is a degree-3 algebraic number; the Galois closure ℚ(∛2, ω) has Galois group S₃, the smallest non-abelian Galois group. Abel–Ruffini uses the non-solvability of the symmetric group Sₙ for n ≥ 5 to prove that the general quintic is not solvable by radicals — the cubic case (degree 3) is solvable, but already exhibits non-abelian Galois behaviour."
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "∛2 is an algebraic number: it is a root of the monic integer polynomial X³ − 2. The set of all algebraic numbers is countable (Cantor 1874), making the existence of transcendental numbers a cardinality consequence. ∛2 is a concrete example of an irrational algebraic number — strictly weaker than transcendental."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "contrasts",
+      "description": "∛2 is irrational but algebraic (degree 3 over ℚ); e is transcendental (no algebraic equation over ℚ). Both proofs illustrate the hierarchy ℚ ⊂ algebraic numbers ⊂ ℝ. The transcendence proof for e (Hermite 1873) is dramatically harder than the irrationality of ∛2, requiring careful estimates on integrals."
+    },
+    {
+      "targetId": "angle-trisection-cos-20-gal",
+      "relationship": "related",
+      "description": "Sibling Greek-construction impossibility: trisection of a general angle is impossible by compass and straightedge because cos(20°) has minimal polynomial 8X³ − 6X − 1 of degree 3 over ℚ. Doubling the cube (this proof) and angle trisection are two of the three classical impossibilities, both proved by exhibiting a degree-3 algebraic number — degree not a power of 2."
+    },
+    {
+      "targetId": "gelfond-schneider",
+      "relationship": "consumed-by",
+      "description": "The alias `irrational_two_pow_one_third` is consumed by GelfondSchneider.lean. The Gelfond–Schneider theorem states that 2^√2 (and similar a^b for algebraic a, irrational algebraic b) is transcendental — a far stronger result whose machinery uses irrationality of expressions like 2^(1/3) as building blocks."
     }
   ],
   "sections": [
@@ -83,56 +135,121 @@
       "title": "Imports",
       "startLine": 1,
       "endLine": 9,
-      "summary": "Imports Mathlib's irrationality library and real power functions needed for the proof."
+      "summary": "Imports Mathlib's irrationality library and real power functions needed for the proof.",
+      "mathContext": "The two crucial Mathlib modules are `Mathlib.Data.Real.Irrational` (providing the `Irrational` predicate and `irrational_nrt_of_notint_nrt`) and `Mathlib.Analysis.SpecialFunctions.Pow.Real` (providing `Real.rpow` and its composition laws `Real.rpow_mul`, `Real.rpow_natCast`). The `Irrational` predicate is defined as $\\neg \\exists r : \\mathbb{Q},\\ (r : \\mathbb{R}) = x$."
     },
     {
       "id": "sec-strategy",
       "title": "Module Documentation and Strategy",
       "startLine": 11,
       "endLine": 25,
-      "summary": "Describes the three-step proof strategy: establish (2^{1/3})^3 = 2, show 2 is not a perfect cube, conclude irrationality via irrational_nrt_of_notint_nrt."
+      "summary": "Describes the three-step proof strategy: establish (2^{1/3})^3 = 2, show 2 is not a perfect cube, conclude irrationality via irrational_nrt_of_notint_nrt.",
+      "mathContext": "The strategy encodes a general meta-theorem: $\\sqrt[n]{m}$ is irrational iff $m$ is not a perfect $n$-th power of an integer. The forward direction is the content of `irrational_nrt_of_notint_nrt` — a rational $p/q$ (lowest terms) with $(p/q)^n = m$ forces $q \\mid 1$ by the rational root theorem, contradicting $\\sqrt[n]{m} \\notin \\mathbb{Z}$."
     },
     {
       "id": "sec-definition",
       "title": "Definition of cbrt2",
       "startLine": 27,
       "endLine": 30,
-      "summary": "Defines cbrt2 = (2 : ℝ)^(1/3 : ℝ) as a noncomputable real via Real.rpow."
+      "summary": "Defines cbrt2 = (2 : ℝ)^(1/3 : ℝ) as a noncomputable real via Real.rpow.",
+      "mathContext": "In Mathlib, `Real.rpow x y = Real.exp (Real.log x * y)` for $x > 0$. Thus $\\sqrt[3]{2} = e^{(\\ln 2)/3}$, the unique positive real whose cube is 2. The `noncomputable` keyword is forced because `Real.rpow` is defined analytically via the exponential function and has no decidable equality. Working with `rpow` rather than a native `cbrt` constant lets the proof reuse Mathlib's general exponent algebra."
     },
     {
       "id": "sec-cbrt2-cubed",
       "title": "Key Property: cbrt2^3 = 2",
       "startLine": 32,
       "endLine": 37,
-      "summary": "Proves cbrt2^3 = 2 using rpow_natCast and rpow_mul to combine exponents: (2^{1/3})^3 = 2^{(1/3)·3} = 2^1 = 2."
+      "summary": "Proves cbrt2^3 = 2 using rpow_natCast and rpow_mul to combine exponents: (2^{1/3})^3 = 2^{(1/3)·3} = 2^1 = 2.",
+      "mathContext": "The chain $(2^{1/3})^3 \\overset{\\text{rpow\\_natCast}}{=} (2^{1/3})^{(3:\\mathbb{R})} \\overset{\\text{rpow\\_mul}}{=} 2^{(1/3) \\cdot 3} = 2^1 = 2$ uses the law $(x^a)^b = x^{ab}$ for $x \\geq 0$. The non-negativity hypothesis $0 \\leq 2$ is required because `Real.rpow_mul` has subtle branch behaviour for negative bases (e.g., $(-1)^{1/2}$ is not $-1$). `norm_num` finishes the elementary $(1/3) \\cdot 3 = 1$ and $2^1 = 2$."
     },
     {
       "id": "sec-not-perfect-cube",
       "title": "2 Is Not a Perfect Cube",
       "startLine": 39,
       "endLine": 66,
-      "summary": "Number-theoretic core: proves ¬∃ n : ℤ, n^3 = 2 by case analysis on n ≤ 0 (n^3 ≤ 0), n ≥ 2 (n^3 ≥ 8), and n = 1 (1^3 = 1 ≠ 2), using nlinarith and omega."
+      "summary": "Number-theoretic core: proves ¬∃ n : ℤ, n^3 = 2 by case analysis on n ≤ 0 (n^3 ≤ 0), n ≥ 2 (n^3 ≥ 8), and n = 1 (1^3 = 1 ≠ 2), using nlinarith and omega.",
+      "mathContext": "The cubic function $f(n) = n^3$ on $\\mathbb{Z}$ satisfies $f(n) \\leq 0$ for $n \\leq 0$, $f(1) = 1$, $f(n) \\geq 8$ for $n \\geq 2$. The gap $(1, 8)$ contains $2$ but no value of $f$. Discrete-monotonicity arguments like this are the workhorse of elementary irrationality proofs and are dispatched in Lean by `nlinarith` (nonlinear arithmetic) and `omega` (linear integer arithmetic). The argument generalises to any non-perfect-cube: integers not of the form $k^3$ lie in some gap $(k^3, (k+1)^3)$."
     },
     {
       "id": "sec-not-int",
       "title": "cbrt2 Is Not an Integer",
       "startLine": 68,
       "endLine": 75,
-      "summary": "Bridge lemma: if cbrt2 = n for some n : ℤ, then n^3 = 2 (by cubing), contradicting two_not_perfect_cube. Uses exact_mod_cast for ℝ/ℤ coercion."
+      "summary": "Bridge lemma: if cbrt2 = n for some n : ℤ, then n^3 = 2 (by cubing), contradicting two_not_perfect_cube. Uses exact_mod_cast for ℝ/ℤ coercion.",
+      "mathContext": "This is the analytic-to-discrete bridge: from $\\sqrt[3]{2} = n$ (as reals) and $(\\sqrt[3]{2})^3 = 2$ (from `cbrt2_cubed`), cubing both sides of the first equation and substituting gives $n^3 = 2$ in $\\mathbb{R}$, then $\\mathbb{Z}$ via `exact_mod_cast` using injectivity of $\\mathbb{Z} \\hookrightarrow \\mathbb{R}$. The pattern — push analytic identities through an integer hypothesis, then contradict via discrete bounds — is the recurring motif of all such irrationality proofs."
     },
     {
       "id": "sec-main-theorem",
       "title": "Main Theorem: irrational_cbrt2",
       "startLine": 77,
       "endLine": 85,
-      "summary": "Applies irrational_nrt_of_notint_nrt 3 2 with the three obligations: cbrt2^3 = 2, cbrt2 not an integer, and 3 > 0."
+      "summary": "Applies irrational_nrt_of_notint_nrt 3 2 with the three obligations: cbrt2^3 = 2, cbrt2 not an integer, and 3 > 0.",
+      "mathContext": "`irrational_nrt_of_notint_nrt n m` (with $m : \\mathbb{Z}$, $n : \\mathbb{N}$, $x : \\mathbb{R}$) packages the rational root theorem: a real $x$ with $x^n = m$ and $x \\notin \\mathbb{Z}$ must be irrational, since any rational $p/q$ (lowest terms) root of $X^n - m$ satisfies $q \\mid 1$ by primitivity of monic polynomials (Gauss's lemma), so $q = 1$ and $x = p \\in \\mathbb{Z}$ — a contradiction with $\\neg \\text{IsInt}(x)$."
     },
     {
       "id": "sec-alias",
       "title": "Alias for Cross-File Use",
       "startLine": 87,
       "endLine": 91,
-      "summary": "Exports irrational_two_pow_one_third as an alias matching the form used by GelfondSchneider.lean and other dependent files."
+      "summary": "Exports irrational_two_pow_one_third as an alias matching the form used by GelfondSchneider.lean and other dependent files.",
+      "mathContext": "Both names assert $\\text{Irrational}(2^{1/3})$ but with different surface forms: `irrational_cbrt2` mentions the named constant `cbrt2`, while `irrational_two_pow_one_third` matches the literal `(2 : \\mathbb{R}) \\hat{\\ } (1/3 : \\mathbb{R})` used by callers that have not unfolded `cbrt2`. Definitional equality means the alias has zero proof overhead. This double-naming convention is standard Lean idiom for theorems with multiple natural call sites."
+    }
+  ],
+  "references": [
+    {
+      "type": "book",
+      "title": "An Introduction to the Theory of Numbers (Chapter 4: Irrational and Transcendental Numbers)",
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "year": 1938,
+      "note": "Classical treatment of irrationality via the rational root theorem; the standard reference for elementary irrationality arguments including the n-th root template used here."
+    },
+    {
+      "type": "book",
+      "title": "Irrational Numbers (Carus Mathematical Monograph 11)",
+      "authors": [
+        "Ivan Niven"
+      ],
+      "year": 1956,
+      "note": "Comprehensive monograph on irrationality, covering the rational-root-theorem approach to ∛2 and the broader theory of irrationality measures."
+    },
+    {
+      "type": "book",
+      "title": "Galois Theory (4th edition, Chapter 7: Constructions by Ruler and Compasses)",
+      "authors": [
+        "Ian Stewart"
+      ],
+      "year": 2015,
+      "note": "Modern textbook treatment of the Delian problem: doubling the cube is impossible because ∛2 has degree 3 over ℚ, while constructible numbers have degree a power of 2 (Wantzel's theorem)."
+    },
+    {
+      "type": "article",
+      "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
+      "authors": [
+        "Pierre Wantzel"
+      ],
+      "year": 1837,
+      "venue": "Journal de mathématiques pures et appliquées, vol. 2, pp. 366–372",
+      "note": "First rigorous proof that doubling the cube (and trisecting a general angle) is impossible by compass and straightedge — directly depends on ∛2 being a degree-3 algebraic number."
+    },
+    {
+      "type": "book",
+      "title": "Algebra (Revised 3rd edition, Chapter V §3: Algebraic Extensions)",
+      "authors": [
+        "Serge Lang"
+      ],
+      "year": 2002,
+      "note": "Reference for Eisenstein's criterion (Theorem 3.1) showing X^n − p is irreducible over ℚ for prime p; instantiated at p = 2, n = 3, this yields the minimal polynomial of ∛2."
+    },
+    {
+      "type": "theorem",
+      "title": "irrational_nrt_of_notint_nrt",
+      "authors": [
+        "Mathlib Contributors"
+      ],
+      "note": "Mathlib lemma in `Mathlib.Data.Real.Irrational`: if x^n = m (with m : ℤ) and x is not an integer, then x is irrational. The proof packages the rational root theorem; this gallery entry instantiates it at n = 3, m = 2."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational` (passes 0 → 1).

## Quality improvements

- **`references` field added** (was absent): 6 substantive entries — Hardy & Wright, Niven (*Irrational Numbers*), Stewart (*Galois Theory* ch. 7), **Wantzel 1837** (the original constructibility-impossibility paper), Lang (*Algebra*), and the Mathlib lemma source.
- **`crossReferences` 2 → 9**: added connections to
  - `nth-root-irrational` (generalisation),
  - `sqrt2-irrational` (n=2 sibling, historical starting point),
  - `abel-ruffini` (degree-3 Galois closure with $S_3$),
  - `algebraic-numbers-countable` (∛2 as concrete irrational-but-algebraic example),
  - `e-transcendental` (irrational-algebraic vs transcendental contrast),
  - `angle-trisection-cos-20-gal` (sibling Greek-construction impossibility),
  - `gelfond-schneider` (consumer of `irrational_two_pow_one_third` for $2^{\sqrt{2}}$ transcendence).
- **`meta.relatedProblems`** added: 3 entries (sibling ∛3, generalisation, Abel–Ruffini / Galois perspective).
- **`overview.keyInsights` 5 → 7**: added Eisenstein irreducibility (X³−2 at p=2 ⇒ minimal polynomial of degree 3) and the Delian-problem connection (constructible numbers have degree a power of 2 over ℚ, so ∛2 is not constructible).
- **`conclusion.implications`** expanded with: Galois closure ℚ(∛2, ω) and $S_3$ as smallest non-abelian Galois group; **Delian problem** (doubling the cube) impossibility by Wantzel 1837; classical-impossibility trilogy (Delian, angle trisection, squaring the circle); the alias `irrational_two_pow_one_third` consumed in `GelfondSchneider.lean`.
- **`conclusion.openQuestions` 3 → 4**: added formalisation of the Delian impossibility using the degree-power-of-2 constraint.
- **`sections[].mathContext` 0/8 → 8/8**: every section now has a LaTeX-rich mathContext field (rpow algebra, Real.rpow definition, nlinarith bounds, rational-root-theorem packaging, etc.).

## Axiom integrity

- `axiomCount = 0`, `sorries = 0`, `status = "verified"`, `badge = "mathlib"` — confirmed accurate. No structure-encoded assumptions (no `Axioms` struct usage). ∛2 is fully machine-verified through Mathlib's `irrational_nrt_of_notint_nrt`.

## Verification

- `pnpm build` passed cleanly (16.77s).
- No competitor PRs open on this slug at push time.
- Only `src/data/proofs/cube-root-2-irrational/meta.json` staged; build-time annotations.json normalisations left unstaged per convention.