### PR TITLE
fix(meta): brouwer-fixed-point-oq-01-oq-02 theoremCount 13→14 (post-S7-ACT-D-1 #18168)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -51,12 +51,12 @@
       "H_n_minus_1_sphere_nonzero: residual deep axiom for H_{n-1}(S^{n-1}) ≠ 0 + retraction-functoriality (Mathlib gap B2)",
       "contractible_singularHomology_zero: thin B1-surrogate axiom — the n-th singular homology of a contractible space is zero for n ≥ 1 (slated for upstream contribution via the prism operator)",
       "singular_homology_retraction_split: composite split, now a derived theorem rather than an axiom; preserved for downstream callers",
-      "13 total theorems separating algebraic core (0 axioms), ball-zero scaffold + substantive form (theorems), and the two residual axioms (B1 surrogate + B2 sphere-nonzero)"
+      "14 total theorems separating algebraic core (0 axioms), ball-zero scaffold + substantive form (theorems), and the residual axioms (B1 surrogate + B2 sphere-nonzero, with the S7 ACT-D-1 substantive H_{n-1}(S^{n-1}) ≠ 0 theorem added)"
     ],
     "dateAdded": "2026-04-04",
     "lineCount": 462,
     "assumptions": "3 axioms. (1) H_n_minus_1_sphere_nonzero (n ≥ 1, r : Retraction n, φ : ℤ →+ Unit) ⇒ ∃ ψ : Unit →+ ℤ, ψ.comp φ = id ℤ — mock-form B2 surrogate composing the deep singular-homology facts H_{n-1}(S^{n-1}) ≅ ℤ (Mathlib gap B2: no Mayer–Vietoris, no excision, no sphere homology) with retraction-functoriality. (2) contractible_singularHomology_zero (n ≥ 1, X : Type, [TopologicalSpace X] [ContractibleSpace X]) ⇒ singularHomology n X is zero — a thin classical-fact surrogate for Mathlib gap B1 (the prism operator bridging topological homotopy and chain homotopy). (3) sphere_singularHomology_nonzero (n ≥ 1) ⇒ singularHomology n (UnitSphere (n+1)) is non-zero — strictly weaker substantive B2 surrogate landed in S7 ACT-D-1 (only asserts non-vanishing, not the full H_n(𝕊 n) ≅ ℤ), driving H_n_minus_1_sphere_nonzero_substantive while leaving the algebraic Section G7 bridge for S8. The mock-form lemma H_n_minus_1_ball_zero is preserved as a trivial theorem (existential witness ⟨0, trivial⟩); alongside it H_n_minus_1_ball_zero_substantive is proved using contractible_singularHomology_zero. The composite singular_homology_retraction_split is preserved as a derived theorem combining the mock form with sphere-nonzero. no_retraction_axiom appears only in a block-comment example, not as an actual axiom. The algebraic argument (Part II) is fully proved with 0 axioms.",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 3
   },
   "overview": {
@@ -152,7 +152,7 @@
     "axiomCount": 4,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 13
+    "theoremCount": 14
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json` reports `theoremCount: 13` in both the `meta` block and the nested `leanFile` block, but the actual file has **14** theorems. PR #18168 (S7 ACT-D-1, merged 2026-05-12) added `H_n_minus_1_sphere_nonzero_substantive` (`BrouwerFixedPointOQ01OQ02.lean:375`); meta was not synced.

## Evidence

The Lean file's own header line 49 already self-documents the truth:

```
## Summary: 14 theorems, 0 sorries, 4 axioms
```

Canonical lexical count (matches `scripts/research/enrich-research.ts:155`):

```
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean
14
```

All 14 matches lie outside `/-...-/` block comments (verified by reading the
file's comment markers at lines 12/110, 143/151, 199/218 — no `theorem`
declarations fall inside any of those ranges).

## Changes

* `meta.theoremCount`: 13 → 14
* `leanFile.theoremCount`: 13 → 14
* `meta.originalContributions[-1]`: "13 total theorems …" → "14 total theorems …"
  with a brief note that S7 ACT-D-1 contributed the substantive
  `H_{n-1}(S^{n-1}) ≠ 0` theorem.

3 line edits in one file.

## Not in scope (deliberately)

* `axiomCount` (meta + leanFile both = 4): the lexical `grep -c '^axiom '` count is also 4. One of those four declarations sits inside the file-header `/-...-/` block at line 44 as an *example*, and `meta.assumptions` text already states "no_retraction_axiom appears only in a block-comment example, not as an actual axiom" and enumerates **3** real axioms. Reconciling that internal inconsistency is non-trivial (overview prose elsewhere still says "2 axioms" — pre-S7 stale) and belongs to enrichment / researcher scope, not a minimal mechanic count-sync.
* Narrative prose in `meta.overview.*` — out of scope for mechanic.
* The Lean file itself — not touched.

## Validation

* JSON parses via `python3 -c "import json; json.load(open(...))"`
* `pnpm build` skipped per single-slug-mechanic convention (avoids regenerating ~1047 research JSONs; see #19663/#19667).

---
Automated fix by lean-mechanic agent.