### PR TITLE
fix(meta): brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02 add missing leanFiles[] entry for G6 (handoff #19646)

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -216,6 +216,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02G6.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02G6.lean",
+      "lineCount": 87,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean"
+    },
+    {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02G7.lean",
       "filename": "BrouwerFixedPointOQ01OQ02G7.lean",
       "lineCount": 94,


### PR DESCRIPTION
## Fix

Add the `Proofs/BrouwerFixedPointOQ01OQ02G6.lean` entry to `leanFiles[]` in the brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02 research JSON. The G6 companion file was created by S13 ACT #19624 (+87 LOC, 5 thms, 0 sorries, 0 axioms); the follow-on S14 STATE-SYNC #19646 self-described as **"0 leanFiles modified"** and deferred the JSON-side leanFiles[] addition to mechanic territory.

## Evidence

**Before**: 19 entries; no `BrouwerFixedPointOQ01OQ02G6.lean` row despite the file existing on `main` and being highlighted in S14's `knowledge.builtItems` append.

**After**: 20 entries; new row inserted at index 3 (between parent `BrouwerFixedPointOQ01OQ02.lean` and sibling `BrouwerFixedPointOQ01OQ02G7.lean`), field order matching G7/G8 convention.

```
$ wc -l proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean
      87
$ grep -cE '^theorem |^lemma ' proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean
5
$ grep -cE '^def ' proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean
0
$ grep -cE 'sorry' proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean
0
$ grep -cE '^axiom ' proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean
0
```

```diff
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02G6.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02G6.lean",
+      "lineCount": 87,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02G6.lean"
+    },
```

## Scope

- **Only** the missing G6 entry per the #19646 handoff (minimal-diff, +11 / -0).
- **Does not** touch any other `leanFiles[]` entries. The parent `BrouwerFixedPointOQ01OQ02.lean` shows separate older drift (JSON L=295, T=12, A=1 vs actual L=462, T=14, D=2, A=4) shared across many sibling slugs; that is broader cross-slug territory and out of scope here.
- **Does not** touch `currentState` / `knowledge` / `state.md` / `sessions/` / `meta.json` / `knowledge.md` / gallery / any Lean file.

## Validation

- `python3 -c "import json; json.load(open('src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json'))"` → JSON OK
- `pnpm build` deliberately skipped per memory pattern `feedback_mechanic_pnpm_build_regenerates_all_research_jsons.md` (would regenerate ~1047 research JSONs and clobber single-slug targeted edits).

Refs: S14 STATE-SYNC #19646; S13 ACT #19624.

---
Automated fix by lean-mechanic agent.