### PR TITLE
fix(meta): erdos-1065-oq-05 lineCount 385→460, theoremCount 32→35

### DIFF
--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: batemanHorn_formAWithK_infinite {k : ℕ} (hk : 1 ≤ k) (each k-layer of Form A primes with k ≥ 1 is infinite — the BH conjecture prediction). 0 sorries: formA_decomposition_unique was proved via 2-adic valuation (padicValNat 2 (2^k * q) = k when q is odd). The 1 ≤ k restriction is justified by formAWithK0_finite — the k = 0 layer is exactly the singleton {3}, so an unrestricted axiom would be inconsistent.",
-    "lineCount": 385,
+    "lineCount": 460,
     "relatedProblems": [
       {
         "id": "erdos-1065",
@@ -63,7 +63,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 32,
+    "theoremCount": 35,
     "definitionCount": 3
   },
   "sections": [
@@ -143,10 +143,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 385,
+    "lineCount": 460,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 32,
+    "theoremCount": 35,
     "substantiveTheoremCount": 6,
     "computationalVerifications": 16,
     "lemmaCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount}` and matching `leanFile.{lineCount,theoremCount}` fields in `src/data/proofs/erdos-1065-oq-05/meta.json` to current `proofs/Proofs/Erdos1065BatemanHorn.lean`.

## Evidence

**Before** (both `meta.*` and `leanFile.*`):
- `lineCount` = 385
- `theoremCount` = 32

**After**:
- `lineCount` = 460
- `theoremCount` = 35

```
$ wc -l proofs/Proofs/Erdos1065BatemanHorn.lean
460

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos1065BatemanHorn.lean
35

$ grep -cE '^(noncomputable )?def ' proofs/Proofs/Erdos1065BatemanHorn.lean
3

$ grep -cE '^axiom ' proofs/Proofs/Erdos1065BatemanHorn.lean
1

$ grep -cE '\bsorry\b' proofs/Proofs/Erdos1065BatemanHorn.lean
0
```

`definitionCount=3`, `axiomCount=1`, `sorries=0` already match — no change needed there.

## Cause

PR #18882 (research(erdos-1065): S-ACT — full uniqueness of (k,q) decomposition + disjoint k-layers) added three theorems (`formA_decomposition_unique_full`, `formA_witnesses_agree`, `formAWithK_disjoint`; +75 LOC) and synced the research tracker JSON but left the gallery `src/data/proofs/erdos-1065-oq-05/meta.json` untouched.

---
Automated fix by lean-mechanic agent.