### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01-oq-02 definitionCount 7 → 6

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "defCount": 6,
     "assumptions": "Two axioms predicated on the file's local `structure EisensteinPrime`: (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. Mathlib v4.26.0 already ships the bearers needed to discharge these axioms (Mathlib.NumberTheory.NumberField.Cyclotomic.Three for ℤ[ω] as 𝓞 K, Mathlib.NumberTheory.NumberField.Cyclotomic.PID.three_pid for IsPrincipalIdealRing (𝓞 K), and Mathlib.NumberTheory.JacobiSum.Basic for the full jacobiSum/gaussSum API following Ireland–Rosen §8.3). Discharging the axioms is therefore an engineering refactor (rebase the local EisensteinPrime onto Mathlib's 𝓞 K and port Ireland–Rosen Theorem 1 of Chapter 9, ~250 LOC) rather than a wait-on-upstream-Mathlib task. See research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md for the bearer catalog and refactor plan. All 27 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card and quarticChar_kernel_card (|ker χ| = (p-1)/3 and (p-1)/4 via IsCyclic.card_pow_eq_one_le), cubicEuler_hard and quarticEuler_hard (both Euler criterion hard directions via discrete log).",
     "mathlib_version": "4.26.0",
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Cubic reciprocity was discovered by Gauss and proved by Eisenstein in 1844 using the Eisenstein integers ℤ[ω] where ω = e^{2πi/3}. The law states that for primary Eisenstein primes π and ρ, the cubic residue symbol (ρ/π)₃ equals (π/ρ)₃. This extends the Zolotarev character uniqueness argument: for primes p ≡ 1 (mod 3), the group (ZMod p)ˣ is cyclic of order p-1 divisible by 3, giving exactly two non-trivial cubic characters (plus the trivial one). The cubic Euler criterion — a is a cube mod p iff a^((p-1)/3) = 1 — is the natural generalization of Euler's quadratic criterion. Ireland and Rosen's book (Ch. 9) gives the definitive modern treatment via Jacobi sums.",
@@ -170,7 +170,7 @@
     "lineCount": 578,
     "axiomCount": 2,
     "theoremCount": 27,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` in `elementary-quadratic-reciprocity-oq-01-oq-02/meta.json` to match `defCount` and the actual Lean source. Both `meta.definitionCount` and `leanFile.definitionCount` were stale at `7`; `meta.defCount` was already correct at `6`.

## Evidence

**Before**:
- `meta.defCount: 6`
- `meta.definitionCount: 7`  ← stale
- `leanFile.definitionCount: 7`  ← stale

**After**:
- `meta.defCount: 6`
- `meta.definitionCount: 6`
- `leanFile.definitionCount: 6`

Verified against `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` at `origin/main` HEAD `1a75a113925`:

```
$ F=proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
$ grep -cE '^(def|noncomputable def|opaque def) ' "$F"   # 6
```

The 6 defs:
- L60  `def IsCubicResidue`
- L63  `def cubExp`
- L84  `noncomputable def cubicChar`
- L308 `def IsQuarticResidue`
- L311 `def quartExp`
- L326 `noncomputable def quarticChar`

Convention matches `scripts/research/enrich-research.ts:161` (`/^(def|noncomputable def|opaque def) /`). The local `structure EisensteinPrime` at L469 is not counted as a `def` under this convention (consistent with `meta.defCount: 6`).

Other slug stats unchanged and match Lean source:
- `lineCount: 578` (= `wc -l`) ✓
- `theoremCount: 27` ✓
- `axiomCount: 2` ✓
- `sorries: 0` ✓

## Scope

Metadata-only fix. Two-line numeric edit. No Lean source change. No build needed.

---
Automated fix by lean-mechanic agent.