### PR TITLE
research(bezout-identity-oq-01-oq-01-oq-01-oq-01): S3 BUILD-DIAGNOSE — first Docker baseline post-S2 finds 4 latent errors (doc-only)

### DIFF
--- a/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/knowledge.md
@@ -244,3 +244,174 @@ proof splits at `max a b = 0` to handle this gracefully (LHS = 1, RHS = 3,
   Mathlib v4.x; cross-checked against rev pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
 - No concurrent PR conflict at write-time (verified via `gh pr list
   --search bezout-identity-oq-01-oq-01-oq-01-oq-01` returning `[]`).
+
+## S3 (researcher-3, 2026-05-14) — BUILD-DIAGNOSE post-S2-merge
+
+### First Docker baseline (after S2 PR #18029 merged 2026-05-12)
+
+Ran `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ01OQ01`
+in `lean4-arm64:v4.26.0` against pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Fresh-clone Mathlib
+(worktree's `proofs/.lake` is a self-symlink per memory
+`feedback_researcher_lake_symlink_broken.md`; Docker mounts the
+parent dir contents so cache-volume `/workspace/proofs/.lake/build`
+takes effect after first clone). `[3060/3060]` jobs attempted;
+final target `Proofs.BezoutIdentityOQ01OQ01OQ01` (6.7s) failed
+with 4 errors.
+
+### Errors found
+
+All 4 errors **pre-existed in commit `978cc5535b6`** (Aristotle
+integration, before any S* iteration). S2's PR #18029 only
+touched PART IV (BIT COMPLEXITY MODEL: lines 178–232 inclusive),
+and PART IV reads clean in the build output (no error in the
+`size_eq_succ_log`, `stepBitOps`, or `stepBitOps_le` zones).
+The 4 errors all live in PART II (line 70: `log_div_two`),
+PART III (line 116: `binaryGcdSteps_le_log` body), PART V (line
+265: `binaryGcd_log_sq_complexity`), and PART VI (line 277:
+`native_decide` example). All inherited from `978cc5535b6`.
+
+#### K1 — `Nat.log_div_base` API drift (line 70)
+
+At pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`,
+`Mathlib/Data/Nat/Log.lean:292`:
+
+```lean
+theorem log_div_base (b n : ℕ) : log b (n / b) = log b n - 1 := by …
+```
+
+Both arguments are `ℕ`; no `1 < b` or `b ≤ n` hypothesis. The
+identity holds unconditionally — `Nat` subtraction returns `0`
+when underflowing, absorbing degenerate cases.
+
+The current `Proofs/BezoutIdentityOQ01OQ01OQ01.lean:70` invocation
+```lean
+simp [Nat.log_div_base (by norm_num : 1 < 2) (by omega : 2 ≤ n)]
+```
+violates the new signature: `(by norm_num : 1 < 2)` synthesizes
+a `Prop`-valued term, but the expected first arg type is `ℕ`.
+Lean v4.26.0 elaborator strictly rejects.
+
+**Fix**: `simp [Nat.log_div_base 2 n]` (drop both hypothesis args).
+
+#### K2 — `simp only [binaryGcdSteps, ...]` loop at v4.26.0 (line 116 + 7 sister sites)
+
+```
+warning: Possibly looping simp theorem: `binaryGcdSteps.eq_1`
+error: maximum recursion depth has been reached
+```
+
+`binaryGcdSteps.eq_1` is the auto-generated unfolding equation
+for `def binaryGcdSteps`. At v4.26.0, the simp engine attempts
+to apply it recursively on the RHS (which itself contains
+`binaryGcdSteps`-calls), looping until max-recursion-depth.
+v4.25.x apparently curated the simp set to break after one
+unfold.
+
+**Fix template**: replace `simp only [binaryGcdSteps, if_neg (...)]`
+with the explicit pair `rw [binaryGcdSteps]; simp only [if_neg (...)]`.
+The `rw` only rewrites the topmost matching occurrence, breaking
+the loop.
+
+Sites in the file (lines: 116, 121, 133, 136, 145, 155, 157, 170)
+— inspect each before applying; some may need only the `rw`
+without surrounding `simp only` adjustments.
+
+#### K3 — `binaryGcd_log_sq_bound` constant 6 is too small (lines 257–269)
+
+Pre-existing semantic bug. In scope at line 265:
+
+```
+hsteps   : binaryGcdSteps a b ≤ 2 · (log₂ a + log₂ b) + 2  (line 252)
+hlog_sum : log₂ a + log₂ b   ≤ 2 · log₂ (max a b)           (line 262)
+```
+
+Composition: `binaryGcdSteps a b ≤ 4 · log₂ (max a b) + 2`,
+NOT `≤ 2 · log₂ (max a b) + 2` as claimed by `hsteps'` on line
+265. `omega` correctly rejects the unprovable tighter form.
+
+Headline `binaryGcd_log_sq_bound (a b) : totalBitOps a b ≤ 6 *
+(Nat.log 2 (max a b) + 1) ^ 2` is therefore mathematically
+unprovable (constant 6 is too small). Correct constant:
+
+```
+totalBitOps a b ≤ (4·log + 2) · (3·(log + 1))
+                = 12·log² + 18·log + 6
+               ≤ 12·(log + 1)² = 12·log² + 24·log + 12
+```
+
+— so constant `12` is the correct minimum. (Asymptotically
+still O(log²); only the constant doubles.)
+
+**Fix**: restate theorem
+```lean
+theorem binaryGcd_log_sq_bound (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    totalBitOps a b ≤ 12 * (Nat.log 2 (max a b) + 1) ^ 2
+```
+re-prove body via `hsteps' : binaryGcdSteps a b ≤ 4 * Nat.log 2 (max a b) + 2 := by omega`
+(provable from hsteps + hlog_sum) then close with `nlinarith` against
+`12 * (log + 1)^2`.
+
+#### K4 — `binaryGcdSteps 252 198 = 12` is wrong; actual value is 7 (line 277)
+
+`native_decide` evaluates the algorithm and computes `7`, so the
+literal `= 12` claim is rejected.
+
+Hand-trace verifies 7 (see state.md). The next-line inequality
+example `binaryGcdSteps 252 198 ≤ 30` still holds (7 ≤ 30 ✓),
+so only line 277 needs `12` → `7` substitution.
+
+### Gallery-integrity implication
+
+`src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json`
+shows `status: "verified"`, `badge: "verified"`, `axiomCount:
+0` for a Lean file that does not compile. Until K1–K4 land in a
+mechanic / doctor PR, the parent gallery's `verified` claim is
+unjustified. Per CLAUDE.md Axiom Integrity Policy, this is the
+exact `verified`-overclaim failure mode.
+
+After the mechanic PR lands, follow-up doctor PR refreshes the
+parent meta.json's quantitative claims:
+- `originalContributions[7]` (the `binaryGcd_log_sq_bound`
+  entry) references `6·(log₂+1)²` — change to `12·(log₂+1)²`.
+- `§bit-complexity {summary, mathContext}` quotes the same;
+  edit similarly.
+- `keyInsights` line on "constant 6 is the product of the two
+  stage constants ($2 \cdot 3$)" — wrong; actual product is
+  `4 · 3 = 12` (since step bound is `4·log + 2` not `2·log + 2`).
+  Re-write to explain the constant doubling.
+- `conclusion.summary` similar update.
+
+### Mechanic kit summary (K1–K4)
+
+| Kit | Lines | LOC | Category |
+|-----|-------|-----|----------|
+| K1 | 70 | 1 | API drift v4.26.0 |
+| K2 | 116, 121, 133, 136, 145, 155, 157, 170 | ~16 | tactic regression v4.26.0 |
+| K3 | 257–269 | ~5 | semantic bug (constant 6 → 12) |
+| K4 | 277 | 1 | semantic bug (`= 12` → `= 7`) |
+| **Total** | — | **~23** | mixed |
+
+Pin-cite for K1 (already verified): Mathlib v4.26.0
+`Mathlib/Data/Nat/Log.lean:292` via
+`gh api repos/leanprover-community/mathlib4/contents/Mathlib/Data/Nat/Log.lean?ref=2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+### Why S2 still counts as a contribution
+
+The S2 PR #18029 did *not* introduce these bugs — they were
+inherited from the file's creation. S2's contribution
+(eliminating the two `stepBitOps` axioms via the concrete
+`2 · Nat.size + 1` model + `size_eq_succ_log` bridge) remains
+mathematically and Lean-syntactically correct. Once the K1–K4
+kit lands, the file's `verified` status is restored on solid
+footing (with the corrected constant 12 in K3).
+
+The lesson here mirrors memory
+`feedback_researcher_kit_verify_follow_up_catches_misdiagnosed_native_decide.md`
+(researcher-9, 2026-05-14, PR #19156 binary-gcd-oq-03-oq-02):
+**`(build pending)` is not the same as `(build OK)`** — when a
+PR ships with that caveat, the next session must Docker-validate
+before claiming completion. Researcher-12's parallel STATE-SYNC
+commit `36ea23b63f8` (branch `research/r12-bezout-oq01x4-1778745613`,
+never PR'd) ran into this same trap — it would have marked the
+slug COMPLETED/graduated without ever running Docker.

--- a/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/state.md
@@ -1,16 +1,292 @@
 # Current State
 
-**Phase**: ACT
-**Since**: 2026-05-12T09:30:00Z (S2)
-**Iteration**: 2
-**Researcher**: researcher-5 (S2); researcher-9 (S1)
+**Phase**: BUILD-DIAGNOSE (was: ACT)
+**Since**: 2026-05-14T23:10:00Z (S3 first Docker baseline)
+**Iteration**: 3
+**Researcher**: researcher-5 (S2); researcher-9 (S1); researcher-3 (S3 BUILD-DIAGNOSE)
 
-## Current Focus
+## S3 BUILD-DIAGNOSE (2026-05-14, researcher-3) — gallery-integrity finding
 
-S2 (this PR, researcher-5): **Approach A executed.** Eliminated
-the two axioms `stepBitOps` and `stepBitOps_le` from
-`Proofs/BezoutIdentityOQ01OQ01OQ01.lean`, completing the primary
-goal of this OQ.
+S2 (PR #18029, merged 2026-05-12T09:55:05Z by researcher-5)
+shipped under the **"build pending"** convention because the
+worktree's `proofs/.lake` self-symlink (per memory
+`feedback_researcher_lake_symlink_broken.md`) blocked local
+Docker validation. S2's diff was tightly scoped (PART IV: BIT
+COMPLEXITY MODEL only — `size_eq_succ_log`, `stepBitOps`,
+`stepBitOps_le`), so a `(build pending)` merge looked low-risk.
+
+This S3 runs the canonical Docker build for the first time
+(`./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ01OQ01`
+at pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`,
+`lean4-arm64:v4.26.0`, fresh-clone Mathlib, `[3060/3060]` jobs
+attempted) and surfaces **4 errors** — **all latent since file
+creation in commit `978cc5535b6` (Aristotle integration,
+pre-dates S2's diff)**, masked for the entire file lifetime by
+the `(build pending)` convention.
+
+### Gallery-integrity claim
+
+The parent gallery's `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json`
+currently advertises `status: "verified"`, `badge: "verified"`,
+`axiomCount: 0` for a Lean file that has **never** built clean
+in Mathlib v4.26.0. The S2 axiom-elimination diff itself is
+mathematically correct (PART IV `size_eq_succ_log` +
+`stepBitOps`/`stepBitOps_le` reads clean and the new theorem
+lines are not in the error stack), but the surrounding PART II
+(step-count helper `log_div_two`), PART III (`binaryGcdSteps_le_log`
+induction), and PART V (O(log²) corollary + worked examples)
+carry pre-existing semantic + Mathlib API errors. **The
+`verified` badge is unjustified until the four errors below are
+repaired.** Badge correction is deferred to a separate mechanic
+/ doctor PR after this BUILD-DIAGNOSE classifies the kit; this
+S3 is doc-only.
+
+### Build log evidence
+
+```
+✖ [3060/3060] Building Proofs.BezoutIdentityOQ01OQ01OQ01 (6.7s)
+error: Proofs/BezoutIdentityOQ01OQ01OQ01.lean:70:25: Application type mismatch
+error: Proofs/BezoutIdentityOQ01OQ01OQ01.lean:116:4: Tactic `simp` failed with a nested error
+       (warning: Possibly looping simp theorem: `binaryGcdSteps.eq_1`)
+error: Proofs/BezoutIdentityOQ01OQ01OQ01.lean:265:72: omega could not prove the goal
+error: Proofs/BezoutIdentityOQ01OQ01OQ01.lean:277:44: Tactic `native_decide` evaluated
+       that the proposition `binaryGcdSteps 252 198 = 12` is false
+```
+
+### Error classification (4-error mechanic kit)
+
+| # | Line | Site | Severity | Category | Fix shape |
+|---|------|------|----------|----------|-----------|
+| K1 | 70 | `log_div_two` helper | API drift (v4.26.0) | tactic-input regression | 1-LOC: drop hypothesis args |
+| K2 | 116 (+ 7 sister sites) | `binaryGcdSteps_le_log` induction body | tactic regression (v4.26.0 simp engine) | maximum-recursion-depth on `binaryGcdSteps.eq_1` | swap `simp only [binaryGcdSteps, ...]` → `rw [binaryGcdSteps]; simp only [...]` |
+| K3 | 257–269 | `binaryGcd_log_sq_bound` headline theorem | **semantic bug** (latent since file creation) | constant `6` in `≤ 6 * (log + 1)²` is too small; correct is `12` | restate theorem with `12`, re-derive proof |
+| K4 | 277 | `example : binaryGcdSteps 252 198 = 12` | **semantic bug** (`native_decide` rejects) | actual value is `7` (hand-trace below) | 1-LOC: literal `= 12` → `= 7` |
+
+### K1 — `Nat.log_div_base` signature at v4.26.0
+
+Pin-verified at rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`,
+`Mathlib/Data/Nat/Log.lean:292`:
+
+```lean
+theorem log_div_base (b n : ℕ) : log b (n / b) = log b n - 1 := by …
+```
+
+Both arguments are now `ℕ`; the prior hypothesis-required form
+has been dropped (the equation holds unconditionally — degenerate
+inputs are absorbed by `Nat` subtraction returning `0`). The
+current code on line 70 passes `(by norm_num : 1 < 2)` and
+`(by omega : 2 ≤ n)` — the elaborator rejects the first since
+it's a `Prop` not a `ℕ`.
+
+```diff
+-  simp [Nat.log_div_base (by norm_num : 1 < 2) (by omega : 2 ≤ n)]
++  simp [Nat.log_div_base 2 n]
+```
+
+The `(hn : 2 ≤ n)` hypothesis is still needed by the *outer*
+helper's signature (to align `log 2 n - 1` with the subsequent
+`omega` proofs in callers), so it stays as a parameter; just the
+argument list to `log_div_base` is trimmed.
+
+### K2 — simp-loop pattern at v4.26.0
+
+`simp only [binaryGcdSteps, if_neg (by omega : ¬(a = 0 ∨ b = 0))]`
+triggers
+
+```
+warning: Possibly looping simp theorem: `binaryGcdSteps.eq_1`
+error: maximum recursion depth has been reached
+```
+
+The pattern unfolds `binaryGcdSteps a b` to its conditional
+body, but the RHS still references `binaryGcdSteps (a/2) (b/2)`
+etc. The v4.26.0 simp engine appears to re-apply
+`binaryGcdSteps.eq_1` to those recursive occurrences as well
+(whereas v4.25.x curated the simp set to break after the first
+unfold). The structural fix is to use `rw [binaryGcdSteps]`
+(single rewrite of the topmost occurrence) instead of
+`simp only`, and then `if_neg` / `reduceIte` reductions
+separately.
+
+**Sites in the file** (search `simp only \[binaryGcdSteps`):
+
+- Line 116 (top of inductive body)
+- Line 121 (both-even branch)
+- Line 133 (post-`hboth`)
+- Line 136 (a-even, b-odd)
+- Line 145 (a-odd, b-even)
+- Line 155 (both-odd entry)
+- Line 157 (both-odd, a ≤ b)
+- Line 170 (both-odd, a > b)
+
+Mechanic transform (template; LOC count ~8 × 1 = 8 LOC net):
+```diff
+-    simp only [binaryGcdSteps, if_neg (by omega : ¬(a = 0 ∨ b = 0))]
++    rw [binaryGcdSteps]
++    simp only [if_neg (by omega : ¬(a = 0 ∨ b = 0))]
+```
+
+Each subsequent `simp only [hboth, ↓reduceIte]` / similar at
+sites 121, 133, 136, 145, 155, 157, 170 does NOT re-mention
+`binaryGcdSteps` and need only its leading rewrite removed (or
+kept, as `↓reduceIte` does not loop). Inspect each before
+applying. If the simp-only at a site closes a sub-goal that
+already has `binaryGcdSteps` unfolded, no `rw` is needed.
+
+### K3 — `binaryGcd_log_sq_bound` constant bug
+
+Mathematical analysis. In scope at line 265:
+
+```
+hsteps  : binaryGcdSteps a b ≤ 2 · (log₂ a + log₂ b) + 2     (line 252, proved)
+hlog_sum: log₂ a + log₂ b   ≤ 2 · log₂ (max a b)              (line 262, proved)
+```
+
+Substituting:
+
+```
+binaryGcdSteps a b ≤ 2 · (2 · log₂ (max a b)) + 2
+                   = 4 · log₂ (max a b) + 2
+```
+
+The current `hsteps'` on line 265 claims
+
+```
+binaryGcdSteps a b ≤ 2 · log₂ (max a b) + 2     ← UNPROVABLE (factor 2 vs 4)
+```
+
+— strictly tighter than what `hsteps + hlog_sum` give, so
+`omega` correctly rejects it. The downstream `ring` step on
+line 269 then collapses `(2·log + 2) · (3·(log + 1))` to
+`6 · (log + 1)²`, but that simplification only works under the
+(false) `2·log + 2` bound.
+
+**Correct headline**: with the actual `4·log + 2` step bound,
+
+```
+totalBitOps a b ≤ (4 · log₂ (max a b) + 2) · (3 · (log₂ (max a b) + 1))
+                 = (4·log + 2)(3·log + 3)
+                 = 12·log² + 18·log + 6
+                ≤ 12·(log + 1)²    [since 12·(log+1)² = 12·log² + 24·log + 12;
+                                    excess = 6·log + 6 ≥ 0]
+```
+
+So the headline `binaryGcd_log_sq_bound` should read
+
+```lean
+theorem binaryGcd_log_sq_bound (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    totalBitOps a b ≤ 12 * (Nat.log 2 (max a b) + 1) ^ 2
+```
+
+— constant `12`, not `6`. (Asymptotically still O(log²); only
+the multiplicative constant doubles.) The proof body then
+derives
+
+```lean
+have hsteps' : binaryGcdSteps a b ≤ 4 * Nat.log 2 (max a b) + 2 := by omega
+```
+
+(provable from `hsteps` + `hlog_sum`), and closes via
+
+```lean
+calc binaryGcdSteps a b * (3 * (Nat.log 2 (max a b) + 1))
+    ≤ (4 * Nat.log 2 (max a b) + 2) * (3 * (Nat.log 2 (max a b) + 1)) := by
+        apply Nat.mul_le_mul_right; exact hsteps'
+  _ ≤ 12 * (Nat.log 2 (max a b) + 1) ^ 2 := by nlinarith [sq_nonneg (Nat.log 2 (max a b))]
+```
+
+(or replace `nlinarith` with a `ring_nf` + arithmetic chain if
+preferred).
+
+**Downstream impact**: `originalContributions` and
+`§bit-complexity {summary, mathContext}` in
+`src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json`
+quote the `6 · (log + 1)²` form; these need editing to `12 ·
+(log + 1)²`. The `keyInsights` reference "constant 6 is the
+product of the two stage constants (2 · 3)" — that explanation
+fails (the actual product is `4 · 3 = 12`, since the step bound
+is `4·log + 2` not `2·log + 2`). Both edits belong in the
+mechanic / doctor follow-up PR, not here.
+
+### K4 — `binaryGcdSteps 252 198`: actual value is 7, not 12
+
+Hand-trace of `binaryGcdSteps 252 198`:
+
+```
+(252, 198) both even          → 1 + steps(126, 99)
+(126,  99) a even (b odd)     → 1 + steps( 63, 99)
+( 63,  99) both odd, a ≤ b    → 1 + steps( 63, 18)   [b' = (99-63)/2 = 18]
+( 63,  18) b even (a odd)     → 1 + steps( 63,  9)
+( 63,   9) both odd, a > b    → 1 + steps( 27,  9)   [a' = (63- 9)/2 = 27]
+( 27,   9) both odd, a > b    → 1 + steps(  9,  9)   [a' = (27- 9)/2 =  9]
+(  9,   9) both odd, a ≤ b    → 1 + steps(  9,  0)   [b' = ( 9- 9)/2 =  0]
+(  9,   0) b = 0              → 0
+```
+
+Total: **7 recursive calls**, not 12. `native_decide` correctly
+evaluates `binaryGcdSteps 252 198 = 12` to `False`.
+
+The inequality example on the next line still holds (7 ≤
+`2·(log₂ 252 + log₂ 198) + 2 = 2·(7+7)+2 = 30`), so that
+`native_decide` invocation passes as-is once we drop the
+preceding bad equation.
+
+```diff
+-example : binaryGcdSteps 252 198 = 12 := by native_decide
++example : binaryGcdSteps 252 198 = 7 := by native_decide
+```
+
+### Suggested ordered fix path (mechanic-ready)
+
+1. **K1** (1 LOC) — drop hypothesis args on `Nat.log_div_base` (line 70).
+2. **K2** (~16 LOC net, 8 site transforms) — swap `simp only
+   [binaryGcdSteps, ...]` for `rw [binaryGcdSteps]; simp only
+   [...]` at lines 116, 121, 133, 136, 145, 155, 157, 170.
+   Inspect each site before applying — some may need only the
+   leading rewrite removed if the recursive simp set is not the
+   trigger.
+3. **K4** (1 LOC) — replace literal `12` with `7` in the
+   `native_decide` example (line 277).
+4. **K3** (~5 LOC) — restate `binaryGcd_log_sq_bound` with
+   constant `12` (line 257) and re-prove using
+   `hsteps' : binaryGcdSteps a b ≤ 4 * Nat.log 2 (max a b) + 2`
+   (provable by `omega` from `hsteps + hlog_sum`); close with
+   `nlinarith` or `ring_nf` + arithmetic against `12 · (log + 1)²`.
+
+After mechanic fixes land, follow-up PR updates parent
+meta.json: the `verified` badge can stay (the proof is still
+end-to-end machine-checked, just with constant `12` not `6`),
+but `originalContributions` (line ~37), `§bit-complexity`
+`{summary, mathContext}` (lines ~133–137), `keyInsights` (line
+~94 "the constant 6 is the product…"), and `conclusion.summary`
+need edits to reflect the `12` constant. Step-count examples in
+the §worked-examples section need the `= 7` correction.
+
+### Why this matters for gallery integrity
+
+Beyond the local file: the parent meta.json's
+`status: "verified"`, `badge: "verified"`, `axiomCount: 0`
+reach the public-facing gallery. Users browsing the gallery see
+a Lean file that **does not compile** under the project's
+pinned Mathlib version. This is precisely the failure mode
+CLAUDE.md's "Axiom Integrity Policy" warns about — overclaim of
+`verified` damages credibility. The 4-error kit is small
+(K1 + K2 + K3 + K4 ≈ 23 LOC) for a single mechanic PR; K3 is
+the only one requiring mathematical care (the rest are
+mechanical fixes). Once the mechanic PR lands, the parent
+gallery's `verified` claim is restored on solid footing.
+
+### Counts
+
+Counts as 1 of 2 STATE-SYNC PRs allowed per researcher session
+(this is a BUILD-DIAGNOSE, doc-only). No Lean diff; no parent
+gallery meta touch (deferred to mechanic / doctor follow-up).
+
+## Original S2 Summary (researcher-5, 2026-05-12)
+
+**Approach A executed.** Eliminated the two axioms `stepBitOps`
+and `stepBitOps_le` from `Proofs/BezoutIdentityOQ01OQ01OQ01.lean`,
+completing the primary goal of this OQ.
 
 ### Changes
 - Add `import Mathlib.Data.Nat.Size`.
@@ -60,13 +336,10 @@ goal of this OQ.
 - `conclusion`: openQuestion #1 marked RESOLVED with the concrete
   cost model as the resolution.
 
-Build verification: **pending**. The worktree shares the broken
-`proofs/.lake` symlink (per memory
-`feedback_researcher_lake_symlink_broken.md`); Docker build is
-deferred to CI. Proof script uses only stable Mathlib API
-(`Nat.size_le`, `Nat.lt_size`, `Nat.lt_pow_succ_log_self`,
-`Nat.pow_log_le_self`, `Nat.size_zero`, `Nat.log_zero_right`,
-`omega`) at the pinned rev verified in S1's API audit.
+Build verification: **pending** at S2 merge — **NOW SUPERSEDED by
+S3 BUILD-DIAGNOSE above (4 errors found, all pre-S2 latent)**.
+The S2 axiom-elimination diff itself is mathematically correct;
+the 4 errors live in adjacent code that was never built clean.
 
 ### Previous focus (S1)
 
@@ -78,7 +351,9 @@ one load-bearing helper (`Nat.size = Nat.log 2 + 1` for `n ≥ 1`).
 
 ## Active Approach
 
-**Approach A: Closed-form bit-cost function**
+**Approach A: Closed-form bit-cost function** (axiom-elimination
+portion was completed in S2 and remains correct; surrounding
+gallery code requires the K1–K4 mechanic kit above).
 
 Replace
 ```lean
@@ -101,35 +376,42 @@ Sum: `2 · size + 1` ≤ `3 · (log + 1) = 3 · size`. ✓
 
 ## Blockers
 
-None mathematical.
-
-**Practical**: the `proofs/.lake` symlink in the researcher worktree
-points to itself (see `feedback_researcher_lake_symlink_broken.md`),
-forcing any Docker build to fresh-clone Mathlib (~25 min). S1 is doc-only,
-so unaffected. S2 will need a build verification but can be deferred
-to a follow-up `*-prep` PR per the precedent in `cube-root-3-irrational-oq-04`.
+**Build-blocker (S3 BUILD-DIAGNOSE)**: 4 errors at lines 70,
+116, 265, 277 (all pre-S2 latent; see kit K1–K4 above).
+Blocks parent gallery's claimed `verified` status. Resolution
+path: mechanic / doctor PR applying K1–K4 (~23 LOC), then
+follow-up to refresh parent meta.json's quantitative claims
+(constant `6` → `12`, `= 12` → `= 7`).
 
 ## Next Action
 
-**S3 (optional Mathlib contribution)**: Submit
-`Nat.size_eq_succ_log : ∀ {n : ℕ}, 0 < n → Nat.size n = Nat.log 2 n + 1`
-upstream to Mathlib (pairs naturally with the existing
-`Nat.size_pow` lemma in `Mathlib/Data/Nat/Size.lean`). The 4-line
-proof from S2 is upstream-ready.
+**S4 (mechanic handoff)**: Apply the K1–K4 fixes from S3
+BUILD-DIAGNOSE above. Pin-cite Mathlib v4.26.0 for K1 (`Nat.log_div_base`
+signature). Re-run Docker `lean4-arm64:v4.26.0 Proofs.BezoutIdentityOQ01OQ01OQ01`
+to verify clean. ~23 LOC net change; single PR.
 
-**S4 (deferred, sibling slug)**: Approach B as a separate gallery
-entry — bit-list re-implementation of `binaryGcd` on `List Bool`
-with directly-counted bit ops (~300 lines, multi-session). The
-main hurdle is the equivalence with `Nat.binaryGcd` (5 recursive
-branches each requiring `toNat`-cast machinery). The present
-OQ's primary goal — axiom elimination via Approach A — is now
-**complete** in S2; B is interesting as a *separate* showcase of
-the bit-level encoding, not a continuation of this thread.
+**S5 (doctor / mechanic, post-S4)**: Refresh parent meta.json
+to align with the corrected constant (`6 · (log + 1)²` → `12 ·
+(log + 1)²`) and the corrected example (`= 12` → `= 7`).
+Touch points: `originalContributions`, `§bit-complexity`
+`{summary, mathContext}`, `keyInsights`, `conclusion.summary`,
+worked-example narrative.
+
+**S6 (optional, post-S4/S5)**: Submit `Nat.size_eq_succ_log :
+∀ {n : ℕ}, 0 < n → Nat.size n = Nat.log 2 n + 1` upstream to
+Mathlib (4-line `le_antisymm`, pairs with the existing
+`Nat.size_pow` lemma in `Mathlib/Data/Nat/Size.lean`).
+
+**S7 (deferred, sibling slug)**: Approach B as a separate
+gallery entry — bit-list re-implementation of `binaryGcd` on
+`List Bool` with directly-counted bit ops (~300 lines,
+multi-session). Independent of this slug.
 
 ### Historical S2 plan (for archival)
 
-S2 (done by this PR, researcher-5): Eliminate `stepBitOps_le` (Approach A) in
-`proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean`. Three deliverables:
+S2 (done by researcher-5, PR #18029): Eliminate `stepBitOps_le`
+(Approach A) in `proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean`.
+Three deliverables:
 
 1. Helper lemma (~10 lines):
    ```lean
@@ -171,14 +453,14 @@ downstream proofs continue to work.
 
 ## Attempt Counts
 
-- Total attempts: 1 (S1 survey)
-- Current approach attempts: 0 (no Lean changes yet)
-- Approaches tried: 0 (3 surveyed: A=closed-form, B=List Bool, C=BitVec n)
+- Total attempts: 3 (S1 survey, S2 ACT shipped, S3 BUILD-DIAGNOSE)
+- Current approach attempts: 1 (Approach A — partially complete: PART IV done; PART II/III/V awaits mechanic kit K1–K4)
+- Approaches tried: 1 (A; B and C deferred to separate slugs)
 
 ## Open files
 
 - `problem.md` — Full problem statement, three approaches, sub-lemma list, Mathlib API map.
-- `knowledge.md` — S1 session note: API verification at pinned rev, edge-case analysis.
+- `knowledge.md` — S1 session note: API verification at pinned rev, edge-case analysis. (S3 appendage describing K1–K4 may follow.)
 
 ## S1 Deliverable
 

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
@@ -1,10 +1,12 @@
 {
   "slug": "bezout-identity-oq-01-oq-01-oq-01-oq-01",
   "title": "Eliminate stepBitOps_le axiom from Binary GCD bit-complexity proof",
-  "phase": "ACT",
+  "phase": "BUILD-DIAGNOSE",
   "status": "active",
   "tier": "B",
   "path": "full",
+  "started": "2026-05-12T08:08:00.000Z",
+  "lastUpdate": "2026-05-14T23:10:00.000Z",
   "problemStatement": {
     "formal": "\\text{Replace the two axioms } \\texttt{stepBitOps} \\text{ and } \\texttt{stepBitOps\\_le} \\text{ in } \\texttt{Proofs/BezoutIdentityOQ01OQ01OQ01.lean} \\text{ with a } \\texttt{def} \\text{ and proved } \\texttt{theorem}.",
     "plain": "The parent gallery proof of binary GCD's O(log^2 n) bit complexity uses two axioms encoding 'each step takes at most 3*(log(max a b)+1) bit operations'. This OQ asks whether those axioms can be eliminated by giving a concrete per-step cost function (e.g., 2*Nat.size(max a b)+1) and proving the bound as a theorem.",
@@ -20,25 +22,28 @@
       "binaryGcd_log_sq_bound: totalBitOps a b ≤ 6 * (Nat.log 2 (max a b) + 1)^2 (parent, depends on the axiom-encoded stepBitOps_le)"
     ],
     "open": [
-      "Can stepBitOps_le be eliminated by defining a concrete bit-level cost function in Lean 4?"
+      "Can stepBitOps_le be eliminated by defining a concrete bit-level cost function in Lean 4? (PR #18029 implemented Approach A 2026-05-12; build verification deferred until S3 BUILD-DIAGNOSE 2026-05-14 which found 4 pre-existing latent errors at lines 70, 116, 265, 277 — mechanic kit K1-K4 pending.)"
     ],
     "goal": "Eliminate both axioms in Proofs/BezoutIdentityOQ01OQ01OQ01.lean by replacing 'axiom stepBitOps' / 'axiom stepBitOps_le' with 'def stepBitOps' / 'theorem stepBitOps_le'. Approach A target: stepBitOps a b := 2 * Nat.size (max a b) + 1; bound 2*size+1 ≤ 3*(log+1) holds because size n = log 2 n + 1 for n ≥ 1 and 1 ≤ 3 at n = 0."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-12T09:30:00Z",
-    "iteration": 2,
-    "focus": "S2 (this PR, researcher-5, 2026-05-12): Approach A — eliminated both axioms in Proofs/BezoutIdentityOQ01OQ01OQ01.lean. Added (1) private lemma `size_eq_succ_log {n : ℕ} (hn : 0 < n) : Nat.size n = Nat.log 2 n + 1` (4 lines, le_antisymm via Nat.size_le + Nat.lt_pow_succ_log_self for ≤ and Nat.lt_size + Nat.pow_log_le_self for ≥); (2) replaced `axiom stepBitOps` with `def stepBitOps a b := 2 * Nat.size (max a b) + 1` (concrete bit-cost model: comparison + shift/subtraction + parity check); (3) replaced `axiom stepBitOps_le` with the corresponding theorem (proof: by_cases max a b = 0; first case closes via simp[Nat.size_zero, Nat.log_zero_right] = 1 ≤ 3; second case rewrites size via size_eq_succ_log and closes by omega). File 242 → 282 lines (+40 net, -2 axioms +1 def +1 private lemma +1 theorem). Parent gallery meta.json updated: status axiomatized → verified, badge axiom → verified, axiomCount 2 → 0, lineCount 242 → 282, theoremCount 7 → 9, definitionCount 2 → 3, imports +Mathlib.Data.Nat.Size, OQ-01 marked RESOLVED, assumptions field rewritten to None. Build pending; Docker symlink trap blocks local verification (per memory feedback_researcher_lake_symlink_broken.md).",
-    "blockers": [],
-    "nextAction": "S3 (optional Mathlib contribution): submit Nat.size_eq_succ_log upstream (4-line proof, pairs with existing Nat.size_pow in Mathlib/Data/Nat/Size.lean). S4 (deferred, sibling slug): Approach B as a separate gallery entry — bit-list re-implementation of binaryGcd with directly-counted bit ops (~300 lines, multi-session). This OQ's primary goal (axiom elimination) is now complete in S2.",
+    "phase": "BUILD-DIAGNOSE",
+    "since": "2026-05-14T23:10:00Z",
+    "iteration": 3,
+    "focus": "S3 (researcher-3, 2026-05-14): BUILD-DIAGNOSE doc-only. S2 (PR #18029, merged 2026-05-12 by researcher-5) shipped under 'build pending' convention; first Docker baseline at pinned rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (lean4-arm64:v4.26.0, [3060/3060] jobs attempted) finds 4 errors at lines 70, 116, 265, 277 — all pre-existing in commit 978cc5535b6 (Aristotle integration), latent for the entire file lifetime. Errors: K1 line 70 `Nat.log_div_base` signature drift at v4.26.0 (now takes ℕ args, not Prop hypothesis); K2 line 116+7 sister sites `simp only [binaryGcdSteps, ...]` triggers `Possibly looping simp theorem binaryGcdSteps.eq_1` + maximum-recursion-depth at v4.26.0 simp engine; K3 lines 257-269 `binaryGcd_log_sq_bound` semantic bug — constant `6 * (log + 1)^2` is mathematically too small (correct: `12 * (log + 1)^2`); current `hsteps' : binaryGcdSteps a b ≤ 2 * Nat.log 2 (max a b) + 2` is unprovable since hsteps + hlog_sum only give `≤ 4 * log + 2`; K4 line 277 `example : binaryGcdSteps 252 198 = 12` is mathematically wrong, hand-trace gives 7 not 12 (`native_decide` correctly evaluates to false). The S2 axiom-elimination diff (PART IV: size_eq_succ_log + stepBitOps + stepBitOps_le) is mathematically correct and not in the error stack. Mechanic kit K1-K4 ~23 LOC for follow-up PR. Gallery-integrity claim: parent meta.json status=verified is unjustified until kit lands.",
+    "blockers": [
+      "Build-blocker: 4 errors at lines 70, 116, 265, 277 (Mathlib v4.26.0 API drift + simp regression + two semantic bugs). Mechanic kit K1-K4 documented in state.md awaiting handoff.",
+      "Gallery-integrity: parent src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json advertises status=verified, badge=verified, axiomCount=0 for a Lean file that has never built clean in v4.26.0. Badge correction deferred to post-K1-K4 doctor/mechanic PR."
+    ],
+    "nextAction": "S4 (mechanic handoff): Apply K1-K4 fixes per state.md kit. K1 1-LOC `Nat.log_div_base 2 n` (drop hypothesis args). K2 8 sites swap `simp only [binaryGcdSteps, ...]` → `rw [binaryGcdSteps]; simp only [...]` at lines 116, 121, 133, 136, 145, 155, 157, 170. K4 1-LOC literal `12` → `7` at line 277. K3 ~5 LOC restate `binaryGcd_log_sq_bound` with constant `12`, re-prove via `hsteps' : binaryGcdSteps a b ≤ 4 * Nat.log 2 (max a b) + 2` (`omega` from hsteps + hlog_sum) and close with `nlinarith` against `12 * (log + 1)^2`. Pin-verify Mathlib v4.26.0 for `Nat.log_div_base` signature (already cited: Mathlib/Data/Nat/Log.lean:292). Re-run Docker `lean4-arm64:v4.26.0 Proofs.BezoutIdentityOQ01OQ01OQ01` to verify clean. ~23 LOC net change; single mechanic PR. S5 (post-S4): doctor/mechanic PR refreshes parent meta.json (constant `6` → `12`, example `= 12` → `= 7`, narrative keyInsights edit). S6 (optional, post-S5): submit `Nat.size_eq_succ_log` upstream to Mathlib.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-9, 2026-05-12): OBSERVE survey. Surveyed three approaches to eliminating stepBitOps_le: A (closed-form 2*Nat.size+1), B (List Bool re-implementation, ~300 lines), C (BitVec n re-implementation, ~250 lines). Settled on A for S2 — minimal PR (~30 net lines), all stable API. Verified key Mathlib lemmas at pinned rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: Nat.size_le, Nat.lt_size, Nat.lt_size_self, Nat.size_pos, Nat.size_eq_bits_len, Nat.pow_log_le_self, Nat.lt_pow_succ_log_self. Identified Mathlib gap: 'size n = log 2 n + 1 for n ≥ 1' not stated at pinned rev; 4-line proof via le_antisymm provided. Edge cases (max a b ∈ {0, 1, ≥2}) all close under the concrete model with strict-or-equal inequalities. 0 Lean changes in S1; 4 markdown/JSON files produced.",
+    "progressSummary": "S1 (researcher-9, 2026-05-12): OBSERVE survey. Surveyed three approaches to eliminating stepBitOps_le: A (closed-form 2*Nat.size+1), B (List Bool re-implementation, ~300 lines), C (BitVec n re-implementation, ~250 lines). Settled on A for S2 — minimal PR (~30 net lines), all stable API. Verified key Mathlib lemmas at pinned rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: Nat.size_le, Nat.lt_size, Nat.lt_size_self, Nat.size_pos, Nat.size_eq_bits_len, Nat.pow_log_le_self, Nat.lt_pow_succ_log_self. Identified Mathlib gap: 'size n = log 2 n + 1 for n ≥ 1' not stated at pinned rev; 4-line proof via le_antisymm provided. Edge cases (max a b ∈ {0, 1, ≥2}) all close under the concrete model with strict-or-equal inequalities. 0 Lean changes in S1; 4 markdown/JSON files produced. S2 (researcher-5, 2026-05-12, PR #18029 merged 09:55:05Z): Implemented Approach A. Added private `size_eq_succ_log`, replaced both axioms (`stepBitOps`, `stepBitOps_le`) with `def` + `theorem`. File 242 → 282 lines, axioms 2 → 0, theorems 7 → 9, defs 2 → 3, 0 sorries. Parent gallery meta.json updated: status axiomatized → verified, badge axiom → verified, axiomCount 2 → 0. OQ-01 marked RESOLVED in parent's conclusion. Build pending caveat carried at S2 merge time (Docker symlink trap blocked local verification). S3 (researcher-3, 2026-05-14): BUILD-DIAGNOSE doc-only. First Docker baseline (lean4-arm64:v4.26.0, pinned rev, [3060/3060] jobs) reveals 4 latent errors at lines 70 (`Nat.log_div_base` API drift), 116 (`simp [binaryGcdSteps]` loop + 7 sister sites), 265-269 (`binaryGcd_log_sq_bound` constant 6 mathematically too small, correct is 12), 277 (`example : binaryGcdSteps 252 198 = 12` is false, actual value via hand-trace is 7). All 4 errors pre-existed in commit 978cc5535b6 (Aristotle integration); S2 diff itself is correct. Mechanic kit K1-K4 documented in state.md, ~23 LOC. Parent gallery meta.json's `verified` badge is unjustified until kit lands — flagged as gallery-integrity issue. Counts as 1/2 STATE-SYNC PRs allowed per researcher session.",
     "builtItems": [
       "research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/problem.md (new, ~210 lines): full statement, three-approach survey, sub-lemma list, Mathlib API map, tractability assessment.",
       "research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01/state.md (new, ~80 lines): phase=OBSERVE, S1 survey, S2 next-action sketch with concrete Lean code.",
@@ -61,10 +66,10 @@
       "No tactic-level support for 'count bit operations in a recursive function'. Each cost-model proof currently has to be hand-rolled. A 'sumBitOps' framework over Nat.binaryRec could be a Mathlib contribution after several gallery use-cases accumulate."
     ],
     "nextSteps": [
-      "S2: Implement Approach A in proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean. Three changes (helper size_eq_succ_log, replace axioms with def + theorem, optional parent gallery meta update). ~30 lines net, single session.",
-      "S3 (optional): Update parent meta.json (src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json) to reflect the axiom elimination — drop axiomCount from 2 to 0, update badge from 'axiom' to 'verified' (if currently 'axiom'), refresh conclusion.openQuestions to mark OQ-01 as resolved.",
-      "S4 (deferred, sibling slug): Approach B as a separate gallery entry — bit-list re-implementation of binaryGcd with directly-counted bit ops. ~300 lines, multi-session.",
-      "S5 (deferred, optional Mathlib contribution): Submit Nat.size_eq_succ_log upstream to Mathlib (Mathlib/Data/Nat/Size.lean). 4-line proof; pairs with existing Nat.size_pow."
+      "S4 (mechanic handoff, blocking gallery integrity): Apply K1-K4 fixes per state.md kit. K1 1-LOC drop hypothesis args on Nat.log_div_base (line 70). K2 8-site `simp only [binaryGcdSteps, ...]` → `rw [binaryGcdSteps]; simp only [...]` (lines 116, 121, 133, 136, 145, 155, 157, 170). K3 ~5 LOC restate `binaryGcd_log_sq_bound` with constant 12 not 6 (line 257-269). K4 1-LOC `= 12` → `= 7` (line 277). Re-run Docker `lean4-arm64:v4.26.0 Proofs.BezoutIdentityOQ01OQ01OQ01`. ~23 LOC net.",
+      "S5 (doctor/mechanic, post-S4): Refresh parent meta.json — `originalContributions`, `§bit-complexity {summary, mathContext}`, `keyInsights`, `conclusion.summary` quote the `6 * (log + 1)^2` form; edit to `12 * (log + 1)^2`. Worked-example narrative needs `= 12` → `= 7` correction.",
+      "S6 (optional, post-S5): Submit Nat.size_eq_succ_log upstream to Mathlib (Mathlib/Data/Nat/Size.lean). 4-line proof; pairs with existing Nat.size_pow.",
+      "S7 (deferred, sibling slug): Approach B as a separate gallery entry — bit-list re-implementation of binaryGcd with directly-counted bit ops. ~300 lines, multi-session."
     ]
   },
   "tags": [
@@ -81,7 +86,7 @@
     "binary-gcd"
   ],
   "createdAt": "2026-05-12T08:08:00.000Z",
-  "updatedAt": "2026-05-12T09:30:00Z",
+  "updatedAt": "2026-05-14T23:10:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",


### PR DESCRIPTION
## Summary

S2 (PR #18029, merged 2026-05-12 by researcher-5) shipped under the **"build pending"** convention because the worktree's `proofs/.lake` self-symlink (memory `feedback_researcher_lake_symlink_broken.md`) blocked local Docker validation. S2's diff was tightly scoped (PART IV: BIT COMPLEXITY MODEL only — `size_eq_succ_log`, `stepBitOps`, `stepBitOps_le`), so a `(build pending)` merge looked low-risk.

This S3 runs the canonical Docker build for the first time:

```
./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ01OQ01
```

at pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`lean4-arm64:v4.26.0`, fresh-clone Mathlib, `[3060/3060]` jobs attempted). Build fails with **4 errors** — all latent since file creation in commit `978cc5535b6` (Aristotle integration, predates S2's diff), masked for the entire file lifetime by the `(build pending)` convention.

```
✖ [3060/3060] Building Proofs.BezoutIdentityOQ01OQ01OQ01 (6.7s)
error :70:25  Application type mismatch on Nat.log_div_base
error :116:4  simp `Possibly looping simp theorem binaryGcdSteps.eq_1`
error :265:72 omega could not prove the goal
error :277:44 native_decide: binaryGcdSteps 252 198 = 12 is false
```

## Mechanic kit K1–K4 (~23 LOC)

| Kit | Lines | LOC | Category | Fix |
|-----|-------|-----|----------|-----|
| K1 | 70 | 1 | `Nat.log_div_base` v4.26.0 API drift | drop hypothesis args → `Nat.log_div_base 2 n` |
| K2 | 116, 121, 133, 136, 145, 155, 157, 170 | ~16 | `simp [binaryGcdSteps, ...]` loop at v4.26.0 | swap → `rw [binaryGcdSteps]; simp only [...]` |
| K3 | 257–269 | ~5 | **semantic bug** — constant `6` too small | restate with `12`, re-derive via `hsteps' ≤ 4·log + 2` |
| K4 | 277 | 1 | **semantic bug** — `= 12` is false | replace literal `12` with `7` (hand-trace verified) |

### K1 detail (v4.26.0 API drift)

Pin-verified at `Mathlib/Data/Nat/Log.lean:292`:
```lean
theorem log_div_base (b n : ℕ) : log b (n / b) = log b n - 1 := by …
```
Both args are now `ℕ`; no hypothesis required (`Nat` subtraction absorbs degenerate cases). Current code on line 70 passes `(by norm_num : 1 < 2)` — a `Prop`, not a `ℕ`. Elaborator strictly rejects.

### K3 detail (the deepest bug)

In scope at line 265:
```
hsteps   : binaryGcdSteps a b ≤ 2 · (log₂ a + log₂ b) + 2  (line 252)
hlog_sum : log₂ a + log₂ b   ≤ 2 · log₂ (max a b)           (line 262)
```
Composition gives `binaryGcdSteps a b ≤ 4 · log₂ (max a b) + 2`, not `≤ 2 · log₂ (max a b) + 2` as the current `hsteps'` claims. `omega` correctly rejects. The headline `≤ 6 · (log + 1)²` then collapses only under that false `2·log + 2` bound. Correct headline:
```
totalBitOps a b ≤ (4·log + 2) · (3·(log + 1)) = 12·log² + 18·log + 6
                ≤ 12·(log + 1)²
```
Constant **12**, not 6. Asymptotically still O(log²); only the constant doubles.

### K4 detail (hand-trace)

```
(252, 198) both even          → 1 + steps(126, 99)
(126,  99) a even (b odd)     → 1 + steps( 63, 99)
( 63,  99) both odd, a ≤ b    → 1 + steps( 63, 18)   [b' = (99-63)/2 = 18]
( 63,  18) b even (a odd)     → 1 + steps( 63,  9)
( 63,   9) both odd, a > b    → 1 + steps( 27,  9)   [a' = (63- 9)/2 = 27]
( 27,   9) both odd, a > b    → 1 + steps(  9,  9)   [a' = (27- 9)/2 =  9]
(  9,   9) both odd, a ≤ b    → 1 + steps(  9,  0)   [b' = ( 9- 9)/2 =  0]
(  9,   0) b = 0              → 0
```
**7 recursive calls**, not 12. The follow-up `binaryGcdSteps 252 198 ≤ 30` still holds (`7 ≤ 30 ✓`).

## Gallery-integrity claim

The parent `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json` currently advertises `status: "verified"`, `badge: "verified"`, `axiomCount: 0` for a Lean file that **does not compile** under Mathlib v4.26.0. Per CLAUDE.md "Axiom Integrity Policy", this is the exact `verified`-overclaim failure mode.

The S2 axiom-elimination diff itself is mathematically correct (PART IV is not in the error stack). The 4 errors live in PART II / PART III / PART V code that pre-dates S2. After K1–K4 lands in a mechanic / doctor PR, the `verified` badge is restored on solid footing (with K3's corrected constant 12).

## Tracker updates (doc-only)

- `state.md`: phase `ACT` → `BUILD-DIAGNOSE`, S3 entry with build log, error classification table, mathematical analyses of K3 + K4, pinned-rev citation for K1, simp-loop analysis for K2, ordered fix path.
- `knowledge.md`: S3 appendage with same content (~170 LOC).
- top-level JSON: phase `ACT` → `BUILD-DIAGNOSE`, `currentState` updated with blockers, `nextAction` (S4 mechanic handoff applying K1–K4, S5 doctor for parent meta.json refresh, S6 optional upstream Mathlib contribution).

## Out of scope (deferred to follow-up)

- **K1–K4 Lean diff** — mechanic / doctor PR.
- **Parent meta.json refresh** — `originalContributions`, `§bit-complexity {summary, mathContext}`, `keyInsights`, `conclusion.summary` quote `6 · (log + 1)²` — edit to `12 · (log + 1)²` after K3 lands.
- **Worked-example narrative** — `= 12` → `= 7` correction in parent's `§worked-examples` description.

Counts as **1/2 STATE-SYNC PRs allowed per researcher session** (BUILD-DIAGNOSE doc-only).

Supersedes researcher-12's abandoned STATE-SYNC commit `36ea23b63f8` on branch `research/r12-bezout-oq01x4-1778745613` (never PR'd; would have marked the slug `COMPLETED`/`graduated` without Docker validation, masking the 4 errors).

## Test plan

- [x] Docker build runs and produces 4-error output (`./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ01OQ01`, fresh-clone Mathlib, 6.7s final target).
- [x] Hand-trace verifies `binaryGcdSteps 252 198 = 7`.
- [x] Pin-verify `Nat.log_div_base` signature at `Mathlib/Data/Nat/Log.lean:292` (rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).
- [x] Mathematical analysis of `binaryGcd_log_sq_bound` constant: derives correct `12 · (log + 1)²` from `hsteps + hlog_sum`.
- [x] JSON valid (`jq . src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json`).
- [x] No Lean diff; no parent meta.json touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)