### PR TITLE
fix(meta): cantor-diagonalization-oq-01 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
@@ -90,7 +90,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01.lean",
       "filename": "CantorDiagonalizationOQ01.lean",
-      "lineCount": 443,
+      "lineCount": 442,
       "theoremCount": 27,
       "axiomCount": 2,
       "defCount": 5,
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01OQ01.lean",
       "filename": "CantorDiagonalizationOQ01OQ01.lean",
-      "lineCount": 304,
+      "lineCount": 303,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean",
       "filename": "CantorDiagonalizationOQ01OQ01OQ02.lean",
-      "lineCount": 256,
+      "lineCount": 255,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
-      "lineCount": 207,
+      "lineCount": 206,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01OQ02.lean",
       "filename": "CantorDiagonalizationOQ01OQ02.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 14,
       "axiomCount": 7,
       "defCount": 10,
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02.lean",
       "filename": "CantorDiagonalizationOQ02.lean",
-      "lineCount": 273,
+      "lineCount": 272,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 2,
@@ -156,7 +156,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
       "filename": "CantorDiagonalizationOQ02OQ01.lean",
-      "lineCount": 131,
+      "lineCount": 130,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
@@ -167,7 +167,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
+      "lineCount": 142,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean",
       "filename": "CantorDiagonalizationOQ02OQ03OQ02.lean",
-      "lineCount": 381,
+      "lineCount": 380,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
@@ -189,7 +189,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean",
       "filename": "CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean",
-      "lineCount": 49,
+      "lineCount": 48,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
@@ -200,7 +200,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ03.lean",
       "filename": "CantorDiagonalizationOQ03.lean",
-      "lineCount": 150,
+      "lineCount": 149,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
@@ -211,7 +211,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
       "filename": "CantorDiagonalizationOQ03OQ01.lean",
-      "lineCount": 304,
+      "lineCount": 303,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean",
       "filename": "CantorDiagonalizationOQ03OQ01Incomplete01.lean",
-      "lineCount": 241,
+      "lineCount": 240,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
@@ -233,7 +233,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
       "filename": "CantorDiagonalizationOQ03OQ01OQ02.lean",
-      "lineCount": 276,
+      "lineCount": 275,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ03.lean",
       "filename": "CantorDiagonalizationOQ03OQ01OQ03.lean",
-      "lineCount": 257,
+      "lineCount": 256,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ04.lean",
       "filename": "CantorDiagonalizationOQ04.lean",
-      "lineCount": 305,
+      "lineCount": 304,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ04OQ03.lean",
       "filename": "CantorDiagonalizationOQ04OQ03.lean",
-      "lineCount": 300,
+      "lineCount": 299,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 6,
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean",
       "filename": "CantorDiagonalizationOQ04OQ03Aristotle.lean",
-      "lineCount": 65,
+      "lineCount": 64,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Flip all 19 `leanFiles[*].lineCount` entries from split('\n').length (`wc -l + 1`) to raw `wc -l` to match the canonical convention used by gallery `meta.json` and the recent mechanic pattern (cf. #19759, #19764, #19767).

## Evidence

**Before** (split-length / `wc -l + 1`):
- CantorDiagonalization.lean: 176
- CantorDiagonalizationOQ01.lean: 443
- CantorDiagonalizationOQ01OQ01.lean: 304
- ... (19 entries total, all off-by-one)

**After** (raw `wc -l`):
- CantorDiagonalization.lean: 175
- CantorDiagonalizationOQ01.lean: 442 (matches gallery `cantor-diagonalization-oq-01/meta.json`)
- CantorDiagonalizationOQ01OQ01.lean: 303
- ... all entries now match `wc -l` output

Only `lineCount` fields were touched (19 insertions / 19 deletions, single file). JSON validated via `python3 json.load`. Other fields (`theoremCount`, `axiomCount`, `defCount`, `sorryCount`, `isAristotle`, `githubUrl`) preserved verbatim.

---
Automated fix by lean-mechanic agent.