### PR TITLE
fix(mechanic): sync erdos-2-oq-01 meta.sorries 0 → 1 (Aristotle companion sorry)

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -18,7 +18,7 @@
       "extension"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 2,
     "erdosUrl": "https://erdosproblems.com/2",
     "erdosProblemStatus": "open-question",
@@ -50,7 +50,7 @@
       "Complete characterization of achievable set as initial segment [0, M]",
       "Gap narrowing framework for future bound improvements"
     ],
-    "assumptions": "3 axiom(s) inherited from imported Lean file. 0 sorry(s).",
+    "assumptions": "3 axiom(s) inherited from imported Lean file. 1 sorry(s) in Aristotle companion file (distinct_sum_lower_bound).",
     "theoremCount": 18,
     "definitionCount": 2
   },


### PR DESCRIPTION
## Fix

Restores aggregated `sorries: 1` on `src/data/proofs/erdos-2-oq-01/meta.json` to match the real-tactic sorry in the Aristotle companion file.

## Evidence

**Before** (`meta.json`):
- `"sorries": 0`
- `"assumptions": "3 axiom(s) inherited from imported Lean file. 0 sorry(s)."`

**Actual Lean state**:
- `proofs/Proofs/Erdos2OQ01.lean` (main, listed via `proofRepoPath`): 0 sorries
- `proofs/Proofs/Erdos2Problem.lean` (additionalFiles): 0 sorries
- `proofs/Proofs/Erdos2OQ01Aristotle.lean` (additionalFiles): **1 sorry at line 88** (`distinct_sum_lower_bound` — induction extracting minimum element)
- Aggregated: **1 sorry**

Block-comment-aware scan across all 2,432 gallery entries (strips `/- ... -/` + `/-! ... -/` + `-- ...` then matches `\bsorry\b`) flags this slug as the sole outlier.

**After**:
- `"sorries": 1`
- `"assumptions": "3 axiom(s) inherited from imported Lean file. 1 sorry(s) in Aristotle companion file (distinct_sum_lower_bound)."`

## Why the prior audit missed this

Audit PR #18702 (2026-05-13 02:22 UTC, sorries `1 → 0`) only ran `grep -nc "sorry" proofs/Proofs/Erdos2OQ01.lean` — i.e. the file at `proofRepoPath`. It did not aggregate `additionalFiles[*]`. Per the gallery aggregation convention documented elsewhere in the codebase, `meta.sorries` reflects **main Lean + every entry in `meta.additionalFiles`** (typically `<Name>Aristotle.lean`). The companion file's lone `sorry` therefore needs to be counted.

## Scope

- Touches **only** `src/data/proofs/erdos-2-oq-01/meta.json` (+2 / -2).
- Does **not** alter Lean source, `annotations.json`, `tacticStates.json`, `review.json`, or the enrichment-tracker.
- Does **not** change `axiomCount: 3`, `status: "axiomatized"`, or `badge: "axiom"` — those remain correct (3 axioms inherited from `Proofs/Erdos2Problem.lean`: `balister_bound`, `owens_construction`, `reciprocal_sum_ge_one`).

---
Automated fix by lean-mechanic agent.