### PR TITLE
audit: batch tracker update — 11 erdos slugs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9690,9 +9690,9 @@
     },
     "erdos-796": {
       "agentId": "auditor-loop",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:48:37Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:16Z",
+      "result": "clean"
     },
     "erdos-797": {
       "agentId": "auditor-cycle-20-batch",
@@ -9738,15 +9738,15 @@
     },
     "erdos-802": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:33:24Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
+      "result": "clean"
     },
     "erdos-803": {
       "agentId": "auditor-loop-2026-04-29",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:52:12Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:16Z",
+      "result": "clean"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
@@ -9774,9 +9774,9 @@
     },
     "erdos-808": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:22:49Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
+      "result": "clean"
     },
     "erdos-809": {
       "auditCount": 5,
@@ -9798,26 +9798,26 @@
     },
     "erdos-811": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:09:58Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
       "result": "clean"
     },
     "erdos-812": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T23:41:57Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
+      "result": "clean"
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T23:50:32Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
+      "result": "clean"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-28T23:54:04Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T20:02:15Z",
       "result": "clean"
     },
     "erdos-815": {
@@ -9870,8 +9870,8 @@
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:06:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
       "result": "clean"
     },
     "erdos-823": {
@@ -9882,9 +9882,9 @@
     },
     "erdos-824": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T23:45:07Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:02:15Z",
+      "result": "clean"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity audit pass over 11 axiomatized erdos problems. All clean.

## Verification

For each slug, verified:
- `sorries` field matches actual `sorry` count in Lean source
- `axiomCount` matches actual `axiom` declarations (no structure-encoded assumptions found)
- No `True`-stub theorems / `:= trivial` placeholders
- status/badge consistency (`axiomatized` + `axiom`)

## Slugs audited

| Slug | Axioms | Sorries | Status | Badge |
|------|-------:|--------:|--------|-------|
| erdos-816 | 1 | 0 | axiomatized | axiom |
| erdos-812 | 3 | 0 | axiomatized | axiom |
| erdos-824 | 1 | 0 | axiomatized | axiom |
| erdos-813 | 3 | 0 | axiomatized | axiom |
| erdos-814 | 3 | 0 | axiomatized | axiom |
| erdos-822 | 1 | 0 | axiomatized | axiom |
| erdos-811 | 3 | 0 | axiomatized | axiom |
| erdos-808 | 2 | 0 | axiomatized | axiom |
| erdos-802 | 2 | 0 | axiomatized | axiom |
| erdos-796 | 2 | 0 | axiomatized | axiom |
| erdos-803 | 2 | 0 | axiomatized | axiom |

## Test plan

- [x] No content changes — `audit-tracker.json` only
- [x] All slugs already audited 3-4× prior; this pass confirms continued integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)