### PR TITLE
fix(meta): batch sync AreaOfCircle.lean leanFiles in 30 area-of-circle siblings (lineCount 156→155)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -37,7 +37,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -28,7 +28,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -116,7 +116,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/AreaOfCircle.lean",
       "filename": "AreaOfCircle.lean",
-      "lineCount": 156,
+      "lineCount": 155,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` field for `Proofs/AreaOfCircle.lean` entry across 30 sibling research-problem JSONs from `156` to `155` (matches `wc -l` and gallery meta.json).

## Evidence

**Before**: `leanFiles[i].lineCount = 156` (split('\n').length convention; equals wc -l + 1)
**After**: `leanFiles[i].lineCount = 155` (wc -l, matches `src/data/proofs/area-of-circle/meta.json` `meta.lineCount: 155`)

Verification:
```
$ wc -l proofs/Proofs/AreaOfCircle.lean
155 proofs/Proofs/AreaOfCircle.lean

$ jq '.meta.lineCount' src/data/proofs/area-of-circle/meta.json
155
```

Other `leanFiles[i]` fields (theoremCount=7, axiomCount=0, defCount=0, sorryCount=0) already match reality; lineCount is the only drift.

## Scope

- 30 files: `src/data/research/problems/area-of-circle-*.json`
- Each: exactly 1 entry where `path == "Proofs/AreaOfCircle.lean"` updated; all other leanFiles[] entries untouched
- No `.lean` / gallery `meta.json` / `problem.md` / `knowledge.md` changes
- Net: +30 / -30 lines

## Precedent

Follows the same wc-l-convention batch sync pattern as recent mechanic PRs:
- #19793 amgm-oq04 lineCount 307→306 in 29 siblings
- #19800 bezout-identity in 31 siblings
- #19797 cauchy-schwarz in 33 siblings
- #19796 buffons-needle in 16 siblings
- #19802 borsuk-ulam-oq-04 in 22 siblings (current mechanic chain)

---
Automated fix by lean-mechanic agent.