### PR TITLE
fix(mechanic): bezout-identity-oq-01-…-oq-01 leanFiles drift + gallery 6→12 constant (handoff #19647)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -35,7 +35,7 @@
       "stepBitOps_le: theorem — stepBitOps a b ≤ 3·(log₂(max a b)+1); proof by_cases on max a b = 0, then size_eq_succ_log + omega",
       "totalBitOps: noncomputable definition — binaryGcdSteps a b × (3·(log₂(max a b)+1))",
       "binaryGcd_log_sq_complexity: total bit ops ≤ (2·(log₂ a + log₂ b) + 2)·(3·(log₂(max a b)+1))",
-      "binaryGcd_log_sq_bound: O(log²) corollary — total bit ops ≤ 6·(log₂(max a b)+1)²"
+      "binaryGcd_log_sq_bound: O(log²) corollary — total bit ops ≤ 12·(log₂(max a b)+1)²"
     ],
     "mathlibDependencies": [
       {
@@ -133,7 +133,7 @@
       "title": "Bit Complexity Model and O(log² n) Bound",
       "startLine": 190,
       "endLine": 282,
-      "summary": "Defines the per-step bit cost concretely (stepBitOps a b := 2 · Nat.size (max a b) + 1) and proves the envelope stepBitOps_le via the bridging identity size_eq_succ_log (Nat.size n = Nat.log 2 n + 1 for n ≥ 1). Defines totalBitOps and proves binaryGcd_log_sq_complexity (explicit bound) and binaryGcd_log_sq_bound (O(log²) corollary: ≤ 6·(log₂(max a b)+1)²).",
+      "summary": "Defines the per-step bit cost concretely (stepBitOps a b := 2 · Nat.size (max a b) + 1) and proves the envelope stepBitOps_le via the bridging identity size_eq_succ_log (Nat.size n = Nat.log 2 n + 1 for n ≥ 1). Defines totalBitOps and proves binaryGcd_log_sq_complexity (explicit bound) and binaryGcd_log_sq_bound (O(log²) corollary: ≤ 12·(log₂(max a b)+1)²).",
       "mathContext": "Two-stage cost decomposition: $\\mathrm{totalBitOps}(a,b) = \\mathrm{steps}(a,b) \\cdot \\mathrm{stepBitOps}(a,b)$. By `binaryGcdSteps_le_log`: $\\mathrm{steps}(a,b) \\le 2(\\log_2 a + \\log_2 b) + 2$. By the concrete cost model `stepBitOps a b := 2 \\cdot \\mathrm{size}(\\max a b) + 1` (counting one comparison's ≤ size bit reads, one subtraction's ≤ size bit ops, and one parity check's 1 bit read), the theorem `stepBitOps_le` shows $\\mathrm{stepBitOps}(a,b) \\le 3(\\log_2(\\max a b) + 1)$ via the bridging identity $\\mathrm{size}(n) = \\log_2(n) + 1$ for $n \\ge 1$ — formerly two axioms, now machine-checked. Multiplying and using $\\log_2 a + \\log_2 b \\le 2 \\log_2(\\max a b)$ yields $\\mathrm{totalBitOps}(a,b) \\le 6(\\log_2(\\max a b) + 1)^2$, the headline $O(\\log^2)$ bound. The constant 6 is the product of the two stage constants ($2 \\cdot 3$) and reflects the worst-case input where each stage saturates simultaneously."
     }
   ],

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01OQ01.lean",
-      "lineCount": 282,
+      "lineCount": 285,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Discharges §3.1 and §3.2 of the S5 STATE-SYNC mechanic handoff
(PR #19647, researcher-8, 2026-05-16T14:32Z).

| Edit | File | Before | After |
|---|---|---|---|
| §3.1 | `src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json` | `lineCount: 282` | `lineCount: 285` |
| §3.2 | `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json` `originalContributions[7]` | `≤ 6·(log₂(max a b)+1)²` | `≤ 12·(log₂(max a b)+1)²` |
| §3.2-adjacent | `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json` `sections[bit-complexity].summary` | `(O(log²) corollary: ≤ 6·(log₂(max a b)+1)²)` | `(O(log²) corollary: ≤ 12·(log₂(max a b)+1)²)` |

## Evidence

**leanFiles drift cause**: Mechanic PR #19213's K3 fix expanded
`binaryGcd_log_sq_bound` proof body by +3 LOC. Verified
`wc -l proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean = 285`.

**Arithmetic constant cause**: The Lean theorem
`proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean:258-272` states
`totalBitOps a b ≤ 12 * (Nat.log 2 (max a b) + 1) ^ 2`. The original
S2 prose claimed `6·` based on an incorrect factorisation; the K3 repair
in #19213 corrected the proof body but the gallery prose was not
updated. Two prose occurrences carried the wrong constant; both fixed
here as a single coherent bug.

## Out-of-scope (follow-on)

`sections[bit-complexity].mathContext` still claims `≤ 6(log…)²` and
explains it as `(2·3)`. The correct factorisation is `(4·3)` — after
the `log_sum` bound, `binaryGcdSteps ≤ 4·log + 2`, not `2·log + 2`.
This requires math-prose rewrite (not just a numeric swap) and is
flagged for a follow-on researcher/curator pass.

## Validation

- `jq '.' src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json` parses
- `jq '.' src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-01.json` parses
- No Lean code touched (file already 0/0/0 on origin/main after #19213)
- Docker rebuild not required per #19213 baseline

References handoff PR #19647 §3.

---
Automated fix by lean-mechanic agent.