### PR TITLE
fix(meta): erdos-57 sorries 2 → 4 (restore chain count per PR #17280)

### DIFF
--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",
     "erdosProblemStatus": "solved",
@@ -202,5 +202,5 @@
       "note": "High-girth constructions showing χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — demonstrating the reciprocal sum divergence in Problem #57 is precisely calibrated"
     }
   ],
-  "sorries": 2
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Restore `src/data/proofs/erdos-57/meta.json` `meta.sorries` and top-level `sorries` to **4** (chain count: main + Aristotle companion). PR #19686 (merged a few hours ago, 2026-05-16T16:20:25Z) regressed these to 2 (main-file-only), inadvertently breaking the gallery-wide convention from PR #17280.

## Convention (per PR #17280)

> Per the auditor convention, `meta.sorries` and top-level `sorries` reflect the total sorry count across the full file chain (main + Aristotle companion via `additionalFiles`), while `leanFile.sorries` counts only the main file.

| Field | Scope | erdos-57 value |
| --- | --- | --- |
| `leanFile.sorries` | main file only | 2 (unchanged — already correct) |
| `meta.sorries` | chain (main + companion) | **2 → 4** |
| top-level `sorries` | chain (main + companion) | **2 → 4** |

## Evidence

```
$ grep -n 'sorry$' proofs/Proofs/Erdos57Problem.lean
148:  sorry
153:  sorry
$ grep -n '^  sorry' proofs/Proofs/Erdos57ProblemAristotle.lean
46:  sorry
64:  sorry
```

Main = 2 sorries (bipartite-characterization theorems). Aristotle companion = 2 open targets. Chain = **4**.

## Convention survey

Of the 78 gallery slugs with Aristotle companions:
- **76** use chain-counted `meta.sorries` (== main + companion)
- **1** uses main-only (was `erdos-57` after PR #19686 — the regression)
- **1** is in a transitional mixed state

This PR restores erdos-57 to the dominant convention.

## Why PR #19686's reasoning didn't apply

PR #19686 cited `leanFile.sorries=2` matching `meta.sorries=4` as a "mismatch" and aligned them. But these fields intentionally measure different scopes — that "mismatch" is by design when an Aristotle companion exists with open targets.

## What this PR does NOT touch

- `leanFile.sorries` (stays at 2 — main-file-only, correct)
- `meta.assumptions` text (freeform; other chain-counted slugs like erdos-1018 also keep main-file numbers in prose)
- `meta.status` / `meta.badge` (axiomatized / axiom — unchanged)
- Lean source files (unchanged)

## Test plan
- [x] `python3 -c 'import json; json.load(open(...))'` passes
- [x] No Lean source changes
- [x] `meta.status` remains `axiomatized`
- [x] `leanFile.sorries` preserved at 2

---
Automated fix by lean-mechanic agent.