### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-04 status/badge sync post-build-verify

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -2,12 +2,12 @@
   "id": "algebraic-numbers-countable-oq-02-oq-04",
   "title": "Countability of Computable Real Numbers",
   "slug": "algebraic-numbers-countable-oq-02-oq-04",
-  "description": "Open question addressing the cardinality layer below algebraic in the real-number hierarchy: prove that the set of computable real numbers is countable. A real `r` is computable when some Turing machine (formalized as a `Computable` function `ℕ → ℚ` in Mathlib) outputs a sequence of rationals converging to `r`. Since Turing-machine descriptions form a countable set, so does the set of computable reals — yielding the hierarchy ℚ ⊊ algebraic ⊊ computable ⊊ ℝ with all but the last carrying cardinality ℵ₀. S3 status (build pending): full proof via `decodeReal : Nat.Partrec.Code → ℝ` pipeline; main theorem `computable_reals_countable` and exact cardinality `card_computable_reals_eq_aleph0` are unconditional, with `wip` badge held until Docker build verifies.",
+  "description": "Open question addressing the cardinality layer below algebraic in the real-number hierarchy: prove that the set of computable real numbers is countable. A real `r` is computable when some Turing machine (formalized as a `Computable` function `ℕ → ℚ` in Mathlib) outputs a sequence of rationals converging to `r`. Since Turing-machine descriptions form a countable set, so does the set of computable reals — yielding the hierarchy ℚ ⊊ algebraic ⊊ computable ⊊ ℝ with all but the last carrying cardinality ℵ₀. S3 (build-verified): full proof via `decodeReal : Nat.Partrec.Code → ℝ` pipeline; main theorem `computable_reals_countable` and exact cardinality `card_computable_reals_eq_aleph0` are unconditional.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Computable_number",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean",
     "tags": [
       "set-theory",
@@ -19,7 +19,7 @@
       "research",
       "seeker-selected"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 656,
@@ -27,7 +27,6 @@
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
     "openQuestions": [
-      "Verify the S3 + S4 build (Docker); on green, bump `badge` from `wip` to `verified`.",
       "Prove that every algebraic real is computable (so the inclusion `algebraic ⊆ computable` lifts to the new definition).",
       "Prove `IsComputable e` and `IsComputable π` to exhibit a computable transcendental (concrete strict inclusion `algebraic ⊊ computable`).",
       "Construct an explicit non-computable real (e.g. Chaitin's Ω). The S4 cardinality argument proves existence; an explicit construction would witness it."


### PR DESCRIPTION
## Fix

Sync `status` and `badge` for `algebraic-numbers-countable-oq-02-oq-04` from the stale build-pending state to `verified` / `verified`, satisfying the bump condition recorded in this entry's own openQuestion[0].

## Evidence

**Lean file** — 0 tactic-position sorries, 0 axiom declarations:

```
$ python3 -c 'import re; s=open("proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean").read()
s=re.sub(r"/-.*?-/","",s,flags=re.S); s=re.sub(r"--[^\n]*","",s)
print("sorries:", len(re.findall(r"\bsorry\b", s)))
print("axioms :", len(re.findall(r"^axiom\s", s, re.M)))'
sorries: 0
axioms : 0
```

(`grep '\bsorry\b'` on the raw file hits 4 mentions, but all sit inside `/- ... -/` docstrings or `--` comments; the comment-stripped count is the source of truth.)

**Parent slug** — `algebraic-numbers-countable` is already `status: verified, badge: original, axiomCount: 0, sorries: 0`. The OQ-02-OQ-04 file imports the parent and adds 18 original contributions on top, with 0 assumptions of its own.

**Build status** — PR #19432 ("research(algebraic-numbers-countable-oq-02-oq-04): S6f STATE-SYNC — post-mechanic build-verified catch-up after 4-day doc freeze") confirms the Docker build is green after the v4.26.0 elaboration repair in #19054.

**Self-documented trigger** — `meta.openQuestions[0]` recorded the precise bump rule:

> "Verify the S3 + S4 build (Docker); on green, bump `badge` from `wip` to `verified`."

That condition is now satisfied.

## Changes

- `meta.status`: `"formalized"` → `"verified"` (file has 0 sorries and 0 axioms; per `CLAUDE.md` "Status field definitions", `formalized` requires sorries remaining)
- `meta.badge`: `"wip"` → `"verified"`
- `meta.openQuestions[0]` removed (the build-verify-then-bump task is complete)
- `description`: trailing clause `"S3 status (build pending): … with `wip` badge held until Docker build verifies."` → `"S3 (build-verified): …"` (three stale "build pending" / "wip" phrases removed in the same sentence)

No Lean source changes; no other meta count changes (sorries=0, axiomCount=0, lineCount=656, theoremCount=31, definitionCount=3 all unchanged).

## Scope

One slug, one logical sync concern (post-build-verify status/badge promotion). Mirrors the pattern of #19327 + #19331 (mean-value-theorem-oq-02-oq-04-oq-01 sorries + status/badge sync post-S7).

---
Automated fix by lean-mechanic agent.