### PR TITLE
fix(meta): minkowski-theorem-oq-04 status/badge sync post-build-verify

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -10,7 +10,7 @@
     "author": "Hans Frederik Blichfeldt (1914)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Blichfeldt%27s_theorem",
     "date": "1914",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinkowskiTheoremOQ04.lean",
     "tags": [
       "number-theory",
@@ -19,13 +19,13 @@
       "geometry-of-numbers",
       "measure-theory"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 987,
     "theoremCount": 16,
     "definitionCount": 0,
-    "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Status flag remains `axiomatized` and badge remains `axiom` pending Docker CI verification of the post-S14 source \u2014 the broken `proofs/.lake` recursive self-symlink in this repo forces every full build into a 30\u201345 min Mathlib refetch, so build verification is gated on a separate Mechanic infra-repair pass. Once CI confirms a green build, the entry will graduate to status `verified` / badge `original` via a follow-up Mechanic/Auditor PR. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
+    "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Docker build verified clean (3075 jobs, PR #19113, 2026-05-14); status promoted from `axiomatized` to `verified` and badge from `axiom` to `original`. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
     "dateAdded": "2026-05-07",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Sync `status` and `badge` for `minkowski-theorem-oq-04` (Blichfeldt's Theorem) from stale `axiomatized` / `axiom` to `verified` / `original`, per the explicit mechanic handoff in PR #19113.

## Evidence

**Lean file** — 0 axiom declarations, 0 tactic-position sorries:

```
$ grep -nE "^axiom " proofs/Proofs/MinkowskiTheoremOQ04.lean
(no matches)
$ grep -c sorry proofs/Proofs/MinkowskiTheoremOQ04.lean
1   # single mention is inside a docstring comment, not a tactic
```

**Build status** — PR #19113 (`research(minkowski-theorem-oq-04): Iter 23 BUILD-VERIFY — 3075-job Docker clean`, merged 2026-05-15T22:58:44Z) ran `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` and confirmed **0 errors / 3075 jobs clean** on Lean v4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

**Self-documented handoff** — PR #19113 §"What this unblocks" recorded the precise bump rule:

> **Meta-status flip (Mechanic next)**: `meta.json`
> - `status: axiomatized → verified`
> - `badge: axiom → original`
> - rewrite `meta.assumptions` to drop "pending Docker CI" caveat

That condition is now satisfied. `mainTheorems[blichfeldt_general].type` is already `"proved"` (line 215) so no edit needed there.

## Changes

- `meta.status`: `"axiomatized"` → `"verified"`
- `meta.badge`: `"axiom"` → `"original"`
- `meta.assumptions`: leading clause about "pending Docker CI verification" / "broken proofs/.lake symlink" / "graduate via follow-up Mechanic PR" replaced with one-sentence "Docker build verified clean (3075 jobs, PR #19113, 2026-05-14); status promoted from axiomatized to verified and badge from axiom to original." History tail preserved unchanged.

No Lean source changes; no count changes (sorries=0, axiomCount=0, lineCount=987, theoremCount=16, definitionCount=0 all unchanged).

## Scope

One slug, one logical sync (post-build-verify status/badge promotion). Mirrors the recent precedent #19457 (algebraic-numbers-countable-oq-02-oq-04). Diff is +3/-3 lines (single file).

Pre-claim cross-checks:
- `gh pr list --search "minkowski-theorem-oq-04 mechanic in:title"` returned `[]` (no open mechanic PR)
- Stale closed PR #16732 was a different counts-sync (4→2 / 3→5 / 227→241), now irrelevant
- `pnpm build` clean (`✓ built in 21.39s`)

---
Automated fix by lean-mechanic agent.