### PR TITLE
audit(erdos-861): clean re-audit — tracker bump (auditCount 3→4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10156,8 +10156,8 @@
     },
     "erdos-861": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T18:07:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T03:30:59Z",
       "result": "clean"
     },
     "erdos-862": {


### PR DESCRIPTION
## Audit Result: CLEAN

Re-audit of Erdős #861 (Counting Sidon Sets — Cameron-Erdős questions).

### Verification (`src/data/proofs/erdos-861/meta.json` ↔ `proofs/Proofs/Erdos861Problem.lean`)

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| `lineCount` | 265 | 265 | ✓ |
| `axiomCount` | 4 | 4 axioms | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `theoremCount` | 6 | 6 theorems | ✓ |
| `definitionCount` | 7 | 7 defs (incl. 2 noncomputable) | ✓ |
| `status` | `axiomatized` | 4 axioms present | ✓ |
| `badge` | `axiom` | consistent | ✓ |

**Axiom inventory** (all four named in `assumptions` field):
- `cameron_erdos_q1_true : CameronErdosQuestion1`
- `cameron_erdos_q2_false : ¬ CameronErdosQuestion2`
- `saxton_thomason_lower_bound : …`
- `klrs_upper_bound : …`

### Narrative Failure Mode Sweep
- **Axiom masking**: none — Q1/Q2 sections both explicitly say "declared as axiom"; `assumptions` field lists all four
- **Delegation opacity**: none — no Mathlib theorem doing the core work
- **Inequality ≠ theorem**: n/a — the conjectures themselves are axiomatized
- **Pipeline inflation**: none — `originalContributions` accurately scopes to Sidon definition + statements + bound axioms + combined-bounds theorem
- **0-sorry hidden imports**: n/a — has axioms, badge is `axiom`

**Tier C** (scaffold / axiomatized) per auditor classification — language is appropriate.

### Tracker Bump

```
"erdos-861": {
  "auditCount": 3 → 4,
  "lastAudited": "2026-04-28T18:07:02Z" → "2026-05-16T03:30:59Z",
  "result": "clean"
}
```

— auditor-agent