### PR TITLE
audit(erdos-1072): sync meta drift — theoremCount 14→15 + leanFile block (169/7 → 241/15)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3540,10 +3540,11 @@
       "result": "clean"
     },
     "erdos-1072": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "lastAudited": "2026-05-13T12:47:32Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-agent"
     },
     "erdos-1073": {
       "auditCount": 4,
@@ -15242,5 +15243,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-13T07:20:25Z"
+  "lastUpdated": "2026-05-13T12:47:32Z"
 }

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 3,
     "lineCount": 241,
     "assumptions": "3 axiom declarations (all OPEN conjectures): erdos_1072a (infinitely many maximal primes), erdos_1072b (f(p)/p → 0 for almost all primes), hardy_subbarao_belief (maximal primes have density 0). All provable axioms eliminated: wilson_theorem, f_le_pred, f_pos, f_of_2, f_of_3, f_of_5, f_of_7, f_of_11, f_of_13. Wilson-maximality decided explicitly on {2,3,5,7,11,13}: maximal {2,3,5,13}; non-maximal {7,11}.",
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 2
   },
   "overview": {
@@ -243,9 +243,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 169,
+    "lineCount": 241,
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 15,
     "definitionCount": 2,
     "path": "Proofs/Erdos1072Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Drift introduced by PR #18767 (`f_of_11, f_of_13 + 6 Wilson-maximal classification corollaries`).

### Counts

| Field | meta (before) | leanFile (before) | source | meta (after) | leanFile (after) |
|---|---|---|---|---|---|
| `axiomCount` | 3 | 3 | 3 | 3 | 3 |
| `theoremCount` | **14** | **7** (stale) | **15** | **15** | **15** |
| `definitionCount` | 2 | 2 | 2 | 2 | 2 |
| `lineCount` | 241 | **169** (stale) | 241 | 241 | 241 |
| `sorries` | 0 | 0 | 0 | 0 | 0 |

### Root cause

PR #18767's commit message arithmetic was **off-by-one**: the message said *"theoremCount 7 → 14"* but it added **8** new theorems (`f_of_11`, `f_of_13`, `isWilsonMaximal_{2,3,5,13}`, `isNotWilsonMaximal_{7,11}`) — the correct sum is 7 + 8 = **15**, not 14.

The nested `leanFile` block was also not refreshed by PR #18767; it still carries the pre-PR counts (169 / 7).

### Verification

Source counts confirmed on current `origin/main` HEAD (`a6f70dc75cf`) against `proofs/Proofs/Erdos1072Problem.lean`:

- **241 lines**, **3 axioms** (`erdos_1072a`, `erdos_1072b`, `hardy_subbarao_belief`), **15 theorems** (lines 44, 56, 65, 105, 112, 124, 135, 148, 162, 176, 180, 185, 189, 195, 203), **2 defs** (`leastFactorialWilson` noncomputable, `isWilsonMaximal`), **0 sorries**, **0 True stubs**.

### Tracker

```diff
 "erdos-1072": {
-  "auditCount": 4,
+  "auditCount": 5,
   "issues": [],
-  "lastAudited": "2026-05-04T04:03:31Z",
-  "result": "clean"
+  "lastAudited": "2026-05-13T12:47:32Z",
+  "result": "issues-fixed",
+  "agentId": "auditor-agent"
 }
```

### Honesty

`erdos_1072a` (infinitely many Wilson-maximal primes) and `erdos_1072b` (f(p)/p → 0 for almost all primes) remain **OPEN** conjectures axiomatized. Status `axiomatized` and badge `axiom` are correct; this PR does not change them.

### Risk

LOW. Pure metadata sync. No Lean files touched. No claims downgraded — meta still describes the same gallery entry, now with internally-consistent counts.

---
Discovered during gallery integrity audit. Audited by `auditor-agent` at 2026-05-13T12:47Z.