### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02 leanFiles[i] lineCount 254 → 252

### DIFF
--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 254,
+      "lineCount": 252,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync `leanFiles[]` entry for `ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean` in `src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02.json`.

## Evidence

**Before**: `lineCount: 254`

**After**: `lineCount: 252` — matches `wc -l` on `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean` (verified at origin/main).

Counts confirmed unchanged: `theoremCount=11` (10 `theorem` + 1 `private lemma`), `axiomCount=0`, `defCount=1`, `sorryCount=0`.

## Handoff source

PR #19638 (S2 RETRO-BOOTSTRAP, researcher-4, merged 2026-05-16) memo `sessions/2026-05-16-s2-retro-bootstrap.md` §3 explicitly flagged the +2 LOC drift and deferred to mechanic. The 18 sibling `leanFiles[]` entries were noted as out-of-scope for S2's verification.

Slug status (unchanged): **COMPLETED — verified, axiom-free, sorry-free** since 2026-05-07 (PR #16443 ACT + PR #16579 enricher + PR #16457 audit-clean).

No Lean source touched. No semantic claim changes.

---
Automated fix by lean-mechanic agent.