### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): S12 ACT — 3 build unblockers retroactively verify S11 templates (build verified)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -387,7 +387,13 @@ private lemma piAntidiag_apply_le {α : Type*} [DecidableEq α]
   · -- i₀ ∈ s: bound by the sum.
     have hle : k i₀ ≤ ∑ i ∈ s, k i :=
       Finset.single_le_sum (s := s) (f := k) (fun i _ => Nat.zero_le _) h
-    omega
+    -- S12 (researcher-9, 2026-05-13): replace bare `omega` with explicit
+    -- chain. Reason: in Mathlib v4.26.0, `Finset.mem_piAntidiag` gives
+    -- `hksum : s.sum k = n` (dot-notation form), which omega's preprocessor
+    -- does NOT unify with `hle`'s `∑ i ∈ s, k i` form, despite definitional
+    -- equality. The calc chain is bulletproof against this notation skew.
+    calc k i₀ ≤ ∑ i ∈ s, k i := hle
+      _       = n             := hksum
   · -- i₀ ∉ s: support condition forces k i₀ = 0.
     by_contra hne
     push_neg at hne
@@ -534,7 +540,16 @@ theorem binomialCDF_le_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
     have hp_eq : p + (1 - p) = (1 : ℝ) := by ring
     rw [hp_eq, one_pow] at hadd
     -- hadd : (1 : ℝ) = ∑ k, p^k * (1 − p)^(n−k) * (Nat.choose n k : ℝ)
-    rw [← hadd]
+    -- S12 (researcher-9, 2026-05-13): use targeted `conv_rhs => rw [hadd]`
+    -- to substitute ONLY the goal's RHS `1` with `∑ m, p^m * (1-p)^(n-m)
+    -- * choose`. A bare `rw [hadd]` would also rewrite the inner `1`
+    -- inside `(1 - p)^(n-j)`, mangling the goal. The `← hadd` direction
+    -- can't find the sum-pattern in the LHS because `binomialCDF` uses
+    -- `choose * p^m * (1-p)^(n-m)` order (choose first), but `add_pow`
+    -- in Mathlib v4.26.0 produces `p^m * (1-p)^(n-m) * choose` order
+    -- (choose last). The subsequent `sum_congr + ring` normalises
+    -- per-term multiplication order.
+    conv_rhs => rw [hadd]
     refine Finset.sum_congr rfl (fun j _ => ?_)
     ring
   -- Step 2: replace `1` on the RHS with the equivalent sum.
@@ -606,7 +621,13 @@ theorem binomialCDF_eq_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
   have hadd := add_pow p (1 - p) n
   have hp_eq : p + (1 - p) = (1 : ℝ) := by ring
   rw [hp_eq, one_pow] at hadd
-  rw [← hadd]
+  -- S12 (researcher-9, 2026-05-13): use targeted `conv_rhs => rw [hadd]`
+  -- (same fix as `binomialCDF_le_one` above) — a bare `rw [hadd]` would
+  -- also rewrite the inner `1` inside `(1 - p)^(n-j)`, mangling the goal.
+  -- Multiplication-order mismatch between `add_pow`'s `p^k * (1-p)^(n-k)
+  -- * choose` and `binomialCDF`'s `choose * p^k * (1-p)^(n-k)` is
+  -- normalised by the subsequent sum_congr + ring step.
+  conv_rhs => rw [hadd]
   refine Finset.sum_congr rfl (fun j _ => ?_)
   ring
 

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,11 +1,57 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT (Phase-4 unblocking — 5/5 S10 repair templates transcribed, build-pending)
+**Phase**: ACT (Phase-4 unblocking — S11 templates BUILD VERIFIED via S12 unblocker fixes)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-13 (Session 11, researcher-1)
-**Iteration**: 11
+**Last Updated**: 2026-05-13 (Session 12, researcher-9)
+**Iteration**: 12
+
+## Session 12 Focus (2026-05-13, researcher-9) — S11 build verification + 3 unblocker fixes
+
+S12 establishes the build baseline that S11 deferred. Per memory pattern
+[researcher-9 build-pending-chain]: this slug had shipped 4+ "(build
+pending)" PRs in a row (S8 #17233/#17234, S9 #17318, S11 #18916), so the
+Mathlib v4.26.0 surface-drift risk had accumulated. Pre-claim Docker
+build (commit 7f555c51, S11 tip) revealed **3 errors in target file
+itself** (not parent-file regressions):
+
+| # | Line | Theorem | Error | Root cause |
+|---|---|---|---|---|
+| 1 | 390 | `piAntidiag_apply_le` (helper) | `omega could not prove the goal` | Mathlib v4.26.0 `Finset.mem_piAntidiag` returns `s.sum k = n` (dot-notation form); omega's preprocessor doesn't bridge to `∑ i ∈ s, k i` form despite definitional equality. |
+| 2 | 537 | `binomialCDF_le_one` (pre-S11, working idiom) | `rewrite failed: pattern not found` | Mathlib v4.26.0 `add_pow` produces `p^m * (1-p)^(n-m) * choose` order (choose last); `binomialCDF` definition uses `choose * p^m * (1-p)^(n-m)` order (choose first). |
+| 3 | 609 | `binomialCDF_eq_one` (S11 transcribed template) | same as #2 | same as #2 |
+
+S12 fixes (3 surgical edits, each in same file):
+
+* **Line 390** (`piAntidiag_apply_le`): replace bare `omega` with explicit `calc k i₀ ≤ ∑ i ∈ s, k i := hle | _ = n := hksum` chain. Bulletproof against the omega/dot-notation skew.
+* **Lines 537 + 609** (both in `add_pow`-using theorems): replace `rw [← hadd]` with `conv_rhs => rw [hadd]`. The `conv_rhs` targets only the goal's RHS `1`, avoiding the over-rewrite that mangles `(1 - p)` inner expressions. The subsequent `Finset.sum_congr rfl + ring` normalises per-term multiplication order (`choose * p^j * (1-p)^(n-j)` vs `p^j * (1-p)^(n-j) * choose`).
+
+**Status: BUILD VERIFIED.** Final docker-build:
+
+```
+✔ [3209/3209] Built Proofs.BinomialTheoremOQ02OQ01OQ01OQ03 (6.3s)
+Build completed successfully (3209 jobs).
+```
+
+(Build log: `.loom/logs/researcher-9-binomial-s12-build2.log`.) Build #1 (cold cache) failed at 3 errors above; build #2 (after fixes 1+2 forward, before targeted `conv_rhs`) failed at 2 errors at 538:62 and 601:58 — `rw [hadd]` over-rewrote the inner `1`, mangling the goal; build #3 with `conv_rhs => rw [hadd]` succeeded.
+
+### File counts (post-S12)
+
+* `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`: **682 → 703** lines (+21, all comment-only documentation of the 3 fixes plus the 3 surgical-tactic edits themselves; no theorem/axiom/sorry-count change).
+* `theoremCount`: 17 (unchanged).
+* `axiomCount`: 1 (`binomial_clt_pointwise`, unchanged).
+* `sorries`: 0 (unchanged — confirmed live, no longer just metadata claim).
+
+The `meta.json` status / badge upgrade noted in S11's "After build is green" plan is now appropriate (mechanic territory):
+
+```json
+"status": "axiomatized" (already current per #18919 sync)
+"badge": "axiom"          (already current per #18919 sync)
+"sorryCount": 0           (already current per #18919 sync)
+```
+
+So no `meta.json` follow-up needed — the S11 mechanic sync (#18919, 2026-05-13) was prescient. **What S12 retroactively validates is that the sync was correct: the file does build with 0 sorries.**
 
 ## Session 11 Focus (2026-05-13, researcher-1) — S10 repair templates transcribed (build-pending ACT)
 


### PR DESCRIPTION
## Summary

S12 ACT for `binomial-theorem-oq-02-oq-01-oq-01-oq-03` — **build verification** of the S11 transcribed templates with **3 surgical Mathlib v4.26.0 unblockers**.

Per memory pattern `feedback_researcher_build_pending_slug_series_silent_parent_regression.md`: this slug had shipped **4+ "(build pending)" PRs in a row** (S8 #17233/#17234, S9 #17318, S11 #18916), so the Mathlib v4.26.0 surface-drift risk had accumulated. Pre-claim Docker build at S11 tip (commit 7f555c5) revealed **3 errors in the target file itself** (no parent-file regressions) — all surgical 1-line fixes, all in research scope.

## Errors found at baseline

| # | Line | Theorem | Error | Root cause |
|---|---|---|---|---|
| 1 | 390 | `piAntidiag_apply_le` (helper) | `omega could not prove the goal` | Mathlib v4.26.0 `Finset.mem_piAntidiag` returns `s.sum k = n` (dot-notation form); omega's preprocessor doesn't bridge to `∑ i ∈ s, k i` form despite definitional equality. |
| 2 | 537 | `binomialCDF_le_one` (pre-S11, *previously working*) | `rewrite failed: pattern not found` | Mathlib v4.26.0 `add_pow` produces `p^m * (1-p)^(n-m) * choose` order (choose **last**); `binomialCDF` definition uses `choose * p^m * (1-p)^(n-m)` order (choose **first**). |
| 3 | 609 | `binomialCDF_eq_one` (S11 transcribed template) | same as #2 | same as #2 — S10 risk note #4 explicitly flagged this template as highest-risk. |

Notable: error #2 is in a **previously working** theorem (`binomialCDF_le_one`, pre-S11 ~line 418, now ~line 527). It is a silent Mathlib-update regression that was masked by the build-pending convention until S12 ran the actual build. This is the exact failure mode the build-pending-chain memory rule was designed to surface.

## S12 fixes

### Fix #1 — `omega` → `calc` chain (line 390)

```lean
-    omega
+    calc k i₀ ≤ ∑ i ∈ s, k i := hle
+      _       = n             := hksum
```

Bulletproof against the omega/dot-notation skew.

### Fixes #2 + #3 — `rw [← hadd]` → `conv_rhs => rw [hadd]` (lines 537, 609)

```lean
-    rw [← hadd]
+    conv_rhs => rw [hadd]
     refine Finset.sum_congr rfl (fun j _ => ?_)
     ring
```

A bare `rw [hadd]` over-rewrites the inner `1` inside `(1 - p)^(n-j)`, mangling the goal (caught by build #2: errors at 538:62 and 601:58 — `(-p + ∑ ...)^(n-j)`). `conv_rhs` targets only the top-level RHS `1`. The subsequent `Finset.sum_congr + ring` normalises per-term multiplication order.

## Build status

Pre-fix (build #1, commit 7f555c5 = S11 tip):
```
✖ [3209/3209] Building Proofs.BinomialTheoremOQ02OQ01OQ01OQ03 (4.1s)
3 errors at 390:4, 537:8, 609:6
```

Post-fix #1+#2 forward (build #2 with bare `rw [hadd]`):
```
✖ 2 unsolved-goals errors at 538:62, 601:58 (over-rewrite mangled `(1 - p)`)
```

Post-fix #1+#2+#3 with `conv_rhs` (build #3, this PR):
```
✔ [3209/3209] Built Proofs.BinomialTheoremOQ02OQ01OQ01OQ03 (6.3s)
Build completed successfully (3209 jobs).
```

Build log: `.loom/logs/researcher-9-binomial-s12-build2.log`.

## Stats

* `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`: **682 → 703** lines (+21, all comment-documentation of the fixes plus the 3 surgical edits themselves).
* Sorries: 0 (unchanged — and now **live-verified**, no longer just metadata claim).
* Axioms: 1 (`binomial_clt_pointwise`, unchanged — Phase-4 elimination target).
* Theorems: 17 (unchanged).
* Definitions: unchanged.

`meta.json` sync (#18919, mechanic, earlier today) was **prescient** — already shows `sorryCount: 0`, `status: axiomatized`, `badge: axiom`. No mechanic follow-up needed; S12 retroactively validates that the metadata was correct.

## Companion to S11

PR #18916 (S11 ACT, build pending) is the immediate companion. Where S11 transcribed the 5 S10 repair templates without verification, S12 verifies them — finding 3 issues (one in S11's own template #4 [risk-noted], one in helper used by S11's template #2, and one **silent regression** in a pre-S11 working idiom).

The Phase-4 Portmanteau bridge is now unblocked: `binomial_clt_pointwise` axiom remains the single remaining target, with a fully-built CDF infrastructure beneath it.
