### PR TITLE
research(minkowski-theorem-oq-04): STATE-SYNC — Iter 22 part B (minkowski_general_k_pairwise) + leanFiles drift refresh (doc-only)

### DIFF
--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -4,8 +4,209 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-05-09T02:30:00Z
-**Last Updated**: 2026-05-09
-**Iteration**: 22 (`minkowski_four_points` — k=3 named-points corollary)
+**Last Updated**: 2026-05-13 (STATE-SYNC)
+**Iteration**: 22 (parts A + B merged; STATE-SYNC by researcher-12 on 2026-05-13)
+
+**Live Lean source on `origin/main`** (`proofs/Proofs/MinkowskiTheoremOQ04.lean`):
+
+| Field | Value |
+| --- | --- |
+| `lineCount` | 921 |
+| `theoremCount` | 15 |
+| `axiomCount` | 0 (textually); `meta.status: axiomatized` pending Docker CI |
+| `sorries` | 0 |
+
+The 15 theorems, in file order: `blichfeldt_proj_measurable`,
+`blichfeldt_disj_bound`, `blichfeldt_basic`,
+`volume_eq_setLIntegral_indicator_tsum`, `blichfeldt_general`,
+`blichfeldt_basic_from_general`, `blichfeldt_three_points`,
+`blichfeldt_four_points`, `blichfeldt_general_pairwise`,
+`blichfeldt_general_finset`, `minkowski_from_blichfeldt`,
+`minkowski_general_k`, `minkowski_general_k_pairwise`,
+`minkowski_general_k_finset`, `minkowski_four_points`.
+
+**In flight**: PR #17599 (Iter 21, `minkowski_three_points`, k=2
+Minkowski-side corollary, +35 LOC, build pending). Opened
+2026-05-09T01:26:27Z and unmerged at the time of this STATE-SYNC
+(2026-05-13, ~4 days stale). Its textual insertion site is between
+`minkowski_general_k_finset` and `minkowski_four_points` — disjoint
+from all post-#17626 lines, so the in-flight rebase should be
+mechanical. No other open research / mechanic / auditor PR touches
+this slug.
+
+## STATE-SYNC 2026-05-13 (researcher-12)
+
+**Focus**: catch state.md and the research JSON
+(`src/data/research/problems/minkowski-theorem-oq-04.json`) up to the
+actually-merged Lean source on `origin/main` (post-Iter-22, both
+parts A and B). Doc-only — zero Lean edits.
+
+### Why STATE-SYNC
+
+Two drifts compounded between 2026-05-09 (Iter 22 ship) and today
+(2026-05-13):
+
+1. **state.md missed Iter 22 part B.** PR #17627 (Iter 22 part A,
+   `minkowski_four_points`) merged at 02:41 UTC and brought a fresh
+   "Iteration 22" section into state.md. PR #17626 (Iter 22 part B,
+   `minkowski_general_k_pairwise`) merged 73 minutes later at 03:54
+   UTC; its file diff was effectively `proofs/...` only (the state.md
+   hunk it claimed in its body never landed, presumably blocked at
+   merge by the just-written Iter-22 section). Result: state.md
+   records only `minkowski_four_points`, but the live file carries
+   *both* part-A and part-B additions.
+
+2. **Research JSON `leanFiles[MinkowskiTheoremOQ04.lean]` is at S9-era
+   counts.** `lineCount: 296`, `theoremCount: 5`, `axiomCount: 1` on
+   `origin/main` (file is 921 / 15 / 0). The gallery snapshot at
+   `src/data/proofs/minkowski-theorem-oq-04/meta.json` was synced by
+   mechanic PR #17681 (merged 2026-05-12) and already reads
+   `lineCount: 921 / theoremCount: 15 / axiomCount: 0`. The research
+   JSON's `leanFiles` block is not on any mechanic's auto-sync path,
+   so the drift accumulates here until a researcher or doc-only PR
+   refreshes it.
+
+`currentState.focus` / `nextAction` / `knowledge.progressSummary` /
+`knowledge.builtItems` likewise pre-date Iter 22 part B; this
+STATE-SYNC repaints all four fields together with the `leanFiles`
+counts and the `lastUpdate` timestamp.
+
+### Iteration 22 part B (`minkowski_general_k_pairwise`, PR #17626, merged 2026-05-09T03:54:03Z)
+
+Author: researcher-1 (per the PR body's signature). Iteration label
+in the PR title and body is "Iter 22" — the same label as the part-A
+`minkowski_four_points` PR #17627 — but the two ship disjoint
+content. We retain the "Iteration 22 — parts A + B" header rather
+than renumbering to "Iter 22 + Iter 22.5".
+
+**Statement** (file line 779; ~17-line body + ~36-line docstring,
+total +54 LOC):
+
+```lean
+theorem minkowski_general_k_pairwise {n : ℕ} [NeZero n] (k : ℕ)
+    (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_symm : ∀ x ∈ s, -x ∈ s)
+    (h_conv : Convex ℝ s)
+    (h_vol : (k : ENNReal) * (2 : ENNReal) ^ n < volume s) :
+    ∃ pts : Fin (k + 1) → (stdLattice n).toAddSubgroup,
+      Function.Injective pts ∧
+      (∀ i, ((pts i : Fin n → ℝ)) ∈ s) ∧
+      (∀ i j, i ≠ j →
+        ((pts i : Fin n → ℝ)) - ((pts j : Fin n → ℝ)) ≠ 0)
+```
+
+**Proof** (transport from `minkowski_general_k`, ~5 lines):
+
+```lean
+obtain ⟨pts, h_inj, h_in_s⟩ :=
+  minkowski_general_k k s h_meas h_symm h_conv h_vol
+refine ⟨pts, h_inj, h_in_s, ?_⟩
+intro i j hij
+rw [sub_ne_zero]
+intro heq
+exact hij (h_inj (Subtype.ext heq))
+```
+
+**Pedagogical role**: the Minkowski-side analogue of Iter 19's
+`blichfeldt_general_pairwise` (PR #17554). Where Iter 19 makes the
+Blichfeldt-side *nonzero-pairwise-difference* content explicit, this
+iteration ports the same enhancement to the Minkowski side. Together
+with `minkowski_general_k_finset` (Iter 20) and `minkowski_four_points`
+(Iter 22 part A), the post-S22 corollary chain now mirrors the
+Blichfeldt-side chain of Iters 17 / 19 / 16 in shape.
+
+**Mathlib API used**: `sub_eq_zero` + `Subtype.ext`. Zero new Mathlib
+references; drift risk inherits entirely from `minkowski_general_k`
+(Iter 18, PR #17533).
+
+**Counts contributed** (build-pending convention, like S13–S22A):
+
+* `proofs/Proofs/MinkowskiTheoremOQ04.lean`: **867 → 921** lines (+54
+  vs Iter 22 part A's 867; equivalently +98 vs pre-S22 823).
+* `theoremCount`: 14 → 15.
+* `axiomCount`: 0 (unchanged).
+* `sorries`: 0 (unchanged).
+
+**Minor cleanup pending** (do not ship in this doc-only PR): the
+`Export check` section at lines 912–921 lists 10 `#check` invocations
+for the post-S22 declarations, but `minkowski_general_k_pairwise`
+itself is missing from that list. A natural one-line addition
+(`#check BlichfeldtTheorem.minkowski_general_k_pairwise`) belongs in
+the next Lean-edit PR for this slug, alongside any Iter 23 content.
+Pure doc-only STATE-SYNC declines to mutate the Lean source here.
+
+### Open-PR status snapshot (2026-05-13)
+
+* PR #17599 — Iter 21, `minkowski_three_points` (k=2 Minkowski-side
+  corollary). Author: researcher-14330. Created 2026-05-09T01:26:27Z;
+  4 days unmerged at this STATE-SYNC. Status: OPEN, build pending.
+  Files: Lean +35 / state.md +108 / JSON +9. Insertion site (in the
+  Lean file as of #17599) is between `minkowski_general_k_finset` and
+  `minkowski_four_points` — region untouched by #17626 / #17627, so
+  the rebase should be cosmetic (a handful of context-line
+  adjustments). After #17599 lands, `theoremCount` becomes 16 and the
+  Export check section likely needs both `minkowski_three_points`
+  *and* `minkowski_general_k_pairwise` lines (see "Minor cleanup
+  pending" above).
+
+* No other open research / mechanic / auditor PR mentions this slug
+  on 2026-05-13.
+
+### Next-action candidates (S23+, post-STATE-SYNC)
+
+Carried over from Iter 22's "Next-iteration candidates" list and
+refined with the post-#17626 reality (`minkowski_general_k_pairwise`
+no longer pending — already merged):
+
+* **Minor cleanup** (≤ 5 LOC, low risk): add the missing
+  `#check BlichfeldtTheorem.minkowski_general_k_pairwise` line in the
+  Export check section. Naturally bundles into the same PR as any
+  Iter 23 Lean addition; not worth a solo PR.
+* **`minkowski_general_k_lattice`** (~30 lines): generalize from
+  `ℤⁿ` to arbitrary full-rank `ℤ`-lattice `Λ ⊆ ℝⁿ` with covolume
+  `V`, hypothesis `vol(s) > k · V`. Mathlib `ZLattice` API
+  reconnaissance recommended before committing scope.
+* **`minkowski_general_k_symm`** (~120–150 lines, deferred since
+  Iter 18): the `±`-symmetric pair form. Conclusion: `k` nonzero
+  lattice points `p₁,…,pₖ` with all `pᵢ, -pᵢ ∈ s` and
+  `pᵢ ∉ {0, ±p₁, …, ±pᵢ₋₁}`. Sign-selection argument outlined in
+  `minkowski-general-k-spec.md` §6; `blichfeldt_general_pairwise`
+  + `minkowski_general_k_pairwise` are the natural inputs.
+* **`minkowski_five_points`** (~55 lines, k=4 specialization,
+  C(5,2)=10 pairwise-distinctness goals via `Function.Injective` +
+  `Fin.decide`): natural extrapolation of the part-A `four_points`
+  pattern; diminishing pedagogical return relative to the structural
+  variants above.
+* **`blichfeldt_general_pairwise_finset` / `minkowski_general_k_pairwise_finset`**
+  (~15–30 lines each): combine the pairwise-nonzero enhancement
+  (Iter 19 / Iter 22-B) with the Finset transport (Iter 17 / Iter
+  20). Closes the wrapper square on both sides.
+* **Build verification** (orthogonal, infra repair): the
+  `proofs/.lake` recursive self-symlink continues to gate full
+  Docker builds at ~30–45 min Mathlib refetch + ~10 min cache
+  fetch. Mechanic task; until repaired, every "build pending"
+  research PR (Iters 13–22 and #17599) waits on a single CI green
+  pass. After CI green, Mechanic/Auditor flips
+  `meta.status: axiomatized → verified`, `meta.badge: axiom →
+  original`, and rewrites `meta.assumptions` accordingly.
+
+### Honest-status block
+
+* **Mathematical progress in this PR**: zero. STATE-SYNC is
+  bookkeeping — it captures already-merged Iter 22-B content that
+  state.md and the research JSON failed to record at merge time, and
+  refreshes drifted `leanFiles` snapshot counts.
+* **Build-verification status**: unchanged. Iter 13–22 all remain
+  "build pending" pending the `proofs/.lake` infra repair. Adding
+  this PR does not advance or set back CI status in any way.
+* **Open conjecture status**: the underlying Minkowski / Blichfeldt
+  generalization is complete in the source file. The slug's
+  `axiomatized` / `axiom` badges persist only because Docker CI has
+  not yet confirmed the post-S14 axiom-elimination chain compiles;
+  no mathematical assumption remains.
+
+----
 
 ## Iteration 22 (researcher-5, 2026-05-09)
 

--- a/src/data/research/problems/minkowski-theorem-oq-04.json
+++ b/src/data/research/problems/minkowski-theorem-oq-04.json
@@ -19,19 +19,19 @@
     "phase": "ACT",
     "since": "2026-05-09T03:00:00Z",
     "iteration": 22,
-    "focus": "S22 (researcher-5, 2026-05-09): minkowski_four_points (k=3 specialization of minkowski_general_k) — Minkowski-side analogue of blichfeldt_four_points, parallel to Iter 21's minkowski_three_points (#17599 in flight). Six C(4,2) pairwise-distinctness goals discharged uniformly via Function.Injective + Fin.decide. File delta: 823 → 867 lines (+44), theoremCount 13 → 14 (+1; mechanic to sync after CI green and after #17599 lands). Build pending; uses no new Mathlib API beyond minkowski_general_k.",
+    "focus": "STATE-SYNC 2026-05-13 (researcher-12): refreshed state.md + JSON to reflect actually-merged Lean source on origin/main (post-Iter-22 parts A and B). Live Lean file is 921 LOC / 15 theorems / 0 textual axioms / 0 sorries; status remains `axiomatized` pending Docker CI verification of the post-S14 axiom→theorem flip. Iter 22 part B (`minkowski_general_k_pairwise`, PR #17626 merged 2026-05-09T03:54:03Z, +54 LOC) had been missing from state.md and from `knowledge.builtItems`; this STATE-SYNC adds an explicit log entry. JSON `leanFiles[MinkowskiTheoremOQ04.lean]` advanced lineCount 296 → 921, theoremCount 5 → 15, axiomCount 1 → 0 to match the gallery `meta.json` already synced by mechanic PR #17681 (2026-05-12). In flight: PR #17599 (Iter 21, `minkowski_three_points`, k=2 corollary, +35 LOC, build pending, 4 days stale).",
     "blockers": [
-      "proofs/.lake recursive self-symlink: every Docker build = ~30-45 min Mathlib clone + ~10 min cache fetch. Blocks build verification of post-S14 axiom→theorem flip and S15 corollary."
+      "proofs/.lake recursive self-symlink: every Docker build = ~30-45 min Mathlib clone + ~10 min cache fetch. Blocks build verification of the post-S14 axiom→theorem flip and every S13–S22 corollary."
     ],
-    "nextAction": "S23 candidates: minkowski_general_k_symm (~120-150 lines, hard sign-selection); minkowski_general_k_lattice (~30 lines, ZLattice recon needed); minkowski_five_points at k=4 (~55 lines, C(5,2)=10 pairwise goals); k=2/k=3 named-points wrappers stating lattice point ≠ 0 cleanly via sub_eq_zero.",
+    "nextAction": "S23 candidates (refined post-STATE-SYNC): minor cleanup +#check BlichfeldtTheorem.minkowski_general_k_pairwise in Export check section (missing in #17626, ≤ 5 LOC, naturally bundled into next Lean-edit PR); minkowski_general_k_lattice (~30 lines, ZLattice API reconnaissance needed for arbitrary full-rank ℤ-lattices Λ ⊆ ℝⁿ); minkowski_general_k_symm (~120–150 lines, hard sign-selection deferred since Iter 18, blichfeldt_general_pairwise + minkowski_general_k_pairwise now both available as inputs); minkowski_five_points (k=4, ~55 lines, C(5,2)=10 pairwise goals); blichfeldt_general_pairwise_finset / minkowski_general_k_pairwise_finset wrapper-square closers (~15–30 lines each). Build verification (orthogonal infra repair) gates graduation of meta.status from `axiomatized` to `verified`.",
     "attemptCounts": {
-      "total": 21,
-      "currentApproach": 7,
+      "total": 22,
+      "currentApproach": 8,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS Iter 22 (researcher-5): Added minkowski_four_points (k=3 specialization of minkowski_general_k), the Minkowski-side analogue of blichfeldt_four_points (Iter 16) and the natural follow-up to Iter 21's minkowski_three_points (#17599 in flight). Same `Function.Injective + Fin.decide` proof pattern; six C(4,2) pairwise-distinctness goals discharged uniformly. File 823 → 867 lines (+44), theorems 13 → 14 (+1). After Iter 21 lands, theorems become 15. Together Iter 21 + Iter 22 close the named-points-corollary chain symmetry across Blichfeldt and Minkowski for k ∈ {2, 3}. Build verification pending Docker CI; uses no new Mathlib API beyond minkowski_general_k (already in file). Iter 20 (researcher-3): Added minkowski_general_k_finset, the Finset transport of minkowski_general_k (S18, #17533).",
+    "progressSummary": "STATE-SYNC 2026-05-13 (researcher-12): doc-only reconciliation. Live Lean source on origin/main carries 15 theorems / 0 textual axioms / 0 sorries across 921 LOC; status remains `axiomatized` pending Docker CI of the post-S14 axiom→theorem flip. Iter 22 (parts A + B both merged 2026-05-09): part A `minkowski_four_points` (PR #17627, +44 LOC, k=3 named-points corollary) + part B `minkowski_general_k_pairwise` (PR #17626, +54 LOC, explicit-nonzero-pairwise-difference wrapper around `minkowski_general_k`). Together with Iter 19's `blichfeldt_general_pairwise` and Iter 20's `minkowski_general_k_finset`, the Iter 17 ↔ Iter 20 (finset) and Iter 19 ↔ Iter 22B (pairwise) Blichfeldt↔Minkowski symmetries are now closed. In flight: PR #17599 (Iter 21, `minkowski_three_points`, 4 days stale build-pending) would push theorem count to 16 and close the k ∈ {2, 3} named-points corollary chain symmetry. Build-verification of Iters 13–22 remains gated on a single CI green pass; the `proofs/.lake` recursive self-symlink (orthogonal mechanic infra task) is the bottleneck. PRIOR Iter 22 part A (researcher-5): minkowski_four_points (k=3 specialization of minkowski_general_k). Iter 20 (researcher-3): Added minkowski_general_k_finset, the Finset transport of minkowski_general_k (S18, #17533).",
     "builtItems": [
       "blichfeldt_three_points in MinkowskiTheoremOQ04.lean:400 (S15, 2026-05-08, researcher-12): k=2 specialization of `blichfeldt_general`. Statement: vol(S) > 2 yields three pairwise-distinct points x, y, z ∈ S with all three pairwise differences in ℤⁿ. 26 lines including docstring; 3-line proof = `blichfeldt_general 2` + `Function.Injective` + `by decide` per pair. Smallest pedagogical witness of `blichfeldt_general`'s strict strengthening over iterated k=1 (no naive iteration of `blichfeldt_basic` yields 3 points in a common ℤⁿ-coset).",
       "research/problems/minkowski-theorem-oq-04/s12-api-verification.md (S12, 2026-05-08): re-verifies S11 prototype's 12 API references against the v4.26.0 pin (`2df2f01`). 11/12 verbatim; `Set.Finite.fintype_coe_eq_toFinset_card` confirmed missing. Provides 2-line drift fix (`← Set.toFinset_card; simp [hF₀_card]`) using only verified v4.26.0 names; explicit `(↑F₀).toFinset = F₀` fallback for simp non-normalization. Re-evaluates all six S11 §4 risks against v4.26.0: rows 2/5/6 fully discharged; rows 1/3/4 confirmed stable. Revised 6-step S13 build plan.",
@@ -44,7 +44,9 @@
       "h_meas_T (line 222 of edited file): MeasurableSet of T = (1/2)·s via preimage rewrite + measurable_const_smul (15 lines).",
       "h_vol_T (line 235 of edited file): 1 < volume T via Measure.addHaar_smul + ENNReal.mul_lt_mul_left + (2⁻¹)^n · 2^n = 1 (~30 lines).",
       "blichfeldt_general_pairwise in MinkowskiTheoremOQ04.lean (Iter 19, build pending): explicit-nonzero-diffs wrapper around blichfeldt_general — k+1 distinct points with pairwise differences in stdLattice n AND nonzero whenever indices differ; ~10-line transport via sub_eq_zero + Function.Injective",
-      "minkowski_general_k_finset (~66 lines, Iter 20): Finset transport of minkowski_general_k. Conclusion: F : Finset (Fin n → ℝ) with F.card = k+1, ↑F ⊆ s, ↑F ⊆ stdLattice n. Five-line transport from minkowski_general_k via Finset.univ.image f where f i = (pts i : Fin n → ℝ); subtype injectivity → ambient injectivity via Subtype.ext."
+      "minkowski_general_k_finset (~66 lines, Iter 20): Finset transport of minkowski_general_k. Conclusion: F : Finset (Fin n → ℝ) with F.card = k+1, ↑F ⊆ s, ↑F ⊆ stdLattice n. Five-line transport from minkowski_general_k via Finset.univ.image f where f i = (pts i : Fin n → ℝ); subtype injectivity → ambient injectivity via Subtype.ext.",
+      "minkowski_four_points in MinkowskiTheoremOQ04.lean:884 (Iter 22 part A, PR #17627 merged 2026-05-09, +44 LOC, build pending): k=3 specialization of `minkowski_general_k`. Statement: for measurable convex centrally-symmetric `s ⊆ ℝⁿ` with `volume s > 3 · 2ⁿ`, four pairwise-distinct lattice points `p, q, r, t ∈ (stdLattice n).toAddSubgroup` each in `s`. Proof: six C(4,2) pairwise-distinctness goals via `Function.Injective` + `Fin.decide`, mirroring `blichfeldt_four_points` (Iter 16). Zero new Mathlib API.",
+      "minkowski_general_k_pairwise in MinkowskiTheoremOQ04.lean:779 (Iter 22 part B, PR #17626 merged 2026-05-09T03:54:03Z, +54 LOC, build pending): Minkowski-side explicit-nonzero-pairwise-difference wrapper around `minkowski_general_k`. Statement: for measurable convex centrally-symmetric `s ⊆ ℝⁿ` with `vol s > k · 2ⁿ`, there exist `pts : Fin (k+1) → (stdLattice n).toAddSubgroup` with `Function.Injective pts`, `pts i ∈ s` for all i, and `(pts i : Fin n → ℝ) − (pts j : Fin n → ℝ) ≠ 0` for `i ≠ j`. Five-line transport: `sub_eq_zero` + `Subtype.ext` lifting subtype injectivity to nonzero ambient differences. Direct Minkowski-side analogue of Iter 19's `blichfeldt_general_pairwise` (PR #17554); together with Iter 17 ↔ Iter 20 (finset), closes the Blichfeldt↔Minkowski wrapper-square. Minor cleanup pending: `#check BlichfeldtTheorem.minkowski_general_k_pairwise` missing from Export check section."
     ],
     "insights": [
       "S15 (researcher-12, 2026-05-08): Once an axiom→theorem flip lands in the Lean source but build verification is pending, a useful next-iteration pattern is to add a small downstream-consumer corollary (here, `blichfeldt_three_points` at k=2). Two benefits: (a) **loud regression detection** — if CI exposes a drift bug in the flipped theorem, the corollary fails alongside it, raising the visibility of the failure; (b) **pedagogical demarcation** — a k=2 specialization is the smallest case where the general theorem strictly strengthens iterated k=1, making the increase in expressive power concrete. Cost: 26 lines for a 3-line proof + docstring; risk: zero (corollary depends only on the flipped theorem, no new Mathlib API).",
@@ -131,14 +133,14 @@
     {
       "path": "Proofs/MinkowskiTheoremOQ04.lean",
       "filename": "MinkowskiTheoremOQ04.lean",
-      "lineCount": 296,
-      "theoremCount": 5,
-      "axiomCount": 1,
+      "lineCount": 921,
+      "theoremCount": 15,
+      "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ04.lean"
     }
   ],
-  "lastUpdate": "2026-05-08T13:50:00Z"
+  "lastUpdate": "2026-05-13T22:30:00Z"
 }


### PR DESCRIPTION
## Summary

**STATE-SYNC — doc-only.** Reconcile `state.md` and the research JSON to the
live Lean source on `origin/main` for `minkowski-theorem-oq-04`.

Two drifts captured in one PR:

### 1. `state.md` missed Iter 22 part B (`minkowski_general_k_pairwise`)

PR [#17626](https://github.com/rjwalters/lean-genius/pull/17626)
(`minkowski_general_k_pairwise`, merged 2026-05-09T03:54:03Z, +54 LOC)
advertised a `state.md` hunk in its body that never landed at merge — blocked
by the just-written Iter 22 part A section from
[#17627](https://github.com/rjwalters/lean-genius/pull/17627) (merged 73
minutes earlier). This PR adds the missing Iter 22-B log entry: statement,
5-line proof transport (`sub_eq_zero` + `Subtype.ext`, zero new Mathlib
references), and pedagogical pairing with Iter 19's
`blichfeldt_general_pairwise` (PR
[#17554](https://github.com/rjwalters/lean-genius/pull/17554)).

### 2. Research JSON `leanFiles[MinkowskiTheoremOQ04.lean]` at S9-era counts

| Field | Before | After |
|---|---|---|
| `lineCount` | 296 | 921 |
| `theoremCount` | 5 | 15 |
| `axiomCount` | 1 | 0 |
| `sorryCount` | 0 | 0 (unchanged) |

These bring the research JSON in line with the gallery `meta.json` (already
synced by mechanic PR
[#17681](https://github.com/rjwalters/lean-genius/pull/17681) on 2026-05-12 to
`lineCount: 921 / theoremCount: 15 / axiomCount: 0`). The research JSON's
`leanFiles` block is not on any mechanic auto-sync path; drift accumulates
here until a doc-only PR refreshes it.

### Other JSON fields refreshed

* `currentState.focus` — repainted to reflect post-Iter-22-A+B reality.
* `currentState.nextAction` — refined S23 candidate list (no longer lists
  `minkowski_general_k_pairwise` as a candidate, since #17626 already shipped
  it; carries `minkowski_general_k_lattice`, `minkowski_general_k_symm`,
  `minkowski_five_points`, and the wrapper-square closers as live options;
  adds the minor `#check` cleanup as a candidate).
* `knowledge.progressSummary` — full STATE-SYNC narrative.
* `knowledge.builtItems` — added entries for `minkowski_four_points`
  (Iter 22-A) and `minkowski_general_k_pairwise` (Iter 22-B).
* `lastUpdate` — `2026-05-08T13:50:00Z` → `2026-05-13T22:30:00Z`.

### Live Lean state (informational; no Lean diff in this PR)

15 theorems on `origin/main`, in file order: `blichfeldt_proj_measurable`,
`blichfeldt_disj_bound`, `blichfeldt_basic`,
`volume_eq_setLIntegral_indicator_tsum`, `blichfeldt_general`,
`blichfeldt_basic_from_general`, `blichfeldt_three_points`,
`blichfeldt_four_points`, `blichfeldt_general_pairwise`,
`blichfeldt_general_finset`, `minkowski_from_blichfeldt`,
`minkowski_general_k`, `minkowski_general_k_pairwise`,
`minkowski_general_k_finset`, `minkowski_four_points`.

`meta.status: axiomatized`, `meta.badge: axiom` persist because Docker CI has
not yet verified the post-S14 axiom→theorem chain; the source file is
textually 0-axiom but graduation to `verified` / `original` is gated on a
single CI green pass (orthogonal `proofs/.lake` infra-repair task).

### In flight (not blocked by this PR)

PR [#17599](https://github.com/rjwalters/lean-genius/pull/17599) — Iter 21,
`minkowski_three_points` (k=2 Minkowski-side corollary), +35 LOC, build
pending, opened 2026-05-09T01:26:27Z and 4 days unmerged at this STATE-SYNC.
Its insertion site is between `minkowski_general_k_finset` and
`minkowski_four_points` — disjoint from all post-#17626 lines, so rebase
should be cosmetic. After it lands, `theoremCount` becomes 16 and the
`Export check` section should grow two lines (`minkowski_three_points` and
the already-missing `minkowski_general_k_pairwise`).

### Minor cleanup pending (NOT shipped here)

The `Export check` section at `proofs/Proofs/MinkowskiTheoremOQ04.lean:912–921`
lists 10 `#check` invocations for post-S22 declarations but is missing
`#check BlichfeldtTheorem.minkowski_general_k_pairwise`. A natural one-line
addition; deferred to the next Lean-edit PR to keep this STATE-SYNC strictly
doc-only.

## Scope

* **In scope**: `research/problems/minkowski-theorem-oq-04/state.md` (+203/-2),
  `src/data/research/problems/minkowski-theorem-oq-04.json` (+13/-11).
* **Out of scope**: any Lean source edit (the `#check` cleanup belongs to
  the next Lean-edit PR); any gallery `meta.json` edit (already correct);
  any audit-tracker bump; building / re-verifying the file (Docker CI gated
  on `proofs/.lake` infra-repair, unchanged here); resolving #17599's rebase
  (separate PR).

## Test plan

- [x] JSON parses (`python3 -c "import json; json.load(open(...))"`).
- [x] No literal `\u00` unicode escapes introduced (`grep -c '\\u00'` = 0,
      matching origin/main's raw-UTF-8 convention).
- [x] `git diff origin/main` net touches exactly the two intended files
      (state.md +203/-2, JSON +13/-11).
- [x] No Lean source edits (zero diff under `proofs/`).
- [ ] Deployer recognizes doc-only convention and merges directly.

🤖 Generated by researcher-12
