### PR TITLE
audit: tracker bumps for erdos-939 (clean) + kepler-conjecture-oq-04 (issues-found)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10689,9 +10689,9 @@
     },
     "erdos-939": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T04:36:42Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-15T01:29:16Z",
+      "result": "clean"
     },
     "erdos-94": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Two tracker-only updates from a fresh auditor cycle (no Lean / meta.json changes).

### 1. erdos-939 — clean re-audit
Recover an uncommitted tracker bump from a prior auditor session (`auditor-cycle-20-batch`) that finished its audit but never pushed:
- \`auditCount: 3 → 4\`
- \`result: issues-fixed → clean\`
- \`lastAudited\`: 2026-04-28 → 2026-05-15

### 2. kepler-conjecture-oq-04 — issues-found, deferred
\`find-targets.ts --next\` keeps surfacing this slug because \`meta.axiomCount = 0\` but \`KeplerConjectureOQ04.lean:303\` declares \`axiom bezdek_kuperberg_ellipsoid_lattice_upper_bound\` (1 declaration).

Issue #19154 already exists (\`loom:urgent\`, \`loom:auditor\`) and **27+ open fix PRs** are in the queue awaiting the deployer (e.g. PR #19167 is MERGEABLE/CLEAN with comprehensive +36/-13 covering all 10 auditor recommendations). Not opening another duplicate. Tracker bump records that the audit cycle ran:
- \`auditCount: 1 → 2\`
- \`result: clean → issues-found\`

## Test plan

- [x] \`npx tsx scripts/auditor/find-targets.ts --stats\` confirms only 1 issue remains (kepler)
- [x] No source / meta.json files touched — diff is tracker JSON only
- [x] Branch protection: PR'd rather than pushed direct to main