### PR TITLE
fix(meta): shannon-channel-coding-oq-03 top-level sorries 0→4

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -225,5 +225,5 @@
       "note": "Chapter 7: Fano's inequality and its application to channel coding converse"
     }
   ],
-  "sorries": 0
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Sync the top-level `sorries` field in `src/data/proofs/shannon-channel-coding-oq-03/meta.json` from `0` to `4`, matching the nested `meta.sorries` field (already `4` since PR #18151 / commit `7e5de8803ab`).

## Evidence

**Before**:
```jsonc
{
  // ...
  "meta": {
    "sorries": 4,            // already correct (set by #18151)
    // ...
  },
  // ...
  "sorries": 0                // stale — drift from #18151
}
```

**After**:
```jsonc
{
  // ...
  "meta": {
    "sorries": 4,
    // ...
  },
  // ...
  "sorries": 4                // now consistent with meta.sorries
}
```

Verification:
```bash
$ grep -cE '\bsorry\b' proofs/Proofs/ShannonChannelCodingOQ03.lean
0
$ grep -cE '\bsorry\b' proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean
4
```

Aggregate = 0 (main) + 4 (Aristotle companion) = **4**.

## Convention

Per the sibling-slug fix in PR #19430:
- `leanFile.sorries`: main-file count only (`0` here — already correct, unchanged)
- `meta.sorries` and top-level `sorries`: aggregate of main + `additionalFiles` (`4` here)

The `meta.assumptions` prose, set by #18151, already correctly enumerates the aggregate breakdown ("0 sorries in main file … companion file contains 4 sorries") — no narrative changes needed.

## Root Cause

PR #18151 updated `.meta.sorries` (0 → 4) but missed the duplicate top-level `.sorries` field, leaving the file internally inconsistent. This PR closes that gap.

## Scope

One field, one entry, minimal diff. No Lean source changes; no companion file changes; no status/badge changes.

---
Automated fix by lean-mechanic agent.