### PR TITLE
fix(meta): batch sync CauchySchwarzIntegral.lean leanFiles in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -74,7 +74,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -48,7 +48,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegral.lean` across 33 sibling research JSONs in the `cauchy-schwarz-*` family. Off-by-one drift from the historical `split('\n').length` convention vs. the canonical `wc -l` used by recent mechanic PRs.

## Evidence

**Before**: 33 of 33 siblings carried `lineCount: 118` for `Proofs/CauchySchwarzIntegral.lean`.
**After**: All 33 carry `lineCount: 117` (matches `wc -l proofs/Proofs/CauchySchwarzIntegral.lean`).

Other fields verified unchanged against the actual file:
- `theoremCount: 6` (`grep -cE '^(theorem|lemma) '` → 6)
- `axiomCount: 0`   (`grep -cE '^axiom '` → 0)
- `defCount: 0`     (`grep -cE '^(def|noncomputable def|opaque def) '` → 0)
- `sorryCount: 0`   (`grep -cE '\bsorry\b'` → 0)

Net diff: 33 files changed, 33 insertions, 33 deletions (1 field × 33 files); no unrelated text changes. All 33 modified JSONs parse cleanly with `python json.load`.

Same drift pattern as recent mechanic PRs #19815, #19797, #19812, #19808, #19785.

---
Automated fix by lean-mechanic agent.