### PR TITLE
research(erdos-218): STATE-SYNC — axiomatized-infrastructure-complete, 2-axiom floor = open conjectures (doc-only)

### DIFF
--- a/research/problems/erdos-218/state.md
+++ b/research/problems/erdos-218/state.md
@@ -1,27 +1,111 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T16:05:28.188Z
-**Iteration**: 1
+**Phase**: AXIOMATIZED-INFRASTRUCTURE-COMPLETE / CONJECTURES-OPEN (state.md reset from seeker-init stub 2026-01-12 → reality 2026-05-13)
+**Since**: 2026-05-13T12:00:00Z (state.md sync; Lean infrastructure progressed via PRs #5383, #7141, #7773, #7795, #8552 between 2026-03-24 and 2026-03-30)
+**Iteration**: 7 (post-PR-#7141 STATE-SYNC; doc-only)
 
 ## Current Focus
 
-Initial exploration of the problem.
+**Erdős Problem #218: Prime Gap Densities** is one of Erdős's open conjectures (Tao: *"looks difficult"*). The slug's Lean formalization (`proofs/Proofs/Erdos218Problem.lean`, 418 LOC, 22 theorems/lemmas, 12 definitions per JSON `leanFiles[]`) builds the full surrounding infrastructure (prime enumeration, gap function, natural-density definition, gap sets, AP equivalence) with **0 sorries** and **2 axioms** — the two axioms are *the* open conjectures themselves (`erdos_218a`, `erdos_218b`), not proof gaps in supporting lemmas.
+
+## What Is Axiomatized vs Proved
+
+### Axiomatized (the open conjectures themselves)
+
+| Axiom | Statement | Status |
+|-------|-----------|--------|
+| `erdos_218a` | `HasDensity gapIncreasingSet (1/2)` — density of `{n : d_{n+1} ≥ d_n}` is 1/2 | OPEN (Erdős Conjecture 218a) |
+| `erdos_218b` | `HasDensity gapDecreasingSet (1/2)` — density of `{n : d_{n+1} ≤ d_n}` is 1/2 | OPEN (Erdős Conjecture 218b) |
+
+Note: Erdős Conjecture 218c (`gapEqualSet.Infinite` — infinitely many `n` with `d_n = d_{n+1}`) is mentioned in the docstring but is NOT currently stated as an axiom. It is equivalent to "infinitely many 3-term APs of consecutive primes" (proved equivalent in the Lean file via `gapEqual_iff_ap` + `infinitely_many_3ap_from_218c`); it is implied by Green-Tao only modulo the consecutive-primes restriction.
+
+### Proved (everything else)
+
+| Theorem | Statement | Approach |
+|---------|-----------|----------|
+| `nthPrime_prime`, `_strictMono`, `_zero/one/two/three/four` | Prime enumeration via `Nat.nth` | Direct from Mathlib `Nat.nth` API + `decide`/`Nat.nth_count` for concrete values |
+| `primeGap_zero/one/two/three`, `primeGap_pos` | `primeGap n := nthPrime (n+1) - nthPrime n` is positive | `unfold` + `rw` from `nthPrime_*` values |
+| `hasDensity_iff_upper_lower` | `HasDensity S d ↔ limsup = d ∧ liminf = d` | Standard limit ↔ limsup ∧ liminf characterization |
+| `zero_mem_gapIncreasingSet` | `0 ∈ gapIncreasingSet` (primeGap 0 = 1 ≤ primeGap 1 = 2) | Direct from `primeGap_zero` + `primeGap_one` |
+| `one_mem_gapEqualSet` | `1 ∈ gapEqualSet` (primeGap 1 = primeGap 2 = 2) | Direct from `primeGap_one` + `primeGap_two` |
+| `gapEqualSet_eq_inter` | `gapEqualSet = gapIncreasingSet ∩ gapDecreasingSet` | `ext` + `le_antisymm` |
+| `gapEqual_iff_ap` | `n ∈ gapEqualSet ↔ threePrimesInAP n` | `omega` on ℕ subtraction with `strictMono` hypotheses |
+| `infinitely_many_3ap_from_218c` | `gapEqualSet.Infinite → apTriples.Infinite` | `convert` via `gapEqual_iff_ap` |
+| `example_ap_1`, `ap_357` | `1 ∈ gapEqualSet`, `1 ∈ apTriples` (primes 3,5,7 form AP) | Direct from `one_mem_gapEqualSet` + `gapEqual_iff_ap` |
+| `infinite_of_hasDensity_pos` (private) | `HasDensity S d ∧ d > 0 → S.Infinite` | Squeeze: finite ⇒ counting function bounded ⇒ ratio → 0; contradicts `d > 0` via `tendsto_nhds_unique` |
+| `gapIncreasingSet_infinite`, `_decreasingSet_infinite` | Both gap-comparison sets are infinite | Apply `infinite_of_hasDensity_pos` to `erdos_218a/b` |
+| `partition` | `strictlyIncreasing ∪ strictlyDecreasing ∪ gapEqualSet = univ` | Trichotomy on `<`/`>`/`=` |
+| `erdos_218_summary` | Composite summary theorem | Composes the above |
+
+## Per-File Inventory
+
+| File | LOC | Sorries | Axioms | Theorems | Defs | Role |
+|------|-----|---------|--------|----------|------|------|
+| `Erdos218Problem.lean` | 418 | 0 | 2 | 22 | 12 | Main + only file; infrastructure + 2 open-conjecture axioms |
+
+`meta.json`: `status: axiomatized`, `badge: axiom`, `sorries: 0`, `axiomCount: 2` — all already accurate for the current Lean state.
+
+(Note: JSON `leanFiles[].lineCount: 419` is 1 line off from actual `wc -l` count of 418 — minor drift, not addressed in this STATE-SYNC as it does not affect any consumer.)
+
+## What Has Already Been Eliminated (PR history)
+
+The slug saw substantial axiom-elimination work over ~6 days in late March 2026:
+
+| PR | Date | Effect |
+|----|------|--------|
+| #5383 | 2026-03-24 | erdos-218 + erdos-738 + erdos-854 — eliminate 22 axioms total (combined slug PR) |
+| #7141 | 2026-03-27 | erdos-218 — eliminate 14 axioms via Mathlib `Nat.nth` definitions |
+| #7773 | 2026-03-29 | erdos-218 — prove `hasDensity_iff_upper_lower` (8 → 7 axioms) |
+| #7795 | 2026-03-29 | meta audit: sorry 0→1, axiom 7→5 |
+| #8552 | 2026-03-30 | meta audit: axiomCount=2 not 5, sorries=0 not 1 |
+| (final) | now | 2 axioms = 2 open Erdős conjectures (lower bound) |
+
+The remaining 2 axioms are at the **theoretical floor** for this slug: they encode the open mathematical conjectures and cannot be eliminated without resolving the conjectures themselves.
 
 ## Active Approach
 
-None yet.
+None pending. Infrastructure is complete and the 2 axioms ARE the open mathematical content; there is no Lean engineering left for the slug as currently scoped.
 
 ## Blockers
 
-None.
+The two remaining axioms encode genuinely open mathematical problems:
+
+1. **`erdos_218a`** (density of gap-increasing set = 1/2): Erdős's original conjecture from [Er55c], [Er57]. Tao characterized the problem as *"looks difficult"*. No known analytic method to obtain density 1/2 (vs. just "infinite", which is already proved).
+2. **`erdos_218b`** (density of gap-decreasing set = 1/2): Same status — open conjecture, no known proof. NOT the set-theoretic complement of 218a (both allow equality at `gapEqualSet`).
+
+Mathlib has no bearer for either conjecture.
 
 ## Next Action
 
-Begin problem exploration.
+Three viable forward levers — but all are research-grade and unlikely to be discharged by routine ACT iterations:
+
+1. **Lever A — Add `erdos_218c` as an explicit axiom + Green-Tao implication chain**: Currently `gapEqualSet.Infinite` is mentioned in docstrings but not formally axiomatized. Adding `axiom erdos_218c : gapEqualSet.Infinite` would expose the AP-of-3-consecutive-primes question explicitly, even though Green-Tao does NOT directly imply it (Green-Tao gives ALL primes contain long APs, not specifically *consecutive* primes). Worth ~20 LOC of explicit statement + connection. Note: this would *increase* axiom count from 2 → 3; weigh against the gain of explicit statement.
+2. **Lever B — Partial density bounds**: Prove `0 < density(gapIncreasingSet) < 1` (positive lower bound, strict upper bound) without claiming `= 1/2`. Some recent analytic work (post-Maynard) gives weak quantitative bounds. ~100-200 LOC, would replace `erdos_218a` with a quantitative range, leaving the exact `= 1/2` as a tightened axiom. Major effort with unclear Mathlib bearer.
+3. **Lever C — Treat as gallery showcase**: Accept axiomatized status (this slug is correctly tagged `tier: A`, `significance: 7-10`). Focus efforts on related slugs (`erdos-2`, `erdos-21`, sibling problems) instead of pushing on the conjectures themselves.
+
+For routine queue management, **Lever C is the right default**: this slug is in its terminal Lean state until a major number-theory breakthrough lands.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 6 (multiple PRs from 2026-01 through 2026-03; this STATE-SYNC = doc-only)
+- Current approach attempts: 0 (no active research push)
+- Approaches tried: 1 (Mathlib `Nat.nth`-based infrastructure — succeeded; reached 2-axiom floor)
+
+## Honesty Block
+
+- **The slug is NOT solved**: Erdős's two density conjectures (`erdos_218a`, `erdos_218b`) remain genuinely open in mathematics. The 2 axioms in the Lean file are honest placeholders for the unsolved conjectures.
+- **The Lean infrastructure IS complete**: All supporting lemmas (prime enumeration, gap function, density characterization, gap sets, AP equivalence, infinite-density-implies-infinite-set, summary theorem) are proved with 0 sorries.
+- **`meta.status: axiomatized` is correct** per `CLAUDE.md`'s axiom integrity policy: open conjectures must be `axiomatized` (not `verified`, not `conditional`). The 2 axioms in this file ARE assumptions encoded as axioms — they would need to be eliminated by a major mathematical advance, not engineering.
+- **`badge: axiom` is correct**: the Lean file declares 2 axioms, and `axiomCount: 2` in the JSON `leanFiles[]` entry matches.
+- **The `progressSummary` in the JSON already says "COMPLETED: Proved infinite_of_hasDensity_pos"** — that referred to the most recent engineering completion (eliminating the last fixable axiom). It does NOT mean the slug overall is solved. This STATE-SYNC PR clarifies that distinction.
+- This is a doc-only STATE-SYNC: no Lean files, no `meta.json` counts, no annotations were touched. The 2-axiom Lean state is unchanged.
+
+## References
+
+- `proofs/Proofs/Erdos218Problem.lean` — Lean source (latest non-trivial PRs #7141, #7773, all in 2026-03)
+- `src/data/research/problems/erdos-218.json` — knowledge graph (this STATE-SYNC updates `currentState` block + `lastUpdate`; refreshes `knowledge.insights` last-line axiom count from 7 → 2)
+- Erdős references: [Er55c], [Er57], [Er61], [Er65b], [Er85c]
+- OEIS: A333230 (gap-increasing indices), A333231 (gap-decreasing), A064113 (equal-gap)
+- Source: https://erdosproblems.com/218
+- Related: Green-Tao (2008) — `Mathlib.NumberTheory.LSeries.PrimesInAP` and related (does NOT directly imply Erdős 218c due to "consecutive primes" restriction)
+- Sibling slugs: `erdos-2`, `erdos-21`

--- a/src/data/research/problems/erdos-218.json
+++ b/src/data/research/problems/erdos-218.json
@@ -16,16 +16,19 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-12T16:05:28.188Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "AXIOMATIZED-INFRASTRUCTURE-COMPLETE",
+    "since": "2026-05-13T12:00:00Z",
+    "iteration": 7,
+    "focus": "Lean infrastructure is complete (418 LOC, 0 sorries, 22 theorems, 12 defs). The 2 remaining axioms (erdos_218a, erdos_218b) ARE the open Erdős conjectures themselves — they are at the theoretical floor for this slug and cannot be eliminated without a major number-theory advance.",
+    "blockers": [
+      "erdos_218a (density(gapIncreasingSet) = 1/2) is an open Erdős conjecture (Tao: 'looks difficult'); no Mathlib bearer.",
+      "erdos_218b (density(gapDecreasingSet) = 1/2) is an open Erdős conjecture; not the set-theoretic complement of 218a (both allow gapEqualSet)."
+    ],
+    "nextAction": "Lever C (default for queue management): accept axiomatized status; this slug is in terminal Lean state until a major number-theory breakthrough lands. Lever A (~20 LOC): add explicit erdos_218c axiom for 'gapEqualSet.Infinite' (currently only in docstring) — would increase axiom count 2 → 3 in exchange for explicit statement. Lever B (~100-200 LOC, speculative): partial density bounds (0 < density < 1) without claiming exact 1/2 — would replace erdos_218a with a tightened axiom; unclear Mathlib bearer.",
     "attemptCounts": {
-      "total": 0,
+      "total": 6,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -50,7 +53,7 @@
       "nthPrime 3=7 and nthPrime 4=11 proved via Nat.nth_count + decide",
       "example_ap_1 and ap_357 follow from one_mem_gapEqualSet + gapEqual_iff_ap",
       "hasDensity_iff_upper_lower proved: Tendsto ↔ limsup=d ∧ liminf=d",
-      "Remaining 7 axioms: 3 open conjectures, Green-Tao, 2 PNT-dependent, 1 PNT-dependent",
+      "Remaining 2 axioms (post 2026-03-30): both are open Erdős conjectures themselves — erdos_218a (density(gapIncreasingSet)=1/2) and erdos_218b (density(gapDecreasingSet)=1/2). At theoretical floor.",
       "Finite set counting function bounded by |S.toFinset|, divided by N tends to 0, contradicting positive density"
     ],
     "mathlibGaps": [],
@@ -71,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T16:05:28.188Z",
-  "lastUpdate": "2026-03-13T07:52:17.044Z",
+  "lastUpdate": "2026-05-13T12:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Doc-only **STATE-SYNC** for `erdos-218` (Erdős Problem #218: Prime Gap Densities — Tao: *"looks difficult"*).

`state.md` was a 4-month-old seeker-init `Phase: NEW since 2026-01-12` stub. The JSON's `currentState` block was identical seeker-init stub, and `knowledge.insights` still listed `"Remaining 7 axioms"` from before the axiom-elimination arc in PRs #5383 → #7141 → #7773 → #7795 → #8552 (2026-03-24 → 2026-03-30) drove the count down to its theoretical floor of **2**.

## Current Reality (verified 2026-05-13)

- `proofs/Proofs/Erdos218Problem.lean`: **418 LOC, 0 sorries, 2 axioms, 22 theorems/lemmas, 12 definitions**.
- The 2 remaining axioms (`erdos_218a`, `erdos_218b`) **ARE the open Erdős conjectures themselves** — they cannot be eliminated without a major number-theory advance.
- `meta.json` `status=axiomatized`, `badge=axiom`, `sorries=0`, `axiomCount=2` — all already accurate (per `CLAUDE.md`'s axiom integrity policy: open conjectures must be \`axiomatized\`, not \`verified\` or \`conditional\`).

## What This PR Changes

**`research/problems/erdos-218/state.md`** (+104 -7 LOC):
- Phase: `NEW` → `AXIOMATIZED-INFRASTRUCTURE-COMPLETE / CONJECTURES-OPEN`
- "What Is Axiomatized vs Proved" tables — the 2 axioms (open conjectures with statements + Tao's *"looks difficult"* characterization) vs the 22 supporting theorems (prime enumeration via \`Nat.nth\`, prime-gap function and concrete values, natural-density characterization, gap sets and their interrelations, AP equivalence \`gapEqual_iff_ap\`, infinite-from-positive-density squeeze, partition trichotomy, composite \`erdos_218_summary\`)
- Per-file inventory with LOC/sorry/axiom/theorem/def counts
- PR history table for the axiom-elimination arc (#5383 → #8552; 22+14+1+2 axiom eliminations across 6 days)
- Three forward levers:
  - **Lever A** (~20 LOC): explicitly axiomatize \`erdos_218c\` (currently only in docstring); axiom count would go 2 → 3 in exchange for explicit statement
  - **Lever B** (~100-200 LOC, speculative): partial density bounds (\`0 < density < 1\`) without claiming exact 1/2; unclear Mathlib bearer
  - **Lever C** (default): accept terminal axiomatized status; this slug is in terminal Lean state until a major number-theory breakthrough lands. Recommended for queue management.
- Honesty block: clarifies that the slug is NOT solved; the 2 axioms encode genuinely open mathematics; the \`progressSummary\`'s `"COMPLETED:"` refers to engineering completion, not mathematical completion.

**`src/data/research/problems/erdos-218.json`** (+13 -7 LOC):
- `currentState.phase`: `NEW` → `AXIOMATIZED-INFRASTRUCTURE-COMPLETE`
- `currentState.since`: `2026-01-12` → `2026-05-13`
- `currentState.iteration`: 1 → 7
- `currentState.focus`, `blockers`, `nextAction` refreshed
- `currentState.attemptCounts.total`: 0 → 6
- `knowledge.insights`: \"Remaining 7 axioms: 3 open conjectures, Green-Tao, 2 PNT-dependent, 1 PNT-dependent\" → \"Remaining 2 axioms (post 2026-03-30): both are open Erdős conjectures themselves — erdos_218a (density(gapIncreasingSet)=1/2) and erdos_218b (density(gapDecreasingSet)=1/2). At theoretical floor.\"
- `lastUpdate`: `2026-03-13` → `2026-05-13`
- Top-level `phase: OBSERVE` **preserved** (it is the working-iteration label; `currentState.phase` is the seeker-history label)

## Scope: doc-only

- **No Lean files touched.** The 2-axiom Lean state is unchanged.
- **No `meta.json` touched.** \`status=axiomatized\`, \`badge=axiom\`, \`sorries=0\`, \`axiomCount=2\` already accurate.
- **No annotations.json touched.**
- **No JSON `leanFiles[]` entries touched.** (Minor 1-line LOC drift in `leanFiles[].lineCount` 419 vs actual 418 is noted in state.md's per-file table but not addressed here — that is auditor's domain.)

## Why STATE-SYNC and not a research push

The 2 remaining axioms are *the* open mathematical conjectures (`erdos_218a`, `erdos_218b`). They are at the **theoretical floor** for the slug as scoped: eliminating them requires resolving Erdős's conjectures, not Lean engineering. Tao characterized the problem as *"looks difficult"*. This is the correct terminal Lean state.

The slug has been ranking RICH (knowledge score 19) under `claim-random`'s depth-first priority, but it has no further engineering work pending. The STATE-SYNC PR replaces the stale seeker-init stub with accurate state so future researchers/seeker recognize this slug's terminal status and either pick Lever A / B (if genuinely interested in stretching) or skip to other problems (Lever C — recommended).

## Pre-push race checks

- `gh pr list --search "erdos-218 in:title" --state open` → 0 results
- `gh pr list --search "erdos-218" --state open` → 0 results
- `git log HEAD~..origin/main -- research/problems/erdos-218/ src/data/research/problems/erdos-218.json` → 0 commits in the gap

## Test plan

- [x] `python3 -c \"import json; json.load(...)\"` confirms JSON validity post-edit.
- [x] Diff is doc-only (+107 -20 across 2 files; no `.lean` / `.ts` / `meta.json` schema changes elsewhere).
- [x] Main Lean file content unchanged (still 418 LOC, 0 sorries, 2 axioms).
- [x] Per-file inventory in state.md matches JSON \`leanFiles[].theoremCount\` (22) and \`defCount\` (12) — uses JSON's authoritative numbers (not my own re-count, to avoid introducing a separate drift).
- [x] No race with concurrent agent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)