### PR TITLE
fix(meta): mean-value-theorem-oq-02-oq-04-oq-01 status/badge sync post-S7 (#19329)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius researchers (refutation by Runge counterexample, formalized 2026)",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MeanValueTheoremOQ02OQ04OQ01.lean",
     "tags": [
       "calculus",
@@ -20,10 +20,10 @@
       "analysis",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 705,
+    "lineCount": 758,
     "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S7, zero sorries remain. The finite-radius form cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R)) was discharged in S7 via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le. The boundary form cauchy_diag_norm_bound (with norm of w over R) is PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven.",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
@@ -94,9 +94,9 @@
       "Identification of the Runge phenomenon as the root cause: real-analyticity + real sup bound does not yield Cauchy coefficient estimates because the complex radius of convergence (the distance to the nearest pole in ℂ) can be much smaller than the real interval radius (the distance to the nearest singularity on ℝ).",
       "Statement of the corrected complex-hypothesis version analytic_taylor_remainder_uniform_bound_complex with explicit Mathlib chain (HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius) for S2 discharge.",
       "Demonstration that the explicit R^n factor in the denominator (M·r^(n+1) / (R^n · (R-r))) is essential; the OQ-04 statement that absorbs R^n into M is too weak to be true under real-only hypotheses.",
-      "S4 (Iter 4): the §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo a single named sub-lemma cauchy_diag_norm_bound. The combination scaffolding (HasFPowerSeriesOnBall.hasSum_sub → per-term geometric bound via cauchy_diag_norm_bound → norm_sub_le_of_geometric_bound_of_hasSum at index n+1 → norm_sub_rev + field_simp + ring rescaling using 1 − r/R = (R−r)/R) is now Lean code, not docstring. Sorry count stays at 1 (moved from main-theorem black-box to a single Cauchy-coefficient gap)."
+      "S4 (Iter 4): the §3b main theorem analytic_taylor_remainder_uniform_bound_complex is now fully proven modulo a single named sub-lemma cauchy_diag_norm_bound. The combination scaffolding (HasFPowerSeriesOnBall.hasSum_sub → per-term geometric bound via cauchy_diag_norm_bound → norm_sub_le_of_geometric_bound_of_hasSum at index n+1 → norm_sub_rev + field_simp + ring rescaling using 1 − r/R = (R−r)/R) is now Lean code, not docstring. Sorry count stays at 1 (moved from main-theorem black-box to a single Cauchy-coefficient gap). (S7 follow-on: the Cauchy-coefficient gap was discharged in PR #19063 via Mathlib's Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le; the file is now sorry-free.)"
     ],
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 3
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale meta drift for `mean-value-theorem-oq-02-oq-04-oq-01` after PR #19063 discharged the final sorry and PR #19327 corrected `sorries: 1→0`. The remaining drift (status / badge / lineCount / theoremCount / S4 contribution prose) is now cleared.

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `status` | `axiomatized` | `verified` |
| `badge` | `axiom` | `mathlib` |
| `lineCount` | `705` | `758` |
| `theoremCount` | `13` | `12` |
| `originalContributions[S4]` | "Sorry count stays at 1 …" | + "(S7 follow-on: discharged in PR #19063; file is now sorry-free.)" |

`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` (verified):

- `wc -l` → **758**
- `^axiom ` → **0** declarations
- `^(theorem|lemma) ` → **12** top-level declarations
- `^(noncomputable )?def ` → **3** top-level declarations
- `\bsorry\b` outside docstrings → **0** (all `sorry` mentions are in `/-- … -/` discussion blocks)

Per `lean-auditor.md` Tier B rule, the §3b positive theorem `analytic_taylor_remainder_uniform_bound_complex` routes through Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (Cauchy integral on `sphere a r'`), so badge = `mathlib` is the load-bearing classification.

Verification: `npx tsx scripts/auditor/find-targets.ts --issues --json` → `[]` (issue cleared).

Out of scope (deferred to a later sweep, not gallery-integrity issues): 12 stale docstring lines in the `.lean` file at L65, L307, L309, L315, L418, L434, L536, L602, L604, L609, L697, L720 that still describe "one remaining sorry" — these are inside `/-- … -/` blocks and do not affect Lean compilation or the gallery render.

Closes #19329

---
Automated fix by lean-mechanic agent.