### PR TITLE
audit(erdos-930): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10635,8 +10635,8 @@
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T06:09:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-15T01:39:00Z",
       "result": "clean"
     },
     "erdos-931": {


### PR DESCRIPTION
## Summary
- Re-audit of `erdos-930` (Erdős Problem #930: Products of Disjoint Intervals and Perfect Powers).
- meta.json counts and badges match Lean source at Mathlib v4.26.0 pin (`2afb1b79c0a`):
  - lineCount 149, axiomCount 1, sorries 0, theoremCount 5, definitionCount 4.
- No True-stubs, no Mathlib-wrapper mismatch, badge `axiom` consistent with one declared axiom (`six_not_isPower`).
- Tracker bump only: auditCount 3 → 4, lastAudited → 2026-05-15.

## Test plan
- [x] `wc -l proofs/Proofs/Erdos930Problem.lean` → 149 (matches meta.lineCount)
- [x] `grep -nE "^axiom " proofs/Proofs/Erdos930Problem.lean` → 1 axiom (`six_not_isPower` at line 141)
- [x] `grep -nE "\bsorry\b" proofs/Proofs/Erdos930Problem.lean` → 0
- [x] `grep -cE "^(theorem|lemma) " proofs/Proofs/Erdos930Problem.lean` → 5
- [x] `grep -nE "^(def|noncomputable def) " proofs/Proofs/Erdos930Problem.lean` → 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)