### PR TITLE
fix(meta): lagrange-theorem-oq-01-oq-01-oq-01 ApproachB lineCount + definitions drift

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
@@ -138,9 +138,9 @@
     "additionalFiles": [
       {
         "path": "Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean",
-        "lineCount": 152,
+        "lineCount": 320,
         "theorems": 6,
-        "definitions": 0,
+        "definitions": 2,
         "axioms": 0,
         "sorries": 0,
         "description": "Approach B preliminaries (S3a, S3b): cyclic structure of (ZMod q)ˣ at every prime q (`isCyclic_units_zmod` instance + `card_units_zmod` theorem) and the order-p element extraction `exists_unit_of_order_p` (g₀^((q-1)/p) construction). Three sanity examples at (p,q) = (2,3), (3,7), (5,11). Deferred to S3c: lift to φ : ZMod p →* AddAut (ZMod q)."


### PR DESCRIPTION
## Fix

`src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json` `leanFile.additionalFiles[0]` had two drifted counts for `Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean`.

## Evidence

```
$ wc -l proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean
     320 proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean
```

Declarations (file is post-S3a/S3b expansion):
- 6 theorems: `card_units_zmod`, `exists_unit_of_order_p`, `unitToAddAut_apply`, `unitToAddAut_injective`, `exists_addAut_of_order_p`, `exists_mulAut_mult_of_order_p`
- 2 definitions: `unitToAddAut` (L149), `actionHom` (L300, noncomputable)
- 0 axioms / 0 sorries

**Before**:
- `lineCount: 152`
- `definitions: 0`

**After**:
- `lineCount: 320` (Δ=+168)
- `definitions: 2`

theoremCount (6), axioms (0), sorries (0) unchanged. No conflict with open research PR #19452 (touches research/*, not src/data/proofs/*).

---
Automated fix by lean-mechanic agent.