### PR TITLE
audit(kepler-conjecture-oq-04): fix axiomCount 0→1 + lineCount drift

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -20,9 +20,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 225,
-    "assumptions": "0 sorries, 0 axioms in this file. The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file adds no new axioms — it defines the Chen-Engel-Glotzer rational constant 4000/4671 and the `tetrahedronDimerPacking : PackingDensity` instance, and proves five theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_315` and `Real.lt_sqrt`, axiom-free) and the existential corollary `exists_packingDensity_gt_fcc`. The ellipsoid (Bezdek-Kuperberg) and Ulam (open conjecture) sub-questions will require axiomatization when introduced in future iterations.",
+    "axiomCount": 1,
+    "lineCount": 321,
+    "assumptions": "0 sorries, 1 axiom in this file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`: every `EllipsoidLatticePacking` has density ≤ `fccDensity`; Bezdek–Kuperberg, Geom. Dedicata 2007). The parent `Proofs/KeplerConjecture.lean` separately axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). The tetrahedral side is axiom-free: the Chen-Engel-Glotzer rational constant 4000/4671 and the `tetrahedronDimerPacking : PackingDensity` instance, plus `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_315` and `Real.lt_sqrt`) and the existential corollary `exists_packingDensity_gt_fcc`, all `nlinarith`-discharged. The Ulam (open conjecture) sub-question will require additional axiomatization when introduced in a future iteration.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

Gallery integrity fix discovered by the lean auditor agent.

`src/data/proofs/kepler-conjecture-oq-04/meta.json` had drifted from `proofs/Proofs/KeplerConjectureOQ04.lean` after S3+ work axiomatized `bezdek_kuperberg_ellipsoid_lattice_upper_bound` (line 303) and grew the file to 321 LOC.

| Field | meta.json (before) | Actual | After |
|-------|--------------------|--------|-------|
| `axiomCount` | 0 | 1 | 1 |
| `lineCount` | 225 | 321 | 321 |
| `assumptions` | "0 axioms in this file" | 1 axiom | rewritten to name the axiom + cite Bezdek–Kuperberg 2007 |

Per **Axiom Integrity Policy** in `CLAUDE.md`: `axiomCount` in meta.json must reflect ALL assumptions (`axiom` declarations + assumption-carrying structure fields). The badge `axiom` and status `axiomatized` are already correct — only the count and assumptions text needed updating.

## Test plan

- [x] Confirmed 1 real `^axiom ` declaration in the source file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound` at line 303; a second `^axiom ` line at 172 is inside a `/-- ... -/` docstring)
- [x] Confirmed 0 sorries
- [x] Confirmed `EllipsoidLatticePacking extends PackingDensity` has no structure-encoded assumption fields
- [x] Confirmed line count of source file is 321
- [x] Doc-only meta.json edit; no Lean changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)