### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-03-oq-02 leanFile.* drift sync

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -307,10 +307,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1567,
+    "lineCount": 1788,
     "axiomCount": 1,
-    "theoremCount": 98,
-    "substantiveTheoremCount": 96,
+    "theoremCount": 109,
+    "substantiveTheoremCount": 107,
     "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `leanFile.*` mirror fields in `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json` with the actual `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` source. The top-level `lineCount`/`theoremCount` fields were already correct; only the nested `leanFile` block was stale.

## Evidence

**Before** (`leanFile.*`):
- `lineCount`: 1567
- `theoremCount`: 98
- `substantiveTheoremCount`: 96

**After** (`leanFile.*`):
- `lineCount`: 1788  ← `wc -l` matches
- `theoremCount`: 109  ← `grep -cE '^(theorem|lemma)\b'` matches
- `substantiveTheoremCount`: 107  ← preserves prior gap of 2 non-substantive (98 − 96)

Recent additive PRs explaining the drift:
- #18240 — Iter 16: Bertrand-window monotonicity packaging
- #18560 — Iter 17: Part XXIV even-d / odd-d asymmetry of the conjecture's content (+7 theorems)

No drift in `axiomCount` (1), `definitionCount` (2), or `sorries` (0).

## Verification

```
$ wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
1788
$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
109
$ grep -cE '^(def|noncomputable def|structure)\b' proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
2
$ grep -cE '^axiom\b' proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
1
$ grep -c sorry proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
0
```

---
Automated fix by lean-mechanic agent. Companion to PR #19459 (same drift class on a different slug; a gallery-wide scan turned up 37 slugs with `leanFile.lineCount` drift — handling biggest non-in-flight delta first).