### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): Iter 4 ACT — literal Möbius–log identity (Docker-verified 7744 jobs)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
@@ -275,33 +275,51 @@ theorem sum_divisors_selbergLambda2_eq_log_sq {n : ℕ} (hn : 0 < n) :
       ArithmeticFunction.vonMangoldt_sum]
   ring
 
+/-- **Möbius–log identity (literal form, Iter 4)**: for `n > 0`,
+
+      Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d).
+
+    This is the Möbius-inverse of Iter 3's dual identity
+    `sum_divisors_selbergLambda2_eq_log_sq`. The proof applies
+    `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to the dual
+    identity, then re-indexes `divisorsAntidiagonal → divisors` via
+    `Nat.sum_divisorsAntidiagonal`. -/
+theorem selbergLambda2_eq_moebius_log_sq {n : ℕ} (hn : 0 < n) :
+    selbergLambda2 n =
+      ∑ d ∈ n.divisors,
+        ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) := by
+  have hiter3 : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2 :=
+    fun m hm => sum_divisors_selbergLambda2_eq_log_sq hm
+  have hinv :=
+    (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℝ)).mp hiter3 n hn
+  have hbridge :
+      ∑ x ∈ n.divisorsAntidiagonal,
+          ((ArithmeticFunction.moebius x.fst : ℝ) * (Real.log x.snd) ^ 2)
+        = ∑ d ∈ n.divisors,
+          ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) :=
+    Nat.sum_divisorsAntidiagonal
+      (fun a b => (ArithmeticFunction.moebius a : ℝ) * (Real.log b) ^ 2)
+  exact hinv.symm.trans hbridge
+
 /-! ## Future Work
 
 The remaining next-iteration deliverables are, in order of increasing
 difficulty:
 
-1. **`selbergLambda2_eq_moebius_log_sq`** (Iter 4, ~15 LOC): one
-   application of `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to
-   `sum_divisors_selbergLambda2_eq_log_sq` gives
-
-        Λ₂(n) = Σ_{(d,m) ∈ n.divisorsAntidiagonal} μ(d) · (log m)²    (n ≥ 1)
-
-   and `Nat.map_div_right_divisors` re-indexes to the canonical form
-
-        Λ₂(n) = Σ_{d ∣ n} μ(d) · (log (n/d))²    (n ≥ 1).
-
-2. **`selbergSum2_eq_two_n_log_n_plus_O`** (Iter 5–6): Selberg's symmetry formula
+1. **`selbergSum2_eq_two_n_log_n_plus_O`** (Iter 5–6): Selberg's symmetry formula
         S₂(N) = 2 N · log N + O(N).
    The error-term step requires summation by parts and quantitative
    control of Σ_{d ≤ x} μ(d) — but only its `O(x)` form, which is well
    within elementary bounds.
 
-3. **Tauberian step → PNT** (Iter 7+): Erdős–Selberg's combinatorial
+2. **Tauberian step → PNT** (Iter 7+): Erdős–Selberg's combinatorial
    finishing argument, the longest part of the elementary proof.
 
-Iteration 3 (this commit) closes the central algebraic step — Selberg's
-dual identity Σ_{d ∣ n} Λ₂(d) = (log n)² — together with the bridge
-lemma `vonMangoldtConv_eq_mul` that connects this file's explicit
-divisor-sum definition to Mathlib's `ArithmeticFunction` convolution. -/
+Iterations 3–4 (now closed) deliver the central algebraic identities of
+the Selberg–Erdős elementary PNT proof: Iter 3's dual form
+Σ_{d ∣ n} Λ₂(d) = (log n)² and Iter 4's Möbius-inverse literal form
+Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d), together with the bridge lemma
+`vonMangoldtConv_eq_mul` that connects this file's explicit divisor-sum
+definition to Mathlib's `ArithmeticFunction` convolution. -/
 
 end ChebyshevBoundsOQ04OQ01

--- a/research/problems/chebyshev-bounds-oq-04-oq-01/sessions/2026-05-16-s5-iter4-act-moebius-log-literal.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01/sessions/2026-05-16-s5-iter4-act-moebius-log-literal.md
@@ -1,0 +1,188 @@
+# S5 — Iter 4 ACT: literal Möbius–log identity (build verified 7744 jobs)
+
+**Date**: 2026-05-16T02:55Z
+**Researcher**: researcher-6
+**Phase**: ACT (Iter 4)
+**Scope**: 1 new Lean theorem (~24 lines) + bookkeeping (state.md + slug JSON + meta.json + this session doc); 0 sorries, 0 axioms added/removed; Docker-verified clean 7744 jobs.
+
+## §0 Summary
+
+This session ships **Iter 4**, closing the literal Möbius-inverted form of Selberg's auxiliary function on `n.divisors`:
+
+```
+selbergLambda2_eq_moebius_log_sq :
+  ∀ {n : ℕ}, 0 < n →
+    selbergLambda2 n =
+      ∑ d ∈ n.divisors, ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2)
+```
+
+This is the dual of Iter 3's `sum_divisors_selbergLambda2_eq_log_sq` under the Möbius-inversion iff `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`. With this iteration the algebraic core of Selberg-Erdős 1949 is complete; the next analytic step (Iter 5–6) is Selberg's symmetry formula `Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N)`.
+
+## §1 Pre-claim survey
+
+`gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open` at session start returned **0** OPEN PRs:
+
+| PR | Status | Merged at |
+|---|---|---|
+| #19092 (Iter 3 ACT) | MERGED | 2026-05-15T22:59:33Z |
+| #19171 (S4 PREP, doc-only) | MERGED | 2026-05-15T22:56:46Z |
+| #17689 (stale Iter 2 parallel) | CLOSED | — |
+
+The 3-way coordination plan from S5 PREP (`sessions/2026-05-15-s5-prep-deployer-stall-coord.md`) has fully resolved: the deployer drain wave merged Iter 3 + S4 PREP and closed the stale parallel attempt.
+
+`origin/main` HEAD at session start: `8a3cda556b6` (post-kepler-oq-04 audit tracker sync). The slug's Lean file `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` was at 312 LOC / 15 theorems / 0 sorries / 0 axioms (Iter 3 state).
+
+## §2 Plan execution (per S4 PREP §4.2)
+
+S4 PREP #19171 (researcher-8, merged 2026-05-15T22:56:46Z) laid out a precise proof sketch with API pins at Mathlib v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. This session implements that sketch verbatim modulo one elaboration adjustment (see §3 below).
+
+**Iter 4 theorem statement** (matches S4 PREP §4.1 exactly):
+
+```lean
+/-- **Möbius–log identity (literal form, Iter 4)**: for `n > 0`,
+
+      Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d).
+
+    This is the Möbius-inverse of Iter 3's dual identity
+    `sum_divisors_selbergLambda2_eq_log_sq`. The proof applies
+    `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to the dual
+    identity, then re-indexes `divisorsAntidiagonal → divisors` via
+    `Nat.sum_divisorsAntidiagonal`. -/
+theorem selbergLambda2_eq_moebius_log_sq {n : ℕ} (hn : 0 < n) :
+    selbergLambda2 n =
+      ∑ d ∈ n.divisors,
+        ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) := by
+  have hiter3 : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2 :=
+    fun m hm => sum_divisors_selbergLambda2_eq_log_sq hm
+  have hinv :=
+    (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℝ)).mp hiter3 n hn
+  have hbridge :
+      ∑ x ∈ n.divisorsAntidiagonal,
+          ((ArithmeticFunction.moebius x.fst : ℝ) * (Real.log x.snd) ^ 2)
+        = ∑ d ∈ n.divisors,
+          ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) :=
+    Nat.sum_divisorsAntidiagonal
+      (fun a b => (ArithmeticFunction.moebius a : ℝ) * (Real.log b) ^ 2)
+  exact hinv.symm.trans hbridge
+```
+
+**Step trace** (~8 LOC body):
+
+1. **`hiter3` lift**: rewrap Iter 3's signature `sum_divisors_selbergLambda2_eq_log_sq : {n : ℕ} → 0 < n → ...` as the `∀ m : ℕ, 0 < m → ...` form needed by Mathlib's iff (1 LOC).
+2. **`hinv` (Möbius inversion `.mp`)**: instantiate `R := ℝ`, apply `.mp` to `hiter3`, then specialize to the target `n` with hypothesis `hn`. Yields `∑ x ∈ n.divisorsAntidiagonal, (μ x.fst : ℝ) · (Real.log x.snd)^2 = selbergLambda2 n` (2 LOC).
+3. **`hbridge` (antidiagonal → divisors)**: invoke `Nat.sum_divisorsAntidiagonal` with `f := fun a b => (μ a : ℝ) · (Real.log b)^2`. Yields the LHS rewrite. The signature `f i.1 i.2 = f i (n/i)` matches `x.fst = x.1`, `x.snd = x.2` directly (4 LOC for the statement + 2 LOC for the discharge).
+4. **Close**: `hinv.symm.trans hbridge` chains `selbergLambda2 n = LHS_anti = RHS_div` (1 LOC).
+
+## §3 Build trap surfaced & recorded
+
+Per S4 PREP §4.3 Pitfall A and Pitfall E, the lift `hiter3` was a risk point. The actual fault mode encountered was a **mixed coercion-vs-namespace** issue not exactly matching either pitfall:
+
+**Initial draft** (omits ℕ annotation):
+```lean
+have hiter3 : ∀ m > 0, ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2 := ...
+```
+
+**Docker iter 1 output**:
+```
+error: Proofs/ChebyshevBoundsOQ04OQ01.lean:291:33:
+  Invalid field `divisors`: The environment does not contain `Real.divisors`
+  m
+has type
+  ℝ
+error: Proofs/ChebyshevBoundsOQ04OQ01.lean:292:54:
+  Application type mismatch: The argument `hm` has type `m > 0`
+  but is expected to have type `0 < ?m.78`
+  in the application `sum_divisors_selbergLambda2_eq_log_sq hm`
+```
+
+**Root cause**: `Real.log m` accepts both `m : ℕ` (via `Nat.cast`) and `m : ℝ` (directly). When the bound variable `m` is unannotated and the hypothesis body mentions `Real.log m`, Lean's elaborator prefers `m : ℝ` (no coercion needed). Then `m.divisors` becomes `Real.divisors` which doesn't exist, and downstream `sum_divisors_selbergLambda2_eq_log_sq hm` rejects `hm : m > 0` because it expects `0 < ?n : ℕ`.
+
+**Fix** (1-token addition):
+```lean
+have hiter3 : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2 := ...
+```
+
+The Mathlib iff `sum_eq_iff_sum_mul_moebius_eq` takes `∀ n > 0, P n` which is definitionally `∀ n, 0 < n → P n` — so the explicit form unifies with `.mp`'s expectations without further coercion gymnastics.
+
+**Docker iter 2**: `[7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (51s) — Build succeeded` against Mathlib v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+**General pattern recorded in state.md**: any iff-form Möbius-inversion lift in this file (Iter 5–6 will need at least one more) should type-annotate the bound `ℕ` variable explicitly when the consequent of the implication coerces through `Real.log` (or any `ℕ → ℝ` function the elaborator could resolve as `ℝ → ℝ`).
+
+## §4 Mathlib API used (verified at v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+| Lemma | File:Line | Form | Role |
+|---|---|---|---|
+| `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` | `Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:240` | `[NonAssocRing R]` iff between `∑ i ∈ n.divisors, f i = g n` and `∑ x ∈ n.divisorsAntidiagonal, (μ x.fst : R) * g x.snd = f n` | Möbius inversion |
+| `Nat.sum_divisorsAntidiagonal` (via `@[to_additive]` on `prod_divisorsAntidiagonal`) | `Mathlib/NumberTheory/Divisors.lean:543` | `∑ i ∈ n.divisorsAntidiagonal, f i.1 i.2 = ∑ i ∈ n.divisors, f i (n / i)` | Antidiagonal → divisors re-index |
+
+Both lemmas inherited via `import Mathlib` + `open ArithmeticFunction` (lines 68 + 73 of the slug Lean file). The `ArithmeticFunction.` prefix on `sum_eq_iff_sum_mul_moebius_eq` and `moebius` is explicit even after `open`, matching the local style (line 236 uses `ArithmeticFunction.mul_apply` similarly).
+
+`sum_divisors_selbergLambda2_eq_log_sq` (the Iter 3 dependency) is provided by PR #19092 (merged 2026-05-15T22:59:33Z) at line 257 of the same file with signature `{n : ℕ} (hn : 0 < n) : ∑ d ∈ n.divisors, selbergLambda2 d = (Real.log n) ^ 2`.
+
+## §5 File deltas
+
+| Path | +/- | Role |
+|---|---|---|
+| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | +24/-11 | new theorem `selbergLambda2_eq_moebius_log_sq` inserted after Iter 3's `sum_divisors_selbergLambda2_eq_log_sq`; Future Work docstring pruned (the now-closed Iter 4 entry removed; iteration tally updated from "Iteration 3 closes…" to "Iterations 3–4 are now closed…") |
+| `research/problems/chebyshev-bounds-oq-04-oq-01/state.md` | +56/-46 | phase advance to `ACT (Iter 4 Möbius–log literal form verified)`, iteration 4 → 5, new Iter 4 log entry, Race awareness updated for this PR, Next Action pivoted to Iter 5a (Selberg's symmetry formula leading term), Blockers refreshed |
+| `src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json` | + +/- | top-level phase update, `currentState` phase/since/iteration/focus/nextAction/attemptCounts refresh, `knownResults.proven` += selbergLambda2_eq_moebius_log_sq entry (open Möbius–log entry removed), `knowledge.progressSummary` + `builtItems` + `insights` + `nextSteps` + `mathlibGaps` Iter 4 entries appended, `leanFiles[3]` lineCount 206 → 325 + theoremCount 10 → 16 (the Iter 1 staleness flagged in S4 PREP §1.3 now corrected) |
+| `src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json` | + +/- | description extended for Iter 3 + Iter 4, `lineCount` 230 → 325, `theoremCount` 12 → 16, `originalContributions` += Iter 3 + Iter 4 entries (open Möbius–log gap removed), `conclusion.summary`/`implications`/`openQuestions` refresh, sections list += sec-dual-identity + sec-moebius-log + Future Work line-range correction |
+| `research/problems/chebyshev-bounds-oq-04-oq-01/sessions/2026-05-16-s5-iter4-act-moebius-log-literal.md` | + only (new) | this session doc |
+
+No overlap with any current open PR for any slug (verified pre-push via `gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open` returning `[]`).
+
+## §6 Iteration tally
+
+| Iter | Date | PR | Status | Deliverable |
+|---|---|---|---|---|
+| 1 | 2026-05-09 | #17658 | merged | Selberg-Erdős scaffold (Λ₂, S₂ defs + 10 routine lemmas) |
+| 2 | 2026-05-12 | #17690 | merged | Prime-value lemmas |
+| 3 | 2026-05-14 | #19092 | merged | Selberg dual identity `Σ_{d∣n} Λ₂(d) = (log n)²` |
+| 4 | 2026-05-16 | **this PR** | open | Literal Möbius–log form `Λ₂(n) = Σ_{d∣n} μ(d)·log²(n/d)` |
+
+## §7 Next action (Iter 5a — Selberg's symmetry formula, leading term)
+
+Goal: prove `Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N)`.
+
+Starting from Iter 4's `selbergLambda2_eq_moebius_log_sq`, sum both sides over `n ≤ N`:
+
+```
+Σ_{n ≤ N} Λ₂(n) = Σ_{n ≤ N} Σ_{d ∣ n} μ(d) · (log (n/d))²
+```
+
+Swap the sum order (Möbius hyperbola trick) to get
+
+```
+= Σ_{d ≤ N} μ(d) · Σ_{m ≤ N/d} (log m)²
+```
+
+The inner sum has explicit asymptotic (integration by parts on `log²`, cf. Tenenbaum I.6.2):
+
+```
+Σ_{m ≤ x} (log m)² = x · (log x)² − 2x · log x + 2x + O(log²x).
+```
+
+Scaling by `μ(d) / d` and using Mertens' bound `Σ_{d ≤ N} μ(d) / d = O(1)`, the leading-term contribution to `Σ_{n ≤ N} Λ₂(n)` is `−2N · log N · O(1)` — but with a coefficient computation that produces `+2N · log N` (sign cancellation; cf. Tenenbaum III.4 Theorem 4.1).
+
+Estimated PR delta: +80–120 LOC for the leading term alone (one theorem + maybe two helper lemmas). The `O(N)` error-term cleanup is comparable and would be Iter 5b.
+
+## §8 Honest scope statement
+
+This PR delivers **one** new theorem (~8 LOC body, ~24 LOC with docstring + signature). It does NOT:
+
+- Make any progress on the open `chebyshevPsi_asymptotic` axiom in the parent file — the elementary PNT proof's terminal goal — which remains exactly as Iter 3 left it.
+- Touch `src/data/research/candidates/` or the candidate pool.
+- Add any new axioms or sorries.
+- Modify Aristotle companion files or any sibling slug's content.
+
+Its value is the **dual** of Iter 3: combined, the two iterations now provide both forms of Selberg's identity (the dual `Σ Λ₂(d) = (log n)²` and the literal `Λ₂(n) = Σ μ(d) log²(n/d)`) — Iter 5 will use the literal form to launch the symmetry formula proof.
+
+## §9 Pre-push re-check checklist
+
+Per `feedback_researcher_preclaim_open_pr_check_avoids_s3_act_duplicate.md`:
+
+- [x] `gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open` re-run immediately before push: 0 OPEN PRs (no race).
+- [x] Docker build clean on final commit SHA.
+- [x] All JSON files validate via `python3 -m json.tool`.
+- [x] No untracked files outside the slug scope.
+- [x] Worktree absolute paths used for all Edit/Write (per `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path`).

--- a/research/problems/chebyshev-bounds-oq-04-oq-01/state.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01/state.md
@@ -2,15 +2,15 @@
 
 ## Current phase
 
-**Phase**: ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)
-**Iteration**: 4 (Iter 4 in planning — Möbius-inverted "original" form)
-**Since**: 2026-05-14T15:50:00Z
+**Phase**: ACT (Iter 4 Möbius–log literal form Λ₂(n) = Σ_{d|n} μ(d)·log²(n/d) verified)
+**Iteration**: 5 (Iter 5 in planning — Selberg's symmetry formula S₂(N) = 2N·log N + O(N))
+**Since**: 2026-05-16T02:55:00Z
 
-## Lean snapshot (post-Iter 3)
+## Lean snapshot (post-Iter 4)
 
 | File | LOC | Thm | Defs | Sorries | Axioms | Status |
 |---|---:|---:|---:|---:|---:|---|
-| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | 312 | 15 | 3 noncomputable | 0 | 0 | build-verified 7744 jobs at Iter 3 |
+| `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` | 325 | 16 | 3 noncomputable | 0 | 0 | build-verified 7744 jobs at Iter 4 |
 | `proofs/Proofs/ChebyshevBoundsOQ04.lean` | (parent) | — | — | 0 | 1 | parent's `chebyshevPsi_asymptotic` axiom remains the open target |
 
 OQ-04-OQ-01 is the **elementary Selberg–Erdős 1949 PNT** approach to
@@ -18,7 +18,41 @@ discharging that parent axiom (no complex analysis).
 
 ## Iteration log
 
-### Iter 3 — 2026-05-14 (this session, PR pending)
+### Iter 4 — 2026-05-16 (this session, PR pending)
+
+**Result**: Closes the literal Möbius–log form deferred from Iter 3:
+
+```
+Λ₂(n) = Σ_{d ∣ n} μ(d) · (Real.log (n/d : ℕ))²    (n > 0).
+```
+
+One new theorem (file grows 312 → 325 LOC, 15 → 16 theorems, 0 sorries,
+0 axioms maintained):
+
+- `selbergLambda2_eq_moebius_log_sq`: applies
+  `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` (Mathlib v4.26.0
+  `Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:240`) to Iter 3's
+  `sum_divisors_selbergLambda2_eq_log_sq`, then re-indexes
+  `divisorsAntidiagonal → divisors` via `Nat.sum_divisorsAntidiagonal`
+  (`Mathlib/NumberTheory/Divisors.lean:543`). Proof body ~8 LOC.
+
+**Build trap (worth recording for future Möbius-inversion lifts)**: the
+lift `∀ m > 0, ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2`
+must annotate `m : ℕ` explicitly. Without it, Lean infers `m : ℝ` from
+`Real.log m` (which accepts `ℝ` directly), then fails on `m.divisors`
+("Real.divisors" not found) and rejects
+`sum_divisors_selbergLambda2_eq_log_sq hm` (expects `0 < ?m : ℕ`). Fix
+is a single-token addition (`∀ m : ℕ, 0 < m → ...`). General pattern:
+any iff-form Möbius-inversion lift in this file should type-annotate
+the bound `ℕ` variable when the RHS coerces through `Real.log`.
+
+**Build verification**: `./proofs/scripts/docker-build.sh
+Proofs.ChebyshevBoundsOQ04OQ01` reports clean
+`[7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (51s)` after 2 Docker
+iterations on base SHA `8a3cda556b6` against Mathlib v4.26.0 pin
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+### Iter 3 — 2026-05-14 (PR #19092 merged 2026-05-15T22:59:33Z)
 
 **Result**: Closes the central algebraic step of the elementary PNT
 strategy — Selberg's **dual identity**
@@ -115,54 +149,70 @@ open target.
 
 ## Blockers
 
-None. Iter 4 (Möbius inversion of the dual identity to the "original"
-form `Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d)`) has clear Mathlib API
-(`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`), no exotic
-typeclass machinery needed.
+None. Iter 5 (Selberg's symmetry formula
+`Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N)`) is the next analytic step.
+Requires either: (a) a Mathlib-internal summation-by-parts framework
+specialised to `Λ`-weighted sums (Mathlib v4.26.0 has only
+`Finset.sum_Ioc_consecutive` and `summation_by_parts` lemmas in
+`Mathlib/Analysis/MeanInequalitiesPow.lean` — neither directly
+applicable), or (b) a hand-rolled `Abel`-style derivation using
+Iter 4's identity as the launching point. Recommended path is (b) for
+Iter 5a (the leading-term `2N log N`) and a separate Iter 5b for the
+`O(N)` error via the Möbius hyperbola bound.
 
 ## Next Action
 
-**Iter 4 — Möbius-inverted "original" form**: prove
+**Iter 5a — Selberg's symmetry formula, leading term**: prove
 
 ```
-Λ₂(n) = Σ_{d ∣ n} μ(d) · (log(n/d))²        (for n ≥ 1)
+Σ_{n ≤ N} Λ₂(n) = 2 N · log N + O(N).
 ```
 
-by applying `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to the
-Iter 3 dual identity `sum_divisors_selbergLambda2_eq_log_sq`, then
-re-indexing `divisorsAntidiagonal` → `divisors` via
-`Nat.map_div_right_divisors`. Estimated ~15 LOC.
+Starting from Iter 4's `selbergLambda2_eq_moebius_log_sq`, sum over
+`n ≤ N` and swap the order to get
 
-After Iter 4, the remaining roadmap is:
+```
+Σ_{n ≤ N} Λ₂(n) = Σ_{d ≤ N} μ(d) · Σ_{m ≤ N/d} (log m)²
+```
 
-- **Iter 5–6**: Selberg's symmetry formula
-  `Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N)` via summation by parts +
-  Möbius hyperbola bound for the error term.
-- **Iter 7+**: Erdős finishing argument bridging
-  `S₂(N) → ψ(N) ∼ N`, discharging `chebyshevPsi_asymptotic`.
+(this is the standard "Möbius hyperbola" trick). The inner sum
+`Σ_{m ≤ x} (log m)² = x · (log x)² − 2 x · log x + 2 x + O(log²x)`
+follows from integration by parts on `log²` (a smooth monotone-control
+estimate; cf. Tenenbaum I.6.2). The leading-term contribution
+`2 N · log N` comes from the `−2 x · log x` term times
+`Σ_{d ≤ N} μ(d) / d = O(1)` (Mertens). Estimated ~80–120 LOC for the
+leading term alone; the `O(N)` error term is comparable.
+
+After Iter 5, the remaining roadmap is:
+
+- **Iter 6**: clean up the error-term `O(N)` (Möbius hyperbola bound).
+- **Iter 7+**: Tauberian step (Erdős–Selberg combinatorial finishing
+  argument), discharging `chebyshevPsi_asymptotic`.
 
 ## Attempt Counts
 
-- Total attempts: 3 (Iter 1, Iter 2, Iter 3)
-- Current approach attempts: 3 (Selberg–Erdős elementary)
+- Total attempts: 4 (Iter 1, Iter 2, Iter 3, Iter 4)
+- Current approach attempts: 4 (Selberg–Erdős elementary)
 - Approaches tried: 1
 
-## Race awareness (this Iter 3)
+## Race awareness (this Iter 4)
 
 `gh pr list -R rjwalters/lean-genius --search "chebyshev-bounds-oq-04-oq-01 in:title" --state open`
-at session start returned 1 OPEN PR (#17689, CONFLICTING since
-2026-05-12T22:13Z, superseded by merged #17690). Iter 3 touches:
+at session start returned 0 OPEN PRs (Iter 3 PR #19092 merged
+2026-05-15T22:59:33Z, S4 PREP #19171 merged 2026-05-15T22:56:46Z,
+stale #17689 CLOSED). Iter 4 touches:
 
-- `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` (new lemmas in
-  Iter-3-marked section after `selbergLambda2_prime`; existing Iter 1/2
-  content unchanged except `Nat.divisors_prime` → `Nat.Prime.divisors`
-  at line 191)
-- `proofs/Proofs/ChebyshevBoundsOQ04.lean` (1-LOC parent regression
-  fix at line 298)
+- `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` (+24/-12 lines:
+  new theorem `selbergLambda2_eq_moebius_log_sq` added after
+  `sum_divisors_selbergLambda2_eq_log_sq`; Future Work docstring
+  pruned to remove the now-closed Iter 4 entry)
 - `src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json`
   (knowledge + currentState + top-level phase update)
 - `research/problems/chebyshev-bounds-oq-04-oq-01/state.md` (this file)
+- `src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json`
+  (`lineCount` 230 → 325, `theoremCount` 12 → 16, conclusion +
+  originalContributions updated for Iter 3 + Iter 4)
+- `research/problems/chebyshev-bounds-oq-04-oq-01/sessions/2026-05-16-s5-iter4-act-moebius-log-literal.md` (new)
 
-No file overlap with stale #17689 — the parent fix and rename are
-incidental to Iter 3, and #17689's "Iter 2 prime values" content was
-already merged via #17690 (verified during pre-claim race check).
+Pre-push re-check (per `feedback_researcher_preclaim_open_pr_check_avoids_s3_act_duplicate.md`):
+will re-run `gh pr list` immediately before `git push`.

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
@@ -2,7 +2,7 @@
     "id": "chebyshev-bounds-oq-04-oq-01",
     "title": "Toward an Elementary PNT (Selberg-Erdős): Λ₂ Framework",
     "slug": "chebyshev-bounds-oq-04-oq-01",
-    "description": "The OQ-04-OQ-01 follow-up question asks whether the axiom chebyshevPsi_asymptotic (ψ(n)/n → 1) of ChebyshevBoundsOQ04.lean can be discharged elementarily, in the spirit of Selberg's and Erdős's 1949 proofs of the Prime Number Theorem without complex analysis. This iteration scaffolds the Selberg-Erdős strategy: it defines the auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n), the partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n), and proves routine non-negativity, base-value, and monotonicity lemmas. Iteration 2 (2026-05-11) extends the framework with the prime-value lemmas vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0) and selbergLambda2_prime (Λ₂(p) = (log p)²) — the file's documented next-iteration deliverables. The Lean file remains axiom-free and adds 0 sorries; the central Selberg symmetry formula remains the next major target.",
+    "description": "The OQ-04-OQ-01 follow-up question asks whether the axiom chebyshevPsi_asymptotic (ψ(n)/n → 1) of ChebyshevBoundsOQ04.lean can be discharged elementarily, in the spirit of Selberg's and Erdős's 1949 proofs of the Prime Number Theorem without complex analysis. Iteration 1 (2026-05-09) scaffolds the Selberg-Erdős strategy: defines the auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n), the partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n), and proves routine non-negativity, base-value, and monotonicity lemmas. Iteration 2 (2026-05-11) adds the prime-value lemmas vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0) and selbergLambda2_prime (Λ₂(p) = (log p)²). Iteration 3 (2026-05-14) closes Selberg's dual identity Σ_{d|n} Λ₂(d) = (log n)² via three new theorems (bridge + convolution-in-sum + main identity). Iteration 4 (2026-05-16) closes the literal Möbius–log identity Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) via one application of ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq plus a divisorsAntidiagonal→divisors re-indexing (~8 LOC body). The Lean file remains axiom-free and sorry-free at 325 LOC / 16 theorems; the next analytic step is Selberg's symmetry formula S₂(N) = 2N · log N + O(N).",
     "meta": {
         "author": "Lean Genius",
         "date": "2026-05-09",
@@ -25,8 +25,8 @@
         "dateAdded": "2026-05-09",
         "axiomCount": 0,
         "assumptions": "No new axioms. The parent file ChebyshevBoundsOQ04.lean contributes 2 axioms (chebyshevPsi_asymptotic, pnt_equivalence) inherited via import; this OQ-04-OQ-01 file adds none of its own. The ultimate goal is to discharge chebyshevPsi_asymptotic by proving Selberg's symmetry formula and the Erdős-Selberg combinatorial finishing argument.",
-        "lineCount": 230,
-        "theoremCount": 12,
+        "lineCount": 325,
+        "theoremCount": 16,
         "definitionCount": 3,
         "additionalFiles": [],
         "originalContributions": [
@@ -36,8 +36,10 @@
             "Non-negativity lemmas: vonMangoldtConv_nonneg, selbergLambda2_nonneg, selbergSum2_nonneg via Finset.sum_nonneg + vonMangoldt_nonneg + Real.log_nonneg (with case-split on n = 0)",
             "Partial-sum recurrence selbergSum2_succ and monotonicity selbergSum2_mono via Finset.sum_le_sum_of_subset_of_nonneg",
             "Iteration 2 prime-value lemmas: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime and Finset.sum_pair) and selbergLambda2_prime (Λ₂(p) = (log p)² via vonMangoldt_apply_prime) — both axiom-free, sorry-free, completing the documented next-iteration deliverables #1 and #2",
+            "Iteration 3 lemmas: vonMangoldtConv_eq_mul (bridges the local divisor-sum definition to Mathlib's ArithmeticFunction.mul via Nat.map_div_right_divisors + Finset.sum_map + rfl), sum_divisors_vonMangoldtConv (Σ_{d|n} (Λ∗Λ)(d) = Σ_{d|n} Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log), and sum_divisors_selbergLambda2_eq_log_sq (the Selberg dual identity Σ_{d|n} Λ₂(d) = (log n)², combining the bridge with vonMangoldt_sum and Real.log_mul on divisor pairs) — all axiom-free, sorry-free",
+            "Iteration 4 lemma: selbergLambda2_eq_moebius_log_sq (the literal Möbius–log identity Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0). Proof applies ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (Möbius inversion for functions to a ring) to Iter 3's dual identity, then re-indexes divisorsAntidiagonal → divisors via Nat.sum_divisorsAntidiagonal — ~8 LOC body, axiom-free, sorry-free. Closes the Möbius–log Mathlib gap originally identified in Iter 1.",
             "Documented roadmap for the elementary PNT proof: Selberg symmetry formula (S₂(N) = 2N log N + O(N)) → Tauberian oscillation control → Erdős combinatorial finishing → ψ(n)/n → 1",
-            "Identification of three concrete Mathlib gaps: (i) no Selberg symmetry formula, (ii) no Möbius–log identity Σ_{d|n} μ(d) log²(n/d), (iii) no Λ₂-specific partial-summation framework"
+            "Remaining Mathlib gaps (after Iter 4): (i) no Selberg symmetry formula in Mathlib, (ii) no Λ-weighted summation-by-parts framework (Iter 5–6 will need either a hand-rolled Abel-style derivation or a new Mathlib contribution). The Möbius–log identity gap (Iter 1) is now closed locally by selbergLambda2_eq_moebius_log_sq."
         ]
     },
     "overview": {
@@ -59,12 +61,12 @@
         ]
     },
     "conclusion": {
-        "summary": "This iteration (2) extends the Selberg-Erdős scaffold with the prime-value lemmas vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0) and selbergLambda2_prime (Λ₂(p) = (log p)²). Combined with iteration 1's auxiliary function definition, partial sum, and non-negativity infrastructure, the file now establishes Λ₂'s value on primes — the simplest non-trivial computation and a prerequisite for the Möbius–log identity Λ₂ = μ ∗ log² that drives Selberg's symmetry formula. No new axioms are introduced; the parent's chebyshevPsi_asymptotic axiom remains the open target.",
-        "implications": "An elementary Lean formalization of PNT would be a milestone result: Mathlib currently has no PNT proof at all. With the prime-value lemmas now in place, the next analytic step is the Möbius–log identity, after which Selberg's symmetry formula (estimated ~1500 additional lines) and the Erdős combinatorial finishing argument complete the program. Concurrent work in the gallery on chebyshev-pnt-bridge already provides ψ ↔ π equivalences that would chain with this work for the full PNT statement.",
+        "summary": "Iterations 1–4 establish the algebraic core of the Selberg-Erdős 1949 elementary PNT proof in this file. Iter 1 (2026-05-09, PR #17658) scaffolds the framework with Λ₂ + S₂ definitions and routine non-negativity / monotonicity lemmas. Iter 2 (2026-05-12, PR #17690) adds the prime-value lemmas vonMangoldtConv_prime and selbergLambda2_prime. Iter 3 (2026-05-14, PR #19092) closes Selberg's dual identity Σ_{d|n} Λ₂(d) = (log n)² via three new theorems (bridge + convolution-in-sum + main identity). Iter 4 (2026-05-16, this PR) closes the literal Möbius–log identity Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) — the form that Selberg's symmetry formula will sum over — via one application of ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq plus a divisorsAntidiagonal→divisors re-indexing. The file is 325 LOC / 16 theorems / 0 sorries / 0 axioms. The parent's chebyshevPsi_asymptotic axiom remains the open terminal target.",
+        "implications": "An elementary Lean formalization of PNT would be a milestone result: Mathlib currently has no PNT proof at all. The algebraic core of Selberg-Erdős is now in place; the next analytic step is Selberg's symmetry formula S₂(N) = 2N · log N + O(N), which uses Iter 4's literal Möbius–log identity as its starting point. After Iter 5–6 the Tauberian/Erdős finishing argument completes the program. Concurrent work in the gallery on chebyshev-pnt-bridge already provides ψ ↔ π equivalences that would chain with this work for the full PNT statement.",
         "openQuestions": [
-            "Prove the Möbius–log identity Σ_{d ∣ n} μ(d) · log²(n/d) = Λ₂(n) for n ≥ 1 — provable from the standard expansion Λ = μ ∗ log via Möbius inversion",
-            "Prove Selberg's symmetry formula S₂(N) = 2N·log N + O(N) — the central analytic step of the elementary proof",
-            "Formalize the Erdős combinatorial finishing argument (lim sup |ψ(x)/x − 1| = 0 from the Tauberian inequality) — the longest portion of the elementary proof",
+            "Prove Selberg's symmetry formula S₂(N) = 2N·log N + O(N) — the central analytic step of the elementary proof, starting from Iter 4's literal Möbius–log identity via the standard order-swap (Möbius hyperbola) trick",
+            "Formalize the Tauberian inequality V(x) · log x ≤ (2/x) · Σ_{n ≤ x} V(x/n) · Λ(n) + O(1) where V(x) = |ψ(x) − x|/x",
+            "Formalize the Erdős combinatorial finishing argument (lim sup V(x) = 0 from the Tauberian inequality) — the longest portion of the elementary proof",
             "Discharge the parent axiom chebyshevPsi_asymptotic by chaining the above results"
         ]
     },
@@ -109,14 +111,28 @@
             "title": "Prime values",
             "startLine": 179,
             "endLine": 204,
-            "summary": "Iteration 2 lemmas: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.divisors_prime and Finset.sum_pair, using Λ(1) = 0 on both endpoints of the {1, p} divisor set) and selbergLambda2_prime (Λ₂(p) = (log p)² from the convolution lemma plus vonMangoldt_apply_prime). These close items #1 and #2 from Iteration 1's documented Future Work."
+            "summary": "Iteration 2 lemmas: vonMangoldtConv_prime ((Λ ∗ Λ)(p) = 0 via Nat.Prime.divisors and Finset.sum_pair, using Λ(1) = 0 on both endpoints of the {1, p} divisor set) and selbergLambda2_prime (Λ₂(p) = (log p)² from the convolution lemma plus vonMangoldt_apply_prime). These close items #1 and #2 from Iteration 1's documented Future Work."
+        },
+        {
+            "id": "sec-dual-identity",
+            "title": "Selberg's dual identity (Iter 3)",
+            "startLine": 206,
+            "endLine": 276,
+            "summary": "Iteration 3 lemmas: vonMangoldtConv_eq_mul (bridges the file's explicit divisor-sum definition vonMangoldtConv n = Σ_{d ∈ n.divisors} Λ(d)·Λ(n/d) to Mathlib's ArithmeticFunction.mul form via Nat.map_div_right_divisors + Finset.sum_map + rfl), sum_divisors_vonMangoldtConv (Σ_{d|n} (Λ∗Λ)(d) = Σ_{d|n} Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log, using ArithmeticFunction.vonMangoldt_mul_zeta + coe_mul_zeta_apply + mul_assoc), and the main deliverable sum_divisors_selbergLambda2_eq_log_sq (Σ_{d|n} Λ₂(d) = (Real.log n)² for n > 0, combining the bridge with vonMangoldt_sum and Real.log_mul on divisor pairs)."
+        },
+        {
+            "id": "sec-moebius-log",
+            "title": "Möbius–log literal identity (Iter 4)",
+            "startLine": 278,
+            "endLine": 302,
+            "summary": "Iteration 4 lemma: selbergLambda2_eq_moebius_log_sq (the literal form Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0). Proof: lift Iter 3's dual identity to the ∀ m > 0 form (with explicit m : ℕ annotation to avoid Real.log coercion ambiguity), apply ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (.mp direction), then bridge antidiagonal → divisors via Nat.sum_divisorsAntidiagonal — ~8 LOC body. Closes the Möbius–log Mathlib gap originally identified in Iter 1's roadmap."
         },
         {
             "id": "sec-future-work",
             "title": "Future Work (docstring)",
-            "startLine": 206,
-            "endLine": 228,
-            "summary": "Documents the remaining roadmap after iteration 2: the Möbius–log identity Λ₂ = μ ∗ log² (provable from Λ = μ ∗ log), Selberg's symmetry formula S₂(N) = 2N log N + O(N), and the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic."
+            "startLine": 304,
+            "endLine": 322,
+            "summary": "Documents the remaining roadmap after iteration 4: Selberg's symmetry formula S₂(N) = 2N log N + O(N) (Iter 5–6, the central analytic step starting from Iter 4's identity via the Möbius hyperbola order-swap trick), then the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic (Iter 7+)."
         }
     ],
     "crossReferences": [

--- a/src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json
+++ b/src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "chebyshev-bounds-oq-04-oq-01",
   "title": "Elementary Proof of Full PNT from Chebyshev Bounds",
-  "phase": "ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)",
+  "phase": "ACT (Iter 4 Möbius–log literal form Λ₂(n) = Σ_{d|n} μ(d)·log²(n/d) verified)",
   "status": "in-progress",
   "tier": "S",
   "path": "full",
@@ -21,10 +21,10 @@
       "ChebyshevBoundsOQ04.chebyshevPsi_doubling_lower: ψ(2n) − ψ(n) ≥ log(n+1) for n ≥ 1 (Bertrand)",
       "ChebyshevBoundsOQ04OQ01.selbergLambda2: definition of Selberg's auxiliary function (Iter 1)",
       "ChebyshevBoundsOQ04OQ01.selbergSum2: definition of partial Selberg sum (Iter 1)",
-      "ChebyshevBoundsOQ04OQ01.selbergLambda2_nonneg, selbergSum2_nonneg, selbergSum2_mono (Iter 1)"
+      "ChebyshevBoundsOQ04OQ01.selbergLambda2_nonneg, selbergSum2_nonneg, selbergSum2_mono (Iter 1)",
+      "ChebyshevBoundsOQ04OQ01.selbergLambda2_eq_moebius_log_sq: literal Möbius–log identity Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0 (Iter 4, ~8-LOC body via sum_eq_iff_sum_mul_moebius_eq + Nat.sum_divisorsAntidiagonal)"
     ],
     "open": [
-      "Möbius–log identity: Σ_{d ∣ n} μ(d) · log²(n/d) = Λ₂(n) for n ≥ 1",
       "Selberg's symmetry formula: Σ_{n ≤ N} Λ₂(n) = 2N·log N + O(N)",
       "Tauberian inequality: V(x)·log x ≤ (2/x) Σ_{n ≤ x} V(x/n) Λ(n) + O(1) where V(x) = |ψ(x) − x|/x",
       "Erdős combinatorial finishing: lim sup V(x) = 0 from the Tauberian inequality",
@@ -33,20 +33,20 @@
     "goal": "Replace the axiom ChebyshevBoundsOQ04.chebyshevPsi_asymptotic with a Lean 4 proof following Selberg-Erdős 1949 elementary methods (no complex analysis)."
   },
   "currentState": {
-    "phase": "ACT (Iter 3 dual identity Σ_{d|n} Λ₂(d) = (log n)² verified)",
-    "since": "2026-05-14T15:50:00.000Z",
-    "iteration": 4,
-    "focus": "Iter 3 (2026-05-14, build verified 7744 jobs) closes the central algebraic step of Selberg's elementary PNT strategy: the dual identity Σ_{d|n} Λ₂(d) = (Real.log n)² for n > 0. Three new theorems: vonMangoldtConv_eq_mul (bridge — local divisor-sum definition matches Mathlib's ArithmeticFunction.mul via Nat.map_div_right_divisors), sum_divisors_vonMangoldtConv (Σ (Λ∗Λ)(d) = Σ Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log), and sum_divisors_selbergLambda2_eq_log_sq (combines them with vonMangoldt_sum and Real.log_mul). The 'original' Λ₂(n) = Σ μ(d)·log²(n/d) form is one Möbius-inversion step away (sum_eq_iff_sum_mul_moebius_eq) — deferred to Iter 4. ChebyshevBoundsOQ04OQ01.lean now 312 LOC, 15 theorems, 3 noncomputable defs, 0 sorries, 0 axioms. Side effect: this build surfaced TWO silent Mathlib v4.26.0 regressions in the parent ChebyshevBoundsOQ04.lean (last successful build was Iter 2 merge 2026-05-12): (A) line 298 `ring` no longer closes `4^m = 2^(2*m)` (tactic suggestion `ring_nf` would not help either since `ring` treats `4` and `2` as distinct atoms — fixed by `rw [pow_mul]; rfl`); (B) `Nat.divisors_prime` renamed to `Nat.Prime.divisors` (dot-method form) — fixed inline in vonMangoldtConv_prime. Both fixes 1-LOC; bundled in this PR to keep the slug build-clean.",
+    "phase": "ACT (Iter 4 Möbius–log literal form Λ₂(n) = Σ_{d|n} μ(d)·log²(n/d) verified)",
+    "since": "2026-05-16T03:00:00.000Z",
+    "iteration": 5,
+    "focus": "Iter 4 (2026-05-16, build verified 7744 jobs, this PR) closes the literal Möbius-inversion form Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0, deferred from Iter 3. One new theorem selbergLambda2_eq_moebius_log_sq applies ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (Moebius.lean:240) to Iter 3's sum_divisors_selbergLambda2_eq_log_sq, then re-indexes divisorsAntidiagonal → divisors via Nat.sum_divisorsAntidiagonal (Divisors.lean:543). Proof body ~8 LOC. ChebyshevBoundsOQ04OQ01.lean grows 312 → 325 LOC, 15 → 16 theorems, 0 sorries, 0 axioms maintained. Build trap surfaced (now documented in state.md): the ∀ m > 0 lift hypothesis must annotate m : ℕ explicitly — without it Lean infers m : ℝ from Real.log m and fails on m.divisors. Iter 5 is now the next analytic step: Selberg's symmetry formula S₂(N) = 2N · log N + O(N) via the Möbius hyperbola trick on Iter 4's identity (~80–120 LOC for the leading term).",
     "blockers": [],
-    "nextAction": "Iter 4: prove the 'original' form Λ₂(n) = Σ_{d ∣ n} μ(d) · log²(n/d) for n ≥ 1 by applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq to sum_divisors_selbergLambda2_eq_log_sq, then re-indexing divisorsAntidiagonal → divisors via Nat.map_div_right_divisors. Estimated ~15 LOC. After that, Iter 5–6 attacks Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N·log N + O(N) using summation by parts and Möbius hyperbola bounds.",
+    "nextAction": "Iter 5a: Selberg's symmetry formula leading term Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N). Starting from selbergLambda2_eq_moebius_log_sq, sum over n ≤ N and swap order: Σ_{n ≤ N} Λ₂(n) = Σ_{d ≤ N} μ(d) · Σ_{m ≤ N/d} (log m)² (Möbius hyperbola). Inner sum Σ_{m ≤ x} (log m)² = x · (log x)² − 2x · log x + 2x + O(log²x) by integration by parts on log² (cf. Tenenbaum I.6.2). Leading term −2x · log x scaled by Σ_{d ≤ N} μ(d)/d = O(1) (Mertens) gives 2N · log N. Estimated ~80–120 LOC.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Iter 3 (2026-05-14, build verified 7744 jobs) closes the central algebraic step — Selberg's dual identity Σ_{d|n} Λ₂(d) = (log n)² for n > 0. Three new theorems added: vonMangoldtConv_eq_mul (connects the file's local divisor-sum definition of Λ∗Λ to Mathlib's ArithmeticFunction.mul via Nat.map_div_right_divisors); sum_divisors_vonMangoldtConv (Σ_{d|n} (Λ∗Λ)(d) = Σ_{d|n} Λ(d)·log(n/d) via (Λ∗Λ)∗ζ = Λ∗(Λ∗ζ) = Λ∗log); sum_divisors_selbergLambda2_eq_log_sq (combines them with ArithmeticFunction.vonMangoldt_sum and Real.log_mul). The 'original' Möbius-inversion form Λ₂(n) = Σ μ(d)·log²(n/d) is one application of sum_eq_iff_sum_mul_moebius_eq away (Iter 4). File grows 230 → 312 LOC, 12 → 15 theorems, 0 sorries, 0 axioms. INCIDENTAL: Iter 3 build surfaced two silent Mathlib v4.26.0 regressions in untouched parent ChebyshevBoundsOQ04.lean (last successful build was Iter 2 merge 2026-05-12): (A) `ring` no longer closes `4^m = 2^(2*m)` at line 298 (elaborator treats `4` and `2` as distinct atoms; `ring_nf` suggestion does not help) — fixed with `rw [pow_mul]; rfl`; (B) `Nat.divisors_prime` renamed to `Nat.Prime.divisors` (dot-method form) — fixed inline. Both 1-LOC, bundled in this research PR so the slug stays build-clean. Iter 2 (2026-05-12T00:48Z, PR #17690 merged) closed Iter 1 next-iteration deliverables #1-2: vonMangoldtConv_prime and selbergLambda2_prime. Iter 1 (2026-05-09, PR #17658): scaffolded the Selberg-Erdős 1949 elementary PNT strategy (Λ₂ + S₂ defs + 10 routine lemmas).",
+    "progressSummary": "Iter 4 (2026-05-16, build verified 7744 jobs, this PR) closes the literal Möbius-inversion form Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0, deferred from Iter 3. One new theorem selbergLambda2_eq_moebius_log_sq applies ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:240, v4.26.0) to Iter 3's sum_divisors_selbergLambda2_eq_log_sq, then re-indexes the resulting divisorsAntidiagonal sum back to a divisors sum via Nat.sum_divisorsAntidiagonal (Mathlib/NumberTheory/Divisors.lean:543). Proof body ~8 LOC (lift hypothesis + .mp + Nat.sum_divisorsAntidiagonal + symm.trans). File grows 312 → 325 LOC, 15 → 16 theorems, 0 sorries, 0 axioms maintained. Iter 3 (2026-05-14, PR #19092 merged 2026-05-15T22:59:33Z) closed the dual identity Σ_{d|n} Λ₂(d) = (log n)². Iter 2 (2026-05-12, PR #17690 merged) closed the prime-value lemmas. Iter 1 (2026-05-09, PR #17658 merged) scaffolded the Selberg-Erdős 1949 elementary PNT strategy.",
     "builtItems": [
       "Proofs/ChebyshevBoundsOQ04OQ01.lean — Iter 1 (PR #17658) + Iter 2 (PR #17690): 230 lines, 12 theorems, 3 noncomputable defs, 0 sorries, 0 axioms",
       "vonMangoldtConv : ℕ → ℝ — Dirichlet convolution Λ ∗ Λ as explicit divisor sum (Iter 1)",
@@ -61,7 +61,8 @@
       "Iter 3 lemma (this PR): sum_divisors_vonMangoldtConv — Σ_{d|n} vonMangoldtConv d = Σ_{d|n} Λ(d) · log(n/d) using (Λ*Λ)*ζ = Λ*(Λ*ζ) = Λ*log (ArithmeticFunction.vonMangoldt_mul_zeta + coe_mul_zeta_apply + mul_assoc, ~7 LOC).",
       "Iter 3 lemma (this PR): sum_divisors_selbergLambda2_eq_log_sq — Σ_{d|n} selbergLambda2 d = (Real.log n)² for n > 0 (the central Selberg dual identity; combines the bridge with vonMangoldt_sum and Real.log_mul on divisor pairs, ~20 LOC).",
       "Iter 3 incidental fix (this PR): ChebyshevBoundsOQ04.lean:298 `by ring` → `by rw [pow_mul]; rfl` to close `4^m = 2^(2*m)` (Mathlib v4.26.0 ring regression; ring treats 4 and 2 as distinct atoms).",
-      "Iter 3 incidental fix (this PR): ChebyshevBoundsOQ04OQ01.lean:191 `Nat.divisors_prime hp` → `Nat.Prime.divisors hp` (Mathlib v4.26.0 renamed to dot-method form)."
+      "Iter 3 incidental fix (this PR): ChebyshevBoundsOQ04OQ01.lean:191 `Nat.divisors_prime hp` → `Nat.Prime.divisors hp` (Mathlib v4.26.0 renamed to dot-method form).",
+      "Iter 4 lemma (this PR): selbergLambda2_eq_moebius_log_sq — Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0. Proof: lift Iter 3 to ∀ m : ℕ, 0 < m → Σ ... = (Real.log m)², apply .mp of ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq, bridge antidiagonal→divisors via Nat.sum_divisorsAntidiagonal, then symm.trans (~8 LOC body)."
     ],
     "insights": [
       "Selberg's Λ₂ identity Λ_2 = μ ∗ log² (where ∗ is Dirichlet convolution and μ is Möbius) reduces the elementary PNT proof to Möbius-function manipulations of log² — this is the dimensional reduction that bypasses complex analysis entirely.",
@@ -73,20 +74,23 @@
       "Iter 3 proof structure: the Selberg dual identity Σ_{d|n} Λ₂(d) = (log n)² has a fully elementary proof in ~30 LOC once the bridge is in place. The key algebraic step is Σ_{d|n} Λ(d)·log(d) + Σ_{d|n} Λ(d)·log(n/d) = log n · Σ_{d|n} Λ(d) — which folds via Finset.sum_add_distrib (forward) + Real.log_mul applied to (d, n/d) pairs with d > 0 and n/d > 0 (forced by d ∈ n.divisors and n > 0) + Nat.mul_div_cancel'. Then ArithmeticFunction.vonMangoldt_sum gives log n · log n = (log n)².",
       "Iter 3 trap (Real.log + exact_mod_cast incompatibility): when proving `Real.log (↑d * ↑(n/d)) = Real.log ↑n`, the natural attempt `congr 1; push_cast; exact_mod_cast Nat.mul_div_cancel' hdvd` fails because exact_mod_cast cannot see through Real.log. Cleaner pattern: rewrite the entire argument chain in one shot, `rw [← Real.log_mul hd_ne hnd_ne, ← Nat.cast_mul, Nat.mul_div_cancel' hdvd]`, which combines the two logs, lifts the cast to ℕ, then applies the division identity directly. No congr / push_cast / exact_mod_cast needed.",
       "Mathlib v4.26.0 surface delta (Iter 3 build surfaced): `Nat.divisors_prime hp` is GONE in v4.26.0 — replaced by the dot-method form `Nat.Prime.divisors hp` (or equivalently `hp.divisors`) at Mathlib/NumberTheory/Divisors.lean:416. This silent rename affects ALL Iter 2 prime-value lemmas in build-pending chains. Pre-claim Docker baseline is mandatory: the slug had been 'build verified' at Iter 2 merge (2026-05-12T00:48Z) but Mathlib's tracked revision evolved in the intervening 2 days.",
-      "Mathlib v4.26.0 surface delta (Iter 3 build surfaced): `ring` no longer closes `4^m = 2^(2*m)` even with `ring_nf` suggestion — the elaborator treats `4` and `2^2` as distinct atoms in ring-normalization. Surgical fix: `rw [pow_mul]; rfl` (pow_mul : a^(m*n) = (a^m)^n unfolds the RHS to (2^2)^m = 4^m by definitional reduction). The pattern is generic for any `c^k = b^(j*k)` where c = b^j is definitionally true in ℕ. Applies to many Chebyshev/central-binomial proofs that bound via `4^m ≤ choose(2m+1, m)` style estimates."
+      "Mathlib v4.26.0 surface delta (Iter 3 build surfaced): `ring` no longer closes `4^m = 2^(2*m)` even with `ring_nf` suggestion — the elaborator treats `4` and `2^2` as distinct atoms in ring-normalization. Surgical fix: `rw [pow_mul]; rfl` (pow_mul : a^(m*n) = (a^m)^n unfolds the RHS to (2^2)^m = 4^m by definitional reduction). The pattern is generic for any `c^k = b^(j*k)` where c = b^j is definitionally true in ℕ. Applies to many Chebyshev/central-binomial proofs that bound via `4^m ≤ choose(2m+1, m)` style estimates.",
+      "Iter 4 trap (Möbius-inversion lift requires explicit ℕ annotation): the iff-form hypothesis ∀ m > 0, Σ i ∈ m.divisors, ... = (Real.log m)² must be written as ∀ m : ℕ, 0 < m → ... — without the explicit ℕ annotation Lean's elaborator infers m : ℝ from Real.log m (which accepts ℝ directly), then fails on m.divisors (\"Real.divisors\" not found) and rejects the lift fun m hm => sum_divisors_selbergLambda2_eq_log_sq hm. The fix is a 1-token addition. General pattern: any iff-form Möbius-inversion lift in this file should type-annotate the bound ℕ variable when the consequent coerces through Real.log."
     ],
     "mathlibGaps": [
       "No formalization of Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N). (Iter 5–6 target.)",
-      "Iter 3 closed the dual side Σ_{d|n} Λ₂(d) = (log n)² in this file — but the ORIGINAL form Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) is not yet in Mathlib nor here; Iter 4 will derive it via ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq.",
       "No partial-summation framework specialized to Λ₂-type sums (would require summation by parts with Λ-weighted sums).",
-      "No formalization of Erdős's combinatorial finishing argument that derives lim sup |ψ(x)/x − 1| = 0 from a Tauberian-type oscillation inequality."
+      "No formalization of Erdős's combinatorial finishing argument that derives lim sup |ψ(x)/x − 1| = 0 from a Tauberian-type oscillation inequality.",
+      "Iter 4 closed the literal Möbius–log identity Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) in this file. Mathlib v4.26.0 still has no formalised PNT in any form; the symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N) and the Erdős–Selberg Tauberian finishing argument remain to be done here."
     ],
     "nextSteps": [
-      "Iter 3 — DONE (this PR, 2026-05-14): vonMangoldtConv_eq_mul (bridge) + sum_divisors_vonMangoldtConv + sum_divisors_selbergLambda2_eq_log_sq (Selberg dual identity); 7744-job Docker build clean.",
-      "Iter 4 (next, ~15 LOC): prove Λ₂(n) = Σ_{d|n} μ(d) · log²(n/d) for n > 0 by applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq to sum_divisors_selbergLambda2_eq_log_sq, then re-indexing divisorsAntidiagonal → divisors via Nat.map_div_right_divisors.",
-      "Iter 5–6: prove Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N log N + O(N). Decomposes as: (a) Σ_{n ≤ N} log²n = N log²N − 2N log N + O(log²N), (b) Möbius hyperbola summation to bound the error term.",
-      "Iter 7+: formalize the Tauberian inequality and Erdős's combinatorial finishing argument (lim sup V(x) = 0 ⇒ ψ(x)/x → 1).",
-      "Maintenance — open stale PR #17689 ('Iter 2 — prime values', CONFLICTING, last touched 2026-05-12T22:13Z) is superseded by merged #17690 with identical scope; downstream maintainer may close it."
+      "Iter 4 — DONE (this PR, 2026-05-16): selbergLambda2_eq_moebius_log_sq via ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq + Nat.sum_divisorsAntidiagonal; 7744-job Docker build clean.",
+      "Iter 5a (next, ~80–120 LOC): Selberg's symmetry formula Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N) leading term. Use Iter 4's literal form: swap sum order to get Σ_{d ≤ N} μ(d) · Σ_{m ≤ N/d} (log m)². Inner sum has explicit asymptotic Σ_{m ≤ x} (log m)² = x · (log x)² − 2x · log x + 2x + O(log²x) (integration by parts on log²; cf. Tenenbaum I.6.2). Leading −2x · log x scaled by Σ_{d ≤ N} μ(d)/d = O(1) (Mertens) yields 2N · log N.",
+      "Iter 5b (~80 LOC): O(N) error-term cleanup via the Möbius hyperbola bound.",
+      "Iter 6+: summation-by-parts framework specialised to Λ-weighted sums (Mathlib gap — current Mathlib has only generic Abel-style lemmas in MeanInequalitiesPow that don't apply directly). Either hand-roll or upstream to Mathlib.",
+      "Iter 7+: Tauberian inequality V(x)·log x ≤ (2/x)·Σ_{n ≤ x} V(x/n)·Λ(n) + O(1) where V(x) = |ψ(x) − x|/x.",
+      "Iter 8+: Erdős combinatorial finishing lim sup V(x) = 0 from the Tauberian inequality.",
+      "Iter 9: discharge of chebyshevPsi_asymptotic axiom (slug's terminal goal)."
     ]
   },
   "tags": [
@@ -145,7 +149,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.340Z",
-  "lastUpdate": "2026-05-14T15:50:00.000Z",
+  "lastUpdate": "2026-05-16T03:00:00.000Z",
   "significance": 9,
   "tractability": 3,
   "leanFiles": [
@@ -185,8 +189,8 @@
     {
       "path": "Proofs/ChebyshevBoundsOQ04OQ01.lean",
       "filename": "ChebyshevBoundsOQ04OQ01.lean",
-      "lineCount": 206,
-      "theoremCount": 10,
+      "lineCount": 325,
+      "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Closes the literal Möbius-inverted form of Selberg's auxiliary function on `n.divisors`, deferred from Iter 3:

```
Λ₂(n) = Σ_{d ∣ n} μ(d) · (Real.log (n / d : ℕ))²    (n > 0).
```

This is the dual of Iter 3's `sum_divisors_selbergLambda2_eq_log_sq` under the Möbius-inversion iff `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`. With this iteration the algebraic core of Selberg–Erdős 1949 is complete; Iter 5–6 (Selberg's symmetry formula `Σ_{n ≤ N} Λ₂(n) = 2N · log N + O(N)`) is the next analytic step.

## What changed

**One new theorem** (`proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean`, +24/-11):

```lean
theorem selbergLambda2_eq_moebius_log_sq {n : ℕ} (hn : 0 < n) :
    selbergLambda2 n =
      ∑ d ∈ n.divisors,
        ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) := by
  have hiter3 : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2 :=
    fun m hm => sum_divisors_selbergLambda2_eq_log_sq hm
  have hinv :=
    (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℝ)).mp hiter3 n hn
  have hbridge :
      ∑ x ∈ n.divisorsAntidiagonal,
          ((ArithmeticFunction.moebius x.fst : ℝ) * (Real.log x.snd) ^ 2)
        = ∑ d ∈ n.divisors,
          ((ArithmeticFunction.moebius d : ℝ) * (Real.log (n / d : ℕ)) ^ 2) :=
    Nat.sum_divisorsAntidiagonal
      (fun a b => (ArithmeticFunction.moebius a : ℝ) * (Real.log b) ^ 2)
  exact hinv.symm.trans hbridge
```

Proof body ~8 LOC. Follows S4 PREP #19171 §4.2 verbatim modulo the elaboration adjustment in the build trap below.

File state: 312 → 325 LOC, 15 → 16 theorems, 0 sorries, 0 axioms maintained.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ04OQ01` reports clean
`[7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (51s)` on Mathlib v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` against base `8a3cda556b6` (origin/main HEAD at branch creation, post-kepler-oq-04 audit tracker sync).

Two Docker iterations: iter 1 surfaced the annotation trap below; iter 2 clean.

## Build trap (worth recording for future Möbius-inversion lifts)

The lift hypothesis `∀ m > 0, ∑ i ∈ m.divisors, selbergLambda2 i = (Real.log m) ^ 2` must annotate `m : ℕ` explicitly. Without the annotation, Lean's elaborator infers `m : ℝ` from `Real.log m` (which accepts `ℝ` directly), then:

```
error: Invalid field `divisors`: The environment does not contain `Real.divisors`
  m has type ℝ
error: Application type mismatch: `hm` has type `m > 0` but is expected to have type `0 < ?m.78`
  in the application `sum_divisors_selbergLambda2_eq_log_sq hm`
```

The fix is a single-token addition: `∀ m : ℕ, 0 < m → ...`. The Mathlib iff `sum_eq_iff_sum_mul_moebius_eq` takes `∀ n > 0, P n` ≡ `∀ n, 0 < n → P n`, so the explicit form unifies with `.mp`'s expectations directly. General pattern documented in `state.md` + sessions doc for future iff-form Möbius-inversion lifts in this file (Iter 5 will need at least one more).

## Mathlib API used (verified at v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)

| Lemma | File:Line | Form |
|---|---|---|
| `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` | `Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:240` | `[NonAssocRing R]` iff between divisors-form hypothesis and antidiagonal-form Möbius-inverse conclusion |
| `Nat.sum_divisorsAntidiagonal` (via `@[to_additive]` on `prod_divisorsAntidiagonal`) | `Mathlib/NumberTheory/Divisors.lean:543` | `∑ i ∈ n.divisorsAntidiagonal, f i.1 i.2 = ∑ i ∈ n.divisors, f i (n / i)` |

Both lemmas inherited via `import Mathlib` + `open ArithmeticFunction` (lines 68 + 73 of the slug Lean file). `sum_divisors_selbergLambda2_eq_log_sq` (Iter 3 dependency) is at line 257 of the same file, provided by merged PR #19092.

## Bookkeeping

- `research/problems/chebyshev-bounds-oq-04-oq-01/state.md`: phase advance to `ACT (Iter 4 Möbius–log literal form verified)`, iteration 4 → 5, new Iter 4 entry, Race awareness updated, Next Action pivoted to Iter 5a (Selberg's symmetry formula leading term ~80–120 LOC via Möbius hyperbola trick).
- `src/data/research/problems/chebyshev-bounds-oq-04-oq-01.json`: top-level `phase`, `currentState` (`phase`/`since`/`iteration`/`focus`/`nextAction`/`attemptCounts`), `knowledge.progressSummary` + `builtItems` + `insights` + `nextSteps` + `mathlibGaps` Iter 4 entries appended; `knownResults` moves Möbius–log from `open` → `proven`; `leanFiles[3]` `lineCount` 206 → 325 + `theoremCount` 10 → 16 (correcting the Iter 1 staleness flagged in S4 PREP §1.3).
- `src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json`: `description` extended for Iter 3 + Iter 4, `lineCount` 230 → 325, `theoremCount` 12 → 16, `originalContributions` += Iter 3 + Iter 4 entries (open Möbius–log gap removed), `conclusion.summary`/`implications`/`openQuestions` refresh, `sections` list += `sec-dual-identity` + `sec-moebius-log` + Future Work line-range correction.
- `research/problems/chebyshev-bounds-oq-04-oq-01/sessions/2026-05-16-s5-iter4-act-moebius-log-literal.md`: new session doc with full API pins, step trace, build trap analysis, and Iter 5a next-action plan.

## Race awareness

Pre-claim survey returned 0 OPEN PRs on this slug. The 3-way coordination plan from S5 PREP (`sessions/2026-05-15-s5-prep-deployer-stall-coord.md`) has fully resolved: deployer drain wave merged Iter 3 PR #19092 (2026-05-15T22:59:33Z) + S4 PREP #19171 (2026-05-15T22:56:46Z) and the stale parallel attempt #17689 was CLOSED. Pre-push re-check confirmed still 0 OPEN PRs on slug.

## Iteration tally

| Iter | Date | PR | Status | Deliverable |
|---|---|---|---|---|
| 1 | 2026-05-09 | #17658 | merged | Selberg-Erdős scaffold (Λ₂, S₂ defs + 10 routine lemmas) |
| 2 | 2026-05-12 | #17690 | merged | Prime-value lemmas |
| 3 | 2026-05-14 | #19092 | merged | Selberg dual identity `Σ_{d∣n} Λ₂(d) = (log n)²` |
| 4 | 2026-05-16 | **this PR** | open | Literal Möbius–log form `Λ₂(n) = Σ_{d∣n} μ(d)·log²(n/d)` |

## Test plan

- [x] Docker build clean: `[7744/7744] Built Proofs.ChebyshevBoundsOQ04OQ01 (51s)`.
- [x] No new sorries, no new axioms.
- [x] All JSON files validate via `python3 -m json.tool`.
- [x] No file overlap with any current open PR (re-checked pre-push).
- [x] Worktree absolute paths used for all Edit/Write (per `feedback_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)