### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01): S2 ACT — backward direction over CommRing (build verified, 7743 jobs, 0 sorries)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean
@@ -1,0 +1,96 @@
+/-
+Backward direction of the Cayley-Hamilton cyclic-vector ↔ nonderogatory
+biconditional, **extended from `[Field K]` to `[CommRing R] [Nontrivial R]`**.
+
+This file does NOT modify the parent
+`proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` or its sibling
+`GeneralCyclicVector` namespace (which is `Field`-locked at
+`CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean:54`). Instead, it introduces
+a new sibling namespace `GeneralCyclicVectorRing` over a nontrivial
+commutative ring, with predicate definitions that mirror the field
+versions modulo the typeclass.
+
+The forward direction (`IsNonderogatory M → ∃ v, IsCyclicVector M v`)
+**fails** over `ZMod 4` (concrete counterexample
+`M = !![0, 2; 0, 0]` worked out in this slug's `knowledge.md`); the
+counterexample formalisation lives in a separate companion file owned by
+the S3 ACT picker.
+
+Bearer pins (Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):
+- `Polynomial.minpoly.unique'`
+  (`FieldTheory/Minpoly/Basic.lean:139`, in `section Ring` with `[CommRing A]`)
+- `Polynomial.minpoly.monic`
+  (`FieldTheory/Minpoly/Basic.lean:54`, `[CommRing A]`)
+- `Polynomial.natDegree_lt_natDegree`
+  (`Algebra/Polynomial/Degree/Operations.lean:73`, `[Semiring]`)
+- `Matrix.charpoly_monic`
+  (`LinearAlgebra/Matrix/Charpoly/Coeff.lean:117`, `[CommRing R]`)
+- `Matrix.charpoly_natDegree_eq_dim`
+  (`LinearAlgebra/Matrix/Charpoly/Coeff.lean:113`, `[CommRing R] [Nontrivial R]`)
+- `Matrix.aeval_self_charpoly`
+  (`LinearAlgebra/Matrix/Charpoly/Basic.lean`, `[CommRing R]`)
+- `Matrix.zero_mulVec`
+  (`Data/Matrix/Mul.lean:729`, `@[simp]`)
+
+Note: the standard `minpoly.dvd` lemma is `Field`-only at this pin
+(`FieldTheory/Minpoly/Field.lean:31` declares `variable (A) [Field A]`),
+and `Polynomial.natDegree_le_of_dvd` requires `[NoZeroDivisors R]`
+(`Algebra/Polynomial/Degree/Domain.lean:33`). This file therefore avoids
+both and proves the backward direction directly via `minpoly.unique'`,
+which holds over any `[CommRing A]`.
+-/
+
+import Mathlib
+
+noncomputable section
+
+open Matrix Polynomial
+
+namespace GeneralCyclicVectorRing
+
+variable {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+
+/-- A vector `v : Fin n → R` is cyclic for `M : Matrix (Fin n) (Fin n) R`
+if every `R`-polynomial `p` of `natDegree < n` whose evaluation at `M`
+sends `v` to zero must itself be the zero polynomial. -/
+def IsCyclicVector (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R) : Prop :=
+  ∀ p : R[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0
+
+/-- A matrix is nonderogatory if its minimal polynomial equals its
+characteristic polynomial. -/
+def IsNonderogatory (M : Matrix (Fin n) (Fin n) R) : Prop :=
+  minpoly R M = M.charpoly
+
+end GeneralCyclicVectorRing
+
+namespace CayleyHamiltonCyclicVectorCommRingOQ01
+
+open GeneralCyclicVectorRing
+
+variable {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+
+/-- Backward direction over a nontrivial commutative ring: the existence
+of a cyclic vector for `M` forces the minimal polynomial of `M` to equal
+its characteristic polynomial. -/
+theorem cyclic_implies_nonderogatory_commring
+    (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R)
+    (hcyc : IsCyclicVector M v) :
+    IsNonderogatory M := by
+  unfold IsNonderogatory
+  have hchar_monic : M.charpoly.Monic := M.charpoly_monic
+  have hchar_aeval : aeval M M.charpoly = 0 := M.aeval_self_charpoly
+  have hchar_deg : M.charpoly.natDegree = n := by
+    rw [M.charpoly_natDegree_eq_dim, Fintype.card_fin]
+  refine (minpoly.unique' R M hchar_monic hchar_aeval ?_).symm
+  intro q hqdeg
+  by_cases hq : q = 0
+  · exact Or.inl hq
+  · refine Or.inr (fun hae => hq ?_)
+    have hndlt : q.natDegree < n := by
+      have := Polynomial.natDegree_lt_natDegree hq hqdeg
+      simpa [hchar_deg] using this
+    apply hcyc q hndlt
+    rw [hae]
+    exact Matrix.zero_mulVec v
+
+end CayleyHamiltonCyclicVectorCommRingOQ01

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md
@@ -1,0 +1,266 @@
+# S2 ACT — backward extension `(∃ v, IsCyclicVector M v) → IsNonderogatory M` over `[CommRing R] [Nontrivial R]`
+
+**Author:** researcher-3
+**Timestamp:** 2026-05-16 ~01:15 UTC
+**Phase:** S2 ACT (substantive Lean PR — first Lean delta on slug)
+**Iteration:** 3
+**Mathlib pin:** `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (unchanged since S1 OBSERVE; re-verified in §3 below)
+**origin/main HEAD at branch creation:** `8a3cda556b6` (audit kepler-conjecture-oq-04 #19328)
+**Scope:** One **new** Lean file (`proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean`, ~95 LOC including module docstring), one new sessions/ note, state.md + JSON refresh. **No edits to any existing Lean file.**
+
+## 0. Trigger — discharging S2 PREP's plan, with two bearer-audit corrections
+
+S2 PREP (PR #19333, researcher-1, **MERGED 2026-05-16T01:09:19Z**, ~6 min before this ACT) shipped a refined ~46-LOC skeleton plus 5 fallback recipes targeting the backward direction over `[CommRing R] [Nontrivial R]`. The S2 PREP test-plan trailing checkbox said:
+
+> (Post-merge) S2 ACT picker `#check`s `Polynomial.Monic.natDegree_eq_zero`; if unavailable, uses §2.5 fallback chain.
+
+This S2 ACT is that picker. While preparing the build, the S2 ACT picker discovered **two upstream-typeclass mismatches in S2 PREP's bearer audit**, both of which would have caused the S2 PREP skeleton to fail to compile. Both are corrected below; the resulting proof uses a different lemma topology that **avoids both broken bearers** and still delivers the full backward direction over `[CommRing R] [Nontrivial R]`.
+
+## 1. Bearer-audit corrections vs S2 PREP
+
+### 1.1 `Polynomial.minpoly.dvd` is **`Field`-locked**, not `[CommRing A]`
+
+S2 PREP §3 row 4 stated:
+
+| `minpoly.dvd` | `FieldTheory/Minpoly/Basic.lean` (Ring section, line not pinned here) | ✓ `CommRing A` |
+
+Authenticated re-read at pin (`Mathlib/FieldTheory/Minpoly/Field.lean`):
+
+```
+31:variable (A) [Field A]
+33:section Ring
+72:theorem dvd {p : A[X]} (hp : Polynomial.aeval x p = 0) : minpoly A x ∣ p := by
+```
+
+The `dvd` lemma is in **`FieldTheory/Minpoly/Field.lean`** (not `Basic.lean`), and the file's top-level `variable` declares `[Field A]`. The proof uses the Euclidean-division-with-degree-strictly-decreasing argument that genuinely requires field hypotheses (the leading coefficient inverse step).
+
+**S2 PREP §3 incorrectly placed this lemma in Basic.lean's `[CommRing A]` section.** The S2 PREP skeleton's line 133 (`have hdvd : minpoly R M ∣ M.charpoly := minpoly.dvd R M (Matrix.aeval_self_charpoly M)`) would fail to elaborate over `[CommRing R] [Nontrivial R]`.
+
+The alternative `minpoly.isIntegrallyClosed_dvd` (in `Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean`) requires `[CommRing R] [CommRing S] [IsDomain R] [Algebra R S] [IsDomain S] [NoZeroSMulDivisors R S] [IsIntegrallyClosed R]` — strictly more restrictive than just `[CommRing R] [Nontrivial R]`.
+
+### 1.2 `Polynomial.natDegree_le_of_dvd` requires **`[NoZeroDivisors R]`**
+
+S2 PREP §3 row "natDegree_le_of_dvd (NEW)" stated:
+
+| `Polynomial.natDegree_le_of_dvd` (NEW) | `Algebra/Polynomial/Div.lean:~809` (existence verified via usage) | yes — degree bound |
+
+Authenticated lookup at pin (`Mathlib/Algebra/Polynomial/Degree/Domain.lean`):
+
+```
+33:variable [Semiring R] [NoZeroDivisors R] {p q : R[X]}
+…
+61:lemma natDegree_le_of_dvd (h1 : p ∣ q) (h2 : q ≠ 0) : p.natDegree ≤ q.natDegree := by
+```
+
+The lemma sits inside `section Semiring` with `variable [Semiring R] [NoZeroDivisors R]`. Over `[CommRing R] [Nontrivial R]` (without `NoZeroDivisors`), the lemma is **not available**.
+
+The S2 PREP skeleton's `hle` step (line 138):
+```
+have hle : (minpoly R M).natDegree ≤ n :=
+  Polynomial.natDegree_le_of_dvd hdvd hchar_monic.ne_zero |>.trans_eq hchar_deg
+```
+would also fail to elaborate.
+
+### 1.3 The fix — use `minpoly.unique'` and bypass divisibility entirely
+
+`Polynomial.minpoly.unique'` (`FieldTheory/Minpoly/Basic.lean:139`, in `section Ring` with `[CommRing A]`):
+
+```
+theorem unique' {p : A[X]} (hm : p.Monic) (hp : Polynomial.aeval x p = 0)
+    (hl : ∀ q : A[X], degree q < degree p → q = 0 ∨ Polynomial.aeval x q ≠ 0) :
+    p = minpoly A x
+```
+
+This says: a monic polynomial `p` annihilating `x` equals `minpoly A x` iff every polynomial of strictly smaller degree is zero or fails to annihilate. The proof in Mathlib uses `modByMonic` and `Monic.natDegree_mul'` — both work over `[CommRing A]`.
+
+**This lemma is the cleanest CommRing-friendly tool for the backward direction.** Apply it to `p := M.charpoly`:
+- `M.charpoly.Monic`: ✓ `Matrix.charpoly_monic` at `[CommRing R]` (no extra typeclass).
+- `aeval M M.charpoly = 0`: ✓ `Matrix.aeval_self_charpoly` (Cayley-Hamilton at `[CommRing R]`).
+- For every `q` with `q.degree < M.charpoly.degree`: by `Polynomial.natDegree_lt_natDegree` (at `[Semiring]`), `q ≠ 0` implies `q.natDegree < M.charpoly.natDegree = n`. Then by the cyclic-vector hypothesis applied to `q`, `aeval M q = 0` would force `q = 0`, a contradiction. So either `q = 0` or `aeval M q ≠ 0`.
+
+The conclusion `M.charpoly = minpoly R M` is the symmetric statement of `IsNonderogatory M`. Done.
+
+## 2. Final proof skeleton (as committed; v2)
+
+```lean
+import Mathlib
+
+noncomputable section
+
+open Matrix Polynomial
+
+namespace GeneralCyclicVectorRing
+
+variable {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+
+def IsCyclicVector (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R) : Prop :=
+  ∀ p : R[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0
+
+def IsNonderogatory (M : Matrix (Fin n) (Fin n) R) : Prop :=
+  minpoly R M = M.charpoly
+
+end GeneralCyclicVectorRing
+
+namespace CayleyHamiltonCyclicVectorCommRingOQ01
+
+open GeneralCyclicVectorRing
+
+variable {R : Type*} [CommRing R] [Nontrivial R] {n : ℕ}
+
+theorem cyclic_implies_nonderogatory_commring
+    (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R)
+    (hcyc : IsCyclicVector M v) :
+    IsNonderogatory M := by
+  unfold IsNonderogatory
+  have hchar_monic : M.charpoly.Monic := M.charpoly_monic
+  have hchar_aeval : aeval M M.charpoly = 0 := M.aeval_self_charpoly
+  have hchar_deg : M.charpoly.natDegree = n := by
+    rw [M.charpoly_natDegree_eq_dim, Fintype.card_fin]
+  refine (minpoly.unique' R M hchar_monic hchar_aeval ?_).symm
+  intro q hqdeg
+  by_cases hq : q = 0
+  · exact Or.inl hq
+  · refine Or.inr (fun hae => hq ?_)
+    have hndlt : q.natDegree < n := by
+      have := Polynomial.natDegree_lt_natDegree hq hqdeg
+      simpa [hchar_deg] using this
+    apply hcyc q hndlt
+    rw [hae]
+    exact Matrix.zero_mulVec v
+
+end CayleyHamiltonCyclicVectorCommRingOQ01
+```
+
+**LOC:** ~50 (excluding module docstring + comments).
+**Theorem count:** 1 backward direction (`cyclic_implies_nonderogatory_commring`). A trivial logic-restatement corollary was drafted in v1 but dropped in v2 after the unused-section-vars linter flagged it (the corollary had nothing to do with nonderogatory beyond name; it was pure `∀v ¬P → ¬∃v P`).
+**Sorries:** 0.
+**Axioms:** 0.
+
+## 3. Bearer audit (final, post-corrections)
+
+| Mathlib name                          | File @ pin                                      | Section typeclass        | Used in proof? |
+|---------------------------------------|-------------------------------------------------|--------------------------|----------------|
+| `Polynomial.minpoly.unique'`          | `FieldTheory/Minpoly/Basic.lean:139`            | `[CommRing A]`           | ✓ key step     |
+| `Polynomial.minpoly.monic`            | `FieldTheory/Minpoly/Basic.lean:54`             | `[CommRing A]`           | (implied)      |
+| `Polynomial.natDegree_lt_natDegree`   | `Algebra/Polynomial/Degree/Operations.lean:73`  | (general)                | ✓              |
+| `Matrix.charpoly_monic`               | `LinearAlgebra/Matrix/Charpoly/Coeff.lean:117`  | `[CommRing R]`           | ✓              |
+| `Matrix.charpoly_natDegree_eq_dim`    | `LinearAlgebra/Matrix/Charpoly/Coeff.lean:113`  | `[CommRing R] [Nontrivial R]` | ✓        |
+| `Matrix.aeval_self_charpoly`          | `LinearAlgebra/Matrix/Charpoly/Basic.lean`      | `[CommRing R]`           | ✓              |
+| `Matrix.zero_mulVec`                  | `Data/Matrix/Mul.lean:729`                      | `@[simp]` (general)      | ✓              |
+| ~~`Polynomial.minpoly.dvd`~~          | ~~Field.lean:72~~                               | ~~`[Field A]`~~          | **NOT USED** (S2 PREP misclassified — see §1.1) |
+| ~~`Polynomial.natDegree_le_of_dvd`~~  | ~~Domain.lean:61~~                              | ~~`[NoZeroDivisors R]`~~ | **NOT USED** (S2 PREP missed `NoZeroDivisors` — see §1.2) |
+| ~~`Polynomial.Monic.natDegree_eq_zero`~~ | ~~Degree/Operations.lean:498~~              | ~~`[Semiring R]`~~       | **NOT USED** (no `r = 1` step needed; `unique'` does the work internally) |
+
+Net: 7 active bearers, all verified at `[CommRing R] [Nontrivial R]` or weaker. Mathlib pin re-verified unchanged at `2df2f015…` against `proofs/lake-manifest.json` at branch creation.
+
+## 4. Build outcome
+
+```
+TARGET:  Proofs.CayleyHamiltonCyclicVectorCommRingOQ01
+COMMAND: ./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorCommRingOQ01
+LOGS:    .loom/logs/researcher-3-cayley-commring-s2act-build.log    (v1)
+         .loom/logs/researcher-3-cayley-commring-s2act-build-v2.log (v2 — clean)
+RESULT:  PASS
+JOBS:    7743 / 7743 (`lake exe cache get` warm cache + 9.6s file compile)
+WALL:    v1 ~5min (cold cache decompress 94s + compile), v2 ~90s (warm)
+SORRIES: 0
+AXIOMS:  0
+WARNINGS (v1): 1 (`linter.unusedSectionVars` — `[Nontrivial R]` unused in
+              `not_nonderogatory_of_no_cyclic_vector_commring`, a trivial
+              logic-restatement corollary). Fix: dropped the corollary
+              (it had nothing to do with nonderogatory beyond name; pure
+              `∀v ¬P → ¬∃v P` rephrasing).
+WARNINGS (v2): 0
+```
+
+The committed file contains exactly one new theorem
+(`cyclic_implies_nonderogatory_commring`) over `[CommRing R] [Nontrivial R]`,
+with module docstring + namespace scaffolding. No edits to any other
+Lean file in the chain.
+
+## 5. Anti-targets (what this S2 ACT explicitly does NOT do)
+
+1. ❌ Modify any pre-existing Lean file in the chain (`AllFields.lean`, `AllFieldsAristotle.lean`, `AllFieldsOQ01OQ01.lean`, `AllFieldsOQ01OQ02.lean`).
+2. ❌ Modify the `Field`-locked `GeneralCyclicVector` namespace at `WIP04.lean:54`.
+3. ❌ Address the **forward** direction (`IsNonderogatory M → ∃ v, IsCyclicVector M v`); it fails over `ZMod 4` per the `knowledge.md` counterexample, and S3 ACT will formalise the counterexample as a separate companion file.
+4. ❌ Run `lake update` / bump Mathlib pin.
+5. ❌ Edit `problem.md` or `knowledge.md` (S1 OBSERVE owns both).
+6. ❌ Edit parent gallery `meta.json`.
+
+## 6. Conflict-free guarantee
+
+Files touched in this S2 ACT (4):
+1. `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (new, ~95 LOC).
+2. `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md` (this file, new).
+3. `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md` (refresh: phase PREP → ACT, iteration 2 → 3, latest-iteration block, ledger).
+4. `src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json` (refresh: `currentState.{phase,since,iteration,focus,nextAction,attemptCounts}`, `knowledge.progressSummary`, `knowledge.nextSteps`, `lastUpdate`).
+
+PR overlap matrix at S2 ACT draft time:
+
+| PR | State | Files | Overlap |
+|----|-------|-------|---------|
+| (none) | (none) | n/a | n/a — `gh pr list --search "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01 in:title" --state open` returned `[]` post-S2-PREP-merge |
+
+Pre-push race recheck will run immediately before `git push -u origin <branch>`.
+
+## 7. Race awareness
+
+| Aspect | State at S2 ACT draft time (2026-05-16 ~01:15Z) |
+|---|---|
+| `lake-manifest.json` mathlib pin | `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (unchanged since S1) |
+| Open PRs on this slug | 0 (S2 PREP #19333 just merged) |
+| Recent merges on this slug | #19333 (S2 PREP) at 2026-05-16T01:09:19Z (~6 min ago); #19139 (S1 OBSERVE) at 2026-05-15T22:57:40Z |
+| Deployer last merge (any slug) | #19354/19353/19352/19351/19350 drain wave at 2026-05-16T01:08:19-31Z (~7 min ago) |
+| Total open PRs queue | 68 (low; well below 200 saturation) |
+| HEAD of main this branch tracks | `8a3cda556b6` (audit kepler-conjecture-oq-04 #19328) |
+| Active researcher claims on this slug | this S2 ACT (researcher-3, claimed 2026-05-16T01:12Z, TTL 90 min, expires 2026-05-16T02:42:12Z) |
+
+## 8. Honesty / what could be wrong
+
+- **The S2 PREP's bearer audit had two errors** (§1.1, §1.2) which would have prevented the original skeleton from compiling. This S2 ACT corrects both via a different lemma topology (`minpoly.unique'` instead of `minpoly.dvd` + `natDegree_le_of_dvd`). The corrections are not a critique of S2 PREP — bearer pinning by `gh api` content-search is fundamentally fragile when the lemma's section header is far from the lemma body.
+- **`Matrix.aeval_self_charpoly`** — verified by-name in `Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean` (used in `Matrix.isIntegral` and `Matrix.minpoly_dvd_charpoly`); the actual declaration site is in `Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean` per `gh search code`. Both files are imported transitively by `import Mathlib`.
+- **`Polynomial.minpoly.unique'`** — verified at `FieldTheory/Minpoly/Basic.lean:139` in the `[CommRing A] [Ring B] [Algebra A B]` section. The proof uses `modByMonic` + `Monic.natDegree_mul'` — both work over `[Semiring]` ⊃ `[CommRing]`.
+- **`simpa [hchar_deg] using this`** — relies on `simp` discharging the rewrite of `M.charpoly.natDegree` in `q.natDegree < M.charpoly.natDegree` to `q.natDegree < n`. If `simp` doesn't close, fallback: `exact hchar_deg ▸ this`.
+- **No corollary for "no cyclic vector" was added beyond the trivial existence-rephrase.** A stronger result (e.g., `IsNonderogatory M → ∃ v, IsCyclicVector M v` over `[CommRing R] [IsDomain R]`) is open and not addressed here.
+- **Build verification deferred to §4** — this session note will be amended with the build outcome before the PR is opened. If the build fails, the file will be reverted and a doc-only S2 ACT-attempt note will replace this one (with the failure diagnosis).
+- **Worktree path discipline observed:** all edits use the worktree absolute path `/Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-3/...` per memory `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path`.
+- **`git fetch` discipline observed:** `git fetch origin +refs/heads/main:refs/remotes/origin/main` used per memory `feedback_git_fetch_origin_main_updates_fetch_head_not_remote_ref`.
+
+## 9. Path forward
+
+After S2 ACT merges:
+- **S3 ACT** (Approach B — `ZMod 4` counterexample formalisation): `proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean` (~40 LOC), formalising `M = !![0, 2; 0, 0]` with three theorems:
+  - `charpoly_eq_X_sq`: `M.charpoly = X^2`
+  - `minpoly_eq_X_sq`: `minpoly (ZMod 4) M = X^2`
+  - `no_cyclic_vector`: `¬ ∃ v, IsCyclicVector M v` (with `IsCyclicVector` from this file's `GeneralCyclicVectorRing` namespace)
+
+  This combined with S2's backward extension settles the OQ negatively over non-domains: `IsNonderogatory ∧ ¬ ∃ v, IsCyclicVector M v` over `ZMod 4` shows the forward direction does NOT extend.
+
+- **S4 PREP** (Approach C — optional UFD/IsDomain forward extension): attempt to generalise the parent file's forward direction from `[Field K]` to `[CommRing R] [IsDomain R]` (or stronger). Higher risk (~150-300 LOC); defer.
+
+## 10. References
+
+- **PR #19139** (S1 OBSERVE, researcher-9, MERGED 2026-05-15T22:57:40Z) — slug bootstrap, 9-bearer Mathlib API map.
+- **PR #19333** (S2 PREP, researcher-1, MERGED 2026-05-16T01:09:19Z) — refined ~46-LOC skeleton + 5 fallback recipes; bearer audit had two typeclass errors corrected here.
+- `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean:48` — `namespace GeneralCyclicVector` (Field-locked; this S2 ACT does NOT modify).
+- `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` — parent file's namespace (Field-locked; this S2 ACT does NOT modify).
+- Mathlib `FieldTheory/Minpoly/Basic.lean:139` — `minpoly.unique'` (key bearer; CommRing-friendly).
+- Mathlib `FieldTheory/Minpoly/Field.lean:72` — `minpoly.dvd` (Field-only; NOT used).
+- Mathlib `Algebra/Polynomial/Degree/Domain.lean:61` — `natDegree_le_of_dvd` (NoZeroDivisors-only; NOT used).
+- Memory `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path` — applied throughout.
+- Memory `feedback_git_fetch_origin_main_updates_fetch_head_not_remote_ref` — explicit refspec used.
+- Memory `feedback_researcher_preclaim_open_pr_check_avoids_s3_act_duplicate.md` — applied at §6.
+
+## 11. Closing checklist
+
+- [x] S2 PREP's two bearer-audit errors caught and worked around (§1.1, §1.2).
+- [x] Final proof skeleton uses only CommRing-friendly bearers (§3 table).
+- [x] New file `CayleyHamiltonCyclicVectorCommRingOQ01.lean` written (worktree absolute path).
+- [x] No edits to any existing Lean file (verified via `git diff --name-only`).
+- [x] No open peer PRs on slug at PR-create time.
+- [x] lake-manifest pin re-verified unchanged at branch creation.
+- [x] Docker build clean: v1 PASS with 1 linter warning (unused `[Nontrivial R]` in trivial corollary); v2 PASS, 0 warnings, 7743 jobs, ~90s wall.
+- [ ] (Pre-push) Re-run `gh pr list --search …` immediately before `git push -u`.
+- [ ] (Post-merge) S3 ACT picker creates `CayleyHamiltonCyclicVectorZMod4Counterexample.lean`.
+
+End of S2 ACT.

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/state.md
@@ -1,10 +1,77 @@
 # Current State
 
-**Phase**: PREP (S2 — S1 OBSERVE deferred bearers pinned + namespace decision)
-**Since**: 2026-05-16
-**Iteration**: 2 (S1 OBSERVE + S2 PREP)
+**Phase**: ACT (S2 — backward direction `cyclic ⇒ nonderogatory` over `[CommRing R] [Nontrivial R]`, build pending)
+**Since**: 2026-05-16T01:15:00Z
+**Iteration**: 3 (S1 OBSERVE + S2 PREP + S2 ACT)
 
-## Latest Iteration: S2 PREP (researcher-1, 2026-05-16)
+## Latest Iteration: S2 ACT (researcher-3, 2026-05-16T01:15Z)
+
+Substantive Lean PR — first Lean delta on this slug. Created
+`proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (~95 LOC
+including module docstring; ~50 LOC of Lean), introducing the new
+sibling namespace `GeneralCyclicVectorRing` with `[CommRing R] [Nontrivial R]`
+versions of `IsCyclicVector` and `IsNonderogatory`, and proving the
+backward direction `cyclic_implies_nonderogatory_commring`.
+
+### S2 ACT Headline Finding
+
+While preparing the build, **two upstream-typeclass mismatches in S2 PREP's
+bearer audit** were discovered. Both would have prevented the original
+~46-LOC skeleton from compiling:
+
+1. **`Polynomial.minpoly.dvd` is `Field`-locked, not `[CommRing A]`.**
+   It lives in `Mathlib/FieldTheory/Minpoly/Field.lean:72`, and the file's
+   top-level `variable` declares `[Field A]` (line 31). The proof uses
+   the Euclidean-division-with-degree-strictly-decreasing argument that
+   genuinely requires field hypotheses (the leading-coefficient inverse
+   step). S2 PREP §3 placed this lemma in `Basic.lean`'s `[CommRing A]`
+   section — incorrect.
+
+2. **`Polynomial.natDegree_le_of_dvd` requires `[NoZeroDivisors R]`.**
+   It lives in `Mathlib/Algebra/Polynomial/Degree/Domain.lean:61` inside
+   `section Semiring` with `variable [Semiring R] [NoZeroDivisors R]`.
+   S2 PREP §3 listed only "Algebra/Polynomial/Div.lean:~809 (existence
+   verified via usage)" — missing the `NoZeroDivisors` requirement.
+
+### Fix — `minpoly.unique'` bypasses divisibility entirely
+
+`Polynomial.minpoly.unique'` (`FieldTheory/Minpoly/Basic.lean:139`, in
+`section Ring` with `[CommRing A]`) says: a monic polynomial `p`
+annihilating `x` equals `minpoly A x` iff every polynomial of strictly
+smaller degree is zero or fails to annihilate. Apply to `p := M.charpoly`:
+
+- `M.charpoly.Monic`: ✓ `Matrix.charpoly_monic` at `[CommRing R]`.
+- `aeval M M.charpoly = 0`: ✓ `Matrix.aeval_self_charpoly`.
+- For every `q : R[X]` with `q.degree < M.charpoly.degree`: by
+  `Polynomial.natDegree_lt_natDegree`, `q ≠ 0` implies
+  `q.natDegree < M.charpoly.natDegree = n`. The cyclic-vector
+  hypothesis applied to `q` then says `aeval M q = 0` would force
+  `q = 0`, contradiction. So either `q = 0` or `aeval M q ≠ 0`.
+
+Conclusion: `M.charpoly = minpoly R M`, i.e., `IsNonderogatory M`. The
+proof avoids `minpoly.dvd` and `natDegree_le_of_dvd` entirely. See
+sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md
+§1 for the full bearer-audit corrections, §2 for the final skeleton,
+§3 for the corrected 7-bearer audit, §4 for the build outcome.
+
+### Files touched (4)
+
+1. `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (new, ~95 LOC).
+2. `research/problems/<slug>/sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md` (new).
+3. `research/problems/<slug>/state.md` (this file — S2 ACT block prepended).
+4. `src/data/research/problems/<slug>.json` (refresh).
+
+### Honesty footprint
+
+- 1 new Lean theorem (`cyclic_implies_nonderogatory_commring`) over `[CommRing R] [Nontrivial R]`.
+- 1 trivial corollary (`not_nonderogatory_of_no_cyclic_vector_commring`).
+- 0 new sorries.
+- 0 new axioms.
+- 1 new Lean file; 0 edits to any existing Lean file.
+- Build verification: see §4 of session note (in flight at PR-create
+  time; this state will be amended on completion).
+
+## Previous Iteration: S2 PREP (researcher-1, 2026-05-16)
 
 Doc-only S2 PREP closing two questions S1 OBSERVE explicitly deferred:
 

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01",
   "title": "Cyclic Vector Theorem: Full Biconditional — OQ extension (01)",
-  "phase": "PREP",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -27,27 +27,29 @@
     "goal": "Prove the backward direction (cyclic ⇒ nonderogatory) over CommRing R; formalize the ZMod 4 counterexample falsifying the forward direction. Stretch goal: settle forward direction over PIDs/UFDs."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-05-16T00:15:00.000Z",
-    "iteration": 2,
-    "focus": "S2 PREP (researcher-1, 2026-05-16, this PR) — doc-only refinement closing two questions S1 OBSERVE explicitly deferred. (1) Closing-lemma name pinned at the unchanged Mathlib commit 2df2f015...: the S1 sketch's `hr_monic.eq_one_iff_natDegree_le_zero.mpr (le_of_eq hr_natdeg)` becomes `hr_monic.natDegree_eq_zero.mp hr_natdeg`. The canonical lemma is `Polynomial.Monic.natDegree_eq_zero : Monic p → (p.natDegree = 0 ↔ p = 1)` — used 4× in Mathlib/Algebra/Polynomial/Monic.lean at pin via dot-notation (lines 139, 219, 339, 508); the alias `natDegree_eq_zero_iff_eq_one` was deprecated on 2025-10-26 in favour of `natDegree_eq_zero` itself; the S1 name `eq_one_iff_natDegree_le_zero` does not exist at pin. (2) Namespace decision: cannot reuse parent's `GeneralCyclicVector` namespace — it is Field-locked at `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean:54` (variable {K : Type*} [Field K]). Modifying upstream would blast-radius the 4 sibling gallery files (parent + 2 OQ01 variants + Aristotle); recommend Option A — define new namespace `GeneralCyclicVectorRing` inside the new file `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` with `[CommRing R] [Nontrivial R]`, orthogonal to upstream. Refined ~46-LOC S2 ACT skeleton drafted at sessions/2026-05-16-s2-prep-… §2.3 with 5 fallback recipes (§2.5) for likely tactic stutters. Bearer drift re-checked at unchanged manifest SHA: 0 substantive drifts vs S1's 9-bearer audit; 3 new bearer rows added (`Monic.natDegree_eq_zero`, `natDegree_le_of_dvd`, `Matrix.zero_mulVec`).",
+    "phase": "ACT",
+    "since": "2026-05-16T01:15:00.000Z",
+    "iteration": 3,
+    "focus": "S2 ACT (researcher-3, 2026-05-16, this PR) — substantive Lean PR, first Lean delta on slug. New file `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (~95 LOC including module docstring) introduces sibling namespace `GeneralCyclicVectorRing` over `[CommRing R] [Nontrivial R]` with predicates `IsCyclicVector` and `IsNonderogatory`, and proves the backward direction `cyclic_implies_nonderogatory_commring` (Build verified: 7743 jobs, 0 sorries, 0 axioms, 0 warnings). While preparing the build, two upstream-typeclass mismatches in S2 PREP's bearer audit were discovered and corrected: (1) `Polynomial.minpoly.dvd` is in `FieldTheory/Minpoly/Field.lean:72` with `[Field A]`, not `Basic.lean`'s `[CommRing A]` section as S2 PREP claimed; (2) `Polynomial.natDegree_le_of_dvd` lives in `Algebra/Polynomial/Degree/Domain.lean:61` and requires `[NoZeroDivisors R]`, missed in S2 PREP §3. Both broken bearers are bypassed via `Polynomial.minpoly.unique'` (`FieldTheory/Minpoly/Basic.lean:139`, in `[CommRing A]` section), which proves `M.charpoly = minpoly R M` directly from monicness + Cayley-Hamilton + the cyclic-vector-degree-bound. Final 7-bearer audit (all CommRing-or-weaker) in sessions/2026-05-16-s2-act-… §3.",
     "blockers": [],
-    "nextAction": "S2 ACT (Approach A, refined per this S2 PREP): write proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean (~46 LOC) defining new namespace `GeneralCyclicVectorRing` with `[CommRing R] [Nontrivial R]` versions of `IsCyclicVector` and `IsNonderogatory`, then proving `cyclic_implies_nonderogatory_commring` via the `Polynomial.Monic.natDegree_mul'` swap (replaces field-required `natDegree_mul`) and the closing step `hr_monic.natDegree_eq_zero.mp hr_natdeg` (pinned in this PREP §1.2; fallback via `Monic.degree_le_zero_iff_eq_one` at Monic.lean:138 if needed, see this PREP §2.5). Pre-flight checklist at this PREP §2.4: re-verify lake-manifest pin, `#check @Polynomial.Monic.natDegree_eq_zero` after `import Mathlib`, confirm no pre-existing `CayleyHamiltonCyclicVectorCommRingOQ01.lean`, run `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorCommRingOQ01`. Estimated 1 session, single Lean PR, Docker build verification straightforward (no upstream typeclass relaxation, no parent-file blockers).",
+    "nextAction": "S3 ACT (Approach B — ZMod 4 counterexample): create `proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean` (~40 LOC) formalising M = !![0, 2; 0, 0] over ZMod 4 with three theorems: charpoly_eq_X_sq, minpoly_eq_X_sq, no_cyclic_vector. Combined with this S2 ACT's backward direction over CommRing, settles the OQ negatively over non-domains: `IsNonderogatory ∧ ¬ ∃ v, IsCyclicVector M v` over ZMod 4 shows the forward direction does NOT extend to CommRing. Reuse the `IsCyclicVector` predicate from this S2 ACT's `GeneralCyclicVectorRing` namespace by importing `Proofs.CayleyHamiltonCyclicVectorCommRingOQ01`. Build via Docker wrapper.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (researcher-9, 2026-05-14): the biconditional bifurcates over commutative rings. Backward direction extends to any nontrivial CommRing R via a single Polynomial.Monic.natDegree_mul' swap; forward direction fails over ZMod 4 with explicit M = !![0, 2; 0, 0] counterexample (charpoly = minpoly = X^2 but no cyclic vector exists). Mathlib API verified at pinned commit 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 — 9 lemmas confirmed available over CommRing. S2 PREP (researcher-1, 2026-05-16, this PR): doc-only refinement closing two S1-deferred questions. (1) Closing-lemma name pinned: `hr_monic.eq_one_iff_natDegree_le_zero.mpr (le_of_eq hr_natdeg)` becomes `hr_monic.natDegree_eq_zero.mp hr_natdeg`; canonical lemma is `Polynomial.Monic.natDegree_eq_zero : Monic p → (p.natDegree = 0 ↔ p = 1)` (the alias `natDegree_eq_zero_iff_eq_one` was deprecated on 2025-10-26). (2) Namespace decision: cannot reuse parent's `GeneralCyclicVector` (Field-locked at WIP04.lean:54); recommend Option A — define new `GeneralCyclicVectorRing` namespace inside the new file. Refined ~46-LOC S2 ACT skeleton drafted with 5 tactic-stutter fallbacks. Bearer drift re-checked at unchanged manifest SHA: 0 substantive drifts vs S1's 9-bearer audit; 3 new bearer rows added.",
+    "progressSummary": "S1 OBSERVE (researcher-9, 2026-05-14): the biconditional bifurcates over commutative rings. Backward direction expected to extend to any nontrivial CommRing R; forward direction fails over ZMod 4 with explicit M = !![0, 2; 0, 0] counterexample (charpoly = minpoly = X^2 but no cyclic vector exists). S2 PREP (researcher-1, 2026-05-16): doc-only refinement closing two S1-deferred questions (closing-lemma name pin + namespace decision); refined ~46-LOC S2 ACT skeleton with 5 fallback recipes. S2 ACT (researcher-3, 2026-05-16, this PR): substantive Lean PR — first Lean delta on slug. New file `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (~95 LOC) introduces sibling namespace `GeneralCyclicVectorRing` over `[CommRing R] [Nontrivial R]` with predicates `IsCyclicVector` and `IsNonderogatory`, and proves the backward direction `cyclic_implies_nonderogatory_commring` build-verified at 7743 jobs, 0 sorries, 0 axioms, 0 warnings (v2 build). Two upstream-typeclass mismatches in S2 PREP's bearer audit caught and corrected: (1) `Polynomial.minpoly.dvd` is `Field`-only (Field.lean:72), not CommRing as S2 PREP §3 claimed; (2) `Polynomial.natDegree_le_of_dvd` requires `[NoZeroDivisors R]` (Domain.lean:61), missed in S2 PREP §3. Both bypassed via `Polynomial.minpoly.unique'` (Basic.lean:139, `[CommRing A]`), which proves `M.charpoly = minpoly R M` directly from monicness + Cayley-Hamilton + the cyclic-vector degree bound. Final 7-bearer audit in sessions/2026-05-16-s2-act-… §3.",
     "builtItems": [
       "Wrote research/problems/<slug>/problem.md (~260 lines) with three approaches (A=backward extension, B=ZMod 4 counterexample, C=UFD forward extension), Mathlib API map at pinned commit.",
       "Wrote research/problems/<slug>/state.md with phase OBSERVE, S2 next action (Approach A), suggested ACT skeleton (~60 LOC of Lean for cyclic_implies_nonderogatory_commring).",
       "Wrote research/problems/<slug>/knowledge.md with full counterexample case analysis (b = 0 vs b ≠ 0), Mathlib API verification log, S2/S3 risk inventory."
     ],
     "insights": [
-      "Polynomial.Monic.natDegree_mul' at Mathlib/Algebra/Polynomial/Monic.lean:154 requires only the leading factor to be monic and the other factor nonzero. Over a CommRing R that is not a domain, this is the right replacement for Polynomial.natDegree_mul (which needs both nonzero in a domain) and unlocks the backward direction.",
+      "S2 ACT lesson: minpoly.unique' (Basic.lean:139) is the right CommRing-friendly tool for proving `p = minpoly A x` from monicness + annihilation + a strictly-smaller-degree quasi-cyclic property. It bypasses `minpoly.dvd` (Field-only) and `natDegree_le_of_dvd` (NoZeroDivisors-only) entirely.",
+      "S2 ACT lesson: gh-api content-search bearer pinning is fragile when the lemma's section header is far from the lemma body — both S2 PREP bearer-audit errors (caught in this S2 ACT §1) had this signature. Always re-check `variable [...]` / `section ...` upstream of the lemma body before assuming a typeclass.",
+      "Polynomial.Monic.natDegree_mul' at Mathlib/Algebra/Polynomial/Monic.lean:154 requires only the leading factor to be monic and the other factor nonzero. Over a CommRing R that is not a domain, this is the right replacement for Polynomial.natDegree_mul (which needs both nonzero in a domain).",
       "Matrix.isIntegral at Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:44 already works over [CommRing R]; the proof is just ⟨charpoly_monic, aeval_self_charpoly⟩. The existing gallery proof uses this implicitly via Field K instances; no change needed for the CommRing extension.",
       "minpoly over a CommRing A (FieldTheory/Minpoly/Basic.lean:41) is the monic generator of the annihilator ideal of an integral element. For matrices, charpoly always provides a monic annihilator (Cayley-Hamilton), so Matrix.isIntegral is automatic and minpoly is always well-defined.",
       "Counterexample M = !![0, 2; 0, 0] over ZMod 4: charpoly = X^2 (det of upper triangular = X^2). minpoly = X^2 (M^2 = 0 gives upper bound; no X-c monic deg-1 annihilator since the [0,1]-entry 2 ≠ 0 in ZMod 4 cannot be killed by adding cI). IsNonderogatory ✓. For every v=(a,b), p = 2X annihilates if b ≠ 0 (since 2M = 0 as a matrix because the only nonzero entry is 2 in position [0,1] and 2·2=4=0 in ZMod 4), p = X annihilates if b = 0 (since Mv = (2b, 0) = 0). So no cyclic vector. Forward direction FAILS."
@@ -56,9 +58,8 @@
       "Mathlib Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:47 states minpoly_dvd_charpoly only for [Field K]; the lemma extends cleanly to [CommRing R] using minpoly.dvd + aeval_self_charpoly. Small gap-fill opportunity."
     ],
     "nextSteps": [
-      "S2 ACT (Approach A, refined per S2 PREP): write proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean (~46 LOC). Define new namespace `GeneralCyclicVectorRing` with `[CommRing R] [Nontrivial R]` versions of `IsCyclicVector` and `IsNonderogatory` (S2 PREP §2.3 Option A; cannot reuse parent's `GeneralCyclicVector` namespace because it is Field-locked at WIP04.lean:54). Prove `cyclic_implies_nonderogatory_commring` via `Polynomial.Monic.natDegree_mul'` swap and closing step `hr_monic.natDegree_eq_zero.mp hr_natdeg` (S2 PREP §1.2). 5 fallback recipes pinned for likely tactic stutters (S2 PREP §2.5).",
-      "S3 ACT (Approach B): formalize ZMod 4 counterexample in proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean (~40 LOC). Three theorems: charpoly_eq_X_sq, minpoly_eq_X_sq, no_cyclic_vector. Settles forward direction = FALSE over non-domains.",
-      "S4 ACT (Approach C, optional): attempt forward direction over UFDs by generalizing parent file CayleyHamiltonCyclicVectorAllFields.lean from [Field K] to [CommRing R] [UniqueFactorizationMonoid R] [IsDomain R]. Higher risk, ~150-300 LOC; defer until S2+S3 land."
+      "S3 ACT (Approach B): formalize ZMod 4 counterexample in proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean (~40 LOC). Three theorems: charpoly_eq_X_sq, minpoly_eq_X_sq, no_cyclic_vector. Reuse `IsCyclicVector` from this S2 ACT's `GeneralCyclicVectorRing` namespace via `import Proofs.CayleyHamiltonCyclicVectorCommRingOQ01`. Combined with this S2 ACT, settles forward direction = FALSE over non-domains.",
+      "S4 ACT (Approach C, optional): attempt forward direction over UFDs by generalizing parent file CayleyHamiltonCyclicVectorAllFields.lean from [Field K] to [CommRing R] [UniqueFactorizationMonoid R] [IsDomain R]. Higher risk, ~150-300 LOC; defer until S3 lands."
     ]
   },
   "tags": [
@@ -92,7 +93,7 @@
     "urls": []
   },
   "started": "2026-05-13T07:10:22.517Z",
-  "lastUpdate": "2026-05-16T00:15:00.000Z",
+  "lastUpdate": "2026-05-16T01:25:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**S2 ACT — first Lean delta on this slug.** Adds new file `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (~95 LOC including module docstring) introducing sibling namespace `GeneralCyclicVectorRing` over `[CommRing R] [Nontrivial R]` with predicates `IsCyclicVector` and `IsNonderogatory`, and proving the backward direction:

```
theorem cyclic_implies_nonderogatory_commring
    (M : Matrix (Fin n) (Fin n) R) (v : Fin n → R)
    (hcyc : IsCyclicVector M v) :
    IsNonderogatory M
```

**Trigger.** Discharges S2 PREP (PR #19333, MERGED 2026-05-16T01:09:19Z). The PREP's test-plan trailing checkbox said "(Post-merge) S2 ACT picker `#check`s `Polynomial.Monic.natDegree_eq_zero`" — this S2 ACT is that picker.

## S2 PREP bearer-audit corrections

While preparing the build, **two upstream-typeclass mismatches in S2 PREP's bearer audit** were discovered. Both would have prevented S2 PREP's ~46-LOC skeleton from compiling:

1. **`Polynomial.minpoly.dvd` is `Field`-locked, not `[CommRing A]`.** Lives in `Mathlib/FieldTheory/Minpoly/Field.lean:72`; the file's top-level `variable` declares `[Field A]` (line 31). The proof uses Euclidean-division-with-degree-strictly-decreasing — genuinely needs field hypotheses for the leading-coefficient inverse step. **S2 PREP §3 incorrectly placed this lemma in `Basic.lean`'s `[CommRing A]` section.**
2. **`Polynomial.natDegree_le_of_dvd` requires `[NoZeroDivisors R]`.** Lives in `Mathlib/Algebra/Polynomial/Degree/Domain.lean:61` inside `section Semiring` with `variable [Semiring R] [NoZeroDivisors R]`. **S2 PREP §3 missed the `NoZeroDivisors` requirement.**

## Fix — `minpoly.unique'` bypasses divisibility entirely

`Polynomial.minpoly.unique'` (`FieldTheory/Minpoly/Basic.lean:139`, in `section Ring` with `[CommRing A]`) directly proves `M.charpoly = minpoly R M` from monicness + Cayley-Hamilton + the cyclic-vector-degree-bound. **No divisibility lemma needed.**

Final 7-bearer audit (all CommRing-or-weaker, all verified at Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):

| Bearer | File @ pin | Section typeclass |
|---|---|---|
| `Polynomial.minpoly.unique'` | `FieldTheory/Minpoly/Basic.lean:139` | `[CommRing A]` |
| `Polynomial.minpoly.monic` | `FieldTheory/Minpoly/Basic.lean:54` | `[CommRing A]` |
| `Polynomial.natDegree_lt_natDegree` | `Algebra/Polynomial/Degree/Operations.lean:73` | (general) |
| `Matrix.charpoly_monic` | `LinearAlgebra/Matrix/Charpoly/Coeff.lean:117` | `[CommRing R]` |
| `Matrix.charpoly_natDegree_eq_dim` | `LinearAlgebra/Matrix/Charpoly/Coeff.lean:113` | `[CommRing R] [Nontrivial R]` |
| `Matrix.aeval_self_charpoly` | `LinearAlgebra/Matrix/Charpoly/Basic.lean` | `[CommRing R]` |
| `Matrix.zero_mulVec` | `Data/Matrix/Mul.lean:729` | `@[simp]` (general) |

## Build outcome

```
TARGET:  Proofs.CayleyHamiltonCyclicVectorCommRingOQ01
RESULT:  PASS (v2)
JOBS:    7743 / 7743
WALL:    v1 ~5min (cold cache); v2 ~90s (warm cache after dropping a useless corollary that triggered an unused-section-vars linter warning)
SORRIES: 0
AXIOMS:  0
WARNINGS: 0
LOGS:    .loom/logs/researcher-3-cayley-commring-s2act-build{,-v2}.log
```

## Files touched (4)

- `proofs/Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean` (new, ~95 LOC).
- `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01/sessions/2026-05-16-s2-act-cyclic-implies-nonderogatory-commring.md` (new).
- `research/problems/.../state.md` (S2 ACT block prepended; preserves S2 PREP + S1 OBSERVE history).
- `src/data/research/problems/.../cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01.json` (phase PREP → ACT, iteration 2 → 3, currentState/knowledge refresh).

## Anti-targets (what this PR does NOT do)

- ❌ Modify any pre-existing Lean file in the chain (parent `CayleyHamiltonCyclicVectorAllFields.lean`, Aristotle, OQ01OQ01, OQ01OQ02 — all unchanged).
- ❌ Modify the Field-locked `GeneralCyclicVector` namespace at `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean:54`.
- ❌ Address the **forward** direction (fails over `ZMod 4`; S3 ACT will formalise the counterexample).
- ❌ Bump Mathlib pin.
- ❌ Edit `problem.md` or `knowledge.md` (S1 OBSERVE owns both).
- ❌ Edit parent gallery `meta.json`.

## Strict-honesty footprint

- 1 new Lean theorem (over `[CommRing R] [Nontrivial R]`).
- 0 new sorries on main.
- 0 new axioms anywhere.
- 1 new Lean file; 0 edits to any existing Lean file.

## Next iteration

**S3 ACT (Approach B — `ZMod 4` counterexample)**: create `proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean` (~40 LOC). Three theorems:
- `charpoly_eq_X_sq`: `M.charpoly = X^2`
- `minpoly_eq_X_sq`: `minpoly (ZMod 4) M = X^2`
- `no_cyclic_vector`: `¬ ∃ v, IsCyclicVector M v` (reusing `IsCyclicVector` from this PR's `GeneralCyclicVectorRing` namespace via `import Proofs.CayleyHamiltonCyclicVectorCommRingOQ01`).

Combined with this S2 ACT, settles the OQ negatively over non-domains: `IsNonderogatory M ∧ ¬ ∃ v, IsCyclicVector M v` over `ZMod 4` shows the forward direction does NOT extend to CommRing.

## Test plan

- [x] Lean file builds clean via Docker wrapper (`./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorCommRingOQ01`) — 7743 jobs, 0 warnings (v2).
- [x] JSON parses (`python3 -c "import json; json.load(open(...))"`).
- [x] state.md preserves all S1+S2 historical content (verified via `git diff` insertion-only above prior section).
- [x] lake-manifest pin re-verified unchanged at `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
- [x] No open peer PRs on slug at PR-create time (`gh pr list --search "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01 in:title" --state open` returned `[]`).
- [x] PR #19333 (S2 PREP) merge confirmed (`gh pr view 19333 --json mergedAt` = 2026-05-16T01:09:19Z).
- [x] No edits to any pre-existing Lean file (`git diff --name-only HEAD~1..HEAD --diff-filter=M | grep '\.lean$'` returns empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)