### PR TITLE
fix(meta): law-of-cosines-oq-04-oq-02-oq-01 add missing leanFiles[] entry for LawOfCosinesOQ04OQ02OQ01.lean (handoff #19704)

### DIFF
--- a/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
@@ -226,6 +226,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ02.lean"
     },
     {
+      "path": "Proofs/LawOfCosinesOQ04OQ02OQ01.lean",
+      "filename": "LawOfCosinesOQ04OQ02OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/LawOfCosinesOQ05.lean",
       "filename": "LawOfCosinesOQ05.lean",
       "lineCount": 694,


### PR DESCRIPTION
## Fix

S5 STATE-SYNC + audit-extension (PR #19704, merged 2026-05-16T17:21Z) explicitly opted out of editing `leanFiles[]` and flagged the gap as mechanic territory at memo § 8.2. The slug Lean file `Proofs/LawOfCosinesOQ04OQ02OQ01.lean` (created by S2 ACT skeleton #18924, modified by S3 ACT #18963) was never added to the canonical research JSON.

Inserts the missing entry after the `LawOfCosinesOQ04OQ02.lean` entry, before `LawOfCosinesOQ05.lean`.

## Evidence

**Before**: `leanFiles[]` had 11 entries; `LawOfCosinesOQ04OQ02OQ01.lean` was absent.

**After**: 12 entries; new entry reflects current file state (post-S3-ACT #18963):

```json
{
  "path": "Proofs/LawOfCosinesOQ04OQ02OQ01.lean",
  "filename": "LawOfCosinesOQ04OQ02OQ01.lean",
  "lineCount": 169,
  "theoremCount": 5,
  "axiomCount": 0,
  "defCount": 0,
  "sorryCount": 1,
  "isAristotle": false,
  "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean"
}
```

## Verification

Counts via strict `enrich-research.ts` conventions (`content.split('\n').length` for lineCount; `^(theorem|lemma) ` / `^axiom ` / `^(def |noncomputable def |opaque def ) ` / `\bsorry\b` regexes):

| Field | Value | Source |
|---|---:|---|
| lineCount | 169 | \`python3 -c \"len(open(f).read().split('\\\\n'))\"\` (\`wc -l\` = 168; file ends with \`\\n\`) |
| theoremCount | 5 | bisector_param_exists, bisector_dist_BD, bisector_dist_DC, angle_bisector_ratio_from_geometry, angle_bisector_length_geometric |
| axiomCount | 0 | no \`^axiom \` |
| defCount | 0 | no \`^(def \\\\|noncomputable def \\\\|opaque def )\` |
| sorryCount | 1 | single \`\\\\bsorry\\\\b\` |

Sibling reference: `LawOfCosinesOQ04OQ02.lean` (parent) has `wc -l` = 173, JSON `lineCount` = 174 — confirming the `wc -l + 1` (split-length) convention is the canonical one in this JSON.

## Memo handoff note

The S5 memo § 8.2 ready-to-paste snippet listed `theoremCount: 4` and `lineCount: 168`. This PR uses `5` and `169` instead because:

- S3 ACT #18963 added `angle_bisector_length_geometric` (the 5th theorem) beyond the four enumerated in S2 skeleton.
- `enrich-research.ts` uses `content.split('\n').length` not raw `wc -l`; file ends with newline so split-length = 169.
- These values match what `pnpm build → research:enrich` would write, avoiding clobber risk.

## Scope

One file edited (`src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json`); no Lean source touched; no gallery `meta.json` (this slug has no `src/data/proofs/law-of-cosines-oq-04-oq-02-oq-01/`); no `lastUpdate` bump (mechanic territory does not edit the timestamp).

Sibling-precedent: #19724/#19725 (binary-gcd-oq-03-oq-02), #19670 (cantor-diagonalization-oq-01-…-oq-02-oq-01), #19711 (brouwer-fixed-point), #19717 (erdos-735-oq-04), #19699 (ballot-problem-oq-02-oq-05) added analogous missing `leanFiles[]` entries via mechanic handoff after researcher STATE-SYNC PRs.

Closes #19704 leanFiles handoff.

---
Automated fix by lean-mechanic agent.