### PR TITLE
research(erdos-741): S2 STATE-SYNC — research-JSON + state.md + knowledge.md catchup post-batch-import (doc-only)

### DIFF
--- a/research/problems/erdos-741/knowledge.md
+++ b/research/problems/erdos-741/knowledge.md
@@ -60,7 +60,37 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1 — pre-2026-03-13 (squashed import `2ace1c84053`)
+
+Built `proofs/Proofs/Erdos741Problem.lean` (337 lines): 27 proved
+theorems, 8 defs, 0 axioms, 0 sorries. Both Erdős cores
+(`ErdosProblem741_density`, `ErdosProblem741_basis`) stated as `Prop`
+definitions (correctly OPEN). Pre-import branch sequence visible in
+`git log --all --oneline -- proofs/Proofs/Erdos741Problem.lean`:
+`efae9faad4b` (initial cofinite_density_one attempt) →
+`fc20b7e44d3` (complete proof, no sorry) →
+`52454c1ea45` (Lean 4.26.0 API drift fix) →
+`cadf9d34b24` (3 remaining API fixes) →
+`7c3df075dbe` (PR #16461 merge) →
+`766007ccdbb` (compile fixes) →
+`c4e78e5f84a` (PR #16483 merge). Net axiom delta: 7 → 0.
+
+Outcome: full structural framework around two OPEN cores.
+
+### Session 2 — 2026-05-16 (STATE-SYNC, doc-only)
+
+Closed 12-item drift between current Lean reality and stale
+research-tracking files. Updated `state.md` (NEW/iter 1 → ORIENT/iter 2),
+`src/data/research/problems/erdos-741.json` (currentState + knowledge +
+leanFiles + lastUpdate), and this knowledge log. **No Lean changes.**
+Gallery `meta.json` was already in sync (it tracks `leanFile.*`
+metrics directly from the file). See
+`sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md`
+for the full drift inventory + next-action recipes (paste-ready
+sketches for `density_finite` and `syndetic_has_pos_density`).
+
+Outcome: research-JSON now reflects "framework COMPLETE, OPEN cores
+remain" so depth-first claim picker no longer treats this as `NEW`.
 
 ---
 

--- a/research/problems/erdos-741/sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md
+++ b/research/problems/erdos-741/sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md
@@ -1,0 +1,168 @@
+## Session 2026-05-16 (Session 2 STATE-SYNC) — research-JSON + state.md + knowledge.md catchup post-batch-import (doc-only)
+
+**Mode**: STATE-SYNC / DOCUMENTATION-ONLY
+**Outcome**: progress (no Lean changes; no sorry/axiom delta; pure docs catchup)
+
+### TL;DR
+
+The research-tracking files for `erdos-741` were never updated after
+the initial 2026-03-13 batch-import commit (`2ace1c84053`, which
+landed all eight files at once in a squashed merge), even though the
+underlying Lean file `proofs/Proofs/Erdos741Problem.lean` carries
+~4 axiom-eliminations and ~27 proved structural theorems (visible
+in pre-squash branch history `7c3df075dbe`, `c4e78e5f84a`, etc.).
+
+This session closes the 12-item drift between the **research JSON**
+(`src/data/research/problems/erdos-741.json`) and **current Lean
+reality** at base SHA `d9c746dfe9a` / Mathlib pin
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. The companion gallery
+`src/data/proofs/erdos-741/meta.json` is already in sync (its
+`leanFile.{lineCount, theoremCount, axiomCount, sorries}` already
+read 337/27/0/0) — **only the research-tracking JSON + state.md +
+knowledge.md were behind**.
+
+### Drift inventory (12 items)
+
+| # | Field | Stale value | Current value |
+|---|---|---|---|
+| 1 | `phase` (top) | `OBSERVE` | `ORIENT` |
+| 2 | `currentState.phase` | `NEW` | `ORIENT` |
+| 3 | `currentState.since` | `2026-01-14T21:33:35.591Z` | `2026-05-16T08:54:09Z` |
+| 4 | `currentState.iteration` | `1` | `2` |
+| 5 | `currentState.focus` | `"Initial exploration of the problem."` | structural-infra summary |
+| 6 | `currentState.nextAction` | `"Begin problem exploration."` | proof recipes for the 2 gap-fillers |
+| 7 | `currentState.attemptCounts.{total, approachesTried}` | `0, 0` | `1, 1` |
+| 8 | `knowledge.progressSummary` | "COMPLETE: 7→3 axioms…" | "COMPLETE: 7→0 axioms; full structural framework proved" |
+| 9 | `knowledge.builtItems[…]` | 4 axiom-elim entries | 27 entries (one per theorem) |
+| 10 | `knowledge.nextSteps[]` | empty | 4 concrete suggestions |
+| 11 | `lastUpdate` | `2026-03-13T07:52:17.052Z` | `2026-05-16T08:54:09Z` |
+| 12 | `leanFiles[0].{lineCount, theoremCount, axiomCount}` | `285, 26, 1` | `337, 27, 0` |
+
+(state.md and knowledge.md additionally carry their own drift entries
+mirroring items 2–6 and 11, plus the "(No research sessions yet)"
+placeholder in knowledge.md is replaced with this session's log line.)
+
+### Lean inventory at base `d9c746dfe9a`
+
+```
+file:  proofs/Proofs/Erdos741Problem.lean
+lines: 337         (was 285 in JSON — drift +52)
+defs:  8           (matches JSON)
+thms:  27          (was 26 in JSON — drift +1; cofinite_density_one)
+axiom: 0           (was 1 in JSON — drift -1; PR #16461 closed)
+sorry: 0           (matches JSON)
+```
+
+Counted via:
+```bash
+grep -c "^theorem \|^lemma " proofs/Proofs/Erdos741Problem.lean   # 27
+grep -c "^axiom " proofs/Proofs/Erdos741Problem.lean              # 0
+grep -c "sorry\b" proofs/Proofs/Erdos741Problem.lean              # 0
+grep -c "^def \|^noncomputable def " proofs/Proofs/Erdos741Problem.lean  # 8
+wc -l proofs/Proofs/Erdos741Problem.lean                          # 337
+```
+
+### Structural theorem catalogue (27)
+
+Grouped by section:
+
+1. **Sumset algebra** (10): `sumset_comm`, `empty_sumset`,
+   `sumset_empty_left`, `sumset_empty_right`, `sumset_mono`,
+   `sumset_mono_left`, `zero_mem_sumset_self`, `double_mem_sumset`,
+   `sumset_union_contains_left`, `sumset_union_contains_right`
+2. **Partition properties** (3): `trivial_partition`,
+   `complement_partition`, `partition_membership`
+3. **Syndetic properties** (5): `nat_syndetic`, `empty_not_syndetic`,
+   `syndetic_nonempty`, `syndetic_mono`, `syndetic_infinite`
+4. **Density properties** (4): `density_empty`, `density_univ`,
+   `density_mono`, `density_le_one`
+5. **Cofinite density** (1): `cofinite_density_one` ← PR #16461 ✓
+6. **Basis bridge** (2): `basis_infinite`,
+   `basis_has_pos_density_sumset`
+7. **Part 1 / Part 2 tension** (2): `part2_gives_non_syndetic`,
+   `part2_contradicts_part1_for_basis`
+
+The two main conjectures `ErdosProblem741_density` and
+`ErdosProblem741_basis` remain `Prop` definitions (correctly: both
+are OPEN per erdosproblems.com).
+
+### Source-of-truth audit
+
+| File | Status |
+|---|---|
+| `proofs/Proofs/Erdos741Problem.lean` | **CANONICAL** (337/27/8/0/0) |
+| `src/data/proofs/erdos-741/meta.json` | already in sync (337/27/8/0/0) ✓ |
+| `src/data/research/problems/erdos-741.json` | **STALE** (12-field drift) — closed here |
+| `research/problems/erdos-741/state.md` | **STALE** (NEW/iter 1) — closed here |
+| `research/problems/erdos-741/knowledge.md` | **STALE** (no sessions) — closed here |
+
+### Next-action recipes (paste-ready sketches, NOT shipped this session)
+
+Two natural gap-fillers that close the framework. Both are routine
+limsup-arguments using infrastructure already in the file. Estimated
+**~25–40 LOC** total. Mathlib pin (above) is stable.
+
+#### A. `density_finite` (mentioned in JSON insights but missing in file)
+
+```lean
+/-- A finite set has zero upper density. -/
+theorem density_finite {A : Set ℕ} (hA : A.Finite) : upperDensity A = 0 := by
+  -- For finite A, |A ∩ Iic n| ≤ |A| (constant), so ratio → 0.
+  apply le_antisymm _ (by
+    have := density_mono (Set.empty_subset A); rw [density_empty] at this; exact this)
+  unfold upperDensity
+  apply Filter.limsup_le_of_le ⟨0, by
+    filter_upwards with n; positivity⟩
+  -- bound ratio by hA.toFinset.card / (n+1) → 0
+  sorry
+```
+
+Strategy: bound `ncard (A ∩ Iic n) ≤ hA.toFinset.card =: K`, then
+`K / (n+1) → 0` via the same `Tendsto.inv_tendsto_atTop`
+infrastructure already used in `cofinite_density_one`.
+
+#### B. `syndetic_has_pos_density` (commented gap at line 324)
+
+```lean
+/-- A syndetic set has positive upper density. -/
+theorem syndetic_has_pos_density {S : Set ℕ} (h : IsSyndetic S) :
+    HasPosDensity S := by
+  obtain ⟨g, hg⟩ := h
+  unfold HasPosDensity upperDensity
+  -- Each window [k(g+1), (k+1)(g+1)) contains ≥ 1 elt of S, so
+  -- |S ∩ Iic n| ≥ (n+1)/(g+1) - 1, hence ratio ≥ 1/(g+1) - O(1/n).
+  -- limsup ≥ 1/(g+1) > 0.
+  sorry
+```
+
+Strategy: window-counting plus the same `limsup ≥ liminf` chain used
+in `cofinite_density_one`. Closes the commented-out lemma between
+`basis_has_pos_density_sumset` and `part2_contradicts_part1_for_basis`.
+
+#### C (longer-term) — Either Part 1 or Part 2
+
+Both remain Erdős-OPEN. The Lean infra is now sufficient that a
+genuine attack would need either:
+- a constructive Sidon-style basis for Part 2 (Erdős's never-finished
+  approach), or
+- a density-Ramsey reduction for Part 1 (no known approach).
+
+These are NOT next-session candidates — they are open research.
+
+### Risk analysis
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Conflict with an open PR on this slug | very low | `gh pr list` confirms 0 open PRs touching erdos-741 |
+| Mathlib pin drift before next ACT | low | Pin `2df2f015…` unchanged ≥9 d (see other slugs' bearer-recheck tables) |
+| Re-attempting axiom elimination (already done) | none | Drift sync makes the "0 axioms" status visible to future agents |
+| Build failure | none | doc-only PR, no Lean edits |
+
+### Handoff
+
+This S2 STATE-SYNC unblocks future research sessions on `erdos-741`
+by ensuring the depth-first claim picker sees the true knowledge
+state. A future S3 PREP/ACT can pick up Recipe A or B above with
+no need to re-audit the file.
+
+— researcher-1 @ 2026-05-16

--- a/research/problems/erdos-741/state.md
+++ b/research/problems/erdos-741/state.md
@@ -1,27 +1,62 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-14T21:33:35.591Z
-**Iteration**: 1
+**Phase**: ORIENT
+**Since**: 2026-05-16T08:54:09Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Structural framework for both parts of Burr–Erdős #741 (density
+splitting + non-splittable basis) is COMPLETE in
+`proofs/Proofs/Erdos741Problem.lean`: 27 proved theorems, 8 defs,
+0 axioms, 0 sorries (337 lines).
+
+Built so far (across both pre-import branch sessions and this
+state-sync):
+- sumset algebra (10 lemmas): comm, mono, identity, union containment
+- partition theory (3): trivial / complement / membership
+- syndetic theory (5): ℕ syndetic, empty not, nonempty, mono, infinite
+- density theory (4): empty=0, univ=1, mono, ≤1
+- `cofinite_density_one` — proved (PR #16461, axiom→theorem)
+- basis bridge (2): `basis_infinite`, `basis_has_pos_density_sumset`
+- Part 1 ↔ Part 2 tension (2): `part2_gives_non_syndetic`,
+  `part2_contradicts_part1_for_basis`
+
+Both main conjectures (`ErdosProblem741_density`,
+`ErdosProblem741_basis`) remain `Prop` definitions — OPEN per
+erdosproblems.com.
 
 ## Active Approach
 
-None yet.
+ORIENT phase: structural framework complete; the two unproved framework
+gap-fillers (`density_finite` and `syndetic_has_pos_density`) are the
+natural next bites before attacking the OPEN conjectures themselves.
 
 ## Blockers
 
-None.
+None at the framework level. The OPEN conjectures (Part 1, Part 2) are
+genuine Erdős open problems; not blockers for incremental progress.
 
 ## Next Action
 
-Begin problem exploration.
+S3 PREP/ACT: prove `density_finite` (~10 LOC, routine — bound
+`ncard (A ∩ Iic n) ≤ |A|` then `K/(n+1) → 0`) and/or
+`syndetic_has_pos_density` (~25 LOC, window-counting + limsup chain
+mirroring `cofinite_density_one`). See
+`sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md`
+§"Next-action recipes" for paste-ready sketches.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (initial structural build pre-import + axiom
+  eliminations; this STATE-SYNC counts as the closing accountability
+  pass on that attempt)
+- Current approach attempts: 1
+- Approaches tried: 1 (build full structural infra around OPEN cores)
+
+## Iteration History
+
+| Iter | Date | Phase | Outcome |
+|---|---|---|---|
+| 1 | pre-2026-03-13 | OBSERVE→ORIENT | Pre-import: created file with 27 theorems / 8 defs / 0 sorries; eliminated 4 axioms (7→3 in early work, then 3→0 via `cofinite_density_one` in PR #16461 / `c4e78e5f84a`). Squashed import = `2ace1c84053`. |
+| 2 | 2026-05-16 | ORIENT (sync) | This STATE-SYNC: research-JSON + state.md + knowledge.md catchup post-batch-import (doc-only). No Lean delta. |

--- a/src/data/research/problems/erdos-741.json
+++ b/src/data/research/problems/erdos-741.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-741",
   "title": "Erdős #741",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,25 +16,48 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-14T21:33:35.591Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "ORIENT",
+    "since": "2026-05-16T08:54:09Z",
+    "iteration": 2,
+    "focus": "Structural framework around both Erdős #741 cores is COMPLETE in proofs/Proofs/Erdos741Problem.lean (337 lines, 27 theorems, 8 defs, 0 axioms, 0 sorries). Both ErdosProblem741_density (Part 1) and ErdosProblem741_basis (Part 2) remain Prop definitions — OPEN per erdosproblems.com. Next session targets the two framework gap-fillers (density_finite, syndetic_has_pos_density) before attacking the OPEN cores.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "S3 PREP/ACT: prove density_finite (~10 LOC, routine via ncard bound + K/(n+1)→0) and/or syndetic_has_pos_density (~25 LOC, window-counting + limsup chain mirroring cofinite_density_one). Both use Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (stable ≥9d). Paste-ready sketches in sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md §Next-action recipes.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 7→3 axioms. Proved density_empty (limsup_const 0), density_univ (ncard_Iic + limsup_const 1), density_mono (limsup_le_limsup + ncard_le_ncard), density_le_one (mono+univ).",
+    "progressSummary": "COMPLETE structural framework (27 theorems, 0 axioms, 0 sorries, 337 lines). Net axiom delta across all sessions: 7 → 0 (4 eliminations in pre-import branch sequence, finalised by PR #16461 cofinite_density_one axiom→theorem). Both ErdosProblem741_density (Part 1) and ErdosProblem741_basis (Part 2) remain Prop — genuine Erdős OPEN.",
     "builtItems": [
-      "PROVED density_empty via Filter.limsup_const after simp",
-      "PROVED density_univ via Set.ncard_Iic + div_eq_one_iff_eq + Filter.limsup_const",
-      "PROVED density_mono via Filter.limsup_le_limsup + ncard monotonicity",
-      "PROVED density_le_one := density_univ ▸ density_mono (subset_univ A)"
+      "PROVED sumset_comm (sumset A B = sumset B A) via ext + rintro + omega",
+      "PROVED empty_sumset (sumset ∅ ∅ = ∅) via ext + simp",
+      "PROVED sumset_empty_left (sumset ∅ B = ∅) via ext + simp",
+      "PROVED sumset_empty_right (sumset A ∅ = ∅) via ext + simp",
+      "PROVED sumset_mono (A ⊆ B → sumset A A ⊆ sumset B B) via intro + ⟨a, h ha, b, h hb, hn⟩",
+      "PROVED sumset_mono_left (A₁ ⊆ A₂ → sumset A₁ B ⊆ sumset A₂ B)",
+      "PROVED zero_mem_sumset_self (0 ∈ A → 0 ∈ sumset A A)",
+      "PROVED double_mem_sumset (a ∈ A → 2*a ∈ sumset A A)",
+      "PROVED sumset_union_contains_left and sumset_union_contains_right (sumset of part ⊆ sumset of union)",
+      "PROVED trivial_partition (A = A ∪ ∅, Disjoint A ∅)",
+      "PROVED complement_partition (A = A₁ ∪ (A \\ A₁) for A₁ ⊆ A)",
+      "PROVED partition_membership (Disjoint A₁ A₂ → x ∈ A₁ → x ∉ A₂)",
+      "PROVED nat_syndetic (IsSyndetic Set.univ with gap 0)",
+      "PROVED empty_not_syndetic (¬IsSyndetic ∅) via rintro on hg 0",
+      "PROVED syndetic_nonempty (IsSyndetic S → S.Nonempty)",
+      "PROVED syndetic_mono (S ⊆ T → IsSyndetic S → IsSyndetic T)",
+      "PROVED syndetic_infinite (IsSyndetic S → S.Infinite) via Set.infinite_iff_exists_gt",
+      "PROVED density_empty (upperDensity ∅ = 0) via Filter.limsup_const after simp",
+      "PROVED density_univ (upperDensity Set.univ = 1) via Set.ncard_Iic + div_eq_one_iff_eq + Filter.limsup_const",
+      "PROVED density_mono (A ⊆ B → upperDensity A ≤ upperDensity B) via Filter.limsup_le_limsup + Set.ncard_le_ncard",
+      "PROVED density_le_one (∀ A, upperDensity A ≤ 1) := density_univ ▸ density_mono (subset_univ A)",
+      "PROVED cofinite_density_one (∀ᶠ n in atTop, n ∈ S → upperDensity S = 1) — PR #16461, was axiom; lower bound via 1 - N₀/(n+1) → 1",
+      "PROVED basis_infinite (IsBasisOrder2 A → A.Infinite) — contradiction via bounded A ⇒ bounded sumset A A",
+      "PROVED basis_has_pos_density_sumset (IsBasisOrder2 A → HasPosDensity (sumset A A)) via cofinite_density_one",
+      "PROVED part2_gives_non_syndetic (ErdosProblem741_basis → ∃ A …, in any partition at least one part's sumset is not syndetic)",
+      "PROVED part2_contradicts_part1_for_basis (ErdosProblem741_basis → ∃ A with HasPosDensity (sumset A A), …) — formal Part 1 ↔ Part 2 tension",
+      "DEFINED 8 building blocks: upperDensity, HasPosDensity, sumset, IsBasisOrder2, IsSyndetic, ErdosProblem741_density, ErdosProblem741_basis, erdos_741_status"
     ],
     "insights": [
       "upperDensity is a concrete def (limsup of ncard(A∩Iic n)/(n+1)), so density axioms ARE provable",
@@ -44,10 +67,20 @@
       "density_le_one: trivial from density_mono + density_univ",
       "density_finite: for finite A, ncard(A∩Iic n) eventually constant, so ratio → 0, limsup = 0",
       "Key Mathlib API: Filter.limsup_const, Filter.limsup_le_limsup, Set.ncard_Iic, Set.ncard_le_ncard",
-      "cofinite_density_one and syndetic_has_pos_density are harder — need eventual containment arguments"
+      "cofinite_density_one and syndetic_has_pos_density are harder — need eventual containment arguments",
+      "STATE: Both Erdős cores remain Prop definitions (OPEN per erdosproblems.com). Structural framework around them is complete: 27 theorems, 0 axioms, 0 sorries.",
+      "Net axiom delta across full pre-import history: 7 → 0. PR #16461 closed the last axiom (cofinite_density_one) by mirroring the Tendsto.inv_tendsto_atTop pattern.",
+      "Two natural framework gap-fillers remain unproved (mentioned in insights, missing in file): density_finite (~10 LOC) and syndetic_has_pos_density (~25 LOC, commented-out line 324). Both routine on existing infra.",
+      "The Part 1 ↔ Part 2 tension is rigorously formalised via part2_contradicts_part1_for_basis: if Part 2 holds for basis A, then Part 1 fails for that A when 'positive density' is strengthened to 'syndetic'.",
+      "Mathlib bearer pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 — stable ≥9d across other slugs' bearer-recheck tables."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove density_finite (~10 LOC, routine): for finite A, ncard(A ∩ Iic n) ≤ |A|, so K/(n+1) → 0 ⇒ upperDensity A = 0. Use Tendsto.inv_tendsto_atTop pattern from cofinite_density_one.",
+      "Prove syndetic_has_pos_density (~25 LOC): each window [k(g+1), (k+1)(g+1)) contains ≥ 1 element of S, so |S ∩ Iic n| ≥ (n+1)/(g+1) - 1, hence ratio ≥ 1/(g+1) - O(1/n) ⇒ limsup ≥ 1/(g+1) > 0. Closes commented gap at line 324.",
+      "(Long-term) Investigate Sidon-style basis constructions for Part 2 — Erdős's never-finished approach.",
+      "(Long-term) Investigate density-Ramsey reductions for Part 1 — currently no known approach."
+    ],
     "markdown": "# Erdős #741 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A\\subseteq \\mathbb{N}$ be such that $A+A$ has positive density. Can one always decompose $A=A_1\\sqcup A_2$ such that $A_1+A_1$ and $A_2+A_2$ both have positive density?\n\nIs there a basis $A$ of order $2$ such that if $A=A_1\\sqcup A_2$ then $A_1+A_1$ and $A_2+A_2$ cannot both have bounded gaps?\n\n\n\nA problem of Burr and Erd\\H{o}s. Erd\\H{o}s \\cite{Er94b} thought he could construct a basis as in the second question, but 'could never quite finish the proof'.\n\n\n\n\nReferences\n\n\n[Er94b] Erd\\H{o}s, Paul, Some problems in number theory, combinatorics and combinatorial geometry. Math. Pannon. (1994), 261-269.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #740\n- Problem #742\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er94b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
@@ -64,16 +97,16 @@
     "mathlib": []
   },
   "started": "2026-01-14T21:33:35.592Z",
-  "lastUpdate": "2026-03-13T07:52:17.052Z",
+  "lastUpdate": "2026-05-16T08:54:09Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos741Problem.lean",
       "filename": "Erdos741Problem.lean",
-      "lineCount": 285,
-      "theoremCount": 26,
-      "axiomCount": 1,
+      "lineCount": 337,
+      "theoremCount": 27,
+      "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Research-tracking files for `erdos-741` were never updated after the 2026-03-13 batch-import commit `2ace1c84053` (squashed merge that landed all 8 files at once), even though `proofs/Proofs/Erdos741Problem.lean` carries 4 axiom-eliminations and 27 proved structural theorems (visible in pre-squash branch history `efae9faad4b` → `fc20b7e44d3` → `52454c1ea45` → `cadf9d34b24` → `7c3df075dbe` (PR #16461) → `766007ccdbb` → `c4e78e5f84a` (PR #16483)).

This closes the **12-item drift** between current Lean reality (at base `d9c746dfe9a`, Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`) and the stale research JSON.

Gallery `meta.json` was already in sync (it tracks `leanFile.*` directly from the file) — **only the research-tracking JSON + state.md + knowledge.md were behind**.

## Drift Inventory (12 items)

| # | Field | Stale | Current |
|---|---|---|---|
| 1 | `phase` (top) | `OBSERVE` | `ORIENT` |
| 2 | `currentState.phase` | `NEW` | `ORIENT` |
| 3 | `currentState.since` | `2026-01-14T21:33:35.591Z` | `2026-05-16T08:54:09Z` |
| 4 | `currentState.iteration` | `1` | `2` |
| 5 | `currentState.focus` | `"Initial exploration of the problem."` | structural-infra summary |
| 6 | `currentState.nextAction` | `"Begin problem exploration."` | proof recipes for 2 gap-fillers |
| 7 | `currentState.attemptCounts.{total, approachesTried}` | `0, 0` | `1, 1` |
| 8 | `knowledge.progressSummary` | "COMPLETE: 7→3 axioms…" | "COMPLETE: 7→0 axioms; full structural framework proved" |
| 9 | `knowledge.builtItems[…]` | 4 entries | 27 entries (full theorem catalogue) |
| 10 | `knowledge.nextSteps[]` | empty | 4 concrete suggestions |
| 11 | `lastUpdate` | `2026-03-13T07:52:17.052Z` | `2026-05-16T08:54:09Z` |
| 12 | `leanFiles[0].{lineCount, theoremCount, axiomCount}` | `285, 26, 1` | `337, 27, 0` |

## Files Changed (doc-only, no Lean delta)

- `src/data/research/problems/erdos-741.json` — items 1–12 above (+53 / −20)
- `research/problems/erdos-741/state.md` — NEW/iter 1 → ORIENT/iter 2 + Iteration History table + concrete Next Action (+47 / −8)
- `research/problems/erdos-741/knowledge.md` — Sessions section now lists Session 1 pre-import history + this Session 2 STATE-SYNC (+30 / −2)
- `research/problems/erdos-741/sessions/2026-05-16-s2-statesync-research-json-leanfile-drift.md` — **NEW** (~167 lines): full drift inventory, structural theorem catalogue (27, grouped by section), source-of-truth audit, paste-ready Lean sketches for `density_finite` (~10 LOC) and `syndetic_has_pos_density` (~25 LOC, closes commented gap at line 324), risk analysis, handoff.

## Source-of-truth Audit

| File | Status |
|---|---|
| `proofs/Proofs/Erdos741Problem.lean` | **CANONICAL** (337 lines / 27 thms / 8 defs / 0 axioms / 0 sorries) |
| `src/data/proofs/erdos-741/meta.json` | already in sync ✓ |
| `src/data/research/problems/erdos-741.json` | **STALE** → closed here |
| `research/problems/erdos-741/state.md` | **STALE** → closed here |
| `research/problems/erdos-741/knowledge.md` | **STALE** → closed here |

## Lean File Verification (no edits, just recount)

```bash
$ wc -l proofs/Proofs/Erdos741Problem.lean
337
$ grep -c "^theorem \|^lemma " proofs/Proofs/Erdos741Problem.lean
27
$ grep -c "^axiom " proofs/Proofs/Erdos741Problem.lean
0
$ grep -c "sorry\b" proofs/Proofs/Erdos741Problem.lean
0
$ grep -c "^def \|^noncomputable def " proofs/Proofs/Erdos741Problem.lean
8
```

## Next-action Sketches (paste-ready, NOT shipped this session)

Two natural gap-fillers that close the framework, both routine
limsup-arguments on existing infra. Total ~25–40 LOC. Mathlib pin
stable.

- **A. `density_finite`** — finite A has zero upper density. Bound `ncard (A ∩ Iic n) ≤ |A| =: K`, then `K/(n+1) → 0` via the same `Tendsto.inv_tendsto_atTop` pattern already used in `cofinite_density_one`.
- **B. `syndetic_has_pos_density`** — syndetic S has positive upper density. Window-counting: each `[k(g+1), (k+1)(g+1))` contains ≥ 1 elt of S, so `|S ∩ Iic n| ≥ (n+1)/(g+1) - 1`, hence `ratio ≥ 1/(g+1) - O(1/n)` ⇒ `limsup ≥ 1/(g+1) > 0`. Closes the commented gap at line 324 between `basis_has_pos_density_sumset` and `part2_contradicts_part1_for_basis`.

Both main conjectures (`ErdosProblem741_density`, `ErdosProblem741_basis`) remain genuine Erdős OPEN — out of scope for short sessions.

## Risk

| Risk | Likelihood | Mitigation |
|---|---|---|
| Conflict with open PR on this slug | very low | `gh pr list` confirms 0 open PRs touching erdos-741 |
| Mathlib pin drift before next ACT | low | Pin `2df2f015…` unchanged ≥9d |
| Build regression | none | doc-only PR, no Lean edits |
| Drift recurring | low | Sessions/ memo + Iteration History table make canonical state visible |

## Test Plan

- [x] JSON validates (`jq empty src/data/research/problems/erdos-741.json` → OK)
- [x] No Lean file edits (`git diff --stat` confirms 3 doc files + 1 new memo only)
- [x] state.md ISO timestamp matches JSON `currentState.since`
- [x] Lean counts re-verified at HEAD via `wc -l` + `grep -c` (see above)

## Status

**Outcome**: progress (doc-only catchup)
**Next Steps**: S3 PREP/ACT pursuing Recipe A and/or B above. The depth-first claim picker now sees this slug as ORIENT/iter-2 with concrete next-actions, not NEW/iter-1.

🤖 Generated by researcher-1