### PR TITLE
research(picks-theorem-oq-01-oq-01-oq-01): S3a-prep — Mathlib v4.26.0 bearer audit + cyclic-symmetric det rewrite refinement (doc-only)

### DIFF
--- a/research/problems/picks-theorem-oq-01-oq-01-oq-01/sessions/2026-05-13-s3a-prep-edge-gcd-bearer-audit.md
+++ b/research/problems/picks-theorem-oq-01-oq-01-oq-01/sessions/2026-05-13-s3a-prep-edge-gcd-bearer-audit.md
@@ -1,0 +1,162 @@
+# S3a-prep — Mathlib v4.26.0 bearer audit for `primitive_edgeGCD_eq_one`
+
+**Date**: 2026-05-13
+**Researcher**: researcher-5
+**Phase**: PLAN → S3a-prep (doc-only, no Lean diff)
+**Predecessor**: S3-prep (#18158, merged 2026-05-12) closed `primitive_realInteriorCount_zero`; #18825 STATE-SYNC identified `primitive_pickInterior_zero` as the dual gap.
+
+## Goal
+
+Bearer-audit every Mathlib / Lean-core API the S3a-plus blueprint depends on, **pinned to the lockfile SHA the lake build will actually consume**, and refine the blueprint's per-edge step using a cyclic-symmetric rewrite of `LatticeTriangle.det` so the proof is uniform across `i ∈ {0, 1, 2}`.
+
+## Pin
+
+| Pin | Value |
+|---|---|
+| `proofs/lean-toolchain` | `leanprover/lean4:v4.26.0` |
+| `proofs/lake-manifest.json` (mathlib `rev`) | `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` |
+| `proofs/lake-manifest.json` (mathlib `inputRev`) | `v4.26.0` |
+
+The audit below references SHA `2df2f015…` (Mathlib) and tag `v4.26.0` (Lean core). Memory-feedback note `feedback_researcher_mathlib_head_vs_lockfile_sha_drift` warned that `gh api .../contents/<path>` defaults to HEAD; every URL below is `?ref=` qualified so re-runs are stable.
+
+## Bearer table
+
+All eight API points used by the S3a-plus blueprint are present at the pin, exactly as named in `state.md`:
+
+| # | Symbol | Source | Line | Statement |
+|---|---|---|---|---|
+| 1 | `Nat.gcd_dvd_left` | `lean4 src/Init/Data/Nat/Gcd.lean` `v4.26.0` | 90 | `gcd_dvd_left (m n : Nat) : gcd m n ∣ m := (gcd_dvd m n).left` |
+| 2 | `Nat.gcd_dvd_right` | `lean4 src/Init/Data/Nat/Gcd.lean` `v4.26.0` | 92 | `gcd_dvd_right (m n : Nat) : gcd m n ∣ n := (gcd_dvd m n).right` |
+| 3 | `Nat.eq_one_of_dvd_one` | `lean4 src/Init/Data/Nat/Dvd.lean` `v4.26.0` | 76 | `eq_one_of_dvd_one {n : Nat} (H : n ∣ 1) : n = 1 := Nat.dvd_antisymm H n.one_dvd` |
+| 4 | `Nat.dvd_one` (`@[simp]`) | `lean4 src/Init/Data/Nat/Dvd.lean` `v4.26.0` | 149-150 | `dvd_one {n : Nat} : n ∣ 1 ↔ n = 1` |
+| 5 | `Int.gcd_def` | Mathlib `Mathlib/Data/Int/GCD.lean` `2df2f015…` | 162 | `gcd_def (i j : ℤ) : gcd i j = Nat.gcd i.natAbs j.natAbs := rfl` |
+| 6 | `Int.gcd_eq_natAbs_gcd_natAbs` (Lean-core analogue) | `lean4 src/Init/Data/Int/Gcd.lean` `v4.26.0` | 41 | `gcd_eq_natAbs_gcd_natAbs (m n : Int) : gcd m n = Nat.gcd m.natAbs n.natAbs := rfl` |
+| 7 | `Int.natAbs_dvd` | `lean4 src/Init/Data/Int/DivMod/Lemmas.lean` `v4.26.0` | 78 | `natAbs_dvd {a b : Int} : (a.natAbs : Int) ∣ b ↔ a ∣ b` |
+| 8 | `Int.dvd_natAbs` | `lean4 src/Init/Data/Int/DivMod/Lemmas.lean` `v4.26.0` | 83 | `dvd_natAbs {a b : Int} : a ∣ b.natAbs ↔ a ∣ b` |
+
+Two observations:
+
+1. **`Int.gcd_def` and `Int.gcd_eq_natAbs_gcd_natAbs` are the same `rfl` lemma under different names** — the former lives in Mathlib, the latter in Lean core. The blueprint's `(d : ℤ) ∣ Δx` lift can be rewritten as `(d : ℤ) ∣ Δx ↔ d ∣ Δx.natAbs` via `Int.natAbs_dvd` (item 7) **without ever invoking `gcd_def`** — only the `Nat.gcd_dvd_left/right` facts on the GCD's natAbs side are needed. This shortens the proof by one rewrite.
+2. **`Nat.dvd_one` is `@[simp]`** — once we have `d ∣ 1`, a single `simpa` or `exact Nat.eq_one_of_dvd_one h` discharges `d = 1`. The blueprint's manual `Nat.eq_one_of_dvd_one` is fine; `simp` would also work.
+
+## Refinement: cyclic-symmetric det rewrite
+
+`state.md` says "the other two edges follow by relabelling vertices and applying the same argument." That relabelling is *not* free in Lean — the determinant is defined relative to `v1`:
+
+```lean
+-- proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean L126-127
+def LatticeTriangle.det (T : LatticeTriangle) : ℤ :=
+  (T.v2.1 - T.v1.1) * (T.v3.2 - T.v1.2) - (T.v3.1 - T.v1.1) * (T.v2.2 - T.v1.2)
+```
+
+Edge 0 has deltas `(v2.1 − v1.1, v2.2 − v1.2)`, which **are** the explicit factors of `det` — direct ℤ-linear combination, `(d_0 : ℤ) ∣ det` is one `Dvd.dvd_sub` step. But edge 1 has deltas `(v3.1 − v2.1, v3.2 − v2.2)` and edge 2 has `(v1.1 − v3.1, v1.2 − v3.2)` — neither pair appears literally in the `det` expression.
+
+The clean fix is the **cyclic-symmetric** rewrite (provable by `ring`):
+
+```
+det = (v2.1 - v1.1) * (v3.2 - v2.2) - (v3.1 - v2.1) * (v2.2 - v1.2)   -- edge 1 form
+    = (v3.1 - v2.1) * (v1.2 - v3.2) - (v1.1 - v3.1) * (v3.2 - v2.2)   -- edge 2 form
+```
+
+(Both follow from the identity `(v2 − v1) ∧ (v3 − v1) = (v2 − v1) ∧ (v3 − v2)`, since adding/subtracting `(v2 − v1) ∧ (v2 − v1) = 0` doesn't change the cross product.)
+
+So the cleanest Lean structuring is a **single internal lemma** that takes a per-edge ℤ-linear-combination expression and discharges all three edges by `ring` then a uniform divisibility argument. Concretely:
+
+```lean
+-- Conceptual (audited names; not yet in tree):
+lemma LatticeTriangle.det_factors (T : LatticeTriangle) : ∀ i : Fin 3,
+    ∃ α β : ℤ,
+      T.det = ((T.edgeDelta i).1 : ℤ) * α - β * ((T.edgeDelta i).2 : ℤ) := by
+  intro i; fin_cases i
+  · exact ⟨T.v3.2 - T.v1.2, T.v3.1 - T.v1.1, by unfold LatticeTriangle.det
+                                                         LatticeTriangle.edgeDelta
+                                                  push_cast; ring⟩
+  · exact ⟨T.v3.2 - T.v2.2, T.v3.1 - T.v2.1, by unfold LatticeTriangle.det
+                                                         LatticeTriangle.edgeDelta
+                                                  push_cast; ring⟩
+  · exact ⟨T.v1.2 - T.v3.2, T.v1.1 - T.v3.1, by unfold LatticeTriangle.det
+                                                         LatticeTriangle.edgeDelta
+                                                  push_cast; ring⟩
+```
+
+(Per-edge `α, β` are the *other-vertex* differences; the `push_cast` is needed because `edgeDelta` lands in `ℕ × ℕ` while the `det` rewrite lives in `ℤ`. A small wrinkle — see §"Cast-direction checkpoint" below.)
+
+## Cast-direction checkpoint (the only fragile spot)
+
+`edgeDelta i` returns `(natAbs Δx, natAbs Δy) : ℕ × ℕ`. The det formula uses `(v2.1 − v1.1) : ℤ`, not its `natAbs`. So the per-edge linear combination above is **strictly speaking** about the *signed* deltas, not their `natAbs`s. The right way to express divisibility is therefore **two stages**:
+
+**Stage A** (signed-delta version, by `ring`):
+```
+∀ i : Fin 3, ∃ α β : ℤ,
+    T.det = (T.signedDelta i).1 * α - β * (T.signedDelta i).2
+```
+where `signedDelta : Fin 3 → ℤ × ℤ` is the (currently absent) helper that returns `(v_{i+1} − v_i)` without `natAbs`. Two options:
+  * **Option A1** — add a small `def signedDelta` (3 cases, `Fin 3 → ℤ × ℤ`); `det_factors` then uses it directly.
+  * **Option A2** — skip the helper and write three local `have` lemmas inline in `primitive_edgeGCD_eq_one`. Simpler at three call sites, no new public surface.
+
+**Stage B** (lift to `natAbs`):
+```
+(T.edgeGCD i : ℤ) ∣ ((T.signedDelta i).1) ∧ (T.edgeGCD i : ℤ) ∣ ((T.signedDelta i).2)
+```
+This is item 7 (`Int.natAbs_dvd`) applied to the `Nat.gcd_dvd_left/right` (items 1, 2) facts, then `Nat.cast`ed up.
+
+Sketch:
+```lean
+have h_x_nat : T.edgeGCD i ∣ (T.edgeDelta i).1 := Nat.gcd_dvd_left _ _   -- item 1
+have h_y_nat : T.edgeGCD i ∣ (T.edgeDelta i).2 := Nat.gcd_dvd_right _ _  -- item 2
+-- Cast to ℤ via Int.natAbs_dvd (item 7) and the fact (T.edgeDelta i).1 = (T.signedDelta i).1.natAbs
+have h_x_int : (T.edgeGCD i : ℤ) ∣ (T.signedDelta i).1 := by
+  rw [show (T.edgeDelta i).1 = (T.signedDelta i).1.natAbs from rfl] at h_x_nat
+  exact (Int.natAbs_dvd.mpr ?).mp ?  -- or use Int.natCast_dvd_natCast composed with dvd_natAbs
+```
+
+The `show ... from rfl` is the load-bearing step; it relies on `edgeDelta i` being literally `((signedDelta i).1.natAbs, (signedDelta i).2.natAbs)`. With option A1 (`signedDelta` as a definition), this is `rfl` by construction. With option A2 (no helper), we replace `(T.edgeDelta i).1` by the explicit signed expression directly.
+
+## Refined LOC estimate
+
+`state.md` estimated **50–100 LOC** for the full S3a-plus chain. After the bearer audit + cyclic-symmetric refinement, a tighter break-down:
+
+| Sub-lemma | Strategy | LOC est. |
+|---|---|---|
+| (opt) `LatticeTriangle.signedDelta : Fin 3 → ℤ × ℤ` | def + `Fin 3` match | 5 |
+| (opt) `LatticeTriangle.edgeDelta_eq_natAbs_signedDelta` | `rfl` after `fin_cases` | 6 |
+| `det_factors_signedDelta` (Stage A) | 3-case `fin_cases` + `ring` | 12 |
+| `edgeGCD_dvd_signedDelta` (Stage B, 2 of them) | `Nat.gcd_dvd_left/right` + `Int.natAbs_dvd` | 10 |
+| `edgeGCD_dvd_det` (assemble) | `dvd_sub`, `dvd_mul_left`, `dvd_mul_right` | 6 |
+| `primitive_edgeGCD_eq_one` (apply `det.natAbs = 1`) | `Int.natAbs_dvd`, `Nat.eq_one_of_dvd_one` | 8 |
+| `primitive_boundaryCount_eq_three` | `unfold`, `simp` of the three `edgeGCD = 1` | 6 |
+| `primitive_pickInterior_zero` | `unfold`, `rw`, `norm_num` | 5 |
+| `primitive_pick_agrees` | combine with `primitive_realInteriorCount_zero` | 4 |
+| **Total (with helpers A1)** | | **~62 LOC** |
+| **Total (option A2, no helper)** | | **~50 LOC** (3 inline `signedDelta` expansions) |
+
+Either path stays within `state.md`'s 50–100 LOC estimate. Option A1 is **slightly more verbose but more reusable** for S3b additivity (which will need `signedDelta` for the gluing identity); option A2 is **leaner now but recomputes the per-edge expressions later**. Recommendation: **Option A1**, paying ~12 extra LOC up front for one reusable helper.
+
+## What this PREP does NOT ship
+
+* No Lean changes to `proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean` (or any other Lean file).
+* No edits to gallery JSON beyond `lastUpdate` and the `currentState` fields.
+* No PR review request label (`loom:review-requested`) — math agents skip Judge per CLAUDE.md.
+* No new annotations or enrichment metadata.
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Mathlib upgrade between PREP and ACT renames items 5–8 | Low (audit pinned to lockfile SHA) | Lockfile SHA is in this memo; ACT references this memo before re-auditing. |
+| `det_factors` ring step fails because `LatticeTriangle.det` definition changes | Low (def is small, no upstream churn) | ACT must re-confirm L126-127 of the file before invoking `ring`. |
+| `edgeDelta i = (signedDelta i).natAbs × natAbs` is not `rfl` (e.g. due to a future `simp` normal form) | Low (both are `Fin 3` matches with literal `natAbs` calls) | If `rfl` fails at ACT, replace the `show ... from rfl` with explicit `Prod.mk.injEq + natAbs_natCast` chain. |
+| Hidden 4th edge case (degenerate triangle with `det = 0`) | None | `T.twiceArea = 1` excludes `det = 0` (`0.natAbs = 0 ≠ 1`). |
+| Concurrent S3a ACT shipped by another researcher mid-PREP | Low (no open ACT PR; last research PR was this slug's STATE-SYNC `#18825`) | Pre-push `gh pr list -R rjwalters/lean-genius --search "picks-theorem-oq-01-oq-01-oq-01 in:title" --state open` re-check; if S3a ACT lands first, this PREP becomes a backward-looking audit (still useful for review). |
+
+## Hand-off
+
+Next iteration (S3a ACT) should:
+
+1. Verify the lockfile SHA still matches `2df2f015…`. If a Mathlib bump intervened, re-run the bearer table queries (commands at the top of each table row imply the `gh api` calls — same `?ref=` SHA, same paths).
+2. Add `signedDelta` and `edgeDelta_eq_natAbs_signedDelta` near the existing `edgeDelta` definition (~L141 of the focal file).
+3. Implement Section IX (`-- SECTION IX (S3a): Primitive case ⇒ pickInterior = 0`) with the four-lemma chain `det_factors → edgeGCD_dvd_det → primitive_edgeGCD_eq_one → primitive_boundaryCount_eq_three → primitive_pickInterior_zero → primitive_pick_agrees`.
+4. Build via `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01` (CLAUDE.md mandate; never `lake build` directly).
+5. Once verified, update `meta.leanFiles[*].lineCount` for the focal file (expected ~552–562 LOC after S3a) and `theoremCount` (current 14 → ~22 after S3a).
+
+S3b additivity then becomes the final genuinely-large step before S4 closes the induction.

--- a/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
@@ -1,10 +1,10 @@
 # Current State
 
 **Phase**: PLAN
-**Since**: 2026-05-13T11:55:00Z
-**Iteration**: 5
-**Last researcher**: researcher-8 (S3-prep JSON sync + S3a-plus identification — doc-only)
-**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S3-prep JSON sync + identify primitive_pickInterior_zero gap (this PR, doc-only)
+**Since**: 2026-05-13T18:30:00Z
+**Iteration**: 6
+**Last researcher**: researcher-5 (S3a-prep — Mathlib v4.26.0 bearer audit for `primitive_edgeGCD_eq_one`, doc-only)
+**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S3a-prep — Mathlib v4.26.0 bearer audit + cyclic-symmetric det rewrite refinement (this PR, doc-only)
 **Most recent Lean change**: research(picks-theorem-oq-01-oq-01-oq-01): S3-prep — general primitive base case via partition-sum identity (#18158, merged 2026-05-12)
 
 ## Current Focus
@@ -137,6 +137,25 @@ S3-prep already established.  The hardest fragment is the `(d : ℤ) ∣ Δx`
 lift, which is a one-step `Int.gcd_dvd_left` invocation once the
 `Int.gcd ↔ Nat.gcd` definitional equality is used.
 
+**S3a-prep refinement (researcher-5, 2026-05-13)** — see
+`sessions/2026-05-13-s3a-prep-edge-gcd-bearer-audit.md`.  Bearer-audited
+all eight Mathlib v4.26.0 / Lean-core API points the blueprint depends
+on against the lockfile pin (`mathlib rev 2df2f015…`, `lean v4.26.0`):
+`Nat.gcd_dvd_left/right`, `Nat.eq_one_of_dvd_one`, `Nat.dvd_one (@[simp])`,
+`Int.gcd_def`, `Int.gcd_eq_natAbs_gcd_natAbs`, `Int.natAbs_dvd`,
+`Int.dvd_natAbs` — all present with the names used above.  The audit
+also flags a per-edge wrinkle: `LatticeTriangle.det` is defined relative
+to `v1`, so edges 1 and 2 don't appear literally in the `det`
+expression.  Resolution: a small `signedDelta : Fin 3 → ℤ × ℤ` helper
+(or three inline `have`s) plus a `det_factors` lemma proved by
+`fin_cases + ring` that exhibits the per-edge ℤ-linear combination
+uniformly.  Refined LOC estimate: ~62 LOC with the helper, ~50 LOC
+without.  The hardest fragment after refinement is the **cast-direction
+checkpoint** — relying on `(edgeDelta i).1 = (signedDelta i).1.natAbs`
+being `rfl` — for which the audit also supplies a fall-back chain
+(`Int.natAbs_dvd ↔ Int.natCast_dvd_natCast` + `Int.dvd_natAbs`) if the
+`rfl` fails at ACT.
+
 **Why before S3b (additivity).**  S3b is the genuinely large
 combinatorial step (200–400 LOC, requiring a union/glue definition and
 careful boundary accounting).  Closing S3a-plus first means S3b only
@@ -170,6 +189,6 @@ Each step is self-contained and could be pursued in a separate iteration.
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 4
+- Total attempts: 5
+- Current approach attempts: 5
 - Approaches tried: 1 (bridge-via-cleared-form + primitive-base-case)

--- a/src/data/research/problems/picks-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/picks-theorem-oq-01-oq-01-oq-01.json
@@ -31,19 +31,19 @@
   },
   "currentState": {
     "phase": "PLAN",
-    "since": "2026-05-13T11:55:00Z",
-    "iteration": 5,
-    "focus": "S3-prep done (general primitive realInteriorCount = 0). Asymmetric base case remains: pickInterior = 0 is only proved on three test triangles, not for every primitive T.",
+    "since": "2026-05-13T18:30:00Z",
+    "iteration": 6,
+    "focus": "S3a-prep done (researcher-5, 2026-05-13): Mathlib v4.26.0 bearer audit confirms all 8 API points named in S3a-plus blueprint exist at the lockfile pin; cyclic-symmetric det rewrite refinement removes the per-edge relabelling gap. ACT can ship a ~50-62 LOC chain (signedDelta helper + det_factors + edgeGCD_dvd_det + primitive_edgeGCD_eq_one + primitive_boundaryCount_eq_three + primitive_pickInterior_zero + primitive_pick_agrees).",
     "blockers": [],
-    "nextAction": "S3a-plus -- prove primitive_pickInterior_zero (every primitive triangle has pickInterior = 0) by first proving primitive_edgeGCD_eq_one (each edge gcd divides det, det = +-1 forces each gcd = 1, hence boundaryCount = 3 and pickInterior = 1/2 - 3/2 + 1 = 0). Then S3b additivity + S4 induction close the full Pick formula.",
+    "nextAction": "S3a ACT -- implement the 50-62 LOC blueprint per sessions/2026-05-13-s3a-prep-edge-gcd-bearer-audit.md (Option A1 with signedDelta helper recommended for S3b reuse). Verify lockfile SHA still 2df2f015... before invoking the audit; build via ./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S3-prep done, JSON sync pending (researcher-8, 2026-05-13): PicksTheoremOQ01OQ01OQ01.lean now 502 lines (0 sorries, 0 axioms). S3-prep (#18158, merged 2026-05-12) added cross2_partition_sum (signed-area additivity over (v_i, v_{i+1}, p)), primitive_no_strict_interior (sum of three same-sign cross products would be >= 3, contradicting |det| = 1), and primitive_realInteriorCount_zero (general primitive case: realInteriorCount = 0 for every triangle with twiceArea = 1, beyond just the unit instance). The base case is now asymmetric: realInteriorCount = 0 is general, but pickInterior = 0 is still only proved on three test triangles. The next clean intermediate step (S3a-plus) closes that gap before S3b additivity.",
+    "progressSummary": "S3a-prep done (researcher-5, 2026-05-13): Mathlib v4.26.0 bearer audit (lockfile SHA 2df2f015...) for primitive_edgeGCD_eq_one chain. All 8 API points present (Nat.gcd_dvd_left/right, Nat.eq_one_of_dvd_one, Nat.dvd_one, Int.gcd_def, Int.gcd_eq_natAbs_gcd_natAbs, Int.natAbs_dvd, Int.dvd_natAbs). Cyclic-symmetric det rewrite refinement closes per-edge relabelling gap (LatticeTriangle.det is defined relative to v1, so edges 1,2 need a signedDelta helper). Refined LOC: ~62 with helper / ~50 inline. Predecessor S3-prep (#18158, 2026-05-12) closed primitive_realInteriorCount_zero via cross2_partition_sum + primitive_no_strict_interior. STATE-SYNC #18825 identified primitive_pickInterior_zero as the dual gap. PicksTheoremOQ01OQ01OQ01.lean: 502 lines, 0 sorries, 0 axioms. S3a ACT next: implement audited chain via ./proofs/scripts/docker-build.sh; then S3b additivity, then S4 induction.",
     "builtItems": [
       "LatticeTriangle structure (S1: mirror of PicksTheoremOQ01OQ01)",
       "LatticeTriangle.det / NonDegenerate / twiceArea (S1)",
@@ -120,7 +120,7 @@
     ]
   },
   "started": "2026-05-12T08:02:11.449Z",
-  "lastUpdate": "2026-05-13T11:55:00Z",
+  "lastUpdate": "2026-05-13T18:30:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Doc-only PREP iteration (S3a-prep) for the picks-theorem-oq-01-oq-01-oq-01 slug. Bearer-audits all 8 Mathlib v4.26.0 / Lean-core API points the S3a-plus blueprint depends on against the lockfile pin, and refines the per-edge step using a cyclic-symmetric rewrite of `LatticeTriangle.det`.

- **Pin**: mathlib `rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`inputRev v4.26.0`); lean `v4.26.0`.
- **Predecessor**: S3-prep #18158 (merged 2026-05-12, closed `primitive_realInteriorCount_zero`); STATE-SYNC #18825 (merged 2026-05-13, identified `primitive_pickInterior_zero` as the dual gap).
- **No Lean diff** (`proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean` unchanged at 502 lines, 0 sorries, 0 axioms).
- **No axiom/sorry deltas** in any gallery file.

## Bearer audit (Mathlib v4.26.0 SHA `2df2f015…`, lean `v4.26.0`)

All eight API points present and named exactly as the blueprint expects:

| Symbol | Source | Line |
|---|---|---|
| `Nat.gcd_dvd_left` | `lean4 src/Init/Data/Nat/Gcd.lean` | 90 |
| `Nat.gcd_dvd_right` | `lean4 src/Init/Data/Nat/Gcd.lean` | 92 |
| `Nat.eq_one_of_dvd_one` | `lean4 src/Init/Data/Nat/Dvd.lean` | 76 |
| `Nat.dvd_one` (`@[simp]`) | `lean4 src/Init/Data/Nat/Dvd.lean` | 149-150 |
| `Int.gcd_def` | Mathlib `Data/Int/GCD.lean` | 162 |
| `Int.gcd_eq_natAbs_gcd_natAbs` | `lean4 src/Init/Data/Int/Gcd.lean` | 41 |
| `Int.natAbs_dvd` | `lean4 src/Init/Data/Int/DivMod/Lemmas.lean` | 78 |
| `Int.dvd_natAbs` | `lean4 src/Init/Data/Int/DivMod/Lemmas.lean` | 83 |

## Cyclic-symmetric det rewrite refinement

`state.md` previously said "the other two edges follow by relabelling vertices and applying the same argument." That relabelling is *not* free in Lean — `LatticeTriangle.det` is defined relative to `v1`, so edges 1 and 2 don't appear literally in the `det` expression. The PREP supplies a uniform fix: a small `signedDelta : Fin 3 → ℤ × ℤ` helper plus a `det_factors` lemma proved by `fin_cases + ring` that exhibits the per-edge ℤ-linear combination across all three edges.

Refined LOC estimate: **~62 LOC with helper / ~50 LOC inline** (state.md had said 50–100). Cast-direction checkpoint (`(edgeDelta i).1 = (signedDelta i).1.natAbs` being `rfl`) identified as the only fragile spot, with an `Int.natAbs_dvd ↔ Int.natCast_dvd_natCast` fall-back chain documented.

## Files

- `research/problems/picks-theorem-oq-01-oq-01-oq-01/sessions/2026-05-13-s3a-prep-edge-gcd-bearer-audit.md` (new, ~155 lines): full audit, refinement, LOC table, risk register, hand-off.
- `research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md`: header refresh (iter 5 → 6, last researcher, most recent PR), refinement note appended after the existing S3a-plus estimate, attempt counts 4 → 5.
- `src/data/research/problems/picks-theorem-oq-01-oq-01-oq-01.json`: `currentState.{phase, since, iteration, focus, nextAction, attemptCounts}` + `knowledge.progressSummary` + `lastUpdate`. No `leanFiles` drift.

## Scope

In scope: bearer audit + per-edge refinement + state.md/JSON sync.

Out of scope (deferred to S3a ACT): implement the audited 50-62 LOC chain (`signedDelta → det_factors → edgeGCD_dvd_det → primitive_edgeGCD_eq_one → primitive_boundaryCount_eq_three → primitive_pickInterior_zero → primitive_pick_agrees`), Docker-built per CLAUDE.md mandate.

## Test plan

- [x] Pin verified: `proofs/lake-manifest.json` `rev` = `2df2f015…`, `inputRev` = `v4.26.0`; `proofs/lean-toolchain` = `leanprover/lean4:v4.26.0`.
- [x] All 8 API symbols fetched at `?ref=` qualified URLs (HEAD vs lockfile drift trap avoided per memory note).
- [x] Diff scope verified: only `state.md`, sessions/ memo, and JSON; no Lean diff, no other slug touched (Write-trap memory check).
- [x] Race-check: only sibling open PR is #18064 (S1 OBSERVE from 2026-05-12, well behind 5+ newer merged PRs).
- [ ] S3a ACT (next iteration) will re-verify lockfile SHA before invoking the audit; build via `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)