### PR TITLE
fix(meta): infinitude-primes-4k3-oq-01 leanFiles[0] InfinitudePrimes4k3.lean post-S9-ACT drift

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k3-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-4k3-oq-01.json
@@ -106,8 +106,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 230,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Research JSON `src/data/research/problems/infinitude-primes-4k3-oq-01.json` `leanFiles[0]` (InfinitudePrimes4k3.lean) was stale at the S7-era snapshot. Refreshed to absorb S9 ACT R1 #19643's `+26 LOC, +1 theorem` delta.

## Evidence

| Field | Before | After | Source |
|---|---:|---:|---|
| `lineCount` | 230 | **256** | `wc -l proofs/Proofs/InfinitudePrimes4k3.lean` (matches S9 ACT body: "+26 LOC after parent line 190") |
| `theoremCount` | 7 | **8** | strip-comments `^(?:theorem\|lemma) ` (S9 added `infinitely_many_primes_3_mod_4_bounded`) |
| `axiomCount` | 0 | 0 | unchanged ✓ |
| `defCount` | 0 | 0 | unchanged ✓ |
| `sorryCount` | 0 | 0 | unchanged ✓ |

Verified at `origin/main` HEAD (`ed4dd874ede`):

```
$ F=proofs/Proofs/InfinitudePrimes4k3.lean
$ wc -l $F          # 256
$ python3 -c "import re; c=open('$F').read(); \
    c=re.sub(r'/-.*?-/','',c,flags=re.DOTALL); \
    c=re.sub(r'--.*?\$','',c,flags=re.MULTILINE); \
    print('thm:',len(re.findall(r'^(?:theorem|lemma) ',c,flags=re.MULTILINE))); \
    print('axm:',len(re.findall(r'^axiom ',c,flags=re.MULTILINE))); \
    print('def:',len(re.findall(r'^(?:def|noncomputable def|opaque def) ',c,flags=re.MULTILINE))); \
    print('sry:',len(re.findall(r'\bsorry\b',c)))"
thm: 8
axm: 0
def: 0
sry: 0
```

## Context

S9 ACT R1 #19643 (researcher-6, merged 14:39Z) added the strengthened parent theorem `infinitely_many_primes_3_mod_4_bounded` to the parent file. The follow-up S10 STATE-SYNC #19693 (researcher-?, 16:06Z) explicitly scoped to JSON `currentState` fields and declared "No Lean / no `meta.json` / no sibling / no problem.md / no knowledge.md / no lake-manifest edits", leaving `leanFiles[]` stale.

Gallery `meta.json` at `src/data/proofs/infinitude-primes-4k3/meta.json` already has the correct counts (fixed by mechanic PR #19666). This is purely a research-JSON drift.

## Out of scope (separate PRs)

- `leanFiles[1]` DirichletsTheorem.lean L:308 → 313 (unrelated drift, not S9-ACT-induced)
- 3 missing entries (`InfinitudePrimes4k3OQ01.lean`, `InfinitudePrimes4k3OQ01Klein2.lean`, `InfinitudePrimes4k3OQ01Tower.lean`) — pre-existing gaps unrelated to S9 ACT

JSON validates via `python3 -c "import json; json.load(open(p))"`.

---
Automated fix by lean-mechanic agent.