### PR TITLE
fix(meta): batch sync Erdos1151OQ04.lean leanFiles in 6 sibling JSONs

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -3564,11 +3564,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -3132,11 +3132,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -3587,11 +3587,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -3574,11 +3574,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },

--- a/src/data/research/problems/erdos-11-oq-03.json
+++ b/src/data/research/problems/erdos-11-oq-03.json
@@ -968,11 +968,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },

--- a/src/data/research/problems/erdos-1151.json
+++ b/src/data/research/problems/erdos-1151.json
@@ -75,11 +75,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1283,
-      "theoremCount": 29,
+      "lineCount": 2695,
+      "theoremCount": 66,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },


### PR DESCRIPTION
## Fix

Aligns `leanFiles[i]` for `Erdos1151OQ04.lean` from the pre-S33 stale entry to the canonical post-S33 entry across 6 sibling JSONs that reference this shared file.

## Evidence

**Before** (in 6 stale siblings):
```
"lineCount": 1283, "theoremCount": 29, "sorryCount": 4
```

**After** (matching canonical `erdos-1151-oq-04.json`):
```
"lineCount": 2695, "theoremCount": 66, "sorryCount": 1
```

`axiomCount` (0) and `defCount` (5) unchanged.

## Source of truth

`erdos-1151-oq-04.json` (canonical slug) was synced in #19688 (S33 pre-BUILD-VERIFY STATE-SYNC). The 6 siblings here were last updated in #19454 (unrelated sperner PR) and held the pre-S33 entry.

## Files

- `erdos-1.json`
- `erdos-1-oq-01.json`
- `erdos-1-oq-02.json`
- `erdos-1-oq-03.json`
- `erdos-1-oq-04.json`
- `erdos-11-oq-03.json`

Wait — actual files: `erdos-1-oq-{01..04}.json`, `erdos-11-oq-03.json`, `erdos-1151.json`. All 6 JSON-parse clean. Diff: 6 files × 3 lines edited = 18/18 ins/del.

## Precedent

#19772 (AbelRuffiniGaloisExtensions.lean × 22), #19766 (BrouwerFixedPointOQ01OQ02.lean × 17), #19734 (AmgmInequalityPowerMeanLimits.lean × 30).

---
Automated fix by lean-mechanic agent.