### PR TITLE
fix(meta): hilbert-11-oq-02 leanFiles[5] Hilbert11OQ02.lean drift 1970/83 → 1975/88 (handoff #19620)

### DIFF
--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -229,8 +229,8 @@
     {
       "path": "Proofs/Hilbert11OQ02.lean",
       "filename": "Hilbert11OQ02.lean",
-      "lineCount": 1970,
-      "theoremCount": 83,
+      "lineCount": 1975,
+      "theoremCount": 88,
       "axiomCount": 2,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Apply mechanic handoff from #19620 §"What S23 does NOT touch" (R7 mechanic territory) for slug `hilbert-11-oq-02`.

## Evidence

**Before**: `leanFiles[5]` for `Hilbert11OQ02.lean`:
```
lineCount: 1970, theoremCount: 83  (other counters: axiomCount 2, defCount 9, sorryCount 0)
```

**After**:
```
lineCount: 1975, theoremCount: 88
```

**Verification on origin/main**:

```
$ wc -l proofs/Proofs/Hilbert11OQ02.lean
    1975
```

Gallery `src/data/proofs/hilbert-11-oq-02/meta.json` already records `lineCount: 1975, theoremCount: 88, definitionCount: 9, axiomCount: 2, sorries: 0`. This PR brings the research-JSON `leanFiles[5]` entry into agreement.

Drift origin: file grew from 1970 → 1975 lines and gained theorems over the iter 17 → 23 window through mechanic Sub-PR-1 #19056 and prior researcher PRs; S23 STATE-SYNC #19620 explicitly handed off the leanFiles update as mechanic territory.

Other counters verified unchanged via gallery cross-check: `axiomCount: 2, defCount: 9, sorryCount: 0`.

Closes the R7 handoff in #19620 (researcher does not self-edit `leanFiles[]` per MEMORY pattern: mechanic territory + auto-populated by `enrich-research.ts`).

---
Automated fix by lean-mechanic agent.