### PR TITLE
fix(meta): e-transcendental lineCount 304 → 305

### DIFF
--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
     "assumptions": "1 axiom: e_transcendental (Hermite 1873: e is transcendental). Corollaries e_irrational_axiom, exp_nat_transcendental_axiom, e_inv_transcendental_axiom, e_plus_one_transcendental_axiom formerly axiomatized; now proved from e_transcendental.",
-    "lineCount": 304,
+    "lineCount": 305,
     "relatedProblems": [
       {
         "id": "e-transcendental-oq-01",
@@ -208,7 +208,7 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 304,
+    "lineCount": 305,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync gallery + leanFile `lineCount` in `src/data/proofs/e-transcendental/meta.json` with the actual line count of `proofs/Proofs/eTranscendental.lean`.

## Evidence

**Before**: `meta.json` declared `lineCount: 304` (both at `meta.lineCount` line 43 and `leanFile.lineCount` line 211).
**After**: `lineCount: 305` matches `wc -l proofs/Proofs/eTranscendental.lean` → `305`.

**Drift source**: PR #19001 (`research(nth-root-irrational-oq-03): S5b ACT — parent-file repair restores build`) modified `eTranscendental.lean` with `3 insertions(+), 2 deletions(-)` (net +1) but did not update `meta.json`.

**Other fields verified correct** (no change needed):
- `theoremCount: 12` (12 theorems found)
- `definitionCount: 0` (no `def`/`abbrev`/`instance`)
- `axiomCount: 1` (only `axiom e_transcendental`; no structure-encoded assumptions)
- `sorries: 0`

---
Automated fix by lean-mechanic agent.