### PR TITLE
fix(meta): batch sync BinomialTheoremOQ02OQ01OQ01.lean leanFiles in 25 binomial-theorem siblings

### DIFF
--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
@@ -147,11 +147,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01.json
@@ -145,11 +145,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
@@ -151,11 +151,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
@@ -154,11 +154,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -245,11 +245,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 265,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -99,11 +99,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
@@ -161,11 +161,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
@@ -141,11 +141,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -154,11 +154,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -149,11 +149,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
@@ -143,11 +143,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
@@ -143,11 +143,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -181,11 +181,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
@@ -148,11 +148,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
@@ -99,11 +99,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
@@ -148,11 +148,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
@@ -99,11 +99,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
@@ -192,11 +192,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01.lean",
-      "lineCount": 248,
+      "lineCount": 292,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 7,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[]` entry for `Proofs/BinomialTheoremOQ02OQ01OQ01.lean`
across 25 sibling research JSONs in the `binomial-theorem` family. Canonical
slug `binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01` was already current
(292 LOC, 4 sorries) per S5 STATE-SYNC #19635 + mechanic handoff #19669,
but siblings sharing the same Lean file as a `leanFiles[]` reference were
never back-synced and still reflect older snapshots.

## Evidence

**Before** (stale snapshots in 25 sibling JSONs):
- 23 refs at `(lineCount: 248, sorryCount: 7)`
- 1 ref at `(lineCount: 248, sorryCount: 5)` — `binomial-theorem-oq-02-oq-01-oq-01-oq-02`
- 1 ref at `(lineCount: 265, sorryCount: 5)` — `binomial-theorem-oq-02-oq-01-oq-01-oq-03`

**After** (all 25 + the canonical 1 = 26 sibling JSONs):
- All at `(lineCount: 292, sorryCount: 4)` matching actual file state.

**Actual file state** (verified at HEAD):
```
$ wc -l proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
292
$ grep -oE "\bsorry\b" proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean | wc -l
4
$ grep -cE "^(theorem|lemma) " proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
7      # matches existing theoremCount — left unchanged
$ grep -cE "^(def|noncomputable def) " proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
2      # matches existing defCount — left unchanged
$ grep -cE "^axiom " proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
0      # matches existing axiomCount — left unchanged
```

Diff is surgical: only `lineCount` and `sorryCount` fields changed per file.
All 26 JSONs (including canonical) validated via `python3 json.load` post-edit.

---
Automated fix by lean-mechanic agent.