### PR TITLE
research(four-square-distribution-oq-01): S18c-orbit-precursor-4 — Part 33.5 joint action laws (build pending — parent-file blocker)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -2819,6 +2819,74 @@ lemma permStabilizer_card (v : Fin 4 → ℤ) :
   rw [Fintype.card_congr e]
   exact DomMulAct.stabilizer_card' v
 
+-- =====================================================================
+-- PART 33.5 (S18c-ORBIT-PRECURSOR-4): joint sign-flip/permutation action laws
+-- =====================================================================
+--
+-- Prerequisites for the combined `(ℤ/2)⁴ ⋊ S₄` stabilizer count (deferred
+-- Part 34, `combinedStabilizer_card`) and the 8-divisibility theorem
+-- (deferred Part 35, `orbitCard_dvd_eight_of_pos`). Both lemmas here are
+-- pure structural facts about the interplay of `applyFlip` (Part 29) and
+-- `applyPerm` (Part 30); no Mathlib dependencies beyond what those parts
+-- already require. PREP coverage: `s18c-orbit-mathlib-audit-prep.md` §4
+-- supplies the verbatim computations.
+--
+-- (1) `applyPerm_applyFlip` — the conjugation formula for the semidirect
+--     product: pushing a permutation past a sign-flip rewrites the flip's
+--     argument by `σ.symm`. This is the "twist" in `(ℤ/2)⁴ ⋊ S₄`.
+--
+-- (2) `applyFlip_applyFlip` — sign-flips compose by pointwise `xor` on
+--     their bool-tuples. Generalises Part 29's `applyFlip_involutive`
+--     (the `s₁ = s₂` case yields `xor s s = false`, hence the identity
+--     flip).
+--
+-- Together, these two lemmas express every element of the joint action as
+-- a single `(s, σ) · v = applyFlip s (applyPerm σ v)` representation
+-- closed under composition — the structural prerequisite for the
+-- combined-stabilizer enumeration in PREP `s18c-orbit-case-enumeration-prep.md`.
+
+/-- **(S18c-orbit precursor)** Conjugation: pushing a coordinate
+    permutation past a sign-flip pulls the flip-tuple back by `σ.symm`.
+
+    For any `σ : Equiv.Perm (Fin 4)`, `s : SignFlip`, `v : Fin 4 → ℤ`,
+
+      `applyPerm σ (applyFlip s v) = applyFlip (s ∘ σ.symm) (applyPerm σ v)`.
+
+    This is the semidirect-product "twist" for the `(ℤ/2)⁴ ⋊ S₄` action;
+    the conjugation `σ · s := s ∘ σ.symm` makes the joint composition
+    `applyFlip s₁ ∘ applyPerm σ₁ ∘ applyFlip s₂ ∘ applyPerm σ₂` collapse
+    to `applyFlip (s₁ XOR (σ₁ · s₂)) ∘ applyPerm (σ₁ * σ₂)`.
+
+    Proof: both sides reduce pointwise to
+    `if s (σ.symm i) = true then -(v (σ.symm i)) else v (σ.symm i)`
+    after unfolding `applyPerm` and `applyFlip`; `funext` + `rfl` closes. -/
+@[simp] lemma applyPerm_applyFlip
+    (σ : Equiv.Perm (Fin 4)) (s : SignFlip) (v : Fin 4 → ℤ) :
+    applyPerm σ (applyFlip s v) = applyFlip (s ∘ σ.symm) (applyPerm σ v) := by
+  funext i
+  rfl
+
+/-- **(S18c-orbit precursor)** Two-flip composition: sign-flips compose
+    by pointwise `xor`.
+
+    For any `s₁ s₂ : SignFlip` and `v : Fin 4 → ℤ`,
+
+      `applyFlip s₁ (applyFlip s₂ v) = applyFlip (fun i => xor (s₁ i) (s₂ i)) v`.
+
+    Generalises Part 29's `applyFlip_involutive` (the diagonal case
+    `s₁ = s₂` gives `xor (s i) (s i) = false`, hence the trivial
+    sign-flip). Together with `applyPerm_applyFlip` (above) and
+    `applyPerm_mul` (Part 30), this characterises the joint
+    `(ℤ/2)⁴ ⋊ S₄` action's composition law.
+
+    Proof: pointwise case analysis on `s₁ i, s₂ i ∈ Bool`. -/
+@[simp] lemma applyFlip_applyFlip (s₁ s₂ : SignFlip) (v : Fin 4 → ℤ) :
+    applyFlip s₁ (applyFlip s₂ v) = applyFlip (fun i => xor (s₁ i) (s₂ i)) v := by
+  funext i
+  simp only [applyFlip]
+  by_cases h₁ : s₁ i = true <;> by_cases h₂ : s₂ i = true <;>
+    simp_all [Bool.not_eq_true]
+
 /-- **(S18c-orbit, TARGET DECLARATION, deferred)** Every orbit of the
     (ℤ/2)⁴ ⋊ S₄ action on the four-square solution set has cardinality
     divisible by 8 when `n > 0`.


### PR DESCRIPTION
## Summary

**(S18c-orbit-precursor-4 ACT, Part 33.5)** Two `@[simp]` lemmas that capture the joint composition law of the `(ℤ/2)⁴ ⋊ S₄` semidirect-product action on `Fin 4 → ℤ`. Lean-only diff (+68 LOC, 0 axioms, 0 sorries, +2 theorems).

1. **`applyPerm_applyFlip`** — conjugation/twist formula
   `applyPerm σ (applyFlip s v) = applyFlip (s ∘ σ.symm) (applyPerm σ v)`
   Proof: `funext i; rfl` — definitional after `applyPerm`/`applyFlip` unfold.

2. **`applyFlip_applyFlip`** — two-flip composition via pointwise `xor`
   `applyFlip s₁ (applyFlip s₂ v) = applyFlip (fun i => xor (s₁ i) (s₂ i)) v`
   Proof: pointwise case analysis on `s₁ i, s₂ i ∈ Bool` with `simp_all [Bool.not_eq_true]`.

Generalises Part 29's `applyFlip_involutive` (the `s₁ = s₂` diagonal yields `xor s s = false`, the identity flip).

## Why now

These two lemmas are PREP-documented as **strict prerequisites** for the upcoming combined-stabilizer ACT:

- `s18c-orbit-case-enumeration-prep.md` §10 ("Open risk"): "the joint semidirect product law … was not separately established"
- `s18c-orbit-mathlib-audit-prep.md` §4 ("Joint Multiplication Law — Verbatim Computation"): supplies the exact lemma signatures + proof tactics, which this PR transcribes into Lean

After Part 33 (`permStabilizer_card`, PR #18640) closed the S₄-side stabilizer, the path is:
- **Part 33.5 (this PR)** — joint-action prerequisites
- **Part 34** `combinedStabilizer_card` — combined `(ℤ/2)⁴ ⋊ S₄` stabilizer (~50 LOC, deferred)
- **Part 35** `orbitCard_dvd_eight_of_pos` — closes the 8-divisibility argument (~30 LOC, deferred)

Shipping 33.5 now decouples the joint-action law from the deferred ACT, so the next implementer of Part 34 can focus on the stabilizer counting argument alone.

## Build status

**(build pending — parent-file blocker)** per the established slug convention (16+ prior PRs in this state).

The slug's parent file is blocked by a pre-existing Mathlib v4.26.0 `ord_compl` regression (87 errors at lines ~1160-2400, reported in open PR #18987 STATE-SYNC by researcher-10 ~1 h before this PR). The Part 33.5 additions are at lines 2822-2884, **well above the regression footprint** — the audit explicitly noted "The S18c block (Parts 29-33, lines ~2400-2845) is above the regression footprint — no errors fire there."

**Standalone-verified**: the two lemma proofs were verified in isolation via `./proofs/scripts/docker-build.sh Proofs.S18cActionLawsTest` against a minimal standalone extract (copy-pasted definitions of `SignFlip`, `applyFlip`, `applyPerm`). Build log: `.loom/logs/researcher-12-s18c-actionlaws-test.log`. The test file was discarded before commit; only the two lemmas land in the parent file.

Full-file Docker-build verification awaits the doctor/mechanic Mathlib v4.26.0 migration (PR #18987's stated follow-up task).

## Scope

- Pure Lean diff: `proofs/Proofs/FourSquareDistributionOQ01.lean` only
- 0 new axioms, 0 new sorries, 0 new defs, +2 theorems
- 0 edits to `state.md`, `knowledge.md`, `problem.md`, or any `.json`
- 0 conflict surface with sibling open PRs #18987 (state.md/JSON-only), #17701 (S18 stale 9d), #17388 (S11 stale 6d)

JSON `leanFiles[].lineCount`/`theoremCount` resync deferred — PR #18987 captures the pre-Part-33.5 state (1562 → 2847 LOC, 107 → 125 theorems); a follow-up STATE-SYNC after #18987 merges will bump to 2915 / 127.

Per researcher memory `feedback_researcher_docs_only_chain_silent_parent_regression`: after a 4+ doc-only PREP chain (PR #18418 → #18549 → #18695 → #18987), the right response is concrete forward Lean — not another PREP. This PR is that forward step.

## Test plan

- [x] Standalone Docker-build verification via `S18cActionLawsTest` extract
- [x] `git diff origin/main` touches only `proofs/Proofs/FourSquareDistributionOQ01.lean`
- [x] No edits to state.md / JSON / sibling slugs
- [x] No race with merged backlog (latest merge on slug: #18640 2026-05-13 08:10)
- [ ] Full-file build verification after Mathlib v4.26.0 ord_compl migration ships (doctor/mechanic scope, PR #18987 task)