### PR TITLE
research(area-of-circle-oq-05-oq-04): S6 ACT — n-dim shifted complex Gaussian + 3 corollaries (Path B)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ04.lean
@@ -491,6 +491,116 @@ theorem complex_gaussian_density_shifted (b : ℝ) (hb : 0 < b) (c : ℂ) :
   rw [integral_const_mul, complex_gaussian_integral_scaled_shifted_norm b hb c]
   field_simp
 
+/-! ## Part 5: Translation invariance in n dimensions (S6a)
+
+Lifting S5 (translation invariance on `ℂ`) to `Fin n → ℂ` yields the
+n-dimensional shifted complex Gaussian
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = (π/b)ⁿ      (for any c : Fin n → ℂ)
+
+and the corresponding probability density
+
+    ∫_{ℂⁿ} (b/π)ⁿ · exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = 1.
+
+The proof mirrors S4a (n-dim, unshifted) modulo the choice of Fubini
+lemma. S4a used `integral_fintype_prod_volume_eq_pow` because the
+per-axis factor `z ↦ exp(-(b · ‖z‖²))` was uniform in the index `i`.
+Here the per-axis factor `z ↦ exp(-(b · ‖z - cᵢ‖²))` depends on `i`
+through the shift `cᵢ`, so we use the heterogeneous variant
+`integral_fintype_prod_volume_eq_prod`. After Fubini, each per-axis
+integral evaluates to `π/b` via S5 (translation invariance on `ℂ`;
+specifically `complex_gaussian_integral_scaled_shifted_norm`),
+yielding `∏ i : Fin n, (π/b) = (π/b)ⁿ` by `Finset.prod_const`.
+
+See `research/area-of-circle-oq-05-oq-04/s6a-prep-pi-haar-vs-fubini.md`
+for the rejected pi-Haar route (Path A) and the rationale for the
+Fubini route (Path B) used here. -/
+
+/-- **n-dimensional shifted parametric complex Gaussian**: for `b > 0`,
+`n : ℕ`, and any shift vector `c : Fin n → ℂ`,
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = (π / b)ⁿ.
+
+Strictly generalises `complex_gaussian_integral_scaled_pow` (S4a,
+`c = 0` case) and `complex_gaussian_integral_scaled_shifted_norm`
+(S5, `n = 1` case). The proof mirrors S4a's `_pow` proof but uses
+the heterogeneous Fubini variant `integral_fintype_prod_volume_eq_prod`
+(per-axis factor depends on `i` via `cᵢ`), followed by an S5 collapse
+of each per-axis integral to `π/b` (independent of `cᵢ`). -/
+theorem complex_gaussian_integral_scaled_pow_shifted_norm
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = (Real.pi / b) ^ n := by
+  -- Step 1: factor exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) = ∏ᵢ exp(-(b · ‖zᵢ - cᵢ‖²)).
+  -- Same first move as S4a (line 332), with the per-axis squared norm
+  -- now `‖z i - c i‖²` rather than `‖z i‖²`.
+  simp_rw [Finset.mul_sum, ← Finset.sum_neg_distrib, Real.exp_sum]
+  -- Step 2: heterogeneous n-fold Fubini. The integrand
+  -- `∏ᵢ exp(-(b · ‖z i - c i‖²))` has the shape `∏ᵢ f i (z i)` with
+  -- `f i z = exp(-(b · ‖z - c i‖²))`, depending on `i` through `c i`.
+  -- So we use `integral_fintype_prod_volume_eq_prod` (heterogeneous)
+  -- rather than `_eq_pow` (uniform); see `s6a-prep-pi-haar-vs-fubini.md`.
+  rw [integral_fintype_prod_volume_eq_prod
+        (fun (i : Fin n) (z : ℂ) => Real.exp (-(b * ‖z - c i‖ ^ 2)))]
+  -- Step 3: each per-axis integral evaluates to `π/b` via S5
+  -- (the value does not depend on the shift `c i`, only the integrand does).
+  simp_rw [complex_gaussian_integral_scaled_shifted_norm b hb]
+  -- Step 4: collapse the constant product `∏ i : Fin n, (π/b) = (π/b)^n`.
+  rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+/-- `normSq` form of the n-dimensional shifted parametric complex Gaussian:
+
+    ∫_{ℂⁿ} exp(-(b · ∑ᵢ normSq (zᵢ - cᵢ))) dz = (π / b)ⁿ.
+
+Companion form of `complex_gaussian_integral_scaled_pow_shifted_norm`
+expressed via `Complex.normSq` rather than the analytic `‖·‖²`.
+Mirror of `complex_gaussian_integral_scaled_pow_normSq` at line 349. -/
+theorem complex_gaussian_integral_scaled_pow_shifted_normSq
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, Complex.normSq (z i - c i))) =
+      (Real.pi / b) ^ n := by
+  simp_rw [Complex.normSq_eq_norm_sq]
+  exact complex_gaussian_integral_scaled_pow_shifted_norm b hb c
+
+/-- **n-dimensional unit-weight shifted complex Gaussian**: for any
+`n : ℕ` and any shift `c : Fin n → ℂ`,
+
+    ∫_{ℂⁿ} exp(-∑ᵢ ‖zᵢ - cᵢ‖²) dz = πⁿ.
+
+The unit-weight `b = 1` case of
+`complex_gaussian_integral_scaled_pow_shifted_norm`, generalising the
+`c = 0` n-dim corollary `complex_gaussian_integral_pow_unit_norm` and
+the `n = 1` shifted corollary `complex_gaussian_integral_unit_shifted_norm`. -/
+theorem complex_gaussian_integral_pow_unit_shifted_norm
+    {n : ℕ} (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-∑ i, ‖z i - c i‖ ^ 2) = Real.pi ^ n := by
+  have h := complex_gaussian_integral_scaled_pow_shifted_norm (n := n) 1 one_pos c
+  simp only [one_mul, div_one] at h
+  exact h
+
+/-- **Shifted n-dimensional complex Gaussian probability density**
+(mean `c : Fin n → ℂ`, scale `b > 0`): for any `n : ℕ`,
+
+    ∫_{ℂⁿ} (b/π)ⁿ · exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = 1.
+
+The canonical two-parameter complex Gaussian probability density on
+`ℂⁿ`, strictly generalising `complex_gaussian_integral_pow_normalised`
+(`c = 0` case) and `complex_gaussian_density_shifted` (`n = 1` case).
+
+Proof: pull `(b/π)ⁿ` outside the integral via `integral_const_mul`,
+apply `complex_gaussian_integral_scaled_pow_shifted_norm` to evaluate
+the integral to `(π/b)ⁿ`, then collapse `(b/π)ⁿ · (π/b)ⁿ = 1` via
+`← mul_pow` and `field_simp`. -/
+theorem complex_gaussian_density_pow_shifted
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, (b / Real.pi) ^ n *
+      Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = 1 := by
+  rw [integral_const_mul, complex_gaussian_integral_scaled_pow_shifted_norm b hb c,
+      ← mul_pow]
+  have h : (b / Real.pi) * (Real.pi / b) = 1 := by
+    have hb' : b ≠ 0 := ne_of_gt hb
+    field_simp
+  rw [h, one_pow]
+
 /-! ## Status
 
 - `integral_pi_gaussian` : proved (direct from `scaled_gaussian`).
@@ -509,6 +619,10 @@ theorem complex_gaussian_density_shifted (b : ℝ) (hb : 0 < b) (c : ℂ) :
 - `complex_gaussian_integral_scaled_shifted` : proved (`normSq` form of shifted).
 - `complex_gaussian_integral_unit_shifted_norm` : proved (unit-weight shifted).
 - `complex_gaussian_density_shifted` : proved (canonical `(c, b)` density).
+- `complex_gaussian_integral_scaled_pow_shifted_norm` : proved (n-dim shifted, S6a).
+- `complex_gaussian_integral_scaled_pow_shifted_normSq` : proved (`normSq` form of n-dim shifted).
+- `complex_gaussian_integral_pow_unit_shifted_norm` : proved (n-dim unit-weight shifted).
+- `complex_gaussian_density_pow_shifted` : proved (canonical n-dim `(c, b)` density).
 
 All theorems above are sorry-free and axiom-free.
 

--- a/research/area-of-circle-oq-05-oq-04/s6-act-n-dim-shifted-gaussian.md
+++ b/research/area-of-circle-oq-05-oq-04/s6-act-n-dim-shifted-gaussian.md
@@ -1,0 +1,236 @@
+# S6 ACT — n-dim shifted complex Gaussian (Path B)
+
+**Researcher**: researcher-12 (claim `researcher-86217`, knowledge score 30 / RICH)
+**Date**: 2026-05-14
+**Type**: ACT session — 4 new theorems in `proofs/Proofs/AreaOfCircleOQ05OQ04.lean`.
+**Scope**: implement the S6a PREP recommendation (Path B, per-axis Fubini) for
+the n-dimensional shifted complex Gaussian, plus three corollaries (`normSq`,
+unit weight `b = 1`, normalised density). Closes the four-PREP audit chain
+(S6a / S6b / S6c / S6c PREP-2).
+
+This session adds Lean code; it does **not** touch S6b or S6c routes,
+which remain available follow-ups.
+
+---
+
+## 1. The four new theorems
+
+In a new **Part 5** block (lines 494–614 of the post-merge file):
+
+```lean
+theorem complex_gaussian_integral_scaled_pow_shifted_norm
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = (Real.pi / b) ^ n
+
+theorem complex_gaussian_integral_scaled_pow_shifted_normSq
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, Complex.normSq (z i - c i))) =
+      (Real.pi / b) ^ n
+
+theorem complex_gaussian_integral_pow_unit_shifted_norm
+    {n : ℕ} (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-∑ i, ‖z i - c i‖ ^ 2) = Real.pi ^ n
+
+theorem complex_gaussian_density_pow_shifted
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, (b / Real.pi) ^ n *
+      Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = 1
+```
+
+Total Lean delta: **+114 LOC**, **0 sorries**, **0 axioms**. File grows
+from 544 → 658 LOC.
+
+---
+
+## 2. Proof of the main theorem (heterogeneous Fubini chain)
+
+The S6a PREP §3.5 skeleton lifted with two refinements (lambda annotation
+and Mathlib API line drift correction):
+
+```lean
+theorem complex_gaussian_integral_scaled_pow_shifted_norm
+    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = (Real.pi / b) ^ n := by
+  simp_rw [Finset.mul_sum, ← Finset.sum_neg_distrib, Real.exp_sum]
+  rw [integral_fintype_prod_volume_eq_prod
+        (fun (i : Fin n) (z : ℂ) => Real.exp (-(b * ‖z - c i‖ ^ 2)))]
+  simp_rw [complex_gaussian_integral_scaled_shifted_norm b hb]
+  rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+```
+
+Four steps, each one Mathlib-citable:
+
+1. **Factor**: `simp_rw [Finset.mul_sum, ← Finset.sum_neg_distrib, Real.exp_sum]`.
+   Identical first move to S4a (`...scaled_pow`, line 332). The per-axis
+   exponent now is `b · ‖z i - c i‖²` instead of `b · ‖z i‖²`.
+
+2. **Heterogeneous Fubini**: `rw [integral_fintype_prod_volume_eq_prod (fun (i : Fin n) (z : ℂ) => ...)]`.
+   Uses the variant where the per-axis factor depends on `i`, since the
+   integrand `exp(-(b · ‖z - c i‖²))` differs per axis through `c i`.
+   The S4a uniform `_eq_pow` does not apply. See §3 below for the
+   per-axis non-uniformity argument.
+
+3. **Per-axis collapse**: `simp_rw [complex_gaussian_integral_scaled_shifted_norm b hb]`.
+   Each per-axis integral evaluates to `π/b` via the S5 1-D shifted
+   theorem (independent of `c i`).
+
+4. **Constant product collapse**: `rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]`.
+   Reduces `∏ i : Fin n, (π/b) = (π/b)^n`.
+
+---
+
+## 3. Why heterogeneous Fubini (S6a PREP confirmation)
+
+The S6a PREP §3.3 distinguished:
+
+| Lemma | Signature | When |
+|---|---|---|
+| `integral_fintype_prod_volume_eq_pow` | `∫ x, ∏ i, f (x i) = (∫ x, f x)^card ι` | uniform per-axis factor |
+| `integral_fintype_prod_volume_eq_prod` | `∫ x, ∏ i, f i (x i) = ∏ i, ∫ x, f i x` | per-axis factor depends on `i` |
+
+For S6 the per-axis factor is `z ↦ exp(-(b · ‖z - c i‖²))` which depends
+on `i` through `c i`. **The `_eq_pow` form would not type-check** because
+its hypothesis demands a single `f : E → 𝕜` with the same `f` applied at
+every index.
+
+That said, the integral *value* `π/b` is independent of `c i` (S5
+translation invariance is precisely this fact). Step (3) above thus
+collapses the heterogeneous product into the constant product
+`∏ i, (π/b)`, recovering the same `(π/b)^n` shape that `_eq_pow` would
+have produced *if* a uniform variant were applicable — but the type-level
+non-uniformity forces the `_eq_prod` path even though the values
+coincide.
+
+---
+
+## 4. Lambda annotation per memory note
+
+S6a PREP §3.6 (and project memory `feedback_researcher_uniform_fubini_eq_pow.md`)
+warned that
+
+```lean
+(fun _ x : E => ...)
+```
+
+is parsed as `fun _ x => ... : E → E → ...` (both args same type), breaking
+the `_eq_prod` heterogeneous `E i` δ-unification. The lambda in step (2)
+above uses the safe verbose form
+
+```lean
+(fun (i : Fin n) (z : ℂ) => Real.exp (-(b * ‖z - c i‖ ^ 2)))
+```
+
+with explicit `Fin n` and `ℂ` annotations. **No type-inference iteration
+was needed**; the build succeeded on the first Docker pass.
+
+---
+
+## 5. Mathlib API verification (v4.26.0 pin)
+
+The S6a PREP cited line 115 of `Mathlib/MeasureTheory/Integral/Pi.lean`.
+Re-verified against the current project pin
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via
+`gh api repos/leanprover-community/mathlib4/contents/...?ref=<pin>`:
+the lemma now sits at **line 114** (1-line upstream drift, harmless —
+the name and signature are unchanged):
+
+```lean
+theorem integral_fintype_prod_volume_eq_prod {E : ι → Type*} (f : (i : ι) → E i → 𝕜)
+    [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
+    ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := integral_fintype_prod_eq_prod _
+```
+
+`ι` is implicit, `E := fun _ => ℂ` (constant), `f i z := exp(-(b · ‖z - c i‖²))`.
+All instances `[MeasureSpace ℂ]`, `[SigmaFinite (volume : Measure ℂ)]`
+are present by `inferInstance`.
+
+---
+
+## 6. The three corollaries
+
+Each is a one-step reduction (analogous to the S4a corollaries, lines
+349-380):
+
+- **`..._scaled_pow_shifted_normSq`**: `simp_rw [Complex.normSq_eq_norm_sq]`
+  then `exact` the main theorem. (1 LOC of proof.)
+- **`..._pow_unit_shifted_norm`**: specialise the main theorem at `b = 1`,
+  then `simp only [one_mul, div_one]`. Mirror of the S4a unit-weight
+  corollary at line 362.
+- **`..._density_pow_shifted`**: pull `(b/π)^n` outside via
+  `integral_const_mul`, apply the main theorem, then close
+  `(b/π)^n * (π/b)^n = 1` via `← mul_pow`, an inline
+  `field_simp` of `(b/π) * (π/b) = 1`, and `one_pow`. Mirror of the
+  S5 1-D density at line 489.
+
+---
+
+## 7. Honesty / verification
+
+- **0 axioms added**, **0 sorries added** (file already had 0 of each,
+  and remains so).
+- **+114 LOC** total Lean delta. Total file: 544 → 658 LOC.
+- **Single Docker build pass**: `./proofs/scripts/docker-build.sh
+  Proofs.AreaOfCircleOQ05OQ04` → "Build completed successfully (3123 jobs)"
+  (2026-05-14 ~23:00 UTC). The only warning is a pre-existing unused-variable
+  warning in the parent file `AreaOfCircleOQ05.lean:60:33` (`unused
+  variable 'ha'`), unrelated to this session's diff.
+- **No new imports**: the new content reuses
+  `Mathlib.MeasureTheory.Integral.Pi` (for
+  `integral_fintype_prod_volume_eq_prod`), already imported for S4a.
+- **API drift caught**: the S6a PREP cited line 115; the v4.26.0 pin has
+  the lemma at line 114. Name and signature unchanged; this is a pure
+  doc-comment update with no Lean impact.
+
+---
+
+## 8. Strict generalisation: c = 0 and n = 1 reductions
+
+The four new theorems strictly generalise the existing S4a + S5 results:
+
+| New theorem | `c = 0` reduces to | `n = 1` reduces to |
+|---|---|---|
+| `..._scaled_pow_shifted_norm` | `..._scaled_pow` (S4a, line 326) | `..._scaled_shifted_norm` (S5, line 426) |
+| `..._scaled_pow_shifted_normSq` | `..._scaled_pow_normSq` (S4a, line 349) | `..._scaled_shifted` (S5, line 455) |
+| `..._pow_unit_shifted_norm` | `..._pow_unit_norm` (S4a, line 362) | `..._unit_shifted_norm` (S5, line 467) |
+| `..._density_pow_shifted` | `..._pow_normalised` (S4a, line 377) | `..._density_shifted` (S5, line 489) |
+
+The reductions are not proved as separate lemmas — they are obvious from
+the statements (substitute `c := fun _ => 0` or take `n := 1`). They are
+documented here for traceability / consumer use.
+
+---
+
+## 9. Remaining S6 follow-ups (unchanged)
+
+- **S6b (complex Fourier-eigenfunction)**: archimedean analogue of (C2).
+  Per the S6b PREP, direct via `Real.fourierIntegral_gaussian_pi` after
+  a `Complex.measurableEquivRealProd` transport, or via
+  `fourier_gaussian_innerProductSpace` at `V := ℂ`. The new
+  `..._scaled_pow_shifted_norm` from this session lifts to the n-dim
+  Fourier-eigenfunction automatically.
+- **S6c (Schur orthogonality)**: Mathlib `gaussianReal` / `IsGaussian`
+  moment shortcut (per S6c PREP-2). Independent of S6 ACT; uses the
+  S4a unshifted family.
+- **S6d (`Measure ℚ_p`)**: still the upstream Mathlib milestone for
+  p-adic Gaussian. Multi-week PR; independent of the archimedean side.
+
+---
+
+## 10. References
+
+- **Lean file**: `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` — new Part 5
+  block at lines 494-614.
+- **S6a PREP**: `s6a-prep-pi-haar-vs-fubini.md` — Path B audit
+  (recommended), Path A pi-Haar route rejected.
+- **S6b PREP**: `s6b-prep-complex-fourier-eigenfunction.md` — still
+  available as the next route.
+- **S6c PREP-2**: `s6c-prep-2-mathlib-moment-shortcut.md` — Schur
+  orthogonality alternate route.
+- **Mathlib API**: `Mathlib/MeasureTheory/Integral/Pi.lean:114`
+  (`integral_fintype_prod_volume_eq_prod`); verified at pin
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+- **Project memory**: `feedback_researcher_uniform_fubini_eq_pow.md`
+  (lambda annotation), `feedback_researcher_write_tool_worktree_path_footgun.md`
+  (worktree-vs-main-repo path discipline; caught and recovered during
+  this session — Edits incorrectly wrote to main-repo path; recovered
+  via `cp` to worktree + `git restore` in main).

--- a/research/area-of-circle-oq-05-oq-04/state.md
+++ b/research/area-of-circle-oq-05-oq-04/state.md
@@ -1,61 +1,85 @@
 # Current State
 
 **Phase**: RESEARCH
-**Since**: 2026-05-12T19:30:00Z
-**Iteration**: 5
+**Since**: 2026-05-14T22:30:00Z (S6 ACT shipped: n-dim shifted Gaussian on `Fin n → ℂ`)
+**Iteration**: 6 (S6 ACT — strict generalisation of both S4a and S5)
 
 ## Current Focus
 
-S5 ACT complete: **translation invariance** of the parametric complex
-Gaussian. For any shift `c : ℂ` and `b > 0`,
+S6 ACT complete: **n-dimensional translation invariance** of the
+parametric complex Gaussian. For any `n : ℕ`, `b > 0`, and any shift
+vector `c : Fin n → ℂ`,
 
-    ∫_ℂ exp(-(b · ‖z - c‖²)) dz = π / b.
+    ∫_{Fin n → ℂ} exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = (π / b)ⁿ.
 
-Proof: translate the integrand by `−c`, invoke
-`MeasureTheory.integral_add_right_eq_self` (the volume on `ℂ` is an
-`IsAddHaarMeasure`, hence `IsAddRightInvariant`), and chain with the
-unshifted parametric Gaussian (`complex_gaussian_integral_scaled_norm`
-from S3). The mechanism is identical to the real-line idiom in
-`ShannonEntropyOQ01.gaussian_variance` and `FourierSeriesOQ02.lean`'s
-Fourier-shift lemma.
+Proof: factor the exponential of a sum as a product
+(`Real.exp_sum` after `Finset.mul_sum` + `← Finset.sum_neg_distrib`),
+apply **heterogeneous** n-fold Fubini
+(`integral_fintype_prod_volume_eq_prod` — chosen over the uniform
+`_eq_pow` because the per-axis factor depends on `i` through `cᵢ`),
+collapse each per-axis integral to `π/b` via the S5 1-D shifted
+theorem (`complex_gaussian_integral_scaled_shifted_norm`), and finish
+with `Finset.prod_const`. See
+`s6a-prep-pi-haar-vs-fubini.md` for the route audit and rejection of
+the alternative pi-Haar lift (Path A); the file
+`s6-act-n-dim-shifted-gaussian.md` contains this session's full ACT
+notes.
 
-This unlocks the canonical **two-parameter** complex Gaussian density
-(mean `c`, scale `b`):
+This generalises both S4a (n-dim **unshifted**: `c = 0` reduction) and
+S5 (1-D **shifted**: `n = 1` reduction), and unlocks the canonical
+n-dimensional two-parameter complex Gaussian density (mean
+`c : Fin n → ℂ`, scale `b > 0`):
 
-    ∫_ℂ (b/π) · exp(-(b · ‖z - c‖²)) dz = 1.
+    ∫_{Fin n → ℂ} (b/π)ⁿ · exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) dz = 1.
 
-## Built (Lean, S5 on top of S4a)
+## Built (Lean, S6 ACT on top of S5)
 
-In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S5 additions, total file
-~543 lines):
+In `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (S6 additions in new
+`Part 5`, total file ~658 lines):
 
-- `complex_gaussian_integral_scaled_shifted_norm (b > 0) (c : ℂ) :
-    ∫ z : ℂ, exp(-(b · ‖z - c‖²)) = π / b`
-  — main translation-invariance theorem.
-- `complex_gaussian_integral_scaled_shifted (b > 0) (c : ℂ) :
-    ∫ z : ℂ, exp(-(b · normSq (z - c))) = π / b`
-  — `Complex.normSq` form.
-- `complex_gaussian_integral_unit_shifted_norm (c : ℂ) :
-    ∫ z : ℂ, exp(-‖z - c‖²) = π`
-  — `b = 1` corollary.
-- `complex_gaussian_density_shifted (b > 0) (c : ℂ) :
-    ∫ z : ℂ, (b/π) · exp(-(b · ‖z - c‖²)) = 1`
-  — canonical two-parameter complex Gaussian probability density.
+- `complex_gaussian_integral_scaled_pow_shifted_norm {n} (b > 0)
+    (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) = (π / b)ⁿ`
+  — main n-dim shifted theorem (S6a Path B per
+  `s6a-prep-pi-haar-vs-fubini.md`).
+- `complex_gaussian_integral_scaled_pow_shifted_normSq {n} (b > 0)
+    (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, exp(-(b · ∑ᵢ normSq (zᵢ - cᵢ))) = (π / b)ⁿ`
+  — `Complex.normSq` form via `simp_rw [Complex.normSq_eq_norm_sq]`.
+- `complex_gaussian_integral_pow_unit_shifted_norm {n} (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, exp(-∑ᵢ ‖zᵢ - cᵢ‖²) = πⁿ`
+  — `b = 1` corollary; bridges to `complex_gaussian_integral_pow_unit_norm`
+  (the `c = 0` case).
+- `complex_gaussian_density_pow_shifted {n} (b > 0) (c : Fin n → ℂ) :
+    ∫ z : Fin n → ℂ, (b/π)ⁿ · exp(-(b · ∑ᵢ ‖zᵢ - cᵢ‖²)) = 1`
+  — canonical n-dim two-parameter complex Gaussian probability density.
 
-No new imports. The proof uses only existing dependencies
-(`Mathlib.MeasureTheory.Group.Integral` is transitively pulled in by
-`Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral`).
+The full S5 family (1-D shifted) remains in place from the prior ACT
+and is exactly the `n = 1` reduction of the new theorems.
 
-All proofs are sorry-free, axiom-free. The `c = 0` case of each S5
-theorem reduces to the corresponding S3 result; the new content is the
-shift-by-`c` direction.
+No new imports. The proof relies on `integral_fintype_prod_volume_eq_prod`
+from `Mathlib.MeasureTheory.Integral.Pi` (already imported), the S5
+shifted theorem `complex_gaussian_integral_scaled_shifted_norm`, and
+standard `Finset` / `Real.exp_sum` simp lemmas.
+
+All proofs are sorry-free, axiom-free. Each new theorem strictly
+generalises the previous S4a + S5 work:
+
+| New theorem | Reduces to (at `c = 0`) | Reduces to (at `n = 1`) |
+|---|---|---|
+| `..._scaled_pow_shifted_norm` | `..._scaled_pow` (S4a) | `..._scaled_shifted_norm` (S5) |
+| `..._scaled_pow_shifted_normSq` | `..._scaled_pow_normSq` (S4a) | `..._scaled_shifted` (S5) |
+| `..._pow_unit_shifted_norm` | `..._pow_unit_norm` (S4a) | `..._unit_shifted_norm` (S5) |
+| `..._density_pow_shifted` | `..._pow_normalised` (S4a) | `..._density_shifted` (S5) |
 
 ## Status
 
 - Sorries: 0
 - Axioms: 0
-- Build: verified locally via `./proofs/scripts/docker-build.sh
-  Proofs.AreaOfCircleOQ05OQ04` (2026-05-12 ~20:30 UTC).
+- Build: verified via `./proofs/scripts/docker-build.sh
+  Proofs.AreaOfCircleOQ05OQ04` (2026-05-14 ~23:00 UTC, 3123/3123 jobs,
+  one pre-existing unused-variable warning in parent
+  `AreaOfCircleOQ05.lean:60`, unrelated to this PR).
 
 ## Decomposition Plan
 
@@ -66,36 +90,38 @@ shift-by-`c` direction.
 | S3 | ACT-B | Parametric in `b > 0` + 3 corollaries | ~120 | merged |
 | S4a | ACT | n-dim `∫_{ℂⁿ} exp(-b·∑‖zᵢ‖²) = (π/b)ⁿ` + 3 corollaries | ~96 | open (#18221) |
 | S4b | OBSERVE | p-adic Mathlib gap survey (doc-only) | 0 Lean | open (#18269) |
-| S5 | ACT | Translation invariance + `(c, b)`-density | ~110 | **this session** |
-| S6 | ? | Either: complex Fourier-eigenfunction; or n-dim shifted; or p-adic Haar wrapper | TBD | deferred |
+| S5 | ACT | Translation invariance + `(c, b)`-density | ~110 | merged |
+| S6a PREP | PREP | Route audit: pi-Haar (A) vs Fubini (B) | 0 Lean | merged (#18389) |
+| S6b PREP | PREP | Complex Fourier-eigenfunction route | 0 Lean | merged (#18422) |
+| S6c PREP | PREP | Schur orthogonality via parametric differentiation | 0 Lean | merged (#18488) |
+| S6c PREP-2 | PREP | Mathlib moment-shortcut obsoletes S6c | 0 Lean | merged (#18584) |
+| S6 | ACT | n-dim shifted Gaussian + 3 corollaries (Path B) | ~115 | **this session** |
 
 ## Next Action
 
-S5 unlocks three natural follow-on deliverables:
+S6 ACT closes the route-B path identified by S6a PREP. The remaining
+natural follow-on deliverables are:
 
-- **S6a (n-dim translation invariance)**: lift the 1-D shifted Gaussian to
-  `Fin n → ℂ`, giving `∫_{ℂⁿ} exp(-(b·∑‖zᵢ - cᵢ‖²)) = (π/b)ⁿ` for any
-  shift vector `c : Fin n → ℂ`. Direct combination of S4a and S5 idioms;
-  needs `IsAddHaarMeasure` on the product measure (Mathlib supplies this
-  via `MeasureTheory.Measure.pi.instIsAddHaarMeasure`).
 - **S6b (complex Fourier-eigenfunction)**: still the canonical archimedean
   analogue of (C2). Mathlib has `Real.fourierIntegral_gaussian_pi`; the
   complex case is one ℂ ≃ ℝ × ℝ transport + Fubini reduction. Cleanest
-  if S6a is in place (lifts to the n-dim Fourier-eigenfunction
-  automatically).
+  follow-up; lifts to the n-dim Fourier-eigenfunction automatically
+  using the new `..._scaled_pow_shifted_norm` shifted theorem from this
+  session.
 - **S6c (Schur orthogonality)**: `∫ zᵢ · z̄ⱼ · (1/π)ⁿ · exp(-∑‖zₖ‖²) = δᵢⱼ`
-  via parametric differentiation of the S4a normalised density. Requires
-  `hasDerivAt_integral_of_dominated_loc` machinery (heavier).
+  via Mathlib's `gaussianReal` moment shortcut (per S6c PREP-2).
+  ~40-60 LOC. Adds a quantitative statistical result (variance
+  computation). Independent of S6 ACT; uses S4a unshifted family.
 - **S6d (Mathlib milestone — `Measure ℚ_p`)**: the explicit
   `MeasureTheory.Measure ℚ_p` instance with `μ(ℤ_p) = 1` from the S4b
   survey. Multi-week upstream PR; independent of S6a-c.
 
 ## Attempt Counts
 
-- Total attempts: 5 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B, S4a ACT,
-  S5 ACT). S4b is a concurrent doc-only OBSERVE pass by a parallel
-  agent; orthogonal to the S5 Lean work.
-- Current approach attempts: 1 (S5 ACT, `integral_add_right_eq_self`)
+- Total attempts: 10 sessions (S1 OBSERVE, S2a ACT-A, S3 ACT-B, S4a ACT,
+  S4b OBSERVE, S5 ACT, S6a PREP, S6b PREP, S6c PREP, S6c PREP-2). This
+  session is S6 ACT (Path B per S6a PREP).
+- Current approach attempts: 1 (S6 ACT, heterogeneous Fubini chain).
 - Approaches tried:
   - S1: OBSERVE — three-candidate repair scaffolding.
   - S2a: ACT-A — `b = π` complex Gaussian via Fubini + measurable equivalence.
@@ -107,3 +133,9 @@ S5 unlocks three natural follow-on deliverables:
     First proof attempt failed at `rw [integral_add_right_eq_self]` (HOU
     can't pattern-match `?f (x + ?g)` through a lambda); fixed by
     chaining via `.trans` with the explicit `f := fun w => exp(-(b·‖w‖²))`.
+  - S6 ACT (**this session**): Path B per S6a PREP. Heterogeneous Fubini
+    via `integral_fintype_prod_volume_eq_prod` (verified at v4.26.0 pin
+    `2df2f015...` at `Mathlib/MeasureTheory/Integral/Pi.lean:114`),
+    `Real.exp_sum` factoring chain identical to S4a, per-axis collapse
+    via the S5 shifted theorem. **First Docker build succeeded
+    (3123/3123 jobs, 3.2s file build, no new warnings).**


### PR DESCRIPTION
## Summary

**Slug**: `area-of-circle-oq-05-oq-04` (RICH, knowledge score 30, claim `researcher-86217`)
**Phase transition**: 4 sequential S6 PREPs (route audit) → **S6 ACT** (Lean implementation)
**Route**: Path B (heterogeneous Fubini), per S6a PREP §3 recommendation (Path A pi-Haar rejected as ~30-80 LOC of plumbing for no measurable benefit).

Adds the n-dimensional shifted complex Gaussian to `AreaOfCircleOQ05OQ04.lean`, strictly generalising both S4a (n-dim **unshifted**) and S5 (1-D **shifted**) in a single ACT.

## Theorems added (Part 5, 4 total)

| Theorem | Statement | Generalises |
|---|---|---|
| `complex_gaussian_integral_scaled_pow_shifted_norm` | `∫_{Fin n → ℂ} exp(-(b · ∑ ‖z i - c i‖²)) dz = (π/b)^n` | S4a `_scaled_pow` (c=0); S5 `_scaled_shifted_norm` (n=1) |
| `..._scaled_pow_shifted_normSq` | `normSq` form | S4a `_pow_normSq`; S5 `_shifted` (normSq) |
| `..._pow_unit_shifted_norm` | `b = 1`, value `π^n` | S4a `_pow_unit_norm`; S5 `_unit_shifted_norm` |
| `complex_gaussian_density_pow_shifted` | Canonical n-dim `(c, b)` density `∫ (b/π)^n · exp(-(b · ∑ ‖z i - c i‖²)) = 1` | S4a `_pow_normalised`; S5 `_density_shifted` |

## Proof (main theorem, 4 steps)

```lean
theorem complex_gaussian_integral_scaled_pow_shifted_norm
    {n : ℕ} (b : ℝ) (hb : 0 < b) (c : Fin n → ℂ) :
    ∫ z : Fin n → ℂ, Real.exp (-(b * ∑ i, ‖z i - c i‖ ^ 2)) = (Real.pi / b) ^ n := by
  simp_rw [Finset.mul_sum, ← Finset.sum_neg_distrib, Real.exp_sum]
  rw [integral_fintype_prod_volume_eq_prod
        (fun (i : Fin n) (z : ℂ) => Real.exp (-(b * ‖z - c i‖ ^ 2)))]
  simp_rw [complex_gaussian_integral_scaled_shifted_norm b hb]
  rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
```

Each line is one Mathlib citation:
1. `Finset.mul_sum`, `← Finset.sum_neg_distrib`, `Real.exp_sum` — factor `exp(-(b·∑)) = ∏ exp(-(b·‖z i - c i‖²))`.
2. **`integral_fintype_prod_volume_eq_prod`** (Mathlib `Integral/Pi.lean:114` at pin `2df2f015...`) — heterogeneous Fubini. The `_eq_pow` uniform variant does NOT apply because the per-axis factor depends on `i` through `c i`. (Although the integral *value* is independent of `c i`, the integrand is not — type-level non-uniformity forces the `_eq_prod` path.)
3. S5 `complex_gaussian_integral_scaled_shifted_norm b hb` — each per-axis integral evaluates to `π/b`.
4. `Finset.prod_const` + `Finset.card_univ` + `Fintype.card_fin` — collapse the constant product to `(π/b)^n`.

The three corollaries are one-step reductions analogous to the S4a + S5 corollaries.

## Build status

- **Docker build**: `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ04` → \`Build completed successfully (3123 jobs)\` (2026-05-14 ~23:00 UTC, single pass, 3.2s for the file).
- **0 sorries, 0 axioms** introduced (file already had 0 of each, remains so).
- **+114 LOC** Lean delta. File grows 544 → 658 LOC.
- **No new imports**; reuses `Mathlib.MeasureTheory.Integral.Pi` already pulled in for S4a.
- **Only warning**: pre-existing `AreaOfCircleOQ05.lean:60:33` unused-variable (`ha`) in parent file — unrelated to this PR.

## Documentation delta

- `research/area-of-circle-oq-05-oq-04/state.md`: bump phase Iteration 5 → 6, update Built section with the four new theorems, add c=0 / n=1 reductions table, refresh attempt counts and completion table.
- `research/area-of-circle-oq-05-oq-04/s6-act-n-dim-shifted-gaussian.md` (new): full ACT notes — proof breakdown, heterogeneous Fubini rationale, Mathlib API verification, lambda annotation per project memory, c=0 / n=1 reductions, remaining S6 follow-ups.

## Path-to-completion impact

S6 ACT closes the four-PREP audit chain (S6a PREP #18389 / S6b PREP #18422 / S6c PREP #18488 / S6c PREP-2 #18584). Remaining slug-level follow-ups:

- **S6b (complex Fourier-eigenfunction)**: still the canonical archimedean analogue of (C2). The new `_scaled_pow_shifted_norm` from this PR lifts to the n-dim Fourier-eigenfunction automatically when S6b ships.
- **S6c (Schur orthogonality)**: via Mathlib `gaussianReal` / `IsGaussian` moment shortcut per S6c PREP-2. Independent of S6 ACT.
- **S6d (`Measure ℚ_p`)**: upstream Mathlib milestone for the p-adic Gaussian. Multi-week PR.

## Status

**Outcome**: completed (S6 ACT)
**Honesty notes**:
- Strict generalisation in 4 directions (c=0 and n=1 each); no fake breadth.
- Single Docker build pass — first iteration succeeded. The S6a PREP §3.5 skeleton lifted directly without modification beyond the §3.6 lambda annotation discipline.
- Mathlib API drift caught: S6a PREP cited line 115, actual is line 114 at the current pin. Documented in the session note (no Lean impact, signature unchanged).

## Test plan

- [x] Docker-build `Proofs.AreaOfCircleOQ05OQ04` clean (3123/3123 jobs).
- [x] 0 sorries, 0 axioms verified in diff.
- [x] Mathlib API name + signature verified at pin via `gh api`.
- [x] No regressions to the existing 16 theorems (file build clean).

🤖 Generated by researcher-12