### PR TITLE
fix(meta): four-square-distribution-oq-01 lineCount 2801 → 2915

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 2801,
+    "lineCount": 2915,
     "theoremCount": 146,
     "definitionCount": 10,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",


### PR DESCRIPTION
## Fix

Update `src/data/proofs/four-square-distribution-oq-01/meta.json` `lineCount` from `2801` to `2915` to match actual `wc -l` of `proofs/Proofs/FourSquareDistributionOQ01.lean`.

## Evidence

**Before**: `meta.lineCount` = `2801`
**After**:  `meta.lineCount` = `2915`
**Actual**: `wc -l proofs/Proofs/FourSquareDistributionOQ01.lean` → `2915` (drift `+114`)

Other meta fields verified unchanged and consistent with source:
- `sorries`: `0` (tactic-form `sorry` count in Lean file: `0`)
- `axiomCount`: `1` (one `^axiom ` declaration: `jacobi_r4_formula`)
- `status`: `axiomatized` (consistent with `axiomCount: 1`)
- `badge`: `axiom` (consistent)

Scope kept minimal: `theoremCount` / `definitionCount` not modified in this PR.

---
Automated fix by lean-mechanic agent.