### PR TITLE
fix(meta): sperner-ndim-mathlib-oq-01-oq-04 theoremCount 3→4 + add signedAdjMap_invol to originalContributions

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
@@ -31,9 +31,10 @@
       "signedDoorCount: signed door count (sum of facet signs over door facets, in ℤ)",
       "signed_interior_doors_sum_zero: the sum of facet signs over interior doors vanishes in ℤ — signed analog of the parent's interior_doors_even, discharged via Finset.sum_involution",
       "sign_ne_zero: facet signs are never zero (immediate from sign_pm_one)",
-      "door_transfer_signed_one_dir: private helper re-proving the parent's private door_transfer for use in the cancellation proof"
+      "door_transfer_signed_one_dir: private helper re-proving the parent's private door_transfer for use in the cancellation proof",
+      "signedAdjMap_invol: private helper showing signedAdjMap is an involution on interior facets, extracted to dodge a dependent-type generalize failure in the main theorem's invol case"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 3,
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex framework: adj_symm, adj_vertices, adj_ne axioms)",


### PR DESCRIPTION
## Fix

Closes the off-by-one drift noted as a low-severity footnote in audit PR #19553: `meta.theoremCount: 3` while the Lean source actually has 4 theorems/lemmas (`leanFile.theoremCount: 4` already correct).

## Evidence

`proofs/Proofs/SpernerNDimMathlibOQ01OQ04.lean` contains 4 theorems/lemmas (2 public + 2 private):

```
77:lemma sign_ne_zero
102:private lemma door_transfer_signed_one_dir
122:private lemma signedAdjMap_invol      ← iter-2 helper, previously unrecorded
140:theorem signed_interior_doors_sum_zero
```

**Before**: `meta.theoremCount: 3`, `originalContributions` length 6 (omits `signedAdjMap_invol`)
**After**: `meta.theoremCount: 4`, `originalContributions` length 7 (adds `signedAdjMap_invol` description)

`signedAdjMap_invol` is the private helper showing `signedAdjMap` is an involution on interior facets; it was extracted (per docstring at lines 118–121) to dodge a dependent-type generalize failure in the main theorem's `invol` case.

## Validation

```
$ jq '{meta_theoremCount: .meta.theoremCount, oc_len: (.meta.originalContributions | length), leanFile_theoremCount: .leanFile.theoremCount}' src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
{
  "meta_theoremCount": 4,
  "oc_len": 7,
  "leanFile_theoremCount": 4
}
```

## Scope

Pure metadata fix; no Lean source or build pipeline touched. No conflict with PR #19553 (which touches `audit-tracker.json` only).

---
Automated fix by lean-mechanic agent.