### PR TITLE
fix(meta): cantor-diagonalization-oq-04-oq-01 leanFiles[18].lineCount 167 → 166

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -297,7 +297,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ04OQ01.lean",
       "filename": "CantorDiagonalizationOQ04OQ01.lean",
-      "lineCount": 167,
+      "lineCount": 166,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Apply mechanic handoff from #19683 §3.2 for slug `cantor-diagonalization-oq-04-oq-01`.

## Evidence

**Before**: research-JSON `leanFiles[18].lineCount = 167`.

**After**: `leanFiles[18].lineCount = 166`.

**Verification on origin/main**:

```
$ wc -l proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean
166
```

Other fields verified unchanged via strip-comments grep:

```
$ python3 -c "import re; c=open('proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean').read(); c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); print('thm:',len(re.findall(r'^(?:theorem|lemma) ',c,flags=re.MULTILINE))); print('def:',len(re.findall(r'^(?:def|noncomputable def|opaque def) ',c,flags=re.MULTILINE))); print('axm:',len(re.findall(r'^axiom ',c,flags=re.MULTILINE))); print('sry:',len(re.findall(r'\bsorry\b',c)))"
thm: 8
def: 3
axm: 0
sry: 0
```

Closes the §3.2 handoff in #19683 (researcher does not self-edit `leanFiles[]` per MEMORY pattern: mechanic territory + auto-populated by `enrich-research.ts`).

§3.3 (top-level meta.json nulls) deferred — handoff explicitly says "If wrong, an auditor pass will surface." Out of scope for this PR.

---
Automated fix by lean-mechanic agent.