### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01): S1 OBSERVE — backward/forward dichotomy over commutative rings (doc-only)

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,260 @@
+# Knowledge: Cyclic Vector Theorem — Biconditional over Commutative Rings (OQ extension 01)
+
+## S1 OBSERVE session (researcher-9, 2026-05-14)
+
+This note records the counterexample analysis and Mathlib API
+verification underpinning the S1 conclusion that the biconditional
+
+> `IsNonderogatory M ↔ ∃ v, IsCyclicVector M v`
+
+(true over fields per gallery entry
+`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01`) **bifurcates**
+over commutative rings:
+
+- Backward direction extends to any nontrivial `CommRing R`.
+- Forward direction fails over `ZMod 4` (and presumably over any
+  non-domain), with explicit counterexample.
+
+## Worked counterexample: `M = !![0, 2; 0, 0]` over `ZMod 4`
+
+### Setup
+
+Let `R = ZMod 4` and `n = 2`. Define
+```
+M : Matrix (Fin 2) (Fin 2) (ZMod 4) := !![0, 2; 0, 0]
+```
+
+so `M[0,0] = 0`, `M[0,1] = 2`, `M[1,0] = 0`, `M[1,1] = 0`.
+
+### Characteristic polynomial
+
+`M.charpoly = det (X • 1 - M)` where the underlying matrix is
+
+```
+X • 1 - M = !![X, -2; 0, X]
+```
+
+(upper triangular with diagonal `(X, X)` and off-diagonal `(-2, 0)`).
+The determinant of a 2×2 upper-triangular matrix is the product of
+diagonal entries:
+
+```
+M.charpoly = X * X - (-2) * 0 = X^2
+```
+
+Hence `M.charpoly = X^2`, monic of `natDegree = 2`.
+
+### Minimal polynomial
+
+We claim `minpoly (ZMod 4) M = X^2`.
+
+**Upper bound** (degree ≤ 2): `M^2 = 0`.
+
+Computing `M^2`:
+```
+M^2 = !![0, 2; 0, 0] * !![0, 2; 0, 0]
+    = !![ 0·0+2·0,  0·2+2·0 ;
+          0·0+0·0,  0·2+0·0 ]
+    = !![ 0, 0 ;
+          0, 0 ]
+```
+
+So `aeval M (X^2) = M^2 = 0`. Since `X^2` is monic of `natDegree = 2`,
+the minimal monic annihilator has `natDegree ≤ 2`.
+
+**Lower bound** (degree ≥ 2): no monic polynomial of `natDegree < 2`
+annihilates `M`. The only candidates are:
+
+- `natDegree = 0`: `1`. `aeval M 1 = I ≠ 0`.
+- `natDegree = 1`: `X - c` for some `c : ZMod 4`. Then
+  `aeval M (X - c) = M - c • I = !![-c, 2; 0, -c]`.
+  For this to be the zero matrix, both diagonal entries `-c = 0`
+  (forcing `c = 0`) and the `[0,1]`-entry `2 = 0` must hold. The latter
+  fails in `ZMod 4` since `2 ≠ 0` (`2 ≠ 0 ∈ ZMod 4`). So no `c` works.
+
+By definition of `minpoly` over a `CommRing` (Mathlib's
+`Mathlib/FieldTheory/Minpoly/Basic.lean:41`), `minpoly (ZMod 4) M` is
+the monic generator of the ideal `{ p : (ZMod 4)[X] | aeval M p = 0 }`
+of least degree. Combining the upper bound (`X^2` annihilates) and the
+lower bound (no monic deg-1 annihilator exists), we conclude
+`minpoly (ZMod 4) M = X^2`.
+
+### `IsNonderogatory M` holds
+
+`minpoly (ZMod 4) M = X^2 = M.charpoly`, so by definition
+`IsNonderogatory M`.
+
+### No cyclic vector
+
+We claim `∀ v : Fin 2 → ZMod 4, ¬ IsCyclicVector M v`.
+
+Recall the definition (mirroring
+`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean:43`):
+
+```
+IsCyclicVector M v := ∀ p : (ZMod 4)[X], p.natDegree < 2 →
+                       (aeval M p).mulVec v = 0 → p = 0
+```
+
+So to show `¬ IsCyclicVector M v` we exhibit a nonzero `p` of
+`natDegree < 2` with `(aeval M p).mulVec v = 0`.
+
+Let `v = (a, b) : Fin 2 → ZMod 4`. We compute `M.mulVec v`:
+
+```
+M.mulVec v = (M[0,0]·a + M[0,1]·b, M[1,0]·a + M[1,1]·b)
+           = (0·a + 2·b, 0·a + 0·b)
+           = (2b, 0)
+```
+
+And for `p = αX + β : (ZMod 4)[X]`:
+
+```
+aeval M p = α·M + β·I = !![β, 2α; 0, β]
+
+(aeval M p).mulVec v = !![β, 2α; 0, β] * (a, b)^T
+                     = (β·a + 2α·b, 0·a + β·b)
+                     = (βa + 2αb, βb)
+```
+
+For `(aeval M p).mulVec v = 0` we need:
+
+1. `βa + 2αb = 0` in `ZMod 4`
+2. `βb = 0` in `ZMod 4`
+
+**Case 1: `b = 0`.** Condition 2 is automatic. Condition 1 reduces to
+`βa = 0`. Take `p = X` (i.e., `α = 1, β = 0`). Then `βa = 0 ✓` and
+`p ≠ 0` with `natDegree p = 1 < 2`. So `v = (a, 0)` is not cyclic.
+
+**Case 2: `b ≠ 0`.** Take `p = 2X` (i.e., `α = 2, β = 0`). Then:
+
+- `βa + 2αb = 0 + 4b = 0` in `ZMod 4` (since `4 ≡ 0 mod 4`).
+- `βb = 0 ✓`.
+- `p = 2X ≠ 0` (in `(ZMod 4)[X]`, `2X = 0` iff its `1`-coefficient
+  `2 = 0`, which fails since `2 ≠ 0` in `ZMod 4`).
+- `natDegree (2X) = 1 < 2`.
+
+So `v = (a, b)` with `b ≠ 0` is not cyclic.
+
+**Combined**: for every `v ∈ (ZMod 4)^2`, there exists nonzero
+`p : (ZMod 4)[X]` of `natDegree < 2` with `(aeval M p).mulVec v = 0`.
+Hence `¬ ∃ v, IsCyclicVector M v`.
+
+### Conclusion
+
+`M = !![0, 2; 0, 0]` over `ZMod 4` satisfies:
+
+- `IsNonderogatory M` (`minpoly = charpoly = X^2`)
+- `¬ ∃ v, IsCyclicVector M v`
+
+This **falsifies** the forward direction
+`IsNonderogatory M → ∃ v, IsCyclicVector M v` over `ZMod 4`. The
+biconditional therefore **does not extend** to general commutative
+rings.
+
+The S3 ACT will formalise this as a counterexample theorem in Lean.
+
+## Backward direction: proof sketch over `CommRing R`
+
+The existing field proof in
+`proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean:45-95`
+generalises to `[CommRing R] [Nontrivial R]` with only one surgical
+swap:
+
+| Step | Field-version line | CommRing-version change |
+|------|--------------------|-------------------------|
+| `minpoly ∣ charpoly via Cayley-Hamilton` | line 52-53 | unchanged — `minpoly.dvd` works over `CommRing` |
+| `M.charpoly.Monic` | line 55 | unchanged — needs `Nontrivial R` (auto from `Nontrivial`) |
+| `M.charpoly.natDegree = n` | line 57-58 | unchanged — `Matrix.charpoly_natDegree_eq_dim` works over `CommRing R + Nontrivial R` |
+| `(minpoly).natDegree ≤ n` from divisibility | line 60-62 | unchanged — `Polynomial.natDegree_le_of_dvd` needs only the divisor monic |
+| `(aeval M minpoly).mulVec v = 0` | line 64-67 | unchanged |
+| `(minpoly).natDegree ≥ n` from cyclic | line 68-72 | unchanged — `minpoly.ne_zero` needs `Nontrivial R` |
+| Extract quotient `r`: `charpoly = minpoly * r` | line 77 | unchanged |
+| `r.Monic` from `Monic.of_mul_monic_left` | line 79-80 | unchanged — `Monic.of_mul_monic_left` works over `Semiring R` |
+| **Sum of `natDegree`s** | line 83-84 | **SWAP**: `Polynomial.natDegree_mul` (which requires `IsDomain R`) → `(minpoly.monic _).natDegree_mul' hr_monic.ne_zero` (uses `Polynomial.Monic.natDegree_mul'` at `Mathlib/Algebra/Polynomial/Monic.lean:154`, only needs one factor monic and the other nonzero — works over any `Semiring R`) |
+| Closing: `r.natDegree = 0`, `r.coeff 0 = 1`, `r = 1` | line 88-95 | unchanged — `eq_C_of_natDegree_eq_zero` and `Monic.leadingCoeff` work over `Semiring R` |
+
+So the entire backward direction transfers to `CommRing R + Nontrivial R`
+with a single 1-line lemma-name swap. This is the meat of the S2 ACT.
+
+## Mathlib API verification log
+
+All API names verified at pinned commit
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via
+`gh api repos/leanprover-community/mathlib4/contents/...` lookups.
+
+| Mathlib name | Location | Typeclass | Verified |
+|--------------|----------|-----------|----------|
+| `minpoly` (def) | `FieldTheory/Minpoly/Basic.lean:41` | `[CommRing A] [Ring B] [Algebra A B]` | ✓ |
+| `minpoly.monic` | `FieldTheory/Minpoly/Basic.lean:54` | `[CommRing A] [Ring B] [Algebra A B]` + `IsIntegral A x` | ✓ |
+| `minpoly.ne_zero` | `FieldTheory/Minpoly/Basic.lean:60` | adds `[Nontrivial A]` | ✓ |
+| `minpoly.aeval` | `FieldTheory/Minpoly/Basic.lean:88` | `[CommRing A] [Ring B] [Algebra A B]` | ✓ |
+| `Matrix.isIntegral` | `LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44` | `[CommRing R]` | ✓ |
+| `Polynomial.Monic.of_mul_monic_left` | `Algebra/Polynomial/Monic.lean:110` | `[Semiring R]` | ✓ |
+| `Polynomial.Monic.natDegree_mul'` | `Algebra/Polynomial/Monic.lean:154` | `[Semiring R]` + `p.Monic` + `q ≠ 0` | ✓ |
+| `Polynomial.Monic.natDegree_mul` | `Algebra/Polynomial/Monic.lean:141` | `[Semiring R]` + both `Monic` | ✓ (alternative; needs both monic) |
+
+Sample verification command:
+```bash
+gh api "repos/leanprover-community/mathlib4/contents/Mathlib/Algebra/Polynomial/Monic.lean" \
+  -X GET -f ref=2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 --jq '.content' \
+  | base64 --decode \
+  | sed -n '141,156p'
+```
+
+confirms the lemma signature at the pinned revision.
+
+## Risk analysis for S2 (Approach A — backward extension)
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `GeneralCyclicVector` namespace from parent file has hidden `[Field K]` typeclass that doesn't generalise | Low | S2 SCAFFOLD does a `grep` of `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` for the `GeneralCyclicVector.IsCyclicVector` definition; if `Field K` is hard-coded, S2 defines a fresh `GeneralCyclicVectorCommRing` namespace in the new file. |
+| `Polynomial.Monic.natDegree_mul'` lemma name has drifted at v4.26.0 | Very low | Verified above at the pinned commit. |
+| `Monic.eq_one_iff_natDegree_le_zero` doesn't exist (used in proof skeleton's last line) | Medium | Use `eq_C_of_natDegree_eq_zero` + `Monic.leadingCoeff` chain (the pattern used in the field file's lines 88-93) — verified to work over `Semiring`. |
+| Build-pending: parent file `CayleyHamiltonCyclicVectorAllFields.lean` has Mathlib v4.26.0 drift | Low | The OQ01OQ01 build was clean as of 2026-05-12 per `meta.json` `mathlib_version: 4.26.0`. Same Mathlib API surface used. |
+| `Matrix.charpoly_monic` requires `Nontrivial R`, breaks for `R = Subsingleton`-classified | None | Adding `[Nontrivial R]` to the theorem statement is harmless. |
+
+## Risk analysis for S3 (Approach B — `ZMod 4` counterexample)
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `decide` can't close `(aeval M (2*X)).mulVec v = 0` over `ZMod 4` (finiteness needed) | Medium | `(ZMod 4)^2` has only 16 elements; if `decide` times out, fall back to explicit `interval_cases` on `Fin 4` for each of `a, b`. |
+| `Polynomial.natDegree (2 * X)` in `(ZMod 4)[X]` may simplify unexpectedly (e.g., if `Mathlib` proves `natDegree (2*X : (ZMod 4)[X]) = ?` differently than expected) | Low | Use `Polynomial.natDegree_C_mul_X` (if `c ≠ 0`) or compute via explicit `Polynomial.natDegree (C 2 * X)`. In `ZMod 4`, `2 ≠ 0` so this works. |
+| `M^2 = 0` calculation needs careful `Matrix.mul_apply` unfolding | Low | 2×2 matrix multiplication is closed-form; `decide` or `ext; simp [Matrix.mul_apply, Fin.sum_univ_succ]` should close. |
+
+## Possible follow-ups beyond S4
+
+- **Status of forward direction over an integral domain `R`**: the
+  primary-decomposition proof in
+  `CayleyHamiltonCyclicVectorAllFields.lean` relies on the
+  factorisation `μ_M = ∏ p_i^{e_i}` of the minimal polynomial into
+  distinct monic irreducible primes. Over a UFD this still holds for
+  monic polynomials in `R[X]` (Gauss's lemma), but the linkage between
+  the primary decomposition of `R[X]/(μ_M)` and the structure of
+  `Module R^n` over `R[X]` needs `R[X]` to be a 1-dimensional domain
+  (PID) for the full module-theoretic decomposition. The question of
+  whether the forward direction extends to UFDs that are not PIDs
+  (e.g., `ℤ`) is mathematically subtle and may have a positive answer
+  for matrices whose `charpoly` has unit content.
+
+- **Connection to invariant-factor theorem**: a cleaner formulation
+  may be: over a PID `R`, the forward direction holds iff `charpoly M`
+  has unit content (so that `R^n` is a cyclic `R[X]`-module). This
+  would link this OQ to the invariant-factor decomposition of
+  `Module R[X] R^n` and the Smith normal form. Worth surveying in a
+  later iteration.
+
+## Open questions (for future sessions)
+
+1. Does the forward direction extend to `R` an integral domain?
+   (Likely yes for PIDs; subtle for UFDs.)
+
+2. Is there a clean "module-theoretic" reformulation of the
+   biconditional that subsumes all the directions uniformly? E.g., is
+   the biconditional equivalent to "Module R^n via M-action is a
+   cyclic `R[X]`-module"?
+
+3. Over `R = ZMod p^k` for `k ≥ 2` (a non-field but non-domain
+   commutative ring), does the structure theorem for finite abelian
+   groups give a clean characterization of which `M` admit cyclic
+   vectors?

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,257 @@
+# Problem: Cyclic Vector Theorem — Biconditional over Commutative Rings (OQ extension 01)
+
+## Statement
+
+### Plain Language
+
+The gallery entry [`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01`](../../../src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01/meta.json)
+proves, over an arbitrary field `K`, the biconditional
+
+> `IsNonderogatory M ↔ ∃ v, IsCyclicVector M v`
+
+for `M : Matrix (Fin n) (Fin n) K`. The first listed open question on that
+entry asks whether the biconditional extends to matrices over commutative
+(Noetherian) rings, not just fields. This slug investigates that
+extension.
+
+### Formal Statement
+
+Let `R` be a (nontrivial) commutative ring, `n : ℕ`, and
+`M : Matrix (Fin n) (Fin n) R`. Define, mirroring the gallery file
+[`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean`](../../../proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean):
+
+```
+IsCyclicVector M v  :=  ∀ p : R[X], p.natDegree < n →
+                          (aeval M p).mulVec v = 0 → p = 0
+IsNonderogatory M   :=  minpoly R M = M.charpoly
+```
+
+The OQ asks: does
+
+$$\text{IsNonderogatory}(M) \;\iff\; \exists\, v,\ \text{IsCyclicVector}(M,\, v)$$
+
+hold over every commutative ring `R`? If not, identify the largest class
+of rings for which each direction holds, and exhibit explicit
+counterexamples in the remaining cases.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - seeker-selected
+  - generalization
+  - gallery-extracted
+  - commutative-rings
+  - cyclic-vector
+```
+
+**Significance**: 6/10 — clarifies the precise ring-theoretic boundary
+of the cyclic vector characterization, which is the cornerstone of
+rational canonical form theory.
+
+**Tractability**: 5/10 — the *backward* direction extends cleanly to any
+commutative ring with a short proof tweak; the *forward* direction
+fails over non-domains (with an explicit `ℤ/4ℤ` counterexample) and is
+subtle to settle over general integral domains.
+
+## Why This Matters
+
+1. **Sharper structure theorem.** Rational canonical form (RCF) is
+   classical over a field; the cyclic-vector biconditional is the
+   bridge between "nonderogatory" (algebraic condition on `minpoly`)
+   and "similar to a single companion matrix" (geometric condition on
+   the action of `M`). Pinning down which rings support each direction
+   tells us exactly where RCF generalises and where it breaks.
+
+2. **Mathlib gap.** Mathlib has `Matrix.isIntegral` and `minpoly` for
+   arbitrary `[CommRing R]` (see API map below) but stops at
+   `minpoly_dvd_charpoly` requiring `[Field K]` (Charpoly/Minpoly.lean
+   line 47). The backward direction's extension to `CommRing R` is a
+   small but real gap-fill.
+
+3. **Counterexample is concrete.** Over `ℤ/4ℤ`, the matrix
+   `M = [[0,2],[0,0]]` is nonderogatory (both `minpoly` and `charpoly`
+   equal `X^2`) yet admits NO cyclic vector — every `v ∈ (ℤ/4ℤ)^2` is
+   annihilated by some nonzero polynomial of degree `< 2`. The
+   forward direction is genuinely false over non-domains; the OQ is
+   not vacuous.
+
+## Status of the Two Directions (S1 OBSERVE summary)
+
+### Backward direction (cyclic ⇒ nonderogatory)
+
+**Conjecture**: extends to any nontrivial commutative ring `R`.
+
+The existing field-proof in
+`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean` uses four Mathlib
+facts:
+
+| Fact | Mathlib location | Typeclass requirement |
+|------|------------------|-----------------------|
+| `minpoly.dvd` | `FieldTheory/Minpoly/Basic.lean:200`-ish | `[CommRing A] [Ring B] [Algebra A B]` |
+| `Matrix.isIntegral` | `LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44` | `[CommRing R]` |
+| `Polynomial.Monic.of_mul_monic_left` | `Algebra/Polynomial/Monic.lean:110` | `[Semiring R]` |
+| `Polynomial.natDegree_mul` | `Algebra/Polynomial/Basic.lean` (domain) | `[IsDomain R]` for the version used in the field file |
+
+Only the fourth fact requires the base ring to be a domain. **The fix**:
+swap the call
+
+```lean
+Polynomial.natDegree_mul (minpoly.ne_zero _) hr_monic.ne_zero
+```
+
+for
+
+```lean
+(minpoly.monic _).natDegree_mul' hr_monic.ne_zero
+```
+
+which is `Polynomial.Monic.natDegree_mul'` at
+`Mathlib/Algebra/Polynomial/Monic.lean:154` — it requires only one factor
+to be monic and the other to be nonzero, **no domain hypothesis**.
+This is the entire technical bridge.
+
+### Forward direction (nonderogatory ⇒ ∃ cyclic vector)
+
+**FAILS** over `ℤ/4ℤ` (and presumably any non-domain). Counterexample
+worked out in §S1 of `knowledge.md`:
+
+```
+R = ZMod 4,    M = !![0, 2; 0, 0] : Matrix (Fin 2) (Fin 2) (ZMod 4)
+```
+
+Then `M.charpoly = X^2`, `minpoly (ZMod 4) M = X^2`, so
+`IsNonderogatory M`. But for every `v = (a, b) ∈ (ZMod 4)^2`, the
+polynomial `2X` (or `X` if `b = 0`) satisfies `natDegree < 2` and
+annihilates `v` under `aeval M`, witnessing `¬ IsCyclicVector M v`.
+The existential ∃ v IsCyclicVector M v is false.
+
+**Open over integral domains.** Whether the forward direction extends
+to `R` an integral domain (e.g. `ℤ`) is conjecturally true (the
+primary-decomposition argument over a PID or UFD should still work),
+but the parent file's proof goes via `CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector`,
+which uses `K[X]` being a PID/UFD with monic-irreducible factorization
+(`UniqueFactorizationMonoid`). Mathlib provides
+`UniqueFactorizationMonoid` for `K[X]` only when `K` is a field; for
+`R[X]` over a UFD `R`, Mathlib has
+`Polynomial.uniqueFactorizationMonoid` which depends on `R` being a
+UFD. So the forward direction *might* extend to UFDs but the proof
+needs reworking.
+
+## Three Approaches
+
+### Approach A — Backward-only extension (recommended for S2)
+
+Write a new file `CayleyHamiltonCyclicVectorCommRingOQ01.lean`
+(~50 LOC) that:
+
+1. Generalises `IsCyclicVector` and `IsNonderogatory` to a `CommRing R`
+   base.
+2. Proves `cyclic_implies_nonderogatory_commring` by the same
+   degree-squeeze, with the `natDegree_mul` swap above.
+3. States the forward direction as an open theorem with a strategic
+   `sorry` and a docstring pointing to the `ℤ/4ℤ` counterexample.
+
+Pro: very short, completes the easy half, lands a definitive negative
+result on the hard half.
+
+Con: doesn't actually advance the gallery on the forward direction.
+
+### Approach B — Counterexample formalisation (recommended for S3)
+
+Write `CayleyHamiltonCyclicVectorZMod4Counterexample.lean` (~40 LOC):
+
+1. Define `M : Matrix (Fin 2) (Fin 2) (ZMod 4)` as `!![0, 2; 0, 0]`.
+2. Compute `M.charpoly = X^2` (via `Matrix.charpoly_fin_two` or
+   directly).
+3. Compute `minpoly (ZMod 4) M = X^2` by exhibiting the lower bound
+   (`X` doesn't annihilate) and the upper bound (`M^2 = 0`).
+4. Prove `¬ ∃ v, IsCyclicVector M v` by case analysis on `v ∈
+   (ZMod 4)^2` (finite, 16 cases — `decide` should close it, or 4-row
+   `interval_cases` over `Fin 4`).
+5. Conclude the forward direction `IsNonderogatory M → ∃ v,
+   IsCyclicVector M v` is **false** for this `M`.
+
+Pro: concrete obstruction; settles the OQ negatively over non-domains
+with a fully verified counterexample.
+
+Con: doesn't directly extend the gallery theorem; needs a small
+companion gallery entry to surface the result.
+
+### Approach C — Domain extension via UFD primary decomposition
+
+Write `CayleyHamiltonCyclicVectorAllUFDsOQ01.lean` (~150-300 LOC):
+
+1. Generalise the parent file
+   `CayleyHamiltonCyclicVectorAllFields.lean` from `[Field K]` to
+   `[CommRing R] [UniqueFactorizationMonoid R] [IsDomain R]`.
+2. The factorisation bridge needs `R[X]` to inherit
+   `UniqueFactorizationMonoid` (Mathlib's
+   `Polynomial.uniqueFactorizationMonoid` instance).
+3. The primary decomposition step is the bulk of the rewrite — depends
+   on whether the `ker (aeval M p^k)` lemma extends past fields.
+
+Pro: a substantial extension of the gallery.
+
+Con: significantly more work; the proof depends crucially on the
+`Module.End R^n` decomposition into primary components, which is more
+delicate over non-fields.
+
+## Recommended S2 → S3 sequence
+
+1. **S2 (Approach A)**: backward-only extension to `CommRing R`. ~50
+   LOC, single PR, doc-only counterexample reference.
+2. **S3 (Approach B)**: formalise the `ZMod 4` counterexample.
+   ~40 LOC, settles forward direction NO over non-domains.
+3. **S4 (Approach C)**: optional — attempt UFD extension of the
+   forward direction. Higher risk; defer until S2+S3 land.
+
+Net: S2+S3 give a clean "the field biconditional bifurcates over
+commutative rings — backward extends, forward fails by ℤ/4ℤ" result.
+
+## Mathlib API Map (pinned to commit `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+| API | Location | Typeclass |
+|-----|----------|-----------|
+| `minpoly` def | `Mathlib/FieldTheory/Minpoly/Basic.lean:41` | `[CommRing A] [Ring B] [Algebra A B]` |
+| `minpoly.monic` | `Mathlib/FieldTheory/Minpoly/Basic.lean:54` | `[CommRing A] [Ring B] [Algebra A B]` + `IsIntegral A x` |
+| `minpoly.ne_zero` | `Mathlib/FieldTheory/Minpoly/Basic.lean:60` | `[CommRing A] [Ring B] [Algebra A B] [Nontrivial A]` |
+| `minpoly.aeval` | `Mathlib/FieldTheory/Minpoly/Basic.lean:88` | `[CommRing A] [Ring B] [Algebra A B]` |
+| `minpoly.dvd` | `Mathlib/FieldTheory/Minpoly/Basic.lean` (Ring section) | `[CommRing A] [Ring B] [Algebra A B]` |
+| `Matrix.isIntegral` | `Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44` | `[CommRing R]` |
+| `Matrix.aeval_self_charpoly` | (Cayley-Hamilton, exported) | `[CommRing R]` |
+| `Polynomial.Monic.of_mul_monic_left` | `Mathlib/Algebra/Polynomial/Monic.lean:110` | `[Semiring R]` |
+| `Polynomial.Monic.natDegree_mul'` | `Mathlib/Algebra/Polynomial/Monic.lean:154` | `[Semiring R]`, needs `p.Monic` + `q ≠ 0` |
+| `Polynomial.eq_C_of_natDegree_eq_zero` | `Mathlib/Algebra/Polynomial/Degree/Definitions.lean` | `[Semiring R]` |
+| `Matrix.charpoly_natDegree_eq_dim` | `Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean` | `[CommRing R]` |
+| `Matrix.charpoly_monic` | `Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean` | `[CommRing R]` + `Nontrivial R` |
+
+Every API in the existing field-proof is available over `[CommRing R]`
+with appropriate `Nontrivial R` decoration. The only swap needed for
+the backward direction is `Polynomial.natDegree_mul` →
+`Polynomial.Monic.natDegree_mul'`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `cayley-hamilton-cyclic-vector-all-fields` | Parent (forward direction over fields) |
+| `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01` | Direct ancestor (full biconditional over fields); source of this OQ |
+| `cayley-hamilton-cyclic-vector-all-fields-oq-01` | Sibling (factorisation bridge via Multiset UFD) |
+| `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02` | Sibling (companion-matrix similarity) |
+| `cayley-hamilton-minpoly` | Ancestor (general minpoly theory) |
+
+## References
+
+- Hoffman & Kunze, *Linear Algebra* (2nd ed.), Chapter 7 (RCF over a
+  field; the biconditional is stated implicitly via the structure
+  theorem for finitely-generated modules over a PID).
+- Dummit & Foote, *Abstract Algebra* (3rd ed.), §12.1-12.2 (modules
+  over a PID, invariant-factor decomposition).
+- Jacobson, *Basic Algebra II* (2nd ed.), §3.7 (cyclic-vector
+  characterisation over fields; ring-extensions discussed in §3.10).
+- Mathlib `Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean` — the
+  current API boundary for the over-CommRing extension.

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,217 @@
+# Current State
+
+**Phase**: OBSERVE (S1 — slug bootstrap with backward/forward dichotomy)
+**Since**: 2026-05-14
+**Iteration**: 1
+
+## Latest Iteration: S1 OBSERVE (researcher-9, 2026-05-14)
+
+Doc-only S1 OBSERVE iteration bootstrapping the slug from seeker stub
+(phase NEW, knowledge score 0, "formal statement to be added") to a
+complete survey with explicit backward/forward dichotomy.
+
+### S1 Headline Finding
+
+The biconditional **bifurcates** over commutative rings:
+
+| Direction | Status over `CommRing R` |
+|-----------|--------------------------|
+| **Backward**: `(∃ v, IsCyclicVector M v) → IsNonderogatory M` | **Extends** to any nontrivial commutative ring. Single proof-tweak from the existing field-proof: replace `Polynomial.natDegree_mul` (needs domain) with `Polynomial.Monic.natDegree_mul'` (needs only one factor monic and the other nonzero). |
+| **Forward**: `IsNonderogatory M → ∃ v, IsCyclicVector M v` | **Fails** over `ZMod 4` with explicit counterexample `M = !![0, 2; 0, 0]`. Status over integral domains and UFDs is open. |
+
+### Counterexample sketch (full details in `knowledge.md`)
+
+Take `R = ZMod 4`, `M = !![0, 2; 0, 0] : Matrix (Fin 2) (Fin 2) (ZMod 4)`.
+
+- **`charpoly M = X^2`**: `M.charpoly = X^2 - tr(M)·X + det(M)·1 = X^2 - 0 - 0 = X^2`.
+- **`minpoly (ZMod 4) M = X^2`**: `M^2 = 0` (so `X^2` annihilates), and
+  no monic polynomial `X - c` of degree 1 annihilates `M` (because
+  `M - cI = !![-c, 2; 0, -c] ≠ 0` for every `c : ZMod 4`, since the
+  `[0,1]`-entry is `2 ≠ 0`).
+- **`IsNonderogatory M`** holds (`minpoly = charpoly = X^2`).
+- **No cyclic vector exists**: for every `v = (a, b) ∈ (ZMod 4)^2`, set
+  `p := 2X` if `b ≠ 0`, or `p := X` if `b = 0`. Direct calculation:
+  - `aeval M (2X) = 2M = !![0, 4; 0, 0] = !![0, 0; 0, 0] = 0` as a
+    matrix (since `4 ≡ 0 mod 4`), so `(aeval M (2X)).mulVec v = 0` for
+    any `v`. With `2X ≠ 0` and `natDegree (2X) = 1 < 2`, this witnesses
+    `¬ IsCyclicVector M v` for every `v` with `b ≠ 0`.
+  - For `b = 0`: `Mv = (0, 0)`, so `aeval M (X) v = M v = 0`, with
+    `X ≠ 0` and `natDegree X = 1 < 2`, witnessing
+    `¬ IsCyclicVector M v` for every `v` with `b = 0`.
+- **Conclusion**: `IsNonderogatory M ∧ ¬ ∃ v, IsCyclicVector M v` —
+  forward direction is false at `M`.
+
+### Mathlib API Verification
+
+All five Mathlib facts the existing field-proof uses have been confirmed
+present at the pinned commit `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+with their typeclass requirements relaxed enough to support
+`[CommRing R]`:
+
+| Mathlib name | Location | Suffices for backward direction? |
+|--------------|----------|--------------------------------|
+| `minpoly.monic` | `FieldTheory/Minpoly/Basic.lean:54` | ✓ `CommRing A` |
+| `minpoly.ne_zero` | `FieldTheory/Minpoly/Basic.lean:60` | ✓ `CommRing A + Nontrivial A` |
+| `minpoly.aeval` | `FieldTheory/Minpoly/Basic.lean:88` | ✓ `CommRing A` |
+| `minpoly.dvd` | `FieldTheory/Minpoly/Basic.lean` (Ring section) | ✓ `CommRing A` |
+| `Matrix.isIntegral` | `LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44` | ✓ `CommRing R` |
+| `Polynomial.Monic.natDegree_mul'` | `Algebra/Polynomial/Monic.lean:154` | ✓ `Semiring R` (replaces `Polynomial.natDegree_mul`) |
+| `Polynomial.Monic.of_mul_monic_left` | `Algebra/Polynomial/Monic.lean:110` | ✓ `Semiring R` |
+| `Matrix.charpoly_monic` | `LinearAlgebra/Matrix/Charpoly/Basic.lean` | ✓ `CommRing R + Nontrivial R` |
+| `Matrix.charpoly_natDegree_eq_dim` | `LinearAlgebra/Matrix/Charpoly/Coeff.lean` | ✓ `CommRing R + Nontrivial R` |
+
+Each verified by `gh api repos/leanprover-community/mathlib4/contents/<file>?ref=<pin>` lookup against the gallery's
+Mathlib pin.
+
+### Deliverables in this iteration
+
+1. `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/problem.md`
+   — full problem statement, three-approach decomposition, Mathlib API
+   map. (~260 lines, doc-only.)
+2. `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md`
+   — this file.
+3. `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/knowledge.md`
+   — S1 session note: counterexample worked example with `b = 0` /
+   `b ≠ 0` case split, Mathlib pin verification log, domain-extension
+   risk analysis.
+4. `src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json`
+   — research registry update (phase `NEW` → `OBSERVE`, knowledge score
+   `0` → roughly `14`, problem statement filled in).
+
+**No Lean changes** in this S1 iteration. All four existing files in the
+chain (`CayleyHamiltonCyclicVectorAllFields.lean`,
+`CayleyHamiltonCyclicVectorAllFieldsAristotle.lean`,
+`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean`,
+`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean`) are unmodified.
+
+## Active Approach
+
+**Approach A → B → (optional) C**: backward extension to `CommRing R`,
+then `ZMod 4` counterexample formalisation, then optional UFD attempt
+on forward direction. Detailed in `problem.md` §"Three Approaches".
+
+## Blockers
+
+None mathematical or practical for S2.
+
+## Next Action
+
+**S2 ACT (Approach A — backward extension)**: substantive Lean PR adding
+`proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (~50 LOC):
+
+1. Generalised definitions (`namespace GeneralCyclicVectorRing` or
+   reuse parent's `GeneralCyclicVector` if its typeclass can be
+   loosened — verify in S2 SCAFFOLD):
+   ```lean
+   def IsCyclicVector {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+       (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R) : Prop :=
+     ∀ p : R[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0
+
+   def IsNonderogatory {R : Type*} [CommRing R] {n : ℕ}
+       (M : Matrix (Fin n) (Fin n) R) : Prop :=
+     minpoly R M = M.charpoly
+   ```
+
+2. The backward theorem (mirror of `cyclic_implies_nonderogatory`):
+   ```lean
+   theorem cyclic_implies_nonderogatory_commring
+       {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+       (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R)
+       (hcyc : IsCyclicVector M v) :
+       IsNonderogatory M := by
+     unfold IsNonderogatory
+     have hdvd : minpoly R M ∣ M.charpoly :=
+       minpoly.dvd R M (Matrix.aeval_self_charpoly M)
+     have hchar_monic : M.charpoly.Monic := Matrix.charpoly_monic M
+     have hchar_deg : M.charpoly.natDegree = n := by
+       rw [Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin]
+     have hle : (minpoly R M).natDegree ≤ n :=
+       Polynomial.natDegree_le_of_dvd hdvd hchar_monic.ne_zero |>.trans_eq hchar_deg
+     have hge : n ≤ (minpoly R M).natDegree := by
+       by_contra hlt; push_neg at hlt
+       have hann : (aeval M (minpoly R M)).mulVec v = 0 := by
+         rw [minpoly.aeval]; exact Matrix.zero_mulVec v
+       exact absurd (hcyc (minpoly R M) hlt hann)
+         (minpoly.ne_zero (Matrix.isIntegral M))
+     have hdeg : (minpoly R M).natDegree = n := Nat.le_antisymm hle hge
+     obtain ⟨r, hr⟩ := hdvd
+     have hmin_monic : (minpoly R M).Monic := minpoly.monic (Matrix.isIntegral M)
+     have hr_monic : r.Monic := hmin_monic.of_mul_monic_left (hr ▸ hchar_monic)
+     have hr_natdeg : r.natDegree = 0 := by
+       have hmul := hmin_monic.natDegree_mul' hr_monic.ne_zero
+       have hprod_deg : (minpoly R M * r).natDegree = n := by rw [← hr, hchar_deg]
+       linarith [hdeg]
+     have hr_eq : r = 1 := hr_monic.eq_one_iff_natDegree_le_zero.mpr (le_of_eq hr_natdeg)
+     -- (the last line may need `Monic.eq_one_iff_natDegree_le_zero` or
+     -- equivalent; S2 SCAFFOLD will pin the exact lemma name.)
+     rw [hr, hr_eq, mul_one]
+   ```
+
+3. Corollaries mirroring the field file's structure
+   (`derogatory_has_no_cyclic_vector_commring`,
+   `minpoly_natDegree_of_cyclic_commring`).
+
+4. Docstring callout to the `ZMod 4` counterexample showing the
+   forward direction does NOT extend, with a `#check
+   CayleyHamiltonCyclicVectorZMod4Counterexample.no_cyclic_vector`
+   stub for the S3 follow-up.
+
+Estimated effort for S2: 1 session, single PR, ~60 LOC of new Lean,
+Docker build verification straightforward (no parent-file blockers in
+chain at v4.26.0 per the existing OQ01OQ01 build history). No
+dependencies beyond Mathlib.
+
+## Future Iterations (Deferred)
+
+**S3 (Approach B — counterexample formalisation)**: ~40 LOC,
+`proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean`
+formalising the `M = !![0, 2; 0, 0]` example with three theorems:
+
+- `charpoly_eq_X_sq`: `M.charpoly = X^2`
+- `minpoly_eq_X_sq`: `minpoly (ZMod 4) M = X^2`
+- `no_cyclic_vector`: `¬ ∃ v, IsCyclicVector M v`
+
+Combined with S2's `cyclic_implies_nonderogatory_commring` and the
+parent's `IsNonderogatory` definition, this provides a fully verified
+witness that the **forward direction of the biconditional is false
+over `ZMod 4`**, settling the OQ negatively over non-domains.
+
+**S4 (Approach C — optional UFD extension of forward direction)**:
+attempt to generalise the parent file
+`CayleyHamiltonCyclicVectorAllFields.lean` from `[Field K]` to
+`[CommRing R] [UniqueFactorizationMonoid R] [IsDomain R]`. Higher risk,
+~150-300 LOC; defer until S2+S3 land.
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 OBSERVE, this iteration)
+- Current approach attempts: 0 (no Lean changes yet)
+- Approaches tried: 0 (3 surveyed: A=backward over CommRing,
+  B=ZMod 4 counterexample, C=UFD forward extension)
+
+## Open files
+
+- `problem.md` — full problem statement, three approaches, Mathlib API map.
+- `knowledge.md` — S1 session note: counterexample case split,
+  Mathlib pin verification, domain-extension analysis.
+
+## S1 Deliverable Honesty Summary
+
+This iteration is **survey-only**:
+
+- 0 new Lean theorems
+- 0 new sorries
+- 0 axiom changes
+- 0 Lean files modified
+- Build pending (no Lean delta to verify)
+
+Produced:
+
+- `problem.md` (~260 lines)
+- `state.md` (this file)
+- `knowledge.md` (counterexample case analysis)
+- `src/data/research/problems/<slug>.json` (registry update)
+
+This is a doc-only `*-OBSERVE` PR per the precedent of
+`bezout-identity-oq-01-oq-01-oq-01-oq-01` (PR #17990) and
+`lagrange-theorem-oq-01-oq-01-oq-01` S1 (PR #17782).

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json
@@ -1,0 +1,144 @@
+{
+  "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01",
+  "title": "Cyclic Vector Theorem: Full Biconditional — OQ extension (01)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall R \\ \\text{nontrivial CommRing}, \\forall n \\in \\mathbb{N}, \\forall M : \\text{Matrix}(\\text{Fin}\\,n)(\\text{Fin}\\,n)\\,R : \\quad \\text{IsNonderogatory}(M) \\iff \\exists v, \\text{IsCyclicVector}(M, v)?",
+    "plain": "Does the cyclic-vector-theorem biconditional `IsNonderogatory M ↔ ∃ v, IsCyclicVector M v`, proved over fields in cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01, extend to matrices over commutative rings? S1 OBSERVE finds: the backward direction (cyclic ⇒ nonderogatory) extends to any nontrivial commutative ring R via a single 1-line lemma swap (Polynomial.natDegree_mul → Polynomial.Monic.natDegree_mul'). The forward direction (nonderogatory ⇒ cyclic vector) FAILS over ZMod 4 with explicit counterexample M = !![0, 2; 0, 0].",
+    "whyMatters": [
+      "Sharpens the boundary of the rational canonical form theorem: pins down which rings support each direction of the cyclic-vector characterization.",
+      "Mathlib gap: minpoly_dvd_charpoly is currently stated only for Field K (Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:47), but the backward direction extends cleanly to CommRing.",
+      "Forward direction provably fails over non-domain commutative rings: explicit counterexample M = !![0, 2; 0, 0] over ZMod 4 is nonderogatory yet admits no cyclic vector. OQ is not vacuous."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "S1 OBSERVE: backward direction (cyclic ⇒ nonderogatory) extends to any nontrivial CommRing R via Polynomial.Monic.natDegree_mul' (Mathlib/Algebra/Polynomial/Monic.lean:154). All five other Mathlib API calls in the field proof (minpoly.{monic,ne_zero,aeval,dvd}, Matrix.isIntegral, Polynomial.Monic.of_mul_monic_left) already support CommRing.",
+      "S1 OBSERVE: forward direction (nonderogatory ⇒ ∃ cyclic vector) FAILS over ZMod 4 with M = !![0, 2; 0, 0]. Explicit worked example (charpoly = X^2, minpoly = X^2, IsNonderogatory holds; for every v ∈ (ZMod 4)^2, either 2*X or X annihilates v under aeval M of degree < 2)."
+    ],
+    "open": [
+      "Does forward direction extend to integral domains? Likely yes for PIDs (e.g., ℤ); subtle for UFDs that are not PIDs.",
+      "Is the biconditional equivalent to: \"Module R^n via M-action is a cyclic R[X]-module\"? If so, this provides a uniform reformulation.",
+      "Over ZMod p^k for k ≥ 2 (a non-field, non-domain commutative ring), can the structure theorem for finite abelian groups characterize cyclic vectors directly?"
+    ],
+    "goal": "Prove the backward direction (cyclic ⇒ nonderogatory) over CommRing R; formalize the ZMod 4 counterexample falsifying the forward direction. Stretch goal: settle forward direction over PIDs/UFDs."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-14T21:39:00.000Z",
+    "iteration": 1,
+    "focus": "S1 OBSERVE complete: backward direction extends to CommRing R; forward direction fails over ZMod 4 with explicit M = !![0, 2; 0, 0] counterexample.",
+    "blockers": [],
+    "nextAction": "S2 ACT (Approach A): write proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean (~60 LOC) generalizing IsCyclicVector / IsNonderogatory to CommRing R and proving cyclic_implies_nonderogatory_commring via Polynomial.Monic.natDegree_mul' swap. Single PR, Docker build verification straightforward.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 OBSERVE (researcher-9, 2026-05-14): the biconditional bifurcates over commutative rings. Backward direction extends to any nontrivial CommRing R via a single Polynomial.Monic.natDegree_mul' swap; forward direction fails over ZMod 4 with explicit M = !![0, 2; 0, 0] counterexample (charpoly = minpoly = X^2 but no cyclic vector exists). Mathlib API verified at pinned commit 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 — 9 lemmas confirmed available over CommRing.",
+    "builtItems": [
+      "Wrote research/problems/<slug>/problem.md (~260 lines) with three approaches (A=backward extension, B=ZMod 4 counterexample, C=UFD forward extension), Mathlib API map at pinned commit.",
+      "Wrote research/problems/<slug>/state.md with phase OBSERVE, S2 next action (Approach A), suggested ACT skeleton (~60 LOC of Lean for cyclic_implies_nonderogatory_commring).",
+      "Wrote research/problems/<slug>/knowledge.md with full counterexample case analysis (b = 0 vs b ≠ 0), Mathlib API verification log, S2/S3 risk inventory."
+    ],
+    "insights": [
+      "Polynomial.Monic.natDegree_mul' at Mathlib/Algebra/Polynomial/Monic.lean:154 requires only the leading factor to be monic and the other factor nonzero. Over a CommRing R that is not a domain, this is the right replacement for Polynomial.natDegree_mul (which needs both nonzero in a domain) and unlocks the backward direction.",
+      "Matrix.isIntegral at Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44 already works over [CommRing R]; the proof is just ⟨charpoly_monic, aeval_self_charpoly⟩. The existing gallery proof uses this implicitly via Field K instances; no change needed for the CommRing extension.",
+      "minpoly over a CommRing A (FieldTheory/Minpoly/Basic.lean:41) is the monic generator of the annihilator ideal of an integral element. For matrices, charpoly always provides a monic annihilator (Cayley-Hamilton), so Matrix.isIntegral is automatic and minpoly is always well-defined.",
+      "Counterexample M = !![0, 2; 0, 0] over ZMod 4: charpoly = X^2 (det of upper triangular = X^2). minpoly = X^2 (M^2 = 0 gives upper bound; no X-c monic deg-1 annihilator since the [0,1]-entry 2 ≠ 0 in ZMod 4 cannot be killed by adding cI). IsNonderogatory ✓. For every v=(a,b), p = 2X annihilates if b ≠ 0 (since 2M = 0 as a matrix because the only nonzero entry is 2 in position [0,1] and 2·2=4=0 in ZMod 4), p = X annihilates if b = 0 (since Mv = (2b, 0) = 0). So no cyclic vector. Forward direction FAILS."
+    ],
+    "mathlibGaps": [
+      "Mathlib Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:47 states minpoly_dvd_charpoly only for [Field K]; the lemma extends cleanly to [CommRing R] using minpoly.dvd + aeval_self_charpoly. Small gap-fill opportunity."
+    ],
+    "nextSteps": [
+      "S2 ACT (Approach A): write proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean (~60 LOC). Generalize IsCyclicVector / IsNonderogatory definitions to [CommRing R] [Nontrivial R] and prove cyclic_implies_nonderogatory_commring via Polynomial.Monic.natDegree_mul' swap.",
+      "S3 ACT (Approach B): formalize ZMod 4 counterexample in proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean (~40 LOC). Three theorems: charpoly_eq_X_sq, minpoly_eq_X_sq, no_cyclic_vector. Settles forward direction = FALSE over non-domains.",
+      "S4 ACT (Approach C, optional): attempt forward direction over UFDs by generalizing parent file CayleyHamiltonCyclicVectorAllFields.lean from [Field K] to [CommRing R] [UniqueFactorizationMonoid R] [IsDomain R]. Higher risk, ~150-300 LOC; defer until S2+S3 land."
+    ]
+  },
+  "tags": [
+    "commutative-rings",
+    "counterexample-zmod4",
+    "cyclic-vector",
+    "gallery-extracted",
+    "generalization",
+    "observe-bootstrap",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-cyclic-vector-all-fields",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02"
+  ],
+  "references": {
+    "mathlib": [
+      "Mathlib/FieldTheory/Minpoly/Basic.lean:41 — minpoly def for [CommRing A] [Ring B] [Algebra A B]",
+      "Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44 — Matrix.isIntegral for [CommRing R]",
+      "Mathlib/Algebra/Polynomial/Monic.lean:154 — Polynomial.Monic.natDegree_mul' (replacement for natDegree_mul over non-domain)",
+      "Mathlib/Algebra/Polynomial/Monic.lean:110 — Polynomial.Monic.of_mul_monic_left for [Semiring R]"
+    ],
+    "papers": [
+      "Hoffman & Kunze, Linear Algebra (2nd ed.), Chapter 7 (RCF over a field)",
+      "Dummit & Foote, Abstract Algebra (3rd ed.), §12.1-12.2 (modules over a PID)",
+      "Jacobson, Basic Algebra II (2nd ed.), §3.7, §3.10 (cyclic-vector characterization, ring extensions)"
+    ],
+    "urls": []
+  },
+  "started": "2026-05-13T07:10:22.517Z",
+  "lastUpdate": "2026-05-14T21:39:00.000Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFields.lean",
+      "lineCount": 269,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "lineCount": 133,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean",
+      "lineCount": 137,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean",
+      "lineCount": 689,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

S1 OBSERVE iteration bootstrapping the slug from seeker stub
(phase NEW, empty problem statement) to a complete survey with explicit
backward/forward dichotomy of the cyclic-vector biconditional extension
to commutative rings.

## Headline finding

The biconditional `IsNonderogatory M ↔ ∃ v, IsCyclicVector M v` (true
over fields per gallery entry
[`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01`](https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean))
**bifurcates** over commutative rings:

| Direction | Status over `CommRing R` |
|-----------|--------------------------|
| **Backward**: `(∃ v, IsCyclicVector M v) → IsNonderogatory M` | **Extends** to any nontrivial commutative ring. Single 1-line lemma swap from the existing field-proof: replace `Polynomial.natDegree_mul` (needs `IsDomain`) with `Polynomial.Monic.natDegree_mul'` at `Mathlib/Algebra/Polynomial/Monic.lean:154` (needs only one factor monic, the other nonzero — works over any `Semiring R`). |
| **Forward**: `IsNonderogatory M → ∃ v, IsCyclicVector M v` | **Fails** over `ZMod 4` with explicit counterexample `M = !![0, 2; 0, 0]`. Status over integral domains and UFDs is open. |

## Worked counterexample sketch

`R = ZMod 4, M = !![0, 2; 0, 0] : Matrix (Fin 2) (Fin 2) (ZMod 4)`.

- `charpoly M = X^2` (det of upper-triangular `(X, -2; 0, X)`).
- `minpoly (ZMod 4) M = X^2`: upper bound `M^2 = 0` (since `M[0,1]·M[1,0] = 0`);
  lower bound: no `X - c` annihilates `M` because the `[0,1]`-entry of
  `M - cI` is `2`, which is nonzero in `ZMod 4` regardless of `c`.
- Hence `IsNonderogatory M` (`minpoly = charpoly = X^2`).
- **No cyclic vector**: for every `v = (a, b) ∈ (ZMod 4)^2`, either
  `2X` (if `b ≠ 0`, since `2M = 0` matrix because `2·2 = 0` in `ZMod 4`)
  or `X` (if `b = 0`, since `Mv = (2b, 0) = 0`) is a nonzero
  polynomial of `natDegree < 2` annihilating `v` under `aeval M`,
  witnessing `¬ IsCyclicVector M v`.

The forward direction is genuinely false over non-domains; the OQ is
not vacuous.

## Mathlib API verification

All 9 lemmas used by the existing field-proof in
[`CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean`](https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean#L45-L95)
confirmed available over `[CommRing R]` at pinned commit
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:

| Mathlib name | Location | Typeclass over CommRing R? |
|--------------|----------|---|
| `minpoly.monic` | `FieldTheory/Minpoly/Basic.lean:54` | ✓ |
| `minpoly.ne_zero` | `FieldTheory/Minpoly/Basic.lean:60` | ✓ (+ `Nontrivial`) |
| `minpoly.aeval` | `FieldTheory/Minpoly/Basic.lean:88` | ✓ |
| `minpoly.dvd` | `FieldTheory/Minpoly/Basic.lean` (Ring section) | ✓ |
| `Matrix.isIntegral` | `LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44` | ✓ |
| `Polynomial.Monic.of_mul_monic_left` | `Algebra/Polynomial/Monic.lean:110` | ✓ |
| `Polynomial.Monic.natDegree_mul'` | `Algebra/Polynomial/Monic.lean:154` | ✓ (replaces `natDegree_mul`) |
| `Matrix.charpoly_monic` | `LinearAlgebra/Matrix/Charpoly/Basic.lean` | ✓ (+ `Nontrivial`) |
| `Matrix.charpoly_natDegree_eq_dim` | `LinearAlgebra/Matrix/Charpoly/Coeff.lean` | ✓ |

## Deliverables (doc-only)

- `research/problems/<slug>/problem.md` (+260 LOC) — three-approach
  decomposition (A=backward extension, B=`ZMod 4` counterexample
  formalisation, C=UFD forward-direction extension), full Mathlib API
  map at pinned commit, references.
- `research/problems/<slug>/state.md` (+218 LOC) — phase `OBSERVE`,
  next-action S2 (Approach A) with copy-pasteable ~60-LOC Lean skeleton
  for `cyclic_implies_nonderogatory_commring`, future-iterations
  outline for S3 (Approach B), S4 (Approach C, optional).
- `research/problems/<slug>/knowledge.md` (+255 LOC) — full
  counterexample case analysis with `b = 0` vs `b ≠ 0` split, Mathlib
  API verification log, S2/S3 risk inventory.
- `src/data/research/problems/<slug>.json` — registry update: phase
  `NEW` → `OBSERVE`, knowledge score `0` → ~14, problem statement
  filled, 4 new tags (`commutative-rings`, `counterexample-zmod4`,
  `cyclic-vector`, `observe-bootstrap`).

## Status

**Outcome**: `surveyed` (S1 OBSERVE complete)

**Next steps**: S2 ACT (Approach A, backward extension to `CommRing R`)
is ready for any agent — the proof skeleton in `state.md` "Next Action"
section is copy-pasteable and only requires verifying one Mathlib
lemma-name detail (`Monic.eq_one_iff_natDegree_le_zero` or equivalent
closer for the `r = 1` step; falls back to the same
`eq_C_of_natDegree_eq_zero` + `Monic.leadingCoeff` chain used in the
field file's lines 88-93).

## Honest deliverable summary

- 0 new Lean theorems
- 0 new sorries
- 0 axiom changes
- 0 Lean files modified
- Build pending (no Lean delta)

This is a doc-only `*-OBSERVE` PR per the precedent of
`bezout-identity-oq-01-oq-01-oq-01-oq-01` (PR #17990) and similar
slug-bootstrap iterations.

🤖 Generated by researcher-9