### PR TITLE
fix(meta): erdos-485-oq-01 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/erdos-485-oq-01.json
+++ b/src/data/research/problems/erdos-485-oq-01.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/Erdos485OQ01.lean",
       "filename": "Erdos485OQ01.lean",
-      "lineCount": 452,
+      "lineCount": 451,
       "theoremCount": 8,
       "axiomCount": 3,
       "defCount": 2,
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/Erdos485OQ02.lean",
       "filename": "Erdos485OQ02.lean",
-      "lineCount": 328,
+      "lineCount": 327,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/Erdos485Problem.lean",
       "filename": "Erdos485Problem.lean",
-      "lineCount": 226,
+      "lineCount": 225,
       "theoremCount": 3,
       "axiomCount": 1,
       "defCount": 6,


### PR DESCRIPTION
## Fix

`src/data/research/problems/erdos-485-oq-01.json` had all 3 `leanFiles[]` `lineCount` values one above `wc -l` — the `split('\n').length` convention rather than the gallery-canonical `wc -l`. Aligning with the sibling `erdos-485-oq-02.json` (already correct) and the 3 gallery meta.json siblings (also correct).

## Evidence

| `leanFiles[i].path` | recorded | `wc -l` (actual) |
|---|---|---|
| `Proofs/Erdos485OQ01.lean` | 452 | 451 |
| `Proofs/Erdos485OQ02.lean` | 328 | 327 |
| `Proofs/Erdos485Problem.lean` | 226 | 225 |

Cross-check against `erdos-485-oq-02.json` (sibling research JSON) — all 3 entries there read `451 / 327 / 225` (correct).

Gallery `src/data/proofs/erdos-485/`, `erdos-485-oq-01/`, `erdos-485-oq-02/` `meta.lineCount`: `225 / 451 / 327` respectively (correct).

Other fields verified — no further drift:

```text
Erdos485OQ01.lean:    axioms=3  sorries=0  theorems=8   defs=2
Erdos485OQ02.lean:    axioms=0  sorries=0  theorems=10  defs=2
Erdos485Problem.lean: axioms=1  sorries=0  theorems=3   defs=6
```

(matches recorded `axiomCount / sorryCount / theoremCount / defCount` in the JSON.)

JSON validated with `python3 -m json.tool`.

---

Automated fix by lean-mechanic agent.