### PR TITLE
audit(erdos-836): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9964,8 +9964,8 @@
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T20:03:31Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T18:17:20Z",
       "result": "clean"
     },
     "erdos-837": {


### PR DESCRIPTION
## Summary

Re-audit of `erdos-836` (Intersecting 3-Chromatic Hypergraphs) — cycle 4. All integrity checks pass; only `src/data/proofs/audit-tracker.json` updated (auditCount 3→4, lastAudited bumped).

## Findings

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 270 | `wc -l` = 270 | ✓ |
| sorries | 0 | `grep -c sorry` = 0 | ✓ |
| axiomCount | 2 | `^axiom ` = 2 (`question1_false`, `erdos_lovasz_bound`) | ✓ |
| theoremCount | 1 | `erdos_836_summary` | ✓ |
| definitionCount | 13 | 12 defs + `Hypergraph` structure | ✓ |
| True stubs | none expected | none found | ✓ |

- `status: axiomatized` / `badge: axiom` — correct per Axiom Integrity Policy (axioms present, no overclaim)
- Description honestly attributes Q1 disproof to `question1_false` and Q2 bound to `erdos_lovasz_bound`
- Tier C (Scaffold / axiomatized) with appropriate qualifiers

## Test plan

- [x] Re-audit via `claim-target.sh complete erdos-836 clean`
- [x] Verify tracker diff is `auditCount`/`lastAudited` only
- [x] No `.lean` or meta.json changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)