### PR TITLE
fix(meta): batch sync Erdos1018OQ04Incomplete01.lean leanFiles in 9 erdos siblings (lineCount 336→737, sorryCount 16→14)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -1100,11 +1100,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -668,11 +668,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -1123,11 +1123,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -1110,11 +1110,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -888,11 +888,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -871,11 +871,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -298,11 +298,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-101.json
+++ b/src/data/research/problems/erdos-101.json
@@ -299,11 +299,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-1018-oq-04.json
+++ b/src/data/research/problems/erdos-1018-oq-04.json
@@ -78,11 +78,11 @@
     {
       "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
       "filename": "Erdos1018OQ04Incomplete01.lean",
-      "lineCount": 336,
+      "lineCount": 737,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 16,
+      "sorryCount": 14,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },


### PR DESCRIPTION
## Fix

Sync 9 `src/data/research/problems/*.json` `leanFiles[i]` entries to current Lean source state. The file was overwritten in PR #19454 (2026-05-16, S2-A ACT) from 336 → 737 LOC; downstream sibling slugs were never back-synced.

## Evidence (per-slug, uniform across all 9)

| Field        | Before | After | Δ      |
| ------------ | ------ | ----- | ------ |
| lineCount    | 336    | 737   | +401   |
| sorryCount   | 16     | 14    | -2     |
| theoremCount | 11     | 11    | (same) |
| axiomCount   | 1      | 1     | (same) |
| defCount     | 1      | 1     | (same) |

## Siblings touched

- `erdos-1`, `erdos-1-oq-01`, `erdos-1-oq-02`, `erdos-1-oq-03`, `erdos-1-oq-04`
- `erdos-10`, `erdos-10-oq-01`
- `erdos-101`, `erdos-101-oq-04`
- `erdos-1018-oq-04`

## Convention

`lineCount` = `wc -l`. `sorryCount` = `grep -oE "\bsorry\b" | wc -l`. Per `scripts/research/enrich-research.ts` + recent mechanic-PR precedents (#19663, #19667, #19794, #19808, #19812).

## Validation

```
$ wc -l proofs/Proofs/Erdos1018OQ04Incomplete01.lean
     737 proofs/Proofs/Erdos1018OQ04Incomplete01.lean
$ grep -oE "\bsorry\b" proofs/Proofs/Erdos1018OQ04Incomplete01.lean | wc -l
      14
$ python3 -c "import json; [json.load(open(f)) for f in [...9 paths...]]"
JSON OK
```

## Not touched (out of mechanic scope)

- Lean source file (already at 737 LOC).
- Other `leanFiles[i]` entries in these slugs (separate-PR territory per "one fix per PR" mechanic discipline).
- `currentState.*` / `knowledge.*` / `lastUpdate` — researcher territory.

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)