### PR TITLE
audit(erdos-9): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10418,10 +10418,10 @@
       "result": "clean"
     },
     "erdos-9": {
-      "agentId": "mechanic-1",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T14:00:00Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T02:56:29Z",
+      "result": "clean"
     },
     "erdos-90": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited `Proofs/Erdos9Problem.lean` against `src/data/proofs/erdos-9/meta.json`. All meta counts match the Lean ground truth exactly:

| field            | Lean source | meta.json | match |
|------------------|-------------|-----------|:-----:|
| `lineCount`      | 253         | 253       | ✓     |
| `axiomCount`     | 2           | 2         | ✓     |
| `sorries`        | 0           | 0         | ✓     |
| `theoremCount`   | 7           | 7         | ✓     |
| `definitionCount`| 10          | 10        | ✓     |

**Axioms** (2, both correctly reflected in `assumptions` field):
- `schinzel_infinite : A.Infinite` (line 114)
- `form_in_every_arithmetic_progression` (line 157)

**Status sanity**: `axiomatized` / badge `axiom` — correct for an OPEN Erdős problem with 2 axiomatized deep results (Schinzel's infinitude + Erdős's covering-system obstruction). No structure-encoded assumptions detected.

Tracker bump only — no Lean source or meta changes.

## Test plan

- [x] `grep -c "^axiom "` in `proofs/Proofs/Erdos9Problem.lean` returns 2
- [x] `grep -c "sorry"` returns 0
- [x] `wc -l proofs/Proofs/Erdos9Problem.lean` returns 253
- [x] meta.json `axiomCount`, `lineCount`, `theoremCount`, `definitionCount`, `sorries` all match
- [x] No structure-encoded assumptions in the file (`NSAxioms`-style typeclasses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)