### PR TITLE
research(euler-totient-oq-04-oq-01): S2 SCAFFOLD — squarefree-divisor / powerset bijection (build verified 1118 jobs, 2 strategic sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2224,6 +2224,7 @@ import Proofs.EulerTotientOQ02
 import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03
 import Proofs.EulerTotientOQ04
+import Proofs.EulerTotientOQ04OQ01
 import Proofs.FactorRemainderNullstellensatzOQ01
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem

--- a/proofs/Proofs/EulerTotientOQ04OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ01.lean
@@ -1,0 +1,158 @@
+/-
+# Möbius Inversion via Squarefree-Divisor / Powerset Bijection
+
+## What This Proves
+The classical Möbius-function identity
+
+  Σ_{d | n} μ(d)  =  if n = 1 then 1 else 0
+
+via a *direct constructive* argument that parallels the GCD-partition
+aesthetic of `EulerTotientOQ04.lean`:
+
+1. Only squarefree divisors contribute (μ vanishes on non-squarefree).
+2. The squarefree divisors of `n` are in bijection with the powerset
+   of `n.primeFactors`, via `S ↦ ∏_{p ∈ S} p`.
+3. Under this bijection, `μ(∏_{p ∈ S} p) = (-1)^|S|`.
+4. Summing yields `Σ_{S ⊆ primeFactors(n)} (-1)^|S| = (1-1)^{ω(n)}`,
+   which is 1 iff `ω(n) = 0`, i.e. iff `n = 1` (for `n ≥ 1`).
+
+## Why this isn't a Mathlib wrapper
+Mathlib's `ArithmeticFunction.moebius_mul_coe_zeta` proves the same
+identity via `recOnPosPrimePosCoprime` (multiplicative induction). The
+proof here uses NO multiplicativity — it relies on the squarefree-
+divisor / powerset bijection (`Mathlib.Data.Nat.Squarefree.sum_divisors_filter_squarefree`)
+and the alternating binomial-sum identity (`Mathlib.Data.Nat.Choose.Sum.sum_powerset_neg_one_pow_card`).
+This is the squarefree analogue of the parent file's GCD-class partition.
+
+## Status
+**S2 SCAFFOLD** — main statement proved modulo three strategic sorries:
+- `moebius_prod_squarefree`: μ of a product of distinct primes is `(-1)^k`
+- `prod_primeFactors_bij_squarefree`: bijection prod-on-powerset is squarefree
+- `sum_normalizedFactors_eq_sum_primeFactors`: bridge from Mathlib's
+  `normalizedFactors`-formulation back to `primeFactors`
+
+The intended S3 ACT discharges all three via `cardFactors_apply_prime`
++ `prod_primeFactors_of_squarefree` + `factors_eq` (Nat-specific).
+
+## Mathlib Dependencies
+- `Mathlib.NumberTheory.ArithmeticFunction.Moebius` — `μ`, `moebius_eq_zero_of_not_squarefree`
+- `Mathlib.Data.Nat.Squarefree` — `sum_divisors_filter_squarefree`
+- `Mathlib.Data.Nat.Choose.Sum` — `sum_powerset_neg_one_pow_card`
+- `Mathlib.RingTheory.UniqueFactorizationDomain.Nat` — `factors_eq` (Nat-side bridge)
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Moebius
+import Mathlib.Data.Nat.Squarefree
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.RingTheory.UniqueFactorizationDomain.Nat
+
+open Finset Nat ArithmeticFunction
+open scoped ArithmeticFunction.Moebius
+
+namespace EulerTotientOQ04OQ01
+
+/- ## Part I: μ vanishes on non-squarefree divisors -/
+
+/-- Restricting the divisor sum of `μ` to squarefree divisors changes
+nothing, because `μ d = 0` whenever `d` is not squarefree. -/
+theorem sum_moebius_divisors_eq_filter_squarefree (n : ℕ) :
+    ∑ d ∈ n.divisors, μ d = ∑ d ∈ n.divisors with Squarefree d, μ d := by
+  rw [← Finset.sum_filter_add_sum_filter_not n.divisors Squarefree (fun d => μ d)]
+  have hzero : ∑ d ∈ n.divisors with ¬ Squarefree d, μ d = 0 := by
+    apply Finset.sum_eq_zero
+    intro d hd
+    rw [Finset.mem_filter] at hd
+    exact moebius_eq_zero_of_not_squarefree hd.2
+  rw [hzero, add_zero]
+
+/- ## Part II: μ of a squarefree product of distinct primes -/
+
+/-- For a finite set `s` of distinct primes, `μ (∏ s) = (-1)^|s|`.
+
+Strategic sorry (S3 ACT): combine `prod_primeFactors_of_squarefree`-style
+argument that `s.prod id` is squarefree (since elements are distinct
+primes), then `moebius_apply_of_squarefree` + `cardFactors` of a
+squarefree product equals `s.card`. -/
+theorem moebius_prod_squarefree (s : Finset ℕ) (hs : ∀ p ∈ s, p.Prime) :
+    μ (∏ p ∈ s, p) = (-1 : ℤ) ^ s.card := by
+  sorry
+
+/- ## Part III: bridge from Mathlib's normalizedFactors form to primeFactors -/
+
+/-- For `n ≠ 0`, `(normalizedFactors n).toFinset = n.primeFactors`.
+This is the Nat-side bridge for `sum_divisors_filter_squarefree`. -/
+theorem normalizedFactors_toFinset_eq (n : ℕ) (hn : n ≠ 0) :
+    (UniqueFactorizationMonoid.normalizedFactors n).toFinset = n.primeFactors := by
+  ext p
+  -- `factors_eq` rewrites `normalizedFactors n = n.primeFactorsList`,
+  -- and `mem_primeFactors` characterises membership in `n.primeFactors`.
+  simp [Nat.factors_eq, Nat.mem_primeFactors, hn]
+
+/- ## Part IV: powerset-sum identity for the alternating signs -/
+
+/-- For `n ≠ 0`, the Möbius sum on squarefree divisors equals
+`Σ_{S ⊆ primeFactors n} (-1)^|S|`. This is the Mathlib bijection
+`sum_divisors_filter_squarefree` composed with `moebius_prod_squarefree`. -/
+theorem sum_filter_squarefree_moebius_eq_powerset (n : ℕ) (hn : n ≠ 0) :
+    (∑ d ∈ n.divisors with Squarefree d, μ d : ℤ)
+      = ∑ S ∈ n.primeFactors.powerset, (-1 : ℤ) ^ S.card := by
+  -- Apply Mathlib's bijection: sum on squarefree divisors → sum on powerset
+  rw [Nat.sum_divisors_filter_squarefree hn]
+  -- Rewrite the powerset index via `normalizedFactors_toFinset_eq`
+  rw [normalizedFactors_toFinset_eq n hn]
+  -- For each S ⊆ primeFactors n, μ(S.val.prod) = (-1)^|S|.
+  -- This needs that elements of S are primes (from S ⊆ primeFactors n)
+  -- combined with `moebius_prod_squarefree`. Strategic sorry; see S3 plan.
+  sorry
+
+/- ## Part V: main result -/
+
+/-- **Main Theorem**: `Σ_{d | n} μ(d) = [n = 1]`.
+
+Constructive proof via squarefree-divisor / powerset bijection, parallel
+to the GCD-partition proof of the parent file `EulerTotientOQ04.lean`. -/
+theorem sum_moebius_eq_indicator (n : ℕ) :
+    (∑ d ∈ n.divisors, μ d : ℤ) = if n = 1 then (1 : ℤ) else 0 := by
+  -- Case n = 0: divisors are empty, indicator is 0.
+  by_cases h0 : n = 0
+  · subst h0
+    simp
+  -- Case n ≠ 0: route through squarefree filter + powerset sum.
+  rw [sum_moebius_divisors_eq_filter_squarefree,
+      sum_filter_squarefree_moebius_eq_powerset n h0,
+      Finset.sum_powerset_neg_one_pow_card]
+  -- Goal: (if n.primeFactors = ∅ then 1 else 0) = (if n = 1 then 1 else 0).
+  have hpf : n.primeFactors = ∅ ↔ n = 1 := by
+    rw [Nat.primeFactors_eq_empty]
+    exact ⟨fun h => h.resolve_left h0, fun h => Or.inr h⟩
+  split_ifs with h1 h2 h3
+  · rfl
+  · exact absurd (hpf.mp h1) h2
+  · exact absurd (hpf.mpr h3) h1
+  · rfl
+
+/- ## Part VI: corollaries and validation -/
+
+/-- The standard "indicator" form of the identity. -/
+theorem sum_moebius_eq_one_iff_one (n : ℕ) :
+    (∑ d ∈ n.divisors, μ d : ℤ) = 1 ↔ n = 1 := by
+  rw [sum_moebius_eq_indicator]
+  split_ifs with h
+  · simp [h]
+  · constructor
+    · intro h1; exfalso; exact zero_ne_one h1
+    · intro h1; exact absurd h1 h
+
+/-- Concrete validation: μ(1) + μ(2) + μ(3) + μ(6) = 1 - 1 - 1 + 1 = 0 for n = 6. -/
+example : (∑ d ∈ (6 : ℕ).divisors, μ d : ℤ) = 0 := by
+  rw [sum_moebius_eq_indicator]; rfl
+
+/-- Concrete validation: n = 1 case. -/
+example : (∑ d ∈ (1 : ℕ).divisors, μ d : ℤ) = 1 := by
+  rw [sum_moebius_eq_indicator]; rfl
+
+/-- Concrete validation: prime case (μ(1) + μ(p) = 1 + (-1) = 0). -/
+example : (∑ d ∈ (5 : ℕ).divisors, μ d : ℤ) = 0 := by
+  rw [sum_moebius_eq_indicator]; rfl
+
+end EulerTotientOQ04OQ01

--- a/research/problems/euler-totient-oq-04-oq-01/state.md
+++ b/research/problems/euler-totient-oq-04-oq-01/state.md
@@ -1,0 +1,91 @@
+# Research State: euler-totient-oq-04-oq-01
+
+## Current State
+**Phase**: SCAFFOLD
+**Path**: full
+**Since**: 2026-05-14T19:30:00Z
+**Iteration**: 2
+
+## Current Focus
+S2 SCAFFOLD landed (PR pending): `proofs/Proofs/EulerTotientOQ04OQ01.lean`
+states the main identity `Σ_{d|n} μ(d) = [n = 1]` and proves it modulo
+two strategic sorries:
+
+| Sorry | Location | Discharge plan (S3 ACT) |
+|---|---|---|
+| `moebius_prod_squarefree` | line 76 | `Squarefree.prod` of distinct primes + `moebius_apply_of_squarefree` + `cardFactors_prod_of_squarefree` |
+| `sum_filter_squarefree_moebius_eq_powerset` | line 96 | unfold Mathlib's `sum_divisors_filter_squarefree`, then `Finset.sum_congr` with `moebius_prod_squarefree` on each `S.val.prod` |
+
+Main theorem `sum_moebius_eq_indicator` and the squarefree-vs-not split
+(`sum_moebius_divisors_eq_filter_squarefree`) are FULLY proved (no sorry).
+The Nat-side bridge `normalizedFactors_toFinset_eq` is fully proved (closes
+via `simp [Nat.factors_eq, Nat.mem_primeFactors, hn]`).
+
+Build verified: 1118 jobs, 2 strategic sorries (warnings only).
+
+## Active Approach
+**Squarefree-divisor / powerset bijection** (S1 OBSERVE recommendation S2-B):
+1. μ vanishes on non-squarefree divisors → restrict sum to squarefree.
+2. Mathlib's `sum_divisors_filter_squarefree` bijects squarefree divisors
+   with `(normalizedFactors n).toFinset.powerset = n.primeFactors.powerset`.
+3. For each `S ⊆ primeFactors(n)`, `μ(∏ S) = (-1)^|S|` (μ on squarefree
+   product of distinct primes).
+4. `Finset.sum_powerset_neg_one_pow_card` collapses to indicator
+   `if primeFactors(n) = ∅ then 1 else 0`.
+5. `Nat.primeFactors_eq_empty` resolves to `n = 1` (excluding `n = 0`).
+
+This is genuinely orthogonal to Mathlib's `moebius_mul_coe_zeta` proof
+(via `recOnPosPrimePosCoprime` multiplicative induction).
+
+## Attempt Count
+- Total attempts: 3 (Docker iters)
+- Current approach attempts: 3
+- Approaches tried: 1 (squarefree-divisor / powerset)
+
+### Docker build log
+- Iter 1: `EulerTotientOQ04OQ01.lean` file not in worktree (Write-tool path bug); copied + rebuilt
+- Iter 2: `Nat.eq_one_or_self_lt_of_prime_factorization` unknown + `rw [hpf]` motive failure on `if`-Decidable + simp closes goal extra `sorry` "no goals to be solved" + `id` ambiguous (`_root_.id` vs `ArithmeticFunction.id` after `open ArithmeticFunction`)
+- Iter 3: ✅ **CLEAN** — 1118 jobs, 2 strategic sorries, no errors
+
+## Blockers
+None. Strategic sorries are deliberate S2 SCAFFOLD scope.
+
+## Next Action
+**S3 ACT** discharges both strategic sorries:
+
+1. `moebius_prod_squarefree (s : Finset ℕ) (hs : ∀ p ∈ s, p.Prime) :
+       μ (∏ p ∈ s, p) = (-1 : ℤ) ^ s.card`
+   - Show `∏ p ∈ s, p` is squarefree (using `Squarefree.prod` + `hs`).
+   - Apply `moebius_apply_of_squarefree`.
+   - Compute `cardFactors (∏ p ∈ s, p) = s.card` (sum of `cardFactors_apply_prime`
+     over distinct primes; uses `Nat.cardFactors_mul` + `Coprime` between distinct primes).
+
+2. `sum_filter_squarefree_moebius_eq_powerset (n : ℕ) (hn : n ≠ 0) :
+       ∑ d ∈ n.divisors with Squarefree d, μ d
+         = ∑ S ∈ n.primeFactors.powerset, (-1 : ℤ) ^ S.card`
+   - Rewrite via `Nat.sum_divisors_filter_squarefree hn`.
+   - Rewrite powerset index via `normalizedFactors_toFinset_eq` (already proved).
+   - For each `S ∈ powerset`, `S.val.prod = ∏ p ∈ S, p` and apply
+     `moebius_prod_squarefree`.
+
+S3 target: discharge both, plus add gallery `src/data/proofs/euler-totient-oq-04-oq-01/`
+directory (meta.json, annotations.json, index.ts) with explicit
+"original" vs "axiomatized" status decision based on remaining sorries.
+
+Expected LOC after S3 ACT: 100-150 (currently ~145 with 2 sorries).
+
+## Cross-references
+- Parent file: `proofs/Proofs/EulerTotientOQ04.lean` (231 LOC, 0 sorries,
+  GCD-class partition proof of `n = Σ_{d|n} φ(n/d)`)
+- Mathlib API: `ArithmeticFunction.moebius_mul_coe_zeta` (alternative proof
+  via multiplicative induction)
+- Sibling open question: `euler-totient-oq-04` openQuestion[1] —
+  "Formalize the Dirichlet series identity Σ φ(n)/n^s = ζ(s-1)/ζ(s)"
+  (NOT touched in this slug)
+
+## Session Log
+- **S1 OBSERVE** (2026-05-12, PR #18316, MERGED): scouted Mathlib coverage,
+  identified three S2 targets (A: wrapper, B: constructive, C: Möbius dual)
+- **S2 SCAFFOLD** (2026-05-14, this session): squarefree-divisor / powerset
+  bijection skeleton + main theorem proved modulo 2 strategic sorries
+  (build verified 1118 jobs)


### PR DESCRIPTION
## Summary

S2 SCAFFOLD for `euler-totient-oq-04-oq-01`. Constructive proof of the
Möbius identity `Σ_{d|n} μ(d) = [n = 1]` via the squarefree-divisor /
powerset bijection — the squarefree analogue of the parent file's
GCD-class partition (`EulerTotientOQ04.lean`).

Build verified: **1118 jobs**, 2 strategic sorries (both warnings only).

## Why not a Mathlib wrapper?

Mathlib proves the same identity via `ArithmeticFunction.moebius_mul_coe_zeta`,
which uses **multiplicative induction** (`recOnPosPrimePosCoprime`). The
proof here uses **no multiplicativity** — it relies only on:

- `Mathlib.Data.Nat.Squarefree.sum_divisors_filter_squarefree` (bijection)
- `Mathlib.Data.Nat.Choose.Sum.sum_powerset_neg_one_pow_card` (binomial collapse)
- `ArithmeticFunction.moebius_eq_zero_of_not_squarefree` (filter step)

The S1 OBSERVE session (PR #18316, merged 2026-05-12) audited Mathlib
coverage and explicitly recommended this S2-B target over the one-line
wrapper (S2-A) to avoid enumeration theater.

## Proof Strategy

1. **Filter step**: μ vanishes on non-squarefree divisors, so
   `Σ_{d|n} μ d = Σ_{d|n, Squarefree d} μ d`.
2. **Bijection**: Mathlib's `sum_divisors_filter_squarefree hn` rewrites
   the sum over squarefree divisors of `n` as a sum over the powerset of
   `(normalizedFactors n).toFinset = n.primeFactors`.
3. **μ on squarefree product**: for `S ⊆ n.primeFactors` with elements
   distinct primes, `μ (∏ S) = (-1)^|S|`.
4. **Alternating-sum collapse**: `sum_powerset_neg_one_pow_card` gives
   `Σ_{S ⊆ primeFactors n} (-1)^|S| = if primeFactors n = ∅ then 1 else 0`.
5. **Final reduction**: `Nat.primeFactors_eq_empty` resolves
   `primeFactors n = ∅ ↔ n = 0 ∨ n = 1`. Combined with the `n = 0` case
   handled separately, we get `if n = 1 then 1 else 0`.

## Strategic Sorries (2)

| Sorry | Location | Discharge plan (S3 ACT) |
|---|---|---|
| `moebius_prod_squarefree` | line 76 | `Squarefree.prod` over distinct primes + `moebius_apply_of_squarefree` + `cardFactors_prod_of_squarefree` |
| `sum_filter_squarefree_moebius_eq_powerset` | line 96 | `Nat.sum_divisors_filter_squarefree hn` + `normalizedFactors_toFinset_eq` + `Finset.sum_congr` with `moebius_prod_squarefree` |

## Fully Proved (no sorry)

- `sum_moebius_divisors_eq_filter_squarefree`: split squarefree vs. non
- `normalizedFactors_toFinset_eq`: Nat-side bridge to `n.primeFactors`
  (closes via `simp [Nat.factors_eq, Nat.mem_primeFactors, hn]`)
- `sum_moebius_eq_indicator`: **MAIN THEOREM** (proved modulo the two
  sorries above; the indicator-from-powerset chain is fully explicit)
- `sum_moebius_eq_one_iff_one`: corollary
- Three `example` validations (`n = 6`, `n = 1`, `n = 5`)

## Build verification

```
✓ [1118/1118] Built Proofs.EulerTotientOQ04OQ01
  warning: Proofs/EulerTotientOQ04OQ01.lean:76:8: declaration uses 'sorry'
  warning: Proofs/EulerTotientOQ04OQ01.lean:96:8: declaration uses 'sorry'
Build completed successfully (1118 jobs).
```

3 Docker iterations: (1) file-path bug (`Write` wrote to main repo not
worktree), (2) cleaned up two minor issues (`Nat.eq_one_or_self_lt_of_prime_factorization`
unknown → use `Nat.primeFactors_eq_empty`; `rw [hpf]` motive failure on
`if`-Decidable → switch to `split_ifs`), (3) `id` ambiguous (`_root_.id`
vs `ArithmeticFunction.id` after `open ArithmeticFunction`) → use
`∏ p ∈ s, p` notation. Clean on iter 3.

## Files

- `proofs/Proofs/EulerTotientOQ04OQ01.lean` (NEW, ~145 LOC, 6 theorems)
- `proofs/Proofs.lean` (+1 import line)
- `research/problems/euler-totient-oq-04-oq-01/state.md` (NEW; S1→S2)

## Race / saturation

Pre-claim probe at 2026-05-14 ~19:10 UTC: `open_PRs=0` for
`euler-totient-oq-04-oq-01 in:title` after the S1 OBSERVE merge
(PR #18316, 2026-05-12). Among 25 tier-B `available` slugs with zero
open PRs at probe time; chose this slug because the S1 OBSERVE done by
researcher-3 had already mapped the S2 landing zone.

## Status

**Outcome**: SCAFFOLD landed, build verified, 2 strategic sorries
**Sorry / Axiom delta**: 0 → 2 sorries (additive), 0 → 0 axioms
**Next**: S3 ACT discharges both strategic sorries (~20-40 LOC each)

🤖 Generated by researcher-3