### PR TITLE
fix(mechanic): wire annotations into gcd-algorithm-oq-02 index.ts

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-02/index.ts
+++ b/src/data/proofs/gcd-algorithm-oq-02/index.ts
@@ -1,4 +1,44 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/GcdAlgorithmOQ02.lean?raw')
+
+export const gcdAlgorithmOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gcdAlgorithmOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gcdAlgorithmOq02Data: ProofData = {
+  proof: gcdAlgorithmOq02Proof,
+  annotations: gcdAlgorithmOq02Annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default gcdAlgorithmOq02Data


### PR DESCRIPTION
## Fix

Replace 4-line `import meta; import annotations; export { meta, annotations }` stub with the canonical 44-line template so the gallery page renders the Lean source.

## Evidence

**Before**: `src/data/proofs/gcd-algorithm-oq-02/index.ts` was a 4-line stub exporting only named `meta`/`annotations`. `getProofAsync` (`src/data/proofs/index.ts:60-79`) fell into the legacy `{ meta, annotations }` branch and constructed a `Proof` with `source: ''` — the Lean view never rendered the formalization.

**After**: Canonical template imports `proofs/Proofs/GcdAlgorithmOQ02.lean?raw` via an async `leanSource()` loader, exports `gcdAlgorithmOq02Proof`, `gcdAlgorithmOq02Annotations`, `gcdAlgorithmOq02Data` (camelCase + `Data` suffix matches `slugToExportName`), and provides `default gcdAlgorithmOq02Data` so `getProofAsync` picks it up at line 57 directly.

## Scope

One slug only (`gcd-algorithm-oq-02`). One of ~30 sibling slugs in the same index.ts-stub trap class. Precedents: PR #17885 (lagrange), PR #18749 (triangle-angle-sum), PR #18755 (konigsberg), PR #18815 (amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01), PR #18862 (ramseys-theorem-oq-04), PR #18865 (erdos-114-oq-04).

- annotations.json: 6 entries (preserved as-is)
- meta.json: unchanged
- Lean file: `proofs/Proofs/GcdAlgorithmOQ02.lean` (confirmed exists; matches `meta.proofRepoPath`)

Out of scope: meta.sorries/axiom counts, annotations content, sibling slugs.

---
Automated fix by lean-mechanic agent.