### PR TITLE
fix(meta): erdos-905 definitionCount 10 → 9

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10461,9 +10461,9 @@
     },
     "erdos-905": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T10:56:23Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T15:22:37Z",
+      "result": "issues-fixed"
     },
     "erdos-906": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -32,7 +32,7 @@
     "assumptions": "1 axiom: bollobas_erdos_theorem. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 10
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Bollobás and Erdős conjectured this result about edge-triangle multiplicity. It was independently proved by Edwards (unpublished) and Hadziivanov-Nikiforov in 1979. The problem connects to Turán's classical theorem on triangle-free graphs. Turán's theorem (1941) established that the complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉} is the unique triangle-free graph on n vertices maximizing the number of edges, at exactly ⌊n²/4⌋. The question posed by Bollobás and Erdős pushed beyond mere existence of triangles to ask about their concentration: once the Turán bound is exceeded, must some edge bear a disproportionate share of the triangle count? The answer n/6 is tight, achieved by graphs close to the balanced complete bipartite graph with a small clique added. Nikiforov subsequently extended these ideas into a broader program on the distribution of cliques above Turán thresholds.",
@@ -168,7 +168,7 @@
     "lineCount": 190,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 10,
+    "definitionCount": 9,
     "path": "Proofs/Erdos905Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Sync stale `meta.definitionCount` and `leanFile.definitionCount` in `src/data/proofs/erdos-905/meta.json` to the current state of `proofs/Proofs/Erdos905Problem.lean`.

## Evidence (canonical regex per `scripts/research/enrich-research.ts`)

```
$ wc -l proofs/Proofs/Erdos905Problem.lean
190

$ grep -cE '^(def|noncomputable def|opaque def) ' \
    proofs/Proofs/Erdos905Problem.lean
9

$ grep -cE '^axiom ' proofs/Proofs/Erdos905Problem.lean
1   # matches existing axiomCount

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos905Problem.lean
1   # matches existing theoremCount
```

## Drift origin

The file contains `structure Graph (n : ℕ)` (line 49) which was counted as a definition by an earlier heuristic (giving 10) but is not matched by the canonical regex. Per recent precedent (#19574 knights-tour-oblique, abel-ruffini-galois-extensions auditor cycle), the canonical regex is authoritative.

`lineCount` (190), `axiomCount` (1), `theoremCount` (1), `sorries` (0) already match; no change.

## Test plan
- [x] `definitionCount` matches `grep -cE '^(def|noncomputable def|opaque def) ' Erdos905Problem.lean`
- [x] No changes to Lean source
- [x] No changes to other counters (already in sync)

Discovered during gallery integrity audit (erdos-905).

🤖 Generated with [Claude Code](https://claude.com/claude-code)