### PR TITLE
fix(mechanic): Hilbert10OQ01OQ02 v4.26.0 parent repair (4-kit)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -71,11 +71,17 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
 -- S12 (iter 12, Path B): `mul_self_nonneg` for the sum-of-squares witness
 -- used in closure of Σ₁ under binary intersection. ℚ is a LinearOrderedField,
--- so `0 ≤ a*a` for every `a : ℚ`.
-import Mathlib.Algebra.Order.Ring.Lemmas
+-- so `0 ≤ a*a` for every `a : ℚ`. Provided transitively via
+-- `Mathlib.Algebra.Order.Ring.Basic` (Mathlib v4.26.0; the historic
+-- `Mathlib.Algebra.Order.Ring.Lemmas` barrel file was removed).
+import Mathlib.Algebra.Order.Ring.Basic
 -- S12 (iter 12, Path B): `linarith` to discharge the conclusion
 -- `a*a + b*b = 0  ∧  0 ≤ a*a  ∧  0 ≤ b*b  →  a*a = 0  ∧  b*b = 0`.
 import Mathlib.Tactic.Linarith
+-- v4.26.0 (Path B mechanic): `ring` tactic, formerly pulled in transitively
+-- via the now-removed `Mathlib.Algebra.Order.Ring.Lemmas` barrel; must be
+-- imported explicitly at v4.26.0.
+import Mathlib.Tactic.Ring
 -- Iter 17 (Path B): `Finset.toList` and `Finset.mem_toList` for Finset
 -- transports of the iter 10 / iter 14 / iter 15 list closures.
 import Mathlib.Data.Finset.Basic
@@ -903,9 +909,9 @@ theorem union_isDiophantineDefinition
   constructor
   · rintro (hS₁ | hS₂)
     · obtain ⟨x, hx⟩ := (hP₁ q).mp hS₁
-      exact ⟨x, by rw [hx, zero_mul]⟩
+      exact ⟨x, by simp only [hx, zero_mul]⟩
     · obtain ⟨x, hx⟩ := (hP₂ q).mp hS₂
-      exact ⟨x, by rw [hx, mul_zero]⟩
+      exact ⟨x, by simp only [hx, mul_zero]⟩
   · rintro ⟨x, hx⟩
     rcases mul_eq_zero.mp hx with hzero | hzero
     · exact Or.inl ((hP₁ q).mpr ⟨x, hzero⟩)
@@ -952,10 +958,10 @@ theorem intersection_isCoDiophantineDefinition
     refine ⟨?_, ?_⟩
     · apply (hP₁ q).mpr
       rintro ⟨x, hx⟩
-      exact hnsol ⟨x, by rw [hx, zero_mul]⟩
+      exact hnsol ⟨x, by simp only [hx, zero_mul]⟩
     · apply (hP₂ q).mpr
       rintro ⟨x, hx⟩
-      exact hnsol ⟨x, by rw [hx, mul_zero]⟩
+      exact hnsol ⟨x, by simp only [hx, mul_zero]⟩
 
 /-- Iter 9 corollary, Path B: **every pair `{a, b} ⊂ ℚ` is Σ₁-definable**
     for any `a, b : ℚ`.
@@ -1257,6 +1263,8 @@ theorem intersection_isDiophantineDefinition
     obtain ⟨x₁, hx₁⟩ := (hP₁ q).mp hS₁
     obtain ⟨x₂, hx₂⟩ := (hP₂ q).mp hS₂
     refine ⟨interleave x₁ x₂, ?_⟩
+    show P₁ q (evenProj (interleave x₁ x₂)) * P₁ q (evenProj (interleave x₁ x₂)) +
+         P₂ q (oddProj (interleave x₁ x₂)) * P₂ q (oddProj (interleave x₁ x₂)) = 0
     rw [evenProj_interleave, oddProj_interleave, hx₁, hx₂]
     ring
   · rintro ⟨x, hx⟩
@@ -1428,7 +1436,7 @@ theorem finIntersectionList_isDiophantineDefinition
       universe_isDiophantineDefinition
   | cons a t ih =>
     have h_head : IsDiophantineDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsDiophantineDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsDiophantineDefinition (fun q : Rat => ∀ S ∈ t, S q) :=
@@ -1442,7 +1450,7 @@ theorem finIntersectionList_isDiophantineDefinition
       intro q
       constructor
       · intro hall
-        refine ⟨hall a (List.mem_cons_self a t),
+        refine ⟨hall a (List.mem_cons_self),
           fun S hS => hall S (List.mem_cons_of_mem a hS)⟩
       · rintro ⟨ha, htail⟩ S hS
         rcases List.mem_cons.mp hS with rfl | hSt
@@ -1495,7 +1503,7 @@ theorem finUnionList_isCoDiophantineDefinition
       empty_isCoDiophantineDefinition
   | cons a t ih =>
     have h_head : IsCoDiophantineDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsCoDiophantineDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsCoDiophantineDefinition (fun q : Rat => ∃ S ∈ t, S q) :=
@@ -1513,7 +1521,7 @@ theorem finUnionList_isCoDiophantineDefinition
         · exact Or.inl hSq
         · exact Or.inr ⟨S, hSt, hSq⟩
       · rintro (ha | ⟨S, hSt, hSq⟩)
-        · exact ⟨a, List.mem_cons_self a t, ha⟩
+        · exact ⟨a, List.mem_cons_self, ha⟩
         · exact ⟨S, List.mem_cons_of_mem a hSt, hSq⟩
     exact (coDiophantineDefinition_iff_of_pred_iff hbridge).mpr h_union
 
@@ -1576,7 +1584,7 @@ theorem finUnionList_isDiophantineDefinition
       empty_isDiophantineDefinition
   | cons a t ih =>
     have h_head : IsDiophantineDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsDiophantineDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsDiophantineDefinition (fun q : Rat => ∃ S ∈ t, S q) :=
@@ -1594,7 +1602,7 @@ theorem finUnionList_isDiophantineDefinition
         · exact Or.inl hSq
         · exact Or.inr ⟨S, hSt, hSq⟩
       · rintro (ha | ⟨S, hSt, hSq⟩)
-        · exact ⟨a, List.mem_cons_self a t, ha⟩
+        · exact ⟨a, List.mem_cons_self, ha⟩
         · exact ⟨S, List.mem_cons_of_mem a hSt, hSq⟩
     exact (diophantineDefinition_iff_of_pred_iff hbridge).mpr h_union
 
@@ -1648,7 +1656,7 @@ theorem finIntersectionList_isCoDiophantineDefinition
       universe_isCoDiophantineDefinition
   | cons a t ih =>
     have h_head : IsCoDiophantineDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsCoDiophantineDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsCoDiophantineDefinition (fun q : Rat => ∀ S ∈ t, S q) :=
@@ -1662,7 +1670,7 @@ theorem finIntersectionList_isCoDiophantineDefinition
       intro q
       constructor
       · intro hall
-        refine ⟨hall a (List.mem_cons_self a t),
+        refine ⟨hall a (List.mem_cons_self),
           fun S hS => hall S (List.mem_cons_of_mem a hS)⟩
       · rintro ⟨ha, htail⟩ S hS
         rcases List.mem_cons.mp hS with rfl | hSt
@@ -1923,7 +1931,7 @@ theorem sigma2_intersection_isExistentialUniversalDefinition
     obtain ⟨y₂, hy₂⟩ := (hP₂ q).mp hS₂
     refine ⟨interleave y₁ y₂, ?_⟩
     rintro ⟨x, hx⟩
-    rw [evenProj_interleave, oddProj_interleave] at hx
+    simp only [evenProj_interleave, oddProj_interleave] at hx
     rcases mul_eq_zero.mp hx with h1 | h2
     · exact hy₁ ⟨x, h1⟩
     · exact hy₂ ⟨x, h2⟩
@@ -1931,10 +1939,10 @@ theorem sigma2_intersection_isExistentialUniversalDefinition
     refine ⟨(hP₁ q).mpr ⟨evenProj y, ?_⟩, (hP₂ q).mpr ⟨oddProj y, ?_⟩⟩
     · rintro ⟨x, hx⟩
       apply hy
-      exact ⟨x, by rw [hx]; ring⟩
+      exact ⟨x, by simp only [hx, zero_mul]⟩
     · rintro ⟨x, hx⟩
       apply hy
-      exact ⟨x, by rw [hx]; ring⟩
+      exact ⟨x, by simp only [hx, mul_zero]⟩
 
 -- ============================================================
 -- Part VIII.22 (iter 20, Path B): Π₂ closed under binary union
@@ -2067,7 +2075,7 @@ theorem sigma2_intersectionList_isExistentialUniversalDefinition
       universe_isExistentialUniversalDefinition
   | cons a t ih =>
     have h_head : IsExistentialUniversalDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsExistentialUniversalDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsExistentialUniversalDefinition
@@ -2082,7 +2090,7 @@ theorem sigma2_intersectionList_isExistentialUniversalDefinition
       intro q
       constructor
       · intro hall
-        refine ⟨hall a (List.mem_cons_self a t),
+        refine ⟨hall a (List.mem_cons_self),
           fun S hS => hall S (List.mem_cons_of_mem a hS)⟩
       · rintro ⟨ha, htail⟩ S hS
         rcases List.mem_cons.mp hS with rfl | hSt
@@ -2143,7 +2151,7 @@ theorem pi2_unionList_isUniversalExistentialDefinition
       empty_isUniversalExistentialDefinition
   | cons a t ih =>
     have h_head : IsUniversalExistentialDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsUniversalExistentialDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsUniversalExistentialDefinition
@@ -2162,7 +2170,7 @@ theorem pi2_unionList_isUniversalExistentialDefinition
         · exact Or.inl hSq
         · exact Or.inr ⟨S, hSt, hSq⟩
       · rintro (ha | ⟨S, hSt, hSq⟩)
-        · exact ⟨a, List.mem_cons_self a t, ha⟩
+        · exact ⟨a, List.mem_cons_self, ha⟩
         · exact ⟨S, List.mem_cons_of_mem a hSt, hSq⟩
     exact (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr h_union
 
@@ -2411,6 +2419,8 @@ theorem pi2_intersection_isUniversalExistentialDefinition
     obtain ⟨x₁, hx₁⟩ := (hP₁ q).mp hS₁ y
     obtain ⟨x₂, hx₂⟩ := (hP₂ q).mp hS₂ y
     refine ⟨interleave x₁ x₂, ?_⟩
+    show P₁ q y (evenProj (interleave x₁ x₂)) * P₁ q y (evenProj (interleave x₁ x₂)) +
+         P₂ q y (oddProj (interleave x₁ x₂)) * P₂ q y (oddProj (interleave x₁ x₂)) = 0
     rw [evenProj_interleave, oddProj_interleave, hx₁, hx₂]
     ring
   · intro hAll
@@ -2540,7 +2550,7 @@ theorem sigma2_unionList_isExistentialUniversalDefinition
       empty_isExistentialUniversalDefinition
   | cons a t ih =>
     have h_head : IsExistentialUniversalDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsExistentialUniversalDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsExistentialUniversalDefinition
@@ -2559,7 +2569,7 @@ theorem sigma2_unionList_isExistentialUniversalDefinition
         · exact Or.inl hSq
         · exact Or.inr ⟨S, hSt, hSq⟩
       · rintro (ha | ⟨S, hSt, hSq⟩)
-        · exact ⟨a, List.mem_cons_self a t, ha⟩
+        · exact ⟨a, List.mem_cons_self, ha⟩
         · exact ⟨S, List.mem_cons_of_mem a hSt, hSq⟩
     exact (existentialUniversalDefinition_iff_of_pred_iff hbridge).mpr h_union
 
@@ -2620,7 +2630,7 @@ theorem pi2_intersectionList_isUniversalExistentialDefinition
       universe_isUniversalExistentialDefinition
   | cons a t ih =>
     have h_head : IsUniversalExistentialDefinition a :=
-      h a (List.mem_cons_self a t)
+      h a (List.mem_cons_self)
     have h_tail : ∀ S ∈ t, IsUniversalExistentialDefinition S :=
       fun S hS => h S (List.mem_cons_of_mem a hS)
     have ih_def : IsUniversalExistentialDefinition
@@ -2635,7 +2645,7 @@ theorem pi2_intersectionList_isUniversalExistentialDefinition
       intro q
       constructor
       · intro hall
-        refine ⟨hall a (List.mem_cons_self a t),
+        refine ⟨hall a (List.mem_cons_self),
           fun S hS => hall S (List.mem_cons_of_mem a hS)⟩
       · rintro ⟨ha, htail⟩ S hS
         rcases List.mem_cons.mp hS with rfl | hSt


### PR DESCRIPTION
## Summary

Repairs the Hilbert10OQ01OQ02.lean v4.26.0 parent regression
flagged by **PR #19117** (research, build-pending iter 26a).
Unblocks iters 22 / 24a / 25 / 26a Σ₂/Π₂ closure verifications.

The original PR #19117 description called this a "mechanic-driven
1-line fix" — in practice the barrel import was masking a 29-error
cascade. This PR is the surgical fix kit.

## Net deltas

* +35 / -25 LOC
* 0 sorries, 0 axioms, 0 theorem-count change
* 1 cleaner Docker build (839 jobs)

## Repair kit (4 clusters)

### 1. Barrel import drop (1 LOC swap, +1 import)

`Mathlib.Algebra.Order.Ring.Lemmas` (deleted at v4.26.0; 404 at pinned
rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) is the obsolete name
for the barrel that transitively provided `mul_self_nonneg`. Replaced
with `Mathlib.Algebra.Order.Ring.Basic`, which references
`mul_self_nonneg` directly (verified at v4.26.0).

### 2. Explicit `Mathlib.Tactic.Ring` import (+1 import)

`ring` tactic was formerly pulled in transitively via the now-removed
barrel. Must be imported explicitly at v4.26.0. Affects 4 call sites
in the parent file (lines 1265, 1937, 1939, 2421 in old numbering).

### 3. `List.mem_cons_self` arity drop (16 sites)

v4.26.0 declares `mem_cons_self` with BOTH `a` and `l` implicit:

```lean
theorem mem_cons_self {a : α} {l : List α} : a ∈ a :: l := ...
```

Old call `List.mem_cons_self a t` now errors with `Function expected`.
Surgical rename: drop both args. Affects 16 sites in 8 list-arity
closure theorems (`finIntersectionList_*`, `finUnionList_*`,
`sigma2_unionList_*`, `pi2_intersectionList_*`, plus their duals).

### 4. Beta-blocked rewrites (7 sites, 4 sub-patterns)

v4.26.0 elaborator no longer auto-beta-reduces `(fun q x => …) q x`
before `rw` / `rw … at hx` pattern matching.

| Sub-pattern | Sites | Fix |
|---|---|---|
| `by rw [hx, zero_mul]` | 2 | `by simp only [hx, zero_mul]` (simp triggers beta) |
| `by rw [hx, mul_zero]` | 2 | `by simp only [hx, mul_zero]` |
| `by rw [hx]; ring` | 2 | `by simp only [hx, zero_mul]` / `[hx, mul_zero]` |
| `rw [evenProj_interleave, oddProj_interleave] at hx` | 1 | `simp only [...] at hx` |
| `rw [...] ring`-style with multiple rewrites | 2 | prepend `show <beta-reduced> = 0` to unblock pattern matching, retain `rw`+`ring` chain |

## Affected theorems

* `union_isDiophantineDefinition` (Σ₁ ∪, lines 908–910)
* `intersection_isCoDiophantineDefinition` (Π₁ ∩, lines 957–960)
* `intersection_isDiophantineDefinition` (Σ₁ ∩ via sum-of-squares, lines 1262–1263)
* `sigma2_intersection_isExistentialUniversalDefinition` (Σ₂ ∩, lines 1929–1939)
* `pi2_intersection_isUniversalExistentialDefinition` (Π₂ ∩, lines 2416–2417)
* 8 list-arity closure theorems (all 16 `List.mem_cons_self` sites)

All zero-math-change: each surgical rewrite produces a definitionally
equal proof term.

## Test plan

- [x] `gh api .../contents/Mathlib/Algebra/Order/Ring/Lemmas.lean?ref=2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` → 404 confirmed.
- [x] `./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02` exit 0 — **839 jobs clean** (iter 3, after iter 1 barrel-drop revealed cascade, iter 2 List.mem_cons_self + simp-only resolved 22/29, iter 3 explicit Ring import + show blocks resolved remaining 7).
- [x] Diff is surgical: zero theorem-count change, zero sorry-count change, zero axiom-count change.

## Unblocks

* **PR #19117** (research iter 26a) — Finset-arity Σ₂ ∪ + Π₂ ∩ closures, currently build-pending awaiting this mechanic fix.
* **Iter 22 / 24a / 25** prior build-pending chain (PRs #18107, #18659, #18785, all merged build-pending awaiting this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)