### PR TITLE
research(gauss-wilson-non-cyclic-oq-01): S9 ACT — outer-theorem NeZero unblocker (build verified 3065 jobs, sorry chain intact)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
@@ -174,18 +174,20 @@ theorem prod_eq_one_of_not_isCyclic_aux {n : ℕ} (hn : n ≥ 3) [NeZero n]
     4 bugs in the proof skeleton flagged by S5b PREP (PR #18607); this
     file ships the corrected version. -/
 theorem prod_univ_units_zmod_eq_neg_one_iff_isCyclic
-    {n : ℕ} (hn : 1 ≤ n) :
+    {n : ℕ} [NeZero n] :
     (∏ x : (ZMod n)ˣ, x) = -1 ↔ IsCyclic (ZMod n)ˣ := by
+  have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr (NeZero.ne n)
   -- Dispatch small cases `n ∈ {1, 2}` separately, then handle `n ≥ 3` generically.
   rcases Nat.lt_or_ge n 3 with hlt | hge
   · -- n ∈ {1, 2}
     interval_cases n
-    · -- n = 1: (ZMod 1)ˣ is trivial; both sides hold.
-      decide
+    · -- n = 1: (ZMod 1)ˣ is trivial (subsingleton); both sides hold.
+      refine ⟨fun _ => isCyclic_of_subsingleton, fun _ => ?_⟩
+      exact Subsingleton.elim _ _
     · -- n = 2: (ZMod 2)ˣ has one element (1 = -1); both sides hold.
-      decide
+      refine ⟨fun _ => isCyclic_of_subsingleton, fun _ => ?_⟩
+      exact Subsingleton.elim _ _
   · -- n ≥ 3
-    haveI : NeZero n := ⟨by omega⟩
     by_cases h_cyc : IsCyclic (ZMod n)ˣ
     · -- Cyclic case: both sides hold (via prod_eq_neg_one_of_isCyclic_aux).
       refine ⟨fun _ => h_cyc, fun _ => ?_⟩


### PR DESCRIPTION
## Summary

S9 ACT for `gauss-wilson-non-cyclic-oq-01`. Unblocks the build-pending chain (since S6 ACT #18652) with a **12-line surgical fix** to the outer theorem's typeclass arg. File now builds clean (3065 jobs), 1 sorry remains (Phase C non-cyclic direction at line 146, unchanged).

## Diagnosis

`prod_univ_units_zmod_eq_neg_one_iff_isCyclic` had signature `{n : ℕ} (hn : 1 ≤ n)`. The goal `(∏ x : (ZMod n)ˣ, x) = -1 ↔ IsCyclic (ZMod n)ˣ` failed elaboration at the STATEMENT level because `Fintype (ZMod n)ˣ` cannot be synthesised from just a hypothesis (no typeclass). The intra-proof `haveI : NeZero n := ⟨by omega⟩` (line 188 in the `n ≥ 3` branch) was too late — the elaborator already refused the statement.

Per memory entry [`feedback_researcher_build_pending_slug_series_silent_parent_regression`](https://...) — slug series with 4+ "build pending" PRs can hide silent regressions; Docker-build pre-claim is the diagnostic. Confirmed: the failure predates S7 ACT (#18743), S8 ACT (#18957), and STATE-SYNC #18942, all of which shipped on the assumption that the file would eventually compile.

## Fix (12-line diff)

1. `(hn : 1 ≤ n)` → `[NeZero n]`. Typeclass arg flows into `Fintype (ZMod n) → Fintype (ZMod n)ˣ` at goal-elaboration time.
2. `have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr (NeZero.ne n)` preserves internal use of `hn` in `interval_cases n`.
3. n = 1 / n = 2 cases: `decide` replaced by `refine ⟨fun _ => isCyclic_of_subsingleton, fun _ => ?_⟩; exact Subsingleton.elim _ _`. Reason: `decide` cannot synthesise `Decidable` for the residual `[NeZero 1]` / `[NeZero 2]` context with `IsCyclic` (non-decidable Prop); the subsingleton path is direct.
4. Drop redundant intra-proof `haveI : NeZero n`.

## Build

```
./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ01
...
⚠ [3065/3065] Built Proofs.GaussWilsonNonCyclicOQ01 (20s)
warning: Proofs/GaussWilsonNonCyclicOQ01.lean:146:8: declaration uses 'sorry'
Build completed successfully (3065 jobs).

=== Build succeeded ===
```

The single `'sorry'` warning is at line 146 (`prod_eq_one_of_not_isCyclic_aux`, Phase C non-cyclic direction), unchanged.

## Out of scope

- Inner sorry discharge. Needs a Subgroup construction (2-torsion), `Fintype ↥T` synthesis (4 Mathlib API gotchas surfaced during the diagnostic attempt: `Finset.card_sdiff` signature, `Fintype ↥T` instance, neg-pow on Units, `decide +revert` universe issue), and a |S| ≥ 3 → |S| ≥ 4 bump via the `-x` trick on the 3rd 2-torsion witness. ~80 LOC, worth a separate ACT.
- No state.md, meta.json, or research JSON edits. The slug's `meta.json sorries: 1` from S8 ACT #18957 already matches.
- No external callers of the outer theorem — `grep prod_univ_units_zmod_eq_neg_one_iff_isCyclic` returns only the file's own docstring references.

## Test plan

- [x] Docker build clean: 3065 jobs, 20s after cache hit.
- [x] Sorry count unchanged (1: `prod_eq_one_of_not_isCyclic_aux` at line 146).
- [x] No external callers of `prod_univ_units_zmod_eq_neg_one_iff_isCyclic` (grep confirms).
- [x] The 12-line diff localised to lines 177-194 of the outer theorem.
