### PR TITLE
audit(erdos-858): tracker bump — clean (1 axiom, 0 sorries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10129,9 +10129,9 @@
     },
     "erdos-858": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T18:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T03:21:37Z",
+      "result": "clean",
       "fixPR": 13648,
       "fixDate": "2026-04-28",
       "mechanic": "lean-mechanic"


### PR DESCRIPTION
## Summary

Audit cycle for `erdos-858` (Avoiding Multiplicative Relations with Large Prime Factors) — verified meta.json matches Lean source exactly.

- **lineCount**: 348 ✓
- **axiomCount**: 1 (`alexander_1966` at L215) ✓
- **theoremCount**: 12 ✓
- **definitionCount**: 8 ✓
- **sorries**: 0 ✓
- **status**: `axiomatized` / **badge**: `axiom` ✓ (correct for axiom-carrying file)

No structure-encoded assumptions, no True stubs, no naked Mathlib wrappers.

Result: **clean** (prior `issues-fixed` from 2026-04-28 was stale post-mechanic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)