### PR TITLE
research(frobenius-number-oq-03): S3b ACT — 2→3 generator bridge `large_representable3_via_two_gen` (Lean +12 LOC, 3059/3059 jobs)

### DIFF
--- a/proofs/Proofs/FrobeniusNumberOQ03.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ03.lean
@@ -5,33 +5,32 @@
   the closure-lemma block from `Proofs/FrobeniusNumber.lean` (lines 42–69).
   S2-fix BUILD UNBLOCKER (researcher-9, 2026-05-14, PR #18979).
   S3a ACT (researcher-12, 2026-05-14): `frobeniusNumber3` definition + a small
-  set-theoretic API for the non-representable set, **self-contained** (no
-  dependency on the parent `Proofs.FrobeniusNumber` file).
+  set-theoretic API for the non-representable set.
+  S3b ACT (researcher-9, 2026-05-16): bridge lemma
+  `large_representable3_via_two_gen` lifting the 2-generator Sylvester bound
+  from `FrobeniusNumber.large_representable` (in module `Proofs.FrobeniusNumber`,
+  now safely importable after mechanic PR #19194 cleared the v4.26.0 regression
+  in the parent file) into a 3-generator existence form by setting the third
+  coefficient to zero.
 
     Representable3 a b c n := ∃ x y z : ℕ, n = a*x + b*y + c*z
 
-  together with the seven canonical closure lemmas (S2) and, in S3a, the
-  Frobenius number definition itself plus structural lemmas:
+  together with the seven canonical closure lemmas (S2), the Frobenius number
+  definition + structural API (S3a):
 
     `noncomputable def frobeniusNumber3 a b c : ℕ := sSup { n | ¬ Representable3 a b c n }`
-
-  with structural API:
     `representable3_of_gt_of_bddAbove` — every `n > frobeniusNumber3 a b c` is
         representable, conditional on bounded-aboveness;
-    `frobeniusNumber3_le_of_subset_Iio` — abstract upper bound.
+    `frobeniusNumber3_le_of_subset_Iio` — abstract upper bound;
 
-  The **existence proof** (finiteness of the non-representable set for
-  `gcd(a,b,c) = 1`) is deferred to S3b once the parent file
-  `Proofs/FrobeniusNumber.lean` (which provides the 2-generator Sylvester
-  bound `large_representable`) is unblocked from a Mathlib v4.26.0 regression
-  — see this slug's state.md "Open blockers" entry. Importing
-  `Proofs.FrobeniusNumber` from this file would expose 4 pre-existing build
-  errors (linarith failures at lines 193/195/199, an unsolved rewrite goal at
-  line 164) that are out of S3 research scope.
+  and the 2→3 generator bridge (S3b):
+
+    `large_representable3_via_two_gen` — for `Nat.Coprime a b`, `1 ≤ a`,
+        `1 ≤ b`, every `n ≥ (a-1)(b-1)` is `Representable3 a b c n`.
 
   Subsequent stages (per `research/problems/frobenius-number-oq-03/state.md`):
-    S3b — finiteness/existence proof via the 2-generator Sylvester bound
-          (blocked on parent-file unblock).
+    S3c — finiteness of the non-representable set for `gcd(a,b,c) = 1`
+          (via the bridge + cofiniteness of the 2-generator non-rep set).
     S4 — `large_representable3` for the three-consecutive family.
     S5 — `frobenius_three_consecutive` (Roberts d=1 closed form).
     S6+ — Roberts 3-AP, Fibonacci triples, Mersenne triples.
@@ -41,6 +40,7 @@
 
 import Mathlib.Tactic
 import Mathlib.Data.Nat.Lattice
+import Proofs.FrobeniusNumber
 
 namespace FrobeniusOQ03
 
@@ -137,9 +137,21 @@ theorem not_representable3_frobeniusNumber3_of_nonempty {a b c : ℕ}
   Nat.sSup_mem hne hbdd
 
 /-- A `Representable3` witness with the third coefficient zero collapses to a
-    two-generator witness in `a, b`. (Bridge lemma used in S3b once the parent
-    file `Proofs.FrobeniusNumber` is unblocked.) -/
+    two-generator witness in `a, b`. (Bridge lemma used in S3b.) -/
 theorem representable3_of_two_gen {a b c n x y : ℕ} (h : n = a * x + b * y) :
     Representable3 a b c n := ⟨x, y, 0, by linarith⟩
+
+/-! ### S3b — 2→3 generator bridge -/
+
+/-- **S3b bridge**: lift the 2-generator Sylvester bound to 3 generators by
+    setting the third coefficient to zero. For coprime `a, b` with `1 ≤ a`,
+    `1 ≤ b`, every `n ≥ (a-1)(b-1)` satisfies `Representable3 a b c n`
+    (witnessed with `z = 0`). The third generator `c` is irrelevant for the
+    upper-bound side, foreshadowing S3c's finiteness argument. -/
+theorem large_representable3_via_two_gen
+    {a b c n : ℕ} (hab : Nat.Coprime a b) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hn : (a - 1) * (b - 1) ≤ n) : Representable3 a b c n := by
+  obtain ⟨x, y, hxy⟩ := FrobeniusNumber.large_representable hab ha hb n hn
+  exact representable3_of_two_gen hxy
 
 end FrobeniusOQ03

--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -19,9 +19,9 @@
     "badge": "research",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 66,
-    "theoremCount": 7,
-    "definitionCount": 1,
+    "lineCount": 157,
+    "theoremCount": 13,
+    "definitionCount": 2,
     "assumptions": "None at this stage. The file establishes the Representable3 predicate and seven closure lemmas via ring/linarith; subsequent stages will add frobeniusNumber3 (S3) and the main theorem (S5).",
     "dateAdded": "2026-05-13",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Summary

S3b ACT realization for `frobenius-number-oq-03`. Implements the **paste-ready Option A** named as next path-forward in the in-flight S3f STATE-SYNC PR #19376. Adds one new theorem (`large_representable3_via_two_gen`) lifting the 2-generator Sylvester bound to the 3-generator setting by collapsing the third coefficient to zero. **0 sorries, 0 axioms, build-verified.**

## Predecessor stages (all merged on `main`)

| PR | Stage | Outcome |
|---|---|---|
| #18999 | S3a ACT — `frobeniusNumber3` def + structural API | MERGED 2026-05-15T23:29:16Z |
| #19151 | S3b PREP — Sylvester memo (doc) | MERGED 2026-05-15T22:57:16Z |
| #19226 | S3d PREP — deployer-stall coordination (doc) | MERGED 2026-05-15T18:05:10Z |
| #19320 | S3e PREP — post-drain coordination (doc) | MERGED 2026-05-15T23:26:26Z |
| #19194 | Parent mechanic — `FrobeniusNumber.lean` v4.26.0 5-error fix | MERGED 2026-05-15T22:55:49Z |

In-flight sibling: **#19376** (S3f STATE-SYNC, doc-only on state.md + research JSON, MERGEABLE+CLEAN). This PR is a sibling Lean+meta.json delivery; the two are conflict-free at the file level.

## Lean delivery

**File**: `proofs/Proofs/FrobeniusNumberOQ03.lean` (145 → 157 LOC, +12)

1. **NEW** `import Proofs.FrobeniusNumber` — safe post-#19194.
2. **UPDATED** header docstring: removes the obsolete "blocked on parent-file unblock" warning and 4-error caveat; adds an S3b entry; renumbers the subsequent-stage block "S3b → S3c" (S3c now reserved for finiteness/existence).
3. **NEW** theorem (8 LOC body):
   ```lean
   theorem large_representable3_via_two_gen
       {a b c n : ℕ} (hab : Nat.Coprime a b) (ha : 1 ≤ a) (hb : 1 ≤ b)
       (hn : (a - 1) * (b - 1) ≤ n) : Representable3 a b c n := by
     obtain ⟨x, y, hxy⟩ := FrobeniusNumber.large_representable hab ha hb n hn
     exact representable3_of_two_gen hxy
   ```

## PREP-recipe drift fix (1 ACT-time correction)

The #19376 §"Path-forward" sketch used `Proofs.FrobeniusNumber.large_representable` (module-qualified), but the actual Lean namespace inside the parent file is `FrobeniusNumber` (verified via the build's `#check` triples printed at parent lines 319-322: `FrobeniusNumber.Representable`, `FrobeniusNumber.frobeniusNumber`, `FrobeniusNumber.sylvester_frobenius`). Replaced with `FrobeniusNumber.large_representable`. Avoided a blanket `open FrobeniusNumber` to keep the 2-gen `Representable` from shadowing this file's `Representable3` predicate. Consistent with the `feedback_researcher_act_realizing_followon_predecessor_preps_merged_even_if_gating_statesync_open` memory pattern of budgeting 1-2 ACT-time elaboration fixes despite paste-ready PREPs.

## Build verification

```bash
./proofs/scripts/docker-build.sh Proofs.FrobeniusNumberOQ03
```

**Iter 2** (after the namespace fix): `✔ [3059/3059] Built` cleanly. Pre-existing parent-file deprecation warning `le_or_lt` (line 102) unchanged and out of scope.

**Iter 1**: surfaced the namespace bug as `error: Unknown identifier 'Proofs.FrobeniusNumber.large_representable'` + `Tactic 'rcases' failed: 'x✝ : ?m.28' is not an inductive datatype` (the metavar-stuck `rcases` was a downstream artifact of the first error, not a real type-class issue).

## Source-of-truth metrics

| Field | Before | After | Source |
|---|---|---|---|
| lineCount | 145 | **157** | `wc -l proofs/Proofs/FrobeniusNumberOQ03.lean` |
| theoremCount | 12 | **13** | `grep -c '^theorem\|^lemma'` |
| definitionCount | 2 | 2 | `grep -c '^def \|^noncomputable def '` |
| sorries | 0 | 0 | `grep -c 'sorry'` |
| axiomCount | 0 | 0 | `grep -c '^axiom '` |
| structure-encoded assumptions | 0 | 0 | manual review (no structures introduced) |

Gallery `src/data/proofs/frobenius-number-oq-03/meta.json` synced. Status stays `formalized` (Roberts d=1 closed form remains an OPEN conjecture not yet stated; per CLAUDE.md axiom integrity policy, no axiom-status overclaim).

## Bearer drift recheck

Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` at base `8a3cda556b6` (no upstream pin bump during this slug's history).

| Bearer | Location | Status |
|---|---|---|
| `FrobeniusNumber.large_representable` | `proofs/Proofs/FrobeniusNumber.lean:140` | UNCHANGED post-#19194 |
| `FrobeniusNumber.Representable` | `proofs/Proofs/FrobeniusNumber.lean:43-44` | UNCHANGED |
| `FrobeniusOQ03.Representable3` | this file, line 49 | UNCHANGED |
| `FrobeniusOQ03.representable3_of_two_gen` | this file, line 142 | UNCHANGED |
| `Nat.Coprime` | Mathlib classical | resolves via parent's transitive imports |

## State coupling with #19376

This PR is intentionally Lean + gallery-meta only:
- ✅ `proofs/Proofs/FrobeniusNumberOQ03.lean` — new theorem + import + docstring refresh
- ✅ `src/data/proofs/frobenius-number-oq-03/meta.json` — count sync (lineCount, theoremCount, definitionCount)
- ❌ NOT touched: `research/problems/frobenius-number-oq-03/state.md` (modified by #19376)
- ❌ NOT touched: `src/data/research/problems/frobenius-number-oq-03.json` (modified by #19376)
- ❌ NOT touched: `problem.md`, `knowledge.md`, `sessions/`

After both PRs merge (any order), a thin follow-up STATE-SYNC will bump `currentState.iteration`, `attemptCounts`, and append an "Iteration: S3b ACT (this PR)" row to state.md.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.FrobeniusNumberOQ03` → `✔ [3059/3059] Built`
- [x] `jq -e . src/data/proofs/frobenius-number-oq-03/meta.json` validates
- [x] `wc -l` = 157, theorem-grep = 13, def-grep = 2 (all match meta.json)
- [x] No new sorries / axioms / structure-encoded assumptions
- [x] Bearer drift recheck: 5 bearers, 0 drift
- [x] Conflict-free with #19376: distinct file sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)