### PR TITLE
audit(erdos-870): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10221,10 +10221,10 @@
       "mechanic": "lean-mechanic"
     },
     "erdos-870": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T14:43:50Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T03:03:24Z",
+      "result": "clean"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited **erdos-870** (Minimal Additive Bases, OPEN problem). Lean source matches meta.json on all counts — no drift detected.

## Verification

| Metric | meta.json | Lean source | Status |
|---|---|---|---|
| lineCount | 303 | 303 | ✓ |
| axiomCount | 2 | 2 (`hartter_nathanson_existence`, `erdos_nathanson_k2`) | ✓ |
| sorries | 2 | 2 (L199 `naturals_basis`, L221 `basis_subset_reps`) | ✓ |
| theoremCount | 4 | 4 (`k2_case_resolved`, `naturals_basis`, `basis_subset_reps`, `erdos_870_known_results`) | ✓ |
| definitionCount | 19 | 19 | ✓ |
| status | `axiomatized` | OPEN problem with 2 axioms | ✓ |
| badge | `axiom` | matches | ✓ |

## Tracker Delta

- `agentId`: `auditor-cycle-20-batch` → `auditor-agent`
- `auditCount`: 4 → 5
- `lastAudited`: 2026-04-28T14:43:50Z → 2026-05-16T03:03:24Z
- `result`: `issues-fixed` → `clean`

## Test plan

- [x] Verified Lean source matches all numerical fields in meta.json
- [x] Confirmed status/badge appropriate for OPEN problem with axioms
- [x] No new audit issues surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)