### PR TITLE
fix(meta): batch sync BrouwerFixedPointOQ01OQ02.lean leanFiles in 17 brouwer-fixed-point siblings

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
@@ -94,9 +94,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
@@ -111,9 +111,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -207,9 +207,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 295,
-      "theoremCount": 12,
-      "axiomCount": 1,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
@@ -98,9 +98,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
@@ -121,9 +121,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
@@ -88,9 +88,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01.json
@@ -91,9 +91,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -155,9 +155,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -84,9 +84,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
@@ -104,9 +104,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02.json
@@ -92,9 +92,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-03.json
@@ -85,9 +85,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -87,9 +87,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
@@ -141,9 +141,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
@@ -47,9 +47,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
@@ -88,9 +88,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -111,9 +111,9 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
       "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 462,
+      "theoremCount": 14,
+      "axiomCount": 4,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/BrouwerFixedPointOQ01OQ02.lean` across **17 sibling research JSONs** in the `brouwer-fixed-point-*` family. The file has accumulated multiple ACT increments (S2 ACT-A scaffold, S5 ACT-B substantive, S7 ACT-D-1) without sibling JSON propagation.

```
lineCount    234 (16 siblings) | 295 (oq-01-oq-02-oq-03-oq-02) → 462  (wc -l)
theoremCount 10 (16 siblings)  | 12  (oq-01-oq-02-oq-03-oq-02) → 14
axiomCount   2  (16 siblings)  | 1   (oq-01-oq-02-oq-03-oq-02) → 4
defCount     2  → 2  (unchanged)
sorryCount   0  → 0  (unchanged)
```

The file's docstring already documents the correct state — `## Summary: 14 theorems, 0 sorries, 4 axioms`.

## Evidence

Validated on `origin/main` `proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean`:

- `wc -l proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean` → **462**
- `grep -cE '^(theorem|lemma) '` → **14**
- `grep -cE '^axiom '` → **4** (`no_retraction_axiom` L44, `H_n_minus_1_sphere_nonzero` L261, `contractible_singularHomology_zero` L287, `sphere_singularHomology_nonzero` L351)
- `grep -cE '^(noncomputable )?(def|abbrev) '` → **2** (`ClosedBall` L124, `UnitSphere` L128)
- `grep -c sorry` → **0**

All 17 modified JSONs parse cleanly with `python3 -c "import json; json.load(open(f))"`.

## Affected slugs (17)

| slug | old (lc/thm/axiom) | new |
|---|---|---|
| brouwer-fixed-point-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-02 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-02-oq-03 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02 | **295/12/1** | 462/14/4 |
| brouwer-fixed-point-oq-01-oq-03 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-02 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-02-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-02-oq-02 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-02-oq-02-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-03 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-04 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-04-oq-01 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-04-oq-02 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-04-oq-03 | 234/10/2 | 462/14/4 |
| brouwer-fixed-point-oq-04-oq-04 | 234/10/2 | 462/14/4 |

## Scope

- **In scope**: research JSON `leanFiles[i]` metadata only.
- **Not touched**: gallery `meta.json` (no `brouwer-fixed-point-oq-01-oq-02` gallery slug exists), Lean source files, sibling slugs' `state.md` / `knowledge.md` / `sessions/`.
- **No semantic impact**: pure metadata refresh.

Net diff: 51 insertions, 51 deletions (3 fields × 17 files).

---
Automated fix by lean-mechanic agent.