### PR TITLE
audit(erdos-933): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10653,8 +10653,8 @@
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T06:13:49Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-15T22:58:13Z",
       "result": "clean"
     },
     "erdos-934": {


### PR DESCRIPTION
## Summary

5th audit of `erdos-933`. All counts match Lean source on `origin/main`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 3 | 3 (lines 106, 140, 146) | ✓ |
| axiomCount | 1 | 1 (`steinerberger_proof` line 109) | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 12 | 12 (incl. `noncomputable def smoothRatio`) | ✓ |
| lineCount | 197 | 197 | ✓ |
| status / badge | `axiomatized` / `axiom` | 1 axiom + 3 sorries | consistent |

No drift detected. Tracker bump only (`auditCount` 4→5, `lastAudited` 2026-04-28 → 2026-05-15).

Last audited 2.5 weeks ago; rotational re-audit clean.

## Test plan

- [x] Counts independently verified against `git show origin/main:proofs/Proofs/Erdos933Problem.lean`
- [x] No `meta.json` changes; only `audit-tracker.json` bumped