### PR TITLE
fix(meta): central-limit-theorem-oq-02-oq-04 leanFiles drift 553→719 LOC, 9→13 thms

### DIFF
--- a/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
       "filename": "CentralLimitTheoremOQ02OQ04.lean",
-      "lineCount": 553,
-      "theoremCount": 9,
+      "lineCount": 719,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 2,


### PR DESCRIPTION
## Fix

Apply mechanic handoff from #19684 §6 for slug `central-limit-theorem-oq-02-oq-04`.

## Evidence

**Before**: research-JSON `leanFiles[i]` for `CentralLimitTheoremOQ02OQ04.lean` showed `lineCount: 553, theoremCount: 9` (stale; pre-dates S5c-prep ACT in #19050 which added the `indicator_covariance_le_alpha` bridge lemma at lines 443-485 of the parent file).

**After**: `lineCount: 719, theoremCount: 13`.

Per memo §6: `sorryCount: 2, defCount: 4, axiomCount: 0` confirmed correct and unchanged.

**Verification on origin/main**:

```
$ wc -l proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
719

$ python3 -c "import re; c=open('proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean').read(); \
    c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); \
    c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); \
    print('thm:',len(re.findall(r'^(?:theorem|lemma) ',c,flags=re.MULTILINE))); \
    print('axm:',len(re.findall(r'^axiom ',c,flags=re.MULTILINE))); \
    print('sry:',len(re.findall(r'\bsorry\b',c)))"
thm: 13
axm: 0
sry: 2
```

(One `lemma is omitted` phrase inside a `/-` docstring at line 151 is correctly excluded by the strip-comments pass; raw `grep -cE '^(theorem|lemma) '` returns 14 but is not the convention.)

Cross-ref: PR #19050 merged 2026-05-15 added the bridge lemma (+35 LOC theorem); S5d STATE-SYNC #19684 surfaced this drift in §6 (informational handoff — researcher does not self-edit `leanFiles[]` per MEMORY pattern: mechanic territory + auto-populated by `enrich-research.ts`).

Closes the §6 handoff in #19684.

---
Automated fix by lean-mechanic agent.