### PR TITLE
fix(mechanic): BallotProblemOQ03OQ02 v4.26.0 Clusters E+F (23→15, #19005)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -2323,19 +2323,35 @@ private theorem gvCanon_self_inverse {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.we
   -- canonCrossN preserved → canonical data for t' matches t
   have hN := canonCrossN_preserved cfg hwf t hht hht'
   have hci' : canonI cfg hwf t' hht' = ci := by
-    simp only [canonI]; congr 1; exact hN
+    apply Fin.ext
+    change canonCrossN cfg hwf t' hht' / r % r = canonCrossN cfg hwf t hht / r % r
+    rw [hN]
   have hcj' : canonJ cfg hwf t' hht' = cj := by
-    simp only [canonJ]; congr 1; exact hN
+    apply Fin.ext
+    change canonCrossN cfg hwf t' hht' % r = canonCrossN cfg hwf t hht % r
+    rw [hN]
   have hc₀' : canonCol cfg hwf t' hht' = c₀ := by
-    simp only [canonCol]; congr 1; exact hN
+    change canonCrossN cfg hwf t' hht' / (yBound cfg * (r * r)) =
+        canonCrossN cfg hwf t hht / (yBound cfg * (r * r))
+    rw [hN]
   have hy₀' : canonY cfg hwf t' hht' = y₀ := by
-    simp only [canonY]; congr 1; exact hN
+    change canonCrossN cfg hwf t' hht' / (r * r) % yBound cfg =
+        canonCrossN cfg hwf t hht / (r * r) % yBound cfg
+    rw [hN]
   -- Split positions for t' = split positions for t
   -- (splitPosAt only uses cfg.sources, not the tuple itself)
   have hki' : splitPosAt cfg t' (canonCol cfg hwf t' hht') (canonY cfg hwf t' hht')
-      (canonI cfg hwf t' hht') = ki := by simp [splitPosAt, hci', hc₀', hy₀']
+      (canonI cfg hwf t' hht') = ki := by
+    show splitPosAt cfg t' (canonCol cfg hwf t' hht') (canonY cfg hwf t' hht')
+        (canonI cfg hwf t' hht') = splitPosAt cfg t c₀ y₀ ci
+    unfold splitPosAt
+    rw [hci', hc₀', hy₀']
   have hkj' : splitPosAt cfg t' (canonCol cfg hwf t' hht') (canonY cfg hwf t' hht')
-      (canonJ cfg hwf t' hht') = kj := by simp [splitPosAt, hcj', hc₀', hy₀']
+      (canonJ cfg hwf t' hht') = kj := by
+    show splitPosAt cfg t' (canonCol cfg hwf t' hht') (canonY cfg hwf t' hht')
+        (canonJ cfg hwf t' hht') = splitPosAt cfg t c₀ y₀ cj
+    unfold splitPosAt
+    rw [hcj', hc₀', hy₀']
   -- Image path values for double application (using helper lemmas)
   have himg_ci : (t'.2 ci).val = (t.2 ci).val.take ki ++ (t.2 cj).val.drop kj :=
     gvCanonInv_val_ci cfg hwf t hht
@@ -2366,8 +2382,8 @@ private theorem gvCanon_self_inverse {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.we
             List.take_zero, List.append_nil, List.take_take, Nat.min_self]
       have h2 : ((t.2 cj).val.take kj ++ (t.2 ci).val.drop ki).drop kj =
                 (t.2 ci).val.drop ki := by
-        have hkj_drop : ((t.2 cj).val.take kj).drop kj = [] := by
-          nth_rw 2 [← List.length_take_of_le hkj_le]; exact List.drop_length
+        have hkj_drop : ((t.2 cj).val.take kj).drop kj = [] :=
+          List.drop_of_length_le (List.length_take_of_le hkj_le).le
         rw [List.drop_append, List.length_take_of_le hkj_le, Nat.sub_self,
             List.drop_zero, hkj_drop, List.nil_append]
       rw [h1, h2, List.take_append_drop]
@@ -2382,8 +2398,8 @@ private theorem gvCanon_self_inverse {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.we
               List.take_zero, List.append_nil, List.take_take, Nat.min_self]
         have h2 : ((t.2 ci).val.take ki ++ (t.2 cj).val.drop kj).drop ki =
                   (t.2 cj).val.drop kj := by
-          have hki_drop : ((t.2 ci).val.take ki).drop ki = [] := by
-            nth_rw 2 [← List.length_take_of_le hki_le]; exact List.drop_length
+          have hki_drop : ((t.2 ci).val.take ki).drop ki = [] :=
+            List.drop_of_length_le (List.length_take_of_le hki_le).le
           rw [List.drop_append, List.length_take_of_le hki_le, Nat.sub_self,
               List.drop_zero, hki_drop, List.nil_append]
         rw [h1, h2, List.take_append_drop]


### PR DESCRIPTION
## Summary

Partial repair of `proofs/Proofs/BallotProblemOQ03OQ02.lean` v4.26.0 build break, applying the verified fixes from PR #19005's 6-cluster mechanic kit (S74 PARENT-TRIAGE) with sharpened recommendations from PR #19244 (S76 PREP).

**Docker-verified**: `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ02` against this branch closes **8 of 23 errors** (23 → 15) by fixing all 6 sites of Cluster E plus both sites of Cluster F. Cluster A/B/C/D remain (require deeper restructuring of `gvCanonInv`'s cast-based encoding to address v4.26.0 higher-order unification on `congrArg`-wrapped proofs — out-of-scope for this mechanic PR).

## Clusters fixed

### Cluster E (`gvCanon_self_inverse`, 6 sites)

`congr 1; exact hN` failed in v4.26.0 because `simp only [canonX]` exposes a goal where `_ / r % r` extraction does not unify with hN's whole-N equality form.

- **Sites 2326/2328/2330/2332** (`canonI`/`canonJ`/`canonCol`/`canonY` = `ci`/`cj`/`c₀`/`y₀`): replaced with `apply Fin.ext; change <explicit>; rw [hN]` for Fin results, and `change <explicit>; rw [hN]` for ℕ results. The `change` forces the goal into a `canonCrossN` equation that hN directly closes.

- **Sites 2336/2338** (`splitPosAt = ki/kj`): replaced fragile `simp [splitPosAt, hci', hc₀', hy₀']` with `show … = splitPosAt cfg t c₀ y₀ ci; unfold splitPosAt; rw [hci', hc₀', hy₀']` to force definitional reduction through the `set`-bound `ki`/`kj`.

### Cluster F (`gvCanon_self_inverse` internal `have`, 2 sites)

`nth_rw 2` targeted the wrong occurrence in v4.26.0 (occurrence renumbering for nested `.take`/`.drop` patterns). PR #19005 proposed `rw [← h, List.drop_length]` but PR #19244's audit found this shares the same failure mode (rewrites *both* occurrences of `kj`).

- **Sites 2370/2386** (`hkj_drop` / `hki_drop`): use the corrected 1-liner `List.drop_of_length_le (List.length_take_of_le h).le`. Drops the `by` block entirely.

## Out-of-scope (remaining 15 errors)

| Cluster | Sites | Reason for deferring |
|---------|-------|----------------------|
| A | 1911/1920/1928/1930 | `cast_PathMN_val` simp dead under `↑(cast …)` — v4.26.0 higher-order unification fails to decompose opaque `congrArg`-wrapped proof terms. Sharpened recovery (`cast_PathMN_coe` companion w/ explicit `↑` LHS) doesn't parse cleanly due to type-ascription absorption; requires either (a) restructuring `gvCanonInv` to use named cast-proof helpers, or (b) Mathlib bumping `Subtype` coercion simp pipeline. |
| B (cascade) | 1971/2035 | Downstream of A; resolves automatically once A is fixed. |
| C | 2170/2180 | `Type mismatch` after `simp only [colEntry, himg_ci]`; appears coupled to A's `↑` vs `.val` normalization but needs goal-shape diagnosis. |
| D | 2249/2250/2253/2263/2266/2276 | `rw [colEntry_eq ci c₀ le_rfl]` fails to find `colEntry (↑(t'.snd ci)) c₀` due to `let`-zeta past `set ci := canonI …`; PR #19244 §4 sharpened recipe (`simp only [show canonI … = ⟨…⟩ from rfl, …]`) needs precise zeta witness per-site. |

A follow-up mechanic PR should target Cluster A (and B by cascade), then C and D separately. Cluster A's resolution likely opens C and D via the same `↑`/`.val` normalization.

## Build evidence

```
$ ./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ02
…
error: Lean exited with code 1
error: build failed
# 15 errors visible (was 23 on origin/main HEAD)
```

Toolchain: `leanprover/lean4:v4.26.0`, Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, Docker image `lean4-arm64:v4.26.0`.

## Scope discipline

- One file modified: `proofs/Proofs/BallotProblemOQ03OQ02.lean` (+26 / -10 LOC).
- Targeted minimal fixes per cluster; no incidental refactoring.
- No `state.md`, JSON tracker, or `meta.json` edits — this is mechanic scope, not research/state.
- Honors PR #19244's sharpened Cluster F recommendation (avoids the same-failure-mode trap in PR #19005's draft).

Refs:
- Trigger: PR #19005 (S74 PARENT-TRIAGE, 6-cluster mechanic kit, doc-only)
- Sharpened recommendations: PR #19244 (S76 PREP, doc-only)
- Workflow guidance: `feedback_researcher_audit_peer_mechanic_kit_fix_recommendations`

---
🤖 Automated fix by lean-mechanic agent (mechanic-3 worktree)