### PR TITLE
fix(meta): shannon-channel-coding-oq-02-oq-01-oq-01 leanFiles[0] post-S18a-1 drift (#19655)

### DIFF
--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -109,10 +109,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 532,
+      "lineCount": 555,
       "theoremCount": 16,
       "axiomCount": 3,
-      "defCount": 5,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json` `leanFiles[0]` block reflected the pre-S18a-1 shape of `ShannonChannelCoding.lean`. S18a-1 ACT (#19655, merged 2026-05-16T15:19:54Z) added `def DMChannel.IsWeaklySymmetric` (+23 LOC, +1 def). This PR brings the structured block into agreement.

## Evidence

**Before**:

```json
{
  "path": "Proofs/ShannonChannelCoding.lean",
  "lineCount": 532,
  "defCount": 5,
  ...
}
```

**After**:

```json
{
  "path": "Proofs/ShannonChannelCoding.lean",
  "lineCount": 555,
  "defCount": 6,
  ...
}
```

Counts verified at `origin/main` HEAD (`ed4dd874ede`):

```
$ F=proofs/Proofs/ShannonChannelCoding.lean
$ wc -l "$F"                                              # 555
$ grep -cE '^(theorem|lemma) ' "$F"                       # 16 (unchanged)
$ grep -cE '^axiom ' "$F"                                 # 3  (unchanged)
$ grep -cE '^(def|noncomputable def|opaque def) ' "$F"    # 6
$ grep -cE '\bsorry\b' "$F"                               # 0  (unchanged)
```

The JSON's own `currentState.focus` and `knowledge.progressSummary` already narrate the 532→555 LOC growth from S18a-1 (\"New file LOC 532 → 555 (+23 LOC, all docstring + def body + section header + blank lines)\"); this PR brings the `leanFiles[]` block into agreement with that narrative.

Convention: `wc -l` (matches gallery meta.json + recent mechanic PRs #19663, #19667, #19670).

## Out of scope

Other `leanFiles[]` entries on this slug have off-by-one drifts (`OQ02.lineCount: 298 → 297`, `OQ02OQ03.lineCount: 163 → 162`, etc.) that match the classic `split('\n').length` vs `wc -l` enricher convention split, and a larger OQ02OQ01 drift (`lineCount: 182 → 312`, `theoremCount: 3 → 6`) unrelated to S18a-1. Those merit separate scoped PRs; this PR is the minimum-needed post-#19655 sync.

---
Automated fix by lean-mechanic agent.