### PR TITLE
fix(meta): motivic-flag-maps lineCount 438→501, theoremCount 26→30, definitionCount 21→17

### DIFF
--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -68,11 +68,11 @@
     ],
     "dateAdded": "2025-01-14",
     "axiomCount": 2,
-    "lineCount": 438,
+    "lineCount": 501,
     "assumptions": "2 axiom(s): motivicClassBasedMaps, motivic_class_flag_maps. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
-    "definitionCount": 21
+    "theoremCount": 30,
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "This result was announced in January 2025 by Jim Bryan, Balázs Elek, Freddie Manners, George Salafatinos, and Ravi Vakil. It represents a significant advance in understanding the motivic structure of moduli spaces of maps.\n\n**Notably, the authors explicitly credit AI assistance**: \"The proof of this result was obtained in conjunction with Google Gemini and related tools.\" This makes it one of the first major mathematical results to credit AI collaboration in the research process.\n\nThe result connects several deep areas of mathematics: algebraic geometry (flag varieties), K-theory (Grothendieck rings), and moduli theory (spaces of rational curves).",
@@ -181,10 +181,10 @@
       "BigOperators"
     ],
     "namespace": "MotivicFlagMaps",
-    "lineCount": 438,
+    "lineCount": 501,
     "axiomCount": 2,
-    "theoremCount": 26,
-    "definitionCount": 21,
+    "theoremCount": 30,
+    "definitionCount": 17,
     "path": "Proofs/MotivicFlagMaps.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Sync `meta.json` and `leanFile.*` counts for `motivic-flag-maps` with actual Lean source (`Proofs/MotivicFlagMaps.lean`).

## Evidence

**Before** (meta.json):
- `lineCount: 438`
- `theoremCount: 26`
- `definitionCount: 21`

**After** (matches `wc -l` / `grep`):
- `lineCount: 501`
- `theoremCount: 30`
- `definitionCount: 17`

```
$ wc -l proofs/Proofs/MotivicFlagMaps.lean
501

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/MotivicFlagMaps.lean
30

$ grep -cE '^(noncomputable )?def ' proofs/Proofs/MotivicFlagMaps.lean
17
```

The file gained +63 LOC and 4 theorems while shedding 4 definitions since the last batch meta-sync (#17453).

**Unchanged**: `axiomCount: 2`, `sorries: 0`, `status: "axiomatized"`, `badge: "axiom"`, `assumptions` field (both axioms `motivicClassBasedMaps`, `motivic_class_flag_maps` still present at lines 309 & 320).

## Test plan

- [x] `wc -l` matches new `lineCount`
- [x] `grep -cE '^(theorem|lemma) '` matches new `theoremCount`
- [x] `grep -cE '^(noncomputable )?def '` matches new `definitionCount`
- [x] `grep -cE '^axiom '` confirms `axiomCount: 2` unchanged
- [x] Both `meta.*` and `leanFile.*` blocks updated consistently

---
Automated fix by lean-mechanic agent.