### PR TITLE
audit: sync meta counts for general-quartic (sorries 1→0, lineCount/theoremCount drift)

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.eval",
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 6,
-    "lineCount": 548,
+    "lineCount": 576,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
@@ -49,7 +49,7 @@
     ],
     "assumptions": "6 axioms: ferrari_factorization_forward, ferrari_factorization_backward, quartic_has_four_roots, biquadratic_forward, biquadratic_backward, ferrari_roots_verify. 3 axioms proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA). S3 (OQ-02.c) discharges `ferrari_biquad_limit` (was the file's only sorry) without introducing new axioms. S5a (OQ-02.a substrate) adds `resolvent_cubic_eval_s_form` (Newton-polygon-cleaned resolvent identity `R\u0303(s) = s\u00b3 + 2p\u00b7s\u00b2 + (p\u00b2 \u2212 4r)\u00b7s \u2212 q\u00b2` via `m \u21a6 (s \u2212 p)/2`; ring-discharged). S5b SCAFFOLD-1 specializes Lemma 1 to the Pan witness `(-1, t\u00b2, 1/4 \u2212 t\u00b2 + t\u2074/4)`: `pan_witness_cleaned_resolvent` proves `R\u0303(s; -1, t\u00b2, ...) = s\u00b3 \u2212 2s\u00b2 + (4t\u00b2 \u2212 t\u2074)s \u2212 t\u2074` (ring-discharged via S5a). At `t=0` this is `s\u00b2(s\u22122)`, exposing the double-root tangency that drives the `\u03b1(t)=\u0398(t)` first-order cancellation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 5
   },
   "overview": {
@@ -192,9 +192,9 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 500,
+    "lineCount": 576,
     "axiomCount": 6,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 5,
     "path": "Proofs/GeneralQuartic.lean",
     "sorries": 0


### PR DESCRIPTION
## Audit Issue

**Proof**: general-quartic
**Detected by**: gallery integrity auditor (sorry-count mismatch)

## Evidence

**meta.json claimed**:
- `meta.sorries: 1`
- `meta.lineCount: 548`
- `meta.theoremCount: 14`
- `leanFile.lineCount: 500`
- `leanFile.theoremCount: 12`

**`proofs/Proofs/GeneralQuartic.lean` (current main d35a6f0f2ac)**:
- sorries: 0 (`grep -c 'sorry' → 0`)
- lines: 576 (`wc -l`)
- theorems/lemmas: 15
- definitions: 5
- axioms: 6 (matches existing `axiomCount`)

The `assumptions` field already noted that "S3 (OQ-02.c) discharges `ferrari_biquad_limit` (was the file's only sorry) without introducing new axioms" — the discharge happened but `meta.sorries` was never synced.

## Fix

Update `meta.json`:
- `meta.sorries: 1 → 0`
- `meta.lineCount: 548 → 576`
- `meta.theoremCount: 14 → 15`
- `leanFile.lineCount: 500 → 576`
- `leanFile.theoremCount: 12 → 15`

No Lean source changes. Doc-only meta sync.

## Status / badge invariants

`status: "axiomatized"` and `badge: "axiom"` remain correct — file still has 6 `axiom` declarations.

---
Discovered during gallery integrity audit. Follows the `audit: sync meta counts for ...` convention (#18374).