### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01 sorry-count drift (top-level 6→5, leanFile 5→4)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -171,7 +171,7 @@
     "duplicateTheorems": 0,
     "definitionCount": 4,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "sorries": 5,
+    "sorries": 4,
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
     ]
@@ -196,5 +196,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Correct two stale sorry counts in `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json`:

- `leanFile.sorries`: `5` → `4` (main file actual count)
- top-level `sorries`: `6` → `5` (aggregate = main + Aristotle companion)

## Evidence

**Main file** — 4 sorries (matches the line-pinned audit already in `meta.assumptions`):

```bash
$ grep -nE '\bsorry\b' proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
164:  sorry -- Follows from the product being nonzero iff each factor is nonzero
185:  sorry -- Requires: fixing k(i) = m, summing over remaining components,
200:  sorry -- Standard: E[Xᵢ] = n·pᵢ for multinomial
213:  sorry -- Cov(Xᵢ, Xⱼ) = E[XᵢXⱼ] - E[Xᵢ]E[Xⱼ] = n(n-1)pᵢpⱼ - (npᵢ)(npⱼ) = -npᵢpⱼ
```

**Aristotle companion** — 1 real sorry (the other two `sorry` mentions are inside comments):

```bash
$ grep -nE '\bsorry\b' proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean
7:  - NOT the Fintype instance sorry (def/instance sorry — Aristotle skips)
19:  - Fintype (Composition α s n): instance sorry (Aristotle skips)
67:  sorry
```

**Aggregate** = 4 (main) + 1 (Aristotle) = **5**, already reflected by `meta.sorries: 5` and the narrative in `meta.assumptions`:

> "5 sorries (aggregate): 4 in main file (support characterization at line 164, marginal distribution at line 185, mean at line 200, covariance at line 213) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean."

## Scope

Two related fields, one file, one slug. No Lean source changes; no companion file changes; no status/badge/narrative changes. The narrative already encodes the correct counts — only the numeric fields were stale.

Follows the same convention as #19430 (`leanFile.sorries` = main file only; top-level `sorries` and `meta.sorries` = main + companion aggregate).

---
Automated fix by lean-mechanic agent.