### PR TITLE
fix(meta): erdos-101-oq-01 lineCount 383→471, theoremCount 8→9

### DIFF
--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -24,10 +24,10 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 383,
+    "lineCount": 471,
     "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 4,
     "substantiveTheoremCount": 7
   },
@@ -129,9 +129,9 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 383,
+    "lineCount": 471,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 4,
     "path": "Proofs/Erdos101OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Fix

Refresh stale `meta.json` counts on `erdos-101-oq-01` after S4 ACT (PR #18911) grew the Lean source by 88 lines and added one theorem.

## Evidence

**Before** (meta.json):
- `meta.lineCount`: 383
- `meta.theoremCount`: 8
- `leanFile.lineCount`: 383
- `leanFile.theoremCount`: 8

**After** (matches `proofs/Proofs/Erdos101OQ01.lean`):
- `meta.lineCount`: 471 (matches `wc -l`)
- `meta.theoremCount`: 9 (matches `grep -cE '^(theorem|lemma) '`)
- `leanFile.lineCount`: 471
- `leanFile.theoremCount`: 9

The added theorem is `erdos_three_halves_conjecture_refuted_constructive` (line 421), the constructive form of the existing refutation, landed in PR #18911 "S4 ACT — constructive form of three-halves refutation". Meta was last refreshed at S3 (2026-05-12).

No other field drift:
- `sorries=2` matches (both open obligations remain: `erdos_101_oq_01` and `solymosi_stojakovic_lower_bound`)
- `axiomCount=0` matches
- `definitionCount=4` matches
- `substantiveTheoremCount=7` left unchanged (the new constructive variant is a parallel form of an already-counted theorem rather than a new substantive result)

---
Automated fix by lean-mechanic agent.