### PR TITLE
fix(meta): sum-of-divisors-oq-02 leanFiles drift 114→138 LOC, 5→3 sorries

### DIFF
--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -100,13 +100,13 @@
   "leanFiles": [
     {
       "path": "proofs/Proofs/SumOfDivisorsOQ02.lean",
-      "lineCount": 114,
+      "lineCount": 138,
       "axiomCount": 0,
-      "sorryCount": 5,
+      "sorryCount": 3,
       "theoremCount": 7,
       "defCount": 0,
       "addedInIteration": 2
     }
   ],
-  "updatedAt": "2026-05-16T10:00:00.000Z"
+  "updatedAt": "2026-05-16T16:14:00.000Z"
 }


### PR DESCRIPTION
## Fix

`src/data/research/problems/sum-of-divisors-oq-02.json` `leanFiles[0]` metadata absorbs two merged research ACTs that touched `proofs/Proofs/SumOfDivisorsOQ02.lean` without refreshing the canonical JSON:

| Field | Before | After |
|-------|--------|-------|
| `lineCount` | 114 | **138** |
| `sorryCount` | 5 | **3** |
| `theoremCount` | 7 | 7 (unchanged) |
| `defCount` | 0 | 0 (unchanged) |
| `axiomCount` | 0 | 0 (unchanged) |
| `updatedAt` | `2026-05-16T10:00:00.000Z` | `2026-05-16T16:14:00.000Z` |

## Handoff Trail (absorbed)

- **#19562** — S5 ACT: closed Step 3, took `sorryCount` 5 → 4 (Mathlib `mersenne_mul_sigma_eq_two_pow_mul` landing)
- **#19644** — S6 ACT: closed Step 4 `mersenne_dvd_odd_part`, took `sorryCount` 4 → 3 and `lineCount` 124 → 138 (build pending — Docker daemon hung)

Both research PRs updated `currentState.focus` prose with the new LOC but neither touched `leanFiles[0]`. The PR descriptions of #19562 and #19644 are the authoritative trail.

## Evidence

```bash
$ wc -l proofs/Proofs/SumOfDivisorsOQ02.lean
138 proofs/Proofs/SumOfDivisorsOQ02.lean

$ grep -nE "(^|[^A-Za-z_'])sorry([^A-Za-z_']|$)" proofs/Proofs/SumOfDivisorsOQ02.lean
29:- Steps 4, 5, 6: `sorry` placeholders. Discharge planned for S6+.    # docstring
30:- Top-level theorem `euler_converse_self_contained`: `sorry` ...     # docstring
115:  sorry                                                              # tactic
127:  sorry                                                              # tactic
136:  sorry                                                              # tactic
# → 3 tactic sites; lines 29-30 are docstring mentions in backticks

$ grep -cE "^theorem |^lemma " proofs/Proofs/SumOfDivisorsOQ02.lean
7

$ grep -cE "^def |^noncomputable def " proofs/Proofs/SumOfDivisorsOQ02.lean
0

$ grep -cE "^axiom " proofs/Proofs/SumOfDivisorsOQ02.lean
0
```

JSON validates via `python3 -c "import json; json.load(open(p))"`.

## Scope

- **One file** edited (`sum-of-divisors-oq-02.json`).
- **No** Lean file changes.
- **No** `pnpm build` invocation (per MEMORY: skip for single-slug fixes; regenerates ~1047 JSONs, leaks untracked files, uses different LOC convention).
- **No** gallery `meta.json` (no `src/data/proofs/sum-of-divisors-oq-02/` directory — research-only slug).

---
Automated fix by lean-mechanic agent.