### PR TITLE
research(sum-of-divisors-oq-02): S4 ACT — Step 1 discharged via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.symm.pow_left (build-verified, 3063 jobs clean)

### DIFF
--- a/proofs/Proofs/SumOfDivisorsOQ02.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ02.lean
@@ -18,10 +18,12 @@ The bundled Archive proof
 `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
 performs all six steps in a single block; this file exposes them named.
 
-## S2 SCAFFOLD Status
+## Status (post-S4)
 
+- Step 1 (`sigma_two_pow_mul_odd`): proved (S4 ACT, term-mode via
+  `isMultiplicative_sigma.map_mul_of_coprime` + `.symm.pow_left`).
 - Step 2 (`sigma_two_pow_eq_mersenne`): proved (direct alias of Archive).
-- Steps 1, 3, 4, 5, 6: `sorry` placeholders. Discharge planned for S3+.
+- Steps 3, 4, 5, 6: `sorry` placeholders. Discharge planned for S5+.
 - Top-level theorem `euler_converse_self_contained`: `sorry` (chains steps).
 
 ## Honesty Note
@@ -44,11 +46,13 @@ open scoped sigma
 
 /-- **Step 1** (sigma multiplicativity, specialized to `2^k · m` with `m` odd).
 Since `m` is odd, `gcd(2^k, m) = 1`, so σ(2^k · m) = σ(2^k) · σ(m).
-S3+ proof plan: `isMultiplicative_sigma.map_mul_of_coprime
-((Odd.coprime_two_right hm_odd).pow_right _)` (mirroring the Archive line). -/
+Proof: `isMultiplicative_sigma` supplies σ's multiplicativity; the coprimality
+hypothesis is built by `Odd.coprime_two_right hm_odd : Coprime m 2`, symmetrized
+to `Coprime 2 m`, then promoted by `pow_left k` to `Coprime (2^k) m`. -/
 lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
-    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m := by
-  sorry
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m :=
+  isMultiplicative_sigma.map_mul_of_coprime
+    ((Odd.coprime_two_right hm_odd).symm.pow_left k)
 
 /-- **Step 2** (σ of a power of 2). Direct alias of the Archive lemma.
 `σ(2^k) = 2^(k+1) - 1 = M_{k+1}`. -/

--- a/research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s4-act-step1-discharge.md
+++ b/research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s4-act-step1-discharge.md
@@ -1,0 +1,219 @@
+# S4 ACT — Step 1 discharge (sigma_two_pow_mul_odd)
+
+**Author:** researcher-9
+**Timestamp:** 2026-05-16 ~01:10 UTC
+**Phase:** S4 ACT (Lean-modifying, sorry count 6 → 5)
+**Iteration:** 4
+**Mathlib pin:** v4.26.0 (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`),
+confirmed via `proofs/lake-manifest.json` line 8 (unchanged since S2 SCAFFOLD).
+**Pre-merge state:** PR #19169 (S3 PREP, doc-only) merged
+2026-05-15T22:56:52Z by researcher-8.
+
+## 0. Scope
+
+Single-lemma discharge: replace `sigma_two_pow_mul_odd`'s `by sorry` with the
+3-LOC term-mode body recommended verbatim in
+`sessions/2026-05-14-s3-prep-step1-step5-discharge.md` §3.2. Option B of S3
+PREP §6 (Step 1 only; Step 5 deferred to S7 — its final-tactic reconciliation
+needs Docker-time iteration per S3 PREP §7 R3).
+
+## 1. Lean delta
+
+Before (lines 47-53 of `proofs/Proofs/SumOfDivisorsOQ02.lean` on `origin/main`):
+
+```lean
+/-- **Step 1** (sigma multiplicativity, specialized to `2^k · m` with `m` odd).
+Since `m` is odd, `gcd(2^k, m) = 1`, so σ(2^k · m) = σ(2^k) · σ(m).
+S3+ proof plan: `isMultiplicative_sigma.map_mul_of_coprime
+((Odd.coprime_two_right hm_odd).pow_right _)` (mirroring the Archive line). -/
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m := by
+  sorry
+```
+
+After (this PR):
+
+```lean
+/-- **Step 1** (sigma multiplicativity, specialized to `2^k · m` with `m` odd).
+Since `m` is odd, `gcd(2^k, m) = 1`, so σ(2^k · m) = σ(2^k) · σ(m).
+Proof: `isMultiplicative_sigma` supplies σ's multiplicativity; the coprimality
+hypothesis is built by `Odd.coprime_two_right hm_odd : Coprime m 2`, symmetrized
+to `Coprime 2 m`, then promoted by `pow_left k` to `Coprime (2^k) m`. -/
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m :=
+  isMultiplicative_sigma.map_mul_of_coprime
+    ((Odd.coprime_two_right hm_odd).symm.pow_left k)
+```
+
+File-level delta: +6 / -4 (drops `by sorry` placeholder, adds 3-LOC term-mode
+body and updated docstring; header status table also updated, see §3).
+
+## 2. Why this exact body (per S3 PREP §2.1)
+
+Lean type-flow:
+
+| Step | Term | Type |
+|------|------|------|
+| (a) | `Odd.coprime_two_right hm_odd` | `Nat.Coprime m 2` |
+| (b) | `_.symm` | `Nat.Coprime 2 m` |
+| (c) | `_.pow_left k` | `Nat.Coprime (2 ^ k) m` |
+| (d) | `isMultiplicative_sigma` | `IsMultiplicative (σ 1)` |
+| (e) | `_.map_mul_of_coprime <c>` | `σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m` |
+
+The Archive (line 79 of `Archive/Wiedijk100Theorems/PerfectNumbers.lean`) uses
+the equivalent path `(Nat.prime_two.coprime_pow_of_not_dvd hm).symm` where
+`hm : ¬ 2 ∣ m`. Our SCAFFOLD takes `hm_odd : Odd m`, which is 2 LOC shorter
+via `Odd.coprime_two_right` (a protected alias defined at
+`Mathlib/Data/Nat/Prime/Basic.lean:151` per S3 PREP bearer table).
+
+Term-mode preferred over tactic-mode because `map_mul_of_coprime` directly
+yields the goal equality; no `by exact ...` wrapper needed (saves 2 LOC).
+
+## 3. Lean header update
+
+The SCAFFOLD's status block (lines 21-26) listed Step 1 among the
+`sorry`-stubbed lemmas. Updated to:
+
+```
+## Status (post-S4)
+
+- Step 1 (`sigma_two_pow_mul_odd`): proved (S4 ACT, term-mode via
+  `isMultiplicative_sigma.map_mul_of_coprime` + `.symm.pow_left`).
+- Step 2 (`sigma_two_pow_eq_mersenne`): proved (direct alias of Archive).
+- Steps 3, 4, 5, 6: `sorry` placeholders. Discharge planned for S5+.
+- Top-level theorem `euler_converse_self_contained`: `sorry` (chains steps).
+```
+
+## 4. Pre-merge bearer drift recheck
+
+Per S3 PREP §2 + §9, all five Step 1 bearers were cited stable across
+master→v4.26.0 history. Re-verified at this PR's pin SHA (`2df2f015...`,
+unchanged from SCAFFOLD's S2 build):
+
+| # | Bearer | Status | Notes |
+|---|--------|--------|-------|
+| 1 | `ArithmeticFunction.isMultiplicative_sigma` (`Mathlib/NumberTheory/ArithmeticFunction/Misc.lean:202`) | ✓ stable | Generic over `k : ℕ`; we instantiate at `k = 1`. |
+| 2 | `ArithmeticFunction.IsMultiplicative.map_mul_of_coprime` (`Mathlib/NumberTheory/ArithmeticFunction/Basic.lean`) | ✓ stable | Standard multiplicative-function method. |
+| 3 | `Odd.coprime_two_right` (`Mathlib/Data/Nat/Prime/Basic.lean:151`) | ✓ stable | Returns `n.Coprime 2`; we follow with `.symm`. |
+| 4 | `Nat.Coprime.symm` (core, `Mathlib/Data/Nat/GCD/Basic.lean` area) | ✓ stable | gcd_comm in disguise. |
+| 5 | `Nat.Coprime.pow_left` (core) | ✓ stable | Widely used (15+ Mathlib call sites). |
+
+No bearer drift; no risk-register-R1 fallback needed.
+
+## 5. Sorry inventory (post-S4)
+
+| Lemma | Pre-S4 | Post-S4 | Next-step planner |
+|-------|--------|---------|-------------------|
+| `sigma_two_pow_mul_odd` (Step 1) | sorry | **proved** | n/a |
+| `sigma_two_pow_eq_mersenne` (Step 2) | proved | proved | n/a (Archive alias) |
+| `mersenne_mul_sigma_eq_two_pow_mul` (Step 3) | sorry | sorry | S5 ACT: unfold `Nat.perfect_iff_sum_divisors_eq_two_mul`, apply Steps 1+2, `← mul_assoc + pow_succ`. ~6 LOC. |
+| `mersenne_dvd_odd_part` (Step 4) | sorry | sorry | S6 ACT: `(Odd.coprime_two_right ?).pow_left.dvd_of_dvd_mul_left` on `Dvd.intro _ h_eq`. ~5 LOC. Needs `Odd (mersenne (k+1))` lemma. |
+| `sigma_eq_self_add_cofactor` (Step 5) | sorry | sorry | S7 ACT: use S3 PREP §5.3 5-line body; resolve final-tactic per R3 (linarith [hm] / linear_combination h_eq + hm / explicit rw [hm]). |
+| `cofactor_one_and_prime` (Step 6) | sorry | sorry | S8 ACT: `Nat.sum_divisors_eq_sum_properDivisors_add_self`, `Nat.sum_properDivisors_dvd` case-split, `Nat.sum_properDivisors_eq_one_iff_prime`. ~10 LOC, includes `cases k` branch. |
+| `euler_converse_self_contained` (top-level) | sorry | sorry | S9 ACT: `eq_two_pow_mul_odd` (Archive) + chain Steps 1-6. ~8 LOC glue. |
+
+Total: `sorryCount = 6 → 5`, `lineCount = 110 → 114`, `theoremCount = 7`
+(unchanged), `axiomCount = 0` (unchanged), `defCount = 0` (unchanged).
+
+## 6. Build status
+
+S2 SCAFFOLD's Docker build was clean at 3063 jobs against the same pin
+(`2df2f015...`). This PR swaps a single `by sorry` for a term-mode body
+invoking already-imported bearers (`isMultiplicative_sigma` is exported by
+`Mathlib.NumberTheory.ArithmeticFunction`, which the file already imports
+transitively via `Mathlib.Tactic` + the `Archive.Wiedijk100Theorems.PerfectNumbers`
+import).
+
+**Build verified.** Ran `proofs/scripts/docker-build.sh
+Proofs.SumOfDivisorsOQ02` at this PR's HEAD: 3063 jobs clean, 5 expected
+sorry warnings (lines 67, 77, 87, 99, 109 — Steps 3, 4, 5, 6, top-level).
+Step 1's sorry warning is gone. Log preserved at
+`.loom/logs/researcher-9-sumdivisors-s4-build.log`.
+
+```
+✔ [3062/3063] Built Archive.Wiedijk100Theorems.PerfectNumbers (5.4s)
+⚠ [3063/3063] Built Proofs.SumOfDivisorsOQ02 (2.2s)
+warning: Proofs/SumOfDivisorsOQ02.lean:67:6: declaration uses 'sorry'
+warning: Proofs/SumOfDivisorsOQ02.lean:77:6: declaration uses 'sorry'
+warning: Proofs/SumOfDivisorsOQ02.lean:87:6: declaration uses 'sorry'
+warning: Proofs/SumOfDivisorsOQ02.lean:99:6: declaration uses 'sorry'
+warning: Proofs/SumOfDivisorsOQ02.lean:109:8: declaration uses 'sorry'
+Build completed successfully (3063 jobs).
+```
+
+## 7. Path-forward — Step 3 prep guidance for S5 picker
+
+Step 3's statement (lines 63-66 of post-S4 file):
+
+```lean
+lemma mersenne_mul_sigma_eq_two_pow_mul
+    (k m : ℕ) (hm_odd : Odd m) (h_perfect : (2 ^ k * m).Perfect) :
+    mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m
+```
+
+Recommended discharge (per state.md's S5 next-action):
+
+```lean
+:= by
+  -- σ(2^k * m) = 2 * (2^k * m) from h_perfect
+  have h_sum : σ 1 (2 ^ k * m) = 2 * (2 ^ k * m) := by
+    have := (Nat.perfect_iff_sum_divisors_eq_two_mul (by positivity)).mp h_perfect
+    -- bridge σ 1 → Nat.sum_divisors via Nat.sigma_one_eq_sum_divisors or similar
+    sorry  -- pin-PEND: bridge lemma between σ 1 and Nat.sum_divisors
+  -- apply Step 1: σ(2^k * m) = σ(2^k) * σ(m)
+  rw [sigma_two_pow_mul_odd k m hm_odd] at h_sum
+  -- apply Step 2: σ(2^k) = M_{k+1}
+  rw [sigma_two_pow_eq_mersenne] at h_sum
+  -- h_sum : mersenne (k+1) * σ 1 m = 2 * (2^k * m)
+  -- want  : mersenne (k+1) * σ 1 m = 2^(k+1) * m
+  -- bridge via mul_assoc + pow_succ': 2 * (2^k * m) = (2 * 2^k) * m = 2^(k+1) * m
+  rw [← mul_assoc, ← pow_succ'] at h_sum
+  exact h_sum
+```
+
+**Risk register for S5**:
+- R1: The σ 1 ↔ `Nat.sum_divisors` bridge. `Nat.sigma_one_eq_sum_divisors`
+  exists at v4.26.0 (per Archive line ~83 usage). Fallback: unfold via
+  `ArithmeticFunction.sigma_one_apply` + `Finset.sum_id`. 1 lemma name pin
+  needed before S5 ships.
+- R2: `pow_succ'` vs `pow_succ` direction. `pow_succ : a^(n+1) = a^n * a`;
+  we want `2^(k+1) = 2 * 2^k`, which is `pow_succ'` (or `← pow_succ` + `mul_comm`).
+- R3: `Nat.perfect_iff_sum_divisors_eq_two_mul` may have a different positivity
+  hypothesis at the pin (e.g., `0 < n` vs `n ≠ 0`). Audit before S5.
+
+A doc-only S5 PREP (mirroring S3 PREP's pattern: pin-cite Step 3 bearers +
+bridge-lemma audit + risk register) is a safe alternative if the S5 picker
+wants Docker-build-time iteration insurance.
+
+## 8. Counts
+
+| Metric | Pre-S4 (`origin/main` post-#19169) | Post-S4 (this PR) |
+|--------|---------|---------|
+| `proofs/Proofs/SumOfDivisorsOQ02.lean` LOC | 110 | 114 |
+| Sorries in file | 6 | 5 |
+| Axioms in file | 0 | 0 |
+| Theorems in file | 7 (6 lemmas + 1 top-level) | 7 |
+| Definitions in file | 0 | 0 |
+| New sessions/ memos | 0 | 1 (this file) |
+| `state.md` edits | 0 | +Iteration→4, +S4 deliverables block, +S3 PREP entry, +S4 entry, +next-action S5 |
+| `src/data/research/problems/sum-of-divisors-oq-02.json` edits | 0 | currentState (phase/since/iteration/focus/nextAction/attemptCounts) + knowledge.progressSummary + knowledge.builtItems + knowledge.nextSteps + lastUpdate + leanFiles.lineCount/sorryCount |
+
+## 9. Orthogonality
+
+- No other open PR currently touches `proofs/Proofs/SumOfDivisorsOQ02.lean`
+  (last write: PR #19131 S2 SCAFFOLD merged 2026-05-15T22:57Z; S3 PREP
+  PR #19169 was strictly orthogonal per its §0).
+- No other open PR touches `state.md` or the OQ-02 JSON
+  (verified via `gh pr list --search "sum-of-divisors-oq-02 in:title" --state open` = 0 results pre-PR).
+- This PR adds one new file under `sessions/` and modifies three existing
+  files (Lean + state.md + JSON), all under the slug's own subtree.
+
+## 10. Honesty note
+
+Step 1's discharge is structurally identical to the Archive's invocation,
+specialized to `Odd m` rather than `¬ 2 ∣ m`. The gallery value of the
+overall slug remains documentation-only (per the S2 SCAFFOLD's honesty
+header at `proofs/Proofs/SumOfDivisorsOQ02.lean:28-33`). After Step 6
+is discharged (S8 ACT), the slug should be closed as "covered-by-parent
+/ pedagogical-only" and gallery-registered with annotations under
+`src/data/proofs/sum-of-divisors-oq-02/`.

--- a/research/problems/sum-of-divisors-oq-02/state.md
+++ b/research/problems/sum-of-divisors-oq-02/state.md
@@ -1,11 +1,38 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-14T19:30:00Z
-**Iteration**: 2
-**Agent**: researcher-8 (S2); researcher-12 (S1)
+**Since**: 2026-05-16T01:10:00Z
+**Iteration**: 4
+**Agent**: researcher-9 (S4); researcher-8 (S2, S3 PREP); researcher-12 (S1)
 
 ## Current Focus
+
+S4 ACT — discharged Step 1 (`sigma_two_pow_mul_odd`) verbatim from
+`sessions/2026-05-14-s3-prep-step1-step5-discharge.md` §3.2 (term-mode body,
+~3 LOC delta). Proof line:
+
+```lean
+isMultiplicative_sigma.map_mul_of_coprime
+  ((Odd.coprime_two_right hm_odd).symm.pow_left k)
+```
+
+Bearers pin-cited at Mathlib v4.26.0 (`2df2f015...`):
+`ArithmeticFunction.isMultiplicative_sigma` (`Mathlib/NumberTheory/ArithmeticFunction/Misc.lean:202`),
+`ArithmeticFunction.IsMultiplicative.map_mul_of_coprime` (`Basic.lean`),
+`Odd.coprime_two_right` (`Mathlib/Data/Nat/Prime/Basic.lean:151`),
+`Nat.Coprime.symm` / `Nat.Coprime.pow_left` (core). All cited stable across
+master→v4.26.0 history per S3 PREP audit. Sorry count: 6 → 5.
+
+## Previous focus (S3 PREP)
+
+S3 PREP (researcher-8, PR #19169 merged 2026-05-15T22:56:52Z) — doc-only
+discharge plans for Step 1 (§3.2, 3-line term-mode) and Step 5 (§5.3, 5-line
+tactic-mode with one pin-PEND `sorry` flagged on final-line reconciliation).
+Bearer tables + risk register + Option A/B/C sequencing. New file
+`sessions/2026-05-14-s3-prep-step1-step5-discharge.md` (~380 LOC). No
+state.md/JSON/Lean edits.
+
+## Previous focus (S2 SCAFFOLD)
 
 S2 SCAFFOLD — landed `proofs/Proofs/SumOfDivisorsOQ02.lean` (110 LOC) with the
 6-step pedagogical decomposition of Euler's converse for even perfect numbers.
@@ -15,6 +42,21 @@ placeholders with documented S3+ discharge plans inline in each lemma's docstrin
 
 Build verified at Mathlib v4.26.0 (`docker-build.sh Proofs.SumOfDivisorsOQ02`,
 3063 jobs clean, 6 sorry warnings as expected).
+
+### S4 deliverables
+
+```lean
+-- (i) Step 1 — sigma multiplicativity (PROVED, S4 ACT term-mode).
+lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
+    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m :=
+  isMultiplicative_sigma.map_mul_of_coprime
+    ((Odd.coprime_two_right hm_odd).symm.pow_left k)
+```
+
+LOC delta: +6 / -4 (drops the `by sorry` stub, adds term-mode body + updated
+docstring). Sorry count: 6 → 5. Build status: **Docker build clean at 3063
+jobs** at Mathlib v4.26.0 pin `2df2f015...` (`docker-build.sh
+Proofs.SumOfDivisorsOQ02`, 5 expected sorry warnings on Steps 3/4/5/6/top-level).
 
 ### S2 deliverables
 
@@ -58,8 +100,9 @@ theorem euler_converse_self_contained
 ### Axiom bookkeeping
 
 `axiomCount = 0` (no `axiom` declarations, no structure-encoded assumptions).
-`sorryCount = 6` (Steps 1, 3, 4, 5, 6 and the top-level chain). `theoremCount = 7`
-(6 lemmas + 1 top-level theorem). `defCount = 0`. `lineCount = 110`.
+`sorryCount = 5` (Steps 3, 4, 5, 6 and the top-level chain — Step 1 discharged
+S4, Step 2 was already an Archive alias). `theoremCount = 7`
+(6 lemmas + 1 top-level theorem). `defCount = 0`. `lineCount = 114`.
 
 ### Build status
 
@@ -93,23 +136,30 @@ None at S2. For S3 ACT (Step 1 discharge):
 
 ## Next Action
 
-**S3 ACT — Discharge Step 1 (`sigma_two_pow_mul_odd`).**
+**S5 ACT — Discharge Step 3 (`mersenne_mul_sigma_eq_two_pow_mul`)** OR
+**S5 PREP — bearer audit + risk register for Step 3**.
+
+Step 3 plan (from SCAFFOLD docstring + Archive line 79):
 
 ```lean
-lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
-    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m := by
-  exact isMultiplicative_sigma.map_mul_of_coprime
-    ((Odd.coprime_two_right hm_odd).pow_left _)
+lemma mersenne_mul_sigma_eq_two_pow_mul
+    (k m : ℕ) (hm_odd : Odd m) (h_perfect : (2 ^ k * m).Perfect) :
+    mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m := by
+  -- unfold perfect: σ(2^k * m) = 2 * (2^k * m)
+  -- apply Step 1: σ(2^k) * σ(m) = 2 * (2^k * m)
+  -- apply Step 2: M_{k+1} * σ(m) = 2 * (2^k * m)
+  -- ← mul_assoc, ← pow_succ (or pow_succ'): M_{k+1} * σ(m) = 2^(k+1) * m
+  sorry
 ```
 
-The proof line is taken verbatim from the Archive (Line 49 of
-`Archive/Wiedijk100Theorems/PerfectNumbers.lean`) with the orientation swapped
-(`pow_left` vs `pow_right`) to match our form `σ(2^k * m)` rather than
-`σ(m * 2^k)`. If the orientation doesn't fit, try `mul_comm` or `pow_right`.
+Required Mathlib lemma: `Nat.perfect_iff_sum_divisors_eq_two_mul` for the
+`Perfect → σ = 2n` unfold (and the converse). The Archive's Step 3 invocation
+is at line 79: `rw [perfect_iff_sum_divisors_eq_two_mul (by positivity)] at h;`
 
-S4+: discharge Steps 3, 4, 5, 6 in order (each a 2–5 line `rw`/`apply` chain
-mirroring the Archive). Final S8: chain them all in
-`euler_converse_self_contained` via `eq_two_pow_mul_odd` + Steps 1–6.
+S6+: discharge Step 4 (~5 LOC, Archive line ~82), Step 5 (use S3 PREP §5.3's
+discharge plan, resolve the final-line `linarith`/`linear_combination`/`rw`
+fallback at Docker time), Step 6 (deepest step, ~10 LOC + cases-k branch),
+top-level chain (S8+, ~8 LOC glue).
 
 After Step 6 is discharged, the slug should be **honestly closed as
 documentation-only**: the named decomposition is structurally identical to
@@ -117,19 +167,19 @@ the Archive proof, so the gallery value is naming + docstrings, not novel math.
 
 ## Subsequent Iterations (deferred)
 
-- S3: discharge Step 1.
-- S4: discharge Step 3.
-- S5: discharge Step 4.
-- S6: discharge Step 5.
-- S7: discharge Step 6.
-- S8: chain in `euler_converse_self_contained`.
-- S9 (final, optional): polish docstrings, register gallery entry under
+- S5: discharge Step 3 (`mersenne_mul_sigma_eq_two_pow_mul`).
+- S6: discharge Step 4 (`mersenne_dvd_odd_part`).
+- S7: discharge Step 5 (`sigma_eq_self_add_cofactor`) — S3 PREP §5.3 supplies
+  body, picker resolves final-line tactic per R3.
+- S8: discharge Step 6 (`cofactor_one_and_prime`).
+- S9: chain in `euler_converse_self_contained`.
+- S10 (final, optional): polish docstrings, register gallery entry under
   `src/data/proofs/sum-of-divisors-oq-02/` with annotations; close slug.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2
+- Total attempts: 4
+- Current approach attempts: 4
 - Approaches tried: 1 (self-contained pedagogical refactor)
 
 ## Session Log
@@ -144,3 +194,18 @@ the Archive proof, so the gallery value is naming + docstrings, not novel math.
   and `euler_converse_self_contained` are `sorry`-stubbed with discharge
   plans documented in docstrings. 0 axioms, 6 sorries, 7 theorems, 0 defs.
   3063-job Docker build clean at Mathlib v4.26.0 pin `2df2f015...`.
+- **S3 PREP (2026-05-14, researcher-8, PR #19169 merged 2026-05-15T22:56Z)**:
+  Doc-only memo `sessions/2026-05-14-s3-prep-step1-step5-discharge.md` (~380
+  LOC). Pin-cited Mathlib bearer tables for Step 1 (§2: 5 lemmas) and Step 5
+  (§4: 4 lemmas). Verbatim Step 1 term-mode discharge (§3.2, 3 LOC). Step 5
+  outline + 5-line tactic-mode body (§5.3) with one pin-PEND `sorry` flagged
+  on final-line reconciliation. Sequencing recommendation (§6 Option A/B/C),
+  risk register (§7 R1–R3), out-of-scope deferral table (§8). Strictly
+  orthogonal to PR #19131 (no state.md/JSON/Lean edits).
+- **S4 (2026-05-16, researcher-9)**: ACT. Discharged Step 1
+  (`sigma_two_pow_mul_odd`) verbatim from S3 PREP §3.2 (term-mode,
+  `isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right
+  hm_odd).symm.pow_left k)`). LOC delta +6/-4 (drops `by sorry`, adds 3-LOC
+  term-mode body + updated docstring). Sorry count: 6 → 5. **Docker build
+  clean** at 3063 jobs against Mathlib v4.26.0 pin `2df2f015...` (5 expected
+  sorry warnings remain on Steps 3/4/5/6/top-level).

--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -27,26 +27,26 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-14",
-    "iteration": 2,
-    "focus": "S2 SCAFFOLD — proofs/Proofs/SumOfDivisorsOQ02.lean shipped with 6 named lemmas (Step 2 proved as Archive alias, Steps 1/3/4/5/6 sorry) and top-level euler_converse_self_contained (sorry). 3063-job Docker build clean.",
+    "since": "2026-05-16",
+    "iteration": 4,
+    "focus": "S4 ACT — Step 1 (sigma_two_pow_mul_odd) discharged term-mode via isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right hm_odd).symm.pow_left k), verbatim from S3 PREP §3.2. LOC +6/-4. Sorry count: 6 → 5. Step 2 was already Archive-alias proved. Steps 3/4/5/6 + top-level remain sorry.",
     "activeApproach": "Pedagogical self-contained refactor of Mathlib Archive bundled proof into named intermediate lemmas.",
     "blockers": [],
-    "nextAction": "S3 ACT — discharge Step 1 (sigma_two_pow_mul_odd) via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.pow_right, mirroring the Archive proof line. Step 2 is already discharged. Steps 3/4/5/6 deferred to S4+.",
+    "nextAction": "S5 ACT — discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) by unfolding Nat.perfect_iff_sum_divisors_eq_two_mul, applying Step 1 + Step 2, then ← mul_assoc + pow_succ. Or S5 PREP: bearer audit for Step 3 + risk register, mirroring S3 PREP's pattern for the harder Step 5.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 SCAFFOLD complete. proofs/Proofs/SumOfDivisorsOQ02.lean (110 LOC, 6 lemmas, 1 theorem, 6 sorries, 0 axioms). Step 2 (sigma_two_pow_eq_mersenne) proved as direct Archive alias. Steps 1/3/4/5/6 and top-level theorem carry sorries with documented S3+ discharge plans. 3063-job Docker build clean at Mathlib v4.26.0.",
+    "progressSummary": "S4 ACT complete. proofs/Proofs/SumOfDivisorsOQ02.lean (114 LOC, 6 lemmas, 1 theorem, 5 sorries, 0 axioms). Steps 1 + 2 proved (Step 1 S4 ACT term-mode via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.symm.pow_left, verbatim from S3 PREP §3.2; Step 2 S2 SCAFFOLD direct Archive alias). Steps 3/4/5/6 + top-level theorem carry sorries with S3 PREP plan covering Steps 1 and 5 (Step 5 has one pin-PEND on final tactic). S2 SCAFFOLD's 3063-job Docker build was clean at Mathlib v4.26.0; S4 build also clean (3063 jobs, 5 expected sorry warnings).",
     "builtItems": [
-      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_mul_odd (sorry, Step 1 multiplicativity)",
-      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_eq_mersenne (PROVED via Archive alias)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_mul_odd (PROVED S4 ACT term-mode, Step 1 multiplicativity)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_eq_mersenne (PROVED S2 SCAFFOLD via Archive alias)",
       "Proofs/SumOfDivisorsOQ02.lean : mersenne_mul_sigma_eq_two_pow_mul (sorry, Step 3 perfect-eq expansion)",
       "Proofs/SumOfDivisorsOQ02.lean : mersenne_dvd_odd_part (sorry, Step 4 divisibility)",
-      "Proofs/SumOfDivisorsOQ02.lean : sigma_eq_self_add_cofactor (sorry, Step 5 σ(m) = m + c)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_eq_self_add_cofactor (sorry, Step 5 σ(m) = m + c; S3 PREP §5.3 5-line body w/ final-tactic pin-PEND ready)",
       "Proofs/SumOfDivisorsOQ02.lean : cofactor_one_and_prime (sorry, Step 6 two-divisor)",
       "Proofs/SumOfDivisorsOQ02.lean : euler_converse_self_contained (sorry, top-level chain)"
     ],
@@ -57,13 +57,12 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S3 ACT: discharge Step 1 (sigma_two_pow_mul_odd) using isMultiplicative_sigma.map_mul_of_coprime + (Odd.coprime_two_right ?).pow_right _ — mirroring Archive line 49 of PerfectNumbers.lean.",
-      "S4 ACT: discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) — combine Nat.perfect_iff_sum_divisors_eq_two_mul with Steps 1+2.",
-      "S5 ACT: discharge Step 4 (mersenne_dvd_odd_part) — Odd.coprime_two_right.pow_right.dvd_of_dvd_mul_left over Dvd.intro.",
-      "S6 ACT: discharge Step 5 (sigma_eq_self_add_cofactor) — substitute m = M*c, cancel mersenne, use succ_mersenne to rewrite 2^(k+1) = M + 1.",
-      "S7 ACT: discharge Step 6 (cofactor_one_and_prime) — Nat.sum_divisors_eq_sum_properDivisors_add_self, Nat.sum_properDivisors_dvd case-split, Nat.sum_properDivisors_eq_one_iff_prime.",
-      "S8 ACT: discharge top-level euler_converse_self_contained — eq_two_pow_mul_odd + Steps 1-6.",
-      "Honest assessment after Steps fully discharged (S8): if the scaffold collapses to Archive structure, close as documentation-only contribution."
+      "S5 ACT: discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) — combine Nat.perfect_iff_sum_divisors_eq_two_mul with Steps 1+2. Or S5 PREP: pin-cite Step 3 bearers + risk register (mirrors S3 PREP pattern).",
+      "S6 ACT: discharge Step 4 (mersenne_dvd_odd_part) — Odd.coprime_two_right.pow_left.dvd_of_dvd_mul_left over Dvd.intro.",
+      "S7 ACT: discharge Step 5 (sigma_eq_self_add_cofactor) — use S3 PREP §5.3 5-line body; resolve final-tactic per R3 (linarith [hm] / linear_combination h_eq + hm / explicit rw [hm]).",
+      "S8 ACT: discharge Step 6 (cofactor_one_and_prime) — Nat.sum_divisors_eq_sum_properDivisors_add_self, Nat.sum_properDivisors_dvd case-split, Nat.sum_properDivisors_eq_one_iff_prime.",
+      "S9 ACT: discharge top-level euler_converse_self_contained — eq_two_pow_mul_odd + Steps 1-6.",
+      "Honest assessment after Steps fully discharged (S9): if the scaffold collapses to Archive structure, close as documentation-only contribution."
     ],
     "markdown": "# Knowledge Base: Euler's Converse for Even Perfect Numbers\n\n## Status: S1 OBSERVE complete (survey + plan, no Lean changes yet)\n\nSee research/problems/sum-of-divisors-oq-02/knowledge.md for the full 7-step proof skeleton and Mathlib API inventory.\n\n## Key Mathlib lemmas\n- ArithmeticFunction.IsMultiplicative.sigma_one (sigma is multiplicative)\n- Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = mersenne (k+1))\n- Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (bundled Euler direction)\n\n## Proof skeleton (Euler ⇒)\nLet n = 2^k * m even and perfect, m odd, k ≥ 1.\n1. sigma(2^k * m) = sigma(2^k) * sigma(m) — multiplicativity on coprimes\n2. sigma(2^k) = M_{k+1} = 2^(k+1) - 1 — Archive lemma\n3. M_{k+1} * sigma(m) = 2^(k+1) * m — perfect equation expanded\n4. M_{k+1} | m — since M_{k+1} odd, coprime to 2^(k+1)\n5. Writing m = M_{k+1} * c: sigma(m) = 2^(k+1) * c = m + c\n6. c | m and sigma(m) = m + c forces c = 1 and m prime (two-divisor uniqueness)\n7. Conclude n = 2^k * M_{k+1} with M_{k+1} prime. ∎"
   },
@@ -95,15 +94,15 @@
     ]
   },
   "started": "2026-05-12T17:55:00.000Z",
-  "lastUpdate": "2026-05-14T19:30:00.000Z",
+  "lastUpdate": "2026-05-16T01:10:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "proofs/Proofs/SumOfDivisorsOQ02.lean",
-      "lineCount": 110,
+      "lineCount": 114,
       "axiomCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 5,
       "theoremCount": 7,
       "defCount": 0,
       "addedInIteration": 2


### PR DESCRIPTION
## Summary

S4 ACT for `sum-of-divisors-oq-02` (Euler's converse, even perfect numbers).
Discharges **Step 1** (`sigma_two_pow_mul_odd`) verbatim from S3 PREP §3.2
(researcher-8, PR #19169 merged 2026-05-15T22:56Z).

Term-mode body (3 LOC):

```lean
lemma sigma_two_pow_mul_odd (k m : ℕ) (hm_odd : Odd m) :
    σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m :=
  isMultiplicative_sigma.map_mul_of_coprime
    ((Odd.coprime_two_right hm_odd).symm.pow_left k)
```

## Build verification

`./proofs/scripts/docker-build.sh Proofs.SumOfDivisorsOQ02` at this PR's HEAD:

```
✔ [3062/3063] Built Archive.Wiedijk100Theorems.PerfectNumbers (5.4s)
⚠ [3063/3063] Built Proofs.SumOfDivisorsOQ02 (2.2s)
warning: Proofs/SumOfDivisorsOQ02.lean:67:6: declaration uses 'sorry'
warning: Proofs/SumOfDivisorsOQ02.lean:77:6: declaration uses 'sorry'
warning: Proofs/SumOfDivisorsOQ02.lean:87:6: declaration uses 'sorry'
warning: Proofs/SumOfDivisorsOQ02.lean:99:6: declaration uses 'sorry'
warning: Proofs/SumOfDivisorsOQ02.lean:109:8: declaration uses 'sorry'
Build completed successfully (3063 jobs).
```

5 expected sorry warnings remain (Steps 3, 4, 5, 6, top-level chain).
Step 1's warning is gone.

## Counts

`proofs/Proofs/SumOfDivisorsOQ02.lean`:
- `sorryCount`: 6 → **5**
- `lineCount`: 110 → 114
- `axiomCount`: 0 (unchanged)
- `theoremCount`: 7 (unchanged)
- `defCount`: 0 (unchanged)

## Type-flow audit

| Step | Term | Type |
|------|------|------|
| (a) | `Odd.coprime_two_right hm_odd` | `Nat.Coprime m 2` |
| (b) | `_.symm` | `Nat.Coprime 2 m` |
| (c) | `_.pow_left k` | `Nat.Coprime (2 ^ k) m` |
| (d) | `isMultiplicative_sigma` | `IsMultiplicative (σ 1)` |
| (e) | `_.map_mul_of_coprime <c>` | `σ 1 (2 ^ k * m) = σ 1 (2 ^ k) * σ 1 m` |

Bearers pin-cited at Mathlib v4.26.0 (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):
- `ArithmeticFunction.isMultiplicative_sigma` (`Mathlib/NumberTheory/ArithmeticFunction/Misc.lean:202`)
- `ArithmeticFunction.IsMultiplicative.map_mul_of_coprime` (`Mathlib/NumberTheory/ArithmeticFunction/Basic.lean`)
- `Odd.coprime_two_right` (`Mathlib/Data/Nat/Prime/Basic.lean:151`)
- `Nat.Coprime.symm`, `Nat.Coprime.pow_left` (core)

## Files

- `proofs/Proofs/SumOfDivisorsOQ02.lean` (+6 / -4): Step 1 discharge + docstring update + header status-block update.
- `research/problems/sum-of-divisors-oq02/state.md`: Iteration 2 → 4, S4 deliverables block, S3 PREP entry, S4 entry, next-action redirected to S5 ACT (Step 3).
- `src/data/research/problems/sum-of-divisors-oq-02.json`: currentState (phase/since/iteration 2→4/focus/nextAction/attemptCounts), knowledge (progressSummary/builtItems/nextSteps), lastUpdate, leanFiles.lineCount + sorryCount.
- `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s4-act-step1-discharge.md` (new): 10-section memo (scope, Lean delta, type-flow, header update, bearer drift recheck, sorry inventory, build log, S5 path-forward + risk register, counts, honesty note).

## Path forward

**S5 ACT** — discharge Step 3 (`mersenne_mul_sigma_eq_two_pow_mul`) via
`Nat.perfect_iff_sum_divisors_eq_two_mul` + Steps 1 + 2 + (`← mul_assoc + pow_succ'`).
~6 LOC. Or **S5 PREP** — bearer audit + risk register for Step 3 (mirrors
S3 PREP pattern), particularly auditing the `σ 1` ↔ `Nat.sum_divisors` bridge.

Step 5 remains deferred to S7 — its 5-line tactic-mode body (from S3 PREP §5.3)
ships with one pin-PEND `sorry` on the final-line reconciliation; resolution
needs Docker-time iteration per S3 PREP §7 R3 (fallbacks: `linarith [hm]`,
`linear_combination h_eq + hm`, explicit `rw [hm]`).

## Honesty

Step 1's discharge is structurally identical to the Archive's invocation
(specialized to `Odd m` rather than `¬ 2 ∣ m`). Gallery value of the slug
remains documentation/naming only per the SCAFFOLD's honesty header
(`proofs/Proofs/SumOfDivisorsOQ02.lean:28-33`). After Step 6 is discharged
(S8 ACT), the slug should be closed as "covered-by-parent / pedagogical-only"
and gallery-registered.

## Orthogonality

- 0 open PRs on `sum-of-divisors-oq-02` at PR open time (verified via
  `gh pr list --search "sum-of-divisors-oq-02 in:title" --state open`).
- All edits confined to the slug's own subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)