### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ01OQ01.lean leanFiles in 20 ballot-problem siblings

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -253,11 +253,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -270,11 +270,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -254,11 +254,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -246,11 +246,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -304,11 +304,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -214,11 +214,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -276,11 +276,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -260,11 +260,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -249,11 +249,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -245,11 +245,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -250,11 +250,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -251,11 +251,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -256,11 +256,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -214,11 +214,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -273,11 +273,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -256,11 +256,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[16]` entry for `Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` across **20 sibling research JSONs** in the `ballot-problem-*` family. All 20 carry an identical template-time stale tuple; the underlying Lean file has grown substantially across the canonical slug's S2 -> S43 PREP chain.

```
lineCount    851 -> 2348  (+1497)
sorryCount     4 ->   17  (+13)
```

`theoremCount` (10), `axiomCount` (0), `defCount` (6) are unchanged in all 20 entries — already correct under the strict `enrich-research.ts` regex (`^(theorem|lemma) `).

## Evidence

- `wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` -> **2348**
- Authoritative gallery `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json`:
  - `lineCount: 2348`
  - `axiomCount: 0`
  - `sorries: 2` (gallery counts raw `sorry` tactics, distinct from research-JSON `\bsorry\b` regex which catches occurrences in comments too — hence 17)
- Strict enrich-research conventions on current file content:
  - `^(theorem|lemma) ` -> 10
  - `^axiom ` -> 0
  - `^(def |noncomputable def |opaque def |abbrev |structure |inductive |class ) ` -> 6
  - `\bsorry\b` -> 17

## Affected slugs (20)

All 20 entries had the identical stale tuple `(lineCount: 851, theoremCount: 10, axiomCount: 0, defCount: 6, sorryCount: 4)`:

| slug | leanFiles idx |
|---|---:|
| `ballot-problem-oq-01` | 16 |
| `ballot-problem-oq-01-oq-01` | 16 |
| `ballot-problem-oq-01-oq-01-oq-01` | 16 |
| `ballot-problem-oq-01-oq-01-oq-02` | 16 |
| `ballot-problem-oq-01-oq-02` | 16 |
| `ballot-problem-oq-01-oq-02-oq-01` | 16 |
| `ballot-problem-oq-01-oq-02-oq-01-oq-02` | 16 |
| `ballot-problem-oq-01-oq-02-oq-02` | 16 |
| `ballot-problem-oq-01-oq-04` | 16 |
| `ballot-problem-oq-01-oq-04-oq-01` | 16 |
| `ballot-problem-oq-02` | 16 |
| `ballot-problem-oq-02-oq-02` | 16 |
| `ballot-problem-oq-03` | 16 |
| `ballot-problem-oq-03-oq-01` | 16 |
| `ballot-problem-oq-03-oq-01-oq-01` | 16 |
| `ballot-problem-oq-03-oq-01-oq-04` | 16 |
| `ballot-problem-oq-03-oq-02` | 16 |
| `ballot-problem-oq-03-oq-03` | 16 |
| `ballot-problem-oq-04` | 16 |
| `ballot-problem-oq-05` | 16 |

20 files × 2 lines each = **40 insertions / 40 deletions**.

## Scope discipline

- Targeted text replacement on the 6-line `filename`/`lineCount`/`theoremCount`/`axiomCount`/`defCount`/`sorryCount` block; preserves key ordering, indentation, and Unicode encoding.
- Excluded siblings (kept as-is):
  - `ballot-problem-oq-03-oq-01-oq-01-oq-01` (canonical) — already at `(2349, 10, 0, 6, 17)` (enricher-set, off-by-one `wc-l + 1` artifact)
  - `ballot-problem-oq-01-oq-01-oq-02-oq-01`, `ballot-problem-oq-01-oq-02-oq-01-oq-01`, `ballot-problem-oq-03-oq-01-oq-02` — same enricher-set off-by-one; orthogonal scope
- Out of scope: other `leanFiles[]` drift in these JSONs (e.g. `BallotProblemOQ03OQ01OQ02Aristotle.lean` +3, `BallotProblemOQ03OQ02.lean` +20) — separate root causes.

## Safety

- `gh pr list --search "ballot in:title is:open"` returned 5 hits at submission; none of their `files[]` overlap with the 20 modified slug JSONs:
  - #17680/#17884/#17892 — canonical slug S34/S39/S40 stack (touch the underlying Lean file plus canonical slug's gallery `meta.json` and canonical research JSON only — disjoint from the 20)
  - #19015 — `ballot-problem-oq-01-oq-01-oq-02-oq-01` (one of the excluded current-tuple siblings)
  - #19065 — `ballot-problem-oq-02-oq-05` (not in family branch covered here)
- JSON parse-validated for all 20 files post-write.
- Mirrors mechanic batch precedents #19701 (birthday-problem, 11 entries), #19685 (basel-problem, 13 entries), #19664 (angle-trisection-cos-20-gal, 5 entries).

---
Automated batch repair by lean-mechanic agent.