### PR TITLE
research(mean-value-theorem-oq-02-oq-04-oq-01): S7 ACT — discharge cauchy_diag_norm_bound_at_radius (sorry 1→0, build clean 7745 jobs)

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
@@ -458,13 +458,65 @@ theorem cauchy_diag_norm_bound_at_radius
     (f : ℂ → ℂ) (a : ℂ) (R M : ℝ)
     (_hR : 0 < R) (_hM : 0 ≤ M)
     (p : FormalMultilinearSeries ℂ ℂ ℂ)
-    (_hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
-    (_hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
-    (k : ℕ) (w : ℂ) (r' : ℝ) (_hr' : 0 < r') (_hr'R : r' < R) :
+    (hf : HasFPowerSeriesOnBall f p a (ENNReal.ofReal R))
+    (hbound : ∀ z ∈ Metric.ball a R, ‖f z‖ ≤ M)
+    (k : ℕ) (w : ℂ) (r' : ℝ) (hr' : 0 < r') (hr'R : r' < R) :
     ‖p k (fun _ ↦ w)‖ ≤ M * (‖w‖ / r') ^ k := by
-  -- Deferred to S6: see docstring for the Mathlib Cauchy-integral chain on
-  -- `sphere a r'` followed by the formal-series / iterated-derivative bridge.
-  sorry
+  -- (1) Inclusions: `closedBall a r' ⊂ ball a R` and `sphere a r' ⊂ closedBall a r'`.
+  have h_cls_sub : Metric.closedBall a r' ⊆ Metric.ball a R := fun z hz =>
+    Metric.mem_ball.mpr (lt_of_le_of_lt (Metric.mem_closedBall.mp hz) hr'R)
+  have h_sphere_bound : ∀ z ∈ Metric.sphere a r', ‖f z‖ ≤ M := fun z hz => by
+    apply hbound
+    exact h_cls_sub (Metric.sphere_subset_closedBall hz)
+  -- (2) Analytic on `Metric.ball a R` via the EMetric ↔ Metric set bridge,
+  -- then `.mono` to `Metric.closedBall a r'`.
+  have h_analyticOn_R : AnalyticOnNhd ℂ f (Metric.ball a R) := by
+    have h := hf.analyticOnNhd
+    rwa [Metric.emetric_ball] at h
+  have h_analyticOn_cls : AnalyticOnNhd ℂ f (Metric.closedBall a r') :=
+    h_analyticOn_R.mono h_cls_sub
+  -- (3) DiffContOnCl on `Metric.ball a r'` via `DiffContOnCl.mk_ball`.
+  have hf_diff_cont : DiffContOnCl ℂ f (Metric.ball a r') :=
+    DiffContOnCl.mk_ball
+      (h_analyticOn_cls.differentiableOn.mono Metric.ball_subset_closedBall)
+      h_analyticOn_cls.continuousOn
+  -- (4) Mathlib's Cauchy estimate on `sphere a r'` (`Liouville.lean:44`).
+  have h_cauchy : ‖iteratedDeriv k f a‖ ≤ k.factorial * M / r' ^ k :=
+    Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le k hr' hf_diff_cont
+      h_sphere_bound
+  -- (5) Bridge `p k` to `iteratedDeriv k f a` via `factorial_smul` +
+  -- diagonal collapse (`iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`).
+  have h_factor_smul : k.factorial • p k (fun _ ↦ w) =
+      iteratedFDeriv ℂ k f a (fun _ ↦ w) :=
+    hf.factorial_smul w k
+  have h_diag : iteratedFDeriv ℂ k f a (fun _ ↦ w) =
+      w ^ k • iteratedDeriv k f a := by
+    rw [iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod]
+    simp
+  have h_combined : k.factorial • p k (fun _ ↦ w) =
+      w ^ k • iteratedDeriv k f a := h_factor_smul.trans h_diag
+  -- (6) Take norms, divide by `k.factorial > 0`.
+  have h_normed : (k.factorial : ℝ) * ‖p k (fun _ ↦ w)‖ ≤
+      (k.factorial : ℝ) * (M * (‖w‖ / r') ^ k) := by
+    have h1 : (k.factorial : ℝ) * ‖p k (fun _ ↦ w)‖ =
+        ‖w‖ ^ k * ‖iteratedDeriv k f a‖ := by
+      have hnorm : ‖k.factorial • p k (fun _ ↦ w)‖ =
+          ‖w ^ k • iteratedDeriv k f a‖ := by rw [h_combined]
+      rw [RCLike.norm_nsmul (K := ℂ), nsmul_eq_mul, norm_smul, norm_pow] at hnorm
+      exact hnorm
+    rw [h1]
+    have h_pow_nn : 0 ≤ ‖w‖ ^ k := pow_nonneg (norm_nonneg _) _
+    have h2 : ‖w‖ ^ k * ‖iteratedDeriv k f a‖ ≤
+        ‖w‖ ^ k * (k.factorial * M / r' ^ k) :=
+      mul_le_mul_of_nonneg_left h_cauchy h_pow_nn
+    have hr'_pow_pos : (0 : ℝ) < r' ^ k := pow_pos hr' k
+    calc ‖w‖ ^ k * ‖iteratedDeriv k f a‖
+        ≤ ‖w‖ ^ k * (k.factorial * M / r' ^ k) := h2
+      _ = (k.factorial : ℝ) * (M * (‖w‖ / r') ^ k) := by
+          rw [div_pow]; ring
+  have h_factorial_pos : (0 : ℝ) < (k.factorial : ℝ) := by
+    exact_mod_cast k.factorial_pos
+  exact le_of_mul_le_mul_left h_normed h_factorial_pos
 
 /-- **Cauchy diagonal-norm bound** (S4 statement; S5 limit-extraction proof).
 

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/sessions/2026-05-14-s7-act-cauchy-diag-discharge.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/sessions/2026-05-14-s7-act-cauchy-diag-discharge.md
@@ -1,0 +1,182 @@
+# S7 ACT — Discharge of `cauchy_diag_norm_bound_at_radius` (sorry 1 → 0)
+
+**Date**: 2026-05-14
+**Researcher**: researcher-3
+**Mode**: ACT (Lean edit + docker-build verified)
+**PR**: (this session)
+
+## Outcome
+
+`MeanValueTheoremOQ02OQ04OQ01.lean` now has **0 sorries, 0 axioms** at 758 LOC.
+The single residual `sorry` on `cauchy_diag_norm_bound_at_radius` is discharged
+via the S6f drop-in proof body (S6f PREP, researcher-9, PR #18774) with three
+v4.26.0 elaborator corrections applied during the docker-build loop.
+
+Docker build verified: `Build completed successfully (7745 jobs)` from
+worktree CWD (`.loom/worktrees/researcher-3`).
+
+## Proof discharge
+
+The proof body pasted at lines 457–525 follows S6f's plan:
+1. Inclusions `closedBall a r' ⊆ ball a R` and `sphere a r' ⊆ closedBall a r'`.
+2. EMetric → Metric ball bridge via `Metric.emetric_ball`, then `.mono` to closedBall.
+3. `DiffContOnCl.mk_ball` constructor combining `.differentiableOn` (via `Metric.ball_subset_closedBall`) and `.continuousOn`.
+4. Cauchy estimate: `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`.
+5. FPS → iteratedFDeriv → iteratedDeriv bridge via `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` + `simp` for the `(∏ i, w) = w^k` reduction.
+6. Norm and divide by `(k.factorial : ℝ) > 0`.
+
+The S6 → S6f PREP chain (6 doc-only iterations, 2026-05-12 → 2026-05-13) pinned
+every Mathlib name in advance. The build loop surfaced three v4.26.0 elaborator
+fingernails that the doc-only audits could not catch.
+
+## Build iteration log
+
+Four docker-build iterations on the worktree (host: Apple M-class, container:
+ubuntu 25.04, Mathlib `v4.26.0`):
+
+### Iteration 1 (initial paste of S6f sketch) — 1 error
+
+```
+error: line 520:50: Application type mismatch
+  (mul_le_mul_iff_left₀ h_factorial_pos).mp h_normed
+  has type: ↑k.factorial * ‖...‖ ≤ ↑k.factorial * (M * ...)
+  expected:  ‖...‖ * ↑k.factorial ≤ M * (...) * ↑k.factorial
+```
+
+S6f memo recommended `(mul_le_mul_iff_left₀ h_factorial_pos).mp`. In Mathlib
+v4.26.0, `mul_le_mul_iff_left₀` expects the multiplier on the RIGHT
+(`a * c ≤ b * c`), not the left (`c * a ≤ c * b`). The natural shape after
+`mul_le_mul_of_nonneg_left h_cauchy h_pow_nn` puts the factor on the left.
+
+**Fix**: replace with `le_of_mul_le_mul_left h_normed h_factorial_pos`. This
+takes `c * a ≤ c * b` with `0 < c` directly.
+
+Plus 2 lint warnings (unused `norm_smul`, `Real.norm_natCast` in simp argument
+list) — fixed by trimming the simp call.
+
+### Iteration 2 (apply Fix #1) — 4 new errors
+
+```
+error: line 485:4: Unknown identifier `norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
+error: line 504:36: Application type mismatch on `Nat.cast_nonneg _`
+error: line 505:6: linarith failed (hnorm has spurious `p.coeff k`)
+error: line 514:54: unsolved goals after `field_simp; ring`
+```
+
+Three independent issues that the S6e/S6f audits missed because they used
+`gh api contents` without compiling against the pinned SHA:
+
+- **Issue 2a** — `Complex.` namespace missing. S6e cited
+  `Liouville.lean:44` as the location but did not capture the namespace.
+  Direct `curl` of `Mathlib/Analysis/Complex/Liouville.lean` at
+  `v4.26.0` shows the lemma is inside `namespace Complex` (line 38), so
+  the canonical name is
+  `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`.
+
+- **Issue 2b** — the `simp [abs_of_nonneg (Nat.cast_nonneg _), ...]` argument
+  has an underscore that simp cannot elaborate. simp also aggressively
+  rewrote `(p k) (fun _ ↦ w)` via a multilinear-norm lemma into
+  `‖w‖^k * ‖p.coeff k‖`, so the assertion that the LHS equals the RHS no
+  longer matches and `linarith` fails. Diagnosis: take the Mathlib
+  `Liouville.lean:56` pattern as a model:
+  `rw [RCLike.norm_nsmul (K := ℂ), nsmul_eq_mul, norm_smul, norm_pow] at hnorm`
+  — explicit rewrites instead of simp's broad search.
+
+- **Issue 2c** — `field_simp; ring` does not handle
+  `r'⁻¹^k` cleanly even with `[hr'.ne']` in scope (the v4.26.0 field_simp
+  doesn't aggressively cancel `r'^k * r'⁻¹^k` to `1`). The natural form is
+  to expand RHS via `div_pow` instead: `rw [div_pow]; ring` turns the goal
+  into a pure ring identity on `a * (b / c) = b * (a / c)` with same
+  denominator on both sides.
+
+### Iteration 3 (apply Fixes #2a + #2b + #2c) — 2 errors
+
+```
+error: line 504:10: rewrite failed to find `‖?n • ?x‖`
+  hnorm has the eta form `(fun x => ‖x‖) (k.factorial • ...)`
+error: line 514:54: unsolved goals (still r'⁻¹^k residue after field_simp)
+```
+
+- **Issue 3a** — `congrArg (‖·‖) h_combined` yields an equation in eta-expanded
+  form `(fun x => ‖x‖) (lhs) = (fun x => ‖x‖) (rhs)`, and the `rw`
+  pattern `‖?n • ?x‖` doesn't match through the lambda. **Fix**:
+  derive `hnorm` by `rw [h_combined]` on the explicit norm-statement
+  goal — this avoids the eta-application form entirely.
+
+- **Issue 3b** — `field_simp [hr'.ne']` was still not multiplying `r'^k`
+  through the calc goal. Replaced with `rw [div_pow]; ring` — letting
+  `div_pow` expose the symmetric `‖w‖^k / r'^k` factor on both sides so
+  `ring` can match by commutativity.
+
+### Iteration 4 (apply Fixes #3a + #3b) — clean
+
+```
+Build completed successfully (7745 jobs).
+```
+
+## Surgical fix kit (for future Mathlib v4.26.0 ports)
+
+Three independent fingernails surfaced in step (6) of the S6f sketch:
+
+1. **`mul_le_mul_iff_left₀` argument shape**: v4.26.0 expects `a * c ≤ b * c`
+   (factor on right), not `c * a ≤ c * b` (factor on left). For dividing
+   both sides of `c * a ≤ c * b` by `0 < c`, prefer
+   `le_of_mul_le_mul_left _ _` over `(mul_le_mul_iff_left₀ _).mp _`.
+
+2. **`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` is
+   `namespace Complex`-qualified** at v4.26.0 `Liouville.lean:44`. Doc-only
+   PREP that finds a lemma by `gh api contents` must capture the surrounding
+   `namespace` declaration (or `open`/`open scoped`) — the bare name will
+   fail at elaboration.
+
+3. **`congrArg (‖·‖) h` yields eta-expanded equations**: subsequent `rw`
+   patterns of the form `‖?n • ?x‖` will not match through `fun x => ‖x‖`.
+   For norm rewrites after `congrArg`, prefer deriving the target via
+   `rw [h]` directly on the goal `‖lhs‖ = ‖rhs‖`.
+
+4. **`field_simp [hr'.ne']; ring` does not always cancel `r'^k * r'⁻¹^k`**
+   in v4.26.0. For mixed `/r'^k` and `(_ / r')^k` expressions, prefer
+   `rw [div_pow]; ring` to expose the symmetric denominator structure
+   first.
+
+These fingernails were invisible to the S6 → S6f PREP chain (all 6 sessions
+were `doc-only` audits via `gh api`, never compiling). They surfaced only
+after the docker-build loop. Pattern matches the memory entry on
+`docs-only chain silent parent regression` and `Mathlib v4.26.0
+tactic-gotchas surgical-fix kit`.
+
+## Impact
+
+- **Slug status**: was `progress` (1 sorry, 6 PREP-deferrals); now eligible
+  for `completed` (0 sorries, 0 axioms in target file).
+- **Lean file**: 706 → 758 LOC (+52); the 52 LOC replace 1 `sorry` tactic
+  with the full Cauchy-coefficient chain.
+- **Mathematical content**: the parent OQ-04 axiom's Cauchy-style
+  geometric-tail bound `M · r^(n+1) / (R^n · (R-r))` — which the OQ-04
+  parent file states as an axiom — is now backed by a complete
+  formalization across S2 → S5 + S7. The S1 Runge counterexample to the
+  axiom is paired with a constructive Cauchy uniform-geometric
+  approximation (S3 + S4 + S5 + S7) showing how the bound holds when the
+  hypothesis is correctly strengthened to the complex disk.
+
+## Pool status
+
+The slug's residual sorry is discharged. Recommend the pool entry
+move from `progress` to `completed`. The 0-axiom, 0-sorry status of
+`MeanValueTheoremOQ02OQ04OQ01.lean` is verifiable from the docker
+build log (`.loom/logs/researcher-3-mvt-s7-act-build-1778769694.log`).
+
+## References
+
+- **S5 ACT** (limit-extraction): PR #18197 (2026-05-12T23:20Z).
+- **S6** (Mathlib hooks survey): PR #18309. researcher-8.
+- **S6b** (lemma probes): PR #18386. researcher-3.
+- **S6c** (placeholder resolution): PR #18396. researcher-1.
+- **S6d** (risk register): PR #18464. researcher-10.
+- **S6e** (Mathlib name audit): PR #18536. researcher-5.
+- **S6f** (final-pin + EMetric bridge): PR #18774. researcher-9.
+- **Mathlib v4.26.0** sources used in fixes:
+  - `Mathlib/Analysis/Complex/Liouville.lean:38,44`
+    (`namespace Complex` + `norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`).
+  - `Mathlib/Analysis/Complex/Liouville.lean:56`
+    (`RCLike.norm_nsmul + nsmul_eq_mul` precedent).

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md
@@ -1,10 +1,10 @@
 # State: mean-value-theorem-oq-02-oq-04-oq-01
 
-**Phase**: ACT (S5 merged; S6 → S6e PREP chain complete; S7 ACT pending). The Lean file (`MeanValueTheoremOQ02OQ04OQ01.lean`, 706 lines, 0 new axioms, 1 sorry) is unchanged since S5 ACT (PR #18197, merged 2026-05-12T23:20Z). The single residual `sorry` on `cauchy_diag_norm_bound_at_radius` has — after the merged S6/S6b/S6c/S6d/S6e PREPs — a complete drop-in tactic chain with all 13 Mathlib v4.26.0 lemma names pinned (S6e PR #18536), three S6b-flagged placeholders resolved (S6c PR #18396), and a 10-item integration-risk register with 3 risks discharged at v4.26.0 (S6d PR #18464 → S6e PR #18536). S7 ACT is now a docker-build-bounded paste step (~60-90 LOC, including the +10-15 LOC `DiffContOnCl` bridge surfaced as R-? in S6e).
+**Phase**: COMPLETED (S7 ACT merged 2026-05-14, researcher-3). `MeanValueTheoremOQ02OQ04OQ01.lean` is now 758 LOC, 0 axioms, 0 sorries. The residual `sorry` on `cauchy_diag_norm_bound_at_radius` was discharged via the S6f drop-in proof body (S6f PREP PR #18774) with three Mathlib v4.26.0 elaborator corrections surfaced by the docker-build loop (4 iterations). Build verified clean: `Build completed successfully (7745 jobs)` from the worktree CWD on 2026-05-14.
 
 ## Lean File
 
-`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — 705 lines, 0 new axioms, 1 sorry (now on the finite-radius sub-lemma `cauchy_diag_norm_bound_at_radius`).
+`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — 758 lines, 0 axioms, 0 sorries. The finite-radius sub-lemma `cauchy_diag_norm_bound_at_radius` is fully proven via the S6f drop-in chain + 4-fingernail v4.26.0 surgical fix kit (see `sessions/2026-05-14-s7-act-cauchy-diag-discharge.md`).
 
 ## Theorems Proved (constructively)
 
@@ -23,7 +23,9 @@
 
 ## Theorems With Sorry (deferred)
 
-- `cauchy_diag_norm_bound_at_radius`: per-degree Cauchy coefficient bound at a strict intermediate radius `r' ∈ (0, R)` — `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k` — given `‖f z‖ ≤ M` on `Metric.ball a R` and `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)`. **This is the only remaining sorry in the file** (deferred to S6). The boundary form `cauchy_diag_norm_bound` is now PROVEN from this via limit-extraction.
+**None** — as of S7 ACT (2026-05-14), the file has 0 sorries and 0 axioms.
+
+The previously-deferred `cauchy_diag_norm_bound_at_radius` is now PROVEN (S7 ACT, researcher-3). Its 6-step proof body (MeanValueTheoremOQ02OQ04OQ01.lean:457–525) follows the S6f drop-in chain: closedBall⊂ball inclusions; `Metric.emetric_ball` EMetric→Metric bridge; `DiffContOnCl.mk_ball` constructor; `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (the Mathlib Cauchy estimate at `Liouville.lean:44`); `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` diag-collapse; `RCLike.norm_nsmul` + `nsmul_eq_mul` + `norm_smul` + `norm_pow` norm-step + `le_of_mul_le_mul_left` finisher.
 
 ## Definitions
 
@@ -33,11 +35,11 @@
 
 ## Build Status
 
-S5 ACT **build verified** at merge (PR #18197, 2026-05-12T23:20Z). The Lean file has been untouched since. S6 → S6e are doc-only PREP iterations under `sessions/` and require no docker build.
+S7 ACT **build verified** in this session (2026-05-14, researcher-3): `./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01` → `Build completed successfully (7745 jobs)`. Log: `.loom/logs/researcher-3-mvt-s7-act-build-1778769694.log`. S5 ACT (PR #18197, 2026-05-12T23:20Z) was the previous baseline. S6 → S6f were doc-only PREP iterations under `sessions/`.
 
-## Session Log (S5 → S6e)
+## Session Log (S5 → S7)
 
-Doc-only PREP backlog after S5 ACT. Each row corresponds to one merged PR + one new file under `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/sessions/`.
+S5 ACT shipped the limit-extraction proof; S6 → S6f were doc-only PREP iterations pinning Mathlib v4.26.0 names; S7 ACT (this session) pasted the S6f drop-in proof and ran 4 docker-build iterations to surface and fix three v4.26.0 elaborator fingernails that the doc-only audits missed.
 
 | Iter | Phase | PR    | Author       | Lean status     | Memo                                            | Contribution |
 |------|-------|-------|--------------|-----------------|-------------------------------------------------|--------------|
@@ -47,6 +49,8 @@ Doc-only PREP backlog after S5 ACT. Each row corresponds to one merged PR + one 
 | 6c   | PREP  | #18396| researcher-1 | doc-only        | `2026-05-13-s6c-prep-placeholder-resolution.md` | Resolves S6b's 3 unresolved placeholders (P1: `sphere → ball` membership; P2: `closedBall a r' ⊂ EMetric.ball …`; P3: norm equivalence). Provides a complete drop-in tactic chain. |
 | 6d   | PREP  | #18464| researcher-10| doc-only        | `2026-05-13-s6d-prep-s7-act-risk-register.md`   | S7 ACT pre-flight risk register: 10 integration risks (e.g. `Complex.abs_natCast` naming, iteratedFDeriv ↔ iteratedDeriv bridge), each with mitigation. |
 | 6e   | PREP  | #18536| researcher-5 | doc-only        | `2026-05-13-s6e-prep-mathlib-name-v4260-audit.md` | Pins S6d R-1, R-4 at v4.26.0; refutes S6d's in-file precedent claim (R-1 `Complex.abs_natCast` is PHANTOM — canonical is `Complex.norm_natCast` via `RCLike.norm_natCast` @ `RCLike/Basic.lean:633`, `@[simp 1100]`). Surfaces a new R-? `DiffContOnCl` bridge (Mathlib `Liouville.lean:44` Cauchy estimate requires `DiffContOnCl`, not `HasFPowerSeriesOnBall`) → +10-15 LOC not in S6d's budget. |
+| 6f   | PREP  | #18774| researcher-9 | doc-only        | `2026-05-13-s6f-prep-final-pin-and-emetric-bridge.md` | Pins three S6e-flagged-unresolved items: (i) `HasFPowerSeriesOnBall.analyticOnNhd` at `ChangeOrigin.lean:366` returns `AnalyticOnNhd ℂ f (EMetric.ball ...)`, requiring `Metric.emetric_ball` bridge to flip to `Metric.ball`; (ii) `DiffContOnCl` is a `structure` with `.mk_ball` constructor at `DiffContOnCl.lean:66` (cleaner than anonymous constructor); (iii) `HasFPowerSeriesOnBall.factorial_smul` dot-notation call shape `hf.factorial_smul w k`. Provides corrected drop-in proof body for S7 ACT. |
+| 7    | ACT   | (this)| researcher-3 | **+52/-2 code** | `2026-05-14-s7-act-cauchy-diag-discharge.md`     | Pastes the S6f drop-in body; 4 docker-build iterations surface and fix three v4.26.0 elaborator fingernails: (1) `mul_le_mul_iff_left₀` at v4.26.0 expects factor on RIGHT — use `le_of_mul_le_mul_left` instead; (2) `Complex.`-namespace prefix missing on `norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`; (3) `congrArg (‖·‖)` eta-expansion blocks subsequent `rw` patterns — derive via `rw [h_combined]` instead; (4) `field_simp [hr'.ne']; ring` does not cancel `r'⁻¹^k` residue — use `rw [div_pow]; ring`. Sorry count 1 → 0. Build clean at 7745 jobs. |
 
 ## S5 Contribution (previous, for reference)
 
@@ -87,9 +91,13 @@ This builds on the merged S4 state (PR #18085). The S5 sub-lemma `cauchy_diag_no
 
 PR #17904 (researcher-1, conflicting) had `cauchy_diag_norm_bound` as a separate `sorry` AND the main combination step as a separate `sorry` (net 2 sorries vs S3's 1). This S4 PR keeps the sorry count at 1 by completing the combination step, leaving only the Cauchy-coefficient gap deferred. The naming `cauchy_diag_norm_bound` is identical to #17904's; the signature differs (uses `_hR`, `_hM`, `_hf`, `_hbound`, `_hw` underscored since the body is `sorry`).
 
-## Next Action (S7 ACT — pre-flighted by S6 → S6e PREP chain)
+## Next Action (post-S7)
 
-Discharge `cauchy_diag_norm_bound_at_radius` by **pasting the S6c drop-in tactic chain** (PR #18396) with the v4.26.0 lemma-name pins from S6b (PR #18386) and S6e (PR #18536), and the +10-15 LOC `DiffContOnCl` bridge surfaced as R-? in S6e. The limit-extraction step is already done in S5; this S7 ACT replaces only the one residual `sorry` on the finite-radius sub-lemma.
+The slug is COMPLETED. Optional follow-ups:
+1. Propagate the 4-fingernail v4.26.0 surgical fix kit (see this session's memo) to memory and to future `gh api`-based PREP audits in other slugs, so the same elaborator gotchas don't burn 4 docker iterations again.
+2. Consider sharpening S2's `analytic_taylor_remainder_uniform_geometric_complex` (existential form via Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'`) into the explicit S4 constant form (`analytic_taylor_remainder_uniform_bound_complex`). The S4 explicit form is already proven; this would be Mathlib-style packaging rather than open content.
+
+The original S7 ACT plan (referenced for archival):
 
 **Lemma table** (all names verified at Mathlib v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`; see `2026-05-13-s6e-prep-mathlib-name-v4260-audit.md` for the 13-step pinned sketch):
 
@@ -115,4 +123,4 @@ Discharge `cauchy_diag_norm_bound_at_radius` by **pasting the S6c drop-in tactic
 
 ## Pool Status Note
 
-This slug remains `progress`. One `sorry` remains on `cauchy_diag_norm_bound_at_radius`. After the S6 → S6e PREP chain, the next iteration is **S7 ACT (high readiness)**: every lemma the proof needs has been pinned at v4.26.0, every S6c placeholder has been resolved, and only one new risk (R-? `DiffContOnCl` bridge) has emerged. Do not status-change to `completed` until docker-build verifies the paste.
+This slug is now `completed` as of S7 ACT (2026-05-14, researcher-3). Zero sorries, zero axioms in `MeanValueTheoremOQ02OQ04OQ01.lean`. Docker-build verified at 7745 jobs from the worktree CWD.

--- a/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "mean-value-theorem-oq-02-oq-04-oq-01",
   "title": "Refutation of the OQ-04 axiom: Cauchy uniform bound fails on real-only hypotheses (Runge phenomenon)",
-  "phase": "ACT (S5 merged; S6 → S6e PREP chain complete; S7 ACT pending). MeanValueTheoremOQ02OQ04OQ01.lean unchanged since S5 (706 LOC, 0 axioms, 1 sorry). Sorry on cauchy_diag_norm_bound_at_radius; complete drop-in tactic chain with v4.26.0 lemma names pinned by S6e (PR #18536) — paste step bounded to ~60-90 LOC plus a ~5-10 LOC DiffContOnCl bridge (R-? in S6e).",
-  "status": "progress",
+  "phase": "COMPLETED (S7 ACT). MeanValueTheoremOQ02OQ04OQ01.lean: 758 LOC, 0 axioms, 0 sorries. The residual cauchy_diag_norm_bound_at_radius sorry was discharged via the S6f drop-in proof body plus three v4.26.0 elaborator corrections surfaced by docker-build (Complex.-namespace prefix on the Cauchy estimate, RCLike.norm_nsmul precedent for the smul-norm step, div_pow + ring for the denominator algebra). 7745-job docker build clean.",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,20 +31,20 @@
     "goal": "Refute the parent OQ-04 axiom by constructive counterexample, identify the root cause (Runge phenomenon: real-analyticity + real sup bound does not control complex Cauchy coefficient bounds), and state the corrected complex-disk version with explicit Mathlib chain for S2 discharge."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-05-12T00:00:00.000Z",
-    "iteration": 13,
-    "focus": "After S5 ACT (PR #18197, merged 2026-05-12T23:20Z), five doc-only PREP iterations (S6 #18309, S6b #18386, S6c #18396, S6d #18464, S6e #18536) have produced a complete drop-in tactic chain for the single residual sorry on cauchy_diag_norm_bound_at_radius: S6b pinned 7 of 8 candidate Mathlib v4.26.0 lemma names (replacing the drifted ...factorial_smul_apply_iteratedFDeriv with HasFPowerSeriesOnBall.factorial_smul); S6c resolved S6b's three placeholders (sphere→ball membership, closedBall ⊂ EMetric.ball, norm equivalence); S6d built a 10-item S7-ACT pre-flight risk register; S6e pinned R-1 and R-4 at v4.26.0 SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (Complex.norm_natCast via RCLike.norm_natCast @ RCLike/Basic.lean:633 @[simp 1100], iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod @ IteratedDeriv/Defs.lean:246) and surfaced a new R-? DiffContOnCl bridge (+5-10 LOC, since Mathlib's Cauchy estimate at Liouville.lean:44 requires DiffContOnCl).",
+    "iteration": 14,
+    "focus": "S7 ACT shipped: 1 sorry to 0 sorries. The 6-PREP chain (S6 to S6f) pinned every Mathlib name in advance; the build loop (4 iterations) only surfaced v4.26.0 elaborator-level fingernails (mul_le_mul_iff_left₀ argument shape, missing Complex. namespace prefix, congrArg eta-expansion blocking subsequent rw, field_simp not cancelling r' inverses).",
     "blockers": [],
-    "nextAction": "S7 ACT: paste the S6c drop-in tactic chain (PR #18396) with S6b/S6e v4.26.0 lemma-name pins and add the +5-10 LOC R-? DiffContOnCl bridge surfaced by S6e. Lemma table fully verified at v4.26.0 SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: HasFPowerSeriesOnBall.factorial_smul @ FDeriv/Analytic.lean:840, iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod @ IteratedDeriv/Defs.lean:246, Complex.norm_natCast via RCLike.norm_natCast @ RCLike/Basic.lean:633. Open risks: R-?, plus the 7 S6d risks (R-2/R-3/R-5..R-10) not yet audited at v4.26.0 by S6e — review each before paste. Build via ./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ04OQ01 (never lake build directly). Estimated S7 ACT diff: 60-90 LOC net new sorry-free content.",
+    "nextAction": "Slug is COMPLETED. Optional follow-ups: (1) propagate the 4-fingernail Mathlib v4.26.0 surgical fix kit to memory for future researchers; (2) consider whether the S2 analytic_taylor_remainder_uniform_geometric_complex existential form can be sharpened to the explicit S4 constant form.",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 1,
+      "total": 5,
+      "currentApproach": 0,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S5 ACT merged (PR #18197, 2026-05-12T23:20Z, researcher-3): cauchy_diag_norm_bound is PROVEN by limit-extraction from a new finite-radius sub-lemma cauchy_diag_norm_bound_at_radius. Five doc-only PREP iterations have since pre-flighted the S7 ACT discharge of the residual sorry. S6 (#18309, researcher-8): Mathlib hooks survey + 4 candidate lemma cross-refs. S6b (#18386, researcher-3): v4.26.0 #check probes against pinned SHA 2df2f01… — 7 of 8 names correct; replacement HasFPowerSeriesOnBall.factorial_smul for the drifted ...factorial_smul_apply_iteratedFDeriv. S6c (#18396, researcher-1): resolved S6b's three unresolved placeholders, providing a complete drop-in tactic chain. S6d (#18464, researcher-10): 10-item S7 ACT pre-flight risk register. S6e (#18536, researcher-5): pinned R-1 (Complex.norm_natCast via RCLike.norm_natCast @ RCLike/Basic.lean:633, refuting S6d's PHANTOM Complex.abs_natCast claim) and R-4 (iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod @ IteratedDeriv/Defs.lean:246); surfaced new R-? DiffContOnCl bridge requiring +5-10 LOC. Sorry count unchanged across S6 → S6e (1 → 1). Next iteration is S7 ACT: 60-90 LOC paste of the pinned chain + DiffContOnCl bridge, verified by docker-build.",
+    "progressSummary": "S7 ACT shipped (researcher-3, 2026-05-14): residual sorry on cauchy_diag_norm_bound_at_radius discharged. File is now 0 axioms, 0 sorries at 758 LOC; 7745-job docker build clean. Path: S5 (#18197) introduced the finite-radius decomposition + limit-extraction proof of cauchy_diag_norm_bound; S6 to S6f (six doc-only PREP iterations, PRs #18309, #18386, #18396, #18464, #18536, #18774) pinned all 13 Mathlib v4.26.0 lemma names and resolved one new R-? DiffContOnCl bridge; S7 ACT (this session) pasted the S6f drop-in and ran 4 docker-build iterations to surface and fix three v4.26.0 elaborator fingernails the doc-only PREP could not catch.",
     "builtItems": [
       "Definition runge in Proofs/MeanValueTheoremOQ02OQ04OQ01.lean (~137) — the Runge function 1/(1+x²)",
       "Theorem runge_one_add_sq_pos (~142) — 1 + x² > 0",
@@ -62,7 +62,8 @@
       "**(S3 RESTATEMENT)** Theorem analytic_taylor_remainder_uniform_bound_complex — corrected partialSum (n+1) indexing; RHS aligns with geometric tail from degree k=n+1; sorry retained",
       "S4: cauchy_diag_norm_bound (sorry, named sub-lemma) — isolates the residual gap to the Cauchy coefficient bound `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖/R)^k` for `‖w‖ < R`, with proof chain sketched in the docstring",
       "S4: analytic_taylor_remainder_uniform_bound_complex (PROVEN modulo cauchy_diag_norm_bound) — full combination chain: hasSum_sub + per-term bound + norm_sub_le_of_geometric_bound_of_hasSum + norm_sub_rev + algebraic rescaling",
-      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound_at_radius (NEW SORRY, deferred to S6) — finite-radius form, statement only. cauchy_diag_norm_bound (S4 statement, S5 PROVEN) — limit-extraction proof using ContinuousAt.mul + ContinuousAt.div + ContinuousAt.pow + ContinuousAt.tendsto.mono_left nhdsWithin_le_nhds + mem_nhdsWithin with Set.Ioi 0 in 𝓝 R witness + Filter.eventually_of_mem + le_of_tendsto. ~50 lines in proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean lines 417-490."
+      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound_at_radius (NEW SORRY, deferred to S6) — finite-radius form, statement only. cauchy_diag_norm_bound (S4 statement, S5 PROVEN) — limit-extraction proof using ContinuousAt.mul + ContinuousAt.div + ContinuousAt.pow + ContinuousAt.tendsto.mono_left nhdsWithin_le_nhds + mem_nhdsWithin with Set.Ioi 0 in 𝓝 R witness + Filter.eventually_of_mem + le_of_tendsto. ~50 lines in proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean lines 417-490.",
+      "Discharged sorry on cauchy_diag_norm_bound_at_radius @ MeanValueTheoremOQ02OQ04OQ01.lean:457-525 via 6-step proof: (1) closedBall subset ball inclusions; (2) Metric.emetric_ball EMetric-to-Metric bridge; (3) DiffContOnCl.mk_ball constructor; (4) Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le; (5) HasFPowerSeriesOnBall.factorial_smul + iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod diag-collapse; (6) RCLike.norm_nsmul + nsmul_eq_mul + norm_smul + norm_pow norm-step + le_of_mul_le_mul_left finisher. 7745-job docker-build clean."
     ],
     "insights": [
       "The parent OQ-04 axiom is mathematically false: real-analyticity + real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk.",
@@ -80,7 +81,8 @@
       "S4: partialSum n y = ∑ k ∈ Finset.range n, p k (fun _ => y) definitionally — rfl closes the unfolding step.",
       "S4: The RHS algebra (`M * (r/R)^(n+1) / (1 - r/R) = M * r^(n+1) / (R^n * (R-r))`) does NOT close by `field_simp + ring` alone — `ring` cannot combine stray `R⁻¹^n` factors. Use an explicit `calc` chain via `div_div_eq_mul_div + mul_assoc + mul_div_assoc + geometric_tail_identity + ← mul_div_assoc`.",
       "S4: `pow_le_pow_left` is unknown in Mathlib v4.26.0 (renamed or removed). Use `gcongr` for monotonicity-of-pow + monotonicity-of-div together.",
-      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound decomposes naturally into (a) the finite-radius Cauchy bound at strict r prime in (0, R), and (b) the limit-extraction r prime to R from below via continuity of r prime to M * (‖w‖/r prime)^k. Isolating (b) into a fully-proven limit-reduction makes the residual sorry exactly the statement Mathlibs Cauchy-integral infrastructure produces directly on sphere a r prime; no further limit plumbing needed in a future S6 iteration."
+      "S5 (2026-05-12, researcher-3): cauchy_diag_norm_bound decomposes naturally into (a) the finite-radius Cauchy bound at strict r prime in (0, R), and (b) the limit-extraction r prime to R from below via continuity of r prime to M * (‖w‖/r prime)^k. Isolating (b) into a fully-proven limit-reduction makes the residual sorry exactly the statement Mathlibs Cauchy-integral infrastructure produces directly on sphere a r prime; no further limit plumbing needed in a future S6 iteration.",
+      "S7 ACT surgical fix kit for Mathlib v4.26.0 (researcher-3, 2026-05-14): (1) mul_le_mul_iff_left₀ at v4.26.0 expects factor on RIGHT (a*c <= b*c); when the natural shape is c*a <= c*b, prefer le_of_mul_le_mul_left. (2) Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le is namespace-Complex-qualified (Liouville.lean:38,44); doc-only audits via gh api contents must capture the surrounding namespace, not just the bare name. (3) congrArg (norm) h yields eta-expanded equations that block subsequent rw on patterns like norm-of-smul; derive hnorm via rw [h] on an explicit norm-statement instead. (4) field_simp [hr'.ne']; ring does not always cancel r'^k * r'^(-1)^k; for mixed /r'^k and (_/r')^k expressions, prefer rw [div_pow]; ring to expose the symmetric denominator structure first."
     ],
     "mathlibGaps": [
       "Bridge from AnalyticOn ℝ (real-analytic on a real interval) to HasFPowerSeriesOnBall on Metric.ball (a:ℂ) R for some complex extension — not directly available; would need real-to-complex analytic continuation lemmas.",
@@ -88,10 +90,8 @@
       "No high-level Mathlib lemma `cauchyEstimate : ‖p k‖ ≤ M/R^k from sup bound on the circle` — must be derived from `Complex.norm_cauchyPowerSeries_le` + `DifferentiableOn.hasFPowerSeriesOnBall` manually. Could be a Mathlib contribution opportunity."
     ],
     "nextSteps": [
-      "S7 ACT: discharge cauchy_diag_norm_bound_at_radius by pasting the S6c drop-in tactic chain (PR #18396) with v4.26.0 lemma-name pins from S6b (#18386) and S6e (#18536). Estimated 60-90 LOC net new sorry-free content, including a +5-10 LOC DiffContOnCl bridge (R-? in S6e) since Mathlib's Cauchy estimate at Liouville.lean:44 requires DiffContOnCl, not HasFPowerSeriesOnBall.",
-      "Pre-S7-ACT: audit the 7 remaining S6d risks (R-2/R-3/R-5..R-10) against Mathlib v4.26.0 SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67, mirroring the S6e pattern for R-1/R-4.",
-      "Audit sibling gallery files that import MeanValueTheoremOQ02OQ04 for similar OQ-04-axiom-dependence (carried over from prior nextSteps).",
-      "Post-S7-ACT: if docker-build verifies the paste, status flips to completed; update knowledge.progressSummary + this slug's status to completed in src/data/research/problems/<slug>.json."
+      "(Optional) Propagate the 4-fingernail v4.26.0 surgical fix kit to memory and to gh-api-based PREP audits in other slugs.",
+      "(Optional) Sharpen S2 analytic_taylor_remainder_uniform_geometric_complex from existential to explicit constants, mirroring the S4 form."
     ]
   },
   "tags": [
@@ -129,7 +129,7 @@
     ]
   },
   "started": "2026-05-12T00:00:00.000Z",
-  "lastUpdate": "2026-05-13T22:39:00.566Z",
+  "lastUpdate": "2026-05-14T14:35:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S7 ACT discharges the single residual `sorry` on `cauchy_diag_norm_bound_at_radius` in `MeanValueTheoremOQ02OQ04OQ01.lean`. The file is now **758 LOC, 0 axioms, 0 sorries**. Docker build verified clean: `Build completed successfully (7745 jobs)` from the worktree CWD.

## Progress

- **Lean file**: 706 → 758 LOC (+52); sorry 1 → 0; axioms 0 → 0.
- **Slug status**: `progress` → `completed`.
- **Files modified**: `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean`, `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/state.md`, `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json`.
- **Files added**: `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/sessions/2026-05-14-s7-act-cauchy-diag-discharge.md`.

## Discharge path

Pasted the S6f drop-in proof body (PR #18774, researcher-9) at lines 457–525:

1. Inclusions `closedBall a r' ⊆ ball a R` and `sphere a r' ⊆ closedBall a r'`.
2. `Metric.emetric_ball` bridge to flip `EMetric.ball a (ENNReal.ofReal R)` to `Metric.ball a R`, then `.mono` to `closedBall a r'`.
3. `DiffContOnCl.mk_ball` constructor combining `.differentiableOn` (via `Metric.ball_subset_closedBall`) and `.continuousOn`.
4. Mathlib's Cauchy estimate: `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (`Liouville.lean:44`).
5. FPS → iteratedFDeriv → iteratedDeriv bridge: `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` + `simp` for the `∏ i, w = w^k` diag-collapse.
6. Norm via `RCLike.norm_nsmul + nsmul_eq_mul + norm_smul + norm_pow`, then divide by `(k.factorial : ℝ) > 0` via `le_of_mul_le_mul_left`.

## Surgical fix kit for Mathlib v4.26.0

The 6-PREP doc-only chain (S6 → S6f, 2026-05-12 → 2026-05-13) pinned every lemma name via `gh api contents` audits but never compiled. The build loop (4 iterations) surfaced four elaborator-level fingernails:

1. **`mul_le_mul_iff_left₀` argument shape**: at v4.26.0 expects the factor on the RIGHT (`a*c ≤ b*c`), not the left (`c*a ≤ c*b`). For dividing `c*a ≤ c*b` by `0 < c`, prefer `le_of_mul_le_mul_left _ _`.

2. **`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` is namespace-`Complex`-qualified**. Cited as `Liouville.lean:44` in S6e; the surrounding `namespace Complex` declaration (line 38) must be captured. `gh api`-based PREP that lists only the bare name leaves the user with an `Unknown identifier` at build time.

3. **`congrArg (‖·‖) h` produces eta-expanded equations** `(fun x => ‖x‖) (lhs) = (fun x => ‖x‖) (rhs)`. Subsequent `rw [‖?n • ?x‖, ...]` cannot match through the lambda. Derive `hnorm` via `rw [h_combined]` on an explicit norm-statement instead.

4. **`field_simp [hr'.ne']; ring` does not always cancel `r'⁻¹^k`** in v4.26.0. For mixed `/r'^k` and `(_/r')^k` expressions, prefer `rw [div_pow]; ring` to expose the symmetric denominator structure first.

These fingernails are invisible to `gh api`-based PREP and only surface via `./proofs/scripts/docker-build.sh`. Memory pattern matches `feedback_researcher_docs_only_chain_silent_parent_regression` and the v4.26.0 tactic-gotchas surgical-fix kit entries.

## Findings

- Mathematical content unchanged from S5: the parent OQ-04 axiom asserts `|f(x) − T_n f(a)(x)| ≤ M · r^(n+1) / (R−r)` from a real-interval hypothesis; the file refutes the axiom via the Runge counterexample (S1, `oq04_axiom_is_false`) AND backs the corresponding *complex-disk* statement with a full Cauchy uniform-geometric approximation chain (S2 + S3 + S4 + S5 + S7).
- The discharged sub-lemma `cauchy_diag_norm_bound_at_radius` is the explicit-radius form `‖p k (fun _ ↦ w)‖ ≤ M · (‖w‖ / r')^k` that Mathlib's Cauchy-integral infrastructure produces directly on `sphere a r'`. The boundary form `cauchy_diag_norm_bound` was already proven from this via S5's limit-extraction.

## Status

**Outcome**: completed.
**Next Steps**: (optional, low priority) propagate the 4-fingernail v4.26.0 fix kit to future `gh api`-based PREP audits; consider sharpening the S2 existential `analytic_taylor_remainder_uniform_geometric_complex` into the S4 explicit-constant form.

## Build log

`.loom/logs/researcher-3-mvt-s7-act-build-1778769694.log` — Build completed successfully (7745 jobs).

🤖 Generated by researcher-3
