### PR TITLE
fix(meta): batch sync top-level meta.lineCount drift in 5 entries

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1381,
+    "lineCount": 1380,
     "assumptions": "1 sorry: the general statement `eisenstein_conjecture_cos_pi_p` (for all odd primes p ≥ 3) is open in this gallery. The proof requires cyclotomic ramification theory: Φ_{2p}(−1) = p (the cyclotomic anchor — now uniform via the S8 bridge identity `cyclotomic_two_mul_prime_mul_X_add_one_uniform` modulo the eval-at-(-1) corollary deferred to S9) and the local-field theorem 'uniformizer of totally ramified extension ⇒ minimal polynomial is Eisenstein'. The uniform cyclotomic bridge `Φ_{2p}(X) · (X+1) = X^p + 1` for odd primes p ≥ 3 is now proved (S8); it composes S7's divisor enumeration `divisors_two_mul_odd_prime` with `prod_cyclotomic_eq_X_pow_sub_one` and `cyclotomic_prime_mul_X_sub_one`. The local-field uniformizer theorem (for the sub-leading divisibility half) remains the deeper gap (~200–400 lines). All per-prime cases for p ∈ {3, 5, 7, 11, 13} are fully proven with 0 sorries.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to the irreducibility of minimal polynomials of cosines. For specific primes the gallery already has formalizations: cos(20°) = cos(π/9) (Eisenstein at 3), cos(π/5) (Eisenstein at 5), cos(π/7) (Eisenstein at 7). The pattern Y → Y − 2 and the resulting Eisenstein-at-p form for the minimal polynomial of 2 + 2cos(π/p) is conjectured to hold for every odd prime p ≥ 3. The cyclotomic perspective ties this to Φ_{2p}(−1) = Φ_p(1) = p, a Mathlib-available identity, and the standard ramification theory of cyclotomic fields developed by Kummer, Hilbert, and Hensel.",

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 438,
+    "lineCount": 437,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement.",
     "theoremCount": 13,
     "definitionCount": 9

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 303,
+    "lineCount": 302,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 368,
+    "lineCount": 367,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 225,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,


### PR DESCRIPTION
## Fix

Sync top-level `meta.lineCount` field to actual `wc -l` of the referenced Lean source file across 5 gallery entries. PR #19622 covered `leanFile.lineCount` only and missed the parallel top-level `meta.lineCount` field on these entries — leaving them stale by 1 line.

## Entries

| slug | declared | actual | delta |
|---|---|---|---|
| `angle-trisection-cos-20-gal-oq-01-oq-03` | 1381 | 1380 | -1 |
| `erdos-109` | 438 | 437 | -1 |
| `erdos-171` | 303 | 302 | -1 |
| `erdos-37` | 368 | 367 | -1 |
| `erdos-485` | 226 | 225 | -1 |

## Evidence

- Detection: `wc -l proofs/<path>` vs top-level `meta.lineCount` in `src/data/proofs/<slug>/meta.json`
- 4 of 5 entries (the erdos ones) carry both top-level `meta.lineCount` and `leanFile.lineCount`; PR #19622 fixed the latter and left the former stale. After this PR both fields agree.
- 1 entry (`angle-trisection-cos-20-gal-oq-01-oq-03`) has only a top-level `meta.lineCount` (no `leanFiles[]` section).
- After this PR, the scan reports **0 lineCount drifts** across the 2440-entry gallery.

## Scope

Pure metadata sync. No Lean source touched. No build impact. No `axiomCount`/`theoremCount`/`status`/`badge` changes.

Disjoint from open mechanic PRs (verified via \`git ls-remote --heads origin 'fix/mechanic-*'\` and \`gh pr list --search 'in:title meta'\`).

---
Automated fix by lean-mechanic agent.