### PR TITLE
fix(meta): ballot-problem-oq-02-oq-05 leanFiles drift post-S6-ACT (handoff #19675)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-02-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-05.json
@@ -144,11 +144,11 @@
   "leanFiles": [
     {
       "path": "proofs/Proofs/BallotProblemOQ02OQ05.lean",
-      "lineCount": 130,
+      "lineCount": 229,
       "axiomCount": 1,
-      "sorryCount": 0,
-      "theoremCount": 0,
-      "defCount": 3,
+      "sorryCount": 4,
+      "theoremCount": 4,
+      "defCount": 7,
       "addedInIteration": 2
     }
   ],


### PR DESCRIPTION
## Fix

Absorb S6 ACT (#19675, merged 2026-05-16T16:20:58Z) into the canonical research JSON's `leanFiles[0]` entry for `proofs/Proofs/BallotProblemOQ02OQ05.lean`. PR #19675 pasted S5 PREP §5's ~99-LOC `section DiscreteReflection` skeleton verbatim into the leaf file and explicitly deferred meta updates ("No S5 design PREP / S6a-c ACT / meta.json updates / leanFiles[] edits — separate iterations").

## Evidence

**Before** (post-#19699 baseline, pre-#19675):
```json
{
  "path": "proofs/Proofs/BallotProblemOQ02OQ05.lean",
  "lineCount": 130, "axiomCount": 1, "sorryCount": 0,
  "theoremCount": 0, "defCount": 3, "addedInIteration": 2
}
```

**After** (this PR):
```json
{
  "path": "proofs/Proofs/BallotProblemOQ02OQ05.lean",
  "lineCount": 229, "axiomCount": 1, "sorryCount": 4,
  "theoremCount": 4, "defCount": 7, "addedInIteration": 2
}
```

| Field | Before | After | Source |
|---|---|---|---|
| lineCount | 130 | 229 | `wc -l` (S6 ACT +99 LOC) |
| sorryCount | 0 | 4 | tactic sites lines 185/196/206/225 (R4/R5/LOW/R6) |
| theoremCount | 0 | 4 | 3 lemmas + 1 theorem (`reflectAt_involutive`, `partialSumBool_reflectAt_endpoint`, `reaches_iff_hits_or_above`, `discrete_reflection`) |
| defCount | 3 | 7 | +`partialSumBool`, +`hitSet`, +`firstHitFin` (noncomputable), +`reflectAt` |
| axiomCount | 1 | 1 | `donsker_fclt` unchanged |

Re-runnable verification on origin/main:
```bash
wc -l proofs/Proofs/BallotProblemOQ02OQ05.lean                                       # → 229
grep -cE "^axiom "                       proofs/Proofs/BallotProblemOQ02OQ05.lean    # → 1
grep -cE "^theorem |^lemma "             proofs/Proofs/BallotProblemOQ02OQ05.lean    # → 4
grep -cE "^def |^noncomputable def "     proofs/Proofs/BallotProblemOQ02OQ05.lean    # → 7
grep -nE "(^|[^A-Za-z_'])sorry([^A-Za-z_'])" proofs/Proofs/BallotProblemOQ02OQ05.lean
# → 6 matches, of which 4 are tactic sites (lines 185, 196, 206, 225) and 2 are
#   comment/docstring mentions (lines 39 "sorry-free" + 134 `sorry`s); use the
#   comment-stripped count of 4 per #19669 convention.
```

Closes the leanFiles[] drift acknowledged by #19675's "Out of scope" §.

## Scope

- 1 file, 4 insertions, 4 deletions (single `leanFiles[0]` entry refresh).
- No Lean source edits.
- No `pnpm build` (would regenerate ~1047 research JSONs per memory feedback).
- No state.md / problem.md / knowledge.md / sibling-slug / lake-manifest edits.
- No gallery `meta.json` edits (this is an OQ-class slug; no `src/data/proofs/ballot-problem-oq-02-oq-05/` directory).

---
Automated fix by lean-mechanic agent.