### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02 leanFiles[].lineCount 235 → 247

### DIFF
--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
@@ -170,7 +170,7 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean",
       "filename": "BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean",
-      "lineCount": 235,
+      "lineCount": 247,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Research JSON `leanFiles[]` entry for `BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean` had stale `lineCount: 235` from S1 ACT-era enrichment snapshot. Actual `wc -l` = 247.

## Evidence

**Before**: `leanFiles[i].lineCount: 235` (stale by -12 LOC)
**After**: `leanFiles[i].lineCount: 247` (matches `wc -l` and gallery `meta.json`)

Verification:
```
$ wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean
     247
```

Gallery `meta.json` already records 247 in both `meta.lineCount` and `leanFile.lineCount`. Other three counters (`theoremCount: 13`, `axiomCount: 0`, `sorryCount: 0`) verified correct and unchanged.

Picks up the mechanic handoff packaged in §3 of #19659 (the still-open S3 STATE-SYNC); the JSON sections modified do not overlap with #19659's `currentState`/`knowledge` field edits.

---
Automated fix by lean-mechanic agent.