### PR TITLE
fix(mechanic): hilbert-11-oq-02 v4.26.0 Sub-PR-2 (clusters B residual + D + E, 17 → 0)

### DIFF
--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -451,13 +451,13 @@ noncomputable def Gint : Polynomial ℤ := C 4 + C 5 * X ^ 3
 private lemma Gint_aeval (a : ℤ_[11]) :
     aeval a Gint = (4 : ℤ_[11]) + (5 : ℤ_[11]) * a ^ 3 := by
   unfold Gint
-  simp [aeval_C, aeval_X_pow] <;> ring
+  simp [aeval_C, aeval_X_pow, map_ofNat] <;> ring
 
 private lemma Gint_derivative_aeval (a : ℤ_[11]) :
     aeval a Gint.derivative = (15 : ℤ_[11]) * a ^ 2 := by
   unfold Gint
   simp [derivative_add, derivative_C, derivative_C_mul, derivative_X_pow,
-        aeval_C, aeval_X_pow] <;> ring
+        aeval_C, aeval_X_pow, map_ofNat] <;> ring
 
 private lemma Gint_aeval_at_2 :
     aeval (2 : ℤ_[11]) Gint = ((44 : ℤ) : ℤ_[11]) := by
@@ -564,20 +564,21 @@ noncomputable def Gint : Polynomial ℤ := C 4 + C 5 * X ^ 3
 private lemma Gint_derivative_eq : Gint.derivative = C 15 * X ^ 2 := by
   unfold Gint
   rw [derivative_add, derivative_C, zero_add, derivative_C_mul,
-      derivative_X_pow]
-  push_cast
-  ring
+      derivative_X_pow, ← mul_assoc, ← C_mul]
+  norm_num
 
 private lemma Gint_aeval {p : ℕ} [Fact (Nat.Prime p)] (a : ℤ_[p]) :
     aeval a Gint = (4 : ℤ_[p]) + (5 : ℤ_[p]) * a ^ 3 := by
   unfold Gint
   rw [map_add, map_mul, map_pow, aeval_C, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
 private lemma Gint_derivative_aeval {p : ℕ} [Fact (Nat.Prime p)] (a : ℤ_[p]) :
     aeval a Gint.derivative = (15 : ℤ_[p]) * a ^ 2 := by
   rw [Gint_derivative_eq, map_mul, map_pow, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
@@ -724,20 +725,21 @@ noncomputable def G (c : ℤ) : Polynomial ℤ := C c + C 5 * X ^ 3
 private lemma G_derivative_eq (c : ℤ) : (G c).derivative = C 15 * X ^ 2 := by
   unfold G
   rw [derivative_add, derivative_C, zero_add, derivative_C_mul,
-      derivative_X_pow]
-  push_cast
-  ring
+      derivative_X_pow, ← mul_assoc, ← C_mul]
+  norm_num
 
 private lemma G_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
     aeval a (G c) = (c : ℤ_[p]) + (5 : ℤ_[p]) * a ^ 3 := by
   unfold G
   rw [map_add, map_mul, map_pow, aeval_C, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
 private lemma G_derivative_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
     aeval a (G c).derivative = (15 : ℤ_[p]) * a ^ 2 := by
   rw [G_derivative_eq, map_mul, map_pow, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
@@ -915,20 +917,21 @@ noncomputable def H (c : ℤ) : Polynomial ℤ := C c + C 3 * X ^ 3
 private lemma H_derivative_eq (c : ℤ) : (H c).derivative = C 9 * X ^ 2 := by
   unfold H
   rw [derivative_add, derivative_C, zero_add, derivative_C_mul,
-      derivative_X_pow]
-  push_cast
-  ring
+      derivative_X_pow, ← mul_assoc, ← C_mul]
+  norm_num
 
 private lemma H_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
     aeval a (H c) = (c : ℤ_[p]) + (3 : ℤ_[p]) * a ^ 3 := by
   unfold H
   rw [map_add, map_mul, map_pow, aeval_C, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
 private lemma H_derivative_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
     aeval a (H c).derivative = (9 : ℤ_[p]) * a ^ 2 := by
   rw [H_derivative_eq, map_mul, map_pow, aeval_C, aeval_X]
+  simp only [algebraMap_int_eq, eq_intCast]
   push_cast
   ring
 
@@ -1145,13 +1148,13 @@ noncomputable def Gint : Polynomial ℤ := C 4 + C 5 * X ^ 3
 private lemma Gint_aeval (a : ℤ_[3]) :
     aeval a Gint = (4 : ℤ_[3]) + (5 : ℤ_[3]) * a ^ 3 := by
   unfold Gint
-  simp [aeval_C, aeval_X_pow] <;> ring
+  simp [aeval_C, aeval_X_pow, map_ofNat] <;> ring
 
 private lemma Gint_derivative_aeval (a : ℤ_[3]) :
     aeval a Gint.derivative = (15 : ℤ_[3]) * a ^ 2 := by
   unfold Gint
   simp [derivative_add, derivative_C, derivative_C_mul, derivative_X_pow,
-        aeval_C, aeval_X_pow] <;> ring
+        aeval_C, aeval_X_pow, map_ofNat] <;> ring
 
 private lemma Gint_aeval_at_4 :
     aeval (4 : ℤ_[3]) Gint = ((324 : ℤ) : ℤ_[3]) := by
@@ -1188,13 +1191,13 @@ private lemma norm_80_eq_one : ‖((80 : ℤ) : ℤ_[3])‖ = 1 := by
 /-- `‖324‖_3 = (1/3)⁴ = 1/81`. -/
 private lemma norm_324_eq :
     ‖((324 : ℤ) : ℤ_[3])‖ = ((3 : ℕ) : ℝ)⁻¹ ^ 4 := by
-  rw [cast_324_factored, PadicInt.norm_mul, PadicInt.norm_pow,
+  rw [cast_324_factored, norm_mul, norm_pow,
       PadicInt.norm_p, norm_4_eq_one, mul_one]
 
 /-- `‖240‖_3 = 1/3`. -/
 private lemma norm_240_eq :
     ‖((240 : ℤ) : ℤ_[3])‖ = ((3 : ℕ) : ℝ)⁻¹ := by
-  rw [cast_240_factored, PadicInt.norm_mul, PadicInt.norm_p,
+  rw [cast_240_factored, norm_mul, PadicInt.norm_p,
       norm_80_eq_one, mul_one]
 
 /-- The strong-form Hensel hypothesis `‖g(4)‖ < ‖g'(4)‖²` for
@@ -1772,9 +1775,10 @@ lemma pow_cubeInverseExp_pow_three {p : ℕ} [Fact (Nat.Prime p)]
     {a : ZMod p} (ha : a ≠ 0) :
     (a ^ cubeInverseExp p) ^ 3 = a := by
   have h_fermat : a ^ (p - 1) = 1 := ZMod.pow_card_sub_one_eq_one ha
-  rw [← pow_mul, mul_comm, three_mul_cubeInverseExp_eq hp_mod3 hp_ne_2]
-  rw [show 2 * (p - 1) + 1 = (p - 1) + ((p - 1) + 1) from by ring,
-      pow_add, pow_add, pow_one, h_fermat, one_mul, h_fermat, one_mul]
+  rw [← pow_mul, mul_comm, three_mul_cubeInverseExp_eq hp_mod3 hp_ne_2,
+      show 2 * (p - 1) + 1 = (p - 1) + (p - 1) + 1 from by ring,
+      pow_succ, pow_add]
+  simp [h_fermat]
 
 /-- Helper: `p` prime and `p ≠ q` (for `q` prime) imply `¬ p ∣ q`. -/
 private lemma prime_not_dvd_of_prime_ne {p q : ℕ}
@@ -1782,7 +1786,7 @@ private lemma prime_not_dvd_of_prime_ne {p q : ℕ}
     ¬ p ∣ q := by
   intro h
   rcases hq.eq_one_or_self_of_dvd p h with h1 | hq'
-  · exact hp.one_lt.ne' h1.symm
+  · exact hp.one_lt.ne' h1
   · exact hne hq'
 
 /-- `(5 : ZMod p) ≠ 0` for `p` prime with `p ≠ 5`. -/


### PR DESCRIPTION
## Summary

**Sub-PR-2** of the 2-PR repair sequence shipped by inventory PR #19034
(S22 PARENT-BREAK 6-cluster kit). Stacked on Sub-PR-1 (#19056). Targets
the **17-error residue** that remains after Sub-PR-1 lands Clusters
A + C + F + deprecation, closing the v4.26.0 tail to **0 errors**.

## Per-cluster repairs

### Cluster B (Cascade residue, NOT fully auto-resolved)

The inventory forecast that Cluster B (18 errors at lines 451/456/563/.../1195)
would auto-resolve once Cluster A added `noncomputable` to the 5 polynomial
defs. Pre-edit Docker rebuild (HEAD = Sub-PR-1) showed **5 of those
sites did NOT cascade-resolve**, requiring manual simp-set tweaks. This
is a correction to inventory §3 "no independent fix" forecast — recorded
in the commit message for future kit accuracy.

| Site | File line | Fix |
|------|-----------|-----|
| `Hensel11.Gint_aeval` | 454 | add `map_ofNat` to simp set |
| `Hensel11.Gint_derivative_aeval` | 460 | add `map_ofNat` to simp set |
| `HenselCaseA.Gint_derivative_eq` | 567-568 | `← mul_assoc, ← C_mul; norm_num` (replaces broken `push_cast; ring` tail) |
| `HenselCaseA.Gint_aeval` | 575 | `simp only [algebraMap_int_eq, eq_intCast]` before `push_cast; ring` |
| `HenselCaseA.Gint_derivative_aeval` | 582 | same `algebraMap_int_eq, eq_intCast` insert |
| `HenselLiftZ.G_derivative_eq` | 728-729 | `← mul_assoc, ← C_mul; norm_num` |
| `HenselLiftZ.G_aeval` | 736 | `algebraMap_int_eq, eq_intCast` insert |
| `HenselLiftZ.G_derivative_aeval` | 743 | `algebraMap_int_eq, eq_intCast` insert |
| `HenselLiftX.H_derivative_eq` | 920-921 | `← mul_assoc, ← C_mul; norm_num` |
| `HenselLiftX.H_aeval` | 928 | `algebraMap_int_eq, eq_intCast` insert |
| `HenselLiftX.H_derivative_aeval` | 935 | `algebraMap_int_eq, eq_intCast` insert |
| `Hensel3.Gint_aeval` | 1151 | add `map_ofNat` to simp set |
| `Hensel3.Gint_derivative_aeval` | 1157 | add `map_ofNat` to simp set |

### Cluster D (`PadicInt.norm_mul` / `PadicInt.norm_pow` removed in v4.26.0)

`ℤ_[p]` inherits the multiplicative norm from `ℚ_[p]` (`NormedField`),
so the generic equality versions `norm_mul`, `norm_pow` apply at the
PadicInt level. Replaced both occurrences:

| Site | Fix |
|------|-----|
| `norm_324_eq` (line 1190) | `PadicInt.norm_mul, PadicInt.norm_pow` → `norm_mul, norm_pow` |
| `norm_240_eq` (line 1196) | `PadicInt.norm_mul` → `norm_mul` |

### Cluster E (`a ^ (p - 1)` Nat-sub cast pattern)

`pow_cubeInverseExp_pow_three` (lines 1772-1781): restructure the
`2 * (p - 1) + 1` rewrite. v4.26.0 Nat-sub elaboration in the original
`((p - 1) + 1)` parenthesization broke pattern matching. New form:

```lean
rw [← pow_mul, mul_comm, three_mul_cubeInverseExp_eq hp_mod3 hp_ne_2,
    show 2 * (p - 1) + 1 = (p - 1) + (p - 1) + 1 from by ring,
    pow_succ, pow_add]
simp [h_fermat]
```

### Downstream cascade fix

`prime_not_dvd_of_prime_ne` (line 1787): drop `.symm` from
`hp.one_lt.ne' h1.symm`. With v4.26.0's tightened
`Nat.Prime.eq_one_or_self_of_dvd` signature, `h1 : p = 1` is now in
the expected direction for `Nat.lt.ne' : 1 < p → p ≠ 1`.

## Validation

```bash
./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02
```

**Result**: `[3069/3069] Replayed Proofs.Hilbert11OQ02`, exit code 0.
0 errors. (39 → 17 → 0 across Sub-PR-1 → Sub-PR-2.)

Build log: `.loom/logs/mechanic-3-hilbert11-subpr2-iter1.log`.

## Residual lint warnings (intentionally deferred)

6 cosmetic warnings remain — all in Cluster B sites where the added
`map_ofNat` simp lemma now closes the goal without the `<;> ring` tail:

```
Proofs/Hilbert11OQ02.lean:454:45: 'ring' tactic does nothing
Proofs/Hilbert11OQ02.lean:454:45: this tactic is never executed
Proofs/Hilbert11OQ02.lean:460:41: Used `tac1 <;> tac2` where `(tac1; tac2)` would suffice
Proofs/Hilbert11OQ02.lean:1151:45: 'ring' tactic does nothing
Proofs/Hilbert11OQ02.lean:1151:45: this tactic is never executed
Proofs/Hilbert11OQ02.lean:1157:41: Used `tac1 <;> tac2` where `(tac1; tac2)` would suffice
```

Left for a follow-up cosmetic Sub-PR-3 to preserve minimal-diff scope
discipline (mechanic rule: "one fix per PR; do not bundle unrelated").

## Files modified

- `proofs/Proofs/Hilbert11OQ02.lean` (+23 / -19, 4 logical fix regions
  across 5 namespaces: `Hensel11`, `HenselCaseA`, `HenselLiftZ`,
  `HenselLiftX`, `Hensel3`, plus top-level `pow_cubeInverseExp_pow_three`
  and `prime_not_dvd_of_prime_ne`).

No edits to `state.md`, `meta.json`, `knowledge.md`, `problem.md`, or
research JSON.

## Stacking note

This PR's base is `fix/mechanic-hilbert-11-oq-02-v426-cluster-a-c-f`
(Sub-PR-1 branch). When #19056 merges into main, GitHub will auto-rebase
this PR onto main; the diff should then show only the +23/-19 from
Sub-PR-2.

If Sub-PR-1 needs to be retargeted, this PR will require a manual base
update.

## References

- Inventory PR (kit source): #19034
- Sub-PR-1 (stacked base, A+C+F+deprecation): #19056

## Test plan

- [x] Docker-build `Proofs.Hilbert11OQ02` exits 0, 3069/3069 replayed,
      0 errors.
- [x] All 5 Cluster B *_eq lemmas (`Gint_derivative_eq`,
      `G_derivative_eq`, `H_derivative_eq`) build via `← mul_assoc,
      ← C_mul; norm_num`.
- [x] All 6 Cluster B *_aeval lemmas (`Gint_aeval`, `G_aeval`,
      `H_aeval`, and their derivative variants) build via
      `algebraMap_int_eq, eq_intCast` insert.
- [x] Cluster D `norm_*_eq` lemmas build with generic `norm_mul` /
      `norm_pow`.
- [x] Cluster E `pow_cubeInverseExp_pow_three` builds with new
      `pow_succ, pow_add; simp [h_fermat]` tail.
- [x] No new sorries (`grep -c "^\s*sorry" proofs/Proofs/Hilbert11OQ02.lean` unchanged from main).
- [x] No new `axiom` declarations.
- [ ] (Follow-up Sub-PR-3) cosmetic lint cleanup of 4 `<;> ring`
      sites at lines 454/460/1151/1157.

---
Automated fix by lean-mechanic agent.