### PR TITLE
fix(mechanic): wire annotations into lagrange-theorem-oq-02-oq-02-oq-01 index.ts

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/index.ts
@@ -1,4 +1,38 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOQ02OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOQ02OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const lagrangeTheoremOQ02OQ02OQ01TacticStates: TacticState[] = []
+
+export const lagrangeTheoremOQ02OQ02OQ01Data: ProofData = {
+  proof: lagrangeTheoremOQ02OQ02OQ01Proof,
+  annotations: lagrangeTheoremOQ02OQ02OQ01Annotations,
+  tacticStates: lagrangeTheoremOQ02OQ02OQ01TacticStates,
+}


### PR DESCRIPTION
## Fix

Replaces the 4-line stub `index.ts` (`import meta; import annotations; export { meta, annotations };`) with the canonical 38-line gallery template so the page for *Burnside's Lemma from the Conjugation-Action Class Equation* renders the existing annotations + Lean source instead of leaving them orphaned.

## Evidence

**Before**: `src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/index.ts` exposed only raw JSON modules. `getProofAsync` (`src/data/proofs/index.ts:50-79`) finds no default / `*Data` export and falls back to a legacy path that constructs a ProofData with `source: ''` (empty Lean source). Net effect: the 6-annotation, 9.4 KB `annotations.json` and `proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01.lean` (195 lines, 0 sorries) never reached the rendered page.

**After**: canonical shape (matches `src/data/proofs/lagrange-theorem-oq-02-oq-01/index.ts` etc.):
- typed `metaJson as unknown as { id, title, slug, description, meta, sections, overview?, conclusion?, crossReferences? }`
- static `import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01.lean?raw'`
- named exports `lagrangeTheoremOQ02OQ02OQ01Proof / Annotations / TacticStates / Data` (UPPERCASE OQ matches slugToExportName lookup; `*Data` is picked up by `getProofAsync`).

## Scope

- Touches **only** `src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/index.ts` (+37 / −3).
- Does **not** alter `meta.json`, `annotations.json`, the Lean source, or any sibling slug.
- Same class as the in-flight stub-wireup wave (PRs #18749 lagrange-theorem-oq-02-oq-02, #18844 lagrange-theorem-oq-02-oq-01, #18840 lagrange-theorem-oq-05, #18815 amgm-…, #18817 erdos-1059-oq-02-oq-01, etc.).

---
Automated fix by lean-mechanic agent.