### PR TITLE
fix(mechanic): wire annotations into erdos-1036-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-1036-oq-01/index.ts
+++ b/src/data/proofs/erdos-1036-oq-01/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1036OQ01.lean?raw')
+
+export const erdos1036Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1036Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1036Oq01Data: ProofData = {
+  proof: erdos1036Oq01Proof,
+  annotations: erdos1036Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1036Oq01Data


### PR DESCRIPTION
## Fix

Replace `erdos-1036-oq-01/index.ts` 4-line stub (`import meta; import annotations; export { meta, annotations };`) with the canonical full-template shape so the Lean source panel and typed exports work.

## Evidence

**Before** (4 lines, 119 bytes):
- No `default` export and no `getProofSource`.
- Falls through to the legacy fallback at `src/data/proofs/index.ts:60-79`, which builds a `ProofData` from `module.meta` + `module.annotations` but leaves `proof.source = ''`.
- `ProofViewer.tsx:20` reads `proof.source.split('\n')` — Lean source panel renders empty for this slug despite `proofs/Proofs/Erdos1036OQ01.lean` containing **7,329 bytes** (169 lines).
- 8 annotations never bind to a typed named export.

**After** (44 lines, canonical template):
- Named exports: `erdos1036Oq01Proof`, `erdos1036Oq01Annotations`, `erdos1036Oq01Data`.
- `default` export: `erdos1036Oq01Data` (hits the `module.default` path at `src/data/proofs/index.ts:57`).
- `getProofSource()` lazy-imports `proofs/Proofs/Erdos1036OQ01.lean?raw` (7,329 bytes), populating `proof.source` so `ProofViewer` renders the Lean source panel with its 8 annotations.

`pnpm exec tsc --noEmit -p tsconfig.json` exits 0.

## Scope

- Touches only `src/data/proofs/erdos-1036-oq-01/index.ts`.
- No changes to `meta.json`, `annotations.json`, or the Lean source.

Companion to in-flight stub-class PRs (#18843, #18844, #18840, #18839, #18838, #18837, #18836, #18834, #18830, #18827, #18822, #18815, #18810, …). Per local survey, remaining unclaimed slugs in this class: `elementary-quadratic-reciprocity-oq-03-oq-01-oq-02`, `erdos-1021-oq-01`, `erdos-114-oq-04`, `erdos-1153`, `gcd-algorithm-oq-02`, `gcd-algorithm-oq-04`, `harmonic-divergence-oq-04`, `lagrange-theorem-oq-02-oq-02-oq-01`, `partition-theorem-oq-03`.

---
Automated fix by lean-mechanic agent.