### PR TITLE
fix(mechanic): v4.26.0 IntervalIntegral + Equiv.Fin barrel split (8-LOC kit)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean
@@ -1,5 +1,5 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic

--- a/proofs/Proofs/AreaOfCircleOQ03OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ03.lean
@@ -1,6 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Analysis.SpecialFunctions.Integrals
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Tactic
 
 /-

--- a/proofs/Proofs/BuffonsNeedleOQ02OQ02.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ02OQ02.lean
@@ -1,5 +1,5 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic

--- a/proofs/Proofs/BuffonsNoodle.lean
+++ b/proofs/Proofs/BuffonsNoodle.lean
@@ -1,6 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic

--- a/proofs/Proofs/Erdos515Problem.lean
+++ b/proofs/Proofs/Erdos515Problem.lean
@@ -31,7 +31,7 @@ References:
 -/
 
 import Mathlib.Analysis.Complex.Basic
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Topology.MetricSpace.Basic
 

--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean
@@ -21,7 +21,7 @@
   Axioms: 0
 -/
 
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.MeasureTheory.Integral.Prod
 import Mathlib.MeasureTheory.Measure.Prod
 import Mathlib.Tactic

--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean
@@ -36,7 +36,7 @@
 
 import Proofs.GreensTheoremOQ01OQ01OQ02
 import Mathlib.MeasureTheory.Constructions.Pi
-import Mathlib.Logic.Equiv.Fin
+import Mathlib.Logic.Equiv.Fin.Basic
 import Mathlib.Tactic
 
 open MeasureTheory intervalIntegral Set

--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean
@@ -39,7 +39,7 @@
   Axioms: 0.
 -/
 
-import Mathlib.MeasureTheory.Integral.IntervalIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.MeasureTheory.Integral.Prod
 import Mathlib.MeasureTheory.Measure.Prod
 import Mathlib.Tactic


### PR DESCRIPTION
## Fix

Applies the surgical import-drift fix-kit specified by research PR
[#19122](https://github.com/rjwalters/lean-genius/pull/19122) (greens-theorem S3 BUILD-DIAGNOSE).

## Root cause

At Mathlib v4.26.0 pin `2df2f015...`, two single-file barrel modules
became directories with canonical `.Basic` submodules:

| Old single-file barrel (≤ v4.25.x) | New v4.26.0 canonical path |
|---|---|
| `Mathlib.MeasureTheory.Integral.IntervalIntegral` | `…IntervalIntegral.Basic` |
| `Mathlib.Logic.Equiv.Fin` | `…Equiv.Fin.Basic` |

Multiple sibling proof files in the gallery (`BuffonsNeedle`,
`NavierStokes`, `FundamentalTheoremCalculus`, `LeibnizPiOQ03`, etc.)
already use the new `.Basic` paths — these 8 files were latent
holdouts.

## Evidence

**Before**: `bad import` failures at the listed import lines (per
PR #19122 build log).

**After (Docker-verified)**:

| File | Build progress |
|---|---|
| `Proofs.BuffonsNoodle` | Import resolves; advances to line 414 (semantic errors, see below) |
| `Proofs.Erdos515Problem` | Import resolves; full Mathlib graph compiled (2539/2539 jobs); advances to line 51 |
| `Proofs.GreensTheoremOQ01OQ01OQ02` | Import resolves; 3058/3059 jobs; advances to line 57 |

The 7727-file Mathlib cache loads cleanly in all three builds — no
`bad import` errors anywhere — confirming both `.Basic` paths
resolve at v4.26.0.

## Diff

8 files changed, 8 insertions(+), 8 deletions(-). One import line
per file. No other changes.

```
proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean
proofs/Proofs/AreaOfCircleOQ03OQ03.lean
proofs/Proofs/BuffonsNeedleOQ02OQ02.lean
proofs/Proofs/BuffonsNoodle.lean
proofs/Proofs/Erdos515Problem.lean
proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean            (greens parent)
proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean        (Equiv.Fin → Equiv.Fin.Basic)
proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean
```

## Out of scope (follow-up mechanic work per slug)

These pre-existing v4.26.0 regressions were masked by the import
failure and surfaced once import resolution succeeded. They are
**separate per-slug repairs** and not part of this fix-kit:

- `BuffonsNoodle:414+` — `div_le_div_right` / `div_lt_div_right`
  identifier renames (4 errors at lines 414, 424, 432, 434).
- `Erdos515Problem:51+` — `Differentiable` rename, `Top ℝ` synthesis
  failure, v4.26.0 `λ` parser strictness (~10 errors at lines 51-283).
- `GreensTheoremOQ01OQ01OQ02:57+` — `Measure.prod_mono`,
  `intervalIntegral.integral_neg` (term-mode application failure),
  `restrict_prod_eq_prod_restrict`, `continuous_prod_mk.mpr`
  (4 errors at lines 57, 72, 191, 201).

## Scope discipline

One root cause (v4.26.0 barrel-file split), one bundled mechanic PR,
as explicitly recommended by PR #19122's fix-kit specification:

> Total: 8 LOC across 8 files... mechanic to apply the 8-LOC fix in
> either one cross-cutting `fix(mechanic):` PR or per-slug mechanic PRs.

Bundled here because the cascade is a single Mathlib path-rename;
splitting into 7 per-slug PRs would create review churn without
isolating different root causes.

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)