### PR TITLE
research(erdos-659-oq-01-oq-02): S3 ACT SCAFFOLD — axis-vs-plane safety for (p,q)=(2,5) modulo 3 strategic sorries (build pending)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1754,6 +1754,7 @@ import Proofs.Erdos656Problem
 import Proofs.Erdos657Problem
 import Proofs.Erdos658Problem
 import Proofs.Erdos659OQ01
+import Proofs.Erdos659OQ01OQ02
 import Proofs.Erdos659Problem
 import Proofs.Erdos65OQ03
 import Proofs.Erdos65Problem

--- a/proofs/Proofs/Erdos659OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos659OQ01OQ02.lean
@@ -1,0 +1,133 @@
+/-
+# Erdős Problem #659 OQ-01-OQ-02 — d ≥ 3 extension: axis-vs-plane scaffold
+
+This file is the S3 ACT **scaffold** for the open question
+
+> Can the O(n/√(log n)) sharp-distance-bound theorem for ℝ² (parent
+> `erdos-659-oq-01`) be extended to ℝ^d for `d ≥ 3`?
+
+The plan (per S1c OBSERVE PR #18431 + S2a OBSERVE PR #18494 + S2b PREP
+PR #18554) is to ship a Pell-equation-safe sub-lattice family
+`L_{p, q} := { (δ₁, δ₂√p, δ₃√q) : δᵢ ∈ ℤ }` for selected squarefree
+prime pairs `(p, q)`, then derive the Θ(n^{2/3}) rate.
+
+S2b PREP §4–§6 isolated the **axis-vs-plane** half of the safety
+predicate into three equations in three unknowns:
+
+```
+(A)   5 c² = a² + 2 b²
+(B)   2 b² = a² + 5 c²
+(C)   a²    = 2 b² + 5 c²
+```
+
+A solution `(a, b, c) ≠ (0, 0, 0)` to any of A/B/C corresponds to an
+axis-vs-plane equidistant 4-tuple in `L_{2, 5}`. The S2b §4–§5 QR-descent
+template proves all three have only the trivial integer solution by
+reducing mod 5 and applying the quadratic-non-residue status of `2` and
+`−2` mod 5.
+
+This file ships the **outer scaffold** — the three predicates,
+their composite, and the named theorem statements — with the descent
+**bodies deferred to S4 ACT** as three strategic sorries. The
+descent recipe is fully written out in
+`research/problems/erdos-659-oq-01-oq-02/sessions/2026-05-13-s2b-prep-qr-descent-mathlib-audit-for-2-5-pair.md`
+§5 (the Lean template) and §7 (generalisation pointer for the other
+six safe pairs identified by S2a).
+
+**Scope.** Axis-vs-plane only. Full-rank safety (per S2c PREP §6.1) is
+deferred to a separate axiomatisation pending Mathlib Hasse-Minkowski
+infrastructure that does not yet exist at v4.26.0.
+
+**Sorries / axioms.** 3 strategic sorries (one per equation); 0 axioms
+in this file. Build pending convention applies (recursive `.lake`
+symlink in the researcher worktree precludes local `lake build`; the
+auditor / next ACT session is expected to verify via the Docker
+wrapper).
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Int.Defs
+
+namespace Erdos659OQ01OQ02
+
+/-- Equation A predicate for the prime pair `(p, q) = (2, 5)`:
+    `5 c² = a² + 2 b²` has only the trivial integer solution.
+
+    Geometric meaning: an axis-vs-plane equidistant 4-tuple in
+    `L_{2, 5}` projecting onto coordinate axis 1 and the (axis 2,
+    axis 3) plane would give a non-trivial solution.
+
+    Discharge plan (S4 ACT, ~30 LOC): reduce mod 5 to deduce
+    `5 ∣ a.natAbs` and `5 ∣ b.natAbs` (using `−2` not a square mod 5);
+    substitute and rearrange to deduce `5 ∣ c.natAbs`; descend by
+    `Nat.strongRecOn` on `c.natAbs`. See S2b PREP §4.1 + §5. -/
+def safe_A : Prop :=
+  ∀ a b c : ℤ, (5 : ℤ) * c ^ 2 = a ^ 2 + 2 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0
+
+/-- Equation B predicate for the prime pair `(p, q) = (2, 5)`:
+    `2 b² = a² + 5 c²` has only the trivial integer solution.
+
+    Discharge plan (S4 ACT, ~30 LOC): analogous to `safe_A` with
+    `b` ↔ `c` (mod-5 reduction via `2` not a square mod 5). See
+    S2b PREP §4.2. -/
+def safe_B : Prop :=
+  ∀ a b c : ℤ, (2 : ℤ) * b ^ 2 = a ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0
+
+/-- Equation C predicate for the prime pair `(p, q) = (2, 5)`:
+    `a² = 2 b² + 5 c²` has only the trivial integer solution.
+
+    Discharge plan (S4 ACT, ~30 LOC): analogous to `safe_A` with
+    `a` ↔ `c`. See S2b PREP §4.3. -/
+def safe_C : Prop :=
+  ∀ a b c : ℤ, a ^ 2 = (2 : ℤ) * b ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0
+
+/-- **(STRATEGIC SORRY — S4 ACT, axis-vs-plane equation A).**
+    `5 c² = a² + 2 b²` has only `(0, 0, 0)`.
+
+    Proof (deferred): see this file's docstring + S2b PREP §5 template. -/
+theorem safe_A_holds : safe_A := by
+  intro a b c _heq
+  sorry
+
+/-- **(STRATEGIC SORRY — S4 ACT, axis-vs-plane equation B).**
+    `2 b² = a² + 5 c²` has only `(0, 0, 0)`.
+
+    Proof (deferred): analogous to `safe_A_holds`; see S2b PREP §4.2. -/
+theorem safe_B_holds : safe_B := by
+  intro a b c _heq
+  sorry
+
+/-- **(STRATEGIC SORRY — S4 ACT, axis-vs-plane equation C).**
+    `a² = 2 b² + 5 c²` has only `(0, 0, 0)`.
+
+    Proof (deferred): analogous to `safe_A_holds`; see S2b PREP §4.3. -/
+theorem safe_C_holds : safe_C := by
+  intro a b c _heq
+  sorry
+
+/-- The axis-vs-plane safety predicate for a prime pair `(p, q)`.
+    Asserts that none of the three QR equations A/B/C admits a
+    non-trivial integer solution. This is the **necessary** condition
+    on `(p, q)` for the lattice `L_{p, q}` to satisfy the
+    `fourPointProperty` along axis-vs-plane equidistant 4-tuples.
+
+    Per S2c PREP §6.1, the corresponding full-rank safety statement is
+    separately axiomatized (Mathlib v4.26.0 lacks the ternary
+    Hasse-Minkowski infrastructure to discharge it as a theorem). -/
+def SafePrimePair_AxisVsPlane (p q : ℕ) : Prop :=
+  (∀ a b c : ℤ, (q : ℤ) * c ^ 2 = a ^ 2 + (p : ℤ) * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0) ∧
+  (∀ a b c : ℤ, (p : ℤ) * b ^ 2 = a ^ 2 + (q : ℤ) * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0) ∧
+  (∀ a b c : ℤ, a ^ 2 = (p : ℤ) * b ^ 2 + (q : ℤ) * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0)
+
+/-- **The main axis-vs-plane safety theorem for the prime pair
+    `(p, q) = (2, 5)`.**
+
+    Derived as the conjunction of `safe_A_holds`, `safe_B_holds`, and
+    `safe_C_holds`. Each conjunct is currently a strategic sorry;
+    closing all three via the S2b §5 QR-descent template completes the
+    axis-vs-plane half of the `L_{2, 5}` safety story. The full-rank
+    half is axiomatised separately per S2c PREP §6.1. -/
+theorem safe_2_5_axis_vs_plane : SafePrimePair_AxisVsPlane 2 5 :=
+  ⟨safe_A_holds, safe_B_holds, safe_C_holds⟩
+
+end Erdos659OQ01OQ02


### PR DESCRIPTION
## Summary

S3 ACT scaffold for `erdos-659-oq-01-oq-02` (d ≥ 3 extension of the
sharp-distance-bound result). Ships the structural skeleton for the
**axis-vs-plane** safety story of the lattice `L_{2, 5}`, derived from
three QR-descent sub-lemmas (one per equation A/B/C of S2b PREP §4).

The three sub-lemma bodies (`safe_A_holds`, `safe_B_holds`,
`safe_C_holds`) are deferred to **S4 ACT** as strategic sorries — same
isolation convention used in the gauss-wilson-non-cyclic-oq-01 Phase B
and Phase C scaffolds (PRs #18232 / #18652).

## What ships

| File | LOC | Sorries | Axioms |
|---|---|---|---|
| **NEW** `proofs/Proofs/Erdos659OQ01OQ02.lean` | 134 | 3 strategic | 0 |
| `proofs/Proofs.lean` | +1 | — | — |

The scaffold exposes:

- 3 predicates: `safe_A` (`5c² = a² + 2b²`), `safe_B` (`2b² = a² + 5c²`),
  `safe_C` (`a² = 2b² + 5c²`).
- 3 strategic-sorry theorems: `safe_A_holds`, `safe_B_holds`,
  `safe_C_holds` — each with a per-theorem discharge-plan docstring
  pointing at S2b PREP §4 + §5.
- 1 composite predicate: `SafePrimePair_AxisVsPlane (p q : ℕ) : Prop`.
- 1 named outer theorem: `safe_2_5_axis_vs_plane :
  SafePrimePair_AxisVsPlane 2 5` (derived from the three sub-lemmas).

## Scope and honesty

- **Axis-vs-plane only.** Full-rank safety (per S2c PREP §6.1
  recommendation) is deferred to a separate axiom in a future PR; this
  PR introduces **0 new axioms**, all gaps are theorem sorries.
- **Build pending.** Researcher worktree `proofs/.lake` is the
  recursive-symlink trap; the auditor or S4 ACT worker is expected to
  verify via `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02`.
- **Narrow imports** (`Mathlib.Tactic` + `Mathlib.Data.Int.Defs`)
  matching the gauss-wilson scaffold convention. The descent bodies
  will additionally need `Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity`
  per S2b PREP §3 — that import is added when the sorries are closed.

## Why scaffold, not full ACT?

S2b PREP §5 provides a Lean **template** for the safe_A descent body
(~30 LOC of strong-induction on `c.natAbs`) but explicitly defers the
body-fill to "the S2 ACT worker, with full
`proofs/scripts/docker-build.sh` access" (S2b §9 anti-target #1). The
worktree build is currently blocked by the recursive `.lake` symlink,
so this PR ships only the parts that don't risk untested
Mathlib-citation errors: the structural decomposition, the named
predicates, and the outer composite theorem. A worker with docker
access can drop in the 3 × 30 LOC descent bodies via a follow-on
S4 ACT.

## Scope guarantees

- **No edits** to `research/problems/erdos-659-oq-01-oq-02/{state.md,
  knowledge.md, problem.md}` — state.md is already current per
  researcher-4's STATE-SYNC PR #18910 (this PR satisfies row 53's
  "Recommended next session" line).
- **No edits** to JSON, sibling slug files, or any gallery data
  outside the two listed files.
- **No new axioms.** Subtree axiom count unchanged.

## Forward levers

- **S4 ACT** (next, any researcher): close the 3 strategic sorries via
  the S2b PREP §5 template (~30 LOC per equation, total ~90 LOC of
  descent body). Mathlib bearers pinned at v4.26.0 per S2b §3 + S2c §3
  audit-corrections.
- **S5 PREP/ACT** (after S4): introduce `SafePrimePair_FullRank`
  predicate + `fullRank_empirically_safe` axiom per S2c §6.1; combine
  with this PR's axis-vs-plane theorem for the full `SafePrimePair 2 5`.
- **S6+**: derive the Θ(n^{2/3}) rate via the safe lattice +
  Solymosi-Vu lower bound (separate axiom).

## Race awareness

`gh pr list -R rjwalters/lean-genius --search "erdos-659-oq-01-oq-02
in:title" --state open` returned `[]` at draft / push / PR-create time.
File-name keyword search (`Erdos659OQ01OQ02`) also empty. Branch
rebased onto current origin/main pre-push (29-commit gap cleanly
fast-forwarded; only intervening `Proofs.lean` edit was the unrelated
`Proofs.FrobeniusNumberOQ03` insertion at line 2284, no overlap).

🤖 Generated by researcher-1