### PR TITLE
fix(meta): batch sync SchauderFixedPointOQ03OQ01.lean leanFiles in 3 schauder siblings (post-S22-ACT #19671)

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-01.json
@@ -95,9 +95,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,

--- a/src/data/research/problems/schauder-fixed-point-oq-02.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-02.json
@@ -94,9 +94,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,

--- a/src/data/research/problems/schauder-fixed-point-oq-03.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03.json
@@ -91,9 +91,9 @@
     {
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 2,
-      "axiomCount": 3,
+      "lineCount": 1284,
+      "theoremCount": 7,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,
       "isAristotle": false,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[]` entries for parent file `SchauderFixedPointOQ03OQ01.lean` across 3 sibling slugs (`schauder-fixed-point-oq-01`, `-oq-02`, `-oq-03`). All three carried an identical pre-axiomatization snapshot — `lineCount=218 / theoremCount=2 / axiomCount=3` — that drifted out across the S2-S22 ACT chain culminating in S22 ACT #19671.

## Evidence

**Before** (3 sibling slugs, identical stale entry):
```
lineCount=218 theoremCount=2 axiomCount=3 defCount=4 sorryCount=3
```

**After** (matches canonical-slug values established in mechanic PR #19706):
```
lineCount=1284 theoremCount=7 axiomCount=2 defCount=4 sorryCount=3
```

Verified at `origin/main` HEAD `c03c24168bc` using the enrich-research.ts regex set (per #19706 precedent):

```
$ F=proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
$ wc -l $F                                    # 1284
$ grep -cE "^(theorem|lemma) " $F            # 7
$ grep -cE "^axiom " $F                       # 2
```

`sorryCount: 3` raw `\bsorry\b` occurrences are all in block comments (lines 217, 342, 1247) — the file is end-to-end sorry-free in code; `sorryCount` left unchanged per the raw-count convention established in #19706.

JSON validates via `python3 -c "import json; json.load(open(p))"` for all 3 files.

## Out of scope

- Other files in these slugs' `leanFiles[]` arrays (e.g. the systematic `split('\n').length` vs `wc -l` off-by-one drift on `SchauderFixedPoint.lean`, `SchauderFixedPointOQ01.lean`, `SchauderFixedPointOQ03.lean` noted in #19706's footer) remain untouched — orthogonal to S22 ACT.
- `schauder-fixed-point-oq-03-oq-01-incomplete-01` was already added to `leanFiles[]` by #19707; no follow-up needed.

---
Automated fix by lean-mechanic agent.