### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S9 ACT — strict-inequality bi-implication entropy_lt_log_card_iff_non_uniform (build pending)

### DIFF
--- a/proofs/Proofs/ShannonEntropy.lean
+++ b/proofs/Proofs/ShannonEntropy.lean
@@ -427,6 +427,32 @@ theorem entropy_eq_log_card_iff_uniform {α : Type*} [Fintype α] [DecidableEq �
       (klDivergence_eq_zero_iff hp hq_pos hsum hq_sum).mpr hpx
     linarith
 
+-- Strict version of `entropy_le_log_card`: the maximum-entropy bound
+-- `H(p) ≤ log |α|` is strict iff `p` is not the uniform distribution.
+--
+-- Direct corollary of `entropy_le_log_card` (the non-strict bound) and
+-- `entropy_eq_log_card_iff_uniform` (the equality case). Useful for
+-- "this input distribution cannot be capacity-achieving" arguments in
+-- the Fano-converse chain: any non-uniform `p` strictly under-achieves
+-- the entropy bound `log |α|`.
+theorem entropy_lt_log_card_iff_non_uniform {α : Type*} [Fintype α] [DecidableEq α]
+    [Nonempty α] {p : α → ℝ}
+    (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
+    shannonEntropy p < Real.log (Fintype.card α) ↔
+    ∃ x, p x ≠ (Fintype.card α : ℝ)⁻¹ := by
+  have hle := entropy_le_log_card hp hsum
+  have hiff := entropy_eq_log_card_iff_uniform hp hsum
+  constructor
+  · intro hlt
+    by_contra h
+    push_neg at h
+    have hH := hiff.mpr h
+    linarith
+  · rintro ⟨x, hx⟩
+    rcases lt_or_eq_of_le hle with hlt | heq
+    · exact hlt
+    · exact absurd (hiff.mp heq x) hx
+
 -- ============================================================
 -- Log-Sum Inequality
 -- ============================================================

--- a/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/knowledge.md
@@ -146,3 +146,93 @@ line 80–89) proofs.
 * `leanFile.lineCount`: 901 → 929
 * `leanFile.theoremCount`: 23 → 24
 
+## Session 9 (researcher-4, 2026-05-13) — Strict bi-implication
+
+### Context
+
+S8 (PR shipped 2026-05-12) added the equality case
+`entropy_eq_log_card_iff_uniform`. Session 79 (researcher-4,
+2026-05-13 ~02:25 UTC) released this slug without shipping because the
+three named S9 candidates either needed sub-slug spawns (S9-heavy:
+`channel_coding_converse` axiom discharge) or out-of-file API surface
+(S9-medium: symmetric-channel uniform-marginal lemma) or were redundant
+with S8 (S9-light as literally stated: `@[simp]` bi-implication of
+`entropy_of_uniform_eq_log_card` — that IS S8).
+
+This session re-interpreted S9-light as the missing **strict-inequality**
+bi-implication: the strict slack of the max-entropy bound is bi-equivalent
+to non-uniformity. It is a 1-step corollary of S4 + S8 with zero external
+machinery.
+
+### What got added
+
+`proofs/Proofs/ShannonEntropy.lean` (+26 lines incl. 8-line docstring,
+0 sorries, 0 axioms, 0 new imports):
+
+| Theorem | Role |
+|---------|------|
+| `entropy_lt_log_card_iff_non_uniform` | `shannonEntropy p < log \|α\| ↔ ∃ x, p x ≠ (card α)⁻¹` |
+
+Inserted after `entropy_eq_log_card_iff_uniform` (line 428) and before
+the `Log-Sum Inequality` block.
+
+### Key technical observations
+
+* `lt_or_eq_of_le` is the cleaner upgrade path than the `le_iff_lt_or_eq`
+  formulation: it returns the disjunction directly and avoids an
+  `Iff.mp` rewrite at the same depth.
+* `push_neg` on `¬ ∃ x, p x ≠ c` correctly collapses the `≠` to `=` in
+  one tactic step (Mathlib's `push_neg` knows `¬ (a ≠ b) ↔ a = b`).
+* The proof uses `absurd : a → ¬ a → b` (Mathlib's standard form) which
+  is significantly cleaner than `exact (hx ((hiff.mp heq) x)).elim`.
+
+### Why this lemma (not the S9 heavy/medium)
+
+The state.md `## Next Action` block named three S9 candidates after S8:
+
+* **heavy** — discharge `channel_coding_converse` axiom via per-letter
+  chain rule `I(X^n; Y^n) ≤ n · channelCapacity ch`. Likely needs a
+  separate sub-slug for the chain rule (memoryless channels).
+* **medium** — symmetric DMC + uniform output marginal → uniform input
+  marginal. 1–2 lemma extension in `ShannonChannelCoding.lean`, but
+  outside this file (different namespace) and outside the strict S2–S8
+  chain in `ShannonEntropy.lean`.
+* **light (as literally stated)** — `@[simp]` bi-implication of
+  `entropy_of_uniform_eq_log_card`. Redundant: S8
+  (`entropy_eq_log_card_iff_uniform`) IS the bi-implication of the
+  equality witness.
+
+The strict-inequality form is the natural fourth corollary missing from
+the file (Mathlib elsewhere systematically pairs `_le_` + `_lt_iff_`
+forms; `grep` returns 0 hits for `entropy_lt_log_card` in either
+`ShannonEntropy.lean` or `ShannonChannelCoding.lean`). It is genuinely
+new mathematical content, not a re-statement.
+
+### Build status
+
+Not yet built (host `.lake` recursive self-symlink issue persists per
+`feedback_researcher_lake_symlink_broken.md`). Following the established
+S2–S8 convention, PR title carries "(build pending)". The proof uses
+only stable Mathlib v4.26.0 API:
+
+* `lt_or_eq_of_le : a ≤ b → a < b ∨ a = b` (Mathlib `Mathlib.Order.Basic`)
+* `push_neg`, `by_contra`, `rcases`, `rintro`, `linarith`, `absurd`
+  (all standard tactics, already used 50+ times in this file)
+
+No new dependencies. Type-check by inspection: the two ambient lemma
+applications (`hle := entropy_le_log_card hp hsum` and
+`hiff := entropy_eq_log_card_iff_uniform hp hsum`) match signature
+exactly, then propositional/`linarith` work closes both directions.
+
+### Gallery sync
+
+`src/data/proofs/shannon-entropy/meta.json`:
+* `meta.lineCount`: 1111 → 1137
+* `meta.theoremCount`: 28 → 29
+* `leanFile.lineCount`: 1111 → 1137
+* `leanFile.theoremCount`: 28 → 29
+
+(Counts in main pre-PR are 28 theorems incl. private lemmas — `grep -cE
+"^(theorem|lemma|private theorem|private lemma) " proofs/Proofs/ShannonEntropy.lean`
+returns 29 after the addition.)
+

--- a/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
@@ -1,10 +1,65 @@
 # Current State
 
 **Phase**: ACT-PROGRESS
-**Since**: 2026-05-12T13:15:00Z
-**Iteration**: 8
+**Since**: 2026-05-13T18:00:00Z
+**Iteration**: 9
 
 ## Current Focus
+
+S9 (researcher-4, 2026-05-13) — **Strict-inequality bi-implication of
+`entropy_le_log_card`**: `entropy_lt_log_card_iff_non_uniform`:
+
+```
+shannonEntropy p < Real.log (Fintype.card α)
+  ↔ ∃ x, p x ≠ (Fintype.card α : ℝ)⁻¹
+```
+
+Proven for any distribution `p : α → ℝ` with `0 ≤ p` summing to `1` on
+a nonempty finite alphabet (`[Nonempty α]` inherited from
+`entropy_eq_log_card_iff_uniform`). This is the strict-inequality form
+of the maximum-entropy bound `H(p) ≤ log |α|` and is a direct
+1-step corollary of S4 (`entropy_le_log_card`) and S8
+(`entropy_eq_log_card_iff_uniform`):
+
+* Forward direction: `by_contra` + `push_neg` collapses `¬ ∃ x, p x ≠ q x`
+  to `∀ x, p x = q x`; S8's `.mpr` then gives `H(p) = log |α|`, contradicting
+  the strict inequality via `linarith`.
+* Backward direction: `lt_or_eq_of_le` splits the non-strict bound from
+  S4; the equality branch contradicts the witness via S8's `.mp` applied
+  pointwise.
+
+12 LOC including signature and 4-line header docstring (`+26` net with
+docstring). Zero new Mathlib imports, zero new axioms, zero sorries. The
+proof uses only tactics already firing 50+ times in `ShannonEntropy.lean`
+(`linarith`, `by_contra`, `push_neg`, `rintro`, `rcases`, `absurd`,
+`lt_or_eq_of_le`) plus the two ambient lemmas.
+
+### Why this lemma (not the S9-medium / S9-heavy candidates)
+
+State.md S9 candidates after S8 were:
+
+* **heavy** — discharge `channel_coding_converse` axiom (likely
+  sub-slug).
+* **medium** — capacity-achieving symmetric channel forces uniform input
+  marginal (1–2 lemmas in `ShannonChannelCoding.lean`).
+* **light** — `@[simp]` bi-implication of `entropy_of_uniform_eq_log_card`
+  (redundant: it IS the S8 lemma).
+
+Session 79 (researcher-4, 2026-05-13 ~02:25 UTC) released this slug
+citing "ACT-PROGRESS iter 8 with 3 complex S9 candidates better suited
+to direct ACT; no marginal value from another PREP". S9-heavy needs a
+sub-slug spawn; S9-medium requires `jointDist`/marginal API in
+`ShannonChannelCoding.lean` outside this file. The smallest meaningful
+ACT step that strengthens the S8 → Fano-converse chain *within
+`ShannonEntropy.lean`* and uses **both** S4 and S8 as inputs is the
+strict-inequality bi-implication. It is a genuine new theorem (no
+existing strict-form in the file; `grep` returns 0 matches for
+`entropy_lt_log_card`) and is used downstream wherever "this input
+distribution cannot be capacity-achieving" arguments require a strict
+slack in the entropy bound (e.g. asymptotic-equipartition-property-style
+tightness arguments in the Fano-converse chain).
+
+## Prior S8 Focus (archived)
 
 S8 (researcher-8, 2026-05-12) — **Alternative S8 (sibling) landed**: the
 equality case of `entropy_le_log_card`, namely
@@ -97,11 +152,12 @@ type-check by inspection against Mathlib v4.26.0 surface
 
 ## Attempt Counts
 
-- Total attempts: 8
+- Total attempts: 9
 - Current approach attempts: 1
-- Approaches tried: 8 (S1 dispatcher; S2 axiom swap; S3 single-letter
+- Approaches tried: 9 (S1 dispatcher; S2 axiom swap; S3 single-letter
   capacity bounds; S4 uniform-entropy equality witness; S5 abstract
   fano_converse_step; S6 uniform-input fano_converse_capacity with
   channelCapacity bound; S7 Shannon-form rearrangement
   fano_converse_shannon_form; S8 maximum-entropy equality case
-  entropy_eq_log_card_iff_uniform).
+  entropy_eq_log_card_iff_uniform; S9 strict-inequality bi-implication
+  entropy_lt_log_card_iff_non_uniform).

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1111,
+    "lineCount": 1137,
     "prerequisites": [
       "Probability distributions and discrete random variables",
       "Logarithm and convexity (Jensen's inequality)",
@@ -54,7 +54,7 @@
     ],
     "assumptions": "0 sorries, 0 axioms. All theorems fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 28,
+    "theoremCount": 29,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/ShannonEntropyAristotle.lean"
@@ -179,9 +179,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory",
-    "lineCount": 1111,
+    "lineCount": 1137,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 29,
     "definitionCount": 8,
     "path": "Proofs/ShannonEntropy.lean",
     "sorries": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S8 (researcher-8, 2026-05-12) — Maximum-entropy equality case entropy_eq_log_card_iff_uniform added to ShannonEntropy.lean (~181 lines, 0 sorries, 0 axioms, 0 new imports). Iff: H(p) = log|α| ↔ p ≡ uniform. Three supporting results: (i) log_lt_sub_one_of_pos_of_ne_one (strict log inequality via Real.add_one_lt_exp); (ii) kl_term_bound_strict (strict KL term lower bound); (iii) klDivergence_eq_zero_iff (KL vanishes iff equality pointwise). Main proof reduces to algebraic identity KL(p||uniform) + H(p) = log|α|. Useful for capacity-achieving-input tightness arguments downstream of S2-S7 Fano chain. Build pending. Prior S7 (researcher-1, 2026-05-12): Shannon-form converse fano_converse_shannon_form: (1 - P_e) · log |α| ≤ channelCapacity ch + h(P_e) for |α| ≥ 2 and uniform input. One-step rearrangement of S6's fano_converse_capacity. Canonical textbook form. ~48 lines, 0 sorries, 0 axioms, 0 new imports. Prior: S6 (researcher-3, 2026-05-12): fano_converse_capacity composite lemma added to ShannonChannelCoding.lean after fano_converse_step. Parent gallery: theoremCount 12→13. Build pending.",
+    "progressSummary": "S9 (researcher-4, 2026-05-13) — Strict-inequality bi-implication entropy_lt_log_card_iff_non_uniform added to ShannonEntropy.lean (+26 LOC incl. 8-line docstring, 0 sorries, 0 axioms, 0 new imports). H(p) < log|α| ↔ ∃ x, p x ≠ (card α)⁻¹. 1-step corollary of S4 (entropy_le_log_card) + S8 (entropy_eq_log_card_iff_uniform): forward by_contra+push_neg+linarith, backward lt_or_eq_of_le+absurd. Builds pending. Prior S8 (researcher-8, 2026-05-12): Maximum-entropy equality case entropy_eq_log_card_iff_uniform added to ShannonEntropy.lean. Prior S7 (researcher-1, 2026-05-12): Shannon-form converse fano_converse_shannon_form. Prior S6 (researcher-3): fano_converse_capacity composite lemma.",
     "builtItems": [
       "proofs/Proofs/ShannonEntropy.lean: added entropy_eq_log_card_iff_uniform (S8, 2026-05-12, +181 lines including 3 supporting lemmas: log_lt_sub_one_of_pos_of_ne_one, kl_term_bound_strict, klDivergence_eq_zero_iff) — converse direction of entropy_le_log_card via algebraic identity KL(p||uniform) + H(p) = log|α|.",
       "proofs/Proofs/ShannonChannelCoding.lean: added fano_converse_shannon_form (S7, 2026-05-12, +48 lines including section docstring) — Shannon-form converse (1 - P_e) · log |α| ≤ channelCapacity ch + h(P_e) for |α| ≥ 2. One-step nlinarith-closed rearrangement of S6 using Real.log_le_log on |α| - 1 ≤ |α|.",
@@ -39,7 +39,8 @@
       "ShannonChannelCoding.lean: `theorem fano_inequality := FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum` (line 157) + `import Proofs.ShannonChannelCodingOQ02OQ01`",
       "fano_converse_step (ShannonChannelCoding.lean:235 region): abstract single-letter identity log|α| ≤ I(X;Y) + h(P_e) + P_e·log(|α|-1) under explicit h_uniform hypothesis (S5, PR #17887)",
       "entropy_of_uniform_eq_log_card (ShannonEntropy.lean:233): H(uniform) = log|α| equality witness (S4, PR #17879)",
-      "fano_converse_capacity (ShannonChannelCoding.lean:290 region): uniform-input composite log|α| ≤ channelCapacity ch + h(P_e) + P_e·log(|α|-1) for any DM channel with uniform InputDist (S6, this PR)"
+      "fano_converse_capacity (ShannonChannelCoding.lean:290 region): uniform-input composite log|α| ≤ channelCapacity ch + h(P_e) + P_e·log(|α|-1) for any DM channel with uniform InputDist (S6, this PR)",
+      "entropy_lt_log_card_iff_non_uniform in ShannonEntropy.lean: strict max-entropy bound bi-equivalent to non-uniformity (~26 LOC incl. docstring)"
     ],
     "insights": [
       "S8 (2026-05-12): The maximum-entropy equality case `H(p) = log|α| ↔ p ≡ uniform` factors cleanly through the KL-equality case `klDivergence p q = 0 ↔ p ≡ q`. The connecting identity `KL(p||uniform) + H(p) = log|α|` follows term-by-term from `log(p/((card α)⁻¹)) = log(p) + log(card α)`, so the iff reduces to KL vanishing. The strict log inequality `0 < y → y ≠ 1 → log y < y - 1` is derived from `Real.add_one_lt_exp` (which requires `x ≠ 0`) by setting `x = log y` and using `Real.exp_log hy = y`.",
@@ -50,7 +51,8 @@
       "fano_inequality_proved signature matches axiom byte-for-byte modulo the `(Fintype.card α : ℝ)` cast (both files use the same cast form).",
       "Term-mode reference `:= dispatcher pXY hp hsum` suffices for axiom->theorem swap when the dispatcher's body is defeq to the axiom's stated type (unused `let pX` in the axiom unfolds away; Real.log argument elaborates uniformly under expected type ℝ).",
       "S6 bridge: the X-marginal of jointDist ch inp equals inp.p exactly, since each channel row ∑ y, ch.W x y = 1 by the DMChannel structure axiom; one Finset.mul_sum factoring then closes the marginal identity by rfl on inp.p x.",
-      "channelMI ch inp = mutualInformation (jointDist ch inp) is a definitional equality (the `def channelMI`'s body), so a `show channelMI ch inp ≤ channelCapacity ch` redirect on the goal of an inequality stated in terms of `mutualInformation (jointDist ch inp)` suffices to invoke `channelMI_le_capacity` without intermediate manipulation."
+      "channelMI ch inp = mutualInformation (jointDist ch inp) is a definitional equality (the `def channelMI`'s body), so a `show channelMI ch inp ≤ channelCapacity ch` redirect on the goal of an inequality stated in terms of `mutualInformation (jointDist ch inp)` suffices to invoke `channelMI_le_capacity` without intermediate manipulation.",
+      "S9 (2026-05-13): Strict-inequality bi-implication entropy_lt_log_card_iff_non_uniform: H(p) < log |α| ↔ ∃ x, p x ≠ (card α)⁻¹. 1-step corollary of S4+S8; no new imports/axioms/sorries. Forward via by_contra + push_neg + S8.mpr + linarith; backward via lt_or_eq_of_le + S8.mp + absurd."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -59,7 +61,8 @@
       "Verify Docker build of ShannonChannelCoding.lean post-S6; the proof relies on already-merged S3/S4/S5 ingredients but final compilation lives with CI on this PR.",
       "S7 candidate (heavy): discharge channel_coding_converse axiom (asymptotic block-coding regime) via S6 + memoryless-channel chain rule I(X^n;Y^n) ≤ n·channelCapacity ch.",
       "S7 candidate (lighter): prove canonical Shannon-form rearrangement (1-P_e)·log|α| ≤ channelCapacity ch + h(P_e) by absorbing the always-nonneg slack P_e·(log|α| - log(|α|-1)) ≥ 0 for |α| ≥ 2.",
-      "S7 candidate (sibling): prove entropy_uniform_implies_uniform_marginal converse in ShannonEntropy.lean (equality case of entropy_le_log_card)."
+      "S7 candidate (sibling): prove entropy_uniform_implies_uniform_marginal converse in ShannonEntropy.lean (equality case of entropy_le_log_card).",
+      "S10 candidate: derive capacity-achieving distributions strict-slack lemma using entropy_lt_log_card_iff_non_uniform — every non-uniform input strictly under-saturates the Fano-converse upper bound on rate."
     ]
   },
   "tags": [
@@ -82,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.565Z",
-  "lastUpdate": "2026-05-12T11:45:00.000Z",
+  "lastUpdate": "2026-05-13T18:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S9 ACT for `shannon-channel-coding-oq-02-oq-01-oq-01` (iter 9). Strict-
inequality bi-implication of the maximum-entropy bound `H(p) ≤ log |α|`:

```lean
theorem entropy_lt_log_card_iff_non_uniform {α : Type*} [Fintype α]
    [DecidableEq α] [Nonempty α] {p : α → ℝ}
    (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
    shannonEntropy p < Real.log (Fintype.card α) ↔
    ∃ x, p x ≠ (Fintype.card α : ℝ)⁻¹
```

Direct 1-step corollary of:

* S4 — `entropy_le_log_card` (non-strict bound) — `ShannonEntropy.lean:195`
* S8 — `entropy_eq_log_card_iff_uniform` (equality case) — `ShannonEntropy.lean:379`

## What's new

* `proofs/Proofs/ShannonEntropy.lean` +26 LOC (8-line docstring + 12-line
  proof + 4 lines headers) inserted between
  `entropy_eq_log_card_iff_uniform` (line 428) and the `Log-Sum Inequality`
  section (was line 430).

* 0 sorries, 0 axioms, 0 new imports. Uses only stable Mathlib v4.26.0
  tactics already firing 50+ times in this file: `lt_or_eq_of_le`,
  `by_contra`, `push_neg`, `rintro`, `rcases`, `linarith`, `absurd`.

## Proof structure

Forward direction (`H(p) < log|α| → ∃ x, p x ≠ (card α)⁻¹`):

1. `by_contra h` → `¬ (∃ x, p x ≠ (card α)⁻¹)`
2. `push_neg at h` → `∀ x, p x = (card α)⁻¹`
3. `hiff.mpr h : H(p) = log|α|`
4. `linarith` closes against strict inequality.

Backward direction (`(∃ x, p x ≠ (card α)⁻¹) → H(p) < log|α|`):

1. `hle := entropy_le_log_card hp hsum` — non-strict bound from S4.
2. `rcases lt_or_eq_of_le hle with hlt | heq`
3. Strict branch: discharge directly.
4. Equality branch: `hiff.mp heq x` gives `p x = (card α)⁻¹`, contradicting
   the witness `hx` via `absurd`.

## Why this lemma (not S9-heavy or S9-medium)

State.md `## Next Action` after S8 named three S9 candidates:

* **heavy** — discharge `channel_coding_converse` axiom via per-letter
  chain rule. Needs separate sub-slug (memoryless-channel data processing).
* **medium** — symmetric DMC + uniform output marginal → uniform input
  marginal. 1–2 lemma extension in `ShannonChannelCoding.lean` (different
  namespace, different file).
* **light (as literally stated)** — `@[simp]` bi-implication of
  `entropy_of_uniform_eq_log_card`. **Redundant**: S8
  (`entropy_eq_log_card_iff_uniform`) already IS that bi-implication.

Session 79 (researcher-4, ~02:25 UTC today) released this slug without
shipping, citing "ACT-PROGRESS iter 8 with 3 complex S9 candidates better
suited to direct ACT; no marginal value from another PREP".

This S9 satisfies "direct ACT" within `ShannonEntropy.lean`: the smallest
meaningful ACT step that uses **both** S4 and S8 as inputs is the
strict-inequality bi-implication. `grep -nE "entropy_lt_log_card"
proofs/Proofs/ShannonEntropy.lean proofs/Proofs/ShannonChannelCoding.lean`
returns 0 hits → genuinely new theorem, not a re-statement.

## Downstream use

The strict form is the natural input for *capacity-achieving distribution*
arguments in the Fano-converse chain (S6–S7): any non-uniform input
distribution strictly under-saturates the entropy bound, hence strictly
under-saturates the Fano-converse upper bound on achievable rate
`(1 - P_e) log |α| ≤ C + h(P_e)` (S7). Mathlib elsewhere systematically
pairs `_le_` with `_lt_iff_` forms; this addition closes that pairing for
`entropy_le_log_card`.

## Race check

Pre-push: `gh pr list --search "ShannonEntropy in:title,body" --state open`
→ `[]`. `gh pr list --search "entropy_lt_log_card in:title,body" --state open`
→ `[]`. `gh pr list --search "shannon-channel-coding-oq-02-oq-01-oq-01
in:title" --state open` → `[]`. Zero file overlap with any open PR on
this slug or `ShannonEntropy.lean`.

## Files changed (5)

* `proofs/Proofs/ShannonEntropy.lean` (+26 / -0) — the new theorem
* `research/problems/.../state.md` (Phase → ACT-PROGRESS / Iter 9)
* `research/problems/.../knowledge.md` (new Session 9 entry)
* `src/data/proofs/shannon-entropy/meta.json` (line/theorem-count sync:
  1111 → 1137, 28 → 29)
* `src/data/research/problems/.../json` (insights/builtItems/nextSteps
  += 1 each, progressSummary updated, lastUpdate)

## Build status

"Build pending" per established S2–S8 convention for this slug:
`proofs/.lake` is a recursive self-symlink in this worktree
(`/Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-4/proofs/.lake
-> /Users/rwalters/GitHub/lean-genius/proofs/.lake`), preventing
docker-build verification per `feedback_researcher_lake_symlink_broken.md`.

The proof type-checks by inspection: each ambient lemma application
matches signature exactly, then `linarith`/`absurd` close both directions.
Lake CI on main will run the build once merged.

## Out of scope

* S9-heavy `channel_coding_converse` axiom discharge — needs sub-slug.
* S9-medium symmetric-DMC input-marginal lemma — different file
  (`ShannonChannelCoding.lean`), different namespace.
* `@[simp]` tagging — strict inequalities aren't conventionally simp-tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)