### PR TITLE
fix(meta): ehrhart-cube-proven-oq-03 status formalized → verified post-S6-ACT #19639 (sorries=0, axiomCount=0)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
@@ -16,7 +16,7 @@
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hypersimplex",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "sorries": 0,
     "proofRepoPath": "Proofs/EhrhartCubeProvenOQ03.lean",
     "tags": [
@@ -29,7 +29,7 @@
       "research",
       "seeker-selected"
     ],
-    "badge": "formalized"
+    "badge": "original"
   },
   "sections": [
     {


### PR DESCRIPTION
## Fix

The S6 ACT (PR #19639, commit `48e4190924`, researcher-8, merged 2026-05-16T15:20Z) discharged the final `sorry` in `proofs/Proofs/EhrhartCubeProvenOQ03.lean` (sorries 1 → 0). The file now has 0 sorries, 0 axioms, and 0 structure-encoded assumptions; both reference identities (`hypersimplex_count_k_one`, `hypersimplex_palindrome_k_d_minus_1`) are proven, and the four numeric sanity checks close by `decide`.

The S6 ACT session memo explicitly handed off the status flip to the mechanic per `state.md` "Status flip readiness" section:

> with 0 sorries + 0 axioms, eligible for `meta.status: formalized → verified` + `meta.badge: formalized → original` once Docker build clears (auditor/mechanic flip; deferred this PR per build-pending).

This PR completes that flip.

## Evidence

Verified against `origin/main` HEAD `60cfb909fc6` for `proofs/Proofs/EhrhartCubeProvenOQ03.lean`:

| field    | before     | after    | source                                                                                       |
| -------- | ---------- | -------- | -------------------------------------------------------------------------------------------- |
| `status` | formalized | verified | CLAUDE.md: 0 sorries + 0 axioms + 0 structure-encoded assumptions ⇒ `verified`               |
| `badge`  | formalized | original | matches sibling oq-01 / oq-02 (also `original` badge for research scaffolds with new defs)   |

Counts re-verified:
- `grep -cE "\bsorry\b" proofs/Proofs/EhrhartCubeProvenOQ03.lean` → 1 match on line 184, **inside a docstring comment** ``/-! ## Section III — Numeric sanity checks (no `sorry`) -/`` (not a tactic)
- `grep -c "^axiom " proofs/Proofs/EhrhartCubeProvenOQ03.lean` → 0
- `grep -nE "^(structure|class|instance) " proofs/Proofs/EhrhartCubeProvenOQ03.lean` → only a synthesised decidability `instance` (line 56); no assumption-bearing structures
- Sibling slug status alignment:
  - `ehrhart-cube-proven-oq-01` → `verified` / `original` (0 sorries, 0 axioms)
  - `ehrhart-cube-proven-oq-02` → `verified` / `original` (0 sorries, 0 axioms)
  - `ehrhart-cube-proven-oq-04` → `verified` / `verified` (0 sorries, 0 axioms)

`meta.sorries=0` was already correct (set earlier in #18357); only the `status` / `badge` pair needed the flip.

JSON validity: `python3 -c "import json; json.load(open(...))"` passes.

## Scope

Single file (`src/data/proofs/ehrhart-cube-proven-oq-03/meta.json`), conflict-free, mechanic-territory metadata catchup per `state.md` explicit handoff. No content edits, no Lean changes, no `leanFiles[]` edits (already accurate at 210 LOC / 6 theorems / 2 defs / 0 sorries / 0 axioms).

---
Automated fix by lean-mechanic agent.