### PR TITLE
fix(meta): batch sync Hilbert15 leanFiles drift in 3 hilbert-15-* siblings

### DIFF
--- a/src/data/research/problems/hilbert-15-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-01.json
@@ -35,7 +35,7 @@
     {
       "path": "Proofs/Hilbert15OQ01.lean",
       "filename": "Hilbert15OQ01.lean",
-      "lineCount": 352,
+      "lineCount": 351,
       "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 8,
@@ -46,8 +46,8 @@
     {
       "path": "Proofs/Hilbert15OQ02.lean",
       "filename": "Hilbert15OQ02.lean",
-      "lineCount": 507,
-      "theoremCount": 25,
+      "lineCount": 533,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -57,7 +57,7 @@
     {
       "path": "Proofs/Hilbert15SchubertCalculus.lean",
       "filename": "Hilbert15SchubertCalculus.lean",
-      "lineCount": 471,
+      "lineCount": 470,
       "theoremCount": 3,
       "axiomCount": 7,
       "defCount": 14,
@@ -68,7 +68,7 @@
     {
       "path": "Proofs/Hilbert15SchubertCalculusOQ01.lean",
       "filename": "Hilbert15SchubertCalculusOQ01.lean",
-      "lineCount": 311,
+      "lineCount": 310,
       "theoremCount": 5,
       "axiomCount": 6,
       "defCount": 13,

--- a/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-15-oq-02-oq-03-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/Hilbert15OQ01.lean",
       "filename": "Hilbert15OQ01.lean",
-      "lineCount": 352,
+      "lineCount": 351,
       "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 8,
@@ -121,8 +121,8 @@
     {
       "path": "Proofs/Hilbert15OQ02.lean",
       "filename": "Hilbert15OQ02.lean",
-      "lineCount": 507,
-      "theoremCount": 25,
+      "lineCount": 533,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/Hilbert15OQ02OQ03.lean",
       "filename": "Hilbert15OQ02OQ03.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 8,
       "axiomCount": 3,
       "defCount": 3,
@@ -147,14 +147,14 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 1,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert15OQ02OQ03OQ01.lean"
     },
     {
       "path": "Proofs/Hilbert15SchubertCalculus.lean",
       "filename": "Hilbert15SchubertCalculus.lean",
-      "lineCount": 471,
+      "lineCount": 470,
       "theoremCount": 3,
       "axiomCount": 7,
       "defCount": 14,
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/Hilbert15SchubertCalculusOQ01.lean",
       "filename": "Hilbert15SchubertCalculusOQ01.lean",
-      "lineCount": 311,
+      "lineCount": 310,
       "theoremCount": 5,
       "axiomCount": 6,
       "defCount": 13,

--- a/src/data/research/problems/hilbert-15-oq-02.json
+++ b/src/data/research/problems/hilbert-15-oq-02.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/Hilbert15OQ01.lean",
       "filename": "Hilbert15OQ01.lean",
-      "lineCount": 352,
+      "lineCount": 351,
       "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 8,
@@ -121,8 +121,8 @@
     {
       "path": "Proofs/Hilbert15OQ02.lean",
       "filename": "Hilbert15OQ02.lean",
-      "lineCount": 507,
-      "theoremCount": 25,
+      "lineCount": 533,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/Hilbert15SchubertCalculus.lean",
       "filename": "Hilbert15SchubertCalculus.lean",
-      "lineCount": 471,
+      "lineCount": 470,
       "theoremCount": 3,
       "axiomCount": 7,
       "defCount": 14,
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/Hilbert15SchubertCalculusOQ01.lean",
       "filename": "Hilbert15SchubertCalculusOQ01.lean",
-      "lineCount": 311,
+      "lineCount": 310,
       "theoremCount": 5,
       "axiomCount": 6,
       "defCount": 13,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[]` metrics across 3 hilbert-15 research JSONs after recent ACTs / Mathlib touch-ups.

## Drift

| File | Drift | Affected slugs |
|------|-------|----------------|
| Hilbert15OQ01.lean | lineCount 352→351 | all 3 |
| Hilbert15OQ02.lean | lineCount 507→533, theoremCount 25→27 | all 3 (post #18797 Session 4 — 2 universal-form zero lemmas) |
| Hilbert15OQ02OQ03.lean | lineCount 250→249 | hilbert-15-oq-02-oq-03-oq-01 |
| Hilbert15OQ02OQ03OQ01.lean | sorryCount 1→2 | hilbert-15-oq-02-oq-03-oq-01 (per S3c STATE-SYNC §5 mechanic ownership note in #19371) |
| Hilbert15SchubertCalculus.lean | lineCount 471→470 | all 3 |
| Hilbert15SchubertCalculusOQ01.lean | lineCount 311→310 | all 3 |

## Conventions

- **lineCount**: `wc -l` (matches recent mechanic PRs #19663/#19667)
- **theoremCount**: narrow regex `^(theorem|lemma) ` per `scripts/research/enrich-research.ts`
- Preserved broad-convention `theoremCount=33` for Hilbert15OQ02OQ03OQ01.lean in hilbert-15-oq-02-oq-03-oq-01.json (slug owner's convention includes `protected`/`private` theorems; narrow regex yields 29, broad yields 33)

## Validation

- `python3 -c "import json; json.load(open(f))"` ✅ all 3 JSONs valid
- All 6 `.lean` files re-counted with `wc -l` + script regex
- No `.lean` edits; no `lake build` needed

Files: 3 changed, +17/-17

---
Automated fix by lean-mechanic agent.