### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02 leanFiles[*] lineCount off-by-one (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/algebraic-numbers-countable-oq-02.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-02.json
@@ -64,7 +64,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountable.lean",
       "filename": "AlgebraicNumbersCountable.lean",
-      "lineCount": 255,
+      "lineCount": 254,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 4,
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableAristotle.lean",
       "filename": "AlgebraicNumbersCountableAristotle.lean",
-      "lineCount": 46,
+      "lineCount": 45,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02.lean",
       "filename": "AlgebraicNumbersCountableOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02.lean",
       "filename": "AlgebraicNumbersCountableOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 5,
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
       "filename": "AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
-      "lineCount": 134,
+      "lineCount": 133,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
       "filename": "AlgebraicNumbersCountableOQ04.lean",
-      "lineCount": 759,
+      "lineCount": 758,
       "theoremCount": 13,
       "axiomCount": 3,
       "defCount": 0,
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
       "filename": "AlgebraicNumbersCountableOQ05.lean",
-      "lineCount": 297,
+      "lineCount": 296,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Flip all 7 `leanFiles[*].lineCount` entries from `split('\n').length` (= `wc -l + 1`) to raw `wc -l` to match the canonical convention used by gallery `meta.json` and the recent mechanic pattern (cf. #19759, #19764, #19767, #19771).

## Evidence

**Before** (split-length / `wc -l + 1`) → **After** (raw `wc -l`):

| file | before | after |
|---|---|---|
| `Proofs/AlgebraicNumbersCountable.lean`            | 255 | 254 |
| `Proofs/AlgebraicNumbersCountableAristotle.lean`    |  46 |  45 |
| `Proofs/AlgebraicNumbersCountableOQ02.lean`        | 193 | 192 |
| `Proofs/AlgebraicNumbersCountableOQ02OQ02.lean`    | 286 | 285 |
| `Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean`| 134 | 133 |
| `Proofs/AlgebraicNumbersCountableOQ04.lean`        | 759 | 758 |
| `Proofs/AlgebraicNumbersCountableOQ05.lean`        | 297 | 296 |

Only `lineCount` fields were touched (7 insertions / 7 deletions, single file). JSON validated via `python3 json.load`. Other fields (`theoremCount`, `axiomCount`, `defCount`, `sorryCount`, `isAristotle`, `githubUrl`) preserved verbatim.

---
Automated fix by lean-mechanic agent.