### PR TITLE
fix(meta): erdos-735-oq-04 add missing leanFiles[] entry (post-S3-ACT #19687)

### DIFF
--- a/src/data/research/problems/erdos-735-oq-04.json
+++ b/src/data/research/problems/erdos-735-oq-04.json
@@ -84,5 +84,18 @@
   "significance": 6,
   "tractability": 5,
   "lastUpdated": "2026-05-13T23:55:00.000Z",
-  "lastUpdate": "2026-05-16T15:55:00.000Z"
+  "lastUpdate": "2026-05-16T15:55:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos735OQ04.lean",
+      "filename": "Erdos735OQ04.lean",
+      "lineCount": 153,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos735OQ04.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Fix

Adds the missing `leanFiles[]` entry for `Proofs/Erdos735OQ04.lean` to the research JSON `src/data/research/problems/erdos-735-oq-04.json`.

## Evidence

**Before**: `leanFiles` key absent from JSON entirely.

**After**: single entry reflecting current file state after S3 ACT (PR #19687):

```json
{
  "path": "Proofs/Erdos735OQ04.lean",
  "filename": "Erdos735OQ04.lean",
  "lineCount": 153,
  "theoremCount": 2,
  "axiomCount": 0,
  "defCount": 5,
  "sorryCount": 0,
  "isAristotle": false,
  "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos735OQ04.lean"
}
```

## Verification

```
$ wc -l proofs/Proofs/Erdos735OQ04.lean
     153
$ grep -cE "^(theorem|lemma) " proofs/Proofs/Erdos735OQ04.lean
2
$ grep -cE "^(def|noncomputable def|abbrev) " proofs/Proofs/Erdos735OQ04.lean
5
$ grep -cE "^axiom " proofs/Proofs/Erdos735OQ04.lean
0
```

Real sorry count is 0 (the single `sorry` grep hit at L15 is inside a `/-` docstring describing pre-S3 state).

## Context

Sibling-precedent: PR #19670 added 2 missing `leanFiles[]` entries for `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01` following an analogous mechanic-handoff pattern. PR #19669 (`binomial-theorem-...-oq-01`) added a missing leaf entry post-ACT. This PR follows the same pattern for `erdos-735-oq-04` post-S3 ACT.

---
Automated fix by lean-mechanic agent.