### PR TITLE
audit(erdos-913): clean re-audit — tracker bump (auditCount 3→4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10521,9 +10521,9 @@
     },
     "erdos-913": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T13:29:21Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T06:01:26Z",
+      "result": "clean"
     },
     "erdos-914": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Substantive re-audit of `erdos-913` at SHA `cf1cfa085e4`. All `meta.json` claims verified against `proofs/Proofs/Erdos913Problem.lean`:

| Field | Claim | Actual | Status |
|-------|-------|--------|--------|
| `sorries` | 0 | 0 (grep count) | ✓ |
| `axiomCount` | 1 | 1 — `axiom infinite_8p_sq_minus_1_primes` @ L69 | ✓ |
| `status` | `axiomatized` | 1 axiom present — correct tier | ✓ |
| `badge` | `axiom` | consistent with axiom presence | ✓ |
| `theoremCount` | 11 | 11 (`grep '^theorem \|^lemma '`) | ✓ |
| `definitionCount` | 6 | 6 (`grep '^def \|^noncomputable def '`) | ✓ |
| `lineCount` | 344 | 344 (`wc -l`) | ✓ |
| True stubs | none claimed | 0 (`:= trivial` / `: True` grep empty) | ✓ |
| Structure-encoded assumptions | none | 0 (no `^structure ` / `^class ` lines) | ✓ |

The sole `axiom infinite_8p_sq_minus_1_primes : PrimePairs8.Infinite` is a stated Bunyakovsky-type hypothesis — properly disclosed in `assumptions` field. Both conditional paths (8p²−1 and Mersenne) are fully proved; no hidden Mathlib wrapper for the core conjecture.

Result: **clean**.

## Test plan
- [x] `wc -l proofs/Proofs/Erdos913Problem.lean` → 344
- [x] `grep -cE '\bsorry\b' proofs/Proofs/Erdos913Problem.lean` → 0
- [x] `grep -nE '^axiom ' proofs/Proofs/Erdos913Problem.lean` → 1 (line 69)
- [x] `grep -nE '^structure |^class ' proofs/Proofs/Erdos913Problem.lean` → empty (no hidden assumptions)
- [x] `audit-tracker.json` updated: `auditCount` 3→4, `lastAudited` bumped, `result` clean

🤖 Auditor agent — substantive re-audit (not just tracker bump)