### PR TITLE
fix(meta): fourier-series-oq-04-oq-01 lineCount 234→279, theoremCount 7→8

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
@@ -8,11 +8,11 @@
     "imports": ["Mathlib"],
     "opens": ["MeasureTheory", "Complex", "Filter", "Topology"],
     "namespace": "FourierSeriesOQ04OQ01",
-    "lineCount": 234,
+    "lineCount": 279,
     "axiomCount": 1,
     "sorries": 1,
     "definitionCount": 5,
-    "theoremCount": 7
+    "theoremCount": 8
   },
   "meta": {
     "author": "Open in mathematics (Stein 1971 ICM; Tao 2002 survey). Formalized statement: Lean Genius contributors.",
@@ -33,8 +33,8 @@
     "sorries": 1,
     "dateAdded": "2026-05-12",
     "axiomCount": 1,
-    "lineCount": 234,
-    "theoremCount": 7,
+    "lineCount": 279,
+    "theoremCount": 8,
     "definitionCount": 5,
     "assumptions": "1 axiom: `carleson_2d_sph` — the open 2D Carleson spherical-summation conjecture on T². 1 sorry: `sphPartialSum_L2_norm_converge` — the unconditional L²-norm convergence statement; provable from Plancherel on T² (Mathlib gap; the orthonormal basis tensor-product structure is implicit but not exposed as a named identity). No other assumptions.",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` drift with actual Lean source.

## Evidence

`proofs/Proofs/FourierSeriesOQ04OQ01.lean`:

| Field | Before (meta) | After (actual) |
|---|---|---|
| `lineCount` | 234 | **279** (`wc -l`) |
| `theoremCount` | 7 | **8** (`grep -cE "^(theorem\|lemma) "`) |
| `axiomCount` | 1 | 1 ✓ |
| `sorries` | 1 | 1 ✓ |
| `definitionCount` | 5 | 5 ✓ (4 `def` + 1 `abbrev`) |

The S2c (`latticeDisc_subset_bbox`, `latticeDisc_card_le_bbox`) and S2d (`bbox_card`, `latticeDisc_card_le_explicit`) sections grew the file past the last meta refresh; the extra theorem comes from S2d's `latticeDisc_card_le_real` (line 250).

Both top-level `leanFile.*` and `meta.*` mirrored counts updated.

---
Automated fix by lean-mechanic agent.