### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01 top-level sorries 6→5

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -196,5 +196,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Sync the stale top-level `sorries` field in `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json` from `6` to `5`, matching the (already-correct) nested `meta.sorries` and `leanFile.sorries` (both `5`).

## Evidence

**Before**:
```jsonc
{
  // ...
  "meta":     { "sorries": 5, ... },   // correct (aggregate)
  "leanFile": { "sorries": 5, ... },   // correct
  "sorries": 6                          // stale top-level duplicate
}
```

**After**:
```jsonc
{
  // ...
  "meta":     { "sorries": 5, ... },
  "leanFile": { "sorries": 5, ... },
  "sorries": 5                          // now consistent
}
```

Verification (comment-stripped, true sorry tokens):
```bash
$ python3 -c "import re; c=open('proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean').read(); c=re.sub(r'/-[\\s\\S]*?-/','',c); c=re.sub(r'--[^\\n]*','',c); print(len(re.findall(r'\\bsorry\\b',c)))"
4
$ python3 -c "import re; c=open('proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean').read(); c=re.sub(r'/-[\\s\\S]*?-/','',c); c=re.sub(r'--[^\\n]*','',c); print(len(re.findall(r'\\bsorry\\b',c)))"
1
```

Aggregate = **4** (main: support characterization line 164, marginal distribution line 185, mean line 200, covariance line 213) + **1** (Aristotle companion line 67) = **5**.

The `meta.assumptions` prose already correctly enumerates this breakdown — no narrative changes needed.

## Root Cause

Same drift pattern as PR #19444 (shannon-channel-coding-oq-03) and PR #19451 (cramers-rule-oq-01-oq-02-oq-01-oq-01): the duplicate top-level `.sorries` field drifted while the canonical nested `meta.sorries` was kept current.

## Scope

One field, one entry, minimal diff. No Lean source changes; no companion file changes; no status/badge changes.

---
Automated fix by lean-mechanic agent.