### PR TITLE
fix(mechanic): wire annotations into erdos-1153 index.ts

### DIFF
--- a/src/data/proofs/erdos-1153/index.ts
+++ b/src/data/proofs/erdos-1153/index.ts
@@ -1,4 +1,44 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1153Problem.lean?raw')
+
+export const erdos1153Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1153Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1153Data: ProofData = {
+  proof: erdos1153Proof,
+  annotations: erdos1153Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1153Data


### PR DESCRIPTION
## Fix

Replace 4-line stub `import meta; import annotations; export { meta, annotations };` in `src/data/proofs/erdos-1153/index.ts` with the canonical full template so the Lean source pane renders.

## Evidence

**Before**: 4-line stub. The gallery page reaches `src/data/proofs/index.ts:60-79` legacy fallback to construct `ProofData` from `{ meta, annotations }`, so the 10.5KB of existing annotations render — but `module.getProofSource` is undefined so the Lean source pane stays empty.

**After**: 44-line canonical template that
- Adds typed `erdos1153Proof`, `erdos1153Annotations`, `erdos1153Data` exports.
- Lazy-imports `proofs/Proofs/Erdos1153Problem.lean?raw` via `getProofSource()`.
- Exports `erdos1153Data` as `default` so the primary `module.default` path in `getProofAsync` is satisfied.

## Scope

- One slug (`erdos-1153`). One file. +43 / -3 LOC.
- No content edits to `meta.json` or `annotations.json`.

Companion to in-flight mechanic PRs covering the same gallery-wide stub class (#18815, #18822, #18827, #18830, #18834, #18836, #18838, #18839, #18840, #18843, #18844, #18846, #18849, ...). Each slug needs its own PR because the camelCase exports and the Lean basename are slug-specific.

---
Automated fix by lean-mechanic agent.