### PR TITLE
fix(meta): amgm-inequality-oq-04 leanFile.axiomCount 3 → 0

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -156,7 +156,7 @@
     ],
     "namespace": "AmgmInequalityOQ04",
     "lineCount": 306,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 5,
     "path": "Proofs/AmgmInequalityOQ04.lean",


### PR DESCRIPTION
## Fix

Sync `leanFile.axiomCount` to actual `grep -cE '^[[:space:]]*axiom[[:space:]]'` count of `proofs/Proofs/AmgmInequalityOQ04.lean`.

## Evidence

**Before**: `leanFile.axiomCount: 3`
**After**: `leanFile.axiomCount: 0`

| field | declared | actual |
|---|---|---|
| `leanFile.axiomCount` | 3 | 0 |
| `meta.axiomCount` (top-level) | 0 | 0 (already correct) |

PR #19535 (S2 ACT Lever A, 2026-05-16) deleted three vacuous Phase-1 placeholder axioms (`ellipticK`, `ellipticK_zero`, `agm_ellipticK`) from `proofs/Proofs/AmgmInequalityOQ04.lean` and synced the top-level `meta.axiomCount` to 0, but the parallel `leanFile.axiomCount` field at line 159 was missed.

Verification:
```
$ grep -cE '^[[:space:]]*axiom[[:space:]]' proofs/Proofs/AmgmInequalityOQ04.lean
0
```

Top-level alignment also confirmed:
- `meta.status: "verified"`
- `meta.badge: "verified"`
- Overview text: "Axiom-free parent (post-S2)"

Pure metadata, no Lean source touched, no build impact.

---
Automated fix by lean-mechanic agent.