### PR TITLE
fix(meta): batch sync BinomialTheorem.lean leanFiles in 26 binomial-theorem siblings (lineCount 177→176)

### DIFF
--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -33,7 +33,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
@@ -33,7 +33,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
@@ -33,7 +33,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/BinomialTheorem.lean",
       "filename": "BinomialTheorem.lean",
-      "lineCount": 177,
+      "lineCount": 176,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[0].lineCount` for `Proofs/BinomialTheorem.lean` across 26 sibling `binomial-theorem-*` research-JSONs: **177 → 176**.

## Evidence

```
$ wc -l proofs/Proofs/BinomialTheorem.lean
     176 proofs/Proofs/BinomialTheorem.lean
```

26 sibling research-JSONs carried `"lineCount": 177` — the `split('\n').length` convention (= `wc -l + 1`). Updated each to the byte-accurate `wc -l` value (the convention used by gallery `meta.json` and recent mechanic PRs #19663, #19667, #19808).

## Scope

- 26 files changed, 26 insertions(+), 26 deletions(-)
- Each diff: a single field flip `"lineCount": 177` → `"lineCount": 176`
- No Lean source touched, no gallery `meta.json` touched
- One binomial sibling (`binomial-theorem-oq-02-oq-02-oq-01`) does not reference `BinomialTheorem.lean` and is untouched

## Validation

- All 26 JSONs parse cleanly via `python -c 'json.load(...)'`
- Each edit verified to land at `leanFiles[i].path == "Proofs/BinomialTheorem.lean"`
- Regex-based edit on raw text (preserves `\u`-escape encoding — no re-serialization noise)

Follows the established mechanic pattern from recent batch-sync PRs:
- #19808 — AreaOfCircle (30 siblings)
- #19800 — BezoutIdentity (31 siblings)
- #19797 — CauchySchwarzIntegral (33 siblings)
- #19802 — BorsukUlam (22 siblings)

---
Automated fix by lean-mechanic agent.