### PR TITLE
fix(mechanic): sync review-tracker actionItems/resolvedItems across 60 entries

### DIFF
--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -6,16 +6,16 @@
       "lastReviewed": "2026-03-24T00:30:06Z",
       "overallGrade": "B-",
       "qualityScore": 6.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 5
     },
     "cantor-diagonalization": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T00:35:05Z",
       "overallGrade": "B+",
       "qualityScore": 7.0,
-      "actionItems": 8,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "lebesgue-measure": {
       "reviewCount": 1,
@@ -23,7 +23,7 @@
       "overallGrade": "B-",
       "qualityScore": 5.5,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 6
     },
     "kroneckers-jugendtraum": {
       "reviewCount": 1,
@@ -31,31 +31,31 @@
       "overallGrade": "C-",
       "qualityScore": 4.2,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "abel-ruffini": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T01:34:04Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "amgm-inequality": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T03:31:21Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 4
     },
     "area-of-circle-oq-01-oq-02-oq-01": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T04:32:36Z",
       "overallGrade": "B+",
       "qualityScore": 8.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "arithmetic-series": {
       "reviewCount": 1,
@@ -63,111 +63,111 @@
       "overallGrade": "B",
       "qualityScore": 7.3,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "ballot-problem": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T05:31:54Z",
       "overallGrade": "C+",
       "qualityScore": 6.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 7
     },
     "cevas-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T05:39:33Z",
       "overallGrade": "B+",
       "qualityScore": 7.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "continuum-hypothesis": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:31:41Z",
       "overallGrade": "C",
       "qualityScore": 5.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 6
     },
     "dissection-of-cubes-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:38:47Z",
       "overallGrade": "B-",
       "qualityScore": 6.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "erdos-szekeres": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T07:31:13Z",
       "overallGrade": "C+",
       "qualityScore": 5.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 4
     },
     "denumerability-rationals": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T08:32:27Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "fair-games-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T09:32:17Z",
       "overallGrade": "B",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 7
     },
     "fundamental-theorem-algebra": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T10:31:52Z",
       "overallGrade": "B-",
       "qualityScore": 6.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "godel-incompleteness": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T11:31:59Z",
       "overallGrade": "D+",
       "qualityScore": 4.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 6
     },
     "hilbert-15": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T14:35:25Z",
       "overallGrade": "C",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 2
     },
     "hilbert-4": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:33:11Z",
       "overallGrade": "C",
       "qualityScore": 5.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 4
     },
     "hilbert-17": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:41:27Z",
       "overallGrade": "C+",
       "qualityScore": 6.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 3
     },
     "hilbert-10": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:38:16Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "bezout-identity": {
       "reviewCount": 1,
@@ -175,7 +175,7 @@
       "overallGrade": "B",
       "qualityScore": 6.7,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "cauchy-schwarz": {
       "reviewCount": 1,
@@ -183,15 +183,15 @@
       "overallGrade": "B+",
       "qualityScore": 7.8,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "lagrange-four-squares": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T16:40:33Z",
       "overallGrade": "C+",
       "qualityScore": 5.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 4
     },
     "angle-trisection": {
       "reviewCount": 1,
@@ -199,7 +199,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "bertrands-postulate": {
       "reviewCount": 1,
@@ -207,7 +207,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.3,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "cramers-rule": {
       "reviewCount": 1,
@@ -215,7 +215,7 @@
       "overallGrade": "B-",
       "qualityScore": 5.7,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "de-moivre": {
       "reviewCount": 1,
@@ -223,7 +223,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "derangements": {
       "reviewCount": 1,
@@ -231,7 +231,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.0,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "euler-totient": {
       "reviewCount": 1,
@@ -239,7 +239,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "fundamental-arithmetic": {
       "reviewCount": 1,
@@ -247,7 +247,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "fundamental-theorem-calculus": {
       "reviewCount": 1,
@@ -255,7 +255,7 @@
       "overallGrade": "C+",
       "qualityScore": 5.3,
       "actionItems": 7,
-      "resolvedItems": 0
+      "resolvedItems": 6
     },
     "herons-formula": {
       "reviewCount": 1,
@@ -263,7 +263,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "isosceles-triangle": {
       "reviewCount": 1,
@@ -271,7 +271,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.3,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "lagrange-theorem": {
       "reviewCount": 1,
@@ -279,207 +279,207 @@
       "overallGrade": "B",
       "qualityScore": 7.0,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "platonic-solids": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T17:32:42Z",
       "overallGrade": "B+",
       "qualityScore": 7.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "liouville-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T18:37:05Z",
       "overallGrade": "B-",
       "qualityScore": 6.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 3
     },
     "triangular-reciprocals": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T19:32:53Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "area-of-circle-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T20:32:37Z",
       "overallGrade": "B+",
       "qualityScore": 8.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "bezout-identity-oq-02-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T21:37:33Z",
       "overallGrade": "A-",
       "qualityScore": 8.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "ptolemys-theorem": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T23:32:03Z",
       "overallGrade": "C+",
       "qualityScore": 5.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 5
     },
     "cevas-theorem-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:38:18Z",
       "overallGrade": "A-",
       "qualityScore": 8.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "ballot-problem-oq-01-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:33:41Z",
       "overallGrade": "B",
       "qualityScore": 7.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "cauchy-schwarz-integral-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:34:20Z",
       "overallGrade": "A-",
       "qualityScore": 8.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 2,
+      "resolvedItems": 2
     },
     "amgm-inequality-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:38:33Z",
       "overallGrade": "B",
       "qualityScore": 7.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "amgm-inequality-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:33:12Z",
       "overallGrade": "B+",
       "qualityScore": 8.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 3
     },
     "amgm-inequality-oq-03-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:37:03Z",
       "overallGrade": "B",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "cauchy-schwarz-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T03:38:16Z",
       "overallGrade": "B+",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "area-of-circle-oq-01-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T04:34:12Z",
       "overallGrade": "B-",
       "qualityScore": 6.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "area-of-circle-oq-01": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-25T06:32:34Z",
       "overallGrade": "B",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "ballot-problem-oq-03-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T05:38:48Z",
       "overallGrade": "B+",
       "qualityScore": 7.4,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "borsuk-ulam": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T06:43:08Z",
       "overallGrade": "B-",
       "qualityScore": 7.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "cantor-diagonalization-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T07:32:47Z",
       "overallGrade": "B+",
       "qualityScore": 8.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "erdos-273": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T08:33:48Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "bezout-identity-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T09:32:56Z",
       "overallGrade": "B+",
       "qualityScore": 8.1,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "cayley-hamilton-minpoly-oq-05": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T10:32:33Z",
       "overallGrade": "B-",
       "qualityScore": 6.9,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "denumerability-rationals-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T11:42:52Z",
       "overallGrade": "A-",
       "qualityScore": 8.4,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 4
     },
     "abel-ruffini-oq-04-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T12:44:41Z",
       "overallGrade": "B+",
       "qualityScore": 7.6,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 9,
+      "resolvedItems": 8
     },
     "de-moivre-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T13:44:16Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "dissection-of-cubes-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T14:44:32Z",
       "overallGrade": "C+",
       "qualityScore": 6.1,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "euler-polyhedral-formula": {
       "reviewCount": 1,


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/review-tracker.json` so every entry's `actionItems` and `resolvedItems` counts match the actual state of the corresponding `src/data/proofs/<slug>/review.json`. **60 of 62 entries** diverged.

## Evidence

`scripts/peer-reviewer/claim-target.sh::do_complete` updates `reviewCount`, `lastReviewed`, and `overallGrade`, but never writes the `actionItems` / `resolvedItems` counters. As enrichers and researchers worked through review action items (marking them `status: resolved` in `review.json`), the tracker stayed frozen at its initial values — `npx tsx scripts/peer-reviewer/find-targets.ts` consumes those counters when scoring priorities and had no signal that any item had been resolved.

**Before** (sample of pre-sync drift):

| slug | tracker (total/resolved) | actual review.json (total/resolved) |
|---|---|---|
| `cantor-diagonalization` | 8/0 | 6/6 |
| `lebesgue-measure` | 6/0 | 6/6 |
| `bezout-identity` | 5/0 | 5/5 |
| `kroneckers-jugendtraum` | 5/0 | 5/4 |
| `arithmetic-series` | 4/0 | 4/4 |
| `abel-ruffini` | 0/0 | 3/3 |
| `continuum-hypothesis` | 0/0 | 8/6 |
| `ballot-problem` | 0/0 | 7/7 |
| `godel-incompleteness` | 0/0 | 8/6 |

(Note: `cantor-diagonalization` also had a stale total — review.json has 6 items, tracker said 8.)

**After**: zero drift across all 60 entries — verified by re-reading every `review.json` and comparing.

## Scope

Pure metadata sync. Touches **only** `src/data/proofs/review-tracker.json` (+105 / -105, symmetric in-place value substitution). No Lean files, no `review.json` files, no scripts.

PR #18684 attempted this same sync earlier today but closed with `additions=0, deletions=0, changed_files=0` (phantom diff — the agent never actually committed). This PR ships the real diff.

## Validation

```
$ python3 -c "import json; json.load(open('src/data/proofs/review-tracker.json')) and print('JSON valid')"
JSON valid

$ git diff --stat src/data/proofs/review-tracker.json
 src/data/proofs/review-tracker.json | 210 ++++++++++++++++++------------------
 1 file changed, 105 insertions(+), 105 deletions(-)
```

---
Automated fix by lean-mechanic agent.