### PR TITLE
fix(meta): algebraic-numbers-countable-oq-01 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/algebraic-numbers-countable-oq-01.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-01.json
@@ -62,7 +62,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountable.lean",
       "filename": "AlgebraicNumbersCountable.lean",
-      "lineCount": 255,
+      "lineCount": 254,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 4,
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableAristotle.lean",
       "filename": "AlgebraicNumbersCountableAristotle.lean",
-      "lineCount": 46,
+      "lineCount": 45,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02.lean",
       "filename": "AlgebraicNumbersCountableOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02.lean",
       "filename": "AlgebraicNumbersCountableOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 5,
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
       "filename": "AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
-      "lineCount": 134,
+      "lineCount": 133,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
       "filename": "AlgebraicNumbersCountableOQ04.lean",
-      "lineCount": 759,
+      "lineCount": 758,
       "theoremCount": 13,
       "axiomCount": 3,
       "defCount": 0,
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
       "filename": "AlgebraicNumbersCountableOQ05.lean",
-      "lineCount": 297,
+      "lineCount": 296,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

`src/data/research/problems/algebraic-numbers-countable-oq-01.json` had all 7 `leanFiles[]` `lineCount` values one above `wc -l` — the `split('\n').length` convention rather than the gallery-canonical `wc -l`. Aligning with the sibling gallery `meta.json` (`lineCount: 254` for `AlgebraicNumbersCountable.lean`) and recent mechanic precedent #19754 (`erdos-485-oq-01`).

## Evidence

| `leanFiles[i].filename` | recorded | `wc -l` (actual) |
|---|---|---|
| `AlgebraicNumbersCountable.lean`             | 255 | 254 |
| `AlgebraicNumbersCountableAristotle.lean`    |  46 |  45 |
| `AlgebraicNumbersCountableOQ02.lean`         | 193 | 192 |
| `AlgebraicNumbersCountableOQ02OQ02.lean`     | 286 | 285 |
| `AlgebraicNumbersCountableOQ02OQ02OQ01.lean` | 134 | 133 |
| `AlgebraicNumbersCountableOQ04.lean`         | 759 | 758 |
| `AlgebraicNumbersCountableOQ05.lean`         | 297 | 296 |

Gallery `src/data/proofs/algebraic-numbers-countable/meta.json` carries `meta.lineCount: 254` for `Proofs/AlgebraicNumbersCountable.lean` — confirms `wc -l` as the canonical convention.

Other fields verified — no further drift:

\`\`\`text
AlgebraicNumbersCountable.lean:             axioms=0  sorries=0  theorems=18  defs=4
AlgebraicNumbersCountableAristotle.lean:    axioms=0  sorries=0  theorems=5   defs=0
AlgebraicNumbersCountableOQ02.lean:         axioms=0  sorries=0  theorems=11  defs=1
AlgebraicNumbersCountableOQ02OQ02.lean:     axioms=0  sorries=0  theorems=17  defs=5
AlgebraicNumbersCountableOQ02OQ02OQ01.lean: axioms=0  sorries=0  theorems=3   defs=0
AlgebraicNumbersCountableOQ04.lean:         axioms=3  sorries=0  theorems=13  defs=0
AlgebraicNumbersCountableOQ05.lean:         axioms=0  sorries=0  theorems=12  defs=2
\`\`\`

(matches recorded `theoremCount` / `axiomCount` / `defCount` / `sorryCount` in the JSON.)

JSON validated with `python3 -m json.tool`.

---

Automated fix by lean-mechanic agent.