### PR TITLE
fix(mechanic): wire annotations into erdos-1021-oq-01 index.ts

### DIFF
--- a/src/data/proofs/erdos-1021-oq-01/index.ts
+++ b/src/data/proofs/erdos-1021-oq-01/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1021OQ01.lean?raw')
+
+export const erdos1021Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1021Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1021Oq01Data: ProofData = {
+  proof: erdos1021Oq01Proof,
+  annotations: erdos1021Oq01Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos1021Oq01Data


### PR DESCRIPTION
## Fix

Replace the 4-line stub \`export { meta, annotations }\` in
\`src/data/proofs/erdos-1021-oq-01/index.ts\` with the canonical
44-line wired template so the gallery page renders the proof,
annotations, sections, and Lean source instead of returning
\`module.default\` (the raw meta dict) to \`getProofAsync\` and silently
breaking the page.

## Evidence

**Before**: 4-line stub. \`module.default\` was the truthy raw meta JSON
dict, so \`getProofAsync\` at \`src/data/proofs/index.ts:60-79\` never
reached the fallback branch. \`ProofPage.tsx:111\` then destructured
\`proof\`/\`annotations\`/\`versionInfo\` from undefined.

**After**: canonical template (matches PR #18749 triangle-angle-sum-oq-01
and PR #17885 lagrange-theorem-oq-02-oq-02). Imports \`annotationsJson\`,
hardcodes \`proofs/Proofs/Erdos1021OQ01.lean?raw\` for the async fetch,
exports camelCase \`erdos1021Oq01Proof\`/\`erdos1021Oq01Annotations\`/
\`erdos1021Oq01Data\` and the \`getProofSource()\` async function.

Restores: 5 keyInsights (k=3 settled, O vs o, probabilistic lower
bound, harder-for-large-k, open for all k≥4), 4 sections plus the
header-imports header (oq01-question, trivial-vs-little-o, k3-settled,
lower-bound), historicalContext, problemStatement, proofStrategy,
conclusion, 2 references (Kővári-Sós-Turán 1954, Bondy-Simonovits 1974),
1 cross-reference to parent erdos-1021, and the full 10.8KB annotation
set.

## Scope

One slug per PR. Orthogonal to the in-flight stub-wire wave (#18805
#18806 #18810 #18813 #18815 #18817 #18820 #18822 #18823 #18824 #18827
#18830 #18834 #18836 #18838 #18839 #18840 #18843 #18844 #18846 #18849
#18850 #18852 #18853 — 24 sibling PRs all on this same drift class).
~7 stub index.ts files remain after this one
(triangular-reciprocals-oq-01, angle-trisection-oq-05-oq-04,
ramseys-theorem-oq-04, harmonic-divergence-oq-04, gcd-algorithm-oq-04,
gcd-algorithm-oq-02, lagrange-theorem-oq-02-oq-02-oq-01,
erdos-114-oq-04) — separate PRs each, if needed.

Out of scope: meta.json (sorries=17 / axiomCount=2 / lineCount=191
unchanged), annotations.json (10.8KB unchanged), Lean source
(\`proofs/Proofs/Erdos1021OQ01.lean\` and its Aristotle companion both
present and untouched).

---
Automated fix by lean-mechanic agent.