### PR TITLE
fix(meta): batch sync AmgmInequalityOQ04.lean leanFiles in 29 amgm-inequality slugs

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -243,9 +243,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -243,9 +243,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -262,9 +262,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -278,9 +278,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -200,9 +200,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -257,9 +257,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -218,9 +218,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -254,9 +254,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -250,9 +250,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -250,9 +250,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -266,9 +266,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -257,9 +257,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -251,9 +251,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -241,9 +241,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -251,9 +251,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -266,9 +266,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -258,9 +258,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -252,9 +252,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -248,9 +248,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -253,9 +253,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -214,9 +214,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -196,9 +196,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -265,9 +265,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -253,9 +253,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -246,9 +246,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -246,9 +246,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -246,9 +246,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -272,9 +272,9 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 307,
       "theoremCount": 21,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -274,8 +274,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 306,
-      "theoremCount": 22,
+      "lineCount": 307,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync of leanFiles[] for `Proofs/AmgmInequalityOQ04.lean` across 29 amgm-inequality research JSONs (28 siblings + owner) to absorb residual drift from S2 ACT axiom-deletion (#19535).

## Evidence

**S2 ACT (PR #19535)** deleted 3 elliptic-integral placeholder axioms in `AmgmInequalityOQ04.lean`:
- `lineCount` 317 → 307
- `axiomCount` 3 → 0

**Gallery meta.json fix (#19648)** updated only `axiomCount` for the owner slug. 28 sibling research JSONs and the owner research JSON were not touched.

**This PR** brings all 29 amgm-inequality research JSONs to canonical:

| Field | Canonical |
|-------|-----------|
| lineCount | 307 |
| theoremCount | 21 |
| defCount | 5 |
| sorryCount | 0 |
| axiomCount | 0 |

Verification (canonical enricher in `scripts/research/enrich-research.ts`):
```
$ wc -l proofs/Proofs/AmgmInequalityOQ04.lean
306  # split('\n').length = 307
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/AmgmInequalityOQ04.lean
21
$ grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ04.lean
0
```

**Before** (28 siblings): `lineCount: 317, axiomCount: 3`
**After**: `lineCount: 307, axiomCount: 0`

**Before** (owner `amgm-inequality-oq-04`): `lineCount: 306, theoremCount: 22`
**After**: `lineCount: 307, theoremCount: 21`

29 files × 4 line changes = 58/58 diff, no other fields touched.

---
Automated fix by lean-mechanic agent.