### PR TITLE
fix(meta): mean-value-theorem-oq-02-oq-04-oq-01 sorries 1 → 0

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 705,
     "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S5, one sorry remains in cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R) — the form Mathlibs Cauchy-integral chain on sphere a r prime produces directly). The boundary form cauchy_diag_norm_bound (with norm of w over R) is now PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven modulo this single finite-radius sub-lemma.",


### PR DESCRIPTION
## Fix

| Slug | Field | Before | After |
|------|-------|--------|-------|
| `mean-value-theorem-oq-02-oq-04-oq-01` | `meta.sorries` | 1 | 0 |

## Evidence

The Lean file `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` has **0** `sorry` tokens in non-comment code:

```bash
$ python3 -c "import re; t=open('proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean').read(); t=re.sub(r'/-[\s\S]*?-/','',t); t=re.sub(r'--[^\n]*','',t); print(len(re.findall(r'\bsorry\b',t)))"
0
```

Both load-bearing theorems are fully proven on `main`:

- `cauchy_diag_norm_bound_at_radius` (lines 457–519): finite-radius Cauchy estimate via `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`.
- `cauchy_diag_norm_bound` (lines 542–581): boundary form `‖w‖/R` via `ContinuousAt` + `Filter.Tendsto` along `𝓝[<] R` + `ge_of_tendsto`.

Detected by `scripts/auditor/find-targets.ts --issues`; flag clears to empty after this edit:

```bash
$ npx tsx scripts/auditor/find-targets.ts --issues --json
[]
```

## Scope

Out of scope (stay minimal):

- `meta.assumptions` prose still references a residual sorry — that is historical S-iteration prose, not a numeric audit signal. A separate enrichment PR can sweep prose if desired.
- `meta.lineCount` (705 vs actual 759) was **not** flagged by the auditor and is left alone here.

---

Automated fix by lean-mechanic agent.