### PR TITLE
fix(meta): erdos-782 axiomCount 4 → 3 (BombieriLang opaque, not axiom)

### DIFF
--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -59,7 +59,7 @@
       "no_4AP_in_squares axiom (classical)",
       "squares_contain_3AP: PROVED by explicit construction {1,25,49}={1²,5²,7²} with d=24 (was axiom)"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 328,
     "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
     "theoremCount": 10,
@@ -186,7 +186,7 @@
     ],
     "namespace": "Erdos782",
     "lineCount": 328,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 10,
     "definitionCount": 18,
     "path": "Proofs/Erdos782Problem.lean",


### PR DESCRIPTION
## Fix

Reconcile internal contradiction in `src/data/proofs/erdos-782/meta.json`: the `meta.assumptions` prose already states **3 axioms**, but both `meta.axiomCount` and `leanFile.axiomCount` were stale at **4**.

Lean source verification:

```
$ grep -nE '^axiom\s+[A-Za-z_]' proofs/Proofs/Erdos782Problem.lean
82:axiom no_4AP_in_squares : ¬ContainsAP Squares 4
167:axiom question1_implies_question2 : Question1 → Question2
213:axiom cilleruelo_granville :
```

Exactly **3** axiom declarations. The 4th (`BombieriLangConjecture`) was converted to an `opaque` Prop in PR #7457 ("4→3"), and `squares_contain_3AP` was proved by explicit construction `{1, 25, 49} = {1², 5², 7²}` (d=24). The assumptions text was updated then, but the numeric count was overlooked.

No structures or classes are declared in this file (`grep -E '^(structure|class)'` returns nothing), so per Axiom Integrity Policy there are no structure-encoded assumptions to add.

## Evidence

**Before**: `meta.axiomCount = 4`, `leanFile.axiomCount = 4`, `assumptions` text says "3 axioms" (contradiction)
**After**:  `meta.axiomCount = 3`, `leanFile.axiomCount = 3`, `assumptions` text unchanged (consistent)

## Scope

Pure metadata numeric sync (2-byte diff, both numeric occurrences). No Lean source touched, no prose changed, no `assumptions`/`originalContributions` edits. Disjoint from open PRs (no other `erdos-782 in:title` open).

---
Automated fix by lean-mechanic agent.