### PR TITLE
fix(meta): sperner-simplicial-bridge-oq-01 leanFiles theoremCount/definitionCount drift

### DIFF
--- a/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
@@ -118,8 +118,8 @@
         {
             "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
             "lineCount": 216,
-            "theoremCount": 9,
-            "definitionCount": 2,
+            "theoremCount": 8,
+            "definitionCount": 3,
             "sorryCount": 0,
             "axiomCount": 0
         }


### PR DESCRIPTION
## Fix

`src/data/research/problems/sperner-simplicial-bridge-oq-01.json` had `leanFiles[0].theoremCount: 9` and `definitionCount: 2`, but the actual `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` (216 LOC, unchanged since S14 ACT #19634 merged 2026-05-16T14:32:23Z) has 8 theorems and 3 defs. Brings the research JSON in line with the canonical gallery `meta.json`, which already reports `8/3`.

## Evidence

**Before** (`leanFiles[0]` in research JSON):
```json
{
  "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
  "lineCount": 216,
  "theoremCount": 9,
  "definitionCount": 2,
  "sorryCount": 0,
  "axiomCount": 0
}
```

**After**:
```json
{
  "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
  "lineCount": 216,
  "theoremCount": 8,
  "definitionCount": 3,
  "sorryCount": 0,
  "axiomCount": 0
}
```

Verified by direct inspection of `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` on `origin/main`:

- Theorems (8 — lines 75, 85, 99, 131, 138, 174, 190, 204):
  - `topCellsOfDim_eq_of_pure`
  - `topCellsOfDim_eq_empty_of_pure`
  - `MixedPseudomanifold.of_pure`
  - `card_of_mem_topCellsOfDim`
  - `hpseudo_of_mixed`
  - `sperner_mixed_panchromatic_at_dim`
  - `sperner_mixed_panchromatic` (S14 alias)
  - `sperner_mixed_panchromatic_global` (S14 global existential)
- Defs (3 — lines 60, 66, 152):
  - `topCellsOfDim`
  - `MixedPseudomanifold`
  - `boundaryDoorCount` (noncomputable)

Cross-check: `src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json` already records `leanFile.theoremCount: 8` and `definitionCount: 3` (set by S14 ACT #19634), so the gallery side was correct; only the research-JSON side carried the wrong attribution.

Net count is unchanged (11 thm+def in both old and new) — only the field allocation moves (1 thm -> 1 def).

## Validation

- `python3 -c "import json; json.load(open('src/data/research/problems/sperner-simplicial-bridge-oq-01.json'))"` -> clean parse
- `git diff --stat` -> 1 file changed, 2 insertions(+), 2 deletions(-)

---
Automated fix by lean-mechanic agent.