### PR TITLE
audit(erdos-934,948,937): clean re-audit batch — counts match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10658,9 +10658,9 @@
     },
     "erdos-934": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T04:08:26Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T12:59:12Z",
+      "result": "clean"
     },
     "erdos-935": {
       "agentId": "auditor-cycle-20-batch",
@@ -10676,9 +10676,9 @@
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T04:20:17Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T12:59:12Z",
+      "result": "clean"
     },
     "erdos-938": {
       "auditCount": 4,
@@ -10754,8 +10754,8 @@
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T04:14:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-13T12:59:12Z",
       "result": "clean"
     },
     "erdos-949": {


### PR DESCRIPTION
## Summary

Clean re-audit batch of three axiomatized Erdős gallery entries. All meta.json counts verified against `proofs/Proofs/*.lean` source files; no integrity issues found.

| Slug | Lines | Axioms | Sorries | Theorems | Defs | Status | Badge |
|------|-------|--------|---------|----------|------|--------|-------|
| erdos-934 | 234 | 4 | 8 | 10 | 10 | axiomatized | axiom |
| erdos-948 | 214 | 1 | 0 | 4 | 19 | axiomatized | axiom |
| erdos-937 | 334 | 3 | 0 | 10 | 11 | axiomatized | axiom |

All five count fields (`lineCount`, `axiomCount`, `sorries`, `theoremCount`, `definitionCount`) in both `meta.meta` and `meta.leanFile` blocks exactly match the corresponding Lean source. Status (`axiomatized`) and badge (`axiom`) accurately reflect the axiom inventory.

## Tracker bump

- `auditCount` 3 → 4 for all three slugs
- `lastAudited` refreshed to 2026-05-13T12:59:12Z
- `result`: erdos-934 / erdos-937 flipped from `issues-fixed` → `clean` (prior drift has been discharged on main); erdos-948 stays `clean`

## Scope

- ✅ Tracker bump only (`src/data/proofs/audit-tracker.json`, +8/-8)
- ❌ No meta.json edits
- ❌ No Lean source edits

## Verification

```bash
for F in proofs/Proofs/Erdos{934,948,937}Problem.lean; do
  echo "=== $F ==="
  echo "lines: $(wc -l < $F)"
  echo "axiom: $(grep -cE '^axiom ' $F)"
  echo "sorry: $(grep -cE '\bsorry\b' $F)"
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)