### PR TITLE
audit(erdos-92): tracker bump (clean) — meta/Lean integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10563,8 +10563,8 @@
     },
     "erdos-92": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T08:37:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T15:15:34Z",
       "result": "clean"
     },
     "erdos-920": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-92` (Erdős Problem #92: Equidistant Points in the Plane). All meta.json claims match the Lean source `proofs/Proofs/Erdos92Problem.lean`.

## Integrity checks

| Field | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 (zero `sorry` tokens) | ✓ |
| axiomCount | 3 | 3 (`maxEquidistantPoints_le_card_sub_one`, `achievableValues_nonempty`, `eventually_exponent_small`) | ✓ |
| theoremCount | 4 | 4 (2 theorems + 2 lemmas) | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 230 | 230 | ✓ |
| status/badge | axiomatized/axiom | axioms present | ✓ |
| True stubs | n/a | none | ✓ |
| Structure-encoded assumptions | none | none | ✓ |

## Narrative review

`originalContributions` correctly disclaims Pach-Sharir, JJMT, lattice lower bound, and Fishburn small-value results as "referenced in docstrings only — not formalized as axioms or theorems." Status `axiomatized` (not `verified`) is appropriate for an open Erdős problem with 3 stated axioms. No delegation opacity, axiom masking, inequality-as-theorem confusion, pipeline inflation, or hidden-imports.

## Tracker update

```
"erdos-92": {
  auditCount: 3 → 4,
  lastAudited: 2026-04-28T08:37Z → 2026-05-16T15:15Z,
  result: clean
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)