### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02-oq-01-oq-01 lineCount 276→293

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 276,
+    "lineCount": 293,
     "assumptions": "None for the qdetF definition and the multiplicative identity. The n=2 specialization theorems require the non-degeneracy hypothesis carried in the parent file (A 1 1 ≠ 0 for the (0,0)-case, A 0 0 ≠ 0 for the (1,1)-case). The S3 SCAFFOLD theorem qdetN_step_eq_qdetF (Route B → Route A bridge over a field) requires (minorIJ A i j).det ≠ 0 and currently carries a sorry pending S4 cofactor-expansion expansion.",
     "originalContributions": [
       "Defined minorIJ: the complementary n×n submatrix of an (n+1)×(n+1) matrix via Fin.succAbove, uniformly in n (generalizes CramersRuleOQ01OQ02OQ01.block3)",
@@ -151,7 +151,7 @@
       "Matrix"
     ],
     "namespace": "CramersRuleOQ01OQ02OQ01OQ01",
-    "lineCount": 276,
+    "lineCount": 293,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

`meta.lineCount` and `leanFile.lineCount` for the **Uniform n×n Quasideterminants over a Field (Route A)** entry both pointed at `276`, but `proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` is currently `293` lines. The drift was introduced when PR #19142 (S4 statement-fix: corrected `(-1)^(i+j)` sign factor on `qdetN_step_eq_qdetF` + mechanic-PR overlay build-verify) grew the file by 17 lines without updating the meta record.

## Evidence

**Before**
```json
"meta.lineCount":     276
"leanFile.lineCount": 276
```

**After**
```json
"meta.lineCount":     293
"leanFile.lineCount": 293
```

Verified via `wc -l proofs/Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean` → `293`.

All other counts already match reality:
- `axiomCount: 0` ✓ (`grep -cE '^axiom ' = 0`)
- `sorries: 1` ✓ (one tactic-form `sorry` at line 287 on `qdetN_step_eq_qdetF`; the four other `sorry` occurrences are narrative-only inside docstring comment blocks)
- `theoremCount: 10`, `definitionCount: 3` ✓ (unchanged since #19451 sync)

No other fields touched.

---
Automated fix by lean-mechanic agent.