### PR TITLE
audit(erdos-88): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10282,9 +10282,9 @@
     },
     "erdos-88": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T13:05:36Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:48:12Z",
+      "result": "clean"
     },
     "erdos-880": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited `Erdos88Problem.lean` against `meta.json` on 2026-05-16. All integrity fields match Lean source:

| Field | meta.json | Lean source | Status |
|---|---|---|---|
| `lineCount` | 257 | 257 | ✓ |
| `axiomCount` | 2 | 2 (`ksss_theorem`, `R`) | ✓ |
| `theoremCount` | 2 | 2 (`delta_pos`, `erdos_88`) | ✓ |
| `definitionCount` | 22 | 22 (1 `abbrev` + 21 `def`) | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `True` stubs | — | 0 | ✓ |

- `status=axiomatized` / `badge=axiom` correct for KSSS axiomatization (prize-winning recent theorem, full proof not formalized — appropriate to keep axiomatized).
- Prior result `issues-fixed` (2026-04-28 phantom-axiom narrative correction, PR #13619) confirmed still holding.

Bumps `auditCount` 3→4, result `issues-fixed`→`clean`.

## Test plan
- [x] `wc -l proofs/Proofs/Erdos88Problem.lean` → 257
- [x] `grep -c '^axiom ' proofs/Proofs/Erdos88Problem.lean` → 2; both names match `assumptions` field
- [x] theorem/lemma count → 2; defs (incl. abbrev) → 22; sorries → 0; True stubs → 0
- [x] Focused single-slug PR (audit-tracker.json only, 3 +/3 -)

🤖 Generated with [Claude Code](https://claude.com/claude-code)