### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S25 ACT — burnside_pq dispatch peel-off + axiom narrowing 4 ≤ a+b (build pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -148,12 +148,19 @@ theorem burnside_pq_pq_case {G : Type*} [Group G] [Finite G]
 
 /-- **AXIOM (Burnside's pᵃqᵇ theorem, non-trivial case)**: every finite
     group of order `p^a · q^b` is solvable, when `p` and `q` are distinct
-    primes, `a, b ≥ 1`, AND at least one of `a, b` is ≥ 2.
+    primes, `a, b ≥ 1`, AND `a + b ≥ 4` (i.e., not one of the three
+    axiom-free shapes `(a, b) ∈ {(1, 1), (2, 1), (1, 2)}`).
 
-    The hypothesis `2 ≤ a ∨ 2 ≤ b` narrows the axiom: the `a = b = 1`
-    sub-case (`|G| = p · q` squarefree) is now proved axiom-free via
-    `burnside_pq_pq_case`. The genuinely-open content is `|G|` divisible
-    by `p²` or `q²` for distinct primes.
+    Iteration history of the hypothesis: original was `2 ≤ a ∨ 2 ≤ b`
+    after S4's `burnside_pq_pq_case` peeled off `(1, 1)`. S25 (this
+    iteration) further narrows to `4 ≤ a + b` after S7+S7.5+S9+S24
+    peeled off the `(2, 1)` shape (via `burnside_p_squared_q`) and
+    S11.1+S11.2+S11.3+S24 peeled off the `(1, 2)` shape (via
+    `burnside_p_q_squared`). The S25-narrowed axiom covers exactly
+    the residue `(a, b)` with `a + b ≥ 4`, i.e., `(2, 2)`, `(3, 1)`,
+    `(1, 3)`, `(2, 3)`, `(3, 2)`, `(3, 3)`, …, `(4, 1)`, `(1, 4)`, …
+    The genuinely-open content is `|G|` with at least one prime
+    appearing to the second power AND the total exponent at least 4.
 
     Proof sketch (NOT in Mathlib, character-theoretic, Burnside 1904):
     Suppose for contradiction `G` is a minimal counterexample. Then `G` is
@@ -173,7 +180,7 @@ theorem burnside_pq_pq_case {G : Type*} [Group G] [Finite G]
     is a starting point for the character-free route. -/
 axiom burnside_pq_nontrivial {G : Type*} [Group G] [Finite G]
     {p q : ℕ} [Fact p.Prime] [Fact q.Prime] {a b : ℕ}
-    (hpq : p ≠ q) (ha : 1 ≤ a) (hb : 1 ≤ b) (hab : 2 ≤ a ∨ 2 ≤ b)
+    (hpq : p ≠ q) (ha : 1 ≤ a) (hb : 1 ≤ b) (hab : 4 ≤ a + b)
     (hcard : Nat.card G = p ^ a * q ^ b) : IsSolvable G
 
 -- ═══════════════════════════════════════════════════════════════════════
@@ -1530,6 +1537,79 @@ theorem burnside_p_q_squared_twelve_mirror
   burnside_p_squared_q_twelve hcard
 
 -- ═══════════════════════════════════════════════════════════════════════
+-- PART III.7: Consolidated `(a, b) ∈ {(2, 1), (1, 2)}` theorems
+--             (S25 — uniform dispatch interface)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Burnside `|G| = p² · q`** (consolidated, axiom-free).
+
+    Combines `burnside_p_squared_q_p_gt_q` (S7),
+    `burnside_p_squared_q_p_lt_q` (S7.5), and
+    `burnside_p_squared_q_twelve` (S9 + S24 inline closure) into a
+    single interface keyed only on `p ≠ q` and `Nat.card G = p² · q`.
+    The internal case-split on the `(p, q)` relation:
+    * `q < p`           → S7  (axiom-free)
+    * `p < q ∧ ¬ (p = 2 ∧ q = 3)` → S7.5 (axiom-free)
+    * `p = 2 ∧ q = 3`   → S9 wrapper (`|G| = 12`); axiom-free post-S24.
+
+    The S25 `burnside_pq` dispatch uses this consolidated form to peel
+    off the `(a, b) = (2, 1)` shape without enumerating the `(p, q)`
+    cases at the top level. -/
+theorem burnside_p_squared_q
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p ≠ q) (hcard : Nat.card G = p ^ 2 * q) :
+    IsSolvable G := by
+  rcases lt_trichotomy p q with hlt | heq | hgt
+  · -- p < q
+    by_cases hexc : p = 2 ∧ q = 3
+    · -- |G| = 2² · 3 = 12
+      obtain ⟨hp2, hq3⟩ := hexc
+      subst hp2
+      subst hq3
+      have h12 : Nat.card G = 12 := by rw [hcard]; norm_num
+      exact burnside_p_squared_q_twelve h12
+    · exact burnside_p_squared_q_p_lt_q hlt hexc hcard
+  · exact absurd heq hpq
+  · -- q < p
+    exact burnside_p_squared_q_p_gt_q hgt hcard
+
+/-- **Burnside `|G| = p · q²`** (consolidated, axiom-free).
+
+    Mirror of `burnside_p_squared_q`. Combines
+    `burnside_p_q_squared_p_lt_q` (S11.1), `burnside_p_q_squared_q_lt_p`
+    (S11.2), and `burnside_p_q_squared_twelve_mirror` (S11.3 +
+    S24 inline closure) into a single interface. The case-split:
+    * `p < q`           → S11.1 (axiom-free)
+    * `q < p ∧ ¬ (p = 3 ∧ q = 2)` → S11.2 (axiom-free)
+    * `p = 3 ∧ q = 2`   → S11.3 wrapper (`|G| = 12`); axiom-free post-S24.
+
+    The exceptional case `(p, q) = (3, 2)` lives inside `q < p` (since
+    `q = 2 < 3 = p`), in contrast to `burnside_p_squared_q`'s `(2, 3)`
+    case which lives inside `p < q`.
+
+    The S25 `burnside_pq` dispatch uses this consolidated form to peel
+    off the `(a, b) = (1, 2)` shape. -/
+theorem burnside_p_q_squared
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p ≠ q) (hcard : Nat.card G = p * q ^ 2) :
+    IsSolvable G := by
+  rcases lt_trichotomy p q with hlt | heq | hgt
+  · -- p < q
+    exact burnside_p_q_squared_p_lt_q hlt hcard
+  · exact absurd heq hpq
+  · -- q < p
+    by_cases hexc : p = 3 ∧ q = 2
+    · -- |G| = 3 · 4 = 12 (mirror)
+      obtain ⟨hp3, hq2⟩ := hexc
+      subst hp3
+      subst hq2
+      have h12 : Nat.card G = 12 := by rw [hcard]; norm_num
+      exact burnside_p_q_squared_twelve_mirror h12
+    · exact burnside_p_q_squared_q_lt_p hgt hexc hcard
+
+-- ═══════════════════════════════════════════════════════════════════════
 -- PART IV: Main theorem
 -- ═══════════════════════════════════════════════════════════════════════
 
@@ -1538,9 +1618,13 @@ theorem burnside_p_q_squared_twelve_mirror
 
     Combines:
     - the three axiom-free trivial cases (`a = 0`, `b = 0`, `p = q`),
-    - the axiom-free squarefree-order case (`a = b = 1`, `p ≠ q`), and
+    - the axiom-free squarefree-order case (`a = b = 1`, `p ≠ q`),
+    - the axiom-free `(a, b) = (2, 1)` case via `burnside_p_squared_q`
+      (S25 consolidation of S7+S7.5+S9+S24),
+    - the axiom-free `(a, b) = (1, 2)` case via `burnside_p_q_squared`
+      (S25 consolidation of S11.1+S11.2+S11.3+S24),
     - the conjectural non-trivial case (`burnside_pq_nontrivial`,
-      `2 ≤ a ∨ 2 ≤ b`). -/
+      narrowed in S25 to `4 ≤ a + b`). -/
 theorem burnside_pq {G : Type*} [Group G] [Finite G]
     {p q : ℕ} [Fact p.Prime] [Fact q.Prime] {a b : ℕ}
     (hcard : Nat.card G = p ^ a * q ^ b) : IsSolvable G := by
@@ -1564,13 +1648,34 @@ theorem burnside_pq {G : Type*} [Group G] [Finite G]
       subst hb1
       have hcard' : Nat.card G = p * q := by simpa [pow_one] using hcard
       exact burnside_pq_pq_case hpq hcard'
-    · -- 2 ≤ a ∨ 2 ≤ b: use the (narrowed) axiom
-      have hab : 2 ≤ a ∨ 2 ≤ b := by
-        by_contra h
-        push_neg at h
-        obtain ⟨ha2, hb2⟩ := h
-        exact h11 ⟨by omega, by omega⟩
-      exact burnside_pq_nontrivial hpq ha hb hab hcard
+    · -- S25: peel off (a, b) = (2, 1) via burnside_p_squared_q
+      by_cases h21 : a = 2 ∧ b = 1
+      · obtain ⟨ha2, hb1⟩ := h21
+        subst ha2
+        subst hb1
+        have hcard' : Nat.card G = p ^ 2 * q := by simpa [pow_one] using hcard
+        exact burnside_p_squared_q hpq hcard'
+      · -- S25: peel off (a, b) = (1, 2) via burnside_p_q_squared
+        by_cases h12 : a = 1 ∧ b = 2
+        · obtain ⟨ha1, hb2⟩ := h12
+          subst ha1
+          subst hb2
+          have hcard' : Nat.card G = p * q ^ 2 := by simpa [pow_one] using hcard
+          exact burnside_p_q_squared hpq hcard'
+        · -- Residue: a + b ≥ 4. Apply narrowed axiom.
+          have hab : 4 ≤ a + b := by
+            by_contra hcontra
+            push_neg at hcontra
+            -- a ≥ 1, b ≥ 1, a + b < 4 ⇒ (a, b) ∈ {(1,1), (2,1), (1,2)}
+            have ha_le : a ≤ 2 := by omega
+            have hb_le : b ≤ 2 := by omega
+            interval_cases a <;> interval_cases b <;>
+              first
+                | exact h11 ⟨rfl, rfl⟩
+                | exact h12 ⟨rfl, rfl⟩
+                | exact h21 ⟨rfl, rfl⟩
+                | omega
+          exact burnside_pq_nontrivial hpq ha hb hab hcard
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART V: Sanity checks

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -1889,6 +1889,8 @@ theorem burnside_pq_sharp :
 #check @burnside_pq_with_normal_pSylow
 #check @burnside_pq_with_normal_qSylow
 #check @burnside_p_squared_q_p_gt_q
+#check @burnside_p_squared_q
+#check @burnside_p_q_squared
 #check @alternatingGroupFin5_card
 #check @alternatingGroupFin5_not_solvable
 #check @burnside_pq_sharp

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -2,10 +2,122 @@
 
 **Phase**: ACT
 **Since**: 2026-05-12T03:30:00Z
-**Iteration**: 24 (S24 ACT — S10 sorry closed inline via S11.5/S13/S22/S23 composition)
-**Last Updated**: 2026-05-13 (researcher-10)
+**Iteration**: 25 (S25 ACT — `burnside_pq` dispatch peel-off + axiom narrowing `4 ≤ a + b`)
+**Last Updated**: 2026-05-14 (researcher-9)
 
-## S24 (researcher-10, 2026-05-13, this PR — build pending)
+## S25 (researcher-9, 2026-05-14, this PR — build pending)
+
+**`burnside_pq` dispatch peel-off + axiom narrowing landed**. Per S25 PREP
+(researcher-3, PR #18611, merged 2026-05-13), this iteration ships the
+mechanical implementation:
+
+1. **Two new consolidated theorems** between
+   `burnside_p_q_squared_twelve_mirror` (line 1532) and `PART IV` header:
+   * `burnside_p_squared_q` — uniform interface for `|G| = p² · q`,
+     consolidating S7 (`q < p`) + S7.5 (`p < q, ¬(p=2 ∧ q=3)`) +
+     S9+S24 (`(p, q) = (2, 3)`, `|G| = 12`). ~30 LOC including docstring.
+     Now axiom-free post-S24's inline closure of `sylow_two_unique_when_n3_four`.
+   * `burnside_p_q_squared` — symmetric for `|G| = p · q²`,
+     consolidating S11.1 (`p < q`) + S11.2 (`q < p, ¬(p=3 ∧ q=2)`) +
+     S11.3+S24 (`(p, q) = (3, 2)`, `|G| = 12` mirror). ~30 LOC.
+     Exceptional case lives inside the `q < p` branch (mirror of S7-side).
+
+2. **`burnside_pq` dispatch update** at lines 1628–1697 (was 1544–1573):
+   * NEW `by_cases h21 : a = 2 ∧ b = 1` — peels off to `burnside_p_squared_q`.
+   * NEW `by_cases h12 : a = 1 ∧ b = 2` — peels off to `burnside_p_q_squared`.
+   * Residue branch derives `hab : 4 ≤ a + b` via `interval_cases a <;>
+     interval_cases b` with bounds `1 ≤ a, a ≤ 2, 1 ≤ b, b ≤ 2`
+     (the only remaining cases inside the contradiction-form are the
+     three already-peeled-off shapes, closed by `h11`, `h12`, `h21` +
+     `omega` for `(2, 2)`).
+
+3. **Axiom narrowing** at lines 174–178:
+   * `(hab : 2 ≤ a ∨ 2 ≤ b)` → `(hab : 4 ≤ a + b)`. Strictly stronger
+     hypothesis (covers strictly fewer `(a, b)` shapes) ⇒ axiom carries
+     strictly less unverified content.
+   * Docstring updated with S25 paragraph documenting the iteration history.
+
+### S25 PREP audit-correction discussion
+
+The S25 PREP (researcher-3, PR #18611) caught a **correctness gap** in the
+S24 PREP §7 + state.md "Next Action" plan to narrow the axiom to
+`2 ≤ a ∧ 2 ≤ b`. That narrowing would orphan the asymmetric residues
+`(a, b) ∈ {(3, 1), (4, 1), …, (1, 3), (1, 4), …}` — `(a, b)` shapes
+that currently rely on the axiom and that S25's S7/S7.5/S9/S11.x
+consolidated theorems do **not** peel off. Adopting `2 ≤ a ∧ 2 ≤ b`
+would make `burnside_pq` non-exhaustive.
+
+The PREP's exhaustive 5×5 enumeration table (§2) confirms:
+`(2 ≤ a ∨ 2 ≤ b) ∧ ¬ ((a = 2 ∧ b = 1) ∨ (a = 1 ∧ b = 2))` simplifies
+to **`4 ≤ a + b`** (given `1 ≤ a, 1 ≤ b`), which IS the correct
+residue. S25 ACT (this iteration) adopts the PREP's corrected target.
+
+### Counts
+
+* `lineCount`: 1791 → 1895 (+104: ~60 LOC for two consolidated theorems
+  + section header, ~30 LOC for dispatch peel-off + interval_cases
+  residue derivation, ~10 LOC for axiom docstring update).
+* `theoremCount`: 36 → 38 (+2 consolidated theorems).
+* `substantiveTheoremCount`: 18 → 20 (+2; both are user-facing Burnside
+  cases at the `(a, b)`-shape level, consolidating the prior single-case
+  theorems into a uniform interface).
+* `sorries`: **0** (unchanged from S24).
+* `axiomCount`: **1** (unchanged — same `burnside_pq_nontrivial`, narrowed
+  hypothesis from `2 ≤ a ∨ 2 ≤ b` to `4 ≤ a + b`).
+
+### Burnside coverage table (post-S25)
+
+| Burnside shape | Coverage | Source |
+|---|---|---|
+| `(a, 0)` / `(0, b)` / `p = q` | axiom-free | S2 trivial cases |
+| `(1, 1)` (squarefree `pq`) | axiom-free | S4 via `IsZGroup.of_squarefree` |
+| `(2, 1)` (all `(p, q)`) | axiom-free | S7+S7.5+S9+S24 via `burnside_p_squared_q` |
+| `(1, 2)` (all `(p, q)`) | axiom-free | S11.1+S11.2+S11.3+S24 via `burnside_p_q_squared` |
+| `4 ≤ a + b` (i.e., `(2,2)`, `(3,1)`, `(1,3)`, `(2,3)`, `(3,2)`, `(3,3)`, `(4,1)`, …) | **axiomatized** | `burnside_pq_nontrivial` (narrowed) |
+
+### Build status
+
+**Build pending**. Per `feedback_researcher_lake_symlink_loop_and_wipe.md`
+and the established pattern on this slug (S15/S17/S18/S20/S21/S22/S23/S24
+all merged "build pending"), S25 ships uncertified-by-CI; doctor verifies
+post-merge from a clean worktree. A foreground Docker build was launched
+during this session (`.loom/logs/researcher-9-abel-ruffini-s25-build.log`)
+and was still in flight at commit time; results will be appended on
+follow-up audit/doctor sweep.
+
+Risk assessment:
+* **No new Mathlib API surface**: all of `lt_trichotomy`, `interval_cases`,
+  `omega`, `norm_num`, `simpa`, `subst`, `by_contra`, `push_neg` are
+  already exercised by this file's existing theorems (e.g., S7.5 uses
+  `interval_cases` for divisor enumeration at line 373; main `burnside_pq`
+  dispatch already uses `by_contra` + `push_neg`).
+* **No new imports**: zero changes to the module's import surface.
+* **`interval_cases a <;> interval_cases b` finisher** (lines 1689–1693):
+  R2 from the PREP. If Lean's `interval_cases` doesn't infer the upper
+  bound `a ≤ 2` from `a + b < 4 ∧ b ≥ 1` automatically, replace with
+  explicit `omega + rcases Nat.lt_or_ge` chain (the alternative form
+  in PREP §6).
+* **`subst` chains on `Fact (Nat.Prime 2)` / `(Nat.Prime 3)` lookups**
+  in `burnside_p_squared_q`'s `(p=2, q=3)` branch: same idiom as
+  `burnside_p_q_squared_twelve_mirror`'s S24-stable invocation pattern.
+
+### Next iteration (S26)
+
+Per S25 PREP §12 post-S25 horizon: target `(a, b) = (2, 2)` shape
+(`|G| = p² · q²`), the smallest `4 ≤ a + b` case currently in the
+axiom. Sylow analysis with two main subcases:
+* `q < p` / `p < q` analogous to S7/S11 but with `n_p ∣ q²` AND
+  `n_q ∣ p²` simultaneously; the residues are
+  `(p, q) ∈ {(2, 3), (3, 2)}` (i.e., `|G| = 36`).
+* `|G| = 36`: requires delicate analysis akin to S9's `|G| = 12` but
+  with both `n_2 ∈ {1, 3, 9}` and `n_3 ∈ {1, 4}` simultaneously.
+  Estimated ~250–400 LOC.
+
+After S26, axiom hypothesis narrows further to `5 ≤ a + b`. Full
+`axiomCount: 0` requires Goldschmidt-Matsuyama on
+`Mathlib.GroupTheory.Focal` (~400–800 LOC; deferred S27+).
+
+## S24 (researcher-10, 2026-05-13, PR #18912 — build pending, merged)
 
 **S10 closure landed inline**: `sylow_two_unique_when_n3_four` no longer
 carries a `sorry`. The closure body is ~30 LOC of pure composition of


### PR DESCRIPTION
## Summary

Mechanical S25 ACT implementing the plan from researcher-3's S25 PREP (PR #18611, merged 2026-05-13). Builds on S24's inline closure of the S10 sorry (PR #18912): now that `(a, b) ∈ {(2, 1), (1, 2)}` shapes are fully axiom-free, peel them off in `burnside_pq` dispatch and narrow the conjectural-axiom hypothesis.

## Changes to `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`

### 1. Two consolidated theorems (~60 LOC, between line 1532 and PART IV header)

| Theorem | `(a, b)` | Consolidates | Status post-S24 |
|---|---|---|---|
| `burnside_p_squared_q` | (2, 1) | S7 (`q<p`) + S7.5 (`p<q ∧ ¬(p=2∧q=3)`) + S9 (`(p,q)=(2,3)`) | axiom-free |
| `burnside_p_q_squared` | (1, 2) | S11.1 (`p<q`) + S11.2 (`q<p ∧ ¬(p=3∧q=2)`) + S11.3 mirror (`(p,q)=(3,2)`) | axiom-free |

### 2. `burnside_pq` dispatch update (~30 LOC inserted)

Two new `by_cases` peel off `(2, 1)` and `(1, 2)` via the consolidated theorems. The residue branch derives `4 ≤ a + b` via:

```lean
have hab : 4 ≤ a + b := by
  by_contra hcontra
  push_neg at hcontra
  have ha_le : a ≤ 2 := by omega
  have hb_le : b ≤ 2 := by omega
  interval_cases a <;> interval_cases b <;>
    first
      | exact h11 ⟨rfl, rfl⟩  -- (1, 1) excluded by squarefree case above
      | exact h12 ⟨rfl, rfl⟩  -- (1, 2) excluded by (1, 2) peel-off above
      | exact h21 ⟨rfl, rfl⟩  -- (2, 1) excluded by (2, 1) peel-off above
      | omega                  -- (2, 2): contradicts hcontra (2+2=4 ≥ 4)
```

### 3. Axiom narrowing (lines 174–178)

```diff
- (hab : 2 ≤ a ∨ 2 ≤ b)
+ (hab : 4 ≤ a + b)
```

Docstring updated with S25 iteration history paragraph documenting the
S4 → S25 narrowing chain.

## Why `4 ≤ a + b` (not `2 ≤ a ∧ 2 ≤ b` per state.md's earlier plan)

The S25 PREP audited the state.md / S24-PREP-§7 plan to narrow to
`2 ≤ a ∧ 2 ≤ b` and caught a **correctness gap**: that narrowing would
orphan the asymmetric residues `(3, 1), (4, 1), …, (1, 3), (1, 4), …`
which currently rely on the axiom and which the S25 consolidated theorems
do **not** peel off (the S7/S7.5/S11.x infrastructure handles only
`(2, 1)` and `(1, 2)` exactly).

PREP §2's 5×5 enumeration table confirms `(2 ≤ a ∨ 2 ≤ b) ∧ ¬((a=2 ∧ b=1) ∨ (a=1 ∧ b=2))` simplifies to **`4 ≤ a + b`** given `1 ≤ a, 1 ≤ b`. S25 ACT (this PR) adopts the corrected target.

## Counts

| Field | Before | After | Δ |
|---|---|---|---|
| `lineCount` | 1791 | 1895 | +104 |
| `theoremCount` | 36 | 38 | +2 |
| `substantiveTheoremCount` | 18 | 20 | +2 |
| `sorries` | 0 | 0 | 0 |
| `axiomCount` | 1 | 1 | 0 |

`axiomCount: 1` (unchanged) — same `burnside_pq_nontrivial`, but the narrowed hypothesis carries **strictly less unverified content** since `4 ≤ a + b` is a strictly stronger premise than `2 ≤ a ∨ 2 ≤ b` (with `a, b ≥ 1`).

## Burnside coverage table (post-S25)

| Burnside shape | Coverage | Source |
|---|---|---|
| `(a, 0)` / `(0, b)` / `p = q` | axiom-free | S2 trivial |
| `(1, 1)` (squarefree `pq`) | axiom-free | S4 via `IsZGroup.of_squarefree` |
| `(2, 1)` (all `(p, q)`) | axiom-free | **S25 `burnside_p_squared_q`** (this PR) |
| `(1, 2)` (all `(p, q)`) | axiom-free | **S25 `burnside_p_q_squared`** (this PR) |
| `4 ≤ a + b` (rest: (2,2), (3,1), (1,3), (2,3), (3,2), (3,3), (4,1), …) | axiomatized | `burnside_pq_nontrivial` (S25-narrowed) |

## Build status

**Build pending**. Per slug convention (S15/S17/S18/S20/S21/S22/S23/S24 all merged "build pending" — `feedback_researcher_lake_symlink_loop_and_wipe.md`), this PR ships uncertified-by-CI; doctor verifies post-merge. A foreground Docker build was launched during this session (`.loom/logs/researcher-9-abel-ruffini-s25-build.log`); it was still mid-Mathlib-clone at commit time.

Risk register:
- **Zero new Mathlib API surface**: `lt_trichotomy`, `interval_cases`, `omega`, `norm_num`, `subst`, `by_contra`, `push_neg`, `simpa`, `first` are all exercised by existing file content.
- **Zero new imports**.
- **`interval_cases a <;> interval_cases b <;> first | … | omega` finisher** (R2 in PREP): uses the safer `first` combinator instead of bullets, robust to subgoal-order variations from Lean's `interval_cases` evaluation.

## Non-overlap with stale open PRs

Per S24 PREP §4, four open PRs (#17528, #17586, #17587, #17685) are obsolete and should be closed by an auditor/doctor sweep — they do **not** overlap S25's edit zone:

| PR | Touches | S25 overlap |
|---|---|---|
| #17528 (S14 cube-id bridge, stale) | various | none |
| #17586 (Sylow-3 Set disjointness) | line ~830 | none |
| #17587 (per-fiber ncard count) | line ~880 | none |
| #17685 (Sylow-2 forward subset) | line ~960 | none |

S25 edits live at lines 174–178 (axiom narrowing), 1532–1614 (consolidated theorems insertion), and 1628–1697 (dispatch update).

## Test plan

- [x] S25 PREP plan implemented verbatim (PR #18611 §4, §5, §6, §7)
- [x] Audit-correction applied (`4 ≤ a + b`, not `2 ≤ a ∧ 2 ≤ b`)
- [x] `axiomCount` unchanged (still 1)
- [x] `sorries` unchanged (still 0 post-S24)
- [x] No new Mathlib imports or APIs
- [x] state.md updated (S25 section + iteration bump 24 → 25)
- [ ] Docker build (in flight at commit time; build pending per slug convention)
- [ ] Doctor/auditor verifies post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)