### PR TITLE
fix(mechanic): wire annotations into lagrange-theorem-oq-02-oq-01 index.ts

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/index.ts
@@ -1,4 +1,38 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ01.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const lagrangeTheoremOQ02OQ01TacticStates: TacticState[] = []
+
+export const lagrangeTheoremOQ02OQ01Data: ProofData = {
+  proof: lagrangeTheoremOQ02OQ01Proof,
+  annotations: lagrangeTheoremOQ02OQ01Annotations,
+  tacticStates: lagrangeTheoremOQ02OQ01TacticStates,
+}


### PR DESCRIPTION
## Fix

The slug `lagrange-theorem-oq-02-oq-01` shipped a 4-line stub `index.ts`:

```ts
import meta from './meta.json';
import annotations from './annotations.json';

export { meta, annotations };
```

This takes the **legacy fallback path** in `src/data/proofs/index.ts:60-79` (`module.default` is undefined, named export `lagrangeTheoremOQ02OQ01Data` is undefined, so it falls back to constructing ProofData from `module.meta`). The fallback hardcodes `source: ''`, so the proof page renders the meta/sections/annotations but the **Lean source code panel is empty**.

The 8.5 KB `annotations.json` (6 annotations) was importable but the page felt incomplete.

## Evidence

**Before**:
- `index.ts`: 4 lines, no typed exports, no `?raw` Lean source import
- `getProofAsync` returns `ProofData` with `source: ''`
- Lean panel on the gallery page renders empty

**After** (37-line canonical template, mirrors sibling `lagrange-theorem-oq-02-oq-02/index.ts`):
- Typed `metaJson` cast, `annotationsJson` import
- `?raw` import of `proofs/Proofs/LagrangeTheoremOQ02OQ01.lean`
- Named camelCase export `lagrangeTheoremOQ02OQ01Data: ProofData` satisfies `slugToExportName(slug)` lookup
- Lean source now renders on the proof page

## Scope

One slug, one file (`src/data/proofs/lagrange-theorem-oq-02-oq-01/index.ts`). No edits to `meta.json`, `annotations.json`, the Lean source, or any other gallery entry.

Out of scope (separate PRs in flight or queued):
- erdos-1059-{oq-01..oq-05,oq-02-oq-01}, divisibility-truncation-general-oq-01, amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 (2-line stubs, fully broken)
- angle-trisection-oq-05-oq-04, elementary-quadratic-reciprocity-oq-03-oq-01-oq-02, erdos-{1021,1036,1153,114-oq-04}-oq-01, gcd-algorithm-oq-{02,04}, harmonic-divergence-oq-04, lagrange-theorem-oq-02-oq-02-oq-01, partition-theorem-oq-03, ramseys-theorem-oq-04, triangular-reciprocals-oq-01 (4-line stubs, source missing)

## Precedent

- #17885 — lagrange-theorem-oq-02-oq-02 (canonical sibling, established the template)
- #18749 — triangle-angle-sum-oq-01
- #18755 — konigsberg-oq-03-oq-02
- ~20 in-flight today across the 23-slug stub class

---
Automated fix by lean-mechanic agent.