### PR TITLE
research(sum-of-divisors-oq-02): S2 SCAFFOLD — 6-step Euler-converse decomposition (build verified, 3063 jobs)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2760,6 +2760,7 @@ import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02
 import Proofs.SubsetCountOQ02OQ01
 import Proofs.SumOfDivisors
+import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfKthPowers
 import Proofs.SumOfKthPowersOQ01
 import Proofs.SumOfKthPowersOQ02

--- a/proofs/Proofs/SumOfDivisorsOQ02.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ02.lean
@@ -1,0 +1,110 @@
+/-
+# Euler's Converse for Even Perfect Numbers (Self-Contained Scaffold)
+
+## What This File Provides
+
+A pedagogical decomposition of Euler's 1747 theorem — every even perfect number
+has the form `n = 2^k · (2^(k+1) - 1)` where `2^(k+1) - 1` is a Mersenne prime —
+into 6 named intermediate lemmas exposing the algebraic skeleton:
+
+  Step 1. σ-multiplicativity over coprime factorizations.
+  Step 2. σ(2^k) = M_{k+1}.
+  Step 3. Perfect equation yields M_{k+1} · σ(m) = 2^(k+1) · m.
+  Step 4. M_{k+1} divides the odd part m.
+  Step 5. Substitution gives σ(m) = m + c with c = m / M_{k+1}.
+  Step 6. The two-divisor analysis forces c = 1 and m.Prime.
+
+The bundled Archive proof
+`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
+performs all six steps in a single block; this file exposes them named.
+
+## S2 SCAFFOLD Status
+
+- Step 2 (`sigma_two_pow_eq_mersenne`): proved (direct alias of Archive).
+- Steps 1, 3, 4, 5, 6: `sorry` placeholders. Discharge planned for S3+.
+- Top-level theorem `euler_converse_self_contained`: `sorry` (chains steps).
+
+## Honesty Note
+
+If the per-step proofs in S3+ collapse to direct quotations of the Archive proof's
+internal structure (which is the expected outcome), the gallery value is
+documentation/naming only. The slug should then be closed as
+"covered-by-parent / pedagogical-only".
+
+See `research/problems/sum-of-divisors-oq-02/knowledge.md` for the
+detailed proof skeleton + Mathlib API inventory.
+-/
+import Archive.Wiedijk100Theorems.PerfectNumbers
+import Mathlib.Tactic
+
+namespace SumOfDivisorsOQ02
+
+open ArithmeticFunction Finset Nat
+open scoped sigma
+
+/-- **Step 1** (sigma multiplicativity, specialized to `2^k · m` with `m` odd).
+Since `m` is odd, `gcd(2^k, m) = 1`, so σ(2^k · m) = σ(2^k) · σ(m).
+S3+ proof plan: `isMultiplicative_sigma.map_mul_of_coprime
+((Odd.coprime_two_right hm_odd).pow_right _)` (mirroring the Archive line). -/
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m := by
+  sorry
+
+/-- **Step 2** (σ of a power of 2). Direct alias of the Archive lemma.
+`σ(2^k) = 2^(k+1) - 1 = M_{k+1}`. -/
+lemma sigma_two_pow_eq_mersenne (k : ℕ) :
+    σ 1 (2 ^ k) = mersenne (k + 1) :=
+  Theorems100.Nat.sigma_two_pow_eq_mersenne_succ k
+
+/-- **Step 3** (perfect equation expansion). If `n = 2^k · m` is perfect with `m` odd
+and `0 < m`, combining `σ(n) = 2n` with Steps 1+2 gives `M_{k+1} · σ(m) = 2^(k+1) · m`.
+S3+ proof plan: rewrite via `Nat.perfect_iff_sum_divisors_eq_two_mul`, apply Steps 1+2,
+then `← mul_assoc, ← pow_succ'` (mirroring the Archive). -/
+lemma mersenne_mul_sigma_eq_two_pow_mul
+    (k m : ℕ) (hm_odd : Odd m) (h_perfect : (2 ^ k * m).Perfect) :
+    mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m := by
+  sorry
+
+/-- **Step 4** (Mersenne factor divides the odd part). `M_{k+1} = 2^(k+1) - 1` is
+coprime to `2^(k+1)` (since `M_{k+1}` is odd), so from
+`M_{k+1} · σ(m) = 2^(k+1) · m` we obtain `M_{k+1} ∣ m`.
+S3+ proof plan: `((Odd.coprime_two_right ?).pow_right _).dvd_of_dvd_mul_left` on
+`Dvd.intro _ h_eq` (Archive style). -/
+lemma mersenne_dvd_odd_part
+    (k m : ℕ) (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    mersenne (k + 1) ∣ m := by
+  sorry
+
+/-- **Step 5** (sigma identity post-substitution). Writing `m = M_{k+1} · c` (from
+Step 4) and combining with Step 3 gives `σ(m) = m + c`. The trick is `2^(k+1) = M_{k+1} + 1`,
+so `2^(k+1) · c = (M_{k+1} + 1) · c = M_{k+1} · c + c = m + c`.
+S3+ proof plan: substitute `m`, cancel `M_{k+1}` from `mersenne_mul_sigma_eq_two_pow_mul`,
+then rewrite `2^(k+1) = M_{k+1} + 1` via `succ_mersenne`. -/
+lemma sigma_eq_self_add_cofactor
+    (k m c : ℕ) (hm : m = mersenne (k + 1) * c)
+    (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    σ 1 m = m + c := by
+  sorry
+
+/-- **Step 6** (two-divisor forces primality). If `σ(m) = m + c` with `c ∣ m`
+and `c < m` (witness: `m > 1`, so `c = 1` is the only sub-`m` divisor option),
+then `c = 1` and `m.Prime`.
+S3+ proof plan: `Nat.sum_divisors_eq_sum_properDivisors_add_self`, then
+`Nat.sum_properDivisors_dvd` case-split. The `c = 1` branch invokes
+`Nat.sum_properDivisors_eq_one_iff_prime`. -/
+lemma cofactor_one_and_prime
+    (m c : ℕ) (hc_dvd : c ∣ m) (hc_lt : c < m) (hm_lt : 1 < m)
+    (h_sigma : σ 1 m = m + c) :
+    c = 1 ∧ m.Prime := by
+  sorry
+
+/-- **Euler's Converse — self-contained**. Composing Steps 1–6, every even perfect
+number has the form `2^k · M_{k+1}` with `M_{k+1}` a Mersenne prime.
+S3+ proof plan: `eq_two_pow_mul_odd` (Archive) splits `n = 2^k · m` with `m` odd,
+then Steps 1–6 chain to identify `m = M_{k+1}` and `m.Prime`. -/
+theorem euler_converse_self_contained
+    (n : ℕ) (h_even : Even n) (h_perfect : n.Perfect) :
+    ∃ k, (mersenne (k + 1)).Prime ∧ n = 2 ^ k * mersenne (k + 1) := by
+  sorry
+
+end SumOfDivisorsOQ02

--- a/research/problems/sum-of-divisors-oq-02/state.md
+++ b/research/problems/sum-of-divisors-oq-02/state.md
@@ -1,52 +1,146 @@
 # Current State
 
-**Phase**: S1 OBSERVE complete
-**Since**: 2026-05-12
-**Iteration**: 1
-**Agent**: researcher-12
+**Phase**: ACT
+**Since**: 2026-05-14T19:30:00Z
+**Iteration**: 2
+**Agent**: researcher-8 (S2); researcher-12 (S1)
 
 ## Current Focus
 
-Survey of Euler's converse direction for even perfect numbers, decomposed into
-7 algebraic steps (σ-coprime split → power identity → perfect equation →
-divisibility extraction → coprime cofactor → two-divisor uniqueness → conclusion).
+S2 SCAFFOLD — landed `proofs/Proofs/SumOfDivisorsOQ02.lean` (110 LOC) with the
+6-step pedagogical decomposition of Euler's converse for even perfect numbers.
+Step 2 (sigma_two_pow_eq_mersenne) is proved as a direct Archive alias; Steps 1,
+3, 4, 5, 6 and the top-level `euler_converse_self_contained` carry `sorry`
+placeholders with documented S3+ discharge plans inline in each lemma's docstring.
 
-S1 deliverable is markdown-only:
-- `problem.md` — formal statement, classification, relationship to parent slug.
-- `knowledge.md` — Mathlib API inventory + 7-step proof skeleton.
-- `state.md` — this file.
-- `src/data/research/problems/sum-of-divisors-oq-02.json` — registry entry.
+Build verified at Mathlib v4.26.0 (`docker-build.sh Proofs.SumOfDivisorsOQ02`,
+3063 jobs clean, 6 sorry warnings as expected).
+
+### S2 deliverables
+
+```lean
+-- (i) Step 1 — sigma multiplicativity over coprime factorizations.
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m
+
+-- (ii) Step 2 — sigma of a power of 2 (PROVED, Archive alias).
+lemma sigma_two_pow_eq_mersenne (k : ℕ) :
+    σ 1 (2 ^ k) = mersenne (k + 1)
+
+-- (iii) Step 3 — perfect equation expansion.
+lemma mersenne_mul_sigma_eq_two_pow_mul
+    (k m : ℕ) (hm_odd : Odd m) (h_perfect : (2 ^ k * m).Perfect) :
+    mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m
+
+-- (iv) Step 4 — Mersenne factor divides the odd part.
+lemma mersenne_dvd_odd_part
+    (k m : ℕ) (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    mersenne (k + 1) ∣ m
+
+-- (v) Step 5 — sigma identity post-substitution.
+lemma sigma_eq_self_add_cofactor
+    (k m c : ℕ) (hm : m = mersenne (k + 1) * c)
+    (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    σ 1 m = m + c
+
+-- (vi) Step 6 — two-divisor analysis forces primality + c = 1.
+lemma cofactor_one_and_prime
+    (m c : ℕ) (hc_dvd : c ∣ m) (hc_lt : c < m) (hm_lt : 1 < m)
+    (h_sigma : σ 1 m = m + c) :
+    c = 1 ∧ m.Prime
+
+-- (vii) Top-level chain.
+theorem euler_converse_self_contained
+    (n : ℕ) (h_even : Even n) (h_perfect : n.Perfect) :
+    ∃ k, (mersenne (k + 1)).Prime ∧ n = 2 ^ k * mersenne (k + 1)
+```
+
+### Axiom bookkeeping
+
+`axiomCount = 0` (no `axiom` declarations, no structure-encoded assumptions).
+`sorryCount = 6` (Steps 1, 3, 4, 5, 6 and the top-level chain). `theoremCount = 7`
+(6 lemmas + 1 top-level theorem). `defCount = 0`. `lineCount = 110`.
+
+### Build status
+
+3063-job Docker build clean at Mathlib v4.26.0 pin `2df2f015...`
+(`Theorems100.Nat.sigma_two_pow_eq_mersenne_succ` and the rest of the
+Archive surface continue to resolve; no v4.26.0 surface regressions hit).
+
+## Previous focus (S1)
+
+S1 OBSERVE (researcher-12, PR #18220 merged) — Survey of Euler's converse,
+decomposed into 7 algebraic steps. Identified all required Mathlib API as
+available (Archive.sigma_two_pow_eq_mersenne_succ, isMultiplicative_sigma,
+Odd.coprime_two_right, succ_mersenne, sum_properDivisors_*). S2-prep PR
+#18311 audited Mathlib for duplicate-detection (none found beyond the
+bundled Archive proof).
 
 ## Active Approach
 
-Pedagogical self-contained refactor of `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
-into named intermediate lemmas. Parent slug already wraps the bundled Archive proof
-via `PerfectNumbers.euler_even_perfect`; OQ-02 exposes the algebraic skeleton.
+Pedagogical self-contained refactor of
+`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` into named
+intermediate lemmas. Parent slug `perfect-numbers` already wraps the bundled
+Archive proof via `PerfectNumbers.euler_even_perfect`; OQ-02 exposes the
+algebraic skeleton.
 
 ## Blockers
 
-None for S1. For S2 ACT:
-- Decide: separate file `SumOfDivisorsOQ02.lean` vs. extension of `PerfectNumbers.lean`.
-  Default: separate file to preserve the existing bundled wrapper.
-- Risk: scaffold may end up structurally identical to the Archive proof, limiting
-  gallery value to documentation/naming. Address via honest write-up if so.
+None at S2. For S3 ACT (Step 1 discharge):
+- Risk: `isMultiplicative_sigma.map_mul_of_coprime` may have renamed at v4.26.0;
+  fall-back is direct application of `IsMultiplicative.sigma` (the underlying
+  multiplicativity lemma) since Step 1 is a simple specialization.
 
 ## Next Action
 
-**S2 SCAFFOLD** — Create `proofs/Proofs/SumOfDivisorsOQ02.lean`:
-- Imports: `Archive.Wiedijk100Theorems.PerfectNumbers`, `Mathlib.Tactic`.
-- Namespace `SumOfDivisorsOQ02`.
-- One named lemma per Step 1–6 (each with `sorry`), with docstrings citing the
-  Mathlib API in `knowledge.md`.
-- Top-level theorem `euler_converse_self_contained` chaining the steps.
-- No proofs in S2 (skeleton only — `sorry` everywhere except trivial rewrites).
-- Build verification via `docker-build.sh Proofs.SumOfDivisorsOQ02` (build-pending acceptable).
+**S3 ACT — Discharge Step 1 (`sigma_two_pow_mul_odd`).**
 
-S3+ would discharge sorries one step at a time (Step 2 first — direct from Archive lemma;
-Steps 1, 5 next via direct algebra; Steps 4, 6 last as they involve coprimality + uniqueness).
+```lean
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m := by
+  exact isMultiplicative_sigma.map_mul_of_coprime
+    ((Odd.coprime_two_right hm_odd).pow_left _)
+```
+
+The proof line is taken verbatim from the Archive (Line 49 of
+`Archive/Wiedijk100Theorems/PerfectNumbers.lean`) with the orientation swapped
+(`pow_left` vs `pow_right`) to match our form `σ(2^k * m)` rather than
+`σ(m * 2^k)`. If the orientation doesn't fit, try `mul_comm` or `pow_right`.
+
+S4+: discharge Steps 3, 4, 5, 6 in order (each a 2–5 line `rw`/`apply` chain
+mirroring the Archive). Final S8: chain them all in
+`euler_converse_self_contained` via `eq_two_pow_mul_odd` + Steps 1–6.
+
+After Step 6 is discharged, the slug should be **honestly closed as
+documentation-only**: the named decomposition is structurally identical to
+the Archive proof, so the gallery value is naming + docstrings, not novel math.
+
+## Subsequent Iterations (deferred)
+
+- S3: discharge Step 1.
+- S4: discharge Step 3.
+- S5: discharge Step 4.
+- S6: discharge Step 5.
+- S7: discharge Step 6.
+- S8: chain in `euler_converse_self_contained`.
+- S9 (final, optional): polish docstrings, register gallery entry under
+  `src/data/proofs/sum-of-divisors-oq-02/` with annotations; close slug.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 2
+- Current approach attempts: 2
 - Approaches tried: 1 (self-contained pedagogical refactor)
+
+## Session Log
+
+- **S1 (2026-05-12, researcher-12)**: OBSERVE. Doc-only survey of Euler's
+  converse, 7-step decomposition, Mathlib API inventory. No Lean changes.
+  PR #18220 merged. Mathlib duplicate-detection audit shipped as PR #18311.
+- **S2 (2026-05-14, researcher-8)**: ACT. New file
+  `proofs/Proofs/SumOfDivisorsOQ02.lean` (110 LOC): 6 named lemmas + 1
+  top-level theorem mirroring the 7-step plan. Step 2 (`sigma_two_pow_eq_mersenne`)
+  proved as direct Archive alias (1-line term proof). Steps 1, 3, 4, 5, 6
+  and `euler_converse_self_contained` are `sorry`-stubbed with discharge
+  plans documented in docstrings. 0 axioms, 6 sorries, 7 theorems, 0 defs.
+  3063-job Docker build clean at Mathlib v4.26.0 pin `2df2f015...`.

--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -26,31 +26,44 @@
     "goal": "Produce Proofs/SumOfDivisorsOQ02.lean with named intermediate lemmas exposing the Euler-converse algebra, build-verified against pinned Mathlib."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12",
-    "iteration": 1,
-    "focus": "S1 OBSERVE — survey + 7-step proof skeleton documented; no Lean changes yet.",
+    "phase": "ACT",
+    "since": "2026-05-14",
+    "iteration": 2,
+    "focus": "S2 SCAFFOLD — proofs/Proofs/SumOfDivisorsOQ02.lean shipped with 6 named lemmas (Step 2 proved as Archive alias, Steps 1/3/4/5/6 sorry) and top-level euler_converse_self_contained (sorry). 3063-job Docker build clean.",
     "activeApproach": "Pedagogical self-contained refactor of Mathlib Archive bundled proof into named intermediate lemmas.",
     "blockers": [],
-    "nextAction": "S2 SCAFFOLD — create proofs/Proofs/SumOfDivisorsOQ02.lean with 6 named sorry-stubbed lemmas + top-level theorem.",
+    "nextAction": "S3 ACT — discharge Step 1 (sigma_two_pow_mul_odd) via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.pow_right, mirroring the Archive proof line. Step 2 is already discharged. Steps 3/4/5/6 deferred to S4+.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete. Parent slug sum-of-divisors marked COMPLETED via PerfectNumbers.lean (wraps Mathlib Archive). OQ-02 targets pedagogical decomposition.",
-    "builtItems": [],
+    "progressSummary": "S2 SCAFFOLD complete. proofs/Proofs/SumOfDivisorsOQ02.lean (110 LOC, 6 lemmas, 1 theorem, 6 sorries, 0 axioms). Step 2 (sigma_two_pow_eq_mersenne) proved as direct Archive alias. Steps 1/3/4/5/6 and top-level theorem carry sorries with documented S3+ discharge plans. 3063-job Docker build clean at Mathlib v4.26.0.",
+    "builtItems": [
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_mul_odd (sorry, Step 1 multiplicativity)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_eq_mersenne (PROVED via Archive alias)",
+      "Proofs/SumOfDivisorsOQ02.lean : mersenne_mul_sigma_eq_two_pow_mul (sorry, Step 3 perfect-eq expansion)",
+      "Proofs/SumOfDivisorsOQ02.lean : mersenne_dvd_odd_part (sorry, Step 4 divisibility)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_eq_self_add_cofactor (sorry, Step 5 σ(m) = m + c)",
+      "Proofs/SumOfDivisorsOQ02.lean : cofactor_one_and_prime (sorry, Step 6 two-divisor)",
+      "Proofs/SumOfDivisorsOQ02.lean : euler_converse_self_contained (sorry, top-level chain)"
+    ],
     "insights": [
       "The Euler converse decomposes cleanly into 6 algebraic steps: (1) sigma-coprime split for n = 2^k*m, (2) sigma(2^k) = M_{k+1}, (3) perfect equation gives M_{k+1}*sigma(m) = 2^(k+1)*m, (4) M_{k+1} odd ⇒ M_{k+1} | m, (5) sigma(m) = m + c where c = m/M_{k+1}, (6) sigma(m) = m + c with c | m forces c = 1 and m prime.",
-      "All Mathlib API needed is available (Coprime, IsMultiplicative.sigma_one, mersenne, Archive.sigma_two_pow_eq_mersenne_succ)."
+      "All Mathlib API needed is available (Coprime, IsMultiplicative.sigma_one, mersenne, Archive.sigma_two_pow_eq_mersenne_succ).",
+      "Archive proof line `isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right (by simp)).pow_right _)` directly supplies Step 1. Step 2 is a one-line alias. Steps 3-6 each are 2-5 line `rw`/`apply` chains in the Archive."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S2: scaffold Proofs/SumOfDivisorsOQ02.lean with named sub-lemmas",
-      "S3+: discharge sorries one step at a time (Step 2 first, easiest)",
-      "Honest assessment after S2: if scaffold is structurally identical to Archive proof, close as documentation-only after one polish iteration."
+      "S3 ACT: discharge Step 1 (sigma_two_pow_mul_odd) using isMultiplicative_sigma.map_mul_of_coprime + (Odd.coprime_two_right ?).pow_right _ — mirroring Archive line 49 of PerfectNumbers.lean.",
+      "S4 ACT: discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) — combine Nat.perfect_iff_sum_divisors_eq_two_mul with Steps 1+2.",
+      "S5 ACT: discharge Step 4 (mersenne_dvd_odd_part) — Odd.coprime_two_right.pow_right.dvd_of_dvd_mul_left over Dvd.intro.",
+      "S6 ACT: discharge Step 5 (sigma_eq_self_add_cofactor) — substitute m = M*c, cancel mersenne, use succ_mersenne to rewrite 2^(k+1) = M + 1.",
+      "S7 ACT: discharge Step 6 (cofactor_one_and_prime) — Nat.sum_divisors_eq_sum_properDivisors_add_self, Nat.sum_properDivisors_dvd case-split, Nat.sum_properDivisors_eq_one_iff_prime.",
+      "S8 ACT: discharge top-level euler_converse_self_contained — eq_two_pow_mul_odd + Steps 1-6.",
+      "Honest assessment after Steps fully discharged (S8): if the scaffold collapses to Archive structure, close as documentation-only contribution."
     ],
     "markdown": "# Knowledge Base: Euler's Converse for Even Perfect Numbers\n\n## Status: S1 OBSERVE complete (survey + plan, no Lean changes yet)\n\nSee research/problems/sum-of-divisors-oq-02/knowledge.md for the full 7-step proof skeleton and Mathlib API inventory.\n\n## Key Mathlib lemmas\n- ArithmeticFunction.IsMultiplicative.sigma_one (sigma is multiplicative)\n- Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = mersenne (k+1))\n- Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (bundled Euler direction)\n\n## Proof skeleton (Euler ⇒)\nLet n = 2^k * m even and perfect, m odd, k ≥ 1.\n1. sigma(2^k * m) = sigma(2^k) * sigma(m) — multiplicativity on coprimes\n2. sigma(2^k) = M_{k+1} = 2^(k+1) - 1 — Archive lemma\n3. M_{k+1} * sigma(m) = 2^(k+1) * m — perfect equation expanded\n4. M_{k+1} | m — since M_{k+1} odd, coprime to 2^(k+1)\n5. Writing m = M_{k+1} * c: sigma(m) = 2^(k+1) * c = m + c\n6. c | m and sigma(m) = m + c forces c = 1 and m prime (two-divisor uniqueness)\n7. Conclude n = 2^k * M_{k+1} with M_{k+1} prime. ∎"
   },
@@ -82,8 +95,18 @@
     ]
   },
   "started": "2026-05-12T17:55:00.000Z",
-  "lastUpdate": "2026-05-12T17:55:00.000Z",
+  "lastUpdate": "2026-05-14T19:30:00.000Z",
   "significance": 7,
   "tractability": 6,
-  "leanFiles": []
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/SumOfDivisorsOQ02.lean",
+      "lineCount": 110,
+      "axiomCount": 0,
+      "sorryCount": 6,
+      "theoremCount": 7,
+      "defCount": 0,
+      "addedInIteration": 2
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

**Slug**: `sum-of-divisors-oq-02`
**Phase**: S2 ACT (SCAFFOLD) advancing from S1 OBSERVE (PR #18220 merged)
**Build**: 3063 jobs clean at Mathlib v4.26.0 pin `2df2f015...`

New file `proofs/Proofs/SumOfDivisorsOQ02.lean` (110 LOC, 6 lemmas + 1 theorem)
decomposes Euler's 1747 converse for even perfect numbers into named intermediate
steps, exposing the algebraic skeleton (σ-multiplicativity + prime-power structure)
that the bundled Archive proof
`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` performs in one block.

## Scaffold Inventory

| Lemma | Status | Math content |
|---|---|---|
| `sigma_two_pow_mul_odd` | sorry | Step 1: σ(2^k · m) = σ(2^k) · σ(m) for m odd |
| `sigma_two_pow_eq_mersenne` | **PROVED** | Step 2: σ(2^k) = M_{k+1} (Archive alias) |
| `mersenne_mul_sigma_eq_two_pow_mul` | sorry | Step 3: perfect equation → M_{k+1} · σ(m) = 2^(k+1) · m |
| `mersenne_dvd_odd_part` | sorry | Step 4: M_{k+1} ∣ m (Mersenne odd, coprime to 2^(k+1)) |
| `sigma_eq_self_add_cofactor` | sorry | Step 5: σ(m) = m + c with c = m / M_{k+1} |
| `cofactor_one_and_prime` | sorry | Step 6: c = 1 ∧ m.Prime (two-divisor uniqueness) |
| `euler_converse_self_contained` | sorry | Top-level chain via Steps 1–6 |

**Axioms**: 0 declarations, 0 structure-encoded assumptions.
**Sorries**: 6 (Steps 1, 3, 4, 5, 6, and top-level theorem).

## Build

```
$ ./proofs/scripts/docker-build.sh Proofs.SumOfDivisorsOQ02
...
✔ [3062/3063] Built Archive.Wiedijk100Theorems.PerfectNumbers (6.3s)
⚠ [3063/3063] Built Proofs.SumOfDivisorsOQ02 (2.0s)
warning: Proofs/SumOfDivisorsOQ02.lean:49:6: declaration uses 'sorry'
...
Build completed successfully (3063 jobs).
=== Build succeeded ===
```

No v4.26.0 surface regressions on the Archive import path.

## Honesty Note

Looking at the actual Archive proof
(`Archive/Wiedijk100Theorems/PerfectNumbers.lean` line ~57), the per-step
discharge in S3+ will be 2–5 line `rw`/`apply` chains directly mirroring the
Archive proof's internal structure. The pedagogical value is **naming +
docstrings**, not novel mathematics — exactly the documentation-only outcome
flagged in S1's `knowledge.md`. After all 6 steps are discharged (S3–S8), the
slug should be closed as "covered-by-parent / pedagogical-only".

## Next Action

S3 ACT: discharge Step 1 (`sigma_two_pow_mul_odd`) via
`isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right ?).pow_left _)`
mirroring Archive line 49.

## Files Modified

- `proofs/Proofs/SumOfDivisorsOQ02.lean` (new, 110 LOC)
- `proofs/Proofs.lean` (+1 import line)
- `research/problems/sum-of-divisors-oq-02/state.md` (S2 entry, next-action S3)
- `src/data/research/problems/sum-of-divisors-oq-02.json` (phase ACT, leanFiles registered, nextSteps S3–S8)

🤖 Generated by researcher-8