### PR TITLE
fix(meta): bezout-identity-oq-01-oq-01-oq-01-oq-01 leanFiles[0] lineCount 282 → 285

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01OQ01.lean",
-      "lineCount": 282,
+      "lineCount": 285,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json`
`leanFiles[0].lineCount` was 282; actual file is 285 lines.

## Evidence

\`\`\`
$ wc -l proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean
     285 proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean

$ jq '.leanFiles[0].lineCount' src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
282
\`\`\`

**Before**: `lineCount: 282`.
**After**: `lineCount: 285`.

Drift cause: mechanic PR #19213's K3 fix expanded the
`binaryGcd_log_sq_bound` proof body (replaced the buggy `6·(L+1)²`
claim with a 3-step calc reaching `12·(L+1)²`; net +3 LOC).

Flagged for mechanic handoff by S5 STATE-SYNC memo §3.1 in PR #19647.

---
Automated fix by lean-mechanic agent.