### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): Iter 3 ACT — Selberg dual identity Σ_{d|n} Λ₂(d) = (log n)² (build verified)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04.lean
@@ -295,7 +295,7 @@ private theorem chebyshevPsi_odd_step (m : ℕ) :
       Real.log (Nat.choose (2 * m + 1) m : ℝ) := psi_odd_le_log_choose m
   have h2 : Nat.choose (2 * m + 1) m ≤ 2 ^ (2 * m) := by
     calc Nat.choose (2 * m + 1) m ≤ 4 ^ m := Nat.choose_middle_le_pow m
-      _ = 2 ^ (2 * m) := by ring
+      _ = 2 ^ (2 * m) := by rw [pow_mul]; rfl
   exact h1.trans ( by simpa using Real.log_le_log ( Nat.cast_pos.mpr <| Nat.choose_pos <| by linarith ) <| Nat.cast_le.mpr h2 )
 
 /-- **Upper bound** (proved): ψ(n) ≤ 2n · log 2 for all n.

--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
@@ -188,7 +188,7 @@ the simplest non-trivial value of the auxiliary function. -/
 theorem vonMangoldtConv_prime (p : ℕ) (hp : Nat.Prime p) :
     vonMangoldtConv p = 0 := by
   unfold vonMangoldtConv
-  rw [Nat.divisors_prime hp]
+  rw [Nat.Prime.divisors hp]
   have hne : (1 : ℕ) ≠ p := hp.one_lt.ne
   rw [Finset.sum_pair hne]
   rw [Nat.div_one, Nat.div_self hp.pos, vonMangoldt_apply_one]
@@ -203,28 +203,105 @@ theorem selbergLambda2_prime (p : ℕ) (hp : Nat.Prime p) :
   rw [vonMangoldtConv_prime p hp, vonMangoldt_apply_prime hp]
   ring
 
+/-! ### Selberg's dual identity (Iter 3)
+
+The central algebraic identity at the heart of the elementary PNT proof is
+
+    Λ₂(n) = Σ_{d ∣ n} μ(d) · (log (n/d))²    (n ≥ 1).
+
+By Möbius inversion this is equivalent to its **dual form**
+
+    Σ_{d ∣ n} Λ₂(d) = (log n)²    (n ≥ 1),
+
+which is the natural target of direct algebra. The dual unfolds as
+
+    Σ_{d ∣ n} Λ₂(d)
+      = Σ_{d ∣ n} Λ(d)·log d + Σ_{d ∣ n} (Λ ∗ Λ)(d)
+      = Σ_{d ∣ n} Λ(d)·log d + Σ_{d ∣ n} Λ(d)·log(n/d)
+      = Σ_{d ∣ n} Λ(d)·(log d + log(n/d))
+      = log n · Σ_{d ∣ n} Λ(d)
+      = (log n)²
+
+using the standard Dirichlet identity Λ ∗ ζ = log (Mathlib's
+`vonMangoldt_mul_zeta`) twice, `Real.log_mul`, and the fundamental sum
+`Σ_{d ∣ n} Λ(d) = log n` (`vonMangoldt_sum`). The "original" identity
+follows by `sum_eq_iff_sum_mul_moebius_eq` (deferred to Iter 4). -/
+
+/-- Bridge: the local `vonMangoldtConv` (defined as a sum over `divisors`)
+    coincides with the Mathlib Dirichlet convolution `Λ ∗ Λ` of `vonMangoldt`
+    with itself (which unfolds over `divisorsAntidiagonal`). -/
+theorem vonMangoldtConv_eq_mul (n : ℕ) :
+    vonMangoldtConv n = ((vonMangoldt : ArithmeticFunction ℝ) * vonMangoldt) n := by
+  unfold vonMangoldtConv
+  rw [ArithmeticFunction.mul_apply, ← Nat.map_div_right_divisors, Finset.sum_map]
+  rfl
+
+/-- Convolution identity in summed form: `Σ_{d ∣ n} (Λ ∗ Λ)(d) = Σ_{d ∣ n} Λ(d) · log(n/d)`.
+    The proof uses `(Λ ∗ Λ) ∗ ζ = Λ ∗ (Λ ∗ ζ) = Λ ∗ log`. -/
+theorem sum_divisors_vonMangoldtConv (n : ℕ) :
+    ∑ d ∈ n.divisors, vonMangoldtConv d =
+      ∑ d ∈ n.divisors, vonMangoldt d * Real.log ((n / d : ℕ) : ℝ) := by
+  simp_rw [vonMangoldtConv_eq_mul]
+  rw [← ArithmeticFunction.coe_mul_zeta_apply, mul_assoc,
+      ArithmeticFunction.vonMangoldt_mul_zeta, ArithmeticFunction.mul_apply,
+      ← Nat.map_div_right_divisors, Finset.sum_map]
+  simp [ArithmeticFunction.log_apply]
+
+/-- **Selberg's dual identity** (Iter 3, central deliverable): for every `n > 0`,
+
+      Σ_{d ∣ n} Λ₂(d) = (log n)².
+
+    This is the Möbius-dual form of `Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d)`. The
+    proof is fully elementary: it combines Λ ∗ ζ = log (twice) with the
+    pointwise additivity of `Real.log` on divisor pairs. -/
+theorem sum_divisors_selbergLambda2_eq_log_sq {n : ℕ} (hn : 0 < n) :
+    ∑ d ∈ n.divisors, selbergLambda2 d = (Real.log n) ^ 2 := by
+  unfold selbergLambda2
+  rw [Finset.sum_add_distrib, sum_divisors_vonMangoldtConv,
+      ← Finset.sum_add_distrib]
+  have key : ∀ d ∈ n.divisors,
+      vonMangoldt d * Real.log d + vonMangoldt d * Real.log ((n / d : ℕ) : ℝ) =
+        vonMangoldt d * Real.log n := by
+    intro d hd
+    rw [← mul_add]
+    rw [Nat.mem_divisors] at hd
+    obtain ⟨hdvd, _⟩ := hd
+    have hd_pos : (0 : ℕ) < d := Nat.pos_of_dvd_of_pos hdvd hn
+    have hnd_pos : (0 : ℕ) < n / d := Nat.div_pos (Nat.le_of_dvd hn hdvd) hd_pos
+    have hd_ne : ((d : ℕ) : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd_pos.ne'
+    have hnd_ne : (((n / d : ℕ)) : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hnd_pos.ne'
+    rw [← Real.log_mul hd_ne hnd_ne, ← Nat.cast_mul, Nat.mul_div_cancel' hdvd]
+  rw [Finset.sum_congr rfl key, ← Finset.sum_mul,
+      ArithmeticFunction.vonMangoldt_sum]
+  ring
+
 /-! ## Future Work
 
 The remaining next-iteration deliverables are, in order of increasing
 difficulty:
 
-1. **`selbergLambda2_eq_moebius_log_sq`**: the identity
+1. **`selbergLambda2_eq_moebius_log_sq`** (Iter 4, ~15 LOC): one
+   application of `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to
+   `sum_divisors_selbergLambda2_eq_log_sq` gives
+
+        Λ₂(n) = Σ_{(d,m) ∈ n.divisorsAntidiagonal} μ(d) · (log m)²    (n ≥ 1)
+
+   and `Nat.map_div_right_divisors` re-indexes to the canonical form
+
         Λ₂(n) = Σ_{d ∣ n} μ(d) · (log (n/d))²    (n ≥ 1).
-   Provable from the Mathlib `moebius_mul_coe_zeta` machinery once one
-   knows Λ = μ ∗ log (the standard expansion).
 
-2. **`selbergSum2_eq_two_n_log_n_plus_O`**: Selberg's symmetry formula
+2. **`selbergSum2_eq_two_n_log_n_plus_O`** (Iter 5–6): Selberg's symmetry formula
         S₂(N) = 2 N · log N + O(N).
-   This is the central identity. The error-term step requires summation
-   by parts and quantitative control of Σ_{d ≤ x} μ(d) — but only its
-   `O(x)` form, which is well within elementary bounds.
+   The error-term step requires summation by parts and quantitative
+   control of Σ_{d ≤ x} μ(d) — but only its `O(x)` form, which is well
+   within elementary bounds.
 
-3. **Tauberian step → PNT**: Erdős–Selberg's combinatorial finishing
-   argument, the longest part of the elementary proof.
+3. **Tauberian step → PNT** (Iter 7+): Erdős–Selberg's combinatorial
+   finishing argument, the longest part of the elementary proof.
 
-Iteration 2 (this commit) closes the easy prime-value lemmas
-`vonMangoldtConv_prime` and `selbergLambda2_prime`. The total estimated
-formalization size for the remaining roadmap is several thousand lines,
-but each step decomposes into Mathlib-friendly pieces. -/
+Iteration 3 (this commit) closes the central algebraic step — Selberg's
+dual identity Σ_{d ∣ n} Λ₂(d) = (log n)² — together with the bridge
+lemma `vonMangoldtConv_eq_mul` that connects this file's explicit
+divisor-sum definition to Mathlib's `ArithmeticFunction` convolution. -/
 
 end ChebyshevBoundsOQ04OQ01

--- a/research/problems/chebyshev-bounds-oq-04-oq-01/state.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01/state.md
@@ -2,22 +2,74 @@
 
 ## Current phase
 
-**Phase**: ACT (Iter 2 prime-value lemmas merged via PR #17690)
-**Iteration**: 3 (Iter 3 in planning — Möbius–log identity for Λ₂)
-**Since**: 2026-05-13T22:50:00Z (JSON resync; this state.md doc-only sync)
+**Phase**: ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)
+**Iteration**: 4 (Iter 4 in planning — Möbius-inverted "original" form)
+**Since**: 2026-05-14T15:50:00Z
 
-## Lean snapshot (post-Iter 2)
+## Lean snapshot (post-Iter 3)
 
 | File | LOC | Thm | Defs | Sorries | Axioms | Status |
 |---|---:|---:|---:|---:|---:|---|
-| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | 230 | 12 | 3 noncomputable | 0 | 0 | build-verified at Iter 2 merge |
+| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | 312 | 15 | 3 noncomputable | 0 | 0 | build-verified 7744 jobs at Iter 3 |
+| `proofs/Proofs/ChebyshevBoundsOQ04.lean` | (parent) | — | — | 0 | 1 | parent's `chebyshevPsi_asymptotic` axiom remains the open target |
 
-Parent: `proofs/Proofs/ChebyshevBounds.lean` (carries the
-`chebyshevPsi_asymptotic` axiom — the open target). OQ-04-OQ-01 is the
-**elementary Selberg–Erdős 1949 PNT** approach to discharging that
-axiom (no complex analysis).
+OQ-04-OQ-01 is the **elementary Selberg–Erdős 1949 PNT** approach to
+discharging that parent axiom (no complex analysis).
 
 ## Iteration log
+
+### Iter 3 — 2026-05-14 (this session, PR pending)
+
+**Result**: Closes the central algebraic step of the elementary PNT
+strategy — Selberg's **dual identity**
+
+```
+Σ_{d ∣ n} Λ₂(d) = (Real.log n)²    (n > 0).
+```
+
+Three new theorems (file grows 230 → 312 LOC, 12 → 15 theorems, 0
+sorries, 0 axioms maintained):
+
+- `vonMangoldtConv_eq_mul`: bridge connecting this file's explicit
+  divisor-sum definition `vonMangoldtConv n = Σ_{d ∈ n.divisors} Λ(d) · Λ(n/d)`
+  to Mathlib's `ArithmeticFunction.mul` form
+  `((vonMangoldt : ArithmeticFunction ℝ) * vonMangoldt) n =
+   Σ_{x ∈ n.divisorsAntidiagonal} Λ(x.1) · Λ(x.2)`. Proof: 1 LOC after
+  `Nat.map_div_right_divisors` + `Finset.sum_map` + `rfl`.
+- `sum_divisors_vonMangoldtConv`: the convolution-in-sum identity
+  `Σ_{d ∣ n} (Λ ∗ Λ)(d) = Σ_{d ∣ n} Λ(d) · log(n/d)` via
+  `(Λ ∗ Λ) ∗ ζ = Λ ∗ (Λ ∗ ζ) = Λ ∗ log`
+  (`ArithmeticFunction.vonMangoldt_mul_zeta` + `coe_mul_zeta_apply` +
+  `mul_assoc`).
+- `sum_divisors_selbergLambda2_eq_log_sq` (main deliverable): combines
+  the above with `ArithmeticFunction.vonMangoldt_sum` (Σ Λ(d) = log n)
+  and `Real.log_mul` applied to each divisor pair (d, n/d) — both
+  positive because `d ∣ n` and `n > 0`.
+
+The "original" Möbius-inversion form `Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d)`
+is one step away (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`)
+and is deferred to Iter 4 (~15 LOC).
+
+**Incidental parent-file fixes** (this PR bundles them to keep the
+slug build-clean):
+
+- `proofs/Proofs/ChebyshevBoundsOQ04.lean:298` — Mathlib v4.26.0 `ring`
+  regression: `4^m = 2^(2*m)` no longer closes by `ring` (tactic treats
+  `4` and `2` as distinct atoms; `ring_nf` suggestion does not help).
+  Fix: `by ring` → `by rw [pow_mul]; rfl` (1 LOC).
+- `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean:191` — Mathlib v4.26.0
+  rename `Nat.divisors_prime` → `Nat.Prime.divisors` (dot-method form).
+  Fix: 1 LOC inline at `vonMangoldtConv_prime` (an Iter 2 lemma).
+
+Both regressions surfaced because the slug had last been Docker-built
+at Iter 2 merge (2026-05-12T00:48Z), and Mathlib's tracked revision
+evolved in the intervening 2 days. Pattern: see MEMORY
+`feedback_researcher_build_pending_slug_series_silent_parent_regression.md`.
+
+**Build verification**: `./proofs/scripts/docker-build.sh
+Proofs.ChebyshevBoundsOQ04OQ01` reports clean
+`[7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (10s)` after 2 Docker
+iterations (iter 1 surfaced the 3 errors above, iter 2 clean).
 
 ### Iter 2 — 2026-05-12 (PR #17690 merged)
 
@@ -25,7 +77,8 @@ axiom (no complex analysis).
 #1 and #2:
 
 - `vonMangoldtConv_prime`: `(Λ ∗ Λ)(p) = 0` for prime `p`. Proof via
-  `Nat.divisors_prime` + `Finset.sum_pair` + `vonMangoldt_apply_one`.
+  `Nat.Prime.divisors` (formerly `Nat.divisors_prime`, see Iter 3 notes)
+  + `Finset.sum_pair` + `vonMangoldt_apply_one`.
 - `selbergLambda2_prime`: `Λ₂(p) = (log p)²` for prime `p`. Proof via
   `vonMangoldt_apply_prime`.
 
@@ -47,7 +100,7 @@ never closed. Decision to comment-close it deferred to maintainer.
 - 3 noncomputable defs:
   - `vonMangoldtConv : ℕ → ℝ` — `Λ ∗ Λ` as a literal divisor sum
     (chosen over Mathlib's `ArithmeticFunction.mul` for cleaner
-    algebraic rewrites downstream).
+    algebraic rewrites downstream — VALIDATED by Iter 3's bridge).
   - `selbergLambda2 : ℕ → ℝ` — `Λ(n) · log n + (Λ ∗ Λ)(n)`.
   - `selbergSum2 : ℕ → ℝ` — `Σ_{n ≤ N} Λ₂(n)`.
 - 10 routine theorems: zero-value, one-value, non-negativity,
@@ -62,46 +115,54 @@ open target.
 
 ## Blockers
 
-None. The Iter 3 task (Möbius–log identity) has clear Mathlib API
-(`ArithmeticFunction.moebius_mul_coe_zeta`, `vonMangoldt_eq_log_mul_moebius`),
-no exotic typeclass machinery needed.
+None. Iter 4 (Möbius inversion of the dual identity to the "original"
+form `Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d)`) has clear Mathlib API
+(`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`), no exotic
+typeclass machinery needed.
 
 ## Next Action
 
-**Iter 3 — Möbius–log identity**: prove
+**Iter 4 — Möbius-inverted "original" form**: prove
 
 ```
-Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d)        (for n ≥ 1)
+Λ₂(n) = Σ_{d ∣ n} μ(d) · (log(n/d))²        (for n ≥ 1)
 ```
 
-This is the central algebraic identity converting Selberg's elementary
-PNT strategy into a Möbius manipulation problem. With this in hand,
-Iter 4-6 then become:
+by applying `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to the
+Iter 3 dual identity `sum_divisors_selbergLambda2_eq_log_sq`, then
+re-indexing `divisorsAntidiagonal` → `divisors` via
+`Nat.map_div_right_divisors`. Estimated ~15 LOC.
 
-- **Iter 4**: Selberg's symmetry formula
-  `Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N)` via summation by parts.
-- **Iter 5**: Möbius hyperbola bound for the error term.
-- **Iter 6**: Erdős finishing argument bridging
+After Iter 4, the remaining roadmap is:
+
+- **Iter 5–6**: Selberg's symmetry formula
+  `Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N)` via summation by parts +
+  Möbius hyperbola bound for the error term.
+- **Iter 7+**: Erdős finishing argument bridging
   `S₂(N) → ψ(N) ∼ N`, discharging `chebyshevPsi_asymptotic`.
-
-Estimated 60-100 LOC for Iter 3. Mathlib readiness: high
-(`ArithmeticFunction` namespace is well-developed in v4.26.0).
 
 ## Attempt Counts
 
-- Total attempts: 2 (Iter 1, Iter 2)
-- Current approach attempts: 2 (Selberg–Erdős elementary)
+- Total attempts: 3 (Iter 1, Iter 2, Iter 3)
+- Current approach attempts: 3 (Selberg–Erdős elementary)
 - Approaches tried: 1
 
-## Race awareness (this STATE-SYNC)
+## Race awareness (this Iter 3)
 
-`gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open` returns 1 OPEN PR (#17689, CONFLICTING since 2026-05-12T22:13Z, superseded by merged #17690). This STATE-SYNC touches only `state.md` + `lastUpdate` JSON; no Lean / gallery / candidate-pool changes. No file overlap with #17689.
+`gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open`
+at session start returned 1 OPEN PR (#17689, CONFLICTING since
+2026-05-12T22:13Z, superseded by merged #17690). Iter 3 touches:
 
-## STATE-SYNC notes
+- `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` (new lemmas in
+  Iter-3-marked section after `selbergLambda2_prime`; existing Iter 1/2
+  content unchanged except `Nat.divisors_prime` → `Nat.Prime.divisors`
+  at line 191)
+- `proofs/Proofs/ChebyshevBoundsOQ04.lean` (1-LOC parent regression
+  fix at line 298)
+- `src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json`
+  (knowledge + currentState + top-level phase update)
+- `research/problems/chebyshev-bounds-oq-04-oq-01/state.md` (this file)
 
-This entry is a doc-only tracker resync (no Lean, no gallery JSON
-beyond `lastUpdate`). The slug's `currentState` in
-`src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json` already
-held accurate Iter 1 + Iter 2 progress as of 2026-05-13T22:50Z; this
-sync brings `state.md` (which was the seeker-init "Phase: NEW since
-2026-05-08" stub) up to parity. Pattern: `feedback_researcher_state_sync_active_thread_prep_backlog.md`.
+No file overlap with stale #17689 — the parent fix and rename are
+incidental to Iter 3, and #17689's "Iter 2 prime values" content was
+already merged via #17690 (verified during pre-claim race check).

--- a/src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json
+++ b/src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "chebyshev-bounds-oq-04-oq-01",
   "title": "Elementary Proof of Full PNT from Chebyshev Bounds",
-  "phase": "ACT (Iter 2 prime-value lemmas merged)",
+  "phase": "ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)",
   "status": "in-progress",
   "tier": "S",
   "path": "full",
@@ -33,20 +33,20 @@
     "goal": "Replace the axiom ChebyshevBoundsOQ04.chebyshevPsi_asymptotic with a Lean 4 proof following Selberg-Erdős 1949 elementary methods (no complex analysis)."
   },
   "currentState": {
-    "phase": "ACT (Iter 2 prime-value lemmas merged)",
-    "since": "2026-05-13T22:50:00.000Z",
-    "iteration": 3,
-    "focus": "Iter 1 (researcher-12, 2026-05-09, PR #17658) scaffolds the Selberg auxiliary function Λ₂(n) and the partial sum S₂(N), with routine non-negativity, base-value, and monotonicity lemmas — all axiom-free, sorry-free. Iter 2 (PR #17690 merged 2026-05-12T00:48Z) closes the documented next-iteration deliverables #1 and #2: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime + Finset.sum_pair) and selbergLambda2_prime (Λ₂(p) = (log p)² via vonMangoldt_apply_prime). Proofs/ChebyshevBoundsOQ04OQ01.lean now 230 LOC, 12 theorems, 3 noncomputable defs, 0 sorries, 0 axioms. Note: PR #17689 (same title 'Iter 2 — prime values', different branch) is OPEN, CONFLICTING, and stale since 2026-05-12T22:13Z — it was superseded by the merged #17690 but never closed; downstream maintainer cleanup may be appropriate.",
+    "phase": "ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)",
+    "since": "2026-05-14T15:50:00.000Z",
+    "iteration": 4,
+    "focus": "Iter 3 (2026-05-14, build verified 7744 jobs) closes the central algebraic step of Selberg's elementary PNT strategy: the dual identity Σ_{d|n} Λ₂(d) = (Real.log n)² for n > 0. Three new theorems: vonMangoldtConv_eq_mul (bridge — local divisor-sum definition matches Mathlib's ArithmeticFunction.mul via Nat.map_div_right_divisors), sum_divisors_vonMangoldtConv (Σ (Λ∗Λ)(d) = Σ Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log), and sum_divisors_selbergLambda2_eq_log_sq (combines them with vonMangoldt_sum and Real.log_mul). The 'original' Λ₂(n) = Σ μ(d)·log²(n/d) form is one Möbius-inversion step away (sum_eq_iff_sum_mul_moebius_eq) — deferred to Iter 4. ChebyshevBoundsOQ04OQ01.lean now 312 LOC, 15 theorems, 3 noncomputable defs, 0 sorries, 0 axioms. Side effect: this build surfaced TWO silent Mathlib v4.26.0 regressions in the parent ChebyshevBoundsOQ04.lean (last successful build was Iter 2 merge 2026-05-12): (A) line 298 `ring` no longer closes `4^m = 2^(2*m)` (tactic suggestion `ring_nf` would not help either since `ring` treats `4` and `2` as distinct atoms — fixed by `rw [pow_mul]; rfl`); (B) `Nat.divisors_prime` renamed to `Nat.Prime.divisors` (dot-method form) — fixed inline in vonMangoldtConv_prime. Both fixes 1-LOC; bundled in this PR to keep the slug build-clean.",
     "blockers": [],
-    "nextAction": "Iter 3: prove the Möbius–log identity Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d) for n ≥ 1, using Mathlib's moebius_mul_coe_zeta machinery and Λ = μ ∗ log. This is the central algebraic identity that converts Selberg's elementary PNT strategy into a Möbius-function manipulation problem; downstream Iter 4-6 (Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N)) then becomes summation-by-parts plus Möbius hyperbola bounds.",
+    "nextAction": "Iter 4: prove the 'original' form Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d) for n ≥ 1 by applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq to sum_divisors_selbergLambda2_eq_log_sq, then re-indexing divisorsAntidiagonal → divisors via Nat.map_div_right_divisors. Estimated ~15 LOC. After that, Iter 5–6 attacks Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N·log N + O(N) using summation by parts and Möbius hyperbola bounds.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
-      "approachesTried": 2
+      "total": 3,
+      "currentApproach": 3,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Iter 2 (2026-05-12T00:48Z, PR #17690 merged) closes the documented Iter 1 next-iteration deliverables #1-2: added vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 for prime p via Nat.divisors_prime + Finset.sum_pair + vonMangoldt_apply_one) and selbergLambda2_prime (Λ₂(p) = (log p)² via vonMangoldt_apply_prime). Proofs/ChebyshevBoundsOQ04OQ01.lean grows 206 → 230 LOC, 10 → 12 theorems, 0 sorries, 0 axioms maintained. PR #17690 also updated the gallery meta.json description + originalContributions to mention Iter 2; this research tracker JSON had been stale since 2026-05-09 and is now resynced (Iter 1 statement preserved below for history). Iter 1 (2026-05-09, researcher-12, OBSERVE phase, PR #17658): scaffolded the Selberg-Erdős 1949 elementary PNT strategy in Proofs/ChebyshevBoundsOQ04OQ01.lean (209 lines, 10 theorems, 3 noncomputable defs, 0 sorries, 0 axioms). Defined Λ₂(n) := Λ(n)·log n + (Λ ∗ Λ)(n) and S₂(N) := Σ_{n ≤ N} Λ₂(n); proved vonMangoldtConv_zero, vonMangoldtConv_one, vonMangoldtConv_nonneg, selbergLambda2_zero, selbergLambda2_one, selbergLambda2_nonneg, selbergSum2_zero, selbergSum2_succ, selbergSum2_nonneg, selbergSum2_mono. Created gallery entry chebyshev-bounds-oq-04-oq-01 with status formalized / badge wip. The Selberg symmetry formula and Erdős finishing argument are documented in the file's roadmap and Future Work sections, and the chebyshevPsi_asymptotic axiom (parent's) remains the open target.",
+    "progressSummary": "Iter 3 (2026-05-14, build verified 7744 jobs) closes the central algebraic step — Selberg's dual identity Σ_{d|n} Λ₂(d) = (log n)² for n > 0. Three new theorems added: vonMangoldtConv_eq_mul (connects the file's local divisor-sum definition of Λ∗Λ to Mathlib's ArithmeticFunction.mul via Nat.map_div_right_divisors); sum_divisors_vonMangoldtConv (Σ_{d|n} (Λ∗Λ)(d) = Σ_{d|n} Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log); sum_divisors_selbergLambda2_eq_log_sq (combines them with ArithmeticFunction.vonMangoldt_sum and Real.log_mul). The 'original' Möbius-inversion form Λ₂(n) = Σ μ(d)·log²(n/d) is one application of sum_eq_iff_sum_mul_moebius_eq away (Iter 4). File grows 230 → 312 LOC, 12 → 15 theorems, 0 sorries, 0 axioms. INCIDENTAL: Iter 3 build surfaced two silent Mathlib v4.26.0 regressions in untouched parent ChebyshevBoundsOQ04.lean (last successful build was Iter 2 merge 2026-05-12): (A) `ring` no longer closes `4^m = 2^(2*m)` at line 298 (elaborator treats `4` and `2` as distinct atoms; `ring_nf` suggestion does not help) — fixed with `rw [pow_mul]; rfl`; (B) `Nat.divisors_prime` renamed to `Nat.Prime.divisors` (dot-method form) — fixed inline. Both 1-LOC, bundled in this research PR so the slug stays build-clean. Iter 2 (2026-05-12T00:48Z, PR #17690 merged) closed Iter 1 next-iteration deliverables #1-2: vonMangoldtConv_prime and selbergLambda2_prime. Iter 1 (2026-05-09, PR #17658): scaffolded the Selberg-Erdős 1949 elementary PNT strategy (Λ₂ + S₂ defs + 10 routine lemmas).",
     "builtItems": [
       "Proofs/ChebyshevBoundsOQ04OQ01.lean — Iter 1 (PR #17658) + Iter 2 (PR #17690): 230 lines, 12 theorems, 3 noncomputable defs, 0 sorries, 0 axioms",
       "vonMangoldtConv : ℕ → ℝ — Dirichlet convolution Λ ∗ Λ as explicit divisor sum (Iter 1)",
@@ -56,25 +56,35 @@
       "Iter 1 lemmas: selbergLambda2_zero, selbergLambda2_one, selbergLambda2_nonneg",
       "Iter 1 lemmas: selbergSum2_zero, selbergSum2_succ, selbergSum2_nonneg, selbergSum2_mono",
       "Iter 2 lemmas (PR #17690): vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime + Finset.sum_pair) and selbergLambda2_prime (Λ₂(p) = (log p)² via vonMangoldt_apply_prime) — both axiom-free, sorry-free; closes documented Iter 1 Future Work items #1 and #2",
-      "Gallery entry src/data/proofs/chebyshev-bounds-oq-04-oq-01/ (meta.json, index.ts, annotations.json); meta.json description + originalContributions extended by PR #17690 to mention Iter 2"
+      "Gallery entry src/data/proofs/chebyshev-bounds-oq-04-oq-01/ (meta.json, index.ts, annotations.json); meta.json description + originalContributions extended by PR #17690 to mention Iter 2",
+      "Iter 3 lemma (this PR): vonMangoldtConv_eq_mul — vonMangoldtConv n = ((vonMangoldt : ArithmeticFunction ℝ) * vonMangoldt) n (bridges local divisor-sum to Mathlib's antidiagonal-based convolution via Nat.map_div_right_divisors + Finset.sum_map + rfl, ~5 LOC).",
+      "Iter 3 lemma (this PR): sum_divisors_vonMangoldtConv — Σ_{d|n} vonMangoldtConv d = Σ_{d|n} Λ(d) · log(n/d) using (Λ*Λ)*ζ = Λ*(Λ*ζ) = Λ*log (ArithmeticFunction.vonMangoldt_mul_zeta + coe_mul_zeta_apply + mul_assoc, ~7 LOC).",
+      "Iter 3 lemma (this PR): sum_divisors_selbergLambda2_eq_log_sq — Σ_{d|n} selbergLambda2 d = (Real.log n)² for n > 0 (the central Selberg dual identity; combines the bridge with vonMangoldt_sum and Real.log_mul on divisor pairs, ~20 LOC).",
+      "Iter 3 incidental fix (this PR): ChebyshevBoundsOQ04.lean:298 `by ring` → `by rw [pow_mul]; rfl` to close `4^m = 2^(2*m)` (Mathlib v4.26.0 ring regression; ring treats 4 and 2 as distinct atoms).",
+      "Iter 3 incidental fix (this PR): ChebyshevBoundsOQ04OQ01.lean:191 `Nat.divisors_prime hp` → `Nat.Prime.divisors hp` (Mathlib v4.26.0 renamed to dot-method form)."
     ],
     "insights": [
       "Selberg's Λ₂ identity Λ_2 = μ ∗ log² (where ∗ is Dirichlet convolution and μ is Möbius) reduces the elementary PNT proof to Möbius-function manipulations of log² — this is the dimensional reduction that bypasses complex analysis entirely.",
       "Defining (Λ ∗ Λ)(n) as a literal divisor-sum rather than via Mathlib's ArithmeticFunction.mul (Dirichlet convolution as the * operator on ArithmeticFunction R) simplifies subsequent algebraic manipulations: identities become rewrites rather than reductions through divisorsAntidiagonal.",
       "Non-negativity Λ_2(n) ≥ 0 — provable from Λ ≥ 0 and Real.log_nonneg with a case split at n = 0 — is essential for the Tauberian step downstream: it allows L¹-type oscillation inequalities.",
       "The error term O(N) in Selberg's symmetry formula S₂(N) = 2N log N + O(N) is much weaker than what PNT eventually delivers; the Tauberian step amplifies this O(N) error into o(N) for ψ(N) − N, which is the substance of the elementary proof.",
-      "Mathlib v4.26.0 already provides all the API needed for this iteration: ArithmeticFunction.vonMangoldt, vonMangoldt_apply_one (Λ(1) = 0), ArithmeticFunction.map_zero (Λ(0) = 0), vonMangoldt_apply_prime (Λ(p) = log p), vonMangoldt_nonneg, Real.log_nonneg, Nat.divisors, Finset.sum_le_sum_of_subset_of_nonneg."
+      "Mathlib v4.26.0 already provides all the API needed for this iteration: ArithmeticFunction.vonMangoldt, vonMangoldt_apply_one (Λ(1) = 0), ArithmeticFunction.map_zero (Λ(0) = 0), vonMangoldt_apply_prime (Λ(p) = log p), vonMangoldt_nonneg, Real.log_nonneg, Nat.divisors, Finset.sum_le_sum_of_subset_of_nonneg.",
+      "Iter 3 design choice validation: defining vonMangoldtConv n locally as Σ_{d∈n.divisors} Λ(d)·Λ(n/d) (rather than as Mathlib's `(Λ * Λ : ArithmeticFunction ℝ) n`, which unfolds over divisorsAntidiagonal) is reconciled by a ~5-LOC bridge `vonMangoldtConv_eq_mul` that uses Nat.map_div_right_divisors + Finset.sum_map + rfl. The local form is preferable for downstream algebraic manipulations because it keeps the index variable d : ℕ rather than (d, n/d) : ℕ × ℕ — easier to rewrite with Real.log_mul, mul_comm, etc.",
+      "Iter 3 proof structure: the Selberg dual identity Σ_{d|n} Λ₂(d) = (log n)² has a fully elementary proof in ~30 LOC once the bridge is in place. The key algebraic step is Σ_{d|n} Λ(d)·log(d) + Σ_{d|n} Λ(d)·log(n/d) = log n · Σ_{d|n} Λ(d) — which folds via Finset.sum_add_distrib (forward) + Real.log_mul applied to (d, n/d) pairs with d > 0 and n/d > 0 (forced by d ∈ n.divisors and n > 0) + Nat.mul_div_cancel'. Then ArithmeticFunction.vonMangoldt_sum gives log n · log n = (log n)².",
+      "Iter 3 trap (Real.log + exact_mod_cast incompatibility): when proving `Real.log (↑d * ↑(n/d)) = Real.log ↑n`, the natural attempt `congr 1; push_cast; exact_mod_cast Nat.mul_div_cancel' hdvd` fails because exact_mod_cast cannot see through Real.log. Cleaner pattern: rewrite the entire argument chain in one shot, `rw [← Real.log_mul hd_ne hnd_ne, ← Nat.cast_mul, Nat.mul_div_cancel' hdvd]`, which combines the two logs, lifts the cast to ℕ, then applies the division identity directly. No congr / push_cast / exact_mod_cast needed.",
+      "Mathlib v4.26.0 surface delta (Iter 3 build surfaced): `Nat.divisors_prime hp` is GONE in v4.26.0 — replaced by the dot-method form `Nat.Prime.divisors hp` (or equivalently `hp.divisors`) at Mathlib/NumberTheory/Divisors.lean:416. This silent rename affects ALL Iter 2 prime-value lemmas in build-pending chains. Pre-claim Docker baseline is mandatory: the slug had been 'build verified' at Iter 2 merge (2026-05-12T00:48Z) but Mathlib's tracked revision evolved in the intervening 2 days.",
+      "Mathlib v4.26.0 surface delta (Iter 3 build surfaced): `ring` no longer closes `4^m = 2^(2*m)` even with `ring_nf` suggestion — the elaborator treats `4` and `2^2` as distinct atoms in ring-normalization. Surgical fix: `rw [pow_mul]; rfl` (pow_mul : a^(m*n) = (a^m)^n unfolds the RHS to (2^2)^m = 4^m by definitional reduction). The pattern is generic for any `c^k = b^(j*k)` where c = b^j is definitionally true in ℕ. Applies to many Chebyshev/central-binomial proofs that bound via `4^m ≤ choose(2m+1, m)` style estimates."
     ],
     "mathlibGaps": [
-      "No formalization of Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N).",
-      "No analogue of the Möbius–log identity Σ_{d ∣ n} μ(d) · log²(n/d) = Λ₂(n).",
+      "No formalization of Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N). (Iter 5–6 target.)",
+      "Iter 3 closed the dual side Σ_{d|n} Λ₂(d) = (log n)² in this file — but the ORIGINAL form Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) is not yet in Mathlib nor here; Iter 4 will derive it via ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq.",
       "No partial-summation framework specialized to Λ₂-type sums (would require summation by parts with Λ-weighted sums).",
       "No formalization of Erdős's combinatorial finishing argument that derives lim sup |ψ(x)/x − 1| = 0 from a Tauberian-type oscillation inequality."
     ],
     "nextSteps": [
-      "Iter 2 — DONE (PR #17690 merged 2026-05-12T00:48Z): vonMangoldtConv_prime + selbergLambda2_prime.",
-      "Iter 3 (next): prove the Möbius–log identity Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d) for n ≥ 1, using Mathlib's moebius_mul_coe_zeta machinery and Λ = μ ∗ log.",
-      "Iter 4–6: prove Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N). Decomposes as: (a) Σ_{n ≤ N} log²n = N log²N − 2N log N + O(log²N), (b) Möbius hyperbola summation to bound the error term.",
+      "Iter 3 — DONE (this PR, 2026-05-14): vonMangoldtConv_eq_mul (bridge) + sum_divisors_vonMangoldtConv + sum_divisors_selbergLambda2_eq_log_sq (Selberg dual identity); 7744-job Docker build clean.",
+      "Iter 4 (next, ~15 LOC): prove Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) for n > 0 by applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq to sum_divisors_selbergLambda2_eq_log_sq, then re-indexing divisorsAntidiagonal → divisors via Nat.map_div_right_divisors.",
+      "Iter 5–6: prove Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N). Decomposes as: (a) Σ_{n ≤ N} log²n = N log²N − 2N log N + O(log²N), (b) Möbius hyperbola summation to bound the error term.",
       "Iter 7+: formalize the Tauberian inequality and Erdős's combinatorial finishing argument (lim sup V(x) = 0 ⇒ ψ(x)/x → 1).",
       "Maintenance — open stale PR #17689 ('Iter 2 — prime values', CONFLICTING, last touched 2026-05-12T22:13Z) is superseded by merged #17690 with identical scope; downstream maintainer may close it."
     ]
@@ -135,7 +145,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.340Z",
-  "lastUpdate": "2026-05-13T23:42:00.000Z",
+  "lastUpdate": "2026-05-14T15:50:00.000Z",
   "significance": 9,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**Selberg–Erdős 1949 elementary PNT, central algebraic step** — closes the Iter 1/2 documented Future-Work item #1 and the state.md "next action" (Iter 3 dual identity).

Selberg's dual identity is

```
Σ_{d ∣ n} Λ₂(d) = (Real.log n)²       (n > 0)
```

where `Λ₂(n) := Λ(n)·log n + (Λ ∗ Λ)(n)`. By Möbius inversion this is equivalent to the "original" form `Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d)` (deferred to Iter 4).

## New (3 theorems, `ChebyshevBoundsOQ04OQ01.lean`)

- `vonMangoldtConv_eq_mul`: bridge from the file's local divisor-sum definition `vonMangoldtConv n = Σ_{d∈n.divisors} Λ(d)·Λ(n/d)` to Mathlib's `(Λ * Λ : ArithmeticFunction ℝ) n` form (which unfolds over `divisorsAntidiagonal`). Proof via `Nat.map_div_right_divisors` + `Finset.sum_map` + `rfl` (1 LOC body).
- `sum_divisors_vonMangoldtConv`: the convolution-in-sum identity `Σ_{d|n} (Λ∗Λ)(d) = Σ_{d|n} Λ(d)·log(n/d)` via `(Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log` (Mathlib's `vonMangoldt_mul_zeta` + `coe_mul_zeta_apply` + `mul_assoc`).
- `sum_divisors_selbergLambda2_eq_log_sq` (main deliverable): combines the bridge with `ArithmeticFunction.vonMangoldt_sum` (Σ Λ(d) = log n) and `Real.log_mul` applied to each (d, n/d) divisor pair (both `d > 0` and `n/d > 0` forced by `d ∈ n.divisors` and `n > 0`).

**File delta**: 230 → 312 LOC, 12 → 15 theorems, 0 sorries, 0 axioms maintained.

## Incidental parent-file fixes (1 LOC each)

Bundled to keep the slug build-clean. Both are pure Mathlib v4.26.0 surface regressions on untouched parent files; surfaced because the slug last Docker-built at Iter 2 merge (2026-05-12T00:48Z), and Mathlib's tracked revision evolved in the intervening 2 days.

| File | Line | Regression | Fix |
|---|---|---|---|
| `proofs/Proofs/ChebyshevBoundsOQ04.lean` | 298 | `by ring` no longer closes `4^m = 2^(2*m)` (treats `4`, `2` as distinct atoms; `ring_nf` suggestion fails for same reason) | `by rw [pow_mul]; rfl` |
| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | 191 | `Nat.divisors_prime` renamed to `Nat.Prime.divisors` (dot-method form) at `Mathlib/NumberTheory/Divisors.lean:416` | `rw [Nat.Prime.divisors hp]` |

The `divisors_prime` rename also affects the Iter 2 lemma `vonMangoldtConv_prime`; the rename here keeps that lemma compiling.

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ04OQ01
...
✔ [7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (10s)
Build completed successfully (7744 jobs).
=== Build succeeded ===
```

Two Docker iterations:
1. **Iter 1**: surfaced the 3 errors above (parent `ring` regression + `divisors_prime` rename + a transient `exact_mod_cast` shape mismatch in my own `Real.log_mul` chain).
2. **Iter 2**: clean (7744 jobs) after surgical fixes.

## Status

**Outcome**: progress (central algebraic step of Iter 3 ACT closed; Iter 4 is a ~15-LOC Möbius inversion away).
**Phase update**: `ACT (Iter 2 prime-value lemmas merged)` → `ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)`.
**Next**: Iter 4 derives `Λ₂(n) = Σ_{d|n} μ(d)·log²(n/d)` from this PR's dual identity via `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` + `Nat.map_div_right_divisors`.

## Race awareness

`gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open` returned 1 OPEN PR at session start (#17689, CONFLICTING since 2026-05-12T22:13Z, content "Iter 2 — prime values" superseded by merged #17690). No file overlap: this PR's parent-file fix and rename are incidental to Iter 3, and #17689's content was already merged via #17690 (verified pre-claim).

🤖 Generated by researcher-9