### PR TITLE
research(knights-tour-oblique-oq-02): S3 ACT — D4 level-set invariance + orbit framework (build pending)

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ02.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02.lean
@@ -209,4 +209,132 @@ theorem obliqueDistribution_sum_Icc_eq_card :
     · exact obliqueDistribution_zero_below_four k hlt
     · exact obliqueDistribution_zero_above_64 k h
 
+/-!
+## Section: D4 action on level sets (S3 ACT)
+
+The parent file provides `oblique_count_invariant`: `obliqueCount` is
+preserved pointwise under every D4 transformation. This section lifts
+that pointwise invariance to the **level sets** of `obliqueDistribution`:
+for any `k` and any `g : Bool × Fin 4`, the endomap `applyD4Tour g`
+restricts to a bijection of `levelSet k` onto itself.
+
+Combined with the orbit-size bound `d4Orbit_card_le_eight` (below), this
+is the infrastructure for the mod-8 orbit-decomposition picture: in the
+absence of self-symmetric tours, `8 ∣ obliqueDistribution k`. Classifying
+self-symmetric tours at each level is deferred to S4.
+
+No new axioms are introduced in this section; every result reduces to
+the parent's public surface (`applyD4Tour`, `applyD4Tour_inv_left`,
+`oblique_count_invariant`, `closedTour_eq_iff`).
+-/
+
+/-- `Finset.image` over a `ClosedTour`-valued function requires
+    `DecidableEq ClosedTour`. The classical instance is consistent with
+    the existing `noncomputable instance : Fintype ClosedTour`, which
+    already opted into `Classical.choice`. -/
+noncomputable instance : DecidableEq ClosedTour := Classical.decEq _
+
+/-- The level set of `obliqueCount` at value `k`: closed tours with
+    exactly `k` oblique turns. Definitionally equal to the underlying
+    filter used in `obliqueDistribution`. -/
+noncomputable def levelSet (k : ℕ) : Finset ClosedTour :=
+  Finset.univ.filter (fun t => obliqueCount t = k)
+
+/-- Reformulation of the histogram in terms of the level set: a direct
+    cardinality identity (true by `rfl`). -/
+theorem obliqueDistribution_eq_levelSet_card (k : ℕ) :
+    obliqueDistribution k = (levelSet k).card := rfl
+
+/-- `applyD4Tour g` is injective on `ClosedTour`: the parent's
+    `applyD4Tour_inv_left` exhibits `applyD4Tour (d4Inv g)` as a left
+    inverse, so any function with a left inverse is injective. -/
+theorem applyD4Tour_injective (g : Bool × Fin 4) :
+    Function.Injective (applyD4Tour g) := by
+  intro t1 t2 h
+  have e1 := applyD4Tour_inv_left g t1
+  have e2 := applyD4Tour_inv_left g t2
+  rw [h] at e1
+  exact e1.symm.trans e2
+
+/-- Closure of the level set under D4: applying `applyD4Tour g` to a
+    tour in `levelSet k` keeps the oblique count at `k`, so the image
+    lies in the same level set (parent's `oblique_count_invariant`). -/
+theorem levelSet_image_applyD4Tour_subset (g : Bool × Fin 4) (k : ℕ) :
+    (levelSet k).image (applyD4Tour g) ⊆ levelSet k := by
+  intro u hu
+  simp only [Finset.mem_image, levelSet, Finset.mem_filter, Finset.mem_univ,
+    true_and] at hu ⊢
+  obtain ⟨t, htk, hgu⟩ := hu
+  rw [← hgu, oblique_count_invariant]
+  exact htk
+
+/-- The image of the level set under `applyD4Tour g` has the same
+    cardinality as the level set itself (injectivity). -/
+theorem levelSet_image_applyD4Tour_card (g : Bool × Fin 4) (k : ℕ) :
+    ((levelSet k).image (applyD4Tour g)).card = (levelSet k).card :=
+  Finset.card_image_of_injective _ (applyD4Tour_injective g)
+
+/-- **Level-set invariance** (headline S3 result): every D4 element
+    `g` induces a bijection of `levelSet k` onto itself. Image equality
+    follows from closure (subset) + cardinality preservation
+    (injectivity) + finiteness, via `Finset.eq_of_subset_of_card_le`. -/
+theorem levelSet_image_applyD4Tour_eq (g : Bool × Fin 4) (k : ℕ) :
+    (levelSet k).image (applyD4Tour g) = levelSet k := by
+  apply Finset.eq_of_subset_of_card_le (levelSet_image_applyD4Tour_subset g k)
+  rw [levelSet_image_applyD4Tour_card]
+
+/-!
+## Section: D4 orbits
+
+The 8-element D4 group acts on `ClosedTour` via `applyD4Tour`. Each tour
+`t` generates a D4-orbit `d4Orbit t : Finset ClosedTour` of size at most
+`|D4| = 8`, with equality iff the D4-stabilizer of `t` is trivial (i.e.,
+`t` is not self-symmetric). By the level-set invariance above, the orbit
+of `t` is contained in `levelSet (obliqueCount t)`.
+
+Downstream (S4): partition `levelSet k` into D4 orbits, classify
+orbit-size divisors of 8, and conclude `obliqueDistribution k ≡ s_k (mod 8)`
+where `s_k` is the count of self-symmetric tours with oblique count `k`. -/
+
+/-- The D4 orbit of a tour: image of the 8-element finset
+    `Finset.univ : Finset (Bool × Fin 4)` under `applyD4Tour · t`. -/
+noncomputable def d4Orbit (t : ClosedTour) : Finset ClosedTour :=
+  (Finset.univ : Finset (Bool × Fin 4)).image (fun g => applyD4Tour g t)
+
+/-- A D4 orbit has at most `|D4| = 8` elements (the bound is achieved
+    iff the tour's D4-stabilizer is trivial). -/
+theorem d4Orbit_card_le_eight (t : ClosedTour) : (d4Orbit t).card ≤ 8 := by
+  unfold d4Orbit
+  refine le_trans (Finset.card_image_le) ?_
+  simp [Fintype.card_prod, Fintype.card_bool, Fintype.card_fin]
+
+/-- Every D4 orbit is contained in the level set at its common oblique
+    count: `oblique_count_invariant` forces every element of `d4Orbit t`
+    to share `obliqueCount t`. -/
+theorem d4Orbit_subset_levelSet (t : ClosedTour) :
+    d4Orbit t ⊆ levelSet (obliqueCount t) := by
+  intro u hu
+  unfold d4Orbit at hu
+  simp only [Finset.mem_image, Finset.mem_univ, true_and] at hu
+  obtain ⟨g, hgu⟩ := hu
+  simp only [levelSet, Finset.mem_filter, Finset.mem_univ, true_and]
+  rw [← hgu, oblique_count_invariant]
+
+/-- The identity element of D4 maps a tour to itself: `(false, 0)`
+    encodes no reflection (`false`) and zero rotations (`0`), and acts
+    as the identity on every `Square`. -/
+theorem applyD4Tour_id (t : ClosedTour) : applyD4Tour (false, 0) t = t := by
+  rw [closedTour_eq_iff]
+  show t.squares.map (applyD4 (false, 0)) = t.squares
+  have h : (applyD4 (false, 0) : Square → Square) = id := by
+    funext s; rfl
+  rw [h, List.map_id]
+
+/-- Every tour lies in its own D4 orbit (witness: the identity
+    `(false, 0)` paired with `applyD4Tour_id`). -/
+theorem tour_mem_d4Orbit_self (t : ClosedTour) : t ∈ d4Orbit t := by
+  unfold d4Orbit
+  simp only [Finset.mem_image, Finset.mem_univ, true_and]
+  exact ⟨(false, 0), applyD4Tour_id t⟩
+
 end KnightsTourOblique

--- a/research/problems/knights-tour-oblique-oq-02/state.md
+++ b/research/problems/knights-tour-oblique-oq-02/state.md
@@ -1,9 +1,9 @@
 # Current State
 
-**Phase**: ORIENT (S3-prep — support upper bound + histogram normalization)
-**Since**: 2026-05-12T13:30:00Z
-**Last Updated**: 2026-05-12 (Iteration 3, researcher-5)
-**Iteration**: 3
+**Phase**: ACT (S3 — D4 level-set invariance + orbit framework)
+**Since**: 2026-05-13T18:30:00Z
+**Last Updated**: 2026-05-13 (Iteration 4, researcher-5)
+**Iteration**: 4
 
 ## Iteration 2 (researcher-8, 2026-05-12) — S2 ORIENT / ACT
 
@@ -182,3 +182,137 @@ strictly out of scope for the OQ02 distribution work.
 Parent `Proofs/KnightsTourOblique.lean` is broken on origin/main —
 needs a separate mechanic-driven Mathlib-drift fix PR. Not a blocker for
 this iteration (matches S1/S2 precedent).
+
+## Iteration 4 (researcher-5, 2026-05-13) — S3 ACT
+
+**Outcome**: built — extended `proofs/Proofs/KnightsTourObliqueOQ02.lean`
+with the D4 level-set invariance result (Target C, headline S3
+deliverable) and a small D4-orbit framework. The file grew from 212 →
+340 lines (+128 LOC). Still **0 sorries, 0 new axioms**.
+
+### What I added
+
+**Level-set machinery (Target C, headline result):**
+
+- `instance : DecidableEq ClosedTour` — `Classical.decEq _` to enable
+  `Finset.image` operations on `ClosedTour`-valued maps. Consistent with
+  the existing `noncomputable instance : Fintype ClosedTour`, which
+  already opted into `Classical.choice`.
+- `def levelSet (k : ℕ) : Finset ClosedTour` —
+  `Finset.univ.filter (obliqueCount · = k)`.
+- `theorem obliqueDistribution_eq_levelSet_card` — `rfl`-level identity
+  reformulating the histogram.
+- `theorem applyD4Tour_injective` — from the parent's
+  `applyD4Tour_inv_left` (left inverse → injective).
+- `theorem levelSet_image_applyD4Tour_subset` — closure of `levelSet k`
+  under `applyD4Tour g` (parent's `oblique_count_invariant`).
+- `theorem levelSet_image_applyD4Tour_card` —
+  `Finset.card_image_of_injective`.
+- `theorem levelSet_image_applyD4Tour_eq` — **the headline**: image
+  equality, via `Finset.eq_of_subset_of_card_le` on (subset + injective).
+
+**D4 orbit framework:**
+
+- `def d4Orbit (t : ClosedTour) : Finset ClosedTour` — image of
+  `Finset.univ : Finset (Bool × Fin 4)` under `applyD4Tour · t`.
+- `theorem d4Orbit_card_le_eight` — `Finset.card_image_le` chained with
+  `Fintype.card_prod, Fintype.card_bool, Fintype.card_fin`.
+- `theorem d4Orbit_subset_levelSet` — orbit ⊆ level set at common
+  oblique count.
+- `theorem applyD4Tour_id` — `(false, 0)` (no reflection, zero rotations)
+  acts as the identity; under `applyD4` the `if`-branch picks `s` and
+  `rotateSquareN 0 s = s` by `rfl`, leaving the underlying list
+  unchanged.
+- `theorem tour_mem_d4Orbit_self` — every tour lies in its own orbit
+  (witness `(false, 0)`).
+
+### Why these pieces, in this order
+
+The plan in S1/S2/S3-prep flagged D4-invariance of the histogram level
+sets as the central S3 deliverable for mod-8 orbit decomposition. The
+parent file already proves `obliqueCount` invariance pointwise
+(`oblique_count_invariant : obliqueCount (applyD4Tour g t) = obliqueCount t`)
+and provides the action (`applyD4Tour`) and its left inverse
+(`applyD4Tour_inv_left`).
+
+Lifting pointwise invariance to **finsets** (the level sets) requires
+three ingredients:
+
+1. **Closure** of the level set under `applyD4Tour g` — direct
+   consequence of `oblique_count_invariant`.
+2. **Cardinality preservation** — from `applyD4Tour_injective` (derived
+   here from `applyD4Tour_inv_left` via the standard "left inverse →
+   injective" argument), then `Finset.card_image_of_injective`.
+3. **Image equality** — closure + cardinality preservation +
+   `Finset.eq_of_subset_of_card_le` on a finite set: a strictly smaller
+   image would contradict cardinality preservation.
+
+With image equality in hand, `applyD4Tour g` restricts to a bijection
+`levelSet k → levelSet k` for each `g`. This is the right abstraction
+for the planned S4 mod-8 divisibility argument (orbit decomposition).
+
+The orbit framework (`d4Orbit`, `d4Orbit_card_le_eight`,
+`d4Orbit_subset_levelSet`, `tour_mem_d4Orbit_self`) is the standard
+finset bridge between the action and orbit-decomposition theory: each
+orbit is a finset of size ≤ 8 inside the level set at the common
+oblique count. The identity-acts-as-identity result (`applyD4Tour_id`)
+is the witness that the orbit is non-empty (contains `t` itself).
+
+### What this does NOT do (deferred)
+
+- **Mod-8 divisibility** (`8 ∣ obliqueDistribution k` when no self-
+  symmetric tour at level `k`): requires (i) a `Finset.partition` of
+  `levelSet k` into orbits, (ii) a free-action characterization (orbit
+  size = 8 iff stabilizer is trivial), (iii) summing |orbit| = 8 over
+  the orbit partition. Each piece is standard but adds ~80–120 LOC and
+  benefits from a `MulAction` instance; deferred to S4.
+- **Reversal symmetry** (Target D) — `obliqueCount (reverse t) =
+  obliqueCount t`. Still requires a `reverse : ClosedTour → ClosedTour`
+  definition first.
+- **Winding-parity joint constraint** (Target E) — unchanged.
+
+### Next action (S4 ORIENT)
+
+Build the mod-8 divisibility statement:
+
+1. Set up a `MulAction (D4Group) ClosedTour` instance using
+   `applyD4Tour` (or work directly with the `Bool × Fin 4` encoding and
+   `Equiv.Perm.subgroupOfHom` style). Optional convenience step;
+   strictly the orbit-partition can be proved without `MulAction`.
+2. Decide whether to use Mathlib's `MulAction.orbitRel` / `orbit` and
+   `MulAction.card_orbit_dvd_card_group` (cleanest, requires the
+   instance), or hand-construct the orbit partition (~80 LOC,
+   instance-free).
+3. State and prove the **stabilizer-aware** mod-8 statement:
+   `obliqueDistribution k = 8 * (free orbit count) + sum of
+   (8 / stabilizer size) over self-symmetric tours`.
+4. Specialize to the "no self-symmetric tour at level `k`" case to get
+   the clean divisibility `8 ∣ obliqueDistribution k`.
+
+Estimated S4 size: ~150–200 LOC if going via `MulAction`, ~100–120 LOC
+otherwise.
+
+### Build status
+
+**Build pending — parent `Proofs/KnightsTourOblique.lean` is still
+broken on origin/main** (same blocker as iter 2/3). The OQ02 additions
+use only the parent's public surface (`applyD4Tour`,
+`applyD4Tour_inv_left`, `oblique_count_invariant`, `closedTour_eq_iff`,
+`applyD4`, `rotateSquareN`'s `match 0` reduction) plus standard Mathlib
+finset/fintype API (`Finset.image`, `Finset.card_image_of_injective`,
+`Finset.eq_of_subset_of_card_le`, `Finset.card_image_le`,
+`Fintype.card_prod`, `List.map_id`, `Classical.decEq`). No new axioms.
+
+Verification by inspection follows the precedent of iter 1 (S1, PR
+#18046), iter 2 (S2, PR #18101), and iter 3 (S3-prep, PR #18144), all
+of which merged "(build pending)" because the parent was already
+broken at the time. A mechanic-driven parent repair would unblock
+build verification for the whole `knights-tour-oblique-oq-02-*`
+descendant chain simultaneously and remains out of scope for the
+distribution-skeleton work.
+
+### Blockers
+
+Parent `Proofs/KnightsTourOblique.lean` is broken on origin/main —
+needs a separate mechanic-driven Mathlib-drift fix PR. Not a blocker
+for this iteration (matches S1/S2/S3-prep precedent).

--- a/src/data/research/problems/knights-tour-oblique-oq-02.json
+++ b/src/data/research/problems/knights-tour-oblique-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "knights-tour-oblique-oq-02",
   "title": "Distribution of oblique counts across all 13+ trillion closed knight's tours (8×8)",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "structural-skeleton",
@@ -21,7 +21,10 @@
       "Minimum oblique count ≥ 4 (n×n for n ≥ 5): `KnightsTourObliqueOQ01.lean:381` `four_oblique_corners`.",
       "Winding constraint: `tour_winding_zero : ∀ t, ∑_i turnAngle (tourMoves t)[i] = 0` (`KnightsTourOblique.lean:678`).",
       "No 180° turn: `no_turn_angle_4_all : ∀ t i, turnAngle ... ≠ 4` (`KnightsTourOblique.lean:587`).",
-      "Oblique iff large turn: `oblique_iff_large_turn` (`KnightsTourOblique.lean:264`)."
+      "Oblique iff large turn: `oblique_iff_large_turn` (`KnightsTourOblique.lean:264`).",
+      "**D4 level-set invariance** (this iteration, S3 ACT): for every g : Bool × Fin 4 and k : ℕ, (levelSet k).image (applyD4Tour g) = levelSet k. (KnightsTourObliqueOQ02.lean:281, levelSet_image_applyD4Tour_eq)",
+      "D4 orbit size ≤ 8 (this iteration, S3 ACT): (d4Orbit t).card ≤ 8. (KnightsTourObliqueOQ02.lean:306)",
+      "D4 orbit subset level set (this iteration, S3 ACT): d4Orbit t ⊆ levelSet (obliqueCount t). (KnightsTourObliqueOQ02.lean:314)"
     ],
     "open": [
       "Define `obliqueDistribution : ℕ → ℕ` (Target A, S2).",
@@ -34,20 +37,20 @@
     "goal": "Build the structural skeleton of the oblique-count distribution — support, D4-mod-8, reversal-mod-2, winding-parity — derivable from the existing infrastructure in `KnightsTourOblique.lean` without enumeration."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-12T11:35:00.000Z",
-    "iteration": 2,
-    "focus": "S2 ORIENT/ACT (researcher-8, 2026-05-12) — built proofs/Proofs/KnightsTourObliqueOQ02.lean (~130 lines, 0 sorries, 0 new axioms): Fintype ClosedTour via injection into Fin 64 → Square, def obliqueDistribution : ℕ → ℕ as Finset.filter over the new Fintype.univ, theorem obliqueDistribution_zero_below_four lifting parent oblique_lower_bound, plus the k ≤ 3 restatement. Registered in Proofs.lean. Parent file untouched.",
+    "phase": "ACT",
+    "since": "2026-05-13T18:30:00.000Z",
+    "iteration": 4,
+    "focus": "S3 ACT (researcher-5, 2026-05-13) — extended KnightsTourObliqueOQ02.lean from 212→340 lines with D4 level-set invariance (headline Target C result) + D4-orbit framework. Added: levelSet, obliqueDistribution_eq_levelSet_card, applyD4Tour_injective, levelSet_image_applyD4Tour_subset/_card/_eq (image-equality via Finset.eq_of_subset_of_card_le on closure + injectivity), d4Orbit, d4Orbit_card_le_eight, d4Orbit_subset_levelSet, applyD4Tour_id ((false,0) acts as identity), tour_mem_d4Orbit_self. Still 0 sorries, 0 new axioms. All results from parent public surface (applyD4Tour, applyD4Tour_inv_left, oblique_count_invariant, closedTour_eq_iff) + standard Mathlib finset/fintype API.",
     "blockers": [],
-    "nextAction": "S3 ORIENT: define the D4 group action on ClosedTour (8 generators on Square lifted pointwise via squares-list map, preserving path/closure/nodup). Prove obliqueCount is D4-invariant (dot product of consecutive moves is rotation/reflection-symmetric). State the orbit-size-divides-8 corollary and the resulting mod-8 divisibility of obliqueDistribution k generically. Defer self-symmetric tour exceptions to S4. Estimated 150-200 lines, possibly 1 sorry on the self-symmetric set classification.",
+    "nextAction": "S4 ORIENT: build the mod-8 divisibility statement. Either (a) set up a MulAction (Bool × Fin 4) ClosedTour instance via applyD4Tour and use Mathlib MulAction.orbit/card_orbit_dvd_card_group (~150-200 LOC), or (b) hand-construct orbit partition of levelSet k via Finset.Equiv (~100-120 LOC). State and prove the stabilizer-aware form: obliqueDistribution k = 8*(free orbit count) + Σ (8/|Stab|) over self-symmetric tours at level k. Specialize to no-self-symmetric-at-k case for the clean 8 ∣ obliqueDistribution k. Still 0-1 sorries acceptable (Mathlib orbit-stabilizer surface may need bridging).",
     "attemptCounts": {
-      "total": 1,
+      "total": 4,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ORIENT/ACT (researcher-8, 2026-05-12): shipped the prerequisite Lean infrastructure. Created Proofs/KnightsTourObliqueOQ02.lean with the Fintype ClosedTour instance (via Fintype.ofInjective into Fin 64 → Square, using List.ext_get for injection proof), the histogram definition obliqueDistribution : ℕ → ℕ, and the support lower bound obliqueDistribution k = 0 for k < 4 (lifted from parent oblique_lower_bound). 0 sorries on the file, 0 new axioms. Parent KnightsTourOblique.lean untouched. Next: D4 group action (S3).",
+    "progressSummary": "S3 ACT complete (researcher-5, 2026-05-13): KnightsTourObliqueOQ02.lean now 340 lines, 0 sorries, 0 new axioms. Cumulative deliverables: Fintype ClosedTour (S2), obliqueDistribution histogram definition (S2), support lower bound k<4 ⇒ histogram=0 (S2), support upper bound k>64 ⇒ histogram=0 (S3-prep), histogram completeness sum over [4,64] = card ClosedTour (S3-prep), **D4 level-set invariance levelSet k image = levelSet k for every g (S3 ACT, headline Target C)**, D4 orbit framework with card ≤ 8 and orbit-in-level-set containment (S3 ACT). Next: S4 mod-8 divisibility via orbit partition + stabilizer-aware count.",
     "builtItems": [
       "research/problems/knights-tour-oblique-oq-02/problem.md — problem description, tractability triage, parent linkage, references (Knuth 2025, Loebbing-Wegener 1996, McKay 1997)",
       "research/problems/knights-tour-oblique-oq-02/knowledge.md — parent infrastructure survey (`obliqueCount`, `tourMoves`, `turnAngle`, `tour_winding_zero`, `no_turn_angle_4_all`), feasibility table, sorries/axioms anticipated",
@@ -60,7 +63,19 @@
       "noncomputable def obliqueDistribution (k : ℕ) : ℕ — Finset.univ.filter (· = k) |>.card",
       "theorem obliqueDistribution_zero_below_four (k : ℕ) (hk : k < 4) : obliqueDistribution k = 0",
       "theorem obliqueDistribution_support_le_three : ∀ k ≤ 3, obliqueDistribution k = 0",
-      "proofs/Proofs.lean — registered the new module"
+      "proofs/Proofs.lean — registered the new module",
+      "noncomputable instance : DecidableEq ClosedTour := Classical.decEq _ — KnightsTourObliqueOQ02.lean:235 (enables Finset.image on ClosedTour-valued maps)",
+      "noncomputable def levelSet (k : ℕ) : Finset ClosedTour := Finset.univ.filter (· = k) — KnightsTourObliqueOQ02.lean:240",
+      "theorem obliqueDistribution_eq_levelSet_card (k) : obliqueDistribution k = (levelSet k).card := rfl — KnightsTourObliqueOQ02.lean:245",
+      "theorem applyD4Tour_injective (g) : Function.Injective (applyD4Tour g) — KnightsTourObliqueOQ02.lean:251 (from parent applyD4Tour_inv_left)",
+      "theorem levelSet_image_applyD4Tour_subset (g) (k) : (levelSet k).image (applyD4Tour g) ⊆ levelSet k — KnightsTourObliqueOQ02.lean:262 (closure via parent oblique_count_invariant)",
+      "theorem levelSet_image_applyD4Tour_card (g) (k) : ((levelSet k).image (applyD4Tour g)).card = (levelSet k).card — KnightsTourObliqueOQ02.lean:273 (Finset.card_image_of_injective)",
+      "theorem levelSet_image_applyD4Tour_eq (g) (k) : (levelSet k).image (applyD4Tour g) = levelSet k — KnightsTourObliqueOQ02.lean:281 (**headline S3 result**: D4 level-set invariance)",
+      "noncomputable def d4Orbit (t : ClosedTour) : Finset ClosedTour := Finset.univ.image (applyD4Tour · t) — KnightsTourObliqueOQ02.lean:301",
+      "theorem d4Orbit_card_le_eight (t) : (d4Orbit t).card ≤ 8 — KnightsTourObliqueOQ02.lean:306",
+      "theorem d4Orbit_subset_levelSet (t) : d4Orbit t ⊆ levelSet (obliqueCount t) — KnightsTourObliqueOQ02.lean:314",
+      "theorem applyD4Tour_id (t) : applyD4Tour (false, 0) t = t — KnightsTourObliqueOQ02.lean:326 (D4 identity)",
+      "theorem tour_mem_d4Orbit_self (t) : t ∈ d4Orbit t — KnightsTourObliqueOQ02.lean:335 (orbit is non-empty)"
     ],
     "insights": [
       "The full histogram is unreachable in Lean (1.3 × 10^13 tours), but the *structural skeleton* of the distribution — support, D4 invariance, reversal symmetry, winding-parity — is reachable using only the parent's existing infrastructure.",
@@ -70,7 +85,12 @@
       "The parent file uses `Classical.choice` to express closed tours; defining `obliqueDistribution` as a `Finset.filter` count requires either a separate `Fintype ClosedTour` derivation (e.g., as a subtype of `Vector Square 64` plus the closure and bijection constraints) or a parametric statement that never instantiates the cardinality. The parametric route is cleaner.",
       "Fintype ClosedTour is achievable by injection into Fin 64 → Square (Square = Fin 8 × Fin 8 is a Fintype). The injection proof reduces to two parts: (1) List.ext_get gives s1 = s2 from pointwise function equality, (2) propositional fields of the ClosedTour structure collapse via proof irrelevance after subst.",
       "The Fintype instance must be noncomputable because Fintype.ofInjective relies on Classical.choice. This propagates: obliqueDistribution is also noncomputable. This is acceptable for the structural-skeleton scope (we never reduce the histogram values computationally; concrete values come from external enumeration).",
-      "The support lower bound is a one-line lift: obliqueDistribution k = 0 iff the filtered set is empty, and the filtered set is empty when oblique_lower_bound rules out obliqueCount t = k for k < 4."
+      "The support lower bound is a one-line lift: obliqueDistribution k = 0 iff the filtered set is empty, and the filtered set is empty when oblique_lower_bound rules out obliqueCount t = k for k < 4.",
+      "Pointwise D4-invariance of obliqueCount (parent oblique_count_invariant) lifts to *image-equality* on level sets without proving full bijectivity directly: closure (subset) + cardinality preservation (injectivity from left inverse) + Finset.eq_of_subset_of_card_le suffices on a Fintype. This is more economical than constructing a Finset.Equiv explicitly. (S3 ACT)",
+      "Injectivity of applyD4Tour g comes free from the parent applyD4Tour_inv_left (left-inverse witness applyD4Tour (d4Inv g)). No need to prove surjectivity or use d4Inv-involutiveness separately for the level-set invariance argument. (S3 ACT)",
+      "DecidableEq ClosedTour is the smallest type-class addition needed to use Finset.image on ClosedTour-valued maps. Classical.decEq is consistent with the existing noncomputable Fintype ClosedTour instance. (S3 ACT)",
+      "The D4 identity (false, 0) acts as the identity on Square via rfl: applyD4 (false, 0) s unfolds to rotateSquareN 0 (if false then ... else s) = rotateSquareN 0 s = s. This makes tour_mem_d4Orbit_self a one-liner. (S3 ACT)",
+      "The bound (d4Orbit t).card ≤ 8 reduces to Finset.card_image_le over the 8-element Bool × Fin 4 source finset. No need to enumerate orbits explicitly; the equality |orbit| = 8 / |stabilizer| is deferred to S4 with a MulAction setup. (S3 ACT)"
     ],
     "mathlibGaps": [
       "No `Fintype` instance for `ClosedTour` in the parent file. The parent uses `Classical.choice` for existential extraction; OQ-02 needs an explicit `Fintype` (or a parametric workaround).",
@@ -81,7 +101,10 @@
       "S2 ORIENT: create `Proofs/KnightsTourObliqueOQ02.lean`. Add `Fintype ClosedTour` (or parametric workaround). Define `obliqueDistribution : ℕ → ℕ`. Prove support lemma `obliqueDistribution k = 0 for k < 4` via parent's minimum theorem. Target 100-150 lines, 0 sorries on the support lemma.",
       "S3 ACT: build the D4 group action (8-element finite group via horizontal flip + 90° rotation generators), prove `MulAction D4 ClosedTour` and `obliqueCount` invariance. Conclude `obliqueDistribution k ≡ 0 mod 8` modulo the symmetric-tour exception set. Target 150-200 lines, 0-1 sorries on orbit-stabilizer.",
       "S4 ACT: reversal symmetry `obliqueCount (reverse t) = obliqueCount t` + winding-parity constraint. Target 80-100 lines, 0 sorries.",
-      "S5 (optional): better support upper bound from the joint winding-mod-8 constraint on (#turnAngle = 3, #turnAngle = 5). Target 50-80 lines, may need 1-2 sorries on `decide`-shaped arithmetic facts."
+      "S5 (optional): better support upper bound from the joint winding-mod-8 constraint on (#turnAngle = 3, #turnAngle = 5). Target 50-80 lines, may need 1-2 sorries on `decide`-shaped arithmetic facts.",
+      "S4 ORIENT/ACT: mod-8 divisibility. Choose MulAction Bool × Fin 4 ClosedTour vs hand orbit-partition. Prove orbit-stabilizer form |orbit| = 8 / |stab|. State stabilizer-aware decomposition obliqueDistribution k = 8 * (free orbit count) + Σ (8/|Stab t|) over self-symmetric tours t with obliqueCount t = k. Target 100-200 LOC, 0-1 sorries on Mathlib bridging.",
+      "S5 ORIENT: reversal symmetry via reverse : ClosedTour → ClosedTour, prove obliqueCount (reverse t) = obliqueCount t (analogue of S3 oblique_count_invariant but for the Z/2 reversal action rather than D4). Target 80-100 LOC.",
+      "S6 ACT: combine D4 + reversal → mod-16 divisibility modulo (self-symmetric + palindromic) tours. Target 60-100 LOC."
     ]
   },
   "references": [
@@ -114,5 +137,6 @@
     "Knuth",
     "scaffold",
     "seeker-selected"
-  ]
+  ],
+  "lastUpdate": "2026-05-13T18:30:00.000Z"
 }


### PR DESCRIPTION
## Summary

Iteration 4 (S3 ACT) on `knights-tour-oblique-oq-02`. Extends
`proofs/Proofs/KnightsTourObliqueOQ02.lean` from 212→340 lines
(**+128 LOC**) with the **headline S3 deliverable**: D4 level-set
invariance of `obliqueDistribution`, plus a small D4-orbit framework
for the S4 mod-8 divisibility argument. Still **0 sorries, 0 new axioms**.

This continues the multi-session thread:
- #18046 (S1 OBSERVE, build pending)
- #18101 (S2 ORIENT/ACT, build pending) — `Fintype ClosedTour` +
  `obliqueDistribution` + support lower bound
- #18144 (S3-prep, build pending) — support upper bound + histogram
  normalization
- **this PR** (S3 ACT) — D4 level-set invariance + orbit framework

## Headline result (Target C)

```
theorem levelSet_image_applyD4Tour_eq (g : Bool × Fin 4) (k : ℕ) :
    (levelSet k).image (applyD4Tour g) = levelSet k
```

For every D4 element `g`, the map `applyD4Tour g` restricts to a
**bijection of `levelSet k` onto itself**. Proof argument:

1. **Closure** of `levelSet k` under `applyD4Tour g` — direct consequence
   of parent's `oblique_count_invariant`.
2. **Cardinality preservation** — `applyD4Tour_injective` (derived here
   from parent's `applyD4Tour_inv_left`) + `Finset.card_image_of_injective`.
3. **Image equality** — closure + cardinality preservation +
   `Finset.eq_of_subset_of_card_le` on a finite set.

## What's new

**Level-set machinery:**
- `instance : DecidableEq ClosedTour` — `Classical.decEq _` to enable
  `Finset.image` on `ClosedTour`-valued maps.
- `def levelSet (k : ℕ) : Finset ClosedTour`
- `theorem obliqueDistribution_eq_levelSet_card` — `rfl`-level identity.
- `theorem applyD4Tour_injective` — from parent left inverse.
- `theorem levelSet_image_applyD4Tour_subset` — closure.
- `theorem levelSet_image_applyD4Tour_card` — cardinality preservation.
- `theorem levelSet_image_applyD4Tour_eq` — **the headline**.

**D4 orbit framework:**
- `def d4Orbit (t : ClosedTour) : Finset ClosedTour`
- `theorem d4Orbit_card_le_eight` — `(d4Orbit t).card ≤ 8`.
- `theorem d4Orbit_subset_levelSet` — orbit ⊆ level set at common
  `obliqueCount`.
- `theorem applyD4Tour_id` — `(false, 0)` acts as identity (`rfl`
  through `rotateSquareN 0 s = s`).
- `theorem tour_mem_d4Orbit_self` — every tour is in its own orbit.

## What this does NOT do

- **Mod-8 divisibility** itself (`8 ∣ obliqueDistribution k` modulo
  self-symmetric tours): deferred to S4. Requires either a `MulAction`
  instance + Mathlib `orbit/card_orbit_dvd_card_group` (~150–200 LOC),
  or a hand orbit-partition of `levelSet k` (~100–120 LOC).
- **Reversal symmetry** (Target D) — still needs a `reverse : ClosedTour
  → ClosedTour` definition first.
- **Winding-parity joint constraint** (Target E) — unchanged.

## Build status

**Build pending — parent `Proofs/KnightsTourOblique.lean` is still
broken on origin/main** (same blocker as iter 2/3; ~50+ errors all in
the parent: `List.getLast_eq_get`, `List.map_eq_nil`, `omega`/`simp`
regressions, a duplicate `tour_consecutive_adj`, etc.). This matches
the precedent for #18046, #18101, and #18144 — all merged "(build
pending)" because the parent was already broken at the time.

The OQ-02 additions use only the parent's **public surface**:
`applyD4Tour`, `applyD4Tour_inv_left`, `oblique_count_invariant`,
`closedTour_eq_iff`, `applyD4`, plus `rotateSquareN`'s `match 0`
reduction. Mathlib API used: `Finset.image`,
`Finset.card_image_of_injective`, `Finset.eq_of_subset_of_card_le`,
`Finset.card_image_le`, `Fintype.card_prod/_bool/_fin`, `List.map_id`,
`Classical.decEq`. **No new axioms.**

A mechanic-driven Mathlib-drift fix for the parent file would unblock
build verification for the whole `knights-tour-oblique-oq-02-*`
descendant chain at once and remains out of scope here.

## Files

- `proofs/Proofs/KnightsTourObliqueOQ02.lean` (+128 / -0, 212→340 LOC)
- `research/problems/knights-tour-oblique-oq-02/state.md` — Iteration 4
  entry (Phase ACT, S3 ACT), refreshed header.
- `src/data/research/problems/knights-tour-oblique-oq-02.json` — sync
  to iteration 4: phase, focus, nextAction, progressSummary, +5
  insights, +12 builtItems, +3 knownResults.proven, +3 nextSteps,
  lastUpdate.

## Honesty notes

- The headline level-set invariance is the **finite-set lift** of the
  parent's pointwise invariance via standard cardinality reasoning. It
  is the expected finite-set consequence of the pointwise invariance,
  packaged in the right form for the downstream orbit-decomposition
  argument — not a new mathematical fact about knight's tours.
- The orbit framework is infrastructure for S4, not progress on OQ-02's
  mathematical content per se. S4 mod-8 divisibility is the next
  real-content step; this PR sets the stage.
- The file goes from 11 declarations (212 LOC) to 23 declarations
  (340 LOC). Still 0 sorries, 0 new axioms.

🤖 Generated by researcher-5