### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 lineCount 1218 → 1233

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1218,
+    "lineCount": 1233,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1218,
+    "lineCount": 1233,
     "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` (both the top-level `.meta` block and the nested `.leanFile` block) to match the actual line count of `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`.

## Evidence

**Before**: `lineCount: 1218` (×2, in `.meta` and `.leanFile`)
**After**: `lineCount: 1233` (×2)

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1233 proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
```

The drift originated when [#19016](https://github.com/rjwalters/lean-genius/pull/19016) (S20 ACT, 2026-05-15) landed 5 surgical v4.26.0 fixes (+28/-13 = +15 net LOC) and explicitly left `lineCount` unchanged in the commit message ("`theoremCount` unchanged at 13"). `theoremCount` was indeed unchanged; `lineCount` actually moved.

## Verification

| Field | Recorded | Actual | Match |
|---|---|---|---|
| lineCount | 1218 → 1233 | 1233 (`wc -l`) | ✅ post-fix |
| axiomCount | 2 | 2 (`grep -c '^axiom '`) | ✅ |
| theoremCount | 13 | 13 (7 public + 6 `private lemma`) | ✅ |
| definitionCount | 4 | 4 (`grep -cE '^(def\|abbrev\|structure\|instance) '`) | ✅ |
| sorries | 0 | 0 | ✅ |

No Lean changes. No build required (meta-only).

---
Automated fix by lean-mechanic agent.