### PR TITLE
research(erdos-101-oq-01): S4 ACT — constructive form of three-halves refutation (build pending)

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -380,4 +380,91 @@ theorem erdos_three_halves_conjecture_refuted :
   -- `m^(3/2) < m^(2-1/2/sqrt log m)` — contradiction.
   linarith [hP_lb, hP_ub_m, h_rpow_lt]
 
+/-! ## S4 ACT: constructive refutation
+
+The S3 negated-existence refutation `erdos_three_halves_conjecture_refuted`
+proves *no global $O(n^{3/2})$ upper bound exists*. The constructive form
+below provides, for every threshold `N`, an explicit no-five-collinear
+witness `P` with `|P| ≥ N` and `|P|^{3/2} < fourPointLineCount(P)`.
+
+The two forms are mutually derivable, but the positive form is more
+useful downstream: it directly produces witnesses rather than refuting
+a hypothetical bound. Both forms depend on the same axiom-free
+deferred theorem `solymosi_stojakovic_lower_bound` (still sorry).
+
+The proof reuses the S3 chain verbatim through the `Real.rpow_lt_rpow_of_exponent_lt`
+step; the only structural change is the final assembly — instead of
+deriving a contradiction from a hypothetical upper bound, we deliver
+the witness directly.
+
+Sorry count: unchanged (still 2: `erdos_101_oq_01` and
+`solymosi_stojakovic_lower_bound`). Axiom count: unchanged (still 0).
+Theorem count: +1 (`erdos_three_halves_conjecture_refuted_constructive`). -/
+
+/-- **Constructive refutation of Erdős's $\Theta(n^{3/2})$ conjecture.**
+
+For every threshold `N`, there exists a no-five-collinear planar point
+set `P` with `|P| ≥ N` and *strictly more* than $|P|^{3/2}$ four-point
+lines. This is the positive form of the S3 negated-existence
+refutation `erdos_three_halves_conjecture_refuted`.
+
+The proof specializes `solymosi_stojakovic_lower_bound` to `C = 1/2`
+and uses the same `m ≥ 3 ⟹ log m > 1 ⟹ sqrt(log m) > 1 ⟹
+(1/2)/sqrt(log m) < 1/2 ⟹ 2 - (1/2)/sqrt(log m) > 3/2` chain as S3,
+then applies the strict monotonicity of `Real.rpow` in the exponent
+for base `> 1`.
+
+Sorry-free; axiom-free; depends only on the S2-recorded
+`solymosi_stojakovic_lower_bound` (which itself remains a deferred
+proof obligation, `theorem ... := by sorry`). -/
+theorem erdos_three_halves_conjecture_refuted_constructive :
+    ∀ N : ℕ, ∃ P : PlanarPointSet, NoFiveCollinear P ∧ N ≤ P.points.card ∧
+      (P.points.card : ℝ) ^ (3 / 2 : ℝ) < (fourPointLineCount P : ℝ) := by
+  intro N
+  -- Apply the Solymosi–Stojaković lower bound with `C = 1/2`.
+  obtain ⟨N₁, hN₁⟩ :=
+    solymosi_stojakovic_lower_bound (1 / 2 : ℝ) (by norm_num)
+  -- Pick a single `m` that simultaneously beats `N`, `N₁`, and `3`.
+  set m : ℕ := max N (max N₁ 3) with hm_def
+  have hm_N : N ≤ m := le_max_left _ _
+  have hm_N₁ : N₁ ≤ m :=
+    (le_max_left N₁ 3).trans (le_max_right _ _)
+  have hm_three : (3 : ℕ) ≤ m :=
+    (le_max_right N₁ 3).trans (le_max_right _ _)
+  -- Solymosi–Stojaković witness at size `m`.
+  obtain ⟨P, hcard, hP_no5, hP_lb⟩ := hN₁ m hm_N₁
+  refine ⟨P, hP_no5, hcard.symm ▸ hm_N, ?_⟩
+  -- Real coercions for `m`.
+  have hm_real_ge_three : (3 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm_three
+  have hm_gt_one : (1 : ℝ) < (m : ℝ) := by linarith
+  -- `Real.log m > 1` since `m ≥ 3 > exp 1`.
+  have h_exp_lt_three : Real.exp 1 < (3 : ℝ) := by
+    linarith [Real.exp_one_lt_d9]
+  have h_exp_lt_m : Real.exp 1 < (m : ℝ) := by linarith
+  have hlog_gt_one : (1 : ℝ) < Real.log (m : ℝ) := by
+    have h := Real.log_lt_log (Real.exp_pos 1) h_exp_lt_m
+    rwa [Real.log_exp] at h
+  -- `Real.sqrt (Real.log m) > 1`.
+  have hsqrt_gt_one : (1 : ℝ) < Real.sqrt (Real.log (m : ℝ)) := by
+    have h := Real.sqrt_lt_sqrt (by norm_num : (0 : ℝ) ≤ 1) hlog_gt_one
+    rwa [Real.sqrt_one] at h
+  have hsqrt_pos : (0 : ℝ) < Real.sqrt (Real.log (m : ℝ)) := by linarith
+  -- `(1/2) / sqrt (log m) < 1/2` and hence `2 - … > 3/2`.
+  have h_frac_lt_half :
+      (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) < 1 / 2 := by
+    rw [div_lt_iff hsqrt_pos]
+    nlinarith [hsqrt_gt_one]
+  have h_exp_gt :
+      (3 / 2 : ℝ) < 2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) := by
+    linarith
+  -- Strict monotonicity of `Real.rpow` in the exponent (base `> 1`).
+  have h_rpow_lt :
+      (m : ℝ) ^ (3 / 2 : ℝ) <
+        (m : ℝ) ^ (2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ))) :=
+    Real.rpow_lt_rpow_of_exponent_lt hm_gt_one h_exp_gt
+  -- Goal: `(P.points.card : ℝ) ^ (3/2) < (fourPointLineCount P : ℝ)`.
+  -- Rewrite `P.points.card` as `m` and chain through `h_rpow_lt` + `hP_lb`.
+  rw [hcard]
+  linarith [hP_lb, h_rpow_lt]
+
 end Erdos101OQ01

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,11 +1,24 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S3)
-**Iteration**: 3
-**Last Updated**: 2026-05-12 (researcher-5)
+**Since**: 2026-05-13 (S4)
+**Iteration**: 4
+**Last Updated**: 2026-05-13 (researcher-1)
 
 ## Current Focus
+
+S4 (researcher-1) extends S3's negated-existence refutation
+`erdos_three_halves_conjecture_refuted` to its positive constructive
+form `erdos_three_halves_conjecture_refuted_constructive`: for every
+threshold `N`, an explicit no-five-collinear witness `P` with
+`|P| ≥ N` and `|P|^{3/2} < fourPointLineCount P`. The proof reuses
+S3's chain verbatim through the `Real.rpow_lt_rpow_of_exponent_lt`
+step; only the final assembly differs (witness delivery vs.
+contradiction). Sorries unchanged at 2 (main conjecture +
+`solymosi_stojakovic_lower_bound`); axioms unchanged at 0; theorems
+8 → 9. File grows 383 → 470 LOC (+87).
+
+## Previous Focus
 
 S3 (researcher-5) discharges `erdos_three_halves_conjecture_refuted`
 from S2's `solymosi_stojakovic_lower_bound` by elementary real-analysis
@@ -34,57 +47,59 @@ free.
 
 ## Next Action
 
-S4 candidates (in order of expected value):
+S5 candidates (in order of expected value):
 
-1. **`Asymptotics.IsBigO` / `IsLittleO` bridge.** Define
-   `maxFourPointLines : ℕ → ℕ` via `Finset.sup'` or `Set.Sup` over the
-   (finite-by-Mathlib-decidable-equality) set of no-five-collinear
-   sets of fixed size at most `n`.  Convert
-   `fourPointLineCount_le_quadratic` into a `Asymptotics.IsBigO ⟨atTop⟩`
-   statement against `n^2`, and record the OPEN conjecture as the
-   `Asymptotics.IsLittleO` form `sorry`.  Bridge to the existing
-   `IsLittleOh_n_squared` definition by direct unfolding.
+1. **`Asymptotics.IsBigO` / `IsLittleO` bridge** (S4-candidate-1
+   carried forward). Define `maxFourPointLines : ℕ → ℕ` via
+   `Finset.sup'` or `Set.Sup` over the (finite-by-Mathlib-decidable-
+   equality) set of no-five-collinear sets of fixed size at most `n`.
+   Convert `fourPointLineCount_le_quadratic` into a
+   `Asymptotics.IsBigO ⟨atTop⟩` statement against `n^2`, and record
+   the OPEN conjecture as the `Asymptotics.IsLittleO` form `sorry`.
+   Bridge to the existing `IsLittleOh_n_squared` definition by direct
+   unfolding.
 
-2. **Refute Erdős's $\Theta(n^{3/2})$ via `Real.rpow` lower-bound
-   formalisation**: extend the S3 refutation to a positive
-   strict-inequality statement `∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P|
-   ∧ (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)`.
-   This is the "constructive" (rather than negated-existence) form of
-   the same fact and is a one-step rephrasing of the S3 proof.
-
-3. **Cauchy–Schwarz refinement** of `fourCollinearThrough_bound`
+2. **Cauchy–Schwarz refinement** of `fourCollinearThrough_bound`
    $\leq (n-1)/3$ to potentially yield a $1 - o(1)$ leading constant
    on the elementary $n^2/12$ bound (not $o(n^2)$, but a real
    improvement on the constant).
 
+3. **Witness extraction at fixed `n`**: pin down what
+   `fourPointLineCount` is for small no-five-collinear sets via
+   `decide` on the underlying finite combinatorics — would supply
+   `native_decide`-certified examples for the gallery entry.
+
 ## Attempt Counts
 
-- Total attempts: 3
-- Current approach attempts: 1 (S3 discharge of refutation corollary)
-- Approaches tried: 2 (S1 scaffold + S2 lower-bound recording;
-  S3 elementary real-analysis discharge)
+- Total attempts: 4
+- Current approach attempts: 1 (S4 constructive refutation, this iteration)
+- Approaches tried: 3 (S1 scaffold + S2 lower-bound recording;
+  S3 elementary real-analysis discharge; S4 constructive rephrasing
+  of S3 chain)
 
 ## Build Status
 
-S3 build: **PENDING** (Docker not available in worktree;
-`proofs/.lake` is a self-symlink and CI is ground truth).  S3
-introduces *no new imports* — all required Mathlib API
+S4 build: **PENDING** (Docker not available in worktree;
+`proofs/.lake` is a self-symlink and CI is ground truth). S4 introduces
+*no new imports* — the same Mathlib API as S3 is used
 (`Real.exp_one_lt_d9`, `Real.exp_pos`, `Real.log_exp`,
 `Real.log_lt_log`, `Real.sqrt_one`, `Real.sqrt_lt_sqrt`,
-`Real.rpow_lt_rpow_of_exponent_lt`, `div_lt_iff`) is already in
-the S2 import set and is exercised by other gallery files
-(see e.g. `Erdos1039Problem.lean`, `Erdos1201Problem.lean`,
-`BinomialTheoremOQ03OQ02OQ03.lean`).
+`Real.rpow_lt_rpow_of_exponent_lt`, `div_lt_iff`).
 
-S3 risk profile:
-* One discharge, no new theorem statements — the existing
-  `erdos_three_halves_conjecture_refuted` is unchanged.
-* The proof uses only well-established Mathlib API.
-* The single tricky cast is `(m : ℕ) → (m : ℝ)`: handled by
-  `exact_mod_cast hm_three : (3 : ℝ) ≤ (m : ℝ)`.
+S4 risk profile:
+* One new theorem statement
+  (`erdos_three_halves_conjecture_refuted_constructive`); no edits
+  to S3's `erdos_three_halves_conjecture_refuted`.
+* The proof is structurally a copy of S3 through the
+  `Real.rpow_lt_rpow_of_exponent_lt` step; only the final assembly
+  changes from `linarith [hP_lb, hP_ub_m, h_rpow_lt]` (contradiction)
+  to `linarith [hP_lb, h_rpow_lt]` (chain `m^(3/2) < m^(2-...) ≤ count`).
+* `hcard.symm ▸ hm_N` provides the `N ≤ P.points.card` part of the
+  triple after destructuring; `rw [hcard]` rewrites `P.points.card`
+  to `m` in the final inequality.
 
 ## Blockers
 
-None for S3.  The remaining OPEN content is the main conjecture
+None for S4.  The remaining OPEN content is the main conjecture
 `erdos_101_oq_01` (a $\$100$ Erdős prize) and the SS construction
 itself (algebraic geometry over finite fields, deferred).

--- a/src/data/research/problems/erdos-101-oq-01.json
+++ b/src/data/research/problems/erdos-101-oq-01.json
@@ -34,19 +34,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T05:00:00Z",
-    "iteration": 3,
-    "focus": "S3: discharged S2's corollary `erdos_three_halves_conjecture_refuted` from the Solymosi–Stojaković lower bound via elementary real-analysis arithmetic. Sorry count drops 3 → 2. Specialise $C = 1/2$, use `Real.exp_one_lt_d9` to obtain $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`.",
+    "since": "2026-05-13T18:00:00.000Z",
+    "iteration": 4,
+    "focus": "S4 (researcher-1, 2026-05-13): extended S3 negated-existence refutation to its positive constructive form. New theorem erdos_three_halves_conjecture_refuted_constructive : ∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ (|P| : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ) — for every threshold N, an explicit no-five-collinear witness with |P| ≥ N and strictly more than |P|^(3/2) four-point lines. Proof reuses S3 chain (Real.exp_one_lt_d9 + Real.log_lt_log + Real.sqrt_lt_sqrt + Real.rpow_lt_rpow_of_exponent_lt) verbatim through h_rpow_lt; only the final assembly differs (witness delivery via refine + rw [hcard] + linarith [hP_lb, h_rpow_lt] instead of contradiction). Sorries unchanged at 2 (main conjecture + solymosi_stojakovic_lower_bound); axioms unchanged at 0; theorems 8 → 9. Lean file 383 → 470 LOC (+87).",
     "blockers": [],
-    "nextAction": "S4 candidates: (1) `Asymptotics.IsBigO`/`IsLittleO` bridge — define `maxFourPointLines : ℕ → ℕ`, convert `fourPointLineCount_le_quadratic` to a `Filter.IsBigO atTop` statement; (2) positive (constructive) form of the refutation as `∀ N, ∃ P, … (P.points.card : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ)`; (3) Cauchy–Schwarz refinement of `fourCollinearThrough_bound` for a $1 - o(1)$ leading constant on the $n^2/12$ elementary bound.",
+    "nextAction": "S5 candidates: (1) Asymptotics.IsBigO/IsLittleO bridge — define maxFourPointLines : ℕ → ℕ, convert fourPointLineCount_le_quadratic to Filter.IsBigO atTop statement; (2) Cauchy–Schwarz refinement of fourCollinearThrough_bound for a 1 - o(1) leading constant on the n^2/12 elementary bound; (3) witness extraction at fixed n via decide on small finite combinatorics for native_decide-certified gallery examples. Main conjecture erdos_101_oq_01 ($100 Erdős prize) and solymosi_stojakovic_lower_bound remain OPEN/deferred.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-3, 2026-05-11) — OBSERVE: formal Σ₂ statement recorded, 5 supporting theorems proved unconditionally, 1 sorry on the main conjecture. S2 (researcher-1, 2026-05-12) — ACT: Solymosi–Stojaković 2013 existential lower bound recorded as `theorem solymosi_stojakovic_lower_bound := by sorry`, plus the corollary `erdos_three_halves_conjecture_refuted` (also sorry). No new axioms. S3 (researcher-5, 2026-05-12) — ACT: discharged `erdos_three_halves_conjecture_refuted` from S2's lower bound via elementary real-analysis arithmetic (50-line proof, no new theorems, no new definitions, no new imports). File grows 325 → 383 lines; sorries 3 → 2; axioms unchanged at 0; theorems unchanged at 8.",
+    "progressSummary": "S4 (researcher-1, 2026-05-13): constructive refutation of Erdős three-halves conjecture landed. New theorem erdos_three_halves_conjecture_refuted_constructive : ∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ |P|^(3/2) < fourPointLineCount P — the positive form of S3 negated-existence refutation. Reuses S3 chain (specialise SS lower bound to C = 1/2, exp 1 < 3 ⟹ log m > 1 ⟹ sqrt log m > 1 ⟹ (1/2)/sqrt log m < 1/2 ⟹ 2-(...)>3/2 ⟹ m^(3/2) < m^(2-...) ≤ count) verbatim through h_rpow_lt; final assembly via refine + rw + linarith. Sorries 2 (unchanged: erdos_101_oq_01 + solymosi_stojakovic_lower_bound), axioms 0 (unchanged), theorems 8 → 9. File 383 → 470 LOC. Build pending (.lake symlink trap). S3 (researcher-5, 2026-05-12): discharged erdos_three_halves_conjecture_refuted via elementary real-analysis arithmetic; 50-line proof; sorries 3 → 2. S2 (researcher-1, 2026-05-12): recorded Solymosi–Stojaković 2013 existential lower bound as theorem ... := by sorry plus corollary erdos_three_halves_conjecture_refuted (also sorry). S1 (researcher-3, 2026-05-11): OBSERVE — formal Σ₂ statement, 5 supporting theorems proved unconditionally.",
     "builtItems": [
       "proofs/Proofs/Erdos101OQ01.lean: IsLittleOh_n_squared (def)",
       "proofs/Proofs/Erdos101OQ01.lean: BoundsAtRate (def)",
@@ -61,14 +61,16 @@
       "src/data/proofs/erdos-101-oq-01/: gallery entry (meta + 6 annotations + index.ts)",
       "research/problems/erdos-101-oq-01/: problem.md + knowledge.md + state.md",
       "proofs/Proofs/Erdos101OQ01.lean: solymosi_stojakovic_lower_bound (theorem stub, S2, sorry — construction deferred)",
-      "proofs/Proofs/Erdos101OQ01.lean: erdos_three_halves_conjecture_refuted (theorem, S3, fully discharged from SS bound via real-analysis arithmetic)"
+      "proofs/Proofs/Erdos101OQ01.lean: erdos_three_halves_conjecture_refuted (theorem, S3, fully discharged from SS bound via real-analysis arithmetic)",
+      "proofs/Proofs/Erdos101OQ01.lean — erdos_three_halves_conjecture_refuted_constructive : ∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ (|P| : ℝ)^(3/2) < (fourPointLineCount P : ℝ) — positive constructive form of S3 refutation (S4 ACT, ~50 LOC, 0 sorries, 0 axioms)"
     ],
     "insights": [
       "The OQ-01 question is the precise quantitative refinement of the trivial $O(n^2)$ upper bound; the $\\Theta(n^2)$ regime is already established elementarily.",
       "Two equivalent formal forms (ε–N primary; rate-witness via $\\exists g$) are mutually convertible by the standard Cauchy criterion; we record both.",
       "Solymosi–Stojaković (2013) refuted Erdős's $\\Theta(n^{3/2})$ conjecture with $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ — the open content is the polylog correction, not the leading order.",
       "All known elementary upper bounds are $\\Theta(n^2)$; closing the gap to $o(n^2)$ requires either a multiplicity-aware Szemerédi–Trotter refinement or a non-incidence argument.",
-      "The ℕ→ℝ cast in `bounds_at_rate_quadratic_over_twelve` weakens $n(n-1)/12$ to $n^2/12$ to avoid `Nat.sub` truncation; asymptotically equivalent."
+      "The ℕ→ℝ cast in `bounds_at_rate_quadratic_over_twelve` weakens $n(n-1)/12$ to $n^2/12$ to avoid `Nat.sub` truncation; asymptotically equivalent.",
+      "S4 (researcher-1, 2026-05-13): the negated-existence form (S3) and positive constructive form (S4) of the three-halves refutation are interconvertible by simple boolean rephrasing, but the constructive form is more useful downstream — it directly supplies witnesses rather than refuting a hypothetical bound. Both depend on the same axiom-free deferred theorem solymosi_stojakovic_lower_bound (still sorry). The S3 chain is reusable across both forms: chain S3 through Real.rpow_lt_rpow_of_exponent_lt, then choose between contradiction (S3) vs. refine+linarith (S4) at the final assembly step."
     ],
     "mathlibGaps": [
       "No direct Σ₂-style $o(n^2)$ uniform-bound vocabulary; we use an explicit ε–N form. Bridge to `Asymptotics.IsLittleO` deferred to S3.",


### PR DESCRIPTION
## Summary

S4 ACT iteration on `erdos-101-oq-01`. Extends S3's negated-existence
refutation `erdos_three_halves_conjecture_refuted` (PR #18737) to its
positive constructive form:

```lean
theorem erdos_three_halves_conjecture_refuted_constructive :
    ∀ N : ℕ, ∃ P : PlanarPointSet, NoFiveCollinear P ∧ N ≤ P.points.card ∧
      (P.points.card : ℝ) ^ (3 / 2 : ℝ) < (fourPointLineCount P : ℝ)
```

For every threshold `N`, an explicit no-five-collinear witness `P` with
`|P| ≥ N` and strictly more than `|P|^(3/2)` four-point lines.

This was S4-candidate-2 in state.md: *"extend the S3 refutation to a
positive strict-inequality statement … This is the 'constructive' (rather
than negated-existence) form of the same fact and is a one-step
rephrasing of the S3 proof."*

## Proof structure

Reuses S3's chain verbatim through the
`Real.rpow_lt_rpow_of_exponent_lt` step:

1. Specialize `solymosi_stojakovic_lower_bound` to `C = 1/2`.
2. Pick `m := max N (max N₁ 3)` (witness threshold ≥ N₁ and ≥ 3).
3. Extract SS witness `P` at size `m`.
4. Chain via `Real.exp_one_lt_d9 + Real.log_lt_log + Real.sqrt_lt_sqrt`:
   `m ≥ 3 > exp 1 ⟹ log m > 1 ⟹ sqrt(log m) > 1 ⟹ (1/2)/sqrt(log m) < 1/2 ⟹ 2 - (...) > 3/2`.
5. Apply `Real.rpow_lt_rpow_of_exponent_lt` for base `m > 1` to get
   `m^(3/2) < m^(2 - (1/2)/sqrt(log m))`.
6. Deliver witness via `refine ⟨P, hP_no5, hcard.symm ▸ hm_N, ?_⟩`
   then `rw [hcard]` and `linarith [hP_lb, h_rpow_lt]` to chain
   `m^(3/2) < m^(2-...) ≤ fourPointLineCount P`.

Identical Mathlib API as S3; no new imports.

## Counts

- `lineCount`: 383 → 470 (+87)
- `theoremCount`: 8 → 9 (added
  `erdos_three_halves_conjecture_refuted_constructive`)
- `sorryCount`: 2 (unchanged — main conjecture `erdos_101_oq_01`
  + deferred `solymosi_stojakovic_lower_bound`)
- `axiomCount`: 0 (unchanged)

## Files modified

- `proofs/Proofs/Erdos101OQ01.lean` +87 LOC.
- `research/problems/erdos-101-oq-01/state.md`: Phase iter 3 → 4,
  Current Focus updated to S4, S3 demoted to Previous Focus, Next
  Action refreshed (S4 candidate #2 resolved; S5 candidates listed).
- `src/data/research/problems/erdos-101-oq-01.json`: currentState
  + knowledge refresh.

## Build status

**Build pending.** Researcher worktree `.lake` symlink-loop blocker.
Proof structurally mirrors S3 line-by-line through the rpow strict-
monotonicity step; algebraic correctness verified by hand. Doctor or
auditor should verify from a clean worktree.

## Honest assessment

This is a one-step rephrasing of S3, not a new mathematical insight.
The value is downstream usability: positive existential witnesses
plug directly into other lemmas that quantify over no-five-collinear
sets, whereas negated-existence statements require contradiction
patterns. Both forms still depend on the same deferred
`solymosi_stojakovic_lower_bound` (which records the algebraic-
geometry-over-finite-fields construction as a deferred proof
obligation, not an axiom).

The main conjecture `erdos_101_oq_01` ($100 Erdős prize) remains
OPEN and is not advanced here.

🤖 Generated by researcher-1
