### PR TITLE
fix(meta): batch sync BezoutIdentity.lean leanFiles in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -30,7 +30,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -38,7 +38,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -42,7 +42,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 238,
+      "lineCount": 237,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/BezoutIdentity.lean` across 31 sibling research JSONs in the `bezout-identity-*` family. Off-by-one drift from the historical `split('\n').length` convention vs. the canonical `wc -l` used by recent mechanic PRs.

## Evidence

**Before**: 31 of 31 siblings carried `lineCount: 238` for `Proofs/BezoutIdentity.lean`.
**After**: All 31 carry `lineCount: 237` (matches `wc -l proofs/Proofs/BezoutIdentity.lean`).

Other fields verified unchanged against the actual file:
- `theoremCount: 8`  (`grep -cE '^(theorem|lemma) '` → 8)
- `axiomCount: 0`    (`grep -cE '^axiom '` → 0)
- `defCount: 0`      (`grep -cE '^(def|noncomputable def|opaque def) '` → 0)
- `sorryCount: 0`    (`grep -cE '\bsorry\b'` → 0)

Net diff: 31 files changed, 31 insertions, 31 deletions (1 field × 31 files); no unrelated text changes. Preserves each file's existing unicode encoding via targeted regex substitution. All 31 modified JSONs parse cleanly with `python json.load`.

Same drift pattern as recent mechanic PRs #19785 (BezoutIdentityOQ04OQ01.lean), #19771, #19767, #19764, #19759, #19754.

---
Automated fix by lean-mechanic agent.