### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 leanFiles[*] lineCount drift (6 of 8 entries)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/BinaryGcdOQ01.lean",
       "filename": "BinaryGcdOQ01.lean",
-      "lineCount": 216,
+      "lineCount": 215,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
@@ -240,7 +240,7 @@
     {
       "path": "Proofs/BinaryGcdOQ01OQ03.lean",
       "filename": "BinaryGcdOQ01OQ03.lean",
-      "lineCount": 226,
+      "lineCount": 225,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
-      "lineCount": 158,
+      "lineCount": 157,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/BinaryGcdOQ02.lean",
       "filename": "BinaryGcdOQ02.lean",
-      "lineCount": 135,
+      "lineCount": 134,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 1,
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
+      "lineCount": 488,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 13,
@@ -284,7 +284,7 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ01.lean",
       "filename": "BinaryGcdOQ03OQ01.lean",
-      "lineCount": 240,
+      "lineCount": 239,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Six `leanFiles[].lineCount` entries in `src/data/research/problems/binary-gcd-oq-03-oq-02.json` were stale:

- 5 entries were off-by-one (`split('\n').length` convention from a prior enrich-research run)
- 1 entry (`BinaryGcdOQ03.lean`) was off-by-three from an older content trim

The two most-recently-modified files (`BinaryGcdOQ03OQ02.lean` + `BinaryGcdOQ03OQ02PathA.lean`) were already in sync from the S46 PREP + S47 ACT (#19702).

Aligns with mechanic precedent:
- #19767 (abel-ruffini-oq-01)
- #19759 (algebraic-numbers-countable-oq-01)
- #19754 (erdos-485-oq-01)

## Evidence

**Before / After**:

| filename                       | recorded | wc -l | diff |
|---|---|---|---|
| BinaryGcdOQ01.lean             |  216 |  215 |  -1 |
| BinaryGcdOQ01OQ03.lean         |  226 |  225 |  -1 |
| BinaryGcdOQ01OQ04.lean         |  158 |  157 |  -1 |
| BinaryGcdOQ02.lean             |  135 |  134 |  -1 |
| BinaryGcdOQ03.lean             |  491 |  488 |  -3 |
| BinaryGcdOQ03OQ01.lean         |  240 |  239 |  -1 |
| BinaryGcdOQ03OQ02.lean         | 2225 | 2225 |  OK |
| BinaryGcdOQ03OQ02PathA.lean    | 3140 | 3140 |  OK |

Other numeric fields verified — no further drift:
- `theoremCount`, `axiomCount`, `defCount` all match under the strict `enrich-research.ts` regex (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `).
- `sorryCount` preserved at gallery-canonical semantic values. In particular, `BinaryGcdOQ03OQ02.lean` `sorryCount=1` matches gallery `src/data/proofs/binary-gcd-oq-03-oq-02/meta.json` `sorries=1`. The 9 other `\bsorry\b` matches in that file are all documentary references to the single proof obligation at line 1078 (e.g., "the sorry at line 1078", "this sorry cannot be discharged"), not proof obligations.

## Scope

Doc-only single-file edit (+6/-6). No Lean source touched. No `pnpm build` (per mechanic memory: `pnpm build` regenerates all 1047 research JSONs via `research:enrich` and uses the `split('\n').length` convention that introduced this drift; it would also re-corrupt the semantic `sorryCount` to 10 by counting comment occurrences).

JSON validated via `python3 -c 'import json; json.load(open(...))'`.

---
Automated fix by lean-mechanic agent.