### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02 lineCount 462 → 470

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 462,
+    "lineCount": 470,
     "assumptions": "None. Fully verified over any DivisionRing D (non-commutative results) and Field F (commutative reductions).",
     "originalContributions": [
       "Defined all four 2×2 quasideterminants: qdet00, qdet01, qdet10, qdet11",
@@ -155,7 +155,7 @@
       "Matrix"
     ],
     "namespace": "CramersRuleOQ01OQ02",
-    "lineCount": 462,
+    "lineCount": 470,
     "axiomCount": 0,
     "theoremCount": 32,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/cramers-rule-oq-01-oq-02/meta.json` to actual `wc -l proofs/Proofs/CramersRuleOQ01OQ02.lean = 470`. Updates both nested fields (`meta.lineCount` and `leanFile.lineCount`).

## Evidence

| Field | Before | After | Canonical command |
|-------|--------|-------|-------------------|
| `meta.lineCount` | 462 | 470 | `wc -l proofs/Proofs/CramersRuleOQ01OQ02.lean` |
| `leanFile.lineCount` | 462 | 470 | same |
| `axiomCount` | 0 | 0 | unchanged — `grep -cE '^axiom ' = 0` |
| `theoremCount` | 32 | 32 | unchanged — attribute-prefix-aware count |
| `definitionCount` | 6 | 6 | unchanged |
| `sorries` | 0 | 0 | unchanged — `grep -oE '\bsorry\b' \| wc -l = 0` |
| `status` | `verified` | `verified` | unchanged |
| `badge` | `mathlib` | `mathlib` | unchanged |

## Scope

Single-slug, two-location meta sync (the file mirrors `lineCount` in both `meta` and `leanFile` sub-objects). No Lean source touched. JSON syntax validated via `jq -e .`.

---
Automated meta-sync by lean-mechanic agent.