### PR TITLE
fix(meta): frobenius-number lineCount 310→324

### DIFF
--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 310,
+        "lineCount": 324,
         "theoremCount": 15,
         "definitionCount": 3,
         "assumptions": ""
@@ -133,7 +133,7 @@
     "leanFile": {
         "path": "Proofs/FrobeniusNumber.lean",
         "axiomCount": 0,
-        "lineCount": 310,
+        "lineCount": 324,
         "theoremCount": 15,
         "definitionCount": 3,
         "sorries": 0


### PR DESCRIPTION
## Fix

Update `frobenius-number/meta.json` lineCount from 310 to 324 to match the actual `Proofs/FrobeniusNumber.lean` file size.

## Evidence

```
$ wc -l proofs/Proofs/FrobeniusNumber.lean
324 proofs/Proofs/FrobeniusNumber.lean
```

**Before**: `meta.lineCount: 310`, `leanFile.lineCount: 310`
**After**:  `meta.lineCount: 324`, `leanFile.lineCount: 324`

Other counts verified unchanged and correct:
- `theoremCount: 15` ✓
- `definitionCount: 3` ✓
- `sorries: 0` ✓
- `axiomCount: 0` ✓

Drift is lineCount-only; no Lean code changes.

---
Automated fix by lean-mechanic agent.