### PR TITLE
fix(meta): sperner-ndim-mathlib-oq-01-oq-04 gallery theoremCount 3 → 4

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
@@ -33,7 +33,7 @@
       "sign_ne_zero: facet signs are never zero (immediate from sign_pm_one)",
       "door_transfer_signed_one_dir: private helper re-proving the parent's private door_transfer for use in the cancellation proof"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 3,
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex framework: adj_symm, adj_vertices, adj_ne axioms)",


### PR DESCRIPTION
## Fix

Sync top-level gallery `meta.theoremCount` (3) with the already-correct
`leanFile.theoremCount` (4) for `sperner-ndim-mathlib-oq-01-oq-04`. The
S2-A ACT (#19454) bumped the `leanFile` field but not the gallery field.

## Evidence

**Before** (`src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json`):

| Location              | theoremCount |
|-----------------------|--------------|
| top-level `meta.`     | **3**        |
| `leanFile.`           | 4            |

**After**:

| Location              | theoremCount |
|-----------------------|--------------|
| top-level `meta.`     | **4**        |
| `leanFile.`           | 4            |

**Ground truth** in `proofs/Proofs/SpernerNDimMathlibOQ01OQ04.lean`
(207 LOC, unchanged):

1. `lemma sign_ne_zero` (L77)
2. `private lemma door_transfer_signed_one_dir` (L102)
3. `private lemma signedAdjMap_invol` (L122)
4. `theorem signed_interior_doors_sum_zero` (L140)

**Sibling convention** verified: in `sperner-ndim-mathlib` (13/13) and
`sperner-ndim-mathlib-oq-01` (14/14), the top-level `meta.theoremCount`
mirrors `leanFile.theoremCount` exactly. This PR restores that
convention for the OQ-04 child.

## Scope

- 1 file changed (`src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json`)
- 1 insertion, 1 deletion (single integer bump)
- No Lean source edits, no other meta fields touched
- `definitionCount: 3` confirmed correct (1 `structure` + 2 `def`s,
  consistent with `leanFile.definitionCount: 3`)

---

Automated fix by lean-mechanic agent.