### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 leanFiles drift on SchauderFixedPointOQ03OQ01.lean

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
@@ -93,9 +93,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json`
`leanFiles[]` entry for `Proofs/SchauderFixedPointOQ03OQ01.lean`:

- `lineCount`: 218 → 1284
- `theoremCount`: 2 → 7
- `axiomCount`: 3 → 2
- `defCount` (4) and `sorryCount` (3) unchanged.

## Evidence

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
    1284 proofs/Proofs/SchauderFixedPointOQ03OQ01.lean

$ grep -cE "^(theorem|lemma) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
7

$ grep -cE "^axiom " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
2

$ jq '.leanFiles[] | select(.filename=="SchauderFixedPointOQ03OQ01.lean")' \
    src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
{
  "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
  "filename": "SchauderFixedPointOQ03OQ01.lean",
  "lineCount": 218,
  "theoremCount": 2,
  "axiomCount": 3,
  ...
}
```

**Before**: `lineCount: 218, theoremCount: 2, axiomCount: 3`.
**After**: `lineCount: 1284, theoremCount: 7, axiomCount: 2`.

## Drift cause

Drift accumulated across the S2 → S22 ACT chain on
`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`. Most recently, S22 ACT
PR #19671 added the private helper `exists_nearest_in_image_F` (+51 LOC,
+1 lemma) under the *build pending — Docker daemon hung* qualifier; that
PR did not edit the parent slug's `leanFiles[]` (the actor slug
`schauder-fixed-point-oq-03-oq-01-incomplete-01` carries `leanFiles: null`).

Verification SHA: `origin/main` at `ed4dd874ede` (Mathlib pin v4.26.0,
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).

## Convention notes

- `lineCount` uses `wc -l` (matches gallery `meta.json` + recent mechanic
  precedents #19663 / #19667 / #19670). The enricher script uses
  `content.split('\n').length` (= `wc -l + 1`); manual fixes use the
  gallery-aligned `wc -l` value per memory-feedback convention.
- `theoremCount` uses the `enrich-research.ts` regex `^(theorem|lemma) `
  (private/protected/noncomputable variants intentionally excluded).
- `sorryCount` uses `\bsorry\b` word-boundary match (catches occurrences
  in comments too, hence 3 even though there are 0 actual `sorry`
  tactics).

## Out of scope

Sibling `leanFiles[]` entries in this slug for `SchauderFixedPoint.lean`,
`SchauderFixedPointOQ01.lean`, and `SchauderFixedPointOQ03.lean` carry
the systematic `split('\n').length` vs `wc -l` off-by-one drift
(-1 LOC each) that is orthogonal to S22 ACT and out of scope.

---
Automated fix by lean-mechanic agent.