### PR TITLE
fix(meta): tractatus-ontology lineCount 1230 → 1235

### DIFF
--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 1,
-    "lineCount": 1230,
+    "lineCount": 1235,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms.",
     "theoremCount": 41,
     "definitionCount": 31
@@ -267,7 +267,7 @@
     ],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 1230,
+    "lineCount": 1235,
     "axiomCount": 1,
     "theoremCount": 41,
     "definitionCount": 31,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` for `tractatus-ontology` from 1230 to 1235 (both `meta.lineCount` and `leanFile.lineCount`).

## Evidence

**Before**: `meta.json` declared `lineCount: 1230`.
**After**: `meta.json` declares `lineCount: 1235`, matching `wc -l proofs/Proofs/TractatusOntology.lean`.

The drift was introduced by PR #19126 (`fix(mechanic): TractatusOntology v4.26.0 22-error parent repair`), which applied a net +5-line edit (+20/-15) to the Lean file without updating meta.json.

Other count fields (`theoremCount=41`, `definitionCount=31`, `axiomCount=1`, `sorries=0`) are left untouched — same convention as prior single-field `fix(meta)` PRs (e.g. #19569, #19572). The companion `TractatusQuantifiers.lean` line count (288) was independently verified and is correct.

Scope: meta.json only, 2 line-number replacements.

---
Automated fix by lean-mechanic agent.