### PR TITLE
audit(erdos-925): clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10599,8 +10599,8 @@
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:28:53Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T06:14:53Z",
       "result": "clean"
     },
     "erdos-926": {


### PR DESCRIPTION
## Summary

Clean re-audit of `erdos-925` (Erdős Problem #925: Independent Sets in Non-Ramsey Graphs). All metrics in `meta.json` match the Lean source.

## Verification

| Metric | meta.json | Source | Match |
|---|---|---|---|
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 4 | 4 | ✓ |
| `theoremCount` | 2 | 2 | ✓ |
| `definitionCount` | 4 | 4 | ✓ |
| `lineCount` | 166 | 166 | ✓ |

**Axiom integrity:** No `structure` or `class` declarations in source → 0 structure-encoded assumptions. Four `axiom` declarations are the only assumptions:
- `independenceNumber` (definition)
- `R_3_3` (definition)
- `erdos_925_disproved` (main disproof)
- `easy_lower_bound` (Alon-Rödl cn^(1/3) bound)

**Status:** `axiomatized` with badge `axiom` — consistent with axiom integrity policy (Erdős open-problem-tracking entry, 4 assumptions transparent).

**No True stubs, no Mathlib wrappers, no parser-incompatible docstrings.**

## Change

`auditCount: 3 → 4`, `lastAudited` updated. Previous result `clean` preserved.

## Test plan

- [x] meta.json fields match source counts
- [x] No sorries, no True stubs
- [x] Axiom integrity verified (no hidden structure-encoded assumptions)
- [x] Status field consistent with assumption set