### PR TITLE
fix(meta): clt-oq-01-oq-01-oq-04 add missing leanFiles[] entry for CentralLimitTheoremOQ01OQ01OQ04.lean (post-S9-ACT #19652)

### DIFF
--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-01-oq-04.json
@@ -138,6 +138,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
+      "filename": "CentralLimitTheoremOQ01OQ01OQ04.lean",
+      "lineCount": 359,
+      "theoremCount": 10,
+      "axiomCount": 6,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
       "filename": "CentralLimitTheoremOQ01OQ02.lean",
       "lineCount": 323,


### PR DESCRIPTION
## Fix

Adds the missing `leanFiles[]` entry for `Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean` in the canonical owning slug `central-limit-theorem-oq-01-oq-01-oq-04`. The slug's own primary Lean file was absent from its `leanFiles[]` array.

## Evidence

**Before**: `leanFiles[]` had 14 CentralLimitTheorem* entries but `CentralLimitTheoremOQ01OQ01OQ04.lean` (the file matching the slug itself) was missing.

**After**: 15 entries — added the missing entry between `CentralLimitTheoremOQ01OQ01.lean` and `CentralLimitTheoremOQ01OQ02.lean` (alphabetical order per `enrich-research.ts` line 206):

```json
{
  "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
  "filename": "CentralLimitTheoremOQ01OQ01OQ04.lean",
  "lineCount": 359,
  "theoremCount": 10,
  "axiomCount": 6,
  "defCount": 7,
  "sorryCount": 0,
  "isAristotle": false,
  "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean"
}
```

Metadata verified via `wc -l` (359) and matches the identical entry that PR #19720 added to the sibling slug `central-limit-theorem-oq-02-oq-04` after the same S9 ACT (#19652) shipped (axiomCount 7→6, +16 LOC, theoremCount 9→10).

## Context

- Trigger: post-S9-ACT #19652 drift; sibling sync #19720 already merged.
- Mechanic territory; researcher S10 STATE-SYNC plan in slug `central-limit-theorem-oq-01-oq-01-oq-04-oq-01` JSON `nextAction` explicitly notes "mechanic auto-update" for gallery + leanFiles refresh.
- Single-slug fix per "minimal diffs" rule; sibling slug `clt-oq-02-oq-04` already synced.

---
Automated fix by lean-mechanic agent.