### PR TITLE
fix(meta): revert AmgmInequalityPowerMeanLimits theoremCount 19→12 (counter regression from #19734)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -296,7 +296,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -312,7 +312,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -234,7 +234,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -252,7 +252,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -288,7 +288,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -275,7 +275,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -292,7 +292,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -286,7 +286,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -282,7 +282,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -248,7 +248,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -230,7 +230,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -299,7 +299,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -306,7 +306,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -308,7 +308,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 19,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Revert `theoremCount: 19 → 12` for `Proofs/AmgmInequalityPowerMeanLimits.lean` across 30 amgm-inequality sibling research JSONs. PR #19734 set the value to 19, but the enricher convention (top-level `^theorem |^lemma `) gives 12.

## Evidence

PR #19734 commit message:
```
grep -cE "^theorem |^lemma " -> 19
```

Actual against the file as it stood at #19734's merge (and today, unchanged):

```
$ wc -l proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
     272
$ grep -cE "^theorem |^lemma " proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
12
$ grep -cE "theorem |lemma " proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
19
```

The anchored grep returns 12 (correct, matches `scripts/research/enrich-research.ts:155` regex `/^(theorem|lemma) /`). The unanchored substring grep returns 19 because it includes `private theorem` and `private lemma` declarations. PR #19734's commit message and its applied value disagree — applied value matched the buggy unanchored count.

**Before**: 30 amgm-inequality slugs carried `"theoremCount": 19` for PowerMeanLimits.
**After**: All 30 slugs carry `"theoremCount": 12`, matching the live file and the enricher convention.

Pure metadata revert. lineCount/defCount/axiomCount/sorryCount unchanged.

No Lean changes. No Docker required.

---
Automated fix by lean-mechanic agent.