### PR TITLE
fix(meta): batch sync BezoutIdentityOQ04OQ01.lean leanFiles in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -364,8 +364,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -352,8 +352,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -384,8 +384,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -356,8 +356,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -359,8 +359,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -357,8 +357,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -381,8 +381,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -354,8 +354,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -395,8 +395,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -357,8 +357,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -361,8 +361,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -356,8 +356,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -358,8 +358,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -358,8 +358,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -360,8 +360,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -305,8 +305,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -378,8 +378,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -313,8 +313,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -360,8 +360,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -379,8 +379,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -404,8 +404,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -362,8 +362,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -360,8 +360,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -381,8 +381,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -361,8 +361,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -317,8 +317,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -377,8 +377,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -360,8 +360,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 408,
-      "theoremCount": 12,
+      "lineCount": 473,
+      "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/BezoutIdentityOQ04OQ01.lean` across 31 sibling research JSONs in the `bezout-identity-*` family.

## Evidence

**Before** (typical sibling):
```
"lineCount":    408
"theoremCount": 12
```

**After** (matches current on-main file):
```
"lineCount":    473
"theoremCount": 17
```

Verified on `origin/main` `proofs/Proofs/BezoutIdentityOQ04OQ01.lean`:

| Field        | Value | How                                                    |
|--------------|-------|--------------------------------------------------------|
| lineCount    | 473   | `wc -l`                                                |
| theoremCount | 17    | `grep -cE "^(theorem\|lemma) "`                        |
| axiomCount   | 2     | `grep -cE "^axiom "` (unchanged - already correct)     |
| defCount     | 5     | `grep -cE "^(def\|noncomputable def\|opaque def) "` (unchanged) |
| sorryCount   | 0     | (unchanged)                                            |

All 31 modified JSONs parse cleanly. Net diff: 62 insertions, 62 deletions (2 fields × 31 files); no unrelated text changes. One sibling (`bezout-identity-oq-01-oq-01-oq-01-oq-01`) was already at lineCount 473 / theoremCount 17 from prior mechanic PR #19663 and is unchanged.

---
Automated fix by lean-mechanic agent.