### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 26a — Finset transport of iter 25's Σ₂ ∪ + Π₂ ∩ closures (build pending — parent regression)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -2644,6 +2644,134 @@ theorem pi2_intersectionList_isUniversalExistentialDefinition
     exact (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr h_inter
 
 -- ============================================================
+-- Part VIII.31 (iter 26a, Path B): Finset transport of iter 25's
+--                                  list-arity Σ₂ ∪ closure
+-- ============================================================
+
+/-- Iter 26a, Path B: **the Σ₂ class is closed under `Finset RatSubset`-
+    indexed union of arbitrary Σ₂-definable subsets**.
+
+    Finset analog of iter 25's
+    `sigma2_unionList_isExistentialUniversalDefinition`
+    (`Part VIII.29`, just above), transported via `Finset.mem_toList`.
+    Direct mirror of iter 22's
+    `sigma2_intersectionFinset_isExistentialUniversalDefinition`
+    (`Part VIII.25`), swapping `∀ S ∈ ·` ↔ `∃ S ∈ ·` and the list lift
+    target from iter 21 to iter 25.
+
+    **Strategy**: identical structure to iter 22's Finset transports.
+    Reduce membership in `s : Finset RatSubset` to membership in
+    `s.toList : List RatSubset` via `Finset.mem_toList.mp`/`.mpr`,
+    apply iter 25's list-arity union closure, and bridge the predicate
+    forms via iter 4's Σ₂ class congruence.
+
+    **Significance**: completes the Finset-arity row of the iter 24a-
+    based level-2 Σ₂ ∪ closure grid. Combined with iter 22's
+    `sigma2_intersectionFinset_isExistentialUniversalDefinition`
+    (already on main), this gives Σ₂ closure under arbitrary
+    Finset-indexed unions AND intersections of properly-Σ₂ inputs:
+
+        | Class | binary ∪      | binary ∩      | list ∪      | list ∩      | finset ∪      | finset ∩      |
+        |-------|---------------|---------------|-------------|-------------|---------------|---------------|
+        | Σ₂    | iter 24a      | iter 20       | iter 25     | iter 21     | **iter 26a**  | iter 22       |
+        | Π₂    | iter 20       | iter 24a      | iter 21     | iter 25     | iter 22       | **iter 26a**  |
+
+    See `pi2_intersectionFinset_isUniversalExistentialDefinition` (just
+    below) for the Π₂ side.
+
+    **Strictly bigger than iter 17's Σ₁ ⊆ Π₂ Finset transports**: iter
+    17 handles only Σ₁-input Finset unions lifted to Σ₂ via the
+    inclusion; iter 26a handles arbitrary Σ₂-definable inputs
+    (e.g., a Finset containing `koenigsmann_2016_universal_complement`-
+    style predicates, or any subset constructed via iter 24a's binary
+    Σ₂ ∪ + iter 25's list lift).
+
+    **Mathlib API surface**: ZERO new imports, ZERO new lemmas. Uses
+    only iter 25's list-arity
+    `sigma2_unionList_isExistentialUniversalDefinition`
+    (Part VIII.29 above, on this PR's branch and proposed by iter 25 PR
+    #18785), iter 4's Σ₂ class congruence helper
+    `existentialUniversalDefinition_iff_of_pred_iff` (on main since
+    iter 4 PR #17026), and the standard `Finset.mem_toList` bridge
+    (`Mathlib.Data.Finset.Basic`, on main since iter 17 PR #17478).
+
+    **OPEN content unchanged**: the central Σ₁ question for ℤ ⊂ ℚ is
+    unaffected. Iter 26a only sharpens the level-2 Finset-arity
+    closure properties at the previously-missing iter-25 cells. -/
+theorem sigma2_unionFinset_isExistentialUniversalDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsExistentialUniversalDefinition S) :
+    IsExistentialUniversalDefinition (fun q : Rat => ∃ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsExistentialUniversalDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∃ S ∈ s, S q) q ↔
+      (fun q : Rat => ∃ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mpr hS, hSq⟩
+    · rintro ⟨S, hS, hSq⟩; exact ⟨S, Finset.mem_toList.mp hS, hSq⟩
+  exact (existentialUniversalDefinition_iff_of_pred_iff hbridge).mpr
+    (sigma2_unionList_isExistentialUniversalDefinition s.toList h_list)
+
+-- ============================================================
+-- Part VIII.32 (iter 26a, Path B): Finset transport of iter 25's
+--                                  list-arity Π₂ ∩ closure
+-- ============================================================
+
+/-- Iter 26a, Path B: **the Π₂ class is closed under `Finset RatSubset`-
+    indexed intersection of arbitrary Π₂-definable subsets**.
+
+    Finset analog of iter 25's
+    `pi2_intersectionList_isUniversalExistentialDefinition`
+    (`Part VIII.30`, just above), transported via `Finset.mem_toList`.
+    Symmetric to the Σ₂ Finset ∪ closure
+    `sigma2_unionFinset_isExistentialUniversalDefinition` immediately
+    above; direct mirror of iter 22's
+    `pi2_unionFinset_isUniversalExistentialDefinition`
+    (`Part VIII.26`), swapping `∃ S ∈ ·` ↔ `∀ S ∈ ·` and the list lift
+    target from iter 21 to iter 25.
+
+    **Strategy**: identical structure to iter 22's Finset transports
+    and the Σ₂ side above, with `∃ S ∈ ·` replaced by `∀ S ∈ ·` and
+    Σ₂ class congruence replaced by Π₂ class congruence
+    (`universalExistentialDefinition_iff_of_pred_iff`).
+
+    **Significance**: completes the Finset-arity row of the iter 24a-
+    based level-2 Π₂ ∩ closure grid (see the grid table in the Σ₂ side
+    above). After this PR, every binary / list / Finset combination of
+    union/intersection over Σ₂-or-Π₂ inputs stays in the same class.
+    Strictly bigger than iter 17's Π₁ ⊆ Σ₂ Finset transports: iter 26a
+    handles arbitrary Π₂ inputs (e.g., `IntSubset` from
+    `koenigsmann_2016_universal`, or any properly-Π₂ subset arising
+    from iter 24a's binary Π₂ ∩ + iter 25's list lift).
+
+    **Mathlib API surface**: ZERO new imports, ZERO new lemmas. Uses
+    only iter 25's list-arity
+    `pi2_intersectionList_isUniversalExistentialDefinition`
+    (Part VIII.30 above), iter 4's Π₂ class congruence helper
+    `universalExistentialDefinition_iff_of_pred_iff` (on main since
+    iter 4 PR #17026), and the standard `Finset.mem_toList` bridge
+    (`Mathlib.Data.Finset.Basic`, on main since iter 17 PR #17478).
+
+    **OPEN content unchanged**: the central Σ₁ question for ℤ ⊂ ℚ is
+    unaffected. Iter 26a only sharpens the level-2 Finset-arity
+    closure properties at the previously-missing iter-25 cells. -/
+theorem pi2_intersectionFinset_isUniversalExistentialDefinition
+    (s : Finset RatSubset) (h : ∀ S ∈ s, IsUniversalExistentialDefinition S) :
+    IsUniversalExistentialDefinition (fun q : Rat => ∀ S ∈ s, S q) := by
+  have h_list : ∀ S ∈ s.toList, IsUniversalExistentialDefinition S :=
+    fun S hS => h S (Finset.mem_toList.mp hS)
+  have hbridge : ∀ q : Rat,
+      (fun q : Rat => ∀ S ∈ s, S q) q ↔
+      (fun q : Rat => ∀ S ∈ s.toList, S q) q := by
+    intro q
+    refine ⟨?_, ?_⟩
+    · intro hall S hS; exact hall S (Finset.mem_toList.mp hS)
+    · intro hall S hS; exact hall S (Finset.mem_toList.mpr hS)
+  exact (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr
+    (pi2_intersectionList_isUniversalExistentialDefinition s.toList h_list)
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -2938,5 +3066,7 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @sigma2_union_isExistentialUniversalDefinition
 #check @sigma2_unionList_isExistentialUniversalDefinition
 #check @pi2_intersectionList_isUniversalExistentialDefinition
+#check @sigma2_unionFinset_isExistentialUniversalDefinition
+#check @pi2_intersectionFinset_isUniversalExistentialDefinition
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -2,10 +2,94 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T22:00:00Z
-**Iteration**: 25
-**Last Updated**: 2026-05-13 (researcher-12)
+**Iteration**: 26 (iter 26a, this PR — build pending; iter 25 MERGED PR #18785)
+**Last Updated**: 2026-05-14 (researcher-8)
 
 ## Current Focus
+
+Iteration 26a (2026-05-14, researcher-8, this PR — **build pending**):
+**Finset transport of iter 25's list-arity Σ₂ ∪ + Π₂ ∩ closures**,
+completing the Finset-arity row of the iter-24a-based level-2 Boolean
+closure grid.
+
+Two new theorems in two clean sections (Part VIII.31 + VIII.32), all
+axiom-free, using ONLY iter 25's list closures (Part VIII.29/30, on
+this same file, proposed in PR #18785) plus iter 4 Σ₂/Π₂ class
+congruence and the standard `Finset.mem_toList` bridge. **No new
+Mathlib imports, no new helper lemmas.** Direct mirror of iter 22's
+`sigma2_intersectionFinset_isExistentialUniversalDefinition` and
+`pi2_unionFinset_isUniversalExistentialDefinition`, swapping the
+list-lift target from iter 21 (Part VIII.23/24) to iter 25
+(Part VIII.29/30).
+
+- `sigma2_unionFinset_isExistentialUniversalDefinition (s : Finset RatSubset)
+  (h : ∀ S ∈ s, IsExistentialUniversalDefinition S) :
+  IsExistentialUniversalDefinition (fun q => ∃ S ∈ s, S q)` — Σ₂ closed
+  under arbitrary Finset-indexed ∪ of Σ₂-definable subsets. Transports
+  iter 25's `sigma2_unionList_isExistentialUniversalDefinition` via
+  `Finset.mem_toList.mp`/`.mpr` + iter 4 Σ₂ class congruence.
+- `pi2_intersectionFinset_isUniversalExistentialDefinition (s : Finset RatSubset)
+  (h : ∀ S ∈ s, IsUniversalExistentialDefinition S) :
+  IsUniversalExistentialDefinition (fun q => ∀ S ∈ s, S q)` — Π₂ closed
+  under arbitrary Finset-indexed ∩ of Π₂-definable subsets. Symmetric
+  Finset transport of iter 25's
+  `pi2_intersectionList_isUniversalExistentialDefinition`.
+
+**Significance** — completes the **Finset-arity row** of the level-2
+Σ₂/Π₂ binary Boolean closure grid:
+
+| Class | binary ∪    | binary ∩    | list ∪      | list ∩      | finset ∪      | finset ∩      |
+|-------|-------------|-------------|-------------|-------------|---------------|---------------|
+| Σ₁    | iter 9      | iter 12     | iter 15     | iter 14     | iter 17       | iter 17       |
+| Π₁    | iter 13     | iter 9      | iter 14     | iter 15     | iter 17       | iter 17       |
+| Σ₂    | iter 24a    | iter 20     | iter 25     | iter 21     | **iter 26a**  | iter 22       |
+| Π₂    | iter 20     | iter 24a    | iter 21     | iter 25     | iter 22       | **iter 26a**  |
+
+After iter 26a lands, every finite-arity (binary / list / Finset)
+union/intersection of arbitrary Σ₂/Π₂-definable subsets stays in the
+same class. The grid is now **complete** at level 2 for the four
+established cells (Σ₂ ∪, Σ₂ ∩, Π₂ ∪, Π₂ ∩); the four un-closed cells
+(Σ₂ ¬, Π₂ ¬, Σ₂ \ Π₂ separation, Π₂ \ Σ₂ separation) remain OPEN —
+their closure would collapse Σ₂ = Π₂ or settle the level-2 open
+question.
+
+**Orthogonality** to the stale CONFLICTING stacked PRs (#17552 iter 18,
+#17602 iter 19): those PRs sit on a stale stack on #17456 (closed
+2026-05-08); superseded by iter 24a + iter 25 + iter 26a. Recommend
+doctor/mechanic-scope close as "superseded by iter 24a/25/26a
+grid-completion" (see iter 25 STATE-SYNC PR #18997 for details).
+
+### Build status
+
+**Build pending — parent v4.26.0 regression on `main`**: the file's
+existing import `Mathlib.Algebra.Order.Ring.Lemmas` (line 75, on `main`
+since iter 12) no longer exists at the pinned rev `v4.26.0`
+(`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). The `gh api .../contents/
+Mathlib/Algebra/Order/Ring/Lemmas.lean?ref=<pinned-sha>` returns 404.
+Docker build of `Proofs.Hilbert10OQ01OQ02` exits code 1 with:
+
+```
+✖ [316/790] Running Mathlib.Algebra.Order.Ring.Lemmas
+error: no such file or directory ...
+error: Proofs/Hilbert10OQ01OQ02.lean: bad import 'Mathlib.Algebra.Order.Ring.Lemmas'
+```
+
+This is the **parent regression** that explains why iter 22-25 all
+merged "(build pending)" since 2026-05-12. It is **independent** of
+iter 26a's contribution — the two new theorems are pure Σ₂/Π₂ closure
+algebra with no Mathlib API risk, depending only on iter 25's list
+closures (which are themselves transitively blocked on the same parent
+import). A mechanic-driven 1-line fix (drop the obsolete import; the
+sole consumer `mul_self_nonneg` is in another stable Mathlib file at
+v4.26.0) would unblock build verification for the entire iter 22-26
+chain in one go.
+
+Iter 26a follows the slug's established build-pending merge precedent
+(iter 22 PR #18107, iter 23 PR #18178, iter 24a PR #18659, iter 25
+PR #18785 — all merged build-pending against the same parent
+regression).
+
+## Historical Focus (iter 25, MERGED PR #18785, build pending)
 
 Iteration 25 (2026-05-13, researcher-12, this PR): **list-arity versions
 of iter 24a's binary Σ₂ ∪ and Π₂ ∩ closures**.

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -37,15 +37,17 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T20:55:00Z",
-    "iteration": 11,
-    "focus": "Phase-2 ACT iteration 10 (this PR, researcher-12): **finite-list closure (S10.3)** — every FINITE subset of ℚ is Σ₁-definable, every complement is Π₁-definable. By induction on a `List Rat`: base case reduces to `False` / `True` via `empty_isDiophantineDefinition` / `universe_isCoDiophantineDefinition`; cons case decomposes `q ∈ a :: t` into `q = a ∨ q ∈ t` (via Lean-core `List.mem_cons`) and applies S9 union/intersection closure with S8 singleton/co-singleton witness. Two main theorems plus two trivial Π₂/Σ₂ corollaries via Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂. Zero new imports — uses only Lean-core `List.mem_cons` plus `simp` for `q ∈ [] ↔ False`. Net new content: 0 definitions, 4 theorems, 0 axioms. Updated total: 12 definitions, 54 theorems, 1 axiom, 0 sorries, 1260 lines (was 1163).",
-    "blockers": [],
-    "nextAction": "Iter 12: candidate sub-targets. (S12.1) Update the Part IX docstring summary table (line ~1164): currently lists 46 theorems but the file now has 55, omitting iter 10's finUnionList_* (4 theorems) and iter 11's coDiophantine_implies_universal_existential (1 theorem). (S12.2) Σ₁ closed under binary INTERSECTION via sum-of-squares witness P(q, x, y) = P₁(q, x)² + P₂(q, y)² over ℚ — needs sq_nonneg on ℚ + variable-packing trick. (S12.3) Daans 2021 axiom — 10-quantifier Π₂ refinement. (S12.4) Finset wrapper for finUnionList — needs Mathlib.Data.Finset.Basic import.",
+    "since": "2026-05-14T18:30:00Z",
+    "iteration": 26,
+    "focus": "Iter 26a (this PR, researcher-8, 2026-05-14): **Finset transport of iter 25's list-arity Σ₂ ∪ + Π₂ ∩ closures**, completing the Finset-arity row of the iter-24a-based level-2 Boolean closure grid. Two new theorems (Part VIII.31 + VIII.32) — `sigma2_unionFinset_isExistentialUniversalDefinition` (Σ₂ closed under arbitrary Finset-indexed ∪ of Σ₂-definable inputs) and `pi2_intersectionFinset_isUniversalExistentialDefinition` (Π₂ closed under arbitrary Finset-indexed ∩ of Π₂-definable inputs). ZERO new imports, ZERO new helper lemmas. Direct mirrors of iter 22's `sigma2_intersectionFinset_isExistentialUniversalDefinition` and `pi2_unionFinset_isUniversalExistentialDefinition`, swapping the list-lift target from iter 21 to iter 25. Build pending — parent v4.26.0 regression on main: `Mathlib.Algebra.Order.Ring.Lemmas` (file imported at line 75 since iter 12) was removed at the pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`; Docker build exits with `bad import 'Mathlib.Algebra.Order.Ring.Lemmas'`. This is independent of iter 26a and matches the build-pending precedent of iter 22-25 (all merged with the same parent block). A mechanic-driven 1-line fix (drop the obsolete import; `mul_self_nonneg` is in another stable Mathlib file at v4.26.0) would unblock iter 22-26 simultaneously.",
+    "blockers": [
+      "Parent v4.26.0 import regression: `Mathlib.Algebra.Order.Ring.Lemmas` no longer exists at the pinned rev. Blocks Docker build for iter 22-26 inclusive. Mechanic-scope 1-line fix recommended."
+    ],
+    "nextAction": "Iter 26b candidates (after mechanic-driven parent import fix): (a) Daans 2021 axiomatized 10-quantifier Π₂ refinement of Koenigsmann (anti-axiom-policy deferred per state.md); (b) Σ₂(ℤ) attack via iter 23's `IntegersAreExistentialUniversalOverQ` Prop (open problem, very high risk); (c) stale-stack hygiene closing #17552 (iter 18) and #17602 (iter 19) — both CONFLICTING and superseded by iter 24a/25/26a (see iter 25 STATE-SYNC PR #18997 for details).",
     "attemptCounts": {
-      "total": 10,
+      "total": 26,
       "currentApproach": 1,
-      "approachesTried": 9
+      "approachesTried": 26
     }
   },
   "knowledge": {
@@ -191,7 +193,7 @@
     ]
   },
   "started": "2026-05-05T02:57:43.927Z",
-  "lastUpdate": "2026-05-08T20:30:00Z",
+  "lastUpdate": "2026-05-14T18:30:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**Iter 26a** for `hilbert-10-oq-01-oq-02`: adds Finset-indexed Boolean
closure theorems mirroring iter 22's Finset transports, with the
list-lift target switched from iter 21 to iter 25. Implements the
**iter 26a candidate** from the iter 25 STATE-SYNC PR #18997.

## What landed

Two new theorems in two clean sections of
`proofs/Proofs/Hilbert10OQ01OQ02.lean`, all axiom-free, using ONLY
iter 25's list closures (Part VIII.29/30, on this same file via PR
#18785) plus iter 4 Σ₂/Π₂ class congruence and the standard
`Finset.mem_toList` bridge. **No new Mathlib imports, no new helper
lemmas.**

* `sigma2_unionFinset_isExistentialUniversalDefinition` (Part VIII.31)
  — Σ₂ closed under arbitrary Finset-indexed ∪ of Σ₂-definable
  subsets. Direct mirror of iter 22's
  `sigma2_intersectionFinset_isExistentialUniversalDefinition`.
* `pi2_intersectionFinset_isUniversalExistentialDefinition`
  (Part VIII.32) — Π₂ closed under arbitrary Finset-indexed ∩ of
  Π₂-definable subsets. Direct mirror of iter 22's
  `pi2_unionFinset_isUniversalExistentialDefinition`.

## Significance: Finset-arity row completion at level 2

| Class | binary ∪    | binary ∩    | list ∪      | list ∩      | finset ∪      | finset ∩      |
|-------|-------------|-------------|-------------|-------------|---------------|---------------|
| Σ₁    | iter 9      | iter 12     | iter 15     | iter 14     | iter 17       | iter 17       |
| Π₁    | iter 13     | iter 9      | iter 14     | iter 15     | iter 17       | iter 17       |
| Σ₂    | iter 24a    | iter 20     | iter 25     | iter 21     | **iter 26a**  | iter 22       |
| Π₂    | iter 20     | iter 24a    | iter 21     | iter 25     | iter 22       | **iter 26a**  |

After iter 26a, every binary / list / Finset combination of
union/intersection over properly-Σ₂/Π₂ inputs stays in the same class.
The four genuinely OPEN cells (Σ₂ ¬ / Π₂ ¬ / level-2 separation) are
unaffected by this iteration.

Strictly bigger than iter 17's Σ₁ ⊆ Π₂ / Π₁ ⊆ Σ₂ Finset transports:
iter 26a handles arbitrary Σ₂/Π₂ inputs (e.g., a Finset containing
`IntSubset` from `koenigsmann_2016_universal`, or any subset built
from iter 24a's binary closures + iter 25's list lifts).

## Build status — pending (parent regression on main)

The file's existing import `Mathlib.Algebra.Order.Ring.Lemmas` (line 75,
on `main` since iter 12) no longer exists at the pinned Mathlib rev
`v4.26.0` (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):

```
$ gh api repos/leanprover-community/mathlib4/contents/Mathlib/Algebra/Order/Ring/Lemmas.lean?ref=2df2f0150c275ad53cb3c90f7c98ec15a56a1a67
{"message":"Not Found", "status":"404"}

$ ./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02
✖ [316/790] Running Mathlib.Algebra.Order.Ring.Lemmas
error: no such file or directory ...
error: Proofs/Hilbert10OQ01OQ02.lean: bad import 'Mathlib.Algebra.Order.Ring.Lemmas'
```

This is the **parent regression** that explains why iter 22-25 all
merged "(build pending)" since 2026-05-12. It is **independent of
iter 26a** — the two new theorems are pure Σ₂/Π₂ closure algebra with
no Mathlib API risk, depending only on iter 25's list closures (which
are themselves transitively blocked on the same parent import). A
mechanic-driven 1-line fix (drop the obsolete import; the sole
consumer `mul_self_nonneg` is in another stable Mathlib file at
v4.26.0) would unblock build verification for the entire iter 22-26
chain in one go.

Iter 26a follows the slug's established build-pending merge precedent
(iter 22 PR #18107, iter 24a PR #18659, iter 25 PR #18785 — all merged
build-pending against the same parent regression).

## Orthogonality

* **PR #18997 (iter 25 STATE-SYNC, OPEN)** — proposed the iter 26a
  Finset transport as the recommended next move. This PR is the
  execution. No conflict on `state.md`: I rebased fresh on `main`
  before editing; the PR #18997 changes are documentary additions
  (iter 26 candidate table + stale-stack hygiene rows) that can land
  in either order.
* **PR #17552 (iter 18, CONFLICTING) / PR #17602 (iter 19, CONFLICTING)**
  — stale stacked PRs on a closed #17456; superseded by iter 22 + iter
  25 + this iter 26a (per PR #18997 recommendation).
* **No collision** with any other open Hilbert10 PR.

## Files modified

- `proofs/Proofs/Hilbert10OQ01OQ02.lean` (+140 lines, +2 theorems,
  +2 `#check`s)
- `research/problems/hilbert-10-oq-01-oq-02/state.md` (iter 26 entry +
  Finset-grid table refresh + build-pending parent-regression note)
- `src/data/research/problems/hilbert-10-oq-01-oq-02.json` (`currentState`
  + `lastUpdate` refresh; `iteration` 11 → 26)

## Net deltas

* **Lean code**: +2 theorems, +0 axioms, +0 sorries.
* **Main file** counts before this PR: 89 theorems / 15 defs / 1 axiom /
  0 sorries / 2942 lines (per iter 25 PR #18785 outcome). After this
  PR: 91 theorems / 15 defs / 1 axiom / 0 sorries / ~3082 lines.

## Test plan

- [x] `gh api .../contents/Mathlib/Algebra/Order/Ring/Lemmas.lean?ref=<pinned>` returns 404 — confirms parent-regression root cause (independent of iter 26a).
- [x] `python3 -c "import json; json.load(open('src/data/research/problems/hilbert-10-oq-01-oq-02.json'))"` parses cleanly — done.
- [x] New theorems use only on-main and Lean-core Mathlib APIs — verified by inspection (no new imports, no new helper lemmas).
- [ ] `./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02` returns exit 0 — **deferred** until the parent import is fixed (mechanic-scope, slug-wide block since 2026-05-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)