### PR TITLE
research(ehrhart-cube-proven-oq-02): STATE-SYNC — top-level JSON + state.md to S7 COMPLETED (doc-only)

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -4,7 +4,7 @@
 **Phase**: COMPLETED — verified, axiom-free, sorry-free
 **Path**: incremental sorry closure (S0 → S2 → S3 → S4 → S6 → S7)
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (S7)
+**Last Updated**: 2026-05-13 (STATE-SYNC: top-level JSON `phase`/`status`/`progressSummary` + `leanFiles[0]` counts refreshed to S7 outcome; duplicate stale S6 block removed from this file)
 **Iteration**: 7
 
 ## Outcome (S7, researcher-10, 2026-05-08)
@@ -31,135 +31,62 @@ S7 also restructured `fiber_card_eq_crossBall_card` to `set fwd / bwd with hfwd_
 hbwd_def` + `refine Finset.card_bij' fwd bwd ?_ ?_ ?_ ?_` (functionally equivalent to
 main's PR #17355 annotation-only fix; both compile).
 
+## Slicing decomposition (S6/S7 architecture)
 
----
+Three new private lemmas added on top of the S3–S4 foundation:
+- `crossBall_succ_d_fiber_card` (~80 lines): for each `j : Fin (2n+1)`, the fiber of
+  `fun y => y (Fin.last d)` over `j` in `crossBall (d+1) n` is in bijection with
+  `crossBall d M_j` where `M_j := if j.val ≤ n then j.val else 2n - j.val
+  = n - cweight(j, n)`. Routed via `Fin.init`/`Fin.snoc` to drop/insert the last
+  coordinate, and `fiber_card_eq_crossBall_card d n M_j (by omega)` from S4 to bridge.
+- `crossBall_succ_d_slice` (~10 lines): the projection `(crossBall (d+1) n).card =
+  ∑ j : Fin (2n+1), (fiber j).card` via `Finset.card_eq_sum_card_fiberwise`.
+- `sum_crossBall_pair` (~55 lines): the j↔(2n−j) pairing
+  `∑ j ∈ range (2n+1), (crossBall d (n - cweight(j, n))).card
+   = (crossBall d n).card + 2 · ∑ m ∈ range n, (crossBall d m).card`
+  via splitting `range (2n+1) = range n ∪ {n} ∪ Ico (n+1) (2n+1)` and reversing the
+  high half through `Finset.sum_nbij'` with `m ↦ 2n - m`.
 
-# Research State: ehrhart-cube-proven-oq-02
+`crossBall_card` itself is then closed by `induction d generalizing n` so the IH
+applies at every `m ≤ n`; the three pieces combine via `crossEhrhart_succ_d` to match
+the recursion exactly.
 
-## Current State
-**Phase**: ACT — Mathlib API drift fix (S6); 1 sorry remains
-**Path**: incremental sorry closure
-**Since**: 2026-05-07
-**Last Updated**: 2026-05-08
-**Iteration**: 6
+## Session History
 
-## Current Focus
-One sorry remains in `proofs/Proofs/EhrhartCrossPolytope.lean`:
-- `crossBall_card` succ-d case — slicing decomposition that uses
-  `fiber_card_eq_crossBall_card` (this session) once fibers are
-  identified with the filter-set form.
+- **Session 1** (researcher-8, OBSERVE): mapped Mathlib tools for `crossEhrhart_is_poly`
+  (descPochhammer-based).
+- **Session 2** (researcher-8, ACT): closed `crossEhrhart_is_poly` (PR #16734).
+- **Session 3** (researcher-11, ACT): added `cweight_le_iff` and `cweight_translate`
+  foundation helpers.
+- **Session 4** (researcher-9, ACT): added `cweight_sum_individual`, `cweight_sum_range`,
+  and `fiber_card_eq_crossBall_card` (via `Finset.card_bij'`).
+- **Session 5** (researcher-12, ORIENT): wrote slicing decomposition spec
+  (`session-5-slicing-spec.md`); deferred Lean prototype.
+- **Session 6** (researcher-1, ACT): Mathlib API drift fix. Three-bug bundle restoring
+  origin/main buildability: (a) `Polynomial.descPochhammer` → `descPochhammer` (5 refs)
+  + `Polynomial.descPochhammer_succ_right` → `descPochhammer_succ_right` (2 refs);
+  (b) drop redundant `ring` after `field_simp [hk_ne]` in `crossEhrhart_is_poly`;
+  (c) explicit `Fin (2 * M + 1)` / `Fin (2 * n + 1)` annotations on bijection lambdas
+  in `Finset.card_bij'` for `fiber_card_eq_crossBall_card`. Build verified via
+  `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope` after `rm proofs/.lake`
+  (broken self-symlink).
+- **Session 7** (researcher-10, ACT, PR #17362): slicing decomposition + final sorry
+  closure as documented above.
 
-## Active Approach (helpers + slicing)
+## Follow-Up (optional, post-completion)
 
-The slicing argument uses the centered-weight characterization. Five
-foundation lemmas are now in place:
-
-- `cweight_le_iff (n a M : ℕ)` — `(if a ≤ n then n - a else a - n) ≤ M
-  ↔ n - M ≤ a ∧ a ≤ n + M`. (Session 3)
-- `cweight_translate (n M a : ℕ) (hM : M ≤ n) (h_lo : n - M ≤ a)
-  (h_hi : a ≤ n + M)` — bridge identity; cweight at center `n` of `a`
-  equals cweight at center `M` of `a - (n - M)`. (Session 3)
-- `cweight_sum_individual {d n M} (y) (hsum) (j)` — sum bound implies
-  individual bound. (Session 4)
-- `cweight_sum_range {d n M} (hM) (y) (hsum) (j)` — sum bound + `M ≤ n`
-  forces `(y j).val ∈ [n - M, n + M]`. (Session 4)
-- `fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n)` — the cardinality
-  identity: `{y : Fin d → Fin (2n+1) | Σ cweight(y, n) ≤ M}` is in bijection
-  with `crossBall d M`, via `yᵢ ↦ ⟨(yᵢ).val - (n - M), _⟩`. (Session 4,
-  via `Finset.card_bij'`, ~80 lines.)
-
-## Path to closing the remaining sorry
-
-1. **Slicing** (the rest of `crossBall_card` succ-d, ≈80–120 lines):
-   `(crossBall (d+1) n).card = ∑ j : Fin (2n+1), (fiber j).card`
-   via `Finset.card_eq_sum_card_fiberwise` projecting on the last coord.
-   For each `j`, the fiber is in bijection with the filter-set used by
-   `fiber_card_eq_crossBall_card` for `M_j = if j.val ≤ n then j.val
-   else 2n - j.val` (= `n - cweight(j, n)`). Apply
-   `fiber_card_eq_crossBall_card d n M_j (by omega)` to get
-   `(fiber j).card = (crossBall d M_j).card`.
-   - The fiber-to-filter-set bijection itself is via `Fin.snoc` /
-     `Fin.init`: drop the last coordinate, and the remaining d
-     coordinates satisfy the cweight-sum-bound at center `n` with
-     budget `M_j`.
-
-2. **j↔(2n−j) pairing**: `∑ j ∈ Finset.range (2n+1),
-   crossEhrhart d (n - cweight(j, n)) = crossEhrhart d n + 2 · ∑ m ∈ range n,
-   crossEhrhart d m` by splitting `range (2n+1) = range n ∪ {n} ∪
-   range n` (shifted by `n+1`) and reversing the high half via the
-   bijection `m ↦ n - 1 - m` (or via `Finset.sum_nbij'`).
-
-3. **Apply IH**: requires `induction d generalizing n` so the IH gives
-   `(crossBall d m).card = crossEhrhart d m` for **every** m. Then
-   `crossEhrhart_succ_d` closes the proof.
-
-## Attempt Count
-- Total attempts: 6
-- Approaches tried:
-  - Session 1 (researcher-8, OBSERVE): mapped Mathlib tools for
-    `crossEhrhart_is_poly` (descPochhammer-based)
-  - Session 2 (researcher-8, ACT): closed `crossEhrhart_is_poly` (PR #16734)
-  - Session 3 (researcher-11, ACT): added `cweight_le_iff` and
-    `cweight_translate` foundation helpers
-  - Session 4 (researcher-9, ACT): added `cweight_sum_individual`,
-    `cweight_sum_range`, and `fiber_card_eq_crossBall_card` (via
-    `Finset.card_bij'`)
-  - Session 5 (researcher-12, ORIENT): wrote slicing decomposition spec
-    (`session-5-slicing-spec.md`); deferred Lean prototype
-  - Session 6 (researcher-1, ACT): **Mathlib API drift fix**. After
-    deleting the broken `proofs/.lake` self-symlink and running the
-    Docker build, found that origin/main no longer compiles due to
-    Mathlib API drift since PR #16734 / #17008 merged unverified.
-    Three fixes restored buildability:
-    (a) `Polynomial.descPochhammer` → `descPochhammer` (5 refs);
-        `Polynomial.descPochhammer_succ_right` → `descPochhammer_succ_right` (2 refs).
-        `descPochhammer` lives at the root namespace (after `open Polynomial`),
-        not inside `namespace Polynomial`.
-    (b) Removed redundant `ring` after `field_simp [hk_ne]` in
-        `crossEhrhart_is_poly` (field_simp now closes the goal directly).
-    (c) Added explicit `Fin (2 * M + 1)` and `Fin (2 * n + 1)` type
-        annotations to the Forward/Backward bijection lambdas inside
-        `Finset.card_bij'` for `fiber_card_eq_crossBall_card`. Without
-        the annotations, Lean's elaborator failed to fix the lambda's
-        codomain, leaving the Fin-bound proof obligation unmaterialized
-        ("No goals to be solved" at the inner `by` block) and leaving
-        a stray metavariable inside the post-`simp only [crossBall, ...]`
-        sum body ("show tactic failed: pattern not definitionally equal"
-        with `↑?m.56` on the target side).
-    Also bumped `is_lt` → `isLt` (cosmetic; both work).
-    Build verified: `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope`
-    in worktree `researcher-1`, exit 0, 1 sorry / 0 axioms / 538 lines.
-
-## Blockers
-- **Local Lean build**: The recursive self-symlink at
-  `/Users/rwalters/GitHub/lean-genius/proofs/.lake` (and the inherited
-  symlink in fresh worktrees) blocks Docker builds. Workaround:
-  `rm proofs/.lake` in the worktree and let the container clone Mathlib
-  fresh — adds ~10 min for clone + ~5 min for cache get on first use,
-  then incremental builds are ~2 min.
-
-## Next Action
-**For Session 7**: Resume the slicing decomposition prototype from
-`session-5-slicing-spec.md` §4-6 on top of the now-buildable
-origin/main. The S6 prototype committed to local branch
-`research/ehrhart-cube-proven-oq-02-fiber-bij-1778229307`
-(`4e9853d0510`) adds `crossBall_succ_d_fiber_card` (~80 lines),
-`crossBall_succ_d_slice` (~10 lines), `sum_crossBall_pair` (~55 lines)
-and the `crossBall_card` wire-in (~6 lines). When pulled into a fresh
-build it will surface its own Mathlib-drift issues
-(`Finset.card_eq_sum_card_fiberwise` MapsTo vs `∀ x ∈ s, f x ∈ t`,
-`Fin.snoc_last` arg order, possible `change`/`omega` interactions on
-opaque sums) which will likely need fixes similar to Session 6.
+1. Replace `fiber_card_eq_crossBall_card`'s `set`/`refine` refactor with main's simpler
+   annotation-only style (cosmetic; both compile).
+2. Clean up the `le_or_lt` deprecation warning (use `le_or_gt`).
+3. Generate follow-up open questions: permutohedron Ehrhart polynomial axiom-free?
+   hypersimplex? flow polytopes? See `conclusion.openQuestions` in `meta.json`.
 
 ## References
-- `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight bridge
-  helpers (Session 3)
-- `proofs/Proofs/EhrhartCrossPolytope.lean:356-374` — sum-bound helpers
-  (Session 4)
-- `proofs/Proofs/EhrhartCrossPolytope.lean:376-468` — fiber bijection
-  (Session 4)
-- `proofs/Proofs/EhrhartCrossPolytope.lean:485-490` — main theorem
-  with sorry
+
+- `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight bridge helpers (Session 3)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:356-374` — sum-bound helpers (Session 4)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:376-468` — fiber bijection (Session 4)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:485-490` — main theorem (now closed, Session 7)
 - `proofs/Proofs/EhrhartCrossPolytope.lean:205-215` — `crossEhrhart_succ_d`
-- Mathlib: `Finset.card_bij'`, `Finset.card_eq_sum_card_fiberwise`,
-  `Fin.snoc`, `Finset.sum_nbij'`
+- Mathlib: `Finset.card_bij'`, `Finset.card_eq_sum_card_fiberwise`, `Fin.snoc`,
+  `Finset.sum_nbij'`, `descPochhammer`

--- a/src/data/research/problems/ehrhart-cube-proven-oq-02.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "ehrhart-cube-proven-oq-02",
   "title": "Ehrhart Polynomials Without General Existence Theorem",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S6 (2026-05-08, researcher-1): Mathlib API drift fix restoring origin/main buildability. Three-bug bundle: (1) `Polynomial.descPochhammer` → `descPochhammer` (5 refs) + `Polynomial.descPochhammer_succ_right` → `descPochhammer_succ_right` (2 refs) — Mathlib's `descPochhammer` lives at root namespace after `open Polynomial`, NOT inside `namespace Polynomial`; (2) drop redundant `ring` after `field_simp [hk_ne]` in `crossEhrhart_is_poly` (field_simp now closes); (3) explicit `Fin (2 * M + 1)` / `Fin (2 * n + 1)` annotations on bijection lambdas in `Finset.card_bij'` for `fiber_card_eq_crossBall_card` — without them the elaborator leaves the Fin-bound proof obligation unmaterialized (\"No goals to be solved\" at inner `by`) and a metavariable inside post-`simp only [crossBall, ...]` sum bodies (\"show tactic failed: pattern not definitionally equal\" with `↑?m.56` on target). Build verified via `./proofs/scripts/docker-build.sh Proofs.EhrhartCrossPolytope` after `rm proofs/.lake` (broken self-symlink). Still 1 sorry (`crossBall_card` succ-d) / 0 axioms / 538 lines. S5 slicing spec (`session-5-slicing-spec.md`) and the local-only S6 prototype branch (`4e9853d0510`, ~195 lines) remain valid but deferred — they'll need their own Mathlib-drift fixes when implemented.",
+    "progressSummary": "COMPLETED (S7, researcher-10, 2026-05-08, PR #17362): `crossBall_card` closed via S6 slicing decomposition. Three new private lemmas added — `crossBall_succ_d_fiber_card` (~80 lines via `Finset.card_eq_sum_card_fiberwise` + per-fiber `Fin.snoc`/`Fin.init` bijection), `crossBall_succ_d_slice` (~10 lines), `sum_crossBall_pair` (~55 lines via `Finset.sum_nbij'` for j↔(2n−j) pairing). `crossBall_card` itself closed by `induction d generalizing n` so the IH gives `(crossBall d m).card = crossEhrhart d m` for every m. Build #3 of `Proofs.EhrhartCrossPolytope` exits 0 (only `le_or_lt` deprecation + 2 unused-var warnings — non-blocking). Final file: 720 lines / 22 theorems / 0 sorries / 0 axioms / verified-original. Companion PR #17355 (parallel agent, merged 2026-05-08 22:07Z) addressed 7 pre-existing main compile errors from S2/S4 via `descPochhammer` namespace fix + drop redundant `ring` after `field_simp` + explicit `Fin (2·M+1)` / `Fin (2·n+1)` codomain annotations on bijection lambdas inside `Finset.card_bij'` for `fiber_card_eq_crossBall_card`. S7 (PR #17362) functionally equivalent to #17355's annotation-only fix via `set fwd / bwd with hfwd_def / hbwd_def` + `refine Finset.card_bij' fwd bwd ?_ ?_ ?_ ?_` restructure. Slug graduated; possible follow-up open questions queued in meta.json conclusion.openQuestions (permutohedron/hypersimplex/flow-polytope Ehrhart axiom-free?).",
     "builtItems": [
       "sum_choose_range: hockey-stick Σ C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:118",
       "sum_shift_hockey: sum interchange at EhrhartCrossPolytope.lean:130",
@@ -83,18 +83,18 @@
     "mathlib": []
   },
   "started": "2026-05-06T13:49:03.933Z",
-  "lastUpdate": "2026-05-08T21:50:00.000Z",
+  "lastUpdate": "2026-05-13T13:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/EhrhartCrossPolytope.lean",
       "filename": "EhrhartCrossPolytope.lean",
-      "lineCount": 539,
-      "theoremCount": 14,
+      "lineCount": 720,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCrossPolytope.lean"
     }


### PR DESCRIPTION
## Scope

Doc-only STATE-SYNC. Refreshes top-level research-state JSON + state.md to
match the S7 outcome (verified-original since 2026-05-08, PR #17362).

No Lean source changes; \`meta.json\` (gallery \`src/data/proofs/...\`) not
touched.

## Drift addressed

The Lean file \`proofs/Proofs/EhrhartCrossPolytope.lean\` is verified-original
since S7: 720 lines / 22 theorems / 0 sorries / 0 axioms. JSON
\`currentState.phase\` was correctly updated to "COMPLETED" at that time, but
the following top-level / knowledge fields lagged:

| Field | Stale value | Synced to |
|---|---|---|
| top-level \`phase\` | \`ACT\` | \`COMPLETED\` |
| top-level \`status\` | \`active\` | \`completed\` |
| \`knowledge.progressSummary\` | S6 Mathlib-drift prose | S7 outcome (slicing + induction-d-generalizing-n) |
| \`lastUpdate\` | 2026-05-08T21:50:00Z | 2026-05-13T13:00:00Z |
| \`leanFiles[0].lineCount\` | 539 | 720 |
| \`leanFiles[0].theoremCount\` | 14 | 22 |
| \`leanFiles[0].sorryCount\` | 1 | 0 |

\`state.md\` also carried a duplicate \`# Research State\` header (lines 35-165
of the pre-edit file) re-declaring \`Phase: ACT / 1 sorry remains\` and
listing \`Path to closing the remaining sorry\` as if the work were still
open. This PR removes that duplicate block, folds its still-relevant
contents (helper inventory, attempt count, references) into the surviving
S7 section as new sub-sections (\"Slicing decomposition (S6/S7
architecture)\", \"Session History\", \"References\", \"Follow-Up (optional,
post-completion)\").

## Files touched

- \`src/data/research/problems/ehrhart-cube-proven-oq-02.json\` (+9 / -9)
- \`research/problems/ehrhart-cube-proven-oq-02/state.md\` (+55 / -128)

## Out of scope (separate sync, separate PR if needed)

- \`src/data/proofs/ehrhart-cube-proven-oq-02/meta.json\` top-level
  \`status\`/\`badge\`/\`axiomCount\`/\`sorryCount\` fields are all \`null\`;
  unclear from this slug alone whether that's by-design (other slugs
  have them populated) or another drift class. Out of scope here —
  mechanic territory if it's drift.
- The legacy candidate pool at \`.lean/state/candidate-pool.json\` is
  gitignored; researcher \`update completed && release\` syncs it locally
  (no PR vehicle).
- \`session-5-slicing-spec.md\` referenced from JSON
  \`knowledge.nextSteps\` still exists in the worktree as design history;
  no edits needed.

## Verification

\`\`\`
$ grep -cE '^[[:space:]]*sorry[[:space:]]*\$|:= sorry\$|:= by sorry' proofs/Proofs/EhrhartCrossPolytope.lean
0
$ grep -cE '^axiom\s' proofs/Proofs/EhrhartCrossPolytope.lean
0
$ wc -l proofs/Proofs/EhrhartCrossPolytope.lean
720
\`\`\`

The 2 docstring mentions of \"sorry\" in the file are on lines 661
(\"Closes the final \`sorry\` in this file.\") and 700 (an item in the
\"Open Questions\" comment block) — both inside doc/comment blocks, no
tactic-level sorry.

## Test plan

- [x] \`jq empty\` on edited JSON passes
- [x] State.md renders without the duplicate-header artifact
- [x] No \`meta.json\` (gallery) or \`.lean\` source edits
- [x] No \`loom:review-requested\` label per CLAUDE.md math-PR policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)