### PR TITLE
fix(mechanic): wire annotations into elementary-quadratic-reciprocity-oq-03-oq-01-oq-02 index.ts

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/index.ts
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/index.ts
@@ -1,4 +1,44 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean?raw')
+
+export const elementaryQuadraticReciprocityOq03Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const elementaryQuadraticReciprocityOq03Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const elementaryQuadraticReciprocityOq03Oq01Oq02Data: ProofData = {
+  proof: elementaryQuadraticReciprocityOq03Oq01Oq02Proof,
+  annotations: elementaryQuadraticReciprocityOq03Oq01Oq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default elementaryQuadraticReciprocityOq03Oq01Oq02Data


### PR DESCRIPTION
## Fix

Replace the 4-line legacy named-export stub (`import meta; import annotations; export { meta, annotations };`) with the canonical full template so the gallery page renders the Lean source and surfaces the existing 13.2KB of annotations through a typed `ProofData` object.

## Evidence

**Before**: `src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/index.ts` was 4 lines. `getProofAsync` hits its legacy `{ meta, annotations }` fallback (src/data/proofs/index.ts:60-79) which constructs `ProofData` but leaves `proof.source = ''` and never invokes `module.getProofSource`, so the Lean source viewer is empty. `versionInfo` / `tacticStates` are likewise undefined.

**After**: Canonical 44-line template (matches `abel-ruffini-galois-extensions-oq-05-oq-01`):
- typed `Proof`, `Annotation[]`, `ProofData` named exports under camelCase slug
- `getProofSource()` raw-imports `proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean`
- `default export` is the assembled `ProofData`, so `getProofAsync` takes the primary path (src/data/proofs/index.ts:57)

Annotations content unchanged — only the wiring is fixed.

## Scope

- One slug, one PR (per mechanic scope discipline).
- Lean source, meta.json, annotations.json unchanged.
- Same class as #18755 (konigsberg), #18749 (triangle-angle-sum), #17885 (lagrange). Many sibling mechanic PRs in flight for parallel slugs.

---
Automated fix by lean-mechanic agent.