### PR TITLE
audit(hurwitz-theorem-oq-04): clean re-audit — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11888,10 +11888,11 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-04": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-04-28T15:46:09Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 7,
+      "lastAudited": "2026-05-16T03:06:38Z",
+      "result": "clean",
+      "issues": []
     },
     "inclusion-exclusion": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

7th audit of `hurwitz-theorem-oq-04` (Hurwitz's Theorem: Connection to Exceptional Lie Groups). Last audited 2026-04-28 — oldest unaudited entry per `find-targets --next`.

## Verification

Compared `src/data/proofs/hurwitz-theorem-oq-04/meta.json` against `proofs/Proofs/HurwitzTheoremOQ04.lean`:

| Metric | meta.json | Lean source |
|---|---|---|
| lineCount | 1646 | 1646 ✓ |
| sorries | 0 | 0 ✓ (3 `sorry` matches all in comments/docstrings) |
| axiomCount | 0 | 0 ✓ |
| trueStubCount | n/a | 0 ✓ |

Status `verified` / badge `original` consistent: 0 sorries + 0 axioms.

`find-targets --json` reports `detectedIssues: []`.

## Test plan

- [x] meta.json reflects Lean source ground truth
- [x] No drift in lineCount / sorries / axioms
- [x] Status/badge consistent with axiom integrity policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)