### PR TITLE
fix(mechanic): Erdos735Problem v4.26.0 parent-file repair (5-cluster, build verified)

### DIFF
--- a/proofs/Proofs/Erdos735Problem.lean
+++ b/proofs/Proofs/Erdos735Problem.lean
@@ -30,16 +30,19 @@
 -/
 
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
 namespace Erdos735
 
+open scoped Classical
+
 /- ## Basic Setup -/
 
 /-- A point configuration in the plane -/
-def PointConfig := Finset (EuclideanSpace ℝ (Fin 2))
+abbrev PointConfig := Finset (EuclideanSpace ℝ (Fin 2))
 
 /-- A weighting assigns a positive real to each point -/
 def Weighting (P : PointConfig) := {w : P → ℝ // ∀ p, w p > 0}
@@ -47,11 +50,11 @@ def Weighting (P : PointConfig) := {w : P → ℝ // ∀ p, w p > 0}
 /-- A line determined by the configuration (at least 2 points) -/
 def ConfigLine (P : PointConfig) :=
   { L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin 2)) //
-    L.direction.toSubmodule.rank = 1 ∧
+    Module.rank ℝ L.direction = 1 ∧
     (P.filter (· ∈ L)).card ≥ 2 }
 
 /-- The sum of weights on a line -/
-def lineSum (P : PointConfig) (w : Weighting P) (L : ConfigLine P) : ℝ :=
+noncomputable def lineSum (P : PointConfig) (w : Weighting P) (L : ConfigLine P) : ℝ :=
   (P.filter (· ∈ L.val)).sum fun p =>
     if h : p ∈ P then w.val ⟨p, h⟩ else 0
 
@@ -70,7 +73,7 @@ noncomputable def magicConstant (P : PointConfig) (hMagic : IsMagic P) : ℝ :=
 /-- Class 1: All points collinear -/
 def IsCollinear (P : PointConfig) : Prop :=
   ∃ L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin 2)),
-    L.direction.toSubmodule.rank = 1 ∧ ∀ p ∈ P, p ∈ L
+    Module.rank ℝ L.direction = 1 ∧ ∀ p ∈ P, p ∈ L
 
 /-- Collinear configurations are trivially magic (only one line). -/
 axiom collinear_is_magic (P : PointConfig) (hP : P.card ≥ 2) :
@@ -79,7 +82,7 @@ axiom collinear_is_magic (P : PointConfig) (hP : P.card ≥ 2) :
 /-- Class 2: General position (no 3 collinear) -/
 def IsGeneralPosition (P : PointConfig) : Prop :=
   ∀ L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin 2)),
-    L.direction.toSubmodule.rank = 1 →
+    Module.rank ℝ L.direction = 1 →
     (P.filter (· ∈ L)).card ≤ 2
 
 /-- General position configurations are magic with equal weights. -/
@@ -89,11 +92,12 @@ axiom general_position_is_magic (P : PointConfig) (hP : P.card ≥ 2) :
 /-- Class 3: Near-pencil (n-1 points on a line) -/
 def IsNearPencil (P : PointConfig) : Prop :=
   ∃ L : AffineSubspace ℝ (EuclideanSpace ℝ (Fin 2)),
-    L.direction.toSubmodule.rank = 1 ∧
+    Module.rank ℝ L.direction = 1 ∧
     (P.filter (· ∈ L)).card = P.card - 1 ∧
     P.card ≥ 3
 
-/-- Near-pencil configurations are magic via careful weight assignment. -/
+/- Near-pencil configurations are magic via careful weight assignment. -/
+
 /-- Class 4: Incenter configuration — a triangle with its incenter and
     points on angle bisectors, or any projective image of such. -/
 def IsIncenterConfig (P : PointConfig) : Prop :=
@@ -105,7 +109,8 @@ def IsIncenterConfig (P : PointConfig) : Prop :=
       Collinear ℝ ({B, I, p} : Set (EuclideanSpace ℝ (Fin 2))) ∨
       Collinear ℝ ({C, I, p} : Set (EuclideanSpace ℝ (Fin 2))))
 
-/-- Incenter configurations are magic. -/
+/- Incenter configurations are magic. -/
+
 /- ## Projective Equivalence -/
 
 /-- Two configurations are projectively equivalent -/
@@ -114,7 +119,8 @@ def ProjectivelyEquivalent (P Q : PointConfig) : Prop :=
     Function.Bijective f ∧
     Q = P.image f
 
-/-- Magic property is preserved under projective equivalence -/
+/- Magic property is preserved under projective equivalence -/
+
 /- ## The Main Classification -/
 
 /-- A configuration belongs to one of the four magic classes -/
@@ -136,8 +142,9 @@ noncomputable def linesThrough (P : PointConfig) (p : EuclideanSpace ℝ (Fin 2)
     (hp : p ∈ P) : ℕ :=
   (P.filter (· ≠ p)).card
 
-/-- In a magic configuration, the weight of a point is determined by
+/- In a magic configuration, the weight of a point is determined by
     the number of lines through it and the magic constant. -/
+
 /- ## The Non-Magic Theorem -/
 
 /-- Configurations not in the four classes are not magic -/
@@ -150,8 +157,10 @@ theorem not_magic_outside_classes (P : PointConfig) (hP : P.card ≥ 3) :
 /- ## Examples -/
 
 /-- Example: Three collinear points are magic -/
-def threeCollinear : PointConfig :=
-  {![0, 0], ![1, 0], ![2, 0]}
+noncomputable def threeCollinear : PointConfig :=
+  {WithLp.toLp 2 ![(0 : ℝ), 0],
+   WithLp.toLp 2 ![(1 : ℝ), 0],
+   WithLp.toLp 2 ![(2 : ℝ), 0]}
 
 axiom three_collinear_card : threeCollinear.card ≥ 2
 axiom three_collinear_collinear : IsCollinear threeCollinear
@@ -160,8 +169,10 @@ theorem three_collinear_is_magic : IsMagic threeCollinear :=
   collinear_is_magic threeCollinear three_collinear_card three_collinear_collinear
 
 /-- Example: Three non-collinear points (triangle) are magic -/
-def triangle : PointConfig :=
-  {![0, 0], ![1, 0], ![0, 1]}
+noncomputable def triangle : PointConfig :=
+  {WithLp.toLp 2 ![(0 : ℝ), 0],
+   WithLp.toLp 2 ![(1 : ℝ), 0],
+   WithLp.toLp 2 ![(0 : ℝ), 1]}
 
 axiom triangle_card : triangle.card ≥ 2
 axiom triangle_general_position : IsGeneralPosition triangle
@@ -176,12 +187,14 @@ noncomputable def incidenceMatrix (P : PointConfig) :
     (ConfigLine P) → P → ℝ :=
   fun L p => if p.val ∈ L.val then 1 else 0
 
-/-- Magic iff the incidence linear system has a positive solution -/
+/- Magic iff the incidence linear system has a positive solution -/
+
 /- ## Dimension Counting Argument -/
 
-/-- The space of valid weightings has dimension at most n minus the number
+/- The space of valid weightings has dimension at most n minus the number
     of independent line constraints. For configurations outside the four
     classes, this dimension is negative — no positive solution exists. -/
+
 end Erdos735
 
 /-

--- a/src/data/proofs/erdos-735/meta.json
+++ b/src/data/proofs/erdos-735/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/735",
     "erdosProblemStatus": "solved",
     "axiomCount": 7,
-    "lineCount": 210,
+    "lineCount": 223,
     "assumptions": "7 axioms: collinear_is_magic, general_position_is_magic, magic_classification, three_collinear_card, three_collinear_collinear, triangle_card, triangle_general_position. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
@@ -140,13 +140,14 @@
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.InnerProductSpace.PiL2",
-      "Mathlib.LinearAlgebra.AffineSpace.AffineSubspace",
+      "Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic",
+      "Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": [],
+    "opens": ["Classical"],
     "namespace": "Erdos735",
-    "lineCount": 210,
+    "lineCount": 223,
     "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 17,


### PR DESCRIPTION
## Summary

Pre-existing build break in `proofs/Proofs/Erdos735Problem.lean` — never validated at v4.26.0. The file was authored before the v4.26.0 toolchain bump and accumulated several latent issues that all surfaced together once we tried to build it.

Audit trigger: PR #19278 (S2 PREP for `erdos-735-oq-04`), which flagged the `.toSubmodule.rank` chain as stale and noted \"if parent is silently broken, a 4-line mechanic fix is needed.\" Actual scope was larger due to compound pre-existing latent bugs.

**Docker-verified**: `./proofs/scripts/docker-build.sh Proofs.Erdos735Problem` → **3061/3061 jobs, build success**.

## Clusters fixed

### 1. Stale import path
`Mathlib.LinearAlgebra.AffineSpace.AffineSubspace` no longer exists at v4.26.0 (split into `AffineSubspace/Basic.lean` and `AffineSubspace/Defs.lean`). Switched to `.Basic` form and added `FiniteDimensional` import for `Collinear` (used in `IsIncenterConfig`).

### 2. Stale `.toSubmodule.rank` chain (4 sites)
`AffineSubspace.direction` now returns `Submodule` directly at v4.26.0 (`AffineSubspace/Defs.lean:188`), and `Submodule.rank` is not a dotted accessor. Replaced with `Module.rank ℝ L.direction = 1` — preserves the original Cardinal-valued semantics.

### 3. `def PointConfig` opacity
`def PointConfig := Finset (EuclideanSpace ℝ (Fin 2))` blocks `CoeSort Finset _` instance resolution downstream — `(P : PointConfig) → ℝ` fails to elaborate as a function type. Changed `def → abbrev` so the underlying `Finset` is transparent for instance synthesis.

### 4. `DecidablePred` synthesis
`(P.filter (· ∈ L))` over Real-valued affine subspaces lacks a `DecidablePred` instance. Added `open scoped Classical` at namespace top.

### 5. Stale `![...]` example construction
`![0, 0]` produces `Fin 2 → ℕ/ℝ`, not `EuclideanSpace ℝ (Fin 2) = WithLp 2 (Fin 2 → ℝ)` (defs aren't reducibly equal). Switched examples to `WithLp.toLp 2 ![(0 : ℝ), 0]` form. Marked `def threeCollinear` / `triangle` / `lineSum` as `noncomputable` (now depend on `Real.decidableEq` via Classical).

### 6. Orphan `/--` docstrings (5 sites)
Lines 96, 108, 117, 140, 179, and the file-tail comment block. v4.26.0 enforces strict docstring attachment to a following declaration; orphan `/--` blocks raise `unexpected token '/--'`. Converted to `/-` plain comments.

## Scope discipline

- One Lean source file: `proofs/Proofs/Erdos735Problem.lean` (+27 / -20 LOC).
- One metadata file: `src/data/proofs/erdos-735/meta.json` (+5 / -4):
  - `lineCount`: 210 → 223
  - `imports`: split `AffineSubspace` path + added `FiniteDimensional`
  - `opens`: `[]` → `[\"Classical\"]`
- **No axiom/sorry/structure change**: `axiomCount` (7), `theoremCount` (3), `definitionCount` (17), `sorries` (0) all preserved.

## Build evidence

\`\`\`
$ ./proofs/scripts/docker-build.sh Proofs.Erdos735Problem
...
✔ [3061/3061] Replayed Proofs.Erdos735Problem
warning: Proofs/Erdos735Problem.lean:142:5: unused variable \`hp\`
Build completed successfully (3061 jobs).
\`\`\`

Toolchain: `leanprover/lean4:v4.26.0`, Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, Docker image `lean4-arm64:v4.26.0`. The single unused-variable warning (`hp` in `linesThrough` def at line 142) is pre-existing and out of mechanic scope.

## Refs

- PR #19278: S2 PREP — flagged `.toSubmodule.rank` chain as stale at v4.26.0
- PR #19012: S2 ACT for `erdos-735-oq-04` — independent child scaffold (3058 jobs) confirms the v4.26.0 API patterns used here

---
🤖 Automated fix by lean-mechanic agent (mechanic-3 worktree).