### PR TITLE
fix(meta): e-transcendental-oq-03 leanFile drift sync (219→312, 2→1, 4→6)

### DIFF
--- a/src/data/proofs/e-transcendental-oq-03/meta.json
+++ b/src/data/proofs/e-transcendental-oq-03/meta.json
@@ -152,9 +152,9 @@
       "Real"
     ],
     "namespace": "ETranscendentalOQ03",
-    "lineCount": 219,
-    "axiomCount": 2,
-    "theoremCount": 4,
+    "lineCount": 312,
+    "axiomCount": 1,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/ETranscendentalOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `leanFile.{lineCount, axiomCount, theoremCount}` in `src/data/proofs/e-transcendental-oq-03/meta.json` to match the current Lean source.

The top-level `meta.{lineCount, axiomCount, theoremCount}` block was already current (312 / 1 / 6) — only the duplicated `leanFile` block was stale, left over from before the 2026-05-16 axiom discharge that proved `irrational_liouvilleWith_two` (the lower-bound axiom became a theorem via Dirichlet's approximation + `rat_approx_bounded_den_finite`).

## Evidence

`proofs/Proofs/ETranscendentalOQ03.lean` at `cf1cfa085e4`:

```
$ wc -l proofs/Proofs/ETranscendentalOQ03.lean
     312 proofs/Proofs/ETranscendentalOQ03.lean
$ grep -cE '^(private |protected |noncomputable )*(theorem|lemma)\s' proofs/Proofs/ETranscendentalOQ03.lean
6
$ grep -cE '^axiom\s' proofs/Proofs/ETranscendentalOQ03.lean
1
$ grep -cE '\bsorry\b' proofs/Proofs/ETranscendentalOQ03.lean
0
```

The 6 theorem/lemma sites: `rat_approx_bounded_den_finite` (L118), `irrational_liouvilleWith_two` (L180), `e_liouvilleWith_two` (L210), `e_irrationality_measure_eq_two` (L257), `e_not_liouville` (L269), `e_irrational_from_measure` (L275). The lone surviving axiom is `e_not_liouvilleWith_gt_two` at L247.

| Field | Before | After |
|-------|--------|-------|
| `leanFile.lineCount` | 219 | 312 |
| `leanFile.axiomCount` | 2 | 1 |
| `leanFile.theoremCount` | 4 | 6 |

Status/badge (`axiomatized` / `axiom`) and `assumptions` text are unchanged — 1 axiom remains, so the axiomatized classification is still correct.

---
Automated fix by lean-mechanic agent.