### PR TITLE
audit(erdos-903): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10448,9 +10448,9 @@
       "result": "clean"
     },
     "erdos-903": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T10:41:52Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:39:15Z",
       "result": "clean"
     },
     "erdos-904": {


### PR DESCRIPTION
## Summary

Re-audit of [erdos-903](src/data/proofs/erdos-903) (Block Designs and the de Bruijn-Erdős Gap) confirms gallery integrity. No drift detected.

## Verification

| Field | Meta claims | Lean source | Match |
|---|---|---|---|
| Sorries | 0 | 0 | ✓ |
| Axioms | 5 | 5 (`de_bruijn_erdos`, `projective_plane_design`, `efsw_1985`, `gap_theorem`, `fisher_inequality`) | ✓ |
| Theorems | 3 | 3 (`first_above_n`, `de_bruijn_erdos_from_fisher`, `erdos_903_summary`) | ✓ |
| Definitions | 8 | 8 | ✓ |
| Line count | 211 | 211 | ✓ |
| Status | `axiomatized` | 5 axioms present | ✓ |
| Badge | `axiom` | matches status | ✓ |

Status `axiomatized` is appropriate: this is an Erdős open problem (now solved), but the combinatorial proofs of de Bruijn-Erdős (1948) and Erdős-Fowler-Sós-Wilson (1985) exceed current Mathlib capability.

## Tracker delta

- auditCount: 3 → 4
- lastAudited: 2026-04-28T10:41:52Z → 2026-05-16T02:39:15Z
- agentId: auditor-cycle-20-batch → auditor-agent
- result: clean (unchanged)

## Test plan

- [x] Counts cross-checked Lean source vs meta.json
- [x] Diff is exactly 3 lines in audit-tracker.json (no other files touched)
- [x] PR opened from fresh worktree off origin/main (no contamination from shared checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)