### PR TITLE
fix(mechanic): PrimeNumberTheoremOQ01.lean v4.26.0 — Nonvanishing import + le_of_eq direction

### DIFF
--- a/proofs/Proofs/PrimeNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PrimeNumberTheoremOQ01.lean
@@ -1,4 +1,5 @@
 import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.LSeries.Nonvanishing
 import Mathlib.NumberTheory.PrimeCounting
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Sqrt
@@ -95,7 +96,7 @@ theorem pnt_zero_free_region (s : ℂ) (hs : 1 ≤ s.re) : riemannZeta s ≠ 0 :
 
 /-- **No zeros on the line Re(s) = 1** (equivalent to PNT). -/
 theorem no_zeros_on_line_one (s : ℂ) (hs : s.re = 1) : riemannZeta s ≠ 0 :=
-  pnt_zero_free_region s (le_of_eq hs)
+  pnt_zero_free_region s hs.ge
 
 /-- **Trivial zeros at s = -2n** (n = 1, 2, 3, ...) — proved in Mathlib. -/
 theorem trivial_zeros (n : ℕ) : riemannZeta (-2 * (↑n + 1)) = 0 :=


### PR DESCRIPTION
## Fix

Two surgical v4.26.0 surface regressions on parent file `proofs/Proofs/PrimeNumberTheoremOQ01.lean` (slug `prime-number-theorem-oq-01`).

Acts on the verified diagnosis in PR #19115 (research-scoped, doc-only).

## Evidence

### Build BEFORE (origin/main, lean4-arm64:v4.26.0)

```
error: Proofs/PrimeNumberTheoremOQ01.lean:88:2: Unknown identifier `riemannZeta_ne_zero_of_one_lt_re`
error: Proofs/PrimeNumberTheoremOQ01.lean:94:2: Unknown identifier `riemannZeta_ne_zero_of_one_le_re`
error: Proofs/PrimeNumberTheoremOQ01.lean:98:35: Application type mismatch: ...
error: Proofs/PrimeNumberTheoremOQ01.lean:275:15: Unknown identifier `riemannZeta_ne_zero_of_one_le_re`
```

### Build AFTER (this branch, lean4-arm64:v4.26.0)

```
⚠ [3292/3292] Built Proofs.PrimeNumberTheoremOQ01 (3.2s)
warning: Proofs/PrimeNumberTheoremOQ01.lean:276:7: unused variable `s`  ← pre-existing
Build completed successfully (3292 jobs).
```

## Changes (2 LOC, 1 import + 1 ge-vs-eq)

### 1. Missing import — 3 errors resolved (lines 88 / 94 / 275)

Both `riemannZeta_ne_zero_of_one_lt_re` and `riemannZeta_ne_zero_of_one_le_re` now live behind:

| Lemma | v4.26.0 file |
|---|---|
| `riemannZeta_ne_zero_of_one_lt_re` | `Mathlib/NumberTheory/LSeries/Dirichlet.lean:325` |
| `riemannZeta_ne_zero_of_one_le_re` | `Mathlib/NumberTheory/LSeries/Nonvanishing.lean:411` |

`Nonvanishing.lean` line 6 reads `public import Mathlib.NumberTheory.LSeries.Dirichlet`, so this single addition makes both lemmas reachable.

```diff
 import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.LSeries.Nonvanishing
 import Mathlib.NumberTheory.PrimeCounting
```

### 2. \`le_of_eq\` direction — 1 error resolved (line 99)

At v4.26.0, `le_of_eq : a = b → a ≤ b` is strict: given `hs : s.re = 1` and goal `1 ≤ s.re`, the elaborator no longer flips the equation. Swap to the dot-method `hs.ge` (which routes through `Eq.ge : a = b → b ≤ a`):

```diff
 theorem no_zeros_on_line_one (s : ℂ) (hs : s.re = 1) : riemannZeta s ≠ 0 :=
-  pnt_zero_free_region s (le_of_eq hs)
+  pnt_zero_free_region s hs.ge
```

## Downstream

- Slug-owned bridge file `PrimeNumberTheoremOQ01OQ01.lean` (slug `prime-number-theorem-oq-01-oq-01`, S2 ACT build-pending from researcher-4 2026-05-13) becomes build-verified automatically once this lands. No bridge changes needed.
- `Proofs.RiemannHypothesis` itself was already clean in the baseline.

## Scope

- One slug, one file, two surgical edits.
- No metadata changes (parent file's `meta.json` unaffected — same theorem signatures).
- No axiom changes.
- Diff: +2 / -1 across one file.

Related: #19115 (diagnostic).

---
Automated fix by lean-mechanic agent (mechanic-3 worktree).