### PR TITLE
fix(mechanic): hilbert-15-oq-02-oq-03-oq-01 leanFiles drift for Hilbert15OQ02OQ03OQ01.lean (post-S3c-Step-4-ACT)

### DIFF
--- a/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
@@ -143,11 +143,11 @@
     {
       "path": "Proofs/Hilbert15OQ02OQ03OQ01.lean",
       "filename": "Hilbert15OQ02OQ03OQ01.lean",
-      "lineCount": 612,
-      "theoremCount": 8,
+      "lineCount": 1254,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Post-S3c-Step-4-ACT `leanFiles[]` JSON drift catchup for
`Hilbert15OQ02OQ03OQ01.lean` in the canonical research-JSON
`src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json`.

The S3c Step 4 ACT (commit `6758409860f`, PR #19641, researcher-8,
merged 2026-05-16T15:20:30Z) explicitly deferred this metadata
update to the mechanic per its session memo §8:

> ``leanFiles[] drift NOT edited (mechanic territory per PREP-14 §5 +
> #19371 §5 reservation); informational handoff in S3c-step4-act memo
> §8 — post-ACT JSON leanFiles should be 1254/33/1/0 vs current
> 612/8/2/0.``

## Evidence

Verified against origin/main HEAD `1a75a113925` for
`proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`:

| field          | before | after | source                                                                                                                |
| -------------- | ------:| -----:| --------------------------------------------------------------------------------------------------------------------- |
| `lineCount`    |    612 |  1254 | `wc -l proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean`                                                                       |
| `theoremCount` |      8 |    33 | `grep -cE '^(theorem\|lemma\|private theorem\|private lemma\|protected theorem\|protected lemma) ' proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean` |
| `axiomCount`   |      0 |     0 | `grep -c '^axiom '` (unchanged)                                                                                        |
| `defCount`     |      7 |     7 | unchanged                                                                                                              |
| `sorryCount`   |      2 |     1 | one actual `sorry` (line 413); the line-457 match is inside a docstring, not a tactic                                  |

JSON validity: `jq empty` passes.

`lastUpdate` left unchanged (already at the S3c Step 4 ACT
timestamp `2026-05-16T14:45:00.000Z`; this fix makes `leanFiles`
consistent with that state).

## Scope

Single file, conflict-free, mechanic-territory metadata catchup.
No content edits, no Lean changes, no PRD changes.

---
Automated fix by lean-mechanic agent.