### PR TITLE
fix(meta): batch sync leanFile.lineCount drift in 7 entries

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 5,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 292,
     "assumptions": "No axioms. 5 sorries (aggregate): 4 in main file (support characterization at line 164, marginal distribution at line 185, mean at line 200, covariance at line 213) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. ENNReal normalization (multinomialPMF_sum_eq_one), the Fintype instance, the PMF construction, and the concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
@@ -164,7 +164,7 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 269,
+    "lineCount": 292,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 6,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 437,
+    "lineCount": 438,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement.",
     "theoremCount": 13,
     "definitionCount": 9
@@ -244,7 +244,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 302,
+    "lineCount": 303,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",
@@ -199,7 +199,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 302,
+    "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 367,
+    "lineCount": 368,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",
@@ -227,7 +227,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 225,
+    "lineCount": 226,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
@@ -117,7 +117,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "1 axiom: knuth_unique_four_oblique — any closed knight's tour with exactly 4 oblique turns is D4-equivalent to the minimal oblique tour. Accepted based on Knuth's exhaustive computational verification of all ~13.3 trillion closed knight's tours (TAOCP Vol 4 Fascicle 8a, December 2025).",
     "proofRepoPath": "Proofs/KnightsTourOblique.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 2469,
+    "lineCount": 2463,
     "sorries": 0,
     "theoremCount": 111,
     "definitionCount": 48
@@ -142,7 +142,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 2469,
+    "lineCount": 2463,
     "structureCount": 2,
     "axiomCount": 1,
     "theoremCount": 111,

--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1218,
+    "lineCount": 1233,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1218,
+    "lineCount": 1233,
     "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Batch sync stale `lineCount` values across 7 gallery meta.json entries to match actual `.lean` source file line counts. Updates both `meta.lineCount` and `leanFile.lineCount` fields.

## Evidence

| Slug | Was | Now | Δ |
|---|---|---|---|
| binomial-theorem-oq-02-oq-01-oq-01 | 269 | 292 | +23 |
| erdos-109 | 437 | 438 | +1 |
| erdos-171 | 302 | 303 | +1 |
| erdos-37 | 367 | 368 | +1 |
| erdos-485 | 225 | 226 | +1 |
| knights-tour-oblique | 2469 | 2463 | -6 |
| schauder-fixed-point-oq-03-oq-01 | 1218 | 1233 | +15 |

Disjoint from in-flight meta-drift PRs (#19608 covers 36 entries, #19606 covers 6 entries, plus several singletons). No overlap.

Diff: **14 insertions, 14 deletions** (2 lineCount fields per file x 7 files).

---
Automated fix by lean-mechanic agent.