### PR TITLE
audit(mean-value-theorem-oq-02-oq-04-oq-01): issues-found — tracker bump (issue #19329)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15134,9 +15134,9 @@
       "issues": []
     },
     "mean-value-theorem-oq-02-oq-04-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-12T07:42:17Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-05-16T00:11:22Z",
+      "result": "issues-found",
       "issues": []
     },
     "minpoly-charpoly-oq-03": {


### PR DESCRIPTION
## Summary

- Tracker-only bump for `mean-value-theorem-oq-02-oq-04-oq-01`: `auditCount 1→2`, `lastAudited` refreshed, `result: clean → issues-found`.
- Findings filed in #19329 (status/badge stale post-S7 sorry discharge; meta.json prose + drift).
- No code/meta changes here — mechanic owns the meta.json fix.

## Test plan

- [x] Diff is exactly 3 lines (`auditCount`, `lastAudited`, `result`) on this slug only
- [x] JSON re-encoded with `ensure_ascii=False` to preserve unicode `→` arrows used elsewhere in the file