### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ02.lean leanFiles in 23 ballot-problem siblings

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -319,10 +319,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -385,10 +385,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -336,10 +336,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -320,10 +320,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -323,10 +323,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -312,10 +312,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -370,10 +370,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -280,10 +280,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -342,10 +342,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -326,10 +326,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -315,10 +315,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -311,10 +311,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -316,10 +316,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -495,10 +495,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2528,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -317,10 +317,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -609,10 +609,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -322,10 +322,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -280,10 +280,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -339,10 +339,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -323,10 +323,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -322,10 +322,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -314,10 +314,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -314,10 +314,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2512,
+      "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 23,
+      "defCount": 24,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/BallotProblemOQ03OQ02.lean` across **23 sibling research JSONs** in the `ballot-problem-*` family. The file has grown to 2532 LOC / 24 defs and post-S78 ACT (#19554) accumulated drift relative to the siblings.

```
lineCount   2512 (or 2528) -> 2532   (wc -l)
defCount    23             -> 24
```

`theoremCount` (28), `sorryCount` (0), `axiomCount` (0) unchanged — already correct.

## Evidence

Validated on `origin/main` `proofs/Proofs/BallotProblemOQ03OQ02.lean`:

- `wc -l proofs/Proofs/BallotProblemOQ03OQ02.lean` → **2532**
- `grep -cE "^(theorem|lemma) "` → **28** (unchanged)
- `grep -cE "^(noncomputable )?(def|abbrev) "` → **24** (was 23)
- `grep -c "sorry"` (excluding comments) → **0** (unchanged)
- `grep -cE "^axiom "` → **0** (unchanged)

All 23 modified JSONs parse cleanly with `python3 -c "import json; json.load(open(f))"`.

## Affected slugs (23)

22 siblings carried 2512/23; one sibling (`ballot-problem-oq-03-oq-01-oq-01-oq-01`) had 2528/23 from an intermediate touch — all now updated to 2532/24:

| slug | leanFiles[i] | old (lc/def) | new |
|---|---:|---:|---:|
| ballot-problem-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-01-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-01-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-01-oq-02-oq-01 | [24] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-02-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-02-oq-01-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-02-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-04 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-01-oq-04-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-02-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-01-oq-01 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | [26] | **2528**/23 | 2532/24 |
| ballot-problem-oq-03-oq-01-oq-02 | [25] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-01-oq-04 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-02 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-03-oq-03 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-04 | [22] | 2512/23 | 2532/24 |
| ballot-problem-oq-05 | [22] | 2512/23 | 2532/24 |

## Scope

- **In scope**: research JSON `leanFiles[i]` metadata only.
- **Not touched**: gallery `meta.json` (already records `lineCount: 2532`), Lean source files, sibling slugs' state.md / knowledge.md / sessions/.
- **No semantic impact**: pure metadata refresh; no theorem / lemma / def reclassification.

Net diff: 46 insertions, 46 deletions (2 fields × 23 files).

---
Automated fix by lean-mechanic agent.