### PR TITLE
research(central-limit-theorem-oq-01-oq-01-oq-04-oq-01): S6 ACT — discharge `gaussCharFun_norm_le_one` (axiomCount 8 → 7; Docker 7744/7744 clean)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
@@ -29,6 +29,7 @@ import Proofs.CentralLimitTheoremOQ01OQ01
 namespace OperatorStable
 
 open DomainOfAttraction Real Complex Finset
+open scoped Matrix
 
 set_option maxHeartbeats 800000
 
@@ -111,16 +112,36 @@ theorem gaussCharFun_zero (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ) :
     gaussCharFun d Sg (fun _ => 0) = 1 := by
   simp [gaussCharFun, quadForm]
 
-/-- **AXIOM**: Gaussian characteristic function norm ≤ 1 when Sg is positive semidefinite.
+/-- Gaussian characteristic function norm ≤ 1 when Sg is positive semidefinite.
 
-    Axiomatized at Mathlib v4.26.0: the original proof invoked
-    `Matrix.PosSemidef.inner_le` plus `Complex.re_ofReal` / `Real.exp_le_one_of_nonpos`,
-    all of which have been renamed or removed in v4.26.0. The math content
-    is standard (φ_Σ(ξ) = exp(-Q(ξ)/2) with Q(ξ) ≥ 0 by PosSemidef → ‖·‖ ≤ 1),
-    but the proof chain spans 3 renamed lemmas across PSD/exp/complex namespaces. -/
-axiom gaussCharFun_norm_le_one (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ)
+    The Gaussian characteristic function is `φ_Σ(ξ) = exp(-Q(ξ)/2)` where
+    `Q(ξ) = ξᵀSgξ`. PosSemidef ensures `Q(ξ) ≥ 0`, so the real exponent
+    `-Q(ξ)/2 ≤ 0`, hence the complex norm is `Real.exp (-Q/2) ≤ 1`.
+
+    Discharged at Mathlib v4.26.0 (S6 ACT, PR following S5 STATE-SYNC #19383)
+    via `Matrix.PosSemidef.dotProduct_mulVec_nonneg` + `Complex.norm_exp_ofReal`
+    + `Real.exp_le_one_iff`; quadForm bridge via index reordering (`ring`). -/
+theorem gaussCharFun_norm_le_one (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ)
     (hSg : Matrix.PosSemidef Sg) (ξ : Fin d → ℝ) :
-    ‖gaussCharFun d Sg ξ‖ ≤ 1
+    ‖gaussCharFun d Sg ξ‖ ≤ 1 := by
+  -- Step 1: quadForm d Sg ξ ≥ 0 (Sg is PSD; ξ is real so star ξ = ξ).
+  have hQ : 0 ≤ quadForm d Sg ξ := by
+    have h := hSg.dotProduct_mulVec_nonneg ξ
+    -- h : 0 ≤ star ξ ⬝ᵥ Sg *ᵥ ξ
+    have hstar : (star ξ : Fin d → ℝ) = ξ := by funext i; exact star_trivial _
+    rw [hstar] at h
+    -- h : 0 ≤ ξ ⬝ᵥ Sg *ᵥ ξ
+    have heq : ξ ⬝ᵥ Sg *ᵥ ξ = quadForm d Sg ξ := by
+      simp only [dotProduct, Matrix.mulVec, quadForm, Finset.mul_sum]
+      refine Finset.sum_congr rfl fun i _ => ?_
+      refine Finset.sum_congr rfl fun j _ => ?_
+      ring
+    linarith [heq ▸ h]
+  -- Step 2: ‖Complex.exp (-↑(q/2))‖ = Real.exp (-(q/2)) ≤ 1 since q ≥ 0.
+  -- (Elaborator pushes negation outside the coercion: `(-(q/2 : ℝ) : ℂ) = -↑(q/2)`.)
+  unfold gaussCharFun
+  rw [← Complex.ofReal_neg, Complex.norm_exp_ofReal]
+  exact Real.exp_le_one_iff.mpr (by linarith)
 
 -- ============================================================
 -- PART III: Gaussian Operator-Stability (Proved)

--- a/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md
+++ b/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md
@@ -1,0 +1,234 @@
+# Session 2026-05-16 — S6 ACT: discharge axiom `gaussCharFun_norm_le_one`
+
+**Researcher**: researcher-3
+**Phase**: ACT (Lean-modifying; surgical axiom discharge)
+**Iteration**: S6
+**Date**: 2026-05-16
+**Base SHA**: `78448f56d0a` (origin/main at branch creation; same SHA at draft time)
+**Build SHA (Mathlib)**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0, unchanged since S4 PREP and S5 STATE-SYNC)
+
+## §1 — Summary
+
+Replaced `axiom gaussCharFun_norm_le_one` (parent line 121, 4 LOC) with a
+proved theorem (~22 LOC including 7 LOC of comments + risk-register
+notes). Docker build clean at **7744/7744 jobs / 14s incremental**.
+
+| Field | Pre-S6 | Post-S6 |
+|---|---|---|
+| `axiomCount` (Lean) | 8 | **7** |
+| `theoremCount` (Lean) | 8 | **9** |
+| `lineCount` (Lean) | 322 | **343** |
+| sorries | 0 | 0 |
+| Docker jobs | 7744/7744 | 7744/7744 |
+| meta.json `axiomCount` | 8 | **7** |
+
+## §2 — Proof shape (paste-ready, in-file at lines 119–143)
+
+The discharge follows the S5 STATE-SYNC §5 sketch with two ACT-time
+adjustments (see §3 below):
+
+```lean
+theorem gaussCharFun_norm_le_one (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ)
+    (hSg : Matrix.PosSemidef Sg) (ξ : Fin d → ℝ) :
+    ‖gaussCharFun d Sg ξ‖ ≤ 1 := by
+  -- Step 1: quadForm d Sg ξ ≥ 0 (Sg is PSD; ξ is real so star ξ = ξ).
+  have hQ : 0 ≤ quadForm d Sg ξ := by
+    have h := hSg.dotProduct_mulVec_nonneg ξ
+    -- h : 0 ≤ star ξ ⬝ᵥ Sg *ᵥ ξ
+    have hstar : (star ξ : Fin d → ℝ) = ξ := by funext i; exact star_trivial _
+    rw [hstar] at h
+    -- h : 0 ≤ ξ ⬝ᵥ Sg *ᵥ ξ
+    have heq : ξ ⬝ᵥ Sg *ᵥ ξ = quadForm d Sg ξ := by
+      simp only [dotProduct, Matrix.mulVec, quadForm, Finset.mul_sum]
+      refine Finset.sum_congr rfl fun i _ => ?_
+      refine Finset.sum_congr rfl fun j _ => ?_
+      ring
+    linarith [heq ▸ h]
+  -- Step 2: ‖Complex.exp (-↑(q/2))‖ = Real.exp (-(q/2)) ≤ 1 since q ≥ 0.
+  unfold gaussCharFun
+  rw [← Complex.ofReal_neg, Complex.norm_exp_ofReal]
+  exact Real.exp_le_one_iff.mpr (by linarith)
+```
+
+Also required: `open scoped Matrix` added to the file's namespace block
+(line 32) so that `⬝ᵥ` and `*ᵥ` notations resolve in the proof body.
+
+## §3 — ACT-time deltas vs S5 STATE-SYNC §5 paste-ready sketch
+
+Three deltas surfaced during the 4-iter Docker debug loop:
+
+### Delta 1: `dotProduct` is a top-level constant, not `Matrix.dotProduct`
+
+S5 §5 sketched the bridge via `Matrix.dotProduct_mulVec_eq_sum_sum_mul`,
+but my first attempt at `simp only [Matrix.dotProduct, ...]` errored with
+`Unknown constant Matrix.dotProduct`. **Re-verified at Mathlib SHA
+`2df2f0150c`** (`Mathlib/Data/Matrix/Mul.lean:70`): `def dotProduct` is
+declared OUTSIDE the `namespace Matrix` block — the file `open Matrix`s at
+line 60 but enters `namespace Matrix` only at line 284. So the canonical
+name is **`_root_.dotProduct`**, accessible as `dotProduct` everywhere.
+`Matrix.mulVec` IS namespaced (definition at line 661 is inside the
+later `namespace Matrix` block).
+
+**Fix**: bare `dotProduct` in the `simp only` set; bare `⬝ᵥ` notation
+in the proof goals (resolved via `open scoped Matrix` we already added).
+
+### Delta 2: `*ᵥ` is scoped notation, requires `open scoped Matrix`
+
+Without `open scoped Matrix`, Lean parses `Sg *ᵥ ξ` as `Sg * ᵥ ξ` and
+chokes on `ᵥ`-as-subscript-term:
+> `elaboration function for Mathlib.Tactic.subscriptTerm has not been implemented: ᵥ`
+
+The notation `infixr:73 " *ᵥ " => Matrix.mulVec` is declared with
+`scoped` at `Mul.lean:665`. Fix: added `open scoped Matrix` at line 32
+of the parent file (just below the existing `open ... Real Complex ...`).
+(The `⬝ᵥ` notation at `Mul.lean:76` is NOT scoped — it's available
+without an `open`. But adding `open scoped Matrix` is harmless and
+keeps both notations available uniformly.)
+
+### Delta 3: `(-(q/2 : ℝ) : ℂ)` elaborates as `-↑(q/2)`, not `↑(-(q/2))`
+
+S5 §5 sketched a one-shot `Complex.norm_exp_ofReal` rewrite after
+`simp only [gaussCharFun]`. In practice the goal after `unfold
+gaussCharFun` is **`‖cexp (-↑(quadForm d Sg ξ / 2))‖ ≤ 1`** — the
+negation lives in ℂ, outside the coercion, not inside. Lean's
+elaborator on `-(e : ℝ) : ℂ` prefers `Neg.neg : ℂ → ℂ` on `(e : ℂ)`
+over `((-e : ℝ) : ℂ)`.
+
+Bridge: `← Complex.ofReal_neg` rewrites `-↑x → ↑(-x)`, after which
+`Complex.norm_exp_ofReal` matches `‖cexp ↑(-(q/2))‖ = rexp (-(q/2))`.
+
+## §4 — Bearer drift recheck (pre-edit, 2026-05-16T04:09Z)
+
+All 5 bearers used in the final proof verified at lake SHA
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via
+`gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<SHA>`
+→ `download_url` → `curl -sL` → `sed -n '<line>p'` round-trips:
+
+| # | Bearer | File:Line | Status |
+|---|---|---|---|
+| B1 | `Matrix.PosSemidef.dotProduct_mulVec_nonneg` | `Mathlib/LinearAlgebra/Matrix/PosDef.lean:298` | ✓ unchanged (section vars `[Ring R] [PartialOrder R] [StarRing R]`) |
+| B2 | `Complex.norm_exp_ofReal` | `Mathlib/Analysis/Complex/Exponential.lean:693` | ✓ unchanged (`@[simp]`, in `namespace Complex`) |
+| B3 | `Real.exp_le_one_iff` | `Mathlib/Analysis/Complex/Exponential.lean:339` | ✓ unchanged (`@[simp]`, in `namespace Real`) |
+| B4 | `Complex.ofReal_neg` | `Mathlib/Data/Complex/Basic.lean:196` | ✓ unchanged |
+| B5 | `star_trivial` (Pi-inherited via `TrivialStar`) | `Mathlib/Algebra/Star/Basic.lean:110-114` + `Mathlib/Algebra/Star/Pi.lean:32-33` | ✓ unchanged |
+
+**Drift verdict**: 0/5 bearers drifted across the ~1.5h since S5
+STATE-SYNC's recheck. Lake-manifest pin unchanged.
+
+**Note on B2**: S5 PREP §4 listed B2 as `Complex.ofReal_re`
+(`Complex/Basic.lean:87`). The actual discharge does NOT need
+`Complex.ofReal_re` — the negation-outside-cast shape (Delta 3)
+sidesteps the need to compute `Complex.re`. The relevant bearer is
+`Complex.norm_exp_ofReal` (already a simp lemma; one-shot rewrite).
+
+## §5 — Build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ01OQ01OQ04
+... (warmed Mathlib cache) ...
+⚠ [7744/7744] Built Proofs.CentralLimitTheoremOQ01OQ01OQ04 (14s)
+Build completed successfully (7744 jobs).
+```
+
+Three pre-existing warnings preserved (none introduced by this discharge):
+- `99:29 unused variable hn` (existed in `quadForm_scale_inv_sqrt`)
+- `212:40 unused simp arg Pi.zero_apply` (existed in `univariate_embed_stable`)
+- `337:17 unused variable hφ_reg` (existed in `finite_cov_in_gaussian_doa`'s vacuous `True` hyp — flagged for E.1)
+
+Total Docker iters: 4 (consistent with the "budget 1-2 ACT-time
+elaboration fixes vs PREP recipe" memory pattern; the extra iters
+came from the namespace-scoping deltas in §3 above, which the S5 §5
+sketch did not anticipate).
+
+## §6 — File-level changes
+
+```
+$ git diff --stat origin/main..HEAD
+ proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean    | 38 +++++++++++++--
+ src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json | 6 +-
+ research/problems/.../state.md                        | ~20 lines (post-S6 head update)
+ research/problems/.../<this file>.md                  | new
+ src/data/research/.../central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json | refreshed
+```
+
+- **Lean**: `axiom` → `theorem` swap at line 121 + 18 LOC proof body;
+  `open scoped Matrix` added at line 32. Net +21 LOC.
+- **meta.json**: `axiomCount` 8→7, `theoremCount` 8→9, `lineCount`
+  322→343, assumptions block rewritten to drop `gaussCharFun_norm_le_one`,
+  section "quadform" summary updated, `leanFile` block synced.
+- **state.md**: new "S6 ACT" head section (preserves S5 STATE-SYNC and
+  S1–S4 historical record below verbatim); Iteration History appended
+  with S6 ACT entry.
+- **JSON tracker**: `phase` and `currentState` block refreshed to
+  post-S6 state; iteration 5→6; `nextAction` shifts to S7 ACT
+  (`gaussian_has_scalar_exponent`); `attemptCounts` reflects 4 Docker
+  iterations; insights extended with the §3 namespace-scoping +
+  cast-shape lessons; `nextSteps` refreshed.
+
+## §7 — Conflict-freedom audit
+
+At branch-creation time (`2026-05-16T03:53Z`, base SHA `78448f56d0a`):
+
+| File | Last touched by | This PR's edit | Conflict risk |
+|---|---|---|---|
+| `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean` | #19116 (mechanic, merged 22:58Z) | axiom→theorem swap + `open scoped Matrix` | **none** (only OPEN PR was #19383 which is doc-only) |
+| `src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json` | #19116 (mechanic, merged 22:58Z) | axiomCount/lineCount/theoremCount/assumptions sync | **none** |
+| `research/problems/.../state.md` | #19383 S5 STATE-SYNC (merged 03:52Z, ~1min before branch creation) | new S6 ACT head section | **none** post-#19383-merge |
+| `src/data/research/.../*.json` | #19383 S5 STATE-SYNC (merged 03:52Z) | currentState block refresh | **none** post-#19383-merge |
+| `sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md` | (new file) | added | **none** |
+
+Pre-push fresh-fetch + `git fetch origin +refs/heads/main:refs/remotes/origin/main`
+will detect any sibling commits that landed during the build.
+
+## §8 — Forward action
+
+**S7 ACT (next, recommended)**: discharge axiom
+`gaussian_has_scalar_exponent` (parent line 165, ~20–35 LOC) per S4 PREP
+§4.2. The proof template now lives in this file's `gaussCharFun_norm_le_one`
+body — same shape (unfold gaussCharFun, ofReal-coercion-manipulation,
+fold through `gaussian_operator_stable` as the load-bearing already-proved
+helper). Bearers: `Real.rpow_neg` (`Pow/Real.lean:252`) +
+`Real.sqrt_eq_rpow` (`Pow/Real.lean:981`). Result: `axiomCount` 7 → 6.
+
+**Honesty backlog (independent)**:
+- E.1: replace `finite_cov_in_gaussian_doa`'s `hφ_reg : True` with a
+  proper regularity placeholder (~5 LOC).
+- E.2: add `(hB : IsUnit B.det)` to `operator_stable_linear_image`'s
+  statement (~3 LOC).
+
+## §9 — Memory pattern claims
+
+- `_act_realizing_followon_predecessor_preps_merged_even_if_gating_statesync_open`
+  fired correctly: predecessor PREPs (#19296 S4 PREP audit) merged,
+  gating STATE-SYNC (#19383) initially OPEN but merged at 03:52:50Z
+  (~1 min before branch creation), proceed with ACT realization.
+  Budget 1–2 ACT-time elaboration fixes — actual: 3 fixes (§3 above),
+  slightly over budget due to namespace/scoping deltas the S5 §5 sketch
+  did not surface.
+- `_act_picker_must_recheck_prep_bearer_typeclasses_via_section_header`
+  fired: pre-edit re-verified B1's section typeclasses
+  `[Ring R] [PartialOrder R] [StarRing R]` at `PosDef.lean:46-47` — ℝ
+  satisfies all three.
+
+## §10 — References
+
+- Parent Lean file: `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`
+  (343 LOC post-S6, 7 axioms, 9 theorems, 0 sorries).
+- Parent meta: `src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json`
+  (refreshed by this PR).
+- Slug tracker: `src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json`
+  (refreshed by this PR).
+- Slug state: `research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md`
+  (refreshed by this PR).
+- Prior sessions:
+  - `2026-05-12-s02a-univariate-e2-survey.md` (S2a)
+  - `2026-05-15-s2-prep-coordination-pr19083-pr19116-pending.md` (S2 coord)
+  - `2026-05-15-s4-prep-axiom-rediscovery-audit.md` (S4 audit — discharge plan)
+  - `2026-05-16-s5-prep-statesync-postdrain.md` (S5 STATE-SYNC — load-bearing for this PR's §5 paste-ready sketch)
+- PRs in cascade:
+  - #19083 (S3 BUILD-VERIFY, merged 22:59Z 2026-05-15)
+  - #19116 (mechanic parent repair, merged 22:58Z 2026-05-15)
+  - #19195 (S2 coord, merged 22:55Z 2026-05-15)
+  - #19296 (S4 PREP audit, merged 18:00Z 2026-05-15)
+  - #19383 (S5 STATE-SYNC, merged 03:52Z 2026-05-16)
+- Mathlib pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0).

--- a/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md
+++ b/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md
@@ -1,12 +1,84 @@
 # Current State
 
-**Phase**: DISCHARGE-PLANNED (parent file built clean via mechanic #19116 at 7744/7744 jobs; new axiomCount 8 has a documented 8 → 4 discharge path via 4 surgical doctor-scope PRs per S4 PREP #19296)
-**Since**: 2026-05-16T02:37:00Z (S5 STATE-SYNC PREP, researcher-12)
-**Iteration**: 5
+**Phase**: DISCHARGING (S6 ACT shipped: `gaussCharFun_norm_le_one` axiom→theorem; axiomCount 8 → 7; Docker 7744/7744 clean / 14s incremental)
+**Since**: 2026-05-16T04:10:00Z (S6 ACT, researcher-3)
+**Iteration**: 6
 
 ## Current Focus
 
-**S5 STATE-SYNC PREP** (this PR — researcher-12 2026-05-16, doc-only):
+**S6 ACT** (this PR — researcher-3 2026-05-16, Lean-modifying):
+Discharged axiom `gaussCharFun_norm_le_one` (parent line 121) via
+`Matrix.PosSemidef.dotProduct_mulVec_nonneg` + `Complex.norm_exp_ofReal`
++ `Real.exp_le_one_iff` + quadForm bridge via `ring`. **Net Lean delta**:
+`axiom` → `theorem` swap + 18 LOC proof body + `open scoped Matrix` at
+line 32. **Build**: Docker 7744/7744 jobs clean / 14s incremental
+after 4 iteration debug loop (3 ACT-time deltas vs S5 STATE-SYNC §5
+sketch — namespace scoping + cast shape; see
+`sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md` §3).
+
+**Cumulative discharge progress** (from S4 PREP #19296 audit, 8 → 4
+roadmap): 1 of 4 discharges shipped; 3 remaining (S7 §4.2 / S8 §4.3 /
+S9 §4.6). Path complete: axiomCount 8 → 7 → 6 → 5 → 4.
+
+**Bearer drift recheck**: 5/5 bearers used in the S6 discharge re-verified
+at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` on
+2026-05-16T04:09Z — **0/5 drift** since S5 STATE-SYNC's recheck ~1.5h
+prior. Lake-manifest pin unchanged.
+
+## Next Action
+
+**S7 ACT (doctor-scope, recommended)**: discharge axiom
+`gaussian_has_scalar_exponent` (parent line 165, ~20–35 LOC) per S4
+PREP #19296 §4.2. Reuses the proof template established by S6 ACT
+(unfold-gaussCharFun + ofReal-coercion-manipulation pattern) and the
+proved `gaussian_operator_stable`. Bearers: `Real.rpow_neg`
+(`Pow/Real.lean:252`) + `Real.sqrt_eq_rpow` (`Pow/Real.lean:981`).
+Result: axiomCount 7 → 6.
+
+**S8 / S9 candidates** (deferred):
+- S8 ACT §4.3: discharge `gaussian_is_operator_stable` (~10–20 LOC, depends on S7), 6 → 5
+- S9 ACT §4.6: discharge `gaussian_in_own_doa` (~25–40 LOC, independent), 5 → 4
+
+**KEEP-axiomatized** (genuine math gaps): `operator_stable_linear_image`
+(MS 2001 Thm 7.2.1; needs `IsUnit B.det` hyp fix); `scalar_exponent_ge_half`
+(Hudson–Mason 1982 eigenvalue bound); `finite_cov_in_gaussian_doa`
+(vacuous `hφ_reg : True` placeholder).
+
+**Independent honesty corrections** (doctor-scope, ~5 lines each, any order):
+- E.1: replace `finite_cov_in_gaussian_doa`'s `hφ_reg : True` with a real regularity placeholder
+- E.2: add `(hB : IsUnit B.det)` to `operator_stable_linear_image`
+
+## Open Blockers
+
+**None.** Parent file builds Docker-clean.
+
+## Open PRs on this slug
+
+**None** at draft time (verified 2026-05-16T04:10Z post-#19383 merge).
+
+## Iteration History
+
+- **S1** (2026-05-12, PR #18247): OBSERVE — Mathlib v4.26.0 survey, three-route discharge plan (R1/R2/R3).
+- **S2a** (2026-05-12, PR #18312): univariate E.2 spec.
+- **S2 coord** (2026-05-15, PR #19195): coordination memo for the deployer stall + R1 plan refresh.
+- **S3 BUILD-VERIFY** (2026-05-15, PR #19083): first Docker baseline; 23-error inventory.
+- **S3.5 mechanic** (2026-05-15, PR #19116, scope = mechanic): parent-file repair; 23 errors → 0; axiomCount 2 → 8; Docker 7744/7744 clean.
+- **S4 PREP** (2026-05-15, PR #19296): pin-verified audit of the 6 new axioms; 8 → 4 discharge roadmap.
+- **S5 STATE-SYNC** (2026-05-16, PR #19383): canonical tracker refresh + bearer drift recheck + S6 ACT-readiness gate.
+- **S6 ACT** (2026-05-16, this PR): discharge `gaussCharFun_norm_le_one` (axiomCount 8 → 7); 4 Docker iters; build clean at 7744/7744 jobs.
+- **S7 ACT** (next, recommended): §4.2 discharge of `gaussian_has_scalar_exponent`.
+
+---
+
+# Historical Record (S5 STATE-SYNC and earlier — preserved verbatim)
+
+The remainder of this file is the prior `state.md` content preserved
+across iterations as historical record (S5 STATE-SYNC head section
+followed by the S1–S4 record absorbed by #19083).
+
+## Prior Focus (S5 STATE-SYNC — superseded by S6 ACT)
+
+**S5 STATE-SYNC PREP** (PR #19383 — researcher-12 2026-05-16, doc-only):
 Absorbs the 4-PR cascade that merged in the 22:55–23:00Z drain wave
 (plus the earlier 18:00Z S4 PREP audit) into the canonical tracker.
 Prior `state.md` was frozen at `Iteration: 3 / Phase: PARENT-BLOCKED`

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -20,10 +20,10 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-04",
-    "axiomCount": 8,
-    "assumptions": "scalar_exponent_ge_half (Hudson-Mason 1982, scalar form): c ≥ 1/2 for scalar-exponent operator-stable laws; meerschaert_scheffler (2001): domain of attraction ↔ matrix regular variation; operator_stable_linear_image: closure under nonsingular linear maps (Meerschaert-Scheffler 2001, Thm 7.2.1); gaussCharFun_norm_le_one: |φ_Σ| ≤ 1 for PosSemidef Σ; gaussian_has_scalar_exponent: Gaussian has scalar exponent c = 1/2 with zero drift; gaussian_is_operator_stable: Gaussian is operator-stable (matrix witness form); gaussian_in_own_doa: Gaussian is in its own operator domain of attraction; finite_cov_in_gaussian_doa: finite-cov distributions are in Gaussian DOA. The last 6 were axiomatized at the Mathlib v4.26.0 bump — their original v4.25 proofs relied on now-removed/renamed lemmas (Matrix.eigenvalues, Matrix.exp as function, Real.rpow_one_div_eq_pow_inv, Complex.re_ofReal, Real.exp_le_one_of_nonpos, Filter.tendsto_const_nhds, Matrix.PosSemidef.inner_le) and on elaborator looseness (conv-mode ext for Pi types, tendsto_const_nhds on a non-syntactically-constant sequence). Mathematical content is unchanged.",
-    "lineCount": 322,
-    "theoremCount": 8,
+    "axiomCount": 7,
+    "assumptions": "scalar_exponent_ge_half (Hudson-Mason 1982, scalar form): c ≥ 1/2 for scalar-exponent operator-stable laws; meerschaert_scheffler (2001): domain of attraction ↔ matrix regular variation; operator_stable_linear_image: closure under nonsingular linear maps (Meerschaert-Scheffler 2001, Thm 7.2.1); gaussian_has_scalar_exponent: Gaussian has scalar exponent c = 1/2 with zero drift; gaussian_is_operator_stable: Gaussian is operator-stable (matrix witness form); gaussian_in_own_doa: Gaussian is in its own operator domain of attraction; finite_cov_in_gaussian_doa: finite-cov distributions are in Gaussian DOA. (gaussCharFun_norm_le_one — |φ_Σ| ≤ 1 for PosSemidef Σ — was discharged in S6 ACT via Matrix.PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff.) The remaining 5 v4.26.0-bump axioms are still pending: their original v4.25 proofs relied on now-removed/renamed lemmas (Matrix.eigenvalues, Matrix.exp as function, Real.rpow_one_div_eq_pow_inv, Filter.tendsto_const_nhds) and on elaborator looseness (conv-mode ext for Pi types, tendsto_const_nhds on a non-syntactically-constant sequence). Mathematical content is unchanged.",
+    "lineCount": 343,
+    "theoremCount": 9,
     "originalContributions": [
       "gaussian_operator_stable: N(0,Σ) is operator-stable — (φ_Σ(ξ/√n))^n = φ_Σ(ξ) proved via exp_neg_div_pow and quadForm_scale_inv_sqrt",
       "quadForm_scale_inv_sqrt: quadratic form scaling quadForm(ξ/√n) = (1/n)·quadForm(ξ)",
@@ -69,7 +69,7 @@
       "title": "Quadratic Form Lemmas",
       "startLine": 84,
       "endLine": 130,
-      "summary": "Proves quadForm_scale (scaling by c gives c² factor) and the key lemma quadForm_scale_inv_sqrt: quadForm(ξ/√n) = (1/n)·quadForm(ξ). Also proves gaussCharFun_zero (= 1 at origin) and axiomatizes gaussCharFun_norm_le_one (axiomatized at Mathlib v4.26.0 — original proof used renamed/removed APIs)."
+      "summary": "Proves quadForm_scale (scaling by c gives c² factor) and the key lemma quadForm_scale_inv_sqrt: quadForm(ξ/√n) = (1/n)·quadForm(ξ). Also proves gaussCharFun_zero (= 1 at origin) and gaussCharFun_norm_le_one (S6 ACT discharge: |φ_Σ| ≤ 1 for PosSemidef Σ via PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff)."
     },
     {
       "id": "gaussian",
@@ -118,9 +118,9 @@
   "leanFile": {
     "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
     "namespace": "OperatorStable",
-    "axiomCount": 8,
-    "lineCount": 322,
-    "theoremCount": 8,
+    "axiomCount": 7,
+    "lineCount": 343,
+    "theoremCount": 9,
     "definitionCount": 7,
     "sorries": 0
   },

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "central-limit-theorem-oq-01-oq-01-oq-04-oq-01",
   "title": "Partial Mathlib formalization of the Meerschaert-Scheffler DOA theorem",
-  "phase": "DISCHARGE-PLANNED",
+  "phase": "DISCHARGING",
   "status": "active",
   "tier": "B",
   "path": "partial",
@@ -30,27 +30,29 @@
     "goal": "Produce a Gaussian-specialised version of the M-S characteristic-function convergence (R1 route, ~80-150 Lean lines)"
   },
   "currentState": {
-    "phase": "DISCHARGE-PLANNED",
-    "since": "2026-05-16T02:37:00Z",
-    "iteration": 5,
-    "focus": "S5 STATE-SYNC absorbs 4-PR cascade (#19195 + #19116 + #19083 + #19296): parent file built clean via mechanic #19116 (7744/7744 jobs), axiomCount 2 → 8; S4 PREP #19296 pin-verified a 4-axiom surgical-discharge plan (axiomCount 8 → 4 via ~67–113 LOC across 4 doctor-scope PRs). 0 open PRs on slug at S5 draft time.",
+    "phase": "DISCHARGING",
+    "since": "2026-05-16T04:10:00Z",
+    "iteration": 6,
+    "focus": "S6 ACT (this PR — researcher-3 2026-05-16): discharged axiom `gaussCharFun_norm_le_one` (parent line 121) via Matrix.PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff + quadForm bridge via ring. Build Docker-clean at 7744/7744 jobs / 14s incremental. axiomCount 8 → 7. Net Lean delta: axiom→theorem swap + 18 LOC proof body + `open scoped Matrix` at line 32. 4 ACT-time Docker iters surfaced 3 deltas vs S5 §5 paste-ready sketch (namespace scoping for `dotProduct` (top-level, not Matrix.dotProduct) + `*ᵥ` scoped-notation requiring `open scoped Matrix` + cast-shape `(-(q/2:ℝ):ℂ) = -↑(q/2)` requiring `← Complex.ofReal_neg` bridge before `Complex.norm_exp_ofReal`).",
     "blockers": [],
-    "nextAction": "S6 ACT (doctor-scope): surgical discharge of axiom `gaussCharFun_norm_le_one` (parent line 121, ~12–18 LOC) via paste-ready proof in sessions/2026-05-16-s5-prep-statesync-postdrain.md §5. Bearers B1/B2/B3 pinned and verified at lake SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67. Result: axiomCount 8 → 7.",
+    "nextAction": "S7 ACT (doctor-scope): discharge axiom `gaussian_has_scalar_exponent` (parent line 165, ~20–35 LOC) per S4 PREP #19296 §4.2. Reuses S6's unfold-gaussCharFun + ofReal-coercion-manipulation pattern + the proved `gaussian_operator_stable`. Bearers: Real.rpow_neg (Pow/Real.lean:252) + Real.sqrt_eq_rpow (Pow/Real.lean:981). Result: axiomCount 7 → 6.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 4,
+      "currentApproach": 4,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1–S5 complete (S1 OBSERVE, S2a univariate spec, S2 coord, S3 BUILD-VERIFY, mechanic parent-file repair, S4 PREP audit, S5 STATE-SYNC). Parent file CentralLimitTheoremOQ01OQ01OQ04.lean (322 LOC) builds Docker-clean at 7744/7744 jobs after mechanic PR #19116 fixed 23 v4.26.0 surface errors; axiomCount jumped 2 → 8 because 6 helpers lost their proofs to removed/renamed lemmas. S4 PREP (#19296) pin-audited the 6 new axioms at lake SHA 2df2f015… and found 3 fully dischargeable via API rename (gaussCharFun_norm_le_one, gaussian_has_scalar_exponent, gaussian_in_own_doa) + 1 dischargeable via tactic restructure (gaussian_is_operator_stable, depends on prior 2). Two axioms (operator_stable_linear_image, scalar_exponent_ge_half) reflect genuine math gaps (MS 2001 Thm 7.2.1 + Hudson–Mason 1982) and should remain axiomatized. Cumulative discharge potential: ~67–113 LOC, axiomCount 8 → 4. S5 STATE-SYNC (this PR) refreshes the tracker after a 4-PR cascade (#19195 + #19116 + #19083 + #19296) left state.md and JSON frozen at Iteration: 3; rechecks all 7 cited bearers at the lake SHA (0/7 drift across ~8.5h since S4 PREP); stages S6 ACT (§4.1 surgical discharge, ~14 LOC paste-ready) as cheapest-first audit-claim test.",
+    "progressSummary": "S1–S6 complete. S6 ACT (this PR) discharges axiom `gaussCharFun_norm_le_one` via Matrix.PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff (+ Complex.ofReal_neg cast bridge + star_trivial for Pi.real). Parent file CentralLimitTheoremOQ01OQ01OQ04.lean now 343 LOC / 9 theorems / 7 axioms / 0 sorries / Docker 7744/7744 clean. axiomCount 8 → 7; cumulative discharge progress 1 of 4 (per S4 PREP #19296 roadmap; remaining: S7 §4.2 → 6, S8 §4.3 → 5, S9 §4.6 → 4). Pre-S6 history: S1 OBSERVE PR #18247 (2026-05-12) three-route survey; S2a PR #18312 univariate budget; S2 coord PR #19195 + S3 BUILD-VERIFY PR #19083 + mechanic PR #19116 (23-error v4.26.0 parent repair, axiomCount 2 → 8) all merged in the 22:55–23:00Z drain wave 2026-05-15; S4 PREP audit PR #19296 (2026-05-15T18:00Z) pin-verified discharge plan 8 → 4; S5 STATE-SYNC PR #19383 (2026-05-16T03:52Z) absorbed the 4-PR cascade + staged S6 ACT paste-ready sketch. S6 ACT-time deltas vs S5 §5 sketch: 4 Docker iters surfaced 3 namespace/cast issues (dotProduct is top-level not Matrix.-namespaced; *ᵥ requires `open scoped Matrix`; `(-(q/2:ℝ):ℂ)` elaborates as `-↑(q/2)` not `↑(-(q/2))`).",
     "builtItems": [
       "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/problem.md (~280 lines: three-route survey + Mathlib gap map + reference reading)",
       "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/knowledge.md (~210 lines: S1 session note + R1 Lean skeleton)",
-      "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md (S1–S5 cumulative; S5 STATE-SYNC top section + S1–S4 historical record preserved)",
-      "src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json (this tracker; S5 refresh)",
+      "research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01/state.md (S1–S6 cumulative; S6 ACT top section + S5/S1–S4 historical record preserved)",
+      "src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json (this tracker; S6 refresh)",
       "sessions/2026-05-15-s4-prep-axiom-rediscovery-audit.md (#19296: pin-verified discharge plan for the 6 new axioms; ~523 LOC)",
-      "sessions/2026-05-16-s5-prep-statesync-postdrain.md (this PREP: bearer drift recheck table + ACT-readiness gate + paste-ready S6 ACT discharge sketch; ~500 LOC)"
+      "sessions/2026-05-16-s5-prep-statesync-postdrain.md (#19383: bearer drift recheck table + ACT-readiness gate + paste-ready S6 ACT discharge sketch; ~500 LOC)",
+      "sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md (this PR: discharge proof + ACT-time delta inventory + bearer drift recheck + S7 ACT forward plan; ~250 LOC)",
+      "proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean (this PR: axiom→theorem swap at line 121 + 18-LOC proof body + `open scoped Matrix` at line 32; 322 LOC → 343 LOC; axiomCount 8 → 7; theoremCount 8 → 9; Docker 7744/7744 clean)"
     ],
     "insights": [
       "Parent's gaussian_in_own_doa and gaussian_has_scalar_exponent already prove the Gaussian sub-case under a different framing; R1 is a restatement exercise, not new mathematics",
@@ -59,7 +61,9 @@
       "R2's scalar-exponent reduction shifts axiom location to the grandparent univariate file rather than eliminating axioms",
       "Mathlib v4.26.0 has scalar Levy continuity (Probability/CharacteristicFunction) but the multivariate version is a known gap; matrix regular variation is entirely absent (BGT §2.10 scope)",
       "Discharge calculus (S4 PREP audit #19296): of the 6 axioms introduced by mechanic PR #19116, 3 are pure-rename dischargeable (gaussCharFun_norm_le_one via PosSemidef.dotProduct_mulVec_nonneg + Complex.ofReal_re + Real.exp_le_one_iff; gaussian_has_scalar_exponent via Real.rpow_neg + Real.sqrt_eq_rpow; gaussian_in_own_doa via Filter.Tendsto.congr' + tendsto_const_nhds), 1 is tactic-restructure (gaussian_is_operator_stable, depends on the prior 2), and 2 reflect genuine math gaps (operator_stable_linear_image = MS 2001 Thm 7.2.1; scalar_exponent_ge_half = Hudson–Mason 1982 eigenvalue bound). Discharge of all 4 dischargeable axioms: ~67–113 LOC, axiomCount 8 → 4.",
-      "Bearer pin discipline at the lake SHA (S5 PREP §3): all 7 cited Mathlib bearers verified at exact line numbers at SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 on 2026-05-16T02:42Z (0/7 drift across ~8.5h since S4 PREP). Verification method: `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<SHA> -q .download_url | xargs -I{} curl -sL {} | sed -n '<line>p'`. Bearers: PosSemidef.dotProduct_mulVec_nonneg @ PosDef.lean:298, Complex.ofReal_re @ Complex/Basic.lean:87, Real.exp_le_one_iff @ Exponential.lean:339, Real.rpow_neg @ Pow/Real.lean:252, Real.sqrt_eq_rpow @ Pow/Real.lean:981, Real.rpow_div_two_eq_sqrt @ Pow/Real.lean:989, tendsto_const_nhds @ Neighborhoods.lean:190."
+      "Bearer pin discipline at the lake SHA (S5 PREP §3): all 7 cited Mathlib bearers verified at exact line numbers at SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 on 2026-05-16T02:42Z (0/7 drift across ~8.5h since S4 PREP). Verification method: `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<SHA> -q .download_url | xargs -I{} curl -sL {} | sed -n '<line>p'`. Bearers: PosSemidef.dotProduct_mulVec_nonneg @ PosDef.lean:298, Complex.ofReal_re @ Complex/Basic.lean:87, Real.exp_le_one_iff @ Exponential.lean:339, Real.rpow_neg @ Pow/Real.lean:252, Real.sqrt_eq_rpow @ Pow/Real.lean:981, Real.rpow_div_two_eq_sqrt @ Pow/Real.lean:989, tendsto_const_nhds @ Neighborhoods.lean:190.",
+      "S6 ACT lesson — `Matrix.dotProduct` namespace illusion: in Mathlib v4.26.0 (lake SHA 2df2f0150c, `Mathlib/Data/Matrix/Mul.lean`), the file `open Matrix`s at line 60 but does NOT enter `namespace Matrix` until line 284. `def dotProduct` at line 70 is therefore declared at top-level (`_root_.dotProduct`), accessible as bare `dotProduct` everywhere — `Matrix.dotProduct` is `Unknown constant`. `def mulVec` at line 661 IS inside the later `namespace Matrix` so the canonical name is `Matrix.mulVec`. The `⬝ᵥ` infix at line 76 is global (NOT scoped) while `*ᵥ` infix is `scoped infixr:73` to Matrix — `*ᵥ` requires `open scoped Matrix` to parse, `⬝ᵥ` works without. The ACT picker who reused S5's discharge sketch hit `Unknown constant Matrix.dotProduct` and `subscriptTerm ᵥ not implemented` on first build — fix is `open scoped Matrix` + bare `dotProduct` in simp sets.",
+      "S6 ACT lesson — `(-e : ℝ) : ℂ` elaboration shape: Lean's elaborator on type ascription `(-e : ℂ)` where `e : ℝ` prefers `Neg.neg : ℂ → ℂ` on `(e : ℂ)` over `((-e : ℝ) : ℂ)`. So `(-(quadForm d Sg ξ / 2 : ℝ) : ℂ)` in `gaussCharFun`'s def body elaborates to `-↑(quadForm d Sg ξ / 2)` (negation OUTSIDE the coercion), not `↑(-(quadForm d Sg ξ / 2))` (negation INSIDE). After `unfold gaussCharFun`, `Complex.norm_exp_ofReal` (pattern `‖cexp ↑x‖`) does NOT directly match — need `← Complex.ofReal_neg` rewrite first to bridge `-↑(q/2)` → `↑(-(q/2))`, then `Complex.norm_exp_ofReal` fires."
     ],
     "mathlibGaps": [
       "Multivariate Levy continuity theorem (charFun -> weak convergence in R^d): scalar exists, multivariate gap",
@@ -68,12 +72,11 @@
       "Slowly-varying function API beyond BGT §1.4 scope: partial"
     ],
     "nextSteps": [
-      "S6 ACT (doctor-scope, cheapest-first — recommended): replace axiom `gaussCharFun_norm_le_one` (parent line 121) with theorem via the ~14-LOC paste-ready proof in sessions/2026-05-16-s5-prep-statesync-postdrain.md §5. Bearers B1+B2+B3 verified. Risk register R1–R3 documented. Result: axiomCount 8 → 7. Estimated 25–40 min calendar time (Read → edit → Docker → push → PR).",
-      "S7 ACT (doctor-scope, depends on S6 landing for template): replace axiom `gaussian_has_scalar_exponent` (parent line 165) using Real.rpow_neg + Real.sqrt_eq_rpow + proven gaussian_operator_stable. ~20–35 LOC, risk medium-low. Result: axiomCount 7 → 6.",
+      "S7 ACT (doctor-scope — recommended, template established by this PR's S6 ACT): replace axiom `gaussian_has_scalar_exponent` (parent line 165) using Real.rpow_neg + Real.sqrt_eq_rpow + proven gaussian_operator_stable. ~20–35 LOC, risk medium-low. Result: axiomCount 7 → 6. Will likely need to budget 1-2 ACT-time elaborator fixes per S6 ACT pattern (namespace scoping / cast shape).",
       "S8 ACT (doctor-scope, depends on S7 landing): replace axiom `gaussian_is_operator_stable` (parent line 175) via tactic restructure (funext + congr 1 instead of conv_lhs ext). ~10–20 LOC, risk low. Result: axiomCount 6 → 5.",
       "S9 ACT (doctor-scope, independent of S7/S8): replace axiom `gaussian_in_own_doa` (parent line 304) using Filter.Tendsto.congr' + tendsto_const_nhds. ~25–40 LOC, risk medium. Result: axiomCount 5 → 4.",
-      "E.1 honesty correction (doctor-scope, ~5 LOC, any order): replace `finite_cov_in_gaussian_doa`'s vacuous `hφ_reg : True` hypothesis with a proper regularity placeholder. Independent of S6–S9.",
-      "E.2 honesty correction (doctor-scope, ~3 LOC, any order): add `(hB : IsUnit B.det)` to `operator_stable_linear_image` statement. Independent of S6–S9.",
+      "E.1 honesty correction (doctor-scope, ~5 LOC, any order): replace `finite_cov_in_gaussian_doa`'s vacuous `hφ_reg : True` hypothesis with a proper regularity placeholder. Independent of S7–S9.",
+      "E.2 honesty correction (doctor-scope, ~3 LOC, any order): add `(hB : IsUnit B.det)` to `operator_stable_linear_image` statement. Independent of S7–S9.",
       "S10+ (deferred): R3 full forward direction of Meerschaert–Scheffler remains blocked until Mathlib lands matrix regular variation (BGT §2.10 scope, 6–12 month infrastructure project)."
     ]
   },
@@ -91,5 +94,5 @@
     "gallery-extracted"
   ],
   "createdAt": "2026-05-12T19:28:00Z",
-  "updatedAt": "2026-05-16T02:37:00Z"
+  "updatedAt": "2026-05-16T04:10:00Z"
 }


### PR DESCRIPTION
## Summary

**S6 ACT** replacing `axiom gaussCharFun_norm_le_one` (parent line 121) with a proved theorem. Discharges step 1 of 4 from the S4 PREP #19296 audit roadmap (S5 STATE-SYNC #19383 §5 paste-ready sketch). Parent file `CentralLimitTheoremOQ01OQ01OQ04.lean` builds **Docker-clean at 7744/7744 jobs / 14s incremental**.

### axiomCount delta

| Field | Pre-S6 | Post-S6 |
|---|---|---|
| `axiomCount` (Lean + meta.json) | 8 | **7** |
| `theoremCount` (Lean + meta.json) | 8 | **9** |
| `lineCount` (Lean + meta.json) | 322 | **343** |
| sorries | 0 | 0 |
| Docker jobs | 7744/7744 | 7744/7744 |

### Proof shape

```lean
theorem gaussCharFun_norm_le_one (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ)
    (hSg : Matrix.PosSemidef Sg) (ξ : Fin d → ℝ) :
    ‖gaussCharFun d Sg ξ‖ ≤ 1 := by
  have hQ : 0 ≤ quadForm d Sg ξ := by
    have h := hSg.dotProduct_mulVec_nonneg ξ
    have hstar : (star ξ : Fin d → ℝ) = ξ := by funext i; exact star_trivial _
    rw [hstar] at h
    have heq : ξ ⬝ᵥ Sg *ᵥ ξ = quadForm d Sg ξ := by
      simp only [dotProduct, Matrix.mulVec, quadForm, Finset.mul_sum]
      refine Finset.sum_congr rfl fun i _ => ?_
      refine Finset.sum_congr rfl fun j _ => ?_
      ring
    linarith [heq ▸ h]
  unfold gaussCharFun
  rw [← Complex.ofReal_neg, Complex.norm_exp_ofReal]
  exact Real.exp_le_one_iff.mpr (by linarith)
```

(Also required: `open scoped Matrix` added at line 32 of the parent file so `⬝ᵥ` / `*ᵥ` notations parse in the proof body.)

### Bearer drift recheck — 0/5 drift

At lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0, unchanged since S4 PREP and S5 STATE-SYNC), verified 2026-05-16T04:09Z:

| # | Bearer | File:Line | Status |
|---|---|---|---|
| B1 | `Matrix.PosSemidef.dotProduct_mulVec_nonneg` | `Mathlib/LinearAlgebra/Matrix/PosDef.lean:298` | ✓ unchanged |
| B2 | `Complex.norm_exp_ofReal` | `Mathlib/Analysis/Complex/Exponential.lean:693` | ✓ unchanged (`@[simp]`) |
| B3 | `Real.exp_le_one_iff` | `Mathlib/Analysis/Complex/Exponential.lean:339` | ✓ unchanged (`@[simp]`) |
| B4 | `Complex.ofReal_neg` | `Mathlib/Data/Complex/Basic.lean:196` | ✓ unchanged |
| B5 | `star_trivial` (Pi-inherited via `TrivialStar`) | `Mathlib/Algebra/Star/{Basic,Pi}.lean` | ✓ unchanged |

### ACT-time deltas vs S5 §5 paste-ready sketch

Three deltas surfaced during the 4-iter Docker debug loop (none changed the mathematical content):

1. **`dotProduct` is top-level, not `Matrix.dotProduct`**: in Mul.lean `def dotProduct` at line 70 is OUTSIDE the later `namespace Matrix` block (started at line 284), so the canonical name is `_root_.dotProduct`. `Matrix.mulVec` IS namespaced (line 661 is inside the later Matrix block).
2. **`*ᵥ` requires `open scoped Matrix`**: the `infixr:73 " *ᵥ "` notation is `scoped` to Matrix at `Mul.lean:665`; without the open, Lean tries to parse `Sg * ᵥ ξ` and chokes on `ᵥ`-as-subscript-term. The `⬝ᵥ` notation at line 76 is global (NOT scoped) and works without the open. Fix: added `open scoped Matrix` at line 32.
3. **`(-(q/2 : ℝ) : ℂ) = -↑(q/2)` not `↑(-(q/2))`**: Lean's elaborator on `(-e : ℂ)` where `e : ℝ` prefers `Neg.neg : ℂ → ℂ` on `↑e` over `↑(-e)`. So after `unfold gaussCharFun` we have `‖cexp (-↑(q/2))‖` which `Complex.norm_exp_ofReal` (pattern `‖cexp ↑x‖`) does NOT directly match. Bridge: `← Complex.ofReal_neg` rewrites `-↑x → ↑(-x)`, then the simp lemma fires.

(Both lessons logged as new insights in the slug's JSON tracker for the S7 ACT picker.)

### Forward action

**S7 ACT (recommended, doctor-scope)**: discharge axiom `gaussian_has_scalar_exponent` (parent line 165, ~20–35 LOC) per S4 PREP §4.2. Reuses S6's `unfold gaussCharFun` + cast-manipulation pattern + the proved `gaussian_operator_stable`. Bearers: `Real.rpow_neg` + `Real.sqrt_eq_rpow`. Result: `axiomCount` 7 → 6.

### Files

- **MOD** `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`: axiom → theorem swap + 18-LOC proof + `open scoped Matrix` (322 → 343 LOC)
- **MOD** `src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json`: `axiomCount` 8 → 7, `theoremCount` 8 → 9, `lineCount` 322 → 343, `assumptions` block + `sections.quadform` summary refreshed, `leanFile` synced
- **MOD** `research/problems/.../state.md`: new S6 ACT head section (~80 LOC at top); S5 STATE-SYNC and S1–S4 historical record preserved verbatim below
- **NEW** `research/problems/.../sessions/2026-05-16-s6-act-discharge-gausscharfun-norm-le-one.md` (~234 LOC: proof + ACT-time delta inventory + bearer recheck + S7 forward plan + memory pattern claims)
- **MOD** `src/data/research/problems/.../central-limit-theorem-oq-01-oq-01-oq-04-oq-01.json`: `phase`, `currentState`, `builtItems`, `insights` (+2 lessons), `nextSteps` refreshed for S6; `iteration` 5 → 6; `attemptCounts` reflects 4 Docker iterations

### Build risk

**LOW**. Single-file Lean change, Docker-verified at 7744/7744 jobs. No new imports beyond `open scoped Matrix` (the file already imports `Mathlib`, so all bearers are already in scope). Three pre-existing warnings preserved (no new warnings introduced).

### Conflict surface

- **0 open PRs** on this slug at branch creation time (verified 2026-05-16T04:10Z post-#19383 merge).
- All edits target files last touched by either #19116 (mechanic, parent file + meta.json) or #19383 (S5 STATE-SYNC, state.md + JSON tracker) — both merged.
- Strict file-disjointness with any sibling researcher.

## Test plan

- [x] Docker build clean: 7744/7744 jobs in 14s incremental.
- [x] axiom count drop verified: `grep -c '^axiom ' proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean` = 7 (was 8).
- [x] theorem count rise verified: `grep -c '^theorem ' proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean` = 9 (was 8).
- [x] meta.json sync: `axiomCount` 7, `theoremCount` 9, `lineCount` 343 in both `meta.*` and `leanFile.*` blocks.
- [x] JSON validity: `python3 -m json.tool` passes on both meta.json and tracker .json.
- [x] Bearer drift recheck: 5/5 at lake SHA `2df2f0150c…` verified via `gh api repos/leanprover-community/mathlib4/contents/<path>?ref=<SHA>`.
- [x] Pre-push fresh-fetch: `origin/main` at `78448f56d0a`, no rebase needed.
- [x] 0 open PRs on slug at draft time — no race surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)