### PR TITLE
fix(meta): batch sync lineCount drift in 6 entries

### DIFF
--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/101",
     "erdosUrl": "https://erdosproblems.com/101",
     "axiomCount": 0,
-    "lineCount": 757,
+    "lineCount": 758,
     "badge": "wip",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
@@ -246,7 +246,7 @@
       "in"
     ],
     "namespace": null,
-    "lineCount": 757,
+    "lineCount": 758,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/931",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 539,
+    "lineCount": 540,
     "assumptions": "2 sorry-stated assumptions (theorem-with-sorry, formerly axioms): stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks_hard (refined: only the hard case with k₁<n₁, tight gap, all factors ≤n₁ — general statement proved as theorem). Computational evidence: hard case hypotheses are vacuously inconsistent for n₁ ≤ 30 with k₁=k₂=3 (hard_case_vacuous_k3_n30). See Lean source. stronger_implies_main and exists_prime_between_blocks_hard converted from axiom to theorem-with-sorry (axiom integrity: do not assert unverified math).",
     "mathlib_version": "4.26.0",
     "theoremCount": 46,
@@ -153,7 +153,7 @@
       "Finset"
     ],
     "namespace": "Erdos931",
-    "lineCount": 539,
+    "lineCount": 540,
     "axiomCount": 0,
     "theoremCount": 46,
     "definitionCount": 5,

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -35,7 +35,7 @@
       "fourCollinearThrough_sub_family: four-collinear-through is a subset of fourCollinearFamily"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 757,
+    "lineCount": 758,
     "theoremCount": 23,
     "definitionCount": 6,
     "mathlib_version": "4.26.0"
@@ -103,7 +103,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": null,
-    "lineCount": 757,
+    "lineCount": 758,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 6,

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-06",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 231,
+    "lineCount": 232,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
@@ -239,7 +239,7 @@
       "MeasureTheory.Measure"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ02",
-    "lineCount": 231,
+    "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 155,
+    "lineCount": 156,
     "assumptions": "No axioms or sorries. All results proved from law of cosines.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -127,7 +127,7 @@
       "Mathlib"
     ],
     "namespace": "StewartsTheorem",
-    "lineCount": 155,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 3,

--- a/src/data/proofs/sperner-simplicial-instance-oq-05/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance-oq-05/meta.json
@@ -13,7 +13,7 @@
     "sorries": 0,
     "theoremCount": 3,
     "definitionCount": 1,
-    "lineCount": 186,
+    "lineCount": 185,
     "imports": [
       "Proofs.SpernerSimplicialInstance"
     ],
@@ -90,7 +90,7 @@
       "Proofs.SpernerSimplicialInstance"
     ],
     "namespace": "SpernerSimplicialInstanceOQ05",
-    "lineCount": 186,
+    "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in 6 gallery entries to match `wc -l` of the referenced Lean source file. Source files have drifted by ±1 line since the meta.json was last refreshed; values are counts-only metadata, no code or proof content changed.

## Entries

| slug | declared | actual | delta |
|---|---|---|---|
| erdos-101 | 757 | 758 | +1 |
| erdos-931 | 539 | 540 | +1 |
| erdos101-problem | 757 | 758 | +1 |
| greens-theorem-oq-01-oq-01-oq-02 | 231 | 232 | +1 |
| law-of-cosines-oq-04 | 155 | 156 | +1 |
| sperner-simplicial-instance-oq-05 | 186 | 185 | -1 |

## Evidence

- Detection: `wc -l proofs/<path>` vs `leanFile.lineCount` in `src/data/proofs/<slug>/meta.json`
- Both `meta.lineCount` (top-level) and `leanFile.lineCount` updated for each entry, per recent merged convention (see #19459, #19465)
- 12 changed lines total across 6 files

---
Automated fix by lean-mechanic agent.