### PR TITLE
fix(meta): mean-value-theorem-oq-02-oq-04 lineCount 105 → 128

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 105,
+    "lineCount": 128,
     "assumptions": "1 axiom (inherited from additionalFiles only; main file is now empty after S2 retraction): taylor_lagrange_remainder in the parent file MeanValueTheoremOQ02.lean (qualitative pointwise Lagrange remainder, listed in additionalFiles below). The false OQ-04 axiom analytic_taylor_remainder_uniform_bound (S1, 2026-05-11) was REMOVED by S2 (researcher-8, 2026-05-14) after the child slug mean-value-theorem-oq-02-oq-04-oq-01 proved oq04_axiom_is_false via Runge counterexample (real sup bound on (a-R, a+R) ⊂ ℝ does not control the Cauchy coefficient bounds, which require a *complex*-disk sup bound). The mathematically correct uniform Cauchy bound lives in the child slug as analytic_taylor_remainder_uniform_bound_complex (fully proven modulo cauchy_diag_norm_bound_at_radius). 0 sorries in this file.",
     "dateAdded": "2026-05-11",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` in `src/data/proofs/mean-value-theorem-oq-02-oq-04/meta.json` to actual `wc -l proofs/Proofs/MeanValueTheoremOQ02OQ04.lean = 128`.

## Evidence

| Field | Before | After | Canonical command |
|-------|--------|-------|-------------------|
| `lineCount` | 105 | 128 | `wc -l proofs/Proofs/MeanValueTheoremOQ02OQ04.lean` |
| `axiomCount` | 1 | 1 | unchanged — file declares 0 axioms locally, `assumptions` attributes 1 inherited from `additionalFiles[0]` (`Proofs/MeanValueTheoremOQ02.lean :: taylor_lagrange_remainder`) per axiom-integrity policy |
| `theoremCount` | 0 | 0 | unchanged — `grep -cE '^(theorem\|lemma) ' …` = 0 |
| `definitionCount` | 0 | 0 | unchanged — `grep -cE '^(def\|noncomputable def\|opaque def) ' …` = 0 |
| `sorries` | 0 | 0 | unchanged — `grep -oE '\bsorry\b' …` = 0 |
| `status` | `axiomatized` | `axiomatized` | unchanged — inherited axiom present |
| `badge` | `axiom` | `axiom` | unchanged |

## Drift origin

The file was retracted to a doc-only stub in S2 (researcher-8, 2026-05-14) after the child slug \`mean-value-theorem-oq-02-oq-04-oq-01\` constructively refuted the S1 \`analytic_taylor_remainder_uniform_bound\` axiom via the Runge counterexample. The S2 commit projected \`lineCount: ~90\` in the in-file bookkeeping note (line 75), but subsequent edits expanded the retraction docstring and "what this file currently contains" / "path forward" / "references" sections, reaching the current 128 lines. The gallery \`meta.lineCount\` was not re-synced.

## Scope

Single-field meta sync. No Lean source touched; other counts and status fields verified unchanged.

---
Automated meta-sync by lean-mechanic agent.