### PR TITLE
fix(meta): batch sync leanFile.lineCount drift in 41 entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -155,7 +155,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04",
-    "lineCount": 316,
+    "lineCount": 306,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -273,7 +273,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 14,

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -189,7 +189,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 118,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -240,7 +240,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 311,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -278,7 +278,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 779,
+    "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 23,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -227,7 +227,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 142,
+    "lineCount": 141,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -244,7 +244,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 438,
+    "lineCount": 437,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -145,7 +145,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -118,7 +118,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 318,
+    "lineCount": 317,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -115,7 +115,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 261,
+    "lineCount": 260,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -221,7 +221,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 120,
+    "lineCount": 119,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -161,7 +161,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 536,
+    "lineCount": 535,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -138,7 +138,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 275,
+    "lineCount": 274,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -143,7 +143,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 181,
+    "lineCount": 180,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -199,7 +199,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 303,
+    "lineCount": 302,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -157,7 +157,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 145,
+    "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -177,7 +177,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 860,
+    "lineCount": 859,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 21,

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -173,7 +173,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 524,
+    "lineCount": 523,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 13,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -172,7 +172,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 387,
+    "lineCount": 386,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -146,7 +146,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 259,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -149,7 +149,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 392,
+    "lineCount": 391,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -227,7 +227,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 368,
+    "lineCount": 367,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -71,7 +71,7 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 285,
+    "lineCount": 284,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -179,7 +179,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 694,
+    "lineCount": 693,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -135,7 +135,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 142,
+    "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -117,7 +117,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -147,7 +147,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 176,
+    "lineCount": 175,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 604,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -184,7 +184,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 386,
+    "lineCount": 385,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -186,7 +186,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 224,
+    "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -174,7 +174,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 219,
+    "lineCount": 218,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 912,
+    "lineCount": 911,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -188,7 +188,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1403,
+    "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 39,
     "definitionCount": 20,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -196,7 +196,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 189,
+    "lineCount": 188,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -172,7 +172,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 499,
+    "lineCount": 498,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -144,7 +144,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 85,
+    "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -180,7 +180,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -266,7 +266,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -183,7 +183,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -204,7 +204,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,


### PR DESCRIPTION
## Fix

Sync `meta.json.leanFile.lineCount` to the actual `wc -l` of each Lean
source file across 41 gallery entries.

## Evidence

Scanned all 2435 gallery `meta.json` files; 42 had `leanFile.lineCount`
mismatches against their Lean source. Skipped 1 already covered by open
PR #19616 (ballot-problem-oq-03-oq-02).

Most are -1 drift (Lean file lost a trailing line); a few larger:

- amgm-inequality-oq-04: 316 → 306 (-10)
- area-of-circle-oq-01-oq-03: 1938 → 1937
- cauchy-schwarz-integral: 118 → 117
- 33 erdos-N problem entries: -1 each
- 4 navier-stokes-* entries (same NavierStokes.lean): 21111 → 21110

**Before**: `leanFile.lineCount` overstated source size by 1-10 lines.
**After**: `leanFile.lineCount` matches `wc -l` of the referenced file.

No Lean source changes. No build impact. Pure metadata.

---
Automated fix by lean-mechanic agent.