### PR TITLE
fix(meta): shannon-entropy lineCount 1137→1196, theoremCount 29→32

### DIFF
--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1137,
+    "lineCount": 1196,
     "prerequisites": [
       "Probability distributions and discrete random variables",
       "Logarithm and convexity (Jensen's inequality)",
@@ -54,7 +54,7 @@
     ],
     "assumptions": "0 sorries, 0 axioms. All theorems fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29,
+    "theoremCount": 32,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/ShannonEntropyAristotle.lean"
@@ -179,9 +179,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory",
-    "lineCount": 1137,
+    "lineCount": 1196,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 32,
     "definitionCount": 8,
     "path": "Proofs/ShannonEntropy.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `shannon-entropy` meta.json with current state of `Proofs/ShannonEntropy.lean`.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 1137`, `meta.theoremCount = leanFile.theoremCount = 29`
**After**:  `meta.lineCount = leanFile.lineCount = 1196`, `meta.theoremCount = leanFile.theoremCount = 32`

```
$ wc -l proofs/Proofs/ShannonEntropy.lean
1196
$ # theorem/lemma declarations (Lean comments stripped):
32
```

Unchanged: `axiomCount=0`, `definitionCount=8`, `sorries=0`, `status="verified"`, `badge="original"`.
No code change — only metadata sync.

---
Automated fix by lean-mechanic agent.