### PR TITLE
fix(mechanic): wire annotations into partition-theorem-oq-03 index.ts

### DIFF
--- a/src/data/proofs/partition-theorem-oq-03/index.ts
+++ b/src/data/proofs/partition-theorem-oq-03/index.ts
@@ -1,4 +1,44 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/PartitionTheoremOQ03.lean?raw')
+
+export const partitionTheoremOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const partitionTheoremOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const partitionTheoremOq03Data: ProofData = {
+  proof: partitionTheoremOq03Proof,
+  annotations: partitionTheoremOq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default partitionTheoremOq03Data


### PR DESCRIPTION
## Fix

Replace the 4-line `import meta; import annotations; export { meta, annotations }` stub at `src/data/proofs/partition-theorem-oq-03/index.ts` with the canonical full template exporting `default` ProofData + named `*Proof`, `*Annotations`, `*Data` exports plus a `getProofSource()` async loader for the Lean source.

## Evidence

**Before**: `module.default` is undefined and `module[partitionTheoremOq03Data]` is undefined, so `getProofAsync` (src/data/proofs/index.ts:48–98) falls through to the legacy reconstruction at line 60 which hardcodes `source: ''`. The Lean source code is never loaded onto the proof page.

**After**: `module.default` resolves to `partitionTheoremOq03Data` (ProofData shape), annotations (7.8KB) are wired through, and `proofs/Proofs/PartitionTheoremOQ03.lean` is lazy-imported via `?raw` so the source renders.

## Scope

One-file diff (+43/-3). No meta/annotations content changes; only the index.ts wiring. Diff shape matches PR #18840 (lagrange-theorem-oq-05) and the broader index.ts-stub class.

Out of scope (separate PRs if needed): other 4-line / 2-line stubs (~12 remain). One slug per PR per scope discipline.

---
Automated fix by lean-mechanic agent.