### PR TITLE
research(law-of-cosines-oq-04-oq-02-oq-01): S2 ACT skeleton — Path A scaffold (build pending)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean
@@ -1,0 +1,145 @@
+import Mathlib
+import Proofs.LawOfCosinesOQ04OQ02
+
+/-
+# Angle Bisector Ratio from Mathlib's Euclidean Geometry API
+
+## Open Question: law-of-cosines-oq-04-oq-02-oq-01
+
+The parent `LawOfCosinesOQ04OQ02.lean` proves the angle-bisector length formula
+`t² · (b+c)² = bc · ((b+c)² − a²)` from Stewart's theorem, but takes the
+**angle-bisector identity** `m · b = n · c` as an *algebraic* hypothesis (`hbis`),
+rather than deriving it from the geometric premise "AD bisects ∠BAC and D ∈ seg(B,C)".
+
+**OQ asks**: derive `m · b = n · c` directly from `Sbtw ℝ B D C` plus `∠ B A D = ∠ D A C`,
+using Mathlib's `EuclideanGeometry.angle` / `dist` API, so the chained
+`angle_bisector_length` becomes parametric in geometric premises only.
+
+## Strategy (Path A — inner-product factorization)
+
+With `u := B -ᵥ A`, `v := C -ᵥ A`:
+1. From `Sbtw ℝ B D C` extract `s ∈ Ioo (0:ℝ) 1` with `D -ᵥ A = (1 - s) • u + s • v`.
+2. Compute `dist B D = s · dist B C` and `dist D C = (1 - s) · dist B C`.
+3. Expand cosines: `cos(∠BAD)` and `cos(∠DAC)` in terms of `s, ⟪u,v⟫, ‖u‖, ‖v‖, ‖D-ᵥA‖`.
+4. From `∠BAD = ∠DAC` (and `arccos` injectivity on `[-1,1]`) derive the cosine equality
+   ⇒ algebraic factorization `((1-s)·c − s·b) · (b·c − ⟪u,v⟫) = 0`.
+5. The non-degeneracy hypothesis `¬ Collinear ℝ ({A,B,C} : Set P)` plus strict Cauchy-Schwarz
+   rules out the second factor; conclude `s = c/(b+c)`, hence `m · b = n · c`.
+
+## Mathlib bearers (lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, v4.26.0)
+
+* `Sbtw.mem_image_Ioo` — `Mathlib/Analysis/Convex/Between.lean:353`
+* `AffineMap.lineMap_apply` — `lineMap a b t = a + t • (b -ᵥ a)`
+* `EuclideanGeometry.angle` (def) — `Geometry/Euclidean/Angle/Unoriented/Affine.lean:42`
+* `InnerProductGeometry.cos_angle` — `Geometry/Euclidean/Angle/Unoriented/Basic.lean:65`
+* `Real.arccos_inj` — `Analysis/SpecialFunctions/Trigonometric/Inverse.lean:336`
+* `dist_eq_norm_vsub` — `Analysis/Normed/Group/AddTorsor.lean:76`
+* `abs_real_inner_le_norm` — `Analysis/InnerProductSpace/Basic.lean:453`
+* `EuclideanGeometry.collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi`
+  — `Affine.lean:378`
+
+See `research/problems/law-of-cosines-oq-04-oq-02-oq-01/s2-prep-bearer-audit.md` for
+the full audit table and re-grounded line numbers at the pinned SHA.
+
+## Status
+
+* This file establishes the S2 ACT scaffold (statements + proof skeletons).
+* Sorries: 3 (helper lemmas + main theorem); to be discharged in S3.
+* Axioms: 0.
+* Build: pending (no `docker-build` run this session).
+-/
+
+open EuclideanGeometry
+
+namespace LawOfCosinesOQ04OQ02OQ01
+
+variable {V : Type*} {P : Type*}
+variable [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+variable [MetricSpace P] [NormedAddTorsor V P]
+
+/-! ## Step 1: Barycentric parameter for D on segment BC
+
+From `Sbtw ℝ B D C` extract `s ∈ Ioo 0 1` placing `D` on the open segment with
+`D -ᵥ A = (1 - s) • (B -ᵥ A) + s • (C -ᵥ A)`. This is the unique parameter
+`s = dist B D / dist B C` (deferred to `bisector_dist_BD` below).
+
+Proof outline:
+* `Sbtw.mem_image_Ioo` yields `⟨s, hs, hD⟩` with `s ∈ Ioo 0 1` and `lineMap B C s = D`.
+* `AffineMap.lineMap_apply` rewrites `lineMap B C s = B + s • (C -ᵥ B)`.
+* Subtracting `A` and using `vsub` lemmas converts to the affine combination
+  `(1 - s) • (B -ᵥ A) + s • (C -ᵥ A)`. -/
+lemma bisector_param_exists {B C D : P} (hD : Sbtw ℝ B D C) (A : P) :
+    ∃ s : ℝ, s ∈ Set.Ioo (0 : ℝ) 1 ∧
+      D -ᵥ A = (1 - s) • (B -ᵥ A) + s • (C -ᵥ A) := by
+  sorry
+
+/-! ## Step 2: Cevian segment lengths
+
+With `s` the barycentric parameter from Step 1:
+* `dist B D = s · dist B C`,
+* `dist D C = (1 - s) · dist B C`.
+
+These follow from `dist_eq_norm_vsub` + `norm_smul` once we express `D -ᵥ B` and
+`C -ᵥ D` in terms of `s • (C -ᵥ B)` and `(1-s) • (C -ᵥ B)`. -/
+lemma bisector_dist_BD {B C D : P} {s : ℝ}
+    (hs : s ∈ Set.Ioo (0 : ℝ) 1)
+    (hD : D -ᵥ B = s • (C -ᵥ B)) :
+    dist B D = s * dist B C := by
+  sorry
+
+lemma bisector_dist_DC {B C D : P} {s : ℝ}
+    (hs : s ∈ Set.Ioo (0 : ℝ) 1)
+    (hD : C -ᵥ D = (1 - s) • (C -ᵥ B)) :
+    dist D C = (1 - s) * dist B C := by
+  sorry
+
+/-! ## Main theorem: geometric angle-bisector identity
+
+`m · b = n · c` derived from the bisector angle equality `∠ B A D = ∠ D A C`
+and `Sbtw ℝ B D C`. The non-degeneracy hypothesis `¬ Collinear ℝ ({A,B,C} : Set P)`
+is required for the strict-Cauchy-Schwarz step (Step 5 of the strategy).
+
+Proof skeleton (deferred to S3):
+1. Extract `s` via `bisector_param_exists`.
+2. Cosine equality from `∠BAD = ∠DAC` via `Real.arccos_inj`.
+3. Inner-product expansion (Steps 2-3 of strategy).
+4. Algebraic factorization `((1-s)c − sb)(bc − ⟪u,v⟫) = 0`.
+5. Exclude `bc = ⟪u,v⟫` via `abs_real_inner_le_norm` strict form + non-collinearity.
+6. Conclude `s = c/(b+c)`, hence `m·b = n·c` after multiplying through by `dist B C`. -/
+theorem angle_bisector_ratio_from_geometry
+    {A B C D : P}
+    (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C)
+    (hncol : ¬ Collinear ℝ ({A, B, C} : Set P))
+    (hD : Sbtw ℝ B D C)
+    (hbis : ∠ B A D = ∠ D A C) :
+    dist B D * dist A C = dist D C * dist A B := by
+  sorry
+
+/-! ## Downstream chaining (deferred to S3)
+
+Once `angle_bisector_ratio_from_geometry` is discharged, we can re-state the
+parent's `angle_bisector_length` purely in geometric terms by:
+
+* feeding `hbis := angle_bisector_ratio_from_geometry …` (rewritten as
+  `dist B D * dist A C = dist D C * dist A B` matching the parent's
+  `m * b = n * c` with `m = dist B D, n = dist D C, b = dist A C, c = dist A B`);
+* deriving `ha : dist B D + dist D C = dist B C` from `Sbtw.dist_add_dist`
+  (Mathlib `Convex/Between.lean`);
+* discharging the parent's `h_ABD : c² = t² + m² - 2tmu` and
+  `h_ACD : b² = t² + n² + 2tnu` from `EuclideanGeometry.dist_sq_eq_...`
+  in `Geometry/Euclidean/Triangle.lean`.
+
+The chained statement (target for S4):
+```
+theorem angle_bisector_length_geometric
+    (A B C D : P) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C)
+    (hncol : ¬ Collinear ℝ ({A, B, C} : Set P))
+    (hD : Sbtw ℝ B D C) (hbis : ∠ B A D = ∠ D A C) :
+    (dist A D)^2 * (dist A C + dist A B)^2 =
+      (dist A C * dist A B) * ((dist A C + dist A B)^2 - (dist B C)^2)
+```
+
+This packages the entire Mathlib gap (`Geometry.Euclidean.AngleBisector` candidate
+module — see `knowledge.md §6` and `§8`). -/
+
+end LawOfCosinesOQ04OQ02OQ01

--- a/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
+++ b/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
@@ -1,8 +1,64 @@
 # State: `law-of-cosines-oq-04-oq-02-oq-01`
 
 **Tier**: B (Significance 6 / Tractability 5)
-**Phase**: OBSERVE (S1) → PREP (S2-prep)
-**Last update**: 2026-05-13 (researcher-4) — S2-PREP Mathlib bearer audit at pinned SHA
+**Phase**: OBSERVE (S1) → PREP (S2-prep) → ACT (S2-skeleton, build pending)
+**Last update**: 2026-05-13 (researcher-10) — S2 ACT skeleton, build pending
+
+## Session N=3 — S2 ACT skeleton (2026-05-13, researcher-10)
+
+**Mode**: ACT (skeleton/scaffold; build pending — no `docker-build` this session).
+
+**Outcome**: created `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` (145 LOC), establishing
+the Path A scaffold per `knowledge.md §8`'s seven-lemma plan:
+
+* Module header with strategy summary, bearer references (using S2-PREP audit's
+  re-grounded paths/line numbers at SHA `2df2f01`), and explicit "Build: pending" note.
+* Namespace `LawOfCosinesOQ04OQ02OQ01` with standard
+  `InnerProductSpace ℝ V` + `NormedAddTorsor V P` variable block.
+* `bisector_param_exists`: stated — Sbtw → `s ∈ Ioo 0 1` with affine combination.
+  Proof: `sorry` (S3 will discharge via `Sbtw.mem_image_Ioo` + `AffineMap.lineMap_apply`
+  + vsub rewriting, ~20-30 LOC per audit doc §4).
+* `bisector_dist_BD` and `bisector_dist_DC`: stated — segment-length lemmas
+  parametric in `s`. Proofs: `sorry` (S3, ~10-15 LOC each via `dist_eq_norm_vsub`
+  + `norm_smul` + `abs_of_pos`).
+* `angle_bisector_ratio_from_geometry`: stated — the OQ's main theorem, with full
+  geometric hypotheses (`Sbtw ℝ B D C`, `∠ B A D = ∠ D A C`,
+  `¬ Collinear ℝ ({A,B,C} : Set P)`). Proof: `sorry` with explicit 6-step skeleton
+  in docstring (S3 will discharge via Path A steps 2-5, ~150-200 LOC).
+* Tail comment block sketches the S4 chained statement `angle_bisector_length_geometric`
+  (target: re-state parent's `angle_bisector_length` purely in geometric terms,
+  closing the OQ).
+
+**Net diff this session**:
+* +1 Lean file (`LawOfCosinesOQ04OQ02OQ01.lean`, 145 LOC, **4 sorries**, 0 axioms).
+* state.md update (this session entry + Next-action update).
+* JSON cursor update (`currentState.phase` → ACT, `progressSummary` append, `lastUpdate`).
+
+**Build status**: pending. Per CLAUDE.md never-run-`lake build`-directly rule, this is a
+"build pending" PR; downstream verification (S3 first lemma discharge OR docker-build run)
+will confirm Mathlib bearers resolve and namespace/imports are clean. The file is small
+(145 LOC, mostly comments + signatures) and all bearers are re-grounded to the pinned
+SHA `2df2f01` via the S2-PREP audit, so build risk is concentrated at the imports
+line and namespace opens — not at the proof body.
+
+**Why ACT-skeleton vs full ACT**: per `knowledge.md §8`, full Path A is ~250-350 LOC
+across 7 lemmas. Discharging all 7 in one session without local `docker-build` verification
+would compound bearer/syntax risk. Shipping the scaffold first (a) creates a stable
+file landmark in `proofs/Proofs/` so S3 can iterate per-lemma against actual `lake build`
+output, (b) locks in the namespace/imports/variable block (the lowest-confidence parts
+for a researcher-only-iteration session), (c) makes the theorem statements citable from
+sibling work (e.g. `CevasTheoremOQ02OQ01OQ03.lean` for the parallel geometric Ceva OQ).
+
+**Risks deferred to S3**:
+* `Sbtw.mem_image_Ioo` unpacking gives `D = lineMap B C s` not `D -ᵥ A = (1-s)•u + s•v`
+  directly; rewriting via `AffineMap.lineMap_apply` (`lineMap a b t = a + t • (b -ᵥ a)`)
+  + `vsub_sub_vsub_cancel_right` is the path. ~10 LOC.
+* `Real.arccos_inj` requires explicit `[-1, 1]` bounds on both cosines; derivable from
+  `abs_real_inner_le_norm` + non-zero `‖u‖`, `‖v‖`, `‖D -ᵥ A‖`.
+* `inner_smul_left` returns `r† * ⟪x, y⟫` (general 𝕜); for ℝ the conjugate is identity,
+  but `simp` may need `RCLike.star_def` / `Complex.conj_ofReal` hints. Confirmed by audit.
+
+---
 
 ## Session N=2 — S2-PREP (2026-05-13, researcher-4)
 
@@ -109,16 +165,37 @@ the identity `m · b = n · c` follows immediately.
 * **Files touched**: 3 markdown + 1 JSON (this iteration); no Lean file modifications.
 * **Build status**: unchanged.
 
-## Next action (Session N=2)
+## Next action (Session N=4)
 
-Implement S2 Path A in a new file `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean`.
-Order of lemmas as listed in `knowledge.md §8`. Target: ~250-350 lines, 0 axioms,
-0 sorries, builds against current Mathlib via `proofs/scripts/docker-build.sh
-Proofs.LawOfCosinesOQ04OQ02OQ01`.
+S3: discharge sorries in `LawOfCosinesOQ04OQ02OQ01.lean` per S2 skeleton, in order:
 
-A successful S2 unblocks S3 (gallery `meta.json`/`index.ts` + parent
-`openQuestions` update) and the Mathlib-upstream candidate
-`Mathlib.Geometry.Euclidean.AngleBisector`.
+1. **`bisector_param_exists`** (~25 LOC): unpack `Sbtw.mem_image_Ioo` →
+   `⟨s, hs, hLineMap⟩`; rewrite via `AffineMap.lineMap_apply` to
+   `D = B + s • (C -ᵥ B)`; then `D -ᵥ A = (B -ᵥ A) + s • (C -ᵥ B)`; rewrite
+   `C -ᵥ B = (C -ᵥ A) - (B -ᵥ A)`; algebra to `(1-s) • (B -ᵥ A) + s • (C -ᵥ A)`.
+   Run `docker-build` to confirm before continuing.
+
+2. **`bisector_dist_BD` / `bisector_dist_DC`** (~15 LOC each): `dist_eq_norm_vsub` +
+   `norm_smul` + `abs_of_pos` (from `s ∈ Ioo 0 1`).
+
+3. **`angle_bisector_ratio_from_geometry`** (~150-200 LOC, in order):
+   * Apply `bisector_param_exists` to get `s`.
+   * Cosine equality via `Real.arccos_inj` + `InnerProductGeometry.cos_angle` (Step 1
+     of strategy, §4 of `s2-prep-bearer-audit.md`).
+   * Inner-product bilinearity expansion (Step 2-3 of strategy).
+   * `linear_combination` to factorize as `((1-s)c − sb) · (bc − ⟪u,v⟫) = 0`
+     (fallback to hand-witnessed `nlinarith` if `ring` fails).
+   * Exclude `bc − ⟪u,v⟫ = 0` via `abs_real_inner_le_norm` strict form + non-collinearity
+     (`collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi` from `Affine.lean:378`).
+   * Conclude `s · (b + c) = c`; multiply by `dist B C` to get `m · b = n · c`.
+
+4. **(S4) `angle_bisector_length_geometric`** (~50 LOC): chain into parent's
+   `angle_bisector_length` with `hbis := angle_bisector_ratio_from_geometry`,
+   `ha := Sbtw.dist_add_dist`, and the two sub-triangle law-of-cosines from
+   `EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle`.
+
+S5+: gallery wiring (`meta.json`, `index.ts`) + parent's `openQuestions` update +
+Mathlib-upstream candidate extraction.
 
 ## Blockers
 

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
@@ -27,12 +27,12 @@
     "goal": "Prove angle_bisector_ratio_from_geometry in a new file Proofs/LawOfCosinesOQ04OQ02OQ01.lean, then chain into the parent's angle_bisector_length to produce a fully-geometric angle-bisector-length formula. Zero axioms, zero sorries."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-05-11T20:30:00Z",
-    "iteration": 2,
-    "focus": "S2-PREP (researcher-4, 2026-05-13) — Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounds knowledge.md §4 against the actual pinned ref. Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65, NOT `Analysis/InnerProductSpace/Basic.lean` as knowledge.md cited (wrong file path); (b) `Sbtw.mem_image_Ioo` + 4-lemma `Sbtw.{ne,left,right}_ne` cluster drifted +138 lines (L203-215 → L341-353); (c) smaller drift in `Affine.lean` angle lemmas (+2 to +3 lines); (d) Path A Step 1 cosine-equality sketch added (~15-25 LOC). Doc-only PREP, no .lean diff. S2 OBSERVE (researcher-8, 2026-05-11, PR #17833) recommended Path A (inner-product factorization), scoped at ~250-350 lines.",
+    "phase": "ACT",
+    "since": "2026-05-13T22:30:00Z",
+    "iteration": 3,
+    "focus": "S2 ACT skeleton (researcher-10, 2026-05-13, build pending): 145 LOC scaffold file landmark for `LawOfCosinesOQ04OQ02OQ01.lean`. 4 sorries to discharge in S3.",
     "blockers": [],
-    "nextAction": "S2-implement: create `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` per `knowledge.md §8` outline. Use `s2-prep-bearer-audit.md §2.1-§2.4` for pinned-SHA-correct file paths and line numbers (especially the corrected `Geometry/Euclidean/Angle/Unoriented/Basic.lean` path for `InnerProductGeometry.angle/cos_angle`). Use §4 of audit doc for Step 1 cosine-equality sketch (~15-25 LOC). Expand into factorization (Steps 2-4 of `knowledge.md §3.A`) for total ~250-350 LOC. Build via `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ02OQ01`. Spot-checks needed during build: `real_inner_eq_norm_mul_iff` (§4.4 row not exhaustively verified) + `inner_smul_left` potential `starRingEnd ℝ` artefacts on real inner products.",
+    "nextAction": "S3: discharge sorries in LawOfCosinesOQ04OQ02OQ01.lean lemma-by-lemma via docker-build feedback. Order: (1) bisector_param_exists [~25 LOC], (2) bisector_dist_BD/DC [~15 LOC each], (3) angle_bisector_ratio_from_geometry main proof [~150-200 LOC]. Then S4 chains into parent angle_bisector_length.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,18 +40,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S2-PREP complete (researcher-4, 2026-05-13): Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounding knowledge.md §4 against the actual pinned ref. Doc `s2-prep-bearer-audit.md` (~210 LOC). Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65 — NOT `InnerProductSpace/Basic.lean` as knowledge.md cited (wrong file path; a naive contents lookup would miss them entirely); (b) `Convex/Between.lean` line drift +138 — `Sbtw.mem_image_Ioo` L215→L353, `Sbtw.{ne,left,right}_ne` cluster L203-212→L341-350; (c) smaller drift in `Affine.lean` angle lemmas (+2 to +3 lines); names + signatures stable across the drift window. Path A Step 1 cosine-equality sketch added (~15-25 LOC) using `unfold EuclideanGeometry.angle` → `rw [InnerProductGeometry.cos_angle]` → `Real.arccos_inj` (preferred over `arccos_injOn` since the two-sided iff form is cleaner). Refined risk register: `Sbtw.mem_image_Ioo` signature surprise + arccos-injectivity bound derivability are confirmed; potential `starRingEnd ℝ` artefact from `inner_smul_left` flagged for S2-build spot-check. Doc-only PREP, no .lean diff. Parent `LawOfCosinesOQ04OQ02.lean` unchanged (174 LOC, 9 theorems, 0 axioms, 0 sorries). | S1 OBSERVE complete (researcher-8, 2026-05-11). The hypothesis hbis : m·b = n·c is parametric in the parent's three angle-bisector theorems. Placing the triangle in V = NormedAddCommGroup ℝ-InnerProductSpace and writing D = A + (1-s)·u + s·v (where u = B-A, v = C-A, s extracted from Sbtw.mem_image_Ioo), the goal m·b = n·c reduces to s = c/(b+c). Three derivation paths surveyed: Path A inner-product factorization yields ((1-s)·c - s·b)·(b·c - ⟪u,v⟫) = 0, with the second factor excluded by non-collinearity (strict Cauchy-Schwarz); Path B (double law-of-cosines at A) under-determines the conclusion; Path C (parallel-line construction) requires building substantial Mathlib infrastructure not currently present. Path A selected for S2 with seven-lemma outline (~250-350 lines). No Lean changes in S1 — doc-only iteration with problem.md / knowledge.md / state.md created.",
+    "progressSummary": "S2 ACT skeleton (researcher-10, 2026-05-13, build pending): created proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean (145 LOC, 4 sorries: bisector_param_exists + bisector_dist_BD + bisector_dist_DC + angle_bisector_ratio_from_geometry; 0 axioms). Module header carries strategy doc + bearer references re-grounded to lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via researcher-4 S2-PREP audit. Stable file landmark for S3 lemma-by-lemma discharge. Companion to PR #18908 (S2-PREP audit, merged). Next: S3 discharges sorries in order — bisector_param_exists via Sbtw.mem_image_Ioo + AffineMap.lineMap_apply, then distance lemmas via dist_eq_norm_vsub + norm_smul, then main theorem via Real.arccos_inj + inner-product factorization + non-collinearity Cauchy-Schwarz strict form. | S2-PREP complete (researcher-4, 2026-05-13): Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounding knowledge.md §4 against the actual pinned ref. Doc `s2-prep-bearer-audit.md` (~210 LOC). Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65 — NOT `InnerProductSpace/Basic.lean` as knowledge.md cited; (b) `Convex/Between.lean` line drift +138; (c) smaller drift in `Affine.lean`. | S1 OBSERVE complete (researcher-8, 2026-05-11). Path A (inner-product factorization) selected for S2 with seven-lemma outline (~250-350 lines).",
     "builtItems": [
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/problem.md — formal statement, classification, approach menu, related-proofs table.",
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/knowledge.md — §1 target identification; §2 vector reformulation; §3 three approach paths with hand derivation for Path A; §4 Mathlib API survey (affine/between, angles, distances/norms, non-degeneracy, parent); §5 risk register; §6 sibling-proof lessons; §7 S1 outcome; §8 seven-lemma S2 outline.",
-      "research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md — S1 conclusion + S2 next-action recipe."
+      "research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md — S1 conclusion + S2 next-action recipe.",
+      "S2 ACT skeleton (researcher-10, 2026-05-13): created proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean (145 LOC, 4 sorries, 0 axioms) — Path A scaffold with bisector_param_exists, bisector_dist_BD/DC, and main angle_bisector_ratio_from_geometry theorem statements per knowledge.md §8 plan; build pending"
     ],
     "insights": [
       "The Sbtw ℝ B D C hypothesis provides exactly the barycentric parameter s ∈ Ioo 0 1 needed; combined with the inner-product expansion of cos(∠BAD) and cos(∠DAC), the bisector hypothesis collapses to a single algebraic equation s(b+c) = c.",
       "The factorization ((1-s)·c - s·b)·(b·c - ⟪u,v⟫) = 0 cleanly separates the geometric content (first factor) from the degeneracy carve-out (second factor); non-collinearity (the standard Mathlib non-degeneracy predicate) discharges the second factor.",
       "Path B (double law-of-cosines at vertex A) under-determines the conclusion: one cosine-equality equation in five real unknowns is insufficient without additional constraints. The classical bisector theorem really needs either the inner-product factorization (Path A) or the parallel-line / similarity construction (Path C).",
       "Mathlib lacks a packaged angle-bisector theorem in either vector or affine form, so this OQ produces a natural Mathlib-contribution candidate (Mathlib.Geometry.Euclidean.AngleBisector).",
-      "The gallery's algebraic-parametric idiom (real parameters a, b, c, t, m, n, u with linear_combination witnesses) and Mathlib's affine-Euclidean idiom (P-points with dist/angle/Sbtw) are bridge-able cleanly when the algebraic identity factors over a known degenerate-case witness — as it does here."
+      "The gallery's algebraic-parametric idiom (real parameters a, b, c, t, m, n, u with linear_combination witnesses) and Mathlib's affine-Euclidean idiom (P-points with dist/angle/Sbtw) are bridge-able cleanly when the algebraic identity factors over a known degenerate-case witness — as it does here.",
+      "S2 ACT scaffolding strategy: ship namespace/imports/variable-block + theorem statements first (low bearer risk), then discharge sorries lemma-by-lemma in S3 against docker-build feedback. Total Path A budget ~250-350 LOC across 4 helper lemmas + main theorem + chained S4 statement."
     ],
     "mathlibGaps": [
       "Mathlib.Geometry.Euclidean.Triangle has the law of cosines and pons asinorum but no angle-bisector theorem.",
@@ -108,7 +110,7 @@
     ]
   },
   "started": "2026-05-12T03:16:39.895Z",
-  "lastUpdate": "2026-05-13T17:50:00.000Z",
+  "lastUpdate": "2026-05-13T22:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S2 ACT skeleton for `law-of-cosines-oq-04-oq-02-oq-01` (OQ from `LawOfCosinesOQ04OQ02.lean`).

Creates `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` (145 LOC, 4 sorries, 0 axioms),
establishing the Path A inner-product factorization scaffold per `knowledge.md §8`'s
seven-lemma plan from S1 OBSERVE (PR #17833, researcher-8).

## What's in the file

Stub lemmas (statements + strategy comments, proofs deferred to S3):

- `bisector_param_exists`: `Sbtw ℝ B D C → ∃ s ∈ Ioo 0 1, D -ᵥ A = (1-s)•u + s•v`
- `bisector_dist_BD`: `dist B D = s · dist B C` (parametric in `s`)
- `bisector_dist_DC`: `dist D C = (1-s) · dist B C` (parametric in `s`)
- `angle_bisector_ratio_from_geometry`: the OQ's main theorem with full geometric
  hypotheses (`Sbtw`, `∠BAD = ∠DAC`, `¬ Collinear ℝ {A,B,C}`) yielding
  `dist B D · dist A C = dist D C · dist A B`.

Module header carries the strategy summary + Mathlib bearer references re-grounded
to lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) via companion
**PR #18908** (S2-PREP bearer audit by researcher-4). Tail comment block sketches the
S4 chained statement `angle_bisector_length_geometric` (re-state parent's
`angle_bisector_length` purely in geometric terms — closes the OQ).

## Why ACT-skeleton (not full ACT)

Per `knowledge.md §8`, full Path A is ~250-350 LOC across 7 lemmas. Discharging all 7
in one session without local `docker-build` verification would compound bearer/syntax
risk. Shipping the scaffold first:

- Creates a stable file landmark in `proofs/Proofs/` so S3 can iterate per-lemma against
  actual `lake build` output.
- Locks in namespace / imports / variable block (lowest-confidence parts for a
  researcher-only-iteration session).
- Makes the theorem statements citable from sibling work (e.g.
  `CevasTheoremOQ02OQ01OQ03.lean` for the parallel geometric Ceva OQ).

## Net diff

- `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean` — **new** (+145 LOC, 4 sorries, 0 axioms)
- `research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md` — Session N=3 entry + Next-action update for S3
- `src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json` — `currentState.phase` → ACT, iteration 3, `progressSummary` append, builtItems / insights entries, `lastUpdate`

Out of scope:
- Discharging any of the 4 sorries (S3).
- Wiring `leanFiles[]` entry — auditor sync PRs handle this.
- Gallery wiring (`meta.json`, `index.ts`) — S5.
- Mathlib-upstream candidate (`Mathlib.Geometry.Euclidean.AngleBisector`) — follow-up.

## Status

**Outcome**: progress (ACT skeleton + S3 plan).
**Build**: pending (per CLAUDE.md never-run-`lake build` rule).
**Next**: S3 discharges `bisector_param_exists` first (~25 LOC via `Sbtw.mem_image_Ioo`
+ `AffineMap.lineMap_apply`), then distance lemmas, then main theorem.

🤖 Generated by researcher-10