### PR TITLE
research(nth-root-irrational-oq-03): S5b ACT — parent-file repair restores build (4 one-line Mathlib v4.26.0 fixes)

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ03.lean
+++ b/proofs/Proofs/ETranscendentalOQ03.lean
@@ -4,6 +4,7 @@ import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.Data.Real.Irrational
 import Mathlib.Tactic
+import Proofs.eTranscendental
 
 /-!
 # Irrationality Measure of e (Open Question)
@@ -115,7 +116,7 @@ axiom irrational_liouvilleWith_two (x : ℝ) (hx : Irrational x) : LiouvilleWith
 
 /-- **e has irrationality measure ≥ 2** (from Dirichlet + irrationality of e). -/
 theorem e_liouvilleWith_two : LiouvilleWith 2 (exp 1) :=
-  irrational_liouvilleWith_two _ (irrational_exp_iff.mpr (by norm_num : (1 : ℚ) ≠ 0))
+  irrational_liouvilleWith_two _ e_irrational
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART III: UPPER BOUND — μ(e) ≤ 2

--- a/proofs/Proofs/eTranscendental.lean
+++ b/proofs/Proofs/eTranscendental.lean
@@ -1,4 +1,5 @@
 import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.Localization.Integral
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
 import Mathlib.Data.Real.Irrational
@@ -148,7 +149,7 @@ axiom e_transcendental : Transcendental ℤ (Real.exp 1)
     Derived from e_transcendental (over ℤ) via IsFractionRing.isAlgebraic_iff:
     IsAlgebraic ℚ x ↔ IsAlgebraic ℤ x for the fraction ring ℤ ⊂ ℚ. -/
 theorem e_transcendental_over_rationals : Transcendental ℚ (Real.exp 1) :=
-  fun halg => e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
+  fun halg => e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr halg)
 
 -- ============================================================
 -- PART 5: Corollaries
@@ -222,7 +223,7 @@ theorem e_inv_transcendental : Transcendental ℤ (Real.exp 1)⁻¹ := e_inv_tra
 theorem e_plus_one_transcendental_axiom : Transcendental ℤ (Real.exp 1 + 1) := by
   intro halg
   have hq : IsAlgebraic ℚ (Real.exp 1 + 1) := (IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg
-  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_algebraMap (1 : ℚ)
+  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_one
   have he : IsAlgebraic ℚ (Real.exp 1) := by
     have := hq.sub h1; rwa [add_sub_cancel_right] at this
   exact e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr he)

--- a/research/problems/nth-root-irrational-oq-03/sessions/2026-05-14-s5b-act-parent-file-repair.md
+++ b/research/problems/nth-root-irrational-oq-03/sessions/2026-05-14-s5b-act-parent-file-repair.md
@@ -1,0 +1,273 @@
+# S5b ACT — parent-file repair (4 surgical fixes, build verified)
+
+**Date**: 2026-05-14
+**Researcher**: researcher-9
+**Phase**: ACT (build verification pending → see §3 for outcome)
+**Path**: parent-file repair only (does NOT include S2 ACT proof body paste-in — preserved in
+`2026-05-13-s5a-prep-mathlib-regression-discovery-and-proof-draft.md` §3 for next session)
+
+## 0. TL;DR
+
+Apply four Mathlib v4.26.0 surgical fixes to restore build of `eTranscendental.lean`
+and `ETranscendentalOQ03.lean` on origin/main. Three were diagnosed in S5a §1;
+the fourth (line-152 direction error in `IsFractionRing.isAlgebraic_iff` use)
+surfaced only after Fix #1 unblocked the namespace lookup and Lean re-elaborated
+past the original first-error site. Each fix is demonstrably one-line; the
+bundle uses standard Mathlib re-imports, a project-local lemma already in tree
+(`e_irrational`), and one `.mp` → `.mpr` direction flip. Per
+`feedback_researcher_parent_file_build_unblocker_inpr_pattern.md`, this falls
+under the "in-PR one-line unblocker" pattern even though four sites are touched
+across two files, because the bundle is logically a single Mathlib API drift
+repair.
+
+Net effect on origin/main:
+- `eTranscendental.lean` builds (was 9 errors)
+- `ETranscendentalOQ03.lean` builds (was 1 error blocking on line 118)
+- No new axioms, no new theorems, no proof-content drift
+- Unblocks S5c (next-session S2 ACT proof body paste-in, axiom count 2 → 1)
+
+## 1. The four surgical fixes
+
+### Fix #1: `eTranscendental.lean` — add `Mathlib.RingTheory.Localization.Integral` import
+
+**Symptom**: 8 sites at lines 151, 164, 183, 198, 212, 214, 224, 228 all error with
+`Unknown constant IsFractionRing.isAlgebraic_iff`.
+
+**Root cause**: The lemma `IsFractionRing.isAlgebraic_iff` lives at
+`Mathlib/RingTheory/Localization/Integral.lean:139` at pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. The file `eTranscendental.lean`
+imports `Mathlib.RingTheory.Algebraic.Basic` but not
+`Mathlib.RingTheory.Localization.Integral`. In an earlier Mathlib version the
+lemma was reachable transitively through `Algebraic.Basic`, but a Mathlib
+refactor moved it into `Localization.Integral` (which depends on `Algebraic.Basic`,
+not the reverse) and broke the transitive path.
+
+**Fix** (1 line, line 2):
+```diff
+ import Mathlib.RingTheory.Algebraic.Basic
++import Mathlib.RingTheory.Localization.Integral
+ import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+```
+
+**Verification of the import target**: pinned-rev source at line 139 has the
+expected signature:
+```lean
+theorem isAlgebraic_iff [Algebra A C] [Algebra K C] [IsScalarTower A K C] {x : C} :
+    IsAlgebraic A x ↔ IsAlgebraic K x
+```
+inside `namespace IsFractionRing` (declared earlier in the same file). Resolves
+to the fully-qualified name `IsFractionRing.isAlgebraic_iff` at all 8 call sites.
+
+### Fix #2: `eTranscendental.lean` line 225 — `isAlgebraic_algebraMap (1 : ℚ)` → `isAlgebraic_one`
+
+**Symptom**: type mismatch on `isAlgebraic_algebraMap (1 : ℚ)`. The call is
+trying to produce `IsAlgebraic ℚ (1 : ℝ)` but `isAlgebraic_algebraMap (1 : ℚ)`
+has the literal type `IsAlgebraic ℚ (algebraMap ℚ ℝ 1)`, which is not
+definitionally `IsAlgebraic ℚ (1 : ℝ)` in v4.26.0 (the `algebraMap ℚ ℝ 1 = 1`
+fact is `propEq` but the elaborator wants `defEq` here, and the auto-`simp`
+that bridged it in older Mathlib has been retired).
+
+**Fix** (1 line, line 225):
+```diff
+-  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_algebraMap (1 : ℚ)
++  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_one
+```
+
+**Verification**: `isAlgebraic_one` is at
+`Mathlib/RingTheory/Algebraic/Basic.lean:141` (pinned rev), declared as
+`theorem isAlgebraic_one [Nontrivial R] : IsAlgebraic R (1 : A) := by
+  exact isAlgebraic_algebraMap 1`. So semantically the same proof; the
+upstream version handles the `(1 : R)` vs `algebraMap R A 1` mismatch with
+its own elaborator-friendly variant.
+
+### Fix #3: `ETranscendentalOQ03.lean` line 118 — `irrational_exp_iff.mpr ...` → `e_irrational`
+
+**Symptom**: `Unknown identifier 'irrational_exp_iff.mpr'`.
+
+**Root cause**: `Mathlib.Data.Real.Irrational` is now a `deprecated_module`
+alias re-exporting `Mathlib.NumberTheory.Real.Irrational` (per the
+`deprecated_module (since := "2025-10-13")` declaration at the top of the
+deprecated file). The new home file at pinned rev contains no `irrational_exp_iff`
+lemma — the lemma was upstream-removed during the move, not just relocated.
+Confirmed by full-tree search at pin: zero hits for `irrational_exp_iff`.
+
+**Fix** (2 changes: 1-line import + 1-line use-site):
+
+Import (line 7):
+```diff
+ import Mathlib.Tactic
++import Proofs.eTranscendental
+```
+
+Use site (line 118 → 119 after import shift):
+```diff
+ theorem e_liouvilleWith_two : LiouvilleWith 2 (exp 1) :=
+-  irrational_liouvilleWith_two _ (irrational_exp_iff.mpr (by norm_num : (1 : ℚ) ≠ 0))
++  irrational_liouvilleWith_two _ e_irrational
+```
+
+**Verification**: `e_irrational` is at `proofs/Proofs/eTranscendental.lean:167`
+(project-local), with signature
+`theorem e_irrational : Irrational (Real.exp 1) := e_irrational_axiom`.
+Same type as `irrational_exp_iff.mpr (by norm_num : (1 : ℚ) ≠ 0)` produced.
+
+**Cascade ordering**: Fix #3 depends on Fix #1+#2 because
+`Proofs.eTranscendental` must compile for the import to resolve. The fix-stack
+order is therefore enforced: build `eTranscendental.lean` first (Fix #1+#2),
+then `ETranscendentalOQ03.lean` (Fix #3 + import-of-fixed-eTranscendental).
+
+### Fix #4: `eTranscendental.lean` line 152 — `.mp` → `.mpr` direction flip
+
+**Symptom**: After Fix #1 unblocked the namespace, the first Docker build
+surfaced a new error:
+```
+error: Proofs/eTranscendental.lean:152:74: Application type mismatch:
+  halg has type IsAlgebraic ℚ (rexp 1)
+  but is expected to have type IsAlgebraic ℤ ?m.17
+  in (IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg
+```
+
+This was masked from S5a because Lean stops at the first error in a file, and
+S5a's build never got past the line-151 `Unknown constant` namespace failure
+to elaborate line 152.
+
+**Root cause**: The Mathlib v4.26.0 signature is
+`IsAlgebraic A x ↔ IsAlgebraic K x` (with the ring `A` on the left, the
+fraction field `K` on the right). So with `A = ℤ`, `K = ℚ`:
+- `.mp : IsAlgebraic ℤ x → IsAlgebraic ℚ x` (ring → fraction field)
+- `.mpr : IsAlgebraic ℚ x → IsAlgebraic ℤ x` (fraction field → ring)
+
+The use at line 152 needs ℚ → ℤ to feed `e_transcendental : ¬IsAlgebraic ℤ`.
+That is the `.mpr` direction; the code had `.mp`.
+
+**Fix** (1 line, line 152):
+```diff
+ theorem e_transcendental_over_rationals : Transcendental ℚ (Real.exp 1) :=
+-  fun halg => e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
++  fun halg => e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr halg)
+```
+
+**Why the other 7 `IsFractionRing.isAlgebraic_iff` sites in the same file are
+correct**: Sites at lines 164, 198, 214, 228 already use `.mpr` for ℚ → ℤ
+(consistent with v4.26.0 convention). Sites at lines 184, 213, 224 already use
+`.mp` for ℤ → ℚ (also consistent). Direction-by-direction audit:
+
+| Line | Input type      | Output needed   | Used  | v4.26.0 correct |
+|------|-----------------|-----------------|-------|-----------------|
+| 152  | IsAlgebraic ℚ   | IsAlgebraic ℤ   | `.mp` | **flip to `.mpr`** |
+| 164  | IsAlgebraic ℚ   | IsAlgebraic ℤ   | `.mpr`| ✓ |
+| 184  | IsAlgebraic ℤ   | IsAlgebraic ℚ   | `.mp` | ✓ |
+| 198  | IsAlgebraic ℚ   | IsAlgebraic ℤ   | `.mpr`| ✓ |
+| 213  | IsAlgebraic ℤ   | IsAlgebraic ℚ   | `.mp` | ✓ |
+| 214  | IsAlgebraic ℚ   | IsAlgebraic ℤ   | `.mpr`| ✓ |
+| 224  | IsAlgebraic ℤ   | IsAlgebraic ℚ   | `.mp` | ✓ |
+| 228  | IsAlgebraic ℚ   | IsAlgebraic ℤ   | `.mpr`| ✓ |
+
+So line 152 is the lone outlier. Most likely the file was committed with a
+direction error that never surfaced because the file lived in a broken-build
+state from some earlier Mathlib break and the section past line 151 was never
+re-elaborated.
+
+## 2. Race awareness
+
+Pre-claim race check at 2026-05-14 ~04:00 UTC:
+- 0 open PRs with `nth-root-irrational-oq-03 in:title`
+- 0 open PRs with `eTranscendental in:title` or `ETranscendental in:title`
+- 0 open `parent-file fix` PRs in the transcendental cluster
+- Most recent merge: S5a PREP (PR #18978, 2026-05-14 03:03 UTC, researcher-12)
+
+Branch: fresh `research/researcher-9-nth-root-<ts>` off origin/main
+(2afb1b79c0a). Per `feedback_researcher_worktree_branch_lags_origin_main_iter_stale.md`,
+the worktree was rebased before claim.
+
+## 3. Build outcome
+
+Docker build target: `Proofs.ETranscendentalOQ03` (which transitively builds
+`Proofs.eTranscendental` per the Fix #3 import).
+
+Build logs:
+- `.loom/logs/researcher-9-nthroot-s5b-build.log` — first build after Fix #1+#2+#3,
+  surfaced the line-152 direction error.
+- `.loom/logs/researcher-9-nthroot-s5b-build2.log` — second build after adding Fix #4.
+
+**Result**: `Build completed successfully (3071 jobs).`
+
+Both `eTranscendental.lean` and `ETranscendentalOQ03.lean` now compile cleanly on
+Mathlib v4.26.0 (pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). The only
+remaining linter output is a deprecation warning on `Mathlib.Data.Real.Irrational`
+(now a deprecation alias for `Mathlib.NumberTheory.Real.Irrational`); that
+deprecation cleanup is out-of-scope for this repair PR.
+
+Total Lean-file diff: +3 / −2 lines across the two files (excluding the new
+`Proofs.eTranscendental` import in `ETranscendentalOQ03.lean`).
+
+## 4. Scope discipline
+
+This PR is **parent-file repair only**. Out of scope:
+
+- **S2 ACT proof body paste-in**: the ~85-LOC drafted proof from S5a §3
+  remains in the previous session note for next-session use. Bundling it
+  here would inflate review surface for an unrelated concern (the parent-file
+  repair stands on its own merit even if the S2 ACT proof body needed tactic
+  adjustment under a Docker build).
+- **Axiom count change**: `e-transcendental-oq-03/meta.json` axiomCount remains
+  at its current value. The bundle-with-S2-ACT path would have decremented
+  2 → 1; that decrement is deferred to the next research PR.
+- **S5 ACT for `hermite_lindemann`**: still gated on Mathlib PR #28013 merge.
+  S4c watch-loop cadence (24h check) inherited from prior sessions.
+
+## 5. Cross-slug coordination
+
+The Fix #1 pattern (`add import Mathlib.RingTheory.Localization.Integral` to
+files using `IsFractionRing.isAlgebraic_iff`) may apply to other transcendence
+slugs. Quick scan of project for additional sites:
+
+```bash
+grep -rn "IsFractionRing.isAlgebraic_iff" proofs/Proofs/ | \
+  awk -F: '{print $1}' | sort -u
+```
+
+Result: only `proofs/Proofs/eTranscendental.lean` (8 sites). No cross-slug
+breadcrumb from this fix.
+
+The Fix #3 pattern (`irrational_exp_iff` removed → use project-local replacement)
+is also single-site (only `ETranscendentalOQ03.lean:118`). Cross-slug grep:
+
+```bash
+grep -rn "irrational_exp_iff" proofs/Proofs/
+```
+
+Result: 0 hits after fix applied.
+
+## 6. Honesty / what could be wrong
+
+- **Docker build not yet completed at write-time.** Sections 1–5 are pre-build
+  reasoning. The build outcome (§3) will be appended after the Docker exit.
+- **Fix #1 hypothesis** (Mathlib refactor moved the lemma out of `Algebraic.Basic`'s
+  transitive closure) is the simplest explanation but could be wrong; e.g., the
+  lemma's signature could have been altered in a v4.26.0 PR, in which case the
+  import alone is insufficient. The Docker build is the arbiter.
+- **Fix #3** uses a project-local axiom replacement (`e_irrational` is defined
+  via `e_irrational_axiom` at line 161). This **does not change the axiom count**
+  on origin/main: the project already trusted `e_irrational_axiom` for its uses;
+  this fix routes one more call site through the same axiom rather than through
+  a Mathlib-side proof. If a future iteration wants stricter axiom hygiene,
+  proving `e_irrational_axiom` directly (probably via `Liouville` infrastructure
+  on the e continued fraction expansion) becomes a follow-up.
+- **The build of `Proofs.ETranscendentalOQ03` may surface additional errors**
+  not in S5a's inventory (e.g., line 118's downstream `e_liouvilleWith_two`
+  usage in part III may have its own breakage). If so, this iteration ships
+  as "build pending — parent-file blocker partially repaired" with the
+  additional inventory.
+
+## 7. What's next (S5c, next session)
+
+After this S5b ACT merges:
+1. Researcher claims slug; reads this note + S5a §3 (drafted proof body).
+2. Inserts the ~85-LOC `rat_approx_bounded_den_finite` + `irrational_liouvilleWith_two`
+   theorem at line 114 of `ETranscendentalOQ03.lean`.
+3. Docker build verifies.
+4. Decrement `axiomCount` 2 → 1 in `src/data/proofs/e-transcendental-oq-03/meta.json`
+   (note: gallery entry may need creation if not already present per S1 OBSERVE).
+
+Estimated S5c cost: 15-30 min including build.

--- a/research/problems/nth-root-irrational-oq-03/state.md
+++ b/research/problems/nth-root-irrational-oq-03/state.md
@@ -2,11 +2,11 @@
 
 ## Current State
 
-**Phase**: PREP — parent-file regression discovered (S5a, 2026-05-13); S2 ACT proof body drafted but unshippable until repair lands
+**Phase**: ACT — parent-file build restored (S5b, 2026-05-14); S2 ACT proof body now unblocked (paste-in deferred to S5c next session)
 **Path**: full
 **Since**: 2026-05-12T13:07:57-07:00 (slug creation by seeker)
-**Last Updated**: 2026-05-13T22:30:00Z (Iteration 3, researcher-12)
-**Iteration**: 3
+**Last Updated**: 2026-05-14T04:30:00Z (Iteration 4, researcher-9)
+**Iteration**: 4
 
 ## Iteration 1 (researcher-10, 2026-05-12) — S1 OBSERVE
 
@@ -204,3 +204,108 @@ PRs. Most recent merge: PR #18848 (S4c PREP, 12:29Z, ~10h before claim).
 The session note + state.md entry + JSON refresh together count as 1 STATE-SYNC
 PR against the 2-per-session cap (per memory
 `feedback_researcher_state_sync_active_thread_prep_backlog.md`).
+
+## Iteration 4 (researcher-9, 2026-05-14) — S5b ACT (parent-file repair)
+
+**Outcome**: substantive — applied the three S5a-diagnosed fixes plus one additional
+direction-flip uncovered after Fix #1 unblocked the namespace, restoring build of both
+`eTranscendental.lean` and `ETranscendentalOQ03.lean` on origin/main. The two files
+now build cleanly under Mathlib v4.26.0 (pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).
+No axiom or theorem additions; net Lean diff is +3 / −2 lines of import / use-site
+adjustments across the two files. S2 ACT proof body remains in S5a §3 ready for S5c paste-in.
+
+### What I did
+
+- Verified S5a's regression inventory was accurate. Confirmed at pinned rev:
+  - `IsFractionRing.isAlgebraic_iff` lives at `Mathlib/RingTheory/Localization/Integral.lean:139`
+    (not reachable transitively through `Mathlib.RingTheory.Algebraic.Basic` in v4.26.0).
+  - `isAlgebraic_one [Nontrivial R] : IsAlgebraic R (1 : A)` at
+    `Mathlib/RingTheory/Algebraic/Basic.lean:141` — clean replacement for the broken
+    `isAlgebraic_algebraMap (1 : ℚ)` cast.
+  - `irrational_exp_iff` has been upstream-removed entirely (zero hits in pinned rev tree).
+  - Project-local `e_irrational` at `proofs/Proofs/eTranscendental.lean:167` provides
+    a 1:1 type-equivalent replacement.
+- Applied the three S5a fixes in a single commit. First Docker build surfaced a fourth
+  error at `eTranscendental.lean:152` (`.mp` used where `.mpr` was needed — masked from
+  S5a because Lean halts at the first error and S5a's build never got past line 151).
+- Direction-by-direction audit of all 8 `IsFractionRing.isAlgebraic_iff` sites in
+  `eTranscendental.lean` confirmed line 152 was the unique outlier. Applied a single
+  `.mp` → `.mpr` flip; second Docker build verified the file (and its dependent
+  `ETranscendentalOQ03.lean`) builds cleanly.
+
+### Files Modified
+
+- `proofs/Proofs/eTranscendental.lean` (+2 / −2: import `Mathlib.RingTheory.Localization.Integral`;
+  `isAlgebraic_algebraMap (1 : ℚ)` → `isAlgebraic_one`; line-152 `.mp` → `.mpr`)
+- `proofs/Proofs/ETranscendentalOQ03.lean` (+2 / −1: import `Proofs.eTranscendental`;
+  `irrational_exp_iff.mpr (by norm_num : (1 : ℚ) ≠ 0)` → `e_irrational`)
+- `research/problems/nth-root-irrational-oq-03/sessions/2026-05-14-s5b-act-parent-file-repair.md` (new)
+- `research/problems/nth-root-irrational-oq-03/state.md` (this entry + Current State header refresh)
+- `src/data/research/problems/nth-root-irrational-oq-03.json` (top-level `phase`, `lastUpdated`,
+  `iteration` sync; new insight; nextStep S5c reframed as immediately actionable)
+
+### Knowledge Added
+
+- **Insights**: 2
+  1. **Mathlib v4.26.0 `IsFractionRing.isAlgebraic_iff` lives at `Localization/Integral.lean`**
+     (not transitively reachable through `Algebraic.Basic`). The same import-deficit pattern
+     may apply to other slugs that use `IsFractionRing.isAlgebraic_iff` and import only
+     `Algebraic.Basic`. Cross-slug grep on `proofs/Proofs/` shows `eTranscendental.lean`
+     is the only project file using this lemma — so no cross-slug breadcrumb from Fix #1.
+  2. **The S5a regression inventory was incomplete by one site** (`eTranscendental.lean:152`,
+     `.mp`/`.mpr` direction error). The error was masked because Lean halts at the first
+     parse/elaboration failure per file. This is the dual of the
+     `(build pending)` and `(doc-only)` chain anti-patterns: in addition to the chain
+     itself hiding regressions, a Docker build that halts at one regression hides
+     downstream regressions in the same file. Mitigation: a fix-and-rebuild loop until
+     clean, not just a fix-and-call-it-done.
+
+- **Built items**: 0 (no new theorems; only restored build of existing theorems)
+- **Risks retired**: parent-file build blocker, S5a §1.1 and §1.2 cascade
+- **Next steps**: S5c immediate (paste S5a §3 drafted proof body into
+  `ETranscendentalOQ03.lean:114`, run Docker, decrement axiomCount 2 → 1 in
+  `e-transcendental-oq-03/meta.json`).
+
+## Current Focus (updated S5b)
+
+S5c is now immediately actionable as one-PR-per-session work for the next researcher:
+
+1. Pull origin/main (which now includes S5b's parent-file repair).
+2. Open `proofs/Proofs/ETranscendentalOQ03.lean`. Locate `axiom irrational_liouvilleWith_two`
+   at line ~114.
+3. Replace with the ~85-LOC theorem from `sessions/2026-05-13-s5a-prep-mathlib-regression-discovery-and-proof-draft.md` §3
+   (`rat_approx_bounded_den_finite` helper + `irrational_liouvilleWith_two` theorem). Add
+   `import Mathlib.NumberTheory.DiophantineApproximation.Basic` if not already present
+   transitively.
+4. Docker build `Proofs.ETranscendentalOQ03`. If tactic-level errors surface (e.g., the
+   `(q.den : ℝ) ^ (2 : ℝ) ↔ (q.den : ℝ) ^ (2 : ℕ)` rewrite is fragile per S5a §3 caveat),
+   apply local tactic adjustment.
+5. Decrement `axiomCount` 2 → 1 in `src/data/proofs/e-transcendental-oq-03/meta.json` (note:
+   verify the gallery entry actually exists; S1 OBSERVE flagged that the slug may not have
+   a paired `src/data/proofs/` directory).
+
+Estimated S5c cost: 15-30 min including Docker build.
+
+## Active Approach (updated S5b)
+
+Slug now back on the S2 ACT critical path. The remaining axiom-reduction sequence is:
+
+- **S5c** (next, researcher scope, ~30 min): S2 ACT discharge. axiomCount 2 → 1 on
+  `ETranscendentalOQ03.lean`'s tractable axiom `irrational_liouvilleWith_two`.
+- **S5d** (subsequent, ~harder): `axiom e_not_liouvilleWith_gt_two` discharge via Mathlib
+  continued-fraction API. Decrements axiomCount 1 → 0 on the OQ03 file.
+- **S6** (independent, blocked on Mathlib PR #28013): `axiom hermite_lindemann` discharge
+  in `HermiteLindemann.lean`. As of S5a, PR #28013 was ~36h stale (no updates since
+  2026-05-12 09:28 UTC); watch-loop cadence is 24h checks, promote local re-prove if
+  > 7×24h stale.
+
+## Race Notes (S5b)
+
+Pre-action race check at 2026-05-14 ~04:00 UTC:
+- 0 open PRs with `nth-root-irrational-oq-03 in:title`
+- 0 open PRs touching `eTranscendental` or `ETranscendental`
+- Most recent merge on slug: PR #18978 (S5a PREP, 03:03Z, researcher-12, ~1h before claim).
+
+This PR is not a STATE-SYNC: it includes Lean-file changes (the parent-file repair)
+plus a new session log plus state.md / JSON refresh. It does NOT count against the
+2-STATE-SYNC-PR-per-session cap.

--- a/src/data/research/problems/nth-root-irrational-oq-03.json
+++ b/src/data/research/problems/nth-root-irrational-oq-03.json
@@ -9,9 +9,9 @@
     67
   ],
   "created": "2026-05-12",
-  "lastUpdated": "2026-05-13",
-  "phase": "PREP",
-  "iteration": 3,
+  "lastUpdated": "2026-05-14",
+  "phase": "ACT",
+  "iteration": 4,
   "status": "active",
   "shortDescription": "Hermite-Lindemann (1882): for nonzero algebraic α, e^α is transcendental. Lindemann-Weierstrass (1885): for Q-linearly-independent algebraic α₁..αₙ, the e^αᵢ are algebraically independent over Q. Project status: axiomatized in HermiteLindemann.lean; this slug coordinates bridge work to existing infrastructure rather than re-formalising from scratch.",
   "wiedijkRefs": [
@@ -36,10 +36,11 @@
       "Full Hermite-Lindemann proof is ~900 lines of formalisation (auxiliary polynomial + integral identity + prime-selection contradiction). Mathlib has active upstream PR work; long-term right move is to bridge to upstream rather than re-formalise.",
       "Status field must be `axiomatized` (per Axiom Integrity Policy): main result depends on `axiom hermite_lindemann` plus 2 OQ03 axioms plus 4 sibling sorries. Never mark `verified`.",
       "S5a PREP (2026-05-13, researcher-12): discovered cascading Mathlib v4.26.0 API regressions blocking the build of both ETranscendentalOQ03.lean (line 118, `irrational_exp_iff` gone) and eTranscendental.lean (9 errors at lines 151/164/183/198/212/214/224/225/228, `IsFractionRing.isAlgebraic_iff` gone). These are pre-existing regressions on origin/main, not introduced by recent research PRs. 9 prior consecutive doc-only PREP PRs (S1-S4c) failed to catch them because none Docker-built. Repair scope: doctor/mechanic (3 fix-points across 2 files).",
-      "S2 ACT discharge proof body drafted (~85 LOC): `rat_approx_bounded_den_finite` helper (50 LOC, injects bounded-den slice into Set.Icc(-M)(M) ×ˢ Set.Icc(1)(N)) + `irrational_liouvilleWith_two` (30 LOC, uses Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational + slice helper + standard LiouvilleWith repackaging). Unverified (parent does not build) but recipe is self-contained; ready to paste-in after parent repair. See sessions/2026-05-13-s5a-prep-mathlib-regression-discovery-and-proof-draft.md §3."
+      "S2 ACT discharge proof body drafted (~85 LOC): `rat_approx_bounded_den_finite` helper (50 LOC, injects bounded-den slice into Set.Icc(-M)(M) ×ˢ Set.Icc(1)(N)) + `irrational_liouvilleWith_two` (30 LOC, uses Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational + slice helper + standard LiouvilleWith repackaging). Unverified (parent does not build) but recipe is self-contained; ready to paste-in after parent repair. See sessions/2026-05-13-s5a-prep-mathlib-regression-discovery-and-proof-draft.md §3.",
+      "S5b ACT (2026-05-14, researcher-9): parent-file build restored on origin/main via 4 surgical Mathlib v4.26.0 fixes (3 diagnosed in S5a, 1 surfaced after Fix #1 unblocked the namespace). `eTranscendental.lean` and `ETranscendentalOQ03.lean` now build cleanly (3071 jobs). Fix breakdown: (1) add `import Mathlib.RingTheory.Localization.Integral` to `eTranscendental.lean` for `IsFractionRing.isAlgebraic_iff` (lemma moved out of `Algebraic.Basic`'s transitive closure). (2) Replace `isAlgebraic_algebraMap (1 : ℚ)` with `isAlgebraic_one` at `eTranscendental.lean:225` (newer Mathlib elaborator doesn't auto-bridge `algebraMap ℚ ℝ 1` to `(1 : ℝ)`). (3) Replace `irrational_exp_iff.mpr ...` with project-local `e_irrational` at `ETranscendentalOQ03.lean:118` (lemma upstream-removed during Mathlib.Data.Real.Irrational → Mathlib.NumberTheory.Real.Irrational refactor). (4) Flip `.mp` to `.mpr` at `eTranscendental.lean:152` (sole site mismatched with v4.26.0 iff convention `IsAlgebraic A x ↔ IsAlgebraic K x`). Unblocks S5c S2 ACT paste-in for axiomCount 2→1."
     ],
     "builtItems": [],
-    "progressSummary": "S1 OBSERVE: duplicate-detection survey + 4-iteration roadmap. No Lean changes this iteration.",
+    "progressSummary": "S1 OBSERVE (duplicate-detection survey), S2-S4c PREP chain (Mathlib API audits, 9 doc-only PRs over 14h), S5a PREP (regression discovery + S2 ACT proof body draft), S5b ACT (parent-file build restored via 4 surgical v4.26.0 fixes; eTranscendental.lean + ETranscendentalOQ03.lean now build cleanly). S5c (axiom 2→1 paste-in) immediately actionable for next session.",
     "approachesAttempted": [],
     "knownDeadEnds": [],
     "nextSteps": [
@@ -47,8 +48,8 @@
       "S3: Survey current `mathlib4` Lindemann-Weierstrass upstream PR status; bridge `axiom hermite_lindemann` if upstream API is stable.",
       "S4: Attempt `axiom e_not_liouvilleWith_gt_two` via Mathlib continued-fraction API (or document blocker if upstream CF support is insufficient on v4.26.0).",
       "S5 (optional): Cross-reference all transcendence files in gallery for unified narrative thread.",
-      "S5b (mechanic/doctor scope): restore build of eTranscendental.lean and ETranscendentalOQ03.lean on origin/main. Replace IsFractionRing.isAlgebraic_iff (9 sites in eTranscendental.lean) with v4.26.0 equivalent; fix isAlgebraic_algebraMap 1 type-mismatch at eTranscendental.lean:225; replace irrational_exp_iff.mpr at ETranscendentalOQ03.lean:118 with e_irrational (via Proofs.eTranscendental import).",
-      "S5c (researcher scope, post-S5b): paste drafted S2 ACT proof body (see sessions/2026-05-13-s5a §3) into ETranscendentalOQ03.lean at line 114; Docker-verify; decrement axiomCount 2 → 1 in src/data/proofs/e-transcendental-oq-03/meta.json."
+      "S5b (researcher-9, 2026-05-14): COMPLETED. Parent-file build restored via 4 one-line surgical fixes; both eTranscendental.lean and ETranscendentalOQ03.lean build cleanly (3071 jobs).",
+      "S5c (researcher scope, immediately actionable post-S5b): paste drafted S2 ACT proof body (see sessions/2026-05-13-s5a §3) into ETranscendentalOQ03.lean at line 114; Docker-verify; decrement axiomCount 2 → 1 in src/data/proofs/e-transcendental-oq-03/meta.json (verify gallery entry exists first per S1 OBSERVE flag)."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

Apply four surgical Mathlib v4.26.0 fixes to restore build of `proofs/Proofs/eTranscendental.lean` and `proofs/Proofs/ETranscendentalOQ03.lean` on origin/main. Three were diagnosed in S5a PREP (#18978); the fourth (line-152 `.mp`/`.mpr` direction mismatch) surfaced only after Fix #1 unblocked the namespace lookup and Lean re-elaborated past the original first-error site.

Build verified: `Build completed successfully (3071 jobs).`

## The four fixes

1. **`eTranscendental.lean`** — add `import Mathlib.RingTheory.Localization.Integral`. The lemma `IsFractionRing.isAlgebraic_iff` lives at `Mathlib/RingTheory/Localization/Integral.lean:139` in v4.26.0; it is no longer reachable transitively through `Mathlib.RingTheory.Algebraic.Basic`. Resolves 8 `Unknown constant IsFractionRing.isAlgebraic_iff` errors at lines 152, 164, 184, 198, 213, 215, 224, 228.
2. **`eTranscendental.lean:225`** — replace `isAlgebraic_algebraMap (1 : ℚ)` with `isAlgebraic_one`. The v4.26.0 elaborator no longer auto-bridges `algebraMap ℚ ℝ 1` to `(1 : ℝ)`; `isAlgebraic_one` is at `Algebraic/Basic.lean:141` and provides the same proof under a friendlier elaborator-target.
3. **`ETranscendentalOQ03.lean:118`** — add `import Proofs.eTranscendental` and replace `irrational_exp_iff.mpr (by norm_num : (1 : ℚ) ≠ 0)` with project-local `e_irrational`. The Mathlib lemma `irrational_exp_iff` was upstream-removed during the `Mathlib.Data.Real.Irrational` → `Mathlib.NumberTheory.Real.Irrational` refactor (the old import is now a `deprecated_module` alias).
4. **`eTranscendental.lean:152`** — flip `.mp` → `.mpr`. Under the v4.26.0 convention `IsAlgebraic A x ↔ IsAlgebraic K x` (with A=ℤ, K=ℚ), the theorem at line 151 needs the ℚ→ℤ direction = `.mpr`. This was the lone outlier among the 8 sites of `IsFractionRing.isAlgebraic_iff` in the file; direction audit is in the session note §1.

## Scope

- **In scope**: parent-file repair only (eTranscendental.lean and ETranscendentalOQ03.lean now build).
- **Out of scope**:
  - The ~85 LOC S2 ACT proof body (drafted in S5a §3) is preserved in `sessions/2026-05-13-s5a-prep-...md` for next-session S5c paste-in (axiomCount 2 → 1 on `e-transcendental-oq-03/meta.json`).
  - `Mathlib.Data.Real.Irrational` deprecation-linter cleanup (remains in both files, surfaced as warning but does not fail the build).
  - `axiom hermite_lindemann` in `HermiteLindemann.lean` — still gated on upstream Mathlib PR #28013 (~36h stale at S5a write-time; S4c watch-loop cadence applies).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ03` — verified `Build completed successfully (3071 jobs).` (build log: `.loom/logs/researcher-9-nthroot-s5b-build2.log`)
- [x] Direction audit of all 8 `IsFractionRing.isAlgebraic_iff` sites in `eTranscendental.lean` to confirm line 152 is the unique outlier (table in session note §1, Fix #4).
- [x] Cross-slug grep confirms `eTranscendental.lean` is the only project file using `IsFractionRing.isAlgebraic_iff` (no cross-slug breadcrumb from Fix #1).
- [x] Pre-push race check: 0 open PRs on slug; 0 open PRs touching the two parent files; most recent slug-merge is #18978 (~1h before claim).
