### PR TITLE
fix(meta): cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 add 2 missing leanFiles[] entries (handoff #19660)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
@@ -218,6 +218,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
+      "filename": "CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 230,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean",
+      "filename": "CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean",
+      "lineCount": 173,
+      "theoremCount": 5,
+      "axiomCount": 4,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean"
+    },
+    {
       "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
       "lineCount": 207,


### PR DESCRIPTION
## Fix

Research JSON `leanFiles[]` had 21 sibling `CantorDiagonalization*.lean` entries but was missing the slug's own two files. Adds entries for the parent and Phase3b files per the mechanic handoff packaged in #19660 §3.

## Evidence

**Before**: `leanFiles[]` length 21; slug parent + Phase3b files absent despite being the slug's own deliverables.

**After**: `leanFiles[]` length 23, sorted alphabetically:

```
[3] Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean
[4] Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean         ← NEW (parent)
[5] Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean  ← NEW (Phase3b)
[6] Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ03.lean
```

Counts verified against `origin/main` HEAD (`1a75a113925`):

```
$ F=proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean
$ wc -l "$F"                         # 230
$ grep -cE '^(theorem|lemma) ' "$F"  # 7
$ grep -cE '^axiom ' "$F"            # 0
$ grep -cE '^def ' "$F"              # 1
$ grep -cE 'sorry' "$F"              # 0

$ F=proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean
$ wc -l "$F"                         # 173
$ grep -cE '^(theorem|lemma) ' "$F"  # 5
$ grep -cE '^axiom ' "$F"            # 4
$ grep -cE '^def ' "$F"              # 0
$ grep -cE 'sorry' "$F"              # 0
```

Picks up the handoff packaged in §3 of #19660 (the still-open S9 STATE-SYNC). JSON sections modified here do not overlap with #19660's `currentState` / `knowledge` field edits, so the two PRs can land in either order.

Gallery `meta.json` is already correct after prior mechanic PR #19593 (`axiomCount: 4`, `lineCount: 230`, `additionalFiles: [Phase3b]`); this PR only fixes the separate research-JSON `leanFiles[]` array.

---
Automated fix by lean-mechanic agent.