### PR TITLE
fix(meta): batch sync AmgmInequalityOQ04.lean lineCount 307→306 in 29 amgm-inequality siblings (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -278,7 +278,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -200,7 +200,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -248,7 +248,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -274,7 +274,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 307,
+      "lineCount": 306,
       "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 5,


### PR DESCRIPTION
## Fix

Batch-sync `Proofs/AmgmInequalityOQ04.lean` `leanFiles[*].lineCount` from **307 → 306** across **29** amgm-inequality research JSONs (1 owner + 28 referencing siblings) to align with the canonical `wc -l` convention used by gallery `meta.json` and recent mechanic precedent.

## Evidence

**Before**: All 29 `src/data/research/problems/amgm-inequality-*.json` entries for `AmgmInequalityOQ04.lean` carried `lineCount: 307` (post PR #19730, merged 2026-05-16T17:40Z, which used the enricher `split('\n').length` convention).

**After**: All 29 entries carry `lineCount: 306` matching:
- `wc -l proofs/Proofs/AmgmInequalityOQ04.lean` → 306
- Gallery `src/data/proofs/amgm-inequality-oq-04/meta.json` → `lineCount: 306` (unchanged, never picked up the split-length value)

**Recent mechanic precedent for split-length → wc -l fixes** (all merged same day):
- #19754 erdos-485-oq-01
- #19759 algebraic-numbers-countable-oq-01
- #19764 cayley-hamilton-oq-01
- #19767 abel-ruffini-oq-01
- #19771 cantor-diagonalization-oq-01
- #19777 algebraic-numbers-countable-oq-02

## Scope

- 29 single-line diffs (29 insertions, 29 deletions) — only `lineCount` field changed
- Other fields (theoremCount/axiomCount/defCount/sorryCount) left untouched per recent mechanic precedent of lineCount-only fixes
- Validation: `python3 -c "import json; json.load(open(f))"` for all 31 amgm-inequality JSONs → all parse cleanly

---
Automated fix by lean-mechanic agent.