### PR TITLE
fix(meta): ballot-problem-oq-02-oq-05 add missing leanFiles[] entry (handoff #19282)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-02-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-05.json
@@ -138,6 +138,16 @@
   "lastUpdate": "2026-05-16T09:32:00.000Z",
   "significance": 8,
   "tractability": 3,
-  "leanFiles": [],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/BallotProblemOQ02OQ05.lean",
+      "lineCount": 130,
+      "axiomCount": 1,
+      "sorryCount": 0,
+      "theoremCount": 0,
+      "defCount": 3,
+      "addedInIteration": 2
+    }
+  ],
   "iteration": 2
 }


### PR DESCRIPTION
## Fix

`src/data/research/problems/ballot-problem-oq-02-oq-05.json` `leanFiles[]` is empty `[]` despite the slug having a Lean file added in S2 ACT (PR #19282, merged 2026-05-14). Adds one entry with current actual-state counts.

| Field | Value |
|-------|-------|
| `path` | `proofs/Proofs/BallotProblemOQ02OQ05.lean` |
| `lineCount` | **130** |
| `axiomCount` | **1** (`donsker_fclt`, line 120) |
| `sorryCount` | **0** |
| `theoremCount` | **0** |
| `defCount` | **3** (`partialSum`, `interpolatedRescaled`, `WeakConvergesInC01`) |
| `addedInIteration` | **2** |

## Evidence

```bash
$ wc -l proofs/Proofs/BallotProblemOQ02OQ05.lean
130

$ grep -nE "^[[:space:]]*(theorem|lemma|def|noncomputable|axiom) " proofs/Proofs/BallotProblemOQ02OQ05.lean
56:noncomputable def partialSum (xi : ℕ → Ω → ℝ) (k : ℕ) (ω : Ω) : ℝ :=
66:noncomputable def interpolatedRescaled
88:def WeakConvergesInC01
120:axiom donsker_fclt

$ grep -nE "(^|[^A-Za-z_'])sorry([^A-Za-z_'])" proofs/Proofs/BallotProblemOQ02OQ05.lean
39:- [ ] Discrete reflection identity (S3, sorry-free target)
# 1 grep hit, all inside a docstring checkbox; 0 tactic sites
```

## Handoff Trail

- File added by **#19282** (S2 ACT — Donsker FCLT statement layer, merged 2026-05-14); JSON was not updated to add the entry then.
- Mathlib SHA pin unchanged since file creation (`2df2f0150c…`).

## Scope

- **One** JSON edit (`leanFiles: []` → 1 entry).
- **No** Lean file changes.
- **No** `pnpm build` (per MEMORY: skip for single-slug fixes).
- **No** gallery `meta.json` (no `src/data/proofs/ballot-problem-oq-02-oq-05/` directory — research-only slug).

## Note on open research PR #19675

PR #19675 (S6 ACT, OPEN) plans `130→229 LOC` + `0→4 sorries`. This mechanic fix records the current pre-merge state. A subsequent mechanic PR will absorb the drift after #19675 lands.

---
Automated fix by lean-mechanic agent.