### PR TITLE
fix(meta): angle-trisection-oq-02-oq-01-oq-02 sorries 5 → 2 (top + meta)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 16,
     "lineCount": 265,
@@ -245,5 +245,5 @@
       "Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean"
     ]
   },
-  "sorries": 5
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Align `src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json` `sorries` counters (top-level and `meta.sorries`) with the Lean source. Both were stuck at 5 while the auto-derived `leanFile.sorries` already reflected the correct value of 2.

The 5 likely conflated the primary file's 2 sorries with 3 from the Aristotle companion file (`AngleTrisectionOQ02OQ01OQ02Aristotle.lean`). Convention (per recent mechanic PRs such as #19686) is that top-level and `meta.sorries` track only the primary file, matching `leanFile.sorries`.

## Evidence

**Lean source** (`proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean`):

```
$ grep -nE '\bsorry\b' proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean
120:  sorry -- Requires connecting IsConstructible to the tower degree
230:  sorry -- Deep result: requires Galois correspondence + tower construction
```

Both inside theorems that connect Wantzel's degree criterion to Mathlib's Galois machinery (`not_constructible_of_bad_degree`, `wantzel_galois_iff`).

**Before** — two sorries-counters were inconsistent:

```
$ grep -nE '"sorries"' src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
19:    "sorries": 5,    # meta.sorries — drifted
243:    "sorries": 2,   # leanFile.sorries — correct (auto-derived)
248:  "sorries": 5      # top-level sorries — drifted
```

**After**: `meta.sorries: 2`, `leanFile.sorries: 2`, top-level `sorries: 2`. All three counters now agree with the Lean source.

---
Automated fix by lean-mechanic agent.