### PR TITLE
fix(mechanic): tracker bump for general-quartic + mean-value-theorem-oq-02-oq-04-oq-01 (stale issues-found)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11537,9 +11537,9 @@
     },
     "general-quartic": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 7,
-      "lastAudited": "2026-05-16T00:39:34Z",
-      "result": "issues-found",
+      "auditCount": 8,
+      "lastAudited": "2026-05-16T04:20:16Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "geometric-series": {
@@ -15135,9 +15135,9 @@
       "issues": []
     },
     "mean-value-theorem-oq-02-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-16T00:11:22Z",
-      "result": "issues-found",
+      "auditCount": 3,
+      "lastAudited": "2026-05-16T04:20:16Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "minpoly-charpoly-oq-03": {


### PR DESCRIPTION
## Fix

Bump two audit-tracker entries from `issues-found` (stale, with empty `issues: []`) to `issues-fixed` -- the underlying drift in both has already been resolved by subsequent merged PRs.

## Background

Both entries were flipped to `issues-found` by recent auditor cycles to flag meta.json drift. Follow-up mechanic / auditor PRs fixed all named drift, but no subsequent step rolled the tracker `result` field back. The two slugs are therefore re-flagged on every auditor pass.

This follows the same pattern as PR #19328 (kepler-conjecture-oq-04 stale-issues-found cleanup).

## Verification (meta.json vs Lean source at HEAD `78448f56d0a`)

### general-quartic

`proofs/Proofs/GeneralQuartic.lean`:

| Field            | meta.json | Lean truth | Status |
|------------------|-----------|------------|--------|
| `lineCount`      | 576       | 576 (`wc -l`) | OK |
| `axiomCount`     | 6         | 6 (`grep -c '^axiom '`) | OK |
| `sorries`        | 0         | 0          | OK |
| `theoremCount`   | 15        | 15         | OK |
| `definitionCount`| 5         | 5          | OK |
| `status`         | axiomatized | 6 axioms -> axiomatized | OK |
| `badge`          | axiom     | consistent | OK |

Resolved by:
- PR #19345 (merged 2026-05-16T01:08:43Z) -- `audit: sync meta counts for general-quartic (sorries 1->0, lineCount/theoremCount drift)`
- PR #19348 (merged 2026-05-16T01:08:34Z) -- `audit: tracker bump for general-quartic + erdos-922 re-audits`

### mean-value-theorem-oq-02-oq-04-oq-01

`proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean`:

| Field            | meta.json | Lean truth | Status |
|------------------|-----------|------------|--------|
| `lineCount`      | 758       | 758 (`wc -l`) | OK |
| `axiomCount`     | 0         | 0          | OK |
| `sorries`        | 0         | 0          | OK |
| `theoremCount`   | 12        | 12         | OK |
| `definitionCount`| 3         | 3          | OK |
| `status`         | verified  | 0 axioms / 0 sorries / 0 structure-encoded assumptions -> verified | OK |
| `badge`          | mathlib   | consistent | OK |

Originating issue (CLOSED-COMPLETED):
- #19329 `Gallery integrity: status/badge stale after S7 sorry discharge` -- closed 2026-05-16T01:09:27Z

Resolved by:
- PR #19327 (merged 2026-05-16T00:08:33Z) -- `fix(mechanic): sorries 1->0 post-S7 (#19063)`
- PR #19331 (merged 2026-05-16T01:09:26Z) -- `fix(meta): status/badge sync post-S7 (#19329)`

## Tracker deltas

```diff
 "general-quartic": {
   "agentId": "auditor-cycle-20-batch",
-  "auditCount": 7,
-  "lastAudited": "2026-05-16T00:39:34Z",
-  "result": "issues-found",
+  "auditCount": 8,
+  "lastAudited": "2026-05-16T04:20:16Z",
+  "result": "issues-fixed",
   "issues": []
 },
 "mean-value-theorem-oq-02-oq-04-oq-01": {
-  "auditCount": 2,
-  "lastAudited": "2026-05-16T00:11:22Z",
-  "result": "issues-found",
+  "auditCount": 3,
+  "lastAudited": "2026-05-16T04:20:16Z",
+  "result": "issues-fixed",
   "issues": []
 }
```

## Scope

- Single file, two entries, 12-line diff (6 insertions + 6 deletions)
- No meta.json / Lean / docs / annotations edits
- Future auditor passes will correctly skip these slugs instead of re-flagging them

---
Automated fix by lean-mechanic agent.