### PR TITLE
fix(meta): batch sync BuffonsNeedleOQ02OQ03.lean leanFiles in 16 buffons-needle siblings

### DIFF
--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
@@ -172,10 +172,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
@@ -159,10 +159,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
@@ -164,10 +164,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
@@ -182,10 +182,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
@@ -186,10 +186,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01.json
@@ -166,10 +166,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
@@ -163,10 +163,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -201,10 +201,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-03.json
@@ -164,10 +164,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-04.json
@@ -165,10 +165,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01.json
@@ -170,10 +170,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-01.json
@@ -120,10 +120,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-02-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-02.json
@@ -140,10 +140,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-02-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-03.json
@@ -41,7 +41,7 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 27,
       "axiomCount": 3,
       "defCount": 7,

--- a/src/data/research/problems/buffons-needle-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02.json
@@ -166,10 +166,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"

--- a/src/data/research/problems/buffons-needle-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-03.json
@@ -174,10 +174,10 @@
     {
       "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
       "filename": "BuffonsNeedleOQ02OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 4,
+      "lineCount": 285,
+      "theoremCount": 27,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"


### PR DESCRIPTION
## Fix

`BuffonsNeedleOQ02OQ03.lean` has grown significantly since its initial enrichment but the 15 sibling buffons-needle research JSONs never picked up the new metrics. Plus the canonical slug (`buffons-needle-oq-02-oq-03`) carried an off-by-one `lineCount` (split-length → wc -l).

## Evidence

**Canonical values** (gallery `src/data/proofs/buffons-needle-oq-02-oq-03/meta.json` + actual file at HEAD):
| metric | value |
|---|---|
| `lineCount` | 285 |
| `theoremCount` | 27 |
| `axiomCount` | 3 |
| `defCount` | 7 |
| `sorryCount` | 0 |

**Sibling drift (15 of 16 slugs)** `leanFiles[9]` for `Proofs/BuffonsNeedleOQ02OQ03.lean`:
| field | recorded | canonical |
|---|---|---|
| `lineCount` | 248 | 285 |
| `theoremCount` | 12 | 27 |
| `axiomCount` | 2 | 3 |
| `defCount` | 4 | 7 |
| `sorryCount` | 0 | 0 |

**Main slug drift (oq-02-oq-03)** `leanFiles[0]`:
| field | recorded | canonical |
|---|---|---|
| `lineCount` | 286 | 285 |

Slugs updated (16 total):
- `buffons-needle-oq-02-oq-03` (main, off-by-one only)
- `buffons-needle-oq-01`, `buffons-needle-oq-02`, `buffons-needle-oq-03`
- `buffons-needle-oq-02-oq-01`, `buffons-needle-oq-02-oq-02`
- `buffons-needle-oq-01-oq-01`, `buffons-needle-oq-01-oq-02`, `buffons-needle-oq-01-oq-03`, `buffons-needle-oq-01-oq-04`
- `buffons-needle-oq-01-oq-01-oq-01` … `oq-04`, `oq-04-oq-01`
- `buffons-needle-oq-01-oq-02-oq-01`, `buffons-needle-oq-01-oq-01-oq-03`

All 16 JSONs validated with `python3 -m json.tool`.

---
Automated fix by lean-mechanic agent.