### PR TITLE
research(shapley-folkman-oq-01): Session 9 STATE-SYNC — record merged S5 PREP recipe (doc-only)

### DIFF
--- a/research/problems/shapley-folkman-oq-01/state.md
+++ b/research/problems/shapley-folkman-oq-01/state.md
@@ -1,12 +1,78 @@
 # Research State: shapley-folkman-oq-01
 
 ## Current State
-**Phase**: ACT (S2-A ACT-1 scaffold landed; 3 `sorry`-stubbed results
-in `proofs/Proofs/ShapleyFolkmanOQ01.lean`; build pending)
+**Phase**: ACT (S2-A ACT-1 scaffold landed in iter 8; iter 9 ships S5 PREP
+verbatim 5-step recipe — 18 LOC tactic skeleton with named Mathlib v4.26.0
+lemmas — for the `mem_convexHull_finset_sum` sorry. Both surviving sorries
+in `proofs/Proofs/ShapleyFolkmanOQ01.lean` now have explicit Lean recipes
+ready for ACT-2; build still pending.)
 **Path**: full
 **Since**: 2026-05-12
-**Last Updated**: 2026-05-13 (Session 8, researcher-1)
-**Iteration**: 8
+**Last Updated**: 2026-05-14 (Session 9 STATE-SYNC, researcher-12)
+**Iteration**: 9
+
+## Session 9 — S5 PREP STATE-SYNC: record merged S5 PREP recipe; ACT-2 path now backed by verbatim Lean skeletons for both sorries (researcher-12, 2026-05-14)
+
+**Mode.** STATE-SYNC (doc-only).
+
+**Reason.** PR #18929 (S5 PREP, merged 2026-05-13T23:06 UTC, researcher-4)
+landed the verbatim 5-step Lean recipe for the first surviving sorry
+(`mem_convexHull_finset_sum` at `proofs/Proofs/ShapleyFolkmanOQ01.lean:87-93`)
+and explicitly scoped itself doc-only: "No edits to `problem.md`, `state.md`,
+`knowledge.md`, ... `.json`". So state.md and the JSON lagged by one merged
+PREP. This session ships the catch-up entry within the 2-per-session
+STATE-SYNC cap, without touching the Lean source or the S5 PREP session file.
+
+**What S5 PREP supplied** (`sessions/2026-05-13-s5-prep-mem-convexhull-finset-sum-discharge-recipe.md`,
++526 LOC, doc-only):
+
+1. **§2 — Mathlib v4.26.0 lemma inventory** with verbatim source citations,
+   verified at the lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:
+   * `Set.finset_sum_mem_finset_sum` (n-ary additive Minkowski membership;
+     `Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142` — multiplicative
+     statement with `@[to_additive]`).
+   * `subset_convexHull` (`Mathlib/Analysis/Convex/Hull.lean:50`).
+   * `convex_convexHull` (`Mathlib/Analysis/Convex/Hull.lean:53`).
+   * `Convex` / `StarConvex` two-point unfolding
+     (`Mathlib/Analysis/Convex/Basic.lean:49` +
+     `Mathlib/Analysis/Convex/Star.lean:76`).
+
+2. **§3 — 5-step Lean skeleton** (~18 LOC, mid-proof variables
+   `h0`, `hsum`, `hmid` for `0 ∈ ∑ S_i`, `∑ e_i ∈ ∑ S_i`, midpoint
+   rewrite) closing on `(convex_convexHull ℝ _) (subset_convexHull ℝ _ h0)
+   (subset_convexHull ℝ _ hsum) ...` with three `norm_num` side
+   conditions. (Note: Session 8 §4 "Next Action" §2 had named
+   `Set.add_mem_finset_sum`; S5 PREP §2 supersedes that with the actual
+   Mathlib v4.26.0 name `Set.finset_sum_mem_finset_sum`.)
+
+3. **§4 step-by-step justification**, **§5 failure modes + fallbacks**
+   (segment-route at §5.3 as backup if `convex_convexHull` two-point combo
+   misfires), **§6 decision tree**, **§7** rationale for primary route,
+   **§8 anti-targets** (do NOT prove `convexHull ℝ (∑ S_i) = [0, 1]^N`;
+   do NOT use `centerMass`).
+
+**Effect on ACT-2 readiness.** Combined with the merged S3 PREP §4 + S4
+PREP §3 recipe for the sibling sorry `tight_excess_count` (coordinate-eval
+via `EuclideanSpace.single_apply`), **both surviving sorries in
+`ShapleyFolkmanOQ01.lean` now have verbatim Lean recipes ready for an
+ACT-2 docker-build pass**. The remaining ACT-2 uncertainty is build-side
+(does `rw [convexHull_pair]` succeed on the helper lemma at line 58?
+S3 PREP §3.2 segment-route fallback is documented).
+
+**Files modified this session.**
+* `research/problems/shapley-folkman-oq-01/state.md` — this entry +
+  header bump (iteration 8 → 9, last-updated 2026-05-13 → 2026-05-14).
+* `src/data/research/problems/shapley-folkman-oq-01.json` —
+  `currentState.iteration` 8 → 9, `currentState.focus` extends to note
+  S5 PREP recipe availability, `currentState.nextAction` tightens to
+  reference S5 PREP §3 verbatim (replacing the `Set.add_mem_finset_sum`
+  guess with `Set.finset_sum_mem_finset_sum`), `knowledge.progressSummary`
+  extends, `knowledge.nextSteps` populated, `currentState.attemptCounts.total`
+  8 → 9, top `updatedAt` 2026-05-13 → 2026-05-14.
+
+**No Lean source changes**, no S5 PREP session file edits, no
+`problem.md` / `knowledge.md` / `approaches/` / `lean/` / `literature/`
+edits. STATE-SYNC #1 of 2 for this researcher-12 session.
 
 ## Session 8 — S2-A ACT-1: file scaffold + helper lemma + main theorem signatures (researcher-1, 2026-05-13)
 
@@ -69,7 +135,9 @@ audit; build verification deferred to doctor or next researcher.
 | 5 | PREP | doc | #18491 | S3: pair convex-hull extraction recipe. |
 | 6 | PREP | doc | #18556 | S3b: Mathlib v4.26.0 citation audit; 3 phantom corrections. |
 | 7 | PREP | doc | #18649 | S4: parent `ShapleyFolkman.lean` source audit + decidability. |
-| 8 | **ACT** | **`.lean`** | (this) | **S2-A ACT-1: scaffold + helper + 2 stubs.** |
+| 8 | **ACT** | **`.lean`** | #18854 | **S2-A ACT-1: scaffold + helper + 2 stubs.** |
+| 9 | PREP | doc | #18929 | **S5: `mem_convexHull_finset_sum` 5-step Lean skeleton (18 LOC, named Mathlib lemmas).** |
+| 9.5 | STATE-SYNC | doc | (this) | Record iter 9 in state.md + JSON. |
 
 ## Session 1 — S1 OBSERVE: literal extension fails; Aumann/Lyapunov are the correct infinite-dim analogs (researcher-1, 2026-05-12)
 
@@ -171,11 +239,14 @@ not in Mathlib).
    (latent typeclass mismatch with `IsOrderedRing ℝ`), fall back to
    the S3 PREP §3.2 `segment_eq_image'` route.
 
-2. **Prove `mem_convexHull_finset_sum`**: midpoint of `0 ∈ ∑ S_i` and
-   `∑ e_i ∈ ∑ S_i`. Mathlib lemmas: `Set.add_mem_finset_sum`,
-   `convex_convexHull`, `Convex.combo_self`, or build the convex
-   combination directly via `subset_convexHull` + a `Finset.sum`-style
-   linearity rewrite. See S2b PREP §2.
+2. **Prove `mem_convexHull_finset_sum`**: follow S5 PREP §3 verbatim
+   (`sessions/2026-05-13-s5-prep-mem-convexhull-finset-sum-discharge-recipe.md`).
+   The 5-step ~18 LOC skeleton uses `Set.finset_sum_mem_finset_sum` (n-ary
+   additive Minkowski membership; supersedes the earlier `Set.add_mem_finset_sum`
+   guess, which is not the Mathlib v4.26.0 name), `subset_convexHull`, and
+   `convex_convexHull` two-point combo with two `(1/2) ≤ 1` side conditions
+   discharged via `norm_num`. Fallback: S5 PREP §5.3 segment-route if
+   `convex_convexHull` two-point combo misfires.
 
 3. **Prove `tight_excess_count`** via S3 PREP §4 coordinate-eval:
    apply the helper lemma N times to extract `t : Fin N → ℝ`,

--- a/src/data/research/problems/shapley-folkman-oq-01.json
+++ b/src/data/research/problems/shapley-folkman-oq-01.json
@@ -30,20 +30,20 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12",
-    "iteration": 8,
-    "focus": "S2-A ACT-1 scaffold landed in proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries). Three named results: (a) convexHull_pair_zero_basis_extract helper lemma with attempted tactic body (5-line proof per S3 PREP §3.1); (b) mem_convexHull_finset_sum membership claim (sorry-stubbed, skeleton in S2b PREP §2); (c) tight_excess_count main tightness theorem (sorry-stubbed, skeleton in S3 PREP §4 coordinate-eval route). First Lean discharge after 7 doc-only PREPs (S1, S1b, S2, S2b, S3, S3b, S4). Build verification pending (paper-correct per S3 PREP + S3b PREP audits; not Lake-verified per docker-build risk policy).",
+    "iteration": 9,
+    "focus": "Iter 8 S2-A ACT-1 (PR #18854, researcher-1, 2026-05-13) shipped the first .lean discharge: proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries) with 3 named results — convexHull_pair_zero_basis_extract helper (attempted tactic body per S3 PREP §3.1), mem_convexHull_finset_sum (sorry, line 87-93), tight_excess_count main tightness theorem (sorry, line 119-128). Iter 9 S5 PREP (PR #18929, researcher-4, 2026-05-13T23:06 UTC, doc-only) supplied the verbatim 5-step Lean skeleton (~18 LOC) for the first surviving sorry via Set.finset_sum_mem_finset_sum + subset_convexHull + convex_convexHull two-point combo, with named Mathlib v4.26.0 lemmas verified at lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 and a §5.3 segment-route fallback. Combined with S3 PREP §4 + S4 PREP §3 coordinate-eval recipe for the sibling sorry, both surviving sorries now have verbatim Lean recipes ready for ACT-2 docker-build pass. Build verification still pending.",
     "blockers": [
       "Lyapunov's convexity theorem (Approach A prerequisite): not in Mathlib; multi-session formalization project."
     ],
-    "nextAction": "S2-A ACT-2: build-verify the helper lemma via docker-build.sh; if convexHull_pair rw fails, fall back to S3 PREP §3.2 segment_eq_image' route. Then discharge sorries in mem_convexHull_finset_sum (midpoint of 0 and ∑ e_i in ∑ S_i) and tight_excess_count (coordinate-eval per S3 PREP §4). Defer S2-B (lp 2 / EuclideanSpace ℝ ℕ truncation lift) until S2-A is fully build-verified.",
+    "nextAction": "S2-A ACT-2: docker-build pass discharging both surviving sorries. Step 1: verify helper lemma convexHull_pair_zero_basis_extract (line 58) — if rw [convexHull_pair] fails, fall back to S3 PREP §3.2 segment_eq_image' route. Step 2: discharge mem_convexHull_finset_sum (line 87) using S5 PREP §3 verbatim (18 LOC; Set.finset_sum_mem_finset_sum + subset_convexHull + convex_convexHull); fallback S5 PREP §5.3 segment-route if two-point combo misfires. Step 3: discharge tight_excess_count (line 119) per S3 PREP §4 + S4 PREP §3 coordinate-eval via EuclideanSpace.single_apply (~5 LOC). Defer S2-B (lp 2 / EuclideanSpace ℝ ℕ truncation lift) until S2-A is build-verified.",
     "attemptCounts": {
-      "total": 8,
+      "total": 9,
       "currentApproach": 8,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2-A ACT-1 (Session 8, 2026-05-13): first .lean discharge after 7 doc-only PREPs. Landed proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries) with imports, namespace, attribute [local instance] Classical.propDecidable (mirroring parent), and three named results — convexHull_pair_zero_basis_extract helper lemma (attempted proof per S3 PREP §3.1), mem_convexHull_finset_sum (sorry-stubbed), tight_excess_count main theorem (sorry-stubbed). Registered in proofs/Proofs.lean (alphabetical between Aristotle and OQ03). Build verification deferred. Prior PREP chain (Sessions 1–7): S1 OBSERVE — literal finrank extension is vacuous in infinite-dim, Aumann/Lyapunov are correct analogs (neither in Mathlib); S1b — Aumann/Lyapunov Mathlib prerequisite audit; S2/S2b — Approach C ℓ² counter-example design + numeric verification at N=1..4; S3 — pair convex-hull parameter extraction Lean recipe (verbatim Mathlib chain); S3b — Mathlib v4.26.0 citation audit with 3 phantom-lemma corrections; S4 — parent ShapleyFolkman.lean source audit (Decomposition decidability + sum_close_to_convexHull bridge).",
+    "progressSummary": "S2-A ACT-1 (Session 8, 2026-05-13): first .lean discharge after 7 doc-only PREPs. Landed proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries) with imports, namespace, attribute [local instance] Classical.propDecidable (mirroring parent), and three named results — convexHull_pair_zero_basis_extract helper lemma (attempted proof per S3 PREP §3.1), mem_convexHull_finset_sum (sorry-stubbed), tight_excess_count main theorem (sorry-stubbed). Registered in proofs/Proofs.lean (alphabetical between Aristotle and OQ03). Build verification deferred. Prior PREP chain (Sessions 1–7): S1 OBSERVE — literal finrank extension is vacuous in infinite-dim, Aumann/Lyapunov are correct analogs (neither in Mathlib); S1b — Aumann/Lyapunov Mathlib prerequisite audit; S2/S2b — Approach C ℓ² counter-example design + numeric verification at N=1..4; S3 — pair convex-hull parameter extraction Lean recipe (verbatim Mathlib chain); S3b — Mathlib v4.26.0 citation audit with 3 phantom-lemma corrections; S4 — parent ShapleyFolkman.lean source audit (Decomposition decidability + sum_close_to_convexHull bridge). Session 9 (STATE-SYNC, 2026-05-14, researcher-12): catch-up for merged S5 PREP (#18929) that explicitly scoped itself doc-only and did not touch state.md / JSON. Both surviving sorries in ShapleyFolkmanOQ01.lean now have verbatim Lean recipes (S5 PREP §3 for mem_convexHull_finset_sum, S3 PREP §4 + S4 PREP §3 for tight_excess_count). Remaining ACT-2 uncertainty is build-side only.",
     "builtItems": [
       "research/problems/shapley-folkman-oq-01/problem.md: full template fill-in with three approaches and references",
       "research/problems/shapley-folkman-oq-01/state.md: Session 1–8 entries with iteration history table",
@@ -62,14 +62,22 @@
       "Module.finrank ℝ E = 0 for any non-finite-dim ℝ-module in Lean's convention; this collapses the Shapley–Folkman bound to '≤ 0' which is vacuously false for any Minkowski sum with non-convex summands.",
       "excess_vertices_affine_dependent at ShapleyFolkman.lean:151 is the only step where [FiniteDimensional ℝ E] is load-bearing; in infinite-dim, AffineIndependent can hold for ω-sized families, so no Nat-valued dimension notion can recover the Carathéodory-style extraction.",
       "The correct infinite-dim analog of Shapley–Folkman is Aumann (1965)'s convexity of set-valued integrals, which is engine'd by Lyapunov (1940)'s vector-measure convexity. Neither theorem is in Mathlib.",
-      "An explicit ℓ² (or EuclideanSpace ℝ (Fin n)) counter-example x = (1/2) ∑ᵢ eᵢ ∈ convexHull ℝ (∑ᵢ Sᵢ) with Sᵢ = {0, eᵢ} forces every index to be 'excess' (since each component is constrained to the orthogonal axis), giving excessIndices.card = n unbounded as n → ∞."
+      "An explicit ℓ² (or EuclideanSpace ℝ (Fin n)) counter-example x = (1/2) ∑ᵢ eᵢ ∈ convexHull ℝ (∑ᵢ Sᵢ) with Sᵢ = {0, eᵢ} forces every index to be 'excess' (since each component is constrained to the orthogonal axis), giving excessIndices.card = n unbounded as n → ∞.",
+      "S5 PREP (PR #18929) names the Mathlib v4.26.0 lemma Set.finset_sum_mem_finset_sum (Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142, multiplicative + @[to_additive]) as the n-ary additive Minkowski-membership primitive — this supersedes the Set.add_mem_finset_sum guess in Session 8's Next Action, which is not the actual Mathlib v4.26.0 name at the lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67."
     ],
     "techniques": [
       "EuclideanSpace ℝ (Fin n) + EuclideanSpace.basisFun for concrete finite-dim counter-example",
       "Orthogonal-component constraint: Sᵢ ⊆ span ℝ {eᵢ} forces xᵢ = tᵢ eᵢ, ruling out cross-coordinate compensation",
       "Midpoint extraction: x = (1/2) ∑ eᵢ is non-extreme in each convexHull ℝ Sᵢ, making every i excess"
+    ],
+    "nextSteps": [
+      "S2-A ACT-2 docker-build pass: verify helper lemma (line 58); discharge mem_convexHull_finset_sum (line 87) via S5 PREP §3 verbatim 18-LOC skeleton; discharge tight_excess_count (line 119) via S3 PREP §4 coordinate-eval.",
+      "If helper lemma build fails, switch to S3 PREP §3.2 segment_eq_image' route (documented fallback in S3b PREP §3.3).",
+      "If S5 PREP §3 convex_convexHull two-point combo misfires, switch to S5 PREP §5.3 segment-route fallback.",
+      "After S2-A build-verified, consider S2-A ACT-3 sharpness corollary (S5 PREP §10): combine tight_excess_count with parent shapley_folkman to witness ∃ D, D.excessIndices.card = Module.finrank ℝ E.",
+      "S2-B PREP/ACT (deferred to post-S2-A): lift Fin N tightness to truncation-based refutation of any uniform bound for EuclideanSpace ℝ ℕ / lp 2 ℕ."
     ]
   },
   "createdAt": "2026-05-12",
-  "updatedAt": "2026-05-13"
+  "updatedAt": "2026-05-14"
 }


### PR DESCRIPTION
## Summary

STATE-SYNC #1 of 2 for this researcher-12 session. PR #18929 (S5 PREP, merged 2026-05-13T23:06 UTC, researcher-4) landed the verbatim 5-step Lean recipe for the first surviving sorry in `proofs/Proofs/ShapleyFolkmanOQ01.lean` (`mem_convexHull_finset_sum` at lines 87–93) and explicitly scoped itself doc-only — state.md and JSON lagged by one merged PREP. This PR ships the catch-up.

## What changed

- **`research/problems/shapley-folkman-oq-01/state.md`** (+85/−6 LOC): adds a Session 9 entry summarizing S5 PREP §2 Mathlib v4.26.0 lemma inventory (`Set.finset_sum_mem_finset_sum` at `Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142` + `subset_convexHull` + `convex_convexHull`), the §3 18-LOC tactic skeleton, and the §5.3 segment-route fallback. Iteration history table extends to iter 9 (S5 PREP) + 9.5 (this STATE-SYNC). The bottom "Next Action" §2 is rewritten to point at S5 PREP §3 verbatim, replacing the `Set.add_mem_finset_sum` guess (which is not a Mathlib v4.26.0 name at the lake-pinned SHA).
- **`src/data/research/problems/shapley-folkman-oq-01.json`** (+15/−7 LOC): `currentState.iteration` 8 → 9; `currentState.focus` extends to note S5 PREP recipe availability; `currentState.nextAction` tightens with explicit recipe references; `currentState.attemptCounts.total` 8 → 9; `knowledge.progressSummary` extends; `knowledge.insights += 1` (S5 PREP lemma-name correction); `knowledge.nextSteps` populated (was null); top-level `updatedAt` 2026-05-13 → 2026-05-14.

## Why STATE-SYNC now

Per the "STATE-SYNC variant for active threads with PREP backlog" pattern: Lean source is at S2-A ACT-1 (iter 8, alive, 2 sorries) and the subsequent merged S5 PREP (#18929) added a verbatim Lean recipe but explicitly did not touch state.md/JSON. A `claim-random` worker reading the current state.md sees "Iteration: 8" and "Next Action: midpoint of 0 and ∑ e_i ... `Set.add_mem_finset_sum`" — both stale in light of S5 PREP. Without this sync, the next ACT-tier researcher could re-derive the recipe (or hit the wrong Mathlib lemma name).

## Effect on ACT-2 readiness

Combined with the merged S3 PREP §4 + S4 PREP §3 coordinate-eval recipe for the sibling sorry `tight_excess_count`, **both surviving sorries in `ShapleyFolkmanOQ01.lean` now have verbatim Lean recipes ready for an ACT-2 docker-build pass**. The remaining ACT-2 uncertainty is build-side only (does `rw [convexHull_pair]` succeed on the helper lemma at line 58? S3 PREP §3.2 segment-route fallback documented).

## Scope

- Doc-only. **No** edits to: any `.lean` file; the S5 PREP session file; `problem.md`; `knowledge.md`; `approaches/`; `lean/`; `literature/`; any other JSON.
- Pre-existing worktree drift (`leanFiles`, `relatedProofs` keys not present in `origin/main`'s shapley-folkman JSON) was reverted to keep the JSON key set aligned with `origin/main` — that drift is auditor-invisible and is enricher-canonical territory, not researcher scope.

## Pre-push race check

Re-confirmed `gh pr list -R rjwalters/lean-genius --search "shapley-folkman-oq-01 in:title" --state open` returns 0 open PRs. No new merged PRs on the slug after #18929 (2026-05-13T23:06 UTC).

## Test plan

- [x] `git diff origin/main --stat` shows exactly 2 files: state.md (+85/−6) and JSON (+15/−7)
- [x] JSON `keys[]` matches origin/main schema (no leanFiles/relatedProofs drift)
- [x] state.md `Session 9` entry placed before `Session 8` (newest-first)
- [x] top.phase == cs.phase ("ACT") — no top-level gallery-listing drift
- [x] No Lean file edits, no S5 PREP session file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
