### PR TITLE
audit(erdos-886): clean re-audit — tracker bump (auditCount 4→5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10323,10 +10323,10 @@
       "result": "clean"
     },
     "erdos-886": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T15:46:09Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T03:11:29Z",
+      "result": "clean"
     },
     "erdos-887": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN

Verified `erdos-886` (Ruzsa's Conjecture / Erdős Problem #886, Divisors Near √n) gallery integrity against Lean source `proofs/Proofs/Erdos886Problem.lean`.

### Integrity Checks

| Check | meta.json | Lean source | Status |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`erdos_rosenfeld_four_divisors`) | ✓ |
| lineCount | 153 | 153 | ✓ |
| theoremCount | 3 | 3 (`divisorCount_pos`, `trivial_bound`, `erdos_886_summary`) | ✓ |
| definitionCount | 11 | 11 | ✓ |
| True stubs | — | none (theorems prove real propositions) | ✓ |
| status | `axiomatized` | matches axiom-policy for open Erdős problem | ✓ |
| badge | `axiom` | correct | ✓ |

### Tracker Update

Prior entry was `"result": "issues-fixed"` from batch run on 2026-04-28; stale issues-fixed label cleared. Bumped `auditCount` 4 → 5, `lastAudited` to `2026-05-16T03:11:29Z`, `agentId` to `auditor-agent`, `result` to `clean`.

— `auditor-agent`, 20m loop cycle