### PR TITLE
audit(erdos-913): theoremCount 16 → 11 (meta drift, Lean ground truth)

### DIFF
--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -23,7 +23,7 @@
     "lineCount": 344,
     "assumptions": "1 axiom: infinite_8p_sq_minus_1_primes (Bunyakovsky-type conjecture: infinitely many primes p with 8p²-1 also prime). Both conditional results (8p²-1 path and Mersenne path) and all exponent structure lemmas are fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 11,
     "definitionCount": 6
   },
   "overview": {
@@ -156,7 +156,7 @@
     "namespace": "Erdos913",
     "lineCount": 344,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 11,
     "definitionCount": 6,
     "path": "Proofs/Erdos913Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`src/data/proofs/erdos-913/meta.json` claimed `theoremCount: 16` in both the top-level `meta` block and the nested `leanFile` block. Actual count in `proofs/Proofs/Erdos913Problem.lean` is **11** theorems (no lemmas).

## Lean ground truth

```
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos913Problem.lean
11
```

Counting logic matches `scripts/research/enrich-research.ts:155` (`/^(theorem|lemma) /`). The 11 theorems are:

1. `exponent_structure` (line 120)
2. `erdos_913_conditional` (line 190)
3. `example_n3` (line 229)
4. `example_n7` (line 234)
5. `example_n8` (line 239)
6. `example_n31` (line 244)
7. `example_n71` (line 251)
8. `example_n127` (line 256)
9. `hasDistinctExponents_mersenne` (line 300)
10. `erdos_913_conditional_mersenne` (line 331)
11. `nonempty_distinctExponentSet` (line 341)

## Other fields already match

| Field | meta.json | Lean | Match |
|-------|-----------|------|-------|
| `axiomCount` | 1 | 1 (`infinite_8p_sq_minus_1_primes`) | ✓ |
| `definitionCount` | 6 | 6 | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `lineCount` | 344 | 344 | ✓ |
| True stubs | — | 0 | ✓ |
| `status` `axiomatized` / `badge` `axiom` | — | 1 axiom present | ✓ |

## Diff

```diff
-    "theoremCount": 16,
+    "theoremCount": 11,
```

(applied to both `meta.theoremCount` line 26 and `leanFile.theoremCount` line 159)

## Test plan

- [x] Verified HEAD = `origin/main` = `8a3cda556b6` at edit time (avoids stale-checkout drift trap)
- [x] No in-flight PRs touching `erdos-913` or `audit/erdos-913-meta-sync-*` at branch creation
- [x] Only `meta.json` modified (2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)