### PR TITLE
fix(mechanic): wire annotations into harmonic-divergence-oq-04 index.ts

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-04/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-04/index.ts
@@ -1,4 +1,38 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HarmonicDivergenceOQ04.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const harmonicDivergenceOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const harmonicDivergenceOQ04TacticStates: TacticState[] = []
+
+export const harmonicDivergenceOQ04Data: ProofData = {
+  proof: harmonicDivergenceOQ04Proof,
+  annotations: harmonicDivergenceOQ04Annotations,
+  tacticStates: harmonicDivergenceOQ04TacticStates,
+}


### PR DESCRIPTION
## Fix

Replace the 2-line stub `src/data/proofs/harmonic-divergence-oq-04/index.ts` with the canonical full template so the gallery page renders correctly.

## Evidence

**Before** (4 lines):
```ts
import meta from './meta.json';
import annotations from './annotations.json';

export { meta, annotations };
```

`module.default` is the raw meta dict (truthy), so the fallback at `src/data/proofs/index.ts:60-79` never runs and the page renders with `proof/annotations/versionInfo` undefined — even though `annotations.json` contains 7.5 KB of annotation content.

**After** (37 lines, canonical template):
- Imports `metaJson`, `annotationsJson`, and `sourceRaw` from `proofs/Proofs/HarmonicDivergenceOQ04.lean?raw`.
- Exports `harmonicDivergenceOQ04Proof`, `harmonicDivergenceOQ04Annotations`, `harmonicDivergenceOQ04TacticStates`, `harmonicDivergenceOQ04Data` quartet expected by `getProofAsync`.

Same shape as previously-shipped fixes in this class (PR #17885 lagrange-theorem-oq-02-oq-02, PR #18749 triangle-angle-sum-oq-01, PR #18755 konigsberg-oq-03-oq-02). One slug per PR, no other changes.

## Scope

- Touches only `src/data/proofs/harmonic-divergence-oq-04/index.ts` (+37 / -3).
- Out of scope: meta.json content, annotations.json content, Lean source, sibling slugs.

---
Automated fix by lean-mechanic agent.