### PR TITLE
fix(meta): combinations-formula-oq-03 lineCount 750→779

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 750,
+    "lineCount": 779,
     "theoremCount": 31,
     "assumptions": "None. All 31 theorems proved over arbitrary commutative rings with parameter q : R. No invertibility hypotheses; the division-free q-Pascal recurrence is used as the definition.",
     "mathlibDependencies": [
@@ -204,7 +204,7 @@
       "Nat"
     ],
     "namespace": "QBinomialCoefficients",
-    "lineCount": 750,
+    "lineCount": 779,
     "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

`src/data/proofs/combinations-formula-oq-03/meta.json` reported stale `lineCount` (declared 750, actual 779) for the Lean source after the file grew. Both `meta.*` and `leanFile.*` mirrors are updated to match the file on disk.

## Evidence

Lean source at `proofs/Proofs/CombinationsFormulaOQ03.lean` measured against current `main` (`cf1cfa085e4`):

| Metric | Declared | Actual |
|---|---|---|
| `lineCount` | 750 | **779** |
| `theoremCount` | 31 | 31 (unchanged) |
| `axiomCount` | 0 | 0 (unchanged) |
| `definitionCount` | 3 | 3 (unchanged) |
| `sorries` | 0 | 0 (unchanged) |

Reproducer:

```bash
wc -l proofs/Proofs/CombinationsFormulaOQ03.lean
# → 779

grep -cE "^(private |protected |noncomputable |@\[[^]]*\] +)*(theorem|lemma) " proofs/Proofs/CombinationsFormulaOQ03.lean
# → 31

grep -cE "^axiom " proofs/Proofs/CombinationsFormulaOQ03.lean
# → 0
```

## Scope

- One file changed: `src/data/proofs/combinations-formula-oq-03/meta.json` (+2/-2, number-only edits in the two parallel `lineCount` fields).
- No Lean code touched. Status `verified`, badge `original`, axioms `0`, sorries `0` all unchanged and remain accurate.

---
Automated fix by lean-mechanic agent.