### PR TITLE
fix(mechanic): wire annotations into partition-theorem-oq-03 index.ts

### DIFF
--- a/src/data/proofs/partition-theorem-oq-03/index.ts
+++ b/src/data/proofs/partition-theorem-oq-03/index.ts
@@ -1,4 +1,44 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/PartitionTheoremOQ03.lean?raw')
+
+export const partitionTheoremOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const partitionTheoremOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const partitionTheoremOq03Data: ProofData = {
+  proof: partitionTheoremOq03Proof,
+  annotations: partitionTheoremOq03Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default partitionTheoremOq03Data


### PR DESCRIPTION
## Fix

Replace 4-line stub `index.ts` (`import meta; import annotations; export { meta, annotations }`) with the canonical 44-line ProofData template so `src/data/proofs/partition-theorem-oq-03/` renders correctly in the gallery.

## Evidence

**Before** (`index.ts`, 4 lines, 109 bytes): only re-exports `meta` and `annotations` as named bindings; no `default` export. `getProofAsync` (`src/data/proofs/index.ts:60-79`) reads `module.default` and gets `undefined`, so `ProofPage.tsx:111` destructures `undefined.proof` / `undefined.annotations` and renders broken despite a 7.8KB `annotations.json` sitting on disk.

**After** (44 lines): canonical template matching `triangle-angle-sum-oq-01/index.ts` (precedent PR #18749, in-flight class). Imports typed meta + annotations, defines `partitionTheoremOq03Proof` / `partitionTheoremOq03Annotations` / `partitionTheoremOq03Data`, exports `partitionTheoremOq03Data` as default, dynamically imports `proofs/Proofs/PartitionTheoremOQ03.lean?raw` for `getProofSource()`.

Diff: 1 file changed, +43 -3.

Same class as in-flight mechanic PRs #18806 / #18810 / #18813 / #18815 / #18817 / #18820 / #18822 / #18823 / #18824 / #18827 / #18830 / #18834 / #18836 / #18837 / #18838 / #18839 / #18840 / #18841 / #18843 (per-slug PRs, one slug per PR by design).

---
Automated fix by lean-mechanic agent.