### PR TITLE
fix(meta): batch sync LiouvilleTheoremOQ04.lean + LiouvilleTheorem.lean leanFiles in 3 liouville siblings

### DIFF
--- a/src/data/research/problems/liouville-theorem-oq-01.json
+++ b/src/data/research/problems/liouville-theorem-oq-01.json
@@ -71,7 +71,7 @@
     {
       "path": "Proofs/LiouvilleTheorem.lean",
       "filename": "LiouvilleTheorem.lean",
-      "lineCount": 529,
+      "lineCount": 528,
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 0,
@@ -82,11 +82,11 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 529,
-      "theoremCount": 20,
+      "lineCount": 1344,
+      "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 7,
+      "defCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LiouvilleTheoremOQ04.lean"
     }

--- a/src/data/research/problems/liouville-theorem-oq-02.json
+++ b/src/data/research/problems/liouville-theorem-oq-02.json
@@ -52,7 +52,7 @@
     {
       "path": "Proofs/LiouvilleTheorem.lean",
       "filename": "LiouvilleTheorem.lean",
-      "lineCount": 529,
+      "lineCount": 528,
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 0,
@@ -63,11 +63,11 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 529,
-      "theoremCount": 20,
+      "lineCount": 1344,
+      "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 7,
+      "defCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LiouvilleTheoremOQ04.lean"
     }

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -58,7 +58,7 @@
     {
       "path": "Proofs/LiouvilleTheorem.lean",
       "filename": "LiouvilleTheorem.lean",
-      "lineCount": 529,
+      "lineCount": 528,
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 0,
@@ -69,11 +69,11 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 529,
-      "theoremCount": 20,
+      "lineCount": 1344,
+      "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 7,
+      "defCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LiouvilleTheoremOQ04.lean"
     }


### PR DESCRIPTION
## Fix

Sync `leanFiles[*]` for `Proofs/LiouvilleTheorem.lean` and `Proofs/LiouvilleTheoremOQ04.lean` across 3 sibling research JSONs (`liouville-theorem-oq-01/02/03`).

## Evidence

**Before** (JSON state, identical across all 3 slugs):
- `LiouvilleTheorem.lean`: `lineCount=529`
- `LiouvilleTheoremOQ04.lean`: `lineCount=529, theoremCount=20, defCount=4, sorryCount=7`

**After** (live, via `wc -l` + enrich-research.ts regex):
- `LiouvilleTheorem.lean`: `lineCount=528` (split-length → wc -l, off-by-one)
- `LiouvilleTheoremOQ04.lean`: `lineCount=1344 (+815), theoremCount=33 (+13), defCount=6 (+2), sorryCount=4 (−3)`, `axiomCount=0` (unchanged)

## Drift Source

`LiouvilleTheoremOQ04.lean` grew substantially via:
- #8372 — Liouville uncountable + irrationality measure of e
- #8382 — Liouville approx + Erdős #301
- Subsequent enrichment touches

Research-json metadata for the three sibling slugs (`liouville-theorem-oq-01/02/03`) was never re-synced after those merges. Capstone sorries on `LiouvilleTheoremOQ04` discharged (7→4), and many new theorems added.

## Convention

`lineCount` uses `wc -l` (matches recent mechanic convention: PR #19754, #19759, #19764, #19767, #19771, #19777, #19806). Other count fields use the `scripts/research/enrich-research.ts` regex definitions verbatim. Unicode preserved via `ensure_ascii=False` (no prose touched, no spurious `\u….` escapes).

## Validation

- All 3 JSONs valid via `python3 -c "import json; json.load(open(p))"`
- Diff: 5 lines per JSON × 3 = 15 lines total; only `leanFiles[*]` fields changed
- No prose mentions of "529" elsewhere — fields-only edit

---
Automated fix by lean-mechanic agent.