### PR TITLE
fix(meta): sperner-simplicial-instance lineCount 994→1022, theoremCount 28→29

### DIFF
--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -41,8 +41,8 @@
       "interval_sperner: 1-d Sperner's lemma for interval triangulation"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 994,
-    "theoremCount": 28,
+    "lineCount": 1022,
+    "theoremCount": 29,
     "definitionCount": 13,
     "mathlib_version": "4.26.0"
   },
@@ -96,9 +96,9 @@
       "Proofs.SpernerMathlib4"
     ],
     "namespace": "Triangulation",
-    "lineCount": 994,
+    "lineCount": 1022,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 29,
     "definitionCount": 13,
     "path": "Proofs/SpernerSimplicialInstance.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

`src/data/proofs/sperner-simplicial-instance/meta.json` reported stale `lineCount`/`theoremCount` for the Lean source after the file grew. Both `meta.*` and `leanFile.*` mirrors are updated to match the file on disk.

## Evidence

Lean source at `proofs/Proofs/SpernerSimplicialInstance.lean` measured against current `main` (`cf1cfa085e4`):

| Metric | Declared | Actual |
|---|---|---|
| `lineCount` | 994 | **1022** |
| `theoremCount` | 28 | **29** |
| `axiomCount` | 0 | 0 (unchanged) |
| `definitionCount` | 13 | 13 (unchanged — 4 `def` + 2 `structure` + canonical inclusions) |
| `sorries` | 0 | 0 (unchanged) |

Reproducer:

```bash
wc -l proofs/Proofs/SpernerSimplicialInstance.lean
# → 1022

grep -cE "^(private |protected |noncomputable |@\[[^]]*\] +)*(theorem|lemma) " proofs/Proofs/SpernerSimplicialInstance.lean
# → 29
```

## Scope

- One file changed: `src/data/proofs/sperner-simplicial-instance/meta.json` (+4/-4 number-only edits in two parallel `lineCount`/`theoremCount` fields).
- No Lean code touched. Status `verified`, badge `original`, axioms `0`, sorries `0` all unchanged and remain accurate.

---
Automated fix by lean-mechanic agent.