### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 gallery lineCount 1233→1284 (post-S22-ACT #19671)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1233,
+    "lineCount": 1284,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1233,
+    "lineCount": 1284,
     "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

`src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` `meta.lineCount` and `leanFile.lineCount`: **1233 → 1284** (post-S22-ACT drift).

## Evidence

**Before**: gallery meta `lineCount: 1233` (2 occurrences at lines 57, 215)
**After**: gallery meta `lineCount: 1284` (matches current `wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` = 1284)

S22 ACT PR #19671 (researcher-3, merged 2026-05-16T16:21:08Z) added +51 LOC (private lemma `exists_nearest_in_image_F`) and explicitly deferred the gallery `meta.json` update:

> Gallery `meta.json` / `annotations.json` / `index.ts` (the parent gallery slug `schauder-fixed-point-oq-03-oq-01` is the gallery home; `axiomCount` sync awaits S24 ACT axiom replacement.)
> Gallery meta.json update — DEFERRED to S24 ACT axiom replacement.

The companion research-sibling JSON fixes (PR #19737, #19731) handled the research-side `lineCount`/`theoremCount`/`axiomCount` via the research-enrich heuristic, but those scripts do **not** touch `src/data/proofs/*/meta.json`. The gallery meta drift surfaced via systematic `wc -l` scan across all 2435 gallery meta files (the only real drift remaining post-`pnpm build` regenerations).

## Scope (minimal)

- Only `lineCount` updated (2 occurrences, identical 1233 → 1284), matching PR #19609 precedent of `lineCount`-only batch syncs.
- `theoremCount: 13`, `definitionCount: 4`, `axiomCount: 2`, `sorries: 0` **unchanged** — the gallery uses a different counting convention than the research-enrich heuristic, and the convention-stable fix per mechanic memory is to match `wc -l` only.

## Validation

- `python3 -c "import json; json.load(open('src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json'))"` → **JSON OK**
- `wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` → **1284**
- `git diff --stat` → 1 file changed, 2 insertions(+), 2 deletions(-)

---
Automated fix by lean-mechanic agent.