### PR TITLE
fix(meta): kepler-conjecture-oq-04 post-S6 ACT meta.json sync (1→2 axioms)

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -20,9 +20,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 321,
-    "assumptions": "0 sorries, 1 axiom in this file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, the Bezdek-Kuperberg 2007 ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, and the `EllipsoidLatticePacking` marker structure; proves six theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, and the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`. The Ulam (open conjecture) sub-question will require axiomatization when introduced in a future iteration.",
+    "axiomCount": 2,
+    "lineCount": 399,
+    "assumptions": "0 sorries, 2 axioms in this file: (1) `bezdek_kuperberg_ellipsoid_lattice_upper_bound`, the Bezdek-Kuperberg 2007 ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0; (2) `ulam_conjecture` (S6 ACT), Ulam's 1972 open conjecture that every centrally symmetric convex body in ℝ³ packs to density at least `π/(3√2)` — currently unproven in the literature, so genuinely a STATEMENT axiom on the open conjecture. The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, the `EllipsoidLatticePacking` marker structure, and the `SymmetricConvexBody3DPacking` marker structure; proves seven theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`, and the Ulam-derived corollary `ulam_le_fccPacking_density`.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -136,6 +136,6 @@
       "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
     }
   ],
-  "theoremCount": 6,
-  "definitionCount": 3
+  "theoremCount": 7,
+  "definitionCount": 4
 }


### PR DESCRIPTION
## Summary

Mechanic repair following PR #19109 (S6 ACT — Ulam conjecture axiom). The S6 ACT added Ulam's open conjecture as a STATEMENT axiom plus its marker structure and derived corollary, but did not update the gallery `meta.json`. The prior canonical sync #19284 had brought meta.json to the post-S5 state; this PR brings it forward to the post-S6 state.

## Why this is not a duplicate

There are ~30 open PRs touching `kepler-conjecture-oq-04/meta.json`, but **all of them are pre-S6** (created 2026-05-14, before #19109 merged). They target the 0→1 axiom transition that the canonical fix #19284 already landed, leaving the file at `axiomCount: 1`. None capture the new content from S6 ACT — they would now be no-ops or conflicts against the current state.

The current actual state of `proofs/Proofs/KeplerConjectureOQ04.lean` (HEAD `2cbed747d7b`):
- `wc -l` → 399
- `grep -E '^axiom '` → 2 (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`)
- `grep -E '^(theorem|lemma) '` → 7 actual theorems
- `grep -E '^(def|noncomputable def|structure) '` → 4 actual decls

vs prior `meta.json`: axiomCount=1, theoremCount=6, definitionCount=3, lineCount=321.

## Corrected fields

| Field | Before | After |
|-------|--------|-------|
| `axiomCount` | 1 | **2** |
| `theoremCount` | 6 | **7** |
| `definitionCount` | 3 | **4** |
| `lineCount` | 321 | **399** |
| `assumptions` | mentions only Bezdek-Kuperberg | now documents both axioms + 7th corollary |

`status` (`axiomatized`) and `badge` (`axiom`) unchanged — both remain correct per the axiom-integrity policy: Ulam's conjecture is genuinely open since 1972, so a STATEMENT axiom is the appropriate treatment.

## Scope

5+/5- lines, single file (`src/data/proofs/kepler-conjecture-oq-04/meta.json`). No Lean changes. No `loom:review-requested` label per math-agent label policy.

## Test plan

- [x] `python3 -c 'import json; json.load(open(...))'` passes
- [x] Manual count cross-checked against `proofs/Proofs/KeplerConjectureOQ04.lean` at HEAD `2cbed747d7b`
- [x] Diff is surgical (1 file, 5+/5-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)