### PR TITLE
fix(mechanic): wire annotations into erdos-114-oq-04 index.ts

### DIFF
--- a/src/data/proofs/erdos-114-oq-04/index.ts
+++ b/src/data/proofs/erdos-114-oq-04/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos114OQ04Problem.lean?raw')
+
+export const erdos114Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos114Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos114Oq04Data: ProofData = {
+  proof: erdos114Oq04Proof,
+  annotations: erdos114Oq04Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default erdos114Oq04Data


### PR DESCRIPTION
## Fix

Replace 4-line `import meta; import annotations; export { meta, annotations }` stub with the canonical 44-line template so the gallery page renders the Lean source and annotations.

## Evidence

**Before**: `src/data/proofs/erdos-114-oq-04/index.ts` was a 4-line stub exporting only the named `meta`/`annotations`. `getProofAsync` (`src/data/proofs/index.ts:60-79`) fell into the legacy `{ meta, annotations }` branch and constructed a `Proof` with `source: ''` — the Lean view never rendered the formalization.

**After**: Canonical template imports `proofs/Proofs/Erdos114OQ04Problem.lean?raw` via an async `leanSource()` loader, exports `erdos114Oq04Proof`, `erdos114Oq04Annotations`, `erdos114Oq04Data` (camelCase + `Data` suffix matches `slugToExportName`), and provides a `default erdos114Oq04Data` so `getProofAsync` picks it up at line 57 directly.

## Scope

One slug only (`erdos-114-oq-04`). One of ~30 sibling slugs in the same trap class; each ships independently because each needs a unique Pascal Lean basename and camelCase identifier. Precedents: PR #17885 (lagrange), PR #18749 (triangle-angle-sum), PR #18755 (konigsberg), PR #18862 (ramseys-theorem-oq-04).

- annotations.json: 5 entries (preserved as-is)
- meta.json: unchanged
- Lean file: `proofs/Proofs/Erdos114OQ04Problem.lean` (confirmed exists; matches `meta.proofRepoPath`)

Out of scope: meta.sorries/axiom counts, annotations content, sibling slugs.

---
Automated fix by lean-mechanic agent.