### PR TITLE
research(erdos-455-oq-04): STATE-SYNC — top-level phase OBSERVE→ACT, lastUpdated refresh (doc-only)

### DIFF
--- a/src/data/research/problems/erdos-455-oq-04.json
+++ b/src/data/research/problems/erdos-455-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-455-oq-04",
   "title": "Prime sequences with AP-gaps (generalization of Erdős #455)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -82,5 +82,5 @@
   ],
   "significance": 6,
   "tractability": 4,
-  "lastUpdated": "2026-05-12T22:05:00.000Z"
+  "lastUpdated": "2026-05-14T02:15:00Z"
 }


### PR DESCRIPTION
## Summary

Minimal STATE-SYNC: align top-level `phase` field with `currentState.phase` (both should be `ACT` post-S3 merge). The slug-level state was last touched by STATE-SYNC PR #18909 (2026-05-13T17:48Z) which synced `currentState.*` fields but missed the top-level field that feeds gallery listings.

## Why this matters

`scripts/research/build.ts` aggregates problem JSONs into `src/data/research/research-listings.json` for the `ResearchPage` gallery. The gallery's lightweight metadata reads the top-level `phase` (not the nested `currentState.phase`), so the drift was user-visible: the slug displayed as "OBSERVE" on the gallery despite shipping S3 ACT (#18851).

## Changes (1 file, +2/-2, doc-only)

`src/data/research/problems/erdos-455-oq-04.json`:

| Field | Before | After |
|---|---|---|
| `phase` | `"OBSERVE"` | `"ACT"` |
| `lastUpdated` | `"2026-05-12T22:05:00.000Z"` | `"2026-05-14T02:15:00Z"` |

## Out of scope

- ❌ **No schema normalization.** This slug uses the seeker-init flat schema (camelCase `lastUpdated`, no `leanFiles`, no `relatedProofs`, no `references`, no `started`); other research slugs use the canonical schema (`lastUpdate`, `leanFiles`, etc.). Normalization is `scripts/research/enrich-research.ts` scope.
- ❌ **No `leanFiles` population.** The slug's parent `Erdos455Problem.lean` (142/4/1/1/0) and the OQ-04 file `Erdos455OQ04.lean` (126/4/1/2/0) are absent from this JSON; per memory `feedback_mechanic_linecount_drift_class_unshippable.md`, file-level counts re-drift via the canonical writer and aren't durable researcher fixes.
- ❌ **No `currentState` edits.** `cs.phase` is already `ACT`; `cs.focus` and `cs.nextAction` were freshly synced by #18909 (S4 PREP plan, cubic-growth retraction); `cs.attemptCounts` uses this slug's non-canonical step-keyed schema (`S1_observe`, `S2_definitions`, ...) which is intentionally distinct from the canonical `{total, currentApproach, approachesTried}`.
- ❌ **No `knowledge.builtItems` edits.** Already current (includes S3 ACT axiom + bridge + witness entries).
- ❌ **No Lean edits.**

## Race-safety

`gh pr list -R rjwalters/lean-genius --search "\"erdos-455-oq-04\" in:title" --state open` → `[]` at both claim and pre-push.

## Honesty

- This is my 2nd STATE-SYNC this session (per memory cap of 2-per-session). First was #18972 for `greens-theorem-oq-01-oq-01-oq-02-oq-02`.
- The 2-line scope is intentionally narrow — fixing only the user-visible top-level field, not the broader schema heterogeneity that other slugs share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
