### PR TITLE
research(unit-distance-independence-oq-02): S3 STATE-SYNC — research-JSON catchup post-S2 + leanFiles scope fix (doc-only)

### DIFF
--- a/research/problems/unit-distance-independence-oq-02/sessions/2026-05-16-s3-statesync-json-leanfile-iter2-drift.md
+++ b/research/problems/unit-distance-independence-oq-02/sessions/2026-05-16-s3-statesync-json-leanfile-iter2-drift.md
@@ -1,0 +1,139 @@
+## Session 2026-05-16 (Session 3 STATE-SYNC) — research-JSON catchup post-S2 (doc-only)
+
+**Mode**: STATE-SYNC / DOCUMENTATION-ONLY
+**Outcome**: progress (no Lean changes; no sorry/axiom delta; pure docs catchup)
+
+### TL;DR
+
+The research-tracking JSON `src/data/research/problems/unit-distance-independence-oq-02.json`
+was never updated after S2 (researcher-1, 2026-04-29) reduced
+`proofs/Proofs/UnitDistanceHN7.lean` from 3 sorries to 1, even though
+`state.md` and `knowledge.md` correctly reflect that work. This session
+closes the resulting **10-item drift** between the research JSON and
+the rest of the source-of-truth tree at base `d9c746dfe9a` /
+Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+In addition, the JSON's `leanFiles` array was missing **two** files
+actually under active work — `UnitDistanceHN7.lean` and
+`UnitDistanceHN7Aristotle.lean` — tracking only the parent
+`UnitDistanceIndependence.lean` (which is essentially passive; the
+hadwiger_nelson_upper_bound axiom there is what HN7.lean aims to
+eliminate).
+
+### Drift inventory (10 items)
+
+| # | Field | Stale value | Current value |
+|---|---|---|---|
+| 1 | `currentState.since` | `2026-04-05T21:40:00Z` | `2026-04-29T03:43Z` (state.md value) |
+| 2 | `currentState.iteration` | `1` | `2` |
+| 3 | `currentState.focus` | iter-1 "Created … 3 geometric sorries" | iter-2 "Reduced 3→1 sorries; `covering_radius` remains" |
+| 4 | `currentState.nextAction` | iter-1 lemma list (mostly done) | iter-2 "Tackle `covering_radius` via cube-norm inequality" |
+| 5 | `knowledge.progressSummary` | pre-iter-1 BUG FIX summary | iter-2 catch-up (3→1 sorry reduction summary) |
+| 6 | `knowledge.builtItems[…]` | 3 iter-1 entries | 6 entries (+`hexCenter_dist_sq`, +inline modular step in `same_color_far`, +companion-file delegate updates) |
+| 7 | `knowledge.insights[…]` | 10 entries (correct as of iter 0–1) | +2 entries (iter-2 proof-pattern insights from S2's `nlinarith` + `omega` discharges) |
+| 8 | `knowledge.nextSteps[]` | 3 stale iter-1 next steps (2 done) | covering_radius cube-norm inequality sketch (from knowledge.md) |
+| 9 | `lastUpdate` | `2026-04-05T21:40:00Z` | `2026-05-16T08:56:13Z` |
+| 10 | `leanFiles[…]` | only parent `UnitDistanceIndependence.lean` tracked (lineCount 949, stale by -1) | +HN7.lean +HN7Aristotle.lean, parent lineCount fixed 949→948 |
+
+### Lean inventory at base `d9c746dfe9a`
+
+```
+file:  proofs/Proofs/UnitDistanceIndependence.lean   948  65  11  2  0   (was 949 in JSON — -1 drift)
+file:  proofs/Proofs/UnitDistanceHN7.lean            287   8   6  0  1   (NOT tracked in JSON)
+file:  proofs/Proofs/UnitDistanceHN7Aristotle.lean    78   3   0  0  1   (NOT tracked in JSON)
+                                                  lines thm def axm sor
+```
+
+Counted via:
+```bash
+for f in proofs/Proofs/UnitDistance*.lean; do
+  echo "$f $(wc -l < $f) $(grep -c '^theorem \|^lemma ' $f) $(grep -c '^def \|^noncomputable def \|^private def ' $f) $(grep -c '^axiom ' $f) $(grep -c 'sorry\b' $f)"
+done
+```
+
+(`HN7Aristotle.lean`'s `grep -c "sorry\b"` returns 2 because one is in
+a comment header on line 6; only line 76 is a real proof obligation.
+Hence reported `sorryCount = 1` below.)
+
+### S2 progress (already reflected in state.md / knowledge.md)
+
+From state.md `## Resolved This Session` and knowledge.md
+`### Session 2026-04-29 progress (researcher-1)`:
+
+1. **`hexCenter_dist_sq`** (UnitDistanceHN7.lean:123) — algebraic
+   distance formula via `EuclideanSpace.dist_sq_eq` + `PiLp.toLp_apply`
+   + `Real.mul_self_sqrt` + `nlinarith`.
+2. **Inline modular step in `same_color_far`** (HN7.lean:180) —
+   extracting `3·Δa + Δb ≡ 0 (mod 7)` via `simp only [hexColor,
+   Fin.mk.injEq]` + `omega`.
+3. **Companion delegate updates** (HN7Aristotle.lean):
+   - `hexCenter_dist_sq_ari` delegates to the main lemma.
+   - `hexColor_eq_implies_mod_ari` proved by parallel `omega`.
+
+After S2: HN7.lean carries **1 remaining sorry** (`covering_radius`,
+line 113–118). HN7Aristotle.lean carries **1 remaining sorry**
+(`covering_radius_ari`, line 76 — same obligation).
+
+### Remaining obligation: `covering_radius` (carried over from S2)
+
+This sync re-states the knowledge.md sketch for the next session's
+reference. Two natural decompositions, both lifting cleanly to a
+~80–120 LOC proof:
+
+#### Path A — cube-norm direct (preferred)
+
+```lean
+/-- The cube-coordinate Voronoi rounding produces (a, b) with
+    Q(q - a, r - b) := (q - a)^2 + (q - a)(r - b) + (r - b)^2 ≤ 1/3. -/
+private lemma hexCoord_cube_bound (p : Plane) :
+    let (a, b) := hexCoord p
+    ((axialQ p) - a) ^ 2 +
+    ((axialQ p) - a) * ((axialR p) - b) +
+    ((axialR p) - b) ^ 2 ≤ 1 / 3 := by
+  -- Case split on which coordinate has the largest rounding error:
+  --   (rq + ry + rr = 0) ⇒ rounding errors satisfy cube identity.
+  --   (rq + ry + rr ≠ 0) ⇒ the largest-error coord is corrected,
+  --                          leaving the other two with |Δ| ≤ 1/2.
+  sorry  -- ~40-60 LOC: 3 sub-cases × Int.floor/Int.ceil bounds + nlinarith.
+
+theorem covering_radius (p : Plane) :
+    dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ≤ hexSideLength := by
+  -- Reduce to squared distance via dist_sq_le_iff (need ≥ 0 RHS).
+  have hs : (0 : ℝ) ≤ hexSideLength := by unfold hexSideLength; norm_num
+  rw [show dist p (hexCenter _ _) = Real.sqrt (dist p _ ^ 2) from
+        (Real.sqrt_sq dist_nonneg).symm]
+  rw [show (hexSideLength : ℝ) = Real.sqrt (hexSideLength ^ 2) from
+        (Real.sqrt_sq hs).symm]
+  apply Real.sqrt_le_sqrt
+  -- Now compare squared dist via hexCenter_dist_sq + cube bound.
+  -- Q(q-a, r-b) ≤ 1/3 ⇒ 3s²·Q ≤ s² ⇒ dist² ≤ s².
+  sorry  -- ~10 LOC orchestration.
+```
+
+#### Path B — geometric fallback (only if Path A nlinariths fail)
+
+Decompose into the 6 cube-rounding sub-cases (3 corrections × 2 signs
+of `rq + ry + rr`), proving each as an isolated `private lemma`. About
+3× the LOC of Path A but each sub-lemma is mechanically discharged by
+`Int.floor_le`/`Int.le_ceil` + `nlinarith`.
+
+### Risk analysis
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Conflict with open PR on this slug | none | `gh pr list --search "unit-distance-independence-oq-02 in:title state:open"` returns `[]` |
+| Docker disk pressure blocking next ACT | high (host disk 100%) | covering_radius is non-trivial; ship as PREP not ACT next session, await Docker recovery |
+| Mathlib pin drift before next ACT | low | Pin `2df2f015…` unchanged ≥9d |
+| Build failure on this PR | none | doc-only, no Lean edits |
+
+### Handoff
+
+This S3 STATE-SYNC unblocks future research sessions on
+`unit-distance-independence-oq-02` by ensuring the depth-first claim
+picker sees the true knowledge state (ACT/iter 2 with concrete
+covering_radius work item) AND tracks all three active Lean files in
+the `leanFiles` array, not just the parent. A future S4 can either
+ship the Path A PREP (paste-ready ~80 LOC sketch above) or attempt
+the ACT directly if Docker disk recovers.
+
+— researcher-1 @ 2026-05-16T08:56:13Z

--- a/src/data/research/problems/unit-distance-independence-oq-02.json
+++ b/src/data/research/problems/unit-distance-independence-oq-02.json
@@ -11,18 +11,23 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-05T21:40:00Z",
-    "iteration": 1,
-    "focus": "Created UnitDistanceHN7.lean with hex coloring structure and 3 geometric sorries",
+    "since": "2026-04-29T03:43Z",
+    "iteration": 2,
+    "focus": "S2 (2026-04-29) reduced proofs/Proofs/UnitDistanceHN7.lean from 3 sorries to 1. Resolved: hexCenter_dist_sq (algebraic distance formula via EuclideanSpace.dist_sq_eq + nlinarith) and the inline modular step in same_color_far (3·Δa+Δb ≡ 0 (mod 7) via simp [hexColor, Fin.mk.injEq] + omega). Companion file HN7Aristotle.lean updated: hexCenter_dist_sq_ari delegates; hexColor_eq_implies_mod_ari parallel-proved. Remaining sorry: covering_radius (A₂ Voronoi cell circumradius ≤ s) in both files (HN7.lean:113 + HN7Aristotle.lean:74).",
     "blockers": [],
-    "nextAction": "Prove geometric lemmas: same_hex_close, color_sublattice_min_norm, same_color_far"
+    "nextAction": "S4 PREP/ACT: tackle covering_radius via the cube-norm inequality outlined in knowledge.md §Suggested-implementation-sketch. Path A (preferred, ~80 LOC): prove private lemma hexCoord_cube_bound (Q(q-a, r-b) ≤ 1/3) by 3-sub-case split on rq+ry+rr correction; combine with proved hexCenter_dist_sq to get dist² ≤ s². Path B (fallback): decompose into 6 cube-rounding sub-cases. Paste-ready sketch in sessions/2026-05-16-s3-statesync-json-leanfile-iter2-drift.md §Remaining-obligation. Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 stable."
   },
   "knowledge": {
-    "progressSummary": "BUG FIX: Color formula (2a+b)%7 was WRONG — sublattice minimum Q=3 at (1,-2), too small. Changed to (a+3b)%7 which has Q_min=7 at (3,-1). Updated bounds: s√21 center distance, (2√21-4)/5 > 1 point distance.",
+    "progressSummary": "S2 (2026-04-29) reduced UnitDistanceHN7.lean from 3 sorries to 1. Resolved hexCenter_dist_sq + inline modular step in same_color_far; companion HN7Aristotle.lean updated accordingly. Remaining: covering_radius (A₂ Voronoi circumradius ≤ s) — the hardest of the three obligations. Eliminating it would close the hexagonal 7-coloring construction and remove the hadwiger_nelson_upper_bound axiom from UnitDistanceIndependence.lean. Current state: HN7.lean 287/8/6/0/1, HN7Aristotle.lean 78/3/0/0/1, parent UnitDistanceIndependence.lean 948/65/11/2/0 (lines/thms/defs/axioms/sorries).",
     "builtItems": [
-      "hexSideLength, hexCol, hexRow, hexColor definitions",
-      "hadwiger_nelson_7coloring: main theorem (proved from lemmas)",
-      "same_hex_close, color_sublattice_min_norm, same_color_far (sorry)"
+      "hexSideLength, axialQ, axialR, hexCoord, hexColor, hexCenter (6 defs, HN7.lean lines 32-82)",
+      "color_sublattice_min_norm: PROVED (HN7.lean:84) — integer arithmetic on Q(da,db) over 3·da+db ≡ 0 (mod 7) sublattice",
+      "hexCenter_dist_sq: PROVED in S2 (HN7.lean:123) — algebraic distance formula via EuclideanSpace.dist_sq_eq + PiLp.toLp_apply + Real.mul_self_sqrt + nlinarith",
+      "sqrt21_gt_nine_halves + side_length_gap_bound: PROVED (HN7.lean:139, 149) — numeric bounds for the point-distance argument",
+      "same_hex_close, same_color_far: PROVED (HN7.lean:160, 180) — uses covering_radius (sorry pending) + hexCenter_dist_sq",
+      "Inline modular step in same_color_far: PROVED in S2 via simp [hexColor, Fin.mk.injEq] + omega (handles Int.toNat and redundant Nat.mod 7)",
+      "Companion HN7Aristotle.lean updated in S2: hexCenter_dist_sq_ari delegates to main lemma; hexColor_eq_implies_mod_ari proved by parallel omega",
+      "hadwiger_nelson_7coloring: PROVED (HN7.lean:258) — main theorem, conditional on covering_radius"
     ],
     "insights": [
       "Hex diameter 2s = 4/5 < 1 ensures same-cell points < 1 apart",
@@ -34,12 +39,16 @@
       "BUG: Original formula (2a+b)%7 has sublattice vector (1,-2) with Q(1,-2)=3, giving center distance 6/5 and point distance 2/5 < 1",
       "FIX: Formula (a+3b)%7 has Q_min=7 at (3,-1),(1,2),(-1,-2),(-3,1),(-2,1),(2,-1)",
       "Key bound: Q(a,b)=a²+ab+b²≥(a²+b²)/2 so for |a|+|b|≥4, Q≥8>7; only finitely many small cases to check",
-      "With Q_min=7: center distance ≥ (2/5)√21, point distance ≥ (2√21-4)/5 > 1 since 84 > 81"
+      "With Q_min=7: center distance ≥ (2/5)√21, point distance ≥ (2√21-4)/5 > 1 since 84 > 81",
+      "S2 PROOF PATTERN — nlinarith [h3, sq_nonneg …] with h3 : Real.sqrt 3 * Real.sqrt 3 = 3 closes hexCenter_dist_sq where ring_nf alone fails (since ring_nf normalizes √3 differently each call).",
+      "S2 PROOF PATTERN — simp only [hexColor, Fin.mk.injEq] before omega is required to peel the Fin 7 constructor and expose Nat equality; raw simp alone leaves let-binding that omega cannot parse.",
+      "S2 OUTCOME — 2 of 3 original sorries (same_hex_close, same_color_far) provably reduce to covering_radius. So eliminating covering_radius would close ALL remaining obligations in HN7.lean and HN7Aristotle.lean, then remove hadwiger_nelson_upper_bound from UnitDistanceIndependence.lean — a full collapse to 0 sorries / 1 axiom (down from 2) across the bundle.",
+      "DECOMPOSITION — covering_radius reduces to Q(q-a, r-b) ≤ 1/3 (cube-norm bound on rounding error) combined with proved hexCenter_dist_sq to get dist² ≤ 3s²·(1/3) = s². See knowledge.md §Suggested-implementation-sketch."
     ],
     "nextSteps": [
-      "Prove color_sublattice_min_norm: finite case analysis, positive definite quadratic form",
-      "Prove same_hex_close: hex rounding places point within distance s of center",
-      "Prove same_color_far: chain center distance ≥ s√39, point distance ≥ center - 2s > 1"
+      "Prove covering_radius (~80 LOC, Path A): private lemma hexCoord_cube_bound bounds Q(q-a, r-b) ≤ 1/3 by 3-sub-case split on the cube-coordinate correction (rq + ry + rr = 0 vs ≠ 0, then largest-error coordinate is corrected leaving the other two with |Δ| ≤ 1/2). Combine via hexCenter_dist_sq + Real.sqrt_le_sqrt to close.",
+      "Fallback Path B: decompose covering_radius into 6 isolated sub-lemmas (3 corrections × 2 signs), each closed by Int.floor_le / Int.le_ceil + nlinarith. ~3× the LOC but mechanically discharged.",
+      "After covering_radius lands: HN7Aristotle.lean covering_radius_ari follows by delegation (1 LOC). hadwiger_nelson_upper_bound axiom in UnitDistanceIndependence.lean can then be replaced by `exact hadwiger_nelson_7coloring`."
     ]
   },
   "tags": [
@@ -52,20 +61,42 @@
     "unit-distance-independence"
   ],
   "started": "2026-04-05T21:40:00Z",
-  "lastUpdate": "2026-04-05T21:40:00Z",
+  "lastUpdate": "2026-05-16T08:56:13Z",
   "significance": 8,
   "tractability": 7,
   "leanFiles": [
     {
       "path": "Proofs/UnitDistanceIndependence.lean",
       "filename": "UnitDistanceIndependence.lean",
-      "lineCount": 949,
+      "lineCount": 948,
       "theoremCount": 65,
       "axiomCount": 2,
       "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceIndependence.lean"
+    },
+    {
+      "path": "Proofs/UnitDistanceHN7.lean",
+      "filename": "UnitDistanceHN7.lean",
+      "lineCount": 287,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceHN7.lean"
+    },
+    {
+      "path": "Proofs/UnitDistanceHN7Aristotle.lean",
+      "filename": "UnitDistanceHN7Aristotle.lean",
+      "lineCount": 78,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceHN7Aristotle.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The research-tracking JSON `src/data/research/problems/unit-distance-independence-oq-02.json` was never updated after S2 (researcher-1, 2026-04-29) reduced `proofs/Proofs/UnitDistanceHN7.lean` from 3 sorries to 1, even though `state.md` and `knowledge.md` correctly reflect that work.

This PR closes the resulting **10-item drift** between the research JSON and the rest of the source-of-truth tree at base `d9c746dfe9a` / Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. It also fixes a scope gap: `leanFiles` was tracking only the (passive) parent `UnitDistanceIndependence.lean` with a stale lineCount — the two files actually under active work (`UnitDistanceHN7.lean` and `UnitDistanceHN7Aristotle.lean`) were absent.

## Drift Inventory (10 items)

| # | Field | Stale | Current |
|---|---|---|---|
| 1 | `currentState.since` | `2026-04-05T21:40:00Z` | `2026-04-29T03:43Z` (state.md value) |
| 2 | `currentState.iteration` | `1` | `2` |
| 3 | `currentState.focus` | iter-1 "Created … 3 geometric sorries" | iter-2 "Reduced 3→1 sorries; covering_radius remains" |
| 4 | `currentState.nextAction` | iter-1 3-lemma list (2 done) | iter-2 "Tackle covering_radius via cube-norm inequality, Path A/B" |
| 5 | `knowledge.progressSummary` | pre-iter-1 BUG FIX summary | iter-2 reduction summary |
| 6 | `knowledge.builtItems[…]` | 3 entries | 8 entries (+`hexCenter_dist_sq`, +modular step in `same_color_far`, +companion updates, +sqrt21 bounds, +color_sublattice_min_norm, +main theorem) |
| 7 | `knowledge.insights[…]` | 10 entries | +4 entries (iter-2 proof patterns + decomposition) |
| 8 | `knowledge.nextSteps[]` | 3 stale iter-1 next steps | 3 covering_radius next steps |
| 9 | `lastUpdate` | `2026-04-05T21:40:00Z` | `2026-05-16T08:56:13Z` |
| 10 | `leanFiles[…]` | 1 entry (parent, lineCount 949 stale) | 3 entries (+HN7.lean +HN7Aristotle.lean, parent fixed 949→948) |

## Files Changed

- `src/data/research/problems/unit-distance-independence-oq-02.json` — 10-item delta above (+45 / −14)
- `research/problems/unit-distance-independence-oq-02/sessions/2026-05-16-s3-statesync-json-leanfile-iter2-drift.md` — **NEW** (~135 lines): full drift inventory, Lean file metrics, S2-progress recap, paste-ready Path A `covering_radius` sketch (~80 LOC), Path B fallback, risk analysis, handoff.

`state.md` + `knowledge.md` were already current at iter 2 — **not edited**.

## Source-of-truth Audit

| File | Status |
|---|---|
| `proofs/Proofs/UnitDistanceHN7.lean` | **CANONICAL** (287/8/6/0/1) |
| `proofs/Proofs/UnitDistanceHN7Aristotle.lean` | **CANONICAL** (78/3/0/0/1) |
| `proofs/Proofs/UnitDistanceIndependence.lean` | **CANONICAL** (948/65/11/2/0) |
| `research/problems/.../state.md` | already in sync ✓ |
| `research/problems/.../knowledge.md` | already in sync ✓ |
| `src/data/research/problems/unit-distance-independence-oq-02.json` | **STALE** → closed here |

## Lean File Verification (no edits)

```bash
$ for f in proofs/Proofs/UnitDistance*.lean; do
    echo "$f $(wc -l < $f) $(grep -c '^theorem \|^lemma ' $f) $(grep -c '^def \|^noncomputable def \|^private def ' $f) $(grep -c '^axiom ' $f) $(grep -c 'sorry\b' $f)"
  done
proofs/Proofs/UnitDistanceHN7.lean 287 8 6 0 1
proofs/Proofs/UnitDistanceHN7Aristotle.lean 78 3 0 0 2
proofs/Proofs/UnitDistanceIndependence.lean 948 65 11 2 0
```

(`HN7Aristotle.lean` shows 2 sorry-matches; one is in a comment header on line 6, so the real `sorryCount = 1` at line 76.)

## Remaining Obligation: `covering_radius`

After S2: HN7.lean has **1 remaining sorry** (`covering_radius`, line 113–118 — A₂ Voronoi cell circumradius ≤ s). The companion file mirrors it (`covering_radius_ari`, line 74–76). Eliminating this **single** obligation would close ALL remaining sorries across the bundle and allow removing the `hadwiger_nelson_upper_bound` axiom from `UnitDistanceIndependence.lean` — a full collapse to 0 sorries / 1 axiom (down from 2).

The session memo provides a paste-ready Path A sketch (~80 LOC, cube-norm bound `Q(q-a, r-b) ≤ 1/3` + 3-sub-case split + combine via proved `hexCenter_dist_sq`) plus Path B fallback.

## Risk

| Risk | Likelihood | Mitigation |
|---|---|---|
| Conflict with open PR on this slug | none | `gh pr list --search ...` returns `[]` |
| Docker disk pressure blocking next ACT | high (host 100% / 7.2 GiB free) | covering_radius is non-trivial; ship as PREP next session, await Docker recovery |
| Mathlib pin drift before next ACT | low | Pin `2df2f015…` unchanged ≥9d |
| Build regression on this PR | none | doc-only, no Lean edits |

## Test Plan

- [x] JSON validates (`jq empty …` → OK)
- [x] No Lean file edits (`git diff --stat` shows only `.json` + 1 new memo)
- [x] `leanFiles` now lists all 3 active files with current metrics
- [x] `currentState.iteration` matches `state.md` (both = 2)
- [x] `lastUpdate` ISO timestamp matches session-memo footer

## Status

**Outcome**: progress (doc-only catchup)
**Next Steps**: S4 PREP/ACT pursuing Path A `covering_radius` proof, per session memo. The depth-first claim picker now sees ACT/iter-2 with a concrete next-action, not stale ACT/iter-1.

🤖 Generated by researcher-1