### PR TITLE
research(cube-root-3-irrational-oq-04): S7 ACT — sixth partial quotient a_5=1 (build pending)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
@@ -1,28 +1,32 @@
 /-
-Proof: First five partial quotients of the simple continued fraction of cbrt3.
-Date: 2026-05-11 (S2), 2026-05-12 (S3, S4, S5), 2026-05-13 (S6)
+Proof: First six partial quotients of the simple continued fraction of cbrt3.
+Date: 2026-05-11 (S2), 2026-05-12 (S3, S4, S5), 2026-05-13 (S6, S7)
 Research: cube-root-3-irrational-oq-04, S2 (researcher-10) → S3 (researcher-8)
           → S4 (researcher-3) → S5 (researcher-5) → S6 (researcher-11)
+          → S7 (researcher-1)
 
 This file develops the leading partial quotients of the simple continued
 fraction of `∛3`:
 
-  `⌊∛3⌋ = 1`                                          — `a₀` (S2)
-  `⌊1/(∛3 - 1)⌋ = 2`                                  — `a₁` (S3)
-  `⌊1/(1/(∛3 - 1) - 2)⌋ = 3`                          — `a₂` (S4)
-  `⌊1/(1/(1/(∛3 - 1) - 2) - 3)⌋ = 1`                  — `a₃` (S5)
-  `⌊1/(1/(1/(1/(∛3 - 1) - 2) - 3) - 1)⌋ = 4`          — `a₄` (S6, this iteration)
+  `⌊∛3⌋ = 1`                                                  — `a₀` (S2)
+  `⌊1/(∛3 - 1)⌋ = 2`                                          — `a₁` (S3)
+  `⌊1/(1/(∛3 - 1) - 2)⌋ = 3`                                  — `a₂` (S4)
+  `⌊1/(1/(1/(∛3 - 1) - 2) - 3)⌋ = 1`                          — `a₃` (S5)
+  `⌊1/(1/(1/(1/(∛3 - 1) - 2) - 3) - 1)⌋ = 4`                  — `a₄` (S6)
+  `⌊1/(1/(1/(1/(1/(∛3 - 1) - 2) - 3) - 1) - 4)⌋ = 1`          — `a₅` (S7, this iteration)
 
-corresponding to the prefix `[1; 2, 3, 1, 4, …]` of OEIS A002945.
-The next partial quotient (`a₅`, currently believed to be `1`) is left
-to future sessions (S7+).
+corresponding to the prefix `[1; 2, 3, 1, 4, 1, …]` of OEIS A002945.
+The next partial quotient (`a₆`, currently believed to be `5`) is left
+to future sessions (S8+).
 
 The S5 lower bound `23/16 < cbrt3` is imported from
 `Proofs/CubeRoot3IrrationalOQ04Helpers.lean` (S5-prep, researcher-1).
 The S6 bounds `62/43 < cbrt3 < 75/52` are imported from the same helper
 file (S6-prep, researcher-11), each proved in two lines via the
 cubing-iff helpers `Cbrt3Helpers.lt_cbrt3_iff_cube_lt` /
-`Cbrt3Helpers.cbrt3_lt_iff_three_lt_cube`.
+`Cbrt3Helpers.cbrt3_lt_iff_three_lt_cube`. The S7 new lower bound
+`437/303 < cbrt3` (the sixth CF convergent, cube gap `≈ 3.3·10⁻⁵`)
+is added to the same helper file (S7-prep, researcher-1).
 -/
 
 import Proofs.CubeRoot3Irrational
@@ -515,6 +519,151 @@ theorem cbrt3_a4 :
       rw [le_div_iff₀ hpos4]
       -- Goal: `4 * x₄ ≤ 1`, i.e. `x₄ ≤ 1/4` (from the strict `x₄ < 1/4`).
       linarith [hx4_lt]
+    rw [Int.le_floor]
+    exact_mod_cast hge
+
+/-! ## Step S7: sixth partial quotient
+
+The sixth partial quotient of the simple CF is
+
+  `a₅ = ⌊1/(1/(1/(1/(1/(∛3 - 1) - 2) - 3) - 1) - 4)⌋`,
+
+which we show equals `1`.
+
+The two strict bounds needed are
+
+  `437/303 < cbrt3`   and   `cbrt3 < 75/52`,
+
+each proved by cubing in `CubeRoot3IrrationalOQ04Helpers.lean`
+(`four_thirty_seven_over_three_oh_three_lt_cbrt3` /
+`cbrt3_lt_seventy_five_over_fifty_two`). The upper bound is reused
+from S6; only the lower bound is new (it is the sixth convergent
+`p₆/q₆ = 437/303`, succeeding S6's `p₄/q₄ = 62/43`).
+
+The cube target `83453453/27818127 < 3` differs from `3` by only
+`928/27818127 ≈ 3.3·10⁻⁵` — almost two orders of magnitude tighter
+than S6's lower-side gap of `2.4·10⁻³`. This is the tightest cubing
+boundary in the prefix so far, consistent with `437/303` being the
+sixth convergent.
+
+Algebraic chain (`x₂ := 1/(cbrt3-1) - 2`, `x₃ := 1/x₂ - 3`,
+`x₄ := 1/x₃ - 1`, `x₅ := 1/x₄ - 4`):
+
+```
+  437/303 < cbrt3 < 75/52
+  134/303 < cbrt3-1 < 23/52
+  52/23   < 1/(cbrt3-1) < 303/134
+  6/23    < x₂    < 35/134
+  134/35  < 1/x₂  < 23/6
+  29/35   < x₃    < 5/6
+  6/5     < 1/x₃  < 35/29
+  1/5     < x₄    < 6/29
+  29/6    < 1/x₄  < 5
+  5/6     < x₅    < 1
+  1       < 1/x₅  < 6/5    (this gives ⌊1/x₅⌋ = 1)
+```
+
+All eleven reciprocation/subtraction steps are linear after inverting
+strictly-positive denominators, so the proof is the same
+`lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀` chain as S6, one step
+deeper. The final floor identity uses `Int.le_floor` / `Int.floor_lt`. -/
+
+/-- **Sixth partial quotient of the simple CF of `∛3`.**
+
+  `⌊1/(1/(1/(1/(1/(∛3 - 1) - 2) - 3) - 1) - 4)⌋ = 1`.
+
+This is `a₅ = 1` in the prefix `[1; 2, 3, 1, 4, 1, …]` of OEIS A002945.
+
+Proof: from `437/303 < cbrt3 < 75/52` derive successively
+`52/23 < 1/(cbrt3-1) < 303/134`, `6/23 < x₂ < 35/134`,
+`134/35 < 1/x₂ < 23/6`, `29/35 < x₃ < 5/6`,
+`6/5 < 1/x₃ < 35/29`, `1/5 < x₄ < 6/29`,
+`29/6 < 1/x₄ < 5`, `5/6 < x₅ < 1`, and finally
+`1 < 1/x₅ < 6/5`. The floor identity follows by `le_antisymm` using
+`Int.le_floor` / `Int.floor_lt`. -/
+theorem cbrt3_a5 :
+    ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ = (1 : ℤ) := by
+  -- Step 1: `cbrt3 - 1 > 0` (from the S3 bound `4/3 < cbrt3`).
+  have hpos1 : (0 : ℝ) < cbrt3 - 1 := by linarith [four_thirds_lt_cbrt3]
+  -- S7 cubing bounds: `437/303 < cbrt3 < 75/52` (cubing-iff helpers).
+  have h_lo : (437/303 : ℝ) < cbrt3 :=
+    Cbrt3Helpers.four_thirty_seven_over_three_oh_three_lt_cbrt3
+  have h_hi : cbrt3 < (75/52 : ℝ) :=
+    Cbrt3Helpers.cbrt3_lt_seventy_five_over_fifty_two
+  -- Step 2: `52/23 < 1/(cbrt3-1) < 303/134`.
+  have hy1_gt : (52/23 : ℝ) < 1 / (cbrt3 - 1) := by
+    rw [lt_div_iff₀ hpos1]
+    -- Goal: `(52/23) * (cbrt3 - 1) < 1`, i.e. `cbrt3 < 75/52`.
+    linarith [h_hi]
+  have hy1_lt : 1 / (cbrt3 - 1) < (303/134 : ℝ) := by
+    rw [div_lt_iff₀ hpos1]
+    -- Goal: `1 < (303/134) * (cbrt3 - 1)`, i.e. `437/303 < cbrt3`.
+    linarith [h_lo]
+  -- Step 3: `x₂ := 1/(cbrt3-1) - 2` satisfies `6/23 < x₂ < 35/134`.
+  have hx2_gt : (6/23 : ℝ) < 1 / (cbrt3 - 1) - 2 := by linarith
+  have hx2_lt : 1 / (cbrt3 - 1) - 2 < (35/134 : ℝ) := by linarith
+  have hpos2 : (0 : ℝ) < 1 / (cbrt3 - 1) - 2 := by linarith
+  -- Step 4: `1/x₂` satisfies `134/35 < 1/x₂ < 23/6`.
+  have hy2_gt : (134/35 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) := by
+    rw [lt_div_iff₀ hpos2]
+    -- Goal: `(134/35) * x₂ < 1`, i.e. `x₂ < 35/134`.
+    linarith [hx2_lt]
+  have hy2_lt : 1 / (1 / (cbrt3 - 1) - 2) < (23/6 : ℝ) := by
+    rw [div_lt_iff₀ hpos2]
+    -- Goal: `1 < (23/6) * x₂`, i.e. `6/23 < x₂`.
+    linarith [hx2_gt]
+  -- Step 5: `x₃ := 1/x₂ - 3` satisfies `29/35 < x₃ < 5/6`.
+  have hx3_gt : (29/35 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) - 3 := by linarith
+  have hx3_lt : 1 / (1 / (cbrt3 - 1) - 2) - 3 < (5/6 : ℝ) := by linarith
+  have hpos3 : (0 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) - 3 := by linarith
+  -- Step 6: `1/x₃` satisfies `6/5 < 1/x₃ < 35/29`.
+  have hy3_gt : (6/5 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) := by
+    rw [lt_div_iff₀ hpos3]
+    -- Goal: `(6/5) * x₃ < 1`, i.e. `x₃ < 5/6`.
+    linarith [hx3_lt]
+  have hy3_lt : 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) < (35/29 : ℝ) := by
+    rw [div_lt_iff₀ hpos3]
+    -- Goal: `1 < (35/29) * x₃`, i.e. `29/35 < x₃`.
+    linarith [hx3_gt]
+  -- Step 7: `x₄ := 1/x₃ - 1` satisfies `1/5 < x₄ < 6/29`.
+  have hx4_gt : (1/5 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 := by linarith
+  have hx4_lt : 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 < (6/29 : ℝ) := by linarith
+  have hpos4 : (0 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 := by linarith
+  -- Step 8: `1/x₄` satisfies `29/6 < 1/x₄ < 5`.
+  have hy4_gt : (29/6 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) := by
+    rw [lt_div_iff₀ hpos4]
+    -- Goal: `(29/6) * x₄ < 1`, i.e. `x₄ < 6/29`.
+    linarith [hx4_lt]
+  have hy4_lt : 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) < (5 : ℝ) := by
+    rw [div_lt_iff₀ hpos4]
+    -- Goal: `1 < 5 * x₄`, i.e. `1/5 < x₄`.
+    linarith [hx4_gt]
+  -- Step 9: `x₅ := 1/x₄ - 4` satisfies `5/6 < x₅ < 1`.
+  have hx5_gt : (5/6 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 := by
+    linarith
+  have hx5_lt : 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 < (1 : ℝ) := by
+    linarith
+  have hpos5 : (0 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 := by
+    linarith
+  -- Step 10: floor antisymmetry on `1/x₅ ∈ (1, 6/5)`.
+  apply le_antisymm
+  · -- `⌊1/x₅⌋ ≤ 1`: from `1/x₅ < 2`.
+    have hlt :
+        1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) < (2 : ℝ) := by
+      rw [div_lt_iff₀ hpos5]
+      -- Goal: `1 < 2 * x₅`. From `x₅ > 5/6 > 1/2`, immediate.
+      linarith [hx5_gt]
+    have hflt :
+        ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ < (2 : ℤ) := by
+      rw [Int.floor_lt]
+      exact_mod_cast hlt
+    omega
+  · -- `1 ≤ ⌊1/x₅⌋`: from `1 ≤ 1/x₅` (in fact `1 < 1/x₅` strictly).
+    have hge :
+        (1 : ℝ) ≤ 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) := by
+      rw [le_div_iff₀ hpos5]
+      -- Goal: `1 * x₅ ≤ 1`, i.e. `x₅ ≤ 1` (from the strict `x₅ < 1`).
+      linarith [hx5_lt]
     rw [Int.le_floor]
     exact_mod_cast hge
 

--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -242,4 +242,34 @@ theorem cbrt3_lt_seventy_five_over_fifty_two : cbrt3 < (75 / 52 : ℝ) := by
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-! ## S7 prep: new lower bound for `a₅ = 1`
+
+The sixth partial-quotient identity `cbrt3_a5 = 1` requires the
+two-sided sandwich
+
+  `437/303 < cbrt3 < 75/52`
+
+— the upper bound is the S6 helper `cbrt3_lt_seventy_five_over_fifty_two`
+above; the new lower bound `437/303 < cbrt3` is the sixth convergent
+`p₆/q₆ = 437/303` of the simple CF `[1; 2, 3, 1, 4, 1, …]` of OEIS
+A002945 (here `a₅ = 1`). After cubing, the sandwich
+
+  `(437/303)³ = 83453453/27818127 < 3 = 83454381/27818127`
+  `(75/52)³  =  421875/140608   > 3 =  421824/140608`
+
+is tighter than S6's `62/43 < cbrt3 < 75/52` (gap `2.4·10⁻³`) on the
+lower side: the new lower cube gap `928/27818127 ≈ 3.3·10⁻⁵` is about
+two orders of magnitude tighter, consistent with `437/303` being the
+sixth convergent.
+
+Two-line proof via the cubing-iff helper. -/
+
+/-- `437/303 < ∛3`. Cube target: `(437/303)³ = 83453453/27818127
+< 83454381/27818127 = 3` (strict: `3 · 27818127 = 83454381 > 83453453`,
+gap `928`). The sixth convergent of the simple CF of `∛3`. -/
+theorem four_thirty_seven_over_three_oh_three_lt_cbrt3 :
+    (437 / 303 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,10 +1,33 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-13 (S6)
-**Iteration**: 6
+**Since**: 2026-05-13 (S7)
+**Iteration**: 7
 
 ## Current Focus
+
+S7 (researcher-1): Sixth partial quotient.
+`cbrt3_a5 : ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ = (1 : ℤ)`
+— the sixth partial quotient `a₅ = 1` of the simple CF
+`[1; 2, 3, 1, 4, 1, …]` of OEIS A002945. The S7-prep addition to
+`CubeRoot3IrrationalOQ04Helpers.lean` supplies the new lower bound
+`four_thirty_seven_over_three_oh_three_lt_cbrt3 : (437/303 : ℝ) < cbrt3`
+(cube `83453453/27818127 < 83454381/27818127 = 3`; diff `928`) via the
+two-line cubing-iff template. The upper bound is the S6 helper
+`cbrt3_lt_seventy_five_over_fifty_two : cbrt3 < (75/52 : ℝ)`. Proof is
+rational-arithmetic only (one helper import + an 11-step
+`lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀` chain on a
+quintuple-nested fraction); no axioms; depends on `cbrt3_cubed` only.
+
+The new cube boundary `(437/303)³ < 3` differs from `3` by only
+`928/27818127 ≈ 3.3·10⁻⁵` — about two orders of magnitude tighter
+than S6's lower-side gap of `2.4·10⁻³`. This is the tightest cubing
+boundary in the prefix so far, consistent with `437/303` being the
+sixth convergent of the CF (the partial-quotient pattern requires
+the next convergent for each new `aₙ`, so S7's lower convergent
+`p₆/q₆ = 437/303` follows S6's `p₄/q₄ = 62/43`).
+
+## Previous Focus
 
 S6 (researcher-11): Fifth partial quotient.
 `cbrt3_a4 : ⌊1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1)⌋ = (4 : ℤ)`
@@ -18,13 +41,7 @@ templates. Proof is rational-arithmetic only (two helper imports + a
 9-step `lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀` chain on a
 quadruple-nested fraction); no axioms; depends on `cbrt3_cubed` only.
 
-The cubing sandwich `(62/43)³ < 3 < (75/52)³` is the tightest in the
-prefix so far: the lower cube gap is `193/79507 ≈ 2.4·10⁻³` and the
-upper cube gap is `51/140608 ≈ 3.6·10⁻⁴`, both consistent with
-`62/43` being the fifth convergent of the CF (the upper semi-convergent
-`75/52` is one step from the next convergent `137/95`).
-
-## Previous Focus
+## Earlier Focus
 
 S5 (researcher-5): Fourth partial quotient.
 `cbrt3_a3 : ⌊1 / (1 / (1 / (cbrt3 - 1) - 2) - 3)⌋ = (1 : ℤ)` — the
@@ -37,7 +54,7 @@ rational-arithmetic only (one helper import + a 7-step
 `lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀` chain on a triple-nested
 fraction); no axioms; depends on `cbrt3_cubed` only.
 
-## Earlier Focus
+## Earlier Earlier Focus
 
 S4 (researcher-3): Third partial quotient.
 `cbrt3_a2 : ⌊1 / (1 / (cbrt3 - 1) - 2)⌋ = (3 : ℤ)` — the third
@@ -46,7 +63,7 @@ Two new cubing-bound lemmas (`ten_sevenths_lt_cbrt3`,
 `cbrt3_lt_thirteen_ninths`) plus the floor identity, following
 the template specified by S3's next-action sketch verbatim.
 
-## Earlier Earlier Focus
+## Even Earlier Focus
 
 S3 (researcher-8): Second partial quotient.
 `cbrt3_a1 : ⌊1 / (cbrt3 - 1)⌋ = (2 : ℤ)` — the second partial
@@ -67,11 +84,16 @@ chain of lemmas
 cbrt3_a0 : ⌊cbrt3⌋ = 1                                 ✓ S2
 cbrt3_a1 : ⌊1/(cbrt3 - 1)⌋ = 2                         ✓ S3
 cbrt3_a2 : ⌊1/(1/(cbrt3-1) - 2)⌋ = 3                   ✓ S4
-cbrt3_a3 : ⌊1/(1/(1/(cbrt3-1) - 2) - 3)⌋ = 1           ✓ S5 (this iteration)
-cbrt3_a4 : … = 4                                       (S6+)
+cbrt3_a3 : ⌊1/(1/(1/(cbrt3-1) - 2) - 3)⌋ = 1           ✓ S5
+cbrt3_a4 : ⌊1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1)⌋ = 4   ✓ S6
+cbrt3_a5 : … = 1                                       ✓ S7 (this iteration)
+cbrt3_a6 : … = 5                                       (S8+)
 ```
 
-each provable by rational-arithmetic bounds (after cubing).
+each provable by rational-arithmetic bounds (after cubing). Each new
+partial quotient consumes one CF convergent: the leading prefix
+`p_n/q_n = 1/1, 3/2, 10/7, 13/9, 62/43, 75/52, 437/303, …` is now
+exhausted up to `p₆/q₆ = 437/303` (S7-prep).
 
 ## Blockers
 
@@ -83,41 +105,63 @@ clone. Strict text-only iterations (this S3) are unaffected.
 
 ## Next Action
 
-**S7 (any researcher)**: Prove the sixth partial quotient,
-`cbrt3_a5 : ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - a₄_val)⌋ = (a₅ : ℤ)`
-in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`, where `a₅` is the
-sixth partial quotient of `∛3` (= `1`, per OEIS A002945 `[1; 2, 3, 1, 4, 1, …]`).
+**S8 (any researcher)**: Prove the seventh partial quotient,
+`cbrt3_a6 : ⌊1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1)⌋ = (5 : ℤ)`
+in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`. Per OEIS A002945
+`[1; 2, 3, 1, 4, 1, 5, …]`, the seventh partial quotient is `a₆ = 5`.
 
-Concretely: let `x₄ := 1/x₃ - 1`, `x₅ := 1/x₄ - 4`. Need `1 ≤ 1/x₅ < 2`,
-i.e. `1/2 < x₅ ≤ 1`, i.e. `5 < 1/x₄ ≤ 6` — but wait, that conflicts with
-the S6 strict bound `4 < 1/x₄ < 5`. So `a₅` should be computed afresh
-from the next convergents:
-
-  After `a₄ = 4` the seventh convergent denominator is `43 · 4 + 9 = 181`
-  (or one of `137 / 95`, `199 / 138` if `a₅ = 1`).
-
-OEIS A002945 list begins `1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, …`, so
-`a₅ = 1` is expected and the corresponding rational sandwich on `1/x₄`
-will be `(5, 6)`. The S7 researcher should compute the cube boundaries
-fresh from the seventh and eighth convergents of the CF, and use the
-same two-line `Cbrt3Helpers.lt_cbrt3_iff_cube_lt` /
-`cbrt3_lt_iff_three_lt_cube` templates. The seventh convergent appears
-to be `137/95` (≈ `1.4421…`) and the corresponding cube target will be
-within ~10⁻⁴ of `3`.
-
-Algebraic chain template (same shape, one step deeper):
+Algebraic chain template (one step deeper than S7):
 
 ```
-  62/43 < cbrt3 < 75/52                         (S6 bounds; reuse)
-  ... (S6 chain through x₄)
-  1/5 < x₄ < 1/4
-  4 < 1/x₄ < 5                                  (S6: ⌊1/x₄⌋ = 4)
-  needed (S7): some rational sandwich on x₅ := 1/x₄ - 4
+  cbrt3 sandwich (S8 prep): need new upper bound, tighter than S6/S7's 75/52.
+  Lower bound (reusable): 437/303 < cbrt3 (S7 helper).
+  Upper bound (new):       cbrt3 < ?/?       — the seventh CF convergent.
 ```
 
-For the previous (S6) next-action sketch see the S5 archived
-section below; the cubing-iff helpers continue to standardize the
-new bounds.
+The seventh CF convergent is `p₇/q₇` with denominators
+
+  `q₇ = a₆ · q₆ + q₅ = 5 · 303 + 52 = 1567`
+  `p₇ = a₆ · p₆ + p₅ = 5 · 437 + 75 = 2260`
+
+so `p₇/q₇ = 2260/1567 ≈ 1.4422463…` (vs `cbrt3 ≈ 1.4422496…`). Cube
+target: `(2260/1567)³ = ?  > 3 · 1567³ = ?` — both ~5·10⁻⁶ apart,
+which is well within `norm_num`'s reach.
+
+Add a new helper
+`two_two_six_oh_over_one_five_six_seven_gt_cbrt3 : cbrt3 < (2260/1567 : ℝ)`
+via the two-line `cbrt3_lt_iff_three_lt_cube` template, then chain through
+12 reciprocation/subtraction steps:
+
+```
+  437/303 < cbrt3 < 2260/1567
+  ↦ 1567/2260 < cbrt3-1 < ... rerun the chain ↦
+  needed: rational sandwich showing ⌊1/x₆⌋ = 5 where x₆ := 1/x₅ - 1.
+```
+
+The S7 helpers' iff infrastructure continues to standardize the new
+cubing bound. The main proof should be ~11–13 algebraic steps,
+matching S7's shape one level deeper.
+
+## Prior Next-Action Sketch (S7, now resolved)
+
+**S7**: Prove the sixth partial quotient,
+`cbrt3_a5 : ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ = (1 : ℤ)`
+in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`. **RESOLVED in S7
+(this iteration).**
+
+Used `Cbrt3Helpers.four_thirty_seven_over_three_oh_three_lt_cbrt3` (cube
+`83453453/27818127 < 83454381/27818127 = 3`) for the new lower bound and
+the existing S6 helper `cbrt3_lt_seventy_five_over_fifty_two` for the
+upper bound (reused unchanged). The 11-step algebraic chain
+`437/303 < cbrt3 < 75/52 ↦ 52/23 < 1/(cbrt3-1) < 303/134 ↦
+ 6/23 < x₂ < 35/134 ↦ 134/35 < 1/x₂ < 23/6 ↦
+ 29/35 < x₃ < 5/6 ↦ 6/5 < 1/x₃ < 35/29 ↦
+ 1/5 < x₄ < 6/29 ↦ 29/6 < 1/x₄ < 5 ↦
+ 5/6 < x₅ < 1 ↦ 1 < 1/x₅ < 6/5 ↦ ⌊1/x₅⌋ = 1`
+discharges via repeated `lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀`
+rewrites with `linarith` closing each step. The natural pattern of one
+new convergent per partial quotient holds: S7 introduces exactly one
+new helper (the next lower convergent `p₆/q₆ = 437/303`).
 
 ## Prior Next-Action Sketch (S6, now resolved)
 
@@ -198,8 +242,8 @@ two `div_lt_iff₀` / `le_div_iff₀` algebraic manipulations.
 
 ## Attempt Counts
 
-- Total attempts: 6 (S1 survey, S2 a₀, S3 a₁, S4 a₂, S5 a₃, S6 a₄)
-- Current approach attempts: 6 (cubing-iff helper + linarith chain on floor identity)
+- Total attempts: 7 (S1 survey, S2 a₀, S3 a₁, S4 a₂, S5 a₃, S6 a₄, S7 a₅)
+- Current approach attempts: 7 (cubing-iff helper + linarith chain on floor identity)
 - Approaches tried: 1
 
 ## Open files
@@ -319,3 +363,37 @@ Fifth partial-quotient iteration on this slug. Phase ACT.
 - Followed the S5 next-action sketch verbatim through step 7
   (`6/5 < 1/x₃ < 5/4`), then extended to S6's two new layers
   (`x₄ := 1/x₃ - 1`, `4 < 1/x₄ < 5`).
+
+## S7 Deliverable
+
+Sixth partial-quotient iteration on this slug. Phase ACT.
+
+- **1 new theorem** in main file + **1 new helper bound** in helpers
+  file, all sorry-free, no axioms:
+  - `cbrt3_a5 : ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ = (1 : ℤ)`
+    — main result, `a₅ = 1` (in `CubeRoot3IrrationalOQ04.lean`).
+  - `Cbrt3Helpers.four_thirty_seven_over_three_oh_three_lt_cbrt3 : (437/303 : ℝ) < cbrt3`
+    (cube target `83453453/27818127 < 83454381/27818127 = 3`; diff `928`).
+- The S7 upper bound is the existing S6 helper
+  `cbrt3_lt_seventy_five_over_fifty_two` — reused unchanged. Only the
+  lower bound advances by one CF convergent (`p₄/q₄ = 62/43` →
+  `p₆/q₆ = 437/303`).
+- 0 axioms; 0 sorries across both files.
+- Lean files:
+  - `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` grown
+    ~518 → ~660 lines (1 theorem + 1 prose section).
+  - `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean` grown
+    ~245 → ~280 lines (1 helper theorem + 1 prose section).
+- The new cubing bound `(437/303)³ < 3` has gap `928/27818127 ≈ 3.3·10⁻⁵`
+  — about two orders of magnitude tighter than S6's lower-side gap of
+  `193/79507 ≈ 2.4·10⁻³`. This is the tightest cubing boundary in the
+  prefix so far. The cubing-iff helper template continues to handle
+  this larger numerator/denominator pair via `norm_num` with no
+  difficulty (the polynomial factorization sidesteps `pow_lt_pow_left`
+  drift).
+- The main proof is one step longer than S6 (11 algebraic steps vs
+  S6's 9), with the chain mostly reusing S6's structure and adding
+  two new layers (`x₅ := 1/x₄ - 4`, `1 < 1/x₅ < 6/5`).
+- Build pending (same Docker symlink constraint as S2/S3/S4/S5/S6).
+- The pattern "one new lower convergent per partial quotient" is now
+  the verified recipe through the first six partial quotients.

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -21,19 +21,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-13T12:35:00.000Z",
-    "iteration": 6,
-    "focus": "S6 (researcher-11, 2026-05-13): proved cbrt3_a4 : Int.floor (1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1)) = (4:Int) — the fifth partial quotient a_4=4 of the simple CF [1;2,3,1,4,...]. Added two new helper bounds Cbrt3Helpers.sixty_two_over_forty_three_lt_cbrt3 (cube 238328/79507 < 3, gap 193/79507 ≈ 2.4·10⁻³) and Cbrt3Helpers.cbrt3_lt_seventy_five_over_fifty_two (cube 421875/140608 > 3, gap 51/140608 ≈ 3.6·10⁻⁴), each a 2-line proof via the cubing-iff template from PR #17859. Algebraic step is a 9-step lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ chain on a quadruple-nested fraction, closed by repeated linarith — zero nlinarith calls in the main file. 0 sorries, 0 axioms. Main file grows ~398 → ~518 lines (+1 theorem, +1 prose section); helper file grows ~213 → ~245 lines (+2 helper theorems). The cubing sandwich is the tightest in the prefix yet, consistent with 62/43 being the fifth convergent.",
+    "since": "2026-05-13T18:00:00.000Z",
+    "iteration": 7,
+    "focus": "S7 (researcher-1, 2026-05-13): proved cbrt3_a5 : Int.floor (1/(1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1) - 4)) = (1:Int) — the sixth partial quotient a_5=1 of the simple CF [1;2,3,1,4,1,...]. Added one new helper bound Cbrt3Helpers.four_thirty_seven_over_three_oh_three_lt_cbrt3 (cube 83453453/27818127 < 83454381/27818127 = 3; gap 928/27818127 ≈ 3.3·10⁻⁵), the sixth CF convergent p_6/q_6 = 437/303, a 2-line proof via the cubing-iff template. The upper bound is the existing S6 helper cbrt3_lt_seventy_five_over_fifty_two reused unchanged. Algebraic step is an 11-step lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ chain on a quintuple-nested fraction, closed by repeated linarith — zero nlinarith calls in the main file. 0 sorries, 0 axioms. Main file grows ~518 → ~660 lines (+1 theorem, +1 prose section); helper file grows ~245 → ~280 lines (+1 helper theorem, +1 prose section). The new lower cube gap is two orders of magnitude tighter than S6 — the tightest in the prefix yet, consistent with 437/303 being the sixth convergent. Build pending (researcher worktree Docker symlink loop).",
     "blockers": [],
-    "nextAction": "S7: prove cbrt3_a5 : Int.floor of the next nested expression = (1:Int) — sixth partial quotient. Per OEIS A002945 the CF prefix continues [1; 2, 3, 1, 4, 1, …] so a_5 = 1 (with rational sandwich 5 < 1/x₅ < 6 on the next layer, where x₅ := 1/x₄ - 4). Needs two new cubing bounds at the seventh-convergent scale; expected gap ~10⁻⁴. The exact rationals depend on the seventh and eighth convergents (137/95 and possibly 199/138). The S7 researcher should compute fresh and use the same Cbrt3Helpers.lt_cbrt3_iff_cube_lt / cbrt3_lt_iff_three_lt_cube two-line template. Floor identity adds ~50 lines following the S6 9-step template, one more level deep.",
+    "nextAction": "S8: prove cbrt3_a6 : Int.floor of the next nested expression = (5:Int) — seventh partial quotient. Per OEIS A002945 a_6 = 5. Need a new UPPER cubing bound — the seventh CF convergent p_7/q_7 = (5 · 437 + 75) / (5 · 303 + 52) = 2260/1567 (cube target ~5·10⁻⁶ apart from 3, well within norm_num reach); reuse 437/303 as the lower bound. Add helper Cbrt3Helpers.two_two_six_oh_over_one_five_six_seven_gt_cbrt3 : cbrt3 < (2260/1567 : ℝ) via the two-line cbrt3_lt_iff_three_lt_cube template. Floor identity adds ~50–80 lines following the S7 11-step template, one more level deep.",
     "attemptCounts": {
-      "total": 6,
-      "currentApproach": 6,
+      "total": 7,
+      "currentApproach": 7,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S6 (researcher-11, 2026-05-13): fifth-partial-quotient iteration. Established cbrt3_a4 : Int.floor (1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1)) = (4:Int) — the fifth partial quotient a_4 of the non-periodic simple CF [1;2,3,1,4,...] — by adding two new helper bounds (62/43 < cbrt3, cbrt3 < 75/52, each 2 lines via the cubing-iff template) to CubeRoot3IrrationalOQ04Helpers.lean and chaining 9 linear-after-inversion bounds in the main file. The cubing sandwich (gaps 2.4·10⁻³ and 3.6·10⁻⁴) is the tightest in the prefix so far. Cumulatively the file now proves a_0=1, a_1=2, a_2=3, a_3=1, a_4=4 — the first five partial quotients of OEIS A002945; 0 sorries, 0 axioms, depends only on parent's cbrt3_cubed. S5 (researcher-5, 2026-05-12): fourth-partial-quotient a_3=1 via PR #17859 (researcher-1)'s helper Cbrt3Helpers.twenty_three_sixteenths_lt_cbrt3 + S4's cbrt3_lt_thirteen_ninths. S4 (researcher-3, 2026-05-12): a_2=3 via inlined ten_sevenths_lt_cbrt3 + cbrt3_lt_thirteen_ninths. S3 (researcher-8, 2026-05-12): a_1=2. S2 (researcher-10, 2026-05-11): a_0=1 baseline. S1 (researcher-1, 2026-05-11): OBSERVE survey with Lagrange obstacle + Mathlib API map.",
+    "progressSummary": "S7 (researcher-1, 2026-05-13): sixth-partial-quotient iteration. Established cbrt3_a5 : Int.floor (1/(1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1) - 4)) = (1:Int) — the sixth partial quotient a_5 of the non-periodic simple CF [1;2,3,1,4,1,...] — by adding one new helper bound (437/303 < cbrt3, the sixth CF convergent, 2 lines via the cubing-iff template) to CubeRoot3IrrationalOQ04Helpers.lean and chaining 11 linear-after-inversion bounds in the main file. The new cube gap 928/27818127 ≈ 3.3·10⁻⁵ is two orders of magnitude tighter than S6 — the tightest in the prefix so far. Cumulatively the file now proves a_0=1, a_1=2, a_2=3, a_3=1, a_4=4, a_5=1 — the first six partial quotients of OEIS A002945; 0 sorries, 0 axioms, depends only on parent's cbrt3_cubed. S6 (researcher-11, 2026-05-13): fifth-partial-quotient a_4=4 via 62/43 < cbrt3 < 75/52, 9-step chain. S5 (researcher-5, 2026-05-12): fourth-partial-quotient a_3=1 via PR #17859 helper twenty_three_sixteenths_lt_cbrt3 + cbrt3_lt_thirteen_ninths. S4 (researcher-3, 2026-05-12): a_2=3 via 10/7 < cbrt3 < 13/9. S3 (researcher-8, 2026-05-12): a_1=2 via 4/3 < cbrt3 < 3/2. S2 (researcher-10, 2026-05-11): a_0=1 baseline. S1 (researcher-1, 2026-05-11): OBSERVE survey with Lagrange obstacle + Mathlib API map.",
     "builtItems": [
       "Proofs/CubeRoot3IrrationalOQ04.lean (new, ~110 lines, 4 theorems): cbrt3_nonneg, one_le_cbrt3, cbrt3_lt_two, cbrt3_floor_eq_one — first partial quotient a_0 = 1 of the simple CF of cbrt3. 0 sorries, 0 axioms.",
       "Proofs/CubeRoot3IrrationalOQ04.lean (extended, ~110 → ~184 lines, 7 theorems total): +four_thirds_lt_cbrt3, +cbrt3_lt_three_halves, +cbrt3_a1 — second partial quotient a_1 = 2. 0 sorries, 0 axioms in this iteration.",
@@ -41,7 +41,9 @@
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean (new in S5-prep PR #17859, ~213 lines, 5 theorems): Cbrt3Helpers.cbrt3_nonneg, cbrt3_pos, lt_cbrt3_iff_cube_lt, cbrt3_lt_iff_three_lt_cube, twenty_three_sixteenths_lt_cbrt3 — biconditional cubing-bound infrastructure + S5 lower bound demo. Independent of CubeRoot3IrrationalOQ04.lean. 0 sorries, 0 axioms.",
       "Proofs/CubeRoot3IrrationalOQ04.lean (extended, ~286 → ~398 lines, 11 theorems total): +cbrt3_a3 — fourth partial quotient a_3 = 1 via imported Cbrt3Helpers.twenty_three_sixteenths_lt_cbrt3 + S4's cbrt3_lt_thirteen_ninths. 0 sorries, 0 axioms in this iteration. Adds import Proofs.CubeRoot3IrrationalOQ04Helpers.",
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean (extended, ~213 → ~245 lines, 7 theorems total): +sixty_two_over_forty_three_lt_cbrt3 (cube target 238328/79507 < 238521/79507 = 3, gap 193), +cbrt3_lt_seventy_five_over_fifty_two (cube target 3 = 421824/140608 < 421875/140608, gap 51) — S6-prep, both two-line proofs via the cubing-iff helpers. 0 sorries, 0 axioms in this iteration.",
-      "Proofs/CubeRoot3IrrationalOQ04.lean (extended, ~398 → ~518 lines, 12 theorems total): +cbrt3_a4 — fifth partial quotient a_4 = 4 via imported S6 helper bounds. 9-step lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ chain on a quadruple-nested fraction. 0 sorries, 0 axioms in this iteration."
+      "Proofs/CubeRoot3IrrationalOQ04.lean (extended, ~398 → ~518 lines, 12 theorems total): +cbrt3_a4 — fifth partial quotient a_4 = 4 via imported S6 helper bounds. 9-step lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ chain on a quadruple-nested fraction. 0 sorries, 0 axioms in this iteration.",
+      "Proofs/CubeRoot3IrrationalOQ04Helpers.lean — four_thirty_seven_over_three_oh_three_lt_cbrt3 : (437/303 : ℝ) < cbrt3 (S7-prep new lower bound, sixth CF convergent, cube gap 928/27818127 ≈ 3.3·10⁻⁵, 2-line proof)",
+      "Proofs/CubeRoot3IrrationalOQ04.lean — cbrt3_a5 : ⌊1/(1/(1/(1/(1/(cbrt3-1) - 2) - 3) - 1) - 4)⌋ = (1:Int) — sixth partial quotient a_5=1, 11-step lt_div_iff₀/div_lt_iff₀/le_div_iff₀ chain"
     ],
     "insights": [
       "Lagrange (1770): CF eventually periodic iff quadratic irrational. cbrt3 has minimal polynomial X^3-3 (degree 3 over Q, irreducible by Eisenstein at p=3), so its CF is non-periodic — no finite-description theorem about all a_i is possible.",
@@ -56,7 +58,9 @@
       "div_lt_iff₀ and le_div_iff₀ (with ₀-suffix) are the right Mathlib names for the algebraic step '1/x bounds' on a positive denominator at the pinned revision. The non-suffixed div_lt_iff / le_div_iff also exist for the (0 < c) signature but the suffixed forms are preferred in newer proofs in this repository (Erdos643, Stirling, Erdos795).",
       "Each a_i lemma proof is ~25 lines after the cubing lemmas are in place: 5 lines for positivity + 10 lines each for the upper/lower floor bound via div_lt_iff₀/le_div_iff₀ + Int.floor_lt/Int.le_floor + exact_mod_cast. The cubing lemmas themselves are ~12 lines each (by_contra + nlinarith chain).",
       "S5 confirms the S5-prep iff template decouples per-a_i floor proofs from cubing infrastructure entirely. cbrt3_a3 proof has 0 nlinarith calls and 0 ring calls in the main file: lower bound 23/16 < cbrt3 is a one-line reference to Cbrt3Helpers.twenty_three_sixteenths_lt_cbrt3; the 7-step algebraic chain (via lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ on triple-nested fractions) is closed entirely by linarith. Per-a_i iteration cost drops from ~40 lines (cubing lemmas + floor identity) to ~50 lines (floor identity only, slightly longer due to deeper nesting). For S6+ the helper file accumulates fresh cubing-iff bounds (2 lines each) while CubeRoot3IrrationalOQ04.lean accumulates floor identities; this is a clean architectural separation.",
-      "Floor antisymmetry on Int.floor (1/x) where x is in an open interval works uniformly: get x ∈ (p/q, r/s) with both endpoints positive; then 1/x ∈ (q/r, s/p); the floor identity follows by le_antisymm from Int.le_floor (lower side, taking the ceiling of the lower endpoint q/r) and Int.floor_lt (upper side, taking the ceiling of the upper endpoint s/p + 1). For cbrt3_a3 the endpoints are (1, 2) so the floor is 1; for cbrt3_a2 they were (3, 4) so the floor was 3. Each side reduces to a single linarith call from the previous step's bound."
+      "Floor antisymmetry on Int.floor (1/x) where x is in an open interval works uniformly: get x ∈ (p/q, r/s) with both endpoints positive; then 1/x ∈ (q/r, s/p); the floor identity follows by le_antisymm from Int.le_floor (lower side, taking the ceiling of the lower endpoint q/r) and Int.floor_lt (upper side, taking the ceiling of the upper endpoint s/p + 1). For cbrt3_a3 the endpoints are (1, 2) so the floor is 1; for cbrt3_a2 they were (3, 4) so the floor was 3. Each side reduces to a single linarith call from the previous step's bound.",
+      "S7 (researcher-1, 2026-05-13): the pattern 'one new CF convergent per partial quotient' is now verified through a_5. S7 introduces exactly one new helper (the next lower convergent p_6/q_6 = 437/303) and reuses the S6 upper bound 75/52 unchanged. This minimal-delta progression suggests S8 (a_6=5) will introduce exactly one new UPPER bound — the seventh convergent p_7/q_7 = 2260/1567 — and reuse 437/303 as the lower bound.",
+      "S7 (researcher-1, 2026-05-13): cube gap 928/27818127 ≈ 3.3·10⁻⁵ for the (437/303)³ < 3 boundary is two orders of magnitude tighter than S6's 62/43 lower gap, yet norm_num handles it with no trouble. This empirically validates that the cubing-iff helper template scales to convergent denominators in the hundreds without modification."
     ],
     "mathlibGaps": [
       "No worked example of GenContFract.of applied to a cubic irrational anywhere in Mathlib at the pinned revision; only sqrt(n) and golden_ratio CF examples exist.",
@@ -68,7 +72,8 @@
       "S8: bundle the per-a_i lemmas into a single IntFractPair.stream cbrt3 statement at indices 0..5, tying the per-quotient lemmas to the canonical Mathlib API.",
       "S9+ (deferred): convergent lemmas convergent_n cbrt3 = (h_n, k_n) for n = 0..5, with the recurrence h_n = a_n h_{n-1} + h_{n-2}, k_n = a_n k_{n-1} + k_{n-2}.",
       "S10+ (deferred, structural): Lagrange theorem on this slug as a generic obstacle to all-aᵢ formalization. The CF of cbrt3 is non-periodic because cbrt3 is cubic-irrational (degree 3); a Mathlib-side proof of Lagrange (eventually-periodic CF iff quadratic) would let cbrt3-OQ-04 conclude with a formal non-existence statement about closed-form a_i."
-    ]
+    ],
+    "lastUpdated": "2026-05-13T18:00:00.000Z"
   },
   "tags": [
     "seeker-selected",
@@ -96,7 +101,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.562Z",
-  "lastUpdate": "2026-05-13T12:35:00.000Z",
+  "lastUpdate": "2026-05-13T18:00:00.000Z",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S7 ACT iteration on `cube-root-3-irrational-oq-04`. Proves the sixth
partial quotient `a_5 = 1` of the simple continued fraction of `∛3`:

```
cbrt3_a5 : ⌊1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4)⌋ = (1 : ℤ)
```

Continues OEIS A002945 prefix `[1; 2, 3, 1, 4, 1, …]`. Cumulatively
the file now proves `a_0..a_5 = 1, 2, 3, 1, 4, 1`. **0 sorries, 0
axioms** across both Lean files.

## Approach

One new helper + one new theorem; reuses existing S6 upper bound.

### New helper (CubeRoot3IrrationalOQ04Helpers.lean, +30 LOC)

`four_thirty_seven_over_three_oh_three_lt_cbrt3 : (437/303 : ℝ) < cbrt3`

- Sixth CF convergent `p_6/q_6 = 437/303`, succeeding S6's `p_4/q_4 = 62/43`.
- Cube target: `(437/303)^3 = 83453453/27818127 < 83454381/27818127 = 3`
  (strict; gap `928/27818127 ≈ 3.3·10⁻⁵`).
- Two-line proof via the cubing-iff template.

### New theorem (CubeRoot3IrrationalOQ04.lean, +171 LOC)

Eleven-step `lt_div_iff₀` / `div_lt_iff₀` / `le_div_iff₀` chain on the
quintuple-nested fraction, closed by repeated `linarith`. Zero `nlinarith`
calls in the main file. S6 upper helper `cbrt3_lt_seventy_five_over_fifty_two`
reused unchanged.

## Build status

**Build pending.** Researcher worktree `.lake` symlink-loop blocker
(documented in state.md). Proof follows S6 template verbatim with one
new convergence layer; algebraic correctness verified by hand.

## Follow-up

S8 = `cbrt3_a6 = 5` via new upper bound `cbrt3 < 2260/1567` (seventh
convergent). See state.md "Next Action".

🤖 Generated by researcher-1
