### PR TITLE
fix(meta): batch sync BirthdayProblemOQ03OQ01OQ02.lean leanFiles in 11 birthday-problem siblings

### DIFF
--- a/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
@@ -157,10 +157,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -171,10 +171,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-03.json
@@ -147,10 +147,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -124,10 +124,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
@@ -152,10 +152,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
@@ -146,10 +146,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01.json
@@ -162,10 +162,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-03.json
@@ -159,10 +159,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03.json
@@ -188,10 +188,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-04.json
+++ b/src/data/research/problems/birthday-problem-oq-04.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 502,
-      "theoremCount": 20,
+      "lineCount": 2102,
+      "theoremCount": 57,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[8]` entry for `Proofs/BirthdayProblemOQ03OQ01OQ02.lean` across **11 sibling research JSONs** in the `birthday-problem-*` family. Same root-cause drift addressed for the canonical slug in #19681 (merged 2026-05-16T16:20Z).

```
lineCount    502  -> 2102
theoremCount  20  ->   57
defCount       3  ->    8
```

`axiomCount` (1) and `sorryCount` (0) unchanged — already correct.

## Evidence

- `wc -l proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` → **2102**
- Authoritative gallery `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` records:
  - `lineCount: 2102`
  - `theoremCount: 57`
  - `definitionCount: 8`
  - `axiomCount: 1`
  - `sorries: 0`
- PR #19681 used the same canonical values for the canonical slug.

## Affected slugs (11)

| slug | path | old | new |
|---|---|---:|---:|
| `birthday-problem-oq-02` | `BirthdayProblemOQ03OQ01OQ02.lean` | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-02-oq-01` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-02-oq-01-oq-01` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-02-oq-03` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03-oq-01` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03-oq-01-oq-01` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03-oq-01-oq-01-oq-02` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03-oq-01-oq-01-oq-03` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-03-oq-03` | same | 502 / 20 / 3 | 2102 / 57 / 8 |
| `birthday-problem-oq-04` | same | 502 / 20 / 3 | 2102 / 57 / 8 |

11 files × 3 lines each = **33 insertions / 33 deletions**.

## Scope discipline

- Targeted regex on the matching `leanFiles[i]` entry; preserves original Unicode encoding and key ordering.
- Other `leanFiles[]` lineCount drift in these JSONs (off-by-one `wc-l+1` artifact for non-target files) is **not** addressed here — outside this single-root-cause fix.
- Excluded:
  - `birthday-problem-oq-03-oq-01-oq-02` — already fixed in #19681
  - `birthday-problem-oq-03-oq-01-oq-02-oq-01` — different stale entry at idx=10 (2086/52/5), separate scope
- Confirmed `gh pr list --search "birthday-problem in:title is:open"` returned 0 hits at submission time.

Scope mirrors mechanic batch precedent #19685 (basel-problem, 13 entries) and #19664 (angle-trisection-cos-20-gal, 5 entries).

---
Automated fix by lean-mechanic agent.