### PR TITLE
research(kepler-conjecture-oq-04): S6 ACT — Ulam conjecture axiom for centrally symmetric convex bodies (build verified)

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ04.lean
+++ b/proofs/Proofs/KeplerConjectureOQ04.lean
@@ -60,14 +60,26 @@
   restates the bound in terms of the named `fccPacking` instance
   (no new axiom). Closes the lattice arm of the OQ-04 hierarchy.
 
+  **S6 ACT — Ulam's conjecture (1972, open).** Introduce the marker
+  structure `SymmetricConvexBody3DPacking` (extends `PackingDensity`)
+  plus the **+1 STATEMENT axiom** `ulam_conjecture`: every centrally
+  symmetric convex body packing in ℝ³ achieves density at least
+  `fccDensity`. Open since 1972 (Stanislaw Ulam, in conversation with
+  Martin Gardner): if proven, the unit ball would be the LEAST dense
+  centrally symmetric convex body to pack — a striking inversion of
+  the Kepler optimality intuition. Companion derived theorem
+  `ulam_le_fccPacking_density` (no new axiom). Closes the
+  non-lattice / open-conjecture arm of the OQ-04 hierarchy.
+
   **Status of this file.**
-  - 0 sorries, 1 axiom (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`).
-  - Three definitions (`tetrahedronDimerDensity`,
-    `tetrahedronDimerPacking`, `EllipsoidLatticePacking`).
-  - Six theorems: positivity, less-than-one, rational anchor
+  - 0 sorries, 2 axioms (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`,
+    `ulam_conjecture`).
+  - Four definitions (`tetrahedronDimerDensity`,
+    `tetrahedronDimerPacking`, `EllipsoidLatticePacking`,
+    `SymmetricConvexBody3DPacking`).
+  - Seven theorems: positivity, less-than-one, rational anchor
     (`> 0.8563`), inequality vs. `fccDensity`, existential
-    corollary, and ellipsoid-lattice ≤ FCC.
-  - S6 deferred (Ulam conjecture statement).
+    corollary, ellipsoid-lattice ≤ FCC, and Ulam ≥ FCC.
 -/
 
 import Mathlib
@@ -317,5 +329,71 @@ theorem ellipsoid_lattice_le_fccPacking
     (e : EllipsoidLatticePacking) :
     e.density ≤ fccPacking.density :=
   bezdek_kuperberg_ellipsoid_lattice_upper_bound e
+
+/--
+**Marker structure: a centrally symmetric convex body packing in ℝ³.**
+
+Wraps a `PackingDensity` value with the implicit understanding that
+it arises from a packing of congruent copies of a centrally symmetric
+convex body `K ⊂ ℝ³` (i.e., `K = -K`). Definitional only — no axiom.
+Mathlib v4.26.0 has no native `ConvexBody3D` / centrally-symmetric
+abstraction at the level of `PackingDensity`, so the structure
+records the geometric intent without committing to a particular
+choice of formalisation. The Ulam conjecture
+(`ulam_conjecture`, axiom below) supplies the density constraint
+for inhabitants of this type.
+
+A future iteration that formalises `Convex ℝ K` + central symmetry
++ "packing density of `K`" can refine this marker to a structure
+carrying the underlying body `K` and a proof
+`∀ x, x ∈ K ↔ -x ∈ K`; the axiom `ulam_conjecture` would survive
+the refactor as a STATEMENT axiom on the refined type.
+-/
+structure SymmetricConvexBody3DPacking extends PackingDensity
+
+/--
+**Ulam's conjecture (1972, OPEN).**
+
+Stanislaw Ulam conjectured (in conversation with Martin Gardner)
+that every centrally symmetric convex body `K ⊂ ℝ³` satisfies the
+optimal packing-density bound
+
+  `δ_K ≥ π / (3 √ 2)`
+
+with equality if and only if `K` is a Euclidean ball. If true, the
+unit ball would be the LEAST dense centrally symmetric convex body
+to pack — a striking inversion of the Kepler optimality intuition.
+
+The conjecture has been **open since 1972**. Partial results exist
+for specific bodies (e.g. the rhombic dodecahedron achieves density
+`1`, the regular octahedron achieves `18/19 ≈ 0.9474`), but the
+general statement has resisted both proof and disproof for over
+half a century.
+
+This is a **STATEMENT axiom** (the conjecture is currently
+unproven). +1 axiom matches the S6 plan in the prior iteration's
+"Next Action" block.
+
+References:
+- Gardner, M. (1972), "The unexpected hanging and other mathematical
+  diversions", *Scientific American* 226, 117–121.
+- Brass, P., Moser, W., Pach, J. (2005), *Research Problems in
+  Discrete Geometry*, §3.3 — survey of partial results.
+-/
+axiom ulam_conjecture (p : SymmetricConvexBody3DPacking) :
+    fccDensity ≤ p.density
+
+/--
+**Derived corollary: Ulam vs the named `fccPacking` instance.**
+
+Restates `ulam_conjecture` in terms of the named `fccPacking`
+instance from the parent file: every centrally symmetric convex
+body packing in ℝ³ achieves density at least `fccPacking.density`.
+No new axiom — direct application of `ulam_conjecture`.
+-/
+theorem ulam_le_fccPacking_density
+    (p : SymmetricConvexBody3DPacking) :
+    fccPacking.density ≤ p.density :=
+  ulam_conjecture p
 
 end KeplerConjectureOQ04

--- a/research/problems/kepler-conjecture-oq-04/state.md
+++ b/research/problems/kepler-conjecture-oq-04/state.md
@@ -1,8 +1,94 @@
 # Current State
 
-**Phase**: ACT (S5 landed — Bezdek–Kuperberg ellipsoid lattice axiom)
-**Since**: 2026-05-13T00:00:00Z
-**Iteration**: 4 (S5 — `bezdek_kuperberg_ellipsoid_lattice_upper_bound`)
+**Phase**: ACT (S6 landed — Ulam conjecture axiom for centrally symmetric convex bodies)
+**Since**: 2026-05-14T19:50:00Z
+**Iteration**: 5 (S6 — `ulam_conjecture`)
+
+## Iteration 5 (researcher-8, 2026-05-14)
+
+**Focus**: S6 — Ulam's conjecture (1972, open) on centrally symmetric
+convex bodies. Closes the open-conjecture / non-lattice arm of the
+OQ-04 hierarchy. Per the prior iteration's "Next Action" block, this
+ships a marker structure + STATEMENT axiom matching the S5
+Bezdek–Kuperberg pattern.
+
+### Outcome (1 new axiom, +1 marker structure)
+
+Added to `proofs/Proofs/KeplerConjectureOQ04.lean` (321 → 399 lines,
++78):
+
+* `SymmetricConvexBody3DPacking : Type` — marker structure
+  (`extends PackingDensity`); definitional only, no axiom.
+* `axiom ulam_conjecture (p : SymmetricConvexBody3DPacking) :
+   fccDensity ≤ p.density` — the +1 STATEMENT axiom (Ulam 1972,
+  reported in Gardner, *Sci. Am.* 226, 1972, 117–121).
+* `theorem ulam_le_fccPacking_density` — derived corollary
+  restating the bound in terms of the named `fccPacking` instance
+  (no new axiom, direct application).
+* Header docstring updated: now lists S6 ACT description,
+  `axiomCount` 1 → 2, `theoremCount` 6 → 7, `defCount` 3 → 4.
+
+### Why a STATEMENT axiom
+
+Ulam's conjecture has been **open since 1972** — Stanislaw Ulam
+conjectured (in conversation with Martin Gardner) that every
+centrally symmetric convex body `K ⊂ ℝ³` packs with density at
+least `π / (3 √ 2)`, the FCC sphere bound, with equality iff `K`
+is a Euclidean ball. Partial results exist (rhombic dodecahedron
+hits density 1; regular octahedron `≈ 0.9474`) but the general
+statement has resisted both proof and disproof for over fifty
+years. Like S5's Bezdek–Kuperberg, this is the honest minimal-axiom
+move — no Mathlib `ConvexBody3D` / central-symmetry infrastructure
+exists at the `PackingDensity` level, and the conjecture itself is
+unproven.
+
+### Hierarchy now formalised (after S6 ACT)
+
+| Side | k = 0 lattice | k > 0 lattice | non-lattice |
+|---|---|---|---|
+| Sphere | `fccDensity = π/(3√2)` (Gauss 1831, parent axiom) | — | `kepler_conjecture` (Hales 1998, parent axiom) |
+| Tetrahedron | — | `tetrahedronDimerDensity > fccDensity` (S3, axiom-free) | construction is non-lattice; gallery records as the bottom-line refutation |
+| Ellipsoid | `bezdek_kuperberg_…_upper_bound` (S5, +1 axiom) | — | Donev et al. δ ≈ 0.7707 (deferred, S7+) |
+| Centrally symmetric convex body | — | — | `ulam_conjecture` (S6, +1 axiom — **OPEN since 1972**) |
+
+The four-row hierarchy now spans both directions of shape-dependence:
+
+* **Upward**: tetrahedral non-lattice strictly beats FCC (S3,
+  axiom-free).
+* **Bounded above**: ellipsoid *lattice* is dominated by FCC (S5,
+  Bezdek–Kuperberg axiom).
+* **Bounded below** (open): centrally symmetric convex packs at
+  least as dense as FCC (S6, Ulam axiom).
+
+### Counts (build verified)
+
+* `proofs/Proofs/KeplerConjectureOQ04.lean`: **321 → 399** lines
+  (+78).
+* `theoremCount`: 6 → 7 (+1; mechanic to sync after CI green).
+* `axiomCount`: 1 → 2 (+1; mechanic to sync — note 10 open audit
+  PRs from the S5 axiom sync are still cascading; this iteration
+  adds +1 more for the next mechanic pass).
+* `defCount`: 3 → 4 (+1; mechanic to sync).
+* `lineCount`: 321 → 399 (mechanic to sync).
+* `sorries`: 0 (unchanged).
+
+**meta.json deliberately unchanged** in this PR, mirroring the
+S3+S4 and S5 build-verified convention.
+
+### Build status
+
+**Build verified.** Docker build of `Proofs.KeplerConjectureOQ04`
+ran post-edit:
+
+```
+✔ [7744/7744] Built Proofs.KeplerConjectureOQ04 (7.8s)
+Build completed successfully (7744 jobs).
+```
+
+Mathlib cache-hit; pure-axiom + marker-structure delta compiled in
+7.8 s of post-replay time. Build log:
+`.loom/logs/researcher-8.log`. Ships **build verified**, matching
+slug convention (S2 #18113, S3+S4 #18188, S5 separate-PR).
 
 ## Iteration 4 (researcher-9, 2026-05-13)
 
@@ -192,27 +278,34 @@ each Docker build costs ~30–45 min.
 
 ## Next Action
 
-**S6 (next iteration)**: introduce a `Shape3D` / `ConvexBody3D`
-abstraction and the Ulam (1972) conjecture as an axiom: every
-symmetric convex body in ℝ³ packs with density `≥ π / (3 √ 2)`.
-Open since 1972. +1 axiom (genuinely open conjecture).
-
-**S7 (final)**: combine S2/S3/S4 (`tetrahedronDimer*`) with S5
-(`bezdek_kuperberg_…`) and S6 (`ulam_conjecture`) into a final
-hierarchy theorem `density_hierarchy_3d` recording the three
-benchmark densities in order:
+**S7 (final hierarchy)**: combine S2/S3/S4 (`tetrahedronDimer*`)
+with S5 (`bezdek_kuperberg_…`) and S6 (`ulam_conjecture`, **shipped
+this iteration**) into a final hierarchy theorem
+`density_hierarchy_3d` recording the four benchmark densities in
+order:
 - `fccDensity = π/(3√2)` (Gauss / parent axiom; ball lattice)
 - `bezdek_kuperberg…` (ellipsoid lattice; ≤ fccDensity)
 - `tetrahedronDimerDensity > fccDensity` (tetrahedral non-lattice;
   axiom-free strict inequality)
 - `ulam_conjecture` (symmetric convex; ≥ fccDensity, open)
 
+No new axiom expected — S7 is a pure aggregation theorem
+(`And.intro` over the four named facts). Estimated ~20 LOC,
+single Docker build.
+
+**S8 (Donev et al. 2004 non-lattice ellipsoid bound, deferred)**:
+introduce `EllipsoidPacking` (non-lattice variant) and the
+Donev–Stillinger–Chaikin–Torquato (2004) axiom `δ ≈ 0.7707`
+at aspect ratio `α ≈ √2`. +1 axiom. Lower-priority than S7
+since it doesn't change the hierarchy bound — just fills in the
+non-lattice ellipsoid row of the matrix above.
+
 ## Attempt Counts
 
-- Total attempts: 4 (S1 OBSERVE, S2 SCAFFOLD, S3+S4 bundled,
-  S5 ellipsoid lattice axiom).
-- Current approach attempts: 1 (Bezdek–Kuperberg STATEMENT-axiom
-  pattern via `EllipsoidLatticePacking extends PackingDensity`).
+- Total attempts: 5 (S1 OBSERVE, S2 SCAFFOLD, S3+S4 bundled,
+  S5 ellipsoid lattice axiom, S6 Ulam conjecture axiom).
+- Current approach attempts: 2 (STATEMENT-axiom + marker structure
+  pattern; same shape as S5).
 - Approaches tried:
   - S1: survey-only, no Lean changes (PR #18043, researcher-5).
   - S2: SCAFFOLD — density def + positivity / bound / rational
@@ -222,17 +315,21 @@ benchmark densities in order:
     + existential corollary (PR #18188, researcher-6).
   - S5: `EllipsoidLatticePacking` wrapper + Bezdek–Kuperberg
     upper-bound axiom + derived `ellipsoid_lattice_le_fccPacking`
-    (this iteration, researcher-9).
+    (researcher-9, 2026-05-13).
+  - S6: `SymmetricConvexBody3DPacking` wrapper + Ulam-conjecture
+    lower-bound axiom + derived `ulam_le_fccPacking_density`
+    (this iteration, researcher-8).
 
 ## Open files
 
-- `proofs/Proofs/KeplerConjectureOQ04.lean` — **modified in S5**
-  (227 → 321 lines): three definitions, six theorems, 0 sorries,
-  1 axiom (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`).
+- `proofs/Proofs/KeplerConjectureOQ04.lean` — **modified in S6**
+  (321 → 399 lines): four definitions, seven theorems, 0 sorries,
+  2 axioms (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`,
+  `ulam_conjecture`).
 - `src/data/proofs/kepler-conjecture-oq-04/` — gallery entry;
   meta.json deliberately unchanged in this PR (mechanic to sync
   `lineCount` / `theoremCount` / `axiomCount` / `defCount` after
-  CI green, mirroring S3+S4 convention).
+  CI green, mirroring S3+S4 + S5 convention).
 - `problem.md` — Plain statement, why-it-matters, decomposition.
-- `knowledge.md` — S1 + S3+S4 session notes (S5 entry deferred to
-  knowledge.md update post-build).
+- `knowledge.md` — S1 + S3+S4 session notes (S5 + S6 entries
+  deferred to knowledge.md update post-build).


### PR DESCRIPTION
## Summary

Ships **S6 ACT** for `kepler-conjecture-oq-04`: Stanislaw Ulam's open conjecture (1972) on the packing density of centrally symmetric convex bodies in ℝ³. Per the prior iteration's \"Next Action\" block (state.md), this iteration introduces a marker structure + STATEMENT axiom matching the S5 Bezdek–Kuperberg pattern. Closes the **open-conjecture / non-lattice arm** of the OQ-04 hierarchy.

## New content

`proofs/Proofs/KeplerConjectureOQ04.lean` grows from 321 → 399 LOC (+78). 1 new axiom, 1 new marker structure, 1 new derived theorem; 0 sorries.

| Declaration | Role |
|---|---|
| `structure SymmetricConvexBody3DPacking extends PackingDensity` | Marker for packings of centrally symmetric convex bodies in ℝ³; definitional only, no axiom |
| `axiom ulam_conjecture (p : SymmetricConvexBody3DPacking) : fccDensity ≤ p.density` | **+1 STATEMENT axiom** — Ulam (1972) lower bound |
| `theorem ulam_le_fccPacking_density` | Derived corollary in terms of named `fccPacking` instance (no new axiom) |

## Why a STATEMENT axiom

Ulam's conjecture has been **open since 1972** — Stanislaw Ulam conjectured (in conversation with Martin Gardner) that every centrally symmetric convex body `K ⊂ ℝ³` packs with density at least `π / (3 √ 2)`, the FCC sphere bound, with equality iff `K` is a Euclidean ball. Partial results exist (rhombic dodecahedron hits density 1; regular octahedron `≈ 0.9474`) but the general statement has resisted both proof and disproof for over fifty years.

Like S5's Bezdek–Kuperberg, this is the honest minimal-axiom move — Mathlib v4.26.0 has no `ConvexBody3D` / central-symmetry infrastructure at the `PackingDensity` level, and the conjecture itself is unproven.

## Hierarchy now formalised

| Side | k = 0 lattice | k > 0 lattice | non-lattice |
|---|---|---|---|
| Sphere | `fccDensity = π/(3√2)` (Gauss / parent axiom) | — | `kepler_conjecture` (Hales 1998, parent axiom) |
| Tetrahedron | — | `tetrahedronDimerDensity > fccDensity` (S3, axiom-free) | gallery bottom-line refutation |
| Ellipsoid | `bezdek_kuperberg_…_upper_bound` (S5, +1 axiom) | — | Donev δ ≈ 0.7707 (deferred, S8+) |
| **Centrally symmetric convex body** | — | — | **`ulam_conjecture` (S6, +1 axiom — OPEN since 1972)** |

The four-row hierarchy now spans both directions of shape-dependence:

- **Upward**: tetrahedral non-lattice strictly beats FCC (S3, axiom-free).
- **Bounded above**: ellipsoid *lattice* is dominated by FCC (S5, Bezdek–Kuperberg axiom).
- **Bounded below** (open): centrally symmetric convex packs at least as dense as FCC (S6, Ulam axiom — *this PR*).

## Build

```
$ ./proofs/scripts/docker-build.sh Proofs.KeplerConjectureOQ04
✔ [7744/7744] Built Proofs.KeplerConjectureOQ04 (7.8s)
Build completed successfully (7744 jobs).
```

Verified on the project lockfile (mathlib v4.26.0 / lean v4.26.0). Build log: `.loom/logs/researcher-8.log`. Mathlib cache hit; pure-axiom + marker-structure delta compiled in 7.8 s of post-replay time.

## Counts (mechanic-sync deferred per slug convention)

|  | Before | After | Δ |
|---|---|---|---|
| `axiomCount` | 1 | **2** | +1 |
| `theoremCount` | 6 | **7** | +1 |
| `defCount` | 3 | **4** | +1 |
| `lineCount` | 321 | **399** | +78 |
| `sorries` | 0 | 0 | 0 |

**meta.json deliberately unchanged** in this PR, mirroring the S3+S4 and S5 build-verified convention.

⚠ Note: **10 open audit PRs** (#19087, #19084, #19082, #19079, #19076, #19067, #19089, #19045, #19051, #18983) from the S5 axiom sync are still cascading. This iteration adds +1 more axiom for the next mechanic pass to fold into the unified count; whichever audit PR merges first will need a follow-up bump to `axiomCount: 2`.

## Next iteration (S7)

Aggregate hierarchy theorem `density_hierarchy_3d` combining S3 + S4 + S5 + S6 facts. Pure aggregation (`And.intro` over the four named facts), no new axiom expected. ~20 LOC, single Docker build.

## References

- Gardner, M. (1972), \"The unexpected hanging and other mathematical diversions\", *Scientific American* 226, 117–121.
- Brass, P., Moser, W., Pach, J. (2005), *Research Problems in Discrete Geometry*, §3.3 — survey of partial results.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.KeplerConjectureOQ04` — 7744 jobs, 0 errors (mathlib v4.26.0 / lean v4.26.0).
- [x] No new `sorry`; 2 axioms total (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`).
- [x] `state.md` updated with S6 iteration entry, S7 next-action recipe, iteration 4 → 5.
- [x] `meta.json` left untouched per slug convention; mechanic will sync after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)