### PR TITLE
fix(meta): batch sync BorsukUlamOQ04.lean leanFiles in 22 borsuk-ulam siblings

### DIFF
--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
@@ -227,10 +227,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
@@ -251,10 +251,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
@@ -232,10 +232,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
@@ -233,10 +233,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
@@ -238,10 +238,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
@@ -289,10 +289,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
@@ -202,10 +202,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
@@ -246,10 +246,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
@@ -236,10 +236,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -240,10 +240,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
@@ -229,10 +229,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -228,10 +228,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -235,10 +235,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -215,10 +215,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
@@ -237,10 +237,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -243,10 +243,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
@@ -251,10 +251,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
@@ -233,10 +233,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -459,10 +459,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
@@ -228,10 +228,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
@@ -238,10 +238,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -269,10 +269,10 @@
     {
       "path": "Proofs/BorsukUlamOQ04.lean",
       "filename": "BorsukUlamOQ04.lean",
-      "lineCount": 301,
-      "theoremCount": 7,
+      "lineCount": 449,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"


### PR DESCRIPTION
## Fix

Research-JSON `leanFiles[i]` for `Proofs/BorsukUlamOQ04.lean` was stale in 22 of 24 borsuk-ulam siblings — last enriched when the file was at 301 LOC (commit `2b692ebea4f`, 2026-05-05, +GCovering framework). Two intervening ACT-touch commits brought the file to its current 449/12/11 state:

  * `2ace1c84053` (2026-05-12, PR #18059 cross-touch)
  * `ecb47b35601` (2026-05-16, PR #19454 sperner-ndim S2-A ACT cross-touch)

Two siblings already had the current values (last enriched at 449 LOC):

  * `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02`
  * `borsuk-ulam-oq-02-oq-01-oq-03-oq-02`

This PR aligns the remaining 22 to match those two and the `enrich-research.ts` script (`split('\n').length` convention, matching recent mechanic batch PRs #19797 / #19785 / #19772 / #19766).

## Evidence

| field          | before | after | actual (script regex)                                              |
|----------------|--------|-------|--------------------------------------------------------------------|
| lineCount      | 301    | 449   | 449 (`split('\n').length`)                                          |
| theoremCount   | 7      | 12    | 12 (`grep -cE '^(theorem\|lemma) '`)                                |
| axiomCount     | 0      | 0     | 0  (no change)                                                      |
| defCount       | 8      | 11    | 11 (`grep -cE '^(def\|noncomputable def\|opaque def) '`)            |
| sorryCount     | 0      | 0     | 0  (no change)                                                      |

Verified against `proofs/Proofs/BorsukUlamOQ04.lean` @ `origin/main` HEAD `0e452672e60` using `scripts/research/enrich-research.ts:140-182` regex.

## Scope

- 22 file edits — exactly 3 numeric fields per file (`lineCount`, `theoremCount`, `defCount`).
- No `.lean` source changes.
- No gallery `src/data/proofs/borsuk-ulam-*/meta.json` changes (those reference the file via `proofRepoPath` not `leanFiles[]` and are already clean per a full-gallery scan I ran).
- No `axiomCount` / `sorryCount` touch (no drift).
- No `state.md` / `knowledge.md` / `problem.md` touch (researcher territory).
- The 2 already-current siblings left untouched.

JSON validated with `python3 -m json.tool` (all 22 parse).

---
Automated fix by lean-mechanic agent.