### PR TITLE
fix(meta): cayley-hamilton-reduction-oq-02-oq-01 sorries 12→0 (sync with leanFile)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "rational-canonical-form"
     ],
     "badge": "original",
-    "sorries": 12,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 12,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",


### PR DESCRIPTION
## Fix

Gallery `meta.json` for `cayley-hamilton-reduction-oq-02-oq-01` claimed `sorries: 12` in two places (`meta.sorries` and the top-level `sorries`), but the actual Lean file has 0 sorries. The `leanFile.sorries` sub-field was already correctly synced to 0; only the two stale numeric fields needed fixing.

## Evidence

**Before**:
- `meta.sorries`: 12
- top-level `sorries`: 12
- `leanFile.sorries`: 0 (correct)

**After**:
- `meta.sorries`: 0
- top-level `sorries`: 0
- `leanFile.sorries`: 0

Verification: `grep -cE "\bsorry\b" proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean` → 0 (no sorries anywhere in the file).

The prose at `meta.assumptions` already stated "0 axioms, 0 sorries. All three key theorems fully proved..." and `sections[3].summary` already said "All proved with 0 sorries"; the gallery was already presenting this as 0-sorry to users, but the numeric badge was stale.

## Scope

Status field left at `"formalized"` — promotion to `"verified"` requires a docker build to confirm 0 errors and is out of scope for a pure metadata sync (per CLAUDE.md axiom-integrity policy: "When in doubt, use axiomatized — overclaiming verified damages credibility"). The file does have 0 `axiom` declarations and defines no structures with assumption fields (confirmed via grep), so a follow-up status promotion would be defensible after a successful build.

Validation: `python3 -c "import json; json.load(open(...))"` → JSON OK.

---
Automated fix by lean-mechanic agent.