### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 add missing leanFiles[] entry for BinaryGcdOQ03OQ02PathA.lean (post-S47-ACT #19702)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -302,6 +302,17 @@
       "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03OQ02PathA.lean",
+      "filename": "BinaryGcdOQ03OQ02PathA.lean",
+      "lineCount": 3140,
+      "theoremCount": 83,
+      "axiomCount": 0,
+      "defCount": 16,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Adds the missing `leanFiles[]` entry for `Proofs/BinaryGcdOQ03OQ02PathA.lean` to the canonical research JSON `src/data/research/problems/binary-gcd-oq-03-oq-02.json`.

## Evidence

**Before**: `leanFiles[]` had 7 entries; `BinaryGcdOQ03OQ02PathA.lean` was absent.

**After**: 8 entries; new entry reflects file state after S47 ACT (PR #19702, +118 LOC → 3140 LOC, +3 theorems → 83):

```json
{
  "path": "Proofs/BinaryGcdOQ03OQ02PathA.lean",
  "filename": "BinaryGcdOQ03OQ02PathA.lean",
  "lineCount": 3140,
  "theoremCount": 83,
  "axiomCount": 0,
  "defCount": 16,
  "sorryCount": 0,
  "isAristotle": false,
  "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean"
}
```

## Verification

```
$ wc -l proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
     3140
$ grep -cE "^(theorem|lemma) " proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
83
$ grep -cE "^(def |noncomputable def |abbrev )" proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
16
$ grep -cE "^axiom " proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
0
```

Real sorry count is 0 (the single `sorry` token in the file at line 1617 is inside a `/-` docstring describing supporting-lemma posture, not a tactic).

## Context

The companion file `BinaryGcdOQ03OQ02PathA.lean` has existed since S18 (PR #17042, 2026-05-09) and is listed in the gallery `meta.json` `additionalFiles` array, but it was never added to the canonical research-JSON `leanFiles[]`. S47 ACT (PR #19702, merged 2026-05-16T17:21:17Z) made the omission more conspicuous (+118 LOC) so this PR adds the entry.

Sibling-precedent: PR #19717 (`erdos-735-oq-04`), PR #19670 (`cantor-diagonalization-oq-01-oq-01-oq-02-oq-01`), PR #19669 (`binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01`) added analogous missing `leanFiles[]` entries post-ACT.

Scope discipline: this PR only adds the missing entry. The pre-existing drift on `BinaryGcdOQ03OQ02.lean` (1759 → 2225 LOC, 54 → 63 thm) is older and out of scope for this fix.

---
Automated fix by lean-mechanic agent.