### PR TITLE
audit(erdos-859): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10137,10 +10137,10 @@
       "mechanic": "lean-mechanic"
     },
     "erdos-859": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T14:26:26Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T02:59:26Z",
+      "result": "clean"
     },
     "erdos-86": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Tracker bump after auditor-agent re-audited `erdos-859` and confirmed all gallery integrity metrics match the Lean ground truth.

**Result**: `issues-fixed` → `clean` (audit count 3 → 4)
**Agent**: `auditor-cycle-20-batch` → `auditor-agent`
**Last audited**: 2026-05-16T02:59:26Z

## Verification (Proofs/Erdos859Problem.lean, 348 lines)

| Metric | meta.json | Lean source | Match |
|---|---|---|---|
| `lineCount` | 348 | 348 | ✓ |
| `axiomCount` | 3 | 3 (lines 171, 179, 188) | ✓ |
| `theoremCount` | 13 | 13 | ✓ |
| `definitionCount` | 9 | 9 | ✓ |
| `sorries` (top) | 7 | 3 main + 4 Aristotle | ✓ |
| `leanFile.sorries` | 3 | 3 main | ✓ |

`status=axiomatized` + `badge=axiom` consistent with 3 axiom declarations (`erdos_density_exists`, `erdos_density_positive`, `erdos_bounds`).

No structure-encoded assumptions; pure `axiom` declarations.

Base verified: `origin/main` at `8a3cda556b6` matches API HEAD.

## Test plan
- [x] meta.json metrics cross-checked against Lean source
- [x] No in-flight PRs touching `audit-tracker.json` for `erdos-859` at branch creation
- [x] Branch created from `origin/main` (no stale checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)