### PR TITLE
fix(meta): sync BallotProblemOQ02OQ05.lean leanFiles entry in ballot-problem-oq-03-oq-01-oq-01-oq-01 (post-S6-ACT #19675)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -396,11 +396,11 @@
     {
       "path": "Proofs/BallotProblemOQ02OQ05.lean",
       "filename": "BallotProblemOQ02OQ05.lean",
-      "lineCount": 131,
-      "theoremCount": 0,
+      "lineCount": 229,
+      "theoremCount": 4,
       "axiomCount": 1,
-      "defCount": 3,
-      "sorryCount": 1,
+      "defCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ05.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[]` entry for `Proofs/BallotProblemOQ02OQ05.lean` in sibling `ballot-problem-oq-03-oq-01-oq-01-oq-01.json` after #19675 (S6 ACT — discrete_reflection skeleton).

## Evidence

PR #19675 expanded the file from 131 -> 229 LOC, adding 4 theorems, 4 new defs, and 3 new sorry tactics. The S6 ACT slug (`ballot-problem-oq-02-oq-05`) absorbed the new values; the sibling tracker still held pre-S6 numbers.

| field         | old | new |
|---------------|----:|----:|
| lineCount     | 131 | 229 |
| theoremCount  |   0 |   4 |
| defCount      |   3 |   7 |
| sorryCount    |   1 |   4 |
| axiomCount    |   1 |   1 (unchanged) |

**Counted on `origin/main` `proofs/Proofs/BallotProblemOQ02OQ05.lean`** using the convention from recent ballot-problem mechanic PRs (#19744, #19726):

- `wc -l` -> **229**
- `grep -cE '^(theorem|lemma) '` -> **4**
- `grep -cE '^(noncomputable )?(def|abbrev) '` -> **7**
- `grep -cE '^axiom '` -> **1**
- Actual `sorry` tactic invocations (lines 185, 196, 206, 225) -> **4**

JSON re-validated with `python3 -m json.tool`. No `.lean`, gallery `meta.json`, or other slug changes.

**Scope note:** Only one tracked sibling JSON referenced this file on `origin/main`. The second nominal sibling (`ballot-problem-oq-01-oq-02-oq-01-oq-01.json`) is not yet present in the repo, so no batch is possible.

---
Automated fix by lean-mechanic agent.