### PR TITLE
fix(meta): batch sync leanFile.lineCount drift in 36 entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -273,7 +273,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1937,
+    "lineCount": 1938,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 14,

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -189,7 +189,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -240,7 +240,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 310,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -278,7 +278,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 778,
+    "lineCount": 779,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 23,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -227,7 +227,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -145,7 +145,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -118,7 +118,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -115,7 +115,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -221,7 +221,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -161,7 +161,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 535,
+    "lineCount": 536,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -138,7 +138,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 274,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -143,7 +143,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -157,7 +157,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -177,7 +177,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 859,
+    "lineCount": 860,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 21,

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -173,7 +173,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 523,
+    "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 13,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -172,7 +172,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -146,7 +146,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -149,7 +149,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -71,7 +71,7 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 284,
+    "lineCount": 285,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -179,7 +179,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 693,
+    "lineCount": 694,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -135,7 +135,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -147,7 +147,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 603,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -184,7 +184,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 385,
+    "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -186,7 +186,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 223,
+    "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -174,7 +174,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 911,
+    "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -188,7 +188,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 39,
     "definitionCount": 20,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -196,7 +196,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 188,
+    "lineCount": 189,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -172,7 +172,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 498,
+    "lineCount": 499,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -144,7 +144,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 84,
+    "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -180,7 +180,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -266,7 +266,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -183,7 +183,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -204,7 +204,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21110,
+    "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount` in 36 gallery entries to match `wc -l` of the referenced Lean source file. Source files have drifted by +1 line each since meta.json was last refreshed (likely a trailing-newline normalization); values are counts-only metadata, no code or proof content changed.

## Entries (all +1 line)

| slug | declared | actual | delta |
|---|---|---|---|
| `area-of-circle-oq-01-oq-03` | 1937 | 1938 | +1 |
| `cauchy-schwarz-integral` | 117 | 118 | +1 |
| `erdos-1028` | 310 | 311 | +1 |
| `erdos-1034` | 778 | 779 | +1 |
| `erdos-108` | 141 | 142 | +1 |
| `erdos-1161` | 323 | 324 | +1 |
| `erdos-123` | 317 | 318 | +1 |
| `erdos-139` | 260 | 261 | +1 |
| `erdos-143` | 119 | 120 | +1 |
| `erdos-157` | 535 | 536 | +1 |
| `erdos-167` | 274 | 275 | +1 |
| `erdos-168` | 180 | 181 | +1 |
| `erdos-172` | 144 | 145 | +1 |
| `erdos-202` | 859 | 860 | +1 |
| `erdos-29` | 523 | 524 | +1 |
| `erdos-299` | 386 | 387 | +1 |
| `erdos-303` | 258 | 259 | +1 |
| `erdos-355` | 391 | 392 | +1 |
| `erdos-370` | 284 | 285 | +1 |
| `erdos-402` | 693 | 694 | +1 |
| `erdos-45` | 141 | 142 | +1 |
| `erdos-517` | 175 | 176 | +1 |
| `erdos-551` | 603 | 604 | +1 |
| `erdos-60` | 385 | 386 | +1 |
| `erdos-604` | 223 | 224 | +1 |
| `erdos-624` | 218 | 219 | +1 |
| `erdos-629` | 911 | 912 | +1 |
| `erdos-643` | 1402 | 1403 | +1 |
| `erdos-69` | 188 | 189 | +1 |
| `erdos-795` | 498 | 499 | +1 |
| `erdos-866` | 84 | 85 | +1 |
| `erdos-941` | 323 | 324 | +1 |
| `navier-stokes` | 21110 | 21111 | +1 |
| `navier-stokes-existence` | 21110 | 21111 | +1 |
| `navier-stokes-oq-01` | 21110 | 21111 | +1 |
| `navier-stokes-oq-02` | 21110 | 21111 | +1 |

(Four `navier-stokes*` entries share the same `Proofs/NavierStokes.lean` source.)

## Evidence

- Detection: `wc -l proofs/<path>` vs `meta.leanFile.lineCount` in `src/data/proofs/<slug>/meta.json`
- Only `leanFile.lineCount` updated (these entries have no top-level `meta.lineCount` field)
- Filtered against open mechanic PRs — none of these 36 slugs overlap with in-flight #19606 (different 6-slug set) or any other open `fix/mechanic-*` PR title/branch/body
- Minimal regex-based edit: 36 files × 1 line each (preserves all other formatting & Unicode)

## Scope

One-line counts-only metadata sync. No Lean code, no proof content, no `axiomCount`/`theoremCount`/`status`/`badge` changes.

---
Automated fix by lean-mechanic agent.