### PR TITLE
fix(meta): ballot-problem-oq-03-oq-02 lineCount 2511→2527

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2511,
+    "lineCount": 2527,
     "theoremCount": 92,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -287,7 +287,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2511,
+    "lineCount": 2527,
     "axiomCount": 0,
     "theoremCount": 92,
     "definitionCount": 46,


### PR DESCRIPTION
## Fix

`src/data/proofs/ballot-problem-oq-03-oq-02/meta.json` reported stale `lineCount` (declared 2511, actual 2527) for the Lean source after the file grew. Both `meta.*` and `leanFile.*` mirrors are updated to match the file on disk.

## Evidence

Lean source at `proofs/Proofs/BallotProblemOQ03OQ02.lean` measured against current `main` (`cf1cfa085e4`):

| Metric | Declared | Actual |
|---|---|---|
| `lineCount` | 2511 | **2527** |
| `theoremCount` | 92 | 92 (unchanged) |
| `axiomCount` | 0 | 0 (unchanged) |
| `definitionCount` | 46 | 46 (unchanged) |
| `sorries` | 0 | 0 (unchanged) |

Reproducer:

```bash
wc -l proofs/Proofs/BallotProblemOQ03OQ02.lean
# → 2527

grep -cE "^(private |protected |noncomputable |@\[[^]]*\] +)*(theorem|lemma) " proofs/Proofs/BallotProblemOQ03OQ02.lean
# → 92

grep -cE "^axiom " proofs/Proofs/BallotProblemOQ03OQ02.lean
# → 0
```

## Scope

- One file changed: `src/data/proofs/ballot-problem-oq-03-oq-02/meta.json` (+2/-2, number-only edits in the two parallel `lineCount` fields).
- No Lean code touched. Status `verified`, badge `original`, axioms `0`, sorries `0` all unchanged and remain accurate.

---
Automated fix by lean-mechanic agent.