### PR TITLE
fix(mechanic): BezoutIdentityOQ01OQ01OQ01 v4.26.0 4-error repair (#19168)

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean
@@ -65,9 +65,8 @@ decreasing_by all_goals simp_wf; omega
 -- ============================================================
 
 /-- Nat.log 2 halves when dividing by 2 for n ≥ 2. -/
-private lemma log_div_two {n : ℕ} (hn : 2 ≤ n) : Nat.log 2 (n / 2) = Nat.log 2 n - 1 := by
-  have : 2 ≤ n := hn
-  simp [Nat.log_div_base (by norm_num : 1 < 2) (by omega : 2 ≤ n)]
+private lemma log_div_two {n : ℕ} (_hn : 2 ≤ n) : Nat.log 2 (n / 2) = Nat.log 2 n - 1 :=
+  Nat.log_div_base 2 n
 
 /-- Log is monotone: m ≤ n → log₂ m ≤ log₂ n. -/
 private lemma log_mono {m n : ℕ} (h : m ≤ n) : Nat.log 2 m ≤ Nat.log 2 n :=
@@ -113,12 +112,13 @@ theorem binaryGcdSteps_le_log (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
   | zero => intro a b hab ha hb; omega
   | succ n ih =>
     intro a b hab ha hb
-    simp only [binaryGcdSteps, if_neg (by omega : ¬(a = 0 ∨ b = 0))]
+    rw [binaryGcdSteps]
+    simp only [if_neg (by omega : ¬(a = 0 ∨ b = 0))]
     set la := Nat.log 2 a
     set lb := Nat.log 2 b
     by_cases hboth : a % 2 = 0 ∧ b % 2 = 0
     · -- Both even: both lose a bit; measure drops by 2
-      simp only [hboth, ↓reduceIte]
+      rw [if_pos hboth]
       obtain ⟨ha2, hb2⟩ := hboth
       have ha2' : 2 ≤ a := by omega
       have hb2' : 2 ≤ b := by omega
@@ -130,7 +130,7 @@ theorem binaryGcdSteps_le_log (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
       have hla_pos : 1 ≤ la := Nat.log_pos (by norm_num) ha2'
       have hlb_pos : 1 ≤ lb := Nat.log_pos (by norm_num) hb2'
       omega
-    · simp only [hboth, ↓reduceIte]
+    · rw [if_neg hboth]
       by_cases ha_even : a % 2 = 0
       · -- a even, b odd: a loses a bit
         simp only [ha_even, ↓reduceIte]
@@ -252,21 +252,24 @@ theorem binaryGcd_log_sq_complexity (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
   exact binaryGcdSteps_le_log a b ha hb
 
 /-- **Corollary**: The bit complexity is O(log²(max a b)).
-    Since log₂ a + log₂ b ≤ 2 * log₂(max a b), the total is
-    ≤ 6 * (log₂(max a b) + 1)². -/
+    Since log₂ a + log₂ b ≤ 2 * log₂(max a b), composing with
+    `binaryGcdSteps_le_log` gives `binaryGcdSteps ≤ 4·log + 2`,
+    so the total is ≤ 12 * (log₂(max a b) + 1)². -/
 theorem binaryGcd_log_sq_bound (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
-    totalBitOps a b ≤ 6 * (Nat.log 2 (max a b) + 1) ^ 2 := by
+    totalBitOps a b ≤ 12 * (Nat.log 2 (max a b) + 1) ^ 2 := by
   have hsteps := binaryGcdSteps_le_log a b ha hb
   have hlog_sum : Nat.log 2 a + Nat.log 2 b ≤ 2 * Nat.log 2 (max a b) := by
     have hma : Nat.log 2 a ≤ Nat.log 2 (max a b) := log_mono (Nat.le_max_left a b)
     have hmb : Nat.log 2 b ≤ Nat.log 2 (max a b) := log_mono (Nat.le_max_right a b)
     omega
   unfold totalBitOps
-  have hsteps' : binaryGcdSteps a b ≤ 2 * Nat.log 2 (max a b) + 2 := by omega
+  have hsteps' : binaryGcdSteps a b ≤ 4 * Nat.log 2 (max a b) + 2 := by omega
   calc binaryGcdSteps a b * (3 * (Nat.log 2 (max a b) + 1))
-      ≤ (2 * Nat.log 2 (max a b) + 2) * (3 * (Nat.log 2 (max a b) + 1)) := by
+      ≤ (4 * Nat.log 2 (max a b) + 2) * (3 * (Nat.log 2 (max a b) + 1)) := by
           apply Nat.mul_le_mul_right; exact hsteps'
-    _ = 6 * (Nat.log 2 (max a b) + 1) ^ 2 := by ring
+    _ ≤ 4 * (Nat.log 2 (max a b) + 1) * (3 * (Nat.log 2 (max a b) + 1)) := by
+          apply Nat.mul_le_mul_right; omega
+    _ = 12 * (Nat.log 2 (max a b) + 1) ^ 2 := by ring
 
 -- ============================================================
 -- PART VI: WORKED EXAMPLES
@@ -274,7 +277,7 @@ theorem binaryGcd_log_sq_bound (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
 
 example : binaryGcdSteps 12 8 = 5 := by native_decide
 example : binaryGcdSteps 21 15 = 4 := by native_decide
-example : binaryGcdSteps 252 198 = 12 := by native_decide
+example : binaryGcdSteps 252 198 = 7 := by native_decide
 -- Verify step count bound: log₂(252) + log₂(198) = 7 + 7 = 14, bound = 30
 example : binaryGcdSteps 252 198 ≤ 2 * (Nat.log 2 252 + Nat.log 2 198) + 2 := by
   native_decide


### PR DESCRIPTION
## Fix

Applies the K1–K4 mechanic kit from research PR #19168 (S3 BUILD-DIAGNOSE) to clear 4 latent errors in `proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean` that have been masked by the `(build pending)` convention since commit `978cc5535b6` (S2 / Aristotle integration).

| Kit | Line | Category | Action |
|-----|------|----------|--------|
| K1 | 70 | `Nat.log_div_base` v4.26.0 API drift (now `(b n : ℕ)`, no hypothesis args) | drop `simp [...]` wrapper → `exact Nat.log_div_base 2 n` |
| K2 | 116, 121, 133 | `simp only [binaryGcdSteps, …]` triggers v4.26.0 looping-simp guard on `binaryGcdSteps.eq_1`; `simp only [hboth, ↓reduceIte]` leaves `True ∧ True` (simp decomposes conjunction hyps) | swap outer to `rw [binaryGcdSteps]; simp only [if_neg …]`; swap inner conjunction-reduces to `rw [if_pos hboth]` / `rw [if_neg hboth]` |
| K3 | 254–272 | **semantic bug** — `binaryGcd_log_sq_bound` claimed `≤ 6·(log+1)²`, but `hsteps + hlog_sum` gives `≤ 4·log + 2`, not `2·log + 2`. Correct constant is `12`. | change theorem statement `6 → 12`, derive `hsteps' : steps ≤ 4·log + 2`, add intermediate calc step `(4L+2)(3(L+1)) ≤ 4(L+1)·3(L+1) = 12·(L+1)²` |
| K4 | 277 | **semantic bug** — `binaryGcdSteps 252 198 = 12` is false. Hand-trace gives **7** recursive calls. | `12 → 7` |

## Evidence

**Pre-edit Docker baseline** (rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, v4.26.0):

```
✖ [3060/3060] Building Proofs.BezoutIdentityOQ01OQ01OQ01 (3.4s)
error :70:25  Application type mismatch on Nat.log_div_base
error :116:4  simp `Possibly looping simp theorem binaryGcdSteps.eq_1`
error :265:72 omega could not prove the goal
error :277:44 native_decide: binaryGcdSteps 252 198 = 12 is false
```

**Post-edit** (this PR, same Docker harness):

```
✔ [3060/3060] Built Proofs.BezoutIdentityOQ01OQ01OQ01 (5.5s)
Build completed successfully (3060 jobs).
```

## Hand-trace for K4

```
(252, 198) both even          → 1 + steps(126, 99)
(126,  99) a even (b odd)     → 1 + steps( 63, 99)
( 63,  99) both odd, a ≤ b    → 1 + steps( 63, 18)   [b' = (99-63)/2 = 18]
( 63,  18) b even (a odd)     → 1 + steps( 63,  9)
( 63,   9) both odd, a > b    → 1 + steps( 27,  9)   [a' = (63- 9)/2 = 27]
( 27,   9) both odd, a > b    → 1 + steps(  9,  9)   [a' = (27- 9)/2 =  9]
(  9,   9) both odd, a ≤ b    → 1 + steps(  9,  0)   [b' = ( 9- 9)/2 =  0]
(  9,   0) b = 0              → 0
```

**7 recursive calls.** The follow-up `binaryGcdSteps 252 198 ≤ 30` still holds (`7 ≤ 30` ✓).

## Diff

+16 / -13 LOC, one file. K2 added one extra mid-proof `rw` for the conjunction-hypothesis reduction not covered by the kit's headline list (simp's decomposition of `hboth : P ∧ Q` is a v4.26.0 normalization change). K3 grew one calc step because `(4L+2)(3(L+1))` is no longer an equality with `12·(L+1)²`, only `≤`.

## Out of scope (deferred follow-up)

Per kit's "Out of scope" section, parent `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json` still quotes `6 · (log + 1)²` in `originalContributions` and elsewhere. A separate doctor PR is needed to refresh that prose to `12 · (log + 1)²` after this lands. `status: "verified"` / `axiomCount: 0` remain accurate (file compiles clean, no sorries, no `axiom` declarations).

Closes #19168

---
Automated fix by lean-mechanic agent.