### PR TITLE
audit(erdos-889): clean re-audit — tracker bump (auditCount 4→5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10342,9 +10342,9 @@
     },
     "erdos-889": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T18:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T03:14:34Z",
+      "result": "clean",
       "fixPR": 13654,
       "fixDate": "2026-04-28",
       "mechanic": "lean-mechanic"


### PR DESCRIPTION
## Summary

Re-audit of `erdos-889` against HEAD `8a3cda556b6` confirms clean integrity. Tracker bumped from stale `issues-fixed` (2026-04-28) to `clean` (2026-05-16).

## Verification

**Lean source** (`proofs/Proofs/Erdos889Problem.lean`, 136 lines):
- 1 `axiom` declaration: `v0_exceptions` (complete exception list `{0,1,2,3,4,7,8,16}`)
- 0 sorries
- 0 `True`-stub theorems
- 4 theorems, 7 definitions

**meta.json claims** (all match):
- `axiomCount: 1` ✓
- `sorries: 0` ✓
- `status: "axiomatized"` ✓ (correct, not "verified")
- `badge: "axiom"` ✓
- `theoremCount: 4`, `definitionCount: 7`, `lineCount: 136` ✓
- `erdosProblemStatus: "open"` ✓

**Narrative integrity**:
- Open conjecture `ErdosProblem889` is a `Prop` `def`, NOT axiomatized — no overclaiming
- Only the exception list is axiomatized; the Erdős–Selfridge bound `v0_ge_2_for_large` (n ≥ 17 → v₀(n) ≥ 2) is derived from `v0_exceptions` by `omega`
- `originalContributions` accurately scoped (definitions, exception axiom, derived bound, generalized variant, exact power variant)
- No delegation opacity, axiom masking, inequality-as-theorem, pipeline inflation, or hidden-import issues

Prior fix PR #13654 (2026-04-28) is preserved in tracker history (`fixPR`/`fixDate`/`mechanic` fields retained).

## Test plan
- [x] Lean source counted: `grep -c "^axiom "` = 1, `grep -c "sorry"` = 0
- [x] No True stubs: `grep -c ":= trivial\|: True :="` = 0
- [x] meta.json fields cross-checked against Lean source
- [x] Tracker delta is single-slug (3-line clean diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)