### PR TITLE
research(ehrhart-cube-proven-oq-03): S2 PREP — Mathlib bearer audit disproves S1 premise + slot-drift triage (doc-only)

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-03/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-03/knowledge.md
@@ -141,5 +141,90 @@ implement Tier 1.
 
 - Barvinok 1994 (canonical algorithm paper).
 - Beck & Robins (2015) ch. 11.
-- Mathlib4 `Mathlib.Combinatorics.Polytope.Ehrhart`.
+- ~~Mathlib4 `Mathlib.Combinatorics.Polytope.Ehrhart`~~ — **does not
+  exist** (see §S2 PREP Mathlib bearer audit below).
 - Lean Genius `Proofs/EhrhartCubeProven.lean` (verified parent).
+
+---
+
+## S2 PREP — Mathlib bearer audit (2026-05-13, researcher-10)
+
+The S1 OBSERVE plan above claims Mathlib v4.26.0 ships
+`Mathlib.Combinatorics.Polytope.Ehrhart` and an Ehrhart-theory toolkit.
+A bearer audit at the lake-pinned Mathlib SHA `2df2f0150c27`
+(`proofs/lake-manifest.json`) shows this is **false**.
+
+### Method
+
+GitHub Search API + Contents API against
+`leanprover-community/mathlib4` at `ref=2df2f0150c27` — the SHA the
+worktree's `lake build` would resolve. Names are stable across Mathlib
+HEAD and the pinned SHA (per project memory
+`Mathlib bearer-audit PREPs frequently cite Mathlib HEAD instead of
+lake-pinned SHA`), so absence at the pinned SHA implies absence on
+HEAD as well; we verified the pinned SHA to be conservative.
+
+### Findings
+
+| Query | Result | Verdict |
+|---|---|---|
+| `q=Ehrhart` (whole repo, lean files) | 0 hits | **No Ehrhart support in Mathlib.** |
+| `q=Polytope in:path` | 0 hits | **No `Polytope` directory in Mathlib.** |
+| `q=LatticePolytope` | 0 hits | **No `LatticePolytope` type in Mathlib.** |
+| `q=hStar` / `q=Eulerian filename:Eulerian` | 0 hits | **No h*-vector or Eulerian-polynomial Polytope link in Mathlib.** |
+| `GET .../contents/Mathlib/Combinatorics/Polytope/Ehrhart.lean?ref=2df2f0150c27` | HTTP 404 | direct fetch confirms absence |
+| `GET .../contents/Mathlib/Combinatorics?ref=2df2f0150c27` | 200, no `Polytope` subdir | confirms absence at the directory level |
+
+The algebraic substrate the Barvinok plan ultimately rests on **does**
+exist, with one path correction:
+
+| Module | Status | Audit |
+|---|---|---|
+| `Mathlib.FieldTheory.RatFunc.Basic` | ✓ exists | 45 125 B, contents-API HTTP 200 |
+| `Mathlib.Algebra.MvPolynomial.Basic` | ✓ exists | 41 370 B, contents-API HTTP 200 |
+| `Mathlib.RingTheory.MvPowerSeries.Basic` | ✓ exists | search HTTP 200 |
+| ~~`Mathlib.RingTheory.PowerSeries.Basic` (S1 plan)~~ | path drift | ✓ exists but the multivariate generating function for [0, n]^d lives in `MvPowerSeries`, not `PowerSeries`; S1 plan cited the univariate path. |
+
+The dead doc-URL
+`leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Polytope/Ehrhart.html`
+listed in the JSON `references.urls` is removed in this PR (the
+HTML mirrors a module that does not exist).
+
+### Corrected Mathlib gap inventory
+
+The S1 OBSERVE `mathlibGaps` list under-stated the gap. Corrected list:
+
+1. **No Ehrhart-theory toolkit at all** — the S1 plan assumed a
+   `Mathlib.Combinatorics.Polytope.Ehrhart` foundation to build on.
+   There is none. Any retargeted Barvinok work must define its own
+   `EhrhartFn` / `LatticePolytope` / `interiorEhrhartFn` shells from
+   scratch over `MvPolynomial` / `RatFunc` / `MvPowerSeries`.
+2. **No `LatticePolytope` type, no `Polytope` namespace.** The unit
+   d-cube would need to be encoded as `Set (Fin d → ℝ)` or via
+   `Fin d → Set.Icc (0 : ℝ) 1` and the lattice-point condition
+   handled by hand.
+3. **No signed simplicial-cone decomposition.** This is the
+   algorithmic core of Barvinok-1994; defer to S3+ stretch or future
+   sibling slug.
+4. **No formal complexity-class library.** Polytime claim must be
+   axiomatic.
+
+### Slot-drift cross-reference
+
+In parallel with the bearer audit, the S2 PREP also discovered the
+slug slot is **already occupied on main** by an entirely orthogonal
+hypersimplex scaffold (`proofs/Proofs/EhrhartCubeProvenOQ03.lean`,
+119 LOC, 2 sorries, `namespace EhrhartCubeProvenOQ03`, gallery dir
+populated). See `state.md` (§Findings 2–4) for the full description
+of the drift and the deferred scope decision (Option A: continue
+hypersimplex; Option B: spin off Barvinok as a new sibling `oq-05`).
+
+### Implication for any future S2 ACT
+
+Whichever scope option is chosen, the S2 ACT Lean file **cannot**
+import `Mathlib.Combinatorics.Polytope.Ehrhart`. The S1 OBSERVE
+"S2.1 probe" must be replaced with hand-rolled definitions over
+`MvPolynomial` and `RatFunc` (or with `import Mathlib` to bring in
+the full algebra substrate). The bearer audit gives the green list
+of modules that actually work; the Docker probe is no longer
+informational and can be skipped.

--- a/research/problems/ehrhart-cube-proven-oq-03/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-03/state.md
@@ -2,103 +2,159 @@
 
 ## Current State
 
-**Phase**: S1 OBSERVE
+**Phase**: S2 PREP (bearer-audit, doc-only)
 **Path**: full
-**Since**: 2026-05-12T20:55Z
-**Last Updated**: 2026-05-12 (Session 1 researcher-12)
-**Iteration**: 1
+**Since**: 2026-05-13T13:50Z (researcher-10, S2)
+**Last Updated**: 2026-05-13 (Session 2 researcher-10)
+**Iteration**: 2
 
-## Session 1 — S1 OBSERVE: Barvinok algorithm gallery-gap survey (researcher-12, 2026-05-12)
+## Session 2 — S2 PREP: Mathlib bearer audit + slot-drift discovery (researcher-10, 2026-05-13)
 
-**Mode.** ANALYSIS-ONLY (no `.lean` edits).
+**Mode.** ANALYSIS-ONLY (no `.lean` edits; pure doc / JSON sync).
 
-**Outcome.** Workspace created.  Slug retargeted to a **concrete
-gallery gap**: the existing `ehrhart-cube-proven*` family is entirely
-identity-type (cube formula, h*-vector, recursions, Eulerian numbers).
-None of them address **algorithmic / generating-function** lattice
-point counting.  Barvinok-1994 fills exactly that gap.
+**Outcome.** The S1 OBSERVE plan (Session 1, 2026-05-12) is built on
+**verifiably false premises** about Mathlib's Ehrhart-theory content,
+and the slug's on-disk state has **drifted** from the JSON metadata.
+Both must be corrected before any S2 ACT (Lean) iteration.
 
-**Key findings.**
+### Finding 1 — Mathlib has no Ehrhart theory
 
-1. **Gap confirmed.**  The four existing entries
-   (`ehrhart-cube-proven`, `ehrhart-cube-proven-oq-01`,
-   `ehrhart-cube-proven-oq-02`, `ehrhart-cube-proven-oq-04`) prove
-   *identities* and *recursions* about `#([0,1]ᵈ ∩ (1/n)ℤᵈ)` and its
-   Eulerian h*-vector.  None state Barvinok's theorem; none introduce
-   the short rational generating function `f(P; x)`.
+The S1 OBSERVE state.md claims:
 
-2. **Mathlib v4.26.0 has Ehrhart theory** in
-   `Mathlib.Combinatorics.Polytope.Ehrhart` and rational-function /
-   power-series infrastructure (`RatFunc`, `MvPowerSeries`,
-   `MvPolynomial.aeval`).  It does **NOT** have signed simplicial-cone
-   decomposition or polytime-complexity statements.  Barvinok's
-   algorithm itself must be **axiomatised** (or stated as an
-   un-implemented `def`/`theorem` with the polytime claim as an
-   axiom) for the gallery entry.
+> Mathlib v4.26.0 has Ehrhart theory in
+> `Mathlib.Combinatorics.Polytope.Ehrhart` and rational-function /
+> power-series infrastructure (`RatFunc`, `MvPowerSeries`, `MvPolynomial.aeval`).
 
-3. **Tractable corollary**: `f([0,n]ᵈ; x) = ∏ᵢ (1 − xᵢⁿ⁺¹) / (1 − xᵢ)`,
-   the short rational generating function for the unit-cube dilation.
-   This is *first-principles provable* via geometric series and acts
-   as a sanity-test corollary linking OQ-03 to the verified parent
-   `ehrhart-cube-proven`.
+This is **false** at the lake-pinned Mathlib SHA `2df2f0150c27`
+(`proofs/lake-manifest.json`). Bearer audit via the GitHub Search API
+returns:
 
-4. **Naming**: file `Proofs/EhrhartCubeProvenOQ03.lean`, gallery dir
-   `src/data/proofs/ehrhart-cube-proven-oq-03/`.  Consistent with the
-   sibling-naming convention used by OQ-01, OQ-02, OQ-04.
+| Query | Count |
+|---|---|
+| `Ehrhart` (any file, any path) | **0** |
+| `Polytope` (any file, any path) | **0** |
+| `LatticePolytope` (anywhere) | **0** |
+| `hStar` / `h_star` / `Eulerian` (filename:Eulerian) | **0** |
+| `Mathlib.Combinatorics.Polytope.Ehrhart` (direct fetch) | 404 |
 
-**Files modified (this PR).**
-* `research/problems/ehrhart-cube-proven-oq-03/problem.md` — new (anchor doc).
-* `research/problems/ehrhart-cube-proven-oq-03/knowledge.md` — new (Mathlib survey + 3-tier strategy).
-* `research/problems/ehrhart-cube-proven-oq-03/state.md` — new (this file).
-* `research/problems/ehrhart-cube-proven-oq-03/sessions/2026-05-12-s01.md` — new (session log).
-* `src/data/research/problems/ehrhart-cube-proven-oq-03.json` — new (index entry, iteration 1).
+Only the algebra dependencies are real:
 
-**Build status.** No `.lean` changes; no build attempted.  Parent
-`Proofs/EhrhartCubeProven.lean` and siblings
-`Proofs/EhrhartCubeProvenOQ04.lean` both build clean on `origin/main`.
+| Module | Status | Size |
+|---|---|---|
+| `Mathlib.FieldTheory.RatFunc.Basic` | ✓ exists | 45 125 B |
+| `Mathlib.Algebra.MvPolynomial.Basic` | ✓ exists | 41 370 B |
+| `Mathlib.RingTheory.MvPowerSeries.Basic` | ✓ exists (path differs from S1 plan, which said `Mathlib.RingTheory.PowerSeries.Basic`) | n/a |
 
-## Next Action (S2 ACT)
+The S1 OBSERVE plan's "S2.1 Docker probe" would have flagged the
+missing `Mathlib.Combinatorics.Polytope.Ehrhart` import on first
+invocation. The bearer audit catches it without Docker (relevant given
+the project-wide `proofs/.lake` self-referential-symlink trap in this
+worktree).
 
-S2.1 — Probe Mathlib v4.26.0 generating-function API:
+**Implication.** Any retargeted S2 ACT toward Barvinok / generating
+functions must build the Ehrhart support from scratch over Mathlib's
+algebraic substrate (`RatFunc` / `MvPowerSeries` / `MvPolynomial`) —
+there is no pre-existing Ehrhart toolkit to specialise.
 
-```bash
-# In Docker (NEVER use direct lake build):
-./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ03Probe
-```
+### Finding 2 — Slug slot is already taken
 
-with `Proofs/EhrhartCubeProvenOQ03Probe.lean` importing
-`Mathlib.Combinatorics.Polytope.Ehrhart`,
-`Mathlib.Algebra.MvPolynomial.Basic`,
-`Mathlib.FieldTheory.RatFunc.Basic`,
-`Mathlib.RingTheory.PowerSeries.Basic`, and `#check`-ing candidate
-identifiers (`@MvPolynomial`, `@RatFunc`, `@MvPowerSeries`,
-`@Polynomial.geom_series_def`).
+`proofs/Proofs/EhrhartCubeProvenOQ03.lean` is **already on main**:
 
-S2.2 — Implement `Proofs/EhrhartCubeProvenOQ03.lean`:
+* Path `proofs/Proofs/EhrhartCubeProvenOQ03.lean` — 119 LOC, 6
+  theorems, 2 definitions, 2 sorries, 0 axioms.
+* Subject: **Hypersimplex** Δ(d, k) lattice-point counting (the slice
+  of [0, 1]^d by the affine hyperplane Σ x_i = k), NOT Barvinok.
+* `namespace EhrhartCubeProvenOQ03`.
+* First committed in PR #18293 (`research(ehrhart-cube-proven-oq-03):
+  S1 OBSERVE — hypersimplex Δ(d,k) Lean scaffold (build pending)`).
+* `src/data/proofs/ehrhart-cube-proven-oq-03/` gallery directory
+  exists with `meta.json` (title "Ehrhart Polynomial of the
+  Hypersimplex: First-Principles Scaffold", `status: formalized`,
+  `sorries: 2`, `badge: formalized`) + `annotations.json` + `index.ts`.
 
-- `def ShortRationalGenFn` — short rational generating function as a
-  finite signed sum.
-- `axiom barvinok_polytime` — Barvinok's polynomial-time bound (the
-  algorithm's existence is the axiomatised core).
-- `theorem cube_generating_fn_factored` — first-principles
-  `f([0,n]ᵈ; x) = ∏ᵢ (1 − xᵢⁿ⁺¹) / (1 − xᵢ)`.
-- `theorem cube_count_eval_at_one` — bridge to `(n+1)ᵈ` via `x → 1`
-  specialisation, importing `EhrhartCubeProven`.
+### Finding 3 — JSON `leanFiles` is empty despite on-main file
 
-S2.3 — Gallery entry `src/data/proofs/ehrhart-cube-proven-oq-03/meta.json`
-with `status: axiomatized`, `badge: axiom`, `axiomCount: 1` (the
-`barvinok_polytime` axiom).
+`src/data/research/problems/ehrhart-cube-proven-oq-03.json` reports
+`leanFiles: []`. Reality: the hypersimplex file exists with 119 LOC.
+
+### Finding 4 — Title / scope drift
+
+| Field | JSON value | meta.json value (on-main) |
+|---|---|---|
+| `title` | "Barvinok's algorithm for lattice point counting in fixed dimension" | "Ehrhart Polynomial of the Hypersimplex: First-Principles Scaffold" |
+| `tags` includes | `barvinok`, `algorithms` | `hypersimplex`, `open-problem` |
+
+The Session 1 (2026-05-12) iteration **retargeted the slug from
+hypersimplex to Barvinok without touching the on-main scaffold** or
+the gallery entry. The slot now holds two incompatible plans.
+
+## Recommended Continuation Paths
+
+Two clean options, surfaced for seeker / curator / human triage —
+this PR does **not** decide between them:
+
+### Option A — Continue the hypersimplex track (low-risk)
+
+Treat the slug as `ehrhart-cube-proven-oq-03` ⇔ hypersimplex Δ(d, k)
+(matches on-main scaffold + gallery + meta.json). S3 next:
+
+1. Discharge `hypersimplex_count_k_one`: Δ(d, 1) lattice count
+   = C(n + d − 1, d − 1) via the multiset-stars-and-bars bijection.
+2. Discharge `hypersimplex_palindrome_k_d_minus_1`: Δ(d, k) count
+   = Δ(d, d − k) count via the involution x ↦ n − x.
+
+Both proofs are tractable in Mathlib v4.26.0 (use `Fintype.card`,
+`Finset.bij`, `Finset.sum`); ~70 LOC each. Pure combinatorics, no
+algebraic-geometry preliminaries.
+
+### Option B — Retarget to a new sibling slug `oq-05` (Barvinok)
+
+Spin off the Barvinok-1994 plan as **`ehrhart-cube-proven-oq-05`**
+(or `-oq-06`; current siblings end at -04). That slug starts with the
+correct Mathlib substrate awareness from this audit and does not
+collide with the hypersimplex slot. The Session 1 S1 OBSERVE
+documentation (problem.md + knowledge.md + Barvinok plan) becomes the
+new slug's bootstrap; `ehrhart-cube-proven-oq-03` reverts to its
+on-main hypersimplex identity.
+
+## Decision: deferred
+
+This PR ships **bearer-audit findings + JSON drift fixes only**.
+Scope decision (Option A vs B) deferred to seeker / curator / human
+triage.
+
+## Files modified (this PR)
+
+* `research/problems/ehrhart-cube-proven-oq-03/state.md` — this file.
+* `research/problems/ehrhart-cube-proven-oq-03/knowledge.md` — append
+  bearer-audit section.
+* `src/data/research/problems/ehrhart-cube-proven-oq-03.json` — phase
+  S1_OBSERVE → S2_PREP, iteration 1 → 2, `lastUpdate`, `knownResults`
+  (remove false Mathlib claim), `currentState.{focus,nextAction}`,
+  `knowledge.{progressSummary,insights,mathlibGaps,nextSteps}`,
+  `references.mathlib` (correct paths), `references.urls` (remove dead
+  Mathlib doc URL), `leanFiles` (add on-main hypersimplex entry).
+
+## Out of scope (this PR)
+
+* No `.lean` edits. The on-main hypersimplex scaffold is untouched.
+* No retitle of the JSON `title` field — that is the scope-decision
+  question deferred to Option A / B triage.
+* No gallery `meta.json` edits — those describe the on-main scaffold
+  accurately and would be modified by Option B only.
+* No new sibling slug creation — seeker / curator can spin off
+  `oq-05` if Option B is chosen.
 
 ## Decision Log
 
-- **2026-05-12 S1**: Decision to introduce Barvinok via an
-  axiomatised polytime statement + first-principles provable
-  generating-function corollary.  Reason: Mathlib has no complexity
-  class infrastructure, so the polytime claim cannot be formalised
-  without major preliminaries.  The generating-function side is
-  algebra-only and tractable.
-
-- **2026-05-12 S1**: Decision NOT to attempt the signed-cone
-  decomposition in S2.  Reason: even the 2-D case requires
-  continued-fraction-style descent in a context Mathlib doesn't
-  directly support.  Defer to a stretch S3 or future OQ.
+* **2026-05-13 S2 (researcher-10)**: Decision to ship S2 as a
+  doc-only PREP rather than S2 ACT. Reason: the S1 ACT plan
+  ("S2.1 probe + S2.2 implement Barvinok scaffold") is built on the
+  false `Mathlib.Combinatorics.Polytope.Ehrhart` premise AND would
+  collide with the already-committed hypersimplex scaffold; both
+  must be triaged first.
+* **2026-05-13 S2 (researcher-10)**: Decision NOT to decide between
+  Option A (continue hypersimplex) and Option B (spin off `oq-05`).
+  Reason: scope decisions of this magnitude (rewriting the slug
+  subject) should be made by the seeker / curator / human, not by a
+  research iteration.

--- a/src/data/research/problems/ehrhart-cube-proven-oq-03.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "ehrhart-cube-proven-oq-03",
   "title": "Barvinok's algorithm for lattice point counting in fixed dimension",
-  "phase": "S1_OBSERVE",
+  "phase": "S2_PREP",
   "status": "in-progress",
   "tier": "B",
   "path": "full",
@@ -20,7 +20,7 @@
       "ehrhart-cube-proven: L([0,1]^d, n) = (n+1)^d (verified, 0 axioms)",
       "ehrhart-cube-proven-oq-02: Ehrhart polynomials without general existence theorem (COMPLETED)",
       "ehrhart-cube-proven-oq-04: Eulerian h*-vector identity for unit cube (PROVED)",
-      "Mathlib v4.26.0 has Mathlib.Combinatorics.Polytope.Ehrhart, MvPolynomial, RatFunc, MvPowerSeries"
+      "Mathlib v4.26.0 (pinned SHA 2df2f0150c27) has MvPolynomial, RatFunc, MvPowerSeries; does NOT have Mathlib.Combinatorics.Polytope.Ehrhart (bearer-audited 2026-05-13, S2 PREP — corrects the S1 OBSERVE claim)"
     ],
     "open": [
       "Algorithmic complexity of lattice point counting for d as part of input is NP-hard (matches integer programming)",
@@ -30,39 +30,48 @@
     "goal": "Add gallery entry for Barvinok-1994 algorithm: axiomatize the polytime claim, define short rational generating function as a Lean type, prove first-principles corollary f([0,n]^d; x) = prod_i (1 - x_i^{n+1}) / (1 - x_i), bridge to ehrhart-cube-proven's (n+1)^d via x -> 1 specialization."
   },
   "currentState": {
-    "phase": "S1_OBSERVE",
-    "since": "2026-05-12T20:55:00Z",
-    "iteration": 1,
-    "focus": "Workspace bootstrap, gallery-gap survey, Mathlib API plan for S2.",
-    "blockers": [],
-    "nextAction": "S2 ACT: probe Mathlib v4.26.0 for MvPolynomial / RatFunc / Polynomial.geom_series via Docker import test, then implement Proofs/EhrhartCubeProvenOQ03.lean (Tier 1: axiomatize barvinok_polytime, define ShortRationalGenFn, prove cube_generating_fn_factored).",
+    "phase": "S2_PREP",
+    "since": "2026-05-13T13:50:00Z",
+    "iteration": 2,
+    "focus": "S2 PREP doc-only — Mathlib bearer audit at lake-pinned SHA 2df2f0150c27 disproves S1's `Mathlib.Combinatorics.Polytope.Ehrhart` premise (0 hits for Ehrhart / Polytope / LatticePolytope / Eulerian anywhere in Mathlib). Slot-drift also discovered: proofs/Proofs/EhrhartCubeProvenOQ03.lean is already on main (119 LOC, 2 sorries) with hypersimplex content (NOT Barvinok); gallery dir exists with corresponding meta.json. Scope decision (continue hypersimplex vs spin off Barvinok as oq-05) deferred to seeker/curator/human triage.",
+    "blockers": [
+      "Bearer audit (2026-05-13): Mathlib has NO Ehrhart-theory toolkit (`Polytope` namespace absent, `LatticePolytope` absent, `Ehrhart` absent). Any retargeted S2 ACT must build from MvPolynomial/RatFunc/MvPowerSeries; no specialisation possible.",
+      "Slot drift: proofs/Proofs/EhrhartCubeProvenOQ03.lean is occupied by hypersimplex Δ(d,k) scaffold from PR #18293; namespace EhrhartCubeProvenOQ03. Any Barvinok retarget collides unless spun off to a new sibling slug."
+    ],
+    "nextAction": "TRIAGE: choose between Option A (continue hypersimplex track on existing on-main scaffold; discharge 2 sorries — tractable ~70 LOC each) and Option B (spin off Barvinok as new sibling slug `ehrhart-cube-proven-oq-05`, leaving oq-03 as hypersimplex). After triage, S3 (Option A) or new-slug S1 (Option B). See state.md §Recommended Continuation Paths.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE doc-only: workspace bootstrap, slug retargeted to algorithmic/generating-function gap (existing ehrhart-cube-proven* siblings are identity-type only). 0 axioms, 0 sorries.",
-    "builtItems": [],
+    "progressSummary": "S2 PREP doc-only (researcher-10, 2026-05-13): Mathlib bearer audit at lake-pinned SHA 2df2f0150c27 disproves S1's `Mathlib.Combinatorics.Polytope.Ehrhart` premise (0 hits for Ehrhart anywhere in Mathlib). Slot-drift discovered: proofs/Proofs/EhrhartCubeProvenOQ03.lean is already on main from PR #18293 with hypersimplex Δ(d,k) content (119 LOC, 2 sorries) — wholly different from this slug's Barvinok plan. Gallery dir + meta.json corroborate hypersimplex identity. Scope decision (Option A continue hypersimplex vs Option B spin off Barvinok as oq-05) deferred to seeker/curator/human triage. 0 .lean edits this iteration.",
+    "builtItems": [
+      "research/problems/ehrhart-cube-proven-oq-03/state.md (rewritten): S2 PREP session log with 4 findings (false Mathlib claim, slot already taken, JSON leanFiles empty drift, title/scope drift) + 2 continuation options.",
+      "research/problems/ehrhart-cube-proven-oq-03/knowledge.md: bearer-audit section appended with method/findings tables, corrected mathlibGaps inventory, dead-doc-URL note."
+    ],
     "insights": [
-      "All four existing ehrhart-cube-proven* slugs cover identity-type results (cube formula, h*-vector, Worpitzky, Eulerian palindrome). None address algorithmic complexity or generating-function representations.",
-      "Mathlib v4.26.0 has the algebraic infrastructure (MvPolynomial, RatFunc, MvPowerSeries) but no formal complexity class library; the polytime claim must be axiomatized.",
-      "The corollary f([0,n]^d; x) = prod_i (1 - x_i^{n+1}) / (1 - x_i) is a tractable first-principles theorem provable via geometric series, providing a sanity bridge to ehrhart-cube-proven's (n+1)^d.",
-      "Signed simplicial-cone decomposition (the algorithm's core) requires continued-fraction-style descent, out of scope for S2; defer to S3 stretch or future OQ."
+      "Mathlib v4.26.0 at the lake-pinned SHA 2df2f0150c27 has ZERO Ehrhart-theory content (0 hits for `Ehrhart`, `Polytope`, `LatticePolytope` anywhere in the repo). The S1 OBSERVE claim 'Mathlib v4.26.0 has Mathlib.Combinatorics.Polytope.Ehrhart' was unverified and is false.",
+      "Algebraic substrate IS present: `Mathlib.FieldTheory.RatFunc.Basic` (45125 B), `Mathlib.Algebra.MvPolynomial.Basic` (41370 B), `Mathlib.RingTheory.MvPowerSeries.Basic` (path drift from S1 plan; multivariate live under MvPowerSeries not PowerSeries).",
+      "Slug slot is already occupied: proofs/Proofs/EhrhartCubeProvenOQ03.lean exists on main with hypersimplex Δ(d,k) scaffold (119 LOC, namespace EhrhartCubeProvenOQ03, 2 sorries on hypersimplex_count_k_one + hypersimplex_palindrome_k_d_minus_1). Gallery dir src/data/proofs/ehrhart-cube-proven-oq-03/ exists with corresponding meta.json. The Session 1 retarget did not account for this.",
+      "Option A (continue hypersimplex): Discharge the 2 on-main sorries — both are tractable in Mathlib v4.26.0 via `Fintype.card` / `Finset.bij` / `Finset.sum`, ~70 LOC each. Low risk, completes existing scaffold.",
+      "Option B (spin off Barvinok as oq-05): Preserves the Session 1 Barvinok plan as a fresh sibling slug; oq-03 reverts to its on-main hypersimplex identity. Clean separation; requires seeker/curator action.",
+      "Whichever option is chosen, the future S2 ACT cannot `import Mathlib.Combinatorics.Polytope.Ehrhart` and the Session 1 'S2.1 Docker probe' is redundant (bearer audit has already done the work). For Option B, S2 ACT would axiomatize Barvinok over `import Mathlib` (heavy) or hand-rolled MvPolynomial / RatFunc imports."
     ],
     "mathlibGaps": [
-      "No signed simplicial-cone decomposition in Mathlib v4.26.0",
-      "No formal complexity-class library; polytime claims must be axiomatized",
-      "No short rational generating function type as a first-class concept"
+      "No Ehrhart-theory toolkit AT ALL in Mathlib v4.26.0 (no `EhrhartFn`, no `LatticePolytope`, no `Polytope` namespace) — bearer-audited 2026-05-13.",
+      "No signed simplicial-cone decomposition (Barvinok algorithmic core).",
+      "No formal complexity-class library; polytime claims must be axiomatized.",
+      "No short rational generating function type as a first-class concept."
     ],
     "nextSteps": [
-      "S2.1 probe: Proofs/EhrhartCubeProvenOQ03Probe.lean with imports of Mathlib.Combinatorics.Polytope.Ehrhart, MvPolynomial, RatFunc, PowerSeries to confirm API surface",
-      "S2.2 implement: Proofs/EhrhartCubeProvenOQ03.lean (axiom barvinok_polytime + def ShortRationalGenFn + theorem cube_generating_fn_factored + theorem cube_count_eval_at_one)",
-      "S2.3 gallery: src/data/proofs/ehrhart-cube-proven-oq-03/{meta.json, annotations.json}",
-      "S3 stretch: 2-D signed cone decomposition (Tier 2)"
+      "TRIAGE (this PR's recommendation): seeker / curator / human picks Option A (continue hypersimplex on-main scaffold) or Option B (spin off Barvinok as ehrhart-cube-proven-oq-05).",
+      "Option A path → S3 ACT: discharge `hypersimplex_count_k_one` (multiset-stars-and-bars bijection, ~70 LOC) and `hypersimplex_palindrome_k_d_minus_1` (involution x ↦ n−x, ~70 LOC). Single Docker build each.",
+      "Option B path → new slug oq-05 S1 OBSERVE: bootstrap fresh workspace for Barvinok with corrected Mathlib substrate awareness; preserve Session 1 problem.md + Barvinok plan; this slug's JSON title/tags revert to hypersimplex.",
+      "Whichever option, the Session 1 S2.1 Docker probe is now redundant (bearer audit has done the work)."
     ],
-    "markdown": "# ehrhart-cube-proven-oq-03: Knowledge\n\n## Slug Mapping\n\nSeeker pool entry name 'Barvinok's algorithm for lattice point counting in fixed dimension' maps to a concrete gap: the gallery's existing ehrhart-cube-proven* family addresses identity-type Ehrhart results; the algorithmic/generating-function angle of Barvinok-1994 is absent.\n\n## Status: S1 OBSERVE doc-only\n\nWorkspace created. Mathlib survey deferred to S2 Docker probe.\n\nSee research/problems/ehrhart-cube-proven-oq-03/ for the full S1 documentation:\n* problem.md - restated goal + gallery survey\n* knowledge.md - Mathlib survey + 3-tier strategy\n* state.md - session anchor\n* sessions/2026-05-12-s01.md - this session log"
+    "markdown": "# ehrhart-cube-proven-oq-03: Knowledge\n\n## Status: S2 PREP doc-only (2026-05-13, researcher-10)\n\nMathlib bearer audit at lake-pinned SHA 2df2f0150c27 disproves S1's `Mathlib.Combinatorics.Polytope.Ehrhart` premise. Slot-drift also found: proofs/Proofs/EhrhartCubeProvenOQ03.lean is already on main with hypersimplex content (not Barvinok). Scope decision deferred to seeker/curator/human triage.\n\nSee research/problems/ehrhart-cube-proven-oq-03/state.md for the 4 findings + 2 continuation options."
   },
   "tags": [
     "seeker-selected",
@@ -87,19 +96,29 @@
       "Beck, M. & Robins, S. (2015) Computing the Continuous Discretely, 2nd ed., Springer UTM, ch. 11."
     ],
     "urls": [
-      "https://en.wikipedia.org/wiki/Barvinok%27s_algorithm",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Polytope/Ehrhart.html"
+      "https://en.wikipedia.org/wiki/Barvinok%27s_algorithm"
     ],
     "mathlib": [
-      "Mathlib.Combinatorics.Polytope.Ehrhart",
       "Mathlib.Algebra.MvPolynomial.Basic",
       "Mathlib.FieldTheory.RatFunc.Basic",
-      "Mathlib.RingTheory.PowerSeries.Basic"
+      "Mathlib.RingTheory.MvPowerSeries.Basic"
     ]
   },
   "started": "2026-05-12T20:55:00Z",
-  "lastUpdate": "2026-05-12T20:55:00Z",
+  "lastUpdate": "2026-05-13T13:50:00Z",
   "significance": 7,
   "tractability": 4,
-  "leanFiles": []
+  "leanFiles": [
+    {
+      "path": "Proofs/EhrhartCubeProvenOQ03.lean",
+      "filename": "EhrhartCubeProvenOQ03.lean",
+      "lineCount": 119,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProvenOQ03.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Doc-only S2 PREP iteration on `ehrhart-cube-proven-oq-03` (the Barvinok generating-function plan from Session 1, 2026-05-12). Two findings force a triage step before any further `.lean` work.

## Finding 1 — Mathlib has no Ehrhart theory

Session 1 OBSERVE claimed Mathlib v4.26.0 ships `Mathlib.Combinatorics.Polytope.Ehrhart`. Bearer audit at the lake-pinned Mathlib SHA `2df2f0150c27` (`proofs/lake-manifest.json`) shows this is **false**:

| Query | Count |
|---|---|
| `Ehrhart` anywhere in Mathlib | **0** |
| `Polytope in:path` | **0** |
| `LatticePolytope` | **0** |
| `Eulerian filename:Eulerian` | **0** |
| Direct contents-API fetch of `Mathlib/Combinatorics/Polytope/Ehrhart.lean@2df2f0150c27` | **HTTP 404** |
| Contents-API fetch of `Mathlib/Combinatorics?ref=2df2f0150c27` | 200; no `Polytope` subdir |

Algebraic substrate that **does** exist (with one path correction):

- `Mathlib.FieldTheory.RatFunc.Basic` — 45 125 B, HTTP 200
- `Mathlib.Algebra.MvPolynomial.Basic` — 41 370 B, HTTP 200
- `Mathlib.RingTheory.MvPowerSeries.Basic` — S1 plan cited the univariate `PowerSeries` path; multivariate generating functions live in `MvPowerSeries`.

The dead doc-URL `https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Polytope/Ehrhart.html` in `references.urls` is removed in this PR (mirrors a non-existent module).

## Finding 2 — Slug slot is already taken

`proofs/Proofs/EhrhartCubeProvenOQ03.lean` is **already on main** as a 119-LOC hypersimplex Δ(d, k) scaffold (`namespace EhrhartCubeProvenOQ03`, 6 theorems, 2 defs, 2 sorries, 0 axioms), first shipped in PR #18293. Gallery dir `src/data/proofs/ehrhart-cube-proven-oq-03/` exists with `meta.json` titled *"Ehrhart Polynomial of the Hypersimplex: First-Principles Scaffold"* (`status: formalized`, `sorries: 2`) — orthogonal to this slug's Barvinok plan.

The Session 1 retarget did not account for the existing scaffold; JSON `leanFiles: []` was drifted (added in this PR).

## Recommended continuation paths (deferred decision)

This PR ships **findings + JSON drift fixes only**. Scope choice is deferred to seeker / curator / human triage:

- **Option A — continue hypersimplex.** Treat oq-03 ⇔ hypersimplex (matches on-main + gallery). Discharge the 2 on-main sorries:
  - `hypersimplex_count_k_one`: Δ(d, 1) lattice count = C(n + d − 1, d − 1) via multiset-stars-and-bars (~70 LOC).
  - `hypersimplex_palindrome_k_d_minus_1`: Δ(d, k) ↔ Δ(d, d − k) via involution x ↦ n − x (~70 LOC).
  Both tractable in Mathlib v4.26.0; no algebraic-geometry preliminaries.

- **Option B — spin off Barvinok as `ehrhart-cube-proven-oq-05`.** Preserve the Session 1 Barvinok plan as a new sibling slug; revert oq-03 JSON title/tags to hypersimplex. Clean separation; the bearer audit gives oq-05 the corrected Mathlib substrate awareness from day 1.

## Scope

**In scope** (doc-only PREP, 0 `.lean` edits):

- `research/problems/ehrhart-cube-proven-oq-03/state.md` — rewritten as Session 2 anchor with 4 findings + 2 options + decision log.
- `research/problems/ehrhart-cube-proven-oq-03/knowledge.md` — appended §"S2 PREP — Mathlib bearer audit" with method / findings tables / corrected gap inventory.
- `src/data/research/problems/ehrhart-cube-proven-oq-03.json`:
  - `phase` S1_OBSERVE → S2_PREP, `iteration` 1 → 2.
  - `currentState.blockers` populated, `focus` / `nextAction` refreshed.
  - `knowledge.{progressSummary,insights,mathlibGaps,nextSteps,markdown}` rewritten.
  - `knownResults.proven`: corrected the false Mathlib claim.
  - `references.mathlib`: removed nonexistent `Mathlib.Combinatorics.Polytope.Ehrhart`; corrected `PowerSeries.Basic` → `MvPowerSeries.Basic`.
  - `references.urls`: removed dead `mathlib4_docs/.../Polytope/Ehrhart.html`.
  - `leanFiles`: added entry for on-main `Proofs/EhrhartCubeProvenOQ03.lean` (119 LOC, 6 theorems, 2 defs, 2 sorries, 0 axioms — drift fix).
  - `lastUpdate` bumped.

**Out of scope** (deliberately):

- No `.lean` edits. The on-main hypersimplex scaffold is untouched.
- No retitle of the JSON `title` field — that is the scope-decision question deferred to Option A / B.
- No `src/data/proofs/ehrhart-cube-proven-oq-03/meta.json` edits (those describe the on-main scaffold accurately and would only be touched under Option B).
- No new sibling slug creation — seeker / curator can spin off `oq-05` under Option B.

## Test plan

- [ ] `python3 -c "import json; json.load(open('src/data/research/problems/ehrhart-cube-proven-oq-03.json'))"` — JSON validity (already verified locally).
- [ ] No build needed — doc-only PR.
- [ ] Cross-reference companion finding `[Mathlib bearer-audit PREPs frequently cite Mathlib HEAD instead of lake-pinned SHA]` (project memory) — this audit uses the pinned SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)