### PR TITLE
research(szemeredi-core-oq-04): S7-prep ACT — Part 8 B-side bias + biased-vertex Finsets (build verified)

### DIFF
--- a/proofs/Proofs/SzemerediCoreOQ04.lean
+++ b/proofs/Proofs/SzemerediCoreOQ04.lean
@@ -862,4 +862,193 @@ theorem witness_regular_symmetric_implies_epsilon_regular
     exact witness_regular_symmetric_implies_epsilon_regular_small_eps
       G heps hlarge A B hreg
 
+/-! ## Part 8: B-side per-vertex bias + biased-vertex Finsets
+    (S7 scaffold for symmetric second-moment route)
+
+Mirroring Part 6 (A-side `vertexBias` over singleton `{a}`), the
+symmetric second-moment proof of
+`witness_regular_symmetric_implies_epsilon_regular_small_eps` needs a
+dual B-side per-vertex bias `|d(A, {b}) - d(A, B)|` for `b ∈ B`. The
+Markov / Chebyshev step then bounds the count of "biased" vertices on
+BOTH sides using `IsWitnessRegular_symmetric`; subsetting `A' ⊆ A` and
+`B' ⊆ B` predominantly to unbiased vertices closes the slack-4
+implication via a final triangle inequality.
+
+The `A_bad` / `A_good` Finsets (and B-side duals) packaged here are the
+exact objects the S6c PREP §5 / §6.2 averaging argument operates on:
+* `A_bad` collects A-vertices whose density bias **exceeds** `eps`;
+* `A_good` collects A-vertices whose bias is `≤ eps`;
+* their cardinalities sum to `|A|` (`A_bad_add_A_good_card_eq`).
+
+All declarations here are sorry-free. The substantive Markov bound
+`|A_bad| ≤ eps · |A|` is **NOT** proved here — it is the deferred ADLRY
+averaging content in `_small_eps`. Part 8 packages only the
+combinatorial primitives needed to **state** that bound and use it
+once obtained. -/
+
+/-- **B-side per-vertex density bias**: the absolute deviation of the
+edge density between `A` and the singleton `{b}` from the bulk edge
+density `d(A, B)`. Dual to `vertexBias`. Always in `[0, 1]` since
+`edgeDensity ∈ [0, 1]`. -/
+noncomputable def vertexBias_B (G : SimpleGraph V) [DecidableRel G.Adj]
+    (b : V) (A B : Finset V) : ℚ :=
+  |edgeDensity G A {b} - edgeDensity G A B|
+
+/-- B-side per-vertex bias is non-negative (absolute value). -/
+lemma vertexBias_B_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
+    (b : V) (A B : Finset V) :
+    0 ≤ vertexBias_B G b A B :=
+  abs_nonneg _
+
+/-- B-side per-vertex bias is at most `1`, since both densities lie in
+`[0, 1]`. Immediate from `abs_edgeDensity_sub_le_one`. -/
+lemma vertexBias_B_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
+    (b : V) (A B : Finset V) :
+    vertexBias_B G b A B ≤ 1 :=
+  abs_edgeDensity_sub_le_one G A B {b}
+
+/-- **Trivial regime for `vertexBias_B`**: if `1 ≤ eps`, every B-vertex
+is "`eps`-unbiased". Dual of `vertexBias_le_of_one_le`. -/
+lemma vertexBias_B_le_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    (b : V) (A B : Finset V) {eps : ℚ} (heps : 1 ≤ eps) :
+    vertexBias_B G b A B ≤ eps :=
+  (vertexBias_B_le_one G b A B).trans heps
+
+/-- **A-bad vertex set**: the subset of `A`-vertices whose per-vertex
+bias **exceeds** `eps`. The Markov step in the symmetric second-moment
+proof bounds `|A_bad| ≤ eps · |A|` using `IsWitnessRegular` (the
+B-side grid) — see S6c PREP §5. Packaged here as a Finset primitive. -/
+noncomputable def A_bad (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) : Finset V :=
+  A.filter (fun a => eps < vertexBias G a A B)
+
+/-- **A-good vertex set**: complement of `A_bad` inside `A` — vertices
+whose bias is `≤ eps`. Used directly in the final triangle-inequality
+step: for `A' ⊆ A` with `|A'| ≥ 4·eps·|A|`, the unbiased bulk
+`A' ∩ A_good` dominates by `≥ 3/4` once the Markov bound is applied. -/
+noncomputable def A_good (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) : Finset V :=
+  A.filter (fun a => ¬ (eps < vertexBias G a A B))
+
+/-- **B-bad vertex set**: dual to `A_bad`, indexed by B-vertices. -/
+noncomputable def B_bad (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) : Finset V :=
+  B.filter (fun b => eps < vertexBias_B G b A B)
+
+/-- **B-good vertex set**: dual to `A_good`. -/
+noncomputable def B_good (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) : Finset V :=
+  B.filter (fun b => ¬ (eps < vertexBias_B G b A B))
+
+/-- `A_bad ⊆ A`. -/
+lemma A_bad_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    A_bad G eps A B ⊆ A :=
+  Finset.filter_subset _ _
+
+/-- `A_good ⊆ A`. -/
+lemma A_good_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    A_good G eps A B ⊆ A :=
+  Finset.filter_subset _ _
+
+/-- `B_bad ⊆ B`. -/
+lemma B_bad_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    B_bad G eps A B ⊆ B :=
+  Finset.filter_subset _ _
+
+/-- `B_good ⊆ B`. -/
+lemma B_good_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    B_good G eps A B ⊆ B :=
+  Finset.filter_subset _ _
+
+/-- **A-bad membership criterion**. -/
+lemma mem_A_bad (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) (a : V) :
+    a ∈ A_bad G eps A B ↔ a ∈ A ∧ eps < vertexBias G a A B := by
+  unfold A_bad
+  exact Finset.mem_filter
+
+/-- **A-good membership criterion** (in the natural `≤` form). -/
+lemma mem_A_good (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) (a : V) :
+    a ∈ A_good G eps A B ↔ a ∈ A ∧ vertexBias G a A B ≤ eps := by
+  unfold A_good
+  rw [Finset.mem_filter]
+  refine ⟨fun ⟨ha, h⟩ => ⟨ha, not_lt.mp h⟩, fun ⟨ha, h⟩ => ⟨ha, not_lt.mpr h⟩⟩
+
+/-- **B-bad membership criterion**. -/
+lemma mem_B_bad (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) (b : V) :
+    b ∈ B_bad G eps A B ↔ b ∈ B ∧ eps < vertexBias_B G b A B := by
+  unfold B_bad
+  exact Finset.mem_filter
+
+/-- **B-good membership criterion** (in the natural `≤` form). -/
+lemma mem_B_good (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) (b : V) :
+    b ∈ B_good G eps A B ↔ b ∈ B ∧ vertexBias_B G b A B ≤ eps := by
+  unfold B_good
+  rw [Finset.mem_filter]
+  refine ⟨fun ⟨hb, h⟩ => ⟨hb, not_lt.mp h⟩, fun ⟨hb, h⟩ => ⟨hb, not_lt.mpr h⟩⟩
+
+/-- **A-bad + A-good partition `A`**: cardinalities sum to `|A|`.
+Directly from `Finset.filter_card_add_filter_neg_card_eq_card`. -/
+lemma A_bad_add_A_good_card_eq (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    (A_bad G eps A B).card + (A_good G eps A B).card = A.card := by
+  unfold A_bad A_good
+  exact Finset.filter_card_add_filter_neg_card_eq_card _
+
+/-- **B-bad + B-good partition `B`**: dual to `A_bad_add_A_good_card_eq`. -/
+lemma B_bad_add_B_good_card_eq (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    (B_bad G eps A B).card + (B_good G eps A B).card = B.card := by
+  unfold B_bad B_good
+  exact Finset.filter_card_add_filter_neg_card_eq_card _
+
+/-- **Trivial regime: A-bad collapse**. If `1 ≤ eps`, no vertex can be
+`eps`-biased (every `vertexBias ≤ 1 ≤ eps`), so `A_bad = ∅`. -/
+lemma A_bad_eq_empty_of_one_le_eps (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
+    A_bad G eps A B = ∅ := by
+  unfold A_bad
+  apply Finset.filter_eq_empty_iff.mpr
+  intro a _ hbias
+  have hle : vertexBias G a A B ≤ eps := vertexBias_le_of_one_le G a A B heps
+  linarith
+
+/-- **Trivial regime: B-bad collapse**. Dual to `A_bad_eq_empty_of_one_le_eps`. -/
+lemma B_bad_eq_empty_of_one_le_eps (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
+    B_bad G eps A B = ∅ := by
+  unfold B_bad
+  apply Finset.filter_eq_empty_iff.mpr
+  intro b _ hbias
+  have hle : vertexBias_B G b A B ≤ eps := vertexBias_B_le_of_one_le G b A B heps
+  linarith
+
+/-- **Trivial regime: A-good is all of `A`** when `1 ≤ eps`. Companion
+to `A_bad_eq_empty_of_one_le_eps`. -/
+lemma A_good_eq_self_of_one_le_eps (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
+    A_good G eps A B = A := by
+  unfold A_good
+  apply Finset.filter_eq_self.mpr
+  intro a _
+  have hle : vertexBias G a A B ≤ eps := vertexBias_le_of_one_le G a A B heps
+  linarith
+
+/-- **Trivial regime: B-good is all of `B`** when `1 ≤ eps`. -/
+lemma B_good_eq_self_of_one_le_eps (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
+    B_good G eps A B = B := by
+  unfold B_good
+  apply Finset.filter_eq_self.mpr
+  intro b _
+  have hle : vertexBias_B G b A B ≤ eps := vertexBias_B_le_of_one_le G b A B heps
+  linarith
+
 end Szemeredi.OQ04

--- a/research/problems/szemeredi-core-oq-04/sessions/2026-05-14-s7-prep-part8-biased-vertex-finsets.md
+++ b/research/problems/szemeredi-core-oq-04/sessions/2026-05-14-s7-prep-part8-biased-vertex-finsets.md
@@ -1,0 +1,59 @@
+# Session 2026-05-14 — S7-prep ACT (Part 8: B-side bias + biased-vertex Finsets)
+
+**Mode**: FRESH (continuation of Iter 10 / PR #18959 S6c-ACT — Option A symmetric surrogate)
+**Researcher**: researcher-9
+**Iteration**: 11
+**Outcome**: progress — 19 sorry-free declarations added at `Proofs/SzemerediCoreOQ04.lean:866-1054` (Part 8). Sorry count unchanged at 2 (Iter 10 baseline). Build verified via Docker wrapper (7744 jobs, 0 errors).
+
+## What I Did
+
+1. Confirmed Iter 10 / PR #18959 (S6c-ACT) had landed on `origin/main` with build verified (per merged PR title).
+2. Diagnosed the S7 next-action options from Iter 10 state.md:
+   - **S7 ACT (main)**: 200-300 LOC, 2-3 sessions — too big for one session.
+   - **S7 ACT-alt** (Target C, `findRegularPartition`): 100-150 LOC, 1 session, but orthogonal to the Iter 10 sorry and touches an independent area (`SzemerediRegularity.lean:436` integration).
+   - **S7 PREP** (doc-only `problem.md` update): ~30 LOC, but counts against memory-noted 2-per-session STATE-SYNC cap.
+3. Decomposed S7 ACT (main) into its natural sub-steps:
+   - (a) Define the bad/good biased-vertex Finsets + dual B-side bias (combinatorial primitives).
+   - (b) Prove `|A_bad| ≤ eps · |A|` via Markov on `IsWitnessRegular` (substantive `Finset.sum` averaging).
+   - (c) Triangle-inequality final assembly.
+4. Picked sub-step (a) as the deliverable for this session — sorry-free, single-session, no `Finset.sum` calculus.
+5. Wrote Part 8 of `Proofs/SzemerediCoreOQ04.lean` (+189 LOC, 19 sorry-free declarations).
+6. Caught the main-repo-absolute-path Edit trap (memory: `feedback_mechanic_edit_absolute_main_repo_path_silent_drift`) — first Edit attempt landed in main repo (mtime jumped to `May 14 04:59`, line count went to 1054 there but worktree stayed at 865); recovered via `git -C /Users/.../lean-genius checkout HEAD --` and re-applied at worktree-rooted absolute path.
+7. Docker-build verified from worktree CWD (memory: `feedback_researcher_docker_build_cwd_must_be_worktree`) → 7744 jobs, 0 errors, 2 sorries (= Iter 10 baseline).
+8. Updated `state.md` (Iter 11 entry) and JSON (`phase`, `currentState.{phase,since,iteration,focus,nextAction,attemptCounts}`, `knowledge.{insights,builtItems,nextSteps,progressSummary}`, top-level `lastUpdate`).
+9. Wrote this session log.
+
+## Key Findings
+
+- **Filter-with-negated-predicate idiom**: defining `A_good` as `A.filter (fun a => ¬ (eps < vertexBias G a A B))` (syntactic negation) lets `Finset.filter_card_add_filter_neg_card_eq_card` fire directly — no extra lemma needed for the cardinality partition. The good-set membership is then re-exposed in the natural `≤` form via `not_lt.mp` / `not_lt.mpr` (one-line `refine ⟨..., ...⟩`).
+- **Trivial-regime collapse template generalizes cleanly**: same `Finset.filter_eq_empty_iff.mpr` / `Finset.filter_eq_self.mpr` + `linarith` pattern used by Part 5 `*_of_one_le_eps` lemmas extends to both `A_bad`/`A_good` and `B_bad`/`B_good`. Four lemmas, identical structure.
+- **Dual B-side bias mirrors Part 6 exactly**: the only difference from `vertexBias` (A-side, `|d({a}, B) - d(A, B)|`) is which `abs_edgeDensity_sub_le_one*` lemma applies — `abs_edgeDensity_sub_le_one` (no suffix, varies right arg) for the B-side dual, vs `abs_edgeDensity_sub_le_one_left` (varies left arg) for the A-side. Both are in Part 5 (lines 448-478).
+- **Scope discipline**: Part 8 is **prerequisite scaffold**, not the Markov bound itself. The hard `Finset.sum` averaging argument that gives `|A_bad| ≤ eps · |A|` is **deferred to S7 ACT next session**. This keeps the deferred sorry tightly scoped at one location (line 831) and lets Aristotle (or a future researcher) target the Markov bound without having to also reproduce the Finset definitions.
+
+## Files Modified
+
+- `proofs/Proofs/SzemerediCoreOQ04.lean` — +189 lines (Part 8 at lines 866-1054).
+- `src/data/research/problems/szemeredi-core-oq-04.json` — iter 10 → 11; refreshed `phase`, `currentState.*`, `knowledge.*`, `lastUpdate`.
+- `research/problems/szemeredi-core-oq-04/state.md` — added Iter 11 entry at top.
+- `research/problems/szemeredi-core-oq-04/sessions/2026-05-14-s7-prep-part8-biased-vertex-finsets.md` — this file.
+
+## Build
+
+`./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04` (from worktree CWD) → `Build completed successfully (7744 jobs)`. Only linter warnings about unused `[Fintype V]` / `[DecidableEq V]` section variables on the new Part 8 lemmas — pre-existing pattern in the file (also present on Part 6 / Part 7 lemmas merged in Iter 10), not blocking. Log: `.loom/logs/researcher-9-szemeredi-s7-build1.log`.
+
+## Net Delta
+
+| Metric | Iter 10 | Iter 11 | Δ |
+|---|---|---|---|
+| `sorry` count | 2 | 2 | 0 |
+| `axiom` declarations | 0 | 0 | 0 |
+| File line count | 865 | 1054 | +189 |
+| Sorry-free declarations (Part 8) | — | 19 | +19 |
+| Markov-step Finset primitives in place | A-side `vertexBias` only | both sides + 4 Finsets + partition lemmas | ✓ |
+
+## Next Steps
+
+1. **S7 ACT (substantive)**: prove `A_bad_card_le_eps_card` via Markov on per-vertex bias averaged over `witnessFamilyB`. ~40-60 LOC.
+2. **S7 ACT (dual)**: prove `B_bad_card_le_eps_card` from `Dual_IsWitnessRegular`. Mirrors above, ~40-60 LOC.
+3. **S7 ACT (assemble)**: close `witness_regular_symmetric_implies_epsilon_regular_small_eps` via triangle inequality. ~50-80 LOC.
+4. **S7 ACT-alt (still independent)**: build `findRegularPartition` (Target C) using merged `witnessOfIrregular` (#17919). ~100-150 LOC.


### PR DESCRIPTION
## Summary

Iter 11 ACT (S7-prep) on `szemeredi-core-oq-04`. Adds **Part 8** to `proofs/Proofs/SzemerediCoreOQ04.lean` (lines 866-1054, +189 LOC) packaging the Markov-step prerequisites for the deferred symmetric ADLRY content in `witness_regular_symmetric_implies_epsilon_regular_small_eps` (line 831, Iter 10 baseline).

**19 sorry-free declarations**:

| Name | Sort | Purpose |
|---|---|---|
| `vertexBias_B` | `noncomputable def` | B-side per-vertex bias `|d(A, {b}) - d(A, B)|` (dual of Part 6) |
| `vertexBias_B_nonneg` / `_le_one` / `_le_of_one_le` | 3 lemmas | basic bounds + trivial-regime |
| `A_bad` / `A_good` / `B_bad` / `B_good` | 4 noncomputable defs | biased-vertex Finsets |
| `*_subset` | 4 lemmas | subset of base |
| `mem_*` | 4 lemmas | membership criteria (good in natural `≤` form via `not_lt`) |
| `*_bad_add_*_good_card_eq` | 2 lemmas | cardinality partitions via `Finset.filter_card_add_filter_neg_card_eq_card` |
| `*_bad_eq_empty_of_one_le_eps` / `*_good_eq_self_of_one_le_eps` | 4 lemmas | trivial-regime collapse |

**Sorry count unchanged at 2** (Iter 10 baseline: one archival-unprovable at line 291, one deferred-provable at line 831). The substantive Markov bound `|A_bad| ≤ eps · |A|` is **NOT** proved here — Part 8 packages only the combinatorial primitives the deferred averaging step operates on.

## Why this is the right S7-prep deliverable

Iter 10 next-action listed three options:
- **S7 ACT (main)**: 200-300 LOC, 2-3 sessions — too big for one session.
- **S7 ACT-alt** (Target C, `findRegularPartition`): 100-150 LOC, 1 session, orthogonal but touches an independent area.
- **S7 PREP** (doc-only): ~30 LOC, counts against memory-noted 2-per-session STATE-SYNC cap.

S7 ACT (main) decomposes naturally into (a) Finset primitives + dual B-side bias, (b) `Finset.sum` Markov averaging, (c) triangle-inequality assembly. This PR delivers (a) sorry-free in one session; (b) and (c) are left for the next two S7 ACT sessions. Mirrors the successful Iter 5 / Iter 10 scaffold-vs-content separation.

## Build status

Verified via `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04` from worktree CWD: **7744 jobs, 0 errors**, 2 sorries (= Iter 10 baseline). Only linter warnings about unused `[Fintype V]` / `[DecidableEq V]` section variables (pre-existing pattern in this file, also on Part 6 / Part 7 lemmas merged in Iter 10).

Log: `.loom/logs/researcher-9-szemeredi-s7-build1.log`.

## Files Modified

- `proofs/Proofs/SzemerediCoreOQ04.lean` — +189 lines (Part 8).
- `src/data/research/problems/szemeredi-core-oq-04.json` — iter 10 → 11; refreshed `phase`, `currentState.{phase,since,focus,nextAction,attemptCounts}`, `knowledge.{insights,builtItems,nextSteps,progressSummary}`, top-level `lastUpdate`.
- `research/problems/szemeredi-core-oq-04/state.md` — added Iter 11 entry at top.
- `research/problems/szemeredi-core-oq-04/sessions/2026-05-14-s7-prep-part8-biased-vertex-finsets.md` — new session log.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.SzemerediCoreOQ04` from worktree CWD passes (7744 jobs, 0 errors).
- [x] Sorry count unchanged (still 2 — at lines 291 and 831).
- [x] No new axioms.
- [x] JSON `phase` (top-level) and `currentState.phase` both set to `"ACT"` (per `feedback_researcher_state_sync_misses_top_level_phase.md`).
- [x] JSON encoding aligned with origin/main (`ensure_ascii=True`, no churn in unaffected fields).
- [x] No open PRs touched this slug at PR-creation time.

## Next action (S7 ACT substantive — next session)

1. **`A_bad_card_le_eps_card`**: `IsWitnessRegular G eps A B → ((A_bad G eps A B).card : ℚ) ≤ eps * A.card` via Markov on per-vertex bias averaged over `witnessFamilyB`. ~40-60 LOC.
2. **`B_bad_card_le_eps_card`** (dual): from `Dual_IsWitnessRegular`. ~40-60 LOC.
3. **`witness_regular_symmetric_implies_epsilon_regular_small_eps` final assembly**: triangle inequality on `A' ⊆ A`, `B' ⊆ B` with `|A'| ≥ 4·eps·|A|`, `|B'| ≥ 4·eps·|B|`. ~50-80 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
