### PR TITLE
research(arithmetic-series-oq-02-oq-04-oq-01): S2 STATE-SYNC — flip top-level phase ACT→DONE / status active→completed (doc-only)

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01/state.md
@@ -1,27 +1,54 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T02:57:02.769Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-16 (researcher-11, S2 STATE-SYNC — close drift from gallery+JSON-inner+Lean)
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+State-sync: gallery `meta.json` (status `verified`, 0 sorries, 0 axioms,
+169 LOC, 12 theorems) and research JSON `currentState.phase = DONE`
+already reflect completion, but this `state.md` was stuck at the
+2026-04-03 bootstrap (phase NEW, iteration 1, "Begin problem
+exploration") and JSON top-level `phase: ACT` / `status: active` were
+not flipped. This sync closes that drift and unblocks claim-random from
+re-serving the slug.
 
 ## Active Approach
 
-None yet.
+Closed. The proof in `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean`
+(169 LOC, 12 theorems, 0 sorries, 0 axioms) directly establishes the
+descending-factorial analogue of the arithmetic series identity:
+
+- `choose_descFactorial`: `C(n,k) · k! = n.descFactorial k`
+- `choose_product`: `C(n,k) · k! = ∏ i ∈ range k, (n − i)`
+- `choose_full_factorial`: `C(n,k) · k! · (n−k)! = n!`
+- `factorial_dvd_descFactorial`: `k! | n.descFactorial k`
+- `ascending_descending_duality`: bridges to OQ-02-OQ-04 ascending form
+- Plus specialisations at `k = 1, 2, 3` and concrete numeric checks
+
+Key Mathlib bearer: `Nat.descFactorial_eq_factorial_mul_choose`.
 
 ## Blockers
 
 None.
 
+## Iteration History
+
+| Iter | Date | Researcher | Type | Outcome |
+|---|---|---|---|---|
+| 0 | 2026-04-03 | seeker/aristotle | SCAFFOLD | bootstrapped problem.md + state.md (NEW) |
+| 1 | (pre-2026-04-27) | researcher | ACT | proved 12 theorems in `ArithmeticSeriesOQ02OQ04OQ01.lean` (0 sorries, 0 axioms); gallery `meta.json` updated to `verified` |
+| 2 | 2026-05-16 | researcher-11 | STATE-SYNC | THIS — close drift between state.md / JSON top-level (`phase: ACT`, `status: active`) and gallery (`status: verified`) / JSON inner (`currentState.phase: DONE`) |
+
 ## Next Action
 
-Begin problem exploration.
+None — work complete; gallery `meta.json` and Lean file in sync. After
+this PR merges, the slug should drop off `claim-random`'s candidate pool
+(JSON top-level `phase` → `DONE`, `status` → `completed`).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2 (1 ACT — Lean proof, 1 STATE-SYNC — this PR)
+- Current approach attempts: 0 (no active research)
+- Approaches tried: 1

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -1,30 +1,39 @@
 {
   "slug": "arithmetic-series-oq-02-oq-04-oq-01",
   "title": "Formalize descending factorial analogue of arithmetic series",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in analysis: Formalize descending factorial analogue of arithmetic series.",
-    "whyMatters": []
+    "formal": "C(n,k) · k! = n.descFactorial k    (Nat.descFactorial_eq_factorial_mul_choose, reversed)",
+    "plain": "Formalize descending factorial analogue of arithmetic series: the ordered-selection formula C(n,k) · k! = n.descFactorial k, dual to the ascending factorial identity in OQ-02-OQ-04.",
+    "whyMatters": [
+      "Closes the descending-factorial leg of the OQ-04 ascending/descending dual pair",
+      "Verified Lean proof: 12 theorems, 0 sorries, 0 axioms, 169 LOC"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "choose_descFactorial: C(n,k) · k! = n.descFactorial k",
+      "choose_product: C(n,k) · k! = ∏ i ∈ range k, (n-i)",
+      "choose_full_factorial: C(n,k) · k! · (n-k)! = n!",
+      "factorial_dvd_descFactorial: k! | n.descFactorial k",
+      "ascending_descending_duality: bridges to OQ-02-OQ-04 ascending leg"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "ACHIEVED: Descending factorial identity verified; 0 sorries, 0 axioms; gallery meta status=verified."
   },
   "currentState": {
-    "phase": "DONE",
-    "since": "2026-04-03T00:00:00Z",
-    "iteration": 1,
-    "focus": "Created ArithmeticSeriesOQ02OQ04OQ01.lean with 11 theorems, 0 sorries, 0 axioms.",
+    "phase": "COMPLETED",
+    "since": "2026-05-16T09:05:00Z",
+    "iteration": 2,
+    "focus": "STATE-SYNC complete. Work was finished pre-2026-04-27 (gallery meta status=verified, 0 sorries, 0 axioms, 169 LOC, 12 theorems) but top-level JSON `phase`/`status` and `state.md` had drifted (still showing ACT/active/NEW). This sync flips top-level phase ACT→DONE, status active→completed, updates state.md head, refreshes problemStatement + knownResults to reflect achieved work.",
     "blockers": [],
-    "nextAction": "Verify compilation with docker-build.sh.",
+    "nextAction": "None — work complete; gallery in sync. After merge, slug drops off claim-random's candidate pool.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 0,
       "approachesTried": 1
     }
   },


### PR DESCRIPTION
## Summary

Doc-only state-sync for `arithmetic-series-oq-02-oq-04-oq-01`. The slug was
returned by `claim-random` because its top-level JSON `phase: ACT` /
`status: active` matched the active filter, but the work has been complete
since pre-2026-04-27 (gallery `verified`, Lean 0 sorries / 0 axioms).

## Drift table

| Source | Pre-PR | Post-PR |
|---|---|---|
| Gallery `meta.json` | `verified`, 0 sorries, 0 axioms, 169 LOC, 12 thms | unchanged |
| Lean `ArithmeticSeriesOQ02OQ04OQ01.lean` | 169 LOC, 12 thms, 0 sorries, 0 axioms | unchanged |
| Research JSON `currentState.phase` | `DONE` | `COMPLETED` |
| Research JSON top-level `phase` | **ACT** | **DONE** |
| Research JSON top-level `status` | **active** | **completed** |
| `state.md` head | **NEW / iter 1 / "Begin problem exploration"** | **COMPLETED / iter 2** |

## Files changed (2, doc-only)

- `research/problems/arithmetic-series-oq-02-oq-04-oq-01/state.md`
- `src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json`

## Effect

After merge, the slug drops off `claim-random`'s candidate pool, preventing
future no-op claim cycles on completed work (memory trap
`_postship_pivot_lands_on_VERIFIED_slug_…`).

## Files NOT changed

- ❌ No Lean file edits
- ❌ No Docker build (work already verified)
- ❌ No `meta.json` edits (already in sync)

## Pre-flight

- Disk: 100% used, 7.2 Gi avail (PREP-class, doc-only)
- Docker: not run
- Open PRs on slug: 0

## Test plan

- [x] JSON validates (`python3 -m json.tool` clean)
- [x] No Lean files touched
- [x] Gallery `meta.json` already in sync — no changes needed
- [ ] Post-merge: confirm `claim-random` no longer serves this slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)