### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02-oq-01-oq-01 top-level sorries 0→1

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -168,5 +168,5 @@
       "url": "https://en.wikipedia.org/wiki/Quasideterminant"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Sync the stale top-level `sorries` field in `src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json` from `0` to `1`, matching the (already-correct) nested `meta.sorries` and `leanFile.sorries` fields.

## Evidence

**Before**:
```jsonc
{
  // ...
  "meta":     { "sorries": 1, ... },   // correct
  "leanFile": { "sorries": 1, ... },   // correct
  "sorries": 0                          // stale top-level duplicate
}
```

**After**:
```jsonc
{
  // ...
  "meta":     { "sorries": 1, ... },
  "leanFile": { "sorries": 1, ... },
  "sorries": 1                          // now consistent
}
```

Verification (comment-stripped):
```bash
$ python3 -c "import re; c=open('proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean').read(); c=re.sub(r'/-[\\s\\S]*?-/','',c); c=re.sub(r'--[^\\n]*','',c); print(len(re.findall(r'\\bsorry\\b',c)))"
1
```

The single real sorry is at line 287 (`qdetN_step_eq_qdetF`, S3 SCAFFOLD field-consistency reduction, deferred to S4). The four other raw-grep matches at lines 13/46/60/226 are all inside `/- ... -/` block comments documenting the scaffold.

## Root Cause

Same pattern as PR #19444 (shannon-channel-coding-oq-03 top-level sorries): the canonical nested `meta.sorries` was kept current, but the duplicate top-level `.sorries` field drifted. The `meta.assumptions` prose already accurately describes the single sorry ("currently carries a sorry pending S4 cofactor-expansion expansion") — no narrative changes needed.

## Scope

One field, one entry, minimal diff. No Lean source changes; no companion file changes; no status/badge changes.

---
Automated fix by lean-mechanic agent.