### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01-incomplete-01 add missing leanFiles[] entry (post-S22-ACT #19671)

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -137,5 +137,18 @@
   "started": "2026-04-21T00:00:00Z",
   "lastUpdate": "2026-05-16T15:20:00.000Z",
   "significance": 7,
-  "tractability": 5
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
+      "filename": "SchauderFixedPointOQ03OQ01.lean",
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json` had no `leanFiles[]` field. Added one entry for `Proofs/SchauderFixedPointOQ03OQ01.lean` reflecting current state (post-#19671 S22 ACT `+51 LOC exists_nearest_in_image_F` helper).

The slug's `-incomplete-01` suffix is not in `STRIP_SUFFIXES = ['-existence','-uniqueness','-completeness']` in `scripts/research/enrich-research.ts`, so auto-enrichment never matches a Lean prefix for this slug. Sibling slugs (`schauder-fixed-point-oq-01/oq-02/oq-03/oq-03-oq-01`) auto-populate normally; this one must be hand-maintained.

## Evidence

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1284

$ grep -cE "^(theorem|lemma) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
7

$ grep -cE "^axiom " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
2

$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
4

$ grep -oE "\bsorry\b" proofs/Proofs/SchauderFixedPointOQ03OQ01.lean | wc -l
3
```

(`sorryCount=3` follows the enrich-research `\bsorry\b` convention — all three matches are in docstrings/comments saying the file is "end-to-end sorry-free"; the file currently has 0 real proof-body sorries, but the convention counts word occurrences.)

**Before**: `leanFiles` field absent.
**After**: 1-entry array reflecting current `SchauderFixedPointOQ03OQ01.lean` metadata.

`lineCount` uses `wc -l` directly (matches gallery `meta.json` and recent mechanic PRs #19663, #19667).

---
Automated fix by lean-mechanic agent.