### PR TITLE
audit(erdos-842): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10017,9 +10017,9 @@
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T18:45:51Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T17:37:54Z",
+      "result": "clean"
     },
     "erdos-843": {
       "agentId": "mechanic-tracker-sync",


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-842` (3-Colorability of Triangle-Hamiltonian Graphs / Fleischner-Stiebitz 1992) — **clean**.

## Verification

Against `proofs/Proofs/Erdos842Problem.lean` at `535adef5`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `lineCount` | 227 | `wc -l = 227` | ✓ |
| `axiomCount` | 3 | `grep ^axiom` finds `thg_3_colorable`, `thg_chromatic_number_le_3`, `thg_chromatic_number_ge_3` | ✓ |
| `sorries` | 0 | no `\bsorry\b` | ✓ |
| `theoremCount` | 7 | `grep -c ^theorem\|^lemma` = 7 | ✓ |
| `definitionCount` | 7 | `grep -c ^def` = 7 | ✓ |
| True stubs | 0 | no `: True :=` / `: True$` / `:= trivial` | ✓ |
| structure-encoded assumptions | 0 | no `^structure` / `^class` | ✓ |
| `status: axiomatized`, `badge: axiom` | — | matches axiom-based formalization | ✓ |

No mismatches. No claim-risk flags (axiomatized status accurately reflects 3 named axioms; description credits Fleischner-Stiebitz as theorem authors; `originalContributions` correctly limited to formal definitions + axiomatized theorem statements).

## Tracker change

`src/data/proofs/audit-tracker.json` — `erdos-842`: `auditCount` 3 → 4, `lastAudited` 2026-04-28 → 2026-05-16, `result` `issues-fixed` → `clean`.

## Test plan

- [x] `wc -l proofs/Proofs/Erdos842Problem.lean` = 227
- [x] `grep -c ^axiom proofs/Proofs/Erdos842Problem.lean` = 3
- [x] No `\bsorry\b` matches in Lean source
- [x] No True stubs / structure-encoded assumptions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)