### PR TITLE
research(central-limit-theorem-oq-02-oq-04): S5b build-verify — retire `(build pending)` qualifier (doc-only)

### DIFF
--- a/research/problems/central-limit-theorem-oq-02-oq-04/sessions/2026-05-14-s5b-build-verify.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/sessions/2026-05-14-s5b-build-verify.md
@@ -1,0 +1,109 @@
+# Session 2026-05-14 — S5b build-verify (researcher-9)
+
+## Scope
+
+Doc-only STATE-SYNC retiring the `(build pending)` qualifier on PR #18728
+(S5b ACT — `davydov_indicator_bound`, ingredient 3 of the Davydov L^p
+covariance-inequality decomposition; merged 2026-05-13T10:17:09Z).
+
+## Why this is doc-only
+
+PR #18728 shipped under `(build pending)` citing the host worktree's
+self-referential `proofs/.lake` symlink ("Too many levels of symbolic
+links"). That symlink is irrelevant to `./proofs/scripts/docker-build.sh`,
+which mounts its own `/lean/.lake` inside the Docker container and ignores
+the host directory. This is the canonical false-alarm pattern documented in
+researcher memory (`feedback_researcher_build_pending_dot_lake_symlink_false_alarm.md`).
+
+## Build evidence
+
+From a fresh worktree off `origin/main 2afb1b79c0a`:
+
+```
+./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04
+
+(cold mathlib clone, 7727 cache files downloaded from Azure)
+⚠ [3130/3131] Replayed Proofs.CentralLimitTheoremOQ02
+⚠ [3131/3131] Built Proofs.CentralLimitTheoremOQ02OQ04 (3.3s)
+Build completed successfully (3131 jobs).
+```
+
+Full log: `.loom/logs/researcher-9-clt-s5b-verify-build.log`.
+
+## Sorries surfaced
+
+The expected 2 sorries (matches `meta.json` `sorries: 2`):
+
+* `Proofs/CentralLimitTheoremOQ02OQ04.lean:475:8` — `davydov_covariance_inequality`
+  (L^p Davydov inequality, S5c target ~100 LOC: level-set decomposition +
+  Hölder + Markov).
+* `Proofs/CentralLimitTheoremOQ02OQ04.lean:671:8` — `mixing_clt_ibragimov`
+  (S6+ target: Bernstein blocks + Lindeberg-Feller).
+
+Parent file `Proofs/CentralLimitTheoremOQ02.lean` has its own 3 sorries
+(lines 480, 519, 538), all reused-by-reference and not in scope for this slug.
+
+## Linter warning (out of scope)
+
+```
+Proofs/CentralLimitTheoremOQ02OQ04.lean:419:12: This simp argument is unused:
+  Set.indicator_apply
+```
+
+The `indicator_pair_covariance_eq` proof (S4 contribution from PR #17939,
+**not** part of S5b's contribution) uses
+`by_cases hωA <;> by_cases hωB <;> simp [Set.indicator_apply, Set.mem_inter_iff, hωA, hωB]`,
+where under Mathlib v4.26.0 the four explicit case splits unfold the
+indicator without needing `Set.indicator_apply` in the simp set. Flagged
+here for a future cleanup pass; **not bundled** with this build-verify
+STATE-SYNC to keep scope minimal (cf. PR #19025 cayley-hamilton-minpoly-oq-03-oq-02
+S2 build-verify template).
+
+## State changes
+
+* `research/problems/central-limit-theorem-oq-02-oq-04/state.md`:
+  - Top-of-file `Phase` / `Since` / `Iteration` / `Last Updated` fields advanced.
+  - S5b section retitled to `(researcher-3, 2026-05-13, PR #18728 — …)` (was `this PR`).
+  - Build-status block flipped from `[BUILD PENDING]` to `[BUILD VERIFIED]`
+    with the actual `[3131/3131]` build line, and the symlink-deferral
+    rationale replaced by the Docker-isolation note.
+  - New preamble section above S5b documenting this build-verify session.
+
+* `src/data/research/problems/central-limit-theorem-oq-02-oq-04.json`:
+  - Top-level `phase`: `ORIENT` → `ACT` (gallery-listings drift fix —
+    `phase` is aggregated by `scripts/research/build.ts` into
+    `research-listings.json` consumed by `ResearchPage`; cf. researcher memory
+    `feedback_researcher_state_sync_misses_top_level_phase`).
+  - Top-level `lastUpdate`: `2026-05-12T14:00:00Z` → `2026-05-14T03:50:00Z`.
+  - `currentState.since`: → `2026-05-14T03:50:00Z`.
+  - `currentState.iteration`: `5` → `7` (S5a + S5b shipped between sync points).
+  - `currentState.focus`: rewritten to reflect S5b shipped + build verified.
+  - `currentState.nextAction`: refocused on S5c (was: S5b, now superseded).
+  - `knowledge.progressSummary`: prepended with the S5b-shipped + build-verified note.
+  - `knowledge.nextSteps[0]`: `S5a ACT (mechanic-pass)` → `S5c ACT (~100 LOC)`
+    (S5a/S5b already shipped; next concrete target is the L^p density step).
+
+* No changes to `meta.json` — already reflects post-S5b state
+  (`sorries: 2`, `lineCount: 684`, `theoremCount: 12`, `axiomCount: 0`).
+* No Lean changes.
+
+## Next iteration (S5c)
+
+S5c ACT (~100 LOC): discharge the L^p density step of
+`davydov_covariance_inequality`. All three named order-theory ingredients
+are now build-verified, so the path is purely measure-theoretic:
+
+1. **Level-set decomposition**: write `X = ∫₀^∞ (𝟙_{X>t} − 𝟙_{X<−t}) dt`
+   (similarly for `Y`).
+2. **Bilinear expansion**: expand `Cov(X, Y)` into a double integral
+   `∫∫ Cov(𝟙_{X>s}, 𝟙_{Y>t}) ds dt` over the four indicator pairs.
+3. **Pointwise application**: apply the now-proven `davydov_indicator_bound`
+   inside the integral.
+4. **Hölder + Markov**: bound the integral by
+   `12 · α^{(p−2)/p} · ‖X‖_p · ‖Y‖_p` via Hölder on the truncated piece and
+   Markov's inequality on the tail.
+
+Reference: Doukhan 1994 §1.2.2, Bradley 2007 Vol I Thm 3.7.
+
+Now that the verification pipeline is known good, S5c can ship verified-build
+from day one — no `(build pending)` qualifier needed.

--- a/research/problems/central-limit-theorem-oq-02-oq-04/state.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/state.md
@@ -1,11 +1,45 @@
 # Current State
 
-**Phase**: ACT (S5b — `davydov_indicator_bound` (ingredient 3) discharged)
-**Since**: 2026-05-13T10:30:00Z
-**Iteration**: 6 (theorem count 11 → 12; build-pending — worktree .lake symlink loop)
-**Last Updated**: 2026-05-13 (researcher-3)
+**Phase**: ACT (S5b verified — all 3 Davydov order-theory ingredients proven; L^p density step (S5c) is the only remaining `davydov_covariance_inequality` sorry)
+**Since**: 2026-05-14T03:50:00Z (build-verify confirmation)
+**Iteration**: 7 (S5b build verified; theorem count 12 stable)
+**Last Updated**: 2026-05-14 (researcher-9)
 
-## S5b (researcher-3, 2026-05-13, this PR — ingredient (3) `davydov_indicator_bound`)
+## S5b build-verify (researcher-9, 2026-05-14, this PR — retire `(build pending)` qualifier)
+
+PR #18728 (S5b ACT, merged 2026-05-13T10:17:09Z) shipped under the `(build pending)` qualifier with the stated reason being the worktree `proofs/.lake` self-referential symlink. That symlink does **not** affect `./proofs/scripts/docker-build.sh`, which mounts its own `/lean/.lake` inside the Docker container — the host worktree's `.lake` is irrelevant. Build re-run from a fresh worktree off `origin/main` (sha `2afb1b79c0a`):
+
+```
+./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04
+⚠ [3130/3131] Replayed Proofs.CentralLimitTheoremOQ02
+⚠ [3131/3131] Built Proofs.CentralLimitTheoremOQ02OQ04 (3.3s)
+Build completed successfully (3131 jobs).
+```
+
+Sorries surfaced (the expected 2; same as `meta.json`):
+
+* `Proofs/CentralLimitTheoremOQ02OQ04.lean:475:8` — `davydov_covariance_inequality` (S5c target, L^p density step).
+* `Proofs/CentralLimitTheoremOQ02OQ04.lean:671:8` — `mixing_clt_ibragimov` (S6+ target).
+
+Parent file `Proofs/CentralLimitTheoremOQ02.lean` carries its own 3 sorries (lines 480, 519, 538), all reused-by-reference and not in scope for this slug.
+
+Doc-only changes:
+* `state.md` — flip `[BUILD PENDING]` to `[BUILD VERIFIED]` in the S5b section header below; refresh top-of-file Phase/Since/Iteration/Last Updated.
+* `src/data/research/problems/central-limit-theorem-oq-02-oq-04.json` — top-level `phase: ORIENT → ACT` (drift fix; gallery listings derived from this), `lastUpdate` advanced; `currentState.{phase,since,iteration,focus,nextAction}` refreshed to post-S5b state; `knowledge.progressSummary` and `knowledge.nextSteps[0]` updated. No Lean changes.
+
+**No Lean changes.** PR #18728 shipped a sound proof; this STATE-SYNC just retires the stale `(build pending)` qualifier and resyncs trackers.
+
+### Linter note (out of scope)
+
+The Docker build surfaced one cosmetic linter warning at line 419 in the pre-existing `indicator_pair_covariance_eq` (S4 contribution, shipped via #17939 — **not** part of S5b's contribution):
+
+```
+Proofs/CentralLimitTheoremOQ02OQ04.lean:419:12: This simp argument is unused: Set.indicator_apply
+```
+
+The `by_cases hωA <;> by_cases hωB <;> simp [Set.indicator_apply, Set.mem_inter_iff, hωA, hωB]` proof closes via `simp [Set.mem_inter_iff, hωA, hωB]` alone (under Mathlib v4.26.0, the four explicit cases unfold the indicator without needing the `indicator_apply` lemma in the simp set). Flagged for a future cleanup pass; **not bundled with this build-verify STATE-SYNC** to keep scope minimal per "(build pending)" retirement template (cf. #19025 cayley-hamilton-minpoly-oq-03-oq-02 S2 build-verify).
+
+## S5b (researcher-3, 2026-05-13, PR #18728 — ingredient (3) `davydov_indicator_bound`)
 
 **Davydov structural decomposition — all 3 named order-theory ingredients now proven.**
 
@@ -91,12 +125,20 @@ the proposition hold — exactly the hypothesis we have at the call site.
 
 ### Build status
 
-**[BUILD PENDING]** — Worktree `proofs/.lake` is a self-referential symlink
-(`stat -L proofs/.lake` → "Too many levels of symbolic links"), so
-`./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04` would
-trigger a fresh Mathlib clone (~30–45 min cold) inside Docker, with the
-known risk of mid-build worktree wipe by the daemon respawn. The proof uses
-only Mathlib API verified against `/Users/rwalters/GitHub/mathlib4`:
+**[BUILD VERIFIED]** — researcher-9, 2026-05-14. The S5b qualifier was a
+false alarm: `./proofs/scripts/docker-build.sh` mounts `/lean/.lake` inside
+the Docker container and ignores the host worktree's self-referential
+`proofs/.lake` symlink. Verified from a fresh worktree off
+`origin/main 2afb1b79c0a`:
+
+```
+./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04
+⚠ [3130/3131] Replayed Proofs.CentralLimitTheoremOQ02
+⚠ [3131/3131] Built Proofs.CentralLimitTheoremOQ02OQ04 (3.3s)
+Build completed successfully (3131 jobs).
+```
+
+The proof uses only Mathlib API surfaced in the build:
 
 * `le_ciSup_of_le` (`Mathlib.Order.ConditionallyCompleteLattice.Indexed`
   line 146): `BddAbove (range f) → ∀ i, a ≤ f i → a ≤ ⨆ j, f j`.
@@ -105,9 +147,10 @@ only Mathlib API verified against `/Users/rwalters/GitHub/mathlib4`:
   `(hp : p) → ⨆ h : p, f h = f hp` (works for ℝ as a
   ConditionallyCompletePartialOrder).
 * `Real.iSup_le` (`Mathlib.Data.Real.Archimedean` line 236),
-  `indicator_cov_le_one` (S4, line 229), `Set.range` — already in scope.
+  `indicator_cov_le_one` (S4, line 229), `Set.range` — in scope.
 
-Build verification deferred to doctor / next session from clean worktree.
+Only the expected 2 sorries (`davydov_covariance_inequality` line 475 and
+`mixing_clt_ibragimov` line 671) remain, matching `meta.json`.
 
 ### Next iteration (S5c / S6)
 


### PR DESCRIPTION
## Summary

Verifies the S5b ACT Lean file shipped in #18728 (`davydov_indicator_bound`, ingredient 3 of the Davydov L^p covariance-inequality decomposition; merged 2026-05-13T10:17:09Z) and retires its **(build pending)** qualifier from the slug trackers.

The original session report cited a worktree `proofs/.lake` self-referential symlink as the reason for deferring verification. That obstacle does **not** apply to `./proofs/scripts/docker-build.sh`, which runs in an isolated Docker container with its own `/lean/.lake` mount — the host worktree's `.lake` symlink is irrelevant. Same false-alarm pattern retired in #19025 (cayley-hamilton-minpoly-oq-03-oq-02 S2 build-verify).

## Build

```
./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04
⚠ [3130/3131] Replayed Proofs.CentralLimitTheoremOQ02
⚠ [3131/3131] Built Proofs.CentralLimitTheoremOQ02OQ04 (3.3s)
Build completed successfully (3131 jobs).
```

From a fresh worktree off `origin/main 2afb1b79c0a`. Full log at `.loom/logs/researcher-9-clt-s5b-verify-build.log`.

Only the expected 2 sorries (matches `meta.json` `sorries: 2`):

- `Proofs/CentralLimitTheoremOQ02OQ04.lean:475:8` — `davydov_covariance_inequality` (S5c target).
- `Proofs/CentralLimitTheoremOQ02OQ04.lean:671:8` — `mixing_clt_ibragimov` (S6+ target).

Parent `CentralLimitTheoremOQ02.lean` carries its own 3 sorries (lines 480, 519, 538), all reused-by-reference and not in scope for this slug.

## Linter note (out of scope)

Build surfaced one cosmetic warning at line 419 in the pre-existing `indicator_pair_covariance_eq` (S4 contribution from #17939, **not** part of S5b's contribution):

```
This simp argument is unused: Set.indicator_apply
```

Under Mathlib v4.26.0, the four `by_cases` splits already unfold the indicator without needing `Set.indicator_apply` in the simp set. Flagged for a future cleanup pass; **not bundled** with this build-verify STATE-SYNC to keep scope minimal (per the #19025 template).

## Changes (doc-only)

- `research/problems/central-limit-theorem-oq-02-oq-04/state.md` — flip `[BUILD PENDING]` → `[BUILD VERIFIED]` in the S5b section; refresh top-of-file Phase/Since/Iteration/Last Updated; add preamble section documenting this build-verify session.
- `src/data/research/problems/central-limit-theorem-oq-02-oq-04.json`:
  - **Top-level `phase`: `ORIENT` → `ACT`** (gallery-listings drift fix — `phase` is aggregated by `scripts/research/build.ts` into `research-listings.json` consumed by `ResearchPage`).
  - Top-level `lastUpdate`: `2026-05-12T14:00:00Z` → `2026-05-14T03:50:00Z`.
  - `currentState.{phase,since,iteration,focus,nextAction}` rewritten to reflect S5b shipped + verified.
  - `currentState.iteration`: `5` → `7` (S5a + S5b shipped between sync points).
  - `knowledge.progressSummary` prepended with the S5b-shipped + build-verified note.
  - `knowledge.nextSteps[0]`: `S5a ACT (mechanic-pass)` → `S5c ACT (~100 LOC)` (S5a/S5b already shipped).
- `research/problems/central-limit-theorem-oq-02-oq-04/sessions/2026-05-14-s5b-build-verify.md` — new session log entry.

**No Lean changes**. **No `meta.json` change** (already reflects post-S5b state: `sorries: 2`, `lineCount: 684`, `theoremCount: 12`, `axiomCount: 0`). PR #18728 shipped a sound proof.

## Race check

`gh pr list -R rjwalters/lean-genius --search "central-limit-theorem-oq-02-oq-04 in:title" --state open` returns 5 stale OPEN PRs (S3/S4 build-pending #17810/#17826/#17943/#17947 conflict-frozen against post-S3 main; auditor drift #18439 already superseded by merged #18440). No conflicting STATE-SYNC PRs in flight; this PR's three files do not overlap any of those branches.

## Next iteration (S5c)

S5c ACT (~100 LOC): discharge the L^p density step of `davydov_covariance_inequality`. With all three named order-theory ingredients (`alphaMixingCoeff_le_one`, `alphaMixingCoeff_nonneg`, `davydov_indicator_bound`) now build-verified, the remaining path is purely measure-theoretic: level-set decomposition → bilinear expansion → pointwise `davydov_indicator_bound` → Hölder + Markov. Reference: Doukhan 1994 §1.2.2, Bradley 2007 Vol I Thm 3.7.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ02OQ04` — 3131 jobs, 2 expected sorries, 0 errors (log: `.loom/logs/researcher-9-clt-s5b-verify-build.log`).
- [x] JSON parses; top-level `phase` aligned with `currentState.phase`.
- [x] No Lean changes; PR #18728 file (`CentralLimitTheoremOQ02OQ04.lean`, 684 LOC) builds clean as-merged.
- [x] State.md, JSON tracker, and session log internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)