### PR TITLE
fix(meta): basel-problem-oq-01-oq-01-oq-02-oq-03 research-json leanFiles[0] sync (341→1642 LOC, 33→73 thm)

### DIFF
--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
       "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
-      "lineCount": 341,
-      "theoremCount": 33,
+      "lineCount": 1642,
+      "theoremCount": 73,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Companion repair to merged gallery-meta PR **#19515** (which fixed
`src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json`
`lineCount` 1469→1642 + `theoremCount` 72→73 for the same Lean file).

The research-side JSON `src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json`'s
`leanFiles[0]` entry for `BaselProblemOQ01OQ01OQ02OQ03.lean` was last set at the
file's original 341 LOC / 33 thm baseline and was missed by every subsequent
research-iteration PR. Current research state (per `progressSummary` quoted
below) is **iter 36, 1642 LOC, 73 theorems, 1 axiom, 0 sorries**.

## Evidence

**Before** (post-bootstrap baseline, never refreshed):
```json
{
  "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
  "lineCount": 341,
  "theoremCount": 33,
  "axiomCount": 1,
  "defCount": 1,
  "sorryCount": 0
}
```

**After** (this PR — matches gallery meta.json + actual file):
```json
{
  "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
  "lineCount": 1642,
  "theoremCount": 73,
  "axiomCount": 1,
  "defCount": 1,
  "sorryCount": 0
}
```

| Field | Before | After | Source |
|---|---|---|---|
| `lineCount` | 341 | 1642 | `wc -l` (matches gallery `meta.lineCount` post-#19515; matches research `progressSummary` "Lean file 1469 → 1642 LOC") |
| `theoremCount` | 33 | 73 | `grep -cE "^(theorem\|lemma) "` → 73 (matches gallery `meta.theoremCount` post-#19515) |
| `axiomCount` | 1 | 1 | unchanged (`grep -cE "^axiom "` → 1, `axiom hanson_bound` at line 1631) |
| `defCount` | 1 | 1 | unchanged (`grep -cE "^(def\|noncomputable def\|opaque def) "` → 1) |
| `sorryCount` | 0 | 0 | unchanged — single `\bsorry\b` match at line 1301 is inside a docstring comment ("`Three-step term-mode, sorry-free, axiom-free. -/`"), not a tactic site; matches gallery `meta.sorries=0` and #19515's same finding |

Re-runnable verification on origin/main:
```bash
wc -l                                              proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean  # → 1642
grep -cE "^(theorem|lemma) "                       proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean  # → 73
grep -cE "^axiom "                                 proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean  # → 1
grep -cE "^(def|noncomputable def|opaque def) "    proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean  # → 1
grep -nE "\bsorry\b"                               proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
# → 1301:    Three-step term-mode, sorry-free, axiom-free. -/   (comment, not tactic)
```

## Scope

- 1 file, 2 insertions, 2 deletions (single `leanFiles[0]` entry refresh).
- No Lean source touched.
- No `pnpm build` (per mechanic memory: regenerates ~1047 research JSONs via `research:enrich` which uses `split('\n').length` = `wc -l + 1`, and would also re-flip `sorryCount` 0 → 1 by counting the docstring mention).
- No state.md / problem.md / knowledge.md / sibling-slug / lake-manifest edits.
- No `currentState` / `knowledge.progressSummary` / `builtItems` edits — those already document the new state ("Lean file 1469 → 1642 LOC"); only the `leanFiles[]` snapshot was lagging.
- 1 slug references this Lean file (verified): `basel-problem-oq-01-oq-01-oq-02-oq-03` only — no batch-sync siblings.

Aligns with mechanic precedent:
- #19515 (this slug's gallery meta.json — same drift, same Lean file)
- #19792 (`prob-method-lovasz-local-oq-01` `MoserTardos.lean` leanFiles refresh post-S6-ACT — same single-entry research-JSON sync template)

JSON validated via `python3 -c 'import json; json.load(open(...))'`.

---
Automated fix by lean-mechanic agent.