### PR TITLE
audit(sperner-ndim-mathlib-oq-01-oq-04): sync meta.theoremCount 3 → 4 (post-S2-A drift)

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
@@ -33,7 +33,7 @@
       "sign_ne_zero: facet signs are never zero (immediate from sign_pm_one)",
       "door_transfer_signed_one_dir: private helper re-proving the parent's private door_transfer for use in the cancellation proof"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 3,
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex framework: adj_symm, adj_vertices, adj_ne axioms)",


### PR DESCRIPTION
## Summary

Routine gallery-integrity audit on the just-merged `sperner-ndim-mathlib-oq-01-oq-04` slug (S2-A ACT, PR #19454) caught a 1-character drift in `meta.json`:

- **Before**: `meta.theoremCount: 3`
- **After**: `meta.theoremCount: 4`
- **Why**: `leanFile.theoremCount` already reads 4, and the actual Lean source has 4 theorems/lemmas:
  - `sign_ne_zero` (public lemma, line 77)
  - `door_transfer_signed_one_dir` (private lemma, line 102)
  - `signedAdjMap_invol` (private lemma, line 122)
  - `signed_interior_doors_sum_zero` (public theorem, line 140)

Sibling slugs in this family (`sperner-ndim-mathlib`, `sperner-ndim-mathlib-oq-01`, `sperner-ndim-mathlib-oq-02`) all keep `meta.theoremCount == leanFile.theoremCount`, so this is genuine local drift, not a convention difference.

## All other public-facing claims verified clean

- 0 sorries (matches Lean source — `grep -E '\bsorry\b'` returns nothing)
- 0 axioms (no `^axiom` declarations)
- 207 lineCount ✓ (matches `wc -l`)
- status `verified` defensible: Tier A — `Finset.sum_involution` is a generic combinatorial tool (additive cousin of `prod_involution` via `@[to_additive]`), not the headline theorem
- badge `original` defensible: new structure + new main theorem; uses parent's adjacency axioms which are structure-encoded (not a Mathlib-wrapper pattern)

## Test plan

- [x] jq reads valid JSON post-edit (1-byte change inside an integer field, no syntactic risk)
- [x] Diff is minimal (1 line, 1 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)