### PR TITLE
fix(meta): erdos-776 lineCount 487→558, theoremCount 20→27, definitionCount 7→8

### DIFF
--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -58,11 +58,11 @@
       "Proved distinctSizes_card_le_n_sub_two: antichain over Fin n (n≥4) has ≤ n-2 distinct sizes"
     ],
     "axiomCount": 3,
-    "lineCount": 487,
+    "lineCount": 558,
     "assumptions": "3 axioms: erdos_trotter_r1_achievable (achievability for r=1, known), erdos_trotter_upper (known), erdos_trotter_achievable (known). erdos_trotter_r1 now proved from upper bound theorem + achievability axiom. erdos_776_threshold proved from erdos_trotter_exact via Nat.find.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
-    "definitionCount": 7
+    "theoremCount": 27,
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős and Trotter studied extremal problems on antichains in the Boolean lattice $2^{[n]}$, extending Sperner's celebrated 1928 theorem that the maximum antichain has size $\\binom{n}{\\lfloor n/2 \\rfloor}$. Problem 776 adds a *multiplicity constraint*: every occurring set size must appear at least $r$ times. For $r = 1$ (no constraint), Griggs showed in 1983 that an antichain can use at most $n - 2$ distinct set sizes for $n > 3$, since sizes $0$ and $n$ correspond to $\\{\\emptyset\\}$ and $\\{[n]\\}$ which are incomparable to nothing else non-trivially. For $r \\geq 2$, the constraint $\\binom{n}{k} \\geq r$ excludes the extreme layers $k \\in \\{0, 1, n-1, n\\}$ for small $r$ and more layers as $r$ grows. Erdős and Trotter showed the maximum drops to $n - 3$ for large $n$, but the precise threshold $N(r)$ remains open. This connects to the 'anatomy' of the Boolean lattice and the LYM inequality.",
@@ -172,10 +172,10 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 487,
+    "lineCount": 558,
     "axiomCount": 3,
-    "theoremCount": 20,
-    "definitionCount": 7,
+    "theoremCount": 27,
+    "definitionCount": 8,
     "path": "Proofs/Erdos776Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount,definitionCount}` and matching `leanFile.*` fields in `src/data/proofs/erdos-776/meta.json` to current `proofs/Proofs/Erdos776Problem.lean`.

## Evidence

**Before** (both `meta.*` and `leanFile.*`):
- `lineCount` = 487
- `theoremCount` = 20
- `definitionCount` = 7

**After**:
- `lineCount` = 558
- `theoremCount` = 27
- `definitionCount` = 8

```
$ wc -l proofs/Proofs/Erdos776Problem.lean
558

$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/Erdos776Problem.lean
27

$ grep -cE '^(noncomputable )?def\b' proofs/Proofs/Erdos776Problem.lean
8

$ grep -cE '^structure\b' proofs/Proofs/Erdos776Problem.lean
0

$ grep -cE '^axiom\b' proofs/Proofs/Erdos776Problem.lean
3
```

`axiomCount=3` and `sorries=0` already match — no change needed there.

## Cause

The S6 ACT PR #18756 (`research(researcher-1 multi-slug): erdos-776 S6 ACT n=5 + …`) grew the file (added n=5 achievability witness + supporting lemmas) but did not bump the meta count fields. Prior meta sync was #16594 (`fix(meta): sync lineCount/theoremCount/definitionCount for erdos-776`), which predates the S6 ACT.

No status/badge changes (still `axiomatized` / `axiom` — the 3 known-result axioms remain).

## Scope

One slug, count-field drift only. No Lean source changes; narrative content (description, sections, conclusion) untouched.

---
Automated fix by lean-mechanic agent.