### PR TITLE
fix(mechanic): knights-tour-oblique v4.26.0 Tier 1+2 (7 deprecations + 1 dup)

### DIFF
--- a/proofs/Proofs/KnightsTourOblique.lean
+++ b/proofs/Proofs/KnightsTourOblique.lean
@@ -455,7 +455,7 @@ theorem tourMoves_getElem_63 (t : ClosedTour) :
     rw [@List.getElem_append_right _ _ t.squares.tail [t.squares.head t.nonempty] h_not_lt _ h'']
     simp only [htail_len, Nat.sub_self, List.getElem_singleton]
   have h63_fst : t.squares[63]'(by rw [t.length_eq]; omega) = t.squares.getLast t.nonempty := by
-    simp only [List.getLast_eq_get, List.get_eq_getElem]
+    simp only [List.getLast_eq_getElem]
     congr 1
     simp [t.length_eq]
   simp only [h63_snd, h63_fst]
@@ -479,7 +479,7 @@ theorem no_turn_angle_4_at_62 (t : ClosedTour) :
   -- moves[63] = getMoveVector(s1, s2) where s1 = getLast
   have hmv2 : (tourMoves t)[63]'(by rw [tourMoves_length]; omega) = getMoveVector s1 s2 := by
     have h63 : t.squares[63]'(by rw [t.length_eq]; omega) = t.squares.getLast t.nonempty := by
-      simp only [List.getLast_eq_get, List.get_eq_getElem]
+      simp only [List.getLast_eq_getElem]
       congr 1
       simp [t.length_eq]
     rw [tourMoves_getElem_63]
@@ -489,7 +489,7 @@ theorem no_turn_angle_4_at_62 (t : ClosedTour) :
   have hadj12 : knightGraph.Adj s1 s2 := by
     -- s1 = squares[63] = getLast, s2 = head
     have h63 : s1 = t.squares.getLast t.nonempty := by
-      simp only [List.getLast_eq_get, List.get_eq_getElem, t.length_eq]
+      simp only [List.getLast_eq_getElem, t.length_eq]
     rw [h63]
     exact t.closes
   -- Turn angle is 4
@@ -532,7 +532,7 @@ theorem no_turn_angle_4_at_63 (t : ClosedTour) :
   -- moves[63] = getMoveVector(s0, s1)
   have hmv1 : (tourMoves t)[63]'(by rw [tourMoves_length]; omega) = getMoveVector s0 s1 := by
     have h63 : t.squares[63]'(by rw [t.length_eq]; omega) = t.squares.getLast t.nonempty := by
-      simp only [List.getLast_eq_get, List.get_eq_getElem, t.length_eq]
+      simp only [List.getLast_eq_getElem, t.length_eq]
     have hhead : t.squares[0]'(by rw [t.length_eq]; omega) = t.squares.head t.nonempty :=
       List.getElem_zero (by rw [t.length_eq]; omega)
     -- Goal after tourMoves_getElem_63: getMoveVector getLast head = getMoveVector s0 s1
@@ -549,7 +549,7 @@ theorem no_turn_angle_4_at_63 (t : ClosedTour) :
     -- s0 = squares[63] = getLast, s1 = squares[0] = head
     -- t.closes says Adj getLast head
     have h63 : s0 = t.squares.getLast t.nonempty := by
-      simp only [List.getLast_eq_get, List.get_eq_getElem, t.length_eq]
+      simp only [List.getLast_eq_getElem, t.length_eq]
     have hhead : s1 = t.squares.head t.nonempty :=
       List.getElem_zero (by rw [t.length_eq]; omega)
     rw [h63, hhead]
@@ -682,7 +682,7 @@ theorem tour_winding_zero (t : ClosedTour) :
   simp only [tourDirections]
   intro h
   have hlen := tourMoves_length t
-  rw [List.map_eq_nil] at h
+  rw [List.map_eq_nil_iff] at h
   simp [h] at hlen
 
 /-- The 4 corner squares of the board -/
@@ -883,12 +883,6 @@ theorem corner_forces_oblique (s prev next : Square)
   · exact corner07_forces_oblique prev next hadj_prev hadj_next hno_rev
   · exact corner70_forces_oblique prev next hadj_prev hadj_next hno_rev
   · exact corner77_forces_oblique prev next hadj_prev hadj_next hno_rev
-
-/-- Consecutive squares in a tour are knight-adjacent -/
-theorem tour_consecutive_adj (t : ClosedTour) (i : Nat) (hi : i + 1 < 64) :
-    knightGraph.Adj (t.squares[i]'(by omega)) (t.squares[i + 1]'(by rw [t.length_eq]; omega)) := by
-  have h := t.path i (by rw [t.length_eq]; omega)
-  convert h using 2 <;> simp [t.length_eq]
 
 /-- In a closed tour, the square at index i is adjacent to square at (i+1) mod 64 -/
 theorem tour_cyclic_adj (t : ClosedTour) (i : Fin 64) :
@@ -1964,7 +1958,7 @@ theorem tourPairs_adj_63 (t : ClosedTour) :
   simp only [h63_snd]
   -- squares[63] is the last element
   have h63_fst : t.squares[63]'(by rw [t.length_eq]; omega) = t.squares.getLast t.nonempty := by
-    simp only [List.getLast_eq_get, List.get_eq_getElem]
+    simp only [List.getLast_eq_getElem]
     congr 1
     simp [t.length_eq]
   simp only [h63_fst]


### PR DESCRIPTION
## Fix

Apply Tier 1 deprecation renames (7 sites) + Tier 2 duplicate-decl removal (1 site) for `proofs/Proofs/KnightsTourOblique.lean`, per the 6-tier mechanic-handoff inventory in PR #19027 (S5 STATE-SYNC).

## Evidence

**Tier 1 — v4.26.0 deprecation renames (7 sites, single-line):**

| Lines | Before | After |
|---|---|---|
| 458, 482, 492, 535, 552, 1967 | `List.getLast_eq_get, List.get_eq_getElem` | `List.getLast_eq_getElem` |
| 685 | `List.map_eq_nil` | `List.map_eq_nil_iff` |

`get_eq_getElem` becomes redundant since `getLast_eq_getElem` rewrites `getLast` directly to `getElem`. The new lemma lives in Lean stdlib `Init/Data/List/Lemmas.lean:780`; `map_eq_nil_iff` at line 1106.

**Tier 2 — duplicate declaration removal (1 site):**

Removed duplicate `tour_consecutive_adj` at original lines 887-891. The canonical copy at line 342 is referenced by name throughout the file.

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.KnightsTourOblique
# Baseline (origin/main): 101 errors (maxErrors=100 cap)
#   includes errors at lines 458/482/492/535/552/685/888/1967 (Tier 1+2)
# Post-fix: 101 errors (cap), all 8 Tier 1+2 sites CLEARED
```

Logs:
- `.loom/logs/mechanic-3-knights-baseline.log` (pre-fix, 28 unique error lines)
- `.loom/logs/mechanic-3-knights-build4.log` (post-fix, 28 unique error lines — same count because maxErrors cap absorbs newly-surfaced Tier 3-6 errors that were previously hidden by Tier 1+2 failure)

## Deferred (out of scope this PR)

The 2 `List.getElem_cons_succ_eq_getElem_tail` sites at original lines 1064 and 1103 are LEFT UNCHANGED. The inventory listed these as "Tier 1 single-line renames" but the lemma is **removed** in v4.26.0 (not renamed), and the surrounding code uses `GetElem [Fin _]` vs `GetElem [Nat]` instances in a way that resists a 1-line rewrite. Verified during this session via 3 Docker iterations attempting `List.getElem_cons + dif_neg hjpos` and explicit-proof-annotation variants; both blocked by syntactic-form mismatch at `rw [hcons] at hspec` (Fin-indexed `hspec` does not match Nat-indexed `hcons`).

These two sites are mechanic-scope but require Tier 5-style case-by-case refactoring (introduce explicit Fin→Nat coercion + reshape `hspec`). Left for the next mechanic claim.

## Recommended next

Per the inventory's 5-iteration plan:
- **Iter 2 (next):** Tier 3 motive-not-type-correct refactors at lines 975/981/1192/1210/1226/1242 (~30-50 LOC).
- **Iter 3:** Tier 4 `failed to prove index is valid` at lines 899/901 (~10 LOC).
- **Iter 4-5:** Tier 5 case-by-case (including the 2 deferred `getElem_cons_succ_eq_getElem_tail` sites) + Tier 6 cascade re-verification.

Refs #19027

---
Automated fix by lean-mechanic agent (mechanic-3 slot).
