### PR TITLE
fix(meta): cayley-hamilton-oq-01 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/CayleyHamilton.lean",
       "filename": "CayleyHamilton.lean",
-      "lineCount": 251,
+      "lineCount": 250,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
       "filename": "CayleyHamiltonCyclicVectorAllFields.lean",
-      "lineCount": 269,
+      "lineCount": 268,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
       "filename": "CayleyHamiltonMinpolyOQ01.lean",
-      "lineCount": 308,
+      "lineCount": 307,
       "theoremCount": 20,
       "axiomCount": 3,
       "defCount": 0,
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ02.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
       "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
-      "lineCount": 391,
+      "lineCount": 390,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 2,
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
       "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
-      "lineCount": 137,
+      "lineCount": 136,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 2,
@@ -168,7 +168,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
       "filename": "CayleyHamiltonMinpolyOQ03.lean",
-      "lineCount": 369,
+      "lineCount": 368,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
       "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
-      "lineCount": 115,
+      "lineCount": 114,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
       "filename": "CayleyHamiltonMinpolyOQ03OQ01.lean",
-      "lineCount": 266,
+      "lineCount": 265,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ04.lean",
-      "lineCount": 317,
+      "lineCount": 316,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 3,
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
       "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
-      "lineCount": 481,
+      "lineCount": 480,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
       "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
-      "lineCount": 126,
+      "lineCount": 125,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
-      "lineCount": 363,
+      "lineCount": 362,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
@@ -278,7 +278,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
-      "lineCount": 346,
+      "lineCount": 345,
       "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 6,
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 288,
+      "lineCount": 287,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
@@ -300,7 +300,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 2,
@@ -311,7 +311,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
-      "lineCount": 576,
+      "lineCount": 575,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 2,
@@ -322,7 +322,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
-      "lineCount": 254,
+      "lineCount": 253,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
@@ -333,7 +333,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
+      "lineCount": 359,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 2,
@@ -344,7 +344,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
-      "lineCount": 191,
+      "lineCount": 190,
       "theoremCount": 1,
       "axiomCount": 1,
       "defCount": 0,
@@ -355,7 +355,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
-      "lineCount": 263,
+      "lineCount": 262,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/CayleyHamiltonOQ01.lean",
       "filename": "CayleyHamiltonOQ01.lean",
-      "lineCount": 448,
+      "lineCount": 447,
       "theoremCount": 30,
       "axiomCount": 0,
       "defCount": 0,
@@ -377,7 +377,7 @@
     {
       "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
       "filename": "CayleyHamiltonOQ01OQ01.lean",
-      "lineCount": 146,
+      "lineCount": 145,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
@@ -388,7 +388,7 @@
     {
       "path": "Proofs/CayleyHamiltonOQ02.lean",
       "filename": "CayleyHamiltonOQ02.lean",
-      "lineCount": 359,
+      "lineCount": 358,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,
@@ -399,7 +399,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ01.lean",
       "filename": "CayleyHamiltonReductionOQ01.lean",
-      "lineCount": 305,
+      "lineCount": 304,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
@@ -410,7 +410,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ01OQ02.lean",
       "filename": "CayleyHamiltonReductionOQ01OQ02.lean",
-      "lineCount": 211,
+      "lineCount": 210,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
@@ -421,7 +421,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02.lean",
       "filename": "CayleyHamiltonReductionOQ02.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
@@ -432,7 +432,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 397,
+      "lineCount": 396,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
@@ -443,7 +443,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

`src/data/research/problems/cayley-hamilton-oq-01.json` had 33 of its 34 `leanFiles[]` entries with `lineCount` values one above `wc -l` — the `split('\n').length` convention rather than the gallery-canonical `wc -l`. Aligning with the gallery `meta.json` files (all use `wc -l`).

The lone `CayleyHamiltonCyclicVectorAllFieldsAristotle.lean` entry (133) was already correct and is untouched.

## Evidence

Spot-check vs gallery `src/data/proofs/<slug>/meta.json` (`leanFile.lineCount`) — all match `wc -l`:

| `leanFiles[i].path`                                            | was | now | gallery |
|----------------------------------------------------------------|-----|-----|---------|
| `Proofs/CayleyHamilton.lean`                                   | 251 | 250 | 250     |
| `Proofs/CayleyHamiltonCyclicVectorAllFields.lean`              | 269 | 268 | 268     |
| `Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean`                    | 391 | 390 | 390     |
| `Proofs/CayleyHamiltonMinpolyOQ03.lean`                        | 369 | 368 | 368     |
| `Proofs/CayleyHamiltonOQ01.lean`                               | 448 | 447 | 447     |
| `Proofs/CayleyHamiltonOQ02.lean`                               | 359 | 358 | 358     |
| `Proofs/CayleyHamiltonReductionOQ02OQ01.lean`                  | 397 | 396 | 396     |

All 33 drifting entries follow the same `recorded = wc -l + 1` pattern; fix subtracts 1 to each. Only field touched is `lineCount`; `theoremCount` / `axiomCount` / `defCount` / `sorryCount` / `path` / `filename` / `isAristotle` / `githubUrl` left as-is.

JSON validated with `python3 -m json.tool`.

Follows recent precedent: #19754 (`erdos-485-oq-01`), #19759 (`algebraic-numbers-countable-oq-01`).

---

Automated fix by lean-mechanic agent.