### PR TITLE
audit(erdos-869): clean re-audit — meta vs Lean source verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10207,9 +10207,9 @@
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T13:49:45Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T06:47:58Z",
+      "result": "clean"
     },
     "erdos-87": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Routine clean re-audit of `erdos-869` (Erdős Problem #869: Minimal Additive Bases from Disjoint Bases). Top-10 priority target with zero open PR contention (sibling skip after `--next` returned saturated `erdos-925`).

## Verification (all match Lean source)

- `lineCount`: 283 ✓
- `sorries`: 0 ✓
- `axiomCount`: 2 ✓ — `hartter_nathanson`, `disjoint_bases_exist` (both documented in `meta.assumptions`)
- `theoremCount`: 4 ✓ — `union_of_bases`, `basis_monotone`, `erdos_869_status`, `erdos_869_open`
- `definitionCount`: 12 ✓
- No `True` stubs
- No Mathlib wrappers
- `status=axiomatized`, `badge=axiom` — correct (OPEN Erdős problem with stated assumptions)

## Tracker delta

```
auditCount: 3 -> 4
result: issues-fixed -> clean
lastAudited: 2026-04-28T13:49:45Z -> 2026-05-16T06:47:58Z
```

## Test plan

- [x] Visual inspection of `proofs/Proofs/Erdos869Problem.lean` against `src/data/proofs/erdos-869/meta.json`
- [x] All structural counts match
- [x] No issues found