### PR TITLE
fix(meta): prob-method-lovasz-local-oq-01 MoserTardos.lean leanFiles drift post-S6-ACT

### DIFF
--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -123,11 +123,11 @@
     {
       "path": "Proofs/MoserTardos.lean",
       "filename": "MoserTardos.lean",
-      "lineCount": 243,
-      "theoremCount": 2,
+      "lineCount": 382,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MoserTardos.lean"
     }


### PR DESCRIPTION
## Fix

Sync the `leanFiles[1]` entry for `proofs/Proofs/MoserTardos.lean` in
`src/data/research/problems/prob-method-lovasz-local-oq-01.json`. The entry was stale at the
post-S2-ACT baseline (243 LOC / 2 thms / 1 sorry); subsequent S3 / S5 / S5b ACT merges (PRs
#18400 / #18629 / #18960) grew the file to 382 LOC and discharged the only algorithmic sorry,
while S6 ACT build-verify (#19103) confirmed the file builds at the larger size — but no PR
in the chain refreshed `leanFiles[]`.

## Evidence

**Before** (post-#18213 S2-ACT baseline, never refreshed since):
```json
{
  "path": "Proofs/MoserTardos.lean",
  "lineCount": 243, "theoremCount": 2, "axiomCount": 0,
  "defCount": 5,   "sorryCount": 1
}
```

**After** (this PR):
```json
{
  "path": "Proofs/MoserTardos.lean",
  "lineCount": 382, "theoremCount": 5, "axiomCount": 0,
  "defCount": 5,   "sorryCount": 0
}
```

| Field | Before | After | Source |
|---|---|---|---|
| `lineCount` | 243 | 382 | `wc -l` (S5b ACT +113, S3/S5/S6 minor; matches progressSummary `269 → 382`) |
| `theoremCount` | 2 | 5 | `grep -cE "^(theorem\|lemma) "` (3 lemmas + 2 theorems) |
| `axiomCount` | 0 | 0 | unchanged (`grep -cE "^axiom "` → 0) |
| `defCount` | 5 | 5 | unchanged (`grep -cE "^(def\|noncomputable def) "` → 5) |
| `sorryCount` | 1 | 0 | S3 ACT (#18400) closed `resampleAt` sorry; both remaining `grep "sorry"` matches are docstring mentions on lines 7 + 22 (file-level `/- ... -/`), not tactic sites |

Re-runnable verification on origin/main:
```bash
wc -l                                          proofs/Proofs/MoserTardos.lean  # → 382
grep -cE "^axiom "                             proofs/Proofs/MoserTardos.lean  # → 0
grep -cE "^(theorem|lemma) "                   proofs/Proofs/MoserTardos.lean  # → 5
grep -cE "^(def|noncomputable def) "           proofs/Proofs/MoserTardos.lean  # → 5
grep -nE "(^|[^A-Za-z_'])sorry([^A-Za-z_'])"   proofs/Proofs/MoserTardos.lean
# → 2 matches at lines 7 + 22, both inside the file-level docstring (`(with `sorry`)` and `` `sorry`s below `` in prose); 0 tactic sites
```

The slug's `progressSummary` already documents the new state ("Net delta +113 LOC (269 → 382), 0 new sorries", "dropped from 1 → 0 algorithmic sorries"); only `leanFiles[]` was missed.

## Scope

- 1 file, 3 insertions, 3 deletions (single `leanFiles[1]` entry refresh).
- No Lean source edits.
- No `pnpm build` (would regenerate ~1047 research JSONs per memory feedback).
- No state.md / problem.md / knowledge.md / sibling-slug / lake-manifest / `builtItems` history edits.
- No gallery `meta.json` edits (no `src/data/proofs/prob-method-lovasz-local-oq-01/` directory).
- `leanFiles[0]` (`LovaszLocalLemma.lean`) left untouched — `lineCount` already correct (364); `theoremCount` 25 vs current grep 24 is a long-standing one-off counting drift unrelated to recent ACT activity, out of scope here.

---
Automated fix by lean-mechanic agent.