### PR TITLE
fix(meta): minpoly-charpoly-oq-03 lineCount 459→484, theoremCount 11→16

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -22,11 +22,11 @@
     "badge": "research",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 459,
+    "lineCount": 484,
     "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT). The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 3,
     "originalContributions": [
       "InvariantFactorChain structure: bundles a list of monic polynomials with divisibility chain p_1 | p_2 | ... | p_k as a first-class invariant",
@@ -152,9 +152,9 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 459,
+    "lineCount": 484,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03.lean",
     "sorries": 1


### PR DESCRIPTION
## Fix

Sync `minpoly-charpoly-oq-03` meta.json with current state of `Proofs/MinpolyCharpolyOQ03.lean`.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 459`, `meta.theoremCount = leanFile.theoremCount = 11`
**After**:  `meta.lineCount = leanFile.lineCount = 484`, `meta.theoremCount = leanFile.theoremCount = 16`

```
$ wc -l proofs/Proofs/MinpolyCharpolyOQ03.lean
484
$ # theorem/lemma declarations (Lean comments stripped):
16
```

Five new theorems/lemmas landed since S5 recovery (PR #18258) without a meta refresh:
- `prodFactors_monic`, `factor_dvd_prodFactors`, `prodFactors_ne_zero`,
  `list_prod_natDegree_of_all_monic`, `nat_list_sum_le_length_mul_of_all_le` (illustrative — count by regex).

Unchanged: `axiomCount=0`, `definitionCount=3`, `sorries=1`, `status="formalized"`, `badge="research"`.
No code change — only metadata sync.

---
Automated fix by lean-mechanic agent.