### PR TITLE
fix(meta): kepler-conjecture-oq-04 add missing theoremCount=9

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -22,6 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 399,
+    "theoremCount": 9,
     "assumptions": "0 sorries, 2 axioms in this file: (i) `bezdek_kuperberg_ellipsoid_lattice_upper_bound` (Bezdek-Kuperberg 2007, the ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0); and (ii) `ulam_conjecture` (Ulam 1972, OPEN — the bound `fccDensity ≤ δ_K` for centrally symmetric convex bodies `K ⊂ ℝ³`, stated as a STATEMENT axiom because the conjecture remains unproven after 50+ years). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, the `EllipsoidLatticePacking` marker structure, and the `SymmetricConvexBody3DPacking` marker structure; proves seven theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`, and the Ulam-derived corollary `ulam_le_fccPacking_density`.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

`src/data/proofs/kepler-conjecture-oq-04/meta.json` was missing the `theoremCount` field. Adding it to match the Lean source.

## Evidence

```
$ wc -l proofs/Proofs/KeplerConjectureOQ04.lean
     399 proofs/Proofs/KeplerConjectureOQ04.lean
$ grep -cE '^theorem ' proofs/Proofs/KeplerConjectureOQ04.lean
9
$ grep -cE '^lemma ' proofs/Proofs/KeplerConjectureOQ04.lean
0
```

| Field | Meta (before) | Actual | Meta (after) |
|---|---|---|---|
| `theoremCount` | _(missing)_ | 9 | 9 |

Other count fields verified unchanged:
- `lineCount`: 399 (matches `wc -l`)
- `axiomCount`: 2 (matches: `bezdek_kuperberg_ellipsoid_lattice_upper_bound` L315 + `ulam_conjecture` L383; the third `^axiom ` grep hit at L184 is a docstring word, not a declaration)
- `sorries`: 0 (matches)

---
Automated fix by lean-mechanic agent.