### PR TITLE
audit(erdos-86): tracker bump — clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10143,9 +10143,9 @@
       "result": "issues-fixed"
     },
     "erdos-86": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-28T18:04:39Z",
+      "lastAudited": "2026-05-16T03:24:09Z",
       "result": "clean"
     },
     "erdos-860": {
@@ -15255,5 +15255,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-13T12:47:32Z"
+  "lastUpdated": "2026-05-16T03:24:09Z"
 }


### PR DESCRIPTION
## Summary

Clean re-audit of `erdos-86` (Erdős Problem #86: C₄-Free Subgraphs of Hypercubes). All five `meta.json` numeric fields verified against `proofs/Proofs/Erdos86Problem.lean` at origin/main `8a3cda556b6`. `auditCount` 3→4.

## Audit findings

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| `lineCount` | 186 | 186 | ✓ |
| `axiomCount` | 2 | 2 (`bhn_lower_bound`, `baber_upper_bound`) | ✓ |
| `theoremCount` | 4 | 4 (`hypercube_vertex_count`, `f_bounds_summary`, `erdos86_open`, `conjecture_implies_limit`) | ✓ |
| `definitionCount` | 9 | 9 (HypercubeVertex, hypercubeAdj, hypercubeGraph, hasC4, isC4Free, HypercubeSubgraph, f, erdos86Conjecture, erdos86ConjectureAlt) | ✓ |
| `sorries` | 0 | 0 | ✓ |

- `status: "axiomatized"` + `badge: "axiom"` consistent with the 2 declared axioms (open Erdős conjecture, $100 prize).
- `assumptions` field correctly enumerates both axioms.
- No `True` stubs in the assumption-bearing theorems (`f_bounds_summary` derives both bounds from the two axioms; the trivially-true `erdos86_open` is a labeled meta-placeholder commented as such and does not feed any other proof).
- No Mathlib-wrapper masking: the open conjecture is not in Mathlib; the bounds are axiomatized rather than imported.

## Test plan

- [x] Verified `wc -l proofs/Proofs/Erdos86Problem.lean` = 186
- [x] Verified `grep -c "^axiom " proofs/Proofs/Erdos86Problem.lean` = 2
- [x] Verified 0 ` sorry`/`sorry$` occurrences
- [x] Verified all four `theorem`/`def` counts match
- [x] Verified `status`/`badge`/`assumptions` consistency
- [x] Tracker `auditCount` 3 → 4 with `result: "clean"` (no `issues` array changes)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)