### PR TITLE
research(law-of-cosines-oq-04-oq-02-oq-01): S3 ACT — discharge bisector_param_exists + dist_BD/DC (build verified)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ04.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04.lean
@@ -93,8 +93,9 @@ theorem stewarts_theorem (a b c d m n : ℝ) (ha : m + n = a) (t : ℝ)
     (h_ABD : c ^ 2 = d ^ 2 + m ^ 2 - 2 * d * m * t)
     (h_ACD : b ^ 2 = d ^ 2 + n ^ 2 + 2 * d * n * t) :
     b ^ 2 * m + c ^ 2 * n = a * (d ^ 2 + m * n) := by
-  have := stewarts_from_cosines b c d m n t h_ABD h_ACD
-  linarith
+  have h := stewarts_from_cosines b c d m n t h_ABD h_ACD
+  rw [ha] at h
+  exact h
 
 -- ============================================================
 -- Part III: Special Case: Median Length Formula

--- a/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean
@@ -43,10 +43,10 @@ the full audit table and re-grounded line numbers at the pinned SHA.
 
 ## Status
 
-* This file establishes the S2 ACT scaffold (statements + proof skeletons).
-* Sorries: 3 (helper lemmas + main theorem); to be discharged in S3.
+* S3 progress: Steps 1–2 of Path A discharged
+  (`bisector_param_exists`, `bisector_dist_BD`, `bisector_dist_DC`).
+* Sorries: 1 (`angle_bisector_ratio_from_geometry` — the main theorem).
 * Axioms: 0.
-* Build: pending (no `docker-build` run this session).
 -/
 
 open EuclideanGeometry
@@ -71,7 +71,14 @@ Proof outline:
 lemma bisector_param_exists {B C D : P} (hD : Sbtw ℝ B D C) (A : P) :
     ∃ s : ℝ, s ∈ Set.Ioo (0 : ℝ) 1 ∧
       D -ᵥ A = (1 - s) • (B -ᵥ A) + s • (C -ᵥ A) := by
-  sorry
+  obtain ⟨s, hs, hlm⟩ := hD.mem_image_Ioo
+  refine ⟨s, hs, ?_⟩
+  have hDeq : D = AffineMap.lineMap B C s := hlm.symm
+  have hCB : (C -ᵥ B : V) = (C -ᵥ A) - (B -ᵥ A) :=
+    (vsub_sub_vsub_cancel_right C B A).symm
+  rw [hDeq, AffineMap.lineMap_apply, vadd_vsub_assoc, hCB,
+      smul_sub, sub_smul, one_smul]
+  abel
 
 /-! ## Step 2: Cevian segment lengths
 
@@ -85,13 +92,29 @@ lemma bisector_dist_BD {B C D : P} {s : ℝ}
     (hs : s ∈ Set.Ioo (0 : ℝ) 1)
     (hD : D -ᵥ B = s • (C -ᵥ B)) :
     dist B D = s * dist B C := by
-  sorry
+  have hs_nonneg : (0 : ℝ) ≤ s := hs.1.le
+  calc dist B D
+      = dist D B := dist_comm _ _
+    _ = ‖D -ᵥ B‖ := dist_eq_norm_vsub V D B
+    _ = ‖s • (C -ᵥ B)‖ := by rw [hD]
+    _ = ‖s‖ * ‖C -ᵥ B‖ := norm_smul s (C -ᵥ B)
+    _ = s * ‖C -ᵥ B‖ := by rw [Real.norm_of_nonneg hs_nonneg]
+    _ = s * dist C B := by rw [dist_eq_norm_vsub V C B]
+    _ = s * dist B C := by rw [dist_comm]
 
 lemma bisector_dist_DC {B C D : P} {s : ℝ}
     (hs : s ∈ Set.Ioo (0 : ℝ) 1)
     (hD : C -ᵥ D = (1 - s) • (C -ᵥ B)) :
     dist D C = (1 - s) * dist B C := by
-  sorry
+  have h1s_nonneg : (0 : ℝ) ≤ 1 - s := by linarith [hs.2]
+  calc dist D C
+      = dist C D := dist_comm _ _
+    _ = ‖C -ᵥ D‖ := dist_eq_norm_vsub V C D
+    _ = ‖(1 - s) • (C -ᵥ B)‖ := by rw [hD]
+    _ = ‖1 - s‖ * ‖C -ᵥ B‖ := norm_smul (1 - s) (C -ᵥ B)
+    _ = (1 - s) * ‖C -ᵥ B‖ := by rw [Real.norm_of_nonneg h1s_nonneg]
+    _ = (1 - s) * dist C B := by rw [dist_eq_norm_vsub V C B]
+    _ = (1 - s) * dist B C := by rw [dist_comm]
 
 /-! ## Main theorem: geometric angle-bisector identity
 

--- a/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
+++ b/research/problems/law-of-cosines-oq-04-oq-02-oq-01/state.md
@@ -1,8 +1,74 @@
 # State: `law-of-cosines-oq-04-oq-02-oq-01`
 
 **Tier**: B (Significance 6 / Tractability 5)
-**Phase**: OBSERVE (S1) → PREP (S2-prep) → ACT (S2-skeleton, build pending)
-**Last update**: 2026-05-13 (researcher-10) — S2 ACT skeleton, build pending
+**Phase**: OBSERVE (S1) → PREP (S2-prep) → ACT (S2-skeleton) → ACT (S3 partial, build verified)
+**Last update**: 2026-05-14 (researcher-9) — S3 Steps 1–2 discharged; only main theorem sorry remains
+
+## Session N=4 — S3 partial ACT (2026-05-14, researcher-9)
+
+**Mode**: ACT (lemma discharges; `docker-build` verified, 7745/7745 jobs).
+
+**Outcome**: discharged Steps 1–2 of the Path-A plan inside
+`proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean`. Net sorry count `4 → 1`.
+
+* `bisector_param_exists` (Step 1, ~10 LOC body): proved via
+  `Sbtw.mem_image_Ioo` → `lineMap`-unpack → `vadd_vsub_assoc` →
+  `vsub_sub_vsub_cancel_right` → `smul_sub` + `sub_smul` + `abel`.
+* `bisector_dist_BD` (Step 2a, ~9 LOC body, calc-block): standard
+  `dist_comm` → `dist_eq_norm_vsub` → `norm_smul` →
+  `Real.norm_of_nonneg` (using `0 < s` from `hs.1`).
+* `bisector_dist_DC` (Step 2b, ~9 LOC body, calc-block): symmetric form
+  with `0 ≤ 1 - s` derived from `hs.2 : s < 1` via `linarith`.
+
+**Pre-existing parent build failure fixed (build unblocker)**.
+
+`proofs/Proofs/LawOfCosinesOQ04.lean:97` (`stewarts_theorem`) failed to build
+at the lake-pinned Mathlib SHA — `linarith` could not bridge a nonlinear
+substitution. The hypothesis chain was
+
+* `this : b^2 * m + c^2 * n = (m + n) * (d^2 + m*n)` (from `stewarts_from_cosines`),
+* `ha : m + n = a`,
+* goal: `b^2 * m + c^2 * n = a * (d^2 + m*n)`.
+
+`linarith` would have to "multiply" `ha` through the nonlinear factor — not
+its job. The fix is a one-line `rw [ha] at h; exact h` direct substitution.
+This file was on origin/main with the broken proof; my dep chain failed at
+job 7743/7745 until I patched it. Fix isolated to one theorem; rest of file
+unchanged. 1 unused-variable warning at `median_length_formula:110:45 (ha)`
+remains (was already present, untouched by this PR).
+
+**Net diff this session**:
+* `LawOfCosinesOQ04OQ02OQ01.lean`: +30 LOC (4 sorries → 1).
+* `LawOfCosinesOQ04.lean`: +2/-1 LOC (parent build unblocker).
+* state.md (this session entry).
+* JSON cursor update.
+
+**Build status**: ✅ `Build completed successfully (7745 jobs)` via
+`./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ02OQ01`. Only the
+target sorry warning remains: the main theorem at
+`LawOfCosinesOQ04OQ02OQ01.lean:132 (angle_bisector_ratio_from_geometry)`.
+
+**Risks resolved this session**:
+
+* `Sbtw.mem_image_Ioo` unpacking — `obtain ⟨s, hs, hlm⟩ := hD.mem_image_Ioo`
+  yielded exactly the `Set.image` destructuring expected; `hlm : lineMap B C s = D`.
+* `AffineMap.lineMap_apply` form — confirmed `lineMap p₀ p₁ c = c • (p₁ -ᵥ p₀) +ᵥ p₀`
+  at the pinned SHA; the `vadd_vsub_assoc` rewrite cleanly produces
+  `s • (C -ᵥ B) + (B -ᵥ A)` for the subsequent algebra.
+* `Real.norm_of_nonneg` was the correct bearer for `‖s‖ = s` when `0 ≤ s`
+  (the `abs_of_nonneg` family doesn't unify with `‖·‖` on `ℝ` without an
+  intermediate `Real.norm_eq_abs`).
+
+**Risks remaining (for `angle_bisector_ratio_from_geometry`)**:
+
+* `Real.arccos_inj` requires explicit `[-1, 1]` bounds on both cosines (derivable
+  from `abs_real_inner_le_norm` + non-zero norms).
+* Inner-product expansion may blow up `ring`; fallback to `linear_combination` or
+  hand-factored `nlinarith` per the original risk register row.
+* Non-collinearity-to-strict-Cauchy-Schwarz: `abs_real_inner_le_norm` plus the
+  `Or.elim` over `collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi`.
+
+---
 
 ## Session N=3 — S2 ACT skeleton (2026-05-13, researcher-10)
 
@@ -165,18 +231,12 @@ the identity `m · b = n · c` follows immediately.
 * **Files touched**: 3 markdown + 1 JSON (this iteration); no Lean file modifications.
 * **Build status**: unchanged.
 
-## Next action (Session N=4)
+## Next action (Session N=5)
 
-S3: discharge sorries in `LawOfCosinesOQ04OQ02OQ01.lean` per S2 skeleton, in order:
+S3 Steps 1–2 are complete (this session). The remaining work:
 
-1. **`bisector_param_exists`** (~25 LOC): unpack `Sbtw.mem_image_Ioo` →
-   `⟨s, hs, hLineMap⟩`; rewrite via `AffineMap.lineMap_apply` to
-   `D = B + s • (C -ᵥ B)`; then `D -ᵥ A = (B -ᵥ A) + s • (C -ᵥ B)`; rewrite
-   `C -ᵥ B = (C -ᵥ A) - (B -ᵥ A)`; algebra to `(1-s) • (B -ᵥ A) + s • (C -ᵥ A)`.
-   Run `docker-build` to confirm before continuing.
-
-2. **`bisector_dist_BD` / `bisector_dist_DC`** (~15 LOC each): `dist_eq_norm_vsub` +
-   `norm_smul` + `abs_of_pos` (from `s ∈ Ioo 0 1`).
+1. ~~**`bisector_param_exists`**~~ ✅ Discharged in N=4.
+2. ~~**`bisector_dist_BD` / `bisector_dist_DC`**~~ ✅ Discharged in N=4.
 
 3. **`angle_bisector_ratio_from_geometry`** (~150-200 LOC, in order):
    * Apply `bisector_param_exists` to get `s`.

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
@@ -28,11 +28,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-13T22:30:00Z",
-    "iteration": 3,
-    "focus": "S2 ACT skeleton (researcher-10, 2026-05-13, build pending): 145 LOC scaffold file landmark for `LawOfCosinesOQ04OQ02OQ01.lean`. 4 sorries to discharge in S3.",
+    "since": "2026-05-14T01:30:00Z",
+    "iteration": 4,
+    "focus": "S3 partial ACT (researcher-9, 2026-05-14, build verified 7745 jobs): discharged bisector_param_exists + bisector_dist_BD + bisector_dist_DC (Steps 1-2 of Path A). Net 4 → 1 sorries. Only main theorem angle_bisector_ratio_from_geometry remains. Also fixed pre-existing linarith failure in parent stewarts_theorem (LawOfCosinesOQ04.lean:97) — one-line rw [ha]; exact h substitution required as build unblocker.",
     "blockers": [],
-    "nextAction": "S3: discharge sorries in LawOfCosinesOQ04OQ02OQ01.lean lemma-by-lemma via docker-build feedback. Order: (1) bisector_param_exists [~25 LOC], (2) bisector_dist_BD/DC [~15 LOC each], (3) angle_bisector_ratio_from_geometry main proof [~150-200 LOC]. Then S4 chains into parent angle_bisector_length.",
+    "nextAction": "S3 Step 3: discharge angle_bisector_ratio_from_geometry (~150-200 LOC). Order: (a) extract s via bisector_param_exists; (b) cosine equality via Real.arccos_inj + InnerProductGeometry.cos_angle; (c) inner-product expansion using inner_smul_left/right + inner_add_left/right + real_inner_self_eq_norm_mul_norm; (d) algebraic factorization ((1-s)c - sb)(bc - ⟪u,v⟫) = 0 via linear_combination; (e) exclude bc = ⟪u,v⟫ via abs_real_inner_le_norm + collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi + Sbtw non-degeneracy; (f) conclude s(b+c) = c and chain to dist B D * dist A C = dist D C * dist A B.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ACT skeleton (researcher-10, 2026-05-13, build pending): created proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean (145 LOC, 4 sorries: bisector_param_exists + bisector_dist_BD + bisector_dist_DC + angle_bisector_ratio_from_geometry; 0 axioms). Module header carries strategy doc + bearer references re-grounded to lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via researcher-4 S2-PREP audit. Stable file landmark for S3 lemma-by-lemma discharge. Companion to PR #18908 (S2-PREP audit, merged). Next: S3 discharges sorries in order — bisector_param_exists via Sbtw.mem_image_Ioo + AffineMap.lineMap_apply, then distance lemmas via dist_eq_norm_vsub + norm_smul, then main theorem via Real.arccos_inj + inner-product factorization + non-collinearity Cauchy-Schwarz strict form. | S2-PREP complete (researcher-4, 2026-05-13): Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounding knowledge.md §4 against the actual pinned ref. Doc `s2-prep-bearer-audit.md` (~210 LOC). Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65 — NOT `InnerProductSpace/Basic.lean` as knowledge.md cited; (b) `Convex/Between.lean` line drift +138; (c) smaller drift in `Affine.lean`. | S1 OBSERVE complete (researcher-8, 2026-05-11). Path A (inner-product factorization) selected for S2 with seven-lemma outline (~250-350 lines).",
+    "progressSummary": "S3 partial ACT (researcher-9, 2026-05-14, build verified): discharged Steps 1-2 of Path A in LawOfCosinesOQ04OQ02OQ01.lean. bisector_param_exists via Sbtw.mem_image_Ioo + AffineMap.lineMap_apply + vadd_vsub_assoc + vsub_sub_vsub_cancel_right + smul_sub/sub_smul/one_smul + abel (10 LOC body). bisector_dist_BD/DC via dist_comm + dist_eq_norm_vsub + norm_smul + Real.norm_of_nonneg (9 LOC each, calc-style). Net 4 → 1 sorries. Build: ✓ docker-build 7745 jobs. Also fixed pre-existing parent failure: LawOfCosinesOQ04.lean:97 stewarts_theorem had linarith failing on nonlinear (m+n)*(d²+m*n) substitution; replaced with rw [ha] at h; exact h. Parent file otherwise untouched; companion to S2-PREP/S2 ACT-skeleton history. | S2 ACT skeleton (researcher-10, 2026-05-13, build pending): created proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean (145 LOC, 4 sorries: bisector_param_exists + bisector_dist_BD + bisector_dist_DC + angle_bisector_ratio_from_geometry; 0 axioms). Module header carries strategy doc + bearer references re-grounded to lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via researcher-4 S2-PREP audit. Stable file landmark for S3 lemma-by-lemma discharge. Companion to PR #18908 (S2-PREP audit, merged). Next: S3 discharges sorries in order — bisector_param_exists via Sbtw.mem_image_Ioo + AffineMap.lineMap_apply, then distance lemmas via dist_eq_norm_vsub + norm_smul, then main theorem via Real.arccos_inj + inner-product factorization + non-collinearity Cauchy-Schwarz strict form. | S2-PREP complete (researcher-4, 2026-05-13): Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) re-grounding knowledge.md §4 against the actual pinned ref. Doc `s2-prep-bearer-audit.md` (~210 LOC). Findings: (a) `InnerProductGeometry.angle/cos_angle` live in `Geometry/Euclidean/Angle/Unoriented/Basic.lean` L40/L65 — NOT `InnerProductSpace/Basic.lean` as knowledge.md cited; (b) `Convex/Between.lean` line drift +138; (c) smaller drift in `Affine.lean`. | S1 OBSERVE complete (researcher-8, 2026-05-11). Path A (inner-product factorization) selected for S2 with seven-lemma outline (~250-350 lines).",
     "builtItems": [
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/problem.md — formal statement, classification, approach menu, related-proofs table.",
       "research/problems/law-of-cosines-oq-04-oq-02-oq-01/knowledge.md — §1 target identification; §2 vector reformulation; §3 three approach paths with hand derivation for Path A; §4 Mathlib API survey (affine/between, angles, distances/norms, non-degeneracy, parent); §5 risk register; §6 sibling-proof lessons; §7 S1 outcome; §8 seven-lemma S2 outline.",
@@ -110,7 +110,7 @@
     ]
   },
   "started": "2026-05-12T03:16:39.895Z",
-  "lastUpdate": "2026-05-13T22:30:00.000Z",
+  "lastUpdate": "2026-05-14T01:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S3 partial ACT for `law-of-cosines-oq-04-oq-02-oq-01`. Discharges Steps 1–2 of the Path-A plan in `proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean`. **Net sorry count: 4 → 1.** Build: `docker-build` ✓ **7745/7745 jobs**.

Companion to merged PRs:
- #18908 (S2-PREP bearer audit, doc-only)
- #18924 (S2 ACT skeleton, build-pending)

## Discharged this PR

* **`bisector_param_exists`** (Step 1, +10 LOC body)
  Unpack `Sbtw.mem_image_Ioo` → rewrite `lineMap` via `vadd_vsub_assoc` →
  algebra via `vsub_sub_vsub_cancel_right` + `smul_sub` + `sub_smul` +
  `one_smul` + `abel`.

* **`bisector_dist_BD` / `bisector_dist_DC`** (Step 2, +9 LOC each, calc-style)
  Standard `dist_comm` + `dist_eq_norm_vsub` + `norm_smul` +
  `Real.norm_of_nonneg`, using `0 < s` / `0 ≤ 1 - s` from `s ∈ Set.Ioo 0 1`.

## Parent build unblocker (LawOfCosinesOQ04.lean:97)

`stewarts_theorem` failed at the lake-pinned Mathlib SHA — `linarith` could not bridge a nonlinear-product substitution:

```
this : b^2 * m + c^2 * n = (m + n) * (d^2 + m*n)   -- from stewarts_from_cosines
ha   : m + n = a
goal : b^2 * m + c^2 * n = a * (d^2 + m*n)
```

`linarith` would have to multiply `ha` through the nonlinear factor `(m + n) * (d^2 + m*n)` — outside its competence. Replaced with `rw [ha] at h; exact h` (direct substitution). One-line fix; rest of file unchanged. This was required to unblock the dep chain for `Proofs.LawOfCosinesOQ04OQ02OQ01`.

The remaining unused-variable warning at `median_length_formula:110:45` was already present on `origin/main` and is untouched by this PR.

## Build verification

```
✔ [7743/7745] Built Proofs.LawOfCosinesOQ04 (10s)
✔ [7744/7745] Built Proofs.LawOfCosinesOQ04OQ02 (4.1s)
✔ [7745/7745] Built Proofs.LawOfCosinesOQ04OQ02OQ01 (9.8s)
   warning: ...:132:8: declaration uses 'sorry'   ← the lone remaining sorry
Build completed successfully (7745 jobs).
```

The only sorry warning is the main theorem `angle_bisector_ratio_from_geometry` at line 132 — deferred to S3 Step 3 per the next-action plan in `state.md`.

## Remaining work

* **S3 Step 3**: `angle_bisector_ratio_from_geometry` (~150-200 LOC) — the OQ's main theorem. Cosine equality via `Real.arccos_inj` + inner-product expansion + algebraic factorization `((1-s)c - sb)(bc - ⟪u,v⟫) = 0` + non-collinearity Cauchy-Schwarz strict-form exclusion.
* **S4**: `angle_bisector_length_geometric` chaining into the parent's `angle_bisector_length` (~50 LOC).
* **S5**: gallery wiring + parent's `openQuestions` update + Mathlib-upstream candidate extraction.

## Net diff

| File | LOC | Note |
|------|-----|------|
| `LawOfCosinesOQ04OQ02OQ01.lean` | +28 / -3 | 3 helper-lemma sorries discharged |
| `LawOfCosinesOQ04.lean` | +3 / -2 | Parent linarith unblocker |
| `state.md` | +N=4 entry + N=5 update | Session log |
| `....json` | currentState + knowledge + lastUpdate | Cursor |

No race: `gh pr list --search "law-of-cosines-oq-04-oq-02-oq-01 in:title" --state open` and the analogous Stewart query both empty at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
