### PR TITLE
fix(meta): shannon-entropy leanFiles[] sync — 7 entries (ShannonEntropy +294 LOC, SSA +184 LOC -1 sorry, 4× off-by-one)

### DIFF
--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -130,8 +130,8 @@
     {
       "path": "Proofs/ShannonEntropy.lean",
       "filename": "ShannonEntropy.lean",
-      "lineCount": 902,
-      "theoremCount": 17,
+      "lineCount": 1196,
+      "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/ShannonEntropyAristotle.lean",
       "filename": "ShannonEntropyAristotle.lean",
-      "lineCount": 123,
+      "lineCount": 122,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 624,
+      "lineCount": 623,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/ShannonEntropyOQ01Aristotle.lean",
       "filename": "ShannonEntropyOQ01Aristotle.lean",
-      "lineCount": 29,
+      "lineCount": 28,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/ShannonEntropyOQ02.lean",
       "filename": "ShannonEntropyOQ02.lean",
-      "lineCount": 384,
+      "lineCount": 383,
       "theoremCount": 9,
       "axiomCount": 3,
       "defCount": 4,
@@ -185,18 +185,18 @@
     {
       "path": "Proofs/ShannonEntropySSA.lean",
       "filename": "ShannonEntropySSA.lean",
-      "lineCount": 342,
+      "lineCount": 526,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropySSA.lean"
     },
     {
       "path": "Proofs/ShannonEntropySSAAristotle.lean",
       "filename": "ShannonEntropySSAAristotle.lean",
-      "lineCount": 75,
+      "lineCount": 74,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 6,


### PR DESCRIPTION
## Fix

Sync `src/data/research/problems/shannon-entropy.json` `leanFiles[]` entries
to current Lean source state. The slug was last touched 2026-03-21 (Iter 1),
while downstream `shannon-channel-coding-oq-02-oq-01-oq-01` ACTs (PRs #19061,
#19393, S11+S15) grew `ShannonEntropy.lean` from 902 → 1196 LOC and
`ShannonEntropySSA.lean` from 342 → 526 LOC (also discharging 1 sorry in
the latter) without back-syncing this slug.

## Evidence (7 leanFiles[i] entries, +9/-9 numeric lines)

| File                              | lineCount   | other     |
| --------------------------------- | ----------- | --------- |
| ShannonEntropy.lean               | 902 → 1196  | thm 17→23 |
| ShannonEntropyAristotle.lean      | 123 → 122   | —         |
| ShannonEntropyOQ01.lean           | 624 → 623   | —         |
| ShannonEntropyOQ01Aristotle.lean  | 29 → 28     | —         |
| ShannonEntropyOQ02.lean           | 384 → 383   | —         |
| ShannonEntropySSA.lean            | 342 → 526   | sorry 1→0 |
| ShannonEntropySSAAristotle.lean   | 75 → 74     | —         |

## Convention

\`lineCount\` = \`wc -l\` (matches gallery \`meta.json\` \`lineCount=1196\`
for shannon-entropy slug + recent mechanic PRs #19663, #19667, #19754, #19767).
\`theoremCount\` = \`grep -cE \"^(theorem|lemma) \"\` per
\`scripts/research/enrich-research.ts\` convention.
\`sorryCount\` = \`grep -oE \"\bsorry\b\"\` per same script.

The 4 off-by-one lineCount fixes are the standard \`split('\n').length → wc -l\`
adjustment per memory + same recent mechanic-PR precedents.

## Validation

\`\`\`
\$ python3 -c \"import json; json.load(open('src/data/research/problems/shannon-entropy.json'))\"
JSON OK
\$ wc -l proofs/Proofs/ShannonEntropy.lean proofs/Proofs/ShannonEntropySSA.lean
    1196 proofs/Proofs/ShannonEntropy.lean
     526 proofs/Proofs/ShannonEntropySSA.lean
\$ grep -cE \"^(theorem|lemma) \" proofs/Proofs/ShannonEntropy.lean
23
\$ grep -oE \"\\\\bsorry\\\\b\" proofs/Proofs/ShannonEntropySSA.lean | wc -l
       0
\`\`\`

## Not touched (out of mechanic scope)

- Sibling slugs (\`shannon-entropy-oq-01\` COMPLETED 2026-05-13, \`-oq-02\`,
  \`-oq-03\`) — separate-PR territory per \"one fix per PR\" mechanic
  discipline.
- \`currentState.iteration\`, \`currentState.focus\`, \`knowledge.*\`,
  \`lastUpdate\` — researcher territory; this PR only syncs \`leanFiles[]\`.
- Lean source files (unchanged; gallery \`meta.json\` already current at
  lineCount=1196).

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)