### PR TITLE
fix(meta): batch sync BinaryGcdOQ03OQ02.lean leanFiles in 8 binary-gcd siblings (post-S47-ACT #19702)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -129,11 +129,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -140,11 +140,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -127,11 +127,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
@@ -132,11 +132,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -141,11 +141,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-01.json
@@ -137,11 +137,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -151,11 +151,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-01.json
@@ -165,11 +165,11 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 2225,
+      "theoremCount": 63,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }


### PR DESCRIPTION
## Fix

Batch-syncs the `BinaryGcdOQ03OQ02.lean` entry in `leanFiles[]` across 8 binary-gcd sibling research JSONs after PR #19702 (S47 ACT, +118 LOC) and PR #19724 (which fixed only the owner slug binary-gcd-oq-03-oq-02).

## Evidence

**Before** (siblings — stale, last accurate ~S16):

```
binary-gcd-oq-01.json              lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-01-oq-01.json        lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-01-oq-02.json        lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-01-oq-03.json        lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-01-oq-04-oq-01.json  lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-02.json              lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-02-oq-01.json        lineCount=1021, theoremCount=33, sorryCount=3
binary-gcd-oq-03-oq-01.json        lineCount=1021, theoremCount=33, sorryCount=3
```

**After** (matches owner slug `binary-gcd-oq-03-oq-02` set by #19724):

```
lineCount=2225, theoremCount=63, sorryCount=1
(axiomCount=0, defCount=6 unchanged)
```

**Source of truth**:

```
$ wc -l proofs/Proofs/BinaryGcdOQ03OQ02.lean
    2225
$ grep -cE "^(theorem|lemma) " proofs/Proofs/BinaryGcdOQ03OQ02.lean
63
$ grep -cE "^(def |noncomputable def |abbrev )" proofs/Proofs/BinaryGcdOQ03OQ02.lean
6
$ grep -cE "^axiom " proofs/Proofs/BinaryGcdOQ03OQ02.lean
0
```

`sorryCount=1` matches the owner slug's `description`: "One sorry remains in the original file for the recursive row-output size bound (S17 PR #17024 found this is FALSE for the unguarded algorithm)." Remaining `sorry` tokens in the file are inside comment blocks.

## Scope

Documentation-only — no Lean source, no `meta.json` description, no other fields touched. Same field set as the owner-slug fix (#19724).

## Precedent

- #19735 — ShannonChannelCoding.lean batch sync across 9 siblings
- #19734 — AmgmInequalityPowerMeanLimits.lean batch sync across 30 siblings
- #19737 — SchauderFixedPointOQ03OQ01.lean batch sync across 3 siblings
- #19714 — BallotProblemOQ03OQ01OQ02Helpers.lean batch sync across 20 siblings

---
Automated fix by lean-mechanic agent.