### PR TITLE
fix(meta): batch sync AmgmInequalityPowerMeanLimits.lean leanFiles in 30 amgm-inequality siblings

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -276,8 +276,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -276,8 +276,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -295,8 +295,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -311,8 +311,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -233,8 +233,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -287,8 +287,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -299,8 +299,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -274,8 +274,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -299,8 +299,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -285,8 +285,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -286,8 +286,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -247,8 +247,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -229,8 +229,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -286,8 +286,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -305,8 +305,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -307,8 +307,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 273,
-      "theoremCount": 12,
+      "lineCount": 272,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

All 30 amgm-inequality research JSON files carried stale `leanFiles[]` entries for `Proofs/AmgmInequalityPowerMeanLimits.lean`. The file gained 7 theorems since the JSONs were last refreshed.

## Evidence

**Before** (29 of 30 slugs):
```json
{ "lineCount": 273, "theoremCount": 12, "axiomCount": 0, "defCount": 3, "sorryCount": 0 }
```

**Before** (1 slug — `-incomplete-01` had lineCount already migrated):
```json
{ "lineCount": 272, "theoremCount": 12, ... }
```

**After** (all 30):
```json
{ "lineCount": 272, "theoremCount": 19, "axiomCount": 0, "defCount": 3, "sorryCount": 0 }
```

**Live verification on origin/main**:
```
$ wc -l proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
272
$ grep -cE "^theorem |^lemma " proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
19
$ grep -cE "^axiom " proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
0
$ grep -c "sorry" proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
0
$ grep -cE "^def |^noncomputable def |^private def |^protected def |^abbrev " proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
3
```

## Scope

- Pure metadata sync (30 JSON files, +59/-59)
- Single Lean file's `leanFiles[]` entry only — no other entries touched
- No Lean changes, no Docker required, no problem.md / state.md / knowledge.md / gallery / lake-manifest edits
- Gallery `meta.json` for `amgm-inequality-oq-03-oq-03-oq-01` uses singular `leanFile` schema (not `leanFiles[]`) and is unaffected
- All 30 files validated with `python3 -c "import json; json.load(open(f))"`

## Test plan

- [x] JSON validates for all 30 files
- [x] Live file state on origin/main verified for all 5 fields
- [x] Branch claim check: no in-flight `fix/mechanic-amgm*` branches on remote
- [x] No prior PR fixed this drift (`gh pr list --search "AmgmInequalityPowerMeanLimits"` returns only #9845 from May 3)

---
Automated fix by lean-mechanic agent. Follows batch-sync precedent set by #19701 (BirthdayProblem), #19728 (BallotProblem), #19731 (Schauder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)