### PR TITLE
audit(kepler-conjecture-oq-04): correct axiom/theorem/line counts

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -20,9 +20,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 225,
-    "assumptions": "0 sorries, 0 axioms in this file. The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file adds no new axioms — it defines the Chen-Engel-Glotzer rational constant 4000/4671 and the `tetrahedronDimerPacking : PackingDensity` instance, and proves five theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_315` and `Real.lt_sqrt`, axiom-free) and the existential corollary `exists_packingDensity_gt_fcc`. The ellipsoid (Bezdek-Kuperberg) and Ulam (open conjecture) sub-questions will require axiomatization when introduced in future iterations.",
+    "axiomCount": 1,
+    "lineCount": 321,
+    "assumptions": "0 sorries, 1 axiom in this file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, the Bezdek-Kuperberg 2007 statement that every ellipsoid lattice packing in ℝ³ has density at most the FCC sphere density). The parent `Proofs/KeplerConjecture.lean` separately axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, and the `EllipsoidLatticePacking` wrapper structure, and proves six theorems: `tetrahedronDimerDensity_pos`, `tetrahedronDimerDensity_lt_one`, `tetrahedronDimerDensity_gt_8563`, `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, and `ellipsoid_lattice_le_fccPacking` (derived from the Bezdek-Kuperberg axiom). The Ulam (open conjecture) sub-question will require axiomatization when introduced in a future iteration.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -131,6 +131,6 @@
       "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
     }
   ],
-  "theoremCount": 5,
+  "theoremCount": 6,
   "definitionCount": 2
 }


### PR DESCRIPTION
Gallery integrity audit fix. The Lean source has had S3-S5 ACT iterations applied since meta.json was last refreshed. meta.json still claimed 0 axioms but the file declares 1 axiom (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, line 303). Updates: axiomCount 0->1, theoremCount 5->6, lineCount 225->321, and rewrites the assumptions prose. status (axiomatized) and badge (axiom) were already correct.

Evidence:
```
grep -n '^axiom ' proofs/Proofs/KeplerConjectureOQ04.lean
# 303:axiom bezdek_kuperberg_ellipsoid_lattice_upper_bound
wc -l proofs/Proofs/KeplerConjectureOQ04.lean
# 321
```

Discovered during gallery integrity audit (auditor-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)