### PR TITLE
fix(meta): schroeder-bernstein-oq-01 leanFiles theoremCount 8→6, defCount 3→1

### DIFF
--- a/src/data/research/problems/schroeder-bernstein-oq-01.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-01.json
@@ -141,9 +141,9 @@
       "path": "Proofs/SchroederBernsteinOQ01.lean",
       "filename": "SchroederBernsteinOQ01.lean",
       "lineCount": 353,
-      "theoremCount": 8,
+      "theoremCount": 6,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroederBernsteinOQ01.lean"


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/schroeder-bernstein-oq-01.json`
`leanFiles[1]` (`Proofs/SchroederBernsteinOQ01.lean`):

- `theoremCount`: 8 → **6**
- `defCount`: 3 → **1**

(`lineCount`, `axiomCount`, `sorryCount` already match — 353/0/0.)

## Evidence

```
$ wc -l proofs/Proofs/SchroederBernsteinOQ01.lean
     353 proofs/Proofs/SchroederBernsteinOQ01.lean

$ grep -nE "^(theorem|lemma) " proofs/Proofs/SchroederBernsteinOQ01.lean
102:theorem hasSBP_Type
122:theorem hasSBP_Discrete
175:theorem not_hasSBP_TopCat
223:theorem hasSBP_of_isDiscrete
263:theorem hasSBP_of_isGroupoid
334:theorem hasSBP_of_fullFaithful_forget

$ grep -cE "^(theorem|lemma) " proofs/Proofs/SchroederBernsteinOQ01.lean
6

$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/SchroederBernsteinOQ01.lean
1
```

## Provenance

- S11 ACT #19424 (merged 2026-05-16T04:40Z) added `hasSBP_of_isGroupoid` (+1 thm, build verified 3069 jobs).
- S12 ACT #19466 (merged 2026-05-16T08:54Z) added `hasSBP_of_fullFaithful_forget` (+1 thm, build pending).
- S13 STATE-SYNC #19578 (merged 2026-05-16T13:52Z) absorbed both into `state.md`; did not touch `leanFiles[]`.

The stale `theoremCount: 8 / defCount: 3` predates the current corpus (pre-S6 era).

## Scope

Single 4-line diff in one file. No Lean / `meta.json` / `problem.md` / `state.md` / `sessions/` edits. No build invocation needed.

---
Automated fix by lean-mechanic agent.