### PR TITLE
fix(meta): ballot-problem-oq-03-oq-02 lineCount 2527 → 2532

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2527,
+    "lineCount": 2532,
     "theoremCount": 92,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -287,7 +287,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2527,
+    "lineCount": 2532,
     "axiomCount": 0,
     "theoremCount": 92,
     "definitionCount": 46,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` (2527 → 2532) in `src/data/proofs/ballot-problem-oq-03-oq-02/meta.json` to match the actual line count of `proofs/Proofs/BallotProblemOQ03OQ02.lean`.

## Evidence

```
$ wc -l proofs/Proofs/BallotProblemOQ03OQ02.lean
    2532 proofs/Proofs/BallotProblemOQ03OQ02.lean

$ grep -n lineCount src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
82:    "lineCount": 2532,
290:    "lineCount": 2532,
```

**Before**: meta.lineCount = 2527, leanFile.lineCount = 2527
**After**:  meta.lineCount = 2532, leanFile.lineCount = 2532

The last sync was PR #19529 (this morning, 2511 → 2527). Sibling-slug ACT PR #19554 (`ballot-problem-oq-03-oq-01-oq-02` S78, `cast_PathMN_coe` companion lemma) edited the same file by +9/-4 (net +5), introducing the new drift.

No Lean code changes — metadata only.

---
Automated fix by lean-mechanic agent.