### PR TITLE
fix(meta): batch sync InfinitudePrimes4k3.lean leanFiles[] in 5 infinitude-primes siblings (post-S9-ACT-R1 #19643)

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k3.json
+++ b/src/data/research/problems/infinitude-primes-4k3.json
@@ -60,8 +60,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 231,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-oq-01.json
@@ -92,8 +92,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 231,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-02.json
+++ b/src/data/research/problems/infinitude-primes-oq-02.json
@@ -92,8 +92,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 231,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-oq-03.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 230,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-04.json
+++ b/src/data/research/problems/infinitude-primes-oq-04.json
@@ -91,8 +91,8 @@
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",
       "filename": "InfinitudePrimes4k3.lean",
-      "lineCount": 231,
-      "theoremCount": 7,
+      "lineCount": 256,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

PR #19643 (S9 ACT R1: Path C Tower) expanded `InfinitudePrimes4k3.lean` from 231 lines / 7 theorems to **256 lines / 8 theorems** (parent `_bounded` +26 LOC).

The S9 ACT slug `infinitude-primes-4k3-oq-01` absorbed the new values; gallery `src/data/proofs/infinitude-primes-4k3/meta.json` was synced in PR #19666. But 5 ancestor / sibling **research JSONs** (`src/data/research/problems/*.json`) still held the pre-S9 numbers.

## Evidence

Actual file stats (current `main`):

```text
proofs/Proofs/InfinitudePrimes4k3.lean: 256 lines, 8 theorems, 0 axioms, 0 defs, 0 sorries
```

Gallery canonical (`src/data/proofs/infinitude-primes-4k3/meta.json`) records `lineCount: 256, theoremCount: 8` for this file — confirms target values.

| slug | filename | `lineCount` | `theoremCount` |
|------|----------|------------:|---------------:|
| `infinitude-primes-4k3`    | `InfinitudePrimes4k3.lean` | 231 → **256** | 7 → **8** |
| `infinitude-primes-oq-01`  | `InfinitudePrimes4k3.lean` | 231 → **256** | 7 → **8** |
| `infinitude-primes-oq-02`  | `InfinitudePrimes4k3.lean` | 231 → **256** | 7 → **8** |
| `infinitude-primes-oq-03`  | `InfinitudePrimes4k3.lean` | 230 → **256** | 7 → **8** |
| `infinitude-primes-oq-04`  | `InfinitudePrimes4k3.lean` | 231 → **256** | 7 → **8** |

Other fields on each entry (`axiomCount=0`, `defCount=0`, `sorryCount=0`) were already correct and remain unchanged.

All 5 JSON files re-validated with `python3 -m json.tool`. No changes to `.lean` files, gallery meta, or other slugs.

---

Automated fix by lean-mechanic agent.