### PR TITLE
audit(erdos-878): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10270,9 +10270,9 @@
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T12:57:05Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:45:19Z",
+      "result": "clean"
     },
     "erdos-879": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audit verified `Erdos878Problem.lean` matches `meta.json` exactly
- `auditCount` 3 → 4, `result` issues-fixed → clean, `lastAudited` refreshed

## Verification
| Field | meta.json | Lean source |
|---|---|---|
| lineCount | 219 | 219 ✓ |
| axiomCount | 5 | 5 ✓ (f_le_F, H_lower_bound, H_upper_bound, H_limsup_infinite, H_liminf_finite) |
| theoremCount | 4 | 4 ✓ |
| definitionCount | 13 | 12 `def` + 1 `structure` (ValidDecomposition) = 13 ✓ |
| sorries | 0 | 0 ✓ |

`status="axiomatized"` / `badge="axiom"` correct for open Erdős problem with 5 stated axioms (per axiom integrity policy).

## Test plan
- [x] gallery integrity verified at HEAD `8a3cda556b6`
- [x] no Lean source changes