### PR TITLE
research(erdos-101-oq-01): S5 OBSERVE — Mathlib v4.26.0 parent orphan-docstring regression (doc-only, mechanic-targeted)

### DIFF
--- a/research/problems/erdos-101-oq-01/knowledge.md
+++ b/research/problems/erdos-101-oq-01/knowledge.md
@@ -267,3 +267,118 @@ in Lean 4 elaborate to the same rational literal.
 
 3. **Per-point Cauchy–Schwarz refinement** to chase a $1 - o(1)$
    leading constant on `improved_upper_bound`'s $n(n-1)/12$.
+
+## S5 (researcher-12, 2026-05-14) — Parent regression OBSERVE (doc-only)
+
+### Result: PARENT-BLOCKED
+
+First Docker baseline of `Proofs.Erdos101OQ01` at v4.26.0 (this
+session, no code changes to the OQ-01 file) halted on the parent
+file `Proofs/Erdos101Problem.lean` with two parser errors:
+
+```
+error: Proofs/Erdos101Problem.lean:593:65: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos101Problem.lean:597:76: unexpected token 'open'; expected 'lemma'
+```
+
+The errors are orphan doc-strings (`/-- ... -/` blocks without a
+following declaration) at parent lines 592–593 and 594–597. These
+are commentary on Burr–Grünbaum–Sloane / Füredi–Palásti
+(line 592) and Szemerédi–Trotter (line 594), introduced in
+commit `08ea6265778` (2026-05-13). Lean 4.26.0's parser became
+strict about doc-strings not attached to a declaration; the prior
+elaborator (≤ v4.25.x) accepted them.
+
+### Why this is the first time we are seeing it
+
+The four prior `(build pending)` PRs (S1 #17751, S2 #17799, S3
+#17844, S4 #18911) all reported "Docker not available in worktree"
+in state.md. None ran a local Docker build; the parent regression
+was masked until this session. The OQ-01 file
+(`Proofs/Erdos101OQ01.lean`, 470 LOC) is therefore **unverified
+at v4.26.0** through S4.
+
+### Mechanic patch (2 LOC, out-of-slug)
+
+```diff
+-/-- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
++/- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
+     sets with ~n²/6 collinear triples but no four-point lines. -/
+-/-- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
++/- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
+     of lines L in ℝ², the number of incidences I(P,L) satisfies
+     I(P,L) ≤ C · (|P|^{2/3}·|L|^{2/3} + |P| + |L|) for some absolute constant C.
+     Note: stated for a given incidence count, not universally quantified. -/
+```
+
+The closing `-/` on lines 593 and 597 is unchanged; only the
+opening `/--` glyphs become `/-`. No semantic content shifts.
+
+### Why this S5 is doc-only
+
+- The parent file `Proofs/Erdos101Problem.lean` is owned by the
+  graduated slug `erdos-101`. Per
+  `feedback_researcher_parent_regression_isolation_via_new_file_split.md`,
+  research PRs must not bundle out-of-slug parent fixes. Mechanic /
+  doctor scope is preferred.
+- A new-file split is **not possible** for this slug: the OQ-01 file
+  depends on the parent's foundational `PlanarPointSet`,
+  `collinear`, `NoFiveCollinear`, `fourPointLineCount`, and
+  `improved_upper_bound` definitions. There is no alternate-parent
+  to pivot toward.
+- Therefore the only research-policy-conforming deliverable is the
+  diagnosis itself (this knowledge.md entry + the state.md
+  Parent Regression Inventory section). The mechanic agent picks
+  the file up next; once the patch merges, the slug returns to
+  ACT phase and the S6 ACT (`IsBigO`/`IsLittleO` bridge) becomes
+  unblocked.
+
+### Why the S4 file is likely still good
+
+The four `(build pending)` PRs introduced only:
+* `Real.rpow_lt_rpow_of_exponent_lt` (still in
+  `Mathlib/Analysis/SpecialFunctions/Pow/Real.lean` at v4.26.0)
+* `Real.log_lt_log`, `Real.log_exp`, `Real.exp_pos`,
+  `Real.exp_one_lt_d9` (still in
+  `Mathlib/Analysis/SpecialFunctions/Log/Basic.lean`)
+* `Real.sqrt_lt_sqrt`, `Real.sqrt_one` (still in
+  `Mathlib/Analysis/SpecialFunctions/Sqrt.lean`)
+* `div_lt_iff`, `linarith`, `nlinarith`
+
+All of these are standard Mathlib analysis APIs that have not been
+reported as regressed in any other 2026-05-12+ research session
+(per memory's v4.26.0 kit list: Matrix-API notation + Squarefree +
+Σ-token + `toAdd_mul` + `set→let` + `divisors_prime` + `4^m = 2^(2m)` +
+`finsetSum_coeff` + `Finset.card_eq_sum_card_fiberwise` — none touch
+`Real.*`). The expected outcome of a re-run of
+`docker-build.sh Proofs.Erdos101OQ01` after the 2-LOC parent
+patch is **green**, retroactively CI-verifying the entire S1–S4 chain.
+
+### S6 next-action (post-parent-unblock)
+
+S5 does not change the next-action ordering from state.md:
+
+1. **`Asymptotics.IsBigO` / `IsLittleO` bridge** — primary target.
+   Adds `import Mathlib.Analysis.Asymptotics.Defs` (or
+   `Asymptotics.Basic` for `IsBigO` / `IsLittleO` themselves);
+   defines `maxFourPointLines : ℕ → ℕ`; states
+   `fourPointLineCount_le_quadratic` in `Asymptotics.IsBigO`
+   form; records the OPEN conjecture as an `Asymptotics.IsLittleO
+   atTop (· ^ 2)` sorry. ~40–60 LOC.
+
+2. **Cauchy–Schwarz refinement** of the per-point bound.
+
+3. **Witness extraction at fixed `n`** for `native_decide`-certified
+   small-set examples.
+
+### Confidence
+
+**High** that the diagnosis is correct: the v4.26.0 parser error
+text is unambiguous and the orphan doc-string pattern matches the
+spherical-law-of-cosines + central-limit-theorem parser-strictness
+class. The 2-LOC patch is mechanical.
+
+**Medium** confidence that S1–S4 ACT compiles green after the
+parent unblocks — predicated on no other Mathlib regression in
+`Real.rpow_lt_rpow_of_exponent_lt`'s neighborhood, which is the
+single most "exotic" Mathlib API used in the file.

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,63 +1,110 @@
 # Current State
 
-**Phase**: ACT
-**Since**: 2026-05-13 (S4)
-**Iteration**: 4
-**Last Updated**: 2026-05-13 (researcher-1)
+**Phase**: BLOCKED (parent regression)
+**Since**: 2026-05-14 (S5)
+**Iteration**: 5
+**Last Updated**: 2026-05-14 (researcher-12)
 
 ## Current Focus
 
-S4 (researcher-1) extends S3's negated-existence refutation
-`erdos_three_halves_conjecture_refuted` to its positive constructive
-form `erdos_three_halves_conjecture_refuted_constructive`: for every
-threshold `N`, an explicit no-five-collinear witness `P` with
-`|P| ≥ N` and `|P|^{3/2} < fourPointLineCount P`. The proof reuses
-S3's chain verbatim through the `Real.rpow_lt_rpow_of_exponent_lt`
-step; only the final assembly differs (witness delivery vs.
-contradiction). Sorries unchanged at 2 (main conjecture +
-`solymosi_stojakovic_lower_bound`); axioms unchanged at 0; theorems
-8 → 9. File grows 383 → 470 LOC (+87).
+S5 (researcher-12) — first Docker baseline of `Proofs/Erdos101OQ01.lean`
+after 4 consecutive `(build pending)` PRs (S1 #17751, S2 #17799, S3
+#17844, S4 #18911 — all merged 2026-05-12 to 2026-05-13). The local
+build halts on the **out-of-slug** parent file
+`Proofs/Erdos101Problem.lean` (owned by graduated slug
+`erdos-101`) with two Mathlib v4.26.0 parser-strictness errors:
+
+```
+error: Proofs/Erdos101Problem.lean:593:65: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos101Problem.lean:597:76: unexpected token 'open'; expected 'lemma'
+```
+
+Both errors are caused by two **orphan doc-strings**
+(`/-- ... -/` blocks not followed by any declaration) at lines
+592–593 and 594–597 introduced in commit `08ea6265778` (2026-05-13).
+Lean 4.26.0's parser became strict about doc-strings without
+a following declaration; the prior compiler accepted them as
+floating commentary. They are commentary blocks documenting Burr–
+Grünbaum–Sloane / Füredi–Palásti (line 592) and Szemerédi–Trotter
+(line 594), positioned between `improved_upper_bound`'s closing
+`linarith` (line 588) and the `fourCollinearFamily` definition
+(line 602), so they are not attached to any theorem.
+
+Sorry/axiom inventory for `Erdos101OQ01.lean` is unchanged from S4:
+470 LOC, 2 sorries (the open `erdos_101_oq_01` main conjecture +
+`solymosi_stojakovic_lower_bound`), 0 axioms. **No edit to the
+OQ-01 file in this session.** This is a doc-only S5 OBSERVE recording
+the parent-regression diagnosis so that the mechanic agent can pick
+up the parent for repair.
 
 ## Previous Focus
 
-S3 (researcher-5) discharges `erdos_three_halves_conjecture_refuted`
-from S2's `solymosi_stojakovic_lower_bound` by elementary real-analysis
-arithmetic.  The sorry count drops from 3 → 2; the file is still axiom
-free.
+S4 (researcher-1) extends S3's negated-existence refutation
+`erdos_three_halves_conjecture_refuted` to its positive constructive
+form `erdos_three_halves_conjecture_refuted_constructive`. Sorries
+unchanged at 2; axioms unchanged at 0; theorems 8 → 9. File grew
+383 → 470 LOC (+87).
 
-## Active Approach
+S3 (researcher-5) discharged `erdos_three_halves_conjecture_refuted`
+from S2's `solymosi_stojakovic_lower_bound` by elementary
+real-analysis arithmetic. Sorries dropped 3 → 2.
 
-**Specialise SS to `C = 1/2` and use the strict monotonicity of
-`Real.rpow` in the exponent.**
+## Parent Regression Inventory (for mechanic pickup)
 
-1. Apply `solymosi_stojakovic_lower_bound (1/2 : ℝ)` to obtain `N₁` and
-   a witness `P` for every `n ≥ N₁`.
-2. Choose `m := max N₀ (max N₁ 3)`, so the hypothesised global upper
-   bound applies at `P` of cardinality `m` and `m ≥ 3` gives the
-   asymptotic threshold.
-3. For `m ≥ 3 > Real.exp 1` (via `Real.exp_one_lt_d9`), `Real.log m > 1`,
-   so `Real.sqrt (Real.log m) > 1`, so
-   `(1/2) / Real.sqrt (Real.log m) < 1/2`, so the SS exponent
-   `2 - (1/2) / Real.sqrt (Real.log m)` strictly exceeds `3/2`.
-4. `Real.rpow_lt_rpow_of_exponent_lt hm_gt_one h_exp_gt` then gives
-   `m^(3/2) < m^(2 - (1/2)/sqrt log m)`, which combined with the
-   hypothesised `count ≤ m^(3/2)` and the SS bound
-   `m^(2 - (1/2)/sqrt log m) ≤ count` produces a contradiction by
-   `linarith`.
+**File**: `proofs/Proofs/Erdos101Problem.lean` (757 LOC,
+0 axioms, 0 sorries, parent slug `erdos-101` graduated).
 
-## Next Action
+**Errors at v4.26.0**:
 
-S5 candidates (in order of expected value):
+| Line:Col | Token | Fix |
+|---|---|---|
+| `593:65` | `unexpected token '/--'; expected 'lemma'` | Convert orphan doc-string at lines 592–593 (`/-- ... -/`) to comment (`/- ... -/`). |
+| `597:76` | `unexpected token 'open'; expected 'lemma'` | Convert orphan doc-string at lines 594–597 (`/-- ... -/`) to comment (`/- ... -/`). |
+
+**Mechanic patch (2 LOC)**:
+
+```diff
+-/-- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
++/- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
+     sets with ~n²/6 collinear triples but no four-point lines. -/
+-/-- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
++/- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
+     of lines L in ℝ², the number of incidences I(P,L) satisfies
+     I(P,L) ≤ C · (|P|^{2/3}·|L|^{2/3} + |P| + |L|) for some absolute constant C.
+     Note: stated for a given incidence count, not universally quantified. -/
+```
+
+Two trailing `-/` lines (593, 597) remain unchanged — only the
+**opening** `/--` glyphs become `/-`. No semantic content is altered;
+the comments stay in place as floating commentary. After patch:
+`docker-build.sh Proofs.Erdos101OQ01` is expected to clear and
+verify the entire S1–S4 ACT chain (4 prior PRs, all `(build
+pending)`).
+
+**Detection signal**: this is the same parser-strictness class
+documented for the spherical-law-of-cosines + central-limit-theorem
+slugs (orphan doc-strings without following declarations); the
+v4.26.0 elaborator rejects all of them but the prior Mathlib (≤
+v4.25.x) accepted them.
+
+## Active Approach (resumes after parent fix)
+
+Once the parent file compiles cleanly, the four `(build pending)`
+PRs (S1 + S2 + S3 + S4) can be CI-verified retroactively against
+v4.26.0. The next-research-iteration approach is preserved from
+S4:
+
+**S6 plan** (next research iteration after parent unblock):
 
 1. **`Asymptotics.IsBigO` / `IsLittleO` bridge** (S4-candidate-1
    carried forward). Define `maxFourPointLines : ℕ → ℕ` via
    `Finset.sup'` or `Set.Sup` over the (finite-by-Mathlib-decidable-
    equality) set of no-five-collinear sets of fixed size at most `n`.
    Convert `fourPointLineCount_le_quadratic` into a
-   `Asymptotics.IsBigO ⟨atTop⟩` statement against `n^2`, and record
+   `Asymptotics.IsBigO atTop` statement against `n^2`, and record
    the OPEN conjecture as the `Asymptotics.IsLittleO` form `sorry`.
-   Bridge to the existing `IsLittleOh_n_squared` definition by direct
-   unfolding.
+   Bridge to the existing `IsLittleOh_n_squared` definition by
+   direct unfolding.
 
 2. **Cauchy–Schwarz refinement** of `fourCollinearThrough_bound`
    $\leq (n-1)/3$ to potentially yield a $1 - o(1)$ leading constant
@@ -69,37 +116,54 @@ S5 candidates (in order of expected value):
    `decide` on the underlying finite combinatorics — would supply
    `native_decide`-certified examples for the gallery entry.
 
+## Next Action
+
+**Block** until mechanic fixes `Proofs/Erdos101Problem.lean`
+orphan doc-strings (2 LOC). Once unblocked, claim slug for S6 ACT
+following the `IsBigO`/`IsLittleO` bridge plan above.
+
+If the mechanic does not act within 24h, a future research session
+may open a separate small fix PR for the parent
+(`fix(erdos-101): orphan doc-string parser unblocker`); this is
+**out-of-research-scope** for the current slug per
+`feedback_researcher_parent_regression_isolation_via_new_file_split.md`,
+and cannot be split off because `Erdos101OQ01.lean` requires the
+parent's foundational `PlanarPointSet` / `collinear` /
+`NoFiveCollinear` / `fourPointLineCount` definitions.
+
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 1 (S4 constructive refutation, this iteration)
-- Approaches tried: 3 (S1 scaffold + S2 lower-bound recording;
-  S3 elementary real-analysis discharge; S4 constructive rephrasing
-  of S3 chain)
+- Total attempts: 5
+- Current approach attempts: 1 (S5 OBSERVE parent regression
+  inventory, this iteration; no code changes to the OQ-01 file)
+- Approaches tried: 4 (S1 scaffold + S2 lower-bound recording;
+  S3 elementary real-analysis discharge; S4 constructive
+  rephrasing of S3 chain; S5 parent-regression diagnosis)
 
 ## Build Status
 
-S4 build: **PENDING** (Docker not available in worktree;
-`proofs/.lake` is a self-symlink and CI is ground truth). S4 introduces
-*no new imports* — the same Mathlib API as S3 is used
-(`Real.exp_one_lt_d9`, `Real.exp_pos`, `Real.log_exp`,
-`Real.log_lt_log`, `Real.sqrt_one`, `Real.sqrt_lt_sqrt`,
-`Real.rpow_lt_rpow_of_exponent_lt`, `div_lt_iff`).
+S5 build: **PARENT-BLOCKED**. First Docker baseline of
+`Proofs.Erdos101OQ01` at v4.26.0 (this session, 2026-05-14)
+halted on parent file `Proofs/Erdos101Problem.lean:593,597`
+parser errors. The OQ-01 file itself (`Erdos101OQ01.lean`) was
+not reached — its compilation state at v4.26.0 remains
+**unverified** (4 prior PRs all `(build pending)`).
 
-S4 risk profile:
-* One new theorem statement
-  (`erdos_three_halves_conjecture_refuted_constructive`); no edits
-  to S3's `erdos_three_halves_conjecture_refuted`.
-* The proof is structurally a copy of S3 through the
-  `Real.rpow_lt_rpow_of_exponent_lt` step; only the final assembly
-  changes from `linarith [hP_lb, hP_ub_m, h_rpow_lt]` (contradiction)
-  to `linarith [hP_lb, h_rpow_lt]` (chain `m^(3/2) < m^(2-...) ≤ count`).
-* `hcard.symm ▸ hm_N` provides the `N ≤ P.points.card` part of the
-  triple after destructuring; `rw [hcard]` rewrites `P.points.card`
-  to `m` in the final inequality.
+S4 risk profile (carried forward): the four `(build pending)` PRs
+introduced `Real.rpow_lt_rpow_of_exponent_lt`, `Real.log_lt_log`,
+`Real.sqrt_lt_sqrt`, `Real.exp_one_lt_d9`, `div_lt_iff`. These are
+all standard Mathlib analysis APIs and per the v4.26.0 release notes
+should still resolve. No known regressions for these names; the
+real-analysis chain is expected to compile once the parent
+unblocks.
 
 ## Blockers
 
-None for S4.  The remaining OPEN content is the main conjecture
-`erdos_101_oq_01` (a $\$100$ Erdős prize) and the SS construction
-itself (algebraic geometry over finite fields, deferred).
+1. **Parent parser regression** (`Proofs/Erdos101Problem.lean:593,597`)
+   — out-of-slug; awaits mechanic / doctor pickup. Documented above
+   with 2-LOC patch recipe.
+2. **(OPEN, deferred)** `erdos_101_oq_01` main conjecture — $100
+   Erdős prize, not a single-session result.
+3. **(OPEN, deferred)** `solymosi_stojakovic_lower_bound` SS
+   construction — algebraic geometry over finite fields, not in
+   Mathlib at present.

--- a/src/data/research/problems/erdos-101-oq-01.json
+++ b/src/data/research/problems/erdos-101-oq-01.json
@@ -1,14 +1,14 @@
 {
   "slug": "erdos-101-oq-01",
   "title": "Erdős #101 OQ-01: Four-Point Lines are $o(n^2)$",
-  "phase": "ACT",
+  "phase": "BLOCKED",
   "status": "active",
   "tier": "B",
   "path": "full",
   "significance": 7,
   "tractability": 5,
   "started": "2026-05-11T19:00:00Z",
-  "lastUpdate": "2026-05-12T05:00:00Z",
+  "lastUpdate": "2026-05-14T17:10:00.000Z",
   "problemStatement": {
     "formal": "\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P : \\text{PlanarPointSet},\\ \\text{NoFiveCollinear}\\ P \\land N \\leq |P| \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon \\cdot |P|^2",
     "plain": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, is the number of lines containing exactly four points $o(n^2)$? Best known: $O(n^2)$ upper (trivial), $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ lower (Solymosi–Stojaković).",
@@ -33,20 +33,22 @@
     "goal": "Prove $\\text{fourPointLineCount}(P) = o(|P|^2)$ for all `NoFiveCollinear P`, or sharpen the bound to an explicit subquadratic rate."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-13T18:00:00.000Z",
-    "iteration": 4,
-    "focus": "S4 (researcher-1, 2026-05-13): extended S3 negated-existence refutation to its positive constructive form. New theorem erdos_three_halves_conjecture_refuted_constructive : ∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ (|P| : ℝ)^(3/2 : ℝ) < (fourPointLineCount P : ℝ) — for every threshold N, an explicit no-five-collinear witness with |P| ≥ N and strictly more than |P|^(3/2) four-point lines. Proof reuses S3 chain (Real.exp_one_lt_d9 + Real.log_lt_log + Real.sqrt_lt_sqrt + Real.rpow_lt_rpow_of_exponent_lt) verbatim through h_rpow_lt; only the final assembly differs (witness delivery via refine + rw [hcard] + linarith [hP_lb, h_rpow_lt] instead of contradiction). Sorries unchanged at 2 (main conjecture + solymosi_stojakovic_lower_bound); axioms unchanged at 0; theorems 8 → 9. Lean file 383 → 470 LOC (+87).",
-    "blockers": [],
-    "nextAction": "S5 candidates: (1) Asymptotics.IsBigO/IsLittleO bridge — define maxFourPointLines : ℕ → ℕ, convert fourPointLineCount_le_quadratic to Filter.IsBigO atTop statement; (2) Cauchy–Schwarz refinement of fourCollinearThrough_bound for a 1 - o(1) leading constant on the n^2/12 elementary bound; (3) witness extraction at fixed n via decide on small finite combinatorics for native_decide-certified gallery examples. Main conjecture erdos_101_oq_01 ($100 Erdős prize) and solymosi_stojakovic_lower_bound remain OPEN/deferred.",
+    "phase": "BLOCKED",
+    "since": "2026-05-14T17:10:00.000Z",
+    "iteration": 5,
+    "focus": "S5 (researcher-12, 2026-05-14) — first Docker baseline of Proofs/Erdos101OQ01.lean at v4.26.0 after 4 consecutive (build pending) PRs (S1 #17751 + S2 #17799 + S3 #17844 + S4 #18911, all merged 2026-05-12 to 2026-05-13). Build halts on OUT-OF-SLUG parent Proofs/Erdos101Problem.lean (owned by graduated slug erdos-101) with 2 v4.26.0 parser-strictness errors at lines 593 and 597 — orphan doc-strings (`/-- ... -/` blocks without a following declaration) introduced 2026-05-13 in commit 08ea6265778. The OQ-01 file itself was not reached; its v4.26.0 compilation state remains unverified. Per feedback_researcher_parent_regression_isolation_via_new_file_split.md, research PRs do not bundle out-of-slug parent fixes; new-file split is impossible because the OQ-01 file depends on the parent foundational definitions. This S5 is doc-only: state.md + knowledge.md updated with diagnosis + 2-LOC mechanic patch recipe. Slug is BLOCKED until mechanic / doctor fixes the parent.",
+    "blockers": [
+      "Parent Proofs/Erdos101Problem.lean:593,597 orphan-docstring parser errors (out-of-slug, mechanic/doctor scope)"
+    ],
+    "nextAction": "BLOCK pending mechanic fix of Proofs/Erdos101Problem.lean orphan doc-strings (2 LOC, lines 593+597 — convert /-- ... -/ to /- ... -/). Patch recipe documented in state.md `Parent Regression Inventory` section. Once parent unblocks, S6 ACT IsBigO/IsLittleO bridge per S4 next-action plan (~40-60 LOC, adds Asymptotics import; defines maxFourPointLines via Finset.sup; states fourPointLineCount_le_quadratic as Asymptotics.IsBigO and records OPEN conjecture as IsLittleO sorry).",
     "attemptCounts": {
-      "total": 4,
+      "total": 5,
       "currentApproach": 1,
-      "approachesTried": 3
+      "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "S4 (researcher-1, 2026-05-13): constructive refutation of Erdős three-halves conjecture landed. New theorem erdos_three_halves_conjecture_refuted_constructive : ∀ N, ∃ P, NoFiveCollinear P ∧ N ≤ |P| ∧ |P|^(3/2) < fourPointLineCount P — the positive form of S3 negated-existence refutation. Reuses S3 chain (specialise SS lower bound to C = 1/2, exp 1 < 3 ⟹ log m > 1 ⟹ sqrt log m > 1 ⟹ (1/2)/sqrt log m < 1/2 ⟹ 2-(...)>3/2 ⟹ m^(3/2) < m^(2-...) ≤ count) verbatim through h_rpow_lt; final assembly via refine + rw + linarith. Sorries 2 (unchanged: erdos_101_oq_01 + solymosi_stojakovic_lower_bound), axioms 0 (unchanged), theorems 8 → 9. File 383 → 470 LOC. Build pending (.lake symlink trap). S3 (researcher-5, 2026-05-12): discharged erdos_three_halves_conjecture_refuted via elementary real-analysis arithmetic; 50-line proof; sorries 3 → 2. S2 (researcher-1, 2026-05-12): recorded Solymosi–Stojaković 2013 existential lower bound as theorem ... := by sorry plus corollary erdos_three_halves_conjecture_refuted (also sorry). S1 (researcher-3, 2026-05-11): OBSERVE — formal Σ₂ statement, 5 supporting theorems proved unconditionally.",
+    "progressSummary": "S5 (researcher-12, 2026-05-14, doc-only): PARENT-BLOCKED. First v4.26.0 Docker baseline of Proofs/Erdos101OQ01.lean halted on parent Proofs/Erdos101Problem.lean orphan-docstring parser errors (lines 593, 597). Diagnosis + mechanic patch recipe documented in state.md and knowledge.md. No edits to OQ-01 file. Slug awaits mechanic / doctor pickup of parent; S6 ACT (IsBigO/IsLittleO bridge) blocked until parent compiles. Sorry/axiom counts unchanged (2 sorries, 0 axioms, 470 LOC).",
     "builtItems": [
       "proofs/Proofs/Erdos101OQ01.lean: IsLittleOh_n_squared (def)",
       "proofs/Proofs/Erdos101OQ01.lean: BoundsAtRate (def)",
@@ -70,7 +72,8 @@
       "Solymosi–Stojaković (2013) refuted Erdős's $\\Theta(n^{3/2})$ conjecture with $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ — the open content is the polylog correction, not the leading order.",
       "All known elementary upper bounds are $\\Theta(n^2)$; closing the gap to $o(n^2)$ requires either a multiplicity-aware Szemerédi–Trotter refinement or a non-incidence argument.",
       "The ℕ→ℝ cast in `bounds_at_rate_quadratic_over_twelve` weakens $n(n-1)/12$ to $n^2/12$ to avoid `Nat.sub` truncation; asymptotically equivalent.",
-      "S4 (researcher-1, 2026-05-13): the negated-existence form (S3) and positive constructive form (S4) of the three-halves refutation are interconvertible by simple boolean rephrasing, but the constructive form is more useful downstream — it directly supplies witnesses rather than refuting a hypothetical bound. Both depend on the same axiom-free deferred theorem solymosi_stojakovic_lower_bound (still sorry). The S3 chain is reusable across both forms: chain S3 through Real.rpow_lt_rpow_of_exponent_lt, then choose between contradiction (S3) vs. refine+linarith (S4) at the final assembly step."
+      "S4 (researcher-1, 2026-05-13): the negated-existence form (S3) and positive constructive form (S4) of the three-halves refutation are interconvertible by simple boolean rephrasing, but the constructive form is more useful downstream — it directly supplies witnesses rather than refuting a hypothetical bound. Both depend on the same axiom-free deferred theorem solymosi_stojakovic_lower_bound (still sorry). The S3 chain is reusable across both forms: chain S3 through Real.rpow_lt_rpow_of_exponent_lt, then choose between contradiction (S3) vs. refine+linarith (S4) at the final assembly step.",
+      "S5 (researcher-12, 2026-05-14): First Docker baseline at v4.26.0 surfaced 2 orphan-doc-string parser errors in OUT-OF-SLUG parent Proofs/Erdos101Problem.lean:593,597 (introduced 2026-05-13 commit 08ea6265778; masked by 4 consecutive (build pending) PRs). Mechanic patch is 2 LOC (/-- → /-). OQ-01 file compilation state at v4.26.0 still unverified; expected green retroactively once parent unblocks because all S1-S4 Mathlib API (Real.rpow_lt_rpow_of_exponent_lt, Real.log_lt_log, Real.sqrt_lt_sqrt, Real.exp_one_lt_d9, div_lt_iff) is in no current v4.26.0 regression kit."
     ],
     "mathlibGaps": [
       "No direct Σ₂-style $o(n^2)$ uniform-bound vocabulary; we use an explicit ε–N form. Bridge to `Asymptotics.IsLittleO` deferred to S3.",


### PR DESCRIPTION
## Summary

S5 OBSERVE (doc-only) for `erdos-101-oq-01`: first Docker baseline of
`Proofs.Erdos101OQ01` at Mathlib v4.26.0 (after 4 consecutive `(build
pending)` PRs — S1 #17751 + S2 #17799 + S3 #17844 + S4 #18911, all
merged 2026-05-12 to 2026-05-13) halts on the **out-of-slug** parent
`Proofs/Erdos101Problem.lean` with two parser-strictness errors.

## Parent Regression (out-of-slug, mechanic/doctor scope)

```
error: Proofs/Erdos101Problem.lean:593:65: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos101Problem.lean:597:76: unexpected token 'open'; expected 'lemma'
```

**Cause**: two orphan doc-strings (`/-- ... -/` without following
declaration) at parent lines 592–593 (Burr–Grünbaum–Sloane commentary)
and 594–597 (Szemerédi–Trotter commentary), introduced 2026-05-13 in
commit `08ea6265778`. v4.26.0's parser is strict about orphan
doc-strings; prior Mathlib (≤ v4.25.x) accepted them.

**Mechanic patch (2 LOC)**:

```diff
-/-- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
+/- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
     sets with ~n²/6 collinear triples but no four-point lines. -/
-/-- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
+/- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
     of lines L in ℝ², the number of incidences I(P,L) satisfies
     I(P,L) ≤ C · (|P|^{2/3}·|L|^{2/3} + |P| + |L|) for some absolute constant C.
     Note: stated for a given incidence count, not universally quantified. -/
```

## Why this is doc-only (no Lean edits in this PR)

The parent file `Proofs/Erdos101Problem.lean` is owned by the
**graduated** slug `erdos-101` (separate from this slug
`erdos-101-oq-01`). Per
`feedback_researcher_parent_regression_isolation_via_new_file_split.md`,
research PRs must not bundle out-of-slug parent fixes; the parent
awaits mechanic / doctor pickup with the recipe above.

A new-file split (the standard mitigation) is **impossible** for
this slug: `Proofs/Erdos101OQ01.lean` depends on the parent's
foundational `PlanarPointSet` / `collinear` / `NoFiveCollinear` /
`fourPointLineCount` / `improved_upper_bound` definitions — there
is no alternate-parent to pivot toward.

Therefore the only research-policy-conforming deliverable is the
diagnosis itself, recorded here for mechanic pickup.

## Files Modified

| File | Change |
|---|---|
| `research/problems/erdos-101-oq-01/state.md` | Phase ACT → BLOCKED (parent regression); iteration 4 → 5; Parent Regression Inventory section added with line-by-line error table and 2-LOC patch recipe. |
| `research/problems/erdos-101-oq-01/knowledge.md` | S5 OBSERVE entry: full diagnosis, masking explanation (4 `(build pending)` PRs hid the regression for 2 days), why-doc-only justification, confidence assessment for S1–S4 retroactive verification. |
| `src/data/research/problems/erdos-101-oq-01.json` | Top-level + cs phase ACT → BLOCKED; iteration 5; blockers populated; lastUpdate refreshed; +1 insight (parser regression). |

**No edit** to `proofs/Proofs/Erdos101OQ01.lean` (470 LOC, 2 sorries,
0 axioms — unchanged).

## Verification

After the mechanic 2-LOC parent patch lands, `docker-build.sh
Proofs.Erdos101OQ01` is expected to verify the entire S1–S4 ACT
chain retroactively. Mathlib API surface used (`Real.rpow_lt_rpow_of_exponent_lt`,
`Real.log_lt_log`, `Real.sqrt_lt_sqrt`, `Real.exp_one_lt_d9`,
`div_lt_iff`) does not appear in any current v4.26.0 regression kit.

## Next Steps

* **Mechanic / doctor**: pick up the parent 2-LOC patch (see
  `state.md` § Parent Regression Inventory).
* **Researcher (post-unblock)**: claim `erdos-101-oq-01` for S6 ACT —
  `Asymptotics.IsBigO` / `IsLittleO` bridge.

## Status

**Outcome**: parent-blocked; doc-only diagnosis for mechanic pickup.
**Sorry count**: unchanged (2). **Axiom count**: unchanged (0).

🤖 Generated by researcher-12 (2026-05-14)