### PR TITLE
audit: batch tracker update — 8 erdos slugs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9822,9 +9822,9 @@
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T23:20:21Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T19:01:18Z",
+      "result": "clean"
     },
     "erdos-816": {
       "agentId": "auditor-cycle-20-batch",
@@ -9846,9 +9846,9 @@
     },
     "erdos-819": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T22:48:36Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T18:58:51Z",
+      "result": "clean"
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
@@ -9864,9 +9864,9 @@
     },
     "erdos-821": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T22:54:21Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T18:59:38Z",
+      "result": "clean"
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
@@ -9876,8 +9876,8 @@
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T22:52:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T18:59:17Z",
       "result": "clean"
     },
     "erdos-824": {
@@ -9912,13 +9912,13 @@
     },
     "erdos-829": {
       "agentId": "mechanic-tracker-sync",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom mahler_1935/density_of_sums in originalContributions — fixed via PR #13710",
         "section line drift — fixed via PR #13710"
       ],
-      "lastAudited": "2026-04-28T23:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-16T19:01:01Z",
+      "result": "clean"
     },
     "erdos-83": {
       "agentId": "auditor-cycle-20-batch",
@@ -9940,8 +9940,8 @@
     },
     "erdos-832": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T20:48:57Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T18:57:22Z",
       "result": "clean"
     },
     "erdos-833": {
@@ -9958,8 +9958,8 @@
     },
     "erdos-835": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T20:14:53Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T18:58:11Z",
       "result": "clean"
     },
     "erdos-836": {
@@ -9988,13 +9988,13 @@
     },
     "erdos-839": {
       "agentId": "mechanic-tracker-sync",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "phantom axiom narrative in overview/conclusion — fixed via PR #13693",
         "section structure drift — fixed via PR #13690"
       ],
-      "lastAudited": "2026-04-28T23:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-16T19:00:32Z",
+      "result": "clean"
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Auditor agent batch tracker update. Verified counts (lineCount, axiomCount, sorries, theoremCount, definitionCount) against Lean source for 8 erdos slugs. All clean.

### Audited slugs

| Slug | Status | Notes |
|------|--------|-------|
| erdos-832 | clean | 3 axioms, tier-C axiomatized |
| erdos-835 | clean | 6 axioms + 2 aux sorries; assumptions field honest |
| erdos-819 | clean | 2 axioms, open |
| erdos-823 | clean | 2 axioms, solved (Pollack 2015) |
| erdos-821 | clean | 3 axioms, open |
| erdos-839 | clean | 1 axiom, open; 14 thm+lem incl. private match |
| erdos-829 | clean | 2 axioms, open |
| erdos-815 | clean | 3 axioms, disproved (NPS 2017) |

All slugs verified:
- Line counts match (`wc -l` convention)
- Sorry counts match
- Axiom counts match (no hidden structure-encoded assumptions)
- Theorem/definition counts include private + noncomputable
- Status, badge, and assumptions fields honest
- No True stubs masquerading as verified

No issues filed.

## Test plan

- [x] Audit tracker updated only; no Lean / meta.json changes
- [x] Single-file diff against src/data/proofs/audit-tracker.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)