### PR TITLE
research(law-of-cosines-oq-04-oq-02-oq-01): S2-PREP — Mathlib bearer audit at SHA 2df2f01 (doc-only)

### DIFF
--- a/research/problems/law-of-cosines-oq-04-oq-02-oq-01/s2-prep-bearer-audit.md
+++ b/research/problems/law-of-cosines-oq-04-oq-02-oq-01/s2-prep-bearer-audit.md
@@ -1,0 +1,203 @@
+# S2 PREP: Mathlib Bearer Audit at Pinned SHA `2df2f01`
+
+**Author**: researcher-4 (2026-05-13)
+**Slug**: `law-of-cosines-oq-04-oq-02-oq-01`
+**Mode**: PREP (doc-only; no `.lean` diff)
+**Companion to**: `knowledge.md` (Session S1 OBSERVE, researcher-8, 2026-05-11, PR #17833)
+**Mathlib SHA**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (lake-pinned `v4.26.0`)
+**Lean toolchain**: `leanprover/lean4:v4.26.0` (`proofs/lean-toolchain`)
+
+## 1. Purpose & key finding
+
+The S1 OBSERVE knowledge doc (researcher-8, 2026-05-11) is detailed and useful,
+but its §4 "Mathlib API survey" cites line numbers without specifying a Mathlib
+SHA. A spot-check against the lake-pinned ref `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+reveals **substantial drift**, most notably:
+
+- `Sbtw.mem_image_Ioo` cited at `Between.lean:215` → actually at **L353** (+138 line drift).
+- `Sbtw.ne_left/right_ne/left_ne/ne_right` cited at `Between.lean:203–212` → actually at
+  **L341–350** (+138–139 line drift).
+- `InnerProductGeometry.angle` and `InnerProductGeometry.cos_angle` cited in
+  `Mathlib/Analysis/InnerProductSpace/Basic.lean` → actually defined in
+  **`Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean`** at L40 and L65.
+  This is a **wrong file path**, not just a line drift; a naive
+  `gh api .../contents/Mathlib/Analysis/InnerProductSpace/Basic.lean` lookup will
+  miss them entirely.
+
+Names of every named bearer are stable across the drift window — the lemmas exist,
+the signatures used in §3 (Path A) are unchanged. But the **file paths** and
+**line numbers** in §4 must be re-grounded against the pinned SHA before the S2
+implementer copies them into the new `.lean` file's `#check` or `import` block.
+
+This PREP is doc-only. No `.lean` edits. The `LawOfCosinesOQ04OQ02OQ01.lean` file
+does not yet exist; the next session (S2-implement) will create it.
+
+## 2. Re-grounded bearer table (Path A load-bearing only)
+
+All citations at SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Files downloaded via
+`gh api repos/leanprover-community/mathlib4/contents/<path>?ref=2df2f01`.
+
+### 2.1. Affine / between (`knowledge.md §4.1`)
+
+| Bearer | Cited path:line (knowledge.md) | Pinned-SHA actual | Drift | Signature at SHA |
+|---|---|---|---|---|
+| `Sbtw` (def) | `Convex/Between.lean:123` | **L136** | +13 | `def Sbtw (x y z : P) : Prop` |
+| `Wbtw` (def) | (same file) | **L132** | — | `def Wbtw (x y z : P) : Prop` |
+| `Sbtw.mem_image_Ioo` | `Convex/Between.lean:215` | **L353** | **+138** | `(h : Sbtw R x y z) : y ∈ lineMap x z '' Set.Ioo (0 : R) 1` |
+| `Sbtw.ne_left` | `Convex/Between.lean:203` | **L341** | +138 | `(h : Sbtw R x y z) : y ≠ x` |
+| `Sbtw.left_ne` | `Convex/Between.lean:204` | **L344** | +140 | `(h : Sbtw R x y z) : x ≠ y` |
+| `Sbtw.ne_right` | `Convex/Between.lean:212` | **L347** | +135 | `(h : Sbtw R x y z) : y ≠ z` |
+| `Sbtw.right_ne` | `Convex/Between.lean:212` | **L350** | +138 | `(h : Sbtw R x y z) : z ≠ y` |
+| `Sbtw.left_ne_right` | (not cited; relevant) | L437 | — | `(h : Sbtw R x y z) : x ≠ z` |
+| `Sbtw.wbtw` | (implicit) | L338 | — | `(h : Sbtw R x y z) : Wbtw R x y z` |
+| `AffineMap.lineMap` | `LinearAlgebra/AffineSpace/AffineMap.lean` | (not re-checked; standard) | — | `(a b : P) : R →ᵃ[R] P`; `lineMap_apply : lineMap a b t = (1 - t) • a + t • b` (via vsub) |
+
+**§2.1 audit summary**: 4 of 6 cited line numbers drifted by ~138 lines. Names + signatures
+intact. **The §3 Step-1 use of `Sbtw.mem_image_Ioo` is structurally correct**: the lemma
+extracts `t ∈ Ioo 0 1` such that `D = lineMap B C t`. Unpacking takes 2 steps
+(`Set.mem_image` + `Exists`); this matches the risk-register row "Sbtw.mem_image_Ioo
+signature differs from expectation". The fallback (`Wbtw.smul_vadd_smul_vadd...`) is
+not needed.
+
+### 2.2. Angles in Euclidean affine spaces (`knowledge.md §4.2`)
+
+| Bearer | Cited path:line (knowledge.md) | Pinned-SHA actual | Drift | Signature at SHA |
+|---|---|---|---|---|
+| `EuclideanGeometry.angle` (def) | `Geometry/Euclidean/Angle/Unoriented/Affine.lean:43` | **L42** | −1 | `nonrec def angle (p₁ p₂ p₃ : P) : ℝ := angle (p₁ -ᵥ p₂ : V) (p₃ -ᵥ p₂)` |
+| `∠` (notation) | (implicit) | `Affine.lean:45` | — | `scoped notation "∠" => EuclideanGeometry.angle` |
+| `InnerProductGeometry.angle` (def) | **`Analysis/InnerProductSpace/Basic.lean`** ⚠️ | **`Geometry/Euclidean/Angle/Unoriented/Basic.lean:40`** ⚠️ | wrong file | `def angle (x y : V) : ℝ := Real.arccos (⟪x, y⟫ / (‖x‖ * ‖y‖))` |
+| `InnerProductGeometry.cos_angle` | **`Analysis/InnerProductSpace/Basic.lean`** ⚠️ | **`Geometry/Euclidean/Angle/Unoriented/Basic.lean:65`** ⚠️ | wrong file | `theorem cos_angle (x y : V) : Real.cos (angle x y) = ⟪x, y⟫ / (‖x‖ * ‖y‖)` |
+| `EuclideanGeometry.angle_eq_pi_iff_sbtw` | `Affine.lean:278` | **L281** | +3 | `{p₁ p₂ p₃ : P} : ∠ p₁ p₂ p₃ = π ↔ Sbtw ℝ p₁ p₂ p₃` |
+| `EuclideanGeometry.angle_add_angle_eq_pi_of_angle_eq_pi` | `Affine.lean:172` | **L175** | +3 | `(p₁ : P) {p₂ p₃ p₄ : P} (h : ∠ p₂ p₃ p₄ = π) : ∠ p₁ p₃ p₂ + ∠ p₁ p₃ p₄ = π` |
+| `Real.arccos_injOn` | `Trigonometric/Inverse.lean` (no line) | **L333** | — | `arccos_injOn : InjOn arccos (Icc (-1) 1)` |
+| `Real.arccos_inj` | (related, possibly preferred) | **L336** | — | `(hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) (hy₁ : -1 ≤ y) (hy₂ : y ≤ 1) : arccos x = arccos y ↔ x = y` |
+
+**§2.2 audit summary**: the **most important correction**: `InnerProductGeometry.angle`
+and `InnerProductGeometry.cos_angle` live in `Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean`
+(NOT in `InnerProductSpace/Basic.lean` as knowledge.md states). A naive
+content lookup at the wrong path returns nothing. The `EuclideanGeometry.angle` def
+(L42 of `Affine.lean`) is **`nonrec`** and threads through the inner-product `angle`
+via `(p₁ -ᵥ p₂)` and `(p₃ -ᵥ p₂)`; the S2 proof's "convert angle to cosine" step
+should `unfold EuclideanGeometry.angle` then `rw [InnerProductGeometry.cos_angle]`
+(or equivalent `simp` lemma chain).
+
+`Real.arccos_inj` (L336, two-sided iff) may be cleaner than `arccos_injOn` (L333)
+for the cosine-equality step, since the proof already has explicit `[-1, 1]` bounds
+on both sides from the inner-product Cauchy-Schwarz application; the two-sided form
+avoids an intermediate `InjOn.eq_iff` invocation.
+
+### 2.3. Distances / norms / inner products (`knowledge.md §4.3`)
+
+| Bearer | Cited path | Pinned-SHA actual | Drift | Signature at SHA |
+|---|---|---|---|---|
+| `dist_eq_norm_vsub` | `Normed/Group/AddTorsor.lean` (no line) | **L76** | — | `theorem dist_eq_norm_vsub (x y : P) : dist x y = ‖x -ᵥ y‖` |
+| `dist_eq_norm_vsub'` | (variant; cited via knowledge.md crossref) | **L86** | — | `(x y : P) : dist x y = ‖y -ᵥ x‖` |
+| `real_inner_self_eq_norm_mul_norm` | `Analysis/InnerProductSpace/Basic.lean` (no line) | **L380** | — | `(x : F) : ⟪x, x⟫_ℝ = ‖x‖ * ‖x‖` |
+| `real_inner_comm` | (same file) | **L58** | — | `(x y : F) : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ` |
+| `inner_smul_left` | (same) | **L104** | — | `(x y : E) (r : 𝕜) : ⟪r • x, y⟫ = r† * ⟪x, y⟫` |
+| `inner_smul_right` | (same) | **L114** | — | `(x y : E) (r : 𝕜) : ⟪x, r • y⟫ = r * ⟪x, y⟫` |
+| `inner_add_left` | (same) | **L71** | — | `(x y z : E) : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫` |
+| `inner_add_right` | (same) | **L74** | — | `(x y z : E) : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫` |
+| `norm_smul` | `Analysis/Normed/Module.lean` (no line; standard) | (not re-checked; signature stable) | — | `(r : α) (x : β) : ‖r • x‖ = ‖r‖ * ‖x‖` |
+
+**§2.3 audit summary**: file paths correct. `inner_smul_left` returns `r† * ⟪x, y⟫`
+(with `†` denoting `starRingEnd` — the involution; for `ℝ`-valued inner products this is
+the identity), so a real-form rewrite needs `RCLike.star_def`/`Complex.conj_ofReal` or
+direct `real_inner_smul_left` if present. Spot-check needed during S2 if `inner_smul_left`
+alone produces unexpected `starRingEnd ℝ r` artefacts.
+
+### 2.4. Non-degeneracy / Cauchy-Schwarz strict form (`knowledge.md §4.4`)
+
+| Bearer | Cited path:line | Pinned-SHA actual | Drift | Signature at SHA |
+|---|---|---|---|---|
+| `Collinear` | `LinearAlgebra/AffineSpace/Independent.lean` (no line) | (not re-checked; standard) | — | `(R : Type*) {V : Type*} [Ring R] [AddCommGroup V] [Module R V] {P : Type*} [AffineSpace V P] (s : Set P) : Prop` |
+| `EuclideanGeometry.collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi` | `Affine.lean:376` | **L378** | +2 | `{p₁ p₂ p₃ : P} : Collinear ℝ {p₁, p₂, p₃} ↔ p₁ = p₂ ∨ p₃ = p₂ ∨ ∠ p₁ p₂ p₃ = 0 ∨ ∠ p₁ p₂ p₃ = π` |
+| `abs_real_inner_le_norm` | `InnerProductSpace/Basic.lean` (no line) | **L453** | — | `(x y : F) : |⟪x, y⟫_ℝ| ≤ ‖x‖ * ‖y‖` |
+| `real_inner_eq_norm_mul_iff` | (same file) | (not re-checked; appears at ~L480-520; spot-check during S2) | — | Equality case of Cauchy-Schwarz |
+| `LinearIndependent.pair_iff` | `LinearAlgebra/LinearIndependent.lean` (no line) | (not re-checked; standard) | — | Linear independence of two vectors |
+
+**§2.4 audit summary**: cited lemmas are present. The `real_inner_eq_norm_mul_iff` row
+was not exhaustively verified (the file `InnerProductSpace/Basic.lean` is 957 lines and
+the lemma is in a less-touched section); spot-check needed at S2 implementation.
+
+## 3. Risk-register updates (refinement of `knowledge.md §5`)
+
+Cross-referencing the original risk register against the audit findings:
+
+| Risk (knowledge.md §5) | Audit verdict |
+|---|---|
+| `Sbtw.mem_image_Ioo` signature surprise | **Confirmed.** Lemma returns `y ∈ lineMap x z '' Set.Ioo (0 : R) 1` (an `image`-set membership); unpacking takes `rcases ... with ⟨t, ht, rfl⟩` — exactly two `rcases` steps. Mitigation cost: ≤2 LOC. |
+| Inner-product `ring` blow-up | **Not testable from audit alone.** Bearers (`inner_add_*`, `inner_smul_*`) all present with the expected bilinearity signatures. `linear_combination` will likely close the factorization given correct expansion. |
+| Non-degeneracy extra hypotheses | **Not testable from audit alone.** `abs_real_inner_le_norm` (L453) gives the inequality; `real_inner_eq_norm_mul_iff` (≈L480-520) gives the equality case. If the latter has been renamed/restructured, fallback path: derive the strict inequality from `Real.add_pow_le_pow_mul_pow_of_sq_le_sq` (Cauchy-Schwarz alternate form) or from `Real.inner_mul_le_norm_mul_norm`. |
+| `EuclideanGeometry.angle` definition uses `arccos` | **Confirmed.** The def `EuclideanGeometry.angle` (L42) is `nonrec def` that delegates to `InnerProductGeometry.angle` (Unoriented/Basic.lean L40), which is `Real.arccos (⟪x, y⟫ / (‖x‖ * ‖y‖))`. The cosine-equality step needs: (i) `unfold EuclideanGeometry.angle`; (ii) `rw [InnerProductGeometry.cos_angle]`; (iii) `Real.arccos_inj` with explicit `[-1, 1]` bounds. |
+| Mathlib version drift | **Confirmed**, but **names stable across the drift window** (lines drift but no rename). The audit doc fixes the only file-path error: `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean`. |
+| `arccos` injectivity bounds | **Bounds derivable.** `abs_real_inner_le_norm` (L453) gives `\|⟪x, y⟫_ℝ\| ≤ ‖x‖ * ‖y‖`, which combined with `‖x‖ * ‖y‖ > 0` (from non-zeroness) gives `\|⟪x, y⟫ / (‖x‖ * ‖y‖)\| ≤ 1`, the input to `arccos_inj`. ≤6 LOC overhead. |
+
+## 4. New: Step-1 cosine-equality sketch (Path A refinement)
+
+Translating §3 Path A Step 1 into pinned-SHA-grounded Lean:
+
+```lean
+-- Inputs: hangle : ∠ B A D = ∠ D A C in EuclideanGeometry sense.
+-- u := B -ᵥ A, v := C -ᵥ A, w := D -ᵥ A.
+-- Goal: ⟪u, w⟫ / (‖u‖ · ‖w‖) = ⟪v, w⟫ / (‖v‖ · ‖w‖)
+
+-- Step 1a: rewrite EuclideanGeometry.angle in terms of InnerProductGeometry.angle.
+unfold EuclideanGeometry.angle at hangle  -- ∠ p q r := angle (p -ᵥ q) (r -ᵥ q)
+
+-- Step 1b: ‖u‖ > 0, ‖w‖ > 0 (from B ≠ A, D ≠ A); similarly ‖v‖ > 0.
+-- These are extracted from `Sbtw.ne_left` (Between.lean L341), strict-betweenness of D
+-- on BC plus the triangle non-degeneracy assumption (¬ Collinear A B C).
+
+-- Step 1c: take Real.cos of both sides via Real.arccos_inj (Inverse.lean L336).
+have h_bounds_u : ⟪u, w⟫ / (‖u‖ * ‖w‖) ∈ Set.Icc (-1 : ℝ) 1 := by
+  rw [Set.mem_Icc, abs_le_iff]; exact abs_inner_div_norm_mul_norm_le_one (B - A) (D - A)
+  -- Or: derived from `abs_real_inner_le_norm` (Basic.lean L453) + positivity.
+have h_bounds_v : ⟪v, w⟫ / (‖v‖ * ‖w‖) ∈ Set.Icc (-1 : ℝ) 1 := by
+  -- analogous
+  sorry
+-- Apply Real.cos to both sides of hangle.
+have hcos_eq : Real.cos (InnerProductGeometry.angle u w)
+             = Real.cos (InnerProductGeometry.angle v w) := by
+  rw [hangle]
+rw [InnerProductGeometry.cos_angle, InnerProductGeometry.cos_angle] at hcos_eq
+-- hcos_eq : ⟪u, w⟫ / (‖u‖ * ‖w‖) = ⟪v, w⟫ / (‖v‖ * ‖w‖)
+```
+
+Estimated 15-25 LOC for Step 1; matches the §3 budget for the cosine-conversion step.
+
+## 5. Next-Session Checklist (S2-implement)
+
+1. Create `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` with imports
+   `Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine` (also pulls in
+   `Unoriented/Basic.lean` and `InnerProductSpace/Basic.lean` transitively),
+   `Mathlib.Analysis.Convex.Between`, and `Proofs.LawOfCosinesOQ04OQ02` for the
+   downstream Stewart-chain.
+2. Use §2.2's corrected `InnerProductGeometry.*` file path
+   (`Geometry/Euclidean/Angle/Unoriented/Basic.lean`) when threading angle→cosine.
+3. Use §2.1's pinned-SHA-correct line numbers when copying `Sbtw.*` invocations.
+4. Apply §4's cosine-equality sketch verbatim for Step 1, then expand into
+   factorization (Step 2-4 of `knowledge.md §3.A`).
+5. Build via `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ02OQ01`.
+
+## 6. Audit scope notes
+
+- Audited `§4.1` (Affine/between) and `§4.2` (Angles) **exhaustively**.
+- Audited `§4.3` (Distances/norms/inner products) **most-used bearers only**;
+  `norm_smul` and `abs_of_pos`/`abs_of_nonneg` not re-grounded (standard, stable across
+  Mathlib versions).
+- Audited `§4.4` (Non-degeneracy/Cauchy-Schwarz strict) **structurally only**; the
+  `real_inner_eq_norm_mul_iff` row is the only spot-check deferred to S2 implementation.
+- `§4.5` (Stewart's theorem / parent file `LawOfCosinesOQ04OQ02.lean`) **not re-audited**;
+  this is in-project code (not Mathlib) and its presence is verified by the
+  existing 174-line `LawOfCosinesOQ04OQ02.lean` with 9 theorems, 0 sorries, 0 axioms.
+
+## 7. Cross-references
+
+- Spec: `knowledge.md` (S1 OBSERVE, researcher-8, 2026-05-11, PR #17833).
+- Parent file: `proofs/Proofs/LawOfCosinesOQ04OQ02.lean` (Stewart-form angle bisector
+  identities, 174 LOC, 9 theorems, 0 axioms).
+- Mathlib pin: `proofs/lake-manifest.json` →
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`).
+- Companion PREP pattern: `birthday-problem-oq-03-oq-01-oq-02-oq-01` S16d PREP follow-up
+  (researcher-4, 2026-05-13, doc-only Mathlib bearer audit at the same pinned SHA).

--- a/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
+++ b/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
@@ -1,10 +1,62 @@
 # State: `law-of-cosines-oq-04-oq-02-oq-01`
 
 **Tier**: B (Significance 6 / Tractability 5)
-**Phase**: OBSERVE (S1)
-**Last update**: 2026-05-11 (researcher-8)
+**Phase**: OBSERVE (S1) → PREP (S2-prep)
+**Last update**: 2026-05-13 (researcher-4) — S2-PREP Mathlib bearer audit at pinned SHA
 
-## Summary
+## Session N=2 — S2-PREP (2026-05-13, researcher-4)
+
+**Mode**: PREP (doc-only; companion to S1 OBSERVE's `knowledge.md`).
+
+**Outcome**: produced `s2-prep-bearer-audit.md` — re-grounds the S1 OBSERVE
+`knowledge.md §4` Mathlib API survey against the lake-pinned Mathlib SHA
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`). Findings:
+
+(a) **Wrong file path detected.** `InnerProductGeometry.angle` (def) and
+    `InnerProductGeometry.cos_angle` cited in `knowledge.md §4.2` as living in
+    `Mathlib/Analysis/InnerProductSpace/Basic.lean` actually live in
+    **`Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean`** (at L40 and L65).
+    A naive `gh api .../contents/<wrong-path>` lookup would have failed silently.
+
+(b) **Substantial line drift** in `Convex/Between.lean`. The cluster
+    `Sbtw.mem_image_Ioo`, `Sbtw.ne_left/left_ne/ne_right/right_ne` cited at L203-215
+    actually sits at L341-353 (+138-line drift). Names + signatures stable; only
+    line numbers moved. The S2 implementer would have been mis-guided by
+    `knowledge.md`'s line citations alone.
+
+(c) **Smaller drift** in `Geometry/Euclidean/Angle/Unoriented/Affine.lean`:
+    `angle_eq_pi_iff_sbtw` L278→L281, `angle_add_angle_eq_pi_of_angle_eq_pi` L172→L175,
+    `collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi` L376→L378. Names/sigs
+    stable.
+
+(d) **Path A Step 1 sketch added** (§4 of new doc): 15-25 LOC of cosine-equality
+    conversion using `unfold EuclideanGeometry.angle` → `rw [InnerProductGeometry.cos_angle]`
+    → `Real.arccos_inj` (Inverse.lean L336, preferred over `arccos_injOn` at L333 since
+    the two-sided iff form is cleaner given explicit `[-1, 1]` bounds).
+
+(e) **Refined risk register** (§3 of new doc): six rows of `knowledge.md §5`
+    re-graded against audit evidence. Of those, two are **confirmed** (the
+    `Sbtw.mem_image_Ioo` signature surprise + the `arccos`-injectivity bound
+    derivability), one is **promoted in priority** (the `inner_smul_left` returning
+    `r† * ⟪x, y⟫` for general `𝕜` may surface `starRingEnd ℝ` artefacts; check during S2),
+    and one is **mostly nullified** (Mathlib version drift — names stable, only line
+    numbers move, audit fixes that).
+
+**Why PREP-only this session**: S2-implement is ~250-350 LOC of new Lean (per
+`knowledge.md §8`) in a file (`LawOfCosinesOQ04OQ02OQ01.lean`) that doesn't yet exist.
+Per `CLAUDE.md`'s "never run `lake build` directly" policy, transcribing 250+ LOC
+without local verification carries non-trivial build risk. Bearer audit + cosine-equality
+sketch (15-25 LOC) de-risks the largest Mathlib-interface uncertainty BEFORE S2-implement
+starts. The remaining inner-product factorization (Steps 2-4 of `knowledge.md §3.A`)
+will benefit from the corrected file paths and line numbers.
+
+**Net diff this session**: +1 markdown file (`s2-prep-bearer-audit.md`, ~210 lines),
+state.md update, JSON cursor update. Zero Lean changes. Parent file
+`LawOfCosinesOQ04OQ02.lean` unchanged (still 174 LOC, 9 theorems, 0 axioms, 0 sorries).
+
+---
+
+## Summary (S1 OBSERVE, 2026-05-11, researcher-8)
 
 S1 OBSERVE for `law-of-cosines-oq-04-oq-02-oq-01` is complete. The OQ — deriving the
 algebraic angle-bisector identity `m · b = n · c` from a geometric premise — has been

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "law-of-cosines-oq-04-oq-02-oq-01",
   "title": "Deriving the angle-bisector identity m·b = n·c from Mathlib's Euclidean-geometry API",
-  "phase": "OBSERVE",
+  "phase": "PREP",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -27,12 +27,12 @@
     "goal": "Prove angle_bisector_ratio_from_geometry in a new file Proofs/LawOfCosinesOQ04OQ02OQ01.lean, then chain into the parent's angle_bisector_length to produce a fully-geometric angle-bisector-length formula. Zero axioms, zero sorries."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "PREP",
     "since": "2026-05-11T20:30:00Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE — hbis premise located in 3 theorems of LawOfCosinesOQ04OQ02.lean; reduced to single algebraic equation in barycentric parameter s; three approach paths surveyed; Path A (inner-product factorization) selected as S2 target.",
+    "iteration": 2,
+    "focus": "S2-PREP (researcher-4, 2026-05-13) — Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounds knowledge.md §4 against the actual pinned ref. Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65, NOT `Analysis/InnerProductSpace/Basic.lean` as knowledge.md cited (wrong file path); (b) `Sbtw.mem_image_Ioo` + 4-lemma `Sbtw.{ne,left,right}_ne` cluster drifted +138 lines (L203-215 → L341-353); (c) smaller drift in `Affine.lean` angle lemmas (+2 to +3 lines); (d) Path A Step 1 cosine-equality sketch added (~15-25 LOC). Doc-only PREP, no .lean diff. S2 OBSERVE (researcher-8, 2026-05-11, PR #17833) recommended Path A (inner-product factorization), scoped at ~250-350 lines.",
     "blockers": [],
-    "nextAction": "S2 — implement Path A: from Sbtw, extract s ∈ Ioo 0 1 with D-A = (1-s)·u + s·v; from ∠BAD = ∠DAC, derive cosine equality and factor as ((1-s)·c - s·b)·(b·c - ⟪u,v⟫) = 0; exclude the second factor via ¬ Collinear; conclude s = c/(b+c) and m·b = n·c. ~250-350 lines in new file Proofs/LawOfCosinesOQ04OQ02OQ01.lean. See knowledge.md §3.A and §8.",
+    "nextAction": "S2-implement: create `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` per `knowledge.md §8` outline. Use `s2-prep-bearer-audit.md §2.1-§2.4` for pinned-SHA-correct file paths and line numbers (especially the corrected `Geometry/Euclidean/Angle/Unoriented/Basic.lean` path for `InnerProductGeometry.angle/cos_angle`). Use §4 of audit doc for Step 1 cosine-equality sketch (~15-25 LOC). Expand into factorization (Steps 2-4 of `knowledge.md §3.A`) for total ~250-350 LOC. Build via `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ02OQ01`. Spot-checks needed during build: `real_inner_eq_norm_mul_iff` (§4.4 row not exhaustively verified) + `inner_smul_left` potential `starRingEnd ℝ` artefacts on real inner products.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete (researcher-8, 2026-05-11). The hypothesis hbis : m·b = n·c is parametric in the parent's three angle-bisector theorems. Placing the triangle in V = NormedAddCommGroup ℝ-InnerProductSpace and writing D = A + (1-s)·u + s·v (where u = B-A, v = C-A, s extracted from Sbtw.mem_image_Ioo), the goal m·b = n·c reduces to s = c/(b+c). Three derivation paths surveyed: Path A inner-product factorization yields ((1-s)·c - s·b)·(b·c - ⟪u,v⟫) = 0, with the second factor excluded by non-collinearity (strict Cauchy-Schwarz); Path B (double law-of-cosines at A) under-determines the conclusion; Path C (parallel-line construction) requires building substantial Mathlib infrastructure not currently present. Path A selected for S2 with seven-lemma outline (~250-350 lines). No Lean changes in S1 — doc-only iteration with problem.md / knowledge.md / state.md created.",
+    "progressSummary": "S2-PREP complete (researcher-4, 2026-05-13): Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounding knowledge.md §4 against the actual pinned ref. Doc `s2-prep-bearer-audit.md` (~210 LOC). Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65 — NOT `InnerProductSpace/Basic.lean` as knowledge.md cited (wrong file path; a naive contents lookup would miss them entirely); (b) `Convex/Between.lean` line drift +138 — `Sbtw.mem_image_Ioo` L215→L353, `Sbtw.{ne,left,right}_ne` cluster L203-212→L341-350; (c) smaller drift in `Affine.lean` angle lemmas (+2 to +3 lines); names + signatures stable across the drift window. Path A Step 1 cosine-equality sketch added (~15-25 LOC) using `unfold EuclideanGeometry.angle` → `rw [InnerProductGeometry.cos_angle]` → `Real.arccos_inj` (preferred over `arccos_injOn` since the two-sided iff form is cleaner). Refined risk register: `Sbtw.mem_image_Ioo` signature surprise + arccos-injectivity bound derivability are confirmed; potential `starRingEnd ℝ` artefact from `inner_smul_left` flagged for S2-build spot-check. Doc-only PREP, no .lean diff. Parent `LawOfCosinesOQ04OQ02.lean` unchanged (174 LOC, 9 theorems, 0 axioms, 0 sorries). | S1 OBSERVE complete (researcher-8, 2026-05-11). The hypothesis hbis : m·b = n·c is parametric in the parent's three angle-bisector theorems. Placing the triangle in V = NormedAddCommGroup ℝ-InnerProductSpace and writing D = A + (1-s)·u + s·v (where u = B-A, v = C-A, s extracted from Sbtw.mem_image_Ioo), the goal m·b = n·c reduces to s = c/(b+c). Three derivation paths surveyed: Path A inner-product factorization yields ((1-s)·c - s·b)·(b·c - ⟪u,v⟫) = 0, with the second factor excluded by non-collinearity (strict Cauchy-Schwarz); Path B (double law-of-cosines at A) under-determines the conclusion; Path C (parallel-line construction) requires building substantial Mathlib infrastructure not currently present. Path A selected for S2 with seven-lemma outline (~250-350 lines). No Lean changes in S1 — doc-only iteration with problem.md / knowledge.md / state.md created.",
     "builtItems": [
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/problem.md — formal statement, classification, approach menu, related-proofs table.",
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/knowledge.md — §1 target identification; §2 vector reformulation; §3 three approach paths with hand derivation for Path A; §4 Mathlib API survey (affine/between, angles, distances/norms, non-degeneracy, parent); §5 risk register; §6 sibling-proof lessons; §7 S1 outcome; §8 seven-lemma S2 outline.",
@@ -108,7 +108,7 @@
     ]
   },
   "started": "2026-05-12T03:16:39.895Z",
-  "lastUpdate": "2026-05-12T03:30:00.000Z",
+  "lastUpdate": "2026-05-13T17:50:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S2-PREP follow-up to **S1 OBSERVE** (researcher-8, 2026-05-11, PR #17833) — re-grounds `knowledge.md §4` Mathlib API survey against the lake-pinned Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) before S2-implement transcribes ~250-350 LOC of new Lean.

## Findings

(a) **Wrong file path detected.** `InnerProductGeometry.angle` (def) and `InnerProductGeometry.cos_angle` cited in `knowledge.md §4.2` as living in `Mathlib/Analysis/InnerProductSpace/Basic.lean` actually live in **`Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean`** (at L40 and L65). A naive `gh api .../contents/<wrong-path>` lookup would have silently failed.

(b) **Substantial line drift** in `Convex/Between.lean`. The cluster `Sbtw.mem_image_Ioo`, `Sbtw.{ne,left,right}_ne` cited at L203-215 actually sits at **L341-353** (+138-line drift). Names + signatures stable.

(c) **Smaller drift** in `Geometry/Euclidean/Angle/Unoriented/Affine.lean`: `angle_eq_pi_iff_sbtw` L278→L281, `angle_add_angle_eq_pi_of_angle_eq_pi` L172→L175, `collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi` L376→L378.

(d) **Path A Step 1 cosine-equality sketch added** (§4 of new doc, ~15-25 LOC): `unfold EuclideanGeometry.angle` → `rw [InnerProductGeometry.cos_angle]` → `Real.arccos_inj` (Inverse.lean L336, preferred over `arccos_injOn` at L333 since two-sided iff form is cleaner).

(e) **Refined risk register** (§3 of new doc): two `knowledge.md §5` rows confirmed (`Sbtw.mem_image_Ioo` signature surprise + arccos-injectivity bound derivability); one promoted in priority (`inner_smul_left` returning `r† * ⟪x, y⟫` may surface `starRingEnd ℝ` artefacts — flag for S2-build); one mostly nullified (Mathlib version drift — names stable across drift window).

## Coverage

| §4 sub | Audit depth |
|---|---|
| §4.1 Affine/between | Exhaustive — 10 bearers re-grounded |
| §4.2 Angles | Exhaustive — 8 bearers re-grounded + 1 file-path correction |
| §4.3 Distances/norms/inner products | Most-used bearers re-grounded (norm_smul, abs_of_pos standard/stable, not re-checked) |
| §4.4 Non-degeneracy / Cauchy-Schwarz strict | Structural only — `real_inner_eq_norm_mul_iff` row deferred to S2-build spot-check |
| §4.5 Parent file LawOfCosinesOQ04OQ02.lean | Not re-audited (in-project code, unchanged since S1 OBSERVE: 174 LOC, 9 theorems, 0 axioms, 0 sorries) |

## Scope

- **Net diff**: +1 markdown (`s2-prep-bearer-audit.md` ~210 LOC), state.md +60/-3 (new Session N=2 S2-PREP entry; Phase OBSERVE → PREP), JSON cursor: top-level `phase` OBSERVE→PREP, `currentState.{phase,iteration,focus,nextAction}` updated, `lastUpdate` refreshed, `knowledge.progressSummary` prepended.
- **Zero Lean changes**. `LawOfCosinesOQ04OQ02OQ01.lean` does not yet exist; this PREP de-risks the next session's creation of it.
- **Out of scope**:
  - S2-implement transcription of `knowledge.md §8`'s seven-lemma outline + this doc's §4 sketch into a new ~250-350 LOC `LawOfCosinesOQ04OQ02OQ01.lean` (next session).
  - S3 gallery wiring (`meta.json`, `index.ts`, optional `annotations.json`) and parent's `openQuestions` update.
  - Mathlib upstream candidate `Mathlib.Geometry.Euclidean.AngleBisector` (post-S2).

## Why doc-only PREP

S2-implement is ~250-350 LOC of new Lean in a file that doesn't yet exist. Per `CLAUDE.md`'s "never run `lake build` directly" policy, transcribing 250+ LOC without local verification carries non-trivial build risk. Bearer audit + cosine-equality sketch de-risks the largest Mathlib-interface uncertainty before S2-implement starts.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] Branch created fresh from `origin/main` (not pushed onto Birthday-S16d branch from same session)
- [x] No race: empty `gh pr list --search "law-of-cosines in:title" --state open` immediately before push
- [x] Doc-only: 0 `.lean` changes, parent `LawOfCosinesOQ04OQ02.lean` untouched
- [ ] Reviewer spot-checks one bearer citation: `gh api repos/leanprover-community/mathlib4/contents/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean?ref=2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` should show `def angle` at L40
- [ ] Next-session implementer creates `LawOfCosinesOQ04OQ02OQ01.lean` using corrected paths from §2

## Companion PREP

`birthday-problem-oq-03-oq-01-oq-02-oq-01` S16d PREP follow-up (researcher-4, same session, PR #18902) — same pinned-SHA bearer audit pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)