### PR TITLE
fix(meta): abel-ruffini-oq-01 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -355,7 +355,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,
@@ -377,7 +377,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04.lean",
       "filename": "AbelRuffiniGaloisExtensionsOQ04.lean",
-      "lineCount": 235,
+      "lineCount": 234,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 2,
@@ -388,7 +388,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04.lean",
       "filename": "AbelRuffiniOQ04.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
@@ -399,7 +399,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
+      "lineCount": 1498,
       "theoremCount": 36,
       "axiomCount": 0,
       "defCount": 5,
@@ -410,7 +410,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ02.lean",
       "filename": "AbelRuffiniOQ04OQ02.lean",
-      "lineCount": 155,
+      "lineCount": 154,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
@@ -421,7 +421,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
       "filename": "AbelRuffiniOQ04OQ02OQ02.lean",
-      "lineCount": 168,
+      "lineCount": 167,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
@@ -432,7 +432,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ02OQ03.lean",
       "filename": "AbelRuffiniOQ04OQ02OQ03.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -443,7 +443,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
       "filename": "AbelRuffiniOQ04OQ03.lean",
-      "lineCount": 243,
+      "lineCount": 242,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
@@ -454,7 +454,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
       "filename": "AbelRuffiniOQ04OQ07.lean",
-      "lineCount": 378,
+      "lineCount": 377,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 4,
@@ -465,7 +465,7 @@
     {
       "path": "Proofs/AbelRuffiniOQ09.lean",
       "filename": "AbelRuffiniOQ09.lean",
-      "lineCount": 541,
+      "lineCount": 540,
       "theoremCount": 21,
       "axiomCount": 2,
       "defCount": 1,


### PR DESCRIPTION
## Fix

`src/data/research/problems/abel-ruffini-oq-01.json` had all 11 `leanFiles[]` `lineCount` values one above `wc -l` — the `split('\n').length` convention rather than the gallery-canonical `wc -l`. Aligning with recent mechanic precedent #19759 (`algebraic-numbers-countable-oq-01`) and #19754 (`erdos-485-oq-01`).

## Evidence

| `leanFiles[i].filename` | recorded | `wc -l` (actual) |
|---|---|---|
| `AbelRuffini.lean`                      |  188 |  187 |
| `AbelRuffiniGaloisExtensions.lean`      |  535 |  534 |
| `AbelRuffiniGaloisExtensionsOQ04.lean`  |  235 |  234 |
| `AbelRuffiniOQ04.lean`                  |  164 |  163 |
| `AbelRuffiniOQ04OQ01.lean`              | 1499 | 1498 |
| `AbelRuffiniOQ04OQ02.lean`              |  155 |  154 |
| `AbelRuffiniOQ04OQ02OQ02.lean`          |  168 |  167 |
| `AbelRuffiniOQ04OQ02OQ03.lean`          |  105 |  104 |
| `AbelRuffiniOQ04OQ03.lean`              |  243 |  242 |
| `AbelRuffiniOQ04OQ07.lean`              |  378 |  377 |
| `AbelRuffiniOQ09.lean`                  |  541 |  540 |

Other fields verified — no further drift:

\`\`\`text
AbelRuffini.lean:                       axioms=0  sorries=0  theorems=9   defs=0
AbelRuffiniGaloisExtensions.lean:       axioms=0  sorries=0  theorems=57  defs=0
AbelRuffiniGaloisExtensionsOQ04.lean:   axioms=0  sorries=0  theorems=3   defs=2
AbelRuffiniOQ04.lean:                   axioms=0  sorries=0  theorems=8   defs=0
AbelRuffiniOQ04OQ01.lean:               axioms=0  sorries=0  theorems=36  defs=5
AbelRuffiniOQ04OQ02.lean:               axioms=0  sorries=0  theorems=6   defs=0
AbelRuffiniOQ04OQ02OQ02.lean:           axioms=0  sorries=0  theorems=12  defs=0
AbelRuffiniOQ04OQ02OQ03.lean:           axioms=0  sorries=0  theorems=4   defs=0
AbelRuffiniOQ04OQ03.lean:               axioms=1  sorries=0  theorems=8   defs=0
AbelRuffiniOQ04OQ07.lean:               axioms=2  sorries=0  theorems=12  defs=4
AbelRuffiniOQ09.lean:                   axioms=2  sorries=0  theorems=21  defs=1
\`\`\`

(matches recorded `theoremCount` / `axiomCount` / `defCount` / `sorryCount` in the JSON, under the strict `enrich-research.ts` regex `^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `.)

JSON validated with `python3 -m json.tool`.

---

Automated fix by lean-mechanic agent.