### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ01OQ01.lean leanFiles in 20 ballot-problem siblings

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -253,11 +253,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -270,11 +270,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -254,11 +254,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -246,11 +246,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -304,11 +304,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -214,11 +214,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -276,11 +276,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -260,11 +260,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -249,11 +249,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -245,11 +245,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -250,11 +250,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -251,11 +251,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -256,11 +256,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -214,11 +214,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -273,11 +273,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -256,11 +256,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
+      "lineCount": 2348,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 17,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[16]` entry for `Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` across **20 sibling research JSONs** in the `ballot-problem-*` family. This file has grown substantially (851 → 2348 LOC, +1497) and the canonical slug's own JSON was updated incrementally (currently records 2349/17), but 20 sibling JSONs still hold pre-S{N} values.

```
lineCount    851 -> 2348   (wc -l)
sorryCount     4 -> 17     (actual sorry tactic sites)
```

`theoremCount` (10), `defCount` (6), `axiomCount` (0) unchanged — already correct.

## Evidence

- `wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` → **2348**
- `grep -cE "\bsorry\b" proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` → **17**
- `grep -cE "^(theorem|lemma) " proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` → **10** (unchanged)
- `grep -cE "^(noncomputable )?def " proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` → **6** (unchanged)
- `grep -cE "^axiom " proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` → **0** (unchanged)
- Canonical slug `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` records 2349/10/6/17/0 (off-by-one lineCount artifact from `split('\n').length` convention).

## Affected slugs (20)

All currently at 851/4 → 2348/17:

| slug | path | old (lc/sorry) | new |
|---|---|---:|---:|
| ballot-problem-oq-01-oq-01-oq-01 | `BallotProblemOQ03OQ01OQ01OQ01.lean` | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-01-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-02-oq-01-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-02-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-02-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-04-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01-oq-04 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-02-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03-oq-01-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03-oq-01-oq-04 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03-oq-01 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03-oq-02 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03-oq-03 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-03 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-04 | same | 851 / 4 | 2348 / 17 |
| ballot-problem-oq-05 | same | 851 / 4 | 2348 / 17 |

20 files × 2 lines each = **40 insertions / 40 deletions**.

## Excluded (3 already-up-to-date entries)

These 3 sibling JSONs already record 2349/17 (off-by-one in lineCount only, otherwise current):
- `ballot-problem-oq-03-oq-01-oq-01-oq-01` (canonical owner of the file)
- `ballot-problem-oq-01-oq-01-oq-02-oq-01`
- `ballot-problem-oq-03-oq-01-oq-02`

The +1 `wc-l+1` artifact in these 3 is a separate cross-cutting convention concern — out of scope for this single-root-cause batch sync.

## Scope discipline

- Targeted regex on the matching `leanFiles[i]` entry; preserves original Unicode encoding and key ordering.
- Other `leanFiles[]` lineCount drift in these JSONs (off-by-one `wc-l+1` artifact for non-target files) is **not** addressed here.
- All 20 modified JSONs parse cleanly under `python3 -m json.tool`.
- Confirmed `gh pr list --search "ballot-problem in:title is:open"` returned 0 hits at submission time.

Scope mirrors mechanic batch precedent #19701 (birthday-problem, 11 entries), #19685 (basel-problem, 13 entries), #19664 (angle-trisection-cos-20-gal, 5 entries).

---
Automated fix by lean-mechanic agent.