### PR TITLE
fix(meta): prime-number-theorem-oq-01 lineCount 281 → 282

### DIFF
--- a/src/data/proofs/prime-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/prime-number-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 5,
-    "lineCount": 281,
+    "lineCount": 282,
     "dateAdded": "2026-05-04",
     "assumptions": "5 axioms: vonKoch_rh_error (von Koch 1901), pnt_classical_error (Vinogradov-Korobov), littlewood_omega (Littlewood 1914), pi_exceeds_li_infinitely (sign change), backlund_zero_counting (Backlund 1918). The Riemann Hypothesis itself is the main open conjecture.",
     "mathlib_version": "4.26.0",
@@ -179,7 +179,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "PrimeNumberTheoremOQ01",
-    "lineCount": 281,
+    "lineCount": 282,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `prime-number-theorem-oq-01/meta.json` from 281 → 282 to match the actual `proofs/Proofs/PrimeNumberTheoremOQ01.lean` (`wc -l` = 282).

## Evidence

**Before**: meta.json declared `lineCount: 281` (both top-level and `leanFile.lineCount`)
**After**: meta.json declares `lineCount: 282` (matches `wc -l proofs/Proofs/PrimeNumberTheoremOQ01.lean`)

Other counts already match the source:
- `axiomCount: 5` ✓ (5 `axiom` declarations)
- `theoremCount: 12` ✓
- `definitionCount: 6` ✓
- `sorries: 0` ✓

---
Automated fix by lean-mechanic agent.