### PR TITLE
fix(mechanic): redirect 2 cross-refs burnside-lemma → burnside-counting

### DIFF
--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -107,7 +107,7 @@
       "description": "Base derangement entry proving D(n) = n!·∑(-1)^k/k! via inclusion-exclusion; the partial derangement decomposition S(n,k) here generalizes that formula"
     },
     {
-      "slug": "burnside-lemma",
+      "slug": "burnside-counting",
       "relationship": "uses",
       "description": "Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) is the direct tool for proving sum_fixedPoints_eq_factorial — the orbit count collapses to 1 via transitivity"
     },

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -109,7 +109,7 @@
       "description": "Parent file proving Lagrange's theorem on subgroup order dividing group order; this entry proves the Sylow partial converse"
     },
     {
-      "slug": "burnside-lemma",
+      "slug": "burnside-counting",
       "relationship": "related",
       "description": "Burnside's lemma (orbit-counting) is used in the proof of the Third Sylow Theorem: the action of a Sylow p-subgroup on the set of Sylow p-subgroups by conjugation has exactly one fixed point, giving n_p ≡ 1 mod p"
     },


### PR DESCRIPTION
## Fix

Two gallery `meta.json` files cross-reference the slug `burnside-lemma`, which has never existed. The Burnside's-Lemma proof actually lives at `src/data/proofs/burnside-counting/` ("Burnside's Lemma and Necklace Counting"). Redirecting the slug resolves both refs to real targets and lets the gallery's link-renderer display them as proper hyperlinks instead of dead text.

## Evidence

Gallery-wide broken-xref scan (target slug not present in `src/data/proofs/<slug>/meta.json`):

| Source slug | Broken target | Resolved → |
|---|---|---|
| `derangements-oq-02-oq-02` | `burnside-lemma` | `burnside-counting` (this PR) |
| `lagrange-theorem-oq-01`   | `burnside-lemma` | `burnside-counting` (this PR) |
| `ehrhart-cube-proven-oq-02` | `ehrhart-polynomials` | (no existing target — left as-is) |
| `greens-theorem-oq-01-oq-01-oq-02-oq-03` | `greens-theorem-oq-01-oq-01-oq-02-oq-01` | (no existing sibling — left as-is) |

`burnside-counting/meta.json` title: **Burnside's Lemma and Necklace Counting** (`description: "Burnside's lemma (orbit-counting theorem): for a finite group G acting on a set X, the number of orbits equals the average number of fixed points."`) — exact semantic match for what both xrefs describe.

## Scope

- Touches **only** the `slug` field of the two affected `crossReferences[]` entries (+2 / -2, symmetric single-token substitution).
- Does **not** edit `description`, `relationship`, or any other field.
- Does **not** touch `burnside-counting/meta.json`, the two Lean files, or anything else.
- Out of scope (separate PR, separate decision): `ehrhart-polynomials` and `greens-theorem-oq-01-oq-01-oq-02-oq-01` broken xrefs — these target slugs that genuinely do not exist in the gallery; removing vs. creating-then-linking is a content question, not a slug-rename mechanic.

## Validation

```
$ python3 -c "import json; json.load(open('src/data/proofs/derangements-oq-02-oq-02/meta.json')); json.load(open('src/data/proofs/lagrange-theorem-oq-01/meta.json')); print('JSON valid')"
JSON valid

$ git diff --stat
 src/data/proofs/derangements-oq-02-oq-02/meta.json | 2 +-
 src/data/proofs/lagrange-theorem-oq-01/meta.json   | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

Post-fix scan: `burnside-lemma` refs drop from 2 → 0; total broken xrefs 4 → 2 (the two left intentionally out of scope above).

---
Automated fix by lean-mechanic agent.