### PR TITLE
fix(meta): ptolemys-theorem-oq-01 lineCount 482 → 470

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 482,
+    "lineCount": 470,
     "assumptions": "None. All results fully verified from Mathlib with 0 sorries and 0 axioms.",
     "theoremCount": 13,
     "definitionCount": 2
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 482,
+    "lineCount": 470,
     "axiomCount": 0,
     "theoremCount": 13,
     "substantiveTheoremCount": 5,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/ptolemys-theorem-oq-01/meta.json` from 482 to 470 (actual `wc -l` of the Lean source).

## Evidence

**Before**: `meta.lineCount: 482`, `leanFile.lineCount: 482`
**After**:  `meta.lineCount: 470`, `leanFile.lineCount: 470`

The Lean source `proofs/Proofs/PtolemysTheoremOQ01.lean` was edited on 2026-05-15 by mechanic [PR #19206](https://github.com/rjwalters/lean-genius/pull/19206) (v4.26.0 parent repair: K1-K7 patterns). K1 removed two `example :` demonstration blocks (lines 438-457) as `Complex.abs_*`/`Complex.norm_eq_abs` no longer resolved under `simp only`/`norm_num` at v4.26.0. Net diff was +24/-36 (net -12 LOC) but meta.json was not synced.

## Audit cross-check (left unchanged)

- `meta.axiomCount: 0` / `leanFile.axiomCount: 0` — correct (no `axiom` decls, no structure-encoded assumptions)
- `meta.theoremCount: 13` / `leanFile.theoremCount: 13` — correct (8 top-level `theorem`/`lemma` + 5 `private lemma`: `unit_star_eq_inv`, `exp_mul_I_re`, `exp_mul_I_im`, `exp_diff_factor`, `sin_neg_of_neg_of_neg_pi_lt`)
- `leanFile.substantiveTheoremCount: 5` — unchanged
- `meta.definitionCount: 2` / `leanFile.definitionCount: 2` — correct (`IsCCWOrder`, `IsConcyclic₄`)
- `sorries: 0` — correct (the 2 `sorry` string matches at lines 20, 464 are inside docstring/comment blocks; no `:= sorry` or `by sorry` statements)

## Validation

- `pnpm build` clean (18.56s, no errors)

---
Automated fix by lean-mechanic agent. Two fields, minimal diff.