### PR TITLE
fix(meta): batch sync KonigsbergOQ01OQ02.lean leanFiles in 7 konigsberg siblings

### DIFF
--- a/src/data/research/problems/konigsberg-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-01.json
@@ -87,11 +87,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01.json
@@ -136,11 +136,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-02.json
@@ -86,11 +86,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-03-oq-01.json
@@ -85,11 +85,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-03-oq-02.json
@@ -84,11 +84,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03.json
+++ b/src/data/research/problems/konigsberg-oq-03.json
@@ -42,11 +42,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-04.json
+++ b/src/data/research/problems/konigsberg-oq-04.json
@@ -98,11 +98,11 @@
     {
       "path": "Proofs/KonigsbergOQ01OQ02.lean",
       "filename": "KonigsbergOQ01OQ02.lean",
-      "lineCount": 849,
+      "lineCount": 1202,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 9,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[2]` snapshot of `Proofs/KonigsbergOQ01OQ02.lean` in 7 sibling research JSONs. Main slug `konigsberg-oq-01-oq-02` was kept current via audits (PRs #16728, #16871, #16875) and recent Hierholzer-progress work (#18755, #19000), but sibling slugs that share the same Lean file as `leanFiles[2]` were never back-synced and still reflect the pre-S6 snapshot (849 LOC, 6 sorries).

## Evidence (7 sibling JSONs, +14/-14 lines)

| Sibling slug | `leanFiles[2].lineCount` | `leanFiles[2].sorryCount` |
|---|---|---|
| konigsberg-oq-01 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-02 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-02-oq-01 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-03 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-03-oq-01 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-03-oq-02 | 849 → 1202 | 6 → 1 |
| konigsberg-oq-04 | 849 → 1202 | 6 → 1 |

`theoremCount=12`, `defCount=9`, `axiomCount=2` already match the bare-regex convention (per `scripts/research/enrich-research.ts`) — left unchanged.

## Convention

- `lineCount` = `wc -l` → 1202 (matches main slug + recent mechanic PRs #19794, #19808, #19812).
- `sorryCount` = `grep -oE "\bsorry\b" | wc -l` → 1 (per `enrich-research.ts:165` and recent mechanic-PR precedents).
- `theoremCount` = `grep -cE "^(theorem|lemma) "` → 12 (already correct).

## Validation

```
$ wc -l proofs/Proofs/KonigsbergOQ01OQ02.lean
    1202 proofs/Proofs/KonigsbergOQ01OQ02.lean
$ grep -oE "\bsorry\b" proofs/Proofs/KonigsbergOQ01OQ02.lean | wc -l
       1
$ grep -cE "^(theorem|lemma) " proofs/Proofs/KonigsbergOQ01OQ02.lean
12
$ for f in src/data/research/problems/konigsberg-oq-0*.json; do
    python3 -c "import json; json.load(open('$f'))" && echo "OK: $f"
  done
# All 7 sibling JSONs → OK
```

## Not touched (out of mechanic scope)

- **Main slug `konigsberg-oq-01-oq-02.json`** — its `leanFiles[2]` uses a different (with-modifier) counting convention (`thm=26, def=13, sorry=2`) that should not be flattened by this batch sync. That convention difference is a researcher decision; mechanic scope is limited to the stale-snapshot drift.
- `currentState.*`, `knowledge.*`, `lastUpdate` — researcher territory; this PR only syncs `leanFiles[2]`.
- Lean source file (unchanged).
- Sibling JSON `leanFiles[0]`, `leanFiles[1]`, `leanFiles[3+]` entries (not the target file).

---
Automated fix by lean-mechanic agent.