### PR TITLE
fix(mechanic): wire annotations into birthday-problem-oq-03-oq-01 index.ts

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01/index.ts
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/BirthdayProblemOQ03OQ01.lean?raw')
+
+export const birthdayProblemOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const birthdayProblemOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const birthdayProblemOq03Oq01Data: ProofData = {
+  proof: birthdayProblemOq03Oq01Proof,
+  annotations: birthdayProblemOq03Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default birthdayProblemOq03Oq01Data


### PR DESCRIPTION
## Fix

Replace `birthday-problem-oq-03-oq-01/index.ts` 4-line stub (`import meta; import annotations; export { meta, annotations };`) with the canonical full-template shape so the Lean source panel and typed exports work.

## Evidence

**Before** (4 lines, 113 bytes):
- No `default` export and no `getProofSource`.
- Falls through to the legacy fallback at `src/data/proofs/index.ts:60-79`, which builds a `ProofData` from `module.meta` + `module.annotations` but leaves `proof.source = ''`.
- `ProofViewer.tsx:20` reads `proof.source.split('\n')` — Lean source panel renders empty for this slug despite `proofs/Proofs/BirthdayProblemOQ03OQ01.lean` containing **9,533 bytes**.
- 6 annotations never bind to a typed named export.

**After** (44 lines, canonical template):
- Named exports: `birthdayProblemOq03Oq01Proof`, `birthdayProblemOq03Oq01Annotations`, `birthdayProblemOq03Oq01Data`.
- `default` export: `birthdayProblemOq03Oq01Data` (hits the `module.default` path at `src/data/proofs/index.ts:57`).
- `getProofSource()` lazy-imports `proofs/Proofs/BirthdayProblemOQ03OQ01.lean?raw` (9,533 bytes), populating `proof.source` so `ProofViewer` renders the Lean source panel with its 6 annotations.

`pnpm exec tsc --noEmit -p tsconfig.json` exits 0.

## Scope

- Touches only `src/data/proofs/birthday-problem-oq-03-oq-01/index.ts`.
- No changes to `meta.json`, `annotations.json`, or the Lean source.

Companion to in-flight named-export-variant PRs #18822, #18830, #18834, #18836, #18838 (same 4-line stub class). Per local survey ~13 such slugs remain unclaimed (`chinese-remainder-constructive-oq-03`, `elementary-quadratic-reciprocity-oq-03-oq-01-oq-02`, `erdos-1021-oq-01`, `erdos-1036-oq-01`, `erdos-114-oq-04`, `erdos-1153`, `gcd-algorithm-oq-02`, `gcd-algorithm-oq-04`, `harmonic-divergence-oq-04`, `lagrange-theorem-oq-02-oq-01`, `lagrange-theorem-oq-02-oq-02-oq-01`, `lagrange-theorem-oq-05`, `partition-theorem-oq-03`).

---
Automated fix by lean-mechanic agent.