### PR TITLE
fix(mechanic): Erdos101Problem v4.26.0 parent build break

### DIFF
--- a/proofs/Proofs/Erdos101Problem.lean
+++ b/proofs/Proofs/Erdos101Problem.lean
@@ -282,18 +282,19 @@ theorem four_collinear_overlap_small (P : PlanarPointSet) (hP : NoFiveCollinear 
 
 /- ## Main Conjecture -/
 
-/-- **Erdős Problem #101**: the number of four-point lines is o(n²).
+/- **Erdős Problem #101**: the number of four-point lines is o(n²).
     For any ε > 0, eventually fourPointLineCount(P) < ε · n². -/
 /- ## Known Results -/
 
-/-- **Grünbaum's Lower Bound**: there exist point sets with no five collinear
+/- **Grünbaum's Lower Bound**: there exist point sets with no five collinear
     achieving ≫ n^{3/2} four-point lines. -/
-/-- **Solymosi–Stojaković**: configurations exist with n^{2−O(1/√(log n))}
+/- **Solymosi–Stojaković**: configurations exist with n^{2−O(1/√(log n))}
     four-point lines, disproving Erdős's Θ(n^{3/2}) conjecture. -/
 /-- **Trivial Upper Bound (n²)**: Under NoFiveCollinear, fourPointLineCount ≤ n².
     Injection from 4-collinear subsets to ordered pairs via existential witnesses. -/
 theorem trivial_upper_bound_sq (P : PlanarPointSet) (hP : NoFiveCollinear P) :
     fourPointLineCount P ≤ P.points.card * P.points.card := by
+  classical
   unfold fourPointLineCount
   set F := P.points.powerset.filter (fun S =>
     S.card = 4 ∧
@@ -589,9 +590,9 @@ theorem improved_upper_bound (P : PlanarPointSet) (hP : NoFiveCollinear P) :
 
 /- ## Related Observations -/
 
-/-- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
+/- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
     sets with ~n²/6 collinear triples but no four-point lines. -/
-/-- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
+/- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
     of lines L in ℝ², the number of incidences I(P,L) satisfies
     I(P,L) ≤ C · (|P|^{2/3}·|L|^{2/3} + |P| + |L|) for some absolute constant C.
     Note: stated for a given incidence count, not universally quantified. -/


### PR DESCRIPTION
## Fix

Unblocks `Proofs.Erdos101Problem` parent build at Mathlib v4.26.0.

**Trigger**: research PR #19097 (`erdos-101-oq-01` S5 OBSERVE) diagnosed the parent as blocked, masked by 4 consecutive `(build pending)` PRs (S1 #17751 + S2 #17799 + S3 #17844 + S4 #18911, merged 2026-05-12 to 2026-05-13) that never Docker-built.

## Evidence

**Before**:
```
$ docker-build.sh Proofs.Erdos101Problem
error: Erdos101Problem.lean:286:64: unexpected token '/--'; expected 'lemma'
error: Erdos101Problem.lean:290:44: unexpected token '/--'; expected 'lemma'
error: Erdos101Problem.lean:292:66: unexpected token '/--'; expected 'lemma'
error: Erdos101Problem.lean:298:11: failed to synthesize DecidablePred ...
error: Erdos101Problem.lean:303:40: failed to synthesize DecidablePred ...
error: Erdos101Problem.lean:306:17: failed to synthesize DecidablePred ...
error: Erdos101Problem.lean:308:4:  failed to synthesize Decidable ...
error: Erdos101Problem.lean:593:65: unexpected token '/--'; expected 'lemma'
error: Erdos101Problem.lean:597:76: unexpected token 'open'; expected 'lemma'
=== Build failed ===
```

**After**:
```
$ docker-build.sh Proofs.Erdos101Problem
✔ [3058/3058] Built Proofs.Erdos101Problem (4.9s)
Build completed successfully (3058 jobs).
```

## Two regression classes

**A. Orphan doc-strings (5 LOC)** — v4.26.0 parser strictness rejects `/-- text -/` blocks not followed by a declaration; prior Mathlib (≤ v4.25.x) accepted them silently.
- Lines 285-286, 289-290, 291-292 (Erdős Problem #101 / Grünbaum / Solymosi–Stojaković commentary above Known Results)
- Lines 592-593, 594-597 (Burr–Grünbaum–Sloane / Szemerédi–Trotter commentary above F-family section)
- Fix: `/--` → `/-` for each orphan block
- Line 293-294's `/-- Trivial Upper Bound -/` is preserved — it's the real docstring for the theorem at line 295.

**B. Decidable synthesis cascade (1 LOC)** — `trivial_upper_bound_sq` filters `P.points.powerset` by a predicate containing `∃ a b, …`. At v4.26.0, `Decidable` is not auto-synthesized for this shape. The file's 13 sibling `noncomputable def` declarations already use `open Classical in` (lines 42, 151, 164, 220, 247, 361, 517, 600, 608, 616, 625, 718, 728).
- Fix: `classical` tactic at the start of `trivial_upper_bound_sq`'s `by` block (`open Classical in` would orphan the preceding docstring).

## Out of scope (filed for follow-up)

After parent unblock, child `Proofs.Erdos101OQ01` reveals its own v4.26.0 regressions — these are a separate mechanic PR targeting the child file:
- Lines 352, 442: `Real.exp_one_lt_d9` unknown constant
- Lines 365, 455: `div_lt_iff` unknown identifier (likely `div_lt_iff₀` rename)
- Line 135: `not a positivity goal` (tactic regression)

The S1–S4 retroactive verification claimed in #19097's description is therefore not achievable from this parent patch alone.

## Mechanic kit (v4.26.0 orphan-docstring detection)

- **Error signature 1**: `error: unexpected token '/--'; expected 'lemma'` at the end of an orphan `/-- ... -/` block.
- **Error signature 2**: `error: unexpected token 'open'; expected 'lemma'` if `open Classical in` immediately follows an orphan docstring.
- **Detection**: any `/-- text -/` that isn't immediately followed by `theorem` / `lemma` / `def` / `structure` / `class` / `instance` / `abbrev` / `inductive`. Section-header comments should use `/- ## ... -/`, not `/-- ## ... -/`.

## Files Modified

| File | Change |
|---|---|
| `proofs/Proofs/Erdos101Problem.lean` | 5 orphan `/--` → `/-` + 1 `classical` tactic; total +6 / -5 LOC |

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos101Problem` — clean at 3058/3058 jobs (~4.9s in-loop after cache warm).

---
Automated fix by lean-mechanic agent.