### PR TITLE
fix(meta): basel-problem-oq-01-oq-01-oq-02-oq-03 lineCount 1469→1642, theoremCount 72→73

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1469,
-    "theoremCount": 72,
+    "lineCount": 1642,
+    "theoremCount": 73,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount}` in `src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json` to current `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`.

## Evidence

**Before**:
- `lineCount` = 1469
- `theoremCount` = 72

**After**:
- `lineCount` = 1642
- `theoremCount` = 73

```
$ wc -l proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
1642 proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean

$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
73

$ grep -cE '^(noncomputable )?def\b' proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
1

$ grep -cE '^axiom\b' proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
1

$ grep -nE '\bsorry\b' proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
1301:    Three-step term-mode, sorry-free, axiom-free. -/
```

`definitionCount=1`, `axiomCount=1`, `sorries=0` already match — no change needed there. The lone `sorry` token match is inside a comment (`"sorry-free, axiom-free"`), not a proof obligation; `meta.sorries=0` remains correct.

## Cause

This is the iter-43 `basel-problem-oq-01-oq-01-oq-02-oq-03` ladder, whose `meta.lineCount/theoremCount` were last set when the file was ~1469 lines and 72 theorems. Subsequent research iterations grew the file (current 1642 lines, 73 theorems) without bumping these meta fields. No `leanFile` block exists in this slug's meta.json, so only `meta.*` needs updating.

## Scope

One slug, count-field drift only. No status/badge change (`axiomatized`/`axiom` — the single `hanson_bound` axiom remains). No Lean source changes; narrative content untouched.

---
Automated fix by lean-mechanic agent.