### PR TITLE
fix(meta): brouwer-fixed-point-oq-01-oq-02 axiomCount 3 → 4

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -149,7 +149,7 @@
   "leanFile": {
     "lineCount": 462,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 3,
+    "axiomCount": 4,
     "sorries": 0,
     "definitionCount": 3,
     "theoremCount": 13


### PR DESCRIPTION
## Fix

Bump `meta.axiomCount` (and parallel `leanFile.axiomCount`) from 3 → 4 for `brouwer-fixed-point-oq-01-oq-02`. The Lean source declares 4 axioms; gallery metadata was stale since S7 ACT-D-1 (2026-05-12) added the 4th axiom (`sphere_singularHomology_nonzero`).

## Evidence

**File**: `proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean`

```
$ grep -nE '^\s*axiom\s+\w' proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean
44:axiom no_retraction_axiom (n : ℕ) (hn : n ≥ 1) : ¬∃ r : Retraction n, True
261:axiom H_n_minus_1_sphere_nonzero (n : ℕ) (hn : n ≥ 1) (r : Retraction n)
287:axiom contractible_singularHomology_zero
351:axiom sphere_singularHomology_nonzero
```

**File's own header docstring** (lines 49 and 64-65):
```
## Summary: 14 theorems, 0 sorries, 4 axioms
...
Net axiom count: 2 → 4 (no_retraction_axiom, H_n_minus_1_sphere_nonzero,
contractible_singularHomology_zero, sphere_singularHomology_nonzero).
```

**Before**: `meta.axiomCount = 3`, `leanFile.axiomCount = 3`
**After**: `meta.axiomCount = 4`, `leanFile.axiomCount = 4`

**Build**: `pnpm build` clean (31s, 0 errors).

## Scope

Pure metadata numeric sync. No Lean source touched. No `description` / `assumptions` / `originalContributions` prose changes (description text "13 theorems, 2 axioms" is also stale — better addressed by a researcher PR that re-narrates which axioms are substantive bridge-gaps vs scaffolding).

Disjoint from open PRs (verified via `gh pr list --search 'brouwer in:title'`):
- PR #18011, #19646 are for the sibling `oq-03-oq-02` slug (G6 companion-file work)
- No open mechanic PR touches `brouwer-fixed-point-oq-01-oq-02`

---
Automated fix by lean-mechanic agent.