### PR TITLE
audit: tracker bumps for erdos-924/927/989 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10593,8 +10593,8 @@
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:11:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:26:54Z",
       "result": "clean"
     },
     "erdos-925": {
@@ -10611,9 +10611,9 @@
     },
     "erdos-927": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T07:56:26Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:20:41Z",
+      "result": "clean"
     },
     "erdos-928": {
       "agentId": "auditor-cycle-20-batch",
@@ -11029,8 +11029,8 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T08:04:40Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T02:24:57Z",
       "result": "clean"
     },
     "erdos-99": {


### PR DESCRIPTION
## Summary

Tracker bump for three gallery entries verified clean against Lean sources:

- **erdos-924** (`auditCount` 3→4) — `Proofs/Erdos924Problem.lean`: 0 sorries, 4 axioms, 3 theorems, 12 defs, 301 lines. `meta.json` axiomCount=4 / sorries=0 / theoremCount=3 / definitionCount=12 / lineCount=301 / status=`axiomatized` / badge=`axiom` all match. No structure-encoded assumptions.
- **erdos-927** (`auditCount` 3→4) — prior cycle `issues-fixed` → re-verified `clean`.
- **erdos-989** (`auditCount` 4→5) — prior cycle bump → re-verified `clean`.

## Test plan

- [x] Lean source counts match `meta.json` for erdos-924 (axioms/sorries/theorems/defs/lines)
- [x] No structure-encoded axioms (grep `^structure|^class` returns 0)
- [x] Status/badge consistent with declared axiom count (axiomatized + axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)