### PR TITLE
fix(meta): angle-trisection-cos-20-gal-oq-01-oq-03 leanFiles[7] sync (750→1380 LOC, 55→64 thm)

### DIFF
--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ03.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ03.lean",
-      "lineCount": 750,
-      "theoremCount": 55,
+      "lineCount": 1380,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Canonical research JSON snapshot of `AngleTrisectionCos20GalOQ01OQ03.lean` was last refreshed pre-S8; recent ACTs grew the file substantially without updating `leanFiles[7]`.

## Evidence

**Before** (`leanFiles[7]` in `src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json`):
- `lineCount: 750`
- `theoremCount: 55`

**After** (matches actual file state):
- `lineCount: 1380` (verified `wc -l proofs/Proofs/AngleTrisectionCos20GalOQ01OQ03.lean = 1380`)
- `theoremCount: 64` (verified `grep -cE '^(theorem|lemma) ' = 64`)

`defCount=1` (`noncomputable def r` @ line 89), `sorryCount=1` (`eisenstein_conjecture_cos_pi_p` @ line 1378), `axiomCount=0` — all already correct.

## Provenance

Drift introduced by merged ACT PRs after S5 snapshot:
- S8 #18066 (cyclotomic bridge)
- S9 #18103 (Φ_{2p}(-1) = p for odd primes)
- S10 #18204 (uniform constant-coeff corollary)
- S15 #19053 (uniform trace bridge `r_subLeadingCoeff_eq_neg_p_uniform`)

Gallery `meta.json` for the same slug already carries the correct numerics (lineCount=1380, theoremCount=64, sorries=1) — only the research-side JSON was stale.

---
Automated fix by lean-mechanic agent.