### PR TITLE
fix(mechanic): ThreeSquares.lean S5 region + 2 masked v4.26.0 errors (#19159)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -757,12 +757,12 @@ theorem dirichletScale_det (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R) :
   have hd' : (0 : ℝ) < d := by exact_mod_cast hd
   have hRle : (0 : ℝ) ≤ R := hR.le
   have hRd : (0 : ℝ) ≤ R / d := (div_pos hR hd').le
-  have h_sqRd : Real.sqrt (R / d) * Real.sqrt (R / d) = R / d := Real.sqrt_mul_self hRd
+  have h_sqRd : Real.sqrt (R / d) * Real.sqrt (R / d) = R / d := Real.mul_self_sqrt hRd
   have h_target : R ^ (3 / 2 : ℝ) = R * Real.sqrt R := by
     rw [show (3 / 2 : ℝ) = 1 + 1 / (2 : ℝ) by norm_num,
         Real.rpow_add hR, Real.rpow_one, ← Real.sqrt_eq_rpow]
   unfold dirichletScale dirichletScaleMatrix
-  rw [Matrix.det_toLin', Matrix.det_diagonal, Fin.prod_univ_three]
+  rw [LinearMap.det_toLin', Matrix.det_diagonal, Fin.prod_univ_three]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
     Matrix.cons_val_succ, Matrix.cons_val_fin_one, Matrix.cons_val_two,
     Matrix.tail_cons]
@@ -787,9 +787,9 @@ theorem dirichletEllipsoid_eq_image (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R
   have hsqrtRd_pos : (0 : ℝ) < Real.sqrt (R / d) := Real.sqrt_pos.mpr hRd_pos
   have hsqrtR_ne : Real.sqrt R ≠ 0 := ne_of_gt hsqrtR_pos
   have hsqrtRd_ne : Real.sqrt (R / d) ≠ 0 := ne_of_gt hsqrtRd_pos
-  have h_sqR : Real.sqrt R * Real.sqrt R = R := Real.sqrt_mul_self hR.le
+  have h_sqR : Real.sqrt R * Real.sqrt R = R := Real.mul_self_sqrt hR.le
   have h_sqRd : Real.sqrt (R / d) * Real.sqrt (R / d) = R / d :=
-    Real.sqrt_mul_self hRd_pos.le
+    Real.mul_self_sqrt hRd_pos.le
   have hRne : R ≠ 0 := ne_of_gt hR
   have hRdne : R / d ≠ 0 := ne_of_gt hRd_pos
   ext v
@@ -809,16 +809,16 @@ theorem dirichletEllipsoid_eq_image (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R
       rw [h0, h1, h2]
       rw [show v 0 ^ 2 / R + v 1 ^ 2 / (R / d) + v 2 ^ 2 / (R / d)
             = (v 0 ^ 2 + d * v 1 ^ 2 + d * v 2 ^ 2) / R by
-          field_simp
-          ring]
+          field_simp]
       rw [div_le_one hR]
       exact hv
     · ext i
       rw [dirichletScale_apply]
       fin_cases i <;>
-        simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
-          Matrix.cons_val_succ, Matrix.cons_val_fin_one, Matrix.cons_val_two,
-          Matrix.tail_cons, hsqrtR_ne, hsqrtRd_ne, mul_div_cancel₀]
+        · simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+            Matrix.cons_val_succ, Matrix.cons_val_fin_one, Matrix.cons_val_two,
+            Matrix.tail_cons, hsqrtR_ne, hsqrtRd_ne, mul_div_cancel₀]
+          try field_simp
   · rintro ⟨u, hu, hTu⟩
     have h_eq : ∀ i : Fin 3, v i =
         ![Real.sqrt R, Real.sqrt (R / d), Real.sqrt (R / d)] i * u i := by
@@ -846,7 +846,6 @@ theorem dirichletEllipsoid_eq_image (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R
         rw [mul_pow, sq, h_sqRd]
       rw [e1, e2, e3]
       field_simp
-      ring
     rw [step]
     calc R * (u 0 ^ 2 + u 1 ^ 2 + u 2 ^ 2) ≤ R * 1 :=
           mul_le_mul_of_nonneg_left hu hR.le
@@ -861,7 +860,9 @@ private theorem unitEuclideanBall3_preimage :
   simp only [Set.mem_preimage, unitEuclideanBall3, Set.mem_setOf_eq,
     Metric.mem_closedBall, dist_zero_right]
   have h_norm_sq : ‖x‖ ^ 2 = x 0 ^ 2 + x 1 ^ 2 + x 2 ^ 2 := by
-    rw [EuclideanSpace.real_norm_sq_eq, Fin.sum_univ_three]
+    rw [EuclideanSpace.norm_sq_eq, Fin.sum_univ_three,
+        Real.norm_eq_abs, Real.norm_eq_abs, Real.norm_eq_abs]
+    simp only [sq_abs]
   have hnn : 0 ≤ ‖x‖ := norm_nonneg _
   constructor
   · intro hv
@@ -1801,6 +1802,7 @@ private lemma exists_sum_three_sq_int_iff_nat (n : ℕ) :
     `not_excluded_form_is_sum_three_sq` via `r3_count_pos_iff`. -/
 theorem general_r3_formula {n : ℕ} (_hn : n ≥ 1) (hne : ¬IsExcludedForm n) :
     r3_count n > 0 := by
+  show 0 < r3_count n
   rw [r3_count_pos_iff, exists_sum_three_sq_int_iff_nat]
   exact not_excluded_form_is_sum_three_sq hne
 


### PR DESCRIPTION
## Fix

Applies the 7-edit S5-region kit from research PR #19159 plus 2 surgical fixes for v4.26.0 errors masked by the original S5 cascade. Build now clean: **3524 jobs**.

## Coverage

| Cluster | Lines | Edits | Notes |
|---|---|---|---|
| **A** (kit) | 760, 790, 792 | `Real.sqrt_mul_self` → `Real.mul_self_sqrt` | direction reversed; v4.26.0 lemma signatures match the `have` RHS only via `mul_self_sqrt`. |
| **B** (kit) | 765 | `Matrix.det_toLin'` → `LinearMap.det_toLin'` | namespace move; `Mathlib/LinearAlgebra/Determinant.lean:211`. |
| **C** (kit) | 864 | `EuclideanSpace.real_norm_sq_eq` → `EuclideanSpace.norm_sq_eq` + `Real.norm_eq_abs`/`sq_abs` bridge | the ℝ-specialised lemma was removed; the polymorphic RCLike version returns `‖x i‖^2` not `x i^2`. |
| **D** (kit) | 813, 849 | drop trailing `ring` | v4.26.0 `field_simp` internally invokes `ring_nf`. |
| **E** (masked, NEW) | 815 (was 816) | per-case tactic blocks + `try field_simp` | v4.26.0 `simp` defaults expand `Real.sqrt (R/d)` → `√R/√↑d` before `mul_div_cancel₀` matches; `try field_simp` mops up the cancellation only on `i = 1, 2`. |
| **r3 notation** (masked, NEW) | 1804 | prepend `show 0 < r3_count n` | v4.26.0 `rw` no longer sees through `> 0` ↔ `0 <` notation; `r3_count_pos_iff` states `0 <` so a `show` normalises the goal first. |

## On cluster D's `<;> ring` form

The kit recommended `field_simp <;> ring` over bare `field_simp` for forward-compat, but applying `<;> ring` triggered a downstream `Real.sqrt_div` normalisation that broke the cancellation closer in the next bullet (the simp at line 818-820 stopped matching the `√(R/d)` pattern). Fell back to bare `field_simp` per the kit's primary fix path. Future Mathlib changes that back off `field_simp` aggression would need a separate touch-up.

## On cluster E being masked, not cascade

The kit (PR #19159) classified line 816 as cluster E ("dissolves when A/B/D land"). It does not — the goal at the second `· ext i` bullet survives independently because v4.26.0 simp defaults reshape `Real.sqrt (R/d)` to `Real.sqrt R / Real.sqrt ↑d` before `mul_div_cancel₀` can match. This is exactly the masking pattern documented in `feedback_mechanic_mathlib_v426_pnt_nonvanishing_import_plus_le_of_eq.md` and `feedback_mechanic_mathlib_v426_hilbert10_4kit.md` — *always Docker-build immediately after a kit fix*. The `try field_simp` follow-up is the minimal addition.

## On the r3 notation fix

Line 1804 errored with `Tactic rewrite failed: Did not find an occurrence of the pattern 0 < r3_count ?n in the target expression r3_count n > 0`. The `r3_count_pos_iff` LHS is `0 < r3_count n` (Mathlib convention) but `general_r3_formula`'s public signature uses `r3_count n > 0`. At v4.26.0 these no longer unify under `rw`. Smallest fix: 1-LOC `show 0 < r3_count n` inside the proof, no public-signature change.

## LOC budget

+13 / -11 = **+2 net LOC**, within the kit's ≤+2 budget.

## Evidence

**Before**: 9 errors in S5 region (760-864) per kit, plus 2 masked latent errors at 815 and 1804 surfaced after S5 fixes landed.
**After**: full file builds clean (3524 jobs) via `./proofs/scripts/docker-build.sh Proofs.ThreeSquares`, modulo the previously documented warnings (simp-arg unused at lines 801/820/821/1007/1444/1448/1580/1584/1587, deprecated names at 1164/1312, unused vars at 1731/1810, the strategic-sorry warning on `needs_four_iff_excluded` at line 1863).

## Conflict scope

Touches only `proofs/Proofs/ThreeSquares.lean` lines 760/765/790/792/810-820/848/863/1804. Zero overlap with:

- PR #19048 (S10D ACT, lines 1593–1659)
- PR #19026 (STATE-SYNC, JSON only)
- PR #19159 (S12 PREP doc-only, kit itself)

Closes #19159.

---
Automated fix by lean-mechanic agent.