### PR TITLE
research(bounded-prime-gaps-oq-03-oq-02): S10 ACT — S9 build unblocker + primesUpTo bearer (build verified, 7745 jobs)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean
@@ -469,10 +469,15 @@ private lemma card_image_image_sub_mod_eq
   have h2 : (a' % p + (p - m % p) + m % p) % p = a' % p := by
     have heq2 : a' % p + (p - m % p) + m % p = a' % p + p := by omega
     rw [heq2, Nat.add_mod_right, Nat.mod_eq_of_lt h_a'mod]
+  -- Beta-reduce `hrr'` so the `rw` below can find the (beta-normal) pattern
+  -- in the goal. Under Mathlib v4.26.0 the bare `hrr'` from the obtained
+  -- equality retains its `(fun r => …) (a % p)` head, but Lean's `rewrite`
+  -- looks for syntactic occurrences and the goal's RHS is already beta-normal.
+  have hrr_beta : (a % p + (p - m % p)) % p = (a' % p + (p - m % p)) % p := hrr'
   have h3 : (a % p + (p - m % p) + m % p) % p =
       (a' % p + (p - m % p) + m % p) % p := by
     rw [Nat.add_mod (a % p + (p - m % p)) (m % p) p,
-        Nat.add_mod (a' % p + (p - m % p)) (m % p) p, hrr']
+        Nat.add_mod (a' % p + (p - m % p)) (m % p) p, hrr_beta]
   rw [h1, h2] at h3
   exact h3
 
@@ -485,6 +490,9 @@ lemma card_image_sub_eq {H : Finset ℕ} {m : ℕ} (hm : ∀ a ∈ H, m ≤ a) :
   intro a ha b hb hab
   have hma := hm a ha
   have hmb := hm b hb
+  -- Beta-reduce `hab : (fun x => x - m) a = (fun x => x - m) b`
+  -- so `omega` can see the natural-subtraction hypothesis `a - m = b - m`.
+  simp only at hab
   omega
 
 /-- `H.image (· - m)` is nonempty iff `H` is. The translation lemma. -/
@@ -554,8 +562,8 @@ private lemma exists_subset_card_50_containing_zero
     · exact h0
     · exact Finset.mem_of_mem_erase (hS_sub hxS)
   · have h0_notin : 0 ∉ S := fun h =>
-      (Finset.not_mem_erase 0 H') (hS_sub h)
-    rw [Finset.card_insert_of_not_mem h0_notin, hS_card]
+      (Finset.notMem_erase 0 H') (hS_sub h)
+    rw [Finset.card_insert_of_notMem h0_notin, hS_card]
 
 /-- **(c) The bridge lemma**: the finitary form of the Engelsma lower
 bound implies the unbounded form. Given any admissible `H : Finset ℕ`
@@ -589,9 +597,12 @@ theorem engelsma_lower_bound_of_finitary
     rw [hH'_def, Finset.mem_image]
     exact ⟨m, Finset.min'_mem _ _, Nat.sub_self _⟩
   -- The translated maximum equals `H.max' - m < 246`.
-  have hH'_max : H'.max' hH'_ne = H.max' hne - m := by
-    rw [hH'_def]
-    exact image_sub_max'_eq hne hm_le
+  -- Apply `image_sub_max'_eq` directly: `H'` is `set` to `H.image (· - m)`
+  -- and proof-irrelevance unifies the two `.Nonempty` proofs, so no `rw`
+  -- on `hH'_def` (which would trigger a motive-not-type-correct failure
+  -- under Lean v4.26.0 because `hH'_ne` depends on the rewritten term).
+  have hH'_max : H'.max' hH'_ne = H.max' hne - m :=
+    image_sub_max'_eq hne hm_le
   have hH'_max_lt : H'.max' hH'_ne < 246 := by
     rw [hH'_max]; exact hlt
   -- Cardinality lifts.
@@ -756,6 +767,69 @@ analogues (kernel `decide` would also work but is slower on
 multi-layer `Decidable` reductions). The `Lean.ofReduceBool`
 axiom from S4 is reused; `axiomCount` stays at `1`. -/
 theorem engelsmaSearch_7_3_eq_true : engelsmaSearch 7 3 = true := by
+  native_decide
+
+/-! ## S10 ACT pre-flight — `primesUpTo` bearer
+
+This section lands the `primesUpTo` utility scheduled for the larger
+S11+ pruned-search work, per the design pinned in
+`research/problems/bounded-prime-gaps-oq-03-oq-02/sessions/2026-05-13-s10c-prep-primesBelow-termination.md`
+§2.3 (canonical bearer choice) and refined in
+`2026-05-13-s10d-prep-leaf-case-and-initialization.md` §5
+(entrypoint shape).
+
+Shipping `primesUpTo` separately from the (larger) recursive
+`searchAux` definition gives three benefits:
+
+1. **API exercise** — verifies that the `Nat.primesBelow` bearer
+   claim (S10c PREP) and the `Finset.sort` default-relation form
+   both compile and `native_decide` correctly under the v4.26.0
+   `Mathlib` pin currently in `proofs/lake-manifest.json`.
+
+2. **Concrete sanity** — the verified equation
+   `primesUpTo 50 = [2, 3, 5, 7, …, 47]` pins the exact list the
+   pruner will branch on at the target parameter.
+
+3. **Scope discipline** — `searchAux` is non-structural-recursion
+   territory (`termination_by primes.length` per S10c PREP §3.4);
+   landing it requires a multi-piece patch with termination
+   machinery + invariant lemmas. `primesUpTo` is a one-liner with
+   two `native_decide` unit tests, which is the minimal
+   build-verifiable step toward S11.
+
+`axiomCount` stays at `1` (the `Lean.ofReduceBool` from S4); the
+two sanity-test theorems reuse `native_decide`. -/
+
+/-- `primesUpTo k` is the list of primes `p ≤ k`, in ascending order.
+
+Implementation: `(Nat.primesBelow (k + 1)).sort (· ≤ ·)`.
+`Nat.primesBelow n` is the `Finset ℕ` of primes `p < n`
+(`Mathlib/NumberTheory/SmoothNumbers.lean:41`), so
+`Nat.primesBelow (k + 1) = {p : ℕ | p ≤ k ∧ p.Prime}`. `Finset.sort`
+then materializes the finset as an ordered `List ℕ` under the
+default `(· ≤ ·)` relation
+(`Mathlib/Data/Finset/Sort.lean:33`).
+
+For the target parameter `k = 50` this returns the 15 primes
+`p ≤ 47`, witnessed by `primesUpTo_50_eq` below. The S11+ pruner
+will be entered as `searchAux w k (primesUpTo k) candidates chosen`. -/
+def primesUpTo (k : ℕ) : List ℕ :=
+  (Nat.primesBelow (k + 1)).sort (· ≤ ·)
+
+/-- **Sanity test** at `k = 10` — relevant to the deferred S7 case
+`(10, 30)` and to the parent file's `BoundedPrimeGaps.lean` smooth-
+prime helpers. The four primes `p ≤ 10` are `[2, 3, 5, 7]`. -/
+theorem primesUpTo_10_eq : primesUpTo 10 = [2, 3, 5, 7] := by
+  native_decide
+
+/-- **Sanity test** at the target parameter `k = 50`. The 15 primes
+`p ≤ 50` are listed in ascending order; `47` is the largest prime
+≤ 50 (the next is `53`). This is the exact list S11+'s pruned
+`searchAux` will branch on at the `engelsmaSearch 246 50 = false`
+discharge. -/
+theorem primesUpTo_50_eq :
+    primesUpTo 50 =
+      [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47] := by
   native_decide
 
 end BoundedPrimeGapsOQ03OQ02


### PR DESCRIPTION
## Summary

Two-part research deliverable, build-verified end-to-end:

### Part A — S9 build unblocker (3 errors + 2 deprecations)

Docker baseline build of the origin/main S9 tip surfaced **3 errors** in `BoundedPrimeGapsOQ03OQ02.lean` that the 7-deep "(build pending)" PR chain (S2–S9, merged 2026-05-11 / 2026-05-12) had hidden:

| Line  | Tactic     | Fix                                                                    |
|-------|------------|------------------------------------------------------------------------|
| 475   | `rewrite`  | Add beta-aliased `hrr_beta := hrr'` so `rw` finds the pattern          |
| 488   | `omega`    | Add `simp only at hab` to beta-reduce `(fun x => x - m) a = (fun x => x - m) b` |
| 593   | `rewrite`  | Drop `rw [hH'_def]`; apply `image_sub_max'_eq` directly (proof-irrel.) |

Plus **2 deprecation renames** (compiler warnings at lines 557/558):
- `Finset.not_mem_erase` → `Finset.notMem_erase`
- `Finset.card_insert_of_not_mem` → `Finset.card_insert_of_notMem`

**Root cause**: all three errors are Mathlib v4.26.0 tactic-elaboration changes (stricter `rewrite` motive checks; `omega`'s beta-reduction behavior on hypothesis-lambdas). The 7-PR "(build pending)" chain meant none of S2–S9 actually compiled on origin/main until this session's Docker baseline build (the local-worktree `proofs/.lake` symlink trap had blocked all prior verification attempts; the chain-warning pattern matches `feedback_researcher_build_pending_slug_series_silent_parent_regression.md`).

### Part B — S10 ACT pre-flight: `primesUpTo` bearer + sanity tests

Per the 4-deep S10/S10b/S10c/S10d PREP chain (PRs #18281, #18500, #18601, #18662), the canonical bearer for "primes ≤ k" is `(Nat.primesBelow (k + 1)).sort (· ≤ ·)`. This PR lands that as a top-level `def primesUpTo (k : ℕ) : List ℕ` with two `native_decide` sanity tests:

```lean
def primesUpTo (k : ℕ) : List ℕ :=
  (Nat.primesBelow (k + 1)).sort (· ≤ ·)

theorem primesUpTo_10_eq : primesUpTo 10 = [2, 3, 5, 7] := by
  native_decide

theorem primesUpTo_50_eq :
    primesUpTo 50 =
      [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47] := by
  native_decide
```

These exercise the v4.26.0 `Nat.primesBelow` + `Finset.sort` API in the smallest verifiable slice. The (larger) recursive `searchAux` definition is deferred to S11 ACT — see S10d PREP §5 for the pinned ~25-LOC skeleton with `termination_by primes.length`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02`:

```
✔ [7745/7745] Built Proofs.BoundedPrimeGapsOQ03OQ02 (8.4s)
Build completed successfully (7745 jobs).
=== Build succeeded ===
```

Target file built in 8.4s (vs ~4s for the S9 baseline; the +4s is `native_decide`'s cost for `primesUpTo_50_eq`).

## Scope

- 1 file: `proofs/Proofs/BoundedPrimeGapsOQ03OQ02.lean` (+80 / -6).
- No JSON, `state.md`, `knowledge.md`, or other Lean edits.
- **Orthogonal** to open PR #19004 (Session 14 STATE-SYNC, JSON/`state.md` only).
- **Orthogonal** to open PR #18024 (S6 `9_26` `native_decide`, different region).

## Axiom bookkeeping

- `axiomCount` stays at `1` (the `Lean.ofReduceBool` from S4).
- `0` sorries.
- `defCount` 2 → 3 (`primesUpTo`).
- `theoremCount` 23 → 25 (`primesUpTo_10_eq`, `primesUpTo_50_eq`).
- `lineCount` 761 → 835 (+74).

## Test plan

- [x] `docker-build.sh Proofs.BoundedPrimeGapsOQ03OQ02` → "Build completed successfully (7745 jobs)"
- [x] `git diff --stat origin/main` → 1 file, 80 insertions, 6 deletions, no other files touched
- [x] Race-check: open PRs #19004 (state.md/JSON only) and #18024 (`9_26` region) are orthogonal
- [x] `axiomCount` unchanged at `1` (reused `Lean.ofReduceBool` from S4)
- [x] No new sorries (`grep -c "sorry" file` matches docstring-only mentions)

🤖 Generated by researcher-9 (Claude Opus 4.7)
