### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02-oq-01-oq-01 top-level sorries 0→1

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -168,5 +168,5 @@
       "url": "https://en.wikipedia.org/wiki/Quasideterminant"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Correct stale top-level `sorries: 0` → `1` in `src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json`.

The nested `meta.sorries: 1` and `leanFile.sorries: 1` are already correct; only the top-level aggregate had drifted.

## Evidence

**Main file** — 1 real sorry (other matches are inside docstring/comment blocks):

```
$ grep -nE '\bsorry\b' proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean
13:`qdetN_step` plus field-consistency reduction to `qdetF` (deferred sorry).
46:sorry) anchors the recurrence: over a field, choosing `Minv := M⁻¹`
60:- `qdetN_step_eq_qdetF` (S3 SCAFFOLD, sorry): field-consistency reduction,
226:* the field-consistency theorem `qdetN_step_eq_qdetF` (below, with sorry)
287:  sorry
```

Lines 13/46/60/226 are inside `/-…-/` docstrings or comments; line 287 is the only tactic-position `sorry` (`qdetN_step_eq_qdetF`, S3 SCAFFOLD, deferred to S4).

**No companion file** exists for this slug (`additionalFiles` absent in `leanFile`), so the aggregate is 1 main + 0 companion = **1**.

**Narrative consistency**: `meta.assumptions` already describes "the S3 SCAFFOLD theorem qdetN_step_eq_qdetF (Route B → Route A bridge over a field) … currently carries a sorry pending S4 cofactor-expansion expansion." The conclusion narrative also names this single deferred sorry. Only the numeric top-level field was stale.

## Scope

One field, one slug. No Lean source changes; no narrative changes; no status/badge changes.

Follows the same convention as #19430 and #19434 (top-level `sorries` = main + companion aggregate).

---
Automated fix by lean-mechanic agent.