### PR TITLE
fix(meta): batch sync BaselProblemOQ02Aristotle.lean lineCount 98 → 95 in 13 basel-problem entries

### DIFF
--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-03.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-03.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-03.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-04-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-04-oq-03.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-04.json
+++ b/src/data/research/problems/basel-problem-oq-04.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-05-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-01.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/basel-problem-oq-05.json
+++ b/src/data/research/problems/basel-problem-oq-05.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/BaselProblemOQ02Aristotle.lean",
       "filename": "BaselProblemOQ02Aristotle.lean",
-      "lineCount": 98,
+      "lineCount": 95,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i].lineCount` (98) for `Proofs/BaselProblemOQ02Aristotle.lean` to match the actual file on `origin/main` (**95 LOC**, via `wc -l`) across **13 sibling research JSONs** in the `basel-problem-*` family. Δ −3 LOC; one sibling (`basel-problem-oq-02`) already carries 95 and is left untouched.

## Evidence

- `wc -l proofs/Proofs/BaselProblemOQ02Aristotle.lean` → `95`
- 13 sibling research JSONs reference `Proofs/BaselProblemOQ02Aristotle.lean` with `lineCount: 98` (stale).
- 1 sibling (`basel-problem-oq-02`) already at `95` — verified in scan, excluded from edit set.
- Per-entry `theoremCount=7`, `axiomCount=0`, `defCount=1`, `sorryCount=0` confirmed correct on inspection; no other fields changed.

## Affected slugs (13)

| slug | file | old | new |
|---|---|---:|---:|
| `basel-problem-oq-01` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-01` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-01-oq-02` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-01-oq-02-oq-02` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-01-oq-03` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-02` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-01-oq-03` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-03` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-04` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-04-oq-03` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-05` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-05-oq-01` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |
| `basel-problem-oq-05-oq-02` | `BaselProblemOQ02Aristotle.lean` | 98 | 95 |

## Scope discipline

- One field per entry; minimal diff (13 files × 1 line each = 13 insertions / 13 deletions).
- Targeted regex on the `lineCount` line of the matching `leanFiles[i]` entry preserves the file's original Unicode encoding and key ordering exactly.
- Other lineCount drift in these JSONs (off-by-one `wc-l+1` artifacts on non-target files) is **not** addressed here — that drift matches the `split('\n').length` convention used by `research:enrich` regeneration and is outside this single-root-cause fix.
- No in-flight `basel-problem-*` PRs touch any of these 13 slugs (`basel-problem-oq-01-oq-01-oq-02-oq-03` has active research PRs #17619, #17551 but is **not** in the edit set).

Scope mirrors mechanic PR #19664 (batch definitionCount sync across 5 angle-trisection siblings) and #19667 (single-slug lineCount sync).

---
Automated fix by lean-mechanic agent.