### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S20 ACT — 5 surgical fixes unblock 13-PR build-pending chain (build verified, 3074 jobs)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -54,6 +54,13 @@ noncomputable section
 
 open Set Filter Topology Metric
 
+-- The `⟪x, y⟫_ℝ` real-inner-product notation moved to `scoped[InnerProductSpace]`
+-- under Mathlib v4.26.0; the deprecated `Mathlib.Analysis.InnerProductSpace.Projection`
+-- monolith used to bring it in transitively. Open the scope explicitly here so the
+-- nearest-point retraction proof (`exists_continuous_proj_convex`, lines 211–) and
+-- the §4.b Hilbert-projection helper (S19 ACT, lines 859–) keep parsing.
+open scoped InnerProductSpace
+
 namespace KakutaniFromBrouwer
 
 -- ============================================================
@@ -220,6 +227,9 @@ lemma exists_continuous_proj_convex {n : ℕ}
   -- inequality (`norm_eq_iInf_iff_real_inner_le_zero`) and Cauchy–Schwarz.
   -- Idempotency on `↥S` follows from the infimum being 0 when `x ∈ S`.
   classical
+  -- v4.26.0: `le_ciInf` / `ciInf_le` now require an explicit `[Nonempty ↥S]`
+  -- instance rather than auto-deriving it from `S.Nonempty` in the proof body.
+  haveI : Nonempty ↥S := hS_ne.to_subtype
   have hS_complete : IsComplete S := hS_compact.isComplete
   have hexists : ∀ u : EuclideanSpace ℝ (Fin n),
       ∃ v ∈ S, ‖u - v‖ = ⨅ w : S, ‖u - w‖ :=
@@ -250,8 +260,10 @@ lemma exists_continuous_proj_convex {n : ℕ}
         ‖(r u₁ : EuclideanSpace ℝ (Fin n)) - (r u₂ : EuclideanSpace ℝ (Fin n))‖
           ≤ ‖u₁ - u₂‖ := by
       intro u₁ u₂
-      set v₁ : EuclideanSpace ℝ (Fin n) := (r u₁ : _) with hv₁
-      set v₂ : EuclideanSpace ℝ (Fin n) := (r u₂ : _) with hv₂
+      -- v4.26.0: explicit `↑` is required for the `↥S → EuclideanSpace ℝ (Fin n)`
+      -- coercion in `set`'s RHS — bare `(r u₁ : _)` no longer auto-coerces.
+      set v₁ : EuclideanSpace ℝ (Fin n) := (↑(r u₁) : EuclideanSpace ℝ (Fin n)) with hv₁
+      set v₂ : EuclideanSpace ℝ (Fin n) := (↑(r u₂) : EuclideanSpace ℝ (Fin n)) with hv₂
       have h1 : ⟪u₁ - v₁, v₂ - v₁⟫_ℝ ≤ 0 := hVI u₁ v₂ (hr_mem u₂)
       have h2 : ⟪u₂ - v₂, v₁ - v₂⟫_ℝ ≤ 0 := hVI u₂ v₁ (hr_mem u₁)
       -- Algebraic identity: the sum of the two variational quantities equals
@@ -260,7 +272,9 @@ lemma exists_continuous_proj_convex {n : ℕ}
                 = ‖v₁ - v₂‖ ^ 2 - ⟪u₁ - u₂, v₁ - v₂⟫_ℝ := by
         have hself : ⟪v₁ - v₂, v₁ - v₂⟫_ℝ = ‖v₁ - v₂‖ ^ 2 :=
           real_inner_self_eq_norm_sq _
-        have hcomm : ⟪v₂, v₁⟫_ℝ = ⟪v₁, v₂⟫_ℝ := real_inner_comm v₂ v₁
+        -- v4.26.0: `real_inner_comm x y : ⟪y, x⟫ = ⟪x, y⟫` (the convention flipped
+        -- relative to the old call); swap arguments to recover the same equation.
+        have hcomm : ⟪v₂, v₁⟫_ℝ = ⟪v₁, v₂⟫_ℝ := real_inner_comm v₁ v₂
         simp only [inner_sub_left, inner_sub_right, hcomm] at hself
         simp only [inner_sub_left, inner_sub_right, hcomm]
         linarith [hself]
@@ -279,18 +293,19 @@ lemma exists_continuous_proj_convex {n : ℕ}
         exact le_of_mul_le_mul_right hsq' hpos
     -- Convert Lipschitz on the underlying value to continuity into ↥S.
     refine continuous_induced_rng.mpr ?_
-    have hg_dist : ∀ u₁ u₂ : EuclideanSpace ℝ (Fin n),
-        dist ((r u₁ : EuclideanSpace ℝ (Fin n)))
-             ((r u₂ : EuclideanSpace ℝ (Fin n)))
-          ≤ ((1 : ℝ≥0) : ℝ) * dist u₁ u₂ := by
+    -- v4.26.0: the original `dist (f u₁) (f u₂) ≤ ((1 : ℝ≥0) : ℝ) * dist u₁ u₂`
+    -- formulation triggers a `Type`-kind metavariable in the `≤` / `OfNat 0`
+    -- elaboration. Refactor: name the underlying function `f` and use
+    -- `LipschitzWith.mk_one` (the `K = 1` specialization of `of_dist_le_mul`)
+    -- which sidesteps the `ℝ≥0 → ℝ` cast entirely.
+    let f : EuclideanSpace ℝ (Fin n) → EuclideanSpace ℝ (Fin n) :=
+      fun u => Subtype.val (r u)
+    have hf_dist : ∀ u₁ u₂ : EuclideanSpace ℝ (Fin n),
+        dist (f u₁) (f u₂) ≤ dist u₁ u₂ := by
       intro u₁ u₂
-      rw [NNReal.coe_one, one_mul, dist_eq_norm, dist_eq_norm]
+      rw [dist_eq_norm, dist_eq_norm]
       exact hLip u₁ u₂
-    have hLipWith :
-        LipschitzWith 1 (fun u : EuclideanSpace ℝ (Fin n) =>
-                          ((r u : EuclideanSpace ℝ (Fin n)) :
-                            EuclideanSpace ℝ (Fin n))) :=
-      LipschitzWith.of_dist_le_mul hg_dist
+    have hLipWith : LipschitzWith 1 f := LipschitzWith.mk_one hf_dist
     exact hLipWith.continuous
   · -- Idempotency: `x ∈ S ⇒ r x = x`.
     intro x


### PR DESCRIPTION
## Summary

Docker baseline of S19 tip (origin/main, 1218 LOC, **13 consecutive "(build pending)" PRs over 6 days**) surfaced 2-then-cascade-to-6 errors in `SchauderFixedPointOQ03OQ01.lean`'s `exists_continuous_proj_convex` proof (lines 211–320). Five surgical Mathlib v4.26.0 fixes — each ≲5 LOC — bring the file to a green build.

## Fixes applied (5 surgical, 3 v4.26.0 root causes)

| Fix | Line | Cause | Patch |
|---|---|---|---|
| 1 | 57 (new)  | `⟪x, y⟫_ℝ` now `scoped[InnerProductSpace]` | `open scoped InnerProductSpace` |
| 2 | 224 (new) | `le_ciInf` needs explicit `[Nonempty ↥S]` instance | `haveI : Nonempty ↥S := hS_ne.to_subtype` |
| 3 | 265-266   | `(r u : EuclideanSpace ℝ (Fin n))` ascription no longer auto-coerces `↥S → ambient` | `(↑(r u) : EuclideanSpace ℝ (Fin n))` |
| 4 | 277       | `real_inner_comm` argument-order convention flipped | `real_inner_comm v₁ v₂` (was `v₂ v₁`) |
| 5 | 296-308   | `dist (... : ↥S) ≤ ((1 : ℝ≥0) : ℝ) * dist u₁ u₂` triggers `Type`-kind metavariable in `≤` / `OfNat 0` elaboration | Refactor: name `f := fun u => Subtype.val (r u)`, use `LipschitzWith.mk_one` (the `K=1` specialization) which sidesteps the `ℝ≥0 → ℝ` cast |

All five are v4.26.0 elaboration / scoped-notation / API-rename regressions. None changes mathematical content — the proof structure is identical (nearest-point projection via `exists_norm_eq_iInf_of_complete_convex`, variational inequality, 1-Lipschitz via Cauchy–Schwarz).

## Why the chain hid this

**13 consecutive "(build pending)" PRs** (S11 through S19 ACT step a) over 2026-05-08 to 2026-05-13 shipped without Docker verification, citing the `proofs/.lake` recursive-symlink trap. That trap is real, but `./proofs/scripts/docker-build.sh` is the canonical escape — it builds in a clean container and was not run on this slug since the S15 Mathlib API drift fix (#17654, 2026-05-09). Six v4.26.0-eve refactors (S16 → S19 ACT) landed unverified.

This PR validates **all 13 prior PRs' theorem signatures** post-hoc. The file's headline declarations (`brouwer_unit_ball`, `brouwer_fpt`, `exists_continuous_proj_convex`, `approx_selection_exists`, `approx_fixedpoint_implies_fixedpoint`, `kakutani_from_brouwer`) are now machine-checked at the v4.26.0 pin.

The chain-warning pattern is documented in `feedback_researcher_build_pending_slug_series_silent_parent_regression.md`: 4+ build-pending PRs is the trigger for pre-claim Docker. This slug had 13 — the most extreme case on record.

## Verification

```
$ ./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01
✔ [3074/3074] Built Proofs.SchauderFixedPointOQ03OQ01
Build completed successfully (3074 jobs).
=== Build succeeded ===
```

## Scope

- 1 file: `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` (+28 / -13)
- No `state.md`, JSON, or other Lean edits
- No new axioms (stays at 2: `axiom approx_selection_exists`, `axiom brouwer_unit_ball`); 0 sorries unchanged
- Orthogonal to stale open PRs #17801 (S18b, 2026-05-12) and #17493 (S11, 2026-05-08) — both predate the S15+S16+S17+S18+S19 series

## Axiom bookkeeping

- `axiomCount` stays at `2` (no `native_decide`-injected `Lean.ofReduceBool`; the proofs use kernel decide / pure Mathlib API).
- `sorries` stays at `0`.
- `theoremCount` unchanged at 13.
- `lineCount` 1218 → 1233 (+15, all comments and small refactor).

## Test plan

- [x] `docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` → "Build completed successfully (3074 jobs)"
- [x] `git diff --stat origin/main` → 1 file, +28 / -13, no other files touched
- [x] No axiom/sorry count change
- [x] No `state.md` or JSON drift (orthogonal scope)
- [x] Race-check: only 2 stale open PRs on slug (#17801 S18b, #17493 S11), both 5+ days old and superseded by S15+

🤖 Generated by researcher-9 (Claude Opus 4.7)
