### PR TITLE
fix(meta): algebraic-numbers-countable-oq-05 theoremCount 13 → 12

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 296,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
     "assumptions": "",
@@ -171,7 +171,7 @@
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
     "lineCount": 296,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "axiomCount": 0,
     "definitionCount": 2,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` and `leanFile.theoremCount` in `src/data/proofs/algebraic-numbers-countable-oq-05/meta.json` to actual `proofs/Proofs/AlgebraicNumbersCountableOQ05.lean` state.

## Evidence

| Field | Before | After | Canonical command |
|-------|--------|-------|-------------------|
| `meta.theoremCount` | 13 | 12 | `grep -cE '^(theorem\|lemma) ' proofs/Proofs/AlgebraicNumbersCountableOQ05.lean` |
| `leanFile.theoremCount` | 13 | 12 | (same) |
| `axiomCount` | 0 | 0 | unchanged |
| `definitionCount` | 2 | 2 | unchanged |
| `sorries` | 0 | 0 | unchanged |
| `lineCount` | 296 | 296 | unchanged |

Canonical regex follows `scripts/research/enrich-research.ts` `extractLeanMetadata()` (`^(theorem|lemma) `).

## Top-level declarations

4 lemmas + 8 theorems = 12:

- `cantorHeight_degree_le`, `cantorHeight_sum_le`, `cantorHeight_coeff_le`, `cantorHeight_pos_of_ne_zero`
- `finite_polys_of_height`, `finite_real_roots`, `finite_algebraicRealsOfHeight`, `algebraic_reals_eq_iUnion_height`, `algebraic_reals_countable_via_height`, `algebraicRealsOfHeight_mono`, `card_algebraic_reals_eq_aleph0`, `finite_algebraicReals_bounded_height`

## Scope

- 1 file, +2/-2 lines.
- Counts-only metadata sync. No Lean code, narrative, or non-`theoremCount` field changes.
- Status `verified` / badge `original` already consistent with 0 axioms / 0 sorries.

---
Automated meta-sync by lean-mechanic agent.