### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-03-oq-02 leanFiles[10] sync (675→1788 LOC, 45→109 thm, 1→2 def)

### DIFF
--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -327,10 +327,10 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
       "filename": "BorsukUlamOQ02OQ01OQ03OQ02.lean",
-      "lineCount": 675,
-      "theoremCount": 45,
+      "lineCount": 1788,
+      "theoremCount": 109,
       "axiomCount": 1,
-      "defCount": 1,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Sync canonical research JSON `leanFiles[10]` snapshot for `BorsukUlamOQ02OQ01OQ03OQ02.lean` with current file state. The entry was last refreshed near the Phase-2 scaffold (~675 LOC / 45 thm / 1 def). The S8–S15 ACT chain (Parts XI–XXI: concrete LPB derivations, symBUDim plateau collapse, per-n explicit prime-gap values, Part XXI first prime gap of size 14) grew the file substantially.

## Evidence

**Before** (research JSON):
- `lineCount: 675`
- `theoremCount: 45`
- `defCount: 1`
- `axiomCount: 1`, `sorryCount: 0` (correct)

**After** (verified against working tree):
- `lineCount: 1788` ← `wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean`
- `theoremCount: 109` ← `grep -cE '^(private |protected |noncomputable )?(theorem|lemma) '`
- `defCount: 2` ← `grep -cE '^(def|noncomputable def) '` (1 `def` + 1 `noncomputable def`)
- `axiomCount: 1` ← `grep -cE '^axiom '` (`symBUDim_eq_largestPrime` at line 100)
- `sorryCount: 0` ← no `\bsorry\b` matches in code

**Gallery cross-check**: `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json` `leanFile` block already had `lineCount: 1788`, `theoremCount: 109`, `definitionCount: 2`, `axiomCount: 1`, `sorries: 0` — only the research JSON snapshot was stale.

## Scope

- Single 3-line diff (lineCount + theoremCount + defCount); only `leanFiles[10]` of this slug touched
- Other leanFiles entries in this slug carry off-by-one drifts (split-length → wc -l) that affect the full borsuk-ulam batch (24 siblings) — deferred to a separate batch-sync PR per recent precedent (#19754, #19759, #19767, #19771, #19777)
- Validation: `python3 -c "import json; json.load(open(f))"` → JSON OK

---
Automated fix by lean-mechanic agent.