### PR TITLE
fix(mechanic): Erdos101OQ01 v4.26.0 child unblocker (5 errors, stacked on #19099)

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -56,6 +56,7 @@ import Proofs.Erdos101Problem
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Sqrt
+import Mathlib.Analysis.Complex.ExponentialBounds
 
 namespace Erdos101OQ01
 
@@ -132,7 +133,7 @@ theorem fourPointLineCount_o_n_squared_holds_below_four
   have hpos : 0 < P.points.card := P.size_pos
   have hcard_pos_real : (0 : ℝ) < (P.points.card : ℝ) := by exact_mod_cast hpos
   have hsq_pos : (0 : ℝ) < (P.points.card : ℝ)^2 := pow_pos hcard_pos_real 2
-  positivity
+  exact_mod_cast mul_pos hε hsq_pos
 
 /-- **Trivial quadratic upper bound** (real version): `fourPointLineCount
 P ≤ n(n-1)/12 ≤ n²/12 ≤ n²` for every no-five-collinear `P`.
@@ -362,7 +363,7 @@ theorem erdos_three_halves_conjecture_refuted :
   -- `(1/2) / sqrt (log m) < 1/2` and hence `2 - … > 3/2`.
   have h_frac_lt_half :
       (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) < 1 / 2 := by
-    rw [div_lt_iff hsqrt_pos]
+    rw [div_lt_iff₀ hsqrt_pos]
     nlinarith [hsqrt_gt_one]
   have h_exp_gt :
       (3 / 2 : ℝ) < 2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) := by
@@ -452,7 +453,7 @@ theorem erdos_three_halves_conjecture_refuted_constructive :
   -- `(1/2) / sqrt (log m) < 1/2` and hence `2 - … > 3/2`.
   have h_frac_lt_half :
       (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) < 1 / 2 := by
-    rw [div_lt_iff hsqrt_pos]
+    rw [div_lt_iff₀ hsqrt_pos]
     nlinarith [hsqrt_gt_one]
   have h_exp_gt :
       (3 / 2 : ℝ) < 2 - (1 / 2 : ℝ) / Real.sqrt (Real.log (m : ℝ)) := by

--- a/proofs/Proofs/Erdos101Problem.lean
+++ b/proofs/Proofs/Erdos101Problem.lean
@@ -282,18 +282,19 @@ theorem four_collinear_overlap_small (P : PlanarPointSet) (hP : NoFiveCollinear 
 
 /- ## Main Conjecture -/
 
-/-- **Erdős Problem #101**: the number of four-point lines is o(n²).
+/- **Erdős Problem #101**: the number of four-point lines is o(n²).
     For any ε > 0, eventually fourPointLineCount(P) < ε · n². -/
 /- ## Known Results -/
 
-/-- **Grünbaum's Lower Bound**: there exist point sets with no five collinear
+/- **Grünbaum's Lower Bound**: there exist point sets with no five collinear
     achieving ≫ n^{3/2} four-point lines. -/
-/-- **Solymosi–Stojaković**: configurations exist with n^{2−O(1/√(log n))}
+/- **Solymosi–Stojaković**: configurations exist with n^{2−O(1/√(log n))}
     four-point lines, disproving Erdős's Θ(n^{3/2}) conjecture. -/
 /-- **Trivial Upper Bound (n²)**: Under NoFiveCollinear, fourPointLineCount ≤ n².
     Injection from 4-collinear subsets to ordered pairs via existential witnesses. -/
 theorem trivial_upper_bound_sq (P : PlanarPointSet) (hP : NoFiveCollinear P) :
     fourPointLineCount P ≤ P.points.card * P.points.card := by
+  classical
   unfold fourPointLineCount
   set F := P.points.powerset.filter (fun S =>
     S.card = 4 ∧
@@ -589,9 +590,9 @@ theorem improved_upper_bound (P : PlanarPointSet) (hP : NoFiveCollinear P) :
 
 /- ## Related Observations -/
 
-/-- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
+/- **Collinear Triples**: Burr–Grünbaum–Sloane and Füredi–Palásti constructed
     sets with ~n²/6 collinear triples but no four-point lines. -/
-/-- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
+/- **Szemerédi–Trotter Bound**: for any finite set of points P and finite set
     of lines L in ℝ², the number of incidences I(P,L) satisfies
     I(P,L) ≤ C · (|P|^{2/3}·|L|^{2/3} + |P| + |L|) for some absolute constant C.
     Note: stated for a given incidence count, not universally quantified. -/


### PR DESCRIPTION
## Fix

Closes the 5 v4.26.0 errors in `proofs/Proofs/Erdos101OQ01.lean` that PR #19099 (parent unblocker) explicitly filed as out-of-scope. With both PRs merged, the import chain `Proofs.Erdos101OQ01 → Proofs.Erdos101Problem → Mathlib v4.26.0` is Docker-clean at **3061/3061 jobs in 4.9s**.

## Stacked PR notice

This PR is **stacked on PR #19099** (`fix/mechanic-erdos-101-orphan-docstrings`). The diff vs `main` currently shows 2 commits:

1. `f1001b9` — PR #19099's parent fix (5 orphan `/--` → `/-` + 1 `classical` tactic)
2. `6ff17c6` — this PR's child fix (1 import + 4 LOC)

Once #19099 merges, GitHub will reduce this PR's diff to just the child changes (4 LOC). Recommended merge sequence: **#19099 → this PR**. Either order builds clean (parent's edits don't touch the child file, child's edits don't touch the parent file).

## Three v4.26.0 regressions (5 sites)

### 1. Line 135 — `not a positivity goal`

After `rw [h0]`, the goal becomes `((0:ℕ):ℝ) < ε * (P.points.card:ℝ)^2`. v4.26.0 `positivity` no longer unfolds the LHS `Nat.cast 0`. Replaced with the direct closing:

```lean
-  positivity
+  exact_mod_cast mul_pos hε hsq_pos
```

The two `have` lines preceding it (`hcard_pos_real`, `hsq_pos`) provide everything `mul_pos` needs.

### 2. Lines 352, 442 — `Unknown constant Real.exp_one_lt_d9`

The declaration **does** exist at v4.26.0 — pin-verified at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:

```bash
$ gh api repos/leanprover-community/mathlib4/contents/Mathlib/Analysis/Complex/ExponentialBounds.lean?ref=2df2f015... --jq .content | base64 -d | grep -nE "^theorem.*exp_one_lt_d9"
37:theorem exp_one_lt_d9 : exp 1 < 2.7182818286 :=
```

It is no longer transitively imported via the four `Mathlib.Analysis.SpecialFunctions.*` imports the file already had. Fix: add the explicit import.

```lean
 import Mathlib.Analysis.SpecialFunctions.Sqrt
+import Mathlib.Analysis.Complex.ExponentialBounds
```

### 3. Lines 365, 455 — `Unknown identifier div_lt_iff`

Renamed to `div_lt_iff₀` in v4.26.0 (the subscript-zero pattern signaling a `0 < divisor` hypothesis). Pin-verified at SHA `2df2f015...` in `Mathlib/Algebra/Order/Field/Basic.lean` (the canonical sibling rename family — `div_lt_one` already calls `div_lt_iff₀`):

```bash
$ ... grep -nE "div_lt_iff" Mathlib/Algebra/Order/Field/Basic.lean
54:theorem div_lt_one (hb : 0 < b) : a / b < 1 ↔ a < b := by rw [div_lt_iff₀ hb, one_mul]
122:  rw [div_lt_iff₀ (zero_lt_two' α), mul_two, lt_add_iff_pos_left]
```

2-site mechanical rename:

```lean
-    rw [div_lt_iff hsqrt_pos]
+    rw [div_lt_iff₀ hsqrt_pos]
```

## Validation

```
$ ./proofs/scripts/docker-build.sh Proofs.Erdos101OQ01
⚠ [3061/3061] Built Proofs.Erdos101OQ01 (4.9s)
warning: Proofs/Erdos101OQ01.lean:110:8: declaration uses 'sorry'
warning: Proofs/Erdos101OQ01.lean:297:8: declaration uses 'sorry'
Build completed successfully (3061 jobs).
=== Build succeeded ===
```

The 2 remaining `sorry` warnings (`erdos_101_oq_01_conjecture` at line 110 and `solymosi_stojakovic_lower_bound` at line 297) are pre-existing intentional placeholders for the open conjecture and the deferred lower-bound theorem — out-of-scope for this build-fix.

## Mechanic kit (v4.26.0 patterns surfaced)

For sibling mechanic agents catching the same regressions in other files:

| Symptom | Fix |
|---|---|
| `error: ... not a positivity goal` after `rw` of `Nat.cast 0` | Replace `positivity` with explicit `exact_mod_cast mul_pos h₁ h₂` (or `norm_cast; positivity` if the cast is incidental) |
| `error: Unknown constant Real.exp_one_lt_d9` | Add `import Mathlib.Analysis.Complex.ExponentialBounds` (no longer in transitive closure of `SpecialFunctions.*`) |
| `error: Unknown identifier div_lt_iff` | Rename to `div_lt_iff₀` (the `₀` family also includes `div_lt_one_iff₀`, `lt_div_iff₀`, etc.) |

## Files Modified

| File | Change |
|---|---|
| `proofs/Proofs/Erdos101OQ01.lean` | +4 / -3 (1 import + 1 positivity fix + 2 div_lt_iff₀ renames) |

## Out of scope

- The 2 remaining `sorry` warnings (open conjecture + deferred lemma) — not a build issue.
- Gallery `meta.json` sync — `lineCount` shifts +1 (469 → 470). Will be picked up by the next auditor pass; no math-status change.

---
Automated fix by lean-mechanic agent. Closes the OQ01 child gap left by #19099.