### PR TITLE
fix(mechanic): binary-gcd-oq-03-oq-02 leanFiles drift + add PathA entry (handoff #19702)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -295,13 +295,24 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1759,
-      "theoremCount": 54,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03OQ02PathA.lean",
+      "filename": "BinaryGcdOQ03OQ02PathA.lean",
+      "lineCount": 3140,
+      "theoremCount": 83,
+      "axiomCount": 0,
+      "defCount": 16,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean"
     }
   ]
 }


### PR DESCRIPTION
## Fix

S47 ACT (#19702) added `BinaryGcdOQ03OQ02PathA.lean` (3140 LOC, 83 thm, 0 sorries, 0 axioms) to the slug's file set but never registered it in the research JSON `leanFiles[]`. Adds the missing entry and corrects drift on the existing `BinaryGcdOQ03OQ02.lean` entry.

## Evidence

| File | Field | Before | After | Source |
|------|-------|-------:|-------:|--------|
| `BinaryGcdOQ03OQ02.lean` | `lineCount` | 1759 | **2225** | `wc -l` |
| `BinaryGcdOQ03OQ02.lean` | `theoremCount` | 54 | **63** | `^(theorem\|lemma) ` |
| `BinaryGcdOQ03OQ02PathA.lean` | (entire entry) | — | **+entry** | new file from S47 ACT |
|   | `lineCount` | — | 3140 | `wc -l` |
|   | `theoremCount` | — | 83 | `^(theorem\|lemma) ` |
|   | `defCount` | — | 16 | `^(def\|noncomputable def\|opaque def) ` |
|   | `axiomCount` | — | 0 | `^axiom ` |
|   | `sorryCount` | — | 0 | only `\bsorry\b` hit at line 1617 is the comment "sorry-free" |

Counts derived via `scripts/research/enrich-research.ts` conventions; `sorryCount` preserved at the actual-code count (the sole `\bsorry\b` match in PathA at line 1617 is a comment "sorry-free, independent…").

### Verification commands

```bash
wc -l proofs/Proofs/BinaryGcdOQ03OQ02.lean       # 2225
wc -l proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean  # 3140
grep -cE '^(theorem|lemma) ' proofs/Proofs/BinaryGcdOQ03OQ02.lean       # 63
grep -cE '^(theorem|lemma) ' proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean  # 83
grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean  # 16
python3 -c "import json; json.load(open('src/data/research/problems/binary-gcd-oq-03-oq-02.json'))"  # validates
```

## Scope

One file edited (`src/data/research/problems/binary-gcd-oq-03-oq-02.json`); no Lean source touched; no gallery `meta.json` (this slug has no `src/data/proofs/binary-gcd-oq-03-oq-02/` directory). No `lastUpdate` bump (mechanic territory does not edit the timestamp).

---

Automated fix by lean-mechanic agent.