### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ02Helpers.lean leanFiles in 20 ballot-problem siblings

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -297,11 +297,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -314,11 +314,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -298,11 +298,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -301,11 +301,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -290,11 +290,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -348,11 +348,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -320,11 +320,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -304,11 +304,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -293,11 +293,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -289,11 +289,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -294,11 +294,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -295,11 +295,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -300,11 +300,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -317,11 +317,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -301,11 +301,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -300,11 +300,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -292,11 +292,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -292,11 +292,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 13899,
-      "theoremCount": 78,
+      "lineCount": 15996,
+      "theoremCount": 79,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 5,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[]` entry for `Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` across **20 sibling research JSONs** in the `ballot-problem-*` family.

```
lineCount    13899 -> 15996
theoremCount    78 ->    79
sorryCount       5 ->     9
```

`axiomCount` (0) and `defCount` (15) unchanged — already correct.

## Evidence

- `wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` → **15995** (split('\n').length convention = **15996** per `scripts/research/enrich-research.ts:174`)
- `grep -cE '^(theorem|lemma) '` → **79**
- `grep -cE '\bsorry\b'` → **9** (enrich-research convention counts word occurrences including comment docstrings)
- `grep -cE '^axiom '` → **0**
- `grep -cE '^(def|noncomputable def|opaque def) '` → **15**
- Canonical slug `ballot-problem-oq-03-oq-01-oq-02` already has the correct values at idx=23:
  ```
  lineCount: 15996, theoremCount: 79, axiomCount: 0, defCount: 15, sorryCount: 9
  ```

## Affected slugs (20)

| slug | path | old | new |
|---|---|---:|---:|
| `ballot-problem-oq-01` | `BallotProblemOQ03OQ01OQ02Helpers.lean` | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-01-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-01-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-02-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-02-oq-01-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-02-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-04` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-01-oq-04-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-02-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03-oq-01-oq-01` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03-oq-01-oq-04` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03-oq-02` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-03-oq-03` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-04` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |
| `ballot-problem-oq-05` | same | 13899 / 78 / 5 | 15996 / 79 / 9 |

20 files × 3 lines each = **60 insertions / 60 deletions**.

## Scope discipline

- Targeted regex on the matching `leanFiles[i]` entry; preserves original encoding and key ordering. All 20 JSONs validated with `python3 -m json.tool`.
- Excluded:
  - `ballot-problem-oq-03-oq-01-oq-02` — canonical, already correct (idx=23)
  - `ballot-problem-oq-01-oq-01-oq-02-oq-01`, `ballot-problem-oq-03-oq-01-oq-01-oq-01` — already up-to-date with target values
  - `ballot-problem-oq-01-incomplete-01`, `ballot-problem-oq-01-oq-01-wip-01`, `ballot-problem-oq-03-oq-01-oq-02-incomplete-01`, `ballot-problem-oq-02-oq-05` — no helper entry in `leanFiles[]`

Scope mirrors mechanic batch precedent #19701 (birthday-problem, 11 entries) and #19685 (basel-problem, 13 entries).

---
Automated fix by lean-mechanic agent.