### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01): S4 STATE-SYNC — pool/JSON drift fix post-S3 merge (doc-only)

### DIFF
--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md
@@ -1,8 +1,65 @@
 # Current State
 
-**Phase**: ACT (S3 back-port complete: parent sorry closed inline)
+**Phase**: COMPLETED (S3 back-port merged; slug goal achieved)
 **Since**: 2026-05-12T12:05:00Z (S3, researcher-6)
 **Iteration**: 3
+
+## Iteration 4 (researcher-12, 2026-05-14) — S4 STATE-SYNC: pool/JSON drift fix (doc-only)
+
+**Outcome**: progress — STATE-SYNC after S1/S2/S3 PRs (#17989, #18002, #18089)
+all merged into `main`. The slug's stated goal — discharging
+`multinomialPMF_sum_eq_one` — was achieved on 2026-05-12; verification:
+`grep "\bsorry\b" proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean`
+returns 4 remaining sorries, all on out-of-scope theorems
+(`multinomialPMF_support`, `multinomial_marginal_binomial`,
+`multinomial_mean`, `multinomial_covariance`; lines 164/185/200/213).
+None is `multinomialPMF_sum_eq_one`. The deferred sorry was closed by S3's
+inline anonymous-Equiv + 4-step `rw` chain.
+
+But the candidate pool kept `status: "available"` for this slug (with
+no `notes` update), and `src/data/research/problems/<slug>.json` kept
+`phase: "ACT"` at the top level — so the slug was visible to depth-first
+claim-random and ResearchPage gallery listings still showed it as
+in-flight. claim-random selected it twice in the same session for
+researcher-12 before the drift was diagnosed.
+
+### What I changed (doc-only, 3 fields)
+
+* `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`:
+  - top-level `phase: "ACT" → "COMPLETED"`
+  - top-level `lastUpdate: "2026-05-12T08:12:00.000Z" → "2026-05-14T16:40:00.000Z"`
+  - `currentState.phase: "ACT" → "COMPLETED"` (mirrors top-level)
+* `.lean/state/candidate-pool.json` (gitignored runtime state; updated
+  out-of-PR via `claim-problem.sh update <slug> completed`):
+  candidate entry `status: "available" → "completed"`. Future
+  claim-random invocations will skip this slug.
+
+### Why STATE-SYNC, not a new iteration
+
+Per problem.md §"What This OQ Entry Does NOT Claim", the four
+remaining sorries in `BinomialTheoremOQ02OQ01OQ01.lean` are explicit
+non-goals; they belong to sibling slugs. Extending the scope here
+would violate the slug's stated boundary. The honest action is to
+flush the drift and let depth-first selection move to the next
+RICH slug.
+
+### Files modified (S4 narrow)
+
+- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`
+  — 3 field updates (top-level `phase`, top-level `lastUpdate`,
+  `currentState.phase`).
+- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md`
+  — this S4 entry.
+
+No `.lean` files touched. No Docker build needed (zero proof delta).
+
+### Pool side-effect (out-of-PR)
+
+`scripts/research/claim-problem.sh update <slug> completed` ran
+out-of-band; `.lean/state/candidate-pool.json` is gitignored and not
+part of this PR.
+
+---
 
 ## Iteration 3 (researcher-6, 2026-05-12) — S3 back-port: close parent sorry
 

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01",
   "title": "Discharge multinomialPMF_sum_eq_one by combining the gallery's piAntidiag bridge with Mathlib's multinomial theorem",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "completed",
   "tier": "B",
   "path": "full",
@@ -27,7 +27,7 @@
     "goal": "Produce a Lean 4 file proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean (~50-60 lines, 0 axioms, 0 sorries) containing (i) a 10-line compositionTypeEquiv bridge between BinomialTheoremOQ02OQ01OQ01.Composition and CompositionFintype.Composition, and (ii) a theorem multinomialPMF_sum_eq_one_proved that closes the parent's sorry by sum_equiv + the two existing lemmas. Add an import line to proofs/Proofs.lean in alphabetical position. Target: build verified inside Docker; ≤ 60 lines."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-05-12T12:05:00.000Z",
     "iteration": 3,
     "focus": "S3 back-port (researcher-6, 2026-05-12) — closed the parent's BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one sorry directly by inlining a record-wise anonymous Equiv plus the same 4-step rw chain used in S2's multinomialPMF_sum_eq_one_proved. The state.md S2 next-action suggestion of `exact ...` (one-line wrapper) could not be used because the new sibling file (where _proved lives) imports the parent — a wrapper would cycle. Instead the parent imports Proofs.BinomialTheoremOQ02OQ01OQ01OQ01 (no cycle: the sibling has no parent-file deps) and inlines the proof body. The slug's stated goal — discharge multinomialPMF_sum_eq_one — is now achieved in both places (sibling file from S2 and parent file from S3). The four remaining downstream sorries (multinomialPMF_support, multinomial_marginal_binomial, multinomial_mean, multinomial_covariance) are explicit non-goals per S1 knowledge.md §10.",
@@ -122,7 +122,7 @@
     ]
   },
   "started": "2026-05-12T08:02:11.448Z",
-  "lastUpdate": "2026-05-12T08:12:00.000Z",
+  "lastUpdate": "2026-05-14T16:40:00.000Z",
   "significance": 5,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S4 STATE-SYNC, doc-only. Refreshes JSON top-level `phase` from `ACT` → `COMPLETED` and `lastUpdate` after the slug's stated goal was achieved by S3 PR #18089 (merged 2026-05-12). Updates `state.md` with an S4 entry.

The slug's stated goal — discharging `BinomialTheoremOQ02OQ01OQ01.multinomialPMF_sum_eq_one` — was reached on 2026-05-12 via S1 #17989 + S2 #18002 + S3 #18089. Verification (run from worktree on main):

```
$ grep "\bsorry\b" proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
164:  sorry -- Follows from the product being nonzero iff each factor is nonzero
185:  sorry -- Requires: fixing k(i) = m, summing over remaining components,
200:  sorry -- Standard: E[Xᵢ] = n·pᵢ for multinomial
213:  sorry -- Cov(Xᵢ, Xⱼ) = E[XᵢXⱼ] - E[Xᵢ]E[Xⱼ] = n(n-1)pᵢpⱼ - (npᵢ)(npⱼ) = -npᵢpⱼ
```

The 4 remaining sorries correspond to `multinomialPMF_support`, `multinomial_marginal_binomial`, `multinomial_mean`, `multinomial_covariance` — all explicit non-goals per problem.md §"What This OQ Entry Does NOT Claim" (they belong to sibling slugs).

## Why this STATE-SYNC matters

- The JSON top-level `phase` field was stale (`ACT` instead of `COMPLETED`); per memory-trap `feedback_researcher_state_sync_misses_top_level_phase`, `scripts/research/build.ts` aggregates top-level `phase` into `research-listings.json` for the gallery's ResearchPage — drift causes user-visible misclassification.
- The candidate pool kept `status: "available"`; depth-first claim-random re-selected this slug for researcher-12 in this session before the drift was diagnosed (~3 wasted attempts).

## Changes (doc-only, 2 files)

- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`: 3 field updates (`phase` top-level, `currentState.phase`, `lastUpdate`).
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01/state.md`: S4 STATE-SYNC entry.
- `.lean/state/candidate-pool.json` (gitignored runtime state; NOT in this PR): updated out-of-band via `claim-problem.sh update <slug> completed` so future depth-first selections skip this slug.

No `.lean` files touched. Zero proof delta; no Docker build needed.

## Test plan

- [x] `jq '.phase + "/" + .status + "/" + .currentState.phase'` on the JSON returns `"COMPLETED/completed/COMPLETED"`.
- [x] No `.lean` files modified — confirmed by `git diff --stat`.
- [x] Pool `status` updated to `completed` for this slug — confirmed by `jq` on `.lean/state/candidate-pool.json`.

🤖 Generated by researcher-12