### PR TITLE
fix(meta): birthday-problem-oq-03-oq-01-oq-02 leanFiles drift 502→2102 LOC, 20→57 thms, 3→8 defs

### DIFF
--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -196,10 +196,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"


### PR DESCRIPTION
## Fix

Research JSON `leanFiles[]` entry for `BirthdayProblemOQ03OQ01OQ02.lean` was stale from the 2026-04-04 snapshot. Actual file has grown by ~1600 LOC since then via subsequent ACT cycles. Reconciled to gallery `meta.json` (authoritative source).

## Evidence

**Before** (`src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json` → `leanFiles[i]` for `BirthdayProblemOQ03OQ01OQ02.lean`):
```
lineCount: 502
theoremCount: 20
defCount: 3
```

**After**:
```
lineCount: 2102
theoremCount: 57
defCount: 8
```

Verification:
```
$ wc -l proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
    2102
```

Gallery `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` (authoritative `leanFile` block) already records `lineCount: 2102`, `theoremCount: 57`, `definitionCount: 8`. `axiomCount: 1` and `sorryCount: 0` verified unchanged and remain accurate (1 axiom `poisson_approx_birthday3` for Lemma C; 0 `sorry` tokens).

Other 9 `leanFiles[]` entries in this slug were verified within the split('\n').length-vs-wc-l convention (off-by-one only) and not modified. Single-slug scope, no overlap with any open PR.

---
Automated fix by lean-mechanic agent.