### PR TITLE
audit(sperner-ndim-mathlib-oq-01-oq-04): theoremCount 3 → 4 + tracker bump (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15259,6 +15259,12 @@
       "lastAudited": "2026-05-16T04:22:49Z",
       "result": "clean",
       "issues": []
+    },
+    "sperner-ndim-mathlib-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-16T10:06:19Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
@@ -33,7 +33,7 @@
       "sign_ne_zero: facet signs are never zero (immediate from sign_pm_one)",
       "door_transfer_signed_one_dir: private helper re-proving the parent's private door_transfer for use in the cancellation proof"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 3,
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex framework: adj_symm, adj_vertices, adj_ne axioms)",


### PR DESCRIPTION
## Audit Summary

**Slug**: `sperner-ndim-mathlib-oq-01-oq-04`
**Result**: issues-fixed (1 meta drift corrected; 0 sorries, 0 axioms, 207 LOC verified clean)
**Audit cycle**: 1 (first audit)

## Findings

### Drift detected
`meta.theoremCount: 3` undercounted by one. The Lean source contains 4 theorem-like declarations:

1. `sign_ne_zero` (public lemma, L77)
2. `door_transfer_signed_one_dir` (private lemma, L102)
3. `signedAdjMap_invol` (private lemma, L122)
4. `signed_interior_doors_sum_zero` (public theorem, L140)

The nested `leanFile.theoremCount` already reported `4` (source-computed); only the outer `meta.theoremCount` was stale.

### Verified clean
- `sorries`: 0 ✅
- `axiomCount`: 0 ✅ (no `axiom` declarations; structure fields `sign_pm_one` / `sign_adj` are proof obligations supplied at instance construction, not free assumptions)
- `lineCount`: 207 ✅
- `status: verified` / `badge: original` ✅
- No True stubs
- No Mathlib wrapper masking (`Finset.sum_involution` is invoked as a generic tool, not as the proof's main result)

## Changes

| File | Change |
|------|--------|
| `src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json` | `theoremCount`: 3 → 4 |
| `src/data/proofs/audit-tracker.json` | new entry: result `issues-fixed`, auditCount 1 |

## Context

This is the lone remaining unaudited gallery entry (1 of 2435). Five stale audit branches existed on origin from prior agents but no PR had been opened, so the tracker entry never landed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)