### PR TITLE
research(triangle-inequality-oq-04-oq-01): S2b ACT — chartArcLength_trans (additivity, build-verified 2551 jobs clean)

### DIFF
--- a/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
+++ b/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
@@ -62,4 +62,23 @@ theorem chartArcLength_nonneg (γ : ℝ → E) {a b : ℝ} (hab : a ≤ b) :
     0 ≤ chartArcLength γ a b :=
   intervalIntegral.integral_nonneg hab (fun _ _ => norm_nonneg _)
 
+/-- **Additivity under interval concatenation** (S2b): for any three parameter
+points `a, b, c : ℝ` such that the speed `‖γ'(·)‖` is interval-integrable on
+both `[a, b]` and `[b, c]`, the chart-local arc lengths over those two
+intervals sum to the arc length over `[a, c]`.
+
+The hypotheses are stated as `IntervalIntegrable` rather than the more
+restrictive `a ≤ b ≤ c`, because `intervalIntegral.integral_add_adjacent_intervals`
+handles the orientation-aware case (`∫_{a..b} + ∫_{b..c} = ∫_{a..c}` for any
+ordering of `a, b, c`) via Mathlib's signed-interval-integral convention. This
+matches the form needed for the S2c chart-local triangle inequality
+(`chartIntrinsicDist_triangle`), where `b` is the intermediate endpoint of a
+broken path. -/
+theorem chartArcLength_trans (γ : ℝ → E) {a b c : ℝ}
+    (hab : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume a b)
+    (hbc : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume b c) :
+    chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c := by
+  simp only [chartArcLength]
+  exact intervalIntegral.integral_add_adjacent_intervals hab hbc
+
 end TriangleInequalityOQ04OQ01

--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,11 +1,36 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: ACT (S2a complete, build-verified)
+**Phase**: ACT (S2b complete, build-verified)
 **Path**: A (chart-local Euclidean length)
 **Since**: 2026-05-14 (researcher-3, S2a)
-**Iteration**: 2 (S1 OBSERVE, S2a ACT)
-**Last Updated**: 2026-05-14 (researcher-3)
+**Iteration**: 3 (S1 OBSERVE, S2a ACT, S2b ACT)
+**Last Updated**: 2026-05-16 (researcher-1, S2b ACT — `chartArcLength_trans` via `intervalIntegral.integral_add_adjacent_intervals`, build-verified 2551 jobs clean)
+
+## S2b ACT 2026-05-16 (researcher-1)
+
+Adds **additivity under interval concatenation** to `TriangleInequalityOQ04OQ01.lean`:
+
+```lean
+theorem chartArcLength_trans (γ : ℝ → E) {a b c : ℝ}
+    (hab : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume a b)
+    (hbc : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume b c) :
+    chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c := by
+  simp only [chartArcLength]
+  exact intervalIntegral.integral_add_adjacent_intervals hab hbc
+```
+
+Inserted at lines 65–83 (between `chartArcLength_nonneg` and `end TriangleInequalityOQ04OQ01`). File grew 66 → 84 LOC (+18 LOC: ~7 LOC body + 1 fact statement + ~10 LOC docstring).
+
+Hypotheses are stated as `IntervalIntegrable` (not `a ≤ b ≤ c`) because `intervalIntegral.integral_add_adjacent_intervals` handles the orientation-aware case via Mathlib's signed-interval-integral convention — this matches the form needed for the upcoming S2c chart-local triangle inequality (`chartIntrinsicDist_triangle`).
+
+**Build verified**: `LEAN_BUILD_TIMEOUT=15m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → `Build completed successfully (2551 jobs).` First-try clean at Lean 4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. No new warnings.
+
+**Sorries**: 0 (unchanged). **Axioms**: 0 (unchanged).
+
+**Next ACT** (S2c): chart-local triangle inequality `chartIntrinsicDist_triangle` mirroring the parent `Proofs.TriangleInequalityOQ04.intrinsicDist_triangle` — uses `chartArcLength_trans` (this S2b) + `iInf` manipulation for the intrinsic-distance infimum.
+
+---
 
 ## Current Focus
 

--- a/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
@@ -18,30 +18,33 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-14T17:50:00Z",
-    "iteration": 2,
-    "focus": "S2a ACT — chart-local Euclidean arc length: definition + 3 sanity lemmas. Build-verified at v4.26.0 (2551 jobs).",
+    "iteration": 3,
+    "focus": "S2b ACT — chart-local arc length additivity (researcher-1, 2026-05-16): shipped `chartArcLength_trans (γ : ℝ → E) {a b c : ℝ} (hab : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume a b) (hbc : IntervalIntegrable _ _ b c) : chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c := by simp only [chartArcLength]; exact intervalIntegral.integral_add_adjacent_intervals hab hbc` to `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (lines 65-83; file 66 → 84 LOC, +18 LOC = ~7 LOC body + ~10 LOC docstring + 1 theorem statement). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`: `Build completed successfully (2551 jobs).` first-try clean. Sorries: 0 (unchanged). Axioms: 0 (unchanged). `IntervalIntegrable` hypotheses (not `a ≤ b ≤ c`) chosen to match the orientation-aware form required by the upcoming S2c chart-local triangle inequality `chartIntrinsicDist_triangle`.",
     "activeApproach": "Path A: chart-local Euclidean length via intervalIntegral of ‖deriv γ t‖ on ℝ → E, with chart map applied externally.",
     "blockers": [
       "**Upstream Mathlib blocker** (full Riemannian formalization): the natural"
     ],
-    "nextAction": "S2b ACT: chartArcLength_trans (additivity under interval concatenation) via intervalIntegral.integral_add_adjacent_intervals.",
+    "nextAction": "S2c ACT: chart-local triangle inequality `chartIntrinsicDist_triangle` mirroring parent `Proofs.TriangleInequalityOQ04.intrinsicDist_triangle`. Uses `chartArcLength_trans` (this S2b) for the additivity step + `iInf` manipulation for the intrinsic-distance infimum bound. Estimated ~50-80 LOC. Single Docker build expected (no new Mathlib bearer touch beyond what S2a+S2b already exercise).",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 1
-    }
+    },
+    "lastUpdate": "2026-05-16T04:55:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "S2a complete: chartArcLength + 3 sanity lemmas (build verified). S2b/c remaining for chart-local triangle inequality (Path A).",
+    "progressSummary": "PROGRESS (S2b ACT, 2026-05-16, researcher-1): shipped chart-local arc-length additivity `chartArcLength_trans` to `TriangleInequalityOQ04OQ01.lean` (+18 LOC, 66→84). Build-verified Docker-clean 2551 jobs first-try at Lean 4.26.0 + Mathlib pin `2df2f0150c`. Sorries 0 / Axioms 0 unchanged. Uses `intervalIntegral.integral_add_adjacent_intervals` with `IntervalIntegrable` hypotheses (matches the form needed for S2c chart-local triangle inequality). S2c follow-up is the next natural step.",
     "builtItems": [
-      "Created Proofs/TriangleInequalityOQ04OQ01.lean: chartArcLength + chartArcLength_self + chartArcLength_const + chartArcLength_nonneg (~60 LOC, 0 sorries, 0 axioms, build verified 2551 jobs)"
+      "Created Proofs/TriangleInequalityOQ04OQ01.lean: chartArcLength + chartArcLength_self + chartArcLength_const + chartArcLength_nonneg (~60 LOC, 0 sorries, 0 axioms, build verified 2551 jobs)",
+      "S2b ACT: `TriangleInequalityOQ04OQ01.chartArcLength_trans` in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean:65-83` — additivity of chart-local arc length under interval concatenation, via `intervalIntegral.integral_add_adjacent_intervals` with `IntervalIntegrable` hypotheses on the speed `‖deriv γ t‖`."
     ],
     "insights": [
       "S2a: chartArcLength typed at ℝ → E (not on manifolds) keeps imports minimal (Deriv.Basic + IntervalIntegral.Basic only); chart map applied externally by callers.",
       "Mathlib v4.26.0: intervalIntegral.integral_same (Basic.lean:641) discharges chartArcLength_self with simp.",
       "Mathlib v4.26.0: deriv_const (eta form, Deriv/Basic.lean:744) discharges chartArcLength_const with simp; pointwise deriv_const requires funext.",
       "Mathlib v4.26.0: intervalIntegral.integral_nonneg (Basic.lean:1246) takes hab : a ≤ b plus pointwise hypothesis on Set.Icc; norm_nonneg discharges trivially.",
-      "Mathlib v4.26.0 surface: Mathlib.MeasureTheory.Integral.IntervalIntegral is now a directory; older shim import path fails with 404. Use .Basic suffix."
+      "Mathlib v4.26.0 surface: Mathlib.MeasureTheory.Integral.IntervalIntegral is now a directory; older shim import path fails with 404. Use .Basic suffix.",
+      "For chart-local arc length on a normed-space-valued curve, the additivity `chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c` discharges via a single `intervalIntegral.integral_add_adjacent_intervals` call after `simp only [chartArcLength]`. The orientation-aware `IntervalIntegrable` hypothesis form (rather than `a ≤ b ≤ c`) is preferred because Mathlib's signed-interval-integral convention handles negative orientations natively — and the orientation-aware form is precisely what the S2c chart-local triangle inequality needs at the `iInf` step."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

**S2b ACT** for `triangle-inequality-oq-04-oq-01`. Adds the chart-local
arc length additivity lemma `chartArcLength_trans` to
`proofs/Proofs/TriangleInequalityOQ04OQ01.lean`, per the S2a `nextAction`
("S2b ACT: chartArcLength_trans via intervalIntegral.integral_add_adjacent_intervals").

This unblocks the S2c chart-local triangle inequality
(`chartIntrinsicDist_triangle`), which uses additivity at the iInf step
over the intermediate endpoint.

## What changed

- **`proofs/Proofs/TriangleInequalityOQ04OQ01.lean`** (+18 LOC,
  66 → 84; +1 theorem, 4 → 5):

```lean
theorem chartArcLength_trans (γ : ℝ → E) {a b c : ℝ}
    (hab : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume a b)
    (hbc : IntervalIntegrable (fun t => ‖deriv γ t‖) MeasureTheory.volume b c) :
    chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c := by
  simp only [chartArcLength]
  exact intervalIntegral.integral_add_adjacent_intervals hab hbc
```

Hypotheses are stated as `IntervalIntegrable` (not the more restrictive
`a ≤ b ≤ c`) because `intervalIntegral.integral_add_adjacent_intervals`
handles the orientation-aware case via Mathlib's signed-interval-integral
convention — matches the form needed for S2c.

- **`research/problems/triangle-inequality-oq-04-oq-01/state.md`**: new
  §"S2b ACT 2026-05-16 (researcher-1)" head block with the theorem
  statement, build attestation, and S2c next-step staging; iteration
  2 → 3; phase descriptor updated.

- **`src/data/research/problems/triangle-inequality-oq-04-oq-01.json`**:
  currentState refreshed (iteration 2 → 3; focus + nextAction repainted
  for S2c); attemptCounts.total bump; knowledge.progressSummary updated;
  +1 builtItems; +1 insight.

## Build verification

```
LEAN_BUILD_TIMEOUT=15m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01
```

→ **`Build completed successfully (2551 jobs).`** — first-try clean at
Lean 4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
No new warnings.

## Honest-status block

- **Mathematical progress**: small but real. S2b adds the standard
  integral-additivity step that the chart-local triangle inequality
  (S2c) requires at the `iInf` reduction. The body is one
  `simp only` + one `exact` against a well-established Mathlib API; no
  novel mathematics.
- **Build-verification status**: ✅ Docker-clean 2551 jobs first-try; no caveats.
- **Axiom status**: 0 textual axioms / 0 structure-encoded assumptions /
  0 sorries (all unchanged from S2a baseline).
- **Open conjecture status**: unchanged. The slug remains chart-local
  (depends on chart `φ`); upstream Mathlib lacks the `RiemannianMetric`
  typeclass needed for chart-invariant Riemannian arc length via
  partition-of-unity gluing. S2b is foundation that lifts cleanly once
  upstream lands the typeclass.

## Anti-scope (S2a retained)

- ❌ No Riemannian distance (chart-local only).
- ❌ No partition-of-unity gluing (gated on upstream `RiemannianMetric`).
- ❌ No parent-level changes to `Proofs.TriangleInequalityOQ04`.
- ❌ No `chartIntrinsicDist_triangle` (that's S2c).
- ❌ No `meta.json` changes (no gallery entry exists yet for this slug).

## Test plan

- [x] Docker build green (2551 jobs first try)
- [x] Existing S2a theorems still compile (`chartArcLength_self`,
      `chartArcLength_const`, `chartArcLength_nonneg`)
- [x] state.md + JSON tracker synced
- [x] S2c staged in nextAction with bearer hint (`intervalIntegral.integral_add_adjacent_intervals` + `iInf` manipulation)

## Next ACT (post-merge)

**S2c**: `chartIntrinsicDist_triangle` (~50-80 LOC) — chart-local
triangle inequality mirroring the parent
`Proofs.TriangleInequalityOQ04.intrinsicDist_triangle`. Uses this S2b's
`chartArcLength_trans` for the additivity step + `iInf` manipulation for
the intrinsic-distance infimum bound. Single Docker build expected (no
new Mathlib bearer touch beyond what S2a + S2b already exercise).

🤖 Generated by researcher-1