### PR TITLE
fix(mechanic): mean-value-theorem-oq-02-oq-04-oq-01 sorries 1 → 0 post-S7 (#19063)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -21,10 +21,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 705,
-    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S5, one sorry remains in cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R) — the form Mathlibs Cauchy-integral chain on sphere a r prime produces directly). The boundary form cauchy_diag_norm_bound (with norm of w over R) is now PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven modulo this single finite-radius sub-lemma.",
+    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S7, zero sorries remain. The finite-radius form cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R)) was discharged in S7 via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le. The boundary form cauchy_diag_norm_bound (with norm of w over R) is PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven.",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync stale `meta.sorries` on `mean-value-theorem-oq-02-oq-04-oq-01` after PR #19063 (S7 ACT) discharged the residual `cauchy_diag_norm_bound_at_radius` sorry.

## Evidence

**Before** (origin/main):

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 1 audit targets (of 1 total):
  mean-value-theorem-oq-02-oq-04-oq-01 (1x, last 2026-05-12) [axiomatized/axiom] ❌ sorry mismatch: claims 1, actual 0
```

**After** (this branch):

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

## Source-of-truth check

- `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` actual sorries: **0** (all 12 textual `sorry` occurrences are inside `/--…-/` docstrings discussing historical/refuted-axiom prose; zero tactic-level sorries).
- PR #19063 description: *"706 → 758 LOC (+52); sorry 1 → 0; axioms 0 → 0. Build completed successfully (7745 jobs)."*

## Changes

| Field | Before | After |
|------|--------|-------|
| `meta.sorries` | `1` | `0` |
| `meta.assumptions` | "After S5, one sorry remains in `cauchy_diag_norm_bound_at_radius` … fully proven modulo this single finite-radius sub-lemma." | "After S7, zero sorries remain. The finite-radius form `cauchy_diag_norm_bound_at_radius` was discharged in S7 via Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`. … The section 3b main theorem `analytic_taylor_remainder_uniform_bound_complex` is fully proven." |

Both edits are surgical; `status`/`badge`/`axiomCount`/`lineCount`/other counts left unchanged (only `sorries` was flagged by the canonical auditor; per scope discipline, no expansion). Slug remains `axiomatized/axiom` because it refutes a parent-file axiom (axiom-flavored research entry).

## Test plan

- [x] `python3 -m json.tool` round-trips the edited meta.json (valid JSON)
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` drops from 1 issue → 0
- [x] Diff scope: 1 file, +2 −2 lines
- [x] No Lean source touched; no axiomCount/status/badge changes
- [x] No `loom:review-requested` label (deployer merges math/mechanic PRs directly)

---
Automated fix by lean-mechanic agent (mechanic-3 slot).