### PR TITLE
fix(meta): batch sync SchauderFixedPointOQ03OQ01.lean leanFiles in 3 schauder siblings

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-01.json
@@ -95,9 +95,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,

--- a/src/data/research/problems/schauder-fixed-point-oq-02.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-02.json
@@ -94,9 +94,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,

--- a/src/data/research/problems/schauder-fixed-point-oq-03.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03.json
@@ -91,9 +91,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,


### PR DESCRIPTION
## Fix

Three schauder-fixed-point research JSON files (`-oq-01`, `-oq-02`, `-oq-03`) carried stale `leanFiles[]` entries for `Proofs/SchauderFixedPointOQ03OQ01.lean` from before the file grew from 218 LOC to 1284 LOC via S20 ACT (#19016) + S22 ACT (#19671).

## Evidence

**Before** (3 stale siblings):
```json
{ "lineCount": 218, "theoremCount": 2, "axiomCount": 3, "defCount": 4, "sorryCount": 3 }
```

**After** (matches canonical entry already in `schauder-fixed-point-oq-03-oq-01.json` from #19706 and `-incomplete-01.json` from #19671):
```json
{ "lineCount": 1284, "theoremCount": 7, "axiomCount": 2, "defCount": 4, "sorryCount": 3 }
```

**Live verification on origin/main**:
```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1284
$ grep -cE "^theorem |^lemma " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
7
$ grep -cE "^axiom " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
2
$ grep -c "sorry" proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
3
```

## Scope

- Pure metadata sync (3 JSON files, +9/-9)
- No Lean changes, no Docker required
- No problem.md / state.md / knowledge.md / gallery / lake-manifest edits
- JSON validated via `python3 -c "import json; json.load(open(f))"`

## Test plan

- [x] JSON validates for all 3 files
- [x] Field values match canonical entry in `-oq-03-oq-01.json` (last fixed by #19706)
- [x] Live file state on origin/main verified for all 5 fields
- [x] Branch claim check: no in-flight PRs on `fix/mechanic-schauder*` for these slugs

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)