### PR TITLE
fix(meta): erdos-402-incomplete-01 research-json leanFiles[0] sync (328→693 LOC)

### DIFF
--- a/src/data/research/problems/erdos-402-incomplete-01.json
+++ b/src/data/research/problems/erdos-402-incomplete-01.json
@@ -97,11 +97,11 @@
     {
       "path": "Proofs/Erdos402Problem.lean",
       "filename": "Erdos402Problem.lean",
-      "lineCount": 328,
-      "theoremCount": 20,
+      "lineCount": 693,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 2,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos402Problem.lean"
     }


### PR DESCRIPTION
## Fix

Sync `src/data/research/problems/erdos-402-incomplete-01.json` `leanFiles[0]` to live measurements of `proofs/Proofs/Erdos402Problem.lean`.

## Evidence

**Before** (JSON state, last synced ~2026-03 via #9845 theoremCount sweep):
- `lineCount`: 328
- `theoremCount`: 20
- `sorryCount`: 2

**After** (live, via `wc -l` + enrich-research.ts regex):
- `lineCount`: 693 (+365)
- `theoremCount`: 19 (−1)
- `sorryCount`: 3 (+1)
- `axiomCount`: 0 (unchanged)
- `defCount`: 4 (unchanged)

## Drift Source

`Erdos402Problem.lean` grew via:
- #8130 — Erdős 402 triple case + structural lemmas
- #10463 — Radon-Nikodým Lp duality + quadruple case
- Subsequent enrichment touches

Research-json metadata was not re-synced after these merges. No prose/narrative in the JSON references the stale `328` value (only the `leanFiles[0].lineCount` field).

## Convention

`lineCount` uses `wc -l` (matches recent mechanic convention: PR #19754, #19759, #19764, #19767, #19771, #19777). Other count fields use the `scripts/research/enrich-research.ts` regex definitions verbatim.

## Validation

- `python3 -c "import json; json.load(open('src/data/research/problems/erdos-402-incomplete-01.json'))"` — valid
- No prose mentions of "328" elsewhere in JSON (`grep -n "328" …` returns only line 100)

---
Automated fix by lean-mechanic agent.