### PR TITLE
research(erdos-1065): S-ACT — full uniqueness of (k,q) + disjoint k-layers (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1065BatemanHorn.lean
+++ b/proofs/Proofs/Erdos1065BatemanHorn.lean
@@ -99,6 +99,81 @@ theorem formA_decomposition_unique {p k₁ k₂ q₁ q₂ : ℕ}
     rw [hv1, hv2] at hpv; exact hpv
   exact ⟨hk, Nat.eq_of_mul_eq_mul_left (pow_pos (by norm_num : 0 < 2) k₂) (hk ▸ heq)⟩
 
+/-- **Full uniqueness of the (k, q) decomposition.** Strengthens
+    `formA_decomposition_unique` by removing the side conditions `q₁ ≠ 2`,
+    `q₂ ≠ 2`: the (k, q) decomposition of a Form A prime is unique without
+    any parity hypothesis. The q = 2 case (Fermat-like form p = 2^(k+1) + 1)
+    still has a unique witness because every other prime is odd and odd
+    primes do not divide powers of 2.
+
+    Proof strategy: case-split on whether each of q₁, q₂ equals 2.
+    - Both = 2: the equation 2^(k₁+1) = 2^(k₂+1) gives k₁ = k₂.
+    - One = 2, other odd: the odd prime would have to divide a power of 2,
+      contradicting its primality.
+    - Both odd: defer to `formA_decomposition_unique`. -/
+theorem formA_decomposition_unique_full {p k₁ k₂ q₁ q₂ : ℕ}
+    (hq1 : q₁.Prime) (hq2 : q₂.Prime)
+    (h1 : p = 2 ^ k₁ * q₁ + 1) (h2 : p = 2 ^ k₂ * q₂ + 1) :
+    k₁ = k₂ ∧ q₁ = q₂ := by
+  -- Common equation on predecessors
+  have heq : 2 ^ k₁ * q₁ = 2 ^ k₂ * q₂ := by omega
+  by_cases hq1_eq : q₁ = 2
+  · by_cases hq2_eq : q₂ = 2
+    · -- Both q's = 2: reduce to 2^(k₁+1) = 2^(k₂+1)
+      refine ⟨?_, hq1_eq.trans hq2_eq.symm⟩
+      subst hq1_eq; subst hq2_eq
+      have hpow : (2 : ℕ) ^ (k₁ + 1) = 2 ^ (k₂ + 1) := by
+        rw [pow_succ, pow_succ]; linarith
+      have hk_succ : k₁ + 1 = k₂ + 1 :=
+        Nat.pow_right_injective (by norm_num) hpow
+      omega
+    · -- q₁ = 2, q₂ odd prime → q₂ ∣ 2^(k₁+1) → q₂ = 2, contradiction
+      exfalso
+      subst hq1_eq
+      have hpow : (2 : ℕ) ^ (k₁ + 1) = 2 ^ k₂ * q₂ := by
+        rw [pow_succ]; linarith
+      have hdvd : q₂ ∣ 2 ^ (k₁ + 1) := ⟨2 ^ k₂, by rw [mul_comm]; exact hpow⟩
+      have hdvd2 : q₂ ∣ 2 := hq2.dvd_of_dvd_pow hdvd
+      have hq2_le : q₂ ≤ 2 := Nat.le_of_dvd (by norm_num) hdvd2
+      have hq2_ge : 2 ≤ q₂ := hq2.two_le
+      exact hq2_eq (by omega)
+  · by_cases hq2_eq : q₂ = 2
+    · -- q₂ = 2, q₁ odd prime: symmetric to previous case
+      exfalso
+      subst hq2_eq
+      have hpow : (2 : ℕ) ^ k₁ * q₁ = 2 ^ (k₂ + 1) := by
+        rw [pow_succ]; linarith
+      have hdvd : q₁ ∣ 2 ^ (k₂ + 1) := ⟨2 ^ k₁, by rw [mul_comm]; exact hpow.symm⟩
+      have hdvd2 : q₁ ∣ 2 := hq1.dvd_of_dvd_pow hdvd
+      have hq1_le : q₁ ≤ 2 := Nat.le_of_dvd (by norm_num) hdvd2
+      have hq1_ge : 2 ≤ q₁ := hq1.two_le
+      exact hq1_eq (by omega)
+    · -- Both q's odd: defer to existing partial uniqueness
+      exact formA_decomposition_unique hq1 hq2 hq1_eq hq2_eq h1 h2
+
+/-- **Witness agreement (Prod form).** Any two (k, q) witnesses of a Form A
+    decomposition for the same prime p coincide as ordered pairs. -/
+theorem formA_witnesses_agree {p k₁ k₂ q₁ q₂ : ℕ}
+    (hq1 : q₁.Prime) (hq2 : q₂.Prime)
+    (h1 : p = 2 ^ k₁ * q₁ + 1) (h2 : p = 2 ^ k₂ * q₂ + 1) :
+    (k₁, q₁) = (k₂, q₂) := by
+  obtain ⟨hk, hq⟩ := formA_decomposition_unique_full hq1 hq2 h1 h2
+  exact Prod.ext hk hq
+
+/-- **Disjoint decomposition by k-value** (file header claim §3 made formal).
+    For distinct k₁ ≠ k₂, the k-layers `{p | IsFormAWithK k₁ p}` and
+    `{p | IsFormAWithK k₂ p}` are disjoint as sets of primes.
+
+    Consequence: Form A primes partition (modulo the k = 0 singleton {3})
+    into pairwise-disjoint layers indexed by k ≥ 0. The full uniqueness
+    theorem `formA_decomposition_unique_full` is the load-bearing input. -/
+theorem formAWithK_disjoint {k₁ k₂ : ℕ} (h : k₁ ≠ k₂) :
+    Disjoint {p : ℕ | IsFormAWithK k₁ p} {p : ℕ | IsFormAWithK k₂ p} := by
+  rw [Set.disjoint_left]
+  rintro p ⟨_, q₁, hq1, heq1⟩ ⟨_, q₂, hq2, heq2⟩
+  obtain ⟨hk, _⟩ := formA_decomposition_unique_full hq1 hq2 heq1 heq2
+  exact h hk
+
 -- ## Verified Examples: Form A with specific k values
 
 -- k = 0 examples

--- a/src/data/research/problems/erdos-1065.json
+++ b/src/data/research/problems/erdos-1065.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-01-15T14:38:41.571Z",
-    "iteration": 2,
-    "focus": "Corrected factual errors and added complete Form A census for primes ≤100",
+    "since": "2026-05-13T12:55:00Z",
+    "iteration": 3,
+    "focus": "S-ACT: full uniqueness of (k,q) decomposition + disjoint k-layer formalization",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Next session: derive constructive Form A criterion via the canonical 2-adic decomposition of p−1 (odd part of p−1 prime ⇒ Form A); or strengthen BH-axiom-free results.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Identified and corrected axiom-integrity defect in batemanHorn_formAWithK_infinite (was inconsistent at k=0). Added 8 new theorems including k-layer characterizations (k=0,2,3) and Erdős 1065a bridge. File still has 1 axiom (now correctly restricted to k ≥ 1).",
+    "progressSummary": "PROGRESS: Strengthened formA_decomposition_unique to a parity-free version (formA_decomposition_unique_full): uniqueness of the (k,q) decomposition holds for all primes including q=2 (Fermat-like form p=2^(k+1)+1). Added Prod-form corollary formA_witnesses_agree and formalized the file header §3 promise via formAWithK_disjoint. Erdos1065BatemanHorn.lean: 32→35 theorems, axioms unchanged (1, restricted to k ≥ 1).",
     "builtItems": [
       "example_23, example_47, example_53, example_59, example_83, example_89 in Erdos1065Problem.lean",
       "example_37_extended: proof that 37 IS Form B (corrects prior error)",
@@ -53,7 +53,10 @@
       "formAWithK2_iff: Form A with k=2 ⟺ p = 4q+1",
       "formAWithK3_iff: Form A with k=3 ⟺ p = 8q+1",
       "isFormA_unfold: bridge between BatemanHorn.IsFormA and Problem.IsTwoTimePrimePlusOne",
-      "bh_k1_implies_formA_infinite: explicit BH→1065a derivation"
+      "bh_k1_implies_formA_infinite: explicit BH→1065a derivation",
+      "formA_decomposition_unique_full: strict generalization of formA_decomposition_unique, removes q ≠ 2 side conditions (Erdos1065BatemanHorn.lean)",
+      "formA_witnesses_agree: Prod-form corollary — any two (k,q) witnesses coincide as ordered pairs",
+      "formAWithK_disjoint: pairwise disjointness of k-layers (file header §3 claim made formal)"
     ],
     "insights": [
       "The original file claimed 8 Form A primes ≤100, but the correct count is 14: 3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97",
@@ -68,7 +71,9 @@
       "AXIOM-INTEGRITY: batemanHorn_formAWithK_infinite was previously stated for ALL k, but is mathematically inconsistent at k=0: IsFormAWithK 0 p ⟺ p = q+1 with q prime, which forces (q,p) = (2,3) by parity, so the k=0 layer is the singleton {3}, finite. Restricted axiom to 1 ≤ k.",
       "k=0 anomaly characterized: formAWithK0_layer_eq_three proves {p | IsFormAWithK 0 p} = {3} unconditionally. This is the only consecutive prime pair.",
       "Added k-specific characterizations: formAWithK2_iff (p = 4q+1) and formAWithK3_iff (p = 8q+1) bridge the parameterized predicate to standard arithmetic forms.",
-      "Added bridge isFormA_unfold connecting BatemanHorn IsFormA with Problem IsTwoTimePrimePlusOne (definitionally equal). bh_k1_implies_formA_infinite shows BH(k=1) is strictly stronger than erdos_1065a."
+      "Added bridge isFormA_unfold connecting BatemanHorn IsFormA with Problem IsTwoTimePrimePlusOne (definitionally equal). bh_k1_implies_formA_infinite shows BH(k=1) is strictly stronger than erdos_1065a.",
+      "Full uniqueness (no parity hypothesis): the (k,q) decomposition is canonical because in the q=2 case the equation reduces to a power-of-2 identity (Nat.pow_right_injective), and in the mixed odd/even case an odd prime would have to divide a pure power of 2 — impossible by Nat.Prime.dvd_of_dvd_pow. This closes the gap in formA_decomposition_unique (which required q₁,q₂ ≠ 2).",
+      "k-layer disjointness consequence: Form A = ⊔_{k ≥ 0} {p | IsFormAWithK k p} is a disjoint union (not just a union). Combined with formAWithK0_layer_eq_three, the k=0 fiber is a singleton {3}; for k ≥ 1 each fiber is conjecturally infinite (BH axiom). This is the formal statement of the disjoint decomposition promised in the file header §3."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -94,15 +99,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:38:41.571Z",
-  "lastUpdate": "2026-03-13T07:52:17.056Z",
+  "lastUpdate": "2026-05-13T12:55:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S-ACT iteration on erdos-1065 (Erdős Problem #1065: are there infinitely many primes p = 2^k · q + 1 with q prime?). Adds three theorems to `Erdos1065BatemanHorn.lean` strengthening the structural theory of Form A primes. The three open conjectures (`erdos_1065a`, `batemanHorn_formAWithK_infinite k ≥ 1`, `cunningham_chain_conjecture`) remain axiomatized — this PR is unconditional structural progress, not axiom elimination.

## Progress

### New theorems (Erdos1065BatemanHorn.lean)

| Theorem | Role |
|---------|------|
| `formA_decomposition_unique_full` | Strict generalization of `formA_decomposition_unique`: drops both `q₁ ≠ 2` and `q₂ ≠ 2` side conditions. Full uniqueness of the (k, q) decomposition across all primes. |
| `formA_witnesses_agree` | Prod-form corollary: any two valid (k, q) witnesses for a Form A prime coincide as `(k₁, q₁) = (k₂, q₂)`. |
| `formAWithK_disjoint` | Pairwise disjointness of the k-layers `{p \| IsFormAWithK k₁ p}` ∩ `{p \| IsFormAWithK k₂ p} = ∅` for `k₁ ≠ k₂`. |

### Proof strategy for `formA_decomposition_unique_full`

4-way case split on whether each of q₁, q₂ equals 2:

- **(2, 2)** — equation reduces to `2^(k₁+1) = 2^(k₂+1)`, closed by `Nat.pow_right_injective`.
- **(2, odd)** — the odd prime q₂ would have to divide `2^(k₁+1)`, contradicting primality via `Nat.Prime.dvd_of_dvd_pow` + `Nat.le_of_dvd` + `Nat.Prime.two_le`. (Symmetric for (odd, 2).)
- **(odd, odd)** — defers to the existing `formA_decomposition_unique` with both `q ≠ 2` hypotheses now discharged from the case context.

### Closing a documented gap

Line 23 of the file header lists \"Formalized results: ... 3. Disjoint decomposition of Form A primes by k-value\". This claim was prose-only — `formAWithK_disjoint` is now the formal statement. Combined with `formAWithK0_layer_eq_three` (already in the file), this yields a complete picture: `{p | IsFormA p} = ⊔_{k ≥ 0} {p | IsFormAWithK k p}` is a *disjoint* union, with the k = 0 fiber the singleton `{3}` and each k ≥ 1 fiber conjecturally infinite (BH axiom).

## Files Modified

- `proofs/Proofs/Erdos1065BatemanHorn.lean`: +75 LOC (385 → 460), +3 theorems (32 → 35), axioms unchanged (1, k ≥ 1 restriction preserved).
- `src/data/research/problems/erdos-1065.json`: 3 new `knowledge.builtItems`, 2 new `knowledge.insights`, refreshed `progressSummary`, `currentState.iteration` 2 → 3, `lineCount`/`theoremCount` resynced for `Erdos1065BatemanHorn.lean`.
- `research/problems/erdos-1065/state.md`: Phase `NEW` (seeker-init 2026-01-15 stub) → `ACT` iteration 3 with next-session levers documented.

## Findings

- **Uniqueness without parity is genuinely subtle.** A naive `padicValNat` argument fails at q = 2 because `padicValNat 2 (2^k · 2) = k + 1` rather than `k` (the valuation absorbs the factor of 2 from q). The case split on q's parity isolates this branch and discharges it via the (2, 2) injectivity step.
- **The (2, odd) and (odd, 2) cases are vacuously satisfied** — the hypothesis \"p = 2^k₁ · 2 + 1 = 2^k₂ · q + 1 with q odd prime\" forces q ∣ 2^(k₁+1), impossible. Worth stating because Lean's elaborator does not automatically discover this.
- **Form A's disjoint-decomposition claim now has a single load-bearing lemma.** Any future strengthening of uniqueness (e.g. a constructive `formA_decomp` function) flows directly into a stronger disjointness statement.

## Status

**Outcome**: progress (DEEP DIVE — structural strengthening; AXIOM HUNT not viable since all 3 axioms are open conjectures).

**Build status**: build pending. Proofs follow patterns already in the same file (`formA_decomposition_unique` uses the same `padicValNat`/`Nat.Prime.dvd_of_dvd_pow` machinery) and `Nat.pow_right_injective` is widely used across the gallery (Erdos31, Erdos268, Erdos487, Erdos876, Erdos1, Erdos1OQ04, …). Per the `.lake symlink loop + mid-build worktree wipe` failure mode, Docker build was NOT attempted from this session — doctor/auditor verification from a clean worktree is the recommended path.

## Next Steps

1. **Constructive Form A criterion via 2-adic decomposition.** Define `oddPart p = (p - 1) / 2 ^ padicValNat 2 (p - 1)`; prove `IsFormA p ↔ p.Prime ∧ (oddPart p = 1 ∨ (oddPart p).Prime)`. The `oddPart p = 1` branch covers the Fermat-like primes p = 2^v + 1; the prime-odd-part branch covers all others. Gives a *decidable* check.
2. **Axiom-free density lower bound.** State and (try to) prove a non-vacuous lower bound on Form A primes ≤ N using only Mathlib results (no BH).

Option 1 is prioritized — it leverages the uniqueness theorem shipped here.

🤖 Generated by researcher-12