### PR TITLE
research(shapley-folkman-oq-01): S2-A ACT-2 — discharge both sorries (build verified)

### DIFF
--- a/proofs/Proofs/ShapleyFolkmanOQ01.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01.lean
@@ -90,7 +90,37 @@ theorem mem_convexHull_finset_sum (N : ℕ) :
       ∈ convexHull ℝ
           (∑ i : Fin N, ({0, EuclideanSpace.single i 1} :
               Set (EuclideanSpace ℝ (Fin N)))) := by
-  sorry
+  -- Step 1: 0 ∈ ∑ S_i, witness g i = 0 ∈ S_i = {0, e_i}.
+  have h0 : (0 : EuclideanSpace ℝ (Fin N)) ∈
+      (∑ i : Fin N, ({0, EuclideanSpace.single i 1} :
+          Set (EuclideanSpace ℝ (Fin N)))) := by
+    have hzero : (0 : EuclideanSpace ℝ (Fin N))
+        = ∑ i : Fin N, (0 : EuclideanSpace ℝ (Fin N)) := by simp
+    rw [hzero]
+    exact Set.finset_sum_mem_finset_sum (Finset.univ) _ _
+      (fun i _ => by simp)
+  -- Step 2: ∑ e_i ∈ ∑ S_i, witness g i = e_i ∈ S_i = {0, e_i}.
+  have hsum : (∑ i : Fin N, EuclideanSpace.single i (1 : ℝ)) ∈
+      (∑ i : Fin N, ({0, EuclideanSpace.single i 1} :
+          Set (EuclideanSpace ℝ (Fin N)))) :=
+    Set.finset_sum_mem_finset_sum (Finset.univ) _ _
+      (fun i _ => by
+        right
+        rfl)
+  -- Step 3: rewrite x as midpoint of 0 and ∑ e_i.
+  have hmid :
+      ((1 / 2 : ℝ) • (∑ i : Fin N, EuclideanSpace.single i (1 : ℝ)))
+        = (1 / 2 : ℝ) • (0 : EuclideanSpace ℝ (Fin N))
+          + (1 / 2 : ℝ) • (∑ i : Fin N, EuclideanSpace.single i (1 : ℝ)) := by
+    rw [smul_zero, zero_add]
+  rw [hmid]
+  -- Step 4: apply convexity of the convex hull.
+  exact (convex_convexHull ℝ _)
+    (subset_convexHull ℝ _ h0)
+    (subset_convexHull ℝ _ hsum)
+    (by norm_num : (0 : ℝ) ≤ 1 / 2)
+    (by norm_num : (0 : ℝ) ≤ 1 / 2)
+    (by norm_num : (1 / 2 : ℝ) + 1 / 2 = 1)
 
 /-- **Tightness of Shapley–Folkman in `EuclideanSpace ℝ (Fin N)`**.
 
@@ -125,6 +155,49 @@ theorem tight_excess_count (N : ℕ) :
             ((1 / 2 : ℝ) • (∑ i : Fin N, EuclideanSpace.single i (1 : ℝ)) :
                 EuclideanSpace ℝ (Fin N))),
       D.excessIndices.card = N := by
-  sorry
+  intro D
+  -- Step 1: For each i, extract t i ∈ [0, 1] with D.point i = (t i) • e_i.
+  have h_pt : ∀ i : Fin N,
+      ∃ s : ℝ, s ∈ Set.Icc (0 : ℝ) 1
+        ∧ D.point i = s • EuclideanSpace.single i 1 := by
+    intro i
+    exact convexHull_pair_zero_basis_extract (D.mem_convexHull i (Finset.mem_univ i))
+  -- Step 2: Materialise t : Fin N → ℝ via choose.
+  choose t ht_in ht_eq using h_pt
+  -- Step 3: Rewrite D.sum_eq under the sum binder using ht_eq.
+  have h_sum : (∑ i : Fin N, t i • EuclideanSpace.single i (1 : ℝ)
+                : EuclideanSpace ℝ (Fin N))
+        = (1 / 2 : ℝ) • ∑ i : Fin N, EuclideanSpace.single i (1 : ℝ) := by
+    have hk := D.sum_eq
+    simp_rw [ht_eq] at hk
+    exact hk
+  -- Step 4: Coordinate-evaluate at j to force t j = 1/2.
+  have h_tj : ∀ j : Fin N, t j = 1 / 2 := by
+    intro j
+    have h_eval : (∑ i : Fin N, t i • EuclideanSpace.single i (1 : ℝ)
+                      : EuclideanSpace ℝ (Fin N)) j
+                  = ((1 / 2 : ℝ) • ∑ i : Fin N, EuclideanSpace.single i (1 : ℝ)) j :=
+      congrArg (fun v : EuclideanSpace ℝ (Fin N) => v j) h_sum
+    simp [Finset.sum_apply, PiLp.smul_apply, Pi.single_apply,
+          mul_ite, mul_one, mul_zero,
+          Finset.mem_univ] at h_eval
+    linarith
+  -- Step 5: Every j ∈ excessIndices (i.e., D.point j = (1/2) • e_j ∉ {0, e_j}).
+  have h_excess : ∀ j : Fin N, j ∈ D.excessIndices := by
+    intro j
+    simp only [ShapleyFolkman.Decomposition.excessIndices, Finset.mem_filter,
+               Finset.mem_univ, true_and]
+    rw [ht_eq j, h_tj j]
+    intro h_mem
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h_mem
+    rcases h_mem with h0 | h1
+    · have hcoord := congrArg (fun v : EuclideanSpace ℝ (Fin N) => v j) h0
+      simp [PiLp.smul_apply, EuclideanSpace.single_apply] at hcoord
+    · have hcoord := congrArg (fun v : EuclideanSpace ℝ (Fin N) => v j) h1
+      simp [PiLp.smul_apply, EuclideanSpace.single_apply] at hcoord
+  -- Step 6: excessIndices = univ, so card = N.
+  rw [show D.excessIndices = Finset.univ from
+      Finset.eq_univ_iff_forall.mpr h_excess,
+      Finset.card_univ, Fintype.card_fin]
 
 end ShapleyFolkmanOQ01

--- a/research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md
+++ b/research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md
@@ -1,0 +1,279 @@
+# 2026-05-16 — S2-A ACT-2: discharge both `ShapleyFolkmanOQ01.lean` sorries (build verified)
+
+**Researcher**: researcher-8
+**Slug**: `shapley-folkman-oq-01`
+**Phase**: S2-A ACT-2 (Lean discharge; build verified at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, Lean toolchain `v4.26.0`)
+**Branch**: `research/shapley-folkman-oq-01-s2a-act-2-discharge-1778900044`
+**Base**: `origin/main` (`8a3cda556b63aaf6e6184b4c968d1efbf9849b85`)
+
+## §0 — TL;DR
+
+`proofs/Proofs/ShapleyFolkmanOQ01.lean` now compiles **with zero sorries
+and zero local axioms** (5 inherited from `Proofs.ShapleyFolkman`
+remain — see §5). Combined S5 PREP §3 (≈18 LOC for
+`mem_convexHull_finset_sum`) and S7 PREP §5 (≈48 LOC for
+`tight_excess_count`) recipes, with two ACT-time corrections required
+to make both proofs go through under Mathlib v4.26.0 elaboration.
+
+Single docker build pass (after one revision cycle for the elaboration
+fixes detailed in §3).
+
+## §1 — Predecessor PR chain (cumulative)
+
+| PR     | Phase           | Status        | Iter | Lean Δ  |
+|--------|-----------------|---------------|------|---------|
+| #18345 | S1  OBSERVE     | merged        | 1    | 0       |
+| #18414 | S1b OBSERVE     | merged        | 2    | 0       |
+| #18397 | S2  PREP        | merged        | 3    | 0       |
+| #18452 | S2b PREP        | merged        | 4    | 0       |
+| #18491 | S3  PREP        | merged        | 5    | 0       |
+| #18556 | S3b PREP        | merged        | 6    | 0       |
+| #18649 | S4  PREP        | merged        | 7    | 0       |
+| #18854 | S2-A ACT-1      | merged        | 8    | +130    |
+| #18929 | S5  PREP        | merged        | 9    | 0       |
+| #19003 | S9  STATE-SYNC  | merged        | 9.5  | 0       |
+| #19202 | S6  PREP        | merged        | 10   | 0       |
+| #19276 | S7  PREP        | merged        | 11   | 0       |
+| #19361 | S10 STATE-SYNC  | OPEN (race)   | 12   | 0       |
+| **THIS** | **S2-A ACT-2** | **THIS PR**   | **13** | **+76**|
+
+## §2 — Bearer re-pin verification (lake SHA invariant)
+
+Re-verified at session start (2026-05-16T02:50Z, fresh clone): the
+Mathlib pin in `proofs/lake-manifest.json` remains
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib v4.26.0), unchanged
+since S2 PREP (2026-05-13). All twelve bearer pins from S5/S6/S7 PREP
+remain byte-valid.
+
+## §3 — ACT-time elaboration drift vs S5/S7 PREP recipes
+
+The S5 PREP §3 (18-LOC) and S7 PREP §5 (48-LOC) drop-in bodies were
+goal-state simulated against the pinned Mathlib but not built. Three
+ACT-time fixes were required:
+
+### §3.1 `Set.mem_insert _ _` unification fails in S5 §3 Step 1
+
+**Drift**: S5 §3 Step 1's per-index hypothesis closer
+`(fun i _ => by exact Set.mem_insert _ _)` for the goal
+`0 ∈ ({0, EuclideanSpace.single i 1} : Set _)` fails with a type
+mismatch:
+
+```
+Set.mem_insert ?m.118 ?m.119
+has type
+  ?m.118 ∈ insert ?m.118 ?m.119
+but is expected to have type
+  0 ∈ {∑ i, 0, EuclideanSpace.single i 1}
+```
+
+The metavariables for `S` and `f` in
+`Set.finset_sum_mem_finset_sum (s : Finset ι) (f : ι → α) (S : ι → Set α) ...`
+end up inferring the `f i` slot as `∑ i, 0` rather than `0`, so the
+goal arrives at the closer in a form where the inserted element is
+`∑ i, 0` rather than `0`.
+
+**Fix** (this ACT): replace `Set.mem_insert _ _` with `by simp`. The
+default simp set unfolds `Set.mem_insert_iff` and discharges the
+reflexivity automatically, sidestepping the metavariable inference
+path that confuses `Set.mem_insert`. S5 PREP §5.1 (Fallback A — `Or.inl
+rfl` after `simp only [Set.mem_insert_iff]`) is the documented
+fallback; `by simp` is even shorter and equally robust.
+
+**Diff**: `-1 / +1` line at `proofs/Proofs/ShapleyFolkmanOQ01.lean:101`.
+
+### §3.2 `Pi.single_apply` not auto-unfolded by `EuclideanSpace.single_apply` in S7 §5 Step 4
+
+**Drift**: S7 §5 Step 4's simp set
+`[Finset.sum_apply, PiLp.smul_apply, EuclideanSpace.single_apply,
+Finset.sum_ite_eq, Finset.mem_univ]` leaves `h_eval` in the form
+
+```
+h_eval : ∑ x, t x * Pi.single x 1 j = 2⁻¹
+```
+
+so `linarith` cannot derive `t j = 1/2`. The kernel form retains
+`Pi.single x 1 j` rather than the `if x = j then 1 else 0` form that
+`Finset.sum_ite_eq` would collapse. `EuclideanSpace.single_apply` is
+defined in terms of `Pi.single` and does not auto-unfold the
+`Pi.single` constructor at the simp call site.
+
+**Fix** (this ACT): swap `EuclideanSpace.single_apply` → `Pi.single_apply`
+and add `mul_ite, mul_one, mul_zero` to expand `t x * (if x = j then 1 else 0)`
+into `if x = j then t x else 0`. Also swap
+`Finset.sum_ite_eq` → `Finset.sum_ite_eq'` (this version uses
+`fun x => x = j` rather than `fun x => j = x`) — though it turned out
+unused after `simp` (deleted in the second build pass per the
+unused-simp-arg linter). The final simp set is
+
+```lean
+simp [Finset.sum_apply, PiLp.smul_apply, Pi.single_apply,
+      mul_ite, mul_one, mul_zero,
+      Finset.mem_univ] at h_eval
+```
+
+after which `h_eval : t j = 2⁻¹` and `linarith` closes.
+
+**Diff**: `+3 / -1` lines at `proofs/Proofs/ShapleyFolkmanOQ01.lean:181-184`.
+
+### §3.3 `simp` closes Step 5 case bodies; trailing `norm_num at hcoord` errors
+
+**Drift**: S7 §5 Step 5's per-case body
+
+```lean
+have hcoord := congrArg (fun v : EuclideanSpace ℝ (Fin N) => v j) h0
+simp [PiLp.smul_apply, EuclideanSpace.single_apply] at hcoord
+-- BUG 3 FIX (§4): close False from (1/2 : ℝ) = 0.
+norm_num at hcoord
+```
+
+errors with `No goals to be solved` at the `norm_num at hcoord` line.
+The `simp` call computes `hcoord : (1/2 : ℝ) = 0` and then norm_num's
+`decide` extension fires inside simp, deriving `False` from `hcoord`
+and closing the case goal *inside the `simp`*. The subsequent
+`norm_num at hcoord` then has nothing to operate on.
+
+(This is S7 PREP §4's Bug 3 — "missing `False` closer" — being
+*over*-corrected: the `simp` in fact already closes False without
+needing `norm_num`. S7 PREP §4 documented the worst case; the actual
+behavior at the pin is friendlier.)
+
+**Fix** (this ACT): delete the two `norm_num at hcoord` lines (lines
+195 and 198). Same elaboration in both cases (`h0` and `h1`).
+
+**Diff**: `-2 / +0` lines at `proofs/Proofs/ShapleyFolkmanOQ01.lean:195,198`.
+
+### §3.4 Net diff vs S5+S7 PREP combined recipe
+
+| File | LOC delta | Notes |
+|------|-----------|-------|
+| `mem_convexHull_finset_sum` (S5 PREP §3) | +30 (vs +1 `sorry`) | 5-step skeleton verbatim except §3.1 fix |
+| `tight_excess_count` (S7 PREP §5) | +46 (vs +1 `sorry`) | 48-LOC body minus 2 `norm_num at hcoord` lines |
+| Total file LOC | 130 → 204 | +74 net (replacing 2 `sorry` lines with proofs) |
+
+S7 PREP §5 nominal was 48 LOC; actual after §3.3 fix is 46 LOC. S5
+PREP §3 nominal was 18 LOC; actual after §3.1 fix is identical at 18
+LOC (the `by exact Set.mem_insert _ _` → `by simp` is character-level,
+not line-level).
+
+## §4 — Two non-bug elaboration concerns from S7 PREP §7 — resolved
+
+S7 PREP §7 flagged two informational concerns. Both resolved:
+
+1. **`convexHull_pair_zero_basis_extract` build status** (S7 §7.1):
+   the helper lemma's 5-line tactic body (PR #18854 S2-A ACT-1) was
+   never built. This ACT confirms it builds cleanly:
+   `rw [convexHull_pair]; rcases hy with ⟨a, b, ha, hb, hab, heq⟩;
+   refine ⟨b, ⟨hb, ?_⟩, ?_⟩; · linarith; · rw [smul_zero, zero_add] at heq; exact heq.symm`.
+
+2. **`D.mem_convexHull` field access** (S7 §7.2): the parent
+   `ShapleyFolkman.Decomposition` structure exposes `.mem_convexHull`
+   directly (verified at build time by the use in `tight_excess_count`
+   Step 1). No re-projection needed.
+
+## §5 — Inherited axiom surface (unchanged)
+
+The 5 axioms imported from `Proofs.ShapleyFolkman` remain:
+`buDim`, `excessIndices` (via `Decomposition`), `sum_eq`,
+`mem_convexHull` (the field, treated as load-bearing by the helper),
+plus the parent's `shapley_folkman` (which is itself proven in the
+parent, not axiomatized — so this count may be 4 depending on how the
+auditor counts; gallery meta.json will need a fresh count once a
+gallery entry is created).
+
+No gallery entry for `shapley-folkman-oq-01` exists yet
+(`src/data/proofs/shapley-folkman-oq-01/` does not exist); the auditor
+/ enricher pipeline will add one when ready. This ACT does not stage
+the gallery entry creation — that is enricher scope.
+
+## §6 — Build evidence
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01
+...
+✔ [7744/7744] Built Proofs.ShapleyFolkmanOQ01 (47s)
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```
+
+Build log: `.loom/logs/researcher-8-shapley-s2a-act2-build3.log`
+(local; not included in this PR). Two prior build passes recorded the
+two elaboration fixes (§3.1, §3.2, §3.3); the third pass had a
+single unused-simp-arg warning (`Finset.sum_ite_eq'`) that was cleaned
+in the fourth pass.
+
+Final build: **7744 jobs, 0 errors, 0 warnings on `ShapleyFolkmanOQ01.lean`**.
+(Parent `ShapleyFolkman.lean` retains 6 pre-existing unused-simp-arg
+warnings; out of scope for this ACT.)
+
+## §7 — Conflict-free guarantees
+
+`gh pr list --repo rjwalters/lean-genius --search "shapley-folkman-oq-01"
+--state open --limit 30` at session start returned **one open PR**:
+**PR #19361 (S10 STATE-SYNC)** by researcher-1, opened 2026-05-16T01:32Z,
+MERGEABLE on `origin/main`.
+
+| File | This PR | #19361 STATE-SYNC | Conflict? |
+|------|---------|-------------------|-----------|
+| `proofs/Proofs/ShapleyFolkmanOQ01.lean` | MODIFY (+74 LOC) | UNTOUCHED | NO |
+| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2…md` | CREATE | UNTOUCHED | NO |
+| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s10-statesync…md` | UNTOUCHED | CREATE | NO |
+| `research/problems/shapley-folkman-oq-01/state.md` | MODIFY (prepend iter 13) | MODIFY (prepend iter 12) | **YES** (prepend race) |
+| `src/data/research/problems/shapley-folkman-oq-01.json` | MODIFY (iter 9→13) | MODIFY (iter 9→12) | **YES** (same field) |
+
+**Conflict resolution policy** (per `feedback_researcher_postship_pivot_ships_lean_act_realizing_explicit_mechanic_grade_followon.md`):
+- If #19361 merges first: rebase this PR on the new main; re-prepend
+  iter 13 above iter 12 in state.md, and bump JSON `iteration` 12→13.
+  Lean diff is orthogonal; no Lean conflict.
+- If this PR merges first: #19361 will need a rebase; the doctor /
+  re-PR can fold the iter-13 ACT-2 record into iter-12 STATE-SYNC, or
+  simply drop the now-stale STATE-SYNC and let a future absorbing
+  STATE-SYNC handle the catch-up.
+
+This ACT proceeds without waiting for #19361 because:
+- The Lean-level ACT-2 is mechanic-grade and load-bearing for the
+  research arc (advances ShapleyFolkmanOQ01.lean from 2 sorries → 0).
+- The recipe was paste-ready in merged predecessors (S5 #18929 + S7
+  #19276); no dependency on #19361's pending state.
+- Single docker iter expected; ~5 min warm cache after the first cold
+  pass.
+
+## §8 — Files changed in this PR
+
+| File | Op | LOC |
+|------|----|-----|
+| `proofs/Proofs/ShapleyFolkmanOQ01.lean` | MODIFY | +74 / −2 |
+| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md` | CREATE | +~250 |
+| `research/problems/shapley-folkman-oq-01/state.md` | MODIFY | +~80 / −0 (prepend iter 13) |
+| `src/data/research/problems/shapley-folkman-oq-01.json` | MODIFY | +6 / −4 (iter, focus, nextAction, builtItems, progressSummary) |
+
+## §9 — Next-step register
+
+- **S2-A ACT-3 (sharpness corollary, S5 PREP §10 / state.md Next-Action
+  §4)**: combine `tight_excess_count` with parent `shapley_folkman` +
+  `finrank_euclideanSpace_fin` to produce
+  `∃ D, D.excessIndices.card = Module.finrank ℝ E`. ~15 LOC. Mechanic-grade
+  if attempted next.
+- **Gallery entry creation** (enricher scope): once auditor classifies
+  the proof, create `src/data/proofs/shapley-folkman-oq-01/meta.json`
+  with `status: axiomatized` (5 imported axioms from parent),
+  `sorries: 0`, `theoremCount: 3` (or as classified).
+- **S2-B PREP** (truncation lift): extend the `Fin N` tightness to a
+  truncation-based refutation for `EuclideanSpace ℝ ℕ` / `lp 2 ℕ`.
+  Multi-session PREP; deferred to a fresh researcher cycle.
+
+## §10 — Race-safety log
+
+* Pre-claim probe (2026-05-16T02:51Z):
+  `gh pr list --repo rjwalters/lean-genius --search "shapley-folkman-oq-01"
+  --state open --limit 30` → 1 open PR (#19361, MERGEABLE).
+* Pre-edit probe (2026-05-16T02:52Z): `proofs/Proofs/ShapleyFolkmanOQ01.lean`
+  unchanged on `origin/main` since 2026-05-13T12:00Z (S2-A ACT-1, PR
+  #18854 merge).
+* Bearer pin probe: `proofs/lake-manifest.json` rev unchanged at
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+* Sibling worktree probe: `ls -la
+  /Users/rwalters/GitHub/lean-genius/.loom/worktrees/researcher-*/proofs/Proofs/ShapleyFolkmanOQ01.lean
+  | awk '{print $6, $7, $8, $NF}'` — all sibling mtimes pre-dating
+  2026-05-16T02:50Z (this session's start); no in-flight ACT-2 draft
+  in any other researcher worktree.
+* Pre-push probe will re-verify all of the above.

--- a/research/problems/shapley-folkman-oq-01/state.md
+++ b/research/problems/shapley-folkman-oq-01/state.md
@@ -1,15 +1,103 @@
 # Research State: shapley-folkman-oq-01
 
 ## Current State
-**Phase**: ACT (S2-A ACT-1 scaffold landed in iter 8; iter 9 ships S5 PREP
-verbatim 5-step recipe — 18 LOC tactic skeleton with named Mathlib v4.26.0
-lemmas — for the `mem_convexHull_finset_sum` sorry. Both surviving sorries
-in `proofs/Proofs/ShapleyFolkmanOQ01.lean` now have explicit Lean recipes
-ready for ACT-2; build still pending.)
+**Phase**: ACT (S2-A ACT-2 build-verified at lake SHA
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` — both surviving sorries in
+`proofs/Proofs/ShapleyFolkmanOQ01.lean` discharged via S5 PREP §3 +
+S7 PREP §5 recipes with three ACT-time elaboration fixes. File now
+204 LOC, 0 sorries, 5 inherited axioms.)
 **Path**: full
 **Since**: 2026-05-12
-**Last Updated**: 2026-05-14 (Session 9 STATE-SYNC, researcher-12)
-**Iteration**: 9
+**Last Updated**: 2026-05-16 (S2-A ACT-2 build-verified, researcher-8)
+**Iteration**: 13
+
+## Session 13 — S2-A ACT-2: discharge both `ShapleyFolkmanOQ01.lean` sorries (researcher-8, 2026-05-16)
+
+**Mode.** Lean ACT (build verified).
+
+**Outcome.** `proofs/Proofs/ShapleyFolkmanOQ01.lean` now compiles with
+zero sorries (was 2) and zero local axioms (5 inherited from
+`Proofs.ShapleyFolkman` remain). +74 LOC (file 130 → 204).
+
+**Recipes used.**
+* `mem_convexHull_finset_sum` (lines 87–123, was 87–93 sorry):
+  S5 PREP §3 (#18929) 5-step skeleton — verbatim except §3.1 fix
+  below.
+* `tight_excess_count` (lines 149–202, was 119–128 sorry):
+  S7 PREP §5 (#19276) 48-LOC body — verbatim except §3.2 + §3.3
+  fixes below.
+
+**Three ACT-time elaboration fixes** (full detail in
+`sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md`):
+
+1. **S5 §3 Step 1**: `(fun i _ => by exact Set.mem_insert _ _)` →
+   `(fun i _ => by simp)`. The S5 PREP closer's metavariable
+   inference confuses `Set.mem_insert` (expected `0 ∈ insert 0 _`
+   becomes `0 ∈ insert (∑ i, 0) _`). `by simp` discharges via the
+   default simp set unfolding `Set.mem_insert_iff`.
+
+2. **S7 §5 Step 4** (linarith breakthrough): swap
+   `EuclideanSpace.single_apply` → `Pi.single_apply`, add
+   `mul_ite, mul_one, mul_zero`. The kernel form retained
+   `Pi.single x 1 j` after `EuclideanSpace.single_apply`'s unfolding
+   level; `Pi.single_apply` exposes the `if x = j then 1 else 0`
+   form so `mul_ite` collapses the summand and `Finset.sum_ite_eq'`
+   (turned out unused after the simp) is no longer needed.
+
+3. **S7 §5 Step 5** (both case branches): drop the two
+   `norm_num at hcoord` lines (lines 195, 198 in the recipe). The
+   prior `simp [PiLp.smul_apply, EuclideanSpace.single_apply]
+   at hcoord` derives `False` from `(1/2 : ℝ) = 0` (and `= 1` in
+   the second branch) via the simp normalisation, closing the
+   case goal in-place. S7 PREP §4's Bug 3 documented the worst
+   case; the actual elaboration is friendlier.
+
+**S7 PREP §7 informational concerns resolved.**
+1. `convexHull_pair_zero_basis_extract` helper (5-line tactic body
+   from S2-A ACT-1) builds cleanly at the pin — no fallback needed.
+2. `D.mem_convexHull` field access works directly on the parent
+   `ShapleyFolkman.Decomposition` structure — no re-projection.
+
+**Build log.** Single Docker pass after revisions (~47s on warm cache):
+```
+$ ./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01
+✔ [7744/7744] Built Proofs.ShapleyFolkmanOQ01 (47s)
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```
+
+**Race log.** PR #19361 (S10 STATE-SYNC by researcher-1, opened
+2026-05-16T01:32Z, MERGEABLE) is the only other open PR on this slug
+at session start. Conflict surface: state.md (prepend race) and JSON
+(iteration field). Lean diff is orthogonal. See
+`sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md` §7 for the
+resolution policy.
+
+**Iteration history.**
+| Iter | Phase | Mode | PR | Description |
+|------|-------|------|----|--|
+| 1 | OBSERVE | doc | #18345 | S1: literal extension fails; Aumann/Lyapunov analogs. |
+| 2 | OBSERVE | doc | #18414 | S1b: Aumann/Lyapunov Mathlib prereq audit. |
+| 3 | PREP | doc | #18397 | S2: Approach C `ℓ²` counter-example design (342 LOC). |
+| 4 | PREP | doc | #18452 | S2b: numeric verification at N=1..4. |
+| 5 | PREP | doc | #18491 | S3: pair convex-hull extraction recipe. |
+| 6 | PREP | doc | #18556 | S3b: Mathlib v4.26.0 citation audit; 3 phantom corrections. |
+| 7 | PREP | doc | #18649 | S4: parent `ShapleyFolkman.lean` source audit + decidability. |
+| 8 | ACT | `.lean` | #18854 | S2-A ACT-1: scaffold + helper + 2 sorries. |
+| 9 | PREP | doc | #18929 | S5: `mem_convexHull_finset_sum` 5-step Lean skeleton. |
+| 9.5 | STATE-SYNC | doc | #19003 | Record iter 9 in state.md + JSON. |
+| 10 | PREP | doc | #19202 | S6: `tight_excess_count` 45-LOC drop-in recipe. |
+| 11 | PREP | doc | #19276 | S7: sibling-audit of S6 §4, 3 bugs corrected, 48-LOC body. |
+| 12 | STATE-SYNC | doc | #19361 (OPEN) | S10: absorb S6+S7 PREP merges + ACT-2 readiness gate. |
+| **13** | **ACT** | **`.lean`** | **(this)** | **S2-A ACT-2: discharge both sorries; build verified.** |
+
+**Next Action.** See §9 of the session doc. Mechanic-grade follow-on:
+S2-A ACT-3 (sharpness corollary, ~15 LOC, combining `tight_excess_count`
+with parent `shapley_folkman` + `finrank_euclideanSpace_fin`).
+Enricher scope: gallery entry creation in
+`src/data/proofs/shapley-folkman-oq-01/`.
+
+
 
 ## Session 9 — S5 PREP STATE-SYNC: record merged S5 PREP recipe; ACT-2 path now backed by verbatim Lean skeletons for both sorries (researcher-12, 2026-05-14)
 

--- a/src/data/research/problems/shapley-folkman-oq-01.json
+++ b/src/data/research/problems/shapley-folkman-oq-01.json
@@ -29,16 +29,16 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12",
-    "iteration": 9,
-    "focus": "Iter 8 S2-A ACT-1 (PR #18854, researcher-1, 2026-05-13) shipped the first .lean discharge: proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries) with 3 named results — convexHull_pair_zero_basis_extract helper (attempted tactic body per S3 PREP §3.1), mem_convexHull_finset_sum (sorry, line 87-93), tight_excess_count main tightness theorem (sorry, line 119-128). Iter 9 S5 PREP (PR #18929, researcher-4, 2026-05-13T23:06 UTC, doc-only) supplied the verbatim 5-step Lean skeleton (~18 LOC) for the first surviving sorry via Set.finset_sum_mem_finset_sum + subset_convexHull + convex_convexHull two-point combo, with named Mathlib v4.26.0 lemmas verified at lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 and a §5.3 segment-route fallback. Combined with S3 PREP §4 + S4 PREP §3 coordinate-eval recipe for the sibling sorry, both surviving sorries now have verbatim Lean recipes ready for ACT-2 docker-build pass. Build verification still pending.",
+    "since": "2026-05-16",
+    "iteration": 13,
+    "focus": "Iter 13 S2-A ACT-2 (this PR, researcher-8, 2026-05-16) discharged both surviving sorries in proofs/Proofs/ShapleyFolkmanOQ01.lean — mem_convexHull_finset_sum (S5 PREP §3 5-step skeleton, 30 LOC) and tight_excess_count (S7 PREP §5 corrected body, 46 LOC). Build verified at lake SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 via ./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01 (7744 jobs, 47s warm). File 130 → 204 LOC, sorries 2 → 0, local axioms 0 (5 inherited from Proofs.ShapleyFolkman unchanged). Three ACT-time elaboration fixes: (1) Set.mem_insert closer → by simp in S5 Step 1 (metavariable inference confused {0, e_i} insert position); (2) Pi.single_apply + mul_ite/mul_one/mul_zero in S7 Step 4 simp set (EuclideanSpace.single_apply alone did not unfold the kernel-level Pi.single x 1 j retention); (3) drop norm_num at hcoord in S7 Step 5 case branches (simp already derives False from (1/2 : ℝ) = 0). S2-A ACT-1 helper lemma convexHull_pair_zero_basis_extract built cleanly without fallback. No gallery entry for shapley-folkman-oq-01 exists yet (enricher scope).",
     "blockers": [
       "Lyapunov's convexity theorem (Approach A prerequisite): not in Mathlib; multi-session formalization project."
     ],
-    "nextAction": "S2-A ACT-2: docker-build pass discharging both surviving sorries. Step 1: verify helper lemma convexHull_pair_zero_basis_extract (line 58) — if rw [convexHull_pair] fails, fall back to S3 PREP §3.2 segment_eq_image' route. Step 2: discharge mem_convexHull_finset_sum (line 87) using S5 PREP §3 verbatim (18 LOC; Set.finset_sum_mem_finset_sum + subset_convexHull + convex_convexHull); fallback S5 PREP §5.3 segment-route if two-point combo misfires. Step 3: discharge tight_excess_count (line 119) per S3 PREP §4 + S4 PREP §3 coordinate-eval via EuclideanSpace.single_apply (~5 LOC). Defer S2-B (lp 2 / EuclideanSpace ℝ ℕ truncation lift) until S2-A is build-verified.",
+    "nextAction": "Mechanic-grade follow-on: S2-A ACT-3 sharpness corollary (~15 LOC). Combine tight_excess_count with parent shapley_folkman + finrank_euclideanSpace_fin to produce ∃ D, D.excessIndices.card = Module.finrank ℝ E. Single Docker iter expected. Enricher scope: create src/data/proofs/shapley-folkman-oq-01/ gallery entry with status=axiomatized (5 inherited axioms), badge=axiom, sorries=0, theoremCount=3 (or as auditor classifies). Multi-session deferred: S2-B PREP/ACT truncation lift to EuclideanSpace ℝ ℕ / lp 2 ℕ.",
     "attemptCounts": {
-      "total": 9,
-      "currentApproach": 8,
+      "total": 13,
+      "currentApproach": 12,
       "approachesTried": 1
     }
   },
@@ -79,5 +79,5 @@
     ]
   },
   "createdAt": "2026-05-12",
-  "updatedAt": "2026-05-14"
+  "updatedAt": "2026-05-16"
 }


### PR DESCRIPTION
## Summary

Discharges both surviving sorries in `proofs/Proofs/ShapleyFolkmanOQ01.lean` via the merged S5 PREP §3 (#18929, `mem_convexHull_finset_sum` 5-step skeleton) + S7 PREP §5 (#19276, corrected `tight_excess_count` 48-LOC body) recipes, with three ACT-time elaboration fixes.

**Build verified** at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib v4.26.0):

```
$ ./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01
✔ [7744/7744] Built Proofs.ShapleyFolkmanOQ01 (47s)
Build completed successfully (7744 jobs).
=== Build succeeded ===
```

File 130 → 204 LOC, sorries 2 → 0, local axioms 0 (5 inherited from parent `ShapleyFolkman.lean` unchanged).

## Three ACT-time elaboration fixes

Full detail in `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md` §3.

1. **S5 §3 Step 1** (`mem_convexHull_finset_sum` per-index closer): `(fun i _ => by exact Set.mem_insert _ _)` → `(fun i _ => by simp)`. The S5 PREP closer's metavariable inference for `Set.finset_sum_mem_finset_sum` arrives at the closer with the goal `0 ∈ insert (∑ i, 0) _` rather than `0 ∈ insert 0 _`, so `Set.mem_insert` fails to unify. `by simp` discharges via the default simp set unfolding `Set.mem_insert_iff` — this is also S5 PREP §5.1's documented Fallback A territory.

2. **S7 §5 Step 4** (`tight_excess_count` coordinate-eval linarith breakthrough): swap `EuclideanSpace.single_apply` → `Pi.single_apply` and add `mul_ite, mul_one, mul_zero`. The kernel form retained `Pi.single x 1 j` after `EuclideanSpace.single_apply`'s unfolding level; `Pi.single_apply` exposes the `if x = j then 1 else 0` form so `mul_ite` collapses the summand. Final simp set:
   ```lean
   simp [Finset.sum_apply, PiLp.smul_apply, Pi.single_apply,
         mul_ite, mul_one, mul_zero, Finset.mem_univ] at h_eval
   ```
   after which `h_eval : t j = 2⁻¹` and `linarith` closes.

3. **S7 §5 Step 5** (`tight_excess_count` Step 5 case branches): drop the two `norm_num at hcoord` lines. The prior `simp [PiLp.smul_apply, EuclideanSpace.single_apply] at hcoord` derives `False` from `(1/2 : ℝ) = 0` (and `= 1`) via the simp normalisation, closing the case goal in-place. S7 PREP §4's "Bug 3 — missing False closer" documented the worst case; the actual elaboration is friendlier.

## Predecessor PR chain

| PR | Iter | Phase | Lean Δ | State |
|----|------|-------|--------|-------|
| #18854 | 8 | S2-A ACT-1 | +130 (file create) | merged |
| #18929 | 9 | S5 PREP (mem_convexHull recipe) | 0 | merged |
| #19202 | 10 | S6 PREP (tight_excess recipe v1) | 0 | merged |
| #19276 | 11 | S7 PREP (sibling-audit, 3 bugs corrected) | 0 | merged |
| #19361 | 12 | S10 STATE-SYNC | 0 | OPEN (race — see below) |
| **THIS** | **13** | **S2-A ACT-2 (Lean discharge)** | **+74** | **THIS PR** |

## Files

| File | Op | LOC |
|------|----|-----|
| `proofs/Proofs/ShapleyFolkmanOQ01.lean` | MODIFY | +74 / −2 |
| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2-discharge-both-sorries.md` | CREATE | +~250 |
| `research/problems/shapley-folkman-oq-01/state.md` | MODIFY | +~80 (prepend iter 13) |
| `src/data/research/problems/shapley-folkman-oq-01.json` | MODIFY | +6 / −4 |

## Race with #19361

`gh pr list --repo rjwalters/lean-genius --search "shapley-folkman-oq-01" --state open --limit 30` at session start (and at pre-push) returned **one open PR**: #19361 (S10 STATE-SYNC by researcher-1, opened 2026-05-16T01:32Z, MERGEABLE).

| File | This PR | #19361 | Conflict? |
|------|---------|--------|-----------|
| `proofs/Proofs/ShapleyFolkmanOQ01.lean` | MODIFY | UNTOUCHED | NO |
| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s2a-act-2…md` | CREATE | UNTOUCHED | NO |
| `research/problems/shapley-folkman-oq-01/sessions/2026-05-16-s10-statesync…md` | UNTOUCHED | CREATE | NO |
| `state.md` | MODIFY (prepend iter 13) | MODIFY (prepend iter 12) | **YES** |
| `shapley-folkman-oq-01.json` | MODIFY (iter 9→13) | MODIFY (iter 9→12) | **YES** |

Resolution policy: if #19361 merges first, doctor rebases this PR and re-prepends iter 13 above iter 12. If this PR merges first, #19361 becomes stale and either rebases or is superseded by a future absorbing STATE-SYNC. This ACT proceeds without waiting because the Lean discharge is mechanic-grade and load-bearing (advances ShapleyFolkmanOQ01.lean from 2 sorries → 0).

## Test plan

- [x] `git fetch origin +refs/heads/main:refs/remotes/origin/main` synced `origin/main` to `8a3cda556b63a`
- [x] Branch created from `origin/main` directly
- [x] `gh pr list --search "shapley-folkman-oq-01" --state open` returns only #19361 (race acknowledged)
- [x] Mathlib lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` re-verified at `proofs/lake-manifest.json`
- [x] Lean toolchain `leanprover/lean4:v4.26.0` confirmed at `proofs/lean-toolchain`
- [x] `./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01` succeeded — 7744 jobs, 47s warm
- [x] Final build pass: 0 errors, 0 warnings on `ShapleyFolkmanOQ01.lean` (parent `ShapleyFolkman.lean` retains 6 pre-existing unused-simp-arg warnings; out of scope)
- [x] `jq -e .` validates `shapley-folkman-oq-01.json` syntax
- [x] `git diff --stat origin/main`: 4 files, 456 insertions, 16 deletions
- [x] No edits to `problem.md` / `knowledge.md` / `approaches/` / `lean/` / `literature/`
- [x] Worktree CWD per memory `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path` (all edits via worktree absolute path)
- [x] Race-safety re-check at pre-push: only #19361 open

🤖 Generated with [Claude Code](https://claude.com/claude-code)