### PR TITLE
fix(meta): dissection-of-cubes-oq-03 lineCount 599 -> 623

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom, all_different_implies_long_chains_axiom. 2 sorries for geometric confinement lemmas (smallest_above_is_smaller, global_min_not_reaching_top).",
-    "lineCount": 599,
+    "lineCount": 623,
     "theoremCount": 17,
     "definitionCount": 13,
     "originalContributions": [
@@ -164,7 +164,7 @@
   },
   "leanFile": {
     "namespace": "(builds on DissectionOfCubes namespace)",
-    "lineCount": 599,
+    "lineCount": 623,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Correct stale `lineCount: 599` → `623` in both `meta.lineCount` and `leanFile.lineCount` for `src/data/proofs/dissection-of-cubes-oq-03/meta.json`.

## Evidence

**Actual file length:**

```bash
$ wc -l proofs/Proofs/DissectionOfCubesOQ03.lean
     623 proofs/Proofs/DissectionOfCubesOQ03.lean
```

**Source of drift:** the file grew from 599 to 623 lines in commit `92d138d5c2b` (`research(dissection-of-cubes-oq-05): S4 ERRATUM-APPLY — global_min_not_reaching_top FALSE-AS-STATED in two regimes (doc-only)`, PR #18826), which expanded the `global_min_not_reaching_top` docstring to document the two-regime counterexample. The Lean change was doc-only (no semantic change), so other counts are unaffected — only the line count drifted.

## Verification — other fields are accurate (no scope creep)

| Field            | meta.json | Lean truth | Status |
|------------------|-----------|------------|--------|
| `lineCount`      | 599       | **623** (`wc -l`) | **FIXING** |
| `axiomCount`     | 2         | 2 (inherited from `DissectionOfCubes.lean`: `smaller_cube_above_axiom`, `all_different_implies_long_chains_axiom`; file itself has 0 `^axiom ` declarations — the count correctly reflects inherited assumptions per CLAUDE.md axiom-integrity policy) | OK |
| `sorries`        | 2         | 2 (`smallest_above_is_smaller`, `global_min_not_reaching_top`) | OK |
| `theoremCount`   | 17        | 17 | OK |
| `definitionCount`| 13        | 13 (2 `structure` + 10 `def` + 1 `noncomputable def`) | OK |
| `status`         | axiomatized | 2 inherited axioms + 2 sorries → `axiomatized` | OK |
| `badge`          | axiom     | consistent | OK |

## Scope

Two related fields, one slug, 4-line diff (2 insertions + 2 deletions). No Lean source changes; no narrative changes; no status/badge changes. Follows the same single-field-drift convention as #19430, #19434, #19435, #19444.

---
Automated fix by lean-mechanic agent.