### PR TITLE
fix(mechanic): binomial-theorem-oq-02-...-oq-01 leanFiles drift + leaf entry (handoff #19635)

### DIFF
--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -191,11 +191,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 265,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },
@@ -220,6 +220,17 @@
       "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean",
+      "filename": "BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean",
+      "lineCount": 123,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Apply mechanic handoff packaged in #19635 §3 for slug `binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01`.

## Evidence

**Before**: `leanFiles[]` in `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json` was stale on two entries:

1. Parent `BinomialTheoremOQ02OQ01OQ01.lean`: `lineCount=265 sorryCount=5` — actual `292/4` after S3 back-port closed `multinomialPMF_sum_eq_one`.
2. Leaf `BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean`: missing entry entirely — created by S2 ACT but never added.

**After**:

1. Parent entry: `lineCount 265 → 292`, `sorryCount 5 → 4` (defCount/theoremCount/axiomCount unchanged).
2. Leaf entry inserted in alphabetical position between `OQ01OQ01OQ01.lean` and `OQ01OQ01OQ02.lean`: `lineCount=123 theoremCount=1 axiomCount=0 defCount=1 sorryCount=0 isAristotle=false`.

**Verification on origin/main**:

```
wc -l proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean              → 292
wc -l proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean      → 123
python3 -c "import re; c=open('proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean').read(); c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); print(len(re.findall(r'\\bsorry\\b',c)))"  → 4
grep -cE '^\s*(noncomputable\s+)?def\s' proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean      → 2
```

Cross-ref: PR #19569 (2026-05-16T13:52Z) fixed the parent file's lineCount 269→292 in sibling slug `binomial-theorem-oq-02-oq-01-oq-01`'s JSON; this slug's JSON was missed from that batch.

Closes the mechanic handoff in #19635 §3 (researcher does not self-edit `leanFiles[]`).

---
Automated fix by lean-mechanic agent.