### PR TITLE
fix(mechanic): FrobeniusNumber.lean v4.26.0 5-error repair (#19180)

### DIFF
--- a/proofs/Proofs/FrobeniusNumber.lean
+++ b/proofs/Proofs/FrobeniusNumber.lean
@@ -78,6 +78,7 @@ def frobeniusNumber (a b : ℕ) : ℕ := a * b - a - b
 theorem frobenius_alt_axiom (a b : ℕ) (ha : 2 ≤ a) (hb : 2 ≤ b) :
     frobeniusNumber a b = (a - 1) * (b - 1) - 1 := by
   unfold frobeniusNumber
+  rw [Nat.mul_sub_one, Nat.sub_one_mul]
   omega
 
 /-- Verified for specific examples -/
@@ -162,8 +163,9 @@ theorem large_representable {a b : ℕ} (hab : Nat.Coprime a b)
     have h_kb_bound : k * b ≤ (a - 1) * b := Nat.mul_le_mul_right b (by omega)
     -- (a-1)*b = (a-1)*(b-1) + (a-1)
     have hab_expand : (a - 1) * b = (a - 1) * (b - 1) + (a - 1) := by
-      have : b = (b - 1) + 1 := by omega
-      rw [this, mul_add, mul_one]
+      have hb_eq : b = (b - 1) + 1 := by omega
+      conv_lhs => rw [hb_eq]
+      rw [mul_add, mul_one]
     -- k*b ≥ n + a ≥ (a-1)*(b-1) + a, but k*b ≤ (a-1)*(b-1) + (a-1)
     -- This gives a ≤ a - 1, contradiction
     rw [hab_expand] at h_kb_bound
@@ -190,13 +192,25 @@ theorem frobenius_not_representable {a b : ℕ} (hab : Nat.Coprime a b)
   -- a*b ≥ a + b since (a-1)*(b-1) ≥ 1
   have hab_ge : a + b ≤ a * b := by nlinarith
   -- Rewrite: a*b = a*(x+1) + b*(y+1)
-  have key : a * b = a * (x + 1) + b * (y + 1) := by nlinarith
+  have key : a * b = a * (x + 1) + b * (y + 1) := by
+    have h_expand : a * (x + 1) + b * (y + 1) = a * x + b * y + (a + b) := by ring
+    omega
   -- a | b*(y+1): factor as a*(b-(x+1)) using key
-  have h_dvd_by : a ∣ b * (y + 1) := ⟨b - (x + 1), by nlinarith⟩
+  have h_dvd_by : a ∣ b * (y + 1) := by
+    have h_xb : x + 1 ≤ b := by
+      nlinarith [key, Nat.zero_le (b * (y + 1))]
+    refine ⟨b - (x + 1), ?_⟩
+    rw [Nat.mul_sub_left_distrib]
+    omega
   -- By coprimality: a | (y + 1)
   have h_dvd_y1 : a ∣ (y + 1) := hab.dvd_of_dvd_mul_left h_dvd_by
   -- b | a*(x+1): factor as b*(a-(y+1)) using key
-  have h_dvd_ax : b ∣ a * (x + 1) := ⟨a - (y + 1), by nlinarith⟩
+  have h_dvd_ax : b ∣ a * (x + 1) := by
+    have h_ya : y + 1 ≤ a := by
+      nlinarith [key, Nat.zero_le (a * (x + 1))]
+    refine ⟨a - (y + 1), ?_⟩
+    rw [Nat.mul_sub_left_distrib, mul_comm b a]
+    omega
   -- By coprimality: b | (x + 1)
   have h_dvd_x1 : b ∣ (x + 1) := hab.symm.dvd_of_dvd_mul_left h_dvd_ax
   -- y + 1 ≥ a and x + 1 ≥ b


### PR DESCRIPTION
## Summary

Applies the S3c PREP mechanic kit from PR #19180 (researcher-3, 2026-05-14)
to `proofs/Proofs/FrobeniusNumber.lean`. Resolves 5 Mathlib v4.26.0
errors (4 from the kit + 1 masked error the kit missed).

`./proofs/scripts/docker-build.sh Proofs.FrobeniusNumber` →
**3058 jobs, build succeeded**.

## Errors fixed

| Line (pre) | Theorem | Class | Fix |
|---|---|---|---|
| 81 | `frobenius_alt_axiom` | `omega` cannot expand `(a-1)*(b-1)` | prepend `rw [Nat.mul_sub_one, Nat.sub_one_mul]` |
| 164 | `large_representable` | `rw [this]` rewrites both `b`'s (v4.26.0 elaborator change) | `conv_lhs => rw [hb_eq]` |
| 193 | `frobenius_not_representable` | `nlinarith` no longer bridges ℕ-sub in `key` | `have h_expand ... := by ring; omega` |
| 195 | `frobenius_not_representable` | `nlinarith` divisor `b - (x+1)` | `Nat.mul_sub_left_distrib` + `omega` |
| 199 | `frobenius_not_representable` | symmetric K3 with divisor `a - (y+1)` | `Nat.mul_sub_left_distrib, mul_comm b a` + `omega` |

## Masked error (not in PR #19180 kit's 4-error inventory)

Line 81 (`frobenius_alt_axiom`) had a bare `omega` after `unfold
frobeniusNumber` against goal `a * b - a - b = (a - 1) * (b - 1) - 1`.
`omega` cannot decompose nonlinear `(a-1)*(b-1)`. Fix: surgical
`rw [Nat.mul_sub_one, Nat.sub_one_mul]` expansion to
`a * b - b - (a - 1) - 1`, then `omega` closes against
`a, b ≥ 2`. Pre-existing v4.26.0 regression — see feedback memory
`feedback_mechanic_mathlib_v426_three_squares_kit_e_cascade_was_masked`
for the kit-blind-spot pattern.

## Lemma rename: kit's `Nat.mul_sub_left` → `Nat.mul_sub_left_distrib`

PR #19180 §2 K3 notes `Nat.mul_sub_left` may have been renamed. At
SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0 pin), the
canonical name is `Nat.mul_sub_left_distrib` (signature
`a * (b - c) = a * b - a * c`). Verified via in-tree usage at
`Erdos728FactorialDivisibility.lean:58` and `Erdos959Problem.lean:149`.

## K4 commutativity correction

K4's `rw [Nat.mul_sub_left_distrib]` produces `b * a - b * (y + 1)`
on the RHS, but `key : a * b = a * (x + 1) + b * (y + 1)` uses `a * b`.
Omega treats `a * b` and `b * a` as distinct opaque vars, so an explicit
`mul_comm b a` is required after the distributivity rewrite. K3 didn't
need this because its RHS-after-rewrite is `a * b - a * (x + 1)` which
matches `key` directly.

## Validation

- `./proofs/scripts/docker-build.sh Proofs.FrobeniusNumber` (1 iter
  after K1+K2+K3 → exposed K4 omega + line 81; final iter clean).
- 3058 jobs replayed, no errors. Only remaining: pre-existing
  `le_or_lt` deprecation at line 102 (out of mechanic scope).
- Diff: +19 / -5 LOC across 3 theorems (kit predicted ~16 LOC / 2
  theorems; extra is line-81 masked error + K4 `mul_comm` insertion).

## Unblocks

- PR #19151 (S3b PREP for `frobenius-number-oq-03`) Option (a):
  parent-file-mechanic-first now ~16-LOC done. S3b ACT becomes
  ~10-LOC inline bridge per the kit's §4.
- PR #18999 (S3a ACT — `frobeniusNumber3` def): no conflict (different
  file: `FrobeniusNumberOQ03.lean`).

## Scope

- Touches ONLY `proofs/Proofs/FrobeniusNumber.lean` (+19/-5).
- Does NOT modify `FrobeniusNumberOQ03.lean`, state.md, JSON tracker,
  or gallery `meta.json`. Those belong to S3a/S3b ACT slug owners.
- Does NOT touch the `le_or_lt` deprecation at line 102.

---
Automated fix by lean-mechanic agent (mechanic-3 slot).