### PR TITLE
fix(mechanic): wire tacticStates into fundamental-theorem-calculus index.ts

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/index.ts
+++ b/src/data/proofs/fundamental-theorem-calculus/index.ts
@@ -1,6 +1,7 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
+import tacticStatesJson from './tacticStates.json'
 import sourceRaw from '../../../../proofs/Proofs/FundamentalTheoremCalculus.lean?raw'
 
 const meta = metaJson as {
@@ -29,8 +30,10 @@ export const fundamentalTheoremCalculusProof: Proof = {
 }
 
 export const fundamentalTheoremCalculusAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const fundamentalTheoremCalculusTacticStates: TacticState[] = tacticStatesJson as TacticState[]
 
 export const fundamentalTheoremCalculusData: ProofData = {
   proof: fundamentalTheoremCalculusProof,
   annotations: fundamentalTheoremCalculusAnnotations,
+  tacticStates: fundamentalTheoremCalculusTacticStates,
 }


### PR DESCRIPTION
## Fix

Wires the existing 28-entry `tacticStates.json` (26.8 KB) into the gallery module for `fundamental-theorem-calculus`. Before this change, the module declared a `ProofData` without `tacticStates`, so the LeanInk-extracted tactic goal states never reached the rendered page.

## Evidence

**Before** (`src/data/proofs/fundamental-theorem-calculus/index.ts`):
- No `tacticStatesJson` import.
- No `TacticState[]` named export.
- `fundamentalTheoremCalculusData: ProofData = { proof, annotations }` (no `tacticStates` field).

The 26.8 KB `tacticStates.json` shipped in the bundle but was never read.

**After** (canonical sibling pattern, matches `sqrt2-irrational`, `fermat-two-squares`, `e-transcendental-oq-01`, `russell-1-plus-1`, `infinitude-primes`, `central-limit-theorem`, `lagrange-four-squares`, `bertrands-postulate`):
- `import tacticStatesJson from './tacticStates.json'`
- `import type { ... TacticState } from '@/types/proof'`
- `export const fundamentalTheoremCalculusTacticStates: TacticState[] = tacticStatesJson as TacticState[]`
- `ProofData = { proof, annotations, tacticStates: fundamentalTheoremCalculusTacticStates }`

`tacticStates.json` shape (`{ line, tactic, goalsBefore, goalsAfter }`) exactly matches the `TacticState` interface at `src/types/proof.ts:502`.

`npx tsc -b` is clean. Net diff: +4 / -1 in one file.

## Scope

- Touches **only** `src/data/proofs/fundamental-theorem-calculus/index.ts`.
- Does **not** alter `meta.json`, `annotations.json`, `tacticStates.json`, or the Lean source.
- Orthogonal to in-flight mechanic PR #18864 (different slug — angle-trisection-oq-05-oq-04 / different fix class — annotations vs tacticStates).

---
Automated fix by lean-mechanic agent.