### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-02): S6 STATE-SYNC — canonical research-JSON catchup with S5 OBSERVE (doc-only)

### DIFF
--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md
@@ -3,7 +3,7 @@
 **Title**: Can the character uniqueness argument be generalized to prove cubic or quartic reciprocity?
 
 **Status**: axiomatized (build state; 0 sorries, 2 axioms)
-**Phase**: S5 OBSERVE — Mathlib bearer audit (post-S4)
+**Phase**: S6 STATE-SYNC — canonical research-JSON catchup with S5 OBSERVE (doc-only)
 
 ## Problem Summary
 
@@ -113,3 +113,65 @@ For primes p ≡ 1 (mod 3), the group (ZMod p)ˣ is cyclic of order p-1 with 3 |
 Zero — no tactic, import, or signature changes. All edits are within comment/doc text
 or JSON prose fields. Sorries unchanged (0). Axiom count unchanged (2). Theorem count
 unchanged (27).
+
+## Session 2026-05-16 (Session 6) — Canonical research-JSON catchup with S5 OBSERVE (STATE-SYNC)
+
+**Mode**: STATE-SYNC (doc-only / research-JSON catchup; no Lean changes, no meta.json changes, no S5 memo modification)
+**Outcome**: progress — reconciled canonical state-of-record with S5 audit findings
+
+### Why
+
+`claim-problem.sh claim-random` returned this slug at 2026-05-16T~14:00Z. Inspection
+revealed `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json`
+(the canonical state-of-record consumed by gallery/research-index tooling) was 3 days
++ 1 audit-session behind the S5 OBSERVE work that landed on origin/main on 2026-05-13.
+The drift was not a Lean or meta.json issue — both of those were correctly updated by
+S5. Only the research-JSON had stale assertions that directly contradicted the S5 audit.
+
+### Drift inventory (research-JSON vs S5 audit)
+
+| Field | Before S6 (stale) | After S6 (S5-aligned) |
+|---|---|---|
+| `currentState.since` | `2026-05-04T00:42:55.000Z` (S1 ship) | `2026-05-16T14:30:00.000Z` (S6) |
+| `currentState.iteration` | `1` | `6` |
+| `currentState.focus` | "Eisenstein integers Mathlib gap" | "Axiomatized-stable… NOT Mathlib-blocked" |
+| `currentState.nextAction` | "Closed pending Mathlib upstream of ℤ[ω]" (FALSE per S5) | "Axiomatized-stable. Future S6/S7 ACT optional… ~250 LOC port using already-shipped Mathlib bearers" |
+| `currentState.attemptCounts.total` | `1` | `6` |
+| `knowledge.progressSummary` | "562 lines… documented Mathlib gaps requiring Eisenstein integers" | "578 lines… NOT Mathlib-blocked… engineering refactor" |
+| `knowledge.insights[4]` | "Eisenstein integers ℤ[ω] not in Mathlib 4.26" (FALSE) | "Eisenstein integers ARE in Mathlib v4.26.0 as 𝓞 K…" |
+| `knowledge.mathlibGaps[0]` | "Eisenstein integers ℤ[ω] structure and prime theory not in Mathlib 4.26" (FALSE) | `[RESOLVED in S5 OBSERVE]` + bearer catalog |
+| `knowledge.mathlibGaps[1]` | "Cubic residue symbol (ρ/π)₃ definition requires ℤ[ω] units" (FALSE) | `[RESOLVED in S5 OBSERVE]` + JacobiSum API note |
+| `knowledge.nextSteps` | `[]` | 6-step refactor plan from S5 memo §"Suggested next ACT" + optional quartic parallel |
+| `leanFiles[3].lineCount` (slug Lean file) | `562` | `578` (+16 from S5 docstring corrections) |
+| `lastUpdate` | `2026-05-07T19:30:00.000Z` | `2026-05-16T14:30:00.000Z` |
+
+Build state on origin/main is unchanged from S5: 0 sorries / 2 axioms / 27 theorems /
+6 defs / 578 lines / no `import` changes / no tactic changes / `lake-manifest.json`
+SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) unchanged at S6 (T+3d).
+
+### Files modified
+
+- `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json` — 13 field edits per drift table above. JSON-validated (`python3 -m json.tool`).
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md` — Phase header refresh + this Session-6 entry (head/tail-only, prior body unchanged).
+- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s6-state-sync-canonical-json-catchup.md` — NEW session memo (full drift trace + bearer-stability verification at SHA-stable T+3d).
+
+### Files NOT modified (intentional scope discipline)
+
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` — no Lean change (S5 already corrected docstrings; S6 is canonical-JSON only).
+- `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` — already at correct lineCount (578) + correct `assumptions`/`description`/`keyInsights[4]`/`openQuestions[0]` text per S5.
+- `proofs/lake-manifest.json` — Mathlib pin unchanged (no bearer re-spot-check needed at T+3d SHA-stable; S5 audit findings still hold).
+- S5 memo (`s5-observe-eisenstein-bearer.md`) — left intact as historical audit artifact.
+- Mathlib bearer re-verification — declined; SHA `2df2f01…` unchanged since S5, so all bearers cited in S5 are bit-identical at S6 — cf. MEMORY `feedback_researcher_postship_pivot_to_own_just_merged_prep_with_zero_json_edits_at_T_plus_minutes_ship_tight_json_catchup_only_no_bundled_respotcheck` for the "tighter cycle, no busywork re-spot-check at SHA-stable" pattern.
+
+### Build Risk
+
+Zero — 0 Lean files modified, 0 imports changed, 0 tactic changes, 0 meta.json field
+edits. Sorries unchanged (0). Axiom count unchanged (2). Theorem count unchanged (27).
+LineCount unchanged on disk (578); S6 only fixes the leanFiles[3].lineCount drift in
+the research-JSON's cached metadata.
+
+### Phase head transition
+
+S5 OBSERVE (Mathlib bearer audit, doc-only) → S6 STATE-SYNC (canonical research-JSON catchup, doc-only) → "axiomatized-stable; future S6/S7 refactor optional, not actively scheduled".
+
+The slug is now in a stable terminal state with a fully-documented optional-refactor pathway. Future claim-random landings on this slug should either (a) ship the ~250-LOC engineering refactor per the S5 memo §"Suggested next ACT (S6) — refactor plan", or (b) release immediately if the refactor is out of scope for the session.

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s6-state-sync-canonical-json-catchup.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s6-state-sync-canonical-json-catchup.md
@@ -1,0 +1,194 @@
+# S6 STATE-SYNC — canonical research-JSON catchup with S5 OBSERVE (researcher-9, 2026-05-16)
+
+**Slug**: `elementary-quadratic-reciprocity-oq-01-oq-02`
+**Phase**: S6 STATE-SYNC (doc-only / research-JSON catchup; no Lean, no meta.json, no S5 memo change)
+**Mathlib SHA (pinned)**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) — unchanged since S5
+**File audited**: `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json` (canonical state-of-record)
+**Predecessor session**: S5 OBSERVE (researcher-5, 2026-05-13) — `s5-observe-eisenstein-bearer.md`
+
+## 1. Why S6 is needed
+
+`claim-problem.sh claim-random` returned this slug at 2026-05-16T~14:00Z (claim id `researcher-47886`,
+TTL 90min, knowledge score RICH 21, tier MODERATE+, 651 candidates available, 119 in tier — depth-first).
+
+Inspection of the four file-of-record surfaces revealed:
+
+| Surface | State | Notes |
+|---|---|---|
+| `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` | ✅ S5-aligned | 578 LOC / 27 thms / 0 sorries / 2 axioms / 6 defs / 4 `^def` + 2 `^noncomputable def` (defCount convention) + 1 `^structure EisensteinPrime` (definitionCount: 7) |
+| `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` | ✅ S5-aligned | `lineCount: 578`, `axiomCount: 2`, `theoremCount: 27`, `defCount: 6`, `assumptions`/`description`/`keyInsights[4]`/`openQuestions[0]` all carry the corrected "engineering refactor" framing |
+| `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md` | ✅ S5-aligned | Head says `Phase: S5 OBSERVE — Mathlib bearer audit (post-S4)`; full Session-5 entry present (lines 59–115) with audit findings and refactor plan |
+| `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md` | ✅ Present | Full audit memo with bearer catalog (Cyclotomic.Three / Cyclotomic.PID / JacobiSum.Basic), implication analysis, 6-step refactor plan, audit trail |
+| `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json` | ❌ **3-days-+-1-audit-session behind S5** | See drift inventory §2 |
+
+The canonical research-JSON is consumed by gallery/research-index tooling and by
+future `claim-random` candidate-pool scoring. Stale assertions in it (e.g.
+`nextAction: "Closed pending Mathlib upstream of ℤ[ω]"`) actively mislead future
+researchers who don't drill into knowledge.md / s5-observe-eisenstein-bearer.md.
+
+## 2. Drift inventory (research-JSON before S6 vs S5 audit truth)
+
+Thirteen field-level drifts identified and corrected:
+
+### 2.1 `currentState` drifts (6 fields)
+
+| Field | Stale value | S6 corrected value | Why |
+|---|---|---|---|
+| `currentState.since` | `2026-05-04T00:42:55.000Z` (S1 ship) | `2026-05-16T14:30:00.000Z` (S6) | S5 + S6 are both post-S1 |
+| `currentState.iteration` | `1` | `6` | knowledge.md heads at S5; S6 is +1 |
+| `currentState.focus` | "All work merged: 27 theorems / 0 sorries / 2 axioms (**Eisenstein integers Mathlib gap**)" | "Axiomatized-stable on origin/main… S5 OBSERVE confirmed the 2 axioms are **NOT Mathlib-blocked**…" | Direct contradiction with S5 finding |
+| `currentState.nextAction` | "**Closed pending Mathlib upstream of Eisenstein integers ℤ[ω]**." (FALSE per S5) | "Axiomatized-stable. Future S6/S7 ACT optional… per s5-observe-eisenstein-bearer.md §'Suggested next ACT (S6) — refactor plan' (6-step Ireland-Rosen Ch.9 port, ~250 LOC)…" | Was actively misleading future claimants — S5 audit proved the bearers exist |
+| `currentState.attemptCounts.total` | `1` | `6` | Six sessions logged in knowledge.md (S1–S5) plus S6 |
+| `currentState.attemptCounts.currentApproach` | `1` | `1` | S5 OBSERVE was not a new approach — same character-uniqueness/cyclic-Euler approach throughout |
+
+### 2.2 `knowledge` drifts (5 fields)
+
+| Field | Stale value | S6 corrected value | Why |
+|---|---|---|---|
+| `knowledge.progressSummary` | "COMPLETE: … **562 lines**, 27 theorems, 6 defs, 0 sorries, 2 axioms. … The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are **documented Mathlib gaps requiring Eisenstein integers ℤ[ω]**, not solvable here. Merged across PRs #15291, #15322, #15334, #15356/#15357, #15360, #15414, #16616." | "AXIOMATIZED-STABLE on origin/main: … **578 lines** as of S5 OBSERVE docstring corrections … S5 OBSERVE audit (2026-05-13) confirmed they are **NOT Mathlib-blocked** — discharging them is an engineering refactor onto Mathlib v4.26.0's already-shipped `IsCyclotomicExtension {3} ℚ K` / `𝓞 K` / `jacobiSum` API, ~250 LOC. Merged across PRs … and the S5 OBSERVE doc-only audit … S6 STATE-SYNC (this PR) reconciles the canonical research-JSON with the S5 audit findings already present in knowledge.md and meta.json." | (a) 562→578 LOC drift; (b) "documented Mathlib gaps" framing contradicts S5 |
+| `knowledge.insights[4]` | "Eisenstein integers ℤ[ω] not in Mathlib 4.26 — cubic reciprocity must remain axiomatized until upstream" | "Eisenstein integers ℤ[ω] ARE in Mathlib v4.26.0 as 𝓞 K for IsCyclotomicExtension {3} ℚ K (Mathlib.NumberTheory.NumberField.Cyclotomic.Three + .PID.three_pid); cubic reciprocity is therefore NOT blocked on a Mathlib feature — the 2 axioms persist only because the file's local `structure EisensteinPrime` is decoupled from Mathlib's richer 𝓞 K formalization. S5 OBSERVE (2026-05-13) corrected the earlier 'not in Mathlib' framing; see s5-observe-eisenstein-bearer.md" | Direct contradiction with S5 §"Bearers found in pinned Mathlib (v4.26.0, SHA 2df2f01)" — Mathlib literally ships the bearers cited as "blocking" |
+| `knowledge.mathlibGaps[0]` | "Eisenstein integers ℤ[ω] structure and prime theory not in Mathlib 4.26 (blocks cubic_reciprocity proof)" | `[RESOLVED in S5 OBSERVE 2026-05-13]` + bearer catalog (Cyclotomic.Three η/λ/lambda_sq/eta_sq/unit-classification/Kummer + PID.three_pid) | Was actively false at pinned SHA |
+| `knowledge.mathlibGaps[1]` | "Cubic residue symbol (ρ/π)₃ definition requires ℤ[ω] units (blocks cubicResidueSymbol axiom removal)" | `[RESOLVED in S5 OBSERVE 2026-05-13]` + JacobiSum API note (cubic residue symbol can be defined on 𝓞 K using IsPrimitiveRoot.toInteger_cube_eq_one; jacobiSum_mem_algebraAdjoin_of_pow_eq_one gives J(χ_π, χ_π) ∈ ℤ[ω]) | μ₃ = {1, η, η²} is already in `𝓞 K`; no external bearer needed |
+| `knowledge.nextSteps` | `[]` | 6-step refactor plan (verbatim from s5-observe-eisenstein-bearer.md §"Suggested next ACT (S6) — refactor plan") + optional quartic parallel (IsCyclotomicExtension {4} ℚ K) | S5 produced a fully-scoped plan that was never surfaced into the canonical state-of-record |
+
+### 2.3 `leanFiles[]` drift (1 field)
+
+| Field | Stale value | S6 corrected value | Why |
+|---|---|---|---|
+| `leanFiles[3].lineCount` (this slug's `ElementaryQuadraticReciprocityOQ01OQ02.lean` entry) | `562` | `578` (+16) | S5 OBSERVE text-only docstring corrections at lines 455–456 and 489 grew the file by 16 lines; never propagated back to research-JSON's cached leanFiles metadata |
+
+### 2.4 Top-level drift (1 field)
+
+| Field | Stale value | S6 corrected value | Why |
+|---|---|---|---|
+| `lastUpdate` | `2026-05-07T19:30:00.000Z` (post-#16616) | `2026-05-16T14:30:00.000Z` | Standard sync timestamp |
+
+Total: **13 field-level edits** to `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json`.
+
+## 3. What S6 deliberately does NOT do
+
+### 3.1 No Lean change
+
+`proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` is unmodified at 578 LOC.
+S5 already corrected the docstring comments at lines 455–456 and 489. S6 is pure
+research-JSON catchup. Build risk: zero.
+
+### 3.2 No meta.json change
+
+`src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` was correctly
+updated by S5 to carry the "engineering refactor" framing in `assumptions`,
+`description`, `keyInsights[4]`, and `openQuestions[0]`. Spot-check at S6 confirmed
+`lineCount: 578`, `axiomCount: 2`, `theoremCount: 27`, `defCount: 6`, `definitionCount: 7`,
+and `assumptions` references both `s5-observe-eisenstein-bearer.md` and the
+already-shipped Mathlib bearers — all correct. S6 leaves meta.json untouched.
+
+### 3.3 No Mathlib bearer re-spot-check
+
+Per MEMORY entry `feedback_researcher_postship_pivot_to_own_just_merged_prep_with_zero_json_edits_at_T_plus_minutes_ship_tight_json_catchup_only_no_bundled_respotcheck`,
+when the predecessor session's bearer audit is at a SHA-stable pin and the cycle is
+small (T+3d here), re-spot-checking bearers is busywork that doesn't surface new
+information. `lake-manifest.json` rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+matches the SHA cited in `s5-observe-eisenstein-bearer.md` line 5 verbatim. All
+bearers listed in S5 §"Bearers found in pinned Mathlib" are bit-identical at S6.
+Re-curl/re-grep would change zero findings and add zero value.
+
+### 3.4 No S5 memo modification
+
+`s5-observe-eisenstein-bearer.md` is an immutable audit artifact. S6 references it
+from the new memo (this file) and from the JSON's `nextAction` + `nextSteps` text.
+
+### 3.5 No phase value change
+
+The JSON's top-level `phase: COMPLETE` and `currentState.phase: COMPLETE` are kept
+unchanged. The slug *is* in a complete (axiomatized-stable) state on origin/main
+with no active work in flight. The refactor pathway documented in `nextSteps` is
+*optional and not actively scheduled* — flipping phase to ACT/REFACTOR would
+overclaim that work is in progress when nobody is currently assigned to do it.
+Changing the prose of `focus` + `nextAction` is sufficient to communicate the
+"axiomatized-stable, refactor-pathway-available" reality.
+
+### 3.6 No related-slug touching
+
+`relatedProofs` lists 12 sibling slugs (oq-01, oq-01-oq-01, oq-02, oq-03, etc.). S6
+does not touch any sibling state — each sibling's own canonical-JSON drift (if any)
+is its own STATE-SYNC's scope.
+
+### 3.7 No claim escalation
+
+Slug remains `status: active` on the tier-B / RICH / depth-first candidate pool. After
+S6 ships, the slug's `nextAction` clearly says "Future S6/S7 ACT optional, not
+actively scheduled", so future `claim-random` landings can either ship the refactor
+(if researcher has 4–8h budget) or release immediately.
+
+## 4. Bearer-stability verification at S6 (SHA-stable, summary only)
+
+`grep -B1 -A4 'name.*mathlib"' proofs/lake-manifest.json` returned:
+
+```
+"rev": "2df2f0150c275ad53cb3c90f7c98ec15a56a1a67",
+"name": "mathlib",
+"manifestFile": "lake-manifest.json",
+"inputRev": "v4.26.0",
+"inherited": false,
+```
+
+Identical to the SHA cited in `s5-observe-eisenstein-bearer.md` line 5. Three days of
+host time elapsed (2026-05-13 → 2026-05-16); zero pin-bump in that window. All
+bearers cataloged in S5 §3 (Cyclotomic.Three, Cyclotomic.Basic, Cyclotomic.PID,
+JacobiSum.Basic, MulChar.Lemmas, GaussSum, RootsOfUnity.Lemmas) are bit-identical at
+the pin. No re-spot-check curl performed — that would be busywork.
+
+## 5. Why this slug went undetected for 9 days
+
+S5 OBSERVE (researcher-5, 2026-05-13) made four file edits per its own §"Files
+touched by this OBSERVE":
+
+1. NEW `s5-observe-eisenstein-bearer.md` ✅ shipped
+2. UPDATED `knowledge.md` (Session-5 entry + Phase header sync) ✅ shipped
+3. UPDATED `src/data/proofs/.../meta.json` (text prose only) ✅ shipped
+4. UPDATED `proofs/Proofs/.../Lean` (docstring comment text only) ✅ shipped
+
+The fifth surface — `src/data/research/problems/.../canonical.json` — was NOT in S5's
+file list. This is consistent with the typical OBSERVE-phase scope (audit + write
+findings + correct gallery-facing metadata). The canonical research-JSON catchup is
+the natural follow-on STATE-SYNC step.
+
+This is *not* a criticism of S5 — STATE-SYNCs typically follow OBSERVE / PREP / ACT
+cycles by design (cf. MEMORY entries `feedback_researcher_state_md_three_sessions_behind_sessions_dir_with_mechanic_cascade_already_discharging_blockers_ship_combined_state_sync_with_leanfiles_drift_fix` and
+`feedback_researcher_long_completed_slug_with_statemd_phase_drift_vs_canonical_json_and_resolved_nextaction_item_still_listed_ship_3file_statesync_bootstrap_sessions_dir` for the canonical pattern). Nine days is just longer than the typical 1-day STATE-SYNC follow-on cadence — likely because:
+
+- This slug doesn't have a `sessions/` dir (only individual session memo files in the slug root), reducing visibility to autonomous-pool drift-detection tooling
+- knowledge.md and meta.json were correctly updated, masking the JSON drift from human spot-checks
+- The slug was labeled `phase: COMPLETE` so it was deprioritized in any "in-flight" sweep
+
+S6 closes the gap and adds the slug to the corpus of fully-reconciled
+axiomatized-stable terminal slugs.
+
+## 6. Acceptance criteria
+
+- [x] Canonical research-JSON `currentState.{since,iteration,focus,nextAction,attemptCounts}` reflects S5 audit findings
+- [x] `knowledge.{progressSummary,insights[4],mathlibGaps,nextSteps}` carry "NOT Mathlib-blocked" framing + 6-step refactor plan
+- [x] `leanFiles[3].lineCount` 562 → 578 (S5 docstring drift)
+- [x] `lastUpdate` refreshed to S6
+- [x] JSON `python3 -m json.tool` valid
+- [x] No Lean file modified (0 build risk)
+- [x] No meta.json modified (S5 territory)
+- [x] No Mathlib pin change
+- [x] No S5 memo modification
+- [x] No sibling-slug touch
+- [x] Knowledge.md head Phase tag refreshed (S5 → S6) + Session-6 entry appended with drift table
+- [x] New session memo (this file) with full drift inventory + bearer-stability declaration + scope-discipline rationale
+
+## 7. Host context (informational, does not affect this PR)
+
+- Docker: daemon hung per `docker info` (Client-only output, no Server section past 10s) — does not affect S6 since no Lean build is required
+- Disk: 6.5 Gi avail (AMBER threshold ≤8 Gi) — does not affect S6 (3 doc-only files ~30 KB)
+- Mathlib pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0), unchanged since S5
+
+## 8. References
+
+- `s5-observe-eisenstein-bearer.md` — predecessor OBSERVE audit (researcher-5, 2026-05-13)
+- `knowledge.md` Session-5 entry (lines 59–115) — S5 audit summary in slug knowledge log
+- `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` — gallery metadata (S5-aligned)
+- MEMORY index entries — `feedback_researcher_long_completed_slug_with_statemd_phase_drift_vs_canonical_json_and_resolved_nextaction_item_still_listed_ship_3file_statesync_bootstrap_sessions_dir` (closest pattern match — 3-file doc-only catchup for long-completed slug with state.md+JSON drift; here state.md absent, scope adapted to 3 files = JSON + knowledge.md head/tail + NEW session memo)
+- Ireland & Rosen, *A Classical Introduction to Modern Number Theory*, 2nd ed., Springer 1990, Chapter 9 (cubic reciprocity proof via Jacobi sums) — Theorem 1 is the load-bearing identity for the optional S6/S7 refactor

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
@@ -17,19 +17,19 @@
   },
   "currentState": {
     "phase": "COMPLETE",
-    "since": "2026-05-04T00:42:55.000Z",
-    "iteration": 1,
-    "focus": "All work merged: 27 theorems / 0 sorries / 2 axioms (Eisenstein integers Mathlib gap)",
+    "since": "2026-05-16T14:30:00.000Z",
+    "iteration": 6,
+    "focus": "Axiomatized-stable on origin/main: 27 theorems / 0 sorries / 2 axioms (cubicResidueSymbol, cubic_reciprocity) at 578 LOC. S5 OBSERVE (2026-05-13) confirmed the 2 axioms are NOT Mathlib-blocked — Mathlib v4.26.0 already ships Eisenstein integers (Mathlib.NumberTheory.NumberField.Cyclotomic.Three for ℤ[ω] as 𝓞 K), the cyclotomic-3 PID instance (NumberField.Cyclotomic.PID.three_pid), and the Jacobi-sum API (NumberTheory.JacobiSum.Basic). Discharging the axioms is an engineering refactor (rebase local `structure EisensteinPrime` onto `𝓞 K`, port Ireland-Rosen Ch.9 Thm 1 using existing jacobiSum/gaussSum API, ~250 LOC), not a wait-on-upstream task.",
     "blockers": [],
-    "nextAction": "Closed pending Mathlib upstream of Eisenstein integers ℤ[ω].",
+    "nextAction": "Axiomatized-stable. Future S6/S7 ACT (optional, not actively scheduled): engineering refactor per research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md §'Suggested next ACT (S6) — refactor plan' (6-step Ireland-Rosen Ch.9 port, ~250 LOC, no new Mathlib bearer needed). Pin SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (v4.26.0) confirmed bearer-stable at S6 (T+3d since S5 audit).",
     "attemptCounts": {
-      "total": 1,
+      "total": 6,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Cubic + quartic characters fully developed in Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean (562 lines, 27 theorems, 6 defs, 0 sorries, 2 axioms). Both Euler criteria proved (easy + hard via discrete log); both kernel cardinalities |ker χ| = (p-1)/k proved via IsCyclic.card_pow_eq_one_le sandwich. The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are documented Mathlib gaps requiring Eisenstein integers ℤ[ω], not solvable here. Merged across PRs #15291 (construction), #15322 (cubicEuler_hard), #15334 (True-stub removal), #15356/#15357 (cubicChar_kernel_card), #15360 (API drift), #15414 (Session 2: quarticEuler_hard + quarticChar_kernel_card), #16616 (leanFiles drift sync).",
+    "progressSummary": "AXIOMATIZED-STABLE on origin/main: Cubic + quartic characters fully developed in Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean (578 lines as of S5 OBSERVE docstring corrections, 27 theorems, 6 defs, 0 sorries, 2 axioms). Both Euler criteria proved (easy + hard via discrete log); both kernel cardinalities |ker χ| = (p-1)/k proved via IsCyclic.card_pow_eq_one_le sandwich. The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are predicated on the file's local `structure EisensteinPrime` (line 469); S5 OBSERVE audit (2026-05-13) confirmed they are NOT Mathlib-blocked — discharging them is an engineering refactor onto Mathlib v4.26.0's already-shipped `IsCyclotomicExtension {3} ℚ K` / `𝓞 K` / `jacobiSum` API, ~250 LOC. Merged across PRs #15291 (construction), #15322 (cubicEuler_hard), #15334 (True-stub removal), #15356/#15357 (cubicChar_kernel_card), #15360 (API drift), #15414 (Session 2: quarticEuler_hard + quarticChar_kernel_card), #16616 (leanFiles drift sync), and the S5 OBSERVE doc-only audit (knowledge.md + meta.json + Lean docstring text-only). S6 STATE-SYNC (this PR) reconciles the canonical research-JSON with the S5 audit findings already present in knowledge.md and meta.json.",
     "builtItems": [
       "cubicChar : (ZMod p)ˣ →* (ZMod p)ˣ in ElementaryQuadraticReciprocityOQ01OQ02.lean:84",
       "cubicChar_pow_three_eq_one : χ₃(a)³ = 1 via Fermat in :106",
@@ -50,14 +50,17 @@
       "Easy Euler criterion: x³=a → a^((p-1)/3)=1 proved via Units.mk0 lift + pow_mul + units_pow_card_sub_one_eq_one",
       "Hard Euler criterion (cubic + quartic): discrete log via IsCyclic.exists_generator + Subgroup.mem_zpowers_iff + orderOf_dvd_iff_zpow_eq_one.mpr; cubExp_mul / quartExp_mul rewrites convert (p-1) | k·cubExp into 3 | k (resp. 4 | k)",
       "Kernel cardinality (cubic + quartic): IsCyclic.card_pow_eq_one_le gives upper bound k; lower bound via Finset.le_card_of_inj_on_range with k ↦ (g^3)^k (resp. g^4) using pow_injOn_Iio_orderOf",
-      "Eisenstein integers ℤ[ω] not in Mathlib 4.26 — cubic reciprocity must remain axiomatized until upstream",
+      "Eisenstein integers ℤ[ω] ARE in Mathlib v4.26.0 as 𝓞 K for IsCyclotomicExtension {3} ℚ K (Mathlib.NumberTheory.NumberField.Cyclotomic.Three + .PID.three_pid); cubic reciprocity is therefore NOT blocked on a Mathlib feature — the 2 axioms persist only because the file's local `structure EisensteinPrime` is decoupled from Mathlib's richer 𝓞 K formalization. S5 OBSERVE (2026-05-13) corrected the earlier 'not in Mathlib' framing; see s5-observe-eisenstein-bearer.md",
       "Quartic character χ₄ = powMonoidHom((p-1)/4) has identical proof structure to χ₃; both kernel-card proofs share the IsCyclic sandwich argument"
     ],
     "mathlibGaps": [
-      "Eisenstein integers ℤ[ω] structure and prime theory not in Mathlib 4.26 (blocks cubic_reciprocity proof)",
-      "Cubic residue symbol (ρ/π)₃ definition requires ℤ[ω] units (blocks cubicResidueSymbol axiom removal)"
+      "[RESOLVED in S5 OBSERVE 2026-05-13] Earlier claim 'Eisenstein integers not in Mathlib 4.26' was incorrect — Mathlib v4.26.0 ships ℤ[ω] as 𝓞 K via Mathlib.NumberTheory.NumberField.Cyclotomic.Three (η = unit primitive cube root, λ = η - 1 prime, lambda_sq, eta_sq, unit classification, Kummer's lemma for λ^2) plus Mathlib.NumberTheory.NumberField.Cyclotomic.PID.three_pid (𝓞 K is PID). The local `structure EisensteinPrime` in the file is a placeholder that decouples from this richer Mathlib formalization; refactoring onto 𝓞 K is engineering work, not a Mathlib feature gap.",
+      "[RESOLVED in S5 OBSERVE 2026-05-13] Earlier claim 'Cubic residue symbol requires ℤ[ω] units not in Mathlib' was incorrect — the cubic residue symbol can be defined directly on 𝓞 K using IsPrimitiveRoot.toInteger_cube_eq_one (η^3 = 1, so μ₃ ⊆ 𝓞 K is {1, η, η^2}). Mathlib.NumberTheory.JacobiSum.Basic also ships jacobiSum_mem_algebraAdjoin_of_pow_eq_one to conclude J(χ_π, χ_π) ∈ ℤ[ω]. No upstream Mathlib feature is needed."
     ],
-    "nextSteps": []
+    "nextSteps": [
+      "[Optional, not scheduled] S6/S7 refactor ACT — discharge the 2 axioms via Ireland-Rosen Ch.9 Thm 1 port. Per s5-observe-eisenstein-bearer.md §'Suggested next ACT (S6) — refactor plan': (1) delete local `structure EisensteinPrime`, replace with context `[hKζ : IsCyclotomicExtension {3} ℚ K] (hζ : IsPrimitiveRoot ζ 3)` and use `𝓞 K`; (2) define cubicResidueSymbol π a := IsPrimitiveRoot.cubicCharLift (a^((Ideal.absNorm (Ideal.span {π}) - 1) / 3) mod π) (image in μ₃ = {1, η, η^2}); (3) define χ_π : MulChar (𝓞 K ⧸ Ideal.span {π}) (𝓞 K) as the lift; (4) apply jacobiSum_mem_algebraAdjoin_of_pow_eq_one for J(χ_π, χ_π) ∈ ℤ[ω]; (5) compute |J|^2 = N(π) via jacobiSum_mul_jacobiSum_inv + gaussSum_pow_eq_prod_jacobiSum; (6) derive cubic reciprocity by comparing J(χ_π, χ_π)^((N(ρ)-1)/3) mod ρ against χ_ρ(N(π)) following Ireland-Rosen Theorem 1 of Chapter 9 verbatim. Estimated ~250 LOC. No new Mathlib bearer needed.",
+      "[Optional, not scheduled] After cubic axioms discharged, parallel refactor for quartic reciprocity using IsCyclotomicExtension {4} ℚ K (Gaussian integers ℤ[i]) — Mathlib has the cyclotomic-4 instance though PID/PID-companion lemmas may need separate audit."
+    ]
   },
   "tags": [
     "number-theory",
@@ -89,7 +92,7 @@
   },
   "started": "2026-05-03T11:41:44.693Z",
   "completed": "2026-05-04T00:42:55.000Z",
-  "lastUpdate": "2026-05-07T19:30:00.000Z",
+  "lastUpdate": "2026-05-16T14:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -129,7 +132,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ01OQ02.lean",
-      "lineCount": 562,
+      "lineCount": 578,
       "theoremCount": 27,
       "axiomCount": 2,
       "defCount": 6,


### PR DESCRIPTION
## Summary

Doc-only **S6 STATE-SYNC** for `elementary-quadratic-reciprocity-oq-01-oq-02`. Reconciles the canonical research-JSON (`src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json`) with the **S5 OBSERVE audit** (researcher-5, 2026-05-13) that already corrected `knowledge.md`, gallery `meta.json`, and the Lean file docstrings but never propagated back to the canonical state-of-record JSON.

The drift was *materially misleading*: the stale JSON claimed `nextAction: "Closed pending Mathlib upstream of Eisenstein integers ℤ[ω]"`, but S5 confirmed Mathlib v4.26.0 already ships the bearers (Cyclotomic.Three for ℤ[ω] as 𝓞 K, PID.three_pid, JacobiSum.Basic API). The 2 axioms persist only because the file's local `structure EisensteinPrime` is decoupled from Mathlib's richer formalization — discharging them is a ~250-LOC engineering refactor, not a wait-on-upstream task.

## 13 field edits to research-JSON

**currentState (6 fields)** — `since` 2026-05-04→2026-05-16, `iteration` 1→6, `focus` rewrite, `nextAction` rewrite, `attemptCounts.total` 1→6.

**knowledge (5 fields)** — `progressSummary` 562→578 LOC + drop "Mathlib gap" framing, `insights[4]` rewrite, `mathlibGaps[0,1]` both marked `[RESOLVED in S5 OBSERVE]` with bearer catalog, `nextSteps` `[]` → 6-step Ireland-Rosen Ch.9 refactor plan + optional quartic parallel.

**leanFiles[3] (1 field)** — `lineCount` 562→578 (S5 docstring corrections at L455-456, L489 of the Lean file).

**Top-level (1 field)** — `lastUpdate` 2026-05-07→2026-05-16.

## Files in this PR (3)

- `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json` — 13 field edits per above. JSON validated.
- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/knowledge.md` — Phase header refresh (S5 → S6) + Session-6 entry appended (~62 LOC body + drift table).
- `research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s6-state-sync-canonical-json-catchup.md` — NEW session memo (194 LOC) with full drift inventory, scope-discipline rationale, bearer-stability declaration at SHA-stable T+3d.

## Files NOT modified (intentional scope discipline)

- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` — no Lean change (0 build risk). S5 already corrected docstrings.
- `src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` — already at correct `lineCount: 578`, `axiomCount: 2`, `theoremCount: 27`, plus S5-corrected `assumptions`/`description`/`keyInsights[4]`/`openQuestions[0]` text.
- `proofs/lake-manifest.json` — Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) unchanged since S5 (T+3d).
- `s5-observe-eisenstein-bearer.md` — immutable audit artifact.
- Mathlib bearer re-spot-check — declined per MEMORY `feedback_researcher_postship_pivot_to_own_just_merged_prep_with_zero_json_edits_at_T_plus_minutes_ship_tight_json_catchup_only_no_bundled_respotcheck` (SHA-stable → busywork; bearers bit-identical to S5 catalog).
- Sibling slugs (12 in `relatedProofs`) — each slug's own STATE-SYNC scope.

## Build verification

**Not required** — 0 Lean files modified, 0 imports changed, 0 tactic changes, 0 meta.json field edits. Build state on origin/main unchanged: 0 sorries / 2 axioms / 27 theorems / 6 defs / 578 lines.

## Test plan

- [x] `python3 -m json.tool src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json` — valid
- [x] `git status -s` — only the 3 expected files modified
- [x] `wc -l` on slug Lean file = 578 (matches updated `leanFiles[3].lineCount`)
- [x] `grep -c "^axiom "` on slug Lean file = 2 (matches unchanged `axiomCount`)
- [x] `grep -B1 -A4 'name.*mathlib"' proofs/lake-manifest.json` rev = `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (matches S5 audit SHA)
- [x] No Lean changes (`git diff --name-only main..HEAD` excludes `proofs/`)
- [x] No meta.json changes (`git diff --name-only main..HEAD` excludes `src/data/proofs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)