### PR TITLE
fix(meta): batch sync AbelRuffiniGaloisExtensions.lean leanFiles in 22 abel-ruffini siblings

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
@@ -53,7 +53,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
@@ -58,7 +58,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
@@ -58,7 +58,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
@@ -68,7 +68,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
@@ -58,7 +58,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions.json
@@ -62,7 +62,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
@@ -71,7 +71,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -49,7 +49,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -94,7 +94,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -45,7 +45,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
-      "lineCount": 535,
+      "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Across 22 sibling JSONs in `src/data/research/problems/`, the `leanFiles[i].lineCount` recorded for the shared file `AbelRuffiniGaloisExtensions.lean` was **535** — the stale `split('\n').length` convention. Aligning to the gallery-canonical `wc -l` value of **534**.

## Evidence

`wc -l proofs/Proofs/AbelRuffiniGaloisExtensions.lean` → **534**

Each touched JSON had a single `lineCount` field flipped 535 → 534 (no other fields changed).

| Slug | path field |
|---|---|
| abel-ruffini-galois-extensions | Proofs/AbelRuffiniGaloisExtensions.lean |
| abel-ruffini-galois-extensions-oq-01 | … |
| abel-ruffini-galois-extensions-oq-02 | … |
| abel-ruffini-galois-extensions-oq-03 | … |
| abel-ruffini-galois-extensions-oq-04 | … |
| abel-ruffini-galois-extensions-oq-05 | … |
| abel-ruffini-galois-extensions-oq-07 | … |
| abel-ruffini-oq-02 | … |
| abel-ruffini-oq-03 | … |
| abel-ruffini-oq-04 | … |
| abel-ruffini-oq-04-oq-01 | … |
| abel-ruffini-oq-04-oq-01-oq-04 | … |
| abel-ruffini-oq-04-oq-02 | … |
| abel-ruffini-oq-04-oq-02-oq-01 | … |
| abel-ruffini-oq-04-oq-02-oq-03 | … |
| abel-ruffini-oq-04-oq-03 | … |
| abel-ruffini-oq-04-oq-06 | … |
| abel-ruffini-oq-04-oq-07 | … |
| abel-ruffini-oq-04-oq-09 | … |
| abel-ruffini-oq-05 | … |
| abel-ruffini-oq-06 | … |
| abel-ruffini-oq-09 | … |

`abel-ruffini-oq-01` is **excluded** — it's already addressed in open PR #19767 (full per-slug 11-file sync).

## Precedent

- #19766 — batch sync `BrouwerFixedPointOQ01OQ02.lean` in 17 brouwer-fixed-point siblings
- #19731 — batch sync `SchauderFixedPointOQ03OQ01.lean` in 3 schauder siblings
- #19767 — full per-slug sync of `abel-ruffini-oq-01` (sibling of this batch)

JSON validated with `python3 -m json.tool` for all 22 files.

---
Automated fix by lean-mechanic agent.