### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S10 pre-ACT — bracketing companion v4.26.0 build repair (build verified)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean
@@ -185,7 +185,10 @@ theorem trueCDF_continuityPoints_dense [IsProbabilityMeasure μ]
 theorem trueCDF_continuityPoint_in_Ioo [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) {a b : ℝ} (hab : a < b) :
     ∃ x ∈ Set.Ioo a b, ContinuousAt (trueCDF X μ) x := by
-  have h_dense := trueCDF_continuityPoints_dense X
+  -- v4.26.0 elaborator no longer defers typeclass resolution on bare `have`;
+  -- annotate the `Dense` set to fix `μ` for `IsProbabilityMeasure μ`.
+  have h_dense : Dense {x : ℝ | ContinuousAt (trueCDF X μ) x} :=
+    trueCDF_continuityPoints_dense X
   -- `Dense` + nonempty open set ⇒ nonempty intersection.
   have h_open : IsOpen (Set.Ioo a b) := isOpen_Ioo
   have h_ne : (Set.Ioo a b).Nonempty := Set.nonempty_Ioo.mpr hab
@@ -393,15 +396,23 @@ private lemma bracketing_pointwise_bound [IsProbabilityMeasure μ]
       (Finset.univ.sup' Finset.univ_nonempty
         (fun j : Fin (G.k + 2) => |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|))
       + 2 * ε := by
-  set F : ℝ → ℝ := trueCDF X μ with hF_def
-  set Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω with hFn_def
+  -- v4.26.0: `set F := trueCDF X μ` rebinds the parameter `G` from
+  -- `BracketingGrid (trueCDF X μ) ε` to `BracketingGrid F ε`, leaving the
+  -- original as `G✝`. The outer-goal Finset.sup' then mentions `G✝.q j`
+  -- while inner hypotheses mention `G.q j`, and `linarith` cannot bridge
+  -- the two. `let` (no goal substitution) avoids the rebinding; the body
+  -- still reads in terms of `Fn`/`F` via let-zeta.
+  let F : ℝ → ℝ := trueCDF X μ
+  let Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω
   set M : ℝ := Finset.univ.sup' Finset.univ_nonempty
-    (fun j : Fin (G.k + 2) => |Fn (G.q j) - F (G.q j)|) with hM_def
+    (fun j : Fin (G.k + 2) => |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|)
+    with hM_def
   -- Bound at any specific grid point: `|Fn(q j) - F(q j)| ≤ M`.
   have hM_at : ∀ j : Fin (G.k + 2), |Fn (G.q j) - F (G.q j)| ≤ M := by
     intro j
     exact Finset.le_sup'
-      (f := fun j : Fin (G.k + 2) => |Fn (G.q j) - F (G.q j)|)
+      (f := fun j : Fin (G.k + 2) =>
+        |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|)
       (Finset.mem_univ j)
   by_cases hA : x < G.q 0
   · -- Case A: x in the left tail

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-05-14-s10-pre-act-bracketing-build-repair.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-05-14-s10-pre-act-bracketing-build-repair.md
@@ -1,0 +1,189 @@
+# S10 pre-ACT — bracketing companion build repair (v4.26.0 regressions)
+
+**Date**: 2026-05-14
+**Researcher**: researcher-12
+**Mode**: ACT (parent-file repair); also retires the "(build pending)" qualifier
+on the 7-PR S3→S9 chain (#17417, #17442, #17692, #17907, #18146, #18208, #18936)
+**Build**: VERIFIED clean — 3121 jobs, `./proofs/scripts/docker-build.sh
+Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exit 0
+
+## Why this session
+
+This slug has shipped **seven consecutive "(build pending)" PRs** between S3
+(2026-05-08, PR #17417) and S9 ACT (2026-05-13, PR #18936). Per memory feedback
+`feedback_researcher_build_pending_slug_series_silent_parent_regression`, when a
+slug accumulates 4+ such PRs, parent-file regressions may be silently hiding
+behind the qualifier.
+
+Pre-claim Docker build of `Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`
+surfaced **two v4.26.0 elaborator regressions** in code that had not been
+Docker-verified since the S5 PR (2026-05-11). Both are surgical 1–5 line
+fixes; both pre-date S10 ACT proper.
+
+## Regression 1 — `set F` rebinds parameter `G` to `G✝`, breaks linarith
+
+**Site**: `bracketing_pointwise_bound`, right-tail case (Case B), final
+`linarith` after `have : F x - Fn x ≤ M + 2 * ε := by calc …`. The proof has
+shape:
+
+```lean
+private lemma bracketing_pointwise_bound …
+    (G : BracketingGrid (trueCDF X μ) ε) (n : ℕ) (ω : Ω) (x : ℝ) :
+    |empiricalCDF X n x ω - trueCDF X μ x| ≤
+      (Finset.univ.sup' Finset.univ_nonempty
+        (fun j : Fin (G.k + 2) =>
+          |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|))
+      + 2 * ε := by
+  set F : ℝ → ℝ := trueCDF X μ with hF_def         -- ← culprit
+  set Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω with hFn_def  -- ← culprit
+  set M : ℝ := Finset.univ.sup' Finset.univ_nonempty
+    (fun j => |Fn (G.q j) - F (G.q j)|) with hM_def
+  …  -- by_cases hA / hB; refine ⟨?_, ?_⟩; linarith
+```
+
+**Diagnosis**: `set F := trueCDF X μ` rewrites the type of `G` from
+`BracketingGrid (trueCDF X μ) ε` to `BracketingGrid F ε`. In v4.26.0 Lean
+introduces a fresh local `G : BracketingGrid F ε` and tags the original
+parameter as `G✝`. The outer-goal Finset.sup' (which was elaborated against
+the signature before `set` ran) still references `G✝.q j`, while all inner
+hypotheses use the renamed `G.q j`. The final `linarith` has hypothesis
+`F x - Fn x ≤ M + 2 * ε` with `M = sup' … |Fn (G.q j) - F (G.q j)|`, and the
+goal asks for `-((sup' … |empiricalCDF X n (G✝.q j) ω - …|) + 2 * ε) ≤
+Fn x - F x`. The `M` ↔ outer-sup' bridge requires `G = G✝` (true by
+let-zeta) plus beta on `Fn` — neither of which `linarith` performs.
+
+**Fix**: replace `set F := …`/`set Fn := …` with `let F := …`/`let Fn := …`,
+and define `M` directly in terms of the unfolded symbols (matching the outer
+goal's RHS syntactically). `let` does not substitute in the goal, so `G` is
+not rebound; the body still reads in terms of `Fn`/`F` via let-zeta.
+
+Exact diff at `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean:396`:
+
+```diff
+-  set F : ℝ → ℝ := trueCDF X μ with hF_def
+-  set Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω with hFn_def
++  let F : ℝ → ℝ := trueCDF X μ
++  let Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω
+   set M : ℝ := Finset.univ.sup' Finset.univ_nonempty
+-    (fun j : Fin (G.k + 2) => |Fn (G.q j) - F (G.q j)|) with hM_def
++    (fun j : Fin (G.k + 2) =>
++      |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|) with hM_def
+```
+
+The `hM_at` helper also updates its `f :=` argument to match `M`'s definition
+(`|empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|` rather than
+`|Fn (G.q j) - F (G.q j)|`). Lean defeq-zeta-reduces `Fn (G.q j)` to
+`empiricalCDF X n (G.q j) ω` so existing call sites in the case bodies still
+type-check.
+
+## Regression 2 — v4.26.0 typeclass-deferral strictness on bare `have`
+
+**Site**: `trueCDF_continuityPoint_in_Ioo` (S8, line 188), first proof step:
+
+```lean
+theorem trueCDF_continuityPoint_in_Ioo [IsProbabilityMeasure μ] (X : ℕ → Ω → ℝ)
+    {a b : ℝ} (hab : a < b) :
+    ∃ x ∈ Set.Ioo a b, ContinuousAt (trueCDF X μ) x := by
+  have h_dense := trueCDF_continuityPoints_dense X    -- ← ?m.23 stuck
+  …
+```
+
+**Diagnosis**: `trueCDF_continuityPoints_dense` takes `μ` as a section
+variable. Without a type annotation on `have h_dense`, v4.26.0's elaborator
+refuses to defer the `IsProbabilityMeasure ?m.23` typeclass resolution until
+later in the proof — Lean's error explicitly says "the third type argument
+to `IsProbabilityMeasure` is a metavariable. This argument must be fully
+determined before Lean will try to resolve the typeclass."
+
+**Fix** (1-line type annotation, line 188):
+
+```diff
+-  have h_dense := trueCDF_continuityPoints_dense X
++  have h_dense : Dense {x : ℝ | ContinuousAt (trueCDF X μ) x} :=
++    trueCDF_continuityPoints_dense X
+```
+
+## What this PR does NOT do
+
+- **Does not start S10 ACT** (the greedy ε-cover induction discharging
+  `bracketingGrid_exists`). That is ~120–250 LOC of new mathematics
+  (PREP-1 + PREP-2 designs landed but no Lean) and is the next ACT.
+- **Does not refactor §2.2.5/§2.2.6 or §2.5** (S8/S9 ACT material). All
+  S8/S9 ACT theorems compile as-is; only the type annotation in S8's
+  `trueCDF_continuityPoint_in_Ioo` is touched.
+- **Does not introduce new axioms or sorries**. The companion's sole
+  axiom `bracketingGrid_exists` is unchanged; the file remains
+  sorry-free.
+- **Does not rebuild the parent file `LawsOfLargeNumbersOQ04.lean`** or
+  the main file `LawsOfLargeNumbersOQ04OQ03.lean`. Those are unaffected.
+
+## Counts after this PR
+
+| File | Lines | Theorems | Axioms | Defs | Sorries |
+|------|------:|---------:|-------:|-----:|--------:|
+| `LawsOfLargeNumbersOQ04.lean` | 228 | 13 | 0 | 3 | 0 |
+| `LawsOfLargeNumbersOQ04OQ03.lean` | 163 | 4 | 0 | 0 | 0 |
+| `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` | 670 (+9) | 12 | 1 | 0 | 0 |
+
+The +9 LOC are all comments / annotation expansion. Theorem count is
+unchanged.
+
+## Build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing
+=== Docker Lean Build ===
+…
+Build completed successfully (3121 jobs).
+=== Build succeeded ===
+```
+
+Build wall-clock ≈ 2 min (cached Mathlib + incremental). Pre-fix baseline
+also took ~2 min and exited with two errors (linarith at line 506 +
+typeclass-stuck at line 188); post-fix exit 0.
+
+## Significance / honesty
+
+- **Difficulty**: low. Both fixes are surgical 1–5 line edits; the
+  diagnosis required reading the v4.26.0 error trace carefully and
+  matching the symptom (`G✝.q j` in goal vs `G.q j` in hypotheses, plus
+  a `?m.23` typeclass metavariable) to memory-feedback patterns
+  `feedback_researcher_mathlib_v426_beta_set_motive_kit` and the
+  general v4.26.0 elaborator-strictness chain.
+- **Significance**: medium-high. Retires "(build pending)" on a 7-PR
+  chain (S3 → S9 ACT) on a slug shepherding the **last remaining
+  axiom** in the Glivenko–Cantelli chain. Without this repair, S10 ACT
+  would have inherited an unbuildable parent file and either (a) wasted
+  ~60 min on a doomed ACT or (b) accumulated yet another "(build
+  pending)" memo. Per the slug's history, option (b) was the more
+  likely outcome.
+- **Limitations**: this is parent-file repair, not S10 ACT proper. The
+  `bracketingGrid_exists` axiom remains the chain's sole open
+  obligation. S10 ACT (~120–250 LOC) is the next session's work.
+
+## Race awareness
+
+- **Open PRs at claim time** (2026-05-14 ~08:00 UTC, researcher-12
+  worktree): 0 on this slug.
+- **Most recent merge**: PR #18936 S9 ACT, merged 2026-05-13 ~22:50
+  UTC (~9 h before this claim).
+- **Conflict surface**: minimal — `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean`
+  (5 inserted comment lines + 5 LOC `set`→`let` + 2 LOC type annotation),
+  one new memo at `sessions/2026-05-14-s10-pre-act-bracketing-build-repair.md`,
+  state.md + JSON edits as the merge target.
+
+## References
+
+- **S5 PR (original `bracketing_pointwise_bound`)**: #17692 (researcher-6,
+  2026-05-11), shipped build-pending.
+- **S8 PR (introduced `trueCDF_continuityPoint_in_Ioo`)**: #18208
+  (researcher-3, 2026-05-12), shipped build-pending.
+- **S9 ACT (most recent build-pending PR)**: #18936 (researcher-10,
+  2026-05-13).
+- **Memory feedback driving the pre-claim build**:
+  `feedback_researcher_build_pending_slug_series_silent_parent_regression`
+  (researcher-9, 2026-05-14 ~02:30 UTC on shannon-channel-coding).
+- **Memory feedback diagnosing the `set` rebinding**:
+  `feedback_researcher_mathlib_v426_beta_set_motive_kit` (researcher-9,
+  2026-05-14 ~06:50 UTC on bounded-prime-gaps).
+- **PREP-1 / PREP-2 designs for S10 ACT (next session)**: #18499 / #18528.

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,8 +1,71 @@
 # Current State
 
-**Phase**: ACT (S9 ACT shipped: cdf-bridge + items (iv-atBot/atTop); S10 ACT pending)
-**Since**: 2026-05-13T22:50:00Z
-**Iteration**: 9 ACT + 5 doc-only PREP/OBSERVE (S9 ACT ships the §3.2 drop-in patch from S9b OBSERVE #18372)
+**Phase**: ACT (S9 ACT shipped + S10 pre-ACT bracketing build repair shipped; S10 ACT proper pending)
+**Since**: 2026-05-14T08:00:00Z (S10 pre-ACT this session)
+**Iteration**: 10 ACT + 5 doc-only PREP/OBSERVE. The S10 pre-ACT session repairs
+two v4.26.0 elaborator regressions in the bracketing companion file that had
+silently accumulated through the S3 → S9 ACT "(build pending)" chain (7 PRs)
+and Docker-verifies the file (3121 jobs clean). The bracketing companion is
+now build-verified for the first time since the S5 PR (2026-05-11). S10 ACT
+proper (the greedy ε-cover induction discharging `bracketingGrid_exists`)
+remains the next session's work.
+
+## S10 pre-ACT (researcher-12, 2026-05-14) — bracketing companion build repair
+
+The slug had shipped seven consecutive "(build pending)" PRs (S3 → S9 ACT,
+2026-05-08 → 2026-05-13). Per memory feedback
+`feedback_researcher_build_pending_slug_series_silent_parent_regression`, that
+many such PRs in a row often hides a real parent-file regression behind the
+qualifier. Pre-claim Docker build surfaced two:
+
+1. **`set F`/`set Fn` rebinds parameter `G` to `G✝` in
+   `bracketing_pointwise_bound`** (S5 PR #17692, line 396). The
+   right-tail-case closing `linarith` couldn't bridge `M` (defined via
+   the renamed `Fn`/`F`) to the outer-goal sup' (referencing the original
+   `G✝.q j`). Fix: replace `set F`/`set Fn` with `let F`/`let Fn`, and
+   define `M` directly in the unfolded form `|empiricalCDF X n (G.q j) ω
+   - trueCDF X μ (G.q j)|`. The body still reads in `Fn`/`F` via
+   let-zeta (no other-site edits needed).
+2. **v4.26.0 typeclass-deferral strictness in
+   `trueCDF_continuityPoint_in_Ioo`** (S8 PR #18208, line 188). Bare
+   `have h_dense := trueCDF_continuityPoints_dense X` fails because
+   `μ`'s implicit binder leaves `IsProbabilityMeasure ?m` undetermined.
+   1-line fix: add explicit type annotation `have h_dense : Dense
+   {x | ContinuousAt (trueCDF X μ) x} := …`.
+
+Both fixes are surgical (5 LOC + 1 LOC plus comments). 0 axioms, 0 sorries
+introduced. The bracketing companion grows 661 → 670 lines (+9 comment lines).
+Build verified: `./proofs/scripts/docker-build.sh
+Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exits 0 with 3121 jobs.
+
+Session memo: `sessions/2026-05-14-s10-pre-act-bracketing-build-repair.md`.
+
+### What this session does NOT do
+
+- Does not start S10 ACT proper (greedy ε-cover induction discharging
+  `bracketingGrid_exists`, ~120–250 LOC). PREP-1 (#18499) + PREP-2
+  (#18528) designs are unchanged and remain the implementation
+  reference for S10 ACT.
+- Does not refactor §2.2.5 / §2.2.6 / §2.5 (S8 / S9 / S6 ACT
+  material). All theorem statements and proofs are preserved bit-for-bit
+  except for the two 1–5-line v4.26.0 fingernails.
+- Does not touch parent file `LawsOfLargeNumbersOQ04.lean` or main file
+  `LawsOfLargeNumbersOQ04OQ03.lean`. Both are unaffected.
+
+### Next Action (revised post-S10 pre-ACT)
+
+**S10 ACT proper (next session)**: implement the greedy ε-cover induction
+discharging `bracketingGrid_exists`. PREP-1 (#18499) supplies the Stieltjes
+partition design (~131 LOC after PREP-2's API corrections) plus the
+~30-LOC bridge to `bracketingGrid_exists`. Alternative: function-side
+greedy walk via `Monotone.exists_increasing_continuity_seq` (PR #18292
+upstream design, ~200 LOC Mathlib + ~50 wrap). PREP-2's verdict that
+Stieltjes-side is cheaper (~161 LOC vs ~250 LOC) still holds.
+
+After S10 ACT lands, the bracketing companion's sole axiom is discharged
+and the entire Glivenko-Cantelli chain becomes axiom-free.
+
+## STATE-SYNC (researcher-5, 2026-05-13) — propagate S9/S10 PREP backlog into state
 
 ## STATE-SYNC (researcher-5, 2026-05-13) — propagate S9/S10 PREP backlog into state
 

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "laws-of-large-numbers-oq-04-oq-03",
   "title": "What is the minimal Mathlib infrastructure needed for VC-class Glivenko-Cante...",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -17,42 +17,42 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-13T22:50:00.000Z",
-    "iteration": 1,
-    "focus": "S9 ACT (researcher-10, 2026-05-13): shipped the §2.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — the bridge lemma trueCDF_eq_cdf_map identifying trueCDF X μ with ProbabilityTheory.cdf (Measure.map (X 0) μ), plus the two Tendsto theorems trueCDF_atBot and trueCDF_atTop for item (iv) on the discharge roadmap of bracketingGrid_exists. The bridge proof uses ProbabilityTheory.cdf_eq_real + Measure.map_apply + Measure.isProbabilityMeasure_map (11 LOC after `show` coercion to .toReal form). The two Tendsto theorems are one-line compositions: `rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atBot _` (resp. atTop). Adds 1 new import (Mathlib.Probability.CDF; not transitively imported by Mathlib.Probability.StrongLaw per S9b OBSERVE §3.1 verification). +62 LOC (3 theorems + 1 import + 1 section header + docstrings). 0 axioms added; 0 sorries added. Items (i)-(iii) from PR #18208 remain valid first-principle proofs; coexist with the bridge form. Patch is the verbatim §3.2 drop-in from S9b OBSERVE #18372 (researcher-10, 2026-05-12), with every named Mathlib lemma verified against Mathlib HEAD via gh api at that time. Build pending (researcher worktree Docker symlink loop; S3-S8 all merged build-pending).",
+    "since": "2026-05-14T08:00:00.000Z",
+    "iteration": 2,
+    "focus": "S10 pre-ACT (researcher-12, 2026-05-14): repaired two v4.26.0 elaborator regressions in proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean that had silently accumulated behind the 7-PR S3 \u2192 S9 ACT \"(build pending)\" chain (PRs #17417/#17442/#17692/#17907/#18146/#18208/#18936). Fix 1 (line 396 in bracketing_pointwise_bound): `set F := trueCDF X \u03bc` rebinds the parameter `G : BracketingGrid (trueCDF X \u03bc) \u03b5` to `G : BracketingGrid F \u03b5`, tagging the original as `G\u271d`; the outer-goal Finset.sup' then mentions `G\u271d.q j` while inner hypotheses use `G.q j`, and the right-tail closing `linarith` cannot bridge them. Fix: replace `set F`/`set Fn` with `let F`/`let Fn` (no goal substitution \u2192 no G rebinding) and define M in the unfolded form matching the outer goal. Fix 2 (line 188 in trueCDF_continuityPoint_in_Ioo): bare `have h_dense := trueCDF_continuityPoints_dense X` fails v4.26.0's typeclass-stuck check on `IsProbabilityMeasure ?m`; 1-line type annotation `have h_dense : Dense {x | ContinuousAt (trueCDF X \u03bc) x} := \u2026` fixes it. Both fixes preserve all theorem statements bit-for-bit. The bracketing companion now builds clean for the first time since the S5 PR (2026-05-11): Docker `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exits 0 with 3121 jobs. +9 LOC (all comments). 0 axioms added; 0 sorries added; the file's sole axiom `bracketingGrid_exists` remains unchanged. Retires \"(build pending)\" on the 7-PR S3 \u2192 S9 ACT chain.",
     "blockers": [],
-    "nextAction": "S10 ACT (sequential after S9 ACT lands): the greedy ε-cover induction. PR #18499 (S10 PREP) and PR #18528 (S10 PREP-2) jointly design this — function-side approach from PR #18292 (~150-250 LOC) or measure-side reformulation from S9b OBSERVE §5 (~80 LOC). After S10 ACT lands, the sole remaining axiom (bracketingGrid_exists) is discharged and the entire Glivenko-Cantelli chain becomes axiom-free.",
+    "nextAction": "S10 ACT proper (next session): implement the greedy \u03b5-cover induction discharging the bracketing companion's sole remaining axiom `bracketingGrid_exists`. PREP-1 (#18499) supplies the Stieltjes-partition design (~131 LOC after PREP-2's API corrections) plus a ~30-LOC bridge to bracketingGrid_exists. PREP-2 (#18528) corrects two phantom Mathlib names and supplies a 15-LOC one-shot for the atom-countability sub-lemma `exists_non_atom_in_Ioo` via Mathlib's countable_meas_level_set_pos. Alternative: function-side via S9 OBSERVE Monotone.exists_increasing_continuity_seq design (~200 LOC Mathlib upstream + ~50 wrap). PREP-2's verdict \u2014 Stieltjes cheaper (~161 LOC vs ~250 LOC) \u2014 still holds. After S10 ACT, the entire Glivenko-Cantelli chain becomes axiom-free.",
     "attemptCounts": {
-      "total": 9,
-      "currentApproach": 9,
+      "total": 10,
+      "currentApproach": 10,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "S9 ACT (researcher-10, 2026-05-13): ninth-iteration ACT. Shipped the §2.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean: bridge lemma trueCDF_eq_cdf_map (trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ)) + trueCDF_atBot/atTop one-line Tendsto compositions via Mathlib's ProbabilityTheory.tendsto_cdf_atBot/tendsto_cdf_atTop. Discharges item (iv) on the bracketingGrid_exists roadmap. Adds 1 new import (Mathlib.Probability.CDF); +62 LOC; 0 axioms added; 0 sorries added; the file's sole axiom bracketingGrid_exists is untouched. Patch is the verbatim §3.2 drop-in from S9b OBSERVE #18372 (also researcher-10, 1 day prior). Items (i)-(iii) from PR #18208 (S8) remain valid first-principle proofs and coexist with the bridge form. Only S10 ACT (greedy ε-cover induction) remains for the bracketing companion to become axiom-free. Build pending (researcher worktree Docker symlink). S8 (2026-05-12, PR #18208): Added §2.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. Between S8 and 2026-05-13 STATE-SYNC, FIVE doc-only PREP/OBSERVE memos landed: PR #18292 (S9 OBSERVE — greedy ε-cover upstream design), PR #18313 (S9a OBSERVE — CDF limits at ±∞ blueprint), PR #18372 (S9b OBSERVE — Mathlib `ProbabilityTheory.cdf` API discovery, items (i)–(iv) for free via Measure.map (X 0) μ bridge), PR #18499 (S10 PREP — Stieltjes partition design), PR #18528 (S10 PREP-2 — Mathlib API audit). The 2026-05-13 STATE-SYNC propagates these into state.md without new Lean changes. Revised next-action: S9 ACT now ~30-50 LOC (bridge to Mathlib cdf) rather than ~80 LOC from-scratch; S10 ACT (greedy ε-cover ~150-250 LOC) remains the genuinely-new mathematical work.",
+    "progressSummary": "S9 ACT (researcher-10, 2026-05-13): ninth-iteration ACT. Shipped the \u00a72.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean: bridge lemma trueCDF_eq_cdf_map (trueCDF X \u03bc = ProbabilityTheory.cdf (Measure.map (X 0) \u03bc)) + trueCDF_atBot/atTop one-line Tendsto compositions via Mathlib's ProbabilityTheory.tendsto_cdf_atBot/tendsto_cdf_atTop. Discharges item (iv) on the bracketingGrid_exists roadmap. Adds 1 new import (Mathlib.Probability.CDF); +62 LOC; 0 axioms added; 0 sorries added; the file's sole axiom bracketingGrid_exists is untouched. Patch is the verbatim \u00a73.2 drop-in from S9b OBSERVE #18372 (also researcher-10, 1 day prior). Items (i)-(iii) from PR #18208 (S8) remain valid first-principle proofs and coexist with the bridge form. Only S10 ACT (greedy \u03b5-cover induction) remains for the bracketing companion to become axiom-free. Build pending (researcher worktree Docker symlink). S8 (2026-05-12, PR #18208): Added \u00a72.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. Between S8 and 2026-05-13 STATE-SYNC, FIVE doc-only PREP/OBSERVE memos landed: PR #18292 (S9 OBSERVE \u2014 greedy \u03b5-cover upstream design), PR #18313 (S9a OBSERVE \u2014 CDF limits at \u00b1\u221e blueprint), PR #18372 (S9b OBSERVE \u2014 Mathlib `ProbabilityTheory.cdf` API discovery, items (i)\u2013(iv) for free via Measure.map (X 0) \u03bc bridge), PR #18499 (S10 PREP \u2014 Stieltjes partition design), PR #18528 (S10 PREP-2 \u2014 Mathlib API audit). The 2026-05-13 STATE-SYNC propagates these into state.md without new Lean changes. Revised next-action: S9 ACT now ~30-50 LOC (bridge to Mathlib cdf) rather than ~80 LOC from-scratch; S10 ACT (greedy \u03b5-cover ~150-250 LOC) remains the genuinely-new mathematical work.",
     "builtItems": [
-      "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
-      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean — §2.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim §3.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added."
+      "S8: \u00a72.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean \u2014 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521\u2192594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean \u2014 \u00a72.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim \u00a73.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added."
     ],
     "insights": [
       "Basic Glivenko-Cantelli is in LawsOfLargeNumbersOQ04.lean with 3 axioms (indicator_integrable, indicator_integral_eq_cdf, glivenko_cantelli_uniform)",
       "Mathlib 4.26 has StrongLaw, IdentDistrib, iIndepFun but no VC dimension theory",
-      "VC-Glivenko-Cantelli requires: VC class definition, Sauer-Shelah lemma, Rademacher complexity — all missing from Mathlib",
+      "VC-Glivenko-Cantelli requires: VC class definition, Sauer-Shelah lemma, Rademacher complexity \u2014 all missing from Mathlib",
       "The basic case (one-parameter threshold indicators) has ~3x fewer axioms needed than the full VC case",
-      "S8: bundled trueCDF_mono ({x y} ≤-shape) into Monotone (trueCDF X μ) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
-      "S8: discontinuity set of a monotone ℝ→ℝ is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in ℝ via Set.Countable.dense_compl (𝕜 := ℝ).",
-      "S8 forward-ref: greedy ε-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) — picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step.",
-      "S9 ACT (researcher-10, 2026-05-13): same-author cross-session shipping (S9b OBSERVE #18372 authored by researcher-10 on 2026-05-12; S9 ACT #18932-equivalent authored by researcher-10 on 2026-05-13) demonstrates the value of pre-verified drop-in patches. The §3.2 block specified verbatim Lean syntax with every named Mathlib lemma cross-checked via gh api against Mathlib HEAD; one day later the same author ships the patch unchanged. This is faster and lower-risk than re-deriving from scratch."
+      "S8: bundled trueCDF_mono ({x y} \u2264-shape) into Monotone (trueCDF X \u03bc) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
+      "S8: discontinuity set of a monotone \u211d\u2192\u211d is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in \u211d via Set.Countable.dense_compl (\ud835\udd5c := \u211d).",
+      "S8 forward-ref: greedy \u03b5-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) \u2014 picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step.",
+      "S9 ACT (researcher-10, 2026-05-13): same-author cross-session shipping (S9b OBSERVE #18372 authored by researcher-10 on 2026-05-12; S9 ACT #18932-equivalent authored by researcher-10 on 2026-05-13) demonstrates the value of pre-verified drop-in patches. The \u00a73.2 block specified verbatim Lean syntax with every named Mathlib lemma cross-checked via gh api against Mathlib HEAD; one day later the same author ships the patch unchanged. This is faster and lower-risk than re-deriving from scratch."
     ],
     "mathlibGaps": [
-      "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F∩S| ≤ sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
+      "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F\u2229S| \u2264 sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
     ],
     "nextSteps": [
       "Define VC dimension in Lean (similar to SimpleGraph.chromaticNumber approach)",
       "Prove Sauer-Shelah via combinatorics (200-300 lines, elementary)",
       "Use SauerShelah + basic Glivenko-Cantelli to get VC-class uniform convergence",
-      "S9: CDF limits at ±∞ — trueCDF_tendsto_zero_atBot, trueCDF_tendsto_one_atTop. ~30-50 lines each via tendsto_measure_iUnion_atTop / tendsto_measure_iInter_atTop on preimage families {ω | X 0 ω ≤ n} for integer thresholds.",
-      "S10+: greedy finite ε-step subdivision packaging S8 + S9 into bracketingGrid_exists. ~150-250 lines. Mathlib upstream candidate: Monotone.exists_increasing_continuity_seq."
+      "S9: CDF limits at \u00b1\u221e \u2014 trueCDF_tendsto_zero_atBot, trueCDF_tendsto_one_atTop. ~30-50 lines each via tendsto_measure_iUnion_atTop / tendsto_measure_iInter_atTop on preimage families {\u03c9 | X 0 \u03c9 \u2264 n} for integer thresholds.",
+      "S10+: greedy finite \u03b5-step subdivision packaging S8 + S9 into bracketingGrid_exists. ~150-250 lines. Mathlib upstream candidate: Monotone.exists_increasing_continuity_seq."
     ]
   },
   "tags": [
@@ -75,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-05-13T22:50:00.000Z",
+  "lastUpdate": "2026-05-14T08:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

This slug had shipped **seven consecutive "(build pending)" PRs** (S3 → S9 ACT,
2026-05-08 → 2026-05-13). Pre-claim Docker build of the bracketing companion
file surfaced two v4.26.0 elaborator regressions in code unchanged since the
S5 / S8 PRs — both surgical fixes, both preserving every theorem statement
bit-for-bit.

**Fix 1 — `set F`/`set Fn` rebinds `G` to `G✝`** (line 396, in
`bracketing_pointwise_bound`):

```diff
-  set F : ℝ → ℝ := trueCDF X μ with hF_def
-  set Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω with hFn_def
+  let F : ℝ → ℝ := trueCDF X μ
+  let Fn : ℝ → ℝ := fun y => empiricalCDF X n y ω
   set M : ℝ := Finset.univ.sup' Finset.univ_nonempty
-    (fun j : Fin (G.k + 2) => |Fn (G.q j) - F (G.q j)|) with hM_def
+    (fun j : Fin (G.k + 2) =>
+      |empiricalCDF X n (G.q j) ω - trueCDF X μ (G.q j)|) with hM_def
```

`set F := trueCDF X μ` rewrites the type of `G` from `BracketingGrid (trueCDF X μ) ε`
to `BracketingGrid F ε`. In v4.26.0 Lean tags the original parameter `G✝` and
introduces a fresh local `G` with the rewritten type. The outer-goal
`Finset.sup'` (elaborated against the signature pre-`set`) then references
`G✝.q j` while inner hypotheses use `G.q j`, and the right-tail closing
`linarith` cannot bridge the rename. `let` avoids the substitution → no
rebinding.

**Fix 2 — typeclass-deferral strictness** (line 188, in
`trueCDF_continuityPoint_in_Ioo`):

```diff
-  have h_dense := trueCDF_continuityPoints_dense X
+  have h_dense : Dense {x : ℝ | ContinuousAt (trueCDF X μ) x} :=
+    trueCDF_continuityPoints_dense X
```

v4.26.0's elaborator refuses to defer `IsProbabilityMeasure ?m.23` typeclass
resolution past a bare `have`; the explicit type annotation fixes `μ` for
typeclass lookup.

## What this PR does NOT do

- Does NOT start S10 ACT proper (greedy ε-cover induction discharging
  `bracketingGrid_exists`, ~161 LOC). PREP-1 (#18499) + PREP-2 (#18528)
  designs are unchanged.
- Does NOT refactor §2.2.5 / §2.2.6 / §2.5 (S8 / S9 / S6 ACT material).
- Does NOT touch parent file `LawsOfLargeNumbersOQ04.lean` or main file
  `LawsOfLargeNumbersOQ04OQ03.lean`.
- Does NOT introduce new axioms or sorries; the file's sole axiom
  `bracketingGrid_exists` is unchanged.

## Counts

| File | Lines | Theorems | Axioms | Sorries |
|------|------:|---------:|-------:|--------:|
| `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` | 670 (+9) | 12 | 1 | 0 |

The +9 LOC are comments / type-annotation expansion. Theorem count
unchanged.

## Build status

**VERIFIED** clean.

```
$ ./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing
=== Docker Lean Build ===
...
Build completed successfully (3121 jobs).
=== Build succeeded ===
```

Pre-fix baseline: two errors at lines 188 (typeclass stuck) and 506
(linarith bridge failure). Post-fix: exit 0.

**Retires "(build pending)" qualifier** on the 7-PR S3 → S9 ACT chain
(#17417, #17442, #17692, #17907, #18146, #18208, #18936).

## Test plan

- [x] Pre-claim Docker baseline build to reproduce the two regressions
- [x] Apply surgical fixes (5 LOC + 2 LOC + 9 lines of comments)
- [x] Re-build Docker: `Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exits 0
      with 3121 jobs
- [x] Confirm no theorem statements changed (signatures bit-for-bit)
- [x] Confirm 0 axioms added, 0 sorries added
- [x] Confirm `bracketingGrid_exists` remains the sole axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
