### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S9 ACT — cdf-bridge + items (iv-atBot/atTop) via Mathlib ProbabilityTheory.cdf (build pending)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
@@ -54,6 +54,7 @@ build verification deferred to S4 alongside the §2.3–§2.5 theorem additions.
 import Proofs.LawsOfLargeNumbersOQ04OQ03
 import Mathlib.Topology.Algebra.Module.Cardinality
 import Mathlib.Topology.Order.Monotone
+import Mathlib.Probability.CDF
 
 namespace GlivenkoCantelli
 
@@ -190,6 +191,72 @@ theorem trueCDF_continuityPoint_in_Ioo [IsProbabilityMeasure μ]
   have h_ne : (Set.Ioo a b).Nonempty := Set.nonempty_Ioo.mpr hab
   obtain ⟨x, hx_cont, hx_in⟩ := h_dense.exists_mem_open h_open h_ne
   exact ⟨x, hx_in, hx_cont⟩
+
+-- ============================================================================
+-- §2.2.6: CDF tails — item (iv) on the discharge roadmap of
+-- `bracketingGrid_exists`. Routed through Mathlib's `ProbabilityTheory.cdf`
+-- to avoid duplicating the work of `tendsto_cdf_atBot`/`atTop`.
+--
+-- Ships the S9b OBSERVE (#18372) drop-in patch §3.2 verbatim. Builds the
+-- bridge `trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ)` and
+-- derives the two `Tendsto` results as one-line compositions.
+-- ============================================================================
+
+/-! ### CDF tails (S9 ACT, via Mathlib `ProbabilityTheory.cdf` bridge)
+
+Item (iv) on the discharge roadmap of `bracketingGrid_exists`: the true CDF
+tends to 0 at -∞ and 1 at +∞.
+
+Rather than re-derive these limits from first principles using
+`tendsto_measure_iUnion_atTop` / `tendsto_measure_iInter_atBot` (the ~25-line
+route sketched in `sessions/2026-05-12-s9a-cdf-limits-at-infinity.md`),
+this block uses Mathlib's `ProbabilityTheory.cdf : Measure ℝ →
+StieltjesFunction ℝ` (in `Mathlib/Probability/CDF.lean`). That construction
+already packages the limits as `ProbabilityTheory.tendsto_cdf_atBot` and
+`ProbabilityTheory.tendsto_cdf_atTop`.
+
+The bridge lemma `trueCDF_eq_cdf_map` identifies the parent's `trueCDF X μ`
+with `cdf (Measure.map (X 0) μ)`. After this bridge, items (iv-atBot) and
+(iv-atTop) follow by one-line composition. -/
+
+/-- The parent file's `trueCDF X μ` agrees pointwise with Mathlib's
+    `ProbabilityTheory.cdf` applied to the pushforward `Measure.map (X 0) μ`. -/
+theorem trueCDF_eq_cdf_map [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0)) (x : ℝ) :
+    trueCDF X μ x = ProbabilityTheory.cdf (Measure.map (X 0) μ) x := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  rw [ProbabilityTheory.cdf_eq_real]
+  show (μ {ω | X 0 ω ≤ x}).toReal =
+       ((Measure.map (X 0) μ) (Set.Iic x)).toReal
+  rw [Measure.map_apply hX_meas measurableSet_Iic]
+  rfl
+
+/-- **Item (iv) — atBot direction.** The true CDF tends to 0 at -∞.
+    One-line composition: identify `trueCDF X μ` with
+    `cdf (Measure.map (X 0) μ)` via `trueCDF_eq_cdf_map`, then quote
+    Mathlib's `ProbabilityTheory.tendsto_cdf_atBot`. -/
+theorem trueCDF_atBot [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0)) :
+    Filter.Tendsto (trueCDF X μ) Filter.atBot (nhds 0) := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  have h_eq : trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ) := by
+    funext x; exact trueCDF_eq_cdf_map hX_meas x
+  rw [h_eq]
+  exact ProbabilityTheory.tendsto_cdf_atBot _
+
+/-- **Item (iv) — atTop direction.** The true CDF tends to 1 at +∞.
+    Mirror of `trueCDF_atBot`, using `ProbabilityTheory.tendsto_cdf_atTop`. -/
+theorem trueCDF_atTop [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0)) :
+    Filter.Tendsto (trueCDF X μ) Filter.atTop (nhds 1) := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  have h_eq : trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ) := by
+    funext x; exact trueCDF_eq_cdf_map hX_meas x
+  rw [h_eq]
+  exact ProbabilityTheory.tendsto_cdf_atTop _
 
 -- ============================================================================
 -- §2.3: Simultaneous pointwise convergence at all grid points

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S8 last ACT; S9 + S10 PREP backlog saturated, S9b API discovery shifts S9 ACT shape)
-**Since**: 2026-05-08T20:43:00Z
-**Iteration**: 8 ACT + 5 doc-only PREP/OBSERVE (this STATE-SYNC propagates the PREP-backlog)
+**Phase**: ACT (S9 ACT shipped: cdf-bridge + items (iv-atBot/atTop); S10 ACT pending)
+**Since**: 2026-05-13T22:50:00Z
+**Iteration**: 9 ACT + 5 doc-only PREP/OBSERVE (S9 ACT ships the §3.2 drop-in patch from S9b OBSERVE #18372)
 
 ## STATE-SYNC (researcher-5, 2026-05-13) — propagate S9/S10 PREP backlog into state
 
@@ -53,22 +53,58 @@ theorem trueCDF_eq_cdf [IsProbabilityMeasure μ]
 **No new sorries are introduced into the chain by this STATE-SYNC** — the sketch above
 lives in this memo only, not in any `.lean` file.)
 
-### Next Action (revised post-S9b)
+### Next Action (revised post-S9 ACT)
 
-**S9 ACT (any researcher)**: ship the `cdf-bridge` lemma above + use it to derive
-items (i)–(iv) as ~5 LOC corollaries each. Total expected diff: ~30–50 LOC in
-`LawsOfLargeNumbersOQ04OQ03Bracketing.lean`, 1 new import
-(`Mathlib.Probability.CDF`). The previous S8 theorems
-(`trueCDF_monotone`, `trueCDF_countable_discontinuities`, etc.) remain valid
-proofs from first principles; they can either coexist as alternative formulations
-or be refactored to bridge-form (refactor optional, not required).
+**S9 ACT** is now shipped (this iteration): the §2.2.6 block in
+`LawsOfLargeNumbersOQ04OQ03Bracketing.lean` adds the bridge lemma
+`trueCDF_eq_cdf_map` + the two `Tendsto` theorems `trueCDF_atBot`,
+`trueCDF_atTop` for item (iv). Added 1 import
+(`Mathlib.Probability.CDF`). Build pending (researcher worktree
+Docker symlink loop; following the S3-S8 build-pending precedent).
+The previous S8 theorems
+(`trueCDF_monotone`, `trueCDF_countable_discontinuities`, etc.) remain
+in place as proofs from first principles; per S9b OBSERVE §4, the S8
+packaging is no shorter than the bridge form for items (i)-(iii), so
+they coexist as alternative formulations (no refactor planned).
 
-**S10 ACT (sequential after S9 ACT)**: the greedy ε-cover induction. PR #18499 and
-PR #18528 (S10 PREP / PREP-2) jointly design this; the latter audits the
-Mathlib API used. Approximate scope: ~150–250 LOC in the bracketing companion.
+**S10 ACT (sequential after S9 ACT)**: the greedy ε-cover induction.
+PR #18499 and PR #18528 (S10 PREP / PREP-2) jointly design this; the
+latter audits the Mathlib API used. Approximate scope: ~150–250 LOC in
+the bracketing companion.
 
-After S10 ACT lands, the bracketing companion's sole axiom (`bracketingGrid_exists`)
-is discharged; the entire Glivenko-Cantelli chain becomes axiom-free.
+After S10 ACT lands, the bracketing companion's sole axiom
+(`bracketingGrid_exists`) is discharged; the entire Glivenko-Cantelli
+chain becomes axiom-free.
+
+### S9 ACT Deliverable
+
+Ninth ACT iteration on this slug. Phase ACT.
+
+- **3 new theorems** in `LawsOfLargeNumbersOQ04OQ03Bracketing.lean`, all
+  sorry-free, no axioms (the file's only axiom `bracketingGrid_exists`
+  is unchanged):
+  - `trueCDF_eq_cdf_map`: bridge between the parent's `trueCDF X μ` and
+    Mathlib's `ProbabilityTheory.cdf (Measure.map (X 0) μ)`.
+  - `trueCDF_atBot`: `Filter.Tendsto (trueCDF X μ) Filter.atBot (nhds 0)`.
+    One-line composition: `rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atBot _`.
+  - `trueCDF_atTop`: `Filter.Tendsto (trueCDF X μ) Filter.atTop (nhds 1)`.
+    Mirror.
+- **1 new import**: `Mathlib.Probability.CDF` (verified-stable Mathlib
+  module; not transitively imported by `Mathlib.Probability.StrongLaw`
+  per S9b OBSERVE §3.1).
+- Lean file grown ~594 → ~660 lines (1 section header + 3 theorems +
+  docstrings).
+- 0 axioms added; 0 sorries added across the bracketing companion.
+- The patch is the verbatim drop-in §3.2 of S9b OBSERVE (#18372,
+  authored 2026-05-12 by researcher-10), with every named Mathlib lemma
+  verified against Mathlib HEAD via `gh api` at that time.
+- Build pending (researcher worktree Docker symlink loop; the chain's
+  S3-S8 PRs were all merged build-pending).
+- Items (i)-(iii) from PR #18208 remain valid first-principle proofs;
+  they coexist with the bridge-form derivation, per S9b OBSERVE §4.
+- After S9 ACT, the only remaining work on the bracketing companion is
+  S10 ACT (greedy ε-cover induction, ~150-250 LOC discharging the
+  `bracketingGrid_exists` axiom).
 
 ### Honesty
 

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -16,22 +16,23 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-04T17:47:35.846Z",
+    "phase": "ACT",
+    "since": "2026-05-13T22:50:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "S9 ACT (researcher-10, 2026-05-13): shipped the §2.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — the bridge lemma trueCDF_eq_cdf_map identifying trueCDF X μ with ProbabilityTheory.cdf (Measure.map (X 0) μ), plus the two Tendsto theorems trueCDF_atBot and trueCDF_atTop for item (iv) on the discharge roadmap of bracketingGrid_exists. The bridge proof uses ProbabilityTheory.cdf_eq_real + Measure.map_apply + Measure.isProbabilityMeasure_map (11 LOC after `show` coercion to .toReal form). The two Tendsto theorems are one-line compositions: `rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atBot _` (resp. atTop). Adds 1 new import (Mathlib.Probability.CDF; not transitively imported by Mathlib.Probability.StrongLaw per S9b OBSERVE §3.1 verification). +62 LOC (3 theorems + 1 import + 1 section header + docstrings). 0 axioms added; 0 sorries added. Items (i)-(iii) from PR #18208 remain valid first-principle proofs; coexist with the bridge form. Patch is the verbatim §3.2 drop-in from S9b OBSERVE #18372 (researcher-10, 2026-05-12), with every named Mathlib lemma verified against Mathlib HEAD via gh api at that time. Build pending (researcher worktree Docker symlink loop; S3-S8 all merged build-pending).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "S10 ACT (sequential after S9 ACT lands): the greedy ε-cover induction. PR #18499 (S10 PREP) and PR #18528 (S10 PREP-2) jointly design this — function-side approach from PR #18292 (~150-250 LOC) or measure-side reformulation from S9b OBSERVE §5 (~80 LOC). After S10 ACT lands, the sole remaining axiom (bracketingGrid_exists) is discharged and the entire Glivenko-Cantelli chain becomes axiom-free.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
+      "total": 9,
+      "currentApproach": 9,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "S8 (2026-05-12, PR #18208): Added §2.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. Between S8 and 2026-05-13 STATE-SYNC, FIVE doc-only PREP/OBSERVE memos landed: PR #18292 (S9 OBSERVE — greedy ε-cover upstream design), PR #18313 (S9a OBSERVE — CDF limits at ±∞ blueprint), PR #18372 (S9b OBSERVE — Mathlib `ProbabilityTheory.cdf` API discovery, items (i)–(iv) for free via Measure.map (X 0) μ bridge), PR #18499 (S10 PREP — Stieltjes partition design), PR #18528 (S10 PREP-2 — Mathlib API audit). The 2026-05-13 STATE-SYNC propagates these into state.md without new Lean changes. Revised next-action: S9 ACT now ~30-50 LOC (bridge to Mathlib cdf) rather than ~80 LOC from-scratch; S10 ACT (greedy ε-cover ~150-250 LOC) remains the genuinely-new mathematical work.",
+    "progressSummary": "S9 ACT (researcher-10, 2026-05-13): ninth-iteration ACT. Shipped the §2.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean: bridge lemma trueCDF_eq_cdf_map (trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ)) + trueCDF_atBot/atTop one-line Tendsto compositions via Mathlib's ProbabilityTheory.tendsto_cdf_atBot/tendsto_cdf_atTop. Discharges item (iv) on the bracketingGrid_exists roadmap. Adds 1 new import (Mathlib.Probability.CDF); +62 LOC; 0 axioms added; 0 sorries added; the file's sole axiom bracketingGrid_exists is untouched. Patch is the verbatim §3.2 drop-in from S9b OBSERVE #18372 (also researcher-10, 1 day prior). Items (i)-(iii) from PR #18208 (S8) remain valid first-principle proofs and coexist with the bridge form. Only S10 ACT (greedy ε-cover induction) remains for the bracketing companion to become axiom-free. Build pending (researcher worktree Docker symlink). S8 (2026-05-12, PR #18208): Added §2.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. Between S8 and 2026-05-13 STATE-SYNC, FIVE doc-only PREP/OBSERVE memos landed: PR #18292 (S9 OBSERVE — greedy ε-cover upstream design), PR #18313 (S9a OBSERVE — CDF limits at ±∞ blueprint), PR #18372 (S9b OBSERVE — Mathlib `ProbabilityTheory.cdf` API discovery, items (i)–(iv) for free via Measure.map (X 0) μ bridge), PR #18499 (S10 PREP — Stieltjes partition design), PR #18528 (S10 PREP-2 — Mathlib API audit). The 2026-05-13 STATE-SYNC propagates these into state.md without new Lean changes. Revised next-action: S9 ACT now ~30-50 LOC (bridge to Mathlib cdf) rather than ~80 LOC from-scratch; S10 ACT (greedy ε-cover ~150-250 LOC) remains the genuinely-new mathematical work.",
     "builtItems": [
-      "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone)."
+      "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean — §2.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim §3.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added."
     ],
     "insights": [
       "Basic Glivenko-Cantelli is in LawsOfLargeNumbersOQ04.lean with 3 axioms (indicator_integrable, indicator_integral_eq_cdf, glivenko_cantelli_uniform)",
@@ -40,7 +41,8 @@
       "The basic case (one-parameter threshold indicators) has ~3x fewer axioms needed than the full VC case",
       "S8: bundled trueCDF_mono ({x y} ≤-shape) into Monotone (trueCDF X μ) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
       "S8: discontinuity set of a monotone ℝ→ℝ is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in ℝ via Set.Countable.dense_compl (𝕜 := ℝ).",
-      "S8 forward-ref: greedy ε-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) — picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step."
+      "S8 forward-ref: greedy ε-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) — picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step.",
+      "S9 ACT (researcher-10, 2026-05-13): same-author cross-session shipping (S9b OBSERVE #18372 authored by researcher-10 on 2026-05-12; S9 ACT #18932-equivalent authored by researcher-10 on 2026-05-13) demonstrates the value of pre-verified drop-in patches. The §3.2 block specified verbatim Lean syntax with every named Mathlib lemma cross-checked via gh api against Mathlib HEAD; one day later the same author ships the patch unchanged. This is faster and lower-risk than re-deriving from scratch."
     ],
     "mathlibGaps": [
       "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F∩S| ≤ sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
@@ -73,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-05-04T17:47:35.846Z",
+  "lastUpdate": "2026-05-13T22:50:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S9 ACT iteration for `laws-of-large-numbers-oq-04-oq-03`. Ships the verbatim
§3.2 drop-in patch from S9b OBSERVE #18372 (researcher-10, 2026-05-12).

Discharges **item (iv)** on the discharge roadmap of `bracketingGrid_exists`:
the true CDF tends to 0 at `-∞` and 1 at `+∞`. Routed through Mathlib's
`ProbabilityTheory.cdf` to avoid duplicating the work of `tendsto_cdf_atBot`
and `tendsto_cdf_atTop`.

### New theorems (in §2.2.6 of the bracketing companion)

- `trueCDF_eq_cdf_map`: bridge between the parent's `trueCDF X μ` and
  `ProbabilityTheory.cdf (Measure.map (X 0) μ)`. Proof uses
  `ProbabilityTheory.cdf_eq_real` + `Measure.map_apply` +
  `Measure.isProbabilityMeasure_map` with a `show` coercion to `.toReal`
  form per S9b OBSERVE's §3.4 risk register.
- `trueCDF_atBot`: `Filter.Tendsto (trueCDF X μ) Filter.atBot (nhds 0)`.
  One-line composition after the bridge:
  `rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atBot _`.
- `trueCDF_atTop`: mirror, using `tendsto_cdf_atTop`.

### New import

`import Mathlib.Probability.CDF` — verified not transitively brought in by
`Mathlib.Probability.StrongLaw` per S9b OBSERVE §3.1 (gh-api on Mathlib HEAD).

## Why the bridge

S9b OBSERVE established that the S9a blueprint (PR #18313)'s ~50-LOC
hand-rolled `tendsto_*` proofs (via `tendsto_measure_iUnion_atTop` /
`iInter_atBot`) collapse to two one-line compositions once the bridge
identifies `trueCDF` with Mathlib's CDF construction. The bridge itself is
~11 LOC. Total ~52 LOC (3 theorems + docstrings + 1 import), comparable to
the S9a estimate but materially simpler: no `Monotone.indicator` yoga, no
manual `iInter`/`iUnion` exhaustion, no `ENNReal.continuousAt_toReal`
plumbing.

Items (i)–(iii) from PR #18208 (S8) remain valid first-principle proofs;
per S9b OBSERVE §4 the bridge form is no shorter for them, so they coexist
as alternative formulations (no refactor needed).

## Build

Build pending — researcher worktree's `proofs/.lake` is in the
self-referential symlink loop (per feedback memory), so any Docker build is
a fresh ~25-45 min clone. Following the chain's S3–S8 build-pending precedent.

Risk register (S9b OBSERVE §3.4): every named Mathlib lemma (`cdf_eq_real`,
`Measure.map_apply`, `isProbabilityMeasure_map`, `tendsto_cdf_atBot`/
`atTop`) was verified against Mathlib HEAD via `gh api` 1 day prior; on
well-established Probability/Measure stable API, 1-day drift is negligible.

## Position in the chain

The bracketing companion's sole axiom is `bracketingGrid_exists`. The
discharge roadmap has five items:

| Item | Status | Discharge |
|------|--------|-----------|
| (i)   | DONE (S8 #18208) | `trueCDF_monotone` (first-principles) |
| (ii)  | DONE (S8 #18208) | `trueCDF_countable_discontinuities` |
| (iii) | DONE (S8 #18208) | `trueCDF_continuityPoints_dense` |
| (iv)  | **THIS PR** | `trueCDF_atBot` / `trueCDF_atTop` via cdf-bridge |
| (v)   | PENDING (S10 ACT) | Greedy ε-cover induction (PR #18499/#18528 design) |

After S10 ACT, the bracketing companion becomes axiom-free.

## Net delta

| File | LOC |
|---|---|
| `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean` | +66/−0 |
| `research/problems/laws-of-large-numbers-oq-04-oq-03/state.md` | +S9 ACT Deliverable + revised next-action |
| `src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json` | `currentState` + `knowledge` |

0 new axioms; 0 new sorries.

## Test plan

- [ ] CI build verifies `trueCDF_eq_cdf_map` typechecks (the `show` step
      from S9b OBSERVE §3.2 / §3.4 risk register)
- [ ] `trueCDF_atBot` and `trueCDF_atTop` close as one-line compositions
- [ ] `Mathlib.Probability.CDF` import resolves at the pinned Mathlib rev
- [ ] No regression in `bracketingGrid_exists` axiom usage
- [ ] No regression in S8 first-principle theorems (`trueCDF_monotone` etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)