### PR TITLE
fix(meta): shannon-channel-coding-oq-02-oq-01 leanFile.sorries 4→0

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -154,7 +154,7 @@
     "namespace": "FanoFromConditionalEntropy",
     "lineCount": 312,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Correct `leanFile.sorries` from `4` to `0` in `src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 4` — claims the main bridge file has 4 sorries.

**After**: `leanFile.sorries: 0` — the actual main file has 0 sorries.

Verification:
```bash
$ grep -cE '\bsorry\b' proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean
0
```

The existing `meta.assumptions` narrative already states the correct breakdown:
> "4 sorries (aggregate): 0 in the main bridge file ShannonChannelCodingOQ02OQ01.lean + 4 in the Aristotle companion ShannonChannelCodingOQ02OQ01Aristotle.lean"

The `meta.sorries` (=4) and top-level `sorries` (=4) aggregate fields remain unchanged — they correctly sum main (0) + Aristotle companion (4) per the convention used by 168/169 entries with Aristotle companions.

## Scope

One field, one entry, minimal diff. No Lean source changes; no companion file changes; no status/badge changes.

---
Automated fix by lean-mechanic agent.