### PR TITLE
research(hilbert-14-oq-04): S2-finite ACT — hilbert_finiteness verified (build verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2367,6 +2367,7 @@ import Proofs.Hilbert13Superposition
 import Proofs.Hilbert14Invariants
 import Proofs.Hilbert14InvariantsOQ01
 import Proofs.Hilbert14NonReductive
+import Proofs.Hilbert14OQ04
 import Proofs.Hilbert15OQ01
 import Proofs.Hilbert15OQ02
 import Proofs.Hilbert15OQ02OQ03

--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-!
+# Hilbert 14: Effective Algorithms for Non-Reductive Invariants (OQ-04)
+
+OQ-04 is the meta-mathematical question of effective algorithms for finite
+generation of non-reductive invariant rings. The OQ-04 conjecture itself is
+not formalizable as a single Lean theorem (it concerns the existence of
+uniform algorithms across infinite classes of groups).
+
+This file scaffolds the algorithmically refinable sibling target:
+**Hilbert finiteness** for invariant rings of finite-group linear actions on
+`MvPolynomial`. Per the S2g PREP audit (PR #18750), the proof chains through
+five Mathlib bearers (all signatures pinned at v4.26.0,
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):
+
+  1. `Algebra.IsInvariant B R G`             — definitional via membership
+  2. `Algebra.IsInvariant.isIntegral`        — `Invariant/Basic.lean:174`
+  3. `Algebra.FiniteType.of_restrictScalars_finiteType`
+                                             — `FiniteType.lean:77`
+  4. `Algebra.IsIntegral.finite`             — `IntegralClosure/Basic.lean:93`
+  5. Artin-Tate `fg_of_fg_of_fg`             — `Adjoin/Tower.lean:150`
+     plus `Subalgebra.fg_iff_finiteType`     — `FiniteType.lean:213`
+
+## Scope
+
+- IN scope: Hilbert finiteness (qualitative half of Noether 1916).
+- OUT (deferred to S3-bound): Noether's degree bound
+  (`generators ⊆ deg ≤ |G|`).
+- OUT: locally nilpotent derivations (Weitzenböck); Nagata counterexample.
+-/
+
+namespace Hilbert14OQ04
+
+open MvPolynomial
+
+variable {k : Type*} [Field k] {n : ℕ}
+variable {G : Type*} [Group G] [Fintype G]
+variable [MulSemiringAction G (MvPolynomial (Fin n) k)]
+variable [SMulCommClass G k (MvPolynomial (Fin n) k)]
+
+/-- The `Algebra.IsInvariant` predicate is definitionally satisfied by the
+fixed-points subalgebra: every fixed point lies in the image of the
+subalgebra inclusion. -/
+instance isInvariant_fixedPoints :
+    Algebra.IsInvariant
+      (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)
+      (MvPolynomial (Fin n) k) G where
+  isInvariant b hb := ⟨⟨b, hb⟩, rfl⟩
+
+/-- Integrality of `R / R^G` for finite `G`: every element of `R` satisfies
+its `G`-orbit polynomial, which is monic of degree `|G|` and has invariant
+coefficients (Mathlib bearer `Algebra.IsInvariant.isIntegral`). -/
+instance isIntegral_fixedPoints :
+    Algebra.IsIntegral
+      (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)
+      (MvPolynomial (Fin n) k) :=
+  Algebra.IsInvariant.isIntegral _ _ G
+
+/-- **Hilbert finiteness** for finite-group linear actions on `MvPolynomial`:
+the invariant subring `R^G` is finitely generated as a `k`-algebra.
+
+This is the qualitative half of Emmy Noether's 1916 theorem. The
+quantitative half (`generators ⊆ deg ≤ |G|`) is deferred to a later
+S3-bound ACT iteration.
+
+**Proof outline**: chain Hilbert basis / Artin-Tate (`fg_of_fg_of_fg`) on
+the tower `k → R^G → R`. The integrality of `R / R^G` gives
+`Module.Finite (R^G) R`; `MvPolynomial`'s built-in `Algebra.FiniteType k R`
+restricts to `Algebra.FiniteType (R^G) R`; Artin-Tate then concludes
+`(⊤ : Subalgebra k (R^G)).FG`, which translates to
+`Algebra.FiniteType k (R^G)` via `Subalgebra.fg_iff_finiteType`. -/
+theorem hilbert_finiteness :
+    Algebra.FiniteType k
+      (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G) := by
+  set R := MvPolynomial (Fin n) k with hR_def
+  set B := FixedPoints.subalgebra k R G with hB_def
+  -- Step 3: Upgrade `Algebra.FiniteType k R` (automatic) to
+  -- `Algebra.FiniteType B R` via the restrict-scalars bearer.
+  haveI hFT_BR : Algebra.FiniteType B R :=
+    Algebra.FiniteType.of_restrictScalars_finiteType k B R
+  -- Step 4: `Module.Finite B R` from integrality + algebra-finiteness.
+  haveI hMF_BR : Module.Finite B R := Algebra.IsIntegral.finite
+  -- Step 5a: algebra hypothesis for Artin-Tate
+  --          (k → R is f.g. as algebras).
+  have h_kR_fg : (⊤ : Subalgebra k R).FG :=
+    (inferInstance : Algebra.FiniteType k R).out
+  -- Step 5b: module hypothesis for Artin-Tate
+  --          (R is f.g. as a B-module).
+  have h_BR_fg : (⊤ : Submodule B R).FG := Module.Finite.fg_top
+  -- Step 5c: injectivity of the subalgebra inclusion B ↪ R.
+  have h_BR_inj : Function.Injective (algebraMap B R) :=
+    Subtype.val_injective
+  -- Step 5d: apply Artin-Tate `fg_of_fg_of_fg` (Adjoin/Tower.lean:150).
+  have h_kB_fg : (⊤ : Subalgebra k B).FG :=
+    fg_of_fg_of_fg k B R h_kR_fg h_BR_fg h_BR_inj
+  -- Step 5e: translate Subalgebra.FG back to Algebra.FiniteType.
+  exact ⟨h_kB_fg⟩
+
+end Hilbert14OQ04

--- a/research/problems/hilbert-14-oq-04/sessions/2026-05-13-s2-finite-act-hilbert-finiteness.md
+++ b/research/problems/hilbert-14-oq-04/sessions/2026-05-13-s2-finite-act-hilbert-finiteness.md
@@ -1,0 +1,189 @@
+# hilbert-14-oq-04 — S2-finite ACT: `hilbert_finiteness` verified
+
+**Date**: 2026-05-13
+**Phase**: S2-finite ACT
+**Researcher**: researcher-1
+**Branch**: `topic/hilbert-14-oq-04-1778727768`
+**Mathlib pin**: v4.26.0 (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+**Build**: `Build completed successfully (7743 jobs)`
+
+## TL;DR
+
+Picked up the 7-PREP-deep audit chain (PRs #18248, #18435, #18501,
+#18562, #18589, #18667, #18714, #18750) and shipped the S2-finite ACT
+that those PREPs were preparing for. The qualitative half of Noether's
+1916 theorem — the invariant ring of a finite-group linear action on
+`MvPolynomial` is finitely generated as a `k`-algebra — is now
+formalized as `Hilbert14OQ04.hilbert_finiteness` in
+`proofs/Proofs/Hilbert14OQ04.lean` (102 LOC, no sorries, no axioms).
+
+## What the file proves
+
+```lean
+theorem hilbert_finiteness :
+    Algebra.FiniteType k
+      (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)
+```
+
+under the standard finite-group linear-action setup:
+- `[Field k]`, `[Group G]`, `[Fintype G]`
+- `[MulSemiringAction G (MvPolynomial (Fin n) k)]`
+- `[SMulCommClass G k (MvPolynomial (Fin n) k)]`
+
+Plus two definitional instances:
+- `instance Algebra.IsInvariant (FixedPoints.subalgebra k R G) R G`
+- `instance Algebra.IsIntegral (FixedPoints.subalgebra k R G) R`
+
+## Proof chain (verified)
+
+```
+Algebra.IsInvariant B R G                         (definitional)
+  ↓ Algebra.IsInvariant.isIntegral [Invariant/Basic.lean:174]
+Algebra.IsIntegral B R                            (integrality of R/R^G)
+  ↓ (combined with FiniteType k R automatic)
+  ↓ Algebra.FiniteType.of_restrictScalars_finiteType k B R
+  ↓                                 [FiniteType.lean:77]
+Algebra.FiniteType B R                            (algebra-finiteness)
+  ↓ Algebra.IsIntegral.finite [IntegralClosure/Basic.lean:93]
+Module.Finite B R                                 (module-finiteness)
+  ↓ + (inferInstance : Algebra.FiniteType k R).out [FiniteType.lean:38]
+  ↓ + Module.Finite.fg_top  [Finiteness/Defs.lean:123]
+  ↓ + Subtype.val_injective for algebraMap B R
+  ↓ fg_of_fg_of_fg k B R ...  [Adjoin/Tower.lean:150]
+(⊤ : Subalgebra k B).FG
+  ↓ ⟨·⟩ as Algebra.FiniteType  [FiniteType.lean:39]
+Algebra.FiniteType k B                            (target)
+```
+
+where `R = MvPolynomial (Fin n) k` and `B = FixedPoints.subalgebra k R G`.
+
+## Build attempts and resolution (3 builds)
+
+### Build #1: failed (3 errors)
+
+```
+error: Proofs/Hilbert14OQ04.lean:81:4: Type mismatch
+  Algebra.FiniteType.of_restrictScalars_finiteType
+has type
+  ∀ (R : Type ...) (S : Type ...) (A : Type ...) [...], Algebra.FiniteType S A
+but is expected to have type
+  Algebra.FiniteType (↥B) R
+
+error: Proofs/Hilbert14OQ04.lean:87:33: Unknown constant `Subalgebra.fg_iff_finiteType.mpr`
+error: Proofs/Hilbert14OQ04.lean:98:37: Unknown constant `Subalgebra.fg_iff_finiteType.mp`
+```
+
+**Root cause #1**: `Algebra.FiniteType.of_restrictScalars_finiteType`'s
+type-level args `R`, `S`, `A` are **explicit** (declared by the file's
+top-level `variable (R : Type uR) (S : Type uS) (A : Type uA) ...` block,
+which makes them explicit by Lean's variable-block convention).
+
+**Root cause #2**: `_root_.Subalgebra.fg_iff_finiteType (S : Subalgebra R A) : S.FG ↔ Algebra.FiniteType R S`
+takes `S` as an **explicit argument**. So `.mp`/`.mpr` cannot be projected
+directly from the name; the theorem must first be applied to its
+explicit argument before iff-projection: `(Subalgebra.fg_iff_finiteType _).mpr`.
+
+### Build #2: failed (2 errors)
+
+```
+error: Proofs/Hilbert14OQ04.lean:87:41: failed to synthesize
+  Algebra.FiniteType k ↥⊤
+(deterministic) timeout at `typeclass`, maximum number of heartbeats (20000) has been reached
+
+error: Proofs/Hilbert14OQ04.lean:98:44: Application type mismatch: The argument
+  h_kB_fg
+has type
+  ⊤.FG
+but is expected to have type
+  B.FG
+```
+
+**Root cause #3**: `(Subalgebra.fg_iff_finiteType _).mpr inferInstance`
+asks Lean to synthesize `Algebra.FiniteType k ↥(⊤ : Subalgebra k R)` —
+the typeclass system **cannot bridge the `↥⊤` coercion cheaply** (it
+times out at 20k heartbeats). Bypass by extracting `.out` directly from
+`Algebra.FiniteType k R`'s class field.
+
+**Root cause #4**: At the closing step, Lean's elaboration of
+`(Subalgebra.fg_iff_finiteType _).mp` resolved `_` to `B` (not
+`(⊤ : Subalgebra k B)`), so the expected input was `B.FG` and we had
+`(⊤ : Subalgebra k B).FG`. Bypass by replacing the iff-application
+with the constructor `⟨h_kB_fg⟩`, since `Algebra.FiniteType k B` is
+**definitionally** `(⊤ : Subalgebra k B).FG`.
+
+### Build #3: succeeded
+
+```
+✔ [7743/7743] Built Proofs.Hilbert14OQ04 (9.8s)
+Build completed successfully (7743 jobs).
+```
+
+## Scope honesty
+
+This PR ships the **qualitative** half of Noether's 1916 theorem:
+`R^G` is finitely generated. It does NOT ship the **quantitative**
+half (Noether's degree bound `generators ⊆ deg ≤ |G|`), which is the
+S3-bound ACT target.
+
+The proof is essentially a five-step composition of pre-existing
+Mathlib results (the heavy lifting was the **bearer-identification
+audit** done by the 7-PREP chain, particularly S2g PREP §2.1–§2.4
+which correctly identified `Algebra.FiniteType.of_finite_of_finiteType_top`
+as a phantom and replaced it with the explicit `fg_of_fg_of_fg` chain).
+What this ACT delivers is the **type-correct elaboration** of the S2g
+skeleton plus three concrete trap-resolutions (explicit Type-level
+args, `.out` projection, `⟨·⟩` constructor).
+
+This work is foundational for the S3-bound ACT next iteration but
+does NOT, on its own, advance OQ-04's open meta-mathematical
+question (effective algorithms for non-reductive invariant rings).
+
+## Diff summary
+
+```
+proofs/Proofs/Hilbert14OQ04.lean                              | 102 +++++++++++++ (NEW)
+proofs/Proofs.lean                                            |   1 +
+research/problems/hilbert-14-oq-04/state.md                   | refreshed
+research/problems/hilbert-14-oq-04/sessions/<this-file>.md     |  +152 (NEW)
+src/data/research/problems/hilbert-14-oq-04.json              | currentState + knowledge refresh
+```
+
+No edits to `problem.md` or `knowledge.md` (the predecessor PREP chain
+already covered those; the live S2-finite proof is new content
+deserving its own state.md entry and ACT-phase advancement).
+
+## Predecessor chain (all merged before this ACT)
+
+| PR     | Phase       | Date (UTC)            |
+|--------|-------------|-----------------------|
+| #18248 | S1 OBSERVE  | 2026-05-12T19:35:13Z  |
+| #18435 | S2 PREP     | 2026-05-13T01:23:22Z  |
+| #18501 | S2b PREP    | 2026-05-13T02:58:26Z  |
+| #18562 | S2c PREP    | 2026-05-13T04:19:56Z  |
+| #18589 | S2d PREP    | 2026-05-13T05:13:43Z  |
+| #18667 | S2e PREP    | 2026-05-13T07:58:13Z  |
+| #18714 | S2f PREP    | 2026-05-13T09:06:55Z  |
+| #18750 | S2g PREP    | 2026-05-13T11:17:53Z  |
+
+Total elapsed from S1 → S2-finite ACT: ~24h45m. PREP audit time:
+~15h45m. ACT shipping (this iteration): ~3.5h (initial scaffold + 3
+Docker builds + state-sync + session log).
+
+## Next iteration
+
+**S3-bound ACT**: prove Noether's degree bound `generators ⊆ deg ≤ |G|`.
+The cleanest path per S2g §2.4 audit:
+
+1. Define orbit polynomial `orbitPoly (v : R) := ∏ g : G, (X - C (g • v))`
+   (or reuse `MulSemiringAction.charpoly` from
+   `Invariant/Basic.lean:138`).
+2. Show coefficients are `G`-invariant ⇒ live in `R^G`.
+3. Show `(orbitPoly v).totalDegree ≤ |G|` via `Polynomial` degree bounds.
+4. Use Vieta + Newton identities
+   (`MvPolynomial.mul_esymm_eq_sum`, `Symmetric/NewtonIdentities.lean:223`)
+   to express power sums in terms of elementary symmetric polynomials.
+5. Conclude the orbit-coefficient subalgebra equals the invariant ring
+   in degrees `≤ |G|`.
+
+Estimated LOC: ~80–120 (orbit-poly definition + invariance lemmas) +
+S3-bound proper which is harder (~150–300 LOC).

--- a/research/problems/hilbert-14-oq-04/state.md
+++ b/research/problems/hilbert-14-oq-04/state.md
@@ -1,183 +1,167 @@
 # Current State
 
-**Phase**: OBSERVE (S1 closed — Mathlib-gap audit + shortlist of Lean-formalizable adjacent targets)
-**Since**: 2026-05-12T19:30:00Z
-**Iteration**: 1
+**Phase**: ACT (S2-finite ACT shipped — `hilbert_finiteness` verified)
+**Since**: 2026-05-13T20:18:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-S1 OBSERVE — **Algorithmic landscape for non-reductive invariant theory
-surveyed**. OQ-04 (effective algorithms for finite generation of
-non-reductive invariant rings) is a meta-mathematical conjecture about
-the existence of uniform algorithms; it cannot be formalized as a single
-Lean theorem. Identified the tractable adjacent target hierarchy and
-selected the S2 entry point.
+S2-finite ACT — **`hilbert_finiteness` theorem verified by Docker build
+(7743/7743 jobs)**. The qualitative half of Emmy Noether's 1916 theorem
+(invariant ring of a finite-group linear action on `MvPolynomial` is
+finitely generated as a `k`-algebra) is now formalized in
+`proofs/Proofs/Hilbert14OQ04.lean`.
 
-## Active Approach
+The quantitative half — Noether's degree bound
+`generators ⊆ degree ≤ |G|` — is deferred to a separate S3-bound ACT
+iteration.
 
-**S2 target: Noether's degree bound (1916) — algorithmic refinement.**
+## What landed in this iteration (S2-finite ACT)
 
-For a finite group `G` acting linearly on `k[V] = k[x_1, …, x_n]` over a
-field `k` with `char k ∤ |G|`, the invariant ring `k[V]^G` is generated,
-as a `k`-algebra, by invariants of **degree at most `|G|`**. Noether's
-bound is the *quantitative* refinement of the OQ-01-side qualitative
-finiteness statement; it converts the existence theorem into an explicit
-algorithm (enumerate monomials of degree `≤ |G|`, apply Reynolds, perform
-Gauss elimination).
+**File**: `proofs/Proofs/Hilbert14OQ04.lean` (NEW, 102 LOC).
 
-Crucially, the sibling slug `hilbert-14-oq-01` already provides the
-**structural** infrastructure (`InvariantSubset`, `ReynoldsOperator`,
-`invariantSubring`, `reynoldsSum` plus seven basic properties) but has
-**no degree-bound machinery**. OQ-04's S2 ACT therefore picks up where
-OQ-01 leaves off, with no duplication.
+**Theorem**:
+```lean
+theorem hilbert_finiteness :
+    Algebra.FiniteType k
+      (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)
+```
+with hypotheses `[Field k]`, `[Group G]`, `[Fintype G]`,
+`[MulSemiringAction G (MvPolynomial (Fin n) k)]`,
+`[SMulCommClass G k (MvPolynomial (Fin n) k)]`.
 
-**Proof outline (5 steps)**:
-1. For each `v ∈ V`, the orbit polynomial
-   `P_v(T) = ∏_{w ∈ Orbit(v)} (T - w)` is `G`-invariant; its coefficients
-   live in `k[V]^G` and have degree `≤ |G|`.
-2. Each `v ∈ V` is integral over `k[V]^G` of degree `|Orbit(v)| ≤ |G|`.
-3. Hence `k[V]` is integral over the subalgebra
-   `S := k[ \text{orbit-polynomial coefficients} ] ⊆ k[V]^G_{≤ |G|}`.
-4. Atiyah-Macdonald 5.1 (integral + finitely-generated-as-algebra ⇒
-   finitely-generated-as-module): `k[V]` is f.g. as an `S`-module.
-5. Hence `k[V]^G` is sandwiched between `S` and `k[V]`, and Noetherian
-   intersection arguments give `S ⊆ k[V]^G` is the full degree-bounded
-   generator set.
+**Two supporting instances** (definitional, both `instance` declarations):
+- `Algebra.IsInvariant (FixedPoints.subalgebra k R G) R G`
+- `Algebra.IsIntegral (FixedPoints.subalgebra k R G) R`
+
+**Proof strategy**: five-step chain through Mathlib v4.26.0 bearers
+(all pinned by the S2g PREP audit, PR #18750):
+
+| Step | Mathlib bearer                                       | File:line                                                           |
+|:-----|:-----------------------------------------------------|:--------------------------------------------------------------------|
+| 1    | `Algebra.IsInvariant` instance (membership defn)     | `Mathlib/RingTheory/Invariant/Defs.lean:31`                          |
+| 2    | `Algebra.IsInvariant.isIntegral`                     | `Mathlib/RingTheory/Invariant/Basic.lean:174`                        |
+| 3    | `Algebra.FiniteType.of_restrictScalars_finiteType`   | `Mathlib/RingTheory/FiniteType.lean:77`                              |
+| 4    | `Algebra.IsIntegral.finite`                          | `Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean:93` |
+| 5a   | `Algebra.FiniteType.out` (top-FG projection)         | `Mathlib/RingTheory/FiniteType.lean:38`                              |
+| 5b   | `Module.Finite.fg_top`                               | `Mathlib/RingTheory/Finiteness/Defs.lean:123`                        |
+| 5c   | `Subtype.val_injective` (subalgebra inclusion)        | Mathlib core                                                         |
+| 5d   | `fg_of_fg_of_fg` (Artin-Tate)                         | `Mathlib/RingTheory/Adjoin/Tower.lean:150`                           |
+| 5e   | `⟨h_kB_fg⟩` (FiniteType constructor)                  | `Mathlib/RingTheory/FiniteType.lean:39`                              |
+
+## Trail of build-attempts in this iteration
+
+Three Docker build attempts (`./proofs/scripts/docker-build.sh
+Proofs.Hilbert14OQ04`), each yielding actionable diagnostics:
+
+1. **Build #1** (failed): `Algebra.FiniteType.of_restrictScalars_finiteType`
+   required explicit `R`, `S`, `A` Type-level args (the surrounding
+   `variable` block in `FiniteType.lean` declares them explicit, not
+   implicit). Also `Subalgebra.fg_iff_finiteType.mpr`/`mp` rejected as
+   unknown constants — but the theorem takes `(S : Subalgebra R A)` as
+   an explicit argument, so it cannot be projected directly; the
+   apply-first pattern `(Subalgebra.fg_iff_finiteType _).mpr` is needed.
+
+2. **Build #2** (failed): instance-search timeout at
+   `Algebra.FiniteType k ↥(⊤ : Subalgebra k R)` — typeclass search
+   couldn't bridge the `↥⊤` coercion. Replaced with the direct
+   projection `(inferInstance : Algebra.FiniteType k R).out` which
+   bypasses the synthesis problem. Also fixed a type mismatch on the
+   final `(Subalgebra.fg_iff_finiteType _).mp h_kB_fg` invocation
+   (LHS resolved to `B.FG` not `(⊤ : Subalgebra k B).FG`); replaced
+   with the constructor `⟨h_kB_fg⟩` (since
+   `Algebra.FiniteType` definitionally unfolds to `(⊤ ...).FG`).
+
+3. **Build #3** (succeeded, 7743/7743 jobs): all three corrections
+   applied; build green.
 
 ## Blockers
 
-None firm. The Mathlib prerequisites for the degree-bound proof are:
-- `IsIntegral` / `Algebra.IsIntegral` (present);
-- `Polynomial` and root-product factorizations (`Polynomial.prod_X_sub`,
-  present);
-- `Algebra.adjoin` (present);
-- `Subalgebra.FG ↔ Algebra.FiniteType` (present in
-  `Mathlib.RingTheory.FiniteType`).
-
-The deeper non-reductive program (Weitzenboeck, LND theory, Nagata's
-counterexample) is *bounded by Mathlib's absence of any locally
-nilpotent derivation framework*. Deferred to S5+ once
-`IsLocallyNilpotent` is introduced.
+None firm for the qualitative half. For the quantitative half (S3-bound
+ACT — Noether's degree bound), the main Mathlib gap is the explicit
+link between `MulSemiringAction.charpoly` and the polynomial-ring orbit
+coefficient map (Vieta/Newton-identity bridge); see S2g PREP §2.4 for
+the bearer audit.
 
 ## Next Action
 
-**S2 ACT**: Scaffold `proofs/Proofs/Hilbert14OQ04.lean` with:
+**S3-bound ACT** (separate iteration): prove
+`(⊤ : Subalgebra k (FixedPoints.subalgebra k R G)) ⊆ degree-bound by |G|`.
+Plan:
 
-1. **Setup**:
-   ```lean
-   variable {k : Type*} [Field k] {n : ℕ} {G : Type*}
-     [Group G] [Fintype G] [MulAction G (MvPolynomial (Fin n) k)]
-     [Invertible (Fintype.card G : k)]
-   ```
-
-2. **Orbit-polynomial definition** (the algorithmic primitive):
-   ```lean
-   noncomputable def orbitPolynomial (v : MvPolynomial (Fin n) k) :
-       Polynomial (MvPolynomial (Fin n) k) :=
-     ∏ g : G, (Polynomial.X - Polynomial.C (g • v))
-   ```
-
-3. **Key lemmas** (scaffolded):
-   - `orbit_polynomial_invariant`: each coefficient of `orbitPolynomial v`
-     lies in `MulAction.fixedPoints G (MvPolynomial (Fin n) k)`.
-   - `orbit_polynomial_degree`: `(orbitPolynomial v).natDegree ≤ |G|`.
-   - `vanishes_at_v`: `(orbitPolynomial v).eval v = 0`, so `v` is
-     integral over `k[V]^G` of degree `≤ |G|`.
-
-4. **Main theorem (statement, sorried)**:
-   ```lean
-   theorem noether_degree_bound :
-       (MulAction.fixedPoints G (MvPolynomial (Fin n) k) :
-           Subalgebra k (MvPolynomial (Fin n) k)) =
-       Algebra.adjoin k
-         { f : MulAction.fixedPoints G (MvPolynomial (Fin n) k) |
-           (f : MvPolynomial (Fin n) k).totalDegree ≤ Fintype.card G }
-     := sorry
-   ```
-   (The discharge of this `sorry` is the deeper S3 ACT step.)
-
-5. **Cross-reference**: Re-export OQ-01's `reynoldsSum` and
-   `InvariantSubset` via Lean `open Hilbert14.NonReductive` for use in
-   the S2 file. (No duplicate definitions.)
-
-6. **Gallery entry**: `src/data/research/problems/hilbert-14-oq-04.json`
-   describing the algorithmic refinement, citing the parent `hilbert-14`
-   and sibling `hilbert-14-oq-01`.
+1. Define the orbit polynomial
+   `orbitPoly (v : R) := ∏ g : G, (Polynomial.X - C (g • v))`,
+   reusing `MulSemiringAction.charpoly` from Invariant/Basic.lean:138.
+2. Show its coefficients are `G`-invariant, hence members of
+   `FixedPoints.subalgebra k R G`.
+3. Prove each coefficient has `totalDegree ≤ |G|` using `Polynomial`
+   degree bounds and the multinomial expansion.
+4. Apply `Vieta's formulas` and `Newton's identities`
+   (`MvPolynomial.mul_esymm_eq_sum` at `Symmetric/NewtonIdentities.lean:223`,
+   pinned in S2g PREP §2.4) to express power sums in terms of elementary
+   symmetric polynomials.
+5. Conclude the orbit-coefficient subalgebra generates the invariant
+   ring in degrees `≤ |G|`.
 
 ## Attempt Counts
 
-- Total attempts: 1 (S1 OBSERVE).
-- Current approach attempts: 1.
+- Total attempts (across all iterations): 2.
+- Current approach attempts: 1 S1 OBSERVE + 7 S2 PREPs + 1 S2 ACT.
 - Approaches tried:
-  - S1: classical-resolution survey, Mathlib-gap audit, shortlist of
-    Lean-formalizable adjacent targets.
+  - S1: algorithmic landscape, Mathlib-gap audit.
+  - S2/S2b–S2g: Mathlib bearer audit (7 PREP PRs over 14h on
+    2026-05-12 → 2026-05-13).
+  - S2-finite ACT (this iteration): scaffold + 5-step proof of
+    `hilbert_finiteness`.
+
+## Predecessor PREP chain (all merged before this ACT)
+
+| PR     | Phase       | Contribution                                                                                          |
+|--------|-------------|-------------------------------------------------------------------------------------------------------|
+| #18248 | S1 OBSERVE  | Algorithmic landscape; Hilbert–Noether (1916) selected as S2 target; 5-step proof outline.            |
+| #18435 | S2 PREP     | Mathlib orbit-polynomial API audit (`prodXSubSMul`, `esymmAlgHom_fin_bijective`, `IsIntegral.finite`). |
+| #18501 | S2b PREP    | Artin–Tate canonical bearer `fg_of_fg_of_fg` (Adjoin/Tower.lean); 4-piece chain.                      |
+| #18562 | S2c PREP    | `IsScalarTower` / `IsNoetherianRing` traps auto-resolved; `Algebra.IsIntegral` assembly.              |
+| #18589 | S2d PREP    | Sibling slug OQ-01 integration; `[MulSemiringAction G R]` typeclass bridge.                            |
+| #18667 | S2e PREP    | `Algebra.IsInvariant.isIntegral` bearer collapses S2b+S2c to 4 LOC.                                    |
+| #18714 | S2f PREP    | Scope clarification: S2 ACT plan proves Hilbert **finiteness**, NOT Noether **degree bound**; two-tier ACT proposed; **§8 lists 4 assumed-name bearers** as TODO. |
+| #18750 | S2g PREP    | Mathlib bearer re-pin: 4 caveats audited, `of_finite_of_finiteType_top` confirmed phantom; corrected 3-step `fg_of_fg_of_fg` chain; full S2-finite ACT skeleton drafted. |
 
 ## Key Files
 
-- `research/problems/hilbert-14-oq-04/problem.md` — **created in S1**
-  (problem statement, sub-problem decomposition, decision: S2 target =
-  Hilbert-Noether for finite groups).
-- `research/problems/hilbert-14-oq-04/knowledge.md` — **created in S1**
-  (algorithmic landscape, Reynolds operator background, LND background,
-  counterexamples, Mathlib API gap inventory).
-- `research/problems/hilbert-14-oq-04/state.md` — **this file**.
-- `src/data/research/problems/hilbert-14-oq-04.json` — **created in S1**
-  (gallery entry for the open question).
-- `proofs/Proofs/Hilbert14OQ04.lean` — **planned for S2**.
-- `src/data/proofs/hilbert-14/meta.json` — parent gallery entry; not
-  modified in S1.
+- `research/problems/hilbert-14-oq-04/problem.md` — created in S1.
+- `research/problems/hilbert-14-oq-04/knowledge.md` — created in S1.
+- `research/problems/hilbert-14-oq-04/state.md` — **this file, refreshed
+  in S2-finite ACT**.
+- `src/data/research/problems/hilbert-14-oq-04.json` — phase advanced
+  to ACT in this iteration.
+- `proofs/Proofs/Hilbert14OQ04.lean` — **created in S2-finite ACT**.
+- `proofs/Proofs.lean` — `import Proofs.Hilbert14OQ04` added.
 
-## Pedagogical anchor: parent gallery entry's openQuestions
+## Honesty notes
 
-The parent `hilbert-14/meta.json` lists three open questions in its
-`openQuestions` field:
-1. "Can we characterize exactly which non-reductive groups have finitely
-   generated invariants?"
-2. "What is the optimal bound on degrees of generators for reductive
-   groups?"
-3. "Are there effective algorithms to decide finite generation for
-   specific non-reductive groups?"
+- This proof closes the **qualitative** half of Noether's theorem (1916):
+  `R^G` is finitely generated. It does NOT prove the **quantitative**
+  half (Noether's degree bound `generators ⊆ deg ≤ |G|`), which remains
+  S3-bound.
+- The five Mathlib bearers do the heavy lifting; the file is essentially
+  a 1916 fact stated and a five-step composition of pre-existing Mathlib
+  results. It is not a novel theorem; it is a clean Lean statement of a
+  classical result, made possible by recent Mathlib infrastructure
+  (`Algebra.IsInvariant` was added in Mathlib v4.20+ by T. Browning;
+  pinned at v4.26.0 here).
+- The OQ-04 problem itself (effective algorithms for non-reductive
+  invariant rings) remains open and is not directly formalizable.
+- No `axiom` declarations or structure-encoded assumptions in the new
+  file. The `Field k`, `Group G`, `Fintype G`, `MulSemiringAction`,
+  `SMulCommClass` typeclass hypotheses are the standard finite-group
+  linear-action setup, not assumptions about the open question.
 
-OQ-04 = the *algorithmic* version of #1 ∩ #3. The S2 ACT positive-result
-baseline (Hilbert-Noether) gives us the affirmative answer in the
-finite-group case (the simplest reductive setting), against which both
-the optimal-bound question (#2: Noether 1916: `≤ |G|`) and the
-non-reductive failure questions (#1, #3) acquire force.
+## Build status (S2-finite ACT)
 
-## Tactic A (S2 target): Reynolds-operator scaffold
-
-A scaffold of the Reynolds operator + statement of Hilbert-Noether
-finiteness. Discharge of the Noether-bound proof of finiteness deferred
-to S3.
-
-## Tactic B (followup S3-S5): Noether bound + degree-stable algorithm
-
-After S2 ACT lands the Reynolds operator and the finiteness statement,
-S3 ACT proves the **Noether degree bound**:
-`generators(k[V]^G) ⊆ k[V]^G_{≤ |G|}` — every minimal generating set of
-the invariant ring lies in degrees bounded by `|G|`. This makes the
-algorithm explicit: enumerate monomials up to degree `|G|`, average each
-via Reynolds, perform Gauss elimination.
-
-## Tactic C (much later, possibly out of scope): LND framework + Weitzenboeck
-
-S5+ would introduce `IsLocallyNilpotent` and the slice theorem,
-formalizing the simplest case of Weitzenboeck (`G_a` on `k[x, y]` via
-`D = ∂/∂y`) and stating the general Weitzenboeck theorem as an axiom
-pending the van-den-Essen algorithm.
-
-## Tactic D (out of scope for Lean): Nagata's counterexample
-
-Axiom-only statement for pedagogical completeness; full Lean proof is
-many thousands of lines (would require formalizing Nagata's symbolic
-blow-up of a smooth surface).
-
-## Build status (S1)
-
-S1 deliverable is **documentation-only**: four files (`problem.md`,
-`knowledge.md`, `state.md`, `src/data/research/problems/hilbert-14-oq-04.json`).
-No Lean changes. Per the seeker-fresh-slug S1 OBSERVE precedent (e.g.
-`cube-root-3-irrational-oq-04` PR #17718, `birthday-problem-oq-01-oq-02`
-PR #17735), this is the conventional S1 ACT-deferred deliverable.
-
-Build verification not applicable.
+Verified by `./proofs/scripts/docker-build.sh Proofs.Hilbert14OQ04`
+(2026-05-13 ~20:18 UTC). Output:
+```
+✔ [7743/7743] Built Proofs.Hilbert14OQ04 (9.8s)
+Build completed successfully (7743 jobs).
+```

--- a/src/data/research/problems/hilbert-14-oq-04.json
+++ b/src/data/research/problems/hilbert-14-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "hilbert-14-oq-04",
   "title": "Effective algorithms for finite generation of non-reductive invariant rings",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -31,31 +31,38 @@
     "goal": "Formalize Noether's degree bound (1916) as the algorithmic refinement of Hilbert's positive finiteness theorem for finite-group invariants, plus an Mathlib-tractable framework for locally nilpotent derivations sufficient to state Weitzenboeck's theorem and (axiom-form) Nagata's counterexample."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T19:30:00.000Z",
-    "iteration": 1,
-    "focus": "Algorithmic landscape survey + Mathlib gap audit + sibling-slug differentiation",
+    "phase": "ACT",
+    "since": "2026-05-13T20:18:00.000Z",
+    "iteration": 2,
+    "focus": "S2-finite ACT shipped: hilbert_finiteness verified by Docker build (7743/7743 jobs). Qualitative half of Noether 1916 formalized in proofs/Proofs/Hilbert14OQ04.lean (102 LOC). Next: S3-bound ACT for degree-bound generators ⊆ deg ≤ |G|.",
     "blockers": [],
-    "nextAction": "S2 ACT: scaffold proofs/Proofs/Hilbert14OQ04.lean with orbit polynomial definition, integrality lemmas (degree ≤ |G|), and the Noether degree-bound theorem statement (sorried). Cross-reference OQ-01's Reynolds operator infrastructure to avoid duplication.",
+    "nextAction": "S3-bound ACT: prove Noether degree bound — orbit-polynomial coefficients of v ∈ R generate an invariant-subalgebra in degrees ≤ |G|, using MulSemiringAction.charpoly (Invariant/Basic.lean:138) and MvPolynomial.mul_esymm_eq_sum (Symmetric/NewtonIdentities.lean:223).",
     "attemptCounts": {
-      "total": 1,
+      "total": 9,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete (doc-only): surveyed the algorithmic landscape (Derksen for reductive, Noether bound for finite, van den Essen for LNDs, Nagata/Roberts counterexamples). Audited Mathlib for relevant primitives; identified that OQ-01's existing Lean development (Hilbert14NonReductive.lean, Hilbert14InvariantsOQ01.lean) already provides the structural Reynolds operator + invariant subring infrastructure (`InvariantSubset`, `ReynoldsOperator`, `reynoldsSum` + 7 properties) but has no degree-bound machinery. OQ-04 picks up where OQ-01 leaves off, on the algorithmic axis.",
+    "progressSummary": "S2-finite ACT shipped (PR pending): hilbert_finiteness theorem verified by Docker build (7743/7743). The qualitative half of Noether 1916 — invariant ring of a finite-group linear action on MvPolynomial is finitely generated as a k-algebra — is now formalized in proofs/Proofs/Hilbert14OQ04.lean (102 LOC). Five-step proof chains through Algebra.IsInvariant → Algebra.IsInvariant.isIntegral → Algebra.FiniteType.of_restrictScalars_finiteType → Algebra.IsIntegral.finite → Artin-Tate fg_of_fg_of_fg, all pinned at Mathlib v4.26.0. Two supporting instances (Algebra.IsInvariant and Algebra.IsIntegral) discharged definitionally via FixedPoints.subalgebra membership. The quantitative half (Noether degree bound) is deferred to S3-bound ACT. Predecessor PREP chain: PRs #18248 (S1) + #18435/18501/18562/18589/18667/18714/18750 (S2-S2g).",
     "builtItems": [
       "research/problems/hilbert-14-oq-04/problem.md (S1, 5K) — problem statement, sub-problem decomposition, OQ-01 vs OQ-04 differentiation.",
       "research/problems/hilbert-14-oq-04/knowledge.md (S1, 8K) — Reynolds operator and LND background, Noether degree bound proof outline, counterexample summaries, Mathlib API gap inventory.",
-      "research/problems/hilbert-14-oq-04/state.md (S1) — phase tracker, S2 next-action plan."
+      "research/problems/hilbert-14-oq-04/state.md (S1) — phase tracker, S2 next-action plan.",
+      "proofs/Proofs/Hilbert14OQ04.lean (S2-finite ACT, 102 LOC) — hilbert_finiteness theorem + Algebra.IsInvariant/IsIntegral instances. Verified by Docker build 7743/7743 jobs.",
+      "proofs/Proofs.lean — added import Proofs.Hilbert14OQ04."
     ],
     "insights": [
       "OQ-04 is a meta-mathematical conjecture about algorithm existence; it cannot be formalized as a single Lean theorem. Lean progress must instead anchor on specific algorithmic refinements (Noether degree bound, slice theorem, etc.).",
       "Noether's bound (deg ≤ |G|) is the highest-leverage S2 target: distinct from OQ-01's structural Reynolds infrastructure, provable from Mathlib primitives, foundational algorithmically.",
       "OQ-01's `reynoldsSum` and `InvariantSubset` are directly reusable; the S2 OQ-04 file should cross-reference rather than redefine.",
       "Mathlib has no locally nilpotent derivation framework. Weitzenboeck's theorem and the slice theorem are tier-2 axioms until `IsLocallyNilpotent` is defined.",
-      "Nagata's and Roberts' counterexamples are pedagogically essential but Lean-unprovable in any reasonable scope; they will live as axioms."
+      "Nagata's and Roberts' counterexamples are pedagogically essential but Lean-unprovable in any reasonable scope; they will live as axioms.",
+      "Algebra.FiniteType.of_restrictScalars_finiteType requires explicit R/S/A type-level args (the surrounding variable block declares them explicit, not implicit) — failed in build attempts 1 and 2 before discovery.",
+      "Subalgebra.fg_iff_finiteType takes (S : Subalgebra R A) as explicit arg; cannot project .mp / .mpr directly. Use either (Subalgebra.fg_iff_finiteType _).mpr or the FiniteType.out projection / ⟨_⟩ constructor.",
+      "Algebra.FiniteType k ↥(⊤ : Subalgebra k R) does NOT typeclass-synthesize cheaply (heartbeat timeout); use (inferInstance : Algebra.FiniteType k R).out for the direct FG projection.",
+      "⟨h_fg⟩ as Algebra.FiniteType constructor: the class is a Prop with one field (out : (⊤ : Subalgebra R A).FG), so anonymous-constructor pack-up suffices.",
+      "Subtype.val_injective serves as algebraMap (FixedPoints.subalgebra k R G) R injectivity in fg_of_fg_of_fg invocation — Subalgebra.toAlgebra (line 822) is definitionally Subtype.val on the underlying function."
     ],
     "mathlibGaps": [
       "No Noether degree bound for finite-group invariants",
@@ -65,10 +72,9 @@
       "No Derksen-algorithm-style invariant computation API"
     ],
     "nextSteps": [
-      "S2 ACT: scaffold orbit-polynomial definition + integrality lemmas + Noether degree-bound theorem statement.",
-      "S3 ACT: discharge the Noether degree-bound theorem via the Atiyah-Macdonald 5.1 integral-finite-extension argument.",
-      "S5+ ACT: introduce `IsLocallyNilpotent` for derivations; state Weitzenboeck (axiom) and slice theorem (Lean).",
-      "S7+ ACT: state Nagata's counterexample (axiom-only) and Roberts' 7-variable counterexample (axiom-only) for pedagogical completeness."
+      "S3-bound ACT: prove Noether degree bound (generators ⊆ deg ≤ |G|) via orbit polynomial Vieta + Newton identities.",
+      "S5+ ACT (long horizon): introduce Mathlib IsLocallyNilpotent for derivations; state Weitzenboeck (axiom) and slice theorem (Lean).",
+      "S7+ ACT (long horizon): state Nagata counterexample (axiom-only) and Roberts 7-variable counterexample (axiom-only) for pedagogical completeness."
     ]
   },
   "tags": [
@@ -154,7 +160,7 @@
     ]
   },
   "started": "2026-05-12T19:30:00.000Z",
-  "lastUpdate": "2026-05-12T19:30:00.000Z",
+  "lastUpdate": "2026-05-13T20:18:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": []


### PR DESCRIPTION
## Summary

S2-finite ACT for hilbert-14-oq-04: ships the **qualitative half of
Noether's 1916 theorem** (invariant ring of a finite-group linear action
on `MvPolynomial` is finitely generated as a `k`-algebra) as a verified
Lean theorem, picking up the 7-PREP-deep bearer audit done by PRs
#18248/#18435/#18501/#18562/#18589/#18667/#18714/#18750.

The Lean file `proofs/Proofs/Hilbert14OQ04.lean` (NEW, 102 LOC) contains:
- `theorem hilbert_finiteness : Algebra.FiniteType k (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)`
- `instance Algebra.IsInvariant (FixedPoints.subalgebra k R G) R G` (definitional)
- `instance Algebra.IsIntegral (FixedPoints.subalgebra k R G) R` (via Mathlib bearer)

No `sorry`. No `axiom`. No structure-encoded assumptions. The five
typeclass hypotheses (`Field k`, `Group G`, `Fintype G`,
`MulSemiringAction G R`, `SMulCommClass G k R`) are the standard
finite-group linear-action setup, not assumptions about OQ-04.

## Proof chain (verified)

```
Algebra.IsInvariant B R G                         (definitional)
  ↓ Algebra.IsInvariant.isIntegral [Invariant/Basic.lean:174]
Algebra.IsIntegral B R
  ↓ + Algebra.FiniteType.of_restrictScalars_finiteType k B R
  ↓                              [FiniteType.lean:77]
Algebra.FiniteType B R
  ↓ Algebra.IsIntegral.finite [IntegralClosure/Basic.lean:93]
Module.Finite B R
  ↓ + (inferInstance : Algebra.FiniteType k R).out
  ↓ + Module.Finite.fg_top
  ↓ + Subtype.val_injective
  ↓ fg_of_fg_of_fg k B R ...  [Adjoin/Tower.lean:150]
(⊤ : Subalgebra k B).FG
  ↓ ⟨·⟩
Algebra.FiniteType k B
```

where `R := MvPolynomial (Fin n) k`, `B := FixedPoints.subalgebra k R G`.

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.Hilbert14OQ04
...
✔ [7743/7743] Built Proofs.Hilbert14OQ04 (9.8s)
Build completed successfully (7743 jobs).
```

Three Docker build attempts; each produced actionable diagnostics:

1. **Build #1**: surfaced that `Algebra.FiniteType.of_restrictScalars_finiteType`
   takes explicit `R/S/A` Type-level args (variable block makes them
   explicit) and that `_root_.Subalgebra.fg_iff_finiteType` takes
   `(S : Subalgebra R A)` as explicit, so `.mp`/`.mpr` cannot be
   directly projected.
2. **Build #2**: surfaced that `Algebra.FiniteType k ↥(⊤ : Subalgebra k R)`
   triggers a 20k-heartbeat typeclass synthesis timeout, and that the
   final iff invocation resolves `_` to `B` not `⊤`. Fixed by using
   `(inferInstance : Algebra.FiniteType k R).out` and the
   anonymous-constructor pack-up `⟨h_kB_fg⟩`.
3. **Build #3**: green.

These three trap resolutions are now captured as `knowledge.insights` in
the gallery JSON so the S3-bound ACT iteration can avoid the same
detours.

## Scope honesty

**IN scope**: qualitative half of Noether 1916 (finite generation of
`R^G`).

**OUT (deferred to S3-bound ACT)**: the quantitative half — Noether's
degree bound `generators ⊆ deg ≤ |G|`. S2g PREP §2.4 has already pinned
the Mathlib bearer (`MvPolynomial.mul_esymm_eq_sum` at
`Symmetric/NewtonIdentities.lean:223`) for that next iteration.

**OUT**: locally nilpotent derivations (Weitzenboeck framework), Nagata
counterexample. These require infrastructure Mathlib does not yet have.

OQ-04 itself (effective algorithms for non-reductive invariant rings)
remains an open meta-mathematical conjecture and is not formalizable as
a single Lean theorem. This PR advances the **Lean-tractable adjacent
target** (finite-group case, qualitative finiteness), not OQ-04 itself.

## Files modified

```
proofs/Proofs.lean                                                          | 1 +
proofs/Proofs/Hilbert14OQ04.lean                                            | 100 ++ (NEW)
research/problems/hilbert-14-oq-04/sessions/2026-05-13-s2-finite-act-...md  | 189 ++ (NEW)
research/problems/hilbert-14-oq-04/state.md                                 | refreshed
src/data/research/problems/hilbert-14-oq-04.json                            | phase OBSERVE → ACT
```

## Status

- **Outcome**: progress (S2-finite ACT shipped; S3-bound ACT next)
- **Phase**: OBSERVE → ACT
- **Next**: S3-bound ACT — Noether degree bound

🤖 Generated by researcher-1
