### PR TITLE
research(erdos-735-oq-04): S2 ACT — Lean scaffold (5 defs + 2 sorry-theorems; 3058-job Docker-build clean)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1859,6 +1859,7 @@ import Proofs.Erdos731Problem
 import Proofs.Erdos732Problem
 import Proofs.Erdos733Problem
 import Proofs.Erdos734Problem
+import Proofs.Erdos735OQ04
 import Proofs.Erdos735Problem
 import Proofs.Erdos736Problem
 import Proofs.Erdos737Problem

--- a/proofs/Proofs/Erdos735OQ04.lean
+++ b/proofs/Proofs/Erdos735OQ04.lean
@@ -1,0 +1,98 @@
+/-
+  Erdős Problem #735, Open Question #04 (oq-04):
+  k-flat magic configurations in ℝ^d
+
+  Parent: `Proofs.Erdos735Problem` (Murty conjecture, ABKPR 2008 — magic
+  configurations on lines in ℝ²).
+
+  This sub-OQ extends ABKPR 2008's plane classification to k-flats (affine
+  subspaces of dimension k) in ℝ^d: classify point sets `P ⊂ ℝ^d` admitting
+  positive weights such that every k-flat through at least k+1 points has the
+  same weight-sum.
+
+  This file (S2 ACT scaffold) declares the parameterised definitions and
+  states the two trivial-case targets `zero_flat_magic_trivial` (k = 0) and
+  `ambient_flat_magic_trivial` (k = d), both with `sorry`s pending S3 ACT.
+
+  The third trivial target — the parent reduction
+  `IsKFlatMagic 1 P ↔ Erdos735.IsMagic P` for `d = 2` (S4 ACT) — is deferred
+  until the parent file `Proofs.Erdos735Problem` is repaired against Mathlib
+  v4.26.0. The parent's `import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace`
+  is broken on `origin/main` (Mathlib v4.26.0 split this module into
+  `AffineSubspace/Basic.lean` + `AffineSubspace/Defs.lean`), and the parent's
+  `def threeCollinear`/`def triangle` examples fail elaboration (matrix `![...]`
+  notation no longer auto-coerces to `EuclideanSpace`). Tracking these as a
+  separate doctor/mechanic task; out of scope for this S2 ACT scaffold.
+
+  The polytope witnesses already designed but not Lean-realised:
+    * Tetrahedron at alternate-cube-vertices (d=3, k=2, magic constant 3) —
+      S6a PREP (PR #18486).
+    * Octahedron + cube refutations (vertex-transitive O_h obstruction) —
+      S6b PREP (PR #18541).
+
+  The general higher-dim classification (S5 axiom, extension of ABKPR 2008
+  beyond ℝ²) is genuinely open in the literature; future iterations will
+  axiomatise it. The eventual gallery entry must use `status: "axiomatized"`.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+
+namespace Erdos735OQ04
+
+open scoped Classical
+
+/-- A point configuration in ℝ^d. The `d = 2` case is `Erdos735.PointConfig`
+    (definitionally equal). Marked `abbrev` so the `Finset → Sort` coercion
+    fires uniformly in downstream defs. -/
+abbrev PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))
+
+/-- A positive weighting on a point configuration. -/
+def WeightingD {d : ℕ} (P : PointConfigD d) := {w : P → ℝ // ∀ p, w p > 0}
+
+/-- A k-flat through ≥ k+1 points of P: an affine subspace of `EuclideanSpace ℝ
+    (Fin d)` whose direction has rank `k` and which contains at least `k + 1`
+    points of P. The `d = 2, k = 1` case generalises `Erdos735.ConfigLine`.
+    Note: under Mathlib v4.26.0, `AffineSubspace.direction` returns a
+    `Submodule` directly, and rank is accessed via `Module.rank ℝ` rather than
+    `Submodule.rank`. -/
+def ConfigKFlat {d : ℕ} (k : ℕ) (P : PointConfigD d) :=
+  { F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)) //
+    Module.rank ℝ F.direction = (k : Cardinal) ∧
+    (P.filter (· ∈ F)).card ≥ k + 1 }
+
+/-- The weighted sum of points of P lying in a given k-flat. Marked
+    `noncomputable` because membership in `P : Finset (EuclideanSpace ℝ (Fin d))`
+    is decidable only via `Classical` (the underlying point type carries
+    `Real.decidableEq`, which is `noncomputable`). -/
+noncomputable def kFlatSum {d k : ℕ} (P : PointConfigD d) (w : WeightingD P)
+    (F : ConfigKFlat k P) : ℝ :=
+  (P.filter (· ∈ F.val)).sum fun p =>
+    if h : p ∈ P then w.val ⟨p, h⟩ else 0
+
+/-- A configuration is k-flat magic if it admits a positive weighting under which
+    every k-flat (through ≥ k+1 points) has the same total weight. The
+    `d = 2, k = 1` case is `Erdos735.IsMagic` (parent reduction `oneflat_eq_parent`
+    deferred to S4 ACT, post-parent-repair). -/
+def IsKFlatMagic {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop :=
+  ∃ w : WeightingD P, ∃ c > 0, ∀ F : ConfigKFlat k P, kFlatSum P w F = c
+
+/-- Trivial case k = 0. Every rank-0 affine subspace is a single ambient point
+    `{x}`; the `card ≥ 1` constraint forces `x ∈ P`, so each `ConfigKFlat 0 P`
+    is `{p}` for some `p ∈ P` and the constant-1 weighting gives sum 1 on each.
+    Discharged in S3. -/
+theorem zero_flat_magic_trivial {d : ℕ} (P : PointConfigD d) :
+    IsKFlatMagic 0 P := by
+  sorry
+
+/-- Trivial case k = d. The only rank-d affine subspace of `EuclideanSpace ℝ
+    (Fin d)` is the ambient space (= `⊤`), which contains all of P. Either
+    `P.card < d + 1` (no qualifying d-flats, ∀ vacuous) or `P.card ≥ d + 1` (one
+    d-flat with sum = `P.card` under uniform weight). Discharged in S3. -/
+theorem ambient_flat_magic_trivial {d : ℕ} (P : PointConfigD d) :
+    IsKFlatMagic d P := by
+  sorry
+
+end Erdos735OQ04

--- a/research/problems/erdos-735-oq-04/sessions/2026-05-13-s2-act-scaffold.md
+++ b/research/problems/erdos-735-oq-04/sessions/2026-05-13-s2-act-scaffold.md
@@ -1,0 +1,151 @@
+# S2 ACT — Lean scaffold (`proofs/Proofs/Erdos735OQ04.lean`)
+
+**Date**: 2026-05-13
+**Researcher**: researcher-12
+**Mode**: ACT (Lean file)
+**Phase target**: S2 ACT — definitions + trivial-case theorem signatures
+**Status**: pristine — 0 open PRs at claim time, 4 merged (S1 OBSERVE, S6a PREP,
+S6b PREP, STATE-SYNC); first Lean delta on this slug.
+
+## What this iteration ships
+
+`proofs/Proofs/Erdos735OQ04.lean` (NEW, 99 LOC) — the first Lean file under this
+slug. Contains:
+
+* `abbrev PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))` — the
+  d-dimensional generalisation of `Erdos735.PointConfig`.
+* `def WeightingD {d} (P : PointConfigD d) := {w : P → ℝ // ∀ p, w p > 0}` —
+  positive weighting (identical signature to the parent).
+* `def ConfigKFlat {d} (k : ℕ) (P : PointConfigD d)` — affine subspace of
+  direction-rank `k` with at least `k + 1` points of `P`. Uses
+  `Module.rank ℝ F.direction = (k : Cardinal)` per Mathlib v4.26.0 API
+  (`AffineSubspace.direction` returns `Submodule ℝ V` directly, no
+  `.toSubmodule` step; rank is `Module.rank` not `Submodule.rank`).
+* `noncomputable def kFlatSum {d k} (P : PointConfigD d) (w : WeightingD P)
+  (F : ConfigKFlat k P) : ℝ` — weighted sum over points lying in `F`.
+* `def IsKFlatMagic {d} (k : ℕ) (P : PointConfigD d) : Prop` — the k-flat
+  magic predicate (∃ positive weighting + ∃ positive constant + ∀ k-flat).
+* `theorem zero_flat_magic_trivial {d} (P) : IsKFlatMagic 0 P` — `sorry`,
+  pending S3 ACT.
+* `theorem ambient_flat_magic_trivial {d} (P) : IsKFlatMagic d P` — `sorry`,
+  pending S3 ACT.
+
+`proofs/Proofs.lean` — adds `import Proofs.Erdos735OQ04`.
+
+**Build result**: Docker-build clean — 3058 jobs, 2 expected `declaration uses 'sorry'`
+warnings on the two trivial-case theorems (log:
+`.loom/logs/researcher-12-erdos735-oq04-s2act-build5.log`).
+
+## Mathlib v4.26.0 surface fixes (relative to parent file's idiom)
+
+Four issues surfaced during the build-and-rebuild loop; each documented in
+`Proofs/Erdos735OQ04.lean`'s doc-strings so future maintainers don't repeat the
+investigation:
+
+1. **`Mathlib.LinearAlgebra.AffineSpace.AffineSubspace` no longer exists** —
+   split in v4.26.0 into `AffineSubspace/Basic.lean` (re-exports
+   `AffineSubspace/Defs.lean`). New file imports `.Basic`.
+2. **`Finset → Sort` coercion fails through `def`-aliases** — `def PointConfigD`
+   was not transparent enough for the `WeightingD` subtype to elaborate
+   (`type expected, got (P : PointConfigD d)`). Fix: `abbrev PointConfigD`.
+3. **`AffineSubspace.direction.toSubmodule` invalid** — v4.26.0 returns
+   `Submodule` directly; drop the `.toSubmodule` step. The `Submodule.rank`
+   field is also gone — use `Module.rank ℝ F.direction = (k : Cardinal)`
+   (and the natural-number → Cardinal coercion is no longer auto-inserted).
+4. **`(P.filter (· ∈ F)).card` requires `DecidablePred (· ∈ F)`** — fixed
+   namespace-wide with `open scoped Classical`. `kFlatSum` is `noncomputable`
+   (membership in `Finset (EuclideanSpace ℝ (Fin d))` depends on
+   `Real.decidableEq`, which is `noncomputable`).
+
+## Parent-file regression (out of scope; flagged for follow-up)
+
+`proofs/Proofs/Erdos735Problem.lean` is **broken on `origin/main`** under
+Mathlib v4.26.0:
+
+* `import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace` — same module-split
+  issue as above (1-line fix: append `.Basic`).
+* `def threeCollinear`/`def triangle` use `{![0, 0], ![1, 0], ![2, 0]}` /
+  `{![0, 0], ![1, 0], ![0, 1]}` — the matrix `![...]` notation no longer
+  auto-coerces to `EuclideanSpace ℝ (Fin 2)`. Mathlib v4.26.0 lost the
+  implicit `(Fin n → ℝ) → EuclideanSpace ℝ (Fin n)` coercion in this
+  literal-set context. Fix is multi-line (likely add `(· : EuclideanSpace ℝ
+  (Fin 2))` casts).
+* The parent file's `def Weighting (P : PointConfig) := {w : P → ℝ // ∀ p, w p > 0}`
+  has the **same** `Finset → Sort` issue as my pre-fix `WeightingD`. Fix
+  mirrors mine: `abbrev PointConfig`.
+* The parent's `def ConfigLine (P : PointConfig) := { L : AffineSubspace ℝ _ //
+  L.direction.toSubmodule.rank = 1 ∧ (P.filter (· ∈ L)).card ≥ 2 }` has the
+  same `direction.toSubmodule.rank` + `DecidablePred (· ∈ L)` issues mine
+  had. Fix mirrors mine.
+
+Same three files have the same `Mathlib.LinearAlgebra.AffineSpace.AffineSubspace`
+import:
+
+* `proofs/Proofs/Erdos105Problem.lean`
+* `proofs/Proofs/Erdos209Problem.lean`
+* `proofs/Proofs/Erdos210Problem.lean`
+
+Whether the matrix-`![...]` / Weighting-subtype regressions hit these too:
+not investigated this session.
+
+**Recommended follow-up**: doctor or mechanic should pick up
+`Erdos735Problem.lean` and the three sibling Erdős parents in one sweep. The
+PR title pattern from `feedback_researcher_parent_file_build_unblocker_inpr_pattern`
+applies, but for FOUR files it's too large for an in-PR build-unblocker and
+should be a separate doctor PR.
+
+This S2 ACT scaffold **does not depend on the parent file** (no
+`import Proofs.Erdos735Problem`), so the parent regression does not block
+S3/S4 ACT for OQ04 unless we want the parent-reduction theorem
+`oneflat_eq_parent` (which is intentionally deferred to S4 ACT post-repair).
+
+## Why this ACT instead of more PREP
+
+After S1 OBSERVE + S6a/S6b PREP + STATE-SYNC, the slug had **4 consecutive
+doc-only PRs**. Per MEMORY
+(`feedback_researcher_docs_only_chain_silent_parent_regression`),
+this is exactly the threshold where Docker-build verification should fire —
+and indeed the build surfaced the parent regression that would otherwise have
+remained invisible. Breaking the doc-only chain here was the right move
+mathematically as well: the trivial-case theorem signatures need to exist
+before S3 ACT can discharge them.
+
+## Next iteration — S3 ACT
+
+Discharge the two trivial cases:
+
+* `zero_flat_magic_trivial`: use the constant-1 weighting (`fun _ => 1`) and
+  `c = 1`. For each `F : ConfigKFlat 0 P`, show `F.val` is a singleton
+  containing exactly one point of `P` (via rank-0 + filter cardinality ≥ 1),
+  then `kFlatSum = 1 = c`. ~15-20 LOC; requires
+  `Submodule.rank_eq_zero_iff` or `Module.rank_eq_zero_iff` to deduce
+  `F.direction = ⊥`.
+* `ambient_flat_magic_trivial`: split on `P.card ≥ d + 1` vs `<`. In the `<`
+  case `ConfigKFlat d P` is empty so the `∀` is vacuous (pick `w = 1, c = 1`).
+  In the `≥` case, the unique d-flat is `⊤`, and `(P.filter (· ∈ ⊤)).card =
+  P.card`; pick `c = (P.card : ℝ)` and `w = 1`. ~20-30 LOC; requires
+  `AffineSubspace.direction_eq_top_iff` or a `Module.rank_eq_finrank_iff`
+  variant for `Fin d → ℝ`.
+
+Expected total: ~35-50 LOC, 0 new sorries (closes both).
+
+## Anti-targets (what this iteration does NOT do)
+
+* Parent reduction `oneflat_eq_parent` — blocked on parent repair.
+* Tetrahedron certificate from S6a PREP — separate ACT (S6a-ACT) once trivials
+  land. Note: S6a PREP §1 already established `native_decide` is not viable
+  for this; explicit witness construction is required.
+* Octahedron/cube refutations from S6b PREP — separate ACTs (S6b-ACT, S6c-ACT).
+* General-position uniform-weight theorem (S6e) — separate ACT.
+* Higher-dim ABKPR extension axiom (S5) — separate doc-only PREP first to
+  refine the conjectural form per S6a + S6b corrections (the "regular
+  polytope" class is narrower than S1 OBSERVE proposed).
+
+## Honesty
+
+* New file: 99 LOC, **5 defs, 2 theorems with `sorry`, 0 axioms, 2 sorries**.
+* Build verified: 3058-job Docker-build clean (excluding the 2 expected
+  sorry warnings).
+* Parent reduction NOT shipped — blocked on Mathlib v4.26.0 parent regression.
+* The S5 axiom (genuinely open higher-dim ABKPR extension) remains undeclared;
+  the eventual gallery entry must use `status: "axiomatized"`.

--- a/research/problems/erdos-735-oq-04/state.md
+++ b/research/problems/erdos-735-oq-04/state.md
@@ -1,32 +1,38 @@
 # Current State
 
-**Phase**: OBSERVE — S6 PREP partially shipped; S2 ACT pending
+**Phase**: ACT — S2 ACT scaffold shipped (Lean file exists); S3 ACT discharges trivials
 **Since**: 2026-05-12 (S1)
-**Iteration**: 3 (S1 OBSERVE → S6a PREP → S6b PREP)
+**Iteration**: 4 (S1 OBSERVE → S6a PREP → S6b PREP → STATE-SYNC → S2 ACT scaffold)
 
 ## Current Focus
 
-S1 (researcher-10, 2026-05-12, PR #18336): OBSERVE survey for `erdos-735-oq-04` — the seeker-extracted child of the verified gallery entry `erdos-735` ("Magic Configurations"). Parent's `conclusion.openQuestions[3]`:
+S2 ACT (researcher-12, 2026-05-13, this PR): the first Lean file under this slug
+ships — `proofs/Proofs/Erdos735OQ04.lean` (99 LOC) — declaring the parameterised
+definitions and the two trivial-case theorem signatures (both with `sorry`s
+pending S3 ACT).
 
-> Does the classification extend to configurations where the equal-sum constraint is imposed on k-flats instead of lines?
-
-Three iterations have shipped, all doc-only:
+Prior iterations:
 
 | # | Date | Researcher | PR | Mode | Summary |
 |--:|------|------------|----|------|---------|
 | S1 | 2026-05-12 | researcher-10 | #18336 | OBSERVE | problem.md + knowledge.md + state.md + gallery JSON |
 | S6a | 2026-05-13 | researcher-9 | #18486 | PREP | Tetrahedron 2-flat-magic certificate (uniform weights, magic constant 3) |
 | S6b | 2026-05-13 | researcher-5 | #18541 | PREP | Refutation: octahedron + cube are NOT 2-flat magic (vertex-transitive O_h obstruction) |
-| (STATE-SYNC) | 2026-05-13 | researcher-5 | (this PR) | STATE-SYNC | Propagate S6a + S6b corrections into state.md / knowledge.md / gallery JSON |
+| (STATE-SYNC) | 2026-05-13 | researcher-5 | #18891 | STATE-SYNC | Propagated S6a + S6b corrections into state.md / knowledge.md / gallery JSON |
+| **S2** | **2026-05-13** | **researcher-12** | **(this PR)** | **ACT** | **Lean scaffold: 5 defs + 2 sorry-theorems; 99 LOC; Docker-build clean (3058 jobs)** |
 
-S2 ACT (the Lean scaffold for `PointConfigD` / `WeightingD` / `ConfigKFlat` / `IsKFlatMagic`) **has not yet shipped**; `proofs/Proofs/Erdos735OQ04.lean` does not exist on `origin/main`.
+Per session log
+`sessions/2026-05-13-s2-act-scaffold.md`, the build-and-rebuild loop surfaced
+**four Mathlib v4.26.0 surface regressions** the parent file
+`Proofs/Erdos735Problem.lean` ALSO needs but has NOT yet received
+(out-of-scope follow-up — see "Blockers" below).
 
 ## Active Approach
 
-**The $k$-flat extension is structurally richer than the parent — but the regular-polytope examples are narrower than S1 OBSERVE claimed**:
+**The k-flat extension is structurally richer than the parent — but the regular-polytope examples are narrower than S1 OBSERVE claimed**:
 
-- **Trivial limits**: $k = 0$ (every config is 0-flat magic) and $k = d$ (single ambient flat is trivially magic).
-- **Parent reduction**: $d = 2, k = 1$ recovers exactly the parent's `IsMagic` (definitional).
+- **Trivial limits**: $k = 0$ (every config is 0-flat magic) and $k = d$ (single ambient flat is trivially magic). Theorem signatures shipped in S2 ACT; bodies pending S3 ACT.
+- **Parent reduction**: $d = 2, k = 1$ recovers exactly the parent's `IsMagic` (definitional). S4 ACT — **blocked on parent file repair under Mathlib v4.26.0**.
 - **Higher ambient dim $d \ge 3$, $k = 1$**: extends parent's 4 classes; conjecturally similar form.
 - **Higher flats $k \ge 2$**: introduces a possibly new "regular-polytope" magic family. The **tetrahedron** at alternate-cube-vertices is 2-flat magic in $\mathbb{R}^3$ with magic constant 3 (uniform weighting; see S6a PREP). The **octahedron and cube are NOT** 2-flat magic — they have 2-flats of two distinct sizes (3 and 4 vertices, per S6b PREP). Their vertex-transitive symmetry group $O_h$ obstructs any positive weighting. The conjectural new magic class is therefore *not* "regular polytopes" but a smaller subfamily (precise characterisation: open).
 
@@ -47,84 +53,90 @@ The author's conjecture: for $\mathbb{R}^d$ with $k = 1$, the parent's 4 classes
 
 For $k \ge 2$, the conjectural new family is a **narrow subfamily of regular polytopes** — at minimum, the tetrahedron survives; the octahedron and cube provably do not. The dodecahedron and icosahedron have not been analysed (S6d, deferred). The general position case in $\mathbb{R}^d$ is *always* $k$-flat magic via uniform weights (every minimal-spanning $k$-flat has exactly $k+1$ points), so the parent's "general position" class extends directly to $1 \le k \le d - 1$.
 
-## Open questions — PREP coverage status
+## Open questions — PREP/ACT coverage status
 
 | Sub-step | Topic | Status | PR |
 |---|---|---|---|
-| S2 | Lean definitions (`PointConfigD`, `ConfigKFlat`, `IsKFlatMagic`) | not shipped | — |
-| S3 | Trivial cases $k = 0$, $k = d$ | not shipped | — |
-| S4 | Parent reduction $d = 2, k = 1$ | not shipped | — |
+| S2 | Lean definitions + 2 sorry-theorems (`PointConfigD`, `WeightingD`, `ConfigKFlat`, `kFlatSum`, `IsKFlatMagic`, `zero_flat_magic_trivial` [sorry], `ambient_flat_magic_trivial` [sorry]) | **scaffold shipped** | **(this PR)** |
+| S3 | Discharge `zero_flat_magic_trivial` (k = 0) + `ambient_flat_magic_trivial` (k = d) | not shipped | — |
+| S4 | Parent reduction `oneflat_eq_parent` (d = 2, k = 1) | **BLOCKED on parent repair** | — |
 | S5 | Higher-dim classification axiom (extension of ABKPR) | not shipped | — |
-| S6a | Tetrahedron certificate | PREP shipped | #18486 |
-| S6b/c | Octahedron + cube refutations | PREP shipped | #18541 |
+| S6a | Tetrahedron certificate (PREP) | PREP shipped | #18486 |
+| S6a-ACT | Tetrahedron certificate (Lean) | not shipped | — |
+| S6b/c | Octahedron + cube refutations (PREP) | PREP shipped | #18541 |
+| S6b/c-ACT | Octahedron + cube refutations (Lean) | not shipped | — |
 | S6d | Dodec/icosa analysis | not shipped | — |
 | S6e | General-position uniform-weight theorem | not shipped | — |
 | S7 | Gallery JSON `status: "axiomatized"` | not shipped | — |
 
 ## Blockers
 
-None mathematical for the S2 ACT scaffold. Practical:
+**S4 ACT is blocked.** Per the S2 ACT session log
+`sessions/2026-05-13-s2-act-scaffold.md` §"Parent-file regression",
+`proofs/Proofs/Erdos735Problem.lean` is broken on `origin/main` under Mathlib
+v4.26.0 (four cumulative regressions: import-path, matrix-literal coercion,
+`Finset → Sort`, `Submodule.rank` / `direction.toSubmodule`). Three sibling
+Erdős parent files (`Erdos105Problem`, `Erdos209Problem`, `Erdos210Problem`)
+share the import-path issue at minimum. Doctor/mechanic sweep recommended;
+out of scope for OQ04 research PRs.
 
-- **ABKPR 2008 absent from Mathlib**: parent axiomatises; reuse for this OQ.
-- **Higher-flat classification absent from published literature**: S5 axiom is genuinely open.
-- **`status: "axiomatized"` mandatory**: ABKPR alone forces this; not overcoming-able by this OQ.
-- **`native_decide` route not viable**: per S6a PREP § 1, the tetrahedron certificate uses explicit proof terms, not `decide`. The S1 OBSERVE's S6 plan ("`native_decide` certificates") needs revising during S2 ACT.
+S5 axiom remains genuinely open in the literature (Mathlib has no published
+k-flat classification beyond ABKPR's ℝ² case). Not overcoming-able by this OQ.
+
+Practical:
+
+- **ABKPR 2008 absent from Mathlib**: parent axiomatises; reuse for this OQ
+  (once parent rebuilds).
+- **`status: "axiomatized"` mandatory**: ABKPR alone forces this; not
+  overcoming-able by this OQ.
+- **`native_decide` route not viable** (per S6a PREP § 1): use explicit proof
+  terms / witness construction.
 
 ## Next Action
 
-**S2 (any researcher)**: Define `PointConfigD`, `WeightingD`, `ConfigKFlat`, `IsKFlatMagic` in `proofs/Proofs/Erdos735OQ04.lean`. Approach: parameterise parent's definitions on $(d, k)$, using `EuclideanSpace ℝ (Fin d)` and `AffineSubspace`. Prove trivial cases $k = 0$, $k = d$.
+**S3 (any researcher)**: Discharge the two trivial-case theorems. Approach
+(per S2 ACT session log §"Next iteration"):
 
-Concrete plan (unchanged from S1):
+* `zero_flat_magic_trivial`: constant-1 weighting + `c = 1`; for each
+  `F : ConfigKFlat 0 P`, show `F.val` is a singleton containing exactly one
+  point of `P` (rank-0 + filter cardinality ≥ 1), then `kFlatSum = 1 = c`.
+  ~15-20 LOC; uses `Submodule.rank_eq_zero_iff` /
+  `Module.rank_eq_zero_iff`.
+* `ambient_flat_magic_trivial`: case split on `P.card ≥ d + 1`. Vacuous case
+  picks `c = 1`. Non-vacuous case picks `c = P.card` with uniform weight.
+  ~20-30 LOC; uses `AffineSubspace.direction_eq_top_iff` or
+  `Module.rank_eq_finrank_iff` for `Fin d → ℝ`.
 
-```lean
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
-import Proofs.Erdos735Problem  -- parent
+Total: ~35-50 LOC, 0 new sorries.
 
-namespace Erdos735OQ04
-
-def PointConfigD (d : ℕ) := Finset (EuclideanSpace ℝ (Fin d))
-
-def WeightingD {d : ℕ} (P : PointConfigD d) := {w : P → ℝ // ∀ p, w p > 0}
-
-def ConfigKFlat {d : ℕ} (k : ℕ) (P : PointConfigD d) :=
-  { F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)) //
-    F.direction.toSubmodule.rank = k ∧ (P.filter (· ∈ F)).card ≥ k + 1 }
-
-def kFlatSum {d k : ℕ} (P : PointConfigD d) (w : WeightingD P)
-    (F : ConfigKFlat k P) : ℝ := ...
-
-def IsKFlatMagic {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop := ...
-
-theorem zero_flat_magic_trivial : IsKFlatMagic 0 P := ...
-theorem ambient_flat_magic_trivial : IsKFlatMagic d P := ...
-theorem oneflat_eq_parent : IsKFlatMagic 1 P ↔ Erdos735.IsMagic P := ...
-
-end Erdos735OQ04
-```
-
-Expected ~50 Lean lines, ~3 sorries on the trivial-case theorems (mechanical to discharge).
-
-**S3** — S4: prove trivial cases and parent reduction.
-**S5** — axiomatise the conjectured higher-dim classification (NB: narrow the "regular-polytope" family to the tetrahedron + dodec/icosa-pending; do NOT include octa/cube).
-**S6a-c** — already designed (PREPs #18486, #18541); ACT (Lean certificates) pending.
-**S6d** — dodec/icosa analysis (Python script in PR #18541 § 3 generalises).
-**S6e** — general-position uniform-weight theorem in $\mathbb{R}^d$ for $1 \le k \le d-1$.
+**S4 — pending parent repair (doctor/mechanic task)**.
+**S5 — design PREP** refining the higher-dim conjecture to narrow the regular-polytope
+class (per S6a + S6b corrections — exclude octa/cube).
+**S6a-c ACT** — already designed (PREPs #18486, #18541); Lean witnesses pending
+S3 + (optionally) S4.
+**S6d** — dodec/icosa analysis.
+**S6e** — general-position uniform-weight theorem in $\mathbb{R}^d$ for
+$1 \le k \le d-1$.
 **S7** — gallery JSON with `status: "axiomatized"`.
 
 ## Honesty
 
-This STATE-SYNC iteration is **doc-only**. It produces:
+This S2 ACT iteration ships:
 
-- 0 new Lean theorems
-- 0 sorry/axiom deltas
-- 0 new design memos
-- Updated `state.md` (this file) reflecting S6a (PR #18486) + S6b (PR #18541) corrections
-- Updated `knowledge.md` retracting octahedron + cube magic claims
-- Updated `src/data/research/problems/erdos-735-oq-04.json` `currentState.focus`, `attemptCounts`, `knowledge.progressSummary`, and first insight
+- 1 NEW Lean file: `proofs/Proofs/Erdos735OQ04.lean` (99 LOC; 5 defs, 2 sorry-theorems, 0 axioms, 2 sorries)
+- 1 import addition to `proofs/Proofs.lean`
+- 1 new session log
+- This `state.md` update (Phase OBSERVE → ACT, iteration 3 → 4)
+- Updated `src/data/research/problems/erdos-735-oq-04.json`
 
-It applies the "corrections owed to upstream text" listed in PR #18541 § 6, which were explicitly deferred to "a future doctor/curator/researcher pass".
+**Docker-build verified**: 3058 jobs clean (2 expected `declaration uses 'sorry'`
+warnings). The new file does NOT depend on the parent (broken on origin/main),
+so it builds standalone.
 
-The higher-flat extension is **research-level open**. After S6a + S6b, the situation is: the *existence* of a new $k \ge 2$ magic class beyond ABKPR's 4 is confirmed (tetrahedron is a witness), but the *shape* of that class is narrower than S1 OBSERVE conjectured — octahedron and cube provably do not belong. The S5 axiom should target a refined subfamily.
+The higher-flat extension is **research-level open**. After S6a + S6b, the
+situation is: the *existence* of a new $k \ge 2$ magic class beyond ABKPR's 4
+is confirmed (tetrahedron is a witness), but the *shape* of that class is
+narrower than S1 OBSERVE conjectured. The S5 axiom (deferred) should target a
+refined subfamily.
 
 Future Lean entry: `status: "axiomatized"`.

--- a/src/data/research/problems/erdos-735-oq-04.json
+++ b/src/data/research/problems/erdos-735-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-735-oq-04",
   "title": "Magic configurations on k-flats in ℝ^d (Erdős #735 extension)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -30,15 +30,18 @@
     "goal": "Formalize in Lean: (1) PointConfigD / WeightingD / ConfigKFlat / IsKFlatMagic definitions parameterised on (d, k). (2) Trivial cases k = 0, k = d. (3) Definitional reduction IsKFlatMagic 1 = parent's IsMagic for d = 2. (4) Axiomatise higher-dim classification (conjectural). (5) native_decide certificates for tetrahedron / octahedron / cube. (6) Gallery JSON with status: axiomatized."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T22:15:00.000Z",
-    "iteration": 3,
-    "focus": "Three doc-only iterations have shipped: S1 OBSERVE (PR #18336, researcher-10, 2026-05-12) + S6a PREP (PR #18486, researcher-9, 2026-05-13, tetrahedron 2-flat-magic certificate, magic constant 3) + S6b PREP (PR #18541, researcher-5, 2026-05-13, refutation of octahedron + cube 2-flat-magic claims via O_h symmetry + exhaustive 2-flat enumeration). S6b explicitly deferred state.md / knowledge.md / gallery-JSON corrections to a future doctor/curator pass; this STATE-SYNC (researcher-5) applies them. Lean S2 ACT scaffold (proofs/Proofs/Erdos735OQ04.lean) has NOT yet shipped; no .lean changes in any of S1, S6a, S6b, or this STATE-SYNC.",
-    "blockers": [],
-    "nextAction": "S2: define PointConfigD, WeightingD, ConfigKFlat, IsKFlatMagic in proofs/Proofs/Erdos735OQ04.lean. Approach: parameterise parent's definitions on (d, k), use EuclideanSpace ℝ (Fin d) and AffineSubspace. Prove trivial cases k = 0 (zero_flat_magic_trivial), k = d (ambient_flat_magic_trivial), and the parent reduction for d = 2, k = 1. Expected ~50 Lean lines, 3 sorries for the trivial cases (mechanical to discharge).",
+    "phase": "ACT",
+    "since": "2026-05-13T23:55:00.000Z",
+    "iteration": 4,
+    "focus": "S2 ACT shipped (researcher-12, 2026-05-13, this PR): first Lean delta under this slug — proofs/Proofs/Erdos735OQ04.lean (99 LOC, 5 defs + 2 sorry-theorems + 0 axioms). Definitions: abbrev PointConfigD, def WeightingD, def ConfigKFlat, noncomputable def kFlatSum, def IsKFlatMagic. Theorem signatures with `sorry`: zero_flat_magic_trivial (k = 0), ambient_flat_magic_trivial (k = d). The third trivial target oneflat_eq_parent (d = 2, k = 1 ↔ parent's IsMagic) is DEFERRED — parent file Proofs/Erdos735Problem.lean is broken on origin/main under Mathlib v4.26.0 (four cumulative regressions: AffineSubspace module-split, Finset → Sort coercion via def-alias, AffineSubspace.direction.toSubmodule.rank API change, matrix ![...] literal coercion to EuclideanSpace). Three sibling Erdős parents (Erdos105/209/210) share the import-path issue at minimum. Docker-build clean: 3058 jobs, 2 expected sorry warnings. Recommended follow-up: doctor/mechanic sweep on the 4 Erdős parent files; OUT OF SCOPE for OQ04 research PRs.",
+    "blockers": [
+      "S4 ACT (parent reduction oneflat_eq_parent): blocked on Proofs/Erdos735Problem.lean repair against Mathlib v4.26.0 (4 cumulative regressions documented in sessions/2026-05-13-s2-act-scaffold.md §'Parent-file regression'). Doctor/mechanic task — out of scope for OQ04 research PRs.",
+      "S5 axiom: genuinely open in the literature (Mathlib has no published k-flat classification beyond ABKPR's ℝ² case). Future iteration must axiomatise."
+    ],
+    "nextAction": "S3 ACT (any researcher): discharge the two trivial-case sorries. (a) zero_flat_magic_trivial: constant-1 weighting + c = 1; for each F : ConfigKFlat 0 P, show F.val is a singleton (rank-0 + filter card ≥ 1 forces uniqueness); kFlatSum = 1. ~15-20 LOC; uses Submodule.rank_eq_zero_iff / Module.rank_eq_zero_iff. (b) ambient_flat_magic_trivial: case split on P.card ≥ d + 1. Vacuous case (no qualifying d-flats) picks c = 1. Non-vacuous case picks c = P.card, uniform weight. ~20-30 LOC; uses AffineSubspace.direction_eq_top_iff or Module.rank_eq_finrank_iff for Fin d → ℝ. Total: ~35-50 LOC, 0 new sorries.",
     "attemptCounts": {
       "S1_observe": 1,
-      "S2_definitions": 0,
+      "S2_definitions": 1,
       "S3_trivial_cases": 0,
       "S4_parent_reduction": 0,
       "S5_higher_dim_classification_axiom": 0,
@@ -60,9 +63,11 @@
       "Created src/data/research/problems/erdos-735-oq-04.json (this file) — S1 OBSERVE, PR #18336.",
       "Wrote research/problems/erdos-735-oq-04/sessions/2026-05-13-s6a-prep-tetrahedron-magic-certificate.md (tetrahedron at alt-cube-vertices, magic constant 3, explicit proof terms; ~3K words) — S6a PREP, PR #18486.",
       "Wrote research/problems/erdos-735-oq-04/sessions/2026-05-13-s6b-prep-octahedron-cube-not-2-flat-magic.md (refutation of S1 OBSERVE's octa+cube claims, Python certificate, O_h symmetry argument; +508 LOC) — S6b PREP, PR #18541.",
-      "Updated state.md / knowledge.md / this JSON to reflect S6a + S6b corrections (proven[3], insights[0], focus, progressSummary, attemptCounts.S6) — STATE-SYNC (this PR)."
+      "Updated state.md / knowledge.md / JSON to reflect S6a + S6b corrections (proven[3], insights[0], focus, progressSummary, attemptCounts.S6) — STATE-SYNC, PR #18891.",
+      "Wrote proofs/Proofs/Erdos735OQ04.lean (99 LOC; 5 defs: PointConfigD/WeightingD/ConfigKFlat/kFlatSum/IsKFlatMagic; 2 sorry-theorems: zero_flat_magic_trivial, ambient_flat_magic_trivial; 0 axioms; 2 sorries). Docker-build verified 3058-job clean. Added Proofs.Erdos735OQ04 import to proofs/Proofs.lean. — S2 ACT (this PR).",
+      "Wrote research/problems/erdos-735-oq-04/sessions/2026-05-13-s2-act-scaffold.md documenting four Mathlib v4.26.0 surface fixes and the parent-file regression that blocks S4 — S2 ACT (this PR)."
     ],
-    "progressSummary": "S1 OBSERVE complete (PR #18336). S6a PREP shipped (PR #18486, tetrahedron 2-flat-magic certificate). S6b PREP shipped (PR #18541, refutation of octahedron + cube 2-flat-magic claims via O_h symmetry + exhaustive Python enumeration). STATE-SYNC (this PR) applies corrections owed: state.md / knowledge.md / JSON now accurately distinguish the magic tetrahedron from the non-magic octahedron and cube. The conjectural 'regular-polytope' new magic family is strictly narrower than S1 OBSERVE suggested: at minimum the tetrahedron survives; dodec/icosa untested (S6d, deferred). Definitions and Lean signatures (S2 ACT) and trivial-case theorems (S3, S4) NOT yet shipped — proofs/Proofs/Erdos735OQ04.lean does not exist on main. Higher-dim ABKPR extension (S5 axiom) genuinely open."
+    "progressSummary": "S1 OBSERVE complete (PR #18336). S6a PREP shipped (PR #18486, tetrahedron 2-flat-magic certificate). S6b PREP shipped (PR #18541, refutation of octahedron + cube 2-flat-magic claims via O_h symmetry + exhaustive Python enumeration). STATE-SYNC (PR #18891) applied corrections owed. S2 ACT (this PR) ships the first Lean delta: proofs/Proofs/Erdos735OQ04.lean (99 LOC, 5 defs + 2 sorry-theorems + 0 axioms + 2 sorries), Docker-build clean (3058 jobs). The parent reduction theorem oneflat_eq_parent (S4) is deferred: parent file Proofs/Erdos735Problem.lean is broken on origin/main against Mathlib v4.26.0 (4 cumulative API regressions, including the AffineSubspace module-split that surfaces in 3 sibling Erdős parents — Erdos105/209/210). Recommended doctor/mechanic sweep. The conjectural 'regular-polytope' new magic family is strictly narrower than S1 OBSERVE suggested: at minimum the tetrahedron survives; dodec/icosa untested (S6d, deferred). Higher-dim ABKPR extension (S5 axiom) genuinely open."
   },
   "tags": [
     "seeker-selected",
@@ -78,5 +83,5 @@
   ],
   "significance": 6,
   "tractability": 5,
-  "lastUpdated": "2026-05-13T17:35:00.000Z"
+  "lastUpdated": "2026-05-13T23:55:00.000Z"
 }


### PR DESCRIPTION
## Summary

S2 ACT for `erdos-735-oq-04` — **first Lean delta** under this slug.

`proofs/Proofs/Erdos735OQ04.lean` (NEW, 99 LOC):

- **5 defs** (`abbrev PointConfigD`, `def WeightingD`, `def ConfigKFlat`, `noncomputable def kFlatSum`, `def IsKFlatMagic`) parameterised on `(d, k)` per the parent's `Erdos735.PointConfig` / `ConfigLine` / `IsMagic` pattern.
- **2 theorem signatures with `sorry`**: `zero_flat_magic_trivial` (k = 0), `ambient_flat_magic_trivial` (k = d). Discharge plan documented in `state.md` and the session log.
- **0 axioms, 2 sorries.**

Phase: `OBSERVE` → `ACT` (iteration 3 → 4). Breaks a 4-consecutive-doc-only-PR chain.

## Build verification

**Docker-build clean: 3058 jobs, 2 expected `declaration uses 'sorry'` warnings.**

Log: `.loom/logs/researcher-12-erdos735-oq04-s2act-build5.log`.

## Mathlib v4.26.0 surface fixes (documented in-file)

The build-and-rebuild loop surfaced four regressions; each documented in `Proofs/Erdos735OQ04.lean` doc-strings:

| # | Symptom | Fix |
|---|---------|-----|
| 1 | `Mathlib.LinearAlgebra.AffineSpace.AffineSubspace` no longer exists | import `.Basic` (which re-exports `.Defs`) |
| 2 | `Finset → Sort` coercion fails through `def`-alias | `abbrev PointConfigD` (transparent unfolding) |
| 3 | `F.direction.toSubmodule.rank` invalid (`AffineSubspace.direction` returns `Submodule` directly, no `Submodule.rank`) | `Module.rank ℝ F.direction = (k : Cardinal)` |
| 4 | `(P.filter (· ∈ F)).card` needs `DecidablePred`; `kFlatSum` over `EuclideanSpace ℝ (Fin d)` involves `Real.decidableEq` | `open scoped Classical`, mark `kFlatSum` `noncomputable` |

## Parent-file regression (out of scope — flagged for follow-up)

`proofs/Proofs/Erdos735Problem.lean` is **broken on `origin/main`** under Mathlib v4.26.0 with **all four** of the above regressions plus a fifth (matrix `![...]` literals no longer auto-coerce to `EuclideanSpace ℝ (Fin n)` in `def threeCollinear` / `def triangle`).

Three sibling Erdős parent files share the import-path issue at minimum:
- `proofs/Proofs/Erdos105Problem.lean`
- `proofs/Proofs/Erdos209Problem.lean`
- `proofs/Proofs/Erdos210Problem.lean`

**Recommended follow-up**: a separate doctor/mechanic PR to sweep these four files in one pass. The fix volume per file is multi-line, exceeding the "build unblocker in-PR" scope from `feedback_researcher_parent_file_build_unblocker_inpr_pattern`.

This S2 ACT scaffold **does not depend on the parent file** (no `import Proofs.Erdos735Problem`), so the parent regression does **not block S3 ACT** (discharging the two trivial-case sorries). It does block S4 ACT (the `oneflat_eq_parent` parent-reduction theorem), which is therefore intentionally deferred to a post-repair iteration.

## Why ACT instead of more PREP

After S1 OBSERVE + S6a/S6b PREP + STATE-SYNC, the slug had **4 consecutive doc-only PRs**. Per `feedback_researcher_docs_only_chain_silent_parent_regression`, this is exactly the threshold where Docker-build verification should fire — and indeed the build surfaced the parent regression that would otherwise have remained invisible.

## Next iteration — S3 ACT

Discharge the two trivial cases (~35-50 LOC, 0 new sorries):

- `zero_flat_magic_trivial`: constant-1 weighting + `c = 1`; for each `F : ConfigKFlat 0 P`, show `F.val` is a singleton (rank-0 + filter card ≥ 1); `kFlatSum = 1`. Uses `Submodule.rank_eq_zero_iff` / `Module.rank_eq_zero_iff`.
- `ambient_flat_magic_trivial`: case split on `P.card ≥ d + 1`. Vacuous case: `c = 1`. Non-vacuous case: `c = (P.card : ℝ)`, uniform weight. Uses `AffineSubspace.direction_eq_top_iff` or `Module.rank_eq_finrank_iff` for `Fin d → ℝ`.

## Test plan

- [x] Docker-build of `Proofs.Erdos735OQ04` clean (3058 jobs, 2 expected sorries)
- [x] JSON validates as JSON
- [x] state.md `Phase` line + JSON `currentState.phase` both updated to `ACT`
- [x] `iteration` 3 → 4 in both state.md and JSON
- [x] Session log documents the build-and-rebuild loop and the parent regression
- [x] `proofs/Proofs.lean` imports `Proofs.Erdos735OQ04` (so the file is included in full builds)
- [ ] (follow-up, separate PR) Doctor/mechanic sweep on `Erdos735/105/209/210Problem.lean`
