### PR TITLE
fix(meta): shannon-channel-coding lineCount 532→555, definitionCount 8→9 (absorb #19655)

### DIFF
--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -42,7 +42,7 @@
     "assumptions": "3 axioms: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 13 theorems proved (jointDist properties, channelMI_le_log_card, capacity_nonneg, channelMI_le_capacity, capacity_le_log_card, rate/BSC bounds, fano_inequality discharged via Proofs.ShannonChannelCodingOQ02OQ01, single-letter Fano-form converse fano_converse_step + fano_converse_capacity). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 532,
+    "lineCount": 555,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",
@@ -52,7 +52,7 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Shannon's noisy channel coding theorem is arguably the most important result in information theory and one of the great theorems of 20th-century mathematics. Published in 1948, it answered a question that engineers had struggled with since the invention of the telegraph: is it possible to communicate reliably over a noisy channel, and if so, at what rate?\n\nBefore Shannon, the prevailing belief was that reducing error probability required reducing the communication rate to zero. Shannon's shocking result was that reliable communication is possible at any positive rate below the channel capacity C = max I(X;Y), and impossible above it. The channel capacity is a single number that completely characterizes the communication capability of a noisy channel.\n\nThe achievability proof uses random coding: choose a codebook at random and show that the average error probability over all codebooks is small. This is a probabilistic method argument -- one of the earliest and most influential. The converse uses Fano's inequality, which bounds the conditional entropy H(X|Y) in terms of the error probability, showing that rates above capacity force large errors.\n\nThe theorem launched the fields of coding theory and telecommunications engineering, leading to error-correcting codes (turbo codes, LDPC codes, polar codes) that approach channel capacity in practice.",
@@ -172,10 +172,10 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 532,
+    "lineCount": 555,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

`shannon-channel-coding` meta.json out of sync with `Proofs/ShannonChannelCoding.lean` after PR #19655 (S18a-1 ACT for child slug `shannon-channel-coding-oq-02-oq-01-oq-01`, merged 2026-05-16) added \`def DMChannel.IsWeaklySymmetric\` (+23 LOC).

## Evidence

\`\`\`
\$ wc -l proofs/Proofs/ShannonChannelCoding.lean
555
\$ grep -cE '^(noncomputable |@\[[^]]*\] +)*(def|structure|class|instance) ' proofs/Proofs/ShannonChannelCoding.lean
9
\$ grep -cE '^(private |protected |noncomputable |@\[[^]]*\] +)*(theorem|lemma) ' proofs/Proofs/ShannonChannelCoding.lean
16
\$ grep -c '^axiom ' proofs/Proofs/ShannonChannelCoding.lean
3
\$ grep -c '\bsorry\b' proofs/Proofs/ShannonChannelCoding.lean
0
\`\`\`

**Before** → **After**:
- \`meta.lineCount\`: 532 → 555
- \`meta.definitionCount\`: 8 → 9
- \`leanFile.lineCount\`: 532 → 555
- \`leanFile.definitionCount\`: 8 → 9

Unchanged: \`axiomCount=3\` (still channel_coding_achievability + channel_coding_converse + bsc_capacity_eq), \`theoremCount=16\`, \`sorries=0\`, \`status=\"axiomatized\"\`, \`badge=\"axiom\"\`. The \`meta.assumptions\` narrative was not edited because the axiom roster is unchanged and the narrative does not enumerate defs.

## Scope

1 file, 4 insertions / 4 deletions. No Lean source change. No status/badge change. Sibling to precedent PR #19527 (the previous shannon mechanic sync of lineCount 442→532, theoremCount 14→16) — same file, same convention.

Detected by previous mechanic cycle as one of three pending lineCount drifts (memo from cycle 1233 alongside #19666 for infinitude-primes-4k3).

---
Automated fix by lean-mechanic agent.