### PR TITLE
research(erdos-1022): S1 STATE-SYNC — first-commit problem.md + state.md (doc-only)

### DIFF
--- a/research/problems/erdos-1022/problem.md
+++ b/research/problems/erdos-1022/problem.md
@@ -1,0 +1,91 @@
+# Problem: Erdős #1022 — Property B and Sparse Set Families
+
+## Statement
+
+### Plain Language
+
+A set family $\mathcal{F}$ on a ground set $V$ has **Property B** (the Bernstein property) if there is a
+2-coloring of $V$ such that no member $f \in \mathcal{F}$ is monochromatic. Equivalently, $\mathcal{F}$
+is 2-colorable as a hypergraph.
+
+For an integer $c \geq 0$, call $\mathcal{F}$ **$c$-sparse** if for every finite $X \subseteq V$,
+$$
+|\{ f \in \mathcal{F} : f \subseteq X \}| \;\leq\; c \cdot |X|.
+$$
+
+**Erdős #1022 (open).** Is there a function $c : \mathbb{N} \to \mathbb{N}$ with $c(t) \to \infty$ as
+$t \to \infty$, such that for every $t$ every $c(t)$-sparse family $\mathcal{F}$ whose members all have
+size at least $t$ has Property B?
+
+### Formal Statement
+
+$$
+\exists \, c : \mathbb{N} \to \mathbb{N},\;
+\bigl( c(t) \to \infty \bigr)
+\;\wedge\;
+\bigl( \forall \mathcal{F}\;\forall t,\;
+ (\forall f \in \mathcal{F},\, |f| \geq t)
+ \wedge \mathcal{F}\text{ is }c(t)\text{-sparse}
+ \;\Longrightarrow\;
+ \mathcal{F} \in \mathrm{PropB}
+\bigr).
+$$
+
+Reference: <https://erdosproblems.com/1022>
+
+## Classification
+
+```yaml
+tier: C
+significance: 6
+tractability: 3
+erdosNumber: 1022
+erdosUrl: https://erdosproblems.com/1022
+
+tags:
+  - erdos
+  - combinatorics
+  - hypergraphs
+  - property-b
+  - 2-coloring
+```
+
+**Significance**: 6/10 — a refinement of the classical Property B threshold programme
+linking sparsity (rather than total edge count) to 2-colorability.
+
+**Tractability**: 3/10 — the conjecture is open. Partial cases (matchings, degree-bounded
+families) are tractable and several are formalized; a general proof would require either a
+fresh combinatorial idea or a probabilistic deletion / LLL argument with a sparsity-aware
+threshold.
+
+## Why This Matters
+
+1. **Sparsity vs. size threshold.** The classical Erdős (1963) first-moment bound forbids
+   only $|\mathcal{F}| < 2^{t-1}$; the conjecture asks whether a *local* sparsity condition
+   ("few members fit inside any small $X$") suffices instead. This is in the spirit of
+   refining global to local constraints — common to the LLL and many modern hypergraph
+   colouring results.
+2. **Property B is the gateway to 2-colorability of hypergraphs.** Improvements feed back to
+   $k$-uniform hypergraph 2-coloring lower / upper bounds (Beck, Radhakrishnan–Srinivasan).
+3. **Mathlib gap.** Mathlib currently has no general hypergraph 2-colorability / Property B
+   API; formalizing the definitions and basic structural lemmas opens the door to a wider
+   programme of hypergraph theorems in Lean.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `erdos-1022-oq-01` | Property $B_k$ ($k$-colorability) generalization — monotonicity, hierarchy |
+| `erdos-1022-oq-03` | Lovász Local Lemma path to Property B from bounded intersection degree |
+| `erdos-100-oq-01` | Other Erdős hypergraph 2-coloring threshold questions |
+| `erdos-13-oq-01` | Beck–Lovász style 2-coloring counterexamples |
+
+## Related Problems
+
+- Lovász (1968): the matching case ($c(2) = 1$) — formalized in `matching_has_propertyB`.
+- Erdős (1963): $|\mathcal{F}| < 2^{t-1}$ probabilistic bound — formalized in
+  `erdos_first_moment_bound`.
+- Radhakrishnan–Srinivasan (2000): improved lower bound on the edge count needed to break
+  Property B in $t$-uniform families.
+- Open Question OQ-01: $k$-colorability generalization (Property $B_k$).
+- Open Question OQ-03: Lovász Local Lemma application to Property B.

--- a/research/problems/erdos-1022/state.md
+++ b/research/problems/erdos-1022/state.md
@@ -1,0 +1,122 @@
+# Current State
+
+**Phase**: AXIOMATIZED — matching case proved; sparsity conjecture and LLL bridge axiomatized
+**Since**: ~2026-03 (multiple sessions; first scaffold 2026-03-28 per problem JSON `started`;
+last research PR `erdos-1022 — degree-bounded ⇒ sparse via double counting` #13269 merged
+2026-04-27)
+**Iteration**: 5+ shipped (exact count unrecorded; see `builtItems` in
+`src/data/research/problems/erdos-1022.json` for granular log)
+
+## Status Summary
+
+Three Lean files now ship in a stable axiomatized rest state:
+
+| File | Lines | Theorems | Defs | Axioms | Sorries | Role |
+|------|------:|---------:|-----:|-------:|--------:|------|
+| `Erdos1022Problem.lean` | 600 | 26 | 6 | 1 | 0 | Main file — Property B, sparsity, matching ⇒ Property B, first-moment, degree-bounded ⇒ sparse |
+| `Erdos1022OQ01.lean` | 165 | 8 | 3 | 0 | 0 | Property $B_k$ ($k$-colorability) hierarchy and monotonicity |
+| `Erdos1022OQ03.lean` | 420 | 21 | 8 | 1 | 0 | LLL infrastructure: monoProb, lllThreshold, propertyB consequences |
+| **Total** | **1185** | **55** | **17** | **2** | **0** | |
+
+`meta.json` for this slug is **not yet wired** to a gallery proof entry (no `src/data/proofs/erdos-1022/`);
+both `erdos-1022-oq-01/` (the $B_k$ Lean file) and `erdos-1022-oq-03/` are independent gallery entries
+with their own `meta.json`. This STATE-SYNC commit does not touch any gallery `meta.json`.
+
+### Headline result (matching case, post all completed iterations)
+
+`matching_has_propertyB` (Erdos1022Problem.lean §5):
+
+```
+∀ α [DecidableEq α] [Fintype α] (F : Finset (Finset α))
+    (hsize : AllSizeAtLeast F 2)
+    (hdeg : IsDegreeBounded F 1),
+  HasPropertyB F.
+```
+
+This is **Lovász (1968) for the matching case ($c(2) = 1$) of Erdős 1022, formally proved
+in Lean 4** from first principles. The companion `matching_implies_sparse` confirms
+matchings are themselves 1-sparse, so `degree_one_size_two_propertyB_and_sparse` exhibits
+the conjecture's matching instance: every 1-bounded-degree family of $\geq 2$-sets has both
+Property B and 1-sparsity.
+
+The general sparsity conjecture ($t \geq 3$, $c(t) \to \infty$) remains axiomatized as
+`erdos_1022_conjecture`.
+
+### Axiom inventory (2 across all three files)
+
+**Foundational / open-conjecture axioms:**
+
+- `erdos_1022_conjecture` (Erdos1022Problem.lean §3, line 77) — the central Erdős #1022
+  statement: $\exists\, c\colon \mathbb{N}\to\mathbb{N}$ with $c(t) \to \infty$ such that
+  every $c(t)$-sparse family of $\geq t$-sets has Property B. **Open** since 1973
+  (Erdős–Lovász). No proof strategy in sight.
+
+**Deep results (research-track, multi-paper proofs):**
+
+- `lll_propertyB` (Erdos1022OQ03.lean §6, line 244) — the Lovász Local Lemma applied to
+  Property B: under `monoProb t ≤ lllThreshold d`, any $t$-uniform family with intersection
+  degree $\leq d$ has Property B. **Discharge path:** finite probability + LLL infrastructure
+  in Mathlib — currently absent. Companion `lll_via_frequency` and the numeric LLL bound
+  theorems (`lll_condition_t3_d1`, `lll_condition_t5_d3`, `lll_condition_t8_d10`) already
+  show the threshold algebra works without the axiom; the axiom is the bridge from
+  "threshold condition holds" to "PropertyB holds".
+
+**No structure-encoded axioms** (`grep -E "Axioms\b" Proofs/Erdos1022*.lean` returns nothing
+of substance): both axioms are free-standing `axiom` declarations. Status `axiomatized` is
+honest.
+
+## Current Focus
+
+None active. Clean axiomatized rest state.
+
+## Active Approach
+
+— (none)
+
+## Forward Levers
+
+Three orthogonal next steps for future iterations:
+
+1. **Discharge `lll_propertyB` via a constructive deletion proof for the matching case
+   $d = 1$.** The `matching_has_propertyB` theorem already covers this regime
+   non-probabilistically; an alternative path is to instantiate `lll_propertyB` at $d = 1$,
+   $t = 2$ and check `monoProb 2 = 1/2 ≤ lllThreshold 1 = 1/4` — but this **fails**
+   ($1/2 > 1/4$). The LLL bridge becomes useful only at $t \geq 3$; the natural next case
+   is $t = 3, d = 1$ where `monoProb 3 = 1/4 ≤ lllThreshold 1 = 1/4` already holds
+   (`lll_condition_t3_d1`), so a 3-uniform family with intersection degree $\leq 1$ has
+   Property B. A clean combinatorial proof of this specific case (no probability needed)
+   would let us drop `lll_propertyB` for $d = 1, t = 3$ at least.
+
+2. **Mine literature for non-trivial sparse families with Property B.** Beck (1978) and
+   later Radhakrishnan–Srinivasan (2000) give edge-count thresholds; translating them to
+   *sparsity* thresholds for fixed $t$ would either confirm $c(t) \to \infty$ for finite
+   ranges or surface an obstacle. Concrete near-term goal: formalize a $c(3) \geq 1$ result
+   — every 1-sparse family of 3-sets has Property B — as a strict generalization of the
+   matching theorem. Compare with `erdos_first_moment_bound` (already proved) to bracket the
+   answer.
+
+3. **Connect to OQ-01 ($k$-colorability hierarchy).** `Erdos1022OQ01.lean` proves
+   $\mathrm{Property}\,B_k \to \mathrm{Property}\,B_{k+1}$ and the threshold
+   $|\mathcal{F}| < k^{t-1}/(k-1)$ implication. A natural lemma to add: under the same
+   sparsity hypothesis, $c(t,k)$-sparse families have Property $B_k$ — i.e., generalize the
+   conjecture statement. This would extend the OQ-01 hierarchy from the threshold regime
+   into the sparsity regime, mirroring the Erdős 1022 generalization.
+
+## Honesty
+
+- **Title in `src/data/research/problems/erdos-1022.json` is still `[Problem Title]`**
+  placeholder from the original seeker-init scaffold; this STATE-SYNC commit replaces it
+  with `Erdős #1022 — Property B and Sparse Set Families` and fills in
+  `problemStatement.formal` / `problemStatement.plain` / `problemStatement.whyMatters` /
+  `knownResults` so the problem JSON matches the Lean reality (1185 LOC, 55 theorems,
+  axiomatized, $c(2) = 1$ Lovász matching case proved).
+- The Lean files have shipped on `main` since at least 2026-04-27 (PR #13269); the JSON
+  metadata is the lagging document.
+- **No `.lean` source is edited** in this PR; the axiom counts in the table above are read
+  from current `origin/main` heads. `Erdos1022Problem.lean` (lineCount 600, axiom 1) /
+  `Erdos1022OQ01.lean` (165, 0) / `Erdos1022OQ03.lean` (420, 1) — totals: 1185 LOC,
+  2 axioms, 0 sorries.
+- **No gallery `meta.json` touched.** The slug `erdos-1022` has no gallery proof directory;
+  `erdos-1022-oq-01/` and `erdos-1022-oq-03/` are separately wired.
+- **No race detected.** `gh pr list --search "erdos-1022 in:title" --state open` returns
+  empty as of the timestamp of this branch.

--- a/src/data/research/problems/erdos-1022.json
+++ b/src/data/research/problems/erdos-1022.json
@@ -1,31 +1,46 @@
 {
   "slug": "erdos-1022",
-  "title": "[Problem Title]",
-  "phase": "OBSERVE",
+  "title": "Erdős #1022 — Property B and Sparse Set Families",
+  "phase": "AXIOMATIZED",
   "status": "active",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{[LaTeX formulation of the theorem/conjecture]}",
-    "plain": "[Explain what we're trying to prove in accessible terms]",
-    "whyMatters": []
+    "formal": "\\exists\\, c : \\mathbb{N} \\to \\mathbb{N},\\; (c(t) \\to \\infty) \\;\\wedge\\; \\bigl(\\forall \\mathcal{F}\\;\\forall t,\\; (\\forall f \\in \\mathcal{F},\\, |f| \\geq t) \\;\\wedge\\; \\mathcal{F}\\text{ is }c(t)\\text{-sparse} \\;\\Longrightarrow\\; \\mathcal{F} \\in \\mathrm{PropB}\\bigr).",
+    "plain": "A finite family F of sets has Property B if there is a 2-coloring of the underlying ground set such that no member of F is monochromatic. F is c-sparse if for every finite X, at most c·|X| members of F are subsets of X. Is there c(t) → ∞ such that every c(t)-sparse family of ≥t-sets has Property B? Lovász (1968) showed c(2) = 1 works; the general case is open.",
+    "whyMatters": [
+      "Refines the classical Erdős (1963) first-moment threshold |F| < 2^{t-1} from a global edge-count constraint to a local sparsity constraint — in the spirit of LLL refinements of probabilistic existence.",
+      "Property B is the gateway to k-uniform hypergraph 2-colorability; improvements feed back to Beck (1978) and Radhakrishnan–Srinivasan (2000) thresholds.",
+      "Mathlib has no general hypergraph 2-colorability / Property B API; the formalization here (HasPropertyB, IsSparse, AllSizeAtLeast, IsDegreeBounded, intDegree, monoProb, lllThreshold) opens that programme."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Matching case (Lovász 1968): every degree-1 family of ≥ 2-sets has Property B — formalized as `matching_has_propertyB` (Erdos1022Problem.lean).",
+      "Erdős (1963) first-moment bound: every family of ≥ t-sets with |F| < 2^{t-1} has Property B — formalized as `erdos_first_moment_bound` (Erdos1022Problem.lean).",
+      "Degree-bounded ⇒ sparse (double counting): every degree-d family of ≥ 1-sets is d-sparse — formalized as `degree_bounded_implies_sparse` (PR #13269, merged).",
+      "Property B_k hierarchy: Property B_k → Property B_{k+1}, and Property B = Property B_2 — formalized in Erdos1022OQ01.lean (OQ-01)."
+    ],
+    "open": [
+      "Existence of c(t) → ∞ for the general sparsity conjecture (axiom `erdos_1022_conjecture`).",
+      "Bridging finite-probability LLL to Property B without an axiom: `lll_propertyB` in Erdos1022OQ03.lean awaits Mathlib LLL infrastructure."
+    ],
+    "goal": "Discharge `lll_propertyB` for at least the small cases (t = 3, d = 1) where the numeric LLL threshold is already verified, en route to a partial sparsity-conjecture result for c(3)."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-28T10:58:21-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "phase": "AXIOMATIZED",
+    "since": "2026-04-27T16:05:13Z",
+    "iteration": 5,
+    "focus": "Stable axiomatized rest state: 3 Lean files (Problem 600 LOC / OQ01 165 LOC / OQ03 420 LOC), 55 theorems, 2 axioms (`erdos_1022_conjecture`, `lll_propertyB`), 0 sorries. Matching case proved.",
+    "blockers": [
+      "Mathlib lacks finite-probability + Lovász Local Lemma infrastructure needed to discharge `lll_propertyB`.",
+      "The sparsity conjecture itself (`erdos_1022_conjecture`) is open since Erdős–Lovász 1973."
+    ],
+    "nextAction": "See research/problems/erdos-1022/state.md §Forward Levers for three orthogonal next steps (discharge LLL at t=3,d=1; small-case c(3); OQ-01 sparsity-aware hierarchy).",
     "attemptCounts": {
-      "total": 0,
+      "total": 5,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 3
     }
   },
   "knowledge": {
@@ -48,9 +63,12 @@
     "markdown": "# Knowledge Base: erdos-1022\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
-    "number-theory  # or: algebra, analysis, topology, combinatorics, etc.",
-    "prime-gaps",
-    "sieve-methods"
+    "erdos",
+    "combinatorics",
+    "hypergraphs",
+    "property-b",
+    "2-coloring",
+    "sparsity"
   ],
   "relatedProofs": [
     "erdos-1",
@@ -60,8 +78,15 @@
     "erdos-1022-oq-01"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
+    "papers": [
+      "Erdős, P., Lovász, L. (1973). Problems and results on 3-chromatic hypergraphs and some related questions. Infinite and finite sets, 609–627.",
+      "Erdős, P. (1963). On a combinatorial problem. Nordisk Mat. Tidskr. 11, 5–10.",
+      "Beck, J. (1978). On 3-chromatic hypergraphs. Discrete Math. 24(2), 127–137.",
+      "Radhakrishnan, J., Srinivasan, A. (2000). Improved bounds and algorithms for hypergraph 2-coloring. Random Structures & Algorithms 16(1), 4–32."
+    ],
+    "urls": [
+      "https://erdosproblems.com/1022"
+    ],
     "mathlib": []
   },
   "started": "2026-03-28T10:58:21-07:00",
@@ -100,5 +125,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1022Problem.lean"
     }
   ],
-  "lastUpdate": "2026-03-29T20:00:00Z"
+  "lastUpdate": "2026-05-13T13:00:00Z"
 }


### PR DESCRIPTION
## Summary

- **First-commit STATE-SYNC** for Erdős #1022 (Property B and sparse set families). 1185 LOC of axiomatized Lean has been on `main` since 2026-04-27 (PR #13269) but the metadata (`src/data/research/problems/erdos-1022.json`) was still in seeker-init stub form (`[Problem Title]`, placeholder LaTeX, empty `whyMatters`/`knownResults`, placeholder tags) and `research/problems/erdos-1022/` directory did not exist on `origin/main`.
- **Doc-only**: no `.lean` source touched. The lean tree is in clean axiomatized rest state — 3 files, 55 theorems, 2 axioms (`erdos_1022_conjecture` + `lll_propertyB`), 0 sorries.

## Files

| File | Change | Purpose |
|------|--------|---------|
| `research/problems/erdos-1022/problem.md` | **+91 (new)** | Plain + formal statement, classification, why-matters, related proofs / problems |
| `research/problems/erdos-1022/state.md` | **+122 (new)** | AXIOMATIZED phase, per-file count table, headline result (matching case = Lovász 1968), axiom inventory, 3 forward levers, honesty block |
| `src/data/research/problems/erdos-1022.json` | **+47 / -22** | Title, formal/plain statement, whyMatters, knownResults, currentState fields, tags, references — all repaired |

## Per-file Lean count table (read from current `origin/main`)

| File | Lines | Theorems | Defs | Axioms | Sorries |
|------|------:|---------:|-----:|-------:|--------:|
| `Erdos1022Problem.lean` | 600 | 26 | 6 | 1 | 0 |
| `Erdos1022OQ01.lean`    | 165 |  8 | 3 | 0 | 0 |
| `Erdos1022OQ03.lean`    | 420 | 21 | 8 | 1 | 0 |
| **Total**               |**1185**|**55**|**17**|**2**|**0**|

## Out of scope

- No edits to `proofs/Proofs/Erdos1022*.lean` (counts already accurate in `leanFiles`).
- No edits to `erdos-1022-oq-01/` or `erdos-1022-oq-03/` gallery `meta.json` — separate slugs, separate sync if needed.
- No `relatedProofs` cleanup — entry includes self-ref `erdos-1022` (known data error), but pure-cleanup is a separate PR.
- No `knowledge.markdown` rewrite — placeholder is harmless; this PR repairs the structured fields.

## Race check

- `gh pr list --search "erdos-1022 in:title" --state open` empty at branch creation (~13:00 UTC) and immediately pre-push.
- Last research PR on this slug merged 2026-04-27 (#13269); last mechanic PR closed 2026-04-29 (#13921). Dormant ≥ 16 days.

## Test plan

- [x] `jq '.' src/data/research/problems/erdos-1022.json` validates (no syntax error).
- [x] `git ls-files origin/main -- research/problems/erdos-1022/` empty pre-commit (true first-commit).
- [x] No race PR (`erdos-1022 in:title --state open` empty).
- [ ] Auditor/Deployer can merge; gallery rebuild should pick up the new title in the research index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)