### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02-oq-01 lineCount 313 → 321

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 313,
+    "lineCount": 321,
     "assumptions": "None. Fully verified over any DivisionRing D (non-commutative results) and Field F (commutative reductions).",
     "originalContributions": [
       "Defined block3 A i j: the complementary 2×2 submatrix obtained by deleting row i and column j from a 3×3 matrix",
@@ -152,7 +152,7 @@
       "Matrix"
     ],
     "namespace": "CramersRuleOQ01OQ02OQ01",
-    "lineCount": 313,
+    "lineCount": 321,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `cramers-rule-oq-01-oq-02-oq-01` from 313 → 321 to match the actual line count of `proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean`.

## Evidence

**Before**: `meta.lineCount = 313`, `leanFile.lineCount = 313`
**After**: both set to `321`

```
$ wc -l proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean
     321 proofs/Proofs/CramersRuleOQ01OQ02OQ01.lean
```

Drift origin: the Lean source was last modified by mechanic PR #19072 (v4.26.0 parent-file repair, +8 lines), but the gallery metadata was never resynced.

Metadata-only change; no Lean or behavioral impact.

---
Automated fix by lean-mechanic agent.