### PR TITLE
audit(kepler-conjecture-oq-04): post-S6 meta.json sync — Ulam axiom + theorem + structure

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -20,9 +20,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 321,
-    "assumptions": "0 sorries, 1 axiom in this file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, the Bezdek-Kuperberg 2007 ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, and the `EllipsoidLatticePacking` marker structure; proves six theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, and the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`. The Ulam (open conjecture) sub-question will require axiomatization when introduced in a future iteration.",
+    "axiomCount": 2,
+    "lineCount": 399,
+    "assumptions": "0 sorries, 2 axioms in this file: (i) `bezdek_kuperberg_ellipsoid_lattice_upper_bound` (Bezdek-Kuperberg 2007, the ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0); and (ii) `ulam_conjecture` (Ulam 1972, OPEN — the bound `fccDensity ≤ δ_K` for centrally symmetric convex bodies `K ⊂ ℝ³`, stated as a STATEMENT axiom because the conjecture remains unproven after 50+ years). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, the `EllipsoidLatticePacking` marker structure, and the `SymmetricConvexBody3DPacking` marker structure; proves seven theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`, and the Ulam-derived corollary `ulam_le_fccPacking_density`.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -136,6 +136,6 @@
       "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
     }
   ],
-  "theoremCount": 6,
-  "definitionCount": 3
+  "theoremCount": 7,
+  "definitionCount": 4
 }


### PR DESCRIPTION
## Summary

S6 ACT ([#19109](https://github.com/rjwalters/lean-genius/pull/19109)) added the Ulam conjecture as a STATEMENT axiom plus the companion `SymmetricConvexBody3DPacking` marker structure and the `ulam_le_fccPacking_density` derived corollary, growing `proofs/Proofs/KeplerConjectureOQ04.lean` from 321 to 399 lines. The canonical S5 sync ([#19284](https://github.com/rjwalters/lean-genius/pull/19284)) ran just before S6 merged, so `meta.json` is again out of sync with current `main`:

- `axiomCount` undercount by 1 (`ulam_conjecture` missing)
- `theoremCount` undercount by 1 (`ulam_le_fccPacking_density` missing)
- `definitionCount` undercount by 1 (`SymmetricConvexBody3DPacking` missing)
- `lineCount` off by 78

## Corrected fields (matching #19284 scope: counts + assumptions only)

- **axiomCount**: `1 → 2` (`ulam_conjecture` added)
- **theoremCount**: `6 → 7` (`ulam_le_fccPacking_density` added)
- **definitionCount**: `3 → 4` (`SymmetricConvexBody3DPacking` added)
- **lineCount**: `321 → 399`
- **assumptions**: rewritten to document both axioms (Bezdek-Kuperberg 2007 + Ulam 1972), name the new marker structure, and update the corollary list (now four named theorems + three numeric bounds = 7 total)

Badge (`axiom`) and status (`axiomatized`) are unchanged (and now correct for the +1 axiom). `mathlibDependencies` is unchanged — the new axiom uses no Mathlib lemmas (statement axiom), and the new theorem's body is the single-tactic application `ulam_conjecture p`.

## Evidence

Against `origin/main` HEAD `0b7be04c5a2` (post-#19109):

```
$ grep -nE '^axiom ' proofs/Proofs/KeplerConjectureOQ04.lean
315:axiom bezdek_kuperberg_ellipsoid_lattice_upper_bound
383:axiom ulam_conjecture (p : SymmetricConvexBody3DPacking) :
```

(The `^axiom` grep also hits line 184 inside the module docstring — `axiom states \`δ ≤ π/(3√2)\`...` — but that is comment text describing the *parent* file's axiom, not a declaration.)

```
$ wc -l proofs/Proofs/KeplerConjectureOQ04.lean
399
```

Theorem count by inspection (excluding two docstring matches at lines 185, 259):

| # | Line | Theorem |
|---|------|---------|
| 1 | 116 | `tetrahedronDimerDensity_pos` |
| 2 | 128 | `tetrahedronDimerDensity_lt_one` |
| 3 | 147 | `tetrahedronDimerDensity_gt_8563` |
| 4 | 198 | `tetrahedronDimerDensity_gt_fccDensity` |
| 5 | 249 | `exists_packingDensity_gt_fcc` |
| 6 | 328 | `ellipsoid_lattice_le_fccPacking` |
| 7 | 394 | `ulam_le_fccPacking_density` (NEW from S6) |

Definitions and structures (excluding line 229 docstring match):

| # | Line | Declaration |
|---|------|-------------|
| 1 | 108 | `noncomputable def tetrahedronDimerDensity` |
| 2 | 233 | `noncomputable def tetrahedronDimerPacking` |
| 3 | 300 | `structure EllipsoidLatticePacking` |
| 4 | 352 | `structure SymmetricConvexBody3DPacking` (NEW from S6) |

## Relationship to existing kepler-oq-04 PRs

The auditor flagged this slug repeatedly across S5; #19284 (canonical S5 sync) landed on `main` at 2026-05-15T18:01:37Z and was followed 1h later by S6 ACT (#19109) at 19:00:56Z. The 31 still-open meta-fix PRs that pre-date #19284 are now `CONFLICTING` against `main` for the S5 fields *and* incomplete for the S6 fields — closing them as obsolete is preferable to rebasing each. This PR is `MERGEABLE` against the post-S6 `main` and is the minimal surgical fix to bring `meta.json` current.

Addresses auditor issues [#19154](https://github.com/rjwalters/lean-genius/issues/19154) (filed for S5 drift, never closed; this PR brings meta past the drift) and [#19285](https://github.com/rjwalters/lean-genius/issues/19285) (same).

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] Counts match grep evidence on the Lean source at `origin/main`
- [x] No code changes — meta-only PR, doc-only style
- [ ] CI lint pipeline (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)