### PR TITLE
audit(erdos-455-oq-04): tracker bump — clean (first audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15253,6 +15253,12 @@
       "lastAudited": "2026-05-15T23:07:09Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-455-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-16T04:22:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

Gallery integrity audit for **erdos-455-oq-04** (Erdős #455 OQ-04: Arithmetic-Progression Gap Generalization).

**Result**: clean (first audit; `auditCount: 0 → 1`).

## Verification

All meta.json claims match `proofs/Proofs/Erdos455OQ04.lean`:

| Claim | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| `lineCount` | 166 | 166 (`wc -l`) | ✓ |
| `axiomCount` | 2 | 2 (`greenTao_finitary` L100, `bunyakovsky_finitary` L147) | ✓ |
| `theoremCount` | 5 | 5 (L93 grep hit lives inside a docstring) | ✓ |
| `definitionCount` | 2 | 2 (`HasAPGaps`, `eulerPoly`; `APGapPrimeSeq` is a `structure`) | ✓ |
| `sorries` | 0 | 0 (both `sorry` mentions are docstring prose) | ✓ |
| `status` | `axiomatized` | matches policy for axiom-bearing files | ✓ |
| `badge` | `axiom` | matches Tier C scaffold/axiomatized classification | ✓ |
| True stubs | none | none | ✓ |

**Narrative integrity**: title and description properly disclose both axioms with provenance (Green-Tao 2008 proved-but-absent-from-Mathlib v4.26.0; Bunyakovsky 1857 open since). `assumptions` field lists both axioms explicitly. `originalContributions` correctly scoped to the AP-gap framework, the sorry-free length-40 Euler witness, the sorry-free k=5 cross-check, and the bridge theorems — not the underlying conjectures.

No overclaim detected. Tier C (scaffold/axiomatized) correctly applied.

## Test plan

- [x] `wc -l proofs/Proofs/Erdos455OQ04.lean` → 166
- [x] Axiom count + theorem count + definition count + sorry count all match meta.json
- [x] No True stubs
- [x] Title/description disclose axiomatization with explicit provenance
- [x] `assumptions` field lists Green-Tao + Bunyakovsky
- [x] Tier C classification correct for axiom-encoded scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)