### PR TITLE
audit(erdos-947): clean re-audit — counts match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10748,8 +10748,8 @@
     },
     "erdos-947": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T04:06:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T12:51:28Z",
       "result": "clean"
     },
     "erdos-948": {


### PR DESCRIPTION
## Summary

Clean re-audit of Erdős Problem #947 (No Exact Covering Systems Exist). All meta.json counts verified against `proofs/Proofs/Erdos947Problem.lean`.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`no_exact_covering_system`, `covering_systems_exist`) | ✓ |
| theoremCount | 2 | 2 (`distinct_moduli_not_exact`, `erdos_947_summary`) | ✓ |
| definitionCount | 7 | 7 (incl. `CoveringSystem` structure) | ✓ |
| lineCount | 192 | 192 | ✓ |
| True stubs | — | 0 | ✓ |

## Narrative integrity

- `status: axiomatized` / `badge: axiom` correctly reflects the 2-axiom architecture
- `assumptions` field accurately lists both axiom names
- `originalContributions` accurately scopes what is *proved* (contrapositive, `exactCoveringWithRepeats` construction, summary) vs *axiomatized* (Mirsky-Newman/Davenport-Rado impossibility, covering-systems existence)
- Mirsky-Newman and Davenport-Rado proof approaches appear in docstrings only — no hidden axioms or theorem declarations beyond the two named

## Tracker change

`auditCount: 3 → 4`, `lastAudited` refreshed to 2026-05-13.

## Test plan

- [x] `grep -nE "^axiom " proofs/Proofs/Erdos947Problem.lean` → 2 matches
- [x] `grep -nE "^theorem " proofs/Proofs/Erdos947Problem.lean` → 2 matches
- [x] `grep -nE "^(def|structure) " proofs/Proofs/Erdos947Problem.lean` → 7 matches
- [x] No `sorry`, `: True`, or `:= trivial` outside docstrings
- [x] `wc -l` confirms 192 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)