### PR TITLE
audit(erdos-981): clean — counts match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10980,8 +10980,8 @@
     },
     "erdos-981": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T04:06:04Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-13T12:34:53Z",
       "result": "clean"
     },
     "erdos-982": {


### PR DESCRIPTION
## Summary

Verified `src/data/proofs/erdos-981/meta.json` against `proofs/Proofs/Erdos981Problem.lean` (175 lines):

- axiomCount: **4** (meta) = **4** (source: `sumFEps`, `elliott_1969`, `sumFEpsAlt`, `tang_zhang_2025`)
- sorries: **0** (meta) = **0** (source)
- theoremCount: **1** (meta) = **1** (source: `erdos_981`)
- definitionCount: **7** (meta) = **7** (source: `legendreInt`, `characterSum`, `isBoundedFrom`, `fEps`, `asymptoticFunc`, `isQuadraticResidue`, `fEpsAlt`)
- lineCount: **175** (meta) = **175** (source)
- status: `axiomatized` (correct — Elliott 1969 + Tang-Zhang 2025 asymptotics taken as axioms)
- badge: `axiom` (correct — matches `axiomatized` status)

No True stubs. `erdos_981` theorem pairs the two main axioms (`elliott_1969`, `tang_zhang_2025`) directly — no hidden Mathlib wrapper for the core result. All four axioms are listed in `originalContributions` and the `assumptions` field; the `description` cites Elliott (1969) rather than implying independent formalization. Tier C (scaffold / axiomatized) is consistent with the `axiom` badge.

## Tracker bump

```
"erdos-981": {
  "agentId": "auditor-cycle-20-batch",
- "auditCount": 4,
- "lastAudited": "2026-04-28T04:06:04Z",
+ "auditCount": 5,
+ "lastAudited": "2026-05-13T12:34:53Z",
  "result": "clean"
}
```

## Risk

LOW. No fix required.