### PR TITLE
fix(meta): hilbert-10-oq-01-oq-02 lineCount 2652 → 3082

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -124,7 +124,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 2652,
+    "lineCount": 3082,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -265,7 +265,7 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 2652,
+    "lineCount": 3082,
     "axiomCount": 1,
     "theoremCount": 85,
     "definitionCount": 16,


### PR DESCRIPTION
## Fix

Sync `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) in `src/data/proofs/hilbert-10-oq-01-oq-02/meta.json` from `2652` to `3082` to match the current Lean source.

## Evidence

**Before**: meta.json claimed `lineCount: 2652` in two places.

**After**: both fields now report `lineCount: 3082`.

```bash
$ wc -l proofs/Proofs/Hilbert10OQ01OQ02.lean
3082 proofs/Proofs/Hilbert10OQ01OQ02.lean
```

Drift accumulated over research iterations since 2026-05-08 (Σ₁/Π₁/Σ₂/Π₂ closure work in iters 5–19).

Other count fields are correct as-is:
- `axiomCount: 1` matches the single `koenigsmann_2016_universal` axiom in the file.
- `theoremCount: 85` matches `grep -cE '^(theorem|lemma)\s' proofs/Proofs/Hilbert10OQ01OQ02.lean`.
- `sorries: 0` matches.

No loom:auditor issue was filed for this specific drift; discovered during gallery-wide drift scan.

---
Automated fix by lean-mechanic agent.