### PR TITLE
research(shannon-source-coding-oq-04): STATE-SYNC — refresh state.md to reflect Track A COMPLETED-WEAK frontier (doc-only)

### DIFF
--- a/research/problems/shannon-source-coding-oq-04/state.md
+++ b/research/problems/shannon-source-coding-oq-04/state.md
@@ -1,93 +1,146 @@
 # Research State: shannon-source-coding-oq-04
 
 ## Current State
-**Phase**: ACT (statement audit; awaiting decision between Track A vs Track B)
-**Since**: 2026-04-27T17:55:00Z
-**Iteration**: 4
+**Phase**: COMPLETED-WEAK — Track A discharged (degenerate-type witness, 0 sorries, 0 axioms)
+**Since**: 2026-05-13 (STATE-SYNC; prior Iteration 4 "ACT awaiting Track A/B decision" since 2026-04-27)
+**Iteration**: STATE-SYNC
 
 ## Current Focus
 
-`ShannonSourceCodingOQ04.lean` has 1 remaining sorry at line 386, in
-`source_coding_achievability_mot`. Session 4 audit (2026-04-27) found that the **statement
-of this theorem is trivially true** — it does not actually capture Shannon's achievability
-claim because:
+State.md was describing an **Iteration 4 audit pending decision between Track A
+(trivial form) and Track B (real theorem with AEP)**, claiming `1 remaining sorry at
+line 386`. Subsequent work shipped Track A: the sorry was discharged with the
+intentionally-weak degenerate-type form, and the companion (Aristotle) file's sorry
+was also closed. State.md never caught up to that frontier.
 
-- `δ` does not appear in the conclusion
-- `code_length = 0` always works (since `n * H(p) + n * ε ≥ 0`)
-- The witness type `f = (n, 0, ..., 0)` has type class `{const 0}` (singleton, ≤ 2^0 = 1)
+This is a doc-only STATE-SYNC refresh. No proof artifact is modified.
 
-The supporting infrastructure is already proved:
+## Source-of-Truth Counts
 
-| Lemma | Role |
-|---|---|
-| `type_class_size_eq_multinomial` | |T_f| = n!/∏(fᵢ!) (combinatorial identity) |
-| `count_types_le` | distinct types ≤ (n+1)^k (polynomial in n) |
-| `total_sequences_eq` | Total k^n sequences |
-| `dominant_type_lower_bound` | Largest type class has ≥ k^n / (n+1)^k sequences |
-| `type_class_size_le_entropy_pow` | |T_f| ≤ 2^{n H(Q)} (entropy upper bound) |
+### `proofs/Proofs/ShannonSourceCodingOQ04.lean` (main, 462 LOC)
+
+| Kind            | Count | Notes                                                        |
+|-----------------|-------|--------------------------------------------------------------|
+| Definitions     | 2     | `empDist`, `typeClass`                                       |
+| Theorems        | 11    | incl. `source_coding_achievability_mot` (was the sorry)      |
+| Sorries         | 0     | verified by `grep -cE '^\s*sorry\s*$\|:= sorry$\|:= by sorry'` |
+| Axioms          | 0     | verified by `grep -cE '^axiom '`                              |
+
+### `proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean` (companion, 233 LOC)
+
+| Kind            | Count |
+|-----------------|-------|
+| Definitions     | 2     |
+| Theorems        | 4     |
+| Sorries         | 0     |
+| Axioms          | 0     |
+
+### `src/data/proofs/shannon-source-coding-oq-04/meta.json`
+
+- `status: "verified"`
+- `badge: "mathlib"`
+- `sorries: 0`
+- `axiomCount: 0`
+- `lineCount: 462`
+- `assumptions: []`
+
+These match the Lean source.
+
+## What Was Actually Discharged
+
+`source_coding_achievability_mot` (main file, lines 377–419) proves:
+
+```
+∀ ε > 0, ∀ δ > 0, ∃ N : ℕ, ∀ n ≥ N,
+  ∃ code_length, code_length ≤ n·H(p) + n·ε ∧
+  ∃ f hf, (typeClass n f hf).card ≤ 2^code_length
+```
+
+The proof witnesses `N = 0`, `code_length = 0`, and `f = update (0 : Fin k → ℕ) 0 n`
+(the constant-zero sequence type). The type class is a singleton (its sole element is
+the constant-zero function `Fin n → Fin k`), so `card ≤ 2^0 = 1`. The bound
+`0 ≤ n·H(p) + n·ε` follows from `shannonEntropy_nonneg` (proved inline from
+`hp_pos`) and `ε > 0`.
+
+This is the **intentionally-weak Track A statement**:
+- `δ` does not appear in the conclusion (intentional — the strong statement would
+  bound the probability-mass coverage by `1 - δ`)
+- `code_length = 0` is admissible because the existential type-class is
+  unconstrained by `p`'s probability mass
+- The witness is the degenerate type, not the dominant type
+
+The docstring at line 386 explicitly documents this: *"δ is unused in the conclusion
+— this is weaker than the true source coding theorem (which requires covering
+probability ≥ 1-δ). Proved via degenerate type."*
+
+## Supporting Infrastructure (proved, dormant for Track B)
+
+The following lemmas in the main file remain available and could be invoked by a
+future Track B strengthening:
+
+| Lemma                              | Statement (informal)                                        |
+|------------------------------------|-------------------------------------------------------------|
+| `type_class_size_eq_multinomial`   | |T_f| = n!/∏(fᵢ!)                                           |
+| `count_types_le`                   | #(distinct empirical distributions) ≤ (n+1)^k               |
+| `total_sequences_eq`               | k^n total sequences                                          |
+| `dominant_type_lower_bound`        | ∃ type class with ≥ k^n / (n+1)^k sequences                 |
+| `type_class_size_le_entropy_pow`   | |T_f| ≤ 2^(n·H(Q))                                          |
+| `empEntropy_eq_shannonEntropy`     | bridge between empirical entropy and Shannon entropy         |
+| `multinomial_le_entropy_pow`       | multinomial coefficient bounded by entropy power            |
+| `type_class_partition`             | sequences partition into type classes                       |
+
+These are **proved, axiom-free** and could be re-used by a Track B effort.
+
+## Forward Levers (NOT a roadmap — Track A is shipped)
+
+1. **Track B (strong achievability) remains open.** Replace
+   `source_coding_achievability_mot` with the AEP-style statement covering
+   probability ≥ 1 − δ. Requires product-measure machinery on `Fin n → Fin k`
+   plus a concentration result (Chernoff/Hoeffding ≈ 150 LOC). Estimated total
+   ≈ 300–500 LOC. The supporting-infrastructure table above gives the available
+   levers — only the AEP step is missing.
+2. **KL-divergence bridge.** `Mathlib.InformationTheory.KullbackLeibler.Basic`
+   exposes `KullbackLeiblerFun`; for finite alphabets `H(p) = log(k) − D(p ‖ uniform)`,
+   which could provide an alternate continuity argument and connect this file to
+   Mathlib's information-theory API.
+3. **Audit the "verified" badge.** The `meta.json` claims `status: "verified"` +
+   `badge: "mathlib"`. The weak statement is mathematically true and proved, but
+   the entry's *name* ("Shannon Source Coding") may oversell the formal content
+   to a casual reader. Optional follow-up: add a `notes` field to meta.json
+   pointing at the weak-statement caveat — this PR does not make that change
+   to avoid widening scope beyond state.md.
 
 ## Active Approach
 
-Two tracks identified:
-
-- **Track A** (Quick Win, ~30 lines): Prove the trivial form to eliminate the sorry.
-  Mark statement as weak in description; status → `axiomatized` (with companion axiom for the
-  real claim).
-- **Track B** (Real Theorem, ~300-500 lines): Strengthen the statement to capture
-  probability-mass coverage; prove via type-class size bounds + AEP / concentration.
-
-## Attempt Count
-- Total attempts: 4 (sessions 1-4)
-- Current approach attempts: 4
-- Approaches tried: 1 (combinatorial method-of-types infrastructure)
+State synchronization only; no proof edits.
 
 ## Blockers
 
-- **Disk pressure** (1.5 GiB free as of 2026-04-27) blocks Docker build verification.
-- Track B requires AEP-like concentration: `∑_x ∏_j p(x j) → 1 - O(ε)` for sequences in the
-  dominant type class. This needs LLN/concentration infrastructure (~300+ lines).
+None. The Lean source builds, and Track A is closed. Track B is open work, not a
+blocker.
 
 ## Next Action
 
-Decide between Track A and Track B (a human-level decision about formalization standards).
+If a researcher wants to pursue Track B: open a fresh branch and replace
+`source_coding_achievability_mot` with the strong AEP statement using the
+supporting infrastructure above. The Track A version can either be kept as
+`source_coding_achievability_mot_weak` or replaced outright.
 
-If Track A:
-1. Prove the trivial form (~30 lines, see knowledge.md Session 4 for sketch)
-2. Add `shannonEntropy_nonneg` lemma if not in scope
-3. Add a clear note in the docstring/description that the statement is weak
-4. Add `axiom source_coding_achievability_mot_strong` for the real claim
-5. Update meta.json: status → `axiomatized`, badge → `axiom`
+## Honesty Block
 
-If Track B:
-1. Replace the statement with the strong version (see knowledge.md)
-2. Build product-measure-on-`Fin n → Fin k` infrastructure (~50 lines)
-3. Prove dominant-type concentration via Chernoff or Hoeffding (~150 lines)
-4. Assemble achievability (~100 lines)
-5. Total: 1 sorry → 0 sorries with REAL achievability content
+- This is a doc-only state.md refresh — no `.lean`, no `meta.json`, no
+  `annotations.json`, and no Mathlib symbol was modified.
+- "Phase: COMPLETED-WEAK" describes the saturated state of the Track A scope;
+  it explicitly does NOT claim the genuine Shannon source coding theorem
+  (probability-mass coverage form) is proved. That is the unbuilt Track B.
+- Counts above were verified by `grep`/`wc` against the Lean files at HEAD.
+- `meta.json` `status: "verified"` reflects that the weak statement compiles
+  without sorry or axiom. It does not reflect the strength of the proof.
 
-## Key Mathlib Lemmas (Session 4 reference)
+## Attempt Counts
 
-- `shannonEntropy` (local, line 42): non-negative for probability distributions
-- `Finset.sum_ite_eq'`: gives `∑ i, (if i = a then x else 0) = x` for the degenerate type
-- `Real.exp_nonneg`: needed for the H + ε bound positivity
-- (Track B only) `Mathlib.Analysis.SpecificLimits.Basic`, `Mathlib.Probability.IdentDistrib`
-
-## Mathlib API Survey (Mathlib 4.26.0)
-
-| Symbol | Use |
-|---|---|
-| `Mathlib.InformationTheory.KullbackLeibler.Basic` | KL divergence — useful for entropy continuity |
-| `Mathlib.InformationTheory.KullbackLeibler.KLFun` | KL function and properties |
-| `Mathlib.InformationTheory.Hamming` | Hamming distance (unrelated) |
-| `Real.logb` | Used in `shannonEntropy` definition |
-| `Real.exp_log` / `Real.rpow_logb` | Conversion between log and rpow |
-
-Mathlib does **not** have a Shannon entropy function with the standard name (the
-file's `shannonEntropy` is locally defined). It does have KL divergence, from which
-H(p) = log(k) - D(p ‖ uniform) for finite alphabets — could be used as a bridge if
-needed.
-
-## Remaining Work
-
-- 1 sorry: `source_coding_achievability_mot` (line 386) — trivially provable per audit
-- For genuine achievability content: need product measure + AEP/concentration (Track B)
+- Total attempts (cumulative): 4 sessions + Track A discharge + STATE-SYNC (this PR)
+- Current approach attempts: STATE-SYNC iteration (this PR)
+- Approaches tried (cumulative): combinatorial method-of-types infrastructure (proved);
+  degenerate-type witness for the weak achievability statement (proved, Track A);
+  AEP/Chernoff strengthening (open, Track B)


### PR DESCRIPTION
## Summary

state.md was Iteration 4 from 2026-04-27 describing **"ACT — statement audit
awaiting decision between Track A (trivial form) and Track B (real theorem)"**
and claiming **1 remaining sorry at line 386**. Subsequent work shipped Track A:
`source_coding_achievability_mot` was discharged with the intentionally-weak
degenerate-type witness, and the companion file's sorry was also closed.

state.md never caught up. This PR is a doc-only refresh.

## Current Lean source state

| File                                                | LOC  | Defs | Theorems | Sorries | Axioms |
|-----------------------------------------------------|------|------|----------|---------|--------|
| `ShannonSourceCodingOQ04.lean` (main)               | 462  | 2    | 11       | 0       | 0      |
| `ShannonSourceCodingOQ04Aristotle.lean` (companion) | 233  | 2    | 4        | 0       | 0      |

`meta.json`: `status: "verified"`, `badge: "mathlib"`, `sorries: 0`, `axiomCount: 0`.

## What the discharged theorem actually says

`source_coding_achievability_mot` (lines 377–419) proves a **deliberately weak**
form: `δ` is unused in the conclusion, `code_length = 0` is admissible, and the
witness type class is `f = (n, 0, …, 0)` — the constant-zero singleton with
`card ≤ 2^0 = 1`. The docstring at line 386 explicitly flags this as weaker
than the strong (probability-mass coverage) Shannon source coding theorem.

This is **Track A** from the prior audit. **Track B** (strong AEP form, ≈ 300–500
LOC requiring product-measure + Chernoff/Hoeffding concentration) remains open.

## Refreshed state.md content

- Phase: COMPLETED-WEAK (was ACT awaiting decision)
- Per-file count tables for main + companion
- Explicit summary of what the weak theorem says (and why it is weak)
- Supporting-infrastructure inventory (8 proved lemmas dormant for Track B reuse):
  `type_class_size_eq_multinomial`, `count_types_le`, `total_sequences_eq`,
  `dominant_type_lower_bound`, `type_class_size_le_entropy_pow`,
  `empEntropy_eq_shannonEntropy`, `multinomial_le_entropy_pow`,
  `type_class_partition`
- 3 forward levers (Track B AEP; KL-divergence bridge via Mathlib; optional
  `meta.json` honesty audit) — all out of scope for this PR
- Honesty block noting Phase: COMPLETED-WEAK does **not** claim the strong
  Shannon source coding theorem is proved

## Scope

- **In scope**: `research/problems/shannon-source-coding-oq-04/state.md` only.
- **Out of scope**: `meta.json` (`status: "verified"` claim — could be argued
  to oversell content but is technically correct); `annotations.json` (dormant
  gallery); the Lean files themselves.

## Test plan

- [x] `git diff origin/main` shows exactly one file changed (state.md only).
- [x] All counts in the tables verified via `grep`/`wc` against
      `proofs/Proofs/ShannonSourceCodingOQ04*.lean`.
- [x] No build needed — doc-only, no Lean or TypeScript change.
- [x] `gh pr list --search "shannon-source-coding-oq-04 in:title" --state open`
      returned `[]` immediately before push (no race).
- [x] This is STATE-SYNC #2 of session per the 2-PR/session cap (per MEMORY.md
      `feedback_researcher_state_sync_doc_only_pr_pattern.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)