### PR TITLE
audit(erdos-841): clean re-audit — tracker bump (auditCount 3→4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10011,9 +10011,9 @@
     },
     "erdos-841": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T19:19:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T06:06:05Z",
+      "result": "clean"
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited `erdos-841` (Erdős Problem #841: Minimal Interval for Square Product).
Last audited 2026-04-28 (17.4 days stale); top-10 stale slugs already in flight
via batch PR #19496 + per-slug audits, so picked the highest-priority
uncontested target (rank 11).

**Result: clean.** Tracker bump only — no Lean or meta.json edits.

## Evidence

Verified meta.json claims against `proofs/Proofs/Erdos841Problem.lean`
at SHA `cf1cfa085e4`:

| Field            | meta.json | source | match |
|------------------|----------:|-------:|:-----:|
| sorries          |         0 |      0 |   ✓   |
| axiomCount       |         4 |      4 |   ✓   |
| theoremCount     |         3 |      3 |   ✓   |
| definitionCount  |         6 |      6 |   ✓   |
| lineCount        |       169 |    169 |   ✓   |
| status           | axiomatized | — |   ✓   |
| badge            | axiom |   — |   ✓   |

- **Axioms (4):** `t`, `trivial_lower_bound`, `selfridge_equality`, `selfridge_upper_bound`
- **Theorems (3):** `example_t6_product`, `erdos_841_characterization`, `erdos_841`
- **Defs (6):** `IsPerfectSquare`, `interval`, `HasSquareProduct`, `HasSquareSubset`, `largestPrimeDivisor`, `IsSmooth`
- **No `True` stubs**; **no hidden Mathlib wrapper** (deep imports used only for definitional infrastructure: `Nat.primeFactors`, `Nat.sqrt`, `Real.sqrt`).
- Status `axiomatized` / badge `axiom` correctly reflect the 4 named assumptions backing the Selfridge characterization of $t_n$.

## Test plan

- [x] `python3 -c '...'` confirms 4 `^axiom ` declarations, 3 theorem-level statements, 6 `def`/`noncomputable def`, 169 lines, 0 `\bsorry\b`
- [x] meta.json `status` / `badge` consistent with axiomatized state
- [x] No racing PR for erdos-841 (`gh pr list --search "audit erdos-841"` returned 0 open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)