### PR TITLE
fix(mechanic): cramers-rule v4.26.0 parent-file repair (27 → 0 errors)

### DIFF
--- a/proofs/Proofs/CramersRuleOQ01OQ02.lean
+++ b/proofs/Proofs/CramersRuleOQ01OQ02.lean
@@ -112,10 +112,11 @@ theorem qdet01_mul_eq_neg_det {F : Type*} [Field F]
   field_simp
   ring
 
-/-- Over a commutative field: a11 * |A|10 = -det(A) -/
+/-- Over a commutative field: a01 * |A|10 = -det(A)
+    (b * |A|10 = -det(A) per the doc table, where b = A 0 1 is the complement of position (1,0)). -/
 theorem mul_qdet10_eq_neg_det {F : Type*} [Field F]
     (A : Matrix (Fin 2) (Fin 2) F) (h : A 0 1 ≠ 0) :
-    A 1 1 * qdet10 A = -A.det := by
+    A 0 1 * qdet10 A = -A.det := by
   simp only [qdet10, det_fin_two]
   field_simp
   ring
@@ -154,12 +155,12 @@ theorem qdet11_lower_tri (A : Matrix (Fin 2) (Fin 2) D) (h : A 0 1 = 0) :
 /-- For an upper triangular matrix, |A|01 = a01. -/
 theorem qdet01_upper_tri (A : Matrix (Fin 2) (Fin 2) D) (h : A 1 0 = 0) :
     qdet01 A = A 0 1 := by
-  simp [qdet01, h, inv_zero, mul_zero, zero_mul]
+  simp [qdet01, h, _root_.inv_zero, mul_zero, zero_mul]
 
 /-- For a lower triangular matrix, |A|10 = a10. -/
 theorem qdet10_lower_tri (A : Matrix (Fin 2) (Fin 2) D) (h : A 0 1 = 0) :
     qdet10 A = A 1 0 := by
-  simp [qdet10, h, inv_zero, mul_zero, zero_mul]
+  simp [qdet10, h, _root_.inv_zero, mul_zero, zero_mul]
 
 -- ============================================================
 -- PART IV: Row and Column Scaling
@@ -184,7 +185,7 @@ theorem qdet00_left_row0_scale (a b c d : D) (lambda : D) :
     qdet00 A' = lambda * qdet00 A := by
   simp only [qdet00, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
     Matrix.head_cons, Matrix.head_fin_const]
-  rw [mul_sub, mul_assoc, mul_assoc]
+  rw [mul_sub, mul_assoc, mul_assoc, mul_assoc]
 
 /-- Right column scaling: |A|00 is right-linear in column 0.
     If a' = a*lambda, c' = c*lambda (col 0 scaled), then |A'|00 = |A|00 * lambda. -/
@@ -277,14 +278,14 @@ theorem nc_kernel_trivial_alt (A : Matrix (Fin 2) (Fin 2) D) (x : Fin 2 → D)
     simp [mulVec, dotProduct, Fin.sum_univ_two] at this; exact this
   -- From row 0: x0 = -(a00^{-1} * a01 * x1)
   have hx0 : x 0 = -((A 0 0)⁻¹ * (A 0 1 * x 1)) := by
-    have h := eq_neg_of_add_eq_zero_right hrow0
+    have h : A 0 0 * x 0 = -(A 0 1 * x 1) := add_eq_zero_iff_eq_neg.mp hrow0
     calc x 0 = (A 0 0)⁻¹ * (A 0 0 * x 0) := by
             rw [← mul_assoc, inv_mul_cancel₀ h00, one_mul]
       _ = -((A 0 0)⁻¹ * (A 0 1 * x 1)) := by rw [h, mul_neg]
   -- Substitute into row 1: qdet11(A) * x1 = 0
   have hqx : qdet11 A * x 1 = 0 := by
     have h1 : A 1 0 * (-((A 0 0)⁻¹ * (A 0 1 * x 1))) + A 1 1 * x 1 = 0 := by rwa [← hx0]
-    rw [mul_neg, ← sub_eq_add_neg] at h1
+    rw [mul_neg, neg_add_eq_sub] at h1
     rw [← mul_assoc (A 1 0), ← mul_assoc (A 1 0 * (A 0 0)⁻¹)] at h1
     rwa [← sub_mul, show A 1 1 - A 1 0 * (A 0 0)⁻¹ * A 0 1 = qdet11 A from rfl] at h1
   -- qdet11 != 0, so x1 = 0; then x0 = 0
@@ -342,11 +343,13 @@ def schurInv (A : Matrix (Fin 2) (Fin 2) D) : Matrix (Fin 2) (Fin 2) D := fun i 
 
 @[simp] lemma schurInv_01 (A : Matrix (Fin 2) (Fin 2) D) :
     schurInv A 0 1 = -((qdet00 A)⁻¹ * A 0 1 * (A 1 1)⁻¹) := by
-  simp only [schurInv, show ¬(1 : Fin 2) = (0 : Fin 2) from by decide]
+  simp only [schurInv, show ¬(1 : Fin 2) = (0 : Fin 2) from by decide,
+    if_true, if_false, ite_true, ite_false]
 
 @[simp] lemma schurInv_10 (A : Matrix (Fin 2) (Fin 2) D) :
     schurInv A 1 0 = -((A 1 1)⁻¹ * A 1 0 * (qdet00 A)⁻¹) := by
-  simp only [schurInv, show ¬(1 : Fin 2) = (0 : Fin 2) from by decide]
+  simp only [schurInv, show ¬(1 : Fin 2) = (0 : Fin 2) from by decide,
+    if_true, if_false, ite_true, ite_false]
 
 @[simp] lemma schurInv_11 (A : Matrix (Fin 2) (Fin 2) D) :
     schurInv A 1 1 =
@@ -360,9 +363,11 @@ theorem mul_schurInv_00 (A : Matrix (Fin 2) (Fin 2) D)
     (hq : qdet00 A ≠ 0) :
     A 0 0 * schurInv A 0 0 + A 0 1 * schurInv A 1 0 = 1 := by
   simp only [schurInv_00, schurInv_10]
-  rw [mul_neg, ← sub_eq_add_neg, ← mul_assoc (A 0 1), ← mul_assoc (A 0 1 * (A 1 1)⁻¹),
-    ← sub_mul]
-  rw [show A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0 = qdet00 A from rfl]
+  rw [mul_neg, ← sub_eq_add_neg]
+  rw [show A 0 1 * ((A 1 1)⁻¹ * A 1 0 * (qdet00 A)⁻¹) =
+        A 0 1 * (A 1 1)⁻¹ * A 1 0 * (qdet00 A)⁻¹ from by
+    rw [← mul_assoc, ← mul_assoc]]
+  rw [← sub_mul, show A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0 = qdet00 A from rfl]
   exact mul_inv_cancel₀ hq
 
 /-- The (1,0) entry of A * schurInv(A) is 0.
@@ -371,7 +376,10 @@ theorem mul_schurInv_10 (A : Matrix (Fin 2) (Fin 2) D)
     (hd : A 1 1 ≠ 0) :
     A 1 0 * schurInv A 0 0 + A 1 1 * schurInv A 1 0 = 0 := by
   simp only [schurInv_00, schurInv_10]
-  rw [mul_neg, ← sub_eq_add_neg, ← mul_assoc, mul_inv_cancel₀ hd, one_mul, sub_self]
+  rw [mul_neg]
+  rw [show A 1 1 * ((A 1 1)⁻¹ * A 1 0 * (qdet00 A)⁻¹) = A 1 0 * (qdet00 A)⁻¹ from by
+    rw [← mul_assoc, ← mul_assoc, mul_inv_cancel₀ hd, one_mul]]
+  exact add_neg_cancel _
 
 -- ============================================================
 -- PART VII: Transpose and Commutativity
@@ -414,12 +422,12 @@ This is the non-commutative analogue of det(triangular) = product of diagonal.
     (Since 0^{-1} = 0 in a DivisionRing, the correction term vanishes.) -/
 theorem qdet00_of_zero_complement (A : Matrix (Fin 2) (Fin 2) D) (h : A 1 1 = 0) :
     qdet00 A = A 0 0 := by
-  simp [qdet00, h, inv_zero, mul_zero, zero_mul]
+  simp [qdet00, h, _root_.inv_zero, mul_zero, zero_mul]
 
 /-- If the complementary entry a00 = 0, then qdet11 = a11. -/
 theorem qdet11_of_zero_complement (A : Matrix (Fin 2) (Fin 2) D) (h : A 0 0 = 0) :
     qdet11 A = A 1 1 := by
-  simp [qdet11, h, inv_zero, mul_zero, zero_mul]
+  simp [qdet11, h, _root_.inv_zero, mul_zero, zero_mul]
 
 -- ============================================================
 -- PART IX: Quasideterminant Product Identities
@@ -446,9 +454,9 @@ theorem qdet00_eq_det_div {F : Type*} [Field F]
 theorem qdet11_eq_det_div {F : Type*} [Field F]
     (A : Matrix (Fin 2) (Fin 2) F) (h : A 0 0 ≠ 0) :
     qdet11 A = A.det * (A 0 0)⁻¹ := by
-  have := mul_qdet11_eq_det A h
-  rw [eq_comm, ← mul_left_cancel₀ h (qdet11 A) (A.det * (A 0 0)⁻¹)]
-  rw [this, mul_assoc, mul_inv_cancel₀ h, mul_one]
+  have hmul := mul_qdet11_eq_det A h
+  rw [← hmul]
+  field_simp
 
 /-- Over a commutative field, the two diagonal quasideterminants are proportional:
     |A|00 * a00 = |A|11 * a11 (both equal det(A)). -/

--- a/proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean
@@ -71,20 +71,20 @@ abbrev block3 (A : Matrix (Fin 3) (Fin 3) D) (i j : Fin 3) : Matrix (Fin 2) (Fin
 @[simp] lemma block3_22_10 (A : Matrix (Fin 3) (Fin 3) D) : block3 A 2 2 1 0 = A 1 0 := rfl
 @[simp] lemma block3_22_11 (A : Matrix (Fin 3) (Fin 3) D) : block3 A 2 2 1 1 = A 1 1 := rfl
 
-/-- det(block3 A 0 0) = A11·A22 - A12·A21 -/
-lemma block3_00_det (A : Matrix (Fin 3) (Fin 3) D) :
+/-- det(block3 A 0 0) = A11·A22 - A12·A21 (Matrix.det requires CommRing, so over F). -/
+lemma block3_00_det {F : Type*} [Field F] (A : Matrix (Fin 3) (Fin 3) F) :
     (block3 A 0 0).det = A 1 1 * A 2 2 - A 1 2 * A 2 1 := by
-  simp [Matrix.det_fin_two]
+  simp only [Matrix.det_fin_two, block3_00_00, block3_00_01, block3_00_10, block3_00_11]
 
-/-- det(block3 A 1 1) = A00·A22 - A02·A20 -/
-lemma block3_11_det (A : Matrix (Fin 3) (Fin 3) D) :
+/-- det(block3 A 1 1) = A00·A22 - A02·A20 (Matrix.det requires CommRing, so over F). -/
+lemma block3_11_det {F : Type*} [Field F] (A : Matrix (Fin 3) (Fin 3) F) :
     (block3 A 1 1).det = A 0 0 * A 2 2 - A 0 2 * A 2 0 := by
-  simp [Matrix.det_fin_two]
+  simp only [Matrix.det_fin_two, block3_11_00, block3_11_01, block3_11_10, block3_11_11]
 
-/-- det(block3 A 2 2) = A00·A11 - A01·A10 -/
-lemma block3_22_det (A : Matrix (Fin 3) (Fin 3) D) :
+/-- det(block3 A 2 2) = A00·A11 - A01·A10 (Matrix.det requires CommRing, so over F). -/
+lemma block3_22_det {F : Type*} [Field F] (A : Matrix (Fin 3) (Fin 3) F) :
     (block3 A 2 2).det = A 0 0 * A 1 1 - A 0 1 * A 1 0 := by
-  simp [Matrix.det_fin_two]
+  simp only [Matrix.det_fin_two, block3_22_00, block3_22_01, block3_22_10, block3_22_11]
 
 -- ============================================================
 -- PART II: The 9 Quasideterminants over a Field
@@ -154,6 +154,7 @@ theorem qdet3_00_schur_expand (A : Matrix (Fin 3) (Fin 3) F)
     qdet3 A 0 0 = A 0 0
       - (A 0 1 * A 2 2 - A 0 2 * A 2 1) / (block3 A 0 0).det * A 1 0
       - (A 0 2 * A 1 1 - A 0 1 * A 1 2) / (block3 A 0 0).det * A 2 0 := by
+  rw [block3_00_det] at h
   simp only [qdet3, block3_00_det, Matrix.det_fin_three]
   field_simp
   ring
@@ -239,6 +240,14 @@ theorem qdet3_00_nc_eq_qdet3 (A : Matrix (Fin 3) (Fin 3) F)
     (hd : A 2 2 ≠ 0)
     (hq : A 1 1 - A 1 2 * (A 2 2)⁻¹ * A 2 1 ≠ 0) :
     qdet3_00_nc A = qdet3 A 0 0 := by
+  -- Derive the un-inverted-form non-vanishing hypothesis field_simp needs.
+  have hq2 : A 1 1 * A 2 2 - A 1 2 * A 2 1 ≠ 0 := by
+    intro hzero
+    apply hq
+    have hmul : (A 1 1 - A 1 2 * (A 2 2)⁻¹ * A 2 1) * A 2 2 = A 1 1 * A 2 2 - A 1 2 * A 2 1 := by
+      field_simp
+    rw [hzero] at hmul
+    exact (mul_eq_zero.mp hmul).resolve_right hd
   simp only [qdet3_00_nc, qdet3, schurComp3, block3_00_det, Matrix.det_fin_three]
   field_simp
   ring
@@ -249,7 +258,6 @@ theorem schurComp3_mul_eq_minor_det (A : Matrix (Fin 3) (Fin 3) F)
     schurComp3 A * A 2 2 = (block3 A 0 0).det := by
   simp only [schurComp3, block3_00_det]
   field_simp
-  ring
 
 -- ============================================================
 -- PART VI: The 3×3 Cramer's Rule
@@ -270,7 +278,7 @@ for any (i,j) with non-zero minor, expressing the denominator via a quasidetermi
 theorem cramer_rule_3x3 (A : Matrix (Fin 3) (Fin 3) F) (b : Fin 3 → F)
     (hA : A.det ≠ 0) :
     A.mulVec (A.det⁻¹ • A.cramer b) = b := by
-  rw [mulVec_smul, Matrix.mulVec_cramer, smul_smul, inv_mul_cancel hA, one_smul]
+  rw [mulVec_smul, Matrix.mulVec_cramer, smul_smul, inv_mul_cancel₀ hA, one_smul]
 
 /-- The quasideterminant denominator: det(A) = qdet₃ A i j · det(block3 A i j). -/
 theorem cramer_denom_qdet (A : Matrix (Fin 3) (Fin 3) F) (i j : Fin 3)


### PR DESCRIPTION
## Fix

Repairs Mathlib v4.26.0 regressions in CramersRule parent chain per inventory in PR #19036 (cramers-rule-oq-01-oq-02-oq-01-oq-01 S4 precheck). Unblocks S4 ACT for the deeper slug.

## Surgical changes

### `CramersRuleOQ01OQ02OQ01.lean` (13 → 0 errors)

| Site | Class | Fix |
|------|-------|-----|
| 75-87 | Typeclass tightening | `block3_XX_det` over `DivisionRing D` → `[Field F]` (Matrix.det requires CommRing in v4.26.0; all call sites already in Field context) |
| 86 | Simp-shift | `Matrix.det_fin_two` no longer auto-reduces `Fin.succAbove 2 _`; switched all three `block3_XX_det` to explicit entry simp lemmas (`block3_XX_00..11`) |
| 156 | field_simp denom | Added `rw [block3_00_det] at h` before `field_simp` so denominator non-vanishing fires |
| 241 | field_simp denom | Derived `A 1 1 * A 2 2 - A 1 2 * A 2 1 ≠ 0` from `hd ∧ hq` to unblock `field_simp` |
| 249 | "no goals" | Trailing `ring` removed; `field_simp` now closes |
| 273 | Lemma rename | `inv_mul_cancel hA` → `inv_mul_cancel₀ hA` (v4.26.0 reserved unconditional name for groups) |

### `CramersRuleOQ01OQ02.lean` (14 → 0 errors)

| Site | Class | Fix |
|------|-------|-----|
| 157, 162, 417, 422 | Ambiguous term | `inv_zero` → `_root_.inv_zero` (4 sites; `Matrix.inv_zero` collision) |
| 118 | Pre-existing typo | `mul_qdet10_eq_neg_det` claimed `A 1 1 * qdet10 A = -A.det` — verified false at `[[1,2],[3,4]]`. Per docstring table line 88 (`b * |A|10 = -det(A)`, `b = A 0 1`), fixed to `A 0 1 * qdet10 A`. Not used elsewhere (grep'd) |
| 184 | mul_assoc chain | Added third `mul_assoc` to the rewrite chain to flatten non-comm DivisionRing bracketing |
| 281 | Convention shift | `eq_neg_of_add_eq_zero_right hrow0` → `add_eq_zero_iff_eq_neg.mp hrow0` (convention-robust against v4.26.0 left/right argument-order shift) |
| 287 | Pattern mismatch | `← sub_eq_add_neg` (pattern `?a + -?b`) didn't match `-?a + ?b` form after `mul_neg`; replaced with `neg_add_eq_sub` (`-a + b = b - a`) |
| 344, 348 | ite-reduce | `schurInv_01`, `schurInv_10` simp set augmented with `if_true, if_false, ite_true, ite_false` (v4.26.0 `simp only` no longer auto-reduces `if True/False` literals) |
| 363 | mul_assoc chain | `mul_schurInv_00`: refactored `← mul_assoc` chain to explicit `show ... = ...` block |
| 374 | mul_assoc chain | `mul_schurInv_10`: same refactor; concludes with `add_neg_cancel _` after explicit re-association |
| 448, 450 | API misuse | `qdet11_eq_det_div` used `mul_left_cancel₀` as a rewrite-rule, but the lemma produces an equality (not a Prop to rewrite by); simplified to `rw [← hmul]; field_simp` |

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.CramersRuleOQ01OQ02OQ01OQ01
✓ [3060/3060] Built Proofs.CramersRuleOQ01OQ02OQ01OQ01 (4.8s)
Build completed successfully (3060 jobs).
warning: ...:265:8: declaration uses 'sorry'   (← S4 ACT research-scope, not mechanic)
```

Both parent files build clean. Deepest slug file (1 sorry, the S4 ACT research target) now elaborates — was previously blocked by parent elaboration failures.

## Honesty checklist

- ✅ All theorem statements preserved verbatim EXCEPT `mul_qdet10_eq_neg_det` (fixed mathematically-false pre-existing typo `A 1 1` → `A 0 1`; not used anywhere else per `grep -rn`)
- ✅ No `sorry` introduced; the slug's existing 1 sorry at `CramersRuleOQ01OQ02OQ01OQ01.lean:265` is the S4 ACT research target, untouched
- ✅ `axiomCount` unchanged (gallery metadata untouched)
- ✅ All `block3_XX_det` call sites verified to be in `[Field F]` context; type tightening is safe
- ✅ Docker-verified via wrapper (not direct `lake build`)
- ✅ No `loom:review-requested` label (math/mechanic scope; deployer merges directly)

## Test plan

- [x] `Proofs.CramersRuleOQ01OQ02` builds clean (3058 jobs)
- [x] `Proofs.CramersRuleOQ01OQ02OQ01` builds clean (3058 jobs)
- [x] `Proofs.CramersRuleOQ01OQ02OQ01OQ01` builds clean (3060 jobs, 1 research-scope sorry)
- [x] Diff scope: 2 Lean files only (no gallery, no metadata)
- [x] `mul_qdet10_eq_neg_det` math verified at `[[1,2],[3,4]]`: `A 0 1 * qdet10 A = 2 * (3 - 4 * (1/2)) = 2 = -det = 2` ✓

Closes part of #19036's actionable inventory; S4 ACT for `cramers-rule-oq-01-oq-02-oq-01-oq-01` is now unblocked.

---
Automated repair by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
