### PR TITLE
research(erdos-1-oq-04): S3 STATE-SYNC — PARTIAL phase + Conway-Guy levers (doc-only)

### DIFF
--- a/research/problems/erdos-1-oq-04/knowledge.md
+++ b/research/problems/erdos-1-oq-04/knowledge.md
@@ -6,16 +6,63 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent problem `erdos-1` asks: if `A ⊆ {1,…,N}` has `|A| = n` with all `2^n` subset sums distinct, must `N ≥ c · 2^n` for some absolute constant `c > 0`? (Erdős OPEN.)
+
+This follow-up (OQ-04) investigates the **structure** of the extremal sets — those achieving the minimum `N = f(n)`. The minimum values form **OEIS A005318**:
+
+| `n` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|-----|---|---|---|---|---|---|---|---|---|
+| `f(n)` | 0 | 1 | 2 | 4 | 7 | 13 | 24 | 44 | 84 |
+
+The **Conway–Guy conjecture** (1968) identifies specific sets achieving these minima:
+
+- `n=4`: `{3, 5, 6, 7}` — max 7
+- `n=5`: `{6, 9, 11, 12, 13}` — max 13
+- `n=6`: `{11, 17, 20, 22, 23, 24}` — max 24
+- `n=7`: `{20, 31, 37, 40, 42, 43, 44}` — max 44
+
+with a recurrence `a_n = a_{n-1} + ⌈S_{n-1}/2⌉` over partial sums.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+1. **`hasDistinctSubsetSums` is decidable**: brute-force enumeration of `A.powerset × A.powerset` gives a `Decidable` instance, enabling `native_decide` for any concrete finite set. This is the workhorse behind the small-case verifications `dss_1, dss_12, dss_124, dss_3567, dss_conway_guy_5` and would extend to `n = 6, 7, 8` directly (Lever A in `state.md`).
+
+2. **The trivial upper bound `f(n) ≤ 2^n − 1`** comes from powers of two `{1, 2, 4, …, 2^{n-1}}`. Each subset has a unique sum because binary representation is unique. The Lean proof (`powers_of_two_dss`) reduces to a `sum_pow_two_inj` lemma proved by induction on `n` with case-analysis on whether `n` is in either subset. This is axiom-free Mathlib-only work and survives in 60 lines including helper lemmas.
+
+3. **The gap `2^n − 1 − f(n)`** is widely conjectured to be the substantive content: Conway–Guy sets give `f(n) ≈ 2^n / √n` asymptotically (Elkies 1986), much smaller than `2^n − 1`. The factor-of-`√n` improvement is non-trivial and comes from entropy/Fourier methods not currently in Mathlib.
+
+4. **Mathlib API used**: `Finset.powerset`, `Finset.sum_image`, `Finset.add_sum_erase`, `Finset.insert_erase`, `Finset.single_le_sum`, `Nat.pow_right_injective`, `Nat.pow_lt_pow_right`. All standard; no API gaps encountered for the verified content.
+
+5. **`conwayGuySeq` recurrence is awkward in Lean ℕ**: `a_n = a_{n-1} + ⌈S_{n-1}/2⌉` requires carrying the partial sum along (so the recurrence is on a pair `(a_n, S_n)`, not on `a_n` alone). The current file sidesteps this by listing OEIS A005318 values up to `n = 8` and defaulting to `0` beyond. A future iteration could fold the partial-sum into a structural recursion to get an exact `conwayGuySeq` for all `n`.
+
+---
+
+## Built items (cross-reference with `src/data/research/problems/erdos-1-oq-04.json`)
+
+- `Erdos1OQ04.lean` (245 LOC, 0 sorries, 0 axioms)
+- `hasDistinctSubsetSums` (definition) + `decidableHasDistinctSubsetSums` (instance)
+- `achievesDistinctSums` (definition)
+- 5 verified small-case theorems via `native_decide`
+- 5 upper-bound theorems `f(n) ≤ …` for `n = 1, 2, 3, 4, 5`
+- `conwayGuySeq` definition for `n ≤ 8` (OEIS A005318)
+- `conwayGuyConjecture` Prop (unverified, stated as the open frontier)
+- 4 private support lemmas for the binary-representation argument
+- `powers_of_two_dss` theorem: universal upper bound `f(n) ≤ 2^n − 1`
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Defining `conwayGuySeq` as primitive recursion on `ℕ`** without carrying the partial sum fails because the recurrence references `S_{n-1} = ∑_{i<n} a_i`, which is a function of the entire history. The current file's list-based definition is a pragmatic workaround.
+
+- **`omega` on `2 ^ i < 2 ^ n`**: must be discharged via `Nat.pow_lt_pow_right`, not `omega` directly (omega does not unfold `Nat.pow`).
+
+---
+
+## Open lines
+
+1. **Lever A**: extend `dss_conway_guy_*` to `n = 6, 7, 8` via `native_decide` (1 session).
+2. **Lever B**: formalize Erdős' counting-argument lower bound `f(n) ≥ (2^n − 1)/n` (2–3 sessions).
+3. **Lever C**: formalize Elkies' Fourier-based improvement `f(n) ≥ (1/2 + o(1)) · 2^n / √n` (multi-session research project).

--- a/research/problems/erdos-1-oq-04/state.md
+++ b/research/problems/erdos-1-oq-04/state.md
@@ -1,25 +1,98 @@
 # Research State: erdos-1-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+
+**Phase**: PARTIAL — small extremal cases verified; Conway-Guy conjecture remains open
 **Path**: full
-**Since**: 2026-03-30T11:35:17-07:00
-**Iteration**: 1
+**Since**: 2026-05-13 (STATE-SYNC; prior `BUILD` snapshot dated to a 119-line draft no longer matches working tree)
+**Iteration**: 3 (S1 OBSERVE-init → S2 BUILD-extremal-cases → S3 STATE-SYNC)
+
+## Status Summary
+
+The Lean file `proofs/Proofs/Erdos1OQ04.lean` is in a stable **partially-verified** rest state:
+
+- **245 lines**, 11 theorems, 4 definitions, 4 private lemmas, 1 decidability instance, **0 sorries**, **0 axioms**.
+- The slug has **no gallery entry** (`src/data/proofs/erdos-1-oq-04/` does not exist); it is research-only formalization at present.
+- The parent problem (`erdos-1`, Distinct Subset Sums) remains an Erdős OPEN problem; this OQ-04 follow-up targets the **structure** of the extremal sets, conjectured by Conway–Guy (1968) but not proved.
+
+### What is proved (axiom-free, from Mathlib 4.26.0)
+
+| Symbol | Statement |
+|--------|-----------|
+| `hasDistinctSubsetSums A` | predicate: distinct subsets of `A : Finset ℕ` have distinct sums |
+| `decidableHasDistinctSubsetSums` | `Decidable (hasDistinctSubsetSums A)` via powerset enumeration |
+| `achievesDistinctSums n N` | predicate: ∃ `A ⊆ {1,…,N}` with `|A|=n`, all positive, having DSS |
+| `dss_1`, `dss_12`, `dss_124`, `dss_3567`, `dss_conway_guy_5` | DSS verified for `{1}`, `{1,2}`, `{1,2,4}`, `{3,5,6,7}`, `{6,9,11,12,13}` via `native_decide` |
+| `f1_eq_1` … `f5_le_13` | upper bounds `f(1)=1, f(2)=2, f(3)≤4, f(4)≤7, f(5)≤13` (OEIS A005318 small values) |
+| `geom_sum_two`, `sum_pow_lt_of_subset_range`, `subset_range_pred` | binary-representation infrastructure |
+| `sum_pow_two_inj` | private: subsets of `Finset.range n` are determined by `∑ 2^i` |
+| `powers_of_two_dss` | **universal upper bound**: `achievesDistinctSums n (2^n - 1)` for every `n` (via binary representation) |
+
+### What is conjectured (the open frontier)
+
+| Definition | Open conjecture |
+|------------|-----------------|
+| `conwayGuySeq : ℕ → ℕ` | the OEIS A005318 sequence (0, 1, 2, 4, 7, 13, 24, 44, 84, …); listed for `n ≤ 8`, defaults to `0` beyond |
+| `conwayGuyConjecture : Prop` | for every `n ≥ 1`, both `achievesDistinctSums n (conwayGuySeq n)` **and** `¬ achievesDistinctSums n (conwayGuySeq n - 1)` — i.e. Conway–Guy gives the EXACT minimum |
+
+`conwayGuyConjecture` is **defined but not proved**, not axiomatized, and (per the parent Erdős problem's open status) is not expected to be discharged in a single iteration. The current file gives existence (`f(n) ≤ 2^n - 1` via `powers_of_two_dss`) but no matching general lower bound.
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+
+None active. The slug is in a **clean partially-verified rest state**. Any further iteration is a multi-session research project, not a single-session continuation.
 
 ## Active Approach
-None yet.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+None pending. The S2 BUILD shipped the small-case + universal-upper-bound infrastructure; no scaffolded tactic sorries remain.
 
-## Blockers
-None.
+## Blockers (for further discharge)
+
+1. **The Conway–Guy conjecture is open** (1968–present). No researcher should claim to "prove" it in a single session. The narrow Lean-formalization question is: can one verify additional Conway–Guy values (`n = 6, 7, 8`) computationally and/or formalize known partial lower bounds (Erdős' `n ≤ N/2^n`, Elkies' improved factor)?
+2. **`conwayGuySeq` beyond `n = 8` requires the recurrence** `a_n = a_{n-1} + ⌈S_{n-1}/2⌉` over partial sums — a non-trivial primitive recursion in Lean ℕ (ceiling of a rational). Current file documents this gap and defaults `n ≥ 9` to `0`.
+3. **No gallery entry** — there is no `src/data/proofs/erdos-1-oq-04/` directory. Adding one would be premature given the partially-verified status; a gallery entry should wait until the lower-bound side (Erdős' `n ≤ N/2^n` factor) is also formalized.
+
+## Research Levers (for future sessions, in order of cost)
+
+### Lever A — additional Conway–Guy `native_decide` verifications
+
+**Cost**: 1 session. **Risk**: low (computational only).
+
+Add `dss_conway_guy_6` for the conjectured `n = 6` set `{11, 17, 20, 22, 23, 24}` (max 24) and `dss_conway_guy_7` for `n = 7` with `{20, 31, 37, 40, 42, 43, 44}` (max 44). Each is a single `native_decide` call. This extends `f(6) ≤ 24` and `f(7) ≤ 44` without touching the open conjecture. Verify the literature for the specific Conway–Guy sets at `n = 6, 7`.
+
+### Lever B — Erdős' general lower bound `f(n) ≥ n + log_2 n - O(1)`
+
+**Cost**: 2–3 sessions. **Risk**: medium (Mathlib API for `Nat.log2` + Finset cardinality lemmas).
+
+The "trivial" lower bound from a counting argument: any DSS set `A` with `|A| = n` and `max A = N` has `2^n` distinct subset sums all in `[0, n·N]`, so `2^n ≤ n·N + 1`, giving `N ≥ (2^n - 1)/n`. Formalize this as `theorem dss_lower_bound : achievesDistinctSums n N → 2^n ≤ n*N + 1`. This is axiom-free Mathlib-only work and turns the file from "verified small cases" into "verified small cases + a non-trivial general lower bound".
+
+### Lever C — Elkies / Bohman improvement `f(n) ≥ (1/2 + o(1)) · 2^n / √n`
+
+**Cost**: multi-session, research-track. **Risk**: high (entropy / Fourier methods not in Mathlib).
+
+Formalize Elkies' 1986 improvement using Fourier/probabilistic methods, or Bohman's `f(n) ≥ 0.22 · 2^n` argument. This is a serious research project; almost certainly out of scope for autonomous iteration. Skipping to Lever B is the correct next step.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+None autonomously. Wait for a seeker selection targeting Lever A (small-case extension) or Lever B (general lower bound). The current `BUILD`-progressSummary in the JSON should be updated to match this file (the prior "119 lines, 2S remain" snapshot is stale; actual file is 245 lines, 0 sorries).
+
+## Attempt Counts
+
+- Total iterations: 3 (S1, S2, S3 = this STATE-SYNC)
+- Current approach attempts: 0 (rest state)
+- Approaches tried: 1 — "verified small extremal cases + binary-representation universal upper bound"; succeeded for `n ≤ 5` and the `2^n - 1` general bound.
+
+## Session History (audit-trail)
+
+Only **shipped** iterations are numbered. Listed in commit-history order on `main`:
+
+| # | Date | Phase | Commit / PR | Outcome |
+|---|------|-------|-------------|---------|
+| S1 | 2026-03-30 | OBSERVE | seeker-init | created problem.md + state.md scaffolding; pool entry added |
+| S2 | (pre-2026-05-07; carried over from `erdos-1-wip-01` historical commit `2f4fcc90e1b` + #12782) | BUILD | landed via parent `erdos-1-wip-01` PRs | shipped 245 LOC Lean file: 5 small extremal cases (`f(1)..f(5)`), Conway–Guy sequence definition, `conwayGuyConjecture` Prop, full proof of `powers_of_two_dss` (universal bound `2^n - 1`) |
+| S3 | 2026-05-13 | STATE-SYNC (this PR) | researcher-9 | corrected progressSummary (stale "119 lines, 2S remain" → accurate "245 lines, 0 sorries"); replaced OBSERVE-stub state.md with PARTIAL phase + Lever A/B/C; added concrete entries to knowledge.md |
+
+## Honesty block
+
+- **No axiom-integrity issue**: file has 0 `axiom` declarations and uses no structure-encoded axioms. `conwayGuyConjecture` is a `Prop` definition, not an axiom — it can be referenced but not assumed.
+- **Open-problem status**: the Conway–Guy conjecture has been open since 1968 (Conway–Guy SIAM Review v. 10 (1968), 304–308). No claim of progress on the conjecture itself is implied by this slug's "0 sorries" status — only the small-case decidability + the universal `2^n - 1` bound are proved.
+- **Gallery omission is deliberate**: this is a partially-verified research workspace, not gallery-ready content. Promoting to gallery awaits Lever B (general lower bound).

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1-oq-04",
   "title": "erdos-1-oq-04",
-  "phase": "ACT",
+  "phase": "PARTIAL",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,38 +16,51 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-30T11:35:17-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "phase": "PARTIAL",
+    "since": "2026-05-13",
+    "iteration": 3,
+    "focus": "Verified small extremal cases (n=1..5) + binary-representation universal upper bound 2^n-1. Conway-Guy conjecture (1968) remains open; awaiting follow-on iteration on Lever A (extend native_decide to n=6,7,8) or Lever B (Erd\u0151s counting-argument lower bound).",
+    "blockers": [
+      "Conway-Guy conjecture is an OPEN problem (1968-present); no claim of single-session discharge",
+      "conwayGuySeq beyond n=8 needs partial-sum recurrence (non-trivial primitive recursion in Lean N)",
+      "No gallery entry \u2014 premature given partially-verified status"
+    ],
+    "nextAction": "Lever A: add dss_conway_guy_6 = {11,17,20,22,23,24} (max 24) + dss_conway_guy_7 = {20,31,37,40,42,43,44} (max 44) via native_decide. Single session. Then Lever B: formalize Erd\u0151s trivial lower bound f(n) >= (2^n-1)/n.",
     "attemptCounts": {
-      "total": 0,
+      "total": 3,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: Created Erdos1OQ04.lean (119 lines). Verified f(1)-f(5) via native_decide. Defined Conway-Guy conjecture. 2S remain.",
+    "progressSummary": "PARTIAL: Erdos1OQ04.lean (245 LOC, 11 theorems, 4 defs, 4 private lemmas, 1 instance, 0 sorries, 0 axioms). Verified f(1)..f(5) via native_decide. Defined Conway-Guy sequence (OEIS A005318 n<=8) and conwayGuyConjecture Prop (1968 OPEN). Proved universal upper bound powers_of_two_dss: achievesDistinctSums n (2^n - 1) via binary-representation lemma sum_pow_two_inj. No gallery entry. Status: PARTIAL rest state pending Lever A/B follow-up.",
     "builtItems": [
-      "Created Erdos1OQ04.lean with extremal set formalization",
-      "Decidable instance for hasDistinctSubsetSums",
-      "Verified DSS for {1}, {1,2}, {1,2,4}, {3,5,6,7}, {6,9,11,12,13}",
-      "Proved f(1)=1, f(2)=2, f(3)<=4, f(4)<=7, f(5)<=13",
-      "Defined Conway-Guy conjecture"
+      "hasDistinctSubsetSums + decidableHasDistinctSubsetSums (powerset enumeration)",
+      "achievesDistinctSums predicate",
+      "Verified DSS for {1}, {1,2}, {1,2,4}, {3,5,6,7}, {6,9,11,12,13} via native_decide",
+      "Upper bounds f(1)=1, f(2)=2, f(3)<=4, f(4)<=7, f(5)<=13 (OEIS A005318 small values)",
+      "conwayGuySeq : N -> N (OEIS A005318 listed for n<=8, 0 beyond \u2014 partial-sum recurrence sidestepped)",
+      "conwayGuyConjecture Prop (open frontier, not axiomatized)",
+      "Binary-representation infrastructure: geom_sum_two, sum_pow_lt_of_subset_range, subset_range_pred, sum_pow_two_inj",
+      "powers_of_two_dss theorem: universal upper bound achievesDistinctSums n (2^n - 1) for all n"
     ],
     "insights": [
-      "hasDistinctSubsetSums is decidable by checking all pairs in powerset",
-      "Conway-Guy sets: {3,5,6,7} for n=4 and {6,9,11,12,13} for n=5",
-      "Powers of 2 give suboptimal max (2^(n-1) vs optimal f(n))"
+      "hasDistinctSubsetSums is decidable by checking all pairs in powerset; enables native_decide",
+      "Conway-Guy sets at small n: {3,5,6,7} (n=4), {6,9,11,12,13} (n=5), {11,17,20,22,23,24} (n=6, unverified in file)",
+      "Powers of 2 give suboptimal max (2^n - 1 vs conjectured optimal Conway-Guy a_n ~ 2^n / sqrt(n))",
+      "Binary representation argument: sum_pow_two_inj proved by induction on n with case-split on whether n is in either subset",
+      "conwayGuySeq recurrence a_n = a_{n-1} + ceil(S_{n-1}/2) is awkward in Lean N: requires carrying partial sum S_n along, so structural recursion is on (a_n, S_n) pair"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "No general API for the partial-sum recurrence pattern (a_n, S_n) jointly; one-off in this file",
+      "Entropy/Fourier methods underlying Elkies 1986 lower bound f(n) >= (1/2 + o(1)) * 2^n / sqrt(n) not in Mathlib (Lever C)"
+    ],
     "nextSteps": [
-      "Define Conway-Guy recurrence precisely",
-      "Prove optimality: no set in {1,...,f(n)-1} has n elements with DSS"
+      "Lever A (1 session): add dss_conway_guy_6 and dss_conway_guy_7 via native_decide",
+      "Lever B (2-3 sessions): formalize Erd\u0151s counting-argument lower bound f(n) >= (2^n - 1) / n",
+      "Lever C (multi-session research): Elkies / Bohman improved lower bound \u2014 Fourier-Mathlib gap"
     ],
-    "markdown": "# Knowledge Base: erdos-1-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "markdown": "# Knowledge Base: erdos-1-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThe parent problem `erdos-1` asks: if `A \u2286 {1,\u2026,N}` has `|A| = n` with all `2^n` subset sums distinct, must `N \u2265 c \u00b7 2^n` for some absolute constant `c > 0`? (Erd\u0151s OPEN.)\n\nThis follow-up (OQ-04) investigates the **structure** of the extremal sets \u2014 those achieving the minimum `N = f(n)`. The minimum values form **OEIS A005318**:\n\n| `n` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |\n|-----|---|---|---|---|---|---|---|---|---|\n| `f(n)` | 0 | 1 | 2 | 4 | 7 | 13 | 24 | 44 | 84 |\n\nThe **Conway\u2013Guy conjecture** (1968) identifies specific sets achieving these minima:\n\n- `n=4`: `{3, 5, 6, 7}` \u2014 max 7\n- `n=5`: `{6, 9, 11, 12, 13}` \u2014 max 13\n- `n=6`: `{11, 17, 20, 22, 23, 24}` \u2014 max 24\n- `n=7`: `{20, 31, 37, 40, 42, 43, 44}` \u2014 max 44\n\nwith a recurrence `a_n = a_{n-1} + \u2308S_{n-1}/2\u2309` over partial sums.\n\n---\n\n## Insights\n\n1. **`hasDistinctSubsetSums` is decidable**: brute-force enumeration of `A.powerset \u00d7 A.powerset` gives a `Decidable` instance, enabling `native_decide` for any concrete finite set. This is the workhorse behind the small-case verifications `dss_1, dss_12, dss_124, dss_3567, dss_conway_guy_5` and would extend to `n = 6, 7, 8` directly (Lever A in `state.md`).\n\n2. **The trivial upper bound `f(n) \u2264 2^n \u2212 1`** comes from powers of two `{1, 2, 4, \u2026, 2^{n-1}}`. Each subset has a unique sum because binary representation is unique. The Lean proof (`powers_of_two_dss`) reduces to a `sum_pow_two_inj` lemma proved by induction on `n` with case-analysis on whether `n` is in either subset. This is axiom-free Mathlib-only work and survives in 60 lines including helper lemmas.\n\n3. **The gap `2^n \u2212 1 \u2212 f(n)`** is widely conjectured to be the substantive content: Conway\u2013Guy sets give `f(n) \u2248 2^n / \u221an` asymptotically (Elkies 1986), much smaller than `2^n \u2212 1`. The factor-of-`\u221an` improvement is non-trivial and comes from entropy/Fourier methods not currently in Mathlib.\n\n4. **Mathlib API used**: `Finset.powerset`, `Finset.sum_image`, `Finset.add_sum_erase`, `Finset.insert_erase`, `Finset.single_le_sum`, `Nat.pow_right_injective`, `Nat.pow_lt_pow_right`. All standard; no API gaps encountered for the verified content.\n\n5. **`conwayGuySeq` recurrence is awkward in Lean \u2115**: `a_n = a_{n-1} + \u2308S_{n-1}/2\u2309` requires carrying the partial sum along (so the recurrence is on a pair `(a_n, S_n)`, not on `a_n` alone). The current file sidesteps this by listing OEIS A005318 values up to `n = 8` and defaulting to `0` beyond. A future iteration could fold the partial-sum into a structural recursion to get an exact `conwayGuySeq` for all `n`.\n\n---\n\n## Built items (cross-reference with `src/data/research/problems/erdos-1-oq-04.json`)\n\n- `Erdos1OQ04.lean` (245 LOC, 0 sorries, 0 axioms)\n- `hasDistinctSubsetSums` (definition) + `decidableHasDistinctSubsetSums` (instance)\n- `achievesDistinctSums` (definition)\n- 5 verified small-case theorems via `native_decide`\n- 5 upper-bound theorems `f(n) \u2264 \u2026` for `n = 1, 2, 3, 4, 5`\n- `conwayGuySeq` definition for `n \u2264 8` (OEIS A005318)\n- `conwayGuyConjecture` Prop (unverified, stated as the open frontier)\n- 4 private support lemmas for the binary-representation argument\n- `powers_of_two_dss` theorem: universal upper bound `f(n) \u2264 2^n \u2212 1`\n\n---\n\n## Dead Ends\n\n- **Defining `conwayGuySeq` as primitive recursion on `\u2115`** without carrying the partial sum fails because the recurrence references `S_{n-1} = \u2211_{i<n} a_i`, which is a function of the entire history. The current file's list-based definition is a pragmatic workaround.\n\n- **`omega` on `2 ^ i < 2 ^ n`**: must be discharged via `Nat.pow_lt_pow_right`, not `omega` directly (omega does not unfold `Nat.pow`).\n\n---\n\n## Open lines\n\n1. **Lever A**: extend `dss_conway_guy_*` to `n = 6, 7, 8` via `native_decide` (1 session).\n2. **Lever B**: formalize Erd\u0151s' counting-argument lower bound `f(n) \u2265 (2^n \u2212 1)/n` (2\u20133 sessions).\n3. **Lever C**: formalize Elkies' Fourier-based improvement `f(n) \u2265 (1/2 + o(1)) \u00b7 2^n / \u221an` (multi-session research project).\n"
   },
   "tags": [],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Doc-only STATE-SYNC for slug `erdos-1-oq-04` (Erdős Problem #1, OQ-04: structure of extremal sets for distinct subset sums).

The Lean file `proofs/Proofs/Erdos1OQ04.lean` has been in a stable PARTIAL rest state for some time, but the slug's `state.md` and JSON `currentState` were still the seeker-init OBSERVE / ACT stubs from 2026-03-30, and `knowledge.progressSummary` referenced an obsolete 119-line draft ("2S remain").

This PR re-aligns the documentation with the actual file state.

## Audit (worktree state, no Lean changes)

`proofs/Proofs/Erdos1OQ04.lean`:

- 245 lines, 11 theorems, 4 definitions, 4 private lemmas, 1 decidability instance, **0 sorries**, **0 axioms**.
- Verified `f(1)..f(5)` via `native_decide` (OEIS A005318 small values).
- Defined `conwayGuySeq` (n≤8 from OEIS A005318) and `conwayGuyConjecture` as a `Prop` (1968 OPEN, **not** axiomatized).
- Proved universal upper bound `powers_of_two_dss`: `achievesDistinctSums n (2^n - 1)` via the binary-representation lemma `sum_pow_two_inj` (axiom-free Mathlib-only).

Per the axiom-integrity policy in `CLAUDE.md`: the open Conway-Guy conjecture is a `Prop` definition, **not** an axiom, and is not assumed anywhere. Status is therefore PARTIAL (not "axiomatized"): the small-case + general-bound infrastructure is verified, the main conjecture remains stated-but-not-proved.

## Files changed (3, doc-only)

| File | Change |
|------|--------|
| `research/problems/erdos-1-oq-04/state.md` | Replace 25-line OBSERVE-stub with 99-line PARTIAL state: status summary, what-is-proved table, what-is-conjectured table, three forward levers (A/B/C), session-history audit-trail, honesty block |
| `research/problems/erdos-1-oq-04/knowledge.md` | Replace template scaffolding with concrete problem-understanding (OEIS A005318 table, Conway-Guy sets), 5 insights, 8 built-items, 1 dead-end, 3 open lines |
| `src/data/research/problems/erdos-1-oq-04.json` | `phase`: `ACT` → `PARTIAL`; rewrite `currentState` (phase/since/iteration/focus/blockers/nextAction/attemptCounts); rewrite `knowledge.progressSummary` (stale "119 lines, 2S remain" → accurate "245 LOC, 0 sorries, 0 axioms"); expand `builtItems` 5 → 8, `insights` 3 → 5, `mathlibGaps` 0 → 2, `nextSteps` 2 → 3 (Lever A/B/C); update `knowledge.markdown` mirror |

No Lean file, no `meta.json`, no Aristotle companion, no gallery entry, no axiom-integrity drift.

## Forward levers (documented in `state.md` for future sessions)

- **Lever A** (1 session, low risk): add `dss_conway_guy_6` for `{11,17,20,22,23,24}` (max 24) and `dss_conway_guy_7` for `{20,31,37,40,42,43,44}` (max 44) via `native_decide`. Extends `f(6) ≤ 24`, `f(7) ≤ 44`.
- **Lever B** (2-3 sessions, medium risk): formalize Erdős' counting-argument lower bound `f(n) ≥ (2^n - 1) / n`. Axiom-free Mathlib-only.
- **Lever C** (multi-session research, high risk): Elkies (1986) Fourier-method improvement `f(n) ≥ (1/2 + o(1)) · 2^n / √n`. Mathlib gap on entropy/Fourier; out of scope for autonomous iteration.

## Race / collision check

- `gh pr list --repo rjwalters/lean-genius --state open --search "erdos-1-oq-04 in:title"` returns `[]` immediately before push.
- `gh pr list --repo rjwalters/lean-genius --state open --search "Erdos1OQ04"` returns `[]`.
- No `audit/sync-*` or `fix(meta)*` open PR touches the slug.
- Branch `research/erdos-1-oq-04-state-sync-1778676234` created fresh from `origin/main`; no contamination from `feature/researcher-9` (which is at `origin/main`).

## Test plan

- [x] `git diff --stat` shows exactly 3 files changed, all doc-only
- [x] No Lean file, no `meta.json`, no `annotations.json`, no `index.ts` touched
- [x] JSON `leanFiles[Erdos1OQ04.lean]` already accurate (`lineCount=246`, `theoremCount=11`, `axiomCount=0`, `defCount=4`, `sorryCount=0`); no drift introduced
- [x] state.md / knowledge.md / JSON-knowledge mutually consistent (built-items, insights, levers reproduced across all three locations)
- [ ] Auditor pass: `axiomCount=0` confirmed (file has 0 `axiom` declarations and no structure-encoded assumptions; `conwayGuyConjecture` is a `Prop`, not an axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)