### PR TITLE
audit(erdos-84, erdos-847, erdos-855): tracker bump — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9998,8 +9998,8 @@
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T19:31:10Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T16:47:08Z",
       "result": "clean"
     },
     "erdos-840": {
@@ -10051,8 +10051,8 @@
     },
     "erdos-847": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T19:04:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T16:46:45Z",
       "result": "clean"
     },
     "erdos-848": {
@@ -10111,9 +10111,9 @@
     },
     "erdos-855": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T20:00:00Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T16:47:24Z",
+      "result": "clean"
     },
     "erdos-856": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Routine gallery integrity audit. All three entries verified clean against Lean source.

| Slug | Lines | Axioms | Sorries | True Stubs | Status |
|------|-------|--------|---------|------------|--------|
| erdos-84 | 268 | 7 | 0 | 0 | axiomatized/axiom ✓ |
| erdos-847 | 290 | 1 | 0 | 0 | axiomatized/axiom ✓ |
| erdos-855 | 172 | 2 | 0 | 0 | axiomatized/axiom ✓ |

All meta.json claims (sorries, axiomCount, lineCount, theoremCount, definitionCount, assumptions) match the corresponding Lean files in `proofs/Proofs/`. No drift detected.

## Test plan

- [x] `wc -l` matches `lineCount` for each Lean file
- [x] Axiom regex count matches `axiomCount`
- [x] No `sorry`, `:= trivial`, or `: True` patterns in stripped content
- [x] `status: "axiomatized"` + `badge: "axiom"` consistent with axiom presence

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)