### PR TITLE
research(birthday-problem-oq-01-oq-02): S4 ACT — Paley-Zygmund-equivalent lower bound (closed form, 7744-job build verified)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ02.lean
@@ -140,4 +140,65 @@ theorem probCollision_le_choose_two_div (k d : ℕ) (hkd : k ≤ d) (hd : 0 < d)
   rw [← hsum]
   exact hbound
 
+-- ============================================================
+-- Part III: Paley-Zygmund-equivalent lower bound (closed form)
+-- ============================================================
+
+/-- Elementary inequality: for nonneg `x`, `1 - exp(-x) ≥ x / (1 + x)`.
+
+    Bridge lemma chaining `OQ02.probCollision_ge` (exponential lower
+    bound) to the closed-form Paley-Zygmund-equivalent lower bound. -/
+private lemma one_sub_exp_neg_ge_div_one_add (x : ℝ) (hx : 0 ≤ x) :
+    x / (1 + x) ≤ 1 - Real.exp (-x) := by
+  have hx1 : 0 < 1 + x := by linarith
+  have hexp_pos : 0 < Real.exp x := Real.exp_pos x
+  have h1 : 1 + x ≤ Real.exp x := by linarith [Real.add_one_le_exp x]
+  have h2 : Real.exp (-x) ≤ 1 / (1 + x) := by
+    rw [Real.exp_neg, ← one_div]
+    exact one_div_le_one_div_of_le hx1 h1
+  have h3 : (1 : ℝ) - 1 / (1 + x) = x / (1 + x) := by
+    field_simp
+    ring
+  linarith
+
+/-- **Paley-Zygmund-equivalent lower bound** (closed form, no OQ01 import).
+
+    Chains OQ02's exponential lower bound `probCollision_ge` with the
+    bridge lemma `one_sub_exp_neg_ge_div_one_add`:
+
+      probCollision k d ≥ 1 - exp(-S)  ≥  S / (1 + S)
+                                       =  k(k-1) / (2d + k(k-1))
+
+    Matches knowledge.md §"Paley–Zygmund bound" weak form. -/
+theorem probCollision_ge_paley_zygmund (k d : ℕ) (hkd : k ≤ d) (hd : 0 < d) :
+    ((k : ℝ) * ((k : ℝ) - 1)) / (2 * (d : ℝ) + (k : ℝ) * ((k : ℝ) - 1))
+      ≤ probCollision k d := by
+  set S : ℝ := (k : ℝ) * ((k : ℝ) - 1) / (2 * (d : ℝ)) with hS
+  have hd_pos : (0 : ℝ) < d := by exact_mod_cast hd
+  have h2d_pos : (0 : ℝ) < 2 * (d : ℝ) := by linarith
+  have hkk_nn : (0 : ℝ) ≤ (k : ℝ) * ((k : ℝ) - 1) := by
+    rcases Nat.eq_zero_or_pos k with rfl | hk
+    · simp
+    · have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+      have hk2 : (0 : ℝ) ≤ (k : ℝ) - 1 := by linarith
+      positivity
+  have hS_nn : 0 ≤ S := by
+    rw [hS]; exact div_nonneg hkk_nn h2d_pos.le
+  -- Step 1: probCollision ≥ 1 - exp(-S)         (OQ02.probCollision_ge)
+  have step1 : 1 - Real.exp (- S) ≤ probCollision k d := by
+    have hge := probCollision_ge k d hkd hd
+    rw [hS]
+    linarith [hge]
+  -- Step 2: S / (1 + S) ≤ 1 - exp(-S)            (bridge lemma)
+  have step2 : S / (1 + S) ≤ 1 - Real.exp (-S) :=
+    one_sub_exp_neg_ge_div_one_add S hS_nn
+  -- Step 3: Rewrite S/(1+S) into the target form.
+  have h1pS_pos : (0 : ℝ) < 1 + S := by linarith
+  have hsum_pos : (0 : ℝ) < 2 * (d : ℝ) + (k : ℝ) * ((k : ℝ) - 1) := by linarith
+  have step3 : S / (1 + S)
+      = ((k : ℝ) * ((k : ℝ) - 1)) / (2 * (d : ℝ) + (k : ℝ) * ((k : ℝ) - 1)) := by
+    rw [hS]
+    field_simp
+  linarith
+
 end BirthdayProblemOQ01OQ02


### PR DESCRIPTION
## Summary

Realizes the S4 PREP Path Z scaffold from **PR #19250** §4 (with F8/F9
fixes pinned by **S5b audit-at-pick-time PR #19417**) as a 61-LOC
insertion into `proofs/Proofs/BirthdayProblemOQ01OQ02.lean` (143 → 203
LOC). Two new declarations: 1 private bridge lemma + 1 public theorem.
Build green at 7744 jobs (no Δ vs PR #19098 baseline — purely
intra-namespace addition).

Closes the S4 ACT step in the chain established by:
- **PR #19098** (S3 ACT, merged 2026-05-15T23:30:27Z) — upper bound `probCollision_le_choose_two_div`
- **PR #19250** (S4 PREP, merged 2026-05-15T18:03:33Z) — Path Z design memo + 25-LOC scaffold
- **PR #19262** (S4b PREP, merged 2026-05-15T18:02:47Z) — bearer pin re-verification
- **PR #19315** (S4c PREP, merged 2026-05-15T19:47Z) — STATE-SYNC + ACT readiness gate
- **PR #19355** (S5 STATE-SYNC, merged 2026-05-16T03:51:17Z [meta]) — paste anchor pinning + post-S3-ACT-merge catch-up
- **PR #19417** (S5b audit-at-pick-time, merged 2026-05-16T03:51:17Z) — F8/F9 elaboration trap pre-pins

## Files touched (1, Lean-only)

- `proofs/Proofs/BirthdayProblemOQ01OQ02.lean` — 143 → 203 LOC (+61
  insertions between previous L142 `exact hbound` and L143
  `end BirthdayProblemOQ01OQ02`; pinned to S5 §4c paste anchor; no
  existing declaration modified)

## What this PR ships

### 1. Bridge lemma (private, inside namespace)

```lean
private lemma one_sub_exp_neg_ge_div_one_add (x : ℝ) (hx : 0 ≤ x) :
    x / (1 + x) ≤ 1 - Real.exp (-x)
```

Elementary inequality chain:
1. `1 + x ≤ Real.exp x` (`Real.add_one_le_exp`, Mathlib `Mathlib/Analysis/Complex/Exponential.lean:646` at SHA `2df2f0150c`).
2. `Real.exp (-x) = (Real.exp x)⁻¹` (`Real.exp_neg`, same file L236).
3. `(Real.exp x)⁻¹ ≤ 1/(1+x)` via `one_div_le_one_div_of_le`.
4. Algebraic identity `1 - 1/(1+x) = x/(1+x)` via `field_simp; ring`.

### 2. Public theorem

```lean
theorem probCollision_ge_paley_zygmund (k d : ℕ) (hkd : k ≤ d) (hd : 0 < d) :
    ((k : ℝ) * ((k : ℝ) - 1)) / (2 * (d : ℝ) + (k : ℝ) * ((k : ℝ) - 1))
      ≤ probCollision k d
```

Chains OQ02's exponential lower bound `probCollision_ge` (`Proofs.BirthdayProblemOQ02:173`)
with the bridge lemma, then rewrites `S / (1 + S)` to the target denominator
form `k(k-1) / (2d + k(k-1))` where `S = k(k-1) / (2d)`.

### 3. Combined bracket on `probCollision k d`

With PR #19098's `probCollision_le_choose_two_div` (now on main at L117), this
slug now states the **closed-form Paley-Zygmund bracket** without any OQ01
parent import:

```
k(k-1) / (2d + k(k-1))  ≤  probCollision k d  ≤  k(k-1) / (2d)
```

Both bounds purely intra-namespace (no OQ01 dependency); OQ01's 7
v4.26.0 regressions at L408/L420/L453/L476/L483/L498-499/L510/L511
remain owned by separate-slug mechanic pass per S5 §5 catalogue.

## ACT-time elaboration fixes

Vs PR #19250 §4 baseline + PR #19417 §5 refined recipe:

| Trap | Source | Fix | LOC |
|------|--------|-----|----:|
| F8: `set S` + `linarith` doesn't bridge unfolded term | S5b §3a pre-pinned | `rw [hS]` between `have hge` and `linarith [hge]` | +1 |
| F9: `Real.exp_neg` gives `⁻¹`, not `1/_` | S5b §4a pre-pinned | `rw [Real.exp_neg, ← one_div]` | +0 (in same line) |
| **F-extra**: `field_simp` on `1 - 1/(1+x) = x/(1+x)` leaves `1 + x - 1 = x` | **NEW at iter 1** | append `ring` | +1 |
| R2: `field_simp` on `step3` needs positivity hyps explicit | S5b §5 pre-pinned | `h1pS_pos` + `hsum_pos` before `step3` | +2 |

**F-extra** is genuinely new — neither S5 §4d nor S5b §5 anticipated it.
S5b §5's claim "`field_simp` is sufficient because `hx1 : 0 < 1 + x` is a
local hypothesis" was correct for the side condition but missed the
algebraic residue. Build iter 1 (failed) surfaced it at L159:51
(`unsolved goals: ⊢ 1 + x - 1 = x`); iter 2 with `ring` appended built
green at `[7744/7744] (10s)`. Total Docker iters: 2.

## Build verification

```
[7744/7744] Built Proofs.BirthdayProblemOQ01OQ02 (10s)
Build completed successfully (7744 jobs).
```

Iter 1: `Proofs/BirthdayProblemOQ01OQ02.lean:159:51: unsolved goals (⊢ 1 + x - 1 = x)` from `field_simp` not auto-closing the algebraic identity in bridge lemma `h3`. Fix: `field_simp` → `field_simp\n    ring`.

Iter 2 (this commit): all 7744 jobs green, 10s build wall, 90s warm-cache total.

## Bearer drift recheck

S5 §3 and S5b §2 each performed the 9-row bearer drift recheck. This
PR inherits both rechecks (0 drift in either round); lake SHA still
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` on origin/main HEAD
`78448f56d0a` at PR-create time. No re-recheck needed.

## Strict-honesty footprint

- 0 new sorries on main
- 0 new axioms anywhere
- 1 new private lemma (`one_sub_exp_neg_ge_div_one_add`)
- 1 new public theorem (`probCollision_ge_paley_zygmund`)
- 0 changes to existing declarations
- 0 new imports
- 61 net insertions; 0 deletions

## Conflict declaration

- **None.** PR #19355 (S5 STATE-SYNC) and PR #19417 (S5b audit) both
  doc-only on different files (`research/problems/` + `src/data/research/`);
  both merged to main before PR-create. This PR is Lean-only on a
  fresh `BirthdayProblemOQ01OQ02.lean` post-merge — no overlap.
- After merge, a follow-on S6 STATE-SYNC is owed to absorb this ACT
  (state.md `phase` → `S4 ACT merged`; `iteration` 6 → 7; JSON
  `currentState` refresh; bearer table augmented with `Real.exp_neg`'s
  `← one_div` form + `field_simp + ring` trap). Not done here to keep
  PR Lean-only.

## Out-of-scope (deferred)

- **Tight Paley-Zygmund** (saves `-1` in denominator, full
  `E[X²]` expansion ~120 LOC) — deferred to S5/S6 per PR #19250 §R5.
- **OQ01 parent regression repair** (7 v4.26.0 errors) — owned by
  separate-slug mechanic/doctor pass per S5 §5.
- **Bridge to `expectedPairs` form** (3 LOC after OQ01 repair) —
  deferred to S6/S7 per PR #19250 §R6.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.BirthdayProblemOQ01OQ02` → `✔ [7744/7744] (10s)`
- [x] `grep -c '^axiom ' proofs/Proofs/BirthdayProblemOQ01OQ02.lean` → 0
- [x] `grep -c sorry proofs/Proofs/BirthdayProblemOQ01OQ02.lean` → 0
- [x] File line count 203 (was 143; +61 insertions)
- [x] Insertion bounded between former L142 and L143 (no edits to existing decls)
- [x] No new `import` lines (uses existing `Mathlib` + `Proofs.BirthdayProblemOQ02`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)