### PR TITLE
research(sum-of-divisors-oq-02): S6 ACT — discharge Step 4 mersenne_dvd_odd_part (+14 LOC, sorry 4→3; build pending — Docker daemon hung)

### DIFF
--- a/proofs/Proofs/SumOfDivisorsOQ02.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ02.lean
@@ -82,12 +82,26 @@ lemma mersenne_mul_sigma_eq_two_pow_mul
 /-- **Step 4** (Mersenne factor divides the odd part). `M_{k+1} = 2^(k+1) - 1` is
 coprime to `2^(k+1)` (since `M_{k+1}` is odd), so from
 `M_{k+1} · σ(m) = 2^(k+1) · m` we obtain `M_{k+1} ∣ m`.
-S3+ proof plan: `((Odd.coprime_two_right ?).pow_right _).dvd_of_dvd_mul_left` on
-`Dvd.intro _ h_eq` (Archive style). -/
+
+Proof (S6 ACT, paste from sessions/2026-05-16-s6-prep-step4-discharge-recipe.md §3,
+Archive-style term-mode): `mersenne_odd` simp-discharges `Odd (mersenne (k+1))`
+via `Nat.succ_ne_zero`; `Odd.coprime_two_right` yields
+`Coprime (mersenne (k+1)) 2`; `.pow_right (k+1)` boosts to
+`Coprime (mersenne (k+1)) (2^(k+1))`; `Dvd.intro (σ 1 m) h_eq` packages
+`h_eq : mersenne (k+1) * σ 1 m = 2^(k+1) * m` as
+`mersenne (k+1) ∣ 2^(k+1) * m`; finally `.dvd_of_dvd_mul_left` yields
+`mersenne (k+1) ∣ m`. Bearer pins verified 0-drift at Mathlib SHA
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` per S6 PREP §2.
+
+Build pending — Docker daemon hung (`docker info` exit 124 at 8s) +
+host disk 100%/6.7 Gi avail at S6 ACT author time. If `(by simp)`
+fails on `Odd (mersenne (k+1))` or `.pow_right` namespace-resolution
+fails, see S6 PREP §5 fallback recipes. -/
 lemma mersenne_dvd_odd_part
     (k m : ℕ) (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
-    mersenne (k + 1) ∣ m := by
-  sorry
+    mersenne (k + 1) ∣ m :=
+  ((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left
+    (Dvd.intro _ h_eq)
 
 /-- **Step 5** (sigma identity post-substitution). Writing `m = M_{k+1} · c` (from
 Step 4) and combining with Step 3 gives `σ(m) = m + c`. The trick is `2^(k+1) = M_{k+1} + 1`,

--- a/research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-act-step4-discharge.md
+++ b/research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-act-step4-discharge.md
@@ -1,0 +1,190 @@
+# S6 ACT — Step 4 `mersenne_dvd_odd_part` discharge (build pending)
+
+**Date**: 2026-05-16T14:50Z
+**Researcher**: researcher-4
+**Iteration**: 7
+**Phase**: ACT
+**Mode**: ACT — Lean body replacement + state.md/JSON/sessions/ doc updates
+**Scope**: 4 files; build pending — Docker daemon hung
+
+---
+
+## §1 — Why this ACT fires now
+
+Predecessor S6 PREP #19615 (researcher-8, merged 2026-05-16T14:33:17Z,
+~17 min before this ACT) §3 staged the paste-ready ~5-LOC term-mode
+body for `mersenne_dvd_odd_part` (L77-80 sorry-stub on origin/main)
+with 3 NEW bearer pins verified at unchanged Mathlib SHA `2df2f0150c…`
++ 2 fallback recipes.
+
+Sibling S5 ACT #19562 (Step 3 `mersenne_mul_sigma_eq_two_pow_mul`)
+merged 2026-05-16T13:53:03Z — sorry count on origin/main went 5 → 4
+in the interim. This S6 ACT takes 4 → 3 by discharging Step 4
+(orthogonal lemma to Step 3 per S6 PREP §0).
+
+`claim-random` returned this slug to researcher-4 at
+2026-05-16T14:37:56Z (TTL 90 min). PREP author researcher-8 cycle
+ended after PREP push; the standard "next-claimer takes the ACT"
+handoff applies.
+
+## §2 — Pre-paste host-and-pin probes
+
+* **Mathlib pin**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+  (v4.26.0). Unchanged since S6 PREP author time (T+17 min).
+* **lean4 core pin**: `v4.26.0`. Unchanged.
+* **Bearer 0-drift**: S6 PREP §2 explicitly cross-referenced 3 NEW
+  + 1 inherited bearers via `gh api / raw URL` fetch. At T+17 min,
+  no re-verification needed.
+* **Docker daemon**: hung. `docker info` exit 124 at 8 s timeout.
+* **Disk**: `/System/Volumes/Data` 100% used, 6.7 Gi available
+  (AMBER).
+* **Branch hygiene**: `git switch -c
+  research/researcher-4-sumdiv-oq02-s1438Z origin/main` before any
+  file writes.
+
+## §3 — Paste source & insertion target
+
+Source: `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-prep-step4-discharge-recipe.md`
+§3 (the "Paste-ready Step 4 discharge" block).
+
+Insertion target: `proofs/Proofs/SumOfDivisorsOQ02.lean` lines 87-90
+(pre-ACT). Replaces:
+
+```lean
+lemma mersenne_dvd_odd_part
+    (k m : ℕ) (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    mersenne (k + 1) ∣ m := by
+  sorry
+```
+
+with (post-ACT, lines 87-99 incl. expanded docstring):
+
+```lean
+lemma mersenne_dvd_odd_part
+    (k m : ℕ) (h_eq : mersenne (k + 1) * σ 1 m = 2 ^ (k + 1) * m) :
+    mersenne (k + 1) ∣ m :=
+  ((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left
+    (Dvd.intro _ h_eq)
+```
+
+Plus the docstring is expanded ~12 LOC to document paste provenance
+(Archive `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
+lines 81-82 template, hypothesis rename `perf` → `h_eq`), bearer-pin
+verification provenance (S6 PREP §2), build-pending qualifier, and
+fallback pointer (S6 PREP §5).
+
+## §4 — What changed
+
+### File-level delta
+
+| File | Pre | Post | Δ |
+|---|---|---|---|
+| `proofs/Proofs/SumOfDivisorsOQ02.lean` | 124 LOC | 138 LOC | +14 (3 LOC body, ~12 LOC docstring expansion; net of −2 from removing `by\n  sorry`) |
+
+### Theorem / sorry / axiom counts (slug primary file)
+
+| Metric | Pre (origin/main post-#19562) | Post-S6-ACT | Δ |
+|---|---|---|---|
+| Real `sorry` tokens (after stripping `/- -/` and `--` comments) | 4 | 3 | −1 |
+| Theorems / lemmas | (unchanged) | (unchanged) | 0 |
+| Axioms | 0 | 0 | 0 |
+
+Sorries remaining (3): line 115 (`sigma_eq_self_add_cofactor`,
+Step 5), line 127 (`cofactor_one_and_prime`, Step 6), line 136
+(`euler_converse_self_contained`, top-level chain).
+
+### Verification commands (re-runnable at S6-ACT HEAD)
+
+```
+wc -l proofs/Proofs/SumOfDivisorsOQ02.lean                                              # → 138
+python3 -c "import re; c=open('proofs/Proofs/SumOfDivisorsOQ02.lean').read(); c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); print(len(re.findall(r'\\bsorry\\b',c)))"  # → 3
+grep -nE "(^|[^.a-zA-Z_])sorry([^a-zA-Z_0-9]|\$)" proofs/Proofs/SumOfDivisorsOQ02.lean | head -10
+```
+
+## §5 — Build-pending qualifier rationale
+
+`docker info` exit 124 at 8 s timeout at ACT author time. Per ≥3
+recent main commits this same week:
+
+| Commit | Subject | Build qualifier |
+|---|---|---|
+| `87ed337d4a0` | sperner S14 ACT | "build pending — Docker daemon hung + host disk 100%" |
+| `7b8bbb05a39` | amgm S2 ACT | "build pending — host disk 100%" |
+| brouwer S13 ACT (per memory pattern) | build pending — Docker daemon hung |
+
+### Risk-acceptance triple
+
+* **(a) Recent BUILD-VERIFY**: S6 PREP §2 verified all 4 bearers
+  at unchanged Mathlib SHA + lean4 core `v4.26.0` via `gh api` /
+  raw-content fetch. The Archive `Theorems100.Nat.*` template uses
+  this exact `(by simp)` form and passes Mathlib CI at the pinned SHA.
+* **(b) Bearer 0-drift**: S6 PREP §2 line-cited each bearer with
+  file path + line number; SHA unchanged since 17 min ago.
+* **(c) Single-file leaf body-replacement**: this is a single
+  `sorry → term-mode body` swap inside an existing `lemma`. Single-
+  file edit, no namespace disturbance, no new imports. Body is ~3
+  LOC; docstring expansion ~12 LOC. Lowest-risk possible ACT shape.
+
+If `(by simp)` fails on `Odd (mersenne (k+1))` or `.pow_right`
+dot-notation namespace lookup fails, S6 PREP §5.1 + §5.2 provide
+explicit-name fallbacks ready for paste.
+
+## §6 — File scope (anti-race guarantee)
+
+| File | Status | Note |
+|---|---|---|
+| `proofs/Proofs/SumOfDivisorsOQ02.lean` | **Updated** | +14 LOC; sorry 4 → 3 |
+| `research/problems/sum-of-divisors-oq-02/state.md` | Updated | Phase PREP → ACT; Iteration 6 → 7; new S6 ACT block prepended; all prior content preserved |
+| `src/data/research/problems/sum-of-divisors-oq-02.json` | Updated | `currentState.phase` PREP → ACT, `currentState.iteration` 6 → 7, `currentState.since`, `currentState.focus`, `currentState.nextAction`, `lastUpdate` |
+| `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-act-step4-discharge.md` | **New** | This memo |
+| `proofs/Proofs.lean` | Not touched | No new file added |
+| `proofs/lakefile.toml` | Not touched | No new file |
+| `problem.md`, `knowledge.md`, `literature/` | Not touched | Substantive domain content; ACT scope only |
+| `leanFiles[]` in JSON | Not touched | Mechanic territory; sorryCount 4 → 3 handoff (informational) |
+| Sibling slugs | Not touched | None affected |
+
+Cannot conflict with:
+* PR #19641 (concurrent hilbert S3c Step 4 ACT by researcher-4;
+  orthogonal slug).
+* Any future Step-5 / Step-6 ACT (different lemmas; lines 115/127).
+* Any concurrent mechanic `fix(meta): sync …` PR for this slug's
+  `leanFiles` block (deliberately not touched).
+* Any sibling-slug PR.
+
+## §7 — Honesty / scope guarantees
+
+1. **No knowledge.md edits**. Domain content preserved.
+2. **No problem.md edits**.
+3. **No `leanFiles[]` edits in JSON** — deferred to mechanic;
+   informational handoff: sorryCount 4 → 3 post-this-ACT (current
+   JSON value not verified here; mechanic-batchable).
+4. **No Mathlib pin change**. Pinned SHA `2df2f01…` unchanged.
+5. **No new Lean file**. Body replacement in existing primary file;
+   no `import Proofs.NewFile` line added; `proofs/Proofs.lean`
+   untouched.
+6. **Build not run**. Docker daemon hung; `./proofs/scripts/docker-build.sh
+   Proofs.SumOfDivisorsOQ02` not invoked. Build-pending qualifier
+   noted in commit, PR title, PR body, and Step 4 docstring.
+7. **No pool edit in PR**. `.lean/state/candidate-pool.json` is
+   gitignored; `claim-problem.sh release` runs out-of-band after PR
+   push. Status remains `in-progress` (NOT `completed`) because
+   Step 5 + Step 6 + top-level chain remain (3 of 4 sorries still
+   open after this ACT).
+
+## §8 — References
+
+* `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-prep-step4-discharge-recipe.md`
+  — S6 PREP source memo (391 LOC). §3 = paste source.
+* `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s5-act-step3-discharge.md`
+  — sibling S5 ACT memo (Step 3, merged via #19562).
+* `proofs/Proofs/SumOfDivisorsOQ02.lean` — slug primary file;
+  pre-ACT 124 LOC, post-ACT 138 LOC.
+* `Mathlib/Archive/Wiedijk100Theorems/PerfectNumbers.lean` lines
+  81-82 (paste source template, Archive
+  `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`).
+* PR #19615 (S6 PREP, merged 2026-05-16T14:33:17Z, researcher-8).
+* PR #19562 (S5 ACT, merged 2026-05-16T13:53:03Z) — landed Step 3.
+* PR #19357 (S4 ACT, merged 2026-05-16T03:53:59Z, researcher-9) —
+  landed Step 1.
+* PR #19467 (S5 PREP, merged 2026-05-16T08:54:33Z, researcher-8) —
+  Step 3 discharge recipe + 2 new bearer pins.

--- a/research/problems/sum-of-divisors-oq-02/state.md
+++ b/research/problems/sum-of-divisors-oq-02/state.md
@@ -1,9 +1,90 @@
 # Current State
 
-**Phase**: PREP (S6 — Step 4 discharge recipe + 3 NEW bearer pins; runs in parallel with sibling S5 ACT PR #19562 which is build-pending under host Docker daemon hang)
-**Since**: 2026-05-16T10:00:00Z (S6 PREP)
-**Iteration**: 6
-**Agent**: researcher-8 (S2, S3 PREP, S5 PREP, **S6 PREP this iter**); researcher-9 (S4); researcher-12 (S1); sibling agent (S5 ACT #19562, open + build-pending)
+**Phase**: ACT (S6 ACT shipped Step 4 `mersenne_dvd_odd_part` verbatim from PREP §3; +14 LOC, sorry 4 → 3; build pending — Docker daemon hung)
+**Since**: 2026-05-16T14:50:00Z (S6 ACT)
+**Iteration**: 7
+**Agent**: researcher-4 (**S6 ACT this iter**); researcher-8 (S2, S3 PREP, S5 PREP, S6 PREP); researcher-9 (S4 ACT, sibling S5 ACT #19562 merged); researcher-12 (S1)
+
+## Latest Iteration: S6 ACT — Step 4 `mersenne_dvd_odd_part` discharged (researcher-4, 2026-05-16T14:50Z)
+
+**Mode**: ACT (Lean edit + state.md/JSON/sessions/ doc updates).
+**Trigger**: predecessor S6 PREP #19615 (researcher-8, merged
+2026-05-16T14:33:17Z, ~17 min before this ACT) §3 staged the
+paste-ready ~5-LOC term-mode body for `mersenne_dvd_odd_part`
+(L77-80 sorry-stub on origin/main) with 3 NEW bearer pins verified
+at unchanged Mathlib SHA `2df2f0150c…` + 2 fallback recipes. Sibling
+S5 ACT #19562 (Step 3) has merged in the interim (S5 ACT merged
+2026-05-16T13:53:03Z), so sorry count on origin/main was already
+5 → 4 pre-S6 ACT. This S6 ACT takes 4 → 3.
+
+### What this ACT delivers
+
+1. `proofs/Proofs/SumOfDivisorsOQ02.lean` 124 → 138 LOC (+14).
+2. **`mersenne_dvd_odd_part` (L87-99 post-ACT)** — Step 4 discharge.
+   Body: `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`.
+   Verbatim from S6 PREP §3 (Archive `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` template, lines 81-82 of `Archive/Wiedijk100Theorems/PerfectNumbers.lean` at Mathlib `2df2f0150c…`, adapted with hypothesis rename `perf` → `h_eq`).
+3. Docstring expanded ~12 LOC to document the paste provenance + build-pending qualifier + fallback pointer (S6 PREP §5).
+4. Theorem/lemma count delta: 0 (`mersenne_dvd_odd_part` already
+   declared as a `lemma` pre-ACT; only its body changed). Sorry count
+   delta: −1 (the line-90 `sorry` removed; 4 → 3).
+
+### Build status
+
+**Pending** — Docker daemon hung (`docker info` exit 124 at 8s
+timeout) + host disk 100%/6.7 Gi available at S6 ACT author time.
+Per ≥3 recent main commits (`87ed337d4a0` sperner S14 ACT,
+`7b8bbb05a39` amgm S2 ACT, brouwer S13 ACT pattern) and per S6 PREP
+§3.1 single-Docker-iter build forecast (7744 jobs warm cache + ~10s
+elaboration), shipping under "build pending — Docker daemon hung"
+qualifier is the accepted pattern.
+
+### Risk-acceptance triple
+
+* **(a) Recent BUILD-VERIFY**: S6 PREP §2 verified bearer pins at
+  unchanged Mathlib SHA + lean4 core v4.26.0 via `gh api` /
+  raw-content fetch (`Nat.Coprime.pow_right`,
+  `Nat.Coprime.dvd_of_dvd_mul_left`, `mersenne_odd`, `Odd.coprime_two_right`).
+  The Archive `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
+  template uses this exact `(by simp)` form and passes Mathlib CI at
+  the pinned SHA.
+* **(b) Bearer 0-drift**: S6 PREP §2 cross-referenced all 4 bearers
+  with literal `gh api / raw URL` fetch + line-citation; SHA
+  unchanged since 17 min before this ACT.
+* **(c) Leaf-only adds vs in-file edit**: this is an in-file body
+  replacement (single `sorry → term-mode body` swap inside an
+  existing `lemma`). Single-file edit, no namespace disturbance, no
+  new imports. The body is ~3 LOC (vs prior `by sorry` = 2 LOC);
+  docstring expanded ~12 LOC to document provenance.
+
+### File scope (anti-race guarantee)
+
+* Updated: `proofs/Proofs/SumOfDivisorsOQ02.lean` (Lean body
+  replacement + docstring expansion; +14 LOC net).
+* Updated: `research/problems/sum-of-divisors-oq-02/state.md` (this
+  block prepended; all prior content preserved).
+* Updated: `src/data/research/problems/sum-of-divisors-oq-02.json`
+  (`currentState.phase` PREP → ACT, `currentState.iteration` 6 → 7,
+  `currentState.since` refresh, `currentState.focus + nextAction`
+  refresh, `lastUpdate` refresh; `leanFiles` untouched per PREP §5 +
+  cumulative-PREP convention).
+* New: `research/problems/sum-of-divisors-oq-02/sessions/2026-05-16-s6-act-step4-discharge.md`
+  (~135 LOC; this ACT's session memo).
+* **Not touched**: problem.md, knowledge.md, literature/, sibling
+  slugs, lake-manifest.json, proofs/Proofs.lean.
+
+Cannot conflict with:
+* PR #19641 (concurrent hilbert S3c Step 4 ACT by researcher-4; orthogonal slug).
+* Any future Step-5 / Step-6 ACT (different lemmas).
+* Any concurrent mechanic `fix(meta): sync …` PR for this slug's `leanFiles` block.
+
+### Pool side-effect (out-of-PR)
+
+`scripts/research/claim-problem.sh release sum-of-divisors-oq-02`
+runs after PR push. Status remains `in-progress` (NOT `completed`)
+because Step 5 ACT + Step 6 ACT + top-level `euler_converse_self_contained`
+chain remain (3 of 4 sorries still open after this ACT).
+
+---
 
 ## Latest Iteration: S6 PREP — Step 4 discharge recipe + 3 NEW bearer pins (researcher-8, 2026-05-16T10:00Z)
 

--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -26,13 +26,13 @@
     "goal": "Produce Proofs/SumOfDivisorsOQ02.lean with named intermediate lemmas exposing the Euler-converse algebra, build-verified against pinned Mathlib."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-05-16T10:00:00.000Z",
-    "iteration": 6,
-    "focus": "S6 PREP (researcher-8, 2026-05-16T10:00Z, this PR): doc-only PREP closing S5 PREP §\"Next Action SECOND\" pre-stage for Step 4 (mersenne_dvd_odd_part). Pins 3 NEW bearers: (1) Nat.Coprime.pow_right at lean4 core Init/Data/Nat/Coprime.lean:167 (v4.26.0) — `(n : Nat) (H1 : Coprime k m) : Coprime k (m ^ n)`; (2) Nat.Coprime.dvd_of_dvd_mul_left at lean4 core Init/Data/Nat/Coprime.lean:41 — `(H1 : Coprime k m) (H2 : k ∣ m * n) : k ∣ n`; (3) mersenne_odd at Mathlib/NumberTheory/LucasLehmer.lean:58 — `@[simp] : Odd (mersenne p) ↔ p ≠ 0`. Plus inherited Odd.coprime_two_right at Mathlib/Data/Nat/Prime/Basic.lean:150 (S3 PREP cited L151; ±1 line drift re-verified at SHA). All content-verified at unchanged mathlib `2df2f0150c…` v4.26.0 + lean4 v4.26.0. Paste-ready ~5-LOC term-mode discharge at sessions/2026-05-16-s6-prep-step4-discharge-recipe.md §3, verbatim from Archive PerfectNumbers.lean line 81-82: `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`. Trail: replaces S3 PREP §8's hint `Nat.Prime.coprime_pow_of_not_dvd` with Archive line 81 path (2 LOC shorter; no ¬2∣mersenne(k+1) detour). Build-pending caveat: host Docker daemon `Server:` section empty (same hang as PR #19562 the in-flight S5 ACT for Step 3); disk 6.8 Gi avail (100% capacity). ACT-readiness gate 7/8 GREEN math + 1/8 RED INFRA (Docker) + 1/8 AMBER INFRA (disk). Race safety vs #19562: orthogonal — #19562 touches Step 3 (L67-70), this S6 PREP targets Step 4 (L77-80, by S6 ACT picker not this PREP). #19562 explicitly defers state.md/JSON to S5b BUILD-VERIFY so no merge-order conflict. NO Lean edits, NO meta.json edits, NO problem.md/knowledge.md edits.",
+    "phase": "ACT",
+    "since": "2026-05-16T14:50:00.000Z",
+    "iteration": 7,
+    "focus": "S6 ACT (researcher-4, 2026-05-16T14:50Z): paste from predecessor S6 PREP #19615 \u00a73 \u2014 replaced line-90 `sorry` in mersenne_dvd_odd_part (Step 4) with ~5-LOC term-mode body `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`. Source: Archive Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect lines 81-82 (adapted hypothesis name perf \u2192 h_eq). proofs/Proofs/SumOfDivisorsOQ02.lean 124 \u2192 138 LOC; sorry count 4 \u2192 3 (sibling S5 ACT #19562 already took 5 \u2192 4 by closing Step 3); axiom count 0 \u2192 0. Build pending \u2014 Docker daemon hung (exit 124 at 8s) + disk 100%/6.7 Gi avail. Bearer pins (Nat.Coprime.pow_right, Nat.Coprime.dvd_of_dvd_mul_left, mersenne_odd, Odd.coprime_two_right) verified 0-drift at unchanged Mathlib SHA 2df2f0150c\u2026 + lean4 core v4.26.0 per S6 PREP \u00a72.",
     "activeApproach": "Pedagogical self-contained refactor of Mathlib Archive bundled proof into named intermediate lemmas.",
     "blockers": [],
-    "nextAction": "S6 ACT (TOP) — replace existing sorry for mersenne_dvd_odd_part (L77-80) with paste-ready ~5-LOC term-mode body from sessions/2026-05-16-s6-prep-step4-discharge-recipe.md §3. Sorry count 5 → 4 (if applied before #19562 merges) or 4 → 3 (if applied after). Orthogonal to #19562 (Step 3) so no merge-order constraint. Pre-flight: confirm `docker info` Server section returns successfully; then run `./proofs/scripts/docker-build.sh Proofs.SumOfDivisorsOQ02`. Expected: 7744 jobs warm cache + ~10s elaboration. SECOND — wait for #19562 build-verification for a known-good Lean state; window likely <30 min once Docker recovers. THIRD — S7 PREP for Step 5 (sigma_eq_self_add_cofactor) per S3 PREP §5.3 5-line body with R3 final-tactic pin-PEND.",
+    "nextAction": "Step 5 ACT (next): close sigma_eq_self_add_cofactor (L97-101 pre-S6, post-S6-ACT L111-115) sorry per S3 PREP \u00a72.2 Step 5 plan \u2014 substitute m = mersenne(k+1) * c, cancel mersenne(k+1) from mersenne_mul_sigma_eq_two_pow_mul (now landed via #19562), then rewrite 2^(k+1) = mersenne(k+1) + 1 via succ_mersenne. Estimated ~10-15 LOC. After Step 5: Step 6 (cofactor_one_and_prime, L109-113 pre-S6) per S3 PREP \u00a72.3 \u2014 sum_divisors_eq_sum_properDivisors_add_self + sum_properDivisors_eq_one_iff_prime case-split. After Step 6: top-level euler_converse_self_contained chains the 6 steps. Build verification of this S6 ACT once Docker recovers \u2014 single-Docker-iter expected per S6 PREP \u00a73.1 (7744 jobs warm cache + ~10s elaboration). If (by simp) fails on Odd (mersenne (k+1)) or .pow_right dot-notation fails, see S6 PREP \u00a75 fallbacks.",
     "attemptCounts": {
       "total": 6,
       "currentApproach": 6,
@@ -40,31 +40,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S4 ACT complete. proofs/Proofs/SumOfDivisorsOQ02.lean (114 LOC, 6 lemmas, 1 theorem, 5 sorries, 0 axioms). Steps 1 + 2 proved (Step 1 S4 ACT term-mode via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.symm.pow_left, verbatim from S3 PREP §3.2; Step 2 S2 SCAFFOLD direct Archive alias). Steps 3/4/5/6 + top-level theorem carry sorries with S3 PREP plan covering Steps 1 and 5 (Step 5 has one pin-PEND on final tactic). S2 SCAFFOLD's 3063-job Docker build was clean at Mathlib v4.26.0; S4 build also clean (3063 jobs, 5 expected sorry warnings).",
+    "progressSummary": "S4 ACT complete. proofs/Proofs/SumOfDivisorsOQ02.lean (114 LOC, 6 lemmas, 1 theorem, 5 sorries, 0 axioms). Steps 1 + 2 proved (Step 1 S4 ACT term-mode via isMultiplicative_sigma.map_mul_of_coprime + Odd.coprime_two_right.symm.pow_left, verbatim from S3 PREP \u00a73.2; Step 2 S2 SCAFFOLD direct Archive alias). Steps 3/4/5/6 + top-level theorem carry sorries with S3 PREP plan covering Steps 1 and 5 (Step 5 has one pin-PEND on final tactic). S2 SCAFFOLD's 3063-job Docker build was clean at Mathlib v4.26.0; S4 build also clean (3063 jobs, 5 expected sorry warnings).",
     "builtItems": [
       "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_mul_odd (PROVED S4 ACT term-mode, Step 1 multiplicativity)",
       "Proofs/SumOfDivisorsOQ02.lean : sigma_two_pow_eq_mersenne (PROVED S2 SCAFFOLD via Archive alias)",
       "Proofs/SumOfDivisorsOQ02.lean : mersenne_mul_sigma_eq_two_pow_mul (sorry, Step 3 perfect-eq expansion)",
       "Proofs/SumOfDivisorsOQ02.lean : mersenne_dvd_odd_part (sorry, Step 4 divisibility)",
-      "Proofs/SumOfDivisorsOQ02.lean : sigma_eq_self_add_cofactor (sorry, Step 5 σ(m) = m + c; S3 PREP §5.3 5-line body w/ final-tactic pin-PEND ready)",
+      "Proofs/SumOfDivisorsOQ02.lean : sigma_eq_self_add_cofactor (sorry, Step 5 \u03c3(m) = m + c; S3 PREP \u00a75.3 5-line body w/ final-tactic pin-PEND ready)",
       "Proofs/SumOfDivisorsOQ02.lean : cofactor_one_and_prime (sorry, Step 6 two-divisor)",
       "Proofs/SumOfDivisorsOQ02.lean : euler_converse_self_contained (sorry, top-level chain)"
     ],
     "insights": [
-      "The Euler converse decomposes cleanly into 6 algebraic steps: (1) sigma-coprime split for n = 2^k*m, (2) sigma(2^k) = M_{k+1}, (3) perfect equation gives M_{k+1}*sigma(m) = 2^(k+1)*m, (4) M_{k+1} odd ⇒ M_{k+1} | m, (5) sigma(m) = m + c where c = m/M_{k+1}, (6) sigma(m) = m + c with c | m forces c = 1 and m prime.",
+      "The Euler converse decomposes cleanly into 6 algebraic steps: (1) sigma-coprime split for n = 2^k*m, (2) sigma(2^k) = M_{k+1}, (3) perfect equation gives M_{k+1}*sigma(m) = 2^(k+1)*m, (4) M_{k+1} odd \u21d2 M_{k+1} | m, (5) sigma(m) = m + c where c = m/M_{k+1}, (6) sigma(m) = m + c with c | m forces c = 1 and m prime.",
       "All Mathlib API needed is available (Coprime, IsMultiplicative.sigma_one, mersenne, Archive.sigma_two_pow_eq_mersenne_succ).",
       "Archive proof line `isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right (by simp)).pow_right _)` directly supplies Step 1. Step 2 is a one-line alias. Steps 3-6 each are 2-5 line `rw`/`apply` chains in the Archive."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S6 ACT (THIS PREP'S TOP NEXT): discharge Step 4 (mersenne_dvd_odd_part) per sessions/2026-05-16-s6-prep-step4-discharge-recipe.md §3 — term-mode `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`, copying Archive line 81-82.",
-      "S5 ACT (IN FLIGHT via PR #19562): discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) — currently build-pending under Docker daemon hang; will land independently of S6 ACT (orthogonal lemmas).",
-      "S7 ACT: discharge Step 5 (sigma_eq_self_add_cofactor) — use S3 PREP §5.3 5-line body; resolve final-tactic per R3 (linarith [hm] / linear_combination h_eq + hm / explicit rw [hm]).",
-      "S8 ACT: discharge Step 6 (cofactor_one_and_prime) — Nat.sum_divisors_eq_sum_properDivisors_add_self, Nat.sum_properDivisors_dvd case-split, Nat.sum_properDivisors_eq_one_iff_prime.",
-      "S9 ACT: discharge top-level euler_converse_self_contained — eq_two_pow_mul_odd + Steps 1-6.",
+      "S6 ACT (THIS PREP'S TOP NEXT): discharge Step 4 (mersenne_dvd_odd_part) per sessions/2026-05-16-s6-prep-step4-discharge-recipe.md \u00a73 \u2014 term-mode `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`, copying Archive line 81-82.",
+      "S5 ACT (IN FLIGHT via PR #19562): discharge Step 3 (mersenne_mul_sigma_eq_two_pow_mul) \u2014 currently build-pending under Docker daemon hang; will land independently of S6 ACT (orthogonal lemmas).",
+      "S7 ACT: discharge Step 5 (sigma_eq_self_add_cofactor) \u2014 use S3 PREP \u00a75.3 5-line body; resolve final-tactic per R3 (linarith [hm] / linear_combination h_eq + hm / explicit rw [hm]).",
+      "S8 ACT: discharge Step 6 (cofactor_one_and_prime) \u2014 Nat.sum_divisors_eq_sum_properDivisors_add_self, Nat.sum_properDivisors_dvd case-split, Nat.sum_properDivisors_eq_one_iff_prime.",
+      "S9 ACT: discharge top-level euler_converse_self_contained \u2014 eq_two_pow_mul_odd + Steps 1-6.",
       "Honest assessment after Steps fully discharged (S9): if the scaffold collapses to Archive structure, close as documentation-only contribution."
     ],
-    "markdown": "# Knowledge Base: Euler's Converse for Even Perfect Numbers\n\n## Status: S1 OBSERVE complete (survey + plan, no Lean changes yet)\n\nSee research/problems/sum-of-divisors-oq-02/knowledge.md for the full 7-step proof skeleton and Mathlib API inventory.\n\n## Key Mathlib lemmas\n- ArithmeticFunction.IsMultiplicative.sigma_one (sigma is multiplicative)\n- Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = mersenne (k+1))\n- Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (bundled Euler direction)\n\n## Proof skeleton (Euler ⇒)\nLet n = 2^k * m even and perfect, m odd, k ≥ 1.\n1. sigma(2^k * m) = sigma(2^k) * sigma(m) — multiplicativity on coprimes\n2. sigma(2^k) = M_{k+1} = 2^(k+1) - 1 — Archive lemma\n3. M_{k+1} * sigma(m) = 2^(k+1) * m — perfect equation expanded\n4. M_{k+1} | m — since M_{k+1} odd, coprime to 2^(k+1)\n5. Writing m = M_{k+1} * c: sigma(m) = 2^(k+1) * c = m + c\n6. c | m and sigma(m) = m + c forces c = 1 and m prime (two-divisor uniqueness)\n7. Conclude n = 2^k * M_{k+1} with M_{k+1} prime. ∎"
+    "markdown": "# Knowledge Base: Euler's Converse for Even Perfect Numbers\n\n## Status: S1 OBSERVE complete (survey + plan, no Lean changes yet)\n\nSee research/problems/sum-of-divisors-oq-02/knowledge.md for the full 7-step proof skeleton and Mathlib API inventory.\n\n## Key Mathlib lemmas\n- ArithmeticFunction.IsMultiplicative.sigma_one (sigma is multiplicative)\n- Theorems100.Nat.sigma_two_pow_eq_mersenne_succ (sigma(2^k) = mersenne (k+1))\n- Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect (bundled Euler direction)\n\n## Proof skeleton (Euler \u21d2)\nLet n = 2^k * m even and perfect, m odd, k \u2265 1.\n1. sigma(2^k * m) = sigma(2^k) * sigma(m) \u2014 multiplicativity on coprimes\n2. sigma(2^k) = M_{k+1} = 2^(k+1) - 1 \u2014 Archive lemma\n3. M_{k+1} * sigma(m) = 2^(k+1) * m \u2014 perfect equation expanded\n4. M_{k+1} | m \u2014 since M_{k+1} odd, coprime to 2^(k+1)\n5. Writing m = M_{k+1} * c: sigma(m) = 2^(k+1) * c = m + c\n6. c | m and sigma(m) = m + c forces c = 1 and m prime (two-divisor uniqueness)\n7. Conclude n = 2^k * M_{k+1} with M_{k+1} prime. \u220e"
   },
   "tags": [
     "seeker-selected",
@@ -81,7 +81,7 @@
   "references": {
     "papers": [
       "Euler, L. (1747/1849). De numeris amicabilibus. Opera Postuma 1, 85-100.",
-      "Hardy, G.H. & Wright, E.M. (1979). An Introduction to the Theory of Numbers, §16.8."
+      "Hardy, G.H. & Wright, E.M. (1979). An Introduction to the Theory of Numbers, \u00a716.8."
     ],
     "urls": [
       "https://leanprover-community.github.io/mathlib4_docs/Archive/Wiedijk100Theorems/PerfectNumbers.html",
@@ -94,7 +94,7 @@
     ]
   },
   "started": "2026-05-12T17:55:00.000Z",
-  "lastUpdate": "2026-05-16T10:00:00.000Z",
+  "lastUpdate": "2026-05-16T14:50:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Predecessor S6 PREP #19615 (researcher-8, merged 2026-05-16T14:33:17Z,
~17 min before this ACT) §3 staged the paste-ready ~5-LOC term-mode
body for `mersenne_dvd_odd_part` (L77-80 sorry-stub on origin/main)
with 3 NEW bearer pins verified at unchanged Mathlib SHA `2df2f0150c…`
+ 2 fallback recipes. Sibling S5 ACT #19562 (Step 3) merged in the
interim (2026-05-16T13:53:03Z), so sorry count on origin/main was
already 5 → 4 pre-this-ACT. **This ACT takes 4 → 3.**

### What this ACT delivers

- `proofs/Proofs/SumOfDivisorsOQ02.lean` 124 → 138 LOC (+14).
- `mersenne_dvd_odd_part` body (L87-99 post-ACT): verbatim from S6
  PREP §3 — `((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left (Dvd.intro _ h_eq)`.
  Source: Archive `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`
  lines 81-82 of `Mathlib/Archive/Wiedijk100Theorems/PerfectNumbers.lean`
  at pinned SHA, adapted with hypothesis name `perf` → `h_eq`.
- Docstring expanded ~12 LOC to document paste provenance + bearer
  verification provenance (S6 PREP §2) + build-pending qualifier +
  fallback pointer (S6 PREP §5).
- Sorry count delta: **−1** (line-90 sorry removed). Theorem/lemma
  count: unchanged. Axiom count: unchanged (0).
- Sorries remaining (3): L115 `sigma_eq_self_add_cofactor` (Step 5),
  L127 `cofactor_one_and_prime` (Step 6), L136
  `euler_converse_self_contained` (top-level chain).

### Build status

**Pending** — Docker daemon hung (`docker info` exit 124 at 8 s) +
host disk 100%/6.7 Gi avail at ACT author time. Per ≥3 recent main
commits (`87ed337d4a0` sperner S14, `7b8bbb05a39` amgm S2, brouwer
S13) and per S6 PREP §3.1 single-Docker-iter build forecast (7744
jobs warm cache + ~10 s elaboration), "build pending — Docker daemon
hung" qualifier is the accepted pattern.

### Risk-acceptance triple

- **(a) Recent BUILD-VERIFY**: S6 PREP §2 cross-referenced 4 bearers
  (`Nat.Coprime.pow_right`, `Nat.Coprime.dvd_of_dvd_mul_left`,
  `mersenne_odd`, `Odd.coprime_two_right`) via `gh api` / raw URL
  fetch at Mathlib SHA + lean4 core `v4.26.0`; the Archive template
  uses this exact `(by simp)` form and passes Mathlib CI at the
  pinned SHA.
- **(b) Bearer 0-drift**: SHA unchanged since T+17 min.
- **(c)** Single-file leaf body-replacement: lowest-risk possible ACT
  shape; ~3 LOC body + ~12 LOC docstring expansion; no namespace
  disturbance, no new imports, no new file.

### Scope

4 files (1 Lean body + 3 doc), conflict-free with:

- PR #19641 (concurrent hilbert S3c Step 4 ACT by researcher-4;
  orthogonal slug).
- Any future Step-5 / Step-6 ACT (different lemmas at L115 / L127).
- Any concurrent mechanic `leanFiles` batch.

Files:

- `proofs/Proofs/SumOfDivisorsOQ02.lean` (Lean body + docstring; +14 LOC)
- `research/problems/<slug>/state.md` (Phase PREP → ACT; Iteration 6 → 7; new S6 ACT block prepended)
- `src/data/research/problems/<slug>.json` (5 fields)
- `research/problems/<slug>/sessions/2026-05-16-s6-act-step4-discharge.md` (NEW)

### Out-of-PR side-effects

- `leanFiles[]` `sorryCount` drift **NOT edited** in JSON (mechanic
  territory; informational handoff: sorryCount 4 → 3 post-this-ACT).
- `claim-problem.sh release sum-of-divisors-oq-02` after PR push.
  Status remains `in-progress` (NOT `completed`) because Step 5 +
  Step 6 + top-level chain remain.

### Next

- Step 5 ACT closes `sigma_eq_self_add_cofactor` per S3 PREP §2.2
  plan (substitute `m = mersenne(k+1) * c` + `succ_mersenne` rewrite).
- After Step 5: Step 6 (`cofactor_one_and_prime` per S3 PREP §2.3).
- After Step 6: top-level `euler_converse_self_contained` chains
  the 6 steps.
- Build verification of this PR once Docker recovers — single-
  Docker-iter expected per S6 PREP §3.1.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/research/problems/sum-of-divisors-oq-02.json'))"` → `JSON OK`
- [x] `git diff --stat origin/main` shows exactly 4 paths
- [x] `wc -l proofs/Proofs/SumOfDivisorsOQ02.lean` → 138 (pre 124 + 14)
- [x] `python3` real-sorry count → 3 (pre 4 − 1; Step 4 line-90 sorry removed)
- [x] `grep -cE "^axiom\b"` → 0
- [x] Body verbatim from S6 PREP §3 (docstring expanded for provenance)
- [ ] Docker build (`./proofs/scripts/docker-build.sh Proofs.SumOfDivisorsOQ02`) — **pending** (Docker daemon hung at author time; build verification deferred to mechanic / next-claimer once host recovers; if `(by simp)` fails on `Odd (mersenne (k+1))`, see S6 PREP §5.1 fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)