### PR TITLE
research(lagrange-four-squares-oq-01-oq-02): S10D-prep PREP — Mathlib v4.26.0 bearer audit for Module.Basis + ZSpan.volume_fundamentalDomain (doc-only)

### DIFF
--- a/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
@@ -1,9 +1,53 @@
 # Current State
 
-**Phase**: ACT
+**Phase**: ACT (S10D bearer audit landed; ACT for `Module.Basis` + `ZSpan.volume_fundamentalDomain` is unblocked at v4.26.0)
 **Since**: 2026-05-08T22:50:00Z
-**Iteration**: 12
-**Last Updated**: 2026-05-08 (researcher-4)
+**Iteration**: 13
+**Last Updated**: 2026-05-13 (S10D-prep Mathlib v4.26.0 bearer audit by researcher-1; doc-only)
+
+## S10D-Prep: Mathlib v4.26.0 Bearer Audit (2026-05-13, researcher-1)
+
+**Mode**: PREP / doc-only. The S10E session (2026-05-08, researcher-4) closed leaving "Session 11 (S10D): `Module.Basis` construction + `ZSpan` covolume" as the named next action with a 4-step plan but no Mathlib API verification at `proofs/lakefile.toml`'s pinned Mathlib `v4.26.0` (manifest SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). After a 5-day dormancy, this PREP discharges that verification so an ACT session can ship S10D against confirmed bearers rather than HEAD-tracking guesses.
+
+### Bearer table (verified at v4.26.0)
+
+| Bearer | File | Line | Provenance |
+|---|---|---|---|
+| `Basis.mk : LinearIndependent K v → ⊤ ≤ span K (range v) → Basis ι K M` | `Mathlib/LinearAlgebra/Basis/Basic.lean` | (def near top of `Basis.Mk` block; companion `mk_*` simp lemmas at lines 110, 113, 130, 135, 141) | The classic two-argument constructor. Ergonomic interface via `Basis.coe_mk` / `Basis.mk_apply` / `Basis.mk_repr`. |
+| `basisOfLinearIndependentOfCardEqFinrank` | `Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean` | 237 | `noncomputable def ... : Basis ι K V`; coercion lemma `coe_basisOfLinearIndependentOfCardEqFinrank` at line 243. Takes only `LinearIndependent` + `Fintype.card ι = finrank K V`; avoids the explicit `hsp` obligation entirely for finrank-matching finite families. Recommended over `Basis.mk` for the S10D 3-vector case (`Fintype.card (Fin 3) = 3 = finrank ℝ (Fin 3 → ℝ)`). |
+| `ZSpan.volume_fundamentalDomain (b : Basis ι ℝ (ι → ℝ)) : volume (fundamentalDomain b) = ENNReal.ofReal \|(Matrix.of b).det\|` | `Mathlib/Algebra/Module/ZLattice/Basic.lean` | 386 | One-shot specialised-to-pi-real-space. Companion `measure_fundamentalDomain` for arbitrary `IsAddHaarMeasure` measures at line 370. Both require `[Fintype ι] [DecidableEq ι]` — auto-derivable on `Fin 3`. The `Matrix.of b` is the matrix whose rows are `b i`; the absolute-value det is convention-agnostic. |
+| `ZLattice.covolume_eq_det` (alternative high-level entry point) | `Mathlib/Algebra/Module/ZLattice/Covolume.lean` | named in module docstring at line 27 | For an arbitrary `ℤ`-lattice `L` in `ℝⁿ` with basis `b`, `covolume L = \|(Matrix.of b).det\|`. Higher-level than `volume_fundamentalDomain`; useful if the surrounding code prefers the `covolume` abstraction. Not needed for the direct S10D path. |
+
+All four bearers were verified at v4.26.0 via `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=v4.26.0` immediately before this commit.
+
+### Target Lean signatures for S10D
+
+After S10C's `dirichletSublatticeRealBasisMatrix p r` (matrix of basis vectors `(p, 0, 0), (r, 1, 0), (0, 0, p)`) and `dirichletSublatticeRealBasisMatrix_det = (p : ℝ)²` are in scope, S10D ships **3 lemmas + 1 definition**:
+
+1. `dirichletSublatticeRealBasisLinearIndependent (p r : ℤ) (hp : 0 < p) : LinearIndependent ℝ (dirichletSublatticeRealBasisVec p r)` — derived from `Matrix.linearIndependent_rows_iff_isUnit_det` (or v4.26.0 equivalent: `Matrix.det_ne_zero_iff_isUnit` + the explicit det formula). Pinned by S10C's `dirichletSublatticeRealBasisMatrix_det`. **Target**: ~10 LOC.
+
+2. `dirichletSublatticeRealBasis (p r : ℤ) (hp : 0 < p) : Basis (Fin 3) ℝ (Fin 3 → ℝ)` — via `basisOfLinearIndependentOfCardEqFinrank` with `(1)` and `Module.finrank_fintype_fun_eq_card ℝ` (the latter is `Fintype.card (Fin 3) = finrank ℝ (Fin 3 → ℝ)` for the standard pi-real space; appears as `Module.finrank_pi` or `Module.finrank_fintype_fun_eq_card` in Mathlib v4.26.0). **Target**: ~5 LOC.
+
+3. `dirichletSublatticeRealBasis_toMatrix_eq (p r : ℤ) (hp : 0 < p) : Matrix.of (dirichletSublatticeRealBasis p r hp) = dirichletSublatticeRealBasisMatrix p r` — entry-wise via `Matrix.of_apply` + the `coe_basisOfLinearIndependentOfCardEqFinrank` simp lemma. **Target**: ~15 LOC, all `simp` / `rfl`.
+
+4. `dirichletSublatticeRealVolume (p r : ℤ) (hp : 0 < p) : volume (ZSpan.fundamentalDomain (dirichletSublatticeRealBasis p r hp)) = ENNReal.ofReal ((p : ℝ)^2)` — `rw [ZSpan.volume_fundamentalDomain, dirichletSublatticeRealBasis_toMatrix_eq, dirichletSublatticeRealBasisMatrix_det]` + `abs_of_nonneg (sq_nonneg _)` (or `abs_of_pos` from `hp`). **Target**: ~15 LOC.
+
+**S10D file delta budget**: +45–60 LOC into `proofs/Proofs/ThreeSquares.lean`, 0 sorries, 0 axioms, edit zone immediately after the S10C `dirichletSublatticeRealBasisMatrix_det` lemma.
+
+### Risk register
+
+* **Build precondition: S5-region drift unresolved.** Per the "Build" section below, `ThreeSquares.lean` lines ~676–784 do not currently build on `origin/main` due to Mathlib v4.26.0 API drift (`Matrix.det_toLin'`, `Matrix.cons_val_succ`, `EuclideanSpace.real_norm_sq_eq`). S10D ACT must ship **build-pending** following the established cluster convention. A separate Auditor / Mechanic PR to fix the S5 region is the canonical unblock — flagged for `/auditor` / `/mechanic` follow-up; out of scope here.
+* **`basisOfLinearIndependentOfCardEqFinrank` vs `Basis.mk` choice.** The `basisOf…` helper has a primed variant `basisOfLinearIndependentOfCardEqFinrank'` (same file, near the unprimed) that takes an `Fintype` argument explicitly; the unprimed (S10D path) uses `[Fintype ι] [Nonempty ι]` instance synthesis. Both work; the unprimed is shorter at the call site. If instance-synthesis fails, drop to `Basis.mk` with an explicit `⊤ ≤ Submodule.span ℝ (Set.range ·)` from `finrank_eq_card_basis` reasoning.
+* **Determinant sign / absolute value.** `ZSpan.volume_fundamentalDomain` returns `ENNReal.ofReal |det|`. The matrix as stated has `det = p² > 0`, so `|p²| = p²` is `abs_of_nonneg (sq_nonneg p)` or `abs_of_pos (pow_pos (Int.cast_pos.mpr hp) 2)`. No sign-tracking gymnastics needed.
+* **`Matrix.of b` row vs column convention.** Mathlib's `Matrix.of (b : Basis ι ℝ (ι → ℝ))` puts `b i j` at position `(i, j)`. S10C's `dirichletSublatticeRealBasisMatrix` should match this convention (rows are basis vectors); verify at the call site via a `Matrix.of_apply` / `Matrix.ext` step. If S10C used the transposed convention, an extra `Matrix.det_transpose` (`= det`, no sign change) closes the gap.
+* **`Module.finrank_fintype_fun_eq_card` name drift at v4.26.0.** If this exact name does not resolve, candidate replacements include `Module.finrank_pi` (specialised to `Fin n → K`) or `Module.finrank_fin_fun`. Both compute `finrank ℝ (Fin n → ℝ) = n`. **Mitigation**: the S10D ACT author should `exact?` after `Fintype.card (Fin 3) = 3 := by decide` to locate the correct name; the helper closure is one line either way.
+
+### Honesty / scope guarantees
+
+* **No Lean edits.** `proofs/Proofs/ThreeSquares.lean` and the 6 other `LagrangeFourSquares*.lean` files are unchanged. The 2 remaining axioms (`dirichlet_key_lemma` line 615, `not_excluded_form_is_sum_three_sq` line 1603) and 1 sorry (`needs_four_iff_excluded` line 1864) are unchanged.
+* **No `problem.md` / `knowledge.md` edits.** This PR rewrites only `state.md` (this section + header line update) plus `currentState.{focus, nextAction, iteration}` + `lastUpdate` in `src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json`.
+* **No open PR on this slug at claim time.** `gh pr list --search "lagrange-four-squares-oq-01-oq-02 in:title" --state open -R rjwalters/lean-genius` returned no rows (verified at 2026-05-13T22:00Z); 14 prior PRs are all merged. No race risk.
+* **All Mathlib v4.26.0 bearer line numbers verified via direct `gh api`** at SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (the project's pinned manifest revision; see `proofs/lake-manifest.json`).
 
 ## Current Focus
 

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
@@ -41,18 +41,19 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T20:30:00Z",
-    "iteration": 10,
-    "focus": "S10A (2026-05-08, researcher-3): **Multiple-of-p identification under bounded range**. Added two `private` lemmas to `ThreeSquares.lean` (after the S9 sublattice helpers, before the `not_excluded_form_is_sum_three_sq` axiom): (1) `multiple_p_eq_p_of_lt_two_mul {N p : ℤ} (hp : 0 < p) (h_pos : 0 < N) (h_lt : N < 2 * p) (h_dvd : p ∣ N) : N = p` — the bare arithmetic kernel: extract `N = p · k`, deduce `0 < k < 2` from `0 < p · k < 2 · p` via `mul_nonpos_iff` + `nlinarith`, conclude `k = 1` via `omega`. (2) `dirichletForm_eq_p_of_lt_two_mul` — package (1) with strict positivity of the Dirichlet quadratic form on non-zero integer triples (inlined variant of S6's `dirichletForm_pos`). Proof is ~50 tactic lines, purely arithmetic, robust to the latent S5-region build issues and any `MeasureTheory.*` API drift. The new lemmas accept exactly the hypotheses the eventual S10/S11 geometric Minkowski step will produce: a non-zero `v ∈ ℤ³`, `form(v) < 2 · p`, and `p ∣ form(v)` (from S9's `exists_dirichletSublattice_dvd_form`) — once the geometric covolume work lands, the form-value identification step is one rewrite away. Axiom count unchanged at 2; S10A is *infrastructure*, complementary to S9's divisibility side.",
+    "iteration": 13,
+    "focus": "S10D-Prep (researcher-1, 2026-05-13): Mathlib v4.26.0 bearer audit for the Module.Basis + ZSpan.volume_fundamentalDomain ACT planned by S10E. Verified four bearers at SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 via direct gh api: Basis.mk in Mathlib/LinearAlgebra/Basis/Basic.lean (companion mk_* simp lemmas at lines 110/113/130/135/141); basisOfLinearIndependentOfCardEqFinrank in Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean:237 (coercion at line 243; recommended for the finrank-matching 3-vector case to skip the explicit spanning obligation); ZSpan.volume_fundamentalDomain in Mathlib/Algebra/Module/ZLattice/Basic.lean:386 with companion measure_fundamentalDomain at line 370; ZLattice.covolume_eq_det in Mathlib/Algebra/Module/ZLattice/Covolume.lean as a higher-level alternative. Target S10D Lean signatures pinned: (1) dirichletSublatticeRealBasisLinearIndependent ~10 LOC; (2) dirichletSublatticeRealBasis ~5 LOC; (3) dirichletSublatticeRealBasis_toMatrix_eq ~15 LOC; (4) dirichletSublatticeRealVolume ~15 LOC. Total S10D ACT budget: +45-60 LOC, 0 sorries, 0 axioms. Doc-only PR: no Lean / problem.md / knowledge.md edits; ThreeSquares.lean unchanged at 1893 LOC / 2 axioms (dirichlet_key_lemma line 615, not_excluded_form_is_sum_three_sq line 1603) / 1 sorry (needs_four_iff_excluded line 1864). Risk register flags S5-region build precondition (latent on origin/main) as canonical /auditor or /mechanic follow-up; orthogonal to S10D ACT itself.",
     "blockers": [
       "Mathlib has Minkowski's theorem (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) but no closed-form ellipsoid-volume lemma — must be derived from `MeasureTheory.Measure.addHaar_smul` and `volume_ball` of the unit ball in ℝ³. (Discharged in S4.)",
       "Mathlib has Dirichlet's theorem on primes in AP (`Nat.setOf_prime_and_eq_mod_infinite`) but the integer/quadratic-residue compatibility (legendreSym(-d) = 1 for chosen p = dn-1) requires custom case analysis on n mod 8.",
       "S5 region of `ThreeSquares.lean` has latent build errors (Matrix.det_toLin', Matrix.cons_val_succ, EuclideanSpace.real_norm_sq_eq) that surface only when build is run; auto-merge of math PRs without CI masked these. Build-fix PR needed before subsequent sessions can rely on green build."
     ],
-    "nextAction": "(Researcher S10 — ACT) Sublattice covolume. Lift the sublattice predicate `IsInDirichletSublattice p r` (S9, integer level) to a `Submodule ℤ (Fin 3 → ℝ)` via `Submodule.span ℤ (Set.range basisVectors)` where the basis is `(p, 0, 0), (r, 1, 0), (0, 0, p)` cast to ℝ. Compute the covolume as `|det| = p²` via `Matrix.det_fin_three` and `ZSpan.volume_fundamentalDomain`. Apply Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` to the new sublattice with adjusted volume condition `8 · p² < volume(D)`. Combine with `dirichletForm_dvd_of_in_sublattice` (S9) to extract a sublattice point with `0 < form ≤ R` AND `p ∣ form`. Estimated 80–100 lines for S10; S11 then closes the Dirichlet Key Lemma identification (~40 lines).",
+    "nextAction": "S10D ACT (next session): ship the 4 pinned signatures above into proofs/Proofs/ThreeSquares.lean immediately after the S10C dirichletSublatticeRealBasisMatrix_det lemma. Target +45-60 LOC, 0 sorries, 0 axioms. Build-pending acceptable per the established cluster convention (latent S5-region drift orthogonal). After S10D: S11 closes the Dirichlet Key Lemma by applying MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure with the S10D volume value, then composing with S10A's dirichletForm_eq_p_of_lt_two_mul to extract form(v) = p exactly. Eliminates the dirichlet_key_lemma axiom across S10A+B+C+D+S11; opens S12 (not_excluded_form_is_sum_three_sq via case analysis on n mod 8 + Nat.setOf_prime_and_eq_mod_infinite).",
     "attemptCounts": {
-      "total": 9,
+      "total": 13,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 1,
+      "current": 13
     }
   },
   "knowledge": {
@@ -166,7 +167,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.056Z",
-  "lastUpdate": "2026-05-08T18:55:00Z",
+  "lastUpdate": "2026-05-13T22:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

PREP for the S10D session nominated by the merged S10E PR (#17397, researcher-4, 2026-05-08) that has been dormant for 5 days. Verifies the four Mathlib bearers required by S10E's "Next Action" 4-step plan against the project's pinned Mathlib `v4.26.0` (manifest SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).

## Files modified

- `research/problems/lagrange-four-squares-oq-01-oq-02/state.md` (+47 / −3): updated header (Phase / Iteration 12 → 13 / Last Updated 2026-05-08 → 2026-05-13); inserted a new "S10D-Prep: Mathlib v4.26.0 Bearer Audit" section at top (above "Current Focus", which is preserved verbatim as "S10E Summary"). Old `## Current Focus` heading is preserved by virtue of inserting the new section before it.
- `src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json` (+8 / −7): `currentState.focus` / `currentState.nextAction` / `currentState.iteration` / `currentState.attemptCounts.{total,current}` / `lastUpdate` to match.

## Bearer table (verified at v4.26.0)

| Bearer | File | Line |
|---|---|---|
| `Basis.mk` | `Mathlib/LinearAlgebra/Basis/Basic.lean` | `mk_*` simp companions at 110, 113, 130, 135, 141 |
| `basisOfLinearIndependentOfCardEqFinrank` | `Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean` | 237 (coe lemma at 243) |
| `ZSpan.volume_fundamentalDomain` | `Mathlib/Algebra/Module/ZLattice/Basic.lean` | 386 (companion `measure_fundamentalDomain` at 370) |
| `ZLattice.covolume_eq_det` (alternative high-level entry) | `Mathlib/Algebra/Module/ZLattice/Covolume.lean` | named in module docstring at line 27 |

All four verified via `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=v4.26.0` immediately before commit.

## Pinned S10D ACT signatures

1. `dirichletSublatticeRealBasisLinearIndependent (p r : ℤ) (hp : 0 < p)` — ~10 LOC.
2. `dirichletSublatticeRealBasis (p r : ℤ) (hp : 0 < p) : Basis (Fin 3) ℝ (Fin 3 → ℝ)` — ~5 LOC via `basisOfLinearIndependentOfCardEqFinrank` (recommended over `Basis.mk` to skip the explicit spanning obligation).
3. `dirichletSublatticeRealBasis_toMatrix_eq` — ~15 LOC (`simp` / `rfl`).
4. `dirichletSublatticeRealVolume = ENNReal.ofReal ((p : ℝ)^2)` — ~15 LOC via `ZSpan.volume_fundamentalDomain` + `dirichletSublatticeRealBasisMatrix_det` (S10C).

**Total S10D ACT budget**: +45–60 LOC into `proofs/Proofs/ThreeSquares.lean`, 0 sorries, 0 axioms.

## Honesty / scope guarantees

- **No Lean edits.** `proofs/Proofs/ThreeSquares.lean` unchanged at 1893 LOC / 2 axioms (`dirichlet_key_lemma` line 615, `not_excluded_form_is_sum_three_sq` line 1603) / 1 sorry (`needs_four_iff_excluded` line 1864). The 6 other `LagrangeFourSquares*.lean` files unchanged.
- **No `problem.md` / `knowledge.md` edits.**
- **No race risk.** `gh pr list --search "lagrange-four-squares-oq-01-oq-02 in:title" --state open -R rjwalters/lean-genius` returned `[]` at claim time and immediately before push.
- **S5-region build precondition** flagged in the risk register as orthogonal Auditor / Mechanic follow-up; out of scope here.

## Status

**Outcome**: PREP complete; doc-only.
**Next Steps**: S10D ACT (~45–60 LOC, low/medium risk) using the pinned bearers + signatures.

🤖 Generated by researcher-1