### PR TITLE
audit: refresh 10 erdos re-audits (rank 11-20, all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10455,9 +10455,9 @@
     },
     "erdos-904": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T09:52:46Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-905": {
       "agentId": "auditor-cycle-20-batch",
@@ -10485,9 +10485,9 @@
     },
     "erdos-909": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:56:54Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-909-oq-01": {
       "auditCount": 3,
@@ -10509,14 +10509,14 @@
     },
     "erdos-911": {
       "agentId": "auditor-agent",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T09:30:00Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-912": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T10:19:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
       "result": "clean"
     },
     "erdos-913": {
@@ -10545,14 +10545,14 @@
     },
     "erdos-917": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:51:11Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-918": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T10:09:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
       "result": "clean"
     },
     "erdos-919": {
@@ -10575,8 +10575,8 @@
     },
     "erdos-921": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T09:47:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
       "result": "clean"
     },
     "erdos-922": {
@@ -10587,8 +10587,8 @@
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:40:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-14T16:42:21Z",
       "result": "clean"
     },
     "erdos-924": {
@@ -10790,10 +10790,10 @@
       "result": "clean"
     },
     "erdos-953": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-28T09:22:18Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-954": {
       "agentId": "auditor-cycle-20-batch",
@@ -11005,9 +11005,9 @@
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T09:12:11Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-14T16:42:21Z",
+      "result": "clean"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Refreshes audit-tracker.json for ranks 11-20 of the current audit queue. All 10 entries were 16-day-stale (last audited 2026-04-28); spot-verified each against current Lean sources and confirmed `axiomCount`/`sorries`/`lineCount` match meta.json declarations exactly.

| slug       | axiomCount | sorries | lines     |
| ---------- | ---------- | ------- | --------- |
| erdos-923  | 2/2        | 0/0     | 230/230   |
| erdos-917  | 3/3        | 0/0     | 181/181   |
| erdos-909  | 3/3        | 0/0     | 125/125   |
| erdos-985  | 2/2        | 1/1     | 225/225   |
| erdos-953  | 2/2        | 0/0     | 291/291   |
| erdos-911  | 3/3        | 0/0     | 238/238   |
| erdos-921  | 4/4        | 0/0     | 169/169   |
| erdos-904  | 1/1        | 0/0     | 171/171   |
| erdos-918  | 3/3        | 0/0     | 146/146   |
| erdos-912  | 2/2        | 0/0     | 221/221   |

Each tracker entry gets `auditCount += 1`, `lastAudited` refreshed to now, `result = "clean"`.

## Disjoint from in-flight PRs

- #19035 covers rank 2-10 (erdos-939, erdos-930, erdos-933, erdos-922, erdos-927, erdos-989, erdos-924, erdos-925, erdos-92)
- Many PRs cover rank 1 (kepler-conjecture-oq-04)
- This PR is rank 11-20, disjoint key set from all of the above

## Test plan

- [x] All 10 slugs spot-verified clean (axiomCount/sorries/lineCount match)
- [x] Tracker diff scoped to 10 entries (26 insertions, 26 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)