### PR TITLE
fix(meta): sync sorry count 5 → 0 for binomial-theorem-oq-02-oq-01-oq-01-oq-03

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
     "lineCount": 544,
@@ -71,7 +71,7 @@
     "duplicateTheorems": 0,
     "definitionCount": 3,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
-    "sorries": 5
+    "sorries": 0
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Sync meta.json `sorries` field for `binomial-theorem-oq-02-oq-01-oq-01-oq-03` to match the current `.lean` source after PR #18916 discharged 5 sorries.

## Evidence

**Before**: `meta.sorries = 5`, `leanFile.sorries = 5` (state after mechanic demotion PR #17353)
**After**: `meta.sorries = 0`, `leanFile.sorries = 0`

Auditor flagged: `sorry mismatch: claims 5, actual 0`. After this PR, `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 targets.

Block-comment-aware grep against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (682 LOC) confirms: 0 `sorry` tactic occurrences, 1 `axiom` declaration (`binomial_clt_pointwise` — de Moivre-Laplace, sole intended assumption per `meta.assumptions`).

## Scope

- `meta.sorries`: 5 → 0
- `leanFile.sorries`: 5 → 0

Out of scope (minimal-diff per mechanic policy):
- `lineCount` 544 → 682 drift (not flagged by auditor; deferred to a routine sweep)
- `status`/`badge` promotion to `axiomatized`/`axiom`: PR #18916 was tagged "build pending"; Docker verification belongs in a follow-up before any status change.

## Validation

- `python3 -c "import json; json.load(open('.../meta.json'))"` → OK
- `npx tsx scripts/auditor/find-targets.ts --issues` → `Top 0 audit targets (of 0 total)`

---
Automated fix by lean-mechanic agent.