### PR TITLE
fix(meta): kepler-conjecture-oq-04 post-S6 ACT meta.json sync (1→2 axioms) [retry of #19308]

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -20,9 +20,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 321,
-    "assumptions": "0 sorries, 1 axiom in this file (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, the Bezdek-Kuperberg 2007 ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, and the `EllipsoidLatticePacking` marker structure; proves six theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, and the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`. The Ulam (open conjecture) sub-question will require axiomatization when introduced in a future iteration.",
+    "axiomCount": 2,
+    "lineCount": 399,
+    "assumptions": "0 sorries, 2 axioms in this file: (i) `bezdek_kuperberg_ellipsoid_lattice_upper_bound` (Bezdek-Kuperberg 2007, the ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0); and (ii) `ulam_conjecture` (Ulam 1972, OPEN — the bound `fccDensity ≤ δ_K` for centrally symmetric convex bodies `K ⊂ ℝ³`, stated as a STATEMENT axiom because the conjecture remains unproven after 50+ years). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, the `EllipsoidLatticePacking` marker structure, and the `SymmetricConvexBody3DPacking` marker structure; proves seven theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`, and the Ulam-derived corollary `ulam_le_fccPacking_density`.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -136,6 +136,6 @@
       "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
     }
   ],
-  "theoremCount": 6,
-  "definitionCount": 3
+  "theoremCount": 7,
+  "definitionCount": 4
 }


### PR DESCRIPTION
## Summary

Mechanic repair following PR #19109 (S6 ACT — Ulam conjecture axiom). The S6 ACT added Ulam's open conjecture as a STATEMENT axiom plus its marker structure and derived corollary, but did not update the gallery `meta.json`. The prior canonical sync #19284 had brought meta.json to the post-S5 state; this PR brings it forward to the post-S6 state.

## Why this is being re-opened

PR #19308 shipped this exact post-S6 sync at 2026-05-15T19:07:22Z but was closed at 19:24:41Z by a concurrent mechanic cycle that mistook a peer branch push (`fix/mechanic-19285-kepler-oq04-s6-meta-sync`, commit `42c78f0b516`) for a direct-to-main commit. The peer branch was never opened as a PR and is no longer on origin; the drift on `main` (HEAD `0b7be04c5a2`) is still present. This PR re-ships the identical fix on a fresh branch.

## Why this is not a duplicate of the 15 open pile-up PRs

There are 15 open PRs touching `kepler-conjecture-oq-04/meta.json` (numbers `18981, 18983, 19022, 19045, 19051, 19067, 19069, 19076, 19079, 19080, 19082, 19084, 19085, 19087, 19089`), but **all are pre-S6** (created 2026-05-14, before #19109 merged) and all are currently `CONFLICTING`. They target the 0→1 axiom transition that the canonical sync #19284 already landed, leaving the file at `axiomCount: 1`. None capture the new content from S6 ACT — they would now be no-ops or conflicts against the current state.

## Current actual state vs `meta.json`

`proofs/Proofs/KeplerConjectureOQ04.lean` at HEAD `2cbed747d7b` (S6 ACT) cross-checked:

| Field | meta.json (before) | Lean actual | meta.json (after) |
|-------|-------------------|-------------|-------------------|
| `axiomCount` | 1 | 2 (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`) | **2** |
| `theoremCount` | 6 | 7 | **7** |
| `definitionCount` | 3 | 4 | **4** |
| `lineCount` | 321 | 399 | **399** |
| `assumptions` | only Bezdek-Kuperberg | both axioms + new corollary | rewritten |

`status` (`axiomatized`) and `badge` (`axiom`) unchanged — both remain correct per the axiom-integrity policy: Ulam's conjecture is genuinely open since 1972, so a STATEMENT axiom is the appropriate treatment.

## Scope

5+/5- lines, single file (`src/data/proofs/kepler-conjecture-oq-04/meta.json`). No Lean changes. Closes auditor issues #19285 and #19154 once merged. No `loom:review-requested` label per math-agent label policy.

## Test plan

- [x] `python3 -c 'import json; json.load(open(...))'` passes
- [x] Manual count cross-checked against `proofs/Proofs/KeplerConjectureOQ04.lean` at HEAD `2cbed747d7b` (axioms: 2 lines starting with `axiom ` outside docstrings; theorems: 7; defs+structures: 4; lineCount: 399)
- [x] Diff is surgical (1 file, 5+/5-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)