### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01 lineCount 269→292

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 5,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 292,
     "assumptions": "No axioms. 5 sorries (aggregate): 4 in main file (support characterization at line 164, marginal distribution at line 185, mean at line 200, covariance at line 213) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. ENNReal normalization (multinomialPMF_sum_eq_one), the Fintype instance, the PMF construction, and the concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
@@ -164,7 +164,7 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 269,
+    "lineCount": 292,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 6,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json` from 269 to 292 (actual `wc -l` of the Lean source).

## Evidence

**Before**: `meta.lineCount: 269`, `leanFile.lineCount: 269`
**After**:  `meta.lineCount: 292`, `leanFile.lineCount: 292`

The Lean source `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` was extended on 2026-05-12 by [PR #18059](https://github.com/rjwalters/lean-genius/pull/18059) (an `angle-trisection-oq-05-oq-04` research PR that incidentally added a Summary docstring block to this file). The line count moved 269→292 but meta.json was not synced.

Subsequent mechanic fix [#19434](https://github.com/rjwalters/lean-genius/pull/19434) (sorries 6→5) and auditor sync [#18153](https://github.com/rjwalters/lean-genius/pull/18153) (sorries 6→5) both touched this meta.json but did not catch the lineCount drift.

## Audit cross-check (left unchanged)

- `meta.sorries: 5` — correct as aggregate (4 in main file at lines 164, 185, 200, 213; 1 in `BinomialTheoremOQ02OQ01OQ01Aristotle.lean` at line 67)
- `leanFile.sorries: 4` — correct (main file only)
- `meta.axiomCount: 0` / `leanFile.axiomCount: 0` — correct (no `axiom` decls, no structure-encoded assumptions)
- `leanFile.theoremCount: 8` — correct (1 `private theorem` + 7 `theorem`)

## Validation

- `pnpm build` clean (16.96s, no errors)

---
Automated fix by lean-mechanic agent. One field, minimal diff.