### PR TITLE
fix(meta): hilbert-15-oq-02 leanFile.lineCount 507→533, theoremCount 25→27

### DIFF
--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -104,9 +104,9 @@
     ],
     "opens": [],
     "namespace": "LRComplexity",
-    "lineCount": 507,
+    "lineCount": 533,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 6,
     "path": "Proofs/Hilbert15OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `leanFile.*` counters in `src/data/proofs/hilbert-15-oq-02/meta.json` with the current state of `proofs/Proofs/Hilbert15OQ02.lean`.

## Evidence

| field | before | after | actual |
|---|---|---|---|
| `leanFile.lineCount` | 507 | **533** | `wc -l` → 533 |
| `leanFile.theoremCount` | 25 | **27** | 27 `theorem`/`lemma` lines (comments stripped) |
| `leanFile.definitionCount` | 6 | 6 (unchanged) | 5 `def` + 1 `structure Partition2` = 6 |
| `leanFile.axiomCount` | 0 | 0 (unchanged) | 0 `axiom` lines |
| `leanFile.sorries` | 0 | 0 (unchanged) | 0 `sorry` occurrences |

Top-level `meta.lineCount` (533) and `meta.theoremCount` (27) were already current — only the `leanFile` block was stale.

`definitionCount` is intentionally not changed: the gallery's count of 6 matches `def + structure` (5 + 1), which is the conventional count for this slug.

---
Automated fix by lean-mechanic agent.