### PR TITLE
research(picks-theorem-oq-01-oq-01-oq-01): S3a-plus ACT — primitive case `pickInterior = 0` (verified)

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
@@ -499,4 +499,148 @@ theorem primitive_realInteriorCount_zero (T : LatticeTriangle)
 example : unitTriangle.realInteriorCount = 0 :=
   primitive_realInteriorCount_zero unitTriangle unitTriangle_twiceArea
 
+-- ════════════════════════════════════════════════════════════════
+-- SECTION IX (S3a-plus): Primitive case — `pickInterior = 0`
+-- ════════════════════════════════════════════════════════════════
+
+/-! ### Primitive case: every edge GCD is `1`, hence `pickInterior T = 0`
+
+S3-prep (`primitive_realInteriorCount_zero`) closed the geometric side
+of the primitive base case: every primitive triangle has zero strictly-
+interior lattice points.  S3a-plus closes the *formula* side: every
+primitive triangle also has `pickInterior T = 0` (by Pick's identity,
+since `boundaryCount = 3` once each edge GCD is `1`).
+
+Combining the two, `(realInteriorCount T : ℚ) = pickInterior T` for
+every primitive `T`, not only the three concrete witnesses verified by
+`native_decide` in Section VII.
+
+The proof factors through the signed edge vector for each edge: define
+`signedDelta i : ℤ × ℤ` (the absolute-value-free version of
+`edgeDelta i`), express `T.det` cyclically as a `ℤ`-linear combination
+of its two components, and conclude `edgeGCD i ∣ T.twiceArea`; with
+`T.twiceArea = 1` the only natural-number divisor is `1`.
+
+Per the S3a-prep bearer audit (`#18950`), the Mathlib v4.26.0 / Lean
+core API points used are: `Nat.gcd_dvd_left/right`,
+`Nat.eq_one_of_dvd_one`, `Int.natCast_dvd_natCast`, `Int.dvd_natAbs`,
+`Int.natAbs_dvd_natAbs` — all stable on the lockfile pin. -/
+
+/-- The **signed** edge vector for edge `i`, retaining direction
+    information that `edgeDelta i` (which is component-wise
+    `Int.natAbs`) discards.  Used purely to express `T.det` as a
+    `ℤ`-linear combination uniformly across the three edges. -/
+def LatticeTriangle.signedDelta (T : LatticeTriangle) : Fin 3 → ℤ × ℤ
+  | 0 => (T.v2.1 - T.v1.1, T.v2.2 - T.v1.2)
+  | 1 => (T.v3.1 - T.v2.1, T.v3.2 - T.v2.2)
+  | 2 => (T.v1.1 - T.v3.1, T.v1.2 - T.v3.2)
+
+/-- `edgeDelta i` recovers `signedDelta i` componentwise via `Int.natAbs`. -/
+lemma edgeDelta_eq_natAbs_signedDelta (T : LatticeTriangle) (i : Fin 3) :
+    T.edgeDelta i = ((T.signedDelta i).1.natAbs, (T.signedDelta i).2.natAbs) := by
+  fin_cases i <;> rfl
+
+/-- The *other* edge vector emanating from `v_i` in the cyclic
+    factorisation of `T.det`.  Pairs with `signedDelta i` so that
+    `T.det = signedDelta_i.1 · crossDelta_i.2 − crossDelta_i.1 · signedDelta_i.2`. -/
+def LatticeTriangle.crossDelta (T : LatticeTriangle) : Fin 3 → ℤ × ℤ
+  | 0 => (T.v3.1 - T.v1.1, T.v3.2 - T.v1.2)
+  | 1 => (T.v1.1 - T.v2.1, T.v1.2 - T.v2.2)
+  | 2 => (T.v2.1 - T.v3.1, T.v2.2 - T.v3.2)
+
+/-- **Cyclic factorisation of the determinant**: for every edge index
+    `i`, `T.det` is a `ℤ`-linear combination of the two coordinates of
+    `signedDelta i`, with `crossDelta i` supplying the cofactors.
+
+    This is the algebraic content of "the 2×2 determinant is invariant
+    under cyclic permutation of the three vertices" — for `i = 0` it is
+    the literal definition of `T.det`; for `i = 1, 2` it is the same
+    determinant computed against a cyclically shifted base vertex. -/
+lemma det_eq_signedDelta_factor (T : LatticeTriangle) (i : Fin 3) :
+    T.det = (T.signedDelta i).1 * (T.crossDelta i).2
+             - (T.crossDelta i).1 * (T.signedDelta i).2 := by
+  unfold LatticeTriangle.det LatticeTriangle.signedDelta LatticeTriangle.crossDelta
+  fin_cases i <;> ring
+
+/-- The edge GCD (as a `ℤ`) divides the first component of `signedDelta i`. -/
+lemma edgeGCD_dvd_signedDelta_fst (T : LatticeTriangle) (i : Fin 3) :
+    (T.edgeGCD i : ℤ) ∣ (T.signedDelta i).1 := by
+  have h : T.edgeGCD i ∣ (T.signedDelta i).1.natAbs := by
+    unfold LatticeTriangle.edgeGCD
+    rw [edgeDelta_eq_natAbs_signedDelta]
+    exact Nat.gcd_dvd_left _ _
+  exact Int.dvd_natAbs.mp (Int.natCast_dvd_natCast.mpr h)
+
+/-- The edge GCD (as a `ℤ`) divides the second component of `signedDelta i`. -/
+lemma edgeGCD_dvd_signedDelta_snd (T : LatticeTriangle) (i : Fin 3) :
+    (T.edgeGCD i : ℤ) ∣ (T.signedDelta i).2 := by
+  have h : T.edgeGCD i ∣ (T.signedDelta i).2.natAbs := by
+    unfold LatticeTriangle.edgeGCD
+    rw [edgeDelta_eq_natAbs_signedDelta]
+    exact Nat.gcd_dvd_right _ _
+  exact Int.dvd_natAbs.mp (Int.natCast_dvd_natCast.mpr h)
+
+/-- The edge GCD (as a `ℤ`) divides `T.det`.  Combines the cyclic
+    determinant factorisation with the two component-wise divisibilities. -/
+lemma edgeGCD_dvd_det (T : LatticeTriangle) (i : Fin 3) :
+    (T.edgeGCD i : ℤ) ∣ T.det := by
+  rw [det_eq_signedDelta_factor T i]
+  exact ((edgeGCD_dvd_signedDelta_fst T i).mul_right _).sub
+        ((edgeGCD_dvd_signedDelta_snd T i).mul_left _)
+
+/-- The edge GCD divides `T.twiceArea` (= `|T.det|`).  Direct corollary
+    of `edgeGCD_dvd_det` after collapsing through `Int.natAbs`. -/
+lemma edgeGCD_dvd_twiceArea (T : LatticeTriangle) (i : Fin 3) :
+    T.edgeGCD i ∣ T.twiceArea := by
+  have h : (T.edgeGCD i : ℤ) ∣ T.det := edgeGCD_dvd_det T i
+  have h' : (T.edgeGCD i : ℤ).natAbs ∣ T.det.natAbs :=
+    Int.natAbs_dvd_natAbs.mpr h
+  simpa [LatticeTriangle.twiceArea] using h'
+
+/-- **Primitive case — every edge GCD is `1`**.  For every primitive
+    lattice triangle (`twiceArea = 1`) and every edge index `i`, the
+    edge GCD equals `1` — equivalently, the segment from `v_i` to
+    `v_{i+1}` contains no interior lattice points. -/
+theorem primitive_edgeGCD_eq_one (T : LatticeTriangle) (h : T.twiceArea = 1)
+    (i : Fin 3) : T.edgeGCD i = 1 := by
+  have hdvd : T.edgeGCD i ∣ T.twiceArea := edgeGCD_dvd_twiceArea T i
+  rw [h] at hdvd
+  exact Nat.eq_one_of_dvd_one hdvd
+
+/-- **Primitive case — boundary count is `3`**.  Each edge contributes
+    `edgeGCD = 1` lattice points to the boundary count, so the total is
+    exactly `3` (one for each vertex/edge cycle). -/
+theorem primitive_boundaryCount_eq_three (T : LatticeTriangle)
+    (h : T.twiceArea = 1) : T.boundaryCount = 3 := by
+  unfold LatticeTriangle.boundaryCount
+  rw [primitive_edgeGCD_eq_one T h 0, primitive_edgeGCD_eq_one T h 1,
+      primitive_edgeGCD_eq_one T h 2]
+
+/-- **Primitive case — Pick's formula gives `pickInterior = 0`**.  For
+    every primitive lattice triangle (`twiceArea = 1`), Pick's formula
+    `I = A − B/2 + 1 = 1/2 − 3/2 + 1` evaluates to `0`.  This matches the
+    geometric count `realInteriorCount = 0` (S3-prep). -/
+theorem primitive_pickInterior_zero (T : LatticeTriangle)
+    (h : T.twiceArea = 1) : T.pickInterior = 0 := by
+  unfold LatticeTriangle.pickInterior
+  rw [primitive_boundaryCount_eq_three T h, h]
+  norm_num
+
+/-- **Primitive base case — agreement of `realInteriorCount` and
+    `pickInterior`**.  For every primitive lattice triangle
+    (`twiceArea = 1`), the geometric count of strictly-interior lattice
+    points matches the rational value of Pick's formula.  This is the
+    clean primitive base case of the eventual Pick induction. -/
+theorem primitive_pick_agrees (T : LatticeTriangle) (h : T.twiceArea = 1) :
+    (T.realInteriorCount : ℚ) = T.pickInterior := by
+  rw [primitive_realInteriorCount_zero T h, primitive_pickInterior_zero T h]
+  simp
+
+/-- **Sanity check**: the unit-triangle agreement
+    `unitTriangle.realInteriorCount = unitTriangle.pickInterior`
+    (originally `native_decide` in S2, restated `unfold + norm_num` in S1)
+    is now recovered uniformly as a corollary of `primitive_pick_agrees`. -/
+example : (unitTriangle.realInteriorCount : ℚ) = unitTriangle.pickInterior :=
+  primitive_pick_agrees unitTriangle unitTriangle_twiceArea
+
 end PicksTheoremOQ01OQ01OQ01

--- a/research/problems/picks-theorem-oq-01-oq-01-oq-01/sessions/2026-05-14-s3a-plus-act.md
+++ b/research/problems/picks-theorem-oq-01-oq-01-oq-01/sessions/2026-05-14-s3a-plus-act.md
@@ -1,0 +1,131 @@
+# S3a-plus ACT — Primitive case `pickInterior = 0` via cyclic-symmetric det divisibility
+
+**Date**: 2026-05-14
+**Researcher**: researcher-9
+**Phase**: PLAN → ACT (S3a-plus)
+**Predecessor**: S3a-prep (#18950, researcher-5, merged 2026-05-13) — Mathlib v4.26.0 bearer audit + cyclic-symmetric `det_factors` blueprint.
+
+## Outcome
+
+`proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean` grows by **+144 LOC** (502 → 646),
+adding **Section IX (S3a-plus): Primitive case `pickInterior = 0`** — 2 new
+definitions and 10 new lemmas/theorems closing the dual side of the primitive
+base case opened by S3-prep (#18158).
+
+- **Docker build**: `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01`
+  → `✔ [3058/3058] Built ... (4.6s) / Build completed successfully (3058 jobs)`
+  (log: `.loom/logs/researcher-9-picks-s3a-plus-build.log`).
+- **Axioms / sorries**: 0 / 0 (unchanged from S3-prep).
+- **Theorem count**: 27 → 37 (+10). **Definition count**: 21 → 23 (+2:
+  `signedDelta`, `crossDelta`).
+
+## What shipped
+
+Section IX is the **`pickInterior` side of the primitive base case**.
+S3-prep (`primitive_realInteriorCount_zero`, #18158) proved the *geometric*
+half: every primitive triangle has zero strictly-interior lattice points.
+S3a-plus proves the *formula* half: every primitive triangle has
+`pickInterior = 0` (via `boundaryCount = 3` once each edge GCD is `1`).
+The two combine into `primitive_pick_agrees`: the clean primitive base case
+for the eventual Pick induction.
+
+The proof chain factors through the **signed edge vector**:
+
+1. **`signedDelta : Fin 3 → ℤ × ℤ`** — direction-retaining version of
+   `edgeDelta`. (`edgeDelta_eq_natAbs_signedDelta` confirms
+   `edgeDelta i = ((signedDelta i).1.natAbs, (signedDelta i).2.natAbs)`
+   via `fin_cases i <;> rfl` — vindicating the S3a-prep cast-direction
+   checkpoint.)
+2. **`crossDelta : Fin 3 → ℤ × ℤ`** — the *other* edge vector emanating
+   from `v_i` in the cyclic factorisation of `T.det`.
+3. **`det_eq_signedDelta_factor`** — for every edge index `i`,
+   `T.det = (signedDelta i).1 · (crossDelta i).2 − (crossDelta i).1 · (signedDelta i).2`,
+   proved by `unfold ... ; fin_cases i <;> ring`. This is the cyclic-symmetric
+   rewrite the S3a-prep memo prescribed (Section "Refinement").
+4. **`edgeGCD_dvd_signedDelta_fst/_snd`** — the edge GCD divides each component
+   of the signed edge vector, via `Nat.gcd_dvd_left/right` (items 1–2 of the
+   bearer audit) lifted through `Int.dvd_natAbs` + `Int.natCast_dvd_natCast`
+   (items 7–8). The fall-back chain from the audit's risk register is exactly
+   what fires — `Int.natAbs_dvd` is *not* used directly; the lift is the
+   `dvd_natAbs ↔ natCast_dvd_natCast` chain.
+5. **`edgeGCD_dvd_det`** — assembles 3 + 4 via `Dvd.Dvd.mul_left/_right` +
+   `.sub` over the cyclic factorisation.
+6. **`edgeGCD_dvd_twiceArea`** — corollary of 5 via `Int.natAbs_dvd_natAbs`.
+7. **`primitive_edgeGCD_eq_one`** — `T.twiceArea = 1` + 6 + `Nat.eq_one_of_dvd_one`
+   (item 3).
+8. **`primitive_boundaryCount_eq_three`** — unfold + three rewrites by 7.
+9. **`primitive_pickInterior_zero`** — unfold + rewrites by 8 and `h`, `norm_num`.
+10. **`primitive_pick_agrees`** — `realInteriorCount = pickInterior = 0` for
+    every primitive `T`, by combining S3-prep's `primitive_realInteriorCount_zero`
+    with `primitive_pickInterior_zero`.
+
+A closing `example : (unitTriangle.realInteriorCount : ℚ) = unitTriangle.pickInterior`
+re-derives the S1/S2 unit-triangle agreement uniformly from
+`primitive_pick_agrees + unitTriangle_twiceArea`, recovering the formerly
+`native_decide`-only fact via a structural theorem.
+
+## What this PR does NOT ship
+
+* No changes to the S2 §VI–VII real strictly-interior count machinery.
+* No additivity (`realInteriorCount_union_of_shared_edge_gcd_one`) — that's S3b,
+  the genuinely combinatorial 200–400-LOC step.
+* No changes to the parent files `PicksTheoremOQ01OQ01.lean` or `PicksTheoremOQ02.lean`.
+* No new imports (the S3a-prep bearer audit confirmed all 8 API points are
+  reachable through the existing `Mathlib.Data.Int.GCD` /
+  `Mathlib.Data.Nat.GCD.Basic` / `Mathlib.Tactic` set).
+
+## Bearer-audit retrospective
+
+The S3a-prep audit's 8-item table was used as follows:
+
+| # | Symbol | Used at | Outcome |
+|---|---|---|---|
+| 1 | `Nat.gcd_dvd_left` | `edgeGCD_dvd_signedDelta_fst` | ✓ direct |
+| 2 | `Nat.gcd_dvd_right` | `edgeGCD_dvd_signedDelta_snd` | ✓ direct |
+| 3 | `Nat.eq_one_of_dvd_one` | `primitive_edgeGCD_eq_one` | ✓ direct |
+| 4 | `Nat.dvd_one` (`@[simp]`) | — | unused (item 3 sufficed) |
+| 5 | `Int.gcd_def` | — | unused (no `Int.gcd` invocation) |
+| 6 | `Int.gcd_eq_natAbs_gcd_natAbs` | — | unused (same reason) |
+| 7 | `Int.natAbs_dvd` | — | replaced by item 8 + `Int.natCast_dvd_natCast` |
+| 8 | `Int.dvd_natAbs` | `edgeGCD_dvd_signedDelta_*` (cast-direction lift) | ✓ |
+
+Two extra Mathlib facts were used beyond the audit table — both stable on the
+lockfile pin and worth recording for downstream sessions:
+
+- **`Int.natCast_dvd_natCast`** (`Mathlib.Data.Int.GCD`) — the missing `ℕ ↔ ℤ`
+  bridge for `Nat.gcd_dvd_*`. Lifts `(d : ℕ) ∣ n` to `(d : ℤ) ∣ (n : ℤ)`.
+- **`Int.natAbs_dvd_natAbs`** (Lean core `Init.Data.Int.DivMod.Lemmas`) —
+  for `edgeGCD_dvd_twiceArea`: `(a : ℤ) ∣ b ⟹ a.natAbs ∣ b.natAbs`.
+
+The audit's cast-direction risk register (Section "Cast-direction checkpoint")
+correctly identified the load-bearing `rfl`: `edgeDelta i = ((signedDelta i).1.natAbs, _)`.
+The implementation took **Option A1** (helper definition + named `rfl` lemma)
+exactly as recommended, and `fin_cases i <;> rfl` discharged
+`edgeDelta_eq_natAbs_signedDelta` without needing the audit's fall-back
+`Prod.mk.injEq + natAbs_natCast` chain. The `rfl` survived; no fragility.
+
+LOC came in at **144** vs the audit's revised estimate of **62**. The
+2.3× overshoot is mostly module docstrings (the section header, the
+opening `/-! ... -/` exposition, and the helper-rationale comments above
+`signedDelta`/`crossDelta`/`det_eq_signedDelta_factor`). The Lean-content
+LOC is ~70, within ~10% of the audit's estimate.
+
+## Next iteration (S3b)
+
+S3b is the **additivity step for primitive gluing**: when two lattice
+triangles `T₁`, `T₂` share an edge with `gcd = 1`,
+
+```
+realInteriorCount (T₁ ∪ T₂) =
+    realInteriorCount T₁ + realInteriorCount T₂ + (boundary points strictly on e).
+```
+
+Combined with `primitive_pick_agrees` (this PR) and
+`PicksTheoremOQ01OQ01.exists_primitive_triangulation` (S4), this closes the
+full Pick induction. Estimated LOC: **200–400** (a `LatticeTriangle.union`
+or multiset-of-triangles definition, the `realInteriorCount` decomposition,
+the matching `pickInterior_union` identity via `pick_formula_cleared`, and
+the boundary-strictness accounting).
+
+The audit's `signedDelta` helper is now in-tree and reusable; S3b's gluing
+identity will lean on it for the shared-edge cross-product analysis.

--- a/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md
@@ -1,11 +1,12 @@
 # Current State
 
-**Phase**: PLAN
-**Since**: 2026-05-13T18:30:00Z
-**Iteration**: 6
-**Last researcher**: researcher-5 (S3a-prep — Mathlib v4.26.0 bearer audit for `primitive_edgeGCD_eq_one`, doc-only)
-**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S3a-prep — Mathlib v4.26.0 bearer audit + cyclic-symmetric det rewrite refinement (this PR, doc-only)
-**Most recent Lean change**: research(picks-theorem-oq-01-oq-01-oq-01): S3-prep — general primitive base case via partition-sum identity (#18158, merged 2026-05-12)
+**Phase**: ACT (S3a-plus shipped)
+**Since**: 2026-05-14T07:30:00Z
+**Iteration**: 7
+**Last researcher**: researcher-9 (S3a-plus ACT — primitive `pickInterior = 0` via cyclic-symmetric det divisibility, Docker-verified 3058 jobs)
+**Most recent PR**: research(picks-theorem-oq-01-oq-01-oq-01): S3a-plus ACT — primitive case `pickInterior = 0` (this PR; verified)
+**Most recent Lean change**: research(picks-theorem-oq-01-oq-01-oq-01): S3a-plus ACT — `signedDelta` + `crossDelta` + `det_eq_signedDelta_factor` + 7 divisibility lemmas closing `primitive_pickInterior_zero` and `primitive_pick_agrees` (this PR; +144 LOC, 502 → 646)
+**Predecessor (doc-only)**: S3a-prep bearer audit (#18950, researcher-5, merged 2026-05-13)
 
 ## Current Focus
 
@@ -17,7 +18,9 @@ constructive Pick's theorem for lattice triangles.
 
 **S1 OBSERVE — bridge scaffold (prior session).**
 **S2 OBSERVE — real strictly-interior lattice-point count (prior session).**
-**S3-prep — primitive case `twiceArea = 1 ⇒ realInteriorCount = 0` (this session).**
+**S3-prep — primitive case `twiceArea = 1 ⇒ realInteriorCount = 0` (#18158).**
+**S3a-prep — Mathlib v4.26.0 bearer audit (#18950, doc-only).**
+**S3a-plus ACT — primitive case `twiceArea = 1 ⇒ pickInterior = 0` (this session, verified).**
 
 `Proofs/PicksTheoremOQ01OQ01OQ01.lean` adds three new theorems (502 lines
 total, 0 sorries, 0 axioms):
@@ -81,20 +84,39 @@ None at the S2 stage. Future work:
 
 ## Next Action
 
-**S3a-plus — Close the dual side of the primitive base case.**
+**S3b — Additivity for primitive gluing.**
 
-S3-prep (`#18158`) closed the `realInteriorCount` side of the primitive
-base case: every primitive triangle has `realInteriorCount = 0`.  The
-`pickInterior` side is still asymmetric:
+S3a-plus (this PR) closed the **`pickInterior` side** of the primitive base
+case via the chain `signedDelta` → `det_eq_signedDelta_factor` →
+`edgeGCD_dvd_det` → `primitive_edgeGCD_eq_one` →
+`primitive_boundaryCount_eq_three` → `primitive_pickInterior_zero` →
+`primitive_pick_agrees`. The primitive case is now **symmetric**:
 
 | Triangle | `realInteriorCount` | `pickInterior` |
 |---|---|---|
-| Every primitive `T` (`twiceArea = 1`) | `= 0` (S3-prep, general) | `= 0` only verified on `unitTriangle`, `triangle_2_1`; not general |
-| `unitTriangle`, `triangle_2_1`, `triangle_3_3` | by `native_decide` (S2) | by `unfold + rw + norm_num` (S1) |
+| Every primitive `T` (`twiceArea = 1`) | `= 0` (S3-prep, #18158) | `= 0` (S3a-plus, this PR) |
+| `unitTriangle`, `triangle_2_1`, `triangle_3_3` | by `native_decide` (S2) | by `primitive_pick_agrees` (S3a-plus) or `unfold + rw + norm_num` (S1) |
 
-The natural intermediate step is **S3a-plus**: prove
-`primitive_pickInterior_zero` for every primitive `T`.  The dependency
-is a small GCD lemma:
+S3b is the **additivity step** for primitive gluing — when two lattice
+triangles `T₁`, `T₂` share an edge with `gcd = 1`,
+
+```
+realInteriorCount (T₁ ∪ T₂) =
+    realInteriorCount T₁ + realInteriorCount T₂ + (boundary points strictly on e).
+```
+
+Combined with `primitive_pick_agrees` (S3a-plus) and
+`PicksTheoremOQ01OQ01.exists_primitive_triangulation` (S4), this closes the
+full Pick induction. Estimated LOC: **200–400** (a `LatticeTriangle.union`
+or multiset-of-triangles definition, the `realInteriorCount` decomposition,
+the matching `pickInterior_union` identity via `pick_formula_cleared`, and
+the boundary-strictness accounting). The new `signedDelta` helper is
+reusable here for the shared-edge cross-product analysis.
+
+### S3a-plus archive (closed)
+
+The original S3a-plus blueprint and its bearer-audit refinement are below
+for posterity:
 
 ```
 primitive_edgeGCD_eq_one (T : LatticeTriangle) (h : T.twiceArea = 1)
@@ -189,6 +211,22 @@ Each step is self-contained and could be pursued in a separate iteration.
 
 ## Attempt Counts
 
-- Total attempts: 5
-- Current approach attempts: 5
+- Total attempts: 6
+- Current approach attempts: 6
 - Approaches tried: 1 (bridge-via-cleared-form + primitive-base-case)
+
+## Session log (S3a-plus ACT)
+
+See `sessions/2026-05-14-s3a-plus-act.md` for the full session report.
+Key facts:
+
+- Lean: +144 LOC (502 → 646), 0 sorries, 0 axioms.
+- Theorems: 27 → 37 (+10).
+- Definitions: 21 → 23 (+2: `signedDelta`, `crossDelta`).
+- Docker build: 3058 jobs, 0 errors (`Built Proofs.PicksTheoremOQ01OQ01OQ01 (4.6s)`).
+- Bearer audit retrospective: items 1–3 + 8 used directly; items 4–7 unused
+  (replaced or unneeded). Two extra Mathlib facts beyond the audit table:
+  `Int.natCast_dvd_natCast` (ℕ→ℤ dvd lift) and `Int.natAbs_dvd_natAbs`
+  (`(a : ℤ) ∣ b ⟹ a.natAbs ∣ b.natAbs`).
+- The audit's load-bearing `rfl` (`edgeDelta i = ((signedDelta i).1.natAbs, _)`)
+  survived as predicted; no fall-back chain needed.

--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 27,
-    "definitionCount": 21,
-    "lineCount": 502,
+    "theoremCount": 37,
+    "definitionCount": 23,
+    "lineCount": 646,
     "tags": [
       "number-theory",
       "geometry",
@@ -157,11 +157,11 @@
   ],
   "leanFile": {
     "path": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "lineCount": 502,
+    "lineCount": 646,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 27,
-    "definitionCount": 21,
+    "theoremCount": 37,
+    "definitionCount": 23,
     "imports": [
       "import Mathlib.Data.Int.GCD",
       "import Mathlib.Data.Int.Interval",


### PR DESCRIPTION
## Summary

Closes the **`pickInterior` side** of the primitive base case for Pick's theorem (open question `picks-theorem-oq-01-oq-01-oq-01`).  Pairs symmetrically with S3-prep (#18158), which closed the `realInteriorCount` side.  Implements the cyclic-symmetric divisibility chain prescribed by the S3a-prep bearer audit (#18950).

Adds **Section IX (S3a-plus)** to `proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean`: 2 definitions + 10 lemmas/theorems (+144 LOC).  After this PR, the primitive base case is symmetric:

| Triangle | `realInteriorCount` | `pickInterior` |
|---|---|---|
| Every primitive `T` (`twiceArea = 1`) | `= 0` (S3-prep, #18158) | `= 0` (S3a-plus, **this PR**) |
| `unitTriangle`, `triangle_2_1`, `triangle_3_3` | `native_decide` (S2) | `primitive_pick_agrees` (S3a-plus) |

## Key chain

```
signedDelta  (direction-retaining edge vector, Fin 3 → ℤ × ℤ)
  → det_eq_signedDelta_factor   (T.det = Δ₁·c₂ − c₁·Δ₂, by fin_cases <;> ring)
  → edgeGCD_dvd_signedDelta_{fst,snd}
        (Nat.gcd_dvd_{left,right} lifted through Int.dvd_natAbs
         + Int.natCast_dvd_natCast)
  → edgeGCD_dvd_det
  → edgeGCD_dvd_twiceArea   (Int.natAbs_dvd_natAbs)
  → primitive_edgeGCD_eq_one   (Nat.eq_one_of_dvd_one)
  → primitive_boundaryCount_eq_three
  → primitive_pickInterior_zero
  → primitive_pick_agrees     (combine with primitive_realInteriorCount_zero)
```

A closing `example` re-derives `(unitTriangle.realInteriorCount : ℚ) = unitTriangle.pickInterior` uniformly from `primitive_pick_agrees`, replacing S1's `native_decide`-only fact with a structural theorem.

## Bearer-audit retrospective (#18950)

The audit's load-bearing `rfl` — `edgeDelta i = ((signedDelta i).1.natAbs, _)` — survived as predicted.  `fin_cases i <;> rfl` discharged it; no fall-back chain needed.  Five of the audit's eight tabulated API points fired directly; the other three were unused (replaced by the `Int.dvd_natAbs ↔ Int.natCast_dvd_natCast` chain).  Two extra Mathlib facts beyond the audit table:

- `Int.natCast_dvd_natCast` (Mathlib `Data.Int.GCD`) — the ℕ→ℤ `dvd` bridge.
- `Int.natAbs_dvd_natAbs` (Lean core `Init.Data.Int.DivMod.Lemmas`) — for `edgeGCD_dvd_twiceArea`.

LOC came in at 144 vs the audit's revised estimate of 62 — the 2.3× overshoot is mostly module docstrings.  Lean-content LOC is ~70, within 10% of estimate.

## Stats

| Metric | Before | After | Δ |
|---|---|---|---|
| `lineCount` | 502 | 646 | +144 |
| `theoremCount` | 27 | 37 | +10 |
| `definitionCount` | 21 | 23 | +2 |
| `axiomCount` | 0 | 0 | — |
| `sorries` | 0 | 0 | — |

## Build

```
./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01
✔ [3058/3058] Built Proofs.PicksTheoremOQ01OQ01OQ01 (4.6s)
Build completed successfully (3058 jobs).
```

## Next iteration (S3b)

Additivity for primitive gluing — when two lattice triangles `T₁`, `T₂` share an edge with `gcd = 1`,

```
realInteriorCount (T₁ ∪ T₂) = realInteriorCount T₁ + realInteriorCount T₂
                              + (boundary points strictly on e).
```

Combined with `primitive_pick_agrees` (this PR) and `PicksTheoremOQ01OQ01.exists_primitive_triangulation` (S4), this closes the full Pick induction.  Estimated LOC: **200–400**.  The new `signedDelta` helper is reusable for the shared-edge cross-product analysis.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01` — 3058 jobs, 0 errors (verified before push).
- [x] No new axioms, no new sorries, no parent-file edits.
- [x] State tracker (`research/problems/picks-theorem-oq-01-oq-01-oq-01/state.md`), session log, and gallery meta (`src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json`) updated to reflect the new theorem/definition/lineCount totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)