### PR TITLE
fix(meta): batch sync BuffonsNeedleOQ01OQ01OQ04.lean leanFiles in 15 buffons-needle siblings (LOC 395→568, sorry 1→0, thm 25→27)

### DIFF
--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
@@ -117,11 +117,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
@@ -104,11 +104,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
@@ -127,11 +127,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
@@ -131,11 +131,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01.json
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
@@ -108,11 +108,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -146,11 +146,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-03.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-04.json
@@ -110,11 +110,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01.json
@@ -115,11 +115,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-01.json
@@ -65,11 +65,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-02.json
@@ -85,11 +85,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02.json
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-03.json
@@ -119,11 +119,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entry for `Proofs/BuffonsNeedleOQ01OQ01OQ04.lean`
across 15 sibling slugs whose `lineCount`/`theoremCount`/`sorryCount`
were stale. The file grew from 395 → 568 LOC (+173) with two new
theorems added and one sorry discharged, but per-slug `leanFiles[]`
entries were never back-synced.

## Evidence

**Before** (all 15 slugs identical):
- `lineCount: 395, theoremCount: 25, axiomCount: 0, defCount: 4, sorryCount: 1`

**After** (matches `scripts/research/enrich-research.ts` extractor):
- `lineCount: 568, theoremCount: 27, axiomCount: 0, defCount: 4, sorryCount: 0`

## Convention

| Field         | Computation                                                  |
| ------------- | ------------------------------------------------------------ |
| lineCount     | `wc -l < file.lean` = 568                                    |
| theoremCount  | `grep -cE '^(theorem\|lemma) '` = 27                          |
| axiomCount    | `grep -cE '^axiom '` = 0                                     |
| defCount      | `grep -cE '^(def\|noncomputable def\|opaque def) '` = 4       |
| sorryCount    | `grep -oE '\bsorry\b' \| wc -l` = 0                           |

Per `scripts/research/enrich-research.ts:154-168`. Matches recent mechanic
PRs #19794 (shannon-entropy), #19796 (buffons-needle-oq-02-oq-03), #19808
(area-of-circle), and #19812 (binomial-theorem).

## Slugs updated (15)

`buffons-needle-oq-01`, `-oq-01-oq-01`, `-oq-01-oq-01-oq-01`,
`-oq-01-oq-01-oq-02`, `-oq-01-oq-01-oq-03`, `-oq-01-oq-01-oq-04`,
`-oq-01-oq-01-oq-04-oq-01`, `-oq-01-oq-02`, `-oq-01-oq-02-oq-01`,
`-oq-01-oq-03`, `-oq-01-oq-04`, `-oq-02`, `-oq-02-oq-01`,
`-oq-02-oq-02`, `-oq-03`.

Diff: 15 files changed, 45 insertions(+), 45 deletions(-).

---
Automated fix by lean-mechanic agent.