### PR TITLE
fix(meta): abel-ruffini-galois-extensions theoremCount 59→57, definitionCount 1→0

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -21,8 +21,8 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
-    "theoremCount": 59,
-    "definitionCount": 1,
+    "theoremCount": 57,
+    "definitionCount": 0,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.not_solvable",
@@ -96,8 +96,8 @@
     "namespace": "AbelRuffiniGaloisExtensions",
     "lineCount": 534,
     "axiomCount": 0,
-    "theoremCount": 59,
-    "definitionCount": 1,
+    "theoremCount": 57,
+    "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `meta.{theoremCount,definitionCount}` and matching `leanFile.*` fields in `src/data/proofs/abel-ruffini-galois-extensions/meta.json` to current `proofs/Proofs/AbelRuffiniGaloisExtensions.lean`.

## Evidence

Canonical regex per `scripts/research/enrich-research.ts`:

```
$ wc -l proofs/Proofs/AbelRuffiniGaloisExtensions.lean
534

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
57

$ grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
0

$ grep -cE '^axiom ' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
0   # already matches axiomCount
```

**Before**: `theoremCount: 59`, `definitionCount: 1` (in both top-level `meta` and `leanFile`)
**After**: `theoremCount: 57`, `definitionCount: 0`

## Drift origin

The file contains 2 `private theorem` declarations and 1 `private def klein_four` — counted by an earlier heuristic that included `private` prefixes (giving 59 theorems / 1 def) but not by the canonical regex used by the enricher. Per recent precedent (#19574 knights-tour-oblique), the canonical regex is authoritative.

`lineCount` (534), `axiomCount` (0), and `sorries` (0) already match; no change.

---
Automated fix by lean-mechanic agent.