### PR TITLE
audit(erdos-868): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10198,9 +10198,9 @@
     },
     "erdos-868": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T18:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T15:59:45Z",
+      "result": "clean",
       "fixPR": 13653,
       "fixDate": "2026-04-28",
       "mechanic": "lean-mechanic"


### PR DESCRIPTION
## Summary

Audit tracker bump for `erdos-868`: result `clean`, auditCount 4 → 5, lastAudited refreshed.

## Audit findings

Audited `src/data/proofs/erdos-868/meta.json` against `proofs/Proofs/Erdos868Problem.lean` (Erdős Problem #868: Additive Bases and Minimal Bases). All gallery integrity checks pass:

| Check | Result |
|-------|--------|
| True stubs | 0 |
| Sorries | 0 (matches `meta.sorries`) |
| Axioms | 2 (matches `meta.axiomCount`; `erdos_nathanson_1979` + `erdos_nathanson_1989`, both listed in `meta.assumptions`) |
| Theorems | 5 (matches `meta.theoremCount`) |
| `lineCount` | 258 (matches `meta.lineCount` via `wc -l`) |
| `status` / `badge` | "axiomatized" / "axiom" — correct (file has axioms) |
| `definitionCount` | 7 (= def 4 + abbrev 3) — matches dominant gallery convention |

## definitionCount note

Canonical regex in `scripts/research/enrich-research.ts` (`^(def|noncomputable def|opaque def) `) gives 4 for this file. Meta says 7 (= def 4 + abbrev 3). Survey of 185 gallery proofs containing `abbrev` declarations:

- 106 use `def + abbrev` convention (matches erdos-868) ← dominant
- 55 use `def + abbrev + structure`
- 1 uses `def` only (canonical regex)
- 23 have other drift

The `def + abbrev` count is the dominant gallery convention. No fix needed.

## No misleading claims

- The two axiom-discharged theorems correctly cite Erdős-Nathanson 1979 + 1989 as the original results
- File overview is explicit: "PARTIALLY SOLVED (main questions are OPEN)"
- Status "axiomatized" + badge "axiom" + assumptions string honestly disclose both axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)