### PR TITLE
fix(meta): batch sync ShannonChannelCoding.lean leanFiles[] across 9 shannon-channel-coding siblings

### DIFF
--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -59,10 +59,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
@@ -93,10 +93,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 442,
-      "theoremCount": 14,
+      "lineCount": 555,
+      "theoremCount": 16,
       "axiomCount": 3,
-      "defCount": 5,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-03.json
@@ -73,10 +73,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-04.json
@@ -70,10 +70,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02.json
@@ -80,10 +80,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-03.json
@@ -71,10 +71,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
@@ -31,10 +31,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04.json
@@ -59,10 +59,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"

--- a/src/data/research/problems/shannon-channel-coding.json
+++ b/src/data/research/problems/shannon-channel-coding.json
@@ -69,10 +69,10 @@
     {
       "path": "Proofs/ShannonChannelCoding.lean",
       "filename": "ShannonChannelCoding.lean",
-      "lineCount": 229,
-      "theoremCount": 8,
-      "axiomCount": 4,
-      "defCount": 5,
+      "lineCount": 555,
+      "theoremCount": 16,
+      "axiomCount": 3,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"


### PR DESCRIPTION
## Fix

Brings `leanFiles[].Proofs/ShannonChannelCoding.lean` to canonical values across 9 sibling `shannon-channel-coding-*` research JSONs after the S18a-1 ACT (PR #19655) added `def DMChannel.IsWeaklySymmetric` (+23 LOC) to the parent file.

## Evidence

**Before** (9 stale slugs):
- 8 slugs (shannon-channel-coding, -oq-01, -oq-02, -oq-02-oq-03, -oq-02-oq-04, -oq-03, -oq-04, -oq-04-oq-01): `lineCount: 229, theoremCount: 8, axiomCount: 4, defCount: 5`
- 1 slug (shannon-channel-coding-oq-02-oq-01): `lineCount: 442, theoremCount: 14, axiomCount: 3, defCount: 5`

**After** (all 9 match canonical):
- `lineCount: 555, theoremCount: 16, axiomCount: 3, defCount: 6, sorryCount: 0`

Canonical values verified against current file state on `origin/main`:
- `wc -l proofs/Proofs/ShannonChannelCoding.lean` → 555
- `grep -cE "^(theorem|lemma) "` → 16
- `grep -cE "^axiom "` → 3
- `grep -cE "^(def|noncomputable def|private def) "` → 6
- `grep -cE "\bsorry\b"` → 0

The canonical slug `shannon-channel-coding-oq-02-oq-01-oq-01` (set by PR #19655) is already correct and not modified.

## Validation

- All 9 modified JSONs parse cleanly (`python3 -c "import json; json.load(open(f))"`)
- Diff is minimal: 5 lines changed per file × 9 files = 35 ins / 35 del

---
Automated fix by lean-mechanic agent.