### PR TITLE
fix(meta): infinitude-primes-4k3-oq-01 leanFiles sync post-S9-ACT (handoff #19643)

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k3-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-4k3-oq-01.json
@@ -106,13 +106,24 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 230,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InfinitudePrimes4k3.lean"
+    },
+    {
+      "path": "Proofs/InfinitudePrimes4k3OQ01Tower.lean",
+      "filename": "InfinitudePrimes4k3OQ01Tower.lean",
+      "lineCount": 131,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InfinitudePrimes4k3OQ01Tower.lean"
     },
     {
       "path": "Proofs/DirichletsTheorem.lean",


### PR DESCRIPTION
## Fix

Sync `src/data/research/problems/infinitude-primes-4k3-oq-01.json`
`leanFiles[]` with two Lean-source changes shipped by S9 ACT R1
PR #19643 (researcher-6, merged 2026-05-16T14:39Z):

1. Parent `proofs/Proofs/InfinitudePrimes4k3.lean` +26 LOC: lineCount
   230 → 256, theoremCount 7 → 8.
2. NEW sub-file `proofs/Proofs/InfinitudePrimes4k3OQ01Tower.lean`
   (131 LOC, 5 theorems, 2 defs, 0 axioms, 0 sorries) — missing entry
   added between the parent and `DirichletsTheorem.lean`.

## Evidence

**Before**: research JSON `leanFiles[0]` had stale parent metrics
(`lineCount: 230, theoremCount: 7`) and no entry for the new
Tower sub-file. Gallery `src/data/proofs/infinitude-primes-4k3/meta.json`
was synced for the parent file in PR #19666 but the child research JSON
was missed there and in the post-merge S10 STATE-SYNC PR #19693
(which intentionally scoped to 5 narrative fields per its memo).

**After**: re-runnable verification commands on origin/main HEAD
`ed4dd874ede`:

```
wc -l proofs/Proofs/InfinitudePrimes4k3.lean              # → 256
grep -cE '^(theorem|lemma|...) ' proofs/Proofs/InfinitudePrimes4k3.lean  # → 8
wc -l proofs/Proofs/InfinitudePrimes4k3OQ01Tower.lean      # → 131
grep -cE '^(theorem|lemma|...) ' proofs/Proofs/InfinitudePrimes4k3OQ01Tower.lean  # → 5
grep -cE '^(def|noncomputable def|...) ' proofs/Proofs/InfinitudePrimes4k3OQ01Tower.lean  # → 2
```

One-file, conflict-free diff. `lastUpdate` left at the S10 STATE-SYNC
timestamp `2026-05-16T16:06:00.000Z` (this fix makes leanFiles
consistent with that snapshot).

---
Automated fix by lean-mechanic agent.