### PR TITLE
fix(mechanic): TractatusOntology v4.26.0 22-error parent repair

### DIFF
--- a/proofs/Proofs/TractatusOntology.lean
+++ b/proofs/Proofs/TractatusOntology.lean
@@ -223,7 +223,13 @@ theorem Proposition.evalBool_correct (p : Proposition S) (w : S → Bool) :
     (p.evalBool w = true) ↔ p.eval (fun s => w s = true) := by
   induction p with
   | elementary s => simp [evalBool, eval]
-  | neg q ih     => simp [evalBool, eval, ih]
+  | neg q ih     =>
+    show (!q.evalBool w) = true ↔ ¬ q.eval (fun s => w s = true)
+    have h1 : (!q.evalBool w) = true ↔ q.evalBool w = false := by
+      cases q.evalBool w <;> simp
+    have h2 : q.evalBool w = false ↔ ¬ q.evalBool w = true := by
+      cases q.evalBool w <;> simp
+    rw [h1, h2, ih]
   | conj q r ihq ihr => simp [evalBool, eval, Bool.and_eq_true, ihq, ihr]
 
 -- ═══════════════════════════════════════════════════════════════
@@ -298,8 +304,8 @@ variable {S : Type} (M : WorldModel S)
 def evalM (p : Proposition S) (w : M.W) : Prop :=
   match p with
   | .elementary s => M.holds w s
-  | .neg q        => ¬ (evalM M q w)
-  | .conj q r     => evalM M q w ∧ evalM M r w
+  | .neg q        => ¬ (evalM q w)
+  | .conj q r     => evalM q w ∧ evalM r w
 
 /-- A proposition is a tautology in model `M` when it holds
     in every world of `M`. -/
@@ -326,8 +332,8 @@ theorem truth_functional_compositionality_gen (p : Proposition S)
     evalM M p w₁ ↔ evalM M p w₂ := by
   induction p with
   | elementary s => exact h s
-  | neg q ih     => simp only [evalM]; exact ih.not
-  | conj q r ihq ihr => simp only [evalM]; exact ihq.and ihr
+  | neg q ih     => simp only [evalM, ih]
+  | conj q r ihq ihr => simp only [evalM, ihq, ihr]
 
 end GeneralSemantics
 
@@ -463,11 +469,13 @@ and conjunction, confirming the adequacy of {¬, ∧} as a basis.
 theorem de_morgan_disj (p q : Proposition S) (w : World S) :
     (Proposition.disj p q).eval w ↔ (p.eval w ∨ q.eval w) := by
   simp [Proposition.disj, Proposition.eval, not_and_or, not_not]
+  tauto
 
 theorem de_morgan_conj (p q : Proposition S) (w : World S) :
     (Proposition.neg (Proposition.conj p q)).eval w ↔
     (¬ p.eval w ∨ ¬ q.eval w) := by
   simp [Proposition.eval, not_and_or]
+  tauto
 
 -- ---------------------------------------------------------------
 -- Theorem 8: Excluded middle is a tautology (TLP 4.46)
@@ -482,7 +490,6 @@ theorem excluded_middle_tautology (p : Proposition S) :
     IsTautology (Proposition.disj p (Proposition.neg p)) := by
   intro w
   simp [Proposition.disj, Proposition.eval, not_and_or, not_not]
-  exact Classical.em _
 
 -- ---------------------------------------------------------------
 -- Theorem 9: Conjunction with negation is a contradiction
@@ -508,7 +515,6 @@ Implication, defined as ¬(p ∧ ¬q), has the standard semantics.
 theorem impl_semantics (p q : Proposition S) (w : World S) :
     (Proposition.impl p q).eval w ↔ (p.eval w → q.eval w) := by
   simp [Proposition.impl, Proposition.eval, not_and_or, not_not]
-  tauto
 
 -- ---------------------------------------------------------------
 -- Theorem 11: Biconditional semantics
@@ -550,7 +556,6 @@ negation and conjunction are expressible via NAND.
 theorem nand_expresses_neg (p : Proposition S) (w : World S) :
     (Proposition.nand p p).eval w ↔ (Proposition.neg p).eval w := by
   simp [Proposition.nand, Proposition.eval]
-  tauto
 
 theorem nand_expresses_conj (p q : Proposition S) (w : World S) :
     (Proposition.neg (Proposition.nand p q)).eval w ↔
@@ -601,7 +606,7 @@ theorem constrained_independence_fails (a b : S) (hab : a ≠ b) :
   obtain ⟨⟨w, hw⟩, hmatch⟩ := h bad
   have ha : w a := (hmatch a).mpr rfl
   have hb : w b := hw ha
-  exact hab ((hmatch b).mp hb)
+  exact hab ((hmatch b).mp hb).symm
 
 -- ---------------------------------------------------------------
 -- 11b: Weather model — concrete constrained example
@@ -841,7 +846,7 @@ theorem formEq_trans {p q r : Proposition S}
   -- (e₁.trans e₂) acts as e₂ ∘ e₁ pointwise
   -- By rename_comp: (p.rename e₁).rename e₂ = p.rename (e₂ ∘ e₁)
   calc p.rename ⇑(e₁.trans e₂)
-      = p.rename (⇑e₂ ∘ ⇑e₁) := by congr 1; ext s; simp [Equiv.trans_apply]
+      = p.rename (⇑e₂ ∘ ⇑e₁) := by congr 1
     _ = (p.rename ⇑e₁).rename ⇑e₂ := (rename_comp _ _ _).symm
     _ = q.rename ⇑e₂ := by rw [heq₁]
     _ = r := heq₂
@@ -860,20 +865,19 @@ private theorem eq_of_structEq : ∀ (p q : Proposition S),
     intro q; cases q with
     | elementary s' =>
       simp [structEq]
-      intro h; subst h; rfl
     | _ => simp [structEq]
   | neg p' ih =>
     intro q; cases q with
     | neg q' =>
       simp [structEq]
-      intro h; exact congrArg Proposition.neg (ih q' h)
+      exact ih q'
     | _ => simp [structEq]
   | conj p' p'' ih₁ ih₂ =>
     intro q; cases q with
     | conj q' q'' =>
       simp [structEq]
       intro h₁ h₂
-      exact congr (congrArg Proposition.conj (ih₁ q' h₁)) (ih₂ q'' h₂)
+      exact ⟨ih₁ q' h₁, ih₂ q'' h₂⟩
     | _ => simp [structEq]
 
 /-- `structEq` implies `formEq`: syntactically identical propositions
@@ -881,7 +885,7 @@ private theorem eq_of_structEq : ∀ (p q : Proposition S),
     permutation. -/
 theorem structEq_implies_formEq {p q : Proposition S}
     (h : p.structEq q) : p.formEq q :=
-  ⟨Equiv.refl S, by rw [rename_id]; exact eq_of_structEq p q h⟩
+  ⟨Equiv.refl S, by simp only [Equiv.coe_refl, rename_id]; exact eq_of_structEq p q h⟩
 
 -- ---------------------------------------------------------------
 -- Hierarchy: formEq → truth-table isomorphism
@@ -914,7 +918,7 @@ theorem formEq_implies_truth_table_iso {p q : Proposition S}
   rw [rename_eval]
   -- Goal: p.eval w ↔ p.eval (fun s => (w ∘ ⇑(e.symm)) (e s))
   -- Since e.symm (e s) = s, both sides are equal.
-  suffices hsuff : (fun s => (w ∘ ⇑(e.symm)) (↑e s)) = w by rw [hsuff]
+  suffices hsuff : (fun s => (w ∘ ⇑(e.symm)) (⇑e s)) = w by rw [hsuff]
   ext s
   simp [Function.comp, Equiv.symm_apply_apply]
 
@@ -1116,6 +1120,7 @@ theorem contingent_propositions_vary (q : Proposition S) [Nonempty S]
     (h_not_taut : ¬ IsTautology q)
     (h_not_contra : ¬ IsContradiction q) :
     ∃ w₁ w₂ : World S, q.eval w₁ ∧ ¬ q.eval w₂ := by
+  unfold IsContradiction at h_not_contra
   push_neg at h_not_contra
   obtain ⟨w₁, hw₁⟩ := h_not_contra
   unfold IsTautology at h_not_taut


### PR DESCRIPTION
## Fix

Repair Mathlib v4.26.0 regressions in `proofs/Proofs/TractatusOntology.lean` — applies the 8-kit repair plan classified by research PR #19107 (which is now build-verified by this PR).

## Evidence

**Before**: 22 errors across 8 patterns (Docker baseline before this fix).

**After**: Build clean — `3058 jobs` succeeded under Mathlib v4.26.0 (`./proofs/scripts/docker-build.sh Proofs.TractatusOntology`).

### Kit application

| Kit | Pattern | Sites fixed |
|-----|---------|---|
| **K1** | `simp [...]; tactic` over-solve | drop trailing `exact Classical.em _` / `tauto` at `excluded_middle_tautology` / `impl_semantics` / `nand_expresses_neg`; drop trailing `simp` after `congr 1` in `formEq_trans` calc; drop dead `intro h; subst h; rfl` in `eq_of_structEq` elementary case |
| **K2** | `simp [...]` undersolve | `evalBool_correct` neg case: explicit `(!b)=true ↔ b=false ↔ ¬b=true` chain + `ih`; `de_morgan_disj`/`de_morgan_conj`: add `tauto` to bridge new simp shape (v4.26 leaves `¬p → q ↔ p ∨ q`) |
| **K3** | Recursive `evalM M q w` positional-arg in `def` body | Strip outer `M` to `evalM q w` (per memory `feedback_researcher_lean_v426_recursive_field_notation_strip`). Compositionality lemmas adapt: `simp only [evalM, ih]` instead of `simp only [evalM]; exact ih.not` |
| **K4** | `constrained_independence_fails` direction | `(hmatch b).mp hb : b = a`, need `a = b` → `.symm` |
| **K5** | `eq_of_structEq` simp + injEq | After `simp [structEq]` reduces RHS via constructor `injEq`, swap `congrArg` for direct IH (`exact ih q'` / `exact ⟨ih₁ q' h₁, ih₂ q'' h₂⟩`). Add `Equiv.coe_refl` before `rename_id` in `structEq_implies_formEq` |
| **K6** | `↑e s` coercion | Replace with `⇑e s` (consistent with surrounding `⇑(e.symm)`) |
| **K8** | `push_neg at h_not_contra` no-progress | Insert `unfold IsContradiction at h_not_contra` (matches existing `unfold IsTautology` pattern below) |

Total: +20 / -15 LOC. Pure repair — no semantic changes, no new sorries, no new axioms.

### Source

Repair-kit classification doc: PR #19107 `research(tractatus-ontology-oq-06): S8 PREP — parent-file Mathlib v4.26.0 repair-kit classification (doc-only)`. The 24-error inventory dated back to PR #18995's Docker run on 2026-05-14 ~03:40 UTC; the parent had not been edited since 2026-05-13, so the line numbers in the kit doc map exactly to the errors fixed here.

This unblocks every pending `tractatus-ontology-oq-06` ACT (S3, S4, S5, S6) that imports `TractatusOntologySpectrum` → `TractatusOntology.lean`.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.TractatusOntology` — 3058 jobs clean
- [x] No new sorries (`grep -n 'sorry' proofs/Proofs/TractatusOntology.lean` unchanged)
- [x] No new axioms (no `axiom` declarations added)
- [x] No new imports

---
Automated fix by lean-mechanic agent.