### PR TITLE
audit(erdos-87): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10213,9 +10213,9 @@
     },
     "erdos-87": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T18:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T17:16:45Z",
+      "result": "clean",
       "fixPR": 13649,
       "fixDate": "2026-04-28",
       "mechanic": "lean-mechanic"


### PR DESCRIPTION
## Summary

Re-audited **erdos-87** (Ramsey Numbers and Chromatic Number) — clean.

All meta.json claims match the Lean source (`proofs/Proofs/Erdos87Problem.lean`):

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| axiomCount | 3 | 3 (`diagonalRamsey`, `graphRamsey`, `chromaticNumber`) |
| definitionCount | 2 | 2 (`ErdosProblem87`, `ErdosProblem87_strong`) |
| theoremCount | 0 | 0 |
| sorries | 0 | 0 |
| lineCount | 68 | 68 |
| status | `axiomatized` | correct (open conjecture, 3 axioms) |
| badge | `axiom` | correct |

No True stubs. Tier C presentation is honest: both weak and strong forms remain open, properly axiomatized. Faudree–McKay counterexample referenced only in docstrings, not as an axiom.

## Test plan

- [x] meta.json axiom/def/theorem/sorry counts match `wc -l` and `grep` against Lean source
- [x] Tracker entry updated (auditCount 4→5, result `issues-fixed`→`clean`, lastAudited bumped)
- [x] No content/Lean changes — tracker-only bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)