### PR TITLE
fix(mechanic): wire annotations into angle-trisection-oq-05-oq-04 index.ts

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-04/index.ts
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/AngleTrisectionOQ05OQ04.lean?raw')
+
+export const angleTrisectionOq05Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOq05Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOq05Oq04Data: ProofData = {
+  proof: angleTrisectionOq05Oq04Proof,
+  annotations: angleTrisectionOq05Oq04Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default angleTrisectionOq05Oq04Data


### PR DESCRIPTION
## Fix

Replaces the 4-line stub `index.ts` (`import meta; import annotations; export { meta, annotations };`) with the canonical 44-line gallery template so the page renders the existing annotations + Lean source instead of leaving them orphaned.

## Evidence

**Before**: `src/data/proofs/angle-trisection-oq-05-oq-04/index.ts` had no default export. `getProofAsync` (`src/data/proofs/index.ts:60-79`) treats a missing/non-object `module.default` as fallback, then the consumer (`ProofPage.tsx:111`) destructures `proof`/`annotations` from `undefined`. Net effect: the 6-annotation, 9.7 KB `annotations.json` and `proofs/Proofs/AngleTrisectionOQ05OQ04.lean` (54 KB source) never reached the rendered page.

**After**: canonical shape (matches `abel-ruffini-galois-extensions-oq-05-oq-01/index.ts` etc.):
- typed `metaJson as unknown as { id, title, slug, description, meta, sections, overview?, conclusion?, crossReferences? }`
- `leanSource = () => import('../../../../proofs/Proofs/AngleTrisectionOQ05OQ04.lean?raw')`
- camelCase exports `angleTrisectionOq05Oq04Proof / Annotations / Data` + async `getProofSource()`
- `export default angleTrisectionOq05Oq04Data` so `getProofAsync` picks up the full `ProofData`.

## Scope

- Touches **only** `src/data/proofs/angle-trisection-oq-05-oq-04/index.ts` (+43 / -3).
- Does **not** alter `meta.json`, `annotations.json`, `tacticStates.json`, the Lean source, or the open research PR #18192 (S8 HH-3 parallel construction).
- Same class as the in-flight stub-wireup wave (PRs #18749 lagrange-theorem-oq-02-oq-02, #18755 konigsberg-oq-03-oq-02, #18850 erdos-1153, #18844 lagrange-theorem-oq-02-oq-01, etc.).

---
Automated fix by lean-mechanic agent.