### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S15 ACT — 2×2 max-entropy bi-implication matrix completed (Docker 7743 jobs)

### DIFF
--- a/proofs/Proofs/ShannonEntropy.lean
+++ b/proofs/Proofs/ShannonEntropy.lean
@@ -453,6 +453,29 @@ theorem entropy_lt_log_card_iff_non_uniform {α : Type*} [Fintype α] [Decidable
     · exact hlt
     · exact absurd (hiff.mp heq x) hx
 
+-- Function-equality strengthening of `entropy_eq_log_card_iff_uniform`.
+-- Restates the pointwise RHS `∀ x, p x = (card α)⁻¹` as the function
+-- equality `p = (fun _ => (card α)⁻¹)`, sidestepping a one-step `funext`
+-- rewrite at downstream call sites in the Fano-converse chain.
+theorem entropy_eq_log_card_iff_eq_uniform {α : Type*} [Fintype α] [DecidableEq α]
+    [Nonempty α] {p : α → ℝ}
+    (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
+    shannonEntropy p = Real.log (Fintype.card α) ↔
+    p = (fun _ : α => (Fintype.card α : ℝ)⁻¹) :=
+  (entropy_eq_log_card_iff_uniform hp hsum).trans
+    ⟨funext, fun h x => congrFun h x⟩
+
+-- Function-inequality strengthening of `entropy_lt_log_card_iff_non_uniform`.
+-- Restates the pointwise existential RHS `∃ x, p x ≠ (card α)⁻¹` as the
+-- function inequality `p ≠ (fun _ => (card α)⁻¹)`, sidestepping a
+-- `push_neg` step at downstream call sites.
+theorem entropy_lt_log_card_iff_ne_uniform {α : Type*} [Fintype α] [DecidableEq α]
+    [Nonempty α] {p : α → ℝ}
+    (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
+    shannonEntropy p < Real.log (Fintype.card α) ↔
+    p ≠ (fun _ : α => (Fintype.card α : ℝ)⁻¹) :=
+  (entropy_lt_log_card_iff_non_uniform hp hsum).trans Function.ne_iff.symm
+
 -- ============================================================
 -- Log-Sum Inequality
 -- ============================================================


### PR DESCRIPTION
## Summary

S15 ACT for `shannon-channel-coding-oq-02-oq-01-oq-01`, shipping
**both** function-equality companion theorems pre-staged by the
two doc-only PREPs that merged in the 2026-05-15T18:02-18:04Z drain
wave (PR #19240 S12 PREP, PR #19269 S13 PREP). Completes the 2×2
max-entropy bi-implication matrix.

Single Docker iter, build-verified clean on the worktree HEAD before
push.

## Lean delta

`proofs/Proofs/ShannonEntropy.lean` +23 / -0 LOC:

| Theorem | Line | LOC | Proof |
|---------|-----:|----:|-------|
| `entropy_eq_log_card_iff_eq_uniform` | 460 | 6 | `(entropy_eq_log_card_iff_uniform hp hsum).trans ⟨funext, fun h x => congrFun h x⟩` |
| `entropy_lt_log_card_iff_ne_uniform` | 472 | 6 | `(entropy_lt_log_card_iff_non_uniform hp hsum).trans Function.ne_iff.symm` |

Plus a 4-line docstring on each (total 23 LOC, in-line with predicted +12-15 LOC body + +8-11 LOC docstrings).

Inserted between S9 (line 438) and the Log-Sum Inequality section
header (was line 457, now line 480). All downstream theorems shift
by +23 LOC (insertion above all subsequent decls); `chain_rule`
(was 611), `strong_subadditivity` (was 852), `entropy_chain_rule`
(was 1090), `entropy_subadditivity` (was 1129) unchanged otherwise.

## 2×2 max-entropy matrix (now closed)

| | Pointwise RHS | Function-equality RHS |
|---|---|---|
| Equality `H = log\|α\|` | S8 `entropy_eq_log_card_iff_uniform` (line 379) | **S12-light** `entropy_eq_log_card_iff_eq_uniform` (line 460) |
| Strict `H < log\|α\|` | S9 `entropy_lt_log_card_iff_non_uniform` (line 438) | **S13** `entropy_lt_log_card_iff_ne_uniform` (line 472) |

## Build verification (local worktree Docker)

- Command: `./proofs/scripts/docker-build.sh Proofs.ShannonEntropy`
- Result: `⚠ [7743/7743] Built Proofs.ShannonEntropy (14s)` → `Build completed successfully (7743 jobs).` → `=== Build succeeded ===`
- 0 new errors / 0 new warnings on insertion sites (lines 460, 472)
- 6 pre-existing linter warnings (lines 637, 688, 728, 868, 1116, 1153) are at unrelated sites and present on origin/main pre-edit — out of scope for this ACT (`unusedVariables` + `unusedSimpArgs`, not blockers)
- 0 sorries, 0 axioms introduced
- File LOC 1173 → 1196 (+23)

## Bearer pins (re-verified pre-push)

Mathlib lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0):

| Bearer | Origin | Status |
|--------|--------|--------|
| `funext` | Lean core `Init/Core.lean:2238` | ✓ stable |
| `congrFun` | Lean core primitive | ✓ stable |
| `Function.ne_iff` | `Mathlib/Logic/Function/Basic.lean:62` | ✓ stable |
| `entropy_eq_log_card_iff_uniform` (S8) | `proofs/Proofs/ShannonEntropy.lean:379` | ✓ this-file |
| `entropy_lt_log_card_iff_non_uniform` (S9) | `proofs/Proofs/ShannonEntropy.lean:438` | ✓ this-file |

No new Mathlib imports needed — `proofs/Proofs/ShannonEntropy.lean:17` imports `Mathlib` (full prelude).

Per S14 STATE-SYNC §2 (PR #19358 in flight): 0/18 drift events across
the 9 Mathlib + 9 in-file bearers since Session 26. This ACT re-touches
S8 + S9 anchors (this-file bearers); both signatures byte-identical to
S12 PREP §3 / S13 PREP §3.1 expected forms.

## v4.26.0 trap surface check

Per S14 STATE-SYNC §6: 0 of 9 S11 trap patterns apply to term-mode
`Iff.trans` insertions. Verified empirically by clean Docker build above:

- `mul_lt_mul_left` — not used
- `Real.log_div` / `Real.log_inv` — not used
- `(fun z => …)` lambdas in `have`-bound helpers — not used (anonymous lambda is in goal-RHS, not `have`)
- Implicit-`f` `Finset.single_le_sum` — not used
- `simp_rw [← Finset.sum_*]` chains — not used
- Triple-sum `linarith` — not used
- `congr 1; exact hlog` — not used
- `field_simp; ring` — not used
- Implicit-`(f := …)` annotations — not used (explicit `?f₁ := p`, `?f₂ := fun _ => …` from goal-RHS pin per S13 PREP §5)

## HoU safety (per S13 PREP §3.3 + S14 STATE-SYNC §3.4)

Both proofs unify via β-reduction only on goal-RHS-pinned lambdas:

- **S12-light**: `funext` takes `(∀ x, p x = c) → p = (fun _ => c)`; `congrFun` is the converse. Anonymous-constructor `⟨funext, fun h x => congrFun h x⟩` is canonical (no HoU step required).
- **S13**: `Function.ne_iff : f ≠ g ↔ ∃ x, f x ≠ g x` symmetrized to match S9's existential RHS shape. Lambda `?g := fun _ => (card α)⁻¹` pinned from goal-RHS (per S13 PREP §5 walkthrough). β-reduction only.

## Conflict-free guarantees with concurrent slug PRs

`gh pr list --repo rjwalters/lean-genius --search "shannon-channel-coding-oq-02-oq-01-oq-01 in:title" --state open` returns exactly **#19358** pre-push.

| File | This PR (S15) | #19358 (S14 STATE-SYNC) |
|------|---------------|--------------------------|
| `proofs/Proofs/ShannonEntropy.lean` | MODIFY (+23 LOC, lines 455-480) | UNTOUCHED |
| `research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/sessions/2026-05-16-s14-statesync-….md` | UNTOUCHED | CREATE |
| `research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md` | UNTOUCHED | MODIFY |
| `src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json` | UNTOUCHED | MODIFY |

Strict file-disjointness. Merge order between #19358 and this PR is irrelevant. state.md/JSON updates (currentState.iteration 11 → 14 in #19358, iteration → 15 to be ratified by next STATE-SYNC after this merge) are deferred to a downstream STATE-SYNC per the "Conflict-free guarantees" discipline.

## Test plan

- [x] `git fetch origin +refs/heads/main:refs/remotes/origin/main` confirms base SHA `8a3cda556b63aaf6e6184b4c968d1efbf9849b85` matches `gh api repos/rjwalters/lean-genius/commits/main --jq .sha`
- [x] Branch created from `origin/main` directly (not stale HEAD)
- [x] `gh pr list --search "shannon-channel-coding-oq-02-oq-01-oq-01 in:title" --state open` returns only #19358 pre-push (file-orthogonal)
- [x] `./proofs/scripts/docker-build.sh Proofs.ShannonEntropy` succeeds: `Built Proofs.ShannonEntropy (14s); Build completed successfully (7743 jobs); === Build succeeded ===`
- [x] 0 new linter warnings on lines 460 / 472 (insertion sites); 6 pre-existing warnings on unchanged unrelated lines
- [x] `grep -c "^theorem entropy_eq_log_card_iff_eq_uniform\|^theorem entropy_lt_log_card_iff_ne_uniform" proofs/Proofs/ShannonEntropy.lean` returns 2 (both inserted)
- [x] No `sorry` / `axiom` / `admit` introduced
- [x] No `.json` / `state.md` / `problem.md` / `knowledge.md` / sessions touched (deferred to next STATE-SYNC per discipline)
- [x] Worktree CWD per memory `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path` — Edit ran on `/Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-11/proofs/Proofs/ShannonEntropy.lean`
- [ ] Deployer merges this ACT; downstream callers in `ShannonChannelCoding.lean` can replace pointwise-quantified premises with function-equality premises (sidesteps `funext` / `push_neg` ceremony)

🤖 Generated by researcher-11 (Claude Opus 4.7)