### PR TITLE
fix(meta): erdos-894 definitionCount drift 12 → 11

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10381,8 +10381,8 @@
     },
     "erdos-894": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T15:46:09Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T15:27:47Z",
       "result": "issues-fixed"
     },
     "erdos-895": {

--- a/src/data/proofs/erdos-894/meta.json
+++ b/src/data/proofs/erdos-894/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 225,
     "assumptions": "3 axioms: chromaticNumber, problem_464_result, katznelson_theorem. 0 sorries.",
     "theoremCount": 8,
-    "definitionCount": 12
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #894 asks whether Cayley graphs on ℤ defined by lacunary sequences have finite chromatic number. A sequence A = {n₁ < n₂ < ...} is lacunary if n_{k+1} ≥ (1+ε)n_k for some ε > 0. The connection to Diophantine approximation was observed by Katznelson (2001): if there exists an irrational θ such that all multiples θ·n_k stay bounded away from integers, then coloring by position on the circle (mod 1) gives a valid finite coloring.\n\nPeres and Schlag (2010) resolved both this problem and the closely related Problem #464 simultaneously. They proved that O(ε⁻¹ log(1/ε)) colors suffice for a lacunary sequence with ratio (1+ε), and that this bound is essentially optimal. Their proof combined harmonic analysis and metric number theory.\n\nThe formalization proves the main theorem (lacunary_finitely_colorable) from two axiomatized results: Problem #464's guarantee of a badly approximable irrational, and Katznelson's observation that this yields a valid coloring. Several proved results include exponential growth of lacunary sequences, the Cayley graph construction with proved symmetry, the logical implication from Problem #464 to #894, and special cases for powers of 2 and 3.",
@@ -186,7 +186,7 @@
     "lineCount": 225,
     "axiomCount": 3,
     "theoremCount": 8,
-    "definitionCount": 12,
+    "definitionCount": 11,
     "path": "Proofs/Erdos894Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

- Sync stale `meta.definitionCount` and `leanFile.definitionCount` for `erdos-894` from 12 → 11 to match canonical regex applied to `proofs/Proofs/Erdos894Problem.lean`.
- Bump audit tracker for `erdos-894`: auditCount 4→5, result `issues-fixed`, lastAudited refresh.

## Evidence

Canonical regex per `scripts/research/enrich-research.ts`:

```
$ wc -l proofs/Proofs/Erdos894Problem.lean
225
$ grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/Erdos894Problem.lean
11
$ grep -cE '^axiom ' proofs/Proofs/Erdos894Problem.lean
3   # matches axiomCount
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos894Problem.lean
8   # matches theoremCount
```

Drift origin: `structure CayleyGraph (A : Set ℕ)` (line 150) was counted as a definition by an earlier heuristic but is not matched by the canonical regex. Same pattern as #19662 (erdos-905, `structure Graph` miscounted). Per precedent (#19574 knights-tour-oblique, abel-ruffini-galois-extensions auditor cycle), the canonical regex is authoritative.

## Audit summary

- `status: axiomatized` ✓ (3 axioms declared)
- `badge: axiom` ✓
- `sorries: 0` ✓ (file has 0 sorries)
- No `True` stubs ✓
- `axiomCount: 3` ✓ matches Lean
- `theoremCount: 8` ✓ matches Lean
- `lineCount: 225` ✓ matches Lean
- `definitionCount: 12` ✗ → **11** (this PR)
- `assumptions` field correctly lists all 3 axioms by name

## Test plan

- [x] `grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/Erdos894Problem.lean` returns 11
- [x] No changes to Lean source or proof structure
- [x] meta.json `axiomCount`, `theoremCount`, `lineCount`, `sorries` all unchanged and match Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)