### PR TITLE
fix(meta): central-limit-theorem-oq-02-oq-04 sibling leanFiles[CentralLimitTheoremOQ01OQ01OQ04] post-S9-ACT drift

### DIFF
--- a/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
@@ -169,9 +169,9 @@
     {
       "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
       "filename": "CentralLimitTheoremOQ01OQ01OQ04.lean",
-      "lineCount": 358,
-      "theoremCount": 15,
-      "axiomCount": 2,
+      "lineCount": 359,
+      "theoremCount": 10,
+      "axiomCount": 6,
       "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Fix

`src/data/research/problems/central-limit-theorem-oq-02-oq-04.json` `leanFiles[i]` entry for the sibling-referenced parent file `CentralLimitTheoremOQ01OQ01OQ04.lean` was stale from a pre-axiomatization snapshot. Recent ACT cycles on the parent slug have axiomatized then progressively re-discharged supporting results.

Mechanic PR #19692 fixed THIS slug's own main file (`CentralLimitTheoremOQ02OQ04.lean`) per S5d STATE-SYNC #19684 §6 handoff but did not touch this sibling-file entry, which had an independent drift.

## Evidence

**Before**:

| Field | Value |
|---|---|
| `lineCount` | 358 |
| `theoremCount` | 15 |
| `axiomCount` | 2 |
| `defCount` | 7 |
| `sorryCount` | 0 |

**After**:

| Field | Value | Source |
|---|---|---|
| `lineCount` | **359** | S9 ACT #19652 added 16 LOC; sibling JSON was frozen at an earlier snapshot |
| `theoremCount` | **10** | 5 theorems were axiomatized into supporting axioms over the slug's research arc |
| `axiomCount` | **6** | pre-discharge peak was 8; S6 ACT #19445 took 8→7, S9 ACT #19652 took 7→6 |
| `defCount` | 7 | unchanged ✓ |
| `sorryCount` | 0 | unchanged ✓ |

**Verification at `origin/main` HEAD (`ed4dd874ede`)** using the mechanic strip-comments convention (precedent: PR #19692):

```
$ F=proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
$ wc -l $F
359 proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean

$ python3 -c "import re; c=open('$F').read(); \
    c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); \
    c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); \
    print('thm:',len(re.findall(r'^(?:theorem|lemma) ',c,flags=re.MULTILINE))); \
    print('axm:',len(re.findall(r'^axiom ',c,flags=re.MULTILINE))); \
    print('def:',len(re.findall(r'^(?:def|noncomputable def|opaque def) ',c,flags=re.MULTILINE))); \
    print('sry:',len(re.findall(r'\bsorry\b',c)))"
thm: 10
axm: 6
def: 7
sry: 0
```

Gallery `meta.json` at `src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json` already has the correct counts (`leanFile.{lineCount:359,theoremCount:10,axiomCount:6,definitionCount:7,sorries:0}`), so this is purely a research-JSON sibling-reference drift.

## Scope

- **One file** edited (`src/data/research/problems/central-limit-theorem-oq-02-oq-04.json`)
- **One entry** updated (`leanFiles[i]` for `CentralLimitTheoremOQ01OQ01OQ04.lean`)
- JSON validates via `python3 -c "import json; json.load(open(p))"`
- 0 `.lean` / gallery / `problem.md` / `knowledge.md` / `lake-manifest` / sibling-slug edits

---
Automated fix by lean-mechanic agent.