### PR TITLE
fix(claude-wrapper): rotate on extra-usage / monthly-cap errors

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -329,8 +329,13 @@ classify_error() {
         return
     fi
 
-    # Token exhausted (quota used up) — rotate to next
-    if echo "$output" | grep -qi "hit your limit\|hit.your.limit"; then
+    # Token exhausted (quota used up) — rotate to next.
+    # Anthropic emits several distinct phrasings; match all of them so the
+    # wrapper rotates instead of pinning to the dead account for 300s ticks:
+    #   - "hit your limit"                              (legacy short form)
+    #   - "You've hit your org's monthly usage limit"   (org cap; multi-word gap defeats `hit.your.limit`)
+    #   - "You're out of extra usage · resets …"        (session/extra-usage cap)
+    if echo "$output" | grep -qi "hit your limit\|monthly usage limit\|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi


### PR DESCRIPTION
## Summary

- Widen `classify_error` in `scripts/agents/claude-wrapper.sh` to mark a cycle `TOKEN_EXHAUSTED` (so the wrapper rotates) when Anthropic returns either of the two new phrasings, in addition to the legacy `hit your limit` string:
  - `You're out of extra usage · resets 3:50pm (America/Los_Angeles)`
  - `You've hit your org's monthly usage limit`
- The old regex `hit.your.limit` only matches a 4-char gap between `your` and `limit`, so `org's monthly usage limit` (24-char gap) fell through to RECOVERABLE; the extra-usage string never contained `limit` at all.
- Consequence on `main`: the wrapper was pinning to dead accounts for 300s cycles instead of rotating. Last successful rotation in any agent log was 2026-05-13 13:16Z; since then 27 distinct agent logs accumulated `out of extra usage` strings while no rotation fired.

## Test plan

- [x] String-match smoke test against all three exhaustion phrasings + a 500 error + a success line — only the three quota strings match.
- [ ] After merge, watch `.loom/logs/*.log` for fresh `[wrapper] Rotated to token: agent-N` entries within one cycle of the next 1-day reset (22:50Z 2026-05-16).
- [ ] Confirm `consecutive failures` counters in `launch.sh health` drop to single digits on agents that were stuck at 10+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)