### PR TITLE
fix(meta): erdos-57 sorries 4 → 2 (top + meta)

### DIFF
--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",
     "erdosProblemStatus": "solved",
@@ -202,5 +202,5 @@
       "note": "High-girth constructions showing χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — demonstrating the reciprocal sum divergence in Problem #57 is precisely calibrated"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Align `src/data/proofs/erdos-57/meta.json` `sorries` counters (top-level and `meta.sorries`) with the Lean source. Both were stuck at 4 while the auto-derived `leanFile.sorries` and the human-readable `assumptions` field already reflected the correct value of 2.

## Evidence

**Lean source** (`proofs/Proofs/Erdos57Problem.lean`):

```
$ grep -nE 'sorry$' proofs/Proofs/Erdos57Problem.lean
148:  sorry
153:  sorry
```

Both inside the bipartite-characterization theorems (`bipartite_iff_no_odd_cycles`, `colorable_two_no_odd_cycles`).

**Before** — three sorries-counters were inconsistent:

```
$ grep -nE '"sorries"' src/data/proofs/erdos-57/meta.json
21:    "sorries": 4,    # meta.sorries — drifted
170:    "sorries": 2,   # leanFile.sorries — correct (auto-derived)
205:  "sorries": 4     # top-level sorries — drifted
```

`meta.assumptions` text already states `"1 axiom(s) and 2 sorry(s)"` — consistent with the fix.

**After**: `meta.sorries: 2`, `leanFile.sorries: 2`, top-level `sorries: 2`. All three counters now agree with the Lean source and the assumptions string.

## Test plan
- [x] `python3 -c 'import json; json.load(open(...))'` passes — valid JSON
- [x] No changes to Lean source
- [x] `meta.status` remains `axiomatized` (1 axiom, 2 open sorries in bipartite characterization → still axiomatized)
- [x] `meta.badge` remains `axiom`
- [x] No changes to any other counters

Discovered during gallery integrity scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)