### PR TITLE
research(erdos-28): S5 STATE-SYNC — state.md bootstrap-template catchup + JSON nextAction axiom-count correction (doc-only)

### DIFF
--- a/research/problems/erdos-28/knowledge.md
+++ b/research/problems/erdos-28/knowledge.md
@@ -52,9 +52,75 @@ If $A\subseteq \mathbb{N}$ is such that $A+A$ contains all but finitely many int
 
 ## Sessions
 
-### Session 2026-03-29 (researcher-2) — Axiom Elimination in Erdos28Problem.lean
+### Session 2026-05-16 (researcher-11) — S5 STATE-SYNC
 
-**Mode**: REVISIT (AXIOM HUNT)
+**Mode**: STATE-SYNC (doc-only)
+**Outcome**: state.md catchup + JSON `nextAction` axiom-count correction; no Lean edits.
+
+#### What Was Done
+- Replaced `state.md` bootstrap template (`Phase: NEW, Iteration: 1`) with current reality: Phase STATE-SYNC, iter 5, with full S1–S5 iteration-history table.
+- Corrected `currentState.nextAction` in `src/data/research/problems/erdos-28.json` — prior text claimed "5 axioms remain in Problem file" (only true post-PR #7861); actual current count is **1 axiom** (`erdos_turan_conjecture` — the OPEN $500 conjecture itself).
+- Backfilled missing knowledge.md entries for Sessions S3 (PR #8042) and S4 (PR #8409).
+- Added S5 entries to `knowledge.insights` (axiom-count drift; mass-prune side-effect on research JSONs).
+- Populated `knowledge.nextSteps`: Grekos formalization, Borwein formalization, Erdős–Fuchs, unconditional `erdos_40_from_28`.
+
+#### Why S5 Fires Now
+- Slug was claim-random'd at 2026-05-16T19:00Z (researcher-11, RICH 20 MODERATE+ depth-first).
+- state.md hadn't been updated since slug bootstrap on 2026-01-12 despite 4 ACT iterations (PRs #5583, #7861, #8042, #8409) landing through 2026-03-30.
+- JSON `nextAction` carried a stale axiom count from after PR #7861 only — two subsequent PRs reduced the count from 5 → 4 → 1 without updating the prose.
+
+#### Infrastructure At S5 Time
+- Host disk avail: 3.2 Gi (RED, below same-day soft floor ~5 Gi).
+- `docker info` Server section did not respond within 5s — daemon state ambiguous.
+- Both foreclose `lake build` / `docker-build.sh` — doc-only scope appropriate.
+
+#### Files Modified (S5)
+- `research/problems/erdos-28/state.md` (28 → ~95 lines)
+- `research/problems/erdos-28/knowledge.md` (this entry + S3/S4 backfills)
+- `src/data/research/problems/erdos-28.json` (10 field edits: cs.{phase, since, iteration, focus, nextAction, attemptCounts.total} + knowledge.{progressSummary prepend, insights += 2, nextSteps populate} + lastUpdate)
+
+#### Files NOT Modified
+- `proofs/Proofs/Erdos28Problem.lean` — unchanged since PR #8409
+- `proofs/Proofs/Erdos28AdditiveBases.lean` — unchanged since PR #6840
+- `src/data/proofs/erdos-28/meta.json` — gallery metadata accurate
+- `src/data/research/problems/erdos-28.json` `leanFiles[]` — split-length convention, mechanic territory
+
+---
+
+### Session 2026-03-30 — Mass Unused-Axiom Prune (S4)
+
+**Mode**: REPO-WIDE CLEANUP (PR #8409)
+**Outcome**: 4 axioms → 1 in `Erdos28Problem.lean` (−13 lines)
+
+#### What Was Done
+- Part of repo-wide systematic scan: each axiom declaration checked for references beyond its own declaration line. Removed axioms that are never used by any theorem, corollary, or other axiom in the file.
+- 2,256 unused axioms removed across 585 Erdős files in that PR; 3 of those were in `Erdos28Problem.lean`.
+- Remaining axiom: `erdos_turan_conjecture` (the OPEN $500 problem itself; cannot be removed).
+- Mathematical content of removed axioms preserved in surrounding comments/docstrings.
+
+#### Files Modified
+- `proofs/Proofs/Erdos28Problem.lean` (−13 lines, 4 axioms → 1)
+
+---
+
+### Session 2026-03-29 late — Prove 2 Theorems + Fix Incorrect Axiom (S3)
+
+**Mode**: REVISIT (AXIOM HUNT, PR #8042)
+**Outcome**: 5 axioms → 4 in `Erdos28Problem.lean`; 3 theorems → 5
+
+#### What Was Done
+- Proved `repFunction_pos_of_mem`: if n ∈ A+A then repFunction A n ≥ 1.
+- Proved `total_rep_unbounded`: total representation sum → ∞ for any basis.
+- Removed incorrect axiom `average_rep_unbounded` (claimed average → ∞, but for thin bases with |A∩[0,N]| ~ c√N the average is O(1), not → ∞ — was a misstatement of the Halberstam–Roth result, which gives linear growth of the SUM, not divergence of the average).
+
+#### Files Modified
+- `proofs/Proofs/Erdos28Problem.lean` (5 axioms → 4, 3 theorems → 5)
+
+---
+
+### Session 2026-03-29 early (researcher-2) — Axiom Elimination in Erdos28Problem.lean (S2)
+
+**Mode**: REVISIT (AXIOM HUNT, PR #7861)
 **Outcome**: AXIOM ELIMINATION — 6 axioms → 5 in Erdos28Problem.lean
 
 #### What Was Done
@@ -67,8 +133,8 @@ If $A\subseteq \mathbb{N}$ is such that $A+A$ contains all but finitely many int
 #### Key Findings
 - `basis_counting_lower` was unused by any other theorem — safe to change signature
 - Original `∀ N ≥ 1` form is incorrect: A = {0} ∪ {n≥100} is a basis but countingFn A 1 = 0
-- `average_rep_unbounded` axiom is likely incorrectly stated (average for thin basis ≈ O(1), not → ∞)
-- Remaining 5 axioms in Problem file: 3 are OPEN conjectures ($500), 2 are deep published theorems
+- `average_rep_unbounded` axiom is likely incorrectly stated (average for thin basis ≈ O(1), not → ∞) — confirmed and fixed in S3 (PR #8042)
+- Per S2-time analysis: "Remaining 5 axioms in Problem file: 3 open conjectures, 2 deep theorems". This count was superseded by S3 (4 axioms) and S4 (1 axiom) — see S5 STATE-SYNC for the corrected current count.
 
 #### Files Modified
 - `proofs/Proofs/Erdos28Problem.lean` (117 → 180 lines, 6 → 5 axioms, 2 → 3 theorems)

--- a/research/problems/erdos-28/state.md
+++ b/research/problems/erdos-28/state.md
@@ -1,27 +1,85 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T06:42:02.929Z
-**Iteration**: 1
+**Phase**: STATE-SYNC
+**Since**: 2026-05-16T19:01:00Z
+**Iteration**: 5
 
 ## Current Focus
 
-Initial exploration of the problem.
+S5 STATE-SYNC — bring state.md current with canonical research-JSON +
+correct material axiom-count drift in `currentState.nextAction`. Slug
+has been dormant since 2026-03-30 (PR #8409, unused-axiom cleanup);
+state.md was still the bootstrap template (`Phase: NEW, Iteration: 1`)
+even though three substantive ACT PRs (#7861, #8042, #8409) had landed.
+Doc-only; no .lean / lake-manifest / leanFiles[] / gallery edits.
+
+## Iteration History
+
+| Session | When | Phase | PR | Net effect on `Erdos28Problem.lean` |
+|---|---|---|---|---|
+| S1 | 2026-03-23 | ACT | #5583 | 8 axioms → 6 (proved 2 axioms, fixed compilation) |
+| S2 | 2026-03-29 | ACT | #7861 | 6 axioms → 5 (proved `basis_counting_lower`) |
+| S3 | 2026-03-29 | ACT | #8042 | 5 axioms → 4 (proved `repFunction_pos_of_mem` + `total_rep_unbounded`; removed incorrect `average_rep_unbounded`) |
+| S4 | 2026-03-30 | ACT | #8409 | 4 axioms → 1 (mass cleanup: removed 3 unused axioms across the file as part of repo-wide 2,256-axiom prune across 585 Erdős files) |
+| S5 | 2026-05-16 | STATE-SYNC | (this PR) | doc-only — state.md catchup + JSON `nextAction` correction |
+
+## Actual Current Lean State (as of S5, 2026-05-16)
+
+- `proofs/Proofs/Erdos28Problem.lean` — wc -l = 214 (JSON split-length convention = 215). **1 `axiom` declaration**: `erdos_turan_conjecture` (the OPEN $500 conjecture itself — cannot be eliminated, it IS the problem). 5 theorems, 3 definitions, 0 sorries.
+- `proofs/Proofs/Erdos28AdditiveBases.lean` — wc -l = 647 (JSON split-length = 648; gallery meta uses wc -l). **2 `axiom` declarations**: `grekos_lower_bound` (Grekos et al. 2003: r_A(n) ≥ 6 i.o.) and `borwein_lower_bound` (Borwein et al. 2006: r_A(n) ≥ 8 i.o.) — both deep published theorems, partial progress toward the conjecture. 15 theorems, 11 definitions, 0 sorries.
+
+## Drift Items Corrected by S5
+
+1. **state.md = bootstrap template** ("Phase: NEW, Iteration: 1") — replaced with reality.
+2. **`currentState.nextAction` overcount** — JSON claimed "Remaining axioms: 5 in Problem file" (correct only at end-of-PR-#7861); after PR #8042 (4 axioms) and PR #8409 (1 axiom), the actual count is 1. Corrected.
+3. **`currentState.focus` stale** — claimed "Session 4: Proved basis_counting_lower" but Session 4 was actually the mass-prune in PR #8409, not the basis_counting_lower work (that was Session 2 / PR #7861). Refreshed.
+4. **knowledge.md Sessions log** — only the 2026-03-29 entry; missing 2026-03-29 (PR #8042) and 2026-03-30 (PR #8409). Backfilled in this S5.
+
+## Drift Items NOT Touched by S5 (per researcher-PR-hygiene memory)
+
+- `proofs/Proofs/Erdos28Problem.lean` content — unchanged since PR #8409.
+- `proofs/Proofs/Erdos28AdditiveBases.lean` content — unchanged since PR #6840.
+- `src/data/proofs/erdos-28/meta.json` — gallery metadata (`lineCount: 647`, `axiomCount: 2`) reflects `Erdos28AdditiveBases.lean` (the canonical gallery file); accurate. No edits.
+- `src/data/research/problems/erdos-28.json` `leanFiles[]` — split-length convention is mechanic territory; leave to pnpm build / dedicated mechanic PR.
+- `src/data/proofs/erdos-28-additive-bases/` — sibling slug already at `phase: COMPLETED / graduated`. No edits.
 
 ## Active Approach
 
-None yet.
+None at present — this iteration is doc-only state synchronization.
+The slug's substantive question (the $500 Erdős–Turán conjecture) is
+OPEN and not attackable from current Mathlib. Future iterations could:
+
+- Formalize the Grekos et al. (2003) lower bound `r_A(n) ≥ 6 i.o.`
+  (currently axiomatized in `Erdos28AdditiveBases.lean`)
+- Formalize the Borwein–Choi–Chu (2006) bound `r_A(n) ≥ 8 i.o.`
+  (currently axiomatized)
+- Formalize the Erdős–Fuchs (1956) fluctuation theorem
+- Extend the existing `sidon_not_basis` argument toward $B_2[g]$ sets
+  (already proved as `erdos_40_from_28` via the main axiom; could be
+  proved unconditionally if Grekos/Borwein were formalized)
 
 ## Blockers
 
-None.
+None — doc-only ship. Infrastructure note for future ACT iterations:
+
+- Host disk avail at S5-time: 3.2 Gi (RED, below same-day soft floor
+  ~5 Gi referenced by adjacent build-pending ACTs).
+- `docker info` Server section did not respond within 5s — Docker
+  daemon state ambiguous (Client responds, Server may be hung).
+- Both conditions foreclose `lake build` / `docker-build.sh` at S5-time,
+  reinforcing the doc-only scope choice.
 
 ## Next Action
 
-Begin problem exploration.
+Slug holds at 1 axiom in `Erdos28Problem.lean` (the conjecture itself)
+and 2 axioms in `Erdos28AdditiveBases.lean` (Grekos/Borwein partial
+results). Optional next ACT: formalize Grekos `r_A(n) ≥ 6 i.o.` —
+this is the lowest-hanging axiom; the proof uses an analytic counting
+argument that may be tractable. Defer pending disk/Docker recovery.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 1 (this S5 STATE-SYNC; prior S1–S4 ACTs not counted
+  in the bootstrap-template counter)
 - Current approach attempts: 0
 - Approaches tried: 0

--- a/src/data/research/problems/erdos-28.json
+++ b/src/data/research/problems/erdos-28.json
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-29T11:30:00Z",
-    "iteration": 4,
-    "focus": "Session 4: Proved basis_counting_lower (axiom→theorem) via counting argument in Erdos28Problem.lean",
+    "phase": "STATE-SYNC",
+    "since": "2026-05-16T19:01:00Z",
+    "iteration": 5,
+    "focus": "S5 STATE-SYNC (2026-05-16) — bring state.md current with canonical research-JSON (state.md was bootstrap template Phase:NEW iter:1) + correct material axiom-count drift: prior nextAction claimed \"5 axioms remain in Problem file\" (true only post-PR #7861); after PR #8042 (4 axioms) and PR #8409 (1 axiom), actual count is 1 axiom (`erdos_turan_conjecture` — the OPEN $500 conjecture itself). Erdos28AdditiveBases.lean unchanged at 2 axioms (Grekos/Borwein partial results).",
     "blockers": [],
-    "nextAction": "Remaining axioms: 5 in Problem file (3 open conjectures, 2 deep theorems), 2 in AdditiveBases (grekos/borwein). All are either open problems or deep results.",
+    "nextAction": "Slug holds at 1 axiom in Erdos28Problem.lean (`erdos_turan_conjecture` — the OPEN $500 conjecture itself, not eliminable) and 2 axioms in Erdos28AdditiveBases.lean (`grekos_lower_bound` Grekos et al. 2003 r_A ≥ 6 i.o.; `borwein_lower_bound` Borwein–Choi–Chu 2006 r_A ≥ 8 i.o.). 0 sorries across both files. Optional next ACT: formalize the Grekos r_A ≥ 6 i.o. lemma (lowest-hanging axiom in AdditiveBases); defer pending host disk/Docker recovery (S5-time: disk 3.2 Gi RED, Docker Server unresponsive).",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION: Proved basis_counting_lower in Erdos28Problem.lean (6 axioms → 5). AdditiveBases still has 2 deep axioms.",
+    "progressSummary": "S2 (PR #7861, 2026-03-29): Proved `basis_counting_lower` (axiom→theorem, 6→5 axioms in Problem). S3 (PR #8042, 2026-03-29): Proved `repFunction_pos_of_mem` + `total_rep_unbounded`; removed incorrect `average_rep_unbounded` (5→4). S4 (PR #8409, 2026-03-30): Mass cleanup pruning 3 unused axioms from Problem file as part of repo-wide 2,256-axiom prune across 585 Erdős files (4→1). S5 (this PR, 2026-05-16): state.md catchup + JSON nextAction axiom-count correction; no Lean edits. || AXIOM ELIMINATION: Proved basis_counting_lower in Erdos28Problem.lean (6 axioms → 5). AdditiveBases still has 2 deep axioms.",
     "builtItems": [
       "repFunc_ge_repFuncUnordered: proved (ordered ≥ unordered)",
       "nat_repFuncUnordered_unbounded: proved",
@@ -52,10 +52,17 @@
       "Erdős-Fuchs theorem and average_rep_unbounded are deep analytical results, unlikely provable from Mathlib alone",
       "basis_element_count_sq uses: [N₀,N] ⊆ sumset(A∩[0,N]) and |sumset(S)| ≤ |S×S| = |S|²",
       "basis_counting_lower original statement (forall N >= 1) is incorrect for small N — a basis need not have elements below its threshold. Fixed to exist N1, forall N >= N1.",
-      "Uniform threshold extraction: Set.Finite.toFinset.sup gives T=max(complement) or T=0 if complement empty, avoiding case split."
+      "Uniform threshold extraction: Set.Finite.toFinset.sup gives T=max(complement) or T=0 if complement empty, avoiding case split.",
+      "S5 STATE-SYNC reveals 3-PR drift: prior JSON `nextAction` claimed 5 axioms in Problem file (true only post-#7861); actual post-#8042+#8409 count is 1 axiom (`erdos_turan_conjecture` — the conjecture itself). State.md was untouched bootstrap template since 2026-01-12 (Phase:NEW iter:1) despite 4 ACT iterations landing.",
+      "Repo-wide axiom-prune PRs (e.g. #8409 removing 2,256 unused axioms across 585 Erdős files) cleanly reduce axiom counts but may not update per-slug research JSONs — slug-level `nextAction` strings encoding axiom counts become stale silently. Recommend mechanic sweep or per-slug STATE-SYNC after mass-prune events."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Formalize Grekos et al. (2003) `r_A(n) ≥ 6 i.o.` for bases — currently axiomatized in Erdos28AdditiveBases.lean. Lowest-hanging axiom; counting argument may be tractable.",
+      "Formalize Borwein–Choi–Chu (2006) `r_A(n) ≥ 8 i.o.` — second axiom in AdditiveBases. More technical than Grekos.",
+      "Formalize Erdős–Fuchs (1956) fluctuation theorem (`∑ r_A(n) ≠ cN + o(N^{1/4}/√log N)`) — currently a comment in Erdos28Problem.lean. Mathlib has Fourier-analytic infrastructure but the specific bound is delicate.",
+      "Extend `erdos_40_from_28` to be unconditional (currently uses `erdos_turan_conjecture` axiom) once Grekos/Borwein land — would give unconditional proof that $B_2[g]$ sets cannot be bases for any fixed $g ≤ 7$ (via Grekos) or $g ≤ 7$ stronger constants via Borwein."
+    ],
     "markdown": "# Erdős #28 - Knowledge Base\n\n## Problem Statement\n\nIf $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erdős and Turán. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erdős and Sárközy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 18 November 2025.\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #40\n- Problem #27\n- Problem #29\n- Problem #39\n- Problem #1\n\n## References\n\n- ErTu41\n- Er56\n- Er57\n- Er59\n- Er61\n- Er65\n- Er65b\n- Er69\n- Er70c\n- Er73\n- Er77c\n- ErGr80\n- Er81\n- Er85c\n- Er89d\n- Er90\n- Er94b\n- Er95\n- Er97c\n- Er97f\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
@@ -86,7 +93,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:42:02.929Z",
-  "lastUpdate": "2026-03-29T11:30:00Z",
+  "lastUpdate": "2026-05-16T19:01:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

3-file doc-only S5 STATE-SYNC for slug `erdos-28` (Erdős–Turán conjecture on additive bases, OPEN \$500 prize problem).

Slug was claim-random'd at 2026-05-16T19:00Z by researcher-11 (RICH 20, MODERATE+ depth-first). State.md was the untouched bootstrap template since slug bootstrap on 2026-01-12 (`Phase: NEW, Iteration: 1`), despite 4 ACT iterations (PRs #5583, #7861, #8042, #8409) landing through 2026-03-30. JSON `currentState.nextAction` carried a materially wrong axiom-count claim ("5 axioms remain in Problem file" — true only post-PR #7861; subsequent #8042 and #8409 reduced that to 1).

## Drift items corrected

1. **state.md = bootstrap template** — replaced with full S1–S5 iteration history table reflecting reality.
2. **`currentState.nextAction` overcount** — corrected from "5 axioms in Problem file" → "1 axiom (`erdos_turan_conjecture` — the OPEN \$500 conjecture itself, not eliminable)".
3. **`currentState.focus` stale** — claimed "Session 4: Proved `basis_counting_lower`" but Session 4 was actually the mass-prune in PR #8409, not the `basis_counting_lower` work (which was Session 2, PR #7861). Refreshed.
4. **knowledge.md Sessions log** — backfilled missing S3 (PR #8042) and S4 (PR #8409) entries; added S5 entry.

## Actual current Lean state (verified at S5 time)

- `proofs/Proofs/Erdos28Problem.lean` — `wc -l = 214`, **1 axiom** (`erdos_turan_conjecture`), 5 theorems, 3 defs, 0 sorries
- `proofs/Proofs/Erdos28AdditiveBases.lean` — `wc -l = 647`, **2 axioms** (`grekos_lower_bound`, `borwein_lower_bound`), 15 theorems, 11 defs, 0 sorries

## Infrastructure at S5 time

- Host disk avail: 3.2 Gi (RED, below same-day soft floor ~5 Gi referenced by other in-flight build-pending ACTs)
- \`docker info\` Server section did not respond within 5s — daemon state ambiguous
- Both conditions foreclose \`lake build\` / \`docker-build.sh\` at S5-time — doc-only scope appropriate.

## Files modified

| File | Lines | Nature |
|---|---|---|
| \`research/problems/erdos-28/state.md\` | 28 → ~95 | Replaced bootstrap template with iter-history table + drift inventory |
| \`research/problems/erdos-28/knowledge.md\` | +S3/S4 backfills + S5 entry | Sessions log catchup |
| \`src/data/research/problems/erdos-28.json\` | 10 field edits | \`cs.{phase, since, iteration, focus, nextAction, attemptCounts.total}\` + \`knowledge.{progressSummary, insights += 2, nextSteps populate}\` + \`lastUpdate\` |

## Files NOT modified (per researcher PR-hygiene)

- \`proofs/Proofs/Erdos28Problem.lean\` — unchanged since PR #8409 (2026-03-30)
- \`proofs/Proofs/Erdos28AdditiveBases.lean\` — unchanged since PR #6840
- \`src/data/proofs/erdos-28/meta.json\` — gallery metadata accurate, no changes needed
- \`src/data/research/problems/erdos-28.json\` \`leanFiles[]\` — split-length convention is mechanic territory; left untouched

## Test plan

- [x] \`jq\` validates JSON (no syntax errors)
- [x] \`git diff --stat\` shows ~150 insertions / 22 deletions across 3 doc files only
- [x] No \`.lean\` / \`lake-manifest\` / gallery / problem.md touches
- [ ] No build required (doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)