### PR TITLE
fix(meta): knights-tour-oblique lineCount/theoremCount/definitionCount sync

### DIFF
--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -23,10 +23,10 @@
     "assumptions": "1 axiom: knuth_unique_four_oblique — any closed knight's tour with exactly 4 oblique turns is D4-equivalent to the minimal oblique tour. Accepted based on Knuth's exhaustive computational verification of all ~13.3 trillion closed knight's tours (TAOCP Vol 4 Fascicle 8a, December 2025).",
     "proofRepoPath": "Proofs/KnightsTourOblique.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 2469,
+    "lineCount": 2463,
     "sorries": 0,
-    "theoremCount": 111,
-    "definitionCount": 48
+    "theoremCount": 100,
+    "definitionCount": 42
   },
   "overview": {
     "historicalContext": "The knight's tour problem has fascinated mathematicians for over 1200 years, with the earliest known reference from the 9th century. Euler studied it in 1759, constructing explicit tours by hand and introducing the technique of dividing the board into regions. Schwenk (1991) completely characterized which rectangular boards admit closed knight's tours. In his 29th Annual Christmas Lecture (December 2025), Donald Knuth revealed a new structural property: the minimum number of oblique turns in any closed tour, and the remarkable uniqueness of the tour achieving this minimum. Knuth's analysis uses techniques from graph theory and combinatorial optimization to certify optimality, extending the classical enumeration results of de Bruijn and others.",
@@ -142,10 +142,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 2469,
+    "lineCount": 2463,
     "structureCount": 2,
     "axiomCount": 1,
-    "theoremCount": 111,
+    "theoremCount": 100,
     "lemmaCount": 0,
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
@@ -157,7 +157,7 @@
     "opens": [],
     "path": "Proofs/KnightsTourOblique.lean",
     "sorries": 0,
-    "definitionCount": 48
+    "definitionCount": 42
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Sync stale `meta.{lineCount,theoremCount,definitionCount}` and matching `leanFile.*` fields in `src/data/proofs/knights-tour-oblique/meta.json` to actual `proofs/Proofs/KnightsTourOblique.lean` state.

## Evidence

| Field | Before | After | Canonical command |
|-------|--------|-------|-------------------|
| `lineCount` | 2469 | 2463 | `wc -l proofs/Proofs/KnightsTourOblique.lean` |
| `theoremCount` | 111 | 100 | `grep -cE '^(theorem\|lemma) ' …` |
| `definitionCount` | 48 | 42 | `grep -cE '^(def\|noncomputable def\|opaque def) ' …` |
| `axiomCount` | 1 | 1 | unchanged — matches `grep -cE '^axiom ' …` |
| `sorries` | 0 | 0 | unchanged — matches `grep -oE '\bsorry\b' …` (0 hits) |

Canonical regex follows `scripts/research/enrich-research.ts` `extractLeanMetadata()` (`^(theorem|lemma) `, `^(def|noncomputable def|opaque def) `, `^axiom `).

## Drift origin

- PR #19059 (mechanic Tier 1+2 cleanup, 2026-05-15) removed duplicate `tour_consecutive_adj` (1 theorem, 5 lines) + applied 7 deprecation renames (net +7/-13 lines = -6); meta was not re-synced.
- Earlier batch fixes (#15037 `feat: ... + batch meta.theoremCount fixes`, #16012 `fix(meta): add missing definitionCount (and theoremCount) to 2003 gallery entries`) may have used broader heuristics including `private` prefixes (which yield 110, not 100), accounting for the additional -10 theoremCount drift.

Both `meta.meta.*` and the duplicated `leanFile.*` blocks updated.

---
Automated meta-sync by lean-mechanic agent.