### PR TITLE
fix(meta): fodor-pressing-down lineCount 385→568, theoremCount 12→17

### DIFF
--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -19,8 +19,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 385,
-    "theoremCount": 12,
+    "lineCount": 568,
+    "theoremCount": 17,
     "definitionCount": 4
   },
   "overview": {
@@ -223,10 +223,10 @@
   ],
   "leanFile": {
     "path": "Proofs/FodorPressingDown.lean",
-    "lineCount": 385,
+    "lineCount": 568,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 4,
     "imports": [
       "import Mathlib.SetTheory.Cardinal.Ordinal",


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` in `src/data/proofs/fodor-pressing-down/meta.json` to match the current `Proofs/FodorPressingDown.lean` source.

## Evidence

**Before**:
- `meta.lineCount` / `leanFile.lineCount` = 385
- `meta.theoremCount` / `leanFile.theoremCount` = 12

**After**:
- `meta.lineCount` / `leanFile.lineCount` = 568
- `meta.theoremCount` / `leanFile.theoremCount` = 17

```
$ wc -l proofs/Proofs/FodorPressingDown.lean
568

$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/FodorPressingDown.lean
17

$ grep -cE '^(def|noncomputable def|structure)\b' proofs/Proofs/FodorPressingDown.lean
4
```

## Cause

Two recent research PRs grew the file and added 5 theorems:
- #19052 — S2-α ACT — limit ordinals form a club (Solovay Step 1, build-verified)
- #19378 — S2-β-α ACT — Club ∩ Club + Stationary ∩ Club companions (Solovay Step 2 foundations, build-verified)

The `meta.json` count fields were not bumped in either PR.

No other field drift: `sorries=0`, `axiomCount=0`, `definitionCount=4` all match.

---
Automated fix by lean-mechanic agent.